### PR TITLE
ci: parallelize E2E tests with 3 workers

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  workers: process.env.CI ? 3 : undefined,
   reporter: 'html',
 
   globalSetup: './e2e/global-setup.ts',


### PR DESCRIPTION
## Summary
- Increase Playwright CI workers from 1 to 3 to run E2E tests in parallel
- Expected speedup: ~5.1min → ~2.0-2.5min test execution (~3.0-3.5min total with setup)

## Why this is safe
- 61 of 69 tests are read-only against seed data — no contention
- 8 serial tests already use `test.describe.configure({ mode: 'serial' })` — Playwright assigns each serial group to one worker
- Write tests (submit-show, register) create independent records
- `ubuntu-latest` has 7GB RAM — 3 Chromium instances fit comfortably alongside backend + PostgreSQL

## Test plan
- [ ] CI E2E tests pass with 3 workers
- [ ] Serial tests (pending-shows, venue-edits, save-show) still pass
- [ ] Compare E2E job duration vs previous runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)