### PR TITLE
chore: reorganize docs, gitignore private docs, remove tracked binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ Thumbs.db
 node_modules/
 
 # Backend specific
+backend/server
 backend/backups/
 backend/logs/
 backend/*.log


### PR DESCRIPTION
## Summary
- Reorganize documentation into LLM/human docs split (`docs/` for LLM workspace, `human-docs/` for human-facing guides)
- Add both `docs/` and `human-docs/` to `.gitignore` to keep private docs out of the repo
- Remove the `backend/server` compiled binary from git tracking and add it to `.gitignore`

## Test plan
- [ ] Verify `backend/server` no longer appears in `git status` after building
- [ ] Verify `docs/` and `human-docs/` directories are ignored by git
- [ ] Confirm app builds and runs normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)