### PR TITLE
feat(discovery): local persistence & daily workflow

### DIFF
--- a/discovery/.gitignore
+++ b/discovery/.gitignore
@@ -14,3 +14,6 @@ dist/
 
 # OS
 .DS_Store
+
+# Local SQLite data
+data/

--- a/discovery/src/App.tsx
+++ b/discovery/src/App.tsx
@@ -18,6 +18,7 @@ export default function App() {
     selectedEventIds,
     scrapedEvents,
     importStatuses,
+    eventMetadata,
     selectVenues,
     handlePreviewComplete,
     toggleEvent,
@@ -25,6 +26,8 @@ export default function App() {
     clearEventSelection,
     addScrapedEvents,
     setImportStatuses,
+    setEventMetadata,
+    updateEventIgnored,
     startOver,
   } = useWizard()
 
@@ -64,8 +67,11 @@ export default function App() {
             previewEvents={previewEvents}
             selectedEventIds={selectedEventIds}
             importStatuses={importStatuses}
+            eventMetadata={eventMetadata}
             onPreviewComplete={handlePreviewComplete}
             onSetImportStatuses={setImportStatuses}
+            onSetEventMetadata={setEventMetadata}
+            onUpdateEventIgnored={updateEventIgnored}
             onToggle={toggleEvent}
             onSelectAll={selectAllEvents}
             onSelectNone={clearEventSelection}

--- a/discovery/src/components/EventPreview.tsx
+++ b/discovery/src/components/EventPreview.tsx
@@ -9,19 +9,25 @@ import {
   checkImportStatus,
   scrapeVenueEvents,
   scrapeVenueEventsWithProgress,
+  recordPreviewEvents,
+  getEventMetadata,
+  toggleEventIgnored,
   type ScrapeProgressEvent,
 } from '../lib/api'
 import { concurrentMap } from '../lib/concurrentMap'
 import { useSettings } from '../context/SettingsContext'
-import type { VenueConfig, PreviewEvent, ScrapedEvent, ImportStatusMap } from '../lib/types'
+import type { VenueConfig, PreviewEvent, ScrapedEvent, ImportStatusMap, EventMetadataMap } from '../lib/types'
 
 interface Props {
   venues: VenueConfig[]
   previewEvents: Record<string, PreviewEvent[]>
   selectedEventIds: Record<string, Set<string>>
   importStatuses: ImportStatusMap
+  eventMetadata: Record<string, EventMetadataMap>
   onPreviewComplete: (venueSlug: string, events: PreviewEvent[]) => void
   onSetImportStatuses: (statuses: ImportStatusMap) => void
+  onSetEventMetadata: (venueSlug: string, metadata: EventMetadataMap) => void
+  onUpdateEventIgnored: (venueSlug: string, eventId: string, ignored: boolean) => void
   onToggle: (venueSlug: string, eventId: string) => void
   onSelectAll: (venueSlug: string) => void
   onSelectNone: (venueSlug: string) => void
@@ -35,8 +41,11 @@ export function EventPreview({
   previewEvents,
   selectedEventIds,
   importStatuses,
+  eventMetadata,
   onPreviewComplete,
   onSetImportStatuses,
+  onSetEventMetadata,
+  onUpdateEventIgnored,
   onToggle,
   onSelectAll,
   onSelectNone,
@@ -62,6 +71,26 @@ export function EventPreview({
     phase?: string
   } | null>(null)
 
+  // Record preview events and fetch metadata whenever previews change
+  const recordedSlugsRef = useRef<Set<string>>(new Set())
+  useEffect(() => {
+    const newSlugs = Object.keys(previewEvents).filter(s => !recordedSlugsRef.current.has(s))
+    if (newSlugs.length === 0) return
+
+    newSlugs.forEach(s => recordedSlugsRef.current.add(s))
+
+    // Record previews + fetch metadata for each new venue
+    for (const venueSlug of newSlugs) {
+      const events = previewEvents[venueSlug] || []
+      if (events.length === 0) continue
+
+      recordPreviewEvents(venueSlug, events)
+        .then(() => getEventMetadata(venueSlug))
+        .then(metadata => onSetEventMetadata(venueSlug, metadata))
+        .catch(() => {}) // Non-critical
+    }
+  }, [previewEvents, onSetEventMetadata])
+
   // Check import statuses in the background whenever previews change
   const checkedSlugsRef = useRef<Set<string>>(new Set())
   useEffect(() => {
@@ -80,9 +109,10 @@ export function EventPreview({
       .catch(() => {}) // Non-critical
   }, [previewEvents, onSetImportStatuses])
 
-  // Re-check import statuses when target environment changes
+  // Re-check import statuses and metadata when target environment changes
   useEffect(() => {
     checkedSlugsRef.current = new Set()
+    recordedSlugsRef.current = new Set()
     onSetImportStatuses({})
   }, [settings.targetEnvironment]) // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -352,9 +382,22 @@ export function EventPreview({
             onRetry={() => retryVenue(venue)}
             selectedIds={selectedEventIds[venue.slug]}
             importStatuses={importStatuses}
+            eventMetadata={eventMetadata[venue.slug]}
             onToggle={(eventId) => onToggle(venue.slug, eventId)}
             onSelectAll={() => onSelectAll(venue.slug)}
             onSelectNone={() => onSelectNone(venue.slug)}
+            onIgnore={async (eventId, ignored) => {
+              onUpdateEventIgnored(venue.slug, eventId, ignored)
+              try {
+                await toggleEventIgnored(venue.slug, eventId, ignored)
+                // Re-fetch metadata to overwrite any stale data from the
+                // recording effect's concurrent getEventMetadata call
+                const metadata = await getEventMetadata(venue.slug)
+                onSetEventMetadata(venue.slug, metadata)
+              } catch {
+                onUpdateEventIgnored(venue.slug, eventId, !ignored)
+              }
+            }}
           />
         ))}
       </div>

--- a/discovery/src/components/discovery/EventList.tsx
+++ b/discovery/src/components/discovery/EventList.tsx
@@ -1,30 +1,61 @@
 import { Checkbox } from '../ui/checkbox'
-import { Label } from '../ui/label'
 import { Badge } from '../ui/badge'
 import { EmptyState } from '../shared/EmptyState'
-import { Calendar } from 'lucide-react'
-import type { PreviewEvent, ImportStatusMap } from '../../lib/types'
+import { Calendar, EyeOff, Eye } from 'lucide-react'
+import type { PreviewEvent, ImportStatusMap, EventMetadataMap, FieldChange } from '../../lib/types'
 import { getLocalDateString } from '../../lib/dates'
+
+export type EventListFilter = 'active' | 'imported' | 'ignored'
 
 interface EventListProps {
   events: PreviewEvent[]
   selectedIds: Set<string>
   importStatuses: ImportStatusMap
+  eventMetadata?: EventMetadataMap
   updatableIds?: Set<string>
   onToggle: (eventId: string) => void
+  onIgnore?: (eventId: string, ignored: boolean) => void
+  filter?: EventListFilter
 }
 
-export function EventList({ events, selectedIds, importStatuses, updatableIds, onToggle }: EventListProps) {
+export function EventList({
+  events,
+  selectedIds,
+  importStatuses,
+  eventMetadata,
+  updatableIds,
+  onToggle,
+  onIgnore,
+  filter = 'active',
+}: EventListProps) {
   // Filter to only show future events
   const today = getLocalDateString()
   const futureEvents = events.filter(e => e.date >= today)
 
-  if (futureEvents.length === 0) {
+  // Filter by tab
+  const filteredEvents = futureEvents.filter(e => {
+    const meta = eventMetadata?.[e.id]
+    const isIgnored = meta?.isIgnored ?? false
+    const isImported = importStatuses[e.id]?.exists ?? false
+
+    switch (filter) {
+      case 'ignored':
+        return isIgnored
+      case 'imported':
+        return !isIgnored && isImported
+      case 'active':
+      default:
+        return !isIgnored && !isImported
+    }
+  })
+
+  if (filteredEvents.length === 0) {
+    if (filter !== 'active') return null
     return (
       <EmptyState
         icon={Calendar}
         title="No upcoming events"
-        description="All events are in the past"
+        description="All events are in the past or already evaluated"
         className="py-6"
       />
     )
@@ -32,33 +63,77 @@ export function EventList({ events, selectedIds, importStatuses, updatableIds, o
 
   return (
     <div className="divide-y divide-border">
-      {futureEvents.map(event => {
+      {filteredEvents.map(event => {
         const status = importStatuses[event.id]
+        const meta = eventMetadata?.[event.id]
         return (
-          <label
+          <div
             key={event.id}
             className="flex items-center gap-3 px-4 py-3 hover:bg-muted/30 cursor-pointer"
+            onClick={() => { if (filter !== 'ignored') onToggle(event.id) }}
           >
-            <Checkbox
-              checked={selectedIds.has(event.id)}
-              onCheckedChange={() => onToggle(event.id)}
-              id={`event-${event.id}`}
-            />
+            {filter !== 'ignored' && (
+              <Checkbox
+                checked={selectedIds.has(event.id)}
+                onCheckedChange={() => onToggle(event.id)}
+                id={`event-${event.id}`}
+                onClick={(e) => e.stopPropagation()}
+              />
+            )}
             <span className="text-sm text-muted-foreground w-16 shrink-0">
               {formatDate(event.date)}
             </span>
-            <Label
-              htmlFor={`event-${event.id}`}
-              className="text-sm text-foreground cursor-pointer flex-1"
-            >
+            <span className="text-sm text-foreground cursor-pointer flex-1 flex items-center gap-2 flex-wrap">
               {event.title}
-            </Label>
+              {meta?.isNew && (
+                <Badge className="bg-purple-100 text-purple-800 hover:bg-purple-100 shrink-0">New</Badge>
+              )}
+              {meta?.changes && meta.changes.map(change => (
+                <ChangeBadge key={change.field} change={change} />
+              ))}
+            </span>
             {status?.exists && <ImportStatusBadge status={status.status} hasUpdates={updatableIds?.has(event.id)} />}
-          </label>
+            {onIgnore && (
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onIgnore(event.id, filter !== 'ignored')
+                }}
+                className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors shrink-0"
+                title={filter === 'ignored' ? 'Unignore this event' : 'Ignore this event'}
+              >
+                {filter === 'ignored' ? <Eye className="h-4 w-4" /> : <EyeOff className="h-4 w-4" />}
+              </button>
+            )}
+          </div>
         )
       })}
     </div>
   )
+}
+
+function ChangeBadge({ change }: { change: FieldChange }) {
+  switch (change.field) {
+    case 'isSoldOut':
+      if (change.newValue) {
+        return <Badge className="bg-red-100 text-red-800 hover:bg-red-100 shrink-0">Sold Out</Badge>
+      }
+      return <Badge className="bg-green-100 text-green-800 hover:bg-green-100 shrink-0">Back on Sale</Badge>
+    case 'isCancelled':
+      if (change.newValue) {
+        return <Badge className="bg-gray-200 text-gray-700 hover:bg-gray-200 shrink-0">Cancelled</Badge>
+      }
+      return <Badge className="bg-green-100 text-green-800 hover:bg-green-100 shrink-0">Uncancelled</Badge>
+    case 'price':
+      return <Badge className="bg-blue-100 text-blue-800 hover:bg-blue-100 shrink-0">Price Changed</Badge>
+    case 'date':
+      return <Badge className="bg-amber-100 text-amber-800 hover:bg-amber-100 shrink-0">Date Changed</Badge>
+    case 'title':
+      return <Badge className="bg-amber-100 text-amber-800 hover:bg-amber-100 shrink-0">Updated</Badge>
+    default:
+      return null
+  }
 }
 
 function ImportStatusBadge({ status, hasUpdates }: { status?: string; hasUpdates?: boolean }) {

--- a/discovery/src/components/discovery/VenuePreviewCard.tsx
+++ b/discovery/src/components/discovery/VenuePreviewCard.tsx
@@ -1,10 +1,11 @@
 import { RefreshCw, AlertCircle } from 'lucide-react'
 import { Button } from '../ui/button'
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '../ui/tabs'
 import { LoadingSpinner } from '../shared/LoadingSpinner'
 import { ListSkeleton } from '../shared/LoadingSkeleton'
 import { EmptyState } from '../shared/EmptyState'
 import { EventList } from './EventList'
-import type { VenueConfig, PreviewEvent, ImportStatusMap } from '../../lib/types'
+import type { VenueConfig, PreviewEvent, ImportStatusMap, EventMetadataMap } from '../../lib/types'
 import { getLocalDateString } from '../../lib/dates'
 
 interface VenuePreviewCardProps {
@@ -16,10 +17,12 @@ interface VenuePreviewCardProps {
   onRetry?: () => void
   selectedIds?: Set<string>
   importStatuses?: ImportStatusMap
+  eventMetadata?: EventMetadataMap
   updatableIds?: Set<string>
   onToggle?: (eventId: string) => void
   onSelectAll?: () => void
   onSelectNone?: () => void
+  onIgnore?: (eventId: string, ignored: boolean) => void
 }
 
 export function VenuePreviewCard({
@@ -31,17 +34,22 @@ export function VenuePreviewCard({
   onRetry,
   selectedIds,
   importStatuses = {},
+  eventMetadata,
   updatableIds,
   onToggle,
   onSelectAll,
   onSelectNone,
+  onIgnore,
 }: VenuePreviewCardProps) {
   const hasEvents = events && events.length > 0
   const selectable = !!selectedIds && !!onToggle
 
-  // Count future events for selection display
+  // Count future events by category
   const today = getLocalDateString()
-  const futureEventCount = events?.filter(e => e.date >= today).length ?? 0
+  const futureEvents = events?.filter(e => e.date >= today) ?? []
+  const ignoredCount = futureEvents.filter(e => eventMetadata?.[e.id]?.isIgnored).length
+  const importedCount = futureEvents.filter(e => !eventMetadata?.[e.id]?.isIgnored && importStatuses[e.id]?.exists).length
+  const activeCount = futureEvents.length - ignoredCount - importedCount
 
   return (
     <div className="bg-card rounded-lg border overflow-hidden">
@@ -55,7 +63,7 @@ export function VenuePreviewCard({
           {hasEvents && (
             <span className="text-sm text-muted-foreground">
               {selectable
-                ? `${selectedIds!.size}/${futureEventCount} selected`
+                ? `${selectedIds!.size}/${activeCount} selected`
                 : `${events.length} events`
               }
             </span>
@@ -128,17 +136,81 @@ export function VenuePreviewCard({
         </div>
       )}
 
-      {/* Events list with checkboxes (selectable mode) */}
+      {/* Events list with tabs (selectable mode) */}
       {selectable && hasEvents && (
-        <div className="max-h-80 overflow-y-auto">
-          <EventList
-            events={events}
-            selectedIds={selectedIds!}
-            importStatuses={importStatuses}
-            updatableIds={updatableIds}
-            onToggle={onToggle!}
-          />
-        </div>
+        <Tabs defaultValue="active">
+          <div className="px-4 pt-2">
+            <TabsList>
+              <TabsTrigger value="active">
+                New{activeCount > 0 ? ` (${activeCount})` : ''}
+              </TabsTrigger>
+              <TabsTrigger value="imported">
+                Imported{importedCount > 0 ? ` (${importedCount})` : ''}
+              </TabsTrigger>
+              <TabsTrigger value="ignored">
+                Ignored{ignoredCount > 0 ? ` (${ignoredCount})` : ''}
+              </TabsTrigger>
+            </TabsList>
+          </div>
+          <TabsContent value="active">
+            <div className="max-h-80 overflow-y-auto">
+              <EventList
+                events={events}
+                selectedIds={selectedIds!}
+                importStatuses={importStatuses}
+                eventMetadata={eventMetadata}
+                updatableIds={updatableIds}
+                onToggle={onToggle!}
+                onIgnore={onIgnore}
+                filter="active"
+              />
+            </div>
+          </TabsContent>
+          <TabsContent value="imported">
+            <div className="max-h-80 overflow-y-auto">
+              {importedCount > 0 ? (
+                <EventList
+                  events={events}
+                  selectedIds={selectedIds!}
+                  importStatuses={importStatuses}
+                  eventMetadata={eventMetadata}
+                  updatableIds={updatableIds}
+                  onToggle={onToggle!}
+                  onIgnore={onIgnore}
+                  filter="imported"
+                />
+              ) : (
+                <EmptyState
+                  title="No imported events"
+                  description="Events you've imported will appear here"
+                  className="py-6"
+                />
+              )}
+            </div>
+          </TabsContent>
+          <TabsContent value="ignored">
+            <div className="max-h-80 overflow-y-auto">
+              {ignoredCount > 0 ? (
+                <EventList
+                  events={events}
+                  selectedIds={selectedIds!}
+                  importStatuses={importStatuses}
+                  eventMetadata={eventMetadata}
+                  updatableIds={updatableIds}
+                  onToggle={onToggle!}
+                  onIgnore={onIgnore}
+                  filter="ignored"
+                />
+              ) : (
+                <EmptyState
+                  title="No ignored events"
+                  description="Use the eye icon to ignore events you don't want to see"
+                  className="py-6"
+                />
+              )}
+            </div>
+          </TabsContent>
+        </Tabs>
       )}
 
       {/* Events table (read-only mode) */}

--- a/discovery/src/context/WizardContext.tsx
+++ b/discovery/src/context/WizardContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useState, useCallback, type ReactNode } from 'react'
-import type { VenueConfig, PreviewEvent, ScrapedEvent, ImportStatusMap } from '../lib/types'
+import type { VenueConfig, PreviewEvent, ScrapedEvent, ImportStatusMap, EventMetadataMap } from '../lib/types'
 import { getLocalDateString } from '../lib/dates'
 
 export type WizardStep = 'venues' | 'preview' | 'import' | 'settings' | 'data-export'
@@ -11,6 +11,7 @@ interface WizardState {
   selectedEventIds: Record<string, Set<string>>
   scrapedEvents: ScrapedEvent[]
   importStatuses: ImportStatusMap
+  eventMetadata: Record<string, EventMetadataMap>
 }
 
 interface WizardActions {
@@ -22,6 +23,8 @@ interface WizardActions {
   clearEventSelection: (venueSlug: string) => void
   addScrapedEvents: (events: ScrapedEvent[]) => void
   setImportStatuses: (statuses: ImportStatusMap) => void
+  setEventMetadata: (venueSlug: string, metadata: EventMetadataMap) => void
+  updateEventIgnored: (venueSlug: string, eventId: string, ignored: boolean) => void
   startOver: () => void
 }
 
@@ -39,6 +42,31 @@ export function WizardProvider({ children }: { children: ReactNode }) {
   const [selectedEventIds, setSelectedEventIds] = useState<Record<string, Set<string>>>({})
   const [scrapedEvents, setScrapedEvents] = useState<ScrapedEvent[]>([])
   const [importStatuses, setImportStatuses] = useState<ImportStatusMap>({})
+  const [eventMetadata, setEventMetadataState] = useState<Record<string, EventMetadataMap>>({})
+
+  const setEventMetadata = useCallback((venueSlug: string, metadata: EventMetadataMap) => {
+    setEventMetadataState(prev => ({ ...prev, [venueSlug]: metadata }))
+  }, [])
+
+  const updateEventIgnored = useCallback((venueSlug: string, eventId: string, ignored: boolean) => {
+    setEventMetadataState(prev => {
+      const venueMetadata = prev[venueSlug] ?? {}
+      const existing = venueMetadata[eventId] ?? {
+        isNew: false,
+        isIgnored: false,
+        firstSeenAt: new Date().toISOString(),
+        lastSeenAt: new Date().toISOString(),
+        changes: [],
+      }
+      return {
+        ...prev,
+        [venueSlug]: {
+          ...venueMetadata,
+          [eventId]: { ...existing, isIgnored: ignored },
+        },
+      }
+    })
+  }, [])
 
   const selectVenues = useCallback((venues: VenueConfig[]) => {
     setSelectedVenues(venues)
@@ -71,13 +99,19 @@ export function WizardProvider({ children }: { children: ReactNode }) {
 
   const selectAllEvents = useCallback((venueSlug: string) => {
     const events = previewEvents[venueSlug] || []
+    const metadata = eventMetadata[venueSlug] || {}
     const today = getLocalDateString()
-    const futureEvents = events.filter(e => e.date >= today)
+    const futureEvents = events.filter(e => {
+      if (e.date < today) return false
+      if (metadata[e.id]?.isIgnored) return false
+      if (importStatuses[e.id]?.exists) return false
+      return true
+    })
     setSelectedEventIds(prev => ({
       ...prev,
       [venueSlug]: new Set(futureEvents.map(e => e.id)),
     }))
-  }, [previewEvents])
+  }, [previewEvents, eventMetadata, importStatuses])
 
   const clearEventSelection = useCallback((venueSlug: string) => {
     setSelectedEventIds(prev => ({
@@ -101,6 +135,7 @@ export function WizardProvider({ children }: { children: ReactNode }) {
     setSelectedEventIds({})
     setScrapedEvents([])
     setImportStatuses({})
+    setEventMetadataState({})
   }, [])
 
   const totalSelectedEvents = Object.values(selectedEventIds).reduce(
@@ -120,6 +155,7 @@ export function WizardProvider({ children }: { children: ReactNode }) {
     selectedEventIds,
     scrapedEvents,
     importStatuses,
+    eventMetadata,
     totalSelectedEvents,
     totalAvailableEvents,
     setStep,
@@ -130,6 +166,8 @@ export function WizardProvider({ children }: { children: ReactNode }) {
     clearEventSelection,
     addScrapedEvents,
     setImportStatuses,
+    setEventMetadata,
+    updateEventIgnored,
     startOver,
   }
 

--- a/discovery/src/lib/api.ts
+++ b/discovery/src/lib/api.ts
@@ -13,6 +13,8 @@ import type {
   ExportedShow,
   ExportedArtist,
   ExportedVenue,
+  EventMetadataMap,
+  LastScrapeInfo,
 } from './types'
 import { DISCOVERY_API_URL } from './config'
 
@@ -221,6 +223,51 @@ export async function scrapeVenueEventsWithProgress(
 
     read()
   })
+}
+
+// ============================================================================
+// Local Persistence API (SQLite event metadata)
+// ============================================================================
+
+// Record preview events and get new event IDs
+export async function recordPreviewEvents(
+  venueSlug: string,
+  events: Array<{ id: string; title: string; date: string }>,
+): Promise<{ newEventIds: string[]; lastScrape: LastScrapeInfo | null }> {
+  const response = await fetch(`${DISCOVERY_API_URL}/events/${venueSlug}/record`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ events }),
+  })
+  if (!response.ok) {
+    throw new Error('Failed to record preview events')
+  }
+  return response.json()
+}
+
+// Get event metadata (new/ignored/changes) for a venue
+export async function getEventMetadata(venueSlug: string): Promise<EventMetadataMap> {
+  const response = await fetch(`${DISCOVERY_API_URL}/events/${venueSlug}/metadata`)
+  if (!response.ok) {
+    throw new Error('Failed to get event metadata')
+  }
+  return response.json()
+}
+
+// Toggle ignore status for an event
+export async function toggleEventIgnored(
+  venueSlug: string,
+  eventId: string,
+  ignored: boolean,
+): Promise<void> {
+  const response = await fetch(`${DISCOVERY_API_URL}/events/${venueSlug}/ignore`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ eventId, ignored }),
+  })
+  if (!response.ok) {
+    throw new Error('Failed to toggle event ignore status')
+  }
 }
 
 // Strip discovery-specific fields that older backends don't know about

--- a/discovery/src/lib/types.ts
+++ b/discovery/src/lib/types.ts
@@ -196,6 +196,31 @@ export interface DataImportResult {
   venues: EntityImportStats
 }
 
+// ============================================================================
+// Local Persistence Types (SQLite event metadata)
+// ============================================================================
+
+export interface FieldChange {
+  field: 'isSoldOut' | 'isCancelled' | 'price' | 'date' | 'title'
+  oldValue: string | boolean | null
+  newValue: string | boolean | null
+}
+
+export interface EventMetadata {
+  isNew: boolean
+  isIgnored: boolean
+  firstSeenAt: string
+  lastSeenAt: string
+  changes: FieldChange[]
+}
+
+export type EventMetadataMap = Record<string, EventMetadata>
+
+export interface LastScrapeInfo {
+  lastScrapeAt: string
+  eventCount: number
+}
+
 // Multi-target import types
 export type ImportTarget = 'stage' | 'production' | 'both'
 

--- a/discovery/src/server/db.ts
+++ b/discovery/src/server/db.ts
@@ -1,0 +1,360 @@
+import { Database } from 'bun:sqlite'
+import { mkdirSync } from 'fs'
+import { join, dirname } from 'path'
+
+const DB_PATH = join(import.meta.dir, '../../data/discovery.db')
+
+let db: Database
+
+function getDb(): Database {
+  if (!db) {
+    mkdirSync(dirname(DB_PATH), { recursive: true })
+    db = new Database(DB_PATH)
+    db.exec('PRAGMA journal_mode = WAL')
+    db.exec('PRAGMA foreign_keys = ON')
+    initSchema()
+  }
+  return db
+}
+
+function initSchema() {
+  const d = getDb()
+  d.exec(`
+    CREATE TABLE IF NOT EXISTS scrape_sessions (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      venue_slug TEXT NOT NULL,
+      scrape_type TEXT NOT NULL CHECK (scrape_type IN ('preview', 'full')),
+      event_count INTEGER NOT NULL DEFAULT 0,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+
+    CREATE TABLE IF NOT EXISTS events (
+      venue_slug TEXT NOT NULL,
+      event_id TEXT NOT NULL,
+      title TEXT NOT NULL,
+      date TEXT NOT NULL,
+      first_seen_at TEXT NOT NULL DEFAULT (datetime('now')),
+      last_seen_at TEXT NOT NULL DEFAULT (datetime('now')),
+      is_ignored INTEGER NOT NULL DEFAULT 0,
+      ignored_at TEXT,
+      PRIMARY KEY (venue_slug, event_id)
+    );
+
+    CREATE TABLE IF NOT EXISTS event_snapshots (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id INTEGER NOT NULL REFERENCES scrape_sessions(id),
+      venue_slug TEXT NOT NULL,
+      event_id TEXT NOT NULL,
+      title TEXT NOT NULL,
+      date TEXT NOT NULL,
+      artists TEXT,
+      price TEXT,
+      is_sold_out INTEGER NOT NULL DEFAULT 0,
+      is_cancelled INTEGER NOT NULL DEFAULT 0,
+      scraped_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+  `)
+}
+
+// ---- Preview recording ----
+
+interface PreviewEventInput {
+  id: string
+  title: string
+  date: string
+}
+
+export function recordPreviewEvents(
+  venueSlug: string,
+  events: PreviewEventInput[],
+): { newEventIds: string[] } {
+  const d = getDb()
+  const now = new Date().toISOString()
+
+  // Record session
+  const sessionStmt = d.prepare(
+    'INSERT INTO scrape_sessions (venue_slug, scrape_type, event_count, created_at) VALUES (?, ?, ?, ?)',
+  )
+  sessionStmt.run(venueSlug, 'preview', events.length, now)
+
+  // Upsert events
+  const upsertStmt = d.prepare(`
+    INSERT INTO events (venue_slug, event_id, title, date, first_seen_at, last_seen_at)
+    VALUES (?, ?, ?, ?, ?, ?)
+    ON CONFLICT (venue_slug, event_id) DO UPDATE SET
+      title = excluded.title,
+      date = excluded.date,
+      last_seen_at = excluded.last_seen_at
+  `)
+
+  const existingStmt = d.prepare(
+    'SELECT event_id FROM events WHERE venue_slug = ? AND event_id = ?',
+  )
+
+  const newEventIds: string[] = []
+
+  const transaction = d.transaction(() => {
+    for (const event of events) {
+      const existing = existingStmt.get(venueSlug, event.id) as { event_id: string } | null
+      if (!existing) {
+        newEventIds.push(event.id)
+      }
+      upsertStmt.run(venueSlug, event.id, event.title, event.date, now, now)
+    }
+  })
+  transaction()
+
+  return { newEventIds }
+}
+
+// ---- Full scrape recording ----
+
+interface ScrapeEventInput {
+  id: string
+  title: string
+  date: string
+  artists?: string[]
+  price?: string
+  isSoldOut?: boolean
+  isCancelled?: boolean
+}
+
+interface FieldChange {
+  field: 'isSoldOut' | 'isCancelled' | 'price' | 'date' | 'title'
+  oldValue: string | boolean | null
+  newValue: string | boolean | null
+}
+
+export function recordScrapeResults(
+  venueSlug: string,
+  events: ScrapeEventInput[],
+): { changes: Record<string, FieldChange[]> } {
+  const d = getDb()
+  const now = new Date().toISOString()
+
+  // Record session
+  const sessionStmt = d.prepare(
+    'INSERT INTO scrape_sessions (venue_slug, scrape_type, event_count, created_at) VALUES (?, ?, ?, ?) RETURNING id',
+  )
+  const session = sessionStmt.get(venueSlug, 'full', events.length, now) as { id: number }
+
+  // Get previous snapshots for change detection
+  const prevSnapshotsStmt = d.prepare(`
+    SELECT es.event_id, es.title, es.date, es.price, es.is_sold_out, es.is_cancelled
+    FROM event_snapshots es
+    INNER JOIN (
+      SELECT event_id, MAX(id) as max_id
+      FROM event_snapshots
+      WHERE venue_slug = ?
+      GROUP BY event_id
+    ) latest ON es.id = latest.max_id
+  `)
+  const prevSnapshots = prevSnapshotsStmt.all(venueSlug) as Array<{
+    event_id: string
+    title: string
+    date: string
+    price: string | null
+    is_sold_out: number
+    is_cancelled: number
+  }>
+  const prevMap = new Map(prevSnapshots.map(s => [s.event_id, s]))
+
+  // Insert new snapshots
+  const snapshotStmt = d.prepare(`
+    INSERT INTO event_snapshots (session_id, venue_slug, event_id, title, date, artists, price, is_sold_out, is_cancelled, scraped_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `)
+
+  // Upsert into events table too
+  const upsertStmt = d.prepare(`
+    INSERT INTO events (venue_slug, event_id, title, date, first_seen_at, last_seen_at)
+    VALUES (?, ?, ?, ?, ?, ?)
+    ON CONFLICT (venue_slug, event_id) DO UPDATE SET
+      title = excluded.title,
+      date = excluded.date,
+      last_seen_at = excluded.last_seen_at
+  `)
+
+  const changes: Record<string, FieldChange[]> = {}
+
+  const transaction = d.transaction(() => {
+    for (const event of events) {
+      snapshotStmt.run(
+        session.id,
+        venueSlug,
+        event.id,
+        event.title,
+        event.date,
+        event.artists ? JSON.stringify(event.artists) : null,
+        event.price ?? null,
+        event.isSoldOut ? 1 : 0,
+        event.isCancelled ? 1 : 0,
+        now,
+      )
+
+      upsertStmt.run(venueSlug, event.id, event.title, event.date, now, now)
+
+      // Detect changes from previous snapshot
+      const prev = prevMap.get(event.id)
+      if (prev) {
+        const eventChanges: FieldChange[] = []
+
+        if (prev.title !== event.title) {
+          eventChanges.push({ field: 'title', oldValue: prev.title, newValue: event.title })
+        }
+        if (prev.date !== event.date) {
+          eventChanges.push({ field: 'date', oldValue: prev.date, newValue: event.date })
+        }
+        if ((prev.price ?? null) !== (event.price ?? null)) {
+          eventChanges.push({ field: 'price', oldValue: prev.price, newValue: event.price ?? null })
+        }
+        if (Boolean(prev.is_sold_out) !== Boolean(event.isSoldOut)) {
+          eventChanges.push({ field: 'isSoldOut', oldValue: Boolean(prev.is_sold_out), newValue: Boolean(event.isSoldOut) })
+        }
+        if (Boolean(prev.is_cancelled) !== Boolean(event.isCancelled)) {
+          eventChanges.push({ field: 'isCancelled', oldValue: Boolean(prev.is_cancelled), newValue: Boolean(event.isCancelled) })
+        }
+
+        if (eventChanges.length > 0) {
+          changes[event.id] = eventChanges
+        }
+      }
+    }
+  })
+  transaction()
+
+  return { changes }
+}
+
+// ---- Ignore toggle ----
+
+export function setEventIgnored(
+  venueSlug: string,
+  eventId: string,
+  ignored: boolean,
+): void {
+  const d = getDb()
+  const now = new Date().toISOString()
+  d.prepare(
+    'UPDATE events SET is_ignored = ?, ignored_at = ? WHERE venue_slug = ? AND event_id = ?',
+  ).run(ignored ? 1 : 0, ignored ? now : null, venueSlug, eventId)
+}
+
+// ---- Metadata retrieval ----
+
+interface EventMetadata {
+  isNew: boolean
+  isIgnored: boolean
+  firstSeenAt: string
+  lastSeenAt: string
+  changes: FieldChange[]
+}
+
+export function getEventMetadata(
+  venueSlug: string,
+): Record<string, EventMetadata> {
+  const d = getDb()
+
+  // Get the timestamp of the second-most-recent preview session for this venue.
+  // Events first seen after that timestamp are "new".
+  const prevSessionStmt = d.prepare(`
+    SELECT created_at FROM scrape_sessions
+    WHERE venue_slug = ? AND scrape_type = 'preview'
+    ORDER BY id DESC
+    LIMIT 1 OFFSET 1
+  `)
+  const prevSession = prevSessionStmt.get(venueSlug) as { created_at: string } | null
+  const newThreshold = prevSession?.created_at ?? null
+
+  // Get all events for this venue
+  const eventsStmt = d.prepare(
+    'SELECT event_id, title, date, first_seen_at, last_seen_at, is_ignored FROM events WHERE venue_slug = ?',
+  )
+  const events = eventsStmt.all(venueSlug) as Array<{
+    event_id: string
+    title: string
+    date: string
+    first_seen_at: string
+    last_seen_at: string
+    is_ignored: number
+  }>
+
+  // Get latest changes from snapshots (compare last two snapshots per event)
+  const changesStmt = d.prepare(`
+    SELECT es1.event_id,
+           es1.title as new_title, es1.date as new_date, es1.price as new_price,
+           es1.is_sold_out as new_sold_out, es1.is_cancelled as new_cancelled,
+           es2.title as old_title, es2.date as old_date, es2.price as old_price,
+           es2.is_sold_out as old_sold_out, es2.is_cancelled as old_cancelled
+    FROM event_snapshots es1
+    INNER JOIN event_snapshots es2 ON es1.venue_slug = es2.venue_slug AND es1.event_id = es2.event_id
+    WHERE es1.venue_slug = ?
+      AND es1.id = (
+        SELECT MAX(id) FROM event_snapshots
+        WHERE venue_slug = es1.venue_slug AND event_id = es1.event_id
+      )
+      AND es2.id = (
+        SELECT MAX(id) FROM event_snapshots
+        WHERE venue_slug = es1.venue_slug AND event_id = es1.event_id AND id < es1.id
+      )
+  `)
+  const snapshotChanges = changesStmt.all(venueSlug) as Array<{
+    event_id: string
+    new_title: string; new_date: string; new_price: string | null; new_sold_out: number; new_cancelled: number
+    old_title: string; old_date: string; old_price: string | null; old_sold_out: number; old_cancelled: number
+  }>
+
+  const changeMap = new Map<string, FieldChange[]>()
+  for (const row of snapshotChanges) {
+    const changes: FieldChange[] = []
+    if (row.old_title !== row.new_title) {
+      changes.push({ field: 'title', oldValue: row.old_title, newValue: row.new_title })
+    }
+    if (row.old_date !== row.new_date) {
+      changes.push({ field: 'date', oldValue: row.old_date, newValue: row.new_date })
+    }
+    if (row.old_price !== row.new_price) {
+      changes.push({ field: 'price', oldValue: row.old_price, newValue: row.new_price })
+    }
+    if (Boolean(row.old_sold_out) !== Boolean(row.new_sold_out)) {
+      changes.push({ field: 'isSoldOut', oldValue: Boolean(row.old_sold_out), newValue: Boolean(row.new_sold_out) })
+    }
+    if (Boolean(row.old_cancelled) !== Boolean(row.new_cancelled)) {
+      changes.push({ field: 'isCancelled', oldValue: Boolean(row.old_cancelled), newValue: Boolean(row.new_cancelled) })
+    }
+    if (changes.length > 0) {
+      changeMap.set(row.event_id, changes)
+    }
+  }
+
+  const result: Record<string, EventMetadata> = {}
+  for (const event of events) {
+    const isNew = newThreshold !== null && event.first_seen_at > newThreshold
+    result[event.event_id] = {
+      isNew,
+      isIgnored: event.is_ignored === 1,
+      firstSeenAt: event.first_seen_at,
+      lastSeenAt: event.last_seen_at,
+      changes: changeMap.get(event.event_id) ?? [],
+    }
+  }
+
+  return result
+}
+
+// ---- Last scrape info ----
+
+export function getLastScrapeInfo(
+  venueSlug: string,
+): { lastScrapeAt: string; eventCount: number } | null {
+  const d = getDb()
+  const stmt = d.prepare(`
+    SELECT created_at, event_count FROM scrape_sessions
+    WHERE venue_slug = ?
+    ORDER BY id DESC
+    LIMIT 1
+  `)
+  const row = stmt.get(venueSlug) as { created_at: string; event_count: number } | null
+  if (!row) return null
+  return { lastScrapeAt: row.created_at, eventCount: row.event_count }
+}

--- a/discovery/src/server/index.ts
+++ b/discovery/src/server/index.ts
@@ -1,4 +1,11 @@
 import { getProvider } from './providers'
+import {
+  recordPreviewEvents,
+  recordScrapeResults,
+  setEventIgnored,
+  getEventMetadata,
+  getLastScrapeInfo,
+} from './db'
 
 const PORT = 3001
 
@@ -181,6 +188,7 @@ const server = Bun.serve({
                 const events = await provider.scrape(venueSlug, eventIds, (progress) => {
                   send('progress', progress)
                 })
+                try { recordScrapeResults(venueSlug, events) } catch (e) { console.error('[server] Failed to record scrape results:', e) }
                 send('complete', events)
               } catch (err) {
                 const message = err instanceof Error ? err.message : 'Scrape failed'
@@ -204,7 +212,38 @@ const server = Bun.serve({
         // Standard JSON mode (backward compatible)
         console.log(`[server] Scrape request for ${venueSlug}, ${eventIds.length} events`)
         const events = await provider.scrape(venueSlug, eventIds)
+        try { recordScrapeResults(venueSlug, events) } catch (e) { console.error('[server] Failed to record scrape results:', e) }
         return jsonResponse(events)
+      }
+
+      // POST /discovery/events/:venueSlug/record — Record preview events, returns new event IDs
+      if (path.match(/^\/discovery\/events\/[^/]+\/record$/) && req.method === 'POST') {
+        const venueSlug = path.split('/')[3]
+        const body = await req.json() as { events?: Array<{ id: string; title: string; date: string }> }
+        if (!Array.isArray(body.events) || body.events.length === 0) {
+          return errorResponse('events array is required')
+        }
+        const result = recordPreviewEvents(venueSlug, body.events)
+        const lastScrape = getLastScrapeInfo(venueSlug)
+        return jsonResponse({ ...result, lastScrape })
+      }
+
+      // GET /discovery/events/:venueSlug/metadata — Get event metadata (new/ignored/changes)
+      if (path.match(/^\/discovery\/events\/[^/]+\/metadata$/) && req.method === 'GET') {
+        const venueSlug = path.split('/')[3]
+        const metadata = getEventMetadata(venueSlug)
+        return jsonResponse(metadata)
+      }
+
+      // POST /discovery/events/:venueSlug/ignore — Toggle ignore on an event
+      if (path.match(/^\/discovery\/events\/[^/]+\/ignore$/) && req.method === 'POST') {
+        const venueSlug = path.split('/')[3]
+        const body = await req.json() as { eventId?: string; ignored?: boolean }
+        if (!body.eventId || typeof body.ignored !== 'boolean') {
+          return errorResponse('eventId (string) and ignored (boolean) are required')
+        }
+        setEventIgnored(venueSlug, body.eventId, body.ignored)
+        return jsonResponse({ ok: true })
       }
 
       // Health check
@@ -228,11 +267,14 @@ const bannerLines = [
   `  Running on http://localhost:${PORT}`,
   ``,
   `  Endpoints:`,
-  `    GET  /discovery/venues          - List venues`,
-  `    GET  /discovery/preview/:slug   - Preview events`,
-  `    POST /discovery/preview-batch   - Parallel preview`,
-  `    POST /discovery/scrape/:slug    - Scrape (SSE/JSON)`,
-  `    GET  /discovery/health          - Health check`,
+  `    GET  /discovery/venues               - List venues`,
+  `    GET  /discovery/preview/:slug        - Preview events`,
+  `    POST /discovery/preview-batch        - Parallel preview`,
+  `    POST /discovery/scrape/:slug         - Scrape (SSE/JSON)`,
+  `    POST /discovery/events/:slug/record  - Record preview`,
+  `    GET  /discovery/events/:slug/metadata- Event metadata`,
+  `    POST /discovery/events/:slug/ignore  - Toggle ignore`,
+  `    GET  /discovery/health               - Health check`,
   ``,
   `  Configured venues: ${Object.keys(VENUES).length}`,
 ]


### PR DESCRIPTION
## Summary

- **SQLite data layer** (`discovery/src/server/db.ts`): Uses `bun:sqlite` to persist scraping history in `discovery/data/discovery.db` (gitignored). Three tables track scrape sessions, canonical events (with ignore status), and point-in-time snapshots for change detection.
- **3 new server endpoints**: Record preview events, get event metadata (new/ignored/changes), and toggle ignore — plus scrape integration that stores snapshots automatically.
- **Tabbed event UI**: Preview cards now show **New** (unevaluated), **Imported** (already in backend), and **Ignored** (dismissed) tabs with counts, so you immediately see what needs attention.
- **Ignore/unignore**: Eye icon on each event row. Ignored events are excluded from "Select All" and persist across sessions.
- **New event detection**: "New" purple badge on events first seen after the previous scrape session.
- **Change detection**: Badges for Sold Out, Price Changed, Cancelled, Date Changed after full scrapes.

## Test plan

- [ ] Start discovery app (`cd discovery && bun run dev`)
- [ ] Preview a venue — verify `discovery/data/discovery.db` is created
- [ ] Verify New/Imported/Ignored tabs appear with correct counts
- [ ] Click ignore on an event — verify it moves to Ignored tab
- [ ] Click unignore — verify it returns to New tab
- [ ] Click "All" — verify only New tab events are selected (not imported/ignored)
- [ ] Restart the app, re-preview — verify ignored events stay ignored and previously-seen events are not marked "New"

🤖 Generated with [Claude Code](https://claude.com/claude-code)