### PR TITLE
feat: shift+click city filters, fix test type errors, iOS updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,10 @@ Thumbs.db
 .idea/
 .vscode/
 *.swp
-*.swo 
+*.swo
+*.xcuserstate
+xcuserdata/
+xcshareddata/
 
 # Environment files (CRITICAL - contains secrets)
 .env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ When starting a new task, read `docs/llm-context.md` first. It has a task-to-doc
 
 - `/frontend` - Next.js 16 app (React 19, TanStack Query, Tailwind CSS 4, Vitest)
 - `/backend` - Go API (Chi router, Huma v2, GORM, PostgreSQL 18)
+- `/ios` - Native iOS app (Swift 6, SwiftUI, iOS 18+, XcodeGen)
 - `/discovery` - Local Bun+Playwright app for scraping venue events and importing to the backend
 - `/docs` - LLM workspace: specs, strategy, plans, learnings (start with `docs/llm-context.md`)
 - `/human-docs` - Human-facing guides: contributing, workflow, release, FAQ, troubleshooting
@@ -113,4 +114,6 @@ Local tool for importing venue events. Lives in `/discovery` with Bun server + P
 **Provider types:**
 - `ticketweb` — Playwright-based, waits for `window.all_events` global (Valley Bar, Crescent Ballroom)
 - `jsonld` — HTTP fetch + JSON-LD `MusicEvent` parsing, Playwright enrichment for performer lineup (The Van Buren, Arizona Financial Theatre)
+- `seetickets` — Playwright-based, scrapes SeeTickets widget event containers (The Rebel Lounge)
+- `emptybottle` — Playwright-based, scrapes date-organized event listings (The Empty Bottle)
 - `wix` — HTTP-only (no Playwright), fetches sitemap XML → concurrent page fetches → JSON-LD `Event` extraction (Celebrity Theatre)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ A music discovery platform for Arizona and beyond — upcoming shows, venues, an
 | `cli/`       | Admin CLI tool                                 |
 | `deploy/`    | Deployment configuration                       |
 | `scripts/`   | Utility scripts (test runner, venue discovery) |
-| `docs/`      | Development documentation, plans, and learnings |
+| `docs/`      | LLM workspace: specs, strategy, plans, learnings |
+| `human-docs/`| Human-facing guides: contributing, workflow, FAQ |
 
 ## Prerequisites
 

--- a/frontend/components/filters/CityFilters.test.tsx
+++ b/frontend/components/filters/CityFilters.test.tsx
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { CityFilters, type CityWithCount, type CityState } from './CityFilters'
+
+const cities: CityWithCount[] = [
+  { city: 'Phoenix', state: 'AZ', count: 8 },
+  { city: 'Mesa', state: 'AZ', count: 3 },
+  { city: 'Tempe', state: 'AZ', count: 2 },
+]
+
+describe('CityFilters', () => {
+  it('renders "All Cities" chip and city chips with counts', () => {
+    render(
+      <CityFilters cities={cities} selectedCities={[]} onFilterChange={vi.fn()} />
+    )
+
+    expect(screen.getByText('All Cities')).toBeInTheDocument()
+    expect(screen.getByText(/Phoenix, AZ/)).toBeInTheDocument()
+    expect(screen.getByText('(8)')).toBeInTheDocument()
+    expect(screen.getByText(/Mesa, AZ/)).toBeInTheDocument()
+    expect(screen.getByText(/Tempe, AZ/)).toBeInTheDocument()
+  })
+
+  it('uses custom allLabel', () => {
+    render(
+      <CityFilters
+        cities={cities}
+        selectedCities={[]}
+        onFilterChange={vi.fn()}
+        allLabel="All Venues"
+      />
+    )
+
+    expect(screen.getByText('All Venues')).toBeInTheDocument()
+  })
+
+  it('clicking "All Cities" calls onFilterChange with empty array', async () => {
+    const onChange = vi.fn()
+    render(
+      <CityFilters
+        cities={cities}
+        selectedCities={[{ city: 'Phoenix', state: 'AZ' }]}
+        onFilterChange={onChange}
+      />
+    )
+
+    await userEvent.click(screen.getByText('All Cities'))
+    expect(onChange).toHaveBeenCalledWith([])
+  })
+
+  describe('single click (no shift)', () => {
+    it('selects only the clicked city', async () => {
+      const onChange = vi.fn()
+      render(
+        <CityFilters cities={cities} selectedCities={[]} onFilterChange={onChange} />
+      )
+
+      await userEvent.click(screen.getByText(/Phoenix, AZ/))
+      expect(onChange).toHaveBeenCalledWith([{ city: 'Phoenix', state: 'AZ' }])
+    })
+
+    it('replaces current selection with clicked city', async () => {
+      const onChange = vi.fn()
+      render(
+        <CityFilters
+          cities={cities}
+          selectedCities={[{ city: 'Phoenix', state: 'AZ' }]}
+          onFilterChange={onChange}
+        />
+      )
+
+      await userEvent.click(screen.getByText(/Mesa, AZ/))
+      expect(onChange).toHaveBeenCalledWith([{ city: 'Mesa', state: 'AZ' }])
+    })
+
+    it('deselects to "All Cities" when clicking the sole selected city', async () => {
+      const onChange = vi.fn()
+      render(
+        <CityFilters
+          cities={cities}
+          selectedCities={[{ city: 'Phoenix', state: 'AZ' }]}
+          onFilterChange={onChange}
+        />
+      )
+
+      await userEvent.click(screen.getByText(/Phoenix, AZ/))
+      expect(onChange).toHaveBeenCalledWith([])
+    })
+
+    it('single-selects when clicking one of multiple selected cities', async () => {
+      const onChange = vi.fn()
+      render(
+        <CityFilters
+          cities={cities}
+          selectedCities={[
+            { city: 'Phoenix', state: 'AZ' },
+            { city: 'Mesa', state: 'AZ' },
+          ]}
+          onFilterChange={onChange}
+        />
+      )
+
+      await userEvent.click(screen.getByText(/Phoenix, AZ/))
+      expect(onChange).toHaveBeenCalledWith([{ city: 'Phoenix', state: 'AZ' }])
+    })
+  })
+
+  describe('shift+click (multi-select)', () => {
+    it('adds a city to the selection', async () => {
+      const user = userEvent.setup()
+      const onChange = vi.fn()
+      render(
+        <CityFilters
+          cities={cities}
+          selectedCities={[{ city: 'Phoenix', state: 'AZ' }]}
+          onFilterChange={onChange}
+        />
+      )
+
+      await user.keyboard('{Shift>}')
+      await user.click(screen.getByText(/Mesa, AZ/))
+      await user.keyboard('{/Shift}')
+
+      expect(onChange).toHaveBeenCalledWith([
+        { city: 'Phoenix', state: 'AZ' },
+        { city: 'Mesa', state: 'AZ' },
+      ])
+    })
+
+    it('removes a city from the selection', async () => {
+      const user = userEvent.setup()
+      const onChange = vi.fn()
+      render(
+        <CityFilters
+          cities={cities}
+          selectedCities={[
+            { city: 'Phoenix', state: 'AZ' },
+            { city: 'Mesa', state: 'AZ' },
+          ]}
+          onFilterChange={onChange}
+        />
+      )
+
+      await user.keyboard('{Shift>}')
+      await user.click(screen.getByText(/Mesa, AZ/))
+      await user.keyboard('{/Shift}')
+
+      expect(onChange).toHaveBeenCalledWith([{ city: 'Phoenix', state: 'AZ' }])
+    })
+
+    it('adds a city when nothing is selected', async () => {
+      const user = userEvent.setup()
+      const onChange = vi.fn()
+      render(
+        <CityFilters cities={cities} selectedCities={[]} onFilterChange={onChange} />
+      )
+
+      await user.keyboard('{Shift>}')
+      await user.click(screen.getByText(/Tempe, AZ/))
+      await user.keyboard('{/Shift}')
+
+      expect(onChange).toHaveBeenCalledWith([{ city: 'Tempe', state: 'AZ' }])
+    })
+  })
+
+  it('renders children', () => {
+    render(
+      <CityFilters cities={cities} selectedCities={[]} onFilterChange={vi.fn()}>
+        <span data-testid="child">Extra</span>
+      </CityFilters>
+    )
+
+    expect(screen.getByTestId('child')).toBeInTheDocument()
+  })
+})

--- a/frontend/components/filters/CityFilters.tsx
+++ b/frontend/components/filters/CityFilters.tsx
@@ -38,14 +38,22 @@ export function CityFilters({
   const isAllSelected = selectedCities.length === 0
   const selectedSet = new Set(selectedCities.map(cityKey))
 
-  const handleToggle = (city: string, state: string) => {
+  const handleToggle = (city: string, state: string, e: React.MouseEvent) => {
     const key = cityKey({ city, state })
-    if (selectedSet.has(key)) {
-      // Remove this city
-      onFilterChange(selectedCities.filter(c => cityKey(c) !== key))
+    if (e.shiftKey) {
+      // Shift+click: toggle this city in the multi-selection
+      if (selectedSet.has(key)) {
+        onFilterChange(selectedCities.filter(c => cityKey(c) !== key))
+      } else {
+        onFilterChange([...selectedCities, { city, state }])
+      }
     } else {
-      // Add this city
-      onFilterChange([...selectedCities, { city, state }])
+      // Single click: select only this city, or deselect if already the sole selection
+      if (selectedSet.has(key) && selectedCities.length === 1) {
+        onFilterChange([])
+      } else {
+        onFilterChange([{ city, state }])
+      }
     }
   }
 
@@ -65,7 +73,7 @@ export function CityFilters({
             key={`${city.city}-${city.state}`}
             label={label}
             isActive={isActive}
-            onClick={() => handleToggle(city.city, city.state)}
+            onClick={(e) => handleToggle(city.city, city.state, e)}
             count={city.count}
           />
         )

--- a/frontend/components/filters/FilterChip.tsx
+++ b/frontend/components/filters/FilterChip.tsx
@@ -1,7 +1,7 @@
 interface FilterChipProps {
   label: string
   isActive: boolean
-  onClick: () => void
+  onClick: (e: React.MouseEvent) => void
   count?: number
 }
 

--- a/frontend/components/forms/show-form-utils.test.ts
+++ b/frontend/components/forms/show-form-utils.test.ts
@@ -51,6 +51,9 @@ function makeShowResponse(overrides?: Partial<ShowResponse>): ShowResponse {
       },
     ],
     created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    is_sold_out: false,
+    is_cancelled: false,
     ...overrides,
   }
 }

--- a/frontend/lib/api.test.ts
+++ b/frontend/lib/api.test.ts
@@ -28,7 +28,7 @@ describe('API Module', () => {
 
     it('uses production URL in production mode', async () => {
       delete process.env.NEXT_PUBLIC_API_URL
-      process.env.NODE_ENV = 'production'
+      ;(process.env as Record<string, string>).NODE_ENV = 'production'
 
       const { API_BASE_URL } = await import('./api')
 
@@ -37,7 +37,7 @@ describe('API Module', () => {
 
     it('uses /api proxy in development browser-side', async () => {
       delete process.env.NEXT_PUBLIC_API_URL
-      process.env.NODE_ENV = 'development'
+      ;(process.env as Record<string, string>).NODE_ENV = 'development'
       // jsdom provides window, so this simulates browser environment
 
       const { API_BASE_URL } = await import('./api')
@@ -345,7 +345,7 @@ describe('API Module', () => {
         json: () => Promise.reject(new Error('Invalid JSON')),
         headers: new Headers(),
       }
-      vi.mocked(fetch).mockResolvedValue(mockResponse as Response)
+      vi.mocked(fetch).mockResolvedValue(mockResponse as unknown as Response)
 
       const { apiRequest } = await import('./api')
 

--- a/frontend/lib/blog.test.ts
+++ b/frontend/lib/blog.test.ts
@@ -38,7 +38,7 @@ describe('blog utilities', () => {
         '2025-01-01-first-post.md',
         '2025-01-15-second-post.md',
         '2025-02-01-third-post.md',
-      ] as unknown as fs.Dirent[])
+      ] as unknown as ReturnType<typeof fs.readdirSync>)
 
       const { getBlogSlugs } = await import('./blog')
       const slugs = getBlogSlugs()
@@ -56,7 +56,7 @@ describe('blog utilities', () => {
         'readme.txt',
         'image.png',
         '2025-02-01-another.md',
-      ] as unknown as fs.Dirent[])
+      ] as unknown as ReturnType<typeof fs.readdirSync>)
 
       const { getBlogSlugs } = await import('./blog')
       vi.resetModules()
@@ -74,7 +74,7 @@ describe('blog utilities', () => {
         '_draft.md',
         '_template.md',
         '2025-01-01-published.md',
-      ] as unknown as fs.Dirent[])
+      ] as unknown as ReturnType<typeof fs.readdirSync>)
 
       vi.resetModules()
       const { getBlogSlugs } = await import('./blog')
@@ -203,7 +203,7 @@ Listen to this track:
         '2025-01-01-old-post.md',
         '2025-03-01-new-post.md',
         '2025-02-01-middle-post.md',
-      ] as unknown as fs.Dirent[])
+      ] as unknown as ReturnType<typeof fs.readdirSync>)
 
       vi.mocked(fs.existsSync).mockReturnValue(true)
 
@@ -244,7 +244,7 @@ Content`
     it('includes metadata for each post', async () => {
       vi.mocked(fs.readdirSync).mockReturnValue([
         '2025-01-15-test.md',
-      ] as unknown as fs.Dirent[])
+      ] as unknown as ReturnType<typeof fs.readdirSync>)
 
       vi.mocked(fs.existsSync).mockReturnValue(true)
       vi.mocked(fs.readFileSync).mockReturnValue(`---
@@ -276,7 +276,7 @@ Post content here.`)
       vi.mocked(fs.readdirSync).mockReturnValue([
         'post1.md',
         'post2.md',
-      ] as unknown as fs.Dirent[])
+      ] as unknown as ReturnType<typeof fs.readdirSync>)
 
       vi.mocked(fs.existsSync).mockReturnValue(true)
 
@@ -313,7 +313,7 @@ Content`
     it('returns empty array when no posts have categories', async () => {
       vi.mocked(fs.readdirSync).mockReturnValue([
         'post.md',
-      ] as unknown as fs.Dirent[])
+      ] as unknown as ReturnType<typeof fs.readdirSync>)
 
       vi.mocked(fs.existsSync).mockReturnValue(true)
       vi.mocked(fs.readFileSync).mockReturnValue(`---
@@ -361,7 +361,7 @@ Content`)
     it('returns category name from slug', async () => {
       vi.mocked(fs.readdirSync).mockReturnValue([
         'post.md',
-      ] as unknown as fs.Dirent[])
+      ] as unknown as ReturnType<typeof fs.readdirSync>)
 
       vi.mocked(fs.existsSync).mockReturnValue(true)
       vi.mocked(fs.readFileSync).mockReturnValue(`---
@@ -383,7 +383,7 @@ Content`)
     it('returns null for non-existent category', async () => {
       vi.mocked(fs.readdirSync).mockReturnValue([
         'post.md',
-      ] as unknown as fs.Dirent[])
+      ] as unknown as ReturnType<typeof fs.readdirSync>)
 
       vi.mocked(fs.existsSync).mockReturnValue(true)
       vi.mocked(fs.readFileSync).mockReturnValue(`---
@@ -407,7 +407,7 @@ Content`)
         'post1.md',
         'post2.md',
         'post3.md',
-      ] as unknown as fs.Dirent[])
+      ] as unknown as ReturnType<typeof fs.readdirSync>)
 
       vi.mocked(fs.existsSync).mockReturnValue(true)
 
@@ -453,7 +453,7 @@ Content`
     it('returns empty array for non-existent category', async () => {
       vi.mocked(fs.readdirSync).mockReturnValue([
         'post.md',
-      ] as unknown as fs.Dirent[])
+      ] as unknown as ReturnType<typeof fs.readdirSync>)
 
       vi.mocked(fs.existsSync).mockReturnValue(true)
       vi.mocked(fs.readFileSync).mockReturnValue(`---
@@ -475,7 +475,7 @@ Content`)
       vi.mocked(fs.readdirSync).mockReturnValue([
         'old.md',
         'new.md',
-      ] as unknown as fs.Dirent[])
+      ] as unknown as ReturnType<typeof fs.readdirSync>)
 
       vi.mocked(fs.existsSync).mockReturnValue(true)
 

--- a/frontend/lib/hooks/useAdminVenues.test.tsx
+++ b/frontend/lib/hooks/useAdminVenues.test.tsx
@@ -52,7 +52,7 @@ describe('useAdminVenues', () => {
       const mockResponse = {
         id: 1,
         name: 'Verified Venue',
-        is_verified: true,
+        verified: true,
       }
       mockApiRequest.mockResolvedValueOnce(mockResponse)
 
@@ -77,7 +77,7 @@ describe('useAdminVenues', () => {
         name: 'The Rebel Lounge',
         city: 'Phoenix',
         state: 'AZ',
-        is_verified: true,
+        verified: true,
       }
       mockApiRequest.mockResolvedValueOnce(mockVenue)
 
@@ -92,11 +92,11 @@ describe('useAdminVenues', () => {
       await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
       expect(result.current.data?.name).toBe('The Rebel Lounge')
-      expect(result.current.data?.is_verified).toBe(true)
+      expect(result.current.data?.verified).toBe(true)
     })
 
     it('invalidates venues and pending shows on success', async () => {
-      mockApiRequest.mockResolvedValueOnce({ id: 20, is_verified: true })
+      mockApiRequest.mockResolvedValueOnce({ id: 20, verified: true })
 
       const queryClient = createTestQueryClient()
       const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')

--- a/frontend/lib/hooks/useArtists.test.tsx
+++ b/frontend/lib/hooks/useArtists.test.tsx
@@ -52,8 +52,10 @@ describe('useArtists', () => {
       const mockArtist = {
         id: 1,
         name: 'Test Artist',
-        bandcamp_url: 'https://testartist.bandcamp.com',
-        spotify_url: null,
+        social: {
+          bandcamp: 'https://testartist.bandcamp.com',
+          spotify: null,
+        },
       }
       mockApiRequest.mockResolvedValueOnce(mockArtist)
 
@@ -113,10 +115,12 @@ describe('useArtists', () => {
       const mockArtist = {
         id: 2,
         name: 'Social Artist',
-        bandcamp_url: 'https://social.bandcamp.com/album/test',
-        spotify_url: 'https://open.spotify.com/artist/123',
-        website: 'https://socialartist.com',
-        instagram: '@socialartist',
+        social: {
+          bandcamp: 'https://social.bandcamp.com/album/test',
+          spotify: 'https://open.spotify.com/artist/123',
+          website: 'https://socialartist.com',
+          instagram: '@socialartist',
+        },
       }
       mockApiRequest.mockResolvedValueOnce(mockArtist)
 
@@ -126,10 +130,10 @@ describe('useArtists', () => {
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
-      expect(result.current.data?.bandcamp_url).toBe(
+      expect(result.current.data?.social.bandcamp).toBe(
         'https://social.bandcamp.com/album/test'
       )
-      expect(result.current.data?.spotify_url).toBe(
+      expect(result.current.data?.social.spotify).toBe(
         'https://open.spotify.com/artist/123'
       )
     })

--- a/frontend/lib/hooks/useAuth.test.tsx
+++ b/frontend/lib/hooks/useAuth.test.tsx
@@ -136,7 +136,7 @@ describe('useAuth hooks', () => {
       await waitFor(() => expect(result.current.isError).toBe(true))
 
       expect((result.current.error as Error).name).toBe('AuthError')
-      expect((result.current.error as { code: string }).code).toBe(
+      expect((result.current.error as unknown as { code: string }).code).toBe(
         AuthErrorCode.INVALID_CREDENTIALS
       )
     })
@@ -234,7 +234,7 @@ describe('useAuth hooks', () => {
       await waitFor(() => expect(result.current.isError).toBe(true))
 
       expect((result.current.error as Error).name).toBe('AuthError')
-      expect((result.current.error as { code: string }).code).toBe(
+      expect((result.current.error as unknown as { code: string }).code).toBe(
         AuthErrorCode.USER_EXISTS
       )
     })

--- a/frontend/lib/hooks/useSavedShows.test.tsx
+++ b/frontend/lib/hooks/useSavedShows.test.tsx
@@ -148,7 +148,7 @@ describe('useIsShowSaved', () => {
   it('checks if a show is saved', async () => {
     mockApiRequest.mockResolvedValueOnce({ is_saved: true })
 
-    const { result } = renderHook(() => useIsShowSaved(123), {
+    const { result } = renderHook(() => useIsShowSaved(123, true), {
       wrapper: createWrapper(),
     })
 
@@ -166,7 +166,7 @@ describe('useIsShowSaved', () => {
   it('returns false for unsaved shows', async () => {
     mockApiRequest.mockResolvedValueOnce({ is_saved: false })
 
-    const { result } = renderHook(() => useIsShowSaved(456), {
+    const { result } = renderHook(() => useIsShowSaved(456, true), {
       wrapper: createWrapper(),
     })
 
@@ -176,7 +176,7 @@ describe('useIsShowSaved', () => {
   })
 
   it('does not fetch when showId is null', async () => {
-    const { result } = renderHook(() => useIsShowSaved(null), {
+    const { result } = renderHook(() => useIsShowSaved(null, true), {
       wrapper: createWrapper(),
     })
 
@@ -187,7 +187,7 @@ describe('useIsShowSaved', () => {
   it('accepts string showId', async () => {
     mockApiRequest.mockResolvedValueOnce({ is_saved: true })
 
-    const { result } = renderHook(() => useIsShowSaved('789'), {
+    const { result } = renderHook(() => useIsShowSaved('789', true), {
       wrapper: createWrapper(),
     })
 
@@ -206,7 +206,7 @@ describe('useIsShowSaved', () => {
     Object.assign(error, { status: 404 })
     mockApiRequest.mockRejectedValueOnce(error)
 
-    const { result } = renderHook(() => useIsShowSaved(999), {
+    const { result } = renderHook(() => useIsShowSaved(999, true), {
       wrapper: createWrapper(),
     })
 
@@ -357,7 +357,7 @@ describe('useSaveShowToggle', () => {
   it('returns isSaved false when show is not saved', async () => {
     mockApiRequest.mockResolvedValueOnce({ is_saved: false })
 
-    const { result } = renderHook(() => useSaveShowToggle(700), {
+    const { result } = renderHook(() => useSaveShowToggle(700, true), {
       wrapper: createWrapper(),
     })
 
@@ -369,7 +369,7 @@ describe('useSaveShowToggle', () => {
   it('returns isSaved true when show is saved', async () => {
     mockApiRequest.mockResolvedValueOnce({ is_saved: true })
 
-    const { result } = renderHook(() => useSaveShowToggle(800), {
+    const { result } = renderHook(() => useSaveShowToggle(800, true), {
       wrapper: createWrapper(),
     })
 
@@ -382,7 +382,7 @@ describe('useSaveShowToggle', () => {
     // Second call: save the show
     mockApiRequest.mockResolvedValueOnce({ message: 'Saved' })
 
-    const { result } = renderHook(() => useSaveShowToggle(900), {
+    const { result } = renderHook(() => useSaveShowToggle(900, true), {
       wrapper: createWrapper(),
     })
 
@@ -407,7 +407,7 @@ describe('useSaveShowToggle', () => {
     // Second call: unsave the show
     mockApiRequest.mockResolvedValueOnce({ message: 'Unsaved' })
 
-    const { result } = renderHook(() => useSaveShowToggle(1000), {
+    const { result } = renderHook(() => useSaveShowToggle(1000, true), {
       wrapper: createWrapper(),
     })
 
@@ -433,7 +433,7 @@ describe('useSaveShowToggle', () => {
     const error = new Error('Network error')
     mockApiRequest.mockRejectedValueOnce(error)
 
-    const { result } = renderHook(() => useSaveShowToggle(1100), {
+    const { result } = renderHook(() => useSaveShowToggle(1100, true), {
       wrapper: createWrapper(),
     })
 
@@ -458,7 +458,7 @@ describe('useSaveShowToggle', () => {
     const error = new Error('Save failed')
     mockApiRequest.mockRejectedValueOnce(error)
 
-    const { result } = renderHook(() => useSaveShowToggle(1200), {
+    const { result } = renderHook(() => useSaveShowToggle(1200, true), {
       wrapper: createWrapper(),
     })
 
@@ -480,7 +480,7 @@ describe('useSaveShowToggle', () => {
     const error = new Error('Unsave failed')
     mockApiRequest.mockRejectedValueOnce(error)
 
-    const { result } = renderHook(() => useSaveShowToggle(1300), {
+    const { result } = renderHook(() => useSaveShowToggle(1300, true), {
       wrapper: createWrapper(),
     })
 

--- a/frontend/lib/hooks/useShows.test.tsx
+++ b/frontend/lib/hooks/useShows.test.tsx
@@ -157,8 +157,11 @@ describe('useShows', () => {
     it('returns has_more flag for pagination', async () => {
       mockApiRequest.mockResolvedValueOnce({
         shows: [{ id: 1 }],
-        has_more: true,
-        next_cursor: 'next-page',
+        pagination: {
+          has_more: true,
+          next_cursor: 'next-page',
+          limit: 25,
+        },
       })
 
       const { result } = renderHook(() => useUpcomingShows(), {
@@ -167,8 +170,8 @@ describe('useShows', () => {
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
-      expect(result.current.data?.has_more).toBe(true)
-      expect(result.current.data?.next_cursor).toBe('next-page')
+      expect(result.current.data?.pagination.has_more).toBe(true)
+      expect(result.current.data?.pagination.next_cursor).toBe('next-page')
     })
   })
 

--- a/frontend/lib/hooks/useVenues.test.tsx
+++ b/frontend/lib/hooks/useVenues.test.tsx
@@ -153,7 +153,7 @@ describe('useVenues', () => {
         city: 'Phoenix',
         state: 'AZ',
         address: '2303 E Indian School Rd',
-        is_verified: true,
+        verified: true,
       }
       mockApiRequest.mockResolvedValueOnce(mockVenue)
 
@@ -216,9 +216,8 @@ describe('useVenues', () => {
         city: 'Phoenix',
         state: 'AZ',
         address: '308 N 2nd Ave',
-        website: 'https://crescentphx.com',
-        phone: '602-716-2222',
-        is_verified: true,
+        social: { website: 'https://crescentphx.com' },
+        verified: true,
         show_count: 15,
       }
       mockApiRequest.mockResolvedValueOnce(mockVenue)
@@ -229,8 +228,8 @@ describe('useVenues', () => {
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
-      expect(result.current.data?.website).toBe('https://crescentphx.com')
-      expect(result.current.data?.is_verified).toBe(true)
+      expect(result.current.data?.social?.website).toBe('https://crescentphx.com')
+      expect(result.current.data?.verified).toBe(true)
     })
   })
 

--- a/frontend/lib/mixes.test.ts
+++ b/frontend/lib/mixes.test.ts
@@ -37,7 +37,7 @@ describe('mixes utilities', () => {
         '2025-01-01-mix-one.md',
         '2025-02-15-mix-two.md',
         '2025-03-01-mix-three.md',
-      ] as unknown as fs.Dirent[])
+      ] as unknown as ReturnType<typeof fs.readdirSync>)
 
       vi.resetModules()
       const { getMixSlugs } = await import('./mixes')
@@ -56,7 +56,7 @@ describe('mixes utilities', () => {
         'cover.jpg',
         'tracklist.txt',
         '2025-02-01-another-mix.md',
-      ] as unknown as fs.Dirent[])
+      ] as unknown as ReturnType<typeof fs.readdirSync>)
 
       vi.resetModules()
       const { getMixSlugs } = await import('./mixes')
@@ -73,7 +73,7 @@ describe('mixes utilities', () => {
         '_template.md',
         '_draft-mix.md',
         '2025-01-01-published-mix.md',
-      ] as unknown as fs.Dirent[])
+      ] as unknown as ReturnType<typeof fs.readdirSync>)
 
       vi.resetModules()
       const { getMixSlugs } = await import('./mixes')
@@ -211,7 +211,7 @@ Content`)
         '2025-01-01-old-mix.md',
         '2025-03-01-new-mix.md',
         '2025-02-01-middle-mix.md',
-      ] as unknown as fs.Dirent[])
+      ] as unknown as ReturnType<typeof fs.readdirSync>)
 
       vi.mocked(fs.existsSync).mockReturnValue(true)
 
@@ -256,7 +256,7 @@ Content`
     it('includes metadata for each mix', async () => {
       vi.mocked(fs.readdirSync).mockReturnValue([
         '2025-01-15-test-mix.md',
-      ] as unknown as fs.Dirent[])
+      ] as unknown as ReturnType<typeof fs.readdirSync>)
 
       vi.mocked(fs.existsSync).mockReturnValue(true)
       vi.mocked(fs.readFileSync).mockReturnValue(`---
@@ -290,7 +290,7 @@ Mix content`)
       vi.mocked(fs.readdirSync).mockReturnValue([
         'valid.md',
         'invalid.md',
-      ] as unknown as fs.Dirent[])
+      ] as unknown as ReturnType<typeof fs.readdirSync>)
 
       vi.mocked(fs.existsSync).mockImplementation(
         (path: fs.PathLike) => !path.toString().includes('invalid')
@@ -322,7 +322,7 @@ Content`)
     it('handles mixes with minimal frontmatter', async () => {
       vi.mocked(fs.readdirSync).mockReturnValue([
         'minimal.md',
-      ] as unknown as fs.Dirent[])
+      ] as unknown as ReturnType<typeof fs.readdirSync>)
 
       vi.mocked(fs.existsSync).mockReturnValue(true)
       vi.mocked(fs.readFileSync).mockReturnValue(`---

--- a/frontend/lib/types/typeHelpers.test.ts
+++ b/frontend/lib/types/typeHelpers.test.ts
@@ -9,6 +9,7 @@ describe('Type Helper Functions', () => {
     it('returns city and state when both are present', () => {
       const artist: Artist = {
         id: 1,
+        slug: 'test-artist',
         name: 'Test Artist',
         city: 'Phoenix',
         state: 'AZ',
@@ -33,6 +34,7 @@ describe('Type Helper Functions', () => {
     it('returns only city when state is null', () => {
       const artist: Artist = {
         id: 2,
+        slug: 'city-artist',
         name: 'City Artist',
         city: 'Los Angeles',
         state: null,
@@ -57,6 +59,7 @@ describe('Type Helper Functions', () => {
     it('returns only state when city is null', () => {
       const artist: Artist = {
         id: 3,
+        slug: 'state-artist',
         name: 'State Artist',
         city: null,
         state: 'California',
@@ -81,6 +84,7 @@ describe('Type Helper Functions', () => {
     it('returns "Location Unknown" when both city and state are null', () => {
       const artist: Artist = {
         id: 4,
+        slug: 'unknown-artist',
         name: 'Unknown Artist',
         city: null,
         state: null,
@@ -105,6 +109,7 @@ describe('Type Helper Functions', () => {
     it('filters out empty strings', () => {
       const artist: Artist = {
         id: 5,
+        slug: 'empty-string-artist',
         name: 'Empty String Artist',
         city: '',
         state: 'AZ',
@@ -132,6 +137,7 @@ describe('Type Helper Functions', () => {
     it('returns city and state formatted correctly', () => {
       const venue: Venue = {
         id: 1,
+        slug: 'the-rebel-lounge',
         name: 'The Rebel Lounge',
         address: '2303 E Indian School Rd',
         city: 'Phoenix',
@@ -147,6 +153,7 @@ describe('Type Helper Functions', () => {
     it('handles different cities and states', () => {
       const venue: Venue = {
         id: 2,
+        slug: 'some-venue',
         name: 'Some Venue',
         address: null,
         city: 'Tempe',
@@ -162,6 +169,7 @@ describe('Type Helper Functions', () => {
     it('handles venues with full state names', () => {
       const venue: Venue = {
         id: 3,
+        slug: 'california-venue',
         name: 'California Venue',
         address: '123 Main St',
         city: 'Los Angeles',
@@ -177,6 +185,7 @@ describe('Type Helper Functions', () => {
     it('returns formatted location for venue with all optional fields', () => {
       const venue: Venue = {
         id: 4,
+        slug: 'full-venue',
         name: 'Full Venue',
         address: '456 Oak Ave',
         city: 'Scottsdale',

--- a/frontend/lib/utils/authLogger.test.ts
+++ b/frontend/lib/utils/authLogger.test.ts
@@ -23,13 +23,13 @@ describe('authLogger', () => {
 
   afterEach(() => {
     // Restore original NODE_ENV
-    process.env.NODE_ENV = originalEnv
+    (process.env as Record<string, string>).NODE_ENV = originalEnv
     vi.restoreAllMocks()
   })
 
   describe('in development mode', () => {
     beforeEach(() => {
-      process.env.NODE_ENV = 'development'
+      (process.env as Record<string, string>).NODE_ENV = 'development'
     })
 
     it('logs debug messages', async () => {
@@ -188,7 +188,7 @@ describe('authLogger', () => {
 
   describe('in production mode', () => {
     beforeEach(() => {
-      process.env.NODE_ENV = 'production'
+      (process.env as Record<string, string>).NODE_ENV = 'production'
     })
 
     it('does not log debug messages', async () => {
@@ -232,7 +232,7 @@ describe('authLogger', () => {
 
   describe('email masking', () => {
     beforeEach(() => {
-      process.env.NODE_ENV = 'development'
+      (process.env as Record<string, string>).NODE_ENV = 'development'
     })
 
     it('masks email with 2 chars before @ and shows domain', async () => {
@@ -280,7 +280,7 @@ describe('authLogger', () => {
 
   describe('error serialization', () => {
     beforeEach(() => {
-      process.env.NODE_ENV = 'development'
+      (process.env as Record<string, string>).NODE_ENV = 'development'
     })
 
     it('serializes Error instances', async () => {

--- a/frontend/lib/utils/showLogger.test.ts
+++ b/frontend/lib/utils/showLogger.test.ts
@@ -23,13 +23,13 @@ describe('showLogger', () => {
 
   afterEach(() => {
     // Restore original NODE_ENV
-    process.env.NODE_ENV = originalEnv
+    (process.env as Record<string, string>).NODE_ENV = originalEnv
     vi.restoreAllMocks()
   })
 
   describe('in development mode', () => {
     beforeEach(() => {
-      process.env.NODE_ENV = 'development'
+      (process.env as Record<string, string>).NODE_ENV = 'development'
     })
 
     it('logs debug messages', async () => {
@@ -230,7 +230,7 @@ describe('showLogger', () => {
 
   describe('in production mode', () => {
     beforeEach(() => {
-      process.env.NODE_ENV = 'production'
+      (process.env as Record<string, string>).NODE_ENV = 'production'
     })
 
     it('does not log debug messages', async () => {
@@ -317,7 +317,7 @@ describe('showLogger', () => {
 
   describe('error serialization', () => {
     beforeEach(() => {
-      process.env.NODE_ENV = 'development'
+      (process.env as Record<string, string>).NODE_ENV = 'development'
     })
 
     it('serializes Error instances', async () => {
@@ -351,7 +351,7 @@ describe('showLogger', () => {
 
   describe('in production mode - error logging', () => {
     beforeEach(() => {
-      process.env.NODE_ENV = 'production'
+      (process.env as Record<string, string>).NODE_ENV = 'production'
     })
 
     it('logs error message with formatted prefix', async () => {

--- a/ios/PsychicHomily.xcodeproj/project.pbxproj
+++ b/ios/PsychicHomily.xcodeproj/project.pbxproj
@@ -332,7 +332,7 @@
 			path = SavedShows;
 			sourceTree = "<group>";
 		};
-		"TEMP_8068849B-8CB9-4065-BA96-1D8FCCCE5E38" /* Resources */ = {
+		"TEMP_C1A80709-7AB9-447B-87D5-E99ADBA27176" /* Resources */ = {
 			isa = PBXGroup;
 			children = (
 			);
@@ -557,7 +557,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -607,7 +607,6 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_ENTITLEMENTS = PsychicHomily/PsychicHomily.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_PREVIEWS = YES;
@@ -629,7 +628,6 @@
 		D1836A8F44B56C9AA38D928C /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_ENTITLEMENTS = PsychicHomilyShareExtension/PsychicHomilyShareExtension.entitlements;
 				CURRENT_PROJECT_VERSION = 1;
 				INFOPLIST_FILE = PsychicHomilyShareExtension/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Psychic Homily";
@@ -691,7 +689,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -708,7 +706,6 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_ENTITLEMENTS = PsychicHomily/PsychicHomily.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_PREVIEWS = YES;
@@ -730,7 +727,6 @@
 		F20846BAB637BECB676F0B3D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_ENTITLEMENTS = PsychicHomilyShareExtension/PsychicHomilyShareExtension.entitlements;
 				CURRENT_PROJECT_VERSION = 1;
 				INFOPLIST_FILE = PsychicHomilyShareExtension/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Psychic Homily";

--- a/ios/PsychicHomily/Extensions/Color+Theme.swift
+++ b/ios/PsychicHomily/Extensions/Color+Theme.swift
@@ -20,3 +20,11 @@ extension Color {
         )
     }
 }
+
+extension ShapeStyle where Self == Color {
+    static var phPrimary: Color { Color.phPrimary }
+    static var phSecondary: Color { Color.phSecondary }
+    static var phBackground: Color { Color.phBackground }
+    static var phSurface: Color { Color.phSurface }
+    static var phAccent: Color { Color.phAccent }
+}

--- a/ios/PsychicHomily/Extensions/Date+Formatting.swift
+++ b/ios/PsychicHomily/Extensions/Date+Formatting.swift
@@ -4,13 +4,13 @@ enum DateFormatting {
     /// Arizona timezone — no DST, always MST (UTC-7)
     static let arizonaTimeZone = TimeZone(identifier: "America/Phoenix")!
 
-    private static let isoParser: ISO8601DateFormatter = {
+    nonisolated(unsafe) private static let isoParser: ISO8601DateFormatter = {
         let f = ISO8601DateFormatter()
         f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         return f
     }()
 
-    private static let fallbackParser: ISO8601DateFormatter = {
+    nonisolated(unsafe) private static let fallbackParser: ISO8601DateFormatter = {
         let f = ISO8601DateFormatter()
         f.formatOptions = [.withInternetDateTime]
         return f

--- a/ios/PsychicHomily/PsychicHomily.entitlements
+++ b/ios/PsychicHomily/PsychicHomily.entitlements
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.developer.applesignin</key>
-	<array>
-		<string>Default</string>
-	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.com.psychichomily</string>

--- a/ios/PsychicHomily/ViewModels/ArtistDetailViewModel.swift
+++ b/ios/PsychicHomily/ViewModels/ArtistDetailViewModel.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-@Observable
+@MainActor @Observable
 final class ArtistDetailViewModel {
     var artist: Artist?
     var shows: [Show] = []

--- a/ios/PsychicHomily/ViewModels/AuthViewModel.swift
+++ b/ios/PsychicHomily/ViewModels/AuthViewModel.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import AuthenticationServices
 
-@Observable
+@MainActor @Observable
 final class AuthViewModel {
     var email = ""
     var password = ""

--- a/ios/PsychicHomily/ViewModels/SavedShowsViewModel.swift
+++ b/ios/PsychicHomily/ViewModels/SavedShowsViewModel.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-@Observable
+@MainActor @Observable
 final class SavedShowsViewModel {
     var shows: [Show] = []
     var isLoading = false

--- a/ios/PsychicHomily/ViewModels/ShowDetailViewModel.swift
+++ b/ios/PsychicHomily/ViewModels/ShowDetailViewModel.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-@Observable
+@MainActor @Observable
 final class ShowDetailViewModel {
     var show: Show?
     var isSaved = false

--- a/ios/PsychicHomily/ViewModels/ShowListViewModel.swift
+++ b/ios/PsychicHomily/ViewModels/ShowListViewModel.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-@Observable
+@MainActor @Observable
 final class ShowListViewModel {
     var shows: [Show] = []
     var cities: [ShowCity] = []

--- a/ios/PsychicHomily/ViewModels/SubmitShowViewModel.swift
+++ b/ios/PsychicHomily/ViewModels/SubmitShowViewModel.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import PhotosUI
 
-@Observable
+@MainActor @Observable
 final class SubmitShowViewModel {
     // Image selection
     var selectedPhoto: PhotosPickerItem?

--- a/ios/PsychicHomily/ViewModels/VenueDetailViewModel.swift
+++ b/ios/PsychicHomily/ViewModels/VenueDetailViewModel.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-@Observable
+@MainActor @Observable
 final class VenueDetailViewModel {
     var venue: Venue?
     var shows: [Show] = []

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -3,7 +3,7 @@ name: PsychicHomily
 options:
   bundleIdPrefix: com.psychichomily
   deploymentTarget:
-    iOS: "17.0"
+    iOS: "18.0"
   developmentLanguage: en
 
 settings:
@@ -11,6 +11,24 @@ settings:
     SWIFT_VERSION: "6.0"
     GENERATE_INFOPLIST_FILE: true
     SWIFT_STRICT_CONCURRENCY: complete
+
+schemes:
+  PsychicHomily:
+    build:
+      targets:
+        PsychicHomily: all
+    run:
+      config: Debug
+    test:
+      config: Debug
+      targets:
+        - PsychicHomilyTests
+    profile:
+      config: Release
+    analyze:
+      config: Debug
+    archive:
+      config: Release
 
 targets:
   PsychicHomily:
@@ -37,15 +55,6 @@ targets:
           SWIFT_ACTIVE_COMPILATION_CONDITIONS: DEBUG
         Release:
           SWIFT_ACTIVE_COMPILATION_CONDITIONS: ""
-    entitlements:
-      path: PsychicHomily/PsychicHomily.entitlements
-      properties:
-        com.apple.developer.applesignin:
-          - Default
-        com.apple.security.application-groups:
-          - group.com.psychichomily
-        keychain-access-groups:
-          - $(AppIdentifierPrefix)com.psychichomily.ios
     info:
       path: PsychicHomily/Info.plist
       properties:
@@ -75,11 +84,6 @@ targets:
         MARKETING_VERSION: "1.0.0"
         CURRENT_PROJECT_VERSION: 1
         INFOPLIST_KEY_CFBundleDisplayName: Psychic Homily
-    entitlements:
-      path: PsychicHomilyShareExtension/PsychicHomilyShareExtension.entitlements
-      properties:
-        com.apple.security.application-groups:
-          - group.com.psychichomily
     info:
       path: PsychicHomilyShareExtension/Info.plist
       properties:

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "frontend": "cd frontend && bun run dev",
     "backend": "cd backend && go run ./cmd/server",
     "discovery": "cd discovery && bun run dev",
-    "test-all": "cd scripts/test-runner && go run ."
+    "test-all": "cd scripts/test-runner && go run .",
+    "db:migrate": "docker compose -f backend/docker-compose.yml --env-file backend/.env.development run --rm migrate"
   }
 }


### PR DESCRIPTION
## Summary

- **City filter UX**: Single click now selects one city exclusively; Shift+click toggles multi-select. Clicking the sole selected city clears back to "All Cities".
- **Fix 47 TypeScript type errors** across 13 test files — tests were out of sync with current types (missing fields, renamed properties, updated function signatures, Node.js Dirent generics, read-only `process.env.NODE_ENV`).
- **iOS changes**: Various in-progress iOS app updates (ViewModels, extensions, project config, entitlements).
- **Docs/config**: Minor CLAUDE.md, README, and package.json updates.

### City filter changes
| Action | Behavior |
|---|---|
| Click a city | Selects only that city |
| Shift+click a city | Toggles it in/out of multi-selection |
| Click the sole selected city | Clears to "All Cities" |
| Click "All Cities" | Clears all filters (unchanged) |

### Test type fixes by category
| Category | Files | Fix |
|---|---|---|
| Missing fields (`slug`, `updated_at`, `is_sold_out`) | typeHelpers, show-form-utils | Added required fields to test fixtures |
| Renamed props (`is_verified` → `verified`, flat → nested `social`) | useAdminVenues, useArtists, useVenues | Updated mock data and assertions |
| Updated function signatures | useSavedShows | Added `isAuthenticated` arg |
| Nested response structure (`pagination.has_more`) | useShows | Wrapped mock data in `pagination` object |
| `process.env.NODE_ENV` read-only | api, authLogger, showLogger | Cast through `Record<string, string>` |
| `fs.Dirent` generic type | blog, mixes | Cast to `ReturnType<typeof fs.readdirSync>` |
| Unsafe error cast | useAuth | Added intermediate `unknown` cast |

## Test plan
- [x] `npx tsc --noEmit` passes with 0 errors
- [x] All 805 frontend tests pass
- [ ] Manual: click a city chip — only that city selected
- [ ] Manual: shift+click another city — both selected
- [ ] Manual: click sole selected city — returns to "All Cities"

🤖 Generated with [Claude Code](https://claude.com/claude-code)