### PR TITLE
feat: artists/venues page overhaul with show counts, search, and multi-city filters

### DIFF
--- a/backend/internal/api/handlers/artist.go
+++ b/backend/internal/api/handlers/artist.go
@@ -75,8 +75,8 @@ type ListArtistsRequest struct {
 // ListArtistsResponse represents the response for listing artists
 type ListArtistsResponse struct {
 	Body struct {
-		Artists []*services.ArtistDetailResponse `json:"artists" doc:"List of artists"`
-		Count   int                              `json:"count" doc:"Number of artists"`
+		Artists []*services.ArtistWithShowCountResponse `json:"artists" doc:"List of artists with upcoming show counts"`
+		Count   int                                     `json:"count" doc:"Number of artists"`
 	}
 }
 
@@ -113,7 +113,7 @@ func (h *ArtistHandler) ListArtistsHandler(ctx context.Context, req *ListArtists
 		}
 	}
 
-	artists, err := h.artistService.GetArtists(filters)
+	artists, err := h.artistService.GetArtistsWithShowCounts(filters)
 	if err != nil {
 		return nil, huma.Error500InternalServerError("Failed to fetch artists", err)
 	}

--- a/backend/internal/api/handlers/artist.go
+++ b/backend/internal/api/handlers/artist.go
@@ -67,8 +67,9 @@ func (h *ArtistHandler) SearchArtistsHandler(ctx context.Context, req *SearchArt
 
 // ListArtistsRequest represents the request for listing all artists
 type ListArtistsRequest struct {
-	State string `query:"state" doc:"Filter by state" example:"AZ"`
-	City  string `query:"city" doc:"Filter by city" example:"Phoenix"`
+	State  string `query:"state" doc:"Filter by state" example:"AZ"`
+	City   string `query:"city" doc:"Filter by city" example:"Phoenix"`
+	Cities string `query:"cities" doc:"Pipe-delimited multi-city filter (max 10): Phoenix,AZ|Mesa,AZ" example:"Phoenix,AZ|Mesa,AZ"`
 }
 
 // ListArtistsResponse represents the response for listing artists
@@ -82,11 +83,34 @@ type ListArtistsResponse struct {
 // ListArtistsHandler handles GET /artists - returns all artists
 func (h *ArtistHandler) ListArtistsHandler(ctx context.Context, req *ListArtistsRequest) (*ListArtistsResponse, error) {
 	filters := make(map[string]interface{})
-	if req.State != "" {
-		filters["state"] = req.State
-	}
-	if req.City != "" {
-		filters["city"] = req.City
+
+	if req.Cities != "" {
+		// Parse pipe-delimited multi-city param: "Phoenix,AZ|Mesa,AZ"
+		pairs := strings.Split(req.Cities, "|")
+		var cityFilters []map[string]string
+		for _, pair := range pairs {
+			parts := strings.SplitN(pair, ",", 2)
+			if len(parts) == 2 && parts[0] != "" && parts[1] != "" {
+				cityFilters = append(cityFilters, map[string]string{
+					"city":  strings.TrimSpace(parts[0]),
+					"state": strings.TrimSpace(parts[1]),
+				})
+			}
+		}
+		// Cap at 10 cities
+		if len(cityFilters) > 10 {
+			cityFilters = cityFilters[:10]
+		}
+		if len(cityFilters) > 0 {
+			filters["cities"] = cityFilters
+		}
+	} else {
+		if req.State != "" {
+			filters["state"] = req.State
+		}
+		if req.City != "" {
+			filters["city"] = req.City
+		}
 	}
 
 	artists, err := h.artistService.GetArtists(filters)
@@ -97,6 +121,29 @@ func (h *ArtistHandler) ListArtistsHandler(ctx context.Context, req *ListArtists
 	resp := &ListArtistsResponse{}
 	resp.Body.Artists = artists
 	resp.Body.Count = len(artists)
+
+	return resp, nil
+}
+
+// GetArtistCitiesRequest represents the request for getting artist cities
+type GetArtistCitiesRequest struct{}
+
+// GetArtistCitiesResponse represents the response for the artist cities endpoint
+type GetArtistCitiesResponse struct {
+	Body struct {
+		Cities []*services.ArtistCityResponse `json:"cities" doc:"List of cities with artist counts"`
+	}
+}
+
+// GetArtistCitiesHandler handles GET /artists/cities
+func (h *ArtistHandler) GetArtistCitiesHandler(ctx context.Context, req *GetArtistCitiesRequest) (*GetArtistCitiesResponse, error) {
+	cities, err := h.artistService.GetArtistCities()
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Failed to fetch artist cities", err)
+	}
+
+	resp := &GetArtistCitiesResponse{}
+	resp.Body.Cities = cities
 
 	return resp, nil
 }

--- a/backend/internal/api/handlers/artist_integration_test.go
+++ b/backend/internal/api/handlers/artist_integration_test.go
@@ -84,21 +84,46 @@ func (s *ArtistHandlerIntegrationSuite) TestSearchArtists_NoResults() {
 	s.Equal(0, resp.Body.Count)
 }
 
+// createArtistWithUpcomingShow creates an artist and gives it an upcoming approved show
+func (s *ArtistHandlerIntegrationSuite) createArtistWithUpcomingShow(name string) uint {
+	artistID := s.createArtistViaService(name)
+	user := createTestUser(s.deps.db)
+	venue := createVerifiedVenue(s.deps.db, fmt.Sprintf("Venue for %s", name), "Phoenix", "AZ")
+
+	show := &models.Show{
+		Title:       fmt.Sprintf("Show for %s", name),
+		EventDate:   time.Now().UTC().AddDate(0, 0, 30),
+		City:        stringPtr("Phoenix"),
+		State:       stringPtr("AZ"),
+		Status:      models.ShowStatusApproved,
+		SubmittedBy: &user.ID,
+	}
+	s.deps.db.Create(show)
+	s.deps.db.Exec("INSERT INTO show_venues (show_id, venue_id) VALUES (?, ?)", show.ID, venue.ID)
+	s.deps.db.Exec("INSERT INTO show_artists (show_id, artist_id, position, set_type) VALUES (?, ?, 0, 'headliner')", show.ID, artistID)
+	return artistID
+}
+
 // --- ListArtistsHandler ---
 
 func (s *ArtistHandlerIntegrationSuite) TestListArtists_Success() {
-	s.createArtistViaService("Artist A")
-	s.createArtistViaService("Artist B")
-	s.createArtistViaService("Artist C")
+	s.createArtistWithUpcomingShow("Artist A")
+	s.createArtistWithUpcomingShow("Artist B")
+	s.createArtistWithUpcomingShow("Artist C")
 
 	req := &ListArtistsRequest{}
 	resp, err := s.handler.ListArtistsHandler(s.deps.ctx, req)
 	s.NoError(err)
 	s.NotNil(resp)
 	s.GreaterOrEqual(resp.Body.Count, 3)
+	// Should include upcoming show counts
+	s.GreaterOrEqual(resp.Body.Artists[0].UpcomingShowCount, 1)
 }
 
 func (s *ArtistHandlerIntegrationSuite) TestListArtists_Empty() {
+	// Artists without upcoming shows should not appear
+	s.createArtistViaService("No Shows Artist")
+
 	req := &ListArtistsRequest{}
 	resp, err := s.handler.ListArtistsHandler(s.deps.ctx, req)
 	s.NoError(err)
@@ -107,8 +132,24 @@ func (s *ArtistHandlerIntegrationSuite) TestListArtists_Empty() {
 }
 
 func (s *ArtistHandlerIntegrationSuite) TestListArtists_CityFilter() {
-	s.createArtistWithCity("Phoenix Band", "Phoenix", "AZ")
+	// Create artist with city + upcoming show
+	artist := s.createArtistWithCity("Phoenix Band", "Phoenix", "AZ")
 	s.createArtistWithCity("Tucson Band", "Tucson", "AZ")
+
+	// Give Phoenix Band an upcoming show
+	user := createTestUser(s.deps.db)
+	venue := createVerifiedVenue(s.deps.db, "PHX Venue", "Phoenix", "AZ")
+	show := &models.Show{
+		Title:       "PHX Show",
+		EventDate:   time.Now().UTC().AddDate(0, 0, 30),
+		City:        stringPtr("Phoenix"),
+		State:       stringPtr("AZ"),
+		Status:      models.ShowStatusApproved,
+		SubmittedBy: &user.ID,
+	}
+	s.deps.db.Create(show)
+	s.deps.db.Exec("INSERT INTO show_venues (show_id, venue_id) VALUES (?, ?)", show.ID, venue.ID)
+	s.deps.db.Exec("INSERT INTO show_artists (show_id, artist_id, position, set_type) VALUES (?, ?, 0, 'headliner')", show.ID, artist.ID)
 
 	req := &ListArtistsRequest{City: "Phoenix"}
 	resp, err := s.handler.ListArtistsHandler(s.deps.ctx, req)

--- a/backend/internal/api/handlers/artist_test.go
+++ b/backend/internal/api/handlers/artist_test.go
@@ -292,8 +292,11 @@ func TestSearchArtists_ServiceError(t *testing.T) {
 
 func TestListArtists_Success(t *testing.T) {
 	mock := &mockArtistService{
-		getArtistsFn: func(filters map[string]interface{}) ([]*services.ArtistDetailResponse, error) {
-			return []*services.ArtistDetailResponse{{ID: 1}, {ID: 2}}, nil
+		getArtistsWithShowCountsFn: func(filters map[string]interface{}) ([]*services.ArtistWithShowCountResponse, error) {
+			return []*services.ArtistWithShowCountResponse{
+				{ArtistDetailResponse: services.ArtistDetailResponse{ID: 1, Name: "Artist A"}, UpcomingShowCount: 3},
+				{ArtistDetailResponse: services.ArtistDetailResponse{ID: 2, Name: "Artist B"}, UpcomingShowCount: 1},
+			}, nil
 		},
 	}
 	h := NewArtistHandler(mock, nil)
@@ -305,18 +308,23 @@ func TestListArtists_Success(t *testing.T) {
 	if resp.Body.Count != 2 {
 		t.Errorf("expected count=2, got %d", resp.Body.Count)
 	}
+	if resp.Body.Artists[0].UpcomingShowCount != 3 {
+		t.Errorf("expected first artist show count=3, got %d", resp.Body.Artists[0].UpcomingShowCount)
+	}
 }
 
 func TestListArtists_WithFilters(t *testing.T) {
 	mock := &mockArtistService{
-		getArtistsFn: func(filters map[string]interface{}) ([]*services.ArtistDetailResponse, error) {
+		getArtistsWithShowCountsFn: func(filters map[string]interface{}) ([]*services.ArtistWithShowCountResponse, error) {
 			if filters["state"] != "AZ" {
 				t.Errorf("expected state='AZ', got %v", filters["state"])
 			}
 			if filters["city"] != "Phoenix" {
 				t.Errorf("expected city='Phoenix', got %v", filters["city"])
 			}
-			return []*services.ArtistDetailResponse{{ID: 1}}, nil
+			return []*services.ArtistWithShowCountResponse{
+				{ArtistDetailResponse: services.ArtistDetailResponse{ID: 1}, UpcomingShowCount: 2},
+			}, nil
 		},
 	}
 	h := NewArtistHandler(mock, nil)
@@ -332,7 +340,7 @@ func TestListArtists_WithFilters(t *testing.T) {
 
 func TestListArtists_ServiceError(t *testing.T) {
 	mock := &mockArtistService{
-		getArtistsFn: func(_ map[string]interface{}) ([]*services.ArtistDetailResponse, error) {
+		getArtistsWithShowCountsFn: func(_ map[string]interface{}) ([]*services.ArtistWithShowCountResponse, error) {
 			return nil, fmt.Errorf("db error")
 		},
 	}
@@ -784,7 +792,7 @@ func TestGetArtistCities_Empty(t *testing.T) {
 
 func TestListArtists_WithCitiesFilter(t *testing.T) {
 	mock := &mockArtistService{
-		getArtistsFn: func(filters map[string]interface{}) ([]*services.ArtistDetailResponse, error) {
+		getArtistsWithShowCountsFn: func(filters map[string]interface{}) ([]*services.ArtistWithShowCountResponse, error) {
 			cities, ok := filters["cities"].([]map[string]string)
 			if !ok {
 				t.Error("expected cities filter to be []map[string]string")
@@ -795,7 +803,9 @@ func TestListArtists_WithCitiesFilter(t *testing.T) {
 			if cities[0]["city"] != "Phoenix" || cities[0]["state"] != "AZ" {
 				t.Errorf("expected first city=Phoenix,AZ, got %v", cities[0])
 			}
-			return []*services.ArtistDetailResponse{{ID: 1}}, nil
+			return []*services.ArtistWithShowCountResponse{
+				{ArtistDetailResponse: services.ArtistDetailResponse{ID: 1}, UpcomingShowCount: 1},
+			}, nil
 		},
 	}
 	h := NewArtistHandler(mock, nil)
@@ -811,7 +821,7 @@ func TestListArtists_WithCitiesFilter(t *testing.T) {
 
 func TestListArtists_CitiesOverridesLegacy(t *testing.T) {
 	mock := &mockArtistService{
-		getArtistsFn: func(filters map[string]interface{}) ([]*services.ArtistDetailResponse, error) {
+		getArtistsWithShowCountsFn: func(filters map[string]interface{}) ([]*services.ArtistWithShowCountResponse, error) {
 			// When Cities param is set, legacy city/state should not be in filters
 			if _, ok := filters["city"]; ok {
 				t.Error("legacy city filter should not be set when Cities param is provided")
@@ -819,7 +829,7 @@ func TestListArtists_CitiesOverridesLegacy(t *testing.T) {
 			if _, ok := filters["state"]; ok {
 				t.Error("legacy state filter should not be set when Cities param is provided")
 			}
-			return []*services.ArtistDetailResponse{}, nil
+			return []*services.ArtistWithShowCountResponse{}, nil
 		},
 	}
 	h := NewArtistHandler(mock, nil)

--- a/backend/internal/api/handlers/artist_test.go
+++ b/backend/internal/api/handlers/artist_test.go
@@ -718,3 +718,118 @@ func TestUpdateSpotify_Success(t *testing.T) {
 		t.Errorf("expected ID=42, got %d", resp.Body.ID)
 	}
 }
+
+// ============================================================================
+// Mock-based tests: GetArtistCitiesHandler
+// ============================================================================
+
+func TestGetArtistCities_Success(t *testing.T) {
+	mock := &mockArtistService{
+		getArtistCitiesFn: func() ([]*services.ArtistCityResponse, error) {
+			return []*services.ArtistCityResponse{
+				{City: "Phoenix", State: "AZ", ArtistCount: 10},
+				{City: "Mesa", State: "AZ", ArtistCount: 5},
+			}, nil
+		},
+	}
+	h := NewArtistHandler(mock, nil)
+
+	resp, err := h.GetArtistCitiesHandler(context.Background(), &GetArtistCitiesRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Body.Cities) != 2 {
+		t.Errorf("expected 2 cities, got %d", len(resp.Body.Cities))
+	}
+	if resp.Body.Cities[0].City != "Phoenix" {
+		t.Errorf("expected first city='Phoenix', got %q", resp.Body.Cities[0].City)
+	}
+	if resp.Body.Cities[0].ArtistCount != 10 {
+		t.Errorf("expected first count=10, got %d", resp.Body.Cities[0].ArtistCount)
+	}
+}
+
+func TestGetArtistCities_ServiceError(t *testing.T) {
+	mock := &mockArtistService{
+		getArtistCitiesFn: func() ([]*services.ArtistCityResponse, error) {
+			return nil, fmt.Errorf("db error")
+		},
+	}
+	h := NewArtistHandler(mock, nil)
+
+	_, err := h.GetArtistCitiesHandler(context.Background(), &GetArtistCitiesRequest{})
+	assertHumaError(t, err, 500)
+}
+
+func TestGetArtistCities_Empty(t *testing.T) {
+	mock := &mockArtistService{
+		getArtistCitiesFn: func() ([]*services.ArtistCityResponse, error) {
+			return []*services.ArtistCityResponse{}, nil
+		},
+	}
+	h := NewArtistHandler(mock, nil)
+
+	resp, err := h.GetArtistCitiesHandler(context.Background(), &GetArtistCitiesRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Body.Cities) != 0 {
+		t.Errorf("expected 0 cities, got %d", len(resp.Body.Cities))
+	}
+}
+
+// ============================================================================
+// Mock-based tests: ListArtistsHandler with multi-city filter
+// ============================================================================
+
+func TestListArtists_WithCitiesFilter(t *testing.T) {
+	mock := &mockArtistService{
+		getArtistsFn: func(filters map[string]interface{}) ([]*services.ArtistDetailResponse, error) {
+			cities, ok := filters["cities"].([]map[string]string)
+			if !ok {
+				t.Error("expected cities filter to be []map[string]string")
+			}
+			if len(cities) != 2 {
+				t.Errorf("expected 2 city filters, got %d", len(cities))
+			}
+			if cities[0]["city"] != "Phoenix" || cities[0]["state"] != "AZ" {
+				t.Errorf("expected first city=Phoenix,AZ, got %v", cities[0])
+			}
+			return []*services.ArtistDetailResponse{{ID: 1}}, nil
+		},
+	}
+	h := NewArtistHandler(mock, nil)
+
+	resp, err := h.ListArtistsHandler(context.Background(), &ListArtistsRequest{Cities: "Phoenix,AZ|Mesa,AZ"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Count != 1 {
+		t.Errorf("expected count=1, got %d", resp.Body.Count)
+	}
+}
+
+func TestListArtists_CitiesOverridesLegacy(t *testing.T) {
+	mock := &mockArtistService{
+		getArtistsFn: func(filters map[string]interface{}) ([]*services.ArtistDetailResponse, error) {
+			// When Cities param is set, legacy city/state should not be in filters
+			if _, ok := filters["city"]; ok {
+				t.Error("legacy city filter should not be set when Cities param is provided")
+			}
+			if _, ok := filters["state"]; ok {
+				t.Error("legacy state filter should not be set when Cities param is provided")
+			}
+			return []*services.ArtistDetailResponse{}, nil
+		},
+	}
+	h := NewArtistHandler(mock, nil)
+
+	_, err := h.ListArtistsHandler(context.Background(), &ListArtistsRequest{
+		Cities: "Phoenix,AZ",
+		City:   "Tempe",
+		State:  "AZ",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
+++ b/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
@@ -891,6 +891,7 @@ type mockArtistService struct {
 	deleteArtistFn      func(artistID uint) error
 	searchArtistsFn     func(query string) ([]*services.ArtistDetailResponse, error)
 	getShowsForArtistFn func(artistID uint, timezone string, limit int, timeFilter string) ([]*services.ArtistShowResponse, int64, error)
+	getArtistCitiesFn   func() ([]*services.ArtistCityResponse, error)
 }
 
 func (m *mockArtistService) CreateArtist(req *services.CreateArtistRequest) (*services.ArtistDetailResponse, error) {
@@ -946,6 +947,12 @@ func (m *mockArtistService) GetShowsForArtist(artistID uint, timezone string, li
 		return m.getShowsForArtistFn(artistID, timezone, limit, timeFilter)
 	}
 	return nil, 0, nil
+}
+func (m *mockArtistService) GetArtistCities() ([]*services.ArtistCityResponse, error) {
+	if m.getArtistCitiesFn != nil {
+		return m.getArtistCitiesFn()
+	}
+	return nil, nil
 }
 
 // ============================================================================

--- a/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
+++ b/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
@@ -882,16 +882,17 @@ func (m *mockVenueService) GetUnverifiedVenues(limit, offset int) ([]*services.U
 // ============================================================================
 
 type mockArtistService struct {
-	createArtistFn      func(req *services.CreateArtistRequest) (*services.ArtistDetailResponse, error)
-	getArtistFn         func(artistID uint) (*services.ArtistDetailResponse, error)
-	getArtistByNameFn   func(name string) (*services.ArtistDetailResponse, error)
-	getArtistBySlugFn   func(slug string) (*services.ArtistDetailResponse, error)
-	getArtistsFn        func(filters map[string]interface{}) ([]*services.ArtistDetailResponse, error)
-	updateArtistFn      func(artistID uint, updates map[string]interface{}) (*services.ArtistDetailResponse, error)
-	deleteArtistFn      func(artistID uint) error
-	searchArtistsFn     func(query string) ([]*services.ArtistDetailResponse, error)
-	getShowsForArtistFn func(artistID uint, timezone string, limit int, timeFilter string) ([]*services.ArtistShowResponse, int64, error)
-	getArtistCitiesFn   func() ([]*services.ArtistCityResponse, error)
+	createArtistFn              func(req *services.CreateArtistRequest) (*services.ArtistDetailResponse, error)
+	getArtistFn                 func(artistID uint) (*services.ArtistDetailResponse, error)
+	getArtistByNameFn           func(name string) (*services.ArtistDetailResponse, error)
+	getArtistBySlugFn           func(slug string) (*services.ArtistDetailResponse, error)
+	getArtistsFn                func(filters map[string]interface{}) ([]*services.ArtistDetailResponse, error)
+	getArtistsWithShowCountsFn  func(filters map[string]interface{}) ([]*services.ArtistWithShowCountResponse, error)
+	updateArtistFn              func(artistID uint, updates map[string]interface{}) (*services.ArtistDetailResponse, error)
+	deleteArtistFn              func(artistID uint) error
+	searchArtistsFn             func(query string) ([]*services.ArtistDetailResponse, error)
+	getShowsForArtistFn         func(artistID uint, timezone string, limit int, timeFilter string) ([]*services.ArtistShowResponse, int64, error)
+	getArtistCitiesFn           func() ([]*services.ArtistCityResponse, error)
 }
 
 func (m *mockArtistService) CreateArtist(req *services.CreateArtistRequest) (*services.ArtistDetailResponse, error) {
@@ -921,6 +922,12 @@ func (m *mockArtistService) GetArtistBySlug(slug string) (*services.ArtistDetail
 func (m *mockArtistService) GetArtists(filters map[string]interface{}) ([]*services.ArtistDetailResponse, error) {
 	if m.getArtistsFn != nil {
 		return m.getArtistsFn(filters)
+	}
+	return nil, nil
+}
+func (m *mockArtistService) GetArtistsWithShowCounts(filters map[string]interface{}) ([]*services.ArtistWithShowCountResponse, error) {
+	if m.getArtistsWithShowCountsFn != nil {
+		return m.getArtistsWithShowCountsFn(filters)
 	}
 	return nil, nil
 }

--- a/backend/internal/api/handlers/venue.go
+++ b/backend/internal/api/handlers/venue.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"psychic-homily-backend/internal/api/middleware"
 	apperrors "psychic-homily-backend/internal/errors"
@@ -54,6 +55,7 @@ func (h *VenueHandler) SearchVenuesHandler(ctx context.Context, req *SearchVenue
 type ListVenuesRequest struct {
 	State  string `query:"state" doc:"Filter by state" example:"AZ"`
 	City   string `query:"city" doc:"Filter by city" example:"Phoenix"`
+	Cities string `query:"cities" doc:"Pipe-delimited multi-city filter (max 10): Phoenix,AZ|Tucson,AZ" example:"Phoenix,AZ|Tucson,AZ"`
 	Limit  int    `query:"limit" default:"50" minimum:"1" maximum:"100" doc:"Maximum number of venues to return"`
 	Offset int    `query:"offset" default:"0" minimum:"0" doc:"Offset for pagination"`
 }
@@ -70,9 +72,29 @@ type ListVenuesResponse struct {
 
 // ListVenuesHandler handles GET /venues - returns verified venues with upcoming show counts
 func (h *VenueHandler) ListVenuesHandler(ctx context.Context, req *ListVenuesRequest) (*ListVenuesResponse, error) {
-	filters := services.VenueListFilters{
-		State: req.State,
-		City:  req.City,
+	filters := services.VenueListFilters{}
+
+	if req.Cities != "" {
+		// Parse pipe-delimited multi-city param: "Phoenix,AZ|Tucson,AZ"
+		pairs := strings.Split(req.Cities, "|")
+		var cityFilters []services.CityStateFilter
+		for _, pair := range pairs {
+			parts := strings.SplitN(pair, ",", 2)
+			if len(parts) == 2 && parts[0] != "" && parts[1] != "" {
+				cityFilters = append(cityFilters, services.CityStateFilter{
+					City:  strings.TrimSpace(parts[0]),
+					State: strings.TrimSpace(parts[1]),
+				})
+			}
+		}
+		// Cap at 10 cities
+		if len(cityFilters) > 10 {
+			cityFilters = cityFilters[:10]
+		}
+		filters.Cities = cityFilters
+	} else {
+		filters.State = req.State
+		filters.City = req.City
 	}
 
 	limit := req.Limit

--- a/backend/internal/api/handlers/venue_integration_test.go
+++ b/backend/internal/api/handlers/venue_integration_test.go
@@ -90,6 +90,18 @@ func (s *VenueHandlerIntegrationSuite) TestListVenues_CityFilter() {
 	s.Equal(int64(1), resp.Body.Total)
 }
 
+func (s *VenueHandlerIntegrationSuite) TestListVenues_MultiCityFilter() {
+	createVerifiedVenue(s.deps.db, "Valley Bar", "Phoenix", "AZ")
+	createVerifiedVenue(s.deps.db, "Club Congress", "Tucson", "AZ")
+	createVerifiedVenue(s.deps.db, "Empty Bottle", "Chicago", "IL")
+
+	req := &ListVenuesRequest{Cities: "Phoenix,AZ|Chicago,IL", Limit: 50, Offset: 0}
+	resp, err := s.handler.ListVenuesHandler(s.deps.ctx, req)
+	s.NoError(err)
+	s.Equal(int64(2), resp.Body.Total)
+	s.Len(resp.Body.Venues, 2)
+}
+
 // --- GetVenueHandler ---
 
 func (s *VenueHandlerIntegrationSuite) TestGetVenue_ByID() {

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -264,6 +264,7 @@ func setupArtistRoutes(api huma.API, protected *huma.Group, sc *services.Service
 	// Public artist endpoints - registered on main API without middleware
 	// Note: Static routes must come before parameterized routes
 	huma.Get(api, "/artists", artistHandler.ListArtistsHandler)
+	huma.Get(api, "/artists/cities", artistHandler.GetArtistCitiesHandler)
 	huma.Get(api, "/artists/search", artistHandler.SearchArtistsHandler)
 	huma.Get(api, "/artists/{artist_id}", artistHandler.GetArtistHandler)
 	huma.Get(api, "/artists/{artist_id}/shows", artistHandler.GetArtistShowsHandler)

--- a/backend/internal/services/artist.go
+++ b/backend/internal/services/artist.go
@@ -345,6 +345,78 @@ func (s *ArtistService) SearchArtists(query string) ([]*ArtistDetailResponse, er
 	return responses, nil
 }
 
+// ArtistWithCount is used internally for querying artists with their show counts
+type ArtistWithCount struct {
+	models.Artist
+	UpcomingShowCount int64 `gorm:"column:upcoming_show_count"`
+}
+
+// ArtistWithShowCountResponse represents an artist with its upcoming show count
+type ArtistWithShowCountResponse struct {
+	ArtistDetailResponse
+	UpcomingShowCount int `json:"upcoming_show_count"`
+}
+
+// GetArtistsWithShowCounts retrieves artists that have upcoming approved shows,
+// with their show counts. Results are sorted by show count (descending), then name (ascending).
+func (s *ArtistService) GetArtistsWithShowCounts(filters map[string]interface{}) ([]*ArtistWithShowCountResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	now := time.Now().UTC()
+
+	// Subquery: count upcoming approved shows per artist
+	subquery := s.db.Table("show_artists").
+		Select("show_artists.artist_id, COUNT(*) as show_count").
+		Joins("JOIN shows ON show_artists.show_id = shows.id").
+		Where("shows.event_date >= ? AND shows.status = ?", now, models.ShowStatusApproved).
+		Group("show_artists.artist_id")
+
+	// Main query: join artists with show counts, only include artists with upcoming shows
+	query := s.db.Table("artists").
+		Select("artists.*, COALESCE(sc.show_count, 0) as upcoming_show_count").
+		Joins("JOIN (?) as sc ON artists.id = sc.artist_id", subquery)
+
+	// Apply filters
+	if cities, ok := filters["cities"].([]map[string]string); ok && len(cities) > 0 {
+		var conditions []string
+		var args []interface{}
+		for _, cs := range cities {
+			if cs["city"] != "" && cs["state"] != "" {
+				conditions = append(conditions, "(artists.city = ? AND artists.state = ?)")
+				args = append(args, cs["city"], cs["state"])
+			}
+		}
+		if len(conditions) > 0 {
+			query = query.Where(strings.Join(conditions, " OR "), args...)
+		}
+	} else {
+		if state, ok := filters["state"].(string); ok && state != "" {
+			query = query.Where("artists.state = ?", state)
+		}
+		if city, ok := filters["city"].(string); ok && city != "" {
+			query = query.Where("artists.city = ?", city)
+		}
+	}
+
+	var artistsWithCount []ArtistWithCount
+	if err := query.Order("upcoming_show_count DESC, artists.name ASC").Find(&artistsWithCount).Error; err != nil {
+		return nil, fmt.Errorf("failed to get artists with show counts: %w", err)
+	}
+
+	// Build responses
+	responses := make([]*ArtistWithShowCountResponse, len(artistsWithCount))
+	for i, ac := range artistsWithCount {
+		responses[i] = &ArtistWithShowCountResponse{
+			ArtistDetailResponse: *s.buildArtistResponse(&ac.Artist),
+			UpcomingShowCount:    int(ac.UpcomingShowCount),
+		}
+	}
+
+	return responses, nil
+}
+
 // ArtistCityResponse represents a city with artist count for filtering
 type ArtistCityResponse struct {
 	City        string `json:"city"`
@@ -352,12 +424,15 @@ type ArtistCityResponse struct {
 	ArtistCount int    `json:"artist_count"`
 }
 
-// GetArtistCities returns distinct cities that have artists, with artist counts.
+// GetArtistCities returns distinct cities for artists that have upcoming approved shows.
+// Only artists with both city and state set are included.
 // Results are sorted by artist count (descending) to show most active cities first.
 func (s *ArtistService) GetArtistCities() ([]*ArtistCityResponse, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
+
+	now := time.Now().UTC()
 
 	type CityResult struct {
 		City        string
@@ -365,10 +440,17 @@ func (s *ArtistService) GetArtistCities() ([]*ArtistCityResponse, error) {
 		ArtistCount int64
 	}
 
+	// Subquery: artist IDs that have upcoming approved shows
+	artistsWithShows := s.db.Table("show_artists").
+		Select("DISTINCT show_artists.artist_id").
+		Joins("JOIN shows ON show_artists.show_id = shows.id").
+		Where("shows.event_date >= ? AND shows.status = ?", now, models.ShowStatusApproved)
+
 	var results []CityResult
 	err := s.db.Table("artists").
 		Select("city, state, COUNT(*) as artist_count").
 		Where("city IS NOT NULL AND city != '' AND state IS NOT NULL AND state != ''").
+		Where("id IN (?)", artistsWithShows).
 		Group("city, state").
 		Order("artist_count DESC, city ASC").
 		Find(&results).Error

--- a/backend/internal/services/artist.go
+++ b/backend/internal/services/artist.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"gorm.io/gorm"
@@ -178,11 +179,26 @@ func (s *ArtistService) GetArtists(filters map[string]interface{}) ([]*ArtistDet
 	query := s.db
 
 	// Apply filters
-	if state, ok := filters["state"].(string); ok && state != "" {
-		query = query.Where("state = ?", state)
-	}
-	if city, ok := filters["city"].(string); ok && city != "" {
-		query = query.Where("city = ?", city)
+	if cities, ok := filters["cities"].([]map[string]string); ok && len(cities) > 0 {
+		// Multi-city filter: (city = ? AND state = ?) OR ...
+		var conditions []string
+		var args []interface{}
+		for _, cs := range cities {
+			if cs["city"] != "" && cs["state"] != "" {
+				conditions = append(conditions, "(city = ? AND state = ?)")
+				args = append(args, cs["city"], cs["state"])
+			}
+		}
+		if len(conditions) > 0 {
+			query = query.Where(strings.Join(conditions, " OR "), args...)
+		}
+	} else {
+		if state, ok := filters["state"].(string); ok && state != "" {
+			query = query.Where("state = ?", state)
+		}
+		if city, ok := filters["city"].(string); ok && city != "" {
+			query = query.Where("city = ?", city)
+		}
 	}
 	if name, ok := filters["name"].(string); ok && name != "" {
 		query = query.Where("LOWER(name) LIKE LOWER(?)", "%"+name+"%")
@@ -324,6 +340,49 @@ func (s *ArtistService) SearchArtists(query string) ([]*ArtistDetailResponse, er
 	responses := make([]*ArtistDetailResponse, len(artists))
 	for i, artist := range artists {
 		responses[i] = s.buildArtistResponse(&artist)
+	}
+
+	return responses, nil
+}
+
+// ArtistCityResponse represents a city with artist count for filtering
+type ArtistCityResponse struct {
+	City        string `json:"city"`
+	State       string `json:"state"`
+	ArtistCount int    `json:"artist_count"`
+}
+
+// GetArtistCities returns distinct cities that have artists, with artist counts.
+// Results are sorted by artist count (descending) to show most active cities first.
+func (s *ArtistService) GetArtistCities() ([]*ArtistCityResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	type CityResult struct {
+		City        string
+		State       string
+		ArtistCount int64
+	}
+
+	var results []CityResult
+	err := s.db.Table("artists").
+		Select("city, state, COUNT(*) as artist_count").
+		Where("city IS NOT NULL AND city != '' AND state IS NOT NULL AND state != ''").
+		Group("city, state").
+		Order("artist_count DESC, city ASC").
+		Find(&results).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to get artist cities: %w", err)
+	}
+
+	responses := make([]*ArtistCityResponse, len(results))
+	for i, r := range results {
+		responses[i] = &ArtistCityResponse{
+			City:        r.City,
+			State:       r.State,
+			ArtistCount: int(r.ArtistCount),
+		}
 	}
 
 	return responses, nil

--- a/backend/internal/services/artist_test.go
+++ b/backend/internal/services/artist_test.go
@@ -94,6 +94,13 @@ func TestArtistService_NilDatabase(t *testing.T) {
 		assert.Nil(t, resp)
 		assert.Zero(t, total)
 	})
+
+	t.Run("GetArtistCities", func(t *testing.T) {
+		resp, err := svc.GetArtistCities()
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
 }
 
 // =============================================================================
@@ -445,6 +452,24 @@ func (suite *ArtistServiceIntegrationTestSuite) TestGetArtists_FilterByCity() {
 	suite.Equal("PHX Artist", resp[0].Name)
 }
 
+func (suite *ArtistServiceIntegrationTestSuite) TestGetArtists_MultiCityFilter() {
+	suite.artistService.CreateArtist(&CreateArtistRequest{Name: "PHX Band", City: stringPtr("Phoenix"), State: stringPtr("AZ")})
+	suite.artistService.CreateArtist(&CreateArtistRequest{Name: "Mesa Band", City: stringPtr("Mesa"), State: stringPtr("AZ")})
+	suite.artistService.CreateArtist(&CreateArtistRequest{Name: "LA Band", City: stringPtr("Los Angeles"), State: stringPtr("CA")})
+
+	cities := []map[string]string{
+		{"city": "Phoenix", "state": "AZ"},
+		{"city": "Mesa", "state": "AZ"},
+	}
+	resp, err := suite.artistService.GetArtists(map[string]interface{}{"cities": cities})
+
+	suite.Require().NoError(err)
+	suite.Require().Len(resp, 2)
+	names := []string{resp[0].Name, resp[1].Name}
+	suite.Contains(names, "Mesa Band")
+	suite.Contains(names, "PHX Band")
+}
+
 func (suite *ArtistServiceIntegrationTestSuite) TestGetArtists_FilterByState() {
 	suite.artistService.CreateArtist(&CreateArtistRequest{Name: "AZ Artist", State: stringPtr("AZ")})
 	suite.artistService.CreateArtist(&CreateArtistRequest{Name: "CA Artist", State: stringPtr("CA")})
@@ -787,4 +812,46 @@ func (suite *ArtistServiceIntegrationTestSuite) TestGetShowsForArtist_RespectsLi
 	suite.Require().NoError(err)
 	suite.Equal(int64(5), total) // total count is still 5
 	suite.Len(resp, 3)           // but only 3 returned
+}
+
+// =============================================================================
+// Group 8: GetArtistCities
+// =============================================================================
+
+func (suite *ArtistServiceIntegrationTestSuite) TestGetArtistCities_Success() {
+	// Create artists in different cities
+	suite.artistService.CreateArtist(&CreateArtistRequest{Name: "PHX Artist 1", City: stringPtr("Phoenix"), State: stringPtr("AZ")})
+	suite.artistService.CreateArtist(&CreateArtistRequest{Name: "PHX Artist 2", City: stringPtr("Phoenix"), State: stringPtr("AZ")})
+	suite.artistService.CreateArtist(&CreateArtistRequest{Name: "Mesa Artist", City: stringPtr("Mesa"), State: stringPtr("AZ")})
+
+	resp, err := suite.artistService.GetArtistCities()
+
+	suite.Require().NoError(err)
+	suite.Require().Len(resp, 2)
+	// Ordered by count DESC, then city ASC
+	suite.Equal("Phoenix", resp[0].City)
+	suite.Equal("AZ", resp[0].State)
+	suite.Equal(2, resp[0].ArtistCount)
+	suite.Equal("Mesa", resp[1].City)
+	suite.Equal(1, resp[1].ArtistCount)
+}
+
+func (suite *ArtistServiceIntegrationTestSuite) TestGetArtistCities_ExcludesNullCity() {
+	// Artist with no city/state should not appear
+	suite.artistService.CreateArtist(&CreateArtistRequest{Name: "No City Artist"})
+	suite.artistService.CreateArtist(&CreateArtistRequest{Name: "Has City", City: stringPtr("Tempe"), State: stringPtr("AZ")})
+
+	resp, err := suite.artistService.GetArtistCities()
+
+	suite.Require().NoError(err)
+	suite.Require().Len(resp, 1)
+	suite.Equal("Tempe", resp[0].City)
+}
+
+func (suite *ArtistServiceIntegrationTestSuite) TestGetArtistCities_Empty() {
+	// No artists at all
+	resp, err := suite.artistService.GetArtistCities()
+
+	suite.Require().NoError(err)
+	suite.Empty(resp)
 }

--- a/backend/internal/services/artist_test.go
+++ b/backend/internal/services/artist_test.go
@@ -101,6 +101,13 @@ func TestArtistService_NilDatabase(t *testing.T) {
 		assert.Equal(t, "database not initialized", err.Error())
 		assert.Nil(t, resp)
 	})
+
+	t.Run("GetArtistsWithShowCounts", func(t *testing.T) {
+		resp, err := svc.GetArtistsWithShowCounts(nil)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
 }
 
 // =============================================================================
@@ -819,10 +826,18 @@ func (suite *ArtistServiceIntegrationTestSuite) TestGetShowsForArtist_RespectsLi
 // =============================================================================
 
 func (suite *ArtistServiceIntegrationTestSuite) TestGetArtistCities_Success() {
-	// Create artists in different cities
-	suite.artistService.CreateArtist(&CreateArtistRequest{Name: "PHX Artist 1", City: stringPtr("Phoenix"), State: stringPtr("AZ")})
-	suite.artistService.CreateArtist(&CreateArtistRequest{Name: "PHX Artist 2", City: stringPtr("Phoenix"), State: stringPtr("AZ")})
-	suite.artistService.CreateArtist(&CreateArtistRequest{Name: "Mesa Artist", City: stringPtr("Mesa"), State: stringPtr("AZ")})
+	venue := suite.createTestVenue("City Venue", "Phoenix", "AZ")
+	user := suite.createTestUser()
+
+	// Create artists in different cities with upcoming shows
+	a1, _ := suite.artistService.CreateArtist(&CreateArtistRequest{Name: "PHX Artist 1", City: stringPtr("Phoenix"), State: stringPtr("AZ")})
+	a2, _ := suite.artistService.CreateArtist(&CreateArtistRequest{Name: "PHX Artist 2", City: stringPtr("Phoenix"), State: stringPtr("AZ")})
+	a3, _ := suite.artistService.CreateArtist(&CreateArtistRequest{Name: "Mesa Artist", City: stringPtr("Mesa"), State: stringPtr("AZ")})
+
+	// Give all three artists upcoming shows
+	suite.createApprovedShowWithArtist(a1.ID, venue.ID, user.ID, time.Now().UTC().AddDate(0, 0, 7))
+	suite.createApprovedShowWithArtist(a2.ID, venue.ID, user.ID, time.Now().UTC().AddDate(0, 0, 14))
+	suite.createApprovedShowWithArtist(a3.ID, venue.ID, user.ID, time.Now().UTC().AddDate(0, 0, 21))
 
 	resp, err := suite.artistService.GetArtistCities()
 
@@ -837,9 +852,16 @@ func (suite *ArtistServiceIntegrationTestSuite) TestGetArtistCities_Success() {
 }
 
 func (suite *ArtistServiceIntegrationTestSuite) TestGetArtistCities_ExcludesNullCity() {
-	// Artist with no city/state should not appear
-	suite.artistService.CreateArtist(&CreateArtistRequest{Name: "No City Artist"})
-	suite.artistService.CreateArtist(&CreateArtistRequest{Name: "Has City", City: stringPtr("Tempe"), State: stringPtr("AZ")})
+	venue := suite.createTestVenue("NullCity Venue", "Phoenix", "AZ")
+	user := suite.createTestUser()
+
+	// Artist with no city/state should not appear even with upcoming show
+	noCityArtist := suite.createTestArtist("No City Artist")
+	suite.createApprovedShowWithArtist(noCityArtist.ID, venue.ID, user.ID, time.Now().UTC().AddDate(0, 0, 7))
+
+	// Artist with city and upcoming show should appear
+	hasCityArtist, _ := suite.artistService.CreateArtist(&CreateArtistRequest{Name: "Has City", City: stringPtr("Tempe"), State: stringPtr("AZ")})
+	suite.createApprovedShowWithArtist(hasCityArtist.ID, venue.ID, user.ID, time.Now().UTC().AddDate(0, 0, 14))
 
 	resp, err := suite.artistService.GetArtistCities()
 
@@ -848,10 +870,103 @@ func (suite *ArtistServiceIntegrationTestSuite) TestGetArtistCities_ExcludesNull
 	suite.Equal("Tempe", resp[0].City)
 }
 
+func (suite *ArtistServiceIntegrationTestSuite) TestGetArtistCities_ExcludesArtistsWithoutUpcomingShows() {
+	venue := suite.createTestVenue("Past Venue", "Phoenix", "AZ")
+	user := suite.createTestUser()
+
+	// Artist with city but only past shows should not appear
+	pastArtist, _ := suite.artistService.CreateArtist(&CreateArtistRequest{Name: "Past Artist", City: stringPtr("Phoenix"), State: stringPtr("AZ")})
+	suite.createApprovedShowWithArtist(pastArtist.ID, venue.ID, user.ID, time.Now().UTC().AddDate(0, 0, -7))
+
+	// Artist with city but no shows at all should not appear
+	suite.artistService.CreateArtist(&CreateArtistRequest{Name: "No Show Artist", City: stringPtr("Mesa"), State: stringPtr("AZ")})
+
+	resp, err := suite.artistService.GetArtistCities()
+
+	suite.Require().NoError(err)
+	suite.Empty(resp)
+}
+
 func (suite *ArtistServiceIntegrationTestSuite) TestGetArtistCities_Empty() {
 	// No artists at all
 	resp, err := suite.artistService.GetArtistCities()
 
 	suite.Require().NoError(err)
 	suite.Empty(resp)
+}
+
+// =============================================================================
+// Group 9: GetArtistsWithShowCounts
+// =============================================================================
+
+func (suite *ArtistServiceIntegrationTestSuite) TestGetArtistsWithShowCounts_OnlyUpcoming() {
+	artist1 := suite.createTestArtist("Active Artist")
+	artist2 := suite.createTestArtist("Inactive Artist")
+	venue := suite.createTestVenue("Test Venue", "Phoenix", "AZ")
+	user := suite.createTestUser()
+
+	// artist1 has an upcoming show
+	suite.createApprovedShowWithArtist(artist1.ID, venue.ID, user.ID, time.Now().UTC().AddDate(0, 0, 7))
+	// artist2 has only a past show
+	suite.createApprovedShowWithArtist(artist2.ID, venue.ID, user.ID, time.Now().UTC().AddDate(0, 0, -7))
+
+	resp, err := suite.artistService.GetArtistsWithShowCounts(map[string]interface{}{})
+
+	suite.Require().NoError(err)
+	suite.Require().Len(resp, 1)
+	suite.Equal("Active Artist", resp[0].Name)
+	suite.Equal(1, resp[0].UpcomingShowCount)
+}
+
+func (suite *ArtistServiceIntegrationTestSuite) TestGetArtistsWithShowCounts_SortedByCount() {
+	artist1 := suite.createTestArtist("Few Shows")
+	artist2 := suite.createTestArtist("Many Shows")
+	venue := suite.createTestVenue("Sort Venue", "Phoenix", "AZ")
+	user := suite.createTestUser()
+
+	// artist1: 1 upcoming show
+	suite.createApprovedShowWithArtist(artist1.ID, venue.ID, user.ID, time.Now().UTC().AddDate(0, 0, 7))
+	// artist2: 3 upcoming shows
+	suite.createApprovedShowWithArtist(artist2.ID, venue.ID, user.ID, time.Now().UTC().AddDate(0, 0, 7))
+	suite.createApprovedShowWithArtist(artist2.ID, venue.ID, user.ID, time.Now().UTC().AddDate(0, 0, 14))
+	suite.createApprovedShowWithArtist(artist2.ID, venue.ID, user.ID, time.Now().UTC().AddDate(0, 0, 21))
+
+	resp, err := suite.artistService.GetArtistsWithShowCounts(map[string]interface{}{})
+
+	suite.Require().NoError(err)
+	suite.Require().Len(resp, 2)
+	// Sorted by count DESC
+	suite.Equal("Many Shows", resp[0].Name)
+	suite.Equal(3, resp[0].UpcomingShowCount)
+	suite.Equal("Few Shows", resp[1].Name)
+	suite.Equal(1, resp[1].UpcomingShowCount)
+}
+
+func (suite *ArtistServiceIntegrationTestSuite) TestGetArtistsWithShowCounts_Empty() {
+	// No artists with upcoming shows
+	suite.createTestArtist("No Shows Artist")
+
+	resp, err := suite.artistService.GetArtistsWithShowCounts(map[string]interface{}{})
+
+	suite.Require().NoError(err)
+	suite.Empty(resp)
+}
+
+func (suite *ArtistServiceIntegrationTestSuite) TestGetArtistsWithShowCounts_WithCityFilter() {
+	artist1 := suite.createTestArtist("PHX Artist")
+	suite.db.Model(artist1).Updates(map[string]interface{}{"city": "Phoenix", "state": "AZ"})
+	artist2 := suite.createTestArtist("LA Artist")
+	suite.db.Model(artist2).Updates(map[string]interface{}{"city": "Los Angeles", "state": "CA"})
+	venue := suite.createTestVenue("Filter Venue", "Phoenix", "AZ")
+	user := suite.createTestUser()
+
+	suite.createApprovedShowWithArtist(artist1.ID, venue.ID, user.ID, time.Now().UTC().AddDate(0, 0, 7))
+	suite.createApprovedShowWithArtist(artist2.ID, venue.ID, user.ID, time.Now().UTC().AddDate(0, 0, 7))
+
+	cities := []map[string]string{{"city": "Phoenix", "state": "AZ"}}
+	resp, err := suite.artistService.GetArtistsWithShowCounts(map[string]interface{}{"cities": cities})
+
+	suite.Require().NoError(err)
+	suite.Require().Len(resp, 1)
+	suite.Equal("PHX Artist", resp[0].Name)
 }

--- a/backend/internal/services/interfaces.go
+++ b/backend/internal/services/interfaces.go
@@ -73,6 +73,7 @@ type ArtistServiceInterface interface {
 	GetArtistByName(name string) (*ArtistDetailResponse, error)
 	GetArtistBySlug(slug string) (*ArtistDetailResponse, error)
 	GetArtists(filters map[string]interface{}) ([]*ArtistDetailResponse, error)
+	GetArtistsWithShowCounts(filters map[string]interface{}) ([]*ArtistWithShowCountResponse, error)
 	UpdateArtist(artistID uint, updates map[string]interface{}) (*ArtistDetailResponse, error)
 	DeleteArtist(artistID uint) error
 	SearchArtists(query string) ([]*ArtistDetailResponse, error)

--- a/backend/internal/services/interfaces.go
+++ b/backend/internal/services/interfaces.go
@@ -77,6 +77,7 @@ type ArtistServiceInterface interface {
 	DeleteArtist(artistID uint) error
 	SearchArtists(query string) ([]*ArtistDetailResponse, error)
 	GetShowsForArtist(artistID uint, timezone string, limit int, timeFilter string) ([]*ArtistShowResponse, int64, error)
+	GetArtistCities() ([]*ArtistCityResponse, error)
 }
 
 // SavedShowServiceInterface defines the contract for saved show operations.

--- a/backend/internal/services/venue.go
+++ b/backend/internal/services/venue.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"gorm.io/gorm"
@@ -486,6 +487,7 @@ type VenueWithShowCountResponse struct {
 type VenueListFilters struct {
 	State    string
 	City     string
+	Cities   []CityStateFilter
 	Verified *bool
 }
 
@@ -520,21 +522,49 @@ func (s *VenueService) GetVenuesWithShowCounts(filters VenueListFilters, limit, 
 		Where("venues.verified = ?", true)
 
 	// Apply optional filters
-	if filters.State != "" {
-		query = query.Where("venues.state = ?", filters.State)
-	}
-	if filters.City != "" {
-		query = query.Where("venues.city = ?", filters.City)
+	if len(filters.Cities) > 0 {
+		var conditions []string
+		var args []interface{}
+		for _, cs := range filters.Cities {
+			if cs.City != "" && cs.State != "" {
+				conditions = append(conditions, "(venues.city = ? AND venues.state = ?)")
+				args = append(args, cs.City, cs.State)
+			}
+		}
+		if len(conditions) > 0 {
+			query = query.Where(strings.Join(conditions, " OR "), args...)
+		}
+	} else {
+		if filters.State != "" {
+			query = query.Where("venues.state = ?", filters.State)
+		}
+		if filters.City != "" {
+			query = query.Where("venues.city = ?", filters.City)
+		}
 	}
 
 	// Get total count of matching venues
 	var total int64
 	countQuery := s.db.Table("venues").Where("verified = ?", true)
-	if filters.State != "" {
-		countQuery = countQuery.Where("state = ?", filters.State)
-	}
-	if filters.City != "" {
-		countQuery = countQuery.Where("city = ?", filters.City)
+	if len(filters.Cities) > 0 {
+		var conditions []string
+		var args []interface{}
+		for _, cs := range filters.Cities {
+			if cs.City != "" && cs.State != "" {
+				conditions = append(conditions, "(city = ? AND state = ?)")
+				args = append(args, cs.City, cs.State)
+			}
+		}
+		if len(conditions) > 0 {
+			countQuery = countQuery.Where(strings.Join(conditions, " OR "), args...)
+		}
+	} else {
+		if filters.State != "" {
+			countQuery = countQuery.Where("state = ?", filters.State)
+		}
+		if filters.City != "" {
+			countQuery = countQuery.Where("city = ?", filters.City)
+		}
 	}
 	if err := countQuery.Count(&total).Error; err != nil {
 		return nil, 0, fmt.Errorf("failed to count venues: %w", err)

--- a/frontend/app/artists/page.tsx
+++ b/frontend/app/artists/page.tsx
@@ -1,0 +1,94 @@
+import { Suspense } from 'react'
+import * as Sentry from '@sentry/nextjs'
+import { ArtistList, ArtistListSkeleton } from '@/components/artists'
+import { JsonLd } from '@/components/seo/JsonLd'
+import { generateItemListSchema, generateBreadcrumbSchema } from '@/lib/seo/jsonld'
+
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL ||
+  (process.env.NODE_ENV === 'development'
+    ? 'http://localhost:8080'
+    : 'https://api.psychichomily.com')
+
+export const metadata = {
+  title: 'Artists',
+  description: 'Browse artists and discover live music in your city.',
+  alternates: {
+    canonical: 'https://psychichomily.com/artists',
+  },
+  openGraph: {
+    title: 'Artists | Psychic Homily',
+    description: 'Browse artists and discover live music in your city.',
+    url: '/artists',
+    type: 'website',
+  },
+}
+
+interface ArtistListItem {
+  slug: string
+  name: string
+}
+
+interface ArtistsApiResponse {
+  artists: ArtistListItem[]
+}
+
+async function getArtists(): Promise<ArtistListItem[]> {
+  try {
+    const res = await fetch(`${API_BASE_URL}/artists`, {
+      next: { revalidate: 3600 },
+    })
+    if (res.ok) {
+      const data: ArtistsApiResponse = await res.json()
+      return data.artists ?? []
+    }
+    if (res.status >= 500) {
+      Sentry.captureMessage(`Artists listing: API returned ${res.status}`, {
+        level: 'error',
+        tags: { service: 'artists-listing' },
+        extra: { status: res.status },
+      })
+    }
+  } catch (error) {
+    Sentry.captureException(error, {
+      level: 'error',
+      tags: { service: 'artists-listing' },
+    })
+  }
+  return []
+}
+
+export default async function ArtistsPage() {
+  const artists = await getArtists()
+
+  const artistsWithSlugs = artists.filter(
+    (a): a is ArtistListItem & { slug: string } => !!a.slug
+  )
+
+  return (
+    <>
+      {artistsWithSlugs.length > 0 && (
+        <JsonLd data={generateItemListSchema({
+          name: 'Artists',
+          description: 'Artists performing live music in Phoenix and beyond.',
+          listItems: artistsWithSlugs.map(artist => ({
+            url: `https://psychichomily.com/artists/${artist.slug}`,
+            name: artist.name,
+          })),
+        })} />
+      )}
+      <JsonLd data={generateBreadcrumbSchema([
+        { name: 'Home', url: 'https://psychichomily.com' },
+        { name: 'Artists', url: 'https://psychichomily.com/artists' },
+      ])} />
+      <div className="flex min-h-screen items-start justify-center">
+        <main className="w-full max-w-4xl px-4 py-8 md:px-8">
+          <h1 className="text-3xl font-bold text-center mb-8">Artists</h1>
+          <Suspense fallback={<ArtistListSkeleton />}>
+            <ArtistList />
+          </Suspense>
+        </main>
+      </div>
+    </>
+  )
+}

--- a/frontend/app/nav-utils.ts
+++ b/frontend/app/nav-utils.ts
@@ -1,5 +1,6 @@
 export const navLinks = [
   { href: '/shows', label: 'Shows' },
+  { href: '/artists', label: 'Artists' },
   { href: '/venues', label: 'Venues' },
   { href: '/blog', label: 'Blog' },
   { href: '/dj-sets', label: 'DJ Sets' },

--- a/frontend/components/artists/ArtistCard.test.tsx
+++ b/frontend/components/artists/ArtistCard.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest'
+import { screen } from '@testing-library/react'
+import { renderWithProviders } from '@/test/utils'
+import { ArtistCard } from './ArtistCard'
+import type { Artist } from '@/lib/types/artist'
+
+function makeArtist(overrides: Partial<Artist> = {}): Artist {
+  return {
+    id: 1,
+    slug: 'test-artist',
+    name: 'Test Artist',
+    city: 'Phoenix',
+    state: 'AZ',
+    bandcamp_embed_url: null,
+    social: {
+      instagram: null,
+      facebook: null,
+      twitter: null,
+      youtube: null,
+      spotify: null,
+      soundcloud: null,
+      bandcamp: null,
+      website: null,
+    },
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('ArtistCard', () => {
+  it('renders artist name as a link', () => {
+    renderWithProviders(<ArtistCard artist={makeArtist()} />)
+
+    const link = screen.getByRole('link', { name: 'Test Artist' })
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', '/artists/test-artist')
+  })
+
+  it('renders location with city and state', () => {
+    renderWithProviders(<ArtistCard artist={makeArtist()} />)
+
+    expect(screen.getByText('Phoenix, AZ')).toBeInTheDocument()
+  })
+
+  it('does not render location when city and state are null', () => {
+    renderWithProviders(
+      <ArtistCard artist={makeArtist({ city: null, state: null })} />
+    )
+
+    expect(screen.queryByText('Location Unknown')).not.toBeInTheDocument()
+  })
+
+  it('renders social links when present', () => {
+    renderWithProviders(
+      <ArtistCard
+        artist={makeArtist({
+          social: {
+            instagram: '@testartist',
+            facebook: null,
+            twitter: null,
+            youtube: null,
+            spotify: 'https://open.spotify.com/artist/123',
+            soundcloud: null,
+            bandcamp: null,
+            website: 'https://testartist.com',
+          },
+        })}
+      />
+    )
+
+    expect(screen.getByTitle('Instagram')).toBeInTheDocument()
+    expect(screen.getByTitle('Spotify')).toBeInTheDocument()
+    expect(screen.getByTitle('Website')).toBeInTheDocument()
+  })
+
+  it('uses correct slug in link', () => {
+    renderWithProviders(
+      <ArtistCard artist={makeArtist({ slug: 'the-national', name: 'The National' })} />
+    )
+
+    const link = screen.getByRole('link', { name: 'The National' })
+    expect(link).toHaveAttribute('href', '/artists/the-national')
+  })
+})

--- a/frontend/components/artists/ArtistCard.test.tsx
+++ b/frontend/components/artists/ArtistCard.test.tsx
@@ -2,9 +2,9 @@ import { describe, it, expect } from 'vitest'
 import { screen } from '@testing-library/react'
 import { renderWithProviders } from '@/test/utils'
 import { ArtistCard } from './ArtistCard'
-import type { Artist } from '@/lib/types/artist'
+import type { ArtistListItem } from '@/lib/types/artist'
 
-function makeArtist(overrides: Partial<Artist> = {}): Artist {
+function makeArtist(overrides: Partial<ArtistListItem> = {}): ArtistListItem {
   return {
     id: 1,
     slug: 'test-artist',
@@ -12,6 +12,7 @@ function makeArtist(overrides: Partial<Artist> = {}): Artist {
     city: 'Phoenix',
     state: 'AZ',
     bandcamp_embed_url: null,
+    upcoming_show_count: 3,
     social: {
       instagram: null,
       facebook: null,
@@ -37,6 +38,12 @@ describe('ArtistCard', () => {
     expect(link).toHaveAttribute('href', '/artists/test-artist')
   })
 
+  it('renders upcoming show count', () => {
+    renderWithProviders(<ArtistCard artist={makeArtist({ upcoming_show_count: 5 })} />)
+
+    expect(screen.getByText('5 upcoming')).toBeInTheDocument()
+  })
+
   it('renders location with city and state', () => {
     renderWithProviders(<ArtistCard artist={makeArtist()} />)
 
@@ -48,30 +55,7 @@ describe('ArtistCard', () => {
       <ArtistCard artist={makeArtist({ city: null, state: null })} />
     )
 
-    expect(screen.queryByText('Location Unknown')).not.toBeInTheDocument()
-  })
-
-  it('renders social links when present', () => {
-    renderWithProviders(
-      <ArtistCard
-        artist={makeArtist({
-          social: {
-            instagram: '@testartist',
-            facebook: null,
-            twitter: null,
-            youtube: null,
-            spotify: 'https://open.spotify.com/artist/123',
-            soundcloud: null,
-            bandcamp: null,
-            website: 'https://testartist.com',
-          },
-        })}
-      />
-    )
-
-    expect(screen.getByTitle('Instagram')).toBeInTheDocument()
-    expect(screen.getByTitle('Spotify')).toBeInTheDocument()
-    expect(screen.getByTitle('Website')).toBeInTheDocument()
+    expect(screen.queryByText('Phoenix, AZ')).not.toBeInTheDocument()
   })
 
   it('uses correct slug in link', () => {

--- a/frontend/components/artists/ArtistCard.tsx
+++ b/frontend/components/artists/ArtistCard.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import Link from 'next/link'
+import { MapPin } from 'lucide-react'
+import type { Artist } from '@/lib/types/artist'
+import { getArtistLocation } from '@/lib/types/artist'
+import { SocialLinks } from '@/components/shared/SocialLinks'
+
+interface ArtistCardProps {
+  artist: Artist
+}
+
+export function ArtistCard({ artist }: ArtistCardProps) {
+  const location = getArtistLocation(artist)
+  const hasLocation = artist.city || artist.state
+
+  return (
+    <article className="border border-border/50 rounded-lg mb-4 overflow-hidden bg-card">
+      <div className="px-4 py-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex-1 min-w-0">
+            <h2 className="text-lg font-semibold truncate">
+              <Link
+                href={`/artists/${artist.slug}`}
+                className="hover:text-primary transition-colors"
+              >
+                {artist.name}
+              </Link>
+            </h2>
+            {hasLocation && (
+              <div className="flex items-center gap-1 text-sm text-muted-foreground mt-1">
+                <MapPin className="h-3.5 w-3.5 shrink-0" />
+                <span>{location}</span>
+              </div>
+            )}
+          </div>
+          <SocialLinks social={artist.social} />
+        </div>
+      </div>
+    </article>
+  )
+}

--- a/frontend/components/artists/ArtistCard.tsx
+++ b/frontend/components/artists/ArtistCard.tsx
@@ -2,40 +2,36 @@
 
 import Link from 'next/link'
 import { MapPin } from 'lucide-react'
-import type { Artist } from '@/lib/types/artist'
+import type { ArtistListItem } from '@/lib/types/artist'
 import { getArtistLocation } from '@/lib/types/artist'
-import { SocialLinks } from '@/components/shared/SocialLinks'
 
 interface ArtistCardProps {
-  artist: Artist
+  artist: ArtistListItem
 }
 
 export function ArtistCard({ artist }: ArtistCardProps) {
-  const location = getArtistLocation(artist)
   const hasLocation = artist.city || artist.state
+  const location = hasLocation ? getArtistLocation(artist) : null
 
   return (
-    <article className="border border-border/50 rounded-lg mb-4 overflow-hidden bg-card">
-      <div className="px-4 py-4">
-        <div className="flex items-start justify-between gap-3">
-          <div className="flex-1 min-w-0">
-            <h2 className="text-lg font-semibold truncate">
-              <Link
-                href={`/artists/${artist.slug}`}
-                className="hover:text-primary transition-colors"
-              >
-                {artist.name}
-              </Link>
-            </h2>
-            {hasLocation && (
-              <div className="flex items-center gap-1 text-sm text-muted-foreground mt-1">
-                <MapPin className="h-3.5 w-3.5 shrink-0" />
-                <span>{location}</span>
-              </div>
-            )}
-          </div>
-          <SocialLinks social={artist.social} />
-        </div>
+    <article className="py-2 px-3 rounded-md hover:bg-muted/50 transition-colors">
+      <Link
+        href={`/artists/${artist.slug}`}
+        className="block hover:text-primary transition-colors"
+      >
+        <span className="font-medium">{artist.name}</span>
+      </Link>
+      <div className="flex items-center gap-2 text-xs text-muted-foreground mt-0.5">
+        <span>{artist.upcoming_show_count} upcoming</span>
+        {hasLocation && (
+          <>
+            <span className="text-border">·</span>
+            <span className="flex items-center gap-0.5">
+              <MapPin className="h-3 w-3 shrink-0" />
+              {location}
+            </span>
+          </>
+        )}
       </div>
     </article>
   )

--- a/frontend/components/artists/ArtistList.tsx
+++ b/frontend/components/artists/ArtistList.tsx
@@ -4,6 +4,7 @@ import { useMemo, useTransition } from 'react'
 import { useSearchParams, useRouter } from 'next/navigation'
 import { useArtists, useArtistCities } from '@/lib/hooks/useArtists'
 import { ArtistCard } from './ArtistCard'
+import { ArtistSearch } from './ArtistSearch'
 import { CityFilters, type CityWithCount, type CityState } from '@/components/filters'
 import { LoadingSpinner } from '@/components/shared'
 import { Button } from '@/components/ui/button'
@@ -86,13 +87,16 @@ export function ArtistList() {
 
   return (
     <section className="w-full max-w-4xl">
-      {cities.length > 1 && (
-        <CityFilters
-          cities={cities}
-          selectedCities={selectedCities}
-          onFilterChange={handleFilterChange}
-        />
-      )}
+      <div className="mb-6 space-y-4">
+        <ArtistSearch />
+        {cities.length > 0 && (
+          <CityFilters
+            cities={cities}
+            selectedCities={selectedCities}
+            onFilterChange={handleFilterChange}
+          />
+        )}
+      </div>
 
       {/* Dim content while fetching, don't hide it */}
       <div className={isUpdating ? 'opacity-60 transition-opacity duration-75' : 'transition-opacity duration-75'}>
@@ -113,9 +117,11 @@ export function ArtistList() {
             )}
           </div>
         ) : (
-          artists.map(artist => (
-            <ArtistCard key={artist.id} artist={artist} />
-          ))
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-2">
+            {artists.map(artist => (
+              <ArtistCard key={artist.id} artist={artist} />
+            ))}
+          </div>
         )}
       </div>
     </section>

--- a/frontend/components/artists/ArtistList.tsx
+++ b/frontend/components/artists/ArtistList.tsx
@@ -1,0 +1,123 @@
+'use client'
+
+import { useMemo, useTransition } from 'react'
+import { useSearchParams, useRouter } from 'next/navigation'
+import { useArtists, useArtistCities } from '@/lib/hooks/useArtists'
+import { ArtistCard } from './ArtistCard'
+import { CityFilters, type CityWithCount, type CityState } from '@/components/filters'
+import { LoadingSpinner } from '@/components/shared'
+import { Button } from '@/components/ui/button'
+
+/** Parse cities param from URL: "Phoenix,AZ|Mesa,AZ" -> CityState[] */
+function parseCitiesParam(param: string | null): CityState[] {
+  if (!param) return []
+  return param
+    .split('|')
+    .map(pair => {
+      const [city, state] = pair.split(',')
+      return city && state ? { city: city.trim(), state: state.trim() } : null
+    })
+    .filter((c): c is CityState => c !== null)
+}
+
+/** Build cities param for URL: CityState[] -> "Phoenix,AZ|Mesa,AZ" */
+function buildCitiesParam(cities: CityState[]): string {
+  return cities.map(c => `${c.city},${c.state}`).join('|')
+}
+
+export function ArtistList() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const [isPending, startTransition] = useTransition()
+
+  // Parse multi-city from URL
+  const citiesParam = searchParams.get('cities')
+  const selectedCities: CityState[] = useMemo(() => {
+    return parseCitiesParam(citiesParam)
+  }, [citiesParam])
+
+  const { data: citiesData, isLoading: citiesLoading, isFetching: citiesFetching } = useArtistCities()
+  const { data, isLoading, isFetching, error, refetch } = useArtists({
+    cities: selectedCities.length > 0 ? selectedCities : undefined,
+  })
+
+  const handleFilterChange = (cities: CityState[]) => {
+    const params = new URLSearchParams()
+    if (cities.length > 0) {
+      params.set('cities', buildCitiesParam(cities))
+    }
+    const queryString = params.toString()
+    startTransition(() => {
+      router.push(queryString ? `/artists?${queryString}` : '/artists')
+    })
+  }
+
+  // Only show full spinner on FIRST load (no data yet)
+  if ((isLoading && !data) || (citiesLoading && !citiesData)) {
+    return (
+      <div className="flex justify-center items-center py-12">
+        <LoadingSpinner />
+      </div>
+    )
+  }
+
+  // Track if we're updating (fetching but already have data)
+  const isUpdating = isFetching || citiesFetching || isPending
+
+  if (error) {
+    return (
+      <div className="text-center py-12 text-destructive">
+        <p>Failed to load artists. Please try again later.</p>
+        <Button variant="outline" className="mt-4" onClick={() => refetch()}>
+          Retry
+        </Button>
+      </div>
+    )
+  }
+
+  // Map ArtistCity to CityWithCount
+  const cities: CityWithCount[] = citiesData?.cities?.map(c => ({
+    city: c.city,
+    state: c.state,
+    count: c.artist_count,
+  })) ?? []
+
+  const artists = data?.artists ?? []
+
+  return (
+    <section className="w-full max-w-4xl">
+      {cities.length > 1 && (
+        <CityFilters
+          cities={cities}
+          selectedCities={selectedCities}
+          onFilterChange={handleFilterChange}
+        />
+      )}
+
+      {/* Dim content while fetching, don't hide it */}
+      <div className={isUpdating ? 'opacity-60 transition-opacity duration-75' : 'transition-opacity duration-75'}>
+        {artists.length === 0 ? (
+          <div className="text-center py-12 text-muted-foreground">
+            <p>
+              {selectedCities.length > 0
+                ? 'No artists found in the selected cities.'
+                : 'No artists available at this time.'}
+            </p>
+            {selectedCities.length > 0 && (
+              <button
+                onClick={() => handleFilterChange([])}
+                className="mt-4 text-primary hover:underline"
+              >
+                View all artists
+              </button>
+            )}
+          </div>
+        ) : (
+          artists.map(artist => (
+            <ArtistCard key={artist.id} artist={artist} />
+          ))
+        )}
+      </div>
+    </section>
+  )
+}

--- a/frontend/components/artists/ArtistListSkeleton.tsx
+++ b/frontend/components/artists/ArtistListSkeleton.tsx
@@ -1,0 +1,35 @@
+export function ArtistListSkeleton() {
+  return (
+    <div className="w-full max-w-4xl animate-pulse">
+      {/* Filter chips skeleton */}
+      <div className="flex flex-wrap gap-2 mb-6">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div
+            key={i}
+            className="h-8 rounded-full bg-muted"
+            style={{ width: `${60 + i * 20}px` }}
+          />
+        ))}
+      </div>
+
+      {/* Card skeletons */}
+      {Array.from({ length: 8 }).map((_, i) => (
+        <div
+          key={i}
+          className="border border-border/50 rounded-lg mb-4 overflow-hidden bg-card px-4 py-4"
+        >
+          <div className="flex items-start justify-between gap-3">
+            <div className="flex-1">
+              <div className="h-5 bg-muted rounded w-48 mb-2" />
+              <div className="h-4 bg-muted rounded w-32" />
+            </div>
+            <div className="flex gap-2">
+              <div className="h-9 w-9 bg-muted rounded" />
+              <div className="h-9 w-9 bg-muted rounded" />
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/frontend/components/artists/ArtistListSkeleton.tsx
+++ b/frontend/components/artists/ArtistListSkeleton.tsx
@@ -1,35 +1,29 @@
 export function ArtistListSkeleton() {
   return (
     <div className="w-full max-w-4xl animate-pulse">
-      {/* Filter chips skeleton */}
-      <div className="flex flex-wrap gap-2 mb-6">
-        {Array.from({ length: 4 }).map((_, i) => (
-          <div
-            key={i}
-            className="h-8 rounded-full bg-muted"
-            style={{ width: `${60 + i * 20}px` }}
-          />
-        ))}
+      {/* Search + filter chips skeleton */}
+      <div className="mb-6 space-y-4">
+        <div className="h-9 w-full max-w-sm rounded-md bg-muted" />
+        <div className="flex flex-wrap gap-2">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-8 rounded-full bg-muted"
+              style={{ width: `${60 + i * 20}px` }}
+            />
+          ))}
+        </div>
       </div>
 
-      {/* Card skeletons */}
-      {Array.from({ length: 8 }).map((_, i) => (
-        <div
-          key={i}
-          className="border border-border/50 rounded-lg mb-4 overflow-hidden bg-card px-4 py-4"
-        >
-          <div className="flex items-start justify-between gap-3">
-            <div className="flex-1">
-              <div className="h-5 bg-muted rounded w-48 mb-2" />
-              <div className="h-4 bg-muted rounded w-32" />
-            </div>
-            <div className="flex gap-2">
-              <div className="h-9 w-9 bg-muted rounded" />
-              <div className="h-9 w-9 bg-muted rounded" />
-            </div>
+      {/* Grid skeleton */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-2">
+        {Array.from({ length: 12 }).map((_, i) => (
+          <div key={i} className="py-2 px-3">
+            <div className="h-5 bg-muted rounded w-36 mb-1" />
+            <div className="h-3 bg-muted rounded w-24" />
           </div>
-        </div>
-      ))}
+        ))}
+      </div>
     </div>
   )
 }

--- a/frontend/components/artists/ArtistSearch.test.tsx
+++ b/frontend/components/artists/ArtistSearch.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders } from '@/test/utils'
+
+// Mock next/navigation
+const mockPush = vi.fn()
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}))
+
+// Mock the search hook
+const mockSearchResults = vi.fn()
+vi.mock('@/lib/hooks/useArtistSearch', () => ({
+  useArtistSearch: ({ query }: { query: string }) => ({
+    data: mockSearchResults(query),
+  }),
+}))
+
+import { ArtistSearch } from './ArtistSearch'
+
+describe('ArtistSearch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSearchResults.mockReturnValue(undefined)
+  })
+
+  it('renders search input with placeholder', () => {
+    renderWithProviders(<ArtistSearch />)
+
+    expect(screen.getByPlaceholderText('Search artists...')).toBeInTheDocument()
+  })
+
+  it('shows dropdown when results are available', async () => {
+    mockSearchResults.mockReturnValue({
+      artists: [
+        { id: 1, slug: 'radiohead', name: 'Radiohead', city: null, state: null, social: {} },
+      ],
+      count: 1,
+    })
+
+    renderWithProviders(<ArtistSearch />)
+
+    const input = screen.getByPlaceholderText('Search artists...')
+    await userEvent.type(input, 'radio')
+
+    expect(screen.getByText('Radiohead')).toBeInTheDocument()
+  })
+
+  it('navigates to artist page on selection', async () => {
+    mockSearchResults.mockReturnValue({
+      artists: [
+        { id: 1, slug: 'radiohead', name: 'Radiohead', city: null, state: null, social: {} },
+      ],
+      count: 1,
+    })
+
+    renderWithProviders(<ArtistSearch />)
+
+    const input = screen.getByPlaceholderText('Search artists...')
+    await userEvent.type(input, 'radio')
+
+    // mouseDown triggers navigation (not click, due to blur handling)
+    fireEvent.mouseDown(screen.getByText('Radiohead'))
+
+    expect(mockPush).toHaveBeenCalledWith('/artists/radiohead')
+  })
+
+  it('shows location for artists with city data', async () => {
+    mockSearchResults.mockReturnValue({
+      artists: [
+        { id: 1, slug: 'local-band', name: 'Local Band', city: 'Phoenix', state: 'AZ', social: {} },
+      ],
+      count: 1,
+    })
+
+    renderWithProviders(<ArtistSearch />)
+
+    const input = screen.getByPlaceholderText('Search artists...')
+    await userEvent.type(input, 'local')
+
+    expect(screen.getByText('Phoenix, AZ')).toBeInTheDocument()
+  })
+
+  it('clears input after selection', async () => {
+    mockSearchResults.mockReturnValue({
+      artists: [
+        { id: 1, slug: 'radiohead', name: 'Radiohead', city: null, state: null, social: {} },
+      ],
+      count: 1,
+    })
+
+    renderWithProviders(<ArtistSearch />)
+
+    const input = screen.getByPlaceholderText('Search artists...') as HTMLInputElement
+    await userEvent.type(input, 'radio')
+    fireEvent.mouseDown(screen.getByText('Radiohead'))
+
+    expect(input.value).toBe('')
+  })
+})

--- a/frontend/components/artists/ArtistSearch.tsx
+++ b/frontend/components/artists/ArtistSearch.tsx
@@ -1,0 +1,128 @@
+'use client'
+
+import { useState, useRef } from 'react'
+import { useRouter } from 'next/navigation'
+import { Search } from 'lucide-react'
+import { Input } from '@/components/ui/input'
+import { useArtistSearch } from '@/lib/hooks/useArtistSearch'
+import { getArtistLocation } from '@/lib/types/artist'
+
+/**
+ * Artist search with autocomplete dropdown.
+ * Navigates to the artist detail page on selection.
+ */
+export function ArtistSearch() {
+  const router = useRouter()
+  const [query, setQuery] = useState('')
+  const [isOpen, setIsOpen] = useState(false)
+  const [activeIndex, setActiveIndex] = useState(-1)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const { data: searchResults } = useArtistSearch({ query })
+  const artists = searchResults?.artists ?? []
+
+  const handleSelect = (slug: string) => {
+    setQuery('')
+    setIsOpen(false)
+    setActiveIndex(-1)
+    router.push(`/artists/${slug}`)
+  }
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value
+    setQuery(value)
+    setIsOpen(value.length > 0)
+    setActiveIndex(-1)
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (!isOpen || artists.length === 0) {
+      if (e.key === 'Escape') {
+        setIsOpen(false)
+        inputRef.current?.blur()
+      }
+      return
+    }
+
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault()
+        setActiveIndex(prev => (prev < artists.length - 1 ? prev + 1 : 0))
+        break
+      case 'ArrowUp':
+        e.preventDefault()
+        setActiveIndex(prev => (prev > 0 ? prev - 1 : artists.length - 1))
+        break
+      case 'Enter':
+        e.preventDefault()
+        if (activeIndex >= 0 && activeIndex < artists.length) {
+          handleSelect(artists[activeIndex].slug)
+        }
+        break
+      case 'Escape':
+        setIsOpen(false)
+        setActiveIndex(-1)
+        inputRef.current?.blur()
+        break
+    }
+  }
+
+  const handleBlur = () => {
+    // Delay to allow click on dropdown items
+    setTimeout(() => {
+      setIsOpen(false)
+      setActiveIndex(-1)
+    }, 150)
+  }
+
+  return (
+    <div className="relative w-full max-w-sm">
+      <div className="relative">
+        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
+        <Input
+          ref={inputRef}
+          type="text"
+          value={query}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          onBlur={handleBlur}
+          placeholder="Search artists..."
+          autoComplete="off"
+          className="pl-8"
+        />
+      </div>
+
+      {isOpen && artists.length > 0 && (
+        <div className="absolute top-full left-0 w-full z-50 mt-1 rounded-md border bg-popover text-popover-foreground shadow-md">
+          <div className="max-h-[300px] overflow-y-auto p-1">
+            {artists.map((artist, i) => (
+              <button
+                type="button"
+                key={artist.id}
+                className={`relative flex w-full cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none ${
+                  i === activeIndex
+                    ? 'bg-accent text-accent-foreground'
+                    : 'hover:bg-accent hover:text-accent-foreground'
+                }`}
+                onMouseDown={e => {
+                  e.preventDefault()
+                  handleSelect(artist.slug)
+                }}
+                onMouseEnter={() => setActiveIndex(i)}
+              >
+                <div className="flex w-full items-center justify-between gap-2">
+                  <span className="truncate">{artist.name}</span>
+                  {(artist.city || artist.state) && (
+                    <span className="flex-shrink-0 text-xs text-muted-foreground">
+                      {getArtistLocation(artist)}
+                    </span>
+                  )}
+                </div>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/components/artists/index.ts
+++ b/frontend/components/artists/index.ts
@@ -1,4 +1,7 @@
+export { ArtistCard } from './ArtistCard'
 export { ArtistDetail } from './ArtistDetail'
+export { ArtistList } from './ArtistList'
+export { ArtistListSkeleton } from './ArtistListSkeleton'
 export { ArtistShowsList } from './ArtistShowsList'
 export { ReportArtistButton } from './ReportArtistButton'
 export { ReportArtistDialog } from './ReportArtistDialog'

--- a/frontend/components/artists/index.ts
+++ b/frontend/components/artists/index.ts
@@ -1,4 +1,5 @@
 export { ArtistCard } from './ArtistCard'
+export { ArtistSearch } from './ArtistSearch'
 export { ArtistDetail } from './ArtistDetail'
 export { ArtistList } from './ArtistList'
 export { ArtistListSkeleton } from './ArtistListSkeleton'

--- a/frontend/components/filters/CityFilters.tsx
+++ b/frontend/components/filters/CityFilters.tsx
@@ -58,7 +58,7 @@ export function CityFilters({
   }
 
   return (
-    <div className="flex flex-wrap items-center gap-2 mb-6">
+    <div className="flex flex-wrap items-center gap-2">
       <FilterChip
         label={allLabel}
         isActive={isAllSelected}

--- a/frontend/components/shows/HomeShowList.tsx
+++ b/frontend/components/shows/HomeShowList.tsx
@@ -374,18 +374,20 @@ export function HomeShowList() {
   return (
     <div className="w-full">
       {cities.length > 1 && (
-        <CityFilters
-          cities={cities}
-          selectedCities={selectedCities}
-          onFilterChange={handleFilterChange}
-        >
-          {isAuthenticated && selectionDiffersFromFavorites && (
-            <SaveDefaultsButton
-              selectedCities={selectedCities}
-              favoriteCities={favoriteCities}
-            />
-          )}
-        </CityFilters>
+        <div className="mb-6">
+          <CityFilters
+            cities={cities}
+            selectedCities={selectedCities}
+            onFilterChange={handleFilterChange}
+          >
+            {isAuthenticated && selectionDiffersFromFavorites && (
+              <SaveDefaultsButton
+                selectedCities={selectedCities}
+                favoriteCities={favoriteCities}
+              />
+            )}
+          </CityFilters>
+        </div>
       )}
 
       <div className={isFetching ? 'opacity-60 transition-opacity duration-75' : 'transition-opacity duration-75'}>

--- a/frontend/components/shows/ShowList.tsx
+++ b/frontend/components/shows/ShowList.tsx
@@ -456,18 +456,20 @@ export function ShowList() {
   return (
     <section className="w-full max-w-4xl">
       {cities.length > 1 && (
-        <CityFilters
-          cities={cities}
-          selectedCities={selectedCities}
-          onFilterChange={handleFilterChange}
-        >
-          {isAuthenticated && selectionDiffersFromFavorites && (
-            <SaveDefaultsButton
-              selectedCities={selectedCities}
-              favoriteCities={favoriteCities}
-            />
-          )}
-        </CityFilters>
+        <div className="mb-6">
+          <CityFilters
+            cities={cities}
+            selectedCities={selectedCities}
+            onFilterChange={handleFilterChange}
+          >
+            {isAuthenticated && selectionDiffersFromFavorites && (
+              <SaveDefaultsButton
+                selectedCities={selectedCities}
+                favoriteCities={favoriteCities}
+              />
+            )}
+          </CityFilters>
+        </div>
       )}
 
       {/* Dim content while fetching, don't hide it */}

--- a/frontend/components/venues/VenueList.tsx
+++ b/frontend/components/venues/VenueList.tsx
@@ -5,11 +5,29 @@ import { useSearchParams, useRouter } from 'next/navigation'
 import { useVenues, useVenueCities } from '@/lib/hooks/useVenues'
 import type { VenueWithShowCount } from '@/lib/types/venue'
 import { VenueCard } from './VenueCard'
+import { VenueSearch } from './VenueSearch'
 import { CityFilters, type CityWithCount, type CityState } from '@/components/filters'
 import { LoadingSpinner } from '@/components/shared'
 import { Button } from '@/components/ui/button'
 
 const VENUES_PER_PAGE = 50
+
+/** Parse cities param from URL: "Phoenix,AZ|Tucson,AZ" -> CityState[] */
+function parseCitiesParam(param: string | null): CityState[] {
+  if (!param) return []
+  return param
+    .split('|')
+    .map(pair => {
+      const [city, state] = pair.split(',')
+      return city && state ? { city: city.trim(), state: state.trim() } : null
+    })
+    .filter((c): c is CityState => c !== null)
+}
+
+/** Build cities param for URL: CityState[] -> "Phoenix,AZ|Tucson,AZ" */
+function buildCitiesParam(cities: CityState[]): string {
+  return cities.map(c => `${c.city},${c.state}`).join('|')
+}
 
 export function VenueList() {
   const router = useRouter()
@@ -18,21 +36,15 @@ export function VenueList() {
   const [offset, setOffset] = useState(0)
   const [accumulatedVenues, setAccumulatedVenues] = useState<VenueWithShowCount[]>([])
 
-  const selectedCity = searchParams.get('city')
-  const selectedState = searchParams.get('state')
-
-  // Adapt single-select URL params to multi-select CityState[]
+  // Parse multi-city from URL
+  const citiesParam = searchParams.get('cities')
   const selectedCities: CityState[] = useMemo(() => {
-    if (selectedCity && selectedState) {
-      return [{ city: selectedCity, state: selectedState }]
-    }
-    return []
-  }, [selectedCity, selectedState])
+    return parseCitiesParam(citiesParam)
+  }, [citiesParam])
 
   const { data: citiesData, isLoading: citiesLoading, isFetching: citiesFetching } = useVenueCities()
   const { data, isLoading, isFetching, error, refetch } = useVenues({
-    city: selectedCity || undefined,
-    state: selectedState || undefined,
+    cities: selectedCities.length > 0 ? selectedCities : undefined,
     limit: VENUES_PER_PAGE,
     offset,
   })
@@ -44,7 +56,6 @@ export function VenueList() {
     }
   }, [data])
 
-  // Venues use single-select: take the last selected city (or clear all)
   const handleFilterChange = (cities: CityState[]) => {
     // Reset pagination on filter change
     setOffset(0)
@@ -52,10 +63,7 @@ export function VenueList() {
 
     const params = new URLSearchParams()
     if (cities.length > 0) {
-      // Take the most recently added city (last in array)
-      const city = cities[cities.length - 1]
-      params.set('city', city.city)
-      params.set('state', city.state)
+      params.set('cities', buildCitiesParam(cities))
     }
 
     const queryString = params.toString()
@@ -96,13 +104,16 @@ export function VenueList() {
 
   return (
     <section className="w-full max-w-4xl">
-      {cities.length > 1 && (
-        <CityFilters
-          cities={cities}
-          selectedCities={selectedCities}
-          onFilterChange={handleFilterChange}
-        />
-      )}
+      <div className="mb-6 space-y-4">
+        <VenueSearch />
+        {cities.length > 0 && (
+          <CityFilters
+            cities={cities}
+            selectedCities={selectedCities}
+            onFilterChange={handleFilterChange}
+          />
+        )}
+      </div>
 
       {/* Dim content while fetching, don't hide it */}
       <div className={isUpdating ? 'opacity-60 transition-opacity duration-75' : 'transition-opacity duration-75'}>
@@ -112,11 +123,11 @@ export function VenueList() {
             return (
               <div className="text-center py-12 text-muted-foreground">
                 <p>
-                  {selectedCity
-                    ? `No venues found in ${selectedCity}.`
+                  {selectedCities.length > 0
+                    ? 'No venues found in the selected cities.'
                     : 'No venues available at this time.'}
                 </p>
-                {selectedCity && (
+                {selectedCities.length > 0 && (
                   <button
                     onClick={() => handleFilterChange([])}
                     className="mt-4 text-primary hover:underline"

--- a/frontend/components/venues/VenueSearch.test.tsx
+++ b/frontend/components/venues/VenueSearch.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders } from '@/test/utils'
+
+// Mock next/navigation
+const mockPush = vi.fn()
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}))
+
+// Mock the search hook
+const mockSearchResults = vi.fn()
+vi.mock('@/lib/hooks/useVenueSearch', () => ({
+  useVenueSearch: ({ query }: { query: string }) => ({
+    data: mockSearchResults(query),
+  }),
+}))
+
+import { VenueSearch } from './VenueSearch'
+
+describe('VenueSearch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSearchResults.mockReturnValue(undefined)
+  })
+
+  it('renders search input with placeholder', () => {
+    renderWithProviders(<VenueSearch />)
+
+    expect(screen.getByPlaceholderText('Search venues...')).toBeInTheDocument()
+  })
+
+  it('shows dropdown when results are available', async () => {
+    mockSearchResults.mockReturnValue({
+      venues: [
+        { id: 1, slug: 'valley-bar', name: 'Valley Bar', city: 'Phoenix', state: 'AZ', verified: true },
+      ],
+      count: 1,
+    })
+
+    renderWithProviders(<VenueSearch />)
+
+    const input = screen.getByPlaceholderText('Search venues...')
+    await userEvent.type(input, 'valley')
+
+    expect(screen.getByText('Valley Bar')).toBeInTheDocument()
+  })
+
+  it('navigates to venue page on selection', async () => {
+    mockSearchResults.mockReturnValue({
+      venues: [
+        { id: 1, slug: 'valley-bar', name: 'Valley Bar', city: 'Phoenix', state: 'AZ', verified: true },
+      ],
+      count: 1,
+    })
+
+    renderWithProviders(<VenueSearch />)
+
+    const input = screen.getByPlaceholderText('Search venues...')
+    await userEvent.type(input, 'valley')
+
+    // mouseDown triggers navigation (not click, due to blur handling)
+    fireEvent.mouseDown(screen.getByText('Valley Bar'))
+
+    expect(mockPush).toHaveBeenCalledWith('/venues/valley-bar')
+  })
+
+  it('shows location for venues', async () => {
+    mockSearchResults.mockReturnValue({
+      venues: [
+        { id: 1, slug: 'valley-bar', name: 'Valley Bar', city: 'Phoenix', state: 'AZ', verified: true },
+      ],
+      count: 1,
+    })
+
+    renderWithProviders(<VenueSearch />)
+
+    const input = screen.getByPlaceholderText('Search venues...')
+    await userEvent.type(input, 'valley')
+
+    expect(screen.getByText('Phoenix, AZ')).toBeInTheDocument()
+  })
+
+  it('clears input after selection', async () => {
+    mockSearchResults.mockReturnValue({
+      venues: [
+        { id: 1, slug: 'valley-bar', name: 'Valley Bar', city: 'Phoenix', state: 'AZ', verified: true },
+      ],
+      count: 1,
+    })
+
+    renderWithProviders(<VenueSearch />)
+
+    const input = screen.getByPlaceholderText('Search venues...') as HTMLInputElement
+    await userEvent.type(input, 'valley')
+    fireEvent.mouseDown(screen.getByText('Valley Bar'))
+
+    expect(input.value).toBe('')
+  })
+})

--- a/frontend/components/venues/VenueSearch.tsx
+++ b/frontend/components/venues/VenueSearch.tsx
@@ -1,0 +1,128 @@
+'use client'
+
+import { useState, useRef } from 'react'
+import { useRouter } from 'next/navigation'
+import { Search } from 'lucide-react'
+import { Input } from '@/components/ui/input'
+import { useVenueSearch } from '@/lib/hooks/useVenueSearch'
+import { getVenueLocation } from '@/lib/types/venue'
+
+/**
+ * Venue search with autocomplete dropdown.
+ * Navigates to the venue detail page on selection.
+ */
+export function VenueSearch() {
+  const router = useRouter()
+  const [query, setQuery] = useState('')
+  const [isOpen, setIsOpen] = useState(false)
+  const [activeIndex, setActiveIndex] = useState(-1)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const { data: searchResults } = useVenueSearch({ query })
+  const venues = searchResults?.venues ?? []
+
+  const handleSelect = (slug: string) => {
+    setQuery('')
+    setIsOpen(false)
+    setActiveIndex(-1)
+    router.push(`/venues/${slug}`)
+  }
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value
+    setQuery(value)
+    setIsOpen(value.length > 0)
+    setActiveIndex(-1)
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (!isOpen || venues.length === 0) {
+      if (e.key === 'Escape') {
+        setIsOpen(false)
+        inputRef.current?.blur()
+      }
+      return
+    }
+
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault()
+        setActiveIndex(prev => (prev < venues.length - 1 ? prev + 1 : 0))
+        break
+      case 'ArrowUp':
+        e.preventDefault()
+        setActiveIndex(prev => (prev > 0 ? prev - 1 : venues.length - 1))
+        break
+      case 'Enter':
+        e.preventDefault()
+        if (activeIndex >= 0 && activeIndex < venues.length) {
+          handleSelect(venues[activeIndex].slug)
+        }
+        break
+      case 'Escape':
+        setIsOpen(false)
+        setActiveIndex(-1)
+        inputRef.current?.blur()
+        break
+    }
+  }
+
+  const handleBlur = () => {
+    // Delay to allow click on dropdown items
+    setTimeout(() => {
+      setIsOpen(false)
+      setActiveIndex(-1)
+    }, 150)
+  }
+
+  return (
+    <div className="relative w-full max-w-sm">
+      <div className="relative">
+        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
+        <Input
+          ref={inputRef}
+          type="text"
+          value={query}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          onBlur={handleBlur}
+          placeholder="Search venues..."
+          autoComplete="off"
+          className="pl-8"
+        />
+      </div>
+
+      {isOpen && venues.length > 0 && (
+        <div className="absolute top-full left-0 w-full z-50 mt-1 rounded-md border bg-popover text-popover-foreground shadow-md">
+          <div className="max-h-[300px] overflow-y-auto p-1">
+            {venues.map((venue, i) => (
+              <button
+                type="button"
+                key={venue.id}
+                className={`relative flex w-full cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none ${
+                  i === activeIndex
+                    ? 'bg-accent text-accent-foreground'
+                    : 'hover:bg-accent hover:text-accent-foreground'
+                }`}
+                onMouseDown={e => {
+                  e.preventDefault()
+                  handleSelect(venue.slug)
+                }}
+                onMouseEnter={() => setActiveIndex(i)}
+              >
+                <div className="flex w-full items-center justify-between gap-2">
+                  <span className="truncate">{venue.name}</span>
+                  {(venue.city || venue.state) && (
+                    <span className="flex-shrink-0 text-xs text-muted-foreground">
+                      {getVenueLocation(venue)}
+                    </span>
+                  )}
+                </div>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/components/venues/index.ts
+++ b/frontend/components/venues/index.ts
@@ -1,4 +1,5 @@
 export { VenueCard } from './VenueCard'
+export { VenueSearch } from './VenueSearch'
 export { VenueDetail } from './VenueDetail'
 export { VenueList } from './VenueList'
 export { VenueLocationCard } from './VenueLocationCard'

--- a/frontend/e2e/pages/collection.spec.ts
+++ b/frontend/e2e/pages/collection.spec.ts
@@ -123,15 +123,24 @@ test.describe('Collection page', () => {
         .getByRole('link', { name: 'Details' })
     ).toBeVisible()
 
-    // Clean up: go back to the show and unsave it
+    // Clean up: go back to the show and unsave it (wait for API response
+    // so the DELETE completes before the test ends and the page closes)
     await authenticatedPage.goto(showUrl)
     await expect(
       authenticatedPage.getByRole('heading', { level: 1 })
     ).toBeVisible({ timeout: 10_000 })
 
-    await authenticatedPage
-      .getByRole('button', { name: 'Remove from My List' })
-      .click()
+    await Promise.all([
+      authenticatedPage.waitForResponse(
+        (resp) =>
+          resp.url().includes('/saved-shows/') &&
+          resp.request().method() === 'DELETE',
+        { timeout: 10_000 }
+      ),
+      authenticatedPage
+        .getByRole('button', { name: 'Remove from My List' })
+        .click(),
+    ])
     await expect(
       authenticatedPage.getByRole('button', { name: 'Add to My List' })
     ).toBeVisible({ timeout: 5_000 })

--- a/frontend/e2e/pages/submit-show.spec.ts
+++ b/frontend/e2e/pages/submit-show.spec.ts
@@ -14,7 +14,7 @@ test.describe('Submit a show', () => {
 
     // Artists section
     await expect(
-      authenticatedPage.getByText('Artists', { exact: true })
+      authenticatedPage.getByRole('heading', { name: 'Artists' })
     ).toBeVisible({ timeout: 5_000 })
 
     // Venue input

--- a/frontend/e2e/setup-db.sh
+++ b/frontend/e2e/setup-db.sh
@@ -10,25 +10,17 @@ set -euo pipefail
 E2E_DB_URL="postgres://e2euser:e2epassword@localhost:5433/e2edb?sslmode=disable"
 
 echo "==> Waiting for migrate service to finish..."
-# Wait up to 60s for the migrate container to exit successfully
-for i in $(seq 1 30); do
-  STATUS=$(docker compose -p e2e -f docker-compose.e2e.yml ps migrate --format json 2>/dev/null | python3 -c "import sys,json; data=json.load(sys.stdin); print(data['State'] if isinstance(data, dict) else data[0]['State'])" 2>/dev/null || echo "unknown")
-  if [ "$STATUS" = "exited" ]; then
-    EXIT_CODE=$(docker compose -p e2e -f docker-compose.e2e.yml ps migrate --format json 2>/dev/null | python3 -c "import sys,json; data=json.load(sys.stdin); print(data['ExitCode'] if isinstance(data, dict) else data[0]['ExitCode'])" 2>/dev/null || echo "1")
-    if [ "$EXIT_CODE" = "0" ]; then
-      echo "    Migrations completed successfully."
-      break
-    else
-      echo "ERROR: Migrate exited with code $EXIT_CODE"
-      docker compose -p e2e -f docker-compose.e2e.yml logs migrate
-      exit 1
-    fi
-  fi
-  sleep 2
-done
+# Block until the migrate container exits; propagates its exit code.
+# (docker compose wait is available since Compose v2.23)
+if ! docker compose -p e2e -f docker-compose.e2e.yml wait migrate; then
+  echo "ERROR: Migrations failed. Container logs:"
+  docker compose -p e2e -f docker-compose.e2e.yml logs migrate
+  exit 1
+fi
+echo "    Migrations completed successfully."
 
 echo "==> Seeding venues and artists..."
-psql "$E2E_DB_URL" <<'SQL'
+psql -v ON_ERROR_STOP=1 "$E2E_DB_URL" <<'SQL'
 -- Minimal set of venues for E2E tests
 INSERT INTO venues (name, address, city, state, zipcode, verified, created_at, updated_at, slug)
 VALUES
@@ -57,7 +49,7 @@ ON CONFLICT DO NOTHING;
 SQL
 
 echo "==> Inserting future-dated test shows..."
-psql "$E2E_DB_URL" <<'SQL'
+psql -v ON_ERROR_STOP=1 "$E2E_DB_URL" <<'SQL'
 -- Insert 55 future-dated approved shows (enough to trigger pagination at limit=50).
 -- Uses venue/artist IDs from the seed data, cycling through them.
 DO $$
@@ -100,12 +92,12 @@ END $$;
 SQL
 
 echo "==> Verifying seeded venues (public API requires verified=true)..."
-psql "$E2E_DB_URL" <<'SQL'
+psql -v ON_ERROR_STOP=1 "$E2E_DB_URL" <<'SQL'
 UPDATE venues SET verified = true WHERE verified = false;
 SQL
 
 echo "==> Backfilling slugs for any records missing them..."
-psql "$E2E_DB_URL" <<'SQL'
+psql -v ON_ERROR_STOP=1 "$E2E_DB_URL" <<'SQL'
 -- Backfill show slugs (the SQL-inserted E2E shows don't have slugs)
 UPDATE shows
 SET slug = LOWER(
@@ -132,7 +124,7 @@ echo "==> Inserting test users..."
 # Pre-computed bcrypt hash for "e2e-test-password-123" (cost 10)
 BCRYPT_HASH='$2a$10$h7GdGcX7SxMFQCohXdTQnuVkygj7RPCcPhPrPMgHkWr50w.Fv0XoW'
 
-psql "$E2E_DB_URL" <<SQL
+psql -v ON_ERROR_STOP=1 "$E2E_DB_URL" <<SQL
 -- Regular test user
 INSERT INTO users (email, password_hash, first_name, last_name, is_active, is_admin, email_verified, created_at, updated_at)
 VALUES ('e2e-user@test.local', '${BCRYPT_HASH}', 'Test', 'User', true, false, true, NOW(), NOW())
@@ -156,7 +148,7 @@ ON CONFLICT (user_id) DO NOTHING;
 SQL
 
 echo "==> Inserting admin workflow test data..."
-psql "$E2E_DB_URL" <<'SQL'
+psql -v ON_ERROR_STOP=1 "$E2E_DB_URL" <<'SQL'
 -- Admin workflow seed data: pending shows, unverified venue, pending venue edits
 DO $$
 DECLARE

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -109,6 +109,7 @@ export const API_ENDPOINTS = {
   },
   ARTISTS: {
     LIST: `${API_BASE_URL}/artists`,
+    CITIES: `${API_BASE_URL}/artists/cities`,
     SEARCH: `${API_BASE_URL}/artists/search`,
     GET: (artistIdOrSlug: string | number) => `${API_BASE_URL}/artists/${artistIdOrSlug}`,
     SHOWS: (artistIdOrSlug: string | number) => `${API_BASE_URL}/artists/${artistIdOrSlug}/shows`,

--- a/frontend/lib/hooks/useArtists.test.tsx
+++ b/frontend/lib/hooks/useArtists.test.tsx
@@ -12,6 +12,8 @@ vi.mock('../api', () => ({
   apiRequest: (...args: unknown[]) => mockApiRequest(...args),
   API_ENDPOINTS: {
     ARTISTS: {
+      LIST: '/artists',
+      CITIES: '/artists/cities',
       GET: (artistId: string | number) => `/artists/${artistId}`,
       SHOWS: (artistId: string | number) => `/artists/${artistId}/shows`,
     },
@@ -23,6 +25,8 @@ vi.mock('../api', () => ({
 vi.mock('../queryClient', () => ({
   queryKeys: {
     artists: {
+      list: (filters?: Record<string, unknown>) => ['artists', 'list', filters],
+      cities: ['artists', 'cities'],
       detail: (id: string | number) => ['artists', 'detail', String(id)],
       shows: (artistId: string | number) => ['artists', 'shows', String(artistId)],
     },
@@ -30,7 +34,7 @@ vi.mock('../queryClient', () => ({
 }))
 
 // Import hooks after mocks are set up
-import { useArtist, useArtistShows } from './useArtists'
+import { useArtists, useArtistCities, useArtist, useArtistShows } from './useArtists'
 
 // Helper to create wrapper with specific query client
 function createWrapperWithClient(queryClient: QueryClient) {
@@ -136,6 +140,88 @@ describe('useArtists', () => {
       expect(result.current.data?.social.spotify).toBe(
         'https://open.spotify.com/artist/123'
       )
+    })
+  })
+
+  describe('useArtists', () => {
+    it('fetches all artists without filters', async () => {
+      const mockResponse = {
+        artists: [{ id: 1, name: 'Artist A' }, { id: 2, name: 'Artist B' }],
+        count: 2,
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(() => useArtists(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/artists', { method: 'GET' })
+      expect(result.current.data?.artists).toHaveLength(2)
+    })
+
+    it('includes cities filter in query params', async () => {
+      mockApiRequest.mockResolvedValueOnce({ artists: [], count: 0 })
+
+      const { result } = renderHook(
+        () => useArtists({ cities: [{ city: 'Phoenix', state: 'AZ' }, { city: 'Mesa', state: 'AZ' }] }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/artists?cities=Phoenix%2CAZ%7CMesa%2CAZ',
+        { method: 'GET' }
+      )
+    })
+
+    it('handles API errors', async () => {
+      const error = new Error('Server error')
+      Object.assign(error, { status: 500 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(() => useArtists(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+    })
+  })
+
+  describe('useArtistCities', () => {
+    it('fetches artist cities', async () => {
+      const mockResponse = {
+        cities: [
+          { city: 'Phoenix', state: 'AZ', artist_count: 10 },
+          { city: 'Mesa', state: 'AZ', artist_count: 5 },
+        ],
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(() => useArtistCities(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/artists/cities', { method: 'GET' })
+      expect(result.current.data?.cities).toHaveLength(2)
+      expect(result.current.data?.cities[0].city).toBe('Phoenix')
+      expect(result.current.data?.cities[0].artist_count).toBe(10)
+    })
+
+    it('handles API errors', async () => {
+      const error = new Error('Server error')
+      Object.assign(error, { status: 500 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(() => useArtistCities(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
     })
   })
 

--- a/frontend/lib/hooks/useArtists.ts
+++ b/frontend/lib/hooks/useArtists.ts
@@ -6,14 +6,66 @@
  * TanStack Query hooks for fetching artist data from the API.
  */
 
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, keepPreviousData } from '@tanstack/react-query'
 import { apiRequest, API_ENDPOINTS } from '../api'
 import { queryKeys } from '../queryClient'
+import type { CityState } from '@/components/filters'
 import type {
   Artist,
+  ArtistsListResponse,
+  ArtistCitiesResponse,
   ArtistShowsResponse,
   ArtistTimeFilter,
 } from '../types/artist'
+
+interface UseArtistsOptions {
+  cities?: CityState[]
+}
+
+/**
+ * Hook to fetch list of artists with optional city filtering
+ */
+export function useArtists(options: UseArtistsOptions = {}) {
+  const { cities } = options
+
+  // Build query params
+  const params = new URLSearchParams()
+  if (cities && cities.length > 0) {
+    params.set('cities', cities.map(c => `${c.city},${c.state}`).join('|'))
+  }
+
+  const queryString = params.toString()
+  const endpoint = queryString
+    ? `${API_ENDPOINTS.ARTISTS.LIST}?${queryString}`
+    : API_ENDPOINTS.ARTISTS.LIST
+
+  return useQuery({
+    queryKey: queryKeys.artists.list(cities ? { cities } : undefined),
+    queryFn: async (): Promise<ArtistsListResponse> => {
+      return apiRequest<ArtistsListResponse>(endpoint, {
+        method: 'GET',
+      })
+    },
+    staleTime: 5 * 60 * 1000, // 5 minutes
+    placeholderData: keepPreviousData,
+  })
+}
+
+/**
+ * Hook to fetch distinct cities with artist counts for filtering
+ */
+export function useArtistCities() {
+  return useQuery({
+    queryKey: queryKeys.artists.cities,
+    queryFn: async (): Promise<ArtistCitiesResponse> => {
+      return apiRequest<ArtistCitiesResponse>(API_ENDPOINTS.ARTISTS.CITIES, {
+        method: 'GET',
+      })
+    },
+    staleTime: 10 * 60 * 1000, // 10 minutes - cities don't change often
+    placeholderData: keepPreviousData,
+  })
+}
 
 interface UseArtistOptions {
   artistId: string | number

--- a/frontend/lib/hooks/useVenues.ts
+++ b/frontend/lib/hooks/useVenues.ts
@@ -16,9 +16,15 @@ import type {
   VenueCitiesResponse,
 } from '../types/venue'
 
+interface CityState {
+  city: string
+  state: string
+}
+
 interface UseVenuesOptions {
   state?: string
   city?: string
+  cities?: CityState[]
   limit?: number
   offset?: number
 }
@@ -27,12 +33,17 @@ interface UseVenuesOptions {
  * Hook to fetch list of venues with show counts
  */
 export const useVenues = (options: UseVenuesOptions = {}) => {
-  const { state, city, limit = 50, offset = 0 } = options
+  const { state, city, cities, limit = 50, offset = 0 } = options
 
   // Build query params
   const params = new URLSearchParams()
-  if (state) params.set('state', state)
-  if (city) params.set('city', city)
+  if (cities && cities.length > 0) {
+    // Multi-city filter: "Phoenix,AZ|Tucson,AZ"
+    params.set('cities', cities.map(c => `${c.city},${c.state}`).join('|'))
+  } else {
+    if (state) params.set('state', state)
+    if (city) params.set('city', city)
+  }
   if (limit) params.set('limit', limit.toString())
   if (offset) params.set('offset', offset.toString())
 
@@ -42,7 +53,7 @@ export const useVenues = (options: UseVenuesOptions = {}) => {
     : API_ENDPOINTS.VENUES.LIST
 
   return useQuery({
-    queryKey: queryKeys.venues.list({ state, city, limit, offset }),
+    queryKey: queryKeys.venues.list({ state, city, cities, limit, offset }),
     queryFn: async (): Promise<VenuesListResponse> => {
       return apiRequest<VenuesListResponse>(endpoint, {
         method: 'GET',

--- a/frontend/lib/queryClient.ts
+++ b/frontend/lib/queryClient.ts
@@ -157,6 +157,9 @@ export const queryKeys = {
   // Artist queries
   artists: {
     all: ['artists'] as const,
+    list: (filters?: Record<string, unknown>) =>
+      ['artists', 'list', filters] as const,
+    cities: ['artists', 'cities'] as const,
     search: (query: string) =>
       ['artists', 'search', query.toLowerCase()] as const,
     detail: (idOrSlug: string | number) => ['artists', 'detail', String(idOrSlug)] as const,

--- a/frontend/lib/types/artist.ts
+++ b/frontend/lib/types/artist.ts
@@ -52,8 +52,12 @@ export interface ArtistCitiesResponse {
   cities: ArtistCity[]
 }
 
+export interface ArtistListItem extends Artist {
+  upcoming_show_count: number
+}
+
 export interface ArtistsListResponse {
-  artists: Artist[]
+  artists: ArtistListItem[]
   count: number
 }
 

--- a/frontend/lib/types/artist.ts
+++ b/frontend/lib/types/artist.ts
@@ -42,6 +42,21 @@ export interface ArtistEditRequest {
   website?: string
 }
 
+export interface ArtistCity {
+  city: string
+  state: string
+  artist_count: number
+}
+
+export interface ArtistCitiesResponse {
+  cities: ArtistCity[]
+}
+
+export interface ArtistsListResponse {
+  artists: Artist[]
+  count: number
+}
+
 export interface ArtistSearchParams {
   query: string
 }


### PR DESCRIPTION
## Summary

- **Show count filtering**: Artists page only displays artists with upcoming approved shows, sorted by show count descending. Backend adds `GetArtistsWithShowCounts` service method with subquery join pattern.
- **Compact grid layout**: Redesigned `ArtistCard` as a dense directory-style grid item (3 columns on desktop) showing name, show count, and location.
- **Autocomplete search**: Added `ArtistSearch` and `VenueSearch` components with debounced search, keyboard navigation (arrow keys, Enter, Escape), and navigation to detail pages on selection.
- **Multi-city filtering for venues**: Venues page now uses pipe-delimited `cities` URL param (matching shows/artists pattern), enabling shift+click multi-select on city filter chips.
- **Layout cleanup**: Search bar stacked above city filter pills on both artists and venues pages. Removed baked-in `mb-6` from `CityFilters` component so consumers control their own spacing.

## Test plan

- [ ] Backend: `go test ./internal/services/ -run TestArtist` — service tests pass
- [ ] Backend: `go test ./internal/api/handlers/ -run TestArtist` — handler tests pass  
- [ ] Backend: `go test ./internal/api/handlers/ -run TestVenue` — handler tests pass (including new multi-city filter test)
- [ ] Frontend: `bun run test:run` — all 836 tests pass (48 files)
- [ ] Frontend: `tsc --noEmit` — zero type errors
- [ ] Navigate to `/artists` — only artists with upcoming shows appear in compact grid
- [ ] Navigate to `/venues` — search bar above city pills, shift+click multi-select works
- [ ] Search works on both pages — type, see dropdown, click or Enter to navigate
- [ ] City filters work on both pages — single click and shift+click

🤖 Generated with [Claude Code](https://claude.com/claude-code)