### PR TITLE
feat: add ICS calendar feed for saved shows

### DIFF
--- a/backend/db/migrations/000033_add_calendar_tokens.down.sql
+++ b/backend/db/migrations/000033_add_calendar_tokens.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS calendar_tokens;

--- a/backend/db/migrations/000033_add_calendar_tokens.up.sql
+++ b/backend/db/migrations/000033_add_calendar_tokens.up.sql
@@ -1,0 +1,8 @@
+CREATE TABLE calendar_tokens (
+    id         SERIAL PRIMARY KEY,
+    user_id    INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    token_hash VARCHAR(64) NOT NULL UNIQUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX idx_calendar_tokens_user_id ON calendar_tokens(user_id);

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -31,6 +31,7 @@ require (
 	dario.cat/mergo v1.0.1 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
+	github.com/arran4/golang-ical v0.3.3 // indirect
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -10,6 +10,8 @@ github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOEl
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+github.com/arran4/golang-ical v0.3.3 h1:8oEhMFS8tBoXmrMf6dKVWPNB1lNfE8xGn/c5NYm3SKg=
+github.com/arran4/golang-ical v0.3.3/go.mod h1:OnguFgjN0Hmx8jzpmWcC+AkHio94ujmLHKoaef7xQh8=
 github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
 github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=

--- a/backend/internal/api/handlers/calendar.go
+++ b/backend/internal/api/handlers/calendar.go
@@ -1,0 +1,214 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/go-chi/chi/v5"
+
+	"psychic-homily-backend/internal/api/middleware"
+	"psychic-homily-backend/internal/config"
+	"psychic-homily-backend/internal/logger"
+	"psychic-homily-backend/internal/services"
+)
+
+// CalendarHandler handles calendar feed and token management
+type CalendarHandler struct {
+	calendarService services.CalendarServiceInterface
+	config          *config.Config
+}
+
+// NewCalendarHandler creates a new calendar handler
+func NewCalendarHandler(calendarService services.CalendarServiceInterface, cfg *config.Config) *CalendarHandler {
+	return &CalendarHandler{
+		calendarService: calendarService,
+		config:          cfg,
+	}
+}
+
+// --- ICS Feed endpoint (Chi http.HandlerFunc, public, token-authenticated) ---
+
+// GetCalendarFeedHandler serves the ICS calendar feed
+func (h *CalendarHandler) GetCalendarFeedHandler(w http.ResponseWriter, r *http.Request) {
+	token := chi.URLParam(r, "token")
+	if token == "" {
+		http.Error(w, "missing token", http.StatusBadRequest)
+		return
+	}
+
+	user, err := h.calendarService.ValidateCalendarToken(token)
+	if err != nil {
+		logger.FromContext(r.Context()).Warn("calendar_feed_invalid_token",
+			"error", err.Error(),
+		)
+		http.Error(w, "invalid or expired token", http.StatusUnauthorized)
+		return
+	}
+
+	frontendURL := h.config.Email.FrontendURL
+	if frontendURL == "" {
+		frontendURL = "http://localhost:3000"
+	}
+
+	icsData, err := h.calendarService.GenerateICSFeed(user.ID, frontendURL)
+	if err != nil {
+		logger.FromContext(r.Context()).Error("calendar_feed_generation_failed",
+			"user_id", user.ID,
+			"error", err.Error(),
+		)
+		http.Error(w, "failed to generate calendar feed", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/calendar; charset=utf-8")
+	w.Header().Set("Content-Disposition", "inline; filename=\"psychic-homily.ics\"")
+	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
+	w.WriteHeader(http.StatusOK)
+	w.Write(icsData)
+}
+
+// --- Token CRUD endpoints (Huma, protected) ---
+
+// CreateCalendarTokenRequest is empty — user is derived from JWT context
+type CreateCalendarTokenRequest struct{}
+
+// CreateCalendarTokenResponse wraps the service response
+type CreateCalendarTokenResponse struct {
+	Body services.CalendarTokenCreateResponse
+}
+
+// CreateCalendarTokenHandler creates or regenerates a calendar token
+func (h *CalendarHandler) CreateCalendarTokenHandler(ctx context.Context, req *CreateCalendarTokenRequest) (*CreateCalendarTokenResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	// Derive the API base URL from config
+	// In production this is the backend's public URL (e.g. https://api.psychichomily.com)
+	apiBaseURL := h.config.Email.FrontendURL
+	if apiBaseURL == "" {
+		apiBaseURL = "http://localhost:8080"
+	}
+	// The feed URL should use the API domain, not the frontend domain
+	// Derive from the MusicDiscovery FrontendURL pattern, but use the API URL
+	apiBaseURL = getAPIBaseURL(h.config)
+
+	result, err := h.calendarService.CreateToken(user.ID, apiBaseURL)
+	if err != nil {
+		logger.FromContext(ctx).Error("create_calendar_token_failed",
+			"user_id", user.ID,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to create calendar token (request_id: %s)", requestID),
+		)
+	}
+
+	logger.FromContext(ctx).Info("create_calendar_token_success",
+		"user_id", user.ID,
+		"request_id", requestID,
+	)
+
+	return &CreateCalendarTokenResponse{Body: *result}, nil
+}
+
+// GetCalendarTokenStatusRequest is empty — user is derived from JWT context
+type GetCalendarTokenStatusRequest struct{}
+
+// GetCalendarTokenStatusResponse wraps the service response
+type GetCalendarTokenStatusResponse struct {
+	Body services.CalendarTokenStatusResponse
+}
+
+// GetCalendarTokenStatusHandler checks if a user has a calendar token
+func (h *CalendarHandler) GetCalendarTokenStatusHandler(ctx context.Context, req *GetCalendarTokenStatusRequest) (*GetCalendarTokenStatusResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	status, err := h.calendarService.GetTokenStatus(user.ID)
+	if err != nil {
+		logger.FromContext(ctx).Error("get_calendar_token_status_failed",
+			"user_id", user.ID,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to get calendar token status (request_id: %s)", requestID),
+		)
+	}
+
+	return &GetCalendarTokenStatusResponse{Body: *status}, nil
+}
+
+// DeleteCalendarTokenRequest is empty — user is derived from JWT context
+type DeleteCalendarTokenRequest struct{}
+
+// DeleteCalendarTokenResponse returns success status
+type DeleteCalendarTokenResponse struct {
+	Body struct {
+		Success bool   `json:"success"`
+		Message string `json:"message"`
+	}
+}
+
+// DeleteCalendarTokenHandler removes a user's calendar token
+func (h *CalendarHandler) DeleteCalendarTokenHandler(ctx context.Context, req *DeleteCalendarTokenRequest) (*DeleteCalendarTokenResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	err := h.calendarService.DeleteToken(user.ID)
+	if err != nil {
+		logger.FromContext(ctx).Error("delete_calendar_token_failed",
+			"user_id", user.ID,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error422UnprocessableEntity(
+			fmt.Sprintf("Failed to delete calendar token (request_id: %s)", requestID),
+		)
+	}
+
+	logger.FromContext(ctx).Info("delete_calendar_token_success",
+		"user_id", user.ID,
+		"request_id", requestID,
+	)
+
+	return &DeleteCalendarTokenResponse{
+		Body: struct {
+			Success bool   `json:"success"`
+			Message string `json:"message"`
+		}{
+			Success: true,
+			Message: "Calendar token deleted successfully",
+		},
+	}, nil
+}
+
+// getAPIBaseURL derives the API's public base URL from config
+func getAPIBaseURL(cfg *config.Config) string {
+	// In production, the API is at api.psychichomily.com
+	// In development, it's localhost:8080
+	frontendURL := cfg.Email.FrontendURL
+	switch frontendURL {
+	case "https://psychichomily.com":
+		return "https://api.psychichomily.com"
+	case "https://stage.psychichomily.com":
+		return "https://api-stage.psychichomily.com"
+	default:
+		return "http://localhost:8080"
+	}
+}

--- a/backend/internal/api/handlers/calendar_test.go
+++ b/backend/internal/api/handlers/calendar_test.go
@@ -1,0 +1,255 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"psychic-homily-backend/internal/config"
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services"
+)
+
+// =============================================================================
+// Mock: CalendarServiceInterface
+// =============================================================================
+
+type mockCalendarService struct {
+	createTokenFn    func(userID uint, apiBaseURL string) (*services.CalendarTokenCreateResponse, error)
+	getTokenStatusFn func(userID uint) (*services.CalendarTokenStatusResponse, error)
+	deleteTokenFn    func(userID uint) error
+	validateTokenFn  func(plainToken string) (*models.User, error)
+	generateFeedFn   func(userID uint, frontendURL string) ([]byte, error)
+}
+
+func (m *mockCalendarService) CreateToken(userID uint, apiBaseURL string) (*services.CalendarTokenCreateResponse, error) {
+	if m.createTokenFn != nil {
+		return m.createTokenFn(userID, apiBaseURL)
+	}
+	return nil, nil
+}
+
+func (m *mockCalendarService) GetTokenStatus(userID uint) (*services.CalendarTokenStatusResponse, error) {
+	if m.getTokenStatusFn != nil {
+		return m.getTokenStatusFn(userID)
+	}
+	return nil, nil
+}
+
+func (m *mockCalendarService) DeleteToken(userID uint) error {
+	if m.deleteTokenFn != nil {
+		return m.deleteTokenFn(userID)
+	}
+	return nil
+}
+
+func (m *mockCalendarService) ValidateCalendarToken(plainToken string) (*models.User, error) {
+	if m.validateTokenFn != nil {
+		return m.validateTokenFn(plainToken)
+	}
+	return nil, nil
+}
+
+func (m *mockCalendarService) GenerateICSFeed(userID uint, frontendURL string) ([]byte, error) {
+	if m.generateFeedFn != nil {
+		return m.generateFeedFn(userID, frontendURL)
+	}
+	return nil, nil
+}
+
+func testCalendarConfig() *config.Config {
+	return &config.Config{
+		Email: config.EmailConfig{
+			FrontendURL: "http://localhost:3000",
+		},
+	}
+}
+
+// =============================================================================
+// CreateCalendarTokenHandler tests
+// =============================================================================
+
+func TestCreateCalendarTokenHandler_NoAuth(t *testing.T) {
+	h := NewCalendarHandler(&mockCalendarService{}, testCalendarConfig())
+	_, err := h.CreateCalendarTokenHandler(context.Background(), &CreateCalendarTokenRequest{})
+	assertHumaError(t, err, 401)
+}
+
+func TestCreateCalendarTokenHandler_Success(t *testing.T) {
+	now := time.Now()
+	mock := &mockCalendarService{
+		createTokenFn: func(userID uint, apiBaseURL string) (*services.CalendarTokenCreateResponse, error) {
+			if userID != 1 {
+				t.Errorf("unexpected userID=%d", userID)
+			}
+			return &services.CalendarTokenCreateResponse{
+				Token:     "phcal_abc123",
+				FeedURL:   apiBaseURL + "/calendar/phcal_abc123",
+				CreatedAt: now,
+			}, nil
+		},
+	}
+	h := NewCalendarHandler(mock, testCalendarConfig())
+	ctx := ctxWithUser(&models.User{ID: 1})
+
+	resp, err := h.CreateCalendarTokenHandler(ctx, &CreateCalendarTokenRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Token != "phcal_abc123" {
+		t.Errorf("expected token phcal_abc123, got %s", resp.Body.Token)
+	}
+	if resp.Body.FeedURL == "" {
+		t.Error("expected non-empty feed URL")
+	}
+}
+
+func TestCreateCalendarTokenHandler_ServiceError(t *testing.T) {
+	mock := &mockCalendarService{
+		createTokenFn: func(_ uint, _ string) (*services.CalendarTokenCreateResponse, error) {
+			return nil, fmt.Errorf("db error")
+		},
+	}
+	h := NewCalendarHandler(mock, testCalendarConfig())
+	ctx := ctxWithUser(&models.User{ID: 1})
+
+	_, err := h.CreateCalendarTokenHandler(ctx, &CreateCalendarTokenRequest{})
+	assertHumaError(t, err, 500)
+}
+
+// =============================================================================
+// GetCalendarTokenStatusHandler tests
+// =============================================================================
+
+func TestGetCalendarTokenStatusHandler_NoAuth(t *testing.T) {
+	h := NewCalendarHandler(&mockCalendarService{}, testCalendarConfig())
+	_, err := h.GetCalendarTokenStatusHandler(context.Background(), &GetCalendarTokenStatusRequest{})
+	assertHumaError(t, err, 401)
+}
+
+func TestGetCalendarTokenStatusHandler_HasToken(t *testing.T) {
+	now := time.Now()
+	mock := &mockCalendarService{
+		getTokenStatusFn: func(userID uint) (*services.CalendarTokenStatusResponse, error) {
+			return &services.CalendarTokenStatusResponse{
+				HasToken:  true,
+				CreatedAt: &now,
+			}, nil
+		},
+	}
+	h := NewCalendarHandler(mock, testCalendarConfig())
+	ctx := ctxWithUser(&models.User{ID: 1})
+
+	resp, err := h.GetCalendarTokenStatusHandler(ctx, &GetCalendarTokenStatusRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.Body.HasToken {
+		t.Error("expected has_token=true")
+	}
+}
+
+func TestGetCalendarTokenStatusHandler_NoToken(t *testing.T) {
+	mock := &mockCalendarService{
+		getTokenStatusFn: func(userID uint) (*services.CalendarTokenStatusResponse, error) {
+			return &services.CalendarTokenStatusResponse{HasToken: false}, nil
+		},
+	}
+	h := NewCalendarHandler(mock, testCalendarConfig())
+	ctx := ctxWithUser(&models.User{ID: 1})
+
+	resp, err := h.GetCalendarTokenStatusHandler(ctx, &GetCalendarTokenStatusRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.HasToken {
+		t.Error("expected has_token=false")
+	}
+}
+
+func TestGetCalendarTokenStatusHandler_ServiceError(t *testing.T) {
+	mock := &mockCalendarService{
+		getTokenStatusFn: func(_ uint) (*services.CalendarTokenStatusResponse, error) {
+			return nil, fmt.Errorf("db error")
+		},
+	}
+	h := NewCalendarHandler(mock, testCalendarConfig())
+	ctx := ctxWithUser(&models.User{ID: 1})
+
+	_, err := h.GetCalendarTokenStatusHandler(ctx, &GetCalendarTokenStatusRequest{})
+	assertHumaError(t, err, 500)
+}
+
+// =============================================================================
+// DeleteCalendarTokenHandler tests
+// =============================================================================
+
+func TestDeleteCalendarTokenHandler_NoAuth(t *testing.T) {
+	h := NewCalendarHandler(&mockCalendarService{}, testCalendarConfig())
+	_, err := h.DeleteCalendarTokenHandler(context.Background(), &DeleteCalendarTokenRequest{})
+	assertHumaError(t, err, 401)
+}
+
+func TestDeleteCalendarTokenHandler_Success(t *testing.T) {
+	mock := &mockCalendarService{
+		deleteTokenFn: func(userID uint) error {
+			if userID != 1 {
+				t.Errorf("unexpected userID=%d", userID)
+			}
+			return nil
+		},
+	}
+	h := NewCalendarHandler(mock, testCalendarConfig())
+	ctx := ctxWithUser(&models.User{ID: 1})
+
+	resp, err := h.DeleteCalendarTokenHandler(ctx, &DeleteCalendarTokenRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.Body.Success {
+		t.Error("expected success=true")
+	}
+}
+
+func TestDeleteCalendarTokenHandler_ServiceError(t *testing.T) {
+	mock := &mockCalendarService{
+		deleteTokenFn: func(_ uint) error {
+			return fmt.Errorf("no calendar token found")
+		},
+	}
+	h := NewCalendarHandler(mock, testCalendarConfig())
+	ctx := ctxWithUser(&models.User{ID: 1})
+
+	_, err := h.DeleteCalendarTokenHandler(ctx, &DeleteCalendarTokenRequest{})
+	assertHumaError(t, err, 422)
+}
+
+// =============================================================================
+// getAPIBaseURL tests
+// =============================================================================
+
+func TestGetAPIBaseURL(t *testing.T) {
+	tests := []struct {
+		name        string
+		frontendURL string
+		expected    string
+	}{
+		{"production", "https://psychichomily.com", "https://api.psychichomily.com"},
+		{"stage", "https://stage.psychichomily.com", "https://api-stage.psychichomily.com"},
+		{"development", "http://localhost:3000", "http://localhost:8080"},
+		{"empty", "", "http://localhost:8080"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{
+				Email: config.EmailConfig{FrontendURL: tt.frontendURL},
+			}
+			result := getAPIBaseURL(cfg)
+			if result != tt.expected {
+				t.Errorf("getAPIBaseURL(%q) = %q, want %q", tt.frontendURL, result, tt.expected)
+			}
+		})
+	}
+}

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -80,6 +80,7 @@ func SetupRoutes(router *chi.Mux, sc *services.ServiceContainer, cfg *config.Con
 	setupShowRoutes(router, api, protectedGroup, sc, cfg)
 	setupArtistRoutes(api, protectedGroup, sc)
 	setupVenueRoutes(api, protectedGroup, sc)
+	setupCalendarRoutes(router, protectedGroup, sc, cfg)
 	setupSavedShowRoutes(protectedGroup, sc)
 	setupFavoriteVenueRoutes(protectedGroup, sc)
 	setupShowReportRoutes(router, protectedGroup, sc, cfg)
@@ -290,6 +291,19 @@ func setupVenueRoutes(api huma.API, protected *huma.Group, sc *services.ServiceC
 	huma.Delete(protected, "/venues/{venue_id}", venueHandler.DeleteVenueHandler)
 	huma.Get(protected, "/venues/{venue_id}/my-pending-edit", venueHandler.GetMyPendingEditHandler)
 	huma.Delete(protected, "/venues/{venue_id}/my-pending-edit", venueHandler.CancelMyPendingEditHandler)
+}
+
+// setupCalendarRoutes configures calendar feed and token management endpoints
+func setupCalendarRoutes(router *chi.Mux, protected *huma.Group, sc *services.ServiceContainer, cfg *config.Config) {
+	calendarHandler := handlers.NewCalendarHandler(sc.Calendar, cfg)
+
+	// Public Chi route for ICS feed (token-authenticated, not JWT)
+	router.Get("/calendar/{token}", calendarHandler.GetCalendarFeedHandler)
+
+	// Protected Huma routes for token CRUD
+	huma.Post(protected, "/calendar/token", calendarHandler.CreateCalendarTokenHandler)
+	huma.Get(protected, "/calendar/token", calendarHandler.GetCalendarTokenStatusHandler)
+	huma.Delete(protected, "/calendar/token", calendarHandler.DeleteCalendarTokenHandler)
 }
 
 // setupSavedShowRoutes configures saved show endpoints (user's personal "My List")

--- a/backend/internal/models/calendar_token.go
+++ b/backend/internal/models/calendar_token.go
@@ -1,0 +1,18 @@
+package models
+
+import "time"
+
+// CalendarToken represents a per-user token for calendar feed access
+type CalendarToken struct {
+	ID        uint      `json:"id" gorm:"primaryKey"`
+	UserID    uint      `json:"user_id" gorm:"uniqueIndex:idx_calendar_tokens_user_id;not null"`
+	TokenHash string    `json:"-" gorm:"column:token_hash;uniqueIndex;not null"`
+	CreatedAt time.Time `json:"created_at"`
+
+	// Relationships
+	User User `json:"-" gorm:"foreignKey:UserID"`
+}
+
+func (CalendarToken) TableName() string {
+	return "calendar_tokens"
+}

--- a/backend/internal/services/calendar.go
+++ b/backend/internal/services/calendar.go
@@ -1,0 +1,264 @@
+package services
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+
+	ics "github.com/arran4/golang-ical"
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/db"
+	"psychic-homily-backend/internal/models"
+)
+
+const (
+	// CalendarTokenPrefix is prepended to calendar tokens for identification
+	CalendarTokenPrefix = "phcal_"
+)
+
+// CalendarService handles calendar feed token and ICS generation
+type CalendarService struct {
+	db           *gorm.DB
+	savedShowSvc SavedShowServiceInterface
+}
+
+// NewCalendarService creates a new calendar service
+func NewCalendarService(database *gorm.DB, savedShowSvc SavedShowServiceInterface) *CalendarService {
+	if database == nil {
+		database = db.GetDB()
+	}
+	return &CalendarService{
+		db:           database,
+		savedShowSvc: savedShowSvc,
+	}
+}
+
+// CalendarTokenCreateResponse is returned when a token is created
+type CalendarTokenCreateResponse struct {
+	Token     string    `json:"token"`
+	FeedURL   string    `json:"feed_url"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// CalendarTokenStatusResponse is returned for token status checks
+type CalendarTokenStatusResponse struct {
+	HasToken  bool       `json:"has_token"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
+}
+
+// generateCalendarToken creates a cryptographically secure random calendar token
+func generateCalendarToken() (string, error) {
+	bytes := make([]byte, TokenLength)
+	if _, err := rand.Read(bytes); err != nil {
+		return "", fmt.Errorf("failed to generate random bytes: %w", err)
+	}
+	return CalendarTokenPrefix + hex.EncodeToString(bytes), nil
+}
+
+// CreateToken generates a new calendar token for a user, replacing any existing token
+func (s *CalendarService) CreateToken(userID uint, apiBaseURL string) (*CalendarTokenCreateResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	plainToken, err := generateCalendarToken()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate token: %w", err)
+	}
+
+	tokenHash := hashToken(plainToken)
+
+	// Delete existing + insert new in a transaction
+	err = s.db.Transaction(func(tx *gorm.DB) error {
+		// Delete any existing token for this user
+		if err := tx.Where("user_id = ?", userID).Delete(&models.CalendarToken{}).Error; err != nil {
+			return fmt.Errorf("failed to delete existing token: %w", err)
+		}
+
+		token := &models.CalendarToken{
+			UserID:    userID,
+			TokenHash: tokenHash,
+		}
+		if err := tx.Create(token).Error; err != nil {
+			return fmt.Errorf("failed to create token: %w", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Fetch the created token to get the server-set created_at
+	var created models.CalendarToken
+	if err := s.db.Where("user_id = ?", userID).First(&created).Error; err != nil {
+		return nil, fmt.Errorf("failed to fetch created token: %w", err)
+	}
+
+	feedURL := fmt.Sprintf("%s/calendar/%s", apiBaseURL, plainToken)
+
+	return &CalendarTokenCreateResponse{
+		Token:     plainToken,
+		FeedURL:   feedURL,
+		CreatedAt: created.CreatedAt,
+	}, nil
+}
+
+// GetTokenStatus checks whether a user has a calendar token
+func (s *CalendarService) GetTokenStatus(userID uint) (*CalendarTokenStatusResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var token models.CalendarToken
+	err := s.db.Where("user_id = ?", userID).First(&token).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return &CalendarTokenStatusResponse{HasToken: false}, nil
+		}
+		return nil, fmt.Errorf("failed to check token status: %w", err)
+	}
+
+	return &CalendarTokenStatusResponse{
+		HasToken:  true,
+		CreatedAt: &token.CreatedAt,
+	}, nil
+}
+
+// DeleteToken removes a user's calendar token
+func (s *CalendarService) DeleteToken(userID uint) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	result := s.db.Where("user_id = ?", userID).Delete(&models.CalendarToken{})
+	if result.Error != nil {
+		return fmt.Errorf("failed to delete token: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("no calendar token found")
+	}
+	return nil
+}
+
+// ValidateCalendarToken validates a plaintext calendar token and returns the associated user
+func (s *CalendarService) ValidateCalendarToken(plainToken string) (*models.User, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	tokenHash := hashToken(plainToken)
+
+	var token models.CalendarToken
+	err := s.db.Preload("User").Where("token_hash = ?", tokenHash).First(&token).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, fmt.Errorf("invalid calendar token")
+		}
+		return nil, fmt.Errorf("failed to validate token: %w", err)
+	}
+
+	if !token.User.IsActive {
+		return nil, fmt.Errorf("user account is not active")
+	}
+
+	return &token.User, nil
+}
+
+// GenerateICSFeed creates an ICS calendar feed for a user's saved shows
+func (s *CalendarService) GenerateICSFeed(userID uint, frontendURL string) ([]byte, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	// Fetch saved shows (large limit to get all relevant shows)
+	shows, _, err := s.savedShowSvc.GetUserSavedShows(userID, 500, 0)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch saved shows: %w", err)
+	}
+
+	cal := ics.NewCalendar()
+	cal.SetMethod(ics.MethodPublish)
+	cal.SetProductId("-//Psychic Homily//Calendar Feed//EN")
+	cal.SetName("Psychic Homily - My Shows")
+	cal.SetDescription("Your saved shows from Psychic Homily")
+	cal.SetXWRCalName("Psychic Homily - My Shows")
+
+	now := time.Now()
+	cutoff := now.AddDate(0, 0, -30) // 30 days in the past
+
+	for _, show := range shows {
+		// Filter: approved, not cancelled, event_date within range
+		if show.Status != "approved" {
+			continue
+		}
+		if show.IsCancelled {
+			continue
+		}
+		if show.EventDate.Before(cutoff) {
+			continue
+		}
+
+		event := cal.AddEvent(fmt.Sprintf("show-%d@psychichomily.com", show.ID))
+		event.SetCreatedTime(show.CreatedAt)
+		event.SetModifiedAt(show.UpdatedAt)
+		event.SetStartAt(show.EventDate)
+		// Default to 3-hour duration for shows
+		event.SetEndAt(show.EventDate.Add(3 * time.Hour))
+
+		// Summary
+		summary := show.Title
+		if show.IsSoldOut {
+			summary += " [SOLD OUT]"
+		}
+		event.SetSummary(summary)
+
+		// Location
+		if len(show.Venues) > 0 {
+			venue := show.Venues[0]
+			location := venue.Name
+			if venue.City != "" {
+				location += ", " + venue.City
+			}
+			if venue.State != "" {
+				location += ", " + venue.State
+			}
+			event.SetLocation(location)
+		}
+
+		// Description
+		var descParts []string
+
+		// Artist lineup
+		if len(show.Artists) > 0 {
+			names := make([]string, len(show.Artists))
+			for i, a := range show.Artists {
+				names[i] = a.Name
+			}
+			descParts = append(descParts, "Artists: "+strings.Join(names, ", "))
+		}
+
+		if show.Price != nil {
+			descParts = append(descParts, fmt.Sprintf("Price: $%.0f", *show.Price))
+		}
+		if show.AgeRequirement != nil && *show.AgeRequirement != "" {
+			descParts = append(descParts, "Ages: "+*show.AgeRequirement)
+		}
+
+		// Show URL
+		slug := show.Slug
+		if slug == "" {
+			slug = fmt.Sprintf("%d", show.ID)
+		}
+		showURL := fmt.Sprintf("%s/shows/%s", frontendURL, slug)
+		descParts = append(descParts, showURL)
+
+		event.SetDescription(strings.Join(descParts, "\n"))
+		event.SetURL(showURL)
+	}
+
+	return []byte(cal.Serialize()), nil
+}

--- a/backend/internal/services/calendar_test.go
+++ b/backend/internal/services/calendar_test.go
@@ -1,0 +1,511 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/internal/models"
+)
+
+// =============================================================================
+// UNIT TESTS (No Database Required)
+// =============================================================================
+
+func TestNewCalendarService(t *testing.T) {
+	svc := NewCalendarService(nil, nil)
+	assert.NotNil(t, svc)
+}
+
+func TestCalendarService_NilDatabase(t *testing.T) {
+	svc := &CalendarService{db: nil}
+
+	t.Run("CreateToken", func(t *testing.T) {
+		resp, err := svc.CreateToken(1, "http://localhost:8080")
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("GetTokenStatus", func(t *testing.T) {
+		resp, err := svc.GetTokenStatus(1)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("DeleteToken", func(t *testing.T) {
+		err := svc.DeleteToken(1)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+	})
+
+	t.Run("ValidateCalendarToken", func(t *testing.T) {
+		user, err := svc.ValidateCalendarToken("phcal_abc123")
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, user)
+	})
+
+	t.Run("GenerateICSFeed", func(t *testing.T) {
+		data, err := svc.GenerateICSFeed(1, "http://localhost:3000")
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, data)
+	})
+}
+
+func TestGenerateCalendarToken_Format(t *testing.T) {
+	token, err := generateCalendarToken()
+	assert.NoError(t, err)
+	assert.True(t, strings.HasPrefix(token, CalendarTokenPrefix), "token should start with %s", CalendarTokenPrefix)
+	// prefix "phcal_" (6) + hex-encoded 32 bytes (64) = 70 chars
+	assert.Len(t, token, 6+64, "token should be prefix(6) + hex(64) = 70 chars")
+}
+
+func TestGenerateCalendarToken_Unique(t *testing.T) {
+	token1, err1 := generateCalendarToken()
+	token2, err2 := generateCalendarToken()
+	assert.NoError(t, err1)
+	assert.NoError(t, err2)
+	assert.NotEqual(t, token1, token2, "two generated tokens should be different")
+}
+
+func TestGenerateICSFeed_Format(t *testing.T) {
+	// Create a service with a mock saved show service
+	mockShows := []*SavedShowResponse{
+		{
+			ShowResponse: ShowResponse{
+				ID:        1,
+				Slug:      "test-show",
+				Title:     "Test Show",
+				EventDate: time.Now().Add(24 * time.Hour),
+				City:      ptrString("Phoenix"),
+				State:     ptrString("AZ"),
+				Status:    "approved",
+				Venues: []VenueResponse{
+					{ID: 1, Name: "The Venue", City: "Phoenix", State: "AZ"},
+				},
+				Artists: []ArtistResponse{
+					{ID: 1, Name: "Artist One"},
+					{ID: 2, Name: "Artist Two"},
+				},
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+			},
+		},
+	}
+	mockSvc := &mockSavedShowSvc{shows: mockShows, total: 1}
+
+	svc := &CalendarService{db: &gorm.DB{}, savedShowSvc: mockSvc}
+	data, err := svc.GenerateICSFeed(1, "https://psychichomily.com")
+	assert.NoError(t, err)
+	assert.NotNil(t, data)
+
+	icsStr := string(data)
+	assert.Contains(t, icsStr, "BEGIN:VCALENDAR")
+	assert.Contains(t, icsStr, "END:VCALENDAR")
+	assert.Contains(t, icsStr, "BEGIN:VEVENT")
+	assert.Contains(t, icsStr, "END:VEVENT")
+	assert.Contains(t, icsStr, "SUMMARY:Test Show")
+	assert.Contains(t, icsStr, "show-1@psychichomily.com")
+	// ICS escapes commas per RFC 5545
+	assert.Contains(t, icsStr, "The Venue\\, Phoenix\\, AZ")
+	assert.Contains(t, icsStr, "Artist One")
+	// ICS uses line folding (CRLF + space) for long lines, so unfold before checking
+	unfolded := strings.ReplaceAll(icsStr, "\n ", "")
+	assert.Contains(t, unfolded, "Artist Two")
+	assert.Contains(t, icsStr, "https://psychichomily.com/shows/test-show")
+	assert.Contains(t, icsStr, "METHOD:PUBLISH")
+}
+
+func TestGenerateICSFeed_SoldOutLabel(t *testing.T) {
+	mockShows := []*SavedShowResponse{
+		{
+			ShowResponse: ShowResponse{
+				ID:        2,
+				Slug:      "sold-out-show",
+				Title:     "Hot Show",
+				EventDate: time.Now().Add(48 * time.Hour),
+				Status:    "approved",
+				IsSoldOut: true,
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+			},
+		},
+	}
+	mockSvc := &mockSavedShowSvc{shows: mockShows, total: 1}
+
+	svc := &CalendarService{db: &gorm.DB{}, savedShowSvc: mockSvc}
+	data, err := svc.GenerateICSFeed(1, "https://psychichomily.com")
+	assert.NoError(t, err)
+	assert.Contains(t, string(data), "SUMMARY:Hot Show [SOLD OUT]")
+}
+
+func TestGenerateICSFeed_FiltersCancelled(t *testing.T) {
+	mockShows := []*SavedShowResponse{
+		{
+			ShowResponse: ShowResponse{
+				ID:          3,
+				Title:       "Cancelled Show",
+				EventDate:   time.Now().Add(24 * time.Hour),
+				Status:      "approved",
+				IsCancelled: true,
+				CreatedAt:   time.Now(),
+				UpdatedAt:   time.Now(),
+			},
+		},
+	}
+	mockSvc := &mockSavedShowSvc{shows: mockShows, total: 1}
+
+	svc := &CalendarService{db: &gorm.DB{}, savedShowSvc: mockSvc}
+	data, err := svc.GenerateICSFeed(1, "https://psychichomily.com")
+	assert.NoError(t, err)
+	assert.NotContains(t, string(data), "Cancelled Show")
+	assert.NotContains(t, string(data), "BEGIN:VEVENT")
+}
+
+func TestGenerateICSFeed_FiltersNonApproved(t *testing.T) {
+	mockShows := []*SavedShowResponse{
+		{
+			ShowResponse: ShowResponse{
+				ID:        4,
+				Title:     "Pending Show",
+				EventDate: time.Now().Add(24 * time.Hour),
+				Status:    "pending",
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+			},
+		},
+	}
+	mockSvc := &mockSavedShowSvc{shows: mockShows, total: 1}
+
+	svc := &CalendarService{db: &gorm.DB{}, savedShowSvc: mockSvc}
+	data, err := svc.GenerateICSFeed(1, "https://psychichomily.com")
+	assert.NoError(t, err)
+	assert.NotContains(t, string(data), "Pending Show")
+}
+
+func TestGenerateICSFeed_FiltersOldShows(t *testing.T) {
+	mockShows := []*SavedShowResponse{
+		{
+			ShowResponse: ShowResponse{
+				ID:        5,
+				Title:     "Old Show",
+				EventDate: time.Now().AddDate(0, 0, -60), // 60 days ago
+				Status:    "approved",
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+			},
+		},
+	}
+	mockSvc := &mockSavedShowSvc{shows: mockShows, total: 1}
+
+	svc := &CalendarService{db: &gorm.DB{}, savedShowSvc: mockSvc}
+	data, err := svc.GenerateICSFeed(1, "https://psychichomily.com")
+	assert.NoError(t, err)
+	assert.NotContains(t, string(data), "Old Show")
+}
+
+func TestGenerateICSFeed_EmptyList(t *testing.T) {
+	mockSvc := &mockSavedShowSvc{shows: []*SavedShowResponse{}, total: 0}
+	svc := &CalendarService{db: &gorm.DB{}, savedShowSvc: mockSvc}
+	data, err := svc.GenerateICSFeed(1, "https://psychichomily.com")
+	assert.NoError(t, err)
+	assert.Contains(t, string(data), "BEGIN:VCALENDAR")
+	assert.NotContains(t, string(data), "BEGIN:VEVENT")
+}
+
+func TestGenerateICSFeed_FallbackToID(t *testing.T) {
+	mockShows := []*SavedShowResponse{
+		{
+			ShowResponse: ShowResponse{
+				ID:        42,
+				Slug:      "", // no slug
+				Title:     "No Slug Show",
+				EventDate: time.Now().Add(24 * time.Hour),
+				Status:    "approved",
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+			},
+		},
+	}
+	mockSvc := &mockSavedShowSvc{shows: mockShows, total: 1}
+
+	svc := &CalendarService{db: &gorm.DB{}, savedShowSvc: mockSvc}
+	data, err := svc.GenerateICSFeed(1, "https://psychichomily.com")
+	assert.NoError(t, err)
+	assert.Contains(t, string(data), "https://psychichomily.com/shows/42")
+}
+
+// =============================================================================
+// Mock saved show service for unit tests
+// =============================================================================
+
+type mockSavedShowSvc struct {
+	shows []*SavedShowResponse
+	total int64
+	err   error
+}
+
+func (m *mockSavedShowSvc) SaveShow(_, _ uint) error { return nil }
+func (m *mockSavedShowSvc) UnsaveShow(_, _ uint) error { return nil }
+func (m *mockSavedShowSvc) GetUserSavedShows(_ uint, _, _ int) ([]*SavedShowResponse, int64, error) {
+	return m.shows, m.total, m.err
+}
+func (m *mockSavedShowSvc) IsShowSaved(_, _ uint) (bool, error) { return false, nil }
+func (m *mockSavedShowSvc) GetSavedShowIDs(_ uint, _ []uint) (map[uint]bool, error) {
+	return nil, nil
+}
+
+func ptrString(s string) *string { return &s }
+
+// =============================================================================
+// INTEGRATION TESTS (With Real Database)
+// =============================================================================
+
+type CalendarIntegrationTestSuite struct {
+	suite.Suite
+	container testcontainers.Container
+	db        *gorm.DB
+	svc       *CalendarService
+	ctx       context.Context
+}
+
+func (suite *CalendarIntegrationTestSuite) SetupSuite() {
+	suite.ctx = context.Background()
+
+	container, err := testcontainers.GenericContainer(suite.ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "postgres:18",
+			ExposedPorts: []string{"5432/tcp"},
+			Env: map[string]string{
+				"POSTGRES_DB":       "test_db",
+				"POSTGRES_USER":     "test_user",
+				"POSTGRES_PASSWORD": "test_password",
+			},
+			WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(120 * time.Second),
+		},
+		Started: true,
+	})
+	if err != nil {
+		suite.T().Fatalf("failed to start postgres container: %v", err)
+	}
+	suite.container = container
+
+	host, err := container.Host(suite.ctx)
+	if err != nil {
+		suite.T().Fatalf("failed to get host: %v", err)
+	}
+	port, err := container.MappedPort(suite.ctx, "5432")
+	if err != nil {
+		suite.T().Fatalf("failed to get port: %v", err)
+	}
+
+	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
+		host, port.Port())
+
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		suite.T().Fatalf("failed to connect to test database: %v", err)
+	}
+	suite.db = db
+
+	sqlDB, err := db.DB()
+	if err != nil {
+		suite.T().Fatalf("failed to get sql.DB: %v", err)
+	}
+
+	// Run required migrations
+	migrations := []string{
+		"000001_create_initial_schema.up.sql",
+		"000012_add_user_deletion_fields.up.sql",
+		"000014_add_account_lockout.up.sql",
+		"000031_add_user_terms_acceptance.up.sql",
+		"000032_add_favorite_cities.up.sql",
+		"000033_add_calendar_tokens.up.sql",
+	}
+	for _, m := range migrations {
+		migrationSQL, err := os.ReadFile(filepath.Join("..", "..", "db", "migrations", m))
+		if err != nil {
+			suite.T().Fatalf("failed to read migration file %s: %v", m, err)
+		}
+		_, err = sqlDB.Exec(string(migrationSQL))
+		if err != nil {
+			suite.T().Fatalf("failed to run migration %s: %v", m, err)
+		}
+	}
+
+	mockSavedShows := &mockSavedShowSvc{shows: []*SavedShowResponse{}, total: 0}
+	suite.svc = &CalendarService{db: db, savedShowSvc: mockSavedShows}
+}
+
+func (suite *CalendarIntegrationTestSuite) TearDownSuite() {
+	if suite.container != nil {
+		if err := suite.container.Terminate(suite.ctx); err != nil {
+			suite.T().Logf("failed to terminate container: %v", err)
+		}
+	}
+}
+
+func (suite *CalendarIntegrationTestSuite) TearDownTest() {
+	sqlDB, err := suite.db.DB()
+	suite.Require().NoError(err)
+	_, _ = sqlDB.Exec("DELETE FROM calendar_tokens")
+	_, _ = sqlDB.Exec("DELETE FROM users")
+}
+
+func TestCalendarIntegrationTestSuite(t *testing.T) {
+	suite.Run(t, new(CalendarIntegrationTestSuite))
+}
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+func (suite *CalendarIntegrationTestSuite) createTestUser(active bool) *models.User {
+	user := &models.User{
+		Email:         stringPtr(fmt.Sprintf("cal-user-%d@test.com", time.Now().UnixNano())),
+		FirstName:     stringPtr("Calendar"),
+		LastName:      stringPtr("User"),
+		IsActive:      active,
+		EmailVerified: true,
+	}
+	err := suite.db.Create(user).Error
+	suite.Require().NoError(err)
+	return user
+}
+
+// =============================================================================
+// CreateToken tests
+// =============================================================================
+
+func (suite *CalendarIntegrationTestSuite) TestCreateToken_Success() {
+	user := suite.createTestUser(true)
+	resp, err := suite.svc.CreateToken(user.ID, "http://localhost:8080")
+	suite.Require().NoError(err)
+	suite.Require().NotNil(resp)
+
+	suite.True(strings.HasPrefix(resp.Token, CalendarTokenPrefix))
+	suite.Contains(resp.FeedURL, "http://localhost:8080/calendar/phcal_")
+	suite.NotZero(resp.CreatedAt)
+}
+
+func (suite *CalendarIntegrationTestSuite) TestCreateToken_ReplacesExisting() {
+	user := suite.createTestUser(true)
+
+	resp1, err := suite.svc.CreateToken(user.ID, "http://localhost:8080")
+	suite.Require().NoError(err)
+
+	resp2, err := suite.svc.CreateToken(user.ID, "http://localhost:8080")
+	suite.Require().NoError(err)
+
+	// New token should be different
+	suite.NotEqual(resp1.Token, resp2.Token)
+
+	// Old token should no longer validate
+	_, err = suite.svc.ValidateCalendarToken(resp1.Token)
+	suite.Error(err)
+	suite.Contains(err.Error(), "invalid calendar token")
+
+	// New token should validate
+	validatedUser, err := suite.svc.ValidateCalendarToken(resp2.Token)
+	suite.Require().NoError(err)
+	suite.Equal(user.ID, validatedUser.ID)
+}
+
+// =============================================================================
+// GetTokenStatus tests
+// =============================================================================
+
+func (suite *CalendarIntegrationTestSuite) TestGetTokenStatus_NoToken() {
+	user := suite.createTestUser(true)
+	status, err := suite.svc.GetTokenStatus(user.ID)
+	suite.Require().NoError(err)
+	suite.False(status.HasToken)
+	suite.Nil(status.CreatedAt)
+}
+
+func (suite *CalendarIntegrationTestSuite) TestGetTokenStatus_HasToken() {
+	user := suite.createTestUser(true)
+	_, err := suite.svc.CreateToken(user.ID, "http://localhost:8080")
+	suite.Require().NoError(err)
+
+	status, err := suite.svc.GetTokenStatus(user.ID)
+	suite.Require().NoError(err)
+	suite.True(status.HasToken)
+	suite.NotNil(status.CreatedAt)
+}
+
+// =============================================================================
+// DeleteToken tests
+// =============================================================================
+
+func (suite *CalendarIntegrationTestSuite) TestDeleteToken_Success() {
+	user := suite.createTestUser(true)
+	resp, err := suite.svc.CreateToken(user.ID, "http://localhost:8080")
+	suite.Require().NoError(err)
+
+	err = suite.svc.DeleteToken(user.ID)
+	suite.NoError(err)
+
+	// Token should no longer validate
+	_, err = suite.svc.ValidateCalendarToken(resp.Token)
+	suite.Error(err)
+
+	// Status should show no token
+	status, err := suite.svc.GetTokenStatus(user.ID)
+	suite.Require().NoError(err)
+	suite.False(status.HasToken)
+}
+
+func (suite *CalendarIntegrationTestSuite) TestDeleteToken_NotFound() {
+	user := suite.createTestUser(true)
+	err := suite.svc.DeleteToken(user.ID)
+	suite.Error(err)
+	suite.Contains(err.Error(), "no calendar token found")
+}
+
+// =============================================================================
+// ValidateCalendarToken tests
+// =============================================================================
+
+func (suite *CalendarIntegrationTestSuite) TestValidateCalendarToken_Success() {
+	user := suite.createTestUser(true)
+	resp, err := suite.svc.CreateToken(user.ID, "http://localhost:8080")
+	suite.Require().NoError(err)
+
+	validatedUser, err := suite.svc.ValidateCalendarToken(resp.Token)
+	suite.Require().NoError(err)
+	suite.Equal(user.ID, validatedUser.ID)
+}
+
+func (suite *CalendarIntegrationTestSuite) TestValidateCalendarToken_Invalid() {
+	_, err := suite.svc.ValidateCalendarToken("phcal_nonexistent_token")
+	suite.Error(err)
+	suite.Contains(err.Error(), "invalid calendar token")
+}
+
+func (suite *CalendarIntegrationTestSuite) TestValidateCalendarToken_InactiveUser() {
+	user := suite.createTestUser(true) // create as active first
+	resp, err := suite.svc.CreateToken(user.ID, "http://localhost:8080")
+	suite.Require().NoError(err)
+
+	// Deactivate the user
+	suite.db.Model(&models.User{}).Where("id = ?", user.ID).Update("is_active", false)
+
+	_, err = suite.svc.ValidateCalendarToken(resp.Token)
+	suite.Error(err)
+	suite.Contains(err.Error(), "user account is not active")
+}

--- a/backend/internal/services/container.go
+++ b/backend/internal/services/container.go
@@ -17,6 +17,7 @@ type ServiceContainer struct {
 	Artist        *ArtistService
 	ArtistReport  *ArtistReportService
 	AuditLog      *AuditLogService
+	Calendar      *CalendarService
 	FavoriteVenue *FavoriteVenueService
 	SavedShow     *SavedShowService
 	Show          *ShowService
@@ -52,6 +53,8 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 		log.Printf("Warning: WebAuthn service init failed (passkeys disabled): %v", err)
 	}
 
+	savedShow := NewSavedShowService(database)
+
 	return &ServiceContainer{
 		// DB-only leaf services
 		AdminStats:    NewAdminStatsService(database),
@@ -59,8 +62,9 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 		Artist:        NewArtistService(database),
 		ArtistReport:  NewArtistReportService(database),
 		AuditLog:      NewAuditLogService(database),
+		Calendar:      NewCalendarService(database, savedShow),
 		FavoriteVenue: NewFavoriteVenueService(database),
-		SavedShow:     NewSavedShowService(database),
+		SavedShow:     savedShow,
 		Show:          NewShowService(database),
 		ShowReport:    NewShowReportService(database),
 		User:          NewUserService(database),

--- a/backend/internal/services/interfaces.go
+++ b/backend/internal/services/interfaces.go
@@ -290,6 +290,15 @@ type AdminStatsServiceInterface interface {
 	GetDashboardStats() (*AdminDashboardStats, error)
 }
 
+// CalendarServiceInterface defines the contract for calendar feed operations.
+type CalendarServiceInterface interface {
+	CreateToken(userID uint, apiBaseURL string) (*CalendarTokenCreateResponse, error)
+	GetTokenStatus(userID uint) (*CalendarTokenStatusResponse, error)
+	DeleteToken(userID uint) error
+	ValidateCalendarToken(plainToken string) (*models.User, error)
+	GenerateICSFeed(userID uint, frontendURL string) ([]byte, error)
+}
+
 // Compile-time interface satisfaction checks.
 var (
 	_ ShowServiceInterface          = (*ShowService)(nil)
@@ -314,4 +323,5 @@ var (
 	_ APITokenServiceInterface      = (*APITokenService)(nil)
 	_ DataSyncServiceInterface      = (*DataSyncService)(nil)
 	_ AdminStatsServiceInterface    = (*AdminStatsService)(nil)
+	_ CalendarServiceInterface      = (*CalendarService)(nil)
 )

--- a/frontend/app/collection/page.tsx
+++ b/frontend/app/collection/page.tsx
@@ -38,6 +38,7 @@ import {
   PublishShowDialog,
 } from '@/components/shows'
 import { VenueDeniedDialog, FavoriteVenuesTab } from '@/components/venues'
+import { CalendarFeedSection } from '@/components/collection'
 import {
   useSetShowSoldOut,
   useSetShowCancelled,
@@ -659,6 +660,7 @@ function CollectionPageContent() {
         </TabsList>
 
         <TabsContent value="saved">
+          <CalendarFeedSection />
           <SavedShowsList
             currentUserId={currentUserId}
             isAdmin={user?.is_admin}

--- a/frontend/components/collection/CalendarFeedSection.tsx
+++ b/frontend/components/collection/CalendarFeedSection.tsx
@@ -1,0 +1,245 @@
+'use client'
+
+import { useState } from 'react'
+import {
+  CalendarDays,
+  Copy,
+  Check,
+  RefreshCw,
+  Trash2,
+  Loader2,
+  ExternalLink,
+} from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  useCalendarTokenStatus,
+  useCreateCalendarToken,
+  useDeleteCalendarToken,
+} from '@/lib/hooks/useCalendarFeed'
+
+export function CalendarFeedSection() {
+  const { data: tokenStatus, isLoading } = useCalendarTokenStatus()
+  const createToken = useCreateCalendarToken()
+  const deleteToken = useDeleteCalendarToken()
+  const [createdToken, setCreatedToken] = useState<{
+    token: string
+    feed_url: string
+  } | null>(null)
+  const [copied, setCopied] = useState(false)
+
+  const handleCreate = async () => {
+    try {
+      const result = await createToken.mutateAsync()
+      setCreatedToken({ token: result.token, feed_url: result.feed_url })
+    } catch {
+      // Error handled by mutation state
+    }
+  }
+
+  const handleRegenerate = async () => {
+    try {
+      const result = await createToken.mutateAsync()
+      setCreatedToken({ token: result.token, feed_url: result.feed_url })
+    } catch {
+      // Error handled by mutation state
+    }
+  }
+
+  const handleDelete = async () => {
+    try {
+      await deleteToken.mutateAsync()
+      setCreatedToken(null)
+    } catch {
+      // Error handled by mutation state
+    }
+  }
+
+  const handleCopy = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Fallback: select the input text
+    }
+  }
+
+  if (isLoading) {
+    return null
+  }
+
+  // Just created a token — show the feed URL
+  if (createdToken) {
+    const webcalUrl = createdToken.feed_url.replace(/^https?:\/\//, 'webcal://')
+    const googleCalUrl = `https://calendar.google.com/calendar/r?cid=${encodeURIComponent(webcalUrl)}`
+
+    return (
+      <div className="mb-6 rounded-lg border border-border bg-card p-4">
+        <div className="flex items-center gap-2 mb-3">
+          <CalendarDays className="h-5 w-5 text-primary" />
+          <h3 className="text-sm font-semibold">Calendar Feed Active</h3>
+        </div>
+        <p className="text-xs text-muted-foreground mb-3">
+          Copy this URL and add it to your calendar app. Your saved shows will
+          automatically stay in sync.
+        </p>
+
+        {/* Feed URL with copy button */}
+        <div className="flex gap-2 mb-3">
+          <Input
+            readOnly
+            value={createdToken.feed_url}
+            className="font-mono text-xs"
+            onFocus={(e) => e.target.select()}
+          />
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => handleCopy(createdToken.feed_url)}
+            className="shrink-0"
+          >
+            {copied ? (
+              <Check className="h-4 w-4" />
+            ) : (
+              <Copy className="h-4 w-4" />
+            )}
+          </Button>
+        </div>
+
+        {/* Quick-add links */}
+        <div className="flex flex-wrap gap-2 mb-3">
+          <a
+            href={googleCalUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 text-xs text-primary hover:text-primary/80 underline underline-offset-2"
+          >
+            Google Calendar
+            <ExternalLink className="h-3 w-3" />
+          </a>
+          <a
+            href={webcalUrl}
+            className="inline-flex items-center gap-1 text-xs text-primary hover:text-primary/80 underline underline-offset-2"
+          >
+            Apple Calendar
+            <ExternalLink className="h-3 w-3" />
+          </a>
+        </div>
+
+        {/* Management actions */}
+        <div className="flex gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleRegenerate}
+            disabled={createToken.isPending}
+            className="text-xs"
+          >
+            {createToken.isPending ? (
+              <Loader2 className="h-3 w-3 mr-1 animate-spin" />
+            ) : (
+              <RefreshCw className="h-3 w-3 mr-1" />
+            )}
+            Regenerate
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleDelete}
+            disabled={deleteToken.isPending}
+            className="text-xs text-destructive hover:text-destructive"
+          >
+            {deleteToken.isPending ? (
+              <Loader2 className="h-3 w-3 mr-1 animate-spin" />
+            ) : (
+              <Trash2 className="h-3 w-3 mr-1" />
+            )}
+            Disable
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  // Token exists (from a previous session) — show status
+  if (tokenStatus?.has_token) {
+    return (
+      <div className="mb-6 rounded-lg border border-border bg-card p-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <CalendarDays className="h-5 w-5 text-primary" />
+            <div>
+              <h3 className="text-sm font-semibold">Calendar Feed Active</h3>
+              <p className="text-xs text-muted-foreground">
+                Your saved shows are syncing to your calendar app.
+              </p>
+            </div>
+          </div>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleRegenerate}
+              disabled={createToken.isPending}
+              className="text-xs"
+            >
+              {createToken.isPending ? (
+                <Loader2 className="h-3 w-3 mr-1 animate-spin" />
+              ) : (
+                <RefreshCw className="h-3 w-3 mr-1" />
+              )}
+              Regenerate
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleDelete}
+              disabled={deleteToken.isPending}
+              className="text-xs text-destructive hover:text-destructive"
+            >
+              {deleteToken.isPending ? (
+                <Loader2 className="h-3 w-3 mr-1 animate-spin" />
+              ) : (
+                <Trash2 className="h-3 w-3 mr-1" />
+              )}
+              Disable
+            </Button>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  // No token — show setup prompt
+  return (
+    <div className="mb-6 rounded-lg border border-dashed border-border bg-card/50 p-4">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <CalendarDays className="h-5 w-5 text-muted-foreground" />
+          <div>
+            <h3 className="text-sm font-semibold">Subscribe to Calendar</h3>
+            <p className="text-xs text-muted-foreground">
+              Sync your saved shows to Google Calendar, Apple Calendar, or
+              Outlook.
+            </p>
+          </div>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleCreate}
+          disabled={createToken.isPending}
+          className="text-xs"
+        >
+          {createToken.isPending ? (
+            <Loader2 className="h-3 w-3 mr-1 animate-spin" />
+          ) : (
+            <CalendarDays className="h-3 w-3 mr-1" />
+          )}
+          Enable
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/components/collection/index.ts
+++ b/frontend/components/collection/index.ts
@@ -1,0 +1,1 @@
+export { CalendarFeedSection } from './CalendarFeedSection'

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -131,6 +131,11 @@ export const API_ENDPOINTS = {
       `${API_BASE_URL}/venues/${venueIdOrSlug}/my-pending-edit`,
   },
 
+  // Calendar feed endpoints
+  CALENDAR: {
+    TOKEN: `${API_BASE_URL}/calendar/token`,
+  },
+
   // Saved shows (user's "My List") endpoints
   SAVED_SHOWS: {
     LIST: `${API_BASE_URL}/saved-shows`,

--- a/frontend/lib/hooks/useCalendarFeed.ts
+++ b/frontend/lib/hooks/useCalendarFeed.ts
@@ -1,0 +1,67 @@
+'use client'
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { apiRequest, API_ENDPOINTS } from '../api'
+import { queryKeys, createInvalidateQueries } from '../queryClient'
+import type {
+  CalendarTokenStatusResponse,
+  CalendarTokenCreateResponse,
+  CalendarTokenDeleteResponse,
+} from '../types/show'
+
+/**
+ * Hook to check if the user has a calendar feed token
+ */
+export const useCalendarTokenStatus = (enabled: boolean = true) => {
+  return useQuery({
+    queryKey: queryKeys.calendar.tokenStatus,
+    queryFn: async (): Promise<CalendarTokenStatusResponse> => {
+      return apiRequest<CalendarTokenStatusResponse>(
+        API_ENDPOINTS.CALENDAR.TOKEN,
+        { method: 'GET' }
+      )
+    },
+    enabled,
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  })
+}
+
+/**
+ * Hook to create (or regenerate) a calendar feed token
+ */
+export const useCreateCalendarToken = () => {
+  const queryClient = useQueryClient()
+  const invalidateQueries = createInvalidateQueries(queryClient)
+
+  return useMutation({
+    mutationFn: async (): Promise<CalendarTokenCreateResponse> => {
+      return apiRequest<CalendarTokenCreateResponse>(
+        API_ENDPOINTS.CALENDAR.TOKEN,
+        { method: 'POST' }
+      )
+    },
+    onSuccess: () => {
+      invalidateQueries.calendar()
+    },
+  })
+}
+
+/**
+ * Hook to delete (disable) a calendar feed token
+ */
+export const useDeleteCalendarToken = () => {
+  const queryClient = useQueryClient()
+  const invalidateQueries = createInvalidateQueries(queryClient)
+
+  return useMutation({
+    mutationFn: async (): Promise<CalendarTokenDeleteResponse> => {
+      return apiRequest<CalendarTokenDeleteResponse>(
+        API_ENDPOINTS.CALENDAR.TOKEN,
+        { method: 'DELETE' }
+      )
+    },
+    onSuccess: () => {
+      invalidateQueries.calendar()
+    },
+  })
+}

--- a/frontend/lib/queryClient.ts
+++ b/frontend/lib/queryClient.ts
@@ -166,6 +166,12 @@ export const queryKeys = {
     shows: (artistIdOrSlug: string | number) => ['artists', 'shows', String(artistIdOrSlug)] as const,
   },
 
+  // Calendar feed queries
+  calendar: {
+    all: ['calendar'] as const,
+    tokenStatus: ['calendar', 'tokenStatus'] as const,
+  },
+
   // Saved shows queries (user's "My List")
   savedShows: {
     all: ['savedShows'] as const,
@@ -233,6 +239,10 @@ export const createInvalidateQueries = (queryClient: QueryClient) => ({
 
   // Invalidate all venue-related queries
   venues: () => queryClient.invalidateQueries({ queryKey: ['venues'] }),
+
+  // Invalidate calendar queries
+  calendar: () =>
+    queryClient.invalidateQueries({ queryKey: ['calendar'] }),
 
   // Invalidate saved shows queries
   savedShows: () =>

--- a/frontend/lib/types/show.ts
+++ b/frontend/lib/types/show.ts
@@ -211,3 +211,20 @@ export interface AdminReportActionRequest {
 export interface ResolveReportRequest extends AdminReportActionRequest {
   set_show_flag?: boolean
 }
+
+// Calendar feed types
+export interface CalendarTokenStatusResponse {
+  has_token: boolean
+  created_at?: string // ISO date string
+}
+
+export interface CalendarTokenCreateResponse {
+  token: string
+  feed_url: string
+  created_at: string // ISO date string
+}
+
+export interface CalendarTokenDeleteResponse {
+  success: boolean
+  message: string
+}


### PR DESCRIPTION
## Summary

- Users can subscribe to their saved shows via an ICS calendar feed URL compatible with Google Calendar, Apple Calendar, and Outlook
- Token-based authentication (`phcal_` prefix) — calendar apps can't do interactive auth, so users generate a long-lived token and get a feed URL
- Backend generates a fresh `.ics` file on each request, filtering to approved/non-cancelled shows from the past 30 days onward
- Three-state UI on the collection page: setup prompt, URL display with copy + quick-add links, and active status with regenerate/disable

## Backend

- **Migration 000033**: `calendar_tokens` table — one token per user (unique on `user_id`), no expiry
- **CalendarService**: Token CRUD (create replaces existing in a transaction), validation, ICS generation via `golang-ical`
- **Calendar handler**: Chi `http.HandlerFunc` for public feed (`GET /calendar/{token}`), Huma handlers for protected token CRUD (`POST/GET/DELETE /calendar/token`)
- **Routes**: Public feed route on Chi router, token management on Huma protected group

## Frontend

- **useCalendarFeed hooks**: `useCalendarTokenStatus`, `useCreateCalendarToken`, `useDeleteCalendarToken`
- **CalendarFeedSection component**: Renders above saved shows list with Enable/Regenerate/Disable actions and Google Calendar + Apple Calendar quick-add links
- **Types, API endpoints, query keys**: Added to existing patterns

## Test plan

- [ ] Create token via API, fetch feed URL in browser — valid `.ics` file downloads
- [ ] Subscribe in Google Calendar or Apple Calendar — events appear
- [ ] Regenerate token — old URL stops working, new URL works
- [ ] Delete token — feed URL returns 401
- [ ] Frontend: Enable → shows URL with copy button and calendar links
- [ ] Frontend: Regenerate → new URL displayed
- [ ] Frontend: Disable → returns to setup prompt
- [ ] Existing test suites pass: `go test ./...` and `bun run test:run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)