### PR TITLE
feat: redesign artist cards (PSY-20)

### DIFF
--- a/frontend/components/artists/ArtistCard.test.tsx
+++ b/frontend/components/artists/ArtistCard.test.tsx
@@ -38,16 +38,45 @@ describe('ArtistCard', () => {
     expect(link).toHaveAttribute('href', '/artists/test-artist')
   })
 
+  it('renders artist name as a heading', () => {
+    renderWithProviders(<ArtistCard artist={makeArtist()} />)
+
+    const heading = screen.getByRole('heading', { level: 3, name: 'Test Artist' })
+    expect(heading).toBeInTheDocument()
+  })
+
   it('renders upcoming show count', () => {
     renderWithProviders(<ArtistCard artist={makeArtist({ upcoming_show_count: 5 })} />)
 
     expect(screen.getByText('5 upcoming')).toBeInTheDocument()
   })
 
+  it('renders zero upcoming shows', () => {
+    renderWithProviders(<ArtistCard artist={makeArtist({ upcoming_show_count: 0 })} />)
+
+    expect(screen.getByText('0 upcoming')).toBeInTheDocument()
+  })
+
   it('renders location with city and state', () => {
     renderWithProviders(<ArtistCard artist={makeArtist()} />)
 
     expect(screen.getByText('Phoenix, AZ')).toBeInTheDocument()
+  })
+
+  it('renders location with only city', () => {
+    renderWithProviders(
+      <ArtistCard artist={makeArtist({ city: 'Chicago', state: null })} />
+    )
+
+    expect(screen.getByText('Chicago')).toBeInTheDocument()
+  })
+
+  it('renders location with only state', () => {
+    renderWithProviders(
+      <ArtistCard artist={makeArtist({ city: null, state: 'IL' })} />
+    )
+
+    expect(screen.getByText('IL')).toBeInTheDocument()
   })
 
   it('does not render location when city and state are null', () => {
@@ -65,5 +94,11 @@ describe('ArtistCard', () => {
 
     const link = screen.getByRole('link', { name: 'The National' })
     expect(link).toHaveAttribute('href', '/artists/the-national')
+  })
+
+  it('renders as an article element', () => {
+    renderWithProviders(<ArtistCard artist={makeArtist()} />)
+
+    expect(screen.getByRole('article')).toBeInTheDocument()
   })
 })

--- a/frontend/components/artists/ArtistCard.tsx
+++ b/frontend/components/artists/ArtistCard.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { MapPin } from 'lucide-react'
+import { MapPin, Music } from 'lucide-react'
 import type { ArtistListItem } from '@/lib/types/artist'
 import { getArtistLocation } from '@/lib/types/artist'
 
@@ -14,23 +14,31 @@ export function ArtistCard({ artist }: ArtistCardProps) {
   const location = hasLocation ? getArtistLocation(artist) : null
 
   return (
-    <article className="py-2 px-3 rounded-md hover:bg-muted/50 transition-colors">
+    <article className="rounded-lg border border-border/50 bg-card p-4 transition-shadow hover:shadow-sm">
       <Link
         href={`/artists/${artist.slug}`}
-        className="block hover:text-primary transition-colors"
+        className="block group"
       >
-        <span className="font-medium">{artist.name}</span>
+        <h3 className="font-semibold text-base text-foreground group-hover:text-primary transition-colors truncate">
+          {artist.name}
+        </h3>
       </Link>
-      <div className="flex items-center gap-2 text-xs text-muted-foreground mt-0.5">
-        <span>{artist.upcoming_show_count} upcoming</span>
+
+      {/* Space for future tag pills - renders nothing until tags exist */}
+
+      <div className="mt-2 space-y-1">
+        <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
+          <Music className="h-3.5 w-3.5 shrink-0" />
+          <span>
+            {artist.upcoming_show_count} upcoming
+          </span>
+        </div>
+
         {hasLocation && (
-          <>
-            <span className="text-border">·</span>
-            <span className="flex items-center gap-0.5">
-              <MapPin className="h-3 w-3 shrink-0" />
-              {location}
-            </span>
-          </>
+          <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
+            <MapPin className="h-3.5 w-3.5 shrink-0" />
+            <span>{location}</span>
+          </div>
         )}
       </div>
     </article>

--- a/frontend/components/artists/ArtistList.tsx
+++ b/frontend/components/artists/ArtistList.tsx
@@ -117,7 +117,7 @@ export function ArtistList() {
             )}
           </div>
         ) : (
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-2">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
             {artists.map(artist => (
               <ArtistCard key={artist.id} artist={artist} />
             ))}

--- a/frontend/components/artists/ArtistListSkeleton.tsx
+++ b/frontend/components/artists/ArtistListSkeleton.tsx
@@ -15,12 +15,15 @@ export function ArtistListSkeleton() {
         </div>
       </div>
 
-      {/* Grid skeleton */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-2">
+      {/* Grid skeleton matching new card layout */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
         {Array.from({ length: 12 }).map((_, i) => (
-          <div key={i} className="py-2 px-3">
-            <div className="h-5 bg-muted rounded w-36 mb-1" />
-            <div className="h-3 bg-muted rounded w-24" />
+          <div key={i} className="rounded-lg border border-border/50 p-4">
+            <div className="h-5 bg-muted rounded w-36 mb-3" />
+            <div className="space-y-2">
+              <div className="h-4 bg-muted rounded w-24" />
+              <div className="h-4 bg-muted rounded w-20" />
+            </div>
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Summary

- Redesign `ArtistCard` from minimal text row to bordered card with hover shadow
- Artist name rendered as `<h3>` with hover color transition
- Metadata lines with icons: upcoming show count (Music icon), location (MapPin icon)
- Layout structured for future tag pills and label affiliation (no fake data)
- Updated `ArtistList` grid gap and `ArtistListSkeleton` to match new card dimensions

## Files changed

- `ArtistCard.tsx` — new bordered card layout with icon-aligned metadata
- `ArtistList.tsx` — grid gap adjustment (`gap-x-2` → `gap-3`)
- `ArtistListSkeleton.tsx` — skeleton matches new card shape
- `ArtistCard.test.tsx` — 5 existing tests pass + 4 new tests (heading level, zero shows, partial location)

## Test plan

- [x] `bun run build` passes
- [x] All 874 tests pass (869 existing + 5 new)
- [ ] Visual check: card borders and hover shadow in light and dark mode
- [ ] Visual check: responsive stacking on mobile
- [ ] Visual check: location displays correctly with various city/state combinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)