### PR TITLE
feat: show reminder emails with settings + unsubscribe (PSY)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,6 @@ human-docs/
 cli/ph-admin
 scripts/test-runner/test-runner
 .test-history.json
+
+# Claude Code worktrees
+.claude/worktrees/

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -156,6 +156,10 @@ func main() {
 	cleanupCtx, cleanupCancel := context.WithCancel(context.Background())
 	sc.Cleanup.Start(cleanupCtx)
 
+	// Start show reminder service (background job for 24h-before email reminders)
+	reminderCtx, reminderCancel := context.WithCancel(context.Background())
+	sc.Reminder.Start(reminderCtx)
+
 	// Create HTTP server
 	srv := &http.Server{
 		Addr:    cfg.Server.Addr,
@@ -183,6 +187,10 @@ func main() {
 	// Stop cleanup service
 	cleanupCancel()
 	sc.Cleanup.Stop()
+
+	// Stop reminder service
+	reminderCancel()
+	sc.Reminder.Stop()
 
 	// Graceful shutdown
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/backend/db/migrations/000034_add_show_reminders.down.sql
+++ b/backend/db/migrations/000034_add_show_reminders.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE user_preferences DROP COLUMN IF EXISTS show_reminders;
+ALTER TABLE user_saved_shows DROP COLUMN IF EXISTS reminder_sent_at;

--- a/backend/db/migrations/000034_add_show_reminders.up.sql
+++ b/backend/db/migrations/000034_add_show_reminders.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE user_preferences ADD COLUMN show_reminders BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE user_saved_shows ADD COLUMN reminder_sent_at TIMESTAMPTZ;

--- a/backend/internal/api/handlers/handler_integration_helpers_test.go
+++ b/backend/internal/api/handlers/handler_integration_helpers_test.go
@@ -114,6 +114,7 @@ func setupHandlerIntegrationDeps(t *testing.T) *handlerIntegrationDeps {
 		"000030_add_artist_reports.up.sql",
 		"000031_add_user_terms_acceptance.up.sql",
 		"000032_add_favorite_cities.up.sql",
+		"000034_add_show_reminders.up.sql",
 	}
 
 	migrationDir := filepath.Join("..", "..", "..", "db", "migrations")

--- a/backend/internal/api/handlers/handler_integration_helpers_test.go
+++ b/backend/internal/api/handlers/handler_integration_helpers_test.go
@@ -3,9 +3,7 @@ package handlers
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -17,6 +15,7 @@ import (
 	"psychic-homily-backend/internal/config"
 	"psychic-homily-backend/internal/models"
 	"psychic-homily-backend/internal/services"
+	"psychic-homily-backend/internal/testutil"
 )
 
 // handlerIntegrationDeps holds all services + DB for handler integration tests
@@ -87,59 +86,7 @@ func setupHandlerIntegrationDeps(t *testing.T) *handlerIntegrationDeps {
 		t.Fatalf("failed to get sql.DB: %v", err)
 	}
 
-	// Run migrations - path from handlers/ -> api/ -> internal/ -> backend/ -> db/migrations/
-	migrations := []string{
-		"000001_create_initial_schema.up.sql",
-		"000002_add_artist_search_indexes.up.sql",
-		"000003_add_venue_search_indexes.up.sql",
-		"000004_update_venue_constraints.up.sql",
-		"000005_add_show_status.up.sql",
-		"000006_add_user_saved_shows.up.sql",
-		"000007_add_private_show_status.up.sql",
-		"000008_add_pending_venue_edits.up.sql",
-		"000009_add_bandcamp_embed_url.up.sql",
-		"000010_add_scraper_source_fields.up.sql",
-		"000011_add_webauthn_tables.up.sql",
-		"000012_add_user_deletion_fields.up.sql",
-		"000013_add_slugs.up.sql",
-		"000014_add_account_lockout.up.sql",
-		"000015_add_user_favorite_venues.up.sql",
-		"000018_add_show_reports.up.sql",
-		"000020_add_show_status_flags.up.sql",
-		"000021_add_api_tokens.up.sql",
-		"000022_add_audit_logs.up.sql",
-		"000023_rename_scraper_to_discovery.up.sql",
-		"000026_add_duplicate_of_show_id.up.sql",
-		"000028_change_event_date_to_timestamptz.up.sql",
-		"000030_add_artist_reports.up.sql",
-		"000031_add_user_terms_acceptance.up.sql",
-		"000032_add_favorite_cities.up.sql",
-		"000034_add_show_reminders.up.sql",
-	}
-
-	migrationDir := filepath.Join("..", "..", "..", "db", "migrations")
-
-	for _, m := range migrations {
-		migrationSQL, err := os.ReadFile(filepath.Join(migrationDir, m))
-		if err != nil {
-			t.Fatalf("failed to read migration file %s: %v", m, err)
-		}
-		_, err = sqlDB.Exec(string(migrationSQL))
-		if err != nil {
-			t.Fatalf("failed to run migration %s: %v", m, err)
-		}
-	}
-
-	// Run migration 000027 with CONCURRENTLY stripped
-	migration27, err := os.ReadFile(filepath.Join(migrationDir, "000027_add_index_duplicate_of_show_id.up.sql"))
-	if err != nil {
-		t.Fatalf("failed to read migration 000027: %v", err)
-	}
-	sql27 := strings.ReplaceAll(string(migration27), "CONCURRENTLY ", "")
-	_, err = sqlDB.Exec(sql27)
-	if err != nil {
-		t.Fatalf("failed to run migration 000027: %v", err)
-	}
+	testutil.RunAllMigrations(t, sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
 
 	// Construct services
 	emptyCfg := &config.Config{}

--- a/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
+++ b/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
@@ -538,6 +538,9 @@ func (m *mockUserService) GetFavoriteCities(userID uint) ([]models.FavoriteCity,
 func (m *mockUserService) SetFavoriteCities(userID uint, cities []models.FavoriteCity) error {
 	return nil
 }
+func (m *mockUserService) SetShowReminders(userID uint, enabled bool) error {
+	return nil
+}
 
 // ============================================================================
 // Mock: ShowServiceInterface
@@ -1302,6 +1305,9 @@ func (m *mockEmailService) SendAccountRecoveryEmail(toEmail, token string, daysR
 	if m.sendAccountRecoveryEmailFn != nil {
 		return m.sendAccountRecoveryEmailFn(toEmail, token, daysRemaining)
 	}
+	return nil
+}
+func (m *mockEmailService) SendShowReminderEmail(toEmail, showTitle, showURL, unsubscribeURL string, eventDate time.Time, venues []string) error {
 	return nil
 }
 

--- a/backend/internal/api/handlers/user_preferences.go
+++ b/backend/internal/api/handlers/user_preferences.go
@@ -15,12 +15,14 @@ import (
 // UserPreferencesHandler handles user preferences endpoints
 type UserPreferencesHandler struct {
 	userService services.UserServiceInterface
+	jwtSecret   string
 }
 
 // NewUserPreferencesHandler creates a new user preferences handler
-func NewUserPreferencesHandler(userService services.UserServiceInterface) *UserPreferencesHandler {
+func NewUserPreferencesHandler(userService services.UserServiceInterface, jwtSecret string) *UserPreferencesHandler {
 	return &UserPreferencesHandler{
 		userService: userService,
+		jwtSecret:   jwtSecret,
 	}
 }
 
@@ -79,6 +81,99 @@ func (h *UserPreferencesHandler) SetFavoriteCitiesHandler(ctx context.Context, r
 			Success: true,
 			Message: "Favorite cities updated",
 			Cities:  cities,
+		},
+	}, nil
+}
+
+// SetShowRemindersRequest represents the request to toggle show reminders
+type SetShowRemindersRequest struct {
+	Body struct {
+		Enabled bool `json:"enabled" doc:"Enable or disable show reminders"`
+	}
+}
+
+// SetShowRemindersResponse represents the response after toggling show reminders
+type SetShowRemindersResponse struct {
+	Body struct {
+		Success       bool `json:"success"`
+		ShowReminders bool `json:"show_reminders"`
+	}
+}
+
+// SetShowRemindersHandler handles PATCH /auth/preferences/show-reminders
+func (h *UserPreferencesHandler) SetShowRemindersHandler(ctx context.Context, req *SetShowRemindersRequest) (*SetShowRemindersResponse, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	if err := h.userService.SetShowReminders(user.ID, req.Body.Enabled); err != nil {
+		logger.FromContext(ctx).Error("set_show_reminders_failed",
+			"error", err.Error(),
+			"user_id", user.ID,
+		)
+		return nil, huma.Error422UnprocessableEntity(
+			fmt.Sprintf("Failed to update show reminders: %s", err.Error()),
+		)
+	}
+
+	logger.FromContext(ctx).Info("set_show_reminders_success",
+		"user_id", user.ID,
+		"enabled", req.Body.Enabled,
+	)
+
+	return &SetShowRemindersResponse{
+		Body: struct {
+			Success       bool `json:"success"`
+			ShowReminders bool `json:"show_reminders"`
+		}{
+			Success:       true,
+			ShowReminders: req.Body.Enabled,
+		},
+	}, nil
+}
+
+// UnsubscribeShowRemindersRequest represents the unsubscribe request (public, no auth)
+type UnsubscribeShowRemindersRequest struct {
+	Body struct {
+		UID uint   `json:"uid" doc:"User ID"`
+		Sig string `json:"sig" doc:"HMAC signature"`
+	}
+}
+
+// UnsubscribeShowRemindersResponse represents the unsubscribe response
+type UnsubscribeShowRemindersResponse struct {
+	Body struct {
+		Success bool   `json:"success"`
+		Message string `json:"message"`
+	}
+}
+
+// UnsubscribeShowRemindersHandler handles POST /auth/unsubscribe/show-reminders (public, no auth)
+func (h *UserPreferencesHandler) UnsubscribeShowRemindersHandler(ctx context.Context, req *UnsubscribeShowRemindersRequest) (*UnsubscribeShowRemindersResponse, error) {
+	if !services.VerifyUnsubscribeSignature(req.Body.UID, req.Body.Sig, h.jwtSecret) {
+		return nil, huma.Error403Forbidden("Invalid unsubscribe link")
+	}
+
+	if err := h.userService.SetShowReminders(req.Body.UID, false); err != nil {
+		logger.FromContext(ctx).Error("unsubscribe_show_reminders_failed",
+			"error", err.Error(),
+			"user_id", req.Body.UID,
+		)
+		return nil, huma.Error500InternalServerError("Failed to unsubscribe")
+	}
+
+	logger.FromContext(ctx).Info("unsubscribe_show_reminders_success",
+		"user_id", req.Body.UID,
+	)
+
+	return &UnsubscribeShowRemindersResponse{
+		Body: struct {
+			Success bool   `json:"success"`
+			Message string `json:"message"`
+		}{
+			Success: true,
+			Message: "Show reminders disabled",
 		},
 	}, nil
 }

--- a/backend/internal/api/middleware/jwt_integration_test.go
+++ b/backend/internal/api/middleware/jwt_integration_test.go
@@ -6,9 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -22,6 +20,7 @@ import (
 	"psychic-homily-backend/internal/config"
 	"psychic-homily-backend/internal/models"
 	"psychic-homily-backend/internal/services"
+	"psychic-homily-backend/internal/testutil"
 )
 
 // JWTMiddlewareIntegrationSuite tests JWT middleware with a real PostgreSQL database.
@@ -77,50 +76,7 @@ func (s *JWTMiddlewareIntegrationSuite) SetupSuite() {
 	sqlDB, err := db.DB()
 	s.Require().NoError(err, "failed to get sql.DB")
 
-	// Run migrations — same list as handler integration tests
-	migrations := []string{
-		"000001_create_initial_schema.up.sql",
-		"000002_add_artist_search_indexes.up.sql",
-		"000003_add_venue_search_indexes.up.sql",
-		"000004_update_venue_constraints.up.sql",
-		"000005_add_show_status.up.sql",
-		"000006_add_user_saved_shows.up.sql",
-		"000007_add_private_show_status.up.sql",
-		"000008_add_pending_venue_edits.up.sql",
-		"000009_add_bandcamp_embed_url.up.sql",
-		"000010_add_scraper_source_fields.up.sql",
-		"000011_add_webauthn_tables.up.sql",
-		"000012_add_user_deletion_fields.up.sql",
-		"000013_add_slugs.up.sql",
-		"000014_add_account_lockout.up.sql",
-		"000015_add_user_favorite_venues.up.sql",
-		"000018_add_show_reports.up.sql",
-		"000020_add_show_status_flags.up.sql",
-		"000021_add_api_tokens.up.sql",
-		"000022_add_audit_logs.up.sql",
-		"000023_rename_scraper_to_discovery.up.sql",
-		"000026_add_duplicate_of_show_id.up.sql",
-		"000028_change_event_date_to_timestamptz.up.sql",
-		"000029_fix_discovery_show_times.up.sql",
-		"000030_add_artist_reports.up.sql",
-		"000031_add_user_terms_acceptance.up.sql",
-	}
-
-	migrationDir := filepath.Join("..", "..", "..", "db", "migrations")
-
-	for _, m := range migrations {
-		migrationSQL, err := os.ReadFile(filepath.Join(migrationDir, m))
-		s.Require().NoError(err, "failed to read migration %s", m)
-		_, err = sqlDB.Exec(string(migrationSQL))
-		s.Require().NoError(err, "failed to run migration %s", m)
-	}
-
-	// Migration 27 uses CONCURRENTLY — strip it for test transactions
-	migration27, err := os.ReadFile(filepath.Join(migrationDir, "000027_add_index_duplicate_of_show_id.up.sql"))
-	s.Require().NoError(err, "failed to read migration 000027")
-	sql27 := strings.ReplaceAll(string(migration27), "CONCURRENTLY ", "")
-	_, err = sqlDB.Exec(sql27)
-	s.Require().NoError(err, "failed to run migration 000027")
+	testutil.RunAllMigrations(s.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
 
 	// Set up config and JWT service with real DB
 	s.cfg = &config.Config{

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -65,8 +65,12 @@ func SetupRoutes(router *chi.Mux, sc *services.ServiceContainer, cfg *config.Con
 	huma.Delete(protectedGroup, "/auth/oauth/accounts/{provider}", oauthAccountHandler.UnlinkOAuthAccountHandler)
 
 	// User preferences endpoints
-	userPrefsHandler := handlers.NewUserPreferencesHandler(sc.User)
+	userPrefsHandler := handlers.NewUserPreferencesHandler(sc.User, cfg.JWT.SecretKey)
 	huma.Put(protectedGroup, "/auth/preferences/favorite-cities", userPrefsHandler.SetFavoriteCitiesHandler)
+	huma.Patch(protectedGroup, "/auth/preferences/show-reminders", userPrefsHandler.SetShowRemindersHandler)
+
+	// Public unsubscribe endpoint (HMAC-signed, no auth required)
+	huma.Post(api, "/auth/unsubscribe/show-reminders", userPrefsHandler.UnsubscribeShowRemindersHandler)
 
 	// Public email verification confirm endpoint (user clicks link from email)
 	huma.Post(api, "/auth/verify-email/confirm", authHandler.ConfirmVerificationHandler)

--- a/backend/internal/models/saved_show.go
+++ b/backend/internal/models/saved_show.go
@@ -4,9 +4,10 @@ import "time"
 
 // UserSavedShow represents the junction table for users' saved shows
 type UserSavedShow struct {
-	UserID  uint      `gorm:"primaryKey;column:user_id"`
-	ShowID  uint      `gorm:"primaryKey;column:show_id"`
-	SavedAt time.Time `gorm:"not null;column:saved_at"`
+	UserID         uint       `gorm:"primaryKey;column:user_id"`
+	ShowID         uint       `gorm:"primaryKey;column:show_id"`
+	SavedAt        time.Time  `gorm:"not null;column:saved_at"`
+	ReminderSentAt *time.Time `gorm:"column:reminder_sent_at"`
 }
 
 // TableName specifies the table name for UserSavedShow

--- a/backend/internal/models/user.go
+++ b/backend/internal/models/user.go
@@ -78,6 +78,7 @@ type UserPreferences struct {
 	Theme             string    `json:"theme" gorm:"default:light"`
 	Timezone          string    `json:"timezone" gorm:"default:UTC"`
 	Language          string           `json:"language" gorm:"default:en"`
+	ShowReminders     bool             `json:"show_reminders" gorm:"default:false"`
 	FavoriteCities    *json.RawMessage `json:"favorite_cities" gorm:"type:jsonb;default:'[]'"`
 	CreatedAt         time.Time        `json:"created_at"`
 	UpdatedAt         time.Time        `json:"updated_at"`

--- a/backend/internal/services/admin_stats_test.go
+++ b/backend/internal/services/admin_stats_test.go
@@ -3,9 +3,7 @@ package services
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -17,6 +15,7 @@ import (
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/testutil"
 )
 
 // =============================================================================
@@ -99,47 +98,7 @@ func (suite *AdminStatsServiceIntegrationTestSuite) SetupSuite() {
 		suite.T().Fatalf("failed to get sql.DB: %v", err)
 	}
 
-	migrations := []string{
-		"000001_create_initial_schema.up.sql",
-		"000004_update_venue_constraints.up.sql",
-		"000005_add_show_status.up.sql",
-		"000007_add_private_show_status.up.sql",
-		"000008_add_pending_venue_edits.up.sql",
-		"000009_add_bandcamp_embed_url.up.sql",
-		"000010_add_scraper_source_fields.up.sql",
-		"000012_add_user_deletion_fields.up.sql",
-		"000013_add_slugs.up.sql",
-		"000014_add_account_lockout.up.sql",
-		"000018_add_show_reports.up.sql",
-		"000020_add_show_status_flags.up.sql",
-		"000023_rename_scraper_to_discovery.up.sql",
-		"000026_add_duplicate_of_show_id.up.sql",
-		"000028_change_event_date_to_timestamptz.up.sql",
-		"000030_add_artist_reports.up.sql",
-		"000031_add_user_terms_acceptance.up.sql",
-		"000032_add_favorite_cities.up.sql",
-	}
-	for _, m := range migrations {
-		migrationSQL, err := os.ReadFile(filepath.Join("..", "..", "db", "migrations", m))
-		if err != nil {
-			suite.T().Fatalf("failed to read migration file %s: %v", m, err)
-		}
-		_, err = sqlDB.Exec(string(migrationSQL))
-		if err != nil {
-			suite.T().Fatalf("failed to run migration %s: %v", m, err)
-		}
-	}
-
-	// Migration 000027 with CONCURRENTLY stripped
-	migration27, err := os.ReadFile(filepath.Join("..", "..", "db", "migrations", "000027_add_index_duplicate_of_show_id.up.sql"))
-	if err != nil {
-		suite.T().Fatalf("failed to read migration 000027: %v", err)
-	}
-	sql27 := strings.ReplaceAll(string(migration27), "CONCURRENTLY ", "")
-	_, err = sqlDB.Exec(sql27)
-	if err != nil {
-		suite.T().Fatalf("failed to run migration 000027: %v", err)
-	}
+	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "db", "migrations"))
 
 	suite.service = &AdminStatsService{db: db}
 }

--- a/backend/internal/services/api_token_test.go
+++ b/backend/internal/services/api_token_test.go
@@ -3,7 +3,6 @@ package services
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -17,6 +16,7 @@ import (
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/testutil"
 )
 
 // =============================================================================
@@ -159,25 +159,7 @@ func (suite *APITokenIntegrationTestSuite) SetupSuite() {
 		suite.T().Fatalf("failed to get sql.DB: %v", err)
 	}
 
-	// Migrations needed: 000001 (users), 000012, 000014, 000021 (api_tokens)
-	migrations := []string{
-		"000001_create_initial_schema.up.sql",
-		"000012_add_user_deletion_fields.up.sql",
-		"000014_add_account_lockout.up.sql",
-		"000021_add_api_tokens.up.sql",
-		"000031_add_user_terms_acceptance.up.sql",
-		"000032_add_favorite_cities.up.sql",
-	}
-	for _, m := range migrations {
-		migrationSQL, err := os.ReadFile(filepath.Join("..", "..", "db", "migrations", m))
-		if err != nil {
-			suite.T().Fatalf("failed to read migration file %s: %v", m, err)
-		}
-		_, err = sqlDB.Exec(string(migrationSQL))
-		if err != nil {
-			suite.T().Fatalf("failed to run migration %s: %v", m, err)
-		}
-	}
+	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "db", "migrations"))
 
 	suite.svc = &APITokenService{db: db}
 }

--- a/backend/internal/services/apple_auth_test.go
+++ b/backend/internal/services/apple_auth_test.go
@@ -9,7 +9,6 @@ import (
 	"math/big"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -25,6 +24,7 @@ import (
 
 	"psychic-homily-backend/internal/config"
 	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/testutil"
 )
 
 // =============================================================================
@@ -377,27 +377,7 @@ func (s *AppleAuthIntegrationTestSuite) SetupSuite() {
 	if err != nil {
 		s.T().Fatalf("failed to get sql.DB: %v", err)
 	}
-
-	migrations := []string{
-		"000001_create_initial_schema.up.sql",
-		"000005_add_show_status.up.sql",
-		"000006_add_user_saved_shows.up.sql",
-		"000012_add_user_deletion_fields.up.sql",
-		"000014_add_account_lockout.up.sql",
-		"000031_add_user_terms_acceptance.up.sql",
-		"000032_add_favorite_cities.up.sql",
-		"000034_add_show_reminders.up.sql",
-	}
-	for _, m := range migrations {
-		migrationSQL, err := os.ReadFile(filepath.Join("..", "..", "db", "migrations", m))
-		if err != nil {
-			s.T().Fatalf("failed to read migration file %s: %v", m, err)
-		}
-		_, err = sqlDB.Exec(string(migrationSQL))
-		if err != nil {
-			s.T().Fatalf("failed to run migration %s: %v", m, err)
-		}
-	}
+	testutil.RunAllMigrations(s.T(), sqlDB, filepath.Join("..", "..", "db", "migrations"))
 
 	s.cfg = &config.Config{
 		Apple: config.AppleConfig{BundleID: "com.test.app"},

--- a/backend/internal/services/apple_auth_test.go
+++ b/backend/internal/services/apple_auth_test.go
@@ -381,10 +381,12 @@ func (s *AppleAuthIntegrationTestSuite) SetupSuite() {
 	migrations := []string{
 		"000001_create_initial_schema.up.sql",
 		"000005_add_show_status.up.sql",
+		"000006_add_user_saved_shows.up.sql",
 		"000012_add_user_deletion_fields.up.sql",
 		"000014_add_account_lockout.up.sql",
 		"000031_add_user_terms_acceptance.up.sql",
 		"000032_add_favorite_cities.up.sql",
+		"000034_add_show_reminders.up.sql",
 	}
 	for _, m := range migrations {
 		migrationSQL, err := os.ReadFile(filepath.Join("..", "..", "db", "migrations", m))

--- a/backend/internal/services/artist_test.go
+++ b/backend/internal/services/artist_test.go
@@ -3,9 +3,7 @@ package services
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -18,6 +16,7 @@ import (
 
 	apperrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/testutil"
 )
 
 // =============================================================================
@@ -162,54 +161,11 @@ func (suite *ArtistServiceIntegrationTestSuite) SetupSuite() {
 	}
 	suite.db = db
 
-	// Run migrations
 	sqlDB, err := db.DB()
 	if err != nil {
 		suite.T().Fatalf("failed to get sql.DB: %v", err)
 	}
-
-	migrations := []string{
-		"000001_create_initial_schema.up.sql",
-		"000002_add_artist_search_indexes.up.sql",
-		"000003_add_venue_search_indexes.up.sql",
-		"000004_update_venue_constraints.up.sql",
-		"000005_add_show_status.up.sql",
-		"000007_add_private_show_status.up.sql",
-		"000008_add_pending_venue_edits.up.sql",
-		"000009_add_bandcamp_embed_url.up.sql",
-		"000010_add_scraper_source_fields.up.sql",
-		"000012_add_user_deletion_fields.up.sql",
-		"000013_add_slugs.up.sql",
-		"000014_add_account_lockout.up.sql",
-		"000020_add_show_status_flags.up.sql",
-		"000023_rename_scraper_to_discovery.up.sql",
-		"000026_add_duplicate_of_show_id.up.sql",
-		"000028_change_event_date_to_timestamptz.up.sql",
-		"000031_add_user_terms_acceptance.up.sql",
-		"000032_add_favorite_cities.up.sql",
-		// 000027 handled below (CONCURRENTLY not allowed in transaction)
-	}
-	for _, m := range migrations {
-		migrationSQL, err := os.ReadFile(filepath.Join("..", "..", "db", "migrations", m))
-		if err != nil {
-			suite.T().Fatalf("failed to read migration file %s: %v", m, err)
-		}
-		_, err = sqlDB.Exec(string(migrationSQL))
-		if err != nil {
-			suite.T().Fatalf("failed to run migration %s: %v", m, err)
-		}
-	}
-
-	// Run migration 000027 with CONCURRENTLY stripped (not valid in test context)
-	migration27, err := os.ReadFile(filepath.Join("..", "..", "db", "migrations", "000027_add_index_duplicate_of_show_id.up.sql"))
-	if err != nil {
-		suite.T().Fatalf("failed to read migration 000027: %v", err)
-	}
-	sql27 := strings.ReplaceAll(string(migration27), "CONCURRENTLY ", "")
-	_, err = sqlDB.Exec(sql27)
-	if err != nil {
-		suite.T().Fatalf("failed to run migration 000027: %v", err)
-	}
+	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "db", "migrations"))
 
 	suite.artistService = &ArtistService{db: db}
 }

--- a/backend/internal/services/audit_log_test.go
+++ b/backend/internal/services/audit_log_test.go
@@ -3,7 +3,6 @@ package services
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -16,6 +15,7 @@ import (
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/testutil"
 )
 
 // =============================================================================
@@ -103,25 +103,7 @@ func (suite *AuditLogServiceIntegrationTestSuite) SetupSuite() {
 		suite.T().Fatalf("failed to get sql.DB: %v", err)
 	}
 
-	// audit_logs needs: initial schema (users table for FK), and 000022 (audit_logs table)
-	migrations := []string{
-		"000001_create_initial_schema.up.sql",
-		"000012_add_user_deletion_fields.up.sql",
-		"000014_add_account_lockout.up.sql",
-		"000022_add_audit_logs.up.sql",
-		"000031_add_user_terms_acceptance.up.sql",
-		"000032_add_favorite_cities.up.sql",
-	}
-	for _, m := range migrations {
-		migrationSQL, err := os.ReadFile(filepath.Join("..", "..", "db", "migrations", m))
-		if err != nil {
-			suite.T().Fatalf("failed to read migration file %s: %v", m, err)
-		}
-		_, err = sqlDB.Exec(string(migrationSQL))
-		if err != nil {
-			suite.T().Fatalf("failed to run migration %s: %v", m, err)
-		}
-	}
+	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "db", "migrations"))
 
 	suite.auditLogService = &AuditLogService{db: db}
 }

--- a/backend/internal/services/calendar_test.go
+++ b/backend/internal/services/calendar_test.go
@@ -3,7 +3,6 @@ package services
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -17,6 +16,7 @@ import (
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/testutil"
 )
 
 // =============================================================================
@@ -327,25 +327,7 @@ func (suite *CalendarIntegrationTestSuite) SetupSuite() {
 		suite.T().Fatalf("failed to get sql.DB: %v", err)
 	}
 
-	// Run required migrations
-	migrations := []string{
-		"000001_create_initial_schema.up.sql",
-		"000012_add_user_deletion_fields.up.sql",
-		"000014_add_account_lockout.up.sql",
-		"000031_add_user_terms_acceptance.up.sql",
-		"000032_add_favorite_cities.up.sql",
-		"000033_add_calendar_tokens.up.sql",
-	}
-	for _, m := range migrations {
-		migrationSQL, err := os.ReadFile(filepath.Join("..", "..", "db", "migrations", m))
-		if err != nil {
-			suite.T().Fatalf("failed to read migration file %s: %v", m, err)
-		}
-		_, err = sqlDB.Exec(string(migrationSQL))
-		if err != nil {
-			suite.T().Fatalf("failed to run migration %s: %v", m, err)
-		}
-	}
+	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "db", "migrations"))
 
 	mockSavedShows := &mockSavedShowSvc{shows: []*SavedShowResponse{}, total: 0}
 	suite.svc = &CalendarService{db: db, savedShowSvc: mockSavedShows}

--- a/backend/internal/services/container.go
+++ b/backend/internal/services/container.go
@@ -42,6 +42,7 @@ type ServiceContainer struct {
 	Cleanup    *CleanupService
 	DataSync   *DataSyncService
 	Discovery  *DiscoveryService
+	Reminder   *ReminderService
 }
 
 // NewServiceContainer creates all services once. WebAuthn failure is non-fatal
@@ -54,6 +55,7 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 	}
 
 	savedShow := NewSavedShowService(database)
+	email := NewEmailService(cfg)
 
 	return &ServiceContainer{
 		// DB-only leaf services
@@ -72,7 +74,7 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 
 		// Config-only services
 		Discord:        NewDiscordService(cfg),
-		Email:          NewEmailService(cfg),
+		Email:          email,
 		MusicDiscovery: NewMusicDiscoveryService(cfg),
 
 		// No-param service
@@ -87,5 +89,6 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 		Cleanup:    NewCleanupService(database),
 		DataSync:   NewDataSyncService(database),
 		Discovery:  NewDiscoveryService(database),
+		Reminder:   NewReminderService(database, email, cfg),
 	}
 }

--- a/backend/internal/services/data_sync_test.go
+++ b/backend/internal/services/data_sync_test.go
@@ -3,7 +3,6 @@ package services
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -17,6 +16,7 @@ import (
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/testutil"
 )
 
 // =============================================================================
@@ -124,45 +124,7 @@ func (suite *DataSyncServiceIntegrationTestSuite) SetupSuite() {
 		suite.T().Fatalf("failed to get sql.DB: %v", err)
 	}
 
-	migrations := []string{
-		"000001_create_initial_schema.up.sql",
-		"000004_update_venue_constraints.up.sql",
-		"000005_add_show_status.up.sql",
-		"000007_add_private_show_status.up.sql",
-		"000008_add_pending_venue_edits.up.sql",
-		"000009_add_bandcamp_embed_url.up.sql",
-		"000010_add_scraper_source_fields.up.sql",
-		"000012_add_user_deletion_fields.up.sql",
-		"000013_add_slugs.up.sql",
-		"000014_add_account_lockout.up.sql",
-		"000020_add_show_status_flags.up.sql",
-		"000023_rename_scraper_to_discovery.up.sql",
-		"000026_add_duplicate_of_show_id.up.sql",
-		"000028_change_event_date_to_timestamptz.up.sql",
-		"000031_add_user_terms_acceptance.up.sql",
-		"000032_add_favorite_cities.up.sql",
-	}
-	for _, m := range migrations {
-		migrationSQL, err := os.ReadFile(filepath.Join("..", "..", "db", "migrations", m))
-		if err != nil {
-			suite.T().Fatalf("failed to read migration file %s: %v", m, err)
-		}
-		_, err = sqlDB.Exec(string(migrationSQL))
-		if err != nil {
-			suite.T().Fatalf("failed to run migration %s: %v", m, err)
-		}
-	}
-
-	// Migration 000027 with CONCURRENTLY stripped
-	migration27, err := os.ReadFile(filepath.Join("..", "..", "db", "migrations", "000027_add_index_duplicate_of_show_id.up.sql"))
-	if err != nil {
-		suite.T().Fatalf("failed to read migration 000027: %v", err)
-	}
-	sql27 := strings.ReplaceAll(string(migration27), "CONCURRENTLY ", "")
-	_, err = sqlDB.Exec(sql27)
-	if err != nil {
-		suite.T().Fatalf("failed to run migration 000027: %v", err)
-	}
+	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "db", "migrations"))
 
 	suite.service = NewDataSyncService(db)
 }

--- a/backend/internal/services/discovery_test.go
+++ b/backend/internal/services/discovery_test.go
@@ -3,9 +3,7 @@ package services
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -17,6 +15,7 @@ import (
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/testutil"
 )
 
 // =============================================================================
@@ -330,47 +329,7 @@ func (suite *DiscoveryIntegrationTestSuite) SetupSuite() {
 		suite.T().Fatalf("failed to get sql.DB: %v", err)
 	}
 
-	// Discovery needs: shows, venues, artists, users, show_venues, show_artists,
-	// show_status enum, show_source enum, source fields, slugs, duplicate_of_show_id
-	migrations := []string{
-		"000001_create_initial_schema.up.sql",
-		"000004_update_venue_constraints.up.sql",
-		"000005_add_show_status.up.sql",
-		"000007_add_private_show_status.up.sql",
-		"000008_add_pending_venue_edits.up.sql",
-		"000009_add_bandcamp_embed_url.up.sql",
-		"000010_add_scraper_source_fields.up.sql",
-		"000012_add_user_deletion_fields.up.sql",
-		"000013_add_slugs.up.sql",
-		"000014_add_account_lockout.up.sql",
-		"000020_add_show_status_flags.up.sql",
-		"000023_rename_scraper_to_discovery.up.sql",
-		"000026_add_duplicate_of_show_id.up.sql",
-		"000028_change_event_date_to_timestamptz.up.sql",
-		"000031_add_user_terms_acceptance.up.sql",
-		"000032_add_favorite_cities.up.sql",
-	}
-	for _, m := range migrations {
-		migrationSQL, err := os.ReadFile(filepath.Join("..", "..", "db", "migrations", m))
-		if err != nil {
-			suite.T().Fatalf("failed to read migration file %s: %v", m, err)
-		}
-		_, err = sqlDB.Exec(string(migrationSQL))
-		if err != nil {
-			suite.T().Fatalf("failed to run migration %s: %v", m, err)
-		}
-	}
-
-	// Run migration 000027 with CONCURRENTLY stripped
-	migration27, err := os.ReadFile(filepath.Join("..", "..", "db", "migrations", "000027_add_index_duplicate_of_show_id.up.sql"))
-	if err != nil {
-		suite.T().Fatalf("failed to read migration 000027: %v", err)
-	}
-	sql27 := strings.ReplaceAll(string(migration27), "CONCURRENTLY ", "")
-	_, err = sqlDB.Exec(sql27)
-	if err != nil {
-		suite.T().Fatalf("failed to run migration 000027: %v", err)
-	}
+	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "db", "migrations"))
 
 	suite.svc = NewDiscoveryService(db)
 }

--- a/backend/internal/services/email.go
+++ b/backend/internal/services/email.go
@@ -2,6 +2,8 @@ package services
 
 import (
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/getsentry/sentry-go"
 
@@ -205,6 +207,70 @@ func (s *EmailService) SendAccountRecoveryEmail(toEmail, token string, daysRemai
 			sentry.CaptureException(err)
 		})
 		return fmt.Errorf("failed to send account recovery email: %w", err)
+	}
+
+	return nil
+}
+
+// SendShowReminderEmail sends a reminder email ~24h before a saved show
+func (s *EmailService) SendShowReminderEmail(toEmail, showTitle, showURL, unsubscribeURL string, eventDate time.Time, venues []string) error {
+	if !s.IsConfigured() {
+		return fmt.Errorf("email service is not configured")
+	}
+
+	formattedDate := eventDate.Format("Monday, January 2, 2006 at 3:04 PM")
+	venueText := ""
+	if len(venues) > 0 {
+		venueText = fmt.Sprintf(`<p style="font-size: 16px; color: #444;">Venue: <strong>%s</strong></p>`, strings.Join(venues, ", "))
+	}
+
+	html := fmt.Sprintf(`
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+    <div style="text-align: center; margin-bottom: 30px;">
+        <h1 style="color: #1a1a1a; margin: 0;">Psychic Homily</h1>
+    </div>
+
+    <div style="background: #f9f9f9; border-radius: 8px; padding: 30px; margin-bottom: 20px;">
+        <h2 style="margin-top: 0; color: #1a1a1a;">%s is tomorrow!</h2>
+        <p style="font-size: 16px; color: #444;">%s</p>
+        %s
+        <p style="text-align: center; margin: 30px 0;">
+            <a href="%s" style="display: inline-block; background: #f97316; color: white; text-decoration: none; padding: 12px 30px; border-radius: 6px; font-weight: 600;">View Show</a>
+        </p>
+    </div>
+
+    <div style="text-align: center; font-size: 12px; color: #999;">
+        <p>Don't want these reminders? <a href="%s" style="color: #666;">Unsubscribe</a></p>
+    </div>
+</body>
+</html>
+`, showTitle, formattedDate, venueText, showURL, unsubscribeURL)
+
+	params := &resend.SendEmailRequest{
+		From:    fmt.Sprintf("Psychic Homily <%s>", s.fromEmail),
+		To:      []string{toEmail},
+		Subject: fmt.Sprintf("Reminder: %s is tomorrow", showTitle),
+		Html:    html,
+		Headers: map[string]string{
+			"List-Unsubscribe":      fmt.Sprintf("<%s>", unsubscribeURL),
+			"List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+		},
+	}
+
+	_, err := s.client.Emails.Send(params)
+	if err != nil {
+		sentry.WithScope(func(scope *sentry.Scope) {
+			scope.SetTag("service", "email")
+			scope.SetTag("email_type", "show_reminder")
+			sentry.CaptureException(err)
+		})
+		return fmt.Errorf("failed to send show reminder email: %w", err)
 	}
 
 	return nil

--- a/backend/internal/services/extraction_test.go
+++ b/backend/internal/services/extraction_test.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -23,6 +22,7 @@ import (
 
 	"psychic-homily-backend/internal/config"
 	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/testutil"
 )
 
 // =============================================================================
@@ -802,53 +802,11 @@ func (suite *ExtractionIntegrationTestSuite) SetupSuite() {
 	}
 	suite.db = db
 
-	// Run migrations
 	sqlDB, err := db.DB()
 	if err != nil {
 		suite.T().Fatalf("failed to get sql.DB: %v", err)
 	}
-
-	migrations := []string{
-		"000001_create_initial_schema.up.sql",
-		"000002_add_artist_search_indexes.up.sql",
-		"000003_add_venue_search_indexes.up.sql",
-		"000004_update_venue_constraints.up.sql",
-		"000005_add_show_status.up.sql",
-		"000007_add_private_show_status.up.sql",
-		"000008_add_pending_venue_edits.up.sql",
-		"000009_add_bandcamp_embed_url.up.sql",
-		"000010_add_scraper_source_fields.up.sql",
-		"000012_add_user_deletion_fields.up.sql",
-		"000013_add_slugs.up.sql",
-		"000014_add_account_lockout.up.sql",
-		"000020_add_show_status_flags.up.sql",
-		"000023_rename_scraper_to_discovery.up.sql",
-		"000026_add_duplicate_of_show_id.up.sql",
-		"000028_change_event_date_to_timestamptz.up.sql",
-		"000031_add_user_terms_acceptance.up.sql",
-		"000032_add_favorite_cities.up.sql",
-	}
-	for _, m := range migrations {
-		migrationSQL, err := os.ReadFile(filepath.Join("..", "..", "db", "migrations", m))
-		if err != nil {
-			suite.T().Fatalf("failed to read migration file %s: %v", m, err)
-		}
-		_, err = sqlDB.Exec(string(migrationSQL))
-		if err != nil {
-			suite.T().Fatalf("failed to run migration %s: %v", m, err)
-		}
-	}
-
-	// Run migration 000027 with CONCURRENTLY stripped
-	migration27, err := os.ReadFile(filepath.Join("..", "..", "db", "migrations", "000027_add_index_duplicate_of_show_id.up.sql"))
-	if err != nil {
-		suite.T().Fatalf("failed to read migration 000027: %v", err)
-	}
-	sql27 := strings.ReplaceAll(string(migration27), "CONCURRENTLY ", "")
-	_, err = sqlDB.Exec(sql27)
-	if err != nil {
-		suite.T().Fatalf("failed to run migration 000027: %v", err)
-	}
+	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "db", "migrations"))
 
 	suite.extractionService = &ExtractionService{
 		config:        &config.Config{},

--- a/backend/internal/services/favorite_venue_test.go
+++ b/backend/internal/services/favorite_venue_test.go
@@ -3,9 +3,7 @@ package services
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -18,6 +16,7 @@ import (
 
 	apperrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/testutil"
 )
 
 // =============================================================================
@@ -131,48 +130,7 @@ func (suite *FavoriteVenueServiceIntegrationTestSuite) SetupSuite() {
 		suite.T().Fatalf("failed to get sql.DB: %v", err)
 	}
 
-	migrations := []string{
-		"000001_create_initial_schema.up.sql",
-		"000002_add_artist_search_indexes.up.sql",
-		"000003_add_venue_search_indexes.up.sql",
-		"000004_update_venue_constraints.up.sql",
-		"000005_add_show_status.up.sql",
-		"000007_add_private_show_status.up.sql",
-		"000008_add_pending_venue_edits.up.sql",
-		"000009_add_bandcamp_embed_url.up.sql",
-		"000010_add_scraper_source_fields.up.sql",
-		"000012_add_user_deletion_fields.up.sql",
-		"000013_add_slugs.up.sql",
-		"000014_add_account_lockout.up.sql",
-		"000015_add_user_favorite_venues.up.sql",
-		"000020_add_show_status_flags.up.sql",
-		"000023_rename_scraper_to_discovery.up.sql",
-		"000026_add_duplicate_of_show_id.up.sql",
-		"000028_change_event_date_to_timestamptz.up.sql",
-		"000031_add_user_terms_acceptance.up.sql",
-		"000032_add_favorite_cities.up.sql",
-	}
-	for _, m := range migrations {
-		migrationSQL, err := os.ReadFile(filepath.Join("..", "..", "db", "migrations", m))
-		if err != nil {
-			suite.T().Fatalf("failed to read migration file %s: %v", m, err)
-		}
-		_, err = sqlDB.Exec(string(migrationSQL))
-		if err != nil {
-			suite.T().Fatalf("failed to run migration %s: %v", m, err)
-		}
-	}
-
-	// Run migration 000027 with CONCURRENTLY stripped
-	migration27, err := os.ReadFile(filepath.Join("..", "..", "db", "migrations", "000027_add_index_duplicate_of_show_id.up.sql"))
-	if err != nil {
-		suite.T().Fatalf("failed to read migration 000027: %v", err)
-	}
-	sql27 := strings.ReplaceAll(string(migration27), "CONCURRENTLY ", "")
-	_, err = sqlDB.Exec(sql27)
-	if err != nil {
-		suite.T().Fatalf("failed to run migration 000027: %v", err)
-	}
+	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "db", "migrations"))
 
 	suite.favoriteVenueService = &FavoriteVenueService{db: db}
 }

--- a/backend/internal/services/interfaces.go
+++ b/backend/internal/services/interfaces.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -188,6 +189,7 @@ type UserServiceInterface interface {
 	UnlinkOAuthAccount(userID uint, provider string) error
 	GetFavoriteCities(userID uint) ([]models.FavoriteCity, error)
 	SetFavoriteCities(userID uint, cities []models.FavoriteCity) error
+	SetShowReminders(userID uint, enabled bool) error
 }
 
 // EmailServiceInterface defines the contract for email operations.
@@ -196,6 +198,14 @@ type EmailServiceInterface interface {
 	SendVerificationEmail(toEmail, token string) error
 	SendMagicLinkEmail(toEmail, token string) error
 	SendAccountRecoveryEmail(toEmail, token string, daysRemaining int) error
+	SendShowReminderEmail(toEmail, showTitle, showURL, unsubscribeURL string, eventDate time.Time, venues []string) error
+}
+
+// ReminderServiceInterface defines the contract for the show reminder background service.
+type ReminderServiceInterface interface {
+	Start(ctx context.Context)
+	Stop()
+	RunReminderCycleNow()
 }
 
 // DiscordServiceInterface defines the contract for Discord notification operations.
@@ -324,4 +334,5 @@ var (
 	_ DataSyncServiceInterface      = (*DataSyncService)(nil)
 	_ AdminStatsServiceInterface    = (*AdminStatsService)(nil)
 	_ CalendarServiceInterface      = (*CalendarService)(nil)
+	_ ReminderServiceInterface      = (*ReminderService)(nil)
 )

--- a/backend/internal/services/reminder.go
+++ b/backend/internal/services/reminder.go
@@ -1,0 +1,238 @@
+package services
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/db"
+	"psychic-homily-backend/internal/config"
+)
+
+// Default reminder check interval (30 minutes)
+const DefaultReminderInterval = 30 * time.Minute
+
+// reminderRow holds the result of the reminder query
+type reminderRow struct {
+	UserID    uint
+	ShowID    uint
+	Email     string
+	ShowTitle string
+	ShowSlug  string
+	EventDate time.Time
+}
+
+// ReminderService sends email reminders for saved shows ~24h before the event
+type ReminderService struct {
+	db           *gorm.DB
+	emailService EmailServiceInterface
+	interval     time.Duration
+	stopCh       chan struct{}
+	wg           sync.WaitGroup
+	logger       *slog.Logger
+	frontendURL  string
+	jwtSecret    string
+}
+
+// NewReminderService creates a new reminder service
+func NewReminderService(database *gorm.DB, emailService EmailServiceInterface, cfg *config.Config) *ReminderService {
+	if database == nil {
+		database = db.GetDB()
+	}
+
+	interval := DefaultReminderInterval
+
+	if envInterval := os.Getenv("REMINDER_INTERVAL_MINUTES"); envInterval != "" {
+		if minutes, err := strconv.Atoi(envInterval); err == nil && minutes > 0 {
+			interval = time.Duration(minutes) * time.Minute
+		}
+	}
+
+	return &ReminderService{
+		db:           database,
+		emailService: emailService,
+		interval:     interval,
+		stopCh:       make(chan struct{}),
+		logger:       slog.Default(),
+		frontendURL:  cfg.Email.FrontendURL,
+		jwtSecret:    cfg.JWT.SecretKey,
+	}
+}
+
+// Start begins the background reminder job
+func (s *ReminderService) Start(ctx context.Context) {
+	s.wg.Add(1)
+	go s.run(ctx)
+	s.logger.Info("show reminder service started",
+		"interval_minutes", s.interval.Minutes(),
+	)
+}
+
+// Stop gracefully stops the reminder service
+func (s *ReminderService) Stop() {
+	close(s.stopCh)
+	s.wg.Wait()
+	s.logger.Info("show reminder service stopped")
+}
+
+// run is the main loop for the reminder service
+func (s *ReminderService) run(ctx context.Context) {
+	defer s.wg.Done()
+
+	// Run immediately on startup
+	s.runReminderCycle()
+
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			s.logger.Info("reminder service context cancelled")
+			return
+		case <-s.stopCh:
+			s.logger.Info("reminder service received stop signal")
+			return
+		case <-ticker.C:
+			s.runReminderCycle()
+		}
+	}
+}
+
+// runReminderCycle finds shows happening in ~24h and sends reminders
+func (s *ReminderService) runReminderCycle() {
+	s.logger.Info("starting show reminder cycle")
+
+	now := time.Now()
+	windowStart := now.Add(23 * time.Hour)
+	windowEnd := now.Add(25 * time.Hour)
+
+	// Query users with saved shows in the reminder window
+	var rows []reminderRow
+	err := s.db.Raw(`
+		SELECT
+			uss.user_id,
+			uss.show_id,
+			u.email,
+			s.title AS show_title,
+			COALESCE(s.slug, CAST(s.id AS TEXT)) AS show_slug,
+			s.event_date
+		FROM user_saved_shows uss
+		JOIN shows s ON s.id = uss.show_id
+		JOIN users u ON u.id = uss.user_id
+		JOIN user_preferences up ON up.user_id = uss.user_id
+		WHERE s.event_date BETWEEN ? AND ?
+			AND s.status = 'approved'
+			AND s.is_cancelled = false
+			AND up.show_reminders = true
+			AND u.is_active = true
+			AND u.deleted_at IS NULL
+			AND u.email IS NOT NULL
+			AND uss.reminder_sent_at IS NULL
+	`, windowStart, windowEnd).Scan(&rows).Error
+	if err != nil {
+		s.logger.Error("failed to query reminder candidates", "error", err)
+		return
+	}
+
+	if len(rows) == 0 {
+		s.logger.Info("no show reminders to send")
+		return
+	}
+
+	s.logger.Info("found shows to send reminders for", "count", len(rows))
+
+	// Collect venue names for each show
+	type showVenueKey struct{ showID uint }
+	venueCache := make(map[uint][]string)
+
+	sentCount := 0
+	errorCount := 0
+
+	for _, row := range rows {
+		// Fetch venues if not cached
+		if _, ok := venueCache[row.ShowID]; !ok {
+			var venueNames []string
+			s.db.Raw(`
+				SELECT v.name FROM venues v
+				JOIN show_venues sv ON sv.venue_id = v.id
+				WHERE sv.show_id = ?
+			`, row.ShowID).Scan(&venueNames)
+			venueCache[row.ShowID] = venueNames
+		}
+
+		showURL := fmt.Sprintf("%s/shows/%s", s.frontendURL, row.ShowSlug)
+		unsubscribeURL := generateUnsubscribeURL(s.frontendURL, row.UserID, s.jwtSecret)
+
+		err := s.emailService.SendShowReminderEmail(
+			row.Email,
+			row.ShowTitle,
+			showURL,
+			unsubscribeURL,
+			row.EventDate,
+			venueCache[row.ShowID],
+		)
+		if err != nil {
+			s.logger.Error("failed to send show reminder email",
+				"user_id", row.UserID,
+				"show_id", row.ShowID,
+				"error", err,
+			)
+			errorCount++
+			continue
+		}
+
+		// Mark as sent for deduplication
+		if err := s.db.Exec(
+			"UPDATE user_saved_shows SET reminder_sent_at = ? WHERE user_id = ? AND show_id = ?",
+			now, row.UserID, row.ShowID,
+		).Error; err != nil {
+			s.logger.Error("failed to mark reminder as sent",
+				"user_id", row.UserID,
+				"show_id", row.ShowID,
+				"error", err,
+			)
+		}
+
+		sentCount++
+	}
+
+	s.logger.Info("show reminder cycle completed",
+		"total", len(rows),
+		"sent", sentCount,
+		"errors", errorCount,
+	)
+}
+
+// RunReminderCycleNow triggers an immediate reminder cycle (useful for testing)
+func (s *ReminderService) RunReminderCycleNow() {
+	s.runReminderCycle()
+}
+
+// generateUnsubscribeURL creates an HMAC-signed URL for one-click unsubscribe
+func generateUnsubscribeURL(baseURL string, userID uint, secret string) string {
+	sig := computeUnsubscribeSignature(userID, secret)
+	return fmt.Sprintf("%s/unsubscribe/show-reminders?uid=%d&sig=%s", baseURL, userID, sig)
+}
+
+// VerifyUnsubscribeSignature checks the HMAC signature for an unsubscribe request
+func VerifyUnsubscribeSignature(userID uint, signature, secret string) bool {
+	expected := computeUnsubscribeSignature(userID, secret)
+	return hmac.Equal([]byte(expected), []byte(signature))
+}
+
+// computeUnsubscribeSignature computes HMAC-SHA256 of the user ID
+func computeUnsubscribeSignature(userID uint, secret string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(fmt.Sprintf("unsubscribe:show-reminders:%d", userID)))
+	return hex.EncodeToString(mac.Sum(nil))
+}

--- a/backend/internal/services/saved_show_test.go
+++ b/backend/internal/services/saved_show_test.go
@@ -3,9 +3,7 @@ package services
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -18,6 +16,7 @@ import (
 
 	apperrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/testutil"
 )
 
 // =============================================================================
@@ -123,49 +122,7 @@ func (suite *SavedShowServiceIntegrationTestSuite) SetupSuite() {
 		suite.T().Fatalf("failed to get sql.DB: %v", err)
 	}
 
-	migrations := []string{
-		"000001_create_initial_schema.up.sql",
-		"000002_add_artist_search_indexes.up.sql",
-		"000003_add_venue_search_indexes.up.sql",
-		"000004_update_venue_constraints.up.sql",
-		"000005_add_show_status.up.sql",
-		"000006_add_user_saved_shows.up.sql",
-		"000007_add_private_show_status.up.sql",
-		"000008_add_pending_venue_edits.up.sql",
-		"000009_add_bandcamp_embed_url.up.sql",
-		"000010_add_scraper_source_fields.up.sql",
-		"000012_add_user_deletion_fields.up.sql",
-		"000013_add_slugs.up.sql",
-		"000014_add_account_lockout.up.sql",
-		"000020_add_show_status_flags.up.sql",
-		"000023_rename_scraper_to_discovery.up.sql",
-		"000026_add_duplicate_of_show_id.up.sql",
-		"000028_change_event_date_to_timestamptz.up.sql",
-		"000031_add_user_terms_acceptance.up.sql",
-		"000032_add_favorite_cities.up.sql",
-		"000034_add_show_reminders.up.sql",
-	}
-	for _, m := range migrations {
-		migrationSQL, err := os.ReadFile(filepath.Join("..", "..", "db", "migrations", m))
-		if err != nil {
-			suite.T().Fatalf("failed to read migration file %s: %v", m, err)
-		}
-		_, err = sqlDB.Exec(string(migrationSQL))
-		if err != nil {
-			suite.T().Fatalf("failed to run migration %s: %v", m, err)
-		}
-	}
-
-	// Run migration 000027 with CONCURRENTLY stripped
-	migration27, err := os.ReadFile(filepath.Join("..", "..", "db", "migrations", "000027_add_index_duplicate_of_show_id.up.sql"))
-	if err != nil {
-		suite.T().Fatalf("failed to read migration 000027: %v", err)
-	}
-	sql27 := strings.ReplaceAll(string(migration27), "CONCURRENTLY ", "")
-	_, err = sqlDB.Exec(sql27)
-	if err != nil {
-		suite.T().Fatalf("failed to run migration 000027: %v", err)
-	}
+	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "db", "migrations"))
 
 	suite.savedShowService = &SavedShowService{db: db}
 }

--- a/backend/internal/services/saved_show_test.go
+++ b/backend/internal/services/saved_show_test.go
@@ -143,6 +143,7 @@ func (suite *SavedShowServiceIntegrationTestSuite) SetupSuite() {
 		"000028_change_event_date_to_timestamptz.up.sql",
 		"000031_add_user_terms_acceptance.up.sql",
 		"000032_add_favorite_cities.up.sql",
+		"000034_add_show_reminders.up.sql",
 	}
 	for _, m := range migrations {
 		migrationSQL, err := os.ReadFile(filepath.Join("..", "..", "db", "migrations", m))

--- a/backend/internal/services/show_report_test.go
+++ b/backend/internal/services/show_report_test.go
@@ -3,9 +3,7 @@ package services
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -17,6 +15,7 @@ import (
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/testutil"
 )
 
 // =============================================================================
@@ -138,48 +137,7 @@ func (suite *ShowReportServiceIntegrationTestSuite) SetupSuite() {
 		suite.T().Fatalf("failed to get sql.DB: %v", err)
 	}
 
-	migrations := []string{
-		"000001_create_initial_schema.up.sql",
-		"000002_add_artist_search_indexes.up.sql",
-		"000003_add_venue_search_indexes.up.sql",
-		"000004_update_venue_constraints.up.sql",
-		"000005_add_show_status.up.sql",
-		"000007_add_private_show_status.up.sql",
-		"000008_add_pending_venue_edits.up.sql",
-		"000009_add_bandcamp_embed_url.up.sql",
-		"000010_add_scraper_source_fields.up.sql",
-		"000012_add_user_deletion_fields.up.sql",
-		"000013_add_slugs.up.sql",
-		"000014_add_account_lockout.up.sql",
-		"000018_add_show_reports.up.sql",
-		"000020_add_show_status_flags.up.sql",
-		"000023_rename_scraper_to_discovery.up.sql",
-		"000026_add_duplicate_of_show_id.up.sql",
-		"000028_change_event_date_to_timestamptz.up.sql",
-		"000031_add_user_terms_acceptance.up.sql",
-		"000032_add_favorite_cities.up.sql",
-	}
-	for _, m := range migrations {
-		migrationSQL, err := os.ReadFile(filepath.Join("..", "..", "db", "migrations", m))
-		if err != nil {
-			suite.T().Fatalf("failed to read migration file %s: %v", m, err)
-		}
-		_, err = sqlDB.Exec(string(migrationSQL))
-		if err != nil {
-			suite.T().Fatalf("failed to run migration %s: %v", m, err)
-		}
-	}
-
-	// Run migration 000027 with CONCURRENTLY stripped
-	migration27, err := os.ReadFile(filepath.Join("..", "..", "db", "migrations", "000027_add_index_duplicate_of_show_id.up.sql"))
-	if err != nil {
-		suite.T().Fatalf("failed to read migration 000027: %v", err)
-	}
-	sql27 := strings.ReplaceAll(string(migration27), "CONCURRENTLY ", "")
-	_, err = sqlDB.Exec(sql27)
-	if err != nil {
-		suite.T().Fatalf("failed to run migration 000027: %v", err)
-	}
+	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "db", "migrations"))
 
 	suite.reportService = &ShowReportService{db: db}
 }

--- a/backend/internal/services/show_test.go
+++ b/backend/internal/services/show_test.go
@@ -3,7 +3,6 @@ package services
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -18,6 +17,7 @@ import (
 
 	apperrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/testutil"
 )
 
 // =============================================================================
@@ -252,52 +252,11 @@ func (suite *ShowServiceIntegrationTestSuite) SetupSuite() {
 	}
 	suite.db = db
 
-	// Run migrations
 	sqlDB, err := db.DB()
 	if err != nil {
 		suite.T().Fatalf("failed to get sql.DB: %v", err)
 	}
-
-	migrations := []string{
-		"000001_create_initial_schema.up.sql",
-		"000004_update_venue_constraints.up.sql",
-		"000005_add_show_status.up.sql",
-		"000007_add_private_show_status.up.sql",
-		"000008_add_pending_venue_edits.up.sql",
-		"000009_add_bandcamp_embed_url.up.sql",
-		"000010_add_scraper_source_fields.up.sql",
-		"000012_add_user_deletion_fields.up.sql",
-		"000013_add_slugs.up.sql",
-		"000014_add_account_lockout.up.sql",
-		"000020_add_show_status_flags.up.sql",
-		"000023_rename_scraper_to_discovery.up.sql",
-		"000026_add_duplicate_of_show_id.up.sql",
-		"000028_change_event_date_to_timestamptz.up.sql",
-		"000031_add_user_terms_acceptance.up.sql",
-		"000032_add_favorite_cities.up.sql",
-		// 000027 handled below (CONCURRENTLY not allowed in transaction)
-	}
-	for _, m := range migrations {
-		migrationSQL, err := os.ReadFile(filepath.Join("..", "..", "db", "migrations", m))
-		if err != nil {
-			suite.T().Fatalf("failed to read migration file %s: %v", m, err)
-		}
-		_, err = sqlDB.Exec(string(migrationSQL))
-		if err != nil {
-			suite.T().Fatalf("failed to run migration %s: %v", m, err)
-		}
-	}
-
-	// Run migration 000027 with CONCURRENTLY stripped (not valid in test context)
-	migration27, err := os.ReadFile(filepath.Join("..", "..", "db", "migrations", "000027_add_index_duplicate_of_show_id.up.sql"))
-	if err != nil {
-		suite.T().Fatalf("failed to read migration 000027: %v", err)
-	}
-	sql27 := strings.ReplaceAll(string(migration27), "CONCURRENTLY ", "")
-	_, err = sqlDB.Exec(sql27)
-	if err != nil {
-		suite.T().Fatalf("failed to run migration 000027: %v", err)
-	}
+	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "db", "migrations"))
 
 	suite.showService = &ShowService{db: db}
 }

--- a/backend/internal/services/user.go
+++ b/backend/internal/services/user.go
@@ -1201,6 +1201,33 @@ func (s *UserService) SetFavoriteCities(userID uint, cities []models.FavoriteCit
 	return nil
 }
 
+// SetShowReminders enables or disables show reminders for a user
+func (s *UserService) SetShowReminders(userID uint, enabled bool) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	result := s.db.Model(&models.UserPreferences{}).
+		Where("user_id = ?", userID).
+		Update("show_reminders", enabled)
+
+	if result.Error != nil {
+		return fmt.Errorf("failed to update show reminders: %w", result.Error)
+	}
+
+	if result.RowsAffected == 0 {
+		prefs := &models.UserPreferences{
+			UserID:        userID,
+			ShowReminders: enabled,
+		}
+		if err := s.db.Create(prefs).Error; err != nil {
+			return fmt.Errorf("failed to create user preferences: %w", err)
+		}
+	}
+
+	return nil
+}
+
 // GetOAuthAccounts returns all OAuth accounts linked to a user
 func (s *UserService) GetOAuthAccounts(userID uint) ([]models.OAuthAccount, error) {
 	var accounts []models.OAuthAccount

--- a/backend/internal/services/user_test.go
+++ b/backend/internal/services/user_test.go
@@ -447,6 +447,7 @@ func (suite *UserServiceIntegrationTestSuite) SetupSuite() {
 		"000015_add_user_favorite_venues.up.sql",
 		"000031_add_user_terms_acceptance.up.sql",
 		"000032_add_favorite_cities.up.sql",
+		"000034_add_show_reminders.up.sql",
 	}
 	for _, m := range migrations {
 		migrationSQL, err := os.ReadFile(filepath.Join("..", "..", "db", "migrations", m))

--- a/backend/internal/services/user_test.go
+++ b/backend/internal/services/user_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -19,6 +18,7 @@ import (
 
 	apperrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/testutil"
 )
 
 // =============================================================================
@@ -431,34 +431,11 @@ func (suite *UserServiceIntegrationTestSuite) SetupSuite() {
 	}
 	suite.db = db
 
-	// Run migrations
 	sqlDB, err := db.DB()
 	if err != nil {
 		suite.T().Fatalf("failed to get sql.DB: %v", err)
 	}
-
-	migrations := []string{
-		"000001_create_initial_schema.up.sql",
-		"000005_add_show_status.up.sql",
-		"000006_add_user_saved_shows.up.sql",
-		"000011_add_webauthn_tables.up.sql",
-		"000012_add_user_deletion_fields.up.sql",
-		"000014_add_account_lockout.up.sql",
-		"000015_add_user_favorite_venues.up.sql",
-		"000031_add_user_terms_acceptance.up.sql",
-		"000032_add_favorite_cities.up.sql",
-		"000034_add_show_reminders.up.sql",
-	}
-	for _, m := range migrations {
-		migrationSQL, err := os.ReadFile(filepath.Join("..", "..", "db", "migrations", m))
-		if err != nil {
-			suite.T().Fatalf("failed to read migration file %s: %v", m, err)
-		}
-		_, err = sqlDB.Exec(string(migrationSQL))
-		if err != nil {
-			suite.T().Fatalf("failed to run migration %s: %v", m, err)
-		}
-	}
+	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "db", "migrations"))
 
 	// Create UserService
 	suite.userService = &UserService{db: db}

--- a/backend/internal/services/venue_test.go
+++ b/backend/internal/services/venue_test.go
@@ -3,9 +3,7 @@ package services
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -18,6 +16,7 @@ import (
 
 	apperrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/testutil"
 )
 
 // =============================================================================
@@ -243,54 +242,11 @@ func (suite *VenueServiceIntegrationTestSuite) SetupSuite() {
 	}
 	suite.db = db
 
-	// Run migrations
 	sqlDB, err := db.DB()
 	if err != nil {
 		suite.T().Fatalf("failed to get sql.DB: %v", err)
 	}
-
-	migrations := []string{
-		"000001_create_initial_schema.up.sql",
-		"000002_add_artist_search_indexes.up.sql",
-		"000003_add_venue_search_indexes.up.sql",
-		"000004_update_venue_constraints.up.sql",
-		"000005_add_show_status.up.sql",
-		"000007_add_private_show_status.up.sql",
-		"000008_add_pending_venue_edits.up.sql",
-		"000009_add_bandcamp_embed_url.up.sql",
-		"000010_add_scraper_source_fields.up.sql",
-		"000012_add_user_deletion_fields.up.sql",
-		"000013_add_slugs.up.sql",
-		"000014_add_account_lockout.up.sql",
-		"000020_add_show_status_flags.up.sql",
-		"000023_rename_scraper_to_discovery.up.sql",
-		"000026_add_duplicate_of_show_id.up.sql",
-		"000028_change_event_date_to_timestamptz.up.sql",
-		"000031_add_user_terms_acceptance.up.sql",
-		"000032_add_favorite_cities.up.sql",
-		// 000027 handled below (CONCURRENTLY not allowed in transaction)
-	}
-	for _, m := range migrations {
-		migrationSQL, err := os.ReadFile(filepath.Join("..", "..", "db", "migrations", m))
-		if err != nil {
-			suite.T().Fatalf("failed to read migration file %s: %v", m, err)
-		}
-		_, err = sqlDB.Exec(string(migrationSQL))
-		if err != nil {
-			suite.T().Fatalf("failed to run migration %s: %v", m, err)
-		}
-	}
-
-	// Run migration 000027 with CONCURRENTLY stripped (not valid in test context)
-	migration27, err := os.ReadFile(filepath.Join("..", "..", "db", "migrations", "000027_add_index_duplicate_of_show_id.up.sql"))
-	if err != nil {
-		suite.T().Fatalf("failed to read migration 000027: %v", err)
-	}
-	sql27 := strings.ReplaceAll(string(migration27), "CONCURRENTLY ", "")
-	_, err = sqlDB.Exec(sql27)
-	if err != nil {
-		suite.T().Fatalf("failed to run migration 000027: %v", err)
-	}
+	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "db", "migrations"))
 
 	suite.venueService = &VenueService{db: db}
 }

--- a/backend/internal/services/webauthn_test.go
+++ b/backend/internal/services/webauthn_test.go
@@ -3,7 +3,6 @@ package services
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -19,6 +18,7 @@ import (
 
 	"psychic-homily-backend/internal/config"
 	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/testutil"
 )
 
 // =============================================================================
@@ -124,26 +124,7 @@ func (suite *WebAuthnServiceIntegrationTestSuite) SetupSuite() {
 		suite.T().Fatalf("failed to get sql.DB: %v", err)
 	}
 
-	// Migrations needed for webauthn: users + webauthn tables + user columns GORM expects
-	migrations := []string{
-		"000001_create_initial_schema.up.sql",
-		"000005_add_show_status.up.sql",
-		"000011_add_webauthn_tables.up.sql",
-		"000012_add_user_deletion_fields.up.sql",
-		"000014_add_account_lockout.up.sql",
-		"000031_add_user_terms_acceptance.up.sql",
-		"000032_add_favorite_cities.up.sql",
-	}
-	for _, m := range migrations {
-		migrationSQL, err := os.ReadFile(filepath.Join("..", "..", "db", "migrations", m))
-		if err != nil {
-			suite.T().Fatalf("failed to read migration file %s: %v", m, err)
-		}
-		_, err = sqlDB.Exec(string(migrationSQL))
-		if err != nil {
-			suite.T().Fatalf("failed to run migration %s: %v", m, err)
-		}
-	}
+	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "db", "migrations"))
 
 	cfg := &config.Config{
 		WebAuthn: config.WebAuthnConfig{

--- a/backend/internal/testutil/migrations.go
+++ b/backend/internal/testutil/migrations.go
@@ -1,0 +1,44 @@
+package testutil
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// RunAllMigrations reads all *.up.sql files from migrationDir, sorts them
+// by filename (which gives numeric order), and executes them against db.
+// It automatically strips CREATE INDEX CONCURRENTLY (not allowed inside
+// transactions) so tests don't need to special-case migration 27.
+func RunAllMigrations(t *testing.T, db *sql.DB, migrationDir string) {
+	t.Helper()
+
+	pattern := filepath.Join(migrationDir, "*.up.sql")
+	files, err := filepath.Glob(pattern)
+	if err != nil {
+		t.Fatalf("failed to glob migration files: %v", err)
+	}
+	if len(files) == 0 {
+		t.Fatalf("no migration files found in %s", migrationDir)
+	}
+
+	sort.Strings(files)
+
+	for _, f := range files {
+		content, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("failed to read migration %s: %v", filepath.Base(f), err)
+		}
+
+		// CONCURRENTLY is not allowed inside transactions (used by testcontainers)
+		migrationSQL := strings.ReplaceAll(string(content), "CONCURRENTLY ", "")
+
+		_, err = db.Exec(migrationSQL)
+		if err != nil {
+			t.Fatalf("failed to run migration %s: %v", filepath.Base(f), err)
+		}
+	}
+}

--- a/docs/strategy/ROADMAP.md
+++ b/docs/strategy/ROADMAP.md
@@ -1,96 +1,250 @@
-# Cross-Track Roadmap
+# Roadmap
 
-> High-level priorities across all tracks. For track-specific details, see the individual track files.
+> Quarterly priorities across all tracks. For the product vision and entity model, see `docs/vision.md`. For track-specific details, see individual track files.
+
+## Guiding Principle
+
+Live shows are the gateway into the knowledge graph. Every phase builds outward from the live experience: shows lead to artist discovery, which leads to releases and labels, which leads to more artists and more shows. The knowledge graph grows from the live foundation — never away from it.
+
+**Build the thing that differentiates us first.** Social features (Going/Interested) are commodity — every event platform has them. The knowledge graph is what makes this the What.cd successor. Prioritize the graph.
+
+**Bake in What.cd DNA from the start.** Features like artist-release roles, tag voting, and similar artist voting are low incremental cost when built alongside the entities they enrich. Don't defer them to a "polish" phase — build them right the first time.
 
 ## Current Priority Order
 
-| Priority | Track | What | Why | Details |
-|----------|-------|------|-----|---------|
-| 1 | Web | Phase 1 features (ICS feed, calendar, reminders) | Artists page shipped; now building daily-habit utility features | [strategy/web.md](web.md) |
-| 2 | iOS | Polish, test, submit to App Store | App is built but needs QA and submission; requires Apple Developer enrollment | [strategy/ios.md](ios.md) |
-| 3 | Discovery | Provider reliability audit, expand coverage | Stable but fragile; more venues = more value for users | [strategy/discovery.md](discovery.md) |
+| Priority | Focus | What | Status |
+|----------|-------|------|--------|
+| 1 | Web | Email preferences UI, then knowledge graph vertical slice | In progress |
+| 2 | iOS | Polish, test, ship to App Store | Blocked (Apple Developer enrollment) |
+| 3 | Discovery | Provider reliability, automated scheduling | Maintenance mode |
 
-## Q1 2026: Launch & Foundation
+---
 
-**Theme**: Ship the web app, get iOS into TestFlight, stabilize discovery.
+## Q1-Q2 2026: Foundation + Knowledge Graph Vertical Slice (Phase 1)
 
-### Web (Primary Focus)
-- [x] **Artists list page (`/artists`)** — show counts, search, multi-city filters, compact grid
-- [x] **Venues page search + multi-city filters** — VenueSearch, shift+click multi-select
-- [ ] Email preferences UI (deferred until notification emails exist)
-- [ ] Calendar sync (ICS feed for saved shows)
-- [ ] One-click "Add to Google Calendar"
-- [ ] Show reminders (email, 24h before)
-- [ ] AI/Agent API Phase 1 (date range filtering, rate limit headers)
+**Theme:** Close out remaining utility work, then immediately start proving the What.cd vision with a vertical slice of the knowledge graph.
 
-### iOS
-- [ ] Enroll in Apple Developer Program ($99/year)
+### Wrap Up (Phase 1 utility)
+- [x] Artists list page with search + multi-city filters
+- [x] Venues page search + multi-city filters
+- [x] Calendar sync (ICS feed for saved shows)
+- [x] Show reminders (email, 24h before, with one-click unsubscribe)
+- [ ] Email preferences UI (in progress)
+
+### Frontend Redesign (Phase 1, before and alongside entity work)
+
+Structural UI redesign to evolve from "show tracker" to "music knowledge graph." Current flat top nav and narrow `max-w-4xl` layout can't accommodate 15+ entity types. Full spec in `docs/strategy/ui-redesign.md`.
+
+**Build order (optimized for agent execution):**
+
+1. **Sidebar navigation + wider layout** -- collapsible sidebar replacing top nav, content area widened to `max-w-6xl`/`max-w-7xl`, 2-column grid for detail pages. Do BEFORE entity pages ship so new pages use the new layout from the start. (Frontend only, no backend deps)
+2. **Cmd+K command palette** -- global search dialog with route navigation and cross-entity search. Uses `cmdk` library. (Frontend only, can parallel with entity backend work)
+3. **Entity detail page template** -- reusable `EntityDetailLayout` with header zone, tabs, sidebar panel. Refactor Venue/Artist detail first, then new entities use it from day one. (Best done WITH first new entity page)
+4. **Show card redesign** -- bill hierarchy, date badge, inline save, tag pills. (Independent, anytime)
+5. **Artist card redesign** -- tag pills, label affiliation, card borders. (Independent, anytime)
+6. **Visual polish** -- bolder typography, card borders, density toggles. (Sweep after structural changes)
+
+**Design references:** Vercel (sidebar, command palette), Discogs (entity navigation), Linear (keyboard-first, density), Gazelle (tag voting, typed relationships, community curation patterns modernized).
+
+### Data Layer Foundation + Knowledge Graph Vertical Slice (Phase 1.5)
+
+Lay the schema foundation for the full knowledge graph, then prove the minimum viable version. A user should navigate from a show to an artist to their releases to their label to label mates, and from a festival to 40 artists on the bill. This is the moment the app stops being "another show tracker."
+
+**Build order:**
+
+1. **Data layer foundation**
+   - Generic `user_bookmarks` table replacing `user_saved_shows` and `user_favorite_venues` — supports all entity types and action types (save, follow, bookmark, going, interested). No users yet, clean migration.
+   - TIMESTAMPTZ standardization (initial schema uses TIMESTAMP without timezone)
+   - Refactor saved show and favorite venue services/handlers/hooks to use generic bookmark infrastructure
+
+2. **Festival entity** — model, migrations, CRUD API, admin UI, pages
+   - Distinct from Show: `series_slug` + `edition_year` (UNIQUE constraint) for recurring festivals
+   - `festival_artists` junction: `billing_tier` (headliner/sub_headliner/mid_card/undercard/local/dj/host), `position`, `day_date`, `stage`, `set_time`, `venue_id`
+   - `festival_venues` junction for multi-venue takeover festivals
+   - `location_name` for non-venue locations (parks, fairgrounds)
+   - URL structure: `/festivals/:series_slug/:year`
+   - Festival listing page (`/festivals`) and series overview (`/festivals/:series_slug`)
+
+3. **Releases entity** — model, migrations, CRUD API, admin UI
+   - Type: LP, EP, single, compilation, live
+   - External links: Bandcamp, Spotify, Discogs, YouTube, Apple Music (the "Listen / Buy" section that replaces What.cd's download button)
+   - Cover art, year
+   - Artist <--> Release relationship with **role types** (main, featured, producer, remixer, composer, DJ) — bake in the What.cd credit model from day one
+
+4. **Labels entity** — model, migrations, CRUD API, admin UI
+   - Name, city, founded year, status, socials, description
+   - Artist <--> Label relationship (junction table)
+   - Release <--> Label relationship
+
+5. **Artist pages enriched** — discography section, label affiliations, festival appearances
+   - Artist detail page shows releases with external links, grouped by role (albums, guest appearances, production credits — like What.cd)
+   - Artist detail page shows label affiliations and "Also on this label" (the discovery moment)
+   - Artist detail page shows festival appearances with billing tier — visible career trajectory
+
+6. **Release pages** (`/releases/:slug`) with "Listen / Buy" external links
+7. **Label pages** (`/labels`, `/labels/:slug`) with roster and catalog
+8. **Festival pages** (`/festivals/:series_slug/:year`) with tiered lineup display, day tabs, "artists you follow" highlights
+
+9. **Data seeding** — populate knowledge graph
+   - Admin festival entry — enter major US festivals (M3F, Levitation, Psycho Las Vegas, Desert Daze, etc.). One festival = ~10 min for 40+ graph connections. Geographic expansion without scrapers.
+   - MusicBrainz integration (artist-label relationships, release metadata, artist roles)
+   - Bandcamp enrichment (release links, label rosters)
+
+**Exit criteria:** Sidebar nav + Cmd+K search live. Entity detail template in use on all detail pages. 50+ Phoenix artist discographies populated. 200+ releases with external links. 20+ labels cataloged. 10+ festivals entered with lineups. Generic bookmarks system live. A user can navigate: show --> artist --> releases (with role credits) --> label --> label mates --> their shows. Festival --> 40 artists --> their releases and shows. Show/artist cards redesigned with bill hierarchy, tag pills, and discovery cues.
+
+### iOS (unchanged, blocked)
+- [ ] Apple Developer enrollment ($99/year)
 - [ ] Re-enable capabilities (Sign in with Apple, App Groups, Keychain Sharing)
-- [ ] Polish & error states (Phase 8)
-- [ ] TestFlight internal beta
+- [ ] Polish & error states
+- [ ] TestFlight --> App Store submission
 
 ### Discovery
 - [ ] Audit all 5 providers against live sites
-- [ ] Fix any broken scrapers
-- [ ] Identify next venues to add
+- [ ] Fix broken scrapers
+- [ ] Automated daily/weekly schedule
+- [ ] Error alerting (Discord/Sentry)
+- [ ] **AI billing enrichment** — add screenshot step to Playwright scrapers, send event detail pages through Claude (extraction service pattern) to determine accurate headliner/support/opener billing. Replaces "first listed = headliner" heuristic with semantic understanding. Low cost (Haiku on ~100 events/month).
+- [ ] Expand `set_type` vocabulary: `headliner` → `direct_support` → `opener` (three-tier minimum), plus `dj`, `special_guest`
+- [ ] **Festival data entry** — admin entry of major US festival lineups. AI-assisted: screenshot festival posters, extract structured lineup with billing tiers from font size/position. Geographic expansion without scrapers.
 
-## Q2 2026: Growth
+---
 
-**Theme**: Social features on web, App Store launch for iOS, automated discovery.
+## Q3 2026: Knowledge Graph Expansion (Phase 2)
 
-### Web
-- [ ] "Going" / "Interested" buttons on shows
-- [ ] Artist claim flow (Spotify OAuth verification)
-- [ ] User follow system
-- [ ] AI/Agent API Phase 2 (full-text search, genre filtering)
+**Theme:** Complete the knowledge graph with tags, relationships, scene pages, and the features that make the graph navigable and alive. This is where passive browsing becomes active exploration.
+
+### Tags & Voting
+- [ ] Genre/tag system (hierarchical taxonomy + freeform tags)
+- [ ] Entity <--> Tag relationships (artists, venues, labels, releases)
+- [ ] **Tag voting** — users upvote/downvote tags on each entity (What.cd core feature)
+- [ ] Genre/tag browsing and filtering UI
+
+### Artist Relationships
+- [ ] Artist <--> Artist relationships (similar, side projects, members of)
+- [ ] **Similar artist voting** — community votes on similarity (up/down), scores determine ranking
+- [ ] **Similar artist visualization** — interactive relationship map or cloud (iconic What.cd feature)
+- [ ] "Toured with" / "shared bills with" auto-derived from show data
+
+### Scene Pages & Venue Intelligence
+- [ ] City landing page (`/scenes/:city`) aggregating local venues, artists, labels, tags, shows
+- [ ] **Scene health metrics** — shows/month, genre diversity index, new artist appearances, venue activity trends
+- [ ] Phoenix as first fully-populated scene
+- [ ] Scene page SEO and social sharing
+- [ ] **Venue personality profiles** — auto-derived genre profiles from booking patterns, "venues like this one" based on booking overlap
+
+### Show & Festival Data Enrichment
+- [ ] **Bill position surfacing & accuracy** — `position` and `set_type` fields already exist on `show_artists` (migration 000001) and the discovery service already assigns headliner/opener. Remaining work: expose `set_type` in API responses (beyond `is_headliner` bool), surface in frontend UI, admin correction UI, and improve data quality via AI billing enrichment (see Discovery section)
+- [ ] **Festival intelligence** — festival-to-festival lineup overlap analysis, "artists you follow at this festival" personalized view, breakout artist tracking (undercard → headliner arc within and across festivals)
+- [ ] **Show-to-recording links** — connect live recordings (Bandcamp, YouTube) to the show entity where they were captured
+
+### Engagement & Discovery
+- [ ] **Notification filters** — "notify me of [genre] shows at [venue]" or "notify me when [label] artists play in Phoenix" (power user feature)
+- [ ] **Top charts** — trending shows, most-followed artists, popular tags, top contributors
+- [ ] "Going" / "Interested" buttons on shows and festivals (built on `user_bookmarks.action` — schema from Phase 1.5)
+- [ ] Attendance counts on show cards and festival pages
+- [ ] User follow system for artists, venues, labels (built on `user_bookmarks.action = 'follow'`)
+- [ ] Artist claim flow (Spotify OAuth)
+
+### Data Enrichment & Radio
+- [ ] Discogs integration (catalog data, genre taxonomy)
+- [ ] Broader Phoenix data seeding (labels, genres, releases beyond initial slice)
+- [ ] **Radio Station & Radio Show entities** — model, migrations, CRUD API, pages (`/radio`, `/radio/:slug`). Stations have live stream embeds, donation page links, and embeddable pledge widgets. Radio Shows link to stations and track playlists.
+- [ ] **Curated radio playlist parsing** — WFMU, NTS, KEXP playlists as discovery signals for releases, labels, and artist-artist affinity (see vision doc for full strategy)
+
+### Discovery Pipeline
+- [ ] **Hybrid scraper + AI pipeline** — traditional scrapers for structured data (dates, prices, links), AI for semantic interpretation (billing order, artist disambiguation, festival detection)
+- [ ] Venue-level `artist_order_hint` config (`headliner_first` vs `chronological`) for scraper accuracy
+- [ ] Admin UI: reorder artists and change set types on show edit page
 
 ### iOS
-- [ ] App Store submission (Phase 9)
-- [ ] Post-launch bug fixes and polish
-- [ ] Push notifications (V2)
+- [ ] Post-launch bug fixes
+- [ ] Push notifications
 
-### Discovery
-- [ ] New venue providers (expand AZ coverage)
-- [ ] Automated scraping schedule
-- [ ] Error alerting (Discord/Sentry on failures)
+**Exit criteria:** Genre tags on 80% of artists with community voting active. Scene page live with health metrics. Similar artist graph navigable with voting. Venue personality profiles derived. Notification filters available. Going/Interested shipped. Festival intelligence queries live (lineup overlap, breakout tracking).
 
-## Q3 2026: Personalization & Monetization
+---
 
-**Theme**: Revenue activation, personalized experience.
+## Q4 2026: Community Engine (Phase 3)
 
-### Web
-- [ ] Spotify listening history → "For You" recommendations
+**Theme:** Let the community build the knowledge graph — the engine that made What.cd irreplaceable. This phase adds the tools that channel community energy into catalog completeness.
+
+### Contribution Infrastructure
+- [ ] Extend pending-edit approval workflow to all entities
+- [ ] User contribution flows (add labels, releases, tag entities, write descriptions)
+- [ ] **Revision history** — full edit history on all community-editable content (artist bios, release descriptions, label descriptions) with diff view and revert capability
+
+### Community-Driven Completeness
+- [ ] **"Needs Attention" dashboards** — surfaces content needing improvement: artists without bios, releases missing external links, labels without descriptions, venues without complete info. Gamifies contribution by showing exactly what needs work. (Inspired by Gazelle's "Better" section, which surfaced releases needing transcoding, tags, artwork, etc.)
+- [ ] **Request system with voting** — users request missing artists, labels, releases, corrections. Community votes to prioritize. Fulfilling requests earns reputation. (What.cd's bounty system drove obsessive completeness)
+
+### Community-Powered Scene Knowledge
+- [ ] **Show field notes** — brief attendee observations capturing the live experience (not star ratings). "The opener stole the show", "They debuted two new songs." Qualitative data no other platform captures.
+- [ ] **Setlist integration** — community-contributed or setlist.fm-sourced track-level show data. Bridge recorded catalog to live performance.
+- [ ] **Promoter / Booker entity** — community-contributed knowledge about who books what. The hidden connectors that shape scenes.
+- [ ] **Musician entity** — individuals distinct from bands, with membership history and date ranges. Enables band member crossover mapping — the "scene family tree."
+
+### Curation & Trust
+- [ ] **Collections with categories** — Genre Introduction ("Intro to free jazz"), Label Roster, Staff Picks, Scene Guide, Charts, Personal. Categorization makes collections discoverable and useful, not just freeform lists.
+- [ ] **Reputation system** — contribution quality --> trust level --> auto-approve privileges
+- [ ] Local ambassador program
+- [ ] Community moderation tools
+
+**Exit criteria:** 100+ community contributions. 10+ active contributors. 5+ categorized collections. 20+ fulfilled requests. "Needs Attention" dashboard driving measurable data quality improvement. Show field notes on 20%+ of attended shows.
+
+---
+
+## Q1 2027: Geographic Expansion (Phase 4)
+
+**Theme:** Prove the model works beyond Phoenix.
+
+- [ ] Second city launch (Tucson — low-risk test)
+- [ ] Third city launch (non-Arizona — validate community-bootstrapped expansion)
+- [ ] Cross-city navigation (touring artists connecting scenes, label presence, festival circuit patterns)
+- [ ] Scene comparison and discovery
+- [ ] Cross-city "shared bills" relationships from touring data
+- [ ] Festival data as expansion bootstrapping — festivals in new cities provide initial artist graph connections before venue scrapers exist
+- [ ] **AI scraper agents** — point an AI agent at any venue's calendar URL, it navigates and extracts all events using vision. No venue-specific scraper code needed. New city onboarding without writing custom providers.
+
+**Key validation:** Can a city launch without custom scrapers? With festival data + AI scraper agents + community contributions + external APIs, the answer should be yes. Festivals provide the initial graph; community and AI fill in venue-level detail.
+
+---
+
+## 2027+: Discovery Engine (Phase 5)
+
+**Theme:** The full What.cd discovery experience, anchored in live music. Unlock the temporal intelligence that only our show data makes possible.
+
+- [ ] "Explore" mode (browse genres across cities, discover scenes)
+- [ ] Travel mode ("I'm visiting Cincinnati next week" --> personalized scene guide)
+- [ ] **Voter picks / collaborative filtering** — "People who saved this show also saved...", "People who follow this artist also follow..."
+- [ ] Personalized recommendations (listening history + saves + follows + attendance)
+- [ ] Similar artist discovery (shared labels, shared bills, genre overlap, touring patterns)
+- [ ] "Fans of [artist] also go to..." (from attendance data)
+- [ ] Related/similar scene suggestions
+- [ ] **Temporal scene graph** — time-slider on scene pages to browse how a city's music ecosystem evolves over months and years. Watch genres rise and fall, venues open and close, artists emerge. The knowledge graph as a living historical record.
+- [ ] **Artist trajectory visualization** — career arc from house shows to headlining, rendered as a visual timeline of venue sizes, show roles, and festival billing tiers over time
+- [ ] **Bill composition intelligence** — "Who opened for [headliner] before they broke?" / "Openers who later became headliners" / cross-genre billing pattern analysis
+- [ ] **Festival circuit analysis** — festival-to-festival artist overlap patterns, genre clustering by festival, "festivals like this one" recommendations
+- [ ] **Scene family tree visualization** — interactive map of band member crossover across an entire city's music scene
+- [ ] API / MCP server (knowledge graph as platform)
 - [ ] Weekly personalized email digest
 - [ ] Venue analytics dashboard (free + paid tiers)
-- [ ] Post-show photo uploads
 
-### iOS
-- [ ] Feature parity with web (social features, recommendations)
-- [ ] Offline mode, widgets
-
-### Discovery
-- [ ] Multi-city provider support (Tucson venues)
-- [ ] Auto-import for high-confidence matches
-
-## Q4 2026+: Scale
-
-**Theme**: Geographic expansion.
-
-- [ ] Multi-city data model refactor
-- [ ] Tucson launch (test expansion city)
-- [ ] City-specific admin roles
-- [ ] AI/Agent API Phase 3 (MCP server, OpenAI plugin)
+---
 
 ## Open Decisions
 
-- **iOS distribution**: TestFlight beta vs. direct App Store submission timing
-- **Multi-city architecture**: First-class city entity vs. tag-based approach
-- **Monetization model**: Venue subscriptions vs. sponsored placements vs. hybrid
-- **Mobile strategy**: Continue native iOS or evaluate PWA
+- **Monetization:** Venue subscriptions vs. premium features vs. donation-supported (What.cd model)
+- **Mobile strategy:** Continue native iOS or evaluate PWA
+- **API openness:** Fully open (MusicBrainz model) vs. tiered access
+- **Geographic scope:** US-first or global-ready data model from the start
+- **Graph DB:** Stay PostgreSQL or evaluate Neo4j when traversal queries become core
+- **Release depth:** Full What.cd-level detail (every pressing/format) or curated highlights? Start simple, let community depth emerge.
 
 ## Risks
 
-- **Single-person team**: Bus factor of 1 for all components
-- **Venue provider fragility**: Scrapers break when venue sites change
-- **Cold start problem**: Social features need critical mass to be valuable
-- **App Store approval**: iOS review process timeline is unpredictable
+- **Single-person team:** Bus factor of 1 across all tracks
+- **Cold start per city:** Each new city needs initial data + at least one community champion
+- **Community quality:** Maintaining data accuracy without heavy moderation burden
+- **Scraper fragility:** Venue sites change without warning
+- **Incentive design:** Community-driven platforms need sustainable motivation structures (What.cd's invite system and ratio requirements were effective but controversial — we need alternatives that motivate without gatekeeping)
+- **External link rot:** Bandcamp/Spotify/YouTube links can go stale; need periodic verification or community reporting

--- a/docs/strategy/web.md
+++ b/docs/strategy/web.md
@@ -1,81 +1,91 @@
 # Web Track
 
-> Frontend + backend web application development. Covers the Next.js frontend, Go backend, E2E tests, and infrastructure.
+> Next.js frontend + Go backend. The primary platform for the Music Scene Index — the spiritual successor to What.cd, anchored in live music.
 
 ## Current Status
 
-v1 feature-complete, in pre-launch hardening phase. 69 E2E tests (3 parallel workers), 68.5% backend coverage, 836+ frontend unit tests. CI fully wired with required checks and Codecov. PostHog + Sentry observability live. All P0/P1 security and legal launch items complete. Favorite cities multi-select shipped. Artists/venues page overhaul shipped (show counts, search, multi-city filters).
+v1 feature-complete, pre-launch hardening. 69 E2E tests, 68.5% backend coverage, 836+ frontend unit tests. PostHog + Sentry live. ICS calendar feed and show reminders shipped.
+
+Core entities: Artists, Venues, Shows with search, multi-city filters, saved shows, show reminders (email, 24h before), admin approval workflows, audit logging.
 
 ## Next Priorities
 
-1. **Calendar sync (ICS feed)** — Phase 1 feature, highest growth impact at low effort
-2. **One-click "Add to Google Calendar"** — pairs with ICS feed for daily-habit utility
-3. **Show reminders (email, 24h before)** — Phase 1 feature, drives retention
-4. **Email preferences UI** — last P3 launch readiness item (deferred until notification emails exist)
-5. **AI/Agent API Phase 1** — date range filtering, rate limit headers, stats endpoint
+1. ~~**Show reminders** (email, 24h before)~~ -- done
+2. **Email preferences UI** -- in progress, close it out
+3. **Frontend redesign: sidebar nav + wider layout** -- structural foundation for knowledge graph UI. See `docs/strategy/ui-redesign.md`
+4. **Frontend redesign: Cmd+K search + entity detail template** -- can parallel with entity backend work
+5. **Data layer foundation** -- generic `user_bookmarks` table (replaces per-entity saved/favorite tables), TIMESTAMPTZ standardization
+6. **Festival entity** -- distinct from Show, with series_slug, billing tiers, multi-venue support
+7. **Knowledge graph vertical slice** -- Releases (with artist roles) + Labels + enriched artist pages + festival appearances (Phase 1.5)
+8. **Show/artist card redesign + visual polish** -- richer cards with bill hierarchy, tags, discovery cues
+9. **Knowledge graph expansion** -- Tags with voting, similar artists with voting/visualization, scene pages, notification filters (Phase 2)
 
 ## Roadmap
 
-### Now: Artists Page & Launch Hardening
+### Now: Frontend Redesign + Data Layer Foundation + Knowledge Graph (Phase 1 / 1.5)
 
-- [x] All P0/P1 security + legal items
-- [x] CI: required checks, Codecov, E2E parallelization
-- [x] Observability: PostHog + Sentry
-- [x] Backend refactoring P0-P3 (DI, interfaces, handler tests)
-- [x] City filter shift+click multi-select UX
-- [x] **Artists list page (`/artists`)** — show counts, search, multi-city filters, compact grid
-- [x] **Venues page search + multi-city filters** — VenueSearch, shift+click multi-select
-- [ ] Email preferences UI (deferred — no notification emails to control yet)
-- [ ] Backend middleware tests (P4 refactoring — context logging)
+- [x] Calendar sync (ICS feed)
+- [x] Artists/venues pages with search + multi-city filters
+- [x] Show reminders (email, 24h before, with one-click unsubscribe)
+- [ ] Email preferences UI (in progress)
+- [ ] **Frontend redesign: sidebar nav + wider layout** -- collapsible sidebar replacing top nav bar, content area widened from `max-w-4xl` to `max-w-6xl`/`max-w-7xl`, 2-column grid for detail pages. Do BEFORE entity pages so new entities use the new layout from the start. See `docs/strategy/ui-redesign.md` Task 1.
+- [ ] **Frontend redesign: Cmd+K command palette** -- global search dialog (`cmdk` library), route navigation, cross-entity search. See `docs/strategy/ui-redesign.md` Task 2.
+- [ ] **Frontend redesign: entity detail template** -- reusable `EntityDetailLayout` with header zone, tabs, sidebar panel. Refactor Venue/Artist detail first, new entity pages (Festival, Release, Label) use it from the start. See `docs/strategy/ui-redesign.md` Task 3.
+- [ ] **Data layer foundation** — generic `user_bookmarks` table replacing `user_saved_shows` + `user_favorite_venues`. Supports all entity types and action types (save, follow, bookmark, going, interested). TIMESTAMPTZ standardization. Refactor services/handlers/hooks.
+- [ ] **Festival entity** — model, migrations, CRUD API, admin UI. `series_slug` + `edition_year` for recurring festivals. `festival_artists` with `billing_tier`/`day_date`/`stage`/`set_time`/`venue_id`. `festival_venues` for multi-venue takeover festivals. `location_name` for non-venue locations.
+- [ ] **Festival pages** — `/festivals` listing, `/festivals/:series_slug` series overview, `/festivals/:series_slug/:year` detail with tiered lineup display, day tabs, "artists you follow" highlights
+- [ ] **Releases entity** — model, migrations, CRUD API, admin UI, `/releases/:slug` pages with "Listen / Buy" external links (Bandcamp, Spotify, Discogs, YouTube, Apple Music). Artist-release roles: main, featured, producer, remixer, composer, DJ.
+- [ ] **Labels entity** — model, migrations, CRUD API, admin UI, `/labels` and `/labels/:slug` pages
+- [ ] **Artist pages enriched** — discography grouped by role (albums, guest appearances, production credits), label affiliations, "also on this label", festival appearances with billing tier
+- [ ] **Data seeding** -- admin festival entry (major US festivals), MusicBrainz + Bandcamp enrichment for Phoenix artists
+- [ ] **Show card redesign** -- bill hierarchy (headliner bold, support with "w/"), date badge, inline save, tag pills (placeholder-ready). See `docs/strategy/ui-redesign.md` Task 4.
+- [ ] **Artist card redesign** -- tag pills, label affiliation, consistent card borders. See `docs/strategy/ui-redesign.md` Task 5.
+- [ ] **Visual language polish** -- bolder typography, card border treatments, density toggles on list pages. See `docs/strategy/ui-redesign.md` Task 6.
 
-### Q1 2026: Foundation Features
+### Next: Knowledge Graph Expansion (Phase 2, Q3 2026)
 
-Focus: Core utility that creates daily habits
+- [ ] **Genre/tag system** — hierarchical taxonomy + freeform tags, **tag voting** (up/down per entity), tag browsing and filtering UI
+- [ ] **Artist <--> Artist relationships** — similar, side projects, members of
+- [ ] **Similar artist voting** — community votes on similarity, scores determine ranking
+- [ ] **Similar artist visualization** — interactive relationship map or cloud
+- [ ] **"Toured with" / "shared bills with"** — auto-derived from show data
+- [ ] **Scene pages** — `/scenes/:city` landing page with scene health metrics (shows/month, genre diversity, new artists, venue activity)
+- [ ] **Venue personality profiles** — auto-derived genre profiles from booking patterns, "venues like this one"
+- [ ] **Bill position surfacing & accuracy** — schema exists (`position` + `set_type` on `show_artists`, discovery service populates them). Remaining: expose `set_type` in API (beyond `is_headliner` bool), frontend display, admin correction UI
+- [ ] **Festival intelligence** — festival-to-festival lineup overlap, "artists you follow at this festival", breakout artist tracking
+- [ ] **Show-to-recording links** — connect live recordings to show entities
+- [ ] **Notification filters** — "notify me of [genre] shows at [venue]"
+- [ ] **Top charts** — trending shows, most-followed artists, popular tags, top contributors
+- [ ] "Going" / "Interested" buttons on shows and festivals (built on `user_bookmarks.action`)
+- [ ] Attendance counts on show cards and festival pages
+- [ ] Artist claim flow (Spotify OAuth)
+- [ ] User follow system for artists, venues, labels (built on `user_bookmarks.action = 'follow'`)
+- [ ] Discogs integration (catalog data, genre taxonomy)
+- [ ] **Radio Station & Radio Show entities** — `/radio`, `/radio/:slug` pages with live stream embeds, donation links, pledge widgets
+- [ ] **Curated radio playlist parsing** — WFMU, NTS, KEXP as discovery/enrichment signals ("as heard on" badges, artist↔radio show links)
 
-- [ ] Calendar sync (ICS feed for saved shows)
-- [ ] One-click "Add to Google Calendar"
-- [ ] Show reminders (email, 24h before)
-- [ ] Basic show save analytics
-- [ ] AI/Agent API Phase 1: date range filtering, rate limit headers, stats endpoint
+### Later: Community & Scale (Phases 3-5)
 
-Success metric: 20% of active users have 3+ saved shows
-
-### Q2 2026: Social & Artist Engagement
-
-Focus: Network effects and artist-driven growth
-
-- [ ] "Going" / "Interested" buttons on shows
-- [ ] Attendance counts on show cards
-- [ ] Artist claim flow (Spotify OAuth verification)
-- [ ] Basic artist dashboard
-- [ ] User follow system
-
-Success metrics: 100+ artists claimed, 30% of shows have 5+ "interested" users
-
-### Q3 2026: Personalization & Monetization
-
-Focus: Personalized experience and revenue activation
-
-- [ ] Spotify listening history → "For You" recommendations
-- [ ] Weekly personalized email digest
-- [ ] Venue analytics dashboard (free + paid tiers)
-- [ ] Post-show photo uploads and ratings/reviews
-
-### Q4 2026+: Scale
-
-- [ ] Multi-city data model refactor
-- [ ] Tucson launch (test expansion city)
-- [ ] AI/Agent API Phases 2-3: search, MCP server, OpenAI plugin
-
-## Active Plans
-
-| Plan | Focus | Status |
-|------|-------|--------|
-| `plans/active/2026-launch-readiness-checklist.md` | Security, legal, compliance | All critical done, email prefs UI pending |
-| `plans/active/backend-refactoring-checklist.md` | DI, interfaces, code quality | P0-P3 done, P4 pending (middleware tests) |
-| `plans/active/backend-test-coverage-plan.md` | Coverage targets by tier | 68.5% overall, 411 handler tests |
-| `plans/active/e2e-testing-playwright.md` | E2E test coverage | 69 tests, Tier 1-3 partial |
-| `plans/active/observability-posthog-sentry.md` | Analytics + error tracking | Complete |
+- [ ] Community contribution flows (add/edit all entities with pending review)
+- [ ] **Revision history** — edit history on all community-editable content with revert
+- [ ] **"Needs Attention" dashboards** — artists without bios, releases missing links, labels without descriptions (Gazelle "Better" section successor)
+- [ ] **Request system with voting** — community fills gaps in the catalog, votes to prioritize
+- [ ] **Collections with categories** — Genre Introduction, Label Roster, Staff Picks, Scene Guide, Charts, Personal
+- [ ] **Show field notes** — brief attendee observations capturing the live experience
+- [ ] **Setlist integration** — community-contributed or setlist.fm-sourced track-level show data
+- [ ] **Promoter / Booker entity** — who books what, the hidden connectors that shape scenes
+- [ ] **Musician entity** — individual people with band membership history, enabling scene family trees
+- [ ] Reputation system (contribution quality --> trust level --> auto-approve)
+- [ ] Multi-city scene browsing and comparison
+- [ ] Travel mode, personalized recommendations
+- [ ] **Voter picks / collaborative filtering** — "People who saved this also saved..."
+- [ ] Similar artist discovery (shared labels, shared bills, genre overlap, touring patterns)
+- [ ] **Temporal scene graph** — time-slider to browse how a city's scene evolves over time
+- [ ] **Artist trajectory visualization** — career arc from house shows to headlining, with festival billing tier progression
+- [ ] **Bill composition intelligence** — opener-to-headliner patterns, cross-genre billing analysis
+- [ ] **Festival circuit analysis** — festival-to-festival artist overlap, genre clustering, "festivals like this one"
+- [ ] **Scene family tree visualization** — interactive band member crossover map
+- [ ] API / MCP server
 
 ## Key Files
 
@@ -85,12 +95,6 @@ Focus: Personalized experience and revenue activation
 | API client | `frontend/lib/api.ts`, `frontend/lib/hooks/` |
 | Backend routes | `backend/internal/api/routes/routes.go` |
 | Service container | `backend/internal/services/container.go` |
+| Models | `backend/internal/models/` |
+| Migrations | `backend/db/migrations/` (latest: 000034) |
 | E2E tests | `frontend/e2e/`, `frontend/playwright.config.ts` |
-| CI | `.github/workflows/` |
-
-## Related Ideas
-
-- `ideas/future-product-roadmap.md` — 7 features across 4 phases
-- `ideas/monetization-strategies.md` — revenue models
-- `ideas/admin-feature-ideas.md` — internal tooling
-- `ideas/shared-component-refactoring.md` — UI/UX improvements

--- a/frontend/app/unsubscribe/show-reminders/page.tsx
+++ b/frontend/app/unsubscribe/show-reminders/page.tsx
@@ -1,0 +1,169 @@
+'use client'
+
+import { Suspense, useEffect, useRef } from 'react'
+import { useSearchParams } from 'next/navigation'
+import Link from 'next/link'
+import { useMutation } from '@tanstack/react-query'
+import { Loader2, CheckCircle2, AlertCircle, BellOff } from 'lucide-react'
+import { apiRequest, API_ENDPOINTS } from '@/lib/api'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+
+function UnsubscribeContent() {
+  const searchParams = useSearchParams()
+  const uid = searchParams.get('uid')
+  const sig = searchParams.get('sig')
+  const attemptedRef = useRef(false)
+
+  const unsubscribe = useMutation({
+    mutationFn: async ({ uid, sig }: { uid: string; sig: string }) => {
+      return apiRequest(API_ENDPOINTS.AUTH.UNSUBSCRIBE_SHOW_REMINDERS, {
+        method: 'POST',
+        body: JSON.stringify({ uid: Number(uid), sig }),
+      })
+    },
+  })
+
+  useEffect(() => {
+    if (!uid || !sig || attemptedRef.current) return
+    attemptedRef.current = true
+    unsubscribe.mutate({ uid, sig })
+  }, [uid, sig, unsubscribe])
+
+  if (!uid || !sig) {
+    return (
+      <div className="min-h-[calc(100vh-64px)] px-4 py-8">
+        <div className="mx-auto max-w-md">
+          <Card className="border-amber-500/20 bg-amber-500/5">
+            <CardHeader className="text-center">
+              <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-amber-500/10">
+                <AlertCircle className="h-6 w-6 text-amber-500" />
+              </div>
+              <CardTitle>Invalid Unsubscribe Link</CardTitle>
+              <CardDescription>
+                This unsubscribe link appears to be invalid.
+              </CardDescription>
+            </CardHeader>
+          </Card>
+        </div>
+      </div>
+    )
+  }
+
+  if (unsubscribe.isPending) {
+    return (
+      <div className="min-h-[calc(100vh-64px)] px-4 py-8">
+        <div className="mx-auto max-w-md">
+          <Card>
+            <CardHeader className="text-center">
+              <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
+                <Loader2 className="h-6 w-6 text-primary animate-spin" />
+              </div>
+              <CardTitle>Unsubscribing...</CardTitle>
+              <CardDescription>
+                Please wait while we process your request.
+              </CardDescription>
+            </CardHeader>
+          </Card>
+        </div>
+      </div>
+    )
+  }
+
+  if (unsubscribe.isError) {
+    return (
+      <div className="min-h-[calc(100vh-64px)] px-4 py-8">
+        <div className="mx-auto max-w-md">
+          <Card className="border-destructive/20 bg-destructive/5">
+            <CardHeader className="text-center">
+              <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-destructive/10">
+                <AlertCircle className="h-6 w-6 text-destructive" />
+              </div>
+              <CardTitle>Unsubscribe Failed</CardTitle>
+              <CardDescription>
+                We could not process your unsubscribe request.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="text-center">
+              <p className="text-sm text-muted-foreground mb-4">
+                You can disable show reminders from your settings instead.
+              </p>
+              <Button asChild>
+                <Link href="/profile?tab=settings">Go to Settings</Link>
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    )
+  }
+
+  if (unsubscribe.isSuccess) {
+    return (
+      <div className="min-h-[calc(100vh-64px)] px-4 py-8">
+        <div className="mx-auto max-w-md">
+          <Card className="border-emerald-500/20 bg-emerald-500/5">
+            <CardHeader className="text-center">
+              <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-emerald-500/10">
+                <CheckCircle2 className="h-6 w-6 text-emerald-500" />
+              </div>
+              <CardTitle>Unsubscribed</CardTitle>
+              <CardDescription>
+                You&apos;ve been unsubscribed from show reminders.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="text-center">
+              <p className="text-sm text-muted-foreground mb-4">
+                You can re-enable reminders anytime from your settings.
+              </p>
+              <Button asChild variant="outline">
+                <Link href="/profile?tab=settings">Go to Settings</Link>
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-[calc(100vh-64px)] px-4 py-8">
+      <div className="mx-auto max-w-md">
+        <Card>
+          <CardHeader className="text-center">
+            <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+              <BellOff className="h-6 w-6 text-muted-foreground" />
+            </div>
+            <CardTitle>Unsubscribe</CardTitle>
+            <CardDescription>Processing your request...</CardDescription>
+          </CardHeader>
+        </Card>
+      </div>
+    </div>
+  )
+}
+
+function UnsubscribeLoading() {
+  return (
+    <div className="min-h-[calc(100vh-64px)] px-4 py-8">
+      <div className="mx-auto max-w-md">
+        <Card>
+          <CardHeader className="text-center">
+            <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
+              <Loader2 className="h-6 w-6 text-primary animate-spin" />
+            </div>
+            <CardTitle>Loading...</CardTitle>
+          </CardHeader>
+        </Card>
+      </div>
+    </div>
+  )
+}
+
+export default function UnsubscribeShowRemindersPage() {
+  return (
+    <Suspense fallback={<UnsubscribeLoading />}>
+      <UnsubscribeContent />
+    </Suspense>
+  )
+}

--- a/frontend/components/settings/SettingsPanel.tsx
+++ b/frontend/components/settings/SettingsPanel.tsx
@@ -25,6 +25,7 @@ import { DeleteAccountDialog } from '@/components/settings/delete-account-dialog
 import { OAuthAccounts } from '@/components/settings/oauth-accounts'
 import { APITokenManagement } from '@/components/settings/api-token-management'
 import { FavoriteCitiesSettings } from '@/components/settings/favorite-cities'
+import { NotificationSettings } from '@/components/settings/notification-settings'
 
 export function SettingsPanel() {
   const { user } = useAuthContext()
@@ -101,6 +102,9 @@ export function SettingsPanel() {
     <div className="space-y-6">
       {/* Favorite Cities Section */}
       <FavoriteCitiesSettings />
+
+      {/* Notification Settings */}
+      <NotificationSettings />
 
       {/* Email Verification Section */}
       <Card>

--- a/frontend/components/settings/notification-settings.tsx
+++ b/frontend/components/settings/notification-settings.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { useProfile } from '@/lib/hooks/useAuth'
+import { useSetShowReminders } from '@/lib/hooks/useShowReminders'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Switch } from '@/components/ui/switch'
+import { Label } from '@/components/ui/label'
+import { Bell, Loader2 } from 'lucide-react'
+
+export function NotificationSettings() {
+  const { data: profileData } = useProfile()
+  const setShowReminders = useSetShowReminders()
+
+  const isEnabled = profileData?.user?.preferences?.show_reminders ?? false
+
+  const handleToggle = (checked: boolean) => {
+    setShowReminders.mutate(checked)
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <Bell className="h-5 w-5" />
+          <CardTitle>Notifications</CardTitle>
+        </div>
+        <CardDescription>
+          Control how you&apos;re notified about upcoming shows
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-center justify-between">
+          <div className="space-y-0.5">
+            <Label htmlFor="show-reminders">Show reminders</Label>
+            <p className="text-sm text-muted-foreground">
+              Get an email 24 hours before your saved shows
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            {setShowReminders.isPending && (
+              <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+            )}
+            <Switch
+              id="show-reminders"
+              checked={isEnabled}
+              onCheckedChange={handleToggle}
+              disabled={setShowReminders.isPending}
+            />
+          </div>
+        </div>
+        {setShowReminders.isError && (
+          <p className="mt-2 text-sm text-destructive">
+            Failed to update setting. Please try again.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/e2e/setup-db.sh
+++ b/frontend/e2e/setup-db.sh
@@ -141,8 +141,8 @@ VALUES ('e2e-unverified@test.local', '${BCRYPT_HASH}', 'Test', 'Unverified', tru
 ON CONFLICT (email) DO NOTHING;
 
 -- Create user_preferences for all test users
-INSERT INTO user_preferences (user_id, notification_email, notification_push, theme, timezone, language, created_at, updated_at)
-SELECT id, true, false, 'system', 'America/Phoenix', 'en', NOW(), NOW()
+INSERT INTO user_preferences (user_id, notification_email, notification_push, show_reminders, theme, timezone, language, created_at, updated_at)
+SELECT id, true, false, false, 'system', 'America/Phoenix', 'en', NOW(), NOW()
 FROM users WHERE email IN ('e2e-user@test.local', 'e2e-admin@test.local', 'e2e-unverified@test.local')
 ON CONFLICT (user_id) DO NOTHING;
 SQL

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -77,6 +77,8 @@ export const API_ENDPOINTS = {
     CLI_TOKEN: `${API_BASE_URL}/auth/cli-token`,
     // User preferences
     FAVORITE_CITIES: `${API_BASE_URL}/auth/preferences/favorite-cities`,
+    SHOW_REMINDERS: `${API_BASE_URL}/auth/preferences/show-reminders`,
+    UNSUBSCRIBE_SHOW_REMINDERS: `${API_BASE_URL}/auth/unsubscribe/show-reminders`,
   },
 
   // Application endpoints

--- a/frontend/lib/hooks/useAuth.ts
+++ b/frontend/lib/hooks/useAuth.ts
@@ -52,6 +52,7 @@ interface FavoriteCity {
 interface UserPreferencesData {
   notification_email?: boolean
   notification_push?: boolean
+  show_reminders?: boolean
   theme?: string
   timezone?: string
   language?: string

--- a/frontend/lib/hooks/useShowReminders.ts
+++ b/frontend/lib/hooks/useShowReminders.ts
@@ -1,0 +1,33 @@
+'use client'
+
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { apiRequest, API_ENDPOINTS } from '../api'
+import { queryKeys } from '../queryClient'
+
+interface SetShowRemindersResponse {
+  success: boolean
+  show_reminders: boolean
+}
+
+/**
+ * Mutation hook to toggle show reminders.
+ * Invalidates profile query on success so the setting propagates.
+ */
+export const useSetShowReminders = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (enabled: boolean): Promise<SetShowRemindersResponse> => {
+      return apiRequest<SetShowRemindersResponse>(
+        API_ENDPOINTS.AUTH.SHOW_REMINDERS,
+        {
+          method: 'PATCH',
+          body: JSON.stringify({ enabled }),
+        }
+      )
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.auth.profile })
+    },
+  })
+}


### PR DESCRIPTION
## Summary

End-to-end show reminder email system:

- **Background job**: `ReminderService` runs every 30min, finds saved shows ~24h away, sends reminder emails. Deduplicates via `reminder_sent_at` timestamp.
- **Email**: HTML template with show title, date, venue names. RFC 8058 `List-Unsubscribe` + `List-Unsubscribe-Post` headers for one-click unsubscribe.
- **Settings toggle**: `NotificationSettings` component in profile settings page
- **Unsubscribe**: Public `/unsubscribe/show-reminders` page with HMAC signature verification (no auth required)
- **Migration 000034**: Adds `show_reminders` boolean pref + `reminder_sent_at` tracking column
- **Test fixes**: Added missing mock methods (`SetShowReminders`, `SendShowReminderEmail`) and migration 34 to test suites
- **Test infra refactor**: New `testutil.RunAllMigrations()` helper replaces manual migration lists across 18 test files (-590 lines). New migrations now work automatically without touching test files.

Also includes: `.claude/worktrees/` added to `.gitignore`, docs updates marking feature complete.

## Architecture

```
User saves show → ReminderService (30min tick) → queries shows 23-25h away
  → SendShowReminderEmail() → marks reminder_sent_at (dedup)
  → Email includes HMAC-signed unsubscribe link
  → /unsubscribe/show-reminders verifies signature, disables pref
```

## Test plan

- [x] All backend tests pass (handlers, middleware, services)
- [x] All frontend tests pass (897 tests)
- [ ] Backend integration tests for ReminderService + handlers (follow-up)
- [ ] Frontend component tests for NotificationSettings + unsubscribe page (follow-up)
- [ ] Manual: toggle show reminders in settings, verify preference saved
- [ ] Manual: unsubscribe link works without auth
- [ ] Manual: reminder email sent ~24h before saved show

🤖 Generated with [Claude Code](https://claude.com/claude-code)