### PR TITLE
fix: command palette dark mode styling

### DIFF
--- a/frontend/components/layout/CommandPalette.tsx
+++ b/frontend/components/layout/CommandPalette.tsx
@@ -2,16 +2,15 @@
 
 import { useCallback, useMemo, useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
+import { Command as CommandPrimitive } from 'cmdk'
 import {
-  Command,
   CommandDialog,
   CommandEmpty,
   CommandGroup,
-  CommandInput,
   CommandItem,
   CommandList,
   CommandSeparator,
-} from 'cmdk'
+} from '@/components/ui/command'
 import {
   Calendar, Mic2, MapPin, BookOpen, Headphones, Send,
   Library, Settings, Shield, Search, Clock, X,
@@ -19,7 +18,6 @@ import {
 import type { LucideIcon } from 'lucide-react'
 import { useAuthContext } from '@/lib/context/AuthContext'
 import { useCommandPalette } from '@/lib/hooks/useCommandPalette'
-import { cn } from '@/lib/utils'
 
 interface RouteItem {
   label: string
@@ -104,7 +102,6 @@ export function CommandPalette() {
   const [recentSearches, setRecentSearches] = useState<string[]>([])
   const [search, setSearch] = useState('')
 
-  // Load recent searches when dialog opens
   useEffect(() => {
     if (open) {
       setRecentSearches(getRecentSearches())
@@ -149,31 +146,12 @@ export function CommandPalette() {
   const showRecent = !search && recentSearches.length > 0
 
   return (
-    <CommandDialog
-      open={open}
-      onOpenChange={setOpen}
-      label="Command palette"
-      overlayClassName="bg-black/50 backdrop-blur-sm"
-      contentClassName={cn(
-        'fixed left-[50%] top-[20%] z-50 w-full max-w-[520px] translate-x-[-50%]',
-        'overflow-hidden rounded-xl border border-border/50 bg-popover shadow-2xl',
-        'data-[state=open]:animate-in data-[state=closed]:animate-out',
-        'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
-        'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
-        'data-[state=closed]:slide-out-to-left-1/2 data-[state=open]:slide-in-from-left-1/2',
-        'data-[state=closed]:slide-out-to-top-2 data-[state=open]:slide-in-from-top-2',
-        'duration-200'
-      )}
-    >
+    <CommandDialog open={open} onOpenChange={setOpen}>
       <div className="flex items-center border-b border-border/50 px-3">
-        <Search className="mr-2 h-4 w-4 shrink-0 text-muted-foreground" />
-        <CommandInput
+        <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+        <CommandPrimitive.Input
           placeholder="Search pages..."
-          className={cn(
-            'flex h-12 w-full bg-transparent py-3 text-sm',
-            'placeholder:text-muted-foreground',
-            'outline-none disabled:cursor-not-allowed disabled:opacity-50'
-          )}
+          className="flex h-11 w-full bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground"
           value={search}
           onValueChange={setSearch}
         />
@@ -188,15 +166,8 @@ export function CommandPalette() {
         )}
       </div>
 
-      <CommandList
-        className={cn(
-          'max-h-[320px] overflow-y-auto overflow-x-hidden',
-          'p-2'
-        )}
-      >
-        <CommandEmpty className="py-6 text-center text-sm text-muted-foreground">
-          No results found.
-        </CommandEmpty>
+      <CommandList className="max-h-[320px] p-2">
+        <CommandEmpty>No results found.</CommandEmpty>
 
         {showRecent && (
           <CommandGroup
@@ -211,7 +182,6 @@ export function CommandPalette() {
                 </button>
               </div>
             }
-            className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground"
           >
             {recentSearches.map(label => {
               const route = routes.find(
@@ -222,10 +192,7 @@ export function CommandPalette() {
                   key={`recent-${label}`}
                   value={`recent-${label}`}
                   onSelect={() => handleRecentSelect(label)}
-                  className={cn(
-                    'flex cursor-pointer items-center gap-3 rounded-lg px-2 py-2.5 text-sm',
-                    'aria-selected:bg-accent aria-selected:text-accent-foreground'
-                  )}
+                  className="cursor-pointer gap-3 rounded-lg px-2 py-2.5"
                   keywords={[label]}
                 >
                   <Clock className="h-4 w-4 text-muted-foreground" />
@@ -241,12 +208,9 @@ export function CommandPalette() {
           </CommandGroup>
         )}
 
-        {showRecent && <CommandSeparator className="mx-2 my-1 bg-border/50" />}
+        {showRecent && <CommandSeparator className="mx-2 my-1" />}
 
-        <CommandGroup
-          heading="Pages"
-          className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground"
-        >
+        <CommandGroup heading="Pages">
           {availableRoutes.map(route => {
             const Icon = route.icon
             return (
@@ -255,10 +219,7 @@ export function CommandPalette() {
                 value={route.label}
                 onSelect={() => handleSelect(route.href, route.label)}
                 keywords={route.keywords}
-                className={cn(
-                  'flex cursor-pointer items-center gap-3 rounded-lg px-2 py-2.5 text-sm',
-                  'aria-selected:bg-accent aria-selected:text-accent-foreground'
-                )}
+                className="cursor-pointer gap-3 rounded-lg px-2 py-2.5"
               >
                 <Icon className="h-4 w-4 text-muted-foreground" />
                 <span>{route.label}</span>

--- a/frontend/components/ui/command.tsx
+++ b/frontend/components/ui/command.tsx
@@ -1,0 +1,149 @@
+'use client'
+
+import * as React from 'react'
+import { type DialogProps } from '@radix-ui/react-dialog'
+import { Command as CommandPrimitive } from 'cmdk'
+import { Search } from 'lucide-react'
+
+import { cn } from '@/lib/utils'
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
+
+const Command = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive
+    ref={ref}
+    className={cn(
+      'flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground',
+      className
+    )}
+    {...props}
+  />
+))
+Command.displayName = CommandPrimitive.displayName
+
+function CommandDialog({ children, ...props }: DialogProps) {
+  return (
+    <Dialog {...props}>
+      <DialogContent className="overflow-hidden p-0 shadow-lg sm:max-w-[520px] [&>button:last-child]:hidden">
+        <DialogTitle className="sr-only">Command palette</DialogTitle>
+        <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground">
+          {children}
+        </Command>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+const CommandInput = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Input>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
+>(({ className, ...props }, ref) => (
+  <div className="flex items-center border-b border-border/50 px-3" cmdk-input-wrapper="">
+    <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+    <CommandPrimitive.Input
+      ref={ref}
+      className={cn(
+        'flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50',
+        className
+      )}
+      {...props}
+    />
+  </div>
+))
+CommandInput.displayName = CommandPrimitive.Input.displayName
+
+const CommandList = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.List
+    ref={ref}
+    className={cn('max-h-[300px] overflow-y-auto overflow-x-hidden', className)}
+    {...props}
+  />
+))
+CommandList.displayName = CommandPrimitive.List.displayName
+
+const CommandEmpty = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Empty>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
+>((props, ref) => (
+  <CommandPrimitive.Empty
+    ref={ref}
+    className="py-6 text-center text-sm text-muted-foreground"
+    {...props}
+  />
+))
+CommandEmpty.displayName = CommandPrimitive.Empty.displayName
+
+const CommandGroup = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Group>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Group>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.Group
+    ref={ref}
+    className={cn(
+      'overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground',
+      className
+    )}
+    {...props}
+  />
+))
+CommandGroup.displayName = CommandPrimitive.Group.displayName
+
+const CommandSeparator = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.Separator
+    ref={ref}
+    className={cn('-mx-1 h-px bg-border', className)}
+    {...props}
+  />
+))
+CommandSeparator.displayName = CommandPrimitive.Separator.displayName
+
+const CommandItem = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected='true']:bg-muted data-[selected='true']:text-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      className
+    )}
+    {...props}
+  />
+))
+CommandItem.displayName = CommandPrimitive.Item.displayName
+
+const CommandShortcut = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) => {
+  return (
+    <span
+      className={cn(
+        'ml-auto text-xs tracking-widest text-muted-foreground',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+CommandShortcut.displayName = 'CommandShortcut'
+
+export {
+  Command,
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandShortcut,
+  CommandSeparator,
+}


### PR DESCRIPTION
## Summary
- Add Shadcn `command.tsx` UI wrapper around `cmdk` with proper theme integration
- Rewrite `CommandPalette.tsx` to import from `@/components/ui/command` instead of raw `cmdk`
- Replace `aria-selected:bg-accent` (intense orange) with `data-[selected='true']:bg-muted` for subtle dark mode highlight
- Remove custom `overlayClassName`/`contentClassName` props that don't exist on Shadcn's `CommandDialog`
- Let Shadcn component defaults handle group heading styles instead of duplicating them

## Test plan
- [x] TypeScript compiles cleanly
- [x] All 897 tests pass
- [ ] Visual check: open Cmd+K in dark mode — selected item should have subtle muted background, not solid orange
- [ ] Verify keyboard navigation (arrow keys, enter, escape) still works
- [ ] Verify recent searches appear and clear button works

🤖 Generated with [Claude Code](https://claude.com/claude-code)