### PR TITLE
feat: add Release model, migration, and junction tables

### DIFF
--- a/backend/db/migrations/000035_create_releases.down.sql
+++ b/backend/db/migrations/000035_create_releases.down.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS release_external_links;
+DROP TABLE IF EXISTS artist_releases;
+DROP TABLE IF EXISTS releases;

--- a/backend/db/migrations/000035_create_releases.up.sql
+++ b/backend/db/migrations/000035_create_releases.up.sql
@@ -1,0 +1,39 @@
+-- releases table
+CREATE TABLE releases (
+    id SERIAL PRIMARY KEY,
+    title VARCHAR(255) NOT NULL,
+    slug VARCHAR(255) UNIQUE,
+    release_type VARCHAR(50) NOT NULL DEFAULT 'lp',
+    release_year INT,
+    release_date DATE,
+    cover_art_url TEXT,
+    description TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- artist_releases junction with roles
+CREATE TABLE artist_releases (
+    artist_id INT NOT NULL REFERENCES artists(id) ON DELETE CASCADE,
+    release_id INT NOT NULL REFERENCES releases(id) ON DELETE CASCADE,
+    role VARCHAR(50) NOT NULL DEFAULT 'main',
+    position INT NOT NULL DEFAULT 0,
+    PRIMARY KEY (artist_id, release_id, role)
+);
+
+-- release_external_links for Listen/Buy links
+CREATE TABLE release_external_links (
+    id SERIAL PRIMARY KEY,
+    release_id INT NOT NULL REFERENCES releases(id) ON DELETE CASCADE,
+    platform VARCHAR(50) NOT NULL,
+    url TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Indexes
+CREATE INDEX idx_releases_slug ON releases(slug);
+CREATE INDEX idx_releases_release_year ON releases(release_year);
+CREATE INDEX idx_releases_release_type ON releases(release_type);
+CREATE INDEX idx_artist_releases_artist_id ON artist_releases(artist_id);
+CREATE INDEX idx_artist_releases_release_id ON artist_releases(release_id);
+CREATE INDEX idx_release_external_links_release_id ON release_external_links(release_id);

--- a/backend/internal/models/release.go
+++ b/backend/internal/models/release.go
@@ -1,0 +1,78 @@
+package models
+
+import "time"
+
+// ReleaseType represents the type/format of a release
+type ReleaseType string
+
+const (
+	ReleaseTypeLP          ReleaseType = "lp"
+	ReleaseTypeEP          ReleaseType = "ep"
+	ReleaseTypeSingle      ReleaseType = "single"
+	ReleaseTypeCompilation ReleaseType = "compilation"
+	ReleaseTypeLive        ReleaseType = "live"
+	ReleaseTypeRemix       ReleaseType = "remix"
+	ReleaseTypeDemo        ReleaseType = "demo"
+)
+
+// ArtistReleaseRole represents the role an artist played on a release
+type ArtistReleaseRole string
+
+const (
+	ArtistReleaseRoleMain     ArtistReleaseRole = "main"
+	ArtistReleaseRoleFeatured ArtistReleaseRole = "featured"
+	ArtistReleaseRoleProducer ArtistReleaseRole = "producer"
+	ArtistReleaseRoleRemixer  ArtistReleaseRole = "remixer"
+	ArtistReleaseRoleComposer ArtistReleaseRole = "composer"
+	ArtistReleaseRoleDJ       ArtistReleaseRole = "dj"
+)
+
+// Release represents a music release (album, EP, single, etc.)
+type Release struct {
+	ID          uint        `gorm:"primaryKey"`
+	Title       string      `gorm:"not null"`
+	Slug        *string     `gorm:"column:slug;uniqueIndex"`
+	ReleaseType ReleaseType `gorm:"column:release_type;not null;default:'lp'"`
+	ReleaseYear *int        `gorm:"column:release_year"`
+	ReleaseDate *string     `gorm:"column:release_date;type:date"` // DATE stored as string (YYYY-MM-DD)
+	CoverArtURL *string     `gorm:"column:cover_art_url"`
+	Description *string     `gorm:"column:description"`
+	CreatedAt   time.Time   `gorm:"not null"`
+	UpdatedAt   time.Time   `gorm:"not null"`
+
+	// Relationships
+	Artists       []Artist              `gorm:"many2many:artist_releases;"`
+	ExternalLinks []ReleaseExternalLink `gorm:"foreignKey:ReleaseID"`
+}
+
+// TableName specifies the table name for Release
+func (Release) TableName() string {
+	return "releases"
+}
+
+// ArtistRelease represents the junction table between artists and releases with role information
+type ArtistRelease struct {
+	ArtistID  uint              `gorm:"primaryKey;column:artist_id"`
+	ReleaseID uint              `gorm:"primaryKey;column:release_id"`
+	Role      ArtistReleaseRole `gorm:"primaryKey;column:role;not null;default:'main'"`
+	Position  int               `gorm:"not null;default:0"`
+}
+
+// TableName specifies the table name for ArtistRelease
+func (ArtistRelease) TableName() string {
+	return "artist_releases"
+}
+
+// ReleaseExternalLink represents a link to an external platform for a release
+type ReleaseExternalLink struct {
+	ID        uint      `gorm:"primaryKey"`
+	ReleaseID uint      `gorm:"not null"`
+	Platform  string    `gorm:"not null"`
+	URL       string    `gorm:"not null"`
+	CreatedAt time.Time `gorm:"not null"`
+}
+
+// TableName specifies the table name for ReleaseExternalLink
+func (ReleaseExternalLink) TableName() string {
+	return "release_external_links"
+}


### PR DESCRIPTION
## Summary
- Add migration `000035_create_releases` with three tables: `releases`, `artist_releases` (junction with typed roles), and `release_external_links`
- Add GORM model `release.go` with `Release`, `ArtistRelease`, and `ReleaseExternalLink` structs
- Define type constants for `ReleaseType` (lp/ep/single/compilation/live/remix/demo) and `ArtistReleaseRole` (main/featured/producer/remixer/composer/dj)

Closes PSY-5

## Details
- Artist-release junction uses composite PK `(artist_id, release_id, role)` — an artist can have multiple roles on the same release (e.g., main artist + producer)
- External links table supports Bandcamp, Spotify, Apple Music, YouTube, Discogs, Tidal, SoundCloud
- Follows existing model patterns (Artist, Show, ShowArtist)
- No service/handler/route changes — those come in PSY-6

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (no existing tests broken)
- [ ] Verify migration applies cleanly against local DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)