### PR TITLE
feat: add Label model, migration, and junction tables

### DIFF
--- a/backend/db/migrations/000036_create_labels.down.sql
+++ b/backend/db/migrations/000036_create_labels.down.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS release_labels;
+DROP TABLE IF EXISTS artist_labels;
+DROP TABLE IF EXISTS labels;

--- a/backend/db/migrations/000036_create_labels.up.sql
+++ b/backend/db/migrations/000036_create_labels.up.sql
@@ -1,0 +1,46 @@
+-- labels table
+CREATE TABLE labels (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    slug VARCHAR(255) UNIQUE,
+    city VARCHAR(255),
+    state VARCHAR(255),
+    country VARCHAR(100),
+    founded_year INT,
+    status VARCHAR(50) NOT NULL DEFAULT 'active',
+    description TEXT,
+    website TEXT,
+    instagram VARCHAR(255),
+    facebook VARCHAR(255),
+    twitter VARCHAR(255),
+    youtube VARCHAR(255),
+    spotify VARCHAR(255),
+    soundcloud VARCHAR(255),
+    bandcamp VARCHAR(255),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- artist_labels junction (an artist is signed to / has released on a label)
+CREATE TABLE artist_labels (
+    artist_id INT NOT NULL REFERENCES artists(id) ON DELETE CASCADE,
+    label_id INT NOT NULL REFERENCES labels(id) ON DELETE CASCADE,
+    PRIMARY KEY (artist_id, label_id)
+);
+
+-- release_labels junction (a release was put out by a label)
+CREATE TABLE release_labels (
+    release_id INT NOT NULL REFERENCES releases(id) ON DELETE CASCADE,
+    label_id INT NOT NULL REFERENCES labels(id) ON DELETE CASCADE,
+    catalog_number VARCHAR(100),
+    PRIMARY KEY (release_id, label_id)
+);
+
+-- Indexes
+CREATE INDEX idx_labels_slug ON labels(slug);
+CREATE INDEX idx_labels_status ON labels(status);
+CREATE INDEX idx_labels_city_state ON labels(city, state);
+CREATE INDEX idx_artist_labels_artist_id ON artist_labels(artist_id);
+CREATE INDEX idx_artist_labels_label_id ON artist_labels(label_id);
+CREATE INDEX idx_release_labels_release_id ON release_labels(release_id);
+CREATE INDEX idx_release_labels_label_id ON release_labels(label_id);

--- a/backend/internal/models/label.go
+++ b/backend/internal/models/label.go
@@ -1,0 +1,60 @@
+package models
+
+import "time"
+
+// LabelStatus represents the operational status of a label
+type LabelStatus string
+
+const (
+	LabelStatusActive   LabelStatus = "active"
+	LabelStatusInactive LabelStatus = "inactive"
+	LabelStatusDefunct  LabelStatus = "defunct"
+)
+
+// Label represents a record label
+type Label struct {
+	ID          uint        `gorm:"primaryKey"`
+	Name        string      `gorm:"not null"`
+	Slug        *string     `gorm:"column:slug;uniqueIndex"`
+	City        *string     `gorm:"column:city"`
+	State       *string     `gorm:"column:state"`
+	Country     *string     `gorm:"column:country"`
+	FoundedYear *int        `gorm:"column:founded_year"`
+	Status      LabelStatus `gorm:"column:status;not null;default:'active'"`
+	Description *string     `gorm:"column:description"`
+	Social      Social      `gorm:"embedded"`
+	CreatedAt   time.Time   `gorm:"not null"`
+	UpdatedAt   time.Time   `gorm:"not null"`
+
+	// Relationships
+	Artists  []Artist  `gorm:"many2many:artist_labels;"`
+	Releases []Release `gorm:"many2many:release_labels;"`
+}
+
+// TableName specifies the table name for Label
+func (Label) TableName() string {
+	return "labels"
+}
+
+// ArtistLabel represents the junction table between artists and labels
+type ArtistLabel struct {
+	ArtistID uint `gorm:"primaryKey;column:artist_id"`
+	LabelID  uint `gorm:"primaryKey;column:label_id"`
+}
+
+// TableName specifies the table name for ArtistLabel
+func (ArtistLabel) TableName() string {
+	return "artist_labels"
+}
+
+// ReleaseLabel represents the junction table between releases and labels
+type ReleaseLabel struct {
+	ReleaseID     uint    `gorm:"primaryKey;column:release_id"`
+	LabelID       uint    `gorm:"primaryKey;column:label_id"`
+	CatalogNumber *string `gorm:"column:catalog_number"`
+}
+
+// TableName specifies the table name for ReleaseLabel
+func (ReleaseLabel) TableName() string {
+	return "release_labels"
+}


### PR DESCRIPTION
## Summary
- Add migration `000036_create_labels` with three tables: `labels`, `artist_labels`, and `release_labels` (with catalog_number)
- Add GORM model `label.go` with `Label`, `ArtistLabel`, and `ReleaseLabel` structs
- Define `LabelStatus` type constants: active, inactive, defunct
- Label uses embedded `Social` struct (same as Artist) for social media links

Closes PSY-9

## Details
- `artist_labels` links artists to labels they're signed to / have released on
- `release_labels` links releases to labels with optional `catalog_number` (e.g., "FI-042")
- Follows existing model patterns (Artist, Release)
- No service/handler/route changes — those come in PSY-10

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (no existing tests broken)
- [ ] Verify migration applies cleanly against local DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)