### PR TITLE
feat: add Release service, handler, and API routes

### DIFF
--- a/backend/internal/api/handlers/handler_integration_helpers_test.go
+++ b/backend/internal/api/handlers/handler_integration_helpers_test.go
@@ -38,6 +38,7 @@ type handlerIntegrationDeps struct {
 	adminStatsService     *services.AdminStatsService
 	discoveryService      *services.DiscoveryService
 	artistService         *services.ArtistService
+	releaseService        *services.ReleaseService
 }
 
 func setupHandlerIntegrationDeps(t *testing.T) *handlerIntegrationDeps {
@@ -110,6 +111,7 @@ func setupHandlerIntegrationDeps(t *testing.T) *handlerIntegrationDeps {
 		adminStatsService:     services.NewAdminStatsService(db),
 		discoveryService:      services.NewDiscoveryService(db),
 		artistService:         services.NewArtistService(db),
+		releaseService:        services.NewReleaseService(db),
 	}
 
 	return deps
@@ -124,6 +126,9 @@ func cleanupTables(db *gorm.DB) {
 	_, _ = sqlDB.Exec("DELETE FROM user_saved_shows")
 	_, _ = sqlDB.Exec("DELETE FROM user_favorite_venues")
 	_, _ = sqlDB.Exec("DELETE FROM pending_venue_edits")
+	_, _ = sqlDB.Exec("DELETE FROM release_external_links")
+	_, _ = sqlDB.Exec("DELETE FROM artist_releases")
+	_, _ = sqlDB.Exec("DELETE FROM releases")
 	_, _ = sqlDB.Exec("DELETE FROM show_artists")
 	_, _ = sqlDB.Exec("DELETE FROM show_venues")
 	_, _ = sqlDB.Exec("DELETE FROM shows")

--- a/backend/internal/api/handlers/release.go
+++ b/backend/internal/api/handlers/release.go
@@ -1,0 +1,533 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"psychic-homily-backend/internal/api/middleware"
+	apperrors "psychic-homily-backend/internal/errors"
+	"psychic-homily-backend/internal/logger"
+	"psychic-homily-backend/internal/services"
+)
+
+type ReleaseHandler struct {
+	releaseService  services.ReleaseServiceInterface
+	artistService   services.ArtistServiceInterface
+	auditLogService services.AuditLogServiceInterface
+}
+
+func NewReleaseHandler(releaseService services.ReleaseServiceInterface, artistService services.ArtistServiceInterface, auditLogService services.AuditLogServiceInterface) *ReleaseHandler {
+	return &ReleaseHandler{
+		releaseService:  releaseService,
+		artistService:   artistService,
+		auditLogService: auditLogService,
+	}
+}
+
+// ============================================================================
+// List Releases
+// ============================================================================
+
+// ListReleasesRequest represents the request for listing releases
+type ListReleasesRequest struct {
+	ArtistID    uint   `query:"artist_id" required:"false" doc:"Filter by artist ID" example:"1"`
+	ReleaseType string `query:"release_type" required:"false" doc:"Filter by release type" example:"lp"`
+	Year        int    `query:"year" required:"false" doc:"Filter by release year" example:"2024"`
+}
+
+// ListReleasesResponse represents the response for listing releases
+type ListReleasesResponse struct {
+	Body struct {
+		Releases []*services.ReleaseListResponse `json:"releases" doc:"List of releases"`
+		Count    int                              `json:"count" doc:"Number of releases"`
+	}
+}
+
+// ListReleasesHandler handles GET /releases
+func (h *ReleaseHandler) ListReleasesHandler(ctx context.Context, req *ListReleasesRequest) (*ListReleasesResponse, error) {
+	filters := make(map[string]interface{})
+
+	if req.ArtistID > 0 {
+		filters["artist_id"] = req.ArtistID
+	}
+	if req.ReleaseType != "" {
+		filters["release_type"] = req.ReleaseType
+	}
+	if req.Year > 0 {
+		filters["year"] = req.Year
+	}
+
+	releases, err := h.releaseService.ListReleases(filters)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Failed to fetch releases", err)
+	}
+
+	resp := &ListReleasesResponse{}
+	resp.Body.Releases = releases
+	resp.Body.Count = len(releases)
+
+	return resp, nil
+}
+
+// ============================================================================
+// Get Release
+// ============================================================================
+
+// GetReleaseRequest represents the request for getting a single release
+type GetReleaseRequest struct {
+	ReleaseID string `path:"release_id" doc:"Release ID or slug" example:"nevermind"`
+}
+
+// GetReleaseResponse represents the response for the get release endpoint
+type GetReleaseResponse struct {
+	Body *services.ReleaseDetailResponse
+}
+
+// GetReleaseHandler handles GET /releases/{release_id}
+func (h *ReleaseHandler) GetReleaseHandler(ctx context.Context, req *GetReleaseRequest) (*GetReleaseResponse, error) {
+	var release *services.ReleaseDetailResponse
+	var err error
+
+	// Try to parse as numeric ID first
+	if id, parseErr := strconv.ParseUint(req.ReleaseID, 10, 32); parseErr == nil {
+		release, err = h.releaseService.GetRelease(uint(id))
+	} else {
+		// Fall back to slug lookup
+		release, err = h.releaseService.GetReleaseBySlug(req.ReleaseID)
+	}
+
+	if err != nil {
+		var releaseErr *apperrors.ReleaseError
+		if errors.As(err, &releaseErr) && releaseErr.Code == apperrors.CodeReleaseNotFound {
+			return nil, huma.Error404NotFound("Release not found")
+		}
+		return nil, huma.Error500InternalServerError("Failed to fetch release", err)
+	}
+
+	return &GetReleaseResponse{Body: release}, nil
+}
+
+// ============================================================================
+// Create Release
+// ============================================================================
+
+// CreateReleaseRequest represents the request for creating a release
+type CreateReleaseRequest struct {
+	Body struct {
+		Title       string `json:"title" doc:"Release title" example:"Nevermind"`
+		ReleaseType string `json:"release_type,omitempty" required:"false" doc:"Release type (lp, ep, single, compilation, live, remix, demo)" example:"lp"`
+		ReleaseYear *int   `json:"release_year,omitempty" required:"false" doc:"Release year" example:"1991"`
+		ReleaseDate *string `json:"release_date,omitempty" required:"false" doc:"Release date (YYYY-MM-DD)" example:"1991-09-24"`
+		CoverArtURL *string `json:"cover_art_url,omitempty" required:"false" doc:"Cover art URL"`
+		Description *string `json:"description,omitempty" required:"false" doc:"Description"`
+		Artists     []CreateReleaseArtistInput `json:"artists,omitempty" required:"false" doc:"Artists with roles"`
+		ExternalLinks []CreateReleaseLinkInput `json:"external_links,omitempty" required:"false" doc:"External links (Bandcamp, Spotify, etc.)"`
+	}
+}
+
+// CreateReleaseArtistInput represents artist input for release creation
+type CreateReleaseArtistInput struct {
+	ArtistID uint   `json:"artist_id" doc:"Artist ID"`
+	Role     string `json:"role,omitempty" required:"false" doc:"Role (main, featured, producer, remixer, composer, dj)" example:"main"`
+}
+
+// CreateReleaseLinkInput represents external link input for release creation
+type CreateReleaseLinkInput struct {
+	Platform string `json:"platform" doc:"Platform name (bandcamp, spotify, discogs, etc.)" example:"bandcamp"`
+	URL      string `json:"url" doc:"URL to the release on the platform"`
+}
+
+// CreateReleaseResponse represents the response for creating a release
+type CreateReleaseResponse struct {
+	Body *services.ReleaseDetailResponse
+}
+
+// CreateReleaseHandler handles POST /releases
+func (h *ReleaseHandler) CreateReleaseHandler(ctx context.Context, req *CreateReleaseRequest) (*CreateReleaseResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	// Verify admin access
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil || !user.IsAdmin {
+		return nil, huma.Error403Forbidden("Admin access required")
+	}
+
+	if req.Body.Title == "" {
+		return nil, huma.Error400BadRequest("Title is required")
+	}
+
+	// Convert handler types to service types
+	artists := make([]services.CreateReleaseArtistEntry, len(req.Body.Artists))
+	for i, a := range req.Body.Artists {
+		artists[i] = services.CreateReleaseArtistEntry{
+			ArtistID: a.ArtistID,
+			Role:     a.Role,
+		}
+	}
+	links := make([]services.CreateReleaseLinkEntry, len(req.Body.ExternalLinks))
+	for i, l := range req.Body.ExternalLinks {
+		links[i] = services.CreateReleaseLinkEntry{
+			Platform: l.Platform,
+			URL:      l.URL,
+		}
+	}
+
+	serviceReq := &services.CreateReleaseRequest{
+		Title:         req.Body.Title,
+		ReleaseType:   req.Body.ReleaseType,
+		ReleaseYear:   req.Body.ReleaseYear,
+		ReleaseDate:   req.Body.ReleaseDate,
+		CoverArtURL:   req.Body.CoverArtURL,
+		Description:   req.Body.Description,
+		Artists:       artists,
+		ExternalLinks: links,
+	}
+
+	release, err := h.releaseService.CreateRelease(serviceReq)
+	if err != nil {
+		logger.FromContext(ctx).Error("create_release_failed",
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to create release (request_id: %s)", requestID),
+		)
+	}
+
+	// Audit log (fire and forget)
+	if h.auditLogService != nil {
+		go func() {
+			h.auditLogService.LogAction(user.ID, "create_release", "release", release.ID, nil)
+		}()
+	}
+
+	logger.FromContext(ctx).Info("release_created",
+		"release_id", release.ID,
+		"admin_id", user.ID,
+		"request_id", requestID,
+	)
+
+	return &CreateReleaseResponse{Body: release}, nil
+}
+
+// ============================================================================
+// Update Release
+// ============================================================================
+
+// UpdateReleaseRequest represents the request for updating a release
+type UpdateReleaseRequest struct {
+	ReleaseID string `path:"release_id" doc:"Release ID or slug" example:"1"`
+	Body      struct {
+		Title       *string `json:"title,omitempty" required:"false" doc:"Release title"`
+		ReleaseType *string `json:"release_type,omitempty" required:"false" doc:"Release type"`
+		ReleaseYear *int    `json:"release_year,omitempty" required:"false" doc:"Release year"`
+		ReleaseDate *string `json:"release_date,omitempty" required:"false" doc:"Release date (YYYY-MM-DD)"`
+		CoverArtURL *string `json:"cover_art_url,omitempty" required:"false" doc:"Cover art URL"`
+		Description *string `json:"description,omitempty" required:"false" doc:"Description"`
+	}
+}
+
+// UpdateReleaseResponse represents the response for updating a release
+type UpdateReleaseResponse struct {
+	Body *services.ReleaseDetailResponse
+}
+
+// UpdateReleaseHandler handles PUT /releases/{release_id}
+func (h *ReleaseHandler) UpdateReleaseHandler(ctx context.Context, req *UpdateReleaseRequest) (*UpdateReleaseResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	// Verify admin access
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil || !user.IsAdmin {
+		return nil, huma.Error403Forbidden("Admin access required")
+	}
+
+	// Resolve release ID
+	releaseID, err := h.resolveReleaseID(req.ReleaseID)
+	if err != nil {
+		return nil, err
+	}
+
+	serviceReq := &services.UpdateReleaseRequest{
+		Title:       req.Body.Title,
+		ReleaseType: req.Body.ReleaseType,
+		ReleaseYear: req.Body.ReleaseYear,
+		ReleaseDate: req.Body.ReleaseDate,
+		CoverArtURL: req.Body.CoverArtURL,
+		Description: req.Body.Description,
+	}
+
+	release, err := h.releaseService.UpdateRelease(releaseID, serviceReq)
+	if err != nil {
+		var releaseErr *apperrors.ReleaseError
+		if errors.As(err, &releaseErr) && releaseErr.Code == apperrors.CodeReleaseNotFound {
+			return nil, huma.Error404NotFound("Release not found")
+		}
+		logger.FromContext(ctx).Error("update_release_failed",
+			"release_id", releaseID,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to update release (request_id: %s)", requestID),
+		)
+	}
+
+	// Audit log (fire and forget)
+	if h.auditLogService != nil {
+		go func() {
+			h.auditLogService.LogAction(user.ID, "edit_release", "release", releaseID, nil)
+		}()
+	}
+
+	logger.FromContext(ctx).Info("release_updated",
+		"release_id", releaseID,
+		"admin_id", user.ID,
+		"request_id", requestID,
+	)
+
+	return &UpdateReleaseResponse{Body: release}, nil
+}
+
+// ============================================================================
+// Delete Release
+// ============================================================================
+
+// DeleteReleaseRequest represents the request for deleting a release
+type DeleteReleaseRequest struct {
+	ReleaseID string `path:"release_id" doc:"Release ID" example:"1"`
+}
+
+// DeleteReleaseHandler handles DELETE /releases/{release_id}
+func (h *ReleaseHandler) DeleteReleaseHandler(ctx context.Context, req *DeleteReleaseRequest) (*struct{}, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	// Verify admin access
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil || !user.IsAdmin {
+		return nil, huma.Error403Forbidden("Admin access required")
+	}
+
+	// Resolve release ID
+	releaseID, err := h.resolveReleaseID(req.ReleaseID)
+	if err != nil {
+		return nil, err
+	}
+
+	err = h.releaseService.DeleteRelease(releaseID)
+	if err != nil {
+		var releaseErr *apperrors.ReleaseError
+		if errors.As(err, &releaseErr) && releaseErr.Code == apperrors.CodeReleaseNotFound {
+			return nil, huma.Error404NotFound("Release not found")
+		}
+		logger.FromContext(ctx).Error("delete_release_failed",
+			"release_id", releaseID,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to delete release (request_id: %s)", requestID),
+		)
+	}
+
+	// Audit log (fire and forget)
+	if h.auditLogService != nil {
+		go func() {
+			h.auditLogService.LogAction(user.ID, "delete_release", "release", releaseID, nil)
+		}()
+	}
+
+	logger.FromContext(ctx).Info("release_deleted",
+		"release_id", releaseID,
+		"admin_id", user.ID,
+		"request_id", requestID,
+	)
+
+	return nil, nil
+}
+
+// ============================================================================
+// Artist Releases (Discography)
+// ============================================================================
+
+// GetArtistReleasesRequest represents the request for getting an artist's releases
+type GetArtistReleasesRequest struct {
+	ArtistID string `path:"artist_id" doc:"Artist ID or slug" example:"nirvana"`
+}
+
+// GetArtistReleasesResponse represents the response for the artist releases endpoint
+type GetArtistReleasesResponse struct {
+	Body struct {
+		Releases []*services.ReleaseListResponse `json:"releases" doc:"List of releases"`
+		Count    int                              `json:"count" doc:"Number of releases"`
+	}
+}
+
+// GetArtistReleasesHandler handles GET /artists/{artist_id}/releases
+func (h *ReleaseHandler) GetArtistReleasesHandler(ctx context.Context, req *GetArtistReleasesRequest) (*GetArtistReleasesResponse, error) {
+	// Resolve artist ID from numeric ID or slug
+	var artistID uint
+	if id, parseErr := strconv.ParseUint(req.ArtistID, 10, 32); parseErr == nil {
+		artistID = uint(id)
+	} else {
+		// Look up by slug to get the ID
+		artist, err := h.artistService.GetArtistBySlug(req.ArtistID)
+		if err != nil {
+			var artistErr *apperrors.ArtistError
+			if errors.As(err, &artistErr) && artistErr.Code == apperrors.CodeArtistNotFound {
+				return nil, huma.Error404NotFound("Artist not found")
+			}
+			return nil, huma.Error500InternalServerError("Failed to fetch artist", err)
+		}
+		artistID = artist.ID
+	}
+
+	releases, err := h.releaseService.GetReleasesForArtist(artistID)
+	if err != nil {
+		var artistErr *apperrors.ArtistError
+		if errors.As(err, &artistErr) && artistErr.Code == apperrors.CodeArtistNotFound {
+			return nil, huma.Error404NotFound("Artist not found")
+		}
+		return nil, huma.Error500InternalServerError("Failed to fetch releases", err)
+	}
+
+	resp := &GetArtistReleasesResponse{}
+	resp.Body.Releases = releases
+	resp.Body.Count = len(releases)
+
+	return resp, nil
+}
+
+// ============================================================================
+// External Links
+// ============================================================================
+
+// AddExternalLinkRequest represents the request for adding an external link
+type AddExternalLinkRequest struct {
+	ReleaseID string `path:"release_id" doc:"Release ID" example:"1"`
+	Body      struct {
+		Platform string `json:"platform" doc:"Platform name (bandcamp, spotify, etc.)" example:"bandcamp"`
+		URL      string `json:"url" doc:"URL to the release"`
+	}
+}
+
+// AddExternalLinkResponse represents the response for adding an external link
+type AddExternalLinkResponse struct {
+	Body *services.ReleaseExternalLinkResponse
+}
+
+// AddExternalLinkHandler handles POST /releases/{release_id}/links
+func (h *ReleaseHandler) AddExternalLinkHandler(ctx context.Context, req *AddExternalLinkRequest) (*AddExternalLinkResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	// Verify admin access
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil || !user.IsAdmin {
+		return nil, huma.Error403Forbidden("Admin access required")
+	}
+
+	releaseID, err := strconv.ParseUint(req.ReleaseID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid release ID")
+	}
+
+	if req.Body.Platform == "" || req.Body.URL == "" {
+		return nil, huma.Error400BadRequest("Platform and URL are required")
+	}
+
+	link, err := h.releaseService.AddExternalLink(uint(releaseID), req.Body.Platform, req.Body.URL)
+	if err != nil {
+		var releaseErr *apperrors.ReleaseError
+		if errors.As(err, &releaseErr) && releaseErr.Code == apperrors.CodeReleaseNotFound {
+			return nil, huma.Error404NotFound("Release not found")
+		}
+		logger.FromContext(ctx).Error("add_external_link_failed",
+			"release_id", releaseID,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to add external link (request_id: %s)", requestID),
+		)
+	}
+
+	// Audit log (fire and forget)
+	if h.auditLogService != nil {
+		go func() {
+			h.auditLogService.LogAction(user.ID, "add_release_link", "release", uint(releaseID), nil)
+		}()
+	}
+
+	return &AddExternalLinkResponse{Body: link}, nil
+}
+
+// RemoveExternalLinkRequest represents the request for removing an external link
+type RemoveExternalLinkRequest struct {
+	ReleaseID string `path:"release_id" doc:"Release ID" example:"1"`
+	LinkID    string `path:"link_id" doc:"Link ID" example:"1"`
+}
+
+// RemoveExternalLinkHandler handles DELETE /releases/{release_id}/links/{link_id}
+func (h *ReleaseHandler) RemoveExternalLinkHandler(ctx context.Context, req *RemoveExternalLinkRequest) (*struct{}, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	// Verify admin access
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil || !user.IsAdmin {
+		return nil, huma.Error403Forbidden("Admin access required")
+	}
+
+	linkID, err := strconv.ParseUint(req.LinkID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid link ID")
+	}
+
+	err = h.releaseService.RemoveExternalLink(uint(linkID))
+	if err != nil {
+		logger.FromContext(ctx).Error("remove_external_link_failed",
+			"link_id", linkID,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to remove external link (request_id: %s)", requestID),
+		)
+	}
+
+	// Audit log (fire and forget)
+	if h.auditLogService != nil {
+		releaseID, _ := strconv.ParseUint(req.ReleaseID, 10, 32)
+		go func() {
+			h.auditLogService.LogAction(user.ID, "remove_release_link", "release", uint(releaseID), nil)
+		}()
+	}
+
+	return nil, nil
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+// resolveReleaseID tries to parse the ID as a number first, then falls back to slug lookup
+func (h *ReleaseHandler) resolveReleaseID(idOrSlug string) (uint, error) {
+	if id, parseErr := strconv.ParseUint(idOrSlug, 10, 32); parseErr == nil {
+		return uint(id), nil
+	}
+
+	// Fall back to slug lookup
+	release, err := h.releaseService.GetReleaseBySlug(idOrSlug)
+	if err != nil {
+		var releaseErr *apperrors.ReleaseError
+		if errors.As(err, &releaseErr) && releaseErr.Code == apperrors.CodeReleaseNotFound {
+			return 0, huma.Error404NotFound("Release not found")
+		}
+		return 0, huma.Error500InternalServerError("Failed to fetch release", err)
+	}
+
+	return release.ID, nil
+}

--- a/backend/internal/api/handlers/release_integration_test.go
+++ b/backend/internal/api/handlers/release_integration_test.go
@@ -1,0 +1,418 @@
+package handlers
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"psychic-homily-backend/internal/services"
+)
+
+type ReleaseHandlerIntegrationSuite struct {
+	suite.Suite
+	deps    *handlerIntegrationDeps
+	handler *ReleaseHandler
+}
+
+func (s *ReleaseHandlerIntegrationSuite) SetupSuite() {
+	s.deps = setupHandlerIntegrationDeps(s.T())
+	s.handler = NewReleaseHandler(s.deps.releaseService, s.deps.artistService, s.deps.auditLogService)
+}
+
+func (s *ReleaseHandlerIntegrationSuite) TearDownTest() {
+	cleanupTables(s.deps.db)
+}
+
+func (s *ReleaseHandlerIntegrationSuite) TearDownSuite() {
+	if s.deps.container != nil {
+		s.deps.container.Terminate(s.deps.ctx)
+	}
+}
+
+func TestReleaseHandlerIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	suite.Run(t, new(ReleaseHandlerIntegrationSuite))
+}
+
+// --- Helpers ---
+
+func (s *ReleaseHandlerIntegrationSuite) createReleaseViaService(title string) *services.ReleaseDetailResponse {
+	resp, err := s.deps.releaseService.CreateRelease(&services.CreateReleaseRequest{Title: title})
+	s.Require().NoError(err)
+	return resp
+}
+
+func (s *ReleaseHandlerIntegrationSuite) createArtistViaService(name string) uint {
+	resp, err := s.deps.artistService.CreateArtist(&services.CreateArtistRequest{Name: name})
+	s.Require().NoError(err)
+	return resp.ID
+}
+
+// --- ListReleasesHandler ---
+
+func (s *ReleaseHandlerIntegrationSuite) TestListReleases_Success() {
+	s.createReleaseViaService("Album A")
+	s.createReleaseViaService("Album B")
+	s.createReleaseViaService("Album C")
+
+	req := &ListReleasesRequest{}
+	resp, err := s.handler.ListReleasesHandler(s.deps.ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.GreaterOrEqual(resp.Body.Count, 3)
+}
+
+func (s *ReleaseHandlerIntegrationSuite) TestListReleases_Empty() {
+	req := &ListReleasesRequest{}
+	resp, err := s.handler.ListReleasesHandler(s.deps.ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal(0, resp.Body.Count)
+}
+
+func (s *ReleaseHandlerIntegrationSuite) TestListReleases_FilterByType() {
+	s.deps.releaseService.CreateRelease(&services.CreateReleaseRequest{Title: "LP Album", ReleaseType: "lp"})
+	s.deps.releaseService.CreateRelease(&services.CreateReleaseRequest{Title: "EP Release", ReleaseType: "ep"})
+
+	req := &ListReleasesRequest{ReleaseType: "ep"}
+	resp, err := s.handler.ListReleasesHandler(s.deps.ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal(1, resp.Body.Count)
+	s.Equal("EP Release", resp.Body.Releases[0].Title)
+}
+
+// --- GetReleaseHandler ---
+
+func (s *ReleaseHandlerIntegrationSuite) TestGetRelease_ByID() {
+	release := s.createReleaseViaService("Test Album")
+
+	req := &GetReleaseRequest{ReleaseID: fmt.Sprintf("%d", release.ID)}
+	resp, err := s.handler.GetReleaseHandler(s.deps.ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal("Test Album", resp.Body.Title)
+}
+
+func (s *ReleaseHandlerIntegrationSuite) TestGetRelease_BySlug() {
+	s.createReleaseViaService("Slug Album")
+
+	req := &GetReleaseRequest{ReleaseID: "slug-album"}
+	resp, err := s.handler.GetReleaseHandler(s.deps.ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal("Slug Album", resp.Body.Title)
+}
+
+func (s *ReleaseHandlerIntegrationSuite) TestGetRelease_NotFound() {
+	req := &GetReleaseRequest{ReleaseID: "99999"}
+	_, err := s.handler.GetReleaseHandler(s.deps.ctx, req)
+	assertHumaError(s.T(), err, 404)
+}
+
+// --- CreateReleaseHandler ---
+
+func (s *ReleaseHandlerIntegrationSuite) TestCreateRelease_AdminSuccess() {
+	admin := createAdminUser(s.deps.db)
+	ctx := ctxWithUser(admin)
+
+	year := 2024
+	req := &CreateReleaseRequest{}
+	req.Body.Title = "New Album"
+	req.Body.ReleaseType = "lp"
+	req.Body.ReleaseYear = &year
+
+	resp, err := s.handler.CreateReleaseHandler(ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal("New Album", resp.Body.Title)
+	s.Equal("lp", resp.Body.ReleaseType)
+	s.Equal(2024, *resp.Body.ReleaseYear)
+}
+
+func (s *ReleaseHandlerIntegrationSuite) TestCreateRelease_WithArtists() {
+	admin := createAdminUser(s.deps.db)
+	ctx := ctxWithUser(admin)
+
+	artistID := s.createArtistViaService("Test Artist")
+
+	req := &CreateReleaseRequest{}
+	req.Body.Title = "Artist Album"
+	req.Body.Artists = []CreateReleaseArtistInput{
+		{ArtistID: artistID, Role: "main"},
+	}
+
+	resp, err := s.handler.CreateReleaseHandler(ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Len(resp.Body.Artists, 1)
+	s.Equal("Test Artist", resp.Body.Artists[0].Name)
+}
+
+func (s *ReleaseHandlerIntegrationSuite) TestCreateRelease_NonAdminForbidden() {
+	user := createTestUser(s.deps.db)
+	ctx := ctxWithUser(user)
+
+	req := &CreateReleaseRequest{}
+	req.Body.Title = "Forbidden Album"
+
+	_, err := s.handler.CreateReleaseHandler(ctx, req)
+	assertHumaError(s.T(), err, 403)
+}
+
+func (s *ReleaseHandlerIntegrationSuite) TestCreateRelease_NoAuth() {
+	req := &CreateReleaseRequest{}
+	req.Body.Title = "No Auth Album"
+
+	_, err := s.handler.CreateReleaseHandler(s.deps.ctx, req)
+	assertHumaError(s.T(), err, 403)
+}
+
+func (s *ReleaseHandlerIntegrationSuite) TestCreateRelease_EmptyTitle() {
+	admin := createAdminUser(s.deps.db)
+	ctx := ctxWithUser(admin)
+
+	req := &CreateReleaseRequest{}
+	req.Body.Title = ""
+
+	_, err := s.handler.CreateReleaseHandler(ctx, req)
+	assertHumaError(s.T(), err, 400)
+}
+
+// --- UpdateReleaseHandler ---
+
+func (s *ReleaseHandlerIntegrationSuite) TestUpdateRelease_Success() {
+	admin := createAdminUser(s.deps.db)
+	release := s.createReleaseViaService("Original Title")
+
+	ctx := ctxWithUser(admin)
+	newTitle := "Updated Title"
+	req := &UpdateReleaseRequest{ReleaseID: fmt.Sprintf("%d", release.ID)}
+	req.Body.Title = &newTitle
+
+	resp, err := s.handler.UpdateReleaseHandler(ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal("Updated Title", resp.Body.Title)
+}
+
+func (s *ReleaseHandlerIntegrationSuite) TestUpdateRelease_BySlug() {
+	admin := createAdminUser(s.deps.db)
+	s.createReleaseViaService("Slug Update Album")
+
+	ctx := ctxWithUser(admin)
+	newType := "ep"
+	req := &UpdateReleaseRequest{ReleaseID: "slug-update-album"}
+	req.Body.ReleaseType = &newType
+
+	resp, err := s.handler.UpdateReleaseHandler(ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal("ep", resp.Body.ReleaseType)
+}
+
+func (s *ReleaseHandlerIntegrationSuite) TestUpdateRelease_NotFound() {
+	admin := createAdminUser(s.deps.db)
+	ctx := ctxWithUser(admin)
+	newTitle := "New Title"
+	req := &UpdateReleaseRequest{ReleaseID: "99999"}
+	req.Body.Title = &newTitle
+
+	_, err := s.handler.UpdateReleaseHandler(ctx, req)
+	assertHumaError(s.T(), err, 404)
+}
+
+func (s *ReleaseHandlerIntegrationSuite) TestUpdateRelease_NonAdminForbidden() {
+	user := createTestUser(s.deps.db)
+	release := s.createReleaseViaService("Forbidden Update")
+
+	ctx := ctxWithUser(user)
+	newTitle := "Hacked Title"
+	req := &UpdateReleaseRequest{ReleaseID: fmt.Sprintf("%d", release.ID)}
+	req.Body.Title = &newTitle
+
+	_, err := s.handler.UpdateReleaseHandler(ctx, req)
+	assertHumaError(s.T(), err, 403)
+}
+
+// --- DeleteReleaseHandler ---
+
+func (s *ReleaseHandlerIntegrationSuite) TestDeleteRelease_Success() {
+	admin := createAdminUser(s.deps.db)
+	release := s.createReleaseViaService("Deletable Album")
+
+	ctx := ctxWithUser(admin)
+	req := &DeleteReleaseRequest{ReleaseID: fmt.Sprintf("%d", release.ID)}
+	_, err := s.handler.DeleteReleaseHandler(ctx, req)
+	s.NoError(err)
+
+	// Verify release is gone
+	getReq := &GetReleaseRequest{ReleaseID: fmt.Sprintf("%d", release.ID)}
+	_, err = s.handler.GetReleaseHandler(s.deps.ctx, getReq)
+	assertHumaError(s.T(), err, 404)
+}
+
+func (s *ReleaseHandlerIntegrationSuite) TestDeleteRelease_NotFound() {
+	admin := createAdminUser(s.deps.db)
+	ctx := ctxWithUser(admin)
+	req := &DeleteReleaseRequest{ReleaseID: "99999"}
+
+	_, err := s.handler.DeleteReleaseHandler(ctx, req)
+	assertHumaError(s.T(), err, 404)
+}
+
+func (s *ReleaseHandlerIntegrationSuite) TestDeleteRelease_NonAdminForbidden() {
+	user := createTestUser(s.deps.db)
+	release := s.createReleaseViaService("Protected Album")
+
+	ctx := ctxWithUser(user)
+	req := &DeleteReleaseRequest{ReleaseID: fmt.Sprintf("%d", release.ID)}
+
+	_, err := s.handler.DeleteReleaseHandler(ctx, req)
+	assertHumaError(s.T(), err, 403)
+}
+
+// --- GetArtistReleasesHandler ---
+
+func (s *ReleaseHandlerIntegrationSuite) TestGetArtistReleases_Success() {
+	artistID := s.createArtistViaService("Discography Artist")
+
+	s.deps.releaseService.CreateRelease(&services.CreateReleaseRequest{
+		Title:   "Album One",
+		Artists: []services.CreateReleaseArtistEntry{{ArtistID: artistID, Role: "main"}},
+	})
+	s.deps.releaseService.CreateRelease(&services.CreateReleaseRequest{
+		Title:   "Album Two",
+		Artists: []services.CreateReleaseArtistEntry{{ArtistID: artistID, Role: "main"}},
+	})
+
+	req := &GetArtistReleasesRequest{ArtistID: fmt.Sprintf("%d", artistID)}
+	resp, err := s.handler.GetArtistReleasesHandler(s.deps.ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal(2, resp.Body.Count)
+}
+
+func (s *ReleaseHandlerIntegrationSuite) TestGetArtistReleases_BySlug() {
+	artistID := s.createArtistViaService("Slug Discography Artist")
+
+	s.deps.releaseService.CreateRelease(&services.CreateReleaseRequest{
+		Title:   "Slug Album",
+		Artists: []services.CreateReleaseArtistEntry{{ArtistID: artistID, Role: "main"}},
+	})
+
+	req := &GetArtistReleasesRequest{ArtistID: "slug-discography-artist"}
+	resp, err := s.handler.GetArtistReleasesHandler(s.deps.ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal(1, resp.Body.Count)
+}
+
+func (s *ReleaseHandlerIntegrationSuite) TestGetArtistReleases_ArtistNotFound() {
+	req := &GetArtistReleasesRequest{ArtistID: "99999"}
+	_, err := s.handler.GetArtistReleasesHandler(s.deps.ctx, req)
+	assertHumaError(s.T(), err, 404)
+}
+
+func (s *ReleaseHandlerIntegrationSuite) TestGetArtistReleases_Empty() {
+	artistID := s.createArtistViaService("Empty Discography")
+
+	req := &GetArtistReleasesRequest{ArtistID: fmt.Sprintf("%d", artistID)}
+	resp, err := s.handler.GetArtistReleasesHandler(s.deps.ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal(0, resp.Body.Count)
+}
+
+// --- AddExternalLinkHandler ---
+
+func (s *ReleaseHandlerIntegrationSuite) TestAddExternalLink_Success() {
+	admin := createAdminUser(s.deps.db)
+	release := s.createReleaseViaService("Link Album")
+
+	ctx := ctxWithUser(admin)
+	req := &AddExternalLinkRequest{ReleaseID: fmt.Sprintf("%d", release.ID)}
+	req.Body.Platform = "bandcamp"
+	req.Body.URL = "https://test.bandcamp.com/album/test"
+
+	resp, err := s.handler.AddExternalLinkHandler(ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal("bandcamp", resp.Body.Platform)
+	s.Equal("https://test.bandcamp.com/album/test", resp.Body.URL)
+}
+
+func (s *ReleaseHandlerIntegrationSuite) TestAddExternalLink_ReleaseNotFound() {
+	admin := createAdminUser(s.deps.db)
+	ctx := ctxWithUser(admin)
+	req := &AddExternalLinkRequest{ReleaseID: "99999"}
+	req.Body.Platform = "bandcamp"
+	req.Body.URL = "https://test.bandcamp.com"
+
+	_, err := s.handler.AddExternalLinkHandler(ctx, req)
+	assertHumaError(s.T(), err, 404)
+}
+
+func (s *ReleaseHandlerIntegrationSuite) TestAddExternalLink_NonAdminForbidden() {
+	user := createTestUser(s.deps.db)
+	release := s.createReleaseViaService("Protected Link Album")
+
+	ctx := ctxWithUser(user)
+	req := &AddExternalLinkRequest{ReleaseID: fmt.Sprintf("%d", release.ID)}
+	req.Body.Platform = "bandcamp"
+	req.Body.URL = "https://test.bandcamp.com"
+
+	_, err := s.handler.AddExternalLinkHandler(ctx, req)
+	assertHumaError(s.T(), err, 403)
+}
+
+// --- RemoveExternalLinkHandler ---
+
+func (s *ReleaseHandlerIntegrationSuite) TestRemoveExternalLink_Success() {
+	admin := createAdminUser(s.deps.db)
+	release, err := s.deps.releaseService.CreateRelease(&services.CreateReleaseRequest{
+		Title: "Remove Link Album",
+		ExternalLinks: []services.CreateReleaseLinkEntry{
+			{Platform: "spotify", URL: "https://open.spotify.com/album/abc"},
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(release.ExternalLinks, 1)
+
+	ctx := ctxWithUser(admin)
+	req := &RemoveExternalLinkRequest{
+		ReleaseID: fmt.Sprintf("%d", release.ID),
+		LinkID:    fmt.Sprintf("%d", release.ExternalLinks[0].ID),
+	}
+
+	_, err = s.handler.RemoveExternalLinkHandler(ctx, req)
+	s.NoError(err)
+
+	// Verify link is gone
+	refreshed, err := s.deps.releaseService.GetRelease(release.ID)
+	s.Require().NoError(err)
+	s.Empty(refreshed.ExternalLinks)
+}
+
+func (s *ReleaseHandlerIntegrationSuite) TestRemoveExternalLink_NonAdminForbidden() {
+	user := createTestUser(s.deps.db)
+	release, err := s.deps.releaseService.CreateRelease(&services.CreateReleaseRequest{
+		Title: "Protected Remove Link",
+		ExternalLinks: []services.CreateReleaseLinkEntry{
+			{Platform: "spotify", URL: "https://open.spotify.com/album/abc"},
+		},
+	})
+	s.Require().NoError(err)
+
+	ctx := ctxWithUser(user)
+	req := &RemoveExternalLinkRequest{
+		ReleaseID: fmt.Sprintf("%d", release.ID),
+		LinkID:    fmt.Sprintf("%d", release.ExternalLinks[0].ID),
+	}
+
+	_, err = s.handler.RemoveExternalLinkHandler(ctx, req)
+	assertHumaError(s.T(), err, 403)
+}

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -83,6 +83,7 @@ func SetupRoutes(router *chi.Mux, sc *services.ServiceContainer, cfg *config.Con
 
 	setupShowRoutes(router, api, protectedGroup, sc, cfg)
 	setupArtistRoutes(api, protectedGroup, sc)
+	setupReleaseRoutes(api, protectedGroup, sc)
 	setupVenueRoutes(api, protectedGroup, sc)
 	setupCalendarRoutes(router, protectedGroup, sc, cfg)
 	setupSavedShowRoutes(protectedGroup, sc)
@@ -277,6 +278,22 @@ func setupArtistRoutes(api huma.API, protected *huma.Group, sc *services.Service
 	// Protected artist endpoints
 	huma.Delete(protected, "/artists/{artist_id}", artistHandler.DeleteArtistHandler)
 	huma.Patch(protected, "/admin/artists/{artist_id}", artistHandler.AdminUpdateArtistHandler)
+}
+
+func setupReleaseRoutes(api huma.API, protected *huma.Group, sc *services.ServiceContainer) {
+	releaseHandler := handlers.NewReleaseHandler(sc.Release, sc.Artist, sc.AuditLog)
+
+	// Public release endpoints
+	huma.Get(api, "/releases", releaseHandler.ListReleasesHandler)
+	huma.Get(api, "/releases/{release_id}", releaseHandler.GetReleaseHandler)
+	huma.Get(api, "/artists/{artist_id}/releases", releaseHandler.GetArtistReleasesHandler)
+
+	// Protected release endpoints (admin-only checks inside handlers)
+	huma.Post(protected, "/releases", releaseHandler.CreateReleaseHandler)
+	huma.Put(protected, "/releases/{release_id}", releaseHandler.UpdateReleaseHandler)
+	huma.Delete(protected, "/releases/{release_id}", releaseHandler.DeleteReleaseHandler)
+	huma.Post(protected, "/releases/{release_id}/links", releaseHandler.AddExternalLinkHandler)
+	huma.Delete(protected, "/releases/{release_id}/links/{link_id}", releaseHandler.RemoveExternalLinkHandler)
 }
 
 func setupVenueRoutes(api huma.API, protected *huma.Group, sc *services.ServiceContainer) {

--- a/backend/internal/errors/release.go
+++ b/backend/internal/errors/release.go
@@ -1,0 +1,50 @@
+package errors
+
+import (
+	"fmt"
+)
+
+// Release error codes
+const (
+	CodeReleaseNotFound = "RELEASE_NOT_FOUND"
+	CodeReleaseExists   = "RELEASE_EXISTS"
+)
+
+// ReleaseError represents a release-related error with additional context.
+type ReleaseError struct {
+	Code      string
+	Message   string
+	Internal  error
+	RequestID string
+	ReleaseID uint
+}
+
+// Error implements the error interface.
+func (e *ReleaseError) Error() string {
+	if e.Internal != nil {
+		return fmt.Sprintf("%s: %s (internal: %v)", e.Code, e.Message, e.Internal)
+	}
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
+// Unwrap returns the internal error for errors.Is/As compatibility.
+func (e *ReleaseError) Unwrap() error {
+	return e.Internal
+}
+
+// ErrReleaseNotFound creates a release not found error.
+func ErrReleaseNotFound(releaseID uint) *ReleaseError {
+	return &ReleaseError{
+		Code:      CodeReleaseNotFound,
+		Message:   "Release not found",
+		ReleaseID: releaseID,
+	}
+}
+
+// ErrReleaseExists creates a release-already-exists error.
+func ErrReleaseExists(title string) *ReleaseError {
+	return &ReleaseError{
+		Code:    CodeReleaseExists,
+		Message: fmt.Sprintf("Release with title '%s' already exists", title),
+	}
+}

--- a/backend/internal/services/container.go
+++ b/backend/internal/services/container.go
@@ -19,6 +19,7 @@ type ServiceContainer struct {
 	AuditLog      *AuditLogService
 	Calendar      *CalendarService
 	FavoriteVenue *FavoriteVenueService
+	Release       *ReleaseService
 	SavedShow     *SavedShowService
 	Show          *ShowService
 	ShowReport    *ShowReportService
@@ -66,6 +67,7 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 		AuditLog:      NewAuditLogService(database),
 		Calendar:      NewCalendarService(database, savedShow),
 		FavoriteVenue: NewFavoriteVenueService(database),
+		Release:       NewReleaseService(database),
 		SavedShow:     savedShow,
 		Show:          NewShowService(database),
 		ShowReport:    NewShowReportService(database),

--- a/backend/internal/services/interfaces.go
+++ b/backend/internal/services/interfaces.go
@@ -300,6 +300,19 @@ type AdminStatsServiceInterface interface {
 	GetDashboardStats() (*AdminDashboardStats, error)
 }
 
+// ReleaseServiceInterface defines the contract for release operations.
+type ReleaseServiceInterface interface {
+	CreateRelease(req *CreateReleaseRequest) (*ReleaseDetailResponse, error)
+	GetRelease(releaseID uint) (*ReleaseDetailResponse, error)
+	GetReleaseBySlug(slug string) (*ReleaseDetailResponse, error)
+	ListReleases(filters map[string]interface{}) ([]*ReleaseListResponse, error)
+	UpdateRelease(releaseID uint, req *UpdateReleaseRequest) (*ReleaseDetailResponse, error)
+	DeleteRelease(releaseID uint) error
+	GetReleasesForArtist(artistID uint) ([]*ReleaseListResponse, error)
+	AddExternalLink(releaseID uint, platform, url string) (*ReleaseExternalLinkResponse, error)
+	RemoveExternalLink(linkID uint) error
+}
+
 // CalendarServiceInterface defines the contract for calendar feed operations.
 type CalendarServiceInterface interface {
 	CreateToken(userID uint, apiBaseURL string) (*CalendarTokenCreateResponse, error)
@@ -335,4 +348,5 @@ var (
 	_ AdminStatsServiceInterface    = (*AdminStatsService)(nil)
 	_ CalendarServiceInterface      = (*CalendarService)(nil)
 	_ ReminderServiceInterface      = (*ReminderService)(nil)
+	_ ReleaseServiceInterface       = (*ReleaseService)(nil)
 )

--- a/backend/internal/services/release.go
+++ b/backend/internal/services/release.go
@@ -1,0 +1,505 @@
+package services
+
+import (
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/db"
+	apperrors "psychic-homily-backend/internal/errors"
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/utils"
+)
+
+// ReleaseService handles release-related business logic
+type ReleaseService struct {
+	db *gorm.DB
+}
+
+// NewReleaseService creates a new release service
+func NewReleaseService(database *gorm.DB) *ReleaseService {
+	if database == nil {
+		database = db.GetDB()
+	}
+	return &ReleaseService{
+		db: database,
+	}
+}
+
+// CreateReleaseRequest represents the data needed to create a new release
+type CreateReleaseRequest struct {
+	Title       string                      `json:"title" validate:"required"`
+	ReleaseType string                      `json:"release_type"`
+	ReleaseYear *int                        `json:"release_year"`
+	ReleaseDate *string                     `json:"release_date"`
+	CoverArtURL *string                     `json:"cover_art_url"`
+	Description *string                     `json:"description"`
+	Artists     []CreateReleaseArtistEntry  `json:"artists"`
+	ExternalLinks []CreateReleaseLinkEntry  `json:"external_links"`
+}
+
+// CreateReleaseArtistEntry represents an artist-role pair for release creation
+type CreateReleaseArtistEntry struct {
+	ArtistID uint   `json:"artist_id"`
+	Role     string `json:"role"`
+}
+
+// CreateReleaseLinkEntry represents an external link for release creation
+type CreateReleaseLinkEntry struct {
+	Platform string `json:"platform"`
+	URL      string `json:"url"`
+}
+
+// UpdateReleaseRequest represents the data that can be updated on a release
+type UpdateReleaseRequest struct {
+	Title       *string `json:"title"`
+	ReleaseType *string `json:"release_type"`
+	ReleaseYear *int    `json:"release_year"`
+	ReleaseDate *string `json:"release_date"`
+	CoverArtURL *string `json:"cover_art_url"`
+	Description *string `json:"description"`
+}
+
+// ReleaseDetailResponse represents the release data returned to clients
+type ReleaseDetailResponse struct {
+	ID            uint                         `json:"id"`
+	Title         string                       `json:"title"`
+	Slug          string                       `json:"slug"`
+	ReleaseType   string                       `json:"release_type"`
+	ReleaseYear   *int                         `json:"release_year"`
+	ReleaseDate   *string                      `json:"release_date"`
+	CoverArtURL   *string                      `json:"cover_art_url"`
+	Description   *string                      `json:"description"`
+	Artists       []ReleaseArtistResponse      `json:"artists"`
+	ExternalLinks []ReleaseExternalLinkResponse `json:"external_links"`
+	CreatedAt     time.Time                    `json:"created_at"`
+	UpdatedAt     time.Time                    `json:"updated_at"`
+}
+
+// ReleaseArtistResponse represents an artist on a release
+type ReleaseArtistResponse struct {
+	ID   uint   `json:"id"`
+	Slug string `json:"slug"`
+	Name string `json:"name"`
+	Role string `json:"role"`
+}
+
+// ReleaseExternalLinkResponse represents an external link for a release
+type ReleaseExternalLinkResponse struct {
+	ID       uint   `json:"id"`
+	Platform string `json:"platform"`
+	URL      string `json:"url"`
+}
+
+// ReleaseListResponse represents a release in list views
+type ReleaseListResponse struct {
+	ID          uint    `json:"id"`
+	Title       string  `json:"title"`
+	Slug        string  `json:"slug"`
+	ReleaseType string  `json:"release_type"`
+	ReleaseYear *int    `json:"release_year"`
+	CoverArtURL *string `json:"cover_art_url"`
+	ArtistCount int     `json:"artist_count"`
+}
+
+// CreateRelease creates a new release
+func (s *ReleaseService) CreateRelease(req *CreateReleaseRequest) (*ReleaseDetailResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	// Generate unique slug
+	baseSlug := utils.GenerateArtistSlug(req.Title)
+	slug := utils.GenerateUniqueSlug(baseSlug, func(candidate string) bool {
+		var count int64
+		s.db.Model(&models.Release{}).Where("slug = ?", candidate).Count(&count)
+		return count > 0
+	})
+
+	// Determine release type, default to "lp"
+	releaseType := models.ReleaseType(req.ReleaseType)
+	if releaseType == "" {
+		releaseType = models.ReleaseTypeLP
+	}
+
+	// Create the release
+	release := &models.Release{
+		Title:       req.Title,
+		Slug:        &slug,
+		ReleaseType: releaseType,
+		ReleaseYear: req.ReleaseYear,
+		ReleaseDate: req.ReleaseDate,
+		CoverArtURL: req.CoverArtURL,
+		Description: req.Description,
+	}
+
+	err := s.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Create(release).Error; err != nil {
+			return fmt.Errorf("failed to create release: %w", err)
+		}
+
+		// Create artist_releases entries
+		for i, artistEntry := range req.Artists {
+			role := artistEntry.Role
+			if role == "" {
+				role = string(models.ArtistReleaseRoleMain)
+			}
+			ar := &models.ArtistRelease{
+				ArtistID:  artistEntry.ArtistID,
+				ReleaseID: release.ID,
+				Role:      models.ArtistReleaseRole(role),
+				Position:  i,
+			}
+			if err := tx.Create(ar).Error; err != nil {
+				return fmt.Errorf("failed to create artist-release link: %w", err)
+			}
+		}
+
+		// Create external links
+		for _, linkEntry := range req.ExternalLinks {
+			link := &models.ReleaseExternalLink{
+				ReleaseID: release.ID,
+				Platform:  linkEntry.Platform,
+				URL:       linkEntry.URL,
+			}
+			if err := tx.Create(link).Error; err != nil {
+				return fmt.Errorf("failed to create external link: %w", err)
+			}
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return s.GetRelease(release.ID)
+}
+
+// GetRelease retrieves a release by ID
+func (s *ReleaseService) GetRelease(releaseID uint) (*ReleaseDetailResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var release models.Release
+	err := s.db.Preload("ExternalLinks").First(&release, releaseID).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, apperrors.ErrReleaseNotFound(releaseID)
+		}
+		return nil, fmt.Errorf("failed to get release: %w", err)
+	}
+
+	return s.buildDetailResponse(&release)
+}
+
+// GetReleaseBySlug retrieves a release by slug
+func (s *ReleaseService) GetReleaseBySlug(slug string) (*ReleaseDetailResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var release models.Release
+	err := s.db.Preload("ExternalLinks").Where("slug = ?", slug).First(&release).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, apperrors.ErrReleaseNotFound(0)
+		}
+		return nil, fmt.Errorf("failed to get release: %w", err)
+	}
+
+	return s.buildDetailResponse(&release)
+}
+
+// ListReleases retrieves releases with optional filtering
+func (s *ReleaseService) ListReleases(filters map[string]interface{}) ([]*ReleaseListResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	query := s.db.Model(&models.Release{})
+
+	// Apply filters
+	if artistID, ok := filters["artist_id"].(uint); ok && artistID > 0 {
+		query = query.Where("id IN (?)",
+			s.db.Table("artist_releases").Select("release_id").Where("artist_id = ?", artistID),
+		)
+	}
+	if releaseType, ok := filters["release_type"].(string); ok && releaseType != "" {
+		query = query.Where("release_type = ?", releaseType)
+	}
+	if year, ok := filters["year"].(int); ok && year > 0 {
+		query = query.Where("release_year = ?", year)
+	}
+
+	// Order by release_year DESC, title ASC
+	query = query.Order("release_year DESC NULLS LAST, title ASC")
+
+	var releases []models.Release
+	err := query.Find(&releases).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to list releases: %w", err)
+	}
+
+	// Batch-load artist counts
+	releaseIDs := make([]uint, len(releases))
+	for i, r := range releases {
+		releaseIDs[i] = r.ID
+	}
+
+	artistCounts := make(map[uint]int)
+	if len(releaseIDs) > 0 {
+		type CountResult struct {
+			ReleaseID uint
+			Count     int
+		}
+		var counts []CountResult
+		s.db.Table("artist_releases").
+			Select("release_id, COUNT(DISTINCT artist_id) as count").
+			Where("release_id IN ?", releaseIDs).
+			Group("release_id").
+			Find(&counts)
+		for _, c := range counts {
+			artistCounts[c.ReleaseID] = c.Count
+		}
+	}
+
+	// Build responses
+	responses := make([]*ReleaseListResponse, len(releases))
+	for i, release := range releases {
+		slug := ""
+		if release.Slug != nil {
+			slug = *release.Slug
+		}
+		responses[i] = &ReleaseListResponse{
+			ID:          release.ID,
+			Title:       release.Title,
+			Slug:        slug,
+			ReleaseType: string(release.ReleaseType),
+			ReleaseYear: release.ReleaseYear,
+			CoverArtURL: release.CoverArtURL,
+			ArtistCount: artistCounts[release.ID],
+		}
+	}
+
+	return responses, nil
+}
+
+// UpdateRelease updates an existing release
+func (s *ReleaseService) UpdateRelease(releaseID uint, req *UpdateReleaseRequest) (*ReleaseDetailResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	// Check if release exists
+	var release models.Release
+	err := s.db.First(&release, releaseID).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, apperrors.ErrReleaseNotFound(releaseID)
+		}
+		return nil, fmt.Errorf("failed to get release: %w", err)
+	}
+
+	updates := map[string]interface{}{}
+
+	if req.Title != nil {
+		updates["title"] = *req.Title
+		// Regenerate slug when title changes
+		baseSlug := utils.GenerateArtistSlug(*req.Title)
+		slug := utils.GenerateUniqueSlug(baseSlug, func(candidate string) bool {
+			var count int64
+			s.db.Model(&models.Release{}).Where("slug = ? AND id != ?", candidate, releaseID).Count(&count)
+			return count > 0
+		})
+		updates["slug"] = slug
+	}
+	if req.ReleaseType != nil {
+		updates["release_type"] = *req.ReleaseType
+	}
+	if req.ReleaseYear != nil {
+		updates["release_year"] = *req.ReleaseYear
+	}
+	if req.ReleaseDate != nil {
+		updates["release_date"] = *req.ReleaseDate
+	}
+	if req.CoverArtURL != nil {
+		updates["cover_art_url"] = *req.CoverArtURL
+	}
+	if req.Description != nil {
+		updates["description"] = *req.Description
+	}
+
+	if len(updates) > 0 {
+		err = s.db.Model(&models.Release{}).Where("id = ?", releaseID).Updates(updates).Error
+		if err != nil {
+			return nil, fmt.Errorf("failed to update release: %w", err)
+		}
+	}
+
+	return s.GetRelease(releaseID)
+}
+
+// DeleteRelease deletes a release
+func (s *ReleaseService) DeleteRelease(releaseID uint) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	// Check if release exists
+	var release models.Release
+	err := s.db.First(&release, releaseID).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return apperrors.ErrReleaseNotFound(releaseID)
+		}
+		return fmt.Errorf("failed to get release: %w", err)
+	}
+
+	// Delete the release (cascades handle junction cleanup via FK)
+	err = s.db.Delete(&release).Error
+	if err != nil {
+		return fmt.Errorf("failed to delete release: %w", err)
+	}
+
+	return nil
+}
+
+// GetReleasesForArtist retrieves all releases for a given artist
+func (s *ReleaseService) GetReleasesForArtist(artistID uint) ([]*ReleaseListResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	// Verify artist exists
+	var artist models.Artist
+	if err := s.db.First(&artist, artistID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, apperrors.ErrArtistNotFound(artistID)
+		}
+		return nil, fmt.Errorf("failed to get artist: %w", err)
+	}
+
+	return s.ListReleases(map[string]interface{}{"artist_id": artistID})
+}
+
+// AddExternalLink adds an external link to a release
+func (s *ReleaseService) AddExternalLink(releaseID uint, platform, url string) (*ReleaseExternalLinkResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	// Verify release exists
+	var release models.Release
+	if err := s.db.First(&release, releaseID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, apperrors.ErrReleaseNotFound(releaseID)
+		}
+		return nil, fmt.Errorf("failed to get release: %w", err)
+	}
+
+	link := &models.ReleaseExternalLink{
+		ReleaseID: releaseID,
+		Platform:  platform,
+		URL:       url,
+	}
+
+	if err := s.db.Create(link).Error; err != nil {
+		return nil, fmt.Errorf("failed to create external link: %w", err)
+	}
+
+	return &ReleaseExternalLinkResponse{
+		ID:       link.ID,
+		Platform: link.Platform,
+		URL:      link.URL,
+	}, nil
+}
+
+// RemoveExternalLink removes an external link
+func (s *ReleaseService) RemoveExternalLink(linkID uint) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	result := s.db.Delete(&models.ReleaseExternalLink{}, linkID)
+	if result.Error != nil {
+		return fmt.Errorf("failed to delete external link: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("external link not found")
+	}
+
+	return nil
+}
+
+// buildDetailResponse converts a Release model to ReleaseDetailResponse
+func (s *ReleaseService) buildDetailResponse(release *models.Release) (*ReleaseDetailResponse, error) {
+	slug := ""
+	if release.Slug != nil {
+		slug = *release.Slug
+	}
+
+	// Load artist_releases with artist data
+	var artistReleases []models.ArtistRelease
+	s.db.Where("release_id = ?", release.ID).Order("position ASC").Find(&artistReleases)
+
+	// Batch-load artist models
+	artistIDs := make([]uint, len(artistReleases))
+	for i, ar := range artistReleases {
+		artistIDs[i] = ar.ArtistID
+	}
+
+	artistMap := make(map[uint]*models.Artist)
+	if len(artistIDs) > 0 {
+		var artists []models.Artist
+		s.db.Where("id IN ?", artistIDs).Find(&artists)
+		for i := range artists {
+			artistMap[artists[i].ID] = &artists[i]
+		}
+	}
+
+	// Build artist responses
+	artistResponses := make([]ReleaseArtistResponse, 0, len(artistReleases))
+	for _, ar := range artistReleases {
+		if artistModel, ok := artistMap[ar.ArtistID]; ok {
+			artistSlug := ""
+			if artistModel.Slug != nil {
+				artistSlug = *artistModel.Slug
+			}
+			artistResponses = append(artistResponses, ReleaseArtistResponse{
+				ID:   artistModel.ID,
+				Slug: artistSlug,
+				Name: artistModel.Name,
+				Role: string(ar.Role),
+			})
+		}
+	}
+
+	// Build external link responses
+	linkResponses := make([]ReleaseExternalLinkResponse, len(release.ExternalLinks))
+	for i, link := range release.ExternalLinks {
+		linkResponses[i] = ReleaseExternalLinkResponse{
+			ID:       link.ID,
+			Platform: link.Platform,
+			URL:      link.URL,
+		}
+	}
+
+	return &ReleaseDetailResponse{
+		ID:            release.ID,
+		Title:         release.Title,
+		Slug:          slug,
+		ReleaseType:   string(release.ReleaseType),
+		ReleaseYear:   release.ReleaseYear,
+		ReleaseDate:   release.ReleaseDate,
+		CoverArtURL:   release.CoverArtURL,
+		Description:   release.Description,
+		Artists:       artistResponses,
+		ExternalLinks: linkResponses,
+		CreatedAt:     release.CreatedAt,
+		UpdatedAt:     release.UpdatedAt,
+	}, nil
+}

--- a/backend/internal/services/release_test.go
+++ b/backend/internal/services/release_test.go
@@ -1,0 +1,651 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+
+	apperrors "psychic-homily-backend/internal/errors"
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/testutil"
+)
+
+// =============================================================================
+// UNIT TESTS (No Database Required)
+// =============================================================================
+
+func TestNewReleaseService(t *testing.T) {
+	releaseService := NewReleaseService(nil)
+	assert.NotNil(t, releaseService)
+}
+
+func TestReleaseService_NilDatabase(t *testing.T) {
+	svc := &ReleaseService{db: nil}
+
+	t.Run("CreateRelease", func(t *testing.T) {
+		resp, err := svc.CreateRelease(&CreateReleaseRequest{Title: "Test"})
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("GetRelease", func(t *testing.T) {
+		resp, err := svc.GetRelease(1)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("GetReleaseBySlug", func(t *testing.T) {
+		resp, err := svc.GetReleaseBySlug("test-slug")
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("ListReleases", func(t *testing.T) {
+		resp, err := svc.ListReleases(nil)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("UpdateRelease", func(t *testing.T) {
+		resp, err := svc.UpdateRelease(1, &UpdateReleaseRequest{})
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("DeleteRelease", func(t *testing.T) {
+		err := svc.DeleteRelease(1)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+	})
+
+	t.Run("GetReleasesForArtist", func(t *testing.T) {
+		resp, err := svc.GetReleasesForArtist(1)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("AddExternalLink", func(t *testing.T) {
+		resp, err := svc.AddExternalLink(1, "bandcamp", "http://test.com")
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("RemoveExternalLink", func(t *testing.T) {
+		err := svc.RemoveExternalLink(1)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+	})
+}
+
+// =============================================================================
+// INTEGRATION TESTS (With Real Database)
+// =============================================================================
+
+type ReleaseServiceIntegrationTestSuite struct {
+	suite.Suite
+	container      testcontainers.Container
+	db             *gorm.DB
+	releaseService *ReleaseService
+	artistService  *ArtistService
+	ctx            context.Context
+}
+
+func (suite *ReleaseServiceIntegrationTestSuite) SetupSuite() {
+	suite.ctx = context.Background()
+
+	// Start PostgreSQL container
+	container, err := testcontainers.GenericContainer(suite.ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "postgres:18",
+			ExposedPorts: []string{"5432/tcp"},
+			Env: map[string]string{
+				"POSTGRES_DB":       "test_db",
+				"POSTGRES_USER":     "test_user",
+				"POSTGRES_PASSWORD": "test_password",
+			},
+			WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(120 * time.Second),
+		},
+		Started: true,
+	})
+	if err != nil {
+		suite.T().Fatalf("failed to start postgres container: %v", err)
+	}
+	suite.container = container
+
+	host, err := container.Host(suite.ctx)
+	if err != nil {
+		suite.T().Fatalf("failed to get host: %v", err)
+	}
+	port, err := container.MappedPort(suite.ctx, "5432")
+	if err != nil {
+		suite.T().Fatalf("failed to get port: %v", err)
+	}
+
+	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
+		host, port.Port())
+
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		suite.T().Fatalf("failed to connect to test database: %v", err)
+	}
+	suite.db = db
+
+	sqlDB, err := db.DB()
+	if err != nil {
+		suite.T().Fatalf("failed to get sql.DB: %v", err)
+	}
+	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "db", "migrations"))
+
+	suite.releaseService = &ReleaseService{db: db}
+	suite.artistService = &ArtistService{db: db}
+}
+
+func (suite *ReleaseServiceIntegrationTestSuite) TearDownSuite() {
+	if suite.container != nil {
+		if err := suite.container.Terminate(suite.ctx); err != nil {
+			suite.T().Logf("failed to terminate container: %v", err)
+		}
+	}
+}
+
+// TearDownTest cleans up data between tests for isolation
+func (suite *ReleaseServiceIntegrationTestSuite) TearDownTest() {
+	sqlDB, err := suite.db.DB()
+	suite.Require().NoError(err)
+	// Delete in FK-safe order
+	_, _ = sqlDB.Exec("DELETE FROM release_external_links")
+	_, _ = sqlDB.Exec("DELETE FROM artist_releases")
+	_, _ = sqlDB.Exec("DELETE FROM releases")
+	_, _ = sqlDB.Exec("DELETE FROM show_artists")
+	_, _ = sqlDB.Exec("DELETE FROM show_venues")
+	_, _ = sqlDB.Exec("DELETE FROM shows")
+	_, _ = sqlDB.Exec("DELETE FROM artists")
+}
+
+func TestReleaseServiceIntegrationTestSuite(t *testing.T) {
+	suite.Run(t, new(ReleaseServiceIntegrationTestSuite))
+}
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+func (suite *ReleaseServiceIntegrationTestSuite) createTestArtist(name string) *models.Artist {
+	artist := &models.Artist{
+		Name: name,
+	}
+	err := suite.db.Create(artist).Error
+	suite.Require().NoError(err)
+	return artist
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+// =============================================================================
+// Group 1: CreateRelease
+// =============================================================================
+
+func (suite *ReleaseServiceIntegrationTestSuite) TestCreateRelease_Success() {
+	year := 2024
+	req := &CreateReleaseRequest{
+		Title:       "Nevermind",
+		ReleaseType: "lp",
+		ReleaseYear: &year,
+	}
+
+	resp, err := suite.releaseService.CreateRelease(req)
+
+	suite.Require().NoError(err)
+	suite.Require().NotNil(resp)
+	suite.NotZero(resp.ID)
+	suite.Equal("Nevermind", resp.Title)
+	suite.Equal("nevermind", resp.Slug)
+	suite.Equal("lp", resp.ReleaseType)
+	suite.Equal(2024, *resp.ReleaseYear)
+	suite.Empty(resp.Artists)
+	suite.Empty(resp.ExternalLinks)
+}
+
+func (suite *ReleaseServiceIntegrationTestSuite) TestCreateRelease_WithArtists() {
+	artist1 := suite.createTestArtist("Nirvana")
+	artist2 := suite.createTestArtist("Butch Vig")
+
+	year := 1991
+	req := &CreateReleaseRequest{
+		Title:       "Nevermind",
+		ReleaseType: "lp",
+		ReleaseYear: &year,
+		Artists: []CreateReleaseArtistEntry{
+			{ArtistID: artist1.ID, Role: "main"},
+			{ArtistID: artist2.ID, Role: "producer"},
+		},
+	}
+
+	resp, err := suite.releaseService.CreateRelease(req)
+
+	suite.Require().NoError(err)
+	suite.Require().NotNil(resp)
+	suite.Require().Len(resp.Artists, 2)
+	suite.Equal("Nirvana", resp.Artists[0].Name)
+	suite.Equal("main", resp.Artists[0].Role)
+	suite.Equal("Butch Vig", resp.Artists[1].Name)
+	suite.Equal("producer", resp.Artists[1].Role)
+}
+
+func (suite *ReleaseServiceIntegrationTestSuite) TestCreateRelease_WithExternalLinks() {
+	req := &CreateReleaseRequest{
+		Title:       "In Utero",
+		ReleaseType: "lp",
+		ExternalLinks: []CreateReleaseLinkEntry{
+			{Platform: "bandcamp", URL: "https://nirvana.bandcamp.com/album/in-utero"},
+			{Platform: "spotify", URL: "https://open.spotify.com/album/abc123"},
+		},
+	}
+
+	resp, err := suite.releaseService.CreateRelease(req)
+
+	suite.Require().NoError(err)
+	suite.Require().NotNil(resp)
+	suite.Require().Len(resp.ExternalLinks, 2)
+	suite.Equal("bandcamp", resp.ExternalLinks[0].Platform)
+	suite.Equal("spotify", resp.ExternalLinks[1].Platform)
+}
+
+func (suite *ReleaseServiceIntegrationTestSuite) TestCreateRelease_DefaultReleaseType() {
+	req := &CreateReleaseRequest{
+		Title: "Mystery Release",
+	}
+
+	resp, err := suite.releaseService.CreateRelease(req)
+
+	suite.Require().NoError(err)
+	suite.Equal("lp", resp.ReleaseType)
+}
+
+func (suite *ReleaseServiceIntegrationTestSuite) TestCreateRelease_UniqueSlug() {
+	req1 := &CreateReleaseRequest{Title: "Homesick"}
+	resp1, err := suite.releaseService.CreateRelease(req1)
+	suite.Require().NoError(err)
+
+	req2 := &CreateReleaseRequest{Title: "Homesick"}
+	resp2, err := suite.releaseService.CreateRelease(req2)
+	suite.Require().NoError(err)
+
+	suite.NotEqual(resp1.Slug, resp2.Slug)
+	suite.Equal("homesick", resp1.Slug)
+	suite.Equal("homesick-2", resp2.Slug)
+}
+
+// =============================================================================
+// Group 2: GetRelease / GetReleaseBySlug
+// =============================================================================
+
+func (suite *ReleaseServiceIntegrationTestSuite) TestGetRelease_Success() {
+	created, err := suite.releaseService.CreateRelease(&CreateReleaseRequest{Title: "Test Album"})
+	suite.Require().NoError(err)
+
+	resp, err := suite.releaseService.GetRelease(created.ID)
+
+	suite.Require().NoError(err)
+	suite.Equal(created.ID, resp.ID)
+	suite.Equal("Test Album", resp.Title)
+}
+
+func (suite *ReleaseServiceIntegrationTestSuite) TestGetRelease_NotFound() {
+	resp, err := suite.releaseService.GetRelease(99999)
+
+	suite.Require().Error(err)
+	suite.Nil(resp)
+	var releaseErr *apperrors.ReleaseError
+	suite.ErrorAs(err, &releaseErr)
+	suite.Equal(apperrors.CodeReleaseNotFound, releaseErr.Code)
+}
+
+func (suite *ReleaseServiceIntegrationTestSuite) TestGetReleaseBySlug_Success() {
+	created, err := suite.releaseService.CreateRelease(&CreateReleaseRequest{Title: "Slug Test Album"})
+	suite.Require().NoError(err)
+
+	resp, err := suite.releaseService.GetReleaseBySlug(created.Slug)
+
+	suite.Require().NoError(err)
+	suite.Equal(created.ID, resp.ID)
+	suite.Equal(created.Slug, resp.Slug)
+}
+
+func (suite *ReleaseServiceIntegrationTestSuite) TestGetReleaseBySlug_NotFound() {
+	resp, err := suite.releaseService.GetReleaseBySlug("nonexistent-slug-xyz")
+
+	suite.Require().Error(err)
+	suite.Nil(resp)
+	var releaseErr *apperrors.ReleaseError
+	suite.ErrorAs(err, &releaseErr)
+	suite.Equal(apperrors.CodeReleaseNotFound, releaseErr.Code)
+}
+
+// =============================================================================
+// Group 3: ListReleases
+// =============================================================================
+
+func (suite *ReleaseServiceIntegrationTestSuite) TestListReleases_All() {
+	suite.releaseService.CreateRelease(&CreateReleaseRequest{Title: "Album A", ReleaseYear: intPtr(2020)})
+	suite.releaseService.CreateRelease(&CreateReleaseRequest{Title: "Album B", ReleaseYear: intPtr(2023)})
+	suite.releaseService.CreateRelease(&CreateReleaseRequest{Title: "Album C", ReleaseYear: intPtr(2021)})
+
+	resp, err := suite.releaseService.ListReleases(map[string]interface{}{})
+
+	suite.Require().NoError(err)
+	suite.Require().Len(resp, 3)
+	// Ordered by release_year DESC, title ASC
+	suite.Equal("Album B", resp[0].Title) // 2023
+	suite.Equal("Album C", resp[1].Title) // 2021
+	suite.Equal("Album A", resp[2].Title) // 2020
+}
+
+func (suite *ReleaseServiceIntegrationTestSuite) TestListReleases_FilterByType() {
+	suite.releaseService.CreateRelease(&CreateReleaseRequest{Title: "LP Release", ReleaseType: "lp"})
+	suite.releaseService.CreateRelease(&CreateReleaseRequest{Title: "EP Release", ReleaseType: "ep"})
+	suite.releaseService.CreateRelease(&CreateReleaseRequest{Title: "Single Release", ReleaseType: "single"})
+
+	resp, err := suite.releaseService.ListReleases(map[string]interface{}{"release_type": "ep"})
+
+	suite.Require().NoError(err)
+	suite.Require().Len(resp, 1)
+	suite.Equal("EP Release", resp[0].Title)
+}
+
+func (suite *ReleaseServiceIntegrationTestSuite) TestListReleases_FilterByYear() {
+	suite.releaseService.CreateRelease(&CreateReleaseRequest{Title: "Old Album", ReleaseYear: intPtr(2020)})
+	suite.releaseService.CreateRelease(&CreateReleaseRequest{Title: "New Album", ReleaseYear: intPtr(2024)})
+
+	resp, err := suite.releaseService.ListReleases(map[string]interface{}{"year": 2024})
+
+	suite.Require().NoError(err)
+	suite.Require().Len(resp, 1)
+	suite.Equal("New Album", resp[0].Title)
+}
+
+func (suite *ReleaseServiceIntegrationTestSuite) TestListReleases_FilterByArtist() {
+	artist1 := suite.createTestArtist("Artist One")
+	artist2 := suite.createTestArtist("Artist Two")
+
+	suite.releaseService.CreateRelease(&CreateReleaseRequest{
+		Title:   "Artist One Album",
+		Artists: []CreateReleaseArtistEntry{{ArtistID: artist1.ID, Role: "main"}},
+	})
+	suite.releaseService.CreateRelease(&CreateReleaseRequest{
+		Title:   "Artist Two Album",
+		Artists: []CreateReleaseArtistEntry{{ArtistID: artist2.ID, Role: "main"}},
+	})
+
+	resp, err := suite.releaseService.ListReleases(map[string]interface{}{"artist_id": artist1.ID})
+
+	suite.Require().NoError(err)
+	suite.Require().Len(resp, 1)
+	suite.Equal("Artist One Album", resp[0].Title)
+}
+
+func (suite *ReleaseServiceIntegrationTestSuite) TestListReleases_ArtistCount() {
+	artist1 := suite.createTestArtist("Count Artist 1")
+	artist2 := suite.createTestArtist("Count Artist 2")
+
+	suite.releaseService.CreateRelease(&CreateReleaseRequest{
+		Title: "Multi Artist Album",
+		Artists: []CreateReleaseArtistEntry{
+			{ArtistID: artist1.ID, Role: "main"},
+			{ArtistID: artist2.ID, Role: "featured"},
+		},
+	})
+
+	resp, err := suite.releaseService.ListReleases(map[string]interface{}{})
+
+	suite.Require().NoError(err)
+	suite.Require().Len(resp, 1)
+	suite.Equal(2, resp[0].ArtistCount)
+}
+
+// =============================================================================
+// Group 4: UpdateRelease
+// =============================================================================
+
+func (suite *ReleaseServiceIntegrationTestSuite) TestUpdateRelease_BasicFields() {
+	created, err := suite.releaseService.CreateRelease(&CreateReleaseRequest{Title: "Original Title", ReleaseYear: intPtr(2020)})
+	suite.Require().NoError(err)
+
+	newTitle := "Updated Title"
+	newYear := 2021
+	resp, err := suite.releaseService.UpdateRelease(created.ID, &UpdateReleaseRequest{
+		Title:       &newTitle,
+		ReleaseYear: &newYear,
+	})
+
+	suite.Require().NoError(err)
+	suite.Equal("Updated Title", resp.Title)
+	suite.Equal(2021, *resp.ReleaseYear)
+}
+
+func (suite *ReleaseServiceIntegrationTestSuite) TestUpdateRelease_TitleChangeRegeneratesSlug() {
+	created, err := suite.releaseService.CreateRelease(&CreateReleaseRequest{Title: "Old Title"})
+	suite.Require().NoError(err)
+	oldSlug := created.Slug
+
+	newTitle := "New Title"
+	resp, err := suite.releaseService.UpdateRelease(created.ID, &UpdateReleaseRequest{
+		Title: &newTitle,
+	})
+
+	suite.Require().NoError(err)
+	suite.Equal("New Title", resp.Title)
+	suite.NotEqual(oldSlug, resp.Slug)
+	suite.Equal("new-title", resp.Slug)
+}
+
+func (suite *ReleaseServiceIntegrationTestSuite) TestUpdateRelease_NotFound() {
+	newTitle := "Anything"
+	resp, err := suite.releaseService.UpdateRelease(99999, &UpdateReleaseRequest{Title: &newTitle})
+
+	suite.Require().Error(err)
+	suite.Nil(resp)
+	var releaseErr *apperrors.ReleaseError
+	suite.ErrorAs(err, &releaseErr)
+	suite.Equal(apperrors.CodeReleaseNotFound, releaseErr.Code)
+}
+
+func (suite *ReleaseServiceIntegrationTestSuite) TestUpdateRelease_NoChanges() {
+	created, err := suite.releaseService.CreateRelease(&CreateReleaseRequest{Title: "Stable Title"})
+	suite.Require().NoError(err)
+
+	// Update with no fields set
+	resp, err := suite.releaseService.UpdateRelease(created.ID, &UpdateReleaseRequest{})
+
+	suite.Require().NoError(err)
+	suite.Equal("Stable Title", resp.Title)
+}
+
+// =============================================================================
+// Group 5: DeleteRelease
+// =============================================================================
+
+func (suite *ReleaseServiceIntegrationTestSuite) TestDeleteRelease_Success() {
+	created, err := suite.releaseService.CreateRelease(&CreateReleaseRequest{Title: "Delete Me"})
+	suite.Require().NoError(err)
+
+	err = suite.releaseService.DeleteRelease(created.ID)
+
+	suite.Require().NoError(err)
+
+	// Verify it's gone
+	_, err = suite.releaseService.GetRelease(created.ID)
+	suite.Error(err)
+}
+
+func (suite *ReleaseServiceIntegrationTestSuite) TestDeleteRelease_NotFound() {
+	err := suite.releaseService.DeleteRelease(99999)
+
+	suite.Require().Error(err)
+	var releaseErr *apperrors.ReleaseError
+	suite.ErrorAs(err, &releaseErr)
+	suite.Equal(apperrors.CodeReleaseNotFound, releaseErr.Code)
+}
+
+func (suite *ReleaseServiceIntegrationTestSuite) TestDeleteRelease_CascadesJunctions() {
+	artist := suite.createTestArtist("Cascade Artist")
+	created, err := suite.releaseService.CreateRelease(&CreateReleaseRequest{
+		Title:   "Cascade Album",
+		Artists: []CreateReleaseArtistEntry{{ArtistID: artist.ID, Role: "main"}},
+		ExternalLinks: []CreateReleaseLinkEntry{
+			{Platform: "bandcamp", URL: "https://test.bandcamp.com"},
+		},
+	})
+	suite.Require().NoError(err)
+
+	err = suite.releaseService.DeleteRelease(created.ID)
+	suite.Require().NoError(err)
+
+	// Verify artist_releases cleaned up
+	var arCount int64
+	suite.db.Model(&models.ArtistRelease{}).Where("release_id = ?", created.ID).Count(&arCount)
+	suite.Equal(int64(0), arCount)
+
+	// Verify external_links cleaned up
+	var linkCount int64
+	suite.db.Model(&models.ReleaseExternalLink{}).Where("release_id = ?", created.ID).Count(&linkCount)
+	suite.Equal(int64(0), linkCount)
+}
+
+// =============================================================================
+// Group 6: GetReleasesForArtist
+// =============================================================================
+
+func (suite *ReleaseServiceIntegrationTestSuite) TestGetReleasesForArtist_Success() {
+	artist := suite.createTestArtist("Discography Artist")
+	otherArtist := suite.createTestArtist("Other Artist")
+
+	suite.releaseService.CreateRelease(&CreateReleaseRequest{
+		Title:       "Album A",
+		ReleaseYear: intPtr(2020),
+		Artists:     []CreateReleaseArtistEntry{{ArtistID: artist.ID, Role: "main"}},
+	})
+	suite.releaseService.CreateRelease(&CreateReleaseRequest{
+		Title:       "Album B",
+		ReleaseYear: intPtr(2023),
+		Artists:     []CreateReleaseArtistEntry{{ArtistID: artist.ID, Role: "main"}},
+	})
+	suite.releaseService.CreateRelease(&CreateReleaseRequest{
+		Title:   "Other Album",
+		Artists: []CreateReleaseArtistEntry{{ArtistID: otherArtist.ID, Role: "main"}},
+	})
+
+	resp, err := suite.releaseService.GetReleasesForArtist(artist.ID)
+
+	suite.Require().NoError(err)
+	suite.Require().Len(resp, 2)
+	// Ordered by year DESC
+	suite.Equal("Album B", resp[0].Title)
+	suite.Equal("Album A", resp[1].Title)
+}
+
+func (suite *ReleaseServiceIntegrationTestSuite) TestGetReleasesForArtist_ArtistNotFound() {
+	resp, err := suite.releaseService.GetReleasesForArtist(99999)
+
+	suite.Require().Error(err)
+	suite.Nil(resp)
+	var artistErr *apperrors.ArtistError
+	suite.ErrorAs(err, &artistErr)
+	suite.Equal(apperrors.CodeArtistNotFound, artistErr.Code)
+}
+
+func (suite *ReleaseServiceIntegrationTestSuite) TestGetReleasesForArtist_Empty() {
+	artist := suite.createTestArtist("No Releases Artist")
+
+	resp, err := suite.releaseService.GetReleasesForArtist(artist.ID)
+
+	suite.Require().NoError(err)
+	suite.Empty(resp)
+}
+
+// =============================================================================
+// Group 7: ExternalLinks
+// =============================================================================
+
+func (suite *ReleaseServiceIntegrationTestSuite) TestAddExternalLink_Success() {
+	created, err := suite.releaseService.CreateRelease(&CreateReleaseRequest{Title: "Link Album"})
+	suite.Require().NoError(err)
+
+	link, err := suite.releaseService.AddExternalLink(created.ID, "bandcamp", "https://test.bandcamp.com/album/test")
+
+	suite.Require().NoError(err)
+	suite.Require().NotNil(link)
+	suite.NotZero(link.ID)
+	suite.Equal("bandcamp", link.Platform)
+	suite.Equal("https://test.bandcamp.com/album/test", link.URL)
+}
+
+func (suite *ReleaseServiceIntegrationTestSuite) TestAddExternalLink_ReleaseNotFound() {
+	link, err := suite.releaseService.AddExternalLink(99999, "bandcamp", "https://test.bandcamp.com")
+
+	suite.Require().Error(err)
+	suite.Nil(link)
+	var releaseErr *apperrors.ReleaseError
+	suite.ErrorAs(err, &releaseErr)
+	suite.Equal(apperrors.CodeReleaseNotFound, releaseErr.Code)
+}
+
+func (suite *ReleaseServiceIntegrationTestSuite) TestRemoveExternalLink_Success() {
+	created, err := suite.releaseService.CreateRelease(&CreateReleaseRequest{
+		Title: "Remove Link Album",
+		ExternalLinks: []CreateReleaseLinkEntry{
+			{Platform: "spotify", URL: "https://open.spotify.com/album/abc"},
+		},
+	})
+	suite.Require().NoError(err)
+	suite.Require().Len(created.ExternalLinks, 1)
+
+	err = suite.releaseService.RemoveExternalLink(created.ExternalLinks[0].ID)
+
+	suite.Require().NoError(err)
+
+	// Verify it's gone
+	refreshed, err := suite.releaseService.GetRelease(created.ID)
+	suite.Require().NoError(err)
+	suite.Empty(refreshed.ExternalLinks)
+}
+
+func (suite *ReleaseServiceIntegrationTestSuite) TestRemoveExternalLink_NotFound() {
+	err := suite.releaseService.RemoveExternalLink(99999)
+	suite.Require().Error(err)
+	suite.Contains(err.Error(), "external link not found")
+}
+
+func (suite *ReleaseServiceIntegrationTestSuite) TestAddMultipleExternalLinks() {
+	created, err := suite.releaseService.CreateRelease(&CreateReleaseRequest{Title: "Multi Link Album"})
+	suite.Require().NoError(err)
+
+	_, err = suite.releaseService.AddExternalLink(created.ID, "bandcamp", "https://test.bandcamp.com")
+	suite.Require().NoError(err)
+	_, err = suite.releaseService.AddExternalLink(created.ID, "spotify", "https://open.spotify.com/album/test")
+	suite.Require().NoError(err)
+	_, err = suite.releaseService.AddExternalLink(created.ID, "discogs", "https://www.discogs.com/release/123")
+	suite.Require().NoError(err)
+
+	refreshed, err := suite.releaseService.GetRelease(created.ID)
+	suite.Require().NoError(err)
+	suite.Require().Len(refreshed.ExternalLinks, 3)
+}


### PR DESCRIPTION
## Summary
- Add `ReleaseService` with full CRUD, filtered listing, artist discography, and external link management
- Add `ReleaseHandler` with 8 Huma endpoints (public list/detail + admin CRUD)
- Add `ReleaseError` types following existing app error patterns
- Add `ReleaseServiceInterface` with compile-time satisfaction check
- Register service in `container.go` and routes in `routes.go`
- 57 new tests (30 service integration + 27 handler integration)

Closes PSY-6

## API Endpoints
| Method | Path | Auth | Description |
|--------|------|------|-------------|
| GET | `/releases` | Public | List with filters (artist_id, release_type, year) |
| GET | `/releases/{release_id}` | Public | Detail by ID or slug |
| GET | `/artists/{artist_id}/releases` | Public | Artist discography |
| POST | `/releases` | Admin | Create release with artists + links |
| PUT | `/releases/{release_id}` | Admin | Update release |
| DELETE | `/releases/{release_id}` | Admin | Delete release |
| POST | `/releases/{release_id}/links` | Admin | Add external link |
| DELETE | `/releases/{release_id}/links/{link_id}` | Admin | Remove external link |

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] 57 new tests pass (service + handler integration)
- [x] `go test ./...` passes (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)