### PR TITLE
feat: add Label service, handler, and API routes

### DIFF
--- a/backend/internal/api/handlers/handler_integration_helpers_test.go
+++ b/backend/internal/api/handlers/handler_integration_helpers_test.go
@@ -38,6 +38,7 @@ type handlerIntegrationDeps struct {
 	adminStatsService     *services.AdminStatsService
 	discoveryService      *services.DiscoveryService
 	artistService         *services.ArtistService
+	labelService          *services.LabelService
 	releaseService        *services.ReleaseService
 }
 
@@ -111,6 +112,7 @@ func setupHandlerIntegrationDeps(t *testing.T) *handlerIntegrationDeps {
 		adminStatsService:     services.NewAdminStatsService(db),
 		discoveryService:      services.NewDiscoveryService(db),
 		artistService:         services.NewArtistService(db),
+		labelService:          services.NewLabelService(db),
 		releaseService:        services.NewReleaseService(db),
 	}
 
@@ -126,6 +128,9 @@ func cleanupTables(db *gorm.DB) {
 	_, _ = sqlDB.Exec("DELETE FROM user_saved_shows")
 	_, _ = sqlDB.Exec("DELETE FROM user_favorite_venues")
 	_, _ = sqlDB.Exec("DELETE FROM pending_venue_edits")
+	_, _ = sqlDB.Exec("DELETE FROM release_labels")
+	_, _ = sqlDB.Exec("DELETE FROM artist_labels")
+	_, _ = sqlDB.Exec("DELETE FROM labels")
 	_, _ = sqlDB.Exec("DELETE FROM release_external_links")
 	_, _ = sqlDB.Exec("DELETE FROM artist_releases")
 	_, _ = sqlDB.Exec("DELETE FROM releases")

--- a/backend/internal/api/handlers/label.go
+++ b/backend/internal/api/handlers/label.go
@@ -1,0 +1,458 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"psychic-homily-backend/internal/api/middleware"
+	apperrors "psychic-homily-backend/internal/errors"
+	"psychic-homily-backend/internal/logger"
+	"psychic-homily-backend/internal/services"
+)
+
+type LabelHandler struct {
+	labelService    services.LabelServiceInterface
+	auditLogService services.AuditLogServiceInterface
+}
+
+func NewLabelHandler(labelService services.LabelServiceInterface, auditLogService services.AuditLogServiceInterface) *LabelHandler {
+	return &LabelHandler{
+		labelService:    labelService,
+		auditLogService: auditLogService,
+	}
+}
+
+// ============================================================================
+// List Labels
+// ============================================================================
+
+// ListLabelsRequest represents the request for listing labels
+type ListLabelsRequest struct {
+	Status string `query:"status" required:"false" doc:"Filter by status (active, inactive, defunct)" example:"active"`
+	City   string `query:"city" required:"false" doc:"Filter by city" example:"Phoenix"`
+	State  string `query:"state" required:"false" doc:"Filter by state" example:"AZ"`
+}
+
+// ListLabelsResponse represents the response for listing labels
+type ListLabelsResponse struct {
+	Body struct {
+		Labels []*services.LabelListResponse `json:"labels" doc:"List of labels"`
+		Count  int                           `json:"count" doc:"Number of labels"`
+	}
+}
+
+// ListLabelsHandler handles GET /labels
+func (h *LabelHandler) ListLabelsHandler(ctx context.Context, req *ListLabelsRequest) (*ListLabelsResponse, error) {
+	filters := make(map[string]interface{})
+
+	if req.Status != "" {
+		filters["status"] = req.Status
+	}
+	if req.City != "" {
+		filters["city"] = req.City
+	}
+	if req.State != "" {
+		filters["state"] = req.State
+	}
+
+	labels, err := h.labelService.ListLabels(filters)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Failed to fetch labels", err)
+	}
+
+	resp := &ListLabelsResponse{}
+	resp.Body.Labels = labels
+	resp.Body.Count = len(labels)
+
+	return resp, nil
+}
+
+// ============================================================================
+// Get Label
+// ============================================================================
+
+// GetLabelRequest represents the request for getting a single label
+type GetLabelRequest struct {
+	LabelID string `path:"label_id" doc:"Label ID or slug" example:"sub-pop"`
+}
+
+// GetLabelResponse represents the response for the get label endpoint
+type GetLabelResponse struct {
+	Body *services.LabelDetailResponse
+}
+
+// GetLabelHandler handles GET /labels/{label_id}
+func (h *LabelHandler) GetLabelHandler(ctx context.Context, req *GetLabelRequest) (*GetLabelResponse, error) {
+	var label *services.LabelDetailResponse
+	var err error
+
+	// Try to parse as numeric ID first
+	if id, parseErr := strconv.ParseUint(req.LabelID, 10, 32); parseErr == nil {
+		label, err = h.labelService.GetLabel(uint(id))
+	} else {
+		// Fall back to slug lookup
+		label, err = h.labelService.GetLabelBySlug(req.LabelID)
+	}
+
+	if err != nil {
+		var labelErr *apperrors.LabelError
+		if errors.As(err, &labelErr) && labelErr.Code == apperrors.CodeLabelNotFound {
+			return nil, huma.Error404NotFound("Label not found")
+		}
+		return nil, huma.Error500InternalServerError("Failed to fetch label", err)
+	}
+
+	return &GetLabelResponse{Body: label}, nil
+}
+
+// ============================================================================
+// Create Label
+// ============================================================================
+
+// CreateLabelRequest represents the request for creating a label
+type CreateLabelRequest struct {
+	Body struct {
+		Name        string  `json:"name" doc:"Label name" example:"Sub Pop"`
+		City        *string `json:"city,omitempty" required:"false" doc:"City" example:"Seattle"`
+		State       *string `json:"state,omitempty" required:"false" doc:"State" example:"WA"`
+		Country     *string `json:"country,omitempty" required:"false" doc:"Country" example:"US"`
+		FoundedYear *int    `json:"founded_year,omitempty" required:"false" doc:"Year founded" example:"1988"`
+		Status      string  `json:"status,omitempty" required:"false" doc:"Status (active, inactive, defunct)" example:"active"`
+		Description *string `json:"description,omitempty" required:"false" doc:"Description"`
+		Instagram   *string `json:"instagram,omitempty" required:"false" doc:"Instagram handle"`
+		Facebook    *string `json:"facebook,omitempty" required:"false" doc:"Facebook URL"`
+		Twitter     *string `json:"twitter,omitempty" required:"false" doc:"Twitter handle"`
+		YouTube     *string `json:"youtube,omitempty" required:"false" doc:"YouTube URL"`
+		Spotify     *string `json:"spotify,omitempty" required:"false" doc:"Spotify URL"`
+		SoundCloud  *string `json:"soundcloud,omitempty" required:"false" doc:"SoundCloud URL"`
+		Bandcamp    *string `json:"bandcamp,omitempty" required:"false" doc:"Bandcamp URL"`
+		Website     *string `json:"website,omitempty" required:"false" doc:"Website URL"`
+	}
+}
+
+// CreateLabelResponse represents the response for creating a label
+type CreateLabelResponse struct {
+	Body *services.LabelDetailResponse
+}
+
+// CreateLabelHandler handles POST /labels
+func (h *LabelHandler) CreateLabelHandler(ctx context.Context, req *CreateLabelRequest) (*CreateLabelResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	// Verify admin access
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil || !user.IsAdmin {
+		return nil, huma.Error403Forbidden("Admin access required")
+	}
+
+	if req.Body.Name == "" {
+		return nil, huma.Error400BadRequest("Name is required")
+	}
+
+	serviceReq := &services.CreateLabelRequest{
+		Name:        req.Body.Name,
+		City:        req.Body.City,
+		State:       req.Body.State,
+		Country:     req.Body.Country,
+		FoundedYear: req.Body.FoundedYear,
+		Status:      req.Body.Status,
+		Description: req.Body.Description,
+		Instagram:   req.Body.Instagram,
+		Facebook:    req.Body.Facebook,
+		Twitter:     req.Body.Twitter,
+		YouTube:     req.Body.YouTube,
+		Spotify:     req.Body.Spotify,
+		SoundCloud:  req.Body.SoundCloud,
+		Bandcamp:    req.Body.Bandcamp,
+		Website:     req.Body.Website,
+	}
+
+	label, err := h.labelService.CreateLabel(serviceReq)
+	if err != nil {
+		logger.FromContext(ctx).Error("create_label_failed",
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to create label (request_id: %s)", requestID),
+		)
+	}
+
+	// Audit log (fire and forget)
+	if h.auditLogService != nil {
+		go func() {
+			h.auditLogService.LogAction(user.ID, "create_label", "label", label.ID, nil)
+		}()
+	}
+
+	logger.FromContext(ctx).Info("label_created",
+		"label_id", label.ID,
+		"admin_id", user.ID,
+		"request_id", requestID,
+	)
+
+	return &CreateLabelResponse{Body: label}, nil
+}
+
+// ============================================================================
+// Update Label
+// ============================================================================
+
+// UpdateLabelRequest represents the request for updating a label
+type UpdateLabelRequest struct {
+	LabelID string `path:"label_id" doc:"Label ID or slug" example:"1"`
+	Body    struct {
+		Name        *string `json:"name,omitempty" required:"false" doc:"Label name"`
+		City        *string `json:"city,omitempty" required:"false" doc:"City"`
+		State       *string `json:"state,omitempty" required:"false" doc:"State"`
+		Country     *string `json:"country,omitempty" required:"false" doc:"Country"`
+		FoundedYear *int    `json:"founded_year,omitempty" required:"false" doc:"Year founded"`
+		Status      *string `json:"status,omitempty" required:"false" doc:"Status (active, inactive, defunct)"`
+		Description *string `json:"description,omitempty" required:"false" doc:"Description"`
+		Instagram   *string `json:"instagram,omitempty" required:"false" doc:"Instagram handle"`
+		Facebook    *string `json:"facebook,omitempty" required:"false" doc:"Facebook URL"`
+		Twitter     *string `json:"twitter,omitempty" required:"false" doc:"Twitter handle"`
+		YouTube     *string `json:"youtube,omitempty" required:"false" doc:"YouTube URL"`
+		Spotify     *string `json:"spotify,omitempty" required:"false" doc:"Spotify URL"`
+		SoundCloud  *string `json:"soundcloud,omitempty" required:"false" doc:"SoundCloud URL"`
+		Bandcamp    *string `json:"bandcamp,omitempty" required:"false" doc:"Bandcamp URL"`
+		Website     *string `json:"website,omitempty" required:"false" doc:"Website URL"`
+	}
+}
+
+// UpdateLabelResponse represents the response for updating a label
+type UpdateLabelResponse struct {
+	Body *services.LabelDetailResponse
+}
+
+// UpdateLabelHandler handles PUT /labels/{label_id}
+func (h *LabelHandler) UpdateLabelHandler(ctx context.Context, req *UpdateLabelRequest) (*UpdateLabelResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	// Verify admin access
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil || !user.IsAdmin {
+		return nil, huma.Error403Forbidden("Admin access required")
+	}
+
+	// Resolve label ID
+	labelID, err := h.resolveLabelID(req.LabelID)
+	if err != nil {
+		return nil, err
+	}
+
+	serviceReq := &services.UpdateLabelRequest{
+		Name:        req.Body.Name,
+		City:        req.Body.City,
+		State:       req.Body.State,
+		Country:     req.Body.Country,
+		FoundedYear: req.Body.FoundedYear,
+		Status:      req.Body.Status,
+		Description: req.Body.Description,
+		Instagram:   req.Body.Instagram,
+		Facebook:    req.Body.Facebook,
+		Twitter:     req.Body.Twitter,
+		YouTube:     req.Body.YouTube,
+		Spotify:     req.Body.Spotify,
+		SoundCloud:  req.Body.SoundCloud,
+		Bandcamp:    req.Body.Bandcamp,
+		Website:     req.Body.Website,
+	}
+
+	label, err := h.labelService.UpdateLabel(labelID, serviceReq)
+	if err != nil {
+		var labelErr *apperrors.LabelError
+		if errors.As(err, &labelErr) && labelErr.Code == apperrors.CodeLabelNotFound {
+			return nil, huma.Error404NotFound("Label not found")
+		}
+		logger.FromContext(ctx).Error("update_label_failed",
+			"label_id", labelID,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to update label (request_id: %s)", requestID),
+		)
+	}
+
+	// Audit log (fire and forget)
+	if h.auditLogService != nil {
+		go func() {
+			h.auditLogService.LogAction(user.ID, "edit_label", "label", labelID, nil)
+		}()
+	}
+
+	logger.FromContext(ctx).Info("label_updated",
+		"label_id", labelID,
+		"admin_id", user.ID,
+		"request_id", requestID,
+	)
+
+	return &UpdateLabelResponse{Body: label}, nil
+}
+
+// ============================================================================
+// Delete Label
+// ============================================================================
+
+// DeleteLabelRequest represents the request for deleting a label
+type DeleteLabelRequest struct {
+	LabelID string `path:"label_id" doc:"Label ID" example:"1"`
+}
+
+// DeleteLabelHandler handles DELETE /labels/{label_id}
+func (h *LabelHandler) DeleteLabelHandler(ctx context.Context, req *DeleteLabelRequest) (*struct{}, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	// Verify admin access
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil || !user.IsAdmin {
+		return nil, huma.Error403Forbidden("Admin access required")
+	}
+
+	// Resolve label ID
+	labelID, err := h.resolveLabelID(req.LabelID)
+	if err != nil {
+		return nil, err
+	}
+
+	err = h.labelService.DeleteLabel(labelID)
+	if err != nil {
+		var labelErr *apperrors.LabelError
+		if errors.As(err, &labelErr) && labelErr.Code == apperrors.CodeLabelNotFound {
+			return nil, huma.Error404NotFound("Label not found")
+		}
+		logger.FromContext(ctx).Error("delete_label_failed",
+			"label_id", labelID,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to delete label (request_id: %s)", requestID),
+		)
+	}
+
+	// Audit log (fire and forget)
+	if h.auditLogService != nil {
+		go func() {
+			h.auditLogService.LogAction(user.ID, "delete_label", "label", labelID, nil)
+		}()
+	}
+
+	logger.FromContext(ctx).Info("label_deleted",
+		"label_id", labelID,
+		"admin_id", user.ID,
+		"request_id", requestID,
+	)
+
+	return nil, nil
+}
+
+// ============================================================================
+// Label Roster (Artists)
+// ============================================================================
+
+// GetLabelRosterRequest represents the request for getting a label's artists
+type GetLabelRosterRequest struct {
+	LabelID string `path:"label_id" doc:"Label ID or slug" example:"sub-pop"`
+}
+
+// GetLabelRosterResponse represents the response for the label roster endpoint
+type GetLabelRosterResponse struct {
+	Body struct {
+		Artists []*services.LabelArtistResponse `json:"artists" doc:"List of artists"`
+		Count   int                             `json:"count" doc:"Number of artists"`
+	}
+}
+
+// GetLabelRosterHandler handles GET /labels/{label_id}/artists
+func (h *LabelHandler) GetLabelRosterHandler(ctx context.Context, req *GetLabelRosterRequest) (*GetLabelRosterResponse, error) {
+	// Resolve label ID
+	labelID, err := h.resolveLabelID(req.LabelID)
+	if err != nil {
+		return nil, err
+	}
+
+	artists, err := h.labelService.GetLabelRoster(labelID)
+	if err != nil {
+		var labelErr *apperrors.LabelError
+		if errors.As(err, &labelErr) && labelErr.Code == apperrors.CodeLabelNotFound {
+			return nil, huma.Error404NotFound("Label not found")
+		}
+		return nil, huma.Error500InternalServerError("Failed to fetch label roster", err)
+	}
+
+	resp := &GetLabelRosterResponse{}
+	resp.Body.Artists = artists
+	resp.Body.Count = len(artists)
+
+	return resp, nil
+}
+
+// ============================================================================
+// Label Catalog (Releases)
+// ============================================================================
+
+// GetLabelCatalogRequest represents the request for getting a label's releases
+type GetLabelCatalogRequest struct {
+	LabelID string `path:"label_id" doc:"Label ID or slug" example:"sub-pop"`
+}
+
+// GetLabelCatalogResponse represents the response for the label catalog endpoint
+type GetLabelCatalogResponse struct {
+	Body struct {
+		Releases []*services.LabelReleaseResponse `json:"releases" doc:"List of releases"`
+		Count    int                               `json:"count" doc:"Number of releases"`
+	}
+}
+
+// GetLabelCatalogHandler handles GET /labels/{label_id}/releases
+func (h *LabelHandler) GetLabelCatalogHandler(ctx context.Context, req *GetLabelCatalogRequest) (*GetLabelCatalogResponse, error) {
+	// Resolve label ID
+	labelID, err := h.resolveLabelID(req.LabelID)
+	if err != nil {
+		return nil, err
+	}
+
+	releases, err := h.labelService.GetLabelCatalog(labelID)
+	if err != nil {
+		var labelErr *apperrors.LabelError
+		if errors.As(err, &labelErr) && labelErr.Code == apperrors.CodeLabelNotFound {
+			return nil, huma.Error404NotFound("Label not found")
+		}
+		return nil, huma.Error500InternalServerError("Failed to fetch label catalog", err)
+	}
+
+	resp := &GetLabelCatalogResponse{}
+	resp.Body.Releases = releases
+	resp.Body.Count = len(releases)
+
+	return resp, nil
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+// resolveLabelID tries to parse the ID as a number first, then falls back to slug lookup
+func (h *LabelHandler) resolveLabelID(idOrSlug string) (uint, error) {
+	if id, parseErr := strconv.ParseUint(idOrSlug, 10, 32); parseErr == nil {
+		return uint(id), nil
+	}
+
+	// Fall back to slug lookup
+	label, err := h.labelService.GetLabelBySlug(idOrSlug)
+	if err != nil {
+		var labelErr *apperrors.LabelError
+		if errors.As(err, &labelErr) && labelErr.Code == apperrors.CodeLabelNotFound {
+			return 0, huma.Error404NotFound("Label not found")
+		}
+		return 0, huma.Error500InternalServerError("Failed to fetch label", err)
+	}
+
+	return label.ID, nil
+}

--- a/backend/internal/api/handlers/label_integration_test.go
+++ b/backend/internal/api/handlers/label_integration_test.go
@@ -1,0 +1,352 @@
+package handlers
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services"
+)
+
+type LabelHandlerIntegrationSuite struct {
+	suite.Suite
+	deps    *handlerIntegrationDeps
+	handler *LabelHandler
+}
+
+func (s *LabelHandlerIntegrationSuite) SetupSuite() {
+	s.deps = setupHandlerIntegrationDeps(s.T())
+	s.handler = NewLabelHandler(s.deps.labelService, s.deps.auditLogService)
+}
+
+func (s *LabelHandlerIntegrationSuite) TearDownTest() {
+	cleanupTables(s.deps.db)
+}
+
+func (s *LabelHandlerIntegrationSuite) TearDownSuite() {
+	if s.deps.container != nil {
+		s.deps.container.Terminate(s.deps.ctx)
+	}
+}
+
+func TestLabelHandlerIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	suite.Run(t, new(LabelHandlerIntegrationSuite))
+}
+
+// --- Helpers ---
+
+func (s *LabelHandlerIntegrationSuite) createLabelViaService(name string) *services.LabelDetailResponse {
+	resp, err := s.deps.labelService.CreateLabel(&services.CreateLabelRequest{Name: name})
+	s.Require().NoError(err)
+	return resp
+}
+
+func (s *LabelHandlerIntegrationSuite) createArtistForLabel(name string) *models.Artist {
+	artist := &models.Artist{Name: name}
+	s.deps.db.Create(artist)
+	return artist
+}
+
+func (s *LabelHandlerIntegrationSuite) createReleaseForLabel(title string) *models.Release {
+	slug := title
+	release := &models.Release{Title: title, Slug: &slug}
+	s.deps.db.Create(release)
+	return release
+}
+
+// --- ListLabelsHandler ---
+
+func (s *LabelHandlerIntegrationSuite) TestListLabels_Success() {
+	s.createLabelViaService("Label A")
+	s.createLabelViaService("Label B")
+	s.createLabelViaService("Label C")
+
+	req := &ListLabelsRequest{}
+	resp, err := s.handler.ListLabelsHandler(s.deps.ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.GreaterOrEqual(resp.Body.Count, 3)
+}
+
+func (s *LabelHandlerIntegrationSuite) TestListLabels_Empty() {
+	req := &ListLabelsRequest{}
+	resp, err := s.handler.ListLabelsHandler(s.deps.ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal(0, resp.Body.Count)
+}
+
+func (s *LabelHandlerIntegrationSuite) TestListLabels_FilterByStatus() {
+	s.deps.labelService.CreateLabel(&services.CreateLabelRequest{Name: "Active Label", Status: "active"})
+	s.deps.labelService.CreateLabel(&services.CreateLabelRequest{Name: "Defunct Label", Status: "defunct"})
+
+	req := &ListLabelsRequest{Status: "defunct"}
+	resp, err := s.handler.ListLabelsHandler(s.deps.ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal(1, resp.Body.Count)
+	s.Equal("Defunct Label", resp.Body.Labels[0].Name)
+}
+
+// --- GetLabelHandler ---
+
+func (s *LabelHandlerIntegrationSuite) TestGetLabel_ByID() {
+	label := s.createLabelViaService("Test Label")
+
+	req := &GetLabelRequest{LabelID: fmt.Sprintf("%d", label.ID)}
+	resp, err := s.handler.GetLabelHandler(s.deps.ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal("Test Label", resp.Body.Name)
+}
+
+func (s *LabelHandlerIntegrationSuite) TestGetLabel_BySlug() {
+	s.createLabelViaService("Slug Label")
+
+	req := &GetLabelRequest{LabelID: "slug-label"}
+	resp, err := s.handler.GetLabelHandler(s.deps.ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal("Slug Label", resp.Body.Name)
+}
+
+func (s *LabelHandlerIntegrationSuite) TestGetLabel_NotFound() {
+	req := &GetLabelRequest{LabelID: "99999"}
+	_, err := s.handler.GetLabelHandler(s.deps.ctx, req)
+	assertHumaError(s.T(), err, 404)
+}
+
+// --- CreateLabelHandler ---
+
+func (s *LabelHandlerIntegrationSuite) TestCreateLabel_AdminSuccess() {
+	admin := createAdminUser(s.deps.db)
+	ctx := ctxWithUser(admin)
+
+	year := 1988
+	req := &CreateLabelRequest{}
+	req.Body.Name = "New Label"
+	req.Body.FoundedYear = &year
+	req.Body.Status = "active"
+
+	resp, err := s.handler.CreateLabelHandler(ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal("New Label", resp.Body.Name)
+	s.Equal(1988, *resp.Body.FoundedYear)
+	s.Equal("active", resp.Body.Status)
+}
+
+func (s *LabelHandlerIntegrationSuite) TestCreateLabel_NonAdminForbidden() {
+	user := createTestUser(s.deps.db)
+	ctx := ctxWithUser(user)
+
+	req := &CreateLabelRequest{}
+	req.Body.Name = "Forbidden Label"
+
+	_, err := s.handler.CreateLabelHandler(ctx, req)
+	assertHumaError(s.T(), err, 403)
+}
+
+func (s *LabelHandlerIntegrationSuite) TestCreateLabel_NoAuth() {
+	req := &CreateLabelRequest{}
+	req.Body.Name = "No Auth Label"
+
+	_, err := s.handler.CreateLabelHandler(s.deps.ctx, req)
+	assertHumaError(s.T(), err, 403)
+}
+
+func (s *LabelHandlerIntegrationSuite) TestCreateLabel_EmptyName() {
+	admin := createAdminUser(s.deps.db)
+	ctx := ctxWithUser(admin)
+
+	req := &CreateLabelRequest{}
+	req.Body.Name = ""
+
+	_, err := s.handler.CreateLabelHandler(ctx, req)
+	assertHumaError(s.T(), err, 400)
+}
+
+// --- UpdateLabelHandler ---
+
+func (s *LabelHandlerIntegrationSuite) TestUpdateLabel_Success() {
+	admin := createAdminUser(s.deps.db)
+	label := s.createLabelViaService("Original Label")
+
+	ctx := ctxWithUser(admin)
+	newName := "Updated Label"
+	req := &UpdateLabelRequest{LabelID: fmt.Sprintf("%d", label.ID)}
+	req.Body.Name = &newName
+
+	resp, err := s.handler.UpdateLabelHandler(ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal("Updated Label", resp.Body.Name)
+}
+
+func (s *LabelHandlerIntegrationSuite) TestUpdateLabel_BySlug() {
+	admin := createAdminUser(s.deps.db)
+	s.createLabelViaService("Slug Update Label")
+
+	ctx := ctxWithUser(admin)
+	newStatus := "inactive"
+	req := &UpdateLabelRequest{LabelID: "slug-update-label"}
+	req.Body.Status = &newStatus
+
+	resp, err := s.handler.UpdateLabelHandler(ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal("inactive", resp.Body.Status)
+}
+
+func (s *LabelHandlerIntegrationSuite) TestUpdateLabel_NotFound() {
+	admin := createAdminUser(s.deps.db)
+	ctx := ctxWithUser(admin)
+	newName := "New Name"
+	req := &UpdateLabelRequest{LabelID: "99999"}
+	req.Body.Name = &newName
+
+	_, err := s.handler.UpdateLabelHandler(ctx, req)
+	assertHumaError(s.T(), err, 404)
+}
+
+func (s *LabelHandlerIntegrationSuite) TestUpdateLabel_NonAdminForbidden() {
+	user := createTestUser(s.deps.db)
+	label := s.createLabelViaService("Forbidden Update Label")
+
+	ctx := ctxWithUser(user)
+	newName := "Hacked Name"
+	req := &UpdateLabelRequest{LabelID: fmt.Sprintf("%d", label.ID)}
+	req.Body.Name = &newName
+
+	_, err := s.handler.UpdateLabelHandler(ctx, req)
+	assertHumaError(s.T(), err, 403)
+}
+
+// --- DeleteLabelHandler ---
+
+func (s *LabelHandlerIntegrationSuite) TestDeleteLabel_Success() {
+	admin := createAdminUser(s.deps.db)
+	label := s.createLabelViaService("Deletable Label")
+
+	ctx := ctxWithUser(admin)
+	req := &DeleteLabelRequest{LabelID: fmt.Sprintf("%d", label.ID)}
+	_, err := s.handler.DeleteLabelHandler(ctx, req)
+	s.NoError(err)
+
+	// Verify label is gone
+	getReq := &GetLabelRequest{LabelID: fmt.Sprintf("%d", label.ID)}
+	_, err = s.handler.GetLabelHandler(s.deps.ctx, getReq)
+	assertHumaError(s.T(), err, 404)
+}
+
+func (s *LabelHandlerIntegrationSuite) TestDeleteLabel_NotFound() {
+	admin := createAdminUser(s.deps.db)
+	ctx := ctxWithUser(admin)
+	req := &DeleteLabelRequest{LabelID: "99999"}
+
+	_, err := s.handler.DeleteLabelHandler(ctx, req)
+	assertHumaError(s.T(), err, 404)
+}
+
+func (s *LabelHandlerIntegrationSuite) TestDeleteLabel_NonAdminForbidden() {
+	user := createTestUser(s.deps.db)
+	label := s.createLabelViaService("Protected Label")
+
+	ctx := ctxWithUser(user)
+	req := &DeleteLabelRequest{LabelID: fmt.Sprintf("%d", label.ID)}
+
+	_, err := s.handler.DeleteLabelHandler(ctx, req)
+	assertHumaError(s.T(), err, 403)
+}
+
+// --- GetLabelRosterHandler ---
+
+func (s *LabelHandlerIntegrationSuite) TestGetLabelRoster_Success() {
+	label := s.createLabelViaService("Roster Label")
+	artist := s.createArtistForLabel("Roster Artist")
+	s.deps.db.Exec("INSERT INTO artist_labels (artist_id, label_id) VALUES (?, ?)", artist.ID, label.ID)
+
+	req := &GetLabelRosterRequest{LabelID: fmt.Sprintf("%d", label.ID)}
+	resp, err := s.handler.GetLabelRosterHandler(s.deps.ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal(1, resp.Body.Count)
+	s.Equal("Roster Artist", resp.Body.Artists[0].Name)
+}
+
+func (s *LabelHandlerIntegrationSuite) TestGetLabelRoster_BySlug() {
+	label := s.createLabelViaService("Slug Roster Label")
+	artist := s.createArtistForLabel("Slug Roster Artist")
+	s.deps.db.Exec("INSERT INTO artist_labels (artist_id, label_id) VALUES (?, ?)", artist.ID, label.ID)
+
+	req := &GetLabelRosterRequest{LabelID: "slug-roster-label"}
+	resp, err := s.handler.GetLabelRosterHandler(s.deps.ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal(1, resp.Body.Count)
+}
+
+func (s *LabelHandlerIntegrationSuite) TestGetLabelRoster_Empty() {
+	label := s.createLabelViaService("Empty Roster")
+
+	req := &GetLabelRosterRequest{LabelID: fmt.Sprintf("%d", label.ID)}
+	resp, err := s.handler.GetLabelRosterHandler(s.deps.ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal(0, resp.Body.Count)
+}
+
+func (s *LabelHandlerIntegrationSuite) TestGetLabelRoster_LabelNotFound() {
+	req := &GetLabelRosterRequest{LabelID: "99999"}
+	_, err := s.handler.GetLabelRosterHandler(s.deps.ctx, req)
+	assertHumaError(s.T(), err, 404)
+}
+
+// --- GetLabelCatalogHandler ---
+
+func (s *LabelHandlerIntegrationSuite) TestGetLabelCatalog_Success() {
+	label := s.createLabelViaService("Catalog Label")
+	release := s.createReleaseForLabel("Catalog Release")
+	s.deps.db.Exec("INSERT INTO release_labels (release_id, label_id, catalog_number) VALUES (?, ?, 'CAT-001')", release.ID, label.ID)
+
+	req := &GetLabelCatalogRequest{LabelID: fmt.Sprintf("%d", label.ID)}
+	resp, err := s.handler.GetLabelCatalogHandler(s.deps.ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal(1, resp.Body.Count)
+	s.Equal("Catalog Release", resp.Body.Releases[0].Title)
+	s.Equal("CAT-001", *resp.Body.Releases[0].CatalogNumber)
+}
+
+func (s *LabelHandlerIntegrationSuite) TestGetLabelCatalog_BySlug() {
+	label := s.createLabelViaService("Slug Catalog Label")
+	release := s.createReleaseForLabel("Slug Catalog Release")
+	s.deps.db.Exec("INSERT INTO release_labels (release_id, label_id) VALUES (?, ?)", release.ID, label.ID)
+
+	req := &GetLabelCatalogRequest{LabelID: "slug-catalog-label"}
+	resp, err := s.handler.GetLabelCatalogHandler(s.deps.ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal(1, resp.Body.Count)
+}
+
+func (s *LabelHandlerIntegrationSuite) TestGetLabelCatalog_Empty() {
+	label := s.createLabelViaService("Empty Catalog")
+
+	req := &GetLabelCatalogRequest{LabelID: fmt.Sprintf("%d", label.ID)}
+	resp, err := s.handler.GetLabelCatalogHandler(s.deps.ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal(0, resp.Body.Count)
+}
+
+func (s *LabelHandlerIntegrationSuite) TestGetLabelCatalog_LabelNotFound() {
+	req := &GetLabelCatalogRequest{LabelID: "99999"}
+	_, err := s.handler.GetLabelCatalogHandler(s.deps.ctx, req)
+	assertHumaError(s.T(), err, 404)
+}

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -84,6 +84,7 @@ func SetupRoutes(router *chi.Mux, sc *services.ServiceContainer, cfg *config.Con
 	setupShowRoutes(router, api, protectedGroup, sc, cfg)
 	setupArtistRoutes(api, protectedGroup, sc)
 	setupReleaseRoutes(api, protectedGroup, sc)
+	setupLabelRoutes(api, protectedGroup, sc)
 	setupVenueRoutes(api, protectedGroup, sc)
 	setupCalendarRoutes(router, protectedGroup, sc, cfg)
 	setupSavedShowRoutes(protectedGroup, sc)
@@ -294,6 +295,21 @@ func setupReleaseRoutes(api huma.API, protected *huma.Group, sc *services.Servic
 	huma.Delete(protected, "/releases/{release_id}", releaseHandler.DeleteReleaseHandler)
 	huma.Post(protected, "/releases/{release_id}/links", releaseHandler.AddExternalLinkHandler)
 	huma.Delete(protected, "/releases/{release_id}/links/{link_id}", releaseHandler.RemoveExternalLinkHandler)
+}
+
+func setupLabelRoutes(api huma.API, protected *huma.Group, sc *services.ServiceContainer) {
+	labelHandler := handlers.NewLabelHandler(sc.Label, sc.AuditLog)
+
+	// Public label endpoints
+	huma.Get(api, "/labels", labelHandler.ListLabelsHandler)
+	huma.Get(api, "/labels/{label_id}", labelHandler.GetLabelHandler)
+	huma.Get(api, "/labels/{label_id}/artists", labelHandler.GetLabelRosterHandler)
+	huma.Get(api, "/labels/{label_id}/releases", labelHandler.GetLabelCatalogHandler)
+
+	// Protected label endpoints (admin-only checks inside handlers)
+	huma.Post(protected, "/labels", labelHandler.CreateLabelHandler)
+	huma.Put(protected, "/labels/{label_id}", labelHandler.UpdateLabelHandler)
+	huma.Delete(protected, "/labels/{label_id}", labelHandler.DeleteLabelHandler)
 }
 
 func setupVenueRoutes(api huma.API, protected *huma.Group, sc *services.ServiceContainer) {

--- a/backend/internal/errors/label.go
+++ b/backend/internal/errors/label.go
@@ -1,0 +1,50 @@
+package errors
+
+import (
+	"fmt"
+)
+
+// Label error codes
+const (
+	CodeLabelNotFound = "LABEL_NOT_FOUND"
+	CodeLabelExists   = "LABEL_EXISTS"
+)
+
+// LabelError represents a label-related error with additional context.
+type LabelError struct {
+	Code      string
+	Message   string
+	Internal  error
+	RequestID string
+	LabelID   uint
+}
+
+// Error implements the error interface.
+func (e *LabelError) Error() string {
+	if e.Internal != nil {
+		return fmt.Sprintf("%s: %s (internal: %v)", e.Code, e.Message, e.Internal)
+	}
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
+// Unwrap returns the internal error for errors.Is/As compatibility.
+func (e *LabelError) Unwrap() error {
+	return e.Internal
+}
+
+// ErrLabelNotFound creates a label not found error.
+func ErrLabelNotFound(labelID uint) *LabelError {
+	return &LabelError{
+		Code:    CodeLabelNotFound,
+		Message: "Label not found",
+		LabelID: labelID,
+	}
+}
+
+// ErrLabelExists creates a label-already-exists error.
+func ErrLabelExists(name string) *LabelError {
+	return &LabelError{
+		Code:    CodeLabelExists,
+		Message: fmt.Sprintf("Label with name '%s' already exists", name),
+	}
+}

--- a/backend/internal/services/container.go
+++ b/backend/internal/services/container.go
@@ -19,6 +19,7 @@ type ServiceContainer struct {
 	AuditLog      *AuditLogService
 	Calendar      *CalendarService
 	FavoriteVenue *FavoriteVenueService
+	Label         *LabelService
 	Release       *ReleaseService
 	SavedShow     *SavedShowService
 	Show          *ShowService
@@ -67,6 +68,7 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 		AuditLog:      NewAuditLogService(database),
 		Calendar:      NewCalendarService(database, savedShow),
 		FavoriteVenue: NewFavoriteVenueService(database),
+		Label:         NewLabelService(database),
 		Release:       NewReleaseService(database),
 		SavedShow:     savedShow,
 		Show:          NewShowService(database),

--- a/backend/internal/services/interfaces.go
+++ b/backend/internal/services/interfaces.go
@@ -300,6 +300,18 @@ type AdminStatsServiceInterface interface {
 	GetDashboardStats() (*AdminDashboardStats, error)
 }
 
+// LabelServiceInterface defines the contract for label operations.
+type LabelServiceInterface interface {
+	CreateLabel(req *CreateLabelRequest) (*LabelDetailResponse, error)
+	GetLabel(labelID uint) (*LabelDetailResponse, error)
+	GetLabelBySlug(slug string) (*LabelDetailResponse, error)
+	ListLabels(filters map[string]interface{}) ([]*LabelListResponse, error)
+	UpdateLabel(labelID uint, req *UpdateLabelRequest) (*LabelDetailResponse, error)
+	DeleteLabel(labelID uint) error
+	GetLabelRoster(labelID uint) ([]*LabelArtistResponse, error)
+	GetLabelCatalog(labelID uint) ([]*LabelReleaseResponse, error)
+}
+
 // ReleaseServiceInterface defines the contract for release operations.
 type ReleaseServiceInterface interface {
 	CreateRelease(req *CreateReleaseRequest) (*ReleaseDetailResponse, error)
@@ -348,5 +360,6 @@ var (
 	_ AdminStatsServiceInterface    = (*AdminStatsService)(nil)
 	_ CalendarServiceInterface      = (*CalendarService)(nil)
 	_ ReminderServiceInterface      = (*ReminderService)(nil)
+	_ LabelServiceInterface          = (*LabelService)(nil)
 	_ ReleaseServiceInterface       = (*ReleaseService)(nil)
 )

--- a/backend/internal/services/label.go
+++ b/backend/internal/services/label.go
@@ -1,0 +1,536 @@
+package services
+
+import (
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/db"
+	apperrors "psychic-homily-backend/internal/errors"
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/utils"
+)
+
+// LabelService handles label-related business logic
+type LabelService struct {
+	db *gorm.DB
+}
+
+// NewLabelService creates a new label service
+func NewLabelService(database *gorm.DB) *LabelService {
+	if database == nil {
+		database = db.GetDB()
+	}
+	return &LabelService{
+		db: database,
+	}
+}
+
+// CreateLabelRequest represents the data needed to create a new label
+type CreateLabelRequest struct {
+	Name        string  `json:"name" validate:"required"`
+	City        *string `json:"city"`
+	State       *string `json:"state"`
+	Country     *string `json:"country"`
+	FoundedYear *int    `json:"founded_year"`
+	Status      string  `json:"status"`
+	Description *string `json:"description"`
+	Instagram   *string `json:"instagram"`
+	Facebook    *string `json:"facebook"`
+	Twitter     *string `json:"twitter"`
+	YouTube     *string `json:"youtube"`
+	Spotify     *string `json:"spotify"`
+	SoundCloud  *string `json:"soundcloud"`
+	Bandcamp    *string `json:"bandcamp"`
+	Website     *string `json:"website"`
+}
+
+// UpdateLabelRequest represents the data that can be updated on a label
+type UpdateLabelRequest struct {
+	Name        *string `json:"name"`
+	City        *string `json:"city"`
+	State       *string `json:"state"`
+	Country     *string `json:"country"`
+	FoundedYear *int    `json:"founded_year"`
+	Status      *string `json:"status"`
+	Description *string `json:"description"`
+	Instagram   *string `json:"instagram"`
+	Facebook    *string `json:"facebook"`
+	Twitter     *string `json:"twitter"`
+	YouTube     *string `json:"youtube"`
+	Spotify     *string `json:"spotify"`
+	SoundCloud  *string `json:"soundcloud"`
+	Bandcamp    *string `json:"bandcamp"`
+	Website     *string `json:"website"`
+}
+
+// LabelDetailResponse represents the label data returned to clients
+type LabelDetailResponse struct {
+	ID           uint           `json:"id"`
+	Name         string         `json:"name"`
+	Slug         string         `json:"slug"`
+	City         *string        `json:"city"`
+	State        *string        `json:"state"`
+	Country      *string        `json:"country"`
+	FoundedYear  *int           `json:"founded_year"`
+	Status       string         `json:"status"`
+	Description  *string        `json:"description"`
+	Social       SocialResponse `json:"social"`
+	ArtistCount  int            `json:"artist_count"`
+	ReleaseCount int            `json:"release_count"`
+	CreatedAt    time.Time      `json:"created_at"`
+	UpdatedAt    time.Time      `json:"updated_at"`
+}
+
+// LabelListResponse represents a label in list views
+type LabelListResponse struct {
+	ID           uint    `json:"id"`
+	Name         string  `json:"name"`
+	Slug         string  `json:"slug"`
+	City         *string `json:"city"`
+	State        *string `json:"state"`
+	Status       string  `json:"status"`
+	ArtistCount  int     `json:"artist_count"`
+	ReleaseCount int     `json:"release_count"`
+}
+
+// LabelArtistResponse represents an artist on a label
+type LabelArtistResponse struct {
+	ID   uint   `json:"id"`
+	Slug string `json:"slug"`
+	Name string `json:"name"`
+}
+
+// LabelReleaseResponse represents a release on a label
+type LabelReleaseResponse struct {
+	ID            uint    `json:"id"`
+	Title         string  `json:"title"`
+	Slug          string  `json:"slug"`
+	ReleaseType   string  `json:"release_type"`
+	ReleaseYear   *int    `json:"release_year"`
+	CoverArtURL   *string `json:"cover_art_url"`
+	CatalogNumber *string `json:"catalog_number"`
+}
+
+// CreateLabel creates a new label
+func (s *LabelService) CreateLabel(req *CreateLabelRequest) (*LabelDetailResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	// Generate unique slug
+	baseSlug := utils.GenerateArtistSlug(req.Name)
+	slug := utils.GenerateUniqueSlug(baseSlug, func(candidate string) bool {
+		var count int64
+		s.db.Model(&models.Label{}).Where("slug = ?", candidate).Count(&count)
+		return count > 0
+	})
+
+	// Determine status, default to "active"
+	status := models.LabelStatus(req.Status)
+	if status == "" {
+		status = models.LabelStatusActive
+	}
+
+	// Create the label
+	label := &models.Label{
+		Name:        req.Name,
+		Slug:        &slug,
+		City:        req.City,
+		State:       req.State,
+		Country:     req.Country,
+		FoundedYear: req.FoundedYear,
+		Status:      status,
+		Description: req.Description,
+		Social: models.Social{
+			Instagram:  req.Instagram,
+			Facebook:   req.Facebook,
+			Twitter:    req.Twitter,
+			YouTube:    req.YouTube,
+			Spotify:    req.Spotify,
+			SoundCloud: req.SoundCloud,
+			Bandcamp:   req.Bandcamp,
+			Website:    req.Website,
+		},
+	}
+
+	if err := s.db.Create(label).Error; err != nil {
+		return nil, fmt.Errorf("failed to create label: %w", err)
+	}
+
+	return s.GetLabel(label.ID)
+}
+
+// GetLabel retrieves a label by ID
+func (s *LabelService) GetLabel(labelID uint) (*LabelDetailResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var label models.Label
+	err := s.db.First(&label, labelID).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, apperrors.ErrLabelNotFound(labelID)
+		}
+		return nil, fmt.Errorf("failed to get label: %w", err)
+	}
+
+	return s.buildDetailResponse(&label)
+}
+
+// GetLabelBySlug retrieves a label by slug
+func (s *LabelService) GetLabelBySlug(slug string) (*LabelDetailResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var label models.Label
+	err := s.db.Where("slug = ?", slug).First(&label).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, apperrors.ErrLabelNotFound(0)
+		}
+		return nil, fmt.Errorf("failed to get label: %w", err)
+	}
+
+	return s.buildDetailResponse(&label)
+}
+
+// ListLabels retrieves labels with optional filtering
+func (s *LabelService) ListLabels(filters map[string]interface{}) ([]*LabelListResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	query := s.db.Model(&models.Label{})
+
+	// Apply filters
+	if status, ok := filters["status"].(string); ok && status != "" {
+		query = query.Where("status = ?", status)
+	}
+	if city, ok := filters["city"].(string); ok && city != "" {
+		query = query.Where("city = ?", city)
+	}
+	if state, ok := filters["state"].(string); ok && state != "" {
+		query = query.Where("state = ?", state)
+	}
+
+	// Order by name ASC
+	query = query.Order("name ASC")
+
+	var labels []models.Label
+	err := query.Find(&labels).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to list labels: %w", err)
+	}
+
+	// Batch-load artist counts and release counts
+	labelIDs := make([]uint, len(labels))
+	for i, l := range labels {
+		labelIDs[i] = l.ID
+	}
+
+	artistCounts := make(map[uint]int)
+	releaseCounts := make(map[uint]int)
+
+	if len(labelIDs) > 0 {
+		type CountResult struct {
+			LabelID uint
+			Count   int
+		}
+
+		// Artist counts
+		var aCounts []CountResult
+		s.db.Table("artist_labels").
+			Select("label_id, COUNT(DISTINCT artist_id) as count").
+			Where("label_id IN ?", labelIDs).
+			Group("label_id").
+			Find(&aCounts)
+		for _, c := range aCounts {
+			artistCounts[c.LabelID] = c.Count
+		}
+
+		// Release counts
+		var rCounts []CountResult
+		s.db.Table("release_labels").
+			Select("label_id, COUNT(DISTINCT release_id) as count").
+			Where("label_id IN ?", labelIDs).
+			Group("label_id").
+			Find(&rCounts)
+		for _, c := range rCounts {
+			releaseCounts[c.LabelID] = c.Count
+		}
+	}
+
+	// Build responses
+	responses := make([]*LabelListResponse, len(labels))
+	for i, label := range labels {
+		slug := ""
+		if label.Slug != nil {
+			slug = *label.Slug
+		}
+		responses[i] = &LabelListResponse{
+			ID:           label.ID,
+			Name:         label.Name,
+			Slug:         slug,
+			City:         label.City,
+			State:        label.State,
+			Status:       string(label.Status),
+			ArtistCount:  artistCounts[label.ID],
+			ReleaseCount: releaseCounts[label.ID],
+		}
+	}
+
+	return responses, nil
+}
+
+// UpdateLabel updates an existing label
+func (s *LabelService) UpdateLabel(labelID uint, req *UpdateLabelRequest) (*LabelDetailResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	// Check if label exists
+	var label models.Label
+	err := s.db.First(&label, labelID).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, apperrors.ErrLabelNotFound(labelID)
+		}
+		return nil, fmt.Errorf("failed to get label: %w", err)
+	}
+
+	updates := map[string]interface{}{}
+
+	if req.Name != nil {
+		updates["name"] = *req.Name
+		// Regenerate slug when name changes
+		baseSlug := utils.GenerateArtistSlug(*req.Name)
+		slug := utils.GenerateUniqueSlug(baseSlug, func(candidate string) bool {
+			var count int64
+			s.db.Model(&models.Label{}).Where("slug = ? AND id != ?", candidate, labelID).Count(&count)
+			return count > 0
+		})
+		updates["slug"] = slug
+	}
+	if req.City != nil {
+		updates["city"] = *req.City
+	}
+	if req.State != nil {
+		updates["state"] = *req.State
+	}
+	if req.Country != nil {
+		updates["country"] = *req.Country
+	}
+	if req.FoundedYear != nil {
+		updates["founded_year"] = *req.FoundedYear
+	}
+	if req.Status != nil {
+		updates["status"] = *req.Status
+	}
+	if req.Description != nil {
+		updates["description"] = *req.Description
+	}
+	if req.Instagram != nil {
+		updates["instagram"] = *req.Instagram
+	}
+	if req.Facebook != nil {
+		updates["facebook"] = *req.Facebook
+	}
+	if req.Twitter != nil {
+		updates["twitter"] = *req.Twitter
+	}
+	if req.YouTube != nil {
+		updates["youtube"] = *req.YouTube
+	}
+	if req.Spotify != nil {
+		updates["spotify"] = *req.Spotify
+	}
+	if req.SoundCloud != nil {
+		updates["soundcloud"] = *req.SoundCloud
+	}
+	if req.Bandcamp != nil {
+		updates["bandcamp"] = *req.Bandcamp
+	}
+	if req.Website != nil {
+		updates["website"] = *req.Website
+	}
+
+	if len(updates) > 0 {
+		err = s.db.Model(&models.Label{}).Where("id = ?", labelID).Updates(updates).Error
+		if err != nil {
+			return nil, fmt.Errorf("failed to update label: %w", err)
+		}
+	}
+
+	return s.GetLabel(labelID)
+}
+
+// DeleteLabel deletes a label
+func (s *LabelService) DeleteLabel(labelID uint) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	// Check if label exists
+	var label models.Label
+	err := s.db.First(&label, labelID).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return apperrors.ErrLabelNotFound(labelID)
+		}
+		return fmt.Errorf("failed to get label: %w", err)
+	}
+
+	// Delete the label (cascades handle junction cleanup via FK)
+	err = s.db.Delete(&label).Error
+	if err != nil {
+		return fmt.Errorf("failed to delete label: %w", err)
+	}
+
+	return nil
+}
+
+// GetLabelRoster retrieves all artists on a label
+func (s *LabelService) GetLabelRoster(labelID uint) ([]*LabelArtistResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	// Verify label exists
+	var label models.Label
+	if err := s.db.First(&label, labelID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, apperrors.ErrLabelNotFound(labelID)
+		}
+		return nil, fmt.Errorf("failed to get label: %w", err)
+	}
+
+	// Get artist IDs from junction table
+	var artistLabels []models.ArtistLabel
+	s.db.Where("label_id = ?", labelID).Find(&artistLabels)
+
+	if len(artistLabels) == 0 {
+		return []*LabelArtistResponse{}, nil
+	}
+
+	artistIDs := make([]uint, len(artistLabels))
+	for i, al := range artistLabels {
+		artistIDs[i] = al.ArtistID
+	}
+
+	var artists []models.Artist
+	s.db.Where("id IN ?", artistIDs).Order("name ASC").Find(&artists)
+
+	responses := make([]*LabelArtistResponse, len(artists))
+	for i, artist := range artists {
+		slug := ""
+		if artist.Slug != nil {
+			slug = *artist.Slug
+		}
+		responses[i] = &LabelArtistResponse{
+			ID:   artist.ID,
+			Slug: slug,
+			Name: artist.Name,
+		}
+	}
+
+	return responses, nil
+}
+
+// GetLabelCatalog retrieves all releases on a label
+func (s *LabelService) GetLabelCatalog(labelID uint) ([]*LabelReleaseResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	// Verify label exists
+	var label models.Label
+	if err := s.db.First(&label, labelID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, apperrors.ErrLabelNotFound(labelID)
+		}
+		return nil, fmt.Errorf("failed to get label: %w", err)
+	}
+
+	// Get release IDs and catalog numbers from junction table
+	var releaseLabels []models.ReleaseLabel
+	s.db.Where("label_id = ?", labelID).Find(&releaseLabels)
+
+	if len(releaseLabels) == 0 {
+		return []*LabelReleaseResponse{}, nil
+	}
+
+	releaseIDs := make([]uint, len(releaseLabels))
+	catalogMap := make(map[uint]*string)
+	for i, rl := range releaseLabels {
+		releaseIDs[i] = rl.ReleaseID
+		catalogMap[rl.ReleaseID] = rl.CatalogNumber
+	}
+
+	var releases []models.Release
+	s.db.Where("id IN ?", releaseIDs).Order("release_year DESC NULLS LAST, title ASC").Find(&releases)
+
+	responses := make([]*LabelReleaseResponse, len(releases))
+	for i, release := range releases {
+		slug := ""
+		if release.Slug != nil {
+			slug = *release.Slug
+		}
+		responses[i] = &LabelReleaseResponse{
+			ID:            release.ID,
+			Title:         release.Title,
+			Slug:          slug,
+			ReleaseType:   string(release.ReleaseType),
+			ReleaseYear:   release.ReleaseYear,
+			CoverArtURL:   release.CoverArtURL,
+			CatalogNumber: catalogMap[release.ID],
+		}
+	}
+
+	return responses, nil
+}
+
+// buildDetailResponse converts a Label model to LabelDetailResponse
+func (s *LabelService) buildDetailResponse(label *models.Label) (*LabelDetailResponse, error) {
+	slug := ""
+	if label.Slug != nil {
+		slug = *label.Slug
+	}
+
+	// Count artists
+	var artistCount int64
+	s.db.Table("artist_labels").Where("label_id = ?", label.ID).Count(&artistCount)
+
+	// Count releases
+	var releaseCount int64
+	s.db.Table("release_labels").Where("label_id = ?", label.ID).Count(&releaseCount)
+
+	return &LabelDetailResponse{
+		ID:          label.ID,
+		Name:        label.Name,
+		Slug:        slug,
+		City:        label.City,
+		State:       label.State,
+		Country:     label.Country,
+		FoundedYear: label.FoundedYear,
+		Status:      string(label.Status),
+		Description: label.Description,
+		Social: SocialResponse{
+			Instagram:  label.Social.Instagram,
+			Facebook:   label.Social.Facebook,
+			Twitter:    label.Social.Twitter,
+			YouTube:    label.Social.YouTube,
+			Spotify:    label.Social.Spotify,
+			SoundCloud: label.Social.SoundCloud,
+			Bandcamp:   label.Social.Bandcamp,
+			Website:    label.Social.Website,
+		},
+		ArtistCount:  int(artistCount),
+		ReleaseCount: int(releaseCount),
+		CreatedAt:    label.CreatedAt,
+		UpdatedAt:    label.UpdatedAt,
+	}, nil
+}

--- a/backend/internal/services/label_test.go
+++ b/backend/internal/services/label_test.go
@@ -1,0 +1,637 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+
+	apperrors "psychic-homily-backend/internal/errors"
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/testutil"
+)
+
+// =============================================================================
+// UNIT TESTS (No Database Required)
+// =============================================================================
+
+func TestNewLabelService(t *testing.T) {
+	labelService := NewLabelService(nil)
+	assert.NotNil(t, labelService)
+}
+
+func TestLabelService_NilDatabase(t *testing.T) {
+	svc := &LabelService{db: nil}
+
+	t.Run("CreateLabel", func(t *testing.T) {
+		resp, err := svc.CreateLabel(&CreateLabelRequest{Name: "Test"})
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("GetLabel", func(t *testing.T) {
+		resp, err := svc.GetLabel(1)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("GetLabelBySlug", func(t *testing.T) {
+		resp, err := svc.GetLabelBySlug("test-slug")
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("ListLabels", func(t *testing.T) {
+		resp, err := svc.ListLabels(nil)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("UpdateLabel", func(t *testing.T) {
+		resp, err := svc.UpdateLabel(1, &UpdateLabelRequest{})
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("DeleteLabel", func(t *testing.T) {
+		err := svc.DeleteLabel(1)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+	})
+
+	t.Run("GetLabelRoster", func(t *testing.T) {
+		resp, err := svc.GetLabelRoster(1)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("GetLabelCatalog", func(t *testing.T) {
+		resp, err := svc.GetLabelCatalog(1)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+}
+
+// =============================================================================
+// INTEGRATION TESTS (With Real Database)
+// =============================================================================
+
+type LabelServiceIntegrationTestSuite struct {
+	suite.Suite
+	container      testcontainers.Container
+	db             *gorm.DB
+	labelService   *LabelService
+	artistService  *ArtistService
+	releaseService *ReleaseService
+	ctx            context.Context
+}
+
+func (suite *LabelServiceIntegrationTestSuite) SetupSuite() {
+	suite.ctx = context.Background()
+
+	// Start PostgreSQL container
+	container, err := testcontainers.GenericContainer(suite.ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "postgres:18",
+			ExposedPorts: []string{"5432/tcp"},
+			Env: map[string]string{
+				"POSTGRES_DB":       "test_db",
+				"POSTGRES_USER":     "test_user",
+				"POSTGRES_PASSWORD": "test_password",
+			},
+			WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(120 * time.Second),
+		},
+		Started: true,
+	})
+	if err != nil {
+		suite.T().Fatalf("failed to start postgres container: %v", err)
+	}
+	suite.container = container
+
+	host, err := container.Host(suite.ctx)
+	if err != nil {
+		suite.T().Fatalf("failed to get host: %v", err)
+	}
+	port, err := container.MappedPort(suite.ctx, "5432")
+	if err != nil {
+		suite.T().Fatalf("failed to get port: %v", err)
+	}
+
+	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
+		host, port.Port())
+
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		suite.T().Fatalf("failed to connect to test database: %v", err)
+	}
+	suite.db = db
+
+	sqlDB, err := db.DB()
+	if err != nil {
+		suite.T().Fatalf("failed to get sql.DB: %v", err)
+	}
+	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "db", "migrations"))
+
+	suite.labelService = &LabelService{db: db}
+	suite.artistService = &ArtistService{db: db}
+	suite.releaseService = &ReleaseService{db: db}
+}
+
+func (suite *LabelServiceIntegrationTestSuite) TearDownSuite() {
+	if suite.container != nil {
+		if err := suite.container.Terminate(suite.ctx); err != nil {
+			suite.T().Logf("failed to terminate container: %v", err)
+		}
+	}
+}
+
+// TearDownTest cleans up data between tests for isolation
+func (suite *LabelServiceIntegrationTestSuite) TearDownTest() {
+	sqlDB, err := suite.db.DB()
+	suite.Require().NoError(err)
+	// Delete in FK-safe order
+	_, _ = sqlDB.Exec("DELETE FROM release_labels")
+	_, _ = sqlDB.Exec("DELETE FROM artist_labels")
+	_, _ = sqlDB.Exec("DELETE FROM labels")
+	_, _ = sqlDB.Exec("DELETE FROM release_external_links")
+	_, _ = sqlDB.Exec("DELETE FROM artist_releases")
+	_, _ = sqlDB.Exec("DELETE FROM releases")
+	_, _ = sqlDB.Exec("DELETE FROM show_artists")
+	_, _ = sqlDB.Exec("DELETE FROM show_venues")
+	_, _ = sqlDB.Exec("DELETE FROM shows")
+	_, _ = sqlDB.Exec("DELETE FROM artists")
+}
+
+func TestLabelServiceIntegrationTestSuite(t *testing.T) {
+	suite.Run(t, new(LabelServiceIntegrationTestSuite))
+}
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+func (suite *LabelServiceIntegrationTestSuite) createTestLabel(name string) *LabelDetailResponse {
+	resp, err := suite.labelService.CreateLabel(&CreateLabelRequest{Name: name})
+	suite.Require().NoError(err)
+	return resp
+}
+
+func (suite *LabelServiceIntegrationTestSuite) createTestArtistForLabel(name string) *models.Artist {
+	artist := &models.Artist{
+		Name: name,
+	}
+	err := suite.db.Create(artist).Error
+	suite.Require().NoError(err)
+	return artist
+}
+
+func (suite *LabelServiceIntegrationTestSuite) createTestReleaseForLabel(title string) *models.Release {
+	slug := title
+	release := &models.Release{
+		Title: title,
+		Slug:  &slug,
+	}
+	err := suite.db.Create(release).Error
+	suite.Require().NoError(err)
+	return release
+}
+
+// =============================================================================
+// Group 1: CreateLabel
+// =============================================================================
+
+func (suite *LabelServiceIntegrationTestSuite) TestCreateLabel_Success() {
+	city := "Seattle"
+	state := "WA"
+	year := 1988
+	req := &CreateLabelRequest{
+		Name:        "Sub Pop",
+		City:        &city,
+		State:       &state,
+		FoundedYear: &year,
+	}
+
+	resp, err := suite.labelService.CreateLabel(req)
+
+	suite.Require().NoError(err)
+	suite.Require().NotNil(resp)
+	suite.NotZero(resp.ID)
+	suite.Equal("Sub Pop", resp.Name)
+	suite.Equal("sub-pop", resp.Slug)
+	suite.Equal("Seattle", *resp.City)
+	suite.Equal("WA", *resp.State)
+	suite.Equal(1988, *resp.FoundedYear)
+	suite.Equal("active", resp.Status)
+	suite.Equal(0, resp.ArtistCount)
+	suite.Equal(0, resp.ReleaseCount)
+}
+
+func (suite *LabelServiceIntegrationTestSuite) TestCreateLabel_DefaultStatus() {
+	req := &CreateLabelRequest{
+		Name: "Mystery Label",
+	}
+
+	resp, err := suite.labelService.CreateLabel(req)
+
+	suite.Require().NoError(err)
+	suite.Equal("active", resp.Status)
+}
+
+func (suite *LabelServiceIntegrationTestSuite) TestCreateLabel_CustomStatus() {
+	req := &CreateLabelRequest{
+		Name:   "Old Label",
+		Status: "defunct",
+	}
+
+	resp, err := suite.labelService.CreateLabel(req)
+
+	suite.Require().NoError(err)
+	suite.Equal("defunct", resp.Status)
+}
+
+func (suite *LabelServiceIntegrationTestSuite) TestCreateLabel_WithSocial() {
+	website := "https://subpop.com"
+	instagram := "subpop"
+	req := &CreateLabelRequest{
+		Name:      "Social Label",
+		Website:   &website,
+		Instagram: &instagram,
+	}
+
+	resp, err := suite.labelService.CreateLabel(req)
+
+	suite.Require().NoError(err)
+	suite.Equal("https://subpop.com", *resp.Social.Website)
+	suite.Equal("subpop", *resp.Social.Instagram)
+}
+
+func (suite *LabelServiceIntegrationTestSuite) TestCreateLabel_UniqueSlug() {
+	req1 := &CreateLabelRequest{Name: "Merge Records"}
+	resp1, err := suite.labelService.CreateLabel(req1)
+	suite.Require().NoError(err)
+
+	req2 := &CreateLabelRequest{Name: "Merge Records"}
+	resp2, err := suite.labelService.CreateLabel(req2)
+	suite.Require().NoError(err)
+
+	suite.NotEqual(resp1.Slug, resp2.Slug)
+	suite.Equal("merge-records", resp1.Slug)
+	suite.Equal("merge-records-2", resp2.Slug)
+}
+
+// =============================================================================
+// Group 2: GetLabel / GetLabelBySlug
+// =============================================================================
+
+func (suite *LabelServiceIntegrationTestSuite) TestGetLabel_Success() {
+	created := suite.createTestLabel("Get Test Label")
+
+	resp, err := suite.labelService.GetLabel(created.ID)
+
+	suite.Require().NoError(err)
+	suite.Equal(created.ID, resp.ID)
+	suite.Equal("Get Test Label", resp.Name)
+}
+
+func (suite *LabelServiceIntegrationTestSuite) TestGetLabel_NotFound() {
+	resp, err := suite.labelService.GetLabel(99999)
+
+	suite.Require().Error(err)
+	suite.Nil(resp)
+	var labelErr *apperrors.LabelError
+	suite.ErrorAs(err, &labelErr)
+	suite.Equal(apperrors.CodeLabelNotFound, labelErr.Code)
+}
+
+func (suite *LabelServiceIntegrationTestSuite) TestGetLabelBySlug_Success() {
+	created := suite.createTestLabel("Slug Test Label")
+
+	resp, err := suite.labelService.GetLabelBySlug(created.Slug)
+
+	suite.Require().NoError(err)
+	suite.Equal(created.ID, resp.ID)
+	suite.Equal(created.Slug, resp.Slug)
+}
+
+func (suite *LabelServiceIntegrationTestSuite) TestGetLabelBySlug_NotFound() {
+	resp, err := suite.labelService.GetLabelBySlug("nonexistent-slug-xyz")
+
+	suite.Require().Error(err)
+	suite.Nil(resp)
+	var labelErr *apperrors.LabelError
+	suite.ErrorAs(err, &labelErr)
+	suite.Equal(apperrors.CodeLabelNotFound, labelErr.Code)
+}
+
+// =============================================================================
+// Group 3: ListLabels
+// =============================================================================
+
+func (suite *LabelServiceIntegrationTestSuite) TestListLabels_All() {
+	suite.labelService.CreateLabel(&CreateLabelRequest{Name: "Alpha Records"})
+	suite.labelService.CreateLabel(&CreateLabelRequest{Name: "Beta Records"})
+	suite.labelService.CreateLabel(&CreateLabelRequest{Name: "Charlie Records"})
+
+	resp, err := suite.labelService.ListLabels(map[string]interface{}{})
+
+	suite.Require().NoError(err)
+	suite.Require().Len(resp, 3)
+	// Ordered by name ASC
+	suite.Equal("Alpha Records", resp[0].Name)
+	suite.Equal("Beta Records", resp[1].Name)
+	suite.Equal("Charlie Records", resp[2].Name)
+}
+
+func (suite *LabelServiceIntegrationTestSuite) TestListLabels_FilterByStatus() {
+	suite.labelService.CreateLabel(&CreateLabelRequest{Name: "Active Label", Status: "active"})
+	suite.labelService.CreateLabel(&CreateLabelRequest{Name: "Defunct Label", Status: "defunct"})
+
+	resp, err := suite.labelService.ListLabels(map[string]interface{}{"status": "defunct"})
+
+	suite.Require().NoError(err)
+	suite.Require().Len(resp, 1)
+	suite.Equal("Defunct Label", resp[0].Name)
+}
+
+func (suite *LabelServiceIntegrationTestSuite) TestListLabels_FilterByCity() {
+	city1 := "Seattle"
+	city2 := "Portland"
+	suite.labelService.CreateLabel(&CreateLabelRequest{Name: "Seattle Label", City: &city1})
+	suite.labelService.CreateLabel(&CreateLabelRequest{Name: "Portland Label", City: &city2})
+
+	resp, err := suite.labelService.ListLabels(map[string]interface{}{"city": "Seattle"})
+
+	suite.Require().NoError(err)
+	suite.Require().Len(resp, 1)
+	suite.Equal("Seattle Label", resp[0].Name)
+}
+
+func (suite *LabelServiceIntegrationTestSuite) TestListLabels_FilterByState() {
+	state1 := "WA"
+	state2 := "OR"
+	suite.labelService.CreateLabel(&CreateLabelRequest{Name: "WA Label", State: &state1})
+	suite.labelService.CreateLabel(&CreateLabelRequest{Name: "OR Label", State: &state2})
+
+	resp, err := suite.labelService.ListLabels(map[string]interface{}{"state": "WA"})
+
+	suite.Require().NoError(err)
+	suite.Require().Len(resp, 1)
+	suite.Equal("WA Label", resp[0].Name)
+}
+
+func (suite *LabelServiceIntegrationTestSuite) TestListLabels_ArtistAndReleaseCounts() {
+	label := suite.createTestLabel("Counted Label")
+
+	artist := suite.createTestArtistForLabel("Label Artist")
+	suite.db.Exec("INSERT INTO artist_labels (artist_id, label_id) VALUES (?, ?)", artist.ID, label.ID)
+
+	release := suite.createTestReleaseForLabel("Label Release")
+	suite.db.Exec("INSERT INTO release_labels (release_id, label_id) VALUES (?, ?)", release.ID, label.ID)
+
+	resp, err := suite.labelService.ListLabels(map[string]interface{}{})
+
+	suite.Require().NoError(err)
+	suite.Require().Len(resp, 1)
+	suite.Equal(1, resp[0].ArtistCount)
+	suite.Equal(1, resp[0].ReleaseCount)
+}
+
+// =============================================================================
+// Group 4: UpdateLabel
+// =============================================================================
+
+func (suite *LabelServiceIntegrationTestSuite) TestUpdateLabel_BasicFields() {
+	created := suite.createTestLabel("Original Label")
+
+	newName := "Updated Label"
+	newCity := "Portland"
+	resp, err := suite.labelService.UpdateLabel(created.ID, &UpdateLabelRequest{
+		Name: &newName,
+		City: &newCity,
+	})
+
+	suite.Require().NoError(err)
+	suite.Equal("Updated Label", resp.Name)
+	suite.Equal("Portland", *resp.City)
+}
+
+func (suite *LabelServiceIntegrationTestSuite) TestUpdateLabel_NameChangeRegeneratesSlug() {
+	created := suite.createTestLabel("Old Label Name")
+	oldSlug := created.Slug
+
+	newName := "New Label Name"
+	resp, err := suite.labelService.UpdateLabel(created.ID, &UpdateLabelRequest{
+		Name: &newName,
+	})
+
+	suite.Require().NoError(err)
+	suite.Equal("New Label Name", resp.Name)
+	suite.NotEqual(oldSlug, resp.Slug)
+	suite.Equal("new-label-name", resp.Slug)
+}
+
+func (suite *LabelServiceIntegrationTestSuite) TestUpdateLabel_NotFound() {
+	newName := "Anything"
+	resp, err := suite.labelService.UpdateLabel(99999, &UpdateLabelRequest{Name: &newName})
+
+	suite.Require().Error(err)
+	suite.Nil(resp)
+	var labelErr *apperrors.LabelError
+	suite.ErrorAs(err, &labelErr)
+	suite.Equal(apperrors.CodeLabelNotFound, labelErr.Code)
+}
+
+func (suite *LabelServiceIntegrationTestSuite) TestUpdateLabel_NoChanges() {
+	created := suite.createTestLabel("Stable Label")
+
+	resp, err := suite.labelService.UpdateLabel(created.ID, &UpdateLabelRequest{})
+
+	suite.Require().NoError(err)
+	suite.Equal("Stable Label", resp.Name)
+}
+
+func (suite *LabelServiceIntegrationTestSuite) TestUpdateLabel_SocialFields() {
+	created := suite.createTestLabel("Social Update Label")
+
+	instagram := "newhandle"
+	website := "https://newsite.com"
+	resp, err := suite.labelService.UpdateLabel(created.ID, &UpdateLabelRequest{
+		Instagram: &instagram,
+		Website:   &website,
+	})
+
+	suite.Require().NoError(err)
+	suite.Equal("newhandle", *resp.Social.Instagram)
+	suite.Equal("https://newsite.com", *resp.Social.Website)
+}
+
+// =============================================================================
+// Group 5: DeleteLabel
+// =============================================================================
+
+func (suite *LabelServiceIntegrationTestSuite) TestDeleteLabel_Success() {
+	created := suite.createTestLabel("Delete Me Label")
+
+	err := suite.labelService.DeleteLabel(created.ID)
+
+	suite.Require().NoError(err)
+
+	// Verify it's gone
+	_, err = suite.labelService.GetLabel(created.ID)
+	suite.Error(err)
+}
+
+func (suite *LabelServiceIntegrationTestSuite) TestDeleteLabel_NotFound() {
+	err := suite.labelService.DeleteLabel(99999)
+
+	suite.Require().Error(err)
+	var labelErr *apperrors.LabelError
+	suite.ErrorAs(err, &labelErr)
+	suite.Equal(apperrors.CodeLabelNotFound, labelErr.Code)
+}
+
+func (suite *LabelServiceIntegrationTestSuite) TestDeleteLabel_CascadesJunctions() {
+	created := suite.createTestLabel("Cascade Label")
+	artist := suite.createTestArtistForLabel("Cascade Artist")
+	release := suite.createTestReleaseForLabel("Cascade Release")
+
+	suite.db.Exec("INSERT INTO artist_labels (artist_id, label_id) VALUES (?, ?)", artist.ID, created.ID)
+	suite.db.Exec("INSERT INTO release_labels (release_id, label_id) VALUES (?, ?)", release.ID, created.ID)
+
+	err := suite.labelService.DeleteLabel(created.ID)
+	suite.Require().NoError(err)
+
+	// Verify artist_labels cleaned up
+	var alCount int64
+	suite.db.Table("artist_labels").Where("label_id = ?", created.ID).Count(&alCount)
+	suite.Equal(int64(0), alCount)
+
+	// Verify release_labels cleaned up
+	var rlCount int64
+	suite.db.Table("release_labels").Where("label_id = ?", created.ID).Count(&rlCount)
+	suite.Equal(int64(0), rlCount)
+}
+
+// =============================================================================
+// Group 6: GetLabelRoster
+// =============================================================================
+
+func (suite *LabelServiceIntegrationTestSuite) TestGetLabelRoster_Success() {
+	label := suite.createTestLabel("Roster Label")
+	artist1 := suite.createTestArtistForLabel("Artist Alpha")
+	artist2 := suite.createTestArtistForLabel("Artist Beta")
+
+	suite.db.Exec("INSERT INTO artist_labels (artist_id, label_id) VALUES (?, ?)", artist1.ID, label.ID)
+	suite.db.Exec("INSERT INTO artist_labels (artist_id, label_id) VALUES (?, ?)", artist2.ID, label.ID)
+
+	resp, err := suite.labelService.GetLabelRoster(label.ID)
+
+	suite.Require().NoError(err)
+	suite.Require().Len(resp, 2)
+	// Ordered by name ASC
+	suite.Equal("Artist Alpha", resp[0].Name)
+	suite.Equal("Artist Beta", resp[1].Name)
+}
+
+func (suite *LabelServiceIntegrationTestSuite) TestGetLabelRoster_Empty() {
+	label := suite.createTestLabel("Empty Roster Label")
+
+	resp, err := suite.labelService.GetLabelRoster(label.ID)
+
+	suite.Require().NoError(err)
+	suite.Empty(resp)
+}
+
+func (suite *LabelServiceIntegrationTestSuite) TestGetLabelRoster_LabelNotFound() {
+	resp, err := suite.labelService.GetLabelRoster(99999)
+
+	suite.Require().Error(err)
+	suite.Nil(resp)
+	var labelErr *apperrors.LabelError
+	suite.ErrorAs(err, &labelErr)
+	suite.Equal(apperrors.CodeLabelNotFound, labelErr.Code)
+}
+
+// =============================================================================
+// Group 7: GetLabelCatalog
+// =============================================================================
+
+func (suite *LabelServiceIntegrationTestSuite) TestGetLabelCatalog_Success() {
+	label := suite.createTestLabel("Catalog Label")
+	release1 := suite.createTestReleaseForLabel("Release Alpha")
+	release2 := suite.createTestReleaseForLabel("Release Beta")
+
+	catNum := "CAT-001"
+	suite.db.Exec("INSERT INTO release_labels (release_id, label_id, catalog_number) VALUES (?, ?, ?)", release1.ID, label.ID, catNum)
+	suite.db.Exec("INSERT INTO release_labels (release_id, label_id) VALUES (?, ?)", release2.ID, label.ID)
+
+	resp, err := suite.labelService.GetLabelCatalog(label.ID)
+
+	suite.Require().NoError(err)
+	suite.Require().Len(resp, 2)
+
+	// Check catalog number is returned for the one that has it
+	var withCatalog *LabelReleaseResponse
+	for _, r := range resp {
+		if r.CatalogNumber != nil {
+			withCatalog = r
+		}
+	}
+	suite.Require().NotNil(withCatalog)
+	suite.Equal("CAT-001", *withCatalog.CatalogNumber)
+}
+
+func (suite *LabelServiceIntegrationTestSuite) TestGetLabelCatalog_Empty() {
+	label := suite.createTestLabel("Empty Catalog Label")
+
+	resp, err := suite.labelService.GetLabelCatalog(label.ID)
+
+	suite.Require().NoError(err)
+	suite.Empty(resp)
+}
+
+func (suite *LabelServiceIntegrationTestSuite) TestGetLabelCatalog_LabelNotFound() {
+	resp, err := suite.labelService.GetLabelCatalog(99999)
+
+	suite.Require().Error(err)
+	suite.Nil(resp)
+	var labelErr *apperrors.LabelError
+	suite.ErrorAs(err, &labelErr)
+	suite.Equal(apperrors.CodeLabelNotFound, labelErr.Code)
+}
+
+// =============================================================================
+// Group 8: DetailResponse counts
+// =============================================================================
+
+func (suite *LabelServiceIntegrationTestSuite) TestGetLabel_WithCounts() {
+	label := suite.createTestLabel("Counts Label")
+	artist1 := suite.createTestArtistForLabel("Count Artist 1")
+	artist2 := suite.createTestArtistForLabel("Count Artist 2")
+	release1 := suite.createTestReleaseForLabel("Count Release 1")
+
+	suite.db.Exec("INSERT INTO artist_labels (artist_id, label_id) VALUES (?, ?)", artist1.ID, label.ID)
+	suite.db.Exec("INSERT INTO artist_labels (artist_id, label_id) VALUES (?, ?)", artist2.ID, label.ID)
+	suite.db.Exec("INSERT INTO release_labels (release_id, label_id) VALUES (?, ?)", release1.ID, label.ID)
+
+	resp, err := suite.labelService.GetLabel(label.ID)
+
+	suite.Require().NoError(err)
+	suite.Equal(2, resp.ArtistCount)
+	suite.Equal(1, resp.ReleaseCount)
+}


### PR DESCRIPTION
## Summary
- Add `LabelService` with full CRUD, filtered listing, label roster, and label catalog
- Add `LabelHandler` with 7 Huma endpoints (public list/detail/roster/catalog + admin CRUD)
- Add `LabelError` types following existing app error patterns
- Add `LabelServiceInterface` with compile-time satisfaction check
- Register service in `container.go` and routes in `routes.go`
- 64 new tests (39 service + 25 handler integration)

Closes PSY-10

## API Endpoints
| Method | Path | Auth | Description |
|--------|------|------|-------------|
| GET | `/labels` | Public | List with filters (status, city, state) |
| GET | `/labels/{label_id}` | Public | Detail by ID or slug |
| GET | `/labels/{label_id}/artists` | Public | Label roster |
| GET | `/labels/{label_id}/releases` | Public | Label catalog (with catalog numbers) |
| POST | `/labels` | Admin | Create label |
| PUT | `/labels/{label_id}` | Admin | Update label |
| DELETE | `/labels/{label_id}` | Admin | Delete label |

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] 64 new tests pass (service + handler integration)
- [x] `go test ./...` passes (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)