### PR TITLE
feat: add Label frontend pages with roster and catalog

### DIFF
--- a/frontend/app/labels/[slug]/page.tsx
+++ b/frontend/app/labels/[slug]/page.tsx
@@ -1,0 +1,116 @@
+import { Suspense } from 'react'
+import { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+import * as Sentry from '@sentry/nextjs'
+import { Loader2 } from 'lucide-react'
+import { LabelDetail } from '@/components/labels'
+
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL ||
+  (process.env.NODE_ENV === 'development'
+    ? 'http://localhost:8080'
+    : 'https://api.psychichomily.com')
+
+interface LabelPageProps {
+  params: Promise<{ slug: string }>
+}
+
+interface LabelData {
+  name: string
+  slug?: string
+  city?: string | null
+  state?: string | null
+  status?: string
+}
+
+async function getLabel(slug: string): Promise<LabelData | null> {
+  try {
+    const res = await fetch(`${API_BASE_URL}/labels/${slug}`, {
+      next: { revalidate: 3600 },
+    })
+    if (res.ok) {
+      return res.json()
+    }
+    if (res.status >= 500) {
+      Sentry.captureMessage(`Label page fetch error: ${res.status}`, {
+        level: 'error',
+        tags: { service: 'label-page' },
+        extra: { slug, status: res.status },
+      })
+    }
+  } catch (error) {
+    Sentry.captureException(error, {
+      level: 'error',
+      tags: { service: 'label-page' },
+      extra: { slug },
+    })
+  }
+  return null
+}
+
+export async function generateMetadata({
+  params,
+}: LabelPageProps): Promise<Metadata> {
+  const { slug } = await params
+  const label = await getLabel(slug)
+
+  if (label) {
+    const locationSuffix =
+      label.city && label.state ? ` - ${label.city}, ${label.state}` : ''
+    return {
+      title: `${label.name}${locationSuffix}`,
+      description: `${label.name}${locationSuffix} - label details on Psychic Homily`,
+      alternates: {
+        canonical: `https://psychichomily.com/labels/${slug}`,
+      },
+      openGraph: {
+        title: `${label.name}${locationSuffix}`,
+        description: `View details for ${label.name}`,
+        type: 'website',
+        url: `/labels/${slug}`,
+      },
+    }
+  }
+
+  return {
+    title: 'Label',
+    description: 'View label details',
+  }
+}
+
+function LabelLoadingFallback() {
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center">
+      <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+    </div>
+  )
+}
+
+export default async function LabelPage({ params }: LabelPageProps) {
+  const { slug } = await params
+
+  if (!slug) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold mb-2">Invalid Label</h1>
+          <p className="text-muted-foreground">
+            The label could not be found.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  const labelData = await getLabel(slug)
+
+  if (!labelData) {
+    notFound()
+  }
+
+  return (
+    <Suspense fallback={<LabelLoadingFallback />}>
+      <LabelDetail idOrSlug={slug} />
+    </Suspense>
+  )
+}

--- a/frontend/app/labels/page.tsx
+++ b/frontend/app/labels/page.tsx
@@ -1,0 +1,36 @@
+import { Suspense } from 'react'
+import { LabelList } from '@/components/labels'
+import { LoadingSpinner } from '@/components/shared'
+
+export const metadata = {
+  title: 'Labels',
+  description: 'Browse record labels and their rosters and catalogs.',
+  alternates: {
+    canonical: 'https://psychichomily.com/labels',
+  },
+  openGraph: {
+    title: 'Labels | Psychic Homily',
+    description: 'Browse record labels and their rosters and catalogs.',
+    url: '/labels',
+    type: 'website',
+  },
+}
+
+export default function LabelsPage() {
+  return (
+    <div className="flex min-h-screen items-start justify-center">
+      <main className="w-full max-w-6xl px-4 py-8 md:px-8">
+        <h1 className="text-3xl font-bold text-center mb-8">Labels</h1>
+        <Suspense
+          fallback={
+            <div className="flex justify-center items-center py-12">
+              <LoadingSpinner />
+            </div>
+          }
+        >
+          <LabelList />
+        </Suspense>
+      </main>
+    </div>
+  )
+}

--- a/frontend/components/labels/LabelCard.tsx
+++ b/frontend/components/labels/LabelCard.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+import Link from 'next/link'
+import { Tag, MapPin, Users, Disc3 } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { Badge } from '@/components/ui/badge'
+import {
+  getLabelStatusLabel,
+  getLabelStatusVariant,
+  formatLabelLocation,
+} from '@/lib/types/label'
+import type { LabelListItem } from '@/lib/types/label'
+
+export type LabelCardDensity = 'compact' | 'comfortable' | 'expanded'
+
+interface LabelCardProps {
+  label: LabelListItem
+  density?: LabelCardDensity
+}
+
+export function LabelCard({ label, density = 'comfortable' }: LabelCardProps) {
+  const location = formatLabelLocation(label)
+
+  return (
+    <article
+      className={cn(
+        'rounded-lg border border-border/50 bg-card transition-shadow hover:shadow-sm',
+        density === 'compact' && 'p-3',
+        density === 'comfortable' && 'p-4',
+        density === 'expanded' && 'p-5'
+      )}
+    >
+      <div className="flex gap-3">
+        {/* Icon placeholder */}
+        <div
+          className={cn(
+            'shrink-0 rounded-md bg-muted/50 flex items-center justify-center',
+            density === 'compact' && 'h-12 w-12',
+            density === 'comfortable' && 'h-16 w-16',
+            density === 'expanded' && 'h-20 w-20'
+          )}
+        >
+          <Tag
+            className={cn(
+              'text-muted-foreground/40',
+              density === 'compact' && 'h-6 w-6',
+              density === 'comfortable' && 'h-8 w-8',
+              density === 'expanded' && 'h-10 w-10'
+            )}
+          />
+        </div>
+
+        {/* Text Content */}
+        <div className="flex-1 min-w-0">
+          <Link href={`/labels/${label.slug}`} className="block group">
+            <h3
+              className={cn(
+                'font-bold text-foreground group-hover:text-primary transition-colors truncate',
+                density === 'compact' && 'text-sm',
+                density === 'comfortable' && 'text-base',
+                density === 'expanded' && 'text-lg'
+              )}
+            >
+              {label.name}
+            </h3>
+          </Link>
+
+          <div
+            className={cn(
+              'flex items-center gap-2 flex-wrap',
+              density === 'compact' && 'mt-0.5',
+              density === 'comfortable' && 'mt-1',
+              density === 'expanded' && 'mt-1.5'
+            )}
+          >
+            <Badge
+              variant={getLabelStatusVariant(label.status)}
+              className="text-[10px] px-1.5 py-0"
+            >
+              {getLabelStatusLabel(label.status)}
+            </Badge>
+            {location && (
+              <span
+                className={cn(
+                  'flex items-center gap-1 text-muted-foreground',
+                  density === 'compact' ? 'text-xs' : 'text-sm'
+                )}
+              >
+                <MapPin className="h-3 w-3" />
+                {location}
+              </span>
+            )}
+          </div>
+
+          {density !== 'compact' && (
+            <div className="mt-1 flex items-center gap-3 text-sm text-muted-foreground">
+              <span className="flex items-center gap-1">
+                <Users className="h-3.5 w-3.5" />
+                {label.artist_count === 1
+                  ? '1 artist'
+                  : `${label.artist_count} artists`}
+              </span>
+              <span className="flex items-center gap-1">
+                <Disc3 className="h-3.5 w-3.5" />
+                {label.release_count === 1
+                  ? '1 release'
+                  : `${label.release_count} releases`}
+              </span>
+            </div>
+          )}
+        </div>
+      </div>
+    </article>
+  )
+}

--- a/frontend/components/labels/LabelDetail.tsx
+++ b/frontend/components/labels/LabelDetail.tsx
@@ -1,0 +1,318 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import {
+  Loader2,
+  Tag,
+  MapPin,
+  Calendar,
+  Users,
+  Disc3,
+  Music,
+} from 'lucide-react'
+import { useLabel, useLabelRoster, useLabelCatalog } from '@/lib/hooks/useLabels'
+import { EntityDetailLayout, EntityHeader, SocialLinks } from '@/components/shared'
+import { TabsContent } from '@/components/ui/tabs'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  getLabelStatusLabel,
+  getLabelStatusVariant,
+  formatLabelLocation,
+} from '@/lib/types/label'
+import { getReleaseTypeLabel } from '@/lib/types/release'
+
+interface LabelDetailProps {
+  idOrSlug: string | number
+}
+
+export function LabelDetail({ idOrSlug }: LabelDetailProps) {
+  const { data: label, isLoading, error } = useLabel({ idOrSlug })
+  const { data: rosterData, isLoading: rosterLoading } = useLabelRoster({
+    labelIdOrSlug: idOrSlug,
+    enabled: !!label,
+  })
+  const { data: catalogData, isLoading: catalogLoading } = useLabelCatalog({
+    labelIdOrSlug: idOrSlug,
+    enabled: !!label,
+  })
+  const [activeTab, setActiveTab] = useState('overview')
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  if (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : 'Failed to load label'
+    const is404 =
+      errorMessage.includes('not found') || errorMessage.includes('404')
+
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold mb-2">
+            {is404 ? 'Label Not Found' : 'Error Loading Label'}
+          </h1>
+          <p className="text-muted-foreground mb-4">
+            {is404
+              ? "The label you're looking for doesn't exist or has been removed."
+              : errorMessage}
+          </p>
+          <Button asChild variant="outline">
+            <Link href="/labels">Back to Labels</Link>
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  if (!label) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold mb-2">Label Not Found</h1>
+          <p className="text-muted-foreground mb-4">
+            The label you&apos;re looking for doesn&apos;t exist.
+          </p>
+          <Button asChild variant="outline">
+            <Link href="/labels">Back to Labels</Link>
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  const location = formatLabelLocation(label)
+  const roster = rosterData?.artists ?? []
+  const catalog = catalogData?.releases ?? []
+
+  const tabs = [
+    { value: 'overview', label: 'Overview' },
+    { value: 'roster', label: `Roster (${label.artist_count})` },
+    { value: 'catalog', label: `Catalog (${label.release_count})` },
+  ]
+
+  const sidebar = (
+    <div className="space-y-6">
+      {/* Label Icon */}
+      <div className="rounded-lg border border-border/50 bg-card overflow-hidden">
+        <div className="w-full aspect-square bg-muted/30 flex items-center justify-center">
+          <Tag className="h-16 w-16 text-muted-foreground/30" />
+        </div>
+      </div>
+
+      {/* Quick Info */}
+      <div className="rounded-lg border border-border/50 bg-card p-4 space-y-3">
+        <h3 className="text-sm font-semibold text-foreground">Details</h3>
+
+        <div className="space-y-2 text-sm">
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <Tag className="h-4 w-4 shrink-0" />
+            <span>
+              Status:{' '}
+              <Badge
+                variant={getLabelStatusVariant(label.status)}
+                className="text-[10px] px-1.5 py-0 ml-1"
+              >
+                {getLabelStatusLabel(label.status)}
+              </Badge>
+            </span>
+          </div>
+
+          {location && (
+            <div className="flex items-center gap-2 text-muted-foreground">
+              <MapPin className="h-4 w-4 shrink-0" />
+              <span>{location}</span>
+            </div>
+          )}
+
+          {label.founded_year && (
+            <div className="flex items-center gap-2 text-muted-foreground">
+              <Calendar className="h-4 w-4 shrink-0" />
+              <span>Founded: {label.founded_year}</span>
+            </div>
+          )}
+
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <Users className="h-4 w-4 shrink-0" />
+            <span>
+              {label.artist_count === 1
+                ? '1 artist'
+                : `${label.artist_count} artists`}
+            </span>
+          </div>
+
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <Disc3 className="h-4 w-4 shrink-0" />
+            <span>
+              {label.release_count === 1
+                ? '1 release'
+                : `${label.release_count} releases`}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+
+  return (
+    <EntityDetailLayout
+      backLink={{ href: '/labels', label: 'Back to Labels' }}
+      header={
+        <EntityHeader
+          title={label.name}
+          subtitle={
+            <>
+              <Badge variant={getLabelStatusVariant(label.status)}>
+                {getLabelStatusLabel(label.status)}
+              </Badge>
+              {location && (
+                <span className="flex items-center gap-1">
+                  <MapPin className="h-3.5 w-3.5" />
+                  {location}
+                </span>
+              )}
+              {label.founded_year && <span>Est. {label.founded_year}</span>}
+            </>
+          }
+        />
+      }
+      tabs={tabs}
+      activeTab={activeTab}
+      onTabChange={setActiveTab}
+      sidebar={sidebar}
+    >
+      {/* Overview Tab */}
+      <TabsContent value="overview">
+        <div className="space-y-8">
+          {/* Description */}
+          {label.description && (
+            <div>
+              <h2 className="text-lg font-semibold mb-3">About</h2>
+              <p className="text-muted-foreground leading-relaxed whitespace-pre-line">
+                {label.description}
+              </p>
+            </div>
+          )}
+
+          {/* Social Links */}
+          {label.social && (
+            <div>
+              <h2 className="text-lg font-semibold mb-3">Links</h2>
+              <SocialLinks social={label.social} />
+            </div>
+          )}
+
+          {/* Quick preview of roster + catalog when no description */}
+          {!label.description && !label.social && (
+            <div className="text-sm text-muted-foreground">
+              No additional information available for this label.
+            </div>
+          )}
+        </div>
+      </TabsContent>
+
+      {/* Roster Tab */}
+      <TabsContent value="roster">
+        <div>
+          <h2 className="text-lg font-semibold mb-4">Artist Roster</h2>
+          {rosterLoading ? (
+            <div className="flex justify-center py-8">
+              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+            </div>
+          ) : roster.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No artists are currently associated with this label.
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {roster.map(artist => (
+                <div
+                  key={artist.id}
+                  className="flex items-center rounded-lg border border-border/50 bg-card p-3"
+                >
+                  <Users className="h-4 w-4 text-muted-foreground mr-3 shrink-0" />
+                  <Link
+                    href={`/artists/${artist.slug}`}
+                    className="font-medium text-foreground hover:text-primary transition-colors"
+                  >
+                    {artist.name}
+                  </Link>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </TabsContent>
+
+      {/* Catalog Tab */}
+      <TabsContent value="catalog">
+        <div>
+          <h2 className="text-lg font-semibold mb-4">Release Catalog</h2>
+          {catalogLoading ? (
+            <div className="flex justify-center py-8">
+              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+            </div>
+          ) : catalog.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No releases are currently in this label&apos;s catalog.
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {catalog.map(release => (
+                <div
+                  key={release.id}
+                  className="flex items-center gap-3 rounded-lg border border-border/50 bg-card p-3"
+                >
+                  {/* Cover art or placeholder */}
+                  <div className="h-10 w-10 shrink-0 rounded-md bg-muted/50 flex items-center justify-center overflow-hidden">
+                    {release.cover_art_url ? (
+                      <img
+                        src={release.cover_art_url}
+                        alt={`${release.title} cover art`}
+                        className="h-full w-full object-cover"
+                      />
+                    ) : (
+                      <Music className="h-5 w-5 text-muted-foreground/40" />
+                    )}
+                  </div>
+
+                  <div className="flex-1 min-w-0">
+                    <Link
+                      href={`/releases/${release.slug}`}
+                      className="font-medium text-foreground hover:text-primary transition-colors truncate block"
+                    >
+                      {release.title}
+                    </Link>
+                    <div className="flex items-center gap-2 text-xs text-muted-foreground mt-0.5">
+                      <Badge
+                        variant="secondary"
+                        className="text-[10px] px-1.5 py-0"
+                      >
+                        {getReleaseTypeLabel(release.release_type)}
+                      </Badge>
+                      {release.release_year && (
+                        <span>{release.release_year}</span>
+                      )}
+                      {release.catalog_number && (
+                        <span className="text-muted-foreground/60">
+                          {release.catalog_number}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </TabsContent>
+    </EntityDetailLayout>
+  )
+}

--- a/frontend/components/labels/LabelList.tsx
+++ b/frontend/components/labels/LabelList.tsx
@@ -1,0 +1,160 @@
+'use client'
+
+import { useTransition } from 'react'
+import { useSearchParams, useRouter } from 'next/navigation'
+import { useLabels } from '@/lib/hooks/useLabels'
+import { LabelCard } from './LabelCard'
+import { LoadingSpinner, DensityToggle } from '@/components/shared'
+import { useDensity } from '@/lib/hooks/useDensity'
+import { Button } from '@/components/ui/button'
+import { LABEL_STATUSES, LABEL_STATUS_LABELS } from '@/lib/types/label'
+import type { LabelStatus } from '@/lib/types/label'
+
+export function LabelList() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const [isPending, startTransition] = useTransition()
+  const { density } = useDensity('labels')
+
+  // Parse filters from URL
+  const statusParam = searchParams.get('status') as LabelStatus | null
+
+  const { data, isLoading, isFetching, error, refetch } = useLabels({
+    status: statusParam ?? undefined,
+  })
+
+  const updateFilters = (params: { status?: string | null }) => {
+    const newParams = new URLSearchParams()
+    const newStatus =
+      params.status !== undefined ? params.status : statusParam
+
+    if (newStatus) newParams.set('status', newStatus)
+
+    const queryString = newParams.toString()
+    startTransition(() => {
+      router.push(queryString ? `/labels?${queryString}` : '/labels')
+    })
+  }
+
+  const handleStatusChange = (status: string | null) => {
+    updateFilters({ status })
+  }
+
+  const clearFilters = () => {
+    startTransition(() => {
+      router.push('/labels')
+    })
+  }
+
+  if (isLoading && !data) {
+    return (
+      <div className="flex justify-center items-center py-12">
+        <LoadingSpinner />
+      </div>
+    )
+  }
+
+  const isUpdating = isFetching || isPending
+
+  if (error) {
+    return (
+      <div className="text-center py-12 text-destructive">
+        <p>Failed to load labels. Please try again later.</p>
+        <Button variant="outline" className="mt-4" onClick={() => refetch()}>
+          Retry
+        </Button>
+      </div>
+    )
+  }
+
+  const labels = data?.labels ?? []
+  const hasFilters = !!statusParam
+
+  return (
+    <section className="w-full max-w-6xl">
+      {/* Filters */}
+      <div className="mb-6 space-y-4">
+        {/* Status Filter */}
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-sm text-muted-foreground mr-1">Status:</span>
+          <button
+            onClick={() => handleStatusChange(null)}
+            className={`px-2.5 py-1 text-xs font-medium rounded-md transition-colors ${
+              !statusParam
+                ? 'bg-background text-foreground shadow-sm border border-border/50'
+                : 'text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            All
+          </button>
+          {LABEL_STATUSES.map(status => (
+            <button
+              key={status}
+              onClick={() => handleStatusChange(status)}
+              className={`px-2.5 py-1 text-xs font-medium rounded-md transition-colors ${
+                statusParam === status
+                  ? 'bg-background text-foreground shadow-sm border border-border/50'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              {LABEL_STATUS_LABELS[status]}
+            </button>
+          ))}
+          {hasFilters && (
+            <button
+              onClick={clearFilters}
+              className="text-xs text-muted-foreground hover:text-foreground underline ml-2"
+            >
+              Clear filters
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="flex justify-end mb-4">
+        <DensityToggle storageKey="labels" />
+      </div>
+
+      {/* Label Grid */}
+      <div
+        className={
+          isUpdating
+            ? 'opacity-60 transition-opacity duration-75'
+            : 'transition-opacity duration-75'
+        }
+      >
+        {labels.length === 0 ? (
+          <div className="text-center py-12 text-muted-foreground">
+            <p>
+              {hasFilters
+                ? 'No labels found matching your filters.'
+                : 'No labels available at this time.'}
+            </p>
+            {hasFilters && (
+              <button
+                onClick={clearFilters}
+                className="mt-4 text-primary hover:underline"
+              >
+                View all labels
+              </button>
+            )}
+          </div>
+        ) : (
+          <div
+            className={
+              density === 'compact'
+                ? 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-2'
+                : density === 'expanded'
+                  ? 'grid grid-cols-1 sm:grid-cols-2 gap-4'
+                  : 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3'
+            }
+          >
+            {labels.map(label => (
+              <LabelCard key={label.id} label={label} density={density} />
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/frontend/components/labels/index.ts
+++ b/frontend/components/labels/index.ts
@@ -1,0 +1,3 @@
+export { LabelCard } from './LabelCard'
+export { LabelDetail } from './LabelDetail'
+export { LabelList } from './LabelList'

--- a/frontend/components/layout/CommandPalette.tsx
+++ b/frontend/components/layout/CommandPalette.tsx
@@ -12,7 +12,7 @@ import {
   CommandSeparator,
 } from '@/components/ui/command'
 import {
-  Calendar, Mic2, MapPin, Disc3, BookOpen, Headphones, Send,
+  Calendar, Mic2, MapPin, Disc3, Tag, BookOpen, Headphones, Send,
   Library, Settings, Shield, Search, Clock, X,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
@@ -52,6 +52,12 @@ const routes: RouteItem[] = [
     href: '/releases',
     icon: Disc3,
     keywords: ['releases', 'albums', 'records', 'eps', 'singles', 'discography', 'music'],
+  },
+  {
+    label: 'Labels',
+    href: '/labels',
+    icon: Tag,
+    keywords: ['labels', 'record labels', 'imprints', 'roster', 'catalog'],
   },
   {
     label: 'Blog',

--- a/frontend/components/layout/Sidebar.test.tsx
+++ b/frontend/components/layout/Sidebar.test.tsx
@@ -25,7 +25,7 @@ describe('sidebarGroups', () => {
 
   it('Discover contains Shows, Artists, Venues', () => {
     const discover = sidebarGroups.find(g => g.label === 'Discover')!
-    expect(discover.items.map(i => i.label)).toEqual(['Shows', 'Artists', 'Venues', 'Releases'])
+    expect(discover.items.map(i => i.label)).toEqual(['Shows', 'Artists', 'Venues', 'Releases', 'Labels'])
   })
 
   it('Community contains Blog, DJ Sets, Substack, Submissions', () => {

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import {
-  Calendar, Mic2, MapPin, Disc3, BookOpen, Headphones, Newspaper,
+  Calendar, Mic2, MapPin, Disc3, Tag, BookOpen, Headphones, Newspaper,
   Send, Library, Settings, Shield, PanelLeftClose, PanelLeft,
   ExternalLink,
 } from 'lucide-react'
@@ -34,6 +34,7 @@ export const sidebarGroups: SidebarGroup[] = [
       { href: '/artists', label: 'Artists', icon: Mic2 },
       { href: '/venues', label: 'Venues', icon: MapPin },
       { href: '/releases', label: 'Releases', icon: Disc3 },
+      { href: '/labels', label: 'Labels', icon: Tag },
     ],
   },
   {

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -138,6 +138,14 @@ export const API_ENDPOINTS = {
     ARTIST_RELEASES: (artistIdOrSlug: string | number) =>
       `${API_BASE_URL}/artists/${artistIdOrSlug}/releases`,
   },
+  LABELS: {
+    LIST: `${API_BASE_URL}/labels`,
+    GET: (idOrSlug: string | number) => `${API_BASE_URL}/labels/${idOrSlug}`,
+    ARTISTS: (idOrSlug: string | number) =>
+      `${API_BASE_URL}/labels/${idOrSlug}/artists`,
+    RELEASES: (idOrSlug: string | number) =>
+      `${API_BASE_URL}/labels/${idOrSlug}/releases`,
+  },
 
   // Calendar feed endpoints
   CALENDAR: {

--- a/frontend/lib/hooks/useLabels.ts
+++ b/frontend/lib/hooks/useLabels.ts
@@ -1,0 +1,137 @@
+'use client'
+
+/**
+ * Labels Hooks
+ *
+ * TanStack Query hooks for fetching label data from the API.
+ */
+
+import { useQuery, keepPreviousData } from '@tanstack/react-query'
+import { apiRequest, API_ENDPOINTS } from '../api'
+import { queryKeys } from '../queryClient'
+import type {
+  LabelsListResponse,
+  LabelDetail,
+  LabelArtistsResponse,
+  LabelReleasesResponse,
+} from '../types/label'
+
+interface UseLabelsOptions {
+  status?: string
+  city?: string
+  state?: string
+}
+
+/**
+ * Hook to fetch list of labels with optional filtering
+ */
+export function useLabels(options: UseLabelsOptions = {}) {
+  const { status, city, state } = options
+
+  const params = new URLSearchParams()
+  if (status) params.set('status', status)
+  if (city) params.set('city', city)
+  if (state) params.set('state', state)
+
+  const queryString = params.toString()
+  const endpoint = queryString
+    ? `${API_ENDPOINTS.LABELS.LIST}?${queryString}`
+    : API_ENDPOINTS.LABELS.LIST
+
+  return useQuery({
+    queryKey: queryKeys.labels.list(
+      status || city || state
+        ? { status, city, state }
+        : undefined
+    ),
+    queryFn: async (): Promise<LabelsListResponse> => {
+      return apiRequest<LabelsListResponse>(endpoint, {
+        method: 'GET',
+      })
+    },
+    staleTime: 5 * 60 * 1000,
+    placeholderData: keepPreviousData,
+  })
+}
+
+interface UseLabelOptions {
+  idOrSlug: string | number
+  enabled?: boolean
+}
+
+/**
+ * Hook to fetch a single label by ID or slug
+ */
+export function useLabel(options: UseLabelOptions) {
+  const { idOrSlug, enabled = true } = options
+
+  return useQuery({
+    queryKey: queryKeys.labels.detail(idOrSlug),
+    queryFn: async (): Promise<LabelDetail> => {
+      return apiRequest<LabelDetail>(
+        API_ENDPOINTS.LABELS.GET(idOrSlug),
+        { method: 'GET' }
+      )
+    },
+    enabled:
+      enabled &&
+      (typeof idOrSlug === 'string' ? Boolean(idOrSlug) : idOrSlug > 0),
+    staleTime: 5 * 60 * 1000,
+  })
+}
+
+interface UseLabelRosterOptions {
+  labelIdOrSlug: string | number
+  enabled?: boolean
+}
+
+/**
+ * Hook to fetch artists on a label (roster)
+ */
+export function useLabelRoster(options: UseLabelRosterOptions) {
+  const { labelIdOrSlug, enabled = true } = options
+
+  return useQuery({
+    queryKey: queryKeys.labels.roster(labelIdOrSlug),
+    queryFn: async (): Promise<LabelArtistsResponse> => {
+      return apiRequest<LabelArtistsResponse>(
+        API_ENDPOINTS.LABELS.ARTISTS(labelIdOrSlug),
+        { method: 'GET' }
+      )
+    },
+    enabled:
+      enabled &&
+      (typeof labelIdOrSlug === 'string'
+        ? Boolean(labelIdOrSlug)
+        : labelIdOrSlug > 0),
+    staleTime: 5 * 60 * 1000,
+  })
+}
+
+interface UseLabelCatalogOptions {
+  labelIdOrSlug: string | number
+  enabled?: boolean
+}
+
+/**
+ * Hook to fetch releases on a label (catalog)
+ */
+export function useLabelCatalog(options: UseLabelCatalogOptions) {
+  const { labelIdOrSlug, enabled = true } = options
+
+  return useQuery({
+    queryKey: queryKeys.labels.catalog(labelIdOrSlug),
+    queryFn: async (): Promise<LabelReleasesResponse> => {
+      return apiRequest<LabelReleasesResponse>(
+        API_ENDPOINTS.LABELS.RELEASES(labelIdOrSlug),
+        { method: 'GET' }
+      )
+    },
+    enabled:
+      enabled &&
+      (typeof labelIdOrSlug === 'string'
+        ? Boolean(labelIdOrSlug)
+        : labelIdOrSlug > 0),
+    staleTime: 5 * 60 * 1000,
+  })
+}

--- a/frontend/lib/queryClient.ts
+++ b/frontend/lib/queryClient.ts
@@ -176,6 +176,16 @@ export const queryKeys = {
       ['releases', 'artist', String(artistIdOrSlug)] as const,
   },
 
+  // Label queries
+  labels: {
+    all: ['labels'] as const,
+    list: (filters?: Record<string, unknown>) =>
+      ['labels', 'list', filters] as const,
+    detail: (idOrSlug: string | number) => ['labels', 'detail', String(idOrSlug)] as const,
+    roster: (idOrSlug: string | number) => ['labels', 'roster', String(idOrSlug)] as const,
+    catalog: (idOrSlug: string | number) => ['labels', 'catalog', String(idOrSlug)] as const,
+  },
+
   // Calendar feed queries
   calendar: {
     all: ['calendar'] as const,
@@ -249,6 +259,9 @@ export const createInvalidateQueries = (queryClient: QueryClient) => ({
 
   // Invalidate release queries
   releases: () => queryClient.invalidateQueries({ queryKey: ['releases'] }),
+
+  // Invalidate label queries
+  labels: () => queryClient.invalidateQueries({ queryKey: ['labels'] }),
 
   // Invalidate all venue-related queries
   venues: () => queryClient.invalidateQueries({ queryKey: ['venues'] }),

--- a/frontend/lib/types/label.ts
+++ b/frontend/lib/types/label.ts
@@ -1,0 +1,119 @@
+/**
+ * Label-related TypeScript types
+ *
+ * These types match the backend API response structures
+ * for label endpoints.
+ */
+
+export type LabelStatus = 'active' | 'inactive' | 'defunct'
+
+/** Labels for display */
+export const LABEL_STATUS_LABELS: Record<LabelStatus, string> = {
+  active: 'Active',
+  inactive: 'Inactive',
+  defunct: 'Defunct',
+}
+
+/** All valid label statuses for filter dropdowns */
+export const LABEL_STATUSES: LabelStatus[] = ['active', 'inactive', 'defunct']
+
+/** Badge variant mapping for label statuses */
+export function getLabelStatusVariant(
+  status: string
+): 'default' | 'secondary' | 'destructive' | 'outline' {
+  switch (status) {
+    case 'active':
+      return 'default'
+    case 'inactive':
+      return 'secondary'
+    case 'defunct':
+      return 'outline'
+    default:
+      return 'secondary'
+  }
+}
+
+export interface LabelSocial {
+  instagram: string | null
+  facebook: string | null
+  twitter: string | null
+  youtube: string | null
+  spotify: string | null
+  soundcloud: string | null
+  bandcamp: string | null
+  website: string | null
+}
+
+export interface LabelDetail {
+  id: number
+  name: string
+  slug: string
+  city: string | null
+  state: string | null
+  country: string | null
+  founded_year: number | null
+  status: string
+  description: string | null
+  social: LabelSocial
+  artist_count: number
+  release_count: number
+  created_at: string
+  updated_at: string
+}
+
+export interface LabelListItem {
+  id: number
+  name: string
+  slug: string
+  city: string | null
+  state: string | null
+  status: string
+  artist_count: number
+  release_count: number
+}
+
+export interface LabelsListResponse {
+  labels: LabelListItem[]
+  count: number
+}
+
+export interface LabelArtist {
+  id: number
+  slug: string
+  name: string
+}
+
+export interface LabelArtistsResponse {
+  artists: LabelArtist[]
+}
+
+export interface LabelRelease {
+  id: number
+  title: string
+  slug: string
+  release_type: string
+  release_year: number | null
+  cover_art_url: string | null
+  catalog_number: string | null
+}
+
+export interface LabelReleasesResponse {
+  releases: LabelRelease[]
+}
+
+/**
+ * Get a display label for a label status
+ */
+export function getLabelStatusLabel(status: string): string {
+  return LABEL_STATUS_LABELS[status as LabelStatus] ?? status.charAt(0).toUpperCase() + status.slice(1)
+}
+
+/**
+ * Format a label's location string
+ */
+export function formatLabelLocation(label: { city: string | null; state: string | null }): string | null {
+  if (label.city && label.state) return `${label.city}, ${label.state}`
+  if (label.city) return label.city
+  if (label.state) return label.state
+  return null
+}


### PR DESCRIPTION
## Summary
- **Label types** (`lib/types/label.ts`) — interfaces, status helpers, display utilities
- **Label hooks** (`lib/hooks/useLabels.ts`) — `useLabels`, `useLabel`, `useLabelRoster`, `useLabelCatalog`
- **LabelCard** — status badge, location, artist/release counts, density support
- **LabelList** — status filter (All/Active/Inactive/Defunct), density toggle, responsive grid
- **LabelDetail** — EntityDetailLayout with Overview (description + socials), Roster (linked artists), Catalog (releases with catalog numbers)
- **Pages** at `/labels` and `/labels/[slug]` with SSR metadata
- **Navigation** — "Labels" added to sidebar and command palette

Closes PSY-12

## Test plan
- [x] All 897 frontend tests pass (`bun run test:run`)
- [x] Build succeeds (`bun run build`)
- [x] Sidebar test updated for "Labels" nav item
- [ ] Visual check: `/labels` list page with status filter
- [ ] Visual check: `/labels/[slug]` detail with roster and catalog tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)