### PR TITLE
feat: enrich artist pages with discography, labels, and discovery links

### DIFF
--- a/backend/internal/api/handlers/artist.go
+++ b/backend/internal/api/handlers/artist.go
@@ -251,6 +251,58 @@ func (h *ArtistHandler) GetArtistShowsHandler(ctx context.Context, req *GetArtis
 }
 
 // ============================================================================
+// Artist Labels
+// ============================================================================
+
+// GetArtistLabelsRequest represents the request for getting labels for an artist
+type GetArtistLabelsRequest struct {
+	ArtistID string `path:"artist_id" doc:"Artist ID or slug" example:"nirvana"`
+}
+
+// GetArtistLabelsResponse represents the response for the artist labels endpoint
+type GetArtistLabelsResponse struct {
+	Body struct {
+		Labels []*services.ArtistLabelResponse `json:"labels" doc:"List of labels"`
+		Count  int                             `json:"count" doc:"Number of labels"`
+	}
+}
+
+// GetArtistLabelsHandler handles GET /artists/{artist_id}/labels
+func (h *ArtistHandler) GetArtistLabelsHandler(ctx context.Context, req *GetArtistLabelsRequest) (*GetArtistLabelsResponse, error) {
+	// Resolve artist ID from numeric ID or slug
+	var artistID uint
+	if id, parseErr := strconv.ParseUint(req.ArtistID, 10, 32); parseErr == nil {
+		artistID = uint(id)
+	} else {
+		// Look up by slug to get the ID
+		artist, err := h.artistService.GetArtistBySlug(req.ArtistID)
+		if err != nil {
+			var artistErr *apperrors.ArtistError
+			if errors.As(err, &artistErr) && artistErr.Code == apperrors.CodeArtistNotFound {
+				return nil, huma.Error404NotFound("Artist not found")
+			}
+			return nil, huma.Error500InternalServerError("Failed to fetch artist", err)
+		}
+		artistID = artist.ID
+	}
+
+	labels, err := h.artistService.GetLabelsForArtist(artistID)
+	if err != nil {
+		var artistErr *apperrors.ArtistError
+		if errors.As(err, &artistErr) && artistErr.Code == apperrors.CodeArtistNotFound {
+			return nil, huma.Error404NotFound("Artist not found")
+		}
+		return nil, huma.Error500InternalServerError("Failed to fetch labels", err)
+	}
+
+	resp := &GetArtistLabelsResponse{}
+	resp.Body.Labels = labels
+	resp.Body.Count = len(labels)
+
+	return resp, nil
+}
+
+// ============================================================================
 // Admin Artist Handlers
 // ============================================================================
 

--- a/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
+++ b/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
@@ -896,6 +896,7 @@ type mockArtistService struct {
 	searchArtistsFn             func(query string) ([]*services.ArtistDetailResponse, error)
 	getShowsForArtistFn         func(artistID uint, timezone string, limit int, timeFilter string) ([]*services.ArtistShowResponse, int64, error)
 	getArtistCitiesFn           func() ([]*services.ArtistCityResponse, error)
+	getLabelsForArtistFn        func(artistID uint) ([]*services.ArtistLabelResponse, error)
 }
 
 func (m *mockArtistService) CreateArtist(req *services.CreateArtistRequest) (*services.ArtistDetailResponse, error) {
@@ -961,6 +962,12 @@ func (m *mockArtistService) GetShowsForArtist(artistID uint, timezone string, li
 func (m *mockArtistService) GetArtistCities() ([]*services.ArtistCityResponse, error) {
 	if m.getArtistCitiesFn != nil {
 		return m.getArtistCitiesFn()
+	}
+	return nil, nil
+}
+func (m *mockArtistService) GetLabelsForArtist(artistID uint) ([]*services.ArtistLabelResponse, error) {
+	if m.getLabelsForArtistFn != nil {
+		return m.getLabelsForArtistFn(artistID)
 	}
 	return nil, nil
 }

--- a/backend/internal/api/handlers/release.go
+++ b/backend/internal/api/handlers/release.go
@@ -362,8 +362,8 @@ type GetArtistReleasesRequest struct {
 // GetArtistReleasesResponse represents the response for the artist releases endpoint
 type GetArtistReleasesResponse struct {
 	Body struct {
-		Releases []*services.ReleaseListResponse `json:"releases" doc:"List of releases"`
-		Count    int                              `json:"count" doc:"Number of releases"`
+		Releases []*services.ArtistReleaseListResponse `json:"releases" doc:"List of releases with artist roles"`
+		Count    int                                    `json:"count" doc:"Number of releases"`
 	}
 }
 
@@ -386,7 +386,7 @@ func (h *ReleaseHandler) GetArtistReleasesHandler(ctx context.Context, req *GetA
 		artistID = artist.ID
 	}
 
-	releases, err := h.releaseService.GetReleasesForArtist(artistID)
+	releases, err := h.releaseService.GetReleasesForArtistWithRoles(artistID)
 	if err != nil {
 		var artistErr *apperrors.ArtistError
 		if errors.As(err, &artistErr) && artistErr.Code == apperrors.CodeArtistNotFound {

--- a/backend/internal/api/handlers/release_integration_test.go
+++ b/backend/internal/api/handlers/release_integration_test.go
@@ -286,7 +286,7 @@ func (s *ReleaseHandlerIntegrationSuite) TestGetArtistReleases_Success() {
 	})
 	s.deps.releaseService.CreateRelease(&services.CreateReleaseRequest{
 		Title:   "Album Two",
-		Artists: []services.CreateReleaseArtistEntry{{ArtistID: artistID, Role: "main"}},
+		Artists: []services.CreateReleaseArtistEntry{{ArtistID: artistID, Role: "featured"}},
 	})
 
 	req := &GetArtistReleasesRequest{ArtistID: fmt.Sprintf("%d", artistID)}
@@ -294,6 +294,14 @@ func (s *ReleaseHandlerIntegrationSuite) TestGetArtistReleases_Success() {
 	s.NoError(err)
 	s.NotNil(resp)
 	s.Equal(2, resp.Body.Count)
+
+	// Verify roles are present in the response
+	roleMap := make(map[string]string)
+	for _, r := range resp.Body.Releases {
+		roleMap[r.Title] = r.Role
+	}
+	s.Equal("main", roleMap["Album One"])
+	s.Equal("featured", roleMap["Album Two"])
 }
 
 func (s *ReleaseHandlerIntegrationSuite) TestGetArtistReleases_BySlug() {

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -275,6 +275,7 @@ func setupArtistRoutes(api huma.API, protected *huma.Group, sc *services.Service
 	huma.Get(api, "/artists/search", artistHandler.SearchArtistsHandler)
 	huma.Get(api, "/artists/{artist_id}", artistHandler.GetArtistHandler)
 	huma.Get(api, "/artists/{artist_id}/shows", artistHandler.GetArtistShowsHandler)
+	huma.Get(api, "/artists/{artist_id}/labels", artistHandler.GetArtistLabelsHandler)
 
 	// Protected artist endpoints
 	huma.Delete(protected, "/artists/{artist_id}", artistHandler.DeleteArtistHandler)

--- a/backend/internal/services/artist.go
+++ b/backend/internal/services/artist.go
@@ -498,6 +498,64 @@ func (s *ArtistService) buildArtistResponse(artist *models.Artist) *ArtistDetail
 	}
 }
 
+// ArtistLabelResponse represents a label the artist is on
+type ArtistLabelResponse struct {
+	ID    uint    `json:"id"`
+	Name  string  `json:"name"`
+	Slug  string  `json:"slug"`
+	City  *string `json:"city"`
+	State *string `json:"state"`
+}
+
+// GetLabelsForArtist retrieves all labels associated with an artist
+func (s *ArtistService) GetLabelsForArtist(artistID uint) ([]*ArtistLabelResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	// Verify artist exists
+	var artist models.Artist
+	if err := s.db.First(&artist, artistID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, apperrors.ErrArtistNotFound(artistID)
+		}
+		return nil, fmt.Errorf("failed to get artist: %w", err)
+	}
+
+	// Get label IDs from junction table
+	var artistLabels []models.ArtistLabel
+	s.db.Where("artist_id = ?", artistID).Find(&artistLabels)
+
+	if len(artistLabels) == 0 {
+		return []*ArtistLabelResponse{}, nil
+	}
+
+	labelIDs := make([]uint, len(artistLabels))
+	for i, al := range artistLabels {
+		labelIDs[i] = al.LabelID
+	}
+
+	var labels []models.Label
+	s.db.Where("id IN ?", labelIDs).Order("name ASC").Find(&labels)
+
+	responses := make([]*ArtistLabelResponse, len(labels))
+	for i, label := range labels {
+		slug := ""
+		if label.Slug != nil {
+			slug = *label.Slug
+		}
+		responses[i] = &ArtistLabelResponse{
+			ID:    label.ID,
+			Name:  label.Name,
+			Slug:  slug,
+			City:  label.City,
+			State: label.State,
+		}
+	}
+
+	return responses, nil
+}
+
 // ArtistShowResponse represents a show in the artist shows endpoint
 type ArtistShowResponse struct {
 	ID             uint                     `json:"id"`

--- a/backend/internal/services/interfaces.go
+++ b/backend/internal/services/interfaces.go
@@ -80,6 +80,7 @@ type ArtistServiceInterface interface {
 	SearchArtists(query string) ([]*ArtistDetailResponse, error)
 	GetShowsForArtist(artistID uint, timezone string, limit int, timeFilter string) ([]*ArtistShowResponse, int64, error)
 	GetArtistCities() ([]*ArtistCityResponse, error)
+	GetLabelsForArtist(artistID uint) ([]*ArtistLabelResponse, error)
 }
 
 // SavedShowServiceInterface defines the contract for saved show operations.
@@ -321,6 +322,7 @@ type ReleaseServiceInterface interface {
 	UpdateRelease(releaseID uint, req *UpdateReleaseRequest) (*ReleaseDetailResponse, error)
 	DeleteRelease(releaseID uint) error
 	GetReleasesForArtist(artistID uint) ([]*ReleaseListResponse, error)
+	GetReleasesForArtistWithRoles(artistID uint) ([]*ArtistReleaseListResponse, error)
 	AddExternalLink(releaseID uint, platform, url string) (*ReleaseExternalLinkResponse, error)
 	RemoveExternalLink(linkID uint) error
 }

--- a/backend/internal/services/release.go
+++ b/backend/internal/services/release.go
@@ -103,6 +103,12 @@ type ReleaseListResponse struct {
 	ArtistCount int     `json:"artist_count"`
 }
 
+// ArtistReleaseListResponse extends ReleaseListResponse with the artist's role on that release
+type ArtistReleaseListResponse struct {
+	ReleaseListResponse
+	Role string `json:"role"`
+}
+
 // CreateRelease creates a new release
 func (s *ReleaseService) CreateRelease(req *CreateReleaseRequest) (*ReleaseDetailResponse, error) {
 	if s.db == nil {
@@ -384,6 +390,90 @@ func (s *ReleaseService) GetReleasesForArtist(artistID uint) ([]*ReleaseListResp
 	}
 
 	return s.ListReleases(map[string]interface{}{"artist_id": artistID})
+}
+
+// GetReleasesForArtistWithRoles retrieves all releases for an artist, including their role on each release
+func (s *ReleaseService) GetReleasesForArtistWithRoles(artistID uint) ([]*ArtistReleaseListResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	// Verify artist exists
+	var artist models.Artist
+	if err := s.db.First(&artist, artistID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, apperrors.ErrArtistNotFound(artistID)
+		}
+		return nil, fmt.Errorf("failed to get artist: %w", err)
+	}
+
+	// Get artist_releases junction entries for this artist (includes role)
+	var artistReleases []models.ArtistRelease
+	if err := s.db.Where("artist_id = ?", artistID).Find(&artistReleases).Error; err != nil {
+		return nil, fmt.Errorf("failed to get artist releases: %w", err)
+	}
+
+	if len(artistReleases) == 0 {
+		return []*ArtistReleaseListResponse{}, nil
+	}
+
+	// Build role map: releaseID -> role (an artist can have multiple roles on a release,
+	// but for grouping we use the first/primary one)
+	roleMap := make(map[uint]string)
+	releaseIDs := make([]uint, 0, len(artistReleases))
+	for _, ar := range artistReleases {
+		if _, exists := roleMap[ar.ReleaseID]; !exists {
+			releaseIDs = append(releaseIDs, ar.ReleaseID)
+		}
+		roleMap[ar.ReleaseID] = string(ar.Role)
+	}
+
+	// Fetch releases
+	var releases []models.Release
+	if err := s.db.Where("id IN ?", releaseIDs).Order("release_year DESC NULLS LAST, title ASC").Find(&releases).Error; err != nil {
+		return nil, fmt.Errorf("failed to get releases: %w", err)
+	}
+
+	// Batch-load artist counts
+	artistCounts := make(map[uint]int)
+	if len(releaseIDs) > 0 {
+		type CountResult struct {
+			ReleaseID uint
+			Count     int
+		}
+		var counts []CountResult
+		s.db.Table("artist_releases").
+			Select("release_id, COUNT(DISTINCT artist_id) as count").
+			Where("release_id IN ?", releaseIDs).
+			Group("release_id").
+			Find(&counts)
+		for _, c := range counts {
+			artistCounts[c.ReleaseID] = c.Count
+		}
+	}
+
+	// Build responses
+	responses := make([]*ArtistReleaseListResponse, len(releases))
+	for i, release := range releases {
+		slug := ""
+		if release.Slug != nil {
+			slug = *release.Slug
+		}
+		responses[i] = &ArtistReleaseListResponse{
+			ReleaseListResponse: ReleaseListResponse{
+				ID:          release.ID,
+				Title:       release.Title,
+				Slug:        slug,
+				ReleaseType: string(release.ReleaseType),
+				ReleaseYear: release.ReleaseYear,
+				CoverArtURL: release.CoverArtURL,
+				ArtistCount: artistCounts[release.ID],
+			},
+			Role: roleMap[release.ID],
+		}
+	}
+
+	return responses, nil
 }
 
 // AddExternalLink adds an external link to a release

--- a/frontend/components/artists/ArtistDetail.tsx
+++ b/frontend/components/artists/ArtistDetail.tsx
@@ -12,9 +12,13 @@ import {
   Check,
   AlertCircle,
   Edit2,
+  Disc3,
+  Tag,
 } from 'lucide-react'
 import { useQueryClient } from '@tanstack/react-query'
 import { useArtist } from '@/lib/hooks/useArtists'
+import { useArtistReleases } from '@/lib/hooks/useReleases'
+import { useArtistLabels, useLabelRoster } from '@/lib/hooks/useLabels'
 import { queryKeys } from '@/lib/queryClient'
 import { useIsAuthenticated } from '@/lib/hooks/useAuth'
 import {
@@ -25,28 +29,368 @@ import {
   useClearArtistSpotify,
   type MusicPlatform,
 } from '@/lib/hooks/useAdminArtists'
-import { SocialLinks, MusicEmbed } from '@/components/shared'
+import { SocialLinks, MusicEmbed, EntityDetailLayout, EntityHeader } from '@/components/shared'
 import { ArtistEditForm } from '@/components/forms/ArtistEditForm'
 import { ArtistShowsList } from './ArtistShowsList'
 import { ReportArtistButton } from './ReportArtistButton'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Alert, AlertDescription } from '@/components/ui/alert'
+import { TabsContent } from '@/components/ui/tabs'
+import { Badge } from '@/components/ui/badge'
+import { getReleaseTypeLabel } from '@/lib/types/release'
+import type { ArtistReleaseListItem } from '@/lib/types/release'
+import type { ArtistLabel } from '@/lib/types/label'
 
 interface ArtistDetailProps {
   artistId: string | number
 }
 
-export function ArtistDetail({ artistId }: ArtistDetailProps) {
+// --- Discography Tab ---
+
+interface DiscographySectionProps {
+  title: string
+  releases: ArtistReleaseListItem[]
+}
+
+function DiscographySection({ title, releases }: DiscographySectionProps) {
+  if (releases.length === 0) return null
+
+  return (
+    <div className="mb-6">
+      <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-3">
+        {title}
+      </h3>
+      <div className="space-y-2">
+        {releases.map(release => (
+          <Link
+            key={release.id}
+            href={`/releases/${release.slug}`}
+            className="flex items-center gap-3 p-2 rounded-md hover:bg-muted/50 transition-colors group"
+          >
+            <div className="w-10 h-10 bg-muted rounded flex-shrink-0 flex items-center justify-center">
+              {release.cover_art_url ? (
+                <img
+                  src={release.cover_art_url}
+                  alt={release.title}
+                  className="w-10 h-10 rounded object-cover"
+                />
+              ) : (
+                <Disc3 className="h-5 w-5 text-muted-foreground" />
+              )}
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium group-hover:text-foreground truncate">
+                {release.title}
+              </p>
+              <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
+                  {getReleaseTypeLabel(release.release_type)}
+                </Badge>
+                {release.release_year && <span>{release.release_year}</span>}
+              </div>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function DiscographyTab({ artistIdOrSlug }: { artistIdOrSlug: string | number }) {
+  const { data, isLoading, error } = useArtistReleases({ artistIdOrSlug })
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-8">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="py-8 text-center text-sm text-destructive">
+        Failed to load discography
+      </div>
+    )
+  }
+
+  if (!data?.releases || data.releases.length === 0) {
+    return (
+      <div className="py-8 text-center text-sm text-muted-foreground">
+        No releases yet
+      </div>
+    )
+  }
+
+  // Group releases by role category
+  const albumsAndEPs = data.releases.filter(
+    r => r.role === 'main' && (r.release_type === 'lp' || r.release_type === 'ep')
+  )
+  const singles = data.releases.filter(
+    r => r.role === 'main' && r.release_type === 'single'
+  )
+  const otherMain = data.releases.filter(
+    r =>
+      r.role === 'main' &&
+      r.release_type !== 'lp' &&
+      r.release_type !== 'ep' &&
+      r.release_type !== 'single'
+  )
+  const appearsOn = data.releases.filter(r => r.role === 'featured')
+  const production = data.releases.filter(
+    r =>
+      r.role === 'producer' ||
+      r.role === 'remixer' ||
+      r.role === 'composer' ||
+      r.role === 'dj'
+  )
+
+  return (
+    <div>
+      <DiscographySection title="Albums & EPs" releases={albumsAndEPs} />
+      <DiscographySection title="Singles" releases={singles} />
+      <DiscographySection title="Other Releases" releases={otherMain} />
+      <DiscographySection title="Appears On" releases={appearsOn} />
+      <DiscographySection title="Production" releases={production} />
+    </div>
+  )
+}
+
+// --- Labels Tab ---
+
+function LabelsTab({ artistIdOrSlug }: { artistIdOrSlug: string | number }) {
+  const { data, isLoading, error } = useArtistLabels({ artistIdOrSlug })
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-8">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="py-8 text-center text-sm text-destructive">
+        Failed to load labels
+      </div>
+    )
+  }
+
+  if (!data?.labels || data.labels.length === 0) {
+    return (
+      <div className="py-8 text-center text-sm text-muted-foreground">
+        No label affiliations yet
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      {data.labels.map(label => (
+        <Link
+          key={label.id}
+          href={`/labels/${label.slug}`}
+          className="flex items-center gap-3 p-3 rounded-md border border-border/50 hover:bg-muted/50 transition-colors group"
+        >
+          <div className="w-10 h-10 bg-muted rounded flex-shrink-0 flex items-center justify-center">
+            <Tag className="h-5 w-5 text-muted-foreground" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium group-hover:text-foreground">
+              {label.name}
+            </p>
+            {(label.city || label.state) && (
+              <p className="text-xs text-muted-foreground">
+                {[label.city, label.state].filter(Boolean).join(', ')}
+              </p>
+            )}
+          </div>
+        </Link>
+      ))}
+    </div>
+  )
+}
+
+// --- Also on this label sidebar section ---
+
+function AlsoOnThisLabel({
+  labels,
+  currentArtistId,
+}: {
+  labels: ArtistLabel[]
+  currentArtistId: number
+}) {
+  if (labels.length === 0) return null
+
+  return (
+    <div className="space-y-4">
+      {labels.map(label => (
+        <AlsoOnLabelSection
+          key={label.id}
+          label={label}
+          currentArtistId={currentArtistId}
+        />
+      ))}
+    </div>
+  )
+}
+
+function AlsoOnLabelSection({
+  label,
+  currentArtistId,
+}: {
+  label: ArtistLabel
+  currentArtistId: number
+}) {
+  const { data } = useLabelRoster({
+    labelIdOrSlug: label.id,
+    enabled: true,
+  })
+
+  // Filter out current artist and limit to 5
+  const otherArtists = data?.artists
+    ?.filter(a => a.id !== currentArtistId)
+    .slice(0, 5)
+
+  if (!otherArtists || otherArtists.length === 0) return null
+
+  return (
+    <div>
+      <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+        Also on{' '}
+        <Link
+          href={`/labels/${label.slug}`}
+          className="text-foreground hover:underline"
+        >
+          {label.name}
+        </Link>
+      </h4>
+      <div className="space-y-1">
+        {otherArtists.map(artist => (
+          <Link
+            key={artist.id}
+            href={`/artists/${artist.slug}`}
+            className="block text-sm text-muted-foreground hover:text-foreground transition-colors py-0.5"
+          >
+            {artist.name}
+          </Link>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// --- Sidebar ---
+
+function ArtistSidebar({
+  artist,
+  labels,
+  labelsLoading,
+}: {
+  artist: {
+    id: number
+    name: string
+    city: string | null
+    state: string | null
+    bandcamp_embed_url: string | null
+    social: {
+      instagram: string | null
+      facebook: string | null
+      twitter: string | null
+      youtube: string | null
+      spotify: string | null
+      soundcloud: string | null
+      bandcamp: string | null
+      website: string | null
+    }
+  }
+  labels: ArtistLabel[]
+  labelsLoading: boolean
+}) {
+  const hasLocation = artist.city || artist.state
+
+  return (
+    <div className="space-y-6">
+      {/* Location */}
+      {hasLocation && (
+        <div>
+          <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+            Location
+          </h3>
+          <div className="flex items-center gap-1.5 text-sm">
+            <MapPin className="h-4 w-4 text-muted-foreground" />
+            <span>{[artist.city, artist.state].filter(Boolean).join(', ')}</span>
+          </div>
+        </div>
+      )}
+
+      {/* Social Links */}
+      {artist.social && (
+        <div>
+          <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+            Links
+          </h3>
+          <SocialLinks social={artist.social} />
+        </div>
+      )}
+
+      {/* Label Affiliations */}
+      {!labelsLoading && labels.length > 0 && (
+        <div>
+          <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+            Labels
+          </h3>
+          <div className="space-y-1">
+            {labels.map(label => (
+              <Link
+                key={label.id}
+                href={`/labels/${label.slug}`}
+                className="block text-sm text-muted-foreground hover:text-foreground transition-colors py-0.5"
+              >
+                {label.name}
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Music Embed */}
+      <MusicEmbed
+        bandcampAlbumUrl={artist.bandcamp_embed_url}
+        bandcampProfileUrl={artist.social?.bandcamp}
+        spotifyUrl={artist.social?.spotify}
+        artistName={artist.name}
+      />
+
+      {/* Also on this label */}
+      {!labelsLoading && labels.length > 0 && (
+        <AlsoOnThisLabel labels={labels} currentArtistId={artist.id} />
+      )}
+    </div>
+  )
+}
+
+// --- Admin Controls ---
+
+function AdminMusicControls({
+  artist,
+  artistId,
+}: {
+  artist: {
+    id: number
+    name: string
+    bandcamp_embed_url: string | null
+    social: {
+      spotify: string | null
+      bandcamp: string | null
+    }
+  }
+  artistId: string | number
+}) {
   const queryClient = useQueryClient()
-  const { data: artist, isLoading, error } = useArtist({ artistId })
-  const { user, isAuthenticated } = useIsAuthenticated()
-  const isAdmin = isAuthenticated && user?.is_admin
-
-  // Admin state for artist edit dialog
-  const [isEditing, setIsEditing] = useState(false)
-
-  // Admin state for music embed management
   const [showManualInput, setShowManualInput] = useState<
     'bandcamp' | 'spotify' | null
   >(null)
@@ -56,7 +400,6 @@ export function ArtistDetail({ artistId }: ArtistDetailProps) {
     message: string
   } | null>(null)
 
-  // Admin mutations
   const discoverMusic = useDiscoverMusic()
   const updateBandcamp = useUpdateArtistBandcamp()
   const clearBandcamp = useClearArtistBandcamp()
@@ -70,18 +413,14 @@ export function ArtistDetail({ artistId }: ArtistDetailProps) {
     updateSpotify.isPending ||
     clearSpotify.isPending
 
-  // Helper to format platform name for display
   const formatPlatformName = (platform: MusicPlatform): string => {
     return platform === 'bandcamp' ? 'Bandcamp' : 'Spotify'
   }
 
-  // Handlers - use artist.id (numeric) for mutations
   const handleDiscover = () => {
-    if (!artist) return
     setFeedback(null)
     discoverMusic.mutate(artist.id, {
       onSuccess: data => {
-        // Invalidate using the original artistId (slug) to refresh the UI
         queryClient.invalidateQueries({
           queryKey: queryKeys.artists.detail(artistId),
         })
@@ -119,17 +458,13 @@ export function ArtistDetail({ artistId }: ArtistDetailProps) {
         } else {
           displayMessage = message
         }
-        setFeedback({
-          type: 'error',
-          message: displayMessage,
-        })
+        setFeedback({ type: 'error', message: displayMessage })
       },
     })
   }
 
   const handleManualSaveBandcamp = () => {
-    if (!manualUrl.trim() || !artist) return
-
+    if (!manualUrl.trim()) return
     setFeedback(null)
     updateBandcamp.mutate(
       { artistId: artist.id, bandcampUrl: manualUrl.trim() },
@@ -153,8 +488,7 @@ export function ArtistDetail({ artistId }: ArtistDetailProps) {
   }
 
   const handleManualSaveSpotify = () => {
-    if (!manualUrl.trim() || !artist) return
-
+    if (!manualUrl.trim()) return
     setFeedback(null)
     updateSpotify.mutate(
       { artistId: artist.id, spotifyUrl: manualUrl.trim() },
@@ -178,7 +512,6 @@ export function ArtistDetail({ artistId }: ArtistDetailProps) {
   }
 
   const handleClearBandcamp = () => {
-    if (!artist) return
     setFeedback(null)
     clearBandcamp.mutate(artist.id, {
       onSuccess: () => {
@@ -198,7 +531,6 @@ export function ArtistDetail({ artistId }: ArtistDetailProps) {
   }
 
   const handleClearSpotify = () => {
-    if (!artist) return
     setFeedback(null)
     clearSpotify.mutate(artist.id, {
       onSuccess: () => {
@@ -217,28 +549,268 @@ export function ArtistDetail({ artistId }: ArtistDetailProps) {
     })
   }
 
-  const handleEditBandcampClick = () => {
-    setManualUrl(artist?.bandcamp_embed_url || '')
-    setShowManualInput('bandcamp')
-    setFeedback(null)
-  }
-
-  const handleEditSpotifyClick = () => {
-    setManualUrl(artist?.social?.spotify || '')
-    setShowManualInput('spotify')
-    setFeedback(null)
-  }
-
   const handleCancelEdit = () => {
     setShowManualInput(null)
     setManualUrl('')
     setFeedback(null)
   }
 
-  // Determine what embeds are configured
-  const hasBandcamp = !!artist?.bandcamp_embed_url
-  const hasSpotify = !!artist?.social?.spotify
+  const hasBandcamp = !!artist.bandcamp_embed_url
+  const hasSpotify = !!artist.social?.spotify
   const hasAnyEmbed = hasBandcamp || hasSpotify
+
+  return (
+    <div className="mb-6">
+      {feedback && (
+        <Alert
+          variant={feedback.type === 'error' ? 'destructive' : 'default'}
+          className="mb-4"
+        >
+          {feedback.type === 'error' && <AlertCircle className="h-4 w-4" />}
+          {feedback.type === 'success' && <Check className="h-4 w-4" />}
+          <AlertDescription>{feedback.message}</AlertDescription>
+        </Alert>
+      )}
+
+      {!hasAnyEmbed && !showManualInput && (
+        <div className="p-4 rounded-lg border border-dashed border-muted-foreground/25 bg-muted/30">
+          <p className="text-sm text-muted-foreground mb-3">
+            No music embed configured
+          </p>
+          <div className="flex flex-wrap gap-2">
+            <Button
+              onClick={handleDiscover}
+              disabled={isAnyLoading}
+              size="sm"
+            >
+              {discoverMusic.isPending ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  Discovering...
+                </>
+              ) : (
+                <>
+                  <Sparkles className="h-4 w-4 mr-2" />
+                  Discover Music
+                </>
+              )}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setShowManualInput('bandcamp')}
+              disabled={isAnyLoading}
+            >
+              <Pencil className="h-4 w-4 mr-2" />
+              Enter Bandcamp URL
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setShowManualInput('spotify')}
+              disabled={isAnyLoading}
+            >
+              <Pencil className="h-4 w-4 mr-2" />
+              Enter Spotify URL
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {hasAnyEmbed && !showManualInput && (
+        <div className="flex flex-wrap gap-2">
+          {hasBandcamp && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                setManualUrl(artist.bandcamp_embed_url || '')
+                setShowManualInput('bandcamp')
+                setFeedback(null)
+              }}
+              disabled={isAnyLoading}
+            >
+              <Pencil className="h-4 w-4 mr-2" />
+              Edit Bandcamp URL
+            </Button>
+          )}
+          {hasSpotify && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                setManualUrl(artist.social?.spotify || '')
+                setShowManualInput('spotify')
+                setFeedback(null)
+              }}
+              disabled={isAnyLoading}
+            >
+              <Pencil className="h-4 w-4 mr-2" />
+              Edit Spotify URL
+            </Button>
+          )}
+          {hasBandcamp && !hasSpotify && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setShowManualInput('spotify')}
+              disabled={isAnyLoading}
+            >
+              <Pencil className="h-4 w-4 mr-2" />
+              Add Spotify URL
+            </Button>
+          )}
+          {hasSpotify && !hasBandcamp && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setShowManualInput('bandcamp')}
+              disabled={isAnyLoading}
+            >
+              <Pencil className="h-4 w-4 mr-2" />
+              Add Bandcamp URL
+            </Button>
+          )}
+        </div>
+      )}
+
+      {showManualInput === 'bandcamp' && (
+        <div className="p-4 rounded-lg border border-muted-foreground/25 bg-muted/30">
+          <label
+            htmlFor="bandcamp-url"
+            className="block text-sm font-medium mb-2"
+          >
+            Bandcamp Album URL
+          </label>
+          <div className="flex gap-2">
+            <Input
+              id="bandcamp-url"
+              type="url"
+              placeholder="https://artist.bandcamp.com/album/album-name"
+              value={manualUrl}
+              onChange={e => setManualUrl(e.target.value)}
+              disabled={isAnyLoading}
+              className="flex-1"
+            />
+            <Button
+              onClick={handleManualSaveBandcamp}
+              disabled={isAnyLoading || !manualUrl.trim()}
+              size="sm"
+            >
+              {updateBandcamp.isPending ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Check className="h-4 w-4" />
+              )}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleCancelEdit}
+              disabled={isAnyLoading}
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
+          {hasBandcamp && (
+            <div className="mt-3 pt-3 border-t border-muted-foreground/25">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={handleClearBandcamp}
+                disabled={isAnyLoading}
+                className="text-destructive hover:text-destructive"
+              >
+                {clearBandcamp.isPending ? (
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                ) : (
+                  <X className="h-4 w-4 mr-2" />
+                )}
+                Clear Bandcamp URL
+              </Button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {showManualInput === 'spotify' && (
+        <div className="p-4 rounded-lg border border-muted-foreground/25 bg-muted/30">
+          <label
+            htmlFor="spotify-url"
+            className="block text-sm font-medium mb-2"
+          >
+            Spotify Artist URL
+          </label>
+          <div className="flex gap-2">
+            <Input
+              id="spotify-url"
+              type="url"
+              placeholder="https://open.spotify.com/artist/..."
+              value={manualUrl}
+              onChange={e => setManualUrl(e.target.value)}
+              disabled={isAnyLoading}
+              className="flex-1"
+            />
+            <Button
+              onClick={handleManualSaveSpotify}
+              disabled={isAnyLoading || !manualUrl.trim()}
+              size="sm"
+            >
+              {updateSpotify.isPending ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Check className="h-4 w-4" />
+              )}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleCancelEdit}
+              disabled={isAnyLoading}
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
+          {hasSpotify && (
+            <div className="mt-3 pt-3 border-t border-muted-foreground/25">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={handleClearSpotify}
+                disabled={isAnyLoading}
+                className="text-destructive hover:text-destructive"
+              >
+                {clearSpotify.isPending ? (
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                ) : (
+                  <X className="h-4 w-4 mr-2" />
+                )}
+                Clear Spotify URL
+              </Button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// --- Main Component ---
+
+export function ArtistDetail({ artistId }: ArtistDetailProps) {
+  const queryClient = useQueryClient()
+  const { data: artist, isLoading, error } = useArtist({ artistId })
+  const { user, isAuthenticated } = useIsAuthenticated()
+  const isAdmin = isAuthenticated && user?.is_admin
+
+  const [activeTab, setActiveTab] = useState('overview')
+  const [isEditing, setIsEditing] = useState(false)
+
+  // Fetch labels for sidebar
+  const { data: labelsData, isLoading: labelsLoading } = useArtistLabels({
+    artistIdOrSlug: artistId,
+    enabled: !!artist,
+  })
 
   if (isLoading) {
     return (
@@ -295,298 +867,81 @@ export function ArtistDetail({ artistId }: ArtistDetailProps) {
     )
   }
 
-  const hasLocation = artist.city || artist.state
+  const labels = labelsData?.labels ?? []
+
+  // Build tabs - only show tabs that have content or always show
+  const tabs = [
+    { value: 'overview', label: 'Overview' },
+    { value: 'discography', label: 'Discography' },
+    { value: 'labels', label: 'Labels' },
+  ]
+
+  const headerSubtitle = (artist.city || artist.state) ? (
+    <>
+      <MapPin className="h-4 w-4" />
+      <span>{[artist.city, artist.state].filter(Boolean).join(', ')}</span>
+    </>
+  ) : undefined
+
+  const headerActions = (
+    <div className="flex items-center gap-2">
+      {isAdmin && (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => setIsEditing(true)}
+          className="text-muted-foreground hover:text-foreground"
+        >
+          <Edit2 className="h-4 w-4" />
+        </Button>
+      )}
+      <ReportArtistButton artistId={artist.id} artistName={artist.name} />
+    </div>
+  )
 
   return (
-    <div className="container max-w-6xl mx-auto px-4 py-6">
-      {/* Back Navigation */}
-      <div className="mb-6">
-        <Link
-          href="/shows"
-          className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground transition-colors"
-        >
-          <ArrowLeft className="h-4 w-4 mr-1" />
-          Back to Shows
-        </Link>
-      </div>
-
-      {/* Header */}
-      <header className="mb-8">
-        <div className="flex items-center gap-3">
-          <h1 className="text-2xl md:text-3xl font-bold leading-8 md:leading-9">
-            {artist.name}
-          </h1>
+    <>
+      <EntityDetailLayout
+        backLink={{ href: '/shows', label: 'Back to Shows' }}
+        header={
+          <EntityHeader
+            title={artist.name}
+            subtitle={headerSubtitle}
+            actions={headerActions}
+          />
+        }
+        tabs={tabs}
+        activeTab={activeTab}
+        onTabChange={setActiveTab}
+        sidebar={
+          <ArtistSidebar
+            artist={artist}
+            labels={labels}
+            labelsLoading={labelsLoading}
+          />
+        }
+      >
+        {/* Overview Tab */}
+        <TabsContent value="overview">
+          {/* Admin music embed controls */}
           {isAdmin && (
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => setIsEditing(true)}
-              className="text-muted-foreground hover:text-foreground"
-            >
-              <Edit2 className="h-4 w-4" />
-            </Button>
-          )}
-          <ReportArtistButton artistId={artist.id} artistName={artist.name} />
-        </div>
-        {hasLocation && (
-          <div className="flex items-center gap-1 text-muted-foreground mt-2">
-            <MapPin className="h-4 w-4" />
-            <span>
-              {[artist.city, artist.state].filter(Boolean).join(', ')}
-            </span>
-          </div>
-        )}
-
-        {/* Social Links */}
-        {artist.social && (
-          <SocialLinks social={artist.social} className="mt-4" />
-        )}
-      </header>
-
-      {/* Music Embed */}
-      <MusicEmbed
-        bandcampAlbumUrl={artist.bandcamp_embed_url}
-        bandcampProfileUrl={artist.social?.bandcamp}
-        spotifyUrl={artist.social?.spotify}
-        artistName={artist.name}
-      />
-
-      {/* Admin Controls for Music Embed Management */}
-      {isAdmin && (
-        <div className="mb-8">
-          {/* Feedback Alert */}
-          {feedback && (
-            <Alert
-              variant={feedback.type === 'error' ? 'destructive' : 'default'}
-              className="mb-4"
-            >
-              {feedback.type === 'error' && <AlertCircle className="h-4 w-4" />}
-              {feedback.type === 'success' && <Check className="h-4 w-4" />}
-              <AlertDescription>{feedback.message}</AlertDescription>
-            </Alert>
+            <AdminMusicControls artist={artist} artistId={artistId} />
           )}
 
-          {/* No embed configured - show discovery options */}
-          {!hasAnyEmbed && !showManualInput && (
-            <div className="p-4 rounded-lg border border-dashed border-muted-foreground/25 bg-muted/30">
-              <p className="text-sm text-muted-foreground mb-3">
-                No music embed configured
-              </p>
-              <div className="flex flex-wrap gap-2">
-                <Button
-                  onClick={handleDiscover}
-                  disabled={isAnyLoading}
-                  size="sm"
-                >
-                  {discoverMusic.isPending ? (
-                    <>
-                      <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                      Discovering...
-                    </>
-                  ) : (
-                    <>
-                      <Sparkles className="h-4 w-4 mr-2" />
-                      Discover Music
-                    </>
-                  )}
-                </Button>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => setShowManualInput('bandcamp')}
-                  disabled={isAnyLoading}
-                >
-                  <Pencil className="h-4 w-4 mr-2" />
-                  Enter Bandcamp URL
-                </Button>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => setShowManualInput('spotify')}
-                  disabled={isAnyLoading}
-                >
-                  <Pencil className="h-4 w-4 mr-2" />
-                  Enter Spotify URL
-                </Button>
-              </div>
-            </div>
-          )}
+          {/* Shows List */}
+          <ArtistShowsList artistId={artist.id} />
+        </TabsContent>
 
-          {/* Embeds exist - show edit buttons */}
-          {hasAnyEmbed && !showManualInput && (
-            <div className="flex flex-wrap gap-2">
-              {hasBandcamp && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={handleEditBandcampClick}
-                  disabled={isAnyLoading}
-                >
-                  <Pencil className="h-4 w-4 mr-2" />
-                  Edit Bandcamp URL
-                </Button>
-              )}
-              {hasSpotify && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={handleEditSpotifyClick}
-                  disabled={isAnyLoading}
-                >
-                  <Pencil className="h-4 w-4 mr-2" />
-                  Edit Spotify URL
-                </Button>
-              )}
-              {/* Allow adding the other platform if only one is configured */}
-              {hasBandcamp && !hasSpotify && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => setShowManualInput('spotify')}
-                  disabled={isAnyLoading}
-                >
-                  <Pencil className="h-4 w-4 mr-2" />
-                  Add Spotify URL
-                </Button>
-              )}
-              {hasSpotify && !hasBandcamp && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => setShowManualInput('bandcamp')}
-                  disabled={isAnyLoading}
-                >
-                  <Pencil className="h-4 w-4 mr-2" />
-                  Add Bandcamp URL
-                </Button>
-              )}
-            </div>
-          )}
+        {/* Discography Tab */}
+        <TabsContent value="discography">
+          <DiscographyTab artistIdOrSlug={artistId} />
+        </TabsContent>
 
-          {/* Bandcamp URL input form */}
-          {showManualInput === 'bandcamp' && (
-            <div className="p-4 rounded-lg border border-muted-foreground/25 bg-muted/30">
-              <label
-                htmlFor="bandcamp-url"
-                className="block text-sm font-medium mb-2"
-              >
-                Bandcamp Album URL
-              </label>
-              <div className="flex gap-2">
-                <Input
-                  id="bandcamp-url"
-                  type="url"
-                  placeholder="https://artist.bandcamp.com/album/album-name"
-                  value={manualUrl}
-                  onChange={e => setManualUrl(e.target.value)}
-                  disabled={isAnyLoading}
-                  className="flex-1"
-                />
-                <Button
-                  onClick={handleManualSaveBandcamp}
-                  disabled={isAnyLoading || !manualUrl.trim()}
-                  size="sm"
-                >
-                  {updateBandcamp.isPending ? (
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                  ) : (
-                    <Check className="h-4 w-4" />
-                  )}
-                </Button>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={handleCancelEdit}
-                  disabled={isAnyLoading}
-                >
-                  <X className="h-4 w-4" />
-                </Button>
-              </div>
-              {hasBandcamp && (
-                <div className="mt-3 pt-3 border-t border-muted-foreground/25">
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={handleClearBandcamp}
-                    disabled={isAnyLoading}
-                    className="text-destructive hover:text-destructive"
-                  >
-                    {clearBandcamp.isPending ? (
-                      <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                    ) : (
-                      <X className="h-4 w-4 mr-2" />
-                    )}
-                    Clear Bandcamp URL
-                  </Button>
-                </div>
-              )}
-            </div>
-          )}
-
-          {/* Spotify URL input form */}
-          {showManualInput === 'spotify' && (
-            <div className="p-4 rounded-lg border border-muted-foreground/25 bg-muted/30">
-              <label
-                htmlFor="spotify-url"
-                className="block text-sm font-medium mb-2"
-              >
-                Spotify Artist URL
-              </label>
-              <div className="flex gap-2">
-                <Input
-                  id="spotify-url"
-                  type="url"
-                  placeholder="https://open.spotify.com/artist/..."
-                  value={manualUrl}
-                  onChange={e => setManualUrl(e.target.value)}
-                  disabled={isAnyLoading}
-                  className="flex-1"
-                />
-                <Button
-                  onClick={handleManualSaveSpotify}
-                  disabled={isAnyLoading || !manualUrl.trim()}
-                  size="sm"
-                >
-                  {updateSpotify.isPending ? (
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                  ) : (
-                    <Check className="h-4 w-4" />
-                  )}
-                </Button>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={handleCancelEdit}
-                  disabled={isAnyLoading}
-                >
-                  <X className="h-4 w-4" />
-                </Button>
-              </div>
-              {hasSpotify && (
-                <div className="mt-3 pt-3 border-t border-muted-foreground/25">
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={handleClearSpotify}
-                    disabled={isAnyLoading}
-                    className="text-destructive hover:text-destructive"
-                  >
-                    {clearSpotify.isPending ? (
-                      <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                    ) : (
-                      <X className="h-4 w-4 mr-2" />
-                    )}
-                    Clear Spotify URL
-                  </Button>
-                </div>
-              )}
-            </div>
-          )}
-        </div>
-      )}
-
-      {/* Shows List */}
-      <ArtistShowsList artistId={artist.id} />
+        {/* Labels Tab */}
+        <TabsContent value="labels">
+          <LabelsTab artistIdOrSlug={artistId} />
+        </TabsContent>
+      </EntityDetailLayout>
 
       {/* Admin Edit Dialog */}
       {isAdmin && (
@@ -601,6 +956,6 @@ export function ArtistDetail({ artistId }: ArtistDetailProps) {
           }}
         />
       )}
-    </div>
+    </>
   )
 }

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -115,6 +115,7 @@ export const API_ENDPOINTS = {
     SEARCH: `${API_BASE_URL}/artists/search`,
     GET: (artistIdOrSlug: string | number) => `${API_BASE_URL}/artists/${artistIdOrSlug}`,
     SHOWS: (artistIdOrSlug: string | number) => `${API_BASE_URL}/artists/${artistIdOrSlug}/shows`,
+    LABELS: (artistIdOrSlug: string | number) => `${API_BASE_URL}/artists/${artistIdOrSlug}/labels`,
     DELETE: (artistId: string | number) => `${API_BASE_URL}/artists/${artistId}`,
     REPORT: (artistId: string | number) =>
       `${API_BASE_URL}/artists/${artistId}/report`,

--- a/frontend/lib/hooks/useLabels.ts
+++ b/frontend/lib/hooks/useLabels.ts
@@ -14,6 +14,7 @@ import type {
   LabelDetail,
   LabelArtistsResponse,
   LabelReleasesResponse,
+  ArtistLabelsResponse,
 } from '../types/label'
 
 interface UseLabelsOptions {
@@ -76,6 +77,34 @@ export function useLabel(options: UseLabelOptions) {
     enabled:
       enabled &&
       (typeof idOrSlug === 'string' ? Boolean(idOrSlug) : idOrSlug > 0),
+    staleTime: 5 * 60 * 1000,
+  })
+}
+
+interface UseArtistLabelsOptions {
+  artistIdOrSlug: string | number
+  enabled?: boolean
+}
+
+/**
+ * Hook to fetch labels for a specific artist
+ */
+export function useArtistLabels(options: UseArtistLabelsOptions) {
+  const { artistIdOrSlug, enabled = true } = options
+
+  return useQuery({
+    queryKey: queryKeys.artists.labels(artistIdOrSlug),
+    queryFn: async (): Promise<ArtistLabelsResponse> => {
+      return apiRequest<ArtistLabelsResponse>(
+        API_ENDPOINTS.ARTISTS.LABELS(artistIdOrSlug),
+        { method: 'GET' }
+      )
+    },
+    enabled:
+      enabled &&
+      (typeof artistIdOrSlug === 'string'
+        ? Boolean(artistIdOrSlug)
+        : artistIdOrSlug > 0),
     staleTime: 5 * 60 * 1000,
   })
 }

--- a/frontend/lib/queryClient.ts
+++ b/frontend/lib/queryClient.ts
@@ -164,6 +164,7 @@ export const queryKeys = {
       ['artists', 'search', query.toLowerCase()] as const,
     detail: (idOrSlug: string | number) => ['artists', 'detail', String(idOrSlug)] as const,
     shows: (artistIdOrSlug: string | number) => ['artists', 'shows', String(artistIdOrSlug)] as const,
+    labels: (artistIdOrSlug: string | number) => ['artists', 'labels', String(artistIdOrSlug)] as const,
   },
 
   // Release queries

--- a/frontend/lib/types/label.ts
+++ b/frontend/lib/types/label.ts
@@ -77,6 +77,20 @@ export interface LabelsListResponse {
   count: number
 }
 
+/** Simplified label info for artist labels endpoint */
+export interface ArtistLabel {
+  id: number
+  name: string
+  slug: string
+  city: string | null
+  state: string | null
+}
+
+export interface ArtistLabelsResponse {
+  labels: ArtistLabel[]
+  count: number
+}
+
 export interface LabelArtist {
   id: number
   slug: string

--- a/frontend/lib/types/release.ts
+++ b/frontend/lib/types/release.ts
@@ -79,10 +79,14 @@ export interface ReleasesListResponse {
   count: number
 }
 
+/** Release with the artist's role, returned from GET /artists/:id/releases */
+export interface ArtistReleaseListItem extends ReleaseListItem {
+  role: string
+}
+
 export interface ArtistReleasesResponse {
-  releases: ReleaseListItem[]
-  artist_id: number
-  total: number
+  releases: ArtistReleaseListItem[]
+  count: number
 }
 
 /**


### PR DESCRIPTION
## Summary
The knowledge graph is now navigable. Artist pages show releases, labels, and "also on this label" discovery links.

### Backend
- New `GET /artists/{artist_id}/labels` endpoint — returns labels an artist is associated with
- Enhanced `GET /artists/{artist_id}/releases` — now includes artist role per release (main/featured/producer/etc.)
- Interface and mock updates for both new methods

### Frontend
- **ArtistDetail** refactored to use `EntityDetailLayout` with three tabs:
  - **Overview**: upcoming shows, admin controls (preserved)
  - **Discography**: releases grouped by role — Albums & EPs, Singles, Appears On, Production
  - **Labels**: linked label cards
- **Sidebar**: location, social links, label affiliations, bandcamp embed, and **"Also on this label"** — shows 5 other artists per label as discovery cues
- All entity names are clickable navigation links (artist → release → label → other artists)

Closes PSY-13

## Test plan
- [x] `go build ./...` passes
- [x] `go test -short ./...` passes
- [x] `bun run build` passes
- [x] All 897 frontend tests pass (`bun run test:run`)
- [ ] Visual check: artist detail with discography tab
- [ ] Visual check: "Also on this label" shows linked artists
- [ ] Test: navigate artist → release → label → label mate (full graph loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)