### PR TITLE
fix: swap show card date badge colors

### DIFF
--- a/frontend/components/shows/ShowCard.tsx
+++ b/frontend/components/shows/ShowCard.tsx
@@ -185,10 +185,10 @@ export function ShowCard({ show, isAdmin, userId, isSaved, density = 'comfortabl
             density === 'expanded' && 'w-16 sm:w-18 py-2.5'
           )}
         >
-          <span className="text-[10px] sm:text-xs font-bold tracking-widest uppercase text-primary leading-none">
+          <span className="text-[10px] sm:text-xs font-bold tracking-widest uppercase text-muted-foreground leading-none">
             {dateBadge.dayOfWeek}
           </span>
-          <span className="text-xs sm:text-sm font-semibold text-muted-foreground leading-tight mt-0.5">
+          <span className="text-xs sm:text-sm font-semibold text-primary leading-tight mt-0.5">
             {dateBadge.monthDay}
           </span>
         </Link>


### PR DESCRIPTION
## Summary
- Make the date (e.g. "MAR 16") orange (`text-primary`) instead of the day-of-week
- Make the day-of-week (e.g. "MON") grey (`text-muted-foreground`) instead of orange
- The date is the more important piece of information and deserves the visual emphasis

## Test plan
- [ ] Verify show cards on `/shows` display date in orange and day-of-week in grey
- [ ] Check all three density modes (compact, comfortable, expanded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)