### PR TITLE
feat: add festival model and migration (PSY-24)

### DIFF
--- a/backend/db/migrations/000039_create_festivals.down.sql
+++ b/backend/db/migrations/000039_create_festivals.down.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS festival_venues;
+DROP TABLE IF EXISTS festival_artists;
+DROP TABLE IF EXISTS festivals;

--- a/backend/db/migrations/000039_create_festivals.up.sql
+++ b/backend/db/migrations/000039_create_festivals.up.sql
@@ -1,0 +1,58 @@
+-- festivals table
+CREATE TABLE festivals (
+    id BIGSERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    slug VARCHAR(255) NOT NULL UNIQUE,
+    series_slug VARCHAR(255) NOT NULL,
+    edition_year INT NOT NULL,
+    description TEXT,
+    location_name VARCHAR(255),
+    city VARCHAR(100),
+    state VARCHAR(100),
+    country VARCHAR(100) DEFAULT 'US',
+    start_date DATE NOT NULL,
+    end_date DATE NOT NULL,
+    website VARCHAR(500),
+    ticket_url VARCHAR(500),
+    flyer_url VARCHAR(500),
+    status VARCHAR(50) NOT NULL DEFAULT 'announced',
+    social JSONB DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(series_slug, edition_year)
+);
+
+-- festival_artists junction (artist performing at a festival)
+CREATE TABLE festival_artists (
+    id BIGSERIAL PRIMARY KEY,
+    festival_id BIGINT NOT NULL REFERENCES festivals(id) ON DELETE CASCADE,
+    artist_id BIGINT NOT NULL REFERENCES artists(id) ON DELETE CASCADE,
+    billing_tier VARCHAR(50) NOT NULL DEFAULT 'mid_card',
+    position INT NOT NULL DEFAULT 0,
+    day_date DATE,
+    stage VARCHAR(255),
+    set_time TIME,
+    venue_id BIGINT REFERENCES venues(id),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(festival_id, artist_id)
+);
+
+-- festival_venues junction (for multi-venue takeover festivals)
+CREATE TABLE festival_venues (
+    id BIGSERIAL PRIMARY KEY,
+    festival_id BIGINT NOT NULL REFERENCES festivals(id) ON DELETE CASCADE,
+    venue_id BIGINT NOT NULL REFERENCES venues(id) ON DELETE CASCADE,
+    is_primary BOOLEAN NOT NULL DEFAULT false,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(festival_id, venue_id)
+);
+
+-- Indexes
+CREATE INDEX idx_festivals_slug ON festivals(slug);
+CREATE INDEX idx_festivals_series_slug ON festivals(series_slug);
+CREATE INDEX idx_festivals_city_state ON festivals(city, state);
+CREATE INDEX idx_festivals_start_date ON festivals(start_date);
+CREATE INDEX idx_festivals_status ON festivals(status);
+CREATE INDEX idx_festival_artists_artist_id ON festival_artists(artist_id);
+CREATE INDEX idx_festival_artists_festival_billing ON festival_artists(festival_id, billing_tier);
+CREATE INDEX idx_festival_venues_venue_id ON festival_venues(venue_id);

--- a/backend/internal/models/festival.go
+++ b/backend/internal/models/festival.go
@@ -1,0 +1,103 @@
+package models
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// FestivalStatus represents the current status of a festival
+type FestivalStatus string
+
+const (
+	FestivalStatusAnnounced FestivalStatus = "announced"
+	FestivalStatusConfirmed FestivalStatus = "confirmed"
+	FestivalStatusCancelled FestivalStatus = "cancelled"
+	FestivalStatusCompleted FestivalStatus = "completed"
+)
+
+// BillingTier represents the billing level of an artist at a festival
+type BillingTier string
+
+const (
+	BillingTierHeadliner    BillingTier = "headliner"
+	BillingTierSubHeadliner BillingTier = "sub_headliner"
+	BillingTierMidCard      BillingTier = "mid_card"
+	BillingTierUndercard    BillingTier = "undercard"
+	BillingTierLocal        BillingTier = "local"
+	BillingTierDJ           BillingTier = "dj"
+	BillingTierHost         BillingTier = "host"
+)
+
+// Festival represents a music festival (distinct from a show — multi-day, tiered billing, multi-venue)
+type Festival struct {
+	ID           uint            `gorm:"primaryKey"`
+	Name         string          `gorm:"not null"`
+	Slug         string          `gorm:"not null;uniqueIndex"`
+	SeriesSlug   string          `gorm:"column:series_slug;not null"`
+	EditionYear  int             `gorm:"column:edition_year;not null"`
+	Description  *string         `gorm:"column:description"`
+	LocationName *string         `gorm:"column:location_name"`
+	City         *string         `gorm:"column:city"`
+	State        *string         `gorm:"column:state"`
+	Country      *string         `gorm:"column:country"`
+	StartDate    string          `gorm:"column:start_date;type:date;not null"`
+	EndDate      string          `gorm:"column:end_date;type:date;not null"`
+	Website      *string         `gorm:"column:website"`
+	TicketURL    *string         `gorm:"column:ticket_url"`
+	FlyerURL     *string         `gorm:"column:flyer_url"`
+	Status       FestivalStatus  `gorm:"column:status;not null;default:'announced'"`
+	Social       *json.RawMessage `gorm:"column:social;type:jsonb;default:'{}'"`
+	CreatedAt    time.Time       `gorm:"not null"`
+	UpdatedAt    time.Time       `gorm:"not null"`
+
+	// Relationships
+	Artists []FestivalArtist `gorm:"foreignKey:FestivalID"`
+	Venues  []FestivalVenue  `gorm:"foreignKey:FestivalID"`
+}
+
+// TableName specifies the table name for Festival
+func (Festival) TableName() string {
+	return "festivals"
+}
+
+// FestivalArtist represents the junction table between festivals and artists
+type FestivalArtist struct {
+	ID          uint        `gorm:"primaryKey"`
+	FestivalID  uint        `gorm:"column:festival_id;not null"`
+	ArtistID    uint        `gorm:"column:artist_id;not null"`
+	BillingTier BillingTier `gorm:"column:billing_tier;not null;default:'mid_card'"`
+	Position    int         `gorm:"not null;default:0"`
+	DayDate     *string     `gorm:"column:day_date;type:date"`
+	Stage       *string     `gorm:"column:stage"`
+	SetTime     *string     `gorm:"column:set_time;type:time"`
+	VenueID     *uint       `gorm:"column:venue_id"`
+	CreatedAt   time.Time   `gorm:"not null"`
+
+	// Relationships
+	Festival Festival `gorm:"foreignKey:FestivalID"`
+	Artist   Artist   `gorm:"foreignKey:ArtistID"`
+	Venue    *Venue   `gorm:"foreignKey:VenueID"`
+}
+
+// TableName specifies the table name for FestivalArtist
+func (FestivalArtist) TableName() string {
+	return "festival_artists"
+}
+
+// FestivalVenue represents the junction table between festivals and venues
+type FestivalVenue struct {
+	ID         uint      `gorm:"primaryKey"`
+	FestivalID uint      `gorm:"column:festival_id;not null"`
+	VenueID    uint      `gorm:"column:venue_id;not null"`
+	IsPrimary  bool      `gorm:"column:is_primary;not null;default:false"`
+	CreatedAt  time.Time `gorm:"not null"`
+
+	// Relationships
+	Festival Festival `gorm:"foreignKey:FestivalID"`
+	Venue    Venue    `gorm:"foreignKey:VenueID"`
+}
+
+// TableName specifies the table name for FestivalVenue
+func (FestivalVenue) TableName() string {
+	return "festival_venues"
+}


### PR DESCRIPTION
## Summary
- Migration 000039 creates `festivals`, `festival_artists`, and `festival_venues` tables
- `festivals`: series_slug + edition_year unique constraint, JSONB social, status enum, date range
- `festival_artists`: billing tier (headliner through host), position, day/stage/set_time, optional venue
- `festival_venues`: multi-venue support with is_primary flag
- 8 indexes for common query patterns
- GORM models with typed constants for status and billing tier, `*json.RawMessage` for JSONB

## Test plan
- [ ] Migration applies cleanly
- [ ] Down migration drops tables in correct order
- [ ] All backend tests pass
- [ ] Backend builds cleanly

Closes PSY-24

🤖 Generated with [Claude Code](https://claude.com/claude-code)