### PR TITLE
test: add unit tests for shared components

### DIFF
--- a/frontend/components/shared/DensityToggle.test.tsx
+++ b/frontend/components/shared/DensityToggle.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { DensityToggle } from './DensityToggle'
+
+const mockSetDensity = vi.fn()
+const mockUseDensity = vi.fn(() => ({
+  density: 'comfortable' as const,
+  setDensity: mockSetDensity,
+}))
+
+vi.mock('@/lib/hooks/useDensity', () => ({
+  useDensity: (...args: unknown[]) => mockUseDensity(...args),
+}))
+
+describe('DensityToggle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseDensity.mockReturnValue({
+      density: 'comfortable',
+      setDensity: mockSetDensity,
+    })
+  })
+
+  it('renders all three density options', () => {
+    render(<DensityToggle />)
+    expect(screen.getByText('Compact')).toBeInTheDocument()
+    expect(screen.getByText('Comfortable')).toBeInTheDocument()
+    expect(screen.getByText('Expanded')).toBeInTheDocument()
+  })
+
+  it('has radiogroup role with aria-label', () => {
+    render(<DensityToggle />)
+    const group = screen.getByRole('radiogroup')
+    expect(group).toHaveAttribute('aria-label', 'Display density')
+  })
+
+  it('renders three radio buttons', () => {
+    render(<DensityToggle />)
+    const radios = screen.getAllByRole('radio')
+    expect(radios).toHaveLength(3)
+  })
+
+  it('marks the current density as checked', () => {
+    render(<DensityToggle />)
+    const comfortable = screen.getByRole('radio', { name: 'Comfortable' })
+    const compact = screen.getByRole('radio', { name: 'Compact' })
+    const expanded = screen.getByRole('radio', { name: 'Expanded' })
+
+    expect(comfortable).toHaveAttribute('aria-checked', 'true')
+    expect(compact).toHaveAttribute('aria-checked', 'false')
+    expect(expanded).toHaveAttribute('aria-checked', 'false')
+  })
+
+  it('marks compact as checked when density is compact', () => {
+    mockUseDensity.mockReturnValue({
+      density: 'compact',
+      setDensity: mockSetDensity,
+    })
+    render(<DensityToggle />)
+    expect(screen.getByRole('radio', { name: 'Compact' })).toHaveAttribute('aria-checked', 'true')
+    expect(screen.getByRole('radio', { name: 'Comfortable' })).toHaveAttribute('aria-checked', 'false')
+  })
+
+  it('calls setDensity with compact when Compact is clicked', async () => {
+    const user = userEvent.setup()
+    render(<DensityToggle />)
+
+    await user.click(screen.getByText('Compact'))
+    expect(mockSetDensity).toHaveBeenCalledWith('compact')
+  })
+
+  it('calls setDensity with expanded when Expanded is clicked', async () => {
+    const user = userEvent.setup()
+    render(<DensityToggle />)
+
+    await user.click(screen.getByText('Expanded'))
+    expect(mockSetDensity).toHaveBeenCalledWith('expanded')
+  })
+
+  it('passes storageKey to useDensity', () => {
+    render(<DensityToggle storageKey="shows" />)
+    expect(mockUseDensity).toHaveBeenCalledWith('shows')
+  })
+
+  it('passes undefined storageKey to useDensity when not provided', () => {
+    render(<DensityToggle />)
+    expect(mockUseDensity).toHaveBeenCalledWith(undefined)
+  })
+
+  it('applies custom className', () => {
+    render(<DensityToggle className="mt-4" />)
+    const group = screen.getByRole('radiogroup')
+    expect(group.className).toContain('mt-4')
+  })
+
+  it('all buttons have type="button"', () => {
+    render(<DensityToggle />)
+    const radios = screen.getAllByRole('radio')
+    for (const radio of radios) {
+      expect(radio).toHaveAttribute('type', 'button')
+    }
+  })
+})

--- a/frontend/components/shared/EntityDetailLayout.test.tsx
+++ b/frontend/components/shared/EntityDetailLayout.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { EntityDetailLayout } from './EntityDetailLayout'
+
+// Mock next/link to render a regular anchor
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode; [key: string]: unknown }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}))
+
+const defaultProps = {
+  backLink: { href: '/releases', label: 'Back to Releases' },
+  header: <div data-testid="test-header">Album Name</div>,
+  tabs: [
+    { value: 'overview', label: 'Overview' },
+    { value: 'links', label: 'Listen/Buy' },
+  ],
+  activeTab: 'overview',
+  onTabChange: vi.fn(),
+  children: <div data-testid="tab-content">Tab content here</div>,
+}
+
+describe('EntityDetailLayout', () => {
+  it('renders back link with correct href and label', () => {
+    render(<EntityDetailLayout {...defaultProps} />)
+    const link = screen.getByRole('link', { name: /Back to Releases/ })
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', '/releases')
+  })
+
+  it('renders header content', () => {
+    render(<EntityDetailLayout {...defaultProps} />)
+    expect(screen.getByTestId('test-header')).toBeInTheDocument()
+    expect(screen.getByText('Album Name')).toBeInTheDocument()
+  })
+
+  it('renders tab triggers for each tab', () => {
+    render(<EntityDetailLayout {...defaultProps} />)
+    expect(screen.getByRole('tab', { name: 'Overview' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Listen/Buy' })).toBeInTheDocument()
+  })
+
+  it('renders children (tab content)', () => {
+    render(<EntityDetailLayout {...defaultProps} />)
+    expect(screen.getByTestId('tab-content')).toBeInTheDocument()
+  })
+
+  it('calls onTabChange when a tab is clicked', async () => {
+    const user = userEvent.setup()
+    const onTabChange = vi.fn()
+    render(<EntityDetailLayout {...defaultProps} onTabChange={onTabChange} />)
+
+    await user.click(screen.getByRole('tab', { name: 'Listen/Buy' }))
+    expect(onTabChange).toHaveBeenCalledWith('links')
+  })
+
+  it('renders sidebar when provided', () => {
+    render(
+      <EntityDetailLayout
+        {...defaultProps}
+        sidebar={<div data-testid="sidebar-content">Sidebar info</div>}
+      />
+    )
+    expect(screen.getByTestId('sidebar-content')).toBeInTheDocument()
+    expect(screen.getByRole('complementary')).toBeInTheDocument()
+  })
+
+  it('does not render aside element when sidebar is not provided', () => {
+    render(<EntityDetailLayout {...defaultProps} />)
+    expect(screen.queryByRole('complementary')).not.toBeInTheDocument()
+  })
+
+  it('renders header inside a header element', () => {
+    render(<EntityDetailLayout {...defaultProps} />)
+    const headerEl = screen.getByTestId('test-header').closest('header')
+    expect(headerEl).toBeInTheDocument()
+  })
+
+  it('renders tablist', () => {
+    render(<EntityDetailLayout {...defaultProps} />)
+    expect(screen.getByRole('tablist')).toBeInTheDocument()
+  })
+
+  it('applies custom className', () => {
+    const { container } = render(
+      <EntityDetailLayout {...defaultProps} className="bg-gray-100" />
+    )
+    expect(container.firstChild).toHaveClass('bg-gray-100')
+  })
+
+  it('renders with a single tab', () => {
+    render(
+      <EntityDetailLayout
+        {...defaultProps}
+        tabs={[{ value: 'overview', label: 'Overview' }]}
+      />
+    )
+    const tabs = screen.getAllByRole('tab')
+    expect(tabs).toHaveLength(1)
+  })
+
+  it('renders with many tabs', () => {
+    render(
+      <EntityDetailLayout
+        {...defaultProps}
+        tabs={[
+          { value: 'overview', label: 'Overview' },
+          { value: 'tracks', label: 'Tracks' },
+          { value: 'links', label: 'Listen/Buy' },
+          { value: 'credits', label: 'Credits' },
+        ]}
+        activeTab="overview"
+      />
+    )
+    const tabs = screen.getAllByRole('tab')
+    expect(tabs).toHaveLength(4)
+  })
+})

--- a/frontend/components/shared/EntityHeader.test.tsx
+++ b/frontend/components/shared/EntityHeader.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { EntityHeader } from './EntityHeader'
+
+describe('EntityHeader', () => {
+  it('renders title as an h1 heading', () => {
+    render(<EntityHeader title="Test Album" />)
+    const heading = screen.getByRole('heading', { level: 1 })
+    expect(heading).toHaveTextContent('Test Album')
+  })
+
+  it('renders subtitle when provided', () => {
+    render(<EntityHeader title="Test Album" subtitle="2024" />)
+    expect(screen.getByText('2024')).toBeInTheDocument()
+  })
+
+  it('does not render subtitle container when subtitle is not provided', () => {
+    const { container } = render(<EntityHeader title="Test Album" />)
+    // The subtitle wrapper div should not exist
+    const subtitleDiv = container.querySelector('.text-muted-foreground')
+    expect(subtitleDiv).not.toBeInTheDocument()
+  })
+
+  it('renders actions when provided', () => {
+    render(
+      <EntityHeader
+        title="Test Album"
+        actions={<button data-testid="save-btn">Save</button>}
+      />
+    )
+    expect(screen.getByTestId('save-btn')).toBeInTheDocument()
+  })
+
+  it('does not render actions container when actions not provided', () => {
+    const { container } = render(<EntityHeader title="Test Album" />)
+    const actionsDiv = container.querySelector('.shrink-0')
+    expect(actionsDiv).not.toBeInTheDocument()
+  })
+
+  it('renders subtitle as ReactNode (JSX)', () => {
+    render(
+      <EntityHeader
+        title="Test Album"
+        subtitle={<span data-testid="subtitle-span">LP - 2024</span>}
+      />
+    )
+    expect(screen.getByTestId('subtitle-span')).toBeInTheDocument()
+    expect(screen.getByTestId('subtitle-span')).toHaveTextContent('LP - 2024')
+  })
+
+  it('renders both subtitle and actions together', () => {
+    render(
+      <EntityHeader
+        title="Test Album"
+        subtitle="2024"
+        actions={<button>Follow</button>}
+      />
+    )
+    expect(screen.getByText('2024')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Follow' })).toBeInTheDocument()
+  })
+
+  it('applies custom className', () => {
+    const { container } = render(
+      <EntityHeader title="Test Album" className="mt-8" />
+    )
+    expect(container.firstChild).toHaveClass('mt-8')
+  })
+})

--- a/frontend/components/shared/LoadingSpinner.test.tsx
+++ b/frontend/components/shared/LoadingSpinner.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { LoadingSpinner } from './LoadingSpinner'
+
+describe('LoadingSpinner', () => {
+  it('renders a div element', () => {
+    const { container } = render(<LoadingSpinner />)
+    expect(container.firstChild).toBeInTheDocument()
+  })
+
+  it('defaults to medium size', () => {
+    const { container } = render(<LoadingSpinner />)
+    const spinner = container.firstChild as HTMLElement
+    expect(spinner.className).toContain('h-8')
+    expect(spinner.className).toContain('w-8')
+  })
+
+  it('renders small size', () => {
+    const { container } = render(<LoadingSpinner size="sm" />)
+    const spinner = container.firstChild as HTMLElement
+    expect(spinner.className).toContain('h-4')
+    expect(spinner.className).toContain('w-4')
+  })
+
+  it('renders large size', () => {
+    const { container } = render(<LoadingSpinner size="lg" />)
+    const spinner = container.firstChild as HTMLElement
+    expect(spinner.className).toContain('h-12')
+    expect(spinner.className).toContain('w-12')
+  })
+
+  it('has animate-spin class for animation', () => {
+    const { container } = render(<LoadingSpinner />)
+    const spinner = container.firstChild as HTMLElement
+    expect(spinner.className).toContain('animate-spin')
+  })
+
+  it('applies custom className', () => {
+    const { container } = render(<LoadingSpinner className="mt-4" />)
+    const spinner = container.firstChild as HTMLElement
+    expect(spinner.className).toContain('mt-4')
+  })
+
+  it('merges custom className with default classes', () => {
+    const { container } = render(<LoadingSpinner size="sm" className="text-red-500" />)
+    const spinner = container.firstChild as HTMLElement
+    expect(spinner.className).toContain('animate-spin')
+    expect(spinner.className).toContain('text-red-500')
+    expect(spinner.className).toContain('h-4')
+  })
+})

--- a/frontend/components/shared/MusicEmbed.test.tsx
+++ b/frontend/components/shared/MusicEmbed.test.tsx
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { MusicEmbed } from './MusicEmbed'
+
+// Mock Sentry
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+}))
+
+describe('MusicEmbed', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.restoreAllMocks()
+  })
+
+  it('renders loading state initially when bandcamp URL is provided', () => {
+    vi.spyOn(global, 'fetch').mockImplementation(
+      () => new Promise(() => {}) // never resolves
+    )
+    render(
+      <MusicEmbed
+        bandcampAlbumUrl="https://band.bandcamp.com/album/test"
+        artistName="Test Artist"
+      />
+    )
+    // Loading section should be visible
+    expect(document.querySelector('.animate-spin')).toBeInTheDocument()
+  })
+
+  it('renders "Music" heading when not compact and loading', () => {
+    vi.spyOn(global, 'fetch').mockImplementation(
+      () => new Promise(() => {})
+    )
+    render(
+      <MusicEmbed
+        bandcampAlbumUrl="https://band.bandcamp.com/album/test"
+        artistName="Test Artist"
+        compact={false}
+      />
+    )
+    expect(screen.getByText('Music')).toBeInTheDocument()
+  })
+
+  it('does not render "Music" heading when compact and loading', () => {
+    vi.spyOn(global, 'fetch').mockImplementation(
+      () => new Promise(() => {})
+    )
+    render(
+      <MusicEmbed
+        bandcampAlbumUrl="https://band.bandcamp.com/album/test"
+        artistName="Test Artist"
+        compact={true}
+      />
+    )
+    expect(screen.queryByText('Music')).not.toBeInTheDocument()
+  })
+
+  it('renders bandcamp iframe when album ID is fetched successfully', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ albumId: '12345' }),
+    } as Response)
+
+    render(
+      <MusicEmbed
+        bandcampAlbumUrl="https://band.bandcamp.com/album/test"
+        artistName="Test Artist"
+      />
+    )
+
+    await waitFor(() => {
+      const iframe = screen.getByTitle('Test Artist on Bandcamp')
+      expect(iframe).toBeInTheDocument()
+      expect(iframe).toHaveAttribute(
+        'src',
+        expect.stringContaining('album=12345')
+      )
+    })
+  })
+
+  it('renders spotify iframe when spotify URL is provided', async () => {
+    render(
+      <MusicEmbed
+        spotifyUrl="https://open.spotify.com/artist/abc123"
+        artistName="Test Artist"
+      />
+    )
+
+    await waitFor(() => {
+      const iframe = screen.getByTitle('Test Artist on Spotify')
+      expect(iframe).toBeInTheDocument()
+      expect(iframe).toHaveAttribute(
+        'src',
+        expect.stringContaining('embed/artist/abc123')
+      )
+    })
+  })
+
+  it('parses spotify URI format', async () => {
+    render(
+      <MusicEmbed
+        spotifyUrl="spotify:artist:xyz789"
+        artistName="Test Artist"
+      />
+    )
+
+    await waitFor(() => {
+      const iframe = screen.getByTitle('Test Artist on Spotify')
+      expect(iframe).toHaveAttribute(
+        'src',
+        expect.stringContaining('embed/artist/xyz789')
+      )
+    })
+  })
+
+  it('renders fallback link when bandcamp fetch fails', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: false,
+    } as Response)
+
+    render(
+      <MusicEmbed
+        bandcampAlbumUrl="https://band.bandcamp.com/album/test"
+        artistName="Test Artist"
+      />
+    )
+
+    await waitFor(() => {
+      const link = screen.getByText('Listen to Test Artist on Bandcamp')
+      expect(link).toBeInTheDocument()
+      expect(link).toHaveAttribute('href', 'https://band.bandcamp.com/album/test')
+      expect(link).toHaveAttribute('target', '_blank')
+    })
+  })
+
+  it('renders fallback link for bandcamp profile URL when no album URL', async () => {
+    render(
+      <MusicEmbed
+        bandcampProfileUrl="https://band.bandcamp.com"
+        artistName="Test Artist"
+      />
+    )
+
+    await waitFor(() => {
+      const link = screen.getByText('Listen to Test Artist on Bandcamp')
+      expect(link).toHaveAttribute('href', 'https://band.bandcamp.com')
+    })
+  })
+
+  it('returns null when no URLs are provided', async () => {
+    const { container } = render(
+      <MusicEmbed artistName="Test Artist" />
+    )
+
+    await waitFor(() => {
+      // After resolving, the section should not be present
+      expect(container.querySelector('section')).not.toBeInTheDocument()
+    })
+  })
+
+  it('prioritizes bandcamp over spotify', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ albumId: '99999' }),
+    } as Response)
+
+    render(
+      <MusicEmbed
+        bandcampAlbumUrl="https://band.bandcamp.com/album/test"
+        spotifyUrl="https://open.spotify.com/artist/abc123"
+        artistName="Test Artist"
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTitle('Test Artist on Bandcamp')).toBeInTheDocument()
+      expect(screen.queryByTitle('Test Artist on Spotify')).not.toBeInTheDocument()
+    })
+  })
+
+  it('falls back to spotify when bandcamp fetch throws an error', async () => {
+    vi.spyOn(global, 'fetch').mockRejectedValueOnce(new Error('Network error'))
+
+    render(
+      <MusicEmbed
+        bandcampAlbumUrl="https://band.bandcamp.com/album/test"
+        spotifyUrl="https://open.spotify.com/artist/abc123"
+        artistName="Test Artist"
+      />
+    )
+
+    // When bandcamp fetch throws, the catch block fires, then priority 2 (spotify) is checked
+    // Since spotify URL is valid, it wins over the bandcamp fallback link
+    await waitFor(() => {
+      expect(screen.getByTitle('Test Artist on Spotify')).toBeInTheDocument()
+    })
+  })
+
+  it('falls back to bandcamp link when fetch throws and no spotify URL', async () => {
+    vi.spyOn(global, 'fetch').mockRejectedValueOnce(new Error('Network error'))
+
+    render(
+      <MusicEmbed
+        bandcampAlbumUrl="https://band.bandcamp.com/album/test"
+        artistName="Test Artist"
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Listen to Test Artist on Bandcamp')).toBeInTheDocument()
+    })
+  })
+
+  it('uses compact height for spotify iframe', async () => {
+    render(
+      <MusicEmbed
+        spotifyUrl="https://open.spotify.com/artist/abc123"
+        artistName="Test Artist"
+        compact={true}
+      />
+    )
+
+    await waitFor(() => {
+      const iframe = screen.getByTitle('Test Artist on Spotify')
+      expect(iframe).toHaveStyle({ height: '152px' })
+    })
+  })
+
+  it('uses full height for spotify iframe when not compact', async () => {
+    render(
+      <MusicEmbed
+        spotifyUrl="https://open.spotify.com/artist/abc123"
+        artistName="Test Artist"
+        compact={false}
+      />
+    )
+
+    await waitFor(() => {
+      const iframe = screen.getByTitle('Test Artist on Spotify')
+      expect(iframe).toHaveStyle({ height: '352px' })
+    })
+  })
+})

--- a/frontend/components/shared/RelationshipBadge.test.tsx
+++ b/frontend/components/shared/RelationshipBadge.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { RelationshipBadge, type RelationshipType } from './RelationshipBadge'
+
+describe('RelationshipBadge', () => {
+  it('renders default label for label-mate type', () => {
+    render(<RelationshipBadge type="label-mate" />)
+    expect(screen.getByText('label mate')).toBeInTheDocument()
+  })
+
+  it('renders default label for similar type', () => {
+    render(<RelationshipBadge type="similar" />)
+    expect(screen.getByText('similar')).toBeInTheDocument()
+  })
+
+  it('renders default label for shared-bills type', () => {
+    render(<RelationshipBadge type="shared-bills" />)
+    expect(screen.getByText('shared bills')).toBeInTheDocument()
+  })
+
+  it('renders default label for side-project type', () => {
+    render(<RelationshipBadge type="side-project" />)
+    expect(screen.getByText('side project')).toBeInTheDocument()
+  })
+
+  it('renders default label for member-of type', () => {
+    render(<RelationshipBadge type="member-of" />)
+    expect(screen.getByText('member of')).toBeInTheDocument()
+  })
+
+  it('renders default label for formerly type', () => {
+    render(<RelationshipBadge type="formerly" />)
+    expect(screen.getByText('formerly')).toBeInTheDocument()
+  })
+
+  it('uses custom label when provided', () => {
+    render(<RelationshipBadge type="side-project" label="side project of" />)
+    expect(screen.getByText('side project of')).toBeInTheDocument()
+    expect(screen.queryByText('side project')).not.toBeInTheDocument()
+  })
+
+  it('formats shared-bills with singular count', () => {
+    render(<RelationshipBadge type="shared-bills" count={1} />)
+    expect(screen.getByText('shared 1 bill')).toBeInTheDocument()
+  })
+
+  it('formats shared-bills with plural count', () => {
+    render(<RelationshipBadge type="shared-bills" count={3} />)
+    expect(screen.getByText('shared 3 bills')).toBeInTheDocument()
+  })
+
+  it('formats shared-bills with zero count', () => {
+    render(<RelationshipBadge type="shared-bills" count={0} />)
+    expect(screen.getByText('shared 0 bills')).toBeInTheDocument()
+  })
+
+  it('ignores count for non-shared-bills types', () => {
+    render(<RelationshipBadge type="similar" count={5} />)
+    expect(screen.getByText('similar')).toBeInTheDocument()
+    expect(screen.queryByText(/5/)).not.toBeInTheDocument()
+  })
+
+  it('renders as a span element', () => {
+    render(<RelationshipBadge type="label-mate" />)
+    const badge = screen.getByText('label mate')
+    expect(badge.tagName).toBe('SPAN')
+  })
+
+  it('applies custom className', () => {
+    render(<RelationshipBadge type="similar" className="ml-2" />)
+    const badge = screen.getByText('similar')
+    expect(badge.className).toContain('ml-2')
+  })
+
+  it('count formatting takes precedence over custom label for shared-bills', () => {
+    // When type is shared-bills and count is provided, the formatted count label is used
+    // regardless of the custom label prop
+    render(<RelationshipBadge type="shared-bills" count={3} label="on the same bills" />)
+    expect(screen.getByText('shared 3 bills')).toBeInTheDocument()
+  })
+
+  it('custom label is used for shared-bills when no count is provided', () => {
+    render(<RelationshipBadge type="shared-bills" label="on the same bills" />)
+    expect(screen.getByText('on the same bills')).toBeInTheDocument()
+  })
+})

--- a/frontend/components/shared/SaveButton.test.tsx
+++ b/frontend/components/shared/SaveButton.test.tsx
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { SaveButton } from './SaveButton'
+
+const mockToggle = vi.fn()
+const mockUseSaveShowToggle = vi.fn(() => ({
+  isSaved: false,
+  isLoading: false,
+  toggle: mockToggle,
+  error: null,
+}))
+
+vi.mock('@/lib/hooks/useSavedShows', () => ({
+  useSaveShowToggle: (...args: unknown[]) => mockUseSaveShowToggle(...args),
+}))
+
+const mockUseAuthContext = vi.fn(() => ({
+  isAuthenticated: true,
+  user: { email: 'test@test.com' },
+  isLoading: false,
+  logout: vi.fn(),
+}))
+
+vi.mock('@/lib/context/AuthContext', () => ({
+  useAuthContext: () => mockUseAuthContext(),
+}))
+
+describe('SaveButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseAuthContext.mockReturnValue({
+      isAuthenticated: true,
+      user: { email: 'test@test.com' },
+      isLoading: false,
+      logout: vi.fn(),
+    })
+    mockUseSaveShowToggle.mockReturnValue({
+      isSaved: false,
+      isLoading: false,
+      toggle: mockToggle,
+      error: null,
+    })
+  })
+
+  it('renders nothing when not authenticated', () => {
+    mockUseAuthContext.mockReturnValue({
+      isAuthenticated: false,
+      user: null,
+      isLoading: false,
+      logout: vi.fn(),
+    })
+    const { container } = render(<SaveButton showId={1} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders save button when authenticated', () => {
+    render(<SaveButton showId={1} />)
+    expect(screen.getByRole('button')).toBeInTheDocument()
+  })
+
+  it('has "Add to My List" aria-label when not saved', () => {
+    render(<SaveButton showId={1} />)
+    expect(screen.getByLabelText('Add to My List')).toBeInTheDocument()
+  })
+
+  it('has "Remove from My List" aria-label when saved', () => {
+    mockUseSaveShowToggle.mockReturnValue({
+      isSaved: true,
+      isLoading: false,
+      toggle: mockToggle,
+      error: null,
+    })
+    render(<SaveButton showId={1} />)
+    expect(screen.getByLabelText('Remove from My List')).toBeInTheDocument()
+  })
+
+  it('has "Add to My List" title when not saved', () => {
+    render(<SaveButton showId={1} />)
+    expect(screen.getByTitle('Add to My List')).toBeInTheDocument()
+  })
+
+  it('has "Remove from My List" title when saved', () => {
+    mockUseSaveShowToggle.mockReturnValue({
+      isSaved: true,
+      isLoading: false,
+      toggle: mockToggle,
+      error: null,
+    })
+    render(<SaveButton showId={1} />)
+    expect(screen.getByTitle('Remove from My List')).toBeInTheDocument()
+  })
+
+  it('calls toggle on click', async () => {
+    const user = userEvent.setup()
+    render(<SaveButton showId={1} />)
+
+    await user.click(screen.getByRole('button'))
+    expect(mockToggle).toHaveBeenCalledOnce()
+  })
+
+  it('disables button when loading', () => {
+    mockUseSaveShowToggle.mockReturnValue({
+      isSaved: false,
+      isLoading: true,
+      toggle: mockToggle,
+      error: null,
+    })
+    render(<SaveButton showId={1} />)
+    expect(screen.getByRole('button')).toBeDisabled()
+  })
+
+  it('shows "Save" label when showLabel is true and not saved', () => {
+    render(<SaveButton showId={1} showLabel={true} />)
+    expect(screen.getByText('Save')).toBeInTheDocument()
+  })
+
+  it('shows "Saved" label when showLabel is true and saved', () => {
+    mockUseSaveShowToggle.mockReturnValue({
+      isSaved: true,
+      isLoading: false,
+      toggle: mockToggle,
+      error: null,
+    })
+    render(<SaveButton showId={1} showLabel={true} />)
+    expect(screen.getByText('Saved')).toBeInTheDocument()
+  })
+
+  it('does not show text label when showLabel is false', () => {
+    render(<SaveButton showId={1} showLabel={false} />)
+    expect(screen.queryByText('Save')).not.toBeInTheDocument()
+    expect(screen.queryByText('Saved')).not.toBeInTheDocument()
+  })
+
+  it('passes showId and isAuthenticated to useSaveShowToggle', () => {
+    render(<SaveButton showId={42} />)
+    expect(mockUseSaveShowToggle).toHaveBeenCalledWith(42, true, undefined)
+  })
+
+  it('passes batchIsSaved to useSaveShowToggle', () => {
+    render(<SaveButton showId={42} isSaved={true} />)
+    expect(mockUseSaveShowToggle).toHaveBeenCalledWith(42, true, true)
+  })
+
+  it('shows error tooltip when toggle fails', async () => {
+    const user = userEvent.setup()
+    mockToggle.mockRejectedValueOnce(new Error('Network error'))
+    mockUseSaveShowToggle.mockReturnValue({
+      isSaved: false,
+      isLoading: false,
+      toggle: mockToggle,
+      error: new Error('Network error'),
+    })
+    render(<SaveButton showId={1} />)
+
+    await user.click(screen.getByRole('button'))
+    expect(await screen.findByText('Failed to save show')).toBeInTheDocument()
+  })
+
+  it('stops event propagation on click', async () => {
+    const user = userEvent.setup()
+    const parentClick = vi.fn()
+    render(
+      <div onClick={parentClick}>
+        <SaveButton showId={1} />
+      </div>
+    )
+
+    await user.click(screen.getByRole('button'))
+    expect(parentClick).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/components/shared/SocialLinks.test.tsx
+++ b/frontend/components/shared/SocialLinks.test.tsx
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { SocialLinks } from './SocialLinks'
+
+describe('SocialLinks', () => {
+  it('returns null when social is null', () => {
+    const { container } = render(<SocialLinks social={null} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('returns null when social is undefined', () => {
+    const { container } = render(<SocialLinks />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('returns null when all social fields are null', () => {
+    const { container } = render(
+      <SocialLinks
+        social={{
+          website: null,
+          instagram: null,
+          facebook: null,
+          twitter: null,
+          youtube: null,
+          spotify: null,
+          bandcamp: null,
+          soundcloud: null,
+        }}
+      />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders a link for a full website URL', () => {
+    render(<SocialLinks social={{ website: 'https://example.com' }} />)
+    const link = screen.getByTitle('Website')
+    expect(link).toHaveAttribute('href', 'https://example.com')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  it('renders Instagram link from handle', () => {
+    render(<SocialLinks social={{ instagram: 'bandname' }} />)
+    const link = screen.getByTitle('Instagram')
+    expect(link).toHaveAttribute('href', 'https://instagram.com/bandname')
+  })
+
+  it('renders Instagram link from handle with @ prefix', () => {
+    render(<SocialLinks social={{ instagram: '@bandname' }} />)
+    const link = screen.getByTitle('Instagram')
+    expect(link).toHaveAttribute('href', 'https://instagram.com/bandname')
+  })
+
+  it('renders Instagram link from full URL', () => {
+    render(<SocialLinks social={{ instagram: 'https://instagram.com/bandname' }} />)
+    const link = screen.getByTitle('Instagram')
+    expect(link).toHaveAttribute('href', 'https://instagram.com/bandname')
+  })
+
+  it('renders Facebook link from handle', () => {
+    render(<SocialLinks social={{ facebook: 'bandpage' }} />)
+    const link = screen.getByTitle('Facebook')
+    expect(link).toHaveAttribute('href', 'https://facebook.com/bandpage')
+  })
+
+  it('renders Twitter link from handle', () => {
+    render(<SocialLinks social={{ twitter: 'bandname' }} />)
+    const link = screen.getByTitle('Twitter/X')
+    expect(link).toHaveAttribute('href', 'https://twitter.com/bandname')
+  })
+
+  it('renders YouTube link from handle', () => {
+    render(<SocialLinks social={{ youtube: 'channel123' }} />)
+    const link = screen.getByTitle('YouTube')
+    expect(link).toHaveAttribute('href', 'https://youtube.com/channel123')
+  })
+
+  it('renders Spotify link from handle', () => {
+    render(<SocialLinks social={{ spotify: 'artist/123' }} />)
+    const link = screen.getByTitle('Spotify')
+    expect(link).toHaveAttribute('href', 'https://open.spotify.com/artist/123')
+  })
+
+  it('renders Bandcamp link from full URL', () => {
+    render(<SocialLinks social={{ bandcamp: 'https://band.bandcamp.com' }} />)
+    const link = screen.getByTitle('Bandcamp')
+    expect(link).toHaveAttribute('href', 'https://band.bandcamp.com')
+  })
+
+  it('renders SoundCloud link from handle', () => {
+    render(<SocialLinks social={{ soundcloud: 'bandname' }} />)
+    const link = screen.getByTitle('SoundCloud')
+    expect(link).toHaveAttribute('href', 'https://soundcloud.com/bandname')
+  })
+
+  it('renders multiple social links when multiple are present', () => {
+    render(
+      <SocialLinks
+        social={{
+          instagram: 'band',
+          spotify: 'https://open.spotify.com/artist/abc',
+          website: 'https://band.com',
+        }}
+      />
+    )
+    expect(screen.getByTitle('Instagram')).toBeInTheDocument()
+    expect(screen.getByTitle('Spotify')).toBeInTheDocument()
+    expect(screen.getByTitle('Website')).toBeInTheDocument()
+  })
+
+  it('only renders links for non-null social fields', () => {
+    render(
+      <SocialLinks
+        social={{
+          instagram: 'band',
+          facebook: null,
+          twitter: null,
+        }}
+      />
+    )
+    expect(screen.getByTitle('Instagram')).toBeInTheDocument()
+    expect(screen.queryByTitle('Facebook')).not.toBeInTheDocument()
+    expect(screen.queryByTitle('Twitter/X')).not.toBeInTheDocument()
+  })
+
+  it('renders screen reader labels for each link', () => {
+    render(
+      <SocialLinks
+        social={{
+          instagram: 'band',
+          youtube: 'channel',
+        }}
+      />
+    )
+    expect(screen.getByText('Instagram')).toBeInTheDocument()
+    expect(screen.getByText('YouTube')).toBeInTheDocument()
+  })
+
+  it('applies custom className', () => {
+    const { container } = render(
+      <SocialLinks social={{ website: 'https://example.com' }} className="mt-4" />
+    )
+    expect(container.firstChild).toHaveClass('mt-4')
+  })
+
+  it('normalizes partial URL with domain but no protocol', () => {
+    render(<SocialLinks social={{ website: 'example.com/page' }} />)
+    const link = screen.getByTitle('Website')
+    expect(link).toHaveAttribute('href', 'https://example.com/page')
+  })
+})

--- a/frontend/components/shared/SubmissionSuccessDialog.test.tsx
+++ b/frontend/components/shared/SubmissionSuccessDialog.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { SubmissionSuccessDialog } from './SubmissionSuccessDialog'
+
+describe('SubmissionSuccessDialog', () => {
+  it('renders dialog content when open', () => {
+    render(<SubmissionSuccessDialog open={true} onOpenChange={vi.fn()} />)
+    expect(screen.getByText('Private Show Added')).toBeInTheDocument()
+  })
+
+  it('renders description text about private show', () => {
+    render(<SubmissionSuccessDialog open={true} onOpenChange={vi.fn()} />)
+    expect(
+      screen.getByText(/saved to your personal list/)
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/won't appear in public listings/)
+    ).toBeInTheDocument()
+  })
+
+  it('renders "Got it" button', () => {
+    render(<SubmissionSuccessDialog open={true} onOpenChange={vi.fn()} />)
+    expect(screen.getByRole('button', { name: /Got it/ })).toBeInTheDocument()
+  })
+
+  it('calls onOpenChange with false when "Got it" is clicked', async () => {
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+    render(<SubmissionSuccessDialog open={true} onOpenChange={onOpenChange} />)
+
+    await user.click(screen.getByRole('button', { name: /Got it/ }))
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('does not render content when closed', () => {
+    render(<SubmissionSuccessDialog open={false} onOpenChange={vi.fn()} />)
+    expect(screen.queryByText('Private Show Added')).not.toBeInTheDocument()
+  })
+
+  it('renders dialog with heading role', () => {
+    render(<SubmissionSuccessDialog open={true} onOpenChange={vi.fn()} />)
+    expect(screen.getByRole('heading', { name: 'Private Show Added' })).toBeInTheDocument()
+  })
+
+  it('renders a dialog element', () => {
+    render(<SubmissionSuccessDialog open={true} onOpenChange={vi.fn()} />)
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+})

--- a/frontend/components/shared/TagPill.test.tsx
+++ b/frontend/components/shared/TagPill.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { TagPill } from './TagPill'
+
+describe('TagPill', () => {
+  it('renders label text', () => {
+    render(<TagPill label="post-punk" />)
+    expect(screen.getByText('post-punk')).toBeInTheDocument()
+  })
+
+  it('renders as a button when no href is provided', () => {
+    render(<TagPill label="shoegaze" />)
+    expect(screen.getByRole('button')).toBeInTheDocument()
+  })
+
+  it('renders as a link when href is provided', () => {
+    render(<TagPill label="shoegaze" href="/shows?tag=shoegaze" />)
+    const link = screen.getByRole('link')
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', '/shows?tag=shoegaze')
+  })
+
+  it('displays positive vote count with + prefix', () => {
+    render(<TagPill label="post-punk" voteCount={12} />)
+    expect(screen.getByText('+12')).toBeInTheDocument()
+  })
+
+  it('displays zero vote count with + prefix', () => {
+    render(<TagPill label="post-punk" voteCount={0} />)
+    expect(screen.getByText('+0')).toBeInTheDocument()
+  })
+
+  it('displays negative vote count without + prefix', () => {
+    render(<TagPill label="post-punk" voteCount={-3} />)
+    expect(screen.getByText('-3')).toBeInTheDocument()
+  })
+
+  it('does not display vote count when undefined', () => {
+    render(<TagPill label="post-punk" />)
+    expect(screen.queryByText(/\+/)).not.toBeInTheDocument()
+  })
+
+  it('calls onClick handler when button is clicked', async () => {
+    const user = userEvent.setup()
+    const onClick = vi.fn()
+    render(<TagPill label="shoegaze" onClick={onClick} />)
+
+    await user.click(screen.getByRole('button'))
+    expect(onClick).toHaveBeenCalledOnce()
+  })
+
+  it('applies custom className', () => {
+    render(<TagPill label="jazz" className="mt-2" />)
+    const button = screen.getByRole('button')
+    expect(button.className).toContain('mt-2')
+  })
+
+  it('renders both label and vote count together in a link', () => {
+    render(<TagPill label="noise-rock" voteCount={7} href="/tag/noise-rock" />)
+    const link = screen.getByRole('link')
+    expect(link).toHaveTextContent('noise-rock')
+    expect(link).toHaveTextContent('+7')
+  })
+
+  it('button has type="button" attribute', () => {
+    render(<TagPill label="ambient" />)
+    expect(screen.getByRole('button')).toHaveAttribute('type', 'button')
+  })
+})


### PR DESCRIPTION
## Summary
- Adds 118 unit tests across 10 test files for `components/shared/` (previously 0% coverage, 119 tracked lines)
- Covers: LoadingSpinner, TagPill, RelationshipBadge, EntityHeader, DensityToggle, SocialLinks, EntityDetailLayout, SubmissionSuccessDialog, SaveButton, MusicEmbed
- No source changes — test files only

## Test plan
- [x] All 118 tests pass: `bun run test:run -- components/shared/`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)