### PR TITLE
test: add unit tests for settings components

### DIFF
--- a/frontend/components/settings/SettingsPanel.test.tsx
+++ b/frontend/components/settings/SettingsPanel.test.tsx
@@ -1,0 +1,425 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders } from '@/test/utils'
+import { SettingsPanel } from './SettingsPanel'
+
+// --- Mocks ---
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+}))
+
+let mockUser: {
+  email: string
+  email_verified: boolean
+  is_admin?: boolean
+} | null = null
+
+vi.mock('@/lib/context/AuthContext', () => ({
+  useAuthContext: () => ({
+    user: mockUser,
+  }),
+}))
+
+const mockSendVerificationMutateAsync = vi.fn()
+let mockSendVerificationState = {
+  isPending: false,
+  isError: false,
+  isSuccess: false,
+  error: null as Error | null,
+}
+
+const mockExportMutateAsync = vi.fn()
+let mockExportState = {
+  isPending: false,
+  isError: false,
+  isSuccess: false,
+  error: null as Error | null,
+}
+
+const mockGenerateCLITokenMutateAsync = vi.fn()
+let mockGenerateCLITokenState = {
+  isPending: false,
+  isError: false,
+  error: null as Error | null,
+}
+
+vi.mock('@/lib/hooks/useAuth', () => ({
+  useSendVerificationEmail: () => ({
+    mutateAsync: mockSendVerificationMutateAsync,
+    ...mockSendVerificationState,
+  }),
+  useExportData: () => ({
+    mutateAsync: mockExportMutateAsync,
+    ...mockExportState,
+  }),
+  useGenerateCLIToken: () => ({
+    mutateAsync: mockGenerateCLITokenMutateAsync,
+    ...mockGenerateCLITokenState,
+  }),
+  useProfile: () => ({ data: null }),
+}))
+
+// Mock sub-components to isolate SettingsPanel tests
+vi.mock('@/components/settings/change-password', () => ({
+  ChangePassword: () => <div data-testid="change-password">ChangePassword</div>,
+}))
+
+vi.mock('@/components/settings/delete-account-dialog', () => ({
+  DeleteAccountDialog: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="delete-dialog">DeleteAccountDialog</div> : null,
+}))
+
+vi.mock('@/components/settings/oauth-accounts', () => ({
+  OAuthAccounts: () => <div data-testid="oauth-accounts">OAuthAccounts</div>,
+}))
+
+vi.mock('@/components/settings/api-token-management', () => ({
+  APITokenManagement: () => (
+    <div data-testid="api-token-management">APITokenManagement</div>
+  ),
+}))
+
+vi.mock('@/components/settings/favorite-cities', () => ({
+  FavoriteCitiesSettings: () => (
+    <div data-testid="favorite-cities">FavoriteCitiesSettings</div>
+  ),
+}))
+
+vi.mock('@/components/settings/notification-settings', () => ({
+  NotificationSettings: () => (
+    <div data-testid="notification-settings">NotificationSettings</div>
+  ),
+}))
+
+// --- Tests ---
+
+describe('SettingsPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUser = {
+      email: 'user@example.com',
+      email_verified: false,
+    }
+    mockSendVerificationState = {
+      isPending: false,
+      isError: false,
+      isSuccess: false,
+      error: null,
+    }
+    mockExportState = {
+      isPending: false,
+      isError: false,
+      isSuccess: false,
+      error: null,
+    }
+    mockGenerateCLITokenState = {
+      isPending: false,
+      isError: false,
+      error: null,
+    }
+    mockSendVerificationMutateAsync.mockReset()
+    mockExportMutateAsync.mockReset()
+    mockGenerateCLITokenMutateAsync.mockReset()
+  })
+
+  // --- Sub-component rendering ---
+
+  it('renders FavoriteCitiesSettings component', () => {
+    renderWithProviders(<SettingsPanel />)
+    expect(screen.getByTestId('favorite-cities')).toBeInTheDocument()
+  })
+
+  it('renders NotificationSettings component', () => {
+    renderWithProviders(<SettingsPanel />)
+    expect(screen.getByTestId('notification-settings')).toBeInTheDocument()
+  })
+
+  it('renders OAuthAccounts component', () => {
+    renderWithProviders(<SettingsPanel />)
+    expect(screen.getByTestId('oauth-accounts')).toBeInTheDocument()
+  })
+
+  it('renders ChangePassword component', () => {
+    renderWithProviders(<SettingsPanel />)
+    expect(screen.getByTestId('change-password')).toBeInTheDocument()
+  })
+
+  // --- Email Verification Section ---
+
+  it('renders email verification section', () => {
+    renderWithProviders(<SettingsPanel />)
+
+    expect(screen.getByText('Email Verification')).toBeInTheDocument()
+    expect(
+      screen.getByText('Verify your email to submit shows to the calendar')
+    ).toBeInTheDocument()
+  })
+
+  it('shows user email', () => {
+    renderWithProviders(<SettingsPanel />)
+
+    expect(screen.getByText('user@example.com')).toBeInTheDocument()
+  })
+
+  it('shows "Not Verified" badge when email is not verified', () => {
+    renderWithProviders(<SettingsPanel />)
+
+    expect(screen.getByText('Not Verified')).toBeInTheDocument()
+  })
+
+  it('shows "Verified" badge when email is verified', () => {
+    mockUser = { email: 'user@example.com', email_verified: true }
+    renderWithProviders(<SettingsPanel />)
+
+    expect(screen.getByText('Verified')).toBeInTheDocument()
+  })
+
+  it('shows "Verified" badge when user is admin (even without email_verified)', () => {
+    mockUser = {
+      email: 'admin@example.com',
+      email_verified: false,
+      is_admin: true,
+    }
+    renderWithProviders(<SettingsPanel />)
+
+    expect(screen.getByText('Verified')).toBeInTheDocument()
+  })
+
+  it('shows Send Verification Email button for unverified users', () => {
+    renderWithProviders(<SettingsPanel />)
+
+    expect(
+      screen.getByRole('button', { name: /Send Verification Email/ })
+    ).toBeInTheDocument()
+  })
+
+  it('does not show Send Verification Email button for verified users', () => {
+    mockUser = { email: 'user@example.com', email_verified: true }
+    renderWithProviders(<SettingsPanel />)
+
+    expect(
+      screen.queryByRole('button', { name: /Send Verification Email/ })
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows "Your email is verified" message for verified non-admin users', () => {
+    mockUser = { email: 'user@example.com', email_verified: true }
+    renderWithProviders(<SettingsPanel />)
+
+    expect(screen.getByText('Your email is verified')).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'You can submit shows to the Arizona music calendar.'
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('shows admin notice for admin users', () => {
+    mockUser = {
+      email: 'admin@example.com',
+      email_verified: false,
+      is_admin: true,
+    }
+    renderWithProviders(<SettingsPanel />)
+
+    // "Admin account" appears both in the email status subtitle and the admin notice
+    const adminTexts = screen.getAllByText('Admin account')
+    expect(adminTexts.length).toBeGreaterThanOrEqual(1)
+    expect(
+      screen.getByText(
+        /As an admin, you can submit shows without email verification/
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('shows verification error when send fails', () => {
+    mockSendVerificationState = {
+      isPending: false,
+      isError: true,
+      isSuccess: false,
+      error: new Error('Too many requests'),
+    }
+    renderWithProviders(<SettingsPanel />)
+
+    expect(screen.getByText('Too many requests')).toBeInTheDocument()
+  })
+
+  // --- Data Export Section ---
+
+  it('renders data export section', () => {
+    renderWithProviders(<SettingsPanel />)
+
+    expect(screen.getByText('Export Your Data')).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'Download a copy of all your data in JSON format'
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('shows export includes list', () => {
+    renderWithProviders(<SettingsPanel />)
+
+    expect(screen.getByText('Profile information')).toBeInTheDocument()
+    expect(screen.getByText('Email preferences')).toBeInTheDocument()
+    expect(screen.getByText('Connected accounts')).toBeInTheDocument()
+    expect(screen.getByText('Passkeys')).toBeInTheDocument()
+    expect(screen.getByText('Saved shows')).toBeInTheDocument()
+    expect(screen.getByText('Submitted shows')).toBeInTheDocument()
+  })
+
+  it('shows Export My Data button', () => {
+    renderWithProviders(<SettingsPanel />)
+
+    expect(
+      screen.getByRole('button', { name: /Export My Data/ })
+    ).toBeInTheDocument()
+  })
+
+  it('shows export error when export fails', () => {
+    mockExportState = {
+      isPending: false,
+      isError: true,
+      isSuccess: false,
+      error: new Error('Export failed'),
+    }
+    renderWithProviders(<SettingsPanel />)
+
+    expect(screen.getByText('Export failed')).toBeInTheDocument()
+  })
+
+  it('shows export success message', () => {
+    mockExportState = {
+      isPending: false,
+      isError: false,
+      isSuccess: true,
+      error: null,
+    }
+    renderWithProviders(<SettingsPanel />)
+
+    expect(
+      screen.getByText(
+        'Data exported successfully! Check your downloads folder.'
+      )
+    ).toBeInTheDocument()
+  })
+
+  // --- Admin-Only Sections ---
+
+  it('does not show API Token Management for non-admin users', () => {
+    renderWithProviders(<SettingsPanel />)
+
+    expect(
+      screen.queryByTestId('api-token-management')
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows API Token Management for admin users', () => {
+    mockUser = {
+      email: 'admin@example.com',
+      email_verified: true,
+      is_admin: true,
+    }
+    renderWithProviders(<SettingsPanel />)
+
+    expect(screen.getByTestId('api-token-management')).toBeInTheDocument()
+  })
+
+  it('does not show CLI Authentication for non-admin users', () => {
+    renderWithProviders(<SettingsPanel />)
+
+    expect(
+      screen.queryByText('CLI Authentication')
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows CLI Authentication section for admin users', () => {
+    mockUser = {
+      email: 'admin@example.com',
+      email_verified: true,
+      is_admin: true,
+    }
+    renderWithProviders(<SettingsPanel />)
+
+    expect(screen.getByText('CLI Authentication')).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'Generate a short-lived token for the admin CLI tool'
+      )
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /Generate CLI Token/ })
+    ).toBeInTheDocument()
+  })
+
+  // --- Danger Zone ---
+
+  it('renders danger zone section', () => {
+    renderWithProviders(<SettingsPanel />)
+
+    expect(screen.getByText('Danger Zone')).toBeInTheDocument()
+    expect(
+      screen.getByText('Irreversible actions that affect your account')
+    ).toBeInTheDocument()
+  })
+
+  it('shows Delete Account button', () => {
+    renderWithProviders(<SettingsPanel />)
+
+    expect(
+      screen.getByRole('button', { name: /Delete Account/ })
+    ).toBeInTheDocument()
+  })
+
+  it('opens delete account dialog when Delete Account is clicked', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<SettingsPanel />)
+
+    expect(screen.queryByTestId('delete-dialog')).not.toBeInTheDocument()
+
+    await user.click(
+      screen.getByRole('button', { name: /Delete Account/ })
+    )
+
+    expect(screen.getByTestId('delete-dialog')).toBeInTheDocument()
+  })
+
+  // --- CLI Token Section ---
+
+  it('generates CLI token when button is clicked', async () => {
+    mockUser = {
+      email: 'admin@example.com',
+      email_verified: true,
+      is_admin: true,
+    }
+    mockGenerateCLITokenMutateAsync.mockResolvedValue({
+      token: 'test-token-abc123',
+    })
+    const user = userEvent.setup()
+    renderWithProviders(<SettingsPanel />)
+
+    await user.click(
+      screen.getByRole('button', { name: /Generate CLI Token/ })
+    )
+
+    expect(mockGenerateCLITokenMutateAsync).toHaveBeenCalled()
+  })
+
+  it('shows CLI token error when generation fails', () => {
+    mockUser = {
+      email: 'admin@example.com',
+      email_verified: true,
+      is_admin: true,
+    }
+    mockGenerateCLITokenState = {
+      isPending: false,
+      isError: true,
+      error: new Error('Token generation failed'),
+    }
+    renderWithProviders(<SettingsPanel />)
+
+    expect(screen.getByText('Token generation failed')).toBeInTheDocument()
+  })
+})

--- a/frontend/components/settings/api-token-management.test.tsx
+++ b/frontend/components/settings/api-token-management.test.tsx
@@ -1,0 +1,264 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders } from '@/test/utils'
+import { APITokenManagement } from './api-token-management'
+
+// --- Mocks ---
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+}))
+
+let mockTokensData: {
+  tokens: {
+    id: number
+    description: string | null
+    scope: string
+    created_at: string
+    expires_at: string
+    last_used_at: string | null
+    is_expired: boolean
+  }[]
+} | undefined = undefined
+
+let mockTokensLoading = false
+let mockTokensError: Error | null = null
+
+const mockCreateMutateAsync = vi.fn()
+let mockCreateMutationState = {
+  isPending: false,
+  isError: false,
+  error: null as Error | null,
+}
+
+const mockRevokeMutateAsync = vi.fn()
+let mockRevokeMutationState = {
+  isPending: false,
+  isError: false,
+  error: null as Error | null,
+}
+
+vi.mock('@/lib/hooks/useAuth', () => ({
+  useAPITokens: () => ({
+    data: mockTokensData,
+    isLoading: mockTokensLoading,
+    error: mockTokensError,
+  }),
+  useCreateAPIToken: () => ({
+    mutateAsync: mockCreateMutateAsync,
+    ...mockCreateMutationState,
+  }),
+  useRevokeAPIToken: () => ({
+    mutateAsync: mockRevokeMutateAsync,
+    ...mockRevokeMutationState,
+  }),
+}))
+
+// --- Tests ---
+
+describe('APITokenManagement', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockTokensData = undefined
+    mockTokensLoading = false
+    mockTokensError = null
+    mockCreateMutateAsync.mockReset()
+    mockRevokeMutateAsync.mockReset()
+    mockCreateMutationState = { isPending: false, isError: false, error: null }
+    mockRevokeMutationState = { isPending: false, isError: false, error: null }
+  })
+
+  it('renders card title and description', () => {
+    renderWithProviders(<APITokenManagement />)
+
+    expect(screen.getByText('API Tokens')).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'Long-lived tokens for the local discovery app and other admin tools'
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('shows Create Token button', () => {
+    renderWithProviders(<APITokenManagement />)
+
+    expect(
+      screen.getByRole('button', { name: /Create Token/ })
+    ).toBeInTheDocument()
+  })
+
+  it('shows loading state', () => {
+    mockTokensLoading = true
+    renderWithProviders(<APITokenManagement />)
+
+    // The loading spinner should be present (no text to check, just no error or empty state)
+    expect(screen.queryByText('No API tokens yet')).not.toBeInTheDocument()
+    expect(
+      screen.queryByText('Failed to load tokens')
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows error state when tokens fail to load', () => {
+    mockTokensError = new Error('Server error')
+    renderWithProviders(<APITokenManagement />)
+
+    expect(
+      screen.getByText('Failed to load tokens. Please try again.')
+    ).toBeInTheDocument()
+  })
+
+  it('shows empty state when no tokens exist', () => {
+    mockTokensData = { tokens: [] }
+    renderWithProviders(<APITokenManagement />)
+
+    expect(screen.getByText('No API tokens yet')).toBeInTheDocument()
+    expect(
+      screen.getByText('Create a token to use with the local discovery app')
+    ).toBeInTheDocument()
+  })
+
+  it('renders token rows with descriptions', () => {
+    mockTokensData = {
+      tokens: [
+        {
+          id: 1,
+          description: 'Discovery App',
+          scope: 'admin',
+          created_at: '2025-06-01T10:00:00Z',
+          expires_at: '2025-09-01T10:00:00Z',
+          last_used_at: '2025-07-15T14:30:00Z',
+          is_expired: false,
+        },
+        {
+          id: 2,
+          description: null,
+          scope: 'admin',
+          created_at: '2025-05-01T10:00:00Z',
+          expires_at: '2025-08-01T10:00:00Z',
+          last_used_at: null,
+          is_expired: true,
+        },
+      ],
+    }
+    renderWithProviders(<APITokenManagement />)
+
+    expect(screen.getByText('Discovery App')).toBeInTheDocument()
+    expect(screen.getByText('Unnamed token')).toBeInTheDocument()
+    expect(screen.getByText('Expired')).toBeInTheDocument()
+  })
+
+  it('shows Active badge for non-expired tokens', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2025-06-15T00:00:00Z'))
+
+    mockTokensData = {
+      tokens: [
+        {
+          id: 1,
+          description: 'My Token',
+          scope: 'admin',
+          created_at: '2025-06-01T10:00:00Z',
+          expires_at: '2025-12-01T10:00:00Z',
+          last_used_at: null,
+          is_expired: false,
+        },
+      ],
+    }
+    renderWithProviders(<APITokenManagement />)
+
+    expect(screen.getByText('Active')).toBeInTheDocument()
+
+    vi.useRealTimers()
+  })
+
+  it('shows Token Usage info section', () => {
+    mockTokensData = { tokens: [] }
+    renderWithProviders(<APITokenManagement />)
+
+    expect(screen.getByText('Token Usage')).toBeInTheDocument()
+    expect(
+      screen.getByText(/Use these tokens with the local discovery app/)
+    ).toBeInTheDocument()
+  })
+
+  it('opens create token dialog when Create Token is clicked', async () => {
+    mockTokensData = { tokens: [] }
+    const user = userEvent.setup()
+    renderWithProviders(<APITokenManagement />)
+
+    await user.click(screen.getByRole('button', { name: /Create Token/ }))
+
+    expect(screen.getByText('Create API Token')).toBeInTheDocument()
+    expect(screen.getByLabelText('Description (optional)')).toBeInTheDocument()
+    expect(screen.getByLabelText('Expiration (days)')).toBeInTheDocument()
+  })
+
+  it('shows create mutation error', () => {
+    mockTokensData = { tokens: [] }
+    mockCreateMutationState = {
+      isPending: false,
+      isError: true,
+      error: new Error('Rate limit exceeded'),
+    }
+    renderWithProviders(<APITokenManagement />)
+
+    expect(screen.getByText('Rate limit exceeded')).toBeInTheDocument()
+  })
+
+  it('shows revoke mutation error', () => {
+    mockTokensData = { tokens: [] }
+    mockRevokeMutationState = {
+      isPending: false,
+      isError: true,
+      error: new Error('Token not found'),
+    }
+    renderWithProviders(<APITokenManagement />)
+
+    expect(screen.getByText('Token not found')).toBeInTheDocument()
+  })
+
+  it('opens revoke confirmation dialog when delete button is clicked on a token', async () => {
+    mockTokensData = {
+      tokens: [
+        {
+          id: 1,
+          description: 'Test Token',
+          scope: 'admin',
+          created_at: '2025-06-01T10:00:00Z',
+          expires_at: '2025-12-01T10:00:00Z',
+          last_used_at: null,
+          is_expired: false,
+        },
+      ],
+    }
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    vi.setSystemTime(new Date('2025-06-15T00:00:00Z'))
+
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    renderWithProviders(<APITokenManagement />)
+
+    // Find the delete/revoke button on the token row (the ghost icon button)
+    const revokeButtons = screen.getAllByRole('button')
+    // The delete button is the one that's not "Create Token"
+    const deleteBtn = revokeButtons.find(
+      btn =>
+        btn.textContent !== 'Create Token' &&
+        !btn.textContent?.includes('Create')
+    )
+    expect(deleteBtn).toBeDefined()
+
+    await user.click(deleteBtn!)
+
+    await waitFor(() => {
+      expect(screen.getByText('Revoke API Token')).toBeInTheDocument()
+    })
+    expect(
+      screen.getByText(
+        /Are you sure you want to revoke this token/
+      )
+    ).toBeInTheDocument()
+
+    vi.useRealTimers()
+  })
+})

--- a/frontend/components/settings/delete-account-dialog.test.tsx
+++ b/frontend/components/settings/delete-account-dialog.test.tsx
@@ -1,0 +1,340 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders } from '@/test/utils'
+import { DeleteAccountDialog } from './delete-account-dialog'
+
+// --- Mocks ---
+
+const mockRouterPush = vi.fn()
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockRouterPush }),
+}))
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+}))
+
+const mockRefetch = vi.fn()
+let mockDeletionSummaryState = {
+  data: null as {
+    shows_count: number
+    saved_shows_count: number
+    passkeys_count: number
+    has_password: boolean
+  } | null,
+  isLoading: false,
+  isError: false,
+  refetch: mockRefetch,
+}
+
+const mockDeleteMutateAsync = vi.fn()
+let mockDeleteMutationState = {
+  isPending: false,
+  isError: false,
+  error: null as Error | null,
+  reset: vi.fn(),
+}
+
+vi.mock('@/lib/hooks/useAuth', () => ({
+  useDeletionSummary: () => ({
+    ...mockDeletionSummaryState,
+  }),
+  useDeleteAccount: () => ({
+    mutateAsync: mockDeleteMutateAsync,
+    ...mockDeleteMutationState,
+  }),
+}))
+
+// --- Helpers ---
+
+function renderDialog(open = true) {
+  const onOpenChange = vi.fn()
+  const user = userEvent.setup()
+  renderWithProviders(
+    <DeleteAccountDialog open={open} onOpenChange={onOpenChange} />
+  )
+  return { user, onOpenChange }
+}
+
+// --- Tests ---
+
+describe('DeleteAccountDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDeletionSummaryState = {
+      data: {
+        shows_count: 5,
+        saved_shows_count: 12,
+        passkeys_count: 2,
+        has_password: true,
+      },
+      isLoading: false,
+      isError: false,
+      refetch: mockRefetch,
+    }
+    mockDeleteMutationState = {
+      isPending: false,
+      isError: false,
+      error: null,
+      reset: vi.fn(),
+    }
+    mockDeleteMutateAsync.mockReset()
+    mockRouterPush.mockReset()
+  })
+
+  it('does not render when open is false', () => {
+    renderDialog(false)
+    expect(screen.queryByText('Delete Account')).not.toBeInTheDocument()
+  })
+
+  it('renders warning step with title and description when open', () => {
+    renderDialog()
+
+    expect(screen.getByText('Delete Account')).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'This action will schedule your account for permanent deletion.'
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('shows data summary counts on warning step', () => {
+    renderDialog()
+
+    expect(screen.getByText('5')).toBeInTheDocument()
+    expect(screen.getByText(/shows you submitted/)).toBeInTheDocument()
+    expect(screen.getByText('12')).toBeInTheDocument()
+    expect(screen.getByText(/saved shows/)).toBeInTheDocument()
+    expect(screen.getByText('2')).toBeInTheDocument()
+    expect(screen.getByText(/passkeys/)).toBeInTheDocument()
+  })
+
+  it('shows 30-day grace period notice', () => {
+    renderDialog()
+
+    expect(screen.getByText('30-Day Grace Period')).toBeInTheDocument()
+    expect(
+      screen.getByText(/Your account will be deactivated immediately/)
+    ).toBeInTheDocument()
+  })
+
+  it('shows loading state when deletion summary is loading', () => {
+    mockDeletionSummaryState = {
+      ...mockDeletionSummaryState,
+      data: null,
+      isLoading: true,
+    }
+    renderDialog()
+
+    // Continue button should be disabled while loading
+    const continueButton = screen.getByRole('button', { name: /Continue/ })
+    expect(continueButton).toBeDisabled()
+  })
+
+  it('shows error state when deletion summary fails', () => {
+    mockDeletionSummaryState = {
+      ...mockDeletionSummaryState,
+      data: null,
+      isLoading: false,
+      isError: true,
+    }
+    renderDialog()
+
+    expect(
+      screen.getByText('Failed to load account data. Please try again.')
+    ).toBeInTheDocument()
+
+    const continueButton = screen.getByRole('button', { name: /Continue/ })
+    expect(continueButton).toBeDisabled()
+  })
+
+  it('navigates to confirm step when Continue is clicked', async () => {
+    const { user } = renderDialog()
+
+    await user.click(screen.getByRole('button', { name: /Continue/ }))
+
+    expect(screen.getByText('Confirm Account Deletion')).toBeInTheDocument()
+  })
+
+  it('shows password field on confirm step when user has password', async () => {
+    const { user } = renderDialog()
+
+    await user.click(screen.getByRole('button', { name: /Continue/ }))
+
+    expect(screen.getByLabelText('Password')).toBeInTheDocument()
+    expect(
+      screen.getByText('Enter your password to confirm deletion.')
+    ).toBeInTheDocument()
+  })
+
+  it('shows OAuth notice on confirm step when user has no password', async () => {
+    mockDeletionSummaryState = {
+      ...mockDeletionSummaryState,
+      data: {
+        shows_count: 0,
+        saved_shows_count: 0,
+        passkeys_count: 0,
+        has_password: false,
+      },
+    }
+    const { user } = renderDialog()
+
+    await user.click(screen.getByRole('button', { name: /Continue/ }))
+
+    expect(
+      screen.getByText(/OAuth accounts require email confirmation/)
+    ).toBeInTheDocument()
+  })
+
+  it('shows reason textarea on confirm step', async () => {
+    const { user } = renderDialog()
+
+    await user.click(screen.getByRole('button', { name: /Continue/ }))
+
+    expect(
+      screen.getByLabelText('Why are you leaving? (optional)')
+    ).toBeInTheDocument()
+  })
+
+  it('shows confirmation checkbox on confirm step', async () => {
+    const { user } = renderDialog()
+
+    await user.click(screen.getByRole('button', { name: /Continue/ }))
+
+    expect(
+      screen.getByText(
+        /I understand that my account will be deactivated/
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('disables Delete button until checkbox is checked and password entered', async () => {
+    const { user } = renderDialog()
+
+    await user.click(screen.getByRole('button', { name: /Continue/ }))
+
+    const deleteButton = screen.getByRole('button', {
+      name: 'Delete My Account',
+    })
+    expect(deleteButton).toBeDisabled()
+
+    // Enter password
+    await user.type(screen.getByLabelText('Password'), 'mypassword123')
+    expect(deleteButton).toBeDisabled()
+
+    // Check confirmation checkbox
+    await user.click(screen.getByRole('checkbox'))
+    expect(deleteButton).toBeEnabled()
+  })
+
+  it('navigates back to warning step when Back is clicked', async () => {
+    const { user } = renderDialog()
+
+    // Go to confirm step
+    await user.click(screen.getByRole('button', { name: /Continue/ }))
+    expect(screen.getByText('Confirm Account Deletion')).toBeInTheDocument()
+
+    // Go back
+    await user.click(screen.getByRole('button', { name: /Back/ }))
+    expect(screen.getByText('Delete Account')).toBeInTheDocument()
+  })
+
+  it('toggles password visibility on confirm step', async () => {
+    const { user } = renderDialog()
+
+    await user.click(screen.getByRole('button', { name: /Continue/ }))
+
+    const passwordInput = screen.getByLabelText('Password')
+    expect(passwordInput).toHaveAttribute('type', 'password')
+
+    await user.click(
+      screen.getByRole('button', { name: 'Show password' })
+    )
+    expect(passwordInput).toHaveAttribute('type', 'text')
+
+    await user.click(
+      screen.getByRole('button', { name: 'Hide password' })
+    )
+    expect(passwordInput).toHaveAttribute('type', 'password')
+  })
+
+  it('calls deleteAccount mutation on submit', async () => {
+    mockDeleteMutateAsync.mockResolvedValue({
+      success: true,
+      deletion_date: '2026-04-06T00:00:00Z',
+    })
+    const { user } = renderDialog()
+
+    // Navigate to confirm step
+    await user.click(screen.getByRole('button', { name: /Continue/ }))
+
+    // Fill in required fields
+    await user.type(screen.getByLabelText('Password'), 'mypassword123')
+    await user.click(screen.getByRole('checkbox'))
+
+    // Submit
+    await user.click(
+      screen.getByRole('button', { name: 'Delete My Account' })
+    )
+
+    expect(mockDeleteMutateAsync).toHaveBeenCalledWith({
+      password: 'mypassword123',
+      reason: undefined,
+    })
+  })
+
+  it('shows success step after successful deletion', async () => {
+    mockDeleteMutateAsync.mockResolvedValue({
+      success: true,
+      deletion_date: '2026-04-06T00:00:00Z',
+    })
+    const { user } = renderDialog()
+
+    // Navigate to confirm step
+    await user.click(screen.getByRole('button', { name: /Continue/ }))
+
+    // Fill in required fields
+    await user.type(screen.getByLabelText('Password'), 'mypassword123')
+    await user.click(screen.getByRole('checkbox'))
+
+    // Submit
+    await user.click(
+      screen.getByRole('button', { name: 'Delete My Account' })
+    )
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Account Scheduled for Deletion')
+      ).toBeInTheDocument()
+    })
+
+    // Date displayed depends on local timezone; just check the year is present
+    expect(screen.getByText(/2026/)).toBeInTheDocument()
+    expect(screen.getByText('Redirecting to home page...')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Go to Home' })
+    ).toBeInTheDocument()
+  })
+
+  it('shows mutation error on confirm step', async () => {
+    mockDeleteMutationState = {
+      ...mockDeleteMutationState,
+      isError: true,
+      error: new Error('Incorrect password'),
+    }
+    const { user } = renderDialog()
+
+    await user.click(screen.getByRole('button', { name: /Continue/ }))
+
+    expect(screen.getByText('Incorrect password')).toBeInTheDocument()
+  })
+
+  it('calls onOpenChange when Cancel is clicked on warning step', async () => {
+    const { user, onOpenChange } = renderDialog()
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+})

--- a/frontend/components/settings/favorite-cities.test.tsx
+++ b/frontend/components/settings/favorite-cities.test.tsx
@@ -1,0 +1,246 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders } from '@/test/utils'
+import { FavoriteCitiesSettings } from './favorite-cities'
+
+// --- Mocks ---
+
+const mockMutate = vi.fn()
+let mockMutationState = {
+  isPending: false,
+  isError: false,
+  isSuccess: false,
+}
+
+let mockProfileData: {
+  user?: {
+    preferences?: {
+      favorite_cities?: { city: string; state: string }[]
+    }
+  }
+} = {}
+
+let mockCitiesData: {
+  cities?: { city: string; state: string; show_count: number }[]
+} | undefined = undefined
+
+let mockCitiesLoading = false
+
+vi.mock('@/lib/hooks/useAuth', () => ({
+  useProfile: () => ({
+    data: mockProfileData,
+  }),
+}))
+
+vi.mock('@/lib/hooks/useShows', () => ({
+  useShowCities: () => ({
+    data: mockCitiesData,
+    isLoading: mockCitiesLoading,
+  }),
+}))
+
+vi.mock('@/lib/hooks/useFavoriteCities', () => ({
+  useSetFavoriteCities: () => ({
+    mutate: mockMutate,
+    ...mockMutationState,
+  }),
+}))
+
+// --- Tests ---
+
+describe('FavoriteCitiesSettings', () => {
+  beforeEach(() => {
+    mockMutate.mockReset()
+    mockMutationState = { isPending: false, isError: false, isSuccess: false }
+    mockProfileData = {}
+    mockCitiesData = undefined
+    mockCitiesLoading = false
+  })
+
+  it('renders the card title and description', () => {
+    renderWithProviders(<FavoriteCitiesSettings />)
+
+    expect(screen.getByText('Favorite Cities')).toBeInTheDocument()
+    expect(
+      screen.getByText(/Choose your default cities for the show calendar/)
+    ).toBeInTheDocument()
+  })
+
+  it('shows loading state when cities are loading', () => {
+    mockCitiesLoading = true
+    renderWithProviders(<FavoriteCitiesSettings />)
+
+    expect(screen.getByText('Loading cities...')).toBeInTheDocument()
+  })
+
+  it('shows empty state when no cities available', () => {
+    mockCitiesData = { cities: [] }
+    renderWithProviders(<FavoriteCitiesSettings />)
+
+    expect(
+      screen.getByText('No cities with upcoming shows found.')
+    ).toBeInTheDocument()
+  })
+
+  it('renders city chips when cities are available', () => {
+    mockCitiesData = {
+      cities: [
+        { city: 'Phoenix', state: 'AZ', show_count: 8 },
+        { city: 'Tempe', state: 'AZ', show_count: 3 },
+      ],
+    }
+    renderWithProviders(<FavoriteCitiesSettings />)
+
+    expect(screen.getByText('Phoenix, AZ')).toBeInTheDocument()
+    expect(screen.getByText('Tempe, AZ')).toBeInTheDocument()
+  })
+
+  it('toggles a city when chip is clicked', async () => {
+    mockCitiesData = {
+      cities: [
+        { city: 'Phoenix', state: 'AZ', show_count: 8 },
+        { city: 'Tempe', state: 'AZ', show_count: 3 },
+      ],
+    }
+    mockProfileData = { user: { preferences: { favorite_cities: [] } } }
+
+    const user = userEvent.setup()
+    renderWithProviders(<FavoriteCitiesSettings />)
+
+    await user.click(screen.getByText('Phoenix, AZ'))
+
+    expect(mockMutate).toHaveBeenCalledWith([{ city: 'Phoenix', state: 'AZ' }])
+  })
+
+  it('removes a city when already-selected chip is clicked', async () => {
+    mockCitiesData = {
+      cities: [
+        { city: 'Phoenix', state: 'AZ', show_count: 8 },
+        { city: 'Tempe', state: 'AZ', show_count: 3 },
+      ],
+    }
+    mockProfileData = {
+      user: {
+        preferences: {
+          favorite_cities: [{ city: 'Phoenix', state: 'AZ' }],
+        },
+      },
+    }
+
+    const user = userEvent.setup()
+    renderWithProviders(<FavoriteCitiesSettings />)
+
+    await user.click(screen.getByText('Phoenix, AZ'))
+
+    expect(mockMutate).toHaveBeenCalledWith([])
+  })
+
+  it('shows selected count and Clear all button when cities are selected', () => {
+    mockCitiesData = {
+      cities: [
+        { city: 'Phoenix', state: 'AZ', show_count: 8 },
+        { city: 'Tempe', state: 'AZ', show_count: 3 },
+      ],
+    }
+    mockProfileData = {
+      user: {
+        preferences: {
+          favorite_cities: [
+            { city: 'Phoenix', state: 'AZ' },
+            { city: 'Tempe', state: 'AZ' },
+          ],
+        },
+      },
+    }
+
+    renderWithProviders(<FavoriteCitiesSettings />)
+
+    expect(screen.getByText('2 cities selected')).toBeInTheDocument()
+    expect(screen.getByText('Clear all')).toBeInTheDocument()
+  })
+
+  it('shows singular "city" when 1 city is selected', () => {
+    mockCitiesData = {
+      cities: [{ city: 'Phoenix', state: 'AZ', show_count: 8 }],
+    }
+    mockProfileData = {
+      user: {
+        preferences: {
+          favorite_cities: [{ city: 'Phoenix', state: 'AZ' }],
+        },
+      },
+    }
+
+    renderWithProviders(<FavoriteCitiesSettings />)
+
+    expect(screen.getByText('1 city selected')).toBeInTheDocument()
+  })
+
+  it('does not show selected count or Clear all when no cities are selected', () => {
+    mockCitiesData = {
+      cities: [{ city: 'Phoenix', state: 'AZ', show_count: 8 }],
+    }
+    mockProfileData = { user: { preferences: { favorite_cities: [] } } }
+
+    renderWithProviders(<FavoriteCitiesSettings />)
+
+    expect(screen.queryByText(/selected/)).not.toBeInTheDocument()
+    expect(screen.queryByText('Clear all')).not.toBeInTheDocument()
+  })
+
+  it('calls mutate with empty array when Clear all is clicked', async () => {
+    mockCitiesData = {
+      cities: [{ city: 'Phoenix', state: 'AZ', show_count: 8 }],
+    }
+    mockProfileData = {
+      user: {
+        preferences: {
+          favorite_cities: [{ city: 'Phoenix', state: 'AZ' }],
+        },
+      },
+    }
+
+    const user = userEvent.setup()
+    renderWithProviders(<FavoriteCitiesSettings />)
+
+    await user.click(screen.getByText('Clear all'))
+
+    expect(mockMutate).toHaveBeenCalledWith([])
+  })
+
+  it('shows Saving indicator when mutation is pending', () => {
+    mockCitiesData = {
+      cities: [{ city: 'Phoenix', state: 'AZ', show_count: 8 }],
+    }
+    mockMutationState = { isPending: true, isError: false, isSuccess: false }
+
+    renderWithProviders(<FavoriteCitiesSettings />)
+
+    expect(screen.getByText('Saving...')).toBeInTheDocument()
+  })
+
+  it('shows Saved indicator when mutation succeeds', () => {
+    mockCitiesData = {
+      cities: [{ city: 'Phoenix', state: 'AZ', show_count: 8 }],
+    }
+    mockMutationState = { isPending: false, isError: false, isSuccess: true }
+
+    renderWithProviders(<FavoriteCitiesSettings />)
+
+    expect(screen.getByText('Saved')).toBeInTheDocument()
+  })
+
+  it('shows error message when mutation fails', () => {
+    mockCitiesData = {
+      cities: [{ city: 'Phoenix', state: 'AZ', show_count: 8 }],
+    }
+    mockMutationState = { isPending: false, isError: true, isSuccess: false }
+
+    renderWithProviders(<FavoriteCitiesSettings />)
+
+    expect(
+      screen.getByText('Failed to save. Please try again.')
+    ).toBeInTheDocument()
+  })
+})

--- a/frontend/components/settings/notification-settings.test.tsx
+++ b/frontend/components/settings/notification-settings.test.tsx
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders } from '@/test/utils'
+import { NotificationSettings } from './notification-settings'
+
+// --- Mocks ---
+
+const mockMutate = vi.fn()
+let mockMutationState = {
+  isPending: false,
+  isError: false,
+  error: null as Error | null,
+}
+
+let mockProfileData: {
+  user?: {
+    preferences?: {
+      show_reminders?: boolean
+    }
+  }
+} = {}
+
+vi.mock('@/lib/hooks/useAuth', () => ({
+  useProfile: () => ({
+    data: mockProfileData,
+  }),
+}))
+
+vi.mock('@/lib/hooks/useShowReminders', () => ({
+  useSetShowReminders: () => ({
+    mutate: mockMutate,
+    ...mockMutationState,
+  }),
+}))
+
+// --- Tests ---
+
+describe('NotificationSettings', () => {
+  beforeEach(() => {
+    mockMutate.mockReset()
+    mockMutationState = { isPending: false, isError: false, error: null }
+    mockProfileData = {}
+  })
+
+  it('renders the card title and description', () => {
+    renderWithProviders(<NotificationSettings />)
+
+    expect(screen.getByText('Notifications')).toBeInTheDocument()
+    expect(
+      screen.getByText(/Control how you're notified about upcoming shows/)
+    ).toBeInTheDocument()
+  })
+
+  it('renders the show reminders label and description', () => {
+    renderWithProviders(<NotificationSettings />)
+
+    expect(screen.getByText('Show reminders')).toBeInTheDocument()
+    expect(
+      screen.getByText('Get an email 24 hours before your saved shows')
+    ).toBeInTheDocument()
+  })
+
+  it('renders the switch in unchecked state when show_reminders is false', () => {
+    mockProfileData = {
+      user: { preferences: { show_reminders: false } },
+    }
+    renderWithProviders(<NotificationSettings />)
+
+    const toggle = screen.getByRole('switch', { name: 'Show reminders' })
+    expect(toggle).toBeInTheDocument()
+    expect(toggle).not.toBeChecked()
+  })
+
+  it('renders the switch in checked state when show_reminders is true', () => {
+    mockProfileData = {
+      user: { preferences: { show_reminders: true } },
+    }
+    renderWithProviders(<NotificationSettings />)
+
+    const toggle = screen.getByRole('switch', { name: 'Show reminders' })
+    expect(toggle).toBeChecked()
+  })
+
+  it('defaults to unchecked when preferences are undefined', () => {
+    mockProfileData = {}
+    renderWithProviders(<NotificationSettings />)
+
+    const toggle = screen.getByRole('switch', { name: 'Show reminders' })
+    expect(toggle).not.toBeChecked()
+  })
+
+  it('calls mutate with true when toggling on', async () => {
+    mockProfileData = {
+      user: { preferences: { show_reminders: false } },
+    }
+    const user = userEvent.setup()
+    renderWithProviders(<NotificationSettings />)
+
+    const toggle = screen.getByRole('switch', { name: 'Show reminders' })
+    await user.click(toggle)
+
+    expect(mockMutate).toHaveBeenCalledWith(true)
+  })
+
+  it('calls mutate with false when toggling off', async () => {
+    mockProfileData = {
+      user: { preferences: { show_reminders: true } },
+    }
+    const user = userEvent.setup()
+    renderWithProviders(<NotificationSettings />)
+
+    const toggle = screen.getByRole('switch', { name: 'Show reminders' })
+    await user.click(toggle)
+
+    expect(mockMutate).toHaveBeenCalledWith(false)
+  })
+
+  it('disables the switch when mutation is pending', () => {
+    mockMutationState = { isPending: true, isError: false, error: null }
+    renderWithProviders(<NotificationSettings />)
+
+    const toggle = screen.getByRole('switch', { name: 'Show reminders' })
+    expect(toggle).toBeDisabled()
+  })
+
+  it('shows error message when mutation fails', () => {
+    mockMutationState = {
+      isPending: false,
+      isError: true,
+      error: new Error('Network error'),
+    }
+    renderWithProviders(<NotificationSettings />)
+
+    expect(
+      screen.getByText('Failed to update setting. Please try again.')
+    ).toBeInTheDocument()
+  })
+
+  it('does not show error message when mutation is successful', () => {
+    mockMutationState = { isPending: false, isError: false, error: null }
+    renderWithProviders(<NotificationSettings />)
+
+    expect(
+      screen.queryByText('Failed to update setting. Please try again.')
+    ).not.toBeInTheDocument()
+  })
+})

--- a/frontend/components/settings/oauth-accounts.test.tsx
+++ b/frontend/components/settings/oauth-accounts.test.tsx
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders } from '@/test/utils'
+import { OAuthAccounts } from './oauth-accounts'
+
+// --- Mocks ---
+
+let mockOAuthData: {
+  accounts?: {
+    provider: string
+    email?: string
+    name?: string
+    avatar_url?: string
+    connected_at: string
+  }[]
+} | undefined = undefined
+
+let mockOAuthLoading = false
+let mockOAuthError: Error | null = null
+
+const mockUnlinkMutateAsync = vi.fn()
+let mockUnlinkMutationState = {
+  isPending: false,
+  isError: false,
+  isSuccess: false,
+  error: null as Error | null,
+}
+
+vi.mock('@/lib/hooks/useAuth', () => ({
+  useOAuthAccounts: () => ({
+    data: mockOAuthData,
+    isLoading: mockOAuthLoading,
+    error: mockOAuthError,
+  }),
+  useUnlinkOAuthAccount: () => ({
+    mutateAsync: mockUnlinkMutateAsync,
+    ...mockUnlinkMutationState,
+  }),
+}))
+
+// Mock Sentry to avoid import errors
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+}))
+
+// --- Tests ---
+
+describe('OAuthAccounts', () => {
+  beforeEach(() => {
+    mockOAuthData = undefined
+    mockOAuthLoading = false
+    mockOAuthError = null
+    mockUnlinkMutateAsync.mockReset()
+    mockUnlinkMutationState = {
+      isPending: false,
+      isError: false,
+      isSuccess: false,
+      error: null,
+    }
+  })
+
+  it('renders card title and description', () => {
+    renderWithProviders(<OAuthAccounts />)
+
+    expect(screen.getByText('Connected Accounts')).toBeInTheDocument()
+    expect(
+      screen.getByText('Manage your connected sign-in methods')
+    ).toBeInTheDocument()
+  })
+
+  it('shows Google as "Not connected" when no Google account is linked', () => {
+    mockOAuthData = { accounts: [] }
+    renderWithProviders(<OAuthAccounts />)
+
+    expect(screen.getByText('Google')).toBeInTheDocument()
+    expect(screen.getByText('Not connected')).toBeInTheDocument()
+  })
+
+  it('shows Connect button when no Google account is linked', () => {
+    mockOAuthData = { accounts: [] }
+    renderWithProviders(<OAuthAccounts />)
+
+    expect(screen.getByRole('button', { name: /Connect/ })).toBeInTheDocument()
+  })
+
+  it('shows connected Google account email and Disconnect button', () => {
+    mockOAuthData = {
+      accounts: [
+        {
+          provider: 'google',
+          email: 'user@gmail.com',
+          connected_at: '2025-06-15T10:00:00Z',
+        },
+      ],
+    }
+    renderWithProviders(<OAuthAccounts />)
+
+    expect(screen.getByText('user@gmail.com')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /Disconnect/ })
+    ).toBeInTheDocument()
+  })
+
+  it('shows connected Google account name when no email', () => {
+    mockOAuthData = {
+      accounts: [
+        {
+          provider: 'google',
+          name: 'Test User',
+          connected_at: '2025-06-15T10:00:00Z',
+        },
+      ],
+    }
+    renderWithProviders(<OAuthAccounts />)
+
+    expect(screen.getByText('Test User')).toBeInTheDocument()
+  })
+
+  it('shows fallback "Google Account" when neither email nor name exists', () => {
+    mockOAuthData = {
+      accounts: [
+        {
+          provider: 'google',
+          connected_at: '2025-06-15T10:00:00Z',
+        },
+      ],
+    }
+    renderWithProviders(<OAuthAccounts />)
+
+    expect(screen.getByText('Google Account')).toBeInTheDocument()
+  })
+
+  it('shows error alert when fetching accounts fails', () => {
+    mockOAuthError = new Error('Network error')
+    renderWithProviders(<OAuthAccounts />)
+
+    expect(
+      screen.getByText('Failed to load connected accounts')
+    ).toBeInTheDocument()
+  })
+
+  it('opens disconnect confirmation dialog when Disconnect is clicked', async () => {
+    mockOAuthData = {
+      accounts: [
+        {
+          provider: 'google',
+          email: 'user@gmail.com',
+          connected_at: '2025-06-15T10:00:00Z',
+        },
+      ],
+    }
+    const user = userEvent.setup()
+    renderWithProviders(<OAuthAccounts />)
+
+    await user.click(screen.getByRole('button', { name: /Disconnect/ }))
+
+    expect(
+      screen.getByText('Disconnect Google Account?')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        /You will no longer be able to sign in with this Google account/
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('shows unlink error message when unlink mutation fails', () => {
+    mockUnlinkMutationState = {
+      isPending: false,
+      isError: true,
+      isSuccess: false,
+      error: new Error('Cannot unlink last auth method'),
+    }
+    renderWithProviders(<OAuthAccounts />)
+
+    expect(
+      screen.getByText('Cannot unlink last auth method')
+    ).toBeInTheDocument()
+  })
+
+  it('shows success message after successful unlink', () => {
+    mockUnlinkMutationState = {
+      isPending: false,
+      isError: false,
+      isSuccess: true,
+      error: null,
+    }
+    renderWithProviders(<OAuthAccounts />)
+
+    expect(
+      screen.getByText('Account disconnected successfully')
+    ).toBeInTheDocument()
+  })
+})

--- a/frontend/components/settings/passkey-management.test.tsx
+++ b/frontend/components/settings/passkey-management.test.tsx
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders } from '@/test/utils'
+import { PasskeyManagement } from './passkey-management'
+
+// --- Mocks ---
+
+let mockSupportsWebAuthn = true
+
+vi.mock('@simplewebauthn/browser', () => ({
+  browserSupportsWebAuthn: () => mockSupportsWebAuthn,
+}))
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+}))
+
+vi.mock('@/components/auth/passkey-register', () => ({
+  PasskeyRegisterButton: ({ onSuccess, onError }: { onSuccess: () => void; onError: (err: string) => void }) => (
+    <button onClick={() => onSuccess()} data-testid="register-passkey-btn">
+      Add Passkey
+    </button>
+  ),
+}))
+
+let mockFetchResponse: {
+  ok: boolean
+  json: () => Promise<unknown>
+} = {
+  ok: true,
+  json: async () => ({ success: true, credentials: [] }),
+}
+
+// --- Tests ---
+
+describe('PasskeyManagement', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSupportsWebAuthn = true
+    mockFetchResponse = {
+      ok: true,
+      json: async () => ({ success: true, credentials: [] }),
+    }
+    vi.spyOn(global, 'fetch').mockImplementation(async () =>
+      mockFetchResponse as Response
+    )
+  })
+
+  it('shows "browser does not support passkeys" when WebAuthn not supported', () => {
+    mockSupportsWebAuthn = false
+    renderWithProviders(<PasskeyManagement />)
+
+    expect(screen.getByText('Passkeys')).toBeInTheDocument()
+    expect(
+      screen.getByText('Your browser does not support passkeys.')
+    ).toBeInTheDocument()
+  })
+
+  it('renders card title and description when WebAuthn is supported', async () => {
+    renderWithProviders(<PasskeyManagement />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Passkeys')).toBeInTheDocument()
+    })
+    expect(
+      screen.getByText(/Passkeys let you sign in securely/)
+    ).toBeInTheDocument()
+  })
+
+  it('shows empty state when no credentials exist', async () => {
+    renderWithProviders(<PasskeyManagement />)
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/No passkeys registered yet/)
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('renders credentials list when passkeys exist', async () => {
+    mockFetchResponse = {
+      ok: true,
+      json: async () => ({
+        success: true,
+        credentials: [
+          {
+            id: 1,
+            display_name: 'MacBook Pro',
+            created_at: '2025-06-15T10:00:00Z',
+            last_used_at: '2025-07-01T14:30:00Z',
+            backup_eligible: true,
+            backup_state: true,
+          },
+          {
+            id: 2,
+            display_name: 'iPhone',
+            created_at: '2025-08-01T10:00:00Z',
+            last_used_at: null,
+            backup_eligible: false,
+            backup_state: false,
+          },
+        ],
+      }),
+    }
+    renderWithProviders(<PasskeyManagement />)
+
+    await waitFor(() => {
+      expect(screen.getByText('MacBook Pro')).toBeInTheDocument()
+    })
+    expect(screen.getByText('iPhone')).toBeInTheDocument()
+    expect(screen.getByText('Synced')).toBeInTheDocument()
+  })
+
+  it('shows "Unnamed passkey" for credentials without display_name', async () => {
+    mockFetchResponse = {
+      ok: true,
+      json: async () => ({
+        success: true,
+        credentials: [
+          {
+            id: 1,
+            display_name: '',
+            created_at: '2025-06-15T10:00:00Z',
+            last_used_at: null,
+            backup_eligible: false,
+            backup_state: false,
+          },
+        ],
+      }),
+    }
+    renderWithProviders(<PasskeyManagement />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Unnamed passkey')).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when fetch fails', async () => {
+    mockFetchResponse = {
+      ok: true,
+      json: async () => ({ success: false, message: 'Unauthorized' }),
+    }
+    renderWithProviders(<PasskeyManagement />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Unauthorized')).toBeInTheDocument()
+    })
+  })
+
+  it('shows generic error when fetch throws', async () => {
+    vi.spyOn(global, 'fetch').mockRejectedValue(new Error('Network error'))
+    renderWithProviders(<PasskeyManagement />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to load passkeys')).toBeInTheDocument()
+    })
+  })
+
+  it('renders delete button for each credential', async () => {
+    mockFetchResponse = {
+      ok: true,
+      json: async () => ({
+        success: true,
+        credentials: [
+          {
+            id: 1,
+            display_name: 'MacBook Pro',
+            created_at: '2025-06-15T10:00:00Z',
+            last_used_at: null,
+            backup_eligible: false,
+            backup_state: false,
+          },
+        ],
+      }),
+    }
+    renderWithProviders(<PasskeyManagement />)
+
+    await waitFor(() => {
+      expect(screen.getByText('MacBook Pro')).toBeInTheDocument()
+    })
+
+    // Delete button should exist (ghost variant with trash icon)
+    const deleteButtons = screen.getAllByRole('button')
+    const deleteBtn = deleteButtons.find(
+      btn => !btn.textContent?.includes('Add')
+    )
+    expect(deleteBtn).toBeDefined()
+  })
+
+  it('renders the passkey register button', async () => {
+    renderWithProviders(<PasskeyManagement />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('register-passkey-btn')).toBeInTheDocument()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Adds 100 new unit tests across 7 test files for `components/settings/` (previously 14.48% coverage, 373 tracked lines)
- Covers: SettingsPanel, NotificationSettings, FavoriteCities, OAuthAccounts, DeleteAccountDialog, PasskeyManagement, ApiTokenManagement
- No source changes — test files only

## Test plan
- [x] All 124 tests pass (100 new + 24 existing): `bun run test:run -- components/settings/`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)