### PR TITLE
test: add unit tests for artists components

### DIFF
--- a/frontend/components/artists/ArtistDetail.test.tsx
+++ b/frontend/components/artists/ArtistDetail.test.tsx
@@ -1,0 +1,535 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders } from '@/test/utils'
+import type { Artist } from '@/lib/types/artist'
+
+// Mock next/link
+vi.mock('next/link', () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string
+    children: React.ReactNode
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}))
+
+// Mock radix tabs to avoid context requirement
+vi.mock('@/components/ui/tabs', () => ({
+  Tabs: ({ children, ...props }: { children: React.ReactNode; value?: string; onValueChange?: (v: string) => void }) => <div data-testid="tabs-root" {...props}>{children}</div>,
+  TabsList: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsTrigger: ({ children, value }: { children: React.ReactNode; value: string }) => <button data-value={value}>{children}</button>,
+  TabsContent: ({ children, value }: { children: React.ReactNode; value: string }) => <div data-testid={`tabs-content-${value}`}>{children}</div>,
+}))
+
+// Mock hooks
+const mockUseArtist = vi.fn()
+vi.mock('@/lib/hooks/useArtists', () => ({
+  useArtist: (opts: unknown) => mockUseArtist(opts),
+  useArtistShows: () => ({
+    data: { shows: [], total: 0 },
+    isLoading: false,
+    error: null,
+  }),
+}))
+
+const mockUseIsAuthenticated = vi.fn()
+vi.mock('@/lib/hooks/useAuth', () => ({
+  useIsAuthenticated: () => mockUseIsAuthenticated(),
+}))
+
+const mockUseArtistLabels = vi.fn()
+vi.mock('@/lib/hooks/useLabels', () => ({
+  useArtistLabels: (opts: unknown) => mockUseArtistLabels(opts),
+  useLabelRoster: () => ({ data: null }),
+}))
+
+vi.mock('@/lib/hooks/useReleases', () => ({
+  useArtistReleases: () => ({
+    data: null,
+    isLoading: false,
+    error: null,
+  }),
+}))
+
+vi.mock('@/lib/hooks/useAdminArtists', () => ({
+  useDiscoverMusic: () => ({ mutate: vi.fn(), isPending: false }),
+  useUpdateArtistBandcamp: () => ({ mutate: vi.fn(), isPending: false }),
+  useClearArtistBandcamp: () => ({ mutate: vi.fn(), isPending: false }),
+  useUpdateArtistSpotify: () => ({ mutate: vi.fn(), isPending: false }),
+  useClearArtistSpotify: () => ({ mutate: vi.fn(), isPending: false }),
+}))
+
+// Mock child components
+vi.mock('./ArtistShowsList', () => ({
+  ArtistShowsList: ({ artistId }: { artistId: number }) => (
+    <div data-testid="artist-shows-list">Shows for {artistId}</div>
+  ),
+}))
+
+vi.mock('./ReportArtistButton', () => ({
+  ReportArtistButton: ({
+    artistName,
+  }: {
+    artistId: number
+    artistName: string
+  }) => <button data-testid="report-button">Report {artistName}</button>,
+}))
+
+vi.mock('@/components/forms/ArtistEditForm', () => ({
+  ArtistEditForm: ({
+    open,
+  }: {
+    open: boolean
+    artist: unknown
+    onOpenChange: (v: boolean) => void
+    onSuccess: () => void
+  }) => (open ? <div data-testid="edit-form">Edit Form</div> : null),
+}))
+
+vi.mock('@/components/shared', () => ({
+  SocialLinks: () => <div data-testid="social-links">Social Links</div>,
+  MusicEmbed: () => <div data-testid="music-embed">Music Embed</div>,
+  EntityDetailLayout: ({
+    children,
+    sidebar,
+    header,
+    tabs,
+    activeTab,
+    onTabChange,
+    backLink,
+  }: {
+    children: React.ReactNode
+    sidebar: React.ReactNode
+    header: React.ReactNode
+    tabs: { value: string; label: string }[]
+    activeTab: string
+    onTabChange: (tab: string) => void
+    backLink: { href: string; label: string }
+  }) => (
+    <div data-testid="entity-layout">
+      <a href={backLink.href}>{backLink.label}</a>
+      <div data-testid="header-slot">{header}</div>
+      <div data-testid="tabs">
+        {tabs.map(tab => (
+          <button
+            key={tab.value}
+            data-testid={`tab-${tab.value}`}
+            onClick={() => onTabChange(tab.value)}
+            data-active={tab.value === activeTab}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+      <div data-testid="sidebar-slot">{sidebar}</div>
+      <div data-testid="content-slot">{children}</div>
+    </div>
+  ),
+  EntityHeader: ({
+    title,
+    subtitle,
+    actions,
+  }: {
+    title: string
+    subtitle?: React.ReactNode
+    actions?: React.ReactNode
+  }) => (
+    <div data-testid="entity-header">
+      <h1>{title}</h1>
+      {subtitle && <div data-testid="subtitle">{subtitle}</div>}
+      {actions && <div data-testid="header-actions">{actions}</div>}
+    </div>
+  ),
+}))
+
+import { ArtistDetail } from './ArtistDetail'
+
+function makeArtist(overrides: Partial<Artist> = {}): Artist {
+  return {
+    id: 42,
+    slug: 'test-artist',
+    name: 'Test Artist',
+    city: 'Phoenix',
+    state: 'AZ',
+    bandcamp_embed_url: null,
+    social: {
+      instagram: null,
+      facebook: null,
+      twitter: null,
+      youtube: null,
+      spotify: null,
+      soundcloud: null,
+      bandcamp: null,
+      website: null,
+    },
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('ArtistDetail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseIsAuthenticated.mockReturnValue({
+      user: null,
+      isAuthenticated: false,
+      isLoading: false,
+    })
+    mockUseArtistLabels.mockReturnValue({
+      data: { labels: [] },
+      isLoading: false,
+    })
+  })
+
+  describe('loading state', () => {
+    it('shows loading spinner while fetching', () => {
+      mockUseArtist.mockReturnValue({
+        data: undefined,
+        isLoading: true,
+        error: null,
+      })
+
+      renderWithProviders(<ArtistDetail artistId="test-artist" />)
+      const spinner = document.querySelector('.animate-spin')
+      expect(spinner).toBeInTheDocument()
+    })
+  })
+
+  describe('error state', () => {
+    it('shows 404 error for not found', () => {
+      mockUseArtist.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        error: new Error('Artist not found'),
+      })
+
+      renderWithProviders(<ArtistDetail artistId="bad-slug" />)
+      expect(screen.getByText('Artist Not Found')).toBeInTheDocument()
+      expect(
+        screen.getByText(
+          "The artist you're looking for doesn't exist or has been removed."
+        )
+      ).toBeInTheDocument()
+    })
+
+    it('shows generic error message for server errors', () => {
+      mockUseArtist.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        error: new Error('Server error'),
+      })
+
+      renderWithProviders(<ArtistDetail artistId="test" />)
+      expect(screen.getByText('Error Loading Artist')).toBeInTheDocument()
+      expect(screen.getByText('Server error')).toBeInTheDocument()
+    })
+
+    it('shows back to shows link on error', () => {
+      mockUseArtist.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        error: new Error('not found'),
+      })
+
+      renderWithProviders(<ArtistDetail artistId="bad" />)
+      const backLink = screen.getByText('Back to Shows')
+      expect(backLink.closest('a')).toHaveAttribute('href', '/shows')
+    })
+  })
+
+  describe('no artist data', () => {
+    it('shows not found when artist is null', () => {
+      mockUseArtist.mockReturnValue({
+        data: null,
+        isLoading: false,
+        error: null,
+      })
+
+      renderWithProviders(<ArtistDetail artistId="missing" />)
+      expect(screen.getByText('Artist Not Found')).toBeInTheDocument()
+    })
+  })
+
+  describe('successful load', () => {
+    beforeEach(() => {
+      mockUseArtist.mockReturnValue({
+        data: makeArtist(),
+        isLoading: false,
+        error: null,
+      })
+    })
+
+    it('renders artist name in header', () => {
+      renderWithProviders(<ArtistDetail artistId="test-artist" />)
+      expect(screen.getByText('Test Artist')).toBeInTheDocument()
+    })
+
+    it('renders entity layout with back link', () => {
+      renderWithProviders(<ArtistDetail artistId="test-artist" />)
+      expect(screen.getByTestId('entity-layout')).toBeInTheDocument()
+      expect(screen.getByText('Back to Shows')).toBeInTheDocument()
+    })
+
+    it('renders tabs for overview, discography, and labels', () => {
+      renderWithProviders(<ArtistDetail artistId="test-artist" />)
+      expect(screen.getByTestId('tab-overview')).toBeInTheDocument()
+      expect(screen.getByTestId('tab-discography')).toBeInTheDocument()
+      expect(screen.getByTestId('tab-labels')).toBeInTheDocument()
+    })
+
+    it('renders report button in header actions', () => {
+      renderWithProviders(<ArtistDetail artistId="test-artist" />)
+      expect(screen.getByTestId('report-button')).toBeInTheDocument()
+      expect(screen.getByText('Report Test Artist')).toBeInTheDocument()
+    })
+
+    it('renders artist shows list', () => {
+      renderWithProviders(<ArtistDetail artistId="test-artist" />)
+      expect(screen.getByTestId('artist-shows-list')).toBeInTheDocument()
+      expect(screen.getByText('Shows for 42')).toBeInTheDocument()
+    })
+
+    it('renders social links in sidebar', () => {
+      renderWithProviders(<ArtistDetail artistId="test-artist" />)
+      expect(screen.getByTestId('social-links')).toBeInTheDocument()
+    })
+
+    it('renders music embed in sidebar', () => {
+      renderWithProviders(<ArtistDetail artistId="test-artist" />)
+      expect(screen.getByTestId('music-embed')).toBeInTheDocument()
+    })
+
+    it('shows location in sidebar when available', () => {
+      renderWithProviders(<ArtistDetail artistId="test-artist" />)
+      // Location appears in both header subtitle and sidebar;
+      // verify sidebar has "Location" heading
+      const sidebarSlot = screen.getByTestId('sidebar-slot')
+      expect(sidebarSlot).toHaveTextContent('Location')
+      expect(sidebarSlot).toHaveTextContent('Phoenix, AZ')
+    })
+
+    it('hides location in sidebar when not available', () => {
+      mockUseArtist.mockReturnValue({
+        data: makeArtist({ city: null, state: null }),
+        isLoading: false,
+        error: null,
+      })
+
+      renderWithProviders(<ArtistDetail artistId="test-artist" />)
+      const sidebarSlot = screen.getByTestId('sidebar-slot')
+      expect(sidebarSlot).not.toHaveTextContent('Location')
+    })
+
+    it('shows label links in sidebar when labels exist', () => {
+      mockUseArtistLabels.mockReturnValue({
+        data: {
+          labels: [
+            { id: 1, name: 'Sub Pop', slug: 'sub-pop', city: null, state: null },
+          ],
+        },
+        isLoading: false,
+      })
+
+      renderWithProviders(<ArtistDetail artistId="test-artist" />)
+      const sidebarSlot = screen.getByTestId('sidebar-slot')
+      expect(sidebarSlot).toHaveTextContent('Sub Pop')
+    })
+
+    it('hides labels section in sidebar when no labels', () => {
+      mockUseArtistLabels.mockReturnValue({
+        data: { labels: [] },
+        isLoading: false,
+      })
+
+      renderWithProviders(<ArtistDetail artistId="test-artist" />)
+      const sidebarSlot = screen.getByTestId('sidebar-slot')
+      // Sidebar should NOT contain the "Labels" heading when there are no labels
+      // Note: The tab labeled "Labels" exists in a different part of the DOM
+      const sidebarHeadings = sidebarSlot.querySelectorAll('h3')
+      const labelsHeading = Array.from(sidebarHeadings).find(
+        h => h.textContent === 'Labels'
+      )
+      expect(labelsHeading).toBeUndefined()
+    })
+  })
+
+  describe('admin features', () => {
+    beforeEach(() => {
+      mockUseArtist.mockReturnValue({
+        data: makeArtist(),
+        isLoading: false,
+        error: null,
+      })
+    })
+
+    it('does not show edit button for non-admin users', () => {
+      mockUseIsAuthenticated.mockReturnValue({
+        user: { is_admin: false },
+        isAuthenticated: true,
+        isLoading: false,
+      })
+
+      renderWithProviders(<ArtistDetail artistId="test-artist" />)
+      // The Edit2 icon button should not be present; check that edit form isn't rendered
+      expect(screen.queryByTestId('edit-form')).not.toBeInTheDocument()
+    })
+
+    it('does not show admin music controls for non-admin users', () => {
+      mockUseIsAuthenticated.mockReturnValue({
+        user: { is_admin: false },
+        isAuthenticated: true,
+        isLoading: false,
+      })
+
+      renderWithProviders(<ArtistDetail artistId="test-artist" />)
+      expect(
+        screen.queryByText('No music embed configured')
+      ).not.toBeInTheDocument()
+    })
+
+    it('shows admin music controls for admin users when no embed', () => {
+      mockUseIsAuthenticated.mockReturnValue({
+        user: { is_admin: true },
+        isAuthenticated: true,
+        isLoading: false,
+      })
+
+      renderWithProviders(<ArtistDetail artistId="test-artist" />)
+      expect(
+        screen.getByText('No music embed configured')
+      ).toBeInTheDocument()
+      expect(screen.getByText('Discover Music')).toBeInTheDocument()
+      expect(screen.getByText('Enter Bandcamp URL')).toBeInTheDocument()
+      expect(screen.getByText('Enter Spotify URL')).toBeInTheDocument()
+    })
+
+    it('shows edit bandcamp button for admin when embed exists', () => {
+      mockUseIsAuthenticated.mockReturnValue({
+        user: { is_admin: true },
+        isAuthenticated: true,
+        isLoading: false,
+      })
+      mockUseArtist.mockReturnValue({
+        data: makeArtist({
+          bandcamp_embed_url: 'https://artist.bandcamp.com/album/test',
+        }),
+        isLoading: false,
+        error: null,
+      })
+
+      renderWithProviders(<ArtistDetail artistId="test-artist" />)
+      expect(screen.getByText('Edit Bandcamp URL')).toBeInTheDocument()
+      expect(screen.getByText('Add Spotify URL')).toBeInTheDocument()
+    })
+
+    it('shows edit spotify button for admin when spotify exists', () => {
+      mockUseIsAuthenticated.mockReturnValue({
+        user: { is_admin: true },
+        isAuthenticated: true,
+        isLoading: false,
+      })
+      mockUseArtist.mockReturnValue({
+        data: makeArtist({
+          social: {
+            instagram: null,
+            facebook: null,
+            twitter: null,
+            youtube: null,
+            spotify: 'https://open.spotify.com/artist/123',
+            soundcloud: null,
+            bandcamp: null,
+            website: null,
+          },
+        }),
+        isLoading: false,
+        error: null,
+      })
+
+      renderWithProviders(<ArtistDetail artistId="test-artist" />)
+      expect(screen.getByText('Edit Spotify URL')).toBeInTheDocument()
+      expect(screen.getByText('Add Bandcamp URL')).toBeInTheDocument()
+    })
+
+    it('opens bandcamp URL input when enter button clicked', async () => {
+      const user = userEvent.setup()
+      mockUseIsAuthenticated.mockReturnValue({
+        user: { is_admin: true },
+        isAuthenticated: true,
+        isLoading: false,
+      })
+
+      renderWithProviders(<ArtistDetail artistId="test-artist" />)
+
+      await user.click(screen.getByText('Enter Bandcamp URL'))
+      expect(screen.getByLabelText('Bandcamp Album URL')).toBeInTheDocument()
+      expect(
+        screen.getByPlaceholderText(
+          'https://artist.bandcamp.com/album/album-name'
+        )
+      ).toBeInTheDocument()
+    })
+
+    it('opens spotify URL input when enter button clicked', async () => {
+      const user = userEvent.setup()
+      mockUseIsAuthenticated.mockReturnValue({
+        user: { is_admin: true },
+        isAuthenticated: true,
+        isLoading: false,
+      })
+
+      renderWithProviders(<ArtistDetail artistId="test-artist" />)
+
+      await user.click(screen.getByText('Enter Spotify URL'))
+      expect(screen.getByLabelText('Spotify Artist URL')).toBeInTheDocument()
+      expect(
+        screen.getByPlaceholderText('https://open.spotify.com/artist/...')
+      ).toBeInTheDocument()
+    })
+  })
+
+  describe('location display', () => {
+    it('shows city and state in header subtitle', () => {
+      mockUseArtist.mockReturnValue({
+        data: makeArtist({ city: 'Chicago', state: 'IL' }),
+        isLoading: false,
+        error: null,
+      })
+
+      renderWithProviders(<ArtistDetail artistId="test-artist" />)
+      const subtitle = screen.getByTestId('subtitle')
+      expect(subtitle).toBeInTheDocument()
+      expect(subtitle).toHaveTextContent('Chicago, IL')
+    })
+
+    it('shows only city when state is null', () => {
+      mockUseArtist.mockReturnValue({
+        data: makeArtist({ city: 'Chicago', state: null }),
+        isLoading: false,
+        error: null,
+      })
+
+      renderWithProviders(<ArtistDetail artistId="test-artist" />)
+      const subtitle = screen.getByTestId('subtitle')
+      expect(subtitle).toHaveTextContent('Chicago')
+    })
+
+    it('does not show subtitle when no location', () => {
+      mockUseArtist.mockReturnValue({
+        data: makeArtist({ city: null, state: null }),
+        isLoading: false,
+        error: null,
+      })
+
+      renderWithProviders(<ArtistDetail artistId="test-artist" />)
+      expect(screen.queryByTestId('subtitle')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/components/artists/ArtistList.test.tsx
+++ b/frontend/components/artists/ArtistList.test.tsx
@@ -1,0 +1,278 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders } from '@/test/utils'
+import type { ArtistListItem } from '@/lib/types/artist'
+
+// Mock next/navigation
+const mockPush = vi.fn()
+const mockGet = vi.fn()
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+  useSearchParams: () => ({
+    get: mockGet,
+  }),
+}))
+
+// Mock hooks
+const mockUseArtists = vi.fn()
+const mockUseArtistCities = vi.fn()
+vi.mock('@/lib/hooks/useArtists', () => ({
+  useArtists: (opts: unknown) => mockUseArtists(opts),
+  useArtistCities: () => mockUseArtistCities(),
+}))
+
+const mockUseDensity = vi.fn()
+vi.mock('@/lib/hooks/useDensity', () => ({
+  useDensity: (key: string) => mockUseDensity(key),
+}))
+
+// Mock child components that are complex
+vi.mock('./ArtistSearch', () => ({
+  ArtistSearch: () => <div data-testid="artist-search">ArtistSearch</div>,
+}))
+
+vi.mock('@/components/filters', () => ({
+  CityFilters: ({
+    onFilterChange,
+    selectedCities,
+  }: {
+    onFilterChange: (cities: { city: string; state: string }[]) => void
+    selectedCities: { city: string; state: string }[]
+    cities: unknown[]
+  }) => (
+    <div data-testid="city-filters">
+      <span data-testid="selected-count">{selectedCities.length}</span>
+      <button
+        data-testid="clear-filters"
+        onClick={() => onFilterChange([])}
+      >
+        Clear
+      </button>
+    </div>
+  ),
+}))
+
+vi.mock('@/components/shared', () => ({
+  LoadingSpinner: () => <div data-testid="loading-spinner">Loading...</div>,
+  DensityToggle: ({ storageKey }: { storageKey: string }) => (
+    <div data-testid="density-toggle">{storageKey}</div>
+  ),
+}))
+
+import { ArtistList } from './ArtistList'
+
+function makeArtist(overrides: Partial<ArtistListItem> = {}): ArtistListItem {
+  return {
+    id: 1,
+    slug: 'test-artist',
+    name: 'Test Artist',
+    city: 'Phoenix',
+    state: 'AZ',
+    bandcamp_embed_url: null,
+    upcoming_show_count: 3,
+    social: {
+      instagram: null,
+      facebook: null,
+      twitter: null,
+      youtube: null,
+      spotify: null,
+      soundcloud: null,
+      bandcamp: null,
+      website: null,
+    },
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('ArtistList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGet.mockReturnValue(null)
+    mockUseDensity.mockReturnValue({ density: 'comfortable', setDensity: vi.fn() })
+    mockUseArtistCities.mockReturnValue({
+      data: { cities: [] },
+      isLoading: false,
+      isFetching: false,
+    })
+    mockUseArtists.mockReturnValue({
+      data: { artists: [], count: 0 },
+      isLoading: false,
+      isFetching: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+  })
+
+  it('shows loading spinner on initial load', () => {
+    mockUseArtists.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isFetching: true,
+      error: null,
+      refetch: vi.fn(),
+    })
+    mockUseArtistCities.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isFetching: true,
+    })
+
+    renderWithProviders(<ArtistList />)
+    expect(screen.getByTestId('loading-spinner')).toBeInTheDocument()
+  })
+
+  it('renders artist search component', () => {
+    renderWithProviders(<ArtistList />)
+    expect(screen.getByTestId('artist-search')).toBeInTheDocument()
+  })
+
+  it('renders density toggle with correct storage key', () => {
+    renderWithProviders(<ArtistList />)
+    expect(screen.getByTestId('density-toggle')).toHaveTextContent('artists')
+  })
+
+  it('renders empty state when no artists', () => {
+    renderWithProviders(<ArtistList />)
+    expect(screen.getByText('No artists available at this time.')).toBeInTheDocument()
+  })
+
+  it('renders filtered empty state when cities selected', () => {
+    mockGet.mockReturnValue('Phoenix,AZ')
+    mockUseArtists.mockReturnValue({
+      data: { artists: [], count: 0 },
+      isLoading: false,
+      isFetching: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+
+    renderWithProviders(<ArtistList />)
+    expect(
+      screen.getByText('No artists found in the selected cities.')
+    ).toBeInTheDocument()
+  })
+
+  it('shows "View all artists" link when filtered and empty', () => {
+    mockGet.mockReturnValue('Phoenix,AZ')
+    mockUseArtists.mockReturnValue({
+      data: { artists: [], count: 0 },
+      isLoading: false,
+      isFetching: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+
+    renderWithProviders(<ArtistList />)
+    expect(screen.getByText('View all artists')).toBeInTheDocument()
+  })
+
+  it('renders artist cards when data available', () => {
+    const artists = [
+      makeArtist({ id: 1, name: 'Artist One', slug: 'artist-one' }),
+      makeArtist({ id: 2, name: 'Artist Two', slug: 'artist-two' }),
+    ]
+    mockUseArtists.mockReturnValue({
+      data: { artists, count: 2 },
+      isLoading: false,
+      isFetching: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+
+    renderWithProviders(<ArtistList />)
+    expect(screen.getByText('Artist One')).toBeInTheDocument()
+    expect(screen.getByText('Artist Two')).toBeInTheDocument()
+  })
+
+  it('shows error state with retry button', () => {
+    const refetch = vi.fn()
+    mockUseArtists.mockReturnValue({
+      data: { artists: [], count: 0 },
+      isLoading: false,
+      isFetching: false,
+      error: new Error('Network error'),
+      refetch,
+    })
+
+    renderWithProviders(<ArtistList />)
+    expect(
+      screen.getByText('Failed to load artists. Please try again later.')
+    ).toBeInTheDocument()
+    expect(screen.getByText('Retry')).toBeInTheDocument()
+  })
+
+  it('calls refetch on retry button click', async () => {
+    const user = userEvent.setup()
+    const refetch = vi.fn()
+    mockUseArtists.mockReturnValue({
+      data: { artists: [], count: 0 },
+      isLoading: false,
+      isFetching: false,
+      error: new Error('Network error'),
+      refetch,
+    })
+
+    renderWithProviders(<ArtistList />)
+    await user.click(screen.getByText('Retry'))
+    expect(refetch).toHaveBeenCalledOnce()
+  })
+
+  it('renders city filters when cities data available', () => {
+    mockUseArtistCities.mockReturnValue({
+      data: {
+        cities: [
+          { city: 'Phoenix', state: 'AZ', artist_count: 5 },
+          { city: 'Mesa', state: 'AZ', artist_count: 3 },
+        ],
+      },
+      isLoading: false,
+      isFetching: false,
+    })
+
+    renderWithProviders(<ArtistList />)
+    expect(screen.getByTestId('city-filters')).toBeInTheDocument()
+  })
+
+  it('does not render city filters when no cities', () => {
+    mockUseArtistCities.mockReturnValue({
+      data: { cities: [] },
+      isLoading: false,
+      isFetching: false,
+    })
+
+    renderWithProviders(<ArtistList />)
+    expect(screen.queryByTestId('city-filters')).not.toBeInTheDocument()
+  })
+
+  it('parses cities from URL search params', () => {
+    mockGet.mockReturnValue('Phoenix,AZ|Mesa,AZ')
+    mockUseArtistCities.mockReturnValue({
+      data: {
+        cities: [{ city: 'Phoenix', state: 'AZ', artist_count: 5 }],
+      },
+      isLoading: false,
+      isFetching: false,
+    })
+
+    renderWithProviders(<ArtistList />)
+    // useArtists should be called with the parsed cities
+    expect(mockUseArtists).toHaveBeenCalledWith({
+      cities: [
+        { city: 'Phoenix', state: 'AZ' },
+        { city: 'Mesa', state: 'AZ' },
+      ],
+    })
+  })
+
+  it('passes no cities filter when no search params', () => {
+    mockGet.mockReturnValue(null)
+
+    renderWithProviders(<ArtistList />)
+    expect(mockUseArtists).toHaveBeenCalledWith({
+      cities: undefined,
+    })
+  })
+})

--- a/frontend/components/artists/ArtistListSkeleton.test.tsx
+++ b/frontend/components/artists/ArtistListSkeleton.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ArtistListSkeleton } from './ArtistListSkeleton'
+
+describe('ArtistListSkeleton', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<ArtistListSkeleton />)
+    expect(container.firstChild).toBeInTheDocument()
+  })
+
+  it('has animate-pulse class for loading animation', () => {
+    const { container } = render(<ArtistListSkeleton />)
+    expect(container.querySelector('.animate-pulse')).toBeInTheDocument()
+  })
+
+  it('renders 12 card skeleton placeholders', () => {
+    const { container } = render(<ArtistListSkeleton />)
+    const cards = container.querySelectorAll('.rounded-lg.border')
+    expect(cards).toHaveLength(12)
+  })
+
+  it('renders 3 filter chip skeleton placeholders', () => {
+    const { container } = render(<ArtistListSkeleton />)
+    const chips = container.querySelectorAll('.rounded-full.bg-muted')
+    expect(chips).toHaveLength(3)
+  })
+
+  it('renders search bar skeleton placeholder', () => {
+    const { container } = render(<ArtistListSkeleton />)
+    const searchBar = container.querySelector('.h-9.w-full.max-w-sm.rounded-md.bg-muted')
+    expect(searchBar).toBeInTheDocument()
+  })
+})

--- a/frontend/components/artists/ArtistShowsList.test.tsx
+++ b/frontend/components/artists/ArtistShowsList.test.tsx
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders } from '@/test/utils'
+import type { ArtistShow } from '@/lib/types/artist'
+
+// Mock the artist shows hook
+const mockUseArtistShows = vi.fn()
+vi.mock('@/lib/hooks/useArtists', () => ({
+  useArtistShows: (opts: unknown) => mockUseArtistShows(opts),
+}))
+
+// Mock CompactShowRow to avoid pulling in its dependencies
+vi.mock('@/components/shows/CompactShowRow', () => ({
+  CompactShowRow: ({
+    show,
+  }: {
+    show: { id: number; title: string }
+  }) => (
+    <div data-testid={`show-row-${show.id}`}>{show.title}</div>
+  ),
+}))
+
+import { ArtistShowsList } from './ArtistShowsList'
+
+function makeShow(overrides: Partial<ArtistShow> = {}): ArtistShow {
+  return {
+    id: 1,
+    slug: 'test-show',
+    title: 'Test Show',
+    event_date: '2025-06-15T20:00:00Z',
+    price: 15,
+    age_requirement: null,
+    venue: {
+      id: 1,
+      slug: 'test-venue',
+      name: 'Test Venue',
+      city: 'Phoenix',
+      state: 'AZ',
+    },
+    artists: [
+      { id: 42, slug: 'main-artist', name: 'Main Artist' },
+      { id: 99, slug: 'opener', name: 'The Opener' },
+    ],
+    ...overrides,
+  }
+}
+
+describe('ArtistShowsList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseArtistShows.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+    })
+  })
+
+  it('renders upcoming and past tabs', () => {
+    renderWithProviders(<ArtistShowsList artistId={42} />)
+    expect(screen.getByText('Upcoming')).toBeInTheDocument()
+    expect(screen.getByText('Past Shows')).toBeInTheDocument()
+  })
+
+  it('defaults to the upcoming tab', () => {
+    renderWithProviders(<ArtistShowsList artistId={42} />)
+    // Upcoming tab should be active - the hook should be called with upcoming enabled
+    expect(mockUseArtistShows).toHaveBeenCalledWith(
+      expect.objectContaining({
+        timeFilter: 'upcoming',
+        enabled: true,
+      })
+    )
+  })
+
+  it('shows loading spinner when loading', () => {
+    mockUseArtistShows.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    })
+
+    renderWithProviders(<ArtistShowsList artistId={42} />)
+    // The loading spinner should be present (a Loader2 with animate-spin)
+    const spinner = document.querySelector('.animate-spin')
+    expect(spinner).toBeInTheDocument()
+  })
+
+  it('shows error message on error', () => {
+    mockUseArtistShows.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('Failed'),
+    })
+
+    renderWithProviders(<ArtistShowsList artistId={42} />)
+    expect(screen.getByText('Failed to load shows')).toBeInTheDocument()
+  })
+
+  it('shows empty state for no upcoming shows', () => {
+    mockUseArtistShows.mockReturnValue({
+      data: { shows: [], total: 0, artist_id: 42 },
+      isLoading: false,
+      error: null,
+    })
+
+    renderWithProviders(<ArtistShowsList artistId={42} />)
+    expect(screen.getByText('No upcoming shows')).toBeInTheDocument()
+  })
+
+  it('renders shows when data available', () => {
+    const shows = [
+      makeShow({ id: 1, title: 'Show One' }),
+      makeShow({ id: 2, title: 'Show Two' }),
+    ]
+    mockUseArtistShows.mockReturnValue({
+      data: { shows, total: 2, artist_id: 42 },
+      isLoading: false,
+      error: null,
+    })
+
+    renderWithProviders(<ArtistShowsList artistId={42} />)
+    expect(screen.getByTestId('show-row-1')).toBeInTheDocument()
+    expect(screen.getByTestId('show-row-2')).toBeInTheDocument()
+  })
+
+  it('switches to past tab on click', async () => {
+    const user = userEvent.setup()
+    // Return empty for both upcoming and past
+    mockUseArtistShows.mockReturnValue({
+      data: { shows: [], total: 0, artist_id: 42 },
+      isLoading: false,
+      error: null,
+    })
+
+    renderWithProviders(<ArtistShowsList artistId={42} />)
+
+    await user.click(screen.getByText('Past Shows'))
+
+    // After click, past tab hook should be called with enabled=true and upcoming with enabled=false
+    const calls = mockUseArtistShows.mock.calls
+    const lastCalls = calls.slice(-2)
+    const pastCall = lastCalls.find(
+      (c: unknown[]) => (c[0] as { timeFilter: string }).timeFilter === 'past'
+    )
+    expect(pastCall).toBeTruthy()
+    expect((pastCall![0] as { enabled: boolean }).enabled).toBe(true)
+  })
+
+  it('shows count indicator when there are more shows than displayed', () => {
+    const shows = [makeShow({ id: 1, title: 'Show One' })]
+    mockUseArtistShows.mockReturnValue({
+      data: { shows, total: 25, artist_id: 42 },
+      isLoading: false,
+      error: null,
+    })
+
+    renderWithProviders(<ArtistShowsList artistId={42} />)
+    expect(screen.getByText('Showing 1 of 25 shows')).toBeInTheDocument()
+  })
+
+  it('does not show count indicator when all shows displayed', () => {
+    const shows = [makeShow({ id: 1, title: 'Show One' })]
+    mockUseArtistShows.mockReturnValue({
+      data: { shows, total: 1, artist_id: 42 },
+      isLoading: false,
+      error: null,
+    })
+
+    renderWithProviders(<ArtistShowsList artistId={42} />)
+    expect(screen.queryByText(/Showing/)).not.toBeInTheDocument()
+  })
+
+  it('shows "No past shows" empty state on past tab', async () => {
+    const user = userEvent.setup()
+    mockUseArtistShows.mockReturnValue({
+      data: { shows: [], total: 0, artist_id: 42 },
+      isLoading: false,
+      error: null,
+    })
+
+    renderWithProviders(<ArtistShowsList artistId={42} />)
+    await user.click(screen.getByText('Past Shows'))
+
+    expect(screen.getByText('No past shows')).toBeInTheDocument()
+  })
+
+  it('applies custom className', () => {
+    mockUseArtistShows.mockReturnValue({
+      data: { shows: [], total: 0, artist_id: 42 },
+      isLoading: false,
+      error: null,
+    })
+
+    const { container } = renderWithProviders(
+      <ArtistShowsList artistId={42} className="custom-class" />
+    )
+    expect(container.firstChild).toHaveClass('custom-class')
+  })
+})

--- a/frontend/components/artists/ReportArtistButton.test.tsx
+++ b/frontend/components/artists/ReportArtistButton.test.tsx
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders } from '@/test/utils'
+
+// Mock next/navigation
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/artists/test-artist',
+}))
+
+// Mock auth context
+const mockAuthContext = vi.fn()
+vi.mock('@/lib/context/AuthContext', () => ({
+  useAuthContext: () => mockAuthContext(),
+}))
+
+// Mock artist reports hook
+const mockMyReport = vi.fn()
+vi.mock('@/lib/hooks/useArtistReports', () => ({
+  useMyArtistReport: (artistId: number | string | null) => mockMyReport(artistId),
+  useReportArtist: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+  }),
+}))
+
+// Mock the dialog components
+vi.mock('./ReportArtistDialog', () => ({
+  ReportArtistDialog: ({
+    open,
+    artistName,
+  }: {
+    open: boolean
+    artistName: string
+    artistId: number
+    onOpenChange: (open: boolean) => void
+  }) =>
+    open ? <div data-testid="report-dialog">Report {artistName}</div> : null,
+}))
+
+vi.mock('@/components/auth/LoginPromptDialog', () => ({
+  LoginPromptDialog: ({
+    open,
+    title,
+  }: {
+    open: boolean
+    title: string
+    description: string
+    returnTo: string
+    onOpenChange: (open: boolean) => void
+  }) =>
+    open ? <div data-testid="login-prompt">{title}</div> : null,
+}))
+
+import { ReportArtistButton } from './ReportArtistButton'
+
+describe('ReportArtistButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuthContext.mockReturnValue({
+      isAuthenticated: false,
+    })
+    mockMyReport.mockReturnValue({
+      data: { report: null },
+      isLoading: false,
+    })
+  })
+
+  it('renders "Report Issue" button for unauthenticated user', () => {
+    renderWithProviders(
+      <ReportArtistButton artistId={1} artistName="Test Artist" />
+    )
+    expect(screen.getByText('Report Issue')).toBeInTheDocument()
+  })
+
+  it('renders "Report Issue" button for authenticated user without report', () => {
+    mockAuthContext.mockReturnValue({ isAuthenticated: true })
+    mockMyReport.mockReturnValue({
+      data: { report: null },
+      isLoading: false,
+    })
+
+    renderWithProviders(
+      <ReportArtistButton artistId={1} artistName="Test Artist" />
+    )
+    expect(screen.getByText('Report Issue')).toBeInTheDocument()
+  })
+
+  it('shows "Reported" disabled button when user has already reported', () => {
+    mockAuthContext.mockReturnValue({ isAuthenticated: true })
+    mockMyReport.mockReturnValue({
+      data: {
+        report: {
+          id: 1,
+          artist_id: 1,
+          report_type: 'inaccurate',
+          status: 'pending',
+        },
+      },
+      isLoading: false,
+    })
+
+    renderWithProviders(
+      <ReportArtistButton artistId={1} artistName="Test Artist" />
+    )
+    const button = screen.getByText('Reported')
+    expect(button).toBeInTheDocument()
+    expect(button.closest('button')).toBeDisabled()
+  })
+
+  it('opens login prompt for unauthenticated user on click', async () => {
+    const user = userEvent.setup()
+    mockAuthContext.mockReturnValue({ isAuthenticated: false })
+
+    renderWithProviders(
+      <ReportArtistButton artistId={1} artistName="Test Artist" />
+    )
+
+    await user.click(screen.getByText('Report Issue'))
+    expect(screen.getByTestId('login-prompt')).toBeInTheDocument()
+    expect(screen.getByText('Sign in to report')).toBeInTheDocument()
+  })
+
+  it('opens report dialog for authenticated user on click', async () => {
+    const user = userEvent.setup()
+    mockAuthContext.mockReturnValue({ isAuthenticated: true })
+    mockMyReport.mockReturnValue({
+      data: { report: null },
+      isLoading: false,
+    })
+
+    renderWithProviders(
+      <ReportArtistButton artistId={1} artistName="Test Artist" />
+    )
+
+    await user.click(screen.getByText('Report Issue'))
+    expect(screen.getByTestId('report-dialog')).toBeInTheDocument()
+    expect(screen.getByText('Report Test Artist')).toBeInTheDocument()
+  })
+
+  it('disables button while loading report status', () => {
+    mockAuthContext.mockReturnValue({ isAuthenticated: true })
+    // When data is undefined (loading), myReport?.report is undefined,
+    // and undefined !== null evaluates to true, so hasReported is true
+    // and the "Reported" disabled button is shown instead
+    mockMyReport.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    })
+
+    renderWithProviders(
+      <ReportArtistButton artistId={1} artistName="Test Artist" />
+    )
+    // During loading, the component shows "Reported" (disabled) because
+    // hasReported defaults to true when data hasn't loaded yet
+    const button = screen.getByText('Reported').closest('button')
+    expect(button).toBeDisabled()
+  })
+
+  it('does not query report status when unauthenticated', () => {
+    mockAuthContext.mockReturnValue({ isAuthenticated: false })
+
+    renderWithProviders(
+      <ReportArtistButton artistId={1} artistName="Test Artist" />
+    )
+    // Should be called with null when unauthenticated
+    expect(mockMyReport).toHaveBeenCalledWith(null)
+  })
+
+  it('queries report status when authenticated', () => {
+    mockAuthContext.mockReturnValue({ isAuthenticated: true })
+    mockMyReport.mockReturnValue({
+      data: { report: null },
+      isLoading: false,
+    })
+
+    renderWithProviders(
+      <ReportArtistButton artistId={42} artistName="Test Artist" />
+    )
+    expect(mockMyReport).toHaveBeenCalledWith(42)
+  })
+
+  it('has the correct title attribute', () => {
+    renderWithProviders(
+      <ReportArtistButton artistId={1} artistName="Test Artist" />
+    )
+    expect(
+      screen.getByTitle('Report an issue with this artist')
+    ).toBeInTheDocument()
+  })
+})

--- a/frontend/components/artists/ReportArtistDialog.test.tsx
+++ b/frontend/components/artists/ReportArtistDialog.test.tsx
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders } from '@/test/utils'
+
+// Mock the report artist hook
+const mockMutate = vi.fn()
+const mockReportMutation = vi.fn()
+vi.mock('@/lib/hooks/useArtistReports', () => ({
+  useReportArtist: () => mockReportMutation(),
+}))
+
+import { ReportArtistDialog } from './ReportArtistDialog'
+
+describe('ReportArtistDialog', () => {
+  const defaultProps = {
+    artistId: 1,
+    artistName: 'Test Artist',
+    open: true,
+    onOpenChange: vi.fn(),
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockMutate.mockReset()
+    mockReportMutation.mockReturnValue({
+      mutate: mockMutate,
+      isPending: false,
+      isError: false,
+      error: null,
+    })
+  })
+
+  it('renders dialog title', () => {
+    renderWithProviders(<ReportArtistDialog {...defaultProps} />)
+    expect(screen.getByText('Report Issue')).toBeInTheDocument()
+  })
+
+  it('shows artist name in description', () => {
+    renderWithProviders(<ReportArtistDialog {...defaultProps} />)
+    expect(
+      screen.getByText(/Report an issue with "Test Artist"/)
+    ).toBeInTheDocument()
+  })
+
+  it('renders report type options', () => {
+    renderWithProviders(<ReportArtistDialog {...defaultProps} />)
+    expect(screen.getByText('Inaccurate Info')).toBeInTheDocument()
+    expect(screen.getByText('Removal Request')).toBeInTheDocument()
+  })
+
+  it('renders option descriptions', () => {
+    renderWithProviders(<ReportArtistDialog {...defaultProps} />)
+    expect(
+      screen.getByText('Some information on this page is incorrect')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("I'm the artist and want this page removed")
+    ).toBeInTheDocument()
+  })
+
+  it('shows submit button disabled when no type selected', () => {
+    renderWithProviders(<ReportArtistDialog {...defaultProps} />)
+    expect(screen.getByText('Submit Report').closest('button')).toBeDisabled()
+  })
+
+  it('shows details textarea after selecting a type', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<ReportArtistDialog {...defaultProps} />)
+
+    // Details should not be visible before selection
+    expect(screen.queryByLabelText(/Additional details/)).not.toBeInTheDocument()
+
+    await user.click(screen.getByText('Inaccurate Info'))
+
+    expect(screen.getByLabelText(/Additional details/)).toBeInTheDocument()
+  })
+
+  it('shows "(recommended)" hint for inaccurate type', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<ReportArtistDialog {...defaultProps} />)
+
+    await user.click(screen.getByText('Inaccurate Info'))
+
+    expect(screen.getByText(/recommended/)).toBeInTheDocument()
+  })
+
+  it('shows "(optional)" hint for removal request type', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<ReportArtistDialog {...defaultProps} />)
+
+    await user.click(screen.getByText('Removal Request'))
+
+    expect(screen.getByText(/optional/)).toBeInTheDocument()
+  })
+
+  it('enables submit button when type is selected', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<ReportArtistDialog {...defaultProps} />)
+
+    await user.click(screen.getByText('Inaccurate Info'))
+
+    expect(
+      screen.getByText('Submit Report').closest('button')
+    ).not.toBeDisabled()
+  })
+
+  it('calls mutate with correct params on submit', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<ReportArtistDialog {...defaultProps} />)
+
+    await user.click(screen.getByText('Inaccurate Info'))
+    const textarea = screen.getByPlaceholderText(
+      'Please describe what information is incorrect...'
+    )
+    await user.type(textarea, 'Wrong hometown listed')
+    await user.click(screen.getByText('Submit Report'))
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      {
+        artistId: 1,
+        reportType: 'inaccurate',
+        details: 'Wrong hometown listed',
+      },
+      expect.objectContaining({ onSuccess: expect.any(Function) })
+    )
+  })
+
+  it('submits with undefined details when field is empty', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<ReportArtistDialog {...defaultProps} />)
+
+    await user.click(screen.getByText('Removal Request'))
+    await user.click(screen.getByText('Submit Report'))
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      {
+        artistId: 1,
+        reportType: 'removal_request',
+        details: undefined,
+      },
+      expect.objectContaining({ onSuccess: expect.any(Function) })
+    )
+  })
+
+  it('renders cancel button', () => {
+    renderWithProviders(<ReportArtistDialog {...defaultProps} />)
+    expect(screen.getByText('Cancel')).toBeInTheDocument()
+  })
+
+  it('calls onOpenChange(false) on cancel click', async () => {
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+    renderWithProviders(
+      <ReportArtistDialog {...defaultProps} onOpenChange={onOpenChange} />
+    )
+
+    await user.click(screen.getByText('Cancel'))
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('shows error message when mutation fails', () => {
+    mockReportMutation.mockReturnValue({
+      mutate: mockMutate,
+      isPending: false,
+      isError: true,
+      error: new Error('Server error'),
+    })
+
+    renderWithProviders(<ReportArtistDialog {...defaultProps} />)
+    expect(screen.getByText('Server error')).toBeInTheDocument()
+  })
+
+  it('shows generic error when no error message', () => {
+    mockReportMutation.mockReturnValue({
+      mutate: mockMutate,
+      isPending: false,
+      isError: true,
+      error: null,
+    })
+
+    renderWithProviders(<ReportArtistDialog {...defaultProps} />)
+    expect(
+      screen.getByText('Failed to submit report. Please try again.')
+    ).toBeInTheDocument()
+  })
+
+  it('shows loading state when submitting', async () => {
+    const user = userEvent.setup()
+    mockReportMutation.mockReturnValue({
+      mutate: mockMutate,
+      isPending: true,
+      isError: false,
+      error: null,
+    })
+
+    renderWithProviders(<ReportArtistDialog {...defaultProps} />)
+
+    expect(screen.getByText('Submitting...')).toBeInTheDocument()
+    // Cancel should be disabled during submission
+    expect(screen.getByText('Cancel').closest('button')).toBeDisabled()
+  })
+
+  it('does not render dialog when closed', () => {
+    renderWithProviders(
+      <ReportArtistDialog {...defaultProps} open={false} />
+    )
+    expect(screen.queryByText('Report Issue')).not.toBeInTheDocument()
+  })
+
+  it('has prompt label "What\'s the issue?"', () => {
+    renderWithProviders(<ReportArtistDialog {...defaultProps} />)
+    expect(screen.getByText("What's the issue?")).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- Adds 82 new unit tests across 6 test files for `components/artists/` (previously 9.67% coverage, 362 tracked lines)
- Covers: ArtistDetail, ArtistList, ArtistListSkeleton, ArtistShowsList, ReportArtistButton, ReportArtistDialog
- No source changes — test files only

## Test plan
- [x] All 97 tests pass (82 new + 15 existing): `bun run test:run -- components/artists/`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)