### PR TITLE
feat: add festival service, handlers, and API routes (PSY-25)

### DIFF
--- a/backend/internal/api/handlers/festival.go
+++ b/backend/internal/api/handlers/festival.go
@@ -1,0 +1,852 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"psychic-homily-backend/internal/api/middleware"
+	apperrors "psychic-homily-backend/internal/errors"
+	"psychic-homily-backend/internal/logger"
+	"psychic-homily-backend/internal/services"
+)
+
+type FestivalHandler struct {
+	festivalService services.FestivalServiceInterface
+	artistService   services.ArtistServiceInterface
+	auditLogService services.AuditLogServiceInterface
+}
+
+func NewFestivalHandler(festivalService services.FestivalServiceInterface, artistService services.ArtistServiceInterface, auditLogService services.AuditLogServiceInterface) *FestivalHandler {
+	return &FestivalHandler{
+		festivalService: festivalService,
+		artistService:   artistService,
+		auditLogService: auditLogService,
+	}
+}
+
+// ============================================================================
+// List Festivals
+// ============================================================================
+
+// ListFestivalsRequest represents the request for listing festivals
+type ListFestivalsRequest struct {
+	City       string `query:"city" required:"false" doc:"Filter by city" example:"Phoenix"`
+	State      string `query:"state" required:"false" doc:"Filter by state" example:"AZ"`
+	Year       int    `query:"year" required:"false" doc:"Filter by edition year" example:"2026"`
+	Status     string `query:"status" required:"false" doc:"Filter by status (announced, confirmed, cancelled, completed)" example:"confirmed"`
+	SeriesSlug string `query:"series_slug" required:"false" doc:"Filter by festival series slug" example:"m3f"`
+}
+
+// ListFestivalsResponse represents the response for listing festivals
+type ListFestivalsResponse struct {
+	Body struct {
+		Festivals []*services.FestivalListResponse `json:"festivals" doc:"List of festivals"`
+		Count     int                              `json:"count" doc:"Number of festivals"`
+	}
+}
+
+// ListFestivalsHandler handles GET /festivals
+func (h *FestivalHandler) ListFestivalsHandler(ctx context.Context, req *ListFestivalsRequest) (*ListFestivalsResponse, error) {
+	filters := make(map[string]interface{})
+
+	if req.City != "" {
+		filters["city"] = req.City
+	}
+	if req.State != "" {
+		filters["state"] = req.State
+	}
+	if req.Year > 0 {
+		filters["year"] = req.Year
+	}
+	if req.Status != "" {
+		filters["status"] = req.Status
+	}
+	if req.SeriesSlug != "" {
+		filters["series_slug"] = req.SeriesSlug
+	}
+
+	festivals, err := h.festivalService.ListFestivals(filters)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Failed to fetch festivals", err)
+	}
+
+	resp := &ListFestivalsResponse{}
+	resp.Body.Festivals = festivals
+	resp.Body.Count = len(festivals)
+
+	return resp, nil
+}
+
+// ============================================================================
+// Get Festival
+// ============================================================================
+
+// GetFestivalRequest represents the request for getting a single festival
+type GetFestivalRequest struct {
+	FestivalID string `path:"festival_id" doc:"Festival ID or slug" example:"m3f-2026"`
+}
+
+// GetFestivalResponse represents the response for the get festival endpoint
+type GetFestivalResponse struct {
+	Body *services.FestivalDetailResponse
+}
+
+// GetFestivalHandler handles GET /festivals/{festival_id}
+func (h *FestivalHandler) GetFestivalHandler(ctx context.Context, req *GetFestivalRequest) (*GetFestivalResponse, error) {
+	var festival *services.FestivalDetailResponse
+	var err error
+
+	// Try to parse as numeric ID first
+	if id, parseErr := strconv.ParseUint(req.FestivalID, 10, 32); parseErr == nil {
+		festival, err = h.festivalService.GetFestival(uint(id))
+	} else {
+		// Fall back to slug lookup
+		festival, err = h.festivalService.GetFestivalBySlug(req.FestivalID)
+	}
+
+	if err != nil {
+		var festivalErr *apperrors.FestivalError
+		if errors.As(err, &festivalErr) && festivalErr.Code == apperrors.CodeFestivalNotFound {
+			return nil, huma.Error404NotFound("Festival not found")
+		}
+		return nil, huma.Error500InternalServerError("Failed to fetch festival", err)
+	}
+
+	return &GetFestivalResponse{Body: festival}, nil
+}
+
+// ============================================================================
+// Create Festival
+// ============================================================================
+
+// CreateFestivalRequest represents the request for creating a festival
+type CreateFestivalRequest struct {
+	Body struct {
+		Name         string  `json:"name" doc:"Festival name" example:"M3F Festival"`
+		SeriesSlug   string  `json:"series_slug" doc:"Festival series slug (for recurring festivals)" example:"m3f"`
+		EditionYear  int     `json:"edition_year" doc:"Festival edition year" example:"2026"`
+		Description  *string `json:"description,omitempty" required:"false" doc:"Description"`
+		LocationName *string `json:"location_name,omitempty" required:"false" doc:"Location name" example:"Margaret T. Hance Park"`
+		City         *string `json:"city,omitempty" required:"false" doc:"City" example:"Phoenix"`
+		State        *string `json:"state,omitempty" required:"false" doc:"State" example:"AZ"`
+		Country      *string `json:"country,omitempty" required:"false" doc:"Country" example:"US"`
+		StartDate    string  `json:"start_date" doc:"Start date (YYYY-MM-DD)" example:"2026-03-06"`
+		EndDate      string  `json:"end_date" doc:"End date (YYYY-MM-DD)" example:"2026-03-08"`
+		Website      *string `json:"website,omitempty" required:"false" doc:"Website URL"`
+		TicketURL    *string `json:"ticket_url,omitempty" required:"false" doc:"Ticket URL"`
+		FlyerURL     *string `json:"flyer_url,omitempty" required:"false" doc:"Flyer URL"`
+		Status       string  `json:"status,omitempty" required:"false" doc:"Status (announced, confirmed, cancelled, completed)" example:"announced"`
+	}
+}
+
+// CreateFestivalResponse represents the response for creating a festival
+type CreateFestivalResponse struct {
+	Body *services.FestivalDetailResponse
+}
+
+// CreateFestivalHandler handles POST /festivals
+func (h *FestivalHandler) CreateFestivalHandler(ctx context.Context, req *CreateFestivalRequest) (*CreateFestivalResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	// Verify admin access
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil || !user.IsAdmin {
+		return nil, huma.Error403Forbidden("Admin access required")
+	}
+
+	if req.Body.Name == "" {
+		return nil, huma.Error400BadRequest("Name is required")
+	}
+	if req.Body.SeriesSlug == "" {
+		return nil, huma.Error400BadRequest("Series slug is required")
+	}
+	if req.Body.EditionYear == 0 {
+		return nil, huma.Error400BadRequest("Edition year is required")
+	}
+	if req.Body.StartDate == "" {
+		return nil, huma.Error400BadRequest("Start date is required")
+	}
+	if req.Body.EndDate == "" {
+		return nil, huma.Error400BadRequest("End date is required")
+	}
+
+	serviceReq := &services.CreateFestivalRequest{
+		Name:         req.Body.Name,
+		SeriesSlug:   req.Body.SeriesSlug,
+		EditionYear:  req.Body.EditionYear,
+		Description:  req.Body.Description,
+		LocationName: req.Body.LocationName,
+		City:         req.Body.City,
+		State:        req.Body.State,
+		Country:      req.Body.Country,
+		StartDate:    req.Body.StartDate,
+		EndDate:      req.Body.EndDate,
+		Website:      req.Body.Website,
+		TicketURL:    req.Body.TicketURL,
+		FlyerURL:     req.Body.FlyerURL,
+		Status:       req.Body.Status,
+	}
+
+	festival, err := h.festivalService.CreateFestival(serviceReq)
+	if err != nil {
+		logger.FromContext(ctx).Error("create_festival_failed",
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to create festival (request_id: %s)", requestID),
+		)
+	}
+
+	// Audit log (fire and forget)
+	if h.auditLogService != nil {
+		go func() {
+			h.auditLogService.LogAction(user.ID, "create_festival", "festival", festival.ID, nil)
+		}()
+	}
+
+	logger.FromContext(ctx).Info("festival_created",
+		"festival_id", festival.ID,
+		"admin_id", user.ID,
+		"request_id", requestID,
+	)
+
+	return &CreateFestivalResponse{Body: festival}, nil
+}
+
+// ============================================================================
+// Update Festival
+// ============================================================================
+
+// UpdateFestivalRequest represents the request for updating a festival
+type UpdateFestivalRequest struct {
+	FestivalID string `path:"festival_id" doc:"Festival ID" example:"1"`
+	Body       struct {
+		Name         *string `json:"name,omitempty" required:"false" doc:"Festival name"`
+		SeriesSlug   *string `json:"series_slug,omitempty" required:"false" doc:"Series slug"`
+		EditionYear  *int    `json:"edition_year,omitempty" required:"false" doc:"Edition year"`
+		Description  *string `json:"description,omitempty" required:"false" doc:"Description"`
+		LocationName *string `json:"location_name,omitempty" required:"false" doc:"Location name"`
+		City         *string `json:"city,omitempty" required:"false" doc:"City"`
+		State        *string `json:"state,omitempty" required:"false" doc:"State"`
+		Country      *string `json:"country,omitempty" required:"false" doc:"Country"`
+		StartDate    *string `json:"start_date,omitempty" required:"false" doc:"Start date (YYYY-MM-DD)"`
+		EndDate      *string `json:"end_date,omitempty" required:"false" doc:"End date (YYYY-MM-DD)"`
+		Website      *string `json:"website,omitempty" required:"false" doc:"Website URL"`
+		TicketURL    *string `json:"ticket_url,omitempty" required:"false" doc:"Ticket URL"`
+		FlyerURL     *string `json:"flyer_url,omitempty" required:"false" doc:"Flyer URL"`
+		Status       *string `json:"status,omitempty" required:"false" doc:"Status"`
+	}
+}
+
+// UpdateFestivalResponse represents the response for updating a festival
+type UpdateFestivalResponse struct {
+	Body *services.FestivalDetailResponse
+}
+
+// UpdateFestivalHandler handles PUT /festivals/{festival_id}
+func (h *FestivalHandler) UpdateFestivalHandler(ctx context.Context, req *UpdateFestivalRequest) (*UpdateFestivalResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	// Verify admin access
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil || !user.IsAdmin {
+		return nil, huma.Error403Forbidden("Admin access required")
+	}
+
+	festivalID, err := h.resolveFestivalID(req.FestivalID)
+	if err != nil {
+		return nil, err
+	}
+
+	serviceReq := &services.UpdateFestivalRequest{
+		Name:         req.Body.Name,
+		SeriesSlug:   req.Body.SeriesSlug,
+		EditionYear:  req.Body.EditionYear,
+		Description:  req.Body.Description,
+		LocationName: req.Body.LocationName,
+		City:         req.Body.City,
+		State:        req.Body.State,
+		Country:      req.Body.Country,
+		StartDate:    req.Body.StartDate,
+		EndDate:      req.Body.EndDate,
+		Website:      req.Body.Website,
+		TicketURL:    req.Body.TicketURL,
+		FlyerURL:     req.Body.FlyerURL,
+		Status:       req.Body.Status,
+	}
+
+	festival, err := h.festivalService.UpdateFestival(festivalID, serviceReq)
+	if err != nil {
+		var festivalErr *apperrors.FestivalError
+		if errors.As(err, &festivalErr) && festivalErr.Code == apperrors.CodeFestivalNotFound {
+			return nil, huma.Error404NotFound("Festival not found")
+		}
+		logger.FromContext(ctx).Error("update_festival_failed",
+			"festival_id", festivalID,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to update festival (request_id: %s)", requestID),
+		)
+	}
+
+	// Audit log (fire and forget)
+	if h.auditLogService != nil {
+		go func() {
+			h.auditLogService.LogAction(user.ID, "edit_festival", "festival", festivalID, nil)
+		}()
+	}
+
+	logger.FromContext(ctx).Info("festival_updated",
+		"festival_id", festivalID,
+		"admin_id", user.ID,
+		"request_id", requestID,
+	)
+
+	return &UpdateFestivalResponse{Body: festival}, nil
+}
+
+// ============================================================================
+// Delete Festival
+// ============================================================================
+
+// DeleteFestivalRequest represents the request for deleting a festival
+type DeleteFestivalRequest struct {
+	FestivalID string `path:"festival_id" doc:"Festival ID" example:"1"`
+}
+
+// DeleteFestivalHandler handles DELETE /festivals/{festival_id}
+func (h *FestivalHandler) DeleteFestivalHandler(ctx context.Context, req *DeleteFestivalRequest) (*struct{}, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	// Verify admin access
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil || !user.IsAdmin {
+		return nil, huma.Error403Forbidden("Admin access required")
+	}
+
+	festivalID, err := h.resolveFestivalID(req.FestivalID)
+	if err != nil {
+		return nil, err
+	}
+
+	err = h.festivalService.DeleteFestival(festivalID)
+	if err != nil {
+		var festivalErr *apperrors.FestivalError
+		if errors.As(err, &festivalErr) && festivalErr.Code == apperrors.CodeFestivalNotFound {
+			return nil, huma.Error404NotFound("Festival not found")
+		}
+		logger.FromContext(ctx).Error("delete_festival_failed",
+			"festival_id", festivalID,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to delete festival (request_id: %s)", requestID),
+		)
+	}
+
+	// Audit log (fire and forget)
+	if h.auditLogService != nil {
+		go func() {
+			h.auditLogService.LogAction(user.ID, "delete_festival", "festival", festivalID, nil)
+		}()
+	}
+
+	logger.FromContext(ctx).Info("festival_deleted",
+		"festival_id", festivalID,
+		"admin_id", user.ID,
+		"request_id", requestID,
+	)
+
+	return nil, nil
+}
+
+// ============================================================================
+// Festival Lineup (Artists)
+// ============================================================================
+
+// GetFestivalArtistsRequest represents the request for getting a festival's artists
+type GetFestivalArtistsRequest struct {
+	FestivalID string `path:"festival_id" doc:"Festival ID or slug" example:"m3f-2026"`
+	DayDate    string `query:"day_date" required:"false" doc:"Filter by day (YYYY-MM-DD)" example:"2026-03-07"`
+}
+
+// GetFestivalArtistsResponse represents the response for the festival lineup endpoint
+type GetFestivalArtistsResponse struct {
+	Body struct {
+		Artists []*services.FestivalArtistResponse `json:"artists" doc:"List of artists in lineup"`
+		Count   int                                `json:"count" doc:"Number of artists"`
+	}
+}
+
+// GetFestivalArtistsHandler handles GET /festivals/{festival_id}/artists
+func (h *FestivalHandler) GetFestivalArtistsHandler(ctx context.Context, req *GetFestivalArtistsRequest) (*GetFestivalArtistsResponse, error) {
+	festivalID, err := h.resolveFestivalID(req.FestivalID)
+	if err != nil {
+		return nil, err
+	}
+
+	var dayDate *string
+	if req.DayDate != "" {
+		dayDate = &req.DayDate
+	}
+
+	artists, err := h.festivalService.GetFestivalArtists(festivalID, dayDate)
+	if err != nil {
+		var festivalErr *apperrors.FestivalError
+		if errors.As(err, &festivalErr) && festivalErr.Code == apperrors.CodeFestivalNotFound {
+			return nil, huma.Error404NotFound("Festival not found")
+		}
+		return nil, huma.Error500InternalServerError("Failed to fetch festival lineup", err)
+	}
+
+	resp := &GetFestivalArtistsResponse{}
+	resp.Body.Artists = artists
+	resp.Body.Count = len(artists)
+
+	return resp, nil
+}
+
+// AddFestivalArtistRequest represents the request for adding an artist to a festival
+type AddFestivalArtistHandlerRequest struct {
+	FestivalID string `path:"festival_id" doc:"Festival ID" example:"1"`
+	Body       struct {
+		ArtistID    uint    `json:"artist_id" doc:"Artist ID"`
+		BillingTier string  `json:"billing_tier,omitempty" required:"false" doc:"Billing tier (headliner, sub_headliner, mid_card, undercard, local, dj, host)" example:"headliner"`
+		Position    int     `json:"position,omitempty" required:"false" doc:"Position within tier (0-based)" example:"0"`
+		DayDate     *string `json:"day_date,omitempty" required:"false" doc:"Day date (YYYY-MM-DD)" example:"2026-03-07"`
+		Stage       *string `json:"stage,omitempty" required:"false" doc:"Stage name" example:"Main Stage"`
+		SetTime     *string `json:"set_time,omitempty" required:"false" doc:"Set time (HH:MM:SS)" example:"21:00:00"`
+		VenueID     *uint   `json:"venue_id,omitempty" required:"false" doc:"Venue ID (for multi-venue festivals)"`
+	}
+}
+
+// AddFestivalArtistResponse represents the response for adding an artist to a festival
+type AddFestivalArtistHandlerResponse struct {
+	Body *services.FestivalArtistResponse
+}
+
+// AddFestivalArtistHandler handles POST /festivals/{festival_id}/artists
+func (h *FestivalHandler) AddFestivalArtistHandler(ctx context.Context, req *AddFestivalArtistHandlerRequest) (*AddFestivalArtistHandlerResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	// Verify admin access
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil || !user.IsAdmin {
+		return nil, huma.Error403Forbidden("Admin access required")
+	}
+
+	festivalID, err := strconv.ParseUint(req.FestivalID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid festival ID")
+	}
+
+	if req.Body.ArtistID == 0 {
+		return nil, huma.Error400BadRequest("Artist ID is required")
+	}
+
+	serviceReq := &services.AddFestivalArtistRequest{
+		ArtistID:    req.Body.ArtistID,
+		BillingTier: req.Body.BillingTier,
+		Position:    req.Body.Position,
+		DayDate:     req.Body.DayDate,
+		Stage:       req.Body.Stage,
+		SetTime:     req.Body.SetTime,
+		VenueID:     req.Body.VenueID,
+	}
+
+	artist, err := h.festivalService.AddFestivalArtist(uint(festivalID), serviceReq)
+	if err != nil {
+		var festivalErr *apperrors.FestivalError
+		if errors.As(err, &festivalErr) && festivalErr.Code == apperrors.CodeFestivalNotFound {
+			return nil, huma.Error404NotFound("Festival not found")
+		}
+		if err.Error() == "artist not found" {
+			return nil, huma.Error404NotFound("Artist not found")
+		}
+		logger.FromContext(ctx).Error("add_festival_artist_failed",
+			"festival_id", festivalID,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to add artist to festival (request_id: %s)", requestID),
+		)
+	}
+
+	// Audit log (fire and forget)
+	if h.auditLogService != nil {
+		go func() {
+			h.auditLogService.LogAction(user.ID, "add_festival_artist", "festival", uint(festivalID), nil)
+		}()
+	}
+
+	return &AddFestivalArtistHandlerResponse{Body: artist}, nil
+}
+
+// UpdateFestivalArtistHandlerRequest represents the request for updating a festival artist
+type UpdateFestivalArtistHandlerRequest struct {
+	FestivalID string `path:"festival_id" doc:"Festival ID" example:"1"`
+	ArtistID   string `path:"artist_id" doc:"Artist ID" example:"1"`
+	Body       struct {
+		BillingTier *string `json:"billing_tier,omitempty" required:"false" doc:"Billing tier"`
+		Position    *int    `json:"position,omitempty" required:"false" doc:"Position within tier"`
+		DayDate     *string `json:"day_date,omitempty" required:"false" doc:"Day date (YYYY-MM-DD)"`
+		Stage       *string `json:"stage,omitempty" required:"false" doc:"Stage name"`
+		SetTime     *string `json:"set_time,omitempty" required:"false" doc:"Set time (HH:MM:SS)"`
+		VenueID     *uint   `json:"venue_id,omitempty" required:"false" doc:"Venue ID"`
+	}
+}
+
+// UpdateFestivalArtistHandlerResponse represents the response for updating a festival artist
+type UpdateFestivalArtistHandlerResponse struct {
+	Body *services.FestivalArtistResponse
+}
+
+// UpdateFestivalArtistHandler handles PUT /festivals/{festival_id}/artists/{artist_id}
+func (h *FestivalHandler) UpdateFestivalArtistHandler(ctx context.Context, req *UpdateFestivalArtistHandlerRequest) (*UpdateFestivalArtistHandlerResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	// Verify admin access
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil || !user.IsAdmin {
+		return nil, huma.Error403Forbidden("Admin access required")
+	}
+
+	festivalID, err := strconv.ParseUint(req.FestivalID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid festival ID")
+	}
+
+	artistID, err := strconv.ParseUint(req.ArtistID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid artist ID")
+	}
+
+	serviceReq := &services.UpdateFestivalArtistRequest{
+		BillingTier: req.Body.BillingTier,
+		Position:    req.Body.Position,
+		DayDate:     req.Body.DayDate,
+		Stage:       req.Body.Stage,
+		SetTime:     req.Body.SetTime,
+		VenueID:     req.Body.VenueID,
+	}
+
+	artist, err := h.festivalService.UpdateFestivalArtist(uint(festivalID), uint(artistID), serviceReq)
+	if err != nil {
+		if err.Error() == "artist not found in festival lineup" {
+			return nil, huma.Error404NotFound("Artist not found in festival lineup")
+		}
+		logger.FromContext(ctx).Error("update_festival_artist_failed",
+			"festival_id", festivalID,
+			"artist_id", artistID,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to update festival artist (request_id: %s)", requestID),
+		)
+	}
+
+	// Audit log (fire and forget)
+	if h.auditLogService != nil {
+		go func() {
+			h.auditLogService.LogAction(user.ID, "update_festival_artist", "festival", uint(festivalID), nil)
+		}()
+	}
+
+	return &UpdateFestivalArtistHandlerResponse{Body: artist}, nil
+}
+
+// RemoveFestivalArtistRequest represents the request for removing an artist from a festival
+type RemoveFestivalArtistRequest struct {
+	FestivalID string `path:"festival_id" doc:"Festival ID" example:"1"`
+	ArtistID   string `path:"artist_id" doc:"Artist ID" example:"1"`
+}
+
+// RemoveFestivalArtistHandler handles DELETE /festivals/{festival_id}/artists/{artist_id}
+func (h *FestivalHandler) RemoveFestivalArtistHandler(ctx context.Context, req *RemoveFestivalArtistRequest) (*struct{}, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	// Verify admin access
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil || !user.IsAdmin {
+		return nil, huma.Error403Forbidden("Admin access required")
+	}
+
+	festivalID, err := strconv.ParseUint(req.FestivalID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid festival ID")
+	}
+
+	artistID, err := strconv.ParseUint(req.ArtistID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid artist ID")
+	}
+
+	err = h.festivalService.RemoveFestivalArtist(uint(festivalID), uint(artistID))
+	if err != nil {
+		if err.Error() == "artist not found in festival lineup" {
+			return nil, huma.Error404NotFound("Artist not found in festival lineup")
+		}
+		logger.FromContext(ctx).Error("remove_festival_artist_failed",
+			"festival_id", festivalID,
+			"artist_id", artistID,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to remove artist from festival (request_id: %s)", requestID),
+		)
+	}
+
+	// Audit log (fire and forget)
+	if h.auditLogService != nil {
+		go func() {
+			h.auditLogService.LogAction(user.ID, "remove_festival_artist", "festival", uint(festivalID), nil)
+		}()
+	}
+
+	return nil, nil
+}
+
+// ============================================================================
+// Festival Venues
+// ============================================================================
+
+// GetFestivalVenuesRequest represents the request for getting a festival's venues
+type GetFestivalVenuesRequest struct {
+	FestivalID string `path:"festival_id" doc:"Festival ID or slug" example:"m3f-2026"`
+}
+
+// GetFestivalVenuesResponse represents the response for the festival venues endpoint
+type GetFestivalVenuesResponse struct {
+	Body struct {
+		Venues []*services.FestivalVenueResponse `json:"venues" doc:"List of venues"`
+		Count  int                               `json:"count" doc:"Number of venues"`
+	}
+}
+
+// GetFestivalVenuesHandler handles GET /festivals/{festival_id}/venues
+func (h *FestivalHandler) GetFestivalVenuesHandler(ctx context.Context, req *GetFestivalVenuesRequest) (*GetFestivalVenuesResponse, error) {
+	festivalID, err := h.resolveFestivalID(req.FestivalID)
+	if err != nil {
+		return nil, err
+	}
+
+	venues, err := h.festivalService.GetFestivalVenues(festivalID)
+	if err != nil {
+		var festivalErr *apperrors.FestivalError
+		if errors.As(err, &festivalErr) && festivalErr.Code == apperrors.CodeFestivalNotFound {
+			return nil, huma.Error404NotFound("Festival not found")
+		}
+		return nil, huma.Error500InternalServerError("Failed to fetch festival venues", err)
+	}
+
+	resp := &GetFestivalVenuesResponse{}
+	resp.Body.Venues = venues
+	resp.Body.Count = len(venues)
+
+	return resp, nil
+}
+
+// AddFestivalVenueHandlerRequest represents the request for adding a venue to a festival
+type AddFestivalVenueHandlerRequest struct {
+	FestivalID string `path:"festival_id" doc:"Festival ID" example:"1"`
+	Body       struct {
+		VenueID   uint `json:"venue_id" doc:"Venue ID"`
+		IsPrimary bool `json:"is_primary,omitempty" required:"false" doc:"Whether this is the primary venue"`
+	}
+}
+
+// AddFestivalVenueHandlerResponse represents the response for adding a venue to a festival
+type AddFestivalVenueHandlerResponse struct {
+	Body *services.FestivalVenueResponse
+}
+
+// AddFestivalVenueHandler handles POST /festivals/{festival_id}/venues
+func (h *FestivalHandler) AddFestivalVenueHandler(ctx context.Context, req *AddFestivalVenueHandlerRequest) (*AddFestivalVenueHandlerResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	// Verify admin access
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil || !user.IsAdmin {
+		return nil, huma.Error403Forbidden("Admin access required")
+	}
+
+	festivalID, err := strconv.ParseUint(req.FestivalID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid festival ID")
+	}
+
+	if req.Body.VenueID == 0 {
+		return nil, huma.Error400BadRequest("Venue ID is required")
+	}
+
+	serviceReq := &services.AddFestivalVenueRequest{
+		VenueID:   req.Body.VenueID,
+		IsPrimary: req.Body.IsPrimary,
+	}
+
+	venue, err := h.festivalService.AddFestivalVenue(uint(festivalID), serviceReq)
+	if err != nil {
+		var festivalErr *apperrors.FestivalError
+		if errors.As(err, &festivalErr) && festivalErr.Code == apperrors.CodeFestivalNotFound {
+			return nil, huma.Error404NotFound("Festival not found")
+		}
+		if err.Error() == "venue not found" {
+			return nil, huma.Error404NotFound("Venue not found")
+		}
+		logger.FromContext(ctx).Error("add_festival_venue_failed",
+			"festival_id", festivalID,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to add venue to festival (request_id: %s)", requestID),
+		)
+	}
+
+	// Audit log (fire and forget)
+	if h.auditLogService != nil {
+		go func() {
+			h.auditLogService.LogAction(user.ID, "add_festival_venue", "festival", uint(festivalID), nil)
+		}()
+	}
+
+	return &AddFestivalVenueHandlerResponse{Body: venue}, nil
+}
+
+// RemoveFestivalVenueRequest represents the request for removing a venue from a festival
+type RemoveFestivalVenueRequest struct {
+	FestivalID string `path:"festival_id" doc:"Festival ID" example:"1"`
+	VenueID    string `path:"venue_id" doc:"Venue ID" example:"1"`
+}
+
+// RemoveFestivalVenueHandler handles DELETE /festivals/{festival_id}/venues/{venue_id}
+func (h *FestivalHandler) RemoveFestivalVenueHandler(ctx context.Context, req *RemoveFestivalVenueRequest) (*struct{}, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	// Verify admin access
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil || !user.IsAdmin {
+		return nil, huma.Error403Forbidden("Admin access required")
+	}
+
+	festivalID, err := strconv.ParseUint(req.FestivalID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid festival ID")
+	}
+
+	venueID, err := strconv.ParseUint(req.VenueID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid venue ID")
+	}
+
+	err = h.festivalService.RemoveFestivalVenue(uint(festivalID), uint(venueID))
+	if err != nil {
+		if err.Error() == "venue not found in festival" {
+			return nil, huma.Error404NotFound("Venue not found in festival")
+		}
+		logger.FromContext(ctx).Error("remove_festival_venue_failed",
+			"festival_id", festivalID,
+			"venue_id", venueID,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to remove venue from festival (request_id: %s)", requestID),
+		)
+	}
+
+	// Audit log (fire and forget)
+	if h.auditLogService != nil {
+		go func() {
+			h.auditLogService.LogAction(user.ID, "remove_festival_venue", "festival", uint(festivalID), nil)
+		}()
+	}
+
+	return nil, nil
+}
+
+// ============================================================================
+// Artist Festivals (cross-entity query)
+// ============================================================================
+
+// GetArtistFestivalsRequest represents the request for getting an artist's festivals
+type GetArtistFestivalsRequest struct {
+	ArtistID string `path:"artist_id" doc:"Artist ID or slug" example:"the-national"`
+}
+
+// GetArtistFestivalsResponse represents the response for the artist festivals endpoint
+type GetArtistFestivalsResponse struct {
+	Body struct {
+		Festivals []*services.ArtistFestivalListResponse `json:"festivals" doc:"List of festivals"`
+		Count     int                                    `json:"count" doc:"Number of festivals"`
+	}
+}
+
+// GetArtistFestivalsHandler handles GET /artists/{artist_id}/festivals
+func (h *FestivalHandler) GetArtistFestivalsHandler(ctx context.Context, req *GetArtistFestivalsRequest) (*GetArtistFestivalsResponse, error) {
+	// Resolve artist ID from numeric ID or slug
+	var artistID uint
+	if id, parseErr := strconv.ParseUint(req.ArtistID, 10, 32); parseErr == nil {
+		artistID = uint(id)
+	} else {
+		// Look up by slug to get the ID
+		artist, err := h.artistService.GetArtistBySlug(req.ArtistID)
+		if err != nil {
+			var artistErr *apperrors.ArtistError
+			if errors.As(err, &artistErr) && artistErr.Code == apperrors.CodeArtistNotFound {
+				return nil, huma.Error404NotFound("Artist not found")
+			}
+			return nil, huma.Error500InternalServerError("Failed to fetch artist", err)
+		}
+		artistID = artist.ID
+	}
+
+	festivals, err := h.festivalService.GetFestivalsForArtist(artistID)
+	if err != nil {
+		var artistErr *apperrors.ArtistError
+		if errors.As(err, &artistErr) && artistErr.Code == apperrors.CodeArtistNotFound {
+			return nil, huma.Error404NotFound("Artist not found")
+		}
+		return nil, huma.Error500InternalServerError("Failed to fetch festivals", err)
+	}
+
+	resp := &GetArtistFestivalsResponse{}
+	resp.Body.Festivals = festivals
+	resp.Body.Count = len(festivals)
+
+	return resp, nil
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+// resolveFestivalID tries to parse the ID as a number first, then falls back to slug lookup
+func (h *FestivalHandler) resolveFestivalID(idOrSlug string) (uint, error) {
+	if id, parseErr := strconv.ParseUint(idOrSlug, 10, 32); parseErr == nil {
+		return uint(id), nil
+	}
+
+	// Fall back to slug lookup
+	festival, err := h.festivalService.GetFestivalBySlug(idOrSlug)
+	if err != nil {
+		var festivalErr *apperrors.FestivalError
+		if errors.As(err, &festivalErr) && festivalErr.Code == apperrors.CodeFestivalNotFound {
+			return 0, huma.Error404NotFound("Festival not found")
+		}
+		return 0, huma.Error500InternalServerError("Failed to fetch festival", err)
+	}
+
+	return festival.ID, nil
+}

--- a/backend/internal/api/handlers/festival_integration_test.go
+++ b/backend/internal/api/handlers/festival_integration_test.go
@@ -1,0 +1,615 @@
+package handlers
+
+import (
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"psychic-homily-backend/internal/services"
+	"psychic-homily-backend/internal/utils"
+)
+
+type FestivalHandlerIntegrationSuite struct {
+	suite.Suite
+	deps    *handlerIntegrationDeps
+	handler *FestivalHandler
+}
+
+func (s *FestivalHandlerIntegrationSuite) SetupSuite() {
+	s.deps = setupHandlerIntegrationDeps(s.T())
+	s.handler = NewFestivalHandler(s.deps.festivalService, s.deps.artistService, s.deps.auditLogService)
+}
+
+func (s *FestivalHandlerIntegrationSuite) TearDownTest() {
+	cleanupTables(s.deps.db)
+}
+
+func (s *FestivalHandlerIntegrationSuite) TearDownSuite() {
+	if s.deps.container != nil {
+		s.deps.container.Terminate(s.deps.ctx)
+	}
+}
+
+func TestFestivalHandlerIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	suite.Run(t, new(FestivalHandlerIntegrationSuite))
+}
+
+// --- Helpers ---
+
+var handlerFestivalCounter int64
+
+func (s *FestivalHandlerIntegrationSuite) createFestivalViaService(name string) *services.FestivalDetailResponse {
+	city := "Phoenix"
+	state := "AZ"
+	counter := atomic.AddInt64(&handlerFestivalCounter, 1)
+	resp, err := s.deps.festivalService.CreateFestival(&services.CreateFestivalRequest{
+		Name:        name,
+		SeriesSlug:  utils.GenerateArtistSlug(name),
+		EditionYear: 2026 + int(counter),
+		City:        &city,
+		State:       &state,
+		StartDate:   "2026-03-06",
+		EndDate:     "2026-03-08",
+	})
+	s.Require().NoError(err)
+	return resp
+}
+
+func (s *FestivalHandlerIntegrationSuite) createArtistViaArtistService(name string) uint {
+	resp, err := s.deps.artistService.CreateArtist(&services.CreateArtistRequest{Name: name})
+	s.Require().NoError(err)
+	return resp.ID
+}
+
+func (s *FestivalHandlerIntegrationSuite) createVenueViaDB(name, city, state string) uint {
+	venue := createVerifiedVenue(s.deps.db, name, city, state)
+	return venue.ID
+}
+
+// --- ListFestivalsHandler ---
+
+func (s *FestivalHandlerIntegrationSuite) TestListFestivals_Success() {
+	s.createFestivalViaService("Festival A")
+	s.createFestivalViaService("Festival B")
+
+	req := &ListFestivalsRequest{}
+	resp, err := s.handler.ListFestivalsHandler(s.deps.ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.GreaterOrEqual(resp.Body.Count, 2)
+}
+
+func (s *FestivalHandlerIntegrationSuite) TestListFestivals_Empty() {
+	req := &ListFestivalsRequest{}
+	resp, err := s.handler.ListFestivalsHandler(s.deps.ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal(0, resp.Body.Count)
+}
+
+func (s *FestivalHandlerIntegrationSuite) TestListFestivals_FilterByStatus() {
+	s.deps.festivalService.CreateFestival(&services.CreateFestivalRequest{
+		Name: "Confirmed Fest", SeriesSlug: "cf", EditionYear: 2026,
+		StartDate: "2026-03-01", EndDate: "2026-03-03", Status: "confirmed",
+	})
+	s.deps.festivalService.CreateFestival(&services.CreateFestivalRequest{
+		Name: "Announced Fest", SeriesSlug: "af", EditionYear: 2026,
+		StartDate: "2026-04-01", EndDate: "2026-04-03",
+	})
+
+	req := &ListFestivalsRequest{Status: "confirmed"}
+	resp, err := s.handler.ListFestivalsHandler(s.deps.ctx, req)
+	s.NoError(err)
+	s.Equal(1, resp.Body.Count)
+	s.Equal("Confirmed Fest", resp.Body.Festivals[0].Name)
+}
+
+// --- GetFestivalHandler ---
+
+func (s *FestivalHandlerIntegrationSuite) TestGetFestival_ByID() {
+	festival := s.createFestivalViaService("Test Festival")
+
+	req := &GetFestivalRequest{FestivalID: fmt.Sprintf("%d", festival.ID)}
+	resp, err := s.handler.GetFestivalHandler(s.deps.ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal("Test Festival", resp.Body.Name)
+}
+
+func (s *FestivalHandlerIntegrationSuite) TestGetFestival_BySlug() {
+	s.createFestivalViaService("Slug Festival")
+
+	req := &GetFestivalRequest{FestivalID: "slug-festival"}
+	resp, err := s.handler.GetFestivalHandler(s.deps.ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal("Slug Festival", resp.Body.Name)
+}
+
+func (s *FestivalHandlerIntegrationSuite) TestGetFestival_NotFound() {
+	req := &GetFestivalRequest{FestivalID: "99999"}
+	_, err := s.handler.GetFestivalHandler(s.deps.ctx, req)
+	assertHumaError(s.T(), err, 404)
+}
+
+// --- CreateFestivalHandler ---
+
+func (s *FestivalHandlerIntegrationSuite) TestCreateFestival_AdminSuccess() {
+	admin := createAdminUser(s.deps.db)
+	ctx := ctxWithUser(admin)
+
+	req := &CreateFestivalRequest{}
+	req.Body.Name = "New Festival"
+	req.Body.SeriesSlug = "new-fest"
+	req.Body.EditionYear = 2026
+	req.Body.StartDate = "2026-06-01"
+	req.Body.EndDate = "2026-06-03"
+
+	resp, err := s.handler.CreateFestivalHandler(ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal("New Festival", resp.Body.Name)
+	s.Equal("new-fest", resp.Body.SeriesSlug)
+	s.Equal(2026, resp.Body.EditionYear)
+}
+
+func (s *FestivalHandlerIntegrationSuite) TestCreateFestival_NonAdminForbidden() {
+	user := createTestUser(s.deps.db)
+	ctx := ctxWithUser(user)
+
+	req := &CreateFestivalRequest{}
+	req.Body.Name = "Forbidden Festival"
+	req.Body.SeriesSlug = "forbidden"
+	req.Body.EditionYear = 2026
+	req.Body.StartDate = "2026-06-01"
+	req.Body.EndDate = "2026-06-03"
+
+	_, err := s.handler.CreateFestivalHandler(ctx, req)
+	assertHumaError(s.T(), err, 403)
+}
+
+func (s *FestivalHandlerIntegrationSuite) TestCreateFestival_NoAuth() {
+	req := &CreateFestivalRequest{}
+	req.Body.Name = "No Auth Festival"
+	req.Body.SeriesSlug = "no-auth"
+	req.Body.EditionYear = 2026
+	req.Body.StartDate = "2026-06-01"
+	req.Body.EndDate = "2026-06-03"
+
+	_, err := s.handler.CreateFestivalHandler(s.deps.ctx, req)
+	assertHumaError(s.T(), err, 403)
+}
+
+func (s *FestivalHandlerIntegrationSuite) TestCreateFestival_EmptyName() {
+	admin := createAdminUser(s.deps.db)
+	ctx := ctxWithUser(admin)
+
+	req := &CreateFestivalRequest{}
+	req.Body.Name = ""
+	req.Body.SeriesSlug = "empty"
+	req.Body.EditionYear = 2026
+	req.Body.StartDate = "2026-06-01"
+	req.Body.EndDate = "2026-06-03"
+
+	_, err := s.handler.CreateFestivalHandler(ctx, req)
+	assertHumaError(s.T(), err, 400)
+}
+
+func (s *FestivalHandlerIntegrationSuite) TestCreateFestival_MissingSeriesSlug() {
+	admin := createAdminUser(s.deps.db)
+	ctx := ctxWithUser(admin)
+
+	req := &CreateFestivalRequest{}
+	req.Body.Name = "Missing Series"
+	req.Body.SeriesSlug = ""
+	req.Body.EditionYear = 2026
+	req.Body.StartDate = "2026-06-01"
+	req.Body.EndDate = "2026-06-03"
+
+	_, err := s.handler.CreateFestivalHandler(ctx, req)
+	assertHumaError(s.T(), err, 400)
+}
+
+// --- UpdateFestivalHandler ---
+
+func (s *FestivalHandlerIntegrationSuite) TestUpdateFestival_Success() {
+	admin := createAdminUser(s.deps.db)
+	festival := s.createFestivalViaService("Original Festival")
+
+	ctx := ctxWithUser(admin)
+	newName := "Updated Festival"
+	req := &UpdateFestivalRequest{FestivalID: fmt.Sprintf("%d", festival.ID)}
+	req.Body.Name = &newName
+
+	resp, err := s.handler.UpdateFestivalHandler(ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal("Updated Festival", resp.Body.Name)
+}
+
+func (s *FestivalHandlerIntegrationSuite) TestUpdateFestival_NotFound() {
+	admin := createAdminUser(s.deps.db)
+	ctx := ctxWithUser(admin)
+	newName := "New Name"
+	req := &UpdateFestivalRequest{FestivalID: "99999"}
+	req.Body.Name = &newName
+
+	_, err := s.handler.UpdateFestivalHandler(ctx, req)
+	assertHumaError(s.T(), err, 404)
+}
+
+func (s *FestivalHandlerIntegrationSuite) TestUpdateFestival_NonAdminForbidden() {
+	user := createTestUser(s.deps.db)
+	festival := s.createFestivalViaService("Forbidden Update")
+
+	ctx := ctxWithUser(user)
+	newName := "Hacked Name"
+	req := &UpdateFestivalRequest{FestivalID: fmt.Sprintf("%d", festival.ID)}
+	req.Body.Name = &newName
+
+	_, err := s.handler.UpdateFestivalHandler(ctx, req)
+	assertHumaError(s.T(), err, 403)
+}
+
+// --- DeleteFestivalHandler ---
+
+func (s *FestivalHandlerIntegrationSuite) TestDeleteFestival_Success() {
+	admin := createAdminUser(s.deps.db)
+	festival := s.createFestivalViaService("Deletable Festival")
+
+	ctx := ctxWithUser(admin)
+	req := &DeleteFestivalRequest{FestivalID: fmt.Sprintf("%d", festival.ID)}
+	_, err := s.handler.DeleteFestivalHandler(ctx, req)
+	s.NoError(err)
+
+	// Verify festival is gone
+	getReq := &GetFestivalRequest{FestivalID: fmt.Sprintf("%d", festival.ID)}
+	_, err = s.handler.GetFestivalHandler(s.deps.ctx, getReq)
+	assertHumaError(s.T(), err, 404)
+}
+
+func (s *FestivalHandlerIntegrationSuite) TestDeleteFestival_NotFound() {
+	admin := createAdminUser(s.deps.db)
+	ctx := ctxWithUser(admin)
+	req := &DeleteFestivalRequest{FestivalID: "99999"}
+
+	_, err := s.handler.DeleteFestivalHandler(ctx, req)
+	assertHumaError(s.T(), err, 404)
+}
+
+func (s *FestivalHandlerIntegrationSuite) TestDeleteFestival_NonAdminForbidden() {
+	user := createTestUser(s.deps.db)
+	festival := s.createFestivalViaService("Protected Festival")
+
+	ctx := ctxWithUser(user)
+	req := &DeleteFestivalRequest{FestivalID: fmt.Sprintf("%d", festival.ID)}
+
+	_, err := s.handler.DeleteFestivalHandler(ctx, req)
+	assertHumaError(s.T(), err, 403)
+}
+
+// --- GetFestivalArtistsHandler ---
+
+func (s *FestivalHandlerIntegrationSuite) TestGetFestivalArtists_Success() {
+	festival := s.createFestivalViaService("Lineup Festival")
+	artistID := s.createArtistViaArtistService("Lineup Artist")
+
+	s.deps.festivalService.AddFestivalArtist(festival.ID, &services.AddFestivalArtistRequest{
+		ArtistID:    artistID,
+		BillingTier: "headliner",
+	})
+
+	req := &GetFestivalArtistsRequest{FestivalID: fmt.Sprintf("%d", festival.ID)}
+	resp, err := s.handler.GetFestivalArtistsHandler(s.deps.ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal(1, resp.Body.Count)
+	s.Equal("Lineup Artist", resp.Body.Artists[0].ArtistName)
+	s.Equal("headliner", resp.Body.Artists[0].BillingTier)
+}
+
+func (s *FestivalHandlerIntegrationSuite) TestGetFestivalArtists_BySlug() {
+	s.createFestivalViaService("Slug Lineup Festival")
+
+	req := &GetFestivalArtistsRequest{FestivalID: "slug-lineup-festival"}
+	resp, err := s.handler.GetFestivalArtistsHandler(s.deps.ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal(0, resp.Body.Count)
+}
+
+func (s *FestivalHandlerIntegrationSuite) TestGetFestivalArtists_NotFound() {
+	req := &GetFestivalArtistsRequest{FestivalID: "99999"}
+	_, err := s.handler.GetFestivalArtistsHandler(s.deps.ctx, req)
+	assertHumaError(s.T(), err, 404)
+}
+
+// --- AddFestivalArtistHandler ---
+
+func (s *FestivalHandlerIntegrationSuite) TestAddFestivalArtist_Success() {
+	admin := createAdminUser(s.deps.db)
+	festival := s.createFestivalViaService("Add Artist Festival")
+	artistID := s.createArtistViaArtistService("Added Artist")
+
+	ctx := ctxWithUser(admin)
+	req := &AddFestivalArtistHandlerRequest{FestivalID: fmt.Sprintf("%d", festival.ID)}
+	req.Body.ArtistID = artistID
+	req.Body.BillingTier = "headliner"
+
+	resp, err := s.handler.AddFestivalArtistHandler(ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal("Added Artist", resp.Body.ArtistName)
+	s.Equal("headliner", resp.Body.BillingTier)
+}
+
+func (s *FestivalHandlerIntegrationSuite) TestAddFestivalArtist_NonAdminForbidden() {
+	user := createTestUser(s.deps.db)
+	festival := s.createFestivalViaService("Protected Add Festival")
+	artistID := s.createArtistViaArtistService("Forbidden Artist")
+
+	ctx := ctxWithUser(user)
+	req := &AddFestivalArtistHandlerRequest{FestivalID: fmt.Sprintf("%d", festival.ID)}
+	req.Body.ArtistID = artistID
+
+	_, err := s.handler.AddFestivalArtistHandler(ctx, req)
+	assertHumaError(s.T(), err, 403)
+}
+
+func (s *FestivalHandlerIntegrationSuite) TestAddFestivalArtist_MissingArtistID() {
+	admin := createAdminUser(s.deps.db)
+	festival := s.createFestivalViaService("Missing Artist ID Festival")
+
+	ctx := ctxWithUser(admin)
+	req := &AddFestivalArtistHandlerRequest{FestivalID: fmt.Sprintf("%d", festival.ID)}
+	req.Body.ArtistID = 0
+
+	_, err := s.handler.AddFestivalArtistHandler(ctx, req)
+	assertHumaError(s.T(), err, 400)
+}
+
+// --- UpdateFestivalArtistHandler ---
+
+func (s *FestivalHandlerIntegrationSuite) TestUpdateFestivalArtist_Success() {
+	admin := createAdminUser(s.deps.db)
+	festival := s.createFestivalViaService("Update Artist Festival")
+	artistID := s.createArtistViaArtistService("Promoted Artist")
+
+	s.deps.festivalService.AddFestivalArtist(festival.ID, &services.AddFestivalArtistRequest{
+		ArtistID:    artistID,
+		BillingTier: "undercard",
+	})
+
+	ctx := ctxWithUser(admin)
+	newTier := "headliner"
+	req := &UpdateFestivalArtistHandlerRequest{
+		FestivalID: fmt.Sprintf("%d", festival.ID),
+		ArtistID:   fmt.Sprintf("%d", artistID),
+	}
+	req.Body.BillingTier = &newTier
+
+	resp, err := s.handler.UpdateFestivalArtistHandler(ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal("headliner", resp.Body.BillingTier)
+}
+
+func (s *FestivalHandlerIntegrationSuite) TestUpdateFestivalArtist_NotFound() {
+	admin := createAdminUser(s.deps.db)
+	ctx := ctxWithUser(admin)
+	newTier := "headliner"
+	req := &UpdateFestivalArtistHandlerRequest{
+		FestivalID: "99999",
+		ArtistID:   "99999",
+	}
+	req.Body.BillingTier = &newTier
+
+	_, err := s.handler.UpdateFestivalArtistHandler(ctx, req)
+	assertHumaError(s.T(), err, 404)
+}
+
+// --- RemoveFestivalArtistHandler ---
+
+func (s *FestivalHandlerIntegrationSuite) TestRemoveFestivalArtist_Success() {
+	admin := createAdminUser(s.deps.db)
+	festival := s.createFestivalViaService("Remove Artist Festival")
+	artistID := s.createArtistViaArtistService("Removed Artist")
+
+	s.deps.festivalService.AddFestivalArtist(festival.ID, &services.AddFestivalArtistRequest{
+		ArtistID: artistID,
+	})
+
+	ctx := ctxWithUser(admin)
+	req := &RemoveFestivalArtistRequest{
+		FestivalID: fmt.Sprintf("%d", festival.ID),
+		ArtistID:   fmt.Sprintf("%d", artistID),
+	}
+
+	_, err := s.handler.RemoveFestivalArtistHandler(ctx, req)
+	s.NoError(err)
+}
+
+func (s *FestivalHandlerIntegrationSuite) TestRemoveFestivalArtist_NonAdminForbidden() {
+	user := createTestUser(s.deps.db)
+	festival := s.createFestivalViaService("Protected Remove Festival")
+	artistID := s.createArtistViaArtistService("Protected Remove Artist")
+
+	s.deps.festivalService.AddFestivalArtist(festival.ID, &services.AddFestivalArtistRequest{
+		ArtistID: artistID,
+	})
+
+	ctx := ctxWithUser(user)
+	req := &RemoveFestivalArtistRequest{
+		FestivalID: fmt.Sprintf("%d", festival.ID),
+		ArtistID:   fmt.Sprintf("%d", artistID),
+	}
+
+	_, err := s.handler.RemoveFestivalArtistHandler(ctx, req)
+	assertHumaError(s.T(), err, 403)
+}
+
+// --- GetFestivalVenuesHandler ---
+
+func (s *FestivalHandlerIntegrationSuite) TestGetFestivalVenues_Success() {
+	festival := s.createFestivalViaService("Venue Festival")
+	venueID := s.createVenueViaDB("Test Venue", "Phoenix", "AZ")
+
+	s.deps.festivalService.AddFestivalVenue(festival.ID, &services.AddFestivalVenueRequest{
+		VenueID:   venueID,
+		IsPrimary: true,
+	})
+
+	req := &GetFestivalVenuesRequest{FestivalID: fmt.Sprintf("%d", festival.ID)}
+	resp, err := s.handler.GetFestivalVenuesHandler(s.deps.ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal(1, resp.Body.Count)
+	s.Equal("Test Venue", resp.Body.Venues[0].VenueName)
+	s.True(resp.Body.Venues[0].IsPrimary)
+}
+
+func (s *FestivalHandlerIntegrationSuite) TestGetFestivalVenues_NotFound() {
+	req := &GetFestivalVenuesRequest{FestivalID: "99999"}
+	_, err := s.handler.GetFestivalVenuesHandler(s.deps.ctx, req)
+	assertHumaError(s.T(), err, 404)
+}
+
+// --- AddFestivalVenueHandler ---
+
+func (s *FestivalHandlerIntegrationSuite) TestAddFestivalVenue_Success() {
+	admin := createAdminUser(s.deps.db)
+	festival := s.createFestivalViaService("Add Venue Festival")
+	venueID := s.createVenueViaDB("Added Venue", "Phoenix", "AZ")
+
+	ctx := ctxWithUser(admin)
+	req := &AddFestivalVenueHandlerRequest{FestivalID: fmt.Sprintf("%d", festival.ID)}
+	req.Body.VenueID = venueID
+	req.Body.IsPrimary = true
+
+	resp, err := s.handler.AddFestivalVenueHandler(ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal("Added Venue", resp.Body.VenueName)
+	s.True(resp.Body.IsPrimary)
+}
+
+func (s *FestivalHandlerIntegrationSuite) TestAddFestivalVenue_NonAdminForbidden() {
+	user := createTestUser(s.deps.db)
+	festival := s.createFestivalViaService("Protected Venue Festival")
+	venueID := s.createVenueViaDB("Protected Venue", "Phoenix", "AZ")
+
+	ctx := ctxWithUser(user)
+	req := &AddFestivalVenueHandlerRequest{FestivalID: fmt.Sprintf("%d", festival.ID)}
+	req.Body.VenueID = venueID
+
+	_, err := s.handler.AddFestivalVenueHandler(ctx, req)
+	assertHumaError(s.T(), err, 403)
+}
+
+func (s *FestivalHandlerIntegrationSuite) TestAddFestivalVenue_MissingVenueID() {
+	admin := createAdminUser(s.deps.db)
+	festival := s.createFestivalViaService("Missing Venue ID Festival")
+
+	ctx := ctxWithUser(admin)
+	req := &AddFestivalVenueHandlerRequest{FestivalID: fmt.Sprintf("%d", festival.ID)}
+	req.Body.VenueID = 0
+
+	_, err := s.handler.AddFestivalVenueHandler(ctx, req)
+	assertHumaError(s.T(), err, 400)
+}
+
+// --- RemoveFestivalVenueHandler ---
+
+func (s *FestivalHandlerIntegrationSuite) TestRemoveFestivalVenue_Success() {
+	admin := createAdminUser(s.deps.db)
+	festival := s.createFestivalViaService("Remove Venue Festival")
+	venueID := s.createVenueViaDB("Removable Venue", "Phoenix", "AZ")
+
+	s.deps.festivalService.AddFestivalVenue(festival.ID, &services.AddFestivalVenueRequest{
+		VenueID: venueID,
+	})
+
+	ctx := ctxWithUser(admin)
+	req := &RemoveFestivalVenueRequest{
+		FestivalID: fmt.Sprintf("%d", festival.ID),
+		VenueID:    fmt.Sprintf("%d", venueID),
+	}
+
+	_, err := s.handler.RemoveFestivalVenueHandler(ctx, req)
+	s.NoError(err)
+}
+
+func (s *FestivalHandlerIntegrationSuite) TestRemoveFestivalVenue_NonAdminForbidden() {
+	user := createTestUser(s.deps.db)
+	festival := s.createFestivalViaService("Protected Remove Venue Festival")
+	venueID := s.createVenueViaDB("Protected Remove Venue", "Phoenix", "AZ")
+
+	s.deps.festivalService.AddFestivalVenue(festival.ID, &services.AddFestivalVenueRequest{
+		VenueID: venueID,
+	})
+
+	ctx := ctxWithUser(user)
+	req := &RemoveFestivalVenueRequest{
+		FestivalID: fmt.Sprintf("%d", festival.ID),
+		VenueID:    fmt.Sprintf("%d", venueID),
+	}
+
+	_, err := s.handler.RemoveFestivalVenueHandler(ctx, req)
+	assertHumaError(s.T(), err, 403)
+}
+
+// --- GetArtistFestivalsHandler ---
+
+func (s *FestivalHandlerIntegrationSuite) TestGetArtistFestivals_Success() {
+	festival := s.createFestivalViaService("Artist Fest History")
+	artistID := s.createArtistViaArtistService("Festival Artist")
+
+	s.deps.festivalService.AddFestivalArtist(festival.ID, &services.AddFestivalArtistRequest{
+		ArtistID:    artistID,
+		BillingTier: "headliner",
+	})
+
+	req := &GetArtistFestivalsRequest{ArtistID: fmt.Sprintf("%d", artistID)}
+	resp, err := s.handler.GetArtistFestivalsHandler(s.deps.ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal(1, resp.Body.Count)
+	s.Equal("Artist Fest History", resp.Body.Festivals[0].Name)
+	s.Equal("headliner", resp.Body.Festivals[0].BillingTier)
+}
+
+func (s *FestivalHandlerIntegrationSuite) TestGetArtistFestivals_BySlug() {
+	festival := s.createFestivalViaService("Slug Artist Festival")
+	artistID := s.createArtistViaArtistService("Slug Festival Artist")
+
+	s.deps.festivalService.AddFestivalArtist(festival.ID, &services.AddFestivalArtistRequest{
+		ArtistID: artistID,
+	})
+
+	req := &GetArtistFestivalsRequest{ArtistID: "slug-festival-artist"}
+	resp, err := s.handler.GetArtistFestivalsHandler(s.deps.ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal(1, resp.Body.Count)
+}
+
+func (s *FestivalHandlerIntegrationSuite) TestGetArtistFestivals_ArtistNotFound() {
+	req := &GetArtistFestivalsRequest{ArtistID: "99999"}
+	_, err := s.handler.GetArtistFestivalsHandler(s.deps.ctx, req)
+	assertHumaError(s.T(), err, 404)
+}
+
+func (s *FestivalHandlerIntegrationSuite) TestGetArtistFestivals_Empty() {
+	artistID := s.createArtistViaArtistService("No Festivals Artist")
+
+	req := &GetArtistFestivalsRequest{ArtistID: fmt.Sprintf("%d", artistID)}
+	resp, err := s.handler.GetArtistFestivalsHandler(s.deps.ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal(0, resp.Body.Count)
+}

--- a/backend/internal/api/handlers/handler_integration_helpers_test.go
+++ b/backend/internal/api/handlers/handler_integration_helpers_test.go
@@ -38,6 +38,7 @@ type handlerIntegrationDeps struct {
 	adminStatsService     *services.AdminStatsService
 	discoveryService      *services.DiscoveryService
 	artistService         *services.ArtistService
+	festivalService       *services.FestivalService
 	labelService          *services.LabelService
 	releaseService        *services.ReleaseService
 }
@@ -112,6 +113,7 @@ func setupHandlerIntegrationDeps(t *testing.T) *handlerIntegrationDeps {
 		adminStatsService:     services.NewAdminStatsService(db),
 		discoveryService:      services.NewDiscoveryService(db),
 		artistService:         services.NewArtistService(db),
+		festivalService:       services.NewFestivalService(db),
 		labelService:          services.NewLabelService(db),
 		releaseService:        services.NewReleaseService(db),
 	}
@@ -127,6 +129,9 @@ func cleanupTables(db *gorm.DB) {
 	_, _ = sqlDB.Exec("DELETE FROM show_reports")
 	_, _ = sqlDB.Exec("DELETE FROM user_bookmarks")
 	_, _ = sqlDB.Exec("DELETE FROM pending_venue_edits")
+	_, _ = sqlDB.Exec("DELETE FROM festival_artists")
+	_, _ = sqlDB.Exec("DELETE FROM festival_venues")
+	_, _ = sqlDB.Exec("DELETE FROM festivals")
 	_, _ = sqlDB.Exec("DELETE FROM release_labels")
 	_, _ = sqlDB.Exec("DELETE FROM artist_labels")
 	_, _ = sqlDB.Exec("DELETE FROM labels")

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -85,6 +85,7 @@ func SetupRoutes(router *chi.Mux, sc *services.ServiceContainer, cfg *config.Con
 	setupArtistRoutes(api, protectedGroup, sc)
 	setupReleaseRoutes(api, protectedGroup, sc)
 	setupLabelRoutes(api, protectedGroup, sc)
+	setupFestivalRoutes(api, protectedGroup, sc)
 	setupVenueRoutes(api, protectedGroup, sc)
 	setupCalendarRoutes(router, protectedGroup, sc, cfg)
 	setupSavedShowRoutes(protectedGroup, sc)
@@ -311,6 +312,27 @@ func setupLabelRoutes(api huma.API, protected *huma.Group, sc *services.ServiceC
 	huma.Post(protected, "/labels", labelHandler.CreateLabelHandler)
 	huma.Put(protected, "/labels/{label_id}", labelHandler.UpdateLabelHandler)
 	huma.Delete(protected, "/labels/{label_id}", labelHandler.DeleteLabelHandler)
+}
+
+func setupFestivalRoutes(api huma.API, protected *huma.Group, sc *services.ServiceContainer) {
+	festivalHandler := handlers.NewFestivalHandler(sc.Festival, sc.Artist, sc.AuditLog)
+
+	// Public festival endpoints
+	huma.Get(api, "/festivals", festivalHandler.ListFestivalsHandler)
+	huma.Get(api, "/festivals/{festival_id}", festivalHandler.GetFestivalHandler)
+	huma.Get(api, "/festivals/{festival_id}/artists", festivalHandler.GetFestivalArtistsHandler)
+	huma.Get(api, "/festivals/{festival_id}/venues", festivalHandler.GetFestivalVenuesHandler)
+	huma.Get(api, "/artists/{artist_id}/festivals", festivalHandler.GetArtistFestivalsHandler)
+
+	// Protected festival endpoints (admin-only checks inside handlers)
+	huma.Post(protected, "/festivals", festivalHandler.CreateFestivalHandler)
+	huma.Put(protected, "/festivals/{festival_id}", festivalHandler.UpdateFestivalHandler)
+	huma.Delete(protected, "/festivals/{festival_id}", festivalHandler.DeleteFestivalHandler)
+	huma.Post(protected, "/festivals/{festival_id}/artists", festivalHandler.AddFestivalArtistHandler)
+	huma.Put(protected, "/festivals/{festival_id}/artists/{artist_id}", festivalHandler.UpdateFestivalArtistHandler)
+	huma.Delete(protected, "/festivals/{festival_id}/artists/{artist_id}", festivalHandler.RemoveFestivalArtistHandler)
+	huma.Post(protected, "/festivals/{festival_id}/venues", festivalHandler.AddFestivalVenueHandler)
+	huma.Delete(protected, "/festivals/{festival_id}/venues/{venue_id}", festivalHandler.RemoveFestivalVenueHandler)
 }
 
 func setupVenueRoutes(api huma.API, protected *huma.Group, sc *services.ServiceContainer) {

--- a/backend/internal/errors/festival.go
+++ b/backend/internal/errors/festival.go
@@ -1,0 +1,50 @@
+package errors
+
+import (
+	"fmt"
+)
+
+// Festival error codes
+const (
+	CodeFestivalNotFound = "FESTIVAL_NOT_FOUND"
+	CodeFestivalExists   = "FESTIVAL_EXISTS"
+)
+
+// FestivalError represents a festival-related error with additional context.
+type FestivalError struct {
+	Code       string
+	Message    string
+	Internal   error
+	RequestID  string
+	FestivalID uint
+}
+
+// Error implements the error interface.
+func (e *FestivalError) Error() string {
+	if e.Internal != nil {
+		return fmt.Sprintf("%s: %s (internal: %v)", e.Code, e.Message, e.Internal)
+	}
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
+// Unwrap returns the internal error for errors.Is/As compatibility.
+func (e *FestivalError) Unwrap() error {
+	return e.Internal
+}
+
+// ErrFestivalNotFound creates a festival not found error.
+func ErrFestivalNotFound(festivalID uint) *FestivalError {
+	return &FestivalError{
+		Code:       CodeFestivalNotFound,
+		Message:    "Festival not found",
+		FestivalID: festivalID,
+	}
+}
+
+// ErrFestivalExists creates a festival-already-exists error.
+func ErrFestivalExists(name string) *FestivalError {
+	return &FestivalError{
+		Code:    CodeFestivalExists,
+		Message: fmt.Sprintf("Festival with name '%s' already exists", name),
+	}
+}

--- a/backend/internal/services/container.go
+++ b/backend/internal/services/container.go
@@ -20,6 +20,7 @@ type ServiceContainer struct {
 	Bookmark      *BookmarkService
 	Calendar      *CalendarService
 	FavoriteVenue *FavoriteVenueService
+	Festival      *FestivalService
 	Label         *LabelService
 	Release       *ReleaseService
 	SavedShow     *SavedShowService
@@ -70,6 +71,7 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 		Bookmark:      NewBookmarkService(database),
 		Calendar:      NewCalendarService(database, savedShow),
 		FavoriteVenue: NewFavoriteVenueService(database),
+		Festival:      NewFestivalService(database),
 		Label:         NewLabelService(database),
 		Release:       NewReleaseService(database),
 		SavedShow:     savedShow,

--- a/backend/internal/services/festival.go
+++ b/backend/internal/services/festival.go
@@ -1,0 +1,968 @@
+package services
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/db"
+	apperrors "psychic-homily-backend/internal/errors"
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/utils"
+)
+
+// FestivalService handles festival-related business logic
+type FestivalService struct {
+	db *gorm.DB
+}
+
+// NewFestivalService creates a new festival service
+func NewFestivalService(database *gorm.DB) *FestivalService {
+	if database == nil {
+		database = db.GetDB()
+	}
+	return &FestivalService{
+		db: database,
+	}
+}
+
+// CreateFestivalRequest represents the data needed to create a new festival
+type CreateFestivalRequest struct {
+	Name         string           `json:"name" validate:"required"`
+	SeriesSlug   string           `json:"series_slug" validate:"required"`
+	EditionYear  int              `json:"edition_year" validate:"required"`
+	Description  *string          `json:"description"`
+	LocationName *string          `json:"location_name"`
+	City         *string          `json:"city"`
+	State        *string          `json:"state"`
+	Country      *string          `json:"country"`
+	StartDate    string           `json:"start_date" validate:"required"`
+	EndDate      string           `json:"end_date" validate:"required"`
+	Website      *string          `json:"website"`
+	TicketURL    *string          `json:"ticket_url"`
+	FlyerURL     *string          `json:"flyer_url"`
+	Status       string           `json:"status"`
+	Social       *json.RawMessage `json:"social"`
+}
+
+// UpdateFestivalRequest represents the data that can be updated on a festival
+type UpdateFestivalRequest struct {
+	Name         *string          `json:"name"`
+	SeriesSlug   *string          `json:"series_slug"`
+	EditionYear  *int             `json:"edition_year"`
+	Description  *string          `json:"description"`
+	LocationName *string          `json:"location_name"`
+	City         *string          `json:"city"`
+	State        *string          `json:"state"`
+	Country      *string          `json:"country"`
+	StartDate    *string          `json:"start_date"`
+	EndDate      *string          `json:"end_date"`
+	Website      *string          `json:"website"`
+	TicketURL    *string          `json:"ticket_url"`
+	FlyerURL     *string          `json:"flyer_url"`
+	Status       *string          `json:"status"`
+	Social       *json.RawMessage `json:"social"`
+}
+
+// FestivalDetailResponse represents the festival data returned to clients
+type FestivalDetailResponse struct {
+	ID           uint             `json:"id"`
+	Name         string           `json:"name"`
+	Slug         string           `json:"slug"`
+	SeriesSlug   string           `json:"series_slug"`
+	EditionYear  int              `json:"edition_year"`
+	Description  *string          `json:"description"`
+	LocationName *string          `json:"location_name"`
+	City         *string          `json:"city"`
+	State        *string          `json:"state"`
+	Country      *string          `json:"country"`
+	StartDate    string           `json:"start_date"`
+	EndDate      string           `json:"end_date"`
+	Website      *string          `json:"website"`
+	TicketURL    *string          `json:"ticket_url"`
+	FlyerURL     *string          `json:"flyer_url"`
+	Status       string           `json:"status"`
+	Social       *json.RawMessage `json:"social"`
+	ArtistCount  int              `json:"artist_count"`
+	VenueCount   int              `json:"venue_count"`
+	CreatedAt    time.Time        `json:"created_at"`
+	UpdatedAt    time.Time        `json:"updated_at"`
+}
+
+// FestivalListResponse represents a festival in list views
+type FestivalListResponse struct {
+	ID          uint    `json:"id"`
+	Name        string  `json:"name"`
+	Slug        string  `json:"slug"`
+	SeriesSlug  string  `json:"series_slug"`
+	EditionYear int     `json:"edition_year"`
+	City        *string `json:"city"`
+	State       *string `json:"state"`
+	StartDate   string  `json:"start_date"`
+	EndDate     string  `json:"end_date"`
+	Status      string  `json:"status"`
+	ArtistCount int     `json:"artist_count"`
+	VenueCount  int     `json:"venue_count"`
+}
+
+// FestivalArtistResponse represents an artist on a festival lineup
+type FestivalArtistResponse struct {
+	ID          uint    `json:"id"`
+	ArtistID    uint    `json:"artist_id"`
+	ArtistSlug  string  `json:"artist_slug"`
+	ArtistName  string  `json:"artist_name"`
+	BillingTier string  `json:"billing_tier"`
+	Position    int     `json:"position"`
+	DayDate     *string `json:"day_date"`
+	Stage       *string `json:"stage"`
+	SetTime     *string `json:"set_time"`
+	VenueID     *uint   `json:"venue_id"`
+}
+
+// FestivalVenueResponse represents a venue at a festival
+type FestivalVenueResponse struct {
+	ID        uint   `json:"id"`
+	VenueID   uint   `json:"venue_id"`
+	VenueName string `json:"venue_name"`
+	VenueSlug string `json:"venue_slug"`
+	City      string `json:"city"`
+	State     string `json:"state"`
+	IsPrimary bool   `json:"is_primary"`
+}
+
+// ArtistFestivalListResponse represents a festival in an artist's festival history
+type ArtistFestivalListResponse struct {
+	FestivalListResponse
+	BillingTier string  `json:"billing_tier"`
+	DayDate     *string `json:"day_date"`
+	Stage       *string `json:"stage"`
+}
+
+// AddFestivalArtistRequest represents the data needed to add an artist to a festival
+type AddFestivalArtistRequest struct {
+	ArtistID    uint    `json:"artist_id" validate:"required"`
+	BillingTier string  `json:"billing_tier"`
+	Position    int     `json:"position"`
+	DayDate     *string `json:"day_date"`
+	Stage       *string `json:"stage"`
+	SetTime     *string `json:"set_time"`
+	VenueID     *uint   `json:"venue_id"`
+}
+
+// UpdateFestivalArtistRequest represents the data that can be updated on a festival artist
+type UpdateFestivalArtistRequest struct {
+	BillingTier *string `json:"billing_tier"`
+	Position    *int    `json:"position"`
+	DayDate     *string `json:"day_date"`
+	Stage       *string `json:"stage"`
+	SetTime     *string `json:"set_time"`
+	VenueID     *uint   `json:"venue_id"`
+}
+
+// AddFestivalVenueRequest represents the data needed to add a venue to a festival
+type AddFestivalVenueRequest struct {
+	VenueID   uint `json:"venue_id" validate:"required"`
+	IsPrimary bool `json:"is_primary"`
+}
+
+// CreateFestival creates a new festival
+func (s *FestivalService) CreateFestival(req *CreateFestivalRequest) (*FestivalDetailResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	// Generate unique slug from name
+	baseSlug := utils.GenerateArtistSlug(req.Name)
+	slug := utils.GenerateUniqueSlug(baseSlug, func(candidate string) bool {
+		var count int64
+		s.db.Model(&models.Festival{}).Where("slug = ?", candidate).Count(&count)
+		return count > 0
+	})
+
+	// Determine status, default to "announced"
+	status := models.FestivalStatus(req.Status)
+	if status == "" {
+		status = models.FestivalStatusAnnounced
+	}
+
+	festival := &models.Festival{
+		Name:         req.Name,
+		Slug:         slug,
+		SeriesSlug:   req.SeriesSlug,
+		EditionYear:  req.EditionYear,
+		Description:  req.Description,
+		LocationName: req.LocationName,
+		City:         req.City,
+		State:        req.State,
+		Country:      req.Country,
+		StartDate:    req.StartDate,
+		EndDate:      req.EndDate,
+		Website:      req.Website,
+		TicketURL:    req.TicketURL,
+		FlyerURL:     req.FlyerURL,
+		Status:       status,
+		Social:       req.Social,
+	}
+
+	if err := s.db.Create(festival).Error; err != nil {
+		return nil, fmt.Errorf("failed to create festival: %w", err)
+	}
+
+	return s.GetFestival(festival.ID)
+}
+
+// GetFestival retrieves a festival by ID
+func (s *FestivalService) GetFestival(festivalID uint) (*FestivalDetailResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var festival models.Festival
+	err := s.db.First(&festival, festivalID).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, apperrors.ErrFestivalNotFound(festivalID)
+		}
+		return nil, fmt.Errorf("failed to get festival: %w", err)
+	}
+
+	return s.buildDetailResponse(&festival)
+}
+
+// GetFestivalBySlug retrieves a festival by slug
+func (s *FestivalService) GetFestivalBySlug(slug string) (*FestivalDetailResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var festival models.Festival
+	err := s.db.Where("slug = ?", slug).First(&festival).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, apperrors.ErrFestivalNotFound(0)
+		}
+		return nil, fmt.Errorf("failed to get festival: %w", err)
+	}
+
+	return s.buildDetailResponse(&festival)
+}
+
+// ListFestivals retrieves festivals with optional filtering
+func (s *FestivalService) ListFestivals(filters map[string]interface{}) ([]*FestivalListResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	query := s.db.Model(&models.Festival{})
+
+	// Apply filters
+	if city, ok := filters["city"].(string); ok && city != "" {
+		query = query.Where("city = ?", city)
+	}
+	if state, ok := filters["state"].(string); ok && state != "" {
+		query = query.Where("state = ?", state)
+	}
+	if year, ok := filters["year"].(int); ok && year > 0 {
+		query = query.Where("edition_year = ?", year)
+	}
+	if status, ok := filters["status"].(string); ok && status != "" {
+		query = query.Where("status = ?", status)
+	}
+	if seriesSlug, ok := filters["series_slug"].(string); ok && seriesSlug != "" {
+		query = query.Where("series_slug = ?", seriesSlug)
+	}
+
+	// Order by start_date DESC, name ASC
+	query = query.Order("start_date DESC, name ASC")
+
+	var festivals []models.Festival
+	err := query.Find(&festivals).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to list festivals: %w", err)
+	}
+
+	// Batch-load artist counts and venue counts
+	festivalIDs := make([]uint, len(festivals))
+	for i, f := range festivals {
+		festivalIDs[i] = f.ID
+	}
+
+	artistCounts := make(map[uint]int)
+	venueCounts := make(map[uint]int)
+
+	if len(festivalIDs) > 0 {
+		type CountResult struct {
+			FestivalID uint
+			Count      int
+		}
+
+		// Artist counts
+		var aCounts []CountResult
+		s.db.Table("festival_artists").
+			Select("festival_id, COUNT(DISTINCT artist_id) as count").
+			Where("festival_id IN ?", festivalIDs).
+			Group("festival_id").
+			Find(&aCounts)
+		for _, c := range aCounts {
+			artistCounts[c.FestivalID] = c.Count
+		}
+
+		// Venue counts
+		var vCounts []CountResult
+		s.db.Table("festival_venues").
+			Select("festival_id, COUNT(DISTINCT venue_id) as count").
+			Where("festival_id IN ?", festivalIDs).
+			Group("festival_id").
+			Find(&vCounts)
+		for _, c := range vCounts {
+			venueCounts[c.FestivalID] = c.Count
+		}
+	}
+
+	// Build responses
+	responses := make([]*FestivalListResponse, len(festivals))
+	for i, festival := range festivals {
+		responses[i] = &FestivalListResponse{
+			ID:          festival.ID,
+			Name:        festival.Name,
+			Slug:        festival.Slug,
+			SeriesSlug:  festival.SeriesSlug,
+			EditionYear: festival.EditionYear,
+			City:        festival.City,
+			State:       festival.State,
+			StartDate:   formatDateString(festival.StartDate),
+			EndDate:     formatDateString(festival.EndDate),
+			Status:      string(festival.Status),
+			ArtistCount: artistCounts[festival.ID],
+			VenueCount:  venueCounts[festival.ID],
+		}
+	}
+
+	return responses, nil
+}
+
+// UpdateFestival updates an existing festival
+func (s *FestivalService) UpdateFestival(festivalID uint, req *UpdateFestivalRequest) (*FestivalDetailResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	// Check if festival exists
+	var festival models.Festival
+	err := s.db.First(&festival, festivalID).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, apperrors.ErrFestivalNotFound(festivalID)
+		}
+		return nil, fmt.Errorf("failed to get festival: %w", err)
+	}
+
+	updates := map[string]interface{}{}
+
+	if req.Name != nil {
+		updates["name"] = *req.Name
+		// Regenerate slug when name changes
+		baseSlug := utils.GenerateArtistSlug(*req.Name)
+		slug := utils.GenerateUniqueSlug(baseSlug, func(candidate string) bool {
+			var count int64
+			s.db.Model(&models.Festival{}).Where("slug = ? AND id != ?", candidate, festivalID).Count(&count)
+			return count > 0
+		})
+		updates["slug"] = slug
+	}
+	if req.SeriesSlug != nil {
+		updates["series_slug"] = *req.SeriesSlug
+	}
+	if req.EditionYear != nil {
+		updates["edition_year"] = *req.EditionYear
+	}
+	if req.Description != nil {
+		updates["description"] = *req.Description
+	}
+	if req.LocationName != nil {
+		updates["location_name"] = *req.LocationName
+	}
+	if req.City != nil {
+		updates["city"] = *req.City
+	}
+	if req.State != nil {
+		updates["state"] = *req.State
+	}
+	if req.Country != nil {
+		updates["country"] = *req.Country
+	}
+	if req.StartDate != nil {
+		updates["start_date"] = *req.StartDate
+	}
+	if req.EndDate != nil {
+		updates["end_date"] = *req.EndDate
+	}
+	if req.Website != nil {
+		updates["website"] = *req.Website
+	}
+	if req.TicketURL != nil {
+		updates["ticket_url"] = *req.TicketURL
+	}
+	if req.FlyerURL != nil {
+		updates["flyer_url"] = *req.FlyerURL
+	}
+	if req.Status != nil {
+		updates["status"] = *req.Status
+	}
+	if req.Social != nil {
+		updates["social"] = *req.Social
+	}
+
+	if len(updates) > 0 {
+		err = s.db.Model(&models.Festival{}).Where("id = ?", festivalID).Updates(updates).Error
+		if err != nil {
+			return nil, fmt.Errorf("failed to update festival: %w", err)
+		}
+	}
+
+	return s.GetFestival(festivalID)
+}
+
+// DeleteFestival deletes a festival
+func (s *FestivalService) DeleteFestival(festivalID uint) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	// Check if festival exists
+	var festival models.Festival
+	err := s.db.First(&festival, festivalID).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return apperrors.ErrFestivalNotFound(festivalID)
+		}
+		return fmt.Errorf("failed to get festival: %w", err)
+	}
+
+	// Delete the festival (cascades handle junction cleanup via FK)
+	err = s.db.Delete(&festival).Error
+	if err != nil {
+		return fmt.Errorf("failed to delete festival: %w", err)
+	}
+
+	return nil
+}
+
+// GetFestivalArtists retrieves the lineup for a festival
+func (s *FestivalService) GetFestivalArtists(festivalID uint, dayDate *string) ([]*FestivalArtistResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	// Verify festival exists
+	var festival models.Festival
+	if err := s.db.First(&festival, festivalID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, apperrors.ErrFestivalNotFound(festivalID)
+		}
+		return nil, fmt.Errorf("failed to get festival: %w", err)
+	}
+
+	query := s.db.Where("festival_id = ?", festivalID)
+	if dayDate != nil && *dayDate != "" {
+		query = query.Where("day_date = ?", *dayDate)
+	}
+
+	var festivalArtists []models.FestivalArtist
+	// Order: billing tier priority (headliner first via CASE), then position
+	err := query.Order(`
+		CASE billing_tier
+			WHEN 'headliner' THEN 1
+			WHEN 'sub_headliner' THEN 2
+			WHEN 'mid_card' THEN 3
+			WHEN 'undercard' THEN 4
+			WHEN 'local' THEN 5
+			WHEN 'dj' THEN 6
+			WHEN 'host' THEN 7
+			ELSE 8
+		END ASC, position ASC
+	`).Find(&festivalArtists).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to get festival artists: %w", err)
+	}
+
+	if len(festivalArtists) == 0 {
+		return []*FestivalArtistResponse{}, nil
+	}
+
+	// Batch-load artist details
+	artistIDs := make([]uint, len(festivalArtists))
+	for i, fa := range festivalArtists {
+		artistIDs[i] = fa.ArtistID
+	}
+
+	artistMap := make(map[uint]*models.Artist)
+	var artists []models.Artist
+	s.db.Where("id IN ?", artistIDs).Find(&artists)
+	for i := range artists {
+		artistMap[artists[i].ID] = &artists[i]
+	}
+
+	// Build responses
+	responses := make([]*FestivalArtistResponse, 0, len(festivalArtists))
+	for _, fa := range festivalArtists {
+		artistModel, ok := artistMap[fa.ArtistID]
+		if !ok {
+			continue
+		}
+		artistSlug := ""
+		if artistModel.Slug != nil {
+			artistSlug = *artistModel.Slug
+		}
+
+		resp := &FestivalArtistResponse{
+			ID:          fa.ID,
+			ArtistID:    fa.ArtistID,
+			ArtistSlug:  artistSlug,
+			ArtistName:  artistModel.Name,
+			BillingTier: string(fa.BillingTier),
+			Position:    fa.Position,
+			DayDate:     formatOptionalDateString(fa.DayDate),
+			Stage:       fa.Stage,
+			SetTime:     fa.SetTime,
+			VenueID:     fa.VenueID,
+		}
+		responses = append(responses, resp)
+	}
+
+	return responses, nil
+}
+
+// AddFestivalArtist adds an artist to a festival lineup
+func (s *FestivalService) AddFestivalArtist(festivalID uint, req *AddFestivalArtistRequest) (*FestivalArtistResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	// Verify festival exists
+	var festival models.Festival
+	if err := s.db.First(&festival, festivalID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, apperrors.ErrFestivalNotFound(festivalID)
+		}
+		return nil, fmt.Errorf("failed to get festival: %w", err)
+	}
+
+	// Verify artist exists
+	var artist models.Artist
+	if err := s.db.First(&artist, req.ArtistID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, fmt.Errorf("artist not found")
+		}
+		return nil, fmt.Errorf("failed to get artist: %w", err)
+	}
+
+	billingTier := models.BillingTier(req.BillingTier)
+	if billingTier == "" {
+		billingTier = models.BillingTierMidCard
+	}
+
+	fa := &models.FestivalArtist{
+		FestivalID:  festivalID,
+		ArtistID:    req.ArtistID,
+		BillingTier: billingTier,
+		Position:    req.Position,
+		DayDate:     req.DayDate,
+		Stage:       req.Stage,
+		SetTime:     req.SetTime,
+		VenueID:     req.VenueID,
+	}
+
+	if err := s.db.Create(fa).Error; err != nil {
+		return nil, fmt.Errorf("failed to add artist to festival: %w", err)
+	}
+
+	artistSlug := ""
+	if artist.Slug != nil {
+		artistSlug = *artist.Slug
+	}
+
+	return &FestivalArtistResponse{
+		ID:          fa.ID,
+		ArtistID:    fa.ArtistID,
+		ArtistSlug:  artistSlug,
+		ArtistName:  artist.Name,
+		BillingTier: string(fa.BillingTier),
+		Position:    fa.Position,
+		DayDate:     formatOptionalDateString(fa.DayDate),
+		Stage:       fa.Stage,
+		SetTime:     fa.SetTime,
+		VenueID:     fa.VenueID,
+	}, nil
+}
+
+// UpdateFestivalArtist updates an artist's festival details
+func (s *FestivalService) UpdateFestivalArtist(festivalID, artistID uint, req *UpdateFestivalArtistRequest) (*FestivalArtistResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	// Find the festival_artist junction entry
+	var fa models.FestivalArtist
+	err := s.db.Where("festival_id = ? AND artist_id = ?", festivalID, artistID).First(&fa).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, fmt.Errorf("artist not found in festival lineup")
+		}
+		return nil, fmt.Errorf("failed to get festival artist: %w", err)
+	}
+
+	updates := map[string]interface{}{}
+	if req.BillingTier != nil {
+		updates["billing_tier"] = *req.BillingTier
+	}
+	if req.Position != nil {
+		updates["position"] = *req.Position
+	}
+	if req.DayDate != nil {
+		updates["day_date"] = *req.DayDate
+	}
+	if req.Stage != nil {
+		updates["stage"] = *req.Stage
+	}
+	if req.SetTime != nil {
+		updates["set_time"] = *req.SetTime
+	}
+	if req.VenueID != nil {
+		updates["venue_id"] = *req.VenueID
+	}
+
+	if len(updates) > 0 {
+		err = s.db.Model(&models.FestivalArtist{}).Where("id = ?", fa.ID).Updates(updates).Error
+		if err != nil {
+			return nil, fmt.Errorf("failed to update festival artist: %w", err)
+		}
+	}
+
+	// Reload the updated entry
+	s.db.First(&fa, fa.ID)
+
+	// Load artist details
+	var artist models.Artist
+	s.db.First(&artist, fa.ArtistID)
+	artistSlug := ""
+	if artist.Slug != nil {
+		artistSlug = *artist.Slug
+	}
+
+	return &FestivalArtistResponse{
+		ID:          fa.ID,
+		ArtistID:    fa.ArtistID,
+		ArtistSlug:  artistSlug,
+		ArtistName:  artist.Name,
+		BillingTier: string(fa.BillingTier),
+		Position:    fa.Position,
+		DayDate:     formatOptionalDateString(fa.DayDate),
+		Stage:       fa.Stage,
+		SetTime:     fa.SetTime,
+		VenueID:     fa.VenueID,
+	}, nil
+}
+
+// RemoveFestivalArtist removes an artist from a festival lineup
+func (s *FestivalService) RemoveFestivalArtist(festivalID, artistID uint) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	result := s.db.Where("festival_id = ? AND artist_id = ?", festivalID, artistID).Delete(&models.FestivalArtist{})
+	if result.Error != nil {
+		return fmt.Errorf("failed to remove artist from festival: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("artist not found in festival lineup")
+	}
+
+	return nil
+}
+
+// GetFestivalVenues retrieves the venues for a festival
+func (s *FestivalService) GetFestivalVenues(festivalID uint) ([]*FestivalVenueResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	// Verify festival exists
+	var festival models.Festival
+	if err := s.db.First(&festival, festivalID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, apperrors.ErrFestivalNotFound(festivalID)
+		}
+		return nil, fmt.Errorf("failed to get festival: %w", err)
+	}
+
+	var festivalVenues []models.FestivalVenue
+	err := s.db.Where("festival_id = ?", festivalID).Order("is_primary DESC, id ASC").Find(&festivalVenues).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to get festival venues: %w", err)
+	}
+
+	if len(festivalVenues) == 0 {
+		return []*FestivalVenueResponse{}, nil
+	}
+
+	// Batch-load venue details
+	venueIDs := make([]uint, len(festivalVenues))
+	for i, fv := range festivalVenues {
+		venueIDs[i] = fv.VenueID
+	}
+
+	venueMap := make(map[uint]*models.Venue)
+	var venues []models.Venue
+	s.db.Where("id IN ?", venueIDs).Find(&venues)
+	for i := range venues {
+		venueMap[venues[i].ID] = &venues[i]
+	}
+
+	// Build responses
+	responses := make([]*FestivalVenueResponse, 0, len(festivalVenues))
+	for _, fv := range festivalVenues {
+		venueModel, ok := venueMap[fv.VenueID]
+		if !ok {
+			continue
+		}
+		venueSlug := ""
+		if venueModel.Slug != nil {
+			venueSlug = *venueModel.Slug
+		}
+		responses = append(responses, &FestivalVenueResponse{
+			ID:        fv.ID,
+			VenueID:   fv.VenueID,
+			VenueName: venueModel.Name,
+			VenueSlug: venueSlug,
+			City:      venueModel.City,
+			State:     venueModel.State,
+			IsPrimary: fv.IsPrimary,
+		})
+	}
+
+	return responses, nil
+}
+
+// AddFestivalVenue adds a venue to a festival
+func (s *FestivalService) AddFestivalVenue(festivalID uint, req *AddFestivalVenueRequest) (*FestivalVenueResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	// Verify festival exists
+	var festival models.Festival
+	if err := s.db.First(&festival, festivalID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, apperrors.ErrFestivalNotFound(festivalID)
+		}
+		return nil, fmt.Errorf("failed to get festival: %w", err)
+	}
+
+	// Verify venue exists
+	var venue models.Venue
+	if err := s.db.First(&venue, req.VenueID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, fmt.Errorf("venue not found")
+		}
+		return nil, fmt.Errorf("failed to get venue: %w", err)
+	}
+
+	fv := &models.FestivalVenue{
+		FestivalID: festivalID,
+		VenueID:    req.VenueID,
+		IsPrimary:  req.IsPrimary,
+	}
+
+	if err := s.db.Create(fv).Error; err != nil {
+		return nil, fmt.Errorf("failed to add venue to festival: %w", err)
+	}
+
+	venueSlug := ""
+	if venue.Slug != nil {
+		venueSlug = *venue.Slug
+	}
+
+	return &FestivalVenueResponse{
+		ID:        fv.ID,
+		VenueID:   fv.VenueID,
+		VenueName: venue.Name,
+		VenueSlug: venueSlug,
+		City:      venue.City,
+		State:     venue.State,
+		IsPrimary: fv.IsPrimary,
+	}, nil
+}
+
+// RemoveFestivalVenue removes a venue from a festival
+func (s *FestivalService) RemoveFestivalVenue(festivalID, venueID uint) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	result := s.db.Where("festival_id = ? AND venue_id = ?", festivalID, venueID).Delete(&models.FestivalVenue{})
+	if result.Error != nil {
+		return fmt.Errorf("failed to remove venue from festival: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("venue not found in festival")
+	}
+
+	return nil
+}
+
+// GetFestivalsForArtist retrieves all festivals an artist has played
+func (s *FestivalService) GetFestivalsForArtist(artistID uint) ([]*ArtistFestivalListResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	// Verify artist exists
+	var artist models.Artist
+	if err := s.db.First(&artist, artistID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, apperrors.ErrArtistNotFound(artistID)
+		}
+		return nil, fmt.Errorf("failed to get artist: %w", err)
+	}
+
+	// Get festival_artist entries for this artist
+	var festivalArtists []models.FestivalArtist
+	if err := s.db.Where("artist_id = ?", artistID).Find(&festivalArtists).Error; err != nil {
+		return nil, fmt.Errorf("failed to get artist festivals: %w", err)
+	}
+
+	if len(festivalArtists) == 0 {
+		return []*ArtistFestivalListResponse{}, nil
+	}
+
+	// Build mapping: festivalID -> festival artist details
+	festivalIDs := make([]uint, 0, len(festivalArtists))
+	billingMap := make(map[uint]string)
+	dayDateMap := make(map[uint]*string)
+	stageMap := make(map[uint]*string)
+	for _, fa := range festivalArtists {
+		festivalIDs = append(festivalIDs, fa.FestivalID)
+		billingMap[fa.FestivalID] = string(fa.BillingTier)
+		dayDateMap[fa.FestivalID] = fa.DayDate
+		stageMap[fa.FestivalID] = fa.Stage
+	}
+
+	// Fetch festivals
+	var festivals []models.Festival
+	if err := s.db.Where("id IN ?", festivalIDs).Order("start_date DESC, name ASC").Find(&festivals).Error; err != nil {
+		return nil, fmt.Errorf("failed to get festivals: %w", err)
+	}
+
+	// Batch-load artist and venue counts
+	artistCounts := make(map[uint]int)
+	venueCounts := make(map[uint]int)
+
+	if len(festivalIDs) > 0 {
+		type CountResult struct {
+			FestivalID uint
+			Count      int
+		}
+
+		var aCounts []CountResult
+		s.db.Table("festival_artists").
+			Select("festival_id, COUNT(DISTINCT artist_id) as count").
+			Where("festival_id IN ?", festivalIDs).
+			Group("festival_id").
+			Find(&aCounts)
+		for _, c := range aCounts {
+			artistCounts[c.FestivalID] = c.Count
+		}
+
+		var vCounts []CountResult
+		s.db.Table("festival_venues").
+			Select("festival_id, COUNT(DISTINCT venue_id) as count").
+			Where("festival_id IN ?", festivalIDs).
+			Group("festival_id").
+			Find(&vCounts)
+		for _, c := range vCounts {
+			venueCounts[c.FestivalID] = c.Count
+		}
+	}
+
+	// Build responses
+	responses := make([]*ArtistFestivalListResponse, len(festivals))
+	for i, festival := range festivals {
+		responses[i] = &ArtistFestivalListResponse{
+			FestivalListResponse: FestivalListResponse{
+				ID:          festival.ID,
+				Name:        festival.Name,
+				Slug:        festival.Slug,
+				SeriesSlug:  festival.SeriesSlug,
+				EditionYear: festival.EditionYear,
+				City:        festival.City,
+				State:       festival.State,
+				StartDate:   formatDateString(festival.StartDate),
+				EndDate:     formatDateString(festival.EndDate),
+				Status:      string(festival.Status),
+				ArtistCount: artistCounts[festival.ID],
+				VenueCount:  venueCounts[festival.ID],
+			},
+			BillingTier: billingMap[festival.ID],
+			DayDate:     formatOptionalDateString(dayDateMap[festival.ID]),
+			Stage:       stageMap[festival.ID],
+		}
+	}
+
+	return responses, nil
+}
+
+// buildDetailResponse converts a Festival model to FestivalDetailResponse
+func (s *FestivalService) buildDetailResponse(festival *models.Festival) (*FestivalDetailResponse, error) {
+	// Count artists
+	var artistCount int64
+	s.db.Table("festival_artists").Where("festival_id = ?", festival.ID).Count(&artistCount)
+
+	// Count venues
+	var venueCount int64
+	s.db.Table("festival_venues").Where("festival_id = ?", festival.ID).Count(&venueCount)
+
+	return &FestivalDetailResponse{
+		ID:           festival.ID,
+		Name:         festival.Name,
+		Slug:         festival.Slug,
+		SeriesSlug:   festival.SeriesSlug,
+		EditionYear:  festival.EditionYear,
+		Description:  festival.Description,
+		LocationName: festival.LocationName,
+		City:         festival.City,
+		State:        festival.State,
+		Country:      festival.Country,
+		StartDate:    formatDateString(festival.StartDate),
+		EndDate:      formatDateString(festival.EndDate),
+		Website:      festival.Website,
+		TicketURL:    festival.TicketURL,
+		FlyerURL:     festival.FlyerURL,
+		Status:       string(festival.Status),
+		Social:       festival.Social,
+		ArtistCount:  int(artistCount),
+		VenueCount:   int(venueCount),
+		CreatedAt:    festival.CreatedAt,
+		UpdatedAt:    festival.UpdatedAt,
+	}, nil
+}
+
+// formatDateString normalizes a date string that may include a timestamp suffix
+// (e.g., "2026-03-06T00:00:00Z") back to just the date part ("2026-03-06").
+func formatDateString(date string) string {
+	if len(date) >= 10 {
+		return date[:10]
+	}
+	return date
+}
+
+// formatOptionalDateString normalizes an optional date string pointer.
+func formatOptionalDateString(date *string) *string {
+	if date == nil {
+		return nil
+	}
+	formatted := formatDateString(*date)
+	return &formatted
+}

--- a/backend/internal/services/festival_test.go
+++ b/backend/internal/services/festival_test.go
@@ -1,0 +1,954 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+
+	apperrors "psychic-homily-backend/internal/errors"
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/testutil"
+	"psychic-homily-backend/internal/utils"
+)
+
+// =============================================================================
+// UNIT TESTS (No Database Required)
+// =============================================================================
+
+func TestNewFestivalService(t *testing.T) {
+	festivalService := NewFestivalService(nil)
+	assert.NotNil(t, festivalService)
+}
+
+func TestFestivalService_NilDatabase(t *testing.T) {
+	svc := &FestivalService{db: nil}
+
+	t.Run("CreateFestival", func(t *testing.T) {
+		resp, err := svc.CreateFestival(&CreateFestivalRequest{Name: "Test"})
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("GetFestival", func(t *testing.T) {
+		resp, err := svc.GetFestival(1)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("GetFestivalBySlug", func(t *testing.T) {
+		resp, err := svc.GetFestivalBySlug("test-slug")
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("ListFestivals", func(t *testing.T) {
+		resp, err := svc.ListFestivals(nil)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("UpdateFestival", func(t *testing.T) {
+		resp, err := svc.UpdateFestival(1, &UpdateFestivalRequest{})
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("DeleteFestival", func(t *testing.T) {
+		err := svc.DeleteFestival(1)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+	})
+
+	t.Run("GetFestivalArtists", func(t *testing.T) {
+		resp, err := svc.GetFestivalArtists(1, nil)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("AddFestivalArtist", func(t *testing.T) {
+		resp, err := svc.AddFestivalArtist(1, &AddFestivalArtistRequest{ArtistID: 1})
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("UpdateFestivalArtist", func(t *testing.T) {
+		resp, err := svc.UpdateFestivalArtist(1, 1, &UpdateFestivalArtistRequest{})
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("RemoveFestivalArtist", func(t *testing.T) {
+		err := svc.RemoveFestivalArtist(1, 1)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+	})
+
+	t.Run("GetFestivalVenues", func(t *testing.T) {
+		resp, err := svc.GetFestivalVenues(1)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("AddFestivalVenue", func(t *testing.T) {
+		resp, err := svc.AddFestivalVenue(1, &AddFestivalVenueRequest{VenueID: 1})
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("RemoveFestivalVenue", func(t *testing.T) {
+		err := svc.RemoveFestivalVenue(1, 1)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+	})
+
+	t.Run("GetFestivalsForArtist", func(t *testing.T) {
+		resp, err := svc.GetFestivalsForArtist(1)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+}
+
+// =============================================================================
+// INTEGRATION TESTS (With Real Database)
+// =============================================================================
+
+type FestivalServiceIntegrationTestSuite struct {
+	suite.Suite
+	container       testcontainers.Container
+	db              *gorm.DB
+	festivalService *FestivalService
+	artistService   *ArtistService
+	venueService    *VenueService
+	ctx             context.Context
+}
+
+func (suite *FestivalServiceIntegrationTestSuite) SetupSuite() {
+	suite.ctx = context.Background()
+
+	// Start PostgreSQL container
+	container, err := testcontainers.GenericContainer(suite.ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "postgres:18",
+			ExposedPorts: []string{"5432/tcp"},
+			Env: map[string]string{
+				"POSTGRES_DB":       "test_db",
+				"POSTGRES_USER":     "test_user",
+				"POSTGRES_PASSWORD": "test_password",
+			},
+			WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(120 * time.Second),
+		},
+		Started: true,
+	})
+	if err != nil {
+		suite.T().Fatalf("failed to start postgres container: %v", err)
+	}
+	suite.container = container
+
+	host, err := container.Host(suite.ctx)
+	if err != nil {
+		suite.T().Fatalf("failed to get host: %v", err)
+	}
+	port, err := container.MappedPort(suite.ctx, "5432")
+	if err != nil {
+		suite.T().Fatalf("failed to get port: %v", err)
+	}
+
+	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
+		host, port.Port())
+
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		suite.T().Fatalf("failed to connect to test database: %v", err)
+	}
+	suite.db = db
+
+	sqlDB, err := db.DB()
+	if err != nil {
+		suite.T().Fatalf("failed to get sql.DB: %v", err)
+	}
+	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "db", "migrations"))
+
+	suite.festivalService = &FestivalService{db: db}
+	suite.artistService = &ArtistService{db: db}
+	suite.venueService = &VenueService{db: db}
+}
+
+func (suite *FestivalServiceIntegrationTestSuite) TearDownSuite() {
+	if suite.container != nil {
+		if err := suite.container.Terminate(suite.ctx); err != nil {
+			suite.T().Logf("failed to terminate container: %v", err)
+		}
+	}
+}
+
+// TearDownTest cleans up data between tests for isolation
+func (suite *FestivalServiceIntegrationTestSuite) TearDownTest() {
+	sqlDB, err := suite.db.DB()
+	suite.Require().NoError(err)
+	// Delete in FK-safe order
+	_, _ = sqlDB.Exec("DELETE FROM festival_artists")
+	_, _ = sqlDB.Exec("DELETE FROM festival_venues")
+	_, _ = sqlDB.Exec("DELETE FROM festivals")
+	_, _ = sqlDB.Exec("DELETE FROM show_artists")
+	_, _ = sqlDB.Exec("DELETE FROM show_venues")
+	_, _ = sqlDB.Exec("DELETE FROM shows")
+	_, _ = sqlDB.Exec("DELETE FROM artists")
+	_, _ = sqlDB.Exec("DELETE FROM venues")
+}
+
+func TestFestivalServiceIntegrationTestSuite(t *testing.T) {
+	suite.Run(t, new(FestivalServiceIntegrationTestSuite))
+}
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+func (suite *FestivalServiceIntegrationTestSuite) createTestArtistForFestival(name string) *models.Artist {
+	artist := &models.Artist{
+		Name: name,
+	}
+	err := suite.db.Create(artist).Error
+	suite.Require().NoError(err)
+	return artist
+}
+
+func (suite *FestivalServiceIntegrationTestSuite) createTestVenue(name, city, state string) *models.Venue {
+	venue := &models.Venue{
+		Name:     name,
+		City:     city,
+		State:    state,
+		Verified: true,
+	}
+	err := suite.db.Create(venue).Error
+	suite.Require().NoError(err)
+	return venue
+}
+
+var festivalCounter int
+
+func (suite *FestivalServiceIntegrationTestSuite) createBasicFestival(name string) *FestivalDetailResponse {
+	festivalCounter++
+	city := "Phoenix"
+	state := "AZ"
+	slug := utils.GenerateArtistSlug(name)
+	req := &CreateFestivalRequest{
+		Name:        name,
+		SeriesSlug:  slug,
+		EditionYear: 2026 + festivalCounter,
+		City:        &city,
+		State:       &state,
+		StartDate:   "2026-03-06",
+		EndDate:     "2026-03-08",
+	}
+	resp, err := suite.festivalService.CreateFestival(req)
+	suite.Require().NoError(err)
+	return resp
+}
+
+func strPtrFestival(s string) *string {
+	return &s
+}
+
+// =============================================================================
+// Group 1: CreateFestival
+// =============================================================================
+
+func (suite *FestivalServiceIntegrationTestSuite) TestCreateFestival_Success() {
+	city := "Phoenix"
+	state := "AZ"
+	req := &CreateFestivalRequest{
+		Name:        "M3F Festival",
+		SeriesSlug:  "m3f",
+		EditionYear: 2026,
+		City:        &city,
+		State:       &state,
+		StartDate:   "2026-03-06",
+		EndDate:     "2026-03-08",
+	}
+
+	resp, err := suite.festivalService.CreateFestival(req)
+
+	suite.Require().NoError(err)
+	suite.Require().NotNil(resp)
+	suite.NotZero(resp.ID)
+	suite.Equal("M3F Festival", resp.Name)
+	suite.Equal("m3f-festival", resp.Slug)
+	suite.Equal("m3f", resp.SeriesSlug)
+	suite.Equal(2026, resp.EditionYear)
+	suite.Equal("Phoenix", *resp.City)
+	suite.Equal("AZ", *resp.State)
+	suite.Equal("2026-03-06", resp.StartDate)
+	suite.Equal("2026-03-08", resp.EndDate)
+	suite.Equal("announced", resp.Status)
+	suite.Equal(0, resp.ArtistCount)
+	suite.Equal(0, resp.VenueCount)
+}
+
+func (suite *FestivalServiceIntegrationTestSuite) TestCreateFestival_DefaultStatus() {
+	req := &CreateFestivalRequest{
+		Name:        "Default Status Fest",
+		SeriesSlug:  "default-fest",
+		EditionYear: 2026,
+		StartDate:   "2026-06-01",
+		EndDate:     "2026-06-03",
+	}
+
+	resp, err := suite.festivalService.CreateFestival(req)
+
+	suite.Require().NoError(err)
+	suite.Equal("announced", resp.Status)
+}
+
+func (suite *FestivalServiceIntegrationTestSuite) TestCreateFestival_CustomStatus() {
+	req := &CreateFestivalRequest{
+		Name:        "Confirmed Fest",
+		SeriesSlug:  "confirmed-fest",
+		EditionYear: 2026,
+		StartDate:   "2026-06-01",
+		EndDate:     "2026-06-03",
+		Status:      "confirmed",
+	}
+
+	resp, err := suite.festivalService.CreateFestival(req)
+
+	suite.Require().NoError(err)
+	suite.Equal("confirmed", resp.Status)
+}
+
+func (suite *FestivalServiceIntegrationTestSuite) TestCreateFestival_UniqueSlug() {
+	req1 := &CreateFestivalRequest{
+		Name:        "Lollapalooza",
+		SeriesSlug:  "lollapalooza",
+		EditionYear: 2025,
+		StartDate:   "2025-08-01",
+		EndDate:     "2025-08-04",
+	}
+	resp1, err := suite.festivalService.CreateFestival(req1)
+	suite.Require().NoError(err)
+
+	req2 := &CreateFestivalRequest{
+		Name:        "Lollapalooza",
+		SeriesSlug:  "lollapalooza",
+		EditionYear: 2026,
+		StartDate:   "2026-08-01",
+		EndDate:     "2026-08-04",
+	}
+	resp2, err := suite.festivalService.CreateFestival(req2)
+	suite.Require().NoError(err)
+
+	suite.NotEqual(resp1.Slug, resp2.Slug)
+	suite.Equal("lollapalooza", resp1.Slug)
+	suite.Equal("lollapalooza-2", resp2.Slug)
+}
+
+// =============================================================================
+// Group 2: GetFestival / GetFestivalBySlug
+// =============================================================================
+
+func (suite *FestivalServiceIntegrationTestSuite) TestGetFestival_Success() {
+	created := suite.createBasicFestival("Get Test Festival")
+
+	resp, err := suite.festivalService.GetFestival(created.ID)
+
+	suite.Require().NoError(err)
+	suite.Equal(created.ID, resp.ID)
+	suite.Equal("Get Test Festival", resp.Name)
+}
+
+func (suite *FestivalServiceIntegrationTestSuite) TestGetFestival_NotFound() {
+	resp, err := suite.festivalService.GetFestival(99999)
+
+	suite.Require().Error(err)
+	suite.Nil(resp)
+	var festivalErr *apperrors.FestivalError
+	suite.ErrorAs(err, &festivalErr)
+	suite.Equal(apperrors.CodeFestivalNotFound, festivalErr.Code)
+}
+
+func (suite *FestivalServiceIntegrationTestSuite) TestGetFestivalBySlug_Success() {
+	created := suite.createBasicFestival("Slug Test Festival")
+
+	resp, err := suite.festivalService.GetFestivalBySlug(created.Slug)
+
+	suite.Require().NoError(err)
+	suite.Equal(created.ID, resp.ID)
+	suite.Equal(created.Slug, resp.Slug)
+}
+
+func (suite *FestivalServiceIntegrationTestSuite) TestGetFestivalBySlug_NotFound() {
+	resp, err := suite.festivalService.GetFestivalBySlug("nonexistent-slug-xyz")
+
+	suite.Require().Error(err)
+	suite.Nil(resp)
+	var festivalErr *apperrors.FestivalError
+	suite.ErrorAs(err, &festivalErr)
+	suite.Equal(apperrors.CodeFestivalNotFound, festivalErr.Code)
+}
+
+// =============================================================================
+// Group 3: ListFestivals
+// =============================================================================
+
+func (suite *FestivalServiceIntegrationTestSuite) TestListFestivals_All() {
+	suite.createBasicFestival("Festival A")
+	suite.createBasicFestival("Festival B")
+	suite.createBasicFestival("Festival C")
+
+	resp, err := suite.festivalService.ListFestivals(map[string]interface{}{})
+
+	suite.Require().NoError(err)
+	suite.Require().Len(resp, 3)
+}
+
+func (suite *FestivalServiceIntegrationTestSuite) TestListFestivals_FilterByStatus() {
+	// Create a confirmed festival
+	city := "Phoenix"
+	state := "AZ"
+	suite.festivalService.CreateFestival(&CreateFestivalRequest{
+		Name: "Confirmed Fest", SeriesSlug: "cf", EditionYear: 2026,
+		City: &city, State: &state, StartDate: "2026-03-01", EndDate: "2026-03-03", Status: "confirmed",
+	})
+	suite.festivalService.CreateFestival(&CreateFestivalRequest{
+		Name: "Announced Fest", SeriesSlug: "af", EditionYear: 2026,
+		StartDate: "2026-04-01", EndDate: "2026-04-03",
+	})
+
+	resp, err := suite.festivalService.ListFestivals(map[string]interface{}{"status": "confirmed"})
+
+	suite.Require().NoError(err)
+	suite.Require().Len(resp, 1)
+	suite.Equal("Confirmed Fest", resp[0].Name)
+}
+
+func (suite *FestivalServiceIntegrationTestSuite) TestListFestivals_FilterByYear() {
+	suite.festivalService.CreateFestival(&CreateFestivalRequest{
+		Name: "2025 Fest", SeriesSlug: "f25", EditionYear: 2025, StartDate: "2025-06-01", EndDate: "2025-06-03",
+	})
+	suite.festivalService.CreateFestival(&CreateFestivalRequest{
+		Name: "2026 Fest", SeriesSlug: "f26", EditionYear: 2026, StartDate: "2026-06-01", EndDate: "2026-06-03",
+	})
+
+	resp, err := suite.festivalService.ListFestivals(map[string]interface{}{"year": 2026})
+
+	suite.Require().NoError(err)
+	suite.Require().Len(resp, 1)
+	suite.Equal("2026 Fest", resp[0].Name)
+}
+
+func (suite *FestivalServiceIntegrationTestSuite) TestListFestivals_FilterByCity() {
+	city1 := "Phoenix"
+	city2 := "Chicago"
+	suite.festivalService.CreateFestival(&CreateFestivalRequest{
+		Name: "PHX Fest", SeriesSlug: "phx", EditionYear: 2026, City: &city1, StartDate: "2026-03-01", EndDate: "2026-03-03",
+	})
+	suite.festivalService.CreateFestival(&CreateFestivalRequest{
+		Name: "CHI Fest", SeriesSlug: "chi", EditionYear: 2026, City: &city2, StartDate: "2026-07-01", EndDate: "2026-07-03",
+	})
+
+	resp, err := suite.festivalService.ListFestivals(map[string]interface{}{"city": "Phoenix"})
+
+	suite.Require().NoError(err)
+	suite.Require().Len(resp, 1)
+	suite.Equal("PHX Fest", resp[0].Name)
+}
+
+func (suite *FestivalServiceIntegrationTestSuite) TestListFestivals_FilterBySeriesSlug() {
+	suite.festivalService.CreateFestival(&CreateFestivalRequest{
+		Name: "M3F 2025", SeriesSlug: "m3f", EditionYear: 2025, StartDate: "2025-03-01", EndDate: "2025-03-03",
+	})
+	suite.festivalService.CreateFestival(&CreateFestivalRequest{
+		Name: "M3F 2026", SeriesSlug: "m3f", EditionYear: 2026, StartDate: "2026-03-01", EndDate: "2026-03-03",
+	})
+	suite.festivalService.CreateFestival(&CreateFestivalRequest{
+		Name: "Other Fest", SeriesSlug: "other", EditionYear: 2026, StartDate: "2026-06-01", EndDate: "2026-06-03",
+	})
+
+	resp, err := suite.festivalService.ListFestivals(map[string]interface{}{"series_slug": "m3f"})
+
+	suite.Require().NoError(err)
+	suite.Require().Len(resp, 2)
+}
+
+// =============================================================================
+// Group 4: UpdateFestival
+// =============================================================================
+
+func (suite *FestivalServiceIntegrationTestSuite) TestUpdateFestival_BasicFields() {
+	created := suite.createBasicFestival("Original Festival")
+
+	newName := "Updated Festival"
+	newStatus := "confirmed"
+	resp, err := suite.festivalService.UpdateFestival(created.ID, &UpdateFestivalRequest{
+		Name:   &newName,
+		Status: &newStatus,
+	})
+
+	suite.Require().NoError(err)
+	suite.Equal("Updated Festival", resp.Name)
+	suite.Equal("confirmed", resp.Status)
+}
+
+func (suite *FestivalServiceIntegrationTestSuite) TestUpdateFestival_NameChangeRegeneratesSlug() {
+	created := suite.createBasicFestival("Old Festival Name")
+	oldSlug := created.Slug
+
+	newName := "New Festival Name"
+	resp, err := suite.festivalService.UpdateFestival(created.ID, &UpdateFestivalRequest{
+		Name: &newName,
+	})
+
+	suite.Require().NoError(err)
+	suite.Equal("New Festival Name", resp.Name)
+	suite.NotEqual(oldSlug, resp.Slug)
+	suite.Equal("new-festival-name", resp.Slug)
+}
+
+func (suite *FestivalServiceIntegrationTestSuite) TestUpdateFestival_NotFound() {
+	newName := "Anything"
+	resp, err := suite.festivalService.UpdateFestival(99999, &UpdateFestivalRequest{Name: &newName})
+
+	suite.Require().Error(err)
+	suite.Nil(resp)
+	var festivalErr *apperrors.FestivalError
+	suite.ErrorAs(err, &festivalErr)
+	suite.Equal(apperrors.CodeFestivalNotFound, festivalErr.Code)
+}
+
+func (suite *FestivalServiceIntegrationTestSuite) TestUpdateFestival_NoChanges() {
+	created := suite.createBasicFestival("Stable Festival")
+
+	resp, err := suite.festivalService.UpdateFestival(created.ID, &UpdateFestivalRequest{})
+
+	suite.Require().NoError(err)
+	suite.Equal("Stable Festival", resp.Name)
+}
+
+// =============================================================================
+// Group 5: DeleteFestival
+// =============================================================================
+
+func (suite *FestivalServiceIntegrationTestSuite) TestDeleteFestival_Success() {
+	created := suite.createBasicFestival("Delete Me Festival")
+
+	err := suite.festivalService.DeleteFestival(created.ID)
+
+	suite.Require().NoError(err)
+
+	// Verify it's gone
+	_, err = suite.festivalService.GetFestival(created.ID)
+	suite.Error(err)
+}
+
+func (suite *FestivalServiceIntegrationTestSuite) TestDeleteFestival_NotFound() {
+	err := suite.festivalService.DeleteFestival(99999)
+
+	suite.Require().Error(err)
+	var festivalErr *apperrors.FestivalError
+	suite.ErrorAs(err, &festivalErr)
+	suite.Equal(apperrors.CodeFestivalNotFound, festivalErr.Code)
+}
+
+func (suite *FestivalServiceIntegrationTestSuite) TestDeleteFestival_CascadesJunctions() {
+	created := suite.createBasicFestival("Cascade Festival")
+	artist := suite.createTestArtistForFestival("Cascade Artist")
+	venue := suite.createTestVenue("Cascade Venue", "Phoenix", "AZ")
+
+	suite.festivalService.AddFestivalArtist(created.ID, &AddFestivalArtistRequest{
+		ArtistID:    artist.ID,
+		BillingTier: "headliner",
+	})
+	suite.festivalService.AddFestivalVenue(created.ID, &AddFestivalVenueRequest{
+		VenueID:   venue.ID,
+		IsPrimary: true,
+	})
+
+	err := suite.festivalService.DeleteFestival(created.ID)
+	suite.Require().NoError(err)
+
+	// Verify junction records cleaned up
+	var faCount int64
+	suite.db.Model(&models.FestivalArtist{}).Where("festival_id = ?", created.ID).Count(&faCount)
+	suite.Equal(int64(0), faCount)
+
+	var fvCount int64
+	suite.db.Model(&models.FestivalVenue{}).Where("festival_id = ?", created.ID).Count(&fvCount)
+	suite.Equal(int64(0), fvCount)
+}
+
+// =============================================================================
+// Group 6: Festival Artists (Lineup Management)
+// =============================================================================
+
+func (suite *FestivalServiceIntegrationTestSuite) TestGetFestivalArtists_Empty() {
+	created := suite.createBasicFestival("Empty Lineup Festival")
+
+	resp, err := suite.festivalService.GetFestivalArtists(created.ID, nil)
+
+	suite.Require().NoError(err)
+	suite.Empty(resp)
+}
+
+func (suite *FestivalServiceIntegrationTestSuite) TestGetFestivalArtists_FestivalNotFound() {
+	resp, err := suite.festivalService.GetFestivalArtists(99999, nil)
+
+	suite.Require().Error(err)
+	suite.Nil(resp)
+	var festivalErr *apperrors.FestivalError
+	suite.ErrorAs(err, &festivalErr)
+}
+
+func (suite *FestivalServiceIntegrationTestSuite) TestAddFestivalArtist_Success() {
+	festival := suite.createBasicFestival("Lineup Festival")
+	artist := suite.createTestArtistForFestival("Headliner Band")
+
+	resp, err := suite.festivalService.AddFestivalArtist(festival.ID, &AddFestivalArtistRequest{
+		ArtistID:    artist.ID,
+		BillingTier: "headliner",
+		Position:    0,
+		DayDate:     strPtrFestival("2026-03-07"),
+		Stage:       strPtrFestival("Main Stage"),
+	})
+
+	suite.Require().NoError(err)
+	suite.Require().NotNil(resp)
+	suite.NotZero(resp.ID)
+	suite.Equal(artist.ID, resp.ArtistID)
+	suite.Equal("Headliner Band", resp.ArtistName)
+	suite.Equal("headliner", resp.BillingTier)
+	suite.Equal(0, resp.Position)
+	suite.Equal("2026-03-07", *resp.DayDate)
+	suite.Equal("Main Stage", *resp.Stage)
+}
+
+func (suite *FestivalServiceIntegrationTestSuite) TestAddFestivalArtist_DefaultBillingTier() {
+	festival := suite.createBasicFestival("Default Tier Festival")
+	artist := suite.createTestArtistForFestival("Default Tier Band")
+
+	resp, err := suite.festivalService.AddFestivalArtist(festival.ID, &AddFestivalArtistRequest{
+		ArtistID: artist.ID,
+	})
+
+	suite.Require().NoError(err)
+	suite.Equal("mid_card", resp.BillingTier)
+}
+
+func (suite *FestivalServiceIntegrationTestSuite) TestAddFestivalArtist_FestivalNotFound() {
+	artist := suite.createTestArtistForFestival("Orphan Band")
+
+	resp, err := suite.festivalService.AddFestivalArtist(99999, &AddFestivalArtistRequest{ArtistID: artist.ID})
+
+	suite.Require().Error(err)
+	suite.Nil(resp)
+}
+
+func (suite *FestivalServiceIntegrationTestSuite) TestAddFestivalArtist_ArtistNotFound() {
+	festival := suite.createBasicFestival("Missing Artist Festival")
+
+	resp, err := suite.festivalService.AddFestivalArtist(festival.ID, &AddFestivalArtistRequest{ArtistID: 99999})
+
+	suite.Require().Error(err)
+	suite.Nil(resp)
+	suite.Contains(err.Error(), "artist not found")
+}
+
+func (suite *FestivalServiceIntegrationTestSuite) TestGetFestivalArtists_OrderedByBillingTier() {
+	festival := suite.createBasicFestival("Ordered Lineup Festival")
+	headliner := suite.createTestArtistForFestival("Headliner")
+	undercard := suite.createTestArtistForFestival("Undercard")
+	local := suite.createTestArtistForFestival("Local Opener")
+
+	// Add in reverse order to test ordering
+	suite.festivalService.AddFestivalArtist(festival.ID, &AddFestivalArtistRequest{
+		ArtistID: local.ID, BillingTier: "local", Position: 0,
+	})
+	suite.festivalService.AddFestivalArtist(festival.ID, &AddFestivalArtistRequest{
+		ArtistID: headliner.ID, BillingTier: "headliner", Position: 0,
+	})
+	suite.festivalService.AddFestivalArtist(festival.ID, &AddFestivalArtistRequest{
+		ArtistID: undercard.ID, BillingTier: "undercard", Position: 0,
+	})
+
+	resp, err := suite.festivalService.GetFestivalArtists(festival.ID, nil)
+
+	suite.Require().NoError(err)
+	suite.Require().Len(resp, 3)
+	suite.Equal("headliner", resp[0].BillingTier)
+	suite.Equal("undercard", resp[1].BillingTier)
+	suite.Equal("local", resp[2].BillingTier)
+}
+
+func (suite *FestivalServiceIntegrationTestSuite) TestGetFestivalArtists_FilterByDay() {
+	festival := suite.createBasicFestival("Multi Day Festival")
+	day1Artist := suite.createTestArtistForFestival("Day 1 Artist")
+	day2Artist := suite.createTestArtistForFestival("Day 2 Artist")
+
+	suite.festivalService.AddFestivalArtist(festival.ID, &AddFestivalArtistRequest{
+		ArtistID: day1Artist.ID, BillingTier: "headliner", DayDate: strPtrFestival("2026-03-06"),
+	})
+	suite.festivalService.AddFestivalArtist(festival.ID, &AddFestivalArtistRequest{
+		ArtistID: day2Artist.ID, BillingTier: "headliner", DayDate: strPtrFestival("2026-03-07"),
+	})
+
+	dayFilter := "2026-03-07"
+	resp, err := suite.festivalService.GetFestivalArtists(festival.ID, &dayFilter)
+
+	suite.Require().NoError(err)
+	suite.Require().Len(resp, 1)
+	suite.Equal("Day 2 Artist", resp[0].ArtistName)
+}
+
+func (suite *FestivalServiceIntegrationTestSuite) TestUpdateFestivalArtist_Success() {
+	festival := suite.createBasicFestival("Update Artist Festival")
+	artist := suite.createTestArtistForFestival("Promoted Band")
+
+	suite.festivalService.AddFestivalArtist(festival.ID, &AddFestivalArtistRequest{
+		ArtistID:    artist.ID,
+		BillingTier: "undercard",
+	})
+
+	newTier := "headliner"
+	newStage := "Main Stage"
+	resp, err := suite.festivalService.UpdateFestivalArtist(festival.ID, artist.ID, &UpdateFestivalArtistRequest{
+		BillingTier: &newTier,
+		Stage:       &newStage,
+	})
+
+	suite.Require().NoError(err)
+	suite.Equal("headliner", resp.BillingTier)
+	suite.Equal("Main Stage", *resp.Stage)
+}
+
+func (suite *FestivalServiceIntegrationTestSuite) TestUpdateFestivalArtist_NotFound() {
+	newTier := "headliner"
+	resp, err := suite.festivalService.UpdateFestivalArtist(99999, 99999, &UpdateFestivalArtistRequest{
+		BillingTier: &newTier,
+	})
+
+	suite.Require().Error(err)
+	suite.Nil(resp)
+	suite.Contains(err.Error(), "artist not found in festival lineup")
+}
+
+func (suite *FestivalServiceIntegrationTestSuite) TestRemoveFestivalArtist_Success() {
+	festival := suite.createBasicFestival("Remove Artist Festival")
+	artist := suite.createTestArtistForFestival("Removed Band")
+
+	suite.festivalService.AddFestivalArtist(festival.ID, &AddFestivalArtistRequest{
+		ArtistID: artist.ID,
+	})
+
+	err := suite.festivalService.RemoveFestivalArtist(festival.ID, artist.ID)
+
+	suite.Require().NoError(err)
+
+	// Verify removal
+	lineup, err := suite.festivalService.GetFestivalArtists(festival.ID, nil)
+	suite.Require().NoError(err)
+	suite.Empty(lineup)
+}
+
+func (suite *FestivalServiceIntegrationTestSuite) TestRemoveFestivalArtist_NotFound() {
+	err := suite.festivalService.RemoveFestivalArtist(99999, 99999)
+
+	suite.Require().Error(err)
+	suite.Contains(err.Error(), "artist not found in festival lineup")
+}
+
+// =============================================================================
+// Group 7: Festival Venues
+// =============================================================================
+
+func (suite *FestivalServiceIntegrationTestSuite) TestGetFestivalVenues_Empty() {
+	festival := suite.createBasicFestival("No Venue Festival")
+
+	resp, err := suite.festivalService.GetFestivalVenues(festival.ID)
+
+	suite.Require().NoError(err)
+	suite.Empty(resp)
+}
+
+func (suite *FestivalServiceIntegrationTestSuite) TestGetFestivalVenues_FestivalNotFound() {
+	resp, err := suite.festivalService.GetFestivalVenues(99999)
+
+	suite.Require().Error(err)
+	suite.Nil(resp)
+}
+
+func (suite *FestivalServiceIntegrationTestSuite) TestAddFestivalVenue_Success() {
+	festival := suite.createBasicFestival("Venue Festival")
+	venue := suite.createTestVenue("Main Park", "Phoenix", "AZ")
+
+	resp, err := suite.festivalService.AddFestivalVenue(festival.ID, &AddFestivalVenueRequest{
+		VenueID:   venue.ID,
+		IsPrimary: true,
+	})
+
+	suite.Require().NoError(err)
+	suite.Require().NotNil(resp)
+	suite.NotZero(resp.ID)
+	suite.Equal(venue.ID, resp.VenueID)
+	suite.Equal("Main Park", resp.VenueName)
+	suite.True(resp.IsPrimary)
+}
+
+func (suite *FestivalServiceIntegrationTestSuite) TestAddFestivalVenue_FestivalNotFound() {
+	venue := suite.createTestVenue("Orphan Venue", "Phoenix", "AZ")
+
+	resp, err := suite.festivalService.AddFestivalVenue(99999, &AddFestivalVenueRequest{VenueID: venue.ID})
+
+	suite.Require().Error(err)
+	suite.Nil(resp)
+}
+
+func (suite *FestivalServiceIntegrationTestSuite) TestAddFestivalVenue_VenueNotFound() {
+	festival := suite.createBasicFestival("Missing Venue Festival")
+
+	resp, err := suite.festivalService.AddFestivalVenue(festival.ID, &AddFestivalVenueRequest{VenueID: 99999})
+
+	suite.Require().Error(err)
+	suite.Nil(resp)
+	suite.Contains(err.Error(), "venue not found")
+}
+
+func (suite *FestivalServiceIntegrationTestSuite) TestRemoveFestivalVenue_Success() {
+	festival := suite.createBasicFestival("Remove Venue Festival")
+	venue := suite.createTestVenue("Removable Venue", "Phoenix", "AZ")
+
+	suite.festivalService.AddFestivalVenue(festival.ID, &AddFestivalVenueRequest{VenueID: venue.ID})
+
+	err := suite.festivalService.RemoveFestivalVenue(festival.ID, venue.ID)
+
+	suite.Require().NoError(err)
+
+	// Verify removal
+	venues, err := suite.festivalService.GetFestivalVenues(festival.ID)
+	suite.Require().NoError(err)
+	suite.Empty(venues)
+}
+
+func (suite *FestivalServiceIntegrationTestSuite) TestRemoveFestivalVenue_NotFound() {
+	err := suite.festivalService.RemoveFestivalVenue(99999, 99999)
+
+	suite.Require().Error(err)
+	suite.Contains(err.Error(), "venue not found in festival")
+}
+
+func (suite *FestivalServiceIntegrationTestSuite) TestGetFestivalVenues_PrimaryFirst() {
+	festival := suite.createBasicFestival("Multi Venue Festival")
+	venue1 := suite.createTestVenue("Secondary Venue", "Phoenix", "AZ")
+	venue2 := suite.createTestVenue("Primary Venue", "Phoenix", "AZ")
+
+	suite.festivalService.AddFestivalVenue(festival.ID, &AddFestivalVenueRequest{
+		VenueID: venue1.ID, IsPrimary: false,
+	})
+	suite.festivalService.AddFestivalVenue(festival.ID, &AddFestivalVenueRequest{
+		VenueID: venue2.ID, IsPrimary: true,
+	})
+
+	resp, err := suite.festivalService.GetFestivalVenues(festival.ID)
+
+	suite.Require().NoError(err)
+	suite.Require().Len(resp, 2)
+	suite.True(resp[0].IsPrimary)
+	suite.False(resp[1].IsPrimary)
+}
+
+// =============================================================================
+// Group 8: GetFestivalsForArtist (cross-entity query)
+// =============================================================================
+
+func (suite *FestivalServiceIntegrationTestSuite) TestGetFestivalsForArtist_Success() {
+	artist := suite.createTestArtistForFestival("Multi Festival Artist")
+
+	fest1 := suite.createBasicFestival("Festival One")
+	fest2 := suite.createBasicFestival("Festival Two")
+	suite.createBasicFestival("Festival Three") // not associated
+
+	suite.festivalService.AddFestivalArtist(fest1.ID, &AddFestivalArtistRequest{
+		ArtistID: artist.ID, BillingTier: "headliner",
+	})
+	suite.festivalService.AddFestivalArtist(fest2.ID, &AddFestivalArtistRequest{
+		ArtistID: artist.ID, BillingTier: "undercard",
+	})
+
+	resp, err := suite.festivalService.GetFestivalsForArtist(artist.ID)
+
+	suite.Require().NoError(err)
+	suite.Require().Len(resp, 2)
+
+	// Verify billing tier is included
+	tierMap := make(map[string]string)
+	for _, f := range resp {
+		tierMap[f.Name] = f.BillingTier
+	}
+	suite.Equal("headliner", tierMap["Festival One"])
+	suite.Equal("undercard", tierMap["Festival Two"])
+}
+
+func (suite *FestivalServiceIntegrationTestSuite) TestGetFestivalsForArtist_ArtistNotFound() {
+	resp, err := suite.festivalService.GetFestivalsForArtist(99999)
+
+	suite.Require().Error(err)
+	suite.Nil(resp)
+	var artistErr *apperrors.ArtistError
+	suite.ErrorAs(err, &artistErr)
+	suite.Equal(apperrors.CodeArtistNotFound, artistErr.Code)
+}
+
+func (suite *FestivalServiceIntegrationTestSuite) TestGetFestivalsForArtist_Empty() {
+	artist := suite.createTestArtistForFestival("No Festivals Artist")
+
+	resp, err := suite.festivalService.GetFestivalsForArtist(artist.ID)
+
+	suite.Require().NoError(err)
+	suite.Empty(resp)
+}
+
+// =============================================================================
+// Group 9: Artist and Venue counts on list/detail
+// =============================================================================
+
+func (suite *FestivalServiceIntegrationTestSuite) TestFestival_ArtistAndVenueCounts() {
+	festival := suite.createBasicFestival("Counted Festival")
+	artist1 := suite.createTestArtistForFestival("Count Artist 1")
+	artist2 := suite.createTestArtistForFestival("Count Artist 2")
+	venue := suite.createTestVenue("Count Venue", "Phoenix", "AZ")
+
+	suite.festivalService.AddFestivalArtist(festival.ID, &AddFestivalArtistRequest{ArtistID: artist1.ID})
+	suite.festivalService.AddFestivalArtist(festival.ID, &AddFestivalArtistRequest{ArtistID: artist2.ID})
+	suite.festivalService.AddFestivalVenue(festival.ID, &AddFestivalVenueRequest{VenueID: venue.ID})
+
+	// Test detail response counts
+	detail, err := suite.festivalService.GetFestival(festival.ID)
+	suite.Require().NoError(err)
+	suite.Equal(2, detail.ArtistCount)
+	suite.Equal(1, detail.VenueCount)
+
+	// Test list response counts
+	list, err := suite.festivalService.ListFestivals(map[string]interface{}{})
+	suite.Require().NoError(err)
+	suite.Require().Len(list, 1)
+	suite.Equal(2, list[0].ArtistCount)
+	suite.Equal(1, list[0].VenueCount)
+}

--- a/backend/internal/services/interfaces.go
+++ b/backend/internal/services/interfaces.go
@@ -324,6 +324,24 @@ type LabelServiceInterface interface {
 	GetLabelCatalog(labelID uint) ([]*LabelReleaseResponse, error)
 }
 
+// FestivalServiceInterface defines the contract for festival operations.
+type FestivalServiceInterface interface {
+	CreateFestival(req *CreateFestivalRequest) (*FestivalDetailResponse, error)
+	GetFestival(festivalID uint) (*FestivalDetailResponse, error)
+	GetFestivalBySlug(slug string) (*FestivalDetailResponse, error)
+	ListFestivals(filters map[string]interface{}) ([]*FestivalListResponse, error)
+	UpdateFestival(festivalID uint, req *UpdateFestivalRequest) (*FestivalDetailResponse, error)
+	DeleteFestival(festivalID uint) error
+	GetFestivalArtists(festivalID uint, dayDate *string) ([]*FestivalArtistResponse, error)
+	AddFestivalArtist(festivalID uint, req *AddFestivalArtistRequest) (*FestivalArtistResponse, error)
+	UpdateFestivalArtist(festivalID, artistID uint, req *UpdateFestivalArtistRequest) (*FestivalArtistResponse, error)
+	RemoveFestivalArtist(festivalID, artistID uint) error
+	GetFestivalVenues(festivalID uint) ([]*FestivalVenueResponse, error)
+	AddFestivalVenue(festivalID uint, req *AddFestivalVenueRequest) (*FestivalVenueResponse, error)
+	RemoveFestivalVenue(festivalID, venueID uint) error
+	GetFestivalsForArtist(artistID uint) ([]*ArtistFestivalListResponse, error)
+}
+
 // ReleaseServiceInterface defines the contract for release operations.
 type ReleaseServiceInterface interface {
 	CreateRelease(req *CreateReleaseRequest) (*ReleaseDetailResponse, error)
@@ -373,6 +391,7 @@ var (
 	_ AdminStatsServiceInterface    = (*AdminStatsService)(nil)
 	_ CalendarServiceInterface      = (*CalendarService)(nil)
 	_ ReminderServiceInterface      = (*ReminderService)(nil)
+	_ FestivalServiceInterface       = (*FestivalService)(nil)
 	_ LabelServiceInterface          = (*LabelService)(nil)
 	_ ReleaseServiceInterface       = (*ReleaseService)(nil)
 	_ BookmarkServiceInterface      = (*BookmarkService)(nil)


### PR DESCRIPTION
## Summary
- Complete festival CRUD service with 14 methods (create, read by ID/slug, list with filters, update, delete)
- Festival lineup management: add/update/remove artists with billing tiers, position, day/stage/set_time
- Festival venue management: add/remove venues with primary flag
- Cross-entity query: festivals by artist ID/slug
- 13 API endpoints (5 public, 8 admin-protected) registered in routes.go
- 82 tests (44 service integration + 38 handler integration), all passing

## Test plan
- [x] All 44 service integration tests pass (testcontainers)
- [x] All 38 handler integration tests pass
- [x] Full backend test suite passes (`go test ./...`)
- [x] Backend builds and passes `go vet`

Closes PSY-25

🤖 Generated with [Claude Code](https://claude.com/claude-code)