### PR TITLE
feat: add festival listing and detail pages with tiered lineup (PSY-27)

### DIFF
--- a/frontend/app/festivals/[slug]/page.tsx
+++ b/frontend/app/festivals/[slug]/page.tsx
@@ -1,0 +1,118 @@
+import { Suspense } from 'react'
+import { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+import * as Sentry from '@sentry/nextjs'
+import { Loader2 } from 'lucide-react'
+import { FestivalDetail } from '@/components/festivals'
+
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL ||
+  (process.env.NODE_ENV === 'development'
+    ? 'http://localhost:8080'
+    : 'https://api.psychichomily.com')
+
+interface FestivalPageProps {
+  params: Promise<{ slug: string }>
+}
+
+interface FestivalData {
+  name: string
+  slug?: string
+  city?: string | null
+  state?: string | null
+  start_date?: string
+  end_date?: string
+  status?: string
+}
+
+async function getFestival(slug: string): Promise<FestivalData | null> {
+  try {
+    const res = await fetch(`${API_BASE_URL}/festivals/${slug}`, {
+      next: { revalidate: 3600 },
+    })
+    if (res.ok) {
+      return res.json()
+    }
+    if (res.status >= 500) {
+      Sentry.captureMessage(`Festival page fetch error: ${res.status}`, {
+        level: 'error',
+        tags: { service: 'festival-page' },
+        extra: { slug, status: res.status },
+      })
+    }
+  } catch (error) {
+    Sentry.captureException(error, {
+      level: 'error',
+      tags: { service: 'festival-page' },
+      extra: { slug },
+    })
+  }
+  return null
+}
+
+export async function generateMetadata({
+  params,
+}: FestivalPageProps): Promise<Metadata> {
+  const { slug } = await params
+  const festival = await getFestival(slug)
+
+  if (festival) {
+    const locationSuffix =
+      festival.city && festival.state ? ` - ${festival.city}, ${festival.state}` : ''
+    return {
+      title: `${festival.name}${locationSuffix}`,
+      description: `${festival.name}${locationSuffix} - festival details on Psychic Homily`,
+      alternates: {
+        canonical: `https://psychichomily.com/festivals/${slug}`,
+      },
+      openGraph: {
+        title: `${festival.name}${locationSuffix}`,
+        description: `View details for ${festival.name}`,
+        type: 'website',
+        url: `/festivals/${slug}`,
+      },
+    }
+  }
+
+  return {
+    title: 'Festival',
+    description: 'View festival details',
+  }
+}
+
+function FestivalLoadingFallback() {
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center">
+      <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+    </div>
+  )
+}
+
+export default async function FestivalPage({ params }: FestivalPageProps) {
+  const { slug } = await params
+
+  if (!slug) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold mb-2">Invalid Festival</h1>
+          <p className="text-muted-foreground">
+            The festival could not be found.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  const festivalData = await getFestival(slug)
+
+  if (!festivalData) {
+    notFound()
+  }
+
+  return (
+    <Suspense fallback={<FestivalLoadingFallback />}>
+      <FestivalDetail idOrSlug={slug} />
+    </Suspense>
+  )
+}

--- a/frontend/app/festivals/page.tsx
+++ b/frontend/app/festivals/page.tsx
@@ -1,0 +1,36 @@
+import { Suspense } from 'react'
+import { FestivalList } from '@/components/festivals'
+import { LoadingSpinner } from '@/components/shared'
+
+export const metadata = {
+  title: 'Festivals',
+  description: 'Browse music festivals, lineups, and schedules.',
+  alternates: {
+    canonical: 'https://psychichomily.com/festivals',
+  },
+  openGraph: {
+    title: 'Festivals | Psychic Homily',
+    description: 'Browse music festivals, lineups, and schedules.',
+    url: '/festivals',
+    type: 'website',
+  },
+}
+
+export default function FestivalsPage() {
+  return (
+    <div className="flex min-h-screen items-start justify-center">
+      <main className="w-full max-w-6xl px-4 py-8 md:px-8">
+        <h1 className="text-3xl font-bold text-center mb-8">Festivals</h1>
+        <Suspense
+          fallback={
+            <div className="flex justify-center items-center py-12">
+              <LoadingSpinner />
+            </div>
+          }
+        >
+          <FestivalList />
+        </Suspense>
+      </main>
+    </div>
+  )
+}

--- a/frontend/components/admin/FestivalManagement.tsx
+++ b/frontend/components/admin/FestivalManagement.tsx
@@ -1156,7 +1156,7 @@ function LineupManagement({ festivalId }: { festivalId: number }) {
 
 function VenueManagement({ festivalId }: { festivalId: number }) {
   const { data: venuesData, isLoading } = useFestivalVenues({
-    festivalId,
+    festivalIdOrSlug: festivalId,
     enabled: festivalId > 0,
   })
   const addVenueMutation = useAddFestivalVenue()

--- a/frontend/components/festivals/FestivalCard.tsx
+++ b/frontend/components/festivals/FestivalCard.tsx
@@ -1,0 +1,122 @@
+'use client'
+
+import Link from 'next/link'
+import { Calendar, MapPin, Users } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { Badge } from '@/components/ui/badge'
+import {
+  getFestivalStatusLabel,
+  getFestivalStatusVariant,
+  formatFestivalDateRange,
+} from '@/lib/types/festival'
+import type { FestivalListItem } from '@/lib/types/festival'
+
+export type FestivalCardDensity = 'compact' | 'comfortable' | 'expanded'
+
+interface FestivalCardProps {
+  festival: FestivalListItem
+  density?: FestivalCardDensity
+}
+
+export function FestivalCard({
+  festival,
+  density = 'comfortable',
+}: FestivalCardProps) {
+  const location =
+    festival.city && festival.state
+      ? `${festival.city}, ${festival.state}`
+      : festival.city ?? festival.state ?? null
+  const dateRange = formatFestivalDateRange(festival.start_date, festival.end_date)
+
+  return (
+    <article
+      className={cn(
+        'rounded-lg border border-border/50 bg-card transition-shadow hover:shadow-sm',
+        density === 'compact' && 'p-3',
+        density === 'comfortable' && 'p-4',
+        density === 'expanded' && 'p-5'
+      )}
+    >
+      <div className="flex gap-3">
+        {/* Date badge */}
+        <div
+          className={cn(
+            'shrink-0 rounded-md bg-muted/50 flex flex-col items-center justify-center text-center',
+            density === 'compact' && 'h-12 w-12',
+            density === 'comfortable' && 'h-16 w-16',
+            density === 'expanded' && 'h-20 w-20'
+          )}
+        >
+          <span
+            className={cn(
+              'font-bold leading-tight text-foreground',
+              density === 'compact' && 'text-sm',
+              density === 'comfortable' && 'text-base',
+              density === 'expanded' && 'text-lg'
+            )}
+          >
+            {festival.edition_year}
+          </span>
+        </div>
+
+        {/* Text Content */}
+        <div className="flex-1 min-w-0">
+          <Link href={`/festivals/${festival.slug}`} className="block group">
+            <h3
+              className={cn(
+                'font-bold text-foreground group-hover:text-primary transition-colors truncate',
+                density === 'compact' && 'text-sm',
+                density === 'comfortable' && 'text-base',
+                density === 'expanded' && 'text-lg'
+              )}
+            >
+              {festival.name}
+            </h3>
+          </Link>
+
+          <div
+            className={cn(
+              'flex items-center gap-2 flex-wrap',
+              density === 'compact' && 'mt-0.5',
+              density === 'comfortable' && 'mt-1',
+              density === 'expanded' && 'mt-1.5'
+            )}
+          >
+            <Badge
+              variant={getFestivalStatusVariant(festival.status)}
+              className="text-[10px] px-1.5 py-0"
+            >
+              {getFestivalStatusLabel(festival.status)}
+            </Badge>
+            {location && (
+              <span
+                className={cn(
+                  'flex items-center gap-1 text-muted-foreground',
+                  density === 'compact' ? 'text-xs' : 'text-sm'
+                )}
+              >
+                <MapPin className="h-3 w-3" />
+                {location}
+              </span>
+            )}
+          </div>
+
+          {density !== 'compact' && (
+            <div className="mt-1 flex items-center gap-3 text-sm text-muted-foreground">
+              <span className="flex items-center gap-1">
+                <Calendar className="h-3.5 w-3.5" />
+                {dateRange}
+              </span>
+              <span className="flex items-center gap-1">
+                <Users className="h-3.5 w-3.5" />
+                {festival.artist_count === 1
+                  ? '1 artist'
+                  : `${festival.artist_count} artists`}
+              </span>
+            </div>
+          )}
+        </div>
+      </div>
+    </article>
+  )
+}

--- a/frontend/components/festivals/FestivalDetail.tsx
+++ b/frontend/components/festivals/FestivalDetail.tsx
@@ -1,0 +1,380 @@
+'use client'
+
+import { useState, useMemo } from 'react'
+import Link from 'next/link'
+import {
+  Loader2,
+  Calendar,
+  MapPin,
+  Users,
+  Globe,
+  Ticket,
+  Building2,
+} from 'lucide-react'
+import {
+  useFestival,
+  useFestivalArtists,
+  useFestivalVenues,
+} from '@/lib/hooks/useFestivals'
+import { EntityDetailLayout, EntityHeader, SocialLinks } from '@/components/shared'
+import { TabsContent } from '@/components/ui/tabs'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { FestivalLineup } from './FestivalLineup'
+import {
+  getFestivalStatusLabel,
+  getFestivalStatusVariant,
+  formatFestivalLocation,
+  formatFestivalDateRange,
+} from '@/lib/types/festival'
+
+interface FestivalDetailProps {
+  idOrSlug: string | number
+}
+
+export function FestivalDetail({ idOrSlug }: FestivalDetailProps) {
+  const { data: festival, isLoading, error } = useFestival({ idOrSlug })
+  const { data: artistsData, isLoading: artistsLoading } = useFestivalArtists({
+    festivalIdOrSlug: idOrSlug,
+    enabled: !!festival,
+  })
+  const { data: venuesData, isLoading: venuesLoading } = useFestivalVenues({
+    festivalIdOrSlug: idOrSlug,
+    enabled: !!festival,
+  })
+  const [activeTab, setActiveTab] = useState('lineup')
+
+  // Determine if this is a multi-day festival with day assignments
+  const hasMultipleDays = useMemo(() => {
+    if (!artistsData?.artists) return false
+    const uniqueDays = new Set(
+      artistsData.artists
+        .map(a => a.day_date)
+        .filter(Boolean)
+    )
+    return uniqueDays.size > 1
+  }, [artistsData])
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  if (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : 'Failed to load festival'
+    const is404 =
+      errorMessage.includes('not found') || errorMessage.includes('404')
+
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold mb-2">
+            {is404 ? 'Festival Not Found' : 'Error Loading Festival'}
+          </h1>
+          <p className="text-muted-foreground mb-4">
+            {is404
+              ? "The festival you're looking for doesn't exist or has been removed."
+              : errorMessage}
+          </p>
+          <Button asChild variant="outline">
+            <Link href="/festivals">Back to Festivals</Link>
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  if (!festival) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold mb-2">Festival Not Found</h1>
+          <p className="text-muted-foreground mb-4">
+            The festival you&apos;re looking for doesn&apos;t exist.
+          </p>
+          <Button asChild variant="outline">
+            <Link href="/festivals">Back to Festivals</Link>
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  const location = formatFestivalLocation(festival)
+  const dateRange = formatFestivalDateRange(festival.start_date, festival.end_date)
+  const artists = artistsData?.artists ?? []
+  const venues = venuesData?.venues ?? []
+
+  const tabs = [
+    { value: 'lineup', label: `Lineup (${festival.artist_count})` },
+    { value: 'info', label: 'Info' },
+  ]
+
+  const sidebar = (
+    <div className="space-y-6">
+      {/* Festival Flyer or Placeholder */}
+      {festival.flyer_url ? (
+        <div className="rounded-lg border border-border/50 bg-card overflow-hidden">
+          <img
+            src={festival.flyer_url}
+            alt={`${festival.name} flyer`}
+            className="w-full object-contain"
+          />
+        </div>
+      ) : (
+        <div className="rounded-lg border border-border/50 bg-card overflow-hidden">
+          <div className="w-full aspect-square bg-muted/30 flex items-center justify-center">
+            <Calendar className="h-16 w-16 text-muted-foreground/30" />
+          </div>
+        </div>
+      )}
+
+      {/* Quick Info */}
+      <div className="rounded-lg border border-border/50 bg-card p-4 space-y-3">
+        <h3 className="text-sm font-semibold text-foreground">Details</h3>
+
+        <div className="space-y-2 text-sm">
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <Calendar className="h-4 w-4 shrink-0" />
+            <span>{dateRange}</span>
+          </div>
+
+          {location && (
+            <div className="flex items-center gap-2 text-muted-foreground">
+              <MapPin className="h-4 w-4 shrink-0" />
+              <span>{location}</span>
+            </div>
+          )}
+
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <Users className="h-4 w-4 shrink-0" />
+            <span>
+              {festival.artist_count === 1
+                ? '1 artist'
+                : `${festival.artist_count} artists`}
+            </span>
+          </div>
+
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <Building2 className="h-4 w-4 shrink-0" />
+            <span>
+              {festival.venue_count === 1
+                ? '1 venue'
+                : `${festival.venue_count} venues`}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* Venues */}
+      {venues.length > 0 && (
+        <div className="rounded-lg border border-border/50 bg-card p-4 space-y-3">
+          <h3 className="text-sm font-semibold text-foreground">Venues</h3>
+          <div className="space-y-2 text-sm">
+            {venues.map(venue => (
+              <div key={venue.id} className="flex items-center gap-2">
+                <Building2 className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                <Link
+                  href={venue.venue_slug ? `/venues/${venue.venue_slug}` : '#'}
+                  className="text-foreground hover:text-primary transition-colors"
+                >
+                  {venue.venue_name}
+                </Link>
+                {venue.is_primary && (
+                  <Badge
+                    variant="secondary"
+                    className="text-[10px] px-1.5 py-0"
+                  >
+                    Primary
+                  </Badge>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Links */}
+      <div className="rounded-lg border border-border/50 bg-card p-4 space-y-3">
+        <h3 className="text-sm font-semibold text-foreground">Links</h3>
+        <div className="space-y-2 text-sm">
+          {festival.website && (
+            <a
+              href={festival.website}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-2 text-primary hover:text-primary/80 transition-colors"
+            >
+              <Globe className="h-4 w-4 shrink-0" />
+              <span>Website</span>
+            </a>
+          )}
+          {festival.ticket_url && (
+            <a
+              href={festival.ticket_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-2 text-primary hover:text-primary/80 transition-colors"
+            >
+              <Ticket className="h-4 w-4 shrink-0" />
+              <span>Tickets</span>
+            </a>
+          )}
+          {festival.social && <SocialLinks social={festival.social} />}
+        </div>
+      </div>
+    </div>
+  )
+
+  return (
+    <EntityDetailLayout
+      backLink={{ href: '/festivals', label: 'Back to Festivals' }}
+      header={
+        <EntityHeader
+          title={festival.name}
+          subtitle={
+            <>
+              <Badge variant={getFestivalStatusVariant(festival.status)}>
+                {getFestivalStatusLabel(festival.status)}
+              </Badge>
+              <span className="flex items-center gap-1">
+                <Calendar className="h-3.5 w-3.5" />
+                {dateRange}
+              </span>
+              {location && (
+                <span className="flex items-center gap-1">
+                  <MapPin className="h-3.5 w-3.5" />
+                  {location}
+                </span>
+              )}
+            </>
+          }
+        />
+      }
+      tabs={tabs}
+      activeTab={activeTab}
+      onTabChange={setActiveTab}
+      sidebar={sidebar}
+    >
+      {/* Lineup Tab */}
+      <TabsContent value="lineup">
+        {artistsLoading ? (
+          <div className="flex justify-center py-8">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        ) : (
+          <FestivalLineup
+            artists={artists}
+            multiDay={hasMultipleDays}
+          />
+        )}
+      </TabsContent>
+
+      {/* Info Tab */}
+      <TabsContent value="info">
+        <div className="space-y-8">
+          {/* Description */}
+          {festival.description && (
+            <div>
+              <h2 className="text-lg font-semibold mb-3">About</h2>
+              <p className="text-muted-foreground leading-relaxed whitespace-pre-line">
+                {festival.description}
+              </p>
+            </div>
+          )}
+
+          {/* Venues Section */}
+          {venuesLoading ? (
+            <div className="flex justify-center py-8">
+              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+            </div>
+          ) : venues.length > 0 ? (
+            <div>
+              <h2 className="text-lg font-semibold mb-4">Venues</h2>
+              <div className="space-y-2">
+                {venues.map(venue => (
+                  <div
+                    key={venue.id}
+                    className="flex items-center gap-3 rounded-lg border border-border/50 bg-card p-3"
+                  >
+                    <Building2 className="h-4 w-4 text-muted-foreground shrink-0" />
+                    <div className="flex-1 min-w-0">
+                      <Link
+                        href={
+                          venue.venue_slug
+                            ? `/venues/${venue.venue_slug}`
+                            : '#'
+                        }
+                        className="font-medium text-foreground hover:text-primary transition-colors"
+                      >
+                        {venue.venue_name}
+                      </Link>
+                      <p className="text-xs text-muted-foreground">
+                        {venue.city}, {venue.state}
+                      </p>
+                    </div>
+                    {venue.is_primary && (
+                      <Badge
+                        variant="secondary"
+                        className="text-[10px] px-1.5 py-0"
+                      >
+                        Primary
+                      </Badge>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : null}
+
+          {/* Social / External Links */}
+          {(festival.website || festival.ticket_url || festival.social) && (
+            <div>
+              <h2 className="text-lg font-semibold mb-3">Links</h2>
+              <div className="space-y-2">
+                {festival.website && (
+                  <a
+                    href={festival.website}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-2 text-primary hover:text-primary/80 transition-colors text-sm"
+                  >
+                    <Globe className="h-4 w-4" />
+                    Official Website
+                  </a>
+                )}
+                {festival.ticket_url && (
+                  <a
+                    href={festival.ticket_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-2 text-primary hover:text-primary/80 transition-colors text-sm"
+                  >
+                    <Ticket className="h-4 w-4" />
+                    Buy Tickets
+                  </a>
+                )}
+                {festival.social && <SocialLinks social={festival.social} />}
+              </div>
+            </div>
+          )}
+
+          {/* Fallback if no info */}
+          {!festival.description &&
+            venues.length === 0 &&
+            !festival.website &&
+            !festival.ticket_url &&
+            !festival.social && (
+              <div className="text-sm text-muted-foreground">
+                No additional information available for this festival.
+              </div>
+            )}
+        </div>
+      </TabsContent>
+    </EntityDetailLayout>
+  )
+}

--- a/frontend/components/festivals/FestivalLineup.tsx
+++ b/frontend/components/festivals/FestivalLineup.tsx
@@ -1,0 +1,225 @@
+'use client'
+
+import { useMemo } from 'react'
+import Link from 'next/link'
+import { cn } from '@/lib/utils'
+import type { FestivalArtist } from '@/lib/types/festival'
+import {
+  BILLING_TIER_ORDER,
+  getBillingTierLabel,
+} from '@/lib/types/festival'
+import type { BillingTier } from '@/lib/types/festival'
+
+interface FestivalLineupProps {
+  artists: FestivalArtist[]
+  /** If true, group by day_date before billing tier */
+  multiDay?: boolean
+}
+
+interface TierGroup {
+  tier: BillingTier
+  artists: FestivalArtist[]
+}
+
+interface DayGroup {
+  date: string | null
+  label: string
+  tiers: TierGroup[]
+}
+
+/**
+ * Groups artists by billing tier, maintaining the tier ordering.
+ */
+function groupByTier(artists: FestivalArtist[]): TierGroup[] {
+  const tierMap = new Map<string, FestivalArtist[]>()
+
+  for (const artist of artists) {
+    const tier = artist.billing_tier || 'mid_card'
+    if (!tierMap.has(tier)) {
+      tierMap.set(tier, [])
+    }
+    tierMap.get(tier)!.push(artist)
+  }
+
+  // Return in the defined display order
+  const groups: TierGroup[] = []
+  for (const tier of BILLING_TIER_ORDER) {
+    const tierArtists = tierMap.get(tier)
+    if (tierArtists && tierArtists.length > 0) {
+      groups.push({ tier, artists: tierArtists })
+    }
+  }
+
+  // Include any unrecognized tiers at the end
+  for (const [tier, tierArtists] of tierMap) {
+    if (!BILLING_TIER_ORDER.includes(tier as BillingTier) && tierArtists.length > 0) {
+      groups.push({ tier: tier as BillingTier, artists: tierArtists })
+    }
+  }
+
+  return groups
+}
+
+/**
+ * Format a day date for display as a day header.
+ */
+function formatDayLabel(dateStr: string): string {
+  const date = new Date(dateStr + 'T00:00:00')
+  return date.toLocaleDateString('en-US', {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+  })
+}
+
+/**
+ * Tiered lineup display component that visually represents festival billing.
+ * Headliners get large text, sub-headliners medium, and lower tiers progressively smaller.
+ * Artists are links to their artist pages.
+ */
+export function FestivalLineup({ artists, multiDay = false }: FestivalLineupProps) {
+  const dayGroups = useMemo((): DayGroup[] => {
+    if (!multiDay) {
+      return [
+        {
+          date: null,
+          label: '',
+          tiers: groupByTier(artists),
+        },
+      ]
+    }
+
+    // Group by day_date first
+    const dayMap = new Map<string, FestivalArtist[]>()
+    const unassigned: FestivalArtist[] = []
+
+    for (const artist of artists) {
+      if (artist.day_date) {
+        if (!dayMap.has(artist.day_date)) {
+          dayMap.set(artist.day_date, [])
+        }
+        dayMap.get(artist.day_date)!.push(artist)
+      } else {
+        unassigned.push(artist)
+      }
+    }
+
+    // Sort days chronologically
+    const sortedDays = Array.from(dayMap.entries()).sort(([a], [b]) =>
+      a.localeCompare(b)
+    )
+
+    const groups: DayGroup[] = sortedDays.map(([date, dayArtists]) => ({
+      date,
+      label: formatDayLabel(date),
+      tiers: groupByTier(dayArtists),
+    }))
+
+    if (unassigned.length > 0) {
+      groups.push({
+        date: null,
+        label: 'Additional Artists',
+        tiers: groupByTier(unassigned),
+      })
+    }
+
+    return groups
+  }, [artists, multiDay])
+
+  if (artists.length === 0) {
+    return (
+      <div className="text-center py-12 text-muted-foreground">
+        <p>No artists have been announced for this festival yet.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-8">
+      {dayGroups.map((day, dayIdx) => (
+        <div key={day.date ?? `day-${dayIdx}`}>
+          {day.label && (
+            <h3 className="text-lg font-semibold mb-4 pb-2 border-b border-border/50">
+              {day.label}
+            </h3>
+          )}
+
+          <div className="space-y-6">
+            {day.tiers.map(tierGroup => (
+              <TierSection key={tierGroup.tier} tierGroup={tierGroup} />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function TierSection({ tierGroup }: { tierGroup: TierGroup }) {
+  const { tier, artists } = tierGroup
+
+  return (
+    <div>
+      <h4
+        className={cn(
+          'uppercase tracking-wider mb-3',
+          tier === 'headliner' && 'text-xs font-bold text-primary/80',
+          tier === 'sub_headliner' && 'text-xs font-semibold text-muted-foreground',
+          tier !== 'headliner' &&
+            tier !== 'sub_headliner' &&
+            'text-[11px] font-medium text-muted-foreground/70'
+        )}
+      >
+        {getBillingTierLabel(tier)}
+      </h4>
+
+      <div
+        className={cn(
+          'flex flex-wrap items-baseline',
+          tier === 'headliner' && 'gap-x-6 gap-y-2',
+          tier === 'sub_headliner' && 'gap-x-4 gap-y-1.5',
+          tier !== 'headliner' &&
+            tier !== 'sub_headliner' &&
+            'gap-x-3 gap-y-1'
+        )}
+      >
+        {artists.map((artist, idx) => (
+          <span key={artist.id} className="inline-flex items-baseline">
+            <Link
+              href={artist.artist_slug ? `/artists/${artist.artist_slug}` : '#'}
+              className={cn(
+                'transition-colors hover:text-primary',
+                tier === 'headliner' &&
+                  'text-xl md:text-2xl font-black text-foreground',
+                tier === 'sub_headliner' &&
+                  'text-lg md:text-xl font-bold text-foreground/90',
+                tier === 'mid_card' &&
+                  'text-base font-semibold text-foreground/80',
+                tier === 'undercard' &&
+                  'text-sm font-medium text-foreground/70',
+                (tier === 'local' || tier === 'dj' || tier === 'host') &&
+                  'text-sm font-normal text-muted-foreground'
+              )}
+            >
+              {artist.artist_name}
+            </Link>
+            {idx < artists.length - 1 && (
+              <span
+                className={cn(
+                  'mx-1 select-none',
+                  tier === 'headliner'
+                    ? 'text-primary/30 text-xl'
+                    : tier === 'sub_headliner'
+                      ? 'text-muted-foreground/30 text-lg'
+                      : 'text-muted-foreground/20 text-sm'
+                )}
+              >
+                {'\u00b7'}
+              </span>
+            )}
+          </span>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/components/festivals/FestivalList.tsx
+++ b/frontend/components/festivals/FestivalList.tsx
@@ -1,0 +1,176 @@
+'use client'
+
+import { useTransition } from 'react'
+import { useSearchParams, useRouter } from 'next/navigation'
+import { useFestivals } from '@/lib/hooks/useFestivals'
+import { FestivalCard } from './FestivalCard'
+import { LoadingSpinner, DensityToggle } from '@/components/shared'
+import { useDensity } from '@/lib/hooks/useDensity'
+import { Button } from '@/components/ui/button'
+import { FESTIVAL_STATUSES, FESTIVAL_STATUS_LABELS } from '@/lib/types/festival'
+import type { FestivalStatus } from '@/lib/types/festival'
+
+export function FestivalList() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const [isPending, startTransition] = useTransition()
+  const { density } = useDensity('festivals')
+
+  // Parse filters from URL
+  const statusParam = searchParams.get('status') as FestivalStatus | null
+  const yearParam = searchParams.get('year')
+  const cityParam = searchParams.get('city')
+
+  const { data, isLoading, isFetching, error, refetch } = useFestivals({
+    status: statusParam ?? undefined,
+    year: yearParam ? parseInt(yearParam, 10) : undefined,
+    city: cityParam ?? undefined,
+  })
+
+  const updateFilters = (params: {
+    status?: string | null
+    year?: string | null
+    city?: string | null
+  }) => {
+    const newParams = new URLSearchParams()
+    const newStatus =
+      params.status !== undefined ? params.status : statusParam
+    const newYear = params.year !== undefined ? params.year : yearParam
+    const newCity = params.city !== undefined ? params.city : cityParam
+
+    if (newStatus) newParams.set('status', newStatus)
+    if (newYear) newParams.set('year', newYear)
+    if (newCity) newParams.set('city', newCity)
+
+    const queryString = newParams.toString()
+    startTransition(() => {
+      router.push(queryString ? `/festivals?${queryString}` : '/festivals')
+    })
+  }
+
+  const handleStatusChange = (status: string | null) => {
+    updateFilters({ status })
+  }
+
+  const clearFilters = () => {
+    startTransition(() => {
+      router.push('/festivals')
+    })
+  }
+
+  if (isLoading && !data) {
+    return (
+      <div className="flex justify-center items-center py-12">
+        <LoadingSpinner />
+      </div>
+    )
+  }
+
+  const isUpdating = isFetching || isPending
+
+  if (error) {
+    return (
+      <div className="text-center py-12 text-destructive">
+        <p>Failed to load festivals. Please try again later.</p>
+        <Button variant="outline" className="mt-4" onClick={() => refetch()}>
+          Retry
+        </Button>
+      </div>
+    )
+  }
+
+  const festivals = data?.festivals ?? []
+  const hasFilters = !!statusParam || !!yearParam || !!cityParam
+
+  return (
+    <section className="w-full max-w-6xl">
+      {/* Filters */}
+      <div className="mb-6 space-y-4">
+        {/* Status Filter */}
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-sm text-muted-foreground mr-1">Status:</span>
+          <button
+            onClick={() => handleStatusChange(null)}
+            className={`px-2.5 py-1 text-xs font-medium rounded-md transition-colors ${
+              !statusParam
+                ? 'bg-background text-foreground shadow-sm border border-border/50'
+                : 'text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            All
+          </button>
+          {FESTIVAL_STATUSES.map(status => (
+            <button
+              key={status}
+              onClick={() => handleStatusChange(status)}
+              className={`px-2.5 py-1 text-xs font-medium rounded-md transition-colors ${
+                statusParam === status
+                  ? 'bg-background text-foreground shadow-sm border border-border/50'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              {FESTIVAL_STATUS_LABELS[status]}
+            </button>
+          ))}
+          {hasFilters && (
+            <button
+              onClick={clearFilters}
+              className="text-xs text-muted-foreground hover:text-foreground underline ml-2"
+            >
+              Clear filters
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="flex justify-end mb-4">
+        <DensityToggle storageKey="festivals" />
+      </div>
+
+      {/* Festival Grid */}
+      <div
+        className={
+          isUpdating
+            ? 'opacity-60 transition-opacity duration-75'
+            : 'transition-opacity duration-75'
+        }
+      >
+        {festivals.length === 0 ? (
+          <div className="text-center py-12 text-muted-foreground">
+            <p>
+              {hasFilters
+                ? 'No festivals found matching your filters.'
+                : 'No festivals available at this time.'}
+            </p>
+            {hasFilters && (
+              <button
+                onClick={clearFilters}
+                className="mt-4 text-primary hover:underline"
+              >
+                View all festivals
+              </button>
+            )}
+          </div>
+        ) : (
+          <div
+            className={
+              density === 'compact'
+                ? 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-2'
+                : density === 'expanded'
+                  ? 'grid grid-cols-1 sm:grid-cols-2 gap-4'
+                  : 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3'
+            }
+          >
+            {festivals.map(festival => (
+              <FestivalCard
+                key={festival.id}
+                festival={festival}
+                density={density}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/frontend/components/festivals/index.ts
+++ b/frontend/components/festivals/index.ts
@@ -1,0 +1,4 @@
+export { FestivalCard } from './FestivalCard'
+export { FestivalDetail } from './FestivalDetail'
+export { FestivalLineup } from './FestivalLineup'
+export { FestivalList } from './FestivalList'

--- a/frontend/components/layout/CommandPalette.tsx
+++ b/frontend/components/layout/CommandPalette.tsx
@@ -12,7 +12,7 @@ import {
   CommandSeparator,
 } from '@/components/ui/command'
 import {
-  Calendar, Mic2, MapPin, Disc3, Tag, BookOpen, Headphones, Send,
+  Calendar, Mic2, MapPin, Disc3, Tag, Tent, BookOpen, Headphones, Send,
   Library, Settings, Shield, Search, Clock, X,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
@@ -34,6 +34,12 @@ const routes: RouteItem[] = [
     href: '/shows',
     icon: Calendar,
     keywords: ['shows', 'concerts', 'events', 'live', 'music', 'gigs'],
+  },
+  {
+    label: 'Festivals',
+    href: '/festivals',
+    icon: Tent,
+    keywords: ['festivals', 'fests', 'lineup', 'multi-day', 'outdoor', 'music festival'],
   },
   {
     label: 'Artists',

--- a/frontend/components/layout/Sidebar.test.tsx
+++ b/frontend/components/layout/Sidebar.test.tsx
@@ -25,7 +25,7 @@ describe('sidebarGroups', () => {
 
   it('Discover contains Shows, Artists, Venues', () => {
     const discover = sidebarGroups.find(g => g.label === 'Discover')!
-    expect(discover.items.map(i => i.label)).toEqual(['Shows', 'Artists', 'Venues', 'Releases', 'Labels'])
+    expect(discover.items.map(i => i.label)).toEqual(['Shows', 'Festivals', 'Artists', 'Venues', 'Releases', 'Labels'])
   })
 
   it('Community contains Blog, DJ Sets, Substack, Submissions', () => {
@@ -76,6 +76,7 @@ describe('Sidebar', () => {
   it('renders all nav item labels when expanded', () => {
     render(<Sidebar collapsed={false} onToggleCollapse={onToggleCollapse} />)
     expect(screen.getByText('Shows')).toBeInTheDocument()
+    expect(screen.getByText('Festivals')).toBeInTheDocument()
     expect(screen.getByText('Artists')).toBeInTheDocument()
     expect(screen.getByText('Venues')).toBeInTheDocument()
     expect(screen.getByText('Blog')).toBeInTheDocument()

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import {
-  Calendar, Mic2, MapPin, Disc3, Tag, BookOpen, Headphones, Newspaper,
+  Calendar, Mic2, MapPin, Disc3, Tag, Tent, BookOpen, Headphones, Newspaper,
   Send, Library, Settings, Shield, PanelLeftClose, PanelLeft,
   ExternalLink,
 } from 'lucide-react'
@@ -31,6 +31,7 @@ export const sidebarGroups: SidebarGroup[] = [
     label: 'Discover',
     items: [
       { href: '/shows', label: 'Shows', icon: Calendar },
+      { href: '/festivals', label: 'Festivals', icon: Tent },
       { href: '/artists', label: 'Artists', icon: Mic2 },
       { href: '/venues', label: 'Venues', icon: MapPin },
       { href: '/releases', label: 'Releases', icon: Disc3 },

--- a/frontend/lib/hooks/useFestivals.ts
+++ b/frontend/lib/hooks/useFestivals.ts
@@ -85,28 +85,27 @@ export function useFestival(options: UseFestivalOptions) {
   })
 }
 
-interface UseFestivalLineupOptions {
-  festivalId: string | number
+interface UseFestivalArtistsOptions {
+  festivalIdOrSlug: string | number
   dayDate?: string
   enabled?: boolean
 }
 
 /**
- * Hook to fetch a festival's artist lineup
+ * Hook to fetch the lineup (artists) for a festival
  */
-export function useFestivalLineup(options: UseFestivalLineupOptions) {
-  const { festivalId, dayDate, enabled = true } = options
+export function useFestivalArtists(options: UseFestivalArtistsOptions) {
+  const { festivalIdOrSlug, dayDate, enabled = true } = options
 
   const params = new URLSearchParams()
   if (dayDate) params.set('day_date', dayDate)
-  const queryString = params.toString()
 
-  const endpoint = queryString
-    ? `${API_ENDPOINTS.FESTIVALS.ARTISTS(festivalId)}?${queryString}`
-    : API_ENDPOINTS.FESTIVALS.ARTISTS(festivalId)
+  const queryString = params.toString()
+  const baseUrl = API_ENDPOINTS.FESTIVALS.ARTISTS(festivalIdOrSlug)
+  const endpoint = queryString ? `${baseUrl}?${queryString}` : baseUrl
 
   return useQuery({
-    queryKey: queryKeys.festivals.artists(festivalId),
+    queryKey: queryKeys.festivals.artists(festivalIdOrSlug, dayDate),
     queryFn: async (): Promise<FestivalArtistsResponse> => {
       return apiRequest<FestivalArtistsResponse>(endpoint, {
         method: 'GET',
@@ -114,37 +113,46 @@ export function useFestivalLineup(options: UseFestivalLineupOptions) {
     },
     enabled:
       enabled &&
-      (typeof festivalId === 'string'
-        ? Boolean(festivalId)
-        : festivalId > 0),
+      (typeof festivalIdOrSlug === 'string'
+        ? Boolean(festivalIdOrSlug)
+        : festivalIdOrSlug > 0),
     staleTime: 5 * 60 * 1000,
   })
 }
 
+/** Alias for backward compatibility with admin components */
+export function useFestivalLineup(options: { festivalId: string | number; dayDate?: string; enabled?: boolean }) {
+  return useFestivalArtists({
+    festivalIdOrSlug: options.festivalId,
+    dayDate: options.dayDate,
+    enabled: options.enabled,
+  })
+}
+
 interface UseFestivalVenuesOptions {
-  festivalId: string | number
+  festivalIdOrSlug: string | number
   enabled?: boolean
 }
 
 /**
- * Hook to fetch a festival's venues
+ * Hook to fetch venues for a festival
  */
 export function useFestivalVenues(options: UseFestivalVenuesOptions) {
-  const { festivalId, enabled = true } = options
+  const { festivalIdOrSlug, enabled = true } = options
 
   return useQuery({
-    queryKey: queryKeys.festivals.venues(festivalId),
+    queryKey: queryKeys.festivals.venues(festivalIdOrSlug),
     queryFn: async (): Promise<FestivalVenuesResponse> => {
       return apiRequest<FestivalVenuesResponse>(
-        API_ENDPOINTS.FESTIVALS.VENUES(festivalId),
+        API_ENDPOINTS.FESTIVALS.VENUES(festivalIdOrSlug),
         { method: 'GET' }
       )
     },
     enabled:
       enabled &&
-      (typeof festivalId === 'string'
-        ? Boolean(festivalId)
-        : festivalId > 0),
+      (typeof festivalIdOrSlug === 'string'
+        ? Boolean(festivalIdOrSlug)
+        : festivalIdOrSlug > 0),
     staleTime: 5 * 60 * 1000,
   })
 }

--- a/frontend/lib/queryClient.ts
+++ b/frontend/lib/queryClient.ts
@@ -193,10 +193,10 @@ export const queryKeys = {
     list: (filters?: Record<string, unknown>) =>
       ['festivals', 'list', filters] as const,
     detail: (idOrSlug: string | number) => ['festivals', 'detail', String(idOrSlug)] as const,
-    artists: (festivalId: string | number) =>
-      ['festivals', 'artists', String(festivalId)] as const,
-    venues: (festivalId: string | number) =>
-      ['festivals', 'venues', String(festivalId)] as const,
+    artists: (idOrSlug: string | number, dayDate?: string) =>
+      ['festivals', 'artists', String(idOrSlug), dayDate] as const,
+    venues: (idOrSlug: string | number) =>
+      ['festivals', 'venues', String(idOrSlug)] as const,
     artistFestivals: (artistIdOrSlug: string | number) =>
       ['festivals', 'artist', String(artistIdOrSlug)] as const,
   },

--- a/frontend/lib/types/festival.ts
+++ b/frontend/lib/types/festival.ts
@@ -82,6 +82,9 @@ export const BILLING_TIERS: BillingTier[] = [
   'host',
 ]
 
+/** Ordered billing tiers for display (alias for BILLING_TIERS) */
+export const BILLING_TIER_ORDER = BILLING_TIERS
+
 /**
  * Get a display label for a billing tier
  */
@@ -187,6 +190,9 @@ export interface ArtistFestivalListItem extends FestivalListItem {
   stage: string | null
 }
 
+/** Alias for backward compatibility */
+export type ArtistFestival = ArtistFestivalListItem
+
 export interface ArtistFestivalsResponse {
   festivals: ArtistFestivalListItem[]
   count: number
@@ -196,37 +202,45 @@ export interface ArtistFestivalsResponse {
  * Format a festival's location string
  */
 export function formatFestivalLocation(festival: {
+  location_name?: string | null
   city: string | null
   state: string | null
 }): string | null {
-  if (festival.city && festival.state) return `${festival.city}, ${festival.state}`
-  if (festival.city) return festival.city
-  if (festival.state) return festival.state
-  return null
+  const parts: string[] = []
+  if (festival.location_name) parts.push(festival.location_name)
+  if (festival.city && festival.state) {
+    parts.push(`${festival.city}, ${festival.state}`)
+  } else if (festival.city) {
+    parts.push(festival.city)
+  } else if (festival.state) {
+    parts.push(festival.state)
+  }
+  return parts.length > 0 ? parts.join(' — ') : null
 }
 
 /**
- * Format a festival's date range string
+ * Format festival date range for display
  */
-export function formatFestivalDates(startDate: string, endDate: string): string {
-  try {
-    // Parse as local dates (YYYY-MM-DD format, avoid timezone issues)
-    const [startYear, startMonth, startDay] = startDate.split('-').map(Number)
-    const [endYear, endMonth, endDay] = endDate.split('-').map(Number)
-    const start = new Date(startYear, startMonth - 1, startDay)
-    const end = new Date(endYear, endMonth - 1, endDay)
+export function formatFestivalDateRange(startDate: string, endDate: string): string {
+  const start = new Date(startDate + 'T00:00:00')
+  const end = new Date(endDate + 'T00:00:00')
 
-    const startStr = start.toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-    })
-    const endStr = end.toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-    })
-    return `${startStr} - ${endStr}`
-  } catch {
-    return `${startDate} - ${endDate}`
+  const startMonth = start.toLocaleDateString('en-US', { month: 'short' })
+  const startDay = start.getDate()
+  const endMonth = end.toLocaleDateString('en-US', { month: 'short' })
+  const endDay = end.getDate()
+  const year = start.getFullYear()
+
+  if (startDate === endDate) {
+    return `${startMonth} ${startDay}, ${year}`
   }
+
+  if (startMonth === endMonth) {
+    return `${startMonth} ${startDay}–${endDay}, ${year}`
+  }
+
+  return `${startMonth} ${startDay} – ${endMonth} ${endDay}, ${year}`
 }
+
+/** Alias for backward compatibility */
+export const formatFestivalDates = formatFestivalDateRange


### PR DESCRIPTION
## Summary
- `/festivals` listing page with status filters and density toggle
- `/festivals/:slug` detail page with tiered lineup display (poster-style visual hierarchy)
- Lineup groups artists by billing tier: headliners (2xl bold), sub-headliners, mid-card, undercard, local/dj/host
- Multi-day support with day headers when artists have day assignments
- Sidebar with flyer image, dates, location, linked venues, social/ticket links
- Festivals added to sidebar nav (Discover section) and Cmd+K command palette
- All 1079 frontend tests pass

## Test plan
- [ ] `/festivals` page lists festivals with status filter
- [ ] `/festivals/:slug` shows tiered lineup with visual hierarchy
- [ ] Multi-day festivals show day groupings
- [ ] Artists link to their artist pages, venues link to venue pages
- [ ] Festivals link appears in sidebar and Cmd+K palette

Closes PSY-27

🤖 Generated with [Claude Code](https://claude.com/claude-code)