### PR TITLE
feat: contributor profile model and API (PSY-63)

### DIFF
--- a/backend/db/migrations/000040_add_profile_visibility.down.sql
+++ b/backend/db/migrations/000040_add_profile_visibility.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_users_profile_visibility;
+ALTER TABLE users DROP COLUMN IF EXISTS profile_visibility;

--- a/backend/db/migrations/000040_add_profile_visibility.up.sql
+++ b/backend/db/migrations/000040_add_profile_visibility.up.sql
@@ -1,0 +1,4 @@
+-- Add profile_visibility to users for contributor profile privacy controls
+ALTER TABLE users ADD COLUMN profile_visibility VARCHAR(20) NOT NULL DEFAULT 'public';
+
+CREATE INDEX idx_users_profile_visibility ON users(profile_visibility);

--- a/backend/db/migrations/000041_profile_enhancements.down.sql
+++ b/backend/db/migrations/000041_profile_enhancements.down.sql
@@ -1,0 +1,4 @@
+DROP TABLE IF EXISTS user_profile_sections;
+DROP INDEX IF EXISTS idx_users_user_tier;
+ALTER TABLE users DROP COLUMN IF EXISTS user_tier;
+ALTER TABLE users DROP COLUMN IF EXISTS privacy_settings;

--- a/backend/db/migrations/000041_profile_enhancements.up.sql
+++ b/backend/db/migrations/000041_profile_enhancements.up.sql
@@ -1,0 +1,24 @@
+-- Granular privacy settings (JSONB) for per-field profile visibility control
+-- Each field: "visible", "count_only", or "hidden"
+-- Only applies when profile_visibility = 'public' (master switch)
+ALTER TABLE users ADD COLUMN privacy_settings JSONB NOT NULL DEFAULT '{"contributions":"visible","saved_shows":"hidden","attendance":"hidden","following":"count_only","collections":"visible","last_active":"visible","profile_sections":"visible"}';
+
+-- User tier for contributor rank progression
+-- Values: new_user, contributor, trusted_contributor, local_ambassador
+ALTER TABLE users ADD COLUMN user_tier VARCHAR(30) NOT NULL DEFAULT 'new_user';
+CREATE INDEX idx_users_user_tier ON users(user_tier);
+
+-- Custom profile sections (max 3 per user, enforced in service layer)
+CREATE TABLE user_profile_sections (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    title VARCHAR(255) NOT NULL,
+    content TEXT NOT NULL DEFAULT '',
+    position INT NOT NULL,
+    is_visible BOOLEAN NOT NULL DEFAULT true,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(user_id, position)
+);
+
+CREATE INDEX idx_user_profile_sections_user_id ON user_profile_sections(user_id);

--- a/backend/internal/api/handlers/contributor_profile.go
+++ b/backend/internal/api/handlers/contributor_profile.go
@@ -1,0 +1,637 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"psychic-homily-backend/internal/api/middleware"
+	"psychic-homily-backend/internal/logger"
+	"psychic-homily-backend/internal/services"
+)
+
+// ContributorProfileHandler handles contributor profile HTTP requests.
+type ContributorProfileHandler struct {
+	profileService services.ContributorProfileServiceInterface
+	userService    services.UserServiceInterface
+}
+
+// NewContributorProfileHandler creates a new contributor profile handler.
+func NewContributorProfileHandler(
+	profileService services.ContributorProfileServiceInterface,
+	userService services.UserServiceInterface,
+) *ContributorProfileHandler {
+	return &ContributorProfileHandler{
+		profileService: profileService,
+		userService:    userService,
+	}
+}
+
+// --- Request/Response Types ---
+
+type GetPublicProfileRequest struct {
+	Username string `path:"username" doc:"Username of the contributor"`
+}
+
+type GetPublicProfileResponse struct {
+	Body *services.PublicProfileResponse
+}
+
+type GetContributionHistoryRequest struct {
+	Username   string `path:"username" doc:"Username of the contributor"`
+	Limit      int    `query:"limit" default:"20" doc:"Number of contributions per page (max 100)"`
+	Offset     int    `query:"offset" default:"0" doc:"Offset for pagination"`
+	EntityType string `query:"entity_type" default:"" doc:"Filter by entity type (show, venue, artist, release, label, festival)"`
+}
+
+type GetContributionHistoryResponse struct {
+	Body struct {
+		Contributions []*services.ContributionEntry `json:"contributions"`
+		Total         int64                         `json:"total"`
+		Limit         int                           `json:"limit"`
+		Offset        int                           `json:"offset"`
+	}
+}
+
+type GetOwnProfileResponse struct {
+	Body *services.PublicProfileResponse
+}
+
+type GetOwnContributionsRequest struct {
+	Limit      int    `query:"limit" default:"20" doc:"Number of contributions per page (max 100)"`
+	Offset     int    `query:"offset" default:"0" doc:"Offset for pagination"`
+	EntityType string `query:"entity_type" default:"" doc:"Filter by entity type"`
+}
+
+type GetOwnContributionsResponse struct {
+	Body struct {
+		Contributions []*services.ContributionEntry `json:"contributions"`
+		Total         int64                         `json:"total"`
+		Limit         int                           `json:"limit"`
+		Offset        int                           `json:"offset"`
+	}
+}
+
+type UpdateProfileVisibilityRequest struct {
+	Body struct {
+		Visibility string `json:"visibility" doc:"Profile visibility: public or private"`
+	}
+}
+
+type UpdateProfileVisibilityResponse struct {
+	Body struct {
+		Success    bool   `json:"success"`
+		Visibility string `json:"visibility"`
+	}
+}
+
+type UpdatePrivacySettingsRequest struct {
+	Body services.PrivacySettings
+}
+
+type UpdatePrivacySettingsResponse struct {
+	Body struct {
+		Success  bool                     `json:"success"`
+		Settings services.PrivacySettings `json:"privacy_settings"`
+	}
+}
+
+type GetUserSectionsRequest struct {
+	Username string `path:"username" doc:"Username of the contributor"`
+}
+
+type GetUserSectionsResponse struct {
+	Body struct {
+		Sections []*services.ProfileSectionResponse `json:"sections"`
+	}
+}
+
+type GetOwnSectionsResponse struct {
+	Body struct {
+		Sections []*services.ProfileSectionResponse `json:"sections"`
+	}
+}
+
+type CreateSectionRequest struct {
+	Body struct {
+		Title    string `json:"title" doc:"Section title (1-255 chars)"`
+		Content  string `json:"content" doc:"Section content (markdown, max 10000 chars)"`
+		Position int    `json:"position" doc:"Position index (0-2)"`
+	}
+}
+
+type CreateSectionResponse struct {
+	Body *services.ProfileSectionResponse
+}
+
+type UpdateSectionRequest struct {
+	SectionID string  `path:"section_id" doc:"Section ID to update"`
+	Body      struct {
+		Title     *string `json:"title,omitempty" required:"false" doc:"Section title"`
+		Content   *string `json:"content,omitempty" required:"false" doc:"Section content (markdown)"`
+		Position  *int    `json:"position,omitempty" required:"false" doc:"Position index"`
+		IsVisible *bool   `json:"is_visible,omitempty" required:"false" doc:"Whether section is publicly visible"`
+	}
+}
+
+type UpdateSectionResponse struct {
+	Body *services.ProfileSectionResponse
+}
+
+type DeleteSectionRequest struct {
+	SectionID string `path:"section_id" doc:"Section ID to delete"`
+}
+
+type DeleteSectionResponse struct {
+	Body struct {
+		Success bool   `json:"success"`
+		Message string `json:"message"`
+	}
+}
+
+// --- Handlers ---
+
+// GetPublicProfileHandler handles GET /users/{username}.
+func (h *ContributorProfileHandler) GetPublicProfileHandler(ctx context.Context, req *GetPublicProfileRequest) (*GetPublicProfileResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	var viewerID *uint
+	user := middleware.GetUserFromContext(ctx)
+	if user != nil {
+		viewerID = &user.ID
+	}
+
+	profile, err := h.profileService.GetPublicProfile(req.Username, viewerID)
+	if err != nil {
+		logger.FromContext(ctx).Error("get_public_profile_failed",
+			"username", req.Username,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to get profile (request_id: %s)", requestID),
+		)
+	}
+
+	if profile == nil {
+		return nil, huma.Error404NotFound("User not found")
+	}
+
+	return &GetPublicProfileResponse{Body: profile}, nil
+}
+
+// GetContributionHistoryHandler handles GET /users/{username}/contributions.
+func (h *ContributorProfileHandler) GetContributionHistoryHandler(ctx context.Context, req *GetContributionHistoryRequest) (*GetContributionHistoryResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	targetUser, err := h.userService.GetUserByUsername(req.Username)
+	if err != nil {
+		logger.FromContext(ctx).Error("get_contribution_history_user_lookup_failed",
+			"username", req.Username,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to look up user (request_id: %s)", requestID),
+		)
+	}
+	if targetUser == nil {
+		return nil, huma.Error404NotFound("User not found")
+	}
+
+	viewer := middleware.GetUserFromContext(ctx)
+	isOwner := viewer != nil && viewer.ID == targetUser.ID
+
+	// Master privacy check
+	if targetUser.ProfileVisibility == "private" && !isOwner {
+		return nil, huma.Error404NotFound("User not found")
+	}
+
+	// Granular privacy check for contributions
+	if !isOwner {
+		privacy := services.DefaultPrivacySettings()
+		if targetUser.PrivacySettings != nil {
+			_ = json.Unmarshal(*targetUser.PrivacySettings, &privacy)
+		}
+
+		switch privacy.Contributions {
+		case services.PrivacyHidden:
+			return nil, huma.Error404NotFound("User not found")
+		case services.PrivacyCountOnly:
+			// Return total count but no items
+			stats, err := h.profileService.GetContributionStats(targetUser.ID)
+			if err != nil {
+				logger.FromContext(ctx).Error("get_contribution_stats_failed",
+					"user_id", targetUser.ID,
+					"error", err.Error(),
+					"request_id", requestID,
+				)
+				return nil, huma.Error500InternalServerError(
+					fmt.Sprintf("Failed to get contributions (request_id: %s)", requestID),
+				)
+			}
+			return &GetContributionHistoryResponse{
+				Body: struct {
+					Contributions []*services.ContributionEntry `json:"contributions"`
+					Total         int64                         `json:"total"`
+					Limit         int                           `json:"limit"`
+					Offset        int                           `json:"offset"`
+				}{
+					Contributions: []*services.ContributionEntry{},
+					Total:         stats.TotalContributions,
+					Limit:         req.Limit,
+					Offset:        req.Offset,
+				},
+			}, nil
+		}
+	}
+
+	contributions, total, err := h.profileService.GetContributionHistory(targetUser.ID, req.Limit, req.Offset, req.EntityType)
+	if err != nil {
+		logger.FromContext(ctx).Error("get_contribution_history_failed",
+			"user_id", targetUser.ID,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to get contributions (request_id: %s)", requestID),
+		)
+	}
+
+	return &GetContributionHistoryResponse{
+		Body: struct {
+			Contributions []*services.ContributionEntry `json:"contributions"`
+			Total         int64                         `json:"total"`
+			Limit         int                           `json:"limit"`
+			Offset        int                           `json:"offset"`
+		}{
+			Contributions: contributions,
+			Total:         total,
+			Limit:         req.Limit,
+			Offset:        req.Offset,
+		},
+	}, nil
+}
+
+// GetOwnProfileHandler handles GET /auth/profile/contributor.
+func (h *ContributorProfileHandler) GetOwnProfileHandler(ctx context.Context, req *struct{}) (*GetOwnProfileResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	profile, err := h.profileService.GetOwnProfile(user.ID)
+	if err != nil {
+		logger.FromContext(ctx).Error("get_own_profile_failed",
+			"user_id", user.ID,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to get profile (request_id: %s)", requestID),
+		)
+	}
+
+	if profile == nil {
+		return nil, huma.Error404NotFound("Profile not found")
+	}
+
+	return &GetOwnProfileResponse{Body: profile}, nil
+}
+
+// GetOwnContributionsHandler handles GET /auth/profile/contributions.
+func (h *ContributorProfileHandler) GetOwnContributionsHandler(ctx context.Context, req *GetOwnContributionsRequest) (*GetOwnContributionsResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	contributions, total, err := h.profileService.GetContributionHistory(user.ID, req.Limit, req.Offset, req.EntityType)
+	if err != nil {
+		logger.FromContext(ctx).Error("get_own_contributions_failed",
+			"user_id", user.ID,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to get contributions (request_id: %s)", requestID),
+		)
+	}
+
+	return &GetOwnContributionsResponse{
+		Body: struct {
+			Contributions []*services.ContributionEntry `json:"contributions"`
+			Total         int64                         `json:"total"`
+			Limit         int                           `json:"limit"`
+			Offset        int                           `json:"offset"`
+		}{
+			Contributions: contributions,
+			Total:         total,
+			Limit:         req.Limit,
+			Offset:        req.Offset,
+		},
+	}, nil
+}
+
+// UpdateProfileVisibilityHandler handles PATCH /auth/profile/visibility.
+func (h *ContributorProfileHandler) UpdateProfileVisibilityHandler(ctx context.Context, req *UpdateProfileVisibilityRequest) (*UpdateProfileVisibilityResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	visibility := req.Body.Visibility
+	if visibility != "public" && visibility != "private" {
+		return nil, huma.Error400BadRequest("Visibility must be 'public' or 'private'")
+	}
+
+	_, err := h.userService.UpdateUser(user.ID, map[string]any{
+		"profile_visibility": visibility,
+	})
+	if err != nil {
+		logger.FromContext(ctx).Error("update_profile_visibility_failed",
+			"user_id", user.ID,
+			"visibility", visibility,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to update visibility (request_id: %s)", requestID),
+		)
+	}
+
+	logger.FromContext(ctx).Info("profile_visibility_updated",
+		"user_id", user.ID,
+		"visibility", visibility,
+	)
+
+	return &UpdateProfileVisibilityResponse{
+		Body: struct {
+			Success    bool   `json:"success"`
+			Visibility string `json:"visibility"`
+		}{
+			Success:    true,
+			Visibility: visibility,
+		},
+	}, nil
+}
+
+// UpdatePrivacySettingsHandler handles PATCH /auth/profile/privacy.
+func (h *ContributorProfileHandler) UpdatePrivacySettingsHandler(ctx context.Context, req *UpdatePrivacySettingsRequest) (*UpdatePrivacySettingsResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	settings, err := h.profileService.UpdatePrivacySettings(user.ID, req.Body)
+	if err != nil {
+		logger.FromContext(ctx).Error("update_privacy_settings_failed",
+			"user_id", user.ID,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error400BadRequest(err.Error())
+	}
+
+	logger.FromContext(ctx).Info("privacy_settings_updated", "user_id", user.ID)
+
+	return &UpdatePrivacySettingsResponse{
+		Body: struct {
+			Success  bool                     `json:"success"`
+			Settings services.PrivacySettings `json:"privacy_settings"`
+		}{
+			Success:  true,
+			Settings: *settings,
+		},
+	}, nil
+}
+
+// GetUserSectionsHandler handles GET /users/{username}/sections.
+func (h *ContributorProfileHandler) GetUserSectionsHandler(ctx context.Context, req *GetUserSectionsRequest) (*GetUserSectionsResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	targetUser, err := h.userService.GetUserByUsername(req.Username)
+	if err != nil {
+		logger.FromContext(ctx).Error("get_user_sections_lookup_failed",
+			"username", req.Username,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to look up user (request_id: %s)", requestID),
+		)
+	}
+	if targetUser == nil {
+		return nil, huma.Error404NotFound("User not found")
+	}
+
+	// Master privacy check
+	viewer := middleware.GetUserFromContext(ctx)
+	isOwner := viewer != nil && viewer.ID == targetUser.ID
+
+	if targetUser.ProfileVisibility == "private" && !isOwner {
+		return nil, huma.Error404NotFound("User not found")
+	}
+
+	var sections []*services.ProfileSectionResponse
+	if isOwner {
+		sections, err = h.profileService.GetOwnSections(targetUser.ID)
+	} else {
+		// Check granular privacy
+		privacy := services.DefaultPrivacySettings()
+		if targetUser.PrivacySettings != nil {
+			_ = json.Unmarshal(*targetUser.PrivacySettings, &privacy)
+		}
+		if privacy.ProfileSections == services.PrivacyHidden {
+			sections = []*services.ProfileSectionResponse{}
+		} else {
+			sections, err = h.profileService.GetUserSections(targetUser.ID)
+		}
+	}
+	if err != nil {
+		logger.FromContext(ctx).Error("get_user_sections_failed",
+			"user_id", targetUser.ID,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to get sections (request_id: %s)", requestID),
+		)
+	}
+
+	return &GetUserSectionsResponse{
+		Body: struct {
+			Sections []*services.ProfileSectionResponse `json:"sections"`
+		}{
+			Sections: sections,
+		},
+	}, nil
+}
+
+// GetOwnSectionsHandler handles GET /auth/profile/sections.
+func (h *ContributorProfileHandler) GetOwnSectionsHandler(ctx context.Context, req *struct{}) (*GetOwnSectionsResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	sections, err := h.profileService.GetOwnSections(user.ID)
+	if err != nil {
+		logger.FromContext(ctx).Error("get_own_sections_failed",
+			"user_id", user.ID,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to get sections (request_id: %s)", requestID),
+		)
+	}
+
+	return &GetOwnSectionsResponse{
+		Body: struct {
+			Sections []*services.ProfileSectionResponse `json:"sections"`
+		}{
+			Sections: sections,
+		},
+	}, nil
+}
+
+// CreateSectionHandler handles POST /auth/profile/sections.
+func (h *ContributorProfileHandler) CreateSectionHandler(ctx context.Context, req *CreateSectionRequest) (*CreateSectionResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	section, err := h.profileService.CreateSection(user.ID, req.Body.Title, req.Body.Content, req.Body.Position)
+	if err != nil {
+		logger.FromContext(ctx).Error("create_section_failed",
+			"user_id", user.ID,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error400BadRequest(err.Error())
+	}
+
+	logger.FromContext(ctx).Info("profile_section_created",
+		"user_id", user.ID,
+		"section_id", section.ID,
+	)
+
+	return &CreateSectionResponse{Body: section}, nil
+}
+
+// UpdateSectionHandler handles PUT /auth/profile/sections/{section_id}.
+func (h *ContributorProfileHandler) UpdateSectionHandler(ctx context.Context, req *UpdateSectionRequest) (*UpdateSectionResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	sectionID, err := strconv.ParseUint(req.SectionID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid section ID")
+	}
+
+	updates := map[string]interface{}{}
+	if req.Body.Title != nil {
+		updates["title"] = *req.Body.Title
+	}
+	if req.Body.Content != nil {
+		updates["content"] = *req.Body.Content
+	}
+	if req.Body.Position != nil {
+		updates["position"] = *req.Body.Position
+	}
+	if req.Body.IsVisible != nil {
+		updates["is_visible"] = *req.Body.IsVisible
+	}
+
+	if len(updates) == 0 {
+		return nil, huma.Error400BadRequest("No fields to update")
+	}
+
+	section, err := h.profileService.UpdateSection(user.ID, uint(sectionID), updates)
+	if err != nil {
+		logger.FromContext(ctx).Error("update_section_failed",
+			"user_id", user.ID,
+			"section_id", sectionID,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		if err.Error() == "profile section not found" {
+			return nil, huma.Error404NotFound("Profile section not found")
+		}
+		return nil, huma.Error400BadRequest(err.Error())
+	}
+
+	logger.FromContext(ctx).Info("profile_section_updated",
+		"user_id", user.ID,
+		"section_id", sectionID,
+	)
+
+	return &UpdateSectionResponse{Body: section}, nil
+}
+
+// DeleteSectionHandler handles DELETE /auth/profile/sections/{section_id}.
+func (h *ContributorProfileHandler) DeleteSectionHandler(ctx context.Context, req *DeleteSectionRequest) (*DeleteSectionResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	sectionID, err := strconv.ParseUint(req.SectionID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid section ID")
+	}
+
+	err = h.profileService.DeleteSection(user.ID, uint(sectionID))
+	if err != nil {
+		logger.FromContext(ctx).Error("delete_section_failed",
+			"user_id", user.ID,
+			"section_id", sectionID,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		if err.Error() == "profile section not found" {
+			return nil, huma.Error404NotFound("Profile section not found")
+		}
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to delete section (request_id: %s)", requestID),
+		)
+	}
+
+	logger.FromContext(ctx).Info("profile_section_deleted",
+		"user_id", user.ID,
+		"section_id", sectionID,
+	)
+
+	return &DeleteSectionResponse{
+		Body: struct {
+			Success bool   `json:"success"`
+			Message string `json:"message"`
+		}{
+			Success: true,
+			Message: "Section deleted",
+		},
+	}, nil
+}

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -93,6 +93,7 @@ func SetupRoutes(router *chi.Mux, sc *services.ServiceContainer, cfg *config.Con
 	setupShowReportRoutes(router, protectedGroup, sc, cfg)
 	setupArtistReportRoutes(router, protectedGroup, sc, cfg)
 	setupAdminRoutes(protectedGroup, sc)
+	setupContributorProfileRoutes(api, protectedGroup, sc)
 
 	return api
 }
@@ -514,6 +515,28 @@ func setupAdminRoutes(protected *huma.Group, sc *services.ServiceContainer) {
 
 	// Admin user list endpoint
 	huma.Get(protected, "/admin/users", adminHandler.GetAdminUsersHandler)
+}
+
+// setupContributorProfileRoutes configures contributor profile endpoints
+func setupContributorProfileRoutes(api huma.API, protected *huma.Group, sc *services.ServiceContainer) {
+	profileHandler := handlers.NewContributorProfileHandler(sc.ContributorProfile, sc.User)
+
+	// Public profile endpoints with optional auth (so profile owner can see their own private profile)
+	optionalAuthGroup := huma.NewGroup(api, "")
+	optionalAuthGroup.UseMiddleware(middleware.OptionalHumaJWTMiddleware(sc.JWT))
+	huma.Get(optionalAuthGroup, "/users/{username}", profileHandler.GetPublicProfileHandler)
+	huma.Get(optionalAuthGroup, "/users/{username}/contributions", profileHandler.GetContributionHistoryHandler)
+	huma.Get(optionalAuthGroup, "/users/{username}/sections", profileHandler.GetUserSectionsHandler)
+
+	// Protected endpoints for authenticated user's own profile
+	huma.Get(protected, "/auth/profile/contributor", profileHandler.GetOwnProfileHandler)
+	huma.Get(protected, "/auth/profile/contributions", profileHandler.GetOwnContributionsHandler)
+	huma.Patch(protected, "/auth/profile/visibility", profileHandler.UpdateProfileVisibilityHandler)
+	huma.Patch(protected, "/auth/profile/privacy", profileHandler.UpdatePrivacySettingsHandler)
+	huma.Get(protected, "/auth/profile/sections", profileHandler.GetOwnSectionsHandler)
+	huma.Post(protected, "/auth/profile/sections", profileHandler.CreateSectionHandler)
+	huma.Put(protected, "/auth/profile/sections/{section_id}", profileHandler.UpdateSectionHandler)
+	huma.Delete(protected, "/auth/profile/sections/{section_id}", profileHandler.DeleteSectionHandler)
 }
 
 // rateLimitHandler handles rate limit exceeded responses with JSON

--- a/backend/internal/models/profile_section.go
+++ b/backend/internal/models/profile_section.go
@@ -1,0 +1,22 @@
+package models
+
+import "time"
+
+// UserProfileSection represents a custom content section on a user's profile page.
+type UserProfileSection struct {
+	ID        uint      `json:"id" gorm:"primaryKey"`
+	UserID    uint      `json:"user_id" gorm:"column:user_id;not null"`
+	Title     string    `json:"title" gorm:"column:title;not null"`
+	Content   string    `json:"content" gorm:"column:content;not null;default:''"`
+	Position  int       `json:"position" gorm:"column:position;not null"`
+	IsVisible bool      `json:"is_visible" gorm:"column:is_visible;not null;default:true"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+
+	User User `json:"-" gorm:"foreignKey:UserID"`
+}
+
+// TableName specifies the table name for UserProfileSection.
+func (UserProfileSection) TableName() string {
+	return "user_profile_sections"
+}

--- a/backend/internal/models/user.go
+++ b/backend/internal/models/user.go
@@ -21,7 +21,10 @@ type User struct {
 	LastName            *string    `json:"last_name" gorm:"column:last_name"`
 	AvatarURL           *string    `json:"avatar_url" gorm:"column:avatar_url"`
 	Bio                 *string    `json:"bio"`
-	IsActive            bool       `json:"is_active" gorm:"default:true"`
+	ProfileVisibility string           `json:"profile_visibility" gorm:"column:profile_visibility;not null;default:'public'"`
+	PrivacySettings   *json.RawMessage `json:"privacy_settings" gorm:"column:privacy_settings;type:jsonb;not null;default:'{\"contributions\":\"visible\",\"saved_shows\":\"hidden\",\"attendance\":\"hidden\",\"following\":\"count_only\",\"collections\":\"visible\",\"last_active\":\"visible\",\"profile_sections\":\"visible\"}'"`
+	UserTier          string           `json:"user_tier" gorm:"column:user_tier;not null;default:'new_user'"`
+	IsActive          bool             `json:"is_active" gorm:"default:true"`
 	IsAdmin             bool       `json:"is_admin" gorm:"default:false"`
 	EmailVerified       bool       `json:"email_verified" gorm:"default:false"`
 	TermsAcceptedAt     *time.Time `json:"-" gorm:"column:terms_accepted_at"` // Legal acceptance evidence

--- a/backend/internal/services/container.go
+++ b/backend/internal/services/container.go
@@ -12,9 +12,10 @@ import (
 // Exported fields — no getters needed for a simple data-holding struct.
 type ServiceContainer struct {
 	// DB-only leaf services
-	AdminStats    *AdminStatsService
-	APIToken      *APITokenService
-	Artist        *ArtistService
+	AdminStats         *AdminStatsService
+	APIToken           *APITokenService
+	Artist             *ArtistService
+	ContributorProfile *ContributorProfileService
 	ArtistReport  *ArtistReportService
 	AuditLog      *AuditLogService
 	Bookmark      *BookmarkService
@@ -63,9 +64,10 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 
 	return &ServiceContainer{
 		// DB-only leaf services
-		AdminStats:    NewAdminStatsService(database),
-		APIToken:      NewAPITokenService(database),
-		Artist:        NewArtistService(database),
+		AdminStats:         NewAdminStatsService(database),
+		APIToken:           NewAPITokenService(database),
+		Artist:             NewArtistService(database),
+		ContributorProfile: NewContributorProfileService(database),
 		ArtistReport:  NewArtistReportService(database),
 		AuditLog:      NewAuditLogService(database),
 		Bookmark:      NewBookmarkService(database),

--- a/backend/internal/services/contributor_profile.go
+++ b/backend/internal/services/contributor_profile.go
@@ -1,0 +1,723 @@
+package services
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/db"
+	"psychic-homily-backend/internal/models"
+)
+
+// ContributorProfileService handles contributor profile and contribution history operations.
+type ContributorProfileService struct {
+	db *gorm.DB
+}
+
+// NewContributorProfileService creates a new contributor profile service.
+func NewContributorProfileService(database *gorm.DB) *ContributorProfileService {
+	if database == nil {
+		database = db.GetDB()
+	}
+	return &ContributorProfileService{
+		db: database,
+	}
+}
+
+// PrivacyLevel represents the visibility level for a profile field.
+type PrivacyLevel string
+
+const (
+	PrivacyVisible   PrivacyLevel = "visible"
+	PrivacyCountOnly PrivacyLevel = "count_only"
+	PrivacyHidden    PrivacyLevel = "hidden"
+)
+
+// PrivacySettings represents the granular privacy configuration for a user profile.
+type PrivacySettings struct {
+	Contributions   PrivacyLevel `json:"contributions"`
+	SavedShows      PrivacyLevel `json:"saved_shows"`
+	Attendance      PrivacyLevel `json:"attendance"`
+	Following       PrivacyLevel `json:"following"`
+	Collections     PrivacyLevel `json:"collections"`
+	LastActive      PrivacyLevel `json:"last_active"`
+	ProfileSections PrivacyLevel `json:"profile_sections"`
+}
+
+// DefaultPrivacySettings returns the default privacy configuration.
+func DefaultPrivacySettings() PrivacySettings {
+	return PrivacySettings{
+		Contributions:   PrivacyVisible,
+		SavedShows:      PrivacyHidden,
+		Attendance:      PrivacyHidden,
+		Following:       PrivacyCountOnly,
+		Collections:     PrivacyVisible,
+		LastActive:      PrivacyVisible,
+		ProfileSections: PrivacyVisible,
+	}
+}
+
+// binaryOnlyFields are privacy fields that only support visible/hidden (not count_only).
+var binaryOnlyFields = map[string]bool{
+	"last_active":      true,
+	"profile_sections": true,
+}
+
+// ValidatePrivacySettings checks that all fields have valid values.
+func ValidatePrivacySettings(ps PrivacySettings) error {
+	fields := map[string]PrivacyLevel{
+		"contributions":    ps.Contributions,
+		"saved_shows":      ps.SavedShows,
+		"attendance":       ps.Attendance,
+		"following":        ps.Following,
+		"collections":      ps.Collections,
+		"last_active":      ps.LastActive,
+		"profile_sections": ps.ProfileSections,
+	}
+	for name, level := range fields {
+		if level != PrivacyVisible && level != PrivacyCountOnly && level != PrivacyHidden {
+			return fmt.Errorf("invalid privacy level %q for field %q", level, name)
+		}
+		if binaryOnlyFields[name] && level == PrivacyCountOnly {
+			return fmt.Errorf("field %q only supports 'visible' or 'hidden'", name)
+		}
+	}
+	return nil
+}
+
+// parsePrivacySettings extracts PrivacySettings from a user's JSONB column.
+func parsePrivacySettings(raw *json.RawMessage) PrivacySettings {
+	if raw == nil {
+		return DefaultPrivacySettings()
+	}
+	var ps PrivacySettings
+	if err := json.Unmarshal(*raw, &ps); err != nil {
+		return DefaultPrivacySettings()
+	}
+	return ps
+}
+
+// ContributionStats represents aggregated contribution counts.
+type ContributionStats struct {
+	ShowsSubmitted      int64 `json:"shows_submitted"`
+	VenuesSubmitted     int64 `json:"venues_submitted"`
+	VenueEditsSubmitted int64 `json:"venue_edits_submitted"`
+	ReleasesCreated     int64 `json:"releases_created"`
+	LabelsCreated       int64 `json:"labels_created"`
+	FestivalsCreated    int64 `json:"festivals_created"`
+	ArtistsEdited       int64 `json:"artists_edited"`
+	ModerationActions   int64 `json:"moderation_actions"`
+	TotalContributions  int64 `json:"total_contributions"`
+}
+
+// PublicProfileResponse is the response for the public profile endpoint.
+type PublicProfileResponse struct {
+	Username          string                   `json:"username"`
+	Bio               *string                  `json:"bio,omitempty"`
+	AvatarURL         *string                  `json:"avatar_url,omitempty"`
+	FirstName         *string                  `json:"first_name,omitempty"`
+	ProfileVisibility string                   `json:"profile_visibility"`
+	UserTier          string                   `json:"user_tier"`
+	PrivacySettings   *PrivacySettings         `json:"privacy_settings,omitempty"`
+	JoinedAt          time.Time                `json:"joined_at"`
+	LastActive        *time.Time               `json:"last_active,omitempty"`
+	Stats             *ContributionStats       `json:"stats,omitempty"`
+	StatsCount        *int64                   `json:"stats_count,omitempty"`
+	Sections          []*ProfileSectionResponse `json:"sections,omitempty"`
+}
+
+// ProfileSectionResponse represents a profile section in API responses.
+type ProfileSectionResponse struct {
+	ID        uint      `json:"id"`
+	Title     string    `json:"title"`
+	Content   string    `json:"content"`
+	Position  int       `json:"position"`
+	IsVisible bool      `json:"is_visible"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// ContributionEntry represents a single contribution in the history.
+type ContributionEntry struct {
+	ID         uint                   `json:"id"`
+	Action     string                 `json:"action"`
+	EntityType string                 `json:"entity_type"`
+	EntityID   uint                   `json:"entity_id"`
+	EntityName string                 `json:"entity_name,omitempty"`
+	Metadata   map[string]interface{} `json:"metadata,omitempty"`
+	CreatedAt  time.Time              `json:"created_at"`
+	Source     string                 `json:"source"`
+}
+
+// contributionRow is a raw scan target for the UNION query.
+type contributionRow struct {
+	ID         uint
+	Action     string
+	EntityType string
+	EntityID   uint
+	Metadata   *json.RawMessage
+	CreatedAt  time.Time
+	Source     string
+}
+
+// moderationActions are audit_log actions that count as moderation, not content creation.
+var moderationActions = map[string]bool{
+	"approve_show":          true,
+	"reject_show":           true,
+	"verify_venue":          true,
+	"approve_venue_edit":    true,
+	"reject_venue_edit":     true,
+	"dismiss_report":        true,
+	"resolve_report":        true,
+	"dismiss_artist_report": true,
+	"resolve_artist_report": true,
+}
+
+// =============================================================================
+// Profile Endpoints
+// =============================================================================
+
+// GetPublicProfile returns a user's public profile with privacy-gated fields.
+func (s *ContributorProfileService) GetPublicProfile(username string, viewerID *uint) (*PublicProfileResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var user models.User
+	err := s.db.Where("username = ?", username).First(&user).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to find user: %w", err)
+	}
+
+	isOwner := viewerID != nil && *viewerID == user.ID
+
+	// Private profile check: only the owner can view
+	if user.ProfileVisibility == "private" && !isOwner {
+		return nil, nil
+	}
+
+	privacy := parsePrivacySettings(user.PrivacySettings)
+
+	username_str := ""
+	if user.Username != nil {
+		username_str = *user.Username
+	}
+
+	resp := &PublicProfileResponse{
+		Username:          username_str,
+		Bio:               user.Bio,
+		AvatarURL:         user.AvatarURL,
+		FirstName:         user.FirstName,
+		ProfileVisibility: user.ProfileVisibility,
+		UserTier:          user.UserTier,
+		JoinedAt:          user.CreatedAt,
+	}
+
+	// Owner always sees everything + privacy settings for editing
+	if isOwner {
+		resp.PrivacySettings = &privacy
+		resp.LastActive = &user.UpdatedAt
+
+		stats, err := s.GetContributionStats(user.ID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get contribution stats: %w", err)
+		}
+		resp.Stats = stats
+
+		sections, err := s.GetOwnSections(user.ID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get profile sections: %w", err)
+		}
+		resp.Sections = sections
+
+		return resp, nil
+	}
+
+	// Non-owner: apply privacy gating
+	switch privacy.Contributions {
+	case PrivacyVisible:
+		stats, err := s.GetContributionStats(user.ID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get contribution stats: %w", err)
+		}
+		resp.Stats = stats
+	case PrivacyCountOnly:
+		stats, err := s.GetContributionStats(user.ID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get contribution stats: %w", err)
+		}
+		resp.StatsCount = &stats.TotalContributions
+	}
+	// PrivacyHidden: Stats and StatsCount both remain nil
+
+	if privacy.LastActive == PrivacyVisible {
+		resp.LastActive = &user.UpdatedAt
+	}
+
+	if privacy.ProfileSections == PrivacyVisible {
+		sections, err := s.GetUserSections(user.ID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get profile sections: %w", err)
+		}
+		resp.Sections = sections
+	}
+
+	return resp, nil
+}
+
+// GetOwnProfile returns the authenticated user's own profile, bypassing visibility checks.
+func (s *ContributorProfileService) GetOwnProfile(userID uint) (*PublicProfileResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var user models.User
+	err := s.db.First(&user, userID).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to find user: %w", err)
+	}
+
+	stats, err := s.GetContributionStats(user.ID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get contribution stats: %w", err)
+	}
+
+	sections, err := s.GetOwnSections(user.ID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get profile sections: %w", err)
+	}
+
+	privacy := parsePrivacySettings(user.PrivacySettings)
+
+	username := ""
+	if user.Username != nil {
+		username = *user.Username
+	}
+
+	return &PublicProfileResponse{
+		Username:          username,
+		Bio:               user.Bio,
+		AvatarURL:         user.AvatarURL,
+		FirstName:         user.FirstName,
+		ProfileVisibility: user.ProfileVisibility,
+		UserTier:          user.UserTier,
+		PrivacySettings:   &privacy,
+		JoinedAt:          user.CreatedAt,
+		LastActive:        &user.UpdatedAt,
+		Stats:             stats,
+		Sections:          sections,
+	}, nil
+}
+
+// =============================================================================
+// Privacy Settings
+// =============================================================================
+
+// UpdatePrivacySettings validates and persists new privacy settings for a user.
+func (s *ContributorProfileService) UpdatePrivacySettings(userID uint, settings PrivacySettings) (*PrivacySettings, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	if err := ValidatePrivacySettings(settings); err != nil {
+		return nil, err
+	}
+
+	raw, err := json.Marshal(settings)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal privacy settings: %w", err)
+	}
+	rawMsg := json.RawMessage(raw)
+
+	if err := s.db.Model(&models.User{}).Where("id = ?", userID).Update("privacy_settings", &rawMsg).Error; err != nil {
+		return nil, fmt.Errorf("failed to update privacy settings: %w", err)
+	}
+
+	return &settings, nil
+}
+
+// =============================================================================
+// Contribution Stats
+// =============================================================================
+
+// GetContributionStats computes aggregate contribution counts for a user.
+func (s *ContributorProfileService) GetContributionStats(userID uint) (*ContributionStats, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	stats := &ContributionStats{}
+
+	// Count submissions from entity tables
+	s.db.Model(&models.Show{}).Where("submitted_by = ?", userID).Count(&stats.ShowsSubmitted)
+	s.db.Model(&models.Venue{}).Where("submitted_by = ?", userID).Count(&stats.VenuesSubmitted)
+	s.db.Table("pending_venue_edits").Where("submitted_by = ?", userID).Count(&stats.VenueEditsSubmitted)
+
+	// Count actions from audit_log grouped by action
+	type actionCount struct {
+		Action string
+		Count  int64
+	}
+	var actionCounts []actionCount
+	s.db.Model(&models.AuditLog{}).
+		Select("action, count(*) as count").
+		Where("actor_id = ?", userID).
+		Group("action").
+		Scan(&actionCounts)
+
+	for _, ac := range actionCounts {
+		if moderationActions[ac.Action] {
+			stats.ModerationActions += ac.Count
+		} else {
+			switch {
+			case ac.Action == "create_release" || ac.Action == "edit_release":
+				stats.ReleasesCreated += ac.Count
+			case ac.Action == "create_label" || ac.Action == "edit_label":
+				stats.LabelsCreated += ac.Count
+			case ac.Action == "create_festival" || ac.Action == "edit_festival" ||
+				ac.Action == "add_festival_artist" || ac.Action == "remove_festival_artist" ||
+				ac.Action == "update_festival_artist" || ac.Action == "add_festival_venue" ||
+				ac.Action == "remove_festival_venue":
+				stats.FestivalsCreated += ac.Count
+			case ac.Action == "edit_artist":
+				stats.ArtistsEdited += ac.Count
+			}
+		}
+	}
+
+	stats.TotalContributions = stats.ShowsSubmitted + stats.VenuesSubmitted +
+		stats.VenueEditsSubmitted + stats.ReleasesCreated + stats.LabelsCreated +
+		stats.FestivalsCreated + stats.ArtistsEdited + stats.ModerationActions
+
+	return stats, nil
+}
+
+// =============================================================================
+// Contribution History
+// =============================================================================
+
+// GetContributionHistory returns a paginated, unified contribution timeline for a user.
+func (s *ContributorProfileService) GetContributionHistory(userID uint, limit, offset int, entityType string) ([]*ContributionEntry, int64, error) {
+	if s.db == nil {
+		return nil, 0, fmt.Errorf("database not initialized")
+	}
+
+	if limit < 1 {
+		limit = 20
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	auditQuery := `SELECT id, action, entity_type, entity_id, metadata, created_at, 'audit_log' as source FROM audit_logs WHERE actor_id = ?`
+	showQuery := `SELECT id, 'submit_show' as action, 'show' as entity_type, id as entity_id, NULL as metadata, created_at, 'submission' as source FROM shows WHERE submitted_by = ?`
+	venueQuery := `SELECT id, 'submit_venue' as action, 'venue' as entity_type, id as entity_id, NULL as metadata, created_at, 'submission' as source FROM venues WHERE submitted_by = ?`
+	venueEditQuery := `SELECT id, 'submit_venue_edit' as action, 'venue_edit' as entity_type, venue_id as entity_id, NULL as metadata, created_at, 'submission' as source FROM pending_venue_edits WHERE submitted_by = ?`
+
+	args := []interface{}{userID, userID, userID, userID}
+
+	unionSQL := fmt.Sprintf("(%s) UNION ALL (%s) UNION ALL (%s) UNION ALL (%s)",
+		auditQuery, showQuery, venueQuery, venueEditQuery)
+
+	entityFilter := ""
+	if entityType != "" {
+		entityFilter = " WHERE entity_type = ?"
+		args = append(args, entityType)
+	}
+
+	countSQL := fmt.Sprintf("SELECT COUNT(*) FROM (%s) AS unified%s", unionSQL, entityFilter)
+	var total int64
+	countArgs := make([]interface{}, len(args))
+	copy(countArgs, args)
+	if err := s.db.Raw(countSQL, countArgs...).Scan(&total).Error; err != nil {
+		return nil, 0, fmt.Errorf("failed to count contributions: %w", err)
+	}
+
+	dataSQL := fmt.Sprintf("SELECT * FROM (%s) AS unified%s ORDER BY created_at DESC LIMIT ? OFFSET ?",
+		unionSQL, entityFilter)
+	args = append(args, limit, offset)
+
+	var rows []contributionRow
+	if err := s.db.Raw(dataSQL, args...).Scan(&rows).Error; err != nil {
+		return nil, 0, fmt.Errorf("failed to get contributions: %w", err)
+	}
+
+	entries := make([]*ContributionEntry, len(rows))
+	for i, row := range rows {
+		entry := &ContributionEntry{
+			ID:         row.ID,
+			Action:     row.Action,
+			EntityType: row.EntityType,
+			EntityID:   row.EntityID,
+			CreatedAt:  row.CreatedAt,
+			Source:     row.Source,
+		}
+		if row.Metadata != nil {
+			var metadata map[string]interface{}
+			if err := json.Unmarshal(*row.Metadata, &metadata); err == nil {
+				entry.Metadata = metadata
+			}
+		}
+		entries[i] = entry
+	}
+
+	s.enrichEntityNames(entries)
+
+	return entries, total, nil
+}
+
+// =============================================================================
+// Profile Sections
+// =============================================================================
+
+const maxProfileSections = 3
+
+// GetUserSections returns visible profile sections for a public user.
+func (s *ContributorProfileService) GetUserSections(userID uint) ([]*ProfileSectionResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var sections []models.UserProfileSection
+	err := s.db.Where("user_id = ? AND is_visible = ?", userID, true).
+		Order("position ASC").
+		Find(&sections).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to get profile sections: %w", err)
+	}
+
+	return buildSectionResponses(sections), nil
+}
+
+// GetOwnSections returns all profile sections for the authenticated user.
+func (s *ContributorProfileService) GetOwnSections(userID uint) ([]*ProfileSectionResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var sections []models.UserProfileSection
+	err := s.db.Where("user_id = ?", userID).
+		Order("position ASC").
+		Find(&sections).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to get profile sections: %w", err)
+	}
+
+	return buildSectionResponses(sections), nil
+}
+
+// CreateSection creates a new profile section. Returns error if user already has max sections.
+func (s *ContributorProfileService) CreateSection(userID uint, title string, content string, position int) (*ProfileSectionResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	if len(title) == 0 || len(title) > 255 {
+		return nil, fmt.Errorf("title must be between 1 and 255 characters")
+	}
+	if len(content) > 10000 {
+		return nil, fmt.Errorf("content must be at most 10000 characters")
+	}
+	if position < 0 || position >= maxProfileSections {
+		return nil, fmt.Errorf("position must be between 0 and %d", maxProfileSections-1)
+	}
+
+	// Check section count
+	var count int64
+	s.db.Model(&models.UserProfileSection{}).Where("user_id = ?", userID).Count(&count)
+	if count >= int64(maxProfileSections) {
+		return nil, fmt.Errorf("maximum %d profile sections allowed", maxProfileSections)
+	}
+
+	section := models.UserProfileSection{
+		UserID:    userID,
+		Title:     title,
+		Content:   content,
+		Position:  position,
+		IsVisible: true,
+	}
+
+	if err := s.db.Create(&section).Error; err != nil {
+		return nil, fmt.Errorf("failed to create profile section: %w", err)
+	}
+
+	return buildSectionResponse(&section), nil
+}
+
+// UpdateSection updates a profile section owned by the user.
+func (s *ContributorProfileService) UpdateSection(userID uint, sectionID uint, updates map[string]interface{}) (*ProfileSectionResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var section models.UserProfileSection
+	err := s.db.Where("id = ? AND user_id = ?", sectionID, userID).First(&section).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, fmt.Errorf("profile section not found")
+		}
+		return nil, fmt.Errorf("failed to find profile section: %w", err)
+	}
+
+	// Validate updates
+	if title, ok := updates["title"]; ok {
+		t := title.(string)
+		if len(t) == 0 || len(t) > 255 {
+			return nil, fmt.Errorf("title must be between 1 and 255 characters")
+		}
+	}
+	if content, ok := updates["content"]; ok {
+		c := content.(string)
+		if len(c) > 10000 {
+			return nil, fmt.Errorf("content must be at most 10000 characters")
+		}
+	}
+	if position, ok := updates["position"]; ok {
+		p := position.(int)
+		if p < 0 || p >= maxProfileSections {
+			return nil, fmt.Errorf("position must be between 0 and %d", maxProfileSections-1)
+		}
+	}
+
+	if err := s.db.Model(&section).Updates(updates).Error; err != nil {
+		return nil, fmt.Errorf("failed to update profile section: %w", err)
+	}
+
+	// Reload after update
+	s.db.First(&section, section.ID)
+
+	return buildSectionResponse(&section), nil
+}
+
+// DeleteSection deletes a profile section owned by the user.
+func (s *ContributorProfileService) DeleteSection(userID uint, sectionID uint) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	result := s.db.Where("id = ? AND user_id = ?", sectionID, userID).Delete(&models.UserProfileSection{})
+	if result.Error != nil {
+		return fmt.Errorf("failed to delete profile section: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("profile section not found")
+	}
+
+	return nil
+}
+
+func buildSectionResponses(sections []models.UserProfileSection) []*ProfileSectionResponse {
+	responses := make([]*ProfileSectionResponse, len(sections))
+	for i := range sections {
+		responses[i] = buildSectionResponse(&sections[i])
+	}
+	return responses
+}
+
+func buildSectionResponse(section *models.UserProfileSection) *ProfileSectionResponse {
+	return &ProfileSectionResponse{
+		ID:        section.ID,
+		Title:     section.Title,
+		Content:   section.Content,
+		Position:  section.Position,
+		IsVisible: section.IsVisible,
+		CreatedAt: section.CreatedAt,
+		UpdatedAt: section.UpdatedAt,
+	}
+}
+
+// =============================================================================
+// Entity Name Enrichment
+// =============================================================================
+
+func (s *ContributorProfileService) enrichEntityNames(entries []*ContributionEntry) {
+	idsByType := make(map[string][]uint)
+	for _, e := range entries {
+		idsByType[e.EntityType] = append(idsByType[e.EntityType], e.EntityID)
+	}
+
+	nameMap := make(map[string]map[uint]string)
+
+	for entityType, ids := range idsByType {
+		if len(ids) == 0 {
+			continue
+		}
+		names := make(map[uint]string)
+		switch entityType {
+		case "show":
+			var results []struct {
+				ID    uint
+				Title string
+			}
+			s.db.Table("shows").Select("id, title").Where("id IN ?", ids).Scan(&results)
+			for _, r := range results {
+				names[r.ID] = r.Title
+			}
+		case "venue", "venue_edit":
+			var results []struct {
+				ID   uint
+				Name string
+			}
+			s.db.Table("venues").Select("id, name").Where("id IN ?", ids).Scan(&results)
+			for _, r := range results {
+				names[r.ID] = r.Name
+			}
+		case "artist":
+			var results []struct {
+				ID   uint
+				Name string
+			}
+			s.db.Table("artists").Select("id, name").Where("id IN ?", ids).Scan(&results)
+			for _, r := range results {
+				names[r.ID] = r.Name
+			}
+		case "release":
+			var results []struct {
+				ID    uint
+				Title string
+			}
+			s.db.Table("releases").Select("id, title").Where("id IN ?", ids).Scan(&results)
+			for _, r := range results {
+				names[r.ID] = r.Title
+			}
+		case "label":
+			var results []struct {
+				ID   uint
+				Name string
+			}
+			s.db.Table("labels").Select("id, name").Where("id IN ?", ids).Scan(&results)
+			for _, r := range results {
+				names[r.ID] = r.Name
+			}
+		case "festival":
+			var results []struct {
+				ID   uint
+				Name string
+			}
+			s.db.Table("festivals").Select("id, name").Where("id IN ?", ids).Scan(&results)
+			for _, r := range results {
+				names[r.ID] = r.Name
+			}
+		}
+		nameMap[entityType] = names
+	}
+
+	for _, e := range entries {
+		if names, ok := nameMap[e.EntityType]; ok {
+			if name, ok := names[e.EntityID]; ok {
+				e.EntityName = name
+			}
+		}
+	}
+}

--- a/backend/internal/services/contributor_profile_test.go
+++ b/backend/internal/services/contributor_profile_test.go
@@ -1,0 +1,1101 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/testutil"
+)
+
+// =============================================================================
+// UNIT TESTS (No Database Required)
+// =============================================================================
+
+func TestNewContributorProfileService(t *testing.T) {
+	svc := NewContributorProfileService(nil)
+	assert.NotNil(t, svc)
+}
+
+func TestContributorProfileService_NilDatabase(t *testing.T) {
+	svc := &ContributorProfileService{db: nil}
+
+	t.Run("GetPublicProfile", func(t *testing.T) {
+		resp, err := svc.GetPublicProfile("testuser", nil)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("GetOwnProfile", func(t *testing.T) {
+		resp, err := svc.GetOwnProfile(1)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("GetContributionStats", func(t *testing.T) {
+		resp, err := svc.GetContributionStats(1)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("GetContributionHistory", func(t *testing.T) {
+		resp, total, err := svc.GetContributionHistory(1, 20, 0, "")
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+		assert.Zero(t, total)
+	})
+
+	t.Run("UpdatePrivacySettings", func(t *testing.T) {
+		resp, err := svc.UpdatePrivacySettings(1, DefaultPrivacySettings())
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("GetUserSections", func(t *testing.T) {
+		resp, err := svc.GetUserSections(1)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("GetOwnSections", func(t *testing.T) {
+		resp, err := svc.GetOwnSections(1)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("CreateSection", func(t *testing.T) {
+		resp, err := svc.CreateSection(1, "Title", "Content", 0)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("UpdateSection", func(t *testing.T) {
+		resp, err := svc.UpdateSection(1, 1, map[string]interface{}{"title": "New"})
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("DeleteSection", func(t *testing.T) {
+		err := svc.DeleteSection(1, 1)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+	})
+}
+
+func TestValidatePrivacySettings(t *testing.T) {
+	t.Run("Valid_Defaults", func(t *testing.T) {
+		err := ValidatePrivacySettings(DefaultPrivacySettings())
+		assert.NoError(t, err)
+	})
+
+	t.Run("Valid_AllVisible", func(t *testing.T) {
+		ps := PrivacySettings{
+			Contributions:   PrivacyVisible,
+			SavedShows:      PrivacyVisible,
+			Attendance:      PrivacyVisible,
+			Following:       PrivacyVisible,
+			Collections:     PrivacyVisible,
+			LastActive:      PrivacyVisible,
+			ProfileSections: PrivacyVisible,
+		}
+		assert.NoError(t, ValidatePrivacySettings(ps))
+	})
+
+	t.Run("Valid_AllHidden", func(t *testing.T) {
+		ps := PrivacySettings{
+			Contributions:   PrivacyHidden,
+			SavedShows:      PrivacyHidden,
+			Attendance:      PrivacyHidden,
+			Following:       PrivacyHidden,
+			Collections:     PrivacyHidden,
+			LastActive:      PrivacyHidden,
+			ProfileSections: PrivacyHidden,
+		}
+		assert.NoError(t, ValidatePrivacySettings(ps))
+	})
+
+	t.Run("Invalid_BadLevel", func(t *testing.T) {
+		ps := DefaultPrivacySettings()
+		ps.Contributions = "invalid"
+		err := ValidatePrivacySettings(ps)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid privacy level")
+	})
+
+	t.Run("Invalid_CountOnly_LastActive", func(t *testing.T) {
+		ps := DefaultPrivacySettings()
+		ps.LastActive = PrivacyCountOnly
+		err := ValidatePrivacySettings(ps)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "only supports 'visible' or 'hidden'")
+	})
+
+	t.Run("Invalid_CountOnly_ProfileSections", func(t *testing.T) {
+		ps := DefaultPrivacySettings()
+		ps.ProfileSections = PrivacyCountOnly
+		err := ValidatePrivacySettings(ps)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "only supports 'visible' or 'hidden'")
+	})
+
+	t.Run("Valid_CountOnly_Contributions", func(t *testing.T) {
+		ps := DefaultPrivacySettings()
+		ps.Contributions = PrivacyCountOnly
+		assert.NoError(t, ValidatePrivacySettings(ps))
+	})
+}
+
+// =============================================================================
+// INTEGRATION TESTS (With Real Database)
+// =============================================================================
+
+type ContributorProfileServiceIntegrationTestSuite struct {
+	suite.Suite
+	container      testcontainers.Container
+	db             *gorm.DB
+	profileService *ContributorProfileService
+	auditLog       *AuditLogService
+	ctx            context.Context
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) SetupSuite() {
+	suite.ctx = context.Background()
+
+	container, err := testcontainers.GenericContainer(suite.ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "postgres:18",
+			ExposedPorts: []string{"5432/tcp"},
+			Env: map[string]string{
+				"POSTGRES_DB":       "test_db",
+				"POSTGRES_USER":     "test_user",
+				"POSTGRES_PASSWORD": "test_password",
+			},
+			WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(120 * time.Second),
+		},
+		Started: true,
+	})
+	if err != nil {
+		suite.T().Fatalf("failed to start postgres container: %v", err)
+	}
+	suite.container = container
+
+	host, err := container.Host(suite.ctx)
+	if err != nil {
+		suite.T().Fatalf("failed to get host: %v", err)
+	}
+	port, err := container.MappedPort(suite.ctx, "5432")
+	if err != nil {
+		suite.T().Fatalf("failed to get port: %v", err)
+	}
+
+	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
+		host, port.Port())
+
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		suite.T().Fatalf("failed to connect to test database: %v", err)
+	}
+	suite.db = db
+
+	sqlDB, err := db.DB()
+	if err != nil {
+		suite.T().Fatalf("failed to get sql.DB: %v", err)
+	}
+
+	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "db", "migrations"))
+
+	suite.profileService = &ContributorProfileService{db: db}
+	suite.auditLog = &AuditLogService{db: db}
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TearDownSuite() {
+	if suite.container != nil {
+		if err := suite.container.Terminate(suite.ctx); err != nil {
+			suite.T().Logf("failed to terminate container: %v", err)
+		}
+	}
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TearDownTest() {
+	sqlDB, err := suite.db.DB()
+	suite.Require().NoError(err)
+	_, _ = sqlDB.Exec("DELETE FROM user_profile_sections")
+	_, _ = sqlDB.Exec("DELETE FROM audit_logs")
+	_, _ = sqlDB.Exec("DELETE FROM pending_venue_edits")
+	_, _ = sqlDB.Exec("DELETE FROM show_artists")
+	_, _ = sqlDB.Exec("DELETE FROM show_venues")
+	_, _ = sqlDB.Exec("DELETE FROM shows")
+	_, _ = sqlDB.Exec("DELETE FROM venues")
+	_, _ = sqlDB.Exec("DELETE FROM artists")
+	_, _ = sqlDB.Exec("DELETE FROM releases")
+	_, _ = sqlDB.Exec("DELETE FROM labels")
+	_, _ = sqlDB.Exec("DELETE FROM festivals")
+	_, _ = sqlDB.Exec("DELETE FROM users")
+}
+
+func TestContributorProfileServiceIntegrationTestSuite(t *testing.T) {
+	suite.Run(t, new(ContributorProfileServiceIntegrationTestSuite))
+}
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) createTestUser(username string) *models.User {
+	user := &models.User{
+		Email:             stringPtr(fmt.Sprintf("%s-%d@test.com", username, time.Now().UnixNano())),
+		Username:          stringPtr(username),
+		FirstName:         stringPtr("Test"),
+		LastName:          stringPtr("User"),
+		Bio:               stringPtr("Music enthusiast"),
+		ProfileVisibility: "public",
+		IsActive:          true,
+		EmailVerified:     true,
+	}
+	err := suite.db.Create(user).Error
+	suite.Require().NoError(err)
+	return user
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) createPrivateUser(username string) *models.User {
+	user := suite.createTestUser(username)
+	err := suite.db.Model(user).Update("profile_visibility", "private").Error
+	suite.Require().NoError(err)
+	user.ProfileVisibility = "private"
+	return user
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) createShow(submittedBy uint, title string) *models.Show {
+	show := &models.Show{
+		Title:       title,
+		SubmittedBy: &submittedBy,
+		Status:      "approved",
+		EventDate:   time.Now(),
+	}
+	err := suite.db.Create(show).Error
+	suite.Require().NoError(err)
+	return show
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) createVenue(submittedBy uint, name string) *models.Venue {
+	venue := &models.Venue{
+		Name:        name,
+		City:        "Phoenix",
+		State:       "AZ",
+		SubmittedBy: &submittedBy,
+	}
+	err := suite.db.Create(venue).Error
+	suite.Require().NoError(err)
+	return venue
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) setPrivacySettings(userID uint, ps PrivacySettings) {
+	raw, err := json.Marshal(ps)
+	suite.Require().NoError(err)
+	rawMsg := json.RawMessage(raw)
+	err = suite.db.Model(&models.User{}).Where("id = ?", userID).Update("privacy_settings", &rawMsg).Error
+	suite.Require().NoError(err)
+}
+
+// =============================================================================
+// Group 1: GetPublicProfile
+// =============================================================================
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetPublicProfile_Success() {
+	user := suite.createTestUser("contributor1")
+
+	profile, err := suite.profileService.GetPublicProfile("contributor1", nil)
+
+	suite.Require().NoError(err)
+	suite.Require().NotNil(profile)
+	suite.Equal("contributor1", profile.Username)
+	suite.Equal("Music enthusiast", *profile.Bio)
+	suite.Equal("Test", *profile.FirstName)
+	suite.Equal("public", profile.ProfileVisibility)
+	suite.Equal(user.CreatedAt.Unix(), profile.JoinedAt.Unix())
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetPublicProfile_NotFound() {
+	profile, err := suite.profileService.GetPublicProfile("nonexistent", nil)
+
+	suite.Require().NoError(err)
+	suite.Nil(profile)
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetPublicProfile_PrivateProfile_Anonymous() {
+	suite.createPrivateUser("privateperson")
+
+	profile, err := suite.profileService.GetPublicProfile("privateperson", nil)
+
+	suite.Require().NoError(err)
+	suite.Nil(profile, "Private profiles should not be visible to anonymous users")
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetPublicProfile_PrivateProfile_OtherUser() {
+	suite.createPrivateUser("privateperson2")
+	otherUser := suite.createTestUser("otheruser")
+
+	profile, err := suite.profileService.GetPublicProfile("privateperson2", &otherUser.ID)
+
+	suite.Require().NoError(err)
+	suite.Nil(profile, "Private profiles should not be visible to other users")
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetPublicProfile_PrivateProfile_Owner() {
+	owner := suite.createPrivateUser("privateperson3")
+
+	profile, err := suite.profileService.GetPublicProfile("privateperson3", &owner.ID)
+
+	suite.Require().NoError(err)
+	suite.Require().NotNil(profile, "Private profiles should be visible to the owner")
+	suite.Equal("privateperson3", profile.Username)
+	suite.Equal("private", profile.ProfileVisibility)
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetPublicProfile_IncludesStats() {
+	user := suite.createTestUser("statsuser")
+	suite.createShow(user.ID, "Show 1")
+	suite.createShow(user.ID, "Show 2")
+	suite.createVenue(user.ID, "Test Venue")
+
+	profile, err := suite.profileService.GetPublicProfile("statsuser", nil)
+
+	suite.Require().NoError(err)
+	suite.Require().NotNil(profile)
+	suite.Equal(int64(2), profile.Stats.ShowsSubmitted)
+	suite.Equal(int64(1), profile.Stats.VenuesSubmitted)
+	suite.Equal(int64(3), profile.Stats.TotalContributions)
+}
+
+// =============================================================================
+// Group 2: GetOwnProfile
+// =============================================================================
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetOwnProfile_Success() {
+	user := suite.createTestUser("ownprofile")
+
+	profile, err := suite.profileService.GetOwnProfile(user.ID)
+
+	suite.Require().NoError(err)
+	suite.Require().NotNil(profile)
+	suite.Equal("ownprofile", profile.Username)
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetOwnProfile_PrivateBypassesVisibility() {
+	user := suite.createPrivateUser("ownprivate")
+
+	profile, err := suite.profileService.GetOwnProfile(user.ID)
+
+	suite.Require().NoError(err)
+	suite.Require().NotNil(profile, "GetOwnProfile should always work regardless of visibility")
+	suite.Equal("ownprivate", profile.Username)
+	suite.Equal("private", profile.ProfileVisibility)
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetOwnProfile_NotFound() {
+	profile, err := suite.profileService.GetOwnProfile(99999)
+
+	suite.Require().NoError(err)
+	suite.Nil(profile)
+}
+
+// =============================================================================
+// Group 3: GetContributionStats
+// =============================================================================
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetContributionStats_Empty() {
+	user := suite.createTestUser("emptystats")
+
+	stats, err := suite.profileService.GetContributionStats(user.ID)
+
+	suite.Require().NoError(err)
+	suite.Require().NotNil(stats)
+	suite.Equal(int64(0), stats.TotalContributions)
+	suite.Equal(int64(0), stats.ShowsSubmitted)
+	suite.Equal(int64(0), stats.VenuesSubmitted)
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetContributionStats_ShowsAndVenues() {
+	user := suite.createTestUser("showvenueuser")
+	suite.createShow(user.ID, "Show A")
+	suite.createShow(user.ID, "Show B")
+	suite.createShow(user.ID, "Show C")
+	suite.createVenue(user.ID, "Venue A")
+
+	stats, err := suite.profileService.GetContributionStats(user.ID)
+
+	suite.Require().NoError(err)
+	suite.Equal(int64(3), stats.ShowsSubmitted)
+	suite.Equal(int64(1), stats.VenuesSubmitted)
+	suite.Equal(int64(4), stats.TotalContributions)
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetContributionStats_AuditLogActions() {
+	user := suite.createTestUser("audituser")
+
+	// Content creation actions
+	suite.auditLog.LogAction(user.ID, "create_release", "release", 1, nil)
+	suite.auditLog.LogAction(user.ID, "create_release", "release", 2, nil)
+	suite.auditLog.LogAction(user.ID, "create_label", "label", 1, nil)
+	suite.auditLog.LogAction(user.ID, "edit_artist", "artist", 1, nil)
+
+	stats, err := suite.profileService.GetContributionStats(user.ID)
+
+	suite.Require().NoError(err)
+	suite.Equal(int64(2), stats.ReleasesCreated)
+	suite.Equal(int64(1), stats.LabelsCreated)
+	suite.Equal(int64(1), stats.ArtistsEdited)
+	suite.Equal(int64(4), stats.TotalContributions)
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetContributionStats_ModerationActions() {
+	user := suite.createTestUser("moderator")
+
+	suite.auditLog.LogAction(user.ID, "approve_show", "show", 1, nil)
+	suite.auditLog.LogAction(user.ID, "reject_show", "show", 2, nil)
+	suite.auditLog.LogAction(user.ID, "verify_venue", "venue", 1, nil)
+
+	stats, err := suite.profileService.GetContributionStats(user.ID)
+
+	suite.Require().NoError(err)
+	suite.Equal(int64(3), stats.ModerationActions)
+	suite.Equal(int64(3), stats.TotalContributions)
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetContributionStats_MixedSources() {
+	user := suite.createTestUser("mixeduser")
+
+	// Submissions
+	suite.createShow(user.ID, "My Show")
+	suite.createVenue(user.ID, "My Venue")
+
+	// Audit actions
+	suite.auditLog.LogAction(user.ID, "create_release", "release", 1, nil)
+	suite.auditLog.LogAction(user.ID, "approve_show", "show", 99, nil)
+
+	stats, err := suite.profileService.GetContributionStats(user.ID)
+
+	suite.Require().NoError(err)
+	suite.Equal(int64(1), stats.ShowsSubmitted)
+	suite.Equal(int64(1), stats.VenuesSubmitted)
+	suite.Equal(int64(1), stats.ReleasesCreated)
+	suite.Equal(int64(1), stats.ModerationActions)
+	suite.Equal(int64(4), stats.TotalContributions)
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetContributionStats_DoesNotCountOtherUsers() {
+	user1 := suite.createTestUser("user1stats")
+	user2 := suite.createTestUser("user2stats")
+
+	suite.createShow(user1.ID, "User1 Show")
+	suite.createShow(user2.ID, "User2 Show")
+	suite.auditLog.LogAction(user2.ID, "create_release", "release", 1, nil)
+
+	stats, err := suite.profileService.GetContributionStats(user1.ID)
+
+	suite.Require().NoError(err)
+	suite.Equal(int64(1), stats.ShowsSubmitted)
+	suite.Equal(int64(0), stats.ReleasesCreated)
+	suite.Equal(int64(1), stats.TotalContributions)
+}
+
+// =============================================================================
+// Group 4: GetContributionHistory
+// =============================================================================
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetContributionHistory_Empty() {
+	user := suite.createTestUser("emptyhistory")
+
+	entries, total, err := suite.profileService.GetContributionHistory(user.ID, 20, 0, "")
+
+	suite.Require().NoError(err)
+	suite.Equal(int64(0), total)
+	suite.Empty(entries)
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetContributionHistory_ShowSubmissions() {
+	user := suite.createTestUser("showhistory")
+	suite.createShow(user.ID, "My Great Show")
+
+	entries, total, err := suite.profileService.GetContributionHistory(user.ID, 20, 0, "")
+
+	suite.Require().NoError(err)
+	suite.Equal(int64(1), total)
+	suite.Require().Len(entries, 1)
+	suite.Equal("submit_show", entries[0].Action)
+	suite.Equal("show", entries[0].EntityType)
+	suite.Equal("submission", entries[0].Source)
+	suite.Equal("My Great Show", entries[0].EntityName)
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetContributionHistory_AuditLogEntries() {
+	user := suite.createTestUser("audithistory")
+	suite.auditLog.LogAction(user.ID, "create_release", "release", 1, map[string]interface{}{
+		"title": "New Album",
+	})
+
+	entries, total, err := suite.profileService.GetContributionHistory(user.ID, 20, 0, "")
+
+	suite.Require().NoError(err)
+	suite.Equal(int64(1), total)
+	suite.Require().Len(entries, 1)
+	suite.Equal("create_release", entries[0].Action)
+	suite.Equal("release", entries[0].EntityType)
+	suite.Equal("audit_log", entries[0].Source)
+	suite.Require().NotNil(entries[0].Metadata)
+	suite.Equal("New Album", entries[0].Metadata["title"])
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetContributionHistory_MergesSources() {
+	user := suite.createTestUser("mergehistory")
+	suite.createShow(user.ID, "Submitted Show")
+	suite.createVenue(user.ID, "Submitted Venue")
+	suite.auditLog.LogAction(user.ID, "create_release", "release", 1, nil)
+
+	entries, total, err := suite.profileService.GetContributionHistory(user.ID, 20, 0, "")
+
+	suite.Require().NoError(err)
+	suite.Equal(int64(3), total)
+	suite.Len(entries, 3)
+
+	// Verify both sources are represented
+	sources := map[string]bool{}
+	for _, e := range entries {
+		sources[e.Source] = true
+	}
+	suite.True(sources["submission"])
+	suite.True(sources["audit_log"])
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetContributionHistory_Pagination() {
+	user := suite.createTestUser("paginationhistory")
+	for i := 0; i < 5; i++ {
+		suite.createShow(user.ID, fmt.Sprintf("Show %d", i))
+	}
+
+	// Page 1
+	page1, total, err := suite.profileService.GetContributionHistory(user.ID, 2, 0, "")
+	suite.Require().NoError(err)
+	suite.Equal(int64(5), total)
+	suite.Len(page1, 2)
+
+	// Page 2
+	page2, _, err := suite.profileService.GetContributionHistory(user.ID, 2, 2, "")
+	suite.Require().NoError(err)
+	suite.Len(page2, 2)
+
+	// Page 3
+	page3, _, err := suite.profileService.GetContributionHistory(user.ID, 2, 4, "")
+	suite.Require().NoError(err)
+	suite.Len(page3, 1)
+
+	// No overlap
+	suite.NotEqual(page1[0].ID, page2[0].ID)
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetContributionHistory_EntityTypeFilter() {
+	user := suite.createTestUser("filterhistory")
+	suite.createShow(user.ID, "A Show")
+	suite.createVenue(user.ID, "A Venue")
+
+	// Filter to shows only
+	entries, total, err := suite.profileService.GetContributionHistory(user.ID, 20, 0, "show")
+
+	suite.Require().NoError(err)
+	suite.Equal(int64(1), total)
+	suite.Require().Len(entries, 1)
+	suite.Equal("show", entries[0].EntityType)
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetContributionHistory_LimitClamping() {
+	user := suite.createTestUser("limithistory")
+
+	// Limit > 100 should be clamped
+	_, _, err := suite.profileService.GetContributionHistory(user.ID, 200, 0, "")
+	suite.Require().NoError(err)
+
+	// Limit < 1 should default to 20
+	_, _, err = suite.profileService.GetContributionHistory(user.ID, 0, 0, "")
+	suite.Require().NoError(err)
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetContributionHistory_VenueSubmissionEnriched() {
+	user := suite.createTestUser("venueenrich")
+	suite.createVenue(user.ID, "The Rebel Lounge")
+
+	entries, _, err := suite.profileService.GetContributionHistory(user.ID, 20, 0, "")
+
+	suite.Require().NoError(err)
+	suite.Require().Len(entries, 1)
+	suite.Equal("submit_venue", entries[0].Action)
+	suite.Equal("venue", entries[0].EntityType)
+	suite.Equal("The Rebel Lounge", entries[0].EntityName)
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetContributionHistory_OrderedByCreatedAtDesc() {
+	user := suite.createTestUser("orderhistory")
+
+	// Create entries with different timestamps
+	show1 := suite.createShow(user.ID, "First Show")
+	time.Sleep(10 * time.Millisecond) // Ensure different timestamps
+	show2 := suite.createShow(user.ID, "Second Show")
+
+	entries, _, err := suite.profileService.GetContributionHistory(user.ID, 20, 0, "")
+
+	suite.Require().NoError(err)
+	suite.Require().Len(entries, 2)
+	// Most recent first
+	suite.Equal(show2.ID, entries[0].EntityID)
+	suite.Equal(show1.ID, entries[1].EntityID)
+}
+
+// =============================================================================
+// Group 5: Privacy Settings
+// =============================================================================
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestUpdatePrivacySettings_Success() {
+	user := suite.createTestUser("privacyuser")
+
+	settings := PrivacySettings{
+		Contributions:   PrivacyHidden,
+		SavedShows:      PrivacyVisible,
+		Attendance:      PrivacyCountOnly,
+		Following:       PrivacyHidden,
+		Collections:     PrivacyCountOnly,
+		LastActive:      PrivacyHidden,
+		ProfileSections: PrivacyVisible,
+	}
+
+	result, err := suite.profileService.UpdatePrivacySettings(user.ID, settings)
+
+	suite.Require().NoError(err)
+	suite.Require().NotNil(result)
+	suite.Equal(PrivacyHidden, result.Contributions)
+	suite.Equal(PrivacyVisible, result.SavedShows)
+	suite.Equal(PrivacyCountOnly, result.Attendance)
+	suite.Equal(PrivacyHidden, result.Following)
+	suite.Equal(PrivacyCountOnly, result.Collections)
+	suite.Equal(PrivacyHidden, result.LastActive)
+	suite.Equal(PrivacyVisible, result.ProfileSections)
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestUpdatePrivacySettings_Persists() {
+	user := suite.createTestUser("privacypersist")
+
+	settings := PrivacySettings{
+		Contributions:   PrivacyHidden,
+		SavedShows:      PrivacyHidden,
+		Attendance:      PrivacyHidden,
+		Following:       PrivacyHidden,
+		Collections:     PrivacyHidden,
+		LastActive:      PrivacyHidden,
+		ProfileSections: PrivacyHidden,
+	}
+
+	_, err := suite.profileService.UpdatePrivacySettings(user.ID, settings)
+	suite.Require().NoError(err)
+
+	// Reload and verify
+	profile, err := suite.profileService.GetOwnProfile(user.ID)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(profile.PrivacySettings)
+	suite.Equal(PrivacyHidden, profile.PrivacySettings.Contributions)
+	suite.Equal(PrivacyHidden, profile.PrivacySettings.LastActive)
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestUpdatePrivacySettings_InvalidLevel() {
+	user := suite.createTestUser("privacyinvalid")
+
+	settings := DefaultPrivacySettings()
+	settings.Contributions = "invalid_level"
+
+	result, err := suite.profileService.UpdatePrivacySettings(user.ID, settings)
+
+	suite.Error(err)
+	suite.Nil(result)
+	suite.Contains(err.Error(), "invalid privacy level")
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestUpdatePrivacySettings_CountOnlyBinaryField() {
+	user := suite.createTestUser("privacybinary")
+
+	settings := DefaultPrivacySettings()
+	settings.LastActive = PrivacyCountOnly
+
+	result, err := suite.profileService.UpdatePrivacySettings(user.ID, settings)
+
+	suite.Error(err)
+	suite.Nil(result)
+	suite.Contains(err.Error(), "only supports 'visible' or 'hidden'")
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetPublicProfile_PrivacyGating_ContributionsHidden() {
+	user := suite.createTestUser("privgatecontrib")
+	suite.createShow(user.ID, "Hidden Show")
+
+	suite.setPrivacySettings(user.ID, PrivacySettings{
+		Contributions:   PrivacyHidden,
+		SavedShows:      PrivacyHidden,
+		Attendance:      PrivacyHidden,
+		Following:       PrivacyHidden,
+		Collections:     PrivacyHidden,
+		LastActive:      PrivacyHidden,
+		ProfileSections: PrivacyHidden,
+	})
+
+	otherUser := suite.createTestUser("viewer1")
+	profile, err := suite.profileService.GetPublicProfile("privgatecontrib", &otherUser.ID)
+
+	suite.Require().NoError(err)
+	suite.Require().NotNil(profile)
+	suite.Nil(profile.Stats, "Stats should be nil when contributions are hidden")
+	suite.Nil(profile.StatsCount, "StatsCount should be nil when contributions are hidden")
+	suite.Nil(profile.LastActive, "LastActive should be nil when hidden")
+	suite.Empty(profile.Sections, "Sections should be empty when hidden")
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetPublicProfile_PrivacyGating_ContributionsCountOnly() {
+	user := suite.createTestUser("privgatecountonly")
+	suite.createShow(user.ID, "Counted Show")
+	suite.createShow(user.ID, "Another Counted Show")
+
+	suite.setPrivacySettings(user.ID, PrivacySettings{
+		Contributions:   PrivacyCountOnly,
+		SavedShows:      PrivacyHidden,
+		Attendance:      PrivacyHidden,
+		Following:       PrivacyHidden,
+		Collections:     PrivacyHidden,
+		LastActive:      PrivacyVisible,
+		ProfileSections: PrivacyVisible,
+	})
+
+	otherUser := suite.createTestUser("viewer2")
+	profile, err := suite.profileService.GetPublicProfile("privgatecountonly", &otherUser.ID)
+
+	suite.Require().NoError(err)
+	suite.Require().NotNil(profile)
+	suite.Nil(profile.Stats, "Full stats should be nil with count_only")
+	suite.Require().NotNil(profile.StatsCount, "StatsCount should be present with count_only")
+	suite.Equal(int64(2), *profile.StatsCount)
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetPublicProfile_OwnerSeesEverything() {
+	user := suite.createTestUser("ownerseesall")
+	suite.createShow(user.ID, "My Show")
+
+	suite.setPrivacySettings(user.ID, PrivacySettings{
+		Contributions:   PrivacyHidden,
+		SavedShows:      PrivacyHidden,
+		Attendance:      PrivacyHidden,
+		Following:       PrivacyHidden,
+		Collections:     PrivacyHidden,
+		LastActive:      PrivacyHidden,
+		ProfileSections: PrivacyHidden,
+	})
+
+	profile, err := suite.profileService.GetPublicProfile("ownerseesall", &user.ID)
+
+	suite.Require().NoError(err)
+	suite.Require().NotNil(profile)
+	suite.Require().NotNil(profile.Stats, "Owner always sees stats")
+	suite.Require().NotNil(profile.PrivacySettings, "Owner sees privacy settings")
+	suite.Require().NotNil(profile.LastActive, "Owner always sees last active")
+}
+
+// =============================================================================
+// Group 6: User Tier
+// =============================================================================
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetPublicProfile_DefaultTier() {
+	suite.createTestUser("tierdefault")
+
+	profile, err := suite.profileService.GetPublicProfile("tierdefault", nil)
+
+	suite.Require().NoError(err)
+	suite.Require().NotNil(profile)
+	suite.Equal("new_user", profile.UserTier)
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetPublicProfile_CustomTier() {
+	user := suite.createTestUser("tiercustom")
+	err := suite.db.Model(user).Update("user_tier", "contributor").Error
+	suite.Require().NoError(err)
+
+	profile, err := suite.profileService.GetPublicProfile("tiercustom", nil)
+
+	suite.Require().NoError(err)
+	suite.Require().NotNil(profile)
+	suite.Equal("contributor", profile.UserTier)
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetOwnProfile_IncludesTier() {
+	user := suite.createTestUser("tierown")
+	err := suite.db.Model(user).Update("user_tier", "trusted_contributor").Error
+	suite.Require().NoError(err)
+
+	profile, err := suite.profileService.GetOwnProfile(user.ID)
+
+	suite.Require().NoError(err)
+	suite.Require().NotNil(profile)
+	suite.Equal("trusted_contributor", profile.UserTier)
+}
+
+// =============================================================================
+// Group 7: Profile Sections CRUD
+// =============================================================================
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestCreateSection_Success() {
+	user := suite.createTestUser("sectioncreate")
+
+	section, err := suite.profileService.CreateSection(user.ID, "My Music", "I love punk rock", 0)
+
+	suite.Require().NoError(err)
+	suite.Require().NotNil(section)
+	suite.Equal("My Music", section.Title)
+	suite.Equal("I love punk rock", section.Content)
+	suite.Equal(0, section.Position)
+	suite.True(section.IsVisible)
+	suite.NotZero(section.ID)
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestCreateSection_MaxSections() {
+	user := suite.createTestUser("sectionmax")
+
+	_, err := suite.profileService.CreateSection(user.ID, "Section 1", "Content", 0)
+	suite.Require().NoError(err)
+	_, err = suite.profileService.CreateSection(user.ID, "Section 2", "Content", 1)
+	suite.Require().NoError(err)
+	_, err = suite.profileService.CreateSection(user.ID, "Section 3", "Content", 2)
+	suite.Require().NoError(err)
+
+	// Fourth should fail
+	section, err := suite.profileService.CreateSection(user.ID, "Section 4", "Content", 0)
+
+	suite.Error(err)
+	suite.Nil(section)
+	suite.Contains(err.Error(), "maximum 3 profile sections allowed")
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestCreateSection_EmptyTitle() {
+	user := suite.createTestUser("sectionempty")
+
+	section, err := suite.profileService.CreateSection(user.ID, "", "Content", 0)
+
+	suite.Error(err)
+	suite.Nil(section)
+	suite.Contains(err.Error(), "title must be between 1 and 255 characters")
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestCreateSection_InvalidPosition() {
+	user := suite.createTestUser("sectionpos")
+
+	section, err := suite.profileService.CreateSection(user.ID, "Title", "Content", 5)
+
+	suite.Error(err)
+	suite.Nil(section)
+	suite.Contains(err.Error(), "position must be between 0 and 2")
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestCreateSection_NegativePosition() {
+	user := suite.createTestUser("sectionneg")
+
+	section, err := suite.profileService.CreateSection(user.ID, "Title", "Content", -1)
+
+	suite.Error(err)
+	suite.Nil(section)
+	suite.Contains(err.Error(), "position must be between 0 and 2")
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetUserSections_OnlyVisible() {
+	user := suite.createTestUser("sectionvisible")
+
+	s1, err := suite.profileService.CreateSection(user.ID, "Visible", "Content", 0)
+	suite.Require().NoError(err)
+	s2, err := suite.profileService.CreateSection(user.ID, "Hidden", "Content", 1)
+	suite.Require().NoError(err)
+
+	// Hide the second section
+	_, err = suite.profileService.UpdateSection(user.ID, s2.ID, map[string]interface{}{"is_visible": false})
+	suite.Require().NoError(err)
+
+	sections, err := suite.profileService.GetUserSections(user.ID)
+
+	suite.Require().NoError(err)
+	suite.Len(sections, 1)
+	suite.Equal(s1.ID, sections[0].ID)
+	suite.Equal("Visible", sections[0].Title)
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetOwnSections_IncludesHidden() {
+	user := suite.createTestUser("sectionown")
+
+	_, err := suite.profileService.CreateSection(user.ID, "Visible", "Content", 0)
+	suite.Require().NoError(err)
+	s2, err := suite.profileService.CreateSection(user.ID, "Hidden", "Content", 1)
+	suite.Require().NoError(err)
+
+	// Hide the second section
+	_, err = suite.profileService.UpdateSection(user.ID, s2.ID, map[string]interface{}{"is_visible": false})
+	suite.Require().NoError(err)
+
+	sections, err := suite.profileService.GetOwnSections(user.ID)
+
+	suite.Require().NoError(err)
+	suite.Len(sections, 2)
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestUpdateSection_Success() {
+	user := suite.createTestUser("sectionupdate")
+
+	section, err := suite.profileService.CreateSection(user.ID, "Original", "Original content", 0)
+	suite.Require().NoError(err)
+
+	updated, err := suite.profileService.UpdateSection(user.ID, section.ID, map[string]interface{}{
+		"title":   "Updated Title",
+		"content": "Updated content",
+	})
+
+	suite.Require().NoError(err)
+	suite.Equal("Updated Title", updated.Title)
+	suite.Equal("Updated content", updated.Content)
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestUpdateSection_NotFound() {
+	user := suite.createTestUser("sectionnotfound")
+
+	section, err := suite.profileService.UpdateSection(user.ID, 99999, map[string]interface{}{
+		"title": "Nope",
+	})
+
+	suite.Error(err)
+	suite.Nil(section)
+	suite.Equal("profile section not found", err.Error())
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestUpdateSection_WrongOwner() {
+	user1 := suite.createTestUser("sectionowner1")
+	user2 := suite.createTestUser("sectionowner2")
+
+	section, err := suite.profileService.CreateSection(user1.ID, "Mine", "Content", 0)
+	suite.Require().NoError(err)
+
+	// user2 tries to update user1's section
+	result, err := suite.profileService.UpdateSection(user2.ID, section.ID, map[string]interface{}{
+		"title": "Hijacked",
+	})
+
+	suite.Error(err)
+	suite.Nil(result)
+	suite.Equal("profile section not found", err.Error())
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestDeleteSection_Success() {
+	user := suite.createTestUser("sectiondelete")
+
+	section, err := suite.profileService.CreateSection(user.ID, "Doomed", "Content", 0)
+	suite.Require().NoError(err)
+
+	err = suite.profileService.DeleteSection(user.ID, section.ID)
+
+	suite.NoError(err)
+
+	// Verify it's gone
+	sections, err := suite.profileService.GetOwnSections(user.ID)
+	suite.Require().NoError(err)
+	suite.Empty(sections)
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestDeleteSection_NotFound() {
+	user := suite.createTestUser("sectiondelnotfound")
+
+	err := suite.profileService.DeleteSection(user.ID, 99999)
+
+	suite.Error(err)
+	suite.Equal("profile section not found", err.Error())
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestDeleteSection_WrongOwner() {
+	user1 := suite.createTestUser("sectiondelowner1")
+	user2 := suite.createTestUser("sectiondelowner2")
+
+	section, err := suite.profileService.CreateSection(user1.ID, "Protected", "Content", 0)
+	suite.Require().NoError(err)
+
+	err = suite.profileService.DeleteSection(user2.ID, section.ID)
+
+	suite.Error(err)
+	suite.Equal("profile section not found", err.Error())
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetPublicProfile_IncludesSections() {
+	user := suite.createTestUser("profilesections")
+
+	_, err := suite.profileService.CreateSection(user.ID, "About Me", "I go to shows", 0)
+	suite.Require().NoError(err)
+	_, err = suite.profileService.CreateSection(user.ID, "Favorite Genres", "Punk, Indie", 1)
+	suite.Require().NoError(err)
+
+	profile, err := suite.profileService.GetPublicProfile("profilesections", nil)
+
+	suite.Require().NoError(err)
+	suite.Require().NotNil(profile)
+	suite.Len(profile.Sections, 2)
+	suite.Equal("About Me", profile.Sections[0].Title)
+	suite.Equal("Favorite Genres", profile.Sections[1].Title)
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetOwnProfile_IncludesAllSections() {
+	user := suite.createTestUser("ownsections")
+
+	_, err := suite.profileService.CreateSection(user.ID, "Visible", "Content", 0)
+	suite.Require().NoError(err)
+	s2, err := suite.profileService.CreateSection(user.ID, "Hidden", "Secret", 1)
+	suite.Require().NoError(err)
+	_, err = suite.profileService.UpdateSection(user.ID, s2.ID, map[string]interface{}{"is_visible": false})
+	suite.Require().NoError(err)
+
+	profile, err := suite.profileService.GetOwnProfile(user.ID)
+
+	suite.Require().NoError(err)
+	suite.Require().NotNil(profile)
+	suite.Len(profile.Sections, 2, "Own profile should include hidden sections")
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetSections_OrderedByPosition() {
+	user := suite.createTestUser("sectionorder")
+
+	_, err := suite.profileService.CreateSection(user.ID, "Third", "Content", 2)
+	suite.Require().NoError(err)
+	_, err = suite.profileService.CreateSection(user.ID, "First", "Content", 0)
+	suite.Require().NoError(err)
+	_, err = suite.profileService.CreateSection(user.ID, "Second", "Content", 1)
+	suite.Require().NoError(err)
+
+	sections, err := suite.profileService.GetUserSections(user.ID)
+
+	suite.Require().NoError(err)
+	suite.Require().Len(sections, 3)
+	suite.Equal("First", sections[0].Title)
+	suite.Equal("Second", sections[1].Title)
+	suite.Equal("Third", sections[2].Title)
+}

--- a/backend/internal/services/interfaces.go
+++ b/backend/internal/services/interfaces.go
@@ -356,6 +356,20 @@ type ReleaseServiceInterface interface {
 	RemoveExternalLink(linkID uint) error
 }
 
+// ContributorProfileServiceInterface defines the contract for contributor profile operations.
+type ContributorProfileServiceInterface interface {
+	GetPublicProfile(username string, viewerID *uint) (*PublicProfileResponse, error)
+	GetOwnProfile(userID uint) (*PublicProfileResponse, error)
+	GetContributionStats(userID uint) (*ContributionStats, error)
+	GetContributionHistory(userID uint, limit, offset int, entityType string) ([]*ContributionEntry, int64, error)
+	UpdatePrivacySettings(userID uint, settings PrivacySettings) (*PrivacySettings, error)
+	GetUserSections(userID uint) ([]*ProfileSectionResponse, error)
+	GetOwnSections(userID uint) ([]*ProfileSectionResponse, error)
+	CreateSection(userID uint, title string, content string, position int) (*ProfileSectionResponse, error)
+	UpdateSection(userID uint, sectionID uint, updates map[string]interface{}) (*ProfileSectionResponse, error)
+	DeleteSection(userID uint, sectionID uint) error
+}
+
 // CalendarServiceInterface defines the contract for calendar feed operations.
 type CalendarServiceInterface interface {
 	CreateToken(userID uint, apiBaseURL string) (*CalendarTokenCreateResponse, error)
@@ -394,5 +408,6 @@ var (
 	_ FestivalServiceInterface       = (*FestivalService)(nil)
 	_ LabelServiceInterface          = (*LabelService)(nil)
 	_ ReleaseServiceInterface       = (*ReleaseService)(nil)
-	_ BookmarkServiceInterface      = (*BookmarkService)(nil)
+	_ BookmarkServiceInterface           = (*BookmarkService)(nil)
+	_ ContributorProfileServiceInterface = (*ContributorProfileService)(nil)
 )

--- a/docs/llm-context.md
+++ b/docs/llm-context.md
@@ -10,39 +10,58 @@ See `docs/vision.md` for the full north star, What.cd feature mapping, and entit
 
 ## Current Checkpoint (March 2026)
 
-**Where we are:** Phase 1.5 — knowledge graph vertical slice actively under construction. Frontend redesign complete, Releases and Labels entities landed.
+**Where we are:** Phase 1.5 complete. **Major roadmap restructuring (March 2026):** Community foundations pulled forward from Phase 3 to Phase 2a, running in parallel with pipeline work. Insight from What.cd user analysis: community curation is the moat, not the data pipeline. Contributor identity, collections, and requests now ship in Phase 2a (March–May 2026), not Q4 2026. Pipeline foundation (Phase 1.6a) ships minimum viable (PSY-32, PSY-34, PSY-36); remaining pipeline work becomes a background track. Admin dashboard polish demoted to opportunistic.
 
-| Area | Status |
-|------|--------|
-| Core entities | Artists, Venues, Shows (many-to-many, slugs, search, filters), **Releases** (with artist roles + external links, full CRUD API), **Labels** (with artist/release junctions, catalog numbers). Building next: Festivals, enriched artist pages. Planned: Tags, Scenes, Collections, Requests, Radio Stations, Radio Shows, Musicians, Promoters. |
-| User features | Accounts, saved shows, ICS calendar feed, favorite venues/cities, show reminders (email, 24h before). Planned: generic `user_bookmarks` table replacing per-entity tables. |
-| Admin | Show/venue approval workflows, pending edits, audit log, discovery imports, release CRUD (admin-only API) |
-| Auth | Email/password, magic link, OAuth (Google/GitHub), passkeys (WebAuthn) |
-| Discovery | 5 venue scrapers (Phoenix metro), admin import UI |
-| Frontend | Sidebar nav, Cmd+K command palette, redesigned show/artist/venue cards, density toggle, TagPill + RelationshipBadge placeholder components |
-| Testing | 69 E2E, 68.5%+ backend coverage, 897+ frontend unit tests |
-| Observability | PostHog analytics, Sentry error tracking |
-| iOS | Code complete (39 files), not shipped — needs Apple Developer enrollment |
 
-**In progress:** Label service/handler/routes (PSY-10), Release frontend pages + entity detail template (PSY-8 + PSY-18).
+| Area          | Status                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Core entities | Artists, Venues, Shows (many-to-many, slugs, search, filters), **Releases** (with artist roles + external links, full CRUD API + admin UI + frontend pages), **Labels** (with artist/release junctions, catalog numbers, full CRUD API + admin UI + frontend pages), **Festivals** (with billing tiers, multi-venue, full CRUD API + admin UI + frontend pages + data entry CLI). Enriched artist pages with discography + label affiliations + festival appearances. Planned: Tags, Scenes, Collections, Requests, Radio Stations, Radio Shows, Musicians, Promoters.                                                    |
+| User features | Accounts, saved shows, ICS calendar feed, favorite venues/cities, show reminders (email, 24h before). Generic `user_bookmarks` table live (replaces per-entity tables). **Contributor profiles** (PSY-63): public profiles with contribution stats/history, 3-level granular privacy (visible/count\_only/hidden per field), user tier model, custom profile sections (up to 3, markdown).                                                                                                                                                                                                                                    |
+| Admin         | Show/venue approval workflows, pending edits, audit log, discovery imports, release/label/festival CRUD (admin-only API). Phase 2b: "Needs Work" data quality dashboard, tag admin, artist merge/split (PSY-45–47). Phase 2c: platform analytics (PSY-48). Phase 1.7 (opportunistic): dashboard UX polish (PSY-37–44). Phase 3: unified moderation queue, trust tiers, contributor leaderboard.                                                                                                                                                                                                                           |
+| Auth          | Email/password, magic link, OAuth (Google/GitHub), passkeys (WebAuthn)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| Discovery     | **AI-first, multi-source pipeline.** PSY-29 audit: 5/7 Playwright scrapers broken. New strategy: iCal/RSS feeds (cheapest) → HTTP JSON-LD → AI web extraction (universal, ~$0.01-0.03/page) → ticketing APIs (enrichment/validation). **Tiered rendering:** static HTTP → chromedp dynamic → chromedp screenshot (auto-detected per venue). Most venue sites are JS-rendered or anti-scrape protected — chromedp (pure Go headless Chrome) is the default path. Change detection skips unchanged pages. APIs for cross-referencing, not primary. Legacy Playwright scrapers deprecated. Phase 1.6: PSY-29 through PSY-36. |
+| Frontend      | Sidebar nav, Cmd+K command palette, redesigned show/artist/venue cards, density toggle, EntityDetailLayout template, festival listing + detail pages with tiered lineup                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| Data seeding  | MusicBrainz CLI, Bandcamp enrichment CLI, Festival data entry CLI (all human-run with --dry-run)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| Testing       | 69 E2E, 68.5%+ backend coverage, 897+ frontend unit tests                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| Observability | PostHog analytics, Sentry error tracking                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| iOS           | Code complete (39 files), not shipped — needs Apple Developer enrollment                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 
-**Recently shipped:** Release model + migration (PSY-5), Release service/handler/routes with 57 tests (PSY-6), Label model + migration (PSY-9), visual polish sweep with density toggle (PSY-21), artist card redesign (PSY-20), sidebar nav (PSY-16), Cmd+K command palette (PSY-17), show card redesign (PSY-19).
 
-**Next up:** Label frontend pages (PSY-12), enriched artist pages with discography + label affiliations (PSY-13), release admin UI (PSY-7), label admin UI (PSY-11), MusicBrainz data seeding (PSY-14), Bandcamp enrichment (PSY-15), generic `user_bookmarks` table, Festival entity.
+**Phase 1.5 complete.** All 24 issues (PSY-5 through PSY-28) shipped.
+
+**Recently shipped:** Contributor profile backend with 58 tests (PSY-63), festival frontend pages (PSY-27), festival admin UI (PSY-26), festival service/handlers with 82 tests (PSY-25), festival model (PSY-24), TIMESTAMPTZ standardization (PSY-23), generic bookmarks (PSY-22), enriched artist pages (PSY-13), MusicBrainz + Bandcamp seeding CLIs (PSY-14, PSY-15), festival data entry CLI (PSY-28).
+
+**Next up (restructured):**
+- **Phase 1.6a + 2a (parallel, NOW):** Pipeline foundation (PSY-32 AI extraction, PSY-34 provenance, PSY-36 venue config) running parallel with community foundations (~~PSY-63~~ DONE, PSY-64 contributor profile frontend, PSY-65–68 collections, PSY-70–72 requests, PSY-73/74 revision history).
+- **Phase 2b (May–July):** Tags (PSY-49/50/51/46), artist relationships (PSY-52/53), scenes (PSY-59/60), "Needs Work" dashboard (PSY-45), artist merge/split (PSY-47), bill position (PSY-54).
+- **Phase 2c (July–Aug):** Going/interested (PSY-55), follow (PSY-56), top charts (PSY-57), notification filters, venue profiles (PSY-61/62), platform analytics (PSY-48).
+- **Phase 1.6b (background):** Pipeline maturation (PSY-30/31/33/35). **Phase 1.7 (opportunistic):** Admin polish (PSY-37–44).
+- **Phase 3 (Q4):** Open edit flows, trust tiers, unified moderation queue, show field notes, data export.
+- All 5 Phase 2 design docs complete. See `docs/strategy/ROADMAP.md` for full details.
 
 ## Task Routing
 
-| If your task involves... | Read these docs |
-|--------------------------|-----------------|
-| Product vision, new entities, strategic direction | `docs/vision.md` |
-| What to build next, quarterly priorities | `docs/strategy/ROADMAP.md` |
-| Frontend UI redesign (sidebar, layout, cards, templates) | `docs/strategy/ui-redesign.md` |
-| Web frontend or Go backend features | `docs/strategy/web.md` |
-| iOS app | `docs/strategy/ios.md` + `docs/learnings/ios.md` |
-| Discovery scrapers or data pipeline | `docs/strategy/discovery.md` + `docs/learnings/discovery.md` |
-| Backend architecture, conventions, test patterns | `CLAUDE.md` (Architecture section) |
-| Gazelle/What.cd implementation patterns (voting, tags, notifications, privacy) | `docs/learnings/gazelle-patterns.md` |
-| Agent workflow, Linear issues, PR process | `docs/agent-workflow.md` |
+
+| If your task involves...                                                       | Read these docs                                              |
+| ------------------------------------------------------------------------------ | ------------------------------------------------------------ |
+| Product vision, new entities, strategic direction                              | `docs/vision.md`                                             |
+| What to build next, quarterly priorities                                       | `docs/strategy/ROADMAP.md`                                   |
+| Frontend UI redesign (sidebar, layout, cards, templates)                       | `docs/strategy/ui-redesign.md`                               |
+| Frontend form patterns, component conventions, query patterns                  | `docs/learnings/frontend-patterns.md`                        |
+| Web frontend or Go backend features                                            | `docs/strategy/web.md`                                       |
+| iOS app                                                                        | `docs/strategy/ios.md` + `docs/learnings/ios.md`             |
+| Discovery scrapers or data pipeline                                            | `docs/strategy/discovery.md` + `docs/learnings/discovery.md` |
+| Backend architecture, conventions, test patterns                               | `CLAUDE.md` (Architecture section)                           |
+| Scene pages, venue intelligence, city landing pages                            | `docs/strategy/scene-pages.md`                               |
+| Similar artist visualization, relationship graph, artist voting                | `docs/strategy/similar-artists.md`                           |
+| Notification filters, matching engine, multi-channel notifications             | `docs/strategy/notification-filters.md`                      |
+| Radio stations, radio shows, playlist parsing, "as heard on", co-occurrence    | `docs/strategy/radio-entities.md`                            |
+| Festival intelligence, lineup overlap, breakout tracking, circuit analysis     | `docs/strategy/festival-intelligence.md`                     |
+| Gazelle/What.cd implementation patterns (voting, tags, notifications, privacy) | `docs/learnings/gazelle-patterns.md`                         |
+| Gazelle user profiles (identity hub, paranoia, ranks, customization, donors)   | `docs/learnings/gazelle-user-profiles.md`                    |
+| What.cd user psychology, contributor motivation, product-market fit lessons     | `docs/learnings/whatcd-user-insights.md`                     |
+| Agent workflow, Linear issues, PR process                                      | `docs/agent-workflow.md`                                     |
+
 
 ## Guardrails
 
@@ -51,4 +70,5 @@ See `docs/vision.md` for the full north star, What.cd feature mapping, and entit
 - **Fire-and-forget** — Discord notifications and audit logs never fail parent operations
 - **JSONB columns** — use `*json.RawMessage` (not `datatypes.JSON`)
 - **Huma quirk** — all request body fields required by default, even pointers; mark optional explicitly
-- **Migration numbering** — latest is 000036 (create_labels); next is 000037
+- **Migration numbering** — latest is 000041 (profile_enhancements, PSY-63); next is 000042
+

--- a/docs/strategy/ROADMAP.md
+++ b/docs/strategy/ROADMAP.md
@@ -2,27 +2,38 @@
 
 > Quarterly priorities across all tracks. For the product vision and entity model, see `docs/vision.md`. For track-specific details, see individual track files.
 
-## Guiding Principle
+## Guiding Principles
 
 Live shows are the gateway into the knowledge graph. Every phase builds outward from the live experience: shows lead to artist discovery, which leads to releases and labels, which leads to more artists and more shows. The knowledge graph grows from the live foundation — never away from it.
 
-**Build the thing that differentiates us first.** Social features (Going/Interested) are commodity — every event platform has them. The knowledge graph is what makes this the What.cd successor. Prioritize the graph.
+**Community curation is the moat, not the data pipeline.** The pipeline produces raw material. Community tools produce the knowledge graph. What.cd's real value was built by thousands of obsessive volunteers working within quality constraints — not by automated ingestion. Build the tools that attract contributors before optimizing the pipeline that feeds them.
 
-**Bake in What.cd DNA from the start.** Features like artist-release roles, tag voting, and similar artist voting are low incremental cost when built alongside the entities they enrich. Don't defer them to a "polish" phase — build them right the first time.
+**Contributor identity is foundational infrastructure.** Attribution ("Added by [username]"), contribution profiles, and visible impact are not late-stage polish — they are the scaffolding that makes people invest. Every feature that allows user contribution ships with attribution from day one. A What.cd user contributed 4 of 5 albums for a Japanese band, importing CDs at personal expense. When the site died, he said "it's like part of me died." That level of ownership is what we're building toward. See `docs/learnings/whatcd-user-insights.md`.
+
+**Ship what creates contributors before what creates passive users.** Tags, collections, and requests create active contributors. Going/Interested creates passive engagement. Prioritize the former.
+
+**Quality standards attract, not repel.** What.cd's strictness was a magnet for the exact people who built the database. Open registration means quality assurance comes from reputation systems and review processes, not entrance barriers.
+
+**Pipeline and community are parallel tracks.** They're independent work streams that reinforce each other. The pipeline feeds data in; the community deepens it. Neither should block the other.
 
 ## Current Priority Order
 
 | Priority | Focus | What | Status |
 |----------|-------|------|--------|
-| 1 | Web | Knowledge graph vertical slice (Releases + Labels landed, frontend pages + enriched artists next) | In progress |
-| 2 | iOS | Polish, test, ship to App Store | Blocked (Apple Developer enrollment) |
-| 3 | Discovery | Provider reliability, automated scheduling | Maintenance mode |
+| 1a | Discovery | Phase 1.6a: Minimum viable AI pipeline (PSY-29, PSY-32, PSY-34, PSY-36) | In progress |
+| 1b | Community | Phase 2a: Community foundations — contributor identity, collections, requests, revision history (PSY-63 through PSY-74) | In progress (PSY-63 done) |
+| 2 | Web | Phase 2b: Knowledge graph connective tissue — tags, relationships, scenes (PSY-45–54, PSY-59/60) | Planned |
+| 3 | Web | Phase 2c: Engagement & social — going/interested, follow, charts, notifications (PSY-55–57, PSY-61/62) | Planned |
+| — | Discovery | Phase 1.6b: Pipeline maturation (PSY-30, PSY-31, PSY-33, PSY-35) | Background track |
+| — | Admin | Phase 1.7: Admin dashboard polish (PSY-37–44) | Opportunistic |
+| 4 | Community | Phase 3: Community at scale — moderation, trust tiers, open edit flows | Planning |
+| 5 | iOS | Polish, test, ship to App Store | Blocked (Apple Developer enrollment) |
 
 ---
 
-## Q1-Q2 2026: Foundation + Knowledge Graph Vertical Slice (Phase 1)
+## COMPLETED: Foundation + Knowledge Graph Vertical Slice (Phase 1 / 1.5)
 
-**Theme:** Close out remaining utility work, then immediately start proving the What.cd vision with a vertical slice of the knowledge graph.
+**Theme:** Close out remaining utility work, then prove the What.cd vision with a vertical slice of the knowledge graph.
 
 ### Wrap Up (Phase 1 utility)
 - [x] Artists list page with search + multi-city filters
@@ -31,164 +42,281 @@ Live shows are the gateway into the knowledge graph. Every phase builds outward 
 - [x] Show reminders (email, 24h before, with one-click unsubscribe)
 - [ ] Email preferences UI (in progress)
 
-### Frontend Redesign (Phase 1, before and alongside entity work)
+### Frontend Redesign (Phase 1)
 
 Structural UI redesign to evolve from "show tracker" to "music knowledge graph." Full spec in `docs/strategy/ui-redesign.md`.
 
-**Build order (optimized for agent execution):**
-
 1. ~~**Sidebar navigation + wider layout**~~ — DONE (PSY-16, PR #11)
 2. ~~**Cmd+K command palette**~~ — DONE (PSY-17, PR #13)
-3. **Entity detail page template** — IN PROGRESS (PSY-18, building with Release frontend pages)
+3. ~~**Entity detail page template**~~ — DONE (PSY-18)
 4. ~~**Show card redesign**~~ — DONE (PSY-19, PR #14)
 5. ~~**Artist card redesign**~~ — DONE (PSY-20)
-6. ~~**Visual polish**~~ — DONE (PSY-21, PR #18) — bolder typography, card borders, density toggle, TagPill + RelationshipBadge placeholder components
+6. ~~**Visual polish**~~ — DONE (PSY-21, PR #18)
 
 ### Data Layer Foundation + Knowledge Graph Vertical Slice (Phase 1.5)
 
-Lay the schema foundation for the full knowledge graph, then prove the minimum viable version. A user should navigate from a show to an artist to their releases to their label to label mates, and from a festival to 40 artists on the bill. This is the moment the app stops being "another show tracker."
+1. ~~**Data layer foundation**~~ — DONE (PSY-22 generic bookmarks, PSY-23 TIMESTAMPTZ)
+2. ~~**Festival entity**~~ — DONE (PSY-24 model, PSY-25 service/handlers 82 tests, PSY-26 admin UI, PSY-27 frontend pages, PSY-28 data entry CLI)
+3. ~~**Releases entity**~~ — DONE (PSY-5 model, PSY-6 service 57 tests, PSY-7 admin UI, PSY-8 frontend pages)
+4. ~~**Labels entity**~~ — DONE (PSY-9 model, PSY-10 service, PSY-11 admin UI, PSY-12 frontend pages)
+5. ~~**Artist pages enriched**~~ — DONE (PSY-13)
+6. ~~**Data seeding**~~ — DONE (PSY-14 MusicBrainz CLI, PSY-15 Bandcamp CLI, PSY-28 festival entry CLI)
+
+**Phase 1.5 exit criteria met.** All 24 issues (PSY-5 through PSY-28) shipped.
+
+### iOS (blocked)
+- [ ] Apple Developer enrollment ($99/year)
+- [ ] Re-enable capabilities, polish, TestFlight → App Store
+
+---
+
+## NOW: Pipeline Foundation + Community Foundations (Phase 1.6a + Phase 2a)
+
+These two tracks run **in parallel**. Phase 1.6a is backend-heavy pipeline infrastructure. Phase 2a is the community features that make PH more than a listing site. They are independent work streams.
+
+### Phase 1.6a: Discovery Pipeline Foundation (March–April 2026)
+
+**Theme:** Get the AI extraction pipeline working well enough that data flows reliably, then shift primary engineering focus to community tools. The remaining pipeline issues become a background track.
+
+**Linear project:** "Phase 1.6: Discovery Pipeline & Data Quality" (PSY-29 through PSY-36)
+
+**Data source tiers (resilience + scalability):**
+1. iCal/RSS feeds — free, structured, standard, most reliable when available
+2. HTTP JSON-LD — free, structured, no browser needed (schema.org markup)
+3. AI web extraction — universal, ~$0.01-0.03/page, works on any website
+4. Ticketing platform APIs — enrichment + cross-referencing (SeatGeek, Bandsintown, Ticketmaster)
+5. Festival lineups + community submissions — human-powered gap-filling
+
+**What ships now (minimum viable pipeline):**
+
+1. ~~**Provider reliability audit** (PSY-29)~~ — DONE. 2/7 passing. Conclusion: pivot to AI-first.
+2. **AI extraction pipeline** (PSY-32, elevated to core) — Tiered rendering: static HTTP → chromedp dynamic → chromedp screenshot, auto-detected per venue. Extend `extraction.go` for multi-event calendar pages. HTTP change detection (ETag/hash). Start with 3-5 Phoenix venues.
+3. **Data provenance tracking** (PSY-34) — `data_source`, `source_confidence`, `last_verified_at` on core entity tables.
+4. **Venue-level source config** (PSY-36) — Per-venue config: preferred source, calendar URL, feed URL, render_method, change detection state, strategy profile.
+
+**What defers to Phase 1.6b (background track):**
+- PSY-30 (AI billing enrichment) — useful but not blocking
+- PSY-31 (Automated scheduling) — manual triggering suffices initially
+- PSY-33 (Consolidate discovery UI) — admin convenience
+- PSY-35 (Post-import enrichment pipeline) — manual seeding CLIs work today
+- iCal/RSS feed detection — opportunistic, per-venue
+
+**Exit criteria:** AI extraction working on 5+ venues. Data provenance on core tables. Venue source config persisted. Change detection reducing unnecessary extractions.
+
+---
+
+### Phase 2a: Community Foundations (March–May 2026, parallel with 1.6a)
+
+**Theme:** Build the three pillars that made What.cd irreplaceable: **contributor identity**, **collections**, and the **request system**. These are the features that turn passive browsers into invested community members. Plus revision history to enable accountable editing.
+
+**Linear project:** "Phase 2a: Community Foundations" (PSY-63 through PSY-74)
+
+**Why now (not Phase 3):** The current roadmap deferred all community features to Q4 2026 — a full year where the app is a read-only browsing experience. But What.cd's moat was never the data; it was the community that built and maintained the data. Contributor identity, collections, and requests are not "community features to add later" — they are the foundation that makes everything else matter. Every subsequent feature (tags, scenes, charts) is more powerful when built on contributor identity.
 
 **Build order:**
 
-1. **Data layer foundation**
-   - Generic `user_bookmarks` table replacing `user_saved_shows` and `user_favorite_venues` — supports all entity types and action types (save, follow, bookmark, going, interested). No users yet, clean migration.
-   - TIMESTAMPTZ standardization (initial schema uses TIMESTAMP without timezone)
-   - Refactor saved show and favorite venue services/handlers/hooks to use generic bookmark infrastructure
+#### 1. Contributor Identity & Profile System (PSY-63, PSY-64)
 
-2. **Festival entity** — model, migrations, CRUD API, admin UI, pages
-   - Distinct from Show: `series_slug` + `edition_year` (UNIQUE constraint) for recurring festivals
-   - `festival_artists` junction: `billing_tier` (headliner/sub_headliner/mid_card/undercard/local/dj/host), `position`, `day_date`, `stage`, `set_time`, `venue_id`
-   - `festival_venues` junction for multi-venue takeover festivals
-   - `location_name` for non-venue locations (parks, fairgrounds)
-   - URL structure: `/festivals/:series_slug/:year`
-   - Festival listing page (`/festivals`) and series overview (`/festivals/:series_slug`)
+The most important new work. Not a feature in itself — infrastructure that makes every subsequent community feature create ownership. Gazelle's profile pages were dense identity hubs where users saw themselves reflected in the knowledge graph. Our current profile is a settings form — this transforms it into the center of contributor identity. *(Deep analysis: `docs/learnings/gazelle-user-profiles.md`)*
 
-3. ~~**Releases entity**~~ — DONE
-   - Model + migration 000035 (PSY-5), service + handler + routes with 57 tests (PSY-6)
-   - Type: LP, EP, single, compilation, live, remix, demo
-   - External links: Bandcamp, Spotify, Discogs, YouTube, Apple Music, Tidal, SoundCloud
-   - Artist <--> Release with role types (main, featured, producer, remixer, composer, DJ)
-   - Frontend pages IN PROGRESS (PSY-8)
+- ~~**PSY-63: Contributor profile model and API**~~ — **DONE** (58 tests, migrations 000040–000041)
+  - **Contribution tracking:** Contribution counts materialized from `audit_log` + entity tables via UNION ALL query. Tracks: shows submitted, venues submitted, venue edits, releases created, labels created, festivals created, artists edited, moderation actions.
+  - **Public profile endpoint:** `GET /users/:username` with optional auth. Returns identity header (username, avatar, join date, tier), contribution stats (privacy-gated), recent activity, custom profile sections. Owner sees everything; non-owner sees per-field privacy-gated data.
+  - **Privacy controls:** `privacy_settings` JSONB column on users with 3-level per-field visibility: `visible` (full data), `count_only` (aggregate count only), `hidden` (omitted). 7 fields: contributions, saved_shows, attendance, following, collections, last_active, profile_sections. Binary-only fields (last_active, profile_sections) reject count_only. Master switch via `profile_visibility` (public/private). Owner always sees all own data.
+  - **User tier model:** `user_tier` VARCHAR on users (new_user/contributor/trusted_contributor/local_ambassador). Displayed on profile. Initially manual; auto-promotion scheduler deferred to Phase 3.
+  - **Custom profile sections:** `user_profile_sections` table with CRUD API. Max 3 sections per user, markdown content (up to 10000 chars), position ordering, visibility toggle. Owner sees all sections; public viewers see only visible ones.
+  - **11 API endpoints:** 3 public with optional auth (`/users/{username}`, `/users/{username}/contributions`, `/users/{username}/sections`), 8 protected (`/auth/profile/contributor`, `/auth/profile/contributions`, `/auth/profile/visibility`, `/auth/profile/privacy`, `/auth/profile/sections` CRUD).
+  - **Deferred to later:** Percentile rankings (Phase 2a exit criteria, additive), impact metrics (downstream views/saves, additive), contribution heatmap (frontend, PSY-64).
 
-4. ~~**Labels entity**~~ — model + migration 000036 DONE (PSY-9), service/handler/routes IN PROGRESS (PSY-10)
-   - Name, city, country, founded year, status, socials, description
-   - Artist <--> Label junction, Release <--> Label junction with catalog_number
-   - Frontend pages TODO (PSY-12)
+- **PSY-64: Contributor profile frontend**
+  - **Public profile page** (`/users/:username`): Identity header with avatar + tier badge + join date. Contribution summary cards by type. Visual recent activity feed (entity images, not just text). Collections showcase (visual grid thumbnails). Customizable profile sections (markdown rendered). Percentile ranking display. Contribution heatmap (GitHub-style activity calendar).
+  - **"Added by [username]"** attribution on entity detail pages (shows, artists, releases, labels, venues). Links to contributor's public profile.
+  - **"Your Impact"** section on private profile: downstream metrics, rank progress (what you need to reach next tier), privacy controls management.
+  - **Profile transformation:** Current `/profile` page evolves from bare settings into tabbed layout: Profile (public identity view) | Contributions (detailed history + stats) | Settings (existing settings panel).
 
-5. **Artist pages enriched** — discography section, label affiliations, festival appearances (PSY-13, TODO)
-   - Artist detail page shows releases with external links, grouped by role (albums, guest appearances, production credits — like What.cd)
-   - Artist detail page shows label affiliations and "Also on this label" (the discovery moment)
-   - Artist detail page shows festival appearances with billing tier — visible career trajectory
+#### 2. Collections (PSY-65 through PSY-68)
 
-6. **Release pages** (`/releases/:slug`) with "Listen / Buy" external links
-7. **Label pages** (`/labels`, `/labels/:slug`) with roster and catalog
-8. **Festival pages** (`/festivals/:series_slug/:year`) with tiered lineup display, day tabs, "artists you follow" highlights
+The primary vessel for community knowledge — a record store at scale. No prescribed categories — collectors use their imagination: "Artists who performed at The Smell in LA 2010-2012", "Pitchfork's Top 100 Albums of the 2010s", "African Psychedelic Punk", "Creation Records 1984-1999", "Shows at Crescent Ballroom that changed my life", "The Phoenix scene in 2019." Open to collaboration by default. Visual grids. Subscribable. Each collection is someone's expertise made navigable — the description is the narrative, the items are the evidence, the graph connections are the context.
 
-9. **Data seeding** — populate knowledge graph
-   - Admin festival entry — enter major US festivals (M3F, Levitation, Psycho Las Vegas, Desert Daze, etc.). One festival = ~10 min for 40+ graph connections. Geographic expansion without scrapers.
-   - MusicBrainz integration (artist-label relationships, release metadata, artist roles)
-   - Bandcamp enrichment (release links, label rosters)
+- **PSY-65: Collection model and migrations** — `collections` table (title, slug, description, creator_id, collaborative, cover_image_url, is_public), `collection_items` table (entity_type, entity_id, position, added_by_user_id, notes), `collection_subscribers` table (last_visited_at for Gazelle-style unread tracking)
+- **PSY-66: Collection service and handlers** — CRUD, item management (add/remove/reorder), subscription, permission model (creator edits, collaborators add items, anyone subscribes, admin features), aggregate stats (item count, contributor count, top tags once tags exist)
+- **PSY-67: Collection admin UI** — admin tab for managing featured collections, moderation
+- **PSY-68: Collection frontend pages** — `/collections` listing with search, `/collections/:slug` detail with visual grid of entity images (album art, venue photos, artist images, show flyers), "Add to collection" flow on entity detail pages, collection display on contributor profiles
+#### 3. Request System (PSY-70 through PSY-72)
 
-**Exit criteria:** Sidebar nav + Cmd+K search live. Entity detail template in use on all detail pages. 50+ Phoenix artist discographies populated. 200+ releases with external links. 20+ labels cataloged. 10+ festivals entered with lineups. Generic bookmarks system live. A user can navigate: show --> artist --> releases (with role credits) --> label --> label mates --> their shows. Festival --> 40 artists --> their releases and shows. Show/artist cards redesigned with bill hierarchy, tag pills, and discovery cues.
+The mechanism that converts passive browsers into active contributors. What.cd users bought and imported rare CDs because someone else requested them. Requests are calls to action, not wishlists.
 
-### iOS (unchanged, blocked)
-- [ ] Apple Developer enrollment ($99/year)
-- [ ] Re-enable capabilities (Sign in with Apple, App Groups, Keychain Sharing)
-- [ ] Polish & error states
-- [ ] TestFlight --> App Store submission
+- **PSY-70: Request model and migrations** — `requests` table (title, description, entity_type, requested_entity_id nullable, status, requester_id, fulfiller_id, vote_score), `request_votes` table (vote up/down)
+- **PSY-71: Request service and handlers** — CRUD, voting with Wilson score, fulfillment workflow linking contribution to request, auto-generated requests from data quality queries ("This label has 12 artists but only 3 have releases", "This festival has 40 artists but only 10 are in our database")
+- **PSY-72: Request frontend pages** — `/requests` listing with filters (entity_type, status, sort by votes), request detail, "Request" buttons on entity pages ("This artist needs releases"), fulfillment flow, request feed on contributor profile
 
-### Discovery
-- [ ] Audit all 5 providers against live sites
-- [ ] Fix broken scrapers
-- [ ] Automated daily/weekly schedule
-- [ ] Error alerting (Discord/Sentry)
-- [ ] **AI billing enrichment** — add screenshot step to Playwright scrapers, send event detail pages through Claude (extraction service pattern) to determine accurate headliner/support/opener billing. Replaces "first listed = headliner" heuristic with semantic understanding. Low cost (Haiku on ~100 events/month).
-- [ ] Expand `set_type` vocabulary: `headliner` → `direct_support` → `opener` (three-tier minimum), plus `dj`, `special_guest`
-- [ ] **Festival data entry** — admin entry of major US festival lineups. AI-assisted: screenshot festival posters, extract structured lineup with billing tiers from font size/position. Geographic expansion without scrapers.
+#### 4. Revision History (PSY-73, PSY-74)
+
+Required before opening edit flows to non-admin users. Accountability and rollback capability.
+
+- **PSY-73: Revision history model and service** — `revisions` table (entity_type, entity_id, user_id, field_changes JSONB diff, summary), automatic diff generation on entity updates, history API endpoint
+- **PSY-74: Revision history frontend** — "View History" link on entity detail pages, chronological edit list with field-level diffs, admin one-click rollback
+
+**Practical sprint sequence (single-person team):**
+```
+Sprint 1: PSY-32 (AI extraction) + ~~PSY-63 (contributor profile backend)~~ DONE
+Sprint 2: PSY-34 + PSY-36 (provenance + venue config) + PSY-64 (contributor profile frontend)
+Sprint 3: PSY-65 + PSY-66 (collections model + service)
+Sprint 4: PSY-67 + PSY-68 (collections admin + frontend)
+Sprint 5: PSY-70 + PSY-71 (requests model + service) + PSY-73 (revision history backend)
+Sprint 6: PSY-72 (requests frontend) + PSY-74 (revision history frontend)
+```
+
+**Phase 2a exit criteria:**
+- Public contributor profiles live at `/users/:username` with identity header, contribution summary, visual recent activity, collections showcase, and customizable profile sections
+- Percentile rankings computed and displayed (at least 3 dimensions: shows, edits, collections)
+- Privacy controls live — users can control per-field visibility of contribution history, saved shows, following list
+- User tier model in place (new_user / contributor achievable; higher tiers display but require Phase 3 auto-promotion)
+- "Added by [username]" attribution on all user-contributed entities
+- "Your Impact" section on private profile with downstream metrics
+- Contribution heatmap on profile
+- Collections CRUD with visual grid display, collaboration, subscriptions, contributor attribution
+- At least 10 seed collections created across diverse organizing principles
+- Request system with voting, fulfillment tracking, and auto-generated requests
+- At least 20 auto-generated requests from data quality queries
+- Revision history on all entity types with admin rollback
+- "View History" link on all entity detail pages
 
 ---
 
-## Q3 2026: Knowledge Graph Expansion (Phase 2)
+## NEXT: Knowledge Graph Connective Tissue (Phase 2b, May–July 2026)
 
-**Theme:** Complete the knowledge graph with tags, relationships, scene pages, and the features that make the graph navigable and alive. This is where passive browsing becomes active exploration.
+**Theme:** Build the connections that make the graph navigable: tags, relationships, and scene pages. These are correctly placed — but now they build on contributor identity infrastructure. Every tag applied shows who applied it, every similar artist vote is attributed, every scene has its contributors visible.
+
+**Linear project:** "Phase 2: Knowledge Graph Expansion" (existing PSY-45 through PSY-62)
 
 ### Tags & Voting
-- [ ] Genre/tag system (hierarchical taxonomy + freeform tags)
-- [ ] Entity <--> Tag relationships (artists, venues, labels, releases)
-- [ ] **Tag voting** — users upvote/downvote tags on each entity (What.cd core feature)
-- [ ] Genre/tag browsing and filtering UI
+- [ ] **Tag model, migration, GORM structs** (PSY-49) — `tags`, `entity_tags`, `tag_votes`, `tag_aliases` tables. Hierarchical taxonomy with parent-child. Official tags immune to pruning.
+- [ ] **Tag service, handlers, API routes** (PSY-50) — CRUD, voting with Wilson score ranking, alias resolution, auto-pruning (CleanupService every 15 min). Tag applications show contributor attribution.
+- [ ] **Tag frontend** (PSY-51) — `/tags` index, `/tags/:slug` detail, tag pills with voting on all entity pages, "add tag" autocomplete, tag filtering on list pages. "[View tagging rules]" link visible on every tag input.
+- [ ] **Tag administration UI** (PSY-46) — admin tag CRUD, alias management, bulk merge/rename, pruning config, moderation queue.
 
 ### Artist Relationships
-- [ ] Artist <--> Artist relationships (similar, side projects, members of)
-- [ ] **Similar artist voting** — community votes on similarity (up/down), scores determine ranking
-- [ ] **Similar artist visualization** — interactive relationship map or cloud (iconic What.cd feature)
-- [ ] "Toured with" / "shared bills with" auto-derived from show data
+- [ ] **Artist relationship model** (PSY-52) — `artist_relationships` + `artist_relationship_votes` tables. Types: similar, side_project, member_of. Auto-derived "shared bills" flag.
+- [ ] **Similar artist voting service** (PSY-53) — vote on similarity (up/down), Wilson score ranking, auto-derived "shared bills" job (daily, from `show_artists` co-occurrences). The iconic What.cd feature — and PH adds empirical "shared bills" data from live shows that What.cd never had.
+- [ ] **Similar artist visualization** — interactive relationship map. Font size/node size proportional to similarity. Edge thickness proportional to score. Cross-connections between similar artists. *(design doc: `docs/strategy/similar-artists.md`)*
 
-### Scene Pages & Venue Intelligence
-- [ ] City landing page (`/scenes/:city`) aggregating local venues, artists, labels, tags, shows
-- [ ] **Scene health metrics** — shows/month, genre diversity index, new artist appearances, venue activity trends
-- [ ] Phoenix as first fully-populated scene
-- [ ] Scene page SEO and social sharing
-- [ ] **Venue personality profiles** — auto-derived genre profiles from booking patterns, "venues like this one" based on booking overlap
+### Scene Pages (Tier 1) *(design doc: `docs/strategy/scene-pages.md`)*
+- [ ] **Scene page backend** (PSY-59) — `SceneService` with computed city aggregations. Virtual scenes, no new table. Data thresholds: 3+ venues AND 5+ upcoming shows.
+- [ ] **Scene page frontend** (PSY-60) — `/scenes` list, `/scenes/:slug` detail with Scene Pulse (shows/month sparkline, new artists, active venues, trend arrows), upcoming shows, top venues, active artists, festivals. Scene pages link to Scene Guide collections.
+
+### Admin Data Quality & Entity Management
+- [ ] **"Needs Work" data quality dashboard** (PSY-45) — query-driven lists of incomplete entities ranked by impact. Each item one-click to fix. Feeds auto-generated requests into the request system (Phase 2a). Completion percentage tracked over time.
+- [ ] **Artist merge/split tool** (PSY-47) — merge duplicates (reassign relationships, create alias redirect, audit log), split misidentified artists. `artist_aliases` table. Critical before geographic expansion.
 
 ### Show & Festival Data Enrichment
-- [ ] **Bill position surfacing & accuracy** — `position` and `set_type` fields already exist on `show_artists` (migration 000001) and the discovery service already assigns headliner/opener. Remaining work: expose `set_type` in API responses (beyond `is_headliner` bool), surface in frontend UI, admin correction UI, and improve data quality via AI billing enrichment (see Discovery section)
-- [ ] **Festival intelligence** — festival-to-festival lineup overlap analysis, "artists you follow at this festival" personalized view, breakout artist tracking (undercard → headliner arc within and across festivals)
-- [ ] **Show-to-recording links** — connect live recordings (Bandcamp, YouTube) to the show entity where they were captured
+- [ ] **Bill position surfacing** (PSY-54) — expose `set_type` and `position` in API responses, render billing roles on show detail/cards, admin reordering UI. Schema exists since migration 000001.
+- [ ] **Decade/year entity rankings** — temporal rankings from community votes, scoped by decade and year (What.cd's "No. 96 for the 1970s, No. 6 for 1976" pattern). Wilson score per time scope, cached with TTL.
+- [ ] **Festival intelligence** — lineup overlap, "artists you follow at this festival", breakout tracking. *(design doc: `docs/strategy/festival-intelligence.md`)*
+- [ ] **Show-to-recording links** — connect live recordings to show entities
 
-### Engagement & Discovery
-- [ ] **Notification filters** — "notify me of [genre] shows at [venue]" or "notify me when [label] artists play in Phoenix" (power user feature)
-- [ ] **Top charts** — trending shows, most-followed artists, popular tags, top contributors
-- [ ] "Going" / "Interested" buttons on shows and festivals (built on `user_bookmarks.action` — schema from Phase 1.5)
-- [ ] Attendance counts on show cards and festival pages
-- [ ] User follow system for artists, venues, labels (built on `user_bookmarks.action = 'follow'`)
-- [ ] Artist claim flow (Spotify OAuth)
+**Build order:**
+1. **Independent foundations (can parallel):** PSY-49 (tag model), PSY-52 (artist relationship model), PSY-47 (artist merge/split), PSY-54 (bill position), PSY-59 (scene backend)
+2. **Depends on models:** PSY-50 (tag service, needs PSY-49), PSY-53 (similar artist service, needs PSY-52)
+3. **Depends on services:** PSY-51 (tag frontend, needs PSY-50), PSY-46 (tag admin, needs PSY-50), PSY-60 (scene frontend, needs PSY-59)
+4. **Integration:** PSY-45 "Needs Work" dashboard (integrates with request system from Phase 2a), collection-tag aggregation (after PSY-51)
 
-### Data Enrichment & Radio
-- [ ] Discogs integration (catalog data, genre taxonomy)
-- [ ] Broader Phoenix data seeding (labels, genres, releases beyond initial slice)
-- [ ] **Radio Station & Radio Show entities** — model, migrations, CRUD API, pages (`/radio`, `/radio/:slug`). Stations have live stream embeds, donation page links, and embeddable pledge widgets. Radio Shows link to stations and track playlists.
-- [ ] **Curated radio playlist parsing** — WFMU, NTS, KEXP playlists as discovery signals for releases, labels, and artist-artist affinity (see vision doc for full strategy)
+**Design docs completed:**
+- Scene pages → `docs/strategy/scene-pages.md`
+- Similar artist visualization → `docs/strategy/similar-artists.md`
+- Festival intelligence → `docs/strategy/festival-intelligence.md`
 
-### Discovery Pipeline
-- [ ] **Hybrid scraper + AI pipeline** — traditional scrapers for structured data (dates, prices, links), AI for semantic interpretation (billing order, artist disambiguation, festival detection)
-- [ ] Venue-level `artist_order_hint` config (`headliner_first` vs `chronological`) for scraper accuracy
-- [ ] Admin UI: reorder artists and change set types on show edit page
-
-### iOS
-- [ ] Post-launch bug fixes
-- [ ] Push notifications
-
-**Exit criteria:** Genre tags on 80% of artists with community voting active. Scene page live with health metrics. Similar artist graph navigable with voting. Venue personality profiles derived. Notification filters available. Going/Interested shipped. Festival intelligence queries live (lineup overlap, breakout tracking).
+**Phase 2b exit criteria:** Genre tags on 80%+ of artists with community voting active. Similar artist graph navigable with voting and "shared bills." Scene page live for Phoenix. "Needs Work" dashboard generating auto-requests. Bill position surfaced in UI. Artist merge/split operational. Tag aliases managing variant spellings.
 
 ---
 
-## Q4 2026: Community Engine (Phase 3)
+## THEN: Engagement & Social (Phase 2c, July–August 2026)
 
-**Theme:** Let the community build the knowledge graph — the engine that made What.cd irreplaceable. This phase adds the tools that channel community energy into catalog completeness.
+**Theme:** The knowledge graph has depth (entities, tags, relationships, scenes, collections) and the community has identity (profiles, attribution, contributions). Now add the social and engagement features that make people come back daily.
 
-### Contribution Infrastructure
+### Engagement
+- [ ] **Going/Interested buttons** (PSY-55) — toggle on shows/festivals using existing `user_bookmarks` (no migration). Attendance counts on cards and detail pages. "My Shows" view.
+- [ ] **Follow system** (PSY-56) — follow artists, venues, labels, collections, users via `user_bookmarks` with `action = 'follow'`. Follower counts on entity pages. "Following" section on profile.
+- [ ] **Top charts** (PSY-57) — trending shows (most going/interested), popular artists (most followed), hot tags (most applied this week), active venues. `/charts` page with period selector.
+
+### Notifications *(design doc: `docs/strategy/notification-filters.md`)*
+- [ ] **Notification filter model and matching engine** — `notification_filters` with array criteria. Matching on show approval. Email delivery via Resend. "Notify me" buttons on entity pages.
+- [ ] **Notification filter frontend** — filter management, create/edit with multi-select autocomplete, notification history.
+
+### Venue Intelligence (needs tags from Phase 2b)
+- [ ] **Venue genre profiles** (PSY-61) — per-venue tag distribution from booking patterns (min 10+ shows), scene-level genre chart.
+- [ ] **Venue similarity** (PSY-62) — Jaccard index on shared artist sets, 3+ shared artists threshold.
+
+### Analytics & Platform Health
+- [ ] **Platform analytics dashboard** (PSY-48) — time-series growth charts, user engagement trends, data quality trends. Now includes community health: contributions per week, active contributors, collection growth, request fulfillment rate.
+
+### Other
+- [ ] Artist claim flow (Spotify OAuth)
+- [ ] Featured content — "Featured Show" / "Featured Collection" / "Community Pick" badges. What.cd's staff picks pushed people outside their comfort zone — PH's equivalent: prominent featured placement that exposes users to genres/venues they wouldn't seek out.
+
+**Phase 2c exit criteria:** Going/Interested and Follow systems live. Top charts page active. Notification filters matching on show approval. Venue genre profiles derived from booking patterns. Platform analytics tracking community health.
+
+---
+
+## BACKGROUND: Pipeline Maturation (Phase 1.6b, ongoing)
+
+**Theme:** The pipeline issues deferred from Phase 1.6a get addressed incrementally, as background work between community feature sprints. Not a phase gate — a maintenance track.
+
+- [ ] **AI billing enrichment** (PSY-30) — extend extraction for headliner/support/opener
+- [ ] **Automated scheduling** (PSY-31) — scheduled runs with change detection, chromedp worker pool, strategy adaptation (`venue_extraction_runs` tracking, anomaly detection)
+- [ ] **Consolidate discovery UI** (PSY-33) — retire standalone discovery app, add "Data Pipeline" admin tab
+- [ ] **Post-import enrichment pipeline** (PSY-35) — automatic artist matching, MusicBrainz lookup, API cross-referencing
+- [ ] iCal/RSS feed detection — auto-detect structured feeds during venue onboarding
+
+**Exit criteria (ongoing):** Pipeline handles 20+ venues reliably. Automated scheduling running daily. At least 3 data source tiers working.
+
+---
+
+## OPPORTUNISTIC: Admin Dashboard Polish (Phase 1.7)
+
+**Theme:** Admin-only UX improvements. Picked up as quick wins between feature sprints, not a blocking phase.
+
+**Linear project:** "Phase 1.7: Admin Dashboard UX" (PSY-37 through PSY-44)
+
+- [ ] PSY-37: Dashboard layout polish (fix clipping, dark mode contrast)
+- [ ] PSY-38: Clickable stat cards
+- [ ] PSY-39: Smart empty states
+- [ ] PSY-40: Dashboard quick actions
+- [ ] PSY-41: Recent activity feed
+- [ ] PSY-42: Stat card trend indicators
+- [ ] PSY-43: Admin tab grouping
+- [ ] PSY-44: Admin Cmd+K commands
+
+---
+
+## Q4 2026: Community at Scale (Phase 3)
+
+**Theme:** With contributor identity, collections, requests, revision history, tags, and engagement all live, Phase 3 focuses on what genuinely needs community scale: opening edit flows to non-admin users, building moderation infrastructure, and trust tier progression.
+
+### Open Contribution Flows
 - [ ] Extend pending-edit approval workflow to all entities
 - [ ] User contribution flows (add labels, releases, tag entities, write descriptions)
-- [ ] **Revision history** — full edit history on all community-editable content (artist bios, release descriptions, label descriptions) with diff view and revert capability
+- [ ] "Needs Attention" public-facing dashboard — extend admin PSY-45 to public contributor view with contribution prompts
 
-### Community-Driven Completeness
-- [ ] **"Needs Attention" dashboards** — surfaces content needing improvement: artists without bios, releases missing external links, labels without descriptions, venues without complete info. Gamifies contribution by showing exactly what needs work. (Inspired by Gazelle's "Better" section, which surfaced releases needing transcoding, tags, artwork, etc.)
-- [ ] **Request system with voting** — users request missing artists, labels, releases, corrections. Community votes to prioritize. Fulfilling requests earns reputation. (What.cd's bounty system drove obsessive completeness)
+### Moderation Infrastructure (Gazelle-inspired)
+- [ ] **Unified moderation queue** — generalize all pending items into one filterable queue with claim/resolve workflow (Gazelle's `reportsv2` pattern)
+- [ ] **Generalized content flagging** — structured reason categories per entity type
+- [ ] **Auto-promotion scheduler** — activate the tier model from Phase 2a. Scheduled job (daily) evaluates all users against tier criteria: Contributor (5+ approved edits, 2+ weeks, verified email), Trusted Contributor (25+ approved, 95%+ approval rate, 2+ months), Local Ambassador (50+ approved, city-active, 6+ months). Auto-demotion if quality drops. PM notifications explaining changes. *(Tier model and display ships in Phase 2a; this activates the automation.)*
+- [ ] **Contributor leaderboard** — top contributors by week/month/all-time with contribution types and accuracy rate. Uses percentile ranking infrastructure from Phase 2a.
+- [ ] **Global site notices** — admin-set banners for community announcements
+- [ ] **Staff/moderation inbox** — centralized message system for appeals, questions, moderator coordination
 
 ### Community-Powered Scene Knowledge
-- [ ] **Show field notes** — brief attendee observations capturing the live experience (not star ratings). "The opener stole the show", "They debuted two new songs." Qualitative data no other platform captures.
-- [ ] **Setlist integration** — community-contributed or setlist.fm-sourced track-level show data. Bridge recorded catalog to live performance.
-- [ ] **Promoter / Booker entity** — community-contributed knowledge about who books what. The hidden connectors that shape scenes.
-- [ ] **Musician entity** — individuals distinct from bands, with membership history and date ranges. Enables band member crossover mapping — the "scene family tree."
+- [ ] **Show field notes** — brief attendee observations (not star ratings). "The opener stole the show." Qualitative data no other platform captures.
+- [ ] **Setlist integration** — community-contributed or setlist.fm-sourced track-level show data
+- [ ] **Promoter / Booker entity** — community knowledge about who books what
+- [ ] **Musician entity** — individuals distinct from bands, with membership history. Scene family tree.
 
-### Curation & Trust
-- [ ] **Collections with categories** — Genre Introduction ("Intro to free jazz"), Label Roster, Staff Picks, Scene Guide, Charts, Personal. Categorization makes collections discoverable and useful, not just freeform lists.
-- [ ] **Reputation system** — contribution quality --> trust level --> auto-approve privileges
-- [ ] Local ambassador program
-- [ ] Community moderation tools
+### Depth & Preservation
+- [ ] **Release editions** — when community contribution flows are mature, allow edition-level detail: year, label, catalog number, country, format, mastering notes. What.cd's Oxygène page had 14+ editions. Start simple, let community demand drive it.
+- [ ] **Knowledge graph export** — data exports in standard formats (JSON-LD, CSV). CC0 for factual data. An open API is insurance that the community's work survives any platform failure.
 
-**Exit criteria:** 100+ community contributions. 10+ active contributors. 5+ categorized collections. 20+ fulfilled requests. "Needs Attention" dashboard driving measurable data quality improvement. Show field notes on 20%+ of attended shows.
+**Phase 3 exit criteria:** 100+ community contributions. 10+ active contributors with trust tier progression. Unified moderation queue processing all types. At least 3 auto-promoted Trusted Contributors. Contributor leaderboard driving engagement. Show field notes on 20%+ of attended shows. Data export available.
 
 ---
 
@@ -196,54 +324,100 @@ Lay the schema foundation for the full knowledge graph, then prove the minimum v
 
 **Theme:** Prove the model works beyond Phoenix.
 
+### Multi-City Infrastructure
 - [ ] Second city launch (Tucson — low-risk test)
 - [ ] Third city launch (non-Arizona — validate community-bootstrapped expansion)
 - [ ] Cross-city navigation (touring artists connecting scenes, label presence, festival circuit patterns)
 - [ ] Scene comparison and discovery
-- [ ] Cross-city "shared bills" relationships from touring data
-- [ ] Festival data as expansion bootstrapping — festivals in new cities provide initial artist graph connections before venue scrapers exist
-- [ ] **AI scraper agents** — point an AI agent at any venue's calendar URL, it navigates and extracts all events using vision. No venue-specific scraper code needed. New city onboarding without writing custom providers.
+- [ ] Festival data as expansion bootstrapping
+- [ ] **Automated venue discovery** — Google Maps API + OpenStreetMap
+- [ ] **AI extraction at scale** — adding a city = discovering venue URLs + extraction schedule. Zero per-venue code.
 
-**Key validation:** Can a city launch without custom scrapers? With festival data + AI scraper agents + community contributions + external APIs, the answer should be yes. Festivals provide the initial graph; community and AI fill in venue-level detail.
+### City-Scoped Admin Tools
+- [ ] Per-city admin dashboard
+- [ ] Pipeline health monitor
+- [ ] City onboarding checklist
+
+**Key validation:** Can a city launch without custom code? With AI extraction + festival data + venue discovery + community contributions, yes.
+
+### Supporter / Monetization (Gazelle Donor Model)
+
+Cosmetic rewards for supporters — **never functional advantages**. Gazelle proved this builds trust: the richest user and the poorest had the same influence on the knowledge graph. *(Analysis: `docs/learnings/gazelle-user-profiles.md`)*
+
+- [ ] **Supporter tier model** — `supporter_rewards` table with tiered cosmetic unlocks
+- [ ] **Tier 1:** "Supporter" badge on profile and contributions, 1 additional custom profile section
+- [ ] **Tier 2:** Custom avatar border/frame, 2nd additional profile section
+- [ ] **Tier 3:** Custom title under username, 3rd additional profile section
+- [ ] **Tier 4+:** Custom badge icon, additional cosmetics TBD
+- [ ] **Payment integration** — Stripe subscriptions, $10-40/month range (What.cd user signal: "$20-40/month, probably")
+
+**Prerequisite:** Community must exist first. This is a Phase 4+ revenue stream, not a launch feature. People pay for something they feel ownership of.
 
 ---
 
 ## 2027+: Discovery Engine (Phase 5)
 
-**Theme:** The full What.cd discovery experience, anchored in live music. Unlock the temporal intelligence that only our show data makes possible.
+**Theme:** The full What.cd discovery experience, anchored in live music. Unlock temporal intelligence only our show data makes possible.
 
 - [ ] "Explore" mode (browse genres across cities, discover scenes)
-- [ ] Travel mode ("I'm visiting Cincinnati next week" --> personalized scene guide)
-- [ ] **Voter picks / collaborative filtering** — "People who saved this show also saved...", "People who follow this artist also follow..."
-- [ ] Personalized recommendations (listening history + saves + follows + attendance)
-- [ ] Similar artist discovery (shared labels, shared bills, genre overlap, touring patterns)
+- [ ] Travel mode ("I'm visiting Cincinnati next week" → personalized scene guide)
+- [ ] **Voter picks / collaborative filtering** — "People who saved this show also saved..."
+- [ ] Personalized recommendations (saves + follows + attendance)
 - [ ] "Fans of [artist] also go to..." (from attendance data)
-- [ ] Related/similar scene suggestions
-- [ ] **Temporal scene graph** — time-slider on scene pages to browse how a city's music ecosystem evolves over months and years. Watch genres rise and fall, venues open and close, artists emerge. The knowledge graph as a living historical record.
-- [ ] **Artist trajectory visualization** — career arc from house shows to headlining, rendered as a visual timeline of venue sizes, show roles, and festival billing tiers over time
-- [ ] **Bill composition intelligence** — "Who opened for [headliner] before they broke?" / "Openers who later became headliners" / cross-genre billing pattern analysis
-- [ ] **Festival circuit analysis** — festival-to-festival artist overlap patterns, genre clustering by festival, "festivals like this one" recommendations
-- [ ] **Scene family tree visualization** — interactive map of band member crossover across an entire city's music scene
+- [ ] **Temporal scene graph** — time-slider on scene pages
+- [ ] **Artist trajectory visualization** — career arc from house shows to headlining
+- [ ] **Bill composition intelligence** — "Who opened for [headliner] before they broke?"
+- [ ] **Festival circuit analysis** — festival-to-festival overlap patterns
+- [ ] **Scene family tree visualization** — band member crossover across a city
+- [ ] **Taste profile integration** — connect Spotify/Last.fm to user profiles, show listening data (privacy-controlled), enable taste compatibility between users, feed into collaborative filtering. Gazelle's Last.fm integration created organic social connections between users with similar taste.
 - [ ] API / MCP server (knowledge graph as platform)
 - [ ] Weekly personalized email digest
 - [ ] Venue analytics dashboard (free + paid tiers)
+
+### Future Discovery Pipeline
+- [ ] Computer Use for multi-page calendars (Anthropic Computer Use API as tier 4)
+- [ ] Social media extraction (venue Instagram/Facebook → events)
+- [ ] Email newsletter parsing (forwarded venue digests → events)
+- [ ] Web search synthesis ("upcoming shows at [venue]" → structured events)
+- [ ] Bandsintown API integration, Setlist.fm integration
+
+### Future Data Enrichment
+- [ ] Radio Station & Radio Show entities *(design doc: `docs/strategy/radio-entities.md`)*
+- [ ] Curated radio playlist parsing (WFMU, NTS, KEXP as discovery signals)
+- [ ] Discogs integration
+- [ ] Broader Phoenix data seeding
 
 ---
 
 ## Open Decisions
 
-- **Monetization:** Venue subscriptions vs. premium features vs. donation-supported (What.cd model)
+- **Monetization:** Leaning toward Gazelle's cosmetic donor model — supporter tiers with cosmetic-only rewards (badges, profile customization, custom titles), never functional advantages. User signal: a power user donated ~$100/yr and said he'd pay "$20-40/month." Gazelle proved cosmetic rewards sustain platforms when users feel ownership. Prerequisite is community, not features. Supporter tier scaffolding designed (see Phase 4), implementation deferred until community exists.
 - **Mobile strategy:** Continue native iOS or evaluate PWA
 - **API openness:** Fully open (MusicBrainz model) vs. tiered access
-- **Geographic scope:** US-first or global-ready data model from the start
+- **Geographic scope:** US-first or global-ready data model. What.cd had "Bach cello suites, Chinese indie rock, Nigerian hip-hop, Thai psych-funk." PH's graph will span geographies through touring artists, festivals, and labels. Architect for global scope even while launching city-by-city.
 - **Graph DB:** Stay PostgreSQL or evaluate Neo4j when traversal queries become core
 - **Release depth:** Full What.cd-level detail (every pressing/format) or curated highlights? Start simple, let community depth emerge.
+- **Data survivability:** Plan for exports and data portability from the start — the community's knowledge must survive any platform failure.
 
 ## Risks
 
 - **Single-person team:** Bus factor of 1 across all tracks
 - **Cold start per city:** Each new city needs initial data + at least one community champion
 - **Community quality:** Maintaining data accuracy without heavy moderation burden
-- **Scraper fragility:** Venue sites change without warning
-- **Incentive design:** Community-driven platforms need sustainable motivation structures (What.cd's invite system and ratio requirements were effective but controversial — we need alternatives that motivate without gatekeeping)
+- **Scraper fragility:** Venue sites change without warning (mitigated by AI extraction — reads any page like a human)
+- **Incentive design:** Community-driven platforms need sustainable motivation structures. What.cd's entrance exam and ratio requirements were effective but controversial — we use open registration with reputation-based quality assurance instead.
 - **External link rot:** Bandcamp/Spotify/YouTube links can go stale; need periodic verification or community reporting
+- **Community cold start:** Contributor identity and collections ship but nobody contributes. Mitigated by: (1) admin as first visible contributor, (2) seed collections as examples, (3) auto-generated requests as specific contribution opportunities, (4) What.cd diaspora (RED, Orpheus, RYM users) actively seeking this
+
+## Design Docs
+
+All Phase 2 design docs complete:
+- Scene pages & venue intelligence → `docs/strategy/scene-pages.md`
+- Notification filters → `docs/strategy/notification-filters.md`
+- Similar artist visualization → `docs/strategy/similar-artists.md`
+- Radio Station & Radio Show entities → `docs/strategy/radio-entities.md`
+- Festival intelligence → `docs/strategy/festival-intelligence.md`
+
+Learnings & reference:
+- Gazelle/What.cd implementation patterns → `docs/learnings/gazelle-patterns.md`
+- What.cd user psychology & product-market fit → `docs/learnings/whatcd-user-insights.md`

--- a/docs/strategy/web.md
+++ b/docs/strategy/web.md
@@ -4,21 +4,24 @@
 
 ## Current Status
 
-v1 feature-complete, pre-launch hardening. 69 E2E tests, 68.5% backend coverage, 836+ frontend unit tests. PostHog + Sentry live. ICS calendar feed and show reminders shipped.
+Phase 1.5 complete — knowledge graph vertical slice shipped. 69 E2E tests, 68.5% backend coverage, 897+ frontend unit tests. PostHog + Sentry live.
 
-Core entities: Artists, Venues, Shows with search, multi-city filters, saved shows, show reminders (email, 24h before), admin approval workflows, audit logging.
+Core entities: Artists, Venues, Shows, **Releases** (with artist roles + external links), **Labels** (with roster + catalog), **Festivals** (with tiered lineups, multi-venue). Enriched artist pages with discography, label affiliations, festival appearances. Generic bookmarks system. **Contributor profiles** (PSY-63): public profiles with contribution stats/history, 3-level granular privacy, user tiers, custom profile sections, 58 tests. Data seeding CLIs (MusicBrainz, Bandcamp, festival entry). Frontend redesign complete (sidebar nav, Cmd+K, entity detail template, card redesigns, visual polish).
 
-## Next Priorities
+## Next Priorities (Restructured March 2026)
 
-1. ~~**Show reminders** (email, 24h before)~~ -- done
-2. **Email preferences UI** -- in progress, close it out
-3. **Frontend redesign: sidebar nav + wider layout** -- structural foundation for knowledge graph UI. See `docs/strategy/ui-redesign.md`
-4. **Frontend redesign: Cmd+K search + entity detail template** -- can parallel with entity backend work
-5. **Data layer foundation** -- generic `user_bookmarks` table (replaces per-entity saved/favorite tables), TIMESTAMPTZ standardization
-6. **Festival entity** -- distinct from Show, with series_slug, billing tiers, multi-venue support
-7. **Knowledge graph vertical slice** -- Releases (with artist roles) + Labels + enriched artist pages + festival appearances (Phase 1.5)
-8. **Show/artist card redesign + visual polish** -- richer cards with bill hierarchy, tags, discovery cues
-9. **Knowledge graph expansion** -- Tags with voting, similar artists with voting/visualization, scene pages, notification filters (Phase 2)
+> Community curation is the moat, not the data pipeline. See `docs/learnings/whatcd-user-insights.md` for the What.cd user analysis that drove this restructuring.
+
+1. ~~**Show reminders** (email, 24h before)~~ — done
+2. **Email preferences UI** — in progress, close it out
+3. ~~**Frontend redesign**~~ — done
+4. ~~**Data layer foundation**~~ — done
+5. ~~**Knowledge graph vertical slice**~~ — done
+6. **Phase 1.6a + Phase 2a (parallel, NOW):**
+   - Pipeline foundation (PSY-32 AI extraction, PSY-34 provenance, PSY-36 venue config)
+   - Community foundations: contributor identity (PSY-63/64), collections (PSY-65–68), requests (PSY-70–72), revision history (PSY-73/74)
+7. **Phase 2b: Knowledge graph connective tissue** — tags (PSY-49–51), relationships (PSY-52/53), scenes (PSY-59/60), data quality (PSY-45/47), bill position (PSY-54)
+8. **Phase 2c: Engagement & social** — going/interested (PSY-55), follow (PSY-56), charts (PSY-57), notifications, venue profiles (PSY-61/62)
 
 ## Roadmap
 
@@ -28,63 +31,64 @@ Core entities: Artists, Venues, Shows with search, multi-city filters, saved sho
 - [x] Artists/venues pages with search + multi-city filters
 - [x] Show reminders (email, 24h before, with one-click unsubscribe)
 - [ ] Email preferences UI (in progress)
-- [ ] **Frontend redesign: sidebar nav + wider layout** -- collapsible sidebar replacing top nav bar, content area widened from `max-w-4xl` to `max-w-6xl`/`max-w-7xl`, 2-column grid for detail pages. Do BEFORE entity pages so new entities use the new layout from the start. See `docs/strategy/ui-redesign.md` Task 1.
-- [ ] **Frontend redesign: Cmd+K command palette** -- global search dialog (`cmdk` library), route navigation, cross-entity search. See `docs/strategy/ui-redesign.md` Task 2.
-- [ ] **Frontend redesign: entity detail template** -- reusable `EntityDetailLayout` with header zone, tabs, sidebar panel. Refactor Venue/Artist detail first, new entity pages (Festival, Release, Label) use it from the start. See `docs/strategy/ui-redesign.md` Task 3.
-- [ ] **Data layer foundation** — generic `user_bookmarks` table replacing `user_saved_shows` + `user_favorite_venues`. Supports all entity types and action types (save, follow, bookmark, going, interested). TIMESTAMPTZ standardization. Refactor services/handlers/hooks.
-- [ ] **Festival entity** — model, migrations, CRUD API, admin UI. `series_slug` + `edition_year` for recurring festivals. `festival_artists` with `billing_tier`/`day_date`/`stage`/`set_time`/`venue_id`. `festival_venues` for multi-venue takeover festivals. `location_name` for non-venue locations.
-- [ ] **Festival pages** — `/festivals` listing, `/festivals/:series_slug` series overview, `/festivals/:series_slug/:year` detail with tiered lineup display, day tabs, "artists you follow" highlights
-- [ ] **Releases entity** — model, migrations, CRUD API, admin UI, `/releases/:slug` pages with "Listen / Buy" external links (Bandcamp, Spotify, Discogs, YouTube, Apple Music). Artist-release roles: main, featured, producer, remixer, composer, DJ.
-- [ ] **Labels entity** — model, migrations, CRUD API, admin UI, `/labels` and `/labels/:slug` pages
-- [ ] **Artist pages enriched** — discography grouped by role (albums, guest appearances, production credits), label affiliations, "also on this label", festival appearances with billing tier
-- [ ] **Data seeding** -- admin festival entry (major US festivals), MusicBrainz + Bandcamp enrichment for Phoenix artists
-- [ ] **Show card redesign** -- bill hierarchy (headliner bold, support with "w/"), date badge, inline save, tag pills (placeholder-ready). See `docs/strategy/ui-redesign.md` Task 4.
-- [ ] **Artist card redesign** -- tag pills, label affiliation, consistent card borders. See `docs/strategy/ui-redesign.md` Task 5.
-- [ ] **Visual language polish** -- bolder typography, card border treatments, density toggles on list pages. See `docs/strategy/ui-redesign.md` Task 6.
+- [x] **Frontend redesign: sidebar nav + wider layout** (PSY-16)
+- [x] **Frontend redesign: Cmd+K command palette** (PSY-17)
+- [x] **Frontend redesign: entity detail template** (PSY-18)
+- [x] **Data layer foundation** — generic `user_bookmarks` table (PSY-22), TIMESTAMPTZ standardization (PSY-23)
+- [x] **Festival entity** — model (PSY-24), service/handlers 82 tests (PSY-25), admin UI (PSY-26), frontend pages (PSY-27), data entry CLI (PSY-28)
+- [x] **Festival pages** — `/festivals` listing, `/festivals/:slug` detail with tiered lineup display and day grouping
+- [x] **Releases entity** — model (PSY-5), service 57 tests (PSY-6), admin UI (PSY-7), frontend pages (PSY-8)
+- [x] **Labels entity** — model (PSY-9), service (PSY-10), admin UI (PSY-11), frontend pages (PSY-12)
+- [x] **Artist pages enriched** — discography, label affiliations, "also on this label", festival appearances (PSY-13)
+- [x] **Data seeding** — MusicBrainz CLI (PSY-14), Bandcamp CLI (PSY-15), festival entry CLI (PSY-28)
+- [x] **Show card redesign** (PSY-19)
+- [x] **Artist card redesign** (PSY-20)
+- [x] **Visual language polish** (PSY-21)
 
-### Next: Knowledge Graph Expansion (Phase 2, Q3 2026)
+### Now: Pipeline Foundation + Community Foundations (Phase 1.6a + 2a, parallel)
 
-- [ ] **Genre/tag system** — hierarchical taxonomy + freeform tags, **tag voting** (up/down per entity), tag browsing and filtering UI
-- [ ] **Artist <--> Artist relationships** — similar, side projects, members of
-- [ ] **Similar artist voting** — community votes on similarity, scores determine ranking
-- [ ] **Similar artist visualization** — interactive relationship map or cloud
-- [ ] **"Toured with" / "shared bills with"** — auto-derived from show data
-- [ ] **Scene pages** — `/scenes/:city` landing page with scene health metrics (shows/month, genre diversity, new artists, venue activity)
-- [ ] **Venue personality profiles** — auto-derived genre profiles from booking patterns, "venues like this one"
-- [ ] **Bill position surfacing & accuracy** — schema exists (`position` + `set_type` on `show_artists`, discovery service populates them). Remaining: expose `set_type` in API (beyond `is_headliner` bool), frontend display, admin correction UI
-- [ ] **Festival intelligence** — festival-to-festival lineup overlap, "artists you follow at this festival", breakout artist tracking
-- [ ] **Show-to-recording links** — connect live recordings to show entities
-- [ ] **Notification filters** — "notify me of [genre] shows at [venue]"
-- [ ] **Top charts** — trending shows, most-followed artists, popular tags, top contributors
-- [ ] "Going" / "Interested" buttons on shows and festivals (built on `user_bookmarks.action`)
-- [ ] Attendance counts on show cards and festival pages
+**Pipeline (Phase 1.6a):**
+- [ ] **AI extraction pipeline** (PSY-32) — tiered rendering, change detection, 5+ venues
+- [ ] **Data provenance tracking** (PSY-34) — source, confidence, last_verified on core tables
+- [ ] **Venue source config** (PSY-36) — per-venue config persisted in DB
+
+**Community (Phase 2a):**
+- [x] **Contributor profile backend** (PSY-63) — 58 tests, 11 API endpoints, 3-level privacy, user tiers, custom sections
+- [ ] **Contributor profile frontend** (PSY-64) — public profile page, "Added by" attribution, "Your Impact" section
+- [ ] **Collections** (PSY-65–68) — the record store at scale. No prescribed categories. Visual grids. Collaboration by default. Subscriptions.
+- [ ] **Request system** (PSY-70–72) — requests with voting, fulfillment workflow, auto-generated from data quality queries
+- [ ] **Revision history** (PSY-73/74) — JSONB diffs on entity updates, "View History", admin rollback
+
+### Next: Knowledge Graph Connective Tissue (Phase 2b)
+
+- [ ] **Genre/tag system** (PSY-49–51, PSY-46) — hierarchical taxonomy, freeform tags, tag voting, alias resolution, auto-pruning
+- [ ] **Artist relationships** (PSY-52/53) — similar, side projects, members of. "Shared bills" auto-derived from show data.
+- [ ] **Similar artist visualization** — interactive relationship map *(design doc: `docs/strategy/similar-artists.md`)*
+- [ ] **Scene pages** (PSY-59/60) — `/scenes/:slug` with Scene Pulse metrics *(design doc: `docs/strategy/scene-pages.md`)*
+- [ ] **"Needs Work" dashboard** (PSY-45) — incomplete entities, feeds auto-requests
+- [ ] **Artist merge/split** (PSY-47) — critical before geographic expansion
+- [ ] **Bill position surfacing** (PSY-54)
+- [ ] **Festival intelligence** *(design doc: `docs/strategy/festival-intelligence.md`)*
+- [ ] **Decade/year entity rankings** — Wilson score per time scope
+
+### Then: Engagement & Social (Phase 2c)
+
+- [ ] **Going/Interested** (PSY-55) + **Follow system** (PSY-56) + **Top charts** (PSY-57)
+- [ ] **Notification filters** *(design doc: `docs/strategy/notification-filters.md`)*
+- [ ] **Venue genre profiles** (PSY-61) + **Venue similarity** (PSY-62)
+- [ ] **Platform analytics** (PSY-48) — includes community health metrics
+- [ ] **Featured content** — "Featured Show" / "Featured Collection" badges
 - [ ] Artist claim flow (Spotify OAuth)
-- [ ] User follow system for artists, venues, labels (built on `user_bookmarks.action = 'follow'`)
-- [ ] Discogs integration (catalog data, genre taxonomy)
-- [ ] **Radio Station & Radio Show entities** — `/radio`, `/radio/:slug` pages with live stream embeds, donation links, pledge widgets
-- [ ] **Curated radio playlist parsing** — WFMU, NTS, KEXP as discovery/enrichment signals ("as heard on" badges, artist↔radio show links)
 
-### Later: Community & Scale (Phases 3-5)
+### Later: Community at Scale + Discovery Engine (Phases 3-5)
 
-- [ ] Community contribution flows (add/edit all entities with pending review)
-- [ ] **Revision history** — edit history on all community-editable content with revert
-- [ ] **"Needs Attention" dashboards** — artists without bios, releases missing links, labels without descriptions (Gazelle "Better" section successor)
-- [ ] **Request system with voting** — community fills gaps in the catalog, votes to prioritize
-- [ ] **Collections with categories** — Genre Introduction, Label Roster, Staff Picks, Scene Guide, Charts, Personal
-- [ ] **Show field notes** — brief attendee observations capturing the live experience
-- [ ] **Setlist integration** — community-contributed or setlist.fm-sourced track-level show data
-- [ ] **Promoter / Booker entity** — who books what, the hidden connectors that shape scenes
-- [ ] **Musician entity** — individual people with band membership history, enabling scene family trees
-- [ ] Reputation system (contribution quality --> trust level --> auto-approve)
-- [ ] Multi-city scene browsing and comparison
-- [ ] Travel mode, personalized recommendations
-- [ ] **Voter picks / collaborative filtering** — "People who saved this also saved..."
-- [ ] Similar artist discovery (shared labels, shared bills, genre overlap, touring patterns)
-- [ ] **Temporal scene graph** — time-slider to browse how a city's scene evolves over time
-- [ ] **Artist trajectory visualization** — career arc from house shows to headlining, with festival billing tier progression
-- [ ] **Bill composition intelligence** — opener-to-headliner patterns, cross-genre billing analysis
-- [ ] **Festival circuit analysis** — festival-to-festival artist overlap, genre clustering, "festivals like this one"
-- [ ] **Scene family tree visualization** — interactive band member crossover map
+- [ ] Open edit flows, trust tiers, unified moderation queue, contributor leaderboard
+- [ ] Show field notes, setlist integration, Promoter/Musician entities
+- [ ] Release editions (community-driven depth), knowledge graph export
+- [ ] Radio Station & Radio Show entities *(design doc: `docs/strategy/radio-entities.md`)*
+- [ ] Multi-city expansion, travel mode, personalized recommendations
+- [ ] Temporal scene graph, artist trajectory, bill composition intelligence
+- [ ] Collaborative filtering, scene family tree visualization
 - [ ] API / MCP server
 
 ## Key Files
@@ -96,5 +100,5 @@ Core entities: Artists, Venues, Shows with search, multi-city filters, saved sho
 | Backend routes | `backend/internal/api/routes/routes.go` |
 | Service container | `backend/internal/services/container.go` |
 | Models | `backend/internal/models/` |
-| Migrations | `backend/db/migrations/` (latest: 000034) |
+| Migrations | `backend/db/migrations/` (latest: 000041) |
 | E2E tests | `frontend/e2e/`, `frontend/playwright.config.ts` |


### PR DESCRIPTION
## Summary

- **Contributor profile backend** with public profiles, contribution stats/history, 3-level granular privacy, user tier model, and custom profile sections
- **2 migrations** (000040: profile_visibility column, 000041: privacy_settings JSONB + user_tier + user_profile_sections table)
- **11 API endpoints**: 3 public with optional auth (`/users/{username}`, contributions, sections), 8 protected (own profile, privacy settings, section CRUD)
- **3-level privacy per field**: `visible` / `count_only` / `hidden` across 7 fields (contributions, saved_shows, attendance, following, collections, last_active, profile_sections). Master switch via profile_visibility (public/private). Owner always sees everything.
- **User tier model**: new_user → contributor → trusted_contributor → local_ambassador (auto-promotion deferred to Phase 3)
- **Custom profile sections**: up to 3 per user, markdown content (10k char limit), position ordering, visibility toggle
- **58 tests** (18 unit + 40 integration with testcontainers) covering privacy gating, section CRUD ownership, contribution stats across 4 source tables
- Docs updated (llm-context.md, ROADMAP.md, web.md) to reflect completion and Phase 2a roadmap restructuring

## Test plan

- [x] `go build ./...` passes
- [x] All 58 contributor profile tests pass (unit + integration with testcontainers postgres:18)
- [ ] Run migrations on dev DB and verify schema
- [ ] Verify public profile endpoint returns privacy-gated data for non-owner viewers
- [ ] Verify section CRUD enforces ownership and max 3 sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes PSY-63