### PR TITLE
Add venue source config and extraction runs tables (PSY-75)

### DIFF
--- a/backend/db/migrations/000042_venue_source_configs.down.sql
+++ b/backend/db/migrations/000042_venue_source_configs.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS venue_source_configs;

--- a/backend/db/migrations/000042_venue_source_configs.up.sql
+++ b/backend/db/migrations/000042_venue_source_configs.up.sql
@@ -1,0 +1,20 @@
+CREATE TABLE venue_source_configs (
+    id BIGSERIAL PRIMARY KEY,
+    venue_id BIGINT NOT NULL REFERENCES venues(id) ON DELETE CASCADE,
+    calendar_url TEXT,
+    preferred_source VARCHAR(20) NOT NULL DEFAULT 'ai',
+    render_method VARCHAR(20),
+    feed_url TEXT,
+    last_content_hash VARCHAR(64),
+    last_etag TEXT,
+    last_extracted_at TIMESTAMPTZ,
+    events_expected INT NOT NULL DEFAULT 0,
+    consecutive_failures INT NOT NULL DEFAULT 0,
+    strategy_locked BOOLEAN NOT NULL DEFAULT false,
+    auto_approve BOOLEAN NOT NULL DEFAULT true,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(venue_id)
+);
+
+CREATE INDEX idx_venue_source_configs_venue_id ON venue_source_configs(venue_id);

--- a/backend/db/migrations/000043_venue_extraction_runs.down.sql
+++ b/backend/db/migrations/000043_venue_extraction_runs.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS venue_extraction_runs;

--- a/backend/db/migrations/000043_venue_extraction_runs.up.sql
+++ b/backend/db/migrations/000043_venue_extraction_runs.up.sql
@@ -1,0 +1,17 @@
+CREATE TABLE venue_extraction_runs (
+    id BIGSERIAL PRIMARY KEY,
+    venue_id BIGINT NOT NULL REFERENCES venues(id) ON DELETE CASCADE,
+    run_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    render_method VARCHAR(20),
+    preferred_source VARCHAR(20),
+    events_extracted INT NOT NULL DEFAULT 0,
+    events_imported INT NOT NULL DEFAULT 0,
+    content_hash VARCHAR(64),
+    http_status INT,
+    error TEXT,
+    duration_ms INT NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_venue_extraction_runs_venue_id ON venue_extraction_runs(venue_id);
+CREATE INDEX idx_venue_extraction_runs_run_at ON venue_extraction_runs(run_at);

--- a/backend/internal/models/venue_extraction_run.go
+++ b/backend/internal/models/venue_extraction_run.go
@@ -1,0 +1,23 @@
+package models
+
+import "time"
+
+// VenueExtractionRun records a single extraction attempt for a venue.
+type VenueExtractionRun struct {
+	ID              uint      `json:"id" gorm:"primaryKey"`
+	VenueID         uint      `json:"venue_id" gorm:"column:venue_id;not null"`
+	RunAt           time.Time `json:"run_at" gorm:"column:run_at;not null;default:NOW()"`
+	RenderMethod    *string   `json:"render_method" gorm:"column:render_method"`
+	PreferredSource *string   `json:"preferred_source" gorm:"column:preferred_source"`
+	EventsExtracted int       `json:"events_extracted" gorm:"column:events_extracted;not null;default:0"`
+	EventsImported  int       `json:"events_imported" gorm:"column:events_imported;not null;default:0"`
+	ContentHash     *string   `json:"content_hash" gorm:"column:content_hash"`
+	HTTPStatus      *int      `json:"http_status" gorm:"column:http_status"`
+	Error           *string   `json:"error" gorm:"column:error"`
+	DurationMs      int       `json:"duration_ms" gorm:"column:duration_ms;not null;default:0"`
+	CreatedAt       time.Time `json:"created_at"`
+
+	Venue Venue `json:"-" gorm:"foreignKey:VenueID"`
+}
+
+func (VenueExtractionRun) TableName() string { return "venue_extraction_runs" }

--- a/backend/internal/models/venue_source_config.go
+++ b/backend/internal/models/venue_source_config.go
@@ -1,0 +1,26 @@
+package models
+
+import "time"
+
+// VenueSourceConfig tracks per-venue extraction configuration for the AI pipeline.
+type VenueSourceConfig struct {
+	ID                  uint       `json:"id" gorm:"primaryKey"`
+	VenueID             uint       `json:"venue_id" gorm:"column:venue_id;uniqueIndex;not null"`
+	CalendarURL         *string    `json:"calendar_url" gorm:"column:calendar_url"`
+	PreferredSource     string     `json:"preferred_source" gorm:"column:preferred_source;not null;default:'ai'"`
+	RenderMethod        *string    `json:"render_method" gorm:"column:render_method"`
+	FeedURL             *string    `json:"feed_url" gorm:"column:feed_url"`
+	LastContentHash     *string    `json:"last_content_hash" gorm:"column:last_content_hash"`
+	LastETag            *string    `json:"last_etag" gorm:"column:last_etag"`
+	LastExtractedAt     *time.Time `json:"last_extracted_at" gorm:"column:last_extracted_at"`
+	EventsExpected      int        `json:"events_expected" gorm:"column:events_expected;not null;default:0"`
+	ConsecutiveFailures int        `json:"consecutive_failures" gorm:"column:consecutive_failures;not null;default:0"`
+	StrategyLocked      bool       `json:"strategy_locked" gorm:"column:strategy_locked;not null;default:false"`
+	AutoApprove         bool       `json:"auto_approve" gorm:"column:auto_approve;not null;default:true"`
+	CreatedAt           time.Time  `json:"created_at"`
+	UpdatedAt           time.Time  `json:"updated_at"`
+
+	Venue Venue `json:"-" gorm:"foreignKey:VenueID"`
+}
+
+func (VenueSourceConfig) TableName() string { return "venue_source_configs" }

--- a/backend/internal/services/container.go
+++ b/backend/internal/services/container.go
@@ -27,8 +27,9 @@ type ServiceContainer struct {
 	SavedShow     *SavedShowService
 	Show          *ShowService
 	ShowReport    *ShowReportService
-	User          *UserService
-	Venue         *VenueService
+	User              *UserService
+	Venue             *VenueService
+	VenueSourceConfig *VenueSourceConfigService
 
 	// Config-only services
 	Discord        *DiscordService
@@ -80,7 +81,8 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 		Show:          NewShowService(database),
 		ShowReport:    NewShowReportService(database),
 		User:          NewUserService(database),
-		Venue:         NewVenueService(database),
+		Venue:             NewVenueService(database),
+		VenueSourceConfig: NewVenueSourceConfigService(database),
 
 		// Config-only services
 		Discord:        NewDiscordService(cfg),

--- a/backend/internal/services/interfaces.go
+++ b/backend/internal/services/interfaces.go
@@ -379,6 +379,17 @@ type CalendarServiceInterface interface {
 	GenerateICSFeed(userID uint, frontendURL string) ([]byte, error)
 }
 
+// VenueSourceConfigServiceInterface defines the contract for venue source config operations.
+type VenueSourceConfigServiceInterface interface {
+	GetByVenueID(venueID uint) (*models.VenueSourceConfig, error)
+	CreateOrUpdate(config *models.VenueSourceConfig) (*models.VenueSourceConfig, error)
+	UpdateAfterRun(venueID uint, contentHash, etag *string, eventsExtracted int) error
+	IncrementFailures(venueID uint) error
+	RecordRun(run *models.VenueExtractionRun) error
+	GetRecentRuns(venueID uint, limit int) ([]models.VenueExtractionRun, error)
+	ListConfigured() ([]models.VenueSourceConfig, error)
+}
+
 // Compile-time interface satisfaction checks.
 var (
 	_ ShowServiceInterface          = (*ShowService)(nil)
@@ -408,6 +419,7 @@ var (
 	_ FestivalServiceInterface       = (*FestivalService)(nil)
 	_ LabelServiceInterface          = (*LabelService)(nil)
 	_ ReleaseServiceInterface       = (*ReleaseService)(nil)
-	_ BookmarkServiceInterface           = (*BookmarkService)(nil)
-	_ ContributorProfileServiceInterface = (*ContributorProfileService)(nil)
+	_ BookmarkServiceInterface              = (*BookmarkService)(nil)
+	_ ContributorProfileServiceInterface    = (*ContributorProfileService)(nil)
+	_ VenueSourceConfigServiceInterface     = (*VenueSourceConfigService)(nil)
 )

--- a/backend/internal/services/venue_source_config.go
+++ b/backend/internal/services/venue_source_config.go
@@ -1,0 +1,179 @@
+package services
+
+import (
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+
+	"psychic-homily-backend/db"
+	"psychic-homily-backend/internal/models"
+)
+
+// VenueSourceConfigService manages per-venue extraction configuration and run history.
+type VenueSourceConfigService struct {
+	db *gorm.DB
+}
+
+// NewVenueSourceConfigService creates a new venue source config service.
+func NewVenueSourceConfigService(database *gorm.DB) *VenueSourceConfigService {
+	if database == nil {
+		database = db.GetDB()
+	}
+	return &VenueSourceConfigService{
+		db: database,
+	}
+}
+
+// GetByVenueID returns the source config for a venue, or nil if not configured.
+func (s *VenueSourceConfigService) GetByVenueID(venueID uint) (*models.VenueSourceConfig, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var config models.VenueSourceConfig
+	err := s.db.Where("venue_id = ?", venueID).First(&config).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get venue source config: %w", err)
+	}
+
+	return &config, nil
+}
+
+// CreateOrUpdate upserts a venue source config. If a config for the venue already
+// exists, it updates the mutable fields; otherwise it creates a new record.
+func (s *VenueSourceConfigService) CreateOrUpdate(config *models.VenueSourceConfig) (*models.VenueSourceConfig, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	if config.VenueID == 0 {
+		return nil, fmt.Errorf("venue_id is required")
+	}
+
+	result := s.db.Clauses(clause.OnConflict{
+		Columns: []clause.Column{{Name: "venue_id"}},
+		DoUpdates: clause.AssignmentColumns([]string{
+			"calendar_url", "preferred_source", "render_method", "feed_url",
+			"strategy_locked", "auto_approve", "updated_at",
+		}),
+	}).Create(config)
+
+	if result.Error != nil {
+		return nil, fmt.Errorf("failed to upsert venue source config: %w", result.Error)
+	}
+
+	return s.GetByVenueID(config.VenueID)
+}
+
+// UpdateAfterRun updates extraction metadata after a successful run.
+func (s *VenueSourceConfigService) UpdateAfterRun(venueID uint, contentHash, etag *string, eventsExtracted int) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	now := time.Now()
+	result := s.db.Model(&models.VenueSourceConfig{}).
+		Where("venue_id = ?", venueID).
+		Updates(map[string]interface{}{
+			"last_extracted_at":    now,
+			"last_content_hash":    contentHash,
+			"last_etag":            etag,
+			"consecutive_failures": 0,
+			"events_expected":      gorm.Expr("(events_expected + ?) / 2", eventsExtracted),
+			"updated_at":           now,
+		})
+
+	if result.Error != nil {
+		return fmt.Errorf("failed to update after run: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("venue source config not found for venue %d", venueID)
+	}
+
+	return nil
+}
+
+// IncrementFailures increments the consecutive_failures counter for a venue.
+func (s *VenueSourceConfigService) IncrementFailures(venueID uint) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	result := s.db.Model(&models.VenueSourceConfig{}).
+		Where("venue_id = ?", venueID).
+		Updates(map[string]interface{}{
+			"consecutive_failures": gorm.Expr("consecutive_failures + 1"),
+			"updated_at":           time.Now(),
+		})
+
+	if result.Error != nil {
+		return fmt.Errorf("failed to increment failures: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("venue source config not found for venue %d", venueID)
+	}
+
+	return nil
+}
+
+// RecordRun inserts a new extraction run record.
+func (s *VenueSourceConfigService) RecordRun(run *models.VenueExtractionRun) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	if run.VenueID == 0 {
+		return fmt.Errorf("venue_id is required")
+	}
+
+	if err := s.db.Create(run).Error; err != nil {
+		return fmt.Errorf("failed to record extraction run: %w", err)
+	}
+
+	return nil
+}
+
+// GetRecentRuns returns the most recent extraction runs for a venue, ordered by run_at desc.
+func (s *VenueSourceConfigService) GetRecentRuns(venueID uint, limit int) ([]models.VenueExtractionRun, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	if limit <= 0 {
+		limit = 10
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	var runs []models.VenueExtractionRun
+	err := s.db.Where("venue_id = ?", venueID).
+		Order("run_at DESC").
+		Limit(limit).
+		Find(&runs).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to get recent runs: %w", err)
+	}
+
+	return runs, nil
+}
+
+// ListConfigured returns all venue source configs, preloading the venue association.
+func (s *VenueSourceConfigService) ListConfigured() ([]models.VenueSourceConfig, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var configs []models.VenueSourceConfig
+	err := s.db.Preload("Venue").Find(&configs).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to list configured venues: %w", err)
+	}
+
+	return configs, nil
+}

--- a/backend/internal/services/venue_source_config_test.go
+++ b/backend/internal/services/venue_source_config_test.go
@@ -1,0 +1,539 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/testutil"
+)
+
+// =============================================================================
+// UNIT TESTS (No Database Required)
+// =============================================================================
+
+func TestNewVenueSourceConfigService(t *testing.T) {
+	svc := NewVenueSourceConfigService(nil)
+	assert.NotNil(t, svc)
+}
+
+func TestVenueSourceConfigService_NilDatabase(t *testing.T) {
+	svc := &VenueSourceConfigService{db: nil}
+
+	t.Run("GetByVenueID", func(t *testing.T) {
+		result, err := svc.GetByVenueID(1)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, result)
+	})
+
+	t.Run("CreateOrUpdate", func(t *testing.T) {
+		result, err := svc.CreateOrUpdate(&models.VenueSourceConfig{VenueID: 1})
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, result)
+	})
+
+	t.Run("UpdateAfterRun", func(t *testing.T) {
+		err := svc.UpdateAfterRun(1, nil, nil, 5)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+	})
+
+	t.Run("IncrementFailures", func(t *testing.T) {
+		err := svc.IncrementFailures(1)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+	})
+
+	t.Run("RecordRun", func(t *testing.T) {
+		err := svc.RecordRun(&models.VenueExtractionRun{VenueID: 1})
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+	})
+
+	t.Run("GetRecentRuns", func(t *testing.T) {
+		result, err := svc.GetRecentRuns(1, 10)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, result)
+	})
+
+	t.Run("ListConfigured", func(t *testing.T) {
+		result, err := svc.ListConfigured()
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, result)
+	})
+}
+
+// =============================================================================
+// INTEGRATION TESTS (With Real Database)
+// =============================================================================
+
+type VenueSourceConfigIntegrationTestSuite struct {
+	suite.Suite
+	container testcontainers.Container
+	db        *gorm.DB
+	svc       *VenueSourceConfigService
+	ctx       context.Context
+	venueID   uint
+}
+
+func (s *VenueSourceConfigIntegrationTestSuite) SetupSuite() {
+	s.ctx = context.Background()
+
+	container, err := testcontainers.GenericContainer(s.ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "postgres:18",
+			ExposedPorts: []string{"5432/tcp"},
+			Env: map[string]string{
+				"POSTGRES_DB":       "test_db",
+				"POSTGRES_USER":     "test_user",
+				"POSTGRES_PASSWORD": "test_password",
+			},
+			WaitingFor: wait.ForListeningPort("5432/tcp").WithStartupTimeout(60 * time.Second),
+		},
+		Started: true,
+	})
+	s.Require().NoError(err)
+	s.container = container
+
+	host, _ := container.Host(s.ctx)
+	port, _ := container.MappedPort(s.ctx, "5432")
+
+	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable", host, port.Port())
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	s.Require().NoError(err)
+	s.db = db
+
+	sqlDB, err := db.DB()
+	s.Require().NoError(err)
+
+	migrationDir, _ := filepath.Abs("../../db/migrations")
+	testutil.RunAllMigrations(s.T(), sqlDB, migrationDir)
+
+	s.svc = NewVenueSourceConfigService(db)
+}
+
+func (s *VenueSourceConfigIntegrationTestSuite) TearDownSuite() {
+	if s.container != nil {
+		s.container.Terminate(s.ctx)
+	}
+}
+
+func (s *VenueSourceConfigIntegrationTestSuite) SetupTest() {
+	// Create a test venue
+	slug := "test-venue"
+	venue := models.Venue{
+		Name:  "Test Venue",
+		Slug:  &slug,
+		City:  "Phoenix",
+		State: "AZ",
+	}
+	s.Require().NoError(s.db.Create(&venue).Error)
+	s.venueID = venue.ID
+}
+
+func (s *VenueSourceConfigIntegrationTestSuite) TearDownTest() {
+	s.db.Exec("DELETE FROM venue_extraction_runs")
+	s.db.Exec("DELETE FROM venue_source_configs")
+	s.db.Exec("DELETE FROM venues")
+}
+
+func TestVenueSourceConfigIntegrationSuite(t *testing.T) {
+	suite.Run(t, new(VenueSourceConfigIntegrationTestSuite))
+}
+
+// --- CreateOrUpdate tests ---
+
+func (s *VenueSourceConfigIntegrationTestSuite) TestCreateOrUpdate_NewConfig() {
+	url := "https://testvenue.com/calendar"
+	config := &models.VenueSourceConfig{
+		VenueID:     s.venueID,
+		CalendarURL: &url,
+	}
+
+	result, err := s.svc.CreateOrUpdate(config)
+	s.NoError(err)
+	s.NotNil(result)
+	s.Equal(s.venueID, result.VenueID)
+	s.Equal(&url, result.CalendarURL)
+	s.Equal("ai", result.PreferredSource)
+	s.True(result.AutoApprove)
+	s.False(result.StrategyLocked)
+}
+
+func (s *VenueSourceConfigIntegrationTestSuite) TestCreateOrUpdate_UpdateExisting() {
+	url1 := "https://testvenue.com/old"
+	config := &models.VenueSourceConfig{
+		VenueID:     s.venueID,
+		CalendarURL: &url1,
+	}
+	_, err := s.svc.CreateOrUpdate(config)
+	s.NoError(err)
+
+	url2 := "https://testvenue.com/new"
+	updated := &models.VenueSourceConfig{
+		VenueID:         s.venueID,
+		CalendarURL:     &url2,
+		PreferredSource: "ical",
+	}
+	result, err := s.svc.CreateOrUpdate(updated)
+	s.NoError(err)
+	s.NotNil(result)
+	s.Equal(&url2, result.CalendarURL)
+	s.Equal("ical", result.PreferredSource)
+}
+
+func (s *VenueSourceConfigIntegrationTestSuite) TestCreateOrUpdate_VenueIDRequired() {
+	config := &models.VenueSourceConfig{}
+	result, err := s.svc.CreateOrUpdate(config)
+	s.Error(err)
+	s.Contains(err.Error(), "venue_id is required")
+	s.Nil(result)
+}
+
+// --- GetByVenueID tests ---
+
+func (s *VenueSourceConfigIntegrationTestSuite) TestGetByVenueID_Found() {
+	url := "https://testvenue.com/calendar"
+	config := &models.VenueSourceConfig{
+		VenueID:     s.venueID,
+		CalendarURL: &url,
+	}
+	_, err := s.svc.CreateOrUpdate(config)
+	s.NoError(err)
+
+	result, err := s.svc.GetByVenueID(s.venueID)
+	s.NoError(err)
+	s.NotNil(result)
+	s.Equal(s.venueID, result.VenueID)
+}
+
+func (s *VenueSourceConfigIntegrationTestSuite) TestGetByVenueID_NotFound() {
+	result, err := s.svc.GetByVenueID(99999)
+	s.NoError(err)
+	s.Nil(result)
+}
+
+// --- UpdateAfterRun tests ---
+
+func (s *VenueSourceConfigIntegrationTestSuite) TestUpdateAfterRun_Success() {
+	url := "https://testvenue.com/calendar"
+	config := &models.VenueSourceConfig{
+		VenueID:     s.venueID,
+		CalendarURL: &url,
+	}
+	_, err := s.svc.CreateOrUpdate(config)
+	s.NoError(err)
+
+	hash := "abc123"
+	etag := "\"etag-1\""
+	err = s.svc.UpdateAfterRun(s.venueID, &hash, &etag, 10)
+	s.NoError(err)
+
+	result, err := s.svc.GetByVenueID(s.venueID)
+	s.NoError(err)
+	s.NotNil(result.LastExtractedAt)
+	s.Equal(&hash, result.LastContentHash)
+	s.Equal(&etag, result.LastETag)
+	s.Equal(0, result.ConsecutiveFailures)
+	s.Equal(5, result.EventsExpected) // (0 + 10) / 2
+}
+
+func (s *VenueSourceConfigIntegrationTestSuite) TestUpdateAfterRun_RollingAverage() {
+	url := "https://testvenue.com/calendar"
+	config := &models.VenueSourceConfig{
+		VenueID:     s.venueID,
+		CalendarURL: &url,
+	}
+	_, err := s.svc.CreateOrUpdate(config)
+	s.NoError(err)
+
+	hash := "h1"
+	err = s.svc.UpdateAfterRun(s.venueID, &hash, nil, 20)
+	s.NoError(err)
+
+	result, _ := s.svc.GetByVenueID(s.venueID)
+	s.Equal(10, result.EventsExpected) // (0 + 20) / 2
+
+	hash = "h2"
+	err = s.svc.UpdateAfterRun(s.venueID, &hash, nil, 20)
+	s.NoError(err)
+
+	result, _ = s.svc.GetByVenueID(s.venueID)
+	s.Equal(15, result.EventsExpected) // (10 + 20) / 2
+}
+
+func (s *VenueSourceConfigIntegrationTestSuite) TestUpdateAfterRun_NotFound() {
+	hash := "abc"
+	err := s.svc.UpdateAfterRun(99999, &hash, nil, 5)
+	s.Error(err)
+	s.Contains(err.Error(), "not found")
+}
+
+func (s *VenueSourceConfigIntegrationTestSuite) TestUpdateAfterRun_ResetsFailures() {
+	url := "https://testvenue.com/calendar"
+	config := &models.VenueSourceConfig{
+		VenueID:     s.venueID,
+		CalendarURL: &url,
+	}
+	_, err := s.svc.CreateOrUpdate(config)
+	s.NoError(err)
+
+	// Increment failures a few times
+	s.NoError(s.svc.IncrementFailures(s.venueID))
+	s.NoError(s.svc.IncrementFailures(s.venueID))
+	result, _ := s.svc.GetByVenueID(s.venueID)
+	s.Equal(2, result.ConsecutiveFailures)
+
+	// UpdateAfterRun should reset
+	hash := "h1"
+	s.NoError(s.svc.UpdateAfterRun(s.venueID, &hash, nil, 5))
+	result, _ = s.svc.GetByVenueID(s.venueID)
+	s.Equal(0, result.ConsecutiveFailures)
+}
+
+// --- IncrementFailures tests ---
+
+func (s *VenueSourceConfigIntegrationTestSuite) TestIncrementFailures_Success() {
+	url := "https://testvenue.com/calendar"
+	config := &models.VenueSourceConfig{
+		VenueID:     s.venueID,
+		CalendarURL: &url,
+	}
+	_, err := s.svc.CreateOrUpdate(config)
+	s.NoError(err)
+
+	err = s.svc.IncrementFailures(s.venueID)
+	s.NoError(err)
+
+	result, _ := s.svc.GetByVenueID(s.venueID)
+	s.Equal(1, result.ConsecutiveFailures)
+
+	err = s.svc.IncrementFailures(s.venueID)
+	s.NoError(err)
+
+	result, _ = s.svc.GetByVenueID(s.venueID)
+	s.Equal(2, result.ConsecutiveFailures)
+}
+
+func (s *VenueSourceConfigIntegrationTestSuite) TestIncrementFailures_NotFound() {
+	err := s.svc.IncrementFailures(99999)
+	s.Error(err)
+	s.Contains(err.Error(), "not found")
+}
+
+// --- RecordRun tests ---
+
+func (s *VenueSourceConfigIntegrationTestSuite) TestRecordRun_Success() {
+	method := "static"
+	source := "ai"
+	hash := "abc123"
+	status := 200
+
+	run := &models.VenueExtractionRun{
+		VenueID:         s.venueID,
+		RenderMethod:    &method,
+		PreferredSource: &source,
+		EventsExtracted: 10,
+		EventsImported:  8,
+		ContentHash:     &hash,
+		HTTPStatus:      &status,
+		DurationMs:      1500,
+	}
+
+	err := s.svc.RecordRun(run)
+	s.NoError(err)
+	s.NotZero(run.ID)
+}
+
+func (s *VenueSourceConfigIntegrationTestSuite) TestRecordRun_VenueIDRequired() {
+	run := &models.VenueExtractionRun{}
+	err := s.svc.RecordRun(run)
+	s.Error(err)
+	s.Contains(err.Error(), "venue_id is required")
+}
+
+func (s *VenueSourceConfigIntegrationTestSuite) TestRecordRun_WithError() {
+	errMsg := "connection timeout"
+	status := 0
+	run := &models.VenueExtractionRun{
+		VenueID:    s.venueID,
+		HTTPStatus: &status,
+		Error:      &errMsg,
+		DurationMs: 30000,
+	}
+
+	err := s.svc.RecordRun(run)
+	s.NoError(err)
+	s.NotZero(run.ID)
+}
+
+// --- GetRecentRuns tests ---
+
+func (s *VenueSourceConfigIntegrationTestSuite) TestGetRecentRuns_OrderByRunAtDesc() {
+	for i := 0; i < 3; i++ {
+		run := &models.VenueExtractionRun{
+			VenueID:         s.venueID,
+			RunAt:           time.Now().Add(time.Duration(i) * time.Hour),
+			EventsExtracted: i + 1,
+			DurationMs:      100,
+		}
+		s.NoError(s.svc.RecordRun(run))
+	}
+
+	runs, err := s.svc.GetRecentRuns(s.venueID, 10)
+	s.NoError(err)
+	s.Len(runs, 3)
+	// Most recent first
+	s.Equal(3, runs[0].EventsExtracted)
+	s.Equal(2, runs[1].EventsExtracted)
+	s.Equal(1, runs[2].EventsExtracted)
+}
+
+func (s *VenueSourceConfigIntegrationTestSuite) TestGetRecentRuns_RespectsLimit() {
+	for i := 0; i < 5; i++ {
+		run := &models.VenueExtractionRun{
+			VenueID:    s.venueID,
+			DurationMs: 100,
+		}
+		s.NoError(s.svc.RecordRun(run))
+	}
+
+	runs, err := s.svc.GetRecentRuns(s.venueID, 2)
+	s.NoError(err)
+	s.Len(runs, 2)
+}
+
+func (s *VenueSourceConfigIntegrationTestSuite) TestGetRecentRuns_DefaultLimit() {
+	runs, err := s.svc.GetRecentRuns(s.venueID, 0)
+	s.NoError(err)
+	s.NotNil(runs) // empty but not nil
+}
+
+func (s *VenueSourceConfigIntegrationTestSuite) TestGetRecentRuns_MaxLimit() {
+	runs, err := s.svc.GetRecentRuns(s.venueID, 500)
+	s.NoError(err)
+	s.NotNil(runs)
+}
+
+// --- ListConfigured tests ---
+
+func (s *VenueSourceConfigIntegrationTestSuite) TestListConfigured_Empty() {
+	configs, err := s.svc.ListConfigured()
+	s.NoError(err)
+	s.Empty(configs)
+}
+
+func (s *VenueSourceConfigIntegrationTestSuite) TestListConfigured_WithConfigs() {
+	url := "https://testvenue.com/calendar"
+	config := &models.VenueSourceConfig{
+		VenueID:     s.venueID,
+		CalendarURL: &url,
+	}
+	_, err := s.svc.CreateOrUpdate(config)
+	s.NoError(err)
+
+	configs, err := s.svc.ListConfigured()
+	s.NoError(err)
+	s.Len(configs, 1)
+	s.Equal(s.venueID, configs[0].VenueID)
+	// Verify venue is preloaded
+	s.Equal("Test Venue", configs[0].Venue.Name)
+}
+
+// --- Cascade delete test ---
+
+func (s *VenueSourceConfigIntegrationTestSuite) TestCascadeDelete_VenueDeleteCleansUp() {
+	url := "https://testvenue.com/calendar"
+	config := &models.VenueSourceConfig{
+		VenueID:     s.venueID,
+		CalendarURL: &url,
+	}
+	_, err := s.svc.CreateOrUpdate(config)
+	s.NoError(err)
+
+	run := &models.VenueExtractionRun{
+		VenueID:    s.venueID,
+		DurationMs: 100,
+	}
+	s.NoError(s.svc.RecordRun(run))
+
+	// Delete the venue
+	s.db.Exec("DELETE FROM venues WHERE id = ?", s.venueID)
+
+	// Config and runs should be gone
+	result, err := s.svc.GetByVenueID(s.venueID)
+	s.NoError(err)
+	s.Nil(result)
+
+	runs, err := s.svc.GetRecentRuns(s.venueID, 10)
+	s.NoError(err)
+	s.Empty(runs)
+}
+
+// --- End-to-end workflow test ---
+
+func (s *VenueSourceConfigIntegrationTestSuite) TestEndToEnd_ExtractionWorkflow() {
+	// 1. Create config
+	url := "https://testvenue.com/calendar"
+	config := &models.VenueSourceConfig{
+		VenueID:     s.venueID,
+		CalendarURL: &url,
+	}
+	created, err := s.svc.CreateOrUpdate(config)
+	s.NoError(err)
+	s.NotNil(created)
+
+	// 2. Simulate successful extraction
+	hash := "abc123"
+	etag := "\"etag-1\""
+	s.NoError(s.svc.UpdateAfterRun(s.venueID, &hash, &etag, 10))
+
+	// Record the run
+	method := "static"
+	source := "ai"
+	status := 200
+	run := &models.VenueExtractionRun{
+		VenueID:         s.venueID,
+		RenderMethod:    &method,
+		PreferredSource: &source,
+		EventsExtracted: 10,
+		EventsImported:  8,
+		ContentHash:     &hash,
+		HTTPStatus:      &status,
+		DurationMs:      1500,
+	}
+	s.NoError(s.svc.RecordRun(run))
+
+	// 3. Simulate a failure
+	s.NoError(s.svc.IncrementFailures(s.venueID))
+
+	result, _ := s.svc.GetByVenueID(s.venueID)
+	s.Equal(1, result.ConsecutiveFailures)
+
+	// 4. Simulate recovery
+	hash2 := "def456"
+	s.NoError(s.svc.UpdateAfterRun(s.venueID, &hash2, nil, 12))
+
+	result, _ = s.svc.GetByVenueID(s.venueID)
+	s.Equal(0, result.ConsecutiveFailures)
+	s.Equal(&hash2, result.LastContentHash)
+
+	// 5. Verify run history
+	runs, err := s.svc.GetRecentRuns(s.venueID, 10)
+	s.NoError(err)
+	s.Len(runs, 1)
+}


### PR DESCRIPTION
## Summary
- Migration 000042: `venue_source_configs` table — per-venue extraction configuration (calendar URL, render method, change detection hashes, failure tracking, auto-approve)
- Migration 000043: `venue_extraction_runs` table — extraction history with event counts, timing, errors
- GORM models with `TableName()` methods
- `VenueSourceConfigService` with 7 methods: `GetByVenueID`, `CreateOrUpdate` (upsert), `UpdateAfterRun` (rolling average events_expected), `IncrementFailures`, `RecordRun`, `GetRecentRuns`, `ListConfigured`
- Interface + container registration
- 22 integration tests + unit tests

## Test plan
- [x] Unit tests: nil DB error paths for all 7 methods
- [x] Integration tests: CRUD, upsert, rolling average, failure tracking, run recording, cascade delete, end-to-end workflow
- [x] `go build ./...` passes
- [x] All tests pass

Closes PSY-75

🤖 Generated with [Claude Code](https://claude.com/claude-code)