### PR TITLE
Add pipeline orchestrator and admin trigger endpoints (PSY-79)

### DIFF
--- a/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
+++ b/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
@@ -998,7 +998,8 @@ func (m *mockMusicDiscoveryService) DiscoverMusicForArtist(artistID uint, artist
 // ============================================================================
 
 type mockExtractionService struct {
-	extractShowFn func(req *services.ExtractShowRequest) (*services.ExtractShowResponse, error)
+	extractShowFn         func(req *services.ExtractShowRequest) (*services.ExtractShowResponse, error)
+	extractCalendarPageFn func(venueName, content, contentType string) (*services.CalendarExtractionResponse, error)
 }
 
 func (m *mockExtractionService) ExtractShow(req *services.ExtractShowRequest) (*services.ExtractShowResponse, error) {
@@ -1006,6 +1007,13 @@ func (m *mockExtractionService) ExtractShow(req *services.ExtractShowRequest) (*
 		return m.extractShowFn(req)
 	}
 	return nil, nil
+}
+
+func (m *mockExtractionService) ExtractCalendarPage(venueName, content, contentType string) (*services.CalendarExtractionResponse, error) {
+	if m.extractCalendarPageFn != nil {
+		return m.extractCalendarPageFn(venueName, content, contentType)
+	}
+	return &services.CalendarExtractionResponse{Success: true, Events: []services.CalendarEvent{}}, nil
 }
 
 // ============================================================================

--- a/backend/internal/api/handlers/pipeline.go
+++ b/backend/internal/api/handlers/pipeline.go
@@ -1,0 +1,151 @@
+package handlers
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"psychic-homily-backend/internal/api/middleware"
+	"psychic-homily-backend/internal/logger"
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services"
+)
+
+// PipelineHandler handles AI extraction pipeline admin endpoints.
+type PipelineHandler struct {
+	pipelineService    services.PipelineServiceInterface
+	venueConfigService services.VenueSourceConfigServiceInterface
+}
+
+// NewPipelineHandler creates a new pipeline handler.
+func NewPipelineHandler(
+	pipelineService services.PipelineServiceInterface,
+	venueConfigService services.VenueSourceConfigServiceInterface,
+) *PipelineHandler {
+	return &PipelineHandler{
+		pipelineService:    pipelineService,
+		venueConfigService: venueConfigService,
+	}
+}
+
+// --- Extract Venue ---
+
+// ExtractVenueRequest is the Huma request for POST /admin/pipeline/extract/{venue_id}
+type ExtractVenueRequest struct {
+	VenueID string `path:"venue_id" validate:"required" doc:"Venue ID to extract"`
+	DryRun  bool   `query:"dry_run" doc:"If true, extract but do not import events"`
+}
+
+// ExtractVenueResponse is the Huma response for POST /admin/pipeline/extract/{venue_id}
+type ExtractVenueResponse struct {
+	Body services.PipelineResult
+}
+
+// ExtractVenueHandler handles POST /admin/pipeline/extract/{venue_id}
+func (h *PipelineHandler) ExtractVenueHandler(ctx context.Context, req *ExtractVenueRequest) (*ExtractVenueResponse, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil || !user.IsAdmin {
+		return nil, huma.Error403Forbidden("Admin access required")
+	}
+
+	venueID, err := strconv.ParseUint(req.VenueID, 10, 64)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid venue ID")
+	}
+
+	logger.FromContext(ctx).Info("pipeline_extract_venue",
+		"venue_id", venueID,
+		"dry_run", req.DryRun,
+		"admin_id", user.ID,
+	)
+
+	result, err := h.pipelineService.ExtractVenue(uint(venueID), req.DryRun)
+	if err != nil {
+		logger.FromContext(ctx).Error("pipeline_extract_failed",
+			"venue_id", venueID,
+			"error", err.Error(),
+		)
+		return nil, huma.Error422UnprocessableEntity(err.Error())
+	}
+
+	return &ExtractVenueResponse{Body: *result}, nil
+}
+
+// --- List Configured Venues ---
+
+// ListPipelineVenuesRequest is the Huma request for GET /admin/pipeline/venues
+type ListPipelineVenuesRequest struct{}
+
+// PipelineVenueInfo represents a venue with its source config and last run info.
+type PipelineVenueInfo struct {
+	VenueID             uint                          `json:"venue_id"`
+	VenueName           string                        `json:"venue_name"`
+	VenueSlug           string                        `json:"venue_slug"`
+	CalendarURL         *string                       `json:"calendar_url"`
+	PreferredSource     string                        `json:"preferred_source"`
+	RenderMethod        *string                       `json:"render_method"`
+	FeedURL             *string                       `json:"feed_url"`
+	LastExtractedAt     *time.Time                    `json:"last_extracted_at"`
+	EventsExpected      int                           `json:"events_expected"`
+	ConsecutiveFailures int                           `json:"consecutive_failures"`
+	StrategyLocked      bool                          `json:"strategy_locked"`
+	AutoApprove         bool                          `json:"auto_approve"`
+	LastRun             *models.VenueExtractionRun    `json:"last_run,omitempty"`
+}
+
+// ListPipelineVenuesResponse is the Huma response for GET /admin/pipeline/venues
+type ListPipelineVenuesResponse struct {
+	Body struct {
+		Venues []PipelineVenueInfo `json:"venues"`
+		Total  int                 `json:"total"`
+	}
+}
+
+// ListPipelineVenuesHandler handles GET /admin/pipeline/venues
+func (h *PipelineHandler) ListPipelineVenuesHandler(ctx context.Context, req *ListPipelineVenuesRequest) (*ListPipelineVenuesResponse, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil || !user.IsAdmin {
+		return nil, huma.Error403Forbidden("Admin access required")
+	}
+
+	configs, err := h.venueConfigService.ListConfigured()
+	if err != nil {
+		logger.FromContext(ctx).Error("pipeline_list_venues_failed", "error", err.Error())
+		return nil, huma.Error500InternalServerError("Failed to list configured venues")
+	}
+
+	venues := make([]PipelineVenueInfo, 0, len(configs))
+	for _, cfg := range configs {
+		info := PipelineVenueInfo{
+			VenueID:             cfg.VenueID,
+			VenueName:           cfg.Venue.Name,
+			CalendarURL:         cfg.CalendarURL,
+			PreferredSource:     cfg.PreferredSource,
+			RenderMethod:        cfg.RenderMethod,
+			FeedURL:             cfg.FeedURL,
+			LastExtractedAt:     cfg.LastExtractedAt,
+			EventsExpected:      cfg.EventsExpected,
+			ConsecutiveFailures: cfg.ConsecutiveFailures,
+			StrategyLocked:      cfg.StrategyLocked,
+			AutoApprove:         cfg.AutoApprove,
+		}
+		if cfg.Venue.Slug != nil {
+			info.VenueSlug = *cfg.Venue.Slug
+		}
+
+		// Get the most recent run (limit 1)
+		runs, runErr := h.venueConfigService.GetRecentRuns(cfg.VenueID, 1)
+		if runErr == nil && len(runs) > 0 {
+			info.LastRun = &runs[0]
+		}
+
+		venues = append(venues, info)
+	}
+
+	resp := &ListPipelineVenuesResponse{}
+	resp.Body.Venues = venues
+	resp.Body.Total = len(venues)
+	return resp, nil
+}

--- a/backend/internal/api/handlers/pipeline_test.go
+++ b/backend/internal/api/handlers/pipeline_test.go
@@ -1,0 +1,320 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services"
+)
+
+// ============================================================================
+// Mock: PipelineServiceInterface
+// ============================================================================
+
+type mockPipelineService struct {
+	extractVenueFn func(venueID uint, dryRun bool) (*services.PipelineResult, error)
+}
+
+func (m *mockPipelineService) ExtractVenue(venueID uint, dryRun bool) (*services.PipelineResult, error) {
+	if m.extractVenueFn != nil {
+		return m.extractVenueFn(venueID, dryRun)
+	}
+	return &services.PipelineResult{
+		VenueID:         venueID,
+		VenueName:       "Test Venue",
+		RenderMethod:    "static",
+		EventsExtracted: 5,
+		EventsImported:  3,
+		DurationMs:      1234,
+		DryRun:          dryRun,
+	}, nil
+}
+
+// ============================================================================
+// Mock: VenueSourceConfigServiceInterface
+// ============================================================================
+
+type mockVenueSourceConfigService struct {
+	getByVenueIDFn      func(venueID uint) (*models.VenueSourceConfig, error)
+	createOrUpdateFn    func(config *models.VenueSourceConfig) (*models.VenueSourceConfig, error)
+	updateAfterRunFn    func(venueID uint, contentHash, etag *string, eventsExtracted int) error
+	incrementFailuresFn func(venueID uint) error
+	recordRunFn         func(run *models.VenueExtractionRun) error
+	getRecentRunsFn     func(venueID uint, limit int) ([]models.VenueExtractionRun, error)
+	listConfiguredFn    func() ([]models.VenueSourceConfig, error)
+}
+
+func (m *mockVenueSourceConfigService) GetByVenueID(venueID uint) (*models.VenueSourceConfig, error) {
+	if m.getByVenueIDFn != nil {
+		return m.getByVenueIDFn(venueID)
+	}
+	return nil, nil
+}
+func (m *mockVenueSourceConfigService) CreateOrUpdate(config *models.VenueSourceConfig) (*models.VenueSourceConfig, error) {
+	if m.createOrUpdateFn != nil {
+		return m.createOrUpdateFn(config)
+	}
+	return config, nil
+}
+func (m *mockVenueSourceConfigService) UpdateAfterRun(venueID uint, contentHash, etag *string, eventsExtracted int) error {
+	if m.updateAfterRunFn != nil {
+		return m.updateAfterRunFn(venueID, contentHash, etag, eventsExtracted)
+	}
+	return nil
+}
+func (m *mockVenueSourceConfigService) IncrementFailures(venueID uint) error {
+	if m.incrementFailuresFn != nil {
+		return m.incrementFailuresFn(venueID)
+	}
+	return nil
+}
+func (m *mockVenueSourceConfigService) RecordRun(run *models.VenueExtractionRun) error {
+	if m.recordRunFn != nil {
+		return m.recordRunFn(run)
+	}
+	return nil
+}
+func (m *mockVenueSourceConfigService) GetRecentRuns(venueID uint, limit int) ([]models.VenueExtractionRun, error) {
+	if m.getRecentRunsFn != nil {
+		return m.getRecentRunsFn(venueID, limit)
+	}
+	return nil, nil
+}
+func (m *mockVenueSourceConfigService) ListConfigured() ([]models.VenueSourceConfig, error) {
+	if m.listConfiguredFn != nil {
+		return m.listConfiguredFn()
+	}
+	return nil, nil
+}
+
+// ============================================================================
+// Test helpers
+// ============================================================================
+
+func testPipelineHandler() *PipelineHandler {
+	return NewPipelineHandler(nil, nil)
+}
+
+func pipelineAdminCtx() context.Context {
+	return ctxWithUser(&models.User{ID: 1, IsAdmin: true})
+}
+
+func pipelineNonAdminCtx() context.Context {
+	return ctxWithUser(&models.User{ID: 2, IsAdmin: false})
+}
+
+// ============================================================================
+// Tests: NewPipelineHandler
+// ============================================================================
+
+func TestNewPipelineHandler(t *testing.T) {
+	h := testPipelineHandler()
+	if h == nil {
+		t.Fatal("expected non-nil PipelineHandler")
+	}
+}
+
+// ============================================================================
+// Tests: Admin Guard
+// ============================================================================
+
+func TestPipelineHandler_RequiresAdmin(t *testing.T) {
+	h := testPipelineHandler()
+
+	tests := []struct {
+		name string
+		fn   func(ctx context.Context) error
+	}{
+		{"ExtractVenue", func(ctx context.Context) error {
+			_, err := h.ExtractVenueHandler(ctx, &ExtractVenueRequest{VenueID: "1"})
+			return err
+		}},
+		{"ListPipelineVenues", func(ctx context.Context) error {
+			_, err := h.ListPipelineVenuesHandler(ctx, &ListPipelineVenuesRequest{})
+			return err
+		}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name+"_NoUser", func(t *testing.T) {
+			err := tc.fn(context.Background())
+			assertHumaError(t, err, 403)
+		})
+		t.Run(tc.name+"_NonAdmin", func(t *testing.T) {
+			err := tc.fn(pipelineNonAdminCtx())
+			assertHumaError(t, err, 403)
+		})
+	}
+}
+
+// ============================================================================
+// Tests: ExtractVenueHandler
+// ============================================================================
+
+func TestPipelineHandler_ExtractVenue_Success(t *testing.T) {
+	h := NewPipelineHandler(
+		&mockPipelineService{},
+		&mockVenueSourceConfigService{},
+	)
+
+	resp, err := h.ExtractVenueHandler(pipelineAdminCtx(), &ExtractVenueRequest{VenueID: "1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.VenueID != 1 {
+		t.Errorf("expected venue_id=1, got %d", resp.Body.VenueID)
+	}
+	if resp.Body.EventsExtracted != 5 {
+		t.Errorf("expected events_extracted=5, got %d", resp.Body.EventsExtracted)
+	}
+}
+
+func TestPipelineHandler_ExtractVenue_DryRun(t *testing.T) {
+	var receivedDryRun bool
+	h := NewPipelineHandler(
+		&mockPipelineService{
+			extractVenueFn: func(venueID uint, dryRun bool) (*services.PipelineResult, error) {
+				receivedDryRun = dryRun
+				return &services.PipelineResult{VenueID: venueID, DryRun: dryRun, EventsExtracted: 3}, nil
+			},
+		},
+		&mockVenueSourceConfigService{},
+	)
+
+	resp, err := h.ExtractVenueHandler(pipelineAdminCtx(), &ExtractVenueRequest{VenueID: "1", DryRun: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !receivedDryRun {
+		t.Error("expected dry_run=true to be passed to service")
+	}
+	if !resp.Body.DryRun {
+		t.Error("expected dry_run=true in response")
+	}
+}
+
+func TestPipelineHandler_ExtractVenue_InvalidVenueID(t *testing.T) {
+	h := NewPipelineHandler(
+		&mockPipelineService{},
+		&mockVenueSourceConfigService{},
+	)
+
+	_, err := h.ExtractVenueHandler(pipelineAdminCtx(), &ExtractVenueRequest{VenueID: "not-a-number"})
+	assertHumaError(t, err, 400)
+}
+
+func TestPipelineHandler_ExtractVenue_ServiceError(t *testing.T) {
+	h := NewPipelineHandler(
+		&mockPipelineService{
+			extractVenueFn: func(venueID uint, dryRun bool) (*services.PipelineResult, error) {
+				return nil, fmt.Errorf("venue has no calendar URL configured")
+			},
+		},
+		&mockVenueSourceConfigService{},
+	)
+
+	_, err := h.ExtractVenueHandler(pipelineAdminCtx(), &ExtractVenueRequest{VenueID: "1"})
+	assertHumaError(t, err, 422)
+}
+
+// ============================================================================
+// Tests: ListPipelineVenuesHandler
+// ============================================================================
+
+func TestPipelineHandler_ListVenues_Success(t *testing.T) {
+	calURL := "https://example.com/events"
+	rm := "static"
+	slug := "test-venue"
+
+	h := NewPipelineHandler(
+		&mockPipelineService{},
+		&mockVenueSourceConfigService{
+			listConfiguredFn: func() ([]models.VenueSourceConfig, error) {
+				return []models.VenueSourceConfig{
+					{
+						ID:              1,
+						VenueID:         10,
+						CalendarURL:     &calURL,
+						PreferredSource: "ai",
+						RenderMethod:    &rm,
+						Venue: models.Venue{
+							ID:   10,
+							Name: "Test Venue",
+							Slug: &slug,
+						},
+					},
+				}, nil
+			},
+			getRecentRunsFn: func(venueID uint, limit int) ([]models.VenueExtractionRun, error) {
+				return []models.VenueExtractionRun{
+					{ID: 1, VenueID: venueID, EventsExtracted: 5, EventsImported: 3},
+				}, nil
+			},
+		},
+	)
+
+	resp, err := h.ListPipelineVenuesHandler(pipelineAdminCtx(), &ListPipelineVenuesRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Total != 1 {
+		t.Errorf("expected total=1, got %d", resp.Body.Total)
+	}
+	if len(resp.Body.Venues) != 1 {
+		t.Fatalf("expected 1 venue, got %d", len(resp.Body.Venues))
+	}
+	v := resp.Body.Venues[0]
+	if v.VenueID != 10 {
+		t.Errorf("expected venue_id=10, got %d", v.VenueID)
+	}
+	if v.VenueName != "Test Venue" {
+		t.Errorf("expected venue_name=Test Venue, got %s", v.VenueName)
+	}
+	if v.VenueSlug != "test-venue" {
+		t.Errorf("expected venue_slug=test-venue, got %s", v.VenueSlug)
+	}
+	if v.LastRun == nil {
+		t.Fatal("expected last_run to be populated")
+	}
+	if v.LastRun.EventsExtracted != 5 {
+		t.Errorf("expected last_run.events_extracted=5, got %d", v.LastRun.EventsExtracted)
+	}
+}
+
+func TestPipelineHandler_ListVenues_Empty(t *testing.T) {
+	h := NewPipelineHandler(
+		&mockPipelineService{},
+		&mockVenueSourceConfigService{
+			listConfiguredFn: func() ([]models.VenueSourceConfig, error) {
+				return []models.VenueSourceConfig{}, nil
+			},
+		},
+	)
+
+	resp, err := h.ListPipelineVenuesHandler(pipelineAdminCtx(), &ListPipelineVenuesRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Total != 0 {
+		t.Errorf("expected total=0, got %d", resp.Body.Total)
+	}
+	if len(resp.Body.Venues) != 0 {
+		t.Errorf("expected 0 venues, got %d", len(resp.Body.Venues))
+	}
+}
+
+func TestPipelineHandler_ListVenues_ServiceError(t *testing.T) {
+	h := NewPipelineHandler(
+		&mockPipelineService{},
+		&mockVenueSourceConfigService{
+			listConfiguredFn: func() ([]models.VenueSourceConfig, error) {
+				return nil, fmt.Errorf("database error")
+			},
+		},
+	)
+
+	_, err := h.ListPipelineVenuesHandler(pipelineAdminCtx(), &ListPipelineVenuesRequest{})
+	assertHumaError(t, err, 500)
+}

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -93,6 +93,7 @@ func SetupRoutes(router *chi.Mux, sc *services.ServiceContainer, cfg *config.Con
 	setupShowReportRoutes(router, protectedGroup, sc, cfg)
 	setupArtistReportRoutes(router, protectedGroup, sc, cfg)
 	setupAdminRoutes(protectedGroup, sc)
+	setupPipelineRoutes(protectedGroup, sc)
 	setupContributorProfileRoutes(api, protectedGroup, sc)
 
 	return api
@@ -537,6 +538,15 @@ func setupContributorProfileRoutes(api huma.API, protected *huma.Group, sc *serv
 	huma.Post(protected, "/auth/profile/sections", profileHandler.CreateSectionHandler)
 	huma.Put(protected, "/auth/profile/sections/{section_id}", profileHandler.UpdateSectionHandler)
 	huma.Delete(protected, "/auth/profile/sections/{section_id}", profileHandler.DeleteSectionHandler)
+}
+
+// setupPipelineRoutes configures AI extraction pipeline admin endpoints.
+// Admin check is performed inside handlers, JWT auth is required via protected group.
+func setupPipelineRoutes(protected *huma.Group, sc *services.ServiceContainer) {
+	pipelineHandler := handlers.NewPipelineHandler(sc.Pipeline, sc.VenueSourceConfig)
+
+	huma.Post(protected, "/admin/pipeline/extract/{venue_id}", pipelineHandler.ExtractVenueHandler)
+	huma.Get(protected, "/admin/pipeline/venues", pipelineHandler.ListPipelineVenuesHandler)
 }
 
 // rateLimitHandler handles rate limit exceeded responses with JSON

--- a/backend/internal/services/container.go
+++ b/backend/internal/services/container.go
@@ -49,6 +49,7 @@ type ServiceContainer struct {
 	Cleanup    *CleanupService
 	DataSync   *DataSyncService
 	Discovery  *DiscoveryService
+	Pipeline   *PipelineService
 	Reminder   *ReminderService
 }
 
@@ -71,6 +72,13 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 	savedShow := NewSavedShowService(database)
 	email := NewEmailService(cfg)
 
+	// Services needed by PipelineService — created first so we can inject them.
+	fetcher := newFetcherWithChromedp()
+	extraction := NewExtractionService(database, cfg)
+	discovery := NewDiscoveryService(database)
+	venueSourceConfig := NewVenueSourceConfigService(database)
+	venue := NewVenueService(database)
+
 	return &ServiceContainer{
 		// DB-only leaf services
 		AdminStats:         NewAdminStatsService(database),
@@ -89,8 +97,8 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 		Show:          NewShowService(database),
 		ShowReport:    NewShowReportService(database),
 		User:          NewUserService(database),
-		Venue:             NewVenueService(database),
-		VenueSourceConfig: NewVenueSourceConfigService(database),
+		Venue:             venue,
+		VenueSourceConfig: venueSourceConfig,
 
 		// Config-only services
 		Discord:        NewDiscordService(cfg),
@@ -98,18 +106,19 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 		MusicDiscovery: NewMusicDiscoveryService(cfg),
 
 		// No-param services
-		Fetcher:           newFetcherWithChromedp(),
+		Fetcher:           fetcher,
 		PasswordValidator: NewPasswordValidator(),
 
 		// DB + Config composite services
 		Auth:       NewAuthService(database, cfg),
 		JWT:        NewJWTService(database, cfg),
 		AppleAuth:  NewAppleAuthService(database, cfg),
-		Extraction: NewExtractionService(database, cfg),
+		Extraction: extraction,
 		WebAuthn:   webauthnService,
 		Cleanup:    NewCleanupService(database),
 		DataSync:   NewDataSyncService(database),
-		Discovery:  NewDiscoveryService(database),
+		Discovery:  discovery,
+		Pipeline:   NewPipelineService(fetcher, extraction, discovery, venueSourceConfig, venue),
 		Reminder:   NewReminderService(database, email, cfg),
 	}
 }

--- a/backend/internal/services/interfaces.go
+++ b/backend/internal/services/interfaces.go
@@ -388,6 +388,11 @@ type CalendarServiceInterface interface {
 	GenerateICSFeed(userID uint, frontendURL string) ([]byte, error)
 }
 
+// PipelineServiceInterface defines the contract for the AI extraction pipeline orchestrator.
+type PipelineServiceInterface interface {
+	ExtractVenue(venueID uint, dryRun bool) (*PipelineResult, error)
+}
+
 // VenueSourceConfigServiceInterface defines the contract for venue source config operations.
 type VenueSourceConfigServiceInterface interface {
 	GetByVenueID(venueID uint) (*models.VenueSourceConfig, error)
@@ -432,4 +437,5 @@ var (
 	_ ContributorProfileServiceInterface    = (*ContributorProfileService)(nil)
 	_ VenueSourceConfigServiceInterface     = (*VenueSourceConfigService)(nil)
 	_ FetcherServiceInterface               = (*FetcherService)(nil)
+	_ PipelineServiceInterface              = (*PipelineService)(nil)
 )

--- a/backend/internal/services/pipeline.go
+++ b/backend/internal/services/pipeline.go
@@ -1,0 +1,249 @@
+package services
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"psychic-homily-backend/internal/models"
+)
+
+// PipelineService orchestrates the end-to-end AI extraction pipeline:
+// fetch page -> detect changes -> extract events -> import shows.
+type PipelineService struct {
+	fetcher     FetcherServiceInterface
+	extraction  ExtractionServiceInterface
+	discovery   DiscoveryServiceInterface
+	venueConfig VenueSourceConfigServiceInterface
+	venue       VenueServiceInterface
+}
+
+// NewPipelineService creates a new pipeline orchestrator.
+func NewPipelineService(
+	fetcher FetcherServiceInterface,
+	extraction ExtractionServiceInterface,
+	discovery DiscoveryServiceInterface,
+	venueConfig VenueSourceConfigServiceInterface,
+	venue VenueServiceInterface,
+) *PipelineService {
+	return &PipelineService{
+		fetcher:     fetcher,
+		extraction:  extraction,
+		discovery:   discovery,
+		venueConfig: venueConfig,
+		venue:       venue,
+	}
+}
+
+// PipelineResult contains the outcome of a single venue extraction run.
+type PipelineResult struct {
+	VenueID         uint     `json:"venue_id"`
+	VenueName       string   `json:"venue_name"`
+	RenderMethod    string   `json:"render_method"`
+	EventsExtracted int      `json:"events_extracted"`
+	EventsImported  int      `json:"events_imported"`
+	DurationMs      int64    `json:"duration_ms"`
+	Skipped         bool     `json:"skipped"`
+	SkipReason      string   `json:"skip_reason,omitempty"`
+	Error           string   `json:"error,omitempty"`
+	Warnings        []string `json:"warnings,omitempty"`
+	DryRun          bool     `json:"dry_run"`
+}
+
+// ExtractVenue runs the full extraction pipeline for a single venue.
+func (s *PipelineService) ExtractVenue(venueID uint, dryRun bool) (*PipelineResult, error) {
+	start := time.Now()
+
+	// 1. Get venue
+	venue, err := s.venue.GetVenueModel(venueID)
+	if err != nil {
+		return nil, fmt.Errorf("venue not found: %w", err)
+	}
+
+	// 2. Get source config
+	config, err := s.venueConfig.GetByVenueID(venueID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get venue source config: %w", err)
+	}
+	if config == nil {
+		return nil, fmt.Errorf("venue %d (%s) has no source config", venueID, venue.Name)
+	}
+	if config.CalendarURL == nil || *config.CalendarURL == "" {
+		return nil, fmt.Errorf("venue %d (%s) has no calendar URL configured", venueID, venue.Name)
+	}
+
+	// 3. Determine render method
+	renderMethod := ""
+	if config.RenderMethod != nil {
+		renderMethod = *config.RenderMethod
+	}
+
+	// 4. Auto-detect render method if not set
+	if renderMethod == "" {
+		detected, detectErr := s.fetcher.DetectRenderMethod(*config.CalendarURL)
+		if detectErr != nil {
+			s.recordFailure(venueID, renderMethod, config.PreferredSource, start, detectErr)
+			return nil, fmt.Errorf("render method auto-detection failed: %w", detectErr)
+		}
+		renderMethod = detected
+		// Persist detected method
+		config.RenderMethod = &renderMethod
+		if _, updateErr := s.venueConfig.CreateOrUpdate(config); updateErr != nil {
+			log.Printf("warning: failed to save detected render method for venue %d: %v", venueID, updateErr)
+		}
+	}
+
+	// 5. Fetch based on render method
+	var fetchResult *FetchResult
+	var fetchErr error
+
+	switch renderMethod {
+	case RenderMethodStatic:
+		lastETag := ""
+		lastHash := ""
+		if config.LastETag != nil {
+			lastETag = *config.LastETag
+		}
+		if config.LastContentHash != nil {
+			lastHash = *config.LastContentHash
+		}
+		fetchResult, fetchErr = s.fetcher.Fetch(*config.CalendarURL, lastETag, lastHash)
+	case RenderMethodDynamic:
+		fetchResult, fetchErr = s.fetcher.FetchDynamic(*config.CalendarURL)
+	case RenderMethodScreenshot:
+		fetchResult, fetchErr = s.fetcher.FetchScreenshot(*config.CalendarURL)
+	default:
+		fetchErr = fmt.Errorf("unknown render method: %s", renderMethod)
+	}
+
+	if fetchErr != nil {
+		s.recordFailure(venueID, renderMethod, config.PreferredSource, start, fetchErr)
+		if incrementErr := s.venueConfig.IncrementFailures(venueID); incrementErr != nil {
+			log.Printf("warning: failed to increment failures for venue %d: %v", venueID, incrementErr)
+		}
+		return nil, fmt.Errorf("fetch failed: %w", fetchErr)
+	}
+
+	// 6. Check for changes (static only -- dynamic/screenshot always proceed)
+	if !fetchResult.Changed && renderMethod == RenderMethodStatic {
+		result := &PipelineResult{
+			VenueID:      venueID,
+			VenueName:    venue.Name,
+			RenderMethod: renderMethod,
+			Skipped:      true,
+			SkipReason:   "page unchanged (hash match)",
+			DurationMs:   time.Since(start).Milliseconds(),
+			DryRun:       dryRun,
+		}
+		s.recordRun(venueID, renderMethod, config.PreferredSource, 0, 0, &fetchResult.ContentHash, fetchResult.HTTPStatus, start, nil)
+		return result, nil
+	}
+
+	// 7. Determine content type for extraction
+	contentType := "text"
+	if renderMethod == RenderMethodScreenshot {
+		contentType = "image"
+	}
+
+	// 8. Extract events via AI
+	extractionResp, err := s.extraction.ExtractCalendarPage(venue.Name, fetchResult.Body, contentType)
+	if err != nil {
+		s.recordFailure(venueID, renderMethod, config.PreferredSource, start, err)
+		if incrementErr := s.venueConfig.IncrementFailures(venueID); incrementErr != nil {
+			log.Printf("warning: failed to increment failures for venue %d: %v", venueID, incrementErr)
+		}
+		return nil, fmt.Errorf("extraction failed: %w", err)
+	}
+
+	if !extractionResp.Success {
+		extractionErr := fmt.Errorf("extraction returned error: %s", extractionResp.Error)
+		s.recordFailure(venueID, renderMethod, config.PreferredSource, start, extractionErr)
+		if incrementErr := s.venueConfig.IncrementFailures(venueID); incrementErr != nil {
+			log.Printf("warning: failed to increment failures for venue %d: %v", venueID, incrementErr)
+		}
+		return nil, extractionErr
+	}
+
+	eventsExtracted := len(extractionResp.Events)
+
+	// 9. Convert to DiscoveredEvent format
+	venueSlug := ""
+	if venue.Slug != nil {
+		venueSlug = *venue.Slug
+	}
+	discoveredEvents := CalendarEventsToDiscoveredEvents(venueSlug, extractionResp.Events)
+
+	// 10. Import events (unless dry run)
+	eventsImported := 0
+	if !dryRun && len(discoveredEvents) > 0 {
+		importResult, importErr := s.discovery.ImportEvents(discoveredEvents, false, false)
+		if importErr != nil {
+			log.Printf("warning: import failed for venue %d: %v (extraction succeeded with %d events)", venueID, importErr, eventsExtracted)
+		} else {
+			eventsImported = importResult.Imported
+		}
+	}
+
+	duration := time.Since(start)
+
+	// 11. Record run
+	s.recordRun(venueID, renderMethod, config.PreferredSource, eventsExtracted, eventsImported, &fetchResult.ContentHash, fetchResult.HTTPStatus, start, nil)
+
+	// 12. Update config after successful run
+	if updateErr := s.venueConfig.UpdateAfterRun(venueID, &fetchResult.ContentHash, &fetchResult.ETag, eventsExtracted); updateErr != nil {
+		log.Printf("warning: failed to update config after run for venue %d: %v", venueID, updateErr)
+	}
+
+	return &PipelineResult{
+		VenueID:         venueID,
+		VenueName:       venue.Name,
+		RenderMethod:    renderMethod,
+		EventsExtracted: eventsExtracted,
+		EventsImported:  eventsImported,
+		DurationMs:      duration.Milliseconds(),
+		Warnings:        extractionResp.Warnings,
+		DryRun:          dryRun,
+	}, nil
+}
+
+// recordRun persists an extraction run record (fire-and-forget).
+func (s *PipelineService) recordRun(venueID uint, renderMethod, preferredSource string, extracted, imported int, contentHash *string, httpStatus int, start time.Time, runErr error) {
+	run := &models.VenueExtractionRun{
+		VenueID:         venueID,
+		RenderMethod:    strPtrIfNonEmpty(renderMethod),
+		PreferredSource: strPtrIfNonEmpty(preferredSource),
+		EventsExtracted: extracted,
+		EventsImported:  imported,
+		ContentHash:     contentHash,
+		HTTPStatus:      intPtrIfNonZero(httpStatus),
+		DurationMs:      int(time.Since(start).Milliseconds()),
+	}
+	if runErr != nil {
+		errStr := runErr.Error()
+		run.Error = &errStr
+	}
+	if err := s.venueConfig.RecordRun(run); err != nil {
+		log.Printf("warning: failed to record extraction run for venue %d: %v", venueID, err)
+	}
+}
+
+// recordFailure is a convenience wrapper for recording a failed run.
+func (s *PipelineService) recordFailure(venueID uint, renderMethod, preferredSource string, start time.Time, err error) {
+	s.recordRun(venueID, renderMethod, preferredSource, 0, 0, nil, 0, start, err)
+}
+
+// strPtrIfNonEmpty returns a pointer to s if non-empty, else nil.
+func strPtrIfNonEmpty(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+// intPtrIfNonZero returns a pointer to i if non-zero, else nil.
+func intPtrIfNonZero(i int) *int {
+	if i == 0 {
+		return nil
+	}
+	return &i
+}

--- a/backend/internal/services/pipeline_test.go
+++ b/backend/internal/services/pipeline_test.go
@@ -1,0 +1,926 @@
+package services
+
+import (
+	"fmt"
+	"testing"
+
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/internal/models"
+)
+
+// ============================================================================
+// Test doubles for PipelineService dependencies
+// ============================================================================
+
+type stubFetcher struct {
+	fetchFn              func(url, lastETag, lastContentHash string) (*FetchResult, error)
+	fetchDynamicFn       func(url string) (*FetchResult, error)
+	fetchScreenshotFn    func(url string) (*FetchResult, error)
+	detectRenderMethodFn func(url string) (string, error)
+}
+
+func (s *stubFetcher) Fetch(url, lastETag, lastContentHash string) (*FetchResult, error) {
+	if s.fetchFn != nil {
+		return s.fetchFn(url, lastETag, lastContentHash)
+	}
+	return &FetchResult{Changed: true, Body: "<html>events</html>", ContentHash: "abc123", HTTPStatus: 200}, nil
+}
+func (s *stubFetcher) FetchDynamic(url string) (*FetchResult, error) {
+	if s.fetchDynamicFn != nil {
+		return s.fetchDynamicFn(url)
+	}
+	return &FetchResult{Changed: true, Body: "<html>dynamic events</html>", ContentHash: "def456", HTTPStatus: 200}, nil
+}
+func (s *stubFetcher) FetchScreenshot(url string) (*FetchResult, error) {
+	if s.fetchScreenshotFn != nil {
+		return s.fetchScreenshotFn(url)
+	}
+	return &FetchResult{Changed: true, Body: "base64screenshot", ContentHash: "ghi789", HTTPStatus: 200, ContentType: "image/png"}, nil
+}
+func (s *stubFetcher) DetectRenderMethod(url string) (string, error) {
+	if s.detectRenderMethodFn != nil {
+		return s.detectRenderMethodFn(url)
+	}
+	return "static", nil
+}
+
+type stubExtraction struct {
+	extractCalendarPageFn func(venueName, content, contentType string) (*CalendarExtractionResponse, error)
+}
+
+func (s *stubExtraction) ExtractShow(req *ExtractShowRequest) (*ExtractShowResponse, error) {
+	return nil, fmt.Errorf("not implemented in stub")
+}
+func (s *stubExtraction) ExtractCalendarPage(venueName, content, contentType string) (*CalendarExtractionResponse, error) {
+	if s.extractCalendarPageFn != nil {
+		return s.extractCalendarPageFn(venueName, content, contentType)
+	}
+	return &CalendarExtractionResponse{
+		Success: true,
+		Events: []CalendarEvent{
+			{Date: "2026-04-01", Title: "Test Band", Artists: []CalendarArtist{{Name: "Test Band", IsHeadliner: true}}},
+			{Date: "2026-04-02", Title: "Other Band", Artists: []CalendarArtist{{Name: "Other Band", IsHeadliner: true}}},
+		},
+	}, nil
+}
+
+type stubDiscovery struct {
+	importEventsFn func(events []DiscoveredEvent, dryRun bool, allowUpdates bool) (*ImportResult, error)
+}
+
+func (s *stubDiscovery) ImportFromJSON(filepath string, dryRun bool) (*ImportResult, error) {
+	return nil, fmt.Errorf("not implemented in stub")
+}
+func (s *stubDiscovery) ImportFromJSONWithDB(filepath string, dryRun bool, database *gorm.DB) (*ImportResult, error) {
+	return nil, fmt.Errorf("not implemented in stub")
+}
+func (s *stubDiscovery) CheckEvents(events []CheckEventInput) (*CheckEventsResult, error) {
+	return nil, fmt.Errorf("not implemented in stub")
+}
+func (s *stubDiscovery) ImportEvents(events []DiscoveredEvent, dryRun bool, allowUpdates bool) (*ImportResult, error) {
+	if s.importEventsFn != nil {
+		return s.importEventsFn(events, dryRun, allowUpdates)
+	}
+	return &ImportResult{Total: len(events), Imported: len(events)}, nil
+}
+
+type stubVenueConfig struct {
+	getByVenueIDFn      func(venueID uint) (*models.VenueSourceConfig, error)
+	createOrUpdateFn    func(config *models.VenueSourceConfig) (*models.VenueSourceConfig, error)
+	updateAfterRunFn    func(venueID uint, contentHash, etag *string, eventsExtracted int) error
+	incrementFailuresFn func(venueID uint) error
+	recordRunFn         func(run *models.VenueExtractionRun) error
+	getRecentRunsFn     func(venueID uint, limit int) ([]models.VenueExtractionRun, error)
+	listConfiguredFn    func() ([]models.VenueSourceConfig, error)
+}
+
+func (s *stubVenueConfig) GetByVenueID(venueID uint) (*models.VenueSourceConfig, error) {
+	if s.getByVenueIDFn != nil {
+		return s.getByVenueIDFn(venueID)
+	}
+	return nil, nil
+}
+func (s *stubVenueConfig) CreateOrUpdate(config *models.VenueSourceConfig) (*models.VenueSourceConfig, error) {
+	if s.createOrUpdateFn != nil {
+		return s.createOrUpdateFn(config)
+	}
+	return config, nil
+}
+func (s *stubVenueConfig) UpdateAfterRun(venueID uint, contentHash, etag *string, eventsExtracted int) error {
+	if s.updateAfterRunFn != nil {
+		return s.updateAfterRunFn(venueID, contentHash, etag, eventsExtracted)
+	}
+	return nil
+}
+func (s *stubVenueConfig) IncrementFailures(venueID uint) error {
+	if s.incrementFailuresFn != nil {
+		return s.incrementFailuresFn(venueID)
+	}
+	return nil
+}
+func (s *stubVenueConfig) RecordRun(run *models.VenueExtractionRun) error {
+	if s.recordRunFn != nil {
+		return s.recordRunFn(run)
+	}
+	return nil
+}
+func (s *stubVenueConfig) GetRecentRuns(venueID uint, limit int) ([]models.VenueExtractionRun, error) {
+	if s.getRecentRunsFn != nil {
+		return s.getRecentRunsFn(venueID, limit)
+	}
+	return nil, nil
+}
+func (s *stubVenueConfig) ListConfigured() ([]models.VenueSourceConfig, error) {
+	if s.listConfiguredFn != nil {
+		return s.listConfiguredFn()
+	}
+	return nil, nil
+}
+
+type stubVenueService struct {
+	getVenueModelFn func(venueID uint) (*models.Venue, error)
+}
+
+// Satisfy the full VenueServiceInterface with panics for methods we don't use.
+func (s *stubVenueService) CreateVenue(req *CreateVenueRequest, isAdmin bool) (*VenueDetailResponse, error) {
+	panic("not implemented")
+}
+func (s *stubVenueService) GetVenue(venueID uint) (*VenueDetailResponse, error) {
+	panic("not implemented")
+}
+func (s *stubVenueService) GetVenueBySlug(slug string) (*VenueDetailResponse, error) {
+	panic("not implemented")
+}
+func (s *stubVenueService) GetVenues(filters map[string]interface{}) ([]*VenueDetailResponse, error) {
+	panic("not implemented")
+}
+func (s *stubVenueService) UpdateVenue(venueID uint, updates map[string]interface{}) (*VenueDetailResponse, error) {
+	panic("not implemented")
+}
+func (s *stubVenueService) DeleteVenue(venueID uint) error { panic("not implemented") }
+func (s *stubVenueService) SearchVenues(query string) ([]*VenueDetailResponse, error) {
+	panic("not implemented")
+}
+func (s *stubVenueService) FindOrCreateVenue(name, city, state string, address, zipcode *string, db *gorm.DB, isAdmin bool) (*models.Venue, bool, error) {
+	panic("not implemented")
+}
+func (s *stubVenueService) VerifyVenue(venueID uint) (*VenueDetailResponse, error) {
+	panic("not implemented")
+}
+func (s *stubVenueService) GetVenuesWithShowCounts(filters VenueListFilters, limit, offset int) ([]*VenueWithShowCountResponse, int64, error) {
+	panic("not implemented")
+}
+func (s *stubVenueService) GetUpcomingShowsForVenue(venueID uint, timezone string, limit int) ([]*VenueShowResponse, int64, error) {
+	panic("not implemented")
+}
+func (s *stubVenueService) GetShowsForVenue(venueID uint, timezone string, limit int, timeFilter string) ([]*VenueShowResponse, int64, error) {
+	panic("not implemented")
+}
+func (s *stubVenueService) GetVenueCities() ([]*VenueCityResponse, error) {
+	panic("not implemented")
+}
+func (s *stubVenueService) CreatePendingVenueEdit(venueID uint, userID uint, req *VenueEditRequest) (*PendingVenueEditResponse, error) {
+	panic("not implemented")
+}
+func (s *stubVenueService) GetPendingEditForVenue(venueID uint, userID uint) (*PendingVenueEditResponse, error) {
+	panic("not implemented")
+}
+func (s *stubVenueService) GetPendingVenueEdits(limit, offset int) ([]*PendingVenueEditResponse, int64, error) {
+	panic("not implemented")
+}
+func (s *stubVenueService) GetPendingVenueEdit(editID uint) (*PendingVenueEditResponse, error) {
+	panic("not implemented")
+}
+func (s *stubVenueService) ApproveVenueEdit(editID uint, reviewerID uint) (*VenueDetailResponse, error) {
+	panic("not implemented")
+}
+func (s *stubVenueService) RejectVenueEdit(editID uint, reviewerID uint, reason string) (*PendingVenueEditResponse, error) {
+	panic("not implemented")
+}
+func (s *stubVenueService) CancelPendingVenueEdit(editID uint, userID uint) error {
+	panic("not implemented")
+}
+func (s *stubVenueService) GetVenueModel(venueID uint) (*models.Venue, error) {
+	if s.getVenueModelFn != nil {
+		return s.getVenueModelFn(venueID)
+	}
+	slug := "test-venue"
+	return &models.Venue{ID: venueID, Name: "Test Venue", Slug: &slug, City: "Phoenix", State: "AZ"}, nil
+}
+func (s *stubVenueService) GetUnverifiedVenues(limit, offset int) ([]*UnverifiedVenueResponse, int64, error) {
+	panic("not implemented")
+}
+
+// ============================================================================
+// Helper to build PipelineService with stubs
+// ============================================================================
+
+func newTestPipeline(opts ...func(*testPipelineOpts)) *PipelineService {
+	o := &testPipelineOpts{
+		fetcher:     &stubFetcher{},
+		extraction:  &stubExtraction{},
+		discovery:   &stubDiscovery{},
+		venueConfig: &stubVenueConfig{},
+		venue:       &stubVenueService{},
+	}
+	for _, opt := range opts {
+		opt(o)
+	}
+	return NewPipelineService(o.fetcher, o.extraction, o.discovery, o.venueConfig, o.venue)
+}
+
+type testPipelineOpts struct {
+	fetcher     FetcherServiceInterface
+	extraction  ExtractionServiceInterface
+	discovery   DiscoveryServiceInterface
+	venueConfig VenueSourceConfigServiceInterface
+	venue       VenueServiceInterface
+}
+
+func withFetcher(f FetcherServiceInterface) func(*testPipelineOpts) {
+	return func(o *testPipelineOpts) { o.fetcher = f }
+}
+func withExtraction(e ExtractionServiceInterface) func(*testPipelineOpts) {
+	return func(o *testPipelineOpts) { o.extraction = e }
+}
+func withDiscovery(d DiscoveryServiceInterface) func(*testPipelineOpts) {
+	return func(o *testPipelineOpts) { o.discovery = d }
+}
+func withVenueConfig(vc VenueSourceConfigServiceInterface) func(*testPipelineOpts) {
+	return func(o *testPipelineOpts) { o.venueConfig = vc }
+}
+func withVenue(v VenueServiceInterface) func(*testPipelineOpts) {
+	return func(o *testPipelineOpts) { o.venue = v }
+}
+
+// defaultConfig returns a VenueSourceConfig with calendar URL and static render method.
+func defaultConfig() *models.VenueSourceConfig {
+	calURL := "https://example.com/events"
+	rm := "static"
+	return &models.VenueSourceConfig{
+		ID:              1,
+		VenueID:         1,
+		CalendarURL:     &calURL,
+		PreferredSource: "ai",
+		RenderMethod:    &rm,
+	}
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+func TestPipeline_NewPipelineService(t *testing.T) {
+	ps := NewPipelineService(nil, nil, nil, nil, nil)
+	if ps == nil {
+		t.Fatal("expected non-nil PipelineService")
+	}
+}
+
+func TestPipeline_ExtractVenue_Success(t *testing.T) {
+	var recordedRun *models.VenueExtractionRun
+	var updatedHash *string
+
+	ps := newTestPipeline(
+		withVenueConfig(&stubVenueConfig{
+			getByVenueIDFn: func(venueID uint) (*models.VenueSourceConfig, error) {
+				return defaultConfig(), nil
+			},
+			recordRunFn: func(run *models.VenueExtractionRun) error {
+				recordedRun = run
+				return nil
+			},
+			updateAfterRunFn: func(venueID uint, contentHash, etag *string, eventsExtracted int) error {
+				updatedHash = contentHash
+				return nil
+			},
+		}),
+	)
+
+	result, err := ps.ExtractVenue(1, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.VenueID != 1 {
+		t.Errorf("expected venue_id=1, got %d", result.VenueID)
+	}
+	if result.VenueName != "Test Venue" {
+		t.Errorf("expected venue_name=Test Venue, got %s", result.VenueName)
+	}
+	if result.RenderMethod != "static" {
+		t.Errorf("expected render_method=static, got %s", result.RenderMethod)
+	}
+	if result.EventsExtracted != 2 {
+		t.Errorf("expected events_extracted=2, got %d", result.EventsExtracted)
+	}
+	if result.EventsImported != 2 {
+		t.Errorf("expected events_imported=2, got %d", result.EventsImported)
+	}
+	if result.Skipped {
+		t.Error("expected skipped=false")
+	}
+	if result.DryRun {
+		t.Error("expected dry_run=false")
+	}
+	if result.DurationMs < 0 {
+		t.Errorf("expected non-negative duration, got %d", result.DurationMs)
+	}
+
+	// Verify run was recorded
+	if recordedRun == nil {
+		t.Fatal("expected run to be recorded")
+	}
+	if recordedRun.VenueID != 1 {
+		t.Errorf("expected run venue_id=1, got %d", recordedRun.VenueID)
+	}
+	if recordedRun.EventsExtracted != 2 {
+		t.Errorf("expected run events_extracted=2, got %d", recordedRun.EventsExtracted)
+	}
+
+	// Verify config was updated
+	if updatedHash == nil {
+		t.Fatal("expected config to be updated with hash")
+	}
+}
+
+func TestPipeline_ExtractVenue_DryRun(t *testing.T) {
+	importCalled := false
+
+	ps := newTestPipeline(
+		withVenueConfig(&stubVenueConfig{
+			getByVenueIDFn: func(venueID uint) (*models.VenueSourceConfig, error) {
+				return defaultConfig(), nil
+			},
+		}),
+		withDiscovery(&stubDiscovery{
+			importEventsFn: func(events []DiscoveredEvent, dryRun bool, allowUpdates bool) (*ImportResult, error) {
+				importCalled = true
+				return &ImportResult{Total: len(events), Imported: len(events)}, nil
+			},
+		}),
+	)
+
+	result, err := ps.ExtractVenue(1, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if importCalled {
+		t.Error("import should not be called in dry run mode")
+	}
+	if !result.DryRun {
+		t.Error("expected dry_run=true in result")
+	}
+	if result.EventsExtracted != 2 {
+		t.Errorf("expected events_extracted=2, got %d", result.EventsExtracted)
+	}
+	if result.EventsImported != 0 {
+		t.Errorf("expected events_imported=0 in dry run, got %d", result.EventsImported)
+	}
+}
+
+func TestPipeline_ExtractVenue_NoConfig(t *testing.T) {
+	ps := newTestPipeline(
+		withVenueConfig(&stubVenueConfig{
+			getByVenueIDFn: func(venueID uint) (*models.VenueSourceConfig, error) {
+				return nil, nil // no config
+			},
+		}),
+	)
+
+	_, err := ps.ExtractVenue(1, false)
+	if err == nil {
+		t.Fatal("expected error for missing config")
+	}
+	if want := "venue 1 (Test Venue) has no source config"; err.Error() != want {
+		t.Errorf("expected error %q, got %q", want, err.Error())
+	}
+}
+
+func TestPipeline_ExtractVenue_NoCalendarURL(t *testing.T) {
+	ps := newTestPipeline(
+		withVenueConfig(&stubVenueConfig{
+			getByVenueIDFn: func(venueID uint) (*models.VenueSourceConfig, error) {
+				return &models.VenueSourceConfig{
+					ID:      1,
+					VenueID: 1,
+					// CalendarURL is nil
+				}, nil
+			},
+		}),
+	)
+
+	_, err := ps.ExtractVenue(1, false)
+	if err == nil {
+		t.Fatal("expected error for missing calendar URL")
+	}
+	if want := "venue 1 (Test Venue) has no calendar URL configured"; err.Error() != want {
+		t.Errorf("expected error %q, got %q", want, err.Error())
+	}
+}
+
+func TestPipeline_ExtractVenue_EmptyCalendarURL(t *testing.T) {
+	ps := newTestPipeline(
+		withVenueConfig(&stubVenueConfig{
+			getByVenueIDFn: func(venueID uint) (*models.VenueSourceConfig, error) {
+				empty := ""
+				return &models.VenueSourceConfig{
+					ID:          1,
+					VenueID:     1,
+					CalendarURL: &empty,
+				}, nil
+			},
+		}),
+	)
+
+	_, err := ps.ExtractVenue(1, false)
+	if err == nil {
+		t.Fatal("expected error for empty calendar URL")
+	}
+}
+
+func TestPipeline_ExtractVenue_UnchangedPage(t *testing.T) {
+	var recordedRun *models.VenueExtractionRun
+
+	ps := newTestPipeline(
+		withFetcher(&stubFetcher{
+			fetchFn: func(url, lastETag, lastContentHash string) (*FetchResult, error) {
+				return &FetchResult{Changed: false, ContentHash: "same-hash", HTTPStatus: 200}, nil
+			},
+		}),
+		withVenueConfig(&stubVenueConfig{
+			getByVenueIDFn: func(venueID uint) (*models.VenueSourceConfig, error) {
+				return defaultConfig(), nil
+			},
+			recordRunFn: func(run *models.VenueExtractionRun) error {
+				recordedRun = run
+				return nil
+			},
+		}),
+	)
+
+	result, err := ps.ExtractVenue(1, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !result.Skipped {
+		t.Error("expected skipped=true for unchanged page")
+	}
+	if result.SkipReason != "page unchanged (hash match)" {
+		t.Errorf("unexpected skip reason: %s", result.SkipReason)
+	}
+	if result.EventsExtracted != 0 {
+		t.Errorf("expected events_extracted=0, got %d", result.EventsExtracted)
+	}
+
+	// Should still record the run
+	if recordedRun == nil {
+		t.Fatal("expected skipped run to be recorded")
+	}
+}
+
+func TestPipeline_ExtractVenue_AutoDetection(t *testing.T) {
+	detectedMethod := ""
+	var savedConfig *models.VenueSourceConfig
+
+	ps := newTestPipeline(
+		withFetcher(&stubFetcher{
+			detectRenderMethodFn: func(url string) (string, error) {
+				return "dynamic", nil
+			},
+			fetchDynamicFn: func(url string) (*FetchResult, error) {
+				return &FetchResult{Changed: true, Body: "<html>dynamic</html>", ContentHash: "dyn-hash", HTTPStatus: 200}, nil
+			},
+		}),
+		withVenueConfig(&stubVenueConfig{
+			getByVenueIDFn: func(venueID uint) (*models.VenueSourceConfig, error) {
+				calURL := "https://example.com/events"
+				return &models.VenueSourceConfig{
+					ID:              1,
+					VenueID:         1,
+					CalendarURL:     &calURL,
+					PreferredSource: "ai",
+					RenderMethod:    nil, // not set — trigger auto-detect
+				}, nil
+			},
+			createOrUpdateFn: func(config *models.VenueSourceConfig) (*models.VenueSourceConfig, error) {
+				savedConfig = config
+				if config.RenderMethod != nil {
+					detectedMethod = *config.RenderMethod
+				}
+				return config, nil
+			},
+		}),
+	)
+
+	result, err := ps.ExtractVenue(1, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if detectedMethod != "dynamic" {
+		t.Errorf("expected detected method=dynamic, got %s", detectedMethod)
+	}
+	if result.RenderMethod != "dynamic" {
+		t.Errorf("expected result render_method=dynamic, got %s", result.RenderMethod)
+	}
+	if savedConfig == nil {
+		t.Fatal("expected config to be saved with detected render method")
+	}
+}
+
+func TestPipeline_ExtractVenue_AutoDetectionFails(t *testing.T) {
+	var failureRecorded bool
+
+	ps := newTestPipeline(
+		withFetcher(&stubFetcher{
+			detectRenderMethodFn: func(url string) (string, error) {
+				return "", fmt.Errorf("detection error")
+			},
+		}),
+		withVenueConfig(&stubVenueConfig{
+			getByVenueIDFn: func(venueID uint) (*models.VenueSourceConfig, error) {
+				calURL := "https://example.com/events"
+				return &models.VenueSourceConfig{
+					ID:              1,
+					VenueID:         1,
+					CalendarURL:     &calURL,
+					PreferredSource: "ai",
+					RenderMethod:    nil, // trigger auto-detect
+				}, nil
+			},
+			recordRunFn: func(run *models.VenueExtractionRun) error {
+				failureRecorded = run.Error != nil
+				return nil
+			},
+		}),
+	)
+
+	_, err := ps.ExtractVenue(1, false)
+	if err == nil {
+		t.Fatal("expected error from auto-detection failure")
+	}
+	if !failureRecorded {
+		t.Error("expected failure to be recorded")
+	}
+}
+
+func TestPipeline_ExtractVenue_ExtractionFails(t *testing.T) {
+	var failureRecorded bool
+	var failuresIncremented bool
+
+	ps := newTestPipeline(
+		withExtraction(&stubExtraction{
+			extractCalendarPageFn: func(venueName, content, contentType string) (*CalendarExtractionResponse, error) {
+				return nil, fmt.Errorf("AI service unavailable")
+			},
+		}),
+		withVenueConfig(&stubVenueConfig{
+			getByVenueIDFn: func(venueID uint) (*models.VenueSourceConfig, error) {
+				return defaultConfig(), nil
+			},
+			recordRunFn: func(run *models.VenueExtractionRun) error {
+				failureRecorded = run.Error != nil
+				return nil
+			},
+			incrementFailuresFn: func(venueID uint) error {
+				failuresIncremented = true
+				return nil
+			},
+		}),
+	)
+
+	_, err := ps.ExtractVenue(1, false)
+	if err == nil {
+		t.Fatal("expected error from extraction failure")
+	}
+	if !failureRecorded {
+		t.Error("expected failure run to be recorded")
+	}
+	if !failuresIncremented {
+		t.Error("expected consecutive failures to be incremented")
+	}
+}
+
+func TestPipeline_ExtractVenue_ExtractionReturnsError(t *testing.T) {
+	var failuresIncremented bool
+
+	ps := newTestPipeline(
+		withExtraction(&stubExtraction{
+			extractCalendarPageFn: func(venueName, content, contentType string) (*CalendarExtractionResponse, error) {
+				return &CalendarExtractionResponse{
+					Success: false,
+					Error:   "AI service not configured",
+				}, nil
+			},
+		}),
+		withVenueConfig(&stubVenueConfig{
+			getByVenueIDFn: func(venueID uint) (*models.VenueSourceConfig, error) {
+				return defaultConfig(), nil
+			},
+			incrementFailuresFn: func(venueID uint) error {
+				failuresIncremented = true
+				return nil
+			},
+		}),
+	)
+
+	_, err := ps.ExtractVenue(1, false)
+	if err == nil {
+		t.Fatal("expected error when extraction returns success=false")
+	}
+	if !failuresIncremented {
+		t.Error("expected consecutive failures to be incremented")
+	}
+}
+
+func TestPipeline_ExtractVenue_FetchFails(t *testing.T) {
+	var failureRecorded bool
+	var failuresIncremented bool
+
+	ps := newTestPipeline(
+		withFetcher(&stubFetcher{
+			fetchFn: func(url, lastETag, lastContentHash string) (*FetchResult, error) {
+				return nil, fmt.Errorf("HTTP 503 server error")
+			},
+		}),
+		withVenueConfig(&stubVenueConfig{
+			getByVenueIDFn: func(venueID uint) (*models.VenueSourceConfig, error) {
+				return defaultConfig(), nil
+			},
+			recordRunFn: func(run *models.VenueExtractionRun) error {
+				failureRecorded = run.Error != nil
+				return nil
+			},
+			incrementFailuresFn: func(venueID uint) error {
+				failuresIncremented = true
+				return nil
+			},
+		}),
+	)
+
+	_, err := ps.ExtractVenue(1, false)
+	if err == nil {
+		t.Fatal("expected error from fetch failure")
+	}
+	if !failureRecorded {
+		t.Error("expected failure run to be recorded")
+	}
+	if !failuresIncremented {
+		t.Error("expected consecutive failures to be incremented")
+	}
+}
+
+func TestPipeline_ExtractVenue_DynamicRenderMethod(t *testing.T) {
+	var fetchedDynamic bool
+
+	ps := newTestPipeline(
+		withFetcher(&stubFetcher{
+			fetchDynamicFn: func(url string) (*FetchResult, error) {
+				fetchedDynamic = true
+				return &FetchResult{Changed: true, Body: "<html>dynamic</html>", ContentHash: "dyn-hash", HTTPStatus: 200}, nil
+			},
+		}),
+		withVenueConfig(&stubVenueConfig{
+			getByVenueIDFn: func(venueID uint) (*models.VenueSourceConfig, error) {
+				calURL := "https://example.com/events"
+				rm := "dynamic"
+				return &models.VenueSourceConfig{
+					ID:              1,
+					VenueID:         1,
+					CalendarURL:     &calURL,
+					PreferredSource: "ai",
+					RenderMethod:    &rm,
+				}, nil
+			},
+		}),
+	)
+
+	result, err := ps.ExtractVenue(1, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !fetchedDynamic {
+		t.Error("expected FetchDynamic to be called")
+	}
+	if result.RenderMethod != "dynamic" {
+		t.Errorf("expected render_method=dynamic, got %s", result.RenderMethod)
+	}
+}
+
+func TestPipeline_ExtractVenue_ScreenshotRenderMethod(t *testing.T) {
+	var fetchedScreenshot bool
+	var extractionContentType string
+
+	ps := newTestPipeline(
+		withFetcher(&stubFetcher{
+			fetchScreenshotFn: func(url string) (*FetchResult, error) {
+				fetchedScreenshot = true
+				return &FetchResult{Changed: true, Body: "base64data", ContentHash: "ss-hash", HTTPStatus: 200, ContentType: "image/png"}, nil
+			},
+		}),
+		withExtraction(&stubExtraction{
+			extractCalendarPageFn: func(venueName, content, contentType string) (*CalendarExtractionResponse, error) {
+				extractionContentType = contentType
+				return &CalendarExtractionResponse{
+					Success: true,
+					Events:  []CalendarEvent{{Date: "2026-04-01", Title: "Test"}},
+				}, nil
+			},
+		}),
+		withVenueConfig(&stubVenueConfig{
+			getByVenueIDFn: func(venueID uint) (*models.VenueSourceConfig, error) {
+				calURL := "https://example.com/events"
+				rm := "screenshot"
+				return &models.VenueSourceConfig{
+					ID:              1,
+					VenueID:         1,
+					CalendarURL:     &calURL,
+					PreferredSource: "ai",
+					RenderMethod:    &rm,
+				}, nil
+			},
+		}),
+	)
+
+	result, err := ps.ExtractVenue(1, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !fetchedScreenshot {
+		t.Error("expected FetchScreenshot to be called")
+	}
+	if extractionContentType != "image" {
+		t.Errorf("expected extraction content_type=image, got %s", extractionContentType)
+	}
+	if result.RenderMethod != "screenshot" {
+		t.Errorf("expected render_method=screenshot, got %s", result.RenderMethod)
+	}
+}
+
+func TestPipeline_ExtractVenue_VenueNotFound(t *testing.T) {
+	ps := newTestPipeline(
+		withVenue(&stubVenueService{
+			getVenueModelFn: func(venueID uint) (*models.Venue, error) {
+				return nil, fmt.Errorf("venue not found")
+			},
+		}),
+	)
+
+	_, err := ps.ExtractVenue(999, false)
+	if err == nil {
+		t.Fatal("expected error for venue not found")
+	}
+}
+
+func TestPipeline_ExtractVenue_UnknownRenderMethod(t *testing.T) {
+	var failuresIncremented bool
+
+	ps := newTestPipeline(
+		withVenueConfig(&stubVenueConfig{
+			getByVenueIDFn: func(venueID uint) (*models.VenueSourceConfig, error) {
+				calURL := "https://example.com/events"
+				rm := "unknown_method"
+				return &models.VenueSourceConfig{
+					ID:              1,
+					VenueID:         1,
+					CalendarURL:     &calURL,
+					PreferredSource: "ai",
+					RenderMethod:    &rm,
+				}, nil
+			},
+			incrementFailuresFn: func(venueID uint) error {
+				failuresIncremented = true
+				return nil
+			},
+		}),
+	)
+
+	_, err := ps.ExtractVenue(1, false)
+	if err == nil {
+		t.Fatal("expected error for unknown render method")
+	}
+	if !failuresIncremented {
+		t.Error("expected failures to be incremented for unknown render method")
+	}
+}
+
+func TestPipeline_ExtractVenue_ImportFails_NonFatal(t *testing.T) {
+	// Import failure should NOT cause the pipeline to error — extraction still succeeded
+	ps := newTestPipeline(
+		withDiscovery(&stubDiscovery{
+			importEventsFn: func(events []DiscoveredEvent, dryRun bool, allowUpdates bool) (*ImportResult, error) {
+				return nil, fmt.Errorf("database error")
+			},
+		}),
+		withVenueConfig(&stubVenueConfig{
+			getByVenueIDFn: func(venueID uint) (*models.VenueSourceConfig, error) {
+				return defaultConfig(), nil
+			},
+		}),
+	)
+
+	result, err := ps.ExtractVenue(1, false)
+	if err != nil {
+		t.Fatalf("import failure should be non-fatal, got: %v", err)
+	}
+	if result.EventsExtracted != 2 {
+		t.Errorf("expected events_extracted=2, got %d", result.EventsExtracted)
+	}
+	if result.EventsImported != 0 {
+		t.Errorf("expected events_imported=0 after import failure, got %d", result.EventsImported)
+	}
+}
+
+func TestPipeline_ExtractVenue_NoEventsExtracted(t *testing.T) {
+	ps := newTestPipeline(
+		withExtraction(&stubExtraction{
+			extractCalendarPageFn: func(venueName, content, contentType string) (*CalendarExtractionResponse, error) {
+				return &CalendarExtractionResponse{
+					Success:  true,
+					Events:   []CalendarEvent{},
+					Warnings: []string{"No events were found on the calendar page"},
+				}, nil
+			},
+		}),
+		withVenueConfig(&stubVenueConfig{
+			getByVenueIDFn: func(venueID uint) (*models.VenueSourceConfig, error) {
+				return defaultConfig(), nil
+			},
+		}),
+	)
+
+	result, err := ps.ExtractVenue(1, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.EventsExtracted != 0 {
+		t.Errorf("expected events_extracted=0, got %d", result.EventsExtracted)
+	}
+	if len(result.Warnings) == 0 {
+		t.Error("expected warnings to be propagated")
+	}
+}
+
+func TestPipeline_ExtractVenue_DynamicAlwaysProceeds(t *testing.T) {
+	// Even when Changed=false (shouldn't happen for dynamic, but test the logic),
+	// dynamic should still proceed because we only check Changed for static.
+	ps := newTestPipeline(
+		withFetcher(&stubFetcher{
+			fetchDynamicFn: func(url string) (*FetchResult, error) {
+				return &FetchResult{Changed: false, Body: "<html>dynamic</html>", ContentHash: "dyn-hash", HTTPStatus: 200}, nil
+			},
+		}),
+		withVenueConfig(&stubVenueConfig{
+			getByVenueIDFn: func(venueID uint) (*models.VenueSourceConfig, error) {
+				calURL := "https://example.com/events"
+				rm := "dynamic"
+				return &models.VenueSourceConfig{
+					ID:              1,
+					VenueID:         1,
+					CalendarURL:     &calURL,
+					PreferredSource: "ai",
+					RenderMethod:    &rm,
+				}, nil
+			},
+		}),
+	)
+
+	result, err := ps.ExtractVenue(1, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Skipped {
+		t.Error("dynamic fetch should not be skipped even if Changed=false")
+	}
+	if result.EventsExtracted != 2 {
+		t.Errorf("expected events_extracted=2, got %d", result.EventsExtracted)
+	}
+}
+
+// ============================================================================
+// Helper function unit tests
+// ============================================================================
+
+func TestPipeline_StrPtrIfNonEmpty(t *testing.T) {
+	if strPtrIfNonEmpty("") != nil {
+		t.Error("expected nil for empty string")
+	}
+	p := strPtrIfNonEmpty("test")
+	if p == nil || *p != "test" {
+		t.Error("expected pointer to 'test'")
+	}
+}
+
+func TestPipeline_IntPtrIfNonZero(t *testing.T) {
+	if intPtrIfNonZero(0) != nil {
+		t.Error("expected nil for zero")
+	}
+	p := intPtrIfNonZero(42)
+	if p == nil || *p != 42 {
+		t.Error("expected pointer to 42")
+	}
+}


### PR DESCRIPTION
## Summary
The final piece of PSY-32 — ties together fetcher, AI extraction, and import into an end-to-end pipeline with admin endpoints.

### PipelineService (`pipeline.go`)
- `ExtractVenue(venueID, dryRun)` orchestrates the full flow:
  1. Load venue + source config
  2. Auto-detect render method on first run (static/dynamic/screenshot)
  3. Fetch page using appropriate tier
  4. Skip if unchanged (hash-based change detection for static)
  5. Send to Claude for calendar extraction
  6. Convert events and import via DiscoveryService (dedup + auto-approve)
  7. Record run in `venue_extraction_runs`
  8. Update source config (hash, etag, events_expected rolling average)
- Import failures are non-fatal (logged, not returned as errors)
- All side-effects (run recording, failure tracking) are fire-and-forget

### Admin endpoints (`handlers/pipeline.go`)
- `POST /admin/pipeline/extract/{venue_id}` — trigger extraction, `?dry_run=true` for preview
- `GET /admin/pipeline/venues` — list configured venues with last run status

### Test coverage
- 20 service unit tests with full dependency stubs
- 10 handler unit tests (admin guard, success paths, error paths)

## Test plan
- [x] 20 pipeline service tests: success, dry run, no config, no URL, unchanged page, auto-detection, extraction/fetch failures, all 3 render methods, import failure (non-fatal), no events, venue not found
- [x] 10 handler tests: admin auth guard (4), extract success/dry_run/invalid_id/service_error, list success/empty/error
- [x] `go build ./...` passes
- [x] All 30 tests pass

Closes PSY-79

🤖 Generated with [Claude Code](https://claude.com/claude-code)