### PR TITLE
Wire auto_approve into pipeline import with non-music filtering (PSY-80)

### DIFF
--- a/backend/db/migrations/000044_auto_approve_default_false.down.sql
+++ b/backend/db/migrations/000044_auto_approve_default_false.down.sql
@@ -1,0 +1,2 @@
+-- Revert auto_approve default back to true.
+ALTER TABLE venue_source_configs ALTER COLUMN auto_approve SET DEFAULT true;

--- a/backend/db/migrations/000044_auto_approve_default_false.up.sql
+++ b/backend/db/migrations/000044_auto_approve_default_false.up.sql
@@ -1,0 +1,6 @@
+-- Change auto_approve default from true to false for new venue source configs.
+-- Pipeline-imported shows should default to pending for admin review.
+ALTER TABLE venue_source_configs ALTER COLUMN auto_approve SET DEFAULT false;
+
+-- Update existing rows to false (no venues should auto-approve until explicitly enabled).
+UPDATE venue_source_configs SET auto_approve = false WHERE auto_approve = true;

--- a/backend/internal/api/handlers/admin.go
+++ b/backend/internal/api/handlers/admin.go
@@ -1345,7 +1345,7 @@ func (h *AdminHandler) DiscoveryImportHandler(ctx context.Context, req *Discover
 	}
 
 	// Import events
-	result, err := h.discoveryService.ImportEvents(events, req.Body.DryRun, req.Body.AllowUpdates)
+	result, err := h.discoveryService.ImportEvents(events, req.Body.DryRun, req.Body.AllowUpdates, models.ShowStatusApproved)
 	if err != nil {
 		logger.FromContext(ctx).Error("admin_discovery_import_failed",
 			"error", err.Error(),

--- a/backend/internal/api/handlers/admin_test.go
+++ b/backend/internal/api/handlers/admin_test.go
@@ -1037,7 +1037,7 @@ func TestDataImportHandler_ServiceError(t *testing.T) {
 func TestDiscoveryImportHandler_Success(t *testing.T) {
 	h := adminHandler(func(ah *AdminHandler) {
 		ah.discoveryService = &mockDiscoveryService{
-			importEventsFn: func(events []services.DiscoveredEvent, dryRun, allowUpdates bool) (*services.ImportResult, error) {
+			importEventsFn: func(events []services.DiscoveredEvent, dryRun, allowUpdates bool, initialStatus models.ShowStatus) (*services.ImportResult, error) {
 				return &services.ImportResult{Total: len(events), Imported: len(events)}, nil
 			},
 		}
@@ -1056,7 +1056,7 @@ func TestDiscoveryImportHandler_Success(t *testing.T) {
 func TestDiscoveryImportHandler_ServiceError(t *testing.T) {
 	h := adminHandler(func(ah *AdminHandler) {
 		ah.discoveryService = &mockDiscoveryService{
-			importEventsFn: func(_ []services.DiscoveredEvent, _, _ bool) (*services.ImportResult, error) {
+			importEventsFn: func(_ []services.DiscoveredEvent, _, _ bool, _ models.ShowStatus) (*services.ImportResult, error) {
 				return nil, fmt.Errorf("import failed")
 			},
 		}

--- a/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
+++ b/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
@@ -1024,7 +1024,7 @@ type mockDiscoveryService struct {
 	importFromJSONFn       func(filepath string, dryRun bool) (*services.ImportResult, error)
 	importFromJSONWithDBFn func(filepath string, dryRun bool, database *gorm.DB) (*services.ImportResult, error)
 	checkEventsFn          func(events []services.CheckEventInput) (*services.CheckEventsResult, error)
-	importEventsFn         func(events []services.DiscoveredEvent, dryRun bool, allowUpdates bool) (*services.ImportResult, error)
+	importEventsFn         func(events []services.DiscoveredEvent, dryRun bool, allowUpdates bool, initialStatus models.ShowStatus) (*services.ImportResult, error)
 }
 
 func (m *mockDiscoveryService) ImportFromJSON(filepath string, dryRun bool) (*services.ImportResult, error) {
@@ -1045,9 +1045,9 @@ func (m *mockDiscoveryService) CheckEvents(events []services.CheckEventInput) (*
 	}
 	return nil, nil
 }
-func (m *mockDiscoveryService) ImportEvents(events []services.DiscoveredEvent, dryRun bool, allowUpdates bool) (*services.ImportResult, error) {
+func (m *mockDiscoveryService) ImportEvents(events []services.DiscoveredEvent, dryRun bool, allowUpdates bool, initialStatus models.ShowStatus) (*services.ImportResult, error) {
 	if m.importEventsFn != nil {
-		return m.importEventsFn(events, dryRun, allowUpdates)
+		return m.importEventsFn(events, dryRun, allowUpdates, initialStatus)
 	}
 	return nil, nil
 }

--- a/backend/internal/models/venue_source_config.go
+++ b/backend/internal/models/venue_source_config.go
@@ -16,7 +16,7 @@ type VenueSourceConfig struct {
 	EventsExpected      int        `json:"events_expected" gorm:"column:events_expected;not null;default:0"`
 	ConsecutiveFailures int        `json:"consecutive_failures" gorm:"column:consecutive_failures;not null;default:0"`
 	StrategyLocked      bool       `json:"strategy_locked" gorm:"column:strategy_locked;not null;default:false"`
-	AutoApprove         bool       `json:"auto_approve" gorm:"column:auto_approve;not null;default:true"`
+	AutoApprove         bool       `json:"auto_approve" gorm:"column:auto_approve;not null;default:false"`
 	CreatedAt           time.Time  `json:"created_at"`
 	UpdatedAt           time.Time  `json:"updated_at"`
 

--- a/backend/internal/services/discovery.go
+++ b/backend/internal/services/discovery.go
@@ -165,7 +165,7 @@ func (s *DiscoveryService) ImportFromJSON(filepath string, dryRun bool) (*Import
 	}
 
 	for _, event := range events {
-		msg, status := s.importEvent(&event, dryRun, false)
+		msg, status := s.importEvent(&event, dryRun, false, models.ShowStatusApproved)
 		result.Messages = append(result.Messages, msg)
 
 		switch status {
@@ -212,7 +212,7 @@ func (s *DiscoveryService) checkHeadlinerDuplicate(headlinerName, venueName stri
 
 // importEvent imports a single scraped event
 // Returns a message and status ("imported", "duplicate", "rejected", "updated", "error")
-func (s *DiscoveryService) importEvent(event *DiscoveredEvent, dryRun bool, allowUpdates bool) (string, string) {
+func (s *DiscoveryService) importEvent(event *DiscoveredEvent, dryRun bool, allowUpdates bool, initialStatus models.ShowStatus) (string, string) {
 	// Validate required fields
 	if event.ID == "" || event.VenueSlug == "" {
 		return fmt.Sprintf("SKIP: Missing required fields (id=%s, venueSlug=%s)", event.ID, event.VenueSlug), "error"
@@ -275,7 +275,7 @@ func (s *DiscoveryService) importEvent(event *DiscoveredEvent, dryRun bool, allo
 	}
 
 	// Create the show
-	err = s.createShowFromEvent(event, eventDate, venueConfig, duplicateOfShowID)
+	err = s.createShowFromEvent(event, eventDate, venueConfig, duplicateOfShowID, initialStatus)
 	if err != nil {
 		return fmt.Sprintf("ERROR: Failed to create show: %v", err), "error"
 	}
@@ -293,7 +293,7 @@ func (s *DiscoveryService) createShowFromEvent(event *DiscoveredEvent, eventDate
 	City    string
 	State   string
 	Address string
-}, duplicateOfShowID *uint) error {
+}, duplicateOfShowID *uint, initialStatus models.ShowStatus) error {
 	return s.db.Transaction(func(tx *gorm.DB) error {
 		// Parse scraped_at timestamp
 		scrapedAt, err := time.Parse(time.RFC3339, event.ScrapedAt)
@@ -318,8 +318,8 @@ func (s *DiscoveryService) createShowFromEvent(event *DiscoveredEvent, eventDate
 			description = &desc
 		}
 
-		// Create the show
-		status := models.ShowStatusApproved
+		// Create the show — use initialStatus, but always override to pending for potential duplicates
+		status := initialStatus
 		if duplicateOfShowID != nil {
 			status = models.ShowStatusPending
 		}
@@ -803,7 +803,7 @@ func (s *DiscoveryService) buildCheckEventStatus(show models.Show) CheckEventSta
 
 // ImportEvents imports events from an array of DiscoveredEvent objects
 // This is used by the HTTP API endpoint for importing scraped data directly
-func (s *DiscoveryService) ImportEvents(events []DiscoveredEvent, dryRun bool, allowUpdates bool) (*ImportResult, error) {
+func (s *DiscoveryService) ImportEvents(events []DiscoveredEvent, dryRun bool, allowUpdates bool, initialStatus models.ShowStatus) (*ImportResult, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
@@ -814,7 +814,7 @@ func (s *DiscoveryService) ImportEvents(events []DiscoveredEvent, dryRun bool, a
 	}
 
 	for _, event := range events {
-		msg, status := s.importEvent(&event, dryRun, allowUpdates)
+		msg, status := s.importEvent(&event, dryRun, allowUpdates, initialStatus)
 		result.Messages = append(result.Messages, msg)
 
 		switch status {

--- a/backend/internal/services/discovery_test.go
+++ b/backend/internal/services/discovery_test.go
@@ -259,7 +259,7 @@ func TestNewDiscoveryService(t *testing.T) {
 
 func TestImportEvents_NilDB(t *testing.T) {
 	svc := &DiscoveryService{db: nil}
-	result, err := svc.ImportEvents([]DiscoveredEvent{}, false, false)
+	result, err := svc.ImportEvents([]DiscoveredEvent{}, false, false, models.ShowStatusApproved)
 	assert.Error(t, err)
 	assert.Equal(t, "database not initialized", err.Error())
 	assert.Nil(t, result)
@@ -382,7 +382,7 @@ func (suite *DiscoveryIntegrationTestSuite) TestImportEvents_Success() {
 		suite.makeEvent("evt-001", "The National", "valley-bar", "2026-06-15", []string{"The National"}),
 	}
 
-	result, err := suite.svc.ImportEvents(events, false, false)
+	result, err := suite.svc.ImportEvents(events, false, false, models.ShowStatusApproved)
 	suite.Require().NoError(err)
 	suite.Equal(1, result.Total)
 	suite.Equal(1, result.Imported)
@@ -405,12 +405,12 @@ func (suite *DiscoveryIntegrationTestSuite) TestImportEvents_SourceDuplicate() {
 	}
 
 	// First import
-	result1, err := suite.svc.ImportEvents(events, false, false)
+	result1, err := suite.svc.ImportEvents(events, false, false, models.ShowStatusApproved)
 	suite.Require().NoError(err)
 	suite.Equal(1, result1.Imported)
 
 	// Second import — same source_venue + source_event_id
-	result2, err := suite.svc.ImportEvents(events, false, false)
+	result2, err := suite.svc.ImportEvents(events, false, false, models.ShowStatusApproved)
 	suite.Require().NoError(err)
 	suite.Equal(0, result2.Imported)
 	suite.Equal(1, result2.Duplicates)
@@ -421,7 +421,7 @@ func (suite *DiscoveryIntegrationTestSuite) TestImportEvents_UnknownVenue() {
 		suite.makeEvent("evt-003", "Test Band", "unknown-venue-xyz", "2026-08-01", []string{"Test Band"}),
 	}
 
-	result, err := suite.svc.ImportEvents(events, false, false)
+	result, err := suite.svc.ImportEvents(events, false, false, models.ShowStatusApproved)
 	suite.Require().NoError(err)
 	suite.Equal(1, result.Errors)
 	suite.Contains(result.Messages[0], "Unknown venue slug")
@@ -432,7 +432,7 @@ func (suite *DiscoveryIntegrationTestSuite) TestImportEvents_HeadlinerDuplicate(
 	events1 := []DiscoveredEvent{
 		suite.makeEvent("evt-004a", "Bon Iver", "valley-bar", "2026-09-01", []string{"Bon Iver"}),
 	}
-	result1, err := suite.svc.ImportEvents(events1, false, false)
+	result1, err := suite.svc.ImportEvents(events1, false, false, models.ShowStatusApproved)
 	suite.Require().NoError(err)
 	suite.Equal(1, result1.Imported)
 
@@ -441,7 +441,7 @@ func (suite *DiscoveryIntegrationTestSuite) TestImportEvents_HeadlinerDuplicate(
 	events2 := []DiscoveredEvent{
 		suite.makeEvent("evt-004b", "Bon Iver (Late Show)", "valley-bar", "2026-09-01", []string{"Bon Iver"}),
 	}
-	result2, err := suite.svc.ImportEvents(events2, false, false)
+	result2, err := suite.svc.ImportEvents(events2, false, false, models.ShowStatusApproved)
 	suite.Require().NoError(err)
 	suite.Equal(1, result2.PendingReview)
 
@@ -477,7 +477,7 @@ func (suite *DiscoveryIntegrationTestSuite) TestImportEvents_RejectedShowSkipped
 		suite.makeEvent("evt-005", "Some New Band", "valley-bar", "2026-10-01", []string{"Some New Band"}),
 	}
 
-	result, err := suite.svc.ImportEvents(events, false, false)
+	result, err := suite.svc.ImportEvents(events, false, false, models.ShowStatusApproved)
 	suite.Require().NoError(err)
 	suite.Equal(1, result.Rejected)
 	suite.Contains(result.Messages[0], "REJECTED")
@@ -488,7 +488,7 @@ func (suite *DiscoveryIntegrationTestSuite) TestImportEvents_DryRun() {
 		suite.makeEvent("evt-006", "Dry Run Band", "valley-bar", "2026-11-01", []string{"Dry Run Band"}),
 	}
 
-	result, err := suite.svc.ImportEvents(events, true, false)
+	result, err := suite.svc.ImportEvents(events, true, false, models.ShowStatusApproved)
 	suite.Require().NoError(err)
 	suite.Equal(1, result.Total)
 	// In dry run, nothing is actually imported but message says "WOULD IMPORT"
@@ -500,6 +500,22 @@ func (suite *DiscoveryIntegrationTestSuite) TestImportEvents_DryRun() {
 	suite.Zero(count)
 }
 
+func (suite *DiscoveryIntegrationTestSuite) TestImportEvents_PendingStatus() {
+	events := []DiscoveredEvent{
+		suite.makeEvent("evt-pending-1", "Pending Band", "valley-bar", "2026-11-15", []string{"Pending Band"}),
+	}
+
+	result, err := suite.svc.ImportEvents(events, false, false, models.ShowStatusPending)
+	suite.Require().NoError(err)
+	suite.Equal(1, result.Imported)
+
+	// Verify show was created with pending status
+	var show models.Show
+	err = suite.db.Where("source_event_id = ?", "evt-pending-1").First(&show).Error
+	suite.Require().NoError(err)
+	suite.Equal(models.ShowStatusPending, show.Status)
+}
+
 // =============================================================================
 // CheckEvents tests
 // =============================================================================
@@ -509,7 +525,7 @@ func (suite *DiscoveryIntegrationTestSuite) TestCheckEvents_Found() {
 	events := []DiscoveredEvent{
 		suite.makeEvent("evt-check-1", "Check Band", "valley-bar", "2026-12-01", []string{"Check Band"}),
 	}
-	_, err := suite.svc.ImportEvents(events, false, false)
+	_, err := suite.svc.ImportEvents(events, false, false, models.ShowStatusApproved)
 	suite.Require().NoError(err)
 
 	// Check it

--- a/backend/internal/services/extraction_calendar.go
+++ b/backend/internal/services/extraction_calendar.go
@@ -25,12 +25,14 @@ Output ONLY a valid JSON array with no additional text, markdown formatting, or 
     ],
     "cost": "$20",
     "ages": "21+",
-    "ticket_url": "https://..."
+    "ticket_url": "https://...",
+    "is_music_event": true
   }
 ]
 
 Rules:
 - Extract EVERY event visible on the page — do not skip any
+- Set is_music_event to false for non-music events like karaoke nights, trivia, comedy shows, open mic (non-music), DJ nights without named artists, private events, and venue closures. Set to true for concerts, live music, album release shows, and music festivals. Default to true if uncertain
 - Convert dates to YYYY-MM-DD format. If only a month/year header is shown, combine with day numbers
 - Convert times to 24-hour HH:MM format. If "doors" and "show" times are both listed, use the show time. Default to 20:00 if only doors time is given
 - The first or most prominent artist listed for an event is the headliner (is_headliner: true), others are is_headliner: false
@@ -47,13 +49,14 @@ Rules:
 
 // CalendarEvent represents a single event extracted from a venue calendar page.
 type CalendarEvent struct {
-	Date      string           `json:"date"`
-	Time      *string          `json:"time,omitempty"`
-	Title     string           `json:"title"`
-	Artists   []CalendarArtist `json:"artists"`
-	Cost      *string          `json:"cost,omitempty"`
-	Ages      *string          `json:"ages,omitempty"`
-	TicketURL *string          `json:"ticket_url,omitempty"`
+	Date         string           `json:"date"`
+	Time         *string          `json:"time,omitempty"`
+	Title        string           `json:"title"`
+	Artists      []CalendarArtist `json:"artists"`
+	Cost         *string          `json:"cost,omitempty"`
+	Ages         *string          `json:"ages,omitempty"`
+	TicketURL    *string          `json:"ticket_url,omitempty"`
+	IsMusicEvent *bool            `json:"is_music_event,omitempty"`
 }
 
 // CalendarArtist represents an artist entry within a calendar event.

--- a/backend/internal/services/interfaces.go
+++ b/backend/internal/services/interfaces.go
@@ -287,7 +287,7 @@ type DiscoveryServiceInterface interface {
 	ImportFromJSON(filepath string, dryRun bool) (*ImportResult, error)
 	ImportFromJSONWithDB(filepath string, dryRun bool, database *gorm.DB) (*ImportResult, error)
 	CheckEvents(events []CheckEventInput) (*CheckEventsResult, error)
-	ImportEvents(events []DiscoveredEvent, dryRun bool, allowUpdates bool) (*ImportResult, error)
+	ImportEvents(events []DiscoveredEvent, dryRun bool, allowUpdates bool, initialStatus models.ShowStatus) (*ImportResult, error)
 }
 
 // APITokenServiceInterface defines the contract for API token operations.

--- a/backend/internal/services/pipeline.go
+++ b/backend/internal/services/pipeline.go
@@ -37,17 +37,19 @@ func NewPipelineService(
 
 // PipelineResult contains the outcome of a single venue extraction run.
 type PipelineResult struct {
-	VenueID         uint     `json:"venue_id"`
-	VenueName       string   `json:"venue_name"`
-	RenderMethod    string   `json:"render_method"`
-	EventsExtracted int      `json:"events_extracted"`
-	EventsImported  int      `json:"events_imported"`
-	DurationMs      int64    `json:"duration_ms"`
-	Skipped         bool     `json:"skipped"`
-	SkipReason      string   `json:"skip_reason,omitempty"`
-	Error           string   `json:"error,omitempty"`
-	Warnings        []string `json:"warnings,omitempty"`
-	DryRun          bool     `json:"dry_run"`
+	VenueID              uint     `json:"venue_id"`
+	VenueName            string   `json:"venue_name"`
+	RenderMethod         string   `json:"render_method"`
+	EventsExtracted      int      `json:"events_extracted"`
+	EventsImported       int      `json:"events_imported"`
+	EventsSkippedNonMusic int     `json:"events_skipped_non_music"`
+	DurationMs           int64    `json:"duration_ms"`
+	Skipped              bool     `json:"skipped"`
+	SkipReason           string   `json:"skip_reason,omitempty"`
+	Error                string   `json:"error,omitempty"`
+	Warnings             []string `json:"warnings,omitempty"`
+	DryRun               bool     `json:"dry_run"`
+	InitialStatus        string   `json:"initial_status"`
 }
 
 // ExtractVenue runs the full extraction pipeline for a single venue.
@@ -134,6 +136,7 @@ func (s *PipelineService) ExtractVenue(venueID uint, dryRun bool) (*PipelineResu
 			SkipReason:   "page unchanged (hash match)",
 			DurationMs:   time.Since(start).Milliseconds(),
 			DryRun:       dryRun,
+			InitialStatus: string(models.ShowStatusPending),
 		}
 		s.recordRun(venueID, renderMethod, config.PreferredSource, 0, 0, &fetchResult.ContentHash, fetchResult.HTTPStatus, start, nil)
 		return result, nil
@@ -166,17 +169,30 @@ func (s *PipelineService) ExtractVenue(venueID uint, dryRun bool) (*PipelineResu
 
 	eventsExtracted := len(extractionResp.Events)
 
-	// 9. Convert to DiscoveredEvent format
+	// 9. Filter out non-music events
+	musicEvents := filterMusicEvents(extractionResp.Events)
+	eventsSkippedNonMusic := eventsExtracted - len(musicEvents)
+	if eventsSkippedNonMusic > 0 {
+		log.Printf("venue %d: filtered %d non-music events out of %d total", venueID, eventsSkippedNonMusic, eventsExtracted)
+	}
+
+	// 10. Convert to DiscoveredEvent format
 	venueSlug := ""
 	if venue.Slug != nil {
 		venueSlug = *venue.Slug
 	}
-	discoveredEvents := CalendarEventsToDiscoveredEvents(venueSlug, extractionResp.Events)
+	discoveredEvents := CalendarEventsToDiscoveredEvents(venueSlug, musicEvents)
 
-	// 10. Import events (unless dry run)
+	// 11. Determine initial status based on auto_approve
+	initialStatus := models.ShowStatusPending
+	if config.AutoApprove {
+		initialStatus = models.ShowStatusApproved
+	}
+
+	// 12. Import events (unless dry run)
 	eventsImported := 0
 	if !dryRun && len(discoveredEvents) > 0 {
-		importResult, importErr := s.discovery.ImportEvents(discoveredEvents, false, false)
+		importResult, importErr := s.discovery.ImportEvents(discoveredEvents, false, false, initialStatus)
 		if importErr != nil {
 			log.Printf("warning: import failed for venue %d: %v (extraction succeeded with %d events)", venueID, importErr, eventsExtracted)
 		} else {
@@ -186,24 +202,39 @@ func (s *PipelineService) ExtractVenue(venueID uint, dryRun bool) (*PipelineResu
 
 	duration := time.Since(start)
 
-	// 11. Record run
+	// 13. Record run
 	s.recordRun(venueID, renderMethod, config.PreferredSource, eventsExtracted, eventsImported, &fetchResult.ContentHash, fetchResult.HTTPStatus, start, nil)
 
-	// 12. Update config after successful run
+	// 14. Update config after successful run
 	if updateErr := s.venueConfig.UpdateAfterRun(venueID, &fetchResult.ContentHash, &fetchResult.ETag, eventsExtracted); updateErr != nil {
 		log.Printf("warning: failed to update config after run for venue %d: %v", venueID, updateErr)
 	}
 
 	return &PipelineResult{
-		VenueID:         venueID,
-		VenueName:       venue.Name,
-		RenderMethod:    renderMethod,
-		EventsExtracted: eventsExtracted,
-		EventsImported:  eventsImported,
-		DurationMs:      duration.Milliseconds(),
-		Warnings:        extractionResp.Warnings,
-		DryRun:          dryRun,
+		VenueID:               venueID,
+		VenueName:             venue.Name,
+		RenderMethod:          renderMethod,
+		EventsExtracted:       eventsExtracted,
+		EventsImported:        eventsImported,
+		EventsSkippedNonMusic: eventsSkippedNonMusic,
+		DurationMs:            duration.Milliseconds(),
+		Warnings:              extractionResp.Warnings,
+		DryRun:                dryRun,
+		InitialStatus:         string(initialStatus),
 	}, nil
+}
+
+// filterMusicEvents returns only events where IsMusicEvent is not explicitly false.
+// Events with IsMusicEvent=nil or IsMusicEvent=true are included.
+func filterMusicEvents(events []CalendarEvent) []CalendarEvent {
+	var filtered []CalendarEvent
+	for _, e := range events {
+		if e.IsMusicEvent != nil && !*e.IsMusicEvent {
+			continue
+		}
+		filtered = append(filtered, e)
+	}
+	return filtered
 }
 
 // recordRun persists an extraction run record (fire-and-forget).

--- a/backend/internal/services/pipeline_test.go
+++ b/backend/internal/services/pipeline_test.go
@@ -66,7 +66,7 @@ func (s *stubExtraction) ExtractCalendarPage(venueName, content, contentType str
 }
 
 type stubDiscovery struct {
-	importEventsFn func(events []DiscoveredEvent, dryRun bool, allowUpdates bool) (*ImportResult, error)
+	importEventsFn func(events []DiscoveredEvent, dryRun bool, allowUpdates bool, initialStatus models.ShowStatus) (*ImportResult, error)
 }
 
 func (s *stubDiscovery) ImportFromJSON(filepath string, dryRun bool) (*ImportResult, error) {
@@ -78,9 +78,9 @@ func (s *stubDiscovery) ImportFromJSONWithDB(filepath string, dryRun bool, datab
 func (s *stubDiscovery) CheckEvents(events []CheckEventInput) (*CheckEventsResult, error) {
 	return nil, fmt.Errorf("not implemented in stub")
 }
-func (s *stubDiscovery) ImportEvents(events []DiscoveredEvent, dryRun bool, allowUpdates bool) (*ImportResult, error) {
+func (s *stubDiscovery) ImportEvents(events []DiscoveredEvent, dryRun bool, allowUpdates bool, initialStatus models.ShowStatus) (*ImportResult, error) {
 	if s.importEventsFn != nil {
-		return s.importEventsFn(events, dryRun, allowUpdates)
+		return s.importEventsFn(events, dryRun, allowUpdates, initialStatus)
 	}
 	return &ImportResult{Total: len(events), Imported: len(events)}, nil
 }
@@ -355,7 +355,7 @@ func TestPipeline_ExtractVenue_DryRun(t *testing.T) {
 			},
 		}),
 		withDiscovery(&stubDiscovery{
-			importEventsFn: func(events []DiscoveredEvent, dryRun bool, allowUpdates bool) (*ImportResult, error) {
+			importEventsFn: func(events []DiscoveredEvent, dryRun bool, allowUpdates bool, initialStatus models.ShowStatus) (*ImportResult, error) {
 				importCalled = true
 				return &ImportResult{Total: len(events), Imported: len(events)}, nil
 			},
@@ -812,7 +812,7 @@ func TestPipeline_ExtractVenue_ImportFails_NonFatal(t *testing.T) {
 	// Import failure should NOT cause the pipeline to error — extraction still succeeded
 	ps := newTestPipeline(
 		withDiscovery(&stubDiscovery{
-			importEventsFn: func(events []DiscoveredEvent, dryRun bool, allowUpdates bool) (*ImportResult, error) {
+			importEventsFn: func(events []DiscoveredEvent, dryRun bool, allowUpdates bool, initialStatus models.ShowStatus) (*ImportResult, error) {
 				return nil, fmt.Errorf("database error")
 			},
 		}),
@@ -922,5 +922,171 @@ func TestPipeline_IntPtrIfNonZero(t *testing.T) {
 	p := intPtrIfNonZero(42)
 	if p == nil || *p != 42 {
 		t.Error("expected pointer to 42")
+	}
+}
+
+// ============================================================================
+// PSY-80: auto_approve + non-music filtering tests
+// ============================================================================
+
+func TestPipeline_ExtractVenue_AutoApproveFalse_ImportsPending(t *testing.T) {
+	var capturedStatus models.ShowStatus
+
+	ps := newTestPipeline(
+		withVenueConfig(&stubVenueConfig{
+			getByVenueIDFn: func(venueID uint) (*models.VenueSourceConfig, error) {
+				cfg := defaultConfig()
+				cfg.AutoApprove = false // explicitly false
+				return cfg, nil
+			},
+		}),
+		withDiscovery(&stubDiscovery{
+			importEventsFn: func(events []DiscoveredEvent, dryRun bool, allowUpdates bool, initialStatus models.ShowStatus) (*ImportResult, error) {
+				capturedStatus = initialStatus
+				return &ImportResult{Total: len(events), Imported: len(events)}, nil
+			},
+		}),
+	)
+
+	result, err := ps.ExtractVenue(1, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if capturedStatus != models.ShowStatusPending {
+		t.Errorf("expected initial status=pending, got %s", capturedStatus)
+	}
+	if result.InitialStatus != string(models.ShowStatusPending) {
+		t.Errorf("expected result initial_status=pending, got %s", result.InitialStatus)
+	}
+}
+
+func TestPipeline_ExtractVenue_AutoApproveTrue_ImportsApproved(t *testing.T) {
+	var capturedStatus models.ShowStatus
+
+	ps := newTestPipeline(
+		withVenueConfig(&stubVenueConfig{
+			getByVenueIDFn: func(venueID uint) (*models.VenueSourceConfig, error) {
+				cfg := defaultConfig()
+				cfg.AutoApprove = true
+				return cfg, nil
+			},
+		}),
+		withDiscovery(&stubDiscovery{
+			importEventsFn: func(events []DiscoveredEvent, dryRun bool, allowUpdates bool, initialStatus models.ShowStatus) (*ImportResult, error) {
+				capturedStatus = initialStatus
+				return &ImportResult{Total: len(events), Imported: len(events)}, nil
+			},
+		}),
+	)
+
+	result, err := ps.ExtractVenue(1, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if capturedStatus != models.ShowStatusApproved {
+		t.Errorf("expected initial status=approved, got %s", capturedStatus)
+	}
+	if result.InitialStatus != string(models.ShowStatusApproved) {
+		t.Errorf("expected result initial_status=approved, got %s", result.InitialStatus)
+	}
+}
+
+func TestPipeline_ExtractVenue_FiltersNonMusicEvents(t *testing.T) {
+	var importedEvents []DiscoveredEvent
+	isMusicTrue := true
+	isMusicFalse := false
+
+	ps := newTestPipeline(
+		withExtraction(&stubExtraction{
+			extractCalendarPageFn: func(venueName, content, contentType string) (*CalendarExtractionResponse, error) {
+				return &CalendarExtractionResponse{
+					Success: true,
+					Events: []CalendarEvent{
+						{Date: "2026-04-01", Title: "Real Concert", Artists: []CalendarArtist{{Name: "Band A", IsHeadliner: true}}, IsMusicEvent: &isMusicTrue},
+						{Date: "2026-04-02", Title: "Karaoke Night", Artists: []CalendarArtist{}, IsMusicEvent: &isMusicFalse},
+						{Date: "2026-04-03", Title: "Another Show", Artists: []CalendarArtist{{Name: "Band B", IsHeadliner: true}}, IsMusicEvent: nil}, // nil defaults to included
+					},
+				}, nil
+			},
+		}),
+		withVenueConfig(&stubVenueConfig{
+			getByVenueIDFn: func(venueID uint) (*models.VenueSourceConfig, error) {
+				return defaultConfig(), nil
+			},
+		}),
+		withDiscovery(&stubDiscovery{
+			importEventsFn: func(events []DiscoveredEvent, dryRun bool, allowUpdates bool, initialStatus models.ShowStatus) (*ImportResult, error) {
+				importedEvents = events
+				return &ImportResult{Total: len(events), Imported: len(events)}, nil
+			},
+		}),
+	)
+
+	result, err := ps.ExtractVenue(1, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.EventsExtracted != 3 {
+		t.Errorf("expected events_extracted=3, got %d", result.EventsExtracted)
+	}
+	if result.EventsSkippedNonMusic != 1 {
+		t.Errorf("expected events_skipped_non_music=1, got %d", result.EventsSkippedNonMusic)
+	}
+	if len(importedEvents) != 2 {
+		t.Errorf("expected 2 events to be imported, got %d", len(importedEvents))
+	}
+}
+
+func TestPipeline_FilterMusicEvents(t *testing.T) {
+	isTrue := true
+	isFalse := false
+
+	tests := []struct {
+		name     string
+		events   []CalendarEvent
+		expected int
+	}{
+		{
+			name:     "all music events",
+			events:   []CalendarEvent{{IsMusicEvent: &isTrue}, {IsMusicEvent: &isTrue}},
+			expected: 2,
+		},
+		{
+			name:     "no music events",
+			events:   []CalendarEvent{{IsMusicEvent: &isFalse}, {IsMusicEvent: &isFalse}},
+			expected: 0,
+		},
+		{
+			name:     "nil defaults to included",
+			events:   []CalendarEvent{{IsMusicEvent: nil}, {IsMusicEvent: nil}},
+			expected: 2,
+		},
+		{
+			name:     "mixed",
+			events:   []CalendarEvent{{IsMusicEvent: &isTrue}, {IsMusicEvent: &isFalse}, {IsMusicEvent: nil}},
+			expected: 2,
+		},
+		{
+			name:     "empty input",
+			events:   []CalendarEvent{},
+			expected: 0,
+		},
+		{
+			name:     "nil input",
+			events:   nil,
+			expected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := filterMusicEvents(tt.events)
+			if len(result) != tt.expected {
+				t.Errorf("expected %d events, got %d", tt.expected, len(result))
+			}
+		})
 	}
 }

--- a/backend/internal/services/venue_source_config_test.go
+++ b/backend/internal/services/venue_source_config_test.go
@@ -170,7 +170,7 @@ func (s *VenueSourceConfigIntegrationTestSuite) TestCreateOrUpdate_NewConfig() {
 	s.Equal(s.venueID, result.VenueID)
 	s.Equal(&url, result.CalendarURL)
 	s.Equal("ai", result.PreferredSource)
-	s.True(result.AutoApprove)
+	s.False(result.AutoApprove) // default is false — requires explicit opt-in
 	s.False(result.StrategyLocked)
 }
 

--- a/docs/llm-context.md
+++ b/docs/llm-context.md
@@ -70,5 +70,5 @@ See `docs/vision.md` for the full north star, What.cd feature mapping, and entit
 - **Fire-and-forget** — Discord notifications and audit logs never fail parent operations
 - **JSONB columns** — use `*json.RawMessage` (not `datatypes.JSON`)
 - **Huma quirk** — all request body fields required by default, even pointers; mark optional explicitly
-- **Migration numbering** — latest is 000041 (profile_enhancements, PSY-63); next is 000042
+- **Migration numbering** — latest is 000044 (auto_approve_default_false, PSY-80); next is 000045
 


### PR DESCRIPTION
## Summary
- Pipeline-imported shows now default to **pending** status for admin review instead of auto-approved
- Per-venue `auto_approve` flag on `venue_source_configs` controls whether shows skip review (default: `false`)
- AI extraction prompt now includes `is_music_event` field — non-music events (karaoke, trivia, comedy, etc.) are filtered out before import
- Added `EventsSkippedNonMusic` and `InitialStatus` to pipeline results for visibility
- Migration 000044 changes `auto_approve` DB default from `true` to `false`

## Changes
- **`extraction_calendar.go`**: Added `IsMusicEvent *bool` to `CalendarEvent`, updated prompt with classification rules
- **`discovery.go`**: Threaded `initialStatus` parameter through `ImportEvents` → `importEvent` → `createShowFromEvent`
- **`pipeline.go`**: Reads `config.AutoApprove`, filters non-music events via `filterMusicEvents()`, passes correct initial status
- **`interfaces.go`**: Updated `DiscoveryServiceInterface.ImportEvents` signature
- **`admin.go`**: Admin manual imports always pass `ShowStatusApproved` (backward compat)
- **`venue_source_config.go`**: GORM default tag changed to `false`
- 4 new pipeline tests, all existing tests updated for new signature

## Test plan
- [x] All pipeline tests pass (22 tests including 4 new: auto_approve false/true, non-music filtering, filterMusicEvents unit)
- [x] All handler tests pass (17 pipeline + discovery handler tests)
- [x] VenueSourceConfig integration test updated and passing
- [x] Discovery integration tests updated and passing
- [x] Full `go build ./...` clean
- [x] Full `go test ./... -short` passes all 8 packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)