### PR TITLE
Extract auth services into auth/ sub-package (PSY-86)

### DIFF
--- a/backend/internal/services/aliases.go
+++ b/backend/internal/services/aliases.go
@@ -1,9 +1,70 @@
 package services
 
-// This file re-exports all types from the contracts sub-package as type aliases.
-// Existing code that references services.FooType continues to work unchanged.
+// This file re-exports all types from the contracts sub-package as type aliases,
+// and concrete types from sub-packages (auth, engagement, pipeline) for backward
+// compatibility. Existing code that references services.FooType continues to work.
 
-import "psychic-homily-backend/internal/services/contracts"
+import (
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/internal/config"
+	"psychic-homily-backend/internal/services/auth"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// ──────────────────────────────────────────────
+// Auth concrete type aliases (from auth sub-package)
+// ──────────────────────────────────────────────
+
+type AuthService = auth.AuthService
+type JWTService = auth.JWTService
+type AppleAuthService = auth.AppleAuthService
+type WebAuthnService = auth.WebAuthnService
+type PasswordValidator = auth.PasswordValidator
+
+// Backward-compatible constructor wrappers for auth sub-package.
+// These maintain the old signatures so callers outside services/ keep compiling.
+
+// NewAuthService creates an AuthService.
+// Deprecated: prefer auth.NewAuthService with explicit userService dependency.
+func NewAuthService(database *gorm.DB, cfg *config.Config) *auth.AuthService {
+	return auth.NewAuthService(database, cfg, NewUserService(database))
+}
+
+// NewJWTService creates a JWTService.
+// Deprecated: prefer auth.NewJWTService with explicit userService dependency.
+func NewJWTService(database *gorm.DB, cfg *config.Config) *auth.JWTService {
+	return auth.NewJWTService(database, cfg, NewUserService(database))
+}
+
+// NewAppleAuthService creates an AppleAuthService.
+// Deprecated: prefer auth.NewAppleAuthService with explicit jwtService dependency.
+func NewAppleAuthService(database *gorm.DB, cfg *config.Config) *auth.AppleAuthService {
+	jwtSvc := auth.NewJWTService(database, cfg, NewUserService(database))
+	return auth.NewAppleAuthService(database, cfg, jwtSvc)
+}
+
+// NewPasswordValidator creates a PasswordValidator.
+func NewPasswordValidator() *auth.PasswordValidator {
+	return auth.NewPasswordValidator()
+}
+
+// NewWebAuthnService creates a WebAuthnService.
+func NewWebAuthnService(database *gorm.DB, cfg *config.Config) (*auth.WebAuthnService, error) {
+	return auth.NewWebAuthnService(database, cfg)
+}
+
+// CalculatePasswordStrength re-exports auth.CalculatePasswordStrength.
+var CalculatePasswordStrength = auth.CalculatePasswordStrength
+
+// GetStrengthLabel re-exports auth.GetStrengthLabel.
+var GetStrengthLabel = auth.GetStrengthLabel
+
+// MinPasswordLength re-exports auth.MinPasswordLength.
+const (
+	MinPasswordLength = auth.MinPasswordLength
+	MaxPasswordLength = auth.MaxPasswordLength
+)
 
 // ──────────────────────────────────────────────
 // Catalog types (show, venue, artist)

--- a/backend/internal/services/auth/apple.go
+++ b/backend/internal/services/auth/apple.go
@@ -1,4 +1,4 @@
-package services
+package auth
 
 import (
 	"crypto/rsa"
@@ -16,6 +16,7 @@ import (
 	"psychic-homily-backend/db"
 	"psychic-homily-backend/internal/config"
 	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
 )
 
 const (
@@ -25,10 +26,9 @@ const (
 
 // AppleAuthService handles Sign in with Apple authentication
 type AppleAuthService struct {
-	db          *gorm.DB
-	config      *config.Config
-	userService *UserService
-	jwtService  *JWTService
+	db         *gorm.DB
+	config     *config.Config
+	jwtService *JWTService
 
 	// Cached Apple public keys
 	keysMu    sync.RWMutex
@@ -40,19 +40,17 @@ type AppleAuthService struct {
 }
 
 // NewAppleAuthService creates a new Apple auth service
-func NewAppleAuthService(database *gorm.DB, cfg *config.Config) *AppleAuthService {
+func NewAppleAuthService(database *gorm.DB, cfg *config.Config, jwtService *JWTService) *AppleAuthService {
 	if database == nil {
 		database = db.GetDB()
 	}
 	return &AppleAuthService{
-		db:          database,
-		config:      cfg,
-		userService: NewUserService(database),
-		jwtService:  NewJWTService(database, cfg),
-		keys:        make(map[string]*rsa.PublicKey),
+		db:         database,
+		config:     cfg,
+		jwtService: jwtService,
+		keys:       make(map[string]*rsa.PublicKey),
 	}
 }
-
 
 // appleJWKSet represents Apple's JWK set response
 type appleJWKSet struct {
@@ -69,10 +67,10 @@ type appleJWK struct {
 }
 
 // ValidateIdentityToken validates an Apple identity token and returns the claims
-func (s *AppleAuthService) ValidateIdentityToken(identityToken string) (*AppleIdentityTokenClaims, error) {
+func (s *AppleAuthService) ValidateIdentityToken(identityToken string) (*contracts.AppleIdentityTokenClaims, error) {
 	// Parse the token header to get the key ID
 	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
-	unverifiedToken, _, err := parser.ParseUnverified(identityToken, &AppleIdentityTokenClaims{})
+	unverifiedToken, _, err := parser.ParseUnverified(identityToken, &contracts.AppleIdentityTokenClaims{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse token header: %w", err)
 	}
@@ -89,7 +87,7 @@ func (s *AppleAuthService) ValidateIdentityToken(identityToken string) (*AppleId
 	}
 
 	// Parse and validate the token with the public key
-	claims := &AppleIdentityTokenClaims{}
+	claims := &contracts.AppleIdentityTokenClaims{}
 	token, err := jwt.ParseWithClaims(identityToken, claims, func(t *jwt.Token) (interface{}, error) {
 		if _, ok := t.Method.(*jwt.SigningMethodRSA); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
@@ -112,7 +110,7 @@ func (s *AppleAuthService) ValidateIdentityToken(identityToken string) (*AppleId
 }
 
 // FindOrCreateAppleUser finds or creates a user from Apple Sign In data
-func (s *AppleAuthService) FindOrCreateAppleUser(claims *AppleIdentityTokenClaims, firstName, lastName string) (*models.User, error) {
+func (s *AppleAuthService) FindOrCreateAppleUser(claims *contracts.AppleIdentityTokenClaims, firstName, lastName string) (*models.User, error) {
 	appleUserID := claims.Subject
 
 	// Look for existing OAuth account with provider=apple

--- a/backend/internal/services/auth/apple_test.go
+++ b/backend/internal/services/auth/apple_test.go
@@ -1,4 +1,4 @@
-package services
+package auth
 
 import (
 	"context"
@@ -24,6 +24,7 @@ import (
 
 	"psychic-homily-backend/internal/config"
 	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
 	"psychic-homily-backend/internal/testutil"
 )
 
@@ -36,10 +37,10 @@ func TestNewAppleAuthService(t *testing.T) {
 		Apple: config.AppleConfig{BundleID: "com.test.app"},
 		JWT:   config.JWTConfig{SecretKey: "test-key", Expiry: 24},
 	}
-	svc := NewAppleAuthService(nil, cfg)
+	jwtSvc := NewJWTService(nil, cfg, newNilDBUserService())
+	svc := NewAppleAuthService(nil, cfg, jwtSvc)
 	assert.NotNil(t, svc)
 	assert.NotNil(t, svc.config)
-	assert.NotNil(t, svc.userService)
 	assert.NotNil(t, svc.jwtService)
 	assert.NotNil(t, svc.keys)
 	assert.Empty(t, svc.keys)
@@ -54,7 +55,8 @@ func TestAppleAuthService_GenerateToken(t *testing.T) {
 		Apple: config.AppleConfig{BundleID: "com.test.app"},
 		JWT:   config.JWTConfig{SecretKey: "test-key-for-apple-generate", Expiry: 24},
 	}
-	svc := NewAppleAuthService(nil, cfg)
+	jwtSvc := NewJWTService(nil, cfg, newNilDBUserService())
+	svc := NewAppleAuthService(nil, cfg, jwtSvc)
 
 	user := &models.User{ID: 42, Email: stringPtr("apple@example.com")}
 	token, err := svc.GenerateToken(user)
@@ -77,32 +79,32 @@ func TestAppleAuthService_GenerateToken(t *testing.T) {
 
 func TestAppleIdentityTokenClaims_IsEmailVerified(t *testing.T) {
 	t.Run("bool_true", func(t *testing.T) {
-		claims := &AppleIdentityTokenClaims{EmailVerified: true}
+		claims := &contracts.AppleIdentityTokenClaims{EmailVerified: true}
 		assert.True(t, claims.IsEmailVerified())
 	})
 
 	t.Run("bool_false", func(t *testing.T) {
-		claims := &AppleIdentityTokenClaims{EmailVerified: false}
+		claims := &contracts.AppleIdentityTokenClaims{EmailVerified: false}
 		assert.False(t, claims.IsEmailVerified())
 	})
 
 	t.Run("string_true", func(t *testing.T) {
-		claims := &AppleIdentityTokenClaims{EmailVerified: "true"}
+		claims := &contracts.AppleIdentityTokenClaims{EmailVerified: "true"}
 		assert.True(t, claims.IsEmailVerified())
 	})
 
 	t.Run("string_false", func(t *testing.T) {
-		claims := &AppleIdentityTokenClaims{EmailVerified: "false"}
+		claims := &contracts.AppleIdentityTokenClaims{EmailVerified: "false"}
 		assert.False(t, claims.IsEmailVerified())
 	})
 
 	t.Run("nil_value", func(t *testing.T) {
-		claims := &AppleIdentityTokenClaims{EmailVerified: nil}
+		claims := &contracts.AppleIdentityTokenClaims{EmailVerified: nil}
 		assert.False(t, claims.IsEmailVerified())
 	})
 
 	t.Run("unexpected_type_int", func(t *testing.T) {
-		claims := &AppleIdentityTokenClaims{EmailVerified: 1}
+		claims := &contracts.AppleIdentityTokenClaims{EmailVerified: 1}
 		assert.False(t, claims.IsEmailVerified())
 	})
 }
@@ -294,7 +296,7 @@ func TestAppleKeyFetching(t *testing.T) {
 func createTestAppleService(cfg *config.Config, mockKeysURL string) *AppleAuthService {
 	svc := &AppleAuthService{
 		config:                cfg,
-		jwtService:            NewJWTService(nil, cfg),
+		jwtService:            NewJWTService(nil, cfg, newNilDBUserService()),
 		keys:                  make(map[string]*rsa.PublicKey),
 		fetchAppleKeysFromURL: mockKeysURL,
 	}
@@ -377,7 +379,7 @@ func (s *AppleAuthIntegrationTestSuite) SetupSuite() {
 	if err != nil {
 		s.T().Fatalf("failed to get sql.DB: %v", err)
 	}
-	testutil.RunAllMigrations(s.T(), sqlDB, filepath.Join("..", "..", "db", "migrations"))
+	testutil.RunAllMigrations(s.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
 
 	s.cfg = &config.Config{
 		Apple: config.AppleConfig{BundleID: "com.test.app"},
@@ -402,11 +404,10 @@ func (s *AppleAuthIntegrationTestSuite) TearDownTest() {
 
 func (s *AppleAuthIntegrationTestSuite) newService() *AppleAuthService {
 	return &AppleAuthService{
-		db:          s.db,
-		config:      s.cfg,
-		userService: &UserService{db: s.db},
-		jwtService:  NewJWTService(s.db, s.cfg),
-		keys:        make(map[string]*rsa.PublicKey),
+		db:         s.db,
+		config:     s.cfg,
+		jwtService: NewJWTService(s.db, s.cfg, newNilDBUserService()),
+		keys:       make(map[string]*rsa.PublicKey),
 	}
 }
 
@@ -416,7 +417,7 @@ func (s *AppleAuthIntegrationTestSuite) newService() *AppleAuthService {
 
 func (s *AppleAuthIntegrationTestSuite) TestFindOrCreateAppleUser_NewUser_CreatesUserAndOAuth() {
 	svc := s.newService()
-	claims := &AppleIdentityTokenClaims{
+	claims := &contracts.AppleIdentityTokenClaims{
 		Email:         "apple@example.com",
 		EmailVerified: true,
 		RegisteredClaims: jwt.RegisteredClaims{
@@ -448,7 +449,7 @@ func (s *AppleAuthIntegrationTestSuite) TestFindOrCreateAppleUser_NewUser_Create
 
 func (s *AppleAuthIntegrationTestSuite) TestFindOrCreateAppleUser_NewUser_NoEmail() {
 	svc := s.newService()
-	claims := &AppleIdentityTokenClaims{
+	claims := &contracts.AppleIdentityTokenClaims{
 		Email: "",
 		RegisteredClaims: jwt.RegisteredClaims{
 			Subject: "apple-sub-no-email",
@@ -469,7 +470,7 @@ func (s *AppleAuthIntegrationTestSuite) TestFindOrCreateAppleUser_ExistingAppleU
 	svc := s.newService()
 
 	// Pre-create user via first call
-	claims := &AppleIdentityTokenClaims{
+	claims := &contracts.AppleIdentityTokenClaims{
 		Email: "existing-apple@example.com",
 		RegisteredClaims: jwt.RegisteredClaims{
 			Subject: "apple-sub-existing",
@@ -493,16 +494,16 @@ func (s *AppleAuthIntegrationTestSuite) TestFindOrCreateAppleUser_ExistingAppleU
 func (s *AppleAuthIntegrationTestSuite) TestFindOrCreateAppleUser_ExistingEmail_LinksAppleAccount() {
 	// Pre-create a user with email but no OAuth
 	existingUser := &models.User{
-		Email:         strPtr("link-apple@example.com"),
-		FirstName:     strPtr("Existing"),
-		LastName:      strPtr("User"),
+		Email:         stringPtr("link-apple@example.com"),
+		FirstName:     stringPtr("Existing"),
+		LastName:      stringPtr("User"),
 		IsActive:      true,
 		EmailVerified: true,
 	}
 	s.Require().NoError(s.db.Create(existingUser).Error)
 
 	svc := s.newService()
-	claims := &AppleIdentityTokenClaims{
+	claims := &contracts.AppleIdentityTokenClaims{
 		Email: "link-apple@example.com",
 		RegisteredClaims: jwt.RegisteredClaims{
 			Subject: "apple-sub-link",
@@ -522,7 +523,7 @@ func (s *AppleAuthIntegrationTestSuite) TestFindOrCreateAppleUser_ExistingEmail_
 	svc := s.newService()
 
 	// Create first user with apple account
-	claims1 := &AppleIdentityTokenClaims{
+	claims1 := &contracts.AppleIdentityTokenClaims{
 		Email: "shared-email@example.com",
 		RegisteredClaims: jwt.RegisteredClaims{
 			Subject: "apple-sub-first",
@@ -534,7 +535,7 @@ func (s *AppleAuthIntegrationTestSuite) TestFindOrCreateAppleUser_ExistingEmail_
 	// Second call with different apple subject but same email
 	// Since first user already has an apple OAuth, this looks up by apple subject (not found),
 	// then finds user by email and links the new apple ID
-	claims2 := &AppleIdentityTokenClaims{
+	claims2 := &contracts.AppleIdentityTokenClaims{
 		Email: "shared-email@example.com",
 		RegisteredClaims: jwt.RegisteredClaims{
 			Subject: "apple-sub-second",
@@ -559,9 +560,9 @@ func (s *AppleAuthIntegrationTestSuite) TestFindOrCreateAppleUser_ExistingEmail_
 func (s *AppleAuthIntegrationTestSuite) TestLinkAppleAccount_Success() {
 	// Pre-create user
 	user := &models.User{
-		Email:     strPtr("link-test@example.com"),
-		FirstName: strPtr("Link"),
-		LastName:  strPtr("Test"),
+		Email:     stringPtr("link-test@example.com"),
+		FirstName: stringPtr("Link"),
+		LastName:  stringPtr("Test"),
 		IsActive:  true,
 	}
 	s.Require().NoError(s.db.Create(user).Error)
@@ -583,9 +584,9 @@ func (s *AppleAuthIntegrationTestSuite) TestLinkAppleAccount_Success() {
 func (s *AppleAuthIntegrationTestSuite) TestLinkAppleAccount_UserHasPreferences() {
 	// Pre-create user with preferences
 	user := &models.User{
-		Email:     strPtr("prefs-test@example.com"),
-		FirstName: strPtr("Prefs"),
-		LastName:  strPtr("Test"),
+		Email:     stringPtr("prefs-test@example.com"),
+		FirstName: stringPtr("Prefs"),
+		LastName:  stringPtr("Test"),
 		IsActive:  true,
 	}
 	s.Require().NoError(s.db.Create(user).Error)
@@ -645,7 +646,7 @@ func (s *AppleAuthIntegrationTestSuite) TestCreateAppleUser_NoEmail() {
 func (s *AppleAuthIntegrationTestSuite) TestCreateAppleUser_DuplicateEmail() {
 	// Pre-create a user with the same email
 	existing := &models.User{
-		Email:    strPtr("dupe@example.com"),
+		Email:    stringPtr("dupe@example.com"),
 		IsActive: true,
 	}
 	s.Require().NoError(s.db.Create(existing).Error)
@@ -664,9 +665,4 @@ func (s *AppleAuthIntegrationTestSuite) TestCreateAppleUser_DuplicateEmail() {
 
 func TestAppleAuthIntegrationTestSuite(t *testing.T) {
 	suite.Run(t, new(AppleAuthIntegrationTestSuite))
-}
-
-// strPtr is a local helper for string pointer literals
-func strPtr(s string) *string {
-	return &s
 }

--- a/backend/internal/services/auth/interfaces.go
+++ b/backend/internal/services/auth/interfaces.go
@@ -1,0 +1,12 @@
+package auth
+
+import "psychic-homily-backend/internal/services/contracts"
+
+// Compile-time interface satisfaction checks for auth sub-package.
+var (
+	_ contracts.AuthServiceInterface       = (*AuthService)(nil)
+	_ contracts.JWTServiceInterface        = (*JWTService)(nil)
+	_ contracts.PasswordValidatorInterface = (*PasswordValidator)(nil)
+	_ contracts.AppleAuthServiceInterface  = (*AppleAuthService)(nil)
+	_ contracts.WebAuthnServiceInterface   = (*WebAuthnService)(nil)
+)

--- a/backend/internal/services/auth/jwt.go
+++ b/backend/internal/services/auth/jwt.go
@@ -1,28 +1,27 @@
-package services
+package auth
 
 import (
 	"errors"
 	"fmt"
 	"time"
 
-	"gorm.io/gorm"
+	"github.com/golang-jwt/jwt/v5"
 
 	"psychic-homily-backend/internal/config"
 	apperrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/models"
-
-	"github.com/golang-jwt/jwt/v5"
+	"psychic-homily-backend/internal/services/contracts"
 )
 
 type JWTService struct {
 	config      *config.Config
-	userService *UserService
+	userService contracts.UserServiceInterface
 }
 
-func NewJWTService(database *gorm.DB, cfg *config.Config) *JWTService {
+func NewJWTService(database interface{}, cfg *config.Config, userService contracts.UserServiceInterface) *JWTService {
 	return &JWTService{
 		config:      cfg,
-		userService: NewUserService(database),
+		userService: userService,
 	}
 }
 
@@ -148,12 +147,10 @@ func (s *JWTService) ValidateTokenLenient(tokenString string, gracePeriod time.D
 	return user, nil
 }
 
-// VerificationTokenClaims holds the claims for email verification tokens
-
 // CreateVerificationToken generates a JWT token for email verification
 // Token expires in 24 hours
 func (s *JWTService) CreateVerificationToken(userID uint, email string) (string, error) {
-	claims := VerificationTokenClaims{
+	claims := contracts.VerificationTokenClaims{
 		UserID: userID,
 		Email:  email,
 		RegisteredClaims: jwt.RegisteredClaims{
@@ -169,8 +166,8 @@ func (s *JWTService) CreateVerificationToken(userID uint, email string) (string,
 }
 
 // ValidateVerificationToken validates an email verification token and returns the claims
-func (s *JWTService) ValidateVerificationToken(tokenString string) (*VerificationTokenClaims, error) {
-	token, err := jwt.ParseWithClaims(tokenString, &VerificationTokenClaims{}, func(token *jwt.Token) (interface{}, error) {
+func (s *JWTService) ValidateVerificationToken(tokenString string) (*contracts.VerificationTokenClaims, error) {
+	token, err := jwt.ParseWithClaims(tokenString, &contracts.VerificationTokenClaims{}, func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 		}
@@ -181,7 +178,7 @@ func (s *JWTService) ValidateVerificationToken(tokenString string) (*Verificatio
 		return nil, fmt.Errorf("invalid verification token: %w", err)
 	}
 
-	claims, ok := token.Claims.(*VerificationTokenClaims)
+	claims, ok := token.Claims.(*contracts.VerificationTokenClaims)
 	if !ok || !token.Valid {
 		return nil, fmt.Errorf("invalid verification token claims")
 	}
@@ -194,12 +191,10 @@ func (s *JWTService) ValidateVerificationToken(tokenString string) (*Verificatio
 	return claims, nil
 }
 
-// MagicLinkTokenClaims holds the claims for magic link tokens
-
 // CreateMagicLinkToken generates a JWT token for magic link login
 // Token expires in 15 minutes for security
 func (s *JWTService) CreateMagicLinkToken(userID uint, email string) (string, error) {
-	claims := MagicLinkTokenClaims{
+	claims := contracts.MagicLinkTokenClaims{
 		UserID: userID,
 		Email:  email,
 		RegisteredClaims: jwt.RegisteredClaims{
@@ -215,8 +210,8 @@ func (s *JWTService) CreateMagicLinkToken(userID uint, email string) (string, er
 }
 
 // ValidateMagicLinkToken validates a magic link token and returns the claims
-func (s *JWTService) ValidateMagicLinkToken(tokenString string) (*MagicLinkTokenClaims, error) {
-	token, err := jwt.ParseWithClaims(tokenString, &MagicLinkTokenClaims{}, func(token *jwt.Token) (interface{}, error) {
+func (s *JWTService) ValidateMagicLinkToken(tokenString string) (*contracts.MagicLinkTokenClaims, error) {
+	token, err := jwt.ParseWithClaims(tokenString, &contracts.MagicLinkTokenClaims{}, func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 		}
@@ -227,7 +222,7 @@ func (s *JWTService) ValidateMagicLinkToken(tokenString string) (*MagicLinkToken
 		return nil, fmt.Errorf("invalid magic link token: %w", err)
 	}
 
-	claims, ok := token.Claims.(*MagicLinkTokenClaims)
+	claims, ok := token.Claims.(*contracts.MagicLinkTokenClaims)
 	if !ok || !token.Valid {
 		return nil, fmt.Errorf("invalid magic link token claims")
 	}
@@ -240,12 +235,10 @@ func (s *JWTService) ValidateMagicLinkToken(tokenString string) (*MagicLinkToken
 	return claims, nil
 }
 
-// AccountRecoveryTokenClaims holds the claims for account recovery tokens
-
 // CreateAccountRecoveryToken generates a JWT token for account recovery
 // Token expires in 1 hour for security
 func (s *JWTService) CreateAccountRecoveryToken(userID uint, email string) (string, error) {
-	claims := AccountRecoveryTokenClaims{
+	claims := contracts.AccountRecoveryTokenClaims{
 		UserID: userID,
 		Email:  email,
 		RegisteredClaims: jwt.RegisteredClaims{
@@ -261,8 +254,8 @@ func (s *JWTService) CreateAccountRecoveryToken(userID uint, email string) (stri
 }
 
 // ValidateAccountRecoveryToken validates an account recovery token and returns the claims
-func (s *JWTService) ValidateAccountRecoveryToken(tokenString string) (*AccountRecoveryTokenClaims, error) {
-	token, err := jwt.ParseWithClaims(tokenString, &AccountRecoveryTokenClaims{}, func(token *jwt.Token) (interface{}, error) {
+func (s *JWTService) ValidateAccountRecoveryToken(tokenString string) (*contracts.AccountRecoveryTokenClaims, error) {
+	token, err := jwt.ParseWithClaims(tokenString, &contracts.AccountRecoveryTokenClaims{}, func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 		}
@@ -273,7 +266,7 @@ func (s *JWTService) ValidateAccountRecoveryToken(tokenString string) (*AccountR
 		return nil, fmt.Errorf("invalid account recovery token: %w", err)
 	}
 
-	claims, ok := token.Claims.(*AccountRecoveryTokenClaims)
+	claims, ok := token.Claims.(*contracts.AccountRecoveryTokenClaims)
 	if !ok || !token.Valid {
 		return nil, fmt.Errorf("invalid account recovery token claims")
 	}

--- a/backend/internal/services/auth/jwt_lenient_test.go
+++ b/backend/internal/services/auth/jwt_lenient_test.go
@@ -1,4 +1,4 @@
-package services
+package auth
 
 import (
 	"testing"
@@ -20,7 +20,7 @@ func TestValidateTokenLenient(t *testing.T) {
 			Expiry:    24,
 		},
 	}
-	jwtService := NewJWTService(nil, cfg)
+	jwtService := NewJWTService(nil, cfg, newNilDBUserService())
 	gracePeriod := 7 * 24 * time.Hour // 7 days
 
 	t.Run("valid_token_passes_strict", func(t *testing.T) {

--- a/backend/internal/services/auth/jwt_test.go
+++ b/backend/internal/services/auth/jwt_test.go
@@ -1,4 +1,4 @@
-package services
+package auth
 
 import (
 	"testing"
@@ -10,6 +10,7 @@ import (
 
 	"psychic-homily-backend/internal/config"
 	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
 )
 
 // =============================================================================
@@ -25,7 +26,7 @@ func TestNewJWTService(t *testing.T) {
 		},
 	}
 
-	jwtService := NewJWTService(nil, cfg)
+	jwtService := NewJWTService(nil, cfg, newNilDBUserService())
 
 	assert.NotNil(t, jwtService)
 	assert.Equal(t, cfg, jwtService.config)
@@ -40,7 +41,7 @@ func TestJWTService_CreateToken(t *testing.T) {
 		},
 	}
 
-	jwtService := NewJWTService(nil, cfg)
+	jwtService := NewJWTService(nil, cfg, newNilDBUserService())
 
 	t.Run("CreateToken_Success", func(t *testing.T) {
 		user := &models.User{
@@ -139,7 +140,7 @@ func TestJWTService_ValidateToken(t *testing.T) {
 		},
 	}
 
-	jwtService := NewJWTService(nil, cfg)
+	jwtService := NewJWTService(nil, cfg, newNilDBUserService())
 
 	t.Run("ValidateToken_Success", func(t *testing.T) {
 		// Create a valid token first
@@ -201,7 +202,7 @@ func TestJWTService_ValidateToken(t *testing.T) {
 				Expiry:    24,
 			},
 		}
-		jwtService1 := NewJWTService(nil, cfg1)
+		jwtService1 := NewJWTService(nil, cfg1, newNilDBUserService())
 
 		user := &models.User{
 			ID:    123,
@@ -227,7 +228,7 @@ func TestJWTService_ValidateToken(t *testing.T) {
 				Expiry:    0, // 0 hours = immediate expiry
 			},
 		}
-		jwtServiceShort := NewJWTService(nil, cfgShort)
+		jwtServiceShort := NewJWTService(nil, cfgShort, newNilDBUserService())
 
 		user := &models.User{
 			ID:    123,
@@ -285,7 +286,7 @@ func TestJWTService_RefreshToken(t *testing.T) {
 		},
 	}
 
-	jwtService := NewJWTService(nil, cfg)
+	jwtService := NewJWTService(nil, cfg, newNilDBUserService())
 
 	t.Run("RefreshToken_Success", func(t *testing.T) {
 		// Create an original token
@@ -332,7 +333,7 @@ func TestJWTService_RefreshToken(t *testing.T) {
 				Expiry:    0, // 0 hours = immediate expiry
 			},
 		}
-		jwtServiceShort := NewJWTService(nil, cfgShort)
+		jwtServiceShort := NewJWTService(nil, cfgShort, newNilDBUserService())
 
 		user := &models.User{
 			ID:    123,
@@ -363,7 +364,7 @@ func TestJWTService_EdgeCases(t *testing.T) {
 		},
 	}
 
-	jwtService := NewJWTService(nil, cfg)
+	jwtService := NewJWTService(nil, cfg, newNilDBUserService())
 
 	t.Run("CreateToken_ZeroUserID", func(t *testing.T) {
 		user := &models.User{
@@ -428,7 +429,7 @@ func TestJWTService_Integration(t *testing.T) {
 		},
 	}
 
-	jwtService := NewJWTService(nil, cfg)
+	jwtService := NewJWTService(nil, cfg, newNilDBUserService())
 
 	t.Run("Complete_Token_Lifecycle", func(t *testing.T) {
 		// 1. Create a user
@@ -498,7 +499,7 @@ func TestJWTService_VerificationToken(t *testing.T) {
 			Expiry:    24,
 		},
 	}
-	jwtService := NewJWTService(nil, cfg)
+	jwtService := NewJWTService(nil, cfg, newNilDBUserService())
 
 	t.Run("CreateAndValidate_Success", func(t *testing.T) {
 		token, err := jwtService.CreateVerificationToken(123, "verify@example.com")
@@ -515,7 +516,7 @@ func TestJWTService_VerificationToken(t *testing.T) {
 
 	t.Run("Validate_ExpiredToken", func(t *testing.T) {
 		// Create a token that's already expired
-		claims := VerificationTokenClaims{
+		claims := contracts.VerificationTokenClaims{
 			UserID: 456,
 			Email:  "expired@example.com",
 			RegisteredClaims: jwt.RegisteredClaims{
@@ -536,7 +537,7 @@ func TestJWTService_VerificationToken(t *testing.T) {
 
 	t.Run("Validate_WrongSubject", func(t *testing.T) {
 		// Create a token with wrong subject
-		claims := VerificationTokenClaims{
+		claims := contracts.VerificationTokenClaims{
 			UserID: 789,
 			Email:  "wrong@example.com",
 			RegisteredClaims: jwt.RegisteredClaims{
@@ -563,7 +564,7 @@ func TestJWTService_VerificationToken(t *testing.T) {
 
 	t.Run("Validate_WrongSecret", func(t *testing.T) {
 		otherCfg := &config.Config{JWT: config.JWTConfig{SecretKey: "other-key", Expiry: 24}}
-		otherService := NewJWTService(nil, otherCfg)
+		otherService := NewJWTService(nil, otherCfg, newNilDBUserService())
 		token, err := otherService.CreateVerificationToken(123, "wrong-key@example.com")
 		require.NoError(t, err)
 
@@ -584,7 +585,7 @@ func TestJWTService_MagicLinkToken(t *testing.T) {
 			Expiry:    24,
 		},
 	}
-	jwtService := NewJWTService(nil, cfg)
+	jwtService := NewJWTService(nil, cfg, newNilDBUserService())
 
 	t.Run("CreateAndValidate_Success", func(t *testing.T) {
 		token, err := jwtService.CreateMagicLinkToken(123, "magic@example.com")
@@ -600,7 +601,7 @@ func TestJWTService_MagicLinkToken(t *testing.T) {
 	})
 
 	t.Run("Validate_ExpiredToken", func(t *testing.T) {
-		claims := MagicLinkTokenClaims{
+		claims := contracts.MagicLinkTokenClaims{
 			UserID: 456,
 			Email:  "expired@example.com",
 			RegisteredClaims: jwt.RegisteredClaims{
@@ -620,7 +621,7 @@ func TestJWTService_MagicLinkToken(t *testing.T) {
 	})
 
 	t.Run("Validate_WrongSubject", func(t *testing.T) {
-		claims := MagicLinkTokenClaims{
+		claims := contracts.MagicLinkTokenClaims{
 			UserID: 789,
 			Email:  "wrong@example.com",
 			RegisteredClaims: jwt.RegisteredClaims{
@@ -657,7 +658,7 @@ func TestJWTService_AccountRecoveryToken(t *testing.T) {
 			Expiry:    24,
 		},
 	}
-	jwtService := NewJWTService(nil, cfg)
+	jwtService := NewJWTService(nil, cfg, newNilDBUserService())
 
 	t.Run("CreateAndValidate_Success", func(t *testing.T) {
 		token, err := jwtService.CreateAccountRecoveryToken(123, "recover@example.com")
@@ -673,7 +674,7 @@ func TestJWTService_AccountRecoveryToken(t *testing.T) {
 	})
 
 	t.Run("Validate_ExpiredToken", func(t *testing.T) {
-		claims := AccountRecoveryTokenClaims{
+		claims := contracts.AccountRecoveryTokenClaims{
 			UserID: 456,
 			Email:  "expired@example.com",
 			RegisteredClaims: jwt.RegisteredClaims{
@@ -693,7 +694,7 @@ func TestJWTService_AccountRecoveryToken(t *testing.T) {
 	})
 
 	t.Run("Validate_WrongSubject", func(t *testing.T) {
-		claims := AccountRecoveryTokenClaims{
+		claims := contracts.AccountRecoveryTokenClaims{
 			UserID: 789,
 			Email:  "wrong@example.com",
 			RegisteredClaims: jwt.RegisteredClaims{
@@ -719,7 +720,7 @@ func TestJWTService_AccountRecoveryToken(t *testing.T) {
 
 	t.Run("Validate_WrongSecret", func(t *testing.T) {
 		otherCfg := &config.Config{JWT: config.JWTConfig{SecretKey: "other-key", Expiry: 24}}
-		otherService := NewJWTService(nil, otherCfg)
+		otherService := NewJWTService(nil, otherCfg, newNilDBUserService())
 		token, err := otherService.CreateAccountRecoveryToken(123, "wrong-key@example.com")
 		require.NoError(t, err)
 

--- a/backend/internal/services/auth/oauth.go
+++ b/backend/internal/services/auth/oauth.go
@@ -1,4 +1,4 @@
-package services
+package auth
 
 import (
 	"fmt"
@@ -12,6 +12,7 @@ import (
 	"psychic-homily-backend/db"
 	"psychic-homily-backend/internal/config"
 	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
 )
 
 // RealOAuthCompleter implements OAuthCompleter using gothic
@@ -24,20 +25,20 @@ func (r *RealOAuthCompleter) CompleteUserAuth(w http.ResponseWriter, req *http.R
 // AuthService handles authentication business logic
 type AuthService struct {
 	db             *gorm.DB
-	userService    *UserService
+	userService    contracts.UserServiceInterface
 	jwtService     *JWTService
-	oauthCompleter OAuthCompleter
+	oauthCompleter contracts.OAuthCompleter
 }
 
 // NewAuthService creates a new authentication service
-func NewAuthService(database *gorm.DB, cfg *config.Config) *AuthService {
+func NewAuthService(database *gorm.DB, cfg *config.Config, userService contracts.UserServiceInterface) *AuthService {
 	if database == nil {
 		database = db.GetDB()
 	}
 	return &AuthService{
 		db:             database,
-		userService:    NewUserService(database),
-		jwtService:     NewJWTService(database, cfg),
+		userService:    userService,
+		jwtService:     NewJWTService(database, cfg, userService),
 		oauthCompleter: &RealOAuthCompleter{},
 	}
 }
@@ -70,7 +71,7 @@ func (s *AuthService) OAuthCallbackWithConsent(
 	w http.ResponseWriter,
 	r *http.Request,
 	provider string,
-	consent *OAuthSignupConsent,
+	consent *contracts.OAuthSignupConsent,
 ) (*models.User, string, error) {
 	return s.oauthCallbackInternal(w, r, provider, consent, true)
 }
@@ -79,7 +80,7 @@ func (s *AuthService) oauthCallbackInternal(
 	w http.ResponseWriter,
 	r *http.Request,
 	provider string,
-	consent *OAuthSignupConsent,
+	consent *contracts.OAuthSignupConsent,
 	enforceConsent bool,
 ) (*models.User, string, error) {
 	// Check for nil request
@@ -119,7 +120,6 @@ func (s *AuthService) oauthCallbackInternal(
 	return user, token, nil
 }
 
-// Add this to backend/internal/services/auth.go
 // GetUserProfile retrieves user profile using the user service
 func (s *AuthService) GetUserProfile(userID uint) (*models.User, error) {
 	return s.userService.GetUserByID(userID)
@@ -138,6 +138,6 @@ func (s *AuthService) Logout(w http.ResponseWriter, r *http.Request) error {
 }
 
 // SetOAuthCompleter allows setting a mock OAuth completer for testing
-func (s *AuthService) SetOAuthCompleter(completer OAuthCompleter) {
+func (s *AuthService) SetOAuthCompleter(completer contracts.OAuthCompleter) {
 	s.oauthCompleter = completer
 }

--- a/backend/internal/services/auth/oauth_test.go
+++ b/backend/internal/services/auth/oauth_test.go
@@ -1,4 +1,4 @@
-package services
+package auth
 
 import (
 	"net/http"
@@ -33,7 +33,7 @@ func TestNewAuthService(t *testing.T) {
 		},
 	}
 
-	authService := NewAuthService(nil, cfg)
+	authService := NewAuthService(nil, cfg, newNilDBUserService())
 
 	if authService == nil {
 		t.Fatal("Expected AuthService to be created, got nil")
@@ -62,7 +62,7 @@ func TestAuthService_OAuthLogin(t *testing.T) {
 		},
 	}
 
-	authService := NewAuthService(nil, cfg)
+	authService := NewAuthService(nil, cfg, newNilDBUserService())
 
 	tests := []struct {
 		name     string
@@ -108,7 +108,7 @@ func TestAuthService_OAuthCallback(t *testing.T) {
 		},
 	}
 
-	authService := NewAuthService(nil, cfg)
+	authService := NewAuthService(nil, cfg, newNilDBUserService())
 
 	tests := []struct {
 		name     string
@@ -163,7 +163,7 @@ func TestAuthService_OAuthCallback_ErrorHandling(t *testing.T) {
 		},
 	}
 
-	authService := NewAuthService(nil, cfg)
+	authService := NewAuthService(nil, cfg, newNilDBUserService())
 
 	t.Run("nil_request", func(t *testing.T) {
 		w := httptest.NewRecorder()
@@ -356,7 +356,7 @@ func TestAuthService_OAuthCallback_EdgeCases(t *testing.T) {
 		},
 	}
 
-	authService := NewAuthService(nil, cfg)
+	authService := NewAuthService(nil, cfg, newNilDBUserService())
 
 	t.Run("request_with_complex_url", func(t *testing.T) {
 		complexURL := "/auth/callback/google?code=abc123&state=xyz789&redirect_uri=https%3A//example.com/callback&scope=email%20profile"
@@ -515,7 +515,7 @@ func TestAuthService_OAuthCallback_WithMock(t *testing.T) {
 		},
 	}
 
-	authService := NewAuthService(nil, cfg)
+	authService := NewAuthService(nil, cfg, newNilDBUserService())
 	mockCompleter := new(MockOAuthCompleter)
 	authService.SetOAuthCompleter(mockCompleter)
 
@@ -680,7 +680,7 @@ func TestAuthService_GetUserProfile(t *testing.T) {
 		},
 	}
 
-	authService := NewAuthService(nil, cfg)
+	authService := NewAuthService(nil, cfg, newNilDBUserService())
 
 	tests := []struct {
 		name   string
@@ -729,7 +729,7 @@ func TestAuthService_RefreshUserToken(t *testing.T) {
 		},
 	}
 
-	authService := NewAuthService(nil, cfg)
+	authService := NewAuthService(nil, cfg, newNilDBUserService())
 
 	tests := []struct {
 		name string
@@ -780,7 +780,7 @@ func TestAuthService_Logout(t *testing.T) {
 			SecretKey: "test-secret-key-32-chars-minimum",
 			Expiry:    24,
 		},
-	})
+	}, newNilDBUserService())
 
 	req := httptest.NewRequest("POST", "/auth/logout", nil)
 	w := httptest.NewRecorder()
@@ -807,7 +807,7 @@ func TestAuthService_Integration(t *testing.T) {
 		},
 	}
 
-	authService := NewAuthService(nil, cfg)
+	authService := NewAuthService(nil, cfg, newNilDBUserService())
 
 	// Test that all components are properly initialized
 	// In test environment, database may not be initialized
@@ -858,7 +858,7 @@ func TestAuthService_ErrorHandling(t *testing.T) {
 		},
 	}
 
-	authService := NewAuthService(nil, cfg)
+	authService := NewAuthService(nil, cfg, newNilDBUserService())
 
 	// Test with nil request
 	t.Run("Nil Request", func(t *testing.T) {
@@ -909,7 +909,7 @@ func TestAuthService_HTTPResponse(t *testing.T) {
 		},
 	}
 
-	authService := NewAuthService(nil, cfg)
+	authService := NewAuthService(nil, cfg, newNilDBUserService())
 
 	t.Run("OAuth Login Response", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "/auth/login/google", nil)
@@ -971,7 +971,3 @@ func TestAuthService_HTTPResponse(t *testing.T) {
 	})
 }
 
-// Helper function to create string pointer
-func stringPtr(s string) *string {
-	return &s
-} 

--- a/backend/internal/services/auth/password.go
+++ b/backend/internal/services/auth/password.go
@@ -1,4 +1,4 @@
-package services
+package auth
 
 import (
 	"bufio"
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"psychic-homily-backend/internal/services/contracts"
 )
 
 // Password validation constants
@@ -33,8 +35,8 @@ func NewPasswordValidator() *PasswordValidator {
 }
 
 // ValidatePassword validates a password against all security requirements
-func (v *PasswordValidator) ValidatePassword(password string) (*PasswordValidationResult, error) {
-	result := &PasswordValidationResult{
+func (v *PasswordValidator) ValidatePassword(password string) (*contracts.PasswordValidationResult, error) {
+	result := &contracts.PasswordValidationResult{
 		Valid:    true,
 		Errors:   []string{},
 		Warnings: []string{},

--- a/backend/internal/services/auth/password_test.go
+++ b/backend/internal/services/auth/password_test.go
@@ -1,4 +1,4 @@
-package services
+package auth
 
 import (
 	"crypto/sha1"

--- a/backend/internal/services/auth/test_helpers_test.go
+++ b/backend/internal/services/auth/test_helpers_test.go
@@ -1,0 +1,159 @@
+package auth
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/markbates/goth"
+
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// nilDBUserService simulates a UserService with no database connection.
+// All methods return "database not initialized" — matching the real
+// UserService behaviour when constructed with a nil *gorm.DB.
+type nilDBUserService struct{}
+
+func (n *nilDBUserService) ListUsers(limit, offset int, filters contracts.AdminUserFilters) ([]*contracts.AdminUserResponse, int64, error) {
+	return nil, 0, fmt.Errorf("database not initialized")
+}
+
+func (n *nilDBUserService) FindOrCreateUser(gothUser goth.User, provider string) (*models.User, error) {
+	return nil, fmt.Errorf("database not initialized")
+}
+
+func (n *nilDBUserService) FindOrCreateUserWithConsent(gothUser goth.User, provider string, consent *contracts.OAuthSignupConsent) (*models.User, error) {
+	return nil, fmt.Errorf("database not initialized")
+}
+
+func (n *nilDBUserService) AuthenticateUserWithPassword(email, password string) (*models.User, error) {
+	return nil, fmt.Errorf("database not initialized")
+}
+
+func (n *nilDBUserService) CreateUserWithPassword(email, password, firstName, lastName string) (*models.User, error) {
+	return nil, fmt.Errorf("database not initialized")
+}
+
+func (n *nilDBUserService) CreateUserWithPasswordWithLegal(email, password, firstName, lastName string, acceptance contracts.LegalAcceptance) (*models.User, error) {
+	return nil, fmt.Errorf("database not initialized")
+}
+
+func (n *nilDBUserService) GetUserByID(userID uint) (*models.User, error) {
+	return nil, fmt.Errorf("database not initialized")
+}
+
+func (n *nilDBUserService) GetUserByEmail(email string) (*models.User, error) {
+	return nil, fmt.Errorf("database not initialized")
+}
+
+func (n *nilDBUserService) GetUserByUsername(username string) (*models.User, error) {
+	return nil, fmt.Errorf("database not initialized")
+}
+
+func (n *nilDBUserService) UpdateUser(userID uint, updates map[string]any) (*models.User, error) {
+	return nil, fmt.Errorf("database not initialized")
+}
+
+func (n *nilDBUserService) HashPassword(password string) (string, error) {
+	return "", fmt.Errorf("database not initialized")
+}
+
+func (n *nilDBUserService) VerifyPassword(hashedPassword, password string) error {
+	return fmt.Errorf("database not initialized")
+}
+
+func (n *nilDBUserService) IsAccountLocked(user *models.User) bool { return false }
+
+func (n *nilDBUserService) GetLockTimeRemaining(user *models.User) time.Duration { return 0 }
+
+func (n *nilDBUserService) IncrementFailedAttempts(userID uint) error {
+	return fmt.Errorf("database not initialized")
+}
+
+func (n *nilDBUserService) ResetFailedAttempts(userID uint) error {
+	return fmt.Errorf("database not initialized")
+}
+
+func (n *nilDBUserService) UpdatePassword(userID uint, currentPassword, newPassword string) error {
+	return fmt.Errorf("database not initialized")
+}
+
+func (n *nilDBUserService) SetEmailVerified(userID uint, verified bool) error {
+	return fmt.Errorf("database not initialized")
+}
+
+func (n *nilDBUserService) GetDeletionSummary(userID uint) (*contracts.DeletionSummary, error) {
+	return nil, fmt.Errorf("database not initialized")
+}
+
+func (n *nilDBUserService) SoftDeleteAccount(userID uint, reason *string) error {
+	return fmt.Errorf("database not initialized")
+}
+
+func (n *nilDBUserService) CreateUserWithoutPassword(email string) (*models.User, error) {
+	return nil, fmt.Errorf("database not initialized")
+}
+
+func (n *nilDBUserService) ExportUserData(userID uint) (*contracts.UserDataExport, error) {
+	return nil, fmt.Errorf("database not initialized")
+}
+
+func (n *nilDBUserService) ExportUserDataJSON(userID uint) ([]byte, error) {
+	return nil, fmt.Errorf("database not initialized")
+}
+
+func (n *nilDBUserService) GetOAuthAccounts(userID uint) ([]models.OAuthAccount, error) {
+	return nil, fmt.Errorf("database not initialized")
+}
+
+func (n *nilDBUserService) GetUserByEmailIncludingDeleted(email string) (*models.User, error) {
+	return nil, fmt.Errorf("database not initialized")
+}
+
+func (n *nilDBUserService) IsAccountRecoverable(user *models.User) bool { return false }
+
+func (n *nilDBUserService) GetDaysUntilPermanentDeletion(user *models.User) int { return 0 }
+
+func (n *nilDBUserService) RestoreAccount(userID uint) error {
+	return fmt.Errorf("database not initialized")
+}
+
+func (n *nilDBUserService) GetExpiredDeletedAccounts() ([]models.User, error) {
+	return nil, fmt.Errorf("database not initialized")
+}
+
+func (n *nilDBUserService) PermanentlyDeleteUser(userID uint) error {
+	return fmt.Errorf("database not initialized")
+}
+
+func (n *nilDBUserService) CanUnlinkOAuthAccount(userID uint, provider string) (bool, string, error) {
+	return false, "", fmt.Errorf("database not initialized")
+}
+
+func (n *nilDBUserService) UnlinkOAuthAccount(userID uint, provider string) error {
+	return fmt.Errorf("database not initialized")
+}
+
+func (n *nilDBUserService) GetFavoriteCities(userID uint) ([]models.FavoriteCity, error) {
+	return nil, fmt.Errorf("database not initialized")
+}
+
+func (n *nilDBUserService) SetFavoriteCities(userID uint, cities []models.FavoriteCity) error {
+	return fmt.Errorf("database not initialized")
+}
+
+func (n *nilDBUserService) SetShowReminders(userID uint, enabled bool) error {
+	return fmt.Errorf("database not initialized")
+}
+
+// newNilDBUserService returns a UserServiceInterface that returns
+// "database not initialized" for every DB-dependent method.
+func newNilDBUserService() contracts.UserServiceInterface {
+	return &nilDBUserService{}
+}
+
+// stringPtr returns a pointer to a string. Test helper.
+func stringPtr(s string) *string {
+	return &s
+}

--- a/backend/internal/services/auth/webauthn.go
+++ b/backend/internal/services/auth/webauthn.go
@@ -1,4 +1,4 @@
-package services
+package auth
 
 import (
 	"encoding/json"
@@ -13,6 +13,7 @@ import (
 	"psychic-homily-backend/db"
 	"psychic-homily-backend/internal/config"
 	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
 )
 
 // WebAuthnService handles WebAuthn/passkey operations
@@ -407,7 +408,7 @@ func (s *WebAuthnService) GetChallengeWithEmail(challengeID string, operation st
 // FinishSignupRegistration completes registration, creates user, and stores credential.
 // Legacy path without legal acceptance metadata.
 func (s *WebAuthnService) FinishSignupRegistration(email string, session *webauthn.SessionData, response *protocol.ParsedCredentialCreationData, displayName string) (*models.User, error) {
-	return s.FinishSignupRegistrationWithLegal(email, session, response, displayName, LegalAcceptance{})
+	return s.FinishSignupRegistrationWithLegal(email, session, response, displayName, contracts.LegalAcceptance{})
 }
 
 // FinishSignupRegistrationWithLegal completes registration and records legal acceptance metadata.
@@ -416,7 +417,7 @@ func (s *WebAuthnService) FinishSignupRegistrationWithLegal(
 	session *webauthn.SessionData,
 	response *protocol.ParsedCredentialCreationData,
 	displayName string,
-	acceptance LegalAcceptance,
+	acceptance contracts.LegalAcceptance,
 ) (*models.User, error) {
 	// Use the same temp user for credential creation
 	tempUser := &signupUser{email: email}

--- a/backend/internal/services/auth/webauthn_test.go
+++ b/backend/internal/services/auth/webauthn_test.go
@@ -1,4 +1,4 @@
-package services
+package auth
 
 import (
 	"context"
@@ -124,7 +124,7 @@ func (suite *WebAuthnServiceIntegrationTestSuite) SetupSuite() {
 		suite.T().Fatalf("failed to get sql.DB: %v", err)
 	}
 
-	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "db", "migrations"))
+	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
 
 	cfg := &config.Config{
 		WebAuthn: config.WebAuthnConfig{

--- a/backend/internal/services/container.go
+++ b/backend/internal/services/container.go
@@ -6,6 +6,7 @@ import (
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/internal/config"
+	"psychic-homily-backend/internal/services/auth"
 	"psychic-homily-backend/internal/services/catalog"
 	"psychic-homily-backend/internal/services/engagement"
 	"psychic-homily-backend/internal/services/pipeline"
@@ -42,14 +43,14 @@ type ServiceContainer struct {
 
 	// No-param services
 	Fetcher           *pipeline.FetcherService
-	PasswordValidator *PasswordValidator
+	PasswordValidator *auth.PasswordValidator
 
 	// DB + Config composite services
-	Auth       *AuthService
-	JWT        *JWTService
-	AppleAuth  *AppleAuthService
+	Auth       *auth.AuthService
+	JWT        *auth.JWTService
+	AppleAuth  *auth.AppleAuthService
 	Extraction *pipeline.ExtractionService
-	WebAuthn   *WebAuthnService // nil if init fails (passkeys optional)
+	WebAuthn   *auth.WebAuthnService // nil if init fails (passkeys optional)
 	Cleanup    *CleanupService
 	DataSync   *DataSyncService
 	Discovery  *pipeline.DiscoveryService
@@ -68,13 +69,14 @@ func newFetcherWithChromedp() *pipeline.FetcherService {
 // (passkeys are optional) — all other services are infallible constructors.
 func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContainer {
 	// WebAuthn may fail — log warning, store nil
-	webauthnService, err := NewWebAuthnService(database, cfg)
+	webauthnService, err := auth.NewWebAuthnService(database, cfg)
 	if err != nil {
 		log.Printf("Warning: WebAuthn service init failed (passkeys disabled): %v", err)
 	}
 
 	savedShow := engagement.NewSavedShowService(database)
 	email := NewEmailService(cfg)
+	userService := NewUserService(database)
 
 	// Services needed by PipelineService — created first so we can inject them.
 	artist := catalog.NewArtistService(database)
@@ -83,6 +85,9 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 	extraction := pipeline.NewExtractionService(database, cfg, artist, venue)
 	discovery := pipeline.NewDiscoveryService(database, venue)
 	venueSourceConfig := pipeline.NewVenueSourceConfigService(database)
+
+	// Auth services — created first so we can share the JWT service with AppleAuth.
+	jwtService := auth.NewJWTService(database, cfg, userService)
 
 	return &ServiceContainer{
 		// DB-only leaf services
@@ -102,7 +107,7 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 		SavedShow:     savedShow,
 		Show:          catalog.NewShowService(database),
 		ShowReport:    NewShowReportService(database),
-		User:          NewUserService(database),
+		User:          userService,
 		Venue:             venue,
 		VenueSourceConfig: venueSourceConfig,
 
@@ -113,12 +118,12 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 
 		// No-param services
 		Fetcher:           fetcher,
-		PasswordValidator: NewPasswordValidator(),
+		PasswordValidator: auth.NewPasswordValidator(),
 
 		// DB + Config composite services
-		Auth:       NewAuthService(database, cfg),
-		JWT:        NewJWTService(database, cfg),
-		AppleAuth:  NewAppleAuthService(database, cfg),
+		Auth:       auth.NewAuthService(database, cfg, userService),
+		JWT:        jwtService,
+		AppleAuth:  auth.NewAppleAuthService(database, cfg, jwtService),
 		Extraction: extraction,
 		WebAuthn:   webauthnService,
 		Cleanup:    NewCleanupService(database),

--- a/backend/internal/services/interfaces.go
+++ b/backend/internal/services/interfaces.go
@@ -47,6 +47,8 @@ type CollectionServiceInterface = contracts.CollectionServiceInterface
 // have their checks in internal/services/engagement/interfaces.go.
 // Pipeline services (Extraction, MusicDiscovery, Discovery, VenueSourceConfig,
 // Fetcher, Pipeline) are checked in internal/services/pipeline/interfaces.go.
+// Auth services (Auth, JWT, PasswordValidator, AppleAuth, WebAuthn)
+// are checked in internal/services/auth/interfaces.go.
 var (
 	_ ShowServiceInterface          = (*catalog.ShowService)(nil)
 	_ VenueServiceInterface         = (*catalog.VenueService)(nil)
@@ -54,14 +56,9 @@ var (
 	_ ShowReportServiceInterface    = (*ShowReportService)(nil)
 	_ ArtistReportServiceInterface  = (*ArtistReportService)(nil)
 	_ AuditLogServiceInterface      = (*AuditLogService)(nil)
-	_ AuthServiceInterface          = (*AuthService)(nil)
-	_ JWTServiceInterface           = (*JWTService)(nil)
 	_ UserServiceInterface          = (*UserService)(nil)
 	_ EmailServiceInterface         = (*EmailService)(nil)
 	_ DiscordServiceInterface       = (*DiscordService)(nil)
-	_ PasswordValidatorInterface    = (*PasswordValidator)(nil)
-	_ AppleAuthServiceInterface     = (*AppleAuthService)(nil)
-	_ WebAuthnServiceInterface      = (*WebAuthnService)(nil)
 	_ APITokenServiceInterface      = (*APITokenService)(nil)
 	_ DataSyncServiceInterface      = (*DataSyncService)(nil)
 	_ AdminStatsServiceInterface    = (*AdminStatsService)(nil)

--- a/backend/internal/services/test_helpers_test.go
+++ b/backend/internal/services/test_helpers_test.go
@@ -1,0 +1,6 @@
+package services
+
+// stringPtr returns a pointer to a string. Test helper.
+func stringPtr(s string) *string {
+	return &s
+}


### PR DESCRIPTION
## Summary
- Move 5 auth services (`AuthService`, `JWTService`, `AppleAuthService`, `WebAuthnService`, `PasswordValidator`) into `internal/services/auth/` sub-package
- Add compile-time interface satisfaction checks in `auth/interfaces.go`
- Update `container.go` imports and constructor calls
- Add backward-compat type aliases and constructor wrappers in `aliases.go`

Closes PSY-86

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/services/auth/...` — all auth tests pass
- [x] Root services tests pass
- [x] Handler tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)