### PR TITLE
Extract notification services into notification/ sub-package (PSY-89)

### DIFF
--- a/backend/internal/api/handlers/auth_integration_test.go
+++ b/backend/internal/api/handlers/auth_integration_test.go
@@ -14,6 +14,7 @@ import (
 	autherrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/models"
 	"psychic-homily-backend/internal/services"
+	"psychic-homily-backend/internal/services/notification"
 )
 
 // --- Suite ---
@@ -77,8 +78,8 @@ func (s *AuthHandlerIntegrationSuite) newAuthHandler(emailConfigured bool) *Auth
 
 	authSvc := services.NewAuthService(s.deps.db, emailCfg)
 	jwtSvc := services.NewJWTService(s.deps.db, emailCfg)
-	emailSvc := services.NewEmailService(emailCfg)
-	discordSvc := services.NewDiscordService(emailCfg)
+	emailSvc := notification.NewEmailService(emailCfg)
+	discordSvc := notification.NewDiscordService(emailCfg)
 	pv := services.NewPasswordValidator()
 
 	return NewAuthHandler(

--- a/backend/internal/api/handlers/handler_integration_helpers_test.go
+++ b/backend/internal/api/handlers/handler_integration_helpers_test.go
@@ -17,6 +17,7 @@ import (
 	"psychic-homily-backend/internal/services"
 	"psychic-homily-backend/internal/services/catalog"
 	"psychic-homily-backend/internal/services/engagement"
+	"psychic-homily-backend/internal/services/notification"
 	"psychic-homily-backend/internal/services/pipeline"
 	"psychic-homily-backend/internal/testutil"
 )
@@ -33,7 +34,7 @@ type handlerIntegrationDeps struct {
 	showReportService     *services.ShowReportService
 	userService           *services.UserService
 	auditLogService       *services.AuditLogService
-	discordService        *services.DiscordService
+	discordService        *notification.DiscordService
 	musicDiscoveryService *pipeline.MusicDiscoveryService
 	extractionService     *pipeline.ExtractionService
 	apiTokenService       *services.APITokenService
@@ -109,7 +110,7 @@ func setupHandlerIntegrationDeps(t *testing.T) *handlerIntegrationDeps {
 		showReportService:     services.NewShowReportService(db),
 		userService:           services.NewUserService(db),
 		auditLogService:       services.NewAuditLogService(db),
-		discordService:        services.NewDiscordService(emptyCfg),
+		discordService:        notification.NewDiscordService(emptyCfg),
 		musicDiscoveryService: pipeline.NewMusicDiscoveryService(emptyCfg),
 		extractionService:     pipeline.NewExtractionService(db, emptyCfg, catalog.NewArtistService(db), catalog.NewVenueService(db)),
 		apiTokenService:       services.NewAPITokenService(db),

--- a/backend/internal/services/cleanup.go
+++ b/backend/internal/services/cleanup.go
@@ -11,6 +11,7 @@ import (
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/db"
+	"psychic-homily-backend/internal/services/notification"
 )
 
 // Default cleanup interval (24 hours)
@@ -125,7 +126,7 @@ func (s *CleanupService) runCleanupCycle() {
 
 		s.logger.Info("purging expired account",
 			"user_id", account.ID,
-			"email_hash", hashEmail(email),
+			"email_hash", notification.HashEmail(email),
 			"deleted_at", deletedAt,
 		)
 

--- a/backend/internal/services/container.go
+++ b/backend/internal/services/container.go
@@ -9,6 +9,7 @@ import (
 	"psychic-homily-backend/internal/services/auth"
 	"psychic-homily-backend/internal/services/catalog"
 	"psychic-homily-backend/internal/services/engagement"
+	"psychic-homily-backend/internal/services/notification"
 	"psychic-homily-backend/internal/services/pipeline"
 )
 
@@ -37,8 +38,8 @@ type ServiceContainer struct {
 	VenueSourceConfig *pipeline.VenueSourceConfigService
 
 	// Config-only services
-	Discord        *DiscordService
-	Email          *EmailService
+	Discord        *notification.DiscordService
+	Email          *notification.EmailService
 	MusicDiscovery *pipeline.MusicDiscoveryService
 
 	// No-param services
@@ -75,7 +76,7 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 	}
 
 	savedShow := engagement.NewSavedShowService(database)
-	email := NewEmailService(cfg)
+	email := notification.NewEmailService(cfg)
 	userService := NewUserService(database)
 
 	// Services needed by PipelineService — created first so we can inject them.
@@ -112,7 +113,7 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 		VenueSourceConfig: venueSourceConfig,
 
 		// Config-only services
-		Discord:        NewDiscordService(cfg),
+		Discord:        notification.NewDiscordService(cfg),
 		Email:          email,
 		MusicDiscovery: pipeline.NewMusicDiscoveryService(cfg),
 

--- a/backend/internal/services/interfaces.go
+++ b/backend/internal/services/interfaces.go
@@ -49,6 +49,8 @@ type CollectionServiceInterface = contracts.CollectionServiceInterface
 // Fetcher, Pipeline) are checked in internal/services/pipeline/interfaces.go.
 // Auth services (Auth, JWT, PasswordValidator, AppleAuth, WebAuthn)
 // are checked in internal/services/auth/interfaces.go.
+// Notification services (Email, Discord) are checked in
+// internal/services/notification/interfaces.go.
 var (
 	_ ShowServiceInterface          = (*catalog.ShowService)(nil)
 	_ VenueServiceInterface         = (*catalog.VenueService)(nil)
@@ -57,8 +59,6 @@ var (
 	_ ArtistReportServiceInterface  = (*ArtistReportService)(nil)
 	_ AuditLogServiceInterface      = (*AuditLogService)(nil)
 	_ UserServiceInterface          = (*UserService)(nil)
-	_ EmailServiceInterface         = (*EmailService)(nil)
-	_ DiscordServiceInterface       = (*DiscordService)(nil)
 	_ APITokenServiceInterface      = (*APITokenService)(nil)
 	_ DataSyncServiceInterface      = (*DataSyncService)(nil)
 	_ AdminStatsServiceInterface    = (*AdminStatsService)(nil)

--- a/backend/internal/services/notification/discord.go
+++ b/backend/internal/services/notification/discord.go
@@ -1,4 +1,4 @@
-package services
+package notification
 
 import (
 	"bytes"
@@ -12,6 +12,7 @@ import (
 
 	"psychic-homily-backend/internal/config"
 	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
 )
 
 // Discord embed colors
@@ -77,7 +78,7 @@ func (s *DiscordService) NotifyNewUser(user *models.User) {
 
 	email := ""
 	if user.Email != nil {
-		email = hashEmail(*user.Email)
+		email = HashEmail(*user.Email)
 	}
 
 	name := buildUserName(user)
@@ -97,7 +98,7 @@ func (s *DiscordService) NotifyNewUser(user *models.User) {
 }
 
 // NotifyNewShow sends a notification when a new show is submitted
-func (s *DiscordService) NotifyNewShow(show *ShowResponse, submitterEmail string) {
+func (s *DiscordService) NotifyNewShow(show *contracts.ShowResponse, submitterEmail string) {
 	if !s.IsConfigured() || show == nil {
 		return
 	}
@@ -108,7 +109,7 @@ func (s *DiscordService) NotifyNewShow(show *ShowResponse, submitterEmail string
 	fields := []DiscordEmbedField{
 		{Name: "Show ID", Value: fmt.Sprintf("%d", show.ID), Inline: true},
 		{Name: "Status", Value: show.Status, Inline: true},
-		{Name: "Submitter", Value: hashEmail(submitterEmail), Inline: true},
+		{Name: "Submitter", Value: HashEmail(submitterEmail), Inline: true},
 		{Name: "Venue(s)", Value: venues, Inline: false},
 		{Name: "Artist(s)", Value: artists, Inline: false},
 	}
@@ -138,7 +139,7 @@ func (s *DiscordService) NotifyShowStatusChange(showTitle string, showID uint, o
 
 	fields := []DiscordEmbedField{
 		{Name: "Show ID", Value: fmt.Sprintf("%d", showID), Inline: true},
-		{Name: "Changed By", Value: hashEmail(actorEmail), Inline: true},
+		{Name: "Changed By", Value: HashEmail(actorEmail), Inline: true},
 	}
 
 	// Add action links based on new status
@@ -159,7 +160,7 @@ func (s *DiscordService) NotifyShowStatusChange(showTitle string, showID uint, o
 }
 
 // NotifyShowApproved sends a notification when an admin approves a show
-func (s *DiscordService) NotifyShowApproved(show *ShowResponse) {
+func (s *DiscordService) NotifyShowApproved(show *contracts.ShowResponse) {
 	if !s.IsConfigured() || show == nil {
 		return
 	}
@@ -183,7 +184,7 @@ func (s *DiscordService) NotifyShowApproved(show *ShowResponse) {
 }
 
 // NotifyShowRejected sends a notification when an admin rejects a show
-func (s *DiscordService) NotifyShowRejected(show *ShowResponse, reason string) {
+func (s *DiscordService) NotifyShowRejected(show *contracts.ShowResponse, reason string) {
 	if !s.IsConfigured() || show == nil {
 		return
 	}
@@ -235,7 +236,7 @@ func (s *DiscordService) NotifyShowReport(report *models.ShowReport, reporterEma
 		{Name: "Report Type", Value: reportTypeDisplay, Inline: true},
 		{Name: "Show", Value: showTitle, Inline: true},
 		{Name: "Event Date", Value: eventDate, Inline: true},
-		{Name: "Reporter", Value: hashEmail(reporterEmail), Inline: true},
+		{Name: "Reporter", Value: HashEmail(reporterEmail), Inline: true},
 	}
 
 	// Add details if provided
@@ -284,7 +285,7 @@ func (s *DiscordService) NotifyArtistReport(report *models.ArtistReport, reporte
 	fields := []DiscordEmbedField{
 		{Name: "Report Type", Value: reportTypeDisplay, Inline: true},
 		{Name: "Artist", Value: artistName, Inline: true},
-		{Name: "Reporter", Value: hashEmail(reporterEmail), Inline: true},
+		{Name: "Reporter", Value: HashEmail(reporterEmail), Inline: true},
 	}
 
 	// Add details if provided
@@ -324,7 +325,7 @@ func (s *DiscordService) NotifyNewVenue(venueID uint, venueName, city, state str
 	fields := []DiscordEmbedField{
 		{Name: "Venue ID", Value: fmt.Sprintf("%d", venueID), Inline: true},
 		{Name: "Location", Value: location, Inline: true},
-		{Name: "Submitted By", Value: hashEmail(submitterEmail), Inline: true},
+		{Name: "Submitted By", Value: HashEmail(submitterEmail), Inline: true},
 	}
 
 	if address != nil && *address != "" {
@@ -355,7 +356,7 @@ func (s *DiscordService) NotifyPendingVenueEdit(editID, venueID uint, venueName,
 	fields := []DiscordEmbedField{
 		{Name: "Venue ID", Value: fmt.Sprintf("%d", venueID), Inline: true},
 		{Name: "Edit ID", Value: fmt.Sprintf("%d", editID), Inline: true},
-		{Name: "Submitted By", Value: hashEmail(submitterEmail), Inline: true},
+		{Name: "Submitted By", Value: HashEmail(submitterEmail), Inline: true},
 	}
 
 	// Add action link
@@ -406,8 +407,8 @@ func (s *DiscordService) sendWebhook(embed DiscordEmbed) {
 	}
 }
 
-// hashEmail masks an email for privacy (e.g., "jo***@example.com")
-func hashEmail(email string) string {
+// HashEmail masks an email for privacy (e.g., "jo***@example.com")
+func HashEmail(email string) string {
 	if email == "" {
 		return "N/A"
 	}
@@ -449,7 +450,7 @@ func buildUserName(user *models.User) string {
 }
 
 // buildVenueList builds a comma-separated list of venue names
-func buildVenueList(venues []VenueResponse) string {
+func buildVenueList(venues []contracts.VenueResponse) string {
 	if len(venues) == 0 {
 		return "N/A"
 	}
@@ -463,7 +464,7 @@ func buildVenueList(venues []VenueResponse) string {
 }
 
 // buildArtistList builds a comma-separated list of artist names
-func buildArtistList(artists []ArtistResponse) string {
+func buildArtistList(artists []contracts.ArtistResponse) string {
 	if len(artists) == 0 {
 		return "N/A"
 	}

--- a/backend/internal/services/notification/discord_test.go
+++ b/backend/internal/services/notification/discord_test.go
@@ -1,4 +1,4 @@
-package services
+package notification
 
 import (
 	"encoding/json"
@@ -13,7 +13,10 @@ import (
 
 	"psychic-homily-backend/internal/config"
 	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
 )
+
+func stringPtr(s string) *string { return &s }
 
 // =============================================================================
 // HELPERS
@@ -153,7 +156,7 @@ func TestHashEmail(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, hashEmail(tt.email))
+			assert.Equal(t, tt.want, HashEmail(tt.email))
 		})
 	}
 }
@@ -181,13 +184,13 @@ func TestBuildUserName(t *testing.T) {
 func TestBuildVenueList(t *testing.T) {
 	tests := []struct {
 		name   string
-		venues []VenueResponse
+		venues []contracts.VenueResponse
 		want   string
 	}{
 		{"no venues", nil, "N/A"},
-		{"empty slice", []VenueResponse{}, "N/A"},
-		{"one venue", []VenueResponse{{Name: "The Crescent"}}, "The Crescent"},
-		{"multiple venues", []VenueResponse{{Name: "Venue A"}, {Name: "Venue B"}, {Name: "Venue C"}}, "Venue A, Venue B, Venue C"},
+		{"empty slice", []contracts.VenueResponse{}, "N/A"},
+		{"one venue", []contracts.VenueResponse{{Name: "The Crescent"}}, "The Crescent"},
+		{"multiple venues", []contracts.VenueResponse{{Name: "Venue A"}, {Name: "Venue B"}, {Name: "Venue C"}}, "Venue A, Venue B, Venue C"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -201,14 +204,14 @@ func TestBuildArtistList(t *testing.T) {
 	notHeadliner := false
 	tests := []struct {
 		name    string
-		artists []ArtistResponse
+		artists []contracts.ArtistResponse
 		want    string
 	}{
 		{"no artists", nil, "N/A"},
-		{"empty slice", []ArtistResponse{}, "N/A"},
-		{"one artist, no headliner flag", []ArtistResponse{{Name: "Band"}}, "Band"},
-		{"one headliner", []ArtistResponse{{Name: "Star", IsHeadliner: &headliner}}, "Star (headliner)"},
-		{"mixed", []ArtistResponse{
+		{"empty slice", []contracts.ArtistResponse{}, "N/A"},
+		{"one artist, no headliner flag", []contracts.ArtistResponse{{Name: "Band"}}, "Band"},
+		{"one headliner", []contracts.ArtistResponse{{Name: "Star", IsHeadliner: &headliner}}, "Star (headliner)"},
+		{"mixed", []contracts.ArtistResponse{
 			{Name: "Headliner", IsHeadliner: &headliner},
 			{Name: "Opener", IsHeadliner: &notHeadliner},
 		}, "Headliner (headliner), Opener"},
@@ -358,13 +361,13 @@ func TestNotifyNewUser_NoName(t *testing.T) {
 func TestNotifyNewShow_Success(t *testing.T) {
 	svc, payloads, _ := setupDiscordTest(t)
 	headliner := true
-	show := &ShowResponse{
+	show := &contracts.ShowResponse{
 		ID:        10,
 		Title:     "Rock Night",
 		EventDate: time.Date(2026, 7, 15, 20, 0, 0, 0, time.UTC),
 		Status:    "pending",
-		Venues:    []VenueResponse{{Name: "Valley Bar"}},
-		Artists:   []ArtistResponse{{Name: "The Band", IsHeadliner: &headliner}},
+		Venues:    []contracts.VenueResponse{{Name: "Valley Bar"}},
+		Artists:   []contracts.ArtistResponse{{Name: "The Band", IsHeadliner: &headliner}},
 	}
 
 	svc.NotifyNewShow(show, "submitter@test.com")
@@ -389,7 +392,7 @@ func TestNotifyNewShow_NotConfigured(t *testing.T) {
 	svc := &DiscordService{enabled: false}
 	payloads := make(chan []byte, 1)
 
-	svc.NotifyNewShow(&ShowResponse{}, "test@test.com")
+	svc.NotifyNewShow(&contracts.ShowResponse{}, "test@test.com")
 	assertNoPayload(t, payloads)
 }
 
@@ -402,11 +405,11 @@ func TestNotifyNewShow_NilShow(t *testing.T) {
 
 func TestNotifyShowApproved_Success(t *testing.T) {
 	svc, payloads, _ := setupDiscordTest(t)
-	show := &ShowResponse{
+	show := &contracts.ShowResponse{
 		ID:        20,
 		Title:     "Approved Gig",
 		EventDate: time.Date(2026, 8, 1, 20, 0, 0, 0, time.UTC),
-		Venues:    []VenueResponse{{Name: "Main Stage"}},
+		Venues:    []contracts.VenueResponse{{Name: "Main Stage"}},
 	}
 
 	svc.NotifyShowApproved(show)
@@ -421,7 +424,7 @@ func TestNotifyShowApproved_NotConfigured(t *testing.T) {
 	svc := &DiscordService{enabled: false}
 	payloads := make(chan []byte, 1)
 
-	svc.NotifyShowApproved(&ShowResponse{})
+	svc.NotifyShowApproved(&contracts.ShowResponse{})
 	assertNoPayload(t, payloads)
 }
 
@@ -434,11 +437,11 @@ func TestNotifyShowApproved_NilShow(t *testing.T) {
 
 func TestNotifyShowRejected_Success(t *testing.T) {
 	svc, payloads, _ := setupDiscordTest(t)
-	show := &ShowResponse{
+	show := &contracts.ShowResponse{
 		ID:        30,
 		Title:     "Bad Show",
 		EventDate: time.Date(2026, 9, 1, 20, 0, 0, 0, time.UTC),
-		Venues:    []VenueResponse{{Name: "Some Venue"}},
+		Venues:    []contracts.VenueResponse{{Name: "Some Venue"}},
 	}
 
 	svc.NotifyShowRejected(show, "Duplicate listing")
@@ -454,7 +457,7 @@ func TestNotifyShowRejected_NotConfigured(t *testing.T) {
 	svc := &DiscordService{enabled: false}
 	payloads := make(chan []byte, 1)
 
-	svc.NotifyShowRejected(&ShowResponse{}, "reason")
+	svc.NotifyShowRejected(&contracts.ShowResponse{}, "reason")
 	assertNoPayload(t, payloads)
 }
 

--- a/backend/internal/services/notification/email.go
+++ b/backend/internal/services/notification/email.go
@@ -1,4 +1,4 @@
-package services
+package notification
 
 import (
 	"fmt"

--- a/backend/internal/services/notification/email_test.go
+++ b/backend/internal/services/notification/email_test.go
@@ -1,4 +1,4 @@
-package services
+package notification
 
 import (
 	"encoding/json"

--- a/backend/internal/services/notification/interfaces.go
+++ b/backend/internal/services/notification/interfaces.go
@@ -1,0 +1,9 @@
+package notification
+
+import "psychic-homily-backend/internal/services/contracts"
+
+// Compile-time interface satisfaction checks for notification services.
+var (
+	_ contracts.EmailServiceInterface   = (*EmailService)(nil)
+	_ contracts.DiscordServiceInterface = (*DiscordService)(nil)
+)


### PR DESCRIPTION
## Summary
- Move 2 notification services (`EmailService`, `DiscordService`) into `internal/services/notification/` sub-package
- Export `HashEmail` (was private `hashEmail`) since `cleanup.go` also uses it
- Add compile-time interface satisfaction checks in `notification/interfaces.go`
- Update `container.go`, handler test helpers, and auth integration test imports

Closes PSY-89

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/services/notification/...` — all 44 notification tests pass
- [x] Root services tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)