### PR TITLE
Extract user services into user/ sub-package (PSY-90)

### DIFF
--- a/backend/internal/api/handlers/handler_integration_helpers_test.go
+++ b/backend/internal/api/handlers/handler_integration_helpers_test.go
@@ -19,6 +19,7 @@ import (
 	"psychic-homily-backend/internal/services/engagement"
 	"psychic-homily-backend/internal/services/notification"
 	"psychic-homily-backend/internal/services/pipeline"
+	usersvc "psychic-homily-backend/internal/services/user"
 	"psychic-homily-backend/internal/testutil"
 )
 
@@ -32,7 +33,7 @@ type handlerIntegrationDeps struct {
 	savedShowService      *engagement.SavedShowService
 	favoriteVenueService  *engagement.FavoriteVenueService
 	showReportService     *services.ShowReportService
-	userService           *services.UserService
+	userService           *usersvc.UserService
 	auditLogService       *services.AuditLogService
 	discordService        *notification.DiscordService
 	musicDiscoveryService *pipeline.MusicDiscoveryService
@@ -108,7 +109,7 @@ func setupHandlerIntegrationDeps(t *testing.T) *handlerIntegrationDeps {
 		savedShowService:      engagement.NewSavedShowService(db),
 		favoriteVenueService:  engagement.NewFavoriteVenueService(db),
 		showReportService:     services.NewShowReportService(db),
-		userService:           services.NewUserService(db),
+		userService:           usersvc.NewUserService(db),
 		auditLogService:       services.NewAuditLogService(db),
 		discordService:        notification.NewDiscordService(emptyCfg),
 		musicDiscoveryService: pipeline.NewMusicDiscoveryService(emptyCfg),

--- a/backend/internal/services/aliases.go
+++ b/backend/internal/services/aliases.go
@@ -10,6 +10,7 @@ import (
 	"psychic-homily-backend/internal/config"
 	"psychic-homily-backend/internal/services/auth"
 	"psychic-homily-backend/internal/services/contracts"
+	usersvc "psychic-homily-backend/internal/services/user"
 )
 
 // ──────────────────────────────────────────────
@@ -28,19 +29,19 @@ type PasswordValidator = auth.PasswordValidator
 // NewAuthService creates an AuthService.
 // Deprecated: prefer auth.NewAuthService with explicit userService dependency.
 func NewAuthService(database *gorm.DB, cfg *config.Config) *auth.AuthService {
-	return auth.NewAuthService(database, cfg, NewUserService(database))
+	return auth.NewAuthService(database, cfg, usersvc.NewUserService(database))
 }
 
 // NewJWTService creates a JWTService.
 // Deprecated: prefer auth.NewJWTService with explicit userService dependency.
 func NewJWTService(database *gorm.DB, cfg *config.Config) *auth.JWTService {
-	return auth.NewJWTService(database, cfg, NewUserService(database))
+	return auth.NewJWTService(database, cfg, usersvc.NewUserService(database))
 }
 
 // NewAppleAuthService creates an AppleAuthService.
 // Deprecated: prefer auth.NewAppleAuthService with explicit jwtService dependency.
 func NewAppleAuthService(database *gorm.DB, cfg *config.Config) *auth.AppleAuthService {
-	jwtSvc := auth.NewJWTService(database, cfg, NewUserService(database))
+	jwtSvc := auth.NewJWTService(database, cfg, usersvc.NewUserService(database))
 	return auth.NewAppleAuthService(database, cfg, jwtSvc)
 }
 

--- a/backend/internal/services/cleanup.go
+++ b/backend/internal/services/cleanup.go
@@ -12,6 +12,7 @@ import (
 
 	"psychic-homily-backend/db"
 	"psychic-homily-backend/internal/services/notification"
+	usersvc "psychic-homily-backend/internal/services/user"
 )
 
 // Default cleanup interval (24 hours)
@@ -20,7 +21,7 @@ const DefaultCleanupInterval = 24 * time.Hour
 // CleanupService handles background cleanup tasks
 type CleanupService struct {
 	db           *gorm.DB
-	userService  *UserService
+	userService  *usersvc.UserService
 	interval     time.Duration
 	stopCh       chan struct{}
 	wg           sync.WaitGroup
@@ -44,7 +45,7 @@ func NewCleanupService(database *gorm.DB) *CleanupService {
 
 	return &CleanupService{
 		db:          database,
-		userService: NewUserService(database),
+		userService: usersvc.NewUserService(database),
 		interval:    interval,
 		stopCh:      make(chan struct{}),
 		logger:      slog.Default(),

--- a/backend/internal/services/container.go
+++ b/backend/internal/services/container.go
@@ -11,6 +11,7 @@ import (
 	"psychic-homily-backend/internal/services/engagement"
 	"psychic-homily-backend/internal/services/notification"
 	"psychic-homily-backend/internal/services/pipeline"
+	usersvc "psychic-homily-backend/internal/services/user"
 )
 
 // ServiceContainer eagerly creates all services once at startup.
@@ -20,7 +21,7 @@ type ServiceContainer struct {
 	AdminStats         *AdminStatsService
 	APIToken           *APITokenService
 	Artist             *catalog.ArtistService
-	ContributorProfile *ContributorProfileService
+	ContributorProfile *usersvc.ContributorProfileService
 	ArtistReport  *ArtistReportService
 	AuditLog      *AuditLogService
 	Bookmark      *engagement.BookmarkService
@@ -33,7 +34,7 @@ type ServiceContainer struct {
 	SavedShow     *engagement.SavedShowService
 	Show          *catalog.ShowService
 	ShowReport    *ShowReportService
-	User              *UserService
+	User              *usersvc.UserService
 	Venue             *catalog.VenueService
 	VenueSourceConfig *pipeline.VenueSourceConfigService
 
@@ -77,7 +78,7 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 
 	savedShow := engagement.NewSavedShowService(database)
 	email := notification.NewEmailService(cfg)
-	userService := NewUserService(database)
+	userService := usersvc.NewUserService(database)
 
 	// Services needed by PipelineService — created first so we can inject them.
 	artist := catalog.NewArtistService(database)
@@ -95,7 +96,7 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 		AdminStats:         NewAdminStatsService(database),
 		APIToken:           NewAPITokenService(database),
 		Artist:             artist,
-		ContributorProfile: NewContributorProfileService(database),
+		ContributorProfile: usersvc.NewContributorProfileService(database),
 		ArtistReport:  NewArtistReportService(database),
 		AuditLog:      NewAuditLogService(database),
 		Bookmark:      engagement.NewBookmarkService(database),

--- a/backend/internal/services/interfaces.go
+++ b/backend/internal/services/interfaces.go
@@ -51,6 +51,8 @@ type CollectionServiceInterface = contracts.CollectionServiceInterface
 // are checked in internal/services/auth/interfaces.go.
 // Notification services (Email, Discord) are checked in
 // internal/services/notification/interfaces.go.
+// User services (UserService, ContributorProfileService) are checked in
+// internal/services/user/interfaces.go.
 var (
 	_ ShowServiceInterface          = (*catalog.ShowService)(nil)
 	_ VenueServiceInterface         = (*catalog.VenueService)(nil)
@@ -58,13 +60,11 @@ var (
 	_ ShowReportServiceInterface    = (*ShowReportService)(nil)
 	_ ArtistReportServiceInterface  = (*ArtistReportService)(nil)
 	_ AuditLogServiceInterface      = (*AuditLogService)(nil)
-	_ UserServiceInterface          = (*UserService)(nil)
 	_ APITokenServiceInterface      = (*APITokenService)(nil)
 	_ DataSyncServiceInterface      = (*DataSyncService)(nil)
 	_ AdminStatsServiceInterface    = (*AdminStatsService)(nil)
 	_ FestivalServiceInterface       = (*catalog.FestivalService)(nil)
 	_ LabelServiceInterface          = (*catalog.LabelService)(nil)
 	_ ReleaseServiceInterface       = (*catalog.ReleaseService)(nil)
-	_ ContributorProfileServiceInterface    = (*ContributorProfileService)(nil)
 	_ CollectionServiceInterface            = (*CollectionService)(nil)
 )

--- a/backend/internal/services/user/contributor_profile.go
+++ b/backend/internal/services/user/contributor_profile.go
@@ -1,4 +1,4 @@
-package services
+package user
 
 import (
 	"encoding/json"
@@ -9,6 +9,7 @@ import (
 
 	"psychic-homily-backend/db"
 	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
 )
 
 // ContributorProfileService handles contributor profile and contribution history operations.
@@ -33,8 +34,8 @@ var binaryOnlyFields = map[string]bool{
 }
 
 // ValidatePrivacySettings checks that all fields have valid values.
-func ValidatePrivacySettings(ps PrivacySettings) error {
-	fields := map[string]PrivacyLevel{
+func ValidatePrivacySettings(ps contracts.PrivacySettings) error {
+	fields := map[string]contracts.PrivacyLevel{
 		"contributions":    ps.Contributions,
 		"saved_shows":      ps.SavedShows,
 		"attendance":       ps.Attendance,
@@ -44,24 +45,24 @@ func ValidatePrivacySettings(ps PrivacySettings) error {
 		"profile_sections": ps.ProfileSections,
 	}
 	for name, level := range fields {
-		if level != PrivacyVisible && level != PrivacyCountOnly && level != PrivacyHidden {
+		if level != contracts.PrivacyVisible && level != contracts.PrivacyCountOnly && level != contracts.PrivacyHidden {
 			return fmt.Errorf("invalid privacy level %q for field %q", level, name)
 		}
-		if binaryOnlyFields[name] && level == PrivacyCountOnly {
+		if binaryOnlyFields[name] && level == contracts.PrivacyCountOnly {
 			return fmt.Errorf("field %q only supports 'visible' or 'hidden'", name)
 		}
 	}
 	return nil
 }
 
-// parsePrivacySettings extracts PrivacySettings from a user's JSONB column.
-func parsePrivacySettings(raw *json.RawMessage) PrivacySettings {
+// parsePrivacySettings extracts contracts.PrivacySettings from a user's JSONB column.
+func parsePrivacySettings(raw *json.RawMessage) contracts.PrivacySettings {
 	if raw == nil {
-		return DefaultPrivacySettings()
+		return contracts.DefaultPrivacySettings()
 	}
-	var ps PrivacySettings
+	var ps contracts.PrivacySettings
 	if err := json.Unmarshal(*raw, &ps); err != nil {
-		return DefaultPrivacySettings()
+		return contracts.DefaultPrivacySettings()
 	}
 	return ps
 }
@@ -96,7 +97,7 @@ var moderationActions = map[string]bool{
 // =============================================================================
 
 // GetPublicProfile returns a user's public profile with privacy-gated fields.
-func (s *ContributorProfileService) GetPublicProfile(username string, viewerID *uint) (*PublicProfileResponse, error) {
+func (s *ContributorProfileService) GetPublicProfile(username string, viewerID *uint) (*contracts.PublicProfileResponse, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
@@ -124,7 +125,7 @@ func (s *ContributorProfileService) GetPublicProfile(username string, viewerID *
 		username_str = *user.Username
 	}
 
-	resp := &PublicProfileResponse{
+	resp := &contracts.PublicProfileResponse{
 		Username:          username_str,
 		Bio:               user.Bio,
 		AvatarURL:         user.AvatarURL,
@@ -156,26 +157,26 @@ func (s *ContributorProfileService) GetPublicProfile(username string, viewerID *
 
 	// Non-owner: apply privacy gating
 	switch privacy.Contributions {
-	case PrivacyVisible:
+	case contracts.PrivacyVisible:
 		stats, err := s.GetContributionStats(user.ID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get contribution stats: %w", err)
 		}
 		resp.Stats = stats
-	case PrivacyCountOnly:
+	case contracts.PrivacyCountOnly:
 		stats, err := s.GetContributionStats(user.ID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get contribution stats: %w", err)
 		}
 		resp.StatsCount = &stats.TotalContributions
 	}
-	// PrivacyHidden: Stats and StatsCount both remain nil
+	// contracts.PrivacyHidden: Stats and StatsCount both remain nil
 
-	if privacy.LastActive == PrivacyVisible {
+	if privacy.LastActive == contracts.PrivacyVisible {
 		resp.LastActive = &user.UpdatedAt
 	}
 
-	if privacy.ProfileSections == PrivacyVisible {
+	if privacy.ProfileSections == contracts.PrivacyVisible {
 		sections, err := s.GetUserSections(user.ID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get profile sections: %w", err)
@@ -187,7 +188,7 @@ func (s *ContributorProfileService) GetPublicProfile(username string, viewerID *
 }
 
 // GetOwnProfile returns the authenticated user's own profile, bypassing visibility checks.
-func (s *ContributorProfileService) GetOwnProfile(userID uint) (*PublicProfileResponse, error) {
+func (s *ContributorProfileService) GetOwnProfile(userID uint) (*contracts.PublicProfileResponse, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
@@ -218,7 +219,7 @@ func (s *ContributorProfileService) GetOwnProfile(userID uint) (*PublicProfileRe
 		username = *user.Username
 	}
 
-	return &PublicProfileResponse{
+	return &contracts.PublicProfileResponse{
 		Username:          username,
 		Bio:               user.Bio,
 		AvatarURL:         user.AvatarURL,
@@ -238,7 +239,7 @@ func (s *ContributorProfileService) GetOwnProfile(userID uint) (*PublicProfileRe
 // =============================================================================
 
 // UpdatePrivacySettings validates and persists new privacy settings for a user.
-func (s *ContributorProfileService) UpdatePrivacySettings(userID uint, settings PrivacySettings) (*PrivacySettings, error) {
+func (s *ContributorProfileService) UpdatePrivacySettings(userID uint, settings contracts.PrivacySettings) (*contracts.PrivacySettings, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
@@ -265,12 +266,12 @@ func (s *ContributorProfileService) UpdatePrivacySettings(userID uint, settings 
 // =============================================================================
 
 // GetContributionStats computes aggregate contribution counts for a user.
-func (s *ContributorProfileService) GetContributionStats(userID uint) (*ContributionStats, error) {
+func (s *ContributorProfileService) GetContributionStats(userID uint) (*contracts.ContributionStats, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
 
-	stats := &ContributionStats{}
+	stats := &contracts.ContributionStats{}
 
 	// Count submissions from entity tables
 	s.db.Model(&models.Show{}).Where("submitted_by = ?", userID).Count(&stats.ShowsSubmitted)
@@ -321,7 +322,7 @@ func (s *ContributorProfileService) GetContributionStats(userID uint) (*Contribu
 // =============================================================================
 
 // GetContributionHistory returns a paginated, unified contribution timeline for a user.
-func (s *ContributorProfileService) GetContributionHistory(userID uint, limit, offset int, entityType string) ([]*ContributionEntry, int64, error) {
+func (s *ContributorProfileService) GetContributionHistory(userID uint, limit, offset int, entityType string) ([]*contracts.ContributionEntry, int64, error) {
 	if s.db == nil {
 		return nil, 0, fmt.Errorf("database not initialized")
 	}
@@ -369,9 +370,9 @@ func (s *ContributorProfileService) GetContributionHistory(userID uint, limit, o
 		return nil, 0, fmt.Errorf("failed to get contributions: %w", err)
 	}
 
-	entries := make([]*ContributionEntry, len(rows))
+	entries := make([]*contracts.ContributionEntry, len(rows))
 	for i, row := range rows {
-		entry := &ContributionEntry{
+		entry := &contracts.ContributionEntry{
 			ID:         row.ID,
 			Action:     row.Action,
 			EntityType: row.EntityType,
@@ -400,7 +401,7 @@ func (s *ContributorProfileService) GetContributionHistory(userID uint, limit, o
 const maxProfileSections = 3
 
 // GetUserSections returns visible profile sections for a public user.
-func (s *ContributorProfileService) GetUserSections(userID uint) ([]*ProfileSectionResponse, error) {
+func (s *ContributorProfileService) GetUserSections(userID uint) ([]*contracts.ProfileSectionResponse, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
@@ -417,7 +418,7 @@ func (s *ContributorProfileService) GetUserSections(userID uint) ([]*ProfileSect
 }
 
 // GetOwnSections returns all profile sections for the authenticated user.
-func (s *ContributorProfileService) GetOwnSections(userID uint) ([]*ProfileSectionResponse, error) {
+func (s *ContributorProfileService) GetOwnSections(userID uint) ([]*contracts.ProfileSectionResponse, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
@@ -434,7 +435,7 @@ func (s *ContributorProfileService) GetOwnSections(userID uint) ([]*ProfileSecti
 }
 
 // CreateSection creates a new profile section. Returns error if user already has max sections.
-func (s *ContributorProfileService) CreateSection(userID uint, title string, content string, position int) (*ProfileSectionResponse, error) {
+func (s *ContributorProfileService) CreateSection(userID uint, title string, content string, position int) (*contracts.ProfileSectionResponse, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
@@ -472,7 +473,7 @@ func (s *ContributorProfileService) CreateSection(userID uint, title string, con
 }
 
 // UpdateSection updates a profile section owned by the user.
-func (s *ContributorProfileService) UpdateSection(userID uint, sectionID uint, updates map[string]interface{}) (*ProfileSectionResponse, error) {
+func (s *ContributorProfileService) UpdateSection(userID uint, sectionID uint, updates map[string]interface{}) (*contracts.ProfileSectionResponse, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
@@ -533,16 +534,16 @@ func (s *ContributorProfileService) DeleteSection(userID uint, sectionID uint) e
 	return nil
 }
 
-func buildSectionResponses(sections []models.UserProfileSection) []*ProfileSectionResponse {
-	responses := make([]*ProfileSectionResponse, len(sections))
+func buildSectionResponses(sections []models.UserProfileSection) []*contracts.ProfileSectionResponse {
+	responses := make([]*contracts.ProfileSectionResponse, len(sections))
 	for i := range sections {
 		responses[i] = buildSectionResponse(&sections[i])
 	}
 	return responses
 }
 
-func buildSectionResponse(section *models.UserProfileSection) *ProfileSectionResponse {
-	return &ProfileSectionResponse{
+func buildSectionResponse(section *models.UserProfileSection) *contracts.ProfileSectionResponse {
+	return &contracts.ProfileSectionResponse{
 		ID:        section.ID,
 		Title:     section.Title,
 		Content:   section.Content,
@@ -557,7 +558,7 @@ func buildSectionResponse(section *models.UserProfileSection) *ProfileSectionRes
 // Entity Name Enrichment
 // =============================================================================
 
-func (s *ContributorProfileService) enrichEntityNames(entries []*ContributionEntry) {
+func (s *ContributorProfileService) enrichEntityNames(entries []*contracts.ContributionEntry) {
 	idsByType := make(map[string][]uint)
 	for _, e := range entries {
 		idsByType[e.EntityType] = append(idsByType[e.EntityType], e.EntityID)

--- a/backend/internal/services/user/contributor_profile_test.go
+++ b/backend/internal/services/user/contributor_profile_test.go
@@ -1,4 +1,4 @@
-package services
+package user
 
 import (
 	"context"
@@ -16,6 +16,7 @@ import (
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
 	"psychic-homily-backend/internal/testutil"
 )
 
@@ -61,7 +62,7 @@ func TestContributorProfileService_NilDatabase(t *testing.T) {
 	})
 
 	t.Run("UpdatePrivacySettings", func(t *testing.T) {
-		resp, err := svc.UpdatePrivacySettings(1, DefaultPrivacySettings())
+		resp, err := svc.UpdatePrivacySettings(1, contracts.DefaultPrivacySettings())
 		assert.Error(t, err)
 		assert.Equal(t, "database not initialized", err.Error())
 		assert.Nil(t, resp)
@@ -104,38 +105,38 @@ func TestContributorProfileService_NilDatabase(t *testing.T) {
 
 func TestValidatePrivacySettings(t *testing.T) {
 	t.Run("Valid_Defaults", func(t *testing.T) {
-		err := ValidatePrivacySettings(DefaultPrivacySettings())
+		err := ValidatePrivacySettings(contracts.DefaultPrivacySettings())
 		assert.NoError(t, err)
 	})
 
 	t.Run("Valid_AllVisible", func(t *testing.T) {
-		ps := PrivacySettings{
-			Contributions:   PrivacyVisible,
-			SavedShows:      PrivacyVisible,
-			Attendance:      PrivacyVisible,
-			Following:       PrivacyVisible,
-			Collections:     PrivacyVisible,
-			LastActive:      PrivacyVisible,
-			ProfileSections: PrivacyVisible,
+		ps := contracts.PrivacySettings{
+			Contributions:   contracts.PrivacyVisible,
+			SavedShows:      contracts.PrivacyVisible,
+			Attendance:      contracts.PrivacyVisible,
+			Following:       contracts.PrivacyVisible,
+			Collections:     contracts.PrivacyVisible,
+			LastActive:      contracts.PrivacyVisible,
+			ProfileSections: contracts.PrivacyVisible,
 		}
 		assert.NoError(t, ValidatePrivacySettings(ps))
 	})
 
 	t.Run("Valid_AllHidden", func(t *testing.T) {
-		ps := PrivacySettings{
-			Contributions:   PrivacyHidden,
-			SavedShows:      PrivacyHidden,
-			Attendance:      PrivacyHidden,
-			Following:       PrivacyHidden,
-			Collections:     PrivacyHidden,
-			LastActive:      PrivacyHidden,
-			ProfileSections: PrivacyHidden,
+		ps := contracts.PrivacySettings{
+			Contributions:   contracts.PrivacyHidden,
+			SavedShows:      contracts.PrivacyHidden,
+			Attendance:      contracts.PrivacyHidden,
+			Following:       contracts.PrivacyHidden,
+			Collections:     contracts.PrivacyHidden,
+			LastActive:      contracts.PrivacyHidden,
+			ProfileSections: contracts.PrivacyHidden,
 		}
 		assert.NoError(t, ValidatePrivacySettings(ps))
 	})
 
 	t.Run("Invalid_BadLevel", func(t *testing.T) {
-		ps := DefaultPrivacySettings()
+		ps := contracts.DefaultPrivacySettings()
 		ps.Contributions = "invalid"
 		err := ValidatePrivacySettings(ps)
 		assert.Error(t, err)
@@ -143,24 +144,24 @@ func TestValidatePrivacySettings(t *testing.T) {
 	})
 
 	t.Run("Invalid_CountOnly_LastActive", func(t *testing.T) {
-		ps := DefaultPrivacySettings()
-		ps.LastActive = PrivacyCountOnly
+		ps := contracts.DefaultPrivacySettings()
+		ps.LastActive = contracts.PrivacyCountOnly
 		err := ValidatePrivacySettings(ps)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "only supports 'visible' or 'hidden'")
 	})
 
 	t.Run("Invalid_CountOnly_ProfileSections", func(t *testing.T) {
-		ps := DefaultPrivacySettings()
-		ps.ProfileSections = PrivacyCountOnly
+		ps := contracts.DefaultPrivacySettings()
+		ps.ProfileSections = contracts.PrivacyCountOnly
 		err := ValidatePrivacySettings(ps)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "only supports 'visible' or 'hidden'")
 	})
 
 	t.Run("Valid_CountOnly_Contributions", func(t *testing.T) {
-		ps := DefaultPrivacySettings()
-		ps.Contributions = PrivacyCountOnly
+		ps := contracts.DefaultPrivacySettings()
+		ps.Contributions = contracts.PrivacyCountOnly
 		assert.NoError(t, ValidatePrivacySettings(ps))
 	})
 }
@@ -174,7 +175,7 @@ type ContributorProfileServiceIntegrationTestSuite struct {
 	container      testcontainers.Container
 	db             *gorm.DB
 	profileService *ContributorProfileService
-	auditLog       *AuditLogService
+	auditLog       *testAuditLogHelper
 	ctx            context.Context
 }
 
@@ -222,10 +223,10 @@ func (suite *ContributorProfileServiceIntegrationTestSuite) SetupSuite() {
 		suite.T().Fatalf("failed to get sql.DB: %v", err)
 	}
 
-	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "db", "migrations"))
+	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
 
 	suite.profileService = &ContributorProfileService{db: db}
-	suite.auditLog = &AuditLogService{db: db}
+	suite.auditLog = &testAuditLogHelper{db: db}
 }
 
 func (suite *ContributorProfileServiceIntegrationTestSuite) TearDownSuite() {
@@ -309,7 +310,7 @@ func (suite *ContributorProfileServiceIntegrationTestSuite) createVenue(submitte
 	return venue
 }
 
-func (suite *ContributorProfileServiceIntegrationTestSuite) setPrivacySettings(userID uint, ps PrivacySettings) {
+func (suite *ContributorProfileServiceIntegrationTestSuite) setPrivacySettings(userID uint, ps contracts.PrivacySettings) {
 	raw, err := json.Marshal(ps)
 	suite.Require().NoError(err)
 	rawMsg := json.RawMessage(raw)
@@ -676,40 +677,40 @@ func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetContributionH
 func (suite *ContributorProfileServiceIntegrationTestSuite) TestUpdatePrivacySettings_Success() {
 	user := suite.createTestUser("privacyuser")
 
-	settings := PrivacySettings{
-		Contributions:   PrivacyHidden,
-		SavedShows:      PrivacyVisible,
-		Attendance:      PrivacyCountOnly,
-		Following:       PrivacyHidden,
-		Collections:     PrivacyCountOnly,
-		LastActive:      PrivacyHidden,
-		ProfileSections: PrivacyVisible,
+	settings := contracts.PrivacySettings{
+		Contributions:   contracts.PrivacyHidden,
+		SavedShows:      contracts.PrivacyVisible,
+		Attendance:      contracts.PrivacyCountOnly,
+		Following:       contracts.PrivacyHidden,
+		Collections:     contracts.PrivacyCountOnly,
+		LastActive:      contracts.PrivacyHidden,
+		ProfileSections: contracts.PrivacyVisible,
 	}
 
 	result, err := suite.profileService.UpdatePrivacySettings(user.ID, settings)
 
 	suite.Require().NoError(err)
 	suite.Require().NotNil(result)
-	suite.Equal(PrivacyHidden, result.Contributions)
-	suite.Equal(PrivacyVisible, result.SavedShows)
-	suite.Equal(PrivacyCountOnly, result.Attendance)
-	suite.Equal(PrivacyHidden, result.Following)
-	suite.Equal(PrivacyCountOnly, result.Collections)
-	suite.Equal(PrivacyHidden, result.LastActive)
-	suite.Equal(PrivacyVisible, result.ProfileSections)
+	suite.Equal(contracts.PrivacyHidden, result.Contributions)
+	suite.Equal(contracts.PrivacyVisible, result.SavedShows)
+	suite.Equal(contracts.PrivacyCountOnly, result.Attendance)
+	suite.Equal(contracts.PrivacyHidden, result.Following)
+	suite.Equal(contracts.PrivacyCountOnly, result.Collections)
+	suite.Equal(contracts.PrivacyHidden, result.LastActive)
+	suite.Equal(contracts.PrivacyVisible, result.ProfileSections)
 }
 
 func (suite *ContributorProfileServiceIntegrationTestSuite) TestUpdatePrivacySettings_Persists() {
 	user := suite.createTestUser("privacypersist")
 
-	settings := PrivacySettings{
-		Contributions:   PrivacyHidden,
-		SavedShows:      PrivacyHidden,
-		Attendance:      PrivacyHidden,
-		Following:       PrivacyHidden,
-		Collections:     PrivacyHidden,
-		LastActive:      PrivacyHidden,
-		ProfileSections: PrivacyHidden,
+	settings := contracts.PrivacySettings{
+		Contributions:   contracts.PrivacyHidden,
+		SavedShows:      contracts.PrivacyHidden,
+		Attendance:      contracts.PrivacyHidden,
+		Following:       contracts.PrivacyHidden,
+		Collections:     contracts.PrivacyHidden,
+		LastActive:      contracts.PrivacyHidden,
+		ProfileSections: contracts.PrivacyHidden,
 	}
 
 	_, err := suite.profileService.UpdatePrivacySettings(user.ID, settings)
@@ -719,14 +720,14 @@ func (suite *ContributorProfileServiceIntegrationTestSuite) TestUpdatePrivacySet
 	profile, err := suite.profileService.GetOwnProfile(user.ID)
 	suite.Require().NoError(err)
 	suite.Require().NotNil(profile.PrivacySettings)
-	suite.Equal(PrivacyHidden, profile.PrivacySettings.Contributions)
-	suite.Equal(PrivacyHidden, profile.PrivacySettings.LastActive)
+	suite.Equal(contracts.PrivacyHidden, profile.PrivacySettings.Contributions)
+	suite.Equal(contracts.PrivacyHidden, profile.PrivacySettings.LastActive)
 }
 
 func (suite *ContributorProfileServiceIntegrationTestSuite) TestUpdatePrivacySettings_InvalidLevel() {
 	user := suite.createTestUser("privacyinvalid")
 
-	settings := DefaultPrivacySettings()
+	settings := contracts.DefaultPrivacySettings()
 	settings.Contributions = "invalid_level"
 
 	result, err := suite.profileService.UpdatePrivacySettings(user.ID, settings)
@@ -739,8 +740,8 @@ func (suite *ContributorProfileServiceIntegrationTestSuite) TestUpdatePrivacySet
 func (suite *ContributorProfileServiceIntegrationTestSuite) TestUpdatePrivacySettings_CountOnlyBinaryField() {
 	user := suite.createTestUser("privacybinary")
 
-	settings := DefaultPrivacySettings()
-	settings.LastActive = PrivacyCountOnly
+	settings := contracts.DefaultPrivacySettings()
+	settings.LastActive = contracts.PrivacyCountOnly
 
 	result, err := suite.profileService.UpdatePrivacySettings(user.ID, settings)
 
@@ -753,14 +754,14 @@ func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetPublicProfile
 	user := suite.createTestUser("privgatecontrib")
 	suite.createShow(user.ID, "Hidden Show")
 
-	suite.setPrivacySettings(user.ID, PrivacySettings{
-		Contributions:   PrivacyHidden,
-		SavedShows:      PrivacyHidden,
-		Attendance:      PrivacyHidden,
-		Following:       PrivacyHidden,
-		Collections:     PrivacyHidden,
-		LastActive:      PrivacyHidden,
-		ProfileSections: PrivacyHidden,
+	suite.setPrivacySettings(user.ID, contracts.PrivacySettings{
+		Contributions:   contracts.PrivacyHidden,
+		SavedShows:      contracts.PrivacyHidden,
+		Attendance:      contracts.PrivacyHidden,
+		Following:       contracts.PrivacyHidden,
+		Collections:     contracts.PrivacyHidden,
+		LastActive:      contracts.PrivacyHidden,
+		ProfileSections: contracts.PrivacyHidden,
 	})
 
 	otherUser := suite.createTestUser("viewer1")
@@ -779,14 +780,14 @@ func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetPublicProfile
 	suite.createShow(user.ID, "Counted Show")
 	suite.createShow(user.ID, "Another Counted Show")
 
-	suite.setPrivacySettings(user.ID, PrivacySettings{
-		Contributions:   PrivacyCountOnly,
-		SavedShows:      PrivacyHidden,
-		Attendance:      PrivacyHidden,
-		Following:       PrivacyHidden,
-		Collections:     PrivacyHidden,
-		LastActive:      PrivacyVisible,
-		ProfileSections: PrivacyVisible,
+	suite.setPrivacySettings(user.ID, contracts.PrivacySettings{
+		Contributions:   contracts.PrivacyCountOnly,
+		SavedShows:      contracts.PrivacyHidden,
+		Attendance:      contracts.PrivacyHidden,
+		Following:       contracts.PrivacyHidden,
+		Collections:     contracts.PrivacyHidden,
+		LastActive:      contracts.PrivacyVisible,
+		ProfileSections: contracts.PrivacyVisible,
 	})
 
 	otherUser := suite.createTestUser("viewer2")
@@ -803,14 +804,14 @@ func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetPublicProfile
 	user := suite.createTestUser("ownerseesall")
 	suite.createShow(user.ID, "My Show")
 
-	suite.setPrivacySettings(user.ID, PrivacySettings{
-		Contributions:   PrivacyHidden,
-		SavedShows:      PrivacyHidden,
-		Attendance:      PrivacyHidden,
-		Following:       PrivacyHidden,
-		Collections:     PrivacyHidden,
-		LastActive:      PrivacyHidden,
-		ProfileSections: PrivacyHidden,
+	suite.setPrivacySettings(user.ID, contracts.PrivacySettings{
+		Contributions:   contracts.PrivacyHidden,
+		SavedShows:      contracts.PrivacyHidden,
+		Attendance:      contracts.PrivacyHidden,
+		Following:       contracts.PrivacyHidden,
+		Collections:     contracts.PrivacyHidden,
+		LastActive:      contracts.PrivacyHidden,
+		ProfileSections: contracts.PrivacyHidden,
 	})
 
 	profile, err := suite.profileService.GetPublicProfile("ownerseesall", &user.ID)

--- a/backend/internal/services/user/interfaces.go
+++ b/backend/internal/services/user/interfaces.go
@@ -1,0 +1,9 @@
+package user
+
+import "psychic-homily-backend/internal/services/contracts"
+
+// Compile-time interface satisfaction checks for user services.
+var (
+	_ contracts.UserServiceInterface               = (*UserService)(nil)
+	_ contracts.ContributorProfileServiceInterface = (*ContributorProfileService)(nil)
+)

--- a/backend/internal/services/user/test_helpers_test.go
+++ b/backend/internal/services/user/test_helpers_test.go
@@ -1,0 +1,40 @@
+package user
+
+import (
+	"encoding/json"
+	"time"
+
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/internal/models"
+)
+
+// stringPtr returns a pointer to a string. Test helper.
+func stringPtr(s string) *string { return &s }
+
+// testAuditLogHelper writes audit log entries directly to the database,
+// avoiding a circular import on the parent services package.
+type testAuditLogHelper struct {
+	db *gorm.DB
+}
+
+// LogAction creates an audit log entry directly in the database.
+func (h *testAuditLogHelper) LogAction(actorID uint, action string, entityType string, entityID uint, metadata map[string]interface{}) {
+	log := models.AuditLog{
+		ActorID:    &actorID,
+		Action:     action,
+		EntityType: entityType,
+		EntityID:   entityID,
+		CreatedAt:  time.Now().UTC(),
+	}
+
+	if metadata != nil {
+		metadataJSON, err := json.Marshal(metadata)
+		if err == nil {
+			raw := json.RawMessage(metadataJSON)
+			log.Metadata = &raw
+		}
+	}
+
+	h.db.Create(&log)
+}

--- a/backend/internal/services/user/user.go
+++ b/backend/internal/services/user/user.go
@@ -1,4 +1,4 @@
-package services
+package user
 
 import (
 	"encoding/json"
@@ -12,6 +12,7 @@ import (
 	"psychic-homily-backend/db"
 	apperrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
 )
 
 // Account lockout constants
@@ -22,7 +23,7 @@ const (
 
 
 // ListUsers returns a paginated list of users for the admin console
-func (s *UserService) ListUsers(limit, offset int, filters AdminUserFilters) ([]*AdminUserResponse, int64, error) {
+func (s *UserService) ListUsers(limit, offset int, filters contracts.AdminUserFilters) ([]*contracts.AdminUserResponse, int64, error) {
 	if s.db == nil {
 		return nil, 0, fmt.Errorf("database not initialized")
 	}
@@ -54,7 +55,7 @@ func (s *UserService) ListUsers(limit, offset int, filters AdminUserFilters) ([]
 	}
 
 	if len(users) == 0 {
-		return []*AdminUserResponse{}, total, nil
+		return []*contracts.AdminUserResponse{}, total, nil
 	}
 
 	// Collect user IDs for batch queries
@@ -93,7 +94,7 @@ func (s *UserService) ListUsers(limit, offset int, filters AdminUserFilters) ([]
 		Group("submitted_by, status").
 		Scan(&showStats)
 
-	statsMap := make(map[uint]UserSubmissionStats, len(users))
+	statsMap := make(map[uint]contracts.UserSubmissionStats, len(users))
 	for _, ss := range showStats {
 		stats := statsMap[ss.SubmittedBy]
 		switch ss.Status {
@@ -109,7 +110,7 @@ func (s *UserService) ListUsers(limit, offset int, filters AdminUserFilters) ([]
 	}
 
 	// Build response
-	result := make([]*AdminUserResponse, len(users))
+	result := make([]*contracts.AdminUserResponse, len(users))
 	for i, u := range users {
 		// Derive auth methods
 		var authMethods []string
@@ -123,7 +124,7 @@ func (s *UserService) ListUsers(limit, offset int, filters AdminUserFilters) ([]
 			authMethods = append(authMethods, "passkey")
 		}
 
-		result[i] = &AdminUserResponse{
+		result[i] = &contracts.AdminUserResponse{
 			ID:              u.ID,
 			Email:           u.Email,
 			Username:        u.Username,
@@ -165,11 +166,11 @@ func (s *UserService) FindOrCreateUser(gothUser goth.User, provider string) (*mo
 }
 
 // FindOrCreateUserWithConsent enforces terms acceptance for brand-new OAuth users.
-func (s *UserService) FindOrCreateUserWithConsent(gothUser goth.User, provider string, consent *OAuthSignupConsent) (*models.User, error) {
+func (s *UserService) FindOrCreateUserWithConsent(gothUser goth.User, provider string, consent *contracts.OAuthSignupConsent) (*models.User, error) {
 	return s.findOrCreateOAuthUser(gothUser, provider, consent, true)
 }
 
-func (s *UserService) findOrCreateOAuthUser(gothUser goth.User, provider string, consent *OAuthSignupConsent, enforceConsent bool) (*models.User, error) {
+func (s *UserService) findOrCreateOAuthUser(gothUser goth.User, provider string, consent *contracts.OAuthSignupConsent, enforceConsent bool) (*models.User, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
@@ -222,7 +223,7 @@ func (s *UserService) CreateUserWithPasswordWithLegal(
 	password,
 	firstName,
 	lastName string,
-	acceptance LegalAcceptance,
+	acceptance contracts.LegalAcceptance,
 ) (*models.User, error) {
 	return s.createUserWithPassword(email, password, firstName, lastName, &acceptance)
 }
@@ -232,7 +233,7 @@ func (s *UserService) createUserWithPassword(
 	password,
 	firstName,
 	lastName string,
-	acceptance *LegalAcceptance,
+	acceptance *contracts.LegalAcceptance,
 ) (*models.User, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
@@ -365,7 +366,7 @@ func (s *UserService) createNewUserOauth(gothUser goth.User, provider string) (*
 func (s *UserService) createNewUserOauthWithConsent(
 	gothUser goth.User,
 	provider string,
-	consent *OAuthSignupConsent,
+	consent *contracts.OAuthSignupConsent,
 	enforceConsent bool,
 ) (*models.User, error) {
 	if s.db == nil {
@@ -456,7 +457,7 @@ func (s *UserService) createNewUserOauthWithConsent(
 	return user, nil
 }
 
-func validateOAuthSignupConsent(consent *OAuthSignupConsent) error {
+func validateOAuthSignupConsent(consent *contracts.OAuthSignupConsent) error {
 	if consent == nil {
 		return fmt.Errorf("terms acceptance required for OAuth signup")
 	}
@@ -756,12 +757,12 @@ func (s *UserService) SetEmailVerified(userID uint, verified bool) error {
 // DeletionSummary contains counts of user data that will be affected by deletion
 
 // GetDeletionSummary returns counts of data that will be affected by account deletion
-func (s *UserService) GetDeletionSummary(userID uint) (*DeletionSummary, error) {
+func (s *UserService) GetDeletionSummary(userID uint) (*contracts.DeletionSummary, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
 
-	summary := &DeletionSummary{}
+	summary := &contracts.DeletionSummary{}
 
 	// Count shows submitted by this user
 	if err := s.db.Model(&models.Show{}).Where("submitted_by = ?", userID).Count(&summary.ShowsCount).Error; err != nil {
@@ -873,7 +874,7 @@ func (s *UserService) CreateUserWithoutPassword(email string) (*models.User, err
 
 // ExportUserData exports all user data in a portable JSON format
 // This supports GDPR Article 20 - Right to data portability
-func (s *UserService) ExportUserData(userID uint) (*UserDataExport, error) {
+func (s *UserService) ExportUserData(userID uint) (*contracts.UserDataExport, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
@@ -888,10 +889,10 @@ func (s *UserService) ExportUserData(userID uint) (*UserDataExport, error) {
 		return nil, fmt.Errorf("failed to get user: %w", err)
 	}
 
-	export := &UserDataExport{
+	export := &contracts.UserDataExport{
 		ExportedAt:    time.Now().UTC(),
 		ExportVersion: "1.0",
-		Profile: UserProfileExport{
+		Profile: contracts.UserProfileExport{
 			ID:            user.ID,
 			Email:         user.Email,
 			Username:      user.Username,
@@ -907,7 +908,7 @@ func (s *UserService) ExportUserData(userID uint) (*UserDataExport, error) {
 
 	// Export preferences
 	if user.Preferences != nil {
-		export.Preferences = &UserPreferencesExport{
+		export.Preferences = &contracts.UserPreferencesExport{
 			NotificationEmail: user.Preferences.NotificationEmail,
 			NotificationPush:  user.Preferences.NotificationPush,
 			Theme:             user.Preferences.Theme,
@@ -918,7 +919,7 @@ func (s *UserService) ExportUserData(userID uint) (*UserDataExport, error) {
 
 	// Export OAuth accounts (without tokens)
 	for _, oauth := range user.OAuthAccounts {
-		export.OAuthAccounts = append(export.OAuthAccounts, OAuthAccountExport{
+		export.OAuthAccounts = append(export.OAuthAccounts, contracts.OAuthAccountExport{
 			Provider:      oauth.Provider,
 			ProviderEmail: oauth.ProviderEmail,
 			ProviderName:  oauth.ProviderName,
@@ -928,7 +929,7 @@ func (s *UserService) ExportUserData(userID uint) (*UserDataExport, error) {
 
 	// Export passkey metadata (no keys)
 	for _, passkey := range user.PasskeyCredentials {
-		export.Passkeys = append(export.Passkeys, PasskeyExport{
+		export.Passkeys = append(export.Passkeys, contracts.PasskeyExport{
 			DisplayName:    passkey.DisplayName,
 			CreatedAt:      passkey.CreatedAt,
 			LastUsedAt:     passkey.LastUsedAt,
@@ -949,7 +950,7 @@ func (s *UserService) ExportUserData(userID uint) (*UserDataExport, error) {
 			continue // Skip if show not found
 		}
 
-		savedExport := SavedShowExport{
+		savedExport := contracts.SavedShowExport{
 			ShowID:    show.ID,
 			Title:     show.Title,
 			EventDate: show.EventDate,
@@ -975,7 +976,7 @@ func (s *UserService) ExportUserData(userID uint) (*UserDataExport, error) {
 	}
 
 	for _, show := range submittedShows {
-		submittedExport := SubmittedShowExport{
+		submittedExport := contracts.SubmittedShowExport{
 			ShowID:      show.ID,
 			Title:       show.Title,
 			EventDate:   show.EventDate,

--- a/backend/internal/services/user/user_test.go
+++ b/backend/internal/services/user/user_test.go
@@ -1,4 +1,4 @@
-package services
+package user
 
 import (
 	"context"
@@ -18,6 +18,7 @@ import (
 
 	apperrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
 	"psychic-homily-backend/internal/testutil"
 )
 
@@ -154,7 +155,7 @@ func TestUserService_NilDatabase(t *testing.T) {
 	})
 
 	t.Run("ListUsers", func(t *testing.T) {
-		users, total, err := userService.ListUsers(10, 0, AdminUserFilters{})
+		users, total, err := userService.ListUsers(10, 0, contracts.AdminUserFilters{})
 		assert.Error(t, err)
 		assert.Equal(t, "database not initialized", err.Error())
 		assert.Nil(t, users)
@@ -435,7 +436,7 @@ func (suite *UserServiceIntegrationTestSuite) SetupSuite() {
 	if err != nil {
 		suite.T().Fatalf("failed to get sql.DB: %v", err)
 	}
-	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "db", "migrations"))
+	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
 
 	// Create UserService
 	suite.userService = &UserService{db: db}
@@ -1835,7 +1836,7 @@ func (suite *UserServiceIntegrationTestSuite) TestListUsers_Success() {
 		})
 	}
 
-	users, total, err := suite.userService.ListUsers(100, 0, AdminUserFilters{
+	users, total, err := suite.userService.ListUsers(100, 0, contracts.AdminUserFilters{
 		Search: "listtest.example.com",
 	})
 	suite.Require().NoError(err)
@@ -1853,7 +1854,7 @@ func (suite *UserServiceIntegrationTestSuite) TestListUsers_WithSearch() {
 		IsActive: true,
 	})
 
-	users, total, err := suite.userService.ListUsers(100, 0, AdminUserFilters{
+	users, total, err := suite.userService.ListUsers(100, 0, contracts.AdminUserFilters{
 		Search: "uniquesearch",
 	})
 	suite.Require().NoError(err)
@@ -1876,7 +1877,7 @@ func (suite *UserServiceIntegrationTestSuite) TestListUsers_WithAuthMethods() {
 		ProviderEmail:  stringPtr("listauth@authmethods.example.com"),
 	})
 
-	users, _, err := suite.userService.ListUsers(100, 0, AdminUserFilters{
+	users, _, err := suite.userService.ListUsers(100, 0, contracts.AdminUserFilters{
 		Search: "authmethods.example.com",
 	})
 	suite.Require().NoError(err)


### PR DESCRIPTION
## Summary
- Move 2 user services (`UserService`, `ContributorProfileService`) into `internal/services/user/` sub-package
- Use `usersvc` import alias to avoid `user` name collision
- Add compile-time interface satisfaction checks in `user/interfaces.go`
- Update `container.go`, auth services, cleanup service, and handler test helpers

Closes PSY-90

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./internal/services/user/...` — all user tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)