### PR TITLE
Extract admin services into admin/ sub-package (PSY-91)

### DIFF
--- a/backend/internal/api/handlers/handler_integration_helpers_test.go
+++ b/backend/internal/api/handlers/handler_integration_helpers_test.go
@@ -15,6 +15,7 @@ import (
 	"psychic-homily-backend/internal/config"
 	"psychic-homily-backend/internal/models"
 	"psychic-homily-backend/internal/services"
+	adminsvc "psychic-homily-backend/internal/services/admin"
 	"psychic-homily-backend/internal/services/catalog"
 	"psychic-homily-backend/internal/services/engagement"
 	"psychic-homily-backend/internal/services/notification"
@@ -32,15 +33,15 @@ type handlerIntegrationDeps struct {
 	venueService          *catalog.VenueService
 	savedShowService      *engagement.SavedShowService
 	favoriteVenueService  *engagement.FavoriteVenueService
-	showReportService     *services.ShowReportService
+	showReportService     *adminsvc.ShowReportService
 	userService           *usersvc.UserService
-	auditLogService       *services.AuditLogService
+	auditLogService       *adminsvc.AuditLogService
 	discordService        *notification.DiscordService
 	musicDiscoveryService *pipeline.MusicDiscoveryService
 	extractionService     *pipeline.ExtractionService
-	apiTokenService       *services.APITokenService
-	dataSyncService       *services.DataSyncService
-	adminStatsService     *services.AdminStatsService
+	apiTokenService       *adminsvc.APITokenService
+	dataSyncService       *adminsvc.DataSyncService
+	adminStatsService     *adminsvc.AdminStatsService
 	discoveryService      *pipeline.DiscoveryService
 	artistService         *catalog.ArtistService
 	festivalService       *catalog.FestivalService
@@ -108,15 +109,15 @@ func setupHandlerIntegrationDeps(t *testing.T) *handlerIntegrationDeps {
 		venueService:          catalog.NewVenueService(db),
 		savedShowService:      engagement.NewSavedShowService(db),
 		favoriteVenueService:  engagement.NewFavoriteVenueService(db),
-		showReportService:     services.NewShowReportService(db),
+		showReportService:     adminsvc.NewShowReportService(db),
 		userService:           usersvc.NewUserService(db),
-		auditLogService:       services.NewAuditLogService(db),
+		auditLogService:       adminsvc.NewAuditLogService(db),
 		discordService:        notification.NewDiscordService(emptyCfg),
 		musicDiscoveryService: pipeline.NewMusicDiscoveryService(emptyCfg),
 		extractionService:     pipeline.NewExtractionService(db, emptyCfg, catalog.NewArtistService(db), catalog.NewVenueService(db)),
-		apiTokenService:       services.NewAPITokenService(db),
-		dataSyncService:       services.NewDataSyncService(db),
-		adminStatsService:     services.NewAdminStatsService(db),
+		apiTokenService:       adminsvc.NewAPITokenService(db),
+		dataSyncService:       adminsvc.NewDataSyncService(db),
+		adminStatsService:     adminsvc.NewAdminStatsService(db),
 		discoveryService:      pipeline.NewDiscoveryService(db, catalog.NewVenueService(db)),
 		artistService:         catalog.NewArtistService(db),
 		festivalService:       catalog.NewFestivalService(db),

--- a/backend/internal/api/middleware/jwt.go
+++ b/backend/internal/api/middleware/jwt.go
@@ -15,6 +15,7 @@ import (
 	"psychic-homily-backend/internal/logger"
 	"psychic-homily-backend/internal/models"
 	"psychic-homily-backend/internal/services"
+	adminsvc "psychic-homily-backend/internal/services/admin"
 )
 
 type contextKey string
@@ -119,7 +120,7 @@ func HumaJWTMiddleware(jwtService *services.JWTService, sessionConfig ...config.
 	}
 
 	// Create API token service for API token validation
-	apiTokenService := services.NewAPITokenService(nil)
+	apiTokenService := adminsvc.NewAPITokenService(nil)
 
 	return func(ctx huma.Context, next func(huma.Context)) {
 		url := ctx.URL()
@@ -309,7 +310,7 @@ func LenientHumaJWTMiddleware(jwtService *services.JWTService, gracePeriod time.
 // but allows unauthenticated requests to proceed without user context.
 // Use this for endpoints that are public but behave differently for authenticated users.
 func OptionalHumaJWTMiddleware(jwtService *services.JWTService) func(ctx huma.Context, next func(huma.Context)) {
-	apiTokenService := services.NewAPITokenService(nil)
+	apiTokenService := adminsvc.NewAPITokenService(nil)
 
 	return func(ctx huma.Context, next func(huma.Context)) {
 		var token string

--- a/backend/internal/services/admin/api_token.go
+++ b/backend/internal/services/admin/api_token.go
@@ -1,4 +1,4 @@
-package services
+package admin
 
 import (
 	"crypto/rand"
@@ -11,6 +11,7 @@ import (
 
 	"psychic-homily-backend/db"
 	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
 )
 
 const (
@@ -54,7 +55,7 @@ func hashToken(token string) string {
 }
 
 // CreateToken generates a new API token for a user
-func (s *APITokenService) CreateToken(userID uint, description *string, expirationDays int) (*APITokenCreateResponse, error) {
+func (s *APITokenService) CreateToken(userID uint, description *string, expirationDays int) (*contracts.APITokenCreateResponse, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
@@ -85,7 +86,7 @@ func (s *APITokenService) CreateToken(userID uint, description *string, expirati
 		return nil, fmt.Errorf("failed to create token: %w", err)
 	}
 
-	return &APITokenCreateResponse{
+	return &contracts.APITokenCreateResponse{
 		ID:          token.ID,
 		Token:       plainToken, // Return plaintext only this once
 		Description: token.Description,
@@ -143,7 +144,7 @@ func (s *APITokenService) ValidateToken(plainToken string) (*models.User, *model
 }
 
 // ListTokens returns all tokens for a user (without hashes)
-func (s *APITokenService) ListTokens(userID uint) ([]APITokenResponse, error) {
+func (s *APITokenService) ListTokens(userID uint) ([]contracts.APITokenResponse, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
@@ -156,9 +157,9 @@ func (s *APITokenService) ListTokens(userID uint) ([]APITokenResponse, error) {
 		return nil, fmt.Errorf("failed to list tokens: %w", err)
 	}
 
-	responses := make([]APITokenResponse, len(tokens))
+	responses := make([]contracts.APITokenResponse, len(tokens))
 	for i, token := range tokens {
-		responses[i] = APITokenResponse{
+		responses[i] = contracts.APITokenResponse{
 			ID:          token.ID,
 			Description: token.Description,
 			Scope:       token.Scope,
@@ -195,7 +196,7 @@ func (s *APITokenService) RevokeToken(userID uint, tokenID uint) error {
 }
 
 // GetToken retrieves a single token by ID (must belong to the user)
-func (s *APITokenService) GetToken(userID uint, tokenID uint) (*APITokenResponse, error) {
+func (s *APITokenService) GetToken(userID uint, tokenID uint) (*contracts.APITokenResponse, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
@@ -209,7 +210,7 @@ func (s *APITokenService) GetToken(userID uint, tokenID uint) (*APITokenResponse
 		return nil, fmt.Errorf("failed to get token: %w", err)
 	}
 
-	return &APITokenResponse{
+	return &contracts.APITokenResponse{
 		ID:          token.ID,
 		Description: token.Description,
 		Scope:       token.Scope,

--- a/backend/internal/services/admin/api_token_test.go
+++ b/backend/internal/services/admin/api_token_test.go
@@ -1,4 +1,4 @@
-package services
+package admin
 
 import (
 	"context"
@@ -159,7 +159,7 @@ func (suite *APITokenIntegrationTestSuite) SetupSuite() {
 		suite.T().Fatalf("failed to get sql.DB: %v", err)
 	}
 
-	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "db", "migrations"))
+	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
 
 	suite.svc = &APITokenService{db: db}
 }

--- a/backend/internal/services/admin/artist_report.go
+++ b/backend/internal/services/admin/artist_report.go
@@ -1,4 +1,4 @@
-package services
+package admin
 
 import (
 	"fmt"
@@ -8,6 +8,7 @@ import (
 
 	"psychic-homily-backend/db"
 	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
 )
 
 // ArtistReportService handles artist report business logic
@@ -26,7 +27,7 @@ func NewArtistReportService(database *gorm.DB) *ArtistReportService {
 }
 
 // CreateReport creates a new artist report
-func (s *ArtistReportService) CreateReport(userID, artistID uint, reportType string, details *string) (*ArtistReportResponse, error) {
+func (s *ArtistReportService) CreateReport(userID, artistID uint, reportType string, details *string) (*contracts.ArtistReportResponse, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
@@ -77,7 +78,7 @@ func (s *ArtistReportService) CreateReport(userID, artistID uint, reportType str
 }
 
 // GetUserReportForArtist returns the user's existing report for an artist, if any
-func (s *ArtistReportService) GetUserReportForArtist(userID, artistID uint) (*ArtistReportResponse, error) {
+func (s *ArtistReportService) GetUserReportForArtist(userID, artistID uint) (*contracts.ArtistReportResponse, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
@@ -97,7 +98,7 @@ func (s *ArtistReportService) GetUserReportForArtist(userID, artistID uint) (*Ar
 }
 
 // GetPendingReports returns pending reports for admin review
-func (s *ArtistReportService) GetPendingReports(limit, offset int) ([]*ArtistReportResponse, int64, error) {
+func (s *ArtistReportService) GetPendingReports(limit, offset int) ([]*contracts.ArtistReportResponse, int64, error) {
 	if s.db == nil {
 		return nil, 0, fmt.Errorf("database not initialized")
 	}
@@ -124,7 +125,7 @@ func (s *ArtistReportService) GetPendingReports(limit, offset int) ([]*ArtistRep
 	}
 
 	// Build responses
-	responses := make([]*ArtistReportResponse, len(reports))
+	responses := make([]*contracts.ArtistReportResponse, len(reports))
 	for i, report := range reports {
 		responses[i] = s.buildReportResponse(&report, &report.Artist)
 	}
@@ -133,7 +134,7 @@ func (s *ArtistReportService) GetPendingReports(limit, offset int) ([]*ArtistRep
 }
 
 // DismissReport marks a report as dismissed (spam/invalid)
-func (s *ArtistReportService) DismissReport(reportID, adminID uint, notes *string) (*ArtistReportResponse, error) {
+func (s *ArtistReportService) DismissReport(reportID, adminID uint, notes *string) (*contracts.ArtistReportResponse, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
@@ -165,7 +166,7 @@ func (s *ArtistReportService) DismissReport(reportID, adminID uint, notes *strin
 }
 
 // ResolveReport marks a report as resolved (action was taken)
-func (s *ArtistReportService) ResolveReport(reportID, adminID uint, notes *string) (*ArtistReportResponse, error) {
+func (s *ArtistReportService) ResolveReport(reportID, adminID uint, notes *string) (*contracts.ArtistReportResponse, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
@@ -213,9 +214,9 @@ func (s *ArtistReportService) GetReportByID(reportID uint) (*models.ArtistReport
 	return &report, nil
 }
 
-// buildReportResponse builds an ArtistReportResponse from a model
-func (s *ArtistReportService) buildReportResponse(report *models.ArtistReport, artist *models.Artist) *ArtistReportResponse {
-	resp := &ArtistReportResponse{
+// buildReportResponse builds an contracts.ArtistReportResponse from a model
+func (s *ArtistReportService) buildReportResponse(report *models.ArtistReport, artist *models.Artist) *contracts.ArtistReportResponse {
+	resp := &contracts.ArtistReportResponse{
 		ID:         report.ID,
 		ArtistID:   report.ArtistID,
 		ReportType: string(report.ReportType),
@@ -237,7 +238,7 @@ func (s *ArtistReportService) buildReportResponse(report *models.ArtistReport, a
 		if artist.Slug != nil {
 			slug = *artist.Slug
 		}
-		resp.Artist = &ArtistReportArtistInfo{
+		resp.Artist = &contracts.ArtistReportArtistInfo{
 			ID:   artist.ID,
 			Name: artist.Name,
 			Slug: slug,

--- a/backend/internal/services/admin/audit_log.go
+++ b/backend/internal/services/admin/audit_log.go
@@ -1,4 +1,4 @@
-package services
+package admin
 
 import (
 	"encoding/json"
@@ -10,6 +10,7 @@ import (
 	"psychic-homily-backend/db"
 	"psychic-homily-backend/internal/logger"
 	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
 )
 
 // AuditLogService handles audit log business logic
@@ -70,7 +71,7 @@ func (s *AuditLogService) LogAction(actorID uint, action string, entityType stri
 }
 
 // GetAuditLogs returns paginated audit log entries with optional filters
-func (s *AuditLogService) GetAuditLogs(limit, offset int, filters AuditLogFilters) ([]*AuditLogResponse, int64, error) {
+func (s *AuditLogService) GetAuditLogs(limit, offset int, filters contracts.AuditLogFilters) ([]*contracts.AuditLogResponse, int64, error) {
 	if s.db == nil {
 		return nil, 0, fmt.Errorf("database not initialized")
 	}
@@ -105,7 +106,7 @@ func (s *AuditLogService) GetAuditLogs(limit, offset int, filters AuditLogFilter
 	}
 
 	// Build responses
-	responses := make([]*AuditLogResponse, len(logs))
+	responses := make([]*contracts.AuditLogResponse, len(logs))
 	for i, log := range logs {
 		responses[i] = s.buildResponse(&log)
 	}
@@ -113,8 +114,8 @@ func (s *AuditLogService) GetAuditLogs(limit, offset int, filters AuditLogFilter
 	return responses, total, nil
 }
 
-func (s *AuditLogService) buildResponse(log *models.AuditLog) *AuditLogResponse {
-	resp := &AuditLogResponse{
+func (s *AuditLogService) buildResponse(log *models.AuditLog) *contracts.AuditLogResponse {
+	resp := &contracts.AuditLogResponse{
 		ID:         log.ID,
 		ActorID:    log.ActorID,
 		Action:     log.Action,

--- a/backend/internal/services/admin/audit_log_test.go
+++ b/backend/internal/services/admin/audit_log_test.go
@@ -1,4 +1,4 @@
-package services
+package admin
 
 import (
 	"context"
@@ -15,6 +15,7 @@ import (
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
 	"psychic-homily-backend/internal/testutil"
 )
 
@@ -39,7 +40,7 @@ func TestAuditLogService_NilDatabase(t *testing.T) {
 	})
 
 	t.Run("GetAuditLogs", func(t *testing.T) {
-		resp, total, err := svc.GetAuditLogs(10, 0, AuditLogFilters{})
+		resp, total, err := svc.GetAuditLogs(10, 0, contracts.AuditLogFilters{})
 		assert.Error(t, err)
 		assert.Equal(t, "database not initialized", err.Error())
 		assert.Nil(t, resp)
@@ -103,7 +104,7 @@ func (suite *AuditLogServiceIntegrationTestSuite) SetupSuite() {
 		suite.T().Fatalf("failed to get sql.DB: %v", err)
 	}
 
-	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "db", "migrations"))
+	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
 
 	suite.auditLogService = &AuditLogService{db: db}
 }
@@ -231,7 +232,7 @@ func (suite *AuditLogServiceIntegrationTestSuite) TestGetAuditLogs_Success() {
 	suite.auditLogService.LogAction(user.ID, "approve_show", "show", 1, nil)
 	suite.auditLogService.LogAction(user.ID, "reject_show", "show", 2, nil)
 
-	resp, total, err := suite.auditLogService.GetAuditLogs(10, 0, AuditLogFilters{})
+	resp, total, err := suite.auditLogService.GetAuditLogs(10, 0, contracts.AuditLogFilters{})
 
 	suite.Require().NoError(err)
 	suite.Equal(int64(2), total)
@@ -246,7 +247,7 @@ func (suite *AuditLogServiceIntegrationTestSuite) TestGetAuditLogs_IncludesActor
 
 	suite.auditLogService.LogAction(user.ID, "approve_show", "show", 1, nil)
 
-	resp, _, err := suite.auditLogService.GetAuditLogs(10, 0, AuditLogFilters{})
+	resp, _, err := suite.auditLogService.GetAuditLogs(10, 0, contracts.AuditLogFilters{})
 
 	suite.Require().NoError(err)
 	suite.Require().Len(resp, 1)
@@ -261,7 +262,7 @@ func (suite *AuditLogServiceIntegrationTestSuite) TestGetAuditLogs_IncludesMetad
 		"title": "Test Show",
 	})
 
-	resp, _, err := suite.auditLogService.GetAuditLogs(10, 0, AuditLogFilters{})
+	resp, _, err := suite.auditLogService.GetAuditLogs(10, 0, contracts.AuditLogFilters{})
 
 	suite.Require().NoError(err)
 	suite.Require().Len(resp, 1)
@@ -275,7 +276,7 @@ func (suite *AuditLogServiceIntegrationTestSuite) TestGetAuditLogs_FilterByEntit
 	suite.auditLogService.LogAction(user.ID, "approve_show", "show", 1, nil)
 	suite.auditLogService.LogAction(user.ID, "verify_venue", "venue", 1, nil)
 
-	resp, total, err := suite.auditLogService.GetAuditLogs(10, 0, AuditLogFilters{EntityType: "venue"})
+	resp, total, err := suite.auditLogService.GetAuditLogs(10, 0, contracts.AuditLogFilters{EntityType: "venue"})
 
 	suite.Require().NoError(err)
 	suite.Equal(int64(1), total)
@@ -290,7 +291,7 @@ func (suite *AuditLogServiceIntegrationTestSuite) TestGetAuditLogs_FilterByActio
 	suite.auditLogService.LogAction(user.ID, "reject_show", "show", 2, nil)
 	suite.auditLogService.LogAction(user.ID, "approve_show", "show", 3, nil)
 
-	resp, total, err := suite.auditLogService.GetAuditLogs(10, 0, AuditLogFilters{Action: "approve_show"})
+	resp, total, err := suite.auditLogService.GetAuditLogs(10, 0, contracts.AuditLogFilters{Action: "approve_show"})
 
 	suite.Require().NoError(err)
 	suite.Equal(int64(2), total)
@@ -307,7 +308,7 @@ func (suite *AuditLogServiceIntegrationTestSuite) TestGetAuditLogs_FilterByActor
 	suite.auditLogService.LogAction(user1.ID, "approve_show", "show", 1, nil)
 	suite.auditLogService.LogAction(user2.ID, "reject_show", "show", 2, nil)
 
-	resp, total, err := suite.auditLogService.GetAuditLogs(10, 0, AuditLogFilters{ActorID: &user2.ID})
+	resp, total, err := suite.auditLogService.GetAuditLogs(10, 0, contracts.AuditLogFilters{ActorID: &user2.ID})
 
 	suite.Require().NoError(err)
 	suite.Equal(int64(1), total)
@@ -322,7 +323,7 @@ func (suite *AuditLogServiceIntegrationTestSuite) TestGetAuditLogs_CombinedFilte
 	suite.auditLogService.LogAction(user.ID, "verify_venue", "venue", 1, nil)
 	suite.auditLogService.LogAction(user.ID, "approve_show", "show", 2, nil)
 
-	resp, total, err := suite.auditLogService.GetAuditLogs(10, 0, AuditLogFilters{
+	resp, total, err := suite.auditLogService.GetAuditLogs(10, 0, contracts.AuditLogFilters{
 		EntityType: "show",
 		Action:     "approve_show",
 		ActorID:    &user.ID,
@@ -341,18 +342,18 @@ func (suite *AuditLogServiceIntegrationTestSuite) TestGetAuditLogs_Pagination() 
 	}
 
 	// Page 1
-	resp1, total, err := suite.auditLogService.GetAuditLogs(2, 0, AuditLogFilters{})
+	resp1, total, err := suite.auditLogService.GetAuditLogs(2, 0, contracts.AuditLogFilters{})
 	suite.Require().NoError(err)
 	suite.Equal(int64(5), total)
 	suite.Len(resp1, 2)
 
 	// Page 2
-	resp2, _, err := suite.auditLogService.GetAuditLogs(2, 2, AuditLogFilters{})
+	resp2, _, err := suite.auditLogService.GetAuditLogs(2, 2, contracts.AuditLogFilters{})
 	suite.Require().NoError(err)
 	suite.Len(resp2, 2)
 
 	// Page 3
-	resp3, _, err := suite.auditLogService.GetAuditLogs(2, 4, AuditLogFilters{})
+	resp3, _, err := suite.auditLogService.GetAuditLogs(2, 4, contracts.AuditLogFilters{})
 	suite.Require().NoError(err)
 	suite.Len(resp3, 1)
 
@@ -361,7 +362,7 @@ func (suite *AuditLogServiceIntegrationTestSuite) TestGetAuditLogs_Pagination() 
 }
 
 func (suite *AuditLogServiceIntegrationTestSuite) TestGetAuditLogs_Empty() {
-	resp, total, err := suite.auditLogService.GetAuditLogs(10, 0, AuditLogFilters{})
+	resp, total, err := suite.auditLogService.GetAuditLogs(10, 0, contracts.AuditLogFilters{})
 
 	suite.Require().NoError(err)
 	suite.Equal(int64(0), total)

--- a/backend/internal/services/admin/cleanup.go
+++ b/backend/internal/services/admin/cleanup.go
@@ -1,35 +1,43 @@
-package services
+package admin
 
 import (
 	"context"
 	"log/slog"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/db"
+	"psychic-homily-backend/internal/models"
 	"psychic-homily-backend/internal/services/notification"
-	usersvc "psychic-homily-backend/internal/services/user"
 )
 
 // Default cleanup interval (24 hours)
 const DefaultCleanupInterval = 24 * time.Hour
 
-// CleanupService handles background cleanup tasks
-type CleanupService struct {
-	db           *gorm.DB
-	userService  *usersvc.UserService
-	interval     time.Duration
-	stopCh       chan struct{}
-	wg           sync.WaitGroup
-	logger       *slog.Logger
+// cleanupUserService is the minimal interface CleanupService needs from UserService.
+type cleanupUserService interface {
+	GetExpiredDeletedAccounts() ([]models.User, error)
+	PermanentlyDeleteUser(userID uint) error
 }
 
-// NewCleanupService creates a new cleanup service
-func NewCleanupService(database *gorm.DB) *CleanupService {
+// CleanupService handles background cleanup tasks
+type CleanupService struct {
+	db          *gorm.DB
+	userService cleanupUserService
+	interval    time.Duration
+	stopCh      chan struct{}
+	wg          sync.WaitGroup
+	logger      *slog.Logger
+}
+
+// NewCleanupService creates a new cleanup service.
+// userSvc must implement GetExpiredDeletedAccounts and PermanentlyDeleteUser.
+func NewCleanupService(database *gorm.DB, userSvc cleanupUserService) *CleanupService {
 	if database == nil {
 		database = db.GetDB()
 	}
@@ -45,7 +53,7 @@ func NewCleanupService(database *gorm.DB) *CleanupService {
 
 	return &CleanupService{
 		db:          database,
-		userService: usersvc.NewUserService(database),
+		userService: userSvc,
 		interval:    interval,
 		stopCh:      make(chan struct{}),
 		logger:      slog.Default(),
@@ -155,4 +163,25 @@ func (s *CleanupService) runCleanupCycle() {
 // RunCleanupNow triggers an immediate cleanup cycle (useful for testing)
 func (s *CleanupService) RunCleanupNow() {
 	s.runCleanupCycle()
+}
+
+// hashEmail masks an email for privacy (e.g., "jo***@example.com")
+func hashEmail(email string) string {
+	if email == "" {
+		return "N/A"
+	}
+
+	parts := strings.Split(email, "@")
+	if len(parts) != 2 {
+		return "N/A"
+	}
+
+	local := parts[0]
+	domain := parts[1]
+
+	if len(local) <= 2 {
+		return local[:1] + "***@" + domain
+	}
+
+	return local[:2] + "***@" + domain
 }

--- a/backend/internal/services/admin/cleanup_test.go
+++ b/backend/internal/services/admin/cleanup_test.go
@@ -1,18 +1,31 @@
-package services
+package admin
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+
+	"psychic-homily-backend/internal/models"
 )
+
+// stubUserService is a minimal stub for cleanup tests.
+type stubUserService struct{}
+
+func (s *stubUserService) GetExpiredDeletedAccounts() ([]models.User, error) {
+	return nil, fmt.Errorf("database not initialized")
+}
+func (s *stubUserService) PermanentlyDeleteUser(userID uint) error {
+	return fmt.Errorf("database not initialized")
+}
 
 // --- NewCleanupService ---
 
 func TestNewCleanupService(t *testing.T) {
-	// Pass nil — will call db.GetDB() which returns nil in test env
-	svc := NewCleanupService(nil)
+	// Pass nil DB — will call db.GetDB() which returns nil in test env
+	svc := NewCleanupService(nil, &stubUserService{})
 	assert.NotNil(t, svc)
 	assert.Equal(t, DefaultCleanupInterval, svc.interval)
 	assert.NotNil(t, svc.stopCh)
@@ -21,32 +34,32 @@ func TestNewCleanupService(t *testing.T) {
 
 func TestNewCleanupService_EnvOverride(t *testing.T) {
 	t.Setenv("CLEANUP_INTERVAL_HOURS", "12")
-	svc := NewCleanupService(nil)
+	svc := NewCleanupService(nil, &stubUserService{})
 	assert.Equal(t, 12*time.Hour, svc.interval)
 }
 
 func TestNewCleanupService_InvalidEnvIgnored(t *testing.T) {
 	t.Setenv("CLEANUP_INTERVAL_HOURS", "not-a-number")
-	svc := NewCleanupService(nil)
+	svc := NewCleanupService(nil, &stubUserService{})
 	assert.Equal(t, DefaultCleanupInterval, svc.interval)
 }
 
 func TestNewCleanupService_ZeroEnvIgnored(t *testing.T) {
 	t.Setenv("CLEANUP_INTERVAL_HOURS", "0")
-	svc := NewCleanupService(nil)
+	svc := NewCleanupService(nil, &stubUserService{})
 	assert.Equal(t, DefaultCleanupInterval, svc.interval)
 }
 
 func TestNewCleanupService_NegativeEnvIgnored(t *testing.T) {
 	t.Setenv("CLEANUP_INTERVAL_HOURS", "-5")
-	svc := NewCleanupService(nil)
+	svc := NewCleanupService(nil, &stubUserService{})
 	assert.Equal(t, DefaultCleanupInterval, svc.interval)
 }
 
 // --- Start / Stop lifecycle ---
 
 func TestCleanupService_StartStop(t *testing.T) {
-	svc := NewCleanupService(nil)
+	svc := NewCleanupService(nil, &stubUserService{})
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -72,7 +85,7 @@ func TestCleanupService_StartStop(t *testing.T) {
 }
 
 func TestCleanupService_ContextCancellation(t *testing.T) {
-	svc := NewCleanupService(nil)
+	svc := NewCleanupService(nil, &stubUserService{})
 	ctx, cancel := context.WithCancel(context.Background())
 
 	svc.Start(ctx)
@@ -99,7 +112,7 @@ func TestCleanupService_ContextCancellation(t *testing.T) {
 // --- RunCleanupNow ---
 
 func TestCleanupService_RunCleanupNow_NilDB(t *testing.T) {
-	svc := NewCleanupService(nil)
+	svc := NewCleanupService(nil, &stubUserService{})
 	// Should not panic — the DB error gets logged and the cycle returns
 	assert.NotPanics(t, func() {
 		svc.RunCleanupNow()

--- a/backend/internal/services/admin/data_sync.go
+++ b/backend/internal/services/admin/data_sync.go
@@ -1,4 +1,4 @@
-package services
+package admin
 
 import (
 	"fmt"
@@ -9,14 +9,13 @@ import (
 
 	"psychic-homily-backend/db"
 	"psychic-homily-backend/internal/models"
-	"psychic-homily-backend/internal/services/catalog"
+	"psychic-homily-backend/internal/services/contracts"
 	"psychic-homily-backend/internal/utils"
 )
 
 // DataSyncService handles exporting and importing data between environments
 type DataSyncService struct {
-	db           *gorm.DB
-	venueService *catalog.VenueService
+	db *gorm.DB
 }
 
 // NewDataSyncService creates a new data sync service
@@ -25,13 +24,12 @@ func NewDataSyncService(database *gorm.DB) *DataSyncService {
 		database = db.GetDB()
 	}
 	return &DataSyncService{
-		db:           database,
-		venueService: catalog.NewVenueService(database),
+		db: database,
 	}
 }
 
 // ExportShows exports shows with their artists and venues
-func (s *DataSyncService) ExportShows(params ExportShowsParams) (*ExportShowsResult, error) {
+func (s *DataSyncService) ExportShows(params contracts.ExportShowsParams) (*contracts.ExportShowsResult, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
@@ -111,9 +109,9 @@ func (s *DataSyncService) ExportShows(params ExportShowsParams) (*ExportShowsRes
 	}
 
 	// Convert to exported format
-	exported := make([]ExportedShow, len(shows))
+	exported := make([]contracts.ExportedShow, len(shows))
 	for i, show := range shows {
-		exported[i] = ExportedShow{
+		exported[i] = contracts.ExportedShow{
 			Title:          show.Title,
 			EventDate:      show.EventDate.Format(time.RFC3339),
 			City:           show.City,
@@ -124,13 +122,13 @@ func (s *DataSyncService) ExportShows(params ExportShowsParams) (*ExportShowsRes
 			Status:         string(show.Status),
 			IsSoldOut:      show.IsSoldOut,
 			IsCancelled:    show.IsCancelled,
-			Venues:         make([]ExportedVenue, len(show.Venues)),
-			Artists:        make([]ExportedShowArtist, 0),
+			Venues:         make([]contracts.ExportedVenue, len(show.Venues)),
+			Artists:        make([]contracts.ExportedShowArtist, 0),
 		}
 
 		// Convert venues
 		for j, venue := range show.Venues {
-			exported[i].Venues[j] = ExportedVenue{
+			exported[i].Venues[j] = contracts.ExportedVenue{
 				Name:       venue.Name,
 				Address:    venue.Address,
 				City:       venue.City,
@@ -161,7 +159,7 @@ func (s *DataSyncService) ExportShows(params ExportShowsParams) (*ExportShowsRes
 				}
 			}
 
-			exported[i].Artists = append(exported[i].Artists, ExportedShowArtist{
+			exported[i].Artists = append(exported[i].Artists, contracts.ExportedShowArtist{
 				Name:     artist.Name,
 				Position: position,
 				SetType:  setType,
@@ -169,15 +167,15 @@ func (s *DataSyncService) ExportShows(params ExportShowsParams) (*ExportShowsRes
 		}
 	}
 
-	return &ExportShowsResult{
+	return &contracts.ExportShowsResult{
 		Shows: exported,
 		Total: total,
 	}, nil
 }
 
-// ExportArtistsParams contains filters for artist export
+// contracts.ExportArtistsParams contains filters for artist export
 // ExportArtists exports artists
-func (s *DataSyncService) ExportArtists(params ExportArtistsParams) (*ExportArtistsResult, error) {
+func (s *DataSyncService) ExportArtists(params contracts.ExportArtistsParams) (*contracts.ExportArtistsResult, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
@@ -209,9 +207,9 @@ func (s *DataSyncService) ExportArtists(params ExportArtistsParams) (*ExportArti
 		return nil, fmt.Errorf("failed to fetch artists: %w", err)
 	}
 
-	exported := make([]ExportedArtist, len(artists))
+	exported := make([]contracts.ExportedArtist, len(artists))
 	for i, artist := range artists {
-		exported[i] = ExportedArtist{
+		exported[i] = contracts.ExportedArtist{
 			Name:             artist.Name,
 			City:             artist.City,
 			State:            artist.State,
@@ -227,15 +225,15 @@ func (s *DataSyncService) ExportArtists(params ExportArtistsParams) (*ExportArti
 		}
 	}
 
-	return &ExportArtistsResult{
+	return &contracts.ExportArtistsResult{
 		Artists: exported,
 		Total:   total,
 	}, nil
 }
 
-// ExportVenuesParams contains filters for venue export
+// contracts.ExportVenuesParams contains filters for venue export
 // ExportVenues exports venues
-func (s *DataSyncService) ExportVenues(params ExportVenuesParams) (*ExportVenuesResult, error) {
+func (s *DataSyncService) ExportVenues(params contracts.ExportVenuesParams) (*contracts.ExportVenuesResult, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
@@ -276,9 +274,9 @@ func (s *DataSyncService) ExportVenues(params ExportVenuesParams) (*ExportVenues
 		return nil, fmt.Errorf("failed to fetch venues: %w", err)
 	}
 
-	exported := make([]ExportedVenue, len(venues))
+	exported := make([]contracts.ExportedVenue, len(venues))
 	for i, venue := range venues {
-		exported[i] = ExportedVenue{
+		exported[i] = contracts.ExportedVenue{
 			Name:       venue.Name,
 			Address:    venue.Address,
 			City:       venue.City,
@@ -296,20 +294,20 @@ func (s *DataSyncService) ExportVenues(params ExportVenuesParams) (*ExportVenues
 		}
 	}
 
-	return &ExportVenuesResult{
+	return &contracts.ExportVenuesResult{
 		Venues: exported,
 		Total:  total,
 	}, nil
 }
 
-// DataImportRequest represents a batch import request
+// contracts.DataImportRequest represents a batch import request
 // ImportData imports shows, artists, and venues with deduplication
-func (s *DataSyncService) ImportData(req DataImportRequest) (*DataImportResult, error) {
+func (s *DataSyncService) ImportData(req contracts.DataImportRequest) (*contracts.DataImportResult, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
 
-	result := &DataImportResult{}
+	result := &contracts.DataImportResult{}
 	result.Shows.Messages = make([]string, 0)
 	result.Artists.Messages = make([]string, 0)
 	result.Venues.Messages = make([]string, 0)
@@ -367,7 +365,7 @@ func (s *DataSyncService) ImportData(req DataImportRequest) (*DataImportResult, 
 }
 
 // importArtist imports a single artist with deduplication
-func (s *DataSyncService) importArtist(artist *ExportedArtist, dryRun bool) (string, string) {
+func (s *DataSyncService) importArtist(artist *contracts.ExportedArtist, dryRun bool) (string, string) {
 	if artist.Name == "" {
 		return "SKIP: Artist name is required", "error"
 	}
@@ -429,7 +427,7 @@ func (s *DataSyncService) importArtist(artist *ExportedArtist, dryRun bool) (str
 }
 
 // importVenue imports a single venue with deduplication
-func (s *DataSyncService) importVenue(venue *ExportedVenue, dryRun bool) (string, string) {
+func (s *DataSyncService) importVenue(venue *contracts.ExportedVenue, dryRun bool) (string, string) {
 	if venue.Name == "" || venue.City == "" || venue.State == "" {
 		return "SKIP: Venue name, city, and state are required", "error"
 	}
@@ -493,7 +491,7 @@ func (s *DataSyncService) importVenue(venue *ExportedVenue, dryRun bool) (string
 }
 
 // importShow imports a single show with deduplication
-func (s *DataSyncService) importShow(show *ExportedShow, dryRun bool) (string, string) {
+func (s *DataSyncService) importShow(show *contracts.ExportedShow, dryRun bool) (string, string) {
 	if show.Title == "" || show.EventDate == "" {
 		return "SKIP: Show title and event date are required", "error"
 	}
@@ -689,7 +687,7 @@ func (s *DataSyncService) importShow(show *ExportedShow, dryRun bool) (string, s
 }
 
 // backfillShowSlugs generates slugs for an existing show and its associated artists/venues if missing.
-func (s *DataSyncService) backfillShowSlugs(existingShow *models.Show, show *ExportedShow, eventDate time.Time, venueName string) {
+func (s *DataSyncService) backfillShowSlugs(existingShow *models.Show, show *contracts.ExportedShow, eventDate time.Time, venueName string) {
 	// Backfill show slug
 	if existingShow.Slug == nil {
 		headlinerName := ""

--- a/backend/internal/services/admin/data_sync_test.go
+++ b/backend/internal/services/admin/data_sync_test.go
@@ -1,4 +1,4 @@
-package services
+package admin
 
 import (
 	"context"
@@ -16,6 +16,7 @@ import (
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
 	"psychic-homily-backend/internal/testutil"
 )
 
@@ -40,28 +41,28 @@ func TestDataSyncService_NilDB(t *testing.T) {
 	svc := &DataSyncService{db: nil}
 
 	t.Run("ExportShows", func(t *testing.T) {
-		result, err := svc.ExportShows(ExportShowsParams{})
+		result, err := svc.ExportShows(contracts.ExportShowsParams{})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "database not initialized")
 		assert.Nil(t, result)
 	})
 
 	t.Run("ExportArtists", func(t *testing.T) {
-		result, err := svc.ExportArtists(ExportArtistsParams{})
+		result, err := svc.ExportArtists(contracts.ExportArtistsParams{})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "database not initialized")
 		assert.Nil(t, result)
 	})
 
 	t.Run("ExportVenues", func(t *testing.T) {
-		result, err := svc.ExportVenues(ExportVenuesParams{})
+		result, err := svc.ExportVenues(contracts.ExportVenuesParams{})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "database not initialized")
 		assert.Nil(t, result)
 	})
 
 	t.Run("ImportData", func(t *testing.T) {
-		result, err := svc.ImportData(DataImportRequest{})
+		result, err := svc.ImportData(contracts.DataImportRequest{})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "database not initialized")
 		assert.Nil(t, result)
@@ -124,7 +125,7 @@ func (suite *DataSyncServiceIntegrationTestSuite) SetupSuite() {
 		suite.T().Fatalf("failed to get sql.DB: %v", err)
 	}
 
-	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "db", "migrations"))
+	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
 
 	suite.service = NewDataSyncService(db)
 }
@@ -255,7 +256,7 @@ func dssBoolPtr(b bool) *bool {
 // =============================================================================
 
 func (suite *DataSyncServiceIntegrationTestSuite) TestExportShows_Empty() {
-	result, err := suite.service.ExportShows(ExportShowsParams{})
+	result, err := suite.service.ExportShows(contracts.ExportShowsParams{})
 	suite.Require().NoError(err)
 	suite.Equal(int64(0), result.Total)
 	suite.Empty(result.Shows)
@@ -268,14 +269,14 @@ func (suite *DataSyncServiceIntegrationTestSuite) TestExportShows_DefaultLimit()
 		suite.createShow(fmt.Sprintf("Show %d", i), time.Now().Add(time.Duration(i)*time.Hour), models.ShowStatusApproved, venue)
 	}
 
-	result, err := suite.service.ExportShows(ExportShowsParams{Status: "all"})
+	result, err := suite.service.ExportShows(contracts.ExportShowsParams{Status: "all"})
 	suite.Require().NoError(err)
 	suite.Equal(int64(60), result.Total)
 	suite.Len(result.Shows, 50) // Default limit
 }
 
 func (suite *DataSyncServiceIntegrationTestSuite) TestExportShows_MaxLimit() {
-	result, err := suite.service.ExportShows(ExportShowsParams{Limit: 500, Status: "all"})
+	result, err := suite.service.ExportShows(contracts.ExportShowsParams{Limit: 500, Status: "all"})
 	suite.Require().NoError(err)
 	// Limit capped to 200 (no data, but verifies no error)
 	suite.Equal(int64(0), result.Total)
@@ -287,7 +288,7 @@ func (suite *DataSyncServiceIntegrationTestSuite) TestExportShows_StatusFilter_A
 	suite.createShow("Approved 2", time.Now(), models.ShowStatusApproved, venue)
 	suite.createShow("Pending 1", time.Now(), models.ShowStatusPending, venue)
 
-	result, err := suite.service.ExportShows(ExportShowsParams{Status: "approved"})
+	result, err := suite.service.ExportShows(contracts.ExportShowsParams{Status: "approved"})
 	suite.Require().NoError(err)
 	suite.Equal(int64(2), result.Total)
 	suite.Len(result.Shows, 2)
@@ -298,7 +299,7 @@ func (suite *DataSyncServiceIntegrationTestSuite) TestExportShows_StatusFilter_P
 	suite.createShow("Approved 1", time.Now(), models.ShowStatusApproved, venue)
 	suite.createShow("Pending 1", time.Now(), models.ShowStatusPending, venue)
 
-	result, err := suite.service.ExportShows(ExportShowsParams{Status: "pending"})
+	result, err := suite.service.ExportShows(contracts.ExportShowsParams{Status: "pending"})
 	suite.Require().NoError(err)
 	suite.Equal(int64(1), result.Total)
 }
@@ -309,7 +310,7 @@ func (suite *DataSyncServiceIntegrationTestSuite) TestExportShows_StatusFilter_A
 	suite.createShow("Pending", time.Now().Add(time.Hour), models.ShowStatusPending, venue)
 	suite.createShow("Rejected", time.Now().Add(2*time.Hour), models.ShowStatusRejected, venue)
 
-	result, err := suite.service.ExportShows(ExportShowsParams{Status: "all"})
+	result, err := suite.service.ExportShows(contracts.ExportShowsParams{Status: "all"})
 	suite.Require().NoError(err)
 	suite.Equal(int64(3), result.Total)
 	suite.Len(result.Shows, 3)
@@ -321,7 +322,7 @@ func (suite *DataSyncServiceIntegrationTestSuite) TestExportShows_DateFilter() {
 	suite.createShow("New Show", time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC), models.ShowStatusApproved, venue)
 
 	fromDate := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
-	result, err := suite.service.ExportShows(ExportShowsParams{
+	result, err := suite.service.ExportShows(contracts.ExportShowsParams{
 		Status:   "approved",
 		FromDate: &fromDate,
 	})
@@ -339,7 +340,7 @@ func (suite *DataSyncServiceIntegrationTestSuite) TestExportShows_LocationFilter
 	// Shows have city set from the createShow helper
 	_ = showNYC
 
-	result, err := suite.service.ExportShows(ExportShowsParams{
+	result, err := suite.service.ExportShows(contracts.ExportShowsParams{
 		Status: "approved",
 		City:   "NYC",
 	})
@@ -353,7 +354,7 @@ func (suite *DataSyncServiceIntegrationTestSuite) TestExportShows_WithArtistsAnd
 	artist2 := suite.createArtist("Band Two")
 	suite.createShow("Big Show", time.Now(), models.ShowStatusApproved, venue, artist1, artist2)
 
-	result, err := suite.service.ExportShows(ExportShowsParams{Status: "all"})
+	result, err := suite.service.ExportShows(contracts.ExportShowsParams{Status: "all"})
 	suite.Require().NoError(err)
 	suite.Require().Len(result.Shows, 1)
 
@@ -374,7 +375,7 @@ func (suite *DataSyncServiceIntegrationTestSuite) TestExportShows_Pagination() {
 		suite.createShow(fmt.Sprintf("Show %d", i), time.Now().Add(time.Duration(i)*time.Hour), models.ShowStatusApproved, venue)
 	}
 
-	result, err := suite.service.ExportShows(ExportShowsParams{
+	result, err := suite.service.ExportShows(contracts.ExportShowsParams{
 		Status: "all",
 		Limit:  2,
 		Offset: 2,
@@ -389,7 +390,7 @@ func (suite *DataSyncServiceIntegrationTestSuite) TestExportShows_Pagination() {
 // =============================================================================
 
 func (suite *DataSyncServiceIntegrationTestSuite) TestExportArtists_Empty() {
-	result, err := suite.service.ExportArtists(ExportArtistsParams{})
+	result, err := suite.service.ExportArtists(contracts.ExportArtistsParams{})
 	suite.Require().NoError(err)
 	suite.Equal(int64(0), result.Total)
 	suite.Empty(result.Artists)
@@ -400,7 +401,7 @@ func (suite *DataSyncServiceIntegrationTestSuite) TestExportArtists_DefaultLimit
 		suite.createArtist(fmt.Sprintf("Artist %03d", i))
 	}
 
-	result, err := suite.service.ExportArtists(ExportArtistsParams{})
+	result, err := suite.service.ExportArtists(contracts.ExportArtistsParams{})
 	suite.Require().NoError(err)
 	suite.Equal(int64(60), result.Total)
 	suite.Len(result.Artists, 50) // Default limit
@@ -411,7 +412,7 @@ func (suite *DataSyncServiceIntegrationTestSuite) TestExportArtists_Search() {
 	suite.createArtist("Another Band")
 	suite.createArtist("Solo Singer")
 
-	result, err := suite.service.ExportArtists(ExportArtistsParams{Search: "band"})
+	result, err := suite.service.ExportArtists(contracts.ExportArtistsParams{Search: "band"})
 	suite.Require().NoError(err)
 	suite.Equal(int64(2), result.Total)
 }
@@ -421,7 +422,7 @@ func (suite *DataSyncServiceIntegrationTestSuite) TestExportArtists_Pagination()
 		suite.createArtist(fmt.Sprintf("Artist %d", i))
 	}
 
-	result, err := suite.service.ExportArtists(ExportArtistsParams{Limit: 2, Offset: 2})
+	result, err := suite.service.ExportArtists(contracts.ExportArtistsParams{Limit: 2, Offset: 2})
 	suite.Require().NoError(err)
 	suite.Equal(int64(5), result.Total)
 	suite.Len(result.Artists, 2)
@@ -431,7 +432,7 @@ func (suite *DataSyncServiceIntegrationTestSuite) TestExportArtists_WithSocial()
 	insta := "@theband"
 	suite.createArtistWithSocial("The Band", &insta)
 
-	result, err := suite.service.ExportArtists(ExportArtistsParams{})
+	result, err := suite.service.ExportArtists(contracts.ExportArtistsParams{})
 	suite.Require().NoError(err)
 	suite.Require().Len(result.Artists, 1)
 	suite.Equal("The Band", result.Artists[0].Name)
@@ -444,7 +445,7 @@ func (suite *DataSyncServiceIntegrationTestSuite) TestExportArtists_WithSocial()
 // =============================================================================
 
 func (suite *DataSyncServiceIntegrationTestSuite) TestExportVenues_Empty() {
-	result, err := suite.service.ExportVenues(ExportVenuesParams{})
+	result, err := suite.service.ExportVenues(contracts.ExportVenuesParams{})
 	suite.Require().NoError(err)
 	suite.Equal(int64(0), result.Total)
 	suite.Empty(result.Venues)
@@ -455,7 +456,7 @@ func (suite *DataSyncServiceIntegrationTestSuite) TestExportVenues_DefaultLimit(
 		suite.createVenue(fmt.Sprintf("Venue %03d", i), "NYC", "NY", true)
 	}
 
-	result, err := suite.service.ExportVenues(ExportVenuesParams{})
+	result, err := suite.service.ExportVenues(contracts.ExportVenuesParams{})
 	suite.Require().NoError(err)
 	suite.Equal(int64(60), result.Total)
 	suite.Len(result.Venues, 50) // Default limit
@@ -466,7 +467,7 @@ func (suite *DataSyncServiceIntegrationTestSuite) TestExportVenues_Search() {
 	suite.createVenue("Concert Hall", "LA", "CA", true)
 	suite.createVenue("The Dive Bar", "CHI", "IL", true)
 
-	result, err := suite.service.ExportVenues(ExportVenuesParams{Search: "hall"})
+	result, err := suite.service.ExportVenues(contracts.ExportVenuesParams{Search: "hall"})
 	suite.Require().NoError(err)
 	suite.Equal(int64(2), result.Total)
 }
@@ -476,7 +477,7 @@ func (suite *DataSyncServiceIntegrationTestSuite) TestExportVenues_FilterVerifie
 	suite.createVenue("Verified 2", "LA", "CA", true)
 	suite.createVenue("Unverified", "CHI", "IL", false)
 
-	result, err := suite.service.ExportVenues(ExportVenuesParams{Verified: dssBoolPtr(true)})
+	result, err := suite.service.ExportVenues(contracts.ExportVenuesParams{Verified: dssBoolPtr(true)})
 	suite.Require().NoError(err)
 	suite.Equal(int64(2), result.Total)
 }
@@ -485,7 +486,7 @@ func (suite *DataSyncServiceIntegrationTestSuite) TestExportVenues_FilterCity() 
 	suite.createVenue("Venue NYC", "New York", "NY", true)
 	suite.createVenue("Venue LA", "Los Angeles", "CA", true)
 
-	result, err := suite.service.ExportVenues(ExportVenuesParams{City: "New York"})
+	result, err := suite.service.ExportVenues(contracts.ExportVenuesParams{City: "New York"})
 	suite.Require().NoError(err)
 	suite.Equal(int64(1), result.Total)
 	suite.Equal("Venue NYC", result.Venues[0].Name)
@@ -495,7 +496,7 @@ func (suite *DataSyncServiceIntegrationTestSuite) TestExportVenues_WithSocial() 
 	insta := "@thevenue"
 	suite.createVenueWithSocial("The Venue", "NYC", "NY", &insta)
 
-	result, err := suite.service.ExportVenues(ExportVenuesParams{})
+	result, err := suite.service.ExportVenues(contracts.ExportVenuesParams{})
 	suite.Require().NoError(err)
 	suite.Require().Len(result.Venues, 1)
 	suite.NotNil(result.Venues[0].Instagram)
@@ -507,7 +508,7 @@ func (suite *DataSyncServiceIntegrationTestSuite) TestExportVenues_WithSocial() 
 // =============================================================================
 
 func (suite *DataSyncServiceIntegrationTestSuite) TestImportData_EmptyRequest() {
-	result, err := suite.service.ImportData(DataImportRequest{})
+	result, err := suite.service.ImportData(contracts.DataImportRequest{})
 	suite.Require().NoError(err)
 	suite.Equal(0, result.Shows.Total)
 	suite.Equal(0, result.Artists.Total)
@@ -515,8 +516,8 @@ func (suite *DataSyncServiceIntegrationTestSuite) TestImportData_EmptyRequest() 
 }
 
 func (suite *DataSyncServiceIntegrationTestSuite) TestImportArtist_Success() {
-	result, err := suite.service.ImportData(DataImportRequest{
-		Artists: []ExportedArtist{
+	result, err := suite.service.ImportData(contracts.DataImportRequest{
+		Artists: []contracts.ExportedArtist{
 			{Name: "New Band"},
 		},
 	})
@@ -534,8 +535,8 @@ func (suite *DataSyncServiceIntegrationTestSuite) TestImportArtist_Success() {
 func (suite *DataSyncServiceIntegrationTestSuite) TestImportArtist_Duplicate() {
 	suite.createArtist("Existing Band")
 
-	result, err := suite.service.ImportData(DataImportRequest{
-		Artists: []ExportedArtist{
+	result, err := suite.service.ImportData(contracts.DataImportRequest{
+		Artists: []contracts.ExportedArtist{
 			{Name: "Existing Band"},
 		},
 	})
@@ -550,8 +551,8 @@ func (suite *DataSyncServiceIntegrationTestSuite) TestImportArtist_DuplicateBack
 	suite.db.Create(artist)
 	suite.Nil(artist.Slug)
 
-	result, err := suite.service.ImportData(DataImportRequest{
-		Artists: []ExportedArtist{
+	result, err := suite.service.ImportData(contracts.DataImportRequest{
+		Artists: []contracts.ExportedArtist{
 			{Name: "No Slug Band"},
 		},
 	})
@@ -565,8 +566,8 @@ func (suite *DataSyncServiceIntegrationTestSuite) TestImportArtist_DuplicateBack
 }
 
 func (suite *DataSyncServiceIntegrationTestSuite) TestImportArtist_EmptyName() {
-	result, err := suite.service.ImportData(DataImportRequest{
-		Artists: []ExportedArtist{
+	result, err := suite.service.ImportData(contracts.DataImportRequest{
+		Artists: []contracts.ExportedArtist{
 			{Name: ""},
 		},
 	})
@@ -576,8 +577,8 @@ func (suite *DataSyncServiceIntegrationTestSuite) TestImportArtist_EmptyName() {
 }
 
 func (suite *DataSyncServiceIntegrationTestSuite) TestImportArtist_DryRun() {
-	result, err := suite.service.ImportData(DataImportRequest{
-		Artists: []ExportedArtist{
+	result, err := suite.service.ImportData(contracts.DataImportRequest{
+		Artists: []contracts.ExportedArtist{
 			{Name: "Dry Run Band"},
 		},
 		DryRun: true,
@@ -597,8 +598,8 @@ func (suite *DataSyncServiceIntegrationTestSuite) TestImportArtist_DryRun() {
 // =============================================================================
 
 func (suite *DataSyncServiceIntegrationTestSuite) TestImportVenue_Success() {
-	result, err := suite.service.ImportData(DataImportRequest{
-		Venues: []ExportedVenue{
+	result, err := suite.service.ImportData(contracts.DataImportRequest{
+		Venues: []contracts.ExportedVenue{
 			{Name: "New Venue", City: "NYC", State: "NY"},
 		},
 	})
@@ -616,8 +617,8 @@ func (suite *DataSyncServiceIntegrationTestSuite) TestImportVenue_Success() {
 func (suite *DataSyncServiceIntegrationTestSuite) TestImportVenue_Duplicate() {
 	suite.createVenue("Existing Venue", "NYC", "NY", true)
 
-	result, err := suite.service.ImportData(DataImportRequest{
-		Venues: []ExportedVenue{
+	result, err := suite.service.ImportData(contracts.DataImportRequest{
+		Venues: []contracts.ExportedVenue{
 			{Name: "Existing Venue", City: "NYC", State: "NY"},
 		},
 	})
@@ -627,8 +628,8 @@ func (suite *DataSyncServiceIntegrationTestSuite) TestImportVenue_Duplicate() {
 }
 
 func (suite *DataSyncServiceIntegrationTestSuite) TestImportVenue_MissingFields() {
-	result, err := suite.service.ImportData(DataImportRequest{
-		Venues: []ExportedVenue{
+	result, err := suite.service.ImportData(contracts.DataImportRequest{
+		Venues: []contracts.ExportedVenue{
 			{Name: "Venue Only"}, // Missing city and state
 		},
 	})
@@ -638,8 +639,8 @@ func (suite *DataSyncServiceIntegrationTestSuite) TestImportVenue_MissingFields(
 }
 
 func (suite *DataSyncServiceIntegrationTestSuite) TestImportVenue_DryRun() {
-	result, err := suite.service.ImportData(DataImportRequest{
-		Venues: []ExportedVenue{
+	result, err := suite.service.ImportData(contracts.DataImportRequest{
+		Venues: []contracts.ExportedVenue{
 			{Name: "Dry Run Venue", City: "NYC", State: "NY"},
 		},
 		DryRun: true,
@@ -658,14 +659,14 @@ func (suite *DataSyncServiceIntegrationTestSuite) TestImportVenue_DryRun() {
 // =============================================================================
 
 func (suite *DataSyncServiceIntegrationTestSuite) TestImportShow_Success() {
-	result, err := suite.service.ImportData(DataImportRequest{
-		Shows: []ExportedShow{
+	result, err := suite.service.ImportData(contracts.DataImportRequest{
+		Shows: []contracts.ExportedShow{
 			{
 				Title:     "New Show",
 				EventDate: time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339),
 				Status:    "approved",
-				Venues:    []ExportedVenue{{Name: "Test Venue", City: "NYC", State: "NY"}},
-				Artists:   []ExportedShowArtist{{Name: "Test Band", Position: 0, SetType: "performer"}},
+				Venues:    []contracts.ExportedVenue{{Name: "Test Venue", City: "NYC", State: "NY"}},
+				Artists:   []contracts.ExportedShowArtist{{Name: "Test Band", Position: 0, SetType: "performer"}},
 			},
 		},
 	})
@@ -693,13 +694,13 @@ func (suite *DataSyncServiceIntegrationTestSuite) TestImportShow_Duplicate() {
 	eventDate := time.Date(2025, 6, 15, 20, 0, 0, 0, time.UTC)
 	suite.createShow("Dupe Show", eventDate, models.ShowStatusApproved, venue)
 
-	result, err := suite.service.ImportData(DataImportRequest{
-		Shows: []ExportedShow{
+	result, err := suite.service.ImportData(contracts.DataImportRequest{
+		Shows: []contracts.ExportedShow{
 			{
 				Title:     "Dupe Show",
 				EventDate: eventDate.Format(time.RFC3339),
 				Status:    "approved",
-				Venues:    []ExportedVenue{{Name: "Dupe Venue", City: "NYC", State: "NY"}},
+				Venues:    []contracts.ExportedVenue{{Name: "Dupe Venue", City: "NYC", State: "NY"}},
 			},
 		},
 	})
@@ -727,14 +728,14 @@ func (suite *DataSyncServiceIntegrationTestSuite) TestImportShow_DuplicateBackfi
 	suite.db.Create(&models.ShowArtist{ShowID: show.ID, ArtistID: artist.ID, Position: 0, SetType: "performer"})
 
 	// Import duplicate — should backfill slugs
-	result, err := suite.service.ImportData(DataImportRequest{
-		Shows: []ExportedShow{
+	result, err := suite.service.ImportData(contracts.DataImportRequest{
+		Shows: []contracts.ExportedShow{
 			{
 				Title:     "No Slug Show",
 				EventDate: eventDate.Format(time.RFC3339),
 				Status:    "approved",
-				Venues:    []ExportedVenue{{Name: "No Slug Venue", City: "NYC", State: "NY"}},
-				Artists:   []ExportedShowArtist{{Name: "No Slug Artist", Position: 0, SetType: "performer"}},
+				Venues:    []contracts.ExportedVenue{{Name: "No Slug Venue", City: "NYC", State: "NY"}},
+				Artists:   []contracts.ExportedShowArtist{{Name: "No Slug Artist", Position: 0, SetType: "performer"}},
 			},
 		},
 	})
@@ -756,8 +757,8 @@ func (suite *DataSyncServiceIntegrationTestSuite) TestImportShow_DuplicateBackfi
 }
 
 func (suite *DataSyncServiceIntegrationTestSuite) TestImportShow_MissingFields() {
-	result, err := suite.service.ImportData(DataImportRequest{
-		Shows: []ExportedShow{
+	result, err := suite.service.ImportData(contracts.DataImportRequest{
+		Shows: []contracts.ExportedShow{
 			{Title: "", EventDate: ""},
 		},
 	})
@@ -767,8 +768,8 @@ func (suite *DataSyncServiceIntegrationTestSuite) TestImportShow_MissingFields()
 }
 
 func (suite *DataSyncServiceIntegrationTestSuite) TestImportShow_InvalidDate() {
-	result, err := suite.service.ImportData(DataImportRequest{
-		Shows: []ExportedShow{
+	result, err := suite.service.ImportData(contracts.DataImportRequest{
+		Shows: []contracts.ExportedShow{
 			{Title: "Bad Date Show", EventDate: "not-a-date"},
 		},
 	})
@@ -779,14 +780,14 @@ func (suite *DataSyncServiceIntegrationTestSuite) TestImportShow_InvalidDate() {
 }
 
 func (suite *DataSyncServiceIntegrationTestSuite) TestImportShow_CreatesNewVenueAndArtist() {
-	result, err := suite.service.ImportData(DataImportRequest{
-		Shows: []ExportedShow{
+	result, err := suite.service.ImportData(contracts.DataImportRequest{
+		Shows: []contracts.ExportedShow{
 			{
 				Title:     "Show With New Everything",
 				EventDate: time.Now().Add(48 * time.Hour).UTC().Format(time.RFC3339),
 				Status:    "approved",
-				Venues:    []ExportedVenue{{Name: "Brand New Venue", City: "Portland", State: "OR"}},
-				Artists:   []ExportedShowArtist{{Name: "Brand New Band", Position: 0, SetType: "headliner"}},
+				Venues:    []contracts.ExportedVenue{{Name: "Brand New Venue", City: "Portland", State: "OR"}},
+				Artists:   []contracts.ExportedShowArtist{{Name: "Brand New Band", Position: 0, SetType: "headliner"}},
 			},
 		},
 	})
@@ -808,13 +809,13 @@ func (suite *DataSyncServiceIntegrationTestSuite) TestImportShow_CreatesNewVenue
 }
 
 func (suite *DataSyncServiceIntegrationTestSuite) TestImportShow_DryRun() {
-	result, err := suite.service.ImportData(DataImportRequest{
-		Shows: []ExportedShow{
+	result, err := suite.service.ImportData(contracts.DataImportRequest{
+		Shows: []contracts.ExportedShow{
 			{
 				Title:     "Dry Run Show",
 				EventDate: time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339),
 				Status:    "approved",
-				Venues:    []ExportedVenue{{Name: "Dry Venue", City: "NYC", State: "NY"}},
+				Venues:    []contracts.ExportedVenue{{Name: "Dry Venue", City: "NYC", State: "NY"}},
 			},
 		},
 		DryRun: true,
@@ -835,25 +836,25 @@ func (suite *DataSyncServiceIntegrationTestSuite) TestImportShow_StatusParsing()
 		time.Now().Add(72 * time.Hour),
 	}
 
-	result, err := suite.service.ImportData(DataImportRequest{
-		Shows: []ExportedShow{
+	result, err := suite.service.ImportData(contracts.DataImportRequest{
+		Shows: []contracts.ExportedShow{
 			{
 				Title:     "Pending Import",
 				EventDate: eventDates[0].UTC().Format(time.RFC3339),
 				Status:    "pending",
-				Venues:    []ExportedVenue{{Name: "Venue A", City: "NYC", State: "NY"}},
+				Venues:    []contracts.ExportedVenue{{Name: "Venue A", City: "NYC", State: "NY"}},
 			},
 			{
 				Title:     "Rejected Import",
 				EventDate: eventDates[1].UTC().Format(time.RFC3339),
 				Status:    "rejected",
-				Venues:    []ExportedVenue{{Name: "Venue B", City: "LA", State: "CA"}},
+				Venues:    []contracts.ExportedVenue{{Name: "Venue B", City: "LA", State: "CA"}},
 			},
 			{
 				Title:     "Private Import",
 				EventDate: eventDates[2].UTC().Format(time.RFC3339),
 				Status:    "private",
-				Venues:    []ExportedVenue{{Name: "Venue C", City: "CHI", State: "IL"}},
+				Venues:    []contracts.ExportedVenue{{Name: "Venue C", City: "CHI", State: "IL"}},
 			},
 		},
 	})
@@ -886,7 +887,7 @@ func (suite *DataSyncServiceIntegrationTestSuite) TestImportData_FullRoundTrip()
 	suite.createShow("RT Show", eventDate, models.ShowStatusApproved, venue, artist)
 
 	// Export
-	exportResult, err := suite.service.ExportShows(ExportShowsParams{Status: "approved"})
+	exportResult, err := suite.service.ExportShows(contracts.ExportShowsParams{Status: "approved"})
 	suite.Require().NoError(err)
 	suite.Require().Len(exportResult.Shows, 1)
 
@@ -904,7 +905,7 @@ func (suite *DataSyncServiceIntegrationTestSuite) TestImportData_FullRoundTrip()
 	_, _ = sqlDB.Exec("DELETE FROM venues")
 
 	// Import the exported data
-	importResult, err := suite.service.ImportData(DataImportRequest{
+	importResult, err := suite.service.ImportData(contracts.DataImportRequest{
 		Shows: exportResult.Shows,
 	})
 	suite.Require().NoError(err)

--- a/backend/internal/services/admin/interfaces.go
+++ b/backend/internal/services/admin/interfaces.go
@@ -1,0 +1,14 @@
+package admin
+
+import "psychic-homily-backend/internal/services/contracts"
+
+// Compile-time interface satisfaction checks for admin services.
+var (
+	_ contracts.AdminStatsServiceInterface   = (*AdminStatsService)(nil)
+	_ contracts.AuditLogServiceInterface     = (*AuditLogService)(nil)
+	_ contracts.DataSyncServiceInterface     = (*DataSyncService)(nil)
+	_ contracts.ShowReportServiceInterface   = (*ShowReportService)(nil)
+	_ contracts.ArtistReportServiceInterface = (*ArtistReportService)(nil)
+	_ contracts.APITokenServiceInterface     = (*APITokenService)(nil)
+	// CleanupService has no interface in contracts — it's a lifecycle service.
+)

--- a/backend/internal/services/admin/show_report.go
+++ b/backend/internal/services/admin/show_report.go
@@ -1,4 +1,4 @@
-package services
+package admin
 
 import (
 	"fmt"
@@ -8,6 +8,7 @@ import (
 
 	"psychic-homily-backend/db"
 	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
 )
 
 // ShowReportService handles show report business logic
@@ -26,7 +27,7 @@ func NewShowReportService(database *gorm.DB) *ShowReportService {
 }
 
 // CreateReport creates a new show report
-func (s *ShowReportService) CreateReport(userID, showID uint, reportType string, details *string) (*ShowReportResponse, error) {
+func (s *ShowReportService) CreateReport(userID, showID uint, reportType string, details *string) (*contracts.ShowReportResponse, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
@@ -78,7 +79,7 @@ func (s *ShowReportService) CreateReport(userID, showID uint, reportType string,
 }
 
 // GetUserReportForShow returns the user's existing report for a show, if any
-func (s *ShowReportService) GetUserReportForShow(userID, showID uint) (*ShowReportResponse, error) {
+func (s *ShowReportService) GetUserReportForShow(userID, showID uint) (*contracts.ShowReportResponse, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
@@ -98,7 +99,7 @@ func (s *ShowReportService) GetUserReportForShow(userID, showID uint) (*ShowRepo
 }
 
 // GetPendingReports returns pending reports for admin review
-func (s *ShowReportService) GetPendingReports(limit, offset int) ([]*ShowReportResponse, int64, error) {
+func (s *ShowReportService) GetPendingReports(limit, offset int) ([]*contracts.ShowReportResponse, int64, error) {
 	if s.db == nil {
 		return nil, 0, fmt.Errorf("database not initialized")
 	}
@@ -125,7 +126,7 @@ func (s *ShowReportService) GetPendingReports(limit, offset int) ([]*ShowReportR
 	}
 
 	// Build responses
-	responses := make([]*ShowReportResponse, len(reports))
+	responses := make([]*contracts.ShowReportResponse, len(reports))
 	for i, report := range reports {
 		responses[i] = s.buildReportResponse(&report, &report.Show)
 	}
@@ -134,7 +135,7 @@ func (s *ShowReportService) GetPendingReports(limit, offset int) ([]*ShowReportR
 }
 
 // DismissReport marks a report as dismissed (spam/invalid)
-func (s *ShowReportService) DismissReport(reportID, adminID uint, notes *string) (*ShowReportResponse, error) {
+func (s *ShowReportService) DismissReport(reportID, adminID uint, notes *string) (*contracts.ShowReportResponse, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
@@ -166,14 +167,14 @@ func (s *ShowReportService) DismissReport(reportID, adminID uint, notes *string)
 }
 
 // ResolveReport marks a report as resolved (action was taken)
-func (s *ShowReportService) ResolveReport(reportID, adminID uint, notes *string) (*ShowReportResponse, error) {
+func (s *ShowReportService) ResolveReport(reportID, adminID uint, notes *string) (*contracts.ShowReportResponse, error) {
 	return s.ResolveReportWithFlag(reportID, adminID, notes, false)
 }
 
 // ResolveReportWithFlag marks a report as resolved and optionally sets the corresponding show flag.
 // If setShowFlag is true and the report type is cancelled or sold_out, the show's corresponding
 // flag (is_cancelled or is_sold_out) will be set to true.
-func (s *ShowReportService) ResolveReportWithFlag(reportID, adminID uint, notes *string, setShowFlag bool) (*ShowReportResponse, error) {
+func (s *ShowReportService) ResolveReportWithFlag(reportID, adminID uint, notes *string, setShowFlag bool) (*contracts.ShowReportResponse, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
@@ -254,9 +255,9 @@ func (s *ShowReportService) GetReportByID(reportID uint) (*models.ShowReport, er
 	return &report, nil
 }
 
-// buildReportResponse builds a ShowReportResponse from a model
-func (s *ShowReportService) buildReportResponse(report *models.ShowReport, show *models.Show) *ShowReportResponse {
-	resp := &ShowReportResponse{
+// buildReportResponse builds a contracts.ShowReportResponse from a model
+func (s *ShowReportService) buildReportResponse(report *models.ShowReport, show *models.Show) *contracts.ShowReportResponse {
+	resp := &contracts.ShowReportResponse{
 		ID:         report.ID,
 		ShowID:     report.ShowID,
 		ReportType: string(report.ReportType),
@@ -278,7 +279,7 @@ func (s *ShowReportService) buildReportResponse(report *models.ShowReport, show 
 		if show.Slug != nil {
 			slug = *show.Slug
 		}
-		resp.Show = &ShowReportShowInfo{
+		resp.Show = &contracts.ShowReportShowInfo{
 			ID:        show.ID,
 			Title:     show.Title,
 			Slug:      slug,

--- a/backend/internal/services/admin/show_report_test.go
+++ b/backend/internal/services/admin/show_report_test.go
@@ -1,4 +1,4 @@
-package services
+package admin
 
 import (
 	"context"
@@ -137,7 +137,7 @@ func (suite *ShowReportServiceIntegrationTestSuite) SetupSuite() {
 		suite.T().Fatalf("failed to get sql.DB: %v", err)
 	}
 
-	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "db", "migrations"))
+	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
 
 	suite.reportService = &ShowReportService{db: db}
 }

--- a/backend/internal/services/admin/stats.go
+++ b/backend/internal/services/admin/stats.go
@@ -1,4 +1,4 @@
-package services
+package admin
 
 import (
 	"time"
@@ -7,6 +7,7 @@ import (
 
 	"psychic-homily-backend/db"
 	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
 )
 
 // AdminStatsService handles admin dashboard statistics
@@ -25,8 +26,8 @@ func NewAdminStatsService(database *gorm.DB) *AdminStatsService {
 }
 
 // GetDashboardStats returns all dashboard statistics
-func (s *AdminStatsService) GetDashboardStats() (*AdminDashboardStats, error) {
-	stats := &AdminDashboardStats{}
+func (s *AdminStatsService) GetDashboardStats() (*contracts.AdminDashboardStats, error) {
+	stats := &contracts.AdminDashboardStats{}
 	sevenDaysAgo := time.Now().AddDate(0, 0, -7)
 
 	// Action items

--- a/backend/internal/services/admin/stats_test.go
+++ b/backend/internal/services/admin/stats_test.go
@@ -1,4 +1,4 @@
-package services
+package admin
 
 import (
 	"context"
@@ -98,7 +98,7 @@ func (suite *AdminStatsServiceIntegrationTestSuite) SetupSuite() {
 		suite.T().Fatalf("failed to get sql.DB: %v", err)
 	}
 
-	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "db", "migrations"))
+	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
 
 	suite.service = &AdminStatsService{db: db}
 }

--- a/backend/internal/services/admin/test_helpers_test.go
+++ b/backend/internal/services/admin/test_helpers_test.go
@@ -1,0 +1,3 @@
+package admin
+
+func stringPtr(s string) *string { return &s }

--- a/backend/internal/services/container.go
+++ b/backend/internal/services/container.go
@@ -6,6 +6,7 @@ import (
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/internal/config"
+	adminsvc "psychic-homily-backend/internal/services/admin"
 	"psychic-homily-backend/internal/services/auth"
 	"psychic-homily-backend/internal/services/catalog"
 	"psychic-homily-backend/internal/services/engagement"
@@ -18,12 +19,12 @@ import (
 // Exported fields — no getters needed for a simple data-holding struct.
 type ServiceContainer struct {
 	// DB-only leaf services
-	AdminStats         *AdminStatsService
-	APIToken           *APITokenService
+	AdminStats         *adminsvc.AdminStatsService
+	APIToken           *adminsvc.APITokenService
 	Artist             *catalog.ArtistService
 	ContributorProfile *usersvc.ContributorProfileService
-	ArtistReport  *ArtistReportService
-	AuditLog      *AuditLogService
+	ArtistReport  *adminsvc.ArtistReportService
+	AuditLog      *adminsvc.AuditLogService
 	Bookmark      *engagement.BookmarkService
 	Calendar      *engagement.CalendarService
 	Collection    *CollectionService
@@ -33,7 +34,7 @@ type ServiceContainer struct {
 	Release       *catalog.ReleaseService
 	SavedShow     *engagement.SavedShowService
 	Show          *catalog.ShowService
-	ShowReport    *ShowReportService
+	ShowReport    *adminsvc.ShowReportService
 	User              *usersvc.UserService
 	Venue             *catalog.VenueService
 	VenueSourceConfig *pipeline.VenueSourceConfigService
@@ -53,8 +54,8 @@ type ServiceContainer struct {
 	AppleAuth  *auth.AppleAuthService
 	Extraction *pipeline.ExtractionService
 	WebAuthn   *auth.WebAuthnService // nil if init fails (passkeys optional)
-	Cleanup    *CleanupService
-	DataSync   *DataSyncService
+	Cleanup    *adminsvc.CleanupService
+	DataSync   *adminsvc.DataSyncService
 	Discovery  *pipeline.DiscoveryService
 	Pipeline   *pipeline.PipelineService
 	Reminder   *engagement.ReminderService
@@ -93,12 +94,12 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 
 	return &ServiceContainer{
 		// DB-only leaf services
-		AdminStats:         NewAdminStatsService(database),
-		APIToken:           NewAPITokenService(database),
+		AdminStats:         adminsvc.NewAdminStatsService(database),
+		APIToken:           adminsvc.NewAPITokenService(database),
 		Artist:             artist,
 		ContributorProfile: usersvc.NewContributorProfileService(database),
-		ArtistReport:  NewArtistReportService(database),
-		AuditLog:      NewAuditLogService(database),
+		ArtistReport:  adminsvc.NewArtistReportService(database),
+		AuditLog:      adminsvc.NewAuditLogService(database),
 		Bookmark:      engagement.NewBookmarkService(database),
 		Calendar:      engagement.NewCalendarService(database, savedShow),
 		Collection:    NewCollectionService(database),
@@ -108,7 +109,7 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 		Release:       catalog.NewReleaseService(database),
 		SavedShow:     savedShow,
 		Show:          catalog.NewShowService(database),
-		ShowReport:    NewShowReportService(database),
+		ShowReport:    adminsvc.NewShowReportService(database),
 		User:          userService,
 		Venue:             venue,
 		VenueSourceConfig: venueSourceConfig,
@@ -128,8 +129,8 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 		AppleAuth:  auth.NewAppleAuthService(database, cfg, jwtService),
 		Extraction: extraction,
 		WebAuthn:   webauthnService,
-		Cleanup:    NewCleanupService(database),
-		DataSync:   NewDataSyncService(database),
+		Cleanup:    adminsvc.NewCleanupService(database, userService),
+		DataSync:   adminsvc.NewDataSyncService(database),
 		Discovery:  discovery,
 		Pipeline:   pipeline.NewPipelineService(fetcher, extraction, discovery, venueSourceConfig, venue),
 		Reminder:   engagement.NewReminderService(database, email, cfg),

--- a/backend/internal/services/interfaces.go
+++ b/backend/internal/services/interfaces.go
@@ -53,16 +53,12 @@ type CollectionServiceInterface = contracts.CollectionServiceInterface
 // internal/services/notification/interfaces.go.
 // User services (UserService, ContributorProfileService) are checked in
 // internal/services/user/interfaces.go.
+// Admin services (AdminStats, AuditLog, DataSync, ShowReport, ArtistReport,
+// APIToken) are checked in internal/services/admin/interfaces.go.
 var (
 	_ ShowServiceInterface          = (*catalog.ShowService)(nil)
 	_ VenueServiceInterface         = (*catalog.VenueService)(nil)
 	_ ArtistServiceInterface        = (*catalog.ArtistService)(nil)
-	_ ShowReportServiceInterface    = (*ShowReportService)(nil)
-	_ ArtistReportServiceInterface  = (*ArtistReportService)(nil)
-	_ AuditLogServiceInterface      = (*AuditLogService)(nil)
-	_ APITokenServiceInterface      = (*APITokenService)(nil)
-	_ DataSyncServiceInterface      = (*DataSyncService)(nil)
-	_ AdminStatsServiceInterface    = (*AdminStatsService)(nil)
 	_ FestivalServiceInterface       = (*catalog.FestivalService)(nil)
 	_ LabelServiceInterface          = (*catalog.LabelService)(nil)
 	_ ReleaseServiceInterface       = (*catalog.ReleaseService)(nil)

--- a/backend/internal/services/user/contributor_profile_test.go
+++ b/backend/internal/services/user/contributor_profile_test.go
@@ -16,6 +16,7 @@ import (
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/internal/models"
+	adminsvc "psychic-homily-backend/internal/services/admin"
 	"psychic-homily-backend/internal/services/contracts"
 	"psychic-homily-backend/internal/testutil"
 )
@@ -175,7 +176,7 @@ type ContributorProfileServiceIntegrationTestSuite struct {
 	container      testcontainers.Container
 	db             *gorm.DB
 	profileService *ContributorProfileService
-	auditLog       *testAuditLogHelper
+	auditLog       *adminsvc.AuditLogService
 	ctx            context.Context
 }
 
@@ -226,7 +227,7 @@ func (suite *ContributorProfileServiceIntegrationTestSuite) SetupSuite() {
 	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
 
 	suite.profileService = &ContributorProfileService{db: db}
-	suite.auditLog = &testAuditLogHelper{db: db}
+	suite.auditLog = adminsvc.NewAuditLogService(db)
 }
 
 func (suite *ContributorProfileServiceIntegrationTestSuite) TearDownSuite() {


### PR DESCRIPTION
## Summary
- Move 7 admin/operational services (`AdminStatsService`, `AuditLogService`, `DataSyncService`, `ShowReportService`, `ArtistReportService`, `CleanupService`, `APITokenService`) into `internal/services/admin/` sub-package
- Change `CleanupService` constructor to accept `userSvc` parameter to avoid import cycles
- Remove dead `venueService` field from `DataSyncService`
- Add compile-time interface satisfaction checks in `admin/interfaces.go`
- Update `container.go`, JWT middleware, handler test helpers, and contributor profile test imports

Closes PSY-91

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./internal/services/admin/...` — all 31 admin tests pass
- [x] All test packages compile successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)