### PR TITLE
Add full CRUD admin UI for venue source configs (PSY-36)

### DIFF
--- a/backend/internal/api/handlers/pipeline.go
+++ b/backend/internal/api/handlers/pipeline.go
@@ -244,3 +244,174 @@ func (h *PipelineHandler) UpdateExtractionNotesHandler(ctx context.Context, req 
 	resp.Body.ExtractionNotes = req.Body.ExtractionNotes
 	return resp, nil
 }
+
+// --- Update Venue Config ---
+
+// UpdateVenueConfigRequest is the Huma request for PUT /admin/pipeline/venues/{venue_id}/config
+type UpdateVenueConfigRequest struct {
+	VenueID string `path:"venue_id" validate:"required" doc:"Venue ID"`
+	Body    struct {
+		CalendarURL     *string `json:"calendar_url" doc:"URL to the venue's event calendar page"`
+		PreferredSource string  `json:"preferred_source" doc:"Extraction source preference (ai, ical, rss)"`
+		RenderMethod    *string `json:"render_method" doc:"Rendering method (static, dynamic, screenshot) or null for auto-detect"`
+		FeedURL         *string `json:"feed_url" doc:"URL to iCal/RSS feed if available"`
+		AutoApprove     bool    `json:"auto_approve" doc:"Whether to auto-approve extracted shows"`
+		StrategyLocked  bool    `json:"strategy_locked" doc:"Lock strategy to prevent automatic re-evaluation"`
+		ExtractionNotes *string `json:"extraction_notes" doc:"Notes included in AI extraction prompt"`
+	}
+}
+
+// UpdateVenueConfigResponse is the Huma response for PUT /admin/pipeline/venues/{venue_id}/config
+type UpdateVenueConfigResponse struct {
+	Body PipelineVenueInfo
+}
+
+// UpdateVenueConfigHandler handles PUT /admin/pipeline/venues/{venue_id}/config
+func (h *PipelineHandler) UpdateVenueConfigHandler(ctx context.Context, req *UpdateVenueConfigRequest) (*UpdateVenueConfigResponse, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil || !user.IsAdmin {
+		return nil, huma.Error403Forbidden("Admin access required")
+	}
+
+	venueID, err := strconv.ParseUint(req.VenueID, 10, 64)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid venue ID")
+	}
+
+	config := &models.VenueSourceConfig{
+		VenueID:         uint(venueID),
+		CalendarURL:     req.Body.CalendarURL,
+		PreferredSource: req.Body.PreferredSource,
+		RenderMethod:    req.Body.RenderMethod,
+		FeedURL:         req.Body.FeedURL,
+		AutoApprove:     req.Body.AutoApprove,
+		StrategyLocked:  req.Body.StrategyLocked,
+		ExtractionNotes: req.Body.ExtractionNotes,
+	}
+
+	updated, err := h.venueConfigService.CreateOrUpdate(config)
+	if err != nil {
+		logger.FromContext(ctx).Error("pipeline_update_config_failed",
+			"venue_id", venueID,
+			"error", err.Error(),
+		)
+		return nil, huma.Error422UnprocessableEntity(err.Error())
+	}
+
+	logger.FromContext(ctx).Info("pipeline_venue_config_updated",
+		"venue_id", venueID,
+		"admin_id", user.ID,
+	)
+
+	info := PipelineVenueInfo{
+		VenueID:             updated.VenueID,
+		VenueName:           updated.Venue.Name,
+		CalendarURL:         updated.CalendarURL,
+		PreferredSource:     updated.PreferredSource,
+		RenderMethod:        updated.RenderMethod,
+		FeedURL:             updated.FeedURL,
+		LastExtractedAt:     updated.LastExtractedAt,
+		EventsExpected:      updated.EventsExpected,
+		ConsecutiveFailures: updated.ConsecutiveFailures,
+		StrategyLocked:      updated.StrategyLocked,
+		AutoApprove:         updated.AutoApprove,
+		ExtractionNotes:     updated.ExtractionNotes,
+	}
+	if updated.Venue.Slug != nil {
+		info.VenueSlug = *updated.Venue.Slug
+	}
+
+	return &UpdateVenueConfigResponse{Body: info}, nil
+}
+
+// --- Get Venue Runs ---
+
+// GetVenueRunsRequest is the Huma request for GET /admin/pipeline/venues/{venue_id}/runs
+type GetVenueRunsRequest struct {
+	VenueID string `path:"venue_id" validate:"required" doc:"Venue ID"`
+	Limit   int    `query:"limit" doc:"Max runs to return (default 10, max 100)"`
+}
+
+// GetVenueRunsResponse is the Huma response for GET /admin/pipeline/venues/{venue_id}/runs
+type GetVenueRunsResponse struct {
+	Body struct {
+		Runs  []models.VenueExtractionRun `json:"runs"`
+		Total int                         `json:"total"`
+	}
+}
+
+// GetVenueRunsHandler handles GET /admin/pipeline/venues/{venue_id}/runs
+func (h *PipelineHandler) GetVenueRunsHandler(ctx context.Context, req *GetVenueRunsRequest) (*GetVenueRunsResponse, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil || !user.IsAdmin {
+		return nil, huma.Error403Forbidden("Admin access required")
+	}
+
+	venueID, err := strconv.ParseUint(req.VenueID, 10, 64)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid venue ID")
+	}
+
+	limit := req.Limit
+	if limit <= 0 {
+		limit = 10
+	}
+
+	runs, err := h.venueConfigService.GetRecentRuns(uint(venueID), limit)
+	if err != nil {
+		logger.FromContext(ctx).Error("pipeline_get_runs_failed",
+			"venue_id", venueID,
+			"error", err.Error(),
+		)
+		return nil, huma.Error422UnprocessableEntity(err.Error())
+	}
+
+	resp := &GetVenueRunsResponse{}
+	resp.Body.Runs = runs
+	resp.Body.Total = len(runs)
+	return resp, nil
+}
+
+// --- Reset Render Method ---
+
+// ResetRenderMethodRequest is the Huma request for POST /admin/pipeline/venues/{venue_id}/reset-render-method
+type ResetRenderMethodRequest struct {
+	VenueID string `path:"venue_id" validate:"required" doc:"Venue ID"`
+}
+
+// ResetRenderMethodResponse is the Huma response for POST /admin/pipeline/venues/{venue_id}/reset-render-method
+type ResetRenderMethodResponse struct {
+	Body struct {
+		Success bool `json:"success"`
+	}
+}
+
+// ResetRenderMethodHandler handles POST /admin/pipeline/venues/{venue_id}/reset-render-method
+func (h *PipelineHandler) ResetRenderMethodHandler(ctx context.Context, req *ResetRenderMethodRequest) (*ResetRenderMethodResponse, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil || !user.IsAdmin {
+		return nil, huma.Error403Forbidden("Admin access required")
+	}
+
+	venueID, err := strconv.ParseUint(req.VenueID, 10, 64)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid venue ID")
+	}
+
+	if err := h.venueConfigService.ResetRenderMethod(uint(venueID)); err != nil {
+		logger.FromContext(ctx).Error("pipeline_reset_render_method_failed",
+			"venue_id", venueID,
+			"error", err.Error(),
+		)
+		return nil, huma.Error422UnprocessableEntity(err.Error())
+	}
+
+	logger.FromContext(ctx).Info("pipeline_render_method_reset",
+		"venue_id", venueID,
+		"admin_id", user.ID,
+	)
+
+	resp := &ResetRenderMethodResponse{}
+	resp.Body.Success = true
+	return resp, nil
+}

--- a/backend/internal/api/handlers/pipeline_test.go
+++ b/backend/internal/api/handlers/pipeline_test.go
@@ -37,15 +37,16 @@ func (m *mockPipelineService) ExtractVenue(venueID uint, dryRun bool) (*services
 // ============================================================================
 
 type mockVenueSourceConfigService struct {
-	getByVenueIDFn        func(venueID uint) (*models.VenueSourceConfig, error)
-	createOrUpdateFn      func(config *models.VenueSourceConfig) (*models.VenueSourceConfig, error)
-	updateAfterRunFn      func(venueID uint, contentHash, etag *string, eventsExtracted int) error
-	incrementFailuresFn   func(venueID uint) error
-	recordRunFn           func(run *models.VenueExtractionRun) error
-	getRecentRunsFn       func(venueID uint, limit int) ([]models.VenueExtractionRun, error)
-	listConfiguredFn      func() ([]models.VenueSourceConfig, error)
-	getRejectionStatsFn   func(venueID uint) (*services.VenueRejectionStats, error)
+	getByVenueIDFn          func(venueID uint) (*models.VenueSourceConfig, error)
+	createOrUpdateFn        func(config *models.VenueSourceConfig) (*models.VenueSourceConfig, error)
+	updateAfterRunFn        func(venueID uint, contentHash, etag *string, eventsExtracted int) error
+	incrementFailuresFn     func(venueID uint) error
+	recordRunFn             func(run *models.VenueExtractionRun) error
+	getRecentRunsFn         func(venueID uint, limit int) ([]models.VenueExtractionRun, error)
+	listConfiguredFn        func() ([]models.VenueSourceConfig, error)
+	getRejectionStatsFn     func(venueID uint) (*services.VenueRejectionStats, error)
 	updateExtractionNotesFn func(venueID uint, notes *string) error
+	resetRenderMethodFn     func(venueID uint) error
 }
 
 func (m *mockVenueSourceConfigService) GetByVenueID(venueID uint) (*models.VenueSourceConfig, error) {
@@ -102,6 +103,12 @@ func (m *mockVenueSourceConfigService) UpdateExtractionNotes(venueID uint, notes
 	}
 	return nil
 }
+func (m *mockVenueSourceConfigService) ResetRenderMethod(venueID uint) error {
+	if m.resetRenderMethodFn != nil {
+		return m.resetRenderMethodFn(venueID)
+	}
+	return nil
+}
 
 // ============================================================================
 // Test helpers
@@ -155,6 +162,18 @@ func TestPipelineHandler_RequiresAdmin(t *testing.T) {
 		}},
 		{"UpdateExtractionNotes", func(ctx context.Context) error {
 			_, err := h.UpdateExtractionNotesHandler(ctx, &UpdateExtractionNotesRequest{VenueID: "1"})
+			return err
+		}},
+		{"UpdateVenueConfig", func(ctx context.Context) error {
+			_, err := h.UpdateVenueConfigHandler(ctx, &UpdateVenueConfigRequest{VenueID: "1"})
+			return err
+		}},
+		{"GetVenueRuns", func(ctx context.Context) error {
+			_, err := h.GetVenueRunsHandler(ctx, &GetVenueRunsRequest{VenueID: "1"})
+			return err
+		}},
+		{"ResetRenderMethod", func(ctx context.Context) error {
+			_, err := h.ResetRenderMethodHandler(ctx, &ResetRenderMethodRequest{VenueID: "1"})
 			return err
 		}},
 	}
@@ -476,5 +495,190 @@ func TestPipelineHandler_UpdateNotes_ServiceError(t *testing.T) {
 	req.Body.ExtractionNotes = &notes
 
 	_, err := h.UpdateExtractionNotesHandler(pipelineAdminCtx(), req)
+	assertHumaError(t, err, 422)
+}
+
+// ============================================================================
+// Tests: UpdateVenueConfigHandler
+// ============================================================================
+
+func TestPipelineHandler_UpdateConfig_Success(t *testing.T) {
+	calURL := "https://example.com/calendar"
+	slug := "test-venue"
+	h := NewPipelineHandler(
+		&mockPipelineService{},
+		&mockVenueSourceConfigService{
+			createOrUpdateFn: func(config *models.VenueSourceConfig) (*models.VenueSourceConfig, error) {
+				config.Venue = models.Venue{ID: config.VenueID, Name: "Test Venue", Slug: &slug}
+				return config, nil
+			},
+		},
+	)
+
+	req := &UpdateVenueConfigRequest{VenueID: "10"}
+	req.Body.CalendarURL = &calURL
+	req.Body.PreferredSource = "ai"
+	req.Body.AutoApprove = true
+	req.Body.StrategyLocked = false
+
+	resp, err := h.UpdateVenueConfigHandler(pipelineAdminCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.VenueID != 10 {
+		t.Errorf("expected venue_id=10, got %d", resp.Body.VenueID)
+	}
+	if resp.Body.VenueName != "Test Venue" {
+		t.Errorf("expected venue_name=Test Venue, got %s", resp.Body.VenueName)
+	}
+	if !resp.Body.AutoApprove {
+		t.Error("expected auto_approve=true")
+	}
+}
+
+func TestPipelineHandler_UpdateConfig_InvalidVenueID(t *testing.T) {
+	h := NewPipelineHandler(&mockPipelineService{}, &mockVenueSourceConfigService{})
+
+	_, err := h.UpdateVenueConfigHandler(pipelineAdminCtx(), &UpdateVenueConfigRequest{VenueID: "abc"})
+	assertHumaError(t, err, 400)
+}
+
+func TestPipelineHandler_UpdateConfig_ServiceError(t *testing.T) {
+	h := NewPipelineHandler(
+		&mockPipelineService{},
+		&mockVenueSourceConfigService{
+			createOrUpdateFn: func(config *models.VenueSourceConfig) (*models.VenueSourceConfig, error) {
+				return nil, fmt.Errorf("database error")
+			},
+		},
+	)
+
+	req := &UpdateVenueConfigRequest{VenueID: "10"}
+	req.Body.PreferredSource = "ai"
+
+	_, err := h.UpdateVenueConfigHandler(pipelineAdminCtx(), req)
+	assertHumaError(t, err, 422)
+}
+
+// ============================================================================
+// Tests: GetVenueRunsHandler
+// ============================================================================
+
+func TestPipelineHandler_GetVenueRuns_Success(t *testing.T) {
+	h := NewPipelineHandler(
+		&mockPipelineService{},
+		&mockVenueSourceConfigService{
+			getRecentRunsFn: func(venueID uint, limit int) ([]models.VenueExtractionRun, error) {
+				return []models.VenueExtractionRun{
+					{ID: 1, VenueID: venueID, EventsExtracted: 10, EventsImported: 8},
+					{ID: 2, VenueID: venueID, EventsExtracted: 5, EventsImported: 3},
+				}, nil
+			},
+		},
+	)
+
+	resp, err := h.GetVenueRunsHandler(pipelineAdminCtx(), &GetVenueRunsRequest{VenueID: "10", Limit: 10})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Total != 2 {
+		t.Errorf("expected total=2, got %d", resp.Body.Total)
+	}
+	if len(resp.Body.Runs) != 2 {
+		t.Fatalf("expected 2 runs, got %d", len(resp.Body.Runs))
+	}
+	if resp.Body.Runs[0].EventsExtracted != 10 {
+		t.Errorf("expected first run events_extracted=10, got %d", resp.Body.Runs[0].EventsExtracted)
+	}
+}
+
+func TestPipelineHandler_GetVenueRuns_DefaultLimit(t *testing.T) {
+	var receivedLimit int
+	h := NewPipelineHandler(
+		&mockPipelineService{},
+		&mockVenueSourceConfigService{
+			getRecentRunsFn: func(venueID uint, limit int) ([]models.VenueExtractionRun, error) {
+				receivedLimit = limit
+				return nil, nil
+			},
+		},
+	)
+
+	_, err := h.GetVenueRunsHandler(pipelineAdminCtx(), &GetVenueRunsRequest{VenueID: "10"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if receivedLimit != 10 {
+		t.Errorf("expected default limit=10, got %d", receivedLimit)
+	}
+}
+
+func TestPipelineHandler_GetVenueRuns_InvalidVenueID(t *testing.T) {
+	h := NewPipelineHandler(&mockPipelineService{}, &mockVenueSourceConfigService{})
+
+	_, err := h.GetVenueRunsHandler(pipelineAdminCtx(), &GetVenueRunsRequest{VenueID: "abc"})
+	assertHumaError(t, err, 400)
+}
+
+func TestPipelineHandler_GetVenueRuns_ServiceError(t *testing.T) {
+	h := NewPipelineHandler(
+		&mockPipelineService{},
+		&mockVenueSourceConfigService{
+			getRecentRunsFn: func(venueID uint, limit int) ([]models.VenueExtractionRun, error) {
+				return nil, fmt.Errorf("database error")
+			},
+		},
+	)
+
+	_, err := h.GetVenueRunsHandler(pipelineAdminCtx(), &GetVenueRunsRequest{VenueID: "10"})
+	assertHumaError(t, err, 422)
+}
+
+// ============================================================================
+// Tests: ResetRenderMethodHandler
+// ============================================================================
+
+func TestPipelineHandler_ResetRenderMethod_Success(t *testing.T) {
+	var receivedVenueID uint
+	h := NewPipelineHandler(
+		&mockPipelineService{},
+		&mockVenueSourceConfigService{
+			resetRenderMethodFn: func(venueID uint) error {
+				receivedVenueID = venueID
+				return nil
+			},
+		},
+	)
+
+	resp, err := h.ResetRenderMethodHandler(pipelineAdminCtx(), &ResetRenderMethodRequest{VenueID: "10"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.Body.Success {
+		t.Error("expected success=true")
+	}
+	if receivedVenueID != 10 {
+		t.Errorf("expected venueID=10, got %d", receivedVenueID)
+	}
+}
+
+func TestPipelineHandler_ResetRenderMethod_InvalidVenueID(t *testing.T) {
+	h := NewPipelineHandler(&mockPipelineService{}, &mockVenueSourceConfigService{})
+
+	_, err := h.ResetRenderMethodHandler(pipelineAdminCtx(), &ResetRenderMethodRequest{VenueID: "abc"})
+	assertHumaError(t, err, 400)
+}
+
+func TestPipelineHandler_ResetRenderMethod_ServiceError(t *testing.T) {
+	h := NewPipelineHandler(
+		&mockPipelineService{},
+		&mockVenueSourceConfigService{
+			resetRenderMethodFn: func(venueID uint) error {
+				return fmt.Errorf("venue source config not found for venue 999")
+			},
+		},
+	)
+
+	_, err := h.ResetRenderMethodHandler(pipelineAdminCtx(), &ResetRenderMethodRequest{VenueID: "999"})
 	assertHumaError(t, err, 422)
 }

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -552,6 +552,9 @@ func setupPipelineRoutes(protected *huma.Group, sc *services.ServiceContainer) {
 	huma.Get(protected, "/admin/pipeline/venues", pipelineHandler.ListPipelineVenuesHandler)
 	huma.Get(protected, "/admin/pipeline/venues/{venue_id}/stats", pipelineHandler.VenueRejectionStatsHandler)
 	huma.Patch(protected, "/admin/pipeline/venues/{venue_id}/notes", pipelineHandler.UpdateExtractionNotesHandler)
+	huma.Put(protected, "/admin/pipeline/venues/{venue_id}/config", pipelineHandler.UpdateVenueConfigHandler)
+	huma.Get(protected, "/admin/pipeline/venues/{venue_id}/runs", pipelineHandler.GetVenueRunsHandler)
+	huma.Post(protected, "/admin/pipeline/venues/{venue_id}/reset-render-method", pipelineHandler.ResetRenderMethodHandler)
 }
 
 // setupCollectionRoutes configures collection endpoints.

--- a/backend/internal/services/contracts/interfaces.go
+++ b/backend/internal/services/contracts/interfaces.go
@@ -406,4 +406,5 @@ type VenueSourceConfigServiceInterface interface {
 	ListConfigured() ([]models.VenueSourceConfig, error)
 	GetRejectionStats(venueID uint) (*VenueRejectionStats, error)
 	UpdateExtractionNotes(venueID uint, notes *string) error
+	ResetRenderMethod(venueID uint) error
 }

--- a/backend/internal/services/pipeline/orchestrator_test.go
+++ b/backend/internal/services/pipeline/orchestrator_test.go
@@ -144,6 +144,9 @@ func (s *stubVenueConfig) GetRejectionStats(venueID uint) (*VenueRejectionStats,
 func (s *stubVenueConfig) UpdateExtractionNotes(venueID uint, notes *string) error {
 	return nil
 }
+func (s *stubVenueConfig) ResetRenderMethod(venueID uint) error {
+	return nil
+}
 
 type stubVenueService struct {
 	getVenueModelFn func(venueID uint) (*models.Venue, error)

--- a/backend/internal/services/pipeline/venue_source_config.go
+++ b/backend/internal/services/pipeline/venue_source_config.go
@@ -266,6 +266,29 @@ func (s *VenueSourceConfigService) UpdateExtractionNotes(venueID uint, notes *st
 	return nil
 }
 
+// ResetRenderMethod clears the render_method for a venue, forcing re-detection on next pipeline run.
+func (s *VenueSourceConfigService) ResetRenderMethod(venueID uint) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	result := s.db.Model(&models.VenueSourceConfig{}).
+		Where("venue_id = ?", venueID).
+		Updates(map[string]interface{}{
+			"render_method": nil,
+			"updated_at":    time.Now(),
+		})
+
+	if result.Error != nil {
+		return fmt.Errorf("failed to reset render method: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("venue source config not found for venue %d", venueID)
+	}
+
+	return nil
+}
+
 // ListConfigured returns all venue source configs, preloading the venue association.
 func (s *VenueSourceConfigService) ListConfigured() ([]models.VenueSourceConfig, error) {
 	if s.db == nil {

--- a/backend/internal/services/pipeline/venue_source_config_test.go
+++ b/backend/internal/services/pipeline/venue_source_config_test.go
@@ -75,6 +75,12 @@ func TestVenueSourceConfigService_NilDatabase(t *testing.T) {
 		assert.Equal(t, "database not initialized", err.Error())
 		assert.Nil(t, result)
 	})
+
+	t.Run("ResetRenderMethod", func(t *testing.T) {
+		err := svc.ResetRenderMethod(1)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+	})
 }
 
 // =============================================================================
@@ -452,6 +458,40 @@ func (s *VenueSourceConfigIntegrationTestSuite) TestListConfigured_WithConfigs()
 	s.Equal(s.venueID, configs[0].VenueID)
 	// Verify venue is preloaded
 	s.Equal("Test Venue", configs[0].Venue.Name)
+}
+
+// --- ResetRenderMethod tests ---
+
+func (s *VenueSourceConfigIntegrationTestSuite) TestResetRenderMethod_Success() {
+	url := "https://testvenue.com/calendar"
+	method := "dynamic"
+	config := &models.VenueSourceConfig{
+		VenueID:      s.venueID,
+		CalendarURL:  &url,
+		RenderMethod: &method,
+	}
+	_, err := s.svc.CreateOrUpdate(config)
+	s.NoError(err)
+
+	// Verify render_method is set
+	result, err := s.svc.GetByVenueID(s.venueID)
+	s.NoError(err)
+	s.Equal(&method, result.RenderMethod)
+
+	// Reset
+	err = s.svc.ResetRenderMethod(s.venueID)
+	s.NoError(err)
+
+	// Verify render_method is nil
+	result, err = s.svc.GetByVenueID(s.venueID)
+	s.NoError(err)
+	s.Nil(result.RenderMethod)
+}
+
+func (s *VenueSourceConfigIntegrationTestSuite) TestResetRenderMethod_NotFound() {
+	err := s.svc.ResetRenderMethod(99999)
+	s.Error(err)
+	s.Contains(err.Error(), "not found")
 }
 
 // --- Cascade delete test ---

--- a/frontend/components/admin/PipelineVenues.tsx
+++ b/frontend/components/admin/PipelineVenues.tsx
@@ -4,10 +4,15 @@ import { useState } from 'react'
 import {
   usePipelineVenues,
   useVenueRejectionStats,
-  useUpdateExtractionNotes,
+  useUpdateVenueConfig,
+  useVenueExtractionRuns,
+  useResetRenderMethod,
   useExtractVenue,
   type PipelineVenueInfo,
+  type VenueExtractionRun,
 } from '@/lib/hooks/usePipeline'
+import { useVenueSearch } from '@/features/venues'
+import { Switch } from '@/components/ui/switch'
 
 function ApprovalBadge({ rate }: { rate?: number }) {
   if (rate === undefined || rate === null) {
@@ -26,6 +31,284 @@ function ApprovalBadge({ rate }: { rate?: number }) {
   )
 }
 
+function RunHistorySection({ venueId }: { venueId: number }) {
+  const [isOpen, setIsOpen] = useState(false)
+  const { data, isLoading } = useVenueExtractionRuns(venueId, { enabled: isOpen })
+
+  return (
+    <div>
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="text-sm font-medium flex items-center gap-1 hover:text-foreground text-muted-foreground"
+      >
+        <span className={`transition-transform ${isOpen ? 'rotate-90' : ''}`}>&#9654;</span>
+        Extraction Run History
+      </button>
+      {isOpen && (
+        <div className="mt-2">
+          {isLoading ? (
+            <p className="text-sm text-muted-foreground">Loading runs...</p>
+          ) : !data?.runs?.length ? (
+            <p className="text-sm text-muted-foreground">No extraction runs yet</p>
+          ) : (
+            <div className="border border-border rounded overflow-hidden">
+              <table className="w-full text-xs">
+                <thead className="bg-muted/50">
+                  <tr>
+                    <th className="text-left p-2 font-medium">Date</th>
+                    <th className="text-left p-2 font-medium">Method</th>
+                    <th className="text-center p-2 font-medium">Extracted</th>
+                    <th className="text-center p-2 font-medium">Imported</th>
+                    <th className="text-right p-2 font-medium">Duration</th>
+                    <th className="text-center p-2 font-medium">Status</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border">
+                  {data.runs.map((run: VenueExtractionRun) => (
+                    <tr key={run.id}>
+                      <td className="p-2 text-muted-foreground">
+                        {new Date(run.run_at || run.created_at).toLocaleString()}
+                      </td>
+                      <td className="p-2 text-muted-foreground">{run.render_method ?? '—'}</td>
+                      <td className="p-2 text-center">{run.events_extracted}</td>
+                      <td className="p-2 text-center">{run.events_imported}</td>
+                      <td className="p-2 text-right text-muted-foreground">{run.duration_ms}ms</td>
+                      <td className="p-2 text-center">
+                        {run.error ? (
+                          <span className="text-red-400" title={run.error}>
+                            Error
+                          </span>
+                        ) : (
+                          <span className="text-green-400">OK</span>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ConfigEditForm({
+  venue,
+  onClose,
+}: {
+  venue: PipelineVenueInfo
+  onClose: () => void
+}) {
+  const updateConfig = useUpdateVenueConfig()
+  const [calendarUrl, setCalendarUrl] = useState(venue.calendar_url ?? '')
+  const [preferredSource, setPreferredSource] = useState(venue.preferred_source || 'ai')
+  const [renderMethod, setRenderMethod] = useState(venue.render_method ?? '')
+  const [feedUrl, setFeedUrl] = useState(venue.feed_url ?? '')
+  const [autoApprove, setAutoApprove] = useState(venue.auto_approve)
+  const [strategyLocked, setStrategyLocked] = useState(venue.strategy_locked)
+  const [extractionNotes, setExtractionNotes] = useState(venue.extraction_notes ?? '')
+
+  const handleSave = () => {
+    updateConfig.mutate(
+      {
+        venueId: venue.venue_id,
+        config: {
+          calendar_url: calendarUrl || null,
+          preferred_source: preferredSource,
+          render_method: renderMethod || null,
+          feed_url: feedUrl || null,
+          auto_approve: autoApprove,
+          strategy_locked: strategyLocked,
+          extraction_notes: extractionNotes || null,
+        },
+      },
+      { onSuccess: () => onClose() }
+    )
+  }
+
+  return (
+    <div className="space-y-3 border border-border rounded p-3 bg-muted/20">
+      <h4 className="text-sm font-medium">Edit Configuration</h4>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label className="text-xs text-muted-foreground block mb-1">Calendar URL</label>
+          <input
+            type="text"
+            value={calendarUrl}
+            onChange={(e) => setCalendarUrl(e.target.value)}
+            className="w-full bg-background border border-border rounded px-2 py-1 text-sm"
+            placeholder="https://venue.com/events"
+          />
+        </div>
+
+        <div>
+          <label className="text-xs text-muted-foreground block mb-1">Feed URL (iCal/RSS)</label>
+          <input
+            type="text"
+            value={feedUrl}
+            onChange={(e) => setFeedUrl(e.target.value)}
+            className="w-full bg-background border border-border rounded px-2 py-1 text-sm"
+            placeholder="https://venue.com/events.ics"
+          />
+        </div>
+
+        <div>
+          <label className="text-xs text-muted-foreground block mb-1">Preferred Source</label>
+          <select
+            value={preferredSource}
+            onChange={(e) => setPreferredSource(e.target.value)}
+            className="w-full bg-background border border-border rounded px-2 py-1 text-sm"
+          >
+            <option value="ai">AI</option>
+            <option value="ical">iCal</option>
+            <option value="rss">RSS</option>
+          </select>
+        </div>
+
+        <div>
+          <label className="text-xs text-muted-foreground block mb-1">Render Method</label>
+          <select
+            value={renderMethod}
+            onChange={(e) => setRenderMethod(e.target.value)}
+            className="w-full bg-background border border-border rounded px-2 py-1 text-sm"
+          >
+            <option value="">Auto-detect</option>
+            <option value="static">Static</option>
+            <option value="dynamic">Dynamic</option>
+            <option value="screenshot">Screenshot</option>
+          </select>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-6">
+        <label className="flex items-center gap-2 text-sm">
+          <Switch checked={autoApprove} onCheckedChange={setAutoApprove} size="sm" />
+          Auto-approve
+        </label>
+        <label className="flex items-center gap-2 text-sm">
+          <Switch checked={strategyLocked} onCheckedChange={setStrategyLocked} size="sm" />
+          Strategy locked
+        </label>
+      </div>
+
+      <div>
+        <label className="text-xs text-muted-foreground block mb-1">Extraction Notes</label>
+        <textarea
+          value={extractionNotes}
+          onChange={(e) => setExtractionNotes(e.target.value)}
+          className="w-full h-20 bg-background border border-border rounded p-2 text-sm resize-none"
+          placeholder='e.g., "Skip karaoke Tuesdays and trivia Wednesdays"'
+        />
+      </div>
+
+      <div className="flex gap-2">
+        <button
+          onClick={handleSave}
+          disabled={updateConfig.isPending}
+          className="px-3 py-1 bg-primary text-primary-foreground rounded text-sm hover:bg-primary/90 disabled:opacity-50"
+        >
+          {updateConfig.isPending ? 'Saving...' : 'Save'}
+        </button>
+        <button
+          onClick={onClose}
+          className="px-3 py-1 border border-border rounded text-sm hover:bg-muted"
+        >
+          Cancel
+        </button>
+      </div>
+      {updateConfig.error && (
+        <p className="text-sm text-red-400">
+          {updateConfig.error instanceof Error ? updateConfig.error.message : 'Save failed'}
+        </p>
+      )}
+    </div>
+  )
+}
+
+function AddVenueDialog({
+  existingVenueIds,
+  onClose,
+}: {
+  existingVenueIds: Set<number>
+  onClose: () => void
+}) {
+  const [searchQuery, setSearchQuery] = useState('')
+  const { data: searchResults } = useVenueSearch({ query: searchQuery })
+  const updateConfig = useUpdateVenueConfig()
+
+  const filteredVenues = (searchResults?.venues ?? []).filter(
+    (v) => !existingVenueIds.has(v.id)
+  )
+
+  const handleSelectVenue = (venueId: number) => {
+    updateConfig.mutate(
+      {
+        venueId,
+        config: {
+          preferred_source: 'ai',
+          auto_approve: false,
+          strategy_locked: false,
+        },
+      },
+      { onSuccess: () => onClose() }
+    )
+  }
+
+  return (
+    <div className="border border-border rounded-lg p-4 space-y-3 bg-card">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-medium">Configure New Venue</h3>
+        <button onClick={onClose} className="text-muted-foreground hover:text-foreground text-sm">
+          Close
+        </button>
+      </div>
+
+      <input
+        type="text"
+        value={searchQuery}
+        onChange={(e) => setSearchQuery(e.target.value)}
+        className="w-full bg-background border border-border rounded px-3 py-2 text-sm"
+        placeholder="Search venues..."
+        autoFocus
+      />
+
+      {searchQuery && filteredVenues.length > 0 && (
+        <div className="max-h-48 overflow-y-auto border border-border rounded divide-y divide-border">
+          {filteredVenues.map((venue) => (
+            <button
+              key={venue.id}
+              onClick={() => handleSelectVenue(venue.id)}
+              disabled={updateConfig.isPending}
+              className="w-full text-left px-3 py-2 text-sm hover:bg-muted disabled:opacity-50"
+            >
+              <span className="font-medium">{venue.name}</span>
+              <span className="text-muted-foreground ml-2 text-xs">
+                {venue.city}, {venue.state}
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+
+      {searchQuery && filteredVenues.length === 0 && (
+        <p className="text-sm text-muted-foreground">No matching venues found</p>
+      )}
+
+      {updateConfig.isPending && (
+        <p className="text-sm text-muted-foreground">Creating config...</p>
+      )}
+      {updateConfig.error && (
+        <p className="text-sm text-red-400">
+          {updateConfig.error instanceof Error ? updateConfig.error.message : 'Failed'}
+        </p>
+      )}
+    </div>
+  )
+}
+
 function VenueDetailPanel({
   venue,
   onClose,
@@ -34,20 +317,18 @@ function VenueDetailPanel({
   onClose: () => void
 }) {
   const { data: stats, isLoading: statsLoading } = useVenueRejectionStats(venue.venue_id)
-  const updateNotes = useUpdateExtractionNotes()
+  const resetRenderMethod = useResetRenderMethod()
   const extractVenue = useExtractVenue()
-  const [notes, setNotes] = useState(venue.extraction_notes ?? '')
-  const [isEditing, setIsEditing] = useState(false)
-
-  const handleSaveNotes = () => {
-    updateNotes.mutate(
-      { venueId: venue.venue_id, extractionNotes: notes || null },
-      { onSuccess: () => setIsEditing(false) }
-    )
-  }
+  const [isEditingConfig, setIsEditingConfig] = useState(false)
 
   const handleExtract = (dryRun: boolean) => {
     extractVenue.mutate({ venueId: venue.venue_id, dryRun })
+  }
+
+  const handleResetRenderMethod = () => {
+    if (window.confirm('Reset render method to auto-detect? It will be re-detected on the next pipeline run.')) {
+      resetRenderMethod.mutate({ venueId: venue.venue_id })
+    }
   }
 
   return (
@@ -60,26 +341,106 @@ function VenueDetailPanel({
       </div>
 
       {/* Config overview */}
-      <div className="grid grid-cols-2 gap-2 text-sm">
-        <div>
-          <span className="text-muted-foreground">Render method:</span>{' '}
-          {venue.render_method ?? 'auto-detect'}
+      {isEditingConfig ? (
+        <ConfigEditForm venue={venue} onClose={() => setIsEditingConfig(false)} />
+      ) : (
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <h4 className="text-sm font-medium">Configuration</h4>
+            <button
+              onClick={() => setIsEditingConfig(true)}
+              className="text-xs text-blue-400 hover:text-blue-300"
+            >
+              Edit
+            </button>
+          </div>
+          <div className="grid grid-cols-2 gap-2 text-sm">
+            <div>
+              <span className="text-muted-foreground">Calendar URL:</span>{' '}
+              {venue.calendar_url ? (
+                <a
+                  href={venue.calendar_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-400 hover:underline break-all"
+                >
+                  {venue.calendar_url.length > 40
+                    ? venue.calendar_url.slice(0, 40) + '...'
+                    : venue.calendar_url}
+                </a>
+              ) : (
+                <span className="text-muted-foreground italic">Not set</span>
+              )}
+            </div>
+            <div>
+              <span className="text-muted-foreground">Preferred source:</span>{' '}
+              {venue.preferred_source || 'ai'}
+            </div>
+            <div>
+              <span className="text-muted-foreground">Render method:</span>{' '}
+              {venue.render_method ?? 'auto-detect'}
+              {venue.render_method && (
+                <button
+                  onClick={handleResetRenderMethod}
+                  disabled={resetRenderMethod.isPending}
+                  className="ml-2 text-xs text-yellow-400 hover:text-yellow-300 disabled:opacity-50"
+                >
+                  {resetRenderMethod.isPending ? 'Resetting...' : 'Reset'}
+                </button>
+              )}
+            </div>
+            <div>
+              <span className="text-muted-foreground">Auto-approve:</span>{' '}
+              {venue.auto_approve ? 'Yes' : 'No'}
+            </div>
+            <div>
+              <span className="text-muted-foreground">Strategy locked:</span>{' '}
+              {venue.strategy_locked ? 'Yes' : 'No'}
+            </div>
+            <div>
+              <span className="text-muted-foreground">Last extracted:</span>{' '}
+              {venue.last_extracted_at
+                ? new Date(venue.last_extracted_at).toLocaleDateString()
+                : 'Never'}
+            </div>
+            <div>
+              <span className="text-muted-foreground">Failures:</span>{' '}
+              {venue.consecutive_failures}
+            </div>
+            <div>
+              <span className="text-muted-foreground">Events expected:</span>{' '}
+              {venue.events_expected}
+              {venue.last_run && venue.events_expected > 0 && (
+                <>
+                  {' '}
+                  <span className="text-muted-foreground">(last:</span>{' '}
+                  <span
+                    className={
+                      venue.last_run.events_extracted < venue.events_expected * 0.5
+                        ? 'text-yellow-400'
+                        : ''
+                    }
+                  >
+                    {venue.last_run.events_extracted}
+                  </span>
+                  <span className="text-muted-foreground">)</span>
+                  {venue.last_run.events_extracted < venue.events_expected * 0.5 && (
+                    <span className="text-yellow-400 text-xs ml-1" title="Less than 50% of expected events">
+                      Low
+                    </span>
+                  )}
+                </>
+              )}
+            </div>
+          </div>
+          {venue.extraction_notes && (
+            <div className="text-sm">
+              <span className="text-muted-foreground">Notes:</span>{' '}
+              <span className="italic">{venue.extraction_notes}</span>
+            </div>
+          )}
         </div>
-        <div>
-          <span className="text-muted-foreground">Auto-approve:</span>{' '}
-          {venue.auto_approve ? 'Yes' : 'No'}
-        </div>
-        <div>
-          <span className="text-muted-foreground">Last extracted:</span>{' '}
-          {venue.last_extracted_at
-            ? new Date(venue.last_extracted_at).toLocaleDateString()
-            : 'Never'}
-        </div>
-        <div>
-          <span className="text-muted-foreground">Failures:</span>{' '}
-          {venue.consecutive_failures}
-        </div>
-      </div>
+      )}
 
       {/* Rejection stats */}
       <div>
@@ -133,50 +494,8 @@ function VenueDetailPanel({
         )}
       </div>
 
-      {/* Extraction notes */}
-      <div>
-        <h4 className="text-sm font-medium mb-2">Extraction Notes</h4>
-        <p className="text-xs text-muted-foreground mb-1">
-          These notes are included in the AI prompt when extracting events for this venue.
-        </p>
-        {isEditing ? (
-          <div className="space-y-2">
-            <textarea
-              value={notes}
-              onChange={(e) => setNotes(e.target.value)}
-              className="w-full h-24 bg-background border border-border rounded p-2 text-sm resize-none"
-              placeholder='e.g., "This venue hosts karaoke every Tuesday and trivia every Wednesday — skip those"'
-            />
-            <div className="flex gap-2">
-              <button
-                onClick={handleSaveNotes}
-                disabled={updateNotes.isPending}
-                className="px-3 py-1 bg-primary text-primary-foreground rounded text-sm hover:bg-primary/90 disabled:opacity-50"
-              >
-                {updateNotes.isPending ? 'Saving...' : 'Save'}
-              </button>
-              <button
-                onClick={() => {
-                  setNotes(venue.extraction_notes ?? '')
-                  setIsEditing(false)
-                }}
-                className="px-3 py-1 border border-border rounded text-sm hover:bg-muted"
-              >
-                Cancel
-              </button>
-            </div>
-          </div>
-        ) : (
-          <div
-            onClick={() => setIsEditing(true)}
-            className="cursor-pointer p-2 border border-border rounded text-sm hover:bg-muted min-h-[2.5rem]"
-          >
-            {venue.extraction_notes || (
-              <span className="text-muted-foreground italic">Click to add notes...</span>
-            )}
-          </div>
-        )}
-      </div>
+      {/* Extraction run history */}
+      <RunHistorySection venueId={venue.venue_id} />
 
       {/* Extract actions */}
       <div className="flex gap-2 pt-2 border-t border-border">
@@ -225,90 +544,116 @@ function VenueDetailPanel({
 export function PipelineVenues() {
   const { data, isLoading, error } = usePipelineVenues()
   const [selectedVenueId, setSelectedVenueId] = useState<number | null>(null)
+  const [showAddVenue, setShowAddVenue] = useState(false)
 
   if (isLoading) return <p className="text-muted-foreground">Loading pipeline venues...</p>
   if (error) return <p className="text-red-400">Failed to load pipeline venues</p>
-  if (!data?.venues.length) return <p className="text-muted-foreground">No venues configured</p>
 
-  const selectedVenue = data.venues.find((v) => v.venue_id === selectedVenueId)
+  const venues = data?.venues ?? []
+  const selectedVenue = venues.find((v) => v.venue_id === selectedVenueId)
+  const existingVenueIds = new Set(venues.map((v) => v.venue_id))
 
   return (
     <div className="space-y-4">
-      <h2 className="text-lg font-semibold">Pipeline Venues</h2>
-
-      {/* Venue table */}
-      <div className="border border-border rounded-lg overflow-hidden">
-        <table className="w-full text-sm">
-          <thead className="bg-muted/50">
-            <tr>
-              <th className="text-left p-3 font-medium">Venue</th>
-              <th className="text-left p-3 font-medium">Method</th>
-              <th className="text-center p-3 font-medium">Approval</th>
-              <th className="text-center p-3 font-medium">Auto</th>
-              <th className="text-left p-3 font-medium">Last Run</th>
-              <th className="text-center p-3 font-medium">Notes</th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-border">
-            {data.venues.map((venue) => (
-              <tr
-                key={venue.venue_id}
-                onClick={() =>
-                  setSelectedVenueId(
-                    selectedVenueId === venue.venue_id ? null : venue.venue_id
-                  )
-                }
-                className={`cursor-pointer hover:bg-muted/30 ${
-                  selectedVenueId === venue.venue_id ? 'bg-muted/50' : ''
-                }`}
-              >
-                <td className="p-3">
-                  <div className="font-medium">{venue.venue_name}</div>
-                  {venue.consecutive_failures > 0 && (
-                    <span className="text-xs text-red-400">
-                      {venue.consecutive_failures} failure(s)
-                    </span>
-                  )}
-                </td>
-                <td className="p-3 text-muted-foreground">
-                  {venue.render_method ?? '—'}
-                </td>
-                <td className="p-3 text-center">
-                  <ApprovalBadge rate={venue.approval_rate} />
-                </td>
-                <td className="p-3 text-center">
-                  {venue.auto_approve ? (
-                    <span className="text-green-400 text-xs">On</span>
-                  ) : (
-                    <span className="text-muted-foreground text-xs">Off</span>
-                  )}
-                </td>
-                <td className="p-3 text-muted-foreground text-xs">
-                  {venue.last_run
-                    ? `${venue.last_run.events_extracted} events, ${new Date(venue.last_run.created_at).toLocaleDateString()}`
-                    : 'Never'}
-                </td>
-                <td className="p-3 text-center">
-                  {venue.extraction_notes ? (
-                    <span className="text-xs text-blue-400" title={venue.extraction_notes}>
-                      Has notes
-                    </span>
-                  ) : (
-                    <span className="text-xs text-muted-foreground">—</span>
-                  )}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold">Pipeline Venues</h2>
+        <button
+          onClick={() => {
+            setShowAddVenue(!showAddVenue)
+            setSelectedVenueId(null)
+          }}
+          className="px-3 py-1 bg-primary text-primary-foreground rounded text-sm hover:bg-primary/90"
+        >
+          {showAddVenue ? 'Cancel' : 'Configure Venue'}
+        </button>
       </div>
 
-      {/* Detail panel */}
-      {selectedVenue && (
-        <VenueDetailPanel
-          venue={selectedVenue}
-          onClose={() => setSelectedVenueId(null)}
+      {showAddVenue && (
+        <AddVenueDialog
+          existingVenueIds={existingVenueIds}
+          onClose={() => setShowAddVenue(false)}
         />
+      )}
+
+      {venues.length === 0 ? (
+        <p className="text-muted-foreground">No venues configured</p>
+      ) : (
+        <>
+          {/* Venue table */}
+          <div className="border border-border rounded-lg overflow-hidden">
+            <table className="w-full text-sm">
+              <thead className="bg-muted/50">
+                <tr>
+                  <th className="text-left p-3 font-medium">Venue</th>
+                  <th className="text-left p-3 font-medium">Method</th>
+                  <th className="text-center p-3 font-medium">Approval</th>
+                  <th className="text-center p-3 font-medium">Auto</th>
+                  <th className="text-left p-3 font-medium">Last Run</th>
+                  <th className="text-center p-3 font-medium">Notes</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {venues.map((venue) => (
+                  <tr
+                    key={venue.venue_id}
+                    onClick={() =>
+                      setSelectedVenueId(
+                        selectedVenueId === venue.venue_id ? null : venue.venue_id
+                      )
+                    }
+                    className={`cursor-pointer hover:bg-muted/30 ${
+                      selectedVenueId === venue.venue_id ? 'bg-muted/50' : ''
+                    }`}
+                  >
+                    <td className="p-3">
+                      <div className="font-medium">{venue.venue_name}</div>
+                      {venue.consecutive_failures > 0 && (
+                        <span className="text-xs text-red-400">
+                          {venue.consecutive_failures} failure(s)
+                        </span>
+                      )}
+                    </td>
+                    <td className="p-3 text-muted-foreground">
+                      {venue.render_method ?? '—'}
+                    </td>
+                    <td className="p-3 text-center">
+                      <ApprovalBadge rate={venue.approval_rate} />
+                    </td>
+                    <td className="p-3 text-center">
+                      {venue.auto_approve ? (
+                        <span className="text-green-400 text-xs">On</span>
+                      ) : (
+                        <span className="text-muted-foreground text-xs">Off</span>
+                      )}
+                    </td>
+                    <td className="p-3 text-muted-foreground text-xs">
+                      {venue.last_run
+                        ? `${venue.last_run.events_extracted} events, ${new Date(venue.last_run.created_at).toLocaleDateString()}`
+                        : 'Never'}
+                    </td>
+                    <td className="p-3 text-center">
+                      {venue.extraction_notes ? (
+                        <span className="text-xs text-blue-400" title={venue.extraction_notes}>
+                          Has notes
+                        </span>
+                      ) : (
+                        <span className="text-xs text-muted-foreground">—</span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Detail panel */}
+          {selectedVenue && (
+            <VenueDetailPanel
+              venue={selectedVenue}
+              onClose={() => setSelectedVenueId(null)}
+            />
+          )}
+        </>
       )}
     </div>
   )

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -281,6 +281,12 @@ export const API_ENDPOINTS = {
         `${API_BASE_URL}/admin/pipeline/venues/${venueId}/stats`,
       VENUE_NOTES: (venueId: string | number) =>
         `${API_BASE_URL}/admin/pipeline/venues/${venueId}/notes`,
+      VENUE_CONFIG: (venueId: string | number) =>
+        `${API_BASE_URL}/admin/pipeline/venues/${venueId}/config`,
+      VENUE_RUNS: (venueId: string | number) =>
+        `${API_BASE_URL}/admin/pipeline/venues/${venueId}/runs`,
+      VENUE_RESET_RENDER: (venueId: string | number) =>
+        `${API_BASE_URL}/admin/pipeline/venues/${venueId}/reset-render-method`,
     },
   },
 

--- a/frontend/lib/hooks/usePipeline.ts
+++ b/frontend/lib/hooks/usePipeline.ts
@@ -108,6 +108,68 @@ export function useUpdateExtractionNotes() {
   })
 }
 
+export function useUpdateVenueConfig() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({
+      venueId,
+      config,
+    }: {
+      venueId: number
+      config: {
+        calendar_url?: string | null
+        preferred_source: string
+        render_method?: string | null
+        feed_url?: string | null
+        auto_approve: boolean
+        strategy_locked: boolean
+        extraction_notes?: string | null
+      }
+    }) => {
+      return apiRequest<PipelineVenueInfo>(
+        API_ENDPOINTS.ADMIN.PIPELINE.VENUE_CONFIG(venueId),
+        {
+          method: 'PUT',
+          body: JSON.stringify(config),
+        }
+      )
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.pipeline.venues })
+    },
+  })
+}
+
+export function useVenueExtractionRuns(venueId: number, options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: queryKeys.pipeline.venueRuns(venueId),
+    queryFn: async () => {
+      const data = await apiRequest<{ runs: VenueExtractionRun[]; total: number }>(
+        API_ENDPOINTS.ADMIN.PIPELINE.VENUE_RUNS(venueId)
+      )
+      return data
+    },
+    enabled: (options?.enabled ?? true) && venueId > 0,
+  })
+}
+
+export function useResetRenderMethod() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ venueId }: { venueId: number }) => {
+      return apiRequest<{ success: boolean }>(
+        API_ENDPOINTS.ADMIN.PIPELINE.VENUE_RESET_RENDER(venueId),
+        { method: 'POST' }
+      )
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.pipeline.venues })
+    },
+  })
+}
+
 export function useExtractVenue() {
   const queryClient = useQueryClient()
 

--- a/frontend/lib/queryClient.ts
+++ b/frontend/lib/queryClient.ts
@@ -256,6 +256,8 @@ export const queryKeys = {
     venues: ['pipeline', 'venues'] as const,
     venueStats: (venueId: string | number) =>
       ['pipeline', 'venueStats', String(venueId)] as const,
+    venueRuns: (venueId: string | number) =>
+      ['pipeline', 'venueRuns', String(venueId)] as const,
   },
 
   // Contributor profile queries


### PR DESCRIPTION
## Summary

- **Backend**: Add `ResetRenderMethod` service method + 3 new admin handlers (`PUT /config`, `GET /runs`, `POST /reset-render-method`) with full test coverage (12 new handler tests, 3 new service tests)
- **Frontend**: Extend PipelineVenues admin tab with editable config form (all fields), "Configure Venue" dialog with venue search, collapsible extraction run history table, reset render method button, and events expected vs actual warning

## Test plan

- [x] `go test ./internal/api/handlers/ -run TestPipelineHandler` — 39 tests pass
- [x] `go test ./internal/services/pipeline/ -run TestVenueSourceConfig` — 26 tests pass (unit + integration)
- [x] Frontend TypeScript compiles cleanly (no new errors)
- [ ] Manual: open admin Pipeline tab, verify edit form saves config
- [ ] Manual: verify run history loads in collapsible section
- [ ] Manual: verify reset render method works with confirmation dialog
- [ ] Manual: verify "Configure Venue" button opens search and creates new config

🤖 Generated with [Claude Code](https://claude.com/claude-code)