### PR TITLE
Add data provenance tracking to core entity tables (PSY-34)

### DIFF
--- a/backend/db/migrations/000048_add_data_provenance.down.sql
+++ b/backend/db/migrations/000048_add_data_provenance.down.sql
@@ -1,0 +1,55 @@
+-- Drop indexes first, then columns from all 6 tables
+
+-- Shows
+DROP INDEX IF EXISTS idx_shows_data_source;
+DROP INDEX IF EXISTS idx_shows_last_verified_at;
+ALTER TABLE shows
+    DROP CONSTRAINT IF EXISTS chk_shows_source_confidence,
+    DROP COLUMN IF EXISTS data_source,
+    DROP COLUMN IF EXISTS source_confidence,
+    DROP COLUMN IF EXISTS last_verified_at;
+
+-- Artists
+DROP INDEX IF EXISTS idx_artists_data_source;
+DROP INDEX IF EXISTS idx_artists_last_verified_at;
+ALTER TABLE artists
+    DROP CONSTRAINT IF EXISTS chk_artists_source_confidence,
+    DROP COLUMN IF EXISTS data_source,
+    DROP COLUMN IF EXISTS source_confidence,
+    DROP COLUMN IF EXISTS last_verified_at;
+
+-- Venues
+DROP INDEX IF EXISTS idx_venues_data_source;
+DROP INDEX IF EXISTS idx_venues_last_verified_at;
+ALTER TABLE venues
+    DROP CONSTRAINT IF EXISTS chk_venues_source_confidence,
+    DROP COLUMN IF EXISTS data_source,
+    DROP COLUMN IF EXISTS source_confidence,
+    DROP COLUMN IF EXISTS last_verified_at;
+
+-- Releases
+DROP INDEX IF EXISTS idx_releases_data_source;
+DROP INDEX IF EXISTS idx_releases_last_verified_at;
+ALTER TABLE releases
+    DROP CONSTRAINT IF EXISTS chk_releases_source_confidence,
+    DROP COLUMN IF EXISTS data_source,
+    DROP COLUMN IF EXISTS source_confidence,
+    DROP COLUMN IF EXISTS last_verified_at;
+
+-- Labels
+DROP INDEX IF EXISTS idx_labels_data_source;
+DROP INDEX IF EXISTS idx_labels_last_verified_at;
+ALTER TABLE labels
+    DROP CONSTRAINT IF EXISTS chk_labels_source_confidence,
+    DROP COLUMN IF EXISTS data_source,
+    DROP COLUMN IF EXISTS source_confidence,
+    DROP COLUMN IF EXISTS last_verified_at;
+
+-- Festivals
+DROP INDEX IF EXISTS idx_festivals_data_source;
+DROP INDEX IF EXISTS idx_festivals_last_verified_at;
+ALTER TABLE festivals
+    DROP CONSTRAINT IF EXISTS chk_festivals_source_confidence,
+    DROP COLUMN IF EXISTS data_source,
+    DROP COLUMN IF EXISTS source_confidence,
+    DROP COLUMN IF EXISTS last_verified_at;

--- a/backend/db/migrations/000048_add_data_provenance.up.sql
+++ b/backend/db/migrations/000048_add_data_provenance.up.sql
@@ -1,0 +1,85 @@
+-- Add data provenance columns to all 6 core entity tables
+-- data_source: where the data came from (user, ai_extraction, musicbrainz, etc.)
+-- source_confidence: confidence score 0.00-1.00
+-- last_verified_at: when the data was last verified/refreshed
+
+-- Shows
+ALTER TABLE shows
+    ADD COLUMN data_source VARCHAR(50),
+    ADD COLUMN source_confidence NUMERIC(3,2),
+    ADD COLUMN last_verified_at TIMESTAMPTZ;
+
+ALTER TABLE shows
+    ADD CONSTRAINT chk_shows_source_confidence
+    CHECK (source_confidence >= 0 AND source_confidence <= 1);
+
+CREATE INDEX idx_shows_data_source ON shows (data_source);
+CREATE INDEX idx_shows_last_verified_at ON shows (last_verified_at);
+
+-- Backfill shows.data_source from existing source column
+UPDATE shows SET data_source = source;
+
+-- Artists
+ALTER TABLE artists
+    ADD COLUMN data_source VARCHAR(50),
+    ADD COLUMN source_confidence NUMERIC(3,2),
+    ADD COLUMN last_verified_at TIMESTAMPTZ;
+
+ALTER TABLE artists
+    ADD CONSTRAINT chk_artists_source_confidence
+    CHECK (source_confidence >= 0 AND source_confidence <= 1);
+
+CREATE INDEX idx_artists_data_source ON artists (data_source);
+CREATE INDEX idx_artists_last_verified_at ON artists (last_verified_at);
+
+-- Venues
+ALTER TABLE venues
+    ADD COLUMN data_source VARCHAR(50),
+    ADD COLUMN source_confidence NUMERIC(3,2),
+    ADD COLUMN last_verified_at TIMESTAMPTZ;
+
+ALTER TABLE venues
+    ADD CONSTRAINT chk_venues_source_confidence
+    CHECK (source_confidence >= 0 AND source_confidence <= 1);
+
+CREATE INDEX idx_venues_data_source ON venues (data_source);
+CREATE INDEX idx_venues_last_verified_at ON venues (last_verified_at);
+
+-- Releases
+ALTER TABLE releases
+    ADD COLUMN data_source VARCHAR(50),
+    ADD COLUMN source_confidence NUMERIC(3,2),
+    ADD COLUMN last_verified_at TIMESTAMPTZ;
+
+ALTER TABLE releases
+    ADD CONSTRAINT chk_releases_source_confidence
+    CHECK (source_confidence >= 0 AND source_confidence <= 1);
+
+CREATE INDEX idx_releases_data_source ON releases (data_source);
+CREATE INDEX idx_releases_last_verified_at ON releases (last_verified_at);
+
+-- Labels
+ALTER TABLE labels
+    ADD COLUMN data_source VARCHAR(50),
+    ADD COLUMN source_confidence NUMERIC(3,2),
+    ADD COLUMN last_verified_at TIMESTAMPTZ;
+
+ALTER TABLE labels
+    ADD CONSTRAINT chk_labels_source_confidence
+    CHECK (source_confidence >= 0 AND source_confidence <= 1);
+
+CREATE INDEX idx_labels_data_source ON labels (data_source);
+CREATE INDEX idx_labels_last_verified_at ON labels (last_verified_at);
+
+-- Festivals
+ALTER TABLE festivals
+    ADD COLUMN data_source VARCHAR(50),
+    ADD COLUMN source_confidence NUMERIC(3,2),
+    ADD COLUMN last_verified_at TIMESTAMPTZ;
+
+ALTER TABLE festivals
+    ADD CONSTRAINT chk_festivals_source_confidence
+    CHECK (source_confidence >= 0 AND source_confidence <= 1);
+
+CREATE INDEX idx_festivals_data_source ON festivals (data_source);
+CREATE INDEX idx_festivals_last_verified_at ON festivals (last_verified_at);

--- a/backend/internal/models/artist.go
+++ b/backend/internal/models/artist.go
@@ -10,6 +10,12 @@ type Artist struct {
 	City             *string   `gorm:"column:city"`
 	BandcampEmbedURL *string   `gorm:"column:bandcamp_embed_url"`
 	Social           Social    `gorm:"embedded"`
+
+	// Data provenance fields
+	DataSource       *string    `json:"data_source,omitempty" gorm:"column:data_source;size:50"`
+	SourceConfidence *float64   `json:"source_confidence,omitempty" gorm:"column:source_confidence;type:numeric(3,2)"`
+	LastVerifiedAt   *time.Time `json:"last_verified_at,omitempty" gorm:"column:last_verified_at"`
+
 	CreatedAt        time.Time `gorm:"not null"`
 	UpdatedAt        time.Time `gorm:"not null"`
 

--- a/backend/internal/models/festival.go
+++ b/backend/internal/models/festival.go
@@ -47,6 +47,12 @@ type Festival struct {
 	FlyerURL     *string         `gorm:"column:flyer_url"`
 	Status       FestivalStatus  `gorm:"column:status;not null;default:'announced'"`
 	Social       *json.RawMessage `gorm:"column:social;type:jsonb;default:'{}'"`
+
+	// Data provenance fields
+	DataSource       *string    `json:"data_source,omitempty" gorm:"column:data_source;size:50"`
+	SourceConfidence *float64   `json:"source_confidence,omitempty" gorm:"column:source_confidence;type:numeric(3,2)"`
+	LastVerifiedAt   *time.Time `json:"last_verified_at,omitempty" gorm:"column:last_verified_at"`
+
 	CreatedAt    time.Time       `gorm:"not null"`
 	UpdatedAt    time.Time       `gorm:"not null"`
 

--- a/backend/internal/models/label.go
+++ b/backend/internal/models/label.go
@@ -23,6 +23,12 @@ type Label struct {
 	Status      LabelStatus `gorm:"column:status;not null;default:'active'"`
 	Description *string     `gorm:"column:description"`
 	Social      Social      `gorm:"embedded"`
+
+	// Data provenance fields
+	DataSource       *string    `json:"data_source,omitempty" gorm:"column:data_source;size:50"`
+	SourceConfidence *float64   `json:"source_confidence,omitempty" gorm:"column:source_confidence;type:numeric(3,2)"`
+	LastVerifiedAt   *time.Time `json:"last_verified_at,omitempty" gorm:"column:last_verified_at"`
+
 	CreatedAt   time.Time   `gorm:"not null"`
 	UpdatedAt   time.Time   `gorm:"not null"`
 

--- a/backend/internal/models/release.go
+++ b/backend/internal/models/release.go
@@ -37,6 +37,12 @@ type Release struct {
 	ReleaseDate *string     `gorm:"column:release_date;type:date"` // DATE stored as string (YYYY-MM-DD)
 	CoverArtURL *string     `gorm:"column:cover_art_url"`
 	Description *string     `gorm:"column:description"`
+
+	// Data provenance fields
+	DataSource       *string    `json:"data_source,omitempty" gorm:"column:data_source;size:50"`
+	SourceConfidence *float64   `json:"source_confidence,omitempty" gorm:"column:source_confidence;type:numeric(3,2)"`
+	LastVerifiedAt   *time.Time `json:"last_verified_at,omitempty" gorm:"column:last_verified_at"`
+
 	CreatedAt   time.Time   `gorm:"not null"`
 	UpdatedAt   time.Time   `gorm:"not null"`
 

--- a/backend/internal/models/show.go
+++ b/backend/internal/models/show.go
@@ -20,6 +20,18 @@ const (
 	ShowSourceDiscovery ShowSource = "discovery" // Automatically imported from the discovery app
 )
 
+// DataSource constants for provenance tracking across all entities
+const (
+	DataSourceUser          = "user"
+	DataSourceAIExtraction  = "ai_extraction"
+	DataSourceMusicBrainz   = "musicbrainz"
+	DataSourceBandcamp      = "bandcamp"
+	DataSourceFestivalData  = "festival_data"
+	DataSourceDiscovery     = "discovery"
+	DataSourceCommunity     = "community"
+	DataSourceAPIEnrichment = "api_enrichment"
+)
+
 type Show struct {
 	ID             uint    `gorm:"primaryKey"`
 	Title          string
@@ -44,6 +56,11 @@ type Show struct {
 	SourceVenue   *string    `gorm:"column:source_venue"`   // e.g., 'valley-bar', 'crescent-ballroom'
 	SourceEventID *string    `gorm:"column:source_event_id"` // External event ID for deduplication
 	ScrapedAt     *time.Time `gorm:"column:scraped_at"`      // When the event was scraped
+
+	// Data provenance fields (generalized across all entities)
+	DataSource       *string    `json:"data_source,omitempty" gorm:"column:data_source;size:50"`
+	SourceConfidence *float64   `json:"source_confidence,omitempty" gorm:"column:source_confidence;type:numeric(3,2)"`
+	LastVerifiedAt   *time.Time `json:"last_verified_at,omitempty" gorm:"column:last_verified_at"`
 
 	// Duplicate detection (for discovery imports flagged as potential duplicates)
 	DuplicateOfShowID *uint `gorm:"column:duplicate_of_show_id"`

--- a/backend/internal/models/venue.go
+++ b/backend/internal/models/venue.go
@@ -15,6 +15,12 @@ type Venue struct {
 	Social      Social `gorm:"embedded"`
 	Verified    bool
 	SubmittedBy *uint     `gorm:"column:submitted_by"` // User ID of the person who originally submitted this venue
+
+	// Data provenance fields
+	DataSource       *string    `json:"data_source,omitempty" gorm:"column:data_source;size:50"`
+	SourceConfidence *float64   `json:"source_confidence,omitempty" gorm:"column:source_confidence;type:numeric(3,2)"`
+	LastVerifiedAt   *time.Time `json:"last_verified_at,omitempty" gorm:"column:last_verified_at"`
+
 	CreatedAt   time.Time `gorm:"not null"`
 	UpdatedAt   time.Time `gorm:"not null"`
 

--- a/backend/internal/services/pipeline/discovery.go
+++ b/backend/internal/services/pipeline/discovery.go
@@ -300,6 +300,11 @@ func (s *DiscoveryService) createShowFromEvent(event *contracts.DiscoveredEvent,
 			status = models.ShowStatusPending
 		}
 
+		// Set data provenance fields for AI-extracted shows
+		aiSource := models.DataSourceAIExtraction
+		aiConfidence := 0.8
+		now := time.Now()
+
 		show := &models.Show{
 			Title:             event.Title,
 			EventDate:         eventDate.UTC(),
@@ -311,6 +316,9 @@ func (s *DiscoveryService) createShowFromEvent(event *contracts.DiscoveredEvent,
 			SourceVenue:       &event.VenueSlug,
 			SourceEventID:     &event.ID,
 			ScrapedAt:         &scrapedAt,
+			DataSource:        &aiSource,
+			SourceConfidence:  &aiConfidence,
+			LastVerifiedAt:    &now,
 			DuplicateOfShowID: duplicateOfShowID,
 			Price:             parsePriceString(ptrStr(event.Price)),
 			AgeRequirement:    event.AgeRestriction,


### PR DESCRIPTION
## Summary

- Migration 000048 adds `data_source`, `source_confidence`, and `last_verified_at` columns to all 6 core entity tables (shows, artists, venues, releases, labels, festivals)
- CHECK constraints enforce confidence in 0.00-1.00 range, indexes on `data_source` and `last_verified_at` for each table
- Backfills `shows.data_source` from existing `source` column
- 8 `DataSource*` constants for provenance values (user, ai_extraction, musicbrainz, bandcamp, etc.)
- Discovery service sets provenance fields on AI-extracted shows (confidence 0.8)

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] Existing handler and service tests pass
- [ ] Manual: run migration 000048, verify columns exist on all 6 tables
- [ ] Manual: verify shows.data_source backfilled from source column

🤖 Generated with [Claude Code](https://claude.com/claude-code)