### PR TITLE
Add revision history model and service (PSY-73)

### DIFF
--- a/backend/db/migrations/000050_create_revisions.down.sql
+++ b/backend/db/migrations/000050_create_revisions.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS revisions;

--- a/backend/db/migrations/000050_create_revisions.up.sql
+++ b/backend/db/migrations/000050_create_revisions.up.sql
@@ -1,0 +1,16 @@
+CREATE TABLE revisions (
+    id BIGSERIAL PRIMARY KEY,
+    entity_type VARCHAR(50) NOT NULL,
+    entity_id BIGINT NOT NULL,
+    user_id BIGINT NOT NULL REFERENCES users(id),
+    field_changes JSONB NOT NULL,
+    summary TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_revisions_entity ON revisions(entity_type, entity_id);
+CREATE INDEX idx_revisions_user_id ON revisions(user_id);
+CREATE INDEX idx_revisions_created_at ON revisions(created_at DESC);
+
+-- Composite index for browsing entity history
+CREATE INDEX idx_revisions_entity_created ON revisions(entity_type, entity_id, created_at DESC);

--- a/backend/internal/models/revision.go
+++ b/backend/internal/models/revision.go
@@ -1,0 +1,29 @@
+package models
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// Revision tracks a single edit to an entity with field-level diffs.
+type Revision struct {
+	ID           uint             `json:"id" gorm:"primaryKey"`
+	EntityType   string           `json:"entity_type" gorm:"column:entity_type;not null;size:50"`
+	EntityID     uint             `json:"entity_id" gorm:"column:entity_id;not null"`
+	UserID       uint             `json:"user_id" gorm:"column:user_id;not null"`
+	FieldChanges *json.RawMessage `json:"field_changes" gorm:"column:field_changes;type:jsonb;not null"`
+	Summary      *string          `json:"summary,omitempty" gorm:"column:summary"`
+	CreatedAt    time.Time        `json:"created_at"`
+
+	User User `json:"-" gorm:"foreignKey:UserID"`
+}
+
+// TableName specifies the table name for Revision.
+func (Revision) TableName() string { return "revisions" }
+
+// FieldChange represents a single field's before/after values.
+type FieldChange struct {
+	Field    string      `json:"field"`
+	OldValue interface{} `json:"old_value"`
+	NewValue interface{} `json:"new_value"`
+}

--- a/backend/internal/services/admin/interfaces.go
+++ b/backend/internal/services/admin/interfaces.go
@@ -10,5 +10,6 @@ var (
 	_ contracts.ShowReportServiceInterface   = (*ShowReportService)(nil)
 	_ contracts.ArtistReportServiceInterface = (*ArtistReportService)(nil)
 	_ contracts.APITokenServiceInterface     = (*APITokenService)(nil)
+	_ contracts.RevisionServiceInterface     = (*RevisionService)(nil)
 	// CleanupService has no interface in contracts — it's a lifecycle service.
 )

--- a/backend/internal/services/admin/revision.go
+++ b/backend/internal/services/admin/revision.go
@@ -1,0 +1,190 @@
+package admin
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/db"
+	"psychic-homily-backend/internal/models"
+)
+
+// RevisionService handles revision history business logic.
+type RevisionService struct {
+	db *gorm.DB
+}
+
+// NewRevisionService creates a new revision service.
+func NewRevisionService(database *gorm.DB) *RevisionService {
+	if database == nil {
+		database = db.GetDB()
+	}
+	return &RevisionService{db: database}
+}
+
+// RecordRevision creates a new revision entry for an entity edit.
+// If changes is empty, it is a no-op (no revision recorded).
+func (s *RevisionService) RecordRevision(entityType string, entityID uint, userID uint, changes []models.FieldChange, summary string) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+	if len(changes) == 0 {
+		return nil // No changes, nothing to record
+	}
+
+	changesJSON, err := json.Marshal(changes)
+	if err != nil {
+		return fmt.Errorf("failed to marshal field changes: %w", err)
+	}
+	raw := json.RawMessage(changesJSON)
+
+	var summaryPtr *string
+	if summary != "" {
+		summaryPtr = &summary
+	}
+
+	revision := &models.Revision{
+		EntityType:   entityType,
+		EntityID:     entityID,
+		UserID:       userID,
+		FieldChanges: &raw,
+		Summary:      summaryPtr,
+	}
+
+	if err := s.db.Create(revision).Error; err != nil {
+		return fmt.Errorf("failed to create revision: %w", err)
+	}
+	return nil
+}
+
+// GetEntityHistory returns paginated revision history for a specific entity.
+func (s *RevisionService) GetEntityHistory(entityType string, entityID uint, limit, offset int) ([]models.Revision, int64, error) {
+	if s.db == nil {
+		return nil, 0, fmt.Errorf("database not initialized")
+	}
+
+	if limit <= 0 {
+		limit = 20
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	var total int64
+	s.db.Model(&models.Revision{}).
+		Where("entity_type = ? AND entity_id = ?", entityType, entityID).
+		Count(&total)
+
+	var revisions []models.Revision
+	err := s.db.Where("entity_type = ? AND entity_id = ?", entityType, entityID).
+		Preload("User").
+		Order("created_at DESC").
+		Limit(limit).
+		Offset(offset).
+		Find(&revisions).Error
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to get entity history: %w", err)
+	}
+
+	return revisions, total, nil
+}
+
+// GetRevision retrieves a single revision by ID.
+// Returns nil, nil if not found.
+func (s *RevisionService) GetRevision(revisionID uint) (*models.Revision, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var revision models.Revision
+	err := s.db.Preload("User").First(&revision, revisionID).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get revision: %w", err)
+	}
+	return &revision, nil
+}
+
+// GetUserRevisions returns paginated revisions made by a specific user.
+func (s *RevisionService) GetUserRevisions(userID uint, limit, offset int) ([]models.Revision, int64, error) {
+	if s.db == nil {
+		return nil, 0, fmt.Errorf("database not initialized")
+	}
+
+	if limit <= 0 {
+		limit = 20
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	var total int64
+	s.db.Model(&models.Revision{}).Where("user_id = ?", userID).Count(&total)
+
+	var revisions []models.Revision
+	err := s.db.Where("user_id = ?", userID).
+		Preload("User").
+		Order("created_at DESC").
+		Limit(limit).
+		Offset(offset).
+		Find(&revisions).Error
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to get user revisions: %w", err)
+	}
+
+	return revisions, total, nil
+}
+
+// Rollback applies the inverse of a revision's changes to the entity.
+// It creates a new revision recording the rollback.
+func (s *RevisionService) Rollback(revisionID uint, adminUserID uint) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	revision, err := s.GetRevision(revisionID)
+	if err != nil {
+		return err
+	}
+	if revision == nil {
+		return fmt.Errorf("revision not found")
+	}
+
+	// Parse field changes
+	var changes []models.FieldChange
+	if err := json.Unmarshal(*revision.FieldChanges, &changes); err != nil {
+		return fmt.Errorf("failed to parse field changes: %w", err)
+	}
+
+	// Build update map from old values (reversing the change)
+	updates := make(map[string]interface{})
+	var rollbackChanges []models.FieldChange
+	for _, c := range changes {
+		updates[c.Field] = c.OldValue
+		rollbackChanges = append(rollbackChanges, models.FieldChange{
+			Field:    c.Field,
+			OldValue: c.NewValue,
+			NewValue: c.OldValue,
+		})
+	}
+
+	// Apply update to the entity table
+	tableName := revision.EntityType + "s" // artist -> artists, show -> shows, etc.
+	updates["updated_at"] = time.Now()
+
+	result := s.db.Table(tableName).Where("id = ?", revision.EntityID).Updates(updates)
+	if result.Error != nil {
+		return fmt.Errorf("failed to apply rollback: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("entity not found: %s %d", revision.EntityType, revision.EntityID)
+	}
+
+	// Record the rollback as a new revision
+	summary := fmt.Sprintf("Rollback of revision #%d", revisionID)
+	return s.RecordRevision(revision.EntityType, revision.EntityID, adminUserID, rollbackChanges, summary)
+}

--- a/backend/internal/services/admin/revision_test.go
+++ b/backend/internal/services/admin/revision_test.go
@@ -1,0 +1,540 @@
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/testutil"
+)
+
+// =============================================================================
+// UNIT TESTS (No Database Required)
+// =============================================================================
+
+func TestNewRevisionService(t *testing.T) {
+	svc := NewRevisionService(nil)
+	assert.NotNil(t, svc)
+}
+
+func TestRevisionService_NilDatabase(t *testing.T) {
+	svc := &RevisionService{db: nil}
+
+	t.Run("RecordRevision", func(t *testing.T) {
+		changes := []models.FieldChange{{Field: "name", OldValue: "old", NewValue: "new"}}
+		err := svc.RecordRevision("artist", 1, 1, changes, "test")
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+	})
+
+	t.Run("GetEntityHistory", func(t *testing.T) {
+		revisions, total, err := svc.GetEntityHistory("artist", 1, 10, 0)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, revisions)
+		assert.Zero(t, total)
+	})
+
+	t.Run("GetRevision", func(t *testing.T) {
+		revision, err := svc.GetRevision(1)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, revision)
+	})
+
+	t.Run("GetUserRevisions", func(t *testing.T) {
+		revisions, total, err := svc.GetUserRevisions(1, 10, 0)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, revisions)
+		assert.Zero(t, total)
+	})
+
+	t.Run("Rollback", func(t *testing.T) {
+		err := svc.Rollback(1, 1)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+	})
+}
+
+// =============================================================================
+// INTEGRATION TESTS (With Real Database)
+// =============================================================================
+
+type RevisionServiceIntegrationTestSuite struct {
+	suite.Suite
+	container testcontainers.Container
+	db        *gorm.DB
+	svc       *RevisionService
+	ctx       context.Context
+}
+
+func (s *RevisionServiceIntegrationTestSuite) SetupSuite() {
+	s.ctx = context.Background()
+
+	container, err := testcontainers.GenericContainer(s.ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "postgres:18",
+			ExposedPorts: []string{"5432/tcp"},
+			Env: map[string]string{
+				"POSTGRES_DB":       "test_db",
+				"POSTGRES_USER":     "test_user",
+				"POSTGRES_PASSWORD": "test_password",
+			},
+			WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(120 * time.Second),
+		},
+		Started: true,
+	})
+	if err != nil {
+		s.T().Fatalf("failed to start postgres container: %v", err)
+	}
+	s.container = container
+
+	host, err := container.Host(s.ctx)
+	if err != nil {
+		s.T().Fatalf("failed to get host: %v", err)
+	}
+	port, err := container.MappedPort(s.ctx, "5432")
+	if err != nil {
+		s.T().Fatalf("failed to get port: %v", err)
+	}
+
+	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
+		host, port.Port())
+
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		s.T().Fatalf("failed to connect to test database: %v", err)
+	}
+	s.db = db
+
+	sqlDB, err := db.DB()
+	if err != nil {
+		s.T().Fatalf("failed to get sql.DB: %v", err)
+	}
+
+	testutil.RunAllMigrations(s.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
+
+	s.svc = NewRevisionService(db)
+}
+
+func (s *RevisionServiceIntegrationTestSuite) TearDownSuite() {
+	if s.container != nil {
+		if err := s.container.Terminate(s.ctx); err != nil {
+			s.T().Logf("failed to terminate container: %v", err)
+		}
+	}
+}
+
+func (s *RevisionServiceIntegrationTestSuite) TearDownTest() {
+	sqlDB, err := s.db.DB()
+	s.Require().NoError(err)
+	_, _ = sqlDB.Exec("DELETE FROM revisions")
+	_, _ = sqlDB.Exec("DELETE FROM venues")
+	_, _ = sqlDB.Exec("DELETE FROM users")
+}
+
+func TestRevisionServiceIntegrationSuite(t *testing.T) {
+	suite.Run(t, new(RevisionServiceIntegrationTestSuite))
+}
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+func (s *RevisionServiceIntegrationTestSuite) createTestUser() *models.User {
+	user := &models.User{
+		Email:         stringPtr(fmt.Sprintf("rev-user-%d@test.com", time.Now().UnixNano())),
+		FirstName:     stringPtr("Test"),
+		LastName:      stringPtr("User"),
+		IsActive:      true,
+		EmailVerified: true,
+	}
+	err := s.db.Create(user).Error
+	s.Require().NoError(err)
+	return user
+}
+
+func (s *RevisionServiceIntegrationTestSuite) createTestVenue(name string) *models.Venue {
+	slug := fmt.Sprintf("test-venue-%d", time.Now().UnixNano())
+	venue := &models.Venue{
+		Name:  name,
+		Slug:  &slug,
+		City:  "Phoenix",
+		State: "AZ",
+	}
+	err := s.db.Create(venue).Error
+	s.Require().NoError(err)
+	return venue
+}
+
+// =============================================================================
+// RecordRevision tests
+// =============================================================================
+
+func (s *RevisionServiceIntegrationTestSuite) TestRecordRevision_Success() {
+	user := s.createTestUser()
+
+	changes := []models.FieldChange{
+		{Field: "name", OldValue: "Old Name", NewValue: "New Name"},
+		{Field: "city", OldValue: "Phoenix", NewValue: "Tempe"},
+	}
+
+	err := s.svc.RecordRevision("venue", 42, user.ID, changes, "Updated venue info")
+	s.NoError(err)
+
+	// Verify the revision was created
+	var revision models.Revision
+	err = s.db.First(&revision).Error
+	s.Require().NoError(err)
+	s.Equal("venue", revision.EntityType)
+	s.Equal(uint(42), revision.EntityID)
+	s.Equal(user.ID, revision.UserID)
+	s.Require().NotNil(revision.Summary)
+	s.Equal("Updated venue info", *revision.Summary)
+	s.Require().NotNil(revision.FieldChanges)
+
+	// Verify field changes deserialization
+	var parsedChanges []models.FieldChange
+	err = json.Unmarshal(*revision.FieldChanges, &parsedChanges)
+	s.NoError(err)
+	s.Len(parsedChanges, 2)
+	s.Equal("name", parsedChanges[0].Field)
+	s.Equal("Old Name", parsedChanges[0].OldValue)
+	s.Equal("New Name", parsedChanges[0].NewValue)
+}
+
+func (s *RevisionServiceIntegrationTestSuite) TestRecordRevision_EmptyChanges() {
+	user := s.createTestUser()
+
+	err := s.svc.RecordRevision("artist", 1, user.ID, []models.FieldChange{}, "no changes")
+	s.NoError(err)
+
+	// Verify no revision was created
+	var count int64
+	s.db.Model(&models.Revision{}).Count(&count)
+	s.Equal(int64(0), count)
+}
+
+func (s *RevisionServiceIntegrationTestSuite) TestRecordRevision_NilChanges() {
+	user := s.createTestUser()
+
+	err := s.svc.RecordRevision("artist", 1, user.ID, nil, "no changes")
+	s.NoError(err)
+
+	var count int64
+	s.db.Model(&models.Revision{}).Count(&count)
+	s.Equal(int64(0), count)
+}
+
+func (s *RevisionServiceIntegrationTestSuite) TestRecordRevision_EmptySummary() {
+	user := s.createTestUser()
+
+	changes := []models.FieldChange{
+		{Field: "name", OldValue: "Old", NewValue: "New"},
+	}
+
+	err := s.svc.RecordRevision("artist", 1, user.ID, changes, "")
+	s.NoError(err)
+
+	var revision models.Revision
+	err = s.db.First(&revision).Error
+	s.Require().NoError(err)
+	s.Nil(revision.Summary) // Empty summary stored as nil
+}
+
+// =============================================================================
+// GetEntityHistory tests
+// =============================================================================
+
+func (s *RevisionServiceIntegrationTestSuite) TestGetEntityHistory_Success() {
+	user := s.createTestUser()
+
+	// Create 3 revisions for the same entity
+	for i := 0; i < 3; i++ {
+		changes := []models.FieldChange{
+			{Field: "name", OldValue: fmt.Sprintf("Name %d", i), NewValue: fmt.Sprintf("Name %d", i+1)},
+		}
+		err := s.svc.RecordRevision("artist", 10, user.ID, changes, fmt.Sprintf("Edit %d", i+1))
+		s.Require().NoError(err)
+	}
+
+	revisions, total, err := s.svc.GetEntityHistory("artist", 10, 10, 0)
+	s.NoError(err)
+	s.Equal(int64(3), total)
+	s.Len(revisions, 3)
+
+	// Verify ordering (newest first)
+	s.Require().NotNil(revisions[0].Summary)
+	s.Equal("Edit 3", *revisions[0].Summary)
+	s.Require().NotNil(revisions[2].Summary)
+	s.Equal("Edit 1", *revisions[2].Summary)
+}
+
+func (s *RevisionServiceIntegrationTestSuite) TestGetEntityHistory_Pagination() {
+	user := s.createTestUser()
+
+	for i := 0; i < 5; i++ {
+		changes := []models.FieldChange{
+			{Field: "name", OldValue: "old", NewValue: "new"},
+		}
+		err := s.svc.RecordRevision("venue", 20, user.ID, changes, fmt.Sprintf("Edit %d", i+1))
+		s.Require().NoError(err)
+	}
+
+	// Page 1
+	revisions, total, err := s.svc.GetEntityHistory("venue", 20, 2, 0)
+	s.NoError(err)
+	s.Equal(int64(5), total)
+	s.Len(revisions, 2)
+
+	// Page 2
+	revisions2, _, err := s.svc.GetEntityHistory("venue", 20, 2, 2)
+	s.NoError(err)
+	s.Len(revisions2, 2)
+
+	// No overlap
+	s.NotEqual(revisions[0].ID, revisions2[0].ID)
+
+	// Page 3
+	revisions3, _, err := s.svc.GetEntityHistory("venue", 20, 2, 4)
+	s.NoError(err)
+	s.Len(revisions3, 1)
+}
+
+func (s *RevisionServiceIntegrationTestSuite) TestGetEntityHistory_DefaultLimit() {
+	revisions, total, err := s.svc.GetEntityHistory("artist", 999, 0, 0)
+	s.NoError(err)
+	s.Equal(int64(0), total)
+	s.Empty(revisions)
+}
+
+func (s *RevisionServiceIntegrationTestSuite) TestGetEntityHistory_MaxLimit() {
+	revisions, total, err := s.svc.GetEntityHistory("artist", 999, 200, 0)
+	s.NoError(err)
+	s.Equal(int64(0), total)
+	s.Empty(revisions)
+}
+
+func (s *RevisionServiceIntegrationTestSuite) TestGetEntityHistory_FiltersByEntity() {
+	user := s.createTestUser()
+
+	changes := []models.FieldChange{{Field: "name", OldValue: "a", NewValue: "b"}}
+	s.Require().NoError(s.svc.RecordRevision("artist", 1, user.ID, changes, "artist edit"))
+	s.Require().NoError(s.svc.RecordRevision("venue", 1, user.ID, changes, "venue edit"))
+	s.Require().NoError(s.svc.RecordRevision("artist", 2, user.ID, changes, "other artist edit"))
+
+	revisions, total, err := s.svc.GetEntityHistory("artist", 1, 10, 0)
+	s.NoError(err)
+	s.Equal(int64(1), total)
+	s.Len(revisions, 1)
+	s.Require().NotNil(revisions[0].Summary)
+	s.Equal("artist edit", *revisions[0].Summary)
+}
+
+func (s *RevisionServiceIntegrationTestSuite) TestGetEntityHistory_PreloadsUser() {
+	user := s.createTestUser()
+
+	changes := []models.FieldChange{{Field: "name", OldValue: "a", NewValue: "b"}}
+	s.Require().NoError(s.svc.RecordRevision("artist", 1, user.ID, changes, "test"))
+
+	revisions, _, err := s.svc.GetEntityHistory("artist", 1, 10, 0)
+	s.NoError(err)
+	s.Require().Len(revisions, 1)
+	s.Equal(user.ID, revisions[0].User.ID)
+	s.Equal(*user.Email, *revisions[0].User.Email)
+}
+
+// =============================================================================
+// GetRevision tests
+// =============================================================================
+
+func (s *RevisionServiceIntegrationTestSuite) TestGetRevision_Found() {
+	user := s.createTestUser()
+
+	changes := []models.FieldChange{
+		{Field: "name", OldValue: "Old", NewValue: "New"},
+	}
+	err := s.svc.RecordRevision("artist", 5, user.ID, changes, "test edit")
+	s.Require().NoError(err)
+
+	// Get the created revision's ID
+	var created models.Revision
+	s.db.First(&created)
+
+	revision, err := s.svc.GetRevision(created.ID)
+	s.NoError(err)
+	s.NotNil(revision)
+	s.Equal(created.ID, revision.ID)
+	s.Equal("artist", revision.EntityType)
+	s.Equal(uint(5), revision.EntityID)
+	s.Equal(user.ID, revision.User.ID)
+}
+
+func (s *RevisionServiceIntegrationTestSuite) TestGetRevision_NotFound() {
+	revision, err := s.svc.GetRevision(99999)
+	s.NoError(err)
+	s.Nil(revision)
+}
+
+// =============================================================================
+// GetUserRevisions tests
+// =============================================================================
+
+func (s *RevisionServiceIntegrationTestSuite) TestGetUserRevisions_Success() {
+	user1 := s.createTestUser()
+	user2 := s.createTestUser()
+
+	changes := []models.FieldChange{{Field: "name", OldValue: "a", NewValue: "b"}}
+
+	// User 1 makes 3 edits
+	for i := 0; i < 3; i++ {
+		s.Require().NoError(s.svc.RecordRevision("artist", uint(i+1), user1.ID, changes, fmt.Sprintf("user1 edit %d", i)))
+	}
+
+	// User 2 makes 1 edit
+	s.Require().NoError(s.svc.RecordRevision("venue", 1, user2.ID, changes, "user2 edit"))
+
+	// Get user1's revisions
+	revisions, total, err := s.svc.GetUserRevisions(user1.ID, 10, 0)
+	s.NoError(err)
+	s.Equal(int64(3), total)
+	s.Len(revisions, 3)
+
+	// All revisions belong to user1
+	for _, r := range revisions {
+		s.Equal(user1.ID, r.UserID)
+	}
+
+	// Get user2's revisions
+	revisions2, total2, err := s.svc.GetUserRevisions(user2.ID, 10, 0)
+	s.NoError(err)
+	s.Equal(int64(1), total2)
+	s.Len(revisions2, 1)
+}
+
+func (s *RevisionServiceIntegrationTestSuite) TestGetUserRevisions_Pagination() {
+	user := s.createTestUser()
+
+	changes := []models.FieldChange{{Field: "name", OldValue: "a", NewValue: "b"}}
+	for i := 0; i < 5; i++ {
+		s.Require().NoError(s.svc.RecordRevision("artist", uint(i+1), user.ID, changes, ""))
+	}
+
+	revisions, total, err := s.svc.GetUserRevisions(user.ID, 2, 0)
+	s.NoError(err)
+	s.Equal(int64(5), total)
+	s.Len(revisions, 2)
+
+	revisions2, _, err := s.svc.GetUserRevisions(user.ID, 2, 2)
+	s.NoError(err)
+	s.Len(revisions2, 2)
+
+	// No overlap
+	s.NotEqual(revisions[0].ID, revisions2[0].ID)
+}
+
+func (s *RevisionServiceIntegrationTestSuite) TestGetUserRevisions_Empty() {
+	user := s.createTestUser()
+
+	revisions, total, err := s.svc.GetUserRevisions(user.ID, 10, 0)
+	s.NoError(err)
+	s.Equal(int64(0), total)
+	s.Empty(revisions)
+}
+
+// =============================================================================
+// Rollback tests
+// =============================================================================
+
+func (s *RevisionServiceIntegrationTestSuite) TestRollback_Success() {
+	user := s.createTestUser()
+	adminUser := s.createTestUser()
+	venue := s.createTestVenue("Original Name")
+
+	// Record a revision changing the venue name
+	changes := []models.FieldChange{
+		{Field: "name", OldValue: "Original Name", NewValue: "Changed Name"},
+	}
+	err := s.svc.RecordRevision("venue", venue.ID, user.ID, changes, "renamed venue")
+	s.Require().NoError(err)
+
+	// Apply the change to the venue (simulating what an edit handler would do)
+	s.db.Table("venues").Where("id = ?", venue.ID).Updates(map[string]interface{}{
+		"name": "Changed Name",
+	})
+
+	// Verify venue has changed name
+	var updatedVenue models.Venue
+	s.db.First(&updatedVenue, venue.ID)
+	s.Equal("Changed Name", updatedVenue.Name)
+
+	// Get the revision to rollback
+	var revision models.Revision
+	s.db.Where("entity_type = ? AND entity_id = ?", "venue", venue.ID).First(&revision)
+
+	// Rollback
+	err = s.svc.Rollback(revision.ID, adminUser.ID)
+	s.NoError(err)
+
+	// Verify venue name is restored
+	var restoredVenue models.Venue
+	s.db.First(&restoredVenue, venue.ID)
+	s.Equal("Original Name", restoredVenue.Name)
+
+	// Verify a rollback revision was created
+	var allRevisions []models.Revision
+	s.db.Where("entity_type = ? AND entity_id = ?", "venue", venue.ID).
+		Order("created_at DESC").
+		Find(&allRevisions)
+	s.Len(allRevisions, 2) // original + rollback
+
+	rollbackRevision := allRevisions[0]
+	s.Equal(adminUser.ID, rollbackRevision.UserID)
+	s.Require().NotNil(rollbackRevision.Summary)
+	s.Contains(*rollbackRevision.Summary, "Rollback of revision #")
+
+	// Verify rollback revision has inverted changes
+	var rollbackChanges []models.FieldChange
+	err = json.Unmarshal(*rollbackRevision.FieldChanges, &rollbackChanges)
+	s.NoError(err)
+	s.Len(rollbackChanges, 1)
+	s.Equal("name", rollbackChanges[0].Field)
+	s.Equal("Changed Name", rollbackChanges[0].OldValue)
+	s.Equal("Original Name", rollbackChanges[0].NewValue)
+}
+
+func (s *RevisionServiceIntegrationTestSuite) TestRollback_RevisionNotFound() {
+	err := s.svc.Rollback(99999, 1)
+	s.Error(err)
+	s.Contains(err.Error(), "revision not found")
+}
+
+func (s *RevisionServiceIntegrationTestSuite) TestRollback_EntityNotFound() {
+	user := s.createTestUser()
+
+	// Record a revision for an entity that doesn't exist
+	changes := []models.FieldChange{
+		{Field: "name", OldValue: "Old", NewValue: "New"},
+	}
+	err := s.svc.RecordRevision("venue", 99999, user.ID, changes, "test")
+	s.Require().NoError(err)
+
+	var revision models.Revision
+	s.db.First(&revision)
+
+	err = s.svc.Rollback(revision.ID, user.ID)
+	s.Error(err)
+	s.Contains(err.Error(), "entity not found")
+}

--- a/backend/internal/services/container.go
+++ b/backend/internal/services/container.go
@@ -21,6 +21,7 @@ type ServiceContainer struct {
 	// DB-only leaf services
 	AdminStats         *adminsvc.AdminStatsService
 	APIToken           *adminsvc.APITokenService
+	Revision           *adminsvc.RevisionService
 	Artist             *catalog.ArtistService
 	ContributorProfile *usersvc.ContributorProfileService
 	ArtistReport  *adminsvc.ArtistReportService
@@ -96,6 +97,7 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 		// DB-only leaf services
 		AdminStats:         adminsvc.NewAdminStatsService(database),
 		APIToken:           adminsvc.NewAPITokenService(database),
+		Revision:           adminsvc.NewRevisionService(database),
 		Artist:             artist,
 		ContributorProfile: usersvc.NewContributorProfileService(database),
 		ArtistReport:  adminsvc.NewArtistReportService(database),

--- a/backend/internal/services/contracts/interfaces.go
+++ b/backend/internal/services/contracts/interfaces.go
@@ -408,3 +408,12 @@ type VenueSourceConfigServiceInterface interface {
 	UpdateExtractionNotes(venueID uint, notes *string) error
 	ResetRenderMethod(venueID uint) error
 }
+
+// RevisionServiceInterface defines the contract for revision history operations.
+type RevisionServiceInterface interface {
+	RecordRevision(entityType string, entityID uint, userID uint, changes []models.FieldChange, summary string) error
+	GetEntityHistory(entityType string, entityID uint, limit, offset int) ([]models.Revision, int64, error)
+	GetRevision(revisionID uint) (*models.Revision, error)
+	GetUserRevisions(userID uint, limit, offset int) ([]models.Revision, int64, error)
+	Rollback(revisionID uint, adminUserID uint) error
+}

--- a/backend/internal/services/interfaces.go
+++ b/backend/internal/services/interfaces.go
@@ -41,6 +41,7 @@ type CalendarServiceInterface = contracts.CalendarServiceInterface
 type PipelineServiceInterface = contracts.PipelineServiceInterface
 type VenueSourceConfigServiceInterface = contracts.VenueSourceConfigServiceInterface
 type CollectionServiceInterface = contracts.CollectionServiceInterface
+type RevisionServiceInterface = contracts.RevisionServiceInterface
 
 // Compile-time interface satisfaction checks.
 // Engagement services (Bookmark, SavedShow, FavoriteVenue, Calendar, Reminder)


### PR DESCRIPTION
## Summary
- Create `revisions` table (migration 000050) with JSONB `field_changes` for field-level edit tracking
- Add `Revision` model and `FieldChange` struct for tracking old/new values per field
- Implement `RevisionService` with 5 methods: `RecordRevision`, `GetEntityHistory`, `GetRevision`, `GetUserRevisions`, `Rollback`
- Wire into service container and add interface to contracts
- 20 unit + integration tests covering all service methods

## Test plan
- [ ] Run service tests: `go test ./internal/services/admin/ -run TestRevision`
- [ ] Verify migration applies: check 000050 up/down SQL
- [ ] Verify compile: `go build ./...`

Closes PSY-73

🤖 Generated with [Claude Code](https://claude.com/claude-code)