### PR TITLE
Add collection browse and detail pages (PSY-68)

### DIFF
--- a/frontend/app/collections/[slug]/page.tsx
+++ b/frontend/app/collections/[slug]/page.tsx
@@ -1,0 +1,117 @@
+import { Suspense } from 'react'
+import { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+import * as Sentry from '@sentry/nextjs'
+import { Loader2 } from 'lucide-react'
+import { CollectionDetail } from '@/features/collections/components'
+
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL ||
+  (process.env.NODE_ENV === 'development'
+    ? 'http://localhost:8080'
+    : 'https://api.psychichomily.com')
+
+interface CollectionPageProps {
+  params: Promise<{ slug: string }>
+}
+
+interface CollectionData {
+  title: string
+  slug?: string
+  description?: string
+  creator_name?: string
+}
+
+async function getCollection(slug: string): Promise<CollectionData | null> {
+  try {
+    const res = await fetch(`${API_BASE_URL}/collections/${slug}`, {
+      next: { revalidate: 3600 },
+    })
+    if (res.ok) {
+      return res.json()
+    }
+    if (res.status >= 500) {
+      Sentry.captureMessage(`Collection page fetch error: ${res.status}`, {
+        level: 'error',
+        tags: { service: 'collection-page' },
+        extra: { slug, status: res.status },
+      })
+    }
+  } catch (error) {
+    Sentry.captureException(error, {
+      level: 'error',
+      tags: { service: 'collection-page' },
+      extra: { slug },
+    })
+  }
+  return null
+}
+
+export async function generateMetadata({
+  params,
+}: CollectionPageProps): Promise<Metadata> {
+  const { slug } = await params
+  const collection = await getCollection(slug)
+
+  if (collection) {
+    const description = collection.description
+      ? collection.description.slice(0, 160)
+      : `${collection.title} - a curated collection on Psychic Homily`
+
+    return {
+      title: collection.title,
+      description,
+      alternates: {
+        canonical: `https://psychichomily.com/collections/${slug}`,
+      },
+      openGraph: {
+        title: collection.title,
+        description,
+        type: 'website',
+        url: `/collections/${slug}`,
+      },
+    }
+  }
+
+  return {
+    title: 'Collection',
+    description: 'View collection details',
+  }
+}
+
+function CollectionLoadingFallback() {
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center">
+      <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+    </div>
+  )
+}
+
+export default async function CollectionPage({ params }: CollectionPageProps) {
+  const { slug } = await params
+
+  if (!slug) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold mb-2">Invalid Collection</h1>
+          <p className="text-muted-foreground">
+            The collection could not be found.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  const collectionData = await getCollection(slug)
+
+  if (!collectionData) {
+    notFound()
+  }
+
+  return (
+    <Suspense fallback={<CollectionLoadingFallback />}>
+      <CollectionDetail slug={slug} />
+    </Suspense>
+  )
+}

--- a/frontend/app/collections/page.tsx
+++ b/frontend/app/collections/page.tsx
@@ -1,0 +1,36 @@
+import { Suspense } from 'react'
+import { CollectionList } from '@/features/collections/components'
+import { LoadingSpinner } from '@/components/shared'
+
+export const metadata = {
+  title: 'Collections',
+  description: 'Browse curated collections of artists, releases, venues, and more.',
+  alternates: {
+    canonical: 'https://psychichomily.com/collections',
+  },
+  openGraph: {
+    title: 'Collections | Psychic Homily',
+    description: 'Browse curated collections of artists, releases, venues, and more.',
+    url: '/collections',
+    type: 'website',
+  },
+}
+
+export default function CollectionsPage() {
+  return (
+    <div className="flex min-h-screen items-start justify-center">
+      <main className="w-full max-w-6xl px-4 py-8 md:px-8">
+        <h1 className="text-3xl font-bold text-center mb-8">Collections</h1>
+        <Suspense
+          fallback={
+            <div className="flex justify-center items-center py-12">
+              <LoadingSpinner />
+            </div>
+          }
+        >
+          <CollectionList />
+        </Suspense>
+      </main>
+    </div>
+  )
+}

--- a/frontend/components/layout/CommandPalette.tsx
+++ b/frontend/components/layout/CommandPalette.tsx
@@ -13,7 +13,7 @@ import {
 } from '@/components/ui/command'
 import {
   Calendar, Mic2, MapPin, Disc3, Tag, Tent, BookOpen, Headphones, Send,
-  Library, Settings, Shield, Search, Clock, X,
+  Library, LayoutList, Settings, Shield, Search, Clock, X,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import { useAuthContext } from '@/lib/context/AuthContext'
@@ -64,6 +64,12 @@ const routes: RouteItem[] = [
     href: '/labels',
     icon: Tag,
     keywords: ['labels', 'record labels', 'imprints', 'roster', 'catalog'],
+  },
+  {
+    label: 'Collections',
+    href: '/collections',
+    icon: LayoutList,
+    keywords: ['collections', 'curated', 'lists', 'playlists'],
   },
   {
     label: 'Blog',

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import {
   Calendar, Mic2, MapPin, Disc3, Tag, Tent, BookOpen, Headphones, Newspaper,
-  Send, Library, Settings, Shield, PanelLeftClose, PanelLeft,
+  Send, Library, LayoutList, Settings, Shield, PanelLeftClose, PanelLeft,
   ExternalLink,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
@@ -36,6 +36,7 @@ export const sidebarGroups: SidebarGroup[] = [
       { href: '/venues', label: 'Venues', icon: MapPin },
       { href: '/releases', label: 'Releases', icon: Disc3 },
       { href: '/labels', label: 'Labels', icon: Tag },
+      { href: '/collections', label: 'Collections', icon: LayoutList },
     ],
   },
   {

--- a/frontend/features/collections/components/CollectionCard.tsx
+++ b/frontend/features/collections/components/CollectionCard.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import Link from 'next/link'
+import { Library, Users, Star } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { Badge } from '@/components/ui/badge'
+import type { Collection } from '../types'
+
+interface CollectionCardProps {
+  collection: Collection
+}
+
+export function CollectionCard({ collection }: CollectionCardProps) {
+  return (
+    <article className="rounded-lg border border-border/50 bg-card p-4 transition-shadow hover:shadow-sm">
+      <div className="flex gap-3">
+        {/* Icon / cover image placeholder */}
+        <div className="h-16 w-16 shrink-0 rounded-md bg-muted/50 flex items-center justify-center overflow-hidden">
+          {collection.cover_image_url ? (
+            <img
+              src={collection.cover_image_url}
+              alt={`${collection.title} cover`}
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <Library className="h-8 w-8 text-muted-foreground/40" />
+          )}
+        </div>
+
+        {/* Text content */}
+        <div className="flex-1 min-w-0">
+          <Link href={`/collections/${collection.slug}`} className="block group">
+            <h3 className="font-bold text-foreground group-hover:text-primary transition-colors truncate">
+              {collection.title}
+            </h3>
+          </Link>
+
+          <div className="flex items-center gap-2 flex-wrap mt-0.5">
+            {collection.is_featured && (
+              <Badge variant="default" className="text-[10px] px-1.5 py-0">
+                <Star className="h-2.5 w-2.5 mr-0.5" />
+                Featured
+              </Badge>
+            )}
+            {collection.collaborative && (
+              <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
+                Collaborative
+              </Badge>
+            )}
+          </div>
+
+          {collection.description && (
+            <p
+              className={cn(
+                'text-sm text-muted-foreground mt-1 line-clamp-2'
+              )}
+            >
+              {collection.description}
+            </p>
+          )}
+
+          <div className="mt-1.5 flex items-center gap-3 text-xs text-muted-foreground">
+            <span>by {collection.creator_name}</span>
+            <span className="flex items-center gap-1">
+              <Library className="h-3 w-3" />
+              {collection.item_count === 1
+                ? '1 item'
+                : `${collection.item_count} items`}
+            </span>
+            {collection.subscriber_count > 0 && (
+              <span className="flex items-center gap-1">
+                <Users className="h-3 w-3" />
+                {collection.subscriber_count === 1
+                  ? '1 subscriber'
+                  : `${collection.subscriber_count} subscribers`}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+    </article>
+  )
+}

--- a/frontend/features/collections/components/CollectionDetail.tsx
+++ b/frontend/features/collections/components/CollectionDetail.tsx
@@ -1,0 +1,464 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import {
+  Loader2,
+  Library,
+  Users,
+  Star,
+  Bell,
+  BellOff,
+  Pencil,
+  Check,
+  X,
+  Trash2,
+  Mic2,
+  MapPin,
+  Calendar,
+  Disc3,
+  Tag,
+  Tent,
+} from 'lucide-react'
+import {
+  useCollection,
+  useUpdateCollection,
+  useRemoveCollectionItem,
+  useSubscribeCollection,
+  useUnsubscribeCollection,
+  useDeleteCollection,
+} from '../hooks'
+import { getEntityUrl, getEntityTypeLabel } from '../types'
+import type { CollectionItem } from '../types'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Badge } from '@/components/ui/badge'
+import { useAuthContext } from '@/lib/context/AuthContext'
+import { useRouter } from 'next/navigation'
+
+interface CollectionDetailProps {
+  slug: string
+}
+
+const ENTITY_ICONS: Record<string, React.ElementType> = {
+  artist: Mic2,
+  venue: MapPin,
+  show: Calendar,
+  release: Disc3,
+  label: Tag,
+  festival: Tent,
+}
+
+export function CollectionDetail({ slug }: CollectionDetailProps) {
+  const router = useRouter()
+  const { user, isAuthenticated } = useAuthContext()
+  const { data: collection, isLoading, error } = useCollection(slug)
+  const subscribeMutation = useSubscribeCollection()
+  const unsubscribeMutation = useUnsubscribeCollection()
+  const deleteMutation = useDeleteCollection()
+
+  const [isEditing, setIsEditing] = useState(false)
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  if (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : 'Failed to load collection'
+    const is404 =
+      errorMessage.includes('not found') || errorMessage.includes('404')
+
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold mb-2">
+            {is404 ? 'Collection Not Found' : 'Error Loading Collection'}
+          </h1>
+          <p className="text-muted-foreground mb-4">
+            {is404
+              ? "The collection you're looking for doesn't exist or has been removed."
+              : errorMessage}
+          </p>
+          <Button asChild variant="outline">
+            <Link href="/collections">Back to Collections</Link>
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  if (!collection) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold mb-2">Collection Not Found</h1>
+          <p className="text-muted-foreground mb-4">
+            The collection you&apos;re looking for doesn&apos;t exist.
+          </p>
+          <Button asChild variant="outline">
+            <Link href="/collections">Back to Collections</Link>
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  const currentUserId = user?.id ? Number(user.id) : undefined
+  const isCreator = currentUserId === collection.creator_id
+  const canSubscribe = isAuthenticated && !isCreator
+
+  const handleSubscribe = () => {
+    if (collection.is_subscribed) {
+      unsubscribeMutation.mutate({ slug })
+    } else {
+      subscribeMutation.mutate({ slug })
+    }
+  }
+
+  const handleDelete = () => {
+    if (window.confirm('Are you sure you want to delete this collection? This action cannot be undone.')) {
+      deleteMutation.mutate(
+        { slug },
+        { onSuccess: () => router.push('/collections') }
+      )
+    }
+  }
+
+  const items = collection.items ?? []
+
+  return (
+    <div className="container max-w-6xl mx-auto px-4 py-6">
+      {/* Back link */}
+      <div className="mb-6">
+        <Link
+          href="/collections"
+          className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          &larr; Back to Collections
+        </Link>
+      </div>
+
+      {/* Header */}
+      <header className="mb-8">
+        {isEditing ? (
+          <InlineEditForm
+            slug={slug}
+            title={collection.title}
+            description={collection.description}
+            isPublic={collection.is_public}
+            collaborative={collection.collaborative}
+            onDone={() => setIsEditing(false)}
+          />
+        ) : (
+          <div>
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <div className="flex items-center gap-3 mb-1">
+                  <h1 className="text-3xl font-bold tracking-tight">
+                    {collection.title}
+                  </h1>
+                  {collection.is_featured && (
+                    <Badge variant="default" className="text-xs">
+                      <Star className="h-3 w-3 mr-0.5" />
+                      Featured
+                    </Badge>
+                  )}
+                  {collection.collaborative && (
+                    <Badge variant="secondary" className="text-xs">
+                      Collaborative
+                    </Badge>
+                  )}
+                </div>
+
+                <p className="text-sm text-muted-foreground">
+                  by {collection.creator_name}
+                </p>
+
+                {collection.description && (
+                  <p className="text-muted-foreground mt-3 whitespace-pre-line">
+                    {collection.description}
+                  </p>
+                )}
+
+                {/* Stats */}
+                <div className="mt-3 flex items-center gap-4 text-sm text-muted-foreground">
+                  <span className="flex items-center gap-1">
+                    <Library className="h-4 w-4" />
+                    {collection.item_count === 1
+                      ? '1 item'
+                      : `${collection.item_count} items`}
+                  </span>
+                  <span className="flex items-center gap-1">
+                    <Users className="h-4 w-4" />
+                    {collection.subscriber_count === 1
+                      ? '1 subscriber'
+                      : `${collection.subscriber_count} subscribers`}
+                  </span>
+                </div>
+              </div>
+
+              {/* Action buttons */}
+              <div className="flex items-center gap-2 shrink-0">
+                {canSubscribe && (
+                  <Button
+                    variant={collection.is_subscribed ? 'secondary' : 'default'}
+                    size="sm"
+                    onClick={handleSubscribe}
+                    disabled={
+                      subscribeMutation.isPending ||
+                      unsubscribeMutation.isPending
+                    }
+                  >
+                    {collection.is_subscribed ? (
+                      <>
+                        <BellOff className="h-4 w-4 mr-1.5" />
+                        Unsubscribe
+                      </>
+                    ) : (
+                      <>
+                        <Bell className="h-4 w-4 mr-1.5" />
+                        Subscribe
+                      </>
+                    )}
+                  </Button>
+                )}
+
+                {isCreator && (
+                  <>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setIsEditing(true)}
+                    >
+                      <Pencil className="h-4 w-4 mr-1.5" />
+                      Edit
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={handleDelete}
+                      disabled={deleteMutation.isPending}
+                      className="text-destructive hover:text-destructive"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
+      </header>
+
+      {/* Items list */}
+      <div>
+        <h2 className="text-lg font-semibold mb-4">Items</h2>
+        {items.length === 0 ? (
+          <div className="text-center py-12 text-muted-foreground">
+            <Library className="h-12 w-12 mx-auto mb-3 text-muted-foreground/30" />
+            <p>This collection is empty.</p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {items.map(item => (
+              <CollectionItemRow
+                key={item.id}
+                item={item}
+                slug={slug}
+                isCreator={isCreator}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ──────────────────────────────────────────────
+// Item Row
+// ──────────────────────────────────────────────
+
+function CollectionItemRow({
+  item,
+  slug,
+  isCreator,
+}: {
+  item: CollectionItem
+  slug: string
+  isCreator: boolean
+}) {
+  const removeMutation = useRemoveCollectionItem()
+  const Icon = ENTITY_ICONS[item.entity_type] ?? Library
+
+  const handleRemove = () => {
+    removeMutation.mutate({ slug, itemId: item.id })
+  }
+
+  return (
+    <div className="flex items-center gap-3 rounded-lg border border-border/50 bg-card p-3">
+      {/* Entity type icon */}
+      <div className="h-8 w-8 shrink-0 rounded-md bg-muted/50 flex items-center justify-center">
+        <Icon className="h-4 w-4 text-muted-foreground/60" />
+      </div>
+
+      {/* Entity info */}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <Link
+            href={getEntityUrl(item.entity_type, item.entity_slug)}
+            className="font-medium text-foreground hover:text-primary transition-colors truncate"
+          >
+            {item.entity_name}
+          </Link>
+          <Badge variant="secondary" className="text-[10px] px-1.5 py-0 shrink-0">
+            {getEntityTypeLabel(item.entity_type)}
+          </Badge>
+        </div>
+        <div className="flex items-center gap-2 text-xs text-muted-foreground mt-0.5">
+          <span>added by {item.added_by_name}</span>
+          {item.notes && (
+            <>
+              <span className="text-muted-foreground/40">|</span>
+              <span className="truncate">{item.notes}</span>
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Remove button (creator only) */}
+      {isCreator && (
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive shrink-0"
+          onClick={handleRemove}
+          disabled={removeMutation.isPending}
+          title="Remove from collection"
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      )}
+    </div>
+  )
+}
+
+// ──────────────────────────────────────────────
+// Inline Edit Form
+// ──────────────────────────────────────────────
+
+function InlineEditForm({
+  slug,
+  title: initialTitle,
+  description: initialDescription,
+  isPublic: initialPublic,
+  collaborative: initialCollaborative,
+  onDone,
+}: {
+  slug: string
+  title: string
+  description: string
+  isPublic: boolean
+  collaborative: boolean
+  onDone: () => void
+}) {
+  const updateMutation = useUpdateCollection()
+  const [title, setTitle] = useState(initialTitle)
+  const [description, setDescription] = useState(initialDescription)
+  const [isPublic, setIsPublic] = useState(initialPublic)
+  const [collaborative, setCollaborative] = useState(initialCollaborative)
+
+  const handleSave = () => {
+    updateMutation.mutate(
+      {
+        slug,
+        title: title.trim(),
+        description: description.trim(),
+        is_public: isPublic,
+        collaborative,
+      },
+      { onSuccess: () => onDone() }
+    )
+  }
+
+  return (
+    <div className="space-y-4 rounded-lg border border-border/50 bg-card p-4">
+      <div>
+        <label htmlFor="edit-title" className="text-sm font-medium mb-1.5 block">
+          Title
+        </label>
+        <Input
+          id="edit-title"
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+          autoFocus
+        />
+      </div>
+
+      <div>
+        <label
+          htmlFor="edit-description"
+          className="text-sm font-medium mb-1.5 block"
+        >
+          Description
+        </label>
+        <Textarea
+          id="edit-description"
+          value={description}
+          onChange={e => setDescription(e.target.value)}
+          rows={3}
+        />
+      </div>
+
+      <div className="flex items-center gap-6">
+        <label className="flex items-center gap-2 text-sm cursor-pointer">
+          <input
+            type="checkbox"
+            checked={isPublic}
+            onChange={e => setIsPublic(e.target.checked)}
+            className="rounded border-border"
+          />
+          Public
+        </label>
+
+        <label className="flex items-center gap-2 text-sm cursor-pointer">
+          <input
+            type="checkbox"
+            checked={collaborative}
+            onChange={e => setCollaborative(e.target.checked)}
+            className="rounded border-border"
+          />
+          Collaborative
+        </label>
+      </div>
+
+      {updateMutation.error && (
+        <p className="text-sm text-destructive">
+          {updateMutation.error instanceof Error
+            ? updateMutation.error.message
+            : 'Failed to update collection'}
+        </p>
+      )}
+
+      <div className="flex gap-2">
+        <Button
+          size="sm"
+          onClick={handleSave}
+          disabled={!title.trim() || updateMutation.isPending}
+        >
+          <Check className="h-4 w-4 mr-1" />
+          {updateMutation.isPending ? 'Saving...' : 'Save'}
+        </Button>
+        <Button size="sm" variant="outline" onClick={onDone}>
+          Cancel
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/features/collections/components/CollectionList.tsx
+++ b/frontend/features/collections/components/CollectionList.tsx
@@ -1,0 +1,220 @@
+'use client'
+
+import { useState } from 'react'
+import { Plus } from 'lucide-react'
+import { useCollections, useCreateCollection } from '../hooks'
+import { CollectionCard } from './CollectionCard'
+import { LoadingSpinner } from '@/components/shared'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import { useAuthContext } from '@/lib/context/AuthContext'
+import type { Collection } from '../types'
+
+export function CollectionList() {
+  const { isAuthenticated } = useAuthContext()
+  const { data, isLoading, error, refetch } = useCollections()
+  const [createDialogOpen, setCreateDialogOpen] = useState(false)
+
+  if (isLoading && !data) {
+    return (
+      <div className="flex justify-center items-center py-12">
+        <LoadingSpinner />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="text-center py-12 text-destructive">
+        <p>Failed to load collections. Please try again later.</p>
+        <Button variant="outline" className="mt-4" onClick={() => refetch()}>
+          Retry
+        </Button>
+      </div>
+    )
+  }
+
+  const allCollections = data?.collections ?? []
+
+  // Separate featured and non-featured
+  const featured = allCollections.filter((c: Collection) => c.is_featured)
+  const regular = allCollections.filter((c: Collection) => !c.is_featured)
+
+  return (
+    <section className="w-full max-w-6xl">
+      {/* Actions bar */}
+      {isAuthenticated && (
+        <div className="flex justify-end mb-6">
+          <Dialog open={createDialogOpen} onOpenChange={setCreateDialogOpen}>
+            <DialogTrigger asChild>
+              <Button size="sm">
+                <Plus className="h-4 w-4 mr-1.5" />
+                Create Collection
+              </Button>
+            </DialogTrigger>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Create Collection</DialogTitle>
+              </DialogHeader>
+              <CreateCollectionForm
+                onSuccess={() => setCreateDialogOpen(false)}
+              />
+            </DialogContent>
+          </Dialog>
+        </div>
+      )}
+
+      {/* Featured collections */}
+      {featured.length > 0 && (
+        <div className="mb-8">
+          <h2 className="text-lg font-semibold mb-4">Featured</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+            {featured.map((collection: Collection) => (
+              <CollectionCard key={collection.id} collection={collection} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* All collections */}
+      <div>
+        {featured.length > 0 && regular.length > 0 && (
+          <h2 className="text-lg font-semibold mb-4">All Collections</h2>
+        )}
+        {allCollections.length === 0 ? (
+          <div className="text-center py-12 text-muted-foreground">
+            <p>No public collections yet.</p>
+            {isAuthenticated && (
+              <p className="text-sm mt-2">
+                Be the first to create one!
+              </p>
+            )}
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+            {regular.map((collection: Collection) => (
+              <CollectionCard key={collection.id} collection={collection} />
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  )
+}
+
+// ──────────────────────────────────────────────
+// Create Collection Form (inline in dialog)
+// ──────────────────────────────────────────────
+
+function CreateCollectionForm({ onSuccess }: { onSuccess: () => void }) {
+  const createMutation = useCreateCollection()
+  const [title, setTitle] = useState('')
+  const [description, setDescription] = useState('')
+  const [isPublic, setIsPublic] = useState(true)
+  const [collaborative, setCollaborative] = useState(false)
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!title.trim()) return
+
+    createMutation.mutate(
+      {
+        title: title.trim(),
+        description: description.trim() || undefined,
+        is_public: isPublic,
+        collaborative,
+      },
+      {
+        onSuccess: () => {
+          setTitle('')
+          setDescription('')
+          onSuccess()
+        },
+      }
+    )
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label
+          htmlFor="collection-title"
+          className="text-sm font-medium mb-1.5 block"
+        >
+          Title
+        </label>
+        <Input
+          id="collection-title"
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+          placeholder="My Favorite Artists"
+          required
+          autoFocus
+        />
+      </div>
+
+      <div>
+        <label
+          htmlFor="collection-description"
+          className="text-sm font-medium mb-1.5 block"
+        >
+          Description (optional)
+        </label>
+        <Textarea
+          id="collection-description"
+          value={description}
+          onChange={e => setDescription(e.target.value)}
+          placeholder="A brief description of this collection..."
+          rows={3}
+        />
+      </div>
+
+      <div className="flex items-center gap-6">
+        <label className="flex items-center gap-2 text-sm cursor-pointer">
+          <input
+            type="checkbox"
+            checked={isPublic}
+            onChange={e => setIsPublic(e.target.checked)}
+            className="rounded border-border"
+          />
+          Public
+        </label>
+
+        <label className="flex items-center gap-2 text-sm cursor-pointer">
+          <input
+            type="checkbox"
+            checked={collaborative}
+            onChange={e => setCollaborative(e.target.checked)}
+            className="rounded border-border"
+          />
+          Collaborative
+        </label>
+      </div>
+
+      {createMutation.error && (
+        <p className="text-sm text-destructive">
+          {createMutation.error instanceof Error
+            ? createMutation.error.message
+            : 'Failed to create collection'}
+        </p>
+      )}
+
+      <div className="flex justify-end gap-2">
+        <Button
+          type="submit"
+          disabled={!title.trim() || createMutation.isPending}
+        >
+          {createMutation.isPending ? 'Creating...' : 'Create'}
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/frontend/features/collections/components/index.ts
+++ b/frontend/features/collections/components/index.ts
@@ -1,5 +1,3 @@
-// Collection components — will be populated when PSY-67/68 (collection UI) ships.
-// Example exports:
-//   export { CollectionCard } from './CollectionCard'
-//   export { CollectionList } from './CollectionList'
-//   export { CollectionDetail } from './CollectionDetail'
+export { CollectionCard } from './CollectionCard'
+export { CollectionDetail } from './CollectionDetail'
+export { CollectionList } from './CollectionList'

--- a/frontend/features/collections/hooks/index.ts
+++ b/frontend/features/collections/hooks/index.ts
@@ -1,84 +1,224 @@
 'use client'
 
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+/**
+ * Collection Hooks
+ *
+ * TanStack Query hooks for collection CRUD, items, and subscriptions.
+ */
+
+import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query'
 import { apiRequest, API_ENDPOINTS } from '@/lib/api'
 import { queryKeys } from '@/lib/queryClient'
 import type { Collection, CollectionDetail, CollectionStats } from '../types'
 
-export function useCollections(options?: { enabled?: boolean }) {
+// ──────────────────────────────────────────────
+// Queries
+// ──────────────────────────────────────────────
+
+/** Fetch public collections list */
+export function useCollections() {
   return useQuery({
     queryKey: queryKeys.collections.all,
-    queryFn: async () => {
-      return apiRequest<{ collections: Collection[]; total: number }>(
+    queryFn: () =>
+      apiRequest<{ collections: Collection[]; total: number }>(
         API_ENDPOINTS.COLLECTIONS.LIST
-      )
-    },
-    enabled: options?.enabled ?? true,
+      ),
+    staleTime: 5 * 60 * 1000,
+    placeholderData: keepPreviousData,
   })
 }
 
-export function useMyCollections(options?: { enabled?: boolean }) {
-  return useQuery({
-    queryKey: queryKeys.collections.my,
-    queryFn: async () => {
-      return apiRequest<{ collections: Collection[]; total: number }>(
-        API_ENDPOINTS.COLLECTIONS.MY
-      )
-    },
-    enabled: options?.enabled ?? true,
-  })
-}
-
+/** Fetch a single collection by slug (includes items) */
 export function useCollection(slug: string, options?: { enabled?: boolean }) {
   return useQuery({
     queryKey: queryKeys.collections.detail(slug),
-    queryFn: async () => {
-      return apiRequest<CollectionDetail>(
-        API_ENDPOINTS.COLLECTIONS.DETAIL(slug)
-      )
-    },
+    queryFn: () =>
+      apiRequest<CollectionDetail>(API_ENDPOINTS.COLLECTIONS.DETAIL(slug)),
     enabled: (options?.enabled ?? true) && slug.length > 0,
+    staleTime: 5 * 60 * 1000,
   })
 }
 
+/** Fetch collection stats */
 export function useCollectionStats(slug: string, options?: { enabled?: boolean }) {
   return useQuery({
     queryKey: queryKeys.collections.stats(slug),
-    queryFn: async () => {
-      return apiRequest<CollectionStats>(
-        API_ENDPOINTS.COLLECTIONS.STATS(slug)
-      )
-    },
+    queryFn: () =>
+      apiRequest<CollectionStats>(API_ENDPOINTS.COLLECTIONS.STATS(slug)),
     enabled: (options?.enabled ?? true) && slug.length > 0,
   })
 }
 
+/** Fetch the authenticated user's own collections */
+export function useMyCollections() {
+  return useQuery({
+    queryKey: queryKeys.collections.my,
+    queryFn: () =>
+      apiRequest<{ collections: Collection[]; total: number }>(
+        API_ENDPOINTS.COLLECTIONS.MY
+      ),
+    staleTime: 5 * 60 * 1000,
+  })
+}
+
+// ──────────────────────────────────────────────
+// Mutations
+// ──────────────────────────────────────────────
+
+/** Toggle featured status on a collection (admin) */
 export function useSetFeatured() {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: async ({ slug, featured }: { slug: string; featured: boolean }) => {
-      return apiRequest<void>(API_ENDPOINTS.COLLECTIONS.FEATURE(slug), {
+    mutationFn: ({ slug, featured }: { slug: string; featured: boolean }) =>
+      apiRequest<void>(API_ENDPOINTS.COLLECTIONS.FEATURE(slug), {
         method: 'PUT',
         body: JSON.stringify({ featured }),
-      })
-    },
+      }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.collections.all })
     },
   })
 }
 
-export function useDeleteCollection() {
+/** Create a new collection */
+export function useCreateCollection() {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: async ({ slug }: { slug: string }) => {
-      return apiRequest<void>(API_ENDPOINTS.COLLECTIONS.DETAIL(slug), {
-        method: 'DELETE',
-      })
-    },
+    mutationFn: (data: {
+      title: string
+      description?: string
+      is_public: boolean
+      collaborative: boolean
+    }) =>
+      apiRequest<CollectionDetail>(API_ENDPOINTS.COLLECTIONS.LIST, {
+        method: 'POST',
+        body: JSON.stringify(data),
+      }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.collections.all })
       queryClient.invalidateQueries({ queryKey: queryKeys.collections.my })
+    },
+  })
+}
+
+/** Update an existing collection */
+export function useUpdateCollection() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      slug,
+      ...data
+    }: {
+      slug: string
+      title?: string
+      description?: string
+      is_public?: boolean
+      collaborative?: boolean
+    }) =>
+      apiRequest<CollectionDetail>(API_ENDPOINTS.COLLECTIONS.DETAIL(slug), {
+        method: 'PUT',
+        body: JSON.stringify(data),
+      }),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.collections.all })
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.collections.detail(variables.slug),
+      })
+      queryClient.invalidateQueries({ queryKey: queryKeys.collections.my })
+    },
+  })
+}
+
+/** Delete a collection */
+export function useDeleteCollection() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ slug }: { slug: string }) =>
+      apiRequest<void>(API_ENDPOINTS.COLLECTIONS.DETAIL(slug), {
+        method: 'DELETE',
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.collections.all })
+      queryClient.invalidateQueries({ queryKey: queryKeys.collections.my })
+    },
+  })
+}
+
+/** Add an item to a collection */
+export function useAddCollectionItem() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      slug,
+      entityType,
+      entityId,
+      notes,
+    }: {
+      slug: string
+      entityType: string
+      entityId: number
+      notes?: string
+    }) =>
+      apiRequest<void>(API_ENDPOINTS.COLLECTIONS.ITEMS(slug), {
+        method: 'POST',
+        body: JSON.stringify({
+          entity_type: entityType,
+          entity_id: entityId,
+          notes,
+        }),
+      }),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.collections.detail(variables.slug),
+      })
+    },
+  })
+}
+
+/** Remove an item from a collection */
+export function useRemoveCollectionItem() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ slug, itemId }: { slug: string; itemId: number }) =>
+      apiRequest<void>(API_ENDPOINTS.COLLECTIONS.ITEM(slug, itemId), {
+        method: 'DELETE',
+      }),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.collections.detail(variables.slug),
+      })
+    },
+  })
+}
+
+/** Subscribe to a collection */
+export function useSubscribeCollection() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ slug }: { slug: string }) =>
+      apiRequest<void>(API_ENDPOINTS.COLLECTIONS.SUBSCRIBE(slug), {
+        method: 'POST',
+      }),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.collections.detail(variables.slug),
+      })
+    },
+  })
+}
+
+/** Unsubscribe from a collection */
+export function useUnsubscribeCollection() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ slug }: { slug: string }) =>
+      apiRequest<void>(API_ENDPOINTS.COLLECTIONS.SUBSCRIBE(slug), {
+        method: 'DELETE',
+      }),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.collections.detail(variables.slug),
+      })
     },
   })
 }

--- a/frontend/features/collections/types.ts
+++ b/frontend/features/collections/types.ts
@@ -1,4 +1,4 @@
-// Collection types — matches backend response types from services/contracts/collection.go
+// Collection types — aligned with backend contracts/collection.go response types.
 
 export const COLLECTION_ENTITY_TYPES = [
   'artist',
@@ -11,6 +11,7 @@ export const COLLECTION_ENTITY_TYPES = [
 
 export type CollectionEntityType = (typeof COLLECTION_ENTITY_TYPES)[number]
 
+/** Collection list item (returned by list endpoints, without items array) */
 export interface Collection {
   id: number
   title: string
@@ -29,11 +30,13 @@ export interface Collection {
   updated_at: string
 }
 
+/** Full collection detail (returned by GET /collections/{slug}) */
 export interface CollectionDetail extends Collection {
   items: CollectionItem[]
   is_subscribed: boolean
 }
 
+/** A single item within a collection */
 export interface CollectionItem {
   id: number
   entity_type: string
@@ -47,9 +50,50 @@ export interface CollectionItem {
   created_at: string
 }
 
+/** Collection stats response */
 export interface CollectionStats {
   item_count: number
   subscriber_count: number
   contributor_count: number
   entity_type_counts: Record<string, number>
+}
+
+/** Helper: build entity URL from entity type and slug */
+export function getEntityUrl(entityType: string, entitySlug: string): string {
+  switch (entityType) {
+    case 'artist':
+      return `/artists/${entitySlug}`
+    case 'venue':
+      return `/venues/${entitySlug}`
+    case 'show':
+      return `/shows/${entitySlug}`
+    case 'release':
+      return `/releases/${entitySlug}`
+    case 'label':
+      return `/labels/${entitySlug}`
+    case 'festival':
+      return `/festivals/${entitySlug}`
+    default:
+      return '#'
+  }
+}
+
+/** Helper: get a display label for an entity type */
+export function getEntityTypeLabel(entityType: string): string {
+  switch (entityType) {
+    case 'artist':
+      return 'Artist'
+    case 'venue':
+      return 'Venue'
+    case 'show':
+      return 'Show'
+    case 'release':
+      return 'Release'
+    case 'label':
+      return 'Label'
+    case 'festival':
+      return 'Festival'
+    default:
+      return entityType
+  }
 }


### PR DESCRIPTION
## Summary
- Create public collection browse page (`/collections`) with grid layout and create dialog
- Create collection detail page (`/collections/[slug]`) with inline editing, item management, and subscribe/unsubscribe
- Add `CollectionCard`, `CollectionList`, and `CollectionDetail` components to `features/collections/`
- Add sidebar navigation link and command palette entry for Collections
- Extend hooks with CRUD mutations, item add/remove, and subscription hooks
- Add `getEntityUrl()` and `getEntityTypeLabel()` helper functions

**Note:** This PR targets the PSY-67 branch and should be merged after PSY-67.

## Test plan
- [ ] Verify TypeScript compiles: `cd frontend && npx tsc --noEmit`
- [ ] Navigate to `/collections` — browse page renders
- [ ] Click a collection → detail page loads with items
- [ ] Sidebar shows Collections link under Discover
- [ ] Cmd+K palette includes Collections route

Closes PSY-68

🤖 Generated with [Claude Code](https://claude.com/claude-code)