### PR TITLE
Add request service, handlers, and API routes (PSY-71)

### DIFF
--- a/backend/internal/api/handlers/handler_integration_helpers_test.go
+++ b/backend/internal/api/handlers/handler_integration_helpers_test.go
@@ -48,6 +48,7 @@ type handlerIntegrationDeps struct {
 	labelService          *catalog.LabelService
 	releaseService        *catalog.ReleaseService
 	collectionService     *services.CollectionService
+	requestService        *services.RequestService
 }
 
 func setupHandlerIntegrationDeps(t *testing.T) *handlerIntegrationDeps {
@@ -124,6 +125,7 @@ func setupHandlerIntegrationDeps(t *testing.T) *handlerIntegrationDeps {
 		labelService:          catalog.NewLabelService(db),
 		releaseService:        catalog.NewReleaseService(db),
 		collectionService:     services.NewCollectionService(db),
+		requestService:        services.NewRequestService(db),
 	}
 
 	return deps
@@ -132,6 +134,8 @@ func setupHandlerIntegrationDeps(t *testing.T) *handlerIntegrationDeps {
 func cleanupTables(db *gorm.DB) {
 	sqlDB, _ := db.DB()
 	// Order respects FK constraints
+	_, _ = sqlDB.Exec("DELETE FROM request_votes")
+	_, _ = sqlDB.Exec("DELETE FROM requests")
 	_, _ = sqlDB.Exec("DELETE FROM collection_subscribers")
 	_, _ = sqlDB.Exec("DELETE FROM collection_items")
 	_, _ = sqlDB.Exec("DELETE FROM collections")

--- a/backend/internal/api/handlers/request.go
+++ b/backend/internal/api/handlers/request.go
@@ -1,0 +1,498 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"psychic-homily-backend/internal/api/middleware"
+	apperrors "psychic-homily-backend/internal/errors"
+	"psychic-homily-backend/internal/logger"
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services"
+)
+
+// RequestHandler handles request-related API requests
+type RequestHandler struct {
+	requestService services.RequestServiceInterface
+	auditLog       services.AuditLogServiceInterface
+}
+
+// NewRequestHandler creates a new RequestHandler
+func NewRequestHandler(requestService services.RequestServiceInterface, auditLog services.AuditLogServiceInterface) *RequestHandler {
+	return &RequestHandler{
+		requestService: requestService,
+		auditLog:       auditLog,
+	}
+}
+
+// ============================================================================
+// Create Request
+// ============================================================================
+
+// CreateRequestHandlerRequest represents the request for creating a request
+type CreateRequestHandlerRequest struct {
+	Body struct {
+		Title             string  `json:"title" doc:"Request title" example:"Add Local Band XYZ"`
+		Description       string  `json:"description" doc:"Detailed description of the request" example:"They play at The Rebel Lounge frequently"`
+		EntityType        string  `json:"entity_type" doc:"Entity type (artist, release, label, show, venue, festival)" example:"artist"`
+		RequestedEntityID *uint   `json:"requested_entity_id,omitempty" required:"false" doc:"Optional ID of an existing entity this relates to"`
+	}
+}
+
+// CreateRequestHandlerResponse represents the response for creating a request
+type CreateRequestHandlerResponse struct {
+	Body *services.RequestResponse
+}
+
+// CreateRequestHandler handles POST /requests
+func (h *RequestHandler) CreateRequestHandler(ctx context.Context, req *CreateRequestHandlerRequest) (*CreateRequestHandlerResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	if req.Body.Title == "" {
+		return nil, huma.Error400BadRequest("Title is required")
+	}
+	if req.Body.EntityType == "" {
+		return nil, huma.Error400BadRequest("Entity type is required")
+	}
+
+	request, err := h.requestService.CreateRequest(user.ID, req.Body.Title, req.Body.Description, req.Body.EntityType, req.Body.RequestedEntityID)
+	if err != nil {
+		logger.FromContext(ctx).Error("create_request_failed",
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to create request (request_id: %s)", requestID),
+		)
+	}
+
+	// Audit log (fire and forget)
+	if h.auditLog != nil {
+		go func() {
+			h.auditLog.LogAction(user.ID, "create_request", "request", request.ID, map[string]interface{}{
+				"entity_type": req.Body.EntityType,
+			})
+		}()
+	}
+
+	resp := buildRequestResponse(request, nil)
+	return &CreateRequestHandlerResponse{Body: resp}, nil
+}
+
+// ============================================================================
+// List Requests
+// ============================================================================
+
+// ListRequestsHandlerRequest represents the request for listing requests
+type ListRequestsHandlerRequest struct {
+	Status     string `query:"status" required:"false" doc:"Filter by status (pending, in_progress, fulfilled, rejected, cancelled)"`
+	EntityType string `query:"entity_type" required:"false" doc:"Filter by entity type (artist, release, label, show, venue, festival)"`
+	Sort       string `query:"sort" required:"false" doc:"Sort by: newest, votes, oldest (default: votes)" example:"votes"`
+	Limit      int    `query:"limit" required:"false" doc:"Max results (default 20)" example:"20"`
+	Offset     int    `query:"offset" required:"false" doc:"Offset for pagination" example:"0"`
+}
+
+// ListRequestsHandlerResponse represents the response for listing requests
+type ListRequestsHandlerResponse struct {
+	Body struct {
+		Requests []*services.RequestResponse `json:"requests" doc:"List of requests"`
+		Total    int64                       `json:"total" doc:"Total number of matching requests"`
+	}
+}
+
+// ListRequestsHandler handles GET /requests
+func (h *RequestHandler) ListRequestsHandler(ctx context.Context, req *ListRequestsHandlerRequest) (*ListRequestsHandlerResponse, error) {
+	limit := req.Limit
+	if limit <= 0 {
+		limit = 20
+	}
+
+	requests, total, err := h.requestService.ListRequests(req.Status, req.EntityType, req.Sort, limit, req.Offset)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Failed to fetch requests", err)
+	}
+
+	// Check if user is authenticated for including their votes
+	user := middleware.GetUserFromContext(ctx)
+
+	responses := make([]*services.RequestResponse, len(requests))
+	for i := range requests {
+		var userVote *int
+		if user != nil {
+			vote, err := h.requestService.GetUserVote(requests[i].ID, user.ID)
+			if err == nil && vote != nil {
+				userVote = &vote.Vote
+			}
+		}
+		responses[i] = buildRequestResponse(&requests[i], userVote)
+	}
+
+	resp := &ListRequestsHandlerResponse{}
+	resp.Body.Requests = responses
+	resp.Body.Total = total
+
+	return resp, nil
+}
+
+// ============================================================================
+// Get Request
+// ============================================================================
+
+// GetRequestHandlerRequest represents the request for getting a single request
+type GetRequestHandlerRequest struct {
+	RequestID string `path:"request_id" doc:"Request ID" example:"1"`
+}
+
+// GetRequestHandlerResponse represents the response for getting a request
+type GetRequestHandlerResponse struct {
+	Body *services.RequestResponse
+}
+
+// GetRequestHandler handles GET /requests/{request_id}
+func (h *RequestHandler) GetRequestHandler(ctx context.Context, req *GetRequestHandlerRequest) (*GetRequestHandlerResponse, error) {
+	id, err := strconv.ParseUint(req.RequestID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid request ID")
+	}
+
+	request, err := h.requestService.GetRequest(uint(id))
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Failed to fetch request")
+	}
+	if request == nil {
+		return nil, huma.Error404NotFound("Request not found")
+	}
+
+	// Include user's vote if authenticated
+	var userVote *int
+	user := middleware.GetUserFromContext(ctx)
+	if user != nil {
+		vote, err := h.requestService.GetUserVote(request.ID, user.ID)
+		if err == nil && vote != nil {
+			userVote = &vote.Vote
+		}
+	}
+
+	resp := buildRequestResponse(request, userVote)
+	return &GetRequestHandlerResponse{Body: resp}, nil
+}
+
+// ============================================================================
+// Update Request
+// ============================================================================
+
+// UpdateRequestHandlerRequest represents the request for updating a request
+type UpdateRequestHandlerRequest struct {
+	RequestID string `path:"request_id" doc:"Request ID" example:"1"`
+	Body struct {
+		Title       *string `json:"title,omitempty" required:"false" doc:"Request title"`
+		Description *string `json:"description,omitempty" required:"false" doc:"Request description"`
+	}
+}
+
+// UpdateRequestHandlerResponse represents the response for updating a request
+type UpdateRequestHandlerResponse struct {
+	Body *services.RequestResponse
+}
+
+// UpdateRequestHandler handles PUT /requests/{request_id}
+func (h *RequestHandler) UpdateRequestHandler(ctx context.Context, req *UpdateRequestHandlerRequest) (*UpdateRequestHandlerResponse, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	id, err := strconv.ParseUint(req.RequestID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid request ID")
+	}
+
+	request, err := h.requestService.UpdateRequest(uint(id), user.ID, req.Body.Title, req.Body.Description)
+	if err != nil {
+		mappedErr := mapRequestError(err)
+		if mappedErr != nil {
+			return nil, mappedErr
+		}
+		return nil, huma.Error500InternalServerError("Failed to update request")
+	}
+
+	// Audit log (fire and forget)
+	if h.auditLog != nil {
+		go func() {
+			h.auditLog.LogAction(user.ID, "update_request", "request", uint(id), nil)
+		}()
+	}
+
+	resp := buildRequestResponse(request, nil)
+	return &UpdateRequestHandlerResponse{Body: resp}, nil
+}
+
+// ============================================================================
+// Delete Request
+// ============================================================================
+
+// DeleteRequestHandlerRequest represents the request for deleting a request
+type DeleteRequestHandlerRequest struct {
+	RequestID string `path:"request_id" doc:"Request ID" example:"1"`
+}
+
+// DeleteRequestHandler handles DELETE /requests/{request_id}
+func (h *RequestHandler) DeleteRequestHandler(ctx context.Context, req *DeleteRequestHandlerRequest) (*struct{}, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	id, err := strconv.ParseUint(req.RequestID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid request ID")
+	}
+
+	err = h.requestService.DeleteRequest(uint(id), user.ID, user.IsAdmin)
+	if err != nil {
+		mappedErr := mapRequestError(err)
+		if mappedErr != nil {
+			return nil, mappedErr
+		}
+		return nil, huma.Error500InternalServerError("Failed to delete request")
+	}
+
+	// Audit log (fire and forget)
+	if h.auditLog != nil {
+		go func() {
+			h.auditLog.LogAction(user.ID, "delete_request", "request", uint(id), nil)
+		}()
+	}
+
+	return nil, nil
+}
+
+// ============================================================================
+// Vote
+// ============================================================================
+
+// VoteRequestHandlerRequest represents the request for voting on a request
+type VoteRequestHandlerRequest struct {
+	RequestID string `path:"request_id" doc:"Request ID" example:"1"`
+	Body struct {
+		IsUpvote bool `json:"is_upvote" doc:"True for upvote, false for downvote"`
+	}
+}
+
+// VoteRequestHandler handles POST /requests/{request_id}/vote
+func (h *RequestHandler) VoteRequestHandler(ctx context.Context, req *VoteRequestHandlerRequest) (*struct{}, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	id, err := strconv.ParseUint(req.RequestID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid request ID")
+	}
+
+	err = h.requestService.Vote(uint(id), user.ID, req.Body.IsUpvote)
+	if err != nil {
+		mappedErr := mapRequestError(err)
+		if mappedErr != nil {
+			return nil, mappedErr
+		}
+		return nil, huma.Error500InternalServerError("Failed to vote")
+	}
+
+	return nil, nil
+}
+
+// ============================================================================
+// Remove Vote
+// ============================================================================
+
+// RemoveVoteRequestHandlerRequest represents the request for removing a vote
+type RemoveVoteRequestHandlerRequest struct {
+	RequestID string `path:"request_id" doc:"Request ID" example:"1"`
+}
+
+// RemoveVoteRequestHandler handles DELETE /requests/{request_id}/vote
+func (h *RequestHandler) RemoveVoteRequestHandler(ctx context.Context, req *RemoveVoteRequestHandlerRequest) (*struct{}, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	id, err := strconv.ParseUint(req.RequestID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid request ID")
+	}
+
+	err = h.requestService.RemoveVote(uint(id), user.ID)
+	if err != nil {
+		mappedErr := mapRequestError(err)
+		if mappedErr != nil {
+			return nil, mappedErr
+		}
+		return nil, huma.Error500InternalServerError("Failed to remove vote")
+	}
+
+	return nil, nil
+}
+
+// ============================================================================
+// Fulfill Request
+// ============================================================================
+
+// FulfillRequestHandlerRequest represents the request for fulfilling a request
+type FulfillRequestHandlerRequest struct {
+	RequestID string `path:"request_id" doc:"Request ID" example:"1"`
+	Body struct {
+		FulfilledEntityID *uint `json:"fulfilled_entity_id,omitempty" required:"false" doc:"Optional ID of the entity that fulfills this request"`
+	}
+}
+
+// FulfillRequestHandler handles POST /requests/{request_id}/fulfill
+func (h *RequestHandler) FulfillRequestHandler(ctx context.Context, req *FulfillRequestHandlerRequest) (*struct{}, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	id, err := strconv.ParseUint(req.RequestID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid request ID")
+	}
+
+	err = h.requestService.FulfillRequest(uint(id), user.ID, req.Body.FulfilledEntityID)
+	if err != nil {
+		mappedErr := mapRequestError(err)
+		if mappedErr != nil {
+			return nil, mappedErr
+		}
+		return nil, huma.Error500InternalServerError("Failed to fulfill request")
+	}
+
+	// Audit log (fire and forget)
+	if h.auditLog != nil {
+		go func() {
+			h.auditLog.LogAction(user.ID, "fulfill_request", "request", uint(id), nil)
+		}()
+	}
+
+	return nil, nil
+}
+
+// ============================================================================
+// Close Request
+// ============================================================================
+
+// CloseRequestHandlerRequest represents the request for closing a request
+type CloseRequestHandlerRequest struct {
+	RequestID string `path:"request_id" doc:"Request ID" example:"1"`
+}
+
+// CloseRequestHandler handles POST /requests/{request_id}/close
+func (h *RequestHandler) CloseRequestHandler(ctx context.Context, req *CloseRequestHandlerRequest) (*struct{}, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	id, err := strconv.ParseUint(req.RequestID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid request ID")
+	}
+
+	err = h.requestService.CloseRequest(uint(id), user.ID, user.IsAdmin)
+	if err != nil {
+		mappedErr := mapRequestError(err)
+		if mappedErr != nil {
+			return nil, mappedErr
+		}
+		return nil, huma.Error500InternalServerError("Failed to close request")
+	}
+
+	// Audit log (fire and forget)
+	if h.auditLog != nil {
+		go func() {
+			h.auditLog.LogAction(user.ID, "close_request", "request", uint(id), nil)
+		}()
+	}
+
+	return nil, nil
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+// buildRequestResponse converts a models.Request to a RequestResponse.
+func buildRequestResponse(request *models.Request, userVote *int) *services.RequestResponse {
+	resp := &services.RequestResponse{
+		ID:                request.ID,
+		Title:             request.Title,
+		Description:       request.Description,
+		EntityType:        request.EntityType,
+		RequestedEntityID: request.RequestedEntityID,
+		Status:            request.Status,
+		RequesterID:       request.RequesterID,
+		FulfillerID:       request.FulfillerID,
+		VoteScore:         request.VoteScore,
+		Upvotes:           request.Upvotes,
+		Downvotes:         request.Downvotes,
+		WilsonScore:       request.WilsonScore(),
+		FulfilledAt:       request.FulfilledAt,
+		UserVote:          userVote,
+		CreatedAt:         request.CreatedAt,
+		UpdatedAt:         request.UpdatedAt,
+	}
+
+	// Resolve requester name
+	if request.Requester.ID > 0 {
+		resp.RequesterName = resolveUserDisplayName(&request.Requester)
+	}
+
+	// Resolve fulfiller name
+	if request.Fulfiller != nil && request.Fulfiller.ID > 0 {
+		resp.FulfillerName = resolveUserDisplayName(request.Fulfiller)
+	}
+
+	return resp
+}
+
+// resolveUserDisplayName returns a display name for a user.
+func resolveUserDisplayName(user *models.User) string {
+	if user.Username != nil && *user.Username != "" {
+		return *user.Username
+	}
+	if user.FirstName != nil && *user.FirstName != "" {
+		name := *user.FirstName
+		if user.LastName != nil && *user.LastName != "" {
+			name += " " + *user.LastName
+		}
+		return name
+	}
+	return "Unknown"
+}
+
+// mapRequestError converts a RequestError to an appropriate Huma HTTP error
+func mapRequestError(err error) error {
+	var requestErr *apperrors.RequestError
+	if errors.As(err, &requestErr) {
+		switch requestErr.Code {
+		case apperrors.CodeRequestNotFound:
+			return huma.Error404NotFound(requestErr.Message)
+		case apperrors.CodeRequestForbidden:
+			return huma.Error403Forbidden(requestErr.Message)
+		case apperrors.CodeRequestAlreadyFulfilled:
+			return huma.Error409Conflict(requestErr.Message)
+		}
+	}
+	return nil
+}

--- a/backend/internal/api/handlers/request_test.go
+++ b/backend/internal/api/handlers/request_test.go
@@ -1,0 +1,668 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"psychic-homily-backend/internal/models"
+)
+
+// ============================================================================
+// Mock: RequestServiceInterface
+// ============================================================================
+
+type mockRequestService struct {
+	createRequestFn   func(userID uint, title, description, entityType string, requestedEntityID *uint) (*models.Request, error)
+	getRequestFn      func(requestID uint) (*models.Request, error)
+	listRequestsFn    func(status string, entityType string, sortBy string, limit, offset int) ([]models.Request, int64, error)
+	updateRequestFn   func(requestID, userID uint, title, description *string) (*models.Request, error)
+	deleteRequestFn   func(requestID, userID uint, isAdmin bool) error
+	voteFn            func(requestID, userID uint, isUpvote bool) error
+	removeVoteFn      func(requestID, userID uint) error
+	fulfillRequestFn  func(requestID, fulfillerID uint, fulfilledEntityID *uint) error
+	closeRequestFn    func(requestID, userID uint, isAdmin bool) error
+	getUserVoteFn     func(requestID, userID uint) (*models.RequestVote, error)
+}
+
+func (m *mockRequestService) CreateRequest(userID uint, title, description, entityType string, requestedEntityID *uint) (*models.Request, error) {
+	if m.createRequestFn != nil {
+		return m.createRequestFn(userID, title, description, entityType, requestedEntityID)
+	}
+	desc := description
+	return &models.Request{
+		ID:          1,
+		Title:       title,
+		Description: &desc,
+		EntityType:  entityType,
+		Status:      models.RequestStatusPending,
+		RequesterID: userID,
+	}, nil
+}
+
+func (m *mockRequestService) GetRequest(requestID uint) (*models.Request, error) {
+	if m.getRequestFn != nil {
+		return m.getRequestFn(requestID)
+	}
+	return &models.Request{
+		ID:          requestID,
+		Title:       "Test Request",
+		EntityType:  "artist",
+		Status:      models.RequestStatusPending,
+		RequesterID: 1,
+	}, nil
+}
+
+func (m *mockRequestService) ListRequests(status string, entityType string, sortBy string, limit, offset int) ([]models.Request, int64, error) {
+	if m.listRequestsFn != nil {
+		return m.listRequestsFn(status, entityType, sortBy, limit, offset)
+	}
+	return []models.Request{
+		{ID: 1, Title: "Request 1", EntityType: "artist", Status: models.RequestStatusPending, RequesterID: 1},
+	}, 1, nil
+}
+
+func (m *mockRequestService) UpdateRequest(requestID, userID uint, title, description *string) (*models.Request, error) {
+	if m.updateRequestFn != nil {
+		return m.updateRequestFn(requestID, userID, title, description)
+	}
+	t := "Updated"
+	return &models.Request{ID: requestID, Title: t, EntityType: "artist", Status: models.RequestStatusPending, RequesterID: userID}, nil
+}
+
+func (m *mockRequestService) DeleteRequest(requestID, userID uint, isAdmin bool) error {
+	if m.deleteRequestFn != nil {
+		return m.deleteRequestFn(requestID, userID, isAdmin)
+	}
+	return nil
+}
+
+func (m *mockRequestService) Vote(requestID, userID uint, isUpvote bool) error {
+	if m.voteFn != nil {
+		return m.voteFn(requestID, userID, isUpvote)
+	}
+	return nil
+}
+
+func (m *mockRequestService) RemoveVote(requestID, userID uint) error {
+	if m.removeVoteFn != nil {
+		return m.removeVoteFn(requestID, userID)
+	}
+	return nil
+}
+
+func (m *mockRequestService) FulfillRequest(requestID, fulfillerID uint, fulfilledEntityID *uint) error {
+	if m.fulfillRequestFn != nil {
+		return m.fulfillRequestFn(requestID, fulfillerID, fulfilledEntityID)
+	}
+	return nil
+}
+
+func (m *mockRequestService) CloseRequest(requestID, userID uint, isAdmin bool) error {
+	if m.closeRequestFn != nil {
+		return m.closeRequestFn(requestID, userID, isAdmin)
+	}
+	return nil
+}
+
+func (m *mockRequestService) GetUserVote(requestID, userID uint) (*models.RequestVote, error) {
+	if m.getUserVoteFn != nil {
+		return m.getUserVoteFn(requestID, userID)
+	}
+	return nil, nil
+}
+
+// ============================================================================
+// Test helpers
+// ============================================================================
+
+func testRequestHandler() *RequestHandler {
+	return NewRequestHandler(&mockRequestService{}, nil)
+}
+
+func requestUserCtx() context.Context {
+	return ctxWithUser(&models.User{ID: 1, IsAdmin: false})
+}
+
+func requestAdminCtx() context.Context {
+	return ctxWithUser(&models.User{ID: 2, IsAdmin: true})
+}
+
+// ============================================================================
+// Tests: NewRequestHandler
+// ============================================================================
+
+func TestNewRequestHandler(t *testing.T) {
+	h := testRequestHandler()
+	if h == nil {
+		t.Fatal("expected non-nil RequestHandler")
+	}
+}
+
+// ============================================================================
+// Tests: Auth Guard — all mutating endpoints require auth
+// ============================================================================
+
+func TestRequestHandler_RequiresAuth(t *testing.T) {
+	h := testRequestHandler()
+
+	tests := []struct {
+		name string
+		fn   func(ctx context.Context) error
+	}{
+		{"CreateRequest", func(ctx context.Context) error {
+			_, err := h.CreateRequestHandler(ctx, &CreateRequestHandlerRequest{})
+			return err
+		}},
+		{"UpdateRequest", func(ctx context.Context) error {
+			_, err := h.UpdateRequestHandler(ctx, &UpdateRequestHandlerRequest{RequestID: "1"})
+			return err
+		}},
+		{"DeleteRequest", func(ctx context.Context) error {
+			_, err := h.DeleteRequestHandler(ctx, &DeleteRequestHandlerRequest{RequestID: "1"})
+			return err
+		}},
+		{"Vote", func(ctx context.Context) error {
+			_, err := h.VoteRequestHandler(ctx, &VoteRequestHandlerRequest{RequestID: "1"})
+			return err
+		}},
+		{"RemoveVote", func(ctx context.Context) error {
+			_, err := h.RemoveVoteRequestHandler(ctx, &RemoveVoteRequestHandlerRequest{RequestID: "1"})
+			return err
+		}},
+		{"FulfillRequest", func(ctx context.Context) error {
+			_, err := h.FulfillRequestHandler(ctx, &FulfillRequestHandlerRequest{RequestID: "1"})
+			return err
+		}},
+		{"CloseRequest", func(ctx context.Context) error {
+			_, err := h.CloseRequestHandler(ctx, &CloseRequestHandlerRequest{RequestID: "1"})
+			return err
+		}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name+"_NoUser", func(t *testing.T) {
+			err := tc.fn(context.Background())
+			assertHumaError(t, err, 401)
+		})
+	}
+}
+
+// ============================================================================
+// Tests: CreateRequestHandler
+// ============================================================================
+
+func TestRequestHandler_Create_Success(t *testing.T) {
+	h := NewRequestHandler(&mockRequestService{}, nil)
+
+	req := &CreateRequestHandlerRequest{}
+	req.Body.Title = "Add Band XYZ"
+	req.Body.Description = "They play shows"
+	req.Body.EntityType = "artist"
+
+	resp, err := h.CreateRequestHandler(requestUserCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Title != "Add Band XYZ" {
+		t.Errorf("expected title 'Add Band XYZ', got %s", resp.Body.Title)
+	}
+}
+
+func TestRequestHandler_Create_MissingTitle(t *testing.T) {
+	h := testRequestHandler()
+
+	req := &CreateRequestHandlerRequest{}
+	req.Body.EntityType = "artist"
+
+	_, err := h.CreateRequestHandler(requestUserCtx(), req)
+	assertHumaError(t, err, 400)
+}
+
+func TestRequestHandler_Create_MissingEntityType(t *testing.T) {
+	h := testRequestHandler()
+
+	req := &CreateRequestHandlerRequest{}
+	req.Body.Title = "Test"
+
+	_, err := h.CreateRequestHandler(requestUserCtx(), req)
+	assertHumaError(t, err, 400)
+}
+
+func TestRequestHandler_Create_ServiceError(t *testing.T) {
+	h := NewRequestHandler(&mockRequestService{
+		createRequestFn: func(userID uint, title, description, entityType string, requestedEntityID *uint) (*models.Request, error) {
+			return nil, fmt.Errorf("database error")
+		},
+	}, nil)
+
+	req := &CreateRequestHandlerRequest{}
+	req.Body.Title = "Test"
+	req.Body.Description = "desc"
+	req.Body.EntityType = "artist"
+
+	_, err := h.CreateRequestHandler(requestUserCtx(), req)
+	assertHumaError(t, err, 500)
+}
+
+// ============================================================================
+// Tests: GetRequestHandler
+// ============================================================================
+
+func TestRequestHandler_Get_Success(t *testing.T) {
+	h := NewRequestHandler(&mockRequestService{}, nil)
+
+	resp, err := h.GetRequestHandler(requestUserCtx(), &GetRequestHandlerRequest{RequestID: "1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.ID != 1 {
+		t.Errorf("expected id=1, got %d", resp.Body.ID)
+	}
+}
+
+func TestRequestHandler_Get_InvalidID(t *testing.T) {
+	h := testRequestHandler()
+
+	_, err := h.GetRequestHandler(requestUserCtx(), &GetRequestHandlerRequest{RequestID: "not-a-number"})
+	assertHumaError(t, err, 400)
+}
+
+func TestRequestHandler_Get_NotFound(t *testing.T) {
+	h := NewRequestHandler(&mockRequestService{
+		getRequestFn: func(requestID uint) (*models.Request, error) {
+			return nil, nil
+		},
+	}, nil)
+
+	_, err := h.GetRequestHandler(requestUserCtx(), &GetRequestHandlerRequest{RequestID: "999"})
+	assertHumaError(t, err, 404)
+}
+
+func TestRequestHandler_Get_ServiceError(t *testing.T) {
+	h := NewRequestHandler(&mockRequestService{
+		getRequestFn: func(requestID uint) (*models.Request, error) {
+			return nil, fmt.Errorf("db error")
+		},
+	}, nil)
+
+	_, err := h.GetRequestHandler(requestUserCtx(), &GetRequestHandlerRequest{RequestID: "1"})
+	assertHumaError(t, err, 500)
+}
+
+// ============================================================================
+// Tests: ListRequestsHandler
+// ============================================================================
+
+func TestRequestHandler_List_Success(t *testing.T) {
+	h := NewRequestHandler(&mockRequestService{}, nil)
+
+	resp, err := h.ListRequestsHandler(requestUserCtx(), &ListRequestsHandlerRequest{Limit: 20})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Total != 1 {
+		t.Errorf("expected total=1, got %d", resp.Body.Total)
+	}
+	if len(resp.Body.Requests) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(resp.Body.Requests))
+	}
+}
+
+func TestRequestHandler_List_DefaultLimit(t *testing.T) {
+	var receivedLimit int
+	h := NewRequestHandler(&mockRequestService{
+		listRequestsFn: func(status string, entityType string, sortBy string, limit, offset int) ([]models.Request, int64, error) {
+			receivedLimit = limit
+			return []models.Request{}, 0, nil
+		},
+	}, nil)
+
+	_, err := h.ListRequestsHandler(requestUserCtx(), &ListRequestsHandlerRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if receivedLimit != 20 {
+		t.Errorf("expected default limit=20, got %d", receivedLimit)
+	}
+}
+
+func TestRequestHandler_List_ServiceError(t *testing.T) {
+	h := NewRequestHandler(&mockRequestService{
+		listRequestsFn: func(status string, entityType string, sortBy string, limit, offset int) ([]models.Request, int64, error) {
+			return nil, 0, fmt.Errorf("database error")
+		},
+	}, nil)
+
+	_, err := h.ListRequestsHandler(requestUserCtx(), &ListRequestsHandlerRequest{})
+	assertHumaError(t, err, 500)
+}
+
+func TestRequestHandler_List_NoAuth_Succeeds(t *testing.T) {
+	// List should work without authentication (public endpoint)
+	h := NewRequestHandler(&mockRequestService{}, nil)
+
+	resp, err := h.ListRequestsHandler(context.Background(), &ListRequestsHandlerRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("expected non-nil response")
+	}
+}
+
+// ============================================================================
+// Tests: UpdateRequestHandler
+// ============================================================================
+
+func TestRequestHandler_Update_Success(t *testing.T) {
+	h := NewRequestHandler(&mockRequestService{}, nil)
+
+	req := &UpdateRequestHandlerRequest{RequestID: "1"}
+	title := "Updated"
+	req.Body.Title = &title
+
+	resp, err := h.UpdateRequestHandler(requestUserCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.ID != 1 {
+		t.Errorf("expected id=1, got %d", resp.Body.ID)
+	}
+}
+
+func TestRequestHandler_Update_InvalidID(t *testing.T) {
+	h := testRequestHandler()
+
+	req := &UpdateRequestHandlerRequest{RequestID: "abc"}
+	_, err := h.UpdateRequestHandler(requestUserCtx(), req)
+	assertHumaError(t, err, 400)
+}
+
+func TestRequestHandler_Update_ServiceError_NotFound(t *testing.T) {
+	h := NewRequestHandler(&mockRequestService{
+		updateRequestFn: func(requestID, userID uint, title, description *string) (*models.Request, error) {
+			return nil, fmt.Errorf("REQUEST_NOT_FOUND: not found")
+		},
+	}, nil)
+
+	req := &UpdateRequestHandlerRequest{RequestID: "999"}
+	_, err := h.UpdateRequestHandler(requestUserCtx(), req)
+	// Falls through to 500 since the plain error doesn't match RequestError type
+	assertHumaError(t, err, 500)
+}
+
+// ============================================================================
+// Tests: DeleteRequestHandler
+// ============================================================================
+
+func TestRequestHandler_Delete_Success(t *testing.T) {
+	h := NewRequestHandler(&mockRequestService{}, nil)
+
+	_, err := h.DeleteRequestHandler(requestUserCtx(), &DeleteRequestHandlerRequest{RequestID: "1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRequestHandler_Delete_InvalidID(t *testing.T) {
+	h := testRequestHandler()
+
+	_, err := h.DeleteRequestHandler(requestUserCtx(), &DeleteRequestHandlerRequest{RequestID: "abc"})
+	assertHumaError(t, err, 400)
+}
+
+func TestRequestHandler_Delete_ServiceError(t *testing.T) {
+	h := NewRequestHandler(&mockRequestService{
+		deleteRequestFn: func(requestID, userID uint, isAdmin bool) error {
+			return fmt.Errorf("db error")
+		},
+	}, nil)
+
+	_, err := h.DeleteRequestHandler(requestUserCtx(), &DeleteRequestHandlerRequest{RequestID: "1"})
+	assertHumaError(t, err, 500)
+}
+
+// ============================================================================
+// Tests: VoteRequestHandler
+// ============================================================================
+
+func TestRequestHandler_Vote_Success(t *testing.T) {
+	h := NewRequestHandler(&mockRequestService{}, nil)
+
+	req := &VoteRequestHandlerRequest{RequestID: "1"}
+	req.Body.IsUpvote = true
+
+	_, err := h.VoteRequestHandler(requestUserCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRequestHandler_Vote_InvalidID(t *testing.T) {
+	h := testRequestHandler()
+
+	_, err := h.VoteRequestHandler(requestUserCtx(), &VoteRequestHandlerRequest{RequestID: "abc"})
+	assertHumaError(t, err, 400)
+}
+
+func TestRequestHandler_Vote_ServiceError(t *testing.T) {
+	h := NewRequestHandler(&mockRequestService{
+		voteFn: func(requestID, userID uint, isUpvote bool) error {
+			return fmt.Errorf("db error")
+		},
+	}, nil)
+
+	req := &VoteRequestHandlerRequest{RequestID: "1"}
+	req.Body.IsUpvote = true
+
+	_, err := h.VoteRequestHandler(requestUserCtx(), req)
+	assertHumaError(t, err, 500)
+}
+
+// ============================================================================
+// Tests: RemoveVoteRequestHandler
+// ============================================================================
+
+func TestRequestHandler_RemoveVote_Success(t *testing.T) {
+	h := NewRequestHandler(&mockRequestService{}, nil)
+
+	_, err := h.RemoveVoteRequestHandler(requestUserCtx(), &RemoveVoteRequestHandlerRequest{RequestID: "1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRequestHandler_RemoveVote_InvalidID(t *testing.T) {
+	h := testRequestHandler()
+
+	_, err := h.RemoveVoteRequestHandler(requestUserCtx(), &RemoveVoteRequestHandlerRequest{RequestID: "abc"})
+	assertHumaError(t, err, 400)
+}
+
+// ============================================================================
+// Tests: FulfillRequestHandler
+// ============================================================================
+
+func TestRequestHandler_Fulfill_Success(t *testing.T) {
+	h := NewRequestHandler(&mockRequestService{}, nil)
+
+	_, err := h.FulfillRequestHandler(requestUserCtx(), &FulfillRequestHandlerRequest{RequestID: "1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRequestHandler_Fulfill_InvalidID(t *testing.T) {
+	h := testRequestHandler()
+
+	_, err := h.FulfillRequestHandler(requestUserCtx(), &FulfillRequestHandlerRequest{RequestID: "abc"})
+	assertHumaError(t, err, 400)
+}
+
+func TestRequestHandler_Fulfill_ServiceError(t *testing.T) {
+	h := NewRequestHandler(&mockRequestService{
+		fulfillRequestFn: func(requestID, fulfillerID uint, fulfilledEntityID *uint) error {
+			return fmt.Errorf("db error")
+		},
+	}, nil)
+
+	_, err := h.FulfillRequestHandler(requestUserCtx(), &FulfillRequestHandlerRequest{RequestID: "1"})
+	assertHumaError(t, err, 500)
+}
+
+// ============================================================================
+// Tests: CloseRequestHandler
+// ============================================================================
+
+func TestRequestHandler_Close_Success(t *testing.T) {
+	h := NewRequestHandler(&mockRequestService{}, nil)
+
+	_, err := h.CloseRequestHandler(requestUserCtx(), &CloseRequestHandlerRequest{RequestID: "1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRequestHandler_Close_InvalidID(t *testing.T) {
+	h := testRequestHandler()
+
+	_, err := h.CloseRequestHandler(requestUserCtx(), &CloseRequestHandlerRequest{RequestID: "abc"})
+	assertHumaError(t, err, 400)
+}
+
+func TestRequestHandler_Close_ServiceError(t *testing.T) {
+	h := NewRequestHandler(&mockRequestService{
+		closeRequestFn: func(requestID, userID uint, isAdmin bool) error {
+			return fmt.Errorf("db error")
+		},
+	}, nil)
+
+	_, err := h.CloseRequestHandler(requestUserCtx(), &CloseRequestHandlerRequest{RequestID: "1"})
+	assertHumaError(t, err, 500)
+}
+
+// ============================================================================
+// Tests: mapRequestError
+// ============================================================================
+
+func TestMapRequestError(t *testing.T) {
+	tests := []struct {
+		name           string
+		err            error
+		expectedStatus int
+		expectNil      bool
+	}{
+		{
+			name:           "not found",
+			err:            &errorWithCode{code: "REQUEST_NOT_FOUND", message: "not found"},
+			expectedStatus: 0,
+			expectNil:      true, // Not a *RequestError, so mapRequestError returns nil
+		},
+		{
+			name:      "generic error",
+			err:       fmt.Errorf("some error"),
+			expectNil: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := mapRequestError(tc.err)
+			if tc.expectNil {
+				if result != nil {
+					t.Errorf("expected nil, got %v", result)
+				}
+			} else {
+				assertHumaError(t, result, tc.expectedStatus)
+			}
+		})
+	}
+}
+
+// errorWithCode is a test helper for errors that have a code but aren't RequestError
+type errorWithCode struct {
+	code    string
+	message string
+}
+
+func (e *errorWithCode) Error() string { return e.code + ": " + e.message }
+
+// ============================================================================
+// Tests: buildRequestResponse
+// ============================================================================
+
+func TestBuildRequestResponse(t *testing.T) {
+	username := "testuser"
+	request := &models.Request{
+		ID:          1,
+		Title:       "Test",
+		EntityType:  "artist",
+		Status:      models.RequestStatusPending,
+		RequesterID: 10,
+		Upvotes:     3,
+		Downvotes:   1,
+		VoteScore:   2,
+		Requester:   models.User{ID: 10, Username: &username},
+	}
+
+	userVote := 1
+	resp := buildRequestResponse(request, &userVote)
+
+	if resp.ID != 1 {
+		t.Errorf("expected id=1, got %d", resp.ID)
+	}
+	if resp.Title != "Test" {
+		t.Errorf("expected title=Test, got %s", resp.Title)
+	}
+	if resp.RequesterName != "testuser" {
+		t.Errorf("expected requester_name=testuser, got %s", resp.RequesterName)
+	}
+	if resp.UserVote == nil || *resp.UserVote != 1 {
+		t.Errorf("expected user_vote=1, got %v", resp.UserVote)
+	}
+	if resp.WilsonScore <= 0 {
+		t.Errorf("expected positive wilson_score, got %f", resp.WilsonScore)
+	}
+}
+
+func TestBuildRequestResponse_NoVote(t *testing.T) {
+	request := &models.Request{
+		ID:          1,
+		Title:       "Test",
+		EntityType:  "artist",
+		Status:      models.RequestStatusPending,
+		RequesterID: 10,
+	}
+
+	resp := buildRequestResponse(request, nil)
+	if resp.UserVote != nil {
+		t.Errorf("expected user_vote=nil, got %v", resp.UserVote)
+	}
+}
+
+func TestResolveUserDisplayName(t *testing.T) {
+	username := "cooluser"
+	firstName := "Jane"
+	lastName := "Doe"
+
+	tests := []struct {
+		name     string
+		user     *models.User
+		expected string
+	}{
+		{"username", &models.User{Username: &username}, "cooluser"},
+		{"first+last", &models.User{FirstName: &firstName, LastName: &lastName}, "Jane Doe"},
+		{"first only", &models.User{FirstName: &firstName}, "Jane"},
+		{"empty", &models.User{}, "Unknown"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := resolveUserDisplayName(tc.user)
+			if result != tc.expected {
+				t.Errorf("expected %q, got %q", tc.expected, result)
+			}
+		})
+	}
+}

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -96,6 +96,7 @@ func SetupRoutes(router *chi.Mux, sc *services.ServiceContainer, cfg *config.Con
 	setupPipelineRoutes(protectedGroup, sc)
 	setupContributorProfileRoutes(api, protectedGroup, sc)
 	setupCollectionRoutes(api, protectedGroup, sc)
+	setupRequestRoutes(api, protectedGroup, sc)
 
 	return api
 }
@@ -589,6 +590,28 @@ func setupCollectionRoutes(api huma.API, protected *huma.Group, sc *services.Ser
 
 	// User's own collections (created + subscribed)
 	huma.Get(protected, "/auth/collections", collectionHandler.GetUserCollectionsHandler)
+}
+
+// setupRequestRoutes configures community request endpoints.
+// Public endpoints use optional auth (so authenticated users see their vote).
+// CRUD, voting, fulfillment, and closing require authentication.
+func setupRequestRoutes(api huma.API, protected *huma.Group, sc *services.ServiceContainer) {
+	requestHandler := handlers.NewRequestHandler(sc.Request, sc.AuditLog)
+
+	// Public request endpoints with optional auth (to include user's vote)
+	optionalAuthGroup := huma.NewGroup(api, "")
+	optionalAuthGroup.UseMiddleware(middleware.OptionalHumaJWTMiddleware(sc.JWT))
+	huma.Get(optionalAuthGroup, "/requests", requestHandler.ListRequestsHandler)
+	huma.Get(optionalAuthGroup, "/requests/{request_id}", requestHandler.GetRequestHandler)
+
+	// Protected request endpoints
+	huma.Post(protected, "/requests", requestHandler.CreateRequestHandler)
+	huma.Put(protected, "/requests/{request_id}", requestHandler.UpdateRequestHandler)
+	huma.Delete(protected, "/requests/{request_id}", requestHandler.DeleteRequestHandler)
+	huma.Post(protected, "/requests/{request_id}/vote", requestHandler.VoteRequestHandler)
+	huma.Delete(protected, "/requests/{request_id}/vote", requestHandler.RemoveVoteRequestHandler)
+	huma.Post(protected, "/requests/{request_id}/fulfill", requestHandler.FulfillRequestHandler)
+	huma.Post(protected, "/requests/{request_id}/close", requestHandler.CloseRequestHandler)
 }
 
 // rateLimitHandler handles rate limit exceeded responses with JSON

--- a/backend/internal/errors/request.go
+++ b/backend/internal/errors/request.go
@@ -1,0 +1,60 @@
+package errors
+
+import (
+	"fmt"
+)
+
+// Request error codes
+const (
+	CodeRequestNotFound       = "REQUEST_NOT_FOUND"
+	CodeRequestForbidden      = "REQUEST_FORBIDDEN"
+	CodeRequestAlreadyFulfilled = "REQUEST_ALREADY_FULFILLED"
+)
+
+// RequestError represents a request-related error with additional context.
+type RequestError struct {
+	Code      string
+	Message   string
+	Internal  error
+	RequestID uint
+}
+
+// Error implements the error interface.
+func (e *RequestError) Error() string {
+	if e.Internal != nil {
+		return fmt.Sprintf("%s: %s (internal: %v)", e.Code, e.Message, e.Internal)
+	}
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
+// Unwrap returns the internal error for errors.Is/As compatibility.
+func (e *RequestError) Unwrap() error {
+	return e.Internal
+}
+
+// ErrRequestNotFound creates a request not found error.
+func ErrRequestNotFound(requestID uint) *RequestError {
+	return &RequestError{
+		Code:      CodeRequestNotFound,
+		Message:   fmt.Sprintf("Request %d not found", requestID),
+		RequestID: requestID,
+	}
+}
+
+// ErrRequestForbidden creates a request forbidden error.
+func ErrRequestForbidden(requestID uint) *RequestError {
+	return &RequestError{
+		Code:      CodeRequestForbidden,
+		Message:   fmt.Sprintf("Access denied for request %d", requestID),
+		RequestID: requestID,
+	}
+}
+
+// ErrRequestAlreadyFulfilled creates an already-fulfilled error.
+func ErrRequestAlreadyFulfilled(requestID uint) *RequestError {
+	return &RequestError{
+		Code:      CodeRequestAlreadyFulfilled,
+		Message:   fmt.Sprintf("Request %d is already fulfilled", requestID),
+		RequestID: requestID,
+	}
+}

--- a/backend/internal/services/aliases.go
+++ b/backend/internal/services/aliases.go
@@ -173,6 +173,12 @@ type CollectionItemResponse = contracts.CollectionItemResponse
 type CollectionStatsResponse = contracts.CollectionStatsResponse
 
 // ──────────────────────────────────────────────
+// Request types
+// ──────────────────────────────────────────────
+
+type RequestResponse = contracts.RequestResponse
+
+// ──────────────────────────────────────────────
 // Auth / JWT / Apple / Password types
 // ──────────────────────────────────────────────
 

--- a/backend/internal/services/container.go
+++ b/backend/internal/services/container.go
@@ -29,6 +29,7 @@ type ServiceContainer struct {
 	Bookmark      *engagement.BookmarkService
 	Calendar      *engagement.CalendarService
 	Collection    *CollectionService
+	Request       *RequestService
 	FavoriteVenue *engagement.FavoriteVenueService
 	Festival      *catalog.FestivalService
 	Label         *catalog.LabelService
@@ -110,6 +111,7 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 		Bookmark:      engagement.NewBookmarkService(database),
 		Calendar:      engagement.NewCalendarService(database, savedShow),
 		Collection:    NewCollectionService(database),
+		Request:       NewRequestService(database),
 		FavoriteVenue: engagement.NewFavoriteVenueService(database),
 		Festival:      catalog.NewFestivalService(database),
 		Label:         catalog.NewLabelService(database),

--- a/backend/internal/services/contracts/request.go
+++ b/backend/internal/services/contracts/request.go
@@ -1,0 +1,47 @@
+package contracts
+
+import (
+	"time"
+
+	"psychic-homily-backend/internal/models"
+)
+
+// ──────────────────────────────────────────────
+// Request types
+// ──────────────────────────────────────────────
+
+// RequestResponse represents a request returned to clients.
+type RequestResponse struct {
+	ID                uint       `json:"id"`
+	Title             string     `json:"title"`
+	Description       *string    `json:"description,omitempty"`
+	EntityType        string     `json:"entity_type"`
+	RequestedEntityID *uint      `json:"requested_entity_id,omitempty"`
+	Status            string     `json:"status"`
+	RequesterID       uint       `json:"requester_id"`
+	RequesterName     string     `json:"requester_name"`
+	FulfillerID       *uint      `json:"fulfiller_id,omitempty"`
+	FulfillerName     string     `json:"fulfiller_name,omitempty"`
+	VoteScore         int        `json:"vote_score"`
+	Upvotes           int        `json:"upvotes"`
+	Downvotes         int        `json:"downvotes"`
+	WilsonScore       float64    `json:"wilson_score"`
+	FulfilledAt       *time.Time `json:"fulfilled_at,omitempty"`
+	UserVote          *int       `json:"user_vote,omitempty"`
+	CreatedAt         time.Time  `json:"created_at"`
+	UpdatedAt         time.Time  `json:"updated_at"`
+}
+
+// RequestServiceInterface defines the contract for community request operations.
+type RequestServiceInterface interface {
+	CreateRequest(userID uint, title, description, entityType string, requestedEntityID *uint) (*models.Request, error)
+	GetRequest(requestID uint) (*models.Request, error)
+	ListRequests(status string, entityType string, sortBy string, limit, offset int) ([]models.Request, int64, error)
+	UpdateRequest(requestID, userID uint, title, description *string) (*models.Request, error)
+	DeleteRequest(requestID, userID uint, isAdmin bool) error
+	Vote(requestID, userID uint, isUpvote bool) error
+	RemoveVote(requestID, userID uint) error
+	FulfillRequest(requestID, fulfillerID uint, fulfilledEntityID *uint) error
+	CloseRequest(requestID, userID uint, isAdmin bool) error
+	GetUserVote(requestID, userID uint) (*models.RequestVote, error)
+}

--- a/backend/internal/services/interfaces.go
+++ b/backend/internal/services/interfaces.go
@@ -43,6 +43,7 @@ type VenueSourceConfigServiceInterface = contracts.VenueSourceConfigServiceInter
 type SchedulerServiceInterface = contracts.SchedulerServiceInterface
 type CollectionServiceInterface = contracts.CollectionServiceInterface
 type RevisionServiceInterface = contracts.RevisionServiceInterface
+type RequestServiceInterface = contracts.RequestServiceInterface
 
 // Compile-time interface satisfaction checks.
 // Engagement services (Bookmark, SavedShow, FavoriteVenue, Calendar, Reminder)
@@ -65,4 +66,5 @@ var (
 	_ LabelServiceInterface          = (*catalog.LabelService)(nil)
 	_ ReleaseServiceInterface       = (*catalog.ReleaseService)(nil)
 	_ CollectionServiceInterface            = (*CollectionService)(nil)
+	_ RequestServiceInterface               = (*RequestService)(nil)
 )

--- a/backend/internal/services/request.go
+++ b/backend/internal/services/request.go
@@ -1,0 +1,390 @@
+package services
+
+import (
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/db"
+	apperrors "psychic-homily-backend/internal/errors"
+	"psychic-homily-backend/internal/models"
+)
+
+// RequestService handles community request business logic.
+type RequestService struct {
+	db *gorm.DB
+}
+
+// NewRequestService creates a new request service.
+func NewRequestService(database *gorm.DB) *RequestService {
+	if database == nil {
+		database = db.GetDB()
+	}
+	return &RequestService{db: database}
+}
+
+// validEntityTypes lists the allowed entity types for requests.
+var validRequestEntityTypes = map[string]bool{
+	models.RequestEntityArtist:   true,
+	models.RequestEntityRelease:  true,
+	models.RequestEntityLabel:    true,
+	models.RequestEntityShow:     true,
+	models.RequestEntityVenue:    true,
+	models.RequestEntityFestival: true,
+}
+
+// CreateRequest creates a new community request.
+func (s *RequestService) CreateRequest(userID uint, title, description, entityType string, requestedEntityID *uint) (*models.Request, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	if !validRequestEntityTypes[entityType] {
+		return nil, fmt.Errorf("invalid entity type: %s", entityType)
+	}
+
+	var desc *string
+	if description != "" {
+		desc = &description
+	}
+
+	request := &models.Request{
+		Title:             title,
+		Description:       desc,
+		EntityType:        entityType,
+		RequestedEntityID: requestedEntityID,
+		Status:            models.RequestStatusPending,
+		RequesterID:       userID,
+	}
+
+	if err := s.db.Create(request).Error; err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	return request, nil
+}
+
+// GetRequest retrieves a request by ID with the requester preloaded.
+func (s *RequestService) GetRequest(requestID uint) (*models.Request, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var request models.Request
+	err := s.db.Preload("Requester").Preload("Fulfiller").First(&request, requestID).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get request: %w", err)
+	}
+
+	return &request, nil
+}
+
+// ListRequests retrieves requests with optional filtering and sorting.
+func (s *RequestService) ListRequests(status string, entityType string, sortBy string, limit, offset int) ([]models.Request, int64, error) {
+	if s.db == nil {
+		return nil, 0, fmt.Errorf("database not initialized")
+	}
+
+	query := s.db.Model(&models.Request{})
+
+	if status != "" {
+		query = query.Where("status = ?", status)
+	}
+	if entityType != "" {
+		query = query.Where("entity_type = ?", entityType)
+	}
+
+	// Count total before pagination
+	var total int64
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, fmt.Errorf("failed to count requests: %w", err)
+	}
+
+	// Apply sorting
+	switch sortBy {
+	case "newest":
+		query = query.Order("created_at DESC")
+	case "oldest":
+		query = query.Order("created_at ASC")
+	case "votes":
+		// Use Wilson score for ranking, computed from upvotes/downvotes
+		// We sort by vote_score DESC as a simple proxy; Wilson is computed on read
+		query = query.Order("vote_score DESC, created_at DESC")
+	default:
+		// Default to votes
+		query = query.Order("vote_score DESC, created_at DESC")
+	}
+
+	// Apply pagination
+	if limit <= 0 {
+		limit = 20
+	}
+	query = query.Preload("Requester").Limit(limit).Offset(offset)
+
+	var requests []models.Request
+	if err := query.Find(&requests).Error; err != nil {
+		return nil, 0, fmt.Errorf("failed to list requests: %w", err)
+	}
+
+	return requests, total, nil
+}
+
+// UpdateRequest updates a request. Only the requester can update.
+func (s *RequestService) UpdateRequest(requestID, userID uint, title, description *string) (*models.Request, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var request models.Request
+	err := s.db.First(&request, requestID).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, apperrors.ErrRequestNotFound(requestID)
+		}
+		return nil, fmt.Errorf("failed to get request: %w", err)
+	}
+
+	// Only the requester can update
+	if request.RequesterID != userID {
+		return nil, apperrors.ErrRequestForbidden(requestID)
+	}
+
+	updates := map[string]interface{}{}
+	if title != nil {
+		updates["title"] = *title
+	}
+	if description != nil {
+		updates["description"] = *description
+	}
+
+	if len(updates) > 0 {
+		if err := s.db.Model(&request).Updates(updates).Error; err != nil {
+			return nil, fmt.Errorf("failed to update request: %w", err)
+		}
+	}
+
+	// Re-fetch with preloads
+	return s.GetRequest(requestID)
+}
+
+// DeleteRequest deletes a request. Only the requester or admin can delete.
+func (s *RequestService) DeleteRequest(requestID, userID uint, isAdmin bool) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	var request models.Request
+	err := s.db.First(&request, requestID).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return apperrors.ErrRequestNotFound(requestID)
+		}
+		return fmt.Errorf("failed to get request: %w", err)
+	}
+
+	// Only the requester or admin can delete
+	if request.RequesterID != userID && !isAdmin {
+		return apperrors.ErrRequestForbidden(requestID)
+	}
+
+	// Delete votes first (FK cascade should handle this, but be explicit)
+	if err := s.db.Where("request_id = ?", requestID).Delete(&models.RequestVote{}).Error; err != nil {
+		return fmt.Errorf("failed to delete request votes: %w", err)
+	}
+
+	if err := s.db.Delete(&request).Error; err != nil {
+		return fmt.Errorf("failed to delete request: %w", err)
+	}
+
+	return nil
+}
+
+// Vote adds or updates a vote on a request.
+func (s *RequestService) Vote(requestID, userID uint, isUpvote bool) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	// Verify request exists
+	var request models.Request
+	if err := s.db.First(&request, requestID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return apperrors.ErrRequestNotFound(requestID)
+		}
+		return fmt.Errorf("failed to get request: %w", err)
+	}
+
+	voteValue := -1
+	if isUpvote {
+		voteValue = 1
+	}
+
+	return s.db.Transaction(func(tx *gorm.DB) error {
+		// Upsert the vote
+		var existingVote models.RequestVote
+		err := tx.Where("request_id = ? AND user_id = ?", requestID, userID).First(&existingVote).Error
+
+		if err == gorm.ErrRecordNotFound {
+			// New vote
+			vote := models.RequestVote{
+				RequestID: requestID,
+				UserID:    userID,
+				Vote:      voteValue,
+			}
+			if err := tx.Create(&vote).Error; err != nil {
+				return fmt.Errorf("failed to create vote: %w", err)
+			}
+		} else if err != nil {
+			return fmt.Errorf("failed to check existing vote: %w", err)
+		} else {
+			// Update existing vote
+			if err := tx.Model(&existingVote).Update("vote", voteValue).Error; err != nil {
+				return fmt.Errorf("failed to update vote: %w", err)
+			}
+		}
+
+		// Recalculate vote counts
+		return s.recalculateVoteCounts(tx, requestID)
+	})
+}
+
+// RemoveVote removes a user's vote on a request.
+func (s *RequestService) RemoveVote(requestID, userID uint) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	// Verify request exists
+	var request models.Request
+	if err := s.db.First(&request, requestID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return apperrors.ErrRequestNotFound(requestID)
+		}
+		return fmt.Errorf("failed to get request: %w", err)
+	}
+
+	return s.db.Transaction(func(tx *gorm.DB) error {
+		result := tx.Where("request_id = ? AND user_id = ?", requestID, userID).Delete(&models.RequestVote{})
+		if result.Error != nil {
+			return fmt.Errorf("failed to remove vote: %w", result.Error)
+		}
+
+		// Recalculate vote counts
+		return s.recalculateVoteCounts(tx, requestID)
+	})
+}
+
+// FulfillRequest marks a request as fulfilled.
+func (s *RequestService) FulfillRequest(requestID, fulfillerID uint, fulfilledEntityID *uint) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	var request models.Request
+	err := s.db.First(&request, requestID).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return apperrors.ErrRequestNotFound(requestID)
+		}
+		return fmt.Errorf("failed to get request: %w", err)
+	}
+
+	// Only pending or in_progress requests can be fulfilled
+	if request.Status != models.RequestStatusPending && request.Status != models.RequestStatusInProgress {
+		return apperrors.ErrRequestAlreadyFulfilled(requestID)
+	}
+
+	now := time.Now()
+	updates := map[string]interface{}{
+		"status":       models.RequestStatusFulfilled,
+		"fulfiller_id": fulfillerID,
+		"fulfilled_at": now,
+	}
+	if fulfilledEntityID != nil {
+		updates["requested_entity_id"] = *fulfilledEntityID
+	}
+
+	if err := s.db.Model(&request).Updates(updates).Error; err != nil {
+		return fmt.Errorf("failed to fulfill request: %w", err)
+	}
+
+	return nil
+}
+
+// CloseRequest closes a request (cancelled by owner, rejected by admin).
+func (s *RequestService) CloseRequest(requestID, userID uint, isAdmin bool) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	var request models.Request
+	err := s.db.First(&request, requestID).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return apperrors.ErrRequestNotFound(requestID)
+		}
+		return fmt.Errorf("failed to get request: %w", err)
+	}
+
+	// Must be the requester or admin
+	if request.RequesterID != userID && !isAdmin {
+		return apperrors.ErrRequestForbidden(requestID)
+	}
+
+	// Determine the new status
+	newStatus := models.RequestStatusCancelled
+	if isAdmin && request.RequesterID != userID {
+		newStatus = models.RequestStatusRejected
+	}
+
+	if err := s.db.Model(&request).Update("status", newStatus).Error; err != nil {
+		return fmt.Errorf("failed to close request: %w", err)
+	}
+
+	return nil
+}
+
+// GetUserVote returns the user's vote on a request, or nil if not voted.
+func (s *RequestService) GetUserVote(requestID, userID uint) (*models.RequestVote, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var vote models.RequestVote
+	err := s.db.Where("request_id = ? AND user_id = ?", requestID, userID).First(&vote).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get user vote: %w", err)
+	}
+
+	return &vote, nil
+}
+
+// recalculateVoteCounts recalculates upvotes, downvotes, and vote_score for a request.
+func (s *RequestService) recalculateVoteCounts(tx *gorm.DB, requestID uint) error {
+	var upvotes, downvotes int64
+
+	tx.Model(&models.RequestVote{}).
+		Where("request_id = ? AND vote = 1", requestID).
+		Count(&upvotes)
+
+	tx.Model(&models.RequestVote{}).
+		Where("request_id = ? AND vote = -1", requestID).
+		Count(&downvotes)
+
+	voteScore := int(upvotes - downvotes)
+
+	return tx.Model(&models.Request{}).
+		Where("id = ?", requestID).
+		Updates(map[string]interface{}{
+			"upvotes":    int(upvotes),
+			"downvotes":  int(downvotes),
+			"vote_score": voteScore,
+		}).Error
+}

--- a/backend/internal/services/request_test.go
+++ b/backend/internal/services/request_test.go
@@ -1,0 +1,770 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+
+	apperrors "psychic-homily-backend/internal/errors"
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/testutil"
+)
+
+// =============================================================================
+// UNIT TESTS (No Database Required)
+// =============================================================================
+
+func TestNewRequestService(t *testing.T) {
+	svc := NewRequestService(nil)
+	assert.NotNil(t, svc)
+}
+
+func TestRequestService_NilDatabase(t *testing.T) {
+	svc := &RequestService{db: nil}
+
+	t.Run("CreateRequest", func(t *testing.T) {
+		resp, err := svc.CreateRequest(1, "Test", "desc", "artist", nil)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("GetRequest", func(t *testing.T) {
+		resp, err := svc.GetRequest(1)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("ListRequests", func(t *testing.T) {
+		resp, total, err := svc.ListRequests("", "", "votes", 20, 0)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+		assert.Equal(t, int64(0), total)
+	})
+
+	t.Run("UpdateRequest", func(t *testing.T) {
+		title := "Updated"
+		resp, err := svc.UpdateRequest(1, 1, &title, nil)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("DeleteRequest", func(t *testing.T) {
+		err := svc.DeleteRequest(1, 1, false)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+	})
+
+	t.Run("Vote", func(t *testing.T) {
+		err := svc.Vote(1, 1, true)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+	})
+
+	t.Run("RemoveVote", func(t *testing.T) {
+		err := svc.RemoveVote(1, 1)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+	})
+
+	t.Run("FulfillRequest", func(t *testing.T) {
+		err := svc.FulfillRequest(1, 1, nil)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+	})
+
+	t.Run("CloseRequest", func(t *testing.T) {
+		err := svc.CloseRequest(1, 1, false)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+	})
+
+	t.Run("GetUserVote", func(t *testing.T) {
+		resp, err := svc.GetUserVote(1, 1)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+}
+
+// =============================================================================
+// INTEGRATION TESTS (With Real Database)
+// =============================================================================
+
+type RequestServiceIntegrationTestSuite struct {
+	suite.Suite
+	container      testcontainers.Container
+	db             *gorm.DB
+	requestService *RequestService
+	ctx            context.Context
+}
+
+func (suite *RequestServiceIntegrationTestSuite) SetupSuite() {
+	suite.ctx = context.Background()
+
+	container, err := testcontainers.GenericContainer(suite.ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "postgres:18",
+			ExposedPorts: []string{"5432/tcp"},
+			Env: map[string]string{
+				"POSTGRES_DB":       "test_db",
+				"POSTGRES_USER":     "test_user",
+				"POSTGRES_PASSWORD": "test_password",
+			},
+			WaitingFor: wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(120 * time.Second),
+		},
+		Started: true,
+	})
+	suite.Require().NoError(err)
+	suite.container = container
+
+	host, err := container.Host(suite.ctx)
+	suite.Require().NoError(err)
+	port, err := container.MappedPort(suite.ctx, "5432")
+	suite.Require().NoError(err)
+
+	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
+		host, port.Port())
+
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	suite.Require().NoError(err)
+
+	sqlDB, err := db.DB()
+	suite.Require().NoError(err)
+	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "db", "migrations"))
+
+	suite.db = db
+	suite.requestService = NewRequestService(db)
+}
+
+func (suite *RequestServiceIntegrationTestSuite) TearDownSuite() {
+	if suite.container != nil {
+		_ = suite.container.Terminate(suite.ctx)
+	}
+}
+
+func (suite *RequestServiceIntegrationTestSuite) SetupTest() {
+	// Clean up between tests
+	sqlDB, _ := suite.db.DB()
+	_, _ = sqlDB.Exec("DELETE FROM request_votes")
+	_, _ = sqlDB.Exec("DELETE FROM requests")
+	_, _ = sqlDB.Exec("DELETE FROM users")
+}
+
+// createTestUserForRequest creates a test user for request tests
+func (suite *RequestServiceIntegrationTestSuite) createTestUser(name string) *models.User {
+	email := fmt.Sprintf("%s-%d@test.com", name, time.Now().UnixNano())
+	user := &models.User{
+		Email:         &email,
+		FirstName:     &name,
+		IsActive:      true,
+		EmailVerified: true,
+	}
+	err := suite.db.Create(user).Error
+	suite.Require().NoError(err)
+	return user
+}
+
+// ============================================================================
+// Test: CreateRequest
+// ============================================================================
+
+func (suite *RequestServiceIntegrationTestSuite) TestCreateRequest_Success() {
+	user := suite.createTestUser("requester")
+
+	request, err := suite.requestService.CreateRequest(user.ID, "Add Local Band XYZ", "They play shows frequently", "artist", nil)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(request)
+
+	suite.Assert().Equal("Add Local Band XYZ", request.Title)
+	suite.Assert().NotNil(request.Description)
+	suite.Assert().Equal("They play shows frequently", *request.Description)
+	suite.Assert().Equal("artist", request.EntityType)
+	suite.Assert().Equal(models.RequestStatusPending, request.Status)
+	suite.Assert().Equal(user.ID, request.RequesterID)
+	suite.Assert().Equal(0, request.VoteScore)
+	suite.Assert().Equal(0, request.Upvotes)
+	suite.Assert().Equal(0, request.Downvotes)
+	suite.Assert().Nil(request.FulfillerID)
+	suite.Assert().Nil(request.FulfilledAt)
+	suite.Assert().NotZero(request.ID)
+}
+
+func (suite *RequestServiceIntegrationTestSuite) TestCreateRequest_WithEntityID() {
+	user := suite.createTestUser("requester")
+
+	entityID := uint(42)
+	request, err := suite.requestService.CreateRequest(user.ID, "Update artist info", "Missing bio", "artist", &entityID)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(request)
+
+	suite.Assert().NotNil(request.RequestedEntityID)
+	suite.Assert().Equal(uint(42), *request.RequestedEntityID)
+}
+
+func (suite *RequestServiceIntegrationTestSuite) TestCreateRequest_InvalidEntityType() {
+	user := suite.createTestUser("requester")
+
+	request, err := suite.requestService.CreateRequest(user.ID, "Test", "desc", "invalid_type", nil)
+	suite.Assert().Error(err)
+	suite.Assert().Contains(err.Error(), "invalid entity type")
+	suite.Assert().Nil(request)
+}
+
+func (suite *RequestServiceIntegrationTestSuite) TestCreateRequest_EmptyDescription() {
+	user := suite.createTestUser("requester")
+
+	request, err := suite.requestService.CreateRequest(user.ID, "Test Request", "", "venue", nil)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(request)
+
+	// Empty description should be stored as nil
+	suite.Assert().Nil(request.Description)
+}
+
+// ============================================================================
+// Test: GetRequest
+// ============================================================================
+
+func (suite *RequestServiceIntegrationTestSuite) TestGetRequest_Success() {
+	user := suite.createTestUser("requester")
+	created, err := suite.requestService.CreateRequest(user.ID, "Test", "desc", "artist", nil)
+	suite.Require().NoError(err)
+
+	request, err := suite.requestService.GetRequest(created.ID)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(request)
+
+	suite.Assert().Equal(created.ID, request.ID)
+	suite.Assert().Equal("Test", request.Title)
+	// Requester should be preloaded
+	suite.Assert().Equal(user.ID, request.Requester.ID)
+}
+
+func (suite *RequestServiceIntegrationTestSuite) TestGetRequest_NotFound() {
+	request, err := suite.requestService.GetRequest(99999)
+	suite.Assert().NoError(err)
+	suite.Assert().Nil(request)
+}
+
+// ============================================================================
+// Test: ListRequests
+// ============================================================================
+
+func (suite *RequestServiceIntegrationTestSuite) TestListRequests_All() {
+	user := suite.createTestUser("requester")
+
+	_, _ = suite.requestService.CreateRequest(user.ID, "Request 1", "", "artist", nil)
+	_, _ = suite.requestService.CreateRequest(user.ID, "Request 2", "", "venue", nil)
+	_, _ = suite.requestService.CreateRequest(user.ID, "Request 3", "", "release", nil)
+
+	requests, total, err := suite.requestService.ListRequests("", "", "newest", 20, 0)
+	suite.Require().NoError(err)
+	suite.Assert().Equal(int64(3), total)
+	suite.Assert().Len(requests, 3)
+}
+
+func (suite *RequestServiceIntegrationTestSuite) TestListRequests_FilterByStatus() {
+	user := suite.createTestUser("requester")
+
+	r1, _ := suite.requestService.CreateRequest(user.ID, "Pending", "", "artist", nil)
+	_, _ = suite.requestService.CreateRequest(user.ID, "Also Pending", "", "venue", nil)
+
+	// Fulfill one request
+	_ = suite.requestService.FulfillRequest(r1.ID, user.ID, nil)
+
+	requests, total, err := suite.requestService.ListRequests("pending", "", "newest", 20, 0)
+	suite.Require().NoError(err)
+	suite.Assert().Equal(int64(1), total)
+	suite.Assert().Len(requests, 1)
+	suite.Assert().Equal("Also Pending", requests[0].Title)
+}
+
+func (suite *RequestServiceIntegrationTestSuite) TestListRequests_FilterByEntityType() {
+	user := suite.createTestUser("requester")
+
+	_, _ = suite.requestService.CreateRequest(user.ID, "Artist Request", "", "artist", nil)
+	_, _ = suite.requestService.CreateRequest(user.ID, "Venue Request", "", "venue", nil)
+
+	requests, total, err := suite.requestService.ListRequests("", "artist", "newest", 20, 0)
+	suite.Require().NoError(err)
+	suite.Assert().Equal(int64(1), total)
+	suite.Assert().Len(requests, 1)
+	suite.Assert().Equal("Artist Request", requests[0].Title)
+}
+
+func (suite *RequestServiceIntegrationTestSuite) TestListRequests_SortByVotes() {
+	user := suite.createTestUser("requester")
+	voter := suite.createTestUser("voter")
+
+	r1, _ := suite.requestService.CreateRequest(user.ID, "Less Popular", "", "artist", nil)
+	r2, _ := suite.requestService.CreateRequest(user.ID, "More Popular", "", "artist", nil)
+
+	// Vote on r2
+	_ = suite.requestService.Vote(r2.ID, voter.ID, true)
+	// Downvote r1
+	_ = suite.requestService.Vote(r1.ID, voter.ID, false)
+
+	requests, _, err := suite.requestService.ListRequests("", "", "votes", 20, 0)
+	suite.Require().NoError(err)
+	suite.Assert().Len(requests, 2)
+	// More popular should come first
+	suite.Assert().Equal("More Popular", requests[0].Title)
+	suite.Assert().Equal("Less Popular", requests[1].Title)
+}
+
+func (suite *RequestServiceIntegrationTestSuite) TestListRequests_Pagination() {
+	user := suite.createTestUser("requester")
+
+	for i := 0; i < 5; i++ {
+		_, _ = suite.requestService.CreateRequest(user.ID, fmt.Sprintf("Request %d", i), "", "artist", nil)
+	}
+
+	requests, total, err := suite.requestService.ListRequests("", "", "newest", 2, 0)
+	suite.Require().NoError(err)
+	suite.Assert().Equal(int64(5), total)
+	suite.Assert().Len(requests, 2)
+
+	// Second page
+	requests2, total2, err := suite.requestService.ListRequests("", "", "newest", 2, 2)
+	suite.Require().NoError(err)
+	suite.Assert().Equal(int64(5), total2)
+	suite.Assert().Len(requests2, 2)
+
+	// Ensure different requests
+	suite.Assert().NotEqual(requests[0].ID, requests2[0].ID)
+}
+
+// ============================================================================
+// Test: UpdateRequest
+// ============================================================================
+
+func (suite *RequestServiceIntegrationTestSuite) TestUpdateRequest_Success() {
+	user := suite.createTestUser("requester")
+	created, _ := suite.requestService.CreateRequest(user.ID, "Original Title", "Original desc", "artist", nil)
+
+	newTitle := "Updated Title"
+	newDesc := "Updated description"
+	updated, err := suite.requestService.UpdateRequest(created.ID, user.ID, &newTitle, &newDesc)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(updated)
+
+	suite.Assert().Equal("Updated Title", updated.Title)
+	suite.Assert().NotNil(updated.Description)
+	suite.Assert().Equal("Updated description", *updated.Description)
+}
+
+func (suite *RequestServiceIntegrationTestSuite) TestUpdateRequest_PartialUpdate() {
+	user := suite.createTestUser("requester")
+	created, _ := suite.requestService.CreateRequest(user.ID, "Original", "desc", "artist", nil)
+
+	newTitle := "Updated Title Only"
+	updated, err := suite.requestService.UpdateRequest(created.ID, user.ID, &newTitle, nil)
+	suite.Require().NoError(err)
+	suite.Assert().Equal("Updated Title Only", updated.Title)
+}
+
+func (suite *RequestServiceIntegrationTestSuite) TestUpdateRequest_NotOwner() {
+	owner := suite.createTestUser("owner")
+	other := suite.createTestUser("other")
+	created, _ := suite.requestService.CreateRequest(owner.ID, "Test", "desc", "artist", nil)
+
+	newTitle := "Hacked"
+	_, err := suite.requestService.UpdateRequest(created.ID, other.ID, &newTitle, nil)
+	suite.Assert().Error(err)
+
+	var requestErr *apperrors.RequestError
+	suite.Assert().ErrorAs(err, &requestErr)
+	suite.Assert().Equal(apperrors.CodeRequestForbidden, requestErr.Code)
+}
+
+func (suite *RequestServiceIntegrationTestSuite) TestUpdateRequest_NotFound() {
+	user := suite.createTestUser("requester")
+	title := "Test"
+	_, err := suite.requestService.UpdateRequest(99999, user.ID, &title, nil)
+	suite.Assert().Error(err)
+
+	var requestErr *apperrors.RequestError
+	suite.Assert().ErrorAs(err, &requestErr)
+	suite.Assert().Equal(apperrors.CodeRequestNotFound, requestErr.Code)
+}
+
+// ============================================================================
+// Test: DeleteRequest
+// ============================================================================
+
+func (suite *RequestServiceIntegrationTestSuite) TestDeleteRequest_ByOwner() {
+	user := suite.createTestUser("requester")
+	created, _ := suite.requestService.CreateRequest(user.ID, "To Delete", "desc", "artist", nil)
+
+	err := suite.requestService.DeleteRequest(created.ID, user.ID, false)
+	suite.Assert().NoError(err)
+
+	// Verify it's gone
+	request, err := suite.requestService.GetRequest(created.ID)
+	suite.Assert().NoError(err)
+	suite.Assert().Nil(request)
+}
+
+func (suite *RequestServiceIntegrationTestSuite) TestDeleteRequest_ByAdmin() {
+	user := suite.createTestUser("requester")
+	admin := suite.createTestUser("admin")
+	created, _ := suite.requestService.CreateRequest(user.ID, "To Delete", "desc", "artist", nil)
+
+	err := suite.requestService.DeleteRequest(created.ID, admin.ID, true)
+	suite.Assert().NoError(err)
+}
+
+func (suite *RequestServiceIntegrationTestSuite) TestDeleteRequest_NotOwnerNotAdmin() {
+	user := suite.createTestUser("requester")
+	other := suite.createTestUser("other")
+	created, _ := suite.requestService.CreateRequest(user.ID, "Test", "desc", "artist", nil)
+
+	err := suite.requestService.DeleteRequest(created.ID, other.ID, false)
+	suite.Assert().Error(err)
+
+	var requestErr *apperrors.RequestError
+	suite.Assert().ErrorAs(err, &requestErr)
+	suite.Assert().Equal(apperrors.CodeRequestForbidden, requestErr.Code)
+}
+
+func (suite *RequestServiceIntegrationTestSuite) TestDeleteRequest_NotFound() {
+	user := suite.createTestUser("requester")
+	err := suite.requestService.DeleteRequest(99999, user.ID, false)
+	suite.Assert().Error(err)
+
+	var requestErr *apperrors.RequestError
+	suite.Assert().ErrorAs(err, &requestErr)
+	suite.Assert().Equal(apperrors.CodeRequestNotFound, requestErr.Code)
+}
+
+func (suite *RequestServiceIntegrationTestSuite) TestDeleteRequest_WithVotes() {
+	user := suite.createTestUser("requester")
+	voter := suite.createTestUser("voter")
+	created, _ := suite.requestService.CreateRequest(user.ID, "With Votes", "desc", "artist", nil)
+
+	// Add a vote
+	_ = suite.requestService.Vote(created.ID, voter.ID, true)
+
+	// Delete should succeed (votes are cleaned up)
+	err := suite.requestService.DeleteRequest(created.ID, user.ID, false)
+	suite.Assert().NoError(err)
+}
+
+// ============================================================================
+// Test: Vote
+// ============================================================================
+
+func (suite *RequestServiceIntegrationTestSuite) TestVote_Upvote() {
+	user := suite.createTestUser("requester")
+	voter := suite.createTestUser("voter")
+	created, _ := suite.requestService.CreateRequest(user.ID, "Test", "desc", "artist", nil)
+
+	err := suite.requestService.Vote(created.ID, voter.ID, true)
+	suite.Require().NoError(err)
+
+	// Verify counts
+	request, _ := suite.requestService.GetRequest(created.ID)
+	suite.Assert().Equal(1, request.Upvotes)
+	suite.Assert().Equal(0, request.Downvotes)
+	suite.Assert().Equal(1, request.VoteScore)
+}
+
+func (suite *RequestServiceIntegrationTestSuite) TestVote_Downvote() {
+	user := suite.createTestUser("requester")
+	voter := suite.createTestUser("voter")
+	created, _ := suite.requestService.CreateRequest(user.ID, "Test", "desc", "artist", nil)
+
+	err := suite.requestService.Vote(created.ID, voter.ID, false)
+	suite.Require().NoError(err)
+
+	request, _ := suite.requestService.GetRequest(created.ID)
+	suite.Assert().Equal(0, request.Upvotes)
+	suite.Assert().Equal(1, request.Downvotes)
+	suite.Assert().Equal(-1, request.VoteScore)
+}
+
+func (suite *RequestServiceIntegrationTestSuite) TestVote_ChangeVote() {
+	user := suite.createTestUser("requester")
+	voter := suite.createTestUser("voter")
+	created, _ := suite.requestService.CreateRequest(user.ID, "Test", "desc", "artist", nil)
+
+	// Upvote first
+	_ = suite.requestService.Vote(created.ID, voter.ID, true)
+	request, _ := suite.requestService.GetRequest(created.ID)
+	suite.Assert().Equal(1, request.Upvotes)
+	suite.Assert().Equal(0, request.Downvotes)
+
+	// Change to downvote
+	err := suite.requestService.Vote(created.ID, voter.ID, false)
+	suite.Require().NoError(err)
+
+	request, _ = suite.requestService.GetRequest(created.ID)
+	suite.Assert().Equal(0, request.Upvotes)
+	suite.Assert().Equal(1, request.Downvotes)
+	suite.Assert().Equal(-1, request.VoteScore)
+}
+
+func (suite *RequestServiceIntegrationTestSuite) TestVote_MultipleVoters() {
+	user := suite.createTestUser("requester")
+	voter1 := suite.createTestUser("voter1")
+	voter2 := suite.createTestUser("voter2")
+	voter3 := suite.createTestUser("voter3")
+	created, _ := suite.requestService.CreateRequest(user.ID, "Popular", "desc", "artist", nil)
+
+	_ = suite.requestService.Vote(created.ID, voter1.ID, true)
+	_ = suite.requestService.Vote(created.ID, voter2.ID, true)
+	_ = suite.requestService.Vote(created.ID, voter3.ID, false)
+
+	request, _ := suite.requestService.GetRequest(created.ID)
+	suite.Assert().Equal(2, request.Upvotes)
+	suite.Assert().Equal(1, request.Downvotes)
+	suite.Assert().Equal(1, request.VoteScore)
+}
+
+func (suite *RequestServiceIntegrationTestSuite) TestVote_NotFound() {
+	voter := suite.createTestUser("voter")
+	err := suite.requestService.Vote(99999, voter.ID, true)
+	suite.Assert().Error(err)
+
+	var requestErr *apperrors.RequestError
+	suite.Assert().ErrorAs(err, &requestErr)
+	suite.Assert().Equal(apperrors.CodeRequestNotFound, requestErr.Code)
+}
+
+// ============================================================================
+// Test: RemoveVote
+// ============================================================================
+
+func (suite *RequestServiceIntegrationTestSuite) TestRemoveVote_Success() {
+	user := suite.createTestUser("requester")
+	voter := suite.createTestUser("voter")
+	created, _ := suite.requestService.CreateRequest(user.ID, "Test", "desc", "artist", nil)
+
+	// Vote first
+	_ = suite.requestService.Vote(created.ID, voter.ID, true)
+
+	// Remove vote
+	err := suite.requestService.RemoveVote(created.ID, voter.ID)
+	suite.Require().NoError(err)
+
+	// Counts should be back to 0
+	request, _ := suite.requestService.GetRequest(created.ID)
+	suite.Assert().Equal(0, request.Upvotes)
+	suite.Assert().Equal(0, request.Downvotes)
+	suite.Assert().Equal(0, request.VoteScore)
+}
+
+func (suite *RequestServiceIntegrationTestSuite) TestRemoveVote_NoExistingVote() {
+	user := suite.createTestUser("requester")
+	voter := suite.createTestUser("voter")
+	created, _ := suite.requestService.CreateRequest(user.ID, "Test", "desc", "artist", nil)
+
+	// Should not error even if no vote exists
+	err := suite.requestService.RemoveVote(created.ID, voter.ID)
+	suite.Assert().NoError(err)
+}
+
+func (suite *RequestServiceIntegrationTestSuite) TestRemoveVote_NotFound() {
+	voter := suite.createTestUser("voter")
+	err := suite.requestService.RemoveVote(99999, voter.ID)
+	suite.Assert().Error(err)
+
+	var requestErr *apperrors.RequestError
+	suite.Assert().ErrorAs(err, &requestErr)
+	suite.Assert().Equal(apperrors.CodeRequestNotFound, requestErr.Code)
+}
+
+// ============================================================================
+// Test: FulfillRequest
+// ============================================================================
+
+func (suite *RequestServiceIntegrationTestSuite) TestFulfillRequest_Success() {
+	user := suite.createTestUser("requester")
+	fulfiller := suite.createTestUser("fulfiller")
+	created, _ := suite.requestService.CreateRequest(user.ID, "To Fulfill", "desc", "artist", nil)
+
+	err := suite.requestService.FulfillRequest(created.ID, fulfiller.ID, nil)
+	suite.Require().NoError(err)
+
+	request, _ := suite.requestService.GetRequest(created.ID)
+	suite.Assert().Equal(models.RequestStatusFulfilled, request.Status)
+	suite.Assert().NotNil(request.FulfillerID)
+	suite.Assert().Equal(fulfiller.ID, *request.FulfillerID)
+	suite.Assert().NotNil(request.FulfilledAt)
+}
+
+func (suite *RequestServiceIntegrationTestSuite) TestFulfillRequest_WithEntityID() {
+	user := suite.createTestUser("requester")
+	fulfiller := suite.createTestUser("fulfiller")
+	created, _ := suite.requestService.CreateRequest(user.ID, "To Fulfill", "desc", "artist", nil)
+
+	entityID := uint(42)
+	err := suite.requestService.FulfillRequest(created.ID, fulfiller.ID, &entityID)
+	suite.Require().NoError(err)
+
+	request, _ := suite.requestService.GetRequest(created.ID)
+	suite.Assert().Equal(models.RequestStatusFulfilled, request.Status)
+	suite.Assert().NotNil(request.RequestedEntityID)
+	suite.Assert().Equal(uint(42), *request.RequestedEntityID)
+}
+
+func (suite *RequestServiceIntegrationTestSuite) TestFulfillRequest_AlreadyFulfilled() {
+	user := suite.createTestUser("requester")
+	fulfiller := suite.createTestUser("fulfiller")
+	created, _ := suite.requestService.CreateRequest(user.ID, "To Fulfill", "desc", "artist", nil)
+
+	_ = suite.requestService.FulfillRequest(created.ID, fulfiller.ID, nil)
+
+	// Try to fulfill again
+	err := suite.requestService.FulfillRequest(created.ID, fulfiller.ID, nil)
+	suite.Assert().Error(err)
+
+	var requestErr *apperrors.RequestError
+	suite.Assert().ErrorAs(err, &requestErr)
+	suite.Assert().Equal(apperrors.CodeRequestAlreadyFulfilled, requestErr.Code)
+}
+
+func (suite *RequestServiceIntegrationTestSuite) TestFulfillRequest_NotFound() {
+	user := suite.createTestUser("fulfiller")
+	err := suite.requestService.FulfillRequest(99999, user.ID, nil)
+	suite.Assert().Error(err)
+
+	var requestErr *apperrors.RequestError
+	suite.Assert().ErrorAs(err, &requestErr)
+	suite.Assert().Equal(apperrors.CodeRequestNotFound, requestErr.Code)
+}
+
+// ============================================================================
+// Test: CloseRequest
+// ============================================================================
+
+func (suite *RequestServiceIntegrationTestSuite) TestCloseRequest_ByOwner() {
+	user := suite.createTestUser("requester")
+	created, _ := suite.requestService.CreateRequest(user.ID, "To Close", "desc", "artist", nil)
+
+	err := suite.requestService.CloseRequest(created.ID, user.ID, false)
+	suite.Require().NoError(err)
+
+	request, _ := suite.requestService.GetRequest(created.ID)
+	suite.Assert().Equal(models.RequestStatusCancelled, request.Status)
+}
+
+func (suite *RequestServiceIntegrationTestSuite) TestCloseRequest_ByAdmin() {
+	user := suite.createTestUser("requester")
+	admin := suite.createTestUser("admin")
+	created, _ := suite.requestService.CreateRequest(user.ID, "To Reject", "desc", "artist", nil)
+
+	err := suite.requestService.CloseRequest(created.ID, admin.ID, true)
+	suite.Require().NoError(err)
+
+	request, _ := suite.requestService.GetRequest(created.ID)
+	suite.Assert().Equal(models.RequestStatusRejected, request.Status)
+}
+
+func (suite *RequestServiceIntegrationTestSuite) TestCloseRequest_AdminSelfClose() {
+	// When admin closes their own request, it should be "cancelled" not "rejected"
+	admin := suite.createTestUser("admin")
+	created, _ := suite.requestService.CreateRequest(admin.ID, "My Request", "desc", "artist", nil)
+
+	err := suite.requestService.CloseRequest(created.ID, admin.ID, true)
+	suite.Require().NoError(err)
+
+	request, _ := suite.requestService.GetRequest(created.ID)
+	// Owner closing their own = cancelled, even if admin
+	suite.Assert().Equal(models.RequestStatusCancelled, request.Status)
+}
+
+func (suite *RequestServiceIntegrationTestSuite) TestCloseRequest_NotOwnerNotAdmin() {
+	user := suite.createTestUser("requester")
+	other := suite.createTestUser("other")
+	created, _ := suite.requestService.CreateRequest(user.ID, "Test", "desc", "artist", nil)
+
+	err := suite.requestService.CloseRequest(created.ID, other.ID, false)
+	suite.Assert().Error(err)
+
+	var requestErr *apperrors.RequestError
+	suite.Assert().ErrorAs(err, &requestErr)
+	suite.Assert().Equal(apperrors.CodeRequestForbidden, requestErr.Code)
+}
+
+func (suite *RequestServiceIntegrationTestSuite) TestCloseRequest_NotFound() {
+	user := suite.createTestUser("requester")
+	err := suite.requestService.CloseRequest(99999, user.ID, false)
+	suite.Assert().Error(err)
+
+	var requestErr *apperrors.RequestError
+	suite.Assert().ErrorAs(err, &requestErr)
+	suite.Assert().Equal(apperrors.CodeRequestNotFound, requestErr.Code)
+}
+
+// ============================================================================
+// Test: GetUserVote
+// ============================================================================
+
+func (suite *RequestServiceIntegrationTestSuite) TestGetUserVote_Exists() {
+	user := suite.createTestUser("requester")
+	voter := suite.createTestUser("voter")
+	created, _ := suite.requestService.CreateRequest(user.ID, "Test", "desc", "artist", nil)
+
+	_ = suite.requestService.Vote(created.ID, voter.ID, true)
+
+	vote, err := suite.requestService.GetUserVote(created.ID, voter.ID)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(vote)
+	suite.Assert().Equal(1, vote.Vote)
+}
+
+func (suite *RequestServiceIntegrationTestSuite) TestGetUserVote_NotVoted() {
+	user := suite.createTestUser("requester")
+	voter := suite.createTestUser("voter")
+	created, _ := suite.requestService.CreateRequest(user.ID, "Test", "desc", "artist", nil)
+
+	vote, err := suite.requestService.GetUserVote(created.ID, voter.ID)
+	suite.Assert().NoError(err)
+	suite.Assert().Nil(vote)
+}
+
+// ============================================================================
+// Test: WilsonScore integration
+// ============================================================================
+
+func (suite *RequestServiceIntegrationTestSuite) TestWilsonScore_Computed() {
+	user := suite.createTestUser("requester")
+	voter1 := suite.createTestUser("voter1")
+	voter2 := suite.createTestUser("voter2")
+	created, _ := suite.requestService.CreateRequest(user.ID, "Popular", "desc", "artist", nil)
+
+	_ = suite.requestService.Vote(created.ID, voter1.ID, true)
+	_ = suite.requestService.Vote(created.ID, voter2.ID, true)
+
+	request, _ := suite.requestService.GetRequest(created.ID)
+	wilsonScore := request.WilsonScore()
+	suite.Assert().Greater(wilsonScore, 0.0)
+	suite.Assert().LessOrEqual(wilsonScore, 1.0)
+}
+
+// ============================================================================
+// Test Suite Runner
+// ============================================================================
+
+func TestRequestServiceIntegrationTestSuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	suite.Run(t, new(RequestServiceIntegrationTestSuite))
+}


### PR DESCRIPTION
## Summary
- **RequestService** with full CRUD, voting (upvote/downvote with atomic recalculation), Wilson score ranking, fulfillment, and close/cancel workflows
- **RequestHandler** with 10 API endpoints: create, list, get, update, delete, vote, remove vote, fulfill, close requests
- **RequestError** structured error type with codes for not-found, forbidden, and already-fulfilled
- **RequestServiceInterface** contract + compile-time check + backward-compat type alias
- **Routes** wired up with optional auth for public list/get (so authenticated users see their vote) and protected routes for mutations
- **47 test cases**: unit tests (nil DB paths, auth guards, error mapping, response building) + integration tests (testcontainers Postgres with full CRUD + voting + fulfillment workflows)

## Files
### New (6)
- `backend/internal/api/handlers/request.go` — handler with 10 endpoints
- `backend/internal/api/handlers/request_test.go` — 30 handler unit tests
- `backend/internal/errors/request.go` — structured error types
- `backend/internal/services/contracts/request.go` — interface + response type
- `backend/internal/services/request.go` — service with business logic
- `backend/internal/services/request_test.go` — 17 integration tests (testcontainers)

### Modified (5)
- `backend/internal/api/routes/routes.go` — `setupRequestRoutes` function
- `backend/internal/services/container.go` — `Request` field + wiring
- `backend/internal/services/interfaces.go` — interface alias + compile-time check
- `backend/internal/services/aliases.go` — `RequestResponse` type alias
- `backend/internal/api/handlers/handler_integration_helpers_test.go` — test deps + cleanup

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test ./internal/api/handlers/ -run TestRequestHandler -count=1 -short` passes
- [x] `go test ./internal/services/ -run TestRequest -count=1 -short` passes
- [ ] Full integration tests with testcontainers: `go test ./internal/services/ -run TestRequestServiceIntegrationTestSuite -count=1`

Closes PSY-71

🤖 Generated with [Claude Code](https://claude.com/claude-code)