### PR TITLE
Add request frontend pages and feature module (PSY-72)

### DIFF
--- a/frontend/app/requests/[id]/page.tsx
+++ b/frontend/app/requests/[id]/page.tsx
@@ -1,0 +1,44 @@
+import { Suspense } from 'react'
+import { Loader2 } from 'lucide-react'
+import { RequestDetail } from '@/features/requests/components'
+
+interface RequestPageProps {
+  params: Promise<{ id: string }>
+}
+
+export const metadata = {
+  title: 'Request',
+  description: 'View request details',
+}
+
+function RequestLoadingFallback() {
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center">
+      <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+    </div>
+  )
+}
+
+export default async function RequestPage({ params }: RequestPageProps) {
+  const { id } = await params
+  const requestId = parseInt(id, 10)
+
+  if (isNaN(requestId) || requestId <= 0) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold mb-2">Invalid Request</h1>
+          <p className="text-muted-foreground">
+            The request could not be found.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <Suspense fallback={<RequestLoadingFallback />}>
+      <RequestDetail requestId={requestId} />
+    </Suspense>
+  )
+}

--- a/frontend/app/requests/page.tsx
+++ b/frontend/app/requests/page.tsx
@@ -1,0 +1,36 @@
+import { Suspense } from 'react'
+import { RequestList } from '@/features/requests/components'
+import { LoadingSpinner } from '@/components/shared'
+
+export const metadata = {
+  title: 'Requests',
+  description: 'Browse and create requests for artists, releases, labels, and more.',
+  alternates: {
+    canonical: 'https://psychichomily.com/requests',
+  },
+  openGraph: {
+    title: 'Requests | Psychic Homily',
+    description: 'Browse and create requests for artists, releases, labels, and more.',
+    url: '/requests',
+    type: 'website',
+  },
+}
+
+export default function RequestsPage() {
+  return (
+    <div className="flex min-h-screen items-start justify-center">
+      <main className="w-full max-w-6xl px-4 py-8 md:px-8">
+        <h1 className="text-3xl font-bold text-center mb-8">Requests</h1>
+        <Suspense
+          fallback={
+            <div className="flex justify-center items-center py-12">
+              <LoadingSpinner />
+            </div>
+          }
+        >
+          <RequestList />
+        </Suspense>
+      </main>
+    </div>
+  )
+}

--- a/frontend/components/layout/CommandPalette.tsx
+++ b/frontend/components/layout/CommandPalette.tsx
@@ -13,7 +13,7 @@ import {
 } from '@/components/ui/command'
 import {
   Calendar, Mic2, MapPin, Disc3, Tag, Tent, BookOpen, Headphones, Send,
-  Library, LayoutList, Settings, Shield, Search, Clock, X,
+  Library, LayoutList, MessageSquarePlus, Settings, Shield, Search, Clock, X,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import { useAuthContext } from '@/lib/context/AuthContext'
@@ -70,6 +70,12 @@ const routes: RouteItem[] = [
     href: '/collections',
     icon: LayoutList,
     keywords: ['collections', 'curated', 'lists', 'playlists'],
+  },
+  {
+    label: 'Requests',
+    href: '/requests',
+    icon: MessageSquarePlus,
+    keywords: ['requests', 'request', 'wanted', 'missing', 'suggest', 'ask'],
   },
   {
     label: 'Blog',

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import {
   Calendar, Mic2, MapPin, Disc3, Tag, Tent, BookOpen, Headphones, Newspaper,
-  Send, Library, LayoutList, Settings, Shield, PanelLeftClose, PanelLeft,
+  Send, Library, LayoutList, MessageSquarePlus, Settings, Shield, PanelLeftClose, PanelLeft,
   ExternalLink,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
@@ -42,6 +42,7 @@ export const sidebarGroups: SidebarGroup[] = [
   {
     label: 'Community',
     items: [
+      { href: '/requests', label: 'Requests', icon: MessageSquarePlus },
       { href: '/blog', label: 'Blog', icon: BookOpen },
       { href: '/dj-sets', label: 'DJ Sets', icon: Headphones },
       { href: 'https://psychichomily.substack.com/', label: 'Substack', icon: Newspaper, external: true },

--- a/frontend/features/requests/components/RequestCard.tsx
+++ b/frontend/features/requests/components/RequestCard.tsx
@@ -1,0 +1,142 @@
+'use client'
+
+import Link from 'next/link'
+import { ThumbsUp, ThumbsDown } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { formatTimeAgo } from '../types'
+import { useAuthContext } from '@/lib/context/AuthContext'
+import { useVoteRequest, useRemoveVoteRequest } from '../hooks'
+import {
+  getEntityTypeLabel,
+  getEntityTypeColor,
+  getStatusLabel,
+  getStatusColor,
+} from '../types'
+import type { Request } from '../types'
+
+interface RequestCardProps {
+  request: Request
+}
+
+export function RequestCard({ request }: RequestCardProps) {
+  const { isAuthenticated } = useAuthContext()
+  const voteMutation = useVoteRequest()
+  const removeVoteMutation = useRemoveVoteRequest()
+
+  const userVote = request.user_vote ?? 0
+
+  const handleUpvote = (e: React.MouseEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    if (!isAuthenticated) return
+
+    if (userVote === 1) {
+      removeVoteMutation.mutate({ requestId: request.id })
+    } else {
+      voteMutation.mutate({ requestId: request.id, is_upvote: true })
+    }
+  }
+
+  const handleDownvote = (e: React.MouseEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    if (!isAuthenticated) return
+
+    if (userVote === -1) {
+      removeVoteMutation.mutate({ requestId: request.id })
+    } else {
+      voteMutation.mutate({ requestId: request.id, is_upvote: false })
+    }
+  }
+
+  const isVoting = voteMutation.isPending || removeVoteMutation.isPending
+
+  return (
+    <article className="rounded-lg border border-border/50 bg-card p-4 transition-shadow hover:shadow-sm">
+      <div className="flex gap-3">
+        {/* Vote widget */}
+        <div className="flex flex-col items-center gap-0.5 shrink-0 pt-0.5">
+          <button
+            onClick={handleUpvote}
+            disabled={isVoting || !isAuthenticated}
+            className={cn(
+              'rounded p-1 transition-colors',
+              userVote === 1
+                ? 'text-green-600 dark:text-green-400'
+                : 'text-muted-foreground/50 hover:text-green-600 dark:hover:text-green-400',
+              !isAuthenticated && 'cursor-default opacity-50'
+            )}
+            title={isAuthenticated ? 'Upvote' : 'Log in to vote'}
+            aria-label="Upvote"
+          >
+            <ThumbsUp className="h-4 w-4" />
+          </button>
+          <span
+            className={cn(
+              'text-sm font-semibold tabular-nums min-w-[1.5rem] text-center',
+              request.vote_score > 0 && 'text-green-600 dark:text-green-400',
+              request.vote_score < 0 && 'text-red-600 dark:text-red-400',
+              request.vote_score === 0 && 'text-muted-foreground'
+            )}
+          >
+            {request.vote_score}
+          </span>
+          <button
+            onClick={handleDownvote}
+            disabled={isVoting || !isAuthenticated}
+            className={cn(
+              'rounded p-1 transition-colors',
+              userVote === -1
+                ? 'text-red-600 dark:text-red-400'
+                : 'text-muted-foreground/50 hover:text-red-600 dark:hover:text-red-400',
+              !isAuthenticated && 'cursor-default opacity-50'
+            )}
+            title={isAuthenticated ? 'Downvote' : 'Log in to vote'}
+            aria-label="Downvote"
+          >
+            <ThumbsDown className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Text content */}
+        <div className="flex-1 min-w-0">
+          <Link href={`/requests/${request.id}`} className="block group">
+            <h3 className="font-bold text-foreground group-hover:text-primary transition-colors truncate">
+              {request.title}
+            </h3>
+          </Link>
+
+          <div className="flex items-center gap-2 flex-wrap mt-1">
+            <span
+              className={cn(
+                'inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium',
+                getEntityTypeColor(request.entity_type)
+              )}
+            >
+              {getEntityTypeLabel(request.entity_type)}
+            </span>
+            <span
+              className={cn(
+                'inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium',
+                getStatusColor(request.status)
+              )}
+            >
+              {getStatusLabel(request.status)}
+            </span>
+          </div>
+
+          {request.description && (
+            <p className="text-sm text-muted-foreground mt-1.5 line-clamp-2">
+              {request.description}
+            </p>
+          )}
+
+          <div className="mt-1.5 flex items-center gap-3 text-xs text-muted-foreground">
+            <span>by {request.requester_name}</span>
+            <span>{formatTimeAgo(request.created_at)}</span>
+          </div>
+        </div>
+      </div>
+    </article>
+  )
+}

--- a/frontend/features/requests/components/RequestDetail.tsx
+++ b/frontend/features/requests/components/RequestDetail.tsx
@@ -1,0 +1,457 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import {
+  Loader2,
+  ThumbsUp,
+  ThumbsDown,
+  Pencil,
+  Check,
+  X,
+  Trash2,
+  CheckCircle,
+  XCircle,
+  ExternalLink,
+} from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { useAuthContext } from '@/lib/context/AuthContext'
+import {
+  useRequest,
+  useUpdateRequest,
+  useDeleteRequest,
+  useVoteRequest,
+  useRemoveVoteRequest,
+  useFulfillRequest,
+  useCloseRequest,
+} from '../hooks'
+import {
+  getEntityTypeLabel,
+  getEntityTypeColor,
+  getStatusLabel,
+  getStatusColor,
+  getEntityUrl,
+  formatTimeAgo,
+  formatDate,
+} from '../types'
+
+interface RequestDetailProps {
+  requestId: number
+}
+
+export function RequestDetail({ requestId }: RequestDetailProps) {
+  const router = useRouter()
+  const { user, isAuthenticated } = useAuthContext()
+  const { data: request, isLoading, error } = useRequest(requestId)
+  const deleteMutation = useDeleteRequest()
+  const voteMutation = useVoteRequest()
+  const removeVoteMutation = useRemoveVoteRequest()
+  const fulfillMutation = useFulfillRequest()
+  const closeMutation = useCloseRequest()
+
+  const [isEditing, setIsEditing] = useState(false)
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  if (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : 'Failed to load request'
+    const is404 =
+      errorMessage.includes('not found') || errorMessage.includes('404')
+
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold mb-2">
+            {is404 ? 'Request Not Found' : 'Error Loading Request'}
+          </h1>
+          <p className="text-muted-foreground mb-4">
+            {is404
+              ? "The request you're looking for doesn't exist or has been removed."
+              : errorMessage}
+          </p>
+          <Button asChild variant="outline">
+            <Link href="/requests">Back to Requests</Link>
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  if (!request) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold mb-2">Request Not Found</h1>
+          <p className="text-muted-foreground mb-4">
+            The request you&apos;re looking for doesn&apos;t exist.
+          </p>
+          <Button asChild variant="outline">
+            <Link href="/requests">Back to Requests</Link>
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  const currentUserId = user?.id ? Number(user.id) : undefined
+  const isRequester = currentUserId === request.requester_id
+  const isAdmin = user?.is_admin === true
+  const canEdit = isRequester || isAdmin
+  const canDelete = isRequester || isAdmin
+  const canFulfill = isAdmin && request.status !== 'fulfilled'
+  const canClose = isAdmin && request.status !== 'cancelled' && request.status !== 'fulfilled'
+
+  const userVote = request.user_vote ?? 0
+  const isVoting = voteMutation.isPending || removeVoteMutation.isPending
+
+  const handleUpvote = () => {
+    if (!isAuthenticated) return
+    if (userVote === 1) {
+      removeVoteMutation.mutate({ requestId: request.id })
+    } else {
+      voteMutation.mutate({ requestId: request.id, is_upvote: true })
+    }
+  }
+
+  const handleDownvote = () => {
+    if (!isAuthenticated) return
+    if (userVote === -1) {
+      removeVoteMutation.mutate({ requestId: request.id })
+    } else {
+      voteMutation.mutate({ requestId: request.id, is_upvote: false })
+    }
+  }
+
+  const handleDelete = () => {
+    if (
+      window.confirm(
+        'Are you sure you want to delete this request? This action cannot be undone.'
+      )
+    ) {
+      deleteMutation.mutate(
+        { requestId: request.id },
+        { onSuccess: () => router.push('/requests') }
+      )
+    }
+  }
+
+  const handleFulfill = () => {
+    fulfillMutation.mutate({ requestId: request.id })
+  }
+
+  const handleClose = () => {
+    if (
+      window.confirm('Are you sure you want to close this request?')
+    ) {
+      closeMutation.mutate({ requestId: request.id })
+    }
+  }
+
+  return (
+    <div className="container max-w-4xl mx-auto px-4 py-6">
+      {/* Back link */}
+      <div className="mb-6">
+        <Link
+          href="/requests"
+          className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          &larr; Back to Requests
+        </Link>
+      </div>
+
+      {/* Header */}
+      <header className="mb-8">
+        {isEditing ? (
+          <InlineEditForm
+            requestId={request.id}
+            title={request.title}
+            description={request.description ?? ''}
+            onDone={() => setIsEditing(false)}
+          />
+        ) : (
+          <div>
+            <div className="flex items-start justify-between gap-4">
+              <div className="flex gap-4">
+                {/* Vote widget (larger for detail) */}
+                <div className="flex flex-col items-center gap-1 shrink-0">
+                  <button
+                    onClick={handleUpvote}
+                    disabled={isVoting || !isAuthenticated}
+                    className={cn(
+                      'rounded p-1.5 transition-colors',
+                      userVote === 1
+                        ? 'text-green-600 dark:text-green-400 bg-green-500/10'
+                        : 'text-muted-foreground/50 hover:text-green-600 dark:hover:text-green-400 hover:bg-green-500/10',
+                      !isAuthenticated && 'cursor-default opacity-50'
+                    )}
+                    title={isAuthenticated ? 'Upvote' : 'Log in to vote'}
+                    aria-label="Upvote"
+                  >
+                    <ThumbsUp className="h-5 w-5" />
+                  </button>
+                  <span
+                    className={cn(
+                      'text-lg font-bold tabular-nums',
+                      request.vote_score > 0 &&
+                        'text-green-600 dark:text-green-400',
+                      request.vote_score < 0 &&
+                        'text-red-600 dark:text-red-400',
+                      request.vote_score === 0 && 'text-muted-foreground'
+                    )}
+                  >
+                    {request.vote_score}
+                  </span>
+                  <button
+                    onClick={handleDownvote}
+                    disabled={isVoting || !isAuthenticated}
+                    className={cn(
+                      'rounded p-1.5 transition-colors',
+                      userVote === -1
+                        ? 'text-red-600 dark:text-red-400 bg-red-500/10'
+                        : 'text-muted-foreground/50 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-500/10',
+                      !isAuthenticated && 'cursor-default opacity-50'
+                    )}
+                    title={isAuthenticated ? 'Downvote' : 'Log in to vote'}
+                    aria-label="Downvote"
+                  >
+                    <ThumbsDown className="h-5 w-5" />
+                  </button>
+                  <div className="text-[10px] text-muted-foreground mt-1 text-center">
+                    {request.upvotes} up / {request.downvotes} down
+                  </div>
+                </div>
+
+                {/* Title and info */}
+                <div>
+                  <h1 className="text-3xl font-bold tracking-tight">
+                    {request.title}
+                  </h1>
+
+                  <div className="flex items-center gap-2 mt-2 flex-wrap">
+                    <span
+                      className={cn(
+                        'inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium',
+                        getEntityTypeColor(request.entity_type)
+                      )}
+                    >
+                      {getEntityTypeLabel(request.entity_type)}
+                    </span>
+                    <span
+                      className={cn(
+                        'inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium',
+                        getStatusColor(request.status)
+                      )}
+                    >
+                      {getStatusLabel(request.status)}
+                    </span>
+                  </div>
+
+                  <p className="text-sm text-muted-foreground mt-2">
+                    Requested by{' '}
+                    <Link
+                      href={`/users/${request.requester_name}`}
+                      className="text-foreground hover:text-primary transition-colors"
+                    >
+                      {request.requester_name}
+                    </Link>{' '}
+                    {formatTimeAgo(request.created_at)}
+                  </p>
+
+                  {request.description && (
+                    <p className="text-muted-foreground mt-4 whitespace-pre-line">
+                      {request.description}
+                    </p>
+                  )}
+
+                  {/* Requested entity link */}
+                  {request.requested_entity_id && (
+                    <div className="mt-4">
+                      <Link
+                        href={getEntityUrl(
+                          request.entity_type,
+                          request.requested_entity_id
+                        )}
+                        className="inline-flex items-center gap-1.5 text-sm text-primary hover:text-primary/80 transition-colors"
+                      >
+                        <ExternalLink className="h-3.5 w-3.5" />
+                        View requested {getEntityTypeLabel(request.entity_type).toLowerCase()}
+                      </Link>
+                    </div>
+                  )}
+
+                  {/* Fulfillment info */}
+                  {request.status === 'fulfilled' && (
+                    <div className="mt-4 rounded-lg border border-green-500/20 bg-green-500/5 p-3">
+                      <div className="flex items-center gap-2 text-sm">
+                        <CheckCircle className="h-4 w-4 text-green-600 dark:text-green-400" />
+                        <span className="font-medium text-green-700 dark:text-green-400">
+                          Fulfilled
+                        </span>
+                      </div>
+                      {request.fulfiller_name && (
+                        <p className="text-sm text-muted-foreground mt-1">
+                          by {request.fulfiller_name}
+                          {request.fulfilled_at &&
+                            ` on ${formatDate(request.fulfilled_at)}`}
+                        </p>
+                      )}
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              {/* Action buttons */}
+              <div className="flex items-center gap-2 shrink-0">
+                {canEdit && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setIsEditing(true)}
+                  >
+                    <Pencil className="h-4 w-4 mr-1.5" />
+                    Edit
+                  </Button>
+                )}
+
+                {canFulfill && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleFulfill}
+                    disabled={fulfillMutation.isPending}
+                    className="text-green-700 hover:text-green-700 dark:text-green-400 dark:hover:text-green-400"
+                  >
+                    <CheckCircle className="h-4 w-4 mr-1.5" />
+                    Fulfill
+                  </Button>
+                )}
+
+                {canClose && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleClose}
+                    disabled={closeMutation.isPending}
+                  >
+                    <XCircle className="h-4 w-4 mr-1.5" />
+                    Close
+                  </Button>
+                )}
+
+                {canDelete && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleDelete}
+                    disabled={deleteMutation.isPending}
+                    className="text-destructive hover:text-destructive"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
+      </header>
+    </div>
+  )
+}
+
+// ──────────────────────────────────────────────
+// Inline Edit Form
+// ──────────────────────────────────────────────
+
+function InlineEditForm({
+  requestId,
+  title: initialTitle,
+  description: initialDescription,
+  onDone,
+}: {
+  requestId: number
+  title: string
+  description: string
+  onDone: () => void
+}) {
+  const updateMutation = useUpdateRequest()
+  const [title, setTitle] = useState(initialTitle)
+  const [description, setDescription] = useState(initialDescription)
+
+  const handleSave = () => {
+    updateMutation.mutate(
+      {
+        requestId,
+        title: title.trim(),
+        description: description.trim() || undefined,
+      },
+      { onSuccess: () => onDone() }
+    )
+  }
+
+  return (
+    <div className="space-y-4 rounded-lg border border-border/50 bg-card p-4">
+      <div>
+        <label
+          htmlFor="edit-title"
+          className="text-sm font-medium mb-1.5 block"
+        >
+          Title
+        </label>
+        <Input
+          id="edit-title"
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+          autoFocus
+        />
+      </div>
+
+      <div>
+        <label
+          htmlFor="edit-description"
+          className="text-sm font-medium mb-1.5 block"
+        >
+          Description
+        </label>
+        <Textarea
+          id="edit-description"
+          value={description}
+          onChange={e => setDescription(e.target.value)}
+          rows={4}
+        />
+      </div>
+
+      {updateMutation.error && (
+        <p className="text-sm text-destructive">
+          {updateMutation.error instanceof Error
+            ? updateMutation.error.message
+            : 'Failed to update request'}
+        </p>
+      )}
+
+      <div className="flex gap-2">
+        <Button
+          size="sm"
+          onClick={handleSave}
+          disabled={!title.trim() || updateMutation.isPending}
+        >
+          <Check className="h-4 w-4 mr-1" />
+          {updateMutation.isPending ? 'Saving...' : 'Save'}
+        </Button>
+        <Button size="sm" variant="outline" onClick={onDone}>
+          Cancel
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/features/requests/components/RequestList.tsx
+++ b/frontend/features/requests/components/RequestList.tsx
@@ -1,0 +1,315 @@
+'use client'
+
+import { useState } from 'react'
+import { Plus } from 'lucide-react'
+import { useRequests, useCreateRequest } from '../hooks'
+import { RequestCard } from './RequestCard'
+import {
+  REQUEST_ENTITY_TYPES,
+  REQUEST_SORT_OPTIONS,
+  getEntityTypeLabel,
+  getStatusLabel,
+} from '../types'
+import type { Request } from '../types'
+import { LoadingSpinner } from '@/components/shared'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import { useAuthContext } from '@/lib/context/AuthContext'
+
+const PAGE_SIZE = 20
+
+const FILTERABLE_STATUSES = ['pending', 'in_progress', 'fulfilled'] as const
+
+export function RequestList() {
+  const { isAuthenticated } = useAuthContext()
+  const [entityType, setEntityType] = useState('')
+  const [status, setStatus] = useState('')
+  const [sortBy, setSortBy] = useState('votes')
+  const [offset, setOffset] = useState(0)
+  const [createDialogOpen, setCreateDialogOpen] = useState(false)
+
+  const { data, isLoading, error, refetch } = useRequests({
+    entity_type: entityType || undefined,
+    status: status || undefined,
+    sort_by: sortBy,
+    limit: PAGE_SIZE,
+    offset,
+  })
+
+  const requests = data?.requests ?? []
+  const total = data?.total ?? 0
+  const hasMore = offset + PAGE_SIZE < total
+
+  const handleFilterChange = () => {
+    setOffset(0)
+  }
+
+  if (isLoading && !data) {
+    return (
+      <div className="flex justify-center items-center py-12">
+        <LoadingSpinner />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="text-center py-12 text-destructive">
+        <p>Failed to load requests. Please try again later.</p>
+        <Button variant="outline" className="mt-4" onClick={() => refetch()}>
+          Retry
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <section className="w-full max-w-6xl">
+      {/* Filter bar + actions */}
+      <div className="flex flex-col sm:flex-row items-start sm:items-center gap-3 mb-6">
+        <div className="flex items-center gap-2 flex-wrap flex-1">
+          {/* Entity type filter */}
+          <select
+            value={entityType}
+            onChange={e => {
+              setEntityType(e.target.value)
+              handleFilterChange()
+            }}
+            className="rounded-md border border-border bg-background px-3 py-1.5 text-sm"
+            aria-label="Filter by entity type"
+          >
+            <option value="">All Types</option>
+            {REQUEST_ENTITY_TYPES.map(type => (
+              <option key={type} value={type}>
+                {getEntityTypeLabel(type)}
+              </option>
+            ))}
+          </select>
+
+          {/* Status filter */}
+          <select
+            value={status}
+            onChange={e => {
+              setStatus(e.target.value)
+              handleFilterChange()
+            }}
+            className="rounded-md border border-border bg-background px-3 py-1.5 text-sm"
+            aria-label="Filter by status"
+          >
+            <option value="">All Statuses</option>
+            {FILTERABLE_STATUSES.map(s => (
+              <option key={s} value={s}>
+                {getStatusLabel(s)}
+              </option>
+            ))}
+          </select>
+
+          {/* Sort */}
+          <select
+            value={sortBy}
+            onChange={e => {
+              setSortBy(e.target.value)
+              handleFilterChange()
+            }}
+            className="rounded-md border border-border bg-background px-3 py-1.5 text-sm"
+            aria-label="Sort by"
+          >
+            {REQUEST_SORT_OPTIONS.map(opt => (
+              <option key={opt} value={opt}>
+                {opt === 'votes'
+                  ? 'Most Votes'
+                  : opt === 'newest'
+                    ? 'Newest'
+                    : 'Oldest'}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {isAuthenticated && (
+          <Dialog open={createDialogOpen} onOpenChange={setCreateDialogOpen}>
+            <DialogTrigger asChild>
+              <Button size="sm">
+                <Plus className="h-4 w-4 mr-1.5" />
+                New Request
+              </Button>
+            </DialogTrigger>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>New Request</DialogTitle>
+              </DialogHeader>
+              <CreateRequestForm
+                onSuccess={() => setCreateDialogOpen(false)}
+              />
+            </DialogContent>
+          </Dialog>
+        )}
+      </div>
+
+      {/* Results count */}
+      {total > 0 && (
+        <p className="text-sm text-muted-foreground mb-4">
+          {total} {total === 1 ? 'request' : 'requests'} found
+        </p>
+      )}
+
+      {/* Request cards */}
+      {requests.length === 0 ? (
+        <div className="text-center py-12 text-muted-foreground">
+          <p>No requests found.</p>
+          {isAuthenticated && (
+            <p className="text-sm mt-2">
+              Be the first to create a request!
+            </p>
+          )}
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+          {requests.map((request: Request) => (
+            <RequestCard key={request.id} request={request} />
+          ))}
+        </div>
+      )}
+
+      {/* Pagination */}
+      {(offset > 0 || hasMore) && (
+        <div className="flex items-center justify-center gap-3 mt-8">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={offset === 0}
+            onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+          >
+            Previous
+          </Button>
+          <span className="text-sm text-muted-foreground">
+            Page {Math.floor(offset / PAGE_SIZE) + 1} of{' '}
+            {Math.ceil(total / PAGE_SIZE)}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={!hasMore}
+            onClick={() => setOffset(offset + PAGE_SIZE)}
+          >
+            Next
+          </Button>
+        </div>
+      )}
+    </section>
+  )
+}
+
+// ──────────────────────────────────────────────
+// Create Request Form (inline in dialog)
+// ──────────────────────────────────────────────
+
+function CreateRequestForm({ onSuccess }: { onSuccess: () => void }) {
+  const createMutation = useCreateRequest()
+  const [title, setTitle] = useState('')
+  const [description, setDescription] = useState('')
+  const [entityType, setEntityType] = useState('artist')
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!title.trim()) return
+
+    createMutation.mutate(
+      {
+        title: title.trim(),
+        description: description.trim() || undefined,
+        entity_type: entityType,
+      },
+      {
+        onSuccess: () => {
+          setTitle('')
+          setDescription('')
+          onSuccess()
+        },
+      }
+    )
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label
+          htmlFor="request-title"
+          className="text-sm font-medium mb-1.5 block"
+        >
+          Title
+        </label>
+        <Input
+          id="request-title"
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+          placeholder="e.g., Add Slowdive discography"
+          required
+          autoFocus
+        />
+      </div>
+
+      <div>
+        <label
+          htmlFor="request-entity-type"
+          className="text-sm font-medium mb-1.5 block"
+        >
+          Entity Type
+        </label>
+        <select
+          id="request-entity-type"
+          value={entityType}
+          onChange={e => setEntityType(e.target.value)}
+          className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
+        >
+          {REQUEST_ENTITY_TYPES.map(type => (
+            <option key={type} value={type}>
+              {getEntityTypeLabel(type)}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label
+          htmlFor="request-description"
+          className="text-sm font-medium mb-1.5 block"
+        >
+          Description (optional)
+        </label>
+        <Textarea
+          id="request-description"
+          value={description}
+          onChange={e => setDescription(e.target.value)}
+          placeholder="Describe what you'd like added and any relevant details..."
+          rows={3}
+        />
+      </div>
+
+      {createMutation.error && (
+        <p className="text-sm text-destructive">
+          {createMutation.error instanceof Error
+            ? createMutation.error.message
+            : 'Failed to create request'}
+        </p>
+      )}
+
+      <div className="flex justify-end gap-2">
+        <Button
+          type="submit"
+          disabled={!title.trim() || createMutation.isPending}
+        >
+          {createMutation.isPending ? 'Creating...' : 'Create Request'}
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/frontend/features/requests/components/index.ts
+++ b/frontend/features/requests/components/index.ts
@@ -1,0 +1,3 @@
+export { RequestCard } from './RequestCard'
+export { RequestDetail } from './RequestDetail'
+export { RequestList } from './RequestList'

--- a/frontend/features/requests/hooks/index.ts
+++ b/frontend/features/requests/hooks/index.ts
@@ -1,0 +1,304 @@
+'use client'
+
+/**
+ * Request Hooks
+ *
+ * TanStack Query hooks for request CRUD, voting, and fulfillment.
+ */
+
+import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query'
+import { apiRequest, API_ENDPOINTS } from '@/lib/api'
+import { queryKeys } from '@/lib/queryClient'
+import type { Request, RequestListResponse } from '../types'
+
+// ──────────────────────────────────────────────
+// Queries
+// ──────────────────────────────────────────────
+
+interface UseRequestsParams {
+  status?: string
+  entity_type?: string
+  sort_by?: string
+  limit?: number
+  offset?: number
+}
+
+/** Fetch requests list with optional filters */
+export function useRequests(params?: UseRequestsParams) {
+  const searchParams = new URLSearchParams()
+  if (params?.status) searchParams.set('status', params.status)
+  if (params?.entity_type) searchParams.set('entity_type', params.entity_type)
+  if (params?.sort_by) searchParams.set('sort_by', params.sort_by)
+  if (params?.limit) searchParams.set('limit', String(params.limit))
+  if (params?.offset) searchParams.set('offset', String(params.offset))
+
+  const queryString = searchParams.toString()
+  const url = queryString
+    ? `${API_ENDPOINTS.REQUESTS.LIST}?${queryString}`
+    : API_ENDPOINTS.REQUESTS.LIST
+
+  return useQuery({
+    queryKey: queryKeys.requests.list(params as Record<string, unknown> | undefined),
+    queryFn: () => apiRequest<RequestListResponse>(url),
+    staleTime: 5 * 60 * 1000,
+    placeholderData: keepPreviousData,
+  })
+}
+
+/** Fetch a single request by ID */
+export function useRequest(requestId: number, options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: queryKeys.requests.detail(requestId),
+    queryFn: () =>
+      apiRequest<Request>(API_ENDPOINTS.REQUESTS.GET(requestId)),
+    enabled: (options?.enabled ?? true) && requestId > 0,
+    staleTime: 5 * 60 * 1000,
+  })
+}
+
+// ──────────────────────────────────────────────
+// Mutations
+// ──────────────────────────────────────────────
+
+/** Create a new request */
+export function useCreateRequest() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (data: {
+      title: string
+      description?: string
+      entity_type: string
+      requested_entity_id?: number
+    }) =>
+      apiRequest<Request>(API_ENDPOINTS.REQUESTS.LIST, {
+        method: 'POST',
+        body: JSON.stringify(data),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.requests.all })
+    },
+  })
+}
+
+/** Update an existing request */
+export function useUpdateRequest() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      requestId,
+      ...data
+    }: {
+      requestId: number
+      title?: string
+      description?: string
+    }) =>
+      apiRequest<Request>(API_ENDPOINTS.REQUESTS.GET(requestId), {
+        method: 'PUT',
+        body: JSON.stringify(data),
+      }),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.requests.all })
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.requests.detail(variables.requestId),
+      })
+    },
+  })
+}
+
+/** Delete a request */
+export function useDeleteRequest() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ requestId }: { requestId: number }) =>
+      apiRequest<void>(API_ENDPOINTS.REQUESTS.GET(requestId), {
+        method: 'DELETE',
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.requests.all })
+    },
+  })
+}
+
+/** Vote on a request (with optimistic updates) */
+export function useVoteRequest() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      requestId,
+      is_upvote,
+    }: {
+      requestId: number
+      is_upvote: boolean
+    }) =>
+      apiRequest<void>(API_ENDPOINTS.REQUESTS.VOTE(requestId), {
+        method: 'POST',
+        body: JSON.stringify({ is_upvote }),
+      }),
+    onMutate: async ({ requestId, is_upvote }) => {
+      // Cancel outgoing refetches
+      await queryClient.cancelQueries({
+        queryKey: queryKeys.requests.detail(requestId),
+      })
+
+      // Snapshot the previous value
+      const previousRequest = queryClient.getQueryData<Request>(
+        queryKeys.requests.detail(requestId)
+      )
+
+      // Optimistically update the detail cache
+      if (previousRequest) {
+        const oldVote = previousRequest.user_vote ?? 0
+        const newVote = is_upvote ? 1 : -1
+
+        let upvoteDelta = 0
+        let downvoteDelta = 0
+
+        if (oldVote === 1) {
+          // Was upvoted
+          upvoteDelta = -1
+          if (newVote === -1) downvoteDelta = 1
+        } else if (oldVote === -1) {
+          // Was downvoted
+          downvoteDelta = -1
+          if (newVote === 1) upvoteDelta = 1
+        } else {
+          // No previous vote
+          if (newVote === 1) upvoteDelta = 1
+          else downvoteDelta = 1
+        }
+
+        // If clicking the same vote direction, this is a toggle (remove vote)
+        // But the API is POST /vote which sets the vote, not toggles.
+        // Removing a vote uses DELETE /vote. So we always set the new vote.
+        queryClient.setQueryData<Request>(
+          queryKeys.requests.detail(requestId),
+          {
+            ...previousRequest,
+            user_vote: newVote,
+            upvotes: previousRequest.upvotes + upvoteDelta,
+            downvotes: previousRequest.downvotes + downvoteDelta,
+            vote_score: previousRequest.vote_score + upvoteDelta - downvoteDelta,
+          }
+        )
+      }
+
+      return { previousRequest }
+    },
+    onError: (_err, variables, context) => {
+      // Roll back on error
+      if (context?.previousRequest) {
+        queryClient.setQueryData(
+          queryKeys.requests.detail(variables.requestId),
+          context.previousRequest
+        )
+      }
+    },
+    onSettled: (_data, _error, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.requests.detail(variables.requestId),
+      })
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.requests.all,
+      })
+    },
+  })
+}
+
+/** Remove vote from a request (with optimistic updates) */
+export function useRemoveVoteRequest() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ requestId }: { requestId: number }) =>
+      apiRequest<void>(API_ENDPOINTS.REQUESTS.VOTE(requestId), {
+        method: 'DELETE',
+      }),
+    onMutate: async ({ requestId }) => {
+      await queryClient.cancelQueries({
+        queryKey: queryKeys.requests.detail(requestId),
+      })
+
+      const previousRequest = queryClient.getQueryData<Request>(
+        queryKeys.requests.detail(requestId)
+      )
+
+      if (previousRequest) {
+        const oldVote = previousRequest.user_vote ?? 0
+        let upvoteDelta = 0
+        let downvoteDelta = 0
+
+        if (oldVote === 1) upvoteDelta = -1
+        else if (oldVote === -1) downvoteDelta = -1
+
+        queryClient.setQueryData<Request>(
+          queryKeys.requests.detail(requestId),
+          {
+            ...previousRequest,
+            user_vote: null,
+            upvotes: previousRequest.upvotes + upvoteDelta,
+            downvotes: previousRequest.downvotes + downvoteDelta,
+            vote_score: previousRequest.vote_score + upvoteDelta - downvoteDelta,
+          }
+        )
+      }
+
+      return { previousRequest }
+    },
+    onError: (_err, variables, context) => {
+      if (context?.previousRequest) {
+        queryClient.setQueryData(
+          queryKeys.requests.detail(variables.requestId),
+          context.previousRequest
+        )
+      }
+    },
+    onSettled: (_data, _error, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.requests.detail(variables.requestId),
+      })
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.requests.all,
+      })
+    },
+  })
+}
+
+/** Fulfill a request (admin) */
+export function useFulfillRequest() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      requestId,
+      fulfilled_entity_id,
+    }: {
+      requestId: number
+      fulfilled_entity_id?: number
+    }) =>
+      apiRequest<Request>(API_ENDPOINTS.REQUESTS.FULFILL(requestId), {
+        method: 'POST',
+        body: JSON.stringify({ fulfilled_entity_id }),
+      }),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.requests.all })
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.requests.detail(variables.requestId),
+      })
+    },
+  })
+}
+
+/** Close a request (admin) */
+export function useCloseRequest() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ requestId }: { requestId: number }) =>
+      apiRequest<Request>(API_ENDPOINTS.REQUESTS.CLOSE(requestId), {
+        method: 'POST',
+      }),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.requests.all })
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.requests.detail(variables.requestId),
+      })
+    },
+  })
+}

--- a/frontend/features/requests/index.ts
+++ b/frontend/features/requests/index.ts
@@ -1,0 +1,35 @@
+// Public API for the requests feature module.
+// Other features should import from '@/features/requests', not from internal paths.
+
+export type {
+  Request,
+  RequestListResponse,
+  RequestEntityType,
+  RequestStatus,
+  RequestSortBy,
+} from './types'
+
+export {
+  REQUEST_ENTITY_TYPES,
+  REQUEST_STATUSES,
+  REQUEST_SORT_OPTIONS,
+  getEntityTypeLabel,
+  getStatusLabel,
+  getEntityTypeColor,
+  getStatusColor,
+  getEntityUrl,
+  formatTimeAgo,
+  formatDate,
+} from './types'
+
+export {
+  useRequests,
+  useRequest,
+  useCreateRequest,
+  useUpdateRequest,
+  useDeleteRequest,
+  useVoteRequest,
+  useRemoveVoteRequest,
+  useFulfillRequest,
+  useCloseRequest,
+} from './hooks'

--- a/frontend/features/requests/types.ts
+++ b/frontend/features/requests/types.ts
@@ -1,0 +1,187 @@
+// Request types — aligned with backend contracts/request.go response types.
+
+export const REQUEST_ENTITY_TYPES = [
+  'artist',
+  'release',
+  'label',
+  'show',
+  'venue',
+  'festival',
+] as const
+
+export type RequestEntityType = (typeof REQUEST_ENTITY_TYPES)[number]
+
+export const REQUEST_STATUSES = [
+  'pending',
+  'in_progress',
+  'fulfilled',
+  'rejected',
+  'cancelled',
+] as const
+
+export type RequestStatus = (typeof REQUEST_STATUSES)[number]
+
+export const REQUEST_SORT_OPTIONS = ['votes', 'newest', 'oldest'] as const
+
+export type RequestSortBy = (typeof REQUEST_SORT_OPTIONS)[number]
+
+/** Request list item and detail response */
+export interface Request {
+  id: number
+  title: string
+  description?: string
+  entity_type: string
+  requested_entity_id?: number
+  status: string
+  requester_id: number
+  requester_name: string
+  fulfiller_id?: number
+  fulfiller_name?: string
+  vote_score: number
+  upvotes: number
+  downvotes: number
+  wilson_score: number
+  fulfilled_at?: string
+  /** 1 = upvote, -1 = downvote, null/undefined = no vote */
+  user_vote?: number | null
+  created_at: string
+  updated_at: string
+}
+
+/** List response shape */
+export interface RequestListResponse {
+  requests: Request[]
+  total: number
+}
+
+/** Helper: get a display label for an entity type */
+export function getEntityTypeLabel(entityType: string): string {
+  switch (entityType) {
+    case 'artist':
+      return 'Artist'
+    case 'venue':
+      return 'Venue'
+    case 'show':
+      return 'Show'
+    case 'release':
+      return 'Release'
+    case 'label':
+      return 'Label'
+    case 'festival':
+      return 'Festival'
+    default:
+      return entityType
+  }
+}
+
+/** Helper: get a display label for a request status */
+export function getStatusLabel(status: string): string {
+  switch (status) {
+    case 'pending':
+      return 'Pending'
+    case 'in_progress':
+      return 'In Progress'
+    case 'fulfilled':
+      return 'Fulfilled'
+    case 'rejected':
+      return 'Rejected'
+    case 'cancelled':
+      return 'Cancelled'
+    default:
+      return status
+  }
+}
+
+/** Helper: get a color class for entity type badge */
+export function getEntityTypeColor(entityType: string): string {
+  switch (entityType) {
+    case 'artist':
+      return 'bg-purple-500/15 text-purple-700 dark:text-purple-400'
+    case 'venue':
+      return 'bg-blue-500/15 text-blue-700 dark:text-blue-400'
+    case 'show':
+      return 'bg-green-500/15 text-green-700 dark:text-green-400'
+    case 'release':
+      return 'bg-orange-500/15 text-orange-700 dark:text-orange-400'
+    case 'label':
+      return 'bg-pink-500/15 text-pink-700 dark:text-pink-400'
+    case 'festival':
+      return 'bg-amber-500/15 text-amber-700 dark:text-amber-400'
+    default:
+      return 'bg-muted text-muted-foreground'
+  }
+}
+
+/** Helper: get a color class for status badge */
+export function getStatusColor(status: string): string {
+  switch (status) {
+    case 'pending':
+      return 'bg-yellow-500/15 text-yellow-700 dark:text-yellow-400'
+    case 'in_progress':
+      return 'bg-blue-500/15 text-blue-700 dark:text-blue-400'
+    case 'fulfilled':
+      return 'bg-green-500/15 text-green-700 dark:text-green-400'
+    case 'rejected':
+      return 'bg-red-500/15 text-red-700 dark:text-red-400'
+    case 'cancelled':
+      return 'bg-muted text-muted-foreground'
+    default:
+      return 'bg-muted text-muted-foreground'
+  }
+}
+
+/** Helper: format a date string as relative time (e.g., "3 hours ago") */
+export function formatTimeAgo(dateString: string): string {
+  const date = new Date(dateString)
+  const now = new Date()
+  const diffMs = now.getTime() - date.getTime()
+  const diffSeconds = Math.floor(diffMs / 1000)
+  const diffMinutes = Math.floor(diffSeconds / 60)
+  const diffHours = Math.floor(diffMinutes / 60)
+  const diffDays = Math.floor(diffHours / 24)
+  const diffWeeks = Math.floor(diffDays / 7)
+  const diffMonths = Math.floor(diffDays / 30)
+
+  if (diffSeconds < 60) return 'just now'
+  if (diffMinutes === 1) return '1 minute ago'
+  if (diffMinutes < 60) return `${diffMinutes} minutes ago`
+  if (diffHours === 1) return '1 hour ago'
+  if (diffHours < 24) return `${diffHours} hours ago`
+  if (diffDays === 1) return '1 day ago'
+  if (diffDays < 7) return `${diffDays} days ago`
+  if (diffWeeks === 1) return '1 week ago'
+  if (diffWeeks < 5) return `${diffWeeks} weeks ago`
+  if (diffMonths === 1) return '1 month ago'
+  if (diffMonths < 12) return `${diffMonths} months ago`
+  return formatDate(dateString)
+}
+
+/** Helper: format a date string as "Jan 5, 2026" */
+export function formatDate(dateString: string): string {
+  const date = new Date(dateString)
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+
+/** Helper: build entity URL from entity type and ID */
+export function getEntityUrl(entityType: string, entityId: number): string {
+  switch (entityType) {
+    case 'artist':
+      return `/artists/${entityId}`
+    case 'venue':
+      return `/venues/${entityId}`
+    case 'show':
+      return `/shows/${entityId}`
+    case 'release':
+      return `/releases/${entityId}`
+    case 'label':
+      return `/labels/${entityId}`
+    case 'festival':
+      return `/festivals/${entityId}`
+    default:
+      return '#'
+  }
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -325,6 +325,18 @@ export const API_ENDPOINTS = {
     MY: `${API_BASE_URL}/auth/collections`,
   },
 
+  // Request endpoints
+  REQUESTS: {
+    LIST: `${API_BASE_URL}/requests`,
+    GET: (requestId: string | number) => `${API_BASE_URL}/requests/${requestId}`,
+    VOTE: (requestId: string | number) =>
+      `${API_BASE_URL}/requests/${requestId}/vote`,
+    FULFILL: (requestId: string | number) =>
+      `${API_BASE_URL}/requests/${requestId}/fulfill`,
+    CLOSE: (requestId: string | number) =>
+      `${API_BASE_URL}/requests/${requestId}/close`,
+  },
+
   // Revision history endpoints
   REVISIONS: {
     ENTITY_HISTORY: (entityType: string, entityId: string | number) =>

--- a/frontend/lib/queryClient.ts
+++ b/frontend/lib/queryClient.ts
@@ -278,6 +278,15 @@ export const queryKeys = {
     my: ['collections', 'my'] as const,
   },
 
+  // Request queries
+  requests: {
+    all: ['requests'] as const,
+    list: (params?: Record<string, unknown>) =>
+      ['requests', 'list', params] as const,
+    detail: (requestId: number) =>
+      ['requests', 'detail', requestId] as const,
+  },
+
   // Revision history queries
   revisions: {
     all: ['revisions'] as const,
@@ -369,6 +378,10 @@ export const createInvalidateQueries = (queryClient: QueryClient) => ({
   // Invalidate collection queries
   collections: () =>
     queryClient.invalidateQueries({ queryKey: ['collections'] }),
+
+  // Invalidate request queries
+  requests: () =>
+    queryClient.invalidateQueries({ queryKey: ['requests'] }),
 
   // Invalidate revision queries
   revisions: () =>


### PR DESCRIPTION
## Summary
- New `features/requests/` feature module with types, 9 hooks (optimistic vote updates), 3 components
- **RequestList**: browse page with entity type / status / sort filter bar, "New Request" create dialog, paginated card grid
- **RequestDetail**: full detail with large vote widget, inline edit (title/description), admin fulfill/close, entity link
- **RequestCard**: compact card with inline voting (thumbs up/down), entity type + status badges, description preview
- Pages at `/requests` and `/requests/[id]`
- Sidebar nav link (Community section) + Cmd+K command palette entry
- API endpoints and query keys added to `api.ts` / `queryClient.ts`

## Test plan
- [x] `npx tsc --noEmit` compiles cleanly
- [ ] Manual: browse requests, create request, vote, edit, fulfill, close
- [ ] Verify optimistic vote updates and rollback on error

Closes PSY-72

🤖 Generated with [Claude Code](https://claude.com/claude-code)