### PR TITLE
Make CI checks non-blocking for coverage and E2E

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
 
   e2e-tests:
     name: E2E Tests
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
## Summary
- Add `codecov.yml` with `informational: true` on both project and patch status checks — coverage reports still appear on PRs but never fail the build
- Limit E2E test suite to pushes to `main` only (skip on PR branches)

## Test plan
- [ ] Open a PR and verify Codecov posts a report but doesn't show a failing check
- [ ] Verify E2E tests don't run on PR, but do run on merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)