### PR TITLE
Add tag service, handlers, and API routes (PSY-50)

### DIFF
--- a/backend/internal/api/handlers/tag.go
+++ b/backend/internal/api/handlers/tag.go
@@ -1,0 +1,702 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"psychic-homily-backend/internal/api/middleware"
+	apperrors "psychic-homily-backend/internal/errors"
+	"psychic-homily-backend/internal/logger"
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// TagHandler handles tag-related API requests.
+type TagHandler struct {
+	tagService services.TagServiceInterface
+	auditLog   services.AuditLogServiceInterface
+}
+
+// NewTagHandler creates a new TagHandler.
+func NewTagHandler(tagService services.TagServiceInterface, auditLog services.AuditLogServiceInterface) *TagHandler {
+	return &TagHandler{
+		tagService: tagService,
+		auditLog:   auditLog,
+	}
+}
+
+// ============================================================================
+// List Tags (public)
+// ============================================================================
+
+type ListTagsRequest struct {
+	Category string `query:"category" required:"false" doc:"Filter by category (genre, mood, era, style, instrument, locale, other)"`
+	Search   string `query:"search" required:"false" doc:"Search tags by name"`
+	ParentID uint   `query:"parent_id" required:"false" doc:"Filter by parent tag ID"`
+	Sort     string `query:"sort" required:"false" doc:"Sort by: usage, name, created (default: usage)"`
+	Limit    int    `query:"limit" required:"false" doc:"Max results (default 50)" example:"50"`
+	Offset   int    `query:"offset" required:"false" doc:"Offset for pagination" example:"0"`
+}
+
+type ListTagsResponse struct {
+	Body struct {
+		Tags  []contracts.TagListItem `json:"tags"`
+		Total int64                   `json:"total"`
+	}
+}
+
+func (h *TagHandler) ListTagsHandler(ctx context.Context, req *ListTagsRequest) (*ListTagsResponse, error) {
+	var parentID *uint
+	if req.ParentID > 0 {
+		parentID = &req.ParentID
+	}
+
+	tags, total, err := h.tagService.ListTags(req.Category, req.Search, parentID, req.Sort, req.Limit, req.Offset)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Failed to list tags")
+	}
+
+	items := make([]contracts.TagListItem, len(tags))
+	for i, t := range tags {
+		items[i] = contracts.TagListItem{
+			ID:         t.ID,
+			Name:       t.Name,
+			Slug:       t.Slug,
+			Category:   t.Category,
+			IsOfficial: t.IsOfficial,
+			UsageCount: t.UsageCount,
+			CreatedAt:  t.CreatedAt,
+		}
+	}
+
+	resp := &ListTagsResponse{}
+	resp.Body.Tags = items
+	resp.Body.Total = total
+	return resp, nil
+}
+
+// ============================================================================
+// Get Tag (public)
+// ============================================================================
+
+type GetTagRequest struct {
+	TagID string `path:"tag_id" doc:"Tag ID or slug" example:"post-punk"`
+}
+
+type GetTagResponse struct {
+	Body *contracts.TagResponse
+}
+
+func (h *TagHandler) GetTagHandler(ctx context.Context, req *GetTagRequest) (*GetTagResponse, error) {
+	tag := h.resolveTag(req.TagID)
+	if tag == nil {
+		return nil, huma.Error404NotFound("Tag not found")
+	}
+
+	resp := buildTagResponse(tag)
+	return &GetTagResponse{Body: resp}, nil
+}
+
+// ============================================================================
+// Search Tags (public, autocomplete)
+// ============================================================================
+
+type SearchTagsRequest struct {
+	Query string `query:"q" doc:"Search query" example:"post"`
+	Limit int    `query:"limit" required:"false" doc:"Max results (default 10)" example:"10"`
+}
+
+type SearchTagsResponse struct {
+	Body struct {
+		Tags []contracts.TagListItem `json:"tags"`
+	}
+}
+
+func (h *TagHandler) SearchTagsHandler(ctx context.Context, req *SearchTagsRequest) (*SearchTagsResponse, error) {
+	if req.Query == "" {
+		return nil, huma.Error400BadRequest("Query parameter 'q' is required")
+	}
+
+	tags, err := h.tagService.SearchTags(req.Query, req.Limit)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Failed to search tags")
+	}
+
+	items := make([]contracts.TagListItem, len(tags))
+	for i, t := range tags {
+		items[i] = contracts.TagListItem{
+			ID:         t.ID,
+			Name:       t.Name,
+			Slug:       t.Slug,
+			Category:   t.Category,
+			IsOfficial: t.IsOfficial,
+			UsageCount: t.UsageCount,
+			CreatedAt:  t.CreatedAt,
+		}
+	}
+
+	resp := &SearchTagsResponse{}
+	resp.Body.Tags = items
+	return resp, nil
+}
+
+// ============================================================================
+// List Entity Tags (optional auth)
+// ============================================================================
+
+type ListEntityTagsRequest struct {
+	EntityType string `path:"entity_type" doc:"Entity type (artist, release, label, show, venue, festival)" example:"artist"`
+	EntityID   string `path:"entity_id" doc:"Entity ID" example:"1"`
+}
+
+type ListEntityTagsResponse struct {
+	Body struct {
+		Tags []contracts.EntityTagResponse `json:"tags"`
+	}
+}
+
+func (h *TagHandler) ListEntityTagsHandler(ctx context.Context, req *ListEntityTagsRequest) (*ListEntityTagsResponse, error) {
+	entityID, err := strconv.ParseUint(req.EntityID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid entity ID")
+	}
+
+	var userID uint
+	user := middleware.GetUserFromContext(ctx)
+	if user != nil {
+		userID = user.ID
+	}
+
+	tags, err := h.tagService.ListEntityTags(req.EntityType, uint(entityID), userID)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Failed to list entity tags")
+	}
+
+	resp := &ListEntityTagsResponse{}
+	resp.Body.Tags = tags
+	return resp, nil
+}
+
+// ============================================================================
+// Add Tag to Entity (protected)
+// ============================================================================
+
+type AddTagToEntityRequest struct {
+	EntityType string `path:"entity_type" doc:"Entity type" example:"artist"`
+	EntityID   string `path:"entity_id" doc:"Entity ID" example:"1"`
+	Body       struct {
+		TagID   uint   `json:"tag_id" required:"false" doc:"Tag ID (provide tag_id or tag_name)"`
+		TagName string `json:"tag_name" required:"false" doc:"Tag name (with alias resolution)"`
+	}
+}
+
+func (h *TagHandler) AddTagToEntityHandler(ctx context.Context, req *AddTagToEntityRequest) (*struct{}, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	entityID, err := strconv.ParseUint(req.EntityID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid entity ID")
+	}
+
+	if req.Body.TagID == 0 && req.Body.TagName == "" {
+		return nil, huma.Error400BadRequest("Either tag_id or tag_name is required")
+	}
+
+	_, err = h.tagService.AddTagToEntity(req.Body.TagID, req.Body.TagName, req.EntityType, uint(entityID), user.ID)
+	if err != nil {
+		mapped := mapTagError(err)
+		if mapped != nil {
+			return nil, mapped
+		}
+		requestID := logger.GetRequestID(ctx)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to add tag (request_id: %s)", requestID),
+		)
+	}
+
+	return nil, nil
+}
+
+// ============================================================================
+// Remove Tag from Entity (protected)
+// ============================================================================
+
+type RemoveTagFromEntityRequest struct {
+	EntityType string `path:"entity_type" doc:"Entity type" example:"artist"`
+	EntityID   string `path:"entity_id" doc:"Entity ID" example:"1"`
+	TagID      string `path:"tag_id" doc:"Tag ID" example:"1"`
+}
+
+func (h *TagHandler) RemoveTagFromEntityHandler(ctx context.Context, req *RemoveTagFromEntityRequest) (*struct{}, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	entityID, err := strconv.ParseUint(req.EntityID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid entity ID")
+	}
+	tagID, err := strconv.ParseUint(req.TagID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid tag ID")
+	}
+
+	err = h.tagService.RemoveTagFromEntity(uint(tagID), req.EntityType, uint(entityID))
+	if err != nil {
+		mapped := mapTagError(err)
+		if mapped != nil {
+			return nil, mapped
+		}
+		return nil, huma.Error500InternalServerError("Failed to remove tag")
+	}
+
+	return nil, nil
+}
+
+// ============================================================================
+// Vote on Tag (protected)
+// ============================================================================
+
+type VoteTagRequest struct {
+	TagID      string `path:"tag_id" doc:"Tag ID" example:"1"`
+	EntityType string `path:"entity_type" doc:"Entity type" example:"artist"`
+	EntityID   string `path:"entity_id" doc:"Entity ID" example:"1"`
+	Body       struct {
+		IsUpvote bool `json:"is_upvote" doc:"True for upvote, false for downvote"`
+	}
+}
+
+func (h *TagHandler) VoteTagHandler(ctx context.Context, req *VoteTagRequest) (*struct{}, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	tagID, err := strconv.ParseUint(req.TagID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid tag ID")
+	}
+	entityID, err := strconv.ParseUint(req.EntityID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid entity ID")
+	}
+
+	err = h.tagService.VoteOnTag(uint(tagID), req.EntityType, uint(entityID), user.ID, req.Body.IsUpvote)
+	if err != nil {
+		mapped := mapTagError(err)
+		if mapped != nil {
+			return nil, mapped
+		}
+		return nil, huma.Error500InternalServerError("Failed to vote on tag")
+	}
+
+	return nil, nil
+}
+
+// ============================================================================
+// Remove Tag Vote (protected)
+// ============================================================================
+
+type RemoveTagVoteRequest struct {
+	TagID      string `path:"tag_id" doc:"Tag ID" example:"1"`
+	EntityType string `path:"entity_type" doc:"Entity type" example:"artist"`
+	EntityID   string `path:"entity_id" doc:"Entity ID" example:"1"`
+}
+
+func (h *TagHandler) RemoveTagVoteHandler(ctx context.Context, req *RemoveTagVoteRequest) (*struct{}, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	tagID, err := strconv.ParseUint(req.TagID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid tag ID")
+	}
+	entityID, err := strconv.ParseUint(req.EntityID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid entity ID")
+	}
+
+	err = h.tagService.RemoveTagVote(uint(tagID), req.EntityType, uint(entityID), user.ID)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Failed to remove vote")
+	}
+
+	return nil, nil
+}
+
+// ============================================================================
+// Create Tag (admin)
+// ============================================================================
+
+type CreateTagRequest struct {
+	Body struct {
+		Name        string  `json:"name" doc:"Tag name" example:"post-punk"`
+		Description *string `json:"description" required:"false" doc:"Tag description"`
+		ParentID    *uint   `json:"parent_id" required:"false" doc:"Parent tag ID for hierarchy"`
+		Category    string  `json:"category" doc:"Tag category (genre, mood, era, style, instrument, locale, other)" example:"genre"`
+		IsOfficial  bool    `json:"is_official" required:"false" doc:"Whether this is an official/canonical tag"`
+	}
+}
+
+type CreateTagResponse struct {
+	Body *contracts.TagResponse
+}
+
+func (h *TagHandler) CreateTagHandler(ctx context.Context, req *CreateTagRequest) (*CreateTagResponse, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+	if !user.IsAdmin {
+		return nil, huma.Error403Forbidden("Admin access required")
+	}
+
+	if req.Body.Name == "" {
+		return nil, huma.Error400BadRequest("Name is required")
+	}
+	if req.Body.Category == "" {
+		return nil, huma.Error400BadRequest("Category is required")
+	}
+
+	tag, err := h.tagService.CreateTag(req.Body.Name, req.Body.Description, req.Body.ParentID, req.Body.Category, req.Body.IsOfficial)
+	if err != nil {
+		mapped := mapTagError(err)
+		if mapped != nil {
+			return nil, mapped
+		}
+		requestID := logger.GetRequestID(ctx)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to create tag (request_id: %s)", requestID),
+		)
+	}
+
+	// Audit log (fire and forget)
+	if h.auditLog != nil {
+		go func() {
+			h.auditLog.LogAction(user.ID, "create_tag", "tag", tag.ID, map[string]interface{}{
+				"name":     tag.Name,
+				"category": tag.Category,
+			})
+		}()
+	}
+
+	// Re-fetch with preloads
+	fullTag, _ := h.tagService.GetTag(tag.ID)
+	if fullTag == nil {
+		fullTag = tag
+	}
+
+	resp := buildTagResponse(fullTag)
+	return &CreateTagResponse{Body: resp}, nil
+}
+
+// ============================================================================
+// Update Tag (admin)
+// ============================================================================
+
+type UpdateTagRequest struct {
+	TagID string `path:"tag_id" doc:"Tag ID" example:"1"`
+	Body  struct {
+		Name        *string `json:"name" required:"false" doc:"Tag name"`
+		Description *string `json:"description" required:"false" doc:"Tag description"`
+		ParentID    *uint   `json:"parent_id" required:"false" doc:"Parent tag ID"`
+		Category    *string `json:"category" required:"false" doc:"Tag category"`
+		IsOfficial  *bool   `json:"is_official" required:"false" doc:"Whether this is official"`
+	}
+}
+
+type UpdateTagResponse struct {
+	Body *contracts.TagResponse
+}
+
+func (h *TagHandler) UpdateTagHandler(ctx context.Context, req *UpdateTagRequest) (*UpdateTagResponse, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+	if !user.IsAdmin {
+		return nil, huma.Error403Forbidden("Admin access required")
+	}
+
+	id, err := strconv.ParseUint(req.TagID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid tag ID")
+	}
+
+	tag, err := h.tagService.UpdateTag(uint(id), req.Body.Name, req.Body.Description, req.Body.ParentID, req.Body.Category, req.Body.IsOfficial)
+	if err != nil {
+		mapped := mapTagError(err)
+		if mapped != nil {
+			return nil, mapped
+		}
+		return nil, huma.Error500InternalServerError("Failed to update tag")
+	}
+
+	// Audit log (fire and forget)
+	if h.auditLog != nil {
+		go func() {
+			h.auditLog.LogAction(user.ID, "update_tag", "tag", uint(id), nil)
+		}()
+	}
+
+	resp := buildTagResponse(tag)
+	return &UpdateTagResponse{Body: resp}, nil
+}
+
+// ============================================================================
+// Delete Tag (admin)
+// ============================================================================
+
+type DeleteTagRequest struct {
+	TagID string `path:"tag_id" doc:"Tag ID" example:"1"`
+}
+
+func (h *TagHandler) DeleteTagHandler(ctx context.Context, req *DeleteTagRequest) (*struct{}, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+	if !user.IsAdmin {
+		return nil, huma.Error403Forbidden("Admin access required")
+	}
+
+	id, err := strconv.ParseUint(req.TagID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid tag ID")
+	}
+
+	err = h.tagService.DeleteTag(uint(id))
+	if err != nil {
+		mapped := mapTagError(err)
+		if mapped != nil {
+			return nil, mapped
+		}
+		return nil, huma.Error500InternalServerError("Failed to delete tag")
+	}
+
+	// Audit log (fire and forget)
+	if h.auditLog != nil {
+		go func() {
+			h.auditLog.LogAction(user.ID, "delete_tag", "tag", uint(id), nil)
+		}()
+	}
+
+	return nil, nil
+}
+
+// ============================================================================
+// List Aliases (public)
+// ============================================================================
+
+type ListAliasesRequest struct {
+	TagID string `path:"tag_id" doc:"Tag ID or slug" example:"post-punk"`
+}
+
+type ListAliasesResponse struct {
+	Body struct {
+		Aliases []contracts.TagAliasResponse `json:"aliases"`
+	}
+}
+
+func (h *TagHandler) ListAliasesHandler(ctx context.Context, req *ListAliasesRequest) (*ListAliasesResponse, error) {
+	tag := h.resolveTag(req.TagID)
+	if tag == nil {
+		return nil, huma.Error404NotFound("Tag not found")
+	}
+
+	aliases, err := h.tagService.ListAliases(tag.ID)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Failed to list aliases")
+	}
+
+	items := make([]contracts.TagAliasResponse, len(aliases))
+	for i, a := range aliases {
+		items[i] = contracts.TagAliasResponse{
+			ID:        a.ID,
+			Alias:     a.Alias,
+			CreatedAt: a.CreatedAt,
+		}
+	}
+
+	resp := &ListAliasesResponse{}
+	resp.Body.Aliases = items
+	return resp, nil
+}
+
+// ============================================================================
+// Create Alias (admin)
+// ============================================================================
+
+type CreateAliasRequest struct {
+	TagID string `path:"tag_id" doc:"Tag ID" example:"1"`
+	Body  struct {
+		Alias string `json:"alias" doc:"Alias name" example:"post punk"`
+	}
+}
+
+type CreateAliasResponse struct {
+	Body *contracts.TagAliasResponse
+}
+
+func (h *TagHandler) CreateAliasHandler(ctx context.Context, req *CreateAliasRequest) (*CreateAliasResponse, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+	if !user.IsAdmin {
+		return nil, huma.Error403Forbidden("Admin access required")
+	}
+
+	id, err := strconv.ParseUint(req.TagID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid tag ID")
+	}
+
+	if req.Body.Alias == "" {
+		return nil, huma.Error400BadRequest("Alias is required")
+	}
+
+	alias, err := h.tagService.CreateAlias(uint(id), req.Body.Alias)
+	if err != nil {
+		mapped := mapTagError(err)
+		if mapped != nil {
+			return nil, mapped
+		}
+		return nil, huma.Error500InternalServerError("Failed to create alias")
+	}
+
+	// Audit log (fire and forget)
+	if h.auditLog != nil {
+		go func() {
+			h.auditLog.LogAction(user.ID, "create_tag_alias", "tag", uint(id), map[string]interface{}{
+				"alias": req.Body.Alias,
+			})
+		}()
+	}
+
+	resp := &contracts.TagAliasResponse{
+		ID:        alias.ID,
+		Alias:     alias.Alias,
+		CreatedAt: alias.CreatedAt,
+	}
+	return &CreateAliasResponse{Body: resp}, nil
+}
+
+// ============================================================================
+// Delete Alias (admin)
+// ============================================================================
+
+type DeleteAliasRequest struct {
+	TagID   string `path:"tag_id" doc:"Tag ID" example:"1"`
+	AliasID string `path:"alias_id" doc:"Alias ID" example:"1"`
+}
+
+func (h *TagHandler) DeleteAliasHandler(ctx context.Context, req *DeleteAliasRequest) (*struct{}, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+	if !user.IsAdmin {
+		return nil, huma.Error403Forbidden("Admin access required")
+	}
+
+	aliasID, err := strconv.ParseUint(req.AliasID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid alias ID")
+	}
+
+	err = h.tagService.DeleteAlias(uint(aliasID))
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Failed to delete alias")
+	}
+
+	// Audit log (fire and forget)
+	if h.auditLog != nil {
+		tagID, _ := strconv.ParseUint(req.TagID, 10, 32)
+		go func() {
+			h.auditLog.LogAction(user.ID, "delete_tag_alias", "tag", uint(tagID), map[string]interface{}{
+				"alias_id": uint(aliasID),
+			})
+		}()
+	}
+
+	return nil, nil
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+// resolveTag resolves a tag by numeric ID or slug.
+func (h *TagHandler) resolveTag(idOrSlug string) *models.Tag {
+	// Try numeric ID first
+	if id, err := strconv.ParseUint(idOrSlug, 10, 32); err == nil {
+		tag, err := h.tagService.GetTag(uint(id))
+		if err == nil && tag != nil {
+			return tag
+		}
+	}
+	// Fall back to slug
+	tag, err := h.tagService.GetTagBySlug(idOrSlug)
+	if err == nil && tag != nil {
+		return tag
+	}
+	return nil
+}
+
+// buildTagResponse converts a models.Tag to a TagResponse.
+func buildTagResponse(tag *models.Tag) *contracts.TagResponse {
+	resp := &contracts.TagResponse{
+		ID:         tag.ID,
+		Name:       tag.Name,
+		Slug:       tag.Slug,
+		Description: tag.Description,
+		ParentID:   tag.ParentID,
+		Category:   tag.Category,
+		IsOfficial: tag.IsOfficial,
+		UsageCount: tag.UsageCount,
+		ChildCount: len(tag.Children),
+		CreatedAt:  tag.CreatedAt,
+		UpdatedAt:  tag.UpdatedAt,
+	}
+
+	if tag.Parent != nil {
+		resp.ParentName = tag.Parent.Name
+	}
+
+	if len(tag.Aliases) > 0 {
+		resp.Aliases = make([]string, len(tag.Aliases))
+		for i, a := range tag.Aliases {
+			resp.Aliases[i] = a.Alias
+		}
+	}
+
+	return resp
+}
+
+// mapTagError converts a TagError to an appropriate Huma HTTP error.
+func mapTagError(err error) error {
+	var tagErr *apperrors.TagError
+	if errors.As(err, &tagErr) {
+		switch tagErr.Code {
+		case apperrors.CodeTagNotFound:
+			return huma.Error404NotFound(tagErr.Message)
+		case apperrors.CodeTagExists, apperrors.CodeTagAliasExists, apperrors.CodeEntityTagExists:
+			return huma.Error409Conflict(tagErr.Message)
+		case apperrors.CodeEntityTagNotFound:
+			return huma.Error404NotFound(tagErr.Message)
+		}
+	}
+	return nil
+}

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -98,6 +98,7 @@ func SetupRoutes(router *chi.Mux, sc *services.ServiceContainer, cfg *config.Con
 	setupCollectionRoutes(api, protectedGroup, sc)
 	setupRequestRoutes(api, protectedGroup, sc)
 	setupRevisionRoutes(api, protectedGroup, sc)
+	setupTagRoutes(api, protectedGroup, sc)
 
 	return api
 }
@@ -627,6 +628,37 @@ func setupRevisionRoutes(api huma.API, protected *huma.Group, sc *services.Servi
 
 	// Admin rollback endpoint
 	huma.Post(protected, "/admin/revisions/{revision_id}/rollback", revisionHandler.RollbackRevisionHandler)
+}
+
+// setupTagRoutes configures tag, entity tagging, and tag voting endpoints.
+// Public endpoints for browsing tags. Optional auth for entity tags (user's vote).
+// Protected endpoints for tagging and voting. Admin endpoints for tag CRUD and aliases.
+func setupTagRoutes(api huma.API, protected *huma.Group, sc *services.ServiceContainer) {
+	tagHandler := handlers.NewTagHandler(sc.Tag, sc.AuditLog)
+
+	// Public tag endpoints
+	huma.Get(api, "/tags", tagHandler.ListTagsHandler)
+	huma.Get(api, "/tags/search", tagHandler.SearchTagsHandler)
+	huma.Get(api, "/tags/{tag_id}", tagHandler.GetTagHandler)
+	huma.Get(api, "/tags/{tag_id}/aliases", tagHandler.ListAliasesHandler)
+
+	// Entity tags with optional auth (includes user's vote if authenticated)
+	optionalAuthGroup := huma.NewGroup(api, "")
+	optionalAuthGroup.UseMiddleware(middleware.OptionalHumaJWTMiddleware(sc.JWT))
+	huma.Get(optionalAuthGroup, "/entities/{entity_type}/{entity_id}/tags", tagHandler.ListEntityTagsHandler)
+
+	// Protected: tagging and voting
+	huma.Post(protected, "/entities/{entity_type}/{entity_id}/tags", tagHandler.AddTagToEntityHandler)
+	huma.Delete(protected, "/entities/{entity_type}/{entity_id}/tags/{tag_id}", tagHandler.RemoveTagFromEntityHandler)
+	huma.Post(protected, "/tags/{tag_id}/entities/{entity_type}/{entity_id}/votes", tagHandler.VoteTagHandler)
+	huma.Delete(protected, "/tags/{tag_id}/entities/{entity_type}/{entity_id}/votes", tagHandler.RemoveTagVoteHandler)
+
+	// Admin: tag CRUD and alias management
+	huma.Post(protected, "/tags", tagHandler.CreateTagHandler)
+	huma.Put(protected, "/tags/{tag_id}", tagHandler.UpdateTagHandler)
+	huma.Delete(protected, "/tags/{tag_id}", tagHandler.DeleteTagHandler)
+	huma.Post(protected, "/tags/{tag_id}/aliases", tagHandler.CreateAliasHandler)
+	huma.Delete(protected, "/tags/{tag_id}/aliases/{alias_id}", tagHandler.DeleteAliasHandler)
 }
 
 // rateLimitHandler handles rate limit exceeded responses with JSON

--- a/backend/internal/errors/tag.go
+++ b/backend/internal/errors/tag.go
@@ -1,0 +1,82 @@
+package errors
+
+import (
+	"fmt"
+)
+
+// Tag error codes
+const (
+	CodeTagNotFound       = "TAG_NOT_FOUND"
+	CodeTagExists         = "TAG_EXISTS"
+	CodeTagAliasExists    = "TAG_ALIAS_EXISTS"
+	CodeEntityTagExists   = "ENTITY_TAG_EXISTS"
+	CodeEntityTagNotFound = "ENTITY_TAG_NOT_FOUND"
+)
+
+// TagError represents a tag-related error with additional context.
+type TagError struct {
+	Code     string
+	Message  string
+	Internal error
+}
+
+// Error implements the error interface.
+func (e *TagError) Error() string {
+	if e.Internal != nil {
+		return fmt.Sprintf("%s: %s (internal: %v)", e.Code, e.Message, e.Internal)
+	}
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
+// Unwrap returns the internal error for errors.Is/As compatibility.
+func (e *TagError) Unwrap() error {
+	return e.Internal
+}
+
+// ErrTagNotFound creates a tag not found error.
+func ErrTagNotFound(tagID uint) *TagError {
+	return &TagError{
+		Code:    CodeTagNotFound,
+		Message: fmt.Sprintf("Tag %d not found", tagID),
+	}
+}
+
+// ErrTagNotFoundBySlug creates a tag not found by slug error.
+func ErrTagNotFoundBySlug(slug string) *TagError {
+	return &TagError{
+		Code:    CodeTagNotFound,
+		Message: fmt.Sprintf("Tag '%s' not found", slug),
+	}
+}
+
+// ErrTagExists creates a duplicate tag error.
+func ErrTagExists(name string) *TagError {
+	return &TagError{
+		Code:    CodeTagExists,
+		Message: fmt.Sprintf("Tag '%s' already exists", name),
+	}
+}
+
+// ErrTagAliasExists creates a duplicate alias error.
+func ErrTagAliasExists(alias string) *TagError {
+	return &TagError{
+		Code:    CodeTagAliasExists,
+		Message: fmt.Sprintf("Alias '%s' already exists", alias),
+	}
+}
+
+// ErrEntityTagExists creates a duplicate entity tag error.
+func ErrEntityTagExists(tagID uint, entityType string, entityID uint) *TagError {
+	return &TagError{
+		Code:    CodeEntityTagExists,
+		Message: fmt.Sprintf("Tag %d already applied to %s %d", tagID, entityType, entityID),
+	}
+}
+
+// ErrEntityTagNotFound creates an entity tag not found error.
+func ErrEntityTagNotFound(tagID uint, entityType string, entityID uint) *TagError {
+	return &TagError{
+		Code:    CodeEntityTagNotFound,
+		Message: fmt.Sprintf("Tag %d not applied to %s %d", tagID, entityType, entityID),
+	}
+}

--- a/backend/internal/services/catalog/tag_service.go
+++ b/backend/internal/services/catalog/tag_service.go
@@ -1,0 +1,669 @@
+package catalog
+
+import (
+	"fmt"
+	"math"
+	"strings"
+
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/db"
+	apperrors "psychic-homily-backend/internal/errors"
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/utils"
+)
+
+// TagService handles tag business logic.
+type TagService struct {
+	db *gorm.DB
+}
+
+// NewTagService creates a new tag service.
+func NewTagService(database *gorm.DB) *TagService {
+	if database == nil {
+		database = db.GetDB()
+	}
+	return &TagService{db: database}
+}
+
+// ──────────────────────────────────────────────
+// CRUD
+// ──────────────────────────────────────────────
+
+// CreateTag creates a new tag.
+func (s *TagService) CreateTag(name string, description *string, parentID *uint, category string, isOfficial bool) (*models.Tag, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	if !models.IsValidTagCategory(category) {
+		return nil, fmt.Errorf("invalid tag category: %s", category)
+	}
+
+	// Check for duplicate name (case-insensitive)
+	var existing models.Tag
+	if err := s.db.Where("LOWER(name) = LOWER(?)", name).First(&existing).Error; err == nil {
+		return nil, apperrors.ErrTagExists(name)
+	}
+
+	// Generate slug
+	baseSlug := utils.GenerateSlug(name)
+	slug := utils.GenerateUniqueSlug(baseSlug, func(candidate string) bool {
+		var count int64
+		s.db.Model(&models.Tag{}).Where("slug = ?", candidate).Count(&count)
+		return count > 0
+	})
+
+	tag := &models.Tag{
+		Name:        name,
+		Slug:        slug,
+		Description: description,
+		ParentID:    parentID,
+		Category:    category,
+		IsOfficial:  isOfficial,
+	}
+
+	if err := s.db.Create(tag).Error; err != nil {
+		return nil, fmt.Errorf("failed to create tag: %w", err)
+	}
+
+	return tag, nil
+}
+
+// GetTag retrieves a tag by ID with relationships.
+func (s *TagService) GetTag(tagID uint) (*models.Tag, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var tag models.Tag
+	err := s.db.Preload("Parent").Preload("Children").Preload("Aliases").First(&tag, tagID).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get tag: %w", err)
+	}
+
+	return &tag, nil
+}
+
+// GetTagBySlug retrieves a tag by slug with relationships.
+func (s *TagService) GetTagBySlug(slug string) (*models.Tag, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var tag models.Tag
+	err := s.db.Preload("Parent").Preload("Children").Preload("Aliases").
+		Where("slug = ?", slug).First(&tag).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get tag by slug: %w", err)
+	}
+
+	return &tag, nil
+}
+
+// ListTags retrieves tags with optional filtering and sorting.
+func (s *TagService) ListTags(category string, search string, parentID *uint, sort string, limit, offset int) ([]models.Tag, int64, error) {
+	if s.db == nil {
+		return nil, 0, fmt.Errorf("database not initialized")
+	}
+
+	query := s.db.Model(&models.Tag{})
+
+	if category != "" {
+		query = query.Where("category = ?", category)
+	}
+	if search != "" {
+		query = query.Where("LOWER(name) LIKE LOWER(?)", "%"+search+"%")
+	}
+	if parentID != nil {
+		query = query.Where("parent_id = ?", *parentID)
+	}
+
+	var total int64
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, fmt.Errorf("failed to count tags: %w", err)
+	}
+
+	switch sort {
+	case "name":
+		query = query.Order("name ASC")
+	case "created":
+		query = query.Order("created_at DESC")
+	default: // "usage" or empty
+		query = query.Order("usage_count DESC, name ASC")
+	}
+
+	if limit <= 0 {
+		limit = 50
+	}
+	query = query.Limit(limit).Offset(offset)
+
+	var tags []models.Tag
+	if err := query.Find(&tags).Error; err != nil {
+		return nil, 0, fmt.Errorf("failed to list tags: %w", err)
+	}
+
+	return tags, total, nil
+}
+
+// UpdateTag updates a tag's fields.
+func (s *TagService) UpdateTag(tagID uint, name *string, description *string, parentID *uint, category *string, isOfficial *bool) (*models.Tag, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var tag models.Tag
+	if err := s.db.First(&tag, tagID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, apperrors.ErrTagNotFound(tagID)
+		}
+		return nil, fmt.Errorf("failed to get tag: %w", err)
+	}
+
+	updates := map[string]interface{}{}
+	if name != nil {
+		updates["name"] = *name
+		// Regenerate slug
+		baseSlug := utils.GenerateSlug(*name)
+		slug := utils.GenerateUniqueSlug(baseSlug, func(candidate string) bool {
+			var count int64
+			s.db.Model(&models.Tag{}).Where("slug = ? AND id != ?", candidate, tagID).Count(&count)
+			return count > 0
+		})
+		updates["slug"] = slug
+	}
+	if description != nil {
+		updates["description"] = *description
+	}
+	if parentID != nil {
+		updates["parent_id"] = *parentID
+	}
+	if category != nil {
+		if !models.IsValidTagCategory(*category) {
+			return nil, fmt.Errorf("invalid tag category: %s", *category)
+		}
+		updates["category"] = *category
+	}
+	if isOfficial != nil {
+		updates["is_official"] = *isOfficial
+	}
+
+	if len(updates) > 0 {
+		if err := s.db.Model(&tag).Updates(updates).Error; err != nil {
+			return nil, fmt.Errorf("failed to update tag: %w", err)
+		}
+	}
+
+	return s.GetTag(tagID)
+}
+
+// DeleteTag deletes a tag and all associated data (cascaded by FK).
+func (s *TagService) DeleteTag(tagID uint) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	result := s.db.Delete(&models.Tag{}, tagID)
+	if result.Error != nil {
+		return fmt.Errorf("failed to delete tag: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return apperrors.ErrTagNotFound(tagID)
+	}
+
+	return nil
+}
+
+// ──────────────────────────────────────────────
+// Entity tagging
+// ──────────────────────────────────────────────
+
+// AddTagToEntity applies a tag to an entity. Supports tag ID or name (with alias resolution).
+func (s *TagService) AddTagToEntity(tagID uint, tagName string, entityType string, entityID uint, userID uint) (*models.EntityTag, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	if !models.IsValidTagEntityType(entityType) {
+		return nil, fmt.Errorf("invalid entity type: %s", entityType)
+	}
+
+	// Resolve tag by ID or name
+	var tag *models.Tag
+	if tagID > 0 {
+		var t models.Tag
+		if err := s.db.First(&t, tagID).Error; err != nil {
+			if err == gorm.ErrRecordNotFound {
+				return nil, apperrors.ErrTagNotFound(tagID)
+			}
+			return nil, fmt.Errorf("failed to get tag: %w", err)
+		}
+		tag = &t
+	} else if tagName != "" {
+		// Try alias resolution first, then name lookup
+		resolved, err := s.ResolveAlias(tagName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve tag: %w", err)
+		}
+		if resolved != nil {
+			tag = resolved
+		} else {
+			// Try direct name match
+			var t models.Tag
+			if err := s.db.Where("LOWER(name) = LOWER(?)", tagName).First(&t).Error; err != nil {
+				if err == gorm.ErrRecordNotFound {
+					return nil, apperrors.ErrTagNotFoundBySlug(tagName)
+				}
+				return nil, fmt.Errorf("failed to find tag by name: %w", err)
+			}
+			tag = &t
+		}
+	} else {
+		return nil, fmt.Errorf("tag_id or tag_name is required")
+	}
+
+	// Check for existing application
+	var existing models.EntityTag
+	err := s.db.Where("tag_id = ? AND entity_type = ? AND entity_id = ?", tag.ID, entityType, entityID).
+		First(&existing).Error
+	if err == nil {
+		return nil, apperrors.ErrEntityTagExists(tag.ID, entityType, entityID)
+	}
+
+	entityTag := &models.EntityTag{
+		TagID:         tag.ID,
+		EntityType:    entityType,
+		EntityID:      entityID,
+		AddedByUserID: userID,
+	}
+
+	if err := s.db.Create(entityTag).Error; err != nil {
+		return nil, fmt.Errorf("failed to add tag to entity: %w", err)
+	}
+
+	// Increment usage count atomically
+	s.db.Model(&models.Tag{}).Where("id = ?", tag.ID).
+		Update("usage_count", gorm.Expr("usage_count + 1"))
+
+	return entityTag, nil
+}
+
+// RemoveTagFromEntity removes a tag from an entity.
+func (s *TagService) RemoveTagFromEntity(tagID uint, entityType string, entityID uint) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	result := s.db.Where("tag_id = ? AND entity_type = ? AND entity_id = ?", tagID, entityType, entityID).
+		Delete(&models.EntityTag{})
+	if result.Error != nil {
+		return fmt.Errorf("failed to remove tag from entity: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return apperrors.ErrEntityTagNotFound(tagID, entityType, entityID)
+	}
+
+	// Decrement usage count atomically (floor at 0)
+	s.db.Model(&models.Tag{}).Where("id = ? AND usage_count > 0", tagID).
+		Update("usage_count", gorm.Expr("usage_count - 1"))
+
+	// Clean up votes for this tag-entity pair
+	s.db.Where("tag_id = ? AND entity_type = ? AND entity_id = ?", tagID, entityType, entityID).
+		Delete(&models.TagVote{})
+
+	return nil
+}
+
+// ListEntityTags lists all tags on an entity with vote counts.
+// Pass userID=0 for unauthenticated requests.
+func (s *TagService) ListEntityTags(entityType string, entityID uint, userID uint) ([]contracts.EntityTagResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	// Get entity tags with tag info and added-by user
+	var entityTags []models.EntityTag
+	err := s.db.Preload("Tag").Preload("AddedBy").
+		Where("entity_type = ? AND entity_id = ?", entityType, entityID).
+		Find(&entityTags).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to list entity tags: %w", err)
+	}
+
+	responses := make([]contracts.EntityTagResponse, len(entityTags))
+	for i, et := range entityTags {
+		// Count votes
+		var upvotes, downvotes int64
+		s.db.Model(&models.TagVote{}).
+			Where("tag_id = ? AND entity_type = ? AND entity_id = ? AND vote = 1", et.TagID, entityType, entityID).
+			Count(&upvotes)
+		s.db.Model(&models.TagVote{}).
+			Where("tag_id = ? AND entity_type = ? AND entity_id = ? AND vote = -1", et.TagID, entityType, entityID).
+			Count(&downvotes)
+
+		resp := contracts.EntityTagResponse{
+			TagID:       et.TagID,
+			Name:        et.Tag.Name,
+			Slug:        et.Tag.Slug,
+			Category:    et.Tag.Category,
+			Upvotes:     int(upvotes),
+			Downvotes:   int(downvotes),
+			WilsonScore: wilsonScore(int(upvotes), int(downvotes)),
+		}
+
+		// Resolve username
+		if et.AddedBy.Username != nil && *et.AddedBy.Username != "" {
+			resp.AddedByUsername = *et.AddedBy.Username
+		}
+
+		// Include user's vote if authenticated
+		if userID > 0 {
+			var vote models.TagVote
+			err := s.db.Where("tag_id = ? AND entity_type = ? AND entity_id = ? AND user_id = ?",
+				et.TagID, entityType, entityID, userID).First(&vote).Error
+			if err == nil {
+				resp.UserVote = &vote.Vote
+			}
+		}
+
+		responses[i] = resp
+	}
+
+	return responses, nil
+}
+
+// ──────────────────────────────────────────────
+// Voting
+// ──────────────────────────────────────────────
+
+// VoteOnTag adds or updates a vote on a tag-entity pair.
+func (s *TagService) VoteOnTag(tagID uint, entityType string, entityID uint, userID uint, isUpvote bool) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	// Verify the tag is actually applied to this entity
+	var entityTag models.EntityTag
+	err := s.db.Where("tag_id = ? AND entity_type = ? AND entity_id = ?", tagID, entityType, entityID).
+		First(&entityTag).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return apperrors.ErrEntityTagNotFound(tagID, entityType, entityID)
+		}
+		return fmt.Errorf("failed to verify entity tag: %w", err)
+	}
+
+	voteValue := -1
+	if isUpvote {
+		voteValue = 1
+	}
+
+	// Upsert vote
+	var existing models.TagVote
+	err = s.db.Where("tag_id = ? AND entity_type = ? AND entity_id = ? AND user_id = ?",
+		tagID, entityType, entityID, userID).First(&existing).Error
+
+	if err == gorm.ErrRecordNotFound {
+		vote := models.TagVote{
+			TagID:      tagID,
+			EntityType: entityType,
+			EntityID:   entityID,
+			UserID:     userID,
+			Vote:       voteValue,
+		}
+		if err := s.db.Create(&vote).Error; err != nil {
+			return fmt.Errorf("failed to create vote: %w", err)
+		}
+	} else if err != nil {
+		return fmt.Errorf("failed to check existing vote: %w", err)
+	} else {
+		if err := s.db.Model(&existing).Update("vote", voteValue).Error; err != nil {
+			return fmt.Errorf("failed to update vote: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// RemoveTagVote removes a user's vote on a tag-entity pair.
+func (s *TagService) RemoveTagVote(tagID uint, entityType string, entityID uint, userID uint) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	result := s.db.Where("tag_id = ? AND entity_type = ? AND entity_id = ? AND user_id = ?",
+		tagID, entityType, entityID, userID).Delete(&models.TagVote{})
+	if result.Error != nil {
+		return fmt.Errorf("failed to remove vote: %w", result.Error)
+	}
+
+	return nil
+}
+
+// ──────────────────────────────────────────────
+// Aliases
+// ──────────────────────────────────────────────
+
+// CreateAlias creates a new alias for a tag.
+func (s *TagService) CreateAlias(tagID uint, alias string) (*models.TagAlias, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	// Verify tag exists
+	var tag models.Tag
+	if err := s.db.First(&tag, tagID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, apperrors.ErrTagNotFound(tagID)
+		}
+		return nil, fmt.Errorf("failed to get tag: %w", err)
+	}
+
+	// Check for duplicate alias (case-insensitive)
+	var existing models.TagAlias
+	if err := s.db.Where("LOWER(alias) = LOWER(?)", alias).First(&existing).Error; err == nil {
+		return nil, apperrors.ErrTagAliasExists(alias)
+	}
+
+	// Also check if alias matches an existing tag name
+	var existingTag models.Tag
+	if err := s.db.Where("LOWER(name) = LOWER(?)", alias).First(&existingTag).Error; err == nil {
+		return nil, apperrors.ErrTagAliasExists(alias)
+	}
+
+	tagAlias := &models.TagAlias{
+		TagID: tagID,
+		Alias: alias,
+	}
+
+	if err := s.db.Create(tagAlias).Error; err != nil {
+		return nil, fmt.Errorf("failed to create alias: %w", err)
+	}
+
+	return tagAlias, nil
+}
+
+// DeleteAlias removes a tag alias.
+func (s *TagService) DeleteAlias(aliasID uint) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	result := s.db.Delete(&models.TagAlias{}, aliasID)
+	if result.Error != nil {
+		return fmt.Errorf("failed to delete alias: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("alias not found")
+	}
+
+	return nil
+}
+
+// ListAliases lists all aliases for a tag.
+func (s *TagService) ListAliases(tagID uint) ([]models.TagAlias, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var aliases []models.TagAlias
+	if err := s.db.Where("tag_id = ?", tagID).Order("alias ASC").Find(&aliases).Error; err != nil {
+		return nil, fmt.Errorf("failed to list aliases: %w", err)
+	}
+
+	return aliases, nil
+}
+
+// ResolveAlias resolves an alias to its canonical tag.
+func (s *TagService) ResolveAlias(alias string) (*models.Tag, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var tagAlias models.TagAlias
+	err := s.db.Where("LOWER(alias) = LOWER(?)", alias).First(&tagAlias).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to resolve alias: %w", err)
+	}
+
+	var tag models.Tag
+	if err := s.db.First(&tag, tagAlias.TagID).Error; err != nil {
+		return nil, fmt.Errorf("failed to get canonical tag: %w", err)
+	}
+
+	return &tag, nil
+}
+
+// ──────────────────────────────────────────────
+// Utility
+// ──────────────────────────────────────────────
+
+// SearchTags performs a case-insensitive search on tag names and aliases.
+func (s *TagService) SearchTags(query string, limit int) ([]models.Tag, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	if limit <= 0 {
+		limit = 10
+	}
+
+	q := strings.ToLower(query)
+
+	// Search tags by name and by alias, dedup by tag ID
+	var tags []models.Tag
+	err := s.db.Where("LOWER(name) LIKE ?", "%"+q+"%").
+		Or("id IN (?)",
+			s.db.Model(&models.TagAlias{}).Select("tag_id").Where("LOWER(alias) LIKE ?", "%"+q+"%"),
+		).
+		Order("usage_count DESC").
+		Limit(limit).
+		Find(&tags).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to search tags: %w", err)
+	}
+
+	return tags, nil
+}
+
+// GetTrendingTags returns the most used tags, optionally filtered by category.
+func (s *TagService) GetTrendingTags(limit int, category string) ([]models.Tag, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	if limit <= 0 {
+		limit = 20
+	}
+
+	query := s.db.Model(&models.Tag{}).Where("usage_count > 0")
+	if category != "" {
+		query = query.Where("category = ?", category)
+	}
+
+	var tags []models.Tag
+	if err := query.Order("usage_count DESC").Limit(limit).Find(&tags).Error; err != nil {
+		return nil, fmt.Errorf("failed to get trending tags: %w", err)
+	}
+
+	return tags, nil
+}
+
+// PruneDownvotedTags removes entity_tags where the community has voted them irrelevant.
+// A tag application is pruned when: downvotes > upvotes AND total votes >= 2.
+// Official tags are immune from pruning.
+func (s *TagService) PruneDownvotedTags() (int64, error) {
+	if s.db == nil {
+		return 0, fmt.Errorf("database not initialized")
+	}
+
+	// Find entity_tags that should be pruned
+	// Subquery: tag-entity pairs with more downvotes than upvotes and at least 2 total votes
+	type pruneCandidate struct {
+		TagID      uint
+		EntityType string
+		EntityID   uint
+	}
+
+	var candidates []pruneCandidate
+	err := s.db.Raw(`
+		SELECT tv.tag_id, tv.entity_type, tv.entity_id
+		FROM tag_votes tv
+		JOIN tags t ON t.id = tv.tag_id
+		WHERE t.is_official = false
+		GROUP BY tv.tag_id, tv.entity_type, tv.entity_id
+		HAVING COUNT(*) >= 2
+		   AND SUM(CASE WHEN tv.vote = -1 THEN 1 ELSE 0 END) > SUM(CASE WHEN tv.vote = 1 THEN 1 ELSE 0 END)
+	`).Scan(&candidates).Error
+	if err != nil {
+		return 0, fmt.Errorf("failed to find prune candidates: %w", err)
+	}
+
+	if len(candidates) == 0 {
+		return 0, nil
+	}
+
+	var totalPruned int64
+	for _, c := range candidates {
+		result := s.db.Where("tag_id = ? AND entity_type = ? AND entity_id = ?",
+			c.TagID, c.EntityType, c.EntityID).Delete(&models.EntityTag{})
+		if result.Error == nil {
+			totalPruned += result.RowsAffected
+			// Decrement usage count
+			if result.RowsAffected > 0 {
+				s.db.Model(&models.Tag{}).Where("id = ? AND usage_count > 0", c.TagID).
+					Update("usage_count", gorm.Expr("usage_count - 1"))
+			}
+		}
+		// Also clean up the votes
+		s.db.Where("tag_id = ? AND entity_type = ? AND entity_id = ?",
+			c.TagID, c.EntityType, c.EntityID).Delete(&models.TagVote{})
+	}
+
+	return totalPruned, nil
+}
+
+// wilsonScore computes the Wilson score lower bound for a binomial proportion.
+// This is the same algorithm used for request voting.
+func wilsonScore(upvotes, downvotes int) float64 {
+	n := float64(upvotes + downvotes)
+	if n == 0 {
+		return 0
+	}
+	p := float64(upvotes) / n
+	z := 1.96 // 95% confidence
+	denominator := 1 + z*z/n
+	centre := p + z*z/(2*n)
+	spread := z * math.Sqrt(p*(1-p)/n+z*z/(4*n*n))
+	return (centre - spread) / denominator
+}

--- a/backend/internal/services/catalog/tag_service_test.go
+++ b/backend/internal/services/catalog/tag_service_test.go
@@ -1,0 +1,810 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+
+	apperrors "psychic-homily-backend/internal/errors"
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/testutil"
+)
+
+// =============================================================================
+// UNIT TESTS (No Database Required)
+// =============================================================================
+
+func TestNewTagService(t *testing.T) {
+	svc := NewTagService(nil)
+	assert.NotNil(t, svc)
+}
+
+func TestTagService_NilDatabase(t *testing.T) {
+	svc := &TagService{db: nil}
+
+	t.Run("CreateTag", func(t *testing.T) {
+		tag, err := svc.CreateTag("test", nil, nil, "genre", false)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, tag)
+	})
+
+	t.Run("GetTag", func(t *testing.T) {
+		tag, err := svc.GetTag(1)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, tag)
+	})
+
+	t.Run("GetTagBySlug", func(t *testing.T) {
+		tag, err := svc.GetTagBySlug("test")
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, tag)
+	})
+
+	t.Run("ListTags", func(t *testing.T) {
+		tags, total, err := svc.ListTags("", "", nil, "usage", 20, 0)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, tags)
+		assert.Equal(t, int64(0), total)
+	})
+
+	t.Run("UpdateTag", func(t *testing.T) {
+		name := "updated"
+		tag, err := svc.UpdateTag(1, &name, nil, nil, nil, nil)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, tag)
+	})
+
+	t.Run("DeleteTag", func(t *testing.T) {
+		err := svc.DeleteTag(1)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+	})
+
+	t.Run("AddTagToEntity", func(t *testing.T) {
+		et, err := svc.AddTagToEntity(1, "", "artist", 1, 1)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, et)
+	})
+
+	t.Run("RemoveTagFromEntity", func(t *testing.T) {
+		err := svc.RemoveTagFromEntity(1, "artist", 1)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+	})
+
+	t.Run("ListEntityTags", func(t *testing.T) {
+		tags, err := svc.ListEntityTags("artist", 1, 0)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, tags)
+	})
+
+	t.Run("VoteOnTag", func(t *testing.T) {
+		err := svc.VoteOnTag(1, "artist", 1, 1, true)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+	})
+
+	t.Run("RemoveTagVote", func(t *testing.T) {
+		err := svc.RemoveTagVote(1, "artist", 1, 1)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+	})
+
+	t.Run("CreateAlias", func(t *testing.T) {
+		alias, err := svc.CreateAlias(1, "test")
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, alias)
+	})
+
+	t.Run("DeleteAlias", func(t *testing.T) {
+		err := svc.DeleteAlias(1)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+	})
+
+	t.Run("ListAliases", func(t *testing.T) {
+		aliases, err := svc.ListAliases(1)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, aliases)
+	})
+
+	t.Run("ResolveAlias", func(t *testing.T) {
+		tag, err := svc.ResolveAlias("test")
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, tag)
+	})
+
+	t.Run("SearchTags", func(t *testing.T) {
+		tags, err := svc.SearchTags("test", 10)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, tags)
+	})
+
+	t.Run("GetTrendingTags", func(t *testing.T) {
+		tags, err := svc.GetTrendingTags(10, "")
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, tags)
+	})
+
+	t.Run("PruneDownvotedTags", func(t *testing.T) {
+		count, err := svc.PruneDownvotedTags()
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Equal(t, int64(0), count)
+	})
+}
+
+func TestWilsonScore(t *testing.T) {
+	t.Run("zero votes returns 0", func(t *testing.T) {
+		score := wilsonScore(0, 0)
+		assert.Equal(t, float64(0), score)
+	})
+
+	t.Run("all upvotes returns positive", func(t *testing.T) {
+		score := wilsonScore(10, 0)
+		assert.Greater(t, score, float64(0))
+	})
+
+	t.Run("all downvotes returns near zero", func(t *testing.T) {
+		score := wilsonScore(0, 10)
+		assert.LessOrEqual(t, score, float64(0))
+	})
+
+	t.Run("mixed votes returns moderate", func(t *testing.T) {
+		score := wilsonScore(7, 3)
+		assert.Greater(t, score, float64(0))
+		assert.Less(t, score, float64(1))
+	})
+
+	t.Run("more votes increases confidence", func(t *testing.T) {
+		// 7/10 vs 70/100 — same ratio but more data should give higher lower bound
+		scoreLow := wilsonScore(7, 3)
+		scoreHigh := wilsonScore(70, 30)
+		assert.Greater(t, scoreHigh, scoreLow)
+	})
+}
+
+// =============================================================================
+// INTEGRATION TESTS (With Real Database)
+// =============================================================================
+
+type TagServiceIntegrationTestSuite struct {
+	suite.Suite
+	container  testcontainers.Container
+	db         *gorm.DB
+	tagService *TagService
+	ctx        context.Context
+}
+
+func (suite *TagServiceIntegrationTestSuite) SetupSuite() {
+	suite.ctx = context.Background()
+
+	container, err := testcontainers.GenericContainer(suite.ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "postgres:18",
+			ExposedPorts: []string{"5432/tcp"},
+			Env: map[string]string{
+				"POSTGRES_DB":       "test_db",
+				"POSTGRES_USER":     "test_user",
+				"POSTGRES_PASSWORD": "test_password",
+			},
+			WaitingFor: wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(120 * time.Second),
+		},
+		Started: true,
+	})
+	suite.Require().NoError(err)
+	suite.container = container
+
+	host, err := container.Host(suite.ctx)
+	suite.Require().NoError(err)
+	port, err := container.MappedPort(suite.ctx, "5432")
+	suite.Require().NoError(err)
+
+	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
+		host, port.Port())
+
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	suite.Require().NoError(err)
+
+	sqlDB, err := db.DB()
+	suite.Require().NoError(err)
+	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
+
+	suite.db = db
+	suite.tagService = NewTagService(db)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TearDownSuite() {
+	if suite.container != nil {
+		_ = suite.container.Terminate(suite.ctx)
+	}
+}
+
+func (suite *TagServiceIntegrationTestSuite) SetupTest() {
+	sqlDB, _ := suite.db.DB()
+	_, _ = sqlDB.Exec("DELETE FROM tag_votes")
+	_, _ = sqlDB.Exec("DELETE FROM entity_tags")
+	_, _ = sqlDB.Exec("DELETE FROM tag_aliases")
+	_, _ = sqlDB.Exec("DELETE FROM tags")
+	_, _ = sqlDB.Exec("DELETE FROM users")
+}
+
+func (suite *TagServiceIntegrationTestSuite) createTestUser(name string) *models.User {
+	email := fmt.Sprintf("%s-%d@test.com", name, time.Now().UnixNano())
+	user := &models.User{
+		Email:         &email,
+		FirstName:     &name,
+		IsActive:      true,
+		EmailVerified: true,
+	}
+	err := suite.db.Create(user).Error
+	suite.Require().NoError(err)
+	return user
+}
+
+func (suite *TagServiceIntegrationTestSuite) createTag(name, category string) *models.Tag {
+	tag, err := suite.tagService.CreateTag(name, nil, nil, category, false)
+	suite.Require().NoError(err)
+	return tag
+}
+
+// createArtist creates a minimal artist for tagging tests
+func (suite *TagServiceIntegrationTestSuite) createArtist(name string) uint {
+	slug := fmt.Sprintf("%s-%d", name, time.Now().UnixNano())
+	artist := &models.Artist{Name: name, Slug: &slug}
+	err := suite.db.Create(artist).Error
+	suite.Require().NoError(err)
+	return artist.ID
+}
+
+// ──────────────────────────────────────────────
+// CRUD Tests
+// ──────────────────────────────────────────────
+
+func (suite *TagServiceIntegrationTestSuite) TestCreateTag_Success() {
+	desc := "A subgenre of punk rock"
+	tag, err := suite.tagService.CreateTag("Post-Punk", &desc, nil, "genre", true)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(tag)
+
+	suite.Assert().Equal("Post-Punk", tag.Name)
+	suite.Assert().Equal("post-punk", tag.Slug)
+	suite.Assert().Equal("genre", tag.Category)
+	suite.Assert().True(tag.IsOfficial)
+	suite.Assert().NotNil(tag.Description)
+	suite.Assert().Equal("A subgenre of punk rock", *tag.Description)
+	suite.Assert().Equal(0, tag.UsageCount)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestCreateTag_InvalidCategory() {
+	tag, err := suite.tagService.CreateTag("Test", nil, nil, "invalid", false)
+	suite.Assert().Error(err)
+	suite.Assert().Contains(err.Error(), "invalid tag category")
+	suite.Assert().Nil(tag)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestCreateTag_DuplicateName() {
+	suite.createTag("rock", "genre")
+
+	tag, err := suite.tagService.CreateTag("Rock", nil, nil, "genre", false)
+	suite.Assert().Error(err)
+	var tagErr *apperrors.TagError
+	suite.Assert().ErrorAs(err, &tagErr)
+	suite.Assert().Equal(apperrors.CodeTagExists, tagErr.Code)
+	suite.Assert().Nil(tag)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestCreateTag_WithParent() {
+	parent := suite.createTag("rock", "genre")
+
+	child, err := suite.tagService.CreateTag("post-punk", nil, &parent.ID, "genre", false)
+	suite.Require().NoError(err)
+	suite.Assert().NotNil(child.ParentID)
+	suite.Assert().Equal(parent.ID, *child.ParentID)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestGetTag_ByID() {
+	created := suite.createTag("electronic", "genre")
+
+	tag, err := suite.tagService.GetTag(created.ID)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(tag)
+	suite.Assert().Equal("electronic", tag.Name)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestGetTag_NotFound() {
+	tag, err := suite.tagService.GetTag(99999)
+	suite.Assert().NoError(err)
+	suite.Assert().Nil(tag)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestGetTagBySlug() {
+	suite.createTag("shoegaze", "genre")
+
+	tag, err := suite.tagService.GetTagBySlug("shoegaze")
+	suite.Require().NoError(err)
+	suite.Require().NotNil(tag)
+	suite.Assert().Equal("shoegaze", tag.Name)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestGetTagBySlug_NotFound() {
+	tag, err := suite.tagService.GetTagBySlug("nonexistent")
+	suite.Assert().NoError(err)
+	suite.Assert().Nil(tag)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestListTags_All() {
+	suite.createTag("rock", "genre")
+	suite.createTag("jazz", "genre")
+	suite.createTag("1990s", "era")
+
+	tags, total, err := suite.tagService.ListTags("", "", nil, "name", 50, 0)
+	suite.Require().NoError(err)
+	suite.Assert().Equal(int64(3), total)
+	suite.Assert().Len(tags, 3)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestListTags_FilterByCategory() {
+	suite.createTag("rock", "genre")
+	suite.createTag("jazz", "genre")
+	suite.createTag("1990s", "era")
+
+	tags, total, err := suite.tagService.ListTags("genre", "", nil, "name", 50, 0)
+	suite.Require().NoError(err)
+	suite.Assert().Equal(int64(2), total)
+	suite.Assert().Len(tags, 2)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestListTags_Search() {
+	suite.createTag("post-punk", "genre")
+	suite.createTag("post-rock", "genre")
+	suite.createTag("jazz", "genre")
+
+	tags, total, err := suite.tagService.ListTags("", "post", nil, "name", 50, 0)
+	suite.Require().NoError(err)
+	suite.Assert().Equal(int64(2), total)
+	suite.Assert().Len(tags, 2)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestListTags_FilterByParent() {
+	parent := suite.createTag("rock", "genre")
+	suite.createTag("post-punk", "genre")
+	// Make post-rock a child of rock
+	suite.tagService.CreateTag("post-rock", nil, &parent.ID, "genre", false)
+
+	tags, total, err := suite.tagService.ListTags("", "", &parent.ID, "name", 50, 0)
+	suite.Require().NoError(err)
+	suite.Assert().Equal(int64(1), total)
+	suite.Assert().Len(tags, 1)
+	suite.Assert().Equal("post-rock", tags[0].Name)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestUpdateTag_Success() {
+	tag := suite.createTag("typo-tag", "genre")
+
+	newName := "corrected-tag"
+	newCategory := "style"
+	updated, err := suite.tagService.UpdateTag(tag.ID, &newName, nil, nil, &newCategory, nil)
+	suite.Require().NoError(err)
+	suite.Assert().Equal("corrected-tag", updated.Name)
+	suite.Assert().Equal("style", updated.Category)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestUpdateTag_NotFound() {
+	name := "test"
+	_, err := suite.tagService.UpdateTag(99999, &name, nil, nil, nil, nil)
+	suite.Assert().Error(err)
+	var tagErr *apperrors.TagError
+	suite.Assert().ErrorAs(err, &tagErr)
+	suite.Assert().Equal(apperrors.CodeTagNotFound, tagErr.Code)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestDeleteTag_Success() {
+	tag := suite.createTag("to-delete", "genre")
+
+	err := suite.tagService.DeleteTag(tag.ID)
+	suite.Assert().NoError(err)
+
+	// Verify deleted
+	found, _ := suite.tagService.GetTag(tag.ID)
+	suite.Assert().Nil(found)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestDeleteTag_NotFound() {
+	err := suite.tagService.DeleteTag(99999)
+	suite.Assert().Error(err)
+	var tagErr *apperrors.TagError
+	suite.Assert().ErrorAs(err, &tagErr)
+	suite.Assert().Equal(apperrors.CodeTagNotFound, tagErr.Code)
+}
+
+// ──────────────────────────────────────────────
+// Entity Tagging Tests
+// ──────────────────────────────────────────────
+
+func (suite *TagServiceIntegrationTestSuite) TestAddTagToEntity_ByID() {
+	user := suite.createTestUser("tagger")
+	tag := suite.createTag("indie", "genre")
+	artistID := suite.createArtist("Test Band")
+
+	et, err := suite.tagService.AddTagToEntity(tag.ID, "", "artist", artistID, user.ID)
+	suite.Require().NoError(err)
+	suite.Assert().Equal(tag.ID, et.TagID)
+	suite.Assert().Equal("artist", et.EntityType)
+	suite.Assert().Equal(artistID, et.EntityID)
+	suite.Assert().Equal(user.ID, et.AddedByUserID)
+
+	// Verify usage count incremented
+	updated, _ := suite.tagService.GetTag(tag.ID)
+	suite.Assert().Equal(1, updated.UsageCount)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestAddTagToEntity_ByName() {
+	user := suite.createTestUser("tagger")
+	tag := suite.createTag("ambient", "genre")
+	artistID := suite.createArtist("Ambient Artist")
+
+	et, err := suite.tagService.AddTagToEntity(0, "ambient", "artist", artistID, user.ID)
+	suite.Require().NoError(err)
+	suite.Assert().Equal(tag.ID, et.TagID)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestAddTagToEntity_ByAlias() {
+	user := suite.createTestUser("tagger")
+	tag := suite.createTag("post-punk", "genre")
+	_, err := suite.tagService.CreateAlias(tag.ID, "post punk")
+	suite.Require().NoError(err)
+	artistID := suite.createArtist("Post Punk Band")
+
+	et, err := suite.tagService.AddTagToEntity(0, "post punk", "artist", artistID, user.ID)
+	suite.Require().NoError(err)
+	suite.Assert().Equal(tag.ID, et.TagID)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestAddTagToEntity_Duplicate() {
+	user := suite.createTestUser("tagger")
+	tag := suite.createTag("rock", "genre")
+	artistID := suite.createArtist("Rock Band")
+
+	_, err := suite.tagService.AddTagToEntity(tag.ID, "", "artist", artistID, user.ID)
+	suite.Require().NoError(err)
+
+	_, err = suite.tagService.AddTagToEntity(tag.ID, "", "artist", artistID, user.ID)
+	suite.Assert().Error(err)
+	var tagErr *apperrors.TagError
+	suite.Assert().ErrorAs(err, &tagErr)
+	suite.Assert().Equal(apperrors.CodeEntityTagExists, tagErr.Code)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestAddTagToEntity_InvalidEntityType() {
+	user := suite.createTestUser("tagger")
+	tag := suite.createTag("rock", "genre")
+
+	_, err := suite.tagService.AddTagToEntity(tag.ID, "", "invalid", 1, user.ID)
+	suite.Assert().Error(err)
+	suite.Assert().Contains(err.Error(), "invalid entity type")
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestRemoveTagFromEntity_Success() {
+	user := suite.createTestUser("tagger")
+	tag := suite.createTag("metal", "genre")
+	artistID := suite.createArtist("Metal Band")
+
+	_, err := suite.tagService.AddTagToEntity(tag.ID, "", "artist", artistID, user.ID)
+	suite.Require().NoError(err)
+
+	err = suite.tagService.RemoveTagFromEntity(tag.ID, "artist", artistID)
+	suite.Assert().NoError(err)
+
+	// Verify usage count decremented
+	updated, _ := suite.tagService.GetTag(tag.ID)
+	suite.Assert().Equal(0, updated.UsageCount)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestRemoveTagFromEntity_NotFound() {
+	err := suite.tagService.RemoveTagFromEntity(99999, "artist", 99999)
+	suite.Assert().Error(err)
+	var tagErr *apperrors.TagError
+	suite.Assert().ErrorAs(err, &tagErr)
+	suite.Assert().Equal(apperrors.CodeEntityTagNotFound, tagErr.Code)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestListEntityTags() {
+	user := suite.createTestUser("tagger")
+	tag1 := suite.createTag("indie", "genre")
+	tag2 := suite.createTag("lo-fi", "style")
+	artistID := suite.createArtist("Indie Lo-Fi Band")
+
+	suite.tagService.AddTagToEntity(tag1.ID, "", "artist", artistID, user.ID)
+	suite.tagService.AddTagToEntity(tag2.ID, "", "artist", artistID, user.ID)
+
+	tags, err := suite.tagService.ListEntityTags("artist", artistID, 0)
+	suite.Require().NoError(err)
+	suite.Assert().Len(tags, 2)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestListEntityTags_WithUserVote() {
+	user := suite.createTestUser("voter")
+	tag := suite.createTag("punk", "genre")
+	artistID := suite.createArtist("Punk Band")
+
+	suite.tagService.AddTagToEntity(tag.ID, "", "artist", artistID, user.ID)
+	suite.tagService.VoteOnTag(tag.ID, "artist", artistID, user.ID, true)
+
+	tags, err := suite.tagService.ListEntityTags("artist", artistID, user.ID)
+	suite.Require().NoError(err)
+	suite.Require().Len(tags, 1)
+	suite.Assert().NotNil(tags[0].UserVote)
+	suite.Assert().Equal(1, *tags[0].UserVote)
+	suite.Assert().Equal(1, tags[0].Upvotes)
+}
+
+// ──────────────────────────────────────────────
+// Voting Tests
+// ──────────────────────────────────────────────
+
+func (suite *TagServiceIntegrationTestSuite) TestVoteOnTag_Upvote() {
+	user := suite.createTestUser("voter")
+	tag := suite.createTag("synth", "genre")
+	artistID := suite.createArtist("Synth Band")
+
+	suite.tagService.AddTagToEntity(tag.ID, "", "artist", artistID, user.ID)
+
+	err := suite.tagService.VoteOnTag(tag.ID, "artist", artistID, user.ID, true)
+	suite.Assert().NoError(err)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestVoteOnTag_ChangeVote() {
+	user := suite.createTestUser("voter")
+	tag := suite.createTag("grunge", "genre")
+	artistID := suite.createArtist("Grunge Band")
+
+	suite.tagService.AddTagToEntity(tag.ID, "", "artist", artistID, user.ID)
+	suite.tagService.VoteOnTag(tag.ID, "artist", artistID, user.ID, true)
+
+	// Change to downvote
+	err := suite.tagService.VoteOnTag(tag.ID, "artist", artistID, user.ID, false)
+	suite.Assert().NoError(err)
+
+	// Verify vote changed
+	tags, _ := suite.tagService.ListEntityTags("artist", artistID, user.ID)
+	suite.Require().Len(tags, 1)
+	suite.Assert().NotNil(tags[0].UserVote)
+	suite.Assert().Equal(-1, *tags[0].UserVote)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestVoteOnTag_TagNotApplied() {
+	user := suite.createTestUser("voter")
+	tag := suite.createTag("doom", "genre")
+
+	err := suite.tagService.VoteOnTag(tag.ID, "artist", 99999, user.ID, true)
+	suite.Assert().Error(err)
+	var tagErr *apperrors.TagError
+	suite.Assert().ErrorAs(err, &tagErr)
+	suite.Assert().Equal(apperrors.CodeEntityTagNotFound, tagErr.Code)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestRemoveTagVote() {
+	user := suite.createTestUser("voter")
+	tag := suite.createTag("noise", "genre")
+	artistID := suite.createArtist("Noise Band")
+
+	suite.tagService.AddTagToEntity(tag.ID, "", "artist", artistID, user.ID)
+	suite.tagService.VoteOnTag(tag.ID, "artist", artistID, user.ID, true)
+
+	err := suite.tagService.RemoveTagVote(tag.ID, "artist", artistID, user.ID)
+	suite.Assert().NoError(err)
+
+	// Verify vote removed
+	tags, _ := suite.tagService.ListEntityTags("artist", artistID, user.ID)
+	suite.Require().Len(tags, 1)
+	suite.Assert().Nil(tags[0].UserVote)
+}
+
+// ──────────────────────────────────────────────
+// Alias Tests
+// ──────────────────────────────────────────────
+
+func (suite *TagServiceIntegrationTestSuite) TestCreateAlias_Success() {
+	tag := suite.createTag("post-punk", "genre")
+
+	alias, err := suite.tagService.CreateAlias(tag.ID, "post punk")
+	suite.Require().NoError(err)
+	suite.Assert().Equal("post punk", alias.Alias)
+	suite.Assert().Equal(tag.ID, alias.TagID)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestCreateAlias_Duplicate() {
+	tag := suite.createTag("hip-hop", "genre")
+	suite.tagService.CreateAlias(tag.ID, "hiphop")
+
+	_, err := suite.tagService.CreateAlias(tag.ID, "HipHop")
+	suite.Assert().Error(err)
+	var tagErr *apperrors.TagError
+	suite.Assert().ErrorAs(err, &tagErr)
+	suite.Assert().Equal(apperrors.CodeTagAliasExists, tagErr.Code)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestCreateAlias_ConflictsWithTagName() {
+	suite.createTag("electronic", "genre")
+	tag2 := suite.createTag("techno", "genre")
+
+	_, err := suite.tagService.CreateAlias(tag2.ID, "electronic")
+	suite.Assert().Error(err)
+	var tagErr *apperrors.TagError
+	suite.Assert().ErrorAs(err, &tagErr)
+	suite.Assert().Equal(apperrors.CodeTagAliasExists, tagErr.Code)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestCreateAlias_TagNotFound() {
+	_, err := suite.tagService.CreateAlias(99999, "test")
+	suite.Assert().Error(err)
+	var tagErr *apperrors.TagError
+	suite.Assert().ErrorAs(err, &tagErr)
+	suite.Assert().Equal(apperrors.CodeTagNotFound, tagErr.Code)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestDeleteAlias() {
+	tag := suite.createTag("rnb", "genre")
+	alias, _ := suite.tagService.CreateAlias(tag.ID, "r&b")
+
+	err := suite.tagService.DeleteAlias(alias.ID)
+	suite.Assert().NoError(err)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestListAliases() {
+	tag := suite.createTag("post-punk", "genre")
+	suite.tagService.CreateAlias(tag.ID, "post punk")
+	suite.tagService.CreateAlias(tag.ID, "postpunk")
+
+	aliases, err := suite.tagService.ListAliases(tag.ID)
+	suite.Require().NoError(err)
+	suite.Assert().Len(aliases, 2)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestResolveAlias_Found() {
+	tag := suite.createTag("post-punk", "genre")
+	suite.tagService.CreateAlias(tag.ID, "post punk")
+
+	resolved, err := suite.tagService.ResolveAlias("Post Punk")
+	suite.Require().NoError(err)
+	suite.Require().NotNil(resolved)
+	suite.Assert().Equal(tag.ID, resolved.ID)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestResolveAlias_NotFound() {
+	resolved, err := suite.tagService.ResolveAlias("nonexistent")
+	suite.Assert().NoError(err)
+	suite.Assert().Nil(resolved)
+}
+
+// ──────────────────────────────────────────────
+// Utility Tests
+// ──────────────────────────────────────────────
+
+func (suite *TagServiceIntegrationTestSuite) TestSearchTags_ByName() {
+	suite.createTag("post-punk", "genre")
+	suite.createTag("post-rock", "genre")
+	suite.createTag("jazz", "genre")
+
+	tags, err := suite.tagService.SearchTags("post", 10)
+	suite.Require().NoError(err)
+	suite.Assert().Len(tags, 2)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestSearchTags_ByAlias() {
+	tag := suite.createTag("post-punk", "genre")
+	suite.tagService.CreateAlias(tag.ID, "post punk revival")
+
+	tags, err := suite.tagService.SearchTags("revival", 10)
+	suite.Require().NoError(err)
+	suite.Assert().Len(tags, 1)
+	suite.Assert().Equal(tag.ID, tags[0].ID)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestGetTrendingTags() {
+	user := suite.createTestUser("tagger")
+	tag1 := suite.createTag("rock", "genre")
+	tag2 := suite.createTag("jazz", "genre")
+	artistID := suite.createArtist("Multi-Genre")
+
+	// Apply tags to entities to increase usage count
+	suite.tagService.AddTagToEntity(tag1.ID, "", "artist", artistID, user.ID)
+	// tag2 not applied, so usage_count stays 0
+
+	_ = tag2
+
+	tags, err := suite.tagService.GetTrendingTags(10, "")
+	suite.Require().NoError(err)
+	suite.Assert().Len(tags, 1) // Only tag1 has usage_count > 0
+	suite.Assert().Equal(tag1.ID, tags[0].ID)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestGetTrendingTags_FilterByCategory() {
+	user := suite.createTestUser("tagger")
+	tag1 := suite.createTag("rock", "genre")
+	tag2 := suite.createTag("1990s", "era")
+	artistID := suite.createArtist("Band")
+
+	suite.tagService.AddTagToEntity(tag1.ID, "", "artist", artistID, user.ID)
+	artist2 := suite.createArtist("Band2")
+	suite.tagService.AddTagToEntity(tag2.ID, "", "artist", artist2, user.ID)
+
+	tags, err := suite.tagService.GetTrendingTags(10, "era")
+	suite.Require().NoError(err)
+	suite.Assert().Len(tags, 1)
+	suite.Assert().Equal("1990s", tags[0].Name)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestPruneDownvotedTags() {
+	user1 := suite.createTestUser("voter1")
+	user2 := suite.createTestUser("voter2")
+	tag := suite.createTag("questionable", "genre")
+	artistID := suite.createArtist("Some Band")
+
+	// Apply tag and get downvoted
+	suite.tagService.AddTagToEntity(tag.ID, "", "artist", artistID, user1.ID)
+	suite.tagService.VoteOnTag(tag.ID, "artist", artistID, user1.ID, false)
+	suite.tagService.VoteOnTag(tag.ID, "artist", artistID, user2.ID, false)
+
+	pruned, err := suite.tagService.PruneDownvotedTags()
+	suite.Require().NoError(err)
+	suite.Assert().Equal(int64(1), pruned)
+
+	// Verify entity_tag was removed
+	tags, _ := suite.tagService.ListEntityTags("artist", artistID, 0)
+	suite.Assert().Len(tags, 0)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestPruneDownvotedTags_OfficialImmune() {
+	user1 := suite.createTestUser("voter1")
+	user2 := suite.createTestUser("voter2")
+	tag, _ := suite.tagService.CreateTag("official-tag", nil, nil, "genre", true)
+	artistID := suite.createArtist("Some Official Band")
+
+	suite.tagService.AddTagToEntity(tag.ID, "", "artist", artistID, user1.ID)
+	suite.tagService.VoteOnTag(tag.ID, "artist", artistID, user1.ID, false)
+	suite.tagService.VoteOnTag(tag.ID, "artist", artistID, user2.ID, false)
+
+	pruned, err := suite.tagService.PruneDownvotedTags()
+	suite.Require().NoError(err)
+	suite.Assert().Equal(int64(0), pruned)
+
+	// Official tag still applied
+	tags, _ := suite.tagService.ListEntityTags("artist", artistID, 0)
+	suite.Assert().Len(tags, 1)
+}
+
+// ──────────────────────────────────────────────
+// Run all integration tests
+// ──────────────────────────────────────────────
+
+func TestTagServiceIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	suite.Run(t, new(TagServiceIntegrationTestSuite))
+}

--- a/backend/internal/services/container.go
+++ b/backend/internal/services/container.go
@@ -30,6 +30,7 @@ type ServiceContainer struct {
 	Calendar      *engagement.CalendarService
 	Collection    *CollectionService
 	Request       *RequestService
+	Tag           *catalog.TagService
 	FavoriteVenue *engagement.FavoriteVenueService
 	Festival      *catalog.FestivalService
 	Label         *catalog.LabelService
@@ -112,6 +113,7 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 		Calendar:      engagement.NewCalendarService(database, savedShow),
 		Collection:    NewCollectionService(database),
 		Request:       NewRequestService(database),
+		Tag:           catalog.NewTagService(database),
 		FavoriteVenue: engagement.NewFavoriteVenueService(database),
 		Festival:      catalog.NewFestivalService(database),
 		Label:         catalog.NewLabelService(database),

--- a/backend/internal/services/contracts/tag.go
+++ b/backend/internal/services/contracts/tag.go
@@ -1,0 +1,90 @@
+package contracts
+
+import (
+	"time"
+
+	"psychic-homily-backend/internal/models"
+)
+
+// ──────────────────────────────────────────────
+// Tag types
+// ──────────────────────────────────────────────
+
+// TagResponse represents a tag returned to clients.
+type TagResponse struct {
+	ID           uint               `json:"id"`
+	Name         string             `json:"name"`
+	Slug         string             `json:"slug"`
+	Description  *string            `json:"description,omitempty"`
+	ParentID     *uint              `json:"parent_id,omitempty"`
+	ParentName   string             `json:"parent_name,omitempty"`
+	Category     string             `json:"category"`
+	IsOfficial   bool               `json:"is_official"`
+	UsageCount   int                `json:"usage_count"`
+	ChildCount   int                `json:"child_count"`
+	Aliases      []string           `json:"aliases,omitempty"`
+	CreatedAt    time.Time          `json:"created_at"`
+	UpdatedAt    time.Time          `json:"updated_at"`
+}
+
+// TagListItem represents a tag in a list response.
+type TagListItem struct {
+	ID         uint      `json:"id"`
+	Name       string    `json:"name"`
+	Slug       string    `json:"slug"`
+	Category   string    `json:"category"`
+	IsOfficial bool      `json:"is_official"`
+	UsageCount int       `json:"usage_count"`
+	CreatedAt  time.Time `json:"created_at"`
+}
+
+// EntityTagResponse represents a tag applied to an entity with vote info.
+type EntityTagResponse struct {
+	TagID           uint    `json:"tag_id"`
+	Name            string  `json:"name"`
+	Slug            string  `json:"slug"`
+	Category        string  `json:"category"`
+	Upvotes         int     `json:"upvotes"`
+	Downvotes       int     `json:"downvotes"`
+	WilsonScore     float64 `json:"wilson_score"`
+	UserVote        *int    `json:"user_vote,omitempty"`
+	AddedByUsername string  `json:"added_by_username,omitempty"`
+}
+
+// TagAliasResponse represents a tag alias returned to clients.
+type TagAliasResponse struct {
+	ID        uint      `json:"id"`
+	Alias     string    `json:"alias"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// TagServiceInterface defines the contract for tag operations.
+type TagServiceInterface interface {
+	// CRUD
+	CreateTag(name string, description *string, parentID *uint, category string, isOfficial bool) (*models.Tag, error)
+	GetTag(tagID uint) (*models.Tag, error)
+	GetTagBySlug(slug string) (*models.Tag, error)
+	ListTags(category string, search string, parentID *uint, sort string, limit, offset int) ([]models.Tag, int64, error)
+	UpdateTag(tagID uint, name *string, description *string, parentID *uint, category *string, isOfficial *bool) (*models.Tag, error)
+	DeleteTag(tagID uint) error
+
+	// Entity tagging
+	AddTagToEntity(tagID uint, tagName string, entityType string, entityID uint, userID uint) (*models.EntityTag, error)
+	RemoveTagFromEntity(tagID uint, entityType string, entityID uint) error
+	ListEntityTags(entityType string, entityID uint, userID uint) ([]EntityTagResponse, error)
+
+	// Voting
+	VoteOnTag(tagID uint, entityType string, entityID uint, userID uint, isUpvote bool) error
+	RemoveTagVote(tagID uint, entityType string, entityID uint, userID uint) error
+
+	// Aliases
+	CreateAlias(tagID uint, alias string) (*models.TagAlias, error)
+	DeleteAlias(aliasID uint) error
+	ListAliases(tagID uint) ([]models.TagAlias, error)
+	ResolveAlias(alias string) (*models.Tag, error)
+
+	// Utility
+	SearchTags(query string, limit int) ([]models.Tag, error)
+	GetTrendingTags(limit int, category string) ([]models.Tag, error)
+	PruneDownvotedTags() (int64, error)
+}

--- a/backend/internal/services/interfaces.go
+++ b/backend/internal/services/interfaces.go
@@ -44,6 +44,7 @@ type SchedulerServiceInterface = contracts.SchedulerServiceInterface
 type CollectionServiceInterface = contracts.CollectionServiceInterface
 type RevisionServiceInterface = contracts.RevisionServiceInterface
 type RequestServiceInterface = contracts.RequestServiceInterface
+type TagServiceInterface = contracts.TagServiceInterface
 
 // Compile-time interface satisfaction checks.
 // Engagement services (Bookmark, SavedShow, FavoriteVenue, Calendar, Reminder)
@@ -67,4 +68,5 @@ var (
 	_ ReleaseServiceInterface       = (*catalog.ReleaseService)(nil)
 	_ CollectionServiceInterface            = (*CollectionService)(nil)
 	_ RequestServiceInterface               = (*RequestService)(nil)
+	_ TagServiceInterface                   = (*catalog.TagService)(nil)
 )


### PR DESCRIPTION
## Summary
- Tag service with 17 methods: CRUD, entity tagging (by ID/name/alias), Wilson score voting, alias management, search/trending, and auto-pruning
- 13 API endpoints: public (list, get, search, entity tags, aliases), protected (add/remove tags, vote), admin (tag CRUD, alias CRUD)
- All admin operations fire-and-forget audit logged
- 67 tests (24 unit + 43 integration with testcontainers)

## Test plan
- [x] All unit tests pass (nil DB, Wilson score computation)
- [x] All integration tests pass with real PostgreSQL (testcontainers)
- [x] Full backend compiles cleanly
- [x] Service wired into container with compile-time interface check

Closes PSY-50

🤖 Generated with [Claude Code](https://claude.com/claude-code)