### PR TITLE
Add artist relationship service and shared bills derivation (PSY-53)

### DIFF
--- a/backend/internal/api/handlers/artist_relationship.go
+++ b/backend/internal/api/handlers/artist_relationship.go
@@ -1,0 +1,249 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"psychic-homily-backend/internal/api/middleware"
+	"psychic-homily-backend/internal/logger"
+	"psychic-homily-backend/internal/services"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// ArtistRelationshipHandler handles artist relationship API requests.
+type ArtistRelationshipHandler struct {
+	relService services.ArtistRelationshipServiceInterface
+	auditLog   services.AuditLogServiceInterface
+}
+
+// NewArtistRelationshipHandler creates a new handler.
+func NewArtistRelationshipHandler(
+	relService services.ArtistRelationshipServiceInterface,
+	auditLog services.AuditLogServiceInterface,
+) *ArtistRelationshipHandler {
+	return &ArtistRelationshipHandler{
+		relService: relService,
+		auditLog:   auditLog,
+	}
+}
+
+// ============================================================================
+// Get Related Artists (optional auth)
+// ============================================================================
+
+type GetRelatedArtistsRequest struct {
+	ArtistID string `path:"artist_id" doc:"Artist ID" example:"1"`
+	Type     string `query:"type" required:"false" doc:"Filter by relationship type (similar, shared_bills, shared_label, side_project, member_of)"`
+	Limit    int    `query:"limit" required:"false" doc:"Max results (default 30)" example:"30"`
+}
+
+type GetRelatedArtistsResponse struct {
+	Body struct {
+		Related []contracts.RelatedArtistResponse `json:"related"`
+	}
+}
+
+func (h *ArtistRelationshipHandler) GetRelatedArtistsHandler(ctx context.Context, req *GetRelatedArtistsRequest) (*GetRelatedArtistsResponse, error) {
+	id, err := strconv.ParseUint(req.ArtistID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid artist ID")
+	}
+
+	related, err := h.relService.GetRelatedArtists(uint(id), req.Type, req.Limit)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Failed to get related artists")
+	}
+
+	// Include user's votes if authenticated
+	user := middleware.GetUserFromContext(ctx)
+	if user != nil {
+		for i := range related {
+			r := &related[i]
+			vote, err := h.relService.GetUserVote(uint(id), r.ArtistID, r.RelationshipType, user.ID)
+			if err == nil && vote != nil {
+				dir := int(vote.Direction)
+				r.UserVote = &dir
+			}
+		}
+	}
+
+	resp := &GetRelatedArtistsResponse{}
+	resp.Body.Related = related
+	return resp, nil
+}
+
+// ============================================================================
+// Create Relationship (protected)
+// ============================================================================
+
+type CreateRelationshipRequest struct {
+	Body struct {
+		SourceArtistID uint   `json:"source_artist_id" doc:"Source artist ID" example:"1"`
+		TargetArtistID uint   `json:"target_artist_id" doc:"Target artist ID" example:"2"`
+		Type           string `json:"type" doc:"Relationship type (similar, side_project, member_of)" example:"similar"`
+	}
+}
+
+type CreateRelationshipResponse struct {
+	Body struct {
+		Success bool `json:"success"`
+	}
+}
+
+func (h *ArtistRelationshipHandler) CreateRelationshipHandler(ctx context.Context, req *CreateRelationshipRequest) (*CreateRelationshipResponse, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	if req.Body.SourceArtistID == 0 || req.Body.TargetArtistID == 0 {
+		return nil, huma.Error400BadRequest("Both source_artist_id and target_artist_id are required")
+	}
+	if req.Body.Type == "" {
+		return nil, huma.Error400BadRequest("Relationship type is required")
+	}
+
+	_, err := h.relService.CreateRelationship(req.Body.SourceArtistID, req.Body.TargetArtistID, req.Body.Type, false)
+	if err != nil {
+		requestID := logger.GetRequestID(ctx)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to create relationship (request_id: %s): %v", requestID, err),
+		)
+	}
+
+	// Cast initial upvote from the creator
+	_ = h.relService.Vote(req.Body.SourceArtistID, req.Body.TargetArtistID, req.Body.Type, user.ID, true)
+
+	// Audit log (fire and forget)
+	if h.auditLog != nil {
+		go func() {
+			h.auditLog.LogAction(user.ID, "create_artist_relationship", "artist", req.Body.SourceArtistID, map[string]interface{}{
+				"target_artist_id": req.Body.TargetArtistID,
+				"type":             req.Body.Type,
+			})
+		}()
+	}
+
+	resp := &CreateRelationshipResponse{}
+	resp.Body.Success = true
+	return resp, nil
+}
+
+// ============================================================================
+// Vote on Relationship (protected)
+// ============================================================================
+
+type VoteRelationshipRequest struct {
+	SourceID string `path:"source_id" doc:"Source artist ID" example:"1"`
+	TargetID string `path:"target_id" doc:"Target artist ID" example:"2"`
+	Body     struct {
+		Type     string `json:"type" doc:"Relationship type" example:"similar"`
+		IsUpvote bool   `json:"is_upvote" doc:"True for upvote, false for downvote"`
+	}
+}
+
+func (h *ArtistRelationshipHandler) VoteHandler(ctx context.Context, req *VoteRelationshipRequest) (*struct{}, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	sourceID, err := strconv.ParseUint(req.SourceID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid source artist ID")
+	}
+	targetID, err := strconv.ParseUint(req.TargetID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid target artist ID")
+	}
+
+	if req.Body.Type == "" {
+		return nil, huma.Error400BadRequest("Relationship type is required")
+	}
+
+	err = h.relService.Vote(uint(sourceID), uint(targetID), req.Body.Type, user.ID, req.Body.IsUpvote)
+	if err != nil {
+		return nil, huma.Error500InternalServerError(fmt.Sprintf("Failed to vote: %v", err))
+	}
+
+	return nil, nil
+}
+
+// ============================================================================
+// Remove Vote (protected)
+// ============================================================================
+
+type RemoveRelationshipVoteRequest struct {
+	SourceID string `path:"source_id" doc:"Source artist ID" example:"1"`
+	TargetID string `path:"target_id" doc:"Target artist ID" example:"2"`
+	Type     string `query:"type" doc:"Relationship type" example:"similar"`
+}
+
+func (h *ArtistRelationshipHandler) RemoveVoteHandler(ctx context.Context, req *RemoveRelationshipVoteRequest) (*struct{}, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	sourceID, err := strconv.ParseUint(req.SourceID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid source artist ID")
+	}
+	targetID, err := strconv.ParseUint(req.TargetID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid target artist ID")
+	}
+
+	if req.Type == "" {
+		return nil, huma.Error400BadRequest("Relationship type is required")
+	}
+
+	err = h.relService.RemoveVote(uint(sourceID), uint(targetID), req.Type, user.ID)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Failed to remove vote")
+	}
+
+	return nil, nil
+}
+
+// ============================================================================
+// Delete Relationship (admin)
+// ============================================================================
+
+type DeleteRelationshipRequest struct {
+	SourceID string `path:"source_id" doc:"Source artist ID" example:"1"`
+	TargetID string `path:"target_id" doc:"Target artist ID" example:"2"`
+	Type     string `query:"type" doc:"Relationship type" example:"similar"`
+}
+
+func (h *ArtistRelationshipHandler) DeleteRelationshipHandler(ctx context.Context, req *DeleteRelationshipRequest) (*struct{}, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+	if !user.IsAdmin {
+		return nil, huma.Error403Forbidden("Admin access required")
+	}
+
+	sourceID, _ := strconv.ParseUint(req.SourceID, 10, 32)
+	targetID, _ := strconv.ParseUint(req.TargetID, 10, 32)
+
+	err := h.relService.DeleteRelationship(uint(sourceID), uint(targetID), req.Type)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Failed to delete relationship")
+	}
+
+	if h.auditLog != nil {
+		go func() {
+			h.auditLog.LogAction(user.ID, "delete_artist_relationship", "artist", uint(sourceID), map[string]interface{}{
+				"target_artist_id": uint(targetID),
+				"type":             req.Type,
+			})
+		}()
+	}
+
+	return nil, nil
+}

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -99,6 +99,7 @@ func SetupRoutes(router *chi.Mux, sc *services.ServiceContainer, cfg *config.Con
 	setupRequestRoutes(api, protectedGroup, sc)
 	setupRevisionRoutes(api, protectedGroup, sc)
 	setupTagRoutes(api, protectedGroup, sc)
+	setupArtistRelationshipRoutes(api, protectedGroup, sc)
 
 	return api
 }
@@ -659,6 +660,24 @@ func setupTagRoutes(api huma.API, protected *huma.Group, sc *services.ServiceCon
 	huma.Delete(protected, "/tags/{tag_id}", tagHandler.DeleteTagHandler)
 	huma.Post(protected, "/tags/{tag_id}/aliases", tagHandler.CreateAliasHandler)
 	huma.Delete(protected, "/tags/{tag_id}/aliases/{alias_id}", tagHandler.DeleteAliasHandler)
+}
+
+// setupArtistRelationshipRoutes configures artist relationship and similar artist endpoints.
+func setupArtistRelationshipRoutes(api huma.API, protected *huma.Group, sc *services.ServiceContainer) {
+	relHandler := handlers.NewArtistRelationshipHandler(sc.ArtistRelationship, sc.AuditLog)
+
+	// Public: get related artists with optional auth (for user's votes)
+	optionalAuthGroup := huma.NewGroup(api, "")
+	optionalAuthGroup.UseMiddleware(middleware.OptionalHumaJWTMiddleware(sc.JWT))
+	huma.Get(optionalAuthGroup, "/artists/{artist_id}/related", relHandler.GetRelatedArtistsHandler)
+
+	// Protected: create relationships and vote
+	huma.Post(protected, "/artists/relationships", relHandler.CreateRelationshipHandler)
+	huma.Post(protected, "/artists/relationships/{source_id}/{target_id}/vote", relHandler.VoteHandler)
+	huma.Delete(protected, "/artists/relationships/{source_id}/{target_id}/vote", relHandler.RemoveVoteHandler)
+
+	// Admin: delete relationships
+	huma.Delete(protected, "/artists/relationships/{source_id}/{target_id}", relHandler.DeleteRelationshipHandler)
 }
 
 // rateLimitHandler handles rate limit exceeded responses with JSON

--- a/backend/internal/services/catalog/artist_relationship_service.go
+++ b/backend/internal/services/catalog/artist_relationship_service.go
@@ -1,0 +1,397 @@
+package catalog
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"time"
+
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/db"
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// ArtistRelationshipService handles artist relationship business logic.
+type ArtistRelationshipService struct {
+	db *gorm.DB
+}
+
+// NewArtistRelationshipService creates a new artist relationship service.
+func NewArtistRelationshipService(database *gorm.DB) *ArtistRelationshipService {
+	if database == nil {
+		database = db.GetDB()
+	}
+	return &ArtistRelationshipService{db: database}
+}
+
+// ──────────────────────────────────────────────
+// CRUD
+// ──────────────────────────────────────────────
+
+// CreateRelationship creates a new artist relationship with canonical ordering.
+func (s *ArtistRelationshipService) CreateRelationship(sourceID, targetID uint, relType string, autoDerived bool) (*models.ArtistRelationship, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	if sourceID == targetID {
+		return nil, fmt.Errorf("cannot create relationship between an artist and itself")
+	}
+
+	src, tgt := models.CanonicalOrder(sourceID, targetID)
+
+	// Check for existing
+	var existing models.ArtistRelationship
+	err := s.db.Where("source_artist_id = ? AND target_artist_id = ? AND relationship_type = ?",
+		src, tgt, relType).First(&existing).Error
+	if err == nil {
+		return nil, fmt.Errorf("relationship already exists between artists %d and %d (type: %s)", src, tgt, relType)
+	}
+
+	rel := &models.ArtistRelationship{
+		SourceArtistID:   src,
+		TargetArtistID:   tgt,
+		RelationshipType: relType,
+		AutoDerived:      autoDerived,
+	}
+
+	if err := s.db.Create(rel).Error; err != nil {
+		return nil, fmt.Errorf("failed to create relationship: %w", err)
+	}
+
+	return rel, nil
+}
+
+// GetRelationship retrieves a relationship between two artists (order-independent).
+func (s *ArtistRelationshipService) GetRelationship(artistA, artistB uint, relType string) (*models.ArtistRelationship, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	src, tgt := models.CanonicalOrder(artistA, artistB)
+
+	var rel models.ArtistRelationship
+	err := s.db.Where("source_artist_id = ? AND target_artist_id = ? AND relationship_type = ?",
+		src, tgt, relType).First(&rel).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get relationship: %w", err)
+	}
+
+	return &rel, nil
+}
+
+// GetRelatedArtists returns artists related to the given artist with vote counts.
+// Pass relType="" to get all types. Results sorted by score descending.
+func (s *ArtistRelationshipService) GetRelatedArtists(artistID uint, relType string, limit int) ([]contracts.RelatedArtistResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	if limit <= 0 {
+		limit = 30
+	}
+
+	// Query both directions
+	query := s.db.Model(&models.ArtistRelationship{}).
+		Where("source_artist_id = ? OR target_artist_id = ?", artistID, artistID)
+
+	if relType != "" {
+		query = query.Where("relationship_type = ?", relType)
+	}
+
+	query = query.Order("score DESC").Limit(limit)
+
+	var rels []models.ArtistRelationship
+	if err := query.Find(&rels).Error; err != nil {
+		return nil, fmt.Errorf("failed to get related artists: %w", err)
+	}
+
+	responses := make([]contracts.RelatedArtistResponse, 0, len(rels))
+	for _, rel := range rels {
+		// Determine the "other" artist
+		otherID := rel.TargetArtistID
+		if otherID == artistID {
+			otherID = rel.SourceArtistID
+		}
+
+		// Fetch artist info
+		var artist models.Artist
+		if err := s.db.First(&artist, otherID).Error; err != nil {
+			continue
+		}
+
+		slug := ""
+		if artist.Slug != nil {
+			slug = *artist.Slug
+		}
+
+		// Get vote counts
+		upvotes, downvotes := s.getVoteCounts(rel.SourceArtistID, rel.TargetArtistID, rel.RelationshipType)
+
+		resp := contracts.RelatedArtistResponse{
+			ArtistID:         otherID,
+			Name:             artist.Name,
+			Slug:             slug,
+			RelationshipType: rel.RelationshipType,
+			Score:            rel.Score,
+			Upvotes:          upvotes,
+			Downvotes:        downvotes,
+			WilsonScore:      rel.WilsonScore(upvotes, downvotes),
+			AutoDerived:      rel.AutoDerived,
+		}
+
+		responses = append(responses, resp)
+	}
+
+	return responses, nil
+}
+
+// DeleteRelationship deletes a relationship and its votes.
+func (s *ArtistRelationshipService) DeleteRelationship(artistA, artistB uint, relType string) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	src, tgt := models.CanonicalOrder(artistA, artistB)
+
+	return s.db.Transaction(func(tx *gorm.DB) error {
+		// Delete votes first
+		tx.Where("source_artist_id = ? AND target_artist_id = ? AND relationship_type = ?",
+			src, tgt, relType).Delete(&models.ArtistRelationshipVote{})
+
+		result := tx.Where("source_artist_id = ? AND target_artist_id = ? AND relationship_type = ?",
+			src, tgt, relType).Delete(&models.ArtistRelationship{})
+		if result.Error != nil {
+			return fmt.Errorf("failed to delete relationship: %w", result.Error)
+		}
+		if result.RowsAffected == 0 {
+			return fmt.Errorf("relationship not found")
+		}
+		return nil
+	})
+}
+
+// ──────────────────────────────────────────────
+// Voting
+// ──────────────────────────────────────────────
+
+// Vote adds or updates a vote on an artist relationship.
+func (s *ArtistRelationshipService) Vote(artistA, artistB uint, relType string, userID uint, isUpvote bool) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	src, tgt := models.CanonicalOrder(artistA, artistB)
+
+	// Verify relationship exists
+	var rel models.ArtistRelationship
+	err := s.db.Where("source_artist_id = ? AND target_artist_id = ? AND relationship_type = ?",
+		src, tgt, relType).First(&rel).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return fmt.Errorf("relationship not found between artists %d and %d (type: %s)", src, tgt, relType)
+		}
+		return fmt.Errorf("failed to verify relationship: %w", err)
+	}
+
+	direction := int16(-1)
+	if isUpvote {
+		direction = 1
+	}
+
+	return s.db.Transaction(func(tx *gorm.DB) error {
+		// Upsert vote
+		var existing models.ArtistRelationshipVote
+		err := tx.Where("source_artist_id = ? AND target_artist_id = ? AND relationship_type = ? AND user_id = ?",
+			src, tgt, relType, userID).First(&existing).Error
+
+		if err == gorm.ErrRecordNotFound {
+			vote := models.ArtistRelationshipVote{
+				SourceArtistID:   src,
+				TargetArtistID:   tgt,
+				RelationshipType: relType,
+				UserID:           userID,
+				Direction:        direction,
+			}
+			if err := tx.Create(&vote).Error; err != nil {
+				return fmt.Errorf("failed to create vote: %w", err)
+			}
+		} else if err != nil {
+			return fmt.Errorf("failed to check existing vote: %w", err)
+		} else {
+			if err := tx.Model(&existing).Update("direction", direction).Error; err != nil {
+				return fmt.Errorf("failed to update vote: %w", err)
+			}
+		}
+
+		// Recalculate score
+		return s.recalculateScore(tx, src, tgt, relType)
+	})
+}
+
+// RemoveVote removes a user's vote on an artist relationship.
+func (s *ArtistRelationshipService) RemoveVote(artistA, artistB uint, relType string, userID uint) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	src, tgt := models.CanonicalOrder(artistA, artistB)
+
+	return s.db.Transaction(func(tx *gorm.DB) error {
+		tx.Where("source_artist_id = ? AND target_artist_id = ? AND relationship_type = ? AND user_id = ?",
+			src, tgt, relType, userID).Delete(&models.ArtistRelationshipVote{})
+
+		return s.recalculateScore(tx, src, tgt, relType)
+	})
+}
+
+// GetUserVote returns a user's vote on a relationship, or nil if not voted.
+func (s *ArtistRelationshipService) GetUserVote(artistA, artistB uint, relType string, userID uint) (*models.ArtistRelationshipVote, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	src, tgt := models.CanonicalOrder(artistA, artistB)
+
+	var vote models.ArtistRelationshipVote
+	err := s.db.Where("source_artist_id = ? AND target_artist_id = ? AND relationship_type = ? AND user_id = ?",
+		src, tgt, relType, userID).First(&vote).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get user vote: %w", err)
+	}
+
+	return &vote, nil
+}
+
+// ──────────────────────────────────────────────
+// Auto-derivation
+// ──────────────────────────────────────────────
+
+// sharedBillRow represents the result of the co-occurrence query.
+type sharedBillRow struct {
+	ArtistA     uint
+	ArtistB     uint
+	SharedCount int
+	LastShared  time.Time
+}
+
+// DeriveSharedBills computes shared_bills relationships from show_artists co-occurrences.
+// Creates or updates relationships where artists share minShows or more approved shows.
+func (s *ArtistRelationshipService) DeriveSharedBills(minShows int) (int64, error) {
+	if s.db == nil {
+		return 0, fmt.Errorf("database not initialized")
+	}
+
+	if minShows <= 0 {
+		minShows = 2
+	}
+
+	var rows []sharedBillRow
+	err := s.db.Raw(`
+		SELECT
+			sa1.artist_id AS artist_a,
+			sa2.artist_id AS artist_b,
+			COUNT(DISTINCT sa1.show_id) AS shared_count,
+			MAX(s.event_date) AS last_shared
+		FROM show_artists sa1
+		JOIN show_artists sa2 ON sa1.show_id = sa2.show_id
+			AND sa1.artist_id < sa2.artist_id
+		JOIN shows s ON s.id = sa1.show_id
+		WHERE s.status = 'approved'
+		GROUP BY sa1.artist_id, sa2.artist_id
+		HAVING COUNT(DISTINCT sa1.show_id) >= ?
+	`, minShows).Scan(&rows).Error
+
+	if err != nil {
+		return 0, fmt.Errorf("failed to query shared bills: %w", err)
+	}
+
+	var upserted int64
+	now := time.Now()
+
+	for _, row := range rows {
+		// Compute recency-weighted score
+		monthsSince := now.Sub(row.LastShared).Hours() / (24 * 30)
+		score := float32(math.Min(float64(row.SharedCount)/10.0, 1.0))
+		// Boost for recency
+		if monthsSince < 3 {
+			score = float32(math.Min(float64(score)*1.2, 1.0))
+		}
+
+		detail, _ := json.Marshal(map[string]interface{}{
+			"shared_count": row.SharedCount,
+			"last_shared":  row.LastShared.Format("2006-01-02"),
+		})
+		detailRaw := json.RawMessage(detail)
+
+		// Upsert
+		var existing models.ArtistRelationship
+		err := s.db.Where("source_artist_id = ? AND target_artist_id = ? AND relationship_type = ?",
+			row.ArtistA, row.ArtistB, models.RelationshipTypeSharedBills).First(&existing).Error
+
+		if err == gorm.ErrRecordNotFound {
+			rel := &models.ArtistRelationship{
+				SourceArtistID:   row.ArtistA,
+				TargetArtistID:   row.ArtistB,
+				RelationshipType: models.RelationshipTypeSharedBills,
+				Score:            score,
+				AutoDerived:      true,
+				Detail:           &detailRaw,
+			}
+			if err := s.db.Create(rel).Error; err == nil {
+				upserted++
+			}
+		} else if err == nil {
+			s.db.Model(&existing).Updates(map[string]interface{}{
+				"score":  score,
+				"detail": &detailRaw,
+			})
+			upserted++
+		}
+	}
+
+	return upserted, nil
+}
+
+// ──────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────
+
+// getVoteCounts returns upvote and downvote counts for a relationship.
+func (s *ArtistRelationshipService) getVoteCounts(sourceID, targetID uint, relType string) (int, int) {
+	var upvotes, downvotes int64
+	s.db.Model(&models.ArtistRelationshipVote{}).
+		Where("source_artist_id = ? AND target_artist_id = ? AND relationship_type = ? AND direction = 1",
+			sourceID, targetID, relType).Count(&upvotes)
+	s.db.Model(&models.ArtistRelationshipVote{}).
+		Where("source_artist_id = ? AND target_artist_id = ? AND relationship_type = ? AND direction = -1",
+			sourceID, targetID, relType).Count(&downvotes)
+	return int(upvotes), int(downvotes)
+}
+
+// recalculateScore recalculates the score for a relationship from vote counts.
+func (s *ArtistRelationshipService) recalculateScore(tx *gorm.DB, sourceID, targetID uint, relType string) error {
+	var upvotes, downvotes int64
+	tx.Model(&models.ArtistRelationshipVote{}).
+		Where("source_artist_id = ? AND target_artist_id = ? AND relationship_type = ? AND direction = 1",
+			sourceID, targetID, relType).Count(&upvotes)
+	tx.Model(&models.ArtistRelationshipVote{}).
+		Where("source_artist_id = ? AND target_artist_id = ? AND relationship_type = ? AND direction = -1",
+			sourceID, targetID, relType).Count(&downvotes)
+
+	var rel models.ArtistRelationship
+	score := float32(rel.WilsonScore(int(upvotes), int(downvotes)))
+
+	return tx.Model(&models.ArtistRelationship{}).
+		Where("source_artist_id = ? AND target_artist_id = ? AND relationship_type = ?",
+			sourceID, targetID, relType).
+		Update("score", score).Error
+}

--- a/backend/internal/services/catalog/artist_relationship_service_test.go
+++ b/backend/internal/services/catalog/artist_relationship_service_test.go
@@ -1,0 +1,481 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/testutil"
+)
+
+// =============================================================================
+// UNIT TESTS
+// =============================================================================
+
+func TestNewArtistRelationshipService(t *testing.T) {
+	svc := NewArtistRelationshipService(nil)
+	assert.NotNil(t, svc)
+}
+
+func TestArtistRelationshipService_NilDatabase(t *testing.T) {
+	svc := &ArtistRelationshipService{db: nil}
+
+	t.Run("CreateRelationship", func(t *testing.T) {
+		_, err := svc.CreateRelationship(1, 2, "similar", false)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+	})
+
+	t.Run("GetRelationship", func(t *testing.T) {
+		_, err := svc.GetRelationship(1, 2, "similar")
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+	})
+
+	t.Run("GetRelatedArtists", func(t *testing.T) {
+		_, err := svc.GetRelatedArtists(1, "", 10)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+	})
+
+	t.Run("DeleteRelationship", func(t *testing.T) {
+		err := svc.DeleteRelationship(1, 2, "similar")
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+	})
+
+	t.Run("Vote", func(t *testing.T) {
+		err := svc.Vote(1, 2, "similar", 1, true)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+	})
+
+	t.Run("RemoveVote", func(t *testing.T) {
+		err := svc.RemoveVote(1, 2, "similar", 1)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+	})
+
+	t.Run("GetUserVote", func(t *testing.T) {
+		_, err := svc.GetUserVote(1, 2, "similar", 1)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+	})
+
+	t.Run("DeriveSharedBills", func(t *testing.T) {
+		_, err := svc.DeriveSharedBills(2)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+	})
+}
+
+// =============================================================================
+// INTEGRATION TESTS
+// =============================================================================
+
+type ArtistRelationshipServiceIntegrationTestSuite struct {
+	suite.Suite
+	container testcontainers.Container
+	db        *gorm.DB
+	svc       *ArtistRelationshipService
+	ctx       context.Context
+}
+
+func (suite *ArtistRelationshipServiceIntegrationTestSuite) SetupSuite() {
+	suite.ctx = context.Background()
+
+	container, err := testcontainers.GenericContainer(suite.ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "postgres:18",
+			ExposedPorts: []string{"5432/tcp"},
+			Env: map[string]string{
+				"POSTGRES_DB":       "test_db",
+				"POSTGRES_USER":     "test_user",
+				"POSTGRES_PASSWORD": "test_password",
+			},
+			WaitingFor: wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(120 * time.Second),
+		},
+		Started: true,
+	})
+	suite.Require().NoError(err)
+	suite.container = container
+
+	host, err := container.Host(suite.ctx)
+	suite.Require().NoError(err)
+	port, err := container.MappedPort(suite.ctx, "5432")
+	suite.Require().NoError(err)
+
+	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
+		host, port.Port())
+
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	suite.Require().NoError(err)
+
+	sqlDB, err := db.DB()
+	suite.Require().NoError(err)
+	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
+
+	suite.db = db
+	suite.svc = NewArtistRelationshipService(db)
+}
+
+func (suite *ArtistRelationshipServiceIntegrationTestSuite) TearDownSuite() {
+	if suite.container != nil {
+		_ = suite.container.Terminate(suite.ctx)
+	}
+}
+
+func (suite *ArtistRelationshipServiceIntegrationTestSuite) SetupTest() {
+	sqlDB, _ := suite.db.DB()
+	_, _ = sqlDB.Exec("DELETE FROM artist_relationship_votes")
+	_, _ = sqlDB.Exec("DELETE FROM artist_relationships")
+	_, _ = sqlDB.Exec("DELETE FROM show_artists")
+	_, _ = sqlDB.Exec("DELETE FROM shows")
+	_, _ = sqlDB.Exec("DELETE FROM artists")
+	_, _ = sqlDB.Exec("DELETE FROM users")
+}
+
+func (suite *ArtistRelationshipServiceIntegrationTestSuite) createArtist(name string) uint {
+	slug := fmt.Sprintf("%s-%d", name, time.Now().UnixNano())
+	artist := &models.Artist{Name: name, Slug: &slug}
+	err := suite.db.Create(artist).Error
+	suite.Require().NoError(err)
+	return artist.ID
+}
+
+func (suite *ArtistRelationshipServiceIntegrationTestSuite) createUser(name string) *models.User {
+	email := fmt.Sprintf("%s-%d@test.com", name, time.Now().UnixNano())
+	user := &models.User{Email: &email, FirstName: &name, IsActive: true, EmailVerified: true}
+	err := suite.db.Create(user).Error
+	suite.Require().NoError(err)
+	return user
+}
+
+func (suite *ArtistRelationshipServiceIntegrationTestSuite) createShow(title string) uint {
+	slug := fmt.Sprintf("show-%d", time.Now().UnixNano())
+	show := &models.Show{
+		Title:     title,
+		Slug:      &slug,
+		EventDate: time.Now().Add(24 * time.Hour),
+		Status:    models.ShowStatusApproved,
+	}
+	err := suite.db.Create(show).Error
+	suite.Require().NoError(err)
+	return show.ID
+}
+
+func (suite *ArtistRelationshipServiceIntegrationTestSuite) addArtistToShow(showID, artistID uint) {
+	suite.db.Exec("INSERT INTO show_artists (show_id, artist_id) VALUES (?, ?)", showID, artistID)
+}
+
+// ──────────────────────────────────────────────
+// CRUD Tests
+// ──────────────────────────────────────────────
+
+func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestCreateRelationship_Success() {
+	a1 := suite.createArtist("Band A")
+	a2 := suite.createArtist("Band B")
+
+	rel, err := suite.svc.CreateRelationship(a1, a2, "similar", false)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(rel)
+	suite.Assert().Equal("similar", rel.RelationshipType)
+	suite.Assert().False(rel.AutoDerived)
+}
+
+func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestCreateRelationship_CanonicalOrdering() {
+	a1 := suite.createArtist("Band A")
+	a2 := suite.createArtist("Band B")
+
+	// Create with reversed order — should still use canonical
+	rel, err := suite.svc.CreateRelationship(a2, a1, "similar", false)
+	suite.Require().NoError(err)
+
+	src, tgt := models.CanonicalOrder(a1, a2)
+	suite.Assert().Equal(src, rel.SourceArtistID)
+	suite.Assert().Equal(tgt, rel.TargetArtistID)
+}
+
+func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestCreateRelationship_SelfRelationship() {
+	a1 := suite.createArtist("Band A")
+
+	_, err := suite.svc.CreateRelationship(a1, a1, "similar", false)
+	suite.Assert().Error(err)
+	suite.Assert().Contains(err.Error(), "cannot create relationship between an artist and itself")
+}
+
+func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestCreateRelationship_Duplicate() {
+	a1 := suite.createArtist("Band A")
+	a2 := suite.createArtist("Band B")
+
+	_, err := suite.svc.CreateRelationship(a1, a2, "similar", false)
+	suite.Require().NoError(err)
+
+	_, err = suite.svc.CreateRelationship(a1, a2, "similar", false)
+	suite.Assert().Error(err)
+	suite.Assert().Contains(err.Error(), "relationship already exists")
+}
+
+func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestCreateRelationship_DifferentTypes() {
+	a1 := suite.createArtist("Band A")
+	a2 := suite.createArtist("Band B")
+
+	_, err := suite.svc.CreateRelationship(a1, a2, "similar", false)
+	suite.Require().NoError(err)
+
+	_, err = suite.svc.CreateRelationship(a1, a2, "side_project", false)
+	suite.Require().NoError(err) // Different type = OK
+}
+
+func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestGetRelationship_Found() {
+	a1 := suite.createArtist("Band A")
+	a2 := suite.createArtist("Band B")
+	suite.svc.CreateRelationship(a1, a2, "similar", false)
+
+	rel, err := suite.svc.GetRelationship(a1, a2, "similar")
+	suite.Require().NoError(err)
+	suite.Require().NotNil(rel)
+}
+
+func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestGetRelationship_ReversedOrder() {
+	a1 := suite.createArtist("Band A")
+	a2 := suite.createArtist("Band B")
+	suite.svc.CreateRelationship(a1, a2, "similar", false)
+
+	// Query with reversed order — should still find it
+	rel, err := suite.svc.GetRelationship(a2, a1, "similar")
+	suite.Require().NoError(err)
+	suite.Require().NotNil(rel)
+}
+
+func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestGetRelationship_NotFound() {
+	rel, err := suite.svc.GetRelationship(99999, 99998, "similar")
+	suite.Assert().NoError(err)
+	suite.Assert().Nil(rel)
+}
+
+func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestGetRelatedArtists() {
+	a1 := suite.createArtist("Center Band")
+	a2 := suite.createArtist("Related Band 1")
+	a3 := suite.createArtist("Related Band 2")
+
+	suite.svc.CreateRelationship(a1, a2, "similar", false)
+	suite.svc.CreateRelationship(a1, a3, "shared_bills", true)
+
+	related, err := suite.svc.GetRelatedArtists(a1, "", 30)
+	suite.Require().NoError(err)
+	suite.Assert().Len(related, 2)
+}
+
+func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestGetRelatedArtists_FilterByType() {
+	a1 := suite.createArtist("Center")
+	a2 := suite.createArtist("Similar")
+	a3 := suite.createArtist("Shared")
+
+	suite.svc.CreateRelationship(a1, a2, "similar", false)
+	suite.svc.CreateRelationship(a1, a3, "shared_bills", true)
+
+	related, err := suite.svc.GetRelatedArtists(a1, "similar", 30)
+	suite.Require().NoError(err)
+	suite.Assert().Len(related, 1)
+	suite.Assert().Equal("Similar", related[0].Name)
+}
+
+func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestDeleteRelationship() {
+	a1 := suite.createArtist("Band A")
+	a2 := suite.createArtist("Band B")
+	suite.svc.CreateRelationship(a1, a2, "similar", false)
+
+	err := suite.svc.DeleteRelationship(a1, a2, "similar")
+	suite.Assert().NoError(err)
+
+	rel, _ := suite.svc.GetRelationship(a1, a2, "similar")
+	suite.Assert().Nil(rel)
+}
+
+func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestDeleteRelationship_NotFound() {
+	err := suite.svc.DeleteRelationship(99999, 99998, "similar")
+	suite.Assert().Error(err)
+}
+
+// ──────────────────────────────────────────────
+// Voting Tests
+// ──────────────────────────────────────────────
+
+func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestVote_Upvote() {
+	a1 := suite.createArtist("Band A")
+	a2 := suite.createArtist("Band B")
+	user := suite.createUser("voter")
+	suite.svc.CreateRelationship(a1, a2, "similar", false)
+
+	err := suite.svc.Vote(a1, a2, "similar", user.ID, true)
+	suite.Assert().NoError(err)
+
+	vote, err := suite.svc.GetUserVote(a1, a2, "similar", user.ID)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(vote)
+	suite.Assert().Equal(int16(1), vote.Direction)
+}
+
+func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestVote_Downvote() {
+	a1 := suite.createArtist("Band A")
+	a2 := suite.createArtist("Band B")
+	user := suite.createUser("voter")
+	suite.svc.CreateRelationship(a1, a2, "similar", false)
+
+	err := suite.svc.Vote(a1, a2, "similar", user.ID, false)
+	suite.Assert().NoError(err)
+
+	vote, _ := suite.svc.GetUserVote(a1, a2, "similar", user.ID)
+	suite.Assert().Equal(int16(-1), vote.Direction)
+}
+
+func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestVote_ChangeDirection() {
+	a1 := suite.createArtist("Band A")
+	a2 := suite.createArtist("Band B")
+	user := suite.createUser("voter")
+	suite.svc.CreateRelationship(a1, a2, "similar", false)
+
+	suite.svc.Vote(a1, a2, "similar", user.ID, true)
+	suite.svc.Vote(a1, a2, "similar", user.ID, false) // Change to downvote
+
+	vote, _ := suite.svc.GetUserVote(a1, a2, "similar", user.ID)
+	suite.Assert().Equal(int16(-1), vote.Direction)
+}
+
+func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestVote_RelationshipNotFound() {
+	user := suite.createUser("voter")
+	err := suite.svc.Vote(99999, 99998, "similar", user.ID, true)
+	suite.Assert().Error(err)
+	suite.Assert().Contains(err.Error(), "relationship not found")
+}
+
+func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestVote_ScoreUpdates() {
+	a1 := suite.createArtist("Band A")
+	a2 := suite.createArtist("Band B")
+	user1 := suite.createUser("voter1")
+	user2 := suite.createUser("voter2")
+	suite.svc.CreateRelationship(a1, a2, "similar", false)
+
+	// Two upvotes
+	suite.svc.Vote(a1, a2, "similar", user1.ID, true)
+	suite.svc.Vote(a1, a2, "similar", user2.ID, true)
+
+	rel, _ := suite.svc.GetRelationship(a1, a2, "similar")
+	suite.Assert().Greater(rel.Score, float32(0))
+}
+
+func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestRemoveVote() {
+	a1 := suite.createArtist("Band A")
+	a2 := suite.createArtist("Band B")
+	user := suite.createUser("voter")
+	suite.svc.CreateRelationship(a1, a2, "similar", false)
+
+	suite.svc.Vote(a1, a2, "similar", user.ID, true)
+	err := suite.svc.RemoveVote(a1, a2, "similar", user.ID)
+	suite.Assert().NoError(err)
+
+	vote, _ := suite.svc.GetUserVote(a1, a2, "similar", user.ID)
+	suite.Assert().Nil(vote)
+}
+
+func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestGetUserVote_NotVoted() {
+	a1 := suite.createArtist("Band A")
+	a2 := suite.createArtist("Band B")
+	user := suite.createUser("voter")
+	suite.svc.CreateRelationship(a1, a2, "similar", false)
+
+	vote, err := suite.svc.GetUserVote(a1, a2, "similar", user.ID)
+	suite.Assert().NoError(err)
+	suite.Assert().Nil(vote)
+}
+
+// ──────────────────────────────────────────────
+// Auto-derivation Tests
+// ──────────────────────────────────────────────
+
+func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestDeriveSharedBills_TwoShows() {
+	a1 := suite.createArtist("Band A")
+	a2 := suite.createArtist("Band B")
+	show1 := suite.createShow("Show 1")
+	show2 := suite.createShow("Show 2")
+
+	suite.addArtistToShow(show1, a1)
+	suite.addArtistToShow(show1, a2)
+	suite.addArtistToShow(show2, a1)
+	suite.addArtistToShow(show2, a2)
+
+	count, err := suite.svc.DeriveSharedBills(2)
+	suite.Require().NoError(err)
+	suite.Assert().Equal(int64(1), count)
+
+	// Verify relationship created
+	rel, err := suite.svc.GetRelationship(a1, a2, "shared_bills")
+	suite.Require().NoError(err)
+	suite.Require().NotNil(rel)
+	suite.Assert().True(rel.AutoDerived)
+	suite.Assert().Greater(rel.Score, float32(0))
+}
+
+func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestDeriveSharedBills_BelowThreshold() {
+	a1 := suite.createArtist("Band A")
+	a2 := suite.createArtist("Band B")
+	show1 := suite.createShow("Show 1")
+
+	suite.addArtistToShow(show1, a1)
+	suite.addArtistToShow(show1, a2)
+
+	// Only 1 shared show, threshold is 2
+	count, err := suite.svc.DeriveSharedBills(2)
+	suite.Require().NoError(err)
+	suite.Assert().Equal(int64(0), count)
+}
+
+func (suite *ArtistRelationshipServiceIntegrationTestSuite) TestDeriveSharedBills_UpdatesExisting() {
+	a1 := suite.createArtist("Band A")
+	a2 := suite.createArtist("Band B")
+	show1 := suite.createShow("Show 1")
+	show2 := suite.createShow("Show 2")
+
+	suite.addArtistToShow(show1, a1)
+	suite.addArtistToShow(show1, a2)
+	suite.addArtistToShow(show2, a1)
+	suite.addArtistToShow(show2, a2)
+
+	suite.svc.DeriveSharedBills(2)
+
+	// Add another show and re-derive
+	show3 := suite.createShow("Show 3")
+	suite.addArtistToShow(show3, a1)
+	suite.addArtistToShow(show3, a2)
+
+	count, err := suite.svc.DeriveSharedBills(2)
+	suite.Require().NoError(err)
+	suite.Assert().Equal(int64(1), count) // Updated existing
+
+	rel, _ := suite.svc.GetRelationship(a1, a2, "shared_bills")
+	suite.Assert().NotNil(rel.Detail) // Has detail JSON
+}
+
+// ──────────────────────────────────────────────
+// Run all integration tests
+// ──────────────────────────────────────────────
+
+func TestArtistRelationshipServiceIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	suite.Run(t, new(ArtistRelationshipServiceIntegrationTestSuite))
+}

--- a/backend/internal/services/container.go
+++ b/backend/internal/services/container.go
@@ -30,8 +30,9 @@ type ServiceContainer struct {
 	Calendar      *engagement.CalendarService
 	Collection    *CollectionService
 	Request       *RequestService
-	Tag           *catalog.TagService
-	FavoriteVenue *engagement.FavoriteVenueService
+	Tag                *catalog.TagService
+	ArtistRelationship *catalog.ArtistRelationshipService
+	FavoriteVenue      *engagement.FavoriteVenueService
 	Festival      *catalog.FestivalService
 	Label         *catalog.LabelService
 	Release       *catalog.ReleaseService
@@ -113,8 +114,9 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 		Calendar:      engagement.NewCalendarService(database, savedShow),
 		Collection:    NewCollectionService(database),
 		Request:       NewRequestService(database),
-		Tag:           catalog.NewTagService(database),
-		FavoriteVenue: engagement.NewFavoriteVenueService(database),
+		Tag:                catalog.NewTagService(database),
+		ArtistRelationship: catalog.NewArtistRelationshipService(database),
+		FavoriteVenue:      engagement.NewFavoriteVenueService(database),
 		Festival:      catalog.NewFestivalService(database),
 		Label:         catalog.NewLabelService(database),
 		Release:       catalog.NewReleaseService(database),

--- a/backend/internal/services/contracts/artist_relationship.go
+++ b/backend/internal/services/contracts/artist_relationship.go
@@ -1,0 +1,38 @@
+package contracts
+
+import "psychic-homily-backend/internal/models"
+
+// ──────────────────────────────────────────────
+// Artist Relationship types
+// ──────────────────────────────────────────────
+
+// RelatedArtistResponse represents a related artist with relationship info.
+type RelatedArtistResponse struct {
+	ArtistID         uint    `json:"artist_id"`
+	Name             string  `json:"name"`
+	Slug             string  `json:"slug"`
+	RelationshipType string  `json:"relationship_type"`
+	Score            float32 `json:"score"`
+	Upvotes          int     `json:"upvotes"`
+	Downvotes        int     `json:"downvotes"`
+	WilsonScore      float64 `json:"wilson_score"`
+	AutoDerived      bool    `json:"auto_derived"`
+	UserVote         *int    `json:"user_vote,omitempty"`
+}
+
+// ArtistRelationshipServiceInterface defines the contract for artist relationship operations.
+type ArtistRelationshipServiceInterface interface {
+	// CRUD
+	CreateRelationship(sourceID, targetID uint, relType string, autoDerived bool) (*models.ArtistRelationship, error)
+	GetRelationship(artistA, artistB uint, relType string) (*models.ArtistRelationship, error)
+	GetRelatedArtists(artistID uint, relType string, limit int) ([]RelatedArtistResponse, error)
+	DeleteRelationship(artistA, artistB uint, relType string) error
+
+	// Voting (only for non-auto-derived, typically "similar")
+	Vote(artistA, artistB uint, relType string, userID uint, isUpvote bool) error
+	RemoveVote(artistA, artistB uint, relType string, userID uint) error
+	GetUserVote(artistA, artistB uint, relType string, userID uint) (*models.ArtistRelationshipVote, error)
+
+	// Auto-derivation
+	DeriveSharedBills(minShows int) (int64, error)
+}

--- a/backend/internal/services/interfaces.go
+++ b/backend/internal/services/interfaces.go
@@ -45,6 +45,7 @@ type CollectionServiceInterface = contracts.CollectionServiceInterface
 type RevisionServiceInterface = contracts.RevisionServiceInterface
 type RequestServiceInterface = contracts.RequestServiceInterface
 type TagServiceInterface = contracts.TagServiceInterface
+type ArtistRelationshipServiceInterface = contracts.ArtistRelationshipServiceInterface
 
 // Compile-time interface satisfaction checks.
 // Engagement services (Bookmark, SavedShow, FavoriteVenue, Calendar, Reminder)
@@ -69,4 +70,5 @@ var (
 	_ CollectionServiceInterface            = (*CollectionService)(nil)
 	_ RequestServiceInterface               = (*RequestService)(nil)
 	_ TagServiceInterface                   = (*catalog.TagService)(nil)
+	_ ArtistRelationshipServiceInterface    = (*catalog.ArtistRelationshipService)(nil)
 )


### PR DESCRIPTION
## Summary
- Similar artist voting service with Wilson score ranking and canonical ordering
- Auto-derived "shared bills" relationships from `show_artists` co-occurrences (2+ shared approved shows)
- 5 API endpoints: GET related artists (optional auth), POST create + initial upvote, POST/DELETE vote, DELETE (admin)
- Recency-weighted scoring for shared bills, detail JSONB with shared count and last shared date
- 32 tests (10 unit + 22 integration with testcontainers)

## Test plan
- [x] Canonical ordering enforced (source < target)
- [x] Voting creates/updates/removes with score recalculation
- [x] Shared bills derivation finds 2+ co-occurrence pairs
- [x] Below-threshold pairs correctly excluded
- [x] Full backend compiles cleanly
- [x] Service wired into container with compile-time check

Closes PSY-53

🤖 Generated with [Claude Code](https://claude.com/claude-code)