### PR TITLE
Add tag frontend: browse, detail, entity tagging with voting (PSY-51)

### DIFF
--- a/frontend/app/tags/[slug]/page.tsx
+++ b/frontend/app/tags/[slug]/page.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import { Suspense } from 'react'
+import { useParams } from 'next/navigation'
+import { Loader2 } from 'lucide-react'
+import { TagDetail } from '@/features/tags/components'
+
+function TagLoadingFallback() {
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center">
+      <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+    </div>
+  )
+}
+
+export default function TagDetailPage() {
+  const params = useParams()
+
+  return (
+    <Suspense fallback={<TagLoadingFallback />}>
+      <TagDetail slug={params.slug as string} />
+    </Suspense>
+  )
+}

--- a/frontend/app/tags/page.tsx
+++ b/frontend/app/tags/page.tsx
@@ -1,0 +1,36 @@
+import { Suspense } from 'react'
+import { TagBrowse } from '@/features/tags/components'
+import { LoadingSpinner } from '@/components/shared'
+
+export const metadata = {
+  title: 'Tags',
+  description: 'Browse tags by category — genres, moods, eras, styles, and more.',
+  alternates: {
+    canonical: 'https://psychichomily.com/tags',
+  },
+  openGraph: {
+    title: 'Tags | Psychic Homily',
+    description: 'Browse tags by category — genres, moods, eras, styles, and more.',
+    url: '/tags',
+    type: 'website',
+  },
+}
+
+export default function TagsPage() {
+  return (
+    <div className="flex min-h-screen items-start justify-center">
+      <main className="w-full max-w-6xl px-4 py-8 md:px-8">
+        <h1 className="text-3xl font-bold text-center mb-8">Tags</h1>
+        <Suspense
+          fallback={
+            <div className="flex justify-center items-center py-12">
+              <LoadingSpinner />
+            </div>
+          }
+        >
+          <TagBrowse />
+        </Suspense>
+      </main>
+    </div>
+  )
+}

--- a/frontend/components/layout/CommandPalette.tsx
+++ b/frontend/components/layout/CommandPalette.tsx
@@ -12,7 +12,7 @@ import {
   CommandSeparator,
 } from '@/components/ui/command'
 import {
-  Calendar, Mic2, MapPin, Disc3, Tag, Tent, BookOpen, Headphones, Send,
+  Calendar, Mic2, MapPin, Disc3, Tag, Tags, Tent, BookOpen, Headphones, Send,
   Library, LayoutList, MessageSquarePlus, Settings, Shield, Search, Clock, X,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
@@ -64,6 +64,12 @@ const routes: RouteItem[] = [
     href: '/labels',
     icon: Tag,
     keywords: ['labels', 'record labels', 'imprints', 'roster', 'catalog'],
+  },
+  {
+    label: 'Tags',
+    href: '/tags',
+    icon: Tags,
+    keywords: ['tags', 'genres', 'moods', 'styles', 'categories', 'tagging'],
   },
   {
     label: 'Collections',

--- a/frontend/components/layout/Sidebar.test.tsx
+++ b/frontend/components/layout/Sidebar.test.tsx
@@ -23,9 +23,9 @@ describe('sidebarGroups', () => {
     expect(sidebarGroups.map(g => g.label)).toEqual(['Discover', 'Community'])
   })
 
-  it('Discover contains Shows, Festivals, Artists, Venues, Releases, Labels, Collections', () => {
+  it('Discover contains Shows, Festivals, Artists, Venues, Releases, Labels, Tags, Collections', () => {
     const discover = sidebarGroups.find(g => g.label === 'Discover')!
-    expect(discover.items.map(i => i.label)).toEqual(['Shows', 'Festivals', 'Artists', 'Venues', 'Releases', 'Labels', 'Collections'])
+    expect(discover.items.map(i => i.label)).toEqual(['Shows', 'Festivals', 'Artists', 'Venues', 'Releases', 'Labels', 'Tags', 'Collections'])
   })
 
   it('Community contains Requests, Blog, DJ Sets, Substack, Submissions', () => {

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import {
-  Calendar, Mic2, MapPin, Disc3, Tag, Tent, BookOpen, Headphones, Newspaper,
+  Calendar, Mic2, MapPin, Disc3, Tag, Tags, Tent, BookOpen, Headphones, Newspaper,
   Send, Library, LayoutList, MessageSquarePlus, Settings, Shield, PanelLeftClose, PanelLeft,
   ExternalLink,
 } from 'lucide-react'
@@ -36,6 +36,7 @@ export const sidebarGroups: SidebarGroup[] = [
       { href: '/venues', label: 'Venues', icon: MapPin },
       { href: '/releases', label: 'Releases', icon: Disc3 },
       { href: '/labels', label: 'Labels', icon: Tag },
+      { href: '/tags', label: 'Tags', icon: Tags },
       { href: '/collections', label: 'Collections', icon: LayoutList },
     ],
   },

--- a/frontend/features/artists/components/ArtistDetail.tsx
+++ b/frontend/features/artists/components/ArtistDetail.tsx
@@ -30,6 +30,7 @@ import {
   type MusicPlatform,
 } from '@/lib/hooks/admin/useAdminArtists'
 import { SocialLinks, MusicEmbed, EntityDetailLayout, EntityHeader, RevisionHistory } from '@/components/shared'
+import { EntityTagList } from '@/features/tags'
 import { ArtistEditForm } from '@/components/forms/ArtistEditForm'
 import { ArtistShowsList } from './ArtistShowsList'
 import { ReportArtistButton } from './ReportArtistButton'
@@ -942,6 +943,15 @@ export function ArtistDetail({ artistId }: ArtistDetailProps) {
           <LabelsTab artistIdOrSlug={artistId} />
         </TabsContent>
       </EntityDetailLayout>
+
+      {/* Tags */}
+      <div className="mt-0 px-4 md:px-0">
+        <EntityTagList
+          entityType="artist"
+          entityId={artist.id}
+          isAuthenticated={isAuthenticated}
+        />
+      </div>
 
       {/* Revision History */}
       <div className="mt-0">

--- a/frontend/features/tags/components/EntityTagList.tsx
+++ b/frontend/features/tags/components/EntityTagList.tsx
@@ -1,0 +1,337 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import Link from 'next/link'
+import { Plus, ThumbsUp, ThumbsDown, X, Search, Loader2 } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import {
+  useEntityTags,
+  useAddTagToEntity,
+  useRemoveTagFromEntity,
+  useVoteOnTag,
+  useRemoveTagVote,
+  useSearchTags,
+} from '../hooks'
+import { getCategoryColor } from '../types'
+import type { EntityTag, TagListItem } from '../types'
+
+interface EntityTagListProps {
+  entityType: string
+  entityId: number
+  isAuthenticated?: boolean
+}
+
+export function EntityTagList({ entityType, entityId, isAuthenticated }: EntityTagListProps) {
+  const { data, isLoading } = useEntityTags(entityType, entityId)
+  const voteMutation = useVoteOnTag()
+  const removeVoteMutation = useRemoveTagVote()
+  const [addDialogOpen, setAddDialogOpen] = useState(false)
+
+  const tags = data?.tags ?? []
+
+  if (isLoading) {
+    return (
+      <div className="py-4">
+        <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  if (tags.length === 0 && !isAuthenticated) {
+    return null
+  }
+
+  const handleVote = (tag: EntityTag, isUpvote: boolean) => {
+    if (!isAuthenticated) return
+    const currentVote = tag.user_vote ?? 0
+    const newVote = isUpvote ? 1 : -1
+
+    if (currentVote === newVote) {
+      // Toggle off
+      removeVoteMutation.mutate({ tagId: tag.tag_id, entityType, entityId })
+    } else {
+      voteMutation.mutate({ tagId: tag.tag_id, entityType, entityId, is_upvote: isUpvote })
+    }
+  }
+
+  return (
+    <div className="py-4">
+      <div className="flex items-center gap-2 mb-3">
+        <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+          Tags
+        </h3>
+        {isAuthenticated && (
+          <Dialog open={addDialogOpen} onOpenChange={setAddDialogOpen}>
+            <DialogTrigger asChild>
+              <button
+                className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+                aria-label="Add tag"
+              >
+                <Plus className="h-3 w-3" />
+                Add
+              </button>
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-md">
+              <DialogHeader>
+                <DialogTitle>Add Tag</DialogTitle>
+              </DialogHeader>
+              <AddTagForm
+                entityType={entityType}
+                entityId={entityId}
+                existingTagIds={tags.map(t => t.tag_id)}
+                onSuccess={() => setAddDialogOpen(false)}
+              />
+            </DialogContent>
+          </Dialog>
+        )}
+      </div>
+
+      {tags.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          No tags yet. Be the first to add one!
+        </p>
+      ) : (
+        <div className="flex flex-wrap gap-2">
+          {tags.map(tag => (
+            <TagWithVotes
+              key={tag.tag_id}
+              tag={tag}
+              isAuthenticated={isAuthenticated}
+              onVote={handleVote}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ──────────────────────────────────────────────
+// Tag pill with voting
+// ──────────────────────────────────────────────
+
+function TagWithVotes({
+  tag,
+  isAuthenticated,
+  onVote,
+}: {
+  tag: EntityTag
+  isAuthenticated?: boolean
+  onVote: (tag: EntityTag, isUpvote: boolean) => void
+}) {
+  const userVote = tag.user_vote ?? 0
+  const score = tag.upvotes - tag.downvotes
+
+  return (
+    <div
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs',
+        getCategoryColor(tag.category)
+      )}
+    >
+      <Link
+        href={`/tags/${tag.slug}`}
+        className="font-medium hover:underline"
+      >
+        {tag.name}
+      </Link>
+
+      {(tag.upvotes > 0 || tag.downvotes > 0) && (
+        <span className="text-[10px] opacity-70 tabular-nums">
+          {score >= 0 ? `+${score}` : score}
+        </span>
+      )}
+
+      {isAuthenticated && (
+        <span className="inline-flex items-center gap-0.5 ml-0.5">
+          <button
+            onClick={() => onVote(tag, true)}
+            className={cn(
+              'rounded p-0.5 transition-colors',
+              userVote === 1
+                ? 'text-green-500'
+                : 'text-current opacity-40 hover:opacity-100 hover:text-green-500'
+            )}
+            title="Upvote"
+            aria-label={`Upvote ${tag.name}`}
+          >
+            <ThumbsUp className="h-3 w-3" />
+          </button>
+          <button
+            onClick={() => onVote(tag, false)}
+            className={cn(
+              'rounded p-0.5 transition-colors',
+              userVote === -1
+                ? 'text-red-500'
+                : 'text-current opacity-40 hover:opacity-100 hover:text-red-500'
+            )}
+            title="Downvote"
+            aria-label={`Downvote ${tag.name}`}
+          >
+            <ThumbsDown className="h-3 w-3" />
+          </button>
+        </span>
+      )}
+    </div>
+  )
+}
+
+// ──────────────────────────────────────────────
+// Add Tag Form
+// ──────────────────────────────────────────────
+
+function AddTagForm({
+  entityType,
+  entityId,
+  existingTagIds,
+  onSuccess,
+}: {
+  entityType: string
+  entityId: number
+  existingTagIds: number[]
+  onSuccess: () => void
+}) {
+  const addMutation = useAddTagToEntity()
+  const [searchQuery, setSearchQuery] = useState('')
+  const [debouncedQuery, setDebouncedQuery] = useState('')
+  const { data: searchResults, isLoading: searchLoading } = useSearchTags(debouncedQuery, 10)
+
+  // Debounce search input
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedQuery(searchQuery)
+    }, 300)
+    return () => clearTimeout(timer)
+  }, [searchQuery])
+
+  const handleSelectTag = (tag: TagListItem) => {
+    addMutation.mutate(
+      { entityType, entityId, tag_id: tag.id },
+      {
+        onSuccess: () => {
+          setSearchQuery('')
+          setDebouncedQuery('')
+          onSuccess()
+        },
+      }
+    )
+  }
+
+  const handleCreateTag = () => {
+    const name = searchQuery.trim()
+    if (!name) return
+    addMutation.mutate(
+      { entityType, entityId, tag_name: name },
+      {
+        onSuccess: () => {
+          setSearchQuery('')
+          setDebouncedQuery('')
+          onSuccess()
+        },
+      }
+    )
+  }
+
+  const filteredResults = searchResults?.tags?.filter(
+    tag => !existingTagIds.includes(tag.id)
+  ) ?? []
+
+  return (
+    <div className="space-y-4">
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+        <Input
+          value={searchQuery}
+          onChange={e => setSearchQuery(e.target.value)}
+          placeholder="Search tags or type a new one..."
+          className="pl-9"
+          autoFocus
+        />
+        {searchQuery && (
+          <button
+            onClick={() => {
+              setSearchQuery('')
+              setDebouncedQuery('')
+            }}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+            aria-label="Clear search"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        )}
+      </div>
+
+      {addMutation.error && (
+        <p className="text-sm text-destructive">
+          {addMutation.error instanceof Error
+            ? addMutation.error.message
+            : 'Failed to add tag'}
+        </p>
+      )}
+
+      {searchLoading && debouncedQuery.length >= 2 && (
+        <div className="flex justify-center py-4">
+          <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+        </div>
+      )}
+
+      {debouncedQuery.length >= 2 && !searchLoading && (
+        <div className="space-y-1 max-h-48 overflow-y-auto">
+          {filteredResults.map(tag => (
+            <button
+              key={tag.id}
+              onClick={() => handleSelectTag(tag)}
+              disabled={addMutation.isPending}
+              className="flex items-center gap-2 w-full rounded-md px-3 py-2 text-sm hover:bg-muted transition-colors text-left"
+            >
+              <span
+                className={cn(
+                  'inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium',
+                  getCategoryColor(tag.category)
+                )}
+              >
+                {tag.category}
+              </span>
+              <span className="font-medium">{tag.name}</span>
+              <span className="ml-auto text-xs text-muted-foreground">
+                {tag.usage_count} {tag.usage_count === 1 ? 'use' : 'uses'}
+              </span>
+            </button>
+          ))}
+
+          {filteredResults.length === 0 && (
+            <div className="px-3 py-2">
+              <p className="text-sm text-muted-foreground mb-2">
+                No matching tags found.
+              </p>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={handleCreateTag}
+                disabled={addMutation.isPending || !searchQuery.trim()}
+              >
+                <Plus className="h-3.5 w-3.5 mr-1.5" />
+                Create &quot;{searchQuery.trim()}&quot;
+              </Button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {debouncedQuery.length < 2 && searchQuery.length > 0 && (
+        <p className="text-sm text-muted-foreground px-1">
+          Type at least 2 characters to search...
+        </p>
+      )}
+    </div>
+  )
+}

--- a/frontend/features/tags/components/TagBrowse.tsx
+++ b/frontend/features/tags/components/TagBrowse.tsx
@@ -1,0 +1,201 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { Search, Hash, Loader2 } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { useTags } from '../hooks'
+import { TAG_CATEGORIES, getCategoryColor, getCategoryLabel } from '../types'
+import type { TagListItem } from '../types'
+
+const PAGE_SIZE = 50
+
+export function TagBrowse() {
+  const [category, setCategory] = useState('')
+  const [searchInput, setSearchInput] = useState('')
+  const [search, setSearch] = useState('')
+  const [offset, setOffset] = useState(0)
+
+  const { data, isLoading, error, refetch } = useTags({
+    category: category || undefined,
+    search: search || undefined,
+    limit: PAGE_SIZE,
+    offset,
+    sort: 'usage',
+  })
+
+  const tags = data?.tags ?? []
+  const total = data?.total ?? 0
+  const hasMore = offset + PAGE_SIZE < total
+
+  const handleCategoryChange = (newCategory: string) => {
+    setCategory(newCategory)
+    setOffset(0)
+  }
+
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault()
+    setSearch(searchInput.trim())
+    setOffset(0)
+  }
+
+  if (error) {
+    return (
+      <div className="text-center py-12 text-destructive">
+        <p>Failed to load tags. Please try again later.</p>
+        <Button variant="outline" className="mt-4" onClick={() => refetch()}>
+          Retry
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <section className="w-full max-w-6xl">
+      {/* Search */}
+      <form onSubmit={handleSearch} className="mb-6">
+        <div className="relative max-w-md">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            value={searchInput}
+            onChange={e => setSearchInput(e.target.value)}
+            placeholder="Search tags..."
+            className="pl-9"
+          />
+        </div>
+      </form>
+
+      {/* Category filter tabs */}
+      <div className="flex items-center gap-1.5 flex-wrap mb-6">
+        <button
+          onClick={() => handleCategoryChange('')}
+          className={cn(
+            'rounded-full px-3 py-1.5 text-xs font-medium transition-colors',
+            !category
+              ? 'bg-foreground text-background'
+              : 'bg-muted text-muted-foreground hover:bg-muted/80 hover:text-foreground'
+          )}
+        >
+          All
+        </button>
+        {TAG_CATEGORIES.map(cat => (
+          <button
+            key={cat}
+            onClick={() => handleCategoryChange(cat)}
+            className={cn(
+              'rounded-full px-3 py-1.5 text-xs font-medium transition-colors border',
+              category === cat
+                ? getCategoryColor(cat)
+                : 'bg-muted text-muted-foreground hover:bg-muted/80 hover:text-foreground border-transparent'
+            )}
+          >
+            {getCategoryLabel(cat)}
+          </button>
+        ))}
+      </div>
+
+      {/* Results count */}
+      {total > 0 && (
+        <p className="text-sm text-muted-foreground mb-4">
+          {total} {total === 1 ? 'tag' : 'tags'} found
+        </p>
+      )}
+
+      {/* Loading state */}
+      {isLoading && !data && (
+        <div className="flex justify-center items-center py-12">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      )}
+
+      {/* Tag cards grid */}
+      {!isLoading && tags.length === 0 ? (
+        <div className="text-center py-12 text-muted-foreground">
+          <p>No tags found.</p>
+          {search && (
+            <p className="text-sm mt-2">
+              Try a different search term.
+            </p>
+          )}
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+          {tags.map((tag: TagListItem) => (
+            <TagCard key={tag.id} tag={tag} />
+          ))}
+        </div>
+      )}
+
+      {/* Pagination */}
+      {(offset > 0 || hasMore) && (
+        <div className="flex items-center justify-center gap-3 mt-8">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={offset === 0}
+            onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+          >
+            Previous
+          </Button>
+          <span className="text-sm text-muted-foreground">
+            Page {Math.floor(offset / PAGE_SIZE) + 1} of{' '}
+            {Math.ceil(total / PAGE_SIZE)}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={!hasMore}
+            onClick={() => setOffset(offset + PAGE_SIZE)}
+          >
+            Next
+          </Button>
+        </div>
+      )}
+    </section>
+  )
+}
+
+// ──────────────────────────────────────────────
+// Tag Card
+// ──────────────────────────────────────────────
+
+function TagCard({ tag }: { tag: TagListItem }) {
+  return (
+    <Link
+      href={`/tags/${tag.slug}`}
+      className="group flex items-start gap-3 rounded-lg border border-border/50 bg-card p-4 hover:border-border hover:bg-muted/30 transition-colors"
+    >
+      <div className="mt-0.5">
+        <Hash className="h-4 w-4 text-muted-foreground group-hover:text-foreground transition-colors" />
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 mb-1">
+          <span className="font-medium text-sm group-hover:text-foreground truncate">
+            {tag.name}
+          </span>
+          {tag.is_official && (
+            <Badge variant="secondary" className="text-[10px] px-1.5 py-0 shrink-0">
+              Official
+            </Badge>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <span
+            className={cn(
+              'inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium',
+              getCategoryColor(tag.category)
+            )}
+          >
+            {getCategoryLabel(tag.category)}
+          </span>
+          <span className="text-xs text-muted-foreground">
+            {tag.usage_count} {tag.usage_count === 1 ? 'use' : 'uses'}
+          </span>
+        </div>
+      </div>
+    </Link>
+  )
+}

--- a/frontend/features/tags/components/TagDetail.tsx
+++ b/frontend/features/tags/components/TagDetail.tsx
@@ -1,0 +1,171 @@
+'use client'
+
+import Link from 'next/link'
+import { ArrowLeft, Hash, Loader2 } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { useTag } from '../hooks'
+import { getCategoryColor, getCategoryLabel } from '../types'
+
+interface TagDetailProps {
+  slug: string
+}
+
+export function TagDetail({ slug }: TagDetailProps) {
+  const { data: tag, isLoading, error } = useTag(slug)
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  if (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : 'Failed to load tag'
+    const is404 =
+      errorMessage.includes('not found') || errorMessage.includes('404')
+
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold mb-2">
+            {is404 ? 'Tag Not Found' : 'Error Loading Tag'}
+          </h1>
+          <p className="text-muted-foreground mb-4">
+            {is404
+              ? "The tag you're looking for doesn't exist."
+              : errorMessage}
+          </p>
+          <Button asChild variant="outline">
+            <Link href="/tags">
+              <ArrowLeft className="h-4 w-4 mr-2" />
+              Back to Tags
+            </Link>
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  if (!tag) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold mb-2">Tag Not Found</h1>
+          <p className="text-muted-foreground mb-4">
+            The tag you&apos;re looking for doesn&apos;t exist.
+          </p>
+          <Button asChild variant="outline">
+            <Link href="/tags">
+              <ArrowLeft className="h-4 w-4 mr-2" />
+              Back to Tags
+            </Link>
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="container max-w-4xl mx-auto px-4 py-6">
+      {/* Back link */}
+      <div className="mb-6">
+        <Link
+          href="/tags"
+          className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <ArrowLeft className="h-4 w-4 mr-1" />
+          Back to Tags
+        </Link>
+      </div>
+
+      {/* Header */}
+      <header className="mb-8">
+        <div className="flex items-start gap-4">
+          <div className="mt-1">
+            <Hash className="h-8 w-8 text-muted-foreground" />
+          </div>
+          <div>
+            <div className="flex items-center gap-3 mb-2">
+              <h1 className="text-3xl font-bold tracking-tight">{tag.name}</h1>
+              {tag.is_official && (
+                <Badge variant="secondary">Official</Badge>
+              )}
+            </div>
+
+            <div className="flex items-center gap-3 mb-4">
+              <span
+                className={cn(
+                  'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium',
+                  getCategoryColor(tag.category)
+                )}
+              >
+                {getCategoryLabel(tag.category)}
+              </span>
+              <span className="text-sm text-muted-foreground">
+                {tag.usage_count} {tag.usage_count === 1 ? 'use' : 'uses'}
+              </span>
+            </div>
+
+            {tag.description && (
+              <p className="text-muted-foreground whitespace-pre-line mb-4">
+                {tag.description}
+              </p>
+            )}
+          </div>
+        </div>
+      </header>
+
+      {/* Parent tag */}
+      {tag.parent_id && tag.parent_name && (
+        <section className="mb-6">
+          <h2 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+            Parent Tag
+          </h2>
+          <Link
+            href={`/tags/${tag.parent_id}`}
+            className="inline-flex items-center gap-1.5 rounded-md px-3 py-2 text-sm border border-border/50 hover:bg-muted/50 transition-colors"
+          >
+            <Hash className="h-3.5 w-3.5 text-muted-foreground" />
+            {tag.parent_name}
+          </Link>
+        </section>
+      )}
+
+      {/* Child tags count */}
+      {tag.child_count > 0 && (
+        <section className="mb-6">
+          <h2 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+            Sub-tags
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            {tag.child_count} {tag.child_count === 1 ? 'sub-tag' : 'sub-tags'}
+          </p>
+        </section>
+      )}
+
+      {/* Aliases */}
+      {tag.aliases && tag.aliases.length > 0 && (
+        <section className="mb-6">
+          <h2 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+            Also known as
+          </h2>
+          <div className="flex flex-wrap gap-2">
+            {tag.aliases.map((alias: string) => (
+              <span
+                key={alias}
+                className="inline-flex items-center rounded-full bg-muted px-2.5 py-0.5 text-xs font-medium text-muted-foreground border border-border/50"
+              >
+                {alias}
+              </span>
+            ))}
+          </div>
+        </section>
+      )}
+    </div>
+  )
+}

--- a/frontend/features/tags/components/index.ts
+++ b/frontend/features/tags/components/index.ts
@@ -1,0 +1,3 @@
+export { EntityTagList } from './EntityTagList'
+export { TagBrowse } from './TagBrowse'
+export { TagDetail } from './TagDetail'

--- a/frontend/features/tags/hooks/index.ts
+++ b/frontend/features/tags/hooks/index.ts
@@ -1,0 +1,301 @@
+'use client'
+
+/**
+ * Tag Hooks
+ *
+ * TanStack Query hooks for tag browsing, entity tagging, and tag voting.
+ */
+
+import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query'
+import { apiRequest, API_ENDPOINTS } from '@/lib/api'
+import { queryKeys } from '@/lib/queryClient'
+import type {
+  TagDetailResponse,
+  TagListResponse,
+  TagSearchResponse,
+  EntityTagsResponse,
+  EntityTag,
+} from '../types'
+
+// ──────────────────────────────────────────────
+// Queries
+// ──────────────────────────────────────────────
+
+interface UseTagsParams {
+  category?: string
+  search?: string
+  parent_id?: number
+  sort?: string
+  limit?: number
+  offset?: number
+}
+
+/** Fetch tags list with optional filters */
+export function useTags(params?: UseTagsParams) {
+  const searchParams = new URLSearchParams()
+  if (params?.category) searchParams.set('category', params.category)
+  if (params?.search) searchParams.set('search', params.search)
+  if (params?.parent_id) searchParams.set('parent_id', String(params.parent_id))
+  if (params?.sort) searchParams.set('sort', params.sort)
+  if (params?.limit) searchParams.set('limit', String(params.limit))
+  if (params?.offset) searchParams.set('offset', String(params.offset))
+
+  const queryString = searchParams.toString()
+  const url = queryString
+    ? `${API_ENDPOINTS.TAGS.LIST}?${queryString}`
+    : API_ENDPOINTS.TAGS.LIST
+
+  return useQuery({
+    queryKey: queryKeys.tags.list(params as Record<string, unknown> | undefined),
+    queryFn: () => apiRequest<TagListResponse>(url),
+    staleTime: 5 * 60 * 1000,
+    placeholderData: keepPreviousData,
+  })
+}
+
+/** Search tags for autocomplete (debounced, enabled when query length >= 2) */
+export function useSearchTags(query: string, limit?: number) {
+  const searchParams = new URLSearchParams()
+  searchParams.set('q', query)
+  if (limit) searchParams.set('limit', String(limit))
+
+  const url = `${API_ENDPOINTS.TAGS.SEARCH}?${searchParams.toString()}`
+
+  return useQuery({
+    queryKey: queryKeys.tags.search(query),
+    queryFn: () => apiRequest<TagSearchResponse>(url),
+    enabled: query.length >= 2,
+    staleTime: 30 * 1000,
+  })
+}
+
+/** Fetch a single tag by ID or slug */
+export function useTag(idOrSlug: string | number, options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: queryKeys.tags.detail(idOrSlug),
+    queryFn: () =>
+      apiRequest<TagDetailResponse>(API_ENDPOINTS.TAGS.GET(idOrSlug)),
+    enabled: options?.enabled ?? true,
+    staleTime: 5 * 60 * 1000,
+  })
+}
+
+/** Fetch tags on an entity */
+export function useEntityTags(
+  entityType: string,
+  entityId: number,
+  options?: { enabled?: boolean }
+) {
+  return useQuery({
+    queryKey: queryKeys.tags.entityTags(entityType, entityId),
+    queryFn: () =>
+      apiRequest<EntityTagsResponse>(API_ENDPOINTS.ENTITY_TAGS.LIST(entityType, entityId)),
+    enabled: (options?.enabled ?? true) && entityId > 0,
+    staleTime: 5 * 60 * 1000,
+  })
+}
+
+// ──────────────────────────────────────────────
+// Mutations
+// ──────────────────────────────────────────────
+
+/** Add a tag to an entity */
+export function useAddTagToEntity() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      entityType,
+      entityId,
+      tag_id,
+      tag_name,
+    }: {
+      entityType: string
+      entityId: number
+      tag_id?: number
+      tag_name?: string
+    }) =>
+      apiRequest<void>(API_ENDPOINTS.ENTITY_TAGS.ADD(entityType, entityId), {
+        method: 'POST',
+        body: JSON.stringify({ tag_id, tag_name }),
+      }),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.tags.entityTags(variables.entityType, variables.entityId),
+      })
+      queryClient.invalidateQueries({ queryKey: queryKeys.tags.all })
+    },
+  })
+}
+
+/** Remove a tag from an entity */
+export function useRemoveTagFromEntity() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      entityType,
+      entityId,
+      tagId,
+    }: {
+      entityType: string
+      entityId: number
+      tagId: number
+    }) =>
+      apiRequest<void>(API_ENDPOINTS.ENTITY_TAGS.REMOVE(entityType, entityId, tagId), {
+        method: 'DELETE',
+      }),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.tags.entityTags(variables.entityType, variables.entityId),
+      })
+      queryClient.invalidateQueries({ queryKey: queryKeys.tags.all })
+    },
+  })
+}
+
+/** Vote on a tag (with optimistic updates) */
+export function useVoteOnTag() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      tagId,
+      entityType,
+      entityId,
+      is_upvote,
+    }: {
+      tagId: number
+      entityType: string
+      entityId: number
+      is_upvote: boolean
+    }) =>
+      apiRequest<void>(API_ENDPOINTS.ENTITY_TAGS.VOTE(tagId, entityType, entityId), {
+        method: 'POST',
+        body: JSON.stringify({ is_upvote }),
+      }),
+    onMutate: async ({ tagId, entityType, entityId, is_upvote }) => {
+      await queryClient.cancelQueries({
+        queryKey: queryKeys.tags.entityTags(entityType, entityId),
+      })
+
+      const previousData = queryClient.getQueryData<EntityTagsResponse>(
+        queryKeys.tags.entityTags(entityType, entityId)
+      )
+
+      if (previousData) {
+        const newVote = is_upvote ? 1 : -1
+        const updatedTags = previousData.tags.map((tag: EntityTag) => {
+          if (tag.tag_id !== tagId) return tag
+
+          const oldVote = tag.user_vote ?? 0
+          let upvoteDelta = 0
+          let downvoteDelta = 0
+
+          if (oldVote === 1) {
+            upvoteDelta = -1
+            if (newVote === -1) downvoteDelta = 1
+          } else if (oldVote === -1) {
+            downvoteDelta = -1
+            if (newVote === 1) upvoteDelta = 1
+          } else {
+            if (newVote === 1) upvoteDelta = 1
+            else downvoteDelta = 1
+          }
+
+          return {
+            ...tag,
+            user_vote: newVote,
+            upvotes: tag.upvotes + upvoteDelta,
+            downvotes: tag.downvotes + downvoteDelta,
+          }
+        })
+
+        queryClient.setQueryData<EntityTagsResponse>(
+          queryKeys.tags.entityTags(entityType, entityId),
+          { ...previousData, tags: updatedTags }
+        )
+      }
+
+      return { previousData }
+    },
+    onError: (_err, variables, context) => {
+      if (context?.previousData) {
+        queryClient.setQueryData(
+          queryKeys.tags.entityTags(variables.entityType, variables.entityId),
+          context.previousData
+        )
+      }
+    },
+    onSettled: (_data, _error, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.tags.entityTags(variables.entityType, variables.entityId),
+      })
+    },
+  })
+}
+
+/** Remove a vote from a tag (with optimistic updates) */
+export function useRemoveTagVote() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      tagId,
+      entityType,
+      entityId,
+    }: {
+      tagId: number
+      entityType: string
+      entityId: number
+    }) =>
+      apiRequest<void>(API_ENDPOINTS.ENTITY_TAGS.VOTE(tagId, entityType, entityId), {
+        method: 'DELETE',
+      }),
+    onMutate: async ({ tagId, entityType, entityId }) => {
+      await queryClient.cancelQueries({
+        queryKey: queryKeys.tags.entityTags(entityType, entityId),
+      })
+
+      const previousData = queryClient.getQueryData<EntityTagsResponse>(
+        queryKeys.tags.entityTags(entityType, entityId)
+      )
+
+      if (previousData) {
+        const updatedTags = previousData.tags.map((tag: EntityTag) => {
+          if (tag.tag_id !== tagId) return tag
+
+          const oldVote = tag.user_vote ?? 0
+          let upvoteDelta = 0
+          let downvoteDelta = 0
+
+          if (oldVote === 1) upvoteDelta = -1
+          else if (oldVote === -1) downvoteDelta = -1
+
+          return {
+            ...tag,
+            user_vote: null,
+            upvotes: tag.upvotes + upvoteDelta,
+            downvotes: tag.downvotes + downvoteDelta,
+          }
+        })
+
+        queryClient.setQueryData<EntityTagsResponse>(
+          queryKeys.tags.entityTags(entityType, entityId),
+          { ...previousData, tags: updatedTags }
+        )
+      }
+
+      return { previousData }
+    },
+    onError: (_err, variables, context) => {
+      if (context?.previousData) {
+        queryClient.setQueryData(
+          queryKeys.tags.entityTags(variables.entityType, variables.entityId),
+          context.previousData
+        )
+      }
+    },
+    onSettled: (_data, _error, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.tags.entityTags(variables.entityType, variables.entityId),
+      })
+    },
+  })
+}

--- a/frontend/features/tags/index.ts
+++ b/frontend/features/tags/index.ts
@@ -1,0 +1,35 @@
+// Public API for the tags feature module.
+// Other features should import from '@/features/tags', not from internal paths.
+
+export type {
+  TagCategory,
+  TagEntityType,
+  TagListItem,
+  TagDetailResponse,
+  EntityTag,
+  TagAlias,
+  TagListResponse,
+  TagSearchResponse,
+  EntityTagsResponse,
+  TagAliasesResponse,
+} from './types'
+
+export {
+  TAG_CATEGORIES,
+  TAG_ENTITY_TYPES,
+  getCategoryColor,
+  getCategoryLabel,
+} from './types'
+
+export {
+  useTags,
+  useSearchTags,
+  useTag,
+  useEntityTags,
+  useAddTagToEntity,
+  useRemoveTagFromEntity,
+  useVoteOnTag,
+  useRemoveTagVote,
+} from './hooks'
+
+export { EntityTagList, TagBrowse, TagDetail } from './components'

--- a/frontend/features/tags/types.ts
+++ b/frontend/features/tags/types.ts
@@ -1,0 +1,82 @@
+// Tag types — aligned with backend contracts/tag.go response types.
+
+export const TAG_CATEGORIES = [
+  'genre', 'mood', 'era', 'style', 'instrument', 'locale', 'other'
+] as const
+export type TagCategory = typeof TAG_CATEGORIES[number]
+
+export const TAG_ENTITY_TYPES = [
+  'artist', 'release', 'label', 'show', 'venue', 'festival'
+] as const
+export type TagEntityType = typeof TAG_ENTITY_TYPES[number]
+
+export interface TagListItem {
+  id: number
+  name: string
+  slug: string
+  category: string
+  is_official: boolean
+  usage_count: number
+  created_at: string
+}
+
+export interface TagDetailResponse extends TagListItem {
+  description?: string
+  parent_id?: number
+  parent_name?: string
+  child_count: number
+  aliases: string[]
+  updated_at: string
+}
+
+export interface EntityTag {
+  tag_id: number
+  name: string
+  slug: string
+  category: string
+  upvotes: number
+  downvotes: number
+  wilson_score: number
+  user_vote?: number | null
+  added_by_username?: string
+}
+
+export interface TagAlias {
+  id: number
+  alias: string
+  created_at: string
+}
+
+export interface TagListResponse {
+  tags: TagListItem[]
+  total: number
+}
+
+export interface TagSearchResponse {
+  tags: TagListItem[]
+}
+
+export interface EntityTagsResponse {
+  tags: EntityTag[]
+}
+
+export interface TagAliasesResponse {
+  aliases: TagAlias[]
+}
+
+export function getCategoryColor(category: string): string {
+  const colors: Record<string, string> = {
+    genre: 'bg-blue-500/10 text-blue-400 border-blue-500/20',
+    mood: 'bg-purple-500/10 text-purple-400 border-purple-500/20',
+    era: 'bg-amber-500/10 text-amber-400 border-amber-500/20',
+    style: 'bg-emerald-500/10 text-emerald-400 border-emerald-500/20',
+    instrument: 'bg-red-500/10 text-red-400 border-red-500/20',
+    locale: 'bg-cyan-500/10 text-cyan-400 border-cyan-500/20',
+    other: 'bg-zinc-500/10 text-zinc-400 border-zinc-500/20',
+  }
+  return colors[category] || colors.other
+}
+
+export function getCategoryLabel(category: string): string {
+  return category.charAt(0).toUpperCase() + category.slice(1)
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -337,6 +337,26 @@ export const API_ENDPOINTS = {
       `${API_BASE_URL}/requests/${requestId}/close`,
   },
 
+  // Tag endpoints
+  TAGS: {
+    LIST: `${API_BASE_URL}/tags`,
+    SEARCH: `${API_BASE_URL}/tags/search`,
+    GET: (idOrSlug: string | number) => `${API_BASE_URL}/tags/${idOrSlug}`,
+    ALIASES: (idOrSlug: string | number) => `${API_BASE_URL}/tags/${idOrSlug}/aliases`,
+  },
+
+  // Entity tag endpoints
+  ENTITY_TAGS: {
+    LIST: (entityType: string, entityId: number) =>
+      `${API_BASE_URL}/entities/${entityType}/${entityId}/tags`,
+    ADD: (entityType: string, entityId: number) =>
+      `${API_BASE_URL}/entities/${entityType}/${entityId}/tags`,
+    REMOVE: (entityType: string, entityId: number, tagId: number) =>
+      `${API_BASE_URL}/entities/${entityType}/${entityId}/tags/${tagId}`,
+    VOTE: (tagId: number, entityType: string, entityId: number) =>
+      `${API_BASE_URL}/tags/${tagId}/entities/${entityType}/${entityId}/votes`,
+  },
+
   // Revision history endpoints
   REVISIONS: {
     ENTITY_HISTORY: (entityType: string, entityId: string | number) =>

--- a/frontend/lib/queryClient.ts
+++ b/frontend/lib/queryClient.ts
@@ -287,6 +287,16 @@ export const queryKeys = {
       ['requests', 'detail', requestId] as const,
   },
 
+  // Tag queries
+  tags: {
+    all: ['tags'] as const,
+    list: (params?: Record<string, unknown>) => ['tags', 'list', params] as const,
+    search: (query: string) => ['tags', 'search', query.toLowerCase()] as const,
+    detail: (idOrSlug: string | number) => ['tags', 'detail', String(idOrSlug)] as const,
+    aliases: (tagId: number) => ['tags', 'aliases', tagId] as const,
+    entityTags: (entityType: string, entityId: number) => ['tags', 'entityTags', entityType, entityId] as const,
+  },
+
   // Revision history queries
   revisions: {
     all: ['revisions'] as const,
@@ -382,6 +392,14 @@ export const createInvalidateQueries = (queryClient: QueryClient) => ({
   // Invalidate request queries
   requests: () =>
     queryClient.invalidateQueries({ queryKey: ['requests'] }),
+
+  // Invalidate tag queries
+  tags: () =>
+    queryClient.invalidateQueries({ queryKey: ['tags'] }),
+
+  // Invalidate entity tag queries
+  entityTags: (entityType: string, entityId: number) =>
+    queryClient.invalidateQueries({ queryKey: ['tags', 'entityTags', entityType, entityId] }),
 
   // Invalidate revision queries
   revisions: () =>


### PR DESCRIPTION
## Summary
- Tag feature module (`features/tags/`) with types, 8 hooks (optimistic vote updates), and 3 components
- `/tags` browse page with category filter tabs, search, and paginated tag grid
- `/tags/[slug]` detail page with hierarchy, aliases, and usage count
- `EntityTagList` component for any entity page — category-colored tag pills with up/down voting and add-tag autocomplete dialog
- Integrated on ArtistDetail page; ready to add to VenueDetail, ReleaseDetail, etc.
- Sidebar nav + Cmd+K command palette entries for Tags

## Test plan
- [x] TypeScript compiles cleanly (no new type errors)
- [x] Sidebar test updated with Tags nav item — 19 tests pass
- [x] Query keys and API endpoints registered
- [x] EntityTagList integrated on ArtistDetail

Closes PSY-51

🤖 Generated with [Claude Code](https://claude.com/claude-code)