### PR TITLE
Add tag admin UI with CRUD and alias management

### DIFF
--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import dynamic from 'next/dynamic'
-import { Shield, MapPin, Loader2, Upload, BadgeCheck, Flag, ScrollText, Users, LayoutDashboard, Clock, Disc3, Tag, Tent, Workflow, Library } from 'lucide-react'
+import { Shield, MapPin, Loader2, Upload, BadgeCheck, Flag, ScrollText, Users, LayoutDashboard, Clock, Disc3, Tag, Tags, Tent, Workflow, Library } from 'lucide-react'
 import { usePendingVenueEdits } from '@/lib/hooks/admin/useAdminVenueEdits'
 import { useUnverifiedVenues } from '@/lib/hooks/admin/useAdminVenues'
 import { usePendingReports } from '@/lib/hooks/admin/useAdminReports'
@@ -107,6 +107,14 @@ const PipelineVenuesComponent = dynamic(
 )
 
 const UsersPage = dynamic(() => import('./users/page'), {
+  loading: () => (
+    <div className="flex items-center justify-center py-12">
+      <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+    </div>
+  ),
+})
+
+const TagsPage = dynamic(() => import('./tags/page'), {
   loading: () => (
     <div className="flex items-center justify-center py-12">
       <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
@@ -232,6 +240,10 @@ export default function AdminPage() {
               <Library className="h-4 w-4" />
               Collections
             </TabsTrigger>
+            <TabsTrigger value="tags" className="gap-2">
+              <Tags className="h-4 w-4" />
+              Tags
+            </TabsTrigger>
             <TabsTrigger value="users" className="gap-2">
               <Users className="h-4 w-4" />
               Users
@@ -284,6 +296,10 @@ export default function AdminPage() {
 
           <TabsContent value="collections" className="space-y-4">
             <CollectionManagementComponent />
+          </TabsContent>
+
+          <TabsContent value="tags" className="space-y-4">
+            <TagsPage />
           </TabsContent>
 
           <TabsContent value="users" className="space-y-4">

--- a/frontend/app/admin/tags/page.tsx
+++ b/frontend/app/admin/tags/page.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import { TagManagement } from '@/features/tags/admin/TagManagement'
+
+export default function AdminTagsPage() {
+  return <TagManagement />
+}

--- a/frontend/features/tags/admin/TagManagement.tsx
+++ b/frontend/features/tags/admin/TagManagement.tsx
@@ -1,0 +1,783 @@
+'use client'
+
+import { useState, useCallback, useEffect } from 'react'
+import {
+  Loader2,
+  Plus,
+  Pencil,
+  Trash2,
+  Search,
+  Inbox,
+  Tags,
+  X,
+  BadgeCheck,
+} from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import { Badge } from '@/components/ui/badge'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog'
+import { useTags, useTag } from '../hooks'
+import {
+  useCreateTag,
+  useUpdateTag,
+  useDeleteTag,
+  useTagAliases,
+  useCreateAlias,
+  useDeleteAlias,
+} from './useAdminTags'
+import {
+  TAG_CATEGORIES,
+  getCategoryColor,
+  getCategoryLabel,
+  type TagCategory,
+} from '../types'
+
+type DialogMode = 'create' | 'edit' | 'delete' | null
+
+// ============================================================================
+// Alias Manager Sub-Component
+// ============================================================================
+
+function AliasManager({ tagId }: { tagId: number }) {
+  const { data: aliasData, isLoading } = useTagAliases(tagId)
+  const createAlias = useCreateAlias()
+  const deleteAlias = useDeleteAlias()
+  const [newAlias, setNewAlias] = useState('')
+
+  const handleAdd = useCallback(() => {
+    if (!newAlias.trim()) return
+    createAlias.mutate(
+      { tagId, alias: newAlias.trim() },
+      { onSuccess: () => setNewAlias('') }
+    )
+  }, [tagId, newAlias, createAlias])
+
+  const handleRemove = useCallback(
+    (aliasId: number) => {
+      deleteAlias.mutate({ tagId, aliasId })
+    },
+    [tagId, deleteAlias]
+  )
+
+  return (
+    <div className="space-y-3">
+      <Label>Aliases</Label>
+      <div className="flex items-end gap-2">
+        <div className="flex-1">
+          <Input
+            placeholder="Add alias (e.g., post punk)..."
+            value={newAlias}
+            onChange={(e) => setNewAlias(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault()
+                handleAdd()
+              }
+            }}
+          />
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={handleAdd}
+          disabled={createAlias.isPending || !newAlias.trim()}
+        >
+          {createAlias.isPending ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Plus className="h-4 w-4" />
+          )}
+        </Button>
+      </div>
+
+      {isLoading ? (
+        <div className="flex items-center justify-center py-2">
+          <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+        </div>
+      ) : aliasData?.aliases && aliasData.aliases.length > 0 ? (
+        <div className="flex flex-wrap gap-2">
+          {aliasData.aliases.map((alias) => (
+            <Badge
+              key={alias.id}
+              variant="secondary"
+              className="gap-1 pl-2 pr-1"
+            >
+              {alias.alias}
+              <button
+                onClick={() => handleRemove(alias.id)}
+                disabled={deleteAlias.isPending}
+                className="ml-0.5 rounded-full p-0.5 hover:bg-muted-foreground/20"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </Badge>
+          ))}
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground">No aliases yet.</p>
+      )}
+    </div>
+  )
+}
+
+// ============================================================================
+// Create Tag Form
+// ============================================================================
+
+function CreateTagForm({
+  onSuccess,
+  onCancel,
+}: {
+  onSuccess: () => void
+  onCancel: () => void
+}) {
+  const createMutation = useCreateTag()
+
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [category, setCategory] = useState<string>('genre')
+  const [isOfficial, setIsOfficial] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault()
+      setError(null)
+
+      if (!name.trim()) {
+        setError('Name is required')
+        return
+      }
+
+      createMutation.mutate(
+        {
+          name: name.trim(),
+          description: description.trim() || undefined,
+          category,
+          is_official: isOfficial,
+        },
+        {
+          onSuccess: () => onSuccess(),
+          onError: (err) => {
+            setError(
+              err instanceof Error ? err.message : 'Failed to create tag'
+            )
+          },
+        }
+      )
+    },
+    [name, description, category, isOfficial, createMutation, onSuccess]
+  )
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      {error && (
+        <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      <div className="space-y-2">
+        <Label htmlFor="create-name">Name *</Label>
+        <Input
+          id="create-name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="e.g., post-punk"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="create-category">Category *</Label>
+        <select
+          id="create-category"
+          value={category}
+          onChange={(e) => setCategory(e.target.value)}
+          className="h-9 w-full rounded-md border bg-background px-3 text-sm"
+        >
+          {TAG_CATEGORIES.map((cat) => (
+            <option key={cat} value={cat}>
+              {getCategoryLabel(cat)}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="create-desc">Description</Label>
+        <Textarea
+          id="create-desc"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="Optional description..."
+          rows={2}
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <input
+          type="checkbox"
+          id="create-official"
+          checked={isOfficial}
+          onChange={(e) => setIsOfficial(e.target.checked)}
+          className="h-4 w-4 rounded border-muted-foreground"
+        />
+        <Label htmlFor="create-official" className="text-sm font-normal">
+          Official tag (canonical, curated by admins)
+        </Label>
+      </div>
+
+      <DialogFooter>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={onCancel}
+          disabled={createMutation.isPending}
+        >
+          Cancel
+        </Button>
+        <Button type="submit" disabled={createMutation.isPending}>
+          {createMutation.isPending ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              Creating...
+            </>
+          ) : (
+            'Create Tag'
+          )}
+        </Button>
+      </DialogFooter>
+    </form>
+  )
+}
+
+// ============================================================================
+// Edit Tag Form
+// ============================================================================
+
+function EditTagForm({
+  tagId,
+  onSuccess,
+  onCancel,
+}: {
+  tagId: number
+  onSuccess: () => void
+  onCancel: () => void
+}) {
+  const { data: tag, isLoading } = useTag(tagId, { enabled: tagId > 0 })
+  const updateMutation = useUpdateTag()
+
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [category, setCategory] = useState<string>('genre')
+  const [isOfficial, setIsOfficial] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [initialized, setInitialized] = useState(false)
+
+  useEffect(() => {
+    if (tag && !initialized) {
+      setName(tag.name)
+      setDescription(tag.description || '')
+      setCategory(tag.category)
+      setIsOfficial(tag.is_official)
+      setInitialized(true)
+    }
+  }, [tag, initialized])
+
+  const handleSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault()
+      setError(null)
+
+      if (!name.trim()) {
+        setError('Name is required')
+        return
+      }
+
+      updateMutation.mutate(
+        {
+          tagId,
+          data: {
+            name: name.trim(),
+            description: description.trim() || null,
+            category,
+            is_official: isOfficial,
+          },
+        },
+        {
+          onSuccess: () => onSuccess(),
+          onError: (err) => {
+            setError(
+              err instanceof Error ? err.message : 'Failed to update tag'
+            )
+          },
+        }
+      )
+    },
+    [name, description, category, isOfficial, tagId, updateMutation, onSuccess]
+  )
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  if (!tag) {
+    return (
+      <div className="text-center py-8 text-muted-foreground">
+        Tag not found.
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <form onSubmit={handleSubmit} className="space-y-4">
+        {error && (
+          <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+            {error}
+          </div>
+        )}
+
+        <div className="space-y-2">
+          <Label htmlFor="edit-name">Name *</Label>
+          <Input
+            id="edit-name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="edit-category">Category *</Label>
+          <select
+            id="edit-category"
+            value={category}
+            onChange={(e) => setCategory(e.target.value)}
+            className="h-9 w-full rounded-md border bg-background px-3 text-sm"
+          >
+            {TAG_CATEGORIES.map((cat) => (
+              <option key={cat} value={cat}>
+                {getCategoryLabel(cat)}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="edit-desc">Description</Label>
+          <Textarea
+            id="edit-desc"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Optional description..."
+            rows={2}
+          />
+        </div>
+
+        <div className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            id="edit-official"
+            checked={isOfficial}
+            onChange={(e) => setIsOfficial(e.target.checked)}
+            className="h-4 w-4 rounded border-muted-foreground"
+          />
+          <Label htmlFor="edit-official" className="text-sm font-normal">
+            Official tag
+          </Label>
+        </div>
+
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <span>Slug: {tag.slug}</span>
+          <span>|</span>
+          <span>Usage: {tag.usage_count}</span>
+          {tag.child_count > 0 && (
+            <>
+              <span>|</span>
+              <span>{tag.child_count} children</span>
+            </>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onCancel}
+            disabled={updateMutation.isPending}
+          >
+            Cancel
+          </Button>
+          <Button type="submit" disabled={updateMutation.isPending}>
+            {updateMutation.isPending ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Saving...
+              </>
+            ) : (
+              'Save Changes'
+            )}
+          </Button>
+        </DialogFooter>
+      </form>
+
+      {/* Alias Management */}
+      <div className="border-t pt-4">
+        <AliasManager tagId={tagId} />
+      </div>
+    </div>
+  )
+}
+
+// ============================================================================
+// Delete Confirmation
+// ============================================================================
+
+function DeleteConfirmation({
+  tagName,
+  tagId,
+  onSuccess,
+  onCancel,
+}: {
+  tagName: string
+  tagId: number
+  onSuccess: () => void
+  onCancel: () => void
+}) {
+  const deleteMutation = useDeleteTag()
+  const [error, setError] = useState<string | null>(null)
+
+  const handleDelete = useCallback(() => {
+    setError(null)
+    deleteMutation.mutate(tagId, {
+      onSuccess: () => onSuccess(),
+      onError: (err) => {
+        setError(
+          err instanceof Error ? err.message : 'Failed to delete tag'
+        )
+      },
+    })
+  }, [tagId, deleteMutation, onSuccess])
+
+  return (
+    <div className="space-y-4">
+      {error && (
+        <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      <p className="text-sm text-muted-foreground">
+        Are you sure you want to delete{' '}
+        <span className="font-semibold text-foreground">
+          &quot;{tagName}&quot;
+        </span>
+        ? This will remove it from all entities and delete all associated aliases
+        and votes.
+      </p>
+
+      <DialogFooter>
+        <Button
+          variant="outline"
+          onClick={onCancel}
+          disabled={deleteMutation.isPending}
+        >
+          Cancel
+        </Button>
+        <Button
+          variant="destructive"
+          onClick={handleDelete}
+          disabled={deleteMutation.isPending}
+        >
+          {deleteMutation.isPending ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              Deleting...
+            </>
+          ) : (
+            'Delete Tag'
+          )}
+        </Button>
+      </DialogFooter>
+    </div>
+  )
+}
+
+// ============================================================================
+// Main Component
+// ============================================================================
+
+export function TagManagement() {
+  const [searchInput, setSearchInput] = useState('')
+  const [debouncedSearch, setDebouncedSearch] = useState('')
+  const [categoryFilter, setCategoryFilter] = useState<string>('')
+  const [dialogMode, setDialogMode] = useState<DialogMode>(null)
+  const [selectedTagId, setSelectedTagId] = useState<number | null>(null)
+  const [selectedTagName, setSelectedTagName] = useState('')
+
+  // Debounce search
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedSearch(searchInput)
+    }, 300)
+    return () => clearTimeout(timer)
+  }, [searchInput])
+
+  const {
+    data: tagsData,
+    isLoading,
+    error,
+  } = useTags({
+    category: categoryFilter || undefined,
+    search: debouncedSearch || undefined,
+    sort: 'usage',
+    limit: 100,
+  })
+
+  const tags = tagsData?.tags || []
+
+  const openCreate = useCallback(() => {
+    setDialogMode('create')
+    setSelectedTagId(null)
+    setSelectedTagName('')
+  }, [])
+
+  const openEdit = useCallback((tagId: number) => {
+    setDialogMode('edit')
+    setSelectedTagId(tagId)
+  }, [])
+
+  const openDelete = useCallback((tagId: number, name: string) => {
+    setDialogMode('delete')
+    setSelectedTagId(tagId)
+    setSelectedTagName(name)
+  }, [])
+
+  const closeDialog = useCallback(() => {
+    setDialogMode(null)
+    setSelectedTagId(null)
+    setSelectedTagName('')
+  }, [])
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-xl font-semibold flex items-center gap-2">
+            <Tags className="h-5 w-5" />
+            Tags
+          </h2>
+          <p className="text-sm text-muted-foreground mt-1">
+            Create, edit, and manage tags and aliases.
+          </p>
+        </div>
+        <Button onClick={openCreate}>
+          <Plus className="mr-2 h-4 w-4" />
+          New Tag
+        </Button>
+      </div>
+
+      {/* Filters */}
+      <div className="flex items-center gap-3">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            placeholder="Search tags..."
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+            className="pl-9"
+          />
+        </div>
+        <select
+          value={categoryFilter}
+          onChange={(e) => setCategoryFilter(e.target.value)}
+          className="h-9 rounded-md border bg-background px-3 text-sm"
+        >
+          <option value="">All Categories</option>
+          {TAG_CATEGORIES.map((cat) => (
+            <option key={cat} value={cat}>
+              {getCategoryLabel(cat)}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Loading */}
+      {isLoading && (
+        <div className="flex items-center justify-center py-12">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      )}
+
+      {/* Error */}
+      {error && (
+        <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-center">
+          <p className="text-destructive">
+            {error instanceof Error
+              ? error.message
+              : 'Failed to load tags.'}
+          </p>
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!isLoading && !error && tags.length === 0 && (
+        <div className="flex flex-col items-center justify-center py-12 text-center">
+          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-muted mb-4">
+            <Inbox className="h-8 w-8 text-muted-foreground" />
+          </div>
+          <h3 className="text-lg font-medium mb-1">No Tags Found</h3>
+          <p className="text-sm text-muted-foreground max-w-sm">
+            {debouncedSearch || categoryFilter
+              ? 'No tags match your filters. Try a different search.'
+              : 'No tags yet. Create your first tag to get started.'}
+          </p>
+        </div>
+      )}
+
+      {/* Tag list */}
+      {!isLoading && !error && tags.length > 0 && (
+        <>
+          <div className="text-sm text-muted-foreground">
+            {tags.length} tag{tags.length !== 1 ? 's' : ''}
+            {debouncedSearch && ` matching "${debouncedSearch}"`}
+            {tagsData?.total && tagsData.total > tags.length && (
+              <span> (of {tagsData.total} total)</span>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            {tags.map((tag) => (
+              <div
+                key={tag.id}
+                className="flex items-center gap-3 rounded-lg border p-3 hover:bg-muted/50 transition-colors"
+              >
+                {/* Info */}
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium text-sm truncate">
+                      {tag.name}
+                    </span>
+                    <Badge
+                      variant="outline"
+                      className={`text-xs flex-shrink-0 ${getCategoryColor(tag.category)}`}
+                    >
+                      {getCategoryLabel(tag.category)}
+                    </Badge>
+                    {tag.is_official && (
+                      <BadgeCheck className="h-3.5 w-3.5 text-primary flex-shrink-0" />
+                    )}
+                  </div>
+                  <div className="flex items-center gap-3 text-xs text-muted-foreground mt-0.5">
+                    <span>{tag.usage_count} uses</span>
+                    <span className="text-muted-foreground/50">
+                      /{tag.slug}
+                    </span>
+                  </div>
+                </div>
+
+                {/* Actions */}
+                <div className="flex items-center gap-1">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => openEdit(tag.id)}
+                    className="h-8 w-8 p-0"
+                  >
+                    <Pencil className="h-3.5 w-3.5" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => openDelete(tag.id, tag.name)}
+                    className="h-8 w-8 p-0 text-muted-foreground hover:text-destructive"
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+
+      {/* Create Dialog */}
+      <Dialog
+        open={dialogMode === 'create'}
+        onOpenChange={(open) => !open && closeDialog()}
+      >
+        <DialogContent className="max-w-md max-h-[90vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>Create Tag</DialogTitle>
+            <DialogDescription>
+              Add a new tag to the taxonomy.
+            </DialogDescription>
+          </DialogHeader>
+          <CreateTagForm onSuccess={closeDialog} onCancel={closeDialog} />
+        </DialogContent>
+      </Dialog>
+
+      {/* Edit Dialog */}
+      <Dialog
+        open={dialogMode === 'edit'}
+        onOpenChange={(open) => !open && closeDialog()}
+      >
+        <DialogContent className="max-w-md max-h-[90vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>Edit Tag</DialogTitle>
+            <DialogDescription>
+              Update tag details and manage aliases.
+            </DialogDescription>
+          </DialogHeader>
+          {selectedTagId && (
+            <EditTagForm
+              tagId={selectedTagId}
+              onSuccess={closeDialog}
+              onCancel={closeDialog}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete Dialog */}
+      <Dialog
+        open={dialogMode === 'delete'}
+        onOpenChange={(open) => !open && closeDialog()}
+      >
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Delete Tag</DialogTitle>
+            <DialogDescription>
+              This action is permanent and cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          {selectedTagId && (
+            <DeleteConfirmation
+              tagName={selectedTagName}
+              tagId={selectedTagId}
+              onSuccess={closeDialog}
+              onCancel={closeDialog}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}
+
+export default TagManagement

--- a/frontend/features/tags/admin/index.ts
+++ b/frontend/features/tags/admin/index.ts
@@ -1,0 +1,9 @@
+export { TagManagement } from './TagManagement'
+export {
+  useCreateTag,
+  useUpdateTag,
+  useDeleteTag,
+  useTagAliases,
+  useCreateAlias,
+  useDeleteAlias,
+} from './useAdminTags'

--- a/frontend/features/tags/admin/useAdminTags.ts
+++ b/frontend/features/tags/admin/useAdminTags.ts
@@ -1,0 +1,140 @@
+'use client'
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { apiRequest, API_ENDPOINTS } from '@/lib/api'
+import { queryKeys } from '@/lib/queryClient'
+import type { TagDetailResponse, TagAliasesResponse } from '../types'
+
+// ──────────────────────────────────────────────
+// Queries
+// ──────────────────────────────────────────────
+
+/** Fetch aliases for a tag (admin detail panel) */
+export function useTagAliases(tagId: number, options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: queryKeys.tags.aliases(tagId),
+    queryFn: () =>
+      apiRequest<TagAliasesResponse>(API_ENDPOINTS.TAGS.ALIASES(tagId)),
+    enabled: (options?.enabled ?? true) && tagId > 0,
+    staleTime: 5 * 60 * 1000,
+  })
+}
+
+// ──────────────────────────────────────────────
+// Mutations
+// ──────────────────────────────────────────────
+
+interface CreateTagInput {
+  name: string
+  description?: string
+  parent_id?: number
+  category: string
+  is_official?: boolean
+}
+
+/** Create a new tag (admin only) */
+export function useCreateTag() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (input: CreateTagInput) =>
+      apiRequest<TagDetailResponse>(API_ENDPOINTS.TAGS.LIST, {
+        method: 'POST',
+        body: JSON.stringify(input),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.tags.all })
+    },
+  })
+}
+
+interface UpdateTagInput {
+  tagId: number
+  data: {
+    name?: string
+    description?: string | null
+    parent_id?: number | null
+    category?: string
+    is_official?: boolean
+  }
+}
+
+/** Update an existing tag (admin only) */
+export function useUpdateTag() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ tagId, data }: UpdateTagInput) =>
+      apiRequest<TagDetailResponse>(API_ENDPOINTS.TAGS.GET(tagId), {
+        method: 'PUT',
+        body: JSON.stringify(data),
+      }),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.tags.all })
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.tags.detail(variables.tagId),
+      })
+    },
+  })
+}
+
+/** Delete a tag (admin only) */
+export function useDeleteTag() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (tagId: number) =>
+      apiRequest<void>(API_ENDPOINTS.TAGS.GET(tagId), {
+        method: 'DELETE',
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.tags.all })
+    },
+  })
+}
+
+interface CreateAliasInput {
+  tagId: number
+  alias: string
+}
+
+/** Create a tag alias (admin only) */
+export function useCreateAlias() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ tagId, alias }: CreateAliasInput) =>
+      apiRequest<void>(API_ENDPOINTS.TAGS.ALIASES(tagId), {
+        method: 'POST',
+        body: JSON.stringify({ alias }),
+      }),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.tags.aliases(variables.tagId),
+      })
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.tags.detail(variables.tagId),
+      })
+    },
+  })
+}
+
+interface DeleteAliasInput {
+  tagId: number
+  aliasId: number
+}
+
+/** Delete a tag alias (admin only) */
+export function useDeleteAlias() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ tagId, aliasId }: DeleteAliasInput) =>
+      apiRequest<void>(API_ENDPOINTS.TAGS.DELETE_ALIAS(tagId, aliasId), {
+        method: 'DELETE',
+      }),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.tags.aliases(variables.tagId),
+      })
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.tags.detail(variables.tagId),
+      })
+    },
+  })
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -343,6 +343,7 @@ export const API_ENDPOINTS = {
     SEARCH: `${API_BASE_URL}/tags/search`,
     GET: (idOrSlug: string | number) => `${API_BASE_URL}/tags/${idOrSlug}`,
     ALIASES: (idOrSlug: string | number) => `${API_BASE_URL}/tags/${idOrSlug}/aliases`,
+    DELETE_ALIAS: (tagId: number, aliasId: number) => `${API_BASE_URL}/tags/${tagId}/aliases/${aliasId}`,
   },
 
   // Entity tag endpoints


### PR DESCRIPTION
## Summary
- New **Tags** tab in admin console for full tag taxonomy management
- Tag list with search, category filter (genre/mood/era/style/instrument/locale/other), usage counts, and official badges
- Create/edit dialogs with name, category, description, and official flag
- Inline alias management (add/remove) in edit dialog
- Delete with confirmation dialog
- 6 admin hooks with query invalidation: `useCreateTag`, `useUpdateTag`, `useDeleteTag`, `useCreateAlias`, `useDeleteAlias`, `useTagAliases`
- Added `DELETE_ALIAS` API endpoint helper

## Test plan
- [x] Frontend builds successfully
- [x] All 1403 frontend tests pass
- [ ] Verify Tags tab appears in admin console
- [ ] Create a tag with name, category, description, official flag
- [ ] Edit a tag — verify form pre-populates
- [ ] Add/remove aliases in edit dialog
- [ ] Delete a tag with confirmation
- [ ] Verify category filter and search work
- [ ] Verify usage counts display correctly

Closes PSY-46

🤖 Generated with [Claude Code](https://claude.com/claude-code)