### PR TITLE
Add artist alias system and merge operation

### DIFF
--- a/backend/db/migrations/000053_create_artist_aliases.down.sql
+++ b/backend/db/migrations/000053_create_artist_aliases.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS artist_aliases;

--- a/backend/db/migrations/000053_create_artist_aliases.up.sql
+++ b/backend/db/migrations/000053_create_artist_aliases.up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE artist_aliases (
+    id BIGSERIAL PRIMARY KEY,
+    artist_id BIGINT NOT NULL REFERENCES artists(id) ON DELETE CASCADE,
+    alias VARCHAR(255) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX idx_artist_aliases_alias_lower ON artist_aliases(LOWER(alias));
+CREATE INDEX idx_artist_aliases_artist ON artist_aliases(artist_id);

--- a/backend/internal/api/handlers/artist.go
+++ b/backend/internal/api/handlers/artist.go
@@ -749,3 +749,219 @@ func nilIfEmpty(s string) *string {
 	}
 	return &s
 }
+
+// ============================================================================
+// Artist Aliases
+// ============================================================================
+
+// GetArtistAliasesRequest represents the request for getting an artist's aliases
+type GetArtistAliasesRequest struct {
+	ArtistID string `path:"artist_id" doc:"Artist ID" example:"42"`
+}
+
+// GetArtistAliasesResponse represents the response for the artist aliases endpoint
+type GetArtistAliasesResponse struct {
+	Body struct {
+		Aliases []*services.ArtistAliasResponse `json:"aliases" doc:"List of aliases"`
+		Count   int                             `json:"count" doc:"Number of aliases"`
+	}
+}
+
+// GetArtistAliasesHandler handles GET /artists/{artist_id}/aliases
+func (h *ArtistHandler) GetArtistAliasesHandler(ctx context.Context, req *GetArtistAliasesRequest) (*GetArtistAliasesResponse, error) {
+	artistID, err := strconv.ParseUint(req.ArtistID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid artist ID")
+	}
+
+	aliases, err := h.artistService.GetArtistAliases(uint(artistID))
+	if err != nil {
+		var artistErr *apperrors.ArtistError
+		if errors.As(err, &artistErr) && artistErr.Code == apperrors.CodeArtistNotFound {
+			return nil, huma.Error404NotFound("Artist not found")
+		}
+		return nil, huma.Error500InternalServerError("Failed to fetch aliases", err)
+	}
+
+	resp := &GetArtistAliasesResponse{}
+	resp.Body.Aliases = aliases
+	resp.Body.Count = len(aliases)
+
+	return resp, nil
+}
+
+// AddArtistAliasRequest represents the request for adding an alias
+type AddArtistAliasRequest struct {
+	ArtistID string `path:"artist_id" doc:"Artist ID" example:"42"`
+	Body     struct {
+		Alias string `json:"alias" doc:"Alias name" example:"The Artist Formerly Known As"`
+	}
+}
+
+// AddArtistAliasResponse represents the response for adding an alias
+type AddArtistAliasResponse struct {
+	Body *services.ArtistAliasResponse
+}
+
+// AddArtistAliasHandler handles POST /admin/artists/{artist_id}/aliases
+func (h *ArtistHandler) AddArtistAliasHandler(ctx context.Context, req *AddArtistAliasRequest) (*AddArtistAliasResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil || !user.IsAdmin {
+		return nil, huma.Error403Forbidden("Admin access required")
+	}
+
+	artistID, err := strconv.ParseUint(req.ArtistID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid artist ID")
+	}
+
+	if strings.TrimSpace(req.Body.Alias) == "" {
+		return nil, huma.Error400BadRequest("Alias cannot be empty")
+	}
+
+	alias, err := h.artistService.AddArtistAlias(uint(artistID), req.Body.Alias)
+	if err != nil {
+		var artistErr *apperrors.ArtistError
+		if errors.As(err, &artistErr) && artistErr.Code == apperrors.CodeArtistNotFound {
+			return nil, huma.Error404NotFound("Artist not found")
+		}
+		if strings.Contains(err.Error(), "already exists") || strings.Contains(err.Error(), "conflicts with") {
+			return nil, huma.Error409Conflict(err.Error())
+		}
+		logger.FromContext(ctx).Error("add_artist_alias_failed",
+			"artist_id", artistID,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to add alias (request_id: %s)", requestID),
+		)
+	}
+
+	// Audit log (fire and forget)
+	if h.auditLogService != nil {
+		h.auditLogService.LogAction(user.ID, "add_artist_alias", "artist", uint(artistID), map[string]interface{}{
+			"alias": req.Body.Alias,
+		})
+	}
+
+	return &AddArtistAliasResponse{Body: alias}, nil
+}
+
+// DeleteArtistAliasRequest represents the request for deleting an alias
+type DeleteArtistAliasRequest struct {
+	ArtistID string `path:"artist_id" doc:"Artist ID" example:"42"`
+	AliasID  string `path:"alias_id" doc:"Alias ID" example:"1"`
+}
+
+// DeleteArtistAliasHandler handles DELETE /admin/artists/{artist_id}/aliases/{alias_id}
+func (h *ArtistHandler) DeleteArtistAliasHandler(ctx context.Context, req *DeleteArtistAliasRequest) (*struct{}, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil || !user.IsAdmin {
+		return nil, huma.Error403Forbidden("Admin access required")
+	}
+
+	aliasID, err := strconv.ParseUint(req.AliasID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid alias ID")
+	}
+
+	err = h.artistService.RemoveArtistAlias(uint(aliasID))
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return nil, huma.Error404NotFound("Alias not found")
+		}
+		logger.FromContext(ctx).Error("delete_artist_alias_failed",
+			"alias_id", aliasID,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to delete alias (request_id: %s)", requestID),
+		)
+	}
+
+	// Audit log (fire and forget)
+	if h.auditLogService != nil {
+		artistID, _ := strconv.ParseUint(req.ArtistID, 10, 32)
+		h.auditLogService.LogAction(user.ID, "delete_artist_alias", "artist", uint(artistID), map[string]interface{}{
+			"alias_id": aliasID,
+		})
+	}
+
+	return nil, nil
+}
+
+// ============================================================================
+// Artist Merge
+// ============================================================================
+
+// MergeArtistsRequest represents the request for merging two artists
+type MergeArtistsRequest struct {
+	Body struct {
+		CanonicalArtistID uint `json:"canonical_artist_id" doc:"ID of the artist to keep"`
+		MergeFromArtistID uint `json:"merge_from_artist_id" doc:"ID of the artist to merge and delete"`
+	}
+}
+
+// MergeArtistsResponse represents the response for merging two artists
+type MergeArtistsResponse struct {
+	Body *services.MergeArtistResult
+}
+
+// MergeArtistsHandler handles POST /admin/artists/merge
+func (h *ArtistHandler) MergeArtistsHandler(ctx context.Context, req *MergeArtistsRequest) (*MergeArtistsResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil || !user.IsAdmin {
+		return nil, huma.Error403Forbidden("Admin access required")
+	}
+
+	if req.Body.CanonicalArtistID == 0 || req.Body.MergeFromArtistID == 0 {
+		return nil, huma.Error400BadRequest("Both canonical_artist_id and merge_from_artist_id are required")
+	}
+
+	result, err := h.artistService.MergeArtists(req.Body.CanonicalArtistID, req.Body.MergeFromArtistID)
+	if err != nil {
+		var artistErr *apperrors.ArtistError
+		if errors.As(err, &artistErr) && artistErr.Code == apperrors.CodeArtistNotFound {
+			return nil, huma.Error404NotFound("Artist not found")
+		}
+		if strings.Contains(err.Error(), "cannot merge an artist with itself") {
+			return nil, huma.Error400BadRequest("Cannot merge an artist with itself")
+		}
+		logger.FromContext(ctx).Error("merge_artists_failed",
+			"canonical_id", req.Body.CanonicalArtistID,
+			"merge_from_id", req.Body.MergeFromArtistID,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to merge artists (request_id: %s)", requestID),
+		)
+	}
+
+	// Audit log (fire and forget)
+	if h.auditLogService != nil {
+		h.auditLogService.LogAction(user.ID, "merge_artists", "artist", req.Body.CanonicalArtistID, map[string]interface{}{
+			"merged_artist_id":   req.Body.MergeFromArtistID,
+			"merged_artist_name": result.MergedArtistName,
+			"shows_moved":        result.ShowsMoved,
+		})
+	}
+
+	logger.FromContext(ctx).Info("artists_merged",
+		"canonical_id", req.Body.CanonicalArtistID,
+		"merged_id", req.Body.MergeFromArtistID,
+		"merged_name", result.MergedArtistName,
+		"admin_id", user.ID,
+		"request_id", requestID,
+	)
+
+	return &MergeArtistsResponse{Body: result}, nil
+}

--- a/backend/internal/api/handlers/artist_test.go
+++ b/backend/internal/api/handlers/artist_test.go
@@ -843,3 +843,288 @@ func TestListArtists_CitiesOverridesLegacy(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+// ============================================================================
+// Mock-based tests: GetArtistAliasesHandler
+// ============================================================================
+
+func TestGetArtistAliases_InvalidID(t *testing.T) {
+	h := testArtistHandler()
+	_, err := h.GetArtistAliasesHandler(context.Background(), &GetArtistAliasesRequest{ArtistID: "abc"})
+	assertHumaError(t, err, 400)
+}
+
+func TestGetArtistAliases_Success(t *testing.T) {
+	mock := &mockArtistService{
+		getArtistAliasesFn: func(artistID uint) ([]*services.ArtistAliasResponse, error) {
+			if artistID != 42 {
+				t.Errorf("expected artistID=42, got %d", artistID)
+			}
+			return []*services.ArtistAliasResponse{
+				{ID: 1, ArtistID: 42, Alias: "Alias One"},
+				{ID: 2, ArtistID: 42, Alias: "Alias Two"},
+			}, nil
+		},
+	}
+	h := NewArtistHandler(mock, nil)
+
+	resp, err := h.GetArtistAliasesHandler(context.Background(), &GetArtistAliasesRequest{ArtistID: "42"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Count != 2 {
+		t.Errorf("expected count=2, got %d", resp.Body.Count)
+	}
+}
+
+func TestGetArtistAliases_NotFound(t *testing.T) {
+	mock := &mockArtistService{
+		getArtistAliasesFn: func(artistID uint) ([]*services.ArtistAliasResponse, error) {
+			return nil, apperrors.ErrArtistNotFound(artistID)
+		},
+	}
+	h := NewArtistHandler(mock, nil)
+
+	_, err := h.GetArtistAliasesHandler(context.Background(), &GetArtistAliasesRequest{ArtistID: "99"})
+	assertHumaError(t, err, 404)
+}
+
+// ============================================================================
+// Mock-based tests: AddArtistAliasHandler
+// ============================================================================
+
+func TestAddArtistAlias_NoUser(t *testing.T) {
+	h := testArtistHandler()
+	req := &AddArtistAliasRequest{ArtistID: "1"}
+	req.Body.Alias = "test"
+
+	_, err := h.AddArtistAliasHandler(context.Background(), req)
+	assertHumaError(t, err, 403)
+}
+
+func TestAddArtistAlias_NonAdmin(t *testing.T) {
+	h := testArtistHandler()
+	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: false})
+	req := &AddArtistAliasRequest{ArtistID: "1"}
+	req.Body.Alias = "test"
+
+	_, err := h.AddArtistAliasHandler(ctx, req)
+	assertHumaError(t, err, 403)
+}
+
+func TestAddArtistAlias_InvalidID(t *testing.T) {
+	h := testArtistHandler()
+	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
+	req := &AddArtistAliasRequest{ArtistID: "abc"}
+	req.Body.Alias = "test"
+
+	_, err := h.AddArtistAliasHandler(ctx, req)
+	assertHumaError(t, err, 400)
+}
+
+func TestAddArtistAlias_EmptyAlias(t *testing.T) {
+	h := testArtistHandler()
+	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
+	req := &AddArtistAliasRequest{ArtistID: "1"}
+	req.Body.Alias = "   "
+
+	_, err := h.AddArtistAliasHandler(ctx, req)
+	assertHumaError(t, err, 400)
+}
+
+func TestAddArtistAlias_Success(t *testing.T) {
+	mock := &mockArtistService{
+		addArtistAliasFn: func(artistID uint, alias string) (*services.ArtistAliasResponse, error) {
+			if artistID != 42 {
+				t.Errorf("expected artistID=42, got %d", artistID)
+			}
+			return &services.ArtistAliasResponse{ID: 1, ArtistID: 42, Alias: alias}, nil
+		},
+	}
+	h := NewArtistHandler(mock, nil)
+	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
+	req := &AddArtistAliasRequest{ArtistID: "42"}
+	req.Body.Alias = "New Alias"
+
+	resp, err := h.AddArtistAliasHandler(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Alias != "New Alias" {
+		t.Errorf("expected alias='New Alias', got %q", resp.Body.Alias)
+	}
+}
+
+func TestAddArtistAlias_Conflict(t *testing.T) {
+	mock := &mockArtistService{
+		addArtistAliasFn: func(artistID uint, alias string) (*services.ArtistAliasResponse, error) {
+			return nil, fmt.Errorf("alias 'Test' already exists")
+		},
+	}
+	h := NewArtistHandler(mock, nil)
+	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
+	req := &AddArtistAliasRequest{ArtistID: "42"}
+	req.Body.Alias = "Test"
+
+	_, err := h.AddArtistAliasHandler(ctx, req)
+	assertHumaError(t, err, 409)
+}
+
+// ============================================================================
+// Mock-based tests: DeleteArtistAliasHandler
+// ============================================================================
+
+func TestDeleteArtistAlias_NoUser(t *testing.T) {
+	h := testArtistHandler()
+	_, err := h.DeleteArtistAliasHandler(context.Background(), &DeleteArtistAliasRequest{ArtistID: "1", AliasID: "1"})
+	assertHumaError(t, err, 403)
+}
+
+func TestDeleteArtistAlias_NonAdmin(t *testing.T) {
+	h := testArtistHandler()
+	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: false})
+	_, err := h.DeleteArtistAliasHandler(ctx, &DeleteArtistAliasRequest{ArtistID: "1", AliasID: "1"})
+	assertHumaError(t, err, 403)
+}
+
+func TestDeleteArtistAlias_InvalidAliasID(t *testing.T) {
+	h := testArtistHandler()
+	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
+	_, err := h.DeleteArtistAliasHandler(ctx, &DeleteArtistAliasRequest{ArtistID: "1", AliasID: "abc"})
+	assertHumaError(t, err, 400)
+}
+
+func TestDeleteArtistAlias_Success(t *testing.T) {
+	mock := &mockArtistService{
+		removeArtistAliasFn: func(aliasID uint) error {
+			if aliasID != 5 {
+				t.Errorf("expected aliasID=5, got %d", aliasID)
+			}
+			return nil
+		},
+	}
+	h := NewArtistHandler(mock, nil)
+	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
+
+	_, err := h.DeleteArtistAliasHandler(ctx, &DeleteArtistAliasRequest{ArtistID: "1", AliasID: "5"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDeleteArtistAlias_NotFound(t *testing.T) {
+	mock := &mockArtistService{
+		removeArtistAliasFn: func(aliasID uint) error {
+			return fmt.Errorf("alias not found")
+		},
+	}
+	h := NewArtistHandler(mock, nil)
+	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
+
+	_, err := h.DeleteArtistAliasHandler(ctx, &DeleteArtistAliasRequest{ArtistID: "1", AliasID: "99"})
+	assertHumaError(t, err, 404)
+}
+
+// ============================================================================
+// Mock-based tests: MergeArtistsHandler
+// ============================================================================
+
+func TestMergeArtists_NoUser(t *testing.T) {
+	h := testArtistHandler()
+	req := &MergeArtistsRequest{}
+	req.Body.CanonicalArtistID = 1
+	req.Body.MergeFromArtistID = 2
+
+	_, err := h.MergeArtistsHandler(context.Background(), req)
+	assertHumaError(t, err, 403)
+}
+
+func TestMergeArtists_NonAdmin(t *testing.T) {
+	h := testArtistHandler()
+	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: false})
+	req := &MergeArtistsRequest{}
+	req.Body.CanonicalArtistID = 1
+	req.Body.MergeFromArtistID = 2
+
+	_, err := h.MergeArtistsHandler(ctx, req)
+	assertHumaError(t, err, 403)
+}
+
+func TestMergeArtists_MissingIDs(t *testing.T) {
+	h := testArtistHandler()
+	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
+	req := &MergeArtistsRequest{}
+	req.Body.CanonicalArtistID = 1
+	req.Body.MergeFromArtistID = 0
+
+	_, err := h.MergeArtistsHandler(ctx, req)
+	assertHumaError(t, err, 400)
+}
+
+func TestMergeArtists_SelfMerge(t *testing.T) {
+	mock := &mockArtistService{
+		mergeArtistsFn: func(canonicalID, mergeFromID uint) (*services.MergeArtistResult, error) {
+			return nil, fmt.Errorf("cannot merge an artist with itself")
+		},
+	}
+	h := NewArtistHandler(mock, nil)
+	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
+	req := &MergeArtistsRequest{}
+	req.Body.CanonicalArtistID = 5
+	req.Body.MergeFromArtistID = 5
+
+	_, err := h.MergeArtistsHandler(ctx, req)
+	assertHumaError(t, err, 400)
+}
+
+func TestMergeArtists_Success(t *testing.T) {
+	mock := &mockArtistService{
+		mergeArtistsFn: func(canonicalID, mergeFromID uint) (*services.MergeArtistResult, error) {
+			if canonicalID != 1 {
+				t.Errorf("expected canonicalID=1, got %d", canonicalID)
+			}
+			if mergeFromID != 2 {
+				t.Errorf("expected mergeFromID=2, got %d", mergeFromID)
+			}
+			return &services.MergeArtistResult{
+				CanonicalArtistID: 1,
+				MergedArtistID:    2,
+				MergedArtistName:  "Old Name",
+				ShowsMoved:        3,
+				AliasCreated:      true,
+			}, nil
+		},
+	}
+	h := NewArtistHandler(mock, nil)
+	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
+	req := &MergeArtistsRequest{}
+	req.Body.CanonicalArtistID = 1
+	req.Body.MergeFromArtistID = 2
+
+	resp, err := h.MergeArtistsHandler(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.MergedArtistName != "Old Name" {
+		t.Errorf("expected merged name='Old Name', got %q", resp.Body.MergedArtistName)
+	}
+	if resp.Body.ShowsMoved != 3 {
+		t.Errorf("expected shows_moved=3, got %d", resp.Body.ShowsMoved)
+	}
+}
+
+func TestMergeArtists_NotFound(t *testing.T) {
+	mock := &mockArtistService{
+		mergeArtistsFn: func(canonicalID, mergeFromID uint) (*services.MergeArtistResult, error) {
+			return nil, apperrors.ErrArtistNotFound(canonicalID)
+		},
+	}
+	h := NewArtistHandler(mock, nil)
+	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
+	req := &MergeArtistsRequest{}
+	req.Body.CanonicalArtistID = 99
+	req.Body.MergeFromArtistID = 2
+
+	_, err := h.MergeArtistsHandler(ctx, req)
+	assertHumaError(t, err, 404)
+}

--- a/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
+++ b/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
@@ -985,6 +985,18 @@ func (m *mockArtistService) GetLabelsForArtist(artistID uint) ([]*services.Artis
 	}
 	return nil, nil
 }
+func (m *mockArtistService) AddArtistAlias(artistID uint, alias string) (*services.ArtistAliasResponse, error) {
+	return nil, nil
+}
+func (m *mockArtistService) RemoveArtistAlias(aliasID uint) error {
+	return nil
+}
+func (m *mockArtistService) GetArtistAliases(artistID uint) ([]*services.ArtistAliasResponse, error) {
+	return nil, nil
+}
+func (m *mockArtistService) MergeArtists(canonicalID, mergeFromID uint) (*services.MergeArtistResult, error) {
+	return nil, nil
+}
 
 // ============================================================================
 // Mock: MusicDiscoveryServiceInterface

--- a/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
+++ b/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
@@ -911,6 +911,10 @@ type mockArtistService struct {
 	getShowsForArtistFn         func(artistID uint, timezone string, limit int, timeFilter string) ([]*services.ArtistShowResponse, int64, error)
 	getArtistCitiesFn           func() ([]*services.ArtistCityResponse, error)
 	getLabelsForArtistFn        func(artistID uint) ([]*services.ArtistLabelResponse, error)
+	addArtistAliasFn            func(artistID uint, alias string) (*services.ArtistAliasResponse, error)
+	removeArtistAliasFn         func(aliasID uint) error
+	getArtistAliasesFn          func(artistID uint) ([]*services.ArtistAliasResponse, error)
+	mergeArtistsFn              func(canonicalID, mergeFromID uint) (*services.MergeArtistResult, error)
 }
 
 func (m *mockArtistService) CreateArtist(req *services.CreateArtistRequest) (*services.ArtistDetailResponse, error) {
@@ -986,15 +990,27 @@ func (m *mockArtistService) GetLabelsForArtist(artistID uint) ([]*services.Artis
 	return nil, nil
 }
 func (m *mockArtistService) AddArtistAlias(artistID uint, alias string) (*services.ArtistAliasResponse, error) {
+	if m.addArtistAliasFn != nil {
+		return m.addArtistAliasFn(artistID, alias)
+	}
 	return nil, nil
 }
 func (m *mockArtistService) RemoveArtistAlias(aliasID uint) error {
+	if m.removeArtistAliasFn != nil {
+		return m.removeArtistAliasFn(aliasID)
+	}
 	return nil
 }
 func (m *mockArtistService) GetArtistAliases(artistID uint) ([]*services.ArtistAliasResponse, error) {
+	if m.getArtistAliasesFn != nil {
+		return m.getArtistAliasesFn(artistID)
+	}
 	return nil, nil
 }
 func (m *mockArtistService) MergeArtists(canonicalID, mergeFromID uint) (*services.MergeArtistResult, error) {
+	if m.mergeArtistsFn != nil {
+		return m.mergeArtistsFn(canonicalID, mergeFromID)
+	}
 	return nil, nil
 }
 

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -284,10 +284,14 @@ func setupArtistRoutes(api huma.API, protected *huma.Group, sc *services.Service
 	huma.Get(api, "/artists/{artist_id}", artistHandler.GetArtistHandler)
 	huma.Get(api, "/artists/{artist_id}/shows", artistHandler.GetArtistShowsHandler)
 	huma.Get(api, "/artists/{artist_id}/labels", artistHandler.GetArtistLabelsHandler)
+	huma.Get(api, "/artists/{artist_id}/aliases", artistHandler.GetArtistAliasesHandler)
 
 	// Protected artist endpoints
 	huma.Delete(protected, "/artists/{artist_id}", artistHandler.DeleteArtistHandler)
 	huma.Patch(protected, "/admin/artists/{artist_id}", artistHandler.AdminUpdateArtistHandler)
+	huma.Post(protected, "/admin/artists/{artist_id}/aliases", artistHandler.AddArtistAliasHandler)
+	huma.Delete(protected, "/admin/artists/{artist_id}/aliases/{alias_id}", artistHandler.DeleteArtistAliasHandler)
+	huma.Post(protected, "/admin/artists/merge", artistHandler.MergeArtistsHandler)
 }
 
 func setupReleaseRoutes(api huma.API, protected *huma.Group, sc *services.ServiceContainer) {

--- a/backend/internal/models/artist.go
+++ b/backend/internal/models/artist.go
@@ -20,9 +20,22 @@ type Artist struct {
 	UpdatedAt        time.Time `gorm:"not null"`
 
 	// Relationships
-	Shows []Show `gorm:"many2many:show_artists;"`
+	Shows   []Show        `gorm:"many2many:show_artists;"`
+	Aliases []ArtistAlias `gorm:"foreignKey:ArtistID"`
 }
 
 func (Artist) TableName() string {
 	return "artists"
+}
+
+// ArtistAlias represents an alternate name that resolves to a canonical artist.
+type ArtistAlias struct {
+	ID        uint      `gorm:"primaryKey" json:"id"`
+	ArtistID  uint      `gorm:"not null" json:"artist_id"`
+	Alias     string    `gorm:"not null;size:255" json:"alias"`
+	CreatedAt time.Time `gorm:"not null" json:"created_at"`
+}
+
+func (ArtistAlias) TableName() string {
+	return "artist_aliases"
 }

--- a/backend/internal/services/aliases.go
+++ b/backend/internal/services/aliases.go
@@ -116,6 +116,8 @@ type ArtistLabelResponse = contracts.ArtistLabelResponse
 type ArtistShowResponse = contracts.ArtistShowResponse
 type ArtistShowVenueResponse = contracts.ArtistShowVenueResponse
 type ArtistShowArtist = contracts.ArtistShowArtist
+type ArtistAliasResponse = contracts.ArtistAliasResponse
+type MergeArtistResult = contracts.MergeArtistResult
 
 // ──────────────────────────────────────────────
 // Label types

--- a/backend/internal/services/catalog/artist.go
+++ b/backend/internal/services/catalog/artist.go
@@ -286,35 +286,22 @@ func (s *ArtistService) SearchArtists(query string) ([]*contracts.ArtistDetailRe
 			Limit(10).
 			Find(&artists).Error
 	} else {
-		// For longer queries: search both names and aliases with similarity scoring
-		err = s.db.
-			Select("DISTINCT ON (artists.id) artists.*, GREATEST(similarity(artists.name, ?), COALESCE((SELECT MAX(similarity(aa.alias, ?)) FROM artist_aliases aa WHERE aa.artist_id = artists.id), 0)) as sim_score", query, query).
-			Where("artists.name ILIKE ? OR artists.name % ? OR artists.id IN (?)",
-				"%"+query+"%", query,
-				s.db.Table("artist_aliases").Select("artist_id").Where("alias ILIKE ? OR alias % ?", "%"+query+"%", query),
-			).
-			Order("artists.id, sim_score DESC").
-			Limit(10).
-			Find(&artists).Error
-		// Re-sort by sim_score since DISTINCT ON requires ordering by the DISTINCT column first
-		if err == nil && len(artists) > 1 {
-			// The DISTINCT ON approach may not sort correctly, so we use a subquery approach instead
-			artists = nil
-			err = s.db.Raw(`
-				SELECT a.* FROM artists a
-				WHERE a.id IN (
-					SELECT id FROM artists WHERE name ILIKE ? OR name % ?
-					UNION
-					SELECT artist_id FROM artist_aliases WHERE alias ILIKE ? OR alias % ?
-				)
-				ORDER BY GREATEST(
-					similarity(a.name, ?),
-					COALESCE((SELECT MAX(similarity(aa.alias, ?)) FROM artist_aliases aa WHERE aa.artist_id = a.id), 0)
-				) DESC, a.name ASC
-				LIMIT 10
-			`, "%"+query+"%", query, "%"+query+"%", query, query, query).
-				Scan(&artists).Error
-		}
+		// For longer queries: search names and aliases with similarity scoring
+		// Uses UNION to find matching artists by name or alias, then ranks by best similarity
+		err = s.db.Raw(`
+			SELECT a.* FROM artists a
+			WHERE a.id IN (
+				SELECT id FROM artists WHERE name ILIKE ? OR name % ?
+				UNION
+				SELECT artist_id FROM artist_aliases WHERE alias ILIKE ? OR alias % ?
+			)
+			ORDER BY GREATEST(
+				similarity(a.name, ?),
+				COALESCE((SELECT MAX(similarity(aa.alias, ?)) FROM artist_aliases aa WHERE aa.artist_id = a.id), 0)
+			) DESC, a.name ASC
+			LIMIT 10
+		`, "%"+query+"%", query, "%"+query+"%", query, query, query).
+			Scan(&artists).Error
 	}
 
 	if err != nil {

--- a/backend/internal/services/catalog/artist.go
+++ b/backend/internal/services/catalog/artist.go
@@ -254,10 +254,11 @@ func (s *ArtistService) DeleteArtist(artistID uint) error {
 	return nil
 }
 
-// SearchArtists performs autocomplete search on artist names
+// SearchArtists performs autocomplete search on artist names and aliases.
 // Uses pg_trgm extension for performant fuzzy matching with intelligent query strategy:
 // - Short queries (1-2 chars): Fast case-insensitive prefix search
 // - Longer queries (3+ chars): Similarity-based fuzzy matching with ranking
+// Alias matches return the canonical artist (deduplicated).
 func (s *ArtistService) SearchArtists(query string) ([]*contracts.ArtistDetailResponse, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
@@ -273,25 +274,47 @@ func (s *ArtistService) SearchArtists(query string) ([]*contracts.ArtistDetailRe
 
 	// Strategy depends on query length for optimal performance
 	if len(query) <= 2 {
-		// For short queries: use fast case-insensitive prefix search
-		// Example: "ra" → "Radiohead", "Rage Against the Machine"
-		// Uses idx_artists_name_lower_prefix for blazing fast results
+		// For short queries: use fast case-insensitive prefix search on name + aliases
 		err = s.db.
-			Where("LOWER(name) LIKE LOWER(?)", query+"%").
+			Where("id IN (?)",
+				s.db.Table("artists").Select("id").Where("LOWER(name) LIKE LOWER(?)", query+"%"),
+			).
+			Or("id IN (?)",
+				s.db.Table("artist_aliases").Select("artist_id").Where("LOWER(alias) LIKE LOWER(?)", query+"%"),
+			).
 			Order("name ASC").
 			Limit(10).
 			Find(&artists).Error
 	} else {
-		// For longer queries: use similarity scoring for better fuzzy matching
-		// Example: "radio mos" → "Radio Moscow" ranked higher than "Radio Dept"
-		// Handles typos and partial matches: "beatls" → "The Beatles"
-		// Uses idx_artists_name_trgm for efficient pattern matching
+		// For longer queries: search both names and aliases with similarity scoring
 		err = s.db.
-			Select("artists.*, similarity(name, ?) as sim_score", query).
-			Where("name ILIKE ? OR name % ?", "%"+query+"%", query).
-			Order("sim_score DESC, name ASC").
+			Select("DISTINCT ON (artists.id) artists.*, GREATEST(similarity(artists.name, ?), COALESCE((SELECT MAX(similarity(aa.alias, ?)) FROM artist_aliases aa WHERE aa.artist_id = artists.id), 0)) as sim_score", query, query).
+			Where("artists.name ILIKE ? OR artists.name % ? OR artists.id IN (?)",
+				"%"+query+"%", query,
+				s.db.Table("artist_aliases").Select("artist_id").Where("alias ILIKE ? OR alias % ?", "%"+query+"%", query),
+			).
+			Order("artists.id, sim_score DESC").
 			Limit(10).
 			Find(&artists).Error
+		// Re-sort by sim_score since DISTINCT ON requires ordering by the DISTINCT column first
+		if err == nil && len(artists) > 1 {
+			// The DISTINCT ON approach may not sort correctly, so we use a subquery approach instead
+			artists = nil
+			err = s.db.Raw(`
+				SELECT a.* FROM artists a
+				WHERE a.id IN (
+					SELECT id FROM artists WHERE name ILIKE ? OR name % ?
+					UNION
+					SELECT artist_id FROM artist_aliases WHERE alias ILIKE ? OR alias % ?
+				)
+				ORDER BY GREATEST(
+					similarity(a.name, ?),
+					COALESCE((SELECT MAX(similarity(aa.alias, ?)) FROM artist_aliases aa WHERE aa.artist_id = a.id), 0)
+				) DESC, a.name ASC
+				LIMIT 10
+			`, "%"+query+"%", query, "%"+query+"%", query, query, query).
+				Scan(&artists).Error
+		}
 	}
 
 	if err != nil {
@@ -677,4 +700,238 @@ func (s *ArtistService) GetShowsForArtist(artistID uint, timezone string, limit 
 	}
 
 	return responses, total, nil
+}
+
+// ──────────────────────────────────────────────
+// Alias CRUD
+// ──────────────────────────────────────────────
+
+// AddArtistAlias adds an alias for an artist. Validates uniqueness against
+// other aliases and artist names (case-insensitive).
+func (s *ArtistService) AddArtistAlias(artistID uint, alias string) (*contracts.ArtistAliasResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	alias = strings.TrimSpace(alias)
+	if alias == "" {
+		return nil, fmt.Errorf("alias cannot be empty")
+	}
+
+	// Verify artist exists
+	var artist models.Artist
+	if err := s.db.First(&artist, artistID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, apperrors.ErrArtistNotFound(artistID)
+		}
+		return nil, fmt.Errorf("failed to get artist: %w", err)
+	}
+
+	// Check for duplicate alias (case-insensitive)
+	var existing models.ArtistAlias
+	if err := s.db.Where("LOWER(alias) = LOWER(?)", alias).First(&existing).Error; err == nil {
+		return nil, fmt.Errorf("alias '%s' already exists", alias)
+	}
+
+	// Check if alias matches an existing artist name
+	var existingArtist models.Artist
+	if err := s.db.Where("LOWER(name) = LOWER(?)", alias).First(&existingArtist).Error; err == nil {
+		return nil, fmt.Errorf("alias '%s' conflicts with existing artist name", alias)
+	}
+
+	artistAlias := &models.ArtistAlias{
+		ArtistID: artistID,
+		Alias:    alias,
+	}
+
+	if err := s.db.Create(artistAlias).Error; err != nil {
+		return nil, fmt.Errorf("failed to create alias: %w", err)
+	}
+
+	return &contracts.ArtistAliasResponse{
+		ID:        artistAlias.ID,
+		ArtistID:  artistAlias.ArtistID,
+		Alias:     artistAlias.Alias,
+		CreatedAt: artistAlias.CreatedAt.Format(time.RFC3339),
+	}, nil
+}
+
+// RemoveArtistAlias deletes an alias by ID.
+func (s *ArtistService) RemoveArtistAlias(aliasID uint) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	result := s.db.Delete(&models.ArtistAlias{}, aliasID)
+	if result.Error != nil {
+		return fmt.Errorf("failed to delete alias: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("alias not found")
+	}
+
+	return nil
+}
+
+// GetArtistAliases returns all aliases for an artist.
+func (s *ArtistService) GetArtistAliases(artistID uint) ([]*contracts.ArtistAliasResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	// Verify artist exists
+	var artist models.Artist
+	if err := s.db.First(&artist, artistID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, apperrors.ErrArtistNotFound(artistID)
+		}
+		return nil, fmt.Errorf("failed to get artist: %w", err)
+	}
+
+	var aliases []models.ArtistAlias
+	if err := s.db.Where("artist_id = ?", artistID).Order("alias ASC").Find(&aliases).Error; err != nil {
+		return nil, fmt.Errorf("failed to list aliases: %w", err)
+	}
+
+	responses := make([]*contracts.ArtistAliasResponse, len(aliases))
+	for i, a := range aliases {
+		responses[i] = &contracts.ArtistAliasResponse{
+			ID:        a.ID,
+			ArtistID:  a.ArtistID,
+			Alias:     a.Alias,
+			CreatedAt: a.CreatedAt.Format(time.RFC3339),
+		}
+	}
+
+	return responses, nil
+}
+
+// ──────────────────────────────────────────────
+// Artist Merge
+// ──────────────────────────────────────────────
+
+// MergeArtists merges the "mergeFrom" artist into the "canonical" artist.
+// All relationships (shows, releases, labels, festivals, etc.) are transferred
+// to the canonical artist. Conflicts (duplicate rows) are deleted before transfer.
+// The merged artist's name is added as an alias, then the merged artist is deleted.
+func (s *ArtistService) MergeArtists(canonicalID, mergeFromID uint) (*contracts.MergeArtistResult, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	if canonicalID == mergeFromID {
+		return nil, fmt.Errorf("cannot merge an artist with itself")
+	}
+
+	// Verify both artists exist
+	var canonical models.Artist
+	if err := s.db.First(&canonical, canonicalID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, apperrors.ErrArtistNotFound(canonicalID)
+		}
+		return nil, fmt.Errorf("failed to get canonical artist: %w", err)
+	}
+
+	var mergeFrom models.Artist
+	if err := s.db.First(&mergeFrom, mergeFromID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, apperrors.ErrArtistNotFound(mergeFromID)
+		}
+		return nil, fmt.Errorf("failed to get merge-from artist: %w", err)
+	}
+
+	result := &contracts.MergeArtistResult{
+		CanonicalArtistID: canonicalID,
+		MergedArtistID:    mergeFromID,
+		MergedArtistName:  mergeFrom.Name,
+	}
+
+	err := s.db.Transaction(func(tx *gorm.DB) error {
+		// 1. show_artists: delete conflicts, then update remaining
+		tx.Where("artist_id = ? AND show_id IN (?)", mergeFromID,
+			tx.Table("show_artists").Select("show_id").Where("artist_id = ?", canonicalID),
+		).Delete(&models.ShowArtist{})
+		r := tx.Model(&models.ShowArtist{}).Where("artist_id = ?", mergeFromID).Update("artist_id", canonicalID)
+		result.ShowsMoved = r.RowsAffected
+
+		// 2. artist_releases: delete conflicts, then update remaining
+		tx.Exec("DELETE FROM artist_releases WHERE artist_id = ? AND (release_id, role) IN (SELECT release_id, role FROM artist_releases WHERE artist_id = ?)", mergeFromID, canonicalID)
+		r = tx.Exec("UPDATE artist_releases SET artist_id = ? WHERE artist_id = ?", canonicalID, mergeFromID)
+		result.ReleasesMoved = r.RowsAffected
+
+		// 3. artist_labels: delete conflicts, then update remaining
+		tx.Exec("DELETE FROM artist_labels WHERE artist_id = ? AND label_id IN (SELECT label_id FROM artist_labels WHERE artist_id = ?)", mergeFromID, canonicalID)
+		r = tx.Exec("UPDATE artist_labels SET artist_id = ? WHERE artist_id = ?", canonicalID, mergeFromID)
+		result.LabelsMoved = r.RowsAffected
+
+		// 4. festival_artists: delete conflicts, then update remaining
+		tx.Exec("DELETE FROM festival_artists WHERE artist_id = ? AND festival_id IN (SELECT festival_id FROM festival_artists WHERE artist_id = ?)", mergeFromID, canonicalID)
+		r = tx.Exec("UPDATE festival_artists SET artist_id = ? WHERE artist_id = ?", canonicalID, mergeFromID)
+		result.FestivalsMoved = r.RowsAffected
+
+		// 5. artist_relationships: re-canonicalize with source < target, delete self-referential and conflicts
+		// First delete any that would become self-referential
+		tx.Exec("DELETE FROM artist_relationship_votes WHERE (source_artist_id = ? OR target_artist_id = ?) AND (source_artist_id = ? OR target_artist_id = ?)",
+			mergeFromID, mergeFromID, canonicalID, canonicalID)
+		tx.Exec("DELETE FROM artist_relationships WHERE (source_artist_id = ? AND target_artist_id = ?) OR (source_artist_id = ? AND target_artist_id = ?)",
+			mergeFromID, canonicalID, canonicalID, mergeFromID)
+		// Delete votes for relationships that will be deleted as self-referential after merge
+		tx.Exec("DELETE FROM artist_relationship_votes WHERE source_artist_id = ? OR target_artist_id = ?", mergeFromID, mergeFromID)
+		// Delete remaining relationships involving mergeFrom (after conflicts removed)
+		r = tx.Exec("DELETE FROM artist_relationships WHERE source_artist_id = ? OR target_artist_id = ?", mergeFromID, mergeFromID)
+		result.RelationshipsMoved = r.RowsAffected
+
+		// 6. entity_tags: delete conflicts, then update remaining
+		tx.Exec("DELETE FROM entity_tags WHERE entity_type = 'artist' AND entity_id = ? AND tag_id IN (SELECT tag_id FROM entity_tags WHERE entity_type = 'artist' AND entity_id = ?)", mergeFromID, canonicalID)
+		tx.Exec("UPDATE entity_tags SET entity_id = ? WHERE entity_type = 'artist' AND entity_id = ?", canonicalID, mergeFromID)
+
+		// 7. user_bookmarks: delete conflicts, then update remaining
+		tx.Exec("DELETE FROM user_bookmarks WHERE entity_type = 'artist' AND entity_id = ? AND (user_id, action) IN (SELECT user_id, action FROM user_bookmarks WHERE entity_type = 'artist' AND entity_id = ?)", mergeFromID, canonicalID)
+		r = tx.Exec("UPDATE user_bookmarks SET entity_id = ? WHERE entity_type = 'artist' AND entity_id = ?", canonicalID, mergeFromID)
+		result.BookmarksMoved = r.RowsAffected
+
+		// 8. artist_reports: delete conflicts, then update remaining
+		tx.Exec("DELETE FROM artist_reports WHERE artist_id = ? AND reported_by IN (SELECT reported_by FROM artist_reports WHERE artist_id = ?)", mergeFromID, canonicalID)
+		tx.Exec("UPDATE artist_reports SET artist_id = ? WHERE artist_id = ?", canonicalID, mergeFromID)
+
+		// 9. revisions: just update entity_id (no conflict key)
+		tx.Exec("UPDATE revisions SET entity_id = ? WHERE entity_type = 'artist' AND entity_id = ?", canonicalID, mergeFromID)
+
+		// 10. tag_votes for entity tags: delete conflicts, then update remaining
+		tx.Exec(`DELETE FROM tag_votes WHERE entity_type = 'artist' AND entity_id = ?
+			AND (tag_id, user_id) IN (SELECT tag_id, user_id FROM tag_votes WHERE entity_type = 'artist' AND entity_id = ?)`, mergeFromID, canonicalID)
+		tx.Exec("UPDATE tag_votes SET entity_id = ? WHERE entity_type = 'artist' AND entity_id = ?", canonicalID, mergeFromID)
+
+		// 11. Transfer aliases from merged artist to canonical
+		tx.Exec("UPDATE artist_aliases SET artist_id = ? WHERE artist_id = ?", canonicalID, mergeFromID)
+
+		// 12. Create alias from merged artist's name (if not conflicting)
+		var aliasCount int64
+		tx.Model(&models.ArtistAlias{}).Where("LOWER(alias) = LOWER(?)", mergeFrom.Name).Count(&aliasCount)
+		var nameCount int64
+		tx.Model(&models.Artist{}).Where("LOWER(name) = LOWER(?)", mergeFrom.Name).Where("id != ?", mergeFromID).Count(&nameCount)
+		if aliasCount == 0 && nameCount == 0 {
+			newAlias := models.ArtistAlias{
+				ArtistID: canonicalID,
+				Alias:    mergeFrom.Name,
+			}
+			if err := tx.Create(&newAlias).Error; err != nil {
+				return fmt.Errorf("failed to create alias from merged artist name: %w", err)
+			}
+			result.AliasCreated = true
+		}
+
+		// 13. Delete the merged artist
+		if err := tx.Delete(&mergeFrom).Error; err != nil {
+			return fmt.Errorf("failed to delete merged artist: %w", err)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("merge failed: %w", err)
+	}
+
+	return result, nil
 }

--- a/backend/internal/services/catalog/artist_test.go
+++ b/backend/internal/services/catalog/artist_test.go
@@ -108,6 +108,33 @@ func TestArtistService_NilDatabase(t *testing.T) {
 		assert.Equal(t, "database not initialized", err.Error())
 		assert.Nil(t, resp)
 	})
+
+	t.Run("AddArtistAlias", func(t *testing.T) {
+		resp, err := svc.AddArtistAlias(1, "test")
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("RemoveArtistAlias", func(t *testing.T) {
+		err := svc.RemoveArtistAlias(1)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+	})
+
+	t.Run("GetArtistAliases", func(t *testing.T) {
+		resp, err := svc.GetArtistAliases(1)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("MergeArtists", func(t *testing.T) {
+		resp, err := svc.MergeArtists(1, 2)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
 }
 
 // =============================================================================

--- a/backend/internal/services/catalog/artist_test.go
+++ b/backend/internal/services/catalog/artist_test.go
@@ -184,11 +184,26 @@ func (suite *ArtistServiceIntegrationTestSuite) TearDownTest() {
 	sqlDB, err := suite.db.DB()
 	suite.Require().NoError(err)
 	// Delete in FK-safe order
+	_, _ = sqlDB.Exec("DELETE FROM artist_relationship_votes")
+	_, _ = sqlDB.Exec("DELETE FROM artist_relationships")
+	_, _ = sqlDB.Exec("DELETE FROM tag_votes")
+	_, _ = sqlDB.Exec("DELETE FROM entity_tags")
+	_, _ = sqlDB.Exec("DELETE FROM artist_aliases")
+	_, _ = sqlDB.Exec("DELETE FROM artist_reports")
+	_, _ = sqlDB.Exec("DELETE FROM artist_releases")
+	_, _ = sqlDB.Exec("DELETE FROM artist_labels")
+	_, _ = sqlDB.Exec("DELETE FROM festival_artists")
+	_, _ = sqlDB.Exec("DELETE FROM user_bookmarks")
+	_, _ = sqlDB.Exec("DELETE FROM revisions")
 	_, _ = sqlDB.Exec("DELETE FROM show_artists")
 	_, _ = sqlDB.Exec("DELETE FROM show_venues")
 	_, _ = sqlDB.Exec("DELETE FROM shows")
 	_, _ = sqlDB.Exec("DELETE FROM artists")
 	_, _ = sqlDB.Exec("DELETE FROM venues")
+	_, _ = sqlDB.Exec("DELETE FROM festivals")
+	_, _ = sqlDB.Exec("DELETE FROM labels")
+	_, _ = sqlDB.Exec("DELETE FROM releases")
+	_, _ = sqlDB.Exec("DELETE FROM tags")
 	_, _ = sqlDB.Exec("DELETE FROM users")
 }
 
@@ -926,4 +941,255 @@ func (suite *ArtistServiceIntegrationTestSuite) TestGetArtistsWithShowCounts_Wit
 	suite.Require().NoError(err)
 	suite.Require().Len(resp, 1)
 	suite.Equal("PHX Artist", resp[0].Name)
+}
+
+// =============================================================================
+// Group 10: Alias CRUD
+// =============================================================================
+
+func (suite *ArtistServiceIntegrationTestSuite) TestAddArtistAlias_Success() {
+	artist, _ := suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "Alias Artist"})
+
+	alias, err := suite.artistService.AddArtistAlias(artist.ID, "Alt Name")
+
+	suite.Require().NoError(err)
+	suite.Require().NotNil(alias)
+	suite.NotZero(alias.ID)
+	suite.Equal(artist.ID, alias.ArtistID)
+	suite.Equal("Alt Name", alias.Alias)
+	suite.NotEmpty(alias.CreatedAt)
+}
+
+func (suite *ArtistServiceIntegrationTestSuite) TestAddArtistAlias_DuplicateAlias_Fails() {
+	artist, _ := suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "Dup Alias Artist"})
+	_, err := suite.artistService.AddArtistAlias(artist.ID, "Same Alias")
+	suite.Require().NoError(err)
+
+	_, err = suite.artistService.AddArtistAlias(artist.ID, "same alias") // case-insensitive
+	suite.Require().Error(err)
+	suite.Contains(err.Error(), "already exists")
+}
+
+func (suite *ArtistServiceIntegrationTestSuite) TestAddArtistAlias_ConflictsWithArtistName_Fails() {
+	suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "Existing Band"})
+	artist2, _ := suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "Another Band"})
+
+	_, err := suite.artistService.AddArtistAlias(artist2.ID, "Existing Band")
+	suite.Require().Error(err)
+	suite.Contains(err.Error(), "conflicts with existing artist name")
+}
+
+func (suite *ArtistServiceIntegrationTestSuite) TestAddArtistAlias_EmptyAlias_Fails() {
+	artist, _ := suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "Empty Alias Artist"})
+
+	_, err := suite.artistService.AddArtistAlias(artist.ID, "  ")
+	suite.Require().Error(err)
+	suite.Contains(err.Error(), "cannot be empty")
+}
+
+func (suite *ArtistServiceIntegrationTestSuite) TestAddArtistAlias_ArtistNotFound() {
+	_, err := suite.artistService.AddArtistAlias(99999, "Some Alias")
+	suite.Require().Error(err)
+	var artistErr *apperrors.ArtistError
+	suite.ErrorAs(err, &artistErr)
+	suite.Equal(apperrors.CodeArtistNotFound, artistErr.Code)
+}
+
+func (suite *ArtistServiceIntegrationTestSuite) TestRemoveArtistAlias_Success() {
+	artist, _ := suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "Remove Alias Artist"})
+	alias, _ := suite.artistService.AddArtistAlias(artist.ID, "To Remove")
+
+	err := suite.artistService.RemoveArtistAlias(alias.ID)
+
+	suite.Require().NoError(err)
+
+	// Verify it's gone
+	aliases, err := suite.artistService.GetArtistAliases(artist.ID)
+	suite.Require().NoError(err)
+	suite.Empty(aliases)
+}
+
+func (suite *ArtistServiceIntegrationTestSuite) TestRemoveArtistAlias_NotFound() {
+	err := suite.artistService.RemoveArtistAlias(99999)
+	suite.Require().Error(err)
+	suite.Contains(err.Error(), "not found")
+}
+
+func (suite *ArtistServiceIntegrationTestSuite) TestGetArtistAliases_Success() {
+	artist, _ := suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "List Aliases Artist"})
+	suite.artistService.AddArtistAlias(artist.ID, "Alias B")
+	suite.artistService.AddArtistAlias(artist.ID, "Alias A")
+
+	aliases, err := suite.artistService.GetArtistAliases(artist.ID)
+
+	suite.Require().NoError(err)
+	suite.Require().Len(aliases, 2)
+	// Should be sorted alphabetically
+	suite.Equal("Alias A", aliases[0].Alias)
+	suite.Equal("Alias B", aliases[1].Alias)
+}
+
+func (suite *ArtistServiceIntegrationTestSuite) TestGetArtistAliases_ArtistNotFound() {
+	_, err := suite.artistService.GetArtistAliases(99999)
+	suite.Require().Error(err)
+	var artistErr *apperrors.ArtistError
+	suite.ErrorAs(err, &artistErr)
+	suite.Equal(apperrors.CodeArtistNotFound, artistErr.Code)
+}
+
+// =============================================================================
+// Group 11: MergeArtists
+// =============================================================================
+
+func (suite *ArtistServiceIntegrationTestSuite) TestMergeArtists_Basic() {
+	canonical, _ := suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "Canonical Artist"})
+	mergeFrom, _ := suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "Duplicate Artist"})
+
+	result, err := suite.artistService.MergeArtists(canonical.ID, mergeFrom.ID)
+
+	suite.Require().NoError(err)
+	suite.Require().NotNil(result)
+	suite.Equal(canonical.ID, result.CanonicalArtistID)
+	suite.Equal(mergeFrom.ID, result.MergedArtistID)
+	suite.Equal("Duplicate Artist", result.MergedArtistName)
+	suite.True(result.AliasCreated)
+
+	// Verify merged artist is deleted
+	_, err = suite.artistService.GetArtist(mergeFrom.ID)
+	suite.Require().Error(err)
+
+	// Verify alias was created
+	aliases, err := suite.artistService.GetArtistAliases(canonical.ID)
+	suite.Require().NoError(err)
+	suite.Require().Len(aliases, 1)
+	suite.Equal("Duplicate Artist", aliases[0].Alias)
+}
+
+func (suite *ArtistServiceIntegrationTestSuite) TestMergeArtists_TransfersShows() {
+	canonical, _ := suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "Merge Canonical"})
+	mergeFrom := suite.createTestArtist("Merge From")
+	venue := suite.createTestVenue("Merge Venue", "Phoenix", "AZ")
+	user := suite.createTestUser()
+
+	// MergeFrom has a show
+	suite.createApprovedShowWithArtist(mergeFrom.ID, venue.ID, user.ID, time.Now().UTC().AddDate(0, 0, 7))
+
+	result, err := suite.artistService.MergeArtists(canonical.ID, mergeFrom.ID)
+
+	suite.Require().NoError(err)
+	suite.Equal(int64(1), result.ShowsMoved)
+
+	// Verify canonical now has the show
+	shows, _, err := suite.artistService.GetShowsForArtist(canonical.ID, "UTC", 10, "upcoming")
+	suite.Require().NoError(err)
+	suite.Len(shows, 1)
+}
+
+func (suite *ArtistServiceIntegrationTestSuite) TestMergeArtists_ShowConflictDedup() {
+	canonical := suite.createTestArtist("Conflict Canonical")
+	mergeFrom := suite.createTestArtist("Conflict MergeFrom")
+	venue := suite.createTestVenue("Conflict Venue", "Phoenix", "AZ")
+	user := suite.createTestUser()
+
+	// Both artists are on the same show
+	show := suite.createApprovedShowWithArtist(canonical.ID, venue.ID, user.ID, time.Now().UTC().AddDate(0, 0, 7))
+	suite.db.Create(&models.ShowArtist{ShowID: show.ID, ArtistID: mergeFrom.ID, Position: 1})
+
+	result, err := suite.artistService.MergeArtists(canonical.ID, mergeFrom.ID)
+
+	suite.Require().NoError(err)
+	// The conflicting show_artist row is deleted, not moved
+	suite.Equal(int64(0), result.ShowsMoved)
+
+	// Verify show still has exactly 1 artist (canonical)
+	var count int64
+	suite.db.Model(&models.ShowArtist{}).Where("show_id = ?", show.ID).Count(&count)
+	suite.Equal(int64(1), count)
+}
+
+func (suite *ArtistServiceIntegrationTestSuite) TestMergeArtists_SelfMerge_Fails() {
+	artist, _ := suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "Self Artist"})
+
+	_, err := suite.artistService.MergeArtists(artist.ID, artist.ID)
+
+	suite.Require().Error(err)
+	suite.Contains(err.Error(), "cannot merge an artist with itself")
+}
+
+func (suite *ArtistServiceIntegrationTestSuite) TestMergeArtists_CanonicalNotFound() {
+	mergeFrom, _ := suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "MergeFrom NotFound"})
+
+	_, err := suite.artistService.MergeArtists(99999, mergeFrom.ID)
+
+	suite.Require().Error(err)
+	var artistErr *apperrors.ArtistError
+	suite.ErrorAs(err, &artistErr)
+	suite.Equal(apperrors.CodeArtistNotFound, artistErr.Code)
+}
+
+func (suite *ArtistServiceIntegrationTestSuite) TestMergeArtists_MergeFromNotFound() {
+	canonical, _ := suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "Canonical NotFound"})
+
+	_, err := suite.artistService.MergeArtists(canonical.ID, 99999)
+
+	suite.Require().Error(err)
+	var artistErr *apperrors.ArtistError
+	suite.ErrorAs(err, &artistErr)
+	suite.Equal(apperrors.CodeArtistNotFound, artistErr.Code)
+}
+
+func (suite *ArtistServiceIntegrationTestSuite) TestMergeArtists_TransfersAliases() {
+	canonical, _ := suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "Alias Canon"})
+	mergeFrom, _ := suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "Alias Merge"})
+
+	// Add existing alias to mergeFrom
+	suite.artistService.AddArtistAlias(mergeFrom.ID, "Old Alias")
+
+	result, err := suite.artistService.MergeArtists(canonical.ID, mergeFrom.ID)
+
+	suite.Require().NoError(err)
+	suite.True(result.AliasCreated)
+
+	// Verify canonical has both "Old Alias" and "Alias Merge"
+	aliases, err := suite.artistService.GetArtistAliases(canonical.ID)
+	suite.Require().NoError(err)
+	suite.Require().Len(aliases, 2)
+	aliasNames := []string{aliases[0].Alias, aliases[1].Alias}
+	suite.Contains(aliasNames, "Old Alias")
+	suite.Contains(aliasNames, "Alias Merge")
+}
+
+func (suite *ArtistServiceIntegrationTestSuite) TestMergeArtists_TransfersRevisions() {
+	canonical, _ := suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "Rev Canonical"})
+	mergeFrom, _ := suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "Rev MergeFrom"})
+	user := suite.createTestUser()
+
+	// Create a revision for mergeFrom
+	suite.db.Exec("INSERT INTO revisions (entity_type, entity_id, user_id, field_changes, summary, created_at) VALUES ('artist', ?, ?, '[]', 'test revision', NOW())", mergeFrom.ID, user.ID)
+
+	_, err := suite.artistService.MergeArtists(canonical.ID, mergeFrom.ID)
+	suite.Require().NoError(err)
+
+	// Verify revision now points to canonical
+	var count int64
+	suite.db.Raw("SELECT COUNT(*) FROM revisions WHERE entity_type = 'artist' AND entity_id = ?", canonical.ID).Scan(&count)
+	suite.Equal(int64(1), count)
+}
+
+func (suite *ArtistServiceIntegrationTestSuite) TestMergeArtists_TransfersBookmarks() {
+	canonical, _ := suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "BM Canonical"})
+	mergeFrom, _ := suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "BM MergeFrom"})
+	user := suite.createTestUser()
+
+	// Create a bookmark for mergeFrom
+	suite.db.Exec("INSERT INTO user_bookmarks (user_id, entity_type, entity_id, action, created_at) VALUES (?, 'artist', ?, 'bookmark', NOW())", user.ID, mergeFrom.ID)
+
+	result, err := suite.artistService.MergeArtists(canonical.ID, mergeFrom.ID)
+	suite.Require().NoError(err)
+	suite.Equal(int64(1), result.BookmarksMoved)
+
+	// Verify bookmark now points to canonical
+	var count int64
+	suite.db.Raw("SELECT COUNT(*) FROM user_bookmarks WHERE entity_type = 'artist' AND entity_id = ?", canonical.ID).Scan(&count)
+	suite.Equal(int64(1), count)
 }

--- a/backend/internal/services/contracts/catalog.go
+++ b/backend/internal/services/contracts/catalog.go
@@ -501,3 +501,25 @@ type ArtistShowArtist struct {
 	Slug string `json:"slug"`
 	Name string `json:"name"`
 }
+
+// ArtistAliasResponse represents an artist alias in API responses
+type ArtistAliasResponse struct {
+	ID        uint   `json:"id"`
+	ArtistID  uint   `json:"artist_id"`
+	Alias     string `json:"alias"`
+	CreatedAt string `json:"created_at"`
+}
+
+// MergeArtistResult contains the outcome of merging two artists
+type MergeArtistResult struct {
+	CanonicalArtistID uint   `json:"canonical_artist_id"`
+	MergedArtistID    uint   `json:"merged_artist_id"`
+	MergedArtistName  string `json:"merged_artist_name"`
+	ShowsMoved        int64  `json:"shows_moved"`
+	ReleasesMoved     int64  `json:"releases_moved"`
+	LabelsMoved       int64  `json:"labels_moved"`
+	FestivalsMoved    int64  `json:"festivals_moved"`
+	RelationshipsMoved int64 `json:"relationships_moved"`
+	BookmarksMoved    int64  `json:"bookmarks_moved"`
+	AliasCreated      bool   `json:"alias_created"`
+}

--- a/backend/internal/services/contracts/interfaces.go
+++ b/backend/internal/services/contracts/interfaces.go
@@ -83,6 +83,10 @@ type ArtistServiceInterface interface {
 	GetShowsForArtist(artistID uint, timezone string, limit int, timeFilter string) ([]*ArtistShowResponse, int64, error)
 	GetArtistCities() ([]*ArtistCityResponse, error)
 	GetLabelsForArtist(artistID uint) ([]*ArtistLabelResponse, error)
+	AddArtistAlias(artistID uint, alias string) (*ArtistAliasResponse, error)
+	RemoveArtistAlias(aliasID uint) error
+	GetArtistAliases(artistID uint) ([]*ArtistAliasResponse, error)
+	MergeArtists(canonicalID, mergeFromID uint) (*MergeArtistResult, error)
 }
 
 // SavedShowServiceInterface defines the contract for saved show operations.

--- a/frontend/app/admin/artists/_components/ArtistManagement.tsx
+++ b/frontend/app/admin/artists/_components/ArtistManagement.tsx
@@ -1,0 +1,398 @@
+'use client'
+
+import { useState } from 'react'
+import { Loader2, Plus, X, Trash2, GitMerge, Search } from 'lucide-react'
+import { useArtistSearch } from '@/features/artists'
+import {
+  useArtistAliases,
+  useCreateArtistAlias,
+  useDeleteArtistAlias,
+  useMergeArtists,
+} from '@/lib/hooks/admin/useAdminArtists'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Badge } from '@/components/ui/badge'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import type { Artist, MergeArtistResult } from '@/features/artists'
+
+// --- Alias Manager ---
+
+function AliasManager({ artist }: { artist: Artist }) {
+  const [newAlias, setNewAlias] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  const { data, isLoading } = useArtistAliases(artist.id)
+  const createAlias = useCreateArtistAlias()
+  const deleteAlias = useDeleteArtistAlias()
+
+  const handleAdd = () => {
+    const trimmed = newAlias.trim()
+    if (!trimmed) return
+    setError(null)
+    createAlias.mutate(
+      { artistId: artist.id, alias: trimmed },
+      {
+        onSuccess: () => setNewAlias(''),
+        onError: err => setError(err instanceof Error ? err.message : 'Failed to add alias'),
+      }
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      <h4 className="text-sm font-medium">Aliases for {artist.name}</h4>
+
+      {isLoading ? (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Loading...
+        </div>
+      ) : (
+        <div className="flex flex-wrap gap-2">
+          {data?.aliases?.map(alias => (
+            <Badge key={alias.id} variant="secondary" className="gap-1 pr-1">
+              {alias.alias}
+              <button
+                onClick={() =>
+                  deleteAlias.mutate({ artistId: artist.id, aliasId: alias.id })
+                }
+                disabled={deleteAlias.isPending}
+                className="ml-1 rounded-full p-0.5 hover:bg-destructive/20"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </Badge>
+          ))}
+          {(!data?.aliases || data.aliases.length === 0) && (
+            <span className="text-sm text-muted-foreground">No aliases</span>
+          )}
+        </div>
+      )}
+
+      <div className="flex gap-2">
+        <Input
+          placeholder="Add alias..."
+          value={newAlias}
+          onChange={e => setNewAlias(e.target.value)}
+          onKeyDown={e => e.key === 'Enter' && handleAdd()}
+          className="flex-1"
+        />
+        <Button
+          size="sm"
+          onClick={handleAdd}
+          disabled={createAlias.isPending || !newAlias.trim()}
+        >
+          {createAlias.isPending ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Plus className="h-4 w-4" />
+          )}
+        </Button>
+      </div>
+
+      {error && <p className="text-sm text-destructive">{error}</p>}
+    </div>
+  )
+}
+
+// --- Artist Search/Select ---
+
+function ArtistSelector({
+  label,
+  selected,
+  onSelect,
+  excludeId,
+}: {
+  label: string
+  selected: Artist | null
+  onSelect: (artist: Artist | null) => void
+  excludeId?: number
+}) {
+  const [query, setQuery] = useState('')
+  const { data: searchData } = useArtistSearch({
+    query,
+  })
+
+  const filteredResults = searchData?.artists?.filter(a => a.id !== excludeId) ?? []
+
+  return (
+    <div className="space-y-2">
+      <label className="text-sm font-medium">{label}</label>
+      {selected ? (
+        <div className="flex items-center gap-2 p-2 rounded-md border bg-muted/50">
+          <span className="flex-1 text-sm font-medium">{selected.name}</span>
+          <span className="text-xs text-muted-foreground">ID: {selected.id}</span>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              onSelect(null)
+              setQuery('')
+            }}
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+      ) : (
+        <div className="relative">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input
+              placeholder="Search artists..."
+              value={query}
+              onChange={e => setQuery(e.target.value)}
+              className="pl-9"
+            />
+          </div>
+          {query.length >= 2 && filteredResults.length > 0 && (
+            <div className="absolute z-10 mt-1 w-full rounded-md border bg-popover shadow-md max-h-48 overflow-y-auto">
+              {filteredResults.map(artist => (
+                <button
+                  key={artist.id}
+                  onClick={() => {
+                    onSelect(artist)
+                    setQuery('')
+                  }}
+                  className="w-full text-left px-3 py-2 text-sm hover:bg-muted transition-colors flex items-center justify-between"
+                >
+                  <span>{artist.name}</span>
+                  <span className="text-xs text-muted-foreground">
+                    {[artist.city, artist.state].filter(Boolean).join(', ')}
+                  </span>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// --- Merge Dialog ---
+
+function MergeDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const [canonical, setCanonical] = useState<Artist | null>(null)
+  const [mergeFrom, setMergeFrom] = useState<Artist | null>(null)
+  const [result, setResult] = useState<MergeArtistResult | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const merge = useMergeArtists()
+
+  const handleMerge = () => {
+    if (!canonical || !mergeFrom) return
+    setError(null)
+    setResult(null)
+    merge.mutate(
+      {
+        canonicalArtistId: canonical.id,
+        mergeFromArtistId: mergeFrom.id,
+      },
+      {
+        onSuccess: data => {
+          setResult(data)
+          setMergeFrom(null)
+        },
+        onError: err => setError(err instanceof Error ? err.message : 'Merge failed'),
+      }
+    )
+  }
+
+  const handleClose = () => {
+    onOpenChange(false)
+    setCanonical(null)
+    setMergeFrom(null)
+    setResult(null)
+    setError(null)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <GitMerge className="h-5 w-5" />
+            Merge Artists
+          </DialogTitle>
+          <DialogDescription>
+            Merge a duplicate artist into the canonical one. All shows, releases,
+            labels, and other relationships will be transferred. The merged
+            artist will be deleted and its name added as an alias.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <ArtistSelector
+            label="Keep (canonical)"
+            selected={canonical}
+            onSelect={setCanonical}
+            excludeId={mergeFrom?.id}
+          />
+          <ArtistSelector
+            label="Merge & delete"
+            selected={mergeFrom}
+            onSelect={setMergeFrom}
+            excludeId={canonical?.id}
+          />
+        </div>
+
+        {result && (
+          <div className="rounded-md border border-green-500/20 bg-green-500/10 p-3 text-sm space-y-1">
+            <p className="font-medium text-green-700 dark:text-green-400">
+              Merged &ldquo;{result.merged_artist_name}&rdquo; successfully
+            </p>
+            <ul className="text-muted-foreground text-xs space-y-0.5">
+              {result.shows_moved > 0 && <li>{result.shows_moved} shows transferred</li>}
+              {result.releases_moved > 0 && <li>{result.releases_moved} releases transferred</li>}
+              {result.labels_moved > 0 && <li>{result.labels_moved} labels transferred</li>}
+              {result.festivals_moved > 0 && <li>{result.festivals_moved} festivals transferred</li>}
+              {result.bookmarks_moved > 0 && <li>{result.bookmarks_moved} bookmarks transferred</li>}
+              {result.alias_created && <li>Alias created from merged name</li>}
+            </ul>
+          </div>
+        )}
+
+        {error && <p className="text-sm text-destructive">{error}</p>}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={handleClose}>
+            {result ? 'Done' : 'Cancel'}
+          </Button>
+          {!result && (
+            <Button
+              variant="destructive"
+              onClick={handleMerge}
+              disabled={!canonical || !mergeFrom || merge.isPending}
+            >
+              {merge.isPending ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  Merging...
+                </>
+              ) : (
+                <>
+                  <GitMerge className="h-4 w-4 mr-2" />
+                  Merge Artists
+                </>
+              )}
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+// --- Main Component ---
+
+export function ArtistManagement() {
+  const [searchQuery, setSearchQuery] = useState('')
+  const [selectedArtist, setSelectedArtist] = useState<Artist | null>(null)
+  const [showMergeDialog, setShowMergeDialog] = useState(false)
+
+  const { data: searchData, isLoading: searchLoading } = useArtistSearch({
+    query: searchQuery,
+  })
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold">Artist Management</h2>
+          <p className="text-sm text-muted-foreground">
+            Manage aliases and merge duplicate artists
+          </p>
+        </div>
+        <Button onClick={() => setShowMergeDialog(true)} variant="outline" className="gap-2">
+          <GitMerge className="h-4 w-4" />
+          Merge Artists
+        </Button>
+      </div>
+
+      {/* Search */}
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+        <Input
+          placeholder="Search artists to manage aliases..."
+          value={searchQuery}
+          onChange={e => {
+            setSearchQuery(e.target.value)
+            if (e.target.value.length < 2) setSelectedArtist(null)
+          }}
+          className="pl-9"
+        />
+      </div>
+
+      {/* Search Results */}
+      {searchQuery.length >= 2 && !selectedArtist && (
+        <div className="rounded-md border divide-y">
+          {searchLoading ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+            </div>
+          ) : searchData?.artists && searchData.artists.length > 0 ? (
+            searchData.artists.map(artist => (
+              <button
+                key={artist.id}
+                onClick={() => setSelectedArtist(artist)}
+                className="w-full text-left px-4 py-3 hover:bg-muted/50 transition-colors flex items-center justify-between"
+              >
+                <div>
+                  <span className="font-medium">{artist.name}</span>
+                  {(artist.city || artist.state) && (
+                    <span className="ml-2 text-sm text-muted-foreground">
+                      {[artist.city, artist.state].filter(Boolean).join(', ')}
+                    </span>
+                  )}
+                </div>
+                <span className="text-xs text-muted-foreground">ID: {artist.id}</span>
+              </button>
+            ))
+          ) : (
+            <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+              No artists found
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Selected Artist - Alias Manager */}
+      {selectedArtist && (
+        <div className="rounded-md border p-4 space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="font-medium">{selectedArtist.name}</h3>
+              <p className="text-sm text-muted-foreground">
+                {[selectedArtist.city, selectedArtist.state].filter(Boolean).join(', ') || 'No location'}
+                {' \u00b7 '}ID: {selectedArtist.id}
+              </p>
+            </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setSelectedArtist(null)}
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
+          <AliasManager artist={selectedArtist} />
+        </div>
+      )}
+
+      <MergeDialog open={showMergeDialog} onOpenChange={setShowMergeDialog} />
+    </div>
+  )
+}

--- a/frontend/app/admin/artists/page.tsx
+++ b/frontend/app/admin/artists/page.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import { ArtistManagement } from './_components/ArtistManagement'
+
+export default function AdminArtistsPage() {
+  return <ArtistManagement />
+}

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import dynamic from 'next/dynamic'
-import { Shield, MapPin, Loader2, Upload, BadgeCheck, Flag, ScrollText, Users, LayoutDashboard, Clock, Disc3, Tag, Tags, Tent, Workflow, Library } from 'lucide-react'
+import { Shield, MapPin, Loader2, Upload, BadgeCheck, Flag, ScrollText, Users, LayoutDashboard, Clock, Disc3, Tag, Tags, Tent, Workflow, Library, Music } from 'lucide-react'
 import { usePendingVenueEdits } from '@/lib/hooks/admin/useAdminVenueEdits'
 import { useUnverifiedVenues } from '@/lib/hooks/admin/useAdminVenues'
 import { usePendingReports } from '@/lib/hooks/admin/useAdminReports'
@@ -115,6 +115,14 @@ const UsersPage = dynamic(() => import('./users/page'), {
 })
 
 const TagsPage = dynamic(() => import('./tags/page'), {
+  loading: () => (
+    <div className="flex items-center justify-center py-12">
+      <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+    </div>
+  ),
+})
+
+const ArtistsPage = dynamic(() => import('./artists/page'), {
   loading: () => (
     <div className="flex items-center justify-center py-12">
       <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
@@ -244,6 +252,10 @@ export default function AdminPage() {
               <Tags className="h-4 w-4" />
               Tags
             </TabsTrigger>
+            <TabsTrigger value="artists-admin" className="gap-2">
+              <Music className="h-4 w-4" />
+              Artists
+            </TabsTrigger>
             <TabsTrigger value="users" className="gap-2">
               <Users className="h-4 w-4" />
               Users
@@ -300,6 +312,10 @@ export default function AdminPage() {
 
           <TabsContent value="tags" className="space-y-4">
             <TagsPage />
+          </TabsContent>
+
+          <TabsContent value="artists-admin" className="space-y-4">
+            <ArtistsPage />
           </TabsContent>
 
           <TabsContent value="users" className="space-y-4">

--- a/frontend/features/artists/components/ArtistDetail.test.tsx
+++ b/frontend/features/artists/components/ArtistDetail.test.tsx
@@ -64,6 +64,7 @@ vi.mock('@/lib/hooks/admin/useAdminArtists', () => ({
   useClearArtistBandcamp: () => ({ mutate: vi.fn(), isPending: false }),
   useUpdateArtistSpotify: () => ({ mutate: vi.fn(), isPending: false }),
   useClearArtistSpotify: () => ({ mutate: vi.fn(), isPending: false }),
+  useArtistAliases: () => ({ data: { aliases: [] }, isLoading: false }),
 }))
 
 // Mock child components

--- a/frontend/features/artists/components/ArtistDetail.tsx
+++ b/frontend/features/artists/components/ArtistDetail.tsx
@@ -18,6 +18,7 @@ import {
 import { useQueryClient } from '@tanstack/react-query'
 import { useArtist } from '../hooks/useArtists'
 import { useArtistReleases } from '@/features/releases/hooks/useReleases'
+import { useArtistAliases } from '@/lib/hooks/admin/useAdminArtists'
 import { useArtistLabels, useLabelRoster } from '@/features/labels/hooks/useLabels'
 import { queryKeys } from '@/lib/queryClient'
 import { useIsAuthenticated } from '@/features/auth'
@@ -312,6 +313,8 @@ function ArtistSidebar({
   labelsLoading: boolean
 }) {
   const hasLocation = artist.city || artist.state
+  const { data: aliasesData } = useArtistAliases(artist.id)
+  const aliases = aliasesData?.aliases ?? []
 
   return (
     <div className="space-y-6">
@@ -324,6 +327,22 @@ function ArtistSidebar({
           <div className="flex items-center gap-1.5 text-sm">
             <MapPin className="h-4 w-4 text-muted-foreground" />
             <span>{[artist.city, artist.state].filter(Boolean).join(', ')}</span>
+          </div>
+        </div>
+      )}
+
+      {/* Aliases */}
+      {aliases.length > 0 && (
+        <div>
+          <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+            Also known as
+          </h3>
+          <div className="space-y-1">
+            {aliases.map(alias => (
+              <p key={alias.id} className="text-sm text-muted-foreground">
+                {alias.alias}
+              </p>
+            ))}
           </div>
         </div>
       )}

--- a/frontend/features/artists/index.ts
+++ b/frontend/features/artists/index.ts
@@ -23,6 +23,9 @@ export type {
   CreateArtistReportRequest,
   MyArtistReportResponse,
   ArtistReportsListResponse,
+  ArtistAlias,
+  ArtistAliasesResponse,
+  MergeArtistResult,
 } from './types'
 
 export { getArtistLocation } from './types'

--- a/frontend/features/artists/types.ts
+++ b/frontend/features/artists/types.ts
@@ -168,3 +168,31 @@ export interface ArtistReportsListResponse {
   reports: ArtistReportResponse[]
   total: number
 }
+
+// Artist alias
+export interface ArtistAlias {
+  id: number
+  artist_id: number
+  alias: string
+  created_at: string
+}
+
+// Response for artist aliases endpoint
+export interface ArtistAliasesResponse {
+  aliases: ArtistAlias[]
+  count: number
+}
+
+// Merge artist result
+export interface MergeArtistResult {
+  canonical_artist_id: number
+  merged_artist_id: number
+  merged_artist_name: string
+  shows_moved: number
+  releases_moved: number
+  labels_moved: number
+  festivals_moved: number
+  relationships_moved: number
+  bookmarks_moved: number
+  alias_created: boolean
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -116,6 +116,7 @@ export const API_ENDPOINTS = {
     GET: (artistIdOrSlug: string | number) => `${API_BASE_URL}/artists/${artistIdOrSlug}`,
     SHOWS: (artistIdOrSlug: string | number) => `${API_BASE_URL}/artists/${artistIdOrSlug}/shows`,
     LABELS: (artistIdOrSlug: string | number) => `${API_BASE_URL}/artists/${artistIdOrSlug}/labels`,
+    ALIASES: (artistId: string | number) => `${API_BASE_URL}/artists/${artistId}/aliases`,
     DELETE: (artistId: string | number) => `${API_BASE_URL}/artists/${artistId}`,
     REPORT: (artistId: string | number) =>
       `${API_BASE_URL}/artists/${artistId}/report`,
@@ -242,6 +243,11 @@ export const API_ENDPOINTS = {
     ARTISTS: {
       UPDATE: (artistId: string | number) =>
         `${API_BASE_URL}/admin/artists/${artistId}`,
+      ALIASES: (artistId: string | number) =>
+        `${API_BASE_URL}/admin/artists/${artistId}/aliases`,
+      DELETE_ALIAS: (artistId: string | number, aliasId: string | number) =>
+        `${API_BASE_URL}/admin/artists/${artistId}/aliases/${aliasId}`,
+      MERGE: `${API_BASE_URL}/admin/artists/merge`,
     },
     REPORTS: {
       LIST: `${API_BASE_URL}/admin/reports`,

--- a/frontend/lib/hooks/admin/useAdminArtists.ts
+++ b/frontend/lib/hooks/admin/useAdminArtists.ts
@@ -7,10 +7,10 @@
  * music discovery (Bandcamp/Spotify) and manual URL updates.
  */
 
-import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { apiRequest, API_ENDPOINTS } from '../../api'
 import { queryKeys } from '../../queryClient'
-import type { Artist, ArtistEditRequest } from '@/features/artists'
+import type { Artist, ArtistEditRequest, ArtistAliasesResponse, ArtistAlias, MergeArtistResult } from '@/features/artists'
 
 /**
  * Platform types for music discovery
@@ -383,6 +383,107 @@ export function useArtistUpdate() {
       queryClient.invalidateQueries({
         queryKey: queryKeys.shows.all,
       })
+    },
+  })
+}
+
+/**
+ * Hook for fetching artist aliases
+ */
+export function useArtistAliases(artistId: number, enabled = true) {
+  return useQuery({
+    queryKey: queryKeys.artists.aliases(artistId),
+    queryFn: () =>
+      apiRequest<ArtistAliasesResponse>(API_ENDPOINTS.ARTISTS.ALIASES(artistId)),
+    enabled: enabled && artistId > 0,
+  })
+}
+
+/**
+ * Hook for creating an artist alias (admin only)
+ */
+export function useCreateArtistAlias() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({
+      artistId,
+      alias,
+    }: {
+      artistId: number
+      alias: string
+    }): Promise<ArtistAlias> => {
+      return apiRequest<ArtistAlias>(
+        API_ENDPOINTS.ADMIN.ARTISTS.ALIASES(artistId),
+        {
+          method: 'POST',
+          body: JSON.stringify({ alias }),
+        }
+      )
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.artists.aliases(variables.artistId),
+      })
+    },
+  })
+}
+
+/**
+ * Hook for deleting an artist alias (admin only)
+ */
+export function useDeleteArtistAlias() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({
+      artistId,
+      aliasId,
+    }: {
+      artistId: number
+      aliasId: number
+    }): Promise<void> => {
+      await apiRequest(
+        API_ENDPOINTS.ADMIN.ARTISTS.DELETE_ALIAS(artistId, aliasId),
+        { method: 'DELETE' }
+      )
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.artists.aliases(variables.artistId),
+      })
+    },
+  })
+}
+
+/**
+ * Hook for merging two artists (admin only)
+ */
+export function useMergeArtists() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({
+      canonicalArtistId,
+      mergeFromArtistId,
+    }: {
+      canonicalArtistId: number
+      mergeFromArtistId: number
+    }): Promise<MergeArtistResult> => {
+      return apiRequest<MergeArtistResult>(
+        API_ENDPOINTS.ADMIN.ARTISTS.MERGE,
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            canonical_artist_id: canonicalArtistId,
+            merge_from_artist_id: mergeFromArtistId,
+          }),
+        }
+      )
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.artists.all })
+      queryClient.invalidateQueries({ queryKey: queryKeys.shows.all })
     },
   })
 }

--- a/frontend/lib/queryClient.ts
+++ b/frontend/lib/queryClient.ts
@@ -165,6 +165,7 @@ export const queryKeys = {
     detail: (idOrSlug: string | number) => ['artists', 'detail', String(idOrSlug)] as const,
     shows: (artistIdOrSlug: string | number) => ['artists', 'shows', String(artistIdOrSlug)] as const,
     labels: (artistIdOrSlug: string | number) => ['artists', 'labels', String(artistIdOrSlug)] as const,
+    aliases: (artistId: number) => ['artists', 'aliases', artistId] as const,
   },
 
   // Release queries


### PR DESCRIPTION
## Summary
- **Artist aliases**: alternate names that resolve to the canonical artist, searchable and displayed in sidebar ("Also known as")
- **Admin merge**: combine duplicate artists in a single transaction — transfers shows, releases, labels, festivals, tags, bookmarks, reports, and revisions with conflict deduplication
- **Admin UI**: new Artists tab with alias manager (add/remove badges) and merge dialog (dual search/select, confirmation, result summary)

## Changes

### Backend
- Migration 000053: `artist_aliases` table with case-insensitive unique index
- `ArtistAlias` model with GORM relationship on `Artist`
- 4 new service methods: `AddArtistAlias`, `RemoveArtistAlias`, `GetArtistAliases`, `MergeArtists`
- `SearchArtists` enhanced to search aliases (UNION query)
- 4 new API endpoints: `GET /artists/{id}/aliases`, `POST /admin/artists/{id}/aliases`, `DELETE /admin/artists/{id}/aliases/{alias_id}`, `POST /admin/artists/merge`
- 15 new integration tests (alias CRUD + merge scenarios)

### Frontend
- Types: `ArtistAlias`, `ArtistAliasesResponse`, `MergeArtistResult`
- Hooks: `useArtistAliases`, `useCreateArtistAlias`, `useDeleteArtistAlias`, `useMergeArtists`
- Admin Artists tab with `ArtistManagement` component
- "Also known as" section in ArtistDetail sidebar

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/services/catalog/ -run TestArtistService` — all 59 tests pass (15 new)
- [x] `bun run build` passes
- [x] `bun run test:run` — all 1403 tests pass
- [ ] Manual: create aliases, search by alias, merge two artists in admin UI

Closes PSY-47

🤖 Generated with [Claude Code](https://claude.com/claude-code)