### PR TITLE
Add scene page backend with computed city aggregations

### DIFF
--- a/backend/internal/api/handlers/scene.go
+++ b/backend/internal/api/handlers/scene.go
@@ -1,0 +1,150 @@
+package handlers
+
+import (
+	"context"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"psychic-homily-backend/internal/services"
+)
+
+// SceneHandler handles scene (city aggregation) endpoints.
+type SceneHandler struct {
+	sceneService services.SceneServiceInterface
+}
+
+// NewSceneHandler creates a new SceneHandler.
+func NewSceneHandler(sceneService services.SceneServiceInterface) *SceneHandler {
+	return &SceneHandler{
+		sceneService: sceneService,
+	}
+}
+
+// ============================================================================
+// List Scenes
+// ============================================================================
+
+// ListScenesRequest represents the request for listing scenes.
+type ListScenesRequest struct{}
+
+// ListScenesResponse represents the response for listing scenes.
+type ListScenesResponse struct {
+	Body struct {
+		Scenes []*services.SceneListResponse `json:"scenes" doc:"List of city scenes"`
+		Count  int                           `json:"count" doc:"Number of scenes"`
+	}
+}
+
+// ListScenesHandler handles GET /scenes — returns cities that qualify as scenes.
+func (h *SceneHandler) ListScenesHandler(ctx context.Context, req *ListScenesRequest) (*ListScenesResponse, error) {
+	scenes, err := h.sceneService.ListScenes()
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Failed to list scenes", err)
+	}
+
+	if scenes == nil {
+		scenes = []*services.SceneListResponse{}
+	}
+
+	resp := &ListScenesResponse{}
+	resp.Body.Scenes = scenes
+	resp.Body.Count = len(scenes)
+
+	return resp, nil
+}
+
+// ============================================================================
+// Get Scene Detail
+// ============================================================================
+
+// GetSceneDetailRequest represents the request for getting scene detail.
+type GetSceneDetailRequest struct {
+	Slug string `path:"slug" doc:"Scene slug (e.g. phoenix-az)" example:"phoenix-az"`
+}
+
+// GetSceneDetailResponse represents the response for scene detail.
+type GetSceneDetailResponse struct {
+	Body *services.SceneDetailResponse
+}
+
+// GetSceneDetailHandler handles GET /scenes/{slug} — returns full computed scene detail.
+func (h *SceneHandler) GetSceneDetailHandler(ctx context.Context, req *GetSceneDetailRequest) (*GetSceneDetailResponse, error) {
+	city, state, err := h.sceneService.ParseSceneSlug(req.Slug)
+	if err != nil {
+		return nil, huma.Error404NotFound("Scene not found")
+	}
+
+	detail, err := h.sceneService.GetSceneDetail(city, state)
+	if err != nil {
+		if isSceneNotFoundErr(err) {
+			return nil, huma.Error404NotFound("Scene not found")
+		}
+		return nil, huma.Error500InternalServerError("Failed to get scene detail", err)
+	}
+
+	return &GetSceneDetailResponse{Body: detail}, nil
+}
+
+// ============================================================================
+// Get Scene Active Artists
+// ============================================================================
+
+// GetSceneActiveArtistsRequest represents the request for getting active artists in a scene.
+type GetSceneActiveArtistsRequest struct {
+	Slug   string `path:"slug" doc:"Scene slug (e.g. phoenix-az)" example:"phoenix-az"`
+	Period int    `query:"period" default:"90" minimum:"7" maximum:"365" doc:"Period in days for activity window"`
+	Limit  int    `query:"limit" default:"20" minimum:"1" maximum:"100" doc:"Maximum number of artists to return"`
+	Offset int    `query:"offset" default:"0" minimum:"0" doc:"Offset for pagination"`
+}
+
+// GetSceneActiveArtistsResponse represents the response for active artists.
+type GetSceneActiveArtistsResponse struct {
+	Body struct {
+		Artists []*services.SceneArtistResponse `json:"artists" doc:"List of active artists"`
+		Total   int64                           `json:"total" doc:"Total number of active artists"`
+	}
+}
+
+// GetSceneActiveArtistsHandler handles GET /scenes/{slug}/artists — returns artists ranked by show count.
+func (h *SceneHandler) GetSceneActiveArtistsHandler(ctx context.Context, req *GetSceneActiveArtistsRequest) (*GetSceneActiveArtistsResponse, error) {
+	city, state, err := h.sceneService.ParseSceneSlug(req.Slug)
+	if err != nil {
+		return nil, huma.Error404NotFound("Scene not found")
+	}
+
+	period := req.Period
+	if period == 0 {
+		period = 90
+	}
+	limit := req.Limit
+	if limit == 0 {
+		limit = 20
+	}
+
+	artists, total, err := h.sceneService.GetActiveArtists(city, state, period, limit, req.Offset)
+	if err != nil {
+		if isSceneNotFoundErr(err) {
+			return nil, huma.Error404NotFound("Scene not found")
+		}
+		return nil, huma.Error500InternalServerError("Failed to get active artists", err)
+	}
+
+	if artists == nil {
+		artists = []*services.SceneArtistResponse{}
+	}
+
+	resp := &GetSceneActiveArtistsResponse{}
+	resp.Body.Artists = artists
+	resp.Body.Total = total
+
+	return resp, nil
+}
+
+// isSceneNotFoundErr checks if an error indicates a scene was not found.
+func isSceneNotFoundErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return len(msg) >= 15 && msg[:15] == "scene not found"
+}

--- a/backend/internal/api/handlers/scene_test.go
+++ b/backend/internal/api/handlers/scene_test.go
@@ -1,0 +1,315 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"psychic-homily-backend/internal/services"
+)
+
+// ============================================================================
+// Mock SceneService
+// ============================================================================
+
+type mockSceneService struct {
+	listScenesFn     func() ([]*services.SceneListResponse, error)
+	getSceneDetailFn func(city, state string) (*services.SceneDetailResponse, error)
+	getActiveArtistsFn func(city, state string, periodDays, limit, offset int) ([]*services.SceneArtistResponse, int64, error)
+	parseSceneSlugFn func(slug string) (string, string, error)
+}
+
+func (m *mockSceneService) ListScenes() ([]*services.SceneListResponse, error) {
+	if m.listScenesFn != nil {
+		return m.listScenesFn()
+	}
+	return []*services.SceneListResponse{}, nil
+}
+
+func (m *mockSceneService) GetSceneDetail(city, state string) (*services.SceneDetailResponse, error) {
+	if m.getSceneDetailFn != nil {
+		return m.getSceneDetailFn(city, state)
+	}
+	return nil, nil
+}
+
+func (m *mockSceneService) GetActiveArtists(city, state string, periodDays, limit, offset int) ([]*services.SceneArtistResponse, int64, error) {
+	if m.getActiveArtistsFn != nil {
+		return m.getActiveArtistsFn(city, state, periodDays, limit, offset)
+	}
+	return []*services.SceneArtistResponse{}, 0, nil
+}
+
+func (m *mockSceneService) ParseSceneSlug(slug string) (string, string, error) {
+	if m.parseSceneSlugFn != nil {
+		return m.parseSceneSlugFn(slug)
+	}
+	return "", "", fmt.Errorf("scene not found for slug: %s", slug)
+}
+
+// ============================================================================
+// Constructor
+// ============================================================================
+
+func TestNewSceneHandler(t *testing.T) {
+	h := NewSceneHandler(nil)
+	if h == nil {
+		t.Fatal("expected non-nil SceneHandler")
+	}
+}
+
+// ============================================================================
+// ListScenesHandler Tests
+// ============================================================================
+
+func TestListScenes_Success(t *testing.T) {
+	mock := &mockSceneService{
+		listScenesFn: func() ([]*services.SceneListResponse, error) {
+			return []*services.SceneListResponse{
+				{City: "Phoenix", State: "AZ", Slug: "phoenix-az", VenueCount: 5, UpcomingShowCount: 12},
+			}, nil
+		},
+	}
+	h := NewSceneHandler(mock)
+	resp, err := h.ListScenesHandler(context.Background(), &ListScenesRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Count != 1 {
+		t.Errorf("expected count 1, got %d", resp.Body.Count)
+	}
+	if resp.Body.Scenes[0].City != "Phoenix" {
+		t.Errorf("expected Phoenix, got %s", resp.Body.Scenes[0].City)
+	}
+}
+
+func TestListScenes_Empty(t *testing.T) {
+	mock := &mockSceneService{
+		listScenesFn: func() ([]*services.SceneListResponse, error) {
+			return nil, nil
+		},
+	}
+	h := NewSceneHandler(mock)
+	resp, err := h.ListScenesHandler(context.Background(), &ListScenesRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Count != 0 {
+		t.Errorf("expected count 0, got %d", resp.Body.Count)
+	}
+}
+
+func TestListScenes_ServiceError(t *testing.T) {
+	mock := &mockSceneService{
+		listScenesFn: func() ([]*services.SceneListResponse, error) {
+			return nil, fmt.Errorf("database error")
+		},
+	}
+	h := NewSceneHandler(mock)
+	_, err := h.ListScenesHandler(context.Background(), &ListScenesRequest{})
+	assertHumaError(t, err, 500)
+}
+
+// ============================================================================
+// GetSceneDetailHandler Tests
+// ============================================================================
+
+func TestGetSceneDetail_Success(t *testing.T) {
+	mock := &mockSceneService{
+		parseSceneSlugFn: func(slug string) (string, string, error) {
+			return "Phoenix", "AZ", nil
+		},
+		getSceneDetailFn: func(city, state string) (*services.SceneDetailResponse, error) {
+			return &services.SceneDetailResponse{
+				City:  city,
+				State: state,
+				Slug:  "phoenix-az",
+				Stats: services.SceneStats{
+					VenueCount:        5,
+					ArtistCount:       30,
+					UpcomingShowCount: 12,
+					FestivalCount:     2,
+				},
+				Pulse: services.ScenePulse{
+					ShowsThisMonth: 8,
+					ShowsPrevMonth: 5,
+					ShowsTrend:     "+3",
+					ShowsByMonth:   []int{3, 4, 5, 6, 5, 8},
+				},
+			}, nil
+		},
+	}
+	h := NewSceneHandler(mock)
+	req := &GetSceneDetailRequest{Slug: "phoenix-az"}
+	resp, err := h.GetSceneDetailHandler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.City != "Phoenix" {
+		t.Errorf("expected Phoenix, got %s", resp.Body.City)
+	}
+	if resp.Body.Stats.VenueCount != 5 {
+		t.Errorf("expected venue count 5, got %d", resp.Body.Stats.VenueCount)
+	}
+}
+
+func TestGetSceneDetail_SlugNotFound(t *testing.T) {
+	mock := &mockSceneService{
+		parseSceneSlugFn: func(slug string) (string, string, error) {
+			return "", "", fmt.Errorf("scene not found for slug: %s", slug)
+		},
+	}
+	h := NewSceneHandler(mock)
+	req := &GetSceneDetailRequest{Slug: "nonexistent-xx"}
+	_, err := h.GetSceneDetailHandler(context.Background(), req)
+	assertHumaError(t, err, 404)
+}
+
+func TestGetSceneDetail_SceneNotFound(t *testing.T) {
+	mock := &mockSceneService{
+		parseSceneSlugFn: func(slug string) (string, string, error) {
+			return "Tiny", "XX", nil
+		},
+		getSceneDetailFn: func(city, state string) (*services.SceneDetailResponse, error) {
+			return nil, fmt.Errorf("scene not found: %s, %s", city, state)
+		},
+	}
+	h := NewSceneHandler(mock)
+	req := &GetSceneDetailRequest{Slug: "tiny-xx"}
+	_, err := h.GetSceneDetailHandler(context.Background(), req)
+	assertHumaError(t, err, 404)
+}
+
+func TestGetSceneDetail_ServiceError(t *testing.T) {
+	mock := &mockSceneService{
+		parseSceneSlugFn: func(slug string) (string, string, error) {
+			return "Phoenix", "AZ", nil
+		},
+		getSceneDetailFn: func(city, state string) (*services.SceneDetailResponse, error) {
+			return nil, fmt.Errorf("database connection lost")
+		},
+	}
+	h := NewSceneHandler(mock)
+	req := &GetSceneDetailRequest{Slug: "phoenix-az"}
+	_, err := h.GetSceneDetailHandler(context.Background(), req)
+	assertHumaError(t, err, 500)
+}
+
+// ============================================================================
+// GetSceneActiveArtistsHandler Tests
+// ============================================================================
+
+func TestGetSceneActiveArtists_Success(t *testing.T) {
+	phoenix := "Phoenix"
+	az := "AZ"
+	mock := &mockSceneService{
+		parseSceneSlugFn: func(slug string) (string, string, error) {
+			return "Phoenix", "AZ", nil
+		},
+		getActiveArtistsFn: func(city, state string, periodDays, limit, offset int) ([]*services.SceneArtistResponse, int64, error) {
+			return []*services.SceneArtistResponse{
+				{ID: 1, Slug: "band-a", Name: "Band A", City: &phoenix, State: &az, ShowCount: 5},
+				{ID: 2, Slug: "band-b", Name: "Band B", City: &phoenix, State: &az, ShowCount: 3},
+			}, 2, nil
+		},
+	}
+	h := NewSceneHandler(mock)
+	req := &GetSceneActiveArtistsRequest{Slug: "phoenix-az", Period: 90, Limit: 20}
+	resp, err := h.GetSceneActiveArtistsHandler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Total != 2 {
+		t.Errorf("expected total 2, got %d", resp.Body.Total)
+	}
+	if len(resp.Body.Artists) != 2 {
+		t.Errorf("expected 2 artists, got %d", len(resp.Body.Artists))
+	}
+}
+
+func TestGetSceneActiveArtists_SlugNotFound(t *testing.T) {
+	mock := &mockSceneService{
+		parseSceneSlugFn: func(slug string) (string, string, error) {
+			return "", "", fmt.Errorf("scene not found for slug: %s", slug)
+		},
+	}
+	h := NewSceneHandler(mock)
+	req := &GetSceneActiveArtistsRequest{Slug: "nonexistent-xx"}
+	_, err := h.GetSceneActiveArtistsHandler(context.Background(), req)
+	assertHumaError(t, err, 404)
+}
+
+func TestGetSceneActiveArtists_SceneNotFound(t *testing.T) {
+	mock := &mockSceneService{
+		parseSceneSlugFn: func(slug string) (string, string, error) {
+			return "Tiny", "XX", nil
+		},
+		getActiveArtistsFn: func(city, state string, periodDays, limit, offset int) ([]*services.SceneArtistResponse, int64, error) {
+			return nil, 0, fmt.Errorf("scene not found: %s, %s", city, state)
+		},
+	}
+	h := NewSceneHandler(mock)
+	req := &GetSceneActiveArtistsRequest{Slug: "tiny-xx"}
+	_, err := h.GetSceneActiveArtistsHandler(context.Background(), req)
+	assertHumaError(t, err, 404)
+}
+
+func TestGetSceneActiveArtists_DefaultPeriodAndLimit(t *testing.T) {
+	var capturedPeriod, capturedLimit int
+	mock := &mockSceneService{
+		parseSceneSlugFn: func(slug string) (string, string, error) {
+			return "Phoenix", "AZ", nil
+		},
+		getActiveArtistsFn: func(city, state string, periodDays, limit, offset int) ([]*services.SceneArtistResponse, int64, error) {
+			capturedPeriod = periodDays
+			capturedLimit = limit
+			return []*services.SceneArtistResponse{}, 0, nil
+		},
+	}
+	h := NewSceneHandler(mock)
+	req := &GetSceneActiveArtistsRequest{Slug: "phoenix-az", Period: 0, Limit: 0}
+	_, err := h.GetSceneActiveArtistsHandler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedPeriod != 90 {
+		t.Errorf("expected default period 90, got %d", capturedPeriod)
+	}
+	if capturedLimit != 20 {
+		t.Errorf("expected default limit 20, got %d", capturedLimit)
+	}
+}
+
+func TestGetSceneActiveArtists_ServiceError(t *testing.T) {
+	mock := &mockSceneService{
+		parseSceneSlugFn: func(slug string) (string, string, error) {
+			return "Phoenix", "AZ", nil
+		},
+		getActiveArtistsFn: func(city, state string, periodDays, limit, offset int) ([]*services.SceneArtistResponse, int64, error) {
+			return nil, 0, fmt.Errorf("database connection lost")
+		},
+	}
+	h := NewSceneHandler(mock)
+	req := &GetSceneActiveArtistsRequest{Slug: "phoenix-az", Period: 90, Limit: 20}
+	_, err := h.GetSceneActiveArtistsHandler(context.Background(), req)
+	assertHumaError(t, err, 500)
+}
+
+// ============================================================================
+// isSceneNotFoundErr Tests
+// ============================================================================
+
+func TestIsSceneNotFoundErr(t *testing.T) {
+	if !isSceneNotFoundErr(fmt.Errorf("scene not found: Phoenix, AZ")) {
+		t.Error("expected true for scene not found error")
+	}
+	if !isSceneNotFoundErr(fmt.Errorf("scene not found for slug: phoenix-az")) {
+		t.Error("expected true for scene not found for slug")
+	}
+	if isSceneNotFoundErr(fmt.Errorf("database error")) {
+		t.Error("expected false for non-scene error")
+	}
+	if isSceneNotFoundErr(nil) {
+		t.Error("expected false for nil error")
+	}
+}

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -100,6 +100,7 @@ func SetupRoutes(router *chi.Mux, sc *services.ServiceContainer, cfg *config.Con
 	setupRevisionRoutes(api, protectedGroup, sc)
 	setupTagRoutes(api, protectedGroup, sc)
 	setupArtistRelationshipRoutes(api, protectedGroup, sc)
+	setupSceneRoutes(api, sc)
 
 	return api
 }
@@ -682,6 +683,16 @@ func setupArtistRelationshipRoutes(api huma.API, protected *huma.Group, sc *serv
 
 	// Admin: delete relationships
 	huma.Delete(protected, "/artists/relationships/{source_id}/{target_id}", relHandler.DeleteRelationshipHandler)
+}
+
+// setupSceneRoutes configures scene (city aggregation) endpoints.
+// All endpoints are public — no authentication required.
+func setupSceneRoutes(api huma.API, sc *services.ServiceContainer) {
+	sceneHandler := handlers.NewSceneHandler(sc.Scene)
+
+	huma.Get(api, "/scenes", sceneHandler.ListScenesHandler)
+	huma.Get(api, "/scenes/{slug}", sceneHandler.GetSceneDetailHandler)
+	huma.Get(api, "/scenes/{slug}/artists", sceneHandler.GetSceneActiveArtistsHandler)
 }
 
 // rateLimitHandler handles rate limit exceeded responses with JSON

--- a/backend/internal/services/aliases.go
+++ b/backend/internal/services/aliases.go
@@ -120,6 +120,16 @@ type ArtistAliasResponse = contracts.ArtistAliasResponse
 type MergeArtistResult = contracts.MergeArtistResult
 
 // ──────────────────────────────────────────────
+// Scene types
+// ──────────────────────────────────────────────
+
+type SceneListResponse = contracts.SceneListResponse
+type SceneDetailResponse = contracts.SceneDetailResponse
+type SceneStats = contracts.SceneStats
+type ScenePulse = contracts.ScenePulse
+type SceneArtistResponse = contracts.SceneArtistResponse
+
+// ──────────────────────────────────────────────
 // Label types
 // ──────────────────────────────────────────────
 

--- a/backend/internal/services/catalog/scene.go
+++ b/backend/internal/services/catalog/scene.go
@@ -1,0 +1,390 @@
+package catalog
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/db"
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// SceneService handles computed city-level aggregations for "scene" pages.
+// No new tables — all data is derived from existing venue, show, and artist tables.
+type SceneService struct {
+	db *gorm.DB
+}
+
+// NewSceneService creates a new scene service.
+func NewSceneService(database *gorm.DB) *SceneService {
+	if database == nil {
+		database = db.GetDB()
+	}
+	return &SceneService{db: database}
+}
+
+// Thresholds for a city to qualify as a "scene".
+const (
+	sceneMinVenues = 3
+	sceneMinShows  = 5
+)
+
+// ListScenes returns cities that meet scene thresholds:
+// 3+ verified venues AND 5+ upcoming approved shows.
+func (s *SceneService) ListScenes() ([]*contracts.SceneListResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	now := time.Now().UTC()
+
+	type cityRow struct {
+		City              string `gorm:"column:city"`
+		State             string `gorm:"column:state"`
+		VenueCount        int    `gorm:"column:venue_count"`
+		UpcomingShowCount int    `gorm:"column:upcoming_show_count"`
+	}
+
+	// Step 1: Find cities with 3+ verified venues.
+	var cities []cityRow
+	err := s.db.Raw(`
+		SELECT v.city, v.state, COUNT(DISTINCT v.id) AS venue_count
+		FROM venues v
+		WHERE v.verified = true
+		  AND v.city IS NOT NULL AND v.city != ''
+		  AND v.state IS NOT NULL AND v.state != ''
+		GROUP BY v.city, v.state
+		HAVING COUNT(DISTINCT v.id) >= ?
+	`, sceneMinVenues).Scan(&cities).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to list scenes: %w", err)
+	}
+
+	// Step 2: For each qualifying city, count upcoming approved shows.
+	var results []*contracts.SceneListResponse
+	for i := range cities {
+		c := &cities[i]
+		var showCount int64
+		err := s.db.Raw(`
+			SELECT COUNT(DISTINCT s.id)
+			FROM shows s
+			JOIN show_venues sv ON sv.show_id = s.id
+			JOIN venues v ON v.id = sv.venue_id
+			WHERE v.city = ? AND v.state = ?
+			  AND s.status = ?
+			  AND s.event_date >= ?
+		`, c.City, c.State, models.ShowStatusApproved, now).Scan(&showCount).Error
+		if err != nil {
+			return nil, fmt.Errorf("failed to count shows for %s, %s: %w", c.City, c.State, err)
+		}
+
+		if int(showCount) < sceneMinShows {
+			continue
+		}
+
+		results = append(results, &contracts.SceneListResponse{
+			City:              c.City,
+			State:             c.State,
+			Slug:              buildSceneSlug(c.City, c.State),
+			VenueCount:        c.VenueCount,
+			UpcomingShowCount: int(showCount),
+		})
+	}
+
+	// Sort by upcoming show count descending (do in Go since we already filtered).
+	// Simple insertion sort is fine for a small number of cities.
+	for i := 1; i < len(results); i++ {
+		for j := i; j > 0 && results[j].UpcomingShowCount > results[j-1].UpcomingShowCount; j-- {
+			results[j], results[j-1] = results[j-1], results[j]
+		}
+	}
+
+	return results, nil
+}
+
+// GetSceneDetail returns computed aggregation stats and pulse for a city.
+func (s *SceneService) GetSceneDetail(city, state string) (*contracts.SceneDetailResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	now := time.Now().UTC()
+
+	// Venue count (verified only)
+	var venueCount int64
+	if err := s.db.Model(&models.Venue{}).
+		Where("city = ? AND state = ? AND verified = true", city, state).
+		Count(&venueCount).Error; err != nil {
+		return nil, fmt.Errorf("failed to count venues: %w", err)
+	}
+	if venueCount < sceneMinVenues {
+		return nil, fmt.Errorf("scene not found: %s, %s", city, state)
+	}
+
+	// Upcoming show count
+	var upcomingShowCount int64
+	if err := s.db.Raw(`
+		SELECT COUNT(DISTINCT s.id)
+		FROM shows s
+		JOIN show_venues sv ON sv.show_id = s.id
+		JOIN venues v ON v.id = sv.venue_id
+		WHERE v.city = ? AND v.state = ?
+		  AND s.status = ?
+		  AND s.event_date >= ?
+	`, city, state, models.ShowStatusApproved, now).Scan(&upcomingShowCount).Error; err != nil {
+		return nil, fmt.Errorf("failed to count upcoming shows: %w", err)
+	}
+
+	// Artist count: distinct artists with approved shows at venues in this city
+	var artistCount int64
+	if err := s.db.Raw(`
+		SELECT COUNT(DISTINCT sa.artist_id)
+		FROM show_artists sa
+		JOIN shows s ON s.id = sa.show_id
+		JOIN show_venues sv ON sv.show_id = s.id
+		JOIN venues v ON v.id = sv.venue_id
+		WHERE v.city = ? AND v.state = ?
+		  AND s.status = ?
+	`, city, state, models.ShowStatusApproved).Scan(&artistCount).Error; err != nil {
+		return nil, fmt.Errorf("failed to count artists: %w", err)
+	}
+
+	// Festival count: festivals with matching city
+	var festivalCount int64
+	if err := s.db.Model(&models.Festival{}).
+		Where("city = ? AND state = ?", city, state).
+		Count(&festivalCount).Error; err != nil {
+		return nil, fmt.Errorf("failed to count festivals: %w", err)
+	}
+
+	// ── Pulse computations ──
+
+	// Current month boundaries
+	thisMonthStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	nextMonthStart := thisMonthStart.AddDate(0, 1, 0)
+	prevMonthStart := thisMonthStart.AddDate(0, -1, 0)
+
+	// Shows this month
+	var showsThisMonth int64
+	s.db.Raw(`
+		SELECT COUNT(DISTINCT s.id)
+		FROM shows s
+		JOIN show_venues sv ON sv.show_id = s.id
+		JOIN venues v ON v.id = sv.venue_id
+		WHERE v.city = ? AND v.state = ?
+		  AND s.status = ?
+		  AND s.event_date >= ? AND s.event_date < ?
+	`, city, state, models.ShowStatusApproved, thisMonthStart, nextMonthStart).Scan(&showsThisMonth)
+
+	// Shows previous month
+	var showsPrevMonth int64
+	s.db.Raw(`
+		SELECT COUNT(DISTINCT s.id)
+		FROM shows s
+		JOIN show_venues sv ON sv.show_id = s.id
+		JOIN venues v ON v.id = sv.venue_id
+		WHERE v.city = ? AND v.state = ?
+		  AND s.status = ?
+		  AND s.event_date >= ? AND s.event_date < ?
+	`, city, state, models.ShowStatusApproved, prevMonthStart, thisMonthStart).Scan(&showsPrevMonth)
+
+	// Trend string
+	diff := int(showsThisMonth) - int(showsPrevMonth)
+	showsTrend := "0"
+	if diff > 0 {
+		showsTrend = fmt.Sprintf("+%d", diff)
+	} else if diff < 0 {
+		showsTrend = fmt.Sprintf("%d", diff)
+	}
+
+	// New artists in last 30 days: artists whose first show in this city was in last 30 days
+	thirtyDaysAgo := now.AddDate(0, 0, -30)
+	var newArtists30d int64
+	s.db.Raw(`
+		SELECT COUNT(*)
+		FROM (
+			SELECT sa.artist_id, MIN(s.event_date) AS first_show
+			FROM show_artists sa
+			JOIN shows s ON s.id = sa.show_id
+			JOIN show_venues sv ON sv.show_id = s.id
+			JOIN venues v ON v.id = sv.venue_id
+			WHERE v.city = ? AND v.state = ?
+			  AND s.status = ?
+			GROUP BY sa.artist_id
+			HAVING MIN(s.event_date) >= ?
+		) AS new_artists
+	`, city, state, models.ShowStatusApproved, thirtyDaysAgo).Scan(&newArtists30d)
+
+	// Active venues this month: venues with at least 1 approved show this month
+	var activeVenuesThisMonth int64
+	s.db.Raw(`
+		SELECT COUNT(DISTINCT v.id)
+		FROM venues v
+		JOIN show_venues sv ON sv.venue_id = v.id
+		JOIN shows s ON s.id = sv.show_id
+		WHERE v.city = ? AND v.state = ?
+		  AND s.status = ?
+		  AND s.event_date >= ? AND s.event_date < ?
+	`, city, state, models.ShowStatusApproved, thisMonthStart, nextMonthStart).Scan(&activeVenuesThisMonth)
+
+	// Shows by month: last 6 months (from 5 months ago through current month)
+	showsByMonth := make([]int, 6)
+	for i := 5; i >= 0; i-- {
+		monthStart := thisMonthStart.AddDate(0, -i, 0)
+		monthEnd := monthStart.AddDate(0, 1, 0)
+		var count int64
+		s.db.Raw(`
+			SELECT COUNT(DISTINCT s.id)
+			FROM shows s
+			JOIN show_venues sv ON sv.show_id = s.id
+			JOIN venues v ON v.id = sv.venue_id
+			WHERE v.city = ? AND v.state = ?
+			  AND s.status = ?
+			  AND s.event_date >= ? AND s.event_date < ?
+		`, city, state, models.ShowStatusApproved, monthStart, monthEnd).Scan(&count)
+		showsByMonth[5-i] = int(count)
+	}
+
+	return &contracts.SceneDetailResponse{
+		City:        city,
+		State:       state,
+		Slug:        buildSceneSlug(city, state),
+		Description: nil, // nil until scenes table exists
+		Stats: contracts.SceneStats{
+			VenueCount:        int(venueCount),
+			ArtistCount:       int(artistCount),
+			UpcomingShowCount: int(upcomingShowCount),
+			FestivalCount:     int(festivalCount),
+		},
+		Pulse: contracts.ScenePulse{
+			ShowsThisMonth:        int(showsThisMonth),
+			ShowsPrevMonth:        int(showsPrevMonth),
+			ShowsTrend:            showsTrend,
+			NewArtists30d:         int(newArtists30d),
+			ActiveVenuesThisMonth: int(activeVenuesThisMonth),
+			ShowsByMonth:          showsByMonth,
+		},
+	}, nil
+}
+
+// GetActiveArtists returns artists ranked by show count in a city within the given period.
+func (s *SceneService) GetActiveArtists(city, state string, periodDays, limit, offset int) ([]*contracts.SceneArtistResponse, int64, error) {
+	if s.db == nil {
+		return nil, 0, fmt.Errorf("database not initialized")
+	}
+
+	// Verify city qualifies as scene
+	var venueCount int64
+	if err := s.db.Model(&models.Venue{}).
+		Where("city = ? AND state = ? AND verified = true", city, state).
+		Count(&venueCount).Error; err != nil {
+		return nil, 0, fmt.Errorf("failed to count venues: %w", err)
+	}
+	if venueCount < sceneMinVenues {
+		return nil, 0, fmt.Errorf("scene not found: %s, %s", city, state)
+	}
+
+	cutoff := time.Now().UTC().AddDate(0, 0, -periodDays)
+
+	// Count total distinct artists
+	var total int64
+	if err := s.db.Raw(`
+		SELECT COUNT(DISTINCT sa.artist_id)
+		FROM show_artists sa
+		JOIN shows s ON s.id = sa.show_id
+		JOIN show_venues sv ON sv.show_id = s.id
+		JOIN venues v ON v.id = sv.venue_id
+		WHERE v.city = ? AND v.state = ?
+		  AND s.status = ?
+		  AND s.event_date >= ?
+	`, city, state, models.ShowStatusApproved, cutoff).Scan(&total).Error; err != nil {
+		return nil, 0, fmt.Errorf("failed to count active artists: %w", err)
+	}
+
+	type artistRow struct {
+		ID        uint    `gorm:"column:id"`
+		Slug      *string `gorm:"column:slug"`
+		Name      string  `gorm:"column:name"`
+		City      *string `gorm:"column:city"`
+		State     *string `gorm:"column:state"`
+		ShowCount int     `gorm:"column:show_count"`
+	}
+
+	var rows []artistRow
+	if err := s.db.Raw(`
+		SELECT a.id, a.slug, a.name, a.city, a.state, COUNT(DISTINCT s.id) AS show_count
+		FROM artists a
+		JOIN show_artists sa ON sa.artist_id = a.id
+		JOIN shows s ON s.id = sa.show_id
+		JOIN show_venues sv ON sv.show_id = s.id
+		JOIN venues v ON v.id = sv.venue_id
+		WHERE v.city = ? AND v.state = ?
+		  AND s.status = ?
+		  AND s.event_date >= ?
+		GROUP BY a.id
+		ORDER BY show_count DESC, a.name ASC
+		LIMIT ? OFFSET ?
+	`, city, state, models.ShowStatusApproved, cutoff, limit, offset).Scan(&rows).Error; err != nil {
+		return nil, 0, fmt.Errorf("failed to get active artists: %w", err)
+	}
+
+	results := make([]*contracts.SceneArtistResponse, len(rows))
+	for i, r := range rows {
+		slug := ""
+		if r.Slug != nil {
+			slug = *r.Slug
+		}
+		results[i] = &contracts.SceneArtistResponse{
+			ID:        r.ID,
+			Slug:      slug,
+			Name:      r.Name,
+			City:      r.City,
+			State:     r.State,
+			ShowCount: r.ShowCount,
+		}
+	}
+
+	return results, total, nil
+}
+
+// ParseSceneSlug resolves a slug like "phoenix-az" to actual city and state
+// by matching against verified venues in the database.
+func (s *SceneService) ParseSceneSlug(slug string) (string, string, error) {
+	if s.db == nil {
+		return "", "", fmt.Errorf("database not initialized")
+	}
+
+	type cityState struct {
+		City  string
+		State string
+	}
+
+	var result cityState
+	err := s.db.Raw(`
+		SELECT DISTINCT city, state
+		FROM venues
+		WHERE verified = true
+		  AND LOWER(REPLACE(city, ' ', '-')) || '-' || LOWER(state) = ?
+		LIMIT 1
+	`, strings.ToLower(slug)).Scan(&result).Error
+	if err != nil {
+		return "", "", fmt.Errorf("failed to resolve scene slug: %w", err)
+	}
+	if result.City == "" {
+		return "", "", fmt.Errorf("scene not found for slug: %s", slug)
+	}
+
+	return result.City, result.State, nil
+}
+
+// buildSceneSlug generates a URL-safe slug from city and state.
+// Example: "Phoenix", "AZ" → "phoenix-az"
+func buildSceneSlug(city, state string) string {
+	slug := strings.ToLower(city)
+	slug = strings.ReplaceAll(slug, " ", "-")
+	slug = slug + "-" + strings.ToLower(state)
+	return slug
+}

--- a/backend/internal/services/catalog/scene_test.go
+++ b/backend/internal/services/catalog/scene_test.go
@@ -1,0 +1,667 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/testutil"
+)
+
+// =============================================================================
+// UNIT TESTS (No Database Required)
+// =============================================================================
+
+func TestNewSceneService(t *testing.T) {
+	svc := NewSceneService(nil)
+	assert.NotNil(t, svc)
+}
+
+func TestSceneService_NilDatabase(t *testing.T) {
+	svc := &SceneService{db: nil}
+
+	t.Run("ListScenes", func(t *testing.T) {
+		resp, err := svc.ListScenes()
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("GetSceneDetail", func(t *testing.T) {
+		resp, err := svc.GetSceneDetail("Phoenix", "AZ")
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("GetActiveArtists", func(t *testing.T) {
+		resp, total, err := svc.GetActiveArtists("Phoenix", "AZ", 90, 20, 0)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+		assert.Zero(t, total)
+	})
+
+	t.Run("ParseSceneSlug", func(t *testing.T) {
+		city, state, err := svc.ParseSceneSlug("phoenix-az")
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Empty(t, city)
+		assert.Empty(t, state)
+	})
+}
+
+func TestBuildSceneSlug(t *testing.T) {
+	tests := []struct {
+		city, state, expected string
+	}{
+		{"Phoenix", "AZ", "phoenix-az"},
+		{"New York", "NY", "new-york-ny"},
+		{"San Francisco", "CA", "san-francisco-ca"},
+		{"Mesa", "AZ", "mesa-az"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.expected, func(t *testing.T) {
+			assert.Equal(t, tc.expected, buildSceneSlug(tc.city, tc.state))
+		})
+	}
+}
+
+// =============================================================================
+// INTEGRATION TESTS (With Real Database)
+// =============================================================================
+
+type SceneServiceIntegrationTestSuite struct {
+	suite.Suite
+	container    testcontainers.Container
+	db           *gorm.DB
+	sceneService *SceneService
+	ctx          context.Context
+}
+
+func (suite *SceneServiceIntegrationTestSuite) SetupSuite() {
+	suite.ctx = context.Background()
+
+	container, err := testcontainers.GenericContainer(suite.ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "postgres:18",
+			ExposedPorts: []string{"5432/tcp"},
+			Env: map[string]string{
+				"POSTGRES_DB":       "test_db",
+				"POSTGRES_USER":     "test_user",
+				"POSTGRES_PASSWORD": "test_password",
+			},
+			WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(120 * time.Second),
+		},
+		Started: true,
+	})
+	if err != nil {
+		suite.T().Fatalf("failed to start postgres container: %v", err)
+	}
+	suite.container = container
+
+	host, err := container.Host(suite.ctx)
+	if err != nil {
+		suite.T().Fatalf("failed to get host: %v", err)
+	}
+	port, err := container.MappedPort(suite.ctx, "5432")
+	if err != nil {
+		suite.T().Fatalf("failed to get port: %v", err)
+	}
+
+	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
+		host, port.Port())
+
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		suite.T().Fatalf("failed to connect to test database: %v", err)
+	}
+	suite.db = db
+
+	sqlDB, err := db.DB()
+	if err != nil {
+		suite.T().Fatalf("failed to get sql.DB: %v", err)
+	}
+	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
+
+	suite.sceneService = &SceneService{db: db}
+}
+
+func (suite *SceneServiceIntegrationTestSuite) TearDownSuite() {
+	if suite.container != nil {
+		if err := suite.container.Terminate(suite.ctx); err != nil {
+			suite.T().Logf("failed to terminate container: %v", err)
+		}
+	}
+}
+
+func (suite *SceneServiceIntegrationTestSuite) TearDownTest() {
+	sqlDB, err := suite.db.DB()
+	suite.Require().NoError(err)
+	// Delete in FK-safe order
+	_, _ = sqlDB.Exec("DELETE FROM show_artists")
+	_, _ = sqlDB.Exec("DELETE FROM show_venues")
+	_, _ = sqlDB.Exec("DELETE FROM shows")
+	_, _ = sqlDB.Exec("DELETE FROM festival_artists")
+	_, _ = sqlDB.Exec("DELETE FROM festival_venues")
+	_, _ = sqlDB.Exec("DELETE FROM festivals")
+	_, _ = sqlDB.Exec("DELETE FROM artists")
+	_, _ = sqlDB.Exec("DELETE FROM venues")
+	_, _ = sqlDB.Exec("DELETE FROM users")
+}
+
+func TestSceneServiceIntegrationTestSuite(t *testing.T) {
+	suite.Run(t, new(SceneServiceIntegrationTestSuite))
+}
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+func (suite *SceneServiceIntegrationTestSuite) createVerifiedVenue(name, city, state string) *models.Venue {
+	venue := &models.Venue{
+		Name:     name,
+		City:     city,
+		State:    state,
+		Verified: true,
+	}
+	// Create as verified=true, then update to true (GORM bool gotcha: false is zero-value)
+	err := suite.db.Create(venue).Error
+	suite.Require().NoError(err)
+	// Explicitly set Verified = true
+	suite.db.Model(venue).Update("verified", true)
+	return venue
+}
+
+func (suite *SceneServiceIntegrationTestSuite) createUnverifiedVenue(name, city, state string) *models.Venue {
+	venue := &models.Venue{
+		Name:  name,
+		City:  city,
+		State: state,
+	}
+	err := suite.db.Create(venue).Error
+	suite.Require().NoError(err)
+	// Explicitly set Verified = false (GORM bool gotcha: default is true in DB)
+	suite.db.Model(venue).Update("verified", false)
+	return venue
+}
+
+func (suite *SceneServiceIntegrationTestSuite) createArtist(name string) *models.Artist {
+	artist := &models.Artist{Name: name}
+	err := suite.db.Create(artist).Error
+	suite.Require().NoError(err)
+	return artist
+}
+
+func (suite *SceneServiceIntegrationTestSuite) createUser() *models.User {
+	user := &models.User{
+		Email:         stringPtr(fmt.Sprintf("scene-user-%d@test.com", time.Now().UnixNano())),
+		FirstName:     stringPtr("Test"),
+		LastName:      stringPtr("User"),
+		IsActive:      true,
+		EmailVerified: true,
+	}
+	err := suite.db.Create(user).Error
+	suite.Require().NoError(err)
+	return user
+}
+
+func (suite *SceneServiceIntegrationTestSuite) createApprovedShow(title string, venueID, artistID, userID uint, eventDate time.Time) *models.Show {
+	show := &models.Show{
+		Title:       title,
+		EventDate:   eventDate,
+		City:        stringPtr("Phoenix"),
+		State:       stringPtr("AZ"),
+		Status:      models.ShowStatusApproved,
+		SubmittedBy: &userID,
+	}
+	err := suite.db.Create(show).Error
+	suite.Require().NoError(err)
+
+	err = suite.db.Create(&models.ShowVenue{ShowID: show.ID, VenueID: venueID}).Error
+	suite.Require().NoError(err)
+
+	err = suite.db.Create(&models.ShowArtist{ShowID: show.ID, ArtistID: artistID, Position: 0}).Error
+	suite.Require().NoError(err)
+
+	return show
+}
+
+func (suite *SceneServiceIntegrationTestSuite) createFestival(name, city, state string) {
+	festival := &models.Festival{
+		Name:        name,
+		Slug:        fmt.Sprintf("%s-%d", name, time.Now().UnixNano()),
+		SeriesSlug:  name,
+		EditionYear: 2026,
+		City:        stringPtr(city),
+		State:       stringPtr(state),
+		StartDate:   "2026-03-01",
+		EndDate:     "2026-03-03",
+	}
+	err := suite.db.Create(festival).Error
+	suite.Require().NoError(err)
+}
+
+// seedSceneData creates the minimum data for Phoenix to qualify as a scene:
+// 3 verified venues + 5 upcoming shows with artists.
+func (suite *SceneServiceIntegrationTestSuite) seedSceneData() (venues []*models.Venue, artists []*models.Artist) {
+	user := suite.createUser()
+
+	v1 := suite.createVerifiedVenue("Crescent Ballroom", "Phoenix", "AZ")
+	v2 := suite.createVerifiedVenue("Valley Bar", "Phoenix", "AZ")
+	v3 := suite.createVerifiedVenue("The Rebel Lounge", "Phoenix", "AZ")
+	venues = []*models.Venue{v1, v2, v3}
+
+	a1 := suite.createArtist("Band A")
+	a2 := suite.createArtist("Band B")
+	a3 := suite.createArtist("Band C")
+	artists = []*models.Artist{a1, a2, a3}
+
+	future := time.Now().UTC().AddDate(0, 0, 7)
+	suite.createApprovedShow("Show 1", v1.ID, a1.ID, user.ID, future)
+	suite.createApprovedShow("Show 2", v1.ID, a2.ID, user.ID, future.AddDate(0, 0, 1))
+	suite.createApprovedShow("Show 3", v2.ID, a1.ID, user.ID, future.AddDate(0, 0, 2))
+	suite.createApprovedShow("Show 4", v2.ID, a3.ID, user.ID, future.AddDate(0, 0, 3))
+	suite.createApprovedShow("Show 5", v3.ID, a2.ID, user.ID, future.AddDate(0, 0, 4))
+
+	return venues, artists
+}
+
+// =============================================================================
+// ListScenes Tests
+// =============================================================================
+
+func (suite *SceneServiceIntegrationTestSuite) TestListScenes_Empty() {
+	scenes, err := suite.sceneService.ListScenes()
+	suite.Require().NoError(err)
+	suite.Empty(scenes)
+}
+
+func (suite *SceneServiceIntegrationTestSuite) TestListScenes_BelowThreshold_TooFewVenues() {
+	// Only 2 verified venues — below the 3-venue threshold
+	user := suite.createUser()
+	v1 := suite.createVerifiedVenue("Venue A", "Tucson", "AZ")
+	v2 := suite.createVerifiedVenue("Venue B", "Tucson", "AZ")
+	a := suite.createArtist("Tucson Band")
+
+	future := time.Now().UTC().AddDate(0, 0, 7)
+	for i := 0; i < 6; i++ {
+		venueID := v1.ID
+		if i%2 == 1 {
+			venueID = v2.ID
+		}
+		suite.createApprovedShow(fmt.Sprintf("Tucson Show %d", i), venueID, a.ID, user.ID, future.AddDate(0, 0, i))
+	}
+
+	scenes, err := suite.sceneService.ListScenes()
+	suite.Require().NoError(err)
+	suite.Empty(scenes)
+}
+
+func (suite *SceneServiceIntegrationTestSuite) TestListScenes_BelowThreshold_TooFewShows() {
+	// 3 venues but only 4 upcoming shows (below 5 threshold)
+	user := suite.createUser()
+	v1 := suite.createVerifiedVenue("Venue X", "Flagstaff", "AZ")
+	v2 := suite.createVerifiedVenue("Venue Y", "Flagstaff", "AZ")
+	v3 := suite.createVerifiedVenue("Venue Z", "Flagstaff", "AZ")
+	a := suite.createArtist("Flagstaff Band")
+
+	future := time.Now().UTC().AddDate(0, 0, 7)
+	suite.createApprovedShow("Flag Show 1", v1.ID, a.ID, user.ID, future)
+	suite.createApprovedShow("Flag Show 2", v2.ID, a.ID, user.ID, future.AddDate(0, 0, 1))
+	suite.createApprovedShow("Flag Show 3", v3.ID, a.ID, user.ID, future.AddDate(0, 0, 2))
+	suite.createApprovedShow("Flag Show 4", v1.ID, a.ID, user.ID, future.AddDate(0, 0, 3))
+
+	scenes, err := suite.sceneService.ListScenes()
+	suite.Require().NoError(err)
+	suite.Empty(scenes)
+}
+
+func (suite *SceneServiceIntegrationTestSuite) TestListScenes_MeetsThreshold() {
+	suite.seedSceneData()
+
+	scenes, err := suite.sceneService.ListScenes()
+	suite.Require().NoError(err)
+	suite.Require().Len(scenes, 1)
+
+	scene := scenes[0]
+	suite.Equal("Phoenix", scene.City)
+	suite.Equal("AZ", scene.State)
+	suite.Equal("phoenix-az", scene.Slug)
+	suite.GreaterOrEqual(scene.VenueCount, 3)
+	suite.GreaterOrEqual(scene.UpcomingShowCount, 5)
+}
+
+func (suite *SceneServiceIntegrationTestSuite) TestListScenes_MultipleScenes() {
+	// Phoenix scene
+	suite.seedSceneData()
+
+	// Chicago scene
+	user := suite.createUser()
+	cv1 := suite.createVerifiedVenue("Metro", "Chicago", "IL")
+	cv2 := suite.createVerifiedVenue("Empty Bottle", "Chicago", "IL")
+	cv3 := suite.createVerifiedVenue("Thalia Hall", "Chicago", "IL")
+	ca := suite.createArtist("Chicago Band")
+
+	future := time.Now().UTC().AddDate(0, 0, 7)
+	for i := 0; i < 7; i++ {
+		venues := []*models.Venue{cv1, cv2, cv3}
+		suite.createApprovedShow(
+			fmt.Sprintf("Chi Show %d", i),
+			venues[i%3].ID, ca.ID, user.ID,
+			future.AddDate(0, 0, i),
+		)
+	}
+
+	scenes, err := suite.sceneService.ListScenes()
+	suite.Require().NoError(err)
+	suite.Require().Len(scenes, 2)
+
+	// Should be sorted by upcoming show count descending
+	// Chicago has 7, Phoenix has 5
+	suite.Equal("Chicago", scenes[0].City)
+	suite.Equal("Phoenix", scenes[1].City)
+}
+
+// =============================================================================
+// GetSceneDetail Tests
+// =============================================================================
+
+func (suite *SceneServiceIntegrationTestSuite) TestGetSceneDetail_Success() {
+	suite.seedSceneData()
+
+	detail, err := suite.sceneService.GetSceneDetail("Phoenix", "AZ")
+	suite.Require().NoError(err)
+	suite.Require().NotNil(detail)
+
+	suite.Equal("Phoenix", detail.City)
+	suite.Equal("AZ", detail.State)
+	suite.Equal("phoenix-az", detail.Slug)
+	suite.Nil(detail.Description) // no scenes table yet
+
+	// Stats
+	suite.GreaterOrEqual(detail.Stats.VenueCount, 3)
+	suite.GreaterOrEqual(detail.Stats.ArtistCount, 1)
+	suite.GreaterOrEqual(detail.Stats.UpcomingShowCount, 5)
+
+	// Pulse
+	suite.NotNil(detail.Pulse.ShowsByMonth)
+	suite.Len(detail.Pulse.ShowsByMonth, 6)
+}
+
+func (suite *SceneServiceIntegrationTestSuite) TestGetSceneDetail_NotFound() {
+	detail, err := suite.sceneService.GetSceneDetail("Nonexistent", "XX")
+	suite.Require().Error(err)
+	suite.Contains(err.Error(), "scene not found")
+	suite.Nil(detail)
+}
+
+func (suite *SceneServiceIntegrationTestSuite) TestGetSceneDetail_VenueCountOnlyVerified() {
+	suite.seedSceneData()
+	// Add an unverified venue — should not be counted
+	suite.createUnverifiedVenue("Sketchy Bar", "Phoenix", "AZ")
+
+	detail, err := suite.sceneService.GetSceneDetail("Phoenix", "AZ")
+	suite.Require().NoError(err)
+	suite.Equal(3, detail.Stats.VenueCount) // only the 3 verified ones
+}
+
+func (suite *SceneServiceIntegrationTestSuite) TestGetSceneDetail_ArtistCount() {
+	_, artists := suite.seedSceneData()
+	// seedSceneData creates 3 artists across 5 shows
+	_ = artists
+
+	detail, err := suite.sceneService.GetSceneDetail("Phoenix", "AZ")
+	suite.Require().NoError(err)
+	suite.Equal(3, detail.Stats.ArtistCount) // 3 distinct artists
+}
+
+func (suite *SceneServiceIntegrationTestSuite) TestGetSceneDetail_FestivalCount() {
+	suite.seedSceneData()
+	suite.createFestival("M3F Fest", "Phoenix", "AZ")
+	suite.createFestival("Arizona Roots", "Phoenix", "AZ")
+
+	detail, err := suite.sceneService.GetSceneDetail("Phoenix", "AZ")
+	suite.Require().NoError(err)
+	suite.Equal(2, detail.Stats.FestivalCount)
+}
+
+func (suite *SceneServiceIntegrationTestSuite) TestGetSceneDetail_PulseShowsByMonth() {
+	// Create shows across different months
+	user := suite.createUser()
+	v1 := suite.createVerifiedVenue("V1", "Phoenix", "AZ")
+	v2 := suite.createVerifiedVenue("V2", "Phoenix", "AZ")
+	v3 := suite.createVerifiedVenue("V3", "Phoenix", "AZ")
+	a := suite.createArtist("Monthly Band")
+
+	now := time.Now().UTC()
+	thisMonthStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+
+	// Create shows in current month (count as upcoming too for threshold)
+	for i := 0; i < 3; i++ {
+		// Use dates in the future portion of this month
+		showDate := thisMonthStart.AddDate(0, 1, -1) // last day of this month
+		suite.createApprovedShow(
+			fmt.Sprintf("This Month Show %d", i),
+			[]*models.Venue{v1, v2, v3}[i%3].ID, a.ID, user.ID,
+			showDate,
+		)
+	}
+
+	// Create shows in previous month
+	prevMonth := thisMonthStart.AddDate(0, -1, 5)
+	suite.createApprovedShow("Prev Month Show 1", v1.ID, a.ID, user.ID, prevMonth)
+	suite.createApprovedShow("Prev Month Show 2", v2.ID, a.ID, user.ID, prevMonth.AddDate(0, 0, 1))
+
+	// Also create upcoming shows to meet threshold
+	future := now.AddDate(0, 0, 7)
+	suite.createApprovedShow("Future 1", v1.ID, a.ID, user.ID, future)
+	suite.createApprovedShow("Future 2", v2.ID, a.ID, user.ID, future.AddDate(0, 0, 1))
+
+	detail, err := suite.sceneService.GetSceneDetail("Phoenix", "AZ")
+	suite.Require().NoError(err)
+
+	// Shows by month should have 6 entries
+	suite.Len(detail.Pulse.ShowsByMonth, 6)
+	// Last entry (index 5) is current month — should have 3+ shows
+	suite.GreaterOrEqual(detail.Pulse.ShowsByMonth[5], 3)
+	// Second to last (index 4) is previous month — should have 2 shows
+	suite.Equal(2, detail.Pulse.ShowsByMonth[4])
+}
+
+func (suite *SceneServiceIntegrationTestSuite) TestGetSceneDetail_PulseShowsTrend() {
+	user := suite.createUser()
+	v1 := suite.createVerifiedVenue("Venue 1", "Phoenix", "AZ")
+	v2 := suite.createVerifiedVenue("Venue 2", "Phoenix", "AZ")
+	v3 := suite.createVerifiedVenue("Venue 3", "Phoenix", "AZ")
+	a := suite.createArtist("Trend Band")
+
+	now := time.Now().UTC()
+	thisMonthStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+
+	// 5 shows this month
+	for i := 0; i < 5; i++ {
+		showDate := thisMonthStart.AddDate(0, 1, -1)
+		suite.createApprovedShow(
+			fmt.Sprintf("This Month %d", i),
+			[]*models.Venue{v1, v2, v3}[i%3].ID, a.ID, user.ID,
+			showDate,
+		)
+	}
+
+	// 2 shows previous month
+	prevMonth := thisMonthStart.AddDate(0, -1, 5)
+	suite.createApprovedShow("Prev 1", v1.ID, a.ID, user.ID, prevMonth)
+	suite.createApprovedShow("Prev 2", v2.ID, a.ID, user.ID, prevMonth.AddDate(0, 0, 1))
+
+	detail, err := suite.sceneService.GetSceneDetail("Phoenix", "AZ")
+	suite.Require().NoError(err)
+
+	suite.Equal("+3", detail.Pulse.ShowsTrend) // 5 - 2 = +3
+}
+
+func (suite *SceneServiceIntegrationTestSuite) TestGetSceneDetail_PulseNewArtists() {
+	user := suite.createUser()
+	v1 := suite.createVerifiedVenue("PNV1", "Phoenix", "AZ")
+	v2 := suite.createVerifiedVenue("PNV2", "Phoenix", "AZ")
+	v3 := suite.createVerifiedVenue("PNV3", "Phoenix", "AZ")
+
+	// Old artist — first show 60 days ago
+	oldArtist := suite.createArtist("Old Band")
+	past := time.Now().UTC().AddDate(0, 0, -60)
+	suite.createApprovedShow("Old Show", v1.ID, oldArtist.ID, user.ID, past)
+
+	// New artist — first show 10 days ago
+	newArtist := suite.createArtist("New Band")
+	recent := time.Now().UTC().AddDate(0, 0, -10)
+	suite.createApprovedShow("New Show", v2.ID, newArtist.ID, user.ID, recent)
+
+	// Another new artist — first show 5 days ago
+	newerArtist := suite.createArtist("Newer Band")
+	moreRecent := time.Now().UTC().AddDate(0, 0, -5)
+	suite.createApprovedShow("Newer Show", v3.ID, newerArtist.ID, user.ID, moreRecent)
+
+	// Need 5+ upcoming shows for threshold
+	future := time.Now().UTC().AddDate(0, 0, 7)
+	suite.createApprovedShow("F1", v1.ID, oldArtist.ID, user.ID, future)
+	suite.createApprovedShow("F2", v2.ID, newArtist.ID, user.ID, future.AddDate(0, 0, 1))
+	suite.createApprovedShow("F3", v3.ID, newerArtist.ID, user.ID, future.AddDate(0, 0, 2))
+	suite.createApprovedShow("F4", v1.ID, newArtist.ID, user.ID, future.AddDate(0, 0, 3))
+	suite.createApprovedShow("F5", v2.ID, oldArtist.ID, user.ID, future.AddDate(0, 0, 4))
+
+	detail, err := suite.sceneService.GetSceneDetail("Phoenix", "AZ")
+	suite.Require().NoError(err)
+
+	// 2 new artists (first show in last 30 days)
+	suite.Equal(2, detail.Pulse.NewArtists30d)
+}
+
+// =============================================================================
+// GetActiveArtists Tests
+// =============================================================================
+
+func (suite *SceneServiceIntegrationTestSuite) TestGetActiveArtists_Success() {
+	_, artists := suite.seedSceneData()
+	// Band A has 2 shows (at v1 and v2), Band B has 2 shows (at v1 and v3), Band C has 1 show (at v2)
+	_ = artists
+
+	results, total, err := suite.sceneService.GetActiveArtists("Phoenix", "AZ", 365, 20, 0)
+	suite.Require().NoError(err)
+	suite.Equal(int64(3), total)
+	suite.Len(results, 3)
+
+	// First should be highest show count (Band A or Band B, both have 2)
+	suite.Equal(2, results[0].ShowCount)
+	suite.Equal(2, results[1].ShowCount)
+	suite.Equal(1, results[2].ShowCount)
+}
+
+func (suite *SceneServiceIntegrationTestSuite) TestGetActiveArtists_RespectsLimit() {
+	suite.seedSceneData()
+
+	results, total, err := suite.sceneService.GetActiveArtists("Phoenix", "AZ", 365, 2, 0)
+	suite.Require().NoError(err)
+	suite.Equal(int64(3), total)
+	suite.Len(results, 2)
+}
+
+func (suite *SceneServiceIntegrationTestSuite) TestGetActiveArtists_RespectsOffset() {
+	suite.seedSceneData()
+
+	results, total, err := suite.sceneService.GetActiveArtists("Phoenix", "AZ", 365, 20, 2)
+	suite.Require().NoError(err)
+	suite.Equal(int64(3), total)
+	suite.Len(results, 1) // 3 total, offset 2 = 1 remaining
+}
+
+func (suite *SceneServiceIntegrationTestSuite) TestGetActiveArtists_Period() {
+	user := suite.createUser()
+	v1 := suite.createVerifiedVenue("Period V1", "Phoenix", "AZ")
+	v2 := suite.createVerifiedVenue("Period V2", "Phoenix", "AZ")
+	v3 := suite.createVerifiedVenue("Period V3", "Phoenix", "AZ")
+
+	recentArtist := suite.createArtist("Recent Artist")
+	oldArtist := suite.createArtist("Old Artist")
+
+	// Recent show (10 days ago)
+	recent := time.Now().UTC().AddDate(0, 0, -10)
+	suite.createApprovedShow("Recent Show", v1.ID, recentArtist.ID, user.ID, recent)
+
+	// Old show (100 days ago — outside 90 day period)
+	old := time.Now().UTC().AddDate(0, 0, -100)
+	suite.createApprovedShow("Old Show", v2.ID, oldArtist.ID, user.ID, old)
+
+	// Need upcoming shows for the scene threshold
+	future := time.Now().UTC().AddDate(0, 0, 7)
+	suite.createApprovedShow("F1", v1.ID, recentArtist.ID, user.ID, future)
+	suite.createApprovedShow("F2", v2.ID, recentArtist.ID, user.ID, future.AddDate(0, 0, 1))
+	suite.createApprovedShow("F3", v3.ID, recentArtist.ID, user.ID, future.AddDate(0, 0, 2))
+	suite.createApprovedShow("F4", v1.ID, recentArtist.ID, user.ID, future.AddDate(0, 0, 3))
+	suite.createApprovedShow("F5", v2.ID, recentArtist.ID, user.ID, future.AddDate(0, 0, 4))
+
+	// With 90-day period: should only include recentArtist
+	results, total, err := suite.sceneService.GetActiveArtists("Phoenix", "AZ", 90, 20, 0)
+	suite.Require().NoError(err)
+	// recentArtist has shows within 90 days; oldArtist does not
+	suite.Equal(int64(1), total)
+	suite.Len(results, 1)
+	suite.Equal("Recent Artist", results[0].Name)
+}
+
+func (suite *SceneServiceIntegrationTestSuite) TestGetActiveArtists_NotFound() {
+	results, total, err := suite.sceneService.GetActiveArtists("Nowhere", "XX", 90, 20, 0)
+	suite.Require().Error(err)
+	suite.Contains(err.Error(), "scene not found")
+	suite.Nil(results)
+	suite.Zero(total)
+}
+
+// =============================================================================
+// ParseSceneSlug Tests
+// =============================================================================
+
+func (suite *SceneServiceIntegrationTestSuite) TestParseSceneSlug_Success() {
+	suite.createVerifiedVenue("Test Venue", "Phoenix", "AZ")
+
+	city, state, err := suite.sceneService.ParseSceneSlug("phoenix-az")
+	suite.Require().NoError(err)
+	suite.Equal("Phoenix", city)
+	suite.Equal("AZ", state)
+}
+
+func (suite *SceneServiceIntegrationTestSuite) TestParseSceneSlug_MultiWordCity() {
+	suite.createVerifiedVenue("Test Venue", "New York", "NY")
+
+	city, state, err := suite.sceneService.ParseSceneSlug("new-york-ny")
+	suite.Require().NoError(err)
+	suite.Equal("New York", city)
+	suite.Equal("NY", state)
+}
+
+func (suite *SceneServiceIntegrationTestSuite) TestParseSceneSlug_NotFound() {
+	city, state, err := suite.sceneService.ParseSceneSlug("nonexistent-xx")
+	suite.Require().Error(err)
+	suite.Contains(err.Error(), "scene not found")
+	suite.Empty(city)
+	suite.Empty(state)
+}
+
+func (suite *SceneServiceIntegrationTestSuite) TestParseSceneSlug_IgnoresUnverifiedVenues() {
+	suite.createUnverifiedVenue("Unverified Place", "Unverified City", "UC")
+
+	city, state, err := suite.sceneService.ParseSceneSlug("unverified-city-uc")
+	suite.Require().Error(err)
+	suite.Contains(err.Error(), "scene not found")
+	suite.Empty(city)
+	suite.Empty(state)
+}

--- a/backend/internal/services/container.go
+++ b/backend/internal/services/container.go
@@ -32,6 +32,7 @@ type ServiceContainer struct {
 	Request       *RequestService
 	Tag                *catalog.TagService
 	ArtistRelationship *catalog.ArtistRelationshipService
+	Scene              *catalog.SceneService
 	FavoriteVenue      *engagement.FavoriteVenueService
 	Festival      *catalog.FestivalService
 	Label         *catalog.LabelService
@@ -116,6 +117,7 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 		Request:       NewRequestService(database),
 		Tag:                catalog.NewTagService(database),
 		ArtistRelationship: catalog.NewArtistRelationshipService(database),
+		Scene:              catalog.NewSceneService(database),
 		FavoriteVenue:      engagement.NewFavoriteVenueService(database),
 		Festival:      catalog.NewFestivalService(database),
 		Label:         catalog.NewLabelService(database),

--- a/backend/internal/services/contracts/catalog.go
+++ b/backend/internal/services/contracts/catalog.go
@@ -523,3 +523,54 @@ type MergeArtistResult struct {
 	BookmarksMoved    int64  `json:"bookmarks_moved"`
 	AliasCreated      bool   `json:"alias_created"`
 }
+
+// ──────────────────────────────────────────────
+// Scene types (computed city aggregations)
+// ──────────────────────────────────────────────
+
+// SceneListResponse represents a city scene in the list endpoint
+type SceneListResponse struct {
+	City              string `json:"city"`
+	State             string `json:"state"`
+	Slug              string `json:"slug"`
+	VenueCount        int    `json:"venue_count"`
+	UpcomingShowCount int    `json:"upcoming_show_count"`
+}
+
+// SceneDetailResponse represents the full computed scene for a city
+type SceneDetailResponse struct {
+	City        string      `json:"city"`
+	State       string      `json:"state"`
+	Slug        string      `json:"slug"`
+	Description *string     `json:"description"` // nil until scenes table exists
+	Stats       SceneStats  `json:"stats"`
+	Pulse       ScenePulse  `json:"pulse"`
+}
+
+// SceneStats holds aggregate counts for a scene
+type SceneStats struct {
+	VenueCount        int `json:"venue_count"`
+	ArtistCount       int `json:"artist_count"`
+	UpcomingShowCount int `json:"upcoming_show_count"`
+	FestivalCount     int `json:"festival_count"`
+}
+
+// ScenePulse holds activity trend data for a scene
+type ScenePulse struct {
+	ShowsThisMonth        int    `json:"shows_this_month"`
+	ShowsPrevMonth        int    `json:"shows_prev_month"`
+	ShowsTrend            string `json:"shows_trend"`
+	NewArtists30d         int    `json:"new_artists_30d"`
+	ActiveVenuesThisMonth int    `json:"active_venues_this_month"`
+	ShowsByMonth          []int  `json:"shows_by_month"` // last 6 months
+}
+
+// SceneArtistResponse represents an artist in the active artists endpoint
+type SceneArtistResponse struct {
+	ID        uint    `json:"id"`
+	Slug      string  `json:"slug"`
+	Name      string  `json:"name"`
+	City      *string `json:"city"`
+	State     *string `json:"state"`
+	ShowCount int     `json:"show_count"`
+}

--- a/backend/internal/services/contracts/interfaces.go
+++ b/backend/internal/services/contracts/interfaces.go
@@ -427,3 +427,11 @@ type RevisionServiceInterface interface {
 	GetUserRevisions(userID uint, limit, offset int) ([]models.Revision, int64, error)
 	Rollback(revisionID uint, adminUserID uint) error
 }
+
+// SceneServiceInterface defines the contract for computed city scene aggregations.
+type SceneServiceInterface interface {
+	ListScenes() ([]*SceneListResponse, error)
+	GetSceneDetail(city, state string) (*SceneDetailResponse, error)
+	GetActiveArtists(city, state string, periodDays, limit, offset int) ([]*SceneArtistResponse, int64, error)
+	ParseSceneSlug(slug string) (string, string, error)
+}

--- a/backend/internal/services/interfaces.go
+++ b/backend/internal/services/interfaces.go
@@ -46,6 +46,7 @@ type RevisionServiceInterface = contracts.RevisionServiceInterface
 type RequestServiceInterface = contracts.RequestServiceInterface
 type TagServiceInterface = contracts.TagServiceInterface
 type ArtistRelationshipServiceInterface = contracts.ArtistRelationshipServiceInterface
+type SceneServiceInterface = contracts.SceneServiceInterface
 
 // Compile-time interface satisfaction checks.
 // Engagement services (Bookmark, SavedShow, FavoriteVenue, Calendar, Reminder)
@@ -71,4 +72,5 @@ var (
 	_ RequestServiceInterface               = (*RequestService)(nil)
 	_ TagServiceInterface                   = (*catalog.TagService)(nil)
 	_ ArtistRelationshipServiceInterface    = (*catalog.ArtistRelationshipService)(nil)
+	_ SceneServiceInterface                 = (*catalog.SceneService)(nil)
 )


### PR DESCRIPTION
## Summary
- **SceneService**: computed city-level aggregations from existing venue/show/artist data (no new tables)
- **3 public API endpoints**: scene list, scene detail with Scene Pulse metrics, active artists with pagination
- **Slug resolution**: parses `phoenix-az` format, supports multi-word cities (`new-york-ny`)

## Endpoints
| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/scenes` | List cities with 3+ verified venues AND 5+ upcoming shows |
| `GET` | `/scenes/{slug}` | Full detail: stats + pulse (monthly trend, new artists, sparkline) |
| `GET` | `/scenes/{slug}/artists` | Active artists ranked by show count, paginated |

## Scene Pulse metrics
- Shows this/prev month with trend arrow
- New artists (first show in city within 30d)
- Active venues this month
- 6-month sparkline (shows per month)

## Test plan
- [x] `go build ./...` passes
- [x] 26 service integration tests pass (testcontainers PostgreSQL)
- [x] 14 handler unit tests pass
- [ ] Manual: verify `/scenes` returns qualifying cities

Closes PSY-59

🤖 Generated with [Claude Code](https://claude.com/claude-code)