### PR TITLE
Add data quality dashboard for admin

### DIFF
--- a/backend/internal/api/handlers/data_quality.go
+++ b/backend/internal/api/handlers/data_quality.go
@@ -1,0 +1,147 @@
+package handlers
+
+import (
+	"context"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"psychic-homily-backend/internal/api/middleware"
+	"psychic-homily-backend/internal/logger"
+	"psychic-homily-backend/internal/services"
+)
+
+// DataQualityHandler handles data quality dashboard endpoints.
+type DataQualityHandler struct {
+	dataQualityService services.DataQualityServiceInterface
+}
+
+// NewDataQualityHandler creates a new data quality handler.
+func NewDataQualityHandler(
+	dataQualityService services.DataQualityServiceInterface,
+) *DataQualityHandler {
+	return &DataQualityHandler{
+		dataQualityService: dataQualityService,
+	}
+}
+
+// --- GetDataQualitySummary ---
+
+// GetDataQualitySummaryRequest is the Huma request for GET /admin/data-quality
+type GetDataQualitySummaryRequest struct{}
+
+// GetDataQualitySummaryResponse is the Huma response for GET /admin/data-quality
+type GetDataQualitySummaryResponse struct {
+	Body struct {
+		Categories []DataQualityCategoryResponse `json:"categories"`
+		TotalItems int                           `json:"total_items"`
+	}
+}
+
+// DataQualityCategoryResponse is the response format for a data quality category.
+type DataQualityCategoryResponse struct {
+	Key         string `json:"key"`
+	Label       string `json:"label"`
+	EntityType  string `json:"entity_type"`
+	Count       int    `json:"count"`
+	Description string `json:"description"`
+}
+
+// GetDataQualitySummaryHandler handles GET /admin/data-quality
+func (h *DataQualityHandler) GetDataQualitySummaryHandler(ctx context.Context, _ *GetDataQualitySummaryRequest) (*GetDataQualitySummaryResponse, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil || !user.IsAdmin {
+		return nil, huma.Error403Forbidden("Admin access required")
+	}
+
+	summary, err := h.dataQualityService.GetSummary()
+	if err != nil {
+		logger.FromContext(ctx).Error("data_quality_summary_failed",
+			"error", err.Error(),
+		)
+		return nil, huma.Error500InternalServerError("Failed to get data quality summary")
+	}
+
+	resp := &GetDataQualitySummaryResponse{}
+	resp.Body.TotalItems = summary.TotalItems
+	categories := make([]DataQualityCategoryResponse, 0, len(summary.Categories))
+	for _, c := range summary.Categories {
+		categories = append(categories, DataQualityCategoryResponse{
+			Key:         c.Key,
+			Label:       c.Label,
+			EntityType:  c.EntityType,
+			Count:       c.Count,
+			Description: c.Description,
+		})
+	}
+	resp.Body.Categories = categories
+	return resp, nil
+}
+
+// --- GetDataQualityCategory ---
+
+// GetDataQualityCategoryRequest is the Huma request for GET /admin/data-quality/{category}
+type GetDataQualityCategoryRequest struct {
+	Category string `path:"category" doc:"Data quality category key"`
+	Limit    int    `query:"limit" required:"false" doc:"Max results (default 50, max 200)"`
+	Offset   int    `query:"offset" required:"false" doc:"Offset for pagination"`
+}
+
+// DataQualityItemResponse is the response format for a data quality item.
+type DataQualityItemResponse struct {
+	EntityType string `json:"entity_type"`
+	EntityID   uint   `json:"entity_id"`
+	Name       string `json:"name"`
+	Slug       string `json:"slug"`
+	Reason     string `json:"reason"`
+	ShowCount  int    `json:"show_count"`
+}
+
+// GetDataQualityCategoryResponse is the Huma response for GET /admin/data-quality/{category}
+type GetDataQualityCategoryResponse struct {
+	Body struct {
+		Items []DataQualityItemResponse `json:"items"`
+		Total int64                     `json:"total"`
+	}
+}
+
+// GetDataQualityCategoryHandler handles GET /admin/data-quality/{category}
+func (h *DataQualityHandler) GetDataQualityCategoryHandler(ctx context.Context, req *GetDataQualityCategoryRequest) (*GetDataQualityCategoryResponse, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil || !user.IsAdmin {
+		return nil, huma.Error403Forbidden("Admin access required")
+	}
+
+	limit := req.Limit
+	if limit <= 0 {
+		limit = 50
+	}
+
+	items, total, err := h.dataQualityService.GetCategoryItems(req.Category, limit, req.Offset)
+	if err != nil {
+		// Check if it's an unknown category error
+		if err.Error() == "unknown category: "+req.Category {
+			return nil, huma.Error400BadRequest("Unknown data quality category: " + req.Category)
+		}
+		logger.FromContext(ctx).Error("data_quality_category_failed",
+			"category", req.Category,
+			"error", err.Error(),
+		)
+		return nil, huma.Error500InternalServerError("Failed to get data quality items")
+	}
+
+	resp := &GetDataQualityCategoryResponse{}
+	resp.Body.Total = total
+	respItems := make([]DataQualityItemResponse, 0, len(items))
+	for _, item := range items {
+		respItems = append(respItems, DataQualityItemResponse{
+			EntityType: item.EntityType,
+			EntityID:   item.EntityID,
+			Name:       item.Name,
+			Slug:       item.Slug,
+			Reason:     item.Reason,
+			ShowCount:  item.ShowCount,
+		})
+	}
+	resp.Body.Items = respItems
+	return resp, nil
+}

--- a/backend/internal/api/handlers/data_quality_test.go
+++ b/backend/internal/api/handlers/data_quality_test.go
@@ -1,0 +1,314 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// ============================================================================
+// Mock: DataQualityServiceInterface
+// ============================================================================
+
+type mockDataQualityService struct {
+	getSummaryFn      func() (*contracts.DataQualitySummary, error)
+	getCategoryItemsFn func(category string, limit, offset int) ([]*contracts.DataQualityItem, int64, error)
+}
+
+func (m *mockDataQualityService) GetSummary() (*contracts.DataQualitySummary, error) {
+	if m.getSummaryFn != nil {
+		return m.getSummaryFn()
+	}
+	return &contracts.DataQualitySummary{Categories: []contracts.DataQualityCategory{}}, nil
+}
+
+func (m *mockDataQualityService) GetCategoryItems(category string, limit, offset int) ([]*contracts.DataQualityItem, int64, error) {
+	if m.getCategoryItemsFn != nil {
+		return m.getCategoryItemsFn(category, limit, offset)
+	}
+	return nil, 0, nil
+}
+
+// ============================================================================
+// Test helpers
+// ============================================================================
+
+func testDataQualityHandler() *DataQualityHandler {
+	return NewDataQualityHandler(&mockDataQualityService{})
+}
+
+func dataQualityAdminCtx() context.Context {
+	return ctxWithUser(&models.User{ID: 1, IsAdmin: true})
+}
+
+func dataQualityNonAdminCtx() context.Context {
+	return ctxWithUser(&models.User{ID: 2, IsAdmin: false})
+}
+
+// ============================================================================
+// Tests: NewDataQualityHandler
+// ============================================================================
+
+func TestNewDataQualityHandler(t *testing.T) {
+	h := testDataQualityHandler()
+	if h == nil {
+		t.Fatal("expected non-nil DataQualityHandler")
+	}
+}
+
+// ============================================================================
+// Tests: Admin Guard
+// ============================================================================
+
+func TestDataQualityHandler_Summary_RequiresAdmin(t *testing.T) {
+	h := testDataQualityHandler()
+
+	t.Run("NoUser", func(t *testing.T) {
+		_, err := h.GetDataQualitySummaryHandler(context.Background(), &GetDataQualitySummaryRequest{})
+		assertHumaError(t, err, 403)
+	})
+	t.Run("NonAdmin", func(t *testing.T) {
+		_, err := h.GetDataQualitySummaryHandler(dataQualityNonAdminCtx(), &GetDataQualitySummaryRequest{})
+		assertHumaError(t, err, 403)
+	})
+}
+
+func TestDataQualityHandler_Category_RequiresAdmin(t *testing.T) {
+	h := testDataQualityHandler()
+
+	t.Run("NoUser", func(t *testing.T) {
+		_, err := h.GetDataQualityCategoryHandler(context.Background(), &GetDataQualityCategoryRequest{Category: "artists_missing_links"})
+		assertHumaError(t, err, 403)
+	})
+	t.Run("NonAdmin", func(t *testing.T) {
+		_, err := h.GetDataQualityCategoryHandler(dataQualityNonAdminCtx(), &GetDataQualityCategoryRequest{Category: "artists_missing_links"})
+		assertHumaError(t, err, 403)
+	})
+}
+
+// ============================================================================
+// Tests: GetDataQualitySummaryHandler
+// ============================================================================
+
+func TestDataQualityHandler_Summary_Success(t *testing.T) {
+	h := NewDataQualityHandler(&mockDataQualityService{
+		getSummaryFn: func() (*contracts.DataQualitySummary, error) {
+			return &contracts.DataQualitySummary{
+				Categories: []contracts.DataQualityCategory{
+					{
+						Key:         "artists_missing_links",
+						Label:       "Artists Missing Links",
+						EntityType:  "artist",
+						Count:       5,
+						Description: "Artists with no social links",
+					},
+					{
+						Key:         "shows_missing_price",
+						Label:       "Shows Missing Price",
+						EntityType:  "show",
+						Count:       3,
+						Description: "Upcoming shows with no price",
+					},
+				},
+				TotalItems: 8,
+			}, nil
+		},
+	})
+
+	resp, err := h.GetDataQualitySummaryHandler(dataQualityAdminCtx(), &GetDataQualitySummaryRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.TotalItems != 8 {
+		t.Errorf("expected total_items=8, got %d", resp.Body.TotalItems)
+	}
+	if len(resp.Body.Categories) != 2 {
+		t.Fatalf("expected 2 categories, got %d", len(resp.Body.Categories))
+	}
+	if resp.Body.Categories[0].Key != "artists_missing_links" {
+		t.Errorf("expected key=artists_missing_links, got %s", resp.Body.Categories[0].Key)
+	}
+	if resp.Body.Categories[0].Count != 5 {
+		t.Errorf("expected count=5, got %d", resp.Body.Categories[0].Count)
+	}
+}
+
+func TestDataQualityHandler_Summary_ServiceError(t *testing.T) {
+	h := NewDataQualityHandler(&mockDataQualityService{
+		getSummaryFn: func() (*contracts.DataQualitySummary, error) {
+			return nil, fmt.Errorf("database error")
+		},
+	})
+
+	_, err := h.GetDataQualitySummaryHandler(dataQualityAdminCtx(), &GetDataQualitySummaryRequest{})
+	assertHumaError(t, err, 500)
+}
+
+func TestDataQualityHandler_Summary_Empty(t *testing.T) {
+	h := NewDataQualityHandler(&mockDataQualityService{
+		getSummaryFn: func() (*contracts.DataQualitySummary, error) {
+			return &contracts.DataQualitySummary{
+				Categories: []contracts.DataQualityCategory{},
+				TotalItems: 0,
+			}, nil
+		},
+	})
+
+	resp, err := h.GetDataQualitySummaryHandler(dataQualityAdminCtx(), &GetDataQualitySummaryRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.TotalItems != 0 {
+		t.Errorf("expected total_items=0, got %d", resp.Body.TotalItems)
+	}
+	if len(resp.Body.Categories) != 0 {
+		t.Fatalf("expected 0 categories, got %d", len(resp.Body.Categories))
+	}
+}
+
+// ============================================================================
+// Tests: GetDataQualityCategoryHandler
+// ============================================================================
+
+func TestDataQualityHandler_Category_Success(t *testing.T) {
+	h := NewDataQualityHandler(&mockDataQualityService{
+		getCategoryItemsFn: func(category string, limit, offset int) ([]*contracts.DataQualityItem, int64, error) {
+			if category != "artists_missing_links" {
+				t.Errorf("expected category=artists_missing_links, got %s", category)
+			}
+			return []*contracts.DataQualityItem{
+				{
+					EntityType: "artist",
+					EntityID:   1,
+					Name:       "Band A",
+					Slug:       "band-a",
+					Reason:     "No social links or website",
+					ShowCount:  10,
+				},
+				{
+					EntityType: "artist",
+					EntityID:   2,
+					Name:       "Band B",
+					Slug:       "band-b",
+					Reason:     "No social links or website",
+					ShowCount:  5,
+				},
+			}, 2, nil
+		},
+	})
+
+	resp, err := h.GetDataQualityCategoryHandler(dataQualityAdminCtx(), &GetDataQualityCategoryRequest{
+		Category: "artists_missing_links",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Total != 2 {
+		t.Errorf("expected total=2, got %d", resp.Body.Total)
+	}
+	if len(resp.Body.Items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(resp.Body.Items))
+	}
+	if resp.Body.Items[0].Name != "Band A" {
+		t.Errorf("expected name=Band A, got %s", resp.Body.Items[0].Name)
+	}
+	if resp.Body.Items[0].ShowCount != 10 {
+		t.Errorf("expected show_count=10, got %d", resp.Body.Items[0].ShowCount)
+	}
+}
+
+func TestDataQualityHandler_Category_InvalidCategory(t *testing.T) {
+	h := NewDataQualityHandler(&mockDataQualityService{
+		getCategoryItemsFn: func(category string, limit, offset int) ([]*contracts.DataQualityItem, int64, error) {
+			return nil, 0, fmt.Errorf("unknown category: %s", category)
+		},
+	})
+
+	_, err := h.GetDataQualityCategoryHandler(dataQualityAdminCtx(), &GetDataQualityCategoryRequest{
+		Category: "nonexistent",
+	})
+	assertHumaError(t, err, 400)
+}
+
+func TestDataQualityHandler_Category_ServiceError(t *testing.T) {
+	h := NewDataQualityHandler(&mockDataQualityService{
+		getCategoryItemsFn: func(category string, limit, offset int) ([]*contracts.DataQualityItem, int64, error) {
+			return nil, 0, fmt.Errorf("database error")
+		},
+	})
+
+	_, err := h.GetDataQualityCategoryHandler(dataQualityAdminCtx(), &GetDataQualityCategoryRequest{
+		Category: "artists_missing_links",
+	})
+	assertHumaError(t, err, 500)
+}
+
+func TestDataQualityHandler_Category_DefaultLimit(t *testing.T) {
+	var receivedLimit int
+	h := NewDataQualityHandler(&mockDataQualityService{
+		getCategoryItemsFn: func(category string, limit, offset int) ([]*contracts.DataQualityItem, int64, error) {
+			receivedLimit = limit
+			return nil, 0, nil
+		},
+	})
+
+	_, err := h.GetDataQualityCategoryHandler(dataQualityAdminCtx(), &GetDataQualityCategoryRequest{
+		Category: "artists_missing_links",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if receivedLimit != 50 {
+		t.Errorf("expected default limit=50, got %d", receivedLimit)
+	}
+}
+
+func TestDataQualityHandler_Category_CustomLimit(t *testing.T) {
+	var receivedLimit, receivedOffset int
+	h := NewDataQualityHandler(&mockDataQualityService{
+		getCategoryItemsFn: func(category string, limit, offset int) ([]*contracts.DataQualityItem, int64, error) {
+			receivedLimit = limit
+			receivedOffset = offset
+			return nil, 0, nil
+		},
+	})
+
+	_, err := h.GetDataQualityCategoryHandler(dataQualityAdminCtx(), &GetDataQualityCategoryRequest{
+		Category: "venues_missing_social",
+		Limit:    25,
+		Offset:   10,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if receivedLimit != 25 {
+		t.Errorf("expected limit=25, got %d", receivedLimit)
+	}
+	if receivedOffset != 10 {
+		t.Errorf("expected offset=10, got %d", receivedOffset)
+	}
+}
+
+func TestDataQualityHandler_Category_Empty(t *testing.T) {
+	h := NewDataQualityHandler(&mockDataQualityService{
+		getCategoryItemsFn: func(category string, limit, offset int) ([]*contracts.DataQualityItem, int64, error) {
+			return []*contracts.DataQualityItem{}, 0, nil
+		},
+	})
+
+	resp, err := h.GetDataQualityCategoryHandler(dataQualityAdminCtx(), &GetDataQualityCategoryRequest{
+		Category: "artists_missing_links",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Total != 0 {
+		t.Errorf("expected total=0, got %d", resp.Body.Total)
+	}
+	if len(resp.Body.Items) != 0 {
+		t.Fatalf("expected 0 items, got %d", len(resp.Body.Items))
+	}
+}

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -528,6 +528,11 @@ func setupAdminRoutes(protected *huma.Group, sc *services.ServiceContainer) {
 
 	// Admin user list endpoint
 	huma.Get(protected, "/admin/users", adminHandler.GetAdminUsersHandler)
+
+	// Admin data quality endpoints
+	dataQualityHandler := handlers.NewDataQualityHandler(sc.DataQuality)
+	huma.Get(protected, "/admin/data-quality", dataQualityHandler.GetDataQualitySummaryHandler)
+	huma.Get(protected, "/admin/data-quality/{category}", dataQualityHandler.GetDataQualityCategoryHandler)
 }
 
 // setupContributorProfileRoutes configures contributor profile endpoints

--- a/backend/internal/services/admin/data_quality.go
+++ b/backend/internal/services/admin/data_quality.go
@@ -1,0 +1,561 @@
+package admin
+
+import (
+	"fmt"
+
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/db"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// DataQualityService handles data quality analysis for the admin dashboard.
+type DataQualityService struct {
+	db *gorm.DB
+}
+
+// NewDataQualityService creates a new data quality service.
+func NewDataQualityService(database *gorm.DB) *DataQualityService {
+	if database == nil {
+		database = db.GetDB()
+	}
+	return &DataQualityService{db: database}
+}
+
+// categoryDefinitions maps category keys to their metadata.
+var categoryDefinitions = map[string]struct {
+	Label       string
+	EntityType  string
+	Description string
+}{
+	"artists_missing_links": {
+		Label:       "Artists Missing Links",
+		EntityType:  "artist",
+		Description: "Artists with no social links or website set",
+	},
+	"artists_missing_location": {
+		Label:       "Artists Missing Location",
+		EntityType:  "artist",
+		Description: "Artists with no city or state set",
+	},
+	"artists_no_aliases": {
+		Label:       "Artists Without Aliases",
+		EntityType:  "artist",
+		Description: "Artists with 5+ shows but no aliases (potential disambiguation needed)",
+	},
+	"venues_missing_social": {
+		Label:       "Venues Missing Social",
+		EntityType:  "venue",
+		Description: "Venues with no social links or website set",
+	},
+	"venues_unverified_with_shows": {
+		Label:       "Unverified Venues With Shows",
+		EntityType:  "venue",
+		Description: "Unverified venues that have 3+ approved shows",
+	},
+	"shows_no_billing_order": {
+		Label:       "Shows Without Billing Order",
+		EntityType:  "show",
+		Description: "Upcoming shows with 2+ artists but no billing differentiation",
+	},
+	"shows_missing_price": {
+		Label:       "Shows Missing Price",
+		EntityType:  "show",
+		Description: "Upcoming approved shows with no price set",
+	},
+}
+
+// categoryOrder defines the display order for categories.
+var categoryOrder = []string{
+	"artists_missing_links",
+	"artists_missing_location",
+	"artists_no_aliases",
+	"venues_missing_social",
+	"venues_unverified_with_shows",
+	"shows_no_billing_order",
+	"shows_missing_price",
+}
+
+// GetSummary returns counts per data quality category.
+func (s *DataQualityService) GetSummary() (*contracts.DataQualitySummary, error) {
+	summary := &contracts.DataQualitySummary{}
+	totalItems := 0
+
+	for _, key := range categoryOrder {
+		def := categoryDefinitions[key]
+		count, err := s.getCategoryCount(key)
+		if err != nil {
+			return nil, fmt.Errorf("counting category %s: %w", key, err)
+		}
+		summary.Categories = append(summary.Categories, contracts.DataQualityCategory{
+			Key:         key,
+			Label:       def.Label,
+			EntityType:  def.EntityType,
+			Count:       count,
+			Description: def.Description,
+		})
+		totalItems += count
+	}
+
+	summary.TotalItems = totalItems
+	return summary, nil
+}
+
+// GetCategoryItems returns paginated items for a specific data quality category.
+func (s *DataQualityService) GetCategoryItems(category string, limit, offset int) ([]*contracts.DataQualityItem, int64, error) {
+	if _, ok := categoryDefinitions[category]; !ok {
+		return nil, 0, fmt.Errorf("unknown category: %s", category)
+	}
+
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 200 {
+		limit = 200
+	}
+
+	switch category {
+	case "artists_missing_links":
+		return s.getArtistsMissingLinks(limit, offset)
+	case "artists_missing_location":
+		return s.getArtistsMissingLocation(limit, offset)
+	case "artists_no_aliases":
+		return s.getArtistsNoAliases(limit, offset)
+	case "venues_missing_social":
+		return s.getVenuesMissingSocial(limit, offset)
+	case "venues_unverified_with_shows":
+		return s.getVenuesUnverifiedWithShows(limit, offset)
+	case "shows_no_billing_order":
+		return s.getShowsNoBillingOrder(limit, offset)
+	case "shows_missing_price":
+		return s.getShowsMissingPrice(limit, offset)
+	default:
+		return nil, 0, fmt.Errorf("unknown category: %s", category)
+	}
+}
+
+// --- Count helpers ---
+
+func (s *DataQualityService) getCategoryCount(category string) (int, error) {
+	var count int64
+	var err error
+
+	switch category {
+	case "artists_missing_links":
+		err = s.db.Raw(`
+			SELECT COUNT(*) FROM artists
+			WHERE instagram IS NULL AND facebook IS NULL AND twitter IS NULL
+			  AND youtube IS NULL AND spotify IS NULL AND soundcloud IS NULL
+			  AND bandcamp IS NULL AND website IS NULL
+		`).Scan(&count).Error
+
+	case "artists_missing_location":
+		err = s.db.Raw(`
+			SELECT COUNT(*) FROM artists
+			WHERE city IS NULL AND state IS NULL
+		`).Scan(&count).Error
+
+	case "artists_no_aliases":
+		err = s.db.Raw(`
+			SELECT COUNT(*) FROM artists a
+			WHERE (SELECT COUNT(*) FROM show_artists WHERE artist_id = a.id) >= 5
+			  AND (SELECT COUNT(*) FROM artist_aliases WHERE artist_id = a.id) = 0
+		`).Scan(&count).Error
+
+	case "venues_missing_social":
+		err = s.db.Raw(`
+			SELECT COUNT(*) FROM venues
+			WHERE instagram IS NULL AND facebook IS NULL AND twitter IS NULL
+			  AND youtube IS NULL AND spotify IS NULL AND soundcloud IS NULL
+			  AND bandcamp IS NULL AND website IS NULL
+		`).Scan(&count).Error
+
+	case "venues_unverified_with_shows":
+		err = s.db.Raw(`
+			SELECT COUNT(*) FROM venues v
+			WHERE v.verified = false
+			  AND (SELECT COUNT(*) FROM show_venues sv
+			       JOIN shows s ON s.id = sv.show_id AND s.status = 'approved'
+			       WHERE sv.venue_id = v.id) >= 3
+		`).Scan(&count).Error
+
+	case "shows_no_billing_order":
+		err = s.db.Raw(`
+			SELECT COUNT(*) FROM shows s
+			WHERE s.status = 'approved' AND s.event_date >= NOW()
+			  AND (SELECT COUNT(*) FROM show_artists WHERE show_id = s.id) >= 2
+			  AND NOT EXISTS (
+			    SELECT 1 FROM show_artists WHERE show_id = s.id AND position > 0
+			  )
+		`).Scan(&count).Error
+
+	case "shows_missing_price":
+		err = s.db.Raw(`
+			SELECT COUNT(*) FROM shows
+			WHERE status = 'approved' AND event_date >= NOW() AND price IS NULL
+		`).Scan(&count).Error
+	}
+
+	if err != nil {
+		return 0, err
+	}
+	return int(count), nil
+}
+
+// --- Item retrieval helpers ---
+
+func (s *DataQualityService) getArtistsMissingLinks(limit, offset int) ([]*contracts.DataQualityItem, int64, error) {
+	var total int64
+	err := s.db.Raw(`
+		SELECT COUNT(*) FROM artists
+		WHERE instagram IS NULL AND facebook IS NULL AND twitter IS NULL
+		  AND youtube IS NULL AND spotify IS NULL AND soundcloud IS NULL
+		  AND bandcamp IS NULL AND website IS NULL
+	`).Scan(&total).Error
+	if err != nil {
+		return nil, 0, err
+	}
+
+	type row struct {
+		ID        uint
+		Name      string
+		Slug      *string
+		ShowCount int
+	}
+	var rows []row
+	err = s.db.Raw(`
+		SELECT a.id, a.name, a.slug, COUNT(sa.show_id) as show_count
+		FROM artists a
+		LEFT JOIN show_artists sa ON sa.artist_id = a.id
+		LEFT JOIN shows s ON s.id = sa.show_id AND s.status = 'approved'
+		WHERE a.instagram IS NULL AND a.facebook IS NULL AND a.twitter IS NULL
+		  AND a.youtube IS NULL AND a.spotify IS NULL AND a.soundcloud IS NULL
+		  AND a.bandcamp IS NULL AND a.website IS NULL
+		GROUP BY a.id
+		ORDER BY show_count DESC, a.name ASC
+		LIMIT ? OFFSET ?
+	`, limit, offset).Scan(&rows).Error
+	if err != nil {
+		return nil, 0, err
+	}
+
+	items := make([]*contracts.DataQualityItem, 0, len(rows))
+	for _, r := range rows {
+		slug := ""
+		if r.Slug != nil {
+			slug = *r.Slug
+		}
+		items = append(items, &contracts.DataQualityItem{
+			EntityType: "artist",
+			EntityID:   r.ID,
+			Name:       r.Name,
+			Slug:       slug,
+			Reason:     "No social links or website",
+			ShowCount:  r.ShowCount,
+		})
+	}
+	return items, total, nil
+}
+
+func (s *DataQualityService) getArtistsMissingLocation(limit, offset int) ([]*contracts.DataQualityItem, int64, error) {
+	var total int64
+	err := s.db.Raw(`
+		SELECT COUNT(*) FROM artists
+		WHERE city IS NULL AND state IS NULL
+	`).Scan(&total).Error
+	if err != nil {
+		return nil, 0, err
+	}
+
+	type row struct {
+		ID        uint
+		Name      string
+		Slug      *string
+		ShowCount int
+	}
+	var rows []row
+	err = s.db.Raw(`
+		SELECT a.id, a.name, a.slug, COUNT(sa.show_id) as show_count
+		FROM artists a
+		LEFT JOIN show_artists sa ON sa.artist_id = a.id
+		LEFT JOIN shows s ON s.id = sa.show_id AND s.status = 'approved'
+		WHERE a.city IS NULL AND a.state IS NULL
+		GROUP BY a.id
+		ORDER BY show_count DESC, a.name ASC
+		LIMIT ? OFFSET ?
+	`, limit, offset).Scan(&rows).Error
+	if err != nil {
+		return nil, 0, err
+	}
+
+	items := make([]*contracts.DataQualityItem, 0, len(rows))
+	for _, r := range rows {
+		slug := ""
+		if r.Slug != nil {
+			slug = *r.Slug
+		}
+		items = append(items, &contracts.DataQualityItem{
+			EntityType: "artist",
+			EntityID:   r.ID,
+			Name:       r.Name,
+			Slug:       slug,
+			Reason:     "No city or state set",
+			ShowCount:  r.ShowCount,
+		})
+	}
+	return items, total, nil
+}
+
+func (s *DataQualityService) getArtistsNoAliases(limit, offset int) ([]*contracts.DataQualityItem, int64, error) {
+	var total int64
+	err := s.db.Raw(`
+		SELECT COUNT(*) FROM artists a
+		WHERE (SELECT COUNT(*) FROM show_artists WHERE artist_id = a.id) >= 5
+		  AND (SELECT COUNT(*) FROM artist_aliases WHERE artist_id = a.id) = 0
+	`).Scan(&total).Error
+	if err != nil {
+		return nil, 0, err
+	}
+
+	type row struct {
+		ID        uint
+		Name      string
+		Slug      *string
+		ShowCount int
+	}
+	var rows []row
+	err = s.db.Raw(`
+		SELECT a.id, a.name, a.slug, COUNT(sa.show_id) as show_count
+		FROM artists a
+		LEFT JOIN show_artists sa ON sa.artist_id = a.id
+		WHERE (SELECT COUNT(*) FROM artist_aliases WHERE artist_id = a.id) = 0
+		GROUP BY a.id
+		HAVING COUNT(sa.show_id) >= 5
+		ORDER BY show_count DESC, a.name ASC
+		LIMIT ? OFFSET ?
+	`, limit, offset).Scan(&rows).Error
+	if err != nil {
+		return nil, 0, err
+	}
+
+	items := make([]*contracts.DataQualityItem, 0, len(rows))
+	for _, r := range rows {
+		slug := ""
+		if r.Slug != nil {
+			slug = *r.Slug
+		}
+		items = append(items, &contracts.DataQualityItem{
+			EntityType: "artist",
+			EntityID:   r.ID,
+			Name:       r.Name,
+			Slug:       slug,
+			Reason:     fmt.Sprintf("%d shows but no aliases", r.ShowCount),
+			ShowCount:  r.ShowCount,
+		})
+	}
+	return items, total, nil
+}
+
+func (s *DataQualityService) getVenuesMissingSocial(limit, offset int) ([]*contracts.DataQualityItem, int64, error) {
+	var total int64
+	err := s.db.Raw(`
+		SELECT COUNT(*) FROM venues
+		WHERE instagram IS NULL AND facebook IS NULL AND twitter IS NULL
+		  AND youtube IS NULL AND spotify IS NULL AND soundcloud IS NULL
+		  AND bandcamp IS NULL AND website IS NULL
+	`).Scan(&total).Error
+	if err != nil {
+		return nil, 0, err
+	}
+
+	type row struct {
+		ID        uint
+		Name      string
+		Slug      *string
+		ShowCount int
+	}
+	var rows []row
+	err = s.db.Raw(`
+		SELECT v.id, v.name, v.slug, COUNT(sv.show_id) as show_count
+		FROM venues v
+		LEFT JOIN show_venues sv ON sv.venue_id = v.id
+		LEFT JOIN shows s ON s.id = sv.show_id AND s.status = 'approved'
+		WHERE v.instagram IS NULL AND v.facebook IS NULL AND v.twitter IS NULL
+		  AND v.youtube IS NULL AND v.spotify IS NULL AND v.soundcloud IS NULL
+		  AND v.bandcamp IS NULL AND v.website IS NULL
+		GROUP BY v.id
+		ORDER BY show_count DESC, v.name ASC
+		LIMIT ? OFFSET ?
+	`, limit, offset).Scan(&rows).Error
+	if err != nil {
+		return nil, 0, err
+	}
+
+	items := make([]*contracts.DataQualityItem, 0, len(rows))
+	for _, r := range rows {
+		slug := ""
+		if r.Slug != nil {
+			slug = *r.Slug
+		}
+		items = append(items, &contracts.DataQualityItem{
+			EntityType: "venue",
+			EntityID:   r.ID,
+			Name:       r.Name,
+			Slug:       slug,
+			Reason:     "No social links or website",
+			ShowCount:  r.ShowCount,
+		})
+	}
+	return items, total, nil
+}
+
+func (s *DataQualityService) getVenuesUnverifiedWithShows(limit, offset int) ([]*contracts.DataQualityItem, int64, error) {
+	var total int64
+	err := s.db.Raw(`
+		SELECT COUNT(*) FROM venues v
+		WHERE v.verified = false
+		  AND (SELECT COUNT(*) FROM show_venues sv
+		       JOIN shows s ON s.id = sv.show_id AND s.status = 'approved'
+		       WHERE sv.venue_id = v.id) >= 3
+	`).Scan(&total).Error
+	if err != nil {
+		return nil, 0, err
+	}
+
+	type row struct {
+		ID        uint
+		Name      string
+		Slug      *string
+		ShowCount int
+	}
+	var rows []row
+	err = s.db.Raw(`
+		SELECT v.id, v.name, v.slug, COUNT(sv.show_id) as show_count
+		FROM venues v
+		JOIN show_venues sv ON sv.venue_id = v.id
+		JOIN shows s ON s.id = sv.show_id AND s.status = 'approved'
+		WHERE v.verified = false
+		GROUP BY v.id
+		HAVING COUNT(sv.show_id) >= 3
+		ORDER BY show_count DESC, v.name ASC
+		LIMIT ? OFFSET ?
+	`, limit, offset).Scan(&rows).Error
+	if err != nil {
+		return nil, 0, err
+	}
+
+	items := make([]*contracts.DataQualityItem, 0, len(rows))
+	for _, r := range rows {
+		slug := ""
+		if r.Slug != nil {
+			slug = *r.Slug
+		}
+		items = append(items, &contracts.DataQualityItem{
+			EntityType: "venue",
+			EntityID:   r.ID,
+			Name:       r.Name,
+			Slug:       slug,
+			Reason:     fmt.Sprintf("Unverified with %d approved shows", r.ShowCount),
+			ShowCount:  r.ShowCount,
+		})
+	}
+	return items, total, nil
+}
+
+func (s *DataQualityService) getShowsNoBillingOrder(limit, offset int) ([]*contracts.DataQualityItem, int64, error) {
+	var total int64
+	err := s.db.Raw(`
+		SELECT COUNT(*) FROM shows s
+		WHERE s.status = 'approved' AND s.event_date >= NOW()
+		  AND (SELECT COUNT(*) FROM show_artists WHERE show_id = s.id) >= 2
+		  AND NOT EXISTS (
+		    SELECT 1 FROM show_artists WHERE show_id = s.id AND position > 0
+		  )
+	`).Scan(&total).Error
+	if err != nil {
+		return nil, 0, err
+	}
+
+	type row struct {
+		ID    uint
+		Title string
+		Slug  *string
+	}
+	var rows []row
+	err = s.db.Raw(`
+		SELECT s.id, s.title, s.slug
+		FROM shows s
+		WHERE s.status = 'approved' AND s.event_date >= NOW()
+		  AND (SELECT COUNT(*) FROM show_artists WHERE show_id = s.id) >= 2
+		  AND NOT EXISTS (
+		    SELECT 1 FROM show_artists WHERE show_id = s.id AND position > 0
+		  )
+		ORDER BY s.event_date ASC
+		LIMIT ? OFFSET ?
+	`, limit, offset).Scan(&rows).Error
+	if err != nil {
+		return nil, 0, err
+	}
+
+	items := make([]*contracts.DataQualityItem, 0, len(rows))
+	for _, r := range rows {
+		slug := ""
+		if r.Slug != nil {
+			slug = *r.Slug
+		}
+		items = append(items, &contracts.DataQualityItem{
+			EntityType: "show",
+			EntityID:   r.ID,
+			Name:       r.Title,
+			Slug:       slug,
+			Reason:     "All artists at position 0 (no billing order)",
+			ShowCount:  0,
+		})
+	}
+	return items, total, nil
+}
+
+func (s *DataQualityService) getShowsMissingPrice(limit, offset int) ([]*contracts.DataQualityItem, int64, error) {
+	var total int64
+	err := s.db.Raw(`
+		SELECT COUNT(*) FROM shows
+		WHERE status = 'approved' AND event_date >= NOW() AND price IS NULL
+	`).Scan(&total).Error
+	if err != nil {
+		return nil, 0, err
+	}
+
+	type row struct {
+		ID    uint
+		Title string
+		Slug  *string
+	}
+	var rows []row
+	err = s.db.Raw(`
+		SELECT id, title, slug
+		FROM shows
+		WHERE status = 'approved' AND event_date >= NOW() AND price IS NULL
+		ORDER BY event_date ASC
+		LIMIT ? OFFSET ?
+	`, limit, offset).Scan(&rows).Error
+	if err != nil {
+		return nil, 0, err
+	}
+
+	items := make([]*contracts.DataQualityItem, 0, len(rows))
+	for _, r := range rows {
+		slug := ""
+		if r.Slug != nil {
+			slug = *r.Slug
+		}
+		items = append(items, &contracts.DataQualityItem{
+			EntityType: "show",
+			EntityID:   r.ID,
+			Name:       r.Title,
+			Slug:       slug,
+			Reason:     "No price set for upcoming show",
+			ShowCount:  0,
+		})
+	}
+	return items, total, nil
+}

--- a/backend/internal/services/admin/data_quality_test.go
+++ b/backend/internal/services/admin/data_quality_test.go
@@ -1,0 +1,539 @@
+package admin
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/testutil"
+)
+
+// =============================================================================
+// UNIT TESTS (No Database Required)
+// =============================================================================
+
+func TestNewDataQualityService(t *testing.T) {
+	t.Run("NilDB", func(t *testing.T) {
+		svc := NewDataQualityService(nil)
+		assert.NotNil(t, svc)
+	})
+
+	t.Run("ExplicitDB", func(t *testing.T) {
+		db := &gorm.DB{}
+		svc := NewDataQualityService(db)
+		assert.NotNil(t, svc)
+	})
+}
+
+func TestDataQualityService_NilDB(t *testing.T) {
+	svc := &DataQualityService{db: nil}
+	assert.Panics(t, func() {
+		svc.GetSummary()
+	})
+}
+
+func TestDataQualityService_InvalidCategory(t *testing.T) {
+	svc := &DataQualityService{db: &gorm.DB{}}
+	_, _, err := svc.GetCategoryItems("nonexistent_category", 10, 0)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown category")
+}
+
+// =============================================================================
+// INTEGRATION TESTS (With Real Database)
+// =============================================================================
+
+type DataQualityServiceIntegrationTestSuite struct {
+	suite.Suite
+	container testcontainers.Container
+	db        *gorm.DB
+	service   *DataQualityService
+	ctx       context.Context
+}
+
+func (suite *DataQualityServiceIntegrationTestSuite) SetupSuite() {
+	suite.ctx = context.Background()
+
+	container, err := testcontainers.GenericContainer(suite.ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "postgres:18",
+			ExposedPorts: []string{"5432/tcp"},
+			Env: map[string]string{
+				"POSTGRES_DB":       "test_db",
+				"POSTGRES_USER":     "test_user",
+				"POSTGRES_PASSWORD": "test_password",
+			},
+			WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(120 * time.Second),
+		},
+		Started: true,
+	})
+	if err != nil {
+		suite.T().Fatalf("failed to start postgres container: %v", err)
+	}
+	suite.container = container
+
+	host, err := container.Host(suite.ctx)
+	if err != nil {
+		suite.T().Fatalf("failed to get host: %v", err)
+	}
+	port, err := container.MappedPort(suite.ctx, "5432")
+	if err != nil {
+		suite.T().Fatalf("failed to get port: %v", err)
+	}
+
+	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
+		host, port.Port())
+
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		suite.T().Fatalf("failed to connect to test database: %v", err)
+	}
+	suite.db = db
+
+	sqlDB, err := db.DB()
+	if err != nil {
+		suite.T().Fatalf("failed to get sql.DB: %v", err)
+	}
+
+	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
+
+	suite.service = &DataQualityService{db: db}
+}
+
+func (suite *DataQualityServiceIntegrationTestSuite) TearDownSuite() {
+	if suite.container != nil {
+		if err := suite.container.Terminate(suite.ctx); err != nil {
+			suite.T().Logf("failed to terminate container: %v", err)
+		}
+	}
+}
+
+func (suite *DataQualityServiceIntegrationTestSuite) TearDownTest() {
+	sqlDB, err := suite.db.DB()
+	suite.Require().NoError(err)
+	_, _ = sqlDB.Exec("DELETE FROM artist_aliases")
+	_, _ = sqlDB.Exec("DELETE FROM show_artists")
+	_, _ = sqlDB.Exec("DELETE FROM show_venues")
+	_, _ = sqlDB.Exec("DELETE FROM shows")
+	_, _ = sqlDB.Exec("DELETE FROM artists")
+	_, _ = sqlDB.Exec("DELETE FROM venues")
+}
+
+func TestDataQualityServiceIntegrationTestSuite(t *testing.T) {
+	suite.Run(t, new(DataQualityServiceIntegrationTestSuite))
+}
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+func (suite *DataQualityServiceIntegrationTestSuite) createArtist(name string, social *models.Social) *models.Artist {
+	artist := &models.Artist{Name: name}
+	if social != nil {
+		artist.Social = *social
+	}
+	err := suite.db.Create(artist).Error
+	suite.Require().NoError(err)
+	return artist
+}
+
+func (suite *DataQualityServiceIntegrationTestSuite) createArtistWithLocation(name string, city, state *string) *models.Artist {
+	artist := &models.Artist{
+		Name:  name,
+		City:  city,
+		State: state,
+	}
+	err := suite.db.Create(artist).Error
+	suite.Require().NoError(err)
+	return artist
+}
+
+func (suite *DataQualityServiceIntegrationTestSuite) createVenue(name, city, state string, verified bool, social *models.Social) *models.Venue {
+	venue := &models.Venue{
+		Name:     name,
+		City:     city,
+		State:    state,
+		Verified: verified,
+	}
+	if social != nil {
+		venue.Social = *social
+	}
+	err := suite.db.Create(venue).Error
+	suite.Require().NoError(err)
+	// If not verified, update explicitly due to GORM bool zero-value gotcha
+	if !verified {
+		suite.db.Exec("UPDATE venues SET verified = false WHERE id = ?", venue.ID)
+	}
+	return venue
+}
+
+func (suite *DataQualityServiceIntegrationTestSuite) createShow(title string, status models.ShowStatus, price *float64) *models.Show {
+	show := &models.Show{
+		Title:     title,
+		EventDate: time.Now().Add(7 * 24 * time.Hour), // future
+		Status:    status,
+		Source:    models.ShowSourceUser,
+		Price:     price,
+	}
+	err := suite.db.Create(show).Error
+	suite.Require().NoError(err)
+	return show
+}
+
+func (suite *DataQualityServiceIntegrationTestSuite) createShowWithDate(title string, status models.ShowStatus, eventDate time.Time) *models.Show {
+	show := &models.Show{
+		Title:     title,
+		EventDate: eventDate,
+		Status:    status,
+		Source:    models.ShowSourceUser,
+	}
+	err := suite.db.Create(show).Error
+	suite.Require().NoError(err)
+	return show
+}
+
+func (suite *DataQualityServiceIntegrationTestSuite) linkShowArtist(showID, artistID uint, position int) {
+	sa := &models.ShowArtist{
+		ShowID:   showID,
+		ArtistID: artistID,
+		Position: position,
+	}
+	err := suite.db.Create(sa).Error
+	suite.Require().NoError(err)
+}
+
+func (suite *DataQualityServiceIntegrationTestSuite) linkShowVenue(showID, venueID uint) {
+	sv := &models.ShowVenue{
+		ShowID:  showID,
+		VenueID: venueID,
+	}
+	err := suite.db.Create(sv).Error
+	suite.Require().NoError(err)
+}
+
+func (suite *DataQualityServiceIntegrationTestSuite) createAlias(artistID uint, alias string) {
+	a := &models.ArtistAlias{
+		ArtistID: artistID,
+		Alias:    alias,
+	}
+	err := suite.db.Create(a).Error
+	suite.Require().NoError(err)
+}
+
+// =============================================================================
+// TESTS: GetSummary
+// =============================================================================
+
+func (suite *DataQualityServiceIntegrationTestSuite) TestGetSummary_Empty() {
+	summary, err := suite.service.GetSummary()
+	suite.Require().NoError(err)
+	suite.Equal(0, summary.TotalItems)
+	suite.Len(summary.Categories, 7)
+
+	// All counts should be 0 in an empty DB
+	for _, cat := range summary.Categories {
+		suite.Equal(0, cat.Count, "category %s should have count 0", cat.Key)
+	}
+}
+
+func (suite *DataQualityServiceIntegrationTestSuite) TestGetSummary_WithData() {
+	// Artist with no links
+	suite.createArtist("No Links Band", nil)
+
+	// Artist with links (should NOT appear)
+	ig := "insta"
+	suite.createArtist("Has Links Band", &models.Social{Instagram: &ig})
+
+	// Artist with no location
+	suite.createArtistWithLocation("No Location Band", nil, nil)
+
+	summary, err := suite.service.GetSummary()
+	suite.Require().NoError(err)
+	suite.Greater(summary.TotalItems, 0)
+
+	// Find the artists_missing_links category
+	for _, cat := range summary.Categories {
+		if cat.Key == "artists_missing_links" {
+			// "No Links Band" and "No Location Band" both have no links
+			suite.Equal(2, cat.Count, "artists_missing_links should count artists with no social links")
+			break
+		}
+	}
+}
+
+// =============================================================================
+// TESTS: GetCategoryItems - Artists Missing Links
+// =============================================================================
+
+func (suite *DataQualityServiceIntegrationTestSuite) TestArtistsMissingLinks() {
+	// Create two artists with no links
+	a1 := suite.createArtist("Popular Band", nil)
+	a2 := suite.createArtist("Unknown Band", nil)
+
+	// Give Popular Band more shows
+	show1 := suite.createShow("Show 1", models.ShowStatusApproved, nil)
+	show2 := suite.createShow("Show 2", models.ShowStatusApproved, nil)
+	suite.linkShowArtist(show1.ID, a1.ID, 0)
+	suite.linkShowArtist(show2.ID, a1.ID, 0)
+	suite.linkShowArtist(show1.ID, a2.ID, 1)
+
+	// Artist with links (should NOT appear)
+	ig := "insta"
+	suite.createArtist("Has Links", &models.Social{Instagram: &ig})
+
+	items, total, err := suite.service.GetCategoryItems("artists_missing_links", 50, 0)
+	suite.Require().NoError(err)
+	suite.Equal(int64(2), total)
+	suite.Len(items, 2)
+
+	// Popular Band should appear first (more shows)
+	suite.Equal("Popular Band", items[0].Name)
+	suite.Equal(2, items[0].ShowCount)
+	suite.Equal("Unknown Band", items[1].Name)
+	suite.Equal(1, items[1].ShowCount)
+}
+
+// =============================================================================
+// TESTS: GetCategoryItems - Artists Missing Location
+// =============================================================================
+
+func (suite *DataQualityServiceIntegrationTestSuite) TestArtistsMissingLocation() {
+	// Artist with no location
+	suite.createArtistWithLocation("No Location Band", nil, nil)
+
+	// Artist with location (should NOT appear)
+	city := "Phoenix"
+	state := "AZ"
+	suite.createArtistWithLocation("Located Band", &city, &state)
+
+	items, total, err := suite.service.GetCategoryItems("artists_missing_location", 50, 0)
+	suite.Require().NoError(err)
+	suite.Equal(int64(1), total)
+	suite.Len(items, 1)
+	suite.Equal("No Location Band", items[0].Name)
+}
+
+// =============================================================================
+// TESTS: GetCategoryItems - Artists No Aliases
+// =============================================================================
+
+func (suite *DataQualityServiceIntegrationTestSuite) TestArtistsNoAliases() {
+	// Artist with 5+ shows but no aliases
+	a1 := suite.createArtist("Prolific Band", nil)
+	for i := 0; i < 5; i++ {
+		show := suite.createShow(fmt.Sprintf("Show %d", i), models.ShowStatusApproved, nil)
+		suite.linkShowArtist(show.ID, a1.ID, 0)
+	}
+
+	// Artist with 5+ shows AND aliases (should NOT appear)
+	a2 := suite.createArtist("Aliased Band", nil)
+	for i := 0; i < 5; i++ {
+		show := suite.createShow(fmt.Sprintf("Aliased Show %d", i), models.ShowStatusApproved, nil)
+		suite.linkShowArtist(show.ID, a2.ID, 0)
+	}
+	suite.createAlias(a2.ID, "Alt Name")
+
+	// Artist with <5 shows (should NOT appear)
+	a3 := suite.createArtist("New Band", nil)
+	show := suite.createShow("Single Show", models.ShowStatusApproved, nil)
+	suite.linkShowArtist(show.ID, a3.ID, 0)
+
+	items, total, err := suite.service.GetCategoryItems("artists_no_aliases", 50, 0)
+	suite.Require().NoError(err)
+	suite.Equal(int64(1), total)
+	suite.Len(items, 1)
+	suite.Equal("Prolific Band", items[0].Name)
+	suite.GreaterOrEqual(items[0].ShowCount, 5)
+}
+
+// =============================================================================
+// TESTS: GetCategoryItems - Venues Missing Social
+// =============================================================================
+
+func (suite *DataQualityServiceIntegrationTestSuite) TestVenuesMissingSocial() {
+	// Venue with no social links
+	suite.createVenue("Bare Venue", "Phoenix", "AZ", true, nil)
+
+	// Venue with social links (should NOT appear)
+	ig := "insta"
+	suite.createVenue("Social Venue", "Phoenix", "AZ", true, &models.Social{Instagram: &ig})
+
+	items, total, err := suite.service.GetCategoryItems("venues_missing_social", 50, 0)
+	suite.Require().NoError(err)
+	suite.Equal(int64(1), total)
+	suite.Len(items, 1)
+	suite.Equal("Bare Venue", items[0].Name)
+}
+
+// =============================================================================
+// TESTS: GetCategoryItems - Venues Unverified With Shows
+// =============================================================================
+
+func (suite *DataQualityServiceIntegrationTestSuite) TestVenuesUnverifiedWithShows() {
+	// Unverified venue with 3 approved shows
+	v1 := suite.createVenue("Busy Unverified", "Phoenix", "AZ", false, nil)
+	for i := 0; i < 3; i++ {
+		show := suite.createShow(fmt.Sprintf("Busy Show %d", i), models.ShowStatusApproved, nil)
+		suite.linkShowVenue(show.ID, v1.ID)
+	}
+
+	// Unverified venue with only 2 shows (should NOT appear)
+	v2 := suite.createVenue("Quiet Unverified", "Phoenix", "AZ", false, nil)
+	for i := 0; i < 2; i++ {
+		show := suite.createShow(fmt.Sprintf("Quiet Show %d", i), models.ShowStatusApproved, nil)
+		suite.linkShowVenue(show.ID, v2.ID)
+	}
+
+	// Verified venue with many shows (should NOT appear)
+	v3 := suite.createVenue("Verified Venue", "Phoenix", "AZ", true, nil)
+	for i := 0; i < 5; i++ {
+		show := suite.createShow(fmt.Sprintf("Verified Show %d", i), models.ShowStatusApproved, nil)
+		suite.linkShowVenue(show.ID, v3.ID)
+	}
+
+	items, total, err := suite.service.GetCategoryItems("venues_unverified_with_shows", 50, 0)
+	suite.Require().NoError(err)
+	suite.Equal(int64(1), total)
+	suite.Len(items, 1)
+	suite.Equal("Busy Unverified", items[0].Name)
+	suite.Equal(3, items[0].ShowCount)
+}
+
+// =============================================================================
+// TESTS: GetCategoryItems - Shows No Billing Order
+// =============================================================================
+
+func (suite *DataQualityServiceIntegrationTestSuite) TestShowsNoBillingOrder() {
+	a1 := suite.createArtist("Band A", nil)
+	a2 := suite.createArtist("Band B", nil)
+	a3 := suite.createArtist("Band C", nil)
+
+	// Future show with 2+ artists, all at position 0
+	show1 := suite.createShow("No Billing Show", models.ShowStatusApproved, nil)
+	suite.linkShowArtist(show1.ID, a1.ID, 0)
+	suite.linkShowArtist(show1.ID, a2.ID, 0)
+
+	// Future show with proper billing (should NOT appear)
+	show2 := suite.createShow("Proper Billing Show", models.ShowStatusApproved, nil)
+	suite.linkShowArtist(show2.ID, a1.ID, 0)
+	suite.linkShowArtist(show2.ID, a3.ID, 1)
+
+	// Future show with only 1 artist (should NOT appear)
+	show3 := suite.createShow("Solo Show", models.ShowStatusApproved, nil)
+	suite.linkShowArtist(show3.ID, a1.ID, 0)
+
+	// Past show with no billing (should NOT appear)
+	pastShow := suite.createShowWithDate("Past No Billing", models.ShowStatusApproved, time.Now().Add(-48*time.Hour))
+	suite.linkShowArtist(pastShow.ID, a1.ID, 0)
+	suite.linkShowArtist(pastShow.ID, a2.ID, 0)
+
+	items, total, err := suite.service.GetCategoryItems("shows_no_billing_order", 50, 0)
+	suite.Require().NoError(err)
+	suite.Equal(int64(1), total)
+	suite.Len(items, 1)
+	suite.Equal("No Billing Show", items[0].Name)
+}
+
+// =============================================================================
+// TESTS: GetCategoryItems - Shows Missing Price
+// =============================================================================
+
+func (suite *DataQualityServiceIntegrationTestSuite) TestShowsMissingPrice() {
+	price := 15.0
+
+	// Future approved show with no price
+	suite.createShow("No Price Show", models.ShowStatusApproved, nil)
+
+	// Future approved show with price (should NOT appear)
+	suite.createShow("Priced Show", models.ShowStatusApproved, &price)
+
+	// Future pending show with no price (should NOT appear)
+	suite.createShow("Pending No Price", models.ShowStatusPending, nil)
+
+	// Past show with no price (should NOT appear)
+	suite.createShowWithDate("Past No Price", models.ShowStatusApproved, time.Now().Add(-48*time.Hour))
+
+	items, total, err := suite.service.GetCategoryItems("shows_missing_price", 50, 0)
+	suite.Require().NoError(err)
+	suite.Equal(int64(1), total)
+	suite.Len(items, 1)
+	suite.Equal("No Price Show", items[0].Name)
+}
+
+// =============================================================================
+// TESTS: Pagination
+// =============================================================================
+
+func (suite *DataQualityServiceIntegrationTestSuite) TestPagination() {
+	// Create 5 artists with no links
+	for i := 0; i < 5; i++ {
+		suite.createArtist(fmt.Sprintf("No Links Band %d", i), nil)
+	}
+
+	// Page 1: limit 2, offset 0
+	items, total, err := suite.service.GetCategoryItems("artists_missing_links", 2, 0)
+	suite.Require().NoError(err)
+	suite.Equal(int64(5), total)
+	suite.Len(items, 2)
+
+	// Page 2: limit 2, offset 2
+	items2, total2, err := suite.service.GetCategoryItems("artists_missing_links", 2, 2)
+	suite.Require().NoError(err)
+	suite.Equal(int64(5), total2)
+	suite.Len(items2, 2)
+
+	// Page 3: limit 2, offset 4
+	items3, total3, err := suite.service.GetCategoryItems("artists_missing_links", 2, 4)
+	suite.Require().NoError(err)
+	suite.Equal(int64(5), total3)
+	suite.Len(items3, 1)
+
+	// Ensure no duplicates across pages
+	names := make(map[string]bool)
+	for _, item := range items {
+		names[item.Name] = true
+	}
+	for _, item := range items2 {
+		suite.False(names[item.Name], "duplicate item across pages: %s", item.Name)
+		names[item.Name] = true
+	}
+	for _, item := range items3 {
+		suite.False(names[item.Name], "duplicate item across pages: %s", item.Name)
+	}
+}
+
+// =============================================================================
+// TESTS: Unknown Category
+// =============================================================================
+
+func (suite *DataQualityServiceIntegrationTestSuite) TestUnknownCategory() {
+	_, _, err := suite.service.GetCategoryItems("nonexistent", 50, 0)
+	suite.Error(err)
+	suite.Contains(err.Error(), "unknown category")
+}
+
+// =============================================================================
+// TESTS: Max Limit
+// =============================================================================
+
+func (suite *DataQualityServiceIntegrationTestSuite) TestMaxLimit() {
+	// Create 3 artists with no links
+	for i := 0; i < 3; i++ {
+		suite.createArtist(fmt.Sprintf("Band %d", i), nil)
+	}
+
+	// Request with limit > 200 should be capped to 200
+	items, _, err := suite.service.GetCategoryItems("artists_missing_links", 500, 0)
+	suite.Require().NoError(err)
+	suite.Len(items, 3) // only 3 exist
+}

--- a/backend/internal/services/admin/interfaces.go
+++ b/backend/internal/services/admin/interfaces.go
@@ -10,6 +10,7 @@ var (
 	_ contracts.ShowReportServiceInterface   = (*ShowReportService)(nil)
 	_ contracts.ArtistReportServiceInterface = (*ArtistReportService)(nil)
 	_ contracts.APITokenServiceInterface     = (*APITokenService)(nil)
-	_ contracts.RevisionServiceInterface     = (*RevisionService)(nil)
+	_ contracts.RevisionServiceInterface      = (*RevisionService)(nil)
+	_ contracts.DataQualityServiceInterface  = (*DataQualityService)(nil)
 	// CleanupService has no interface in contracts — it's a lifecycle service.
 )

--- a/backend/internal/services/container.go
+++ b/backend/internal/services/container.go
@@ -21,6 +21,7 @@ type ServiceContainer struct {
 	// DB-only leaf services
 	AdminStats         *adminsvc.AdminStatsService
 	APIToken           *adminsvc.APITokenService
+	DataQuality        *adminsvc.DataQualityService
 	Revision           *adminsvc.RevisionService
 	Artist             *catalog.ArtistService
 	ContributorProfile *usersvc.ContributorProfileService
@@ -106,6 +107,7 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 		// DB-only leaf services
 		AdminStats:         adminsvc.NewAdminStatsService(database),
 		APIToken:           adminsvc.NewAPITokenService(database),
+		DataQuality:        adminsvc.NewDataQualityService(database),
 		Revision:           adminsvc.NewRevisionService(database),
 		Artist:             artist,
 		ContributorProfile: usersvc.NewContributorProfileService(database),

--- a/backend/internal/services/contracts/admin.go
+++ b/backend/internal/services/contracts/admin.go
@@ -194,3 +194,32 @@ type DataImportResult struct {
 		Messages   []string `json:"messages"`
 	} `json:"venues"`
 }
+
+// ──────────────────────────────────────────────
+// Data Quality types
+// ──────────────────────────────────────────────
+
+// DataQualitySummary contains counts per data quality category.
+type DataQualitySummary struct {
+	Categories []DataQualityCategory `json:"categories"`
+	TotalItems int                   `json:"total_items"`
+}
+
+// DataQualityCategory represents a single data quality check category.
+type DataQualityCategory struct {
+	Key         string `json:"key"`
+	Label       string `json:"label"`
+	EntityType  string `json:"entity_type"`
+	Count       int    `json:"count"`
+	Description string `json:"description"`
+}
+
+// DataQualityItem represents a single entity needing attention.
+type DataQualityItem struct {
+	EntityType string `json:"entity_type"`
+	EntityID   uint   `json:"entity_id"`
+	Name       string `json:"name"`
+	Slug       string `json:"slug"`
+	Reason     string `json:"reason"`
+	ShowCount  int    `json:"show_count"`
+}

--- a/backend/internal/services/contracts/interfaces.go
+++ b/backend/internal/services/contracts/interfaces.go
@@ -435,3 +435,9 @@ type SceneServiceInterface interface {
 	GetActiveArtists(city, state string, periodDays, limit, offset int) ([]*SceneArtistResponse, int64, error)
 	ParseSceneSlug(slug string) (string, string, error)
 }
+
+// DataQualityServiceInterface defines the contract for data quality dashboard operations.
+type DataQualityServiceInterface interface {
+	GetSummary() (*DataQualitySummary, error)
+	GetCategoryItems(category string, limit, offset int) ([]*DataQualityItem, int64, error)
+}

--- a/backend/internal/services/interfaces.go
+++ b/backend/internal/services/interfaces.go
@@ -47,6 +47,7 @@ type RequestServiceInterface = contracts.RequestServiceInterface
 type TagServiceInterface = contracts.TagServiceInterface
 type ArtistRelationshipServiceInterface = contracts.ArtistRelationshipServiceInterface
 type SceneServiceInterface = contracts.SceneServiceInterface
+type DataQualityServiceInterface = contracts.DataQualityServiceInterface
 
 // Compile-time interface satisfaction checks.
 // Engagement services (Bookmark, SavedShow, FavoriteVenue, Calendar, Reminder)

--- a/frontend/app/admin/data-quality/_components/DataQualityDashboard.tsx
+++ b/frontend/app/admin/data-quality/_components/DataQualityDashboard.tsx
@@ -1,0 +1,287 @@
+'use client'
+
+import { useState } from 'react'
+import {
+  AlertTriangle,
+  ChevronLeft,
+  ExternalLink,
+  Loader2,
+  type LucideIcon,
+  MapPin,
+  Music,
+  Ticket,
+  Users,
+  BadgeCheck,
+  DollarSign,
+  ListOrdered,
+} from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import {
+  useDataQualitySummary,
+  useDataQualityCategory,
+  type DataQualityCategory,
+  type DataQualityItem,
+} from '@/lib/hooks/admin/useDataQuality'
+
+// Map category keys to icons
+const categoryIcons: Record<string, LucideIcon> = {
+  artists_missing_links: Music,
+  artists_missing_location: MapPin,
+  artists_no_aliases: Users,
+  venues_missing_social: Ticket,
+  venues_unverified_with_shows: BadgeCheck,
+  shows_no_billing_order: ListOrdered,
+  shows_missing_price: DollarSign,
+}
+
+// Map entity types to base paths for links
+function getEntityUrl(item: DataQualityItem): string {
+  const slug = item.slug || String(item.entity_id)
+  switch (item.entity_type) {
+    case 'artist':
+      return `/artists/${slug}`
+    case 'venue':
+      return `/venues/${slug}`
+    case 'show':
+      return `/shows/${slug}`
+    default:
+      return '#'
+  }
+}
+
+// Summary card for a single category
+function CategoryCard({
+  category,
+  onClick,
+}: {
+  category: DataQualityCategory
+  onClick: () => void
+}) {
+  const Icon = categoryIcons[category.key] || AlertTriangle
+
+  return (
+    <Card
+      className="cursor-pointer transition-colors hover:bg-muted/50"
+      onClick={onClick}
+    >
+      <CardContent className="flex items-center gap-4 py-4">
+        <div
+          className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-lg ${
+            category.count > 0
+              ? 'bg-amber-500/15 text-amber-600 dark:text-amber-400'
+              : 'bg-muted text-muted-foreground'
+          }`}
+        >
+          <Icon className="h-5 w-5" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <p className="font-medium">{category.label}</p>
+            {category.count > 0 && (
+              <Badge variant="secondary" className="tabular-nums">
+                {category.count}
+              </Badge>
+            )}
+          </div>
+          <p className="text-sm text-muted-foreground">
+            {category.description}
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+// Item row for category detail view
+function ItemRow({ item }: { item: DataQualityItem }) {
+  const entityUrl = getEntityUrl(item)
+
+  return (
+    <div className="flex items-center justify-between border-b border-border py-3 last:border-0">
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <a
+            href={entityUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium text-foreground hover:text-primary hover:underline"
+          >
+            {item.name}
+          </a>
+          <ExternalLink className="h-3 w-3 text-muted-foreground" />
+        </div>
+        <p className="text-sm text-muted-foreground">{item.reason}</p>
+      </div>
+      <div className="flex items-center gap-3">
+        {item.show_count > 0 && (
+          <Badge variant="outline" className="tabular-nums">
+            {item.show_count} show{item.show_count !== 1 ? 's' : ''}
+          </Badge>
+        )}
+        <Badge variant="secondary" className="capitalize">
+          {item.entity_type}
+        </Badge>
+      </div>
+    </div>
+  )
+}
+
+// Category detail view with paginated items
+function CategoryDetail({
+  category,
+  onBack,
+}: {
+  category: DataQualityCategory
+  onBack: () => void
+}) {
+  const [page, setPage] = useState(0)
+  const limit = 50
+  const offset = page * limit
+
+  const { data, isLoading } = useDataQualityCategory(
+    category.key,
+    limit,
+    offset
+  )
+
+  const totalPages = data ? Math.ceil(data.total / limit) : 0
+
+  return (
+    <div>
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={onBack}
+        className="mb-4 gap-1"
+      >
+        <ChevronLeft className="h-4 w-4" />
+        Back to summary
+      </Button>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            {category.label}
+            <Badge variant="secondary" className="tabular-nums">
+              {data?.total ?? category.count} total
+            </Badge>
+          </CardTitle>
+          <p className="text-sm text-muted-foreground">
+            {category.description}
+          </p>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+            </div>
+          ) : data?.items && data.items.length > 0 ? (
+            <>
+              <div className="divide-y divide-border">
+                {data.items.map((item) => (
+                  <ItemRow
+                    key={`${item.entity_type}-${item.entity_id}`}
+                    item={item}
+                  />
+                ))}
+              </div>
+
+              {totalPages > 1 && (
+                <div className="mt-4 flex items-center justify-between">
+                  <p className="text-sm text-muted-foreground">
+                    Showing {offset + 1}--
+                    {Math.min(offset + limit, data.total)} of {data.total}
+                  </p>
+                  <div className="flex gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={page === 0}
+                      onClick={() => setPage((p) => p - 1)}
+                    >
+                      Previous
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={page >= totalPages - 1}
+                      onClick={() => setPage((p) => p + 1)}
+                    >
+                      Next
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </>
+          ) : (
+            <p className="py-8 text-center text-muted-foreground">
+              No items in this category.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+// Main dashboard component
+export function DataQualityDashboard() {
+  const { data: summary, isLoading, error } = useDataQualitySummary()
+  const [selectedCategory, setSelectedCategory] =
+    useState<DataQualityCategory | null>(null)
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4">
+        <p className="text-sm text-destructive">
+          Failed to load data quality summary.
+        </p>
+      </div>
+    )
+  }
+
+  if (selectedCategory) {
+    return (
+      <CategoryDetail
+        category={selectedCategory}
+        onBack={() => setSelectedCategory(null)}
+      />
+    )
+  }
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h2 className="text-lg font-semibold">Data Quality</h2>
+        <p className="text-sm text-muted-foreground">
+          Entities that need attention, ranked by impact.
+          {summary && summary.total_items > 0 && (
+            <span className="ml-1 font-medium text-amber-600 dark:text-amber-400">
+              {summary.total_items} total items need work.
+            </span>
+          )}
+        </p>
+      </div>
+
+      <div className="grid gap-3">
+        {summary?.categories.map((category) => (
+          <CategoryCard
+            key={category.key}
+            category={category}
+            onClick={() => setSelectedCategory(category)}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/app/admin/data-quality/page.tsx
+++ b/frontend/app/admin/data-quality/page.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import { DataQualityDashboard } from '@/app/admin/data-quality/_components/DataQualityDashboard'
+
+export default function DataQualityPage() {
+  return <DataQualityDashboard />
+}

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import dynamic from 'next/dynamic'
-import { Shield, MapPin, Loader2, Upload, BadgeCheck, Flag, ScrollText, Users, LayoutDashboard, Clock, Disc3, Tag, Tags, Tent, Workflow, Library, Music } from 'lucide-react'
+import { Shield, MapPin, Loader2, Upload, BadgeCheck, Flag, ScrollText, Users, LayoutDashboard, Clock, Disc3, Tag, Tags, Tent, Workflow, Library, Music, ClipboardCheck } from 'lucide-react'
 import { usePendingVenueEdits } from '@/lib/hooks/admin/useAdminVenueEdits'
 import { useUnverifiedVenues } from '@/lib/hooks/admin/useAdminVenues'
 import { usePendingReports } from '@/lib/hooks/admin/useAdminReports'
@@ -115,6 +115,14 @@ const UsersPage = dynamic(() => import('./users/page'), {
 })
 
 const TagsPage = dynamic(() => import('./tags/page'), {
+  loading: () => (
+    <div className="flex items-center justify-center py-12">
+      <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+    </div>
+  ),
+})
+
+const DataQualityPage = dynamic(() => import('./data-quality/page'), {
   loading: () => (
     <div className="flex items-center justify-center py-12">
       <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
@@ -252,6 +260,10 @@ export default function AdminPage() {
               <Tags className="h-4 w-4" />
               Tags
             </TabsTrigger>
+            <TabsTrigger value="data-quality" className="gap-2">
+              <ClipboardCheck className="h-4 w-4" />
+              Data Quality
+            </TabsTrigger>
             <TabsTrigger value="artists-admin" className="gap-2">
               <Music className="h-4 w-4" />
               Artists
@@ -312,6 +324,10 @@ export default function AdminPage() {
 
           <TabsContent value="tags" className="space-y-4">
             <TagsPage />
+          </TabsContent>
+
+          <TabsContent value="data-quality" className="space-y-4">
+            <DataQualityPage />
           </TabsContent>
 
           <TabsContent value="artists-admin" className="space-y-4">

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -279,6 +279,11 @@ export const API_ENDPOINTS = {
     DISCOVERY: {
       IMPORT: `${API_BASE_URL}/admin/discovery/import`,
     },
+    DATA_QUALITY: {
+      SUMMARY: `${API_BASE_URL}/admin/data-quality`,
+      CATEGORY: (category: string) =>
+        `${API_BASE_URL}/admin/data-quality/${category}`,
+    },
     PIPELINE: {
       VENUES: `${API_BASE_URL}/admin/pipeline/venues`,
       EXTRACT: (venueId: string | number) =>

--- a/frontend/lib/hooks/admin/index.ts
+++ b/frontend/lib/hooks/admin/index.ts
@@ -41,6 +41,15 @@ export {
 
 export { useAdminStats } from './useAdminStats'
 
+export {
+  type DataQualityCategory,
+  type DataQualitySummary,
+  type DataQualityItem,
+  type DataQualityCategoryResponse,
+  useDataQualitySummary,
+  useDataQualityCategory,
+} from './useDataQuality'
+
 export { useAdminUsers } from './useAdminUsers'
 
 export {

--- a/frontend/lib/hooks/admin/useDataQuality.ts
+++ b/frontend/lib/hooks/admin/useDataQuality.ts
@@ -1,0 +1,70 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import { apiRequest, API_ENDPOINTS } from '../../api'
+import { queryKeys } from '../../queryClient'
+
+// Types
+
+export interface DataQualityCategory {
+  key: string
+  label: string
+  entity_type: string
+  count: number
+  description: string
+}
+
+export interface DataQualitySummary {
+  categories: DataQualityCategory[]
+  total_items: number
+}
+
+export interface DataQualityItem {
+  entity_type: string
+  entity_id: number
+  name: string
+  slug: string
+  reason: string
+  show_count: number
+}
+
+export interface DataQualityCategoryResponse {
+  items: DataQualityItem[]
+  total: number
+}
+
+/**
+ * Hook to fetch data quality summary (counts per category)
+ */
+export const useDataQualitySummary = () => {
+  return useQuery({
+    queryKey: queryKeys.admin.dataQuality.summary,
+    queryFn: async (): Promise<DataQualitySummary> => {
+      return apiRequest<DataQualitySummary>(
+        API_ENDPOINTS.ADMIN.DATA_QUALITY.SUMMARY,
+        { method: 'GET' }
+      )
+    },
+    staleTime: 60 * 1000, // 1 minute
+  })
+}
+
+/**
+ * Hook to fetch paginated items for a specific data quality category
+ */
+export const useDataQualityCategory = (
+  category: string,
+  limit: number = 50,
+  offset: number = 0,
+  options?: { enabled?: boolean }
+) => {
+  return useQuery({
+    queryKey: queryKeys.admin.dataQuality.category(category, limit, offset),
+    queryFn: async (): Promise<DataQualityCategoryResponse> => {
+      const url = `${API_ENDPOINTS.ADMIN.DATA_QUALITY.CATEGORY(category)}?limit=${limit}&offset=${offset}`
+      return apiRequest<DataQualityCategoryResponse>(url, { method: 'GET' })
+    },
+    enabled: options?.enabled !== false && !!category,
+    staleTime: 60 * 1000, // 1 minute
+  })
+}

--- a/frontend/lib/queryClient.ts
+++ b/frontend/lib/queryClient.ts
@@ -152,6 +152,11 @@ export const queryKeys = {
       ['admin', 'auditLogs', { limit, offset }] as const,
     users: (limit: number, offset: number, search: string) =>
       ['admin', 'users', { limit, offset, search }] as const,
+    dataQuality: {
+      summary: ['admin', 'dataQuality', 'summary'] as const,
+      category: (category: string, limit: number, offset: number) =>
+        ['admin', 'dataQuality', 'category', category, { limit, offset }] as const,
+    },
   },
 
   // Artist queries


### PR DESCRIPTION
## Summary
- **DataQualityService**: query-driven detection of entities with missing data, ranked by impact (show count)
- **7 quality categories**: artists missing links/location/aliases, venues missing social/unverified, shows missing billing/price
- **Admin dashboard tab**: summary cards with counts, drill-down to paginated item lists, direct links to entity pages

## Endpoints
| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/admin/data-quality` | Summary with counts per category |
| `GET` | `/admin/data-quality/{category}` | Paginated items for a category |

## Categories
| Key | Entity | Description |
|-----|--------|-------------|
| `artists_missing_links` | Artist | No social links at all |
| `artists_missing_location` | Artist | No city/state set |
| `artists_no_aliases` | Artist | 5+ shows but 0 aliases |
| `venues_missing_social` | Venue | No social links |
| `venues_unverified_with_shows` | Venue | Unverified with 3+ shows |
| `shows_no_billing_order` | Show | 2+ artists all at position 0 |
| `shows_missing_price` | Show | Upcoming, no price set |

## Test plan
- [x] `go build ./...` passes
- [x] 16 service tests pass (4 unit + 12 integration)
- [x] 12 handler unit tests pass
- [x] `bun run build` passes
- [x] All 1403 frontend tests pass
- [ ] Manual: verify dashboard shows correct counts

Closes PSY-45

🤖 Generated with [Claude Code](https://claude.com/claude-code)