### PR TITLE
Add scene page frontend with city landing pages

### DIFF
--- a/frontend/app/scenes/[slug]/page.tsx
+++ b/frontend/app/scenes/[slug]/page.tsx
@@ -1,0 +1,65 @@
+import { Suspense } from 'react'
+import { Loader2 } from 'lucide-react'
+import { SceneDetailView } from '@/features/scenes'
+
+interface ScenePageProps {
+  params: Promise<{ slug: string }>
+}
+
+export async function generateMetadata({ params }: ScenePageProps) {
+  const { slug } = await params
+
+  // Parse slug to create a readable title (e.g., "phoenix-az" -> "Phoenix, AZ")
+  const parts = slug.split('-')
+  const state = parts.pop()?.toUpperCase() || ''
+  const city = parts.map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ')
+
+  return {
+    title: `${city}, ${state} Music Scene`,
+    description: `Explore the ${city}, ${state} music scene — venues, active artists, upcoming shows, and scene pulse.`,
+    alternates: {
+      canonical: `https://psychichomily.com/scenes/${slug}`,
+    },
+    openGraph: {
+      title: `${city}, ${state} Music Scene | Psychic Homily`,
+      description: `Explore the ${city}, ${state} music scene — venues, active artists, upcoming shows, and scene pulse.`,
+      url: `/scenes/${slug}`,
+      type: 'website',
+    },
+  }
+}
+
+function SceneLoadingFallback() {
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center">
+      <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+    </div>
+  )
+}
+
+export default async function ScenePage({ params }: ScenePageProps) {
+  const { slug } = await params
+
+  if (!slug) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold mb-2">Invalid Scene</h1>
+          <p className="text-muted-foreground">
+            The scene could not be found.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex min-h-screen items-start justify-center">
+      <main className="w-full max-w-6xl px-4 py-8 md:px-8">
+        <Suspense fallback={<SceneLoadingFallback />}>
+          <SceneDetailView slug={slug} />
+        </Suspense>
+      </main>
+    </div>
+  )
+}

--- a/frontend/app/scenes/page.tsx
+++ b/frontend/app/scenes/page.tsx
@@ -1,0 +1,39 @@
+import { Suspense } from 'react'
+import { LoadingSpinner } from '@/components/shared'
+import { SceneList } from '@/features/scenes'
+
+export const metadata = {
+  title: 'Scenes',
+  description: 'Explore music scenes by city — venues, artists, shows, and live music activity.',
+  alternates: {
+    canonical: 'https://psychichomily.com/scenes',
+  },
+  openGraph: {
+    title: 'Scenes | Psychic Homily',
+    description: 'Explore music scenes by city — venues, artists, shows, and live music activity.',
+    url: '/scenes',
+    type: 'website',
+  },
+}
+
+export default function ScenesPage() {
+  return (
+    <div className="flex min-h-screen items-start justify-center">
+      <main className="w-full max-w-6xl px-4 py-8 md:px-8">
+        <h1 className="text-3xl font-bold text-center mb-2">Scenes</h1>
+        <p className="text-center text-muted-foreground mb-8 max-w-lg mx-auto">
+          City-level music scenes with venue activity, artist trends, and live show data.
+        </p>
+        <Suspense
+          fallback={
+            <div className="flex justify-center items-center py-12">
+              <LoadingSpinner />
+            </div>
+          }
+        >
+          <SceneList />
+        </Suspense>
+      </main>
+    </div>
+  )
+}

--- a/frontend/components/layout/CommandPalette.tsx
+++ b/frontend/components/layout/CommandPalette.tsx
@@ -13,7 +13,7 @@ import {
 } from '@/components/ui/command'
 import {
   Calendar, Mic2, MapPin, Disc3, Tag, Tags, Tent, BookOpen, Headphones, Send,
-  Library, LayoutList, MessageSquarePlus, Settings, Shield, Search, Clock, X,
+  Library, LayoutList, MessageSquarePlus, Settings, Shield, Search, Clock, X, Globe,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import { useAuthContext } from '@/lib/context/AuthContext'
@@ -70,6 +70,12 @@ const routes: RouteItem[] = [
     href: '/tags',
     icon: Tags,
     keywords: ['tags', 'genres', 'moods', 'styles', 'categories', 'tagging'],
+  },
+  {
+    label: 'Scenes',
+    href: '/scenes',
+    icon: Globe,
+    keywords: ['scenes', 'cities', 'city', 'local', 'geographic', 'phoenix', 'music scene'],
   },
   {
     label: 'Collections',

--- a/frontend/components/layout/Sidebar.test.tsx
+++ b/frontend/components/layout/Sidebar.test.tsx
@@ -25,7 +25,7 @@ describe('sidebarGroups', () => {
 
   it('Discover contains Shows, Festivals, Artists, Venues, Releases, Labels, Tags, Collections', () => {
     const discover = sidebarGroups.find(g => g.label === 'Discover')!
-    expect(discover.items.map(i => i.label)).toEqual(['Shows', 'Festivals', 'Artists', 'Venues', 'Releases', 'Labels', 'Tags', 'Collections'])
+    expect(discover.items.map(i => i.label)).toEqual(['Shows', 'Festivals', 'Artists', 'Venues', 'Releases', 'Labels', 'Tags', 'Scenes', 'Collections'])
   })
 
   it('Community contains Requests, Blog, DJ Sets, Substack, Submissions', () => {

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -5,7 +5,7 @@ import { usePathname } from 'next/navigation'
 import {
   Calendar, Mic2, MapPin, Disc3, Tag, Tags, Tent, BookOpen, Headphones, Newspaper,
   Send, Library, LayoutList, MessageSquarePlus, Settings, Shield, PanelLeftClose, PanelLeft,
-  ExternalLink,
+  ExternalLink, Globe,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import { cn } from '@/lib/utils'
@@ -37,6 +37,7 @@ export const sidebarGroups: SidebarGroup[] = [
       { href: '/releases', label: 'Releases', icon: Disc3 },
       { href: '/labels', label: 'Labels', icon: Tag },
       { href: '/tags', label: 'Tags', icon: Tags },
+      { href: '/scenes', label: 'Scenes', icon: Globe },
       { href: '/collections', label: 'Collections', icon: LayoutList },
     ],
   },

--- a/frontend/features/scenes/components/SceneDetail.tsx
+++ b/frontend/features/scenes/components/SceneDetail.tsx
@@ -1,0 +1,213 @@
+'use client'
+
+import Link from 'next/link'
+import {
+  MapPin, Building2, Mic2, Calendar, Tent, ArrowRight, Loader2,
+} from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { useSceneDetail, useSceneArtists } from '../hooks'
+import { ScenePulse } from './ScenePulse'
+
+interface SceneDetailProps {
+  slug: string
+}
+
+function SceneArtistsList({ slug }: { slug: string }) {
+  const { data, isLoading } = useSceneArtists({ slug, limit: 10 })
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-4">
+        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  if (!data?.artists || data.artists.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground py-2">
+        No active artists in the last 90 days.
+      </p>
+    )
+  }
+
+  return (
+    <div className="space-y-1.5">
+      {data.artists.map((artist) => (
+        <Link
+          key={artist.id}
+          href={`/artists/${artist.slug}`}
+          className="flex items-center justify-between rounded-md px-3 py-2 text-sm transition-colors hover:bg-muted/50"
+        >
+          <div className="flex items-center gap-2 min-w-0">
+            <Mic2 className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+            <span className="truncate font-medium">{artist.name}</span>
+          </div>
+          <Badge variant="secondary" className="ml-2 shrink-0 text-xs">
+            {artist.show_count} show{artist.show_count !== 1 ? 's' : ''}
+          </Badge>
+        </Link>
+      ))}
+      {data.total > 10 && (
+        <p className="text-xs text-muted-foreground px-3 pt-1">
+          and {data.total - 10} more artist{data.total - 10 !== 1 ? 's' : ''}
+        </p>
+      )}
+    </div>
+  )
+}
+
+export function SceneDetailView({ slug }: SceneDetailProps) {
+  const { data: scene, isLoading, error } = useSceneDetail(slug)
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  if (error || !scene) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <div className="text-center">
+          <MapPin className="h-12 w-12 mx-auto text-muted-foreground/50 mb-4" />
+          <h1 className="text-2xl font-bold mb-2">Scene not found</h1>
+          <p className="text-muted-foreground text-sm mb-4">
+            This scene page doesn&apos;t exist or there isn&apos;t enough activity yet.
+          </p>
+          <Link
+            href="/scenes"
+            className="text-sm text-primary hover:underline"
+          >
+            Browse all scenes
+          </Link>
+        </div>
+      </div>
+    )
+  }
+
+  const { stats } = scene
+  const statParts = [
+    stats.venue_count > 0 && `${stats.venue_count} venue${stats.venue_count !== 1 ? 's' : ''}`,
+    stats.artist_count > 0 && `${stats.artist_count} artist${stats.artist_count !== 1 ? 's' : ''}`,
+    stats.upcoming_show_count > 0 && `${stats.upcoming_show_count} upcoming show${stats.upcoming_show_count !== 1 ? 's' : ''}`,
+  ].filter(Boolean)
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <div className="flex items-center gap-2 text-sm text-muted-foreground mb-1">
+          <Link href="/scenes" className="hover:text-foreground transition-colors">
+            Scenes
+          </Link>
+          <span>/</span>
+        </div>
+        <h1 className="text-3xl font-bold">
+          {scene.city}, {scene.state}
+        </h1>
+        {statParts.length > 0 && (
+          <p className="text-muted-foreground mt-1">
+            {statParts.join(' \u00B7 ')}
+          </p>
+        )}
+        {scene.description && (
+          <p className="text-muted-foreground mt-3 max-w-2xl">
+            {scene.description}
+          </p>
+        )}
+      </div>
+
+      {/* Scene Pulse */}
+      <ScenePulse pulse={scene.pulse} />
+
+      {/* Content sections */}
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        {/* Upcoming Shows */}
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="flex items-center gap-2 text-base">
+              <Calendar className="h-4 w-4 text-muted-foreground" />
+              Upcoming Shows
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-muted-foreground mb-3">
+              {stats.upcoming_show_count} show{stats.upcoming_show_count !== 1 ? 's' : ''} coming up in {scene.city}.
+            </p>
+            <Link
+              href={`/shows?city=${encodeURIComponent(scene.city)}&state=${encodeURIComponent(scene.state)}`}
+              className="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
+            >
+              View upcoming shows
+              <ArrowRight className="h-3.5 w-3.5" />
+            </Link>
+          </CardContent>
+        </Card>
+
+        {/* Top Venues */}
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="flex items-center gap-2 text-base">
+              <Building2 className="h-4 w-4 text-muted-foreground" />
+              Venues
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-muted-foreground mb-3">
+              {stats.venue_count} venue{stats.venue_count !== 1 ? 's' : ''} in {scene.city}.
+            </p>
+            <Link
+              href={`/venues?city=${encodeURIComponent(scene.city)}&state=${encodeURIComponent(scene.state)}`}
+              className="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
+            >
+              View all venues
+              <ArrowRight className="h-3.5 w-3.5" />
+            </Link>
+          </CardContent>
+        </Card>
+
+        {/* Active Artists */}
+        <Card className="lg:col-span-2">
+          <CardHeader className="pb-3">
+            <CardTitle className="flex items-center gap-2 text-base">
+              <Mic2 className="h-4 w-4 text-muted-foreground" />
+              Active Artists
+              <span className="text-xs font-normal text-muted-foreground">(last 90 days)</span>
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <SceneArtistsList slug={slug} />
+          </CardContent>
+        </Card>
+
+        {/* Festivals (only show if there are festivals) */}
+        {stats.festival_count > 0 && (
+          <Card className="lg:col-span-2">
+            <CardHeader className="pb-3">
+              <CardTitle className="flex items-center gap-2 text-base">
+                <Tent className="h-4 w-4 text-muted-foreground" />
+                Festivals
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-muted-foreground mb-3">
+                {stats.festival_count} festival{stats.festival_count !== 1 ? 's' : ''} in {scene.city}.
+              </p>
+              <Link
+                href="/festivals"
+                className="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
+              >
+                View festivals
+                <ArrowRight className="h-3.5 w-3.5" />
+              </Link>
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/features/scenes/components/SceneList.tsx
+++ b/frontend/features/scenes/components/SceneList.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import Link from 'next/link'
+import { MapPin, Building2, Calendar } from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { LoadingSpinner } from '@/components/shared'
+import { useScenes } from '../hooks'
+
+export function SceneList() {
+  const { data, isLoading, error } = useScenes()
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center items-center py-12">
+        <LoadingSpinner />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-muted-foreground">
+          Failed to load scenes. Please try again later.
+        </p>
+      </div>
+    )
+  }
+
+  if (!data?.scenes || data.scenes.length === 0) {
+    return (
+      <div className="text-center py-12">
+        <MapPin className="h-12 w-12 mx-auto text-muted-foreground/50 mb-4" />
+        <h2 className="text-lg font-medium mb-2">No scenes yet</h2>
+        <p className="text-muted-foreground text-sm max-w-md mx-auto">
+          Scene pages appear for cities with enough venue and show activity.
+          Check back as the community grows.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {data.scenes.map((scene) => (
+        <Link key={scene.slug} href={`/scenes/${scene.slug}`}>
+          <Card className="h-full transition-colors hover:bg-muted/50 cursor-pointer">
+            <CardHeader className="pb-2">
+              <CardTitle className="flex items-center gap-2 text-lg">
+                <MapPin className="h-4 w-4 text-muted-foreground" />
+                {scene.city}, {scene.state}
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="flex items-center gap-4 text-sm text-muted-foreground">
+                <span className="flex items-center gap-1.5">
+                  <Building2 className="h-3.5 w-3.5" />
+                  {scene.venue_count} venue{scene.venue_count !== 1 ? 's' : ''}
+                </span>
+                <span className="flex items-center gap-1.5">
+                  <Calendar className="h-3.5 w-3.5" />
+                  {scene.upcoming_show_count} upcoming show{scene.upcoming_show_count !== 1 ? 's' : ''}
+                </span>
+              </div>
+            </CardContent>
+          </Card>
+        </Link>
+      ))}
+    </div>
+  )
+}

--- a/frontend/features/scenes/components/ScenePulse.tsx
+++ b/frontend/features/scenes/components/ScenePulse.tsx
@@ -1,0 +1,141 @@
+'use client'
+
+import { TrendingUp, TrendingDown, Minus, Users, Building2, Calendar } from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import type { ScenePulse as ScenePulseData } from '../types'
+
+interface ScenePulseProps {
+  pulse: ScenePulseData
+}
+
+/**
+ * Get abbreviated month label for N months ago from today
+ */
+function getMonthLabel(monthsAgo: number): string {
+  const date = new Date()
+  date.setMonth(date.getMonth() - monthsAgo)
+  return date.toLocaleString('default', { month: 'short' })
+}
+
+/**
+ * Simple sparkline bar chart using CSS
+ */
+function Sparkline({ data }: { data: number[] }) {
+  const max = Math.max(...data, 1) // Avoid division by zero
+  // shows_by_month is last 6 months, index 0 = oldest
+  const months = data.map((value, i) => ({
+    value,
+    label: getMonthLabel(data.length - 1 - i),
+    height: (value / max) * 100,
+  }))
+
+  return (
+    <div className="flex items-end gap-1.5 h-24 mt-2">
+      {months.map((month, i) => (
+        <div key={i} className="flex flex-col items-center gap-1 flex-1 min-w-0">
+          <div className="w-full flex flex-col items-center justify-end h-[72px]">
+            <span className="text-[10px] text-muted-foreground mb-1">
+              {month.value > 0 ? month.value : ''}
+            </span>
+            <div
+              className="w-full max-w-[28px] rounded-sm bg-primary/80 transition-all"
+              style={{ height: `${Math.max(month.height, 2)}%` }}
+            />
+          </div>
+          <span className="text-[10px] text-muted-foreground truncate">
+            {month.label}
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function TrendIndicator({ trend }: { trend: number }) {
+  if (trend > 0) {
+    return (
+      <span className="inline-flex items-center gap-1 text-sm font-medium text-green-500">
+        <TrendingUp className="h-4 w-4" />
+        +{trend}
+      </span>
+    )
+  }
+  if (trend < 0) {
+    return (
+      <span className="inline-flex items-center gap-1 text-sm font-medium text-red-500">
+        <TrendingDown className="h-4 w-4" />
+        {trend}
+      </span>
+    )
+  }
+  return (
+    <span className="inline-flex items-center gap-1 text-sm font-medium text-muted-foreground">
+      <Minus className="h-4 w-4" />
+      0
+    </span>
+  )
+}
+
+export function ScenePulse({ pulse }: ScenePulseProps) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base">Scene Pulse</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-3 gap-4 mb-4">
+          {/* Shows this month */}
+          <div>
+            <div className="flex items-center gap-1.5 text-sm text-muted-foreground mb-1">
+              <Calendar className="h-3.5 w-3.5" />
+              Shows this month
+            </div>
+            <div className="flex items-baseline gap-2">
+              <span className="text-2xl font-bold">{pulse.shows_this_month}</span>
+              <TrendIndicator trend={pulse.shows_trend} />
+            </div>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              vs {pulse.shows_prev_month} last month
+            </p>
+          </div>
+
+          {/* New artists */}
+          <div>
+            <div className="flex items-center gap-1.5 text-sm text-muted-foreground mb-1">
+              <Users className="h-3.5 w-3.5" />
+              New artists
+            </div>
+            <div className="flex items-baseline gap-2">
+              <span className="text-2xl font-bold">{pulse.new_artists_30d}</span>
+            </div>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              past 30 days
+            </p>
+          </div>
+
+          {/* Active venues */}
+          <div>
+            <div className="flex items-center gap-1.5 text-sm text-muted-foreground mb-1">
+              <Building2 className="h-3.5 w-3.5" />
+              Active venues
+            </div>
+            <div className="flex items-baseline gap-2">
+              <span className="text-2xl font-bold">{pulse.active_venues_this_month}</span>
+            </div>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              this month
+            </p>
+          </div>
+        </div>
+
+        {/* Sparkline */}
+        {pulse.shows_by_month && pulse.shows_by_month.length > 0 && (
+          <div className="border-t border-border/50 pt-3">
+            <p className="text-xs text-muted-foreground mb-1">Shows per month (last 6 months)</p>
+            <Sparkline data={pulse.shows_by_month} />
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/features/scenes/components/index.ts
+++ b/frontend/features/scenes/components/index.ts
@@ -1,0 +1,3 @@
+export { SceneList } from './SceneList'
+export { ScenePulse } from './ScenePulse'
+export { SceneDetailView } from './SceneDetail'

--- a/frontend/features/scenes/hooks/index.ts
+++ b/frontend/features/scenes/hooks/index.ts
@@ -1,0 +1,5 @@
+export {
+  useScenes,
+  useSceneDetail,
+  useSceneArtists,
+} from './useScenes'

--- a/frontend/features/scenes/hooks/useScenes.ts
+++ b/frontend/features/scenes/hooks/useScenes.ts
@@ -1,0 +1,82 @@
+'use client'
+
+/**
+ * Scenes Hooks
+ *
+ * TanStack Query hooks for fetching scene data from the API.
+ */
+
+import { useQuery } from '@tanstack/react-query'
+import { apiRequest, API_ENDPOINTS } from '@/lib/api'
+import { queryKeys } from '@/lib/queryClient'
+import type {
+  SceneListResponse,
+  SceneDetail,
+  SceneArtistsResponse,
+} from '../types'
+
+/**
+ * Hook to fetch the list of scenes (cities meeting the threshold)
+ */
+export function useScenes() {
+  return useQuery({
+    queryKey: queryKeys.scenes.list,
+    queryFn: async (): Promise<SceneListResponse> => {
+      return apiRequest<SceneListResponse>(API_ENDPOINTS.SCENES.LIST, {
+        method: 'GET',
+      })
+    },
+    staleTime: 10 * 60 * 1000, // 10 minutes — scenes don't change often
+  })
+}
+
+/**
+ * Hook to fetch detail for a single scene by slug
+ */
+export function useSceneDetail(slug: string) {
+  return useQuery({
+    queryKey: queryKeys.scenes.detail(slug),
+    queryFn: async (): Promise<SceneDetail> => {
+      return apiRequest<SceneDetail>(API_ENDPOINTS.SCENES.DETAIL(slug), {
+        method: 'GET',
+      })
+    },
+    enabled: Boolean(slug),
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  })
+}
+
+interface UseSceneArtistsOptions {
+  slug: string
+  period?: number
+  limit?: number
+  offset?: number
+}
+
+/**
+ * Hook to fetch active artists for a scene
+ */
+export function useSceneArtists(options: UseSceneArtistsOptions) {
+  const { slug, period = 90, limit = 20, offset = 0 } = options
+
+  const params = new URLSearchParams()
+  if (period) params.set('period', period.toString())
+  if (limit) params.set('limit', limit.toString())
+  if (offset) params.set('offset', offset.toString())
+
+  const queryString = params.toString()
+  const endpoint = queryString
+    ? `${API_ENDPOINTS.SCENES.ARTISTS(slug)}?${queryString}`
+    : API_ENDPOINTS.SCENES.ARTISTS(slug)
+
+  return useQuery({
+    queryKey: queryKeys.scenes.artists(slug, period),
+    queryFn: async (): Promise<SceneArtistsResponse> => {
+      return apiRequest<SceneArtistsResponse>(endpoint, {
+        method: 'GET',
+      })
+    },
+    enabled: Boolean(slug),
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  })
+}

--- a/frontend/features/scenes/index.ts
+++ b/frontend/features/scenes/index.ts
@@ -1,0 +1,23 @@
+// Public API for the scenes feature module.
+// Other features should import from '@/features/scenes', not from internal paths.
+
+// Types
+export type {
+  SceneListItem,
+  SceneListResponse,
+  SceneStats,
+  ScenePulse,
+  SceneDetail,
+  SceneArtist,
+  SceneArtistsResponse,
+} from './types'
+
+// Hooks
+export {
+  useScenes,
+  useSceneDetail,
+  useSceneArtists,
+} from './hooks'
+
+// Components
+export { SceneList, ScenePulse as ScenePulseCard, SceneDetailView } from './components'

--- a/frontend/features/scenes/types.ts
+++ b/frontend/features/scenes/types.ts
@@ -1,0 +1,58 @@
+/**
+ * Scene-related TypeScript types
+ *
+ * These types match the backend API response structures
+ * from backend/internal/services/catalog/scene_service.go
+ */
+
+export interface SceneListItem {
+  city: string
+  state: string
+  slug: string
+  venue_count: number
+  upcoming_show_count: number
+}
+
+export interface SceneListResponse {
+  scenes: SceneListItem[]
+  count: number
+}
+
+export interface SceneStats {
+  venue_count: number
+  artist_count: number
+  upcoming_show_count: number
+  festival_count: number
+}
+
+export interface ScenePulse {
+  shows_this_month: number
+  shows_prev_month: number
+  shows_trend: number
+  new_artists_30d: number
+  active_venues_this_month: number
+  shows_by_month: number[]
+}
+
+export interface SceneDetail {
+  city: string
+  state: string
+  slug: string
+  description: string | null
+  stats: SceneStats
+  pulse: ScenePulse
+}
+
+export interface SceneArtist {
+  id: number
+  slug: string
+  name: string
+  city: string
+  state: string
+  show_count: number
+}
+
+export interface SceneArtistsResponse {
+  artists: SceneArtist[]
+  total: number
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -381,6 +381,13 @@ export const API_ENDPOINTS = {
       `${API_BASE_URL}/admin/revisions/${revisionId}/rollback`,
   },
 
+  // Scene endpoints
+  SCENES: {
+    LIST: `${API_BASE_URL}/scenes`,
+    DETAIL: (slug: string) => `${API_BASE_URL}/scenes/${slug}`,
+    ARTISTS: (slug: string) => `${API_BASE_URL}/scenes/${slug}/artists`,
+  },
+
   // System endpoints
   HEALTH: `${API_BASE_URL}/health`,
   OPENAPI: `${API_BASE_URL}/openapi.json`,

--- a/frontend/lib/queryClient.ts
+++ b/frontend/lib/queryClient.ts
@@ -303,6 +303,14 @@ export const queryKeys = {
     entityTags: (entityType: string, entityId: number) => ['tags', 'entityTags', entityType, entityId] as const,
   },
 
+  // Scene queries
+  scenes: {
+    all: ['scenes'] as const,
+    list: ['scenes', 'list'] as const,
+    detail: (slug: string) => ['scenes', 'detail', slug] as const,
+    artists: (slug: string, period?: number) => ['scenes', 'artists', slug, period] as const,
+  },
+
   // Revision history queries
   revisions: {
     all: ['revisions'] as const,
@@ -406,6 +414,10 @@ export const createInvalidateQueries = (queryClient: QueryClient) => ({
   // Invalidate entity tag queries
   entityTags: (entityType: string, entityId: number) =>
     queryClient.invalidateQueries({ queryKey: ['tags', 'entityTags', entityType, entityId] }),
+
+  // Invalidate scene queries
+  scenes: () =>
+    queryClient.invalidateQueries({ queryKey: ['scenes'] }),
 
   // Invalidate revision queries
   revisions: () =>


### PR DESCRIPTION
## Summary
- **Scene list page** (`/scenes`): card grid of cities meeting activity thresholds
- **Scene detail page** (`/scenes/{slug}`): full city landing page with Scene Pulse metrics, upcoming shows, venues, active artists, festivals
- **Scene Pulse card**: shows/month with trend arrow, new artists (30d), active venues, 6-month sparkline bar chart (CSS-only, no chart library)
- **Navigation**: "Scenes" added to sidebar (Globe icon) and Cmd+K command palette

## New feature module: `features/scenes/`
- 7 TypeScript types matching backend API
- 3 TanStack Query hooks (`useScenes`, `useSceneDetail`, `useSceneArtists`)
- 3 components (`SceneList`, `SceneDetailView`, `ScenePulse`)
- Barrel exports via `index.ts`

## Test plan
- [x] `bun run build` passes
- [x] All 1403 frontend tests pass
- [x] No backend files modified
- [ ] Manual: navigate to `/scenes`, click into a scene, verify pulse metrics

Closes PSY-60

🤖 Generated with [Claude Code](https://claude.com/claude-code)