### PR TITLE
Add going/interested attendance backend

### DIFF
--- a/backend/internal/api/handlers/attendance.go
+++ b/backend/internal/api/handlers/attendance.go
@@ -1,0 +1,408 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"psychic-homily-backend/internal/api/middleware"
+	"psychic-homily-backend/internal/logger"
+	"psychic-homily-backend/internal/services"
+)
+
+// AttendanceHandler handles show attendance (going/interested) HTTP requests.
+type AttendanceHandler struct {
+	attendanceService services.AttendanceServiceInterface
+}
+
+// NewAttendanceHandler creates a new attendance handler.
+func NewAttendanceHandler(attendanceService services.AttendanceServiceInterface) *AttendanceHandler {
+	return &AttendanceHandler{attendanceService: attendanceService}
+}
+
+// ──────────────────────────────────────────────
+// Request / Response types
+// ──────────────────────────────────────────────
+
+// SetAttendanceRequest is the request for POST /shows/{show_id}/attendance
+type SetAttendanceRequest struct {
+	ShowID string `path:"show_id" validate:"required" doc:"Show ID"`
+	Body   struct {
+		Status string `json:"status" doc:"Attendance status: going, interested, or empty string to clear"`
+	}
+}
+
+// SetAttendanceResponse is the response for POST /shows/{show_id}/attendance
+type SetAttendanceResponse struct {
+	Body struct {
+		Success bool   `json:"success"`
+		Message string `json:"message"`
+	}
+}
+
+// RemoveAttendanceRequest is the request for DELETE /shows/{show_id}/attendance
+type RemoveAttendanceRequest struct {
+	ShowID string `path:"show_id" validate:"required" doc:"Show ID"`
+}
+
+// RemoveAttendanceResponse is the response for DELETE /shows/{show_id}/attendance
+type RemoveAttendanceResponse struct {
+	Body struct {
+		Success bool   `json:"success"`
+		Message string `json:"message"`
+	}
+}
+
+// GetAttendanceRequest is the request for GET /shows/{show_id}/attendance
+type GetAttendanceRequest struct {
+	ShowID string `path:"show_id" validate:"required" doc:"Show ID"`
+}
+
+// GetAttendanceResponse is the response for GET /shows/{show_id}/attendance
+type GetAttendanceResponse struct {
+	Body struct {
+		ShowID          uint   `json:"show_id"`
+		GoingCount      int    `json:"going_count"`
+		InterestedCount int    `json:"interested_count"`
+		UserStatus      string `json:"user_status,omitempty"`
+	}
+}
+
+// BatchAttendanceRequest is the request for POST /shows/attendance/batch
+type BatchAttendanceRequest struct {
+	Body struct {
+		ShowIDs []int `json:"show_ids" validate:"required,max=100" doc:"List of show IDs (max 100)"`
+	}
+}
+
+// BatchAttendanceEntry represents a single show's attendance data in a batch response
+type BatchAttendanceEntry struct {
+	GoingCount      int    `json:"going_count"`
+	InterestedCount int    `json:"interested_count"`
+	UserStatus      string `json:"user_status,omitempty"`
+}
+
+// BatchAttendanceResponse is the response for POST /shows/attendance/batch
+type BatchAttendanceResponse struct {
+	Body struct {
+		Attendance map[string]*BatchAttendanceEntry `json:"attendance"`
+	}
+}
+
+// GetMyShowsRequest is the request for GET /attendance/my-shows
+type GetMyShowsRequest struct {
+	Status string `query:"status" default:"all" doc:"Filter: going, interested, or all"`
+	Limit  int    `query:"limit" default:"20" doc:"Number of shows per page"`
+	Offset int    `query:"offset" default:"0" doc:"Offset for pagination"`
+}
+
+// GetMyShowsResponse is the response for GET /attendance/my-shows
+type GetMyShowsResponse struct {
+	Body struct {
+		Shows  []*services.AttendingShowResponse `json:"shows"`
+		Total  int64                             `json:"total"`
+		Limit  int                               `json:"limit"`
+		Offset int                               `json:"offset"`
+	}
+}
+
+// ──────────────────────────────────────────────
+// Handlers
+// ──────────────────────────────────────────────
+
+// SetAttendanceHandler handles POST /shows/{show_id}/attendance
+func (h *AttendanceHandler) SetAttendanceHandler(ctx context.Context, req *SetAttendanceRequest) (*SetAttendanceResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	showID, err := strconv.ParseUint(req.ShowID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid show ID")
+	}
+
+	status := req.Body.Status
+	if status != "going" && status != "interested" && status != "" {
+		return nil, huma.Error400BadRequest("Status must be 'going', 'interested', or empty string")
+	}
+
+	logger.FromContext(ctx).Debug("set_attendance_attempt",
+		"user_id", user.ID,
+		"show_id", showID,
+		"status", status,
+	)
+
+	if err := h.attendanceService.SetAttendance(user.ID, uint(showID), status); err != nil {
+		logger.FromContext(ctx).Error("set_attendance_failed",
+			"user_id", user.ID,
+			"show_id", showID,
+			"status", status,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		if err.Error() == "show not found" {
+			return nil, huma.Error404NotFound("Show not found")
+		}
+		return nil, huma.Error422UnprocessableEntity(
+			fmt.Sprintf("Failed to set attendance (request_id: %s)", requestID),
+		)
+	}
+
+	msg := "Attendance cleared"
+	if status != "" {
+		msg = fmt.Sprintf("Marked as %s", status)
+	}
+
+	logger.FromContext(ctx).Info("set_attendance_success",
+		"user_id", user.ID,
+		"show_id", showID,
+		"status", status,
+		"request_id", requestID,
+	)
+
+	return &SetAttendanceResponse{
+		Body: struct {
+			Success bool   `json:"success"`
+			Message string `json:"message"`
+		}{
+			Success: true,
+			Message: msg,
+		},
+	}, nil
+}
+
+// RemoveAttendanceHandler handles DELETE /shows/{show_id}/attendance
+func (h *AttendanceHandler) RemoveAttendanceHandler(ctx context.Context, req *RemoveAttendanceRequest) (*RemoveAttendanceResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	showID, err := strconv.ParseUint(req.ShowID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid show ID")
+	}
+
+	logger.FromContext(ctx).Debug("remove_attendance_attempt",
+		"user_id", user.ID,
+		"show_id", showID,
+	)
+
+	if err := h.attendanceService.RemoveAttendance(user.ID, uint(showID)); err != nil {
+		logger.FromContext(ctx).Error("remove_attendance_failed",
+			"user_id", user.ID,
+			"show_id", showID,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error422UnprocessableEntity(
+			fmt.Sprintf("Failed to remove attendance (request_id: %s)", requestID),
+		)
+	}
+
+	logger.FromContext(ctx).Info("remove_attendance_success",
+		"user_id", user.ID,
+		"show_id", showID,
+		"request_id", requestID,
+	)
+
+	return &RemoveAttendanceResponse{
+		Body: struct {
+			Success bool   `json:"success"`
+			Message string `json:"message"`
+		}{
+			Success: true,
+			Message: "Attendance removed",
+		},
+	}, nil
+}
+
+// GetAttendanceHandler handles GET /shows/{show_id}/attendance
+// Uses optional auth: if authenticated, includes user's status.
+func (h *AttendanceHandler) GetAttendanceHandler(ctx context.Context, req *GetAttendanceRequest) (*GetAttendanceResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	showID, err := strconv.ParseUint(req.ShowID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid show ID")
+	}
+
+	counts, err := h.attendanceService.GetAttendanceCounts(uint(showID))
+	if err != nil {
+		logger.FromContext(ctx).Error("get_attendance_counts_failed",
+			"show_id", showID,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to get attendance counts (request_id: %s)", requestID),
+		)
+	}
+
+	resp := &GetAttendanceResponse{}
+	resp.Body.ShowID = uint(showID)
+	resp.Body.GoingCount = counts.GoingCount
+	resp.Body.InterestedCount = counts.InterestedCount
+
+	// If user is authenticated, include their status
+	user := middleware.GetUserFromContext(ctx)
+	if user != nil {
+		userStatus, err := h.attendanceService.GetUserAttendance(user.ID, uint(showID))
+		if err != nil {
+			logger.FromContext(ctx).Warn("get_user_attendance_failed",
+				"user_id", user.ID,
+				"show_id", showID,
+				"error", err.Error(),
+			)
+			// Non-fatal — still return counts
+		} else {
+			resp.Body.UserStatus = userStatus
+		}
+	}
+
+	return resp, nil
+}
+
+// BatchAttendanceHandler handles POST /shows/attendance/batch
+// Uses optional auth: if authenticated, includes user's status for each show.
+func (h *AttendanceHandler) BatchAttendanceHandler(ctx context.Context, req *BatchAttendanceRequest) (*BatchAttendanceResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	if len(req.Body.ShowIDs) == 0 {
+		resp := &BatchAttendanceResponse{}
+		resp.Body.Attendance = make(map[string]*BatchAttendanceEntry)
+		return resp, nil
+	}
+
+	if len(req.Body.ShowIDs) > 100 {
+		return nil, huma.Error400BadRequest("Maximum 100 show IDs allowed")
+	}
+
+	// Convert to []uint and validate
+	showIDs := make([]uint, len(req.Body.ShowIDs))
+	for i, id := range req.Body.ShowIDs {
+		if id <= 0 {
+			return nil, huma.Error400BadRequest("Invalid show ID")
+		}
+		showIDs[i] = uint(id)
+	}
+
+	// Get counts
+	countsMap, err := h.attendanceService.GetBatchAttendanceCounts(showIDs)
+	if err != nil {
+		logger.FromContext(ctx).Error("batch_attendance_counts_failed",
+			"count", len(showIDs),
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to get attendance counts (request_id: %s)", requestID),
+		)
+	}
+
+	// Build response
+	attendance := make(map[string]*BatchAttendanceEntry, len(showIDs))
+	for id, counts := range countsMap {
+		attendance[strconv.FormatUint(uint64(id), 10)] = &BatchAttendanceEntry{
+			GoingCount:      counts.GoingCount,
+			InterestedCount: counts.InterestedCount,
+		}
+	}
+
+	// If user is authenticated, include their statuses
+	user := middleware.GetUserFromContext(ctx)
+	if user != nil {
+		userStatuses, err := h.attendanceService.GetBatchUserAttendance(user.ID, showIDs)
+		if err != nil {
+			logger.FromContext(ctx).Warn("batch_user_attendance_failed",
+				"user_id", user.ID,
+				"count", len(showIDs),
+				"error", err.Error(),
+			)
+			// Non-fatal — still return counts
+		} else {
+			for showID, status := range userStatuses {
+				key := strconv.FormatUint(uint64(showID), 10)
+				if entry, ok := attendance[key]; ok {
+					entry.UserStatus = status
+				}
+			}
+		}
+	}
+
+	resp := &BatchAttendanceResponse{}
+	resp.Body.Attendance = attendance
+	return resp, nil
+}
+
+// GetMyShowsHandler handles GET /attendance/my-shows
+func (h *AttendanceHandler) GetMyShowsHandler(ctx context.Context, req *GetMyShowsRequest) (*GetMyShowsResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	// Validate status filter
+	status := req.Status
+	if status != "going" && status != "interested" && status != "all" && status != "" {
+		return nil, huma.Error400BadRequest("Status must be 'going', 'interested', or 'all'")
+	}
+	if status == "" {
+		status = "all"
+	}
+
+	// Clamp pagination
+	limit := req.Limit
+	if limit < 1 {
+		limit = 20
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	offset := req.Offset
+	if offset < 0 {
+		offset = 0
+	}
+
+	logger.FromContext(ctx).Debug("get_my_shows_attempt",
+		"user_id", user.ID,
+		"status", status,
+		"limit", limit,
+		"offset", offset,
+	)
+
+	shows, total, err := h.attendanceService.GetUserAttendingShows(user.ID, status, limit, offset)
+	if err != nil {
+		logger.FromContext(ctx).Error("get_my_shows_failed",
+			"user_id", user.ID,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to get attending shows (request_id: %s)", requestID),
+		)
+	}
+
+	return &GetMyShowsResponse{
+		Body: struct {
+			Shows  []*services.AttendingShowResponse `json:"shows"`
+			Total  int64                             `json:"total"`
+			Limit  int                               `json:"limit"`
+			Offset int                               `json:"offset"`
+		}{
+			Shows:  shows,
+			Total:  total,
+			Limit:  limit,
+			Offset: offset,
+		},
+	}, nil
+}

--- a/backend/internal/api/handlers/attendance_test.go
+++ b/backend/internal/api/handlers/attendance_test.go
@@ -1,0 +1,533 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services"
+)
+
+func testAttendanceHandler() *AttendanceHandler {
+	return NewAttendanceHandler(nil)
+}
+
+// --- NewAttendanceHandler ---
+
+func TestNewAttendanceHandler(t *testing.T) {
+	h := testAttendanceHandler()
+	if h == nil {
+		t.Fatal("expected non-nil AttendanceHandler")
+	}
+}
+
+// --- SetAttendanceHandler ---
+
+func TestSetAttendanceHandler_NoAuth(t *testing.T) {
+	h := testAttendanceHandler()
+	req := &SetAttendanceRequest{ShowID: "1"}
+	req.Body.Status = "going"
+
+	_, err := h.SetAttendanceHandler(context.Background(), req)
+	assertHumaError(t, err, 401)
+}
+
+func TestSetAttendanceHandler_InvalidID(t *testing.T) {
+	h := testAttendanceHandler()
+	ctx := ctxWithUser(&models.User{ID: 1})
+	req := &SetAttendanceRequest{ShowID: "abc"}
+	req.Body.Status = "going"
+
+	_, err := h.SetAttendanceHandler(ctx, req)
+	assertHumaError(t, err, 400)
+}
+
+func TestSetAttendanceHandler_InvalidStatus(t *testing.T) {
+	h := NewAttendanceHandler(&mockAttendanceService{})
+	ctx := ctxWithUser(&models.User{ID: 1})
+	req := &SetAttendanceRequest{ShowID: "42"}
+	req.Body.Status = "maybe"
+
+	_, err := h.SetAttendanceHandler(ctx, req)
+	assertHumaError(t, err, 400)
+}
+
+func TestSetAttendanceHandler_Going_Success(t *testing.T) {
+	mock := &mockAttendanceService{
+		setAttendanceFn: func(userID, showID uint, status string) error {
+			if userID != 1 || showID != 42 || status != "going" {
+				t.Errorf("unexpected args: userID=%d, showID=%d, status=%s", userID, showID, status)
+			}
+			return nil
+		},
+	}
+	h := NewAttendanceHandler(mock)
+	ctx := ctxWithUser(&models.User{ID: 1})
+	req := &SetAttendanceRequest{ShowID: "42"}
+	req.Body.Status = "going"
+
+	resp, err := h.SetAttendanceHandler(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.Body.Success {
+		t.Error("expected success=true")
+	}
+}
+
+func TestSetAttendanceHandler_Interested_Success(t *testing.T) {
+	mock := &mockAttendanceService{
+		setAttendanceFn: func(_, _ uint, status string) error {
+			if status != "interested" {
+				t.Errorf("expected status=interested, got %s", status)
+			}
+			return nil
+		},
+	}
+	h := NewAttendanceHandler(mock)
+	ctx := ctxWithUser(&models.User{ID: 1})
+	req := &SetAttendanceRequest{ShowID: "42"}
+	req.Body.Status = "interested"
+
+	resp, err := h.SetAttendanceHandler(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.Body.Success {
+		t.Error("expected success=true")
+	}
+}
+
+func TestSetAttendanceHandler_Clear_Success(t *testing.T) {
+	mock := &mockAttendanceService{
+		setAttendanceFn: func(_, _ uint, status string) error {
+			if status != "" {
+				t.Errorf("expected empty status, got %s", status)
+			}
+			return nil
+		},
+	}
+	h := NewAttendanceHandler(mock)
+	ctx := ctxWithUser(&models.User{ID: 1})
+	req := &SetAttendanceRequest{ShowID: "42"}
+	req.Body.Status = ""
+
+	resp, err := h.SetAttendanceHandler(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.Body.Success {
+		t.Error("expected success=true")
+	}
+}
+
+func TestSetAttendanceHandler_ShowNotFound(t *testing.T) {
+	mock := &mockAttendanceService{
+		setAttendanceFn: func(_, _ uint, _ string) error {
+			return fmt.Errorf("show not found")
+		},
+	}
+	h := NewAttendanceHandler(mock)
+	ctx := ctxWithUser(&models.User{ID: 1})
+	req := &SetAttendanceRequest{ShowID: "999"}
+	req.Body.Status = "going"
+
+	_, err := h.SetAttendanceHandler(ctx, req)
+	assertHumaError(t, err, 404)
+}
+
+func TestSetAttendanceHandler_ServiceError(t *testing.T) {
+	mock := &mockAttendanceService{
+		setAttendanceFn: func(_, _ uint, _ string) error {
+			return fmt.Errorf("db error")
+		},
+	}
+	h := NewAttendanceHandler(mock)
+	ctx := ctxWithUser(&models.User{ID: 1})
+	req := &SetAttendanceRequest{ShowID: "42"}
+	req.Body.Status = "going"
+
+	_, err := h.SetAttendanceHandler(ctx, req)
+	assertHumaError(t, err, 422)
+}
+
+// --- RemoveAttendanceHandler ---
+
+func TestRemoveAttendanceHandler_NoAuth(t *testing.T) {
+	h := testAttendanceHandler()
+	req := &RemoveAttendanceRequest{ShowID: "1"}
+
+	_, err := h.RemoveAttendanceHandler(context.Background(), req)
+	assertHumaError(t, err, 401)
+}
+
+func TestRemoveAttendanceHandler_InvalidID(t *testing.T) {
+	h := testAttendanceHandler()
+	ctx := ctxWithUser(&models.User{ID: 1})
+	req := &RemoveAttendanceRequest{ShowID: "abc"}
+
+	_, err := h.RemoveAttendanceHandler(ctx, req)
+	assertHumaError(t, err, 400)
+}
+
+func TestRemoveAttendanceHandler_Success(t *testing.T) {
+	mock := &mockAttendanceService{
+		removeAttendanceFn: func(userID, showID uint) error {
+			if userID != 1 || showID != 42 {
+				t.Errorf("unexpected args: userID=%d, showID=%d", userID, showID)
+			}
+			return nil
+		},
+	}
+	h := NewAttendanceHandler(mock)
+	ctx := ctxWithUser(&models.User{ID: 1})
+	req := &RemoveAttendanceRequest{ShowID: "42"}
+
+	resp, err := h.RemoveAttendanceHandler(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.Body.Success {
+		t.Error("expected success=true")
+	}
+}
+
+func TestRemoveAttendanceHandler_ServiceError(t *testing.T) {
+	mock := &mockAttendanceService{
+		removeAttendanceFn: func(_, _ uint) error {
+			return fmt.Errorf("db error")
+		},
+	}
+	h := NewAttendanceHandler(mock)
+	ctx := ctxWithUser(&models.User{ID: 1})
+	req := &RemoveAttendanceRequest{ShowID: "42"}
+
+	_, err := h.RemoveAttendanceHandler(ctx, req)
+	assertHumaError(t, err, 422)
+}
+
+// --- GetAttendanceHandler ---
+
+func TestGetAttendanceHandler_InvalidID(t *testing.T) {
+	h := NewAttendanceHandler(&mockAttendanceService{})
+	req := &GetAttendanceRequest{ShowID: "abc"}
+
+	_, err := h.GetAttendanceHandler(context.Background(), req)
+	assertHumaError(t, err, 400)
+}
+
+func TestGetAttendanceHandler_Success_NoAuth(t *testing.T) {
+	mock := &mockAttendanceService{
+		getAttendanceCountsFn: func(showID uint) (*services.AttendanceCountsResponse, error) {
+			return &services.AttendanceCountsResponse{
+				ShowID:          showID,
+				GoingCount:      5,
+				InterestedCount: 10,
+			}, nil
+		},
+	}
+	h := NewAttendanceHandler(mock)
+	req := &GetAttendanceRequest{ShowID: "42"}
+
+	resp, err := h.GetAttendanceHandler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.GoingCount != 5 {
+		t.Errorf("expected going_count=5, got %d", resp.Body.GoingCount)
+	}
+	if resp.Body.InterestedCount != 10 {
+		t.Errorf("expected interested_count=10, got %d", resp.Body.InterestedCount)
+	}
+	if resp.Body.UserStatus != "" {
+		t.Errorf("expected empty user_status for unauthenticated, got %s", resp.Body.UserStatus)
+	}
+}
+
+func TestGetAttendanceHandler_Success_WithAuth(t *testing.T) {
+	mock := &mockAttendanceService{
+		getAttendanceCountsFn: func(showID uint) (*services.AttendanceCountsResponse, error) {
+			return &services.AttendanceCountsResponse{
+				ShowID:          showID,
+				GoingCount:      3,
+				InterestedCount: 7,
+			}, nil
+		},
+		getUserAttendanceFn: func(userID, showID uint) (string, error) {
+			return "going", nil
+		},
+	}
+	h := NewAttendanceHandler(mock)
+	ctx := ctxWithUser(&models.User{ID: 1})
+	req := &GetAttendanceRequest{ShowID: "42"}
+
+	resp, err := h.GetAttendanceHandler(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.GoingCount != 3 {
+		t.Errorf("expected going_count=3, got %d", resp.Body.GoingCount)
+	}
+	if resp.Body.UserStatus != "going" {
+		t.Errorf("expected user_status=going, got %s", resp.Body.UserStatus)
+	}
+}
+
+func TestGetAttendanceHandler_CountsError(t *testing.T) {
+	mock := &mockAttendanceService{
+		getAttendanceCountsFn: func(_ uint) (*services.AttendanceCountsResponse, error) {
+			return nil, fmt.Errorf("db error")
+		},
+	}
+	h := NewAttendanceHandler(mock)
+	req := &GetAttendanceRequest{ShowID: "42"}
+
+	_, err := h.GetAttendanceHandler(context.Background(), req)
+	assertHumaError(t, err, 500)
+}
+
+// --- BatchAttendanceHandler ---
+
+func TestBatchAttendanceHandler_EmptyList(t *testing.T) {
+	h := NewAttendanceHandler(&mockAttendanceService{})
+	req := &BatchAttendanceRequest{}
+	req.Body.ShowIDs = []int{}
+
+	resp, err := h.BatchAttendanceHandler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Body.Attendance) != 0 {
+		t.Errorf("expected empty map, got %v", resp.Body.Attendance)
+	}
+}
+
+func TestBatchAttendanceHandler_TooMany(t *testing.T) {
+	h := NewAttendanceHandler(&mockAttendanceService{})
+	req := &BatchAttendanceRequest{}
+	req.Body.ShowIDs = make([]int, 101)
+	for i := range req.Body.ShowIDs {
+		req.Body.ShowIDs[i] = i + 1
+	}
+
+	_, err := h.BatchAttendanceHandler(context.Background(), req)
+	assertHumaError(t, err, 400)
+}
+
+func TestBatchAttendanceHandler_NegativeID(t *testing.T) {
+	h := NewAttendanceHandler(&mockAttendanceService{})
+	req := &BatchAttendanceRequest{}
+	req.Body.ShowIDs = []int{1, -5, 3}
+
+	_, err := h.BatchAttendanceHandler(context.Background(), req)
+	assertHumaError(t, err, 400)
+}
+
+func TestBatchAttendanceHandler_Success_NoAuth(t *testing.T) {
+	mock := &mockAttendanceService{
+		getBatchCountsFn: func(showIDs []uint) (map[uint]*services.AttendanceCountsResponse, error) {
+			result := make(map[uint]*services.AttendanceCountsResponse)
+			for _, id := range showIDs {
+				result[id] = &services.AttendanceCountsResponse{
+					ShowID:          id,
+					GoingCount:      2,
+					InterestedCount: 3,
+				}
+			}
+			return result, nil
+		},
+	}
+	h := NewAttendanceHandler(mock)
+	req := &BatchAttendanceRequest{}
+	req.Body.ShowIDs = []int{1, 2}
+
+	resp, err := h.BatchAttendanceHandler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Body.Attendance) != 2 {
+		t.Errorf("expected 2 entries, got %d", len(resp.Body.Attendance))
+	}
+	entry := resp.Body.Attendance["1"]
+	if entry == nil {
+		t.Fatal("expected entry for show 1")
+	}
+	if entry.GoingCount != 2 {
+		t.Errorf("expected going_count=2, got %d", entry.GoingCount)
+	}
+	if entry.UserStatus != "" {
+		t.Errorf("expected empty user_status for unauthenticated, got %s", entry.UserStatus)
+	}
+}
+
+func TestBatchAttendanceHandler_Success_WithAuth(t *testing.T) {
+	mock := &mockAttendanceService{
+		getBatchCountsFn: func(showIDs []uint) (map[uint]*services.AttendanceCountsResponse, error) {
+			result := make(map[uint]*services.AttendanceCountsResponse)
+			for _, id := range showIDs {
+				result[id] = &services.AttendanceCountsResponse{ShowID: id}
+			}
+			return result, nil
+		},
+		getBatchUserAttendanceFn: func(userID uint, showIDs []uint) (map[uint]string, error) {
+			return map[uint]string{1: "going", 2: "interested"}, nil
+		},
+	}
+	h := NewAttendanceHandler(mock)
+	ctx := ctxWithUser(&models.User{ID: 1})
+	req := &BatchAttendanceRequest{}
+	req.Body.ShowIDs = []int{1, 2, 3}
+
+	resp, err := h.BatchAttendanceHandler(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Attendance["1"].UserStatus != "going" {
+		t.Errorf("expected user_status=going for show 1, got %s", resp.Body.Attendance["1"].UserStatus)
+	}
+	if resp.Body.Attendance["2"].UserStatus != "interested" {
+		t.Errorf("expected user_status=interested for show 2, got %s", resp.Body.Attendance["2"].UserStatus)
+	}
+	if resp.Body.Attendance["3"].UserStatus != "" {
+		t.Errorf("expected empty user_status for show 3, got %s", resp.Body.Attendance["3"].UserStatus)
+	}
+}
+
+func TestBatchAttendanceHandler_CountsError(t *testing.T) {
+	mock := &mockAttendanceService{
+		getBatchCountsFn: func(_ []uint) (map[uint]*services.AttendanceCountsResponse, error) {
+			return nil, fmt.Errorf("db error")
+		},
+	}
+	h := NewAttendanceHandler(mock)
+	req := &BatchAttendanceRequest{}
+	req.Body.ShowIDs = []int{1}
+
+	_, err := h.BatchAttendanceHandler(context.Background(), req)
+	assertHumaError(t, err, 500)
+}
+
+// --- GetMyShowsHandler ---
+
+func TestGetMyShowsHandler_NoAuth(t *testing.T) {
+	h := testAttendanceHandler()
+	req := &GetMyShowsRequest{}
+
+	_, err := h.GetMyShowsHandler(context.Background(), req)
+	assertHumaError(t, err, 401)
+}
+
+func TestGetMyShowsHandler_InvalidStatus(t *testing.T) {
+	h := NewAttendanceHandler(&mockAttendanceService{})
+	ctx := ctxWithUser(&models.User{ID: 1})
+	req := &GetMyShowsRequest{Status: "maybe"}
+
+	_, err := h.GetMyShowsHandler(ctx, req)
+	assertHumaError(t, err, 400)
+}
+
+func TestGetMyShowsHandler_Success(t *testing.T) {
+	now := time.Now().UTC()
+	shows := []*services.AttendingShowResponse{
+		{
+			ShowID:    1,
+			Title:     "Test Show",
+			Slug:      "test-show",
+			EventDate: now.AddDate(0, 0, 7),
+			Status:    "going",
+		},
+	}
+	mock := &mockAttendanceService{
+		getUserAttendingShowsFn: func(userID uint, status string, limit, offset int) ([]*services.AttendingShowResponse, int64, error) {
+			if userID != 1 {
+				t.Errorf("unexpected userID=%d", userID)
+			}
+			if status != "all" {
+				t.Errorf("unexpected status=%s", status)
+			}
+			return shows, 1, nil
+		},
+	}
+	h := NewAttendanceHandler(mock)
+	ctx := ctxWithUser(&models.User{ID: 1})
+	req := &GetMyShowsRequest{Status: "all", Limit: 20, Offset: 0}
+
+	resp, err := h.GetMyShowsHandler(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Total != 1 {
+		t.Errorf("expected total=1, got %d", resp.Body.Total)
+	}
+	if len(resp.Body.Shows) != 1 {
+		t.Errorf("expected 1 show, got %d", len(resp.Body.Shows))
+	}
+}
+
+func TestGetMyShowsHandler_ServiceError(t *testing.T) {
+	mock := &mockAttendanceService{
+		getUserAttendingShowsFn: func(_ uint, _ string, _, _ int) ([]*services.AttendingShowResponse, int64, error) {
+			return nil, 0, fmt.Errorf("db error")
+		},
+	}
+	h := NewAttendanceHandler(mock)
+	ctx := ctxWithUser(&models.User{ID: 1})
+	req := &GetMyShowsRequest{Status: "all", Limit: 20}
+
+	_, err := h.GetMyShowsHandler(ctx, req)
+	assertHumaError(t, err, 500)
+}
+
+func TestGetMyShowsHandler_PaginationClamping(t *testing.T) {
+	var capturedLimit, capturedOffset int
+	mock := &mockAttendanceService{
+		getUserAttendingShowsFn: func(_ uint, _ string, limit, offset int) ([]*services.AttendingShowResponse, int64, error) {
+			capturedLimit = limit
+			capturedOffset = offset
+			return nil, 0, nil
+		},
+	}
+	h := NewAttendanceHandler(mock)
+	ctx := ctxWithUser(&models.User{ID: 1})
+
+	// limit=0 -> 20, offset=-1 -> 0
+	_, err := h.GetMyShowsHandler(ctx, &GetMyShowsRequest{Status: "all", Limit: 0, Offset: -1})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedLimit != 20 {
+		t.Errorf("expected limit=20, got %d", capturedLimit)
+	}
+	if capturedOffset != 0 {
+		t.Errorf("expected offset=0, got %d", capturedOffset)
+	}
+
+	// limit=999 -> 100
+	h.GetMyShowsHandler(ctx, &GetMyShowsRequest{Status: "all", Limit: 999})
+	if capturedLimit != 100 {
+		t.Errorf("expected limit=100, got %d", capturedLimit)
+	}
+}
+
+func TestGetMyShowsHandler_DefaultStatus(t *testing.T) {
+	var capturedStatus string
+	mock := &mockAttendanceService{
+		getUserAttendingShowsFn: func(_ uint, status string, _, _ int) ([]*services.AttendingShowResponse, int64, error) {
+			capturedStatus = status
+			return nil, 0, nil
+		},
+	}
+	h := NewAttendanceHandler(mock)
+	ctx := ctxWithUser(&models.User{ID: 1})
+
+	// Empty status defaults to "all"
+	_, err := h.GetMyShowsHandler(ctx, &GetMyShowsRequest{Status: "", Limit: 20})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedStatus != "all" {
+		t.Errorf("expected status=all, got %s", capturedStatus)
+	}
+}

--- a/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
+++ b/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
@@ -1398,9 +1398,71 @@ func (m *mockPasswordValidator) IsCommonPassword(password string) bool {
 }
 
 // ============================================================================
+// Mock: AttendanceServiceInterface
+// ============================================================================
+
+type mockAttendanceService struct {
+	setAttendanceFn          func(userID, showID uint, status string) error
+	removeAttendanceFn       func(userID, showID uint) error
+	getUserAttendanceFn      func(userID, showID uint) (string, error)
+	getAttendanceCountsFn    func(showID uint) (*services.AttendanceCountsResponse, error)
+	getBatchCountsFn         func(showIDs []uint) (map[uint]*services.AttendanceCountsResponse, error)
+	getBatchUserAttendanceFn func(userID uint, showIDs []uint) (map[uint]string, error)
+	getUserAttendingShowsFn  func(userID uint, status string, limit, offset int) ([]*services.AttendingShowResponse, int64, error)
+}
+
+func (m *mockAttendanceService) SetAttendance(userID, showID uint, status string) error {
+	if m.setAttendanceFn != nil {
+		return m.setAttendanceFn(userID, showID, status)
+	}
+	return nil
+}
+func (m *mockAttendanceService) RemoveAttendance(userID, showID uint) error {
+	if m.removeAttendanceFn != nil {
+		return m.removeAttendanceFn(userID, showID)
+	}
+	return nil
+}
+func (m *mockAttendanceService) GetUserAttendance(userID, showID uint) (string, error) {
+	if m.getUserAttendanceFn != nil {
+		return m.getUserAttendanceFn(userID, showID)
+	}
+	return "", nil
+}
+func (m *mockAttendanceService) GetAttendanceCounts(showID uint) (*services.AttendanceCountsResponse, error) {
+	if m.getAttendanceCountsFn != nil {
+		return m.getAttendanceCountsFn(showID)
+	}
+	return &services.AttendanceCountsResponse{ShowID: showID}, nil
+}
+func (m *mockAttendanceService) GetBatchAttendanceCounts(showIDs []uint) (map[uint]*services.AttendanceCountsResponse, error) {
+	if m.getBatchCountsFn != nil {
+		return m.getBatchCountsFn(showIDs)
+	}
+	result := make(map[uint]*services.AttendanceCountsResponse)
+	for _, id := range showIDs {
+		result[id] = &services.AttendanceCountsResponse{ShowID: id}
+	}
+	return result, nil
+}
+func (m *mockAttendanceService) GetBatchUserAttendance(userID uint, showIDs []uint) (map[uint]string, error) {
+	if m.getBatchUserAttendanceFn != nil {
+		return m.getBatchUserAttendanceFn(userID, showIDs)
+	}
+	return make(map[uint]string), nil
+}
+func (m *mockAttendanceService) GetUserAttendingShows(userID uint, status string, limit, offset int) ([]*services.AttendingShowResponse, int64, error) {
+	if m.getUserAttendingShowsFn != nil {
+		return m.getUserAttendingShowsFn(userID, status, limit, offset)
+	}
+	return nil, 0, nil
+}
+
+// ============================================================================
 // Compile-time interface satisfaction checks
 // ============================================================================
 
+var _ services.AttendanceServiceInterface = (*mockAttendanceService)(nil)
 var _ services.SavedShowServiceInterface = (*mockSavedShowService)(nil)
 var _ services.FavoriteVenueServiceInterface = (*mockFavoriteVenueService)(nil)
 var _ services.AuditLogServiceInterface = (*mockAuditLogService)(nil)

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -101,6 +101,7 @@ func SetupRoutes(router *chi.Mux, sc *services.ServiceContainer, cfg *config.Con
 	setupTagRoutes(api, protectedGroup, sc)
 	setupArtistRelationshipRoutes(api, protectedGroup, sc)
 	setupSceneRoutes(api, sc)
+	setupAttendanceRoutes(api, protectedGroup, sc)
 
 	return api
 }
@@ -698,6 +699,24 @@ func setupSceneRoutes(api huma.API, sc *services.ServiceContainer) {
 	huma.Get(api, "/scenes", sceneHandler.ListScenesHandler)
 	huma.Get(api, "/scenes/{slug}", sceneHandler.GetSceneDetailHandler)
 	huma.Get(api, "/scenes/{slug}/artists", sceneHandler.GetSceneActiveArtistsHandler)
+}
+
+// setupAttendanceRoutes configures show attendance (going/interested) endpoints.
+// Public endpoints use optional auth (counts always available; user status if authenticated).
+// Set/remove attendance requires authentication.
+func setupAttendanceRoutes(api huma.API, protected *huma.Group, sc *services.ServiceContainer) {
+	attendanceHandler := handlers.NewAttendanceHandler(sc.Attendance)
+
+	// Public endpoints with optional auth (counts + user status if authenticated)
+	optionalAuthGroup := huma.NewGroup(api, "")
+	optionalAuthGroup.UseMiddleware(middleware.OptionalHumaJWTMiddleware(sc.JWT))
+	huma.Get(optionalAuthGroup, "/shows/{show_id}/attendance", attendanceHandler.GetAttendanceHandler)
+	huma.Post(optionalAuthGroup, "/shows/attendance/batch", attendanceHandler.BatchAttendanceHandler)
+
+	// Protected endpoints (require authentication)
+	huma.Post(protected, "/shows/{show_id}/attendance", attendanceHandler.SetAttendanceHandler)
+	huma.Delete(protected, "/shows/{show_id}/attendance", attendanceHandler.RemoveAttendanceHandler)
+	huma.Get(protected, "/attendance/my-shows", attendanceHandler.GetMyShowsHandler)
 }
 
 // rateLimitHandler handles rate limit exceeded responses with JSON

--- a/backend/internal/services/aliases.go
+++ b/backend/internal/services/aliases.go
@@ -249,6 +249,8 @@ type ArtistReportResponse = contracts.ArtistReportResponse
 type ArtistReportArtistInfo = contracts.ArtistReportArtistInfo
 type CalendarTokenCreateResponse = contracts.CalendarTokenCreateResponse
 type CalendarTokenStatusResponse = contracts.CalendarTokenStatusResponse
+type AttendanceCountsResponse = contracts.AttendanceCountsResponse
+type AttendingShowResponse = contracts.AttendingShowResponse
 
 // ──────────────────────────────────────────────
 // Notification types (audit log)

--- a/backend/internal/services/container.go
+++ b/backend/internal/services/container.go
@@ -34,6 +34,7 @@ type ServiceContainer struct {
 	Tag                *catalog.TagService
 	ArtistRelationship *catalog.ArtistRelationshipService
 	Scene              *catalog.SceneService
+	Attendance         *engagement.AttendanceService
 	FavoriteVenue      *engagement.FavoriteVenueService
 	Festival      *catalog.FestivalService
 	Label         *catalog.LabelService
@@ -120,6 +121,7 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 		Tag:                catalog.NewTagService(database),
 		ArtistRelationship: catalog.NewArtistRelationshipService(database),
 		Scene:              catalog.NewSceneService(database),
+		Attendance:         engagement.NewAttendanceService(database),
 		FavoriteVenue:      engagement.NewFavoriteVenueService(database),
 		Festival:      catalog.NewFestivalService(database),
 		Label:         catalog.NewLabelService(database),

--- a/backend/internal/services/contracts/engagement.go
+++ b/backend/internal/services/contracts/engagement.go
@@ -120,3 +120,27 @@ type CalendarTokenStatusResponse struct {
 	HasToken  bool       `json:"has_token"`
 	CreatedAt *time.Time `json:"created_at,omitempty"`
 }
+
+// ──────────────────────────────────────────────
+// Attendance types (going/interested)
+// ──────────────────────────────────────────────
+
+// AttendanceCountsResponse contains going and interested counts for a show
+type AttendanceCountsResponse struct {
+	ShowID          uint `json:"show_id"`
+	GoingCount      int  `json:"going_count"`
+	InterestedCount int  `json:"interested_count"`
+}
+
+// AttendingShowResponse represents a show the user is attending or interested in
+type AttendingShowResponse struct {
+	ShowID    uint      `json:"show_id"`
+	Title     string    `json:"title"`
+	Slug      string    `json:"slug"`
+	EventDate time.Time `json:"event_date"`
+	Status    string    `json:"status"` // "going" or "interested"
+	VenueName *string   `json:"venue_name"`
+	VenueSlug *string   `json:"venue_slug"`
+	City      *string   `json:"city"`
+	State     *string   `json:"state"`
+}

--- a/backend/internal/services/contracts/interfaces.go
+++ b/backend/internal/services/contracts/interfaces.go
@@ -441,3 +441,14 @@ type DataQualityServiceInterface interface {
 	GetSummary() (*DataQualitySummary, error)
 	GetCategoryItems(category string, limit, offset int) ([]*DataQualityItem, int64, error)
 }
+
+// AttendanceServiceInterface defines the contract for show attendance (going/interested) operations.
+type AttendanceServiceInterface interface {
+	SetAttendance(userID, showID uint, status string) error
+	RemoveAttendance(userID, showID uint) error
+	GetUserAttendance(userID, showID uint) (string, error)
+	GetAttendanceCounts(showID uint) (*AttendanceCountsResponse, error)
+	GetBatchAttendanceCounts(showIDs []uint) (map[uint]*AttendanceCountsResponse, error)
+	GetBatchUserAttendance(userID uint, showIDs []uint) (map[uint]string, error)
+	GetUserAttendingShows(userID uint, status string, limit, offset int) ([]*AttendingShowResponse, int64, error)
+}

--- a/backend/internal/services/engagement/attendance.go
+++ b/backend/internal/services/engagement/attendance.go
@@ -1,0 +1,358 @@
+package engagement
+
+import (
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/db"
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// AttendanceService handles show attendance (going/interested) operations.
+// It wraps the generic user_bookmarks table with attendance-specific logic,
+// ensuring a user can only have one status per show (going XOR interested).
+type AttendanceService struct {
+	db *gorm.DB
+}
+
+// NewAttendanceService creates a new attendance service.
+func NewAttendanceService(database *gorm.DB) *AttendanceService {
+	if database == nil {
+		database = db.GetDB()
+	}
+	return &AttendanceService{db: database}
+}
+
+// SetAttendance sets the user's attendance status for a show.
+// status must be "going", "interested", or "" (to clear).
+// Setting "going" removes any existing "interested" and vice versa (atomic via transaction).
+func (s *AttendanceService) SetAttendance(userID, showID uint, status string) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	if status != string(models.BookmarkActionGoing) && status != string(models.BookmarkActionInterested) && status != "" {
+		return fmt.Errorf("invalid attendance status: %s", status)
+	}
+
+	// Empty status means clear both
+	if status == "" {
+		return s.RemoveAttendance(userID, showID)
+	}
+
+	// Check that the show exists
+	var show models.Show
+	if err := s.db.First(&show, showID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return fmt.Errorf("show not found")
+		}
+		return fmt.Errorf("failed to verify show: %w", err)
+	}
+
+	// Determine which status to set and which to remove
+	setAction := models.BookmarkAction(status)
+	var removeAction models.BookmarkAction
+	if setAction == models.BookmarkActionGoing {
+		removeAction = models.BookmarkActionInterested
+	} else {
+		removeAction = models.BookmarkActionGoing
+	}
+
+	return s.db.Transaction(func(tx *gorm.DB) error {
+		// Remove the opposite status (if any) — ignore "not found"
+		tx.Where(
+			"user_id = ? AND entity_type = ? AND entity_id = ? AND action = ?",
+			userID, models.BookmarkEntityShow, showID, removeAction,
+		).Delete(&models.UserBookmark{})
+
+		// Upsert the desired status
+		bookmark := models.UserBookmark{
+			UserID:     userID,
+			EntityType: models.BookmarkEntityShow,
+			EntityID:   showID,
+			Action:     setAction,
+			CreatedAt:  time.Now().UTC(),
+		}
+		return tx.Where(models.UserBookmark{
+			UserID:     userID,
+			EntityType: models.BookmarkEntityShow,
+			EntityID:   showID,
+			Action:     setAction,
+		}).Assign(models.UserBookmark{
+			CreatedAt: bookmark.CreatedAt,
+		}).FirstOrCreate(&bookmark).Error
+	})
+}
+
+// RemoveAttendance removes both going and interested bookmarks for a user+show.
+func (s *AttendanceService) RemoveAttendance(userID, showID uint) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	result := s.db.Where(
+		"user_id = ? AND entity_type = ? AND entity_id = ? AND action IN ?",
+		userID, models.BookmarkEntityShow, showID,
+		[]models.BookmarkAction{models.BookmarkActionGoing, models.BookmarkActionInterested},
+	).Delete(&models.UserBookmark{})
+
+	if result.Error != nil {
+		return fmt.Errorf("failed to remove attendance: %w", result.Error)
+	}
+
+	return nil
+}
+
+// GetUserAttendance returns the user's attendance status for a show.
+// Returns "going", "interested", or "" if not attending.
+func (s *AttendanceService) GetUserAttendance(userID, showID uint) (string, error) {
+	if s.db == nil {
+		return "", fmt.Errorf("database not initialized")
+	}
+
+	var bookmark models.UserBookmark
+	err := s.db.Where(
+		"user_id = ? AND entity_type = ? AND entity_id = ? AND action IN ?",
+		userID, models.BookmarkEntityShow, showID,
+		[]models.BookmarkAction{models.BookmarkActionGoing, models.BookmarkActionInterested},
+	).First(&bookmark).Error
+
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return "", nil
+		}
+		return "", fmt.Errorf("failed to get attendance: %w", err)
+	}
+
+	return string(bookmark.Action), nil
+}
+
+// GetAttendanceCounts returns the going and interested counts for a show.
+func (s *AttendanceService) GetAttendanceCounts(showID uint) (*contracts.AttendanceCountsResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	type countRow struct {
+		Action string
+		Count  int
+	}
+	var rows []countRow
+
+	err := s.db.Model(&models.UserBookmark{}).
+		Select("action, COUNT(*) as count").
+		Where("entity_type = ? AND entity_id = ? AND action IN ?",
+			models.BookmarkEntityShow, showID,
+			[]models.BookmarkAction{models.BookmarkActionGoing, models.BookmarkActionInterested},
+		).
+		Group("action").
+		Find(&rows).Error
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to get attendance counts: %w", err)
+	}
+
+	resp := &contracts.AttendanceCountsResponse{ShowID: showID}
+	for _, row := range rows {
+		switch models.BookmarkAction(row.Action) {
+		case models.BookmarkActionGoing:
+			resp.GoingCount = row.Count
+		case models.BookmarkActionInterested:
+			resp.InterestedCount = row.Count
+		}
+	}
+
+	return resp, nil
+}
+
+// GetBatchAttendanceCounts returns attendance counts for multiple shows efficiently.
+func (s *AttendanceService) GetBatchAttendanceCounts(showIDs []uint) (map[uint]*contracts.AttendanceCountsResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	result := make(map[uint]*contracts.AttendanceCountsResponse)
+	if len(showIDs) == 0 {
+		return result, nil
+	}
+
+	// Initialize all requested show IDs in the result map
+	for _, id := range showIDs {
+		result[id] = &contracts.AttendanceCountsResponse{ShowID: id}
+	}
+
+	type countRow struct {
+		EntityID uint
+		Action   string
+		Count    int
+	}
+	var rows []countRow
+
+	err := s.db.Model(&models.UserBookmark{}).
+		Select("entity_id, action, COUNT(*) as count").
+		Where("entity_type = ? AND entity_id IN ? AND action IN ?",
+			models.BookmarkEntityShow, showIDs,
+			[]models.BookmarkAction{models.BookmarkActionGoing, models.BookmarkActionInterested},
+		).
+		Group("entity_id, action").
+		Find(&rows).Error
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to get batch attendance counts: %w", err)
+	}
+
+	for _, row := range rows {
+		resp, ok := result[row.EntityID]
+		if !ok {
+			continue
+		}
+		switch models.BookmarkAction(row.Action) {
+		case models.BookmarkActionGoing:
+			resp.GoingCount = row.Count
+		case models.BookmarkActionInterested:
+			resp.InterestedCount = row.Count
+		}
+	}
+
+	return result, nil
+}
+
+// GetBatchUserAttendance returns the user's attendance status for multiple shows.
+// The returned map contains show_id -> status ("going", "interested", or absent if none).
+func (s *AttendanceService) GetBatchUserAttendance(userID uint, showIDs []uint) (map[uint]string, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	result := make(map[uint]string)
+	if len(showIDs) == 0 {
+		return result, nil
+	}
+
+	var bookmarks []models.UserBookmark
+	err := s.db.Where(
+		"user_id = ? AND entity_type = ? AND entity_id IN ? AND action IN ?",
+		userID, models.BookmarkEntityShow, showIDs,
+		[]models.BookmarkAction{models.BookmarkActionGoing, models.BookmarkActionInterested},
+	).Find(&bookmarks).Error
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to get batch user attendance: %w", err)
+	}
+
+	for _, b := range bookmarks {
+		result[b.EntityID] = string(b.Action)
+	}
+
+	return result, nil
+}
+
+// GetUserAttendingShows returns shows a user is going to or interested in.
+// status filter: "going", "interested", or "all" (default).
+// Only returns upcoming approved shows, ordered by event_date ASC.
+func (s *AttendanceService) GetUserAttendingShows(userID uint, status string, limit, offset int) ([]*contracts.AttendingShowResponse, int64, error) {
+	if s.db == nil {
+		return nil, 0, fmt.Errorf("database not initialized")
+	}
+
+	// Build the bookmark filter
+	actions := []models.BookmarkAction{models.BookmarkActionGoing, models.BookmarkActionInterested}
+	if status == string(models.BookmarkActionGoing) {
+		actions = []models.BookmarkAction{models.BookmarkActionGoing}
+	} else if status == string(models.BookmarkActionInterested) {
+		actions = []models.BookmarkAction{models.BookmarkActionInterested}
+	}
+
+	now := time.Now().UTC()
+
+	// Count total matching shows
+	var total int64
+	err := s.db.Model(&models.UserBookmark{}).
+		Joins("JOIN shows ON shows.id = user_bookmarks.entity_id").
+		Where("user_bookmarks.user_id = ? AND user_bookmarks.entity_type = ? AND user_bookmarks.action IN ?",
+			userID, models.BookmarkEntityShow, actions).
+		Where("shows.status = ? AND shows.event_date >= ?", models.ShowStatusApproved, now).
+		Count(&total).Error
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to count attending shows: %w", err)
+	}
+
+	if total == 0 {
+		return []*contracts.AttendingShowResponse{}, 0, nil
+	}
+
+	// Query bookmarks joined with shows and first venue
+	type attendingRow struct {
+		ShowID    uint
+		Title     string
+		Slug      *string
+		EventDate time.Time
+		Action    string
+		City      *string
+		State     *string
+		VenueName *string
+		VenueSlug *string
+	}
+
+	var rows []attendingRow
+	err = s.db.
+		Table("user_bookmarks").
+		Select(`
+			shows.id as show_id,
+			shows.title,
+			shows.slug,
+			shows.event_date,
+			user_bookmarks.action,
+			shows.city,
+			shows.state,
+			venues.name as venue_name,
+			venues.slug as venue_slug
+		`).
+		Joins("JOIN shows ON shows.id = user_bookmarks.entity_id").
+		Joins("LEFT JOIN show_venues ON show_venues.show_id = shows.id").
+		Joins("LEFT JOIN venues ON venues.id = show_venues.venue_id").
+		Where("user_bookmarks.user_id = ? AND user_bookmarks.entity_type = ? AND user_bookmarks.action IN ?",
+			userID, models.BookmarkEntityShow, actions).
+		Where("shows.status = ? AND shows.event_date >= ?", models.ShowStatusApproved, now).
+		Order("shows.event_date ASC").
+		Limit(limit).
+		Offset(offset).
+		Find(&rows).Error
+
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to get attending shows: %w", err)
+	}
+
+	// Deduplicate rows by show ID (a show may have multiple venues)
+	// Keep the first venue encountered for each show
+	seen := make(map[uint]bool)
+	responses := make([]*contracts.AttendingShowResponse, 0, len(rows))
+	for _, row := range rows {
+		if seen[row.ShowID] {
+			continue
+		}
+		seen[row.ShowID] = true
+
+		slug := ""
+		if row.Slug != nil {
+			slug = *row.Slug
+		}
+
+		responses = append(responses, &contracts.AttendingShowResponse{
+			ShowID:    row.ShowID,
+			Title:     row.Title,
+			Slug:      slug,
+			EventDate: row.EventDate,
+			Status:    row.Action,
+			VenueName: row.VenueName,
+			VenueSlug: row.VenueSlug,
+			City:      row.City,
+			State:     row.State,
+		})
+	}
+
+	return responses, total, nil
+}

--- a/backend/internal/services/engagement/attendance_test.go
+++ b/backend/internal/services/engagement/attendance_test.go
@@ -1,0 +1,654 @@
+package engagement
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/testutil"
+)
+
+// =============================================================================
+// UNIT TESTS (No Database Required)
+// =============================================================================
+
+func TestNewAttendanceService(t *testing.T) {
+	svc := NewAttendanceService(nil)
+	assert.NotNil(t, svc)
+}
+
+func TestAttendanceService_NilDatabase(t *testing.T) {
+	svc := &AttendanceService{db: nil}
+
+	t.Run("SetAttendance", func(t *testing.T) {
+		err := svc.SetAttendance(1, 1, "going")
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+	})
+
+	t.Run("RemoveAttendance", func(t *testing.T) {
+		err := svc.RemoveAttendance(1, 1)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+	})
+
+	t.Run("GetUserAttendance", func(t *testing.T) {
+		status, err := svc.GetUserAttendance(1, 1)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Empty(t, status)
+	})
+
+	t.Run("GetAttendanceCounts", func(t *testing.T) {
+		counts, err := svc.GetAttendanceCounts(1)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, counts)
+	})
+
+	t.Run("GetBatchAttendanceCounts", func(t *testing.T) {
+		result, err := svc.GetBatchAttendanceCounts([]uint{1, 2})
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, result)
+	})
+
+	t.Run("GetBatchUserAttendance", func(t *testing.T) {
+		result, err := svc.GetBatchUserAttendance(1, []uint{1, 2})
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, result)
+	})
+
+	t.Run("GetUserAttendingShows", func(t *testing.T) {
+		shows, total, err := svc.GetUserAttendingShows(1, "all", 10, 0)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, shows)
+		assert.Zero(t, total)
+	})
+}
+
+// =============================================================================
+// INTEGRATION TESTS (With Real Database)
+// =============================================================================
+
+type AttendanceServiceIntegrationTestSuite struct {
+	suite.Suite
+	container         testcontainers.Container
+	db                *gorm.DB
+	attendanceService *AttendanceService
+	ctx               context.Context
+}
+
+func (suite *AttendanceServiceIntegrationTestSuite) SetupSuite() {
+	suite.ctx = context.Background()
+
+	container, err := testcontainers.GenericContainer(suite.ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "postgres:18",
+			ExposedPorts: []string{"5432/tcp"},
+			Env: map[string]string{
+				"POSTGRES_DB":       "test_db",
+				"POSTGRES_USER":     "test_user",
+				"POSTGRES_PASSWORD": "test_password",
+			},
+			WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(120 * time.Second),
+		},
+		Started: true,
+	})
+	if err != nil {
+		suite.T().Fatalf("failed to start postgres container: %v", err)
+	}
+	suite.container = container
+
+	host, err := container.Host(suite.ctx)
+	if err != nil {
+		suite.T().Fatalf("failed to get host: %v", err)
+	}
+	port, err := container.MappedPort(suite.ctx, "5432")
+	if err != nil {
+		suite.T().Fatalf("failed to get port: %v", err)
+	}
+
+	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
+		host, port.Port())
+
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		suite.T().Fatalf("failed to connect to test database: %v", err)
+	}
+	suite.db = db
+
+	sqlDB, err := db.DB()
+	if err != nil {
+		suite.T().Fatalf("failed to get sql.DB: %v", err)
+	}
+
+	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
+
+	suite.attendanceService = NewAttendanceService(db)
+}
+
+func (suite *AttendanceServiceIntegrationTestSuite) TearDownSuite() {
+	if suite.container != nil {
+		if err := suite.container.Terminate(suite.ctx); err != nil {
+			suite.T().Logf("failed to terminate container: %v", err)
+		}
+	}
+}
+
+func (suite *AttendanceServiceIntegrationTestSuite) TearDownTest() {
+	sqlDB, err := suite.db.DB()
+	suite.Require().NoError(err)
+	_, _ = sqlDB.Exec("DELETE FROM user_bookmarks")
+	_, _ = sqlDB.Exec("DELETE FROM show_artists")
+	_, _ = sqlDB.Exec("DELETE FROM show_venues")
+	_, _ = sqlDB.Exec("DELETE FROM shows")
+	_, _ = sqlDB.Exec("DELETE FROM artists")
+	_, _ = sqlDB.Exec("DELETE FROM venues")
+	_, _ = sqlDB.Exec("DELETE FROM users")
+}
+
+func TestAttendanceServiceIntegrationTestSuite(t *testing.T) {
+	suite.Run(t, new(AttendanceServiceIntegrationTestSuite))
+}
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+func (suite *AttendanceServiceIntegrationTestSuite) createTestUser() *models.User {
+	user := &models.User{
+		Email:         stringPtr(fmt.Sprintf("user-%d@test.com", time.Now().UnixNano())),
+		FirstName:     stringPtr("Test"),
+		LastName:      stringPtr("User"),
+		IsActive:      true,
+		EmailVerified: true,
+	}
+	err := suite.db.Create(user).Error
+	suite.Require().NoError(err)
+	return user
+}
+
+func (suite *AttendanceServiceIntegrationTestSuite) createApprovedShow(title string, userID uint) *models.Show {
+	show := &models.Show{
+		Title:       title,
+		EventDate:   time.Now().UTC().AddDate(0, 0, 7), // 1 week from now (upcoming)
+		City:        stringPtr("Phoenix"),
+		State:       stringPtr("AZ"),
+		Status:      models.ShowStatusApproved,
+		SubmittedBy: &userID,
+	}
+	err := suite.db.Create(show).Error
+	suite.Require().NoError(err)
+	return show
+}
+
+func (suite *AttendanceServiceIntegrationTestSuite) createPastShow(title string, userID uint) *models.Show {
+	show := &models.Show{
+		Title:       title,
+		EventDate:   time.Now().UTC().AddDate(0, 0, -7), // 1 week ago
+		City:        stringPtr("Phoenix"),
+		State:       stringPtr("AZ"),
+		Status:      models.ShowStatusApproved,
+		SubmittedBy: &userID,
+	}
+	err := suite.db.Create(show).Error
+	suite.Require().NoError(err)
+	return show
+}
+
+func (suite *AttendanceServiceIntegrationTestSuite) createShowWithVenue(title string, userID uint) (*models.Show, *models.Venue) {
+	venue := &models.Venue{
+		Name:  fmt.Sprintf("Venue for %s", title),
+		City:  "Phoenix",
+		State: "AZ",
+	}
+	suite.db.Create(venue)
+
+	show := suite.createApprovedShow(title, userID)
+	suite.db.Create(&models.ShowVenue{ShowID: show.ID, VenueID: venue.ID})
+
+	return show, venue
+}
+
+// =============================================================================
+// Group 1: SetAttendance
+// =============================================================================
+
+func (suite *AttendanceServiceIntegrationTestSuite) TestSetAttendance_Going() {
+	user := suite.createTestUser()
+	show := suite.createApprovedShow("Going Show", user.ID)
+
+	err := suite.attendanceService.SetAttendance(user.ID, show.ID, "going")
+	suite.Require().NoError(err)
+
+	// Verify in DB
+	var count int64
+	suite.db.Model(&models.UserBookmark{}).
+		Where("user_id = ? AND entity_type = ? AND entity_id = ? AND action = ?",
+			user.ID, models.BookmarkEntityShow, show.ID, models.BookmarkActionGoing).
+		Count(&count)
+	suite.Equal(int64(1), count)
+}
+
+func (suite *AttendanceServiceIntegrationTestSuite) TestSetAttendance_Interested() {
+	user := suite.createTestUser()
+	show := suite.createApprovedShow("Interested Show", user.ID)
+
+	err := suite.attendanceService.SetAttendance(user.ID, show.ID, "interested")
+	suite.Require().NoError(err)
+
+	var count int64
+	suite.db.Model(&models.UserBookmark{}).
+		Where("user_id = ? AND entity_type = ? AND entity_id = ? AND action = ?",
+			user.ID, models.BookmarkEntityShow, show.ID, models.BookmarkActionInterested).
+		Count(&count)
+	suite.Equal(int64(1), count)
+}
+
+func (suite *AttendanceServiceIntegrationTestSuite) TestSetAttendance_ToggleGoingToInterested() {
+	user := suite.createTestUser()
+	show := suite.createApprovedShow("Toggle Show", user.ID)
+
+	err := suite.attendanceService.SetAttendance(user.ID, show.ID, "going")
+	suite.Require().NoError(err)
+
+	err = suite.attendanceService.SetAttendance(user.ID, show.ID, "interested")
+	suite.Require().NoError(err)
+
+	var goingCount int64
+	suite.db.Model(&models.UserBookmark{}).
+		Where("user_id = ? AND entity_type = ? AND entity_id = ? AND action = ?",
+			user.ID, models.BookmarkEntityShow, show.ID, models.BookmarkActionGoing).
+		Count(&goingCount)
+	suite.Equal(int64(0), goingCount)
+
+	var interestedCount int64
+	suite.db.Model(&models.UserBookmark{}).
+		Where("user_id = ? AND entity_type = ? AND entity_id = ? AND action = ?",
+			user.ID, models.BookmarkEntityShow, show.ID, models.BookmarkActionInterested).
+		Count(&interestedCount)
+	suite.Equal(int64(1), interestedCount)
+}
+
+func (suite *AttendanceServiceIntegrationTestSuite) TestSetAttendance_ToggleInterestedToGoing() {
+	user := suite.createTestUser()
+	show := suite.createApprovedShow("Toggle Show 2", user.ID)
+
+	err := suite.attendanceService.SetAttendance(user.ID, show.ID, "interested")
+	suite.Require().NoError(err)
+
+	err = suite.attendanceService.SetAttendance(user.ID, show.ID, "going")
+	suite.Require().NoError(err)
+
+	var interestedCount int64
+	suite.db.Model(&models.UserBookmark{}).
+		Where("user_id = ? AND entity_type = ? AND entity_id = ? AND action = ?",
+			user.ID, models.BookmarkEntityShow, show.ID, models.BookmarkActionInterested).
+		Count(&interestedCount)
+	suite.Equal(int64(0), interestedCount)
+
+	var goingCount int64
+	suite.db.Model(&models.UserBookmark{}).
+		Where("user_id = ? AND entity_type = ? AND entity_id = ? AND action = ?",
+			user.ID, models.BookmarkEntityShow, show.ID, models.BookmarkActionGoing).
+		Count(&goingCount)
+	suite.Equal(int64(1), goingCount)
+}
+
+func (suite *AttendanceServiceIntegrationTestSuite) TestSetAttendance_ClearWithEmptyString() {
+	user := suite.createTestUser()
+	show := suite.createApprovedShow("Clear Show", user.ID)
+
+	err := suite.attendanceService.SetAttendance(user.ID, show.ID, "going")
+	suite.Require().NoError(err)
+
+	err = suite.attendanceService.SetAttendance(user.ID, show.ID, "")
+	suite.Require().NoError(err)
+
+	var count int64
+	suite.db.Model(&models.UserBookmark{}).
+		Where("user_id = ? AND entity_type = ? AND entity_id = ? AND action IN ?",
+			user.ID, models.BookmarkEntityShow, show.ID,
+			[]models.BookmarkAction{models.BookmarkActionGoing, models.BookmarkActionInterested}).
+		Count(&count)
+	suite.Equal(int64(0), count)
+}
+
+func (suite *AttendanceServiceIntegrationTestSuite) TestSetAttendance_InvalidStatus() {
+	user := suite.createTestUser()
+	show := suite.createApprovedShow("Invalid Status Show", user.ID)
+
+	err := suite.attendanceService.SetAttendance(user.ID, show.ID, "maybe")
+	suite.Require().Error(err)
+	suite.Contains(err.Error(), "invalid attendance status")
+}
+
+func (suite *AttendanceServiceIntegrationTestSuite) TestSetAttendance_ShowNotFound() {
+	user := suite.createTestUser()
+
+	err := suite.attendanceService.SetAttendance(user.ID, 99999, "going")
+	suite.Require().Error(err)
+	suite.Contains(err.Error(), "show not found")
+}
+
+func (suite *AttendanceServiceIntegrationTestSuite) TestSetAttendance_Idempotent() {
+	user := suite.createTestUser()
+	show := suite.createApprovedShow("Idempotent Show", user.ID)
+
+	err := suite.attendanceService.SetAttendance(user.ID, show.ID, "going")
+	suite.Require().NoError(err)
+	err = suite.attendanceService.SetAttendance(user.ID, show.ID, "going")
+	suite.Require().NoError(err)
+
+	var count int64
+	suite.db.Model(&models.UserBookmark{}).
+		Where("user_id = ? AND entity_type = ? AND entity_id = ? AND action = ?",
+			user.ID, models.BookmarkEntityShow, show.ID, models.BookmarkActionGoing).
+		Count(&count)
+	suite.Equal(int64(1), count)
+}
+
+// =============================================================================
+// Group 2: RemoveAttendance
+// =============================================================================
+
+func (suite *AttendanceServiceIntegrationTestSuite) TestRemoveAttendance_RemovesBoth() {
+	user := suite.createTestUser()
+	show := suite.createApprovedShow("Remove Both Show", user.ID)
+
+	err := suite.attendanceService.SetAttendance(user.ID, show.ID, "going")
+	suite.Require().NoError(err)
+
+	err = suite.attendanceService.RemoveAttendance(user.ID, show.ID)
+	suite.Require().NoError(err)
+
+	var count int64
+	suite.db.Model(&models.UserBookmark{}).
+		Where("user_id = ? AND entity_type = ? AND entity_id = ? AND action IN ?",
+			user.ID, models.BookmarkEntityShow, show.ID,
+			[]models.BookmarkAction{models.BookmarkActionGoing, models.BookmarkActionInterested}).
+		Count(&count)
+	suite.Equal(int64(0), count)
+}
+
+func (suite *AttendanceServiceIntegrationTestSuite) TestRemoveAttendance_NoExistingStatus() {
+	user := suite.createTestUser()
+	show := suite.createApprovedShow("Never Attended Show", user.ID)
+
+	err := suite.attendanceService.RemoveAttendance(user.ID, show.ID)
+	suite.Require().NoError(err)
+}
+
+// =============================================================================
+// Group 3: GetUserAttendance
+// =============================================================================
+
+func (suite *AttendanceServiceIntegrationTestSuite) TestGetUserAttendance_Going() {
+	user := suite.createTestUser()
+	show := suite.createApprovedShow("Get Going Show", user.ID)
+
+	suite.attendanceService.SetAttendance(user.ID, show.ID, "going")
+
+	status, err := suite.attendanceService.GetUserAttendance(user.ID, show.ID)
+	suite.Require().NoError(err)
+	suite.Equal("going", status)
+}
+
+func (suite *AttendanceServiceIntegrationTestSuite) TestGetUserAttendance_Interested() {
+	user := suite.createTestUser()
+	show := suite.createApprovedShow("Get Interested Show", user.ID)
+
+	suite.attendanceService.SetAttendance(user.ID, show.ID, "interested")
+
+	status, err := suite.attendanceService.GetUserAttendance(user.ID, show.ID)
+	suite.Require().NoError(err)
+	suite.Equal("interested", status)
+}
+
+func (suite *AttendanceServiceIntegrationTestSuite) TestGetUserAttendance_None() {
+	user := suite.createTestUser()
+	show := suite.createApprovedShow("Not Attending Show", user.ID)
+
+	status, err := suite.attendanceService.GetUserAttendance(user.ID, show.ID)
+	suite.Require().NoError(err)
+	suite.Empty(status)
+}
+
+// =============================================================================
+// Group 4: GetAttendanceCounts
+// =============================================================================
+
+func (suite *AttendanceServiceIntegrationTestSuite) TestGetAttendanceCounts_MultipleUsers() {
+	user1 := suite.createTestUser()
+	user2 := suite.createTestUser()
+	user3 := suite.createTestUser()
+	show := suite.createApprovedShow("Count Show", user1.ID)
+
+	suite.attendanceService.SetAttendance(user1.ID, show.ID, "going")
+	suite.attendanceService.SetAttendance(user2.ID, show.ID, "going")
+	suite.attendanceService.SetAttendance(user3.ID, show.ID, "interested")
+
+	counts, err := suite.attendanceService.GetAttendanceCounts(show.ID)
+	suite.Require().NoError(err)
+	suite.Equal(show.ID, counts.ShowID)
+	suite.Equal(2, counts.GoingCount)
+	suite.Equal(1, counts.InterestedCount)
+}
+
+func (suite *AttendanceServiceIntegrationTestSuite) TestGetAttendanceCounts_NoAttendance() {
+	user := suite.createTestUser()
+	show := suite.createApprovedShow("Empty Count Show", user.ID)
+
+	counts, err := suite.attendanceService.GetAttendanceCounts(show.ID)
+	suite.Require().NoError(err)
+	suite.Equal(0, counts.GoingCount)
+	suite.Equal(0, counts.InterestedCount)
+}
+
+// =============================================================================
+// Group 5: GetBatchAttendanceCounts
+// =============================================================================
+
+func (suite *AttendanceServiceIntegrationTestSuite) TestGetBatchAttendanceCounts_MultipleShows() {
+	user1 := suite.createTestUser()
+	user2 := suite.createTestUser()
+	show1 := suite.createApprovedShow("Batch Show 1", user1.ID)
+	show2 := suite.createApprovedShow("Batch Show 2", user1.ID)
+	show3 := suite.createApprovedShow("Batch Show 3", user1.ID)
+
+	suite.attendanceService.SetAttendance(user1.ID, show1.ID, "going")
+	suite.attendanceService.SetAttendance(user2.ID, show1.ID, "interested")
+	suite.attendanceService.SetAttendance(user1.ID, show2.ID, "interested")
+
+	result, err := suite.attendanceService.GetBatchAttendanceCounts([]uint{show1.ID, show2.ID, show3.ID})
+	suite.Require().NoError(err)
+	suite.Len(result, 3)
+
+	suite.Equal(1, result[show1.ID].GoingCount)
+	suite.Equal(1, result[show1.ID].InterestedCount)
+	suite.Equal(0, result[show2.ID].GoingCount)
+	suite.Equal(1, result[show2.ID].InterestedCount)
+	suite.Equal(0, result[show3.ID].GoingCount)
+	suite.Equal(0, result[show3.ID].InterestedCount)
+}
+
+func (suite *AttendanceServiceIntegrationTestSuite) TestGetBatchAttendanceCounts_Empty() {
+	result, err := suite.attendanceService.GetBatchAttendanceCounts([]uint{})
+	suite.Require().NoError(err)
+	suite.Empty(result)
+}
+
+// =============================================================================
+// Group 6: GetBatchUserAttendance
+// =============================================================================
+
+func (suite *AttendanceServiceIntegrationTestSuite) TestGetBatchUserAttendance_MixedStatuses() {
+	user := suite.createTestUser()
+	show1 := suite.createApprovedShow("Batch User Show 1", user.ID)
+	show2 := suite.createApprovedShow("Batch User Show 2", user.ID)
+	show3 := suite.createApprovedShow("Batch User Show 3", user.ID)
+
+	suite.attendanceService.SetAttendance(user.ID, show1.ID, "going")
+	suite.attendanceService.SetAttendance(user.ID, show2.ID, "interested")
+
+	result, err := suite.attendanceService.GetBatchUserAttendance(user.ID, []uint{show1.ID, show2.ID, show3.ID})
+	suite.Require().NoError(err)
+
+	suite.Equal("going", result[show1.ID])
+	suite.Equal("interested", result[show2.ID])
+	_, hasShow3 := result[show3.ID]
+	suite.False(hasShow3)
+}
+
+func (suite *AttendanceServiceIntegrationTestSuite) TestGetBatchUserAttendance_Empty() {
+	user := suite.createTestUser()
+
+	result, err := suite.attendanceService.GetBatchUserAttendance(user.ID, []uint{})
+	suite.Require().NoError(err)
+	suite.Empty(result)
+}
+
+// =============================================================================
+// Group 7: GetUserAttendingShows
+// =============================================================================
+
+func (suite *AttendanceServiceIntegrationTestSuite) TestGetUserAttendingShows_All() {
+	user := suite.createTestUser()
+	show1, _ := suite.createShowWithVenue("Attending Show 1", user.ID)
+	show2, _ := suite.createShowWithVenue("Attending Show 2", user.ID)
+
+	suite.attendanceService.SetAttendance(user.ID, show1.ID, "going")
+	suite.attendanceService.SetAttendance(user.ID, show2.ID, "interested")
+
+	shows, total, err := suite.attendanceService.GetUserAttendingShows(user.ID, "all", 10, 0)
+	suite.Require().NoError(err)
+	suite.Equal(int64(2), total)
+	suite.Len(shows, 2)
+}
+
+func (suite *AttendanceServiceIntegrationTestSuite) TestGetUserAttendingShows_FilterGoing() {
+	user := suite.createTestUser()
+	show1, _ := suite.createShowWithVenue("Going Only Show", user.ID)
+	show2, _ := suite.createShowWithVenue("Interested Only Show", user.ID)
+
+	suite.attendanceService.SetAttendance(user.ID, show1.ID, "going")
+	suite.attendanceService.SetAttendance(user.ID, show2.ID, "interested")
+
+	shows, total, err := suite.attendanceService.GetUserAttendingShows(user.ID, "going", 10, 0)
+	suite.Require().NoError(err)
+	suite.Equal(int64(1), total)
+	suite.Require().Len(shows, 1)
+	suite.Equal("going", shows[0].Status)
+}
+
+func (suite *AttendanceServiceIntegrationTestSuite) TestGetUserAttendingShows_FilterInterested() {
+	user := suite.createTestUser()
+	show1, _ := suite.createShowWithVenue("Going Show for Filter", user.ID)
+	show2, _ := suite.createShowWithVenue("Interested Show for Filter", user.ID)
+
+	suite.attendanceService.SetAttendance(user.ID, show1.ID, "going")
+	suite.attendanceService.SetAttendance(user.ID, show2.ID, "interested")
+
+	shows, total, err := suite.attendanceService.GetUserAttendingShows(user.ID, "interested", 10, 0)
+	suite.Require().NoError(err)
+	suite.Equal(int64(1), total)
+	suite.Require().Len(shows, 1)
+	suite.Equal("interested", shows[0].Status)
+}
+
+func (suite *AttendanceServiceIntegrationTestSuite) TestGetUserAttendingShows_OnlyUpcoming() {
+	user := suite.createTestUser()
+	upcomingShow, _ := suite.createShowWithVenue("Upcoming Show", user.ID)
+	pastShow := suite.createPastShow("Past Show", user.ID)
+
+	suite.attendanceService.SetAttendance(user.ID, upcomingShow.ID, "going")
+	suite.attendanceService.SetAttendance(user.ID, pastShow.ID, "going")
+
+	shows, total, err := suite.attendanceService.GetUserAttendingShows(user.ID, "all", 10, 0)
+	suite.Require().NoError(err)
+	suite.Equal(int64(1), total)
+	suite.Require().Len(shows, 1)
+	suite.Equal(upcomingShow.ID, shows[0].ShowID)
+}
+
+func (suite *AttendanceServiceIntegrationTestSuite) TestGetUserAttendingShows_OnlyApproved() {
+	user := suite.createTestUser()
+	approvedShow, _ := suite.createShowWithVenue("Approved Show", user.ID)
+
+	pendingShow := &models.Show{
+		Title:       "Pending Show",
+		EventDate:   time.Now().UTC().AddDate(0, 0, 7),
+		City:        stringPtr("Phoenix"),
+		State:       stringPtr("AZ"),
+		Status:      models.ShowStatusPending,
+		SubmittedBy: &user.ID,
+	}
+	suite.db.Create(pendingShow)
+
+	suite.attendanceService.SetAttendance(user.ID, approvedShow.ID, "going")
+	suite.attendanceService.SetAttendance(user.ID, pendingShow.ID, "going")
+
+	shows, total, err := suite.attendanceService.GetUserAttendingShows(user.ID, "all", 10, 0)
+	suite.Require().NoError(err)
+	suite.Equal(int64(1), total)
+	suite.Require().Len(shows, 1)
+	suite.Equal(approvedShow.ID, shows[0].ShowID)
+}
+
+func (suite *AttendanceServiceIntegrationTestSuite) TestGetUserAttendingShows_Pagination() {
+	user := suite.createTestUser()
+	for i := 0; i < 5; i++ {
+		show, _ := suite.createShowWithVenue(fmt.Sprintf("Paginated Show %d", i), user.ID)
+		suite.attendanceService.SetAttendance(user.ID, show.ID, "going")
+	}
+
+	shows1, total, err := suite.attendanceService.GetUserAttendingShows(user.ID, "all", 2, 0)
+	suite.Require().NoError(err)
+	suite.Equal(int64(5), total)
+	suite.Len(shows1, 2)
+
+	shows2, _, err := suite.attendanceService.GetUserAttendingShows(user.ID, "all", 2, 2)
+	suite.Require().NoError(err)
+	suite.Len(shows2, 2)
+
+	shows3, _, err := suite.attendanceService.GetUserAttendingShows(user.ID, "all", 2, 4)
+	suite.Require().NoError(err)
+	suite.Len(shows3, 1)
+
+	suite.NotEqual(shows1[0].ShowID, shows2[0].ShowID)
+}
+
+func (suite *AttendanceServiceIntegrationTestSuite) TestGetUserAttendingShows_IncludesVenueInfo() {
+	user := suite.createTestUser()
+	show, venue := suite.createShowWithVenue("Venue Info Show", user.ID)
+
+	suite.attendanceService.SetAttendance(user.ID, show.ID, "going")
+
+	shows, _, err := suite.attendanceService.GetUserAttendingShows(user.ID, "all", 10, 0)
+	suite.Require().NoError(err)
+	suite.Require().Len(shows, 1)
+	suite.Require().NotNil(shows[0].VenueName)
+	suite.Equal(venue.Name, *shows[0].VenueName)
+}
+
+func (suite *AttendanceServiceIntegrationTestSuite) TestGetUserAttendingShows_Empty() {
+	user := suite.createTestUser()
+
+	shows, total, err := suite.attendanceService.GetUserAttendingShows(user.ID, "all", 10, 0)
+	suite.Require().NoError(err)
+	suite.Equal(int64(0), total)
+	suite.Empty(shows)
+}

--- a/backend/internal/services/engagement/interfaces.go
+++ b/backend/internal/services/engagement/interfaces.go
@@ -9,4 +9,5 @@ var (
 	_ contracts.FavoriteVenueServiceInterface = (*FavoriteVenueService)(nil)
 	_ contracts.CalendarServiceInterface      = (*CalendarService)(nil)
 	_ contracts.ReminderServiceInterface      = (*ReminderService)(nil)
+	_ contracts.AttendanceServiceInterface    = (*AttendanceService)(nil)
 )

--- a/backend/internal/services/interfaces.go
+++ b/backend/internal/services/interfaces.go
@@ -48,6 +48,7 @@ type TagServiceInterface = contracts.TagServiceInterface
 type ArtistRelationshipServiceInterface = contracts.ArtistRelationshipServiceInterface
 type SceneServiceInterface = contracts.SceneServiceInterface
 type DataQualityServiceInterface = contracts.DataQualityServiceInterface
+type AttendanceServiceInterface = contracts.AttendanceServiceInterface
 
 // Compile-time interface satisfaction checks.
 // Engagement services (Bookmark, SavedShow, FavoriteVenue, Calendar, Reminder)


### PR DESCRIPTION
## Summary
- **AttendanceService**: going/interested toggle for shows using existing `user_bookmarks` table (no migration needed)
- **Atomic toggle**: setting "going" automatically removes "interested" and vice versa
- **Batch endpoints**: efficient counts + user status for rendering show cards
- **My Shows**: paginated list of user's attending shows with venue info

## Endpoints
| Method | Path | Auth | Description |
|--------|------|------|-------------|
| `POST` | `/shows/{id}/attendance` | Protected | Set status (`going`/`interested`) |
| `DELETE` | `/shows/{id}/attendance` | Protected | Remove attendance |
| `GET` | `/shows/{id}/attendance` | Optional | Counts + user status |
| `POST` | `/shows/attendance/batch` | Optional | Batch counts for show cards (max 100) |
| `GET` | `/attendance/my-shows` | Protected | User's attending shows |

## Test plan
- [x] `go build ./...` passes
- [x] 35 service tests pass (8 unit + 27 integration)
- [x] 28 handler unit tests pass
- [x] No frontend files modified, no migration needed
- [ ] Manual: set going/interested, verify counts, check my-shows

Closes PSY-55

🤖 Generated with [Claude Code](https://claude.com/claude-code)