### PR TITLE
Add analytics dashboard frontend (PSY-104)

### DIFF
--- a/frontend/app/admin/analytics/_components/AnalyticsDashboard.test.tsx
+++ b/frontend/app/admin/analytics/_components/AnalyticsDashboard.test.tsx
@@ -1,0 +1,322 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, fireEvent } from '@testing-library/react'
+import { renderWithProviders } from '@/test/utils'
+import { AnalyticsDashboard } from './AnalyticsDashboard'
+
+// Mock recharts to avoid SVG rendering issues in JSDOM
+vi.mock('recharts', () => {
+  const MockResponsiveContainer = ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="responsive-container">{children}</div>
+  )
+  const MockLineChart = ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="line-chart">{children}</div>
+  )
+  const MockAreaChart = ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="area-chart">{children}</div>
+  )
+  const MockBarChart = ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="bar-chart">{children}</div>
+  )
+  const MockLine = () => <div data-testid="chart-line" />
+  const MockArea = () => <div data-testid="chart-area" />
+  const MockBar = () => <div data-testid="chart-bar" />
+  const MockXAxis = () => <div />
+  const MockYAxis = () => <div />
+  const MockCartesianGrid = () => <div />
+  const MockTooltip = () => <div />
+  const MockLegend = () => <div />
+
+  return {
+    ResponsiveContainer: MockResponsiveContainer,
+    LineChart: MockLineChart,
+    Line: MockLine,
+    AreaChart: MockAreaChart,
+    Area: MockArea,
+    BarChart: MockBarChart,
+    Bar: MockBar,
+    XAxis: MockXAxis,
+    YAxis: MockYAxis,
+    CartesianGrid: MockCartesianGrid,
+    Tooltip: MockTooltip,
+    Legend: MockLegend,
+  }
+})
+
+// Mock the hooks
+const mockGrowthData = {
+  shows: [
+    { month: '2025-10', count: 50 },
+    { month: '2025-11', count: 65 },
+  ],
+  artists: [
+    { month: '2025-10', count: 20 },
+    { month: '2025-11', count: 25 },
+  ],
+  venues: [
+    { month: '2025-10', count: 5 },
+    { month: '2025-11', count: 7 },
+  ],
+  releases: [
+    { month: '2025-10', count: 10 },
+    { month: '2025-11', count: 12 },
+  ],
+  labels: [
+    { month: '2025-10', count: 2 },
+    { month: '2025-11', count: 3 },
+  ],
+  users: [
+    { month: '2025-10', count: 15 },
+    { month: '2025-11', count: 18 },
+  ],
+}
+
+const mockEngagementData = {
+  bookmarks: [{ month: '2025-10', count: 30 }],
+  tags_added: [{ month: '2025-10', count: 20 }],
+  tag_votes: [{ month: '2025-10', count: 50 }],
+  collection_items: [{ month: '2025-10', count: 10 }],
+  requests: [{ month: '2025-10', count: 5 }],
+  request_votes: [{ month: '2025-10', count: 15 }],
+  revisions: [{ month: '2025-10', count: 8 }],
+  follows: [{ month: '2025-10', count: 25 }],
+  attendance: [{ month: '2025-10', count: 40 }],
+}
+
+const mockCommunityData = {
+  active_contributors_30d: 42,
+  contributions_per_week: [
+    { week: '2026-W10', count: 15 },
+    { week: '2026-W11', count: 20 },
+  ],
+  request_fulfillment_rate: 0.72,
+  new_collections_30d: 8,
+  top_contributors: [
+    { user_id: 1, username: 'alice', display_name: 'Alice M.', count: 50 },
+    { user_id: 2, username: 'bob', count: 35 },
+  ],
+}
+
+const mockDataQualityData = {
+  shows_approved: [{ month: '2025-10', count: 100 }],
+  shows_rejected: [{ month: '2025-10', count: 15 }],
+  pending_review_count: 23,
+  artists_without_releases: 45,
+  inactive_venues_90d: 12,
+}
+
+const mockUseGrowthMetrics = vi.fn()
+const mockUseEngagementMetrics = vi.fn()
+const mockUseCommunityHealth = vi.fn()
+const mockUseDataQualityTrends = vi.fn()
+
+vi.mock('@/lib/hooks/admin/useAnalytics', () => ({
+  useGrowthMetrics: (...args: unknown[]) => mockUseGrowthMetrics(...args),
+  useEngagementMetrics: (...args: unknown[]) => mockUseEngagementMetrics(...args),
+  useCommunityHealth: (...args: unknown[]) => mockUseCommunityHealth(...args),
+  useDataQualityTrends: (...args: unknown[]) => mockUseDataQualityTrends(...args),
+}))
+
+describe('AnalyticsDashboard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    // Default: growth data loaded
+    mockUseGrowthMetrics.mockReturnValue({
+      data: mockGrowthData,
+      isLoading: false,
+      error: null,
+    })
+    mockUseEngagementMetrics.mockReturnValue({
+      data: mockEngagementData,
+      isLoading: false,
+      error: null,
+    })
+    mockUseCommunityHealth.mockReturnValue({
+      data: mockCommunityData,
+      isLoading: false,
+      error: null,
+    })
+    mockUseDataQualityTrends.mockReturnValue({
+      data: mockDataQualityData,
+      isLoading: false,
+      error: null,
+    })
+  })
+
+  it('renders the header', () => {
+    renderWithProviders(<AnalyticsDashboard />)
+
+    expect(screen.getByText('Analytics')).toBeInTheDocument()
+    expect(
+      screen.getByText('Platform growth, engagement, and data health metrics.')
+    ).toBeInTheDocument()
+  })
+
+  it('renders all view selector buttons', () => {
+    renderWithProviders(<AnalyticsDashboard />)
+
+    expect(screen.getByRole('button', { name: /Growth/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Engagement/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Community Health/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Data Quality/i })).toBeInTheDocument()
+  })
+
+  it('renders month range selector on growth view', () => {
+    renderWithProviders(<AnalyticsDashboard />)
+
+    expect(screen.getByText('Range:')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '3mo' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '6mo' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '12mo' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '24mo' })).toBeInTheDocument()
+  })
+
+  it('shows growth chart on default view', () => {
+    renderWithProviders(<AnalyticsDashboard />)
+
+    expect(screen.getByText('Entity Creation Trends')).toBeInTheDocument()
+  })
+
+  it('shows loading state when growth data is loading', () => {
+    mockUseGrowthMetrics.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    })
+
+    renderWithProviders(<AnalyticsDashboard />)
+
+    // Loading spinner should be present (Loader2 icon)
+    expect(screen.queryByText('Entity Creation Trends')).not.toBeInTheDocument()
+  })
+
+  it('shows error state when growth data fails', () => {
+    mockUseGrowthMetrics.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('Failed'),
+    })
+
+    renderWithProviders(<AnalyticsDashboard />)
+
+    expect(screen.getByText('Failed to load growth metrics.')).toBeInTheDocument()
+  })
+
+  it('switches to engagement view on click', () => {
+    renderWithProviders(<AnalyticsDashboard />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Engagement/i }))
+
+    expect(screen.getByText('Content Curation')).toBeInTheDocument()
+    expect(screen.getByText('Requests & Voting')).toBeInTheDocument()
+    expect(screen.getByText('Social Engagement')).toBeInTheDocument()
+  })
+
+  it('switches to community health view on click', () => {
+    renderWithProviders(<AnalyticsDashboard />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Community Health/i }))
+
+    expect(screen.getByText('Active Contributors (30d)')).toBeInTheDocument()
+    expect(screen.getByText('42')).toBeInTheDocument()
+    expect(screen.getByText('Request Fulfillment Rate')).toBeInTheDocument()
+    expect(screen.getByText('72%')).toBeInTheDocument()
+    expect(screen.getByText('New Collections (30d)')).toBeInTheDocument()
+    expect(screen.getByText('8')).toBeInTheDocument()
+  })
+
+  it('hides month range selector on community health view', () => {
+    renderWithProviders(<AnalyticsDashboard />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Community Health/i }))
+
+    expect(screen.queryByText('Range:')).not.toBeInTheDocument()
+  })
+
+  it('renders top contributors table in community view', () => {
+    renderWithProviders(<AnalyticsDashboard />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Community Health/i }))
+
+    expect(screen.getByText('Top Contributors (30d)')).toBeInTheDocument()
+    expect(screen.getByText('Alice M.')).toBeInTheDocument()
+    expect(screen.getByText('@alice')).toBeInTheDocument()
+    expect(screen.getByText('50 contributions')).toBeInTheDocument()
+    expect(screen.getByText('bob')).toBeInTheDocument()
+    expect(screen.getByText('35 contributions')).toBeInTheDocument()
+  })
+
+  it('switches to data quality view on click', () => {
+    renderWithProviders(<AnalyticsDashboard />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Data Quality/i }))
+
+    expect(screen.getByText('Pending Review')).toBeInTheDocument()
+    expect(screen.getByText('23')).toBeInTheDocument()
+    expect(screen.getByText('Artists Without Releases')).toBeInTheDocument()
+    expect(screen.getByText('45')).toBeInTheDocument()
+    expect(screen.getByText('Inactive Venues (90d)')).toBeInTheDocument()
+    expect(screen.getByText('12')).toBeInTheDocument()
+    expect(screen.getByText('Show Approval Trends')).toBeInTheDocument()
+  })
+
+  it('changes month range when selector is clicked', () => {
+    renderWithProviders(<AnalyticsDashboard />)
+
+    // Click 12mo
+    fireEvent.click(screen.getByRole('button', { name: '12mo' }))
+
+    // The hook should be called with 12
+    expect(mockUseGrowthMetrics).toHaveBeenCalledWith(12)
+  })
+
+  it('shows loading state for community health', () => {
+    mockUseCommunityHealth.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    })
+
+    renderWithProviders(<AnalyticsDashboard />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Community Health/i }))
+
+    expect(screen.queryByText('Active Contributors (30d)')).not.toBeInTheDocument()
+  })
+
+  it('shows error state for data quality trends', () => {
+    mockUseDataQualityTrends.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('Failed'),
+    })
+
+    renderWithProviders(<AnalyticsDashboard />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Data Quality/i }))
+
+    expect(
+      screen.getByText('Failed to load data quality trends.')
+    ).toBeInTheDocument()
+  })
+
+  it('shows empty top contributors message', () => {
+    mockUseCommunityHealth.mockReturnValue({
+      data: {
+        ...mockCommunityData,
+        top_contributors: [],
+      },
+      isLoading: false,
+      error: null,
+    })
+
+    renderWithProviders(<AnalyticsDashboard />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Community Health/i }))
+
+    expect(
+      screen.getByText('No contributions in the last 30 days.')
+    ).toBeInTheDocument()
+  })
+})

--- a/frontend/app/admin/analytics/_components/AnalyticsDashboard.tsx
+++ b/frontend/app/admin/analytics/_components/AnalyticsDashboard.tsx
@@ -1,0 +1,726 @@
+'use client'
+
+import { useState } from 'react'
+import { Loader2, TrendingUp, Heart, Users, ShieldCheck } from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  useGrowthMetrics,
+  useEngagementMetrics,
+  useCommunityHealth,
+  useDataQualityTrends,
+} from '@/lib/hooks/admin/useAnalytics'
+import type {
+  MonthlyCount,
+  TopContributor,
+  WeeklyContribution,
+} from '@/lib/hooks/admin/useAnalytics'
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  AreaChart,
+  Area,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+} from 'recharts'
+
+// --- Constants ---
+
+type MonthRange = 3 | 6 | 12 | 24
+const MONTH_OPTIONS: MonthRange[] = [3, 6, 12, 24]
+
+// Chart color palette — distinct, accessible colors
+const COLORS = {
+  shows: '#3b82f6', // blue-500
+  artists: '#8b5cf6', // violet-500
+  venues: '#f97316', // orange-500
+  releases: '#10b981', // emerald-500
+  labels: '#ec4899', // pink-500
+  users: '#6366f1', // indigo-500
+  // Engagement
+  bookmarks: '#3b82f6',
+  tags_added: '#8b5cf6',
+  tag_votes: '#a78bfa',
+  collection_items: '#f97316',
+  requests: '#10b981',
+  request_votes: '#34d399',
+  revisions: '#ec4899',
+  follows: '#6366f1',
+  attendance: '#f59e0b',
+  // Data quality
+  approved: '#10b981',
+  rejected: '#ef4444',
+}
+
+// --- Sub-section labels ---
+type AnalyticsView = 'growth' | 'engagement' | 'community' | 'data-quality'
+
+const VIEW_CONFIG: { key: AnalyticsView; label: string; icon: typeof TrendingUp }[] = [
+  { key: 'growth', label: 'Growth', icon: TrendingUp },
+  { key: 'engagement', label: 'Engagement', icon: Heart },
+  { key: 'community', label: 'Community Health', icon: Users },
+  { key: 'data-quality', label: 'Data Quality', icon: ShieldCheck },
+]
+
+// --- Helpers ---
+
+/** Format "2026-03" → "Mar 2026" */
+function formatMonth(month: string): string {
+  const [year, mon] = month.split('-')
+  const date = new Date(Number(year), Number(mon) - 1)
+  return date.toLocaleDateString('en-US', { month: 'short', year: 'numeric' })
+}
+
+/** Format "2026-W11" → "W11" */
+function formatWeek(week: string): string {
+  const match = week.match(/W(\d+)/)
+  return match ? `W${match[1]}` : week
+}
+
+/** Format float 0-1 → "72%" */
+function formatPercent(value: number): string {
+  return `${Math.round(value * 100)}%`
+}
+
+/** Build unified chart data from multiple series keyed by month */
+function mergeMonthlyData(
+  series: Record<string, MonthlyCount[]>
+): Record<string, string | number>[] {
+  const monthMap = new Map<string, Record<string, string | number>>()
+  for (const [key, data] of Object.entries(series)) {
+    for (const item of data) {
+      if (!monthMap.has(item.month)) {
+        monthMap.set(item.month, { month: formatMonth(item.month) })
+      }
+      monthMap.get(item.month)![key] = item.count
+    }
+  }
+  // Sort chronologically
+  const entries = Array.from(monthMap.entries())
+  entries.sort(([a], [b]) => a.localeCompare(b))
+  return entries.map(([, v]) => v)
+}
+
+// --- Stat Card Component ---
+
+function StatCard({
+  label,
+  value,
+  description,
+}: {
+  label: string
+  value: string | number
+  description?: string
+}) {
+  return (
+    <Card>
+      <CardContent className="py-4">
+        <p className="text-sm font-medium text-muted-foreground">{label}</p>
+        <p className="mt-1 text-2xl font-bold tabular-nums">{value}</p>
+        {description && (
+          <p className="mt-1 text-xs text-muted-foreground">{description}</p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+// --- Month Range Selector ---
+
+function MonthRangeSelector({
+  value,
+  onChange,
+}: {
+  value: MonthRange
+  onChange: (m: MonthRange) => void
+}) {
+  return (
+    <div className="flex items-center gap-1">
+      <span className="mr-2 text-sm text-muted-foreground">Range:</span>
+      {MONTH_OPTIONS.map((m) => (
+        <Button
+          key={m}
+          variant={value === m ? 'default' : 'outline'}
+          size="sm"
+          onClick={() => onChange(m)}
+          className="h-7 px-2.5 text-xs"
+        >
+          {m}mo
+        </Button>
+      ))}
+    </div>
+  )
+}
+
+// --- Chart Wrapper ---
+
+function ChartCard({
+  title,
+  children,
+}: {
+  title: string
+  children: React.ReactNode
+}) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-medium">{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="h-72">{children}</div>
+      </CardContent>
+    </Card>
+  )
+}
+
+// --- Growth Section ---
+
+function GrowthSection({ months }: { months: MonthRange }) {
+  const { data, isLoading, error } = useGrowthMetrics(months)
+
+  if (isLoading) return <LoadingState />
+  if (error) return <ErrorState message="Failed to load growth metrics." />
+  if (!data) return null
+
+  const chartData = mergeMonthlyData({
+    shows: data.shows,
+    artists: data.artists,
+    venues: data.venues,
+    releases: data.releases,
+    labels: data.labels,
+    users: data.users,
+  })
+
+  return (
+    <div className="space-y-4">
+      <ChartCard title="Entity Creation Trends">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={chartData}>
+            <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+            <XAxis
+              dataKey="month"
+              tick={{ fontSize: 12 }}
+              className="fill-muted-foreground"
+            />
+            <YAxis tick={{ fontSize: 12 }} className="fill-muted-foreground" />
+            <Tooltip
+              contentStyle={{
+                backgroundColor: 'hsl(var(--popover))',
+                border: '1px solid hsl(var(--border))',
+                borderRadius: '0.5rem',
+                color: 'hsl(var(--popover-foreground))',
+              }}
+            />
+            <Legend />
+            <Line
+              type="monotone"
+              dataKey="shows"
+              stroke={COLORS.shows}
+              strokeWidth={2}
+              dot={false}
+              name="Shows"
+            />
+            <Line
+              type="monotone"
+              dataKey="artists"
+              stroke={COLORS.artists}
+              strokeWidth={2}
+              dot={false}
+              name="Artists"
+            />
+            <Line
+              type="monotone"
+              dataKey="venues"
+              stroke={COLORS.venues}
+              strokeWidth={2}
+              dot={false}
+              name="Venues"
+            />
+            <Line
+              type="monotone"
+              dataKey="releases"
+              stroke={COLORS.releases}
+              strokeWidth={2}
+              dot={false}
+              name="Releases"
+            />
+            <Line
+              type="monotone"
+              dataKey="labels"
+              stroke={COLORS.labels}
+              strokeWidth={2}
+              dot={false}
+              name="Labels"
+            />
+            <Line
+              type="monotone"
+              dataKey="users"
+              stroke={COLORS.users}
+              strokeWidth={2}
+              dot={false}
+              name="Users"
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </ChartCard>
+    </div>
+  )
+}
+
+// --- Engagement Section ---
+
+function EngagementSection({ months }: { months: MonthRange }) {
+  const { data, isLoading, error } = useEngagementMetrics(months)
+
+  if (isLoading) return <LoadingState />
+  if (error) return <ErrorState message="Failed to load engagement metrics." />
+  if (!data) return null
+
+  // Group 1: Content curation (tags + collections)
+  const curationData = mergeMonthlyData({
+    tags_added: data.tags_added,
+    tag_votes: data.tag_votes,
+    collection_items: data.collection_items,
+  })
+
+  // Group 2: Requests & voting
+  const requestsData = mergeMonthlyData({
+    requests: data.requests,
+    request_votes: data.request_votes,
+  })
+
+  // Group 3: Social engagement
+  const socialData = mergeMonthlyData({
+    bookmarks: data.bookmarks,
+    follows: data.follows,
+    attendance: data.attendance,
+    revisions: data.revisions,
+  })
+
+  return (
+    <div className="space-y-4">
+      <ChartCard title="Content Curation">
+        <ResponsiveContainer width="100%" height="100%">
+          <AreaChart data={curationData}>
+            <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+            <XAxis
+              dataKey="month"
+              tick={{ fontSize: 12 }}
+              className="fill-muted-foreground"
+            />
+            <YAxis tick={{ fontSize: 12 }} className="fill-muted-foreground" />
+            <Tooltip
+              contentStyle={{
+                backgroundColor: 'hsl(var(--popover))',
+                border: '1px solid hsl(var(--border))',
+                borderRadius: '0.5rem',
+                color: 'hsl(var(--popover-foreground))',
+              }}
+            />
+            <Legend />
+            <Area
+              type="monotone"
+              dataKey="tags_added"
+              stroke={COLORS.tags_added}
+              fill={COLORS.tags_added}
+              fillOpacity={0.15}
+              strokeWidth={2}
+              name="Tags Added"
+            />
+            <Area
+              type="monotone"
+              dataKey="tag_votes"
+              stroke={COLORS.tag_votes}
+              fill={COLORS.tag_votes}
+              fillOpacity={0.15}
+              strokeWidth={2}
+              name="Tag Votes"
+            />
+            <Area
+              type="monotone"
+              dataKey="collection_items"
+              stroke={COLORS.collection_items}
+              fill={COLORS.collection_items}
+              fillOpacity={0.15}
+              strokeWidth={2}
+              name="Collection Items"
+            />
+          </AreaChart>
+        </ResponsiveContainer>
+      </ChartCard>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <ChartCard title="Requests & Voting">
+          <ResponsiveContainer width="100%" height="100%">
+            <AreaChart data={requestsData}>
+              <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+              <XAxis
+                dataKey="month"
+                tick={{ fontSize: 12 }}
+                className="fill-muted-foreground"
+              />
+              <YAxis tick={{ fontSize: 12 }} className="fill-muted-foreground" />
+              <Tooltip
+                contentStyle={{
+                  backgroundColor: 'hsl(var(--popover))',
+                  border: '1px solid hsl(var(--border))',
+                  borderRadius: '0.5rem',
+                  color: 'hsl(var(--popover-foreground))',
+                }}
+              />
+              <Legend />
+              <Area
+                type="monotone"
+                dataKey="requests"
+                stroke={COLORS.requests}
+                fill={COLORS.requests}
+                fillOpacity={0.15}
+                strokeWidth={2}
+                name="Requests"
+              />
+              <Area
+                type="monotone"
+                dataKey="request_votes"
+                stroke={COLORS.request_votes}
+                fill={COLORS.request_votes}
+                fillOpacity={0.15}
+                strokeWidth={2}
+                name="Request Votes"
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        </ChartCard>
+
+        <ChartCard title="Social Engagement">
+          <ResponsiveContainer width="100%" height="100%">
+            <AreaChart data={socialData}>
+              <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+              <XAxis
+                dataKey="month"
+                tick={{ fontSize: 12 }}
+                className="fill-muted-foreground"
+              />
+              <YAxis tick={{ fontSize: 12 }} className="fill-muted-foreground" />
+              <Tooltip
+                contentStyle={{
+                  backgroundColor: 'hsl(var(--popover))',
+                  border: '1px solid hsl(var(--border))',
+                  borderRadius: '0.5rem',
+                  color: 'hsl(var(--popover-foreground))',
+                }}
+              />
+              <Legend />
+              <Area
+                type="monotone"
+                dataKey="bookmarks"
+                stroke={COLORS.bookmarks}
+                fill={COLORS.bookmarks}
+                fillOpacity={0.15}
+                strokeWidth={2}
+                name="Bookmarks"
+              />
+              <Area
+                type="monotone"
+                dataKey="follows"
+                stroke={COLORS.follows}
+                fill={COLORS.follows}
+                fillOpacity={0.15}
+                strokeWidth={2}
+                name="Follows"
+              />
+              <Area
+                type="monotone"
+                dataKey="attendance"
+                stroke={COLORS.attendance}
+                fill={COLORS.attendance}
+                fillOpacity={0.15}
+                strokeWidth={2}
+                name="Attendance"
+              />
+              <Area
+                type="monotone"
+                dataKey="revisions"
+                stroke={COLORS.revisions}
+                fill={COLORS.revisions}
+                fillOpacity={0.15}
+                strokeWidth={2}
+                name="Revisions"
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        </ChartCard>
+      </div>
+    </div>
+  )
+}
+
+// --- Community Health Section ---
+
+function CommunityHealthSection() {
+  const { data, isLoading, error } = useCommunityHealth()
+
+  if (isLoading) return <LoadingState />
+  if (error) return <ErrorState message="Failed to load community health." />
+  if (!data) return null
+
+  const weeklyData = data.contributions_per_week.map(
+    (w: WeeklyContribution) => ({
+      week: formatWeek(w.week),
+      count: w.count,
+    })
+  )
+
+  return (
+    <div className="space-y-4">
+      {/* Stat cards */}
+      <div className="grid gap-4 sm:grid-cols-3">
+        <StatCard
+          label="Active Contributors (30d)"
+          value={data.active_contributors_30d}
+          description="Users with at least 1 contribution in the last 30 days"
+        />
+        <StatCard
+          label="Request Fulfillment Rate"
+          value={formatPercent(data.request_fulfillment_rate)}
+          description="Percentage of requests that have been fulfilled"
+        />
+        <StatCard
+          label="New Collections (30d)"
+          value={data.new_collections_30d}
+          description="Collections created in the last 30 days"
+        />
+      </div>
+
+      {/* Weekly contributions chart */}
+      <ChartCard title="Weekly Contributions (Last 12 Weeks)">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={weeklyData}>
+            <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+            <XAxis
+              dataKey="week"
+              tick={{ fontSize: 12 }}
+              className="fill-muted-foreground"
+            />
+            <YAxis tick={{ fontSize: 12 }} className="fill-muted-foreground" />
+            <Tooltip
+              contentStyle={{
+                backgroundColor: 'hsl(var(--popover))',
+                border: '1px solid hsl(var(--border))',
+                borderRadius: '0.5rem',
+                color: 'hsl(var(--popover-foreground))',
+              }}
+            />
+            <Bar
+              dataKey="count"
+              fill={COLORS.shows}
+              radius={[4, 4, 0, 0]}
+              name="Contributions"
+            />
+          </BarChart>
+        </ResponsiveContainer>
+      </ChartCard>
+
+      {/* Top contributors table */}
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium">
+            Top Contributors (30d)
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {data.top_contributors.length === 0 ? (
+            <p className="py-4 text-center text-sm text-muted-foreground">
+              No contributions in the last 30 days.
+            </p>
+          ) : (
+            <div className="divide-y divide-border">
+              {data.top_contributors.map(
+                (contributor: TopContributor, index: number) => (
+                  <div
+                    key={contributor.user_id}
+                    className="flex items-center justify-between py-2.5"
+                  >
+                    <div className="flex items-center gap-3">
+                      <span className="flex h-6 w-6 items-center justify-center rounded-full bg-muted text-xs font-medium text-muted-foreground">
+                        {index + 1}
+                      </span>
+                      <div>
+                        <p className="text-sm font-medium">
+                          {contributor.display_name || contributor.username}
+                        </p>
+                        {contributor.display_name && (
+                          <p className="text-xs text-muted-foreground">
+                            @{contributor.username}
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                    <Badge variant="secondary" className="tabular-nums">
+                      {contributor.count} contribution
+                      {contributor.count !== 1 ? 's' : ''}
+                    </Badge>
+                  </div>
+                )
+              )}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+// --- Data Quality Trends Section ---
+
+function DataQualityTrendsSection({ months }: { months: MonthRange }) {
+  const { data, isLoading, error } = useDataQualityTrends(months)
+
+  if (isLoading) return <LoadingState />
+  if (error) return <ErrorState message="Failed to load data quality trends." />
+  if (!data) return null
+
+  const chartData = mergeMonthlyData({
+    approved: data.shows_approved,
+    rejected: data.shows_rejected,
+  })
+
+  return (
+    <div className="space-y-4">
+      {/* Snapshot stat cards */}
+      <div className="grid gap-4 sm:grid-cols-3">
+        <StatCard
+          label="Pending Review"
+          value={data.pending_review_count}
+          description="Shows awaiting admin review"
+        />
+        <StatCard
+          label="Artists Without Releases"
+          value={data.artists_without_releases}
+          description="Artists with no linked releases"
+        />
+        <StatCard
+          label="Inactive Venues (90d)"
+          value={data.inactive_venues_90d}
+          description="Venues with no shows in the last 90 days"
+        />
+      </div>
+
+      {/* Approved vs Rejected trends */}
+      <ChartCard title="Show Approval Trends">
+        <ResponsiveContainer width="100%" height="100%">
+          <AreaChart data={chartData}>
+            <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+            <XAxis
+              dataKey="month"
+              tick={{ fontSize: 12 }}
+              className="fill-muted-foreground"
+            />
+            <YAxis tick={{ fontSize: 12 }} className="fill-muted-foreground" />
+            <Tooltip
+              contentStyle={{
+                backgroundColor: 'hsl(var(--popover))',
+                border: '1px solid hsl(var(--border))',
+                borderRadius: '0.5rem',
+                color: 'hsl(var(--popover-foreground))',
+              }}
+            />
+            <Legend />
+            <Area
+              type="monotone"
+              dataKey="approved"
+              stroke={COLORS.approved}
+              fill={COLORS.approved}
+              fillOpacity={0.2}
+              strokeWidth={2}
+              name="Approved"
+            />
+            <Area
+              type="monotone"
+              dataKey="rejected"
+              stroke={COLORS.rejected}
+              fill={COLORS.rejected}
+              fillOpacity={0.2}
+              strokeWidth={2}
+              name="Rejected"
+            />
+          </AreaChart>
+        </ResponsiveContainer>
+      </ChartCard>
+    </div>
+  )
+}
+
+// --- Shared states ---
+
+function LoadingState() {
+  return (
+    <div className="flex items-center justify-center py-12">
+      <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+    </div>
+  )
+}
+
+function ErrorState({ message }: { message: string }) {
+  return (
+    <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4">
+      <p className="text-sm text-destructive">{message}</p>
+    </div>
+  )
+}
+
+// --- Main Dashboard ---
+
+export function AnalyticsDashboard() {
+  const [activeView, setActiveView] = useState<AnalyticsView>('growth')
+  const [months, setMonths] = useState<MonthRange>(6)
+
+  const showMonthSelector = activeView !== 'community'
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h2 className="text-lg font-semibold">Analytics</h2>
+        <p className="text-sm text-muted-foreground">
+          Platform growth, engagement, and data health metrics.
+        </p>
+      </div>
+
+      {/* View selector + month range */}
+      <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-wrap gap-1">
+          {VIEW_CONFIG.map(({ key, label, icon: Icon }) => (
+            <Button
+              key={key}
+              variant={activeView === key ? 'default' : 'outline'}
+              size="sm"
+              onClick={() => setActiveView(key)}
+              className="gap-1.5"
+            >
+              <Icon className="h-3.5 w-3.5" />
+              {label}
+            </Button>
+          ))}
+        </div>
+
+        {showMonthSelector && (
+          <MonthRangeSelector value={months} onChange={setMonths} />
+        )}
+      </div>
+
+      {/* Active section */}
+      {activeView === 'growth' && <GrowthSection months={months} />}
+      {activeView === 'engagement' && <EngagementSection months={months} />}
+      {activeView === 'community' && <CommunityHealthSection />}
+      {activeView === 'data-quality' && (
+        <DataQualityTrendsSection months={months} />
+      )}
+    </div>
+  )
+}

--- a/frontend/app/admin/analytics/page.tsx
+++ b/frontend/app/admin/analytics/page.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import { AnalyticsDashboard } from '@/app/admin/analytics/_components/AnalyticsDashboard'
+
+export default function AnalyticsPage() {
+  return <AnalyticsDashboard />
+}

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import dynamic from 'next/dynamic'
-import { Shield, MapPin, Loader2, Upload, BadgeCheck, Flag, ScrollText, Users, LayoutDashboard, Clock, Disc3, Tag, Tags, Tent, Workflow, Library, Music, ClipboardCheck } from 'lucide-react'
+import { Shield, MapPin, Loader2, Upload, BadgeCheck, Flag, ScrollText, Users, LayoutDashboard, Clock, Disc3, Tag, Tags, Tent, Workflow, Library, Music, ClipboardCheck, BarChart3 } from 'lucide-react'
 import { usePendingVenueEdits } from '@/lib/hooks/admin/useAdminVenueEdits'
 import { useUnverifiedVenues } from '@/lib/hooks/admin/useAdminVenues'
 import { usePendingReports } from '@/lib/hooks/admin/useAdminReports'
@@ -123,6 +123,14 @@ const TagsPage = dynamic(() => import('./tags/page'), {
 })
 
 const DataQualityPage = dynamic(() => import('./data-quality/page'), {
+  loading: () => (
+    <div className="flex items-center justify-center py-12">
+      <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+    </div>
+  ),
+})
+
+const AnalyticsPage = dynamic(() => import('./analytics/page'), {
   loading: () => (
     <div className="flex items-center justify-center py-12">
       <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
@@ -264,6 +272,10 @@ export default function AdminPage() {
               <ClipboardCheck className="h-4 w-4" />
               Data Quality
             </TabsTrigger>
+            <TabsTrigger value="analytics" className="gap-2">
+              <BarChart3 className="h-4 w-4" />
+              Analytics
+            </TabsTrigger>
             <TabsTrigger value="artists-admin" className="gap-2">
               <Music className="h-4 w-4" />
               Artists
@@ -328,6 +340,10 @@ export default function AdminPage() {
 
           <TabsContent value="data-quality" className="space-y-4">
             <DataQualityPage />
+          </TabsContent>
+
+          <TabsContent value="analytics" className="space-y-4">
+            <AnalyticsPage />
           </TabsContent>
 
           <TabsContent value="artists-admin" className="space-y-4">

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -32,6 +32,7 @@
         "radix-ui": "^1.4.3",
         "react": "19.2.0",
         "react-dom": "19.2.0",
+        "recharts": "^3.8.0",
         "tailwind-merge": "^3.4.0",
         "use-debounce": "^10.0.6",
         "zod": "^4.1.13",
@@ -563,6 +564,8 @@
 
     "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
 
+    "@reduxjs/toolkit": ["@reduxjs/toolkit@2.11.2", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^11.0.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" }, "optionalPeers": ["react", "react-redux"] }, "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ=="],
+
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.53", "", {}, "sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ=="],
 
     "@rollup/plugin-commonjs": ["@rollup/plugin-commonjs@28.0.1", "", { "dependencies": { "@rollup/pluginutils": "^5.0.1", "commondir": "^1.0.1", "estree-walker": "^2.0.2", "fdir": "^6.2.0", "is-reference": "1.2.1", "magic-string": "^0.30.3", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^2.68.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-+tNWdlWKbpB3WgBN7ijjYkq9X5uhjmcvyjEght4NmH5fAU++zfQzAJ6wumLS+dNcvwEZhKx2Z+skY8m7v0wGSA=="],
@@ -673,6 +676,8 @@
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
+    "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
+
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.1.17", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "enhanced-resolve": "^5.18.3", "jiti": "^2.6.1", "lightningcss": "1.30.2", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.1.17" } }, "sha512-csIkHIgLb3JisEFQ0vxr2Y57GUNYh447C8xzwj89U/8fdW8LhProdxvnVH6U8M2Y73QKiTIH+LWbK3V2BBZsAg=="],
@@ -745,6 +750,24 @@
 
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
     "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
 
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
@@ -786,6 +809,8 @@
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.47.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.10.0", "@typescript-eslint/scope-manager": "8.47.0", "@typescript-eslint/type-utils": "8.47.0", "@typescript-eslint/utils": "8.47.0", "@typescript-eslint/visitor-keys": "8.47.0", "graphemer": "^1.4.0", "ignore": "^7.0.0", "natural-compare": "^1.4.0", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.47.0", "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-fe0rz9WJQ5t2iaLfdbDc9T80GJy0AeO453q8C3YCilnGozvOyCG5t+EZtg7j7D88+c3FipfP/x+wzGnh1xp8ZA=="],
 
@@ -1051,6 +1076,28 @@
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
     "damerau-levenshtein": ["damerau-levenshtein@1.0.8", "", {}, "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA=="],
 
     "data-urls": ["data-urls@6.0.0", "", { "dependencies": { "whatwg-mimetype": "^4.0.0", "whatwg-url": "^15.0.0" } }, "sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA=="],
@@ -1066,6 +1113,8 @@
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
+
+    "decimal.js-light": ["decimal.js-light@2.5.1", "", {}, "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="],
 
     "decode-named-character-reference": ["decode-named-character-reference@1.2.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q=="],
 
@@ -1122,6 +1171,8 @@
     "es-shim-unscopables": ["es-shim-unscopables@1.1.0", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw=="],
 
     "es-to-primitive": ["es-to-primitive@1.3.0", "", { "dependencies": { "is-callable": "^1.2.7", "is-date-object": "^1.0.5", "is-symbol": "^1.0.4" } }, "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g=="],
+
+    "es-toolkit": ["es-toolkit@1.45.1", "", {}, "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw=="],
 
     "esast-util-from-estree": ["esast-util-from-estree@2.0.0", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "devlop": "^1.0.0", "estree-util-visit": "^2.0.0", "unist-util-position-from-estree": "^2.0.0" } }, "sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ=="],
 
@@ -1184,6 +1235,8 @@
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
     "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
 
@@ -1307,6 +1360,8 @@
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
+    "immer": ["immer@10.2.0", "", {}, "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw=="],
+
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
     "import-in-the-middle": ["import-in-the-middle@2.0.6", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw=="],
@@ -1318,6 +1373,8 @@
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
 
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
+
+    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
     "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
 
@@ -1727,6 +1784,8 @@
 
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
+    "react-redux": ["react-redux@9.2.0", "", { "dependencies": { "@types/use-sync-external-store": "^0.0.6", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "@types/react": "^18.2.25 || ^19", "react": "^18.0 || ^19", "redux": "^5.0.0" }, "optionalPeers": ["@types/react", "redux"] }, "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g=="],
+
     "react-refresh": ["react-refresh@0.18.0", "", {}, "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw=="],
 
     "react-remove-scroll": ["react-remove-scroll@2.7.1", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-HpMh8+oahmIdOuS5aFKKY6Pyog+FNaZV/XyJOq7b4YFwsFHe5yYfdbIalI4k3vU2nSDql7YskmUseHsRrJqIPA=="],
@@ -1737,6 +1796,8 @@
 
     "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
+    "recharts": ["recharts@3.8.0", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^10.1.1", "react-redux": "8.x.x || 9.x.x", "reselect": "5.1.1", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ=="],
+
     "recma-build-jsx": ["recma-build-jsx@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-util-build-jsx": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew=="],
 
     "recma-jsx": ["recma-jsx@1.0.1", "", { "dependencies": { "acorn-jsx": "^5.0.0", "estree-util-to-js": "^2.0.0", "recma-parse": "^1.0.0", "recma-stringify": "^1.0.0", "unified": "^11.0.0" }, "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-huSIy7VU2Z5OLv6oFLosQGGDqPqdO1iq6bWNAdhzMxSJP7RAso4fCZ1cKu8j9YHCZf3TPrq4dw3okhrylgcd7w=="],
@@ -1746,6 +1807,10 @@
     "recma-stringify": ["recma-stringify@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-util-to-js": "^2.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g=="],
 
     "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
+
+    "redux": ["redux@5.0.1", "", {}, "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="],
+
+    "redux-thunk": ["redux-thunk@3.1.0", "", { "peerDependencies": { "redux": "^5.0.0" } }, "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw=="],
 
     "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw=="],
 
@@ -1762,6 +1827,8 @@
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
     "require-in-the-middle": ["require-in-the-middle@8.0.1", "", { "dependencies": { "debug": "^4.3.5", "module-details-from-path": "^1.0.3" } }, "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ=="],
+
+    "reselect": ["reselect@5.1.1", "", {}, "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="],
 
     "resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
 
@@ -1895,6 +1962,8 @@
 
     "terser-webpack-plugin": ["terser-webpack-plugin@5.3.16", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.25", "jest-worker": "^27.4.5", "schema-utils": "^4.3.0", "serialize-javascript": "^6.0.2", "terser": "^5.31.1" }, "peerDependencies": { "webpack": "^5.1.0" } }, "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q=="],
 
+    "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
+
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
     "tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
@@ -1990,6 +2059,8 @@
     "vfile-matter": ["vfile-matter@5.0.1", "", { "dependencies": { "vfile": "^6.0.0", "yaml": "^2.0.0" } }, "sha512-o6roP82AiX0XfkyTHyRCMXgHfltUNlXSEqCIS80f+mbAyiQBE2fxtDVMtseyytGx75sihiJFo/zR6r/4LTs2Cw=="],
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
+
+    "victory-vendor": ["victory-vendor@37.3.6", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ=="],
 
     "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
 
@@ -2106,6 +2177,8 @@
     "@radix-ui/react-select/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@radix-ui/react-tooltip/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@reduxjs/toolkit/immer": ["immer@11.1.4", "", {}, "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw=="],
 
     "@rollup/plugin-commonjs/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -284,6 +284,12 @@ export const API_ENDPOINTS = {
       CATEGORY: (category: string) =>
         `${API_BASE_URL}/admin/data-quality/${category}`,
     },
+    ANALYTICS: {
+      GROWTH: `${API_BASE_URL}/admin/analytics/growth`,
+      ENGAGEMENT: `${API_BASE_URL}/admin/analytics/engagement`,
+      COMMUNITY: `${API_BASE_URL}/admin/analytics/community`,
+      DATA_QUALITY: `${API_BASE_URL}/admin/analytics/data-quality`,
+    },
     PIPELINE: {
       VENUES: `${API_BASE_URL}/admin/pipeline/venues`,
       EXTRACT: (venueId: string | number) =>

--- a/frontend/lib/hooks/admin/index.ts
+++ b/frontend/lib/hooks/admin/index.ts
@@ -60,3 +60,17 @@ export {
   useUnverifiedVenues,
   useVerifyVenue,
 } from './useAdminVenues'
+
+export {
+  type MonthlyCount,
+  type GrowthMetrics,
+  type EngagementMetrics,
+  type WeeklyContribution,
+  type TopContributor,
+  type CommunityHealth,
+  type DataQualityTrends,
+  useGrowthMetrics,
+  useEngagementMetrics,
+  useCommunityHealth,
+  useDataQualityTrends,
+} from './useAnalytics'

--- a/frontend/lib/hooks/admin/useAnalytics.test.tsx
+++ b/frontend/lib/hooks/admin/useAnalytics.test.tsx
@@ -1,0 +1,281 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { createWrapper } from '@/test/utils'
+
+// Create mock
+const mockApiRequest = vi.fn()
+
+// Mock the api module
+vi.mock('../../api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    ADMIN: {
+      ANALYTICS: {
+        GROWTH: '/admin/analytics/growth',
+        ENGAGEMENT: '/admin/analytics/engagement',
+        COMMUNITY: '/admin/analytics/community',
+        DATA_QUALITY: '/admin/analytics/data-quality',
+      },
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+// Mock queryClient module
+vi.mock('../../queryClient', () => ({
+  queryKeys: {
+    admin: {
+      analytics: {
+        growth: (months: number) => ['admin', 'analytics', 'growth', months],
+        engagement: (months: number) => ['admin', 'analytics', 'engagement', months],
+        community: ['admin', 'analytics', 'community'],
+        dataQualityTrends: (months: number) => ['admin', 'analytics', 'data-quality', months],
+      },
+    },
+  },
+}))
+
+// Import hooks after mocks
+import {
+  useGrowthMetrics,
+  useEngagementMetrics,
+  useCommunityHealth,
+  useDataQualityTrends,
+} from './useAnalytics'
+
+describe('useAnalytics hooks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  describe('useGrowthMetrics', () => {
+    it('fetches growth metrics with default months', async () => {
+      const mockResponse = {
+        shows: [{ month: '2026-01', count: 10 }],
+        artists: [{ month: '2026-01', count: 5 }],
+        venues: [{ month: '2026-01', count: 2 }],
+        releases: [{ month: '2026-01', count: 3 }],
+        labels: [{ month: '2026-01', count: 1 }],
+        users: [{ month: '2026-01', count: 8 }],
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(() => useGrowthMetrics(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/admin/analytics/growth?months=6',
+        { method: 'GET' }
+      )
+      expect(result.current.data?.shows).toHaveLength(1)
+      expect(result.current.data?.shows[0].count).toBe(10)
+    })
+
+    it('fetches growth metrics with custom months', async () => {
+      mockApiRequest.mockResolvedValueOnce({
+        shows: [],
+        artists: [],
+        venues: [],
+        releases: [],
+        labels: [],
+        users: [],
+      })
+
+      const { result } = renderHook(() => useGrowthMetrics(12), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/admin/analytics/growth?months=12',
+        { method: 'GET' }
+      )
+    })
+
+    it('handles API errors', async () => {
+      const error = new Error('Server error')
+      Object.assign(error, { status: 500 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(() => useGrowthMetrics(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+    })
+  })
+
+  describe('useEngagementMetrics', () => {
+    it('fetches engagement metrics with default months', async () => {
+      const mockResponse = {
+        bookmarks: [{ month: '2026-01', count: 20 }],
+        tags_added: [{ month: '2026-01', count: 15 }],
+        tag_votes: [{ month: '2026-01', count: 30 }],
+        collection_items: [{ month: '2026-01', count: 10 }],
+        requests: [{ month: '2026-01', count: 5 }],
+        request_votes: [{ month: '2026-01', count: 12 }],
+        revisions: [{ month: '2026-01', count: 8 }],
+        follows: [{ month: '2026-01', count: 25 }],
+        attendance: [{ month: '2026-01', count: 40 }],
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(() => useEngagementMetrics(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/admin/analytics/engagement?months=6',
+        { method: 'GET' }
+      )
+      expect(result.current.data?.bookmarks[0].count).toBe(20)
+      expect(result.current.data?.attendance[0].count).toBe(40)
+    })
+
+    it('fetches with custom months parameter', async () => {
+      mockApiRequest.mockResolvedValueOnce({
+        bookmarks: [],
+        tags_added: [],
+        tag_votes: [],
+        collection_items: [],
+        requests: [],
+        request_votes: [],
+        revisions: [],
+        follows: [],
+        attendance: [],
+      })
+
+      const { result } = renderHook(() => useEngagementMetrics(24), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/admin/analytics/engagement?months=24',
+        { method: 'GET' }
+      )
+    })
+
+    it('handles API errors', async () => {
+      mockApiRequest.mockRejectedValueOnce(new Error('Forbidden'))
+
+      const { result } = renderHook(() => useEngagementMetrics(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+    })
+  })
+
+  describe('useCommunityHealth', () => {
+    it('fetches community health snapshot', async () => {
+      const mockResponse = {
+        active_contributors_30d: 42,
+        contributions_per_week: [
+          { week: '2026-W10', count: 15 },
+          { week: '2026-W11', count: 20 },
+        ],
+        request_fulfillment_rate: 0.72,
+        new_collections_30d: 8,
+        top_contributors: [
+          { user_id: 1, username: 'alice', display_name: 'Alice', count: 50 },
+          { user_id: 2, username: 'bob', count: 35 },
+        ],
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(() => useCommunityHealth(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/admin/analytics/community',
+        { method: 'GET' }
+      )
+      expect(result.current.data?.active_contributors_30d).toBe(42)
+      expect(result.current.data?.request_fulfillment_rate).toBe(0.72)
+      expect(result.current.data?.top_contributors).toHaveLength(2)
+    })
+
+    it('handles API errors', async () => {
+      mockApiRequest.mockRejectedValueOnce(new Error('Server error'))
+
+      const { result } = renderHook(() => useCommunityHealth(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+    })
+  })
+
+  describe('useDataQualityTrends', () => {
+    it('fetches data quality trends with default months', async () => {
+      const mockResponse = {
+        shows_approved: [{ month: '2026-01', count: 100 }],
+        shows_rejected: [{ month: '2026-01', count: 15 }],
+        pending_review_count: 23,
+        artists_without_releases: 45,
+        inactive_venues_90d: 12,
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(() => useDataQualityTrends(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/admin/analytics/data-quality?months=6',
+        { method: 'GET' }
+      )
+      expect(result.current.data?.pending_review_count).toBe(23)
+      expect(result.current.data?.artists_without_releases).toBe(45)
+      expect(result.current.data?.inactive_venues_90d).toBe(12)
+    })
+
+    it('fetches with custom months parameter', async () => {
+      mockApiRequest.mockResolvedValueOnce({
+        shows_approved: [],
+        shows_rejected: [],
+        pending_review_count: 0,
+        artists_without_releases: 0,
+        inactive_venues_90d: 0,
+      })
+
+      const { result } = renderHook(() => useDataQualityTrends(3), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/admin/analytics/data-quality?months=3',
+        { method: 'GET' }
+      )
+    })
+
+    it('handles API errors', async () => {
+      const error = new Error('Server error')
+      Object.assign(error, { status: 500 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(() => useDataQualityTrends(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+    })
+  })
+})

--- a/frontend/lib/hooks/admin/useAnalytics.ts
+++ b/frontend/lib/hooks/admin/useAnalytics.ts
@@ -1,0 +1,121 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import { apiRequest, API_ENDPOINTS } from '../../api'
+import { queryKeys } from '../../queryClient'
+
+// --- Types ---
+
+export interface MonthlyCount {
+  month: string
+  count: number
+}
+
+export interface GrowthMetrics {
+  shows: MonthlyCount[]
+  artists: MonthlyCount[]
+  venues: MonthlyCount[]
+  releases: MonthlyCount[]
+  labels: MonthlyCount[]
+  users: MonthlyCount[]
+}
+
+export interface EngagementMetrics {
+  bookmarks: MonthlyCount[]
+  tags_added: MonthlyCount[]
+  tag_votes: MonthlyCount[]
+  collection_items: MonthlyCount[]
+  requests: MonthlyCount[]
+  request_votes: MonthlyCount[]
+  revisions: MonthlyCount[]
+  follows: MonthlyCount[]
+  attendance: MonthlyCount[]
+}
+
+export interface WeeklyContribution {
+  week: string
+  count: number
+}
+
+export interface TopContributor {
+  user_id: number
+  username: string
+  display_name?: string
+  count: number
+}
+
+export interface CommunityHealth {
+  active_contributors_30d: number
+  contributions_per_week: WeeklyContribution[]
+  request_fulfillment_rate: number
+  new_collections_30d: number
+  top_contributors: TopContributor[]
+}
+
+export interface DataQualityTrends {
+  shows_approved: MonthlyCount[]
+  shows_rejected: MonthlyCount[]
+  pending_review_count: number
+  artists_without_releases: number
+  inactive_venues_90d: number
+}
+
+// --- Hooks ---
+
+/**
+ * Hook to fetch growth metrics (entity creation trends over time)
+ */
+export const useGrowthMetrics = (months: number = 6) => {
+  return useQuery({
+    queryKey: queryKeys.admin.analytics.growth(months),
+    queryFn: async (): Promise<GrowthMetrics> => {
+      const url = `${API_ENDPOINTS.ADMIN.ANALYTICS.GROWTH}?months=${months}`
+      return apiRequest<GrowthMetrics>(url, { method: 'GET' })
+    },
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  })
+}
+
+/**
+ * Hook to fetch engagement metrics (user activity trends over time)
+ */
+export const useEngagementMetrics = (months: number = 6) => {
+  return useQuery({
+    queryKey: queryKeys.admin.analytics.engagement(months),
+    queryFn: async (): Promise<EngagementMetrics> => {
+      const url = `${API_ENDPOINTS.ADMIN.ANALYTICS.ENGAGEMENT}?months=${months}`
+      return apiRequest<EngagementMetrics>(url, { method: 'GET' })
+    },
+    staleTime: 5 * 60 * 1000,
+  })
+}
+
+/**
+ * Hook to fetch community health snapshot
+ */
+export const useCommunityHealth = () => {
+  return useQuery({
+    queryKey: queryKeys.admin.analytics.community,
+    queryFn: async (): Promise<CommunityHealth> => {
+      return apiRequest<CommunityHealth>(
+        API_ENDPOINTS.ADMIN.ANALYTICS.COMMUNITY,
+        { method: 'GET' }
+      )
+    },
+    staleTime: 5 * 60 * 1000,
+  })
+}
+
+/**
+ * Hook to fetch data quality trends (approval/rejection over time + snapshots)
+ */
+export const useDataQualityTrends = (months: number = 6) => {
+  return useQuery({
+    queryKey: queryKeys.admin.analytics.dataQualityTrends(months),
+    queryFn: async (): Promise<DataQualityTrends> => {
+      const url = `${API_ENDPOINTS.ADMIN.ANALYTICS.DATA_QUALITY}?months=${months}`
+      return apiRequest<DataQualityTrends>(url, { method: 'GET' })
+    },
+    staleTime: 5 * 60 * 1000,
+  })
+}

--- a/frontend/lib/queryClient.ts
+++ b/frontend/lib/queryClient.ts
@@ -157,6 +157,12 @@ export const queryKeys = {
       category: (category: string, limit: number, offset: number) =>
         ['admin', 'dataQuality', 'category', category, { limit, offset }] as const,
     },
+    analytics: {
+      growth: (months: number) => ['admin', 'analytics', 'growth', months] as const,
+      engagement: (months: number) => ['admin', 'analytics', 'engagement', months] as const,
+      community: ['admin', 'analytics', 'community'] as const,
+      dataQualityTrends: (months: number) => ['admin', 'analytics', 'data-quality', months] as const,
+    },
   },
 
   // Artist queries

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,6 +46,7 @@
     "radix-ui": "^1.4.3",
     "react": "19.2.0",
     "react-dom": "19.2.0",
+    "recharts": "^3.8.0",
     "tailwind-merge": "^3.4.0",
     "use-debounce": "^10.0.6",
     "zod": "^4.1.13"


### PR DESCRIPTION
## Summary
- Admin "Analytics" tab with 4 views: Growth, Engagement, Community Health, Data Quality
- Line/area charts via recharts showing entity creation and engagement trends over time
- Stat cards for community health metrics and data quality snapshots
- Top contributors table and weekly contributions chart
- Month range selector (3/6/12/24) shared across views
- 26 tests passing (11 hook + 15 component)

Closes PSY-104

## Test plan
- [ ] Verify Analytics tab appears in admin page
- [ ] Check all 4 views render with live data
- [ ] Test month range selector changes chart data
- [ ] Verify loading and error states
- [ ] Run `bun run test:run` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)