### PR TITLE
Add top charts backend with trending and popular endpoints (PSY-57)

### DIFF
--- a/backend/internal/api/handlers/charts.go
+++ b/backend/internal/api/handlers/charts.go
@@ -1,0 +1,331 @@
+package handlers
+
+import (
+	"context"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"psychic-homily-backend/internal/logger"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// ChartsHandler handles public top charts endpoints.
+type ChartsHandler struct {
+	chartsService contracts.ChartsServiceInterface
+}
+
+// NewChartsHandler creates a new charts handler.
+func NewChartsHandler(
+	chartsService contracts.ChartsServiceInterface,
+) *ChartsHandler {
+	return &ChartsHandler{
+		chartsService: chartsService,
+	}
+}
+
+// --- GetTrendingShows ---
+
+// GetTrendingShowsRequest is the Huma request for GET /charts/trending-shows
+type GetTrendingShowsRequest struct {
+	Limit int `query:"limit" required:"false" doc:"Number of results (default 20, max 50)"`
+}
+
+// TrendingShowResponse is a single trending show in the response.
+type TrendingShowResponse struct {
+	ShowID          uint      `json:"show_id"`
+	Title           string    `json:"title"`
+	Slug            string    `json:"slug"`
+	Date            time.Time `json:"date"`
+	VenueName       string    `json:"venue_name"`
+	VenueSlug       string    `json:"venue_slug"`
+	City            string    `json:"city"`
+	GoingCount      int       `json:"going_count"`
+	InterestedCount int       `json:"interested_count"`
+	TotalAttendance int       `json:"total_attendance"`
+}
+
+// GetTrendingShowsResponse is the Huma response for GET /charts/trending-shows
+type GetTrendingShowsResponse struct {
+	Body struct {
+		Shows []TrendingShowResponse `json:"shows"`
+	}
+}
+
+// GetTrendingShowsHandler handles GET /charts/trending-shows
+func (h *ChartsHandler) GetTrendingShowsHandler(ctx context.Context, req *GetTrendingShowsRequest) (*GetTrendingShowsResponse, error) {
+	limit := normalizeChartsLimit(req.Limit)
+
+	data, err := h.chartsService.GetTrendingShows(limit)
+	if err != nil {
+		logger.FromContext(ctx).Error("charts_trending_shows_failed", "error", err.Error())
+		return nil, huma.Error500InternalServerError("Failed to get trending shows")
+	}
+
+	resp := &GetTrendingShowsResponse{}
+	resp.Body.Shows = make([]TrendingShowResponse, len(data))
+	for i, s := range data {
+		resp.Body.Shows[i] = TrendingShowResponse{
+			ShowID:          s.ShowID,
+			Title:           s.Title,
+			Slug:            s.Slug,
+			Date:            s.Date,
+			VenueName:       s.VenueName,
+			VenueSlug:       s.VenueSlug,
+			City:            s.City,
+			GoingCount:      s.GoingCount,
+			InterestedCount: s.InterestedCount,
+			TotalAttendance: s.TotalAttendance,
+		}
+	}
+	return resp, nil
+}
+
+// --- GetPopularArtists ---
+
+// GetPopularArtistsRequest is the Huma request for GET /charts/popular-artists
+type GetPopularArtistsRequest struct {
+	Limit int `query:"limit" required:"false" doc:"Number of results (default 20, max 50)"`
+}
+
+// PopularArtistResponse is a single popular artist in the response.
+type PopularArtistResponse struct {
+	ArtistID          uint   `json:"artist_id"`
+	Name              string `json:"name"`
+	Slug              string `json:"slug"`
+	ImageURL          string `json:"image_url"`
+	FollowCount       int    `json:"follow_count"`
+	UpcomingShowCount int    `json:"upcoming_show_count"`
+	Score             int    `json:"score"`
+}
+
+// GetPopularArtistsResponse is the Huma response for GET /charts/popular-artists
+type GetPopularArtistsResponse struct {
+	Body struct {
+		Artists []PopularArtistResponse `json:"artists"`
+	}
+}
+
+// GetPopularArtistsHandler handles GET /charts/popular-artists
+func (h *ChartsHandler) GetPopularArtistsHandler(ctx context.Context, req *GetPopularArtistsRequest) (*GetPopularArtistsResponse, error) {
+	limit := normalizeChartsLimit(req.Limit)
+
+	data, err := h.chartsService.GetPopularArtists(limit)
+	if err != nil {
+		logger.FromContext(ctx).Error("charts_popular_artists_failed", "error", err.Error())
+		return nil, huma.Error500InternalServerError("Failed to get popular artists")
+	}
+
+	resp := &GetPopularArtistsResponse{}
+	resp.Body.Artists = make([]PopularArtistResponse, len(data))
+	for i, a := range data {
+		resp.Body.Artists[i] = PopularArtistResponse{
+			ArtistID:          a.ArtistID,
+			Name:              a.Name,
+			Slug:              a.Slug,
+			ImageURL:          a.ImageURL,
+			FollowCount:       a.FollowCount,
+			UpcomingShowCount: a.UpcomingShowCount,
+			Score:             a.Score,
+		}
+	}
+	return resp, nil
+}
+
+// --- GetActiveVenues ---
+
+// GetActiveVenuesRequest is the Huma request for GET /charts/active-venues
+type GetActiveVenuesRequest struct {
+	Limit int `query:"limit" required:"false" doc:"Number of results (default 20, max 50)"`
+}
+
+// ActiveVenueResponse is a single active venue in the response.
+type ActiveVenueResponse struct {
+	VenueID           uint   `json:"venue_id"`
+	Name              string `json:"name"`
+	Slug              string `json:"slug"`
+	City              string `json:"city"`
+	State             string `json:"state"`
+	UpcomingShowCount int    `json:"upcoming_show_count"`
+	FollowCount       int    `json:"follow_count"`
+	Score             int    `json:"score"`
+}
+
+// GetActiveVenuesResponse is the Huma response for GET /charts/active-venues
+type GetActiveVenuesResponse struct {
+	Body struct {
+		Venues []ActiveVenueResponse `json:"venues"`
+	}
+}
+
+// GetActiveVenuesHandler handles GET /charts/active-venues
+func (h *ChartsHandler) GetActiveVenuesHandler(ctx context.Context, req *GetActiveVenuesRequest) (*GetActiveVenuesResponse, error) {
+	limit := normalizeChartsLimit(req.Limit)
+
+	data, err := h.chartsService.GetActiveVenues(limit)
+	if err != nil {
+		logger.FromContext(ctx).Error("charts_active_venues_failed", "error", err.Error())
+		return nil, huma.Error500InternalServerError("Failed to get active venues")
+	}
+
+	resp := &GetActiveVenuesResponse{}
+	resp.Body.Venues = make([]ActiveVenueResponse, len(data))
+	for i, v := range data {
+		resp.Body.Venues[i] = ActiveVenueResponse{
+			VenueID:           v.VenueID,
+			Name:              v.Name,
+			Slug:              v.Slug,
+			City:              v.City,
+			State:             v.State,
+			UpcomingShowCount: v.UpcomingShowCount,
+			FollowCount:       v.FollowCount,
+			Score:             v.Score,
+		}
+	}
+	return resp, nil
+}
+
+// --- GetHotReleases ---
+
+// GetHotReleasesRequest is the Huma request for GET /charts/hot-releases
+type GetHotReleasesRequest struct {
+	Limit int `query:"limit" required:"false" doc:"Number of results (default 20, max 50)"`
+}
+
+// HotReleaseResponse is a single hot release in the response.
+type HotReleaseResponse struct {
+	ReleaseID     uint       `json:"release_id"`
+	Title         string     `json:"title"`
+	Slug          string     `json:"slug"`
+	ReleaseDate   *time.Time `json:"release_date"`
+	ArtistNames   []string   `json:"artist_names"`
+	BookmarkCount int        `json:"bookmark_count"`
+}
+
+// GetHotReleasesResponse is the Huma response for GET /charts/hot-releases
+type GetHotReleasesResponse struct {
+	Body struct {
+		Releases []HotReleaseResponse `json:"releases"`
+	}
+}
+
+// GetHotReleasesHandler handles GET /charts/hot-releases
+func (h *ChartsHandler) GetHotReleasesHandler(ctx context.Context, req *GetHotReleasesRequest) (*GetHotReleasesResponse, error) {
+	limit := normalizeChartsLimit(req.Limit)
+
+	data, err := h.chartsService.GetHotReleases(limit)
+	if err != nil {
+		logger.FromContext(ctx).Error("charts_hot_releases_failed", "error", err.Error())
+		return nil, huma.Error500InternalServerError("Failed to get hot releases")
+	}
+
+	resp := &GetHotReleasesResponse{}
+	resp.Body.Releases = make([]HotReleaseResponse, len(data))
+	for i, r := range data {
+		resp.Body.Releases[i] = HotReleaseResponse{
+			ReleaseID:     r.ReleaseID,
+			Title:         r.Title,
+			Slug:          r.Slug,
+			ReleaseDate:   r.ReleaseDate,
+			ArtistNames:   r.ArtistNames,
+			BookmarkCount: r.BookmarkCount,
+		}
+	}
+	return resp, nil
+}
+
+// --- GetChartsOverview ---
+
+// GetChartsOverviewRequest is the Huma request for GET /charts/overview
+type GetChartsOverviewRequest struct{}
+
+// GetChartsOverviewResponse is the Huma response for GET /charts/overview
+type GetChartsOverviewResponse struct {
+	Body struct {
+		TrendingShows  []TrendingShowResponse  `json:"trending_shows"`
+		PopularArtists []PopularArtistResponse `json:"popular_artists"`
+		ActiveVenues   []ActiveVenueResponse   `json:"active_venues"`
+		HotReleases    []HotReleaseResponse    `json:"hot_releases"`
+	}
+}
+
+// GetChartsOverviewHandler handles GET /charts/overview
+func (h *ChartsHandler) GetChartsOverviewHandler(ctx context.Context, _ *GetChartsOverviewRequest) (*GetChartsOverviewResponse, error) {
+	data, err := h.chartsService.GetChartsOverview()
+	if err != nil {
+		logger.FromContext(ctx).Error("charts_overview_failed", "error", err.Error())
+		return nil, huma.Error500InternalServerError("Failed to get charts overview")
+	}
+
+	resp := &GetChartsOverviewResponse{}
+
+	resp.Body.TrendingShows = make([]TrendingShowResponse, len(data.TrendingShows))
+	for i, s := range data.TrendingShows {
+		resp.Body.TrendingShows[i] = TrendingShowResponse{
+			ShowID:          s.ShowID,
+			Title:           s.Title,
+			Slug:            s.Slug,
+			Date:            s.Date,
+			VenueName:       s.VenueName,
+			VenueSlug:       s.VenueSlug,
+			City:            s.City,
+			GoingCount:      s.GoingCount,
+			InterestedCount: s.InterestedCount,
+			TotalAttendance: s.TotalAttendance,
+		}
+	}
+
+	resp.Body.PopularArtists = make([]PopularArtistResponse, len(data.PopularArtists))
+	for i, a := range data.PopularArtists {
+		resp.Body.PopularArtists[i] = PopularArtistResponse{
+			ArtistID:          a.ArtistID,
+			Name:              a.Name,
+			Slug:              a.Slug,
+			ImageURL:          a.ImageURL,
+			FollowCount:       a.FollowCount,
+			UpcomingShowCount: a.UpcomingShowCount,
+			Score:             a.Score,
+		}
+	}
+
+	resp.Body.ActiveVenues = make([]ActiveVenueResponse, len(data.ActiveVenues))
+	for i, v := range data.ActiveVenues {
+		resp.Body.ActiveVenues[i] = ActiveVenueResponse{
+			VenueID:           v.VenueID,
+			Name:              v.Name,
+			Slug:              v.Slug,
+			City:              v.City,
+			State:             v.State,
+			UpcomingShowCount: v.UpcomingShowCount,
+			FollowCount:       v.FollowCount,
+			Score:             v.Score,
+		}
+	}
+
+	resp.Body.HotReleases = make([]HotReleaseResponse, len(data.HotReleases))
+	for i, r := range data.HotReleases {
+		resp.Body.HotReleases[i] = HotReleaseResponse{
+			ReleaseID:     r.ReleaseID,
+			Title:         r.Title,
+			Slug:          r.Slug,
+			ReleaseDate:   r.ReleaseDate,
+			ArtistNames:   r.ArtistNames,
+			BookmarkCount: r.BookmarkCount,
+		}
+	}
+
+	return resp, nil
+}
+
+// --- Helpers ---
+
+// normalizeChartsLimit clamps the limit param to a valid range [1, 50], defaulting to 20.
+func normalizeChartsLimit(limit int) int {
+	if limit <= 0 {
+		return 20
+	}
+	if limit > 50 {
+		return 50
+	}
+	return limit
+}

--- a/backend/internal/api/handlers/charts_test.go
+++ b/backend/internal/api/handlers/charts_test.go
@@ -1,0 +1,416 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// ============================================================================
+// Mock: ChartsServiceInterface
+// ============================================================================
+
+type mockChartsService struct {
+	getTrendingShowsFn  func(limit int) ([]contracts.TrendingShow, error)
+	getPopularArtistsFn func(limit int) ([]contracts.PopularArtist, error)
+	getActiveVenuesFn   func(limit int) ([]contracts.ActiveVenue, error)
+	getHotReleasesFn    func(limit int) ([]contracts.HotRelease, error)
+	getChartsOverviewFn func() (*contracts.ChartsOverview, error)
+}
+
+func (m *mockChartsService) GetTrendingShows(limit int) ([]contracts.TrendingShow, error) {
+	if m.getTrendingShowsFn != nil {
+		return m.getTrendingShowsFn(limit)
+	}
+	return []contracts.TrendingShow{}, nil
+}
+
+func (m *mockChartsService) GetPopularArtists(limit int) ([]contracts.PopularArtist, error) {
+	if m.getPopularArtistsFn != nil {
+		return m.getPopularArtistsFn(limit)
+	}
+	return []contracts.PopularArtist{}, nil
+}
+
+func (m *mockChartsService) GetActiveVenues(limit int) ([]contracts.ActiveVenue, error) {
+	if m.getActiveVenuesFn != nil {
+		return m.getActiveVenuesFn(limit)
+	}
+	return []contracts.ActiveVenue{}, nil
+}
+
+func (m *mockChartsService) GetHotReleases(limit int) ([]contracts.HotRelease, error) {
+	if m.getHotReleasesFn != nil {
+		return m.getHotReleasesFn(limit)
+	}
+	return []contracts.HotRelease{}, nil
+}
+
+func (m *mockChartsService) GetChartsOverview() (*contracts.ChartsOverview, error) {
+	if m.getChartsOverviewFn != nil {
+		return m.getChartsOverviewFn()
+	}
+	return &contracts.ChartsOverview{
+		TrendingShows:  []contracts.TrendingShow{},
+		PopularArtists: []contracts.PopularArtist{},
+		ActiveVenues:   []contracts.ActiveVenue{},
+		HotReleases:    []contracts.HotRelease{},
+	}, nil
+}
+
+// ============================================================================
+// Test helpers
+// ============================================================================
+
+func testChartsHandler() *ChartsHandler {
+	return NewChartsHandler(&mockChartsService{})
+}
+
+// ============================================================================
+// Tests: NewChartsHandler
+// ============================================================================
+
+func TestNewChartsHandler(t *testing.T) {
+	h := testChartsHandler()
+	if h == nil {
+		t.Fatal("expected non-nil ChartsHandler")
+	}
+}
+
+// ============================================================================
+// Tests: normalizeChartsLimit
+// ============================================================================
+
+func TestNormalizeChartsLimit(t *testing.T) {
+	tests := []struct {
+		input    int
+		expected int
+	}{
+		{0, 20},
+		{-1, 20},
+		{1, 1},
+		{20, 20},
+		{50, 50},
+		{51, 50},
+		{100, 50},
+	}
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("input_%d", tc.input), func(t *testing.T) {
+			result := normalizeChartsLimit(tc.input)
+			if result != tc.expected {
+				t.Errorf("normalizeChartsLimit(%d) = %d, want %d", tc.input, result, tc.expected)
+			}
+		})
+	}
+}
+
+// ============================================================================
+// Tests: GetTrendingShowsHandler
+// ============================================================================
+
+func TestChartsHandler_TrendingShows_Success(t *testing.T) {
+	h := NewChartsHandler(&mockChartsService{
+		getTrendingShowsFn: func(limit int) ([]contracts.TrendingShow, error) {
+			if limit != 20 {
+				t.Errorf("expected limit=20, got %d", limit)
+			}
+			return []contracts.TrendingShow{
+				{ShowID: 1, Title: "Big Show", Slug: "big-show", GoingCount: 10, InterestedCount: 5, TotalAttendance: 15, VenueName: "The Venue", City: "Phoenix"},
+			}, nil
+		},
+	})
+
+	resp, err := h.GetTrendingShowsHandler(context.Background(), &GetTrendingShowsRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Body.Shows) != 1 {
+		t.Fatalf("expected 1 show, got %d", len(resp.Body.Shows))
+	}
+	if resp.Body.Shows[0].TotalAttendance != 15 {
+		t.Errorf("expected total_attendance=15, got %d", resp.Body.Shows[0].TotalAttendance)
+	}
+	if resp.Body.Shows[0].Title != "Big Show" {
+		t.Errorf("expected title='Big Show', got %s", resp.Body.Shows[0].Title)
+	}
+}
+
+func TestChartsHandler_TrendingShows_CustomLimit(t *testing.T) {
+	var receivedLimit int
+	h := NewChartsHandler(&mockChartsService{
+		getTrendingShowsFn: func(limit int) ([]contracts.TrendingShow, error) {
+			receivedLimit = limit
+			return []contracts.TrendingShow{}, nil
+		},
+	})
+
+	_, err := h.GetTrendingShowsHandler(context.Background(), &GetTrendingShowsRequest{Limit: 10})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if receivedLimit != 10 {
+		t.Errorf("expected limit=10, got %d", receivedLimit)
+	}
+}
+
+func TestChartsHandler_TrendingShows_LimitCapped(t *testing.T) {
+	var receivedLimit int
+	h := NewChartsHandler(&mockChartsService{
+		getTrendingShowsFn: func(limit int) ([]contracts.TrendingShow, error) {
+			receivedLimit = limit
+			return []contracts.TrendingShow{}, nil
+		},
+	})
+
+	_, err := h.GetTrendingShowsHandler(context.Background(), &GetTrendingShowsRequest{Limit: 100})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if receivedLimit != 50 {
+		t.Errorf("expected limit capped to 50, got %d", receivedLimit)
+	}
+}
+
+func TestChartsHandler_TrendingShows_ServiceError(t *testing.T) {
+	h := NewChartsHandler(&mockChartsService{
+		getTrendingShowsFn: func(limit int) ([]contracts.TrendingShow, error) {
+			return nil, fmt.Errorf("database error")
+		},
+	})
+
+	_, err := h.GetTrendingShowsHandler(context.Background(), &GetTrendingShowsRequest{})
+	assertHumaError(t, err, 500)
+}
+
+// ============================================================================
+// Tests: GetPopularArtistsHandler
+// ============================================================================
+
+func TestChartsHandler_PopularArtists_Success(t *testing.T) {
+	h := NewChartsHandler(&mockChartsService{
+		getPopularArtistsFn: func(limit int) ([]contracts.PopularArtist, error) {
+			return []contracts.PopularArtist{
+				{ArtistID: 1, Name: "Great Band", Slug: "great-band", FollowCount: 100, UpcomingShowCount: 5, Score: 205},
+				{ArtistID: 2, Name: "Good Band", Slug: "good-band", FollowCount: 50, UpcomingShowCount: 2, Score: 102},
+			}, nil
+		},
+	})
+
+	resp, err := h.GetPopularArtistsHandler(context.Background(), &GetPopularArtistsRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Body.Artists) != 2 {
+		t.Fatalf("expected 2 artists, got %d", len(resp.Body.Artists))
+	}
+	if resp.Body.Artists[0].Score != 205 {
+		t.Errorf("expected score=205, got %d", resp.Body.Artists[0].Score)
+	}
+}
+
+func TestChartsHandler_PopularArtists_ServiceError(t *testing.T) {
+	h := NewChartsHandler(&mockChartsService{
+		getPopularArtistsFn: func(limit int) ([]contracts.PopularArtist, error) {
+			return nil, fmt.Errorf("database error")
+		},
+	})
+
+	_, err := h.GetPopularArtistsHandler(context.Background(), &GetPopularArtistsRequest{})
+	assertHumaError(t, err, 500)
+}
+
+func TestChartsHandler_PopularArtists_DefaultLimit(t *testing.T) {
+	var receivedLimit int
+	h := NewChartsHandler(&mockChartsService{
+		getPopularArtistsFn: func(limit int) ([]contracts.PopularArtist, error) {
+			receivedLimit = limit
+			return []contracts.PopularArtist{}, nil
+		},
+	})
+
+	_, err := h.GetPopularArtistsHandler(context.Background(), &GetPopularArtistsRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if receivedLimit != 20 {
+		t.Errorf("expected default limit=20, got %d", receivedLimit)
+	}
+}
+
+// ============================================================================
+// Tests: GetActiveVenuesHandler
+// ============================================================================
+
+func TestChartsHandler_ActiveVenues_Success(t *testing.T) {
+	h := NewChartsHandler(&mockChartsService{
+		getActiveVenuesFn: func(limit int) ([]contracts.ActiveVenue, error) {
+			return []contracts.ActiveVenue{
+				{VenueID: 1, Name: "Best Venue", Slug: "best-venue", City: "Phoenix", State: "AZ", UpcomingShowCount: 10, FollowCount: 50, Score: 70},
+			}, nil
+		},
+	})
+
+	resp, err := h.GetActiveVenuesHandler(context.Background(), &GetActiveVenuesRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Body.Venues) != 1 {
+		t.Fatalf("expected 1 venue, got %d", len(resp.Body.Venues))
+	}
+	if resp.Body.Venues[0].Name != "Best Venue" {
+		t.Errorf("expected name='Best Venue', got %s", resp.Body.Venues[0].Name)
+	}
+	if resp.Body.Venues[0].Score != 70 {
+		t.Errorf("expected score=70, got %d", resp.Body.Venues[0].Score)
+	}
+}
+
+func TestChartsHandler_ActiveVenues_ServiceError(t *testing.T) {
+	h := NewChartsHandler(&mockChartsService{
+		getActiveVenuesFn: func(limit int) ([]contracts.ActiveVenue, error) {
+			return nil, fmt.Errorf("database error")
+		},
+	})
+
+	_, err := h.GetActiveVenuesHandler(context.Background(), &GetActiveVenuesRequest{})
+	assertHumaError(t, err, 500)
+}
+
+func TestChartsHandler_ActiveVenues_DefaultLimit(t *testing.T) {
+	var receivedLimit int
+	h := NewChartsHandler(&mockChartsService{
+		getActiveVenuesFn: func(limit int) ([]contracts.ActiveVenue, error) {
+			receivedLimit = limit
+			return []contracts.ActiveVenue{}, nil
+		},
+	})
+
+	_, err := h.GetActiveVenuesHandler(context.Background(), &GetActiveVenuesRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if receivedLimit != 20 {
+		t.Errorf("expected default limit=20, got %d", receivedLimit)
+	}
+}
+
+// ============================================================================
+// Tests: GetHotReleasesHandler
+// ============================================================================
+
+func TestChartsHandler_HotReleases_Success(t *testing.T) {
+	now := time.Now()
+	h := NewChartsHandler(&mockChartsService{
+		getHotReleasesFn: func(limit int) ([]contracts.HotRelease, error) {
+			return []contracts.HotRelease{
+				{ReleaseID: 1, Title: "Hot Album", Slug: "hot-album", ReleaseDate: &now, ArtistNames: []string{"Artist A", "Artist B"}, BookmarkCount: 42},
+			}, nil
+		},
+	})
+
+	resp, err := h.GetHotReleasesHandler(context.Background(), &GetHotReleasesRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Body.Releases) != 1 {
+		t.Fatalf("expected 1 release, got %d", len(resp.Body.Releases))
+	}
+	if resp.Body.Releases[0].BookmarkCount != 42 {
+		t.Errorf("expected bookmark_count=42, got %d", resp.Body.Releases[0].BookmarkCount)
+	}
+	if len(resp.Body.Releases[0].ArtistNames) != 2 {
+		t.Errorf("expected 2 artist names, got %d", len(resp.Body.Releases[0].ArtistNames))
+	}
+}
+
+func TestChartsHandler_HotReleases_ServiceError(t *testing.T) {
+	h := NewChartsHandler(&mockChartsService{
+		getHotReleasesFn: func(limit int) ([]contracts.HotRelease, error) {
+			return nil, fmt.Errorf("database error")
+		},
+	})
+
+	_, err := h.GetHotReleasesHandler(context.Background(), &GetHotReleasesRequest{})
+	assertHumaError(t, err, 500)
+}
+
+func TestChartsHandler_HotReleases_DefaultLimit(t *testing.T) {
+	var receivedLimit int
+	h := NewChartsHandler(&mockChartsService{
+		getHotReleasesFn: func(limit int) ([]contracts.HotRelease, error) {
+			receivedLimit = limit
+			return []contracts.HotRelease{}, nil
+		},
+	})
+
+	_, err := h.GetHotReleasesHandler(context.Background(), &GetHotReleasesRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if receivedLimit != 20 {
+		t.Errorf("expected default limit=20, got %d", receivedLimit)
+	}
+}
+
+// ============================================================================
+// Tests: GetChartsOverviewHandler
+// ============================================================================
+
+func TestChartsHandler_Overview_Success(t *testing.T) {
+	h := NewChartsHandler(&mockChartsService{
+		getChartsOverviewFn: func() (*contracts.ChartsOverview, error) {
+			return &contracts.ChartsOverview{
+				TrendingShows:  []contracts.TrendingShow{{ShowID: 1, Title: "Show", TotalAttendance: 5}},
+				PopularArtists: []contracts.PopularArtist{{ArtistID: 1, Name: "Artist", Score: 10}},
+				ActiveVenues:   []contracts.ActiveVenue{{VenueID: 1, Name: "Venue", Score: 7}},
+				HotReleases:    []contracts.HotRelease{{ReleaseID: 1, Title: "Release", ArtistNames: []string{"A"}, BookmarkCount: 3}},
+			}, nil
+		},
+	})
+
+	resp, err := h.GetChartsOverviewHandler(context.Background(), &GetChartsOverviewRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Body.TrendingShows) != 1 {
+		t.Errorf("expected 1 trending show, got %d", len(resp.Body.TrendingShows))
+	}
+	if len(resp.Body.PopularArtists) != 1 {
+		t.Errorf("expected 1 popular artist, got %d", len(resp.Body.PopularArtists))
+	}
+	if len(resp.Body.ActiveVenues) != 1 {
+		t.Errorf("expected 1 active venue, got %d", len(resp.Body.ActiveVenues))
+	}
+	if len(resp.Body.HotReleases) != 1 {
+		t.Errorf("expected 1 hot release, got %d", len(resp.Body.HotReleases))
+	}
+}
+
+func TestChartsHandler_Overview_Empty(t *testing.T) {
+	h := testChartsHandler()
+
+	resp, err := h.GetChartsOverviewHandler(context.Background(), &GetChartsOverviewRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Body.TrendingShows) != 0 {
+		t.Errorf("expected 0 trending shows, got %d", len(resp.Body.TrendingShows))
+	}
+	if len(resp.Body.PopularArtists) != 0 {
+		t.Errorf("expected 0 popular artists, got %d", len(resp.Body.PopularArtists))
+	}
+}
+
+func TestChartsHandler_Overview_ServiceError(t *testing.T) {
+	h := NewChartsHandler(&mockChartsService{
+		getChartsOverviewFn: func() (*contracts.ChartsOverview, error) {
+			return nil, fmt.Errorf("database error")
+		},
+	})
+
+	_, err := h.GetChartsOverviewHandler(context.Background(), &GetChartsOverviewRequest{})
+	assertHumaError(t, err, 500)
+}

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -103,6 +103,7 @@ func SetupRoutes(router *chi.Mux, sc *services.ServiceContainer, cfg *config.Con
 	setupSceneRoutes(api, sc)
 	setupAttendanceRoutes(api, protectedGroup, sc)
 	setupFollowRoutes(api, protectedGroup, sc)
+	setupChartsRoutes(api, sc)
 
 	return api
 }
@@ -752,6 +753,18 @@ func setupFollowRoutes(api huma.API, protected *huma.Group, sc *services.Service
 
 	// User's following list (protected)
 	huma.Get(protected, "/me/following", followHandler.GetMyFollowingHandler)
+}
+
+// setupChartsRoutes configures public top charts endpoints.
+// All endpoints are public — no authentication required.
+func setupChartsRoutes(api huma.API, sc *services.ServiceContainer) {
+	chartsHandler := handlers.NewChartsHandler(sc.Charts)
+
+	huma.Get(api, "/charts/trending-shows", chartsHandler.GetTrendingShowsHandler)
+	huma.Get(api, "/charts/popular-artists", chartsHandler.GetPopularArtistsHandler)
+	huma.Get(api, "/charts/active-venues", chartsHandler.GetActiveVenuesHandler)
+	huma.Get(api, "/charts/hot-releases", chartsHandler.GetHotReleasesHandler)
+	huma.Get(api, "/charts/overview", chartsHandler.GetChartsOverviewHandler)
 }
 
 // rateLimitHandler handles rate limit exceeded responses with JSON

--- a/backend/internal/services/aliases.go
+++ b/backend/internal/services/aliases.go
@@ -296,6 +296,16 @@ type CommunityHealthResponse = contracts.CommunityHealthResponse
 type DataQualityTrendsResponse = contracts.DataQualityTrendsResponse
 
 // ──────────────────────────────────────────────
+// Charts types
+// ──────────────────────────────────────────────
+
+type TrendingShow = contracts.TrendingShow
+type PopularArtist = contracts.PopularArtist
+type ActiveVenue = contracts.ActiveVenue
+type HotRelease = contracts.HotRelease
+type ChartsOverview = contracts.ChartsOverview
+
+// ──────────────────────────────────────────────
 // Pipeline types (extraction, fetcher, discovery, pipeline)
 // ──────────────────────────────────────────────
 

--- a/backend/internal/services/catalog/charts_service.go
+++ b/backend/internal/services/catalog/charts_service.go
@@ -1,0 +1,366 @@
+package catalog
+
+import (
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/db"
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// ChartsService computes top charts / trending content from engagement signals.
+// No new tables — all data is derived from existing bookmark, show, artist, venue,
+// and release tables.
+type ChartsService struct {
+	db *gorm.DB
+}
+
+// NewChartsService creates a new charts service.
+func NewChartsService(database *gorm.DB) *ChartsService {
+	if database == nil {
+		database = db.GetDB()
+	}
+	return &ChartsService{db: database}
+}
+
+// GetTrendingShows returns upcoming shows ranked by total attendance (going + interested).
+// Only includes future shows with approved status.
+func (s *ChartsService) GetTrendingShows(limit int) ([]contracts.TrendingShow, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	now := time.Now().UTC()
+
+	type trendingRow struct {
+		ShowID          uint      `gorm:"column:show_id"`
+		Title           string    `gorm:"column:title"`
+		Slug            string    `gorm:"column:slug"`
+		Date            time.Time `gorm:"column:event_date"`
+		VenueName       string    `gorm:"column:venue_name"`
+		VenueSlug       string    `gorm:"column:venue_slug"`
+		City            string    `gorm:"column:city"`
+		GoingCount      int       `gorm:"column:going_count"`
+		InterestedCount int       `gorm:"column:interested_count"`
+		TotalAttendance int       `gorm:"column:total_attendance"`
+	}
+
+	var rows []trendingRow
+	err := s.db.Raw(`
+		SELECT
+			s.id AS show_id,
+			s.title,
+			COALESCE(s.slug, '') AS slug,
+			s.event_date,
+			COALESCE(v.name, '') AS venue_name,
+			COALESCE(v.slug, '') AS venue_slug,
+			COALESCE(v.city, '') AS city,
+			COALESCE(SUM(CASE WHEN ub.action = 'going' THEN 1 ELSE 0 END), 0) AS going_count,
+			COALESCE(SUM(CASE WHEN ub.action = 'interested' THEN 1 ELSE 0 END), 0) AS interested_count,
+			COUNT(ub.id) AS total_attendance
+		FROM shows s
+		LEFT JOIN show_venues sv ON sv.show_id = s.id
+		LEFT JOIN venues v ON v.id = sv.venue_id
+		JOIN user_bookmarks ub ON ub.entity_id = s.id
+			AND ub.entity_type = ?
+			AND ub.action IN (?, ?)
+		WHERE s.status = ?
+			AND s.event_date >= ?
+		GROUP BY s.id, s.title, s.slug, s.event_date, v.name, v.slug, v.city
+		ORDER BY total_attendance DESC, s.event_date ASC
+		LIMIT ?
+	`, models.BookmarkEntityShow, models.BookmarkActionGoing, models.BookmarkActionInterested,
+		models.ShowStatusApproved, now, limit).Scan(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to get trending shows: %w", err)
+	}
+
+	results := make([]contracts.TrendingShow, len(rows))
+	for i, r := range rows {
+		results[i] = contracts.TrendingShow{
+			ShowID:          r.ShowID,
+			Title:           r.Title,
+			Slug:            r.Slug,
+			Date:            r.Date,
+			VenueName:       r.VenueName,
+			VenueSlug:       r.VenueSlug,
+			City:            r.City,
+			GoingCount:      r.GoingCount,
+			InterestedCount: r.InterestedCount,
+			TotalAttendance: r.TotalAttendance,
+		}
+	}
+
+	return results, nil
+}
+
+// GetPopularArtists returns artists ranked by a composite score of followers and upcoming shows.
+// Score = follow_count * 2 + upcoming_show_count.
+func (s *ChartsService) GetPopularArtists(limit int) ([]contracts.PopularArtist, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	now := time.Now().UTC()
+
+	type artistRow struct {
+		ArtistID          uint   `gorm:"column:artist_id"`
+		Name              string `gorm:"column:name"`
+		Slug              string `gorm:"column:slug"`
+		ImageURL          string `gorm:"column:image_url"`
+		FollowCount       int    `gorm:"column:follow_count"`
+		UpcomingShowCount int    `gorm:"column:upcoming_show_count"`
+		Score             int    `gorm:"column:score"`
+	}
+
+	var rows []artistRow
+	err := s.db.Raw(`
+		SELECT
+			a.id AS artist_id,
+			a.name,
+			COALESCE(a.slug, '') AS slug,
+			COALESCE(a.bandcamp_embed_url, '') AS image_url,
+			COALESCE(follow_counts.cnt, 0) AS follow_count,
+			COALESCE(show_counts.cnt, 0) AS upcoming_show_count,
+			(COALESCE(follow_counts.cnt, 0) * 2 + COALESCE(show_counts.cnt, 0)) AS score
+		FROM artists a
+		LEFT JOIN (
+			SELECT entity_id, COUNT(*) AS cnt
+			FROM user_bookmarks
+			WHERE entity_type = ? AND action = ?
+			GROUP BY entity_id
+		) follow_counts ON follow_counts.entity_id = a.id
+		LEFT JOIN (
+			SELECT sa.artist_id, COUNT(DISTINCT s.id) AS cnt
+			FROM show_artists sa
+			JOIN shows s ON s.id = sa.show_id
+			WHERE s.status = ? AND s.event_date >= ?
+			GROUP BY sa.artist_id
+		) show_counts ON show_counts.artist_id = a.id
+		WHERE (COALESCE(follow_counts.cnt, 0) > 0 OR COALESCE(show_counts.cnt, 0) > 0)
+		ORDER BY score DESC, a.name ASC
+		LIMIT ?
+	`, models.BookmarkEntityArtist, models.BookmarkActionFollow,
+		models.ShowStatusApproved, now, limit).Scan(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to get popular artists: %w", err)
+	}
+
+	results := make([]contracts.PopularArtist, len(rows))
+	for i, r := range rows {
+		results[i] = contracts.PopularArtist{
+			ArtistID:          r.ArtistID,
+			Name:              r.Name,
+			Slug:              r.Slug,
+			ImageURL:          r.ImageURL,
+			FollowCount:       r.FollowCount,
+			UpcomingShowCount: r.UpcomingShowCount,
+			Score:             r.Score,
+		}
+	}
+
+	return results, nil
+}
+
+// GetActiveVenues returns venues ranked by a composite score of upcoming shows and followers.
+// Score = upcoming_show_count * 2 + follow_count.
+func (s *ChartsService) GetActiveVenues(limit int) ([]contracts.ActiveVenue, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	now := time.Now().UTC()
+
+	type venueRow struct {
+		VenueID           uint   `gorm:"column:venue_id"`
+		Name              string `gorm:"column:name"`
+		Slug              string `gorm:"column:slug"`
+		City              string `gorm:"column:city"`
+		State             string `gorm:"column:state"`
+		UpcomingShowCount int    `gorm:"column:upcoming_show_count"`
+		FollowCount       int    `gorm:"column:follow_count"`
+		Score             int    `gorm:"column:score"`
+	}
+
+	var rows []venueRow
+	err := s.db.Raw(`
+		SELECT
+			v.id AS venue_id,
+			v.name,
+			COALESCE(v.slug, '') AS slug,
+			COALESCE(v.city, '') AS city,
+			COALESCE(v.state, '') AS state,
+			COALESCE(show_counts.cnt, 0) AS upcoming_show_count,
+			COALESCE(follow_counts.cnt, 0) AS follow_count,
+			(COALESCE(show_counts.cnt, 0) * 2 + COALESCE(follow_counts.cnt, 0)) AS score
+		FROM venues v
+		LEFT JOIN (
+			SELECT sv.venue_id, COUNT(DISTINCT s.id) AS cnt
+			FROM show_venues sv
+			JOIN shows s ON s.id = sv.show_id
+			WHERE s.status = ? AND s.event_date >= ?
+			GROUP BY sv.venue_id
+		) show_counts ON show_counts.venue_id = v.id
+		LEFT JOIN (
+			SELECT entity_id, COUNT(*) AS cnt
+			FROM user_bookmarks
+			WHERE entity_type = ? AND action = ?
+			GROUP BY entity_id
+		) follow_counts ON follow_counts.entity_id = v.id
+		WHERE (COALESCE(show_counts.cnt, 0) > 0 OR COALESCE(follow_counts.cnt, 0) > 0)
+		ORDER BY score DESC, v.name ASC
+		LIMIT ?
+	`, models.ShowStatusApproved, now,
+		models.BookmarkEntityVenue, models.BookmarkActionFollow, limit).Scan(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to get active venues: %w", err)
+	}
+
+	results := make([]contracts.ActiveVenue, len(rows))
+	for i, r := range rows {
+		results[i] = contracts.ActiveVenue{
+			VenueID:           r.VenueID,
+			Name:              r.Name,
+			Slug:              r.Slug,
+			City:              r.City,
+			State:             r.State,
+			UpcomingShowCount: r.UpcomingShowCount,
+			FollowCount:       r.FollowCount,
+			Score:             r.Score,
+		}
+	}
+
+	return results, nil
+}
+
+// GetHotReleases returns releases ranked by bookmark count in the last 30 days.
+func (s *ChartsService) GetHotReleases(limit int) ([]contracts.HotRelease, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	thirtyDaysAgo := time.Now().UTC().AddDate(0, 0, -30)
+
+	type releaseRow struct {
+		ReleaseID     uint    `gorm:"column:release_id"`
+		Title         string  `gorm:"column:title"`
+		Slug          string  `gorm:"column:slug"`
+		ReleaseDate   *string `gorm:"column:release_date"`
+		BookmarkCount int     `gorm:"column:bookmark_count"`
+	}
+
+	var rows []releaseRow
+	err := s.db.Raw(`
+		SELECT
+			r.id AS release_id,
+			r.title,
+			COALESCE(r.slug, '') AS slug,
+			r.release_date,
+			COUNT(ub.id) AS bookmark_count
+		FROM releases r
+		JOIN user_bookmarks ub ON ub.entity_id = r.id
+			AND ub.entity_type = ?
+			AND ub.action = ?
+			AND ub.created_at >= ?
+		GROUP BY r.id, r.title, r.slug, r.release_date
+		ORDER BY bookmark_count DESC, r.title ASC
+		LIMIT ?
+	`, models.BookmarkEntityRelease, models.BookmarkActionBookmark, thirtyDaysAgo, limit).Scan(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to get hot releases: %w", err)
+	}
+
+	// Build result list, then enrich with artist names
+	results := make([]contracts.HotRelease, len(rows))
+	releaseIDs := make([]uint, len(rows))
+	for i, r := range rows {
+		var releaseDate *time.Time
+		if r.ReleaseDate != nil {
+			if t, err := time.Parse("2006-01-02", *r.ReleaseDate); err == nil {
+				releaseDate = &t
+			}
+		}
+		results[i] = contracts.HotRelease{
+			ReleaseID:     r.ReleaseID,
+			Title:         r.Title,
+			Slug:          r.Slug,
+			ReleaseDate:   releaseDate,
+			ArtistNames:   []string{},
+			BookmarkCount: r.BookmarkCount,
+		}
+		releaseIDs[i] = r.ReleaseID
+	}
+
+	// Fetch artist names for all releases in one query
+	if len(releaseIDs) > 0 {
+		type artistNameRow struct {
+			ReleaseID uint   `gorm:"column:release_id"`
+			Name      string `gorm:"column:name"`
+		}
+		var artistRows []artistNameRow
+		err := s.db.Raw(`
+			SELECT ar.release_id, a.name
+			FROM artist_releases ar
+			JOIN artists a ON a.id = ar.artist_id
+			WHERE ar.release_id IN ?
+			ORDER BY ar.release_id, ar.position
+		`, releaseIDs).Scan(&artistRows).Error
+		if err != nil {
+			return nil, fmt.Errorf("failed to get release artists: %w", err)
+		}
+
+		// Build map of release_id -> artist names
+		artistMap := make(map[uint][]string)
+		for _, ar := range artistRows {
+			artistMap[ar.ReleaseID] = append(artistMap[ar.ReleaseID], ar.Name)
+		}
+
+		// Assign to results
+		for i := range results {
+			if names, ok := artistMap[results[i].ReleaseID]; ok {
+				results[i].ArtistNames = names
+			}
+		}
+	}
+
+	return results, nil
+}
+
+// GetChartsOverview returns a condensed summary with top 5 of each chart.
+func (s *ChartsService) GetChartsOverview() (*contracts.ChartsOverview, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	const overviewLimit = 5
+
+	shows, err := s.GetTrendingShows(overviewLimit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get trending shows for overview: %w", err)
+	}
+
+	artists, err := s.GetPopularArtists(overviewLimit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get popular artists for overview: %w", err)
+	}
+
+	venues, err := s.GetActiveVenues(overviewLimit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get active venues for overview: %w", err)
+	}
+
+	releases, err := s.GetHotReleases(overviewLimit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get hot releases for overview: %w", err)
+	}
+
+	return &contracts.ChartsOverview{
+		TrendingShows:  shows,
+		PopularArtists: artists,
+		ActiveVenues:   venues,
+		HotReleases:    releases,
+	}, nil
+}

--- a/backend/internal/services/catalog/charts_service_test.go
+++ b/backend/internal/services/catalog/charts_service_test.go
@@ -1,0 +1,613 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/testutil"
+)
+
+// =============================================================================
+// UNIT TESTS (No Database Required)
+// =============================================================================
+
+func TestNewChartsService(t *testing.T) {
+	svc := NewChartsService(nil)
+	assert.NotNil(t, svc)
+}
+
+func TestChartsService_NilDatabase(t *testing.T) {
+	svc := &ChartsService{db: nil}
+
+	t.Run("GetTrendingShows", func(t *testing.T) {
+		resp, err := svc.GetTrendingShows(20)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("GetPopularArtists", func(t *testing.T) {
+		resp, err := svc.GetPopularArtists(20)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("GetActiveVenues", func(t *testing.T) {
+		resp, err := svc.GetActiveVenues(20)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("GetHotReleases", func(t *testing.T) {
+		resp, err := svc.GetHotReleases(20)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("GetChartsOverview", func(t *testing.T) {
+		resp, err := svc.GetChartsOverview()
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+}
+
+// =============================================================================
+// INTEGRATION TESTS (With Real Database)
+// =============================================================================
+
+type ChartsServiceIntegrationTestSuite struct {
+	suite.Suite
+	container     testcontainers.Container
+	db            *gorm.DB
+	chartsService *ChartsService
+	ctx           context.Context
+}
+
+func (suite *ChartsServiceIntegrationTestSuite) SetupSuite() {
+	suite.ctx = context.Background()
+
+	container, err := testcontainers.GenericContainer(suite.ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "postgres:18",
+			ExposedPorts: []string{"5432/tcp"},
+			Env: map[string]string{
+				"POSTGRES_DB":       "test_db",
+				"POSTGRES_USER":     "test_user",
+				"POSTGRES_PASSWORD": "test_password",
+			},
+			WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(120 * time.Second),
+		},
+		Started: true,
+	})
+	if err != nil {
+		suite.T().Fatalf("failed to start postgres container: %v", err)
+	}
+	suite.container = container
+
+	host, err := container.Host(suite.ctx)
+	if err != nil {
+		suite.T().Fatalf("failed to get host: %v", err)
+	}
+	port, err := container.MappedPort(suite.ctx, "5432")
+	if err != nil {
+		suite.T().Fatalf("failed to get port: %v", err)
+	}
+
+	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
+		host, port.Port())
+
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		suite.T().Fatalf("failed to connect to test database: %v", err)
+	}
+	suite.db = db
+
+	sqlDB, err := db.DB()
+	if err != nil {
+		suite.T().Fatalf("failed to get sql.DB: %v", err)
+	}
+	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
+
+	suite.chartsService = &ChartsService{db: db}
+}
+
+func (suite *ChartsServiceIntegrationTestSuite) TearDownSuite() {
+	if suite.container != nil {
+		if err := suite.container.Terminate(suite.ctx); err != nil {
+			suite.T().Logf("failed to terminate container: %v", err)
+		}
+	}
+}
+
+func (suite *ChartsServiceIntegrationTestSuite) TearDownTest() {
+	sqlDB, err := suite.db.DB()
+	suite.Require().NoError(err)
+	// Delete in FK-safe order
+	_, _ = sqlDB.Exec("DELETE FROM user_bookmarks")
+	_, _ = sqlDB.Exec("DELETE FROM show_artists")
+	_, _ = sqlDB.Exec("DELETE FROM show_venues")
+	_, _ = sqlDB.Exec("DELETE FROM shows")
+	_, _ = sqlDB.Exec("DELETE FROM artist_releases")
+	_, _ = sqlDB.Exec("DELETE FROM releases")
+	_, _ = sqlDB.Exec("DELETE FROM artists")
+	_, _ = sqlDB.Exec("DELETE FROM venues")
+	_, _ = sqlDB.Exec("DELETE FROM users")
+}
+
+func TestChartsServiceIntegrationTestSuite(t *testing.T) {
+	suite.Run(t, new(ChartsServiceIntegrationTestSuite))
+}
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+func (suite *ChartsServiceIntegrationTestSuite) createUser(email string) *models.User {
+	user := &models.User{
+		Email:         stringPtr(email),
+		FirstName:     stringPtr("Test"),
+		LastName:      stringPtr("User"),
+		IsActive:      true,
+		EmailVerified: true,
+	}
+	err := suite.db.Create(user).Error
+	suite.Require().NoError(err)
+	return user
+}
+
+func (suite *ChartsServiceIntegrationTestSuite) createVenue(name, city, state string) *models.Venue {
+	venue := &models.Venue{
+		Name:  name,
+		City:  city,
+		State: state,
+	}
+	err := suite.db.Create(venue).Error
+	suite.Require().NoError(err)
+	return venue
+}
+
+func (suite *ChartsServiceIntegrationTestSuite) createArtist(name string) *models.Artist {
+	artist := &models.Artist{Name: name}
+	err := suite.db.Create(artist).Error
+	suite.Require().NoError(err)
+	return artist
+}
+
+func (suite *ChartsServiceIntegrationTestSuite) createApprovedShow(title string, venueID, artistID, userID uint, eventDate time.Time) *models.Show {
+	show := &models.Show{
+		Title:       title,
+		EventDate:   eventDate,
+		City:        stringPtr("Phoenix"),
+		State:       stringPtr("AZ"),
+		Status:      models.ShowStatusApproved,
+		SubmittedBy: &userID,
+	}
+	err := suite.db.Create(show).Error
+	suite.Require().NoError(err)
+
+	err = suite.db.Create(&models.ShowVenue{ShowID: show.ID, VenueID: venueID}).Error
+	suite.Require().NoError(err)
+
+	err = suite.db.Create(&models.ShowArtist{ShowID: show.ID, ArtistID: artistID, Position: 0}).Error
+	suite.Require().NoError(err)
+
+	return show
+}
+
+func (suite *ChartsServiceIntegrationTestSuite) createBookmark(userID uint, entityType models.BookmarkEntityType, entityID uint, action models.BookmarkAction) {
+	bookmark := &models.UserBookmark{
+		UserID:     userID,
+		EntityType: entityType,
+		EntityID:   entityID,
+		Action:     action,
+	}
+	err := suite.db.Create(bookmark).Error
+	suite.Require().NoError(err)
+}
+
+func (suite *ChartsServiceIntegrationTestSuite) createRelease(title string) *models.Release {
+	release := &models.Release{
+		Title: title,
+	}
+	err := suite.db.Create(release).Error
+	suite.Require().NoError(err)
+	return release
+}
+
+func (suite *ChartsServiceIntegrationTestSuite) addArtistToRelease(artistID, releaseID uint) {
+	ar := &models.ArtistRelease{
+		ArtistID:  artistID,
+		ReleaseID: releaseID,
+		Role:      models.ArtistReleaseRoleMain,
+		Position:  0,
+	}
+	err := suite.db.Create(ar).Error
+	suite.Require().NoError(err)
+}
+
+// =============================================================================
+// GetTrendingShows Tests
+// =============================================================================
+
+func (suite *ChartsServiceIntegrationTestSuite) TestGetTrendingShows_Empty() {
+	shows, err := suite.chartsService.GetTrendingShows(20)
+	suite.Require().NoError(err)
+	suite.Empty(shows)
+}
+
+func (suite *ChartsServiceIntegrationTestSuite) TestGetTrendingShows_WithData() {
+	user1 := suite.createUser("charts-user1@test.com")
+	user2 := suite.createUser("charts-user2@test.com")
+	user3 := suite.createUser("charts-user3@test.com")
+	venue := suite.createVenue("Crescent Ballroom", "Phoenix", "AZ")
+	artist := suite.createArtist("Band A")
+
+	future := time.Now().UTC().AddDate(0, 0, 7)
+	show1 := suite.createApprovedShow("Popular Show", venue.ID, artist.ID, user1.ID, future)
+	show2 := suite.createApprovedShow("Less Popular Show", venue.ID, artist.ID, user1.ID, future.AddDate(0, 0, 1))
+
+	// Show 1 has 3 attendees (2 going, 1 interested)
+	suite.createBookmark(user1.ID, models.BookmarkEntityShow, show1.ID, models.BookmarkActionGoing)
+	suite.createBookmark(user2.ID, models.BookmarkEntityShow, show1.ID, models.BookmarkActionGoing)
+	suite.createBookmark(user3.ID, models.BookmarkEntityShow, show1.ID, models.BookmarkActionInterested)
+
+	// Show 2 has 1 attendee
+	suite.createBookmark(user1.ID, models.BookmarkEntityShow, show2.ID, models.BookmarkActionGoing)
+
+	shows, err := suite.chartsService.GetTrendingShows(20)
+	suite.Require().NoError(err)
+	suite.Require().Len(shows, 2)
+
+	// Most popular show first
+	suite.Equal(show1.ID, shows[0].ShowID)
+	suite.Equal("Popular Show", shows[0].Title)
+	suite.Equal(2, shows[0].GoingCount)
+	suite.Equal(1, shows[0].InterestedCount)
+	suite.Equal(3, shows[0].TotalAttendance)
+	suite.Equal("Crescent Ballroom", shows[0].VenueName)
+	suite.Equal("Phoenix", shows[0].City)
+
+	// Less popular show second
+	suite.Equal(show2.ID, shows[1].ShowID)
+	suite.Equal(1, shows[1].TotalAttendance)
+}
+
+func (suite *ChartsServiceIntegrationTestSuite) TestGetTrendingShows_ExcludesPastShows() {
+	user := suite.createUser("charts-past@test.com")
+	venue := suite.createVenue("Valley Bar", "Phoenix", "AZ")
+	artist := suite.createArtist("Past Band")
+
+	// Past show
+	past := time.Now().UTC().AddDate(0, 0, -7)
+	pastShow := suite.createApprovedShow("Past Show", venue.ID, artist.ID, user.ID, past)
+	suite.createBookmark(user.ID, models.BookmarkEntityShow, pastShow.ID, models.BookmarkActionGoing)
+
+	// Future show
+	future := time.Now().UTC().AddDate(0, 0, 7)
+	futureShow := suite.createApprovedShow("Future Show", venue.ID, artist.ID, user.ID, future)
+	suite.createBookmark(user.ID, models.BookmarkEntityShow, futureShow.ID, models.BookmarkActionGoing)
+
+	shows, err := suite.chartsService.GetTrendingShows(20)
+	suite.Require().NoError(err)
+	suite.Require().Len(shows, 1)
+	suite.Equal(futureShow.ID, shows[0].ShowID)
+}
+
+func (suite *ChartsServiceIntegrationTestSuite) TestGetTrendingShows_RespectsLimit() {
+	user := suite.createUser("charts-limit@test.com")
+	venue := suite.createVenue("Venue Limit", "Phoenix", "AZ")
+	artist := suite.createArtist("Limit Band")
+
+	future := time.Now().UTC().AddDate(0, 0, 7)
+	for i := 0; i < 5; i++ {
+		show := suite.createApprovedShow(
+			fmt.Sprintf("Show %d", i),
+			venue.ID, artist.ID, user.ID,
+			future.AddDate(0, 0, i),
+		)
+		suite.createBookmark(user.ID, models.BookmarkEntityShow, show.ID, models.BookmarkActionGoing)
+	}
+
+	shows, err := suite.chartsService.GetTrendingShows(3)
+	suite.Require().NoError(err)
+	suite.Len(shows, 3)
+}
+
+// =============================================================================
+// GetPopularArtists Tests
+// =============================================================================
+
+func (suite *ChartsServiceIntegrationTestSuite) TestGetPopularArtists_Empty() {
+	artists, err := suite.chartsService.GetPopularArtists(20)
+	suite.Require().NoError(err)
+	suite.Empty(artists)
+}
+
+func (suite *ChartsServiceIntegrationTestSuite) TestGetPopularArtists_WithData() {
+	user1 := suite.createUser("pop-artist1@test.com")
+	user2 := suite.createUser("pop-artist2@test.com")
+	venue := suite.createVenue("Pop Venue", "Phoenix", "AZ")
+
+	artistA := suite.createArtist("Popular Artist")
+	artistB := suite.createArtist("Less Popular Artist")
+
+	// Artist A: 2 followers + 2 upcoming shows = 2*2 + 2 = 6
+	suite.createBookmark(user1.ID, models.BookmarkEntityArtist, artistA.ID, models.BookmarkActionFollow)
+	suite.createBookmark(user2.ID, models.BookmarkEntityArtist, artistA.ID, models.BookmarkActionFollow)
+	future := time.Now().UTC().AddDate(0, 0, 7)
+	suite.createApprovedShow("Show A1", venue.ID, artistA.ID, user1.ID, future)
+	suite.createApprovedShow("Show A2", venue.ID, artistA.ID, user1.ID, future.AddDate(0, 0, 1))
+
+	// Artist B: 1 follower + 0 upcoming shows = 1*2 + 0 = 2
+	suite.createBookmark(user1.ID, models.BookmarkEntityArtist, artistB.ID, models.BookmarkActionFollow)
+
+	artists, err := suite.chartsService.GetPopularArtists(20)
+	suite.Require().NoError(err)
+	suite.Require().Len(artists, 2)
+
+	// Artist A should be first (higher score)
+	suite.Equal(artistA.ID, artists[0].ArtistID)
+	suite.Equal("Popular Artist", artists[0].Name)
+	suite.Equal(2, artists[0].FollowCount)
+	suite.Equal(2, artists[0].UpcomingShowCount)
+	suite.Equal(6, artists[0].Score) // 2*2 + 2
+
+	// Artist B second
+	suite.Equal(artistB.ID, artists[1].ArtistID)
+	suite.Equal(1, artists[1].FollowCount)
+	suite.Equal(0, artists[1].UpcomingShowCount)
+	suite.Equal(2, artists[1].Score) // 1*2 + 0
+}
+
+func (suite *ChartsServiceIntegrationTestSuite) TestGetPopularArtists_OnlyUpcomingShows() {
+	user := suite.createUser("pop-upcoming@test.com")
+	venue := suite.createVenue("Upcoming Venue", "Phoenix", "AZ")
+	artist := suite.createArtist("Upcoming Artist")
+
+	// Artist with no followers but 3 upcoming shows = 0*2 + 3 = 3
+	future := time.Now().UTC().AddDate(0, 0, 7)
+	suite.createApprovedShow("U1", venue.ID, artist.ID, user.ID, future)
+	suite.createApprovedShow("U2", venue.ID, artist.ID, user.ID, future.AddDate(0, 0, 1))
+	suite.createApprovedShow("U3", venue.ID, artist.ID, user.ID, future.AddDate(0, 0, 2))
+
+	artists, err := suite.chartsService.GetPopularArtists(20)
+	suite.Require().NoError(err)
+	suite.Require().Len(artists, 1)
+	suite.Equal(3, artists[0].UpcomingShowCount)
+	suite.Equal(3, artists[0].Score)
+}
+
+func (suite *ChartsServiceIntegrationTestSuite) TestGetPopularArtists_RespectsLimit() {
+	user := suite.createUser("pop-limit@test.com")
+
+	for i := 0; i < 5; i++ {
+		artist := suite.createArtist(fmt.Sprintf("Limit Artist %d", i))
+		suite.createBookmark(user.ID, models.BookmarkEntityArtist, artist.ID, models.BookmarkActionFollow)
+	}
+
+	artists, err := suite.chartsService.GetPopularArtists(3)
+	suite.Require().NoError(err)
+	suite.Len(artists, 3)
+}
+
+// =============================================================================
+// GetActiveVenues Tests
+// =============================================================================
+
+func (suite *ChartsServiceIntegrationTestSuite) TestGetActiveVenues_Empty() {
+	venues, err := suite.chartsService.GetActiveVenues(20)
+	suite.Require().NoError(err)
+	suite.Empty(venues)
+}
+
+func (suite *ChartsServiceIntegrationTestSuite) TestGetActiveVenues_WithData() {
+	user1 := suite.createUser("active-venue1@test.com")
+	user2 := suite.createUser("active-venue2@test.com")
+
+	venueA := suite.createVenue("Active Venue A", "Phoenix", "AZ")
+	venueB := suite.createVenue("Active Venue B", "Phoenix", "AZ")
+	artist := suite.createArtist("Active Artist")
+
+	// Venue A: 3 upcoming shows + 1 follower = 3*2 + 1 = 7
+	future := time.Now().UTC().AddDate(0, 0, 7)
+	suite.createApprovedShow("VA1", venueA.ID, artist.ID, user1.ID, future)
+	suite.createApprovedShow("VA2", venueA.ID, artist.ID, user1.ID, future.AddDate(0, 0, 1))
+	suite.createApprovedShow("VA3", venueA.ID, artist.ID, user1.ID, future.AddDate(0, 0, 2))
+	suite.createBookmark(user1.ID, models.BookmarkEntityVenue, venueA.ID, models.BookmarkActionFollow)
+
+	// Venue B: 1 upcoming show + 2 followers = 1*2 + 2 = 4
+	suite.createApprovedShow("VB1", venueB.ID, artist.ID, user1.ID, future)
+	suite.createBookmark(user1.ID, models.BookmarkEntityVenue, venueB.ID, models.BookmarkActionFollow)
+	suite.createBookmark(user2.ID, models.BookmarkEntityVenue, venueB.ID, models.BookmarkActionFollow)
+
+	venues, err := suite.chartsService.GetActiveVenues(20)
+	suite.Require().NoError(err)
+	suite.Require().Len(venues, 2)
+
+	// Venue A should be first (higher score)
+	suite.Equal(venueA.ID, venues[0].VenueID)
+	suite.Equal("Active Venue A", venues[0].Name)
+	suite.Equal(3, venues[0].UpcomingShowCount)
+	suite.Equal(1, venues[0].FollowCount)
+	suite.Equal(7, venues[0].Score)
+
+	// Venue B second
+	suite.Equal(venueB.ID, venues[1].VenueID)
+	suite.Equal(1, venues[1].UpcomingShowCount)
+	suite.Equal(2, venues[1].FollowCount)
+	suite.Equal(4, venues[1].Score)
+}
+
+func (suite *ChartsServiceIntegrationTestSuite) TestGetActiveVenues_RespectsLimit() {
+	user := suite.createUser("venue-limit@test.com")
+	artist := suite.createArtist("Venue Limit Artist")
+
+	future := time.Now().UTC().AddDate(0, 0, 7)
+	for i := 0; i < 5; i++ {
+		venue := suite.createVenue(fmt.Sprintf("Limit Venue %d", i), "Phoenix", "AZ")
+		suite.createApprovedShow(
+			fmt.Sprintf("VL Show %d", i),
+			venue.ID, artist.ID, user.ID, future.AddDate(0, 0, i),
+		)
+	}
+
+	venues, err := suite.chartsService.GetActiveVenues(3)
+	suite.Require().NoError(err)
+	suite.Len(venues, 3)
+}
+
+// =============================================================================
+// GetHotReleases Tests
+// =============================================================================
+
+func (suite *ChartsServiceIntegrationTestSuite) TestGetHotReleases_Empty() {
+	releases, err := suite.chartsService.GetHotReleases(20)
+	suite.Require().NoError(err)
+	suite.Empty(releases)
+}
+
+func (suite *ChartsServiceIntegrationTestSuite) TestGetHotReleases_WithData() {
+	user1 := suite.createUser("hot-release1@test.com")
+	user2 := suite.createUser("hot-release2@test.com")
+	user3 := suite.createUser("hot-release3@test.com")
+
+	artist := suite.createArtist("Release Artist")
+	releaseA := suite.createRelease("Hot Album")
+	releaseB := suite.createRelease("Warm Album")
+	suite.addArtistToRelease(artist.ID, releaseA.ID)
+	suite.addArtistToRelease(artist.ID, releaseB.ID)
+
+	// Release A: 3 bookmarks
+	suite.createBookmark(user1.ID, models.BookmarkEntityRelease, releaseA.ID, models.BookmarkActionBookmark)
+	suite.createBookmark(user2.ID, models.BookmarkEntityRelease, releaseA.ID, models.BookmarkActionBookmark)
+	suite.createBookmark(user3.ID, models.BookmarkEntityRelease, releaseA.ID, models.BookmarkActionBookmark)
+
+	// Release B: 1 bookmark
+	suite.createBookmark(user1.ID, models.BookmarkEntityRelease, releaseB.ID, models.BookmarkActionBookmark)
+
+	releases, err := suite.chartsService.GetHotReleases(20)
+	suite.Require().NoError(err)
+	suite.Require().Len(releases, 2)
+
+	// Hot Album first (3 bookmarks)
+	suite.Equal(releaseA.ID, releases[0].ReleaseID)
+	suite.Equal("Hot Album", releases[0].Title)
+	suite.Equal(3, releases[0].BookmarkCount)
+	suite.Require().Len(releases[0].ArtistNames, 1)
+	suite.Equal("Release Artist", releases[0].ArtistNames[0])
+
+	// Warm Album second (1 bookmark)
+	suite.Equal(releaseB.ID, releases[1].ReleaseID)
+	suite.Equal(1, releases[1].BookmarkCount)
+}
+
+func (suite *ChartsServiceIntegrationTestSuite) TestGetHotReleases_MultipleArtists() {
+	user := suite.createUser("hot-multi@test.com")
+
+	artistA := suite.createArtist("Alice")
+	artistB := suite.createArtist("Bob")
+	release := suite.createRelease("Collab Album")
+	suite.addArtistToRelease(artistA.ID, release.ID)
+
+	// Add second artist at position 1
+	ar := &models.ArtistRelease{
+		ArtistID:  artistB.ID,
+		ReleaseID: release.ID,
+		Role:      models.ArtistReleaseRoleFeatured,
+		Position:  1,
+	}
+	suite.Require().NoError(suite.db.Create(ar).Error)
+
+	suite.createBookmark(user.ID, models.BookmarkEntityRelease, release.ID, models.BookmarkActionBookmark)
+
+	releases, err := suite.chartsService.GetHotReleases(20)
+	suite.Require().NoError(err)
+	suite.Require().Len(releases, 1)
+	suite.Require().Len(releases[0].ArtistNames, 2)
+	suite.Equal("Alice", releases[0].ArtistNames[0])
+	suite.Equal("Bob", releases[0].ArtistNames[1])
+}
+
+func (suite *ChartsServiceIntegrationTestSuite) TestGetHotReleases_RespectsLimit() {
+	user := suite.createUser("hot-limit@test.com")
+	artist := suite.createArtist("Limit Release Artist")
+
+	for i := 0; i < 5; i++ {
+		release := suite.createRelease(fmt.Sprintf("Release %d", i))
+		suite.addArtistToRelease(artist.ID, release.ID)
+		suite.createBookmark(user.ID, models.BookmarkEntityRelease, release.ID, models.BookmarkActionBookmark)
+	}
+
+	releases, err := suite.chartsService.GetHotReleases(3)
+	suite.Require().NoError(err)
+	suite.Len(releases, 3)
+}
+
+func (suite *ChartsServiceIntegrationTestSuite) TestGetHotReleases_Only30Days() {
+	user := suite.createUser("hot-30d@test.com")
+	artist := suite.createArtist("Old Release Artist")
+
+	release := suite.createRelease("Old Bookmarked Release")
+	suite.addArtistToRelease(artist.ID, release.ID)
+
+	// Create a bookmark, then manually backdate it to 31 days ago
+	suite.createBookmark(user.ID, models.BookmarkEntityRelease, release.ID, models.BookmarkActionBookmark)
+	suite.db.Exec("UPDATE user_bookmarks SET created_at = ? WHERE entity_id = ? AND entity_type = ? AND action = ?",
+		time.Now().UTC().AddDate(0, 0, -31), release.ID, models.BookmarkEntityRelease, models.BookmarkActionBookmark)
+
+	releases, err := suite.chartsService.GetHotReleases(20)
+	suite.Require().NoError(err)
+	suite.Empty(releases) // Should not include bookmark older than 30 days
+}
+
+// =============================================================================
+// GetChartsOverview Tests
+// =============================================================================
+
+func (suite *ChartsServiceIntegrationTestSuite) TestGetChartsOverview_Empty() {
+	overview, err := suite.chartsService.GetChartsOverview()
+	suite.Require().NoError(err)
+	suite.Require().NotNil(overview)
+	suite.Empty(overview.TrendingShows)
+	suite.Empty(overview.PopularArtists)
+	suite.Empty(overview.ActiveVenues)
+	suite.Empty(overview.HotReleases)
+}
+
+func (suite *ChartsServiceIntegrationTestSuite) TestGetChartsOverview_LimitsToFive() {
+	user := suite.createUser("overview@test.com")
+	venue := suite.createVenue("Overview Venue", "Phoenix", "AZ")
+
+	future := time.Now().UTC().AddDate(0, 0, 7)
+	for i := 0; i < 8; i++ {
+		artist := suite.createArtist(fmt.Sprintf("Overview Artist %d", i))
+		show := suite.createApprovedShow(
+			fmt.Sprintf("Overview Show %d", i),
+			venue.ID, artist.ID, user.ID,
+			future.AddDate(0, 0, i),
+		)
+		suite.createBookmark(user.ID, models.BookmarkEntityShow, show.ID, models.BookmarkActionGoing)
+		suite.createBookmark(user.ID, models.BookmarkEntityArtist, artist.ID, models.BookmarkActionFollow)
+	}
+
+	overview, err := suite.chartsService.GetChartsOverview()
+	suite.Require().NoError(err)
+	suite.Require().NotNil(overview)
+	suite.LessOrEqual(len(overview.TrendingShows), 5)
+	suite.LessOrEqual(len(overview.PopularArtists), 5)
+}

--- a/backend/internal/services/container.go
+++ b/backend/internal/services/container.go
@@ -24,6 +24,7 @@ type ServiceContainer struct {
 	APIToken           *adminsvc.APITokenService
 	DataQuality        *adminsvc.DataQualityService
 	Revision           *adminsvc.RevisionService
+	Charts             *catalog.ChartsService
 	Artist             *catalog.ArtistService
 	ContributorProfile *usersvc.ContributorProfileService
 	ArtistReport  *adminsvc.ArtistReportService
@@ -113,6 +114,7 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 		APIToken:           adminsvc.NewAPITokenService(database),
 		DataQuality:        adminsvc.NewDataQualityService(database),
 		Revision:           adminsvc.NewRevisionService(database),
+		Charts:             catalog.NewChartsService(database),
 		Artist:             artist,
 		ContributorProfile: usersvc.NewContributorProfileService(database),
 		ArtistReport:  adminsvc.NewArtistReportService(database),

--- a/backend/internal/services/contracts/charts.go
+++ b/backend/internal/services/contracts/charts.go
@@ -1,0 +1,62 @@
+package contracts
+
+import "time"
+
+// ──────────────────────────────────────────────
+// Charts types (top charts / trending content)
+// ──────────────────────────────────────────────
+
+// TrendingShow represents a show ranked by attendance (going + interested).
+type TrendingShow struct {
+	ShowID          uint      `json:"show_id"`
+	Title           string    `json:"title"`
+	Slug            string    `json:"slug"`
+	Date            time.Time `json:"date"`
+	VenueName       string    `json:"venue_name"`
+	VenueSlug       string    `json:"venue_slug"`
+	City            string    `json:"city"`
+	GoingCount      int       `json:"going_count"`
+	InterestedCount int       `json:"interested_count"`
+	TotalAttendance int       `json:"total_attendance"`
+}
+
+// PopularArtist represents an artist ranked by followers and upcoming shows.
+type PopularArtist struct {
+	ArtistID          uint   `json:"artist_id"`
+	Name              string `json:"name"`
+	Slug              string `json:"slug"`
+	ImageURL          string `json:"image_url"`
+	FollowCount       int    `json:"follow_count"`
+	UpcomingShowCount int    `json:"upcoming_show_count"`
+	Score             int    `json:"score"`
+}
+
+// ActiveVenue represents a venue ranked by upcoming shows and followers.
+type ActiveVenue struct {
+	VenueID           uint   `json:"venue_id"`
+	Name              string `json:"name"`
+	Slug              string `json:"slug"`
+	City              string `json:"city"`
+	State             string `json:"state"`
+	UpcomingShowCount int    `json:"upcoming_show_count"`
+	FollowCount       int    `json:"follow_count"`
+	Score             int    `json:"score"`
+}
+
+// HotRelease represents a release ranked by recent bookmarks.
+type HotRelease struct {
+	ReleaseID     uint       `json:"release_id"`
+	Title         string     `json:"title"`
+	Slug          string     `json:"slug"`
+	ReleaseDate   *time.Time `json:"release_date"`
+	ArtistNames   []string   `json:"artist_names"`
+	BookmarkCount int        `json:"bookmark_count"`
+}
+
+// ChartsOverview contains condensed top-5 versions of all charts for dashboard use.
+type ChartsOverview struct {
+	TrendingShows  []TrendingShow  `json:"trending_shows"`
+	PopularArtists []PopularArtist `json:"popular_artists"`
+	ActiveVenues   []ActiveVenue   `json:"active_venues"`
+	HotReleases    []HotRelease    `json:"hot_releases"`
+}

--- a/backend/internal/services/contracts/interfaces.go
+++ b/backend/internal/services/contracts/interfaces.go
@@ -461,6 +461,15 @@ type AttendanceServiceInterface interface {
 	GetUserAttendingShows(userID uint, status string, limit, offset int) ([]*AttendingShowResponse, int64, error)
 }
 
+// ChartsServiceInterface defines the contract for top charts / trending content.
+type ChartsServiceInterface interface {
+	GetTrendingShows(limit int) ([]TrendingShow, error)
+	GetPopularArtists(limit int) ([]PopularArtist, error)
+	GetActiveVenues(limit int) ([]ActiveVenue, error)
+	GetHotReleases(limit int) ([]HotRelease, error)
+	GetChartsOverview() (*ChartsOverview, error)
+}
+
 // FollowServiceInterface defines the contract for entity follow operations.
 type FollowServiceInterface interface {
 	Follow(userID uint, entityType string, entityID uint) error

--- a/backend/internal/services/interfaces.go
+++ b/backend/internal/services/interfaces.go
@@ -50,6 +50,7 @@ type SceneServiceInterface = contracts.SceneServiceInterface
 type DataQualityServiceInterface = contracts.DataQualityServiceInterface
 type AnalyticsServiceInterface = contracts.AnalyticsServiceInterface
 type AttendanceServiceInterface = contracts.AttendanceServiceInterface
+type ChartsServiceInterface = contracts.ChartsServiceInterface
 type FollowServiceInterface = contracts.FollowServiceInterface
 
 // Compile-time interface satisfaction checks.
@@ -77,4 +78,5 @@ var (
 	_ TagServiceInterface                   = (*catalog.TagService)(nil)
 	_ ArtistRelationshipServiceInterface    = (*catalog.ArtistRelationshipService)(nil)
 	_ SceneServiceInterface                 = (*catalog.SceneService)(nil)
+	_ ChartsServiceInterface                = (*catalog.ChartsService)(nil)
 )


### PR DESCRIPTION
## Summary
- 5 public API endpoints under `/charts/`: trending-shows, popular-artists, active-venues, hot-releases, overview
- Composite scoring: follows + upcoming shows for artists/venues, attendance for shows, recent bookmarks for releases
- Future-only shows for trending, 30-day window for hot releases
- Configurable limit (default 20, max 50), overview returns top 5 each
- 47 tests passing (7 unit + 18 integration + 22 handler)

Closes PSY-57

## Test plan
- [ ] Run `go test ./internal/services/catalog/ -run TestCharts` — 25 tests pass
- [ ] Run `go test ./internal/api/handlers/ -run TestCharts` — 22 tests pass
- [ ] Verify endpoints return correct data with seeded DB
- [ ] Check empty state returns empty arrays, not errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)