### PR TITLE
Add accessible labels to attendance buttons on show cards

### DIFF
--- a/frontend/features/shows/components/AttendanceButton.tsx
+++ b/frontend/features/shows/components/AttendanceButton.tsx
@@ -82,6 +82,7 @@ export function AttendanceButton({
                   handleClick('going')
                 }}
                 disabled={isPending}
+                aria-label={`Going${goingCount > 0 ? ` ${goingCount}` : ''}`}
               >
                 <CalendarCheck className="h-3.5 w-3.5" />
                 {goingCount > 0 && <span>{goingCount}</span>}
@@ -112,6 +113,7 @@ export function AttendanceButton({
                   handleClick('interested')
                 }}
                 disabled={isPending}
+                aria-label={`Interested${interestedCount > 0 ? ` ${interestedCount}` : ''}`}
               >
                 <Star className="h-3.5 w-3.5" />
                 {interestedCount > 0 && <span>{interestedCount}</span>}


### PR DESCRIPTION
## Summary
- Add `aria-label` attributes to the compact Going/Interested buttons on show cards
- Buttons were rendering as unnamed `button` elements in the accessibility tree
- Detail page already had correct labels; this brings cards into parity

## Test plan
- [ ] Verify show cards on homepage and `/shows` have accessible button names
- [ ] Screen reader announces "Going" / "Interested" (with counts when present)
- [ ] Detail page attendance buttons still work correctly

Closes PSY-112

🤖 Generated with [Claude Code](https://claude.com/claude-code)