### PR TITLE
Fix show slug timezone off-by-one: use local date

### DIFF
--- a/backend/cmd/backfill-slugs/main.go
+++ b/backend/cmd/backfill-slugs/main.go
@@ -99,7 +99,14 @@ func main() {
 			venueName = show.Venues[0].Name
 		}
 
-		baseSlug := utils.GenerateShowSlug(show.EventDate, headlinerName, venueName)
+		// Use venue state for timezone-aware slug date
+		showState := ""
+		if show.State != nil {
+			showState = *show.State
+		} else if len(show.Venues) > 0 {
+			showState = show.Venues[0].State
+		}
+		baseSlug := utils.GenerateShowSlug(show.EventDate, headlinerName, venueName, showState)
 		slug := utils.GenerateUniqueSlug(baseSlug, func(candidate string) bool {
 			var count int64
 			database.Model(&models.Show{}).Where("slug = ? AND id != ?", candidate, show.ID).Count(&count)

--- a/backend/cmd/seed/main.go
+++ b/backend/cmd/seed/main.go
@@ -278,7 +278,7 @@ func createShowWithAssociations(db *gorm.DB, showData ShowData) error {
 	if len(showData.Venues) > 0 {
 		venueName = normalizeVenueName(showData.Venues[0])
 	}
-	showSlug := utils.GenerateShowSlug(eventDateUTC, headlinerName, venueName)
+	showSlug := utils.GenerateShowSlug(eventDateUTC, headlinerName, venueName, showData.State)
 
 	// Create the show
 	show := &models.Show{

--- a/backend/internal/services/admin/data_sync.go
+++ b/backend/internal/services/admin/data_sync.go
@@ -556,8 +556,16 @@ func (s *DataSyncService) importShow(show *contracts.ExportedShow, dryRun bool) 
 			}
 		}
 
+		// Determine state for timezone-aware slug
+		showState := ""
+		if show.State != nil {
+			showState = *show.State
+		} else if len(show.Venues) > 0 {
+			showState = show.Venues[0].State
+		}
+
 		// Generate show slug
-		baseShowSlug := utils.GenerateShowSlug(eventDate.UTC(), headlinerName, venueName)
+		baseShowSlug := utils.GenerateShowSlug(eventDate.UTC(), headlinerName, venueName, showState)
 		showSlug := utils.GenerateUniqueSlug(baseShowSlug, func(candidate string) bool {
 			var count int64
 			tx.Model(&models.Show{}).Where("slug = ?", candidate).Count(&count)
@@ -696,7 +704,13 @@ func (s *DataSyncService) backfillShowSlugs(existingShow *models.Show, show *con
 				headlinerName = a.Name
 			}
 		}
-		baseSlug := utils.GenerateShowSlug(eventDate.UTC(), headlinerName, venueName)
+		showState := ""
+		if show.State != nil {
+			showState = *show.State
+		} else if len(show.Venues) > 0 {
+			showState = show.Venues[0].State
+		}
+		baseSlug := utils.GenerateShowSlug(eventDate.UTC(), headlinerName, venueName, showState)
 		slug := utils.GenerateUniqueSlug(baseSlug, func(candidate string) bool {
 			var count int64
 			s.db.Model(&models.Show{}).Where("slug = ?", candidate).Count(&count)

--- a/backend/internal/services/catalog/show.go
+++ b/backend/internal/services/catalog/show.go
@@ -110,7 +110,12 @@ func (s *ShowService) CreateShow(req *contracts.CreateShowRequest) (*contracts.S
 			venueName = venues[0].Name
 		}
 
-		baseSlug := utils.GenerateShowSlug(show.EventDate, headlinerName, venueName)
+		// Use show state for timezone-aware slug date
+		showState := ""
+		if show.State != nil {
+			showState = *show.State
+		}
+		baseSlug := utils.GenerateShowSlug(show.EventDate, headlinerName, venueName, showState)
 		slug := utils.GenerateUniqueSlug(baseSlug, func(candidate string) bool {
 			var count int64
 			tx.Model(&models.Show{}).Where("slug = ?", candidate).Count(&count)

--- a/backend/internal/services/pipeline/discovery.go
+++ b/backend/internal/services/pipeline/discovery.go
@@ -448,7 +448,7 @@ func (s *DiscoveryService) createShowFromEvent(event *contracts.DiscoveredEvent,
 		if len(artistEntries) > 0 {
 			headlinerName = artistEntries[0].Name
 		}
-		baseShowSlug := utils.GenerateShowSlug(show.EventDate, headlinerName, venueConfig.Name)
+		baseShowSlug := utils.GenerateShowSlug(show.EventDate, headlinerName, venueConfig.Name, venueConfig.State)
 		showSlug := utils.GenerateUniqueSlug(baseShowSlug, func(candidate string) bool {
 			var count int64
 			tx.Model(&models.Show{}).Where("slug = ?", candidate).Count(&count)
@@ -522,25 +522,9 @@ func (s *DiscoveryService) updateShowFromEvent(existing *models.Show, event *con
 	return fmt.Sprintf("UPDATED: %s (show #%d) -- %s", event.Title, existing.ID, changeStr), "updated"
 }
 
-// stateTimezones maps US state abbreviations to IANA timezone names
-var stateTimezones = map[string]string{
-	"AZ": "America/Phoenix",
-	"CA": "America/Los_Angeles",
-	"NV": "America/Los_Angeles",
-	"CO": "America/Denver",
-	"NM": "America/Denver",
-	"IL": "America/Chicago",
-	"TX": "America/Chicago",
-	"NY": "America/New_York",
-}
-
-// getTimezoneForState returns the IANA timezone for a US state abbreviation.
-// Defaults to "America/Phoenix" if the state is not found.
+// getTimezoneForState delegates to the shared utils.GetTimezoneForState.
 func getTimezoneForState(state string) string {
-	if tz, ok := stateTimezones[strings.ToUpper(state)]; ok {
-		return tz
-	}
-	return "America/Phoenix"
+	return utils.GetTimezoneForState(state)
 }
 
 // parseEventDate parses the event date and optional show time into a time.Time (UTC).

--- a/backend/internal/utils/slug.go
+++ b/backend/internal/utils/slug.go
@@ -48,10 +48,18 @@ func GenerateVenueSlug(name, city, state string) string {
 	return GenerateSlug(name, city, state)
 }
 
-// GenerateShowSlug creates a slug from date, headliner name, and venue name
+// GenerateShowSlug creates a slug from date, headliner name, and venue name.
+// The state parameter is used to convert the UTC event date to the venue's local
+// date so that the slug date matches the date displayed in the UI.
 // Format: "2026-01-30-the-national-at-valley-bar"
-func GenerateShowSlug(eventDate time.Time, headlinerName, venueName string) string {
-	dateStr := eventDate.Format("2006-01-02")
+func GenerateShowSlug(eventDate time.Time, headlinerName, venueName, state string) string {
+	localDate := eventDate
+	if tz := GetTimezoneForState(state); tz != "" {
+		if loc, err := time.LoadLocation(tz); err == nil {
+			localDate = eventDate.In(loc)
+		}
+	}
+	dateStr := localDate.Format("2006-01-02")
 	return GenerateSlug(dateStr, headlinerName, "at", venueName)
 }
 

--- a/backend/internal/utils/slug_test.go
+++ b/backend/internal/utils/slug_test.go
@@ -98,16 +98,49 @@ func TestGenerateVenueSlug(t *testing.T) {
 // --- GenerateShowSlug ---
 
 func TestGenerateShowSlug(t *testing.T) {
-	date := time.Date(2026, 1, 30, 20, 0, 0, 0, time.UTC)
-	slug := GenerateShowSlug(date, "The National", "Valley Bar")
+	// 8pm Phoenix time = 3am UTC next day (UTC-7)
+	date := time.Date(2026, 1, 31, 3, 0, 0, 0, time.UTC)
+	slug := GenerateShowSlug(date, "The National", "Valley Bar", "AZ")
+	// Should use Phoenix local date (Jan 30), not UTC date (Jan 31)
 	assert.Equal(t, "2026-01-30-the-national-at-valley-bar", slug)
 }
 
 func TestGenerateShowSlug_DateFormatting(t *testing.T) {
 	// Verify single-digit month/day get zero-padded
 	date := time.Date(2026, 3, 5, 0, 0, 0, 0, time.UTC)
-	slug := GenerateShowSlug(date, "Turnstile", "Crescent Ballroom")
-	assert.Equal(t, "2026-03-05-turnstile-at-crescent-ballroom", slug)
+	slug := GenerateShowSlug(date, "Turnstile", "Crescent Ballroom", "AZ")
+	// 3/5 00:00 UTC = 3/4 5pm Phoenix, so local date is March 4
+	assert.Equal(t, "2026-03-04-turnstile-at-crescent-ballroom", slug)
+}
+
+func TestGenerateShowSlug_TimezoneConversion(t *testing.T) {
+	// A show at 7:30 PM Phoenix time on March 16 is stored as 2:30 AM UTC on March 17
+	date := time.Date(2026, 3, 17, 2, 30, 0, 0, time.UTC)
+	slug := GenerateShowSlug(date, "Radiohead", "Valley Bar", "AZ")
+	// Slug should use the Phoenix local date (March 16), not UTC (March 17)
+	assert.Equal(t, "2026-03-16-radiohead-at-valley-bar", slug)
+}
+
+func TestGenerateShowSlug_EasternTimezone(t *testing.T) {
+	// 11pm ET on Jan 15 = 4am UTC Jan 16 (UTC-5)
+	date := time.Date(2026, 1, 16, 4, 0, 0, 0, time.UTC)
+	slug := GenerateShowSlug(date, "The National", "Brooklyn Steel", "NY")
+	assert.Equal(t, "2026-01-15-the-national-at-brooklyn-steel", slug)
+}
+
+func TestGenerateShowSlug_EmptyState(t *testing.T) {
+	// Empty state defaults to America/Phoenix
+	date := time.Date(2026, 3, 17, 2, 30, 0, 0, time.UTC)
+	slug := GenerateShowSlug(date, "Radiohead", "Valley Bar", "")
+	assert.Equal(t, "2026-03-16-radiohead-at-valley-bar", slug)
+}
+
+func TestGenerateShowSlug_SameDateNoShift(t *testing.T) {
+	// A show at 2pm Phoenix time on March 16 is stored as 9pm UTC on March 16
+	// No date shift expected
+	date := time.Date(2026, 3, 16, 21, 0, 0, 0, time.UTC)
+	slug := GenerateShowSlug(date, "Radiohead", "Valley Bar", "AZ")
+	assert.Equal(t, "2026-03-16-radiohead-at-valley-bar", slug)
 }
 
 // --- GenerateUniqueSlug ---

--- a/backend/internal/utils/timezone.go
+++ b/backend/internal/utils/timezone.go
@@ -1,0 +1,24 @@
+package utils
+
+import "strings"
+
+// StateTimezones maps US state abbreviations to IANA timezone names.
+var StateTimezones = map[string]string{
+	"AZ": "America/Phoenix",
+	"CA": "America/Los_Angeles",
+	"NV": "America/Los_Angeles",
+	"CO": "America/Denver",
+	"NM": "America/Denver",
+	"IL": "America/Chicago",
+	"TX": "America/Chicago",
+	"NY": "America/New_York",
+}
+
+// GetTimezoneForState returns the IANA timezone for a US state abbreviation.
+// Defaults to "America/Phoenix" if the state is not found.
+func GetTimezoneForState(state string) string {
+	if tz, ok := StateTimezones[strings.ToUpper(state)]; ok {
+		return tz
+	}
+	return "America/Phoenix"
+}

--- a/backend/internal/utils/timezone_test.go
+++ b/backend/internal/utils/timezone_test.go
@@ -1,0 +1,29 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetTimezoneForState_KnownStates(t *testing.T) {
+	assert.Equal(t, "America/Phoenix", GetTimezoneForState("AZ"))
+	assert.Equal(t, "America/Los_Angeles", GetTimezoneForState("CA"))
+	assert.Equal(t, "America/Los_Angeles", GetTimezoneForState("NV"))
+	assert.Equal(t, "America/Denver", GetTimezoneForState("CO"))
+	assert.Equal(t, "America/Denver", GetTimezoneForState("NM"))
+	assert.Equal(t, "America/Chicago", GetTimezoneForState("IL"))
+	assert.Equal(t, "America/Chicago", GetTimezoneForState("TX"))
+	assert.Equal(t, "America/New_York", GetTimezoneForState("NY"))
+}
+
+func TestGetTimezoneForState_CaseInsensitive(t *testing.T) {
+	assert.Equal(t, "America/Phoenix", GetTimezoneForState("az"))
+	assert.Equal(t, "America/Los_Angeles", GetTimezoneForState("ca"))
+	assert.Equal(t, "America/Phoenix", GetTimezoneForState("Az"))
+}
+
+func TestGetTimezoneForState_UnknownDefaultsToPhoenix(t *testing.T) {
+	assert.Equal(t, "America/Phoenix", GetTimezoneForState("XX"))
+	assert.Equal(t, "America/Phoenix", GetTimezoneForState(""))
+}


### PR DESCRIPTION
## Summary
- Show slugs used UTC date, but UI displays local (venue timezone) dates
- Evening shows in US timezones had slug dates one day ahead of displayed dates
- Added shared `GetTimezoneForState()` utility mapping state abbreviations to IANA timezones
- `GenerateShowSlug` now converts event date to local time before formatting
- Updated all 6 callers across show service, discovery, data_sync, backfill, and seed
- Added 6 new tests covering timezone conversion and edge cases

## Test plan
- [ ] Show card date matches the date in the URL slug
- [ ] Show slugs for evening Phoenix shows use the local date (not UTC+1 day)
- [ ] All backend tests pass (`go test ./internal/utils/ ./internal/services/catalog/`)

Closes PSY-115

🤖 Generated with [Claude Code](https://claude.com/claude-code)