### PR TITLE
Fix artist detail 'Back to Shows' → 'Back to Artists'

### DIFF
--- a/frontend/e2e/pages/artist-detail.spec.ts
+++ b/frontend/e2e/pages/artist-detail.spec.ts
@@ -29,9 +29,9 @@ test.describe('Artist detail', () => {
     await expect(heading).toBeVisible({ timeout: 10_000 })
     await expect(heading).toContainText(artistName!)
 
-    // Back to Shows link
+    // Back to Artists link
     await expect(
-      page.getByRole('link', { name: /back to shows/i })
+      page.getByRole('link', { name: /back to artists/i })
     ).toBeVisible()
 
     // Upcoming and Past Shows tabs
@@ -41,7 +41,7 @@ test.describe('Artist detail', () => {
     ).toBeVisible()
   })
 
-  test('back to shows link navigates to shows list', async ({ page }) => {
+  test('back to artists link navigates to artists list', async ({ page }) => {
     await page.goto('/shows')
     await expect(page.locator('article').first()).toBeVisible({
       timeout: 10_000,
@@ -59,11 +59,11 @@ test.describe('Artist detail', () => {
     await artistLink.click()
     await page.waitForURL(/\/artists\//, { timeout: 10_000 })
 
-    await page.getByRole('link', { name: /back to shows/i }).click()
-    await page.waitForURL(/\/shows$/, { timeout: 10_000 })
+    await page.getByRole('link', { name: /back to artists/i }).click()
+    await page.waitForURL(/\/artists$/, { timeout: 10_000 })
 
     await expect(
-      page.getByRole('heading', { name: /upcoming shows/i })
+      page.getByRole('heading', { name: /artists/i })
     ).toBeVisible()
   })
 

--- a/frontend/features/artists/components/ArtistDetail.test.tsx
+++ b/frontend/features/artists/components/ArtistDetail.test.tsx
@@ -245,8 +245,8 @@ describe('ArtistDetail', () => {
       })
 
       renderWithProviders(<ArtistDetail artistId="bad" />)
-      const backLink = screen.getByText('Back to Shows')
-      expect(backLink.closest('a')).toHaveAttribute('href', '/shows')
+      const backLink = screen.getByText('Back to Artists')
+      expect(backLink.closest('a')).toHaveAttribute('href', '/artists')
     })
   })
 
@@ -280,7 +280,7 @@ describe('ArtistDetail', () => {
     it('renders entity layout with back link', () => {
       renderWithProviders(<ArtistDetail artistId="test-artist" />)
       expect(screen.getByTestId('entity-layout')).toBeInTheDocument()
-      expect(screen.getByText('Back to Shows')).toBeInTheDocument()
+      expect(screen.getByText('Back to Artists')).toBeInTheDocument()
     })
 
     it('renders tabs for overview, discography, and labels', () => {

--- a/frontend/features/artists/components/ArtistDetail.tsx
+++ b/frontend/features/artists/components/ArtistDetail.tsx
@@ -858,9 +858,9 @@ export function ArtistDetail({ artistId }: ArtistDetailProps) {
               : errorMessage}
           </p>
           <Button asChild variant="outline">
-            <Link href="/shows">
+            <Link href="/artists">
               <ArrowLeft className="h-4 w-4 mr-2" />
-              Back to Shows
+              Back to Artists
             </Link>
           </Button>
         </div>
@@ -877,9 +877,9 @@ export function ArtistDetail({ artistId }: ArtistDetailProps) {
             The artist you&apos;re looking for doesn&apos;t exist.
           </p>
           <Button asChild variant="outline">
-            <Link href="/shows">
+            <Link href="/artists">
               <ArrowLeft className="h-4 w-4 mr-2" />
-              Back to Shows
+              Back to Artists
             </Link>
           </Button>
         </div>
@@ -923,7 +923,7 @@ export function ArtistDetail({ artistId }: ArtistDetailProps) {
   return (
     <>
       <EntityDetailLayout
-        backLink={{ href: '/shows', label: 'Back to Shows' }}
+        backLink={{ href: '/artists', label: 'Back to Artists' }}
         header={
           <EntityHeader
             title={artist.name}


### PR DESCRIPTION
## Summary
- Artist detail page had "Back to Shows" linking to `/shows` — copy-paste error
- Changed to "Back to Artists" linking to `/artists`
- Updated component, unit tests (26/26 pass), and e2e tests

## Test plan
- [ ] Artist detail page shows "Back to Artists" breadcrumb
- [ ] Clicking it navigates to `/artists`
- [ ] Other entity detail pages unaffected (venues still say "Back to Venues", etc.)

Closes PSY-113

🤖 Generated with [Claude Code](https://claude.com/claude-code)