### PR TITLE
Fix request creation 422 — make description optional

### DIFF
--- a/backend/internal/api/handlers/request.go
+++ b/backend/internal/api/handlers/request.go
@@ -37,7 +37,7 @@ func NewRequestHandler(requestService services.RequestServiceInterface, auditLog
 type CreateRequestHandlerRequest struct {
 	Body struct {
 		Title             string  `json:"title" doc:"Request title" example:"Add Local Band XYZ"`
-		Description       string  `json:"description" doc:"Detailed description of the request" example:"They play at The Rebel Lounge frequently"`
+		Description       *string `json:"description,omitempty" required:"false" doc:"Detailed description of the request" example:"They play at The Rebel Lounge frequently"`
 		EntityType        string  `json:"entity_type" doc:"Entity type (artist, release, label, show, venue, festival)" example:"artist"`
 		RequestedEntityID *uint   `json:"requested_entity_id,omitempty" required:"false" doc:"Optional ID of an existing entity this relates to"`
 	}
@@ -64,7 +64,11 @@ func (h *RequestHandler) CreateRequestHandler(ctx context.Context, req *CreateRe
 		return nil, huma.Error400BadRequest("Entity type is required")
 	}
 
-	request, err := h.requestService.CreateRequest(user.ID, req.Body.Title, req.Body.Description, req.Body.EntityType, req.Body.RequestedEntityID)
+	description := ""
+	if req.Body.Description != nil {
+		description = *req.Body.Description
+	}
+	request, err := h.requestService.CreateRequest(user.ID, req.Body.Title, description, req.Body.EntityType, req.Body.RequestedEntityID)
 	if err != nil {
 		logger.FromContext(ctx).Error("create_request_failed",
 			"error", err.Error(),

--- a/backend/internal/api/handlers/request_test.go
+++ b/backend/internal/api/handlers/request_test.go
@@ -196,8 +196,9 @@ func TestRequestHandler_Create_Success(t *testing.T) {
 	h := NewRequestHandler(&mockRequestService{}, nil)
 
 	req := &CreateRequestHandlerRequest{}
+	desc := "They play shows"
 	req.Body.Title = "Add Band XYZ"
-	req.Body.Description = "They play shows"
+	req.Body.Description = &desc
 	req.Body.EntityType = "artist"
 
 	resp, err := h.CreateRequestHandler(requestUserCtx(), req)
@@ -237,8 +238,9 @@ func TestRequestHandler_Create_ServiceError(t *testing.T) {
 	}, nil)
 
 	req := &CreateRequestHandlerRequest{}
+	errDesc := "desc"
 	req.Body.Title = "Test"
-	req.Body.Description = "desc"
+	req.Body.Description = &errDesc
 	req.Body.EntityType = "artist"
 
 	_, err := h.CreateRequestHandler(requestUserCtx(), req)


### PR DESCRIPTION
## Summary
- Request creation always failed with 422 because Huma treated the `Description` field as required
- Changed `Description` from `string` to `*string` with `required:"false"` in the handler input struct
- Handler now dereferences the pointer safely before passing to the service

## Test plan
- [ ] Create a request with title only (no description) — should succeed
- [ ] Create a request with title + description — should still work
- [ ] Backend compiles cleanly

Closes PSY-114

🤖 Generated with [Claude Code](https://claude.com/claude-code)