### PR TITLE
Update Cmd+K placeholder to 'Go to page...' for clearer UX

### DIFF
--- a/frontend/components/layout/CommandPalette.test.tsx
+++ b/frontend/components/layout/CommandPalette.test.tsx
@@ -46,7 +46,7 @@ describe('CommandPalette', () => {
     render(<CommandPalette />)
 
     // Dialog should not be visible initially
-    expect(screen.queryByPlaceholderText('Search pages...')).not.toBeInTheDocument()
+    expect(screen.queryByPlaceholderText('Go to page...')).not.toBeInTheDocument()
 
     // Press Cmd+K
     act(() => {
@@ -56,7 +56,7 @@ describe('CommandPalette', () => {
     })
 
     // Dialog should be visible
-    expect(screen.getByPlaceholderText('Search pages...')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Go to page...')).toBeInTheDocument()
   })
 
   it('should show public pages for unauthenticated users', async () => {
@@ -164,11 +164,11 @@ describe('CommandPalette', () => {
       )
     })
 
-    expect(screen.getByPlaceholderText('Search pages...')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Go to page...')).toBeInTheDocument()
 
     await user.keyboard('{Escape}')
 
-    expect(screen.queryByPlaceholderText('Search pages...')).not.toBeInTheDocument()
+    expect(screen.queryByPlaceholderText('Go to page...')).not.toBeInTheDocument()
   })
 
   it('should show keyboard navigation hints', async () => {
@@ -192,6 +192,6 @@ describe('CommandPalette', () => {
       window.dispatchEvent(new Event('open-command-palette'))
     })
 
-    expect(screen.getByPlaceholderText('Search pages...')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Go to page...')).toBeInTheDocument()
   })
 })

--- a/frontend/components/layout/CommandPalette.tsx
+++ b/frontend/components/layout/CommandPalette.tsx
@@ -206,7 +206,7 @@ export function CommandPalette() {
       <div className="flex items-center border-b border-border/50 px-3">
         <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
         <CommandPrimitive.Input
-          placeholder="Search pages..."
+          placeholder="Go to page..."
           className="flex h-11 w-full bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground"
           value={search}
           onValueChange={setSearch}
@@ -223,7 +223,7 @@ export function CommandPalette() {
       </div>
 
       <CommandList className="max-h-[320px] p-2">
-        <CommandEmpty>No results found.</CommandEmpty>
+        <CommandEmpty>No matching pages.</CommandEmpty>
 
         {showRecent && (
           <CommandGroup


### PR DESCRIPTION
## Summary
- Command palette only searches navigation routes, not content entities
- Changed placeholder from "Search pages..." to "Go to page..."
- Changed empty state from "No results found." to "No matching pages."
- Sets correct user expectations (navigation, not search)
- All 9 tests updated and passing

## Test plan
- [ ] Cmd+K shows "Go to page..." placeholder
- [ ] Empty search results show "No matching pages."
- [ ] Navigation filtering still works correctly

Closes PSY-117

🤖 Generated with [Claude Code](https://claude.com/claude-code)