### PR TITLE
Add charts page with trending and popular content (PSY-105)

### DIFF
--- a/frontend/app/charts/page.tsx
+++ b/frontend/app/charts/page.tsx
@@ -1,0 +1,39 @@
+import { Suspense } from 'react'
+import { LoadingSpinner } from '@/components/shared'
+import { ChartsPage } from '@/features/charts'
+
+export const metadata = {
+  title: 'Charts',
+  description: 'Top charts — trending shows, popular artists, active venues, and hot releases.',
+  alternates: {
+    canonical: 'https://psychichomily.com/charts',
+  },
+  openGraph: {
+    title: 'Charts | Psychic Homily',
+    description: 'Top charts — trending shows, popular artists, active venues, and hot releases.',
+    url: '/charts',
+    type: 'website',
+  },
+}
+
+export default function ChartsRoute() {
+  return (
+    <div className="flex min-h-screen items-start justify-center">
+      <main className="w-full max-w-6xl px-4 py-8 md:px-8">
+        <h1 className="text-3xl font-bold text-center mb-2">Charts</h1>
+        <p className="text-center text-muted-foreground mb-8 max-w-lg mx-auto">
+          Trending shows, popular artists, active venues, and hot releases.
+        </p>
+        <Suspense
+          fallback={
+            <div className="flex justify-center items-center py-12">
+              <LoadingSpinner />
+            </div>
+          }
+        >
+          <ChartsPage />
+        </Suspense>
+      </main>
+    </div>
+  )
+}

--- a/frontend/components/layout/CommandPalette.tsx
+++ b/frontend/components/layout/CommandPalette.tsx
@@ -14,6 +14,7 @@ import {
 import {
   Calendar, CalendarCheck, Mic2, MapPin, Disc3, Tag, Tags, Tent, BookOpen, Headphones, Send,
   Library, LayoutList, MessageSquarePlus, Settings, Shield, Search, Clock, X, Globe, UserCheck,
+  TrendingUp,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import { useAuthContext } from '@/lib/context/AuthContext'
@@ -82,6 +83,12 @@ const routes: RouteItem[] = [
     href: '/collections',
     icon: LayoutList,
     keywords: ['collections', 'curated', 'lists', 'playlists'],
+  },
+  {
+    label: 'Charts',
+    href: '/charts',
+    icon: TrendingUp,
+    keywords: ['charts', 'trending', 'popular', 'top', 'hot', 'rankings', 'leaderboard'],
   },
   {
     label: 'Requests',

--- a/frontend/components/layout/Sidebar.test.tsx
+++ b/frontend/components/layout/Sidebar.test.tsx
@@ -25,7 +25,7 @@ describe('sidebarGroups', () => {
 
   it('Discover contains Shows, Festivals, Artists, Venues, Releases, Labels, Tags, Collections', () => {
     const discover = sidebarGroups.find(g => g.label === 'Discover')!
-    expect(discover.items.map(i => i.label)).toEqual(['Shows', 'Festivals', 'Artists', 'Venues', 'Releases', 'Labels', 'Tags', 'Scenes', 'Collections'])
+    expect(discover.items.map(i => i.label)).toEqual(['Shows', 'Festivals', 'Artists', 'Venues', 'Releases', 'Labels', 'Tags', 'Scenes', 'Collections', 'Charts'])
   })
 
   it('Community contains Requests, Blog, DJ Sets, Substack, Submissions', () => {

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -5,7 +5,7 @@ import { usePathname } from 'next/navigation'
 import {
   Calendar, CalendarCheck, Mic2, MapPin, Disc3, Tag, Tags, Tent, BookOpen, Headphones, Newspaper,
   Send, Library, LayoutList, MessageSquarePlus, Settings, Shield, PanelLeftClose, PanelLeft,
-  ExternalLink, Globe, UserCheck,
+  ExternalLink, Globe, UserCheck, TrendingUp,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import { cn } from '@/lib/utils'
@@ -39,6 +39,7 @@ export const sidebarGroups: SidebarGroup[] = [
       { href: '/tags', label: 'Tags', icon: Tags },
       { href: '/scenes', label: 'Scenes', icon: Globe },
       { href: '/collections', label: 'Collections', icon: LayoutList },
+      { href: '/charts', label: 'Charts', icon: TrendingUp },
     ],
   },
   {

--- a/frontend/features/charts/components/ActiveVenuesList.tsx
+++ b/frontend/features/charts/components/ActiveVenuesList.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import Link from 'next/link'
+import { Calendar, UserCheck, MapPin } from 'lucide-react'
+import type { ActiveVenue } from '../types'
+
+interface ActiveVenuesListProps {
+  venues: ActiveVenue[]
+  compact?: boolean
+}
+
+export function ActiveVenuesList({ venues, compact = false }: ActiveVenuesListProps) {
+  if (venues.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground py-4 text-center">
+        No active venues right now.
+      </p>
+    )
+  }
+
+  return (
+    <ol className="space-y-1">
+      {venues.map((venue, index) => (
+        <li key={venue.venue_id}>
+          <Link
+            href={`/venues/${venue.slug}`}
+            className="group flex items-center gap-3 rounded-lg px-3 py-2.5 transition-colors hover:bg-muted/50"
+          >
+            <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-semibold text-muted-foreground">
+              {index + 1}
+            </span>
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-medium group-hover:text-primary truncate">
+                {venue.name}
+              </p>
+              {!compact && (
+                <div className="mt-0.5 flex items-center gap-1 text-xs text-muted-foreground">
+                  <MapPin className="h-3 w-3" />
+                  {venue.city}{venue.state ? `, ${venue.state}` : ''}
+                </div>
+              )}
+            </div>
+            {!compact && (
+              <div className="flex shrink-0 items-center gap-3 text-xs text-muted-foreground">
+                <span className="flex items-center gap-1" title="Upcoming shows">
+                  <Calendar className="h-3 w-3" />
+                  {venue.upcoming_show_count}
+                </span>
+                <span className="flex items-center gap-1" title="Followers">
+                  <UserCheck className="h-3 w-3" />
+                  {venue.follow_count}
+                </span>
+              </div>
+            )}
+          </Link>
+        </li>
+      ))}
+    </ol>
+  )
+}

--- a/frontend/features/charts/components/ChartsPage.test.tsx
+++ b/frontend/features/charts/components/ChartsPage.test.tsx
@@ -1,0 +1,323 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders } from '@/test/utils'
+
+const mockApiRequest = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    CHARTS: {
+      OVERVIEW: '/charts/overview',
+      TRENDING_SHOWS: '/charts/trending-shows',
+      POPULAR_ARTISTS: '/charts/popular-artists',
+      ACTIVE_VENUES: '/charts/active-venues',
+      HOT_RELEASES: '/charts/hot-releases',
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    charts: {
+      all: ['charts'],
+      overview: ['charts', 'overview'],
+      trendingShows: (limit?: number) => ['charts', 'trending-shows', limit],
+      popularArtists: (limit?: number) => ['charts', 'popular-artists', limit],
+      activeVenues: (limit?: number) => ['charts', 'active-venues', limit],
+      hotReleases: (limit?: number) => ['charts', 'hot-releases', limit],
+    },
+  },
+}))
+
+import { ChartsPage } from './ChartsPage'
+
+const mockOverviewData = {
+  trending_shows: [
+    {
+      show_id: 1,
+      title: 'Night of Echoes',
+      slug: 'night-of-echoes',
+      date: '2026-04-15T20:00:00Z',
+      venue_name: 'Valley Bar',
+      venue_slug: 'valley-bar',
+      city: 'Phoenix',
+      going_count: 42,
+      interested_count: 88,
+      total_attendance: 130,
+    },
+  ],
+  popular_artists: [
+    {
+      artist_id: 1,
+      name: 'Moonlight Parade',
+      slug: 'moonlight-parade',
+      image_url: '',
+      follow_count: 120,
+      upcoming_show_count: 5,
+      score: 125,
+    },
+  ],
+  active_venues: [
+    {
+      venue_id: 1,
+      name: 'The Rebel Lounge',
+      slug: 'the-rebel-lounge',
+      city: 'Phoenix',
+      state: 'AZ',
+      upcoming_show_count: 18,
+      follow_count: 65,
+      score: 83,
+    },
+  ],
+  hot_releases: [
+    {
+      release_id: 1,
+      title: 'Eternal Drift',
+      slug: 'eternal-drift',
+      release_date: '2026-03-01',
+      artist_names: ['Moonlight Parade'],
+      bookmark_count: 34,
+    },
+  ],
+}
+
+describe('ChartsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('renders overview by default with all chart sections', async () => {
+    mockApiRequest.mockResolvedValueOnce(mockOverviewData)
+
+    renderWithProviders(<ChartsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Night of Echoes')).toBeInTheDocument()
+    })
+
+    // Section headings appear in both tabs and card headers — use getAllByText
+    expect(screen.getAllByText('Trending Shows').length).toBeGreaterThanOrEqual(2)
+    expect(screen.getAllByText('Popular Artists').length).toBeGreaterThanOrEqual(2)
+    expect(screen.getAllByText('Active Venues').length).toBeGreaterThanOrEqual(2)
+    expect(screen.getAllByText('Hot Releases').length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('renders entity names as links', async () => {
+    mockApiRequest.mockResolvedValueOnce(mockOverviewData)
+
+    renderWithProviders(<ChartsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Night of Echoes')).toBeInTheDocument()
+    })
+
+    const links = screen.getAllByRole('link')
+
+    // Show title links to show detail
+    const showLink = links.find(l => l.textContent?.includes('Night of Echoes'))
+    expect(showLink).toHaveAttribute('href', '/shows/night-of-echoes')
+
+    // Artist name links to artist detail
+    const artistLink = links.find(l => l.textContent?.includes('Moonlight Parade'))
+    expect(artistLink).toHaveAttribute('href', '/artists/moonlight-parade')
+
+    // Venue name links to venue detail
+    const venueLink = links.find(l => l.textContent?.includes('The Rebel Lounge'))
+    expect(venueLink).toHaveAttribute('href', '/venues/the-rebel-lounge')
+
+    // Release title links to release detail
+    const releaseLink = links.find(l => l.textContent?.includes('Eternal Drift'))
+    expect(releaseLink).toHaveAttribute('href', '/releases/eternal-drift')
+  })
+
+  it('shows error message when API fails', async () => {
+    mockApiRequest.mockRejectedValueOnce(new Error('Server error'))
+
+    renderWithProviders(<ChartsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to load charts. Please try again later.')).toBeInTheDocument()
+    })
+  })
+
+  it('switches to trending shows detail view', async () => {
+    mockApiRequest.mockResolvedValueOnce(mockOverviewData)
+
+    const user = userEvent.setup()
+    renderWithProviders(<ChartsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Night of Echoes')).toBeInTheDocument()
+    })
+
+    // Get tab buttons (first match in the tab bar, not the card header)
+    const trendingButtons = screen.getAllByRole('button', { name: /Trending Shows/i })
+    const tabButton = trendingButtons[0]
+
+    mockApiRequest.mockResolvedValueOnce({
+      shows: [
+        mockOverviewData.trending_shows[0],
+        {
+          show_id: 2,
+          title: 'Desert Bloom Fest',
+          slug: 'desert-bloom-fest',
+          date: '2026-05-01T19:00:00Z',
+          venue_name: 'Crescent Ballroom',
+          venue_slug: 'crescent-ballroom',
+          city: 'Phoenix',
+          going_count: 30,
+          interested_count: 60,
+          total_attendance: 90,
+        },
+      ],
+    })
+
+    await user.click(tabButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('Shows with the most going and interested activity.')).toBeInTheDocument()
+    })
+  })
+
+  it('switches to popular artists detail view', async () => {
+    mockApiRequest.mockResolvedValueOnce(mockOverviewData)
+
+    const user = userEvent.setup()
+    renderWithProviders(<ChartsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Moonlight Parade')).toBeInTheDocument()
+    })
+
+    const artistsTab = screen.getAllByRole('button', { name: /Popular Artists/i })[0]
+
+    mockApiRequest.mockResolvedValueOnce({
+      artists: [mockOverviewData.popular_artists[0]],
+    })
+
+    await user.click(artistsTab)
+
+    await waitFor(() => {
+      expect(screen.getByText('Artists with the most followers and upcoming shows.')).toBeInTheDocument()
+    })
+  })
+
+  it('switches to active venues detail view', async () => {
+    mockApiRequest.mockResolvedValueOnce(mockOverviewData)
+
+    const user = userEvent.setup()
+    renderWithProviders(<ChartsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('The Rebel Lounge')).toBeInTheDocument()
+    })
+
+    const venuesTab = screen.getAllByRole('button', { name: /Active Venues/i })[0]
+
+    mockApiRequest.mockResolvedValueOnce({
+      venues: [mockOverviewData.active_venues[0]],
+    })
+
+    await user.click(venuesTab)
+
+    await waitFor(() => {
+      expect(screen.getByText('Venues with the most upcoming shows and followers.')).toBeInTheDocument()
+    })
+  })
+
+  it('switches to hot releases detail view', async () => {
+    mockApiRequest.mockResolvedValueOnce(mockOverviewData)
+
+    const user = userEvent.setup()
+    renderWithProviders(<ChartsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Eternal Drift')).toBeInTheDocument()
+    })
+
+    const releasesTab = screen.getAllByRole('button', { name: /Hot Releases/i })[0]
+
+    mockApiRequest.mockResolvedValueOnce({
+      releases: [mockOverviewData.hot_releases[0]],
+    })
+
+    await user.click(releasesTab)
+
+    await waitFor(() => {
+      expect(screen.getByText('Most bookmarked releases right now.')).toBeInTheDocument()
+    })
+  })
+
+  it('returns to overview via Overview tab', async () => {
+    // First call: overview data
+    mockApiRequest.mockResolvedValueOnce(mockOverviewData)
+
+    const user = userEvent.setup()
+    renderWithProviders(<ChartsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Night of Echoes')).toBeInTheDocument()
+    })
+
+    // Second call: trending shows detail data
+    mockApiRequest.mockResolvedValueOnce({
+      shows: [mockOverviewData.trending_shows[0]],
+    })
+
+    // Switch to trending shows detail
+    const trendingTab = screen.getAllByRole('button', { name: /Trending Shows/i })[0]
+    await user.click(trendingTab)
+
+    await waitFor(() => {
+      expect(screen.getByText('Shows with the most going and interested activity.')).toBeInTheDocument()
+    })
+
+    // Third call: overview data again when switching back
+    mockApiRequest.mockResolvedValueOnce(mockOverviewData)
+
+    // Switch back to overview
+    const overviewTab = screen.getByRole('button', { name: /Overview/i })
+    await user.click(overviewTab)
+
+    // Should show overview grid with "View all" buttons
+    await waitFor(() => {
+      expect(screen.getAllByText('View all')).toHaveLength(4)
+    })
+  })
+
+  it('renders empty state messages when no data', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      trending_shows: [],
+      popular_artists: [],
+      active_venues: [],
+      hot_releases: [],
+    })
+
+    renderWithProviders(<ChartsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('No trending shows right now.')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('No popular artists right now.')).toBeInTheDocument()
+    expect(screen.getByText('No active venues right now.')).toBeInTheDocument()
+    expect(screen.getByText('No hot releases right now.')).toBeInTheDocument()
+  })
+
+  it('renders all tab buttons', () => {
+    mockApiRequest.mockResolvedValueOnce(mockOverviewData)
+
+    renderWithProviders(<ChartsPage />)
+
+    expect(screen.getByRole('button', { name: /Overview/i })).toBeInTheDocument()
+    // Tab buttons exist (may also appear as card headings)
+    expect(screen.getAllByRole('button', { name: /Trending Shows/i }).length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByRole('button', { name: /Popular Artists/i }).length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByRole('button', { name: /Active Venues/i }).length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByRole('button', { name: /Hot Releases/i }).length).toBeGreaterThanOrEqual(1)
+  })
+})

--- a/frontend/features/charts/components/ChartsPage.tsx
+++ b/frontend/features/charts/components/ChartsPage.tsx
@@ -1,0 +1,242 @@
+'use client'
+
+import { useState } from 'react'
+import { Flame, Mic2, MapPin, Disc3, ArrowRight, Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  useChartsOverview,
+  useTrendingShows,
+  usePopularArtists,
+  useActiveVenues,
+  useHotReleases,
+} from '../hooks'
+import { TrendingShowsList } from './TrendingShowsList'
+import { PopularArtistsList } from './PopularArtistsList'
+import { ActiveVenuesList } from './ActiveVenuesList'
+import { HotReleasesList } from './HotReleasesList'
+import type { ChartView } from '../types'
+
+const views: { id: ChartView; label: string; icon: typeof Flame }[] = [
+  { id: 'overview', label: 'Overview', icon: Flame },
+  { id: 'trending-shows', label: 'Trending Shows', icon: Flame },
+  { id: 'popular-artists', label: 'Popular Artists', icon: Mic2 },
+  { id: 'active-venues', label: 'Active Venues', icon: MapPin },
+  { id: 'hot-releases', label: 'Hot Releases', icon: Disc3 },
+]
+
+export function ChartsPage() {
+  const [activeView, setActiveView] = useState<ChartView>('overview')
+
+  return (
+    <div className="space-y-6">
+      {/* View selector tabs */}
+      <div className="flex flex-wrap gap-1.5 rounded-lg bg-muted/50 p-1">
+        {views.map(view => {
+          const Icon = view.icon
+          const isActive = activeView === view.id
+          return (
+            <Button
+              key={view.id}
+              variant={isActive ? 'secondary' : 'ghost'}
+              size="sm"
+              onClick={() => setActiveView(view.id)}
+              className="gap-1.5 text-xs"
+            >
+              <Icon className="h-3.5 w-3.5" />
+              {view.label}
+            </Button>
+          )
+        })}
+      </div>
+
+      {/* Content */}
+      {activeView === 'overview' ? (
+        <OverviewGrid onViewAll={setActiveView} />
+      ) : activeView === 'trending-shows' ? (
+        <DetailView title="Trending Shows" description="Shows with the most going and interested activity.">
+          <TrendingShowsDetail />
+        </DetailView>
+      ) : activeView === 'popular-artists' ? (
+        <DetailView title="Popular Artists" description="Artists with the most followers and upcoming shows.">
+          <PopularArtistsDetail />
+        </DetailView>
+      ) : activeView === 'active-venues' ? (
+        <DetailView title="Active Venues" description="Venues with the most upcoming shows and followers.">
+          <ActiveVenuesDetail />
+        </DetailView>
+      ) : (
+        <DetailView title="Hot Releases" description="Most bookmarked releases right now.">
+          <HotReleasesDetail />
+        </DetailView>
+      )}
+    </div>
+  )
+}
+
+// --- Overview Grid ---
+
+function OverviewGrid({ onViewAll }: { onViewAll: (view: ChartView) => void }) {
+  const { data, isLoading, error } = useChartsOverview()
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <p className="text-sm text-destructive py-4 text-center">
+        Failed to load charts. Please try again later.
+      </p>
+    )
+  }
+
+  if (!data) return null
+
+  return (
+    <div className="grid gap-6 md:grid-cols-2">
+      <ChartCard
+        title="Trending Shows"
+        icon={Flame}
+        onViewAll={() => onViewAll('trending-shows')}
+      >
+        <TrendingShowsList shows={data.trending_shows} compact />
+      </ChartCard>
+      <ChartCard
+        title="Popular Artists"
+        icon={Mic2}
+        onViewAll={() => onViewAll('popular-artists')}
+      >
+        <PopularArtistsList artists={data.popular_artists} compact />
+      </ChartCard>
+      <ChartCard
+        title="Active Venues"
+        icon={MapPin}
+        onViewAll={() => onViewAll('active-venues')}
+      >
+        <ActiveVenuesList venues={data.active_venues} compact />
+      </ChartCard>
+      <ChartCard
+        title="Hot Releases"
+        icon={Disc3}
+        onViewAll={() => onViewAll('hot-releases')}
+      >
+        <HotReleasesList releases={data.hot_releases} compact />
+      </ChartCard>
+    </div>
+  )
+}
+
+// --- Chart Card ---
+
+function ChartCard({
+  title,
+  icon: Icon,
+  onViewAll,
+  children,
+}: {
+  title: string
+  icon: typeof Flame
+  onViewAll: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <div className="rounded-xl border border-border/50 bg-card">
+      <div className="flex items-center justify-between border-b border-border/30 px-4 py-3">
+        <div className="flex items-center gap-2">
+          <Icon className="h-4 w-4 text-muted-foreground" />
+          <h2 className="text-sm font-semibold">{title}</h2>
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onViewAll}
+          className="gap-1 text-xs text-muted-foreground hover:text-foreground"
+        >
+          View all
+          <ArrowRight className="h-3 w-3" />
+        </Button>
+      </div>
+      <div className="p-2">
+        {children}
+      </div>
+    </div>
+  )
+}
+
+// --- Detail View Wrapper ---
+
+function DetailView({
+  title,
+  description,
+  children,
+}: {
+  title: string
+  description: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="rounded-xl border border-border/50 bg-card">
+      <div className="border-b border-border/30 px-4 py-3">
+        <h2 className="text-lg font-semibold">{title}</h2>
+        <p className="text-xs text-muted-foreground">{description}</p>
+      </div>
+      <div className="p-2">
+        {children}
+      </div>
+    </div>
+  )
+}
+
+// --- Detail Loaders ---
+
+function TrendingShowsDetail() {
+  const { data, isLoading, error } = useTrendingShows()
+  if (isLoading) return <DetailLoading />
+  if (error) return <DetailError />
+  if (!data) return null
+  return <TrendingShowsList shows={data.shows} />
+}
+
+function PopularArtistsDetail() {
+  const { data, isLoading, error } = usePopularArtists()
+  if (isLoading) return <DetailLoading />
+  if (error) return <DetailError />
+  if (!data) return null
+  return <PopularArtistsList artists={data.artists} />
+}
+
+function ActiveVenuesDetail() {
+  const { data, isLoading, error } = useActiveVenues()
+  if (isLoading) return <DetailLoading />
+  if (error) return <DetailError />
+  if (!data) return null
+  return <ActiveVenuesList venues={data.venues} />
+}
+
+function HotReleasesDetail() {
+  const { data, isLoading, error } = useHotReleases()
+  if (isLoading) return <DetailLoading />
+  if (error) return <DetailError />
+  if (!data) return null
+  return <HotReleasesList releases={data.releases} />
+}
+
+function DetailLoading() {
+  return (
+    <div className="flex items-center justify-center py-8">
+      <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+    </div>
+  )
+}
+
+function DetailError() {
+  return (
+    <p className="text-sm text-destructive py-4 text-center">
+      Failed to load chart data. Please try again later.
+    </p>
+  )
+}

--- a/frontend/features/charts/components/HotReleasesList.tsx
+++ b/frontend/features/charts/components/HotReleasesList.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import Link from 'next/link'
+import { Bookmark, Calendar } from 'lucide-react'
+import type { HotRelease } from '../types'
+
+interface HotReleasesListProps {
+  releases: HotRelease[]
+  compact?: boolean
+}
+
+export function HotReleasesList({ releases, compact = false }: HotReleasesListProps) {
+  if (releases.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground py-4 text-center">
+        No hot releases right now.
+      </p>
+    )
+  }
+
+  return (
+    <ol className="space-y-1">
+      {releases.map((release, index) => (
+        <li key={release.release_id}>
+          <Link
+            href={`/releases/${release.slug}`}
+            className="group flex items-center gap-3 rounded-lg px-3 py-2.5 transition-colors hover:bg-muted/50"
+          >
+            <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-semibold text-muted-foreground">
+              {index + 1}
+            </span>
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-medium group-hover:text-primary truncate">
+                {release.title}
+              </p>
+              {!compact && (
+                <div className="mt-0.5 flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs text-muted-foreground">
+                  {release.artist_names && release.artist_names.length > 0 && (
+                    <span className="truncate">
+                      {release.artist_names.join(', ')}
+                    </span>
+                  )}
+                  {release.release_date && (
+                    <span className="flex items-center gap-1">
+                      <Calendar className="h-3 w-3" />
+                      {new Date(release.release_date).toLocaleDateString('en-US', {
+                        month: 'short',
+                        day: 'numeric',
+                        year: 'numeric',
+                      })}
+                    </span>
+                  )}
+                </div>
+              )}
+            </div>
+            <div className="flex shrink-0 items-center gap-1 text-xs text-muted-foreground">
+              <Bookmark className="h-3 w-3" />
+              {release.bookmark_count}
+            </div>
+          </Link>
+        </li>
+      ))}
+    </ol>
+  )
+}

--- a/frontend/features/charts/components/PopularArtistsList.tsx
+++ b/frontend/features/charts/components/PopularArtistsList.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import Link from 'next/link'
+import { UserCheck, Calendar } from 'lucide-react'
+import type { PopularArtist } from '../types'
+
+interface PopularArtistsListProps {
+  artists: PopularArtist[]
+  compact?: boolean
+}
+
+export function PopularArtistsList({ artists, compact = false }: PopularArtistsListProps) {
+  if (artists.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground py-4 text-center">
+        No popular artists right now.
+      </p>
+    )
+  }
+
+  return (
+    <ol className="space-y-1">
+      {artists.map((artist, index) => (
+        <li key={artist.artist_id}>
+          <Link
+            href={`/artists/${artist.slug}`}
+            className="group flex items-center gap-3 rounded-lg px-3 py-2.5 transition-colors hover:bg-muted/50"
+          >
+            <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-semibold text-muted-foreground">
+              {index + 1}
+            </span>
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-medium group-hover:text-primary truncate">
+                {artist.name}
+              </p>
+            </div>
+            {!compact && (
+              <div className="flex shrink-0 items-center gap-3 text-xs text-muted-foreground">
+                <span className="flex items-center gap-1" title="Followers">
+                  <UserCheck className="h-3 w-3" />
+                  {artist.follow_count}
+                </span>
+                <span className="flex items-center gap-1" title="Upcoming shows">
+                  <Calendar className="h-3 w-3" />
+                  {artist.upcoming_show_count}
+                </span>
+              </div>
+            )}
+          </Link>
+        </li>
+      ))}
+    </ol>
+  )
+}

--- a/frontend/features/charts/components/TrendingShowsList.tsx
+++ b/frontend/features/charts/components/TrendingShowsList.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import Link from 'next/link'
+import { Calendar, MapPin, Users, Eye } from 'lucide-react'
+import type { TrendingShow } from '../types'
+
+interface TrendingShowsListProps {
+  shows: TrendingShow[]
+  compact?: boolean
+}
+
+export function TrendingShowsList({ shows, compact = false }: TrendingShowsListProps) {
+  if (shows.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground py-4 text-center">
+        No trending shows right now.
+      </p>
+    )
+  }
+
+  return (
+    <ol className="space-y-1">
+      {shows.map((show, index) => (
+        <li key={show.show_id}>
+          <Link
+            href={`/shows/${show.slug}`}
+            className="group flex items-start gap-3 rounded-lg px-3 py-2.5 transition-colors hover:bg-muted/50"
+          >
+            <span className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-semibold text-muted-foreground">
+              {index + 1}
+            </span>
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-medium leading-tight group-hover:text-primary truncate">
+                {show.title}
+              </p>
+              {!compact && (
+                <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs text-muted-foreground">
+                  <span className="flex items-center gap-1">
+                    <Calendar className="h-3 w-3" />
+                    {new Date(show.date).toLocaleDateString('en-US', {
+                      month: 'short',
+                      day: 'numeric',
+                    })}
+                  </span>
+                  <span className="flex items-center gap-1">
+                    <MapPin className="h-3 w-3" />
+                    <span className="truncate">{show.venue_name}</span>
+                  </span>
+                  {show.city && (
+                    <span className="text-muted-foreground/70">{show.city}</span>
+                  )}
+                </div>
+              )}
+            </div>
+            <div className="flex shrink-0 items-center gap-3 text-xs text-muted-foreground">
+              <span className="flex items-center gap-1" title="Going">
+                <Users className="h-3 w-3" />
+                {show.going_count}
+              </span>
+              <span className="flex items-center gap-1" title="Interested">
+                <Eye className="h-3 w-3" />
+                {show.interested_count}
+              </span>
+            </div>
+          </Link>
+        </li>
+      ))}
+    </ol>
+  )
+}

--- a/frontend/features/charts/components/index.ts
+++ b/frontend/features/charts/components/index.ts
@@ -1,0 +1,5 @@
+export { ChartsPage } from './ChartsPage'
+export { TrendingShowsList } from './TrendingShowsList'
+export { PopularArtistsList } from './PopularArtistsList'
+export { ActiveVenuesList } from './ActiveVenuesList'
+export { HotReleasesList } from './HotReleasesList'

--- a/frontend/features/charts/hooks/index.ts
+++ b/frontend/features/charts/hooks/index.ts
@@ -1,0 +1,7 @@
+export {
+  useChartsOverview,
+  useTrendingShows,
+  usePopularArtists,
+  useActiveVenues,
+  useHotReleases,
+} from './useCharts'

--- a/frontend/features/charts/hooks/useCharts.test.tsx
+++ b/frontend/features/charts/hooks/useCharts.test.tsx
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { createWrapper } from '@/test/utils'
+
+const mockApiRequest = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    CHARTS: {
+      OVERVIEW: '/charts/overview',
+      TRENDING_SHOWS: '/charts/trending-shows',
+      POPULAR_ARTISTS: '/charts/popular-artists',
+      ACTIVE_VENUES: '/charts/active-venues',
+      HOT_RELEASES: '/charts/hot-releases',
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    charts: {
+      all: ['charts'],
+      overview: ['charts', 'overview'],
+      trendingShows: (limit?: number) => ['charts', 'trending-shows', limit],
+      popularArtists: (limit?: number) => ['charts', 'popular-artists', limit],
+      activeVenues: (limit?: number) => ['charts', 'active-venues', limit],
+      hotReleases: (limit?: number) => ['charts', 'hot-releases', limit],
+    },
+  },
+}))
+
+import {
+  useChartsOverview,
+  useTrendingShows,
+  usePopularArtists,
+  useActiveVenues,
+  useHotReleases,
+} from './useCharts'
+
+describe('useCharts hooks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  describe('useChartsOverview', () => {
+    it('fetches charts overview data', async () => {
+      const mockData = {
+        trending_shows: [
+          { show_id: 1, title: 'Show A', slug: 'show-a', date: '2026-04-01T20:00:00Z', venue_name: 'Venue A', venue_slug: 'venue-a', city: 'Phoenix', going_count: 10, interested_count: 25, total_attendance: 35 },
+        ],
+        popular_artists: [
+          { artist_id: 1, name: 'Artist A', slug: 'artist-a', image_url: '', follow_count: 50, upcoming_show_count: 3, score: 53 },
+        ],
+        active_venues: [
+          { venue_id: 1, name: 'Venue A', slug: 'venue-a', city: 'Phoenix', state: 'AZ', upcoming_show_count: 12, follow_count: 30, score: 42 },
+        ],
+        hot_releases: [
+          { release_id: 1, title: 'Album A', slug: 'album-a', release_date: '2026-03-01', artist_names: ['Artist A'], bookmark_count: 15 },
+        ],
+      }
+      mockApiRequest.mockResolvedValueOnce(mockData)
+
+      const { result } = renderHook(() => useChartsOverview(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/charts/overview', { method: 'GET' })
+      expect(result.current.data?.trending_shows).toHaveLength(1)
+      expect(result.current.data?.popular_artists).toHaveLength(1)
+      expect(result.current.data?.active_venues).toHaveLength(1)
+      expect(result.current.data?.hot_releases).toHaveLength(1)
+    })
+
+    it('handles API errors gracefully', async () => {
+      mockApiRequest.mockRejectedValueOnce(new Error('Network error'))
+
+      const { result } = renderHook(() => useChartsOverview(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+      expect(result.current.error?.message).toBe('Network error')
+    })
+  })
+
+  describe('useTrendingShows', () => {
+    it('fetches trending shows without limit', async () => {
+      const mockData = {
+        shows: [
+          { show_id: 1, title: 'Show A', slug: 'show-a', date: '2026-04-01T20:00:00Z', venue_name: 'Venue A', venue_slug: 'venue-a', city: 'Phoenix', going_count: 10, interested_count: 25, total_attendance: 35 },
+        ],
+      }
+      mockApiRequest.mockResolvedValueOnce(mockData)
+
+      const { result } = renderHook(() => useTrendingShows(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/charts/trending-shows', { method: 'GET' })
+      expect(result.current.data?.shows).toHaveLength(1)
+    })
+
+    it('fetches trending shows with limit', async () => {
+      const mockData = { shows: [] }
+      mockApiRequest.mockResolvedValueOnce(mockData)
+
+      const { result } = renderHook(() => useTrendingShows(10), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/charts/trending-shows?limit=10', { method: 'GET' })
+    })
+  })
+
+  describe('usePopularArtists', () => {
+    it('fetches popular artists', async () => {
+      const mockData = {
+        artists: [
+          { artist_id: 1, name: 'Artist A', slug: 'artist-a', image_url: '', follow_count: 50, upcoming_show_count: 3, score: 53 },
+        ],
+      }
+      mockApiRequest.mockResolvedValueOnce(mockData)
+
+      const { result } = renderHook(() => usePopularArtists(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/charts/popular-artists', { method: 'GET' })
+      expect(result.current.data?.artists).toHaveLength(1)
+      expect(result.current.data?.artists[0].name).toBe('Artist A')
+    })
+
+    it('passes limit param', async () => {
+      mockApiRequest.mockResolvedValueOnce({ artists: [] })
+
+      const { result } = renderHook(() => usePopularArtists(5), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      expect(mockApiRequest).toHaveBeenCalledWith('/charts/popular-artists?limit=5', { method: 'GET' })
+    })
+  })
+
+  describe('useActiveVenues', () => {
+    it('fetches active venues', async () => {
+      const mockData = {
+        venues: [
+          { venue_id: 1, name: 'Venue A', slug: 'venue-a', city: 'Phoenix', state: 'AZ', upcoming_show_count: 12, follow_count: 30, score: 42 },
+        ],
+      }
+      mockApiRequest.mockResolvedValueOnce(mockData)
+
+      const { result } = renderHook(() => useActiveVenues(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/charts/active-venues', { method: 'GET' })
+      expect(result.current.data?.venues).toHaveLength(1)
+      expect(result.current.data?.venues[0].name).toBe('Venue A')
+    })
+
+    it('passes limit param', async () => {
+      mockApiRequest.mockResolvedValueOnce({ venues: [] })
+
+      const { result } = renderHook(() => useActiveVenues(15), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      expect(mockApiRequest).toHaveBeenCalledWith('/charts/active-venues?limit=15', { method: 'GET' })
+    })
+  })
+
+  describe('useHotReleases', () => {
+    it('fetches hot releases', async () => {
+      const mockData = {
+        releases: [
+          { release_id: 1, title: 'Album A', slug: 'album-a', release_date: '2026-03-01', artist_names: ['Artist A'], bookmark_count: 15 },
+        ],
+      }
+      mockApiRequest.mockResolvedValueOnce(mockData)
+
+      const { result } = renderHook(() => useHotReleases(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/charts/hot-releases', { method: 'GET' })
+      expect(result.current.data?.releases).toHaveLength(1)
+      expect(result.current.data?.releases[0].title).toBe('Album A')
+    })
+
+    it('passes limit param', async () => {
+      mockApiRequest.mockResolvedValueOnce({ releases: [] })
+
+      const { result } = renderHook(() => useHotReleases(25), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      expect(mockApiRequest).toHaveBeenCalledWith('/charts/hot-releases?limit=25', { method: 'GET' })
+    })
+  })
+})

--- a/frontend/features/charts/hooks/useCharts.ts
+++ b/frontend/features/charts/hooks/useCharts.ts
@@ -1,0 +1,101 @@
+'use client'
+
+/**
+ * Charts Hooks
+ *
+ * TanStack Query hooks for fetching top charts data from the public API.
+ */
+
+import { useQuery } from '@tanstack/react-query'
+import { apiRequest, API_ENDPOINTS } from '@/lib/api'
+import { queryKeys } from '@/lib/queryClient'
+import type {
+  ChartsOverviewResponse,
+  TrendingShowsResponse,
+  PopularArtistsResponse,
+  ActiveVenuesResponse,
+  HotReleasesResponse,
+} from '../types'
+
+/**
+ * Hook to fetch the charts overview (top 5 of each category)
+ */
+export function useChartsOverview() {
+  return useQuery({
+    queryKey: queryKeys.charts.overview,
+    queryFn: async (): Promise<ChartsOverviewResponse> => {
+      return apiRequest<ChartsOverviewResponse>(API_ENDPOINTS.CHARTS.OVERVIEW, {
+        method: 'GET',
+      })
+    },
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  })
+}
+
+/**
+ * Hook to fetch trending shows chart
+ */
+export function useTrendingShows(limit?: number) {
+  const params = limit ? `?limit=${limit}` : ''
+  return useQuery({
+    queryKey: queryKeys.charts.trendingShows(limit),
+    queryFn: async (): Promise<TrendingShowsResponse> => {
+      return apiRequest<TrendingShowsResponse>(
+        `${API_ENDPOINTS.CHARTS.TRENDING_SHOWS}${params}`,
+        { method: 'GET' }
+      )
+    },
+    staleTime: 5 * 60 * 1000,
+  })
+}
+
+/**
+ * Hook to fetch popular artists chart
+ */
+export function usePopularArtists(limit?: number) {
+  const params = limit ? `?limit=${limit}` : ''
+  return useQuery({
+    queryKey: queryKeys.charts.popularArtists(limit),
+    queryFn: async (): Promise<PopularArtistsResponse> => {
+      return apiRequest<PopularArtistsResponse>(
+        `${API_ENDPOINTS.CHARTS.POPULAR_ARTISTS}${params}`,
+        { method: 'GET' }
+      )
+    },
+    staleTime: 5 * 60 * 1000,
+  })
+}
+
+/**
+ * Hook to fetch active venues chart
+ */
+export function useActiveVenues(limit?: number) {
+  const params = limit ? `?limit=${limit}` : ''
+  return useQuery({
+    queryKey: queryKeys.charts.activeVenues(limit),
+    queryFn: async (): Promise<ActiveVenuesResponse> => {
+      return apiRequest<ActiveVenuesResponse>(
+        `${API_ENDPOINTS.CHARTS.ACTIVE_VENUES}${params}`,
+        { method: 'GET' }
+      )
+    },
+    staleTime: 5 * 60 * 1000,
+  })
+}
+
+/**
+ * Hook to fetch hot releases chart
+ */
+export function useHotReleases(limit?: number) {
+  const params = limit ? `?limit=${limit}` : ''
+  return useQuery({
+    queryKey: queryKeys.charts.hotReleases(limit),
+    queryFn: async (): Promise<HotReleasesResponse> => {
+      return apiRequest<HotReleasesResponse>(
+        `${API_ENDPOINTS.CHARTS.HOT_RELEASES}${params}`,
+        { method: 'GET' }
+      )
+    },
+    staleTime: 5 * 60 * 1000,
+  })
+}

--- a/frontend/features/charts/index.ts
+++ b/frontend/features/charts/index.ts
@@ -1,0 +1,34 @@
+// Public API for the charts feature module.
+// Other features should import from '@/features/charts', not from internal paths.
+
+// Types
+export type {
+  TrendingShow,
+  PopularArtist,
+  ActiveVenue,
+  HotRelease,
+  ChartsOverviewResponse,
+  TrendingShowsResponse,
+  PopularArtistsResponse,
+  ActiveVenuesResponse,
+  HotReleasesResponse,
+  ChartView,
+} from './types'
+
+// Hooks
+export {
+  useChartsOverview,
+  useTrendingShows,
+  usePopularArtists,
+  useActiveVenues,
+  useHotReleases,
+} from './hooks'
+
+// Components
+export {
+  ChartsPage,
+  TrendingShowsList,
+  PopularArtistsList,
+  ActiveVenuesList,
+  HotReleasesList,
+} from './components'

--- a/frontend/features/charts/types.ts
+++ b/frontend/features/charts/types.ts
@@ -1,0 +1,74 @@
+/**
+ * Charts-related TypeScript types
+ *
+ * These types match the backend API response structures
+ * from backend/internal/api/handlers/charts.go
+ */
+
+export interface TrendingShow {
+  show_id: number
+  title: string
+  slug: string
+  date: string
+  venue_name: string
+  venue_slug: string
+  city: string
+  going_count: number
+  interested_count: number
+  total_attendance: number
+}
+
+export interface PopularArtist {
+  artist_id: number
+  name: string
+  slug: string
+  image_url: string
+  follow_count: number
+  upcoming_show_count: number
+  score: number
+}
+
+export interface ActiveVenue {
+  venue_id: number
+  name: string
+  slug: string
+  city: string
+  state: string
+  upcoming_show_count: number
+  follow_count: number
+  score: number
+}
+
+export interface HotRelease {
+  release_id: number
+  title: string
+  slug: string
+  release_date: string | null
+  artist_names: string[]
+  bookmark_count: number
+}
+
+export interface TrendingShowsResponse {
+  shows: TrendingShow[]
+}
+
+export interface PopularArtistsResponse {
+  artists: PopularArtist[]
+}
+
+export interface ActiveVenuesResponse {
+  venues: ActiveVenue[]
+}
+
+export interface HotReleasesResponse {
+  releases: HotRelease[]
+}
+
+export interface ChartsOverviewResponse {
+  trending_shows: TrendingShow[]
+  popular_artists: PopularArtist[]
+  active_venues: ActiveVenue[]
+  hot_releases: HotRelease[]
+}
+
+export type ChartView = 'overview' | 'trending-shows' | 'popular-artists' | 'active-venues' | 'hot-releases'

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -407,6 +407,15 @@ export const API_ENDPOINTS = {
     ARTISTS: (slug: string) => `${API_BASE_URL}/scenes/${slug}/artists`,
   },
 
+  // Charts endpoints (public)
+  CHARTS: {
+    OVERVIEW: `${API_BASE_URL}/charts/overview`,
+    TRENDING_SHOWS: `${API_BASE_URL}/charts/trending-shows`,
+    POPULAR_ARTISTS: `${API_BASE_URL}/charts/popular-artists`,
+    ACTIVE_VENUES: `${API_BASE_URL}/charts/active-venues`,
+    HOT_RELEASES: `${API_BASE_URL}/charts/hot-releases`,
+  },
+
   // System endpoints
   HEALTH: `${API_BASE_URL}/health`,
   OPENAPI: `${API_BASE_URL}/openapi.json`,

--- a/frontend/lib/queryClient.ts
+++ b/frontend/lib/queryClient.ts
@@ -332,6 +332,16 @@ export const queryKeys = {
     artists: (slug: string, period?: number) => ['scenes', 'artists', slug, period] as const,
   },
 
+  // Charts queries (public)
+  charts: {
+    all: ['charts'] as const,
+    overview: ['charts', 'overview'] as const,
+    trendingShows: (limit?: number) => ['charts', 'trending-shows', limit] as const,
+    popularArtists: (limit?: number) => ['charts', 'popular-artists', limit] as const,
+    activeVenues: (limit?: number) => ['charts', 'active-venues', limit] as const,
+    hotReleases: (limit?: number) => ['charts', 'hot-releases', limit] as const,
+  },
+
   // Revision history queries
   revisions: {
     all: ['revisions'] as const,


### PR DESCRIPTION
## Summary
- Public `/charts` page with overview dashboard (top 5 each) and 4 detail tab views
- `features/charts/` module: 5 hooks, 5 list components, types
- Consumes 5 existing public `/charts/*` endpoints
- Sidebar nav entry (Discover group) + Cmd+K command palette entry
- 20 tests passing (10 hook + 10 component)

Closes PSY-105

## Test plan
- [ ] Verify `/charts` page renders overview with top 5 per category
- [ ] Test tab switching between overview/trending/popular/active/hot views
- [ ] Verify entity links navigate to correct detail pages
- [ ] Run `bun run test:run` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)