### PR TITLE
Fix density toggle state sync — layouts now actually change

### DIFF
--- a/frontend/components/shared/DensityToggle.test.tsx
+++ b/frontend/components/shared/DensityToggle.test.tsx
@@ -3,46 +3,34 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { DensityToggle } from './DensityToggle'
 
-const mockSetDensity = vi.fn()
-const mockUseDensity = vi.fn(() => ({
-  density: 'comfortable' as const,
-  setDensity: mockSetDensity,
-}))
-
-vi.mock('@/lib/hooks/common/useDensity', () => ({
-  useDensity: (...args: unknown[]) => mockUseDensity(...args),
-}))
+const mockOnDensityChange = vi.fn()
 
 describe('DensityToggle', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockUseDensity.mockReturnValue({
-      density: 'comfortable',
-      setDensity: mockSetDensity,
-    })
   })
 
   it('renders all three density options', () => {
-    render(<DensityToggle />)
+    render(<DensityToggle density="comfortable" onDensityChange={mockOnDensityChange} />)
     expect(screen.getByText('Compact')).toBeInTheDocument()
     expect(screen.getByText('Comfortable')).toBeInTheDocument()
     expect(screen.getByText('Expanded')).toBeInTheDocument()
   })
 
   it('has radiogroup role with aria-label', () => {
-    render(<DensityToggle />)
+    render(<DensityToggle density="comfortable" onDensityChange={mockOnDensityChange} />)
     const group = screen.getByRole('radiogroup')
     expect(group).toHaveAttribute('aria-label', 'Display density')
   })
 
   it('renders three radio buttons', () => {
-    render(<DensityToggle />)
+    render(<DensityToggle density="comfortable" onDensityChange={mockOnDensityChange} />)
     const radios = screen.getAllByRole('radio')
     expect(radios).toHaveLength(3)
   })
 
   it('marks the current density as checked', () => {
-    render(<DensityToggle />)
+    render(<DensityToggle density="comfortable" onDensityChange={mockOnDensityChange} />)
     const comfortable = screen.getByRole('radio', { name: 'Comfortable' })
     const compact = screen.getByRole('radio', { name: 'Compact' })
     const expanded = screen.getByRole('radio', { name: 'Expanded' })
@@ -53,49 +41,35 @@ describe('DensityToggle', () => {
   })
 
   it('marks compact as checked when density is compact', () => {
-    mockUseDensity.mockReturnValue({
-      density: 'compact',
-      setDensity: mockSetDensity,
-    })
-    render(<DensityToggle />)
+    render(<DensityToggle density="compact" onDensityChange={mockOnDensityChange} />)
     expect(screen.getByRole('radio', { name: 'Compact' })).toHaveAttribute('aria-checked', 'true')
     expect(screen.getByRole('radio', { name: 'Comfortable' })).toHaveAttribute('aria-checked', 'false')
   })
 
-  it('calls setDensity with compact when Compact is clicked', async () => {
+  it('calls onDensityChange with compact when Compact is clicked', async () => {
     const user = userEvent.setup()
-    render(<DensityToggle />)
+    render(<DensityToggle density="comfortable" onDensityChange={mockOnDensityChange} />)
 
     await user.click(screen.getByText('Compact'))
-    expect(mockSetDensity).toHaveBeenCalledWith('compact')
+    expect(mockOnDensityChange).toHaveBeenCalledWith('compact')
   })
 
-  it('calls setDensity with expanded when Expanded is clicked', async () => {
+  it('calls onDensityChange with expanded when Expanded is clicked', async () => {
     const user = userEvent.setup()
-    render(<DensityToggle />)
+    render(<DensityToggle density="comfortable" onDensityChange={mockOnDensityChange} />)
 
     await user.click(screen.getByText('Expanded'))
-    expect(mockSetDensity).toHaveBeenCalledWith('expanded')
-  })
-
-  it('passes storageKey to useDensity', () => {
-    render(<DensityToggle storageKey="shows" />)
-    expect(mockUseDensity).toHaveBeenCalledWith('shows')
-  })
-
-  it('passes undefined storageKey to useDensity when not provided', () => {
-    render(<DensityToggle />)
-    expect(mockUseDensity).toHaveBeenCalledWith(undefined)
+    expect(mockOnDensityChange).toHaveBeenCalledWith('expanded')
   })
 
   it('applies custom className', () => {
-    render(<DensityToggle className="mt-4" />)
+    render(<DensityToggle density="comfortable" onDensityChange={mockOnDensityChange} className="mt-4" />)
     const group = screen.getByRole('radiogroup')
     expect(group.className).toContain('mt-4')
   })
 
   it('all buttons have type="button"', () => {
-    render(<DensityToggle />)
+    render(<DensityToggle density="comfortable" onDensityChange={mockOnDensityChange} />)
     const radios = screen.getAllByRole('radio')
     for (const radio of radios) {
       expect(radio).toHaveAttribute('type', 'button')

--- a/frontend/components/shared/DensityToggle.tsx
+++ b/frontend/components/shared/DensityToggle.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { cn } from '@/lib/utils'
-import { type Density, useDensity } from '@/lib/hooks/common/useDensity'
+import { type Density } from '@/lib/hooks/common/useDensity'
 
 const DENSITY_OPTIONS: { value: Density; label: string }[] = [
   { value: 'compact', label: 'Compact' },
@@ -10,21 +10,23 @@ const DENSITY_OPTIONS: { value: Density; label: string }[] = [
 ]
 
 export interface DensityToggleProps {
-  /** localStorage key suffix for the density preference (e.g., 'shows', 'artists') */
-  storageKey?: string
+  /** Current density value (from parent's useDensity hook) */
+  density: Density
+  /** Density setter (from parent's useDensity hook) */
+  onDensityChange: (value: Density) => void
   /** Additional CSS classes */
   className?: string
 }
 
 /**
  * A toggle control for switching between compact, comfortable, and expanded density modes.
- * Persists the preference in localStorage.
+ * The parent component owns the density state via useDensity() and passes it down.
  *
  * Usage:
- *   <DensityToggle storageKey="shows" />
+ *   const { density, setDensity } = useDensity('shows')
+ *   <DensityToggle density={density} onDensityChange={setDensity} />
  */
-export function DensityToggle({ storageKey, className }: DensityToggleProps) {
-  const { density, setDensity } = useDensity(storageKey)
+export function DensityToggle({ density, onDensityChange, className }: DensityToggleProps) {
 
   return (
     <div
@@ -38,7 +40,7 @@ export function DensityToggle({ storageKey, className }: DensityToggleProps) {
           type="button"
           role="radio"
           aria-checked={density === option.value}
-          onClick={() => setDensity(option.value)}
+          onClick={() => onDensityChange(option.value)}
           className={cn(
             'px-2.5 py-1 text-xs font-medium rounded-md transition-colors duration-100',
             density === option.value

--- a/frontend/features/artists/components/ArtistList.test.tsx
+++ b/frontend/features/artists/components/ArtistList.test.tsx
@@ -55,8 +55,8 @@ vi.mock('@/components/filters', () => ({
 
 vi.mock('@/components/shared', () => ({
   LoadingSpinner: () => <div data-testid="loading-spinner">Loading...</div>,
-  DensityToggle: ({ storageKey }: { storageKey: string }) => (
-    <div data-testid="density-toggle">{storageKey}</div>
+  DensityToggle: ({ density }: { density: string; onDensityChange: (v: string) => void }) => (
+    <div data-testid="density-toggle">{density}</div>
   ),
 }))
 
@@ -129,9 +129,9 @@ describe('ArtistList', () => {
     expect(screen.getByTestId('artist-search')).toBeInTheDocument()
   })
 
-  it('renders density toggle with correct storage key', () => {
+  it('renders density toggle with current density', () => {
     renderWithProviders(<ArtistList />)
-    expect(screen.getByTestId('density-toggle')).toHaveTextContent('artists')
+    expect(screen.getByTestId('density-toggle')).toHaveTextContent('comfortable')
   })
 
   it('renders empty state when no artists', () => {

--- a/frontend/features/artists/components/ArtistList.tsx
+++ b/frontend/features/artists/components/ArtistList.tsx
@@ -31,7 +31,7 @@ export function ArtistList() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const [isPending, startTransition] = useTransition()
-  const { density } = useDensity('artists')
+  const { density, setDensity } = useDensity('artists')
 
   // Parse multi-city from URL
   const citiesParam = searchParams.get('cities')
@@ -101,7 +101,7 @@ export function ArtistList() {
       </div>
 
       <div className="flex justify-end mb-4">
-        <DensityToggle storageKey="artists" />
+        <DensityToggle density={density} onDensityChange={setDensity} />
       </div>
 
       {/* Dim content while fetching, don't hide it */}

--- a/frontend/features/artists/components/ArtistList.tsx
+++ b/frontend/features/artists/components/ArtistList.tsx
@@ -123,16 +123,18 @@ export function ArtistList() {
             )}
           </div>
         ) : (
-          <div className={
-            density === 'compact'
-              ? 'flex flex-col gap-px'
-              : density === 'expanded'
-                ? '@container grid grid-cols-1 gap-5'
-                : '@container grid grid-cols-1 @sm:grid-cols-2 @2xl:grid-cols-3 gap-3'
-          }>
-            {artists.map(artist => (
-              <ArtistCard key={artist.id} artist={artist} density={density} />
-            ))}
+          <div className="@container">
+            <div className={
+              density === 'compact'
+                ? 'flex flex-col gap-px'
+                : density === 'expanded'
+                  ? 'grid grid-cols-1 gap-5'
+                  : 'grid grid-cols-1 @sm:grid-cols-2 @2xl:grid-cols-3 gap-3'
+            }>
+              {artists.map(artist => (
+                <ArtistCard key={artist.id} artist={artist} density={density} />
+              ))}
+            </div>
           </div>
         )}
       </div>

--- a/frontend/features/festivals/components/FestivalList.tsx
+++ b/frontend/features/festivals/components/FestivalList.tsx
@@ -153,23 +153,24 @@ export function FestivalList() {
             )}
           </div>
         ) : (
-          <div
-            className={cn(
-              '@container',
-              density === 'compact'
-                ? 'flex flex-col gap-px'
-                : density === 'expanded'
-                  ? 'grid grid-cols-1 gap-5'
-                  : 'grid grid-cols-1 @sm:grid-cols-2 @2xl:grid-cols-3 gap-3'
-            )}
-          >
-            {festivals.map(festival => (
-              <FestivalCard
-                key={festival.id}
-                festival={festival}
-                density={density}
-              />
-            ))}
+          <div className="@container">
+            <div
+              className={
+                density === 'compact'
+                  ? 'flex flex-col gap-px'
+                  : density === 'expanded'
+                    ? 'grid grid-cols-1 gap-5'
+                    : 'grid grid-cols-1 @sm:grid-cols-2 @2xl:grid-cols-3 gap-3'
+              }
+            >
+              {festivals.map(festival => (
+                <FestivalCard
+                  key={festival.id}
+                  festival={festival}
+                  density={density}
+                />
+              ))}
+            </div>
           </div>
         )}
       </div>

--- a/frontend/features/festivals/components/FestivalList.tsx
+++ b/frontend/features/festivals/components/FestivalList.tsx
@@ -15,7 +15,7 @@ export function FestivalList() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const [isPending, startTransition] = useTransition()
-  const { density } = useDensity('festivals')
+  const { density, setDensity } = useDensity('festivals')
 
   // Parse filters from URL
   const statusParam = searchParams.get('status') as FestivalStatus | null
@@ -125,7 +125,7 @@ export function FestivalList() {
       </div>
 
       <div className="flex justify-end mb-4">
-        <DensityToggle storageKey="festivals" />
+        <DensityToggle density={density} onDensityChange={setDensity} />
       </div>
 
       {/* Festival Grid */}

--- a/frontend/features/labels/components/LabelList.tsx
+++ b/frontend/features/labels/components/LabelList.tsx
@@ -15,7 +15,7 @@ export function LabelList() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const [isPending, startTransition] = useTransition()
-  const { density } = useDensity('labels')
+  const { density, setDensity } = useDensity('labels')
 
   // Parse filters from URL
   const statusParam = searchParams.get('status') as LabelStatus | null
@@ -113,7 +113,7 @@ export function LabelList() {
       </div>
 
       <div className="flex justify-end mb-4">
-        <DensityToggle storageKey="labels" />
+        <DensityToggle density={density} onDensityChange={setDensity} />
       </div>
 
       {/* Label Grid */}

--- a/frontend/features/labels/components/LabelList.tsx
+++ b/frontend/features/labels/components/LabelList.tsx
@@ -141,19 +141,20 @@ export function LabelList() {
             )}
           </div>
         ) : (
-          <div
-            className={cn(
-              '@container',
-              density === 'compact'
-                ? 'flex flex-col gap-px'
-                : density === 'expanded'
-                  ? 'grid grid-cols-1 gap-5'
-                  : 'grid grid-cols-1 @sm:grid-cols-2 @2xl:grid-cols-3 gap-3'
-            )}
-          >
-            {labels.map(label => (
-              <LabelCard key={label.id} label={label} density={density} />
-            ))}
+          <div className="@container">
+            <div
+              className={
+                density === 'compact'
+                  ? 'flex flex-col gap-px'
+                  : density === 'expanded'
+                    ? 'grid grid-cols-1 gap-5'
+                    : 'grid grid-cols-1 @sm:grid-cols-2 @2xl:grid-cols-3 gap-3'
+              }
+            >
+              {labels.map(label => (
+                <LabelCard key={label.id} label={label} density={density} />
+              ))}
+            </div>
           </div>
         )}
       </div>

--- a/frontend/features/releases/components/ReleaseList.tsx
+++ b/frontend/features/releases/components/ReleaseList.tsx
@@ -14,7 +14,7 @@ export function ReleaseList() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const [isPending, startTransition] = useTransition()
-  const { density } = useDensity('releases')
+  const { density, setDensity } = useDensity('releases')
 
   // Parse filters from URL
   const typeParam = searchParams.get('type') as ReleaseType | null
@@ -147,7 +147,7 @@ export function ReleaseList() {
       </div>
 
       <div className="flex justify-end mb-4">
-        <DensityToggle storageKey="releases" />
+        <DensityToggle density={density} onDensityChange={setDensity} />
       </div>
 
       {/* Release Grid */}

--- a/frontend/features/releases/components/ReleaseList.tsx
+++ b/frontend/features/releases/components/ReleaseList.tsx
@@ -175,22 +175,24 @@ export function ReleaseList() {
             )}
           </div>
         ) : (
-          <div
-            className={
-              density === 'compact'
-                ? 'flex flex-col gap-px'
-                : density === 'expanded'
-                  ? 'grid grid-cols-1 gap-5'
-                  : '@container grid grid-cols-1 @sm:grid-cols-2 @2xl:grid-cols-3 gap-3'
-            }
-          >
-            {releases.map(release => (
-              <ReleaseCard
-                key={release.id}
-                release={release}
-                density={density}
-              />
-            ))}
+          <div className="@container">
+            <div
+              className={
+                density === 'compact'
+                  ? 'flex flex-col gap-px'
+                  : density === 'expanded'
+                    ? 'grid grid-cols-1 gap-5'
+                    : 'grid grid-cols-1 @sm:grid-cols-2 @2xl:grid-cols-3 gap-3'
+              }
+            >
+              {releases.map(release => (
+                <ReleaseCard
+                  key={release.id}
+                  release={release}
+                  density={density}
+                />
+              ))}
+            </div>
           </div>
         )}
       </div>

--- a/frontend/features/shows/components/ShowList.tsx
+++ b/frontend/features/shows/components/ShowList.tsx
@@ -219,7 +219,7 @@ export function ShowList() {
         ) : (
           <>
             <div className={cn(
-              '@container flex flex-col',
+              'flex flex-col',
               density === 'compact' && 'gap-0.5',
               density === 'comfortable' && 'gap-3',
               density === 'expanded' && 'gap-5'

--- a/frontend/features/shows/components/ShowList.tsx
+++ b/frontend/features/shows/components/ShowList.tsx
@@ -50,7 +50,7 @@ export function ShowList() {
   const [isPending, startTransition] = useTransition()
   const { data: profileData } = useProfile()
   const hasAppliedDefaults = useRef(false)
-  const { density } = useDensity('shows')
+  const { density, setDensity } = useDensity('shows')
 
   // Parse multi-city or legacy single-city from URL
   const citiesParam = searchParams.get('cities')
@@ -189,7 +189,7 @@ export function ShowList() {
       )}
 
       <div className="flex justify-end mb-4">
-        <DensityToggle storageKey="shows" />
+        <DensityToggle density={density} onDensityChange={setDensity} />
       </div>
 
       {/* Dim content while fetching, don't hide it */}


### PR DESCRIPTION
## Summary
- **Root cause**: `DensityToggle` and each `*List` component both called `useDensity()` separately, creating two independent React state instances. Clicking the toggle updated its own state + localStorage, but the list's state stayed stale.
- **Fix**: `DensityToggle` is now a controlled component — accepts `density` and `onDensityChange` props from the parent. The parent owns the single `useDensity()` hook.
- Updated all 5 list components (Artists, Shows, Releases, Labels, Festivals) to pass state down.
- Updated DensityToggle tests for new props API.

## Test plan
- [ ] Toggle density on `/artists` — compact (dense rows), comfortable (cards), expanded (rich cards) all render immediately
- [ ] Toggle density on `/shows` — same three distinct layouts
- [ ] Density persists across page navigation (localStorage still works)
- [ ] All 1455 frontend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)