### PR TITLE
Wire revision recording to entity update handlers

### DIFF
--- a/backend/internal/api/handlers/admin_integration_test.go
+++ b/backend/internal/api/handlers/admin_integration_test.go
@@ -278,7 +278,7 @@ func (s *AdminHandlerIntegrationSuite) TestGetPendingVenueEdits_Success() {
 	s.deps.db.Create(venue)
 
 	// Create pending edit via venue handler
-	venueHandler := NewVenueHandler(s.deps.venueService, s.deps.discordService)
+	venueHandler := NewVenueHandler(s.deps.venueService, s.deps.discordService, nil)
 	userCtx := ctxWithUser(user)
 	newName := "Updated Name"
 	updateReq := &UpdateVenueRequest{VenueID: fmt.Sprintf("%d", venue.ID)}
@@ -310,7 +310,7 @@ func (s *AdminHandlerIntegrationSuite) TestApproveVenueEdit_Success() {
 	s.deps.db.Create(venue)
 
 	// Create pending edit
-	venueHandler := NewVenueHandler(s.deps.venueService, s.deps.discordService)
+	venueHandler := NewVenueHandler(s.deps.venueService, s.deps.discordService, nil)
 	userCtx := ctxWithUser(user)
 	newName := "Approved Name"
 	updateReq := &UpdateVenueRequest{VenueID: fmt.Sprintf("%d", venue.ID)}
@@ -353,7 +353,7 @@ func (s *AdminHandlerIntegrationSuite) TestRejectVenueEdit_Success() {
 	s.deps.db.Create(venue)
 
 	// Create pending edit
-	venueHandler := NewVenueHandler(s.deps.venueService, s.deps.discordService)
+	venueHandler := NewVenueHandler(s.deps.venueService, s.deps.discordService, nil)
 	userCtx := ctxWithUser(user)
 	newName := "Rejected Name"
 	updateReq := &UpdateVenueRequest{VenueID: fmt.Sprintf("%d", venue.ID)}

--- a/backend/internal/api/handlers/artist.go
+++ b/backend/internal/api/handlers/artist.go
@@ -13,6 +13,7 @@ import (
 	"psychic-homily-backend/internal/api/middleware"
 	apperrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/logger"
+	"psychic-homily-backend/internal/models"
 	"psychic-homily-backend/internal/services"
 )
 
@@ -29,12 +30,14 @@ func isInternalServiceRequest(ctx huma.Context) bool {
 type ArtistHandler struct {
 	artistService   services.ArtistServiceInterface
 	auditLogService services.AuditLogServiceInterface
+	revisionService services.RevisionServiceInterface
 }
 
-func NewArtistHandler(artistService services.ArtistServiceInterface, auditLogService services.AuditLogServiceInterface) *ArtistHandler {
+func NewArtistHandler(artistService services.ArtistServiceInterface, auditLogService services.AuditLogServiceInterface, revisionService services.RevisionServiceInterface) *ArtistHandler {
 	return &ArtistHandler{
 		artistService:   artistService,
 		auditLogService: auditLogService,
+		revisionService: revisionService,
 	}
 }
 
@@ -641,6 +644,7 @@ type AdminUpdateArtistRequest struct {
 		Soundcloud *string `json:"soundcloud,omitempty" required:"false" doc:"SoundCloud URL"`
 		Bandcamp   *string `json:"bandcamp,omitempty" required:"false" doc:"Bandcamp URL"`
 		Website    *string `json:"website,omitempty" required:"false" doc:"Website URL"`
+		Summary    *string `json:"summary,omitempty" required:"false" doc:"Edit summary explaining the change"`
 	}
 }
 
@@ -712,6 +716,12 @@ func (h *ArtistHandler) AdminUpdateArtistHandler(ctx context.Context, req *Admin
 		return nil, huma.Error400BadRequest("No fields to update")
 	}
 
+	// Capture old values before update for revision recording
+	var oldArtist *services.ArtistDetailResponse
+	if h.revisionService != nil {
+		oldArtist, _ = h.artistService.GetArtist(uint(artistID))
+	}
+
 	artist, err := h.artistService.UpdateArtist(uint(artistID), updates)
 	if err != nil {
 		var artistErr *apperrors.ArtistError
@@ -731,6 +741,22 @@ func (h *ArtistHandler) AdminUpdateArtistHandler(ctx context.Context, req *Admin
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
 		h.auditLogService.LogAction(user.ID, "edit_artist", "artist", uint(artistID), nil)
+	}
+
+	// Record revision (fire and forget)
+	if h.revisionService != nil && oldArtist != nil {
+		changes := computeArtistChanges(oldArtist, artist, updates)
+		var summary string
+		if req.Body.Summary != nil {
+			summary = *req.Body.Summary
+		}
+		if err := h.revisionService.RecordRevision("artist", uint(artistID), user.ID, changes, summary); err != nil {
+			logger.FromContext(ctx).Error("revision_record_failed",
+				"entity_type", "artist",
+				"entity_id", artistID,
+				"error", err.Error(),
+			)
+		}
 	}
 
 	logger.FromContext(ctx).Info("admin_update_artist_success",
@@ -964,4 +990,54 @@ func (h *ArtistHandler) MergeArtistsHandler(ctx context.Context, req *MergeArtis
 	)
 
 	return &MergeArtistsResponse{Body: result}, nil
+}
+
+// computeArtistChanges computes field-level diffs between old and new artist responses
+// for the fields that were requested in the updates map.
+func computeArtistChanges(old, updated *services.ArtistDetailResponse, updates map[string]interface{}) []models.FieldChange {
+	var changes []models.FieldChange
+	if old == nil || updated == nil {
+		return changes
+	}
+
+	// Map of field name → (old value, new value) extractors from the response objects
+	fieldMap := map[string][2]interface{}{
+		"name":       {old.Name, updated.Name},
+		"city":       {ptrToStr(old.City), ptrToStr(updated.City)},
+		"state":      {ptrToStr(old.State), ptrToStr(updated.State)},
+		"instagram":  {ptrToStr(old.Social.Instagram), ptrToStr(updated.Social.Instagram)},
+		"facebook":   {ptrToStr(old.Social.Facebook), ptrToStr(updated.Social.Facebook)},
+		"twitter":    {ptrToStr(old.Social.Twitter), ptrToStr(updated.Social.Twitter)},
+		"youtube":    {ptrToStr(old.Social.YouTube), ptrToStr(updated.Social.YouTube)},
+		"spotify":    {ptrToStr(old.Social.Spotify), ptrToStr(updated.Social.Spotify)},
+		"soundcloud": {ptrToStr(old.Social.SoundCloud), ptrToStr(updated.Social.SoundCloud)},
+		"bandcamp":   {ptrToStr(old.Social.Bandcamp), ptrToStr(updated.Social.Bandcamp)},
+		"website":    {ptrToStr(old.Social.Website), ptrToStr(updated.Social.Website)},
+	}
+
+	for field := range updates {
+		pair, ok := fieldMap[field]
+		if !ok {
+			continue
+		}
+		oldVal := pair[0]
+		newVal := pair[1]
+		if fmt.Sprintf("%v", oldVal) != fmt.Sprintf("%v", newVal) {
+			changes = append(changes, models.FieldChange{
+				Field:    field,
+				OldValue: oldVal,
+				NewValue: newVal,
+			})
+		}
+	}
+
+	return changes
+}
+
+// ptrToStr safely dereferences a *string, returning "" for nil.
+func ptrToStr(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
 }

--- a/backend/internal/api/handlers/artist_integration_test.go
+++ b/backend/internal/api/handlers/artist_integration_test.go
@@ -19,7 +19,7 @@ type ArtistHandlerIntegrationSuite struct {
 
 func (s *ArtistHandlerIntegrationSuite) SetupSuite() {
 	s.deps = setupHandlerIntegrationDeps(s.T())
-	s.handler = NewArtistHandler(s.deps.artistService, s.deps.auditLogService)
+	s.handler = NewArtistHandler(s.deps.artistService, s.deps.auditLogService, nil)
 }
 
 func (s *ArtistHandlerIntegrationSuite) TearDownTest() {

--- a/backend/internal/api/handlers/artist_test.go
+++ b/backend/internal/api/handlers/artist_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func testArtistHandler() *ArtistHandler {
-	return NewArtistHandler(nil, nil)
+	return NewArtistHandler(nil, nil, nil)
 }
 
 // --- NewArtistHandler ---
@@ -258,7 +258,7 @@ func TestSearchArtists_Success(t *testing.T) {
 			return []*services.ArtistDetailResponse{{ID: 1, Name: "Radiohead"}}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 
 	resp, err := h.SearchArtistsHandler(context.Background(), &SearchArtistsRequest{Query: "radio"})
 	if err != nil {
@@ -278,7 +278,7 @@ func TestSearchArtists_ServiceError(t *testing.T) {
 			return nil, fmt.Errorf("db error")
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 
 	_, err := h.SearchArtistsHandler(context.Background(), &SearchArtistsRequest{Query: "test"})
 	if err == nil {
@@ -299,7 +299,7 @@ func TestListArtists_Success(t *testing.T) {
 			}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 
 	resp, err := h.ListArtistsHandler(context.Background(), &ListArtistsRequest{})
 	if err != nil {
@@ -327,7 +327,7 @@ func TestListArtists_WithFilters(t *testing.T) {
 			}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 
 	resp, err := h.ListArtistsHandler(context.Background(), &ListArtistsRequest{State: "AZ", City: "Phoenix"})
 	if err != nil {
@@ -344,7 +344,7 @@ func TestListArtists_ServiceError(t *testing.T) {
 			return nil, fmt.Errorf("db error")
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 
 	_, err := h.ListArtistsHandler(context.Background(), &ListArtistsRequest{})
 	assertHumaError(t, err, 500)
@@ -363,7 +363,7 @@ func TestGetArtist_ByID(t *testing.T) {
 			return &services.ArtistDetailResponse{ID: 42, Name: "Test Artist"}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 
 	resp, err := h.GetArtistHandler(context.Background(), &GetArtistRequest{ArtistID: "42"})
 	if err != nil {
@@ -383,7 +383,7 @@ func TestGetArtist_BySlug(t *testing.T) {
 			return &services.ArtistDetailResponse{ID: 10, Slug: "the-national"}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 
 	resp, err := h.GetArtistHandler(context.Background(), &GetArtistRequest{ArtistID: "the-national"})
 	if err != nil {
@@ -400,7 +400,7 @@ func TestGetArtist_NotFound(t *testing.T) {
 			return nil, apperrors.ErrArtistNotFound(99)
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 
 	_, err := h.GetArtistHandler(context.Background(), &GetArtistRequest{ArtistID: "99"})
 	assertHumaError(t, err, 404)
@@ -412,7 +412,7 @@ func TestGetArtist_ServiceError(t *testing.T) {
 			return nil, fmt.Errorf("db error")
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 
 	_, err := h.GetArtistHandler(context.Background(), &GetArtistRequest{ArtistID: "42"})
 	assertHumaError(t, err, 500)
@@ -431,7 +431,7 @@ func TestGetArtistShows_ByID(t *testing.T) {
 			return []*services.ArtistShowResponse{{ID: 100}}, 1, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 
 	resp, err := h.GetArtistShowsHandler(context.Background(), &GetArtistShowsRequest{ArtistID: "5", Limit: 20})
 	if err != nil {
@@ -457,7 +457,7 @@ func TestGetArtistShows_BySlug(t *testing.T) {
 			return []*services.ArtistShowResponse{{ID: 200}}, 1, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 
 	resp, err := h.GetArtistShowsHandler(context.Background(), &GetArtistShowsRequest{ArtistID: "the-national", Limit: 20})
 	if err != nil {
@@ -474,7 +474,7 @@ func TestGetArtistShows_ArtistNotFound(t *testing.T) {
 			return nil, 0, apperrors.ErrArtistNotFound(99)
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 
 	_, err := h.GetArtistShowsHandler(context.Background(), &GetArtistShowsRequest{ArtistID: "99", Limit: 20})
 	assertHumaError(t, err, 404)
@@ -486,7 +486,7 @@ func TestGetArtistShows_ServiceError(t *testing.T) {
 			return nil, 0, fmt.Errorf("db error")
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 
 	_, err := h.GetArtistShowsHandler(context.Background(), &GetArtistShowsRequest{ArtistID: "5", Limit: 20})
 	assertHumaError(t, err, 500)
@@ -505,7 +505,7 @@ func TestDeleteArtist_Success(t *testing.T) {
 			return nil
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1})
 
 	_, err := h.DeleteArtistHandler(ctx, &DeleteArtistRequest{ArtistID: "42"})
@@ -520,7 +520,7 @@ func TestDeleteArtist_NotFound(t *testing.T) {
 			return apperrors.ErrArtistNotFound(99)
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1})
 
 	_, err := h.DeleteArtistHandler(ctx, &DeleteArtistRequest{ArtistID: "99"})
@@ -533,7 +533,7 @@ func TestDeleteArtist_HasShows(t *testing.T) {
 			return apperrors.ErrArtistHasShows(42, 3)
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1})
 
 	_, err := h.DeleteArtistHandler(ctx, &DeleteArtistRequest{ArtistID: "42"})
@@ -546,7 +546,7 @@ func TestDeleteArtist_ServiceError(t *testing.T) {
 			return fmt.Errorf("db error")
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1})
 
 	_, err := h.DeleteArtistHandler(ctx, &DeleteArtistRequest{ArtistID: "42"})
@@ -566,7 +566,7 @@ func TestAdminUpdateArtist_Success(t *testing.T) {
 			return &services.ArtistDetailResponse{ID: 42, Name: "Updated"}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
 	name := "Updated"
 	req := &AdminUpdateArtistRequest{ArtistID: "42"}
@@ -587,7 +587,7 @@ func TestAdminUpdateArtist_NotFound(t *testing.T) {
 			return nil, apperrors.ErrArtistNotFound(99)
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
 	name := "Test"
 	req := &AdminUpdateArtistRequest{ArtistID: "99"}
@@ -621,7 +621,7 @@ func TestAdminUpdateArtist_AuditLogCalled(t *testing.T) {
 			}
 		},
 	}
-	h := NewArtistHandler(artistMock, auditMock)
+	h := NewArtistHandler(artistMock, auditMock, nil)
 	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
 	name := "New Name"
 	req := &AdminUpdateArtistRequest{ArtistID: "42"}
@@ -633,6 +633,116 @@ func TestAdminUpdateArtist_AuditLogCalled(t *testing.T) {
 	}
 	if !auditCalled {
 		t.Error("expected audit log to be called")
+	}
+}
+
+func TestAdminUpdateArtist_RevisionRecorded(t *testing.T) {
+	var revisionCalled bool
+	oldCity := "Phoenix"
+	artistMock := &mockArtistService{
+		getArtistFn: func(artistID uint) (*services.ArtistDetailResponse, error) {
+			return &services.ArtistDetailResponse{
+				ID:   42,
+				Name: "Old Name",
+				City: &oldCity,
+			}, nil
+		},
+		updateArtistFn: func(_ uint, _ map[string]interface{}) (*services.ArtistDetailResponse, error) {
+			return &services.ArtistDetailResponse{ID: 42, Name: "New Name", City: &oldCity}, nil
+		},
+	}
+	revisionMock := &mockRevisionService{
+		recordRevisionFn: func(entityType string, entityID uint, userID uint, changes []models.FieldChange, summary string) error {
+			revisionCalled = true
+			if entityType != "artist" {
+				t.Errorf("expected entityType='artist', got %q", entityType)
+			}
+			if entityID != 42 {
+				t.Errorf("expected entityID=42, got %d", entityID)
+			}
+			if userID != 1 {
+				t.Errorf("expected userID=1, got %d", userID)
+			}
+			if summary != "Fixed typo" {
+				t.Errorf("expected summary='Fixed typo', got %q", summary)
+			}
+			// Should have exactly 1 change (name changed, city didn't)
+			if len(changes) != 1 {
+				t.Errorf("expected 1 change, got %d", len(changes))
+			}
+			if len(changes) > 0 && changes[0].Field != "name" {
+				t.Errorf("expected field='name', got %q", changes[0].Field)
+			}
+			return nil
+		},
+	}
+	h := NewArtistHandler(artistMock, nil, revisionMock)
+	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
+	name := "New Name"
+	summary := "Fixed typo"
+	req := &AdminUpdateArtistRequest{ArtistID: "42"}
+	req.Body.Name = &name
+	req.Body.Summary = &summary
+
+	_, err := h.AdminUpdateArtistHandler(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !revisionCalled {
+		t.Error("expected revision service to be called")
+	}
+}
+
+func TestAdminUpdateArtist_RevisionNotCalledWhenNil(t *testing.T) {
+	// When revisionService is nil, the update should still succeed
+	artistMock := &mockArtistService{
+		updateArtistFn: func(_ uint, _ map[string]interface{}) (*services.ArtistDetailResponse, error) {
+			return &services.ArtistDetailResponse{ID: 42, Name: "Updated"}, nil
+		},
+	}
+	h := NewArtistHandler(artistMock, nil, nil)
+	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
+	name := "Updated"
+	req := &AdminUpdateArtistRequest{ArtistID: "42"}
+	req.Body.Name = &name
+
+	resp, err := h.AdminUpdateArtistHandler(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Name != "Updated" {
+		t.Errorf("expected name='Updated', got %q", resp.Body.Name)
+	}
+}
+
+func TestAdminUpdateArtist_RevisionErrorDoesNotFailUpdate(t *testing.T) {
+	// Revision service error should not fail the update
+	oldName := "Old Name"
+	artistMock := &mockArtistService{
+		getArtistFn: func(artistID uint) (*services.ArtistDetailResponse, error) {
+			return &services.ArtistDetailResponse{ID: 42, Name: oldName}, nil
+		},
+		updateArtistFn: func(_ uint, _ map[string]interface{}) (*services.ArtistDetailResponse, error) {
+			return &services.ArtistDetailResponse{ID: 42, Name: "New Name"}, nil
+		},
+	}
+	revisionMock := &mockRevisionService{
+		recordRevisionFn: func(_ string, _ uint, _ uint, _ []models.FieldChange, _ string) error {
+			return fmt.Errorf("database error")
+		},
+	}
+	h := NewArtistHandler(artistMock, nil, revisionMock)
+	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
+	name := "New Name"
+	req := &AdminUpdateArtistRequest{ArtistID: "42"}
+	req.Body.Name = &name
+
+	resp, err := h.AdminUpdateArtistHandler(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Name != "New Name" {
+		t.Errorf("expected name='New Name', got %q", resp.Body.Name)
 	}
 }
 
@@ -657,7 +767,7 @@ func TestUpdateBandcamp_Success(t *testing.T) {
 			return &services.ArtistDetailResponse{ID: 42}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
 	url := "https://artist.bandcamp.com/album/cool-album"
 	req := &UpdateArtistBandcampRequest{ArtistID: "42"}
@@ -684,7 +794,7 @@ func TestUpdateBandcamp_ClearURL(t *testing.T) {
 			return &services.ArtistDetailResponse{ID: 42}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
 	empty := ""
 	req := &UpdateArtistBandcampRequest{ArtistID: "42"}
@@ -712,7 +822,7 @@ func TestUpdateSpotify_Success(t *testing.T) {
 			return &services.ArtistDetailResponse{ID: 42}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
 	url := "https://open.spotify.com/artist/abc123"
 	req := &UpdateArtistSpotifyRequest{ArtistID: "42"}
@@ -740,7 +850,7 @@ func TestGetArtistCities_Success(t *testing.T) {
 			}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 
 	resp, err := h.GetArtistCitiesHandler(context.Background(), &GetArtistCitiesRequest{})
 	if err != nil {
@@ -763,7 +873,7 @@ func TestGetArtistCities_ServiceError(t *testing.T) {
 			return nil, fmt.Errorf("db error")
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 
 	_, err := h.GetArtistCitiesHandler(context.Background(), &GetArtistCitiesRequest{})
 	assertHumaError(t, err, 500)
@@ -775,7 +885,7 @@ func TestGetArtistCities_Empty(t *testing.T) {
 			return []*services.ArtistCityResponse{}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 
 	resp, err := h.GetArtistCitiesHandler(context.Background(), &GetArtistCitiesRequest{})
 	if err != nil {
@@ -808,7 +918,7 @@ func TestListArtists_WithCitiesFilter(t *testing.T) {
 			}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 
 	resp, err := h.ListArtistsHandler(context.Background(), &ListArtistsRequest{Cities: "Phoenix,AZ|Mesa,AZ"})
 	if err != nil {
@@ -832,7 +942,7 @@ func TestListArtists_CitiesOverridesLegacy(t *testing.T) {
 			return []*services.ArtistWithShowCountResponse{}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 
 	_, err := h.ListArtistsHandler(context.Background(), &ListArtistsRequest{
 		Cities: "Phoenix,AZ",
@@ -866,7 +976,7 @@ func TestGetArtistAliases_Success(t *testing.T) {
 			}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 
 	resp, err := h.GetArtistAliasesHandler(context.Background(), &GetArtistAliasesRequest{ArtistID: "42"})
 	if err != nil {
@@ -883,7 +993,7 @@ func TestGetArtistAliases_NotFound(t *testing.T) {
 			return nil, apperrors.ErrArtistNotFound(artistID)
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 
 	_, err := h.GetArtistAliasesHandler(context.Background(), &GetArtistAliasesRequest{ArtistID: "99"})
 	assertHumaError(t, err, 404)
@@ -941,7 +1051,7 @@ func TestAddArtistAlias_Success(t *testing.T) {
 			return &services.ArtistAliasResponse{ID: 1, ArtistID: 42, Alias: alias}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
 	req := &AddArtistAliasRequest{ArtistID: "42"}
 	req.Body.Alias = "New Alias"
@@ -961,7 +1071,7 @@ func TestAddArtistAlias_Conflict(t *testing.T) {
 			return nil, fmt.Errorf("alias 'Test' already exists")
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
 	req := &AddArtistAliasRequest{ArtistID: "42"}
 	req.Body.Alias = "Test"
@@ -1003,7 +1113,7 @@ func TestDeleteArtistAlias_Success(t *testing.T) {
 			return nil
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
 
 	_, err := h.DeleteArtistAliasHandler(ctx, &DeleteArtistAliasRequest{ArtistID: "1", AliasID: "5"})
@@ -1018,7 +1128,7 @@ func TestDeleteArtistAlias_NotFound(t *testing.T) {
 			return fmt.Errorf("alias not found")
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
 
 	_, err := h.DeleteArtistAliasHandler(ctx, &DeleteArtistAliasRequest{ArtistID: "1", AliasID: "99"})
@@ -1067,7 +1177,7 @@ func TestMergeArtists_SelfMerge(t *testing.T) {
 			return nil, fmt.Errorf("cannot merge an artist with itself")
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
 	req := &MergeArtistsRequest{}
 	req.Body.CanonicalArtistID = 5
@@ -1095,7 +1205,7 @@ func TestMergeArtists_Success(t *testing.T) {
 			}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
 	req := &MergeArtistsRequest{}
 	req.Body.CanonicalArtistID = 1
@@ -1119,7 +1229,7 @@ func TestMergeArtists_NotFound(t *testing.T) {
 			return nil, apperrors.ErrArtistNotFound(canonicalID)
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
 	req := &MergeArtistsRequest{}
 	req.Body.CanonicalArtistID = 99

--- a/backend/internal/api/handlers/festival.go
+++ b/backend/internal/api/handlers/festival.go
@@ -11,6 +11,7 @@ import (
 	"psychic-homily-backend/internal/api/middleware"
 	apperrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/logger"
+	"psychic-homily-backend/internal/models"
 	"psychic-homily-backend/internal/services"
 )
 
@@ -18,13 +19,15 @@ type FestivalHandler struct {
 	festivalService services.FestivalServiceInterface
 	artistService   services.ArtistServiceInterface
 	auditLogService services.AuditLogServiceInterface
+	revisionService services.RevisionServiceInterface
 }
 
-func NewFestivalHandler(festivalService services.FestivalServiceInterface, artistService services.ArtistServiceInterface, auditLogService services.AuditLogServiceInterface) *FestivalHandler {
+func NewFestivalHandler(festivalService services.FestivalServiceInterface, artistService services.ArtistServiceInterface, auditLogService services.AuditLogServiceInterface, revisionService services.RevisionServiceInterface) *FestivalHandler {
 	return &FestivalHandler{
 		festivalService: festivalService,
 		artistService:   artistService,
 		auditLogService: auditLogService,
+		revisionService: revisionService,
 	}
 }
 
@@ -240,6 +243,7 @@ type UpdateFestivalRequest struct {
 		TicketURL    *string `json:"ticket_url,omitempty" required:"false" doc:"Ticket URL"`
 		FlyerURL     *string `json:"flyer_url,omitempty" required:"false" doc:"Flyer URL"`
 		Status       *string `json:"status,omitempty" required:"false" doc:"Status"`
+		Summary      *string `json:"summary,omitempty" required:"false" doc:"Edit summary explaining the change"`
 	}
 }
 
@@ -261,6 +265,12 @@ func (h *FestivalHandler) UpdateFestivalHandler(ctx context.Context, req *Update
 	festivalID, err := h.resolveFestivalID(req.FestivalID)
 	if err != nil {
 		return nil, err
+	}
+
+	// Capture old values before update for revision recording
+	var oldFestival *services.FestivalDetailResponse
+	if h.revisionService != nil {
+		oldFestival, _ = h.festivalService.GetFestival(festivalID)
 	}
 
 	serviceReq := &services.UpdateFestivalRequest{
@@ -301,6 +311,22 @@ func (h *FestivalHandler) UpdateFestivalHandler(ctx context.Context, req *Update
 		go func() {
 			h.auditLogService.LogAction(user.ID, "edit_festival", "festival", festivalID, nil)
 		}()
+	}
+
+	// Record revision (fire and forget)
+	if h.revisionService != nil && oldFestival != nil {
+		changes := computeFestivalChanges(oldFestival, festival, req)
+		var summary string
+		if req.Body.Summary != nil {
+			summary = *req.Body.Summary
+		}
+		if err := h.revisionService.RecordRevision("festival", festivalID, user.ID, changes, summary); err != nil {
+			logger.FromContext(ctx).Error("revision_record_failed",
+				"entity_type", "festival",
+				"entity_id", festivalID,
+				"error", err.Error(),
+			)
+		}
 	}
 
 	logger.FromContext(ctx).Info("festival_updated",
@@ -849,4 +875,52 @@ func (h *FestivalHandler) resolveFestivalID(idOrSlug string) (uint, error) {
 	}
 
 	return festival.ID, nil
+}
+
+// computeFestivalChanges computes field-level diffs between old and new festival responses
+// for the fields that were provided in the update request.
+func computeFestivalChanges(old, updated *services.FestivalDetailResponse, req *UpdateFestivalRequest) []models.FieldChange {
+	var changes []models.FieldChange
+	if old == nil || updated == nil {
+		return changes
+	}
+
+	type fieldPair struct {
+		field    string
+		oldVal   interface{}
+		newVal   interface{}
+		provided bool
+	}
+
+	pairs := []fieldPair{
+		{"name", old.Name, updated.Name, req.Body.Name != nil},
+		{"series_slug", old.SeriesSlug, updated.SeriesSlug, req.Body.SeriesSlug != nil},
+		{"edition_year", old.EditionYear, updated.EditionYear, req.Body.EditionYear != nil},
+		{"description", ptrToStr(old.Description), ptrToStr(updated.Description), req.Body.Description != nil},
+		{"location_name", ptrToStr(old.LocationName), ptrToStr(updated.LocationName), req.Body.LocationName != nil},
+		{"city", ptrToStr(old.City), ptrToStr(updated.City), req.Body.City != nil},
+		{"state", ptrToStr(old.State), ptrToStr(updated.State), req.Body.State != nil},
+		{"country", ptrToStr(old.Country), ptrToStr(updated.Country), req.Body.Country != nil},
+		{"start_date", old.StartDate, updated.StartDate, req.Body.StartDate != nil},
+		{"end_date", old.EndDate, updated.EndDate, req.Body.EndDate != nil},
+		{"website", ptrToStr(old.Website), ptrToStr(updated.Website), req.Body.Website != nil},
+		{"ticket_url", ptrToStr(old.TicketURL), ptrToStr(updated.TicketURL), req.Body.TicketURL != nil},
+		{"flyer_url", ptrToStr(old.FlyerURL), ptrToStr(updated.FlyerURL), req.Body.FlyerURL != nil},
+		{"status", old.Status, updated.Status, req.Body.Status != nil},
+	}
+
+	for _, p := range pairs {
+		if !p.provided {
+			continue
+		}
+		if fmt.Sprintf("%v", p.oldVal) != fmt.Sprintf("%v", p.newVal) {
+			changes = append(changes, models.FieldChange{
+				Field:    p.field,
+				OldValue: p.oldVal,
+				NewValue: p.newVal,
+			})
+		}
+	}
+
+	return changes
 }

--- a/backend/internal/api/handlers/festival_integration_test.go
+++ b/backend/internal/api/handlers/festival_integration_test.go
@@ -19,7 +19,7 @@ type FestivalHandlerIntegrationSuite struct {
 
 func (s *FestivalHandlerIntegrationSuite) SetupSuite() {
 	s.deps = setupHandlerIntegrationDeps(s.T())
-	s.handler = NewFestivalHandler(s.deps.festivalService, s.deps.artistService, s.deps.auditLogService)
+	s.handler = NewFestivalHandler(s.deps.festivalService, s.deps.artistService, s.deps.auditLogService, nil)
 }
 
 func (s *FestivalHandlerIntegrationSuite) TearDownTest() {

--- a/backend/internal/api/handlers/venue.go
+++ b/backend/internal/api/handlers/venue.go
@@ -10,20 +10,23 @@ import (
 	"psychic-homily-backend/internal/api/middleware"
 	apperrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/logger"
+	"psychic-homily-backend/internal/models"
 	"psychic-homily-backend/internal/services"
 
 	"github.com/danielgtaylor/huma/v2"
 )
 
 type VenueHandler struct {
-	venueService   services.VenueServiceInterface
-	discordService services.DiscordServiceInterface
+	venueService    services.VenueServiceInterface
+	discordService  services.DiscordServiceInterface
+	revisionService services.RevisionServiceInterface
 }
 
-func NewVenueHandler(venueService services.VenueServiceInterface, discordService services.DiscordServiceInterface) *VenueHandler {
+func NewVenueHandler(venueService services.VenueServiceInterface, discordService services.DiscordServiceInterface, revisionService services.RevisionServiceInterface) *VenueHandler {
 	return &VenueHandler{
-		venueService:   venueService,
-		discordService: discordService,
+		venueService:    venueService,
+		discordService:  discordService,
+		revisionService: revisionService,
 	}
 }
 
@@ -263,6 +266,7 @@ type UpdateVenueRequest struct {
 		SoundCloud *string `json:"soundcloud,omitempty" required:"false" doc:"SoundCloud URL"`
 		Bandcamp   *string `json:"bandcamp,omitempty" required:"false" doc:"Bandcamp URL"`
 		Website    *string `json:"website,omitempty" required:"false" doc:"Website URL"`
+		Summary    *string `json:"summary,omitempty" required:"false" doc:"Edit summary explaining the change"`
 	}
 }
 
@@ -343,6 +347,12 @@ func (h *VenueHandler) UpdateVenueHandler(ctx context.Context, req *UpdateVenueR
 			"request_id", requestID,
 		)
 
+		// Capture old values before update for revision recording
+		var oldVenue *services.VenueDetailResponse
+		if h.revisionService != nil {
+			oldVenue, _ = h.venueService.GetVenue(uint(venueID))
+		}
+
 		// Build updates map
 		updates := make(map[string]interface{})
 		if editReq.Name != nil {
@@ -395,6 +405,22 @@ func (h *VenueHandler) UpdateVenueHandler(ctx context.Context, req *UpdateVenueR
 			return nil, huma.Error422UnprocessableEntity(
 				fmt.Sprintf("Failed to update venue (request_id: %s)", requestID),
 			)
+		}
+
+		// Record revision (fire and forget)
+		if h.revisionService != nil && oldVenue != nil {
+			changes := computeVenueChanges(oldVenue, updatedVenue, updates)
+			var summary string
+			if req.Body.Summary != nil {
+				summary = *req.Body.Summary
+			}
+			if err := h.revisionService.RecordRevision("venue", uint(venueID), user.ID, changes, summary); err != nil {
+				logger.FromContext(ctx).Error("revision_record_failed",
+					"entity_type", "venue",
+					"entity_id", venueID,
+					"error", err.Error(),
+				)
+			}
 		}
 
 		return &UpdateVenueResponse{
@@ -702,4 +728,47 @@ func (h *VenueHandler) DeleteVenueHandler(ctx context.Context, req *DeleteVenueR
 			Message: "Venue deleted successfully",
 		},
 	}, nil
+}
+
+// computeVenueChanges computes field-level diffs between old and new venue responses
+// for the fields that were requested in the updates map.
+func computeVenueChanges(old, updated *services.VenueDetailResponse, updates map[string]interface{}) []models.FieldChange {
+	var changes []models.FieldChange
+	if old == nil || updated == nil {
+		return changes
+	}
+
+	fieldMap := map[string][2]interface{}{
+		"name":       {old.Name, updated.Name},
+		"address":    {ptrToStr(old.Address), ptrToStr(updated.Address)},
+		"city":       {old.City, updated.City},
+		"state":      {old.State, updated.State},
+		"zipcode":    {ptrToStr(old.Zipcode), ptrToStr(updated.Zipcode)},
+		"instagram":  {ptrToStr(old.Social.Instagram), ptrToStr(updated.Social.Instagram)},
+		"facebook":   {ptrToStr(old.Social.Facebook), ptrToStr(updated.Social.Facebook)},
+		"twitter":    {ptrToStr(old.Social.Twitter), ptrToStr(updated.Social.Twitter)},
+		"youtube":    {ptrToStr(old.Social.YouTube), ptrToStr(updated.Social.YouTube)},
+		"spotify":    {ptrToStr(old.Social.Spotify), ptrToStr(updated.Social.Spotify)},
+		"soundcloud": {ptrToStr(old.Social.SoundCloud), ptrToStr(updated.Social.SoundCloud)},
+		"bandcamp":   {ptrToStr(old.Social.Bandcamp), ptrToStr(updated.Social.Bandcamp)},
+		"website":    {ptrToStr(old.Social.Website), ptrToStr(updated.Social.Website)},
+	}
+
+	for field := range updates {
+		pair, ok := fieldMap[field]
+		if !ok {
+			continue
+		}
+		oldVal := pair[0]
+		newVal := pair[1]
+		if fmt.Sprintf("%v", oldVal) != fmt.Sprintf("%v", newVal) {
+			changes = append(changes, models.FieldChange{
+				Field:    field,
+				OldValue: oldVal,
+				NewValue: newVal,
+			})
+		}
+	}
+
+	return changes
 }

--- a/backend/internal/api/handlers/venue_integration_test.go
+++ b/backend/internal/api/handlers/venue_integration_test.go
@@ -17,7 +17,7 @@ type VenueHandlerIntegrationSuite struct {
 
 func (s *VenueHandlerIntegrationSuite) SetupSuite() {
 	s.deps = setupHandlerIntegrationDeps(s.T())
-	s.handler = NewVenueHandler(s.deps.venueService, s.deps.discordService)
+	s.handler = NewVenueHandler(s.deps.venueService, s.deps.discordService, nil)
 }
 
 func (s *VenueHandlerIntegrationSuite) TearDownTest() {

--- a/backend/internal/api/handlers/venue_test.go
+++ b/backend/internal/api/handlers/venue_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func testVenueHandler() *VenueHandler {
-	return NewVenueHandler(nil, nil)
+	return NewVenueHandler(nil, nil, nil)
 }
 
 // --- NewVenueHandler ---

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -279,7 +279,7 @@ func setupShowRoutes(router *chi.Mux, api huma.API, protected *huma.Group, sc *s
 }
 
 func setupArtistRoutes(api huma.API, protected *huma.Group, sc *services.ServiceContainer) {
-	artistHandler := handlers.NewArtistHandler(sc.Artist, sc.AuditLog)
+	artistHandler := handlers.NewArtistHandler(sc.Artist, sc.AuditLog, sc.Revision)
 
 	// Public artist endpoints - registered on main API without middleware
 	// Note: Static routes must come before parameterized routes
@@ -331,7 +331,7 @@ func setupLabelRoutes(api huma.API, protected *huma.Group, sc *services.ServiceC
 }
 
 func setupFestivalRoutes(api huma.API, protected *huma.Group, sc *services.ServiceContainer) {
-	festivalHandler := handlers.NewFestivalHandler(sc.Festival, sc.Artist, sc.AuditLog)
+	festivalHandler := handlers.NewFestivalHandler(sc.Festival, sc.Artist, sc.AuditLog, sc.Revision)
 
 	// Public festival endpoints
 	huma.Get(api, "/festivals", festivalHandler.ListFestivalsHandler)
@@ -360,7 +360,7 @@ func setupFestivalRoutes(api huma.API, protected *huma.Group, sc *services.Servi
 }
 
 func setupVenueRoutes(api huma.API, protected *huma.Group, sc *services.ServiceContainer) {
-	venueHandler := handlers.NewVenueHandler(sc.Venue, sc.Discord)
+	venueHandler := handlers.NewVenueHandler(sc.Venue, sc.Discord, sc.Revision)
 
 	// Public venue endpoints - registered on main API without middleware
 	// Note: Static routes must come before parameterized routes
@@ -480,7 +480,7 @@ func setupAdminRoutes(protected *huma.Group, sc *services.ServiceContainer) {
 		sc.APIToken, sc.DataSync, sc.AuditLog, sc.User, sc.AdminStats,
 		sc.NotificationFilter,
 	)
-	artistHandler := handlers.NewArtistHandler(sc.Artist, sc.AuditLog)
+	artistHandler := handlers.NewArtistHandler(sc.Artist, sc.AuditLog, sc.Revision)
 	auditLogHandler := handlers.NewAuditLogHandler(sc.AuditLog)
 
 	// Admin dashboard stats endpoint


### PR DESCRIPTION
## Summary
- Artist, venue, and festival update handlers now call `RevisionService.RecordRevision()` after successful updates, so the `RevisionHistory` component on detail pages actually shows edit history
- Each handler captures old values before the update, computes field-level diffs (old → new), and records a revision fire-and-forget
- All three update request structs gain an optional `summary` field so admins can explain why they made a change
- `computeArtistChanges()`, `computeVenueChanges()`, `computeFestivalChanges()` helper functions compare old vs new response objects
- Routes updated to pass `sc.Revision` to all handler constructors

## Test plan
- [x] 3 new unit tests: revision recorded with correct fields, nil-safety, fire-and-forget error handling
- [x] All existing handler tests updated for new constructor signature
- [x] Backend compiles cleanly
- [ ] Manual test: edit an artist in admin UI, verify revision appears in View History

Closes PSY-124

🤖 Generated with [Claude Code](https://claude.com/claude-code)