### PR TITLE
Add search endpoints for releases, labels, and festivals

### DIFF
--- a/backend/internal/api/handlers/festival.go
+++ b/backend/internal/api/handlers/festival.go
@@ -29,6 +29,37 @@ func NewFestivalHandler(festivalService services.FestivalServiceInterface, artis
 }
 
 // ============================================================================
+// Search Festivals
+// ============================================================================
+
+// SearchFestivalsRequest represents the autocomplete search request
+type SearchFestivalsRequest struct {
+	Query string `query:"q" doc:"Search query for festival autocomplete" example:"m3f"`
+}
+
+// SearchFestivalsResponse represents the autocomplete search response
+type SearchFestivalsResponse struct {
+	Body struct {
+		Festivals []*services.FestivalListResponse `json:"festivals" doc:"Matching festivals"`
+		Count     int                              `json:"count" doc:"Number of results"`
+	}
+}
+
+// SearchFestivalsHandler handles GET /festivals/search?q=query
+func (h *FestivalHandler) SearchFestivalsHandler(ctx context.Context, req *SearchFestivalsRequest) (*SearchFestivalsResponse, error) {
+	festivals, err := h.festivalService.SearchFestivals(req.Query)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := &SearchFestivalsResponse{}
+	resp.Body.Festivals = festivals
+	resp.Body.Count = len(festivals)
+
+	return resp, nil
+}
+
+// ============================================================================
 // List Festivals
 // ============================================================================
 

--- a/backend/internal/api/handlers/label.go
+++ b/backend/internal/api/handlers/label.go
@@ -27,6 +27,37 @@ func NewLabelHandler(labelService services.LabelServiceInterface, auditLogServic
 }
 
 // ============================================================================
+// Search Labels
+// ============================================================================
+
+// SearchLabelsRequest represents the autocomplete search request
+type SearchLabelsRequest struct {
+	Query string `query:"q" doc:"Search query for label autocomplete" example:"sub pop"`
+}
+
+// SearchLabelsResponse represents the autocomplete search response
+type SearchLabelsResponse struct {
+	Body struct {
+		Labels []*services.LabelListResponse `json:"labels" doc:"Matching labels"`
+		Count  int                           `json:"count" doc:"Number of results"`
+	}
+}
+
+// SearchLabelsHandler handles GET /labels/search?q=query
+func (h *LabelHandler) SearchLabelsHandler(ctx context.Context, req *SearchLabelsRequest) (*SearchLabelsResponse, error) {
+	labels, err := h.labelService.SearchLabels(req.Query)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := &SearchLabelsResponse{}
+	resp.Body.Labels = labels
+	resp.Body.Count = len(labels)
+
+	return resp, nil
+}
+
+// ============================================================================
 // List Labels
 // ============================================================================
 

--- a/backend/internal/api/handlers/release.go
+++ b/backend/internal/api/handlers/release.go
@@ -29,6 +29,37 @@ func NewReleaseHandler(releaseService services.ReleaseServiceInterface, artistSe
 }
 
 // ============================================================================
+// Search Releases
+// ============================================================================
+
+// SearchReleasesRequest represents the autocomplete search request
+type SearchReleasesRequest struct {
+	Query string `query:"q" doc:"Search query for release autocomplete" example:"nevermind"`
+}
+
+// SearchReleasesResponse represents the autocomplete search response
+type SearchReleasesResponse struct {
+	Body struct {
+		Releases []*services.ReleaseListResponse `json:"releases" doc:"Matching releases"`
+		Count    int                              `json:"count" doc:"Number of results"`
+	}
+}
+
+// SearchReleasesHandler handles GET /releases/search?q=query
+func (h *ReleaseHandler) SearchReleasesHandler(ctx context.Context, req *SearchReleasesRequest) (*SearchReleasesResponse, error) {
+	releases, err := h.releaseService.SearchReleases(req.Query)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := &SearchReleasesResponse{}
+	resp.Body.Releases = releases
+	resp.Body.Count = len(releases)
+
+	return resp, nil
+}
+
+// ============================================================================
 // List Releases
 // ============================================================================
 

--- a/backend/internal/api/handlers/search_test.go
+++ b/backend/internal/api/handlers/search_test.go
@@ -1,0 +1,323 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"psychic-homily-backend/internal/services"
+)
+
+// ============================================================================
+// Mock: ReleaseServiceInterface (minimal for search tests)
+// ============================================================================
+
+type mockReleaseServiceForSearch struct {
+	searchReleasesFn func(query string) ([]*services.ReleaseListResponse, error)
+}
+
+func (m *mockReleaseServiceForSearch) CreateRelease(req *services.CreateReleaseRequest) (*services.ReleaseDetailResponse, error) {
+	return nil, nil
+}
+func (m *mockReleaseServiceForSearch) GetRelease(releaseID uint) (*services.ReleaseDetailResponse, error) {
+	return nil, nil
+}
+func (m *mockReleaseServiceForSearch) GetReleaseBySlug(slug string) (*services.ReleaseDetailResponse, error) {
+	return nil, nil
+}
+func (m *mockReleaseServiceForSearch) ListReleases(filters map[string]interface{}) ([]*services.ReleaseListResponse, error) {
+	return nil, nil
+}
+func (m *mockReleaseServiceForSearch) SearchReleases(query string) ([]*services.ReleaseListResponse, error) {
+	if m.searchReleasesFn != nil {
+		return m.searchReleasesFn(query)
+	}
+	return nil, nil
+}
+func (m *mockReleaseServiceForSearch) UpdateRelease(releaseID uint, req *services.UpdateReleaseRequest) (*services.ReleaseDetailResponse, error) {
+	return nil, nil
+}
+func (m *mockReleaseServiceForSearch) DeleteRelease(releaseID uint) error { return nil }
+func (m *mockReleaseServiceForSearch) GetReleasesForArtist(artistID uint) ([]*services.ReleaseListResponse, error) {
+	return nil, nil
+}
+func (m *mockReleaseServiceForSearch) GetReleasesForArtistWithRoles(artistID uint) ([]*services.ArtistReleaseListResponse, error) {
+	return nil, nil
+}
+func (m *mockReleaseServiceForSearch) AddExternalLink(releaseID uint, platform, url string) (*services.ReleaseExternalLinkResponse, error) {
+	return nil, nil
+}
+func (m *mockReleaseServiceForSearch) RemoveExternalLink(linkID uint) error { return nil }
+
+// ============================================================================
+// Mock: LabelServiceInterface (minimal for search tests)
+// ============================================================================
+
+type mockLabelServiceForSearch struct {
+	searchLabelsFn func(query string) ([]*services.LabelListResponse, error)
+}
+
+func (m *mockLabelServiceForSearch) CreateLabel(req *services.CreateLabelRequest) (*services.LabelDetailResponse, error) {
+	return nil, nil
+}
+func (m *mockLabelServiceForSearch) GetLabel(labelID uint) (*services.LabelDetailResponse, error) {
+	return nil, nil
+}
+func (m *mockLabelServiceForSearch) GetLabelBySlug(slug string) (*services.LabelDetailResponse, error) {
+	return nil, nil
+}
+func (m *mockLabelServiceForSearch) ListLabels(filters map[string]interface{}) ([]*services.LabelListResponse, error) {
+	return nil, nil
+}
+func (m *mockLabelServiceForSearch) SearchLabels(query string) ([]*services.LabelListResponse, error) {
+	if m.searchLabelsFn != nil {
+		return m.searchLabelsFn(query)
+	}
+	return nil, nil
+}
+func (m *mockLabelServiceForSearch) UpdateLabel(labelID uint, req *services.UpdateLabelRequest) (*services.LabelDetailResponse, error) {
+	return nil, nil
+}
+func (m *mockLabelServiceForSearch) DeleteLabel(labelID uint) error { return nil }
+func (m *mockLabelServiceForSearch) GetLabelRoster(labelID uint) ([]*services.LabelArtistResponse, error) {
+	return nil, nil
+}
+func (m *mockLabelServiceForSearch) GetLabelCatalog(labelID uint) ([]*services.LabelReleaseResponse, error) {
+	return nil, nil
+}
+
+// ============================================================================
+// Mock: FestivalServiceInterface (minimal for search tests)
+// ============================================================================
+
+type mockFestivalServiceForSearch struct {
+	searchFestivalsFn func(query string) ([]*services.FestivalListResponse, error)
+}
+
+func (m *mockFestivalServiceForSearch) CreateFestival(req *services.CreateFestivalRequest) (*services.FestivalDetailResponse, error) {
+	return nil, nil
+}
+func (m *mockFestivalServiceForSearch) GetFestival(festivalID uint) (*services.FestivalDetailResponse, error) {
+	return nil, nil
+}
+func (m *mockFestivalServiceForSearch) GetFestivalBySlug(slug string) (*services.FestivalDetailResponse, error) {
+	return nil, nil
+}
+func (m *mockFestivalServiceForSearch) ListFestivals(filters map[string]interface{}) ([]*services.FestivalListResponse, error) {
+	return nil, nil
+}
+func (m *mockFestivalServiceForSearch) SearchFestivals(query string) ([]*services.FestivalListResponse, error) {
+	if m.searchFestivalsFn != nil {
+		return m.searchFestivalsFn(query)
+	}
+	return nil, nil
+}
+func (m *mockFestivalServiceForSearch) UpdateFestival(festivalID uint, req *services.UpdateFestivalRequest) (*services.FestivalDetailResponse, error) {
+	return nil, nil
+}
+func (m *mockFestivalServiceForSearch) DeleteFestival(festivalID uint) error { return nil }
+func (m *mockFestivalServiceForSearch) GetFestivalArtists(festivalID uint, dayDate *string) ([]*services.FestivalArtistResponse, error) {
+	return nil, nil
+}
+func (m *mockFestivalServiceForSearch) AddFestivalArtist(festivalID uint, req *services.AddFestivalArtistRequest) (*services.FestivalArtistResponse, error) {
+	return nil, nil
+}
+func (m *mockFestivalServiceForSearch) UpdateFestivalArtist(festivalID, artistID uint, req *services.UpdateFestivalArtistRequest) (*services.FestivalArtistResponse, error) {
+	return nil, nil
+}
+func (m *mockFestivalServiceForSearch) RemoveFestivalArtist(festivalID, artistID uint) error {
+	return nil
+}
+func (m *mockFestivalServiceForSearch) GetFestivalVenues(festivalID uint) ([]*services.FestivalVenueResponse, error) {
+	return nil, nil
+}
+func (m *mockFestivalServiceForSearch) AddFestivalVenue(festivalID uint, req *services.AddFestivalVenueRequest) (*services.FestivalVenueResponse, error) {
+	return nil, nil
+}
+func (m *mockFestivalServiceForSearch) RemoveFestivalVenue(festivalID, venueID uint) error {
+	return nil
+}
+func (m *mockFestivalServiceForSearch) GetFestivalsForArtist(artistID uint) ([]*services.ArtistFestivalListResponse, error) {
+	return nil, nil
+}
+
+// ============================================================================
+// Tests: SearchReleasesHandler
+// ============================================================================
+
+func TestSearchReleases_Success(t *testing.T) {
+	year := 1991
+	mock := &mockReleaseServiceForSearch{
+		searchReleasesFn: func(query string) ([]*services.ReleaseListResponse, error) {
+			if query != "nevermind" {
+				t.Errorf("expected query='nevermind', got %q", query)
+			}
+			return []*services.ReleaseListResponse{
+				{ID: 1, Title: "Nevermind", Slug: "nevermind", ReleaseType: "lp", ReleaseYear: &year},
+			}, nil
+		},
+	}
+	h := NewReleaseHandler(mock, nil, nil)
+
+	resp, err := h.SearchReleasesHandler(context.Background(), &SearchReleasesRequest{Query: "nevermind"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Count != 1 {
+		t.Errorf("expected count=1, got %d", resp.Body.Count)
+	}
+	if resp.Body.Releases[0].Title != "Nevermind" {
+		t.Errorf("expected title='Nevermind', got %q", resp.Body.Releases[0].Title)
+	}
+}
+
+func TestSearchReleases_EmptyQuery(t *testing.T) {
+	mock := &mockReleaseServiceForSearch{
+		searchReleasesFn: func(query string) ([]*services.ReleaseListResponse, error) {
+			return []*services.ReleaseListResponse{}, nil
+		},
+	}
+	h := NewReleaseHandler(mock, nil, nil)
+
+	resp, err := h.SearchReleasesHandler(context.Background(), &SearchReleasesRequest{Query: ""})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Count != 0 {
+		t.Errorf("expected count=0, got %d", resp.Body.Count)
+	}
+}
+
+func TestSearchReleases_ServiceError(t *testing.T) {
+	mock := &mockReleaseServiceForSearch{
+		searchReleasesFn: func(_ string) ([]*services.ReleaseListResponse, error) {
+			return nil, fmt.Errorf("db error")
+		},
+	}
+	h := NewReleaseHandler(mock, nil, nil)
+
+	_, err := h.SearchReleasesHandler(context.Background(), &SearchReleasesRequest{Query: "test"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+// ============================================================================
+// Tests: SearchLabelsHandler
+// ============================================================================
+
+func TestSearchLabels_Success(t *testing.T) {
+	mock := &mockLabelServiceForSearch{
+		searchLabelsFn: func(query string) ([]*services.LabelListResponse, error) {
+			if query != "sub pop" {
+				t.Errorf("expected query='sub pop', got %q", query)
+			}
+			return []*services.LabelListResponse{
+				{ID: 1, Name: "Sub Pop", Slug: "sub-pop", Status: "active"},
+			}, nil
+		},
+	}
+	h := NewLabelHandler(mock, nil)
+
+	resp, err := h.SearchLabelsHandler(context.Background(), &SearchLabelsRequest{Query: "sub pop"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Count != 1 {
+		t.Errorf("expected count=1, got %d", resp.Body.Count)
+	}
+	if resp.Body.Labels[0].Name != "Sub Pop" {
+		t.Errorf("expected name='Sub Pop', got %q", resp.Body.Labels[0].Name)
+	}
+}
+
+func TestSearchLabels_EmptyQuery(t *testing.T) {
+	mock := &mockLabelServiceForSearch{
+		searchLabelsFn: func(query string) ([]*services.LabelListResponse, error) {
+			return []*services.LabelListResponse{}, nil
+		},
+	}
+	h := NewLabelHandler(mock, nil)
+
+	resp, err := h.SearchLabelsHandler(context.Background(), &SearchLabelsRequest{Query: ""})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Count != 0 {
+		t.Errorf("expected count=0, got %d", resp.Body.Count)
+	}
+}
+
+func TestSearchLabels_ServiceError(t *testing.T) {
+	mock := &mockLabelServiceForSearch{
+		searchLabelsFn: func(_ string) ([]*services.LabelListResponse, error) {
+			return nil, fmt.Errorf("db error")
+		},
+	}
+	h := NewLabelHandler(mock, nil)
+
+	_, err := h.SearchLabelsHandler(context.Background(), &SearchLabelsRequest{Query: "test"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+// ============================================================================
+// Tests: SearchFestivalsHandler
+// ============================================================================
+
+func TestSearchFestivals_Success(t *testing.T) {
+	mock := &mockFestivalServiceForSearch{
+		searchFestivalsFn: func(query string) ([]*services.FestivalListResponse, error) {
+			if query != "m3f" {
+				t.Errorf("expected query='m3f', got %q", query)
+			}
+			return []*services.FestivalListResponse{
+				{ID: 1, Name: "M3F Festival", Slug: "m3f-2026", EditionYear: 2026, Status: "confirmed"},
+			}, nil
+		},
+	}
+	h := NewFestivalHandler(mock, nil, nil)
+
+	resp, err := h.SearchFestivalsHandler(context.Background(), &SearchFestivalsRequest{Query: "m3f"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Count != 1 {
+		t.Errorf("expected count=1, got %d", resp.Body.Count)
+	}
+	if resp.Body.Festivals[0].Name != "M3F Festival" {
+		t.Errorf("expected name='M3F Festival', got %q", resp.Body.Festivals[0].Name)
+	}
+}
+
+func TestSearchFestivals_EmptyQuery(t *testing.T) {
+	mock := &mockFestivalServiceForSearch{
+		searchFestivalsFn: func(query string) ([]*services.FestivalListResponse, error) {
+			return []*services.FestivalListResponse{}, nil
+		},
+	}
+	h := NewFestivalHandler(mock, nil, nil)
+
+	resp, err := h.SearchFestivalsHandler(context.Background(), &SearchFestivalsRequest{Query: ""})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Count != 0 {
+		t.Errorf("expected count=0, got %d", resp.Body.Count)
+	}
+}
+
+func TestSearchFestivals_ServiceError(t *testing.T) {
+	mock := &mockFestivalServiceForSearch{
+		searchFestivalsFn: func(_ string) ([]*services.FestivalListResponse, error) {
+			return nil, fmt.Errorf("db error")
+		},
+	}
+	h := NewFestivalHandler(mock, nil, nil)
+
+	_, err := h.SearchFestivalsHandler(context.Background(), &SearchFestivalsRequest{Query: "test"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -304,7 +304,9 @@ func setupReleaseRoutes(api huma.API, protected *huma.Group, sc *services.Servic
 	releaseHandler := handlers.NewReleaseHandler(sc.Release, sc.Artist, sc.AuditLog)
 
 	// Public release endpoints
+	// Note: Static routes must come before parameterized routes
 	huma.Get(api, "/releases", releaseHandler.ListReleasesHandler)
+	huma.Get(api, "/releases/search", releaseHandler.SearchReleasesHandler)
 	huma.Get(api, "/releases/{release_id}", releaseHandler.GetReleaseHandler)
 	huma.Get(api, "/artists/{artist_id}/releases", releaseHandler.GetArtistReleasesHandler)
 
@@ -320,7 +322,9 @@ func setupLabelRoutes(api huma.API, protected *huma.Group, sc *services.ServiceC
 	labelHandler := handlers.NewLabelHandler(sc.Label, sc.AuditLog)
 
 	// Public label endpoints
+	// Note: Static routes must come before parameterized routes
 	huma.Get(api, "/labels", labelHandler.ListLabelsHandler)
+	huma.Get(api, "/labels/search", labelHandler.SearchLabelsHandler)
 	huma.Get(api, "/labels/{label_id}", labelHandler.GetLabelHandler)
 	huma.Get(api, "/labels/{label_id}/artists", labelHandler.GetLabelRosterHandler)
 	huma.Get(api, "/labels/{label_id}/releases", labelHandler.GetLabelCatalogHandler)
@@ -335,7 +339,9 @@ func setupFestivalRoutes(api huma.API, protected *huma.Group, sc *services.Servi
 	festivalHandler := handlers.NewFestivalHandler(sc.Festival, sc.Artist, sc.AuditLog)
 
 	// Public festival endpoints
+	// Note: Static routes must come before parameterized routes
 	huma.Get(api, "/festivals", festivalHandler.ListFestivalsHandler)
+	huma.Get(api, "/festivals/search", festivalHandler.SearchFestivalsHandler)
 	huma.Get(api, "/festivals/{festival_id}", festivalHandler.GetFestivalHandler)
 	huma.Get(api, "/festivals/{festival_id}/artists", festivalHandler.GetFestivalArtistsHandler)
 	huma.Get(api, "/festivals/{festival_id}/venues", festivalHandler.GetFestivalVenuesHandler)

--- a/backend/internal/services/catalog/festival.go
+++ b/backend/internal/services/catalog/festival.go
@@ -203,6 +203,100 @@ func (s *FestivalService) ListFestivals(filters map[string]interface{}) ([]*cont
 	return responses, nil
 }
 
+// SearchFestivals searches for festivals by name using ILIKE matching
+func (s *FestivalService) SearchFestivals(query string) ([]*contracts.FestivalListResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	// Return empty results for empty query
+	if query == "" {
+		return []*contracts.FestivalListResponse{}, nil
+	}
+
+	var festivals []models.Festival
+	var err error
+
+	if len(query) <= 2 {
+		// For short queries: prefix match
+		err = s.db.
+			Where("LOWER(name) LIKE LOWER(?)", query+"%").
+			Order("name ASC").
+			Limit(20).
+			Find(&festivals).Error
+	} else {
+		// For longer queries: ILIKE substring match, ordered by name
+		err = s.db.
+			Where("name ILIKE ?", "%"+query+"%").
+			Order("name ASC").
+			Limit(20).
+			Find(&festivals).Error
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to search festivals: %w", err)
+	}
+
+	// Batch-load artist counts and venue counts
+	festivalIDs := make([]uint, len(festivals))
+	for i, f := range festivals {
+		festivalIDs[i] = f.ID
+	}
+
+	artistCounts := make(map[uint]int)
+	venueCounts := make(map[uint]int)
+
+	if len(festivalIDs) > 0 {
+		type CountResult struct {
+			FestivalID uint
+			Count      int
+		}
+
+		// Artist counts
+		var aCounts []CountResult
+		s.db.Table("festival_artists").
+			Select("festival_id, COUNT(DISTINCT artist_id) as count").
+			Where("festival_id IN ?", festivalIDs).
+			Group("festival_id").
+			Find(&aCounts)
+		for _, c := range aCounts {
+			artistCounts[c.FestivalID] = c.Count
+		}
+
+		// Venue counts
+		var vCounts []CountResult
+		s.db.Table("festival_venues").
+			Select("festival_id, COUNT(DISTINCT venue_id) as count").
+			Where("festival_id IN ?", festivalIDs).
+			Group("festival_id").
+			Find(&vCounts)
+		for _, c := range vCounts {
+			venueCounts[c.FestivalID] = c.Count
+		}
+	}
+
+	// Build responses
+	responses := make([]*contracts.FestivalListResponse, len(festivals))
+	for i, festival := range festivals {
+		responses[i] = &contracts.FestivalListResponse{
+			ID:          festival.ID,
+			Name:        festival.Name,
+			Slug:        festival.Slug,
+			SeriesSlug:  festival.SeriesSlug,
+			EditionYear: festival.EditionYear,
+			City:        festival.City,
+			State:       festival.State,
+			StartDate:   formatDateString(festival.StartDate),
+			EndDate:     formatDateString(festival.EndDate),
+			Status:      string(festival.Status),
+			ArtistCount: artistCounts[festival.ID],
+			VenueCount:  venueCounts[festival.ID],
+		}
+	}
+
+	return responses, nil
+}
+
 // UpdateFestival updates an existing festival
 func (s *FestivalService) UpdateFestival(festivalID uint, req *contracts.UpdateFestivalRequest) (*contracts.FestivalDetailResponse, error) {
 	if s.db == nil {

--- a/backend/internal/services/catalog/label.go
+++ b/backend/internal/services/catalog/label.go
@@ -200,6 +200,100 @@ func (s *LabelService) ListLabels(filters map[string]interface{}) ([]*contracts.
 	return responses, nil
 }
 
+// SearchLabels searches for labels by name using ILIKE matching
+func (s *LabelService) SearchLabels(query string) ([]*contracts.LabelListResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	// Return empty results for empty query
+	if query == "" {
+		return []*contracts.LabelListResponse{}, nil
+	}
+
+	var labels []models.Label
+	var err error
+
+	if len(query) <= 2 {
+		// For short queries: prefix match
+		err = s.db.
+			Where("LOWER(name) LIKE LOWER(?)", query+"%").
+			Order("name ASC").
+			Limit(20).
+			Find(&labels).Error
+	} else {
+		// For longer queries: ILIKE substring match, ordered by name
+		err = s.db.
+			Where("name ILIKE ?", "%"+query+"%").
+			Order("name ASC").
+			Limit(20).
+			Find(&labels).Error
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to search labels: %w", err)
+	}
+
+	// Batch-load artist counts and release counts
+	labelIDs := make([]uint, len(labels))
+	for i, l := range labels {
+		labelIDs[i] = l.ID
+	}
+
+	artistCounts := make(map[uint]int)
+	releaseCounts := make(map[uint]int)
+
+	if len(labelIDs) > 0 {
+		type CountResult struct {
+			LabelID uint
+			Count   int
+		}
+
+		// Artist counts
+		var aCounts []CountResult
+		s.db.Table("artist_labels").
+			Select("label_id, COUNT(DISTINCT artist_id) as count").
+			Where("label_id IN ?", labelIDs).
+			Group("label_id").
+			Find(&aCounts)
+		for _, c := range aCounts {
+			artistCounts[c.LabelID] = c.Count
+		}
+
+		// Release counts
+		var rCounts []CountResult
+		s.db.Table("release_labels").
+			Select("label_id, COUNT(DISTINCT release_id) as count").
+			Where("label_id IN ?", labelIDs).
+			Group("label_id").
+			Find(&rCounts)
+		for _, c := range rCounts {
+			releaseCounts[c.LabelID] = c.Count
+		}
+	}
+
+	// Build responses
+	responses := make([]*contracts.LabelListResponse, len(labels))
+	for i, label := range labels {
+		slug := ""
+		if label.Slug != nil {
+			slug = *label.Slug
+		}
+		responses[i] = &contracts.LabelListResponse{
+			ID:           label.ID,
+			Name:         label.Name,
+			Slug:         slug,
+			City:         label.City,
+			State:        label.State,
+			Status:       string(label.Status),
+			ArtistCount:  artistCounts[label.ID],
+			ReleaseCount: releaseCounts[label.ID],
+		}
+	}
+
+	return responses, nil
+}
+
 // UpdateLabel updates an existing label
 func (s *LabelService) UpdateLabel(labelID uint, req *contracts.UpdateLabelRequest) (*contracts.LabelDetailResponse, error) {
 	if s.db == nil {

--- a/backend/internal/services/catalog/release.go
+++ b/backend/internal/services/catalog/release.go
@@ -212,6 +212,84 @@ func (s *ReleaseService) ListReleases(filters map[string]interface{}) ([]*contra
 	return responses, nil
 }
 
+// SearchReleases searches for releases by title using ILIKE matching
+func (s *ReleaseService) SearchReleases(query string) ([]*contracts.ReleaseListResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	// Return empty results for empty query
+	if query == "" {
+		return []*contracts.ReleaseListResponse{}, nil
+	}
+
+	var releases []models.Release
+	var err error
+
+	if len(query) <= 2 {
+		// For short queries: prefix match
+		err = s.db.
+			Where("LOWER(title) LIKE LOWER(?)", query+"%").
+			Order("title ASC").
+			Limit(20).
+			Find(&releases).Error
+	} else {
+		// For longer queries: ILIKE substring match, ordered by title
+		err = s.db.
+			Where("title ILIKE ?", "%"+query+"%").
+			Order("title ASC").
+			Limit(20).
+			Find(&releases).Error
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to search releases: %w", err)
+	}
+
+	// Batch-load artist counts
+	releaseIDs := make([]uint, len(releases))
+	for i, r := range releases {
+		releaseIDs[i] = r.ID
+	}
+
+	artistCounts := make(map[uint]int)
+	if len(releaseIDs) > 0 {
+		type CountResult struct {
+			ReleaseID uint
+			Count     int
+		}
+		var counts []CountResult
+		s.db.Table("artist_releases").
+			Select("release_id, COUNT(DISTINCT artist_id) as count").
+			Where("release_id IN ?", releaseIDs).
+			Group("release_id").
+			Find(&counts)
+		for _, c := range counts {
+			artistCounts[c.ReleaseID] = c.Count
+		}
+	}
+
+	// Build responses
+	responses := make([]*contracts.ReleaseListResponse, len(releases))
+	for i, release := range releases {
+		slug := ""
+		if release.Slug != nil {
+			slug = *release.Slug
+		}
+		responses[i] = &contracts.ReleaseListResponse{
+			ID:          release.ID,
+			Title:       release.Title,
+			Slug:        slug,
+			ReleaseType: string(release.ReleaseType),
+			ReleaseYear: release.ReleaseYear,
+			CoverArtURL: release.CoverArtURL,
+			ArtistCount: artistCounts[release.ID],
+		}
+	}
+
+	return responses, nil
+}
+
 // UpdateRelease updates an existing release
 func (s *ReleaseService) UpdateRelease(releaseID uint, req *contracts.UpdateReleaseRequest) (*contracts.ReleaseDetailResponse, error) {
 	if s.db == nil {

--- a/backend/internal/services/contracts/interfaces.go
+++ b/backend/internal/services/contracts/interfaces.go
@@ -326,6 +326,7 @@ type LabelServiceInterface interface {
 	GetLabel(labelID uint) (*LabelDetailResponse, error)
 	GetLabelBySlug(slug string) (*LabelDetailResponse, error)
 	ListLabels(filters map[string]interface{}) ([]*LabelListResponse, error)
+	SearchLabels(query string) ([]*LabelListResponse, error)
 	UpdateLabel(labelID uint, req *UpdateLabelRequest) (*LabelDetailResponse, error)
 	DeleteLabel(labelID uint) error
 	GetLabelRoster(labelID uint) ([]*LabelArtistResponse, error)
@@ -338,6 +339,7 @@ type FestivalServiceInterface interface {
 	GetFestival(festivalID uint) (*FestivalDetailResponse, error)
 	GetFestivalBySlug(slug string) (*FestivalDetailResponse, error)
 	ListFestivals(filters map[string]interface{}) ([]*FestivalListResponse, error)
+	SearchFestivals(query string) ([]*FestivalListResponse, error)
 	UpdateFestival(festivalID uint, req *UpdateFestivalRequest) (*FestivalDetailResponse, error)
 	DeleteFestival(festivalID uint) error
 	GetFestivalArtists(festivalID uint, dayDate *string) ([]*FestivalArtistResponse, error)
@@ -356,6 +358,7 @@ type ReleaseServiceInterface interface {
 	GetRelease(releaseID uint) (*ReleaseDetailResponse, error)
 	GetReleaseBySlug(slug string) (*ReleaseDetailResponse, error)
 	ListReleases(filters map[string]interface{}) ([]*ReleaseListResponse, error)
+	SearchReleases(query string) ([]*ReleaseListResponse, error)
 	UpdateRelease(releaseID uint, req *UpdateReleaseRequest) (*ReleaseDetailResponse, error)
 	DeleteRelease(releaseID uint) error
 	GetReleasesForArtist(artistID uint) ([]*ReleaseListResponse, error)


### PR DESCRIPTION
## Summary
- Add `GET /releases/search?q=`, `GET /labels/search?q=`, `GET /festivals/search?q=` public endpoints
- ILIKE queries with prefix match optimization for short queries, substring for longer
- Added `SearchReleases`, `SearchLabels`, `SearchFestivals` to service interfaces in contracts
- 9 handler unit tests (3 per entity: success, empty query, service error)
- Part of PH CLI project — enables duplicate detection in `ph submit` commands ([#127](https://github.com/mtrifilo/psychic-homily-web/pull/127))

## Test plan
- [x] Each endpoint returns matching results for valid queries
- [x] Empty query returns empty results
- [x] Service errors propagate correctly
- [x] Routes registered before parameterized `{id}` routes
- [x] All existing tests pass

Closes PSY-140

🤖 Generated with [Claude Code](https://claude.com/claude-code)