### PR TITLE
Add duplicate detection engine and entity validation for PH CLI

### DIFF
--- a/cli/src/lib/duplicates.ts
+++ b/cli/src/lib/duplicates.ts
@@ -1,0 +1,500 @@
+import type { APIClient } from "./api";
+import type { EntityType } from "./types";
+
+export type MatchResult = "exact" | "fuzzy" | "none";
+export type ActionType = "create" | "update" | "skip";
+
+export interface FieldComparison {
+  field: string;
+  existing: string;
+  proposed: string;
+  status: "new_info" | "already_set" | "unchanged";
+}
+
+export interface DuplicateCheckResult {
+  action: ActionType;
+  match: MatchResult;
+  existingId?: number;
+  existingSlug?: string;
+  existingName?: string;
+  fields: FieldComparison[];
+  confidence: number;
+}
+
+export interface EntitySearchResult {
+  id: number;
+  name: string;
+  slug: string;
+  [key: string]: unknown;
+}
+
+/** Normalize a string for comparison: lowercase, trim, collapse whitespace, strip accents. */
+export function normalizeForComparison(s: string): string {
+  return s
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "") // strip combining diacritical marks
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, " ");
+}
+
+/** Simple similarity score between two strings (0-1). Uses normalized comparison. */
+export function similarityScore(a: string, b: string): number {
+  const na = normalizeForComparison(a);
+  const nb = normalizeForComparison(b);
+
+  if (na === nb) return 1.0;
+  if (na.length === 0 || nb.length === 0) return 0;
+
+  // One contains the other
+  const longer = na.length >= nb.length ? na : nb;
+  const shorter = na.length < nb.length ? na : nb;
+
+  if (longer.includes(shorter)) {
+    // Scale by how much of the longer string the shorter covers
+    return 0.8 + 0.2 * (shorter.length / longer.length);
+  }
+
+  // Common prefix scoring
+  let commonPrefix = 0;
+  const minLen = Math.min(na.length, nb.length);
+  for (let i = 0; i < minLen; i++) {
+    if (na[i] === nb[i]) {
+      commonPrefix++;
+    } else {
+      break;
+    }
+  }
+
+  // Common suffix scoring
+  let commonSuffix = 0;
+  for (let i = 0; i < minLen - commonPrefix; i++) {
+    if (na[na.length - 1 - i] === nb[nb.length - 1 - i]) {
+      commonSuffix++;
+    } else {
+      break;
+    }
+  }
+
+  const totalOverlap = commonPrefix + commonSuffix;
+  const maxLen = Math.max(na.length, nb.length);
+
+  return totalOverlap / maxLen;
+}
+
+/** Compare fields between an existing entity and a proposed entity. */
+export function compareFields(
+  existing: Record<string, unknown>,
+  proposed: Record<string, unknown>,
+  fieldNames: string[],
+): FieldComparison[] {
+  const comparisons: FieldComparison[] = [];
+
+  for (const field of fieldNames) {
+    const proposedVal = proposed[field];
+
+    // Skip fields not present or empty in the proposed data
+    if (proposedVal === undefined || proposedVal === null || proposedVal === "") {
+      continue;
+    }
+
+    const existingVal = existing[field];
+    const existingStr = existingVal != null ? String(existingVal) : "";
+    const proposedStr = String(proposedVal);
+
+    let status: FieldComparison["status"];
+
+    if (!existingStr && proposedStr) {
+      status = "new_info";
+    } else if (existingStr === proposedStr) {
+      status = "unchanged";
+    } else {
+      status = "already_set";
+    }
+
+    comparisons.push({
+      field,
+      existing: existingStr,
+      proposed: proposedStr,
+      status,
+    });
+  }
+
+  return comparisons;
+}
+
+/** Classify the action based on match confidence and field comparisons. */
+export function classifyAction(
+  confidence: number,
+  fields: FieldComparison[],
+): ActionType {
+  if (confidence < 0.6) return "create";
+
+  const hasNewInfo = fields.some((f) => f.status === "new_info");
+  return hasNewInfo ? "update" : "skip";
+}
+
+/** Classify the match result based on confidence. */
+export function classifyMatch(confidence: number): MatchResult {
+  if (confidence >= 1.0) return "exact";
+  if (confidence >= 0.6) return "fuzzy";
+  return "none";
+}
+
+// -- Entity-specific field lists for comparison --
+
+const ARTIST_FIELDS = [
+  "name", "city", "state", "country", "website", "bandcamp_url",
+  "spotify_url", "instagram_url", "description",
+];
+
+const VENUE_FIELDS = [
+  "name", "city", "state", "country", "address", "zip_code",
+  "website", "capacity", "description",
+];
+
+const RELEASE_FIELDS = [
+  "title", "release_type", "release_year", "release_date",
+  "bandcamp_url", "spotify_url", "description",
+];
+
+const LABEL_FIELDS = [
+  "name", "city", "state", "country", "website", "description",
+  "bandcamp_url",
+];
+
+const FESTIVAL_FIELDS = [
+  "name", "series_slug", "edition_year", "start_date", "end_date",
+  "city", "state", "country", "website", "description",
+];
+
+/** Get the comparable fields for a given entity type. */
+function getFieldsForType(entityType: EntityType): string[] {
+  switch (entityType) {
+    case "artist": return ARTIST_FIELDS;
+    case "venue": return VENUE_FIELDS;
+    case "release": return RELEASE_FIELDS;
+    case "label": return LABEL_FIELDS;
+    case "festival": return FESTIVAL_FIELDS;
+    case "show": return [];
+  }
+}
+
+/** Get the display name field from a proposed entity. */
+function getEntityName(entityType: EntityType, proposed: Record<string, unknown>): string {
+  if (entityType === "release") {
+    return String(proposed.title || "");
+  }
+  return String(proposed.name || "");
+}
+
+// -- Entity-specific search functions --
+
+async function searchArtists(
+  client: APIClient,
+  name: string,
+): Promise<EntitySearchResult[]> {
+  const result = await client.get<{
+    artists: Array<{
+      id: number;
+      name: string;
+      slug: string;
+      city?: string;
+      state?: string;
+      country?: string;
+      website?: string;
+      bandcamp_url?: string;
+      spotify_url?: string;
+      instagram_url?: string;
+      description?: string;
+    }>;
+  }>("/artists/search", { q: name });
+
+  return (result.artists || []).map((a) => ({
+    id: a.id,
+    name: a.name,
+    slug: a.slug,
+    city: a.city || "",
+    state: a.state || "",
+    country: a.country || "",
+    website: a.website || "",
+    bandcamp_url: a.bandcamp_url || "",
+    spotify_url: a.spotify_url || "",
+    instagram_url: a.instagram_url || "",
+    description: a.description || "",
+  }));
+}
+
+async function searchVenues(
+  client: APIClient,
+  name: string,
+): Promise<EntitySearchResult[]> {
+  const result = await client.get<{
+    venues: Array<{
+      id: number;
+      name: string;
+      slug: string;
+      city: string;
+      state: string;
+      country?: string;
+      address?: string;
+      zip_code?: string;
+      website?: string;
+      capacity?: number;
+      description?: string;
+    }>;
+  }>("/venues/search", { q: name });
+
+  return (result.venues || []).map((v) => ({
+    id: v.id,
+    name: v.name,
+    slug: v.slug,
+    city: v.city,
+    state: v.state,
+    country: v.country || "",
+    address: v.address || "",
+    zip_code: v.zip_code || "",
+    website: v.website || "",
+    capacity: v.capacity ? String(v.capacity) : "",
+    description: v.description || "",
+  }));
+}
+
+async function searchReleases(
+  client: APIClient,
+  title: string,
+): Promise<EntitySearchResult[]> {
+  // Client-side filter until backend search endpoint exists
+  const result = await client.get<{
+    releases: Array<{
+      id: number;
+      title: string;
+      slug: string;
+      release_type?: string;
+      release_year?: number;
+      release_date?: string;
+      bandcamp_url?: string;
+      spotify_url?: string;
+      description?: string;
+    }>;
+  }>("/releases", {});
+
+  const normalizedTitle = normalizeForComparison(title);
+  return (result.releases || [])
+    .filter((r) => normalizeForComparison(r.title).includes(normalizedTitle) ||
+      normalizedTitle.includes(normalizeForComparison(r.title)))
+    .map((r) => ({
+      id: r.id,
+      name: r.title,
+      slug: r.slug,
+      title: r.title,
+      release_type: r.release_type || "",
+      release_year: r.release_year ? String(r.release_year) : "",
+      release_date: r.release_date || "",
+      bandcamp_url: r.bandcamp_url || "",
+      spotify_url: r.spotify_url || "",
+      description: r.description || "",
+    }));
+}
+
+async function searchLabels(
+  client: APIClient,
+  name: string,
+): Promise<EntitySearchResult[]> {
+  // Client-side filter until backend search endpoint exists
+  const result = await client.get<{
+    labels: Array<{
+      id: number;
+      name: string;
+      slug: string;
+      city?: string;
+      state?: string;
+      country?: string;
+      website?: string;
+      description?: string;
+      bandcamp_url?: string;
+    }>;
+  }>("/labels", {});
+
+  const normalizedName = normalizeForComparison(name);
+  return (result.labels || [])
+    .filter((l) => normalizeForComparison(l.name).includes(normalizedName) ||
+      normalizedName.includes(normalizeForComparison(l.name)))
+    .map((l) => ({
+      id: l.id,
+      name: l.name,
+      slug: l.slug,
+      city: l.city || "",
+      state: l.state || "",
+      country: l.country || "",
+      website: l.website || "",
+      description: l.description || "",
+      bandcamp_url: l.bandcamp_url || "",
+    }));
+}
+
+async function searchFestivals(
+  client: APIClient,
+  name: string,
+): Promise<EntitySearchResult[]> {
+  // Client-side filter until backend search endpoint exists
+  const result = await client.get<{
+    festivals: Array<{
+      id: number;
+      name: string;
+      slug: string;
+      series_slug?: string;
+      edition_year?: number;
+      start_date?: string;
+      end_date?: string;
+      city?: string;
+      state?: string;
+      country?: string;
+      website?: string;
+      description?: string;
+    }>;
+  }>("/festivals", {});
+
+  const normalizedName = normalizeForComparison(name);
+  return (result.festivals || [])
+    .filter((f) => normalizeForComparison(f.name).includes(normalizedName) ||
+      normalizedName.includes(normalizeForComparison(f.name)))
+    .map((f) => ({
+      id: f.id,
+      name: f.name,
+      slug: f.slug,
+      series_slug: f.series_slug || "",
+      edition_year: f.edition_year ? String(f.edition_year) : "",
+      start_date: f.start_date || "",
+      end_date: f.end_date || "",
+      city: f.city || "",
+      state: f.state || "",
+      country: f.country || "",
+      website: f.website || "",
+      description: f.description || "",
+    }));
+}
+
+/** Find the best matching entity from search results. */
+function findBestMatch(
+  entityType: EntityType,
+  proposed: Record<string, unknown>,
+  results: EntitySearchResult[],
+): { entity: EntitySearchResult; confidence: number } | null {
+  if (results.length === 0) return null;
+
+  const proposedName = getEntityName(entityType, proposed);
+  if (!proposedName) return null;
+
+  let bestMatch: EntitySearchResult | null = null;
+  let bestScore = 0;
+
+  for (const result of results) {
+    let score = similarityScore(proposedName, result.name);
+
+    // Boost score for venue matches when city also matches
+    if (entityType === "venue" && proposed.city && result.city) {
+      const cityScore = similarityScore(
+        String(proposed.city),
+        String(result.city),
+      );
+      if (cityScore >= 0.8) {
+        score = Math.min(1.0, score + 0.1);
+      }
+    }
+
+    // Boost score for festival matches when edition year matches
+    if (entityType === "festival" && proposed.edition_year && result.edition_year) {
+      if (String(proposed.edition_year) === String(result.edition_year)) {
+        score = Math.min(1.0, score + 0.1);
+      }
+    }
+
+    if (score > bestScore) {
+      bestScore = score;
+      bestMatch = result;
+    }
+  }
+
+  if (!bestMatch || bestScore < 0.6) return null;
+
+  return { entity: bestMatch, confidence: bestScore };
+}
+
+/**
+ * Check for duplicates by searching the API and comparing with the proposed entity.
+ *
+ * For each entity type:
+ * 1. Extracts the name/title from the proposed entity
+ * 2. Calls the appropriate search endpoint via the API client
+ * 3. Fuzzy-matches results against the proposed entity
+ * 4. If a match is found, compares all fields to classify the action
+ */
+export async function checkDuplicate(
+  client: APIClient,
+  entityType: EntityType,
+  proposed: Record<string, unknown>,
+): Promise<DuplicateCheckResult> {
+  const noMatch: DuplicateCheckResult = {
+    action: "create",
+    match: "none",
+    fields: [],
+    confidence: 0,
+  };
+
+  // Shows use a simpler date+venue match — not implemented in v1
+  if (entityType === "show") {
+    return noMatch;
+  }
+
+  const name = getEntityName(entityType, proposed);
+  if (!name) return noMatch;
+
+  let results: EntitySearchResult[];
+  try {
+    switch (entityType) {
+      case "artist":
+        results = await searchArtists(client, name);
+        break;
+      case "venue":
+        results = await searchVenues(client, name);
+        break;
+      case "release":
+        results = await searchReleases(client, name);
+        break;
+      case "label":
+        results = await searchLabels(client, name);
+        break;
+      case "festival":
+        results = await searchFestivals(client, name);
+        break;
+      default:
+        return noMatch;
+    }
+  } catch {
+    // If search fails, default to create
+    return noMatch;
+  }
+
+  const best = findBestMatch(entityType, proposed, results);
+  if (!best) return noMatch;
+
+  const fields = compareFields(
+    best.entity as unknown as Record<string, unknown>,
+    proposed,
+    getFieldsForType(entityType),
+  );
+
+  const action = classifyAction(best.confidence, fields);
+  const match = classifyMatch(best.confidence);
+
+  return {
+    action,
+    match,
+    existingId: best.entity.id,
+    existingSlug: best.entity.slug,
+    existingName: best.entity.name,
+    fields,
+    confidence: best.confidence,
+  };
+}

--- a/cli/src/lib/schemas.ts
+++ b/cli/src/lib/schemas.ts
@@ -1,0 +1,163 @@
+import type { EntityType } from "./types";
+
+export interface ValidationError {
+  field: string;
+  message: string;
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: ValidationError[];
+}
+
+function isNonEmptyString(value: unknown): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isNonEmptyArray(value: unknown): boolean {
+  return Array.isArray(value) && value.length > 0;
+}
+
+function requireField(
+  data: Record<string, unknown>,
+  field: string,
+  errors: ValidationError[],
+  message?: string,
+): void {
+  if (!isNonEmptyString(data[field])) {
+    errors.push({
+      field,
+      message: message || `${field} is required`,
+    });
+  }
+}
+
+/** Validate artist data. Required: name. */
+export function validateArtist(data: unknown): ValidationResult {
+  const errors: ValidationError[] = [];
+
+  if (!data || typeof data !== "object") {
+    return { valid: false, errors: [{ field: "_root", message: "Data must be an object" }] };
+  }
+
+  const d = data as Record<string, unknown>;
+  requireField(d, "name", errors);
+
+  return { valid: errors.length === 0, errors };
+}
+
+/** Validate venue data. Required: name, city, state. */
+export function validateVenue(data: unknown): ValidationResult {
+  const errors: ValidationError[] = [];
+
+  if (!data || typeof data !== "object") {
+    return { valid: false, errors: [{ field: "_root", message: "Data must be an object" }] };
+  }
+
+  const d = data as Record<string, unknown>;
+  requireField(d, "name", errors);
+  requireField(d, "city", errors);
+  requireField(d, "state", errors);
+
+  return { valid: errors.length === 0, errors };
+}
+
+/** Validate show data. Required: event_date, city, state, at least 1 artist and 1 venue. */
+export function validateShow(data: unknown): ValidationResult {
+  const errors: ValidationError[] = [];
+
+  if (!data || typeof data !== "object") {
+    return { valid: false, errors: [{ field: "_root", message: "Data must be an object" }] };
+  }
+
+  const d = data as Record<string, unknown>;
+  requireField(d, "event_date", errors);
+  requireField(d, "city", errors);
+  requireField(d, "state", errors);
+
+  if (!isNonEmptyArray(d.artists)) {
+    errors.push({ field: "artists", message: "At least one artist is required" });
+  }
+
+  if (!isNonEmptyArray(d.venues)) {
+    errors.push({ field: "venues", message: "At least one venue is required" });
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+/** Validate release data. Required: title, at least 1 artist. */
+export function validateRelease(data: unknown): ValidationResult {
+  const errors: ValidationError[] = [];
+
+  if (!data || typeof data !== "object") {
+    return { valid: false, errors: [{ field: "_root", message: "Data must be an object" }] };
+  }
+
+  const d = data as Record<string, unknown>;
+  requireField(d, "title", errors);
+
+  if (!isNonEmptyArray(d.artists)) {
+    errors.push({ field: "artists", message: "At least one artist is required" });
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+/** Validate label data. Required: name. */
+export function validateLabel(data: unknown): ValidationResult {
+  const errors: ValidationError[] = [];
+
+  if (!data || typeof data !== "object") {
+    return { valid: false, errors: [{ field: "_root", message: "Data must be an object" }] };
+  }
+
+  const d = data as Record<string, unknown>;
+  requireField(d, "name", errors);
+
+  return { valid: errors.length === 0, errors };
+}
+
+/** Validate festival data. Required: name, series_slug, edition_year, start_date, end_date. */
+export function validateFestival(data: unknown): ValidationResult {
+  const errors: ValidationError[] = [];
+
+  if (!data || typeof data !== "object") {
+    return { valid: false, errors: [{ field: "_root", message: "Data must be an object" }] };
+  }
+
+  const d = data as Record<string, unknown>;
+  requireField(d, "name", errors);
+  requireField(d, "series_slug", errors);
+
+  if (d.edition_year === undefined || d.edition_year === null || d.edition_year === "") {
+    errors.push({ field: "edition_year", message: "edition_year is required" });
+  }
+
+  requireField(d, "start_date", errors);
+  requireField(d, "end_date", errors);
+
+  return { valid: errors.length === 0, errors };
+}
+
+/** Validate any entity by type. */
+export function validateEntity(entityType: EntityType, data: unknown): ValidationResult {
+  switch (entityType) {
+    case "artist":
+      return validateArtist(data);
+    case "venue":
+      return validateVenue(data);
+    case "show":
+      return validateShow(data);
+    case "release":
+      return validateRelease(data);
+    case "label":
+      return validateLabel(data);
+    case "festival":
+      return validateFestival(data);
+    default: {
+      const _exhaustive: never = entityType;
+      return { valid: false, errors: [{ field: "_root", message: `Unknown entity type: ${_exhaustive}` }] };
+    }
+  }
+}

--- a/cli/test/duplicates.test.ts
+++ b/cli/test/duplicates.test.ts
@@ -1,0 +1,256 @@
+import { describe, test, expect } from "bun:test";
+import {
+  normalizeForComparison,
+  similarityScore,
+  compareFields,
+  classifyAction,
+  classifyMatch,
+} from "../src/lib/duplicates";
+
+describe("normalizeForComparison", () => {
+  test("lowercases text", () => {
+    expect(normalizeForComparison("Hello World")).toBe("hello world");
+  });
+
+  test("trims whitespace", () => {
+    expect(normalizeForComparison("  hello  ")).toBe("hello");
+  });
+
+  test("collapses multiple spaces", () => {
+    expect(normalizeForComparison("hello    world")).toBe("hello world");
+  });
+
+  test("collapses tabs and newlines into single space", () => {
+    expect(normalizeForComparison("hello\t\n  world")).toBe("hello world");
+  });
+
+  test("strips accents/diacritics", () => {
+    expect(normalizeForComparison("Motörhead")).toBe("motorhead");
+    expect(normalizeForComparison("café")).toBe("cafe");
+    expect(normalizeForComparison("naïve")).toBe("naive");
+    expect(normalizeForComparison("résumé")).toBe("resume");
+  });
+
+  test("handles empty string", () => {
+    expect(normalizeForComparison("")).toBe("");
+  });
+
+  test("handles already normalized string", () => {
+    expect(normalizeForComparison("already clean")).toBe("already clean");
+  });
+
+  test("handles combined transformations", () => {
+    expect(normalizeForComparison("  Beyoncé   Knowles  ")).toBe("beyonce knowles");
+  });
+});
+
+describe("similarityScore", () => {
+  test("exact match returns 1.0", () => {
+    expect(similarityScore("Radiohead", "radiohead")).toBe(1.0);
+  });
+
+  test("exact match after normalization returns 1.0", () => {
+    expect(similarityScore("  The  Beatles  ", "the beatles")).toBe(1.0);
+  });
+
+  test("exact match with accents returns 1.0", () => {
+    expect(similarityScore("Motörhead", "Motorhead")).toBe(1.0);
+  });
+
+  test("substring match returns > 0.6", () => {
+    const score = similarityScore("The National", "National");
+    expect(score).toBeGreaterThan(0.6);
+  });
+
+  test("contained string returns > 0.8", () => {
+    const score = similarityScore("National", "The National");
+    expect(score).toBeGreaterThan(0.8);
+  });
+
+  test("completely different strings return < 0.3", () => {
+    const score = similarityScore("Radiohead", "Beyonce");
+    expect(score).toBeLessThan(0.3);
+  });
+
+  test("empty string against non-empty returns 0", () => {
+    expect(similarityScore("", "something")).toBe(0);
+    expect(similarityScore("something", "")).toBe(0);
+  });
+
+  test("both empty strings return 1.0", () => {
+    expect(similarityScore("", "")).toBe(1.0);
+  });
+
+  test("common prefix boosts score", () => {
+    const score = similarityScore("Radiohead", "Radiograph");
+    // Shares "Radio" prefix (5/10)
+    expect(score).toBeGreaterThan(0.3);
+  });
+
+  test("very similar names score high", () => {
+    // "the shins" vs "the shin" — one character difference, common prefix + suffix
+    const score = similarityScore("The Shins", "The Shin");
+    expect(score).toBeGreaterThan(0.6);
+  });
+});
+
+describe("compareFields", () => {
+  test("detects new_info when existing is empty", () => {
+    const result = compareFields(
+      { name: "Test", city: "" },
+      { name: "Test", city: "Phoenix" },
+      ["name", "city"],
+    );
+
+    const cityField = result.find((f) => f.field === "city");
+    expect(cityField).toBeDefined();
+    expect(cityField!.status).toBe("new_info");
+    expect(cityField!.existing).toBe("");
+    expect(cityField!.proposed).toBe("Phoenix");
+  });
+
+  test("detects unchanged when values match", () => {
+    const result = compareFields(
+      { name: "Test" },
+      { name: "Test" },
+      ["name"],
+    );
+
+    expect(result[0].status).toBe("unchanged");
+  });
+
+  test("detects already_set when existing has different value", () => {
+    const result = compareFields(
+      { city: "Phoenix" },
+      { city: "Tempe" },
+      ["city"],
+    );
+
+    expect(result[0].status).toBe("already_set");
+    expect(result[0].existing).toBe("Phoenix");
+    expect(result[0].proposed).toBe("Tempe");
+  });
+
+  test("skips fields not in proposed data", () => {
+    const result = compareFields(
+      { name: "Test", city: "Phoenix" },
+      { name: "Test" },
+      ["name", "city"],
+    );
+
+    // Only name should be in results since city is missing from proposed
+    expect(result.length).toBe(1);
+    expect(result[0].field).toBe("name");
+  });
+
+  test("skips fields with null or undefined proposed values", () => {
+    const result = compareFields(
+      { name: "Test", city: "Phoenix" },
+      { name: "Test", city: null },
+      ["name", "city"],
+    );
+
+    expect(result.length).toBe(1);
+    expect(result[0].field).toBe("name");
+  });
+
+  test("skips fields with empty string proposed values", () => {
+    const result = compareFields(
+      { name: "Test", city: "Phoenix" },
+      { name: "Test", city: "" },
+      ["name", "city"],
+    );
+
+    expect(result.length).toBe(1);
+  });
+
+  test("handles multiple fields with mixed statuses", () => {
+    const result = compareFields(
+      { name: "Test", city: "", state: "AZ", website: "https://old.com" },
+      { name: "Test", city: "Phoenix", state: "AZ", website: "https://new.com" },
+      ["name", "city", "state", "website"],
+    );
+
+    const statusMap = Object.fromEntries(result.map((f) => [f.field, f.status]));
+    expect(statusMap.name).toBe("unchanged");
+    expect(statusMap.city).toBe("new_info");
+    expect(statusMap.state).toBe("unchanged");
+    expect(statusMap.website).toBe("already_set");
+  });
+
+  test("converts non-string values to strings for comparison", () => {
+    const result = compareFields(
+      { capacity: 500 },
+      { capacity: 500 },
+      ["capacity"],
+    );
+
+    expect(result[0].status).toBe("unchanged");
+    expect(result[0].existing).toBe("500");
+    expect(result[0].proposed).toBe("500");
+  });
+
+  test("treats null existing as empty string for new_info detection", () => {
+    const result = compareFields(
+      { website: null },
+      { website: "https://example.com" },
+      ["website"],
+    );
+
+    expect(result[0].status).toBe("new_info");
+    expect(result[0].existing).toBe("");
+  });
+});
+
+describe("classifyAction", () => {
+  test("returns create when confidence < 0.6", () => {
+    expect(classifyAction(0.5, [])).toBe("create");
+    expect(classifyAction(0.0, [])).toBe("create");
+    expect(classifyAction(0.59, [])).toBe("create");
+  });
+
+  test("returns update when match found and has new_info", () => {
+    const fields = [
+      { field: "name", existing: "Test", proposed: "Test", status: "unchanged" as const },
+      { field: "city", existing: "", proposed: "Phoenix", status: "new_info" as const },
+    ];
+    expect(classifyAction(0.8, fields)).toBe("update");
+  });
+
+  test("returns skip when match found and no new_info", () => {
+    const fields = [
+      { field: "name", existing: "Test", proposed: "Test", status: "unchanged" as const },
+      { field: "city", existing: "Phoenix", proposed: "Tempe", status: "already_set" as const },
+    ];
+    expect(classifyAction(0.9, fields)).toBe("skip");
+  });
+
+  test("returns skip when match found and fields are empty", () => {
+    expect(classifyAction(1.0, [])).toBe("skip");
+  });
+
+  test("returns update at exact 0.6 threshold with new_info", () => {
+    const fields = [
+      { field: "city", existing: "", proposed: "Phoenix", status: "new_info" as const },
+    ];
+    expect(classifyAction(0.6, fields)).toBe("update");
+  });
+});
+
+describe("classifyMatch", () => {
+  test("returns exact for confidence 1.0", () => {
+    expect(classifyMatch(1.0)).toBe("exact");
+  });
+
+  test("returns fuzzy for confidence >= 0.6 and < 1.0", () => {
+    expect(classifyMatch(0.6)).toBe("fuzzy");
+    expect(classifyMatch(0.8)).toBe("fuzzy");
+    expect(classifyMatch(0.99)).toBe("fuzzy");
+  });
+
+  test("returns none for confidence < 0.6", () => {
+    expect(classifyMatch(0.5)).toBe("none");
+    expect(classifyMatch(0.0)).toBe("none");
+    expect(classifyMatch(0.59)).toBe("none");
+  });
+});

--- a/cli/test/schemas.test.ts
+++ b/cli/test/schemas.test.ts
@@ -1,0 +1,336 @@
+import { describe, test, expect } from "bun:test";
+import {
+  validateArtist,
+  validateVenue,
+  validateShow,
+  validateRelease,
+  validateLabel,
+  validateFestival,
+  validateEntity,
+} from "../src/lib/schemas";
+
+describe("validateArtist", () => {
+  test("passes with valid data", () => {
+    const result = validateArtist({ name: "Radiohead" });
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("fails when name is missing", () => {
+    const result = validateArtist({});
+    expect(result.valid).toBe(false);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].field).toBe("name");
+  });
+
+  test("fails when name is empty string", () => {
+    const result = validateArtist({ name: "" });
+    expect(result.valid).toBe(false);
+    expect(result.errors[0].field).toBe("name");
+  });
+
+  test("fails when name is whitespace only", () => {
+    const result = validateArtist({ name: "   " });
+    expect(result.valid).toBe(false);
+  });
+
+  test("fails when data is null", () => {
+    const result = validateArtist(null);
+    expect(result.valid).toBe(false);
+    expect(result.errors[0].field).toBe("_root");
+  });
+
+  test("fails when data is not an object", () => {
+    const result = validateArtist("string");
+    expect(result.valid).toBe(false);
+  });
+
+  test("passes with extra fields", () => {
+    const result = validateArtist({ name: "Radiohead", city: "Oxford", website: "https://radiohead.com" });
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe("validateVenue", () => {
+  test("passes with valid data", () => {
+    const result = validateVenue({ name: "The Rebel Lounge", city: "Phoenix", state: "AZ" });
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("fails when name is missing", () => {
+    const result = validateVenue({ city: "Phoenix", state: "AZ" });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.field === "name")).toBe(true);
+  });
+
+  test("fails when city is missing", () => {
+    const result = validateVenue({ name: "The Rebel Lounge", state: "AZ" });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.field === "city")).toBe(true);
+  });
+
+  test("fails when state is missing", () => {
+    const result = validateVenue({ name: "The Rebel Lounge", city: "Phoenix" });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.field === "state")).toBe(true);
+  });
+
+  test("fails when all required fields missing", () => {
+    const result = validateVenue({});
+    expect(result.valid).toBe(false);
+    expect(result.errors).toHaveLength(3);
+  });
+});
+
+describe("validateShow", () => {
+  test("passes with valid data", () => {
+    const result = validateShow({
+      event_date: "2026-03-15",
+      city: "Phoenix",
+      state: "AZ",
+      artists: ["Radiohead"],
+      venues: ["The Rebel Lounge"],
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  test("fails when event_date is missing", () => {
+    const result = validateShow({
+      city: "Phoenix",
+      state: "AZ",
+      artists: ["Radiohead"],
+      venues: ["The Rebel Lounge"],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.field === "event_date")).toBe(true);
+  });
+
+  test("fails when city is missing", () => {
+    const result = validateShow({
+      event_date: "2026-03-15",
+      state: "AZ",
+      artists: ["Radiohead"],
+      venues: ["The Rebel Lounge"],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.field === "city")).toBe(true);
+  });
+
+  test("fails when state is missing", () => {
+    const result = validateShow({
+      event_date: "2026-03-15",
+      city: "Phoenix",
+      artists: ["Radiohead"],
+      venues: ["The Rebel Lounge"],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.field === "state")).toBe(true);
+  });
+
+  test("fails when artists array is empty", () => {
+    const result = validateShow({
+      event_date: "2026-03-15",
+      city: "Phoenix",
+      state: "AZ",
+      artists: [],
+      venues: ["The Rebel Lounge"],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.field === "artists")).toBe(true);
+  });
+
+  test("fails when artists is missing", () => {
+    const result = validateShow({
+      event_date: "2026-03-15",
+      city: "Phoenix",
+      state: "AZ",
+      venues: ["The Rebel Lounge"],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.field === "artists")).toBe(true);
+  });
+
+  test("fails when venues array is empty", () => {
+    const result = validateShow({
+      event_date: "2026-03-15",
+      city: "Phoenix",
+      state: "AZ",
+      artists: ["Radiohead"],
+      venues: [],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.field === "venues")).toBe(true);
+  });
+
+  test("fails when all required fields are missing", () => {
+    const result = validateShow({});
+    expect(result.valid).toBe(false);
+    expect(result.errors).toHaveLength(5);
+  });
+});
+
+describe("validateRelease", () => {
+  test("passes with valid data", () => {
+    const result = validateRelease({ title: "OK Computer", artists: ["Radiohead"] });
+    expect(result.valid).toBe(true);
+  });
+
+  test("fails when title is missing", () => {
+    const result = validateRelease({ artists: ["Radiohead"] });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.field === "title")).toBe(true);
+  });
+
+  test("fails when artists is missing", () => {
+    const result = validateRelease({ title: "OK Computer" });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.field === "artists")).toBe(true);
+  });
+
+  test("fails when both missing", () => {
+    const result = validateRelease({});
+    expect(result.valid).toBe(false);
+    expect(result.errors).toHaveLength(2);
+  });
+});
+
+describe("validateLabel", () => {
+  test("passes with valid data", () => {
+    const result = validateLabel({ name: "Sacred Bones Records" });
+    expect(result.valid).toBe(true);
+  });
+
+  test("fails when name is missing", () => {
+    const result = validateLabel({});
+    expect(result.valid).toBe(false);
+    expect(result.errors[0].field).toBe("name");
+  });
+
+  test("fails when name is empty", () => {
+    const result = validateLabel({ name: "" });
+    expect(result.valid).toBe(false);
+  });
+});
+
+describe("validateFestival", () => {
+  test("passes with valid data", () => {
+    const result = validateFestival({
+      name: "M3F Festival 2026",
+      series_slug: "m3f-festival",
+      edition_year: 2026,
+      start_date: "2026-03-01",
+      end_date: "2026-03-02",
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  test("fails when name is missing", () => {
+    const result = validateFestival({
+      series_slug: "m3f-festival",
+      edition_year: 2026,
+      start_date: "2026-03-01",
+      end_date: "2026-03-02",
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.field === "name")).toBe(true);
+  });
+
+  test("fails when series_slug is missing", () => {
+    const result = validateFestival({
+      name: "M3F Festival 2026",
+      edition_year: 2026,
+      start_date: "2026-03-01",
+      end_date: "2026-03-02",
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.field === "series_slug")).toBe(true);
+  });
+
+  test("fails when edition_year is missing", () => {
+    const result = validateFestival({
+      name: "M3F Festival 2026",
+      series_slug: "m3f-festival",
+      start_date: "2026-03-01",
+      end_date: "2026-03-02",
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.field === "edition_year")).toBe(true);
+  });
+
+  test("fails when start_date is missing", () => {
+    const result = validateFestival({
+      name: "M3F Festival 2026",
+      series_slug: "m3f-festival",
+      edition_year: 2026,
+      end_date: "2026-03-02",
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.field === "start_date")).toBe(true);
+  });
+
+  test("fails when end_date is missing", () => {
+    const result = validateFestival({
+      name: "M3F Festival 2026",
+      series_slug: "m3f-festival",
+      edition_year: 2026,
+      start_date: "2026-03-01",
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.field === "end_date")).toBe(true);
+  });
+
+  test("fails when all required fields are missing", () => {
+    const result = validateFestival({});
+    expect(result.valid).toBe(false);
+    expect(result.errors).toHaveLength(5);
+  });
+});
+
+describe("validateEntity", () => {
+  test("dispatches to artist validator", () => {
+    expect(validateEntity("artist", { name: "Test" }).valid).toBe(true);
+    expect(validateEntity("artist", {}).valid).toBe(false);
+  });
+
+  test("dispatches to venue validator", () => {
+    expect(validateEntity("venue", { name: "Test", city: "Phoenix", state: "AZ" }).valid).toBe(true);
+    expect(validateEntity("venue", {}).valid).toBe(false);
+  });
+
+  test("dispatches to show validator", () => {
+    expect(
+      validateEntity("show", {
+        event_date: "2026-03-15",
+        city: "Phoenix",
+        state: "AZ",
+        artists: ["Test"],
+        venues: ["Test"],
+      }).valid,
+    ).toBe(true);
+    expect(validateEntity("show", {}).valid).toBe(false);
+  });
+
+  test("dispatches to release validator", () => {
+    expect(validateEntity("release", { title: "Test", artists: ["Test"] }).valid).toBe(true);
+    expect(validateEntity("release", {}).valid).toBe(false);
+  });
+
+  test("dispatches to label validator", () => {
+    expect(validateEntity("label", { name: "Test" }).valid).toBe(true);
+    expect(validateEntity("label", {}).valid).toBe(false);
+  });
+
+  test("dispatches to festival validator", () => {
+    expect(
+      validateEntity("festival", {
+        name: "Test",
+        series_slug: "test",
+        edition_year: 2026,
+        start_date: "2026-01-01",
+        end_date: "2026-01-02",
+      }).valid,
+    ).toBe(true);
+    expect(validateEntity("festival", {}).valid).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `duplicates.ts`: string normalization (accent stripping, whitespace collapsing), similarity scoring, field-by-field comparison (new_info/already_set/unchanged), `checkDuplicate()` with entity-specific search strategies
- Add `schemas.ts`: validators for all 6 entity types (artist, venue, show, release, label, festival) with required field checks and type-safe dispatcher
- 75 new tests (45 duplicates + 30 schemas), 93 total CLI tests passing
- Zero TypeScript type errors
- Part of PH CLI project — core engine used by all `ph submit` commands ([#127](https://github.com/mtrifilo/psychic-homily-web/pull/127))

## Test plan
- [x] `normalizeForComparison`: lowercase, trim, whitespace collapse, accent stripping
- [x] `similarityScore`: exact=1.0, substring>0.6, no match<0.3
- [x] `compareFields`: correctly classifies new_info, already_set, unchanged
- [x] Action classification: create/update/skip based on match + fields
- [x] All 6 entity validators: valid input passes, missing required fields fails
- [x] `validateEntity` dispatcher works for all types
- [x] TypeScript type check passes (`tsc --noEmit`)

Closes PSY-141

🤖 Generated with [Claude Code](https://claude.com/claude-code)