### PR TITLE
Wire revision recording to entity update handlers

### DIFF
--- a/backend/internal/api/handlers/admin_integration_test.go
+++ b/backend/internal/api/handlers/admin_integration_test.go
@@ -278,7 +278,7 @@ func (s *AdminHandlerIntegrationSuite) TestGetPendingVenueEdits_Success() {
 	s.deps.db.Create(venue)
 
 	// Create pending edit via venue handler
-	venueHandler := NewVenueHandler(s.deps.venueService, s.deps.discordService, s.deps.auditLogService)
+	venueHandler := NewVenueHandler(s.deps.venueService, s.deps.discordService, s.deps.auditLogService, nil)
 	userCtx := ctxWithUser(user)
 	newName := "Updated Name"
 	updateReq := &UpdateVenueRequest{VenueID: fmt.Sprintf("%d", venue.ID)}
@@ -310,7 +310,7 @@ func (s *AdminHandlerIntegrationSuite) TestApproveVenueEdit_Success() {
 	s.deps.db.Create(venue)
 
 	// Create pending edit
-	venueHandler := NewVenueHandler(s.deps.venueService, s.deps.discordService, s.deps.auditLogService)
+	venueHandler := NewVenueHandler(s.deps.venueService, s.deps.discordService, s.deps.auditLogService, nil)
 	userCtx := ctxWithUser(user)
 	newName := "Approved Name"
 	updateReq := &UpdateVenueRequest{VenueID: fmt.Sprintf("%d", venue.ID)}
@@ -353,7 +353,7 @@ func (s *AdminHandlerIntegrationSuite) TestRejectVenueEdit_Success() {
 	s.deps.db.Create(venue)
 
 	// Create pending edit
-	venueHandler := NewVenueHandler(s.deps.venueService, s.deps.discordService, s.deps.auditLogService)
+	venueHandler := NewVenueHandler(s.deps.venueService, s.deps.discordService, s.deps.auditLogService, nil)
 	userCtx := ctxWithUser(user)
 	newName := "Rejected Name"
 	updateReq := &UpdateVenueRequest{VenueID: fmt.Sprintf("%d", venue.ID)}

--- a/backend/internal/api/handlers/artist.go
+++ b/backend/internal/api/handlers/artist.go
@@ -13,6 +13,7 @@ import (
 	"psychic-homily-backend/internal/api/middleware"
 	apperrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/logger"
+	"psychic-homily-backend/internal/models"
 	"psychic-homily-backend/internal/services"
 )
 
@@ -29,12 +30,14 @@ func isInternalServiceRequest(ctx huma.Context) bool {
 type ArtistHandler struct {
 	artistService   services.ArtistServiceInterface
 	auditLogService services.AuditLogServiceInterface
+	revisionService services.RevisionServiceInterface
 }
 
-func NewArtistHandler(artistService services.ArtistServiceInterface, auditLogService services.AuditLogServiceInterface) *ArtistHandler {
+func NewArtistHandler(artistService services.ArtistServiceInterface, auditLogService services.AuditLogServiceInterface, revisionService services.RevisionServiceInterface) *ArtistHandler {
 	return &ArtistHandler{
 		artistService:   artistService,
 		auditLogService: auditLogService,
+		revisionService: revisionService,
 	}
 }
 
@@ -726,6 +729,7 @@ type AdminUpdateArtistRequest struct {
 		Soundcloud *string `json:"soundcloud,omitempty" required:"false" doc:"SoundCloud URL"`
 		Bandcamp   *string `json:"bandcamp,omitempty" required:"false" doc:"Bandcamp URL"`
 		Website    *string `json:"website,omitempty" required:"false" doc:"Website URL"`
+		Summary    *string `json:"summary,omitempty" required:"false" doc:"Revision summary describing the change"`
 	}
 }
 
@@ -754,6 +758,12 @@ func (h *ArtistHandler) AdminUpdateArtistHandler(ctx context.Context, req *Admin
 	// Validate name if provided
 	if req.Body.Name != nil && strings.TrimSpace(*req.Body.Name) == "" {
 		return nil, huma.Error400BadRequest("Artist name cannot be empty")
+	}
+
+	// Capture old values for revision diff (fire-and-forget safe)
+	var oldArtist *services.ArtistDetailResponse
+	if h.revisionService != nil {
+		oldArtist, _ = h.artistService.GetArtist(uint(artistID))
 	}
 
 	// Build updates map with only provided fields
@@ -818,6 +828,25 @@ func (h *ArtistHandler) AdminUpdateArtistHandler(ctx context.Context, req *Admin
 		h.auditLogService.LogAction(user.ID, "edit_artist", "artist", uint(artistID), nil)
 	}
 
+	// Record revision (fire and forget)
+	if h.revisionService != nil && oldArtist != nil {
+		go func() {
+			changes := computeArtistChanges(oldArtist, artist)
+			if len(changes) > 0 {
+				summary := ""
+				if req.Body.Summary != nil {
+					summary = *req.Body.Summary
+				}
+				if err := h.revisionService.RecordRevision("artist", uint(artistID), user.ID, changes, summary); err != nil {
+					logger.Default().Error("record_artist_revision_failed",
+						"artist_id", artistID,
+						"error", err.Error(),
+					)
+				}
+			}
+		}()
+	}
+
 	logger.FromContext(ctx).Info("admin_update_artist_success",
 		"artist_id", artistID,
 		"admin_id", user.ID,
@@ -825,6 +854,55 @@ func (h *ArtistHandler) AdminUpdateArtistHandler(ctx context.Context, req *Admin
 	)
 
 	return &AdminUpdateArtistResponse{Body: artist}, nil
+}
+
+// computeArtistChanges compares old and new artist detail responses and returns field-level diffs.
+func computeArtistChanges(old, new *services.ArtistDetailResponse) []models.FieldChange {
+	var changes []models.FieldChange
+
+	if old.Name != new.Name {
+		changes = append(changes, models.FieldChange{Field: "name", OldValue: old.Name, NewValue: new.Name})
+	}
+	if ptrToStr(old.City) != ptrToStr(new.City) {
+		changes = append(changes, models.FieldChange{Field: "city", OldValue: ptrToStr(old.City), NewValue: ptrToStr(new.City)})
+	}
+	if ptrToStr(old.State) != ptrToStr(new.State) {
+		changes = append(changes, models.FieldChange{Field: "state", OldValue: ptrToStr(old.State), NewValue: ptrToStr(new.State)})
+	}
+	if ptrToStr(old.Social.Instagram) != ptrToStr(new.Social.Instagram) {
+		changes = append(changes, models.FieldChange{Field: "instagram", OldValue: ptrToStr(old.Social.Instagram), NewValue: ptrToStr(new.Social.Instagram)})
+	}
+	if ptrToStr(old.Social.Facebook) != ptrToStr(new.Social.Facebook) {
+		changes = append(changes, models.FieldChange{Field: "facebook", OldValue: ptrToStr(old.Social.Facebook), NewValue: ptrToStr(new.Social.Facebook)})
+	}
+	if ptrToStr(old.Social.Twitter) != ptrToStr(new.Social.Twitter) {
+		changes = append(changes, models.FieldChange{Field: "twitter", OldValue: ptrToStr(old.Social.Twitter), NewValue: ptrToStr(new.Social.Twitter)})
+	}
+	if ptrToStr(old.Social.YouTube) != ptrToStr(new.Social.YouTube) {
+		changes = append(changes, models.FieldChange{Field: "youtube", OldValue: ptrToStr(old.Social.YouTube), NewValue: ptrToStr(new.Social.YouTube)})
+	}
+	if ptrToStr(old.Social.Spotify) != ptrToStr(new.Social.Spotify) {
+		changes = append(changes, models.FieldChange{Field: "spotify", OldValue: ptrToStr(old.Social.Spotify), NewValue: ptrToStr(new.Social.Spotify)})
+	}
+	if ptrToStr(old.Social.SoundCloud) != ptrToStr(new.Social.SoundCloud) {
+		changes = append(changes, models.FieldChange{Field: "soundcloud", OldValue: ptrToStr(old.Social.SoundCloud), NewValue: ptrToStr(new.Social.SoundCloud)})
+	}
+	if ptrToStr(old.Social.Bandcamp) != ptrToStr(new.Social.Bandcamp) {
+		changes = append(changes, models.FieldChange{Field: "bandcamp", OldValue: ptrToStr(old.Social.Bandcamp), NewValue: ptrToStr(new.Social.Bandcamp)})
+	}
+	if ptrToStr(old.Social.Website) != ptrToStr(new.Social.Website) {
+		changes = append(changes, models.FieldChange{Field: "website", OldValue: ptrToStr(old.Social.Website), NewValue: ptrToStr(new.Social.Website)})
+	}
+
+	return changes
+}
+
+// ptrToStr safely dereferences a *string, returning "" if nil.
+func ptrToStr(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
 }
 
 // nilIfEmpty returns nil if the string is empty, otherwise returns a pointer to the string

--- a/backend/internal/api/handlers/artist_integration_test.go
+++ b/backend/internal/api/handlers/artist_integration_test.go
@@ -19,7 +19,7 @@ type ArtistHandlerIntegrationSuite struct {
 
 func (s *ArtistHandlerIntegrationSuite) SetupSuite() {
 	s.deps = setupHandlerIntegrationDeps(s.T())
-	s.handler = NewArtistHandler(s.deps.artistService, s.deps.auditLogService)
+	s.handler = NewArtistHandler(s.deps.artistService, s.deps.auditLogService, nil)
 }
 
 func (s *ArtistHandlerIntegrationSuite) TearDownTest() {

--- a/backend/internal/api/handlers/artist_test.go
+++ b/backend/internal/api/handlers/artist_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func testArtistHandler() *ArtistHandler {
-	return NewArtistHandler(nil, nil)
+	return NewArtistHandler(nil, nil, nil)
 }
 
 // --- NewArtistHandler ---
@@ -258,7 +258,7 @@ func TestSearchArtists_Success(t *testing.T) {
 			return []*services.ArtistDetailResponse{{ID: 1, Name: "Radiohead"}}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 
 	resp, err := h.SearchArtistsHandler(context.Background(), &SearchArtistsRequest{Query: "radio"})
 	if err != nil {
@@ -278,7 +278,7 @@ func TestSearchArtists_ServiceError(t *testing.T) {
 			return nil, fmt.Errorf("db error")
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 
 	_, err := h.SearchArtistsHandler(context.Background(), &SearchArtistsRequest{Query: "test"})
 	if err == nil {
@@ -299,7 +299,7 @@ func TestListArtists_Success(t *testing.T) {
 			}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 
 	resp, err := h.ListArtistsHandler(context.Background(), &ListArtistsRequest{})
 	if err != nil {
@@ -327,7 +327,7 @@ func TestListArtists_WithFilters(t *testing.T) {
 			}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 
 	resp, err := h.ListArtistsHandler(context.Background(), &ListArtistsRequest{State: "AZ", City: "Phoenix"})
 	if err != nil {
@@ -344,7 +344,7 @@ func TestListArtists_ServiceError(t *testing.T) {
 			return nil, fmt.Errorf("db error")
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 
 	_, err := h.ListArtistsHandler(context.Background(), &ListArtistsRequest{})
 	assertHumaError(t, err, 500)
@@ -363,7 +363,7 @@ func TestGetArtist_ByID(t *testing.T) {
 			return &services.ArtistDetailResponse{ID: 42, Name: "Test Artist"}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 
 	resp, err := h.GetArtistHandler(context.Background(), &GetArtistRequest{ArtistID: "42"})
 	if err != nil {
@@ -383,7 +383,7 @@ func TestGetArtist_BySlug(t *testing.T) {
 			return &services.ArtistDetailResponse{ID: 10, Slug: "the-national"}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 
 	resp, err := h.GetArtistHandler(context.Background(), &GetArtistRequest{ArtistID: "the-national"})
 	if err != nil {
@@ -400,7 +400,7 @@ func TestGetArtist_NotFound(t *testing.T) {
 			return nil, apperrors.ErrArtistNotFound(99)
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 
 	_, err := h.GetArtistHandler(context.Background(), &GetArtistRequest{ArtistID: "99"})
 	assertHumaError(t, err, 404)
@@ -412,7 +412,7 @@ func TestGetArtist_ServiceError(t *testing.T) {
 			return nil, fmt.Errorf("db error")
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 
 	_, err := h.GetArtistHandler(context.Background(), &GetArtistRequest{ArtistID: "42"})
 	assertHumaError(t, err, 500)
@@ -431,7 +431,7 @@ func TestGetArtistShows_ByID(t *testing.T) {
 			return []*services.ArtistShowResponse{{ID: 100}}, 1, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 
 	resp, err := h.GetArtistShowsHandler(context.Background(), &GetArtistShowsRequest{ArtistID: "5", Limit: 20})
 	if err != nil {
@@ -457,7 +457,7 @@ func TestGetArtistShows_BySlug(t *testing.T) {
 			return []*services.ArtistShowResponse{{ID: 200}}, 1, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 
 	resp, err := h.GetArtistShowsHandler(context.Background(), &GetArtistShowsRequest{ArtistID: "the-national", Limit: 20})
 	if err != nil {
@@ -474,7 +474,7 @@ func TestGetArtistShows_ArtistNotFound(t *testing.T) {
 			return nil, 0, apperrors.ErrArtistNotFound(99)
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 
 	_, err := h.GetArtistShowsHandler(context.Background(), &GetArtistShowsRequest{ArtistID: "99", Limit: 20})
 	assertHumaError(t, err, 404)
@@ -486,7 +486,7 @@ func TestGetArtistShows_ServiceError(t *testing.T) {
 			return nil, 0, fmt.Errorf("db error")
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 
 	_, err := h.GetArtistShowsHandler(context.Background(), &GetArtistShowsRequest{ArtistID: "5", Limit: 20})
 	assertHumaError(t, err, 500)
@@ -505,7 +505,7 @@ func TestDeleteArtist_Success(t *testing.T) {
 			return nil
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1})
 
 	_, err := h.DeleteArtistHandler(ctx, &DeleteArtistRequest{ArtistID: "42"})
@@ -520,7 +520,7 @@ func TestDeleteArtist_NotFound(t *testing.T) {
 			return apperrors.ErrArtistNotFound(99)
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1})
 
 	_, err := h.DeleteArtistHandler(ctx, &DeleteArtistRequest{ArtistID: "99"})
@@ -533,7 +533,7 @@ func TestDeleteArtist_HasShows(t *testing.T) {
 			return apperrors.ErrArtistHasShows(42, 3)
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1})
 
 	_, err := h.DeleteArtistHandler(ctx, &DeleteArtistRequest{ArtistID: "42"})
@@ -546,7 +546,7 @@ func TestDeleteArtist_ServiceError(t *testing.T) {
 			return fmt.Errorf("db error")
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1})
 
 	_, err := h.DeleteArtistHandler(ctx, &DeleteArtistRequest{ArtistID: "42"})
@@ -566,7 +566,7 @@ func TestAdminUpdateArtist_Success(t *testing.T) {
 			return &services.ArtistDetailResponse{ID: 42, Name: "Updated"}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
 	name := "Updated"
 	req := &AdminUpdateArtistRequest{ArtistID: "42"}
@@ -587,7 +587,7 @@ func TestAdminUpdateArtist_NotFound(t *testing.T) {
 			return nil, apperrors.ErrArtistNotFound(99)
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
 	name := "Test"
 	req := &AdminUpdateArtistRequest{ArtistID: "99"}
@@ -621,7 +621,7 @@ func TestAdminUpdateArtist_AuditLogCalled(t *testing.T) {
 			}
 		},
 	}
-	h := NewArtistHandler(artistMock, auditMock)
+	h := NewArtistHandler(artistMock, auditMock, nil)
 	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
 	name := "New Name"
 	req := &AdminUpdateArtistRequest{ArtistID: "42"}
@@ -657,7 +657,7 @@ func TestUpdateBandcamp_Success(t *testing.T) {
 			return &services.ArtistDetailResponse{ID: 42}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
 	url := "https://artist.bandcamp.com/album/cool-album"
 	req := &UpdateArtistBandcampRequest{ArtistID: "42"}
@@ -684,7 +684,7 @@ func TestUpdateBandcamp_ClearURL(t *testing.T) {
 			return &services.ArtistDetailResponse{ID: 42}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
 	empty := ""
 	req := &UpdateArtistBandcampRequest{ArtistID: "42"}
@@ -712,7 +712,7 @@ func TestUpdateSpotify_Success(t *testing.T) {
 			return &services.ArtistDetailResponse{ID: 42}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
 	url := "https://open.spotify.com/artist/abc123"
 	req := &UpdateArtistSpotifyRequest{ArtistID: "42"}
@@ -740,7 +740,7 @@ func TestGetArtistCities_Success(t *testing.T) {
 			}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 
 	resp, err := h.GetArtistCitiesHandler(context.Background(), &GetArtistCitiesRequest{})
 	if err != nil {
@@ -763,7 +763,7 @@ func TestGetArtistCities_ServiceError(t *testing.T) {
 			return nil, fmt.Errorf("db error")
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 
 	_, err := h.GetArtistCitiesHandler(context.Background(), &GetArtistCitiesRequest{})
 	assertHumaError(t, err, 500)
@@ -775,7 +775,7 @@ func TestGetArtistCities_Empty(t *testing.T) {
 			return []*services.ArtistCityResponse{}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 
 	resp, err := h.GetArtistCitiesHandler(context.Background(), &GetArtistCitiesRequest{})
 	if err != nil {
@@ -808,7 +808,7 @@ func TestListArtists_WithCitiesFilter(t *testing.T) {
 			}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 
 	resp, err := h.ListArtistsHandler(context.Background(), &ListArtistsRequest{Cities: "Phoenix,AZ|Mesa,AZ"})
 	if err != nil {
@@ -832,7 +832,7 @@ func TestListArtists_CitiesOverridesLegacy(t *testing.T) {
 			return []*services.ArtistWithShowCountResponse{}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 
 	_, err := h.ListArtistsHandler(context.Background(), &ListArtistsRequest{
 		Cities: "Phoenix,AZ",
@@ -866,7 +866,7 @@ func TestGetArtistAliases_Success(t *testing.T) {
 			}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 
 	resp, err := h.GetArtistAliasesHandler(context.Background(), &GetArtistAliasesRequest{ArtistID: "42"})
 	if err != nil {
@@ -883,7 +883,7 @@ func TestGetArtistAliases_NotFound(t *testing.T) {
 			return nil, apperrors.ErrArtistNotFound(artistID)
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 
 	_, err := h.GetArtistAliasesHandler(context.Background(), &GetArtistAliasesRequest{ArtistID: "99"})
 	assertHumaError(t, err, 404)
@@ -941,7 +941,7 @@ func TestAddArtistAlias_Success(t *testing.T) {
 			return &services.ArtistAliasResponse{ID: 1, ArtistID: 42, Alias: alias}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
 	req := &AddArtistAliasRequest{ArtistID: "42"}
 	req.Body.Alias = "New Alias"
@@ -961,7 +961,7 @@ func TestAddArtistAlias_Conflict(t *testing.T) {
 			return nil, fmt.Errorf("alias 'Test' already exists")
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
 	req := &AddArtistAliasRequest{ArtistID: "42"}
 	req.Body.Alias = "Test"
@@ -1003,7 +1003,7 @@ func TestDeleteArtistAlias_Success(t *testing.T) {
 			return nil
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
 
 	_, err := h.DeleteArtistAliasHandler(ctx, &DeleteArtistAliasRequest{ArtistID: "1", AliasID: "5"})
@@ -1018,7 +1018,7 @@ func TestDeleteArtistAlias_NotFound(t *testing.T) {
 			return fmt.Errorf("alias not found")
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
 
 	_, err := h.DeleteArtistAliasHandler(ctx, &DeleteArtistAliasRequest{ArtistID: "1", AliasID: "99"})
@@ -1067,7 +1067,7 @@ func TestMergeArtists_SelfMerge(t *testing.T) {
 			return nil, fmt.Errorf("cannot merge an artist with itself")
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
 	req := &MergeArtistsRequest{}
 	req.Body.CanonicalArtistID = 5
@@ -1095,7 +1095,7 @@ func TestMergeArtists_Success(t *testing.T) {
 			}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
 	req := &MergeArtistsRequest{}
 	req.Body.CanonicalArtistID = 1
@@ -1119,7 +1119,7 @@ func TestMergeArtists_NotFound(t *testing.T) {
 			return nil, apperrors.ErrArtistNotFound(canonicalID)
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
 	req := &MergeArtistsRequest{}
 	req.Body.CanonicalArtistID = 99
@@ -1171,7 +1171,7 @@ func TestAdminCreateArtist_Success(t *testing.T) {
 			return &services.ArtistDetailResponse{ID: 42, Name: "New Artist", Slug: "new-artist"}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
 	req := &AdminCreateArtistRequest{}
 	req.Body.Name = "New Artist"
@@ -1212,7 +1212,7 @@ func TestAdminCreateArtist_WithSocials(t *testing.T) {
 			return &services.ArtistDetailResponse{ID: 43, Name: "Social Artist"}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
 	req := &AdminCreateArtistRequest{}
 	req.Body.Name = "Social Artist"
@@ -1240,7 +1240,7 @@ func TestAdminCreateArtist_Conflict(t *testing.T) {
 			return nil, fmt.Errorf("artist with name 'Existing' already exists")
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
 	req := &AdminCreateArtistRequest{}
 	req.Body.Name = "Existing"
@@ -1255,7 +1255,7 @@ func TestAdminCreateArtist_ServiceError(t *testing.T) {
 			return nil, fmt.Errorf("db error")
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
 	req := &AdminCreateArtistRequest{}
 	req.Body.Name = "Test"
@@ -1291,7 +1291,7 @@ func TestAdminCreateArtist_AuditLogCalled(t *testing.T) {
 			}
 		},
 	}
-	h := NewArtistHandler(artistMock, auditMock)
+	h := NewArtistHandler(artistMock, auditMock, nil)
 	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
 	req := &AdminCreateArtistRequest{}
 	req.Body.Name = "Audit Test Artist"
@@ -1314,7 +1314,7 @@ func TestAdminCreateArtist_NameTrimmed(t *testing.T) {
 			return &services.ArtistDetailResponse{ID: 44, Name: "Trimmed Name"}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil)
+	h := NewArtistHandler(mock, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
 	req := &AdminCreateArtistRequest{}
 	req.Body.Name = "  Trimmed Name  "

--- a/backend/internal/api/handlers/festival.go
+++ b/backend/internal/api/handlers/festival.go
@@ -11,6 +11,7 @@ import (
 	"psychic-homily-backend/internal/api/middleware"
 	apperrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/logger"
+	"psychic-homily-backend/internal/models"
 	"psychic-homily-backend/internal/services"
 )
 
@@ -18,13 +19,15 @@ type FestivalHandler struct {
 	festivalService services.FestivalServiceInterface
 	artistService   services.ArtistServiceInterface
 	auditLogService services.AuditLogServiceInterface
+	revisionService services.RevisionServiceInterface
 }
 
-func NewFestivalHandler(festivalService services.FestivalServiceInterface, artistService services.ArtistServiceInterface, auditLogService services.AuditLogServiceInterface) *FestivalHandler {
+func NewFestivalHandler(festivalService services.FestivalServiceInterface, artistService services.ArtistServiceInterface, auditLogService services.AuditLogServiceInterface, revisionService services.RevisionServiceInterface) *FestivalHandler {
 	return &FestivalHandler{
 		festivalService: festivalService,
 		artistService:   artistService,
 		auditLogService: auditLogService,
+		revisionService: revisionService,
 	}
 }
 
@@ -240,6 +243,7 @@ type UpdateFestivalRequest struct {
 		TicketURL    *string `json:"ticket_url,omitempty" required:"false" doc:"Ticket URL"`
 		FlyerURL     *string `json:"flyer_url,omitempty" required:"false" doc:"Flyer URL"`
 		Status       *string `json:"status,omitempty" required:"false" doc:"Status"`
+		Summary      *string `json:"summary,omitempty" required:"false" doc:"Revision summary describing the change"`
 	}
 }
 
@@ -261,6 +265,12 @@ func (h *FestivalHandler) UpdateFestivalHandler(ctx context.Context, req *Update
 	festivalID, err := h.resolveFestivalID(req.FestivalID)
 	if err != nil {
 		return nil, err
+	}
+
+	// Capture old values for revision diff (fire-and-forget safe)
+	var oldFestival *services.FestivalDetailResponse
+	if h.revisionService != nil {
+		oldFestival, _ = h.festivalService.GetFestival(festivalID)
 	}
 
 	serviceReq := &services.UpdateFestivalRequest{
@@ -300,6 +310,25 @@ func (h *FestivalHandler) UpdateFestivalHandler(ctx context.Context, req *Update
 	if h.auditLogService != nil {
 		go func() {
 			h.auditLogService.LogAction(user.ID, "edit_festival", "festival", festivalID, nil)
+		}()
+	}
+
+	// Record revision (fire and forget)
+	if h.revisionService != nil && oldFestival != nil {
+		go func() {
+			changes := computeFestivalChanges(oldFestival, festival)
+			if len(changes) > 0 {
+				summary := ""
+				if req.Body.Summary != nil {
+					summary = *req.Body.Summary
+				}
+				if err := h.revisionService.RecordRevision("festival", festivalID, user.ID, changes, summary); err != nil {
+					logger.Default().Error("record_festival_revision_failed",
+						"festival_id", festivalID,
+						"error", err.Error(),
+					)
+				}
+			}
 		}()
 	}
 
@@ -849,4 +878,54 @@ func (h *FestivalHandler) resolveFestivalID(idOrSlug string) (uint, error) {
 	}
 
 	return festival.ID, nil
+}
+
+// computeFestivalChanges compares old and new festival detail responses and returns field-level diffs.
+func computeFestivalChanges(old, new *services.FestivalDetailResponse) []models.FieldChange {
+	var changes []models.FieldChange
+
+	if old.Name != new.Name {
+		changes = append(changes, models.FieldChange{Field: "name", OldValue: old.Name, NewValue: new.Name})
+	}
+	if old.SeriesSlug != new.SeriesSlug {
+		changes = append(changes, models.FieldChange{Field: "series_slug", OldValue: old.SeriesSlug, NewValue: new.SeriesSlug})
+	}
+	if old.EditionYear != new.EditionYear {
+		changes = append(changes, models.FieldChange{Field: "edition_year", OldValue: old.EditionYear, NewValue: new.EditionYear})
+	}
+	if ptrToStr(old.Description) != ptrToStr(new.Description) {
+		changes = append(changes, models.FieldChange{Field: "description", OldValue: ptrToStr(old.Description), NewValue: ptrToStr(new.Description)})
+	}
+	if ptrToStr(old.LocationName) != ptrToStr(new.LocationName) {
+		changes = append(changes, models.FieldChange{Field: "location_name", OldValue: ptrToStr(old.LocationName), NewValue: ptrToStr(new.LocationName)})
+	}
+	if ptrToStr(old.City) != ptrToStr(new.City) {
+		changes = append(changes, models.FieldChange{Field: "city", OldValue: ptrToStr(old.City), NewValue: ptrToStr(new.City)})
+	}
+	if ptrToStr(old.State) != ptrToStr(new.State) {
+		changes = append(changes, models.FieldChange{Field: "state", OldValue: ptrToStr(old.State), NewValue: ptrToStr(new.State)})
+	}
+	if ptrToStr(old.Country) != ptrToStr(new.Country) {
+		changes = append(changes, models.FieldChange{Field: "country", OldValue: ptrToStr(old.Country), NewValue: ptrToStr(new.Country)})
+	}
+	if old.StartDate != new.StartDate {
+		changes = append(changes, models.FieldChange{Field: "start_date", OldValue: old.StartDate, NewValue: new.StartDate})
+	}
+	if old.EndDate != new.EndDate {
+		changes = append(changes, models.FieldChange{Field: "end_date", OldValue: old.EndDate, NewValue: new.EndDate})
+	}
+	if ptrToStr(old.Website) != ptrToStr(new.Website) {
+		changes = append(changes, models.FieldChange{Field: "website", OldValue: ptrToStr(old.Website), NewValue: ptrToStr(new.Website)})
+	}
+	if ptrToStr(old.TicketURL) != ptrToStr(new.TicketURL) {
+		changes = append(changes, models.FieldChange{Field: "ticket_url", OldValue: ptrToStr(old.TicketURL), NewValue: ptrToStr(new.TicketURL)})
+	}
+	if ptrToStr(old.FlyerURL) != ptrToStr(new.FlyerURL) {
+		changes = append(changes, models.FieldChange{Field: "flyer_url", OldValue: ptrToStr(old.FlyerURL), NewValue: ptrToStr(new.FlyerURL)})
+	}
+	if old.Status != new.Status {
+		changes = append(changes, models.FieldChange{Field: "status", OldValue: old.Status, NewValue: new.Status})
+	}
+
+	return changes
 }

--- a/backend/internal/api/handlers/festival_integration_test.go
+++ b/backend/internal/api/handlers/festival_integration_test.go
@@ -19,7 +19,7 @@ type FestivalHandlerIntegrationSuite struct {
 
 func (s *FestivalHandlerIntegrationSuite) SetupSuite() {
 	s.deps = setupHandlerIntegrationDeps(s.T())
-	s.handler = NewFestivalHandler(s.deps.festivalService, s.deps.artistService, s.deps.auditLogService)
+	s.handler = NewFestivalHandler(s.deps.festivalService, s.deps.artistService, s.deps.auditLogService, nil)
 }
 
 func (s *FestivalHandlerIntegrationSuite) TearDownTest() {

--- a/backend/internal/api/handlers/venue.go
+++ b/backend/internal/api/handlers/venue.go
@@ -10,6 +10,7 @@ import (
 	"psychic-homily-backend/internal/api/middleware"
 	apperrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/logger"
+	"psychic-homily-backend/internal/models"
 	"psychic-homily-backend/internal/services"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -19,13 +20,15 @@ type VenueHandler struct {
 	venueService    services.VenueServiceInterface
 	discordService  services.DiscordServiceInterface
 	auditLogService services.AuditLogServiceInterface
+	revisionService services.RevisionServiceInterface
 }
 
-func NewVenueHandler(venueService services.VenueServiceInterface, discordService services.DiscordServiceInterface, auditLogService services.AuditLogServiceInterface) *VenueHandler {
+func NewVenueHandler(venueService services.VenueServiceInterface, discordService services.DiscordServiceInterface, auditLogService services.AuditLogServiceInterface, revisionService services.RevisionServiceInterface) *VenueHandler {
 	return &VenueHandler{
 		venueService:    venueService,
 		discordService:  discordService,
 		auditLogService: auditLogService,
+		revisionService: revisionService,
 	}
 }
 
@@ -354,6 +357,7 @@ type UpdateVenueRequest struct {
 		SoundCloud *string `json:"soundcloud,omitempty" required:"false" doc:"SoundCloud URL"`
 		Bandcamp   *string `json:"bandcamp,omitempty" required:"false" doc:"Bandcamp URL"`
 		Website    *string `json:"website,omitempty" required:"false" doc:"Website URL"`
+		Summary    *string `json:"summary,omitempty" required:"false" doc:"Revision summary describing the change"`
 	}
 }
 
@@ -434,6 +438,12 @@ func (h *VenueHandler) UpdateVenueHandler(ctx context.Context, req *UpdateVenueR
 			"request_id", requestID,
 		)
 
+		// Capture old values for revision diff (fire-and-forget safe)
+		var oldVenue *services.VenueDetailResponse
+		if h.revisionService != nil {
+			oldVenue, _ = h.venueService.GetVenue(uint(venueID))
+		}
+
 		// Build updates map
 		updates := make(map[string]interface{})
 		if editReq.Name != nil {
@@ -486,6 +496,25 @@ func (h *VenueHandler) UpdateVenueHandler(ctx context.Context, req *UpdateVenueR
 			return nil, huma.Error422UnprocessableEntity(
 				fmt.Sprintf("Failed to update venue (request_id: %s)", requestID),
 			)
+		}
+
+		// Record revision (fire and forget)
+		if h.revisionService != nil && oldVenue != nil {
+			go func() {
+				changes := computeVenueChanges(oldVenue, updatedVenue)
+				if len(changes) > 0 {
+					summary := ""
+					if req.Body.Summary != nil {
+						summary = *req.Body.Summary
+					}
+					if err := h.revisionService.RecordRevision("venue", uint(venueID), user.ID, changes, summary); err != nil {
+						logger.Default().Error("record_venue_revision_failed",
+							"venue_id", venueID,
+							"error", err.Error(),
+						)
+					}
+				}
+			}()
 		}
 
 		return &UpdateVenueResponse{
@@ -793,4 +822,51 @@ func (h *VenueHandler) DeleteVenueHandler(ctx context.Context, req *DeleteVenueR
 			Message: "Venue deleted successfully",
 		},
 	}, nil
+}
+
+// computeVenueChanges compares old and new venue detail responses and returns field-level diffs.
+func computeVenueChanges(old, new *services.VenueDetailResponse) []models.FieldChange {
+	var changes []models.FieldChange
+
+	if old.Name != new.Name {
+		changes = append(changes, models.FieldChange{Field: "name", OldValue: old.Name, NewValue: new.Name})
+	}
+	if ptrToStr(old.Address) != ptrToStr(new.Address) {
+		changes = append(changes, models.FieldChange{Field: "address", OldValue: ptrToStr(old.Address), NewValue: ptrToStr(new.Address)})
+	}
+	if old.City != new.City {
+		changes = append(changes, models.FieldChange{Field: "city", OldValue: old.City, NewValue: new.City})
+	}
+	if old.State != new.State {
+		changes = append(changes, models.FieldChange{Field: "state", OldValue: old.State, NewValue: new.State})
+	}
+	if ptrToStr(old.Zipcode) != ptrToStr(new.Zipcode) {
+		changes = append(changes, models.FieldChange{Field: "zipcode", OldValue: ptrToStr(old.Zipcode), NewValue: ptrToStr(new.Zipcode)})
+	}
+	if ptrToStr(old.Social.Instagram) != ptrToStr(new.Social.Instagram) {
+		changes = append(changes, models.FieldChange{Field: "instagram", OldValue: ptrToStr(old.Social.Instagram), NewValue: ptrToStr(new.Social.Instagram)})
+	}
+	if ptrToStr(old.Social.Facebook) != ptrToStr(new.Social.Facebook) {
+		changes = append(changes, models.FieldChange{Field: "facebook", OldValue: ptrToStr(old.Social.Facebook), NewValue: ptrToStr(new.Social.Facebook)})
+	}
+	if ptrToStr(old.Social.Twitter) != ptrToStr(new.Social.Twitter) {
+		changes = append(changes, models.FieldChange{Field: "twitter", OldValue: ptrToStr(old.Social.Twitter), NewValue: ptrToStr(new.Social.Twitter)})
+	}
+	if ptrToStr(old.Social.YouTube) != ptrToStr(new.Social.YouTube) {
+		changes = append(changes, models.FieldChange{Field: "youtube", OldValue: ptrToStr(old.Social.YouTube), NewValue: ptrToStr(new.Social.YouTube)})
+	}
+	if ptrToStr(old.Social.Spotify) != ptrToStr(new.Social.Spotify) {
+		changes = append(changes, models.FieldChange{Field: "spotify", OldValue: ptrToStr(old.Social.Spotify), NewValue: ptrToStr(new.Social.Spotify)})
+	}
+	if ptrToStr(old.Social.SoundCloud) != ptrToStr(new.Social.SoundCloud) {
+		changes = append(changes, models.FieldChange{Field: "soundcloud", OldValue: ptrToStr(old.Social.SoundCloud), NewValue: ptrToStr(new.Social.SoundCloud)})
+	}
+	if ptrToStr(old.Social.Bandcamp) != ptrToStr(new.Social.Bandcamp) {
+		changes = append(changes, models.FieldChange{Field: "bandcamp", OldValue: ptrToStr(old.Social.Bandcamp), NewValue: ptrToStr(new.Social.Bandcamp)})
+	}
+	if ptrToStr(old.Social.Website) != ptrToStr(new.Social.Website) {
+		changes = append(changes, models.FieldChange{Field: "website", OldValue: ptrToStr(old.Social.Website), NewValue: ptrToStr(new.Social.Website)})
+	}
+
+	return changes
 }

--- a/backend/internal/api/handlers/venue_integration_test.go
+++ b/backend/internal/api/handlers/venue_integration_test.go
@@ -17,7 +17,7 @@ type VenueHandlerIntegrationSuite struct {
 
 func (s *VenueHandlerIntegrationSuite) SetupSuite() {
 	s.deps = setupHandlerIntegrationDeps(s.T())
-	s.handler = NewVenueHandler(s.deps.venueService, s.deps.discordService, s.deps.auditLogService)
+	s.handler = NewVenueHandler(s.deps.venueService, s.deps.discordService, s.deps.auditLogService, nil)
 }
 
 func (s *VenueHandlerIntegrationSuite) TearDownTest() {

--- a/backend/internal/api/handlers/venue_test.go
+++ b/backend/internal/api/handlers/venue_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func testVenueHandler() *VenueHandler {
-	return NewVenueHandler(nil, nil, nil)
+	return NewVenueHandler(nil, nil, nil, nil)
 }
 
 // --- NewVenueHandler ---

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -279,7 +279,7 @@ func setupShowRoutes(router *chi.Mux, api huma.API, protected *huma.Group, sc *s
 }
 
 func setupArtistRoutes(api huma.API, protected *huma.Group, sc *services.ServiceContainer) {
-	artistHandler := handlers.NewArtistHandler(sc.Artist, sc.AuditLog)
+	artistHandler := handlers.NewArtistHandler(sc.Artist, sc.AuditLog, sc.Revision)
 
 	// Public artist endpoints - registered on main API without middleware
 	// Note: Static routes must come before parameterized routes
@@ -332,7 +332,7 @@ func setupLabelRoutes(api huma.API, protected *huma.Group, sc *services.ServiceC
 }
 
 func setupFestivalRoutes(api huma.API, protected *huma.Group, sc *services.ServiceContainer) {
-	festivalHandler := handlers.NewFestivalHandler(sc.Festival, sc.Artist, sc.AuditLog)
+	festivalHandler := handlers.NewFestivalHandler(sc.Festival, sc.Artist, sc.AuditLog, sc.Revision)
 
 	// Public festival endpoints
 	huma.Get(api, "/festivals", festivalHandler.ListFestivalsHandler)
@@ -361,7 +361,7 @@ func setupFestivalRoutes(api huma.API, protected *huma.Group, sc *services.Servi
 }
 
 func setupVenueRoutes(api huma.API, protected *huma.Group, sc *services.ServiceContainer) {
-	venueHandler := handlers.NewVenueHandler(sc.Venue, sc.Discord, sc.AuditLog)
+	venueHandler := handlers.NewVenueHandler(sc.Venue, sc.Discord, sc.AuditLog, sc.Revision)
 
 	// Public venue endpoints - registered on main API without middleware
 	// Note: Static routes must come before parameterized routes
@@ -482,7 +482,7 @@ func setupAdminRoutes(protected *huma.Group, sc *services.ServiceContainer) {
 		sc.APIToken, sc.DataSync, sc.AuditLog, sc.User, sc.AdminStats,
 		sc.NotificationFilter,
 	)
-	artistHandler := handlers.NewArtistHandler(sc.Artist, sc.AuditLog)
+	artistHandler := handlers.NewArtistHandler(sc.Artist, sc.AuditLog, sc.Revision)
 	auditLogHandler := handlers.NewAuditLogHandler(sc.AuditLog)
 
 	// Admin dashboard stats endpoint


### PR DESCRIPTION
## Summary
- Added `revisionService` field **alongside** existing `auditLogService` in artist, venue, and festival handlers
- Each admin update handler now captures old values before the update, computes field-level diffs, and calls `RecordRevision()` fire-and-forget
- All three update request structs gain an optional `summary` field for edit reasons
- Routes updated to pass `sc.Revision` to all handler constructors
- All test files updated with the additional constructor parameter

This makes the existing `RevisionHistory` component on ArtistDetail/VenueDetail pages actually show edit history.

## Test plan
- [x] All existing handler tests pass (unit + integration)
- [x] Backend compiles cleanly
- [x] Constructor calls updated in all 6 test files
- [ ] Manual test: edit an artist in admin UI, verify revision appears in View History

Closes PSY-124

🤖 Generated with [Claude Code](https://claude.com/claude-code)