### PR TITLE
Add ph submit venue command

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -6,6 +6,7 @@ import * as display from "./lib/display";
 import { runInit } from "./commands/init";
 import { runConfigShow, runConfigSet } from "./commands/config";
 import { runSearch } from "./commands/search";
+import { runSubmitVenue } from "./commands/submit-venue";
 
 const program = new Command();
 
@@ -68,6 +69,12 @@ program
   .description("Submit entities for creation/update (artist, venue, show, release, label, festival)")
   .option("--confirm", "Actually submit (default is dry-run)")
   .action(async (entityType: string, json: string | undefined, opts: { confirm?: boolean }) => {
+    if (entityType === "venue") {
+      const env = await resolveEnvOrExit(program.opts().env);
+      await runSubmitVenue(json, opts, env);
+      return;
+    }
+
     display.warn(
       `"ph submit ${entityType}" is not yet implemented. Coming in PSY-142 through PSY-147.`,
     );

--- a/cli/src/commands/submit-venue.ts
+++ b/cli/src/commands/submit-venue.ts
@@ -1,0 +1,281 @@
+import { APIClient } from "../lib/api";
+import type { EnvironmentConfig } from "../lib/types";
+import { validateVenue } from "../lib/schemas";
+import { checkDuplicate, type DuplicateCheckResult } from "../lib/duplicates";
+import * as display from "../lib/display";
+
+interface VenueInput {
+  name: string;
+  city: string;
+  state: string;
+  country?: string;
+  address?: string;
+  zip_code?: string;
+  website?: string;
+  capacity?: number;
+  description?: string;
+}
+
+export interface SubmitVenuesResult {
+  creates: number;
+  updates: number;
+  skips: number;
+  errors: number;
+  results: Array<{
+    venue: VenueInput;
+    action: "create" | "update" | "skip" | "error";
+    message: string;
+  }>;
+}
+
+/**
+ * Parse venue JSON from a CLI argument or stdin.
+ * Accepts a single venue object or an array of venue objects.
+ */
+export async function parseVenueInput(
+  jsonArg: string | undefined,
+): Promise<Record<string, unknown>[]> {
+  let raw: string;
+
+  if (jsonArg) {
+    raw = jsonArg;
+  } else {
+    // Read from stdin
+    raw = await readStdin();
+  }
+
+  if (!raw.trim()) {
+    throw new Error("No JSON input provided. Pass JSON as argument or pipe via stdin.");
+  }
+
+  const parsed = JSON.parse(raw);
+
+  if (Array.isArray(parsed)) {
+    return parsed;
+  }
+
+  return [parsed];
+}
+
+async function readStdin(): Promise<string> {
+  const chunks: string[] = [];
+  const reader = Bun.stdin.stream().getReader();
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(new TextDecoder().decode(value));
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  return chunks.join("");
+}
+
+/**
+ * Submit venues for creation/update.
+ *
+ * Validates each venue, checks for duplicates, previews changes,
+ * and optionally executes API calls when confirm is true.
+ */
+export async function submitVenues(
+  client: APIClient,
+  venues: Record<string, unknown>[],
+  confirm: boolean,
+): Promise<SubmitVenuesResult> {
+  const result: SubmitVenuesResult = {
+    creates: 0,
+    updates: 0,
+    skips: 0,
+    errors: 0,
+    results: [],
+  };
+
+  // Step 1: Validate all venues first
+  const validVenues: Array<{ venue: Record<string, unknown>; index: number }> = [];
+
+  for (let i = 0; i < venues.length; i++) {
+    const venue = venues[i];
+    const validation = validateVenue(venue);
+
+    if (!validation.valid) {
+      const errorMsg = validation.errors
+        .map((e) => `${e.field}: ${e.message}`)
+        .join(", ");
+      display.error(
+        `Venue ${i + 1}: validation failed — ${errorMsg}`,
+      );
+      result.errors++;
+      result.results.push({
+        venue: venue as unknown as VenueInput,
+        action: "error",
+        message: `Validation failed: ${errorMsg}`,
+      });
+      continue;
+    }
+
+    validVenues.push({ venue, index: i });
+  }
+
+  if (validVenues.length === 0) {
+    return result;
+  }
+
+  // Step 2: Check for duplicates and classify actions
+  const plans: Array<{
+    venue: Record<string, unknown>;
+    index: number;
+    dupResult: DuplicateCheckResult;
+  }> = [];
+
+  for (const { venue, index } of validVenues) {
+    const dupResult = await checkDuplicate(client, "venue", venue);
+    plans.push({ venue, index, dupResult });
+  }
+
+  // Step 3: Display preview
+  display.header("Venue Submit Preview");
+
+  for (const { venue, index, dupResult } of plans) {
+    const venueName = String(venue.name);
+    const venueLocation = `${venue.city}, ${venue.state}`;
+
+    if (dupResult.action === "create") {
+      display.info(`#${index + 1} CREATE: ${venueName} (${venueLocation})`);
+    } else if (dupResult.action === "update") {
+      display.info(
+        `#${index + 1} UPDATE: ${venueName} → existing "${dupResult.existingName}" (ID ${dupResult.existingId})`,
+      );
+      for (const field of dupResult.fields) {
+        if (field.status === "new_info") {
+          display.fieldDiff(field.field, field.existing, field.proposed);
+        }
+      }
+    } else {
+      display.info(
+        `#${index + 1} SKIP: ${venueName} — already exists as "${dupResult.existingName}" (ID ${dupResult.existingId})`,
+      );
+    }
+  }
+
+  // Step 4: Summary
+  const createCount = plans.filter((p) => p.dupResult.action === "create").length;
+  const updateCount = plans.filter((p) => p.dupResult.action === "update").length;
+  const skipCount = plans.filter((p) => p.dupResult.action === "skip").length;
+
+  display.summary(createCount, updateCount, skipCount);
+
+  // Step 5: Execute if --confirm
+  if (!confirm) {
+    display.warn("Dry run — pass --confirm to execute.");
+    result.creates = createCount;
+    result.updates = updateCount;
+    result.skips = skipCount;
+
+    for (const { venue, dupResult } of plans) {
+      result.results.push({
+        venue: venue as unknown as VenueInput,
+        action: dupResult.action,
+        message: `Dry run: would ${dupResult.action}`,
+      });
+    }
+
+    return result;
+  }
+
+  // Execute API calls
+  for (const { venue, index, dupResult } of plans) {
+    const venueName = String(venue.name);
+
+    try {
+      if (dupResult.action === "create") {
+        await client.post("/admin/venues", venue);
+        display.success(`Created venue: ${venueName}`);
+        result.creates++;
+        result.results.push({
+          venue: venue as unknown as VenueInput,
+          action: "create",
+          message: "Created successfully",
+        });
+      } else if (dupResult.action === "update") {
+        // Build update body with only new_info fields
+        const updateBody: Record<string, unknown> = {};
+        for (const field of dupResult.fields) {
+          if (field.status === "new_info") {
+            updateBody[field.field] = venue[field.field];
+          }
+        }
+
+        if (Object.keys(updateBody).length > 0) {
+          await client.put(
+            `/venues/${dupResult.existingId}`,
+            updateBody,
+          );
+          display.success(
+            `Updated venue: ${venueName} (ID ${dupResult.existingId})`,
+          );
+        }
+        result.updates++;
+        result.results.push({
+          venue: venue as unknown as VenueInput,
+          action: "update",
+          message: `Updated (ID ${dupResult.existingId})`,
+        });
+      } else {
+        display.info(`Skipped venue: ${venueName} (already exists)`);
+        result.skips++;
+        result.results.push({
+          venue: venue as unknown as VenueInput,
+          action: "skip",
+          message: `Already exists (ID ${dupResult.existingId})`,
+        });
+      }
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Unknown error";
+      display.error(`Failed to ${dupResult.action} venue #${index + 1} "${venueName}": ${message}`);
+      result.errors++;
+      result.results.push({
+        venue: venue as unknown as VenueInput,
+        action: "error",
+        message: `API error: ${message}`,
+      });
+    }
+  }
+
+  return result;
+}
+
+/** CLI entry point for `ph submit venue`. */
+export async function runSubmitVenue(
+  json: string | undefined,
+  opts: { confirm?: boolean },
+  env: EnvironmentConfig,
+): Promise<void> {
+  const client = new APIClient(env);
+
+  let venues: Record<string, unknown>[];
+  try {
+    venues = await parseVenueInput(json);
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : "Invalid JSON input";
+    display.error(message);
+    process.exit(1);
+  }
+
+  if (venues.length === 0) {
+    display.warn("No venues in input.");
+    process.exit(0);
+  }
+
+  display.info(`Processing ${venues.length} venue${venues.length !== 1 ? "s" : ""}...`);
+
+  const result = await submitVenues(client, venues, opts.confirm ?? false);
+
+  if (result.errors > 0) {
+    process.exit(1);
+  }
+}

--- a/cli/test/submit-venue.test.ts
+++ b/cli/test/submit-venue.test.ts
@@ -1,0 +1,413 @@
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+import { submitVenues } from "../src/commands/submit-venue";
+import type { APIClient } from "../src/lib/api";
+
+/** Create a mock API client with configurable responses. */
+function createMockClient(overrides: {
+  get?: (path: string, params?: Record<string, string>) => Promise<unknown>;
+  post?: (path: string, body?: unknown) => Promise<unknown>;
+  put?: (path: string, body?: unknown) => Promise<unknown>;
+} = {}): APIClient {
+  return {
+    get: overrides.get ?? mock(() => Promise.resolve({ venues: [] })),
+    post: overrides.post ?? mock(() => Promise.resolve({ id: 1, name: "Test Venue", slug: "test-venue" })),
+    put: overrides.put ?? mock(() => Promise.resolve({ id: 1, name: "Test Venue", slug: "test-venue" })),
+    patch: mock(() => Promise.resolve({})),
+    delete: mock(() => Promise.resolve({})),
+    healthCheck: mock(() => Promise.resolve(true)),
+    verifyAuth: mock(() => Promise.resolve(null)),
+  } as unknown as APIClient;
+}
+
+describe("submitVenues", () => {
+  // Suppress stderr output during tests
+  let originalWrite: typeof process.stderr.write;
+  beforeEach(() => {
+    originalWrite = process.stderr.write;
+    process.stderr.write = mock(() => true) as unknown as typeof process.stderr.write;
+  });
+
+  // Restore after each test
+  const restoreStderr = () => {
+    process.stderr.write = originalWrite;
+  };
+
+  test("single venue create — no duplicates found", async () => {
+    const client = createMockClient({
+      get: mock(() => Promise.resolve({ venues: [] })),
+    });
+
+    const venues = [
+      { name: "Crescent Ballroom", city: "Phoenix", state: "AZ", website: "https://crescentphx.com" },
+    ];
+
+    const result = await submitVenues(client, venues, false);
+    restoreStderr();
+
+    expect(result.creates).toBe(1);
+    expect(result.updates).toBe(0);
+    expect(result.skips).toBe(0);
+    expect(result.errors).toBe(0);
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0].action).toBe("create");
+  });
+
+  test("single venue create with --confirm calls POST /admin/venues", async () => {
+    const postMock = mock(() =>
+      Promise.resolve({ id: 5, name: "Crescent Ballroom", slug: "crescent-ballroom" }),
+    );
+    const client = createMockClient({
+      get: mock(() => Promise.resolve({ venues: [] })),
+      post: postMock,
+    });
+
+    const venues = [
+      { name: "Crescent Ballroom", city: "Phoenix", state: "AZ" },
+    ];
+
+    const result = await submitVenues(client, venues, true);
+    restoreStderr();
+
+    expect(result.creates).toBe(1);
+    expect(result.errors).toBe(0);
+    expect(postMock).toHaveBeenCalledTimes(1);
+    expect(postMock).toHaveBeenCalledWith("/admin/venues", venues[0]);
+    expect(result.results[0].action).toBe("create");
+    expect(result.results[0].message).toBe("Created successfully");
+  });
+
+  test("single venue update — existing match with new address info", async () => {
+    const client = createMockClient({
+      get: mock(() =>
+        Promise.resolve({
+          venues: [
+            {
+              id: 42,
+              name: "Crescent Ballroom",
+              slug: "crescent-ballroom",
+              city: "Phoenix",
+              state: "AZ",
+              country: "",
+              address: "",
+              zip_code: "",
+              website: "",
+              capacity: "",
+              description: "",
+            },
+          ],
+        }),
+      ),
+    });
+
+    const venues = [
+      {
+        name: "Crescent Ballroom",
+        city: "Phoenix",
+        state: "AZ",
+        address: "308 N 2nd Ave",
+        website: "https://crescentphx.com",
+      },
+    ];
+
+    const result = await submitVenues(client, venues, false);
+    restoreStderr();
+
+    expect(result.updates).toBe(1);
+    expect(result.creates).toBe(0);
+    expect(result.skips).toBe(0);
+    expect(result.errors).toBe(0);
+    expect(result.results[0].action).toBe("update");
+  });
+
+  test("single venue update with --confirm calls PUT /venues/{id} with new_info fields only", async () => {
+    const putMock = mock(() =>
+      Promise.resolve({ id: 42, name: "Crescent Ballroom", slug: "crescent-ballroom" }),
+    );
+    const client = createMockClient({
+      get: mock(() =>
+        Promise.resolve({
+          venues: [
+            {
+              id: 42,
+              name: "Crescent Ballroom",
+              slug: "crescent-ballroom",
+              city: "Phoenix",
+              state: "AZ",
+              country: "",
+              address: "",
+              zip_code: "",
+              website: "https://existing.com",
+              capacity: "",
+              description: "",
+            },
+          ],
+        }),
+      ),
+      put: putMock,
+    });
+
+    const venues = [
+      {
+        name: "Crescent Ballroom",
+        city: "Phoenix",
+        state: "AZ",
+        address: "308 N 2nd Ave",
+        website: "https://crescentphx.com",
+      },
+    ];
+
+    const result = await submitVenues(client, venues, true);
+    restoreStderr();
+
+    expect(result.updates).toBe(1);
+    expect(putMock).toHaveBeenCalledTimes(1);
+    // Should only send address (new_info), not website (already_set)
+    expect(putMock).toHaveBeenCalledWith("/venues/42", { address: "308 N 2nd Ave" });
+  });
+
+  test("single venue skip — exact duplicate, no new info", async () => {
+    const client = createMockClient({
+      get: mock(() =>
+        Promise.resolve({
+          venues: [
+            {
+              id: 10,
+              name: "The Van Buren",
+              slug: "the-van-buren",
+              city: "Phoenix",
+              state: "AZ",
+              country: "US",
+              address: "401 W Van Buren St",
+              zip_code: "85003",
+              website: "https://thevanburenphx.com",
+              capacity: "1800",
+              description: "Live music venue in downtown Phoenix",
+            },
+          ],
+        }),
+      ),
+    });
+
+    const venues = [
+      {
+        name: "The Van Buren",
+        city: "Phoenix",
+        state: "AZ",
+      },
+    ];
+
+    const result = await submitVenues(client, venues, false);
+    restoreStderr();
+
+    expect(result.skips).toBe(1);
+    expect(result.creates).toBe(0);
+    expect(result.updates).toBe(0);
+    expect(result.errors).toBe(0);
+    expect(result.results[0].action).toBe("skip");
+  });
+
+  test("validation error — missing city", async () => {
+    const client = createMockClient();
+
+    const venues = [
+      { name: "Test Venue", state: "AZ" },
+    ];
+
+    const result = await submitVenues(client, venues, false);
+    restoreStderr();
+
+    expect(result.errors).toBe(1);
+    expect(result.creates).toBe(0);
+    expect(result.results[0].action).toBe("error");
+    expect(result.results[0].message).toContain("city");
+  });
+
+  test("validation error — missing state", async () => {
+    const client = createMockClient();
+
+    const venues = [
+      { name: "Test Venue", city: "Phoenix" },
+    ];
+
+    const result = await submitVenues(client, venues, false);
+    restoreStderr();
+
+    expect(result.errors).toBe(1);
+    expect(result.results[0].action).toBe("error");
+    expect(result.results[0].message).toContain("state");
+  });
+
+  test("validation error — missing name", async () => {
+    const client = createMockClient();
+
+    const venues = [
+      { city: "Phoenix", state: "AZ" },
+    ];
+
+    const result = await submitVenues(client, venues, false);
+    restoreStderr();
+
+    expect(result.errors).toBe(1);
+    expect(result.results[0].message).toContain("name");
+  });
+
+  test("validation error — not an object", async () => {
+    const client = createMockClient();
+
+    const venues = ["not an object" as unknown as Record<string, unknown>];
+
+    const result = await submitVenues(client, venues, false);
+    restoreStderr();
+
+    expect(result.errors).toBe(1);
+    expect(result.results[0].action).toBe("error");
+  });
+
+  test("dry-run mode does not make API calls", async () => {
+    const postMock = mock(() => Promise.resolve({}));
+    const putMock = mock(() => Promise.resolve({}));
+
+    const client = createMockClient({
+      get: mock(() => Promise.resolve({ venues: [] })),
+      post: postMock,
+      put: putMock,
+    });
+
+    const venues = [
+      { name: "New Venue", city: "Phoenix", state: "AZ" },
+    ];
+
+    const result = await submitVenues(client, venues, false);
+    restoreStderr();
+
+    expect(result.creates).toBe(1);
+    expect(postMock).not.toHaveBeenCalled();
+    expect(putMock).not.toHaveBeenCalled();
+    expect(result.results[0].message).toContain("Dry run");
+  });
+
+  test("confirm mode makes API calls for creates", async () => {
+    const postMock = mock(() =>
+      Promise.resolve({ id: 1, name: "New Venue", slug: "new-venue" }),
+    );
+
+    const client = createMockClient({
+      get: mock(() => Promise.resolve({ venues: [] })),
+      post: postMock,
+    });
+
+    const venues = [
+      { name: "New Venue", city: "Phoenix", state: "AZ" },
+    ];
+
+    const result = await submitVenues(client, venues, true);
+    restoreStderr();
+
+    expect(result.creates).toBe(1);
+    expect(postMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("multiple venues with mixed actions", async () => {
+    const client = createMockClient({
+      get: mock((path: string, params?: Record<string, string>) => {
+        // Simulate: first venue matches nothing, second matches existing
+        const q = params?.q ?? "";
+        if (q === "Brand New Venue") {
+          return Promise.resolve({ venues: [] });
+        }
+        if (q === "Existing Place") {
+          return Promise.resolve({
+            venues: [
+              {
+                id: 99,
+                name: "Existing Place",
+                slug: "existing-place",
+                city: "Phoenix",
+                state: "AZ",
+                country: "",
+                address: "",
+                zip_code: "",
+                website: "",
+                capacity: "",
+                description: "",
+              },
+            ],
+          });
+        }
+        return Promise.resolve({ venues: [] });
+      }),
+    });
+
+    const venues = [
+      { name: "Brand New Venue", city: "Tempe", state: "AZ" },
+      { name: "Existing Place", city: "Phoenix", state: "AZ" },
+    ];
+
+    const result = await submitVenues(client, venues, false);
+    restoreStderr();
+
+    expect(result.creates).toBe(1);
+    expect(result.skips).toBe(1);
+    expect(result.errors).toBe(0);
+    expect(result.results).toHaveLength(2);
+  });
+
+  test("API error during confirm is handled gracefully", async () => {
+    const client = createMockClient({
+      get: mock(() => Promise.resolve({ venues: [] })),
+      post: mock(() => Promise.reject(new Error("Server error: 500"))),
+    });
+
+    const venues = [
+      { name: "Failing Venue", city: "Phoenix", state: "AZ" },
+    ];
+
+    const result = await submitVenues(client, venues, true);
+    restoreStderr();
+
+    expect(result.errors).toBe(1);
+    expect(result.creates).toBe(0);
+    expect(result.results[0].action).toBe("error");
+    expect(result.results[0].message).toContain("500");
+  });
+
+  test("skip with --confirm logs skip without API calls", async () => {
+    const postMock = mock(() => Promise.resolve({}));
+    const putMock = mock(() => Promise.resolve({}));
+
+    const client = createMockClient({
+      get: mock(() =>
+        Promise.resolve({
+          venues: [
+            {
+              id: 10,
+              name: "The Van Buren",
+              slug: "the-van-buren",
+              city: "Phoenix",
+              state: "AZ",
+              country: "",
+              address: "",
+              zip_code: "",
+              website: "",
+              capacity: "",
+              description: "",
+            },
+          ],
+        }),
+      ),
+      post: postMock,
+      put: putMock,
+    });
+
+    const venues = [
+      { name: "The Van Buren", city: "Phoenix", state: "AZ" },
+    ];
+
+    const result = await submitVenues(client, venues, true);
+    restoreStderr();
+
+    expect(result.skips).toBe(1);
+    expect(postMock).not.toHaveBeenCalled();
+    expect(putMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Add `ph submit venue` command with duplicate detection (name+city matching), dry-run preview, create/update flow
- Updates only send `new_info` fields via PUT
- 14 tests covering create, update, skip, validation, dry-run, confirm, API errors
- Part of [PH CLI project](https://github.com/mtrifilo/psychic-homily-web/pull/127)

## Test plan
- [x] Single venue create, update (new address), skip
- [x] Validation errors (missing city/state)
- [x] Dry-run vs confirm modes
- [x] `bun test` passes, `tsc --noEmit` clean

Closes PSY-143

🤖 Generated with [Claude Code](https://claude.com/claude-code)