### PR TITLE
Add ph submit show command

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -6,6 +6,7 @@ import * as display from "./lib/display";
 import { runInit } from "./commands/init";
 import { runConfigShow, runConfigSet } from "./commands/config";
 import { runSearch } from "./commands/search";
+import { runSubmitShow } from "./commands/submit-show";
 
 const program = new Command();
 
@@ -68,10 +69,18 @@ program
   .description("Submit entities for creation/update (artist, venue, show, release, label, festival)")
   .option("--confirm", "Actually submit (default is dry-run)")
   .action(async (entityType: string, json: string | undefined, opts: { confirm?: boolean }) => {
-    display.warn(
-      `"ph submit ${entityType}" is not yet implemented. Coming in PSY-142 through PSY-147.`,
-    );
-    process.exit(1);
+    switch (entityType) {
+      case "show": {
+        const env = await resolveEnvOrExit(program.opts().env);
+        await runSubmitShow(json, env, !!opts.confirm);
+        break;
+      }
+      default:
+        display.warn(
+          `"ph submit ${entityType}" is not yet implemented. Coming in PSY-142 through PSY-147.`,
+        );
+        process.exit(1);
+    }
   });
 
 // ─── ph batch (stub — will be implemented in PSY-148) ──────────────────────

--- a/cli/src/commands/submit-show.ts
+++ b/cli/src/commands/submit-show.ts
@@ -1,0 +1,366 @@
+import { APIClient } from "../lib/api";
+import type { EnvironmentConfig } from "../lib/types";
+import { validateShow } from "../lib/schemas";
+import { searchArtistsByName, searchVenuesByName } from "../lib/duplicates";
+import * as display from "../lib/display";
+import { green, yellow, dim, gray } from "../lib/ansi";
+
+// -- Types -------------------------------------------------------------------
+
+interface ShowArtistInput {
+  name: string;
+  is_headliner?: boolean;
+}
+
+interface ShowVenueInput {
+  name: string;
+  city?: string;
+  state?: string;
+  address?: string;
+}
+
+interface ShowInput {
+  event_date: string;
+  title?: string;
+  city: string;
+  state: string;
+  price?: number;
+  age_requirement?: string;
+  description?: string;
+  artists: ShowArtistInput[];
+  venues: ShowVenueInput[];
+}
+
+interface ResolvedArtist {
+  id?: number;
+  name: string;
+  is_headliner?: boolean;
+  status: "existing" | "new";
+}
+
+interface ResolvedVenue {
+  id?: number;
+  name: string;
+  city?: string;
+  state?: string;
+  address?: string;
+  status: "existing" | "new";
+}
+
+export interface ShowPlan {
+  input: ShowInput;
+  artists: ResolvedArtist[];
+  venues: ResolvedVenue[];
+  valid: boolean;
+  errors: string[];
+}
+
+export interface SubmitShowsResult {
+  plans: ShowPlan[];
+  created: number;
+  failed: number;
+  skipped: number;
+}
+
+// -- Core logic (exported for testing) ---------------------------------------
+
+/** Parse JSON input into an array of show objects. */
+export function parseShowInput(jsonStr: string): ShowInput[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonStr);
+  } catch {
+    throw new Error("Invalid JSON input");
+  }
+
+  if (Array.isArray(parsed)) {
+    return parsed as ShowInput[];
+  }
+  return [parsed as ShowInput];
+}
+
+/** Resolve artists against the API, returning resolved entries with IDs when found. */
+export async function resolveArtists(
+  client: APIClient,
+  artists: ShowArtistInput[],
+): Promise<ResolvedArtist[]> {
+  const resolved: ResolvedArtist[] = [];
+
+  for (const artist of artists) {
+    try {
+      const results = await searchArtistsByName(client, artist.name);
+      if (results.length > 0) {
+        // Use the best match (first result from search)
+        resolved.push({
+          id: results[0].id,
+          name: results[0].name,
+          is_headliner: artist.is_headliner,
+          status: "existing",
+        });
+      } else {
+        resolved.push({
+          name: artist.name,
+          is_headliner: artist.is_headliner,
+          status: "new",
+        });
+      }
+    } catch {
+      // If search fails, treat as new
+      resolved.push({
+        name: artist.name,
+        is_headliner: artist.is_headliner,
+        status: "new",
+      });
+    }
+  }
+
+  return resolved;
+}
+
+/** Resolve venues against the API, returning resolved entries with IDs when found. */
+export async function resolveVenues(
+  client: APIClient,
+  venues: ShowVenueInput[],
+): Promise<ResolvedVenue[]> {
+  const resolved: ResolvedVenue[] = [];
+
+  for (const venue of venues) {
+    try {
+      const results = await searchVenuesByName(client, venue.name);
+      if (results.length > 0) {
+        resolved.push({
+          id: results[0].id,
+          name: results[0].name,
+          city: venue.city,
+          state: venue.state,
+          address: venue.address,
+          status: "existing",
+        });
+      } else {
+        resolved.push({
+          name: venue.name,
+          city: venue.city,
+          state: venue.state,
+          address: venue.address,
+          status: "new",
+        });
+      }
+    } catch {
+      resolved.push({
+        name: venue.name,
+        city: venue.city,
+        state: venue.state,
+        address: venue.address,
+        status: "new",
+      });
+    }
+  }
+
+  return resolved;
+}
+
+/** Build the API request body for creating a show. */
+export function buildShowPayload(plan: ShowPlan): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    event_date: plan.input.event_date,
+    city: plan.input.city,
+    state: plan.input.state,
+    artists: plan.artists.map((a) => {
+      const artist: Record<string, unknown> = {};
+      if (a.id) artist.id = a.id;
+      if (!a.id) artist.name = a.name;
+      if (a.is_headliner !== undefined) artist.is_headliner = a.is_headliner;
+      return artist;
+    }),
+    venues: plan.venues.map((v) => {
+      const venue: Record<string, unknown> = {};
+      if (v.id) venue.id = v.id;
+      if (!v.id) {
+        venue.name = v.name;
+        if (v.city) venue.city = v.city;
+        if (v.state) venue.state = v.state;
+        if (v.address) venue.address = v.address;
+      }
+      return venue;
+    }),
+  };
+
+  if (plan.input.title) payload.title = plan.input.title;
+  if (plan.input.price !== undefined) payload.price = plan.input.price;
+  if (plan.input.age_requirement) payload.age_requirement = plan.input.age_requirement;
+  if (plan.input.description) payload.description = plan.input.description;
+
+  return payload;
+}
+
+/** Main entry point: validate, resolve, preview, and optionally submit shows. */
+export async function submitShows(
+  client: APIClient,
+  jsonStr: string,
+  confirm: boolean,
+): Promise<SubmitShowsResult> {
+  // 1. Parse input
+  const shows = parseShowInput(jsonStr);
+
+  // 2. Validate and resolve each show
+  const plans: ShowPlan[] = [];
+
+  for (const show of shows) {
+    const validation = validateShow(show);
+    if (!validation.valid) {
+      plans.push({
+        input: show,
+        artists: [],
+        venues: [],
+        valid: false,
+        errors: validation.errors.map((e) => `${e.field}: ${e.message}`),
+      });
+      continue;
+    }
+
+    // Resolve artists and venues against API
+    const artists = await resolveArtists(client, show.artists);
+    const venues = await resolveVenues(client, show.venues);
+
+    plans.push({
+      input: show,
+      artists,
+      venues,
+      valid: true,
+      errors: [],
+    });
+  }
+
+  // 3. Display preview
+  displayPreview(plans);
+
+  // 4. Summary
+  const validPlans = plans.filter((p) => p.valid);
+  const invalidCount = plans.length - validPlans.length;
+
+  if (invalidCount > 0) {
+    display.warn(`${invalidCount} show${invalidCount !== 1 ? "s" : ""} failed validation and will be skipped.`);
+  }
+
+  if (validPlans.length === 0) {
+    display.error("No valid shows to submit.");
+    return { plans, created: 0, failed: 0, skipped: plans.length };
+  }
+
+  // 5. Submit if confirmed
+  if (!confirm) {
+    display.info(`Dry run: ${validPlans.length} show${validPlans.length !== 1 ? "s" : ""} would be created. Use --confirm to submit.`);
+    return { plans, created: 0, failed: 0, skipped: validPlans.length };
+  }
+
+  let created = 0;
+  let failed = 0;
+
+  for (const plan of validPlans) {
+    const payload = buildShowPayload(plan);
+    try {
+      const result = await client.post<{ id: number; slug?: string }>("/shows", payload);
+      created++;
+      const label = plan.input.title || `${plan.input.event_date} show`;
+      display.success(`Created: ${label} (ID: ${result.id})`);
+    } catch (err) {
+      failed++;
+      const label = plan.input.title || `${plan.input.event_date} show`;
+      const message = err instanceof Error ? err.message : "Unknown error";
+      display.error(`Failed to create ${label}: ${message}`);
+    }
+  }
+
+  display.summary(created, 0, failed + invalidCount);
+
+  return { plans, created, failed, skipped: invalidCount };
+}
+
+// -- Display helpers ---------------------------------------------------------
+
+function displayPreview(plans: ShowPlan[]): void {
+  for (let i = 0; i < plans.length; i++) {
+    const plan = plans[i];
+    const idx = plans.length > 1 ? ` [${i + 1}/${plans.length}]` : "";
+
+    if (!plan.valid) {
+      display.header(`Show${idx}: INVALID`);
+      for (const err of plan.errors) {
+        display.error(err);
+      }
+      continue;
+    }
+
+    const label = plan.input.title || `${plan.input.event_date} in ${plan.input.city}, ${plan.input.state}`;
+    display.header(`Show${idx}: ${label}`);
+    display.kv("Date", plan.input.event_date);
+    display.kv("Location", `${plan.input.city}, ${plan.input.state}`);
+
+    if (plan.input.price !== undefined) {
+      display.kv("Price", `$${plan.input.price}`);
+    }
+    if (plan.input.age_requirement) {
+      display.kv("Ages", plan.input.age_requirement);
+    }
+
+    // Artists
+    process.stderr.write(`\n  ${gray("Artists:")}\n`);
+    for (const artist of plan.artists) {
+      const tag = artist.status === "existing"
+        ? green(`EXISTING (ID: ${artist.id})`)
+        : yellow("NEW");
+      const headliner = artist.is_headliner ? dim(" [headliner]") : "";
+      process.stderr.write(`    ${artist.name} ${tag}${headliner}\n`);
+    }
+
+    // Venues
+    process.stderr.write(`\n  ${gray("Venues:")}\n`);
+    for (const venue of plan.venues) {
+      const tag = venue.status === "existing"
+        ? green(`EXISTING (ID: ${venue.id})`)
+        : yellow("NEW");
+      process.stderr.write(`    ${venue.name} ${tag}\n`);
+    }
+  }
+}
+
+// -- CLI runner (called from cli.ts) -----------------------------------------
+
+export async function runSubmitShow(
+  json: string | undefined,
+  env: EnvironmentConfig,
+  confirm: boolean,
+): Promise<void> {
+  let jsonStr: string;
+
+  if (json) {
+    jsonStr = json;
+  } else {
+    // Read from stdin
+    jsonStr = await readStdin();
+    if (!jsonStr.trim()) {
+      display.error("No JSON input provided. Pass JSON as argument or pipe via stdin.");
+      process.exit(1);
+    }
+  }
+
+  const client = new APIClient(env);
+  const result = await submitShows(client, jsonStr, confirm);
+
+  if (result.failed > 0 || (result.created === 0 && confirm)) {
+    process.exit(1);
+  }
+}
+
+async function readStdin(): Promise<string> {
+  // Check if stdin has data (piped input)
+  if (process.stdin.isTTY) {
+    return "";
+  }
+
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(new Uint8Array(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf-8");
+}

--- a/cli/src/lib/duplicates.ts
+++ b/cli/src/lib/duplicates.ts
@@ -498,3 +498,21 @@ export async function checkDuplicate(
     confidence: best.confidence,
   };
 }
+
+// -- Public search helpers for use by submit commands -------------------------
+
+/** Search for artists by name. Returns matching results from the API. */
+export async function searchArtistsByName(
+  client: APIClient,
+  name: string,
+): Promise<EntitySearchResult[]> {
+  return searchArtists(client, name);
+}
+
+/** Search for venues by name. Returns matching results from the API. */
+export async function searchVenuesByName(
+  client: APIClient,
+  name: string,
+): Promise<EntitySearchResult[]> {
+  return searchVenues(client, name);
+}

--- a/cli/test/submit-show.test.ts
+++ b/cli/test/submit-show.test.ts
@@ -1,0 +1,510 @@
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+import {
+  parseShowInput,
+  resolveArtists,
+  resolveVenues,
+  buildShowPayload,
+  submitShows,
+  type ShowPlan,
+} from "../src/commands/submit-show";
+import { APIClient } from "../src/lib/api";
+
+// -- Mock helpers ------------------------------------------------------------
+
+function createMockClient(overrides: {
+  get?: (path: string, params?: Record<string, string>) => Promise<unknown>;
+  post?: (path: string, body?: unknown) => Promise<unknown>;
+} = {}): APIClient {
+  const client = Object.create(APIClient.prototype) as APIClient;
+
+  if (overrides.get) {
+    (client as unknown as Record<string, unknown>).get = overrides.get;
+  } else {
+    (client as unknown as Record<string, unknown>).get = async () => ({});
+  }
+
+  if (overrides.post) {
+    (client as unknown as Record<string, unknown>).post = overrides.post;
+  } else {
+    (client as unknown as Record<string, unknown>).post = async () => ({ id: 1 });
+  }
+
+  return client;
+}
+
+// -- parseShowInput ----------------------------------------------------------
+
+describe("parseShowInput", () => {
+  test("parses a single show object", () => {
+    const input = JSON.stringify({
+      event_date: "2026-04-15",
+      city: "Phoenix",
+      state: "AZ",
+      artists: [{ name: "Nina Hagen" }],
+      venues: [{ name: "Crescent Ballroom", city: "Phoenix", state: "AZ" }],
+    });
+
+    const result = parseShowInput(input);
+    expect(result).toHaveLength(1);
+    expect(result[0].event_date).toBe("2026-04-15");
+    expect(result[0].artists[0].name).toBe("Nina Hagen");
+  });
+
+  test("parses an array of shows", () => {
+    const input = JSON.stringify([
+      {
+        event_date: "2026-04-15",
+        city: "Phoenix",
+        state: "AZ",
+        artists: [{ name: "Nina Hagen" }],
+        venues: [{ name: "Crescent Ballroom", city: "Phoenix", state: "AZ" }],
+      },
+      {
+        event_date: "2026-04-16",
+        city: "Tucson",
+        state: "AZ",
+        artists: [{ name: "Nina Hagen" }],
+        venues: [{ name: "191 Toole", city: "Tucson", state: "AZ" }],
+      },
+    ]);
+
+    const result = parseShowInput(input);
+    expect(result).toHaveLength(2);
+    expect(result[0].city).toBe("Phoenix");
+    expect(result[1].city).toBe("Tucson");
+  });
+
+  test("throws on invalid JSON", () => {
+    expect(() => parseShowInput("not json")).toThrow("Invalid JSON input");
+  });
+});
+
+// -- resolveArtists ----------------------------------------------------------
+
+describe("resolveArtists", () => {
+  test("marks artist as existing when found in search", async () => {
+    const client = createMockClient({
+      get: async (path: string) => {
+        if (path.includes("/artists/search")) {
+          return {
+            artists: [{ id: 42, name: "Nina Hagen", slug: "nina-hagen" }],
+          };
+        }
+        return {};
+      },
+    });
+
+    const result = await resolveArtists(client, [{ name: "Nina Hagen" }]);
+    expect(result).toHaveLength(1);
+    expect(result[0].status).toBe("existing");
+    expect(result[0].id).toBe(42);
+    expect(result[0].name).toBe("Nina Hagen");
+  });
+
+  test("marks artist as new when not found in search", async () => {
+    const client = createMockClient({
+      get: async () => ({ artists: [] }),
+    });
+
+    const result = await resolveArtists(client, [{ name: "Unknown Band" }]);
+    expect(result).toHaveLength(1);
+    expect(result[0].status).toBe("new");
+    expect(result[0].name).toBe("Unknown Band");
+    expect(result[0].id).toBeUndefined();
+  });
+
+  test("preserves is_headliner flag", async () => {
+    const client = createMockClient({
+      get: async () => ({
+        artists: [{ id: 1, name: "Headliner", slug: "headliner" }],
+      }),
+    });
+
+    const result = await resolveArtists(client, [
+      { name: "Headliner", is_headliner: true },
+    ]);
+    expect(result[0].is_headliner).toBe(true);
+  });
+
+  test("treats search failure as new artist", async () => {
+    const client = createMockClient({
+      get: async () => { throw new Error("Network error"); },
+    });
+
+    const result = await resolveArtists(client, [{ name: "Test" }]);
+    expect(result).toHaveLength(1);
+    expect(result[0].status).toBe("new");
+  });
+});
+
+// -- resolveVenues -----------------------------------------------------------
+
+describe("resolveVenues", () => {
+  test("marks venue as existing when found in search", async () => {
+    const client = createMockClient({
+      get: async (path: string) => {
+        if (path.includes("/venues/search")) {
+          return {
+            venues: [
+              { id: 10, name: "Crescent Ballroom", slug: "crescent-ballroom", city: "Phoenix", state: "AZ" },
+            ],
+          };
+        }
+        return {};
+      },
+    });
+
+    const result = await resolveVenues(client, [
+      { name: "Crescent Ballroom", city: "Phoenix", state: "AZ" },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].status).toBe("existing");
+    expect(result[0].id).toBe(10);
+  });
+
+  test("marks venue as new when not found", async () => {
+    const client = createMockClient({
+      get: async () => ({ venues: [] }),
+    });
+
+    const result = await resolveVenues(client, [
+      { name: "New Venue", city: "Phoenix", state: "AZ" },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].status).toBe("new");
+    expect(result[0].name).toBe("New Venue");
+  });
+
+  test("treats search failure as new venue", async () => {
+    const client = createMockClient({
+      get: async () => { throw new Error("Network error"); },
+    });
+
+    const result = await resolveVenues(client, [
+      { name: "Test Venue", city: "Phoenix", state: "AZ" },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].status).toBe("new");
+  });
+});
+
+// -- buildShowPayload --------------------------------------------------------
+
+describe("buildShowPayload", () => {
+  test("builds payload with existing artist ID", () => {
+    const plan: ShowPlan = {
+      input: {
+        event_date: "2026-04-15",
+        city: "Phoenix",
+        state: "AZ",
+        artists: [{ name: "Nina Hagen" }],
+        venues: [{ name: "Crescent Ballroom", city: "Phoenix", state: "AZ" }],
+      },
+      artists: [{ id: 42, name: "Nina Hagen", status: "existing" }],
+      venues: [{ id: 10, name: "Crescent Ballroom", status: "existing" }],
+      valid: true,
+      errors: [],
+    };
+
+    const payload = buildShowPayload(plan);
+    expect(payload.event_date).toBe("2026-04-15");
+    expect(payload.city).toBe("Phoenix");
+
+    const artists = payload.artists as Array<Record<string, unknown>>;
+    expect(artists[0].id).toBe(42);
+    expect(artists[0].name).toBeUndefined();
+
+    const venues = payload.venues as Array<Record<string, unknown>>;
+    expect(venues[0].id).toBe(10);
+    expect(venues[0].name).toBeUndefined();
+  });
+
+  test("builds payload with new artist name", () => {
+    const plan: ShowPlan = {
+      input: {
+        event_date: "2026-04-15",
+        city: "Phoenix",
+        state: "AZ",
+        artists: [{ name: "New Band" }],
+        venues: [{ name: "New Venue", city: "Phoenix", state: "AZ" }],
+      },
+      artists: [{ name: "New Band", status: "new" }],
+      venues: [{ name: "New Venue", city: "Phoenix", state: "AZ", status: "new" }],
+      valid: true,
+      errors: [],
+    };
+
+    const payload = buildShowPayload(plan);
+    const artists = payload.artists as Array<Record<string, unknown>>;
+    expect(artists[0].name).toBe("New Band");
+    expect(artists[0].id).toBeUndefined();
+
+    const venues = payload.venues as Array<Record<string, unknown>>;
+    expect(venues[0].name).toBe("New Venue");
+    expect(venues[0].city).toBe("Phoenix");
+    expect(venues[0].state).toBe("AZ");
+  });
+
+  test("includes optional fields when provided", () => {
+    const plan: ShowPlan = {
+      input: {
+        event_date: "2026-04-15",
+        city: "Phoenix",
+        state: "AZ",
+        title: "Special Show",
+        price: 25,
+        age_requirement: "21+",
+        description: "A great show",
+        artists: [{ name: "Test" }],
+        venues: [{ name: "Test Venue" }],
+      },
+      artists: [{ name: "Test", status: "new" }],
+      venues: [{ name: "Test Venue", status: "new" }],
+      valid: true,
+      errors: [],
+    };
+
+    const payload = buildShowPayload(plan);
+    expect(payload.title).toBe("Special Show");
+    expect(payload.price).toBe(25);
+    expect(payload.age_requirement).toBe("21+");
+    expect(payload.description).toBe("A great show");
+  });
+});
+
+// -- submitShows (integration) -----------------------------------------------
+
+describe("submitShows", () => {
+  test("single show with existing artist and venue (resolved by search)", async () => {
+    const getMock = async (path: string) => {
+      if (path.includes("/artists/search")) {
+        return { artists: [{ id: 42, name: "Nina Hagen", slug: "nina-hagen" }] };
+      }
+      if (path.includes("/venues/search")) {
+        return {
+          venues: [
+            { id: 10, name: "Crescent Ballroom", slug: "crescent-ballroom", city: "Phoenix", state: "AZ" },
+          ],
+        };
+      }
+      return {};
+    };
+
+    const postMock = async (_path: string, body?: unknown) => {
+      return { id: 100, slug: "2026-04-15-crescent-ballroom" };
+    };
+
+    const client = createMockClient({ get: getMock, post: postMock });
+
+    const json = JSON.stringify({
+      event_date: "2026-04-15",
+      city: "Phoenix",
+      state: "AZ",
+      artists: [{ name: "Nina Hagen" }],
+      venues: [{ name: "Crescent Ballroom", city: "Phoenix", state: "AZ" }],
+    });
+
+    const result = await submitShows(client, json, true);
+    expect(result.created).toBe(1);
+    expect(result.failed).toBe(0);
+    expect(result.plans[0].artists[0].status).toBe("existing");
+    expect(result.plans[0].artists[0].id).toBe(42);
+    expect(result.plans[0].venues[0].status).toBe("existing");
+    expect(result.plans[0].venues[0].id).toBe(10);
+  });
+
+  test("show with new artist (not found in search)", async () => {
+    const getMock = async (path: string) => {
+      if (path.includes("/artists/search")) {
+        return { artists: [] }; // Not found
+      }
+      if (path.includes("/venues/search")) {
+        return {
+          venues: [
+            { id: 10, name: "Crescent Ballroom", slug: "crescent-ballroom", city: "Phoenix", state: "AZ" },
+          ],
+        };
+      }
+      return {};
+    };
+
+    const client = createMockClient({
+      get: getMock,
+      post: async () => ({ id: 101 }),
+    });
+
+    const json = JSON.stringify({
+      event_date: "2026-04-15",
+      city: "Phoenix",
+      state: "AZ",
+      artists: [{ name: "Brand New Band" }],
+      venues: [{ name: "Crescent Ballroom", city: "Phoenix", state: "AZ" }],
+    });
+
+    const result = await submitShows(client, json, true);
+    expect(result.created).toBe(1);
+    expect(result.plans[0].artists[0].status).toBe("new");
+    expect(result.plans[0].artists[0].name).toBe("Brand New Band");
+  });
+
+  test("tour announcement: array of shows with shared artist, different venues", async () => {
+    const getMock = async (path: string) => {
+      if (path.includes("/artists/search")) {
+        return { artists: [{ id: 42, name: "Nina Hagen", slug: "nina-hagen" }] };
+      }
+      if (path.includes("/venues/search")) {
+        return { venues: [] }; // All venues new for simplicity
+      }
+      return {};
+    };
+
+    let postCount = 0;
+    const client = createMockClient({
+      get: getMock,
+      post: async () => ({ id: 200 + ++postCount }),
+    });
+
+    const json = JSON.stringify([
+      {
+        event_date: "2026-04-15",
+        city: "Phoenix",
+        state: "AZ",
+        artists: [{ name: "Nina Hagen" }],
+        venues: [{ name: "Crescent Ballroom", city: "Phoenix", state: "AZ" }],
+      },
+      {
+        event_date: "2026-04-16",
+        city: "Tucson",
+        state: "AZ",
+        artists: [{ name: "Nina Hagen" }],
+        venues: [{ name: "191 Toole", city: "Tucson", state: "AZ" }],
+      },
+      {
+        event_date: "2026-04-17",
+        city: "Flagstaff",
+        state: "AZ",
+        artists: [{ name: "Nina Hagen" }],
+        venues: [{ name: "The Orpheum", city: "Flagstaff", state: "AZ" }],
+      },
+    ]);
+
+    const result = await submitShows(client, json, true);
+    expect(result.created).toBe(3);
+    expect(result.failed).toBe(0);
+    expect(result.plans).toHaveLength(3);
+    // All share same artist resolved as existing
+    for (const plan of result.plans) {
+      expect(plan.artists[0].status).toBe("existing");
+      expect(plan.artists[0].id).toBe(42);
+    }
+  });
+
+  test("validation error: missing event_date", async () => {
+    const client = createMockClient();
+
+    const json = JSON.stringify({
+      city: "Phoenix",
+      state: "AZ",
+      artists: [{ name: "Test" }],
+      venues: [{ name: "Test Venue" }],
+    });
+
+    const result = await submitShows(client, json, true);
+    expect(result.created).toBe(0);
+    expect(result.plans[0].valid).toBe(false);
+    expect(result.plans[0].errors.some((e) => e.includes("event_date"))).toBe(true);
+  });
+
+  test("dry-run mode: does not call POST", async () => {
+    let postCalled = false;
+    const client = createMockClient({
+      get: async () => ({ artists: [], venues: [] }),
+      post: async () => {
+        postCalled = true;
+        return { id: 1 };
+      },
+    });
+
+    const json = JSON.stringify({
+      event_date: "2026-04-15",
+      city: "Phoenix",
+      state: "AZ",
+      artists: [{ name: "Test" }],
+      venues: [{ name: "Test Venue" }],
+    });
+
+    const result = await submitShows(client, json, false); // dry-run
+    expect(result.created).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(postCalled).toBe(false);
+  });
+
+  test("confirm mode: calls POST and reports success", async () => {
+    let postCalled = false;
+    const client = createMockClient({
+      get: async () => ({ artists: [], venues: [] }),
+      post: async () => {
+        postCalled = true;
+        return { id: 99 };
+      },
+    });
+
+    const json = JSON.stringify({
+      event_date: "2026-04-15",
+      city: "Phoenix",
+      state: "AZ",
+      artists: [{ name: "Test" }],
+      venues: [{ name: "Test Venue" }],
+    });
+
+    const result = await submitShows(client, json, true); // confirm
+    expect(result.created).toBe(1);
+    expect(postCalled).toBe(true);
+  });
+
+  test("handles API error during creation", async () => {
+    const client = createMockClient({
+      get: async () => ({ artists: [], venues: [] }),
+      post: async () => { throw new Error("Server error"); },
+    });
+
+    const json = JSON.stringify({
+      event_date: "2026-04-15",
+      city: "Phoenix",
+      state: "AZ",
+      artists: [{ name: "Test" }],
+      venues: [{ name: "Test Venue" }],
+    });
+
+    const result = await submitShows(client, json, true);
+    expect(result.created).toBe(0);
+    expect(result.failed).toBe(1);
+  });
+
+  test("mixed valid and invalid shows in array", async () => {
+    const client = createMockClient({
+      get: async () => ({ artists: [], venues: [] }),
+      post: async () => ({ id: 1 }),
+    });
+
+    const json = JSON.stringify([
+      {
+        event_date: "2026-04-15",
+        city: "Phoenix",
+        state: "AZ",
+        artists: [{ name: "Test" }],
+        venues: [{ name: "Test Venue" }],
+      },
+      {
+        // Missing event_date, city, state
+        artists: [{ name: "Test" }],
+        venues: [{ name: "Test Venue" }],
+      },
+    ]);
+
+    const result = await submitShows(client, json, true);
+    expect(result.created).toBe(1);
+    expect(result.plans[0].valid).toBe(true);
+    expect(result.plans[1].valid).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `ph submit show` command with artist/venue resolution (searches existing, uses ID or creates new)
- Supports tour announcements (array of shows with shared artists, different venues)
- Preview shows which artists/venues are EXISTING vs NEW
- Added `searchArtistsByName()` and `searchVenuesByName()` public helpers to duplicates.ts
- 18 tests covering resolution, tour arrays, validation, dry-run, confirm, API errors
- Part of [PH CLI project](https://github.com/mtrifilo/psychic-homily-web/pull/127)

## Test plan
- [x] Show with existing artist/venue (resolved by search)
- [x] Show with new artist (not found → created by POST /shows)
- [x] Tour announcement (3 shows, shared artist)
- [x] Validation errors (missing event_date)
- [x] Dry-run vs confirm modes
- [x] `bun test` passes, `tsc --noEmit` clean

Closes PSY-144

🤖 Generated with [Claude Code](https://claude.com/claude-code)