### PR TITLE
Add ph submit label command

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -6,6 +6,7 @@ import * as display from "./lib/display";
 import { runInit } from "./commands/init";
 import { runConfigShow, runConfigSet } from "./commands/config";
 import { runSearch } from "./commands/search";
+import { runSubmitLabel } from "./commands/submit-label";
 
 const program = new Command();
 
@@ -68,10 +69,17 @@ program
   .description("Submit entities for creation/update (artist, venue, show, release, label, festival)")
   .option("--confirm", "Actually submit (default is dry-run)")
   .action(async (entityType: string, json: string | undefined, opts: { confirm?: boolean }) => {
-    display.warn(
-      `"ph submit ${entityType}" is not yet implemented. Coming in PSY-142 through PSY-147.`,
-    );
-    process.exit(1);
+    const env = await resolveEnvOrExit(program.opts().env);
+    switch (entityType) {
+      case "label":
+        await runSubmitLabel(json, opts, env);
+        break;
+      default:
+        display.warn(
+          `"ph submit ${entityType}" is not yet implemented. Coming in PSY-142 through PSY-147.`,
+        );
+        process.exit(1);
+    }
   });
 
 // ─── ph batch (stub — will be implemented in PSY-148) ──────────────────────

--- a/cli/src/commands/submit-label.ts
+++ b/cli/src/commands/submit-label.ts
@@ -1,0 +1,241 @@
+import { APIClient } from "../lib/api";
+import type { EnvironmentConfig } from "../lib/types";
+import { validateLabel } from "../lib/schemas";
+import { checkDuplicate, type DuplicateCheckResult } from "../lib/duplicates";
+import * as display from "../lib/display";
+
+interface LabelInput {
+  name: string;
+  city?: string;
+  state?: string;
+  country?: string;
+  website?: string;
+  description?: string;
+  bandcamp_url?: string;
+  [key: string]: unknown;
+}
+
+interface SubmitResult {
+  created: number;
+  updated: number;
+  skipped: number;
+  errors: number;
+}
+
+/**
+ * Parse JSON input, accepting either a single label object or an array.
+ * Reads from the argument string or from stdin if no argument provided.
+ */
+export async function parseInput(jsonArg?: string): Promise<unknown[]> {
+  let raw: string;
+
+  if (jsonArg) {
+    raw = jsonArg;
+  } else {
+    // Read from stdin
+    const chunks: Uint8Array[] = [];
+    for await (const chunk of process.stdin) {
+      chunks.push(chunk as Uint8Array);
+    }
+    raw = Buffer.concat(chunks).toString("utf-8").trim();
+  }
+
+  if (!raw) {
+    throw new Error("No JSON input provided. Pass JSON as argument or pipe via stdin.");
+  }
+
+  const parsed = JSON.parse(raw);
+  return Array.isArray(parsed) ? parsed : [parsed];
+}
+
+/**
+ * Build the update payload containing only fields with new_info status.
+ */
+function buildUpdatePayload(
+  dupResult: DuplicateCheckResult,
+  proposed: LabelInput,
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {};
+
+  for (const field of dupResult.fields) {
+    if (field.status === "new_info") {
+      payload[field.field] = proposed[field.field];
+    }
+  }
+
+  return payload;
+}
+
+/**
+ * Core submit function. Validates, deduplicates, previews, and optionally submits labels.
+ *
+ * @param items - Parsed label objects
+ * @param client - API client instance
+ * @param confirm - If true, actually submit; if false, dry-run only
+ * @returns Summary of results
+ */
+export async function submitLabels(
+  items: unknown[],
+  client: APIClient,
+  confirm: boolean,
+): Promise<SubmitResult> {
+  const result: SubmitResult = { created: 0, updated: 0, skipped: 0, errors: 0 };
+
+  // Phase 1: Validate all items
+  const validated: { label: LabelInput; index: number }[] = [];
+
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    const validation = validateLabel(item);
+
+    if (!validation.valid) {
+      display.error(
+        `Label #${i + 1}: Validation failed — ${validation.errors.map((e) => e.message).join(", ")}`,
+      );
+      result.errors++;
+      continue;
+    }
+
+    validated.push({ label: item as LabelInput, index: i });
+  }
+
+  if (validated.length === 0) {
+    display.warn("No valid labels to process.");
+    return result;
+  }
+
+  // Phase 2: Check duplicates and classify actions
+  const plans: {
+    label: LabelInput;
+    dupResult: DuplicateCheckResult;
+    index: number;
+  }[] = [];
+
+  for (const { label, index } of validated) {
+    const dupResult = await checkDuplicate(
+      client,
+      "label",
+      label as Record<string, unknown>,
+    );
+    plans.push({ label, dupResult, index });
+  }
+
+  // Phase 3: Display preview
+  let creates = 0;
+  let updates = 0;
+  let skips = 0;
+
+  for (const { label, dupResult } of plans) {
+    switch (dupResult.action) {
+      case "create": {
+        display.header(`CREATE: ${label.name}`);
+        if (label.city) display.kv("City", label.city);
+        if (label.state) display.kv("State", label.state);
+        if (label.country) display.kv("Country", label.country);
+        if (label.website) display.kv("Website", label.website);
+        if (label.bandcamp_url) display.kv("Bandcamp", label.bandcamp_url);
+        if (label.description) display.kv("Description", label.description);
+        creates++;
+        break;
+      }
+
+      case "update": {
+        display.header(
+          `UPDATE: ${label.name} → ${dupResult.existingName} (#${dupResult.existingId})`,
+        );
+        for (const field of dupResult.fields) {
+          display.fieldDiff(field.field, field.existing, field.proposed);
+        }
+        updates++;
+        break;
+      }
+
+      case "skip": {
+        display.info(
+          `SKIP: ${label.name} — already exists as "${dupResult.existingName}" (#${dupResult.existingId})`,
+        );
+        skips++;
+        break;
+      }
+    }
+  }
+
+  display.summary(creates, updates, skips);
+
+  // Phase 4: Execute if --confirm
+  if (!confirm) {
+    display.warn('Dry-run mode. Pass --confirm to submit.');
+    result.created = creates;
+    result.updated = updates;
+    result.skipped = skips;
+    return result;
+  }
+
+  for (const { label, dupResult } of plans) {
+    try {
+      switch (dupResult.action) {
+        case "create": {
+          await client.post("/labels", label);
+          display.success(`Created: ${label.name}`);
+          result.created++;
+          break;
+        }
+
+        case "update": {
+          const payload = buildUpdatePayload(dupResult, label);
+          if (Object.keys(payload).length > 0) {
+            await client.put(`/labels/${dupResult.existingId}`, payload);
+            display.success(
+              `Updated: ${dupResult.existingName} (#${dupResult.existingId})`,
+            );
+          } else {
+            display.info(
+              `No new fields to update for ${dupResult.existingName}`,
+            );
+          }
+          result.updated++;
+          break;
+        }
+
+        case "skip": {
+          result.skipped++;
+          break;
+        }
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      display.error(`Failed to submit ${label.name}: ${message}`);
+      result.errors++;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * CLI entry point for `ph submit label`.
+ */
+export async function runSubmitLabel(
+  json: string | undefined,
+  opts: { confirm?: boolean },
+  env: EnvironmentConfig,
+): Promise<void> {
+  const client = new APIClient(env);
+
+  let items: unknown[];
+  try {
+    items = await parseInput(json);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    display.error(`Invalid JSON input: ${message}`);
+    process.exit(1);
+  }
+
+  display.info(`Processing ${items.length} label${items.length !== 1 ? "s" : ""}...`);
+
+  const result = await submitLabels(items, client, opts.confirm ?? false);
+
+  if (result.errors > 0) {
+    process.exit(1);
+  }
+}

--- a/cli/test/submit-label.test.ts
+++ b/cli/test/submit-label.test.ts
@@ -1,0 +1,277 @@
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+import { submitLabels, parseInput } from "../src/commands/submit-label";
+import type { APIClient } from "../src/lib/api";
+
+/** Create a mock API client with controllable get/post/put responses. */
+function createMockClient(overrides: {
+  getResponse?: unknown;
+  postResponse?: unknown;
+  putResponse?: unknown;
+} = {}): APIClient {
+  return {
+    get: mock(() => Promise.resolve(overrides.getResponse ?? { labels: [] })),
+    post: mock(() => Promise.resolve(overrides.postResponse ?? { success: true, label: { id: 1 } })),
+    put: mock(() => Promise.resolve(overrides.putResponse ?? { success: true, label: { id: 1 } })),
+  } as unknown as APIClient;
+}
+
+describe("submitLabels", () => {
+  beforeEach(() => {
+    // Silence display output during tests
+    mock.module("../src/lib/display", () => ({
+      header: () => {},
+      success: () => {},
+      warn: () => {},
+      error: () => {},
+      info: () => {},
+      kv: () => {},
+      table: () => {},
+      fieldDiff: () => {},
+      summary: () => {},
+    }));
+  });
+
+  test("creates a single new label (dry-run)", async () => {
+    const client = createMockClient();
+    const items = [{ name: "Numero", city: "Chicago", state: "IL" }];
+
+    const result = await submitLabels(items, client, false);
+
+    expect(result.created).toBe(1);
+    expect(result.updated).toBe(0);
+    expect(result.skipped).toBe(0);
+    expect(result.errors).toBe(0);
+    // In dry-run mode, no POST calls should be made
+    expect((client.post as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+  });
+
+  test("creates a single new label (--confirm)", async () => {
+    const client = createMockClient();
+    const items = [{ name: "Numero", city: "Chicago", state: "IL" }];
+
+    const result = await submitLabels(items, client, true);
+
+    expect(result.created).toBe(1);
+    expect(result.updated).toBe(0);
+    expect(result.skipped).toBe(0);
+    expect(result.errors).toBe(0);
+    expect((client.post as ReturnType<typeof mock>).mock.calls.length).toBe(1);
+    // Verify the POST payload
+    const postCall = (client.post as ReturnType<typeof mock>).mock.calls[0];
+    expect(postCall[0]).toBe("/labels");
+    expect(postCall[1]).toEqual({ name: "Numero", city: "Chicago", state: "IL" });
+  });
+
+  test("updates a label with new website info (--confirm)", async () => {
+    const client = createMockClient({
+      getResponse: {
+        labels: [
+          {
+            id: 42,
+            name: "Numero Group",
+            slug: "numero-group",
+            city: "Chicago",
+            state: "IL",
+            country: "",
+            website: "",
+            description: "",
+            bandcamp_url: "",
+          },
+        ],
+      },
+    });
+
+    const items = [
+      {
+        name: "Numero Group",
+        city: "Chicago",
+        state: "IL",
+        website: "https://numerogroup.com",
+      },
+    ];
+
+    const result = await submitLabels(items, client, true);
+
+    expect(result.updated).toBe(1);
+    expect(result.created).toBe(0);
+    expect(result.skipped).toBe(0);
+    expect(result.errors).toBe(0);
+    // Should PUT only the new_info field (website)
+    expect((client.put as ReturnType<typeof mock>).mock.calls.length).toBe(1);
+    const putCall = (client.put as ReturnType<typeof mock>).mock.calls[0];
+    expect(putCall[0]).toBe("/labels/42");
+    expect(putCall[1]).toEqual({ website: "https://numerogroup.com" });
+  });
+
+  test("skips a label that already exists with no new info", async () => {
+    const client = createMockClient({
+      getResponse: {
+        labels: [
+          {
+            id: 42,
+            name: "Sacred Bones Records",
+            slug: "sacred-bones-records",
+            city: "Brooklyn",
+            state: "NY",
+            country: "",
+            website: "https://sacredbonesrecords.com",
+            description: "",
+            bandcamp_url: "",
+          },
+        ],
+      },
+    });
+
+    const items = [
+      {
+        name: "Sacred Bones Records",
+        city: "Brooklyn",
+        state: "NY",
+        website: "https://sacredbonesrecords.com",
+      },
+    ];
+
+    const result = await submitLabels(items, client, true);
+
+    expect(result.skipped).toBe(1);
+    expect(result.created).toBe(0);
+    expect(result.updated).toBe(0);
+    // No POST or PUT calls for skipped items
+    expect((client.post as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+    expect((client.put as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+  });
+
+  test("handles minimal label (name-only, WFMU-style)", async () => {
+    const client = createMockClient();
+    const items = [{ name: "Drag City" }];
+
+    const result = await submitLabels(items, client, false);
+
+    expect(result.created).toBe(1);
+    expect(result.errors).toBe(0);
+  });
+
+  test("reports validation error for missing name", async () => {
+    const client = createMockClient();
+    const items = [{ city: "Chicago", state: "IL" }];
+
+    const result = await submitLabels(items, client, false);
+
+    expect(result.errors).toBe(1);
+    expect(result.created).toBe(0);
+  });
+
+  test("processes array of mixed labels", async () => {
+    const client = createMockClient({
+      getResponse: { labels: [] },
+    });
+
+    const items = [
+      { name: "Label A", city: "Phoenix", state: "AZ" },
+      { name: "Label B" },
+      { city: "Missing Name" }, // invalid
+    ];
+
+    const result = await submitLabels(items, client, false);
+
+    expect(result.created).toBe(2);
+    expect(result.errors).toBe(1);
+  });
+
+  test("dry-run does not call POST or PUT", async () => {
+    const client = createMockClient({
+      getResponse: {
+        labels: [
+          {
+            id: 1,
+            name: "Existing",
+            slug: "existing",
+            city: "",
+            state: "",
+            country: "",
+            website: "",
+            description: "",
+            bandcamp_url: "",
+          },
+        ],
+      },
+    });
+
+    const items = [
+      { name: "New Label" },
+      { name: "Existing", website: "https://new.com" },
+    ];
+
+    const result = await submitLabels(items, client, false);
+
+    expect(result.created + result.updated).toBeGreaterThan(0);
+    expect((client.post as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+    expect((client.put as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+  });
+
+  test("handles API error during create gracefully", async () => {
+    const client = createMockClient();
+    (client.post as ReturnType<typeof mock>).mockImplementation(() =>
+      Promise.reject(new Error("403 Forbidden")),
+    );
+
+    const items = [{ name: "Test Label" }];
+
+    const result = await submitLabels(items, client, true);
+
+    expect(result.errors).toBe(1);
+    expect(result.created).toBe(0);
+  });
+
+  test("handles API error during update gracefully", async () => {
+    const client = createMockClient({
+      getResponse: {
+        labels: [
+          {
+            id: 5,
+            name: "Test Label",
+            slug: "test-label",
+            city: "",
+            state: "",
+            country: "",
+            website: "",
+            description: "",
+            bandcamp_url: "",
+          },
+        ],
+      },
+    });
+    (client.put as ReturnType<typeof mock>).mockImplementation(() =>
+      Promise.reject(new Error("500 Internal Server Error")),
+    );
+
+    const items = [{ name: "Test Label", website: "https://new.com" }];
+
+    const result = await submitLabels(items, client, true);
+
+    expect(result.errors).toBe(1);
+    expect(result.updated).toBe(0);
+  });
+});
+
+describe("parseInput", () => {
+  test("parses single JSON object from argument", async () => {
+    const items = await parseInput('{"name": "Test"}');
+    expect(items).toEqual([{ name: "Test" }]);
+  });
+
+  test("parses JSON array from argument", async () => {
+    const items = await parseInput('[{"name": "A"}, {"name": "B"}]');
+    expect(items).toHaveLength(2);
+    expect(items[0]).toEqual({ name: "A" });
+    expect(items[1]).toEqual({ name: "B" });
+  });
+
+  test("throws on invalid JSON", async () => {
+    await expect(parseInput("not json")).rejects.toThrow();
+  });
+
+  test("throws on empty string", async () => {
+    await expect(parseInput("")).rejects.toThrow("No JSON input provided");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `ph submit label` command with duplicate detection, create/update flow
- Supports minimal name-only labels (common from WFMU playlist data)
- Updates only send `new_info` fields via PUT
- 12 tests covering create, update, skip, WFMU-style labels, validation, dry-run, confirm
- Part of [PH CLI project](https://github.com/mtrifilo/psychic-homily-web/pull/127)

## Test plan
- [x] Label create, update (new website/city), skip
- [x] Name-only label (WFMU style)
- [x] Validation errors (missing name)
- [x] Dry-run vs confirm modes
- [x] `bun test` passes, `tsc --noEmit` clean

Closes PSY-146

🤖 Generated with [Claude Code](https://claude.com/claude-code)