### PR TITLE
Add ph submit festival command

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -6,6 +6,7 @@ import * as display from "./lib/display";
 import { runInit } from "./commands/init";
 import { runConfigShow, runConfigSet } from "./commands/config";
 import { runSearch } from "./commands/search";
+import { runSubmitFestival } from "./commands/submit-festival";
 
 const program = new Command();
 
@@ -68,10 +69,17 @@ program
   .description("Submit entities for creation/update (artist, venue, show, release, label, festival)")
   .option("--confirm", "Actually submit (default is dry-run)")
   .action(async (entityType: string, json: string | undefined, opts: { confirm?: boolean }) => {
-    display.warn(
-      `"ph submit ${entityType}" is not yet implemented. Coming in PSY-142 through PSY-147.`,
-    );
-    process.exit(1);
+    const env = await resolveEnvOrExit(program.opts().env);
+    switch (entityType) {
+      case "festival":
+        await runSubmitFestival(json, env, !!opts.confirm);
+        break;
+      default:
+        display.warn(
+          `"ph submit ${entityType}" is not yet implemented. Coming in PSY-142 through PSY-147.`,
+        );
+        process.exit(1);
+    }
   });
 
 // ─── ph batch (stub — will be implemented in PSY-148) ──────────────────────

--- a/cli/src/commands/submit-festival.ts
+++ b/cli/src/commands/submit-festival.ts
@@ -1,0 +1,608 @@
+import { APIClient } from "../lib/api";
+import type { EnvironmentConfig } from "../lib/types";
+import * as display from "../lib/display";
+import { green, yellow, gray, dim, cyan } from "../lib/ansi";
+import { validateFestival } from "../lib/schemas";
+import {
+  checkDuplicate,
+  type DuplicateCheckResult,
+  type FieldComparison,
+} from "../lib/duplicates";
+
+/** Festival artist entry from the input JSON. */
+interface FestivalArtistInput {
+  name: string;
+  billing_tier?: string;
+  position?: number;
+  day_date?: string;
+  stage?: string;
+  set_time?: string;
+}
+
+/** Festival venue entry from the input JSON. */
+interface FestivalVenueInput {
+  name: string;
+  is_primary?: boolean;
+}
+
+/** Parsed festival input data. */
+interface FestivalInput {
+  name: string;
+  series_slug: string;
+  edition_year: number;
+  start_date: string;
+  end_date: string;
+  description?: string;
+  location_name?: string;
+  city?: string;
+  state?: string;
+  country?: string;
+  website?: string;
+  ticket_url?: string;
+  flyer_url?: string;
+  status?: string;
+  artists?: FestivalArtistInput[];
+  venues?: FestivalVenueInput[];
+}
+
+/** Result of processing a single festival. */
+export interface FestivalResult {
+  name: string;
+  action: "created" | "updated" | "skipped" | "error";
+  id?: number;
+  artistResults?: ArtistLinkResult[];
+  venueResults?: VenueLinkResult[];
+  error?: string;
+}
+
+interface ArtistLinkResult {
+  name: string;
+  action: "linked" | "not_found" | "error";
+  artistId?: number;
+  error?: string;
+}
+
+interface VenueLinkResult {
+  name: string;
+  action: "linked" | "not_found" | "error";
+  venueId?: number;
+  error?: string;
+}
+
+/** Planned action for a festival, after duplicate check. */
+interface PlannedFestival {
+  input: FestivalInput;
+  dupResult: DuplicateCheckResult;
+}
+
+const VALID_BILLING_TIERS = [
+  "headliner",
+  "sub_headliner",
+  "mid_card",
+  "undercard",
+  "local",
+  "dj",
+  "host",
+];
+
+/**
+ * Resolve an artist name to an ID via GET /artists/search.
+ * Returns the best match's ID, or null if not found.
+ */
+async function resolveArtistId(
+  client: APIClient,
+  name: string,
+): Promise<{ id: number; name: string } | null> {
+  try {
+    const result = await client.get<{
+      artists: Array<{ id: number; name: string; slug: string }>;
+    }>("/artists/search", { q: name });
+
+    if (!result.artists?.length) return null;
+
+    // Look for exact match first (case-insensitive)
+    const exact = result.artists.find(
+      (a) => a.name.toLowerCase() === name.toLowerCase(),
+    );
+    if (exact) return { id: exact.id, name: exact.name };
+
+    // Fall back to first result if it's a close enough match
+    return { id: result.artists[0].id, name: result.artists[0].name };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve a venue name to an ID via GET /venues/search.
+ * Returns the best match's ID, or null if not found.
+ */
+async function resolveVenueId(
+  client: APIClient,
+  name: string,
+): Promise<{ id: number; name: string } | null> {
+  try {
+    const result = await client.get<{
+      venues: Array<{ id: number; name: string; slug: string }>;
+    }>("/venues/search", { q: name });
+
+    if (!result.venues?.length) return null;
+
+    const exact = result.venues.find(
+      (v) => v.name.toLowerCase() === name.toLowerCase(),
+    );
+    if (exact) return { id: exact.id, name: exact.name };
+
+    return { id: result.venues[0].id, name: result.venues[0].name };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build the update body, sending only fields with "new_info" status.
+ */
+function buildUpdateBody(
+  fields: FieldComparison[],
+  input: FestivalInput,
+): Record<string, unknown> {
+  const body: Record<string, unknown> = {};
+
+  for (const f of fields) {
+    if (f.status !== "new_info") continue;
+
+    const value = (input as unknown as Record<string, unknown>)[f.field];
+    if (value !== undefined && value !== null && value !== "") {
+      body[f.field] = value;
+    }
+  }
+
+  return body;
+}
+
+/**
+ * Parse JSON input (single object or array) into an array of festival inputs.
+ */
+export function parseFestivalInput(jsonStr: string): FestivalInput[] {
+  const parsed = JSON.parse(jsonStr);
+
+  if (Array.isArray(parsed)) {
+    return parsed;
+  }
+
+  return [parsed];
+}
+
+/**
+ * Submit festivals: validate, check duplicates, preview, and optionally create/update.
+ *
+ * Exported for testing.
+ */
+export async function submitFestivals(
+  festivals: FestivalInput[],
+  env: EnvironmentConfig,
+  confirm: boolean,
+): Promise<FestivalResult[]> {
+  const client = new APIClient(env);
+
+  // --- Phase 1: Validate ---
+  display.header("Validating festivals...");
+
+  const validFestivals: FestivalInput[] = [];
+  const results: FestivalResult[] = [];
+
+  for (const festival of festivals) {
+    const validation = validateFestival(festival);
+    if (!validation.valid) {
+      const errMsg = validation.errors
+        .map((e) => `${e.field}: ${e.message}`)
+        .join(", ");
+      display.error(`${festival.name || "(unnamed)"}: ${errMsg}`);
+      results.push({
+        name: festival.name || "(unnamed)",
+        action: "error",
+        error: errMsg,
+      });
+      continue;
+    }
+
+    // Validate billing tiers on artists if present
+    if (festival.artists) {
+      let tierError = false;
+      for (const artist of festival.artists) {
+        if (
+          artist.billing_tier &&
+          !VALID_BILLING_TIERS.includes(artist.billing_tier)
+        ) {
+          display.error(
+            `${festival.name}: artist "${artist.name}" has invalid billing_tier "${artist.billing_tier}". ` +
+              `Must be one of: ${VALID_BILLING_TIERS.join(", ")}`,
+          );
+          tierError = true;
+        }
+      }
+      if (tierError) {
+        results.push({
+          name: festival.name,
+          action: "error",
+          error: "Invalid billing tier",
+        });
+        continue;
+      }
+    }
+
+    validFestivals.push(festival);
+  }
+
+  if (validFestivals.length === 0) {
+    display.warn("No valid festivals to process.");
+    return results;
+  }
+
+  // --- Phase 2: Duplicate check ---
+  display.header("Checking for duplicates...");
+
+  const planned: PlannedFestival[] = [];
+
+  for (const festival of validFestivals) {
+    const dupResult = await checkDuplicate(
+      client,
+      "festival",
+      festival as unknown as Record<string, unknown>,
+    );
+    planned.push({ input: festival, dupResult });
+  }
+
+  // --- Phase 3: Preview ---
+  display.header("Preview");
+
+  const creates = planned.filter((p) => p.dupResult.action === "create");
+  const updates = planned.filter((p) => p.dupResult.action === "update");
+  const skips = planned.filter((p) => p.dupResult.action === "skip");
+
+  for (const p of creates) {
+    const f = p.input;
+    display.info(
+      `${green("CREATE")} ${f.name} (${f.series_slug} ${f.edition_year})`,
+    );
+    display.kv("Dates", `${f.start_date} to ${f.end_date}`);
+    if (f.city) display.kv("Location", `${f.city}${f.state ? `, ${f.state}` : ""}`);
+    if (f.artists?.length) {
+      display.kv("Artists", `${f.artists.length} to resolve`);
+    }
+    if (f.venues?.length) {
+      display.kv("Venues", `${f.venues.length} to resolve`);
+    }
+  }
+
+  for (const p of updates) {
+    const f = p.input;
+    const newFields = p.dupResult.fields.filter(
+      (field) => field.status === "new_info",
+    );
+    display.info(
+      `${yellow("UPDATE")} ${f.name} → ${p.dupResult.existingName} (ID: ${p.dupResult.existingId})`,
+    );
+    display.kv("Match", `${p.dupResult.match} (${(p.dupResult.confidence * 100).toFixed(0)}%)`);
+    for (const field of newFields) {
+      display.fieldDiff(field.field, field.existing, field.proposed);
+    }
+    if (f.artists?.length) {
+      display.kv("Artists", `${f.artists.length} to resolve & link`);
+    }
+    if (f.venues?.length) {
+      display.kv("Venues", `${f.venues.length} to resolve & link`);
+    }
+  }
+
+  for (const p of skips) {
+    display.info(
+      `${dim("SKIP")} ${p.input.name} → already exists as "${p.dupResult.existingName}" (ID: ${p.dupResult.existingId})`,
+    );
+  }
+
+  display.summary(creates.length, updates.length, skips.length);
+
+  // Add skip results
+  for (const p of skips) {
+    results.push({
+      name: p.input.name,
+      action: "skipped",
+      id: p.dupResult.existingId,
+    });
+  }
+
+  // --- Phase 4: Execute (if --confirm) ---
+  if (!confirm) {
+    display.warn('Dry run. Pass --confirm to submit.');
+    return results;
+  }
+
+  display.header("Submitting...");
+
+  // Process creates
+  for (const p of creates) {
+    const f = p.input;
+    try {
+      const body: Record<string, unknown> = {
+        name: f.name,
+        series_slug: f.series_slug,
+        edition_year: f.edition_year,
+        start_date: f.start_date,
+        end_date: f.end_date,
+      };
+      if (f.description) body.description = f.description;
+      if (f.location_name) body.location_name = f.location_name;
+      if (f.city) body.city = f.city;
+      if (f.state) body.state = f.state;
+      if (f.country) body.country = f.country;
+      if (f.website) body.website = f.website;
+      if (f.ticket_url) body.ticket_url = f.ticket_url;
+      if (f.flyer_url) body.flyer_url = f.flyer_url;
+      if (f.status) body.status = f.status;
+
+      const created = await client.post<{ id: number }>(
+        "/festivals",
+        body,
+      );
+
+      const festivalId = created.id;
+      display.success(`Created "${f.name}" (ID: ${festivalId})`);
+
+      const result: FestivalResult = {
+        name: f.name,
+        action: "created",
+        id: festivalId,
+        artistResults: [],
+        venueResults: [],
+      };
+
+      // Link artists
+      if (f.artists?.length) {
+        result.artistResults = await linkArtists(client, festivalId, f.artists);
+      }
+
+      // Link venues
+      if (f.venues?.length) {
+        result.venueResults = await linkVenues(client, festivalId, f.venues);
+      }
+
+      results.push(result);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unknown error";
+      display.error(`Failed to create "${f.name}": ${message}`);
+      results.push({ name: f.name, action: "error", error: message });
+    }
+  }
+
+  // Process updates
+  for (const p of updates) {
+    const f = p.input;
+    const festivalId = p.dupResult.existingId!;
+    try {
+      const updateBody = buildUpdateBody(p.dupResult.fields, f);
+
+      if (Object.keys(updateBody).length > 0) {
+        await client.put(`/festivals/${festivalId}`, updateBody);
+        display.success(
+          `Updated "${p.dupResult.existingName}" (ID: ${festivalId}) with ${Object.keys(updateBody).length} field(s)`,
+        );
+      } else {
+        display.info(
+          `No field updates needed for "${p.dupResult.existingName}" (ID: ${festivalId})`,
+        );
+      }
+
+      const result: FestivalResult = {
+        name: f.name,
+        action: "updated",
+        id: festivalId,
+        artistResults: [],
+        venueResults: [],
+      };
+
+      // Link artists
+      if (f.artists?.length) {
+        result.artistResults = await linkArtists(client, festivalId, f.artists);
+      }
+
+      // Link venues
+      if (f.venues?.length) {
+        result.venueResults = await linkVenues(client, festivalId, f.venues);
+      }
+
+      results.push(result);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unknown error";
+      display.error(
+        `Failed to update "${p.dupResult.existingName}" (ID: ${festivalId}): ${message}`,
+      );
+      results.push({ name: f.name, action: "error", error: message });
+    }
+  }
+
+  // --- Phase 5: Final report ---
+  display.header("Results");
+
+  const created = results.filter((r) => r.action === "created").length;
+  const updated = results.filter((r) => r.action === "updated").length;
+  const skipped = results.filter((r) => r.action === "skipped").length;
+  const errored = results.filter((r) => r.action === "error").length;
+
+  display.summary(created, updated, skipped);
+  if (errored > 0) {
+    display.error(`${errored} error(s)`);
+  }
+
+  return results;
+}
+
+/**
+ * Resolve artist names and link them to a festival.
+ */
+async function linkArtists(
+  client: APIClient,
+  festivalId: number,
+  artists: FestivalArtistInput[],
+): Promise<ArtistLinkResult[]> {
+  const linkResults: ArtistLinkResult[] = [];
+
+  for (const artist of artists) {
+    const resolved = await resolveArtistId(client, artist.name);
+    if (!resolved) {
+      display.warn(
+        `Artist "${artist.name}" not found in database — skipping`,
+      );
+      linkResults.push({
+        name: artist.name,
+        action: "not_found",
+      });
+      continue;
+    }
+
+    try {
+      const body: Record<string, unknown> = {
+        artist_id: resolved.id,
+      };
+      if (artist.billing_tier) body.billing_tier = artist.billing_tier;
+      if (artist.position !== undefined) body.position = artist.position;
+      if (artist.day_date) body.day_date = artist.day_date;
+      if (artist.stage) body.stage = artist.stage;
+      if (artist.set_time) body.set_time = artist.set_time;
+
+      await client.post(`/festivals/${festivalId}/artists`, body);
+      display.success(
+        `  Linked artist "${resolved.name}" (ID: ${resolved.id})${artist.billing_tier ? ` as ${artist.billing_tier}` : ""}`,
+      );
+      linkResults.push({
+        name: artist.name,
+        action: "linked",
+        artistId: resolved.id,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unknown error";
+      display.error(
+        `  Failed to link artist "${resolved.name}": ${message}`,
+      );
+      linkResults.push({
+        name: artist.name,
+        action: "error",
+        artistId: resolved.id,
+        error: message,
+      });
+    }
+  }
+
+  return linkResults;
+}
+
+/**
+ * Resolve venue names and link them to a festival.
+ */
+async function linkVenues(
+  client: APIClient,
+  festivalId: number,
+  venues: FestivalVenueInput[],
+): Promise<VenueLinkResult[]> {
+  const linkResults: VenueLinkResult[] = [];
+
+  for (const venue of venues) {
+    const resolved = await resolveVenueId(client, venue.name);
+    if (!resolved) {
+      display.warn(
+        `Venue "${venue.name}" not found in database — skipping`,
+      );
+      linkResults.push({
+        name: venue.name,
+        action: "not_found",
+      });
+      continue;
+    }
+
+    try {
+      const body: Record<string, unknown> = {
+        venue_id: resolved.id,
+      };
+      if (venue.is_primary !== undefined) body.is_primary = venue.is_primary;
+
+      await client.post(`/festivals/${festivalId}/venues`, body);
+      display.success(
+        `  Linked venue "${resolved.name}" (ID: ${resolved.id})${venue.is_primary ? " (primary)" : ""}`,
+      );
+      linkResults.push({
+        name: venue.name,
+        action: "linked",
+        venueId: resolved.id,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unknown error";
+      display.error(
+        `  Failed to link venue "${resolved.name}": ${message}`,
+      );
+      linkResults.push({
+        name: venue.name,
+        action: "error",
+        venueId: resolved.id,
+        error: message,
+      });
+    }
+  }
+
+  return linkResults;
+}
+
+/**
+ * Entry point called from CLI dispatcher.
+ */
+export async function runSubmitFestival(
+  json: string | undefined,
+  env: EnvironmentConfig,
+  confirm: boolean,
+): Promise<void> {
+  let jsonStr = json;
+
+  // Read from stdin if no JSON argument provided
+  if (!jsonStr) {
+    const chunks: string[] = [];
+    const reader = process.stdin;
+    reader.resume();
+    reader.setEncoding("utf-8");
+
+    jsonStr = await new Promise<string>((resolve, reject) => {
+      reader.on("data", (chunk: string) => chunks.push(chunk));
+      reader.on("end", () => resolve(chunks.join("")));
+      reader.on("error", reject);
+    });
+  }
+
+  if (!jsonStr?.trim()) {
+    display.error(
+      "No JSON provided. Pass as argument or pipe to stdin.",
+    );
+    process.exit(1);
+  }
+
+  let festivals: FestivalInput[];
+  try {
+    festivals = parseFestivalInput(jsonStr);
+  } catch (err) {
+    display.error(
+      `Invalid JSON: ${err instanceof Error ? err.message : "parse error"}`,
+    );
+    process.exit(1);
+  }
+
+  if (festivals.length === 0) {
+    display.warn("Empty array — nothing to submit.");
+    return;
+  }
+
+  display.info(`Processing ${festivals.length} festival(s)...`);
+
+  const results = await submitFestivals(festivals, env, confirm);
+
+  const hasErrors = results.some((r) => r.action === "error");
+  if (hasErrors) {
+    process.exit(1);
+  }
+}

--- a/cli/test/submit-festival.test.ts
+++ b/cli/test/submit-festival.test.ts
@@ -1,0 +1,464 @@
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+import {
+  submitFestivals,
+  parseFestivalInput,
+  type FestivalResult,
+} from "../src/commands/submit-festival";
+
+// --- Mock fetch for API calls ---
+
+type MockRoute = {
+  method: string;
+  pattern: RegExp;
+  handler: (url: string, body?: unknown) => unknown;
+};
+
+let mockRoutes: MockRoute[] = [];
+let fetchCalls: { method: string; url: string; body?: unknown }[] = [];
+
+function addMockRoute(
+  method: string,
+  pattern: RegExp,
+  handler: (url: string, body?: unknown) => unknown,
+): void {
+  mockRoutes.push({ method, pattern, handler });
+}
+
+function resetMocks(): void {
+  mockRoutes = [];
+  fetchCalls = [];
+}
+
+// Install global fetch mock
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  resetMocks();
+
+  globalThis.fetch = (async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const method = init?.method || "GET";
+    const body = init?.body ? JSON.parse(init.body as string) : undefined;
+
+    fetchCalls.push({ method, url, body });
+
+    for (const route of mockRoutes) {
+      if (route.method === method && route.pattern.test(url)) {
+        const responseBody = route.handler(url, body);
+        return new Response(JSON.stringify(responseBody), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+    }
+
+    // Default: 404
+    return new Response(
+      JSON.stringify({ message: "Not found" }),
+      { status: 404 },
+    );
+  }) as typeof fetch;
+});
+
+// Restore original fetch after all tests
+// (Bun test runner handles this via module isolation)
+
+const TEST_ENV = { url: "http://localhost:8080", token: "phk_test_token" };
+
+// Helper to make a valid festival input
+function validFestival(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    name: "M3F Fest 2026",
+    series_slug: "m3f",
+    edition_year: 2026,
+    start_date: "2026-03-06",
+    end_date: "2026-03-08",
+    city: "Phoenix",
+    state: "AZ",
+    ...overrides,
+  };
+}
+
+// Setup mock that returns no festival matches (for create scenarios)
+function setupNoMatchMocks(): void {
+  // Festival search returns empty (for duplicate check)
+  addMockRoute("GET", /\/festivals(\?|$)/, () => ({
+    festivals: [],
+    count: 0,
+  }));
+}
+
+// Setup mock that returns an existing festival (for update/skip scenarios)
+function setupExistingFestivalMock(
+  festival: Record<string, unknown> = {},
+): void {
+  const existing = {
+    id: 42,
+    name: "M3F Fest 2026",
+    slug: "m3f-fest-2026",
+    series_slug: "m3f",
+    edition_year: 2026,
+    start_date: "2026-03-06",
+    end_date: "2026-03-08",
+    city: "Phoenix",
+    state: "AZ",
+    ...festival,
+  };
+
+  addMockRoute("GET", /\/festivals(\?|$)/, () => ({
+    festivals: [existing],
+    count: 1,
+  }));
+}
+
+describe("parseFestivalInput", () => {
+  test("parses single festival object", () => {
+    const input = JSON.stringify(validFestival());
+    const result = parseFestivalInput(input);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("M3F Fest 2026");
+  });
+
+  test("parses array of festivals", () => {
+    const input = JSON.stringify([
+      validFestival(),
+      validFestival({ name: "Innings Festival 2026", series_slug: "innings" }),
+    ]);
+    const result = parseFestivalInput(input);
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toBe("M3F Fest 2026");
+    expect(result[1].name).toBe("Innings Festival 2026");
+  });
+
+  test("throws on invalid JSON", () => {
+    expect(() => parseFestivalInput("not json")).toThrow();
+  });
+});
+
+describe("submitFestivals", () => {
+  test("creates a single festival in dry-run mode", async () => {
+    setupNoMatchMocks();
+
+    const festivals = [validFestival()] as any[];
+    const results = await submitFestivals(festivals, TEST_ENV, false);
+
+    expect(results).toHaveLength(0);
+
+    // Should not have called POST /festivals
+    const postCalls = fetchCalls.filter(
+      (c) => c.method === "POST" && /\/festivals$/.test(c.url),
+    );
+    expect(postCalls).toHaveLength(0);
+  });
+
+  test("creates a single festival with --confirm", async () => {
+    setupNoMatchMocks();
+
+    addMockRoute("POST", /\/festivals$/, (_url, body) => ({
+      id: 99,
+      name: (body as Record<string, unknown>).name,
+      slug: "m3f-fest-2026",
+    }));
+
+    const festivals = [validFestival()] as any[];
+    const results = await submitFestivals(festivals, TEST_ENV, true);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].action).toBe("created");
+    expect(results[0].id).toBe(99);
+    expect(results[0].name).toBe("M3F Fest 2026");
+
+    // Verify POST was called
+    const postCalls = fetchCalls.filter(
+      (c) => c.method === "POST" && /\/festivals$/.test(c.url),
+    );
+    expect(postCalls).toHaveLength(1);
+    expect(postCalls[0].body).toMatchObject({
+      name: "M3F Fest 2026",
+      series_slug: "m3f",
+      edition_year: 2026,
+    });
+  });
+
+  test("creates a festival with artist lineup resolved by search", async () => {
+    setupNoMatchMocks();
+
+    // POST /festivals creates the festival
+    addMockRoute("POST", /\/festivals$/, () => ({
+      id: 100,
+      name: "M3F Fest 2026",
+      slug: "m3f-fest-2026",
+    }));
+
+    // GET /artists/search resolves artist names to IDs
+    addMockRoute("GET", /\/artists\/search/, (url) => {
+      const urlObj = new URL(url);
+      const q = urlObj.searchParams.get("q") || "";
+      if (q.toLowerCase().includes("khruangbin")) {
+        return {
+          artists: [{ id: 10, name: "Khruangbin", slug: "khruangbin" }],
+        };
+      }
+      if (q.toLowerCase().includes("japanese breakfast")) {
+        return {
+          artists: [
+            {
+              id: 20,
+              name: "Japanese Breakfast",
+              slug: "japanese-breakfast",
+            },
+          ],
+        };
+      }
+      return { artists: [] };
+    });
+
+    // POST /festivals/{id}/artists links artists
+    addMockRoute("POST", /\/festivals\/\d+\/artists$/, () => ({
+      id: 1,
+    }));
+
+    const festivals = [
+      validFestival({
+        artists: [
+          { name: "Khruangbin", billing_tier: "headliner" },
+          { name: "Japanese Breakfast", billing_tier: "sub_headliner" },
+        ],
+      }),
+    ] as any[];
+
+    const results = await submitFestivals(festivals, TEST_ENV, true);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].action).toBe("created");
+    expect(results[0].artistResults).toHaveLength(2);
+    expect(results[0].artistResults![0]).toMatchObject({
+      name: "Khruangbin",
+      action: "linked",
+      artistId: 10,
+    });
+    expect(results[0].artistResults![1]).toMatchObject({
+      name: "Japanese Breakfast",
+      action: "linked",
+      artistId: 20,
+    });
+
+    // Verify artist link calls
+    const artistLinkCalls = fetchCalls.filter(
+      (c) => c.method === "POST" && /\/festivals\/\d+\/artists$/.test(c.url),
+    );
+    expect(artistLinkCalls).toHaveLength(2);
+    expect(artistLinkCalls[0].body).toMatchObject({
+      artist_id: 10,
+      billing_tier: "headliner",
+    });
+    expect(artistLinkCalls[1].body).toMatchObject({
+      artist_id: 20,
+      billing_tier: "sub_headliner",
+    });
+  });
+
+  test("updates a festival when new info is available", async () => {
+    // Existing festival has no website
+    setupExistingFestivalMock({ website: "" });
+
+    // PUT /festivals/{id} updates the festival
+    addMockRoute("PUT", /\/festivals\/\d+$/, () => ({
+      id: 42,
+      name: "M3F Fest 2026",
+    }));
+
+    const festivals = [
+      validFestival({ website: "https://m3ffest.com" }),
+    ] as any[];
+
+    const results = await submitFestivals(festivals, TEST_ENV, true);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].action).toBe("updated");
+    expect(results[0].id).toBe(42);
+
+    // Verify PUT was called with only the new field
+    const putCalls = fetchCalls.filter(
+      (c) => c.method === "PUT" && /\/festivals\/42$/.test(c.url),
+    );
+    expect(putCalls).toHaveLength(1);
+    expect(putCalls[0].body).toMatchObject({ website: "https://m3ffest.com" });
+  });
+
+  test("skips a festival when no new info", async () => {
+    setupExistingFestivalMock();
+
+    const festivals = [validFestival()] as any[];
+    const results = await submitFestivals(festivals, TEST_ENV, true);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].action).toBe("skipped");
+    expect(results[0].id).toBe(42);
+
+    // Verify no PUT or POST was called
+    const mutationCalls = fetchCalls.filter(
+      (c) => c.method === "PUT" || (c.method === "POST" && /\/festivals/.test(c.url)),
+    );
+    expect(mutationCalls).toHaveLength(0);
+  });
+
+  test("reports validation error for missing required fields", async () => {
+    const festivals = [
+      { name: "Bad Festival" }, // Missing series_slug, edition_year, start_date, end_date
+    ] as any[];
+
+    const results = await submitFestivals(festivals, TEST_ENV, true);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].action).toBe("error");
+    expect(results[0].error).toContain("series_slug");
+    expect(results[0].error).toContain("edition_year");
+  });
+
+  test("reports validation error for invalid billing tier", async () => {
+    const festivals = [
+      validFestival({
+        artists: [{ name: "SomeArtist", billing_tier: "mega_star" }],
+      }),
+    ] as any[];
+
+    const results = await submitFestivals(festivals, TEST_ENV, true);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].action).toBe("error");
+    expect(results[0].error).toContain("Invalid billing tier");
+  });
+
+  test("handles artist not found gracefully", async () => {
+    setupNoMatchMocks();
+
+    addMockRoute("POST", /\/festivals$/, () => ({
+      id: 101,
+      name: "Test Fest",
+    }));
+
+    // Artist search returns empty
+    addMockRoute("GET", /\/artists\/search/, () => ({
+      artists: [],
+    }));
+
+    const festivals = [
+      validFestival({
+        name: "Test Fest",
+        artists: [{ name: "Unknown Band", billing_tier: "undercard" }],
+      }),
+    ] as any[];
+
+    const results = await submitFestivals(festivals, TEST_ENV, true);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].action).toBe("created");
+    expect(results[0].artistResults).toHaveLength(1);
+    expect(results[0].artistResults![0]).toMatchObject({
+      name: "Unknown Band",
+      action: "not_found",
+    });
+  });
+
+  test("creates festival with venues resolved by search", async () => {
+    setupNoMatchMocks();
+
+    addMockRoute("POST", /\/festivals$/, () => ({
+      id: 102,
+      name: "Multi Venue Fest",
+    }));
+
+    addMockRoute("GET", /\/venues\/search/, (url) => {
+      const urlObj = new URL(url);
+      const q = urlObj.searchParams.get("q") || "";
+      if (q.toLowerCase().includes("hance park")) {
+        return {
+          venues: [{ id: 5, name: "Margaret T. Hance Park", slug: "hance-park" }],
+        };
+      }
+      return { venues: [] };
+    });
+
+    addMockRoute("POST", /\/festivals\/\d+\/venues$/, () => ({
+      id: 1,
+    }));
+
+    const festivals = [
+      validFestival({
+        name: "Multi Venue Fest",
+        venues: [{ name: "Hance Park", is_primary: true }],
+      }),
+    ] as any[];
+
+    const results = await submitFestivals(festivals, TEST_ENV, true);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].action).toBe("created");
+    expect(results[0].venueResults).toHaveLength(1);
+    expect(results[0].venueResults![0]).toMatchObject({
+      name: "Hance Park",
+      action: "linked",
+      venueId: 5,
+    });
+
+    const venueLinkCalls = fetchCalls.filter(
+      (c) => c.method === "POST" && /\/festivals\/\d+\/venues$/.test(c.url),
+    );
+    expect(venueLinkCalls).toHaveLength(1);
+    expect(venueLinkCalls[0].body).toMatchObject({
+      venue_id: 5,
+      is_primary: true,
+    });
+  });
+
+  test("dry-run does not make mutation API calls", async () => {
+    setupNoMatchMocks();
+
+    const festivals = [
+      validFestival({
+        artists: [{ name: "SomeArtist", billing_tier: "headliner" }],
+      }),
+    ] as any[];
+
+    const results = await submitFestivals(festivals, TEST_ENV, false);
+
+    // Dry-run should produce no results (only skips are added in dry-run)
+    // Creates/updates only happen with --confirm
+    expect(results).toHaveLength(0);
+
+    // No POST or PUT calls (only GET for duplicate check)
+    const mutationCalls = fetchCalls.filter(
+      (c) => c.method === "POST" || c.method === "PUT",
+    );
+    expect(mutationCalls).toHaveLength(0);
+  });
+
+  test("processes multiple festivals in one batch", async () => {
+    setupNoMatchMocks();
+
+    addMockRoute("POST", /\/festivals$/, (_url, body) => {
+      const name = (body as Record<string, unknown>).name;
+      return {
+        id: name === "Fest A" ? 200 : 201,
+        name,
+      };
+    });
+
+    const festivals = [
+      validFestival({ name: "Fest A", series_slug: "fest-a" }),
+      validFestival({ name: "Fest B", series_slug: "fest-b" }),
+    ] as any[];
+
+    const results = await submitFestivals(festivals, TEST_ENV, true);
+
+    expect(results).toHaveLength(2);
+    expect(results[0].action).toBe("created");
+    expect(results[0].name).toBe("Fest A");
+    expect(results[1].action).toBe("created");
+    expect(results[1].name).toBe("Fest B");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `ph submit festival` command with duplicate detection, multi-step creation (festival → artists → venues)
- Resolves artist/venue names to IDs, links with billing tiers via `POST /festivals/{id}/artists`
- 14 tests covering create, lineup resolution, update, skip, validation, dry-run, confirm
- Part of [PH CLI project](https://github.com/mtrifilo/psychic-homily-web/pull/127)

## Test plan
- [x] Festival create with artist lineup (resolved by search)
- [x] Festival update with new info
- [x] Festival skip (exact duplicate)
- [x] Validation errors (missing required fields)
- [x] Dry-run vs confirm modes
- [x] `bun test` passes, `tsc --noEmit` clean

Closes PSY-147

🤖 Generated with [Claude Code](https://claude.com/claude-code)