### PR TITLE
Fix search test build error from revision recording signature change

### DIFF
--- a/backend/internal/api/handlers/search_test.go
+++ b/backend/internal/api/handlers/search_test.go
@@ -277,7 +277,7 @@ func TestSearchFestivals_Success(t *testing.T) {
 			}, nil
 		},
 	}
-	h := NewFestivalHandler(mock, nil, nil)
+	h := NewFestivalHandler(mock, nil, nil, nil)
 
 	resp, err := h.SearchFestivalsHandler(context.Background(), &SearchFestivalsRequest{Query: "m3f"})
 	if err != nil {
@@ -297,7 +297,7 @@ func TestSearchFestivals_EmptyQuery(t *testing.T) {
 			return []*services.FestivalListResponse{}, nil
 		},
 	}
-	h := NewFestivalHandler(mock, nil, nil)
+	h := NewFestivalHandler(mock, nil, nil, nil)
 
 	resp, err := h.SearchFestivalsHandler(context.Background(), &SearchFestivalsRequest{Query: ""})
 	if err != nil {
@@ -314,7 +314,7 @@ func TestSearchFestivals_ServiceError(t *testing.T) {
 			return nil, fmt.Errorf("db error")
 		},
 	}
-	h := NewFestivalHandler(mock, nil, nil)
+	h := NewFestivalHandler(mock, nil, nil, nil)
 
 	_, err := h.SearchFestivalsHandler(context.Background(), &SearchFestivalsRequest{Query: "test"})
 	if err == nil {


### PR DESCRIPTION
## Summary
- Fix latent build error in `search_test.go` where `NewFestivalHandler` calls used 3 arguments instead of 4
- The revision recording PR (PSY-124) added a `revisionService` parameter to `NewFestivalHandler` but didn't update the search test mock calls
- Passes nil for the new parameter in all 3 call sites

## Context

The festival intelligence feature (PSY-150 scope) is already fully shipped on main:
- **Backend**: `FestivalIntelligenceService` with 5 methods (GetSimilarFestivals, GetFestivalOverlap, GetFestivalBreakouts, GetArtistFestivalTrajectory, GetSeriesComparison)
- **Contracts**: All intelligence types (SimilarFestival, FestivalOverlap, FestivalBreakouts, ArtistTrajectory, SeriesComparison)
- **Handlers**: 5 endpoints registered on public routes
- **Tests**: 21 service integration tests + 5 nil-db unit tests + 4 helper unit tests + 13 handler integration tests = 43 total
- **Frontend**: Types, hooks (useSimilarFestivals, useFestivalBreakouts, useArtistFestivalTrajectory, useSeriesComparison), and components (SimilarFestivals, RisingArtists, ArtistTrajectoryChart, SeriesHistory) all integrated into FestivalDetail page

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test ./internal/services/catalog/ -run TestFestivalIntelligence` -- 21/21 pass
- [x] `go test ./internal/api/handlers/ -run TestFestivalIntelligence` -- 13/13 pass
- [x] `go test ./internal/api/handlers/ -run TestSearch` -- 11/11 pass (was failing before this fix)
- [x] `bun run test:run` -- 1455/1455 pass

Closes PSY-150

🤖 Generated with [Claude Code](https://claude.com/claude-code)