### PR TITLE
Admin Cmd+K commands — 17 admin shortcuts with deep-linking

### DIFF
--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useState, useEffect } from 'react'
-import { useRouter } from 'next/navigation'
+import { useState, useEffect, useCallback, Suspense } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
 import dynamic from 'next/dynamic'
 import { Shield, MapPin, Loader2, Upload, BadgeCheck, Flag, ScrollText, Users, LayoutDashboard, Clock, Disc3, Tag, Tags, Tent, Workflow, Library, Music, ClipboardCheck, BarChart3 } from 'lucide-react'
 import { usePendingVenueEdits } from '@/lib/hooks/admin/useAdminVenueEdits'
@@ -158,11 +158,42 @@ const CollectionManagementComponent = dynamic(
   }
 )
 
-export default function AdminPage() {
-  const [activeTab, setActiveTab] = useState('dashboard')
+const VALID_TABS = [
+  'dashboard', 'pending-shows', 'pending-venue-edits', 'unverified-venues',
+  'reports', 'import-show', 'releases', 'labels', 'festivals', 'pipeline',
+  'collections', 'tags', 'data-quality', 'analytics', 'artists-admin',
+  'users', 'audit-log',
+] as const
+
+type AdminTab = (typeof VALID_TABS)[number]
+
+function isValidTab(value: string | null): value is AdminTab {
+  return value !== null && (VALID_TABS as readonly string[]).includes(value)
+}
+
+function AdminPageContent() {
+  const searchParams = useSearchParams()
+  const tabParam = searchParams.get('tab')
+  const initialTab = isValidTab(tabParam) ? tabParam : 'dashboard'
+  const [activeTab, setActiveTab] = useState<string>(initialTab)
   const { user, isLoading, isAuthenticated } = useAuthContext()
   const isAdmin = !!user?.is_admin
   const router = useRouter()
+
+  // Sync tab state when URL search params change (e.g. from Cmd+K navigation)
+  useEffect(() => {
+    const newTab = searchParams.get('tab')
+    if (isValidTab(newTab) && newTab !== activeTab) {
+      setActiveTab(newTab)
+    }
+  }, [searchParams]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleTabChange = useCallback((value: string) => {
+    setActiveTab(value)
+    // Update URL without full navigation so the tab is bookmarkable
+    const url = value === 'dashboard' ? '/admin' : `/admin?tab=${value}`
+    router.replace(url, { scroll: false })
+  }, [router])
 
   useEffect(() => {
     if (isLoading) return
@@ -214,7 +245,7 @@ export default function AdminPage() {
         </div>
 
         {/* Tabs */}
-        <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
+        <Tabs value={activeTab} onValueChange={handleTabChange} className="w-full">
           <TabsList className="mb-6">
             <TabsTrigger value="dashboard" className="gap-2">
               <LayoutDashboard className="h-4 w-4" />
@@ -379,5 +410,19 @@ export default function AdminPage() {
         </Tabs>
       </div>
     </div>
+  )
+}
+
+export default function AdminPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-[calc(100vh-64px)] items-center justify-center">
+          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        </div>
+      }
+    >
+      <AdminPageContent />
+    </Suspense>
   )
 }

--- a/frontend/components/layout/CommandPalette.tsx
+++ b/frontend/components/layout/CommandPalette.tsx
@@ -13,8 +13,9 @@ import {
 } from '@/components/ui/command'
 import {
   Calendar, CalendarCheck, Mic2, MapPin, Disc3, Tag, Tags, Tent, BookOpen, Headphones, Send,
-  Library, LayoutList, MessageSquarePlus, Settings, Shield, Search, Clock, X, Globe, UserCheck,
-  TrendingUp,
+  Library, LayoutList, MessageSquarePlus, Settings, Search, Clock, X, Globe, UserCheck,
+  TrendingUp, LayoutDashboard, Upload, BadgeCheck, Flag, ScrollText, Users, Workflow,
+  ClipboardCheck, BarChart3, Music,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import { useAuthContext } from '@/lib/context/AuthContext'
@@ -142,14 +143,131 @@ const routes: RouteItem[] = [
     keywords: ['settings', 'profile', 'account', 'preferences', 'email'],
     requireAuth: true,
   },
+]
+
+const adminRoutes: RouteItem[] = [
   {
-    label: 'Admin',
+    label: 'Admin: Dashboard',
     href: '/admin',
-    icon: Shield,
-    keywords: ['admin', 'dashboard', 'manage', 'moderate'],
+    icon: LayoutDashboard,
+    keywords: ['admin', 'dashboard', 'overview', 'stats'],
+    requireAdmin: true,
+  },
+  {
+    label: 'Admin: Pending Shows',
+    href: '/admin?tab=pending-shows',
+    icon: Clock,
+    keywords: ['admin', 'pending', 'shows', 'approve', 'review', 'moderate'],
+    requireAdmin: true,
+  },
+  {
+    label: 'Admin: Venue Edits',
+    href: '/admin?tab=pending-venue-edits',
+    icon: MapPin,
+    keywords: ['admin', 'venue', 'edits', 'pending', 'approve'],
+    requireAdmin: true,
+  },
+  {
+    label: 'Admin: Unverified Venues',
+    href: '/admin?tab=unverified-venues',
+    icon: BadgeCheck,
+    keywords: ['admin', 'unverified', 'venues', 'verify'],
+    requireAdmin: true,
+  },
+  {
+    label: 'Admin: Reports',
+    href: '/admin?tab=reports',
+    icon: Flag,
+    keywords: ['admin', 'reports', 'flags', 'flagged', 'issues'],
+    requireAdmin: true,
+  },
+  {
+    label: 'Admin: Import Show',
+    href: '/admin?tab=import-show',
+    icon: Upload,
+    keywords: ['admin', 'import', 'show', 'add', 'upload'],
+    requireAdmin: true,
+  },
+  {
+    label: 'Admin: Releases',
+    href: '/admin?tab=releases',
+    icon: Disc3,
+    keywords: ['admin', 'releases', 'albums', 'manage'],
+    requireAdmin: true,
+  },
+  {
+    label: 'Admin: Labels',
+    href: '/admin?tab=labels',
+    icon: Tag,
+    keywords: ['admin', 'labels', 'record labels', 'manage'],
+    requireAdmin: true,
+  },
+  {
+    label: 'Admin: Festivals',
+    href: '/admin?tab=festivals',
+    icon: Tent,
+    keywords: ['admin', 'festivals', 'manage'],
+    requireAdmin: true,
+  },
+  {
+    label: 'Admin: Pipeline',
+    href: '/admin?tab=pipeline',
+    icon: Workflow,
+    keywords: ['admin', 'pipeline', 'extraction', 'scraping', 'venues'],
+    requireAdmin: true,
+  },
+  {
+    label: 'Admin: Collections',
+    href: '/admin?tab=collections',
+    icon: Library,
+    keywords: ['admin', 'collections', 'manage', 'featured'],
+    requireAdmin: true,
+  },
+  {
+    label: 'Admin: Tags',
+    href: '/admin?tab=tags',
+    icon: Tags,
+    keywords: ['admin', 'tags', 'manage', 'genres'],
+    requireAdmin: true,
+  },
+  {
+    label: 'Admin: Data Quality',
+    href: '/admin?tab=data-quality',
+    icon: ClipboardCheck,
+    keywords: ['admin', 'data', 'quality', 'health', 'issues'],
+    requireAdmin: true,
+  },
+  {
+    label: 'Admin: Analytics',
+    href: '/admin?tab=analytics',
+    icon: BarChart3,
+    keywords: ['admin', 'analytics', 'metrics', 'growth', 'engagement'],
+    requireAdmin: true,
+  },
+  {
+    label: 'Admin: Artists',
+    href: '/admin?tab=artists-admin',
+    icon: Music,
+    keywords: ['admin', 'artists', 'manage', 'merge', 'aliases'],
+    requireAdmin: true,
+  },
+  {
+    label: 'Admin: Users',
+    href: '/admin?tab=users',
+    icon: Users,
+    keywords: ['admin', 'users', 'accounts', 'manage'],
+    requireAdmin: true,
+  },
+  {
+    label: 'Admin: Audit Log',
+    href: '/admin?tab=audit-log',
+    icon: ScrollText,
+    keywords: ['admin', 'audit', 'log', 'history', 'actions'],
     requireAdmin: true,
   },
 ]
+
+const allRoutes = [...routes, ...adminRoutes]
 
 export function CommandPalette() {
   const router = useRouter()
@@ -174,11 +292,15 @@ export function CommandPalette() {
 
   const availableRoutes = useMemo(() => {
     return routes.filter(route => {
-      if (route.requireAdmin) return user?.is_admin
       if (route.requireAuth) return isAuthenticated
       return true
     })
-  }, [isAuthenticated, user?.is_admin])
+  }, [isAuthenticated])
+
+  const availableAdminRoutes = useMemo(() => {
+    if (!user?.is_admin) return []
+    return adminRoutes
+  }, [user?.is_admin])
 
   const handleSelect = useCallback(
     (href: string, label: string) => {
@@ -191,7 +313,7 @@ export function CommandPalette() {
 
   const handleRecentSelect = useCallback(
     (label: string) => {
-      const route = routes.find(
+      const route = allRoutes.find(
         r => r.label.toLowerCase() === label.toLowerCase()
       )
       if (route) {
@@ -247,7 +369,7 @@ export function CommandPalette() {
             }
           >
             {recentSearches.map(label => {
-              const route = routes.find(
+              const route = allRoutes.find(
                 r => r.label.toLowerCase() === label.toLowerCase()
               )
               return (
@@ -293,6 +415,32 @@ export function CommandPalette() {
             )
           })}
         </CommandGroup>
+
+        {availableAdminRoutes.length > 0 && (
+          <>
+            <CommandSeparator className="mx-2 my-1" />
+            <CommandGroup heading="Admin">
+              {availableAdminRoutes.map(route => {
+                const Icon = route.icon
+                return (
+                  <CommandItem
+                    key={route.href}
+                    value={route.label}
+                    onSelect={() => handleSelect(route.href, route.label)}
+                    keywords={route.keywords}
+                    className="cursor-pointer gap-3 rounded-lg px-2 py-2.5"
+                  >
+                    <Icon className="h-4 w-4 text-muted-foreground" />
+                    <span>{route.label}</span>
+                    <span className="ml-auto text-xs text-muted-foreground">
+                      /admin
+                    </span>
+                  </CommandItem>
+                )
+              })}
+            </CommandGroup>
+          </>
+        )}
       </CommandList>
 
       <div className="flex items-center justify-between border-t border-border/50 px-3 py-2">


### PR DESCRIPTION
## Summary
- Added 17 admin-specific commands to Cmd+K palette (only visible to admin users)
- Each command deep-links to the specific admin tab via `?tab=` URL parameter
- Admin page now reads `?tab=` from URL on load and syncs tab state
- Tabs are bookmarkable — clicking a tab updates the URL
- Admin group in Cmd+K has icons matching the admin page

## Test plan
- [ ] Cmd+K as admin shows "Admin" section with all 17 commands
- [ ] Cmd+K as non-admin does NOT show admin section
- [ ] Clicking "Admin: Pending Shows" navigates to `/admin?tab=pending-shows`
- [ ] Direct URL `/admin?tab=analytics` opens the Analytics tab
- [ ] All 1455 frontend tests pass

Closes PSY-44

🤖 Generated with [Claude Code](https://claude.com/claude-code)