### PR TITLE
Add tag integration, /ingest skill, and CLI tooling improvements

### DIFF
--- a/.claude/skills/ingest/SKILL.md
+++ b/.claude/skills/ingest/SKILL.md
@@ -1,12 +1,27 @@
 ---
 name: ingest
 description: Extract entities from screenshots (show flyers, WFMU playlists, tour announcements, festival lineups) and import them into the Psychic Homily knowledge graph via the ph CLI.
-argument-hint: "[description of what to ingest, or paste a screenshot]"
+argument-hint: "[description or screenshot] [--env production|local]"
 ---
 
 # Ingest: Screenshot to Knowledge Graph
 
 Extract structured entity data from screenshots and import into Psychic Homily using the `ph` CLI.
+
+## Environment Targeting
+
+By default, commands use whichever environment is set as default in `~/.psychic-homily/config.json`.
+
+- `/ingest` — uses default environment
+- `/ingest --env production` — targets production regardless of default
+- `/ingest --env local` — targets local dev regardless of default
+
+When `--env` is specified in the skill argument, append `--env <name>` to ALL `ph` commands in this workflow.
+
+Check current default with:
+```bash
+cd /Users/mtrifilo/dev/psychic-homily-web/cli && bun run src/entry.ts config show
+```
 
 ## Prerequisites
 
@@ -83,9 +98,11 @@ The batch command processes in dependency order: labels → artists → releases
 
 ### Step 3: Dry Run
 
-Run the batch in dry-run mode and show the user the preview:
+Run the batch in dry-run mode and show the user the preview. If `--env` was specified in the `/ingest` arguments, include it on all commands:
 ```bash
 cd /Users/mtrifilo/dev/psychic-homily-web/cli && bun run src/entry.ts batch /tmp/ph-ingest.json
+# Or with explicit environment:
+cd /Users/mtrifilo/dev/psychic-homily-web/cli && bun run src/entry.ts --env production batch /tmp/ph-ingest.json
 ```
 
 Present the output to the user and ask for confirmation. Highlight:
@@ -96,16 +113,18 @@ Present the output to the user and ask for confirmation. Highlight:
 
 ### Step 4: Confirm
 
-After user approval:
+After user approval (use same `--env` flag if specified):
 ```bash
 cd /Users/mtrifilo/dev/psychic-homily-web/cli && bun run src/entry.ts batch --confirm /tmp/ph-ingest.json
+# Or with explicit environment:
+cd /Users/mtrifilo/dev/psychic-homily-web/cli && bun run src/entry.ts --env production batch --confirm /tmp/ph-ingest.json
 ```
 
 Report the results: how many created, updated, skipped, errored.
 
 ### Step 5: Fix-ups (if needed)
 
-If any entities failed (e.g., unresolved artists for releases), fix them individually:
+If any entities failed (e.g., unresolved artists for releases), fix them individually (use same `--env` flag if specified):
 ```bash
 # Create the missing artist
 bun run src/entry.ts submit artist --confirm '[{"name": "Missing Artist"}]'

--- a/.claude/skills/ingest/SKILL.md
+++ b/.claude/skills/ingest/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: ingest
+description: Extract entities from screenshots (show flyers, WFMU playlists, tour announcements, festival lineups) and import them into the Psychic Homily knowledge graph via the ph CLI.
+argument-hint: "[description of what to ingest, or paste a screenshot]"
+---
+
+# Ingest: Screenshot to Knowledge Graph
+
+Extract structured entity data from screenshots and import into Psychic Homily using the `ph` CLI.
+
+## Prerequisites
+
+The `ph` CLI must be configured. Check with:
+```bash
+cd /Users/mtrifilo/dev/psychic-homily-web/cli && bun run src/entry.ts status
+```
+
+If not configured, set up with:
+```bash
+# Generate API token (local dev)
+cd /Users/mtrifilo/dev/psychic-homily-web/backend && go run ./cmd/gen-api-token --make-admin
+
+# Configure CLI (use the token from above)
+cd /Users/mtrifilo/dev/psychic-homily-web/cli && bun run src/entry.ts init --url http://localhost:8080 --token phk_xxx --name local
+```
+
+## Workflow
+
+### Step 1: Extract Data from Screenshot
+
+When the user provides a screenshot (show flyer, WFMU playlist, tour poster, festival lineup, etc.), extract ALL entities visible:
+
+**For WFMU playlists** — extract: artists, tracks, albums (→ releases), labels, years
+**For show flyers** — extract: artists (with headliner/opener), venue, date, city/state, price
+**For tour announcements** — extract: artist, multiple dates/venues/cities
+**For festival lineups** — extract: festival name, dates, artists with billing tiers, venue(s)
+
+### Step 2: Build Batch JSON
+
+Create a JSON file at `/tmp/ph-ingest.json` with the extracted data. Use this format:
+
+```json
+[
+  {"entity_type": "label", "name": "Label Name", "country": "US", "website": "https://..."},
+  {"entity_type": "artist", "name": "Artist Name", "city": "City", "tags": ["genre-tag", {"name": "Japanese", "category": "locale"}]},
+  {"entity_type": "release", "title": "Album Title", "release_type": "lp", "release_year": 2025, "artists": [{"name": "Artist Name"}]},
+  {"entity_type": "venue", "name": "Venue Name", "city": "City", "state": "ST", "website": "https://..."},
+  {"entity_type": "show", "event_date": "2026-04-15", "city": "Phoenix", "state": "AZ", "artists": [{"name": "Artist Name", "is_headliner": true}], "venues": [{"name": "Venue Name", "city": "Phoenix", "state": "AZ"}]},
+  {"entity_type": "festival", "name": "Fest Name 2026", "series_slug": "fest-name", "edition_year": 2026, "start_date": "2026-06-01", "end_date": "2026-06-03", "artists": [{"name": "Artist", "billing_tier": "headliner"}]}
+]
+```
+
+#### Entity schemas
+
+**artist**: `name` (required), `city`, `state`, `instagram`, `bandcamp`, `spotify`, `website`, `tags`
+**venue**: `name` (required), `city` (required), `state` (required), `address`, `website`, `tags`
+**show**: `event_date` (required, YYYY-MM-DD), `city` (required), `state` (required), `title`, `price`, `artists` (required, array of `{name, is_headliner?}`), `venues` (required, array of `{name, city, state}`)
+**release**: `title` (required), `release_type` (lp/ep/single/compilation/live/remix/demo), `release_year`, `artists` (required), `external_links` ([{platform, url}]), `tags`
+**label**: `name` (required), `city`, `state`, `country`, `website`, `bandcamp`, `tags`
+**festival**: `name` (required), `series_slug` (required), `edition_year` (required), `start_date` (required), `end_date` (required), `city`, `state`, `artists` ([{name, billing_tier}]), `tags`
+
+#### Tag format
+
+Tags can be strings (defaults to genre) or objects with category:
+```json
+"tags": ["punk", "noise rock", {"name": "Japanese", "category": "locale"}]
+```
+
+Categories: `genre`, `locale`, `mood`, `era`, `style`, `instrument`, `other`
+
+#### Processing order
+
+The batch command processes in dependency order: labels → artists → releases → venues → festivals → shows. Put entities in any order — the CLI handles sequencing.
+
+#### Guidelines for data extraction
+
+- **Artist names**: Use the exact spelling from the source. Don't correct or normalize.
+- **Release types**: `lp` for full albums, `ep` for EPs, `compilation` for comps/anthologies, `live` for live recordings, `single` for singles.
+- **Release years**: Use the original release year when available. For reissues, use the reissue year.
+- **Tags**: Add genre and locale tags where you can confidently identify them. Common genres: punk, post-punk, noise rock, psychedelic, electronic, industrial, experimental, ambient, folk, gospel, funk, disco, synth pop, avant-garde, hip-hop, jazz, metal. Locale tags use `category: "locale"`: Japanese, German, Spanish, Russian, Thai, Brazilian, etc.
+- **Billing tiers** (festivals): headliner, sub_headliner, mid_card, undercard, local, dj, host.
+- **Skip non-music entries**: DJ interludes, radio commercials, compilation album titles without a distinct artist, trivia nights.
+
+### Step 3: Dry Run
+
+Run the batch in dry-run mode and show the user the preview:
+```bash
+cd /Users/mtrifilo/dev/psychic-homily-web/cli && bun run src/entry.ts batch /tmp/ph-ingest.json
+```
+
+Present the output to the user and ask for confirmation. Highlight:
+- How many entities of each type will be created/updated/skipped
+- Any fuzzy tag matches (where existing similar tags were found)
+- Any unresolved artists (for releases/shows)
+- Any validation errors
+
+### Step 4: Confirm
+
+After user approval:
+```bash
+cd /Users/mtrifilo/dev/psychic-homily-web/cli && bun run src/entry.ts batch --confirm /tmp/ph-ingest.json
+```
+
+Report the results: how many created, updated, skipped, errored.
+
+### Step 5: Fix-ups (if needed)
+
+If any entities failed (e.g., unresolved artists for releases), fix them individually:
+```bash
+# Create the missing artist
+bun run src/entry.ts submit artist --confirm '[{"name": "Missing Artist"}]'
+
+# Retry the release
+bun run src/entry.ts submit release --confirm '[{"title": "Album", "artists": [{"name": "Missing Artist"}]}]'
+```
+
+## Individual Commands Reference
+
+```bash
+# Search before creating
+bun run src/entry.ts search artist "name"
+bun run src/entry.ts search venue "name"
+bun run src/entry.ts search release "title"
+bun run src/entry.ts search label "name"
+
+# Submit single entities
+bun run src/entry.ts submit artist '[{"name": "...", "tags": ["punk"]}]'
+bun run src/entry.ts submit venue '[{"name": "...", "city": "...", "state": "..."}]'
+bun run src/entry.ts submit show '[{"event_date": "2026-04-15", ...}]'
+bun run src/entry.ts submit release '[{"title": "...", "artists": [...]}]'
+bun run src/entry.ts submit label '[{"name": "..."}]'
+bun run src/entry.ts submit festival '[{"name": "...", "series_slug": "...", ...}]'
+
+# All commands support --confirm (default is dry-run)
+# All commands accept JSON as argument or piped via stdin
+```

--- a/backend/cmd/gen-api-token/main.go
+++ b/backend/cmd/gen-api-token/main.go
@@ -1,0 +1,93 @@
+// gen-api-token generates a phk_ API token for a user directly against the database.
+// Intended for local development only — bypasses API auth entirely.
+//
+// Usage:
+//
+//	go run ./cmd/gen-api-token                    # token for user ID 1
+//	go run ./cmd/gen-api-token --user-id 3        # token for user ID 3
+//	go run ./cmd/gen-api-token --email admin@test  # token for user by email
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
+
+	"psychic-homily-backend/internal/config"
+	"psychic-homily-backend/internal/models"
+	adminsvc "psychic-homily-backend/internal/services/admin"
+)
+
+func main() {
+	userID := flag.Uint("user-id", 1, "User ID to generate token for")
+	email := flag.String("email", "", "User email (alternative to --user-id)")
+	days := flag.Int("days", 365, "Token expiration in days")
+	desc := flag.String("description", "CLI dev token", "Token description")
+	makeAdmin := flag.Bool("make-admin", false, "Make the user an admin if not already")
+	flag.Parse()
+
+	cfg, err := config.Load()
+	if err != nil {
+		// In dev, validation errors are expected (placeholder secrets)
+		// We only need the database URL which has a usable default
+		cfg = &config.Config{
+			Database: config.DatabaseConfig{
+				URL: config.GetEnv("DATABASE_URL", "postgres://psychicadmin:secretpassword@localhost:5432/psychicdb?sslmode=disable"),
+			},
+		}
+	}
+	_ = err
+
+	db, err := gorm.Open(postgres.Open(cfg.Database.URL), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to connect to database: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Resolve user
+	var user models.User
+	if *email != "" {
+		if err := db.Where("email = ?", *email).First(&user).Error; err != nil {
+			fmt.Fprintf(os.Stderr, "User with email %q not found: %v\n", *email, err)
+			os.Exit(1)
+		}
+	} else {
+		if err := db.First(&user, *userID).Error; err != nil {
+			fmt.Fprintf(os.Stderr, "User with ID %d not found: %v\n", *userID, err)
+			os.Exit(1)
+		}
+	}
+
+	// Optionally make admin
+	if *makeAdmin && !user.IsAdmin {
+		db.Model(&user).Update("is_admin", true)
+		fmt.Fprintf(os.Stderr, "Made user %d (%s) an admin\n", user.ID, *user.Email)
+	}
+
+	if !user.IsAdmin {
+		fmt.Fprintf(os.Stderr, "Warning: user %d is not an admin. Most ph commands require admin access.\n", user.ID)
+		fmt.Fprintf(os.Stderr, "Run with --make-admin to fix.\n")
+	}
+
+	// Generate token
+	svc := adminsvc.NewAPITokenService(db)
+	resp, err := svc.CreateToken(user.ID, desc, *days)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to create token: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Fprintf(os.Stderr, "Token created for user %d (%s)\n", user.ID, *user.Email)
+	fmt.Fprintf(os.Stderr, "Expires: %s\n", resp.ExpiresAt.Format("2006-01-02"))
+	fmt.Fprintf(os.Stderr, "\nRun this to configure the CLI:\n\n")
+	fmt.Fprintf(os.Stderr, "  cd cli && bun run src/entry.ts init --url http://localhost:8080 --token %s --name local\n\n", resp.Token)
+
+	// Print just the token to stdout (for piping)
+	fmt.Println(resp.Token)
+}

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,205 @@
+# PH CLI — Knowledge Graph Ingest Tool
+
+CLI for rapidly adding entities (artists, venues, shows, releases, labels, festivals) to the Psychic Homily knowledge graph. Designed for use from Claude Code sessions — Claude extracts structured data from screenshots and text, the CLI validates, detects duplicates, and submits to the API.
+
+## Quick Start
+
+```bash
+# 1. Install dependencies
+bun install
+
+# 2. Generate an API token (local dev — requires backend + PostgreSQL running)
+cd ../backend && go run ./cmd/gen-api-token --make-admin
+
+# 3. Configure the CLI
+bun run src/entry.ts init --url http://localhost:8080 --token phk_xxx --name local
+
+# 4. Verify
+bun run src/entry.ts status
+```
+
+## Usage
+
+### Search for existing entities
+
+```bash
+bun run src/entry.ts search artist "Nina Hagen"
+bun run src/entry.ts search venue "Crescent"
+bun run src/entry.ts search release "Satori"
+bun run src/entry.ts search label "Numero"
+bun run src/entry.ts search festival "M3F"
+```
+
+### Submit entities (single or batch)
+
+Every submit command defaults to **dry-run** — it shows what would happen without making changes. Add `--confirm` to execute.
+
+```bash
+# Dry-run (preview only)
+bun run src/entry.ts submit artist '[{"name": "Nina Hagen", "city": "Berlin", "tags": ["punk", {"name": "German", "category": "locale"}]}]'
+
+# Execute
+bun run src/entry.ts submit artist --confirm '[{"name": "Nina Hagen", "city": "Berlin"}]'
+
+# Pipe from stdin
+echo '[{"name": "Artist"}]' | bun run src/entry.ts submit artist --confirm
+```
+
+### Batch import (mixed entity types)
+
+```bash
+# Dry-run
+bun run src/entry.ts batch /tmp/data.json
+
+# Execute
+bun run src/entry.ts batch --confirm /tmp/data.json
+```
+
+Batch files are JSON arrays with an `entity_type` field on each item. The CLI processes them in dependency order: labels → artists → releases → venues → festivals → shows.
+
+### Environment targeting
+
+```bash
+# Default environment is set during init
+bun run src/entry.ts --env local submit artist '[...]'
+bun run src/entry.ts --env production submit artist '[...]'
+
+# Change default
+bun run src/entry.ts config set default_environment local
+```
+
+## Entity Schemas
+
+### Artist
+```json
+{"name": "Required", "city": "Optional", "state": "Optional", "instagram": "@handle", "bandcamp": "url", "spotify": "url", "website": "url", "tags": ["genre", {"name": "Locale", "category": "locale"}]}
+```
+
+### Venue
+```json
+{"name": "Required", "city": "Required", "state": "Required", "address": "Optional", "website": "url"}
+```
+
+### Show
+```json
+{"event_date": "2026-04-15", "city": "Required", "state": "Required", "title": "Optional", "price": 25.00, "artists": [{"name": "Artist", "is_headliner": true}], "venues": [{"name": "Venue", "city": "City", "state": "ST"}]}
+```
+- `event_date` accepts `YYYY-MM-DD` (auto-normalized to `YYYY-MM-DDT20:00:00Z`)
+- Artists and venues are resolved by name search — existing entities use their ID, new ones are created automatically
+
+### Release
+```json
+{"title": "Required", "release_type": "lp", "release_year": 2025, "artists": [{"name": "Artist"}], "external_links": [{"platform": "bandcamp", "url": "https://..."}], "tags": ["genre"]}
+```
+- `release_type`: `lp`, `ep`, `single`, `compilation`, `live`, `remix`, `demo`
+
+### Label
+```json
+{"name": "Required", "city": "Optional", "state": "Optional", "country": "Optional", "website": "url"}
+```
+
+### Festival
+```json
+{"name": "Required", "series_slug": "required-slug", "edition_year": 2026, "start_date": "2026-06-01", "end_date": "2026-06-03", "city": "Optional", "state": "Optional", "artists": [{"name": "Artist", "billing_tier": "headliner"}]}
+```
+- `billing_tier`: `headliner`, `sub_headliner`, `mid_card`, `undercard`, `local`, `dj`, `host`
+
+## Tags
+
+Tags can be included on any entity (artist, release, label, festival, venue). They're specified as an array of strings or objects:
+
+```json
+"tags": ["punk", "noise rock", {"name": "Japanese", "category": "locale"}]
+```
+
+- String tags default to `category: "genre"`
+- Object tags specify a category: `genre`, `locale`, `mood`, `era`, `style`, `instrument`, `other`
+- The CLI auto-detects existing tags (case-insensitive, with alias resolution)
+- Fuzzy duplicates are flagged in dry-run (e.g., "post punk" matches "post-punk")
+- New tags are created automatically on `--confirm`
+- Tags are applied even when an entity is skipped (already exists)
+
+## Duplicate Detection
+
+The CLI searches for existing entities before creating. For each entity it classifies the action:
+
+- **CREATE** — no match found, will create new entity
+- **UPDATE** — match found, proposed data has new fields to add (never overwrites existing values)
+- **SKIP** — match found, no new information to add
+
+## Agent Usage Guide
+
+### Using the `/ingest` skill
+
+The `/ingest` skill automates the full screenshot-to-knowledge-graph flow. When a user pastes a screenshot (WFMU playlist, show flyer, tour poster, festival lineup), invoke `/ingest` to guide the extraction.
+
+### Common mistakes to avoid
+
+1. **Don't forget `--confirm`** — without it, nothing is submitted. Always dry-run first, then confirm.
+
+2. **Don't skip the dry-run** — show the user the preview before confirming. They need to verify entity names, tag assignments, and duplicate detection results.
+
+3. **Don't guess artist/venue IDs** — let the CLI resolve them by name. Use `name` fields, not `id` fields, unless you've verified the ID via `ph search`.
+
+4. **Don't normalize artist names** — use the exact spelling from the source material. The duplicate detection handles case-insensitive matching.
+
+5. **Event dates are just YYYY-MM-DD** — the CLI normalizes to ISO 8601 automatically. Don't add timezone info.
+
+6. **Use batch for multi-entity imports** — don't run 20 separate `ph submit` commands. Write a batch JSON file and use `ph batch`. The dependency ordering (labels → artists → releases → venues → festivals → shows) is handled automatically.
+
+7. **Tags are optional but valuable** — add genre and locale tags when you can confidently identify them from the source material. Don't guess genres you're unsure about.
+
+8. **Check for existing entities first** — before a large import, use `ph search` to check if key entities already exist. This helps you anticipate which items will be creates vs updates vs skips.
+
+9. **The CLI needs the backend running** — for local dev, the Go backend must be running on port 8080. Use `ph status` to verify connectivity before starting an import.
+
+10. **Config defaults to production** — make sure `default_environment` is set correctly. Use `ph config show` to check, and `ph config set default_environment local` to change.
+
+### Batch JSON tips for agents
+
+- Put all entities in a single flat array with `entity_type` on each item
+- Labels and artists before releases (releases reference artists by name)
+- Venues before shows (shows reference venues by name)
+- The CLI deduplicates — if the same artist appears in multiple releases, list them once in the artists section
+- For WFMU playlists: skip DJ interludes, compilation album entries without distinct artists, and radio commercials
+- For release types: use `compilation` for various-artist compilations, `lp` for standard albums, `live` for live recordings/bootlegs
+
+## Development
+
+```bash
+bun install          # Install dependencies
+bun test             # Run tests (232 tests)
+bunx tsc --noEmit    # Type check
+bun run src/entry.ts --help  # CLI help
+```
+
+## Architecture
+
+```
+cli/
+├── src/
+│   ├── entry.ts              # Bun shebang entry point
+│   ├── cli.ts                # Commander.js command wiring
+│   ├── commands/
+│   │   ├── init.ts           # ph init (configure environment)
+│   │   ├── config.ts         # ph config show/set
+│   │   ├── search.ts         # ph search <type> <query>
+│   │   ├── status.ts         # ph status (connection check)
+│   │   ├── batch.ts          # ph batch <file.json>
+│   │   ├── submit-artist.ts  # ph submit artist
+│   │   ├── submit-venue.ts   # ph submit venue
+│   │   ├── submit-show.ts    # ph submit show
+│   │   ├── submit-release.ts # ph submit release
+│   │   ├── submit-label.ts   # ph submit label
+│   │   └── submit-festival.ts # ph submit festival
+│   └── lib/
+│       ├── api.ts            # API client (fetch + auth)
+│       ├── config.ts         # Config file management
+│       ├── types.ts          # Shared TypeScript types
+│       ├── display.ts        # Terminal output (tables, diffs, colors)
+│       ├── ansi.ts           # ANSI color helpers (NO_COLOR aware)
+│       ├── duplicates.ts     # Duplicate detection engine
+│       ├── schemas.ts        # Entity validation
+│       └── tags.ts           # Tag resolution (search, create, apply)
+└── test/                     # 232 tests across 15 files
+```

--- a/cli/src/commands/submit-artist.ts
+++ b/cli/src/commands/submit-artist.ts
@@ -3,6 +3,8 @@ import type { EnvironmentConfig } from "../lib/types";
 import type { DuplicateCheckResult, FieldComparison } from "../lib/duplicates";
 import { checkDuplicate } from "../lib/duplicates";
 import { validateArtist } from "../lib/schemas";
+import { TagResolver, formatTagsPreview, formatFuzzyWarning } from "../lib/tags";
+import type { TagInput, ResolvedTag } from "../lib/tags";
 import * as display from "../lib/display";
 import { green, yellow, gray, dim } from "../lib/ansi";
 
@@ -157,6 +159,18 @@ export async function submitArtists(
     dupResults.push(result);
   }
 
+  // Phase 2b: Resolve tags for all artists
+  const tagResolver = new TagResolver(client);
+  const resolvedTags: ResolvedTag[][] = [];
+  for (const artist of artists) {
+    const tags = TagResolver.parseTags(artist.tags as TagInput[] | undefined);
+    if (tags.length > 0) {
+      resolvedTags.push(await tagResolver.resolveAll(tags));
+    } else {
+      resolvedTags.push([]);
+    }
+  }
+
   // Phase 3: Display preview
   let creates = 0;
   let updates = 0;
@@ -164,6 +178,15 @@ export async function submitArtists(
 
   for (let i = 0; i < artists.length; i++) {
     displayArtistPreview(artists[i], dupResults[i], i);
+
+    // Show tags if any
+    if (resolvedTags[i].length > 0) {
+      display.kv("tags", formatTagsPreview(resolvedTags[i]));
+      for (const tag of resolvedTags[i]) {
+        const warning = formatFuzzyWarning(tag);
+        if (warning) display.warn(warning);
+      }
+    }
 
     switch (dupResults[i].action) {
       case "create":
@@ -211,6 +234,14 @@ export async function submitArtists(
           }>("/admin/artists", artist);
           const id = response.artist?.id ?? response.id;
           display.success(`Created "${name}" (ID ${id})`);
+          // Apply tags if any
+          if (id && resolvedTags[i].length > 0) {
+            const parsedTags = TagResolver.parseTags(artist.tags as TagInput[] | undefined);
+            const tagResult = await tagResolver.applyToEntity("artist", id, parsedTags);
+            if (tagResult.applied > 0) {
+              display.info(`  Applied ${tagResult.applied} tag(s)`);
+            }
+          }
           results.push({ name, action: "created", id });
           break;
         }
@@ -233,6 +264,14 @@ export async function submitArtists(
           display.success(
             `Updated "${dup.existingName || name}" (ID ${dup.existingId})`,
           );
+          // Apply tags if any
+          if (dup.existingId && resolvedTags[i].length > 0) {
+            const parsedTags = TagResolver.parseTags(artist.tags as TagInput[] | undefined);
+            const tagResult = await tagResolver.applyToEntity("artist", dup.existingId, parsedTags);
+            if (tagResult.applied > 0) {
+              display.info(`  Applied ${tagResult.applied} tag(s)`);
+            }
+          }
           results.push({
             name,
             action: "updated",
@@ -245,6 +284,14 @@ export async function submitArtists(
           display.info(
             `Skipped "${dup.existingName || name}" (ID ${dup.existingId}) — no new info.`,
           );
+          // Still apply tags even on skip
+          if (dup.existingId && resolvedTags[i].length > 0) {
+            const parsedTags = TagResolver.parseTags(artist.tags as TagInput[] | undefined);
+            const tagResult = await tagResolver.applyToEntity("artist", dup.existingId, parsedTags);
+            if (tagResult.applied > 0) {
+              display.info(`  Applied ${tagResult.applied} tag(s)`);
+            }
+          }
           results.push({
             name,
             action: "skipped",

--- a/cli/src/commands/submit-festival.ts
+++ b/cli/src/commands/submit-festival.ts
@@ -8,6 +8,8 @@ import {
   type DuplicateCheckResult,
   type FieldComparison,
 } from "../lib/duplicates";
+import { TagResolver, formatTagsPreview, formatFuzzyWarning } from "../lib/tags";
+import type { TagInput, ResolvedTag } from "../lib/tags";
 
 /** Festival artist entry from the input JSON. */
 interface FestivalArtistInput {
@@ -43,6 +45,7 @@ interface FestivalInput {
   status?: string;
   artists?: FestivalArtistInput[];
   venues?: FestivalVenueInput[];
+  tags?: TagInput[];
 }
 
 /** Result of processing a single festival. */
@@ -253,6 +256,18 @@ export async function submitFestivals(
     planned.push({ input: festival, dupResult });
   }
 
+  // --- Phase 2b: Resolve tags ---
+  const tagResolver = new TagResolver(client);
+  const resolvedTags: ResolvedTag[][] = [];
+  for (const p of planned) {
+    const tags = TagResolver.parseTags(p.input.tags as TagInput[] | undefined);
+    if (tags.length > 0) {
+      resolvedTags.push(await tagResolver.resolveAll(tags));
+    } else {
+      resolvedTags.push([]);
+    }
+  }
+
   // --- Phase 3: Preview ---
   display.header("Preview");
 
@@ -261,6 +276,7 @@ export async function submitFestivals(
   const skips = planned.filter((p) => p.dupResult.action === "skip");
 
   for (const p of creates) {
+    const planIdx = planned.indexOf(p);
     const f = p.input;
     display.info(
       `${green("CREATE")} ${f.name} (${f.series_slug} ${f.edition_year})`,
@@ -273,9 +289,18 @@ export async function submitFestivals(
     if (f.venues?.length) {
       display.kv("Venues", `${f.venues.length} to resolve`);
     }
+    // Show tags if any
+    if (resolvedTags[planIdx].length > 0) {
+      display.kv("tags", formatTagsPreview(resolvedTags[planIdx]));
+      for (const tag of resolvedTags[planIdx]) {
+        const warning = formatFuzzyWarning(tag);
+        if (warning) display.warn(warning);
+      }
+    }
   }
 
   for (const p of updates) {
+    const planIdx = planned.indexOf(p);
     const f = p.input;
     const newFields = p.dupResult.fields.filter(
       (field) => field.status === "new_info",
@@ -293,18 +318,57 @@ export async function submitFestivals(
     if (f.venues?.length) {
       display.kv("Venues", `${f.venues.length} to resolve & link`);
     }
+    // Show tags if any
+    if (resolvedTags[planIdx].length > 0) {
+      display.kv("tags", formatTagsPreview(resolvedTags[planIdx]));
+      for (const tag of resolvedTags[planIdx]) {
+        const warning = formatFuzzyWarning(tag);
+        if (warning) display.warn(warning);
+      }
+    }
   }
 
   for (const p of skips) {
+    const planIdx = planned.indexOf(p);
     display.info(
       `${dim("SKIP")} ${p.input.name} → already exists as "${p.dupResult.existingName}" (ID: ${p.dupResult.existingId})`,
     );
+    // Show tags if any
+    if (resolvedTags[planIdx].length > 0) {
+      display.kv("tags", formatTagsPreview(resolvedTags[planIdx]));
+      for (const tag of resolvedTags[planIdx]) {
+        const warning = formatFuzzyWarning(tag);
+        if (warning) display.warn(warning);
+      }
+    }
   }
 
   display.summary(creates.length, updates.length, skips.length);
 
-  // Add skip results
+  // --- Phase 4: Execute (if --confirm) ---
+  if (!confirm) {
+    // Add skip results for dry run
+    for (const p of skips) {
+      results.push({
+        name: p.input.name,
+        action: "skipped",
+        id: p.dupResult.existingId,
+      });
+    }
+    display.warn('Dry run. Pass --confirm to submit.');
+    return results;
+  }
+
+  // Add skip results and apply tags for skipped festivals
   for (const p of skips) {
+    const parsedTags = TagResolver.parseTags(p.input.tags as TagInput[] | undefined);
+    // Still apply tags even on skip
+    if (p.dupResult.existingId && parsedTags.length > 0) {
+      const tagResult = await tagResolver.applyToEntity("festival", p.dupResult.existingId, parsedTags);
+      if (tagResult.applied > 0) {
+        display.info(`  Applied ${tagResult.applied} tag(s) to "${p.input.name}"`);
+      }
+    }
     results.push({
       name: p.input.name,
       action: "skipped",
@@ -312,17 +376,13 @@ export async function submitFestivals(
     });
   }
 
-  // --- Phase 4: Execute (if --confirm) ---
-  if (!confirm) {
-    display.warn('Dry run. Pass --confirm to submit.');
-    return results;
-  }
-
   display.header("Submitting...");
 
   // Process creates
   for (const p of creates) {
+    const planIdx = planned.indexOf(p);
     const f = p.input;
+    const parsedTags = TagResolver.parseTags(f.tags as TagInput[] | undefined);
     try {
       const body: Record<string, unknown> = {
         name: f.name,
@@ -367,6 +427,14 @@ export async function submitFestivals(
         result.venueResults = await linkVenues(client, festivalId, f.venues);
       }
 
+      // Apply tags if any
+      if (festivalId && parsedTags.length > 0) {
+        const tagResult = await tagResolver.applyToEntity("festival", festivalId, parsedTags);
+        if (tagResult.applied > 0) {
+          display.info(`  Applied ${tagResult.applied} tag(s)`);
+        }
+      }
+
       results.push(result);
     } catch (err) {
       const message = err instanceof Error ? err.message : "Unknown error";
@@ -377,8 +445,10 @@ export async function submitFestivals(
 
   // Process updates
   for (const p of updates) {
+    const planIdx = planned.indexOf(p);
     const f = p.input;
     const festivalId = p.dupResult.existingId!;
+    const parsedTags = TagResolver.parseTags(f.tags as TagInput[] | undefined);
     try {
       const updateBody = buildUpdateBody(p.dupResult.fields, f);
 
@@ -409,6 +479,14 @@ export async function submitFestivals(
       // Link venues
       if (f.venues?.length) {
         result.venueResults = await linkVenues(client, festivalId, f.venues);
+      }
+
+      // Apply tags if any
+      if (festivalId && parsedTags.length > 0) {
+        const tagResult = await tagResolver.applyToEntity("festival", festivalId, parsedTags);
+        if (tagResult.applied > 0) {
+          display.info(`  Applied ${tagResult.applied} tag(s)`);
+        }
       }
 
       results.push(result);

--- a/cli/src/commands/submit-label.ts
+++ b/cli/src/commands/submit-label.ts
@@ -2,6 +2,8 @@ import { APIClient } from "../lib/api";
 import type { EnvironmentConfig } from "../lib/types";
 import { validateLabel } from "../lib/schemas";
 import { checkDuplicate, type DuplicateCheckResult } from "../lib/duplicates";
+import { TagResolver, formatTagsPreview, formatFuzzyWarning } from "../lib/tags";
+import type { TagInput, ResolvedTag } from "../lib/tags";
 import * as display from "../lib/display";
 
 interface LabelInput {
@@ -120,12 +122,25 @@ export async function submitLabels(
     plans.push({ label, dupResult, index });
   }
 
+  // Phase 2b: Resolve tags for all labels
+  const tagResolver = new TagResolver(client);
+  const resolvedTags: ResolvedTag[][] = [];
+  for (const { label } of plans) {
+    const tags = TagResolver.parseTags(label.tags as TagInput[] | undefined);
+    if (tags.length > 0) {
+      resolvedTags.push(await tagResolver.resolveAll(tags));
+    } else {
+      resolvedTags.push([]);
+    }
+  }
+
   // Phase 3: Display preview
   let creates = 0;
   let updates = 0;
   let skips = 0;
 
-  for (const { label, dupResult } of plans) {
+  for (let planIdx = 0; planIdx < plans.length; planIdx++) {
+    const { label, dupResult } = plans[planIdx];
     switch (dupResult.action) {
       case "create": {
         display.header(`CREATE: ${label.name}`);
@@ -158,6 +173,15 @@ export async function submitLabels(
         break;
       }
     }
+
+    // Show tags if any
+    if (resolvedTags[planIdx].length > 0) {
+      display.kv("tags", formatTagsPreview(resolvedTags[planIdx]));
+      for (const tag of resolvedTags[planIdx]) {
+        const warning = formatFuzzyWarning(tag);
+        if (warning) display.warn(warning);
+      }
+    }
   }
 
   display.summary(creates, updates, skips);
@@ -171,12 +195,26 @@ export async function submitLabels(
     return result;
   }
 
-  for (const { label, dupResult } of plans) {
+  for (let planIdx = 0; planIdx < plans.length; planIdx++) {
+    const { label, dupResult } = plans[planIdx];
+    const parsedTags = TagResolver.parseTags(label.tags as TagInput[] | undefined);
+
     try {
       switch (dupResult.action) {
         case "create": {
-          await client.post("/labels", label);
+          const response = await client.post<{
+            label?: { id: number };
+            id?: number;
+          }>("/labels", label);
+          const labelId = response.label?.id ?? response.id;
           display.success(`Created: ${label.name}`);
+          // Apply tags if any
+          if (labelId && parsedTags.length > 0) {
+            const tagResult = await tagResolver.applyToEntity("label", labelId, parsedTags);
+            if (tagResult.applied > 0) {
+              display.info(`  Applied ${tagResult.applied} tag(s)`);
+            }
+          }
           result.created++;
           break;
         }
@@ -193,11 +231,25 @@ export async function submitLabels(
               `No new fields to update for ${dupResult.existingName}`,
             );
           }
+          // Apply tags if any
+          if (dupResult.existingId && parsedTags.length > 0) {
+            const tagResult = await tagResolver.applyToEntity("label", dupResult.existingId, parsedTags);
+            if (tagResult.applied > 0) {
+              display.info(`  Applied ${tagResult.applied} tag(s)`);
+            }
+          }
           result.updated++;
           break;
         }
 
         case "skip": {
+          // Still apply tags even on skip
+          if (dupResult.existingId && parsedTags.length > 0) {
+            const tagResult = await tagResolver.applyToEntity("label", dupResult.existingId, parsedTags);
+            if (tagResult.applied > 0) {
+              display.info(`  Applied ${tagResult.applied} tag(s)`);
+            }
+          }
           result.skipped++;
           break;
         }

--- a/cli/src/commands/submit-release.ts
+++ b/cli/src/commands/submit-release.ts
@@ -6,6 +6,8 @@ import {
   type DuplicateCheckResult,
   type FieldComparison,
 } from "../lib/duplicates";
+import { TagResolver, formatTagsPreview, formatFuzzyWarning } from "../lib/tags";
+import type { TagInput, ResolvedTag } from "../lib/tags";
 import * as display from "../lib/display";
 import { dim } from "../lib/ansi";
 
@@ -31,6 +33,7 @@ interface ReleaseInput {
   artists: ReleaseArtistInput[];
   labels?: string[];
   external_links?: ReleaseLinkInput[];
+  tags?: TagInput[];
 }
 
 interface ResolvedArtist {
@@ -191,12 +194,13 @@ export async function planReleases(
 }
 
 /** Display the planned actions as a preview. */
-export function displayPreview(actions: ReleaseAction[]): void {
+export function displayPreview(actions: ReleaseAction[], resolvedTags?: ResolvedTag[][]): void {
   let creates = 0;
   let updates = 0;
   let skips = 0;
 
-  for (const action of actions) {
+  for (let i = 0; i < actions.length; i++) {
+    const action = actions[i];
     const title = action.release.title || "(untitled)";
 
     if (action.validationErrors?.length) {
@@ -268,6 +272,15 @@ export function displayPreview(actions: ReleaseAction[]): void {
         break;
       }
     }
+
+    // Show tags if any
+    if (resolvedTags && resolvedTags[i].length > 0) {
+      display.kv("tags", formatTagsPreview(resolvedTags[i]));
+      for (const tag of resolvedTags[i]) {
+        const warning = formatFuzzyWarning(tag);
+        if (warning) display.warn(warning);
+      }
+    }
   }
 
   display.summary(creates, updates, skips);
@@ -277,6 +290,7 @@ export function displayPreview(actions: ReleaseAction[]): void {
 async function executeActions(
   client: APIClient,
   actions: ReleaseAction[],
+  tagResolver?: TagResolver,
 ): Promise<SubmitResult> {
   let created = 0;
   let updated = 0;
@@ -289,7 +303,18 @@ async function executeActions(
       continue;
     }
 
+    const parsedTags = tagResolver
+      ? TagResolver.parseTags(action.release.tags as TagInput[] | undefined)
+      : [];
+
     if (action.action === "skip") {
+      // Still apply tags even on skip
+      if (tagResolver && action.dupCheck.existingId && parsedTags.length > 0) {
+        const tagResult = await tagResolver.applyToEntity("release", action.dupCheck.existingId, parsedTags);
+        if (tagResult.applied > 0) {
+          display.info(`  Applied ${tagResult.applied} tag(s)`);
+        }
+      }
       skipped++;
       continue;
     }
@@ -332,8 +357,16 @@ async function executeActions(
           body.external_links = action.release.external_links;
         }
 
-        await client.post("/releases", body);
+        const result = await client.post<{ id?: number; release?: { id: number } }>("/releases", body);
+        const releaseId = result.release?.id ?? result.id;
         display.success(`Created: ${action.release.title}`);
+        // Apply tags if any
+        if (tagResolver && releaseId && parsedTags.length > 0) {
+          const tagResult = await tagResolver.applyToEntity("release", releaseId, parsedTags);
+          if (tagResult.applied > 0) {
+            display.info(`  Applied ${tagResult.applied} tag(s)`);
+          }
+        }
         created++;
       } catch (err) {
         const message =
@@ -352,6 +385,13 @@ async function executeActions(
       );
 
       if (newFields.length === 0) {
+        // Still apply tags even when no field updates
+        if (tagResolver && action.dupCheck.existingId && parsedTags.length > 0) {
+          const tagResult = await tagResolver.applyToEntity("release", action.dupCheck.existingId, parsedTags);
+          if (tagResult.applied > 0) {
+            display.info(`  Applied ${tagResult.applied} tag(s)`);
+          }
+        }
         skipped++;
         continue;
       }
@@ -374,6 +414,13 @@ async function executeActions(
         display.success(
           `Updated: ${action.release.title} (ID: ${action.dupCheck.existingId})`,
         );
+        // Apply tags if any
+        if (tagResolver && action.dupCheck.existingId && parsedTags.length > 0) {
+          const tagResult = await tagResolver.applyToEntity("release", action.dupCheck.existingId, parsedTags);
+          if (tagResult.applied > 0) {
+            display.info(`  Applied ${tagResult.applied} tag(s)`);
+          }
+        }
         updated++;
       } catch (err) {
         const message =
@@ -416,8 +463,20 @@ export async function submitReleases(
   // Plan
   const actions = await planReleases(client, releases);
 
+  // Resolve tags for all releases
+  const tagResolver = new TagResolver(client);
+  const resolvedTags: ResolvedTag[][] = [];
+  for (const action of actions) {
+    const tags = TagResolver.parseTags(action.release.tags as TagInput[] | undefined);
+    if (tags.length > 0 && !action.validationErrors?.length) {
+      resolvedTags.push(await tagResolver.resolveAll(tags));
+    } else {
+      resolvedTags.push([]);
+    }
+  }
+
   // Preview
-  displayPreview(actions);
+  displayPreview(actions, resolvedTags);
 
   if (!confirm) {
     display.info('Dry run complete. Use --confirm to submit.');
@@ -434,5 +493,5 @@ export async function submitReleases(
 
   // Execute
   display.header("Submitting...");
-  return executeActions(client, actions);
+  return executeActions(client, actions, tagResolver);
 }

--- a/cli/src/commands/submit-show.ts
+++ b/cli/src/commands/submit-show.ts
@@ -2,8 +2,18 @@ import { APIClient } from "../lib/api";
 import type { EnvironmentConfig } from "../lib/types";
 import { validateShow } from "../lib/schemas";
 import { searchArtistsByName, searchVenuesByName } from "../lib/duplicates";
+import { TagResolver, formatTagsPreview, formatFuzzyWarning } from "../lib/tags";
+import type { TagInput, ResolvedTag } from "../lib/tags";
 import * as display from "../lib/display";
 import { green, yellow, dim, gray } from "../lib/ansi";
+
+/** Normalize a date string to ISO 8601. Adds T20:00:00Z if only YYYY-MM-DD. */
+function normalizeDate(date: string): string {
+  if (/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    return `${date}T20:00:00Z`;
+  }
+  return date;
+}
 
 // -- Types -------------------------------------------------------------------
 
@@ -29,6 +39,7 @@ interface ShowInput {
   description?: string;
   artists: ShowArtistInput[];
   venues: ShowVenueInput[];
+  tags?: TagInput[];
 }
 
 interface ResolvedArtist {
@@ -162,7 +173,7 @@ export async function resolveVenues(
 /** Build the API request body for creating a show. */
 export function buildShowPayload(plan: ShowPlan): Record<string, unknown> {
   const payload: Record<string, unknown> = {
-    event_date: plan.input.event_date,
+    event_date: normalizeDate(plan.input.event_date),
     city: plan.input.city,
     state: plan.input.state,
     artists: plan.artists.map((a) => {
@@ -231,8 +242,20 @@ export async function submitShows(
     });
   }
 
+  // 2b. Resolve tags for all shows
+  const tagResolver = new TagResolver(client);
+  const resolvedTags: ResolvedTag[][] = [];
+  for (const plan of plans) {
+    const tags = TagResolver.parseTags(plan.input.tags as TagInput[] | undefined);
+    if (tags.length > 0 && plan.valid) {
+      resolvedTags.push(await tagResolver.resolveAll(tags));
+    } else {
+      resolvedTags.push([]);
+    }
+  }
+
   // 3. Display preview
-  displayPreview(plans);
+  displayPreview(plans, resolvedTags);
 
   // 4. Summary
   const validPlans = plans.filter((p) => p.valid);
@@ -263,6 +286,14 @@ export async function submitShows(
       created++;
       const label = plan.input.title || `${plan.input.event_date} show`;
       display.success(`Created: ${label} (ID: ${result.id})`);
+      // Apply tags if any
+      const parsedTags = TagResolver.parseTags(plan.input.tags as TagInput[] | undefined);
+      if (result.id && parsedTags.length > 0) {
+        const tagResult = await tagResolver.applyToEntity("show", result.id, parsedTags);
+        if (tagResult.applied > 0) {
+          display.info(`  Applied ${tagResult.applied} tag(s)`);
+        }
+      }
     } catch (err) {
       failed++;
       const label = plan.input.title || `${plan.input.event_date} show`;
@@ -278,7 +309,7 @@ export async function submitShows(
 
 // -- Display helpers ---------------------------------------------------------
 
-function displayPreview(plans: ShowPlan[]): void {
+function displayPreview(plans: ShowPlan[], resolvedTags?: ResolvedTag[][]): void {
   for (let i = 0; i < plans.length; i++) {
     const plan = plans[i];
     const idx = plans.length > 1 ? ` [${i + 1}/${plans.length}]` : "";
@@ -320,6 +351,15 @@ function displayPreview(plans: ShowPlan[]): void {
         ? green(`EXISTING (ID: ${venue.id})`)
         : yellow("NEW");
       process.stderr.write(`    ${venue.name} ${tag}\n`);
+    }
+
+    // Tags
+    if (resolvedTags && resolvedTags[i].length > 0) {
+      display.kv("tags", formatTagsPreview(resolvedTags[i]));
+      for (const tag of resolvedTags[i]) {
+        const warning = formatFuzzyWarning(tag);
+        if (warning) display.warn(warning);
+      }
     }
   }
 }

--- a/cli/src/commands/submit-venue.ts
+++ b/cli/src/commands/submit-venue.ts
@@ -2,6 +2,8 @@ import { APIClient } from "../lib/api";
 import type { EnvironmentConfig } from "../lib/types";
 import { validateVenue } from "../lib/schemas";
 import { checkDuplicate, type DuplicateCheckResult } from "../lib/duplicates";
+import { TagResolver, formatTagsPreview, formatFuzzyWarning } from "../lib/tags";
+import type { TagInput, ResolvedTag } from "../lib/tags";
 import * as display from "../lib/display";
 
 interface VenueInput {
@@ -135,10 +137,23 @@ export async function submitVenues(
     plans.push({ venue, index, dupResult });
   }
 
+  // Step 2b: Resolve tags for all venues
+  const tagResolver = new TagResolver(client);
+  const resolvedTags: ResolvedTag[][] = [];
+  for (const { venue } of validVenues) {
+    const tags = TagResolver.parseTags(venue.tags as TagInput[] | undefined);
+    if (tags.length > 0) {
+      resolvedTags.push(await tagResolver.resolveAll(tags));
+    } else {
+      resolvedTags.push([]);
+    }
+  }
+
   // Step 3: Display preview
   display.header("Venue Submit Preview");
 
-  for (const { venue, index, dupResult } of plans) {
+  for (let planIdx = 0; planIdx < plans.length; planIdx++) {
+    const { venue, index, dupResult } = plans[planIdx];
     const venueName = String(venue.name);
     const venueLocation = `${venue.city}, ${venue.state}`;
 
@@ -157,6 +172,15 @@ export async function submitVenues(
       display.info(
         `#${index + 1} SKIP: ${venueName} — already exists as "${dupResult.existingName}" (ID ${dupResult.existingId})`,
       );
+    }
+
+    // Show tags if any
+    if (resolvedTags[planIdx].length > 0) {
+      display.kv("tags", formatTagsPreview(resolvedTags[planIdx]));
+      for (const tag of resolvedTags[planIdx]) {
+        const warning = formatFuzzyWarning(tag);
+        if (warning) display.warn(warning);
+      }
     }
   }
 
@@ -186,13 +210,26 @@ export async function submitVenues(
   }
 
   // Execute API calls
-  for (const { venue, index, dupResult } of plans) {
+  for (let planIdx = 0; planIdx < plans.length; planIdx++) {
+    const { venue, index, dupResult } = plans[planIdx];
     const venueName = String(venue.name);
+    const parsedTags = TagResolver.parseTags(venue.tags as TagInput[] | undefined);
 
     try {
       if (dupResult.action === "create") {
-        await client.post("/admin/venues", venue);
+        const response = await client.post<{
+          venue?: { id: number };
+          id?: number;
+        }>("/admin/venues", venue);
+        const venueId = response.venue?.id ?? response.id;
         display.success(`Created venue: ${venueName}`);
+        // Apply tags if any
+        if (venueId && parsedTags.length > 0) {
+          const tagResult = await tagResolver.applyToEntity("venue", venueId, parsedTags);
+          if (tagResult.applied > 0) {
+            display.info(`  Applied ${tagResult.applied} tag(s)`);
+          }
+        }
         result.creates++;
         result.results.push({
           venue: venue as unknown as VenueInput,
@@ -217,6 +254,13 @@ export async function submitVenues(
             `Updated venue: ${venueName} (ID ${dupResult.existingId})`,
           );
         }
+        // Apply tags if any
+        if (dupResult.existingId && parsedTags.length > 0) {
+          const tagResult = await tagResolver.applyToEntity("venue", dupResult.existingId, parsedTags);
+          if (tagResult.applied > 0) {
+            display.info(`  Applied ${tagResult.applied} tag(s)`);
+          }
+        }
         result.updates++;
         result.results.push({
           venue: venue as unknown as VenueInput,
@@ -225,6 +269,13 @@ export async function submitVenues(
         });
       } else {
         display.info(`Skipped venue: ${venueName} (already exists)`);
+        // Still apply tags even on skip
+        if (dupResult.existingId && parsedTags.length > 0) {
+          const tagResult = await tagResolver.applyToEntity("venue", dupResult.existingId, parsedTags);
+          if (tagResult.applied > 0) {
+            display.info(`  Applied ${tagResult.applied} tag(s)`);
+          }
+        }
         result.skips++;
         result.results.push({
           venue: venue as unknown as VenueInput,

--- a/cli/src/lib/tags.ts
+++ b/cli/src/lib/tags.ts
@@ -1,0 +1,250 @@
+import { APIClient, APIError } from "./api";
+import { normalizeForComparison, similarityScore } from "./duplicates";
+import * as display from "./display";
+import { green, yellow, gray, dim, cyan } from "./ansi";
+
+/** Tag input as provided by the user — string (defaults to genre) or object. */
+export type TagInput = string | { name: string; category?: string };
+
+/** Normalized tag after parsing user input. */
+export interface ParsedTag {
+  name: string;
+  category: string;
+}
+
+/** Result of resolving a tag against the database. */
+export interface ResolvedTag {
+  id: number;
+  name: string;
+  category: string;
+  status: "exists" | "created" | "fuzzy_match";
+  originalName?: string; // if fuzzy-matched, the user's original input
+}
+
+interface APITag {
+  id: number;
+  name: string;
+  slug: string;
+  category: string;
+  usage_count?: number;
+}
+
+/**
+ * TagResolver handles searching, creating, and applying tags with:
+ * - Session cache to avoid duplicate API calls
+ * - Fuzzy duplicate detection (warns on similar existing tags)
+ * - Idempotent operations (409 on duplicate = success)
+ */
+export class TagResolver {
+  private client: APIClient;
+  private cache = new Map<string, ResolvedTag>();
+
+  constructor(client: APIClient) {
+    this.client = client;
+  }
+
+  /** Parse user-provided tag inputs into normalized form. */
+  static parseTags(tags: TagInput[] | undefined): ParsedTag[] {
+    if (!tags || tags.length === 0) return [];
+    return tags.map((t) => {
+      if (typeof t === "string") {
+        return { name: t.trim(), category: "genre" };
+      }
+      return { name: t.name.trim(), category: t.category || "genre" };
+    }).filter((t) => t.name.length > 0);
+  }
+
+  /**
+   * Resolve all tags — search for existing, detect fuzzy duplicates,
+   * prepare for creation. Does NOT create tags (that happens on confirm).
+   */
+  async resolveAll(tags: ParsedTag[]): Promise<ResolvedTag[]> {
+    const results: ResolvedTag[] = [];
+
+    for (const tag of tags) {
+      const cacheKey = normalizeForComparison(tag.name);
+
+      // Check session cache
+      if (this.cache.has(cacheKey)) {
+        results.push(this.cache.get(cacheKey)!);
+        continue;
+      }
+
+      const resolved = await this.resolveOne(tag);
+      this.cache.set(cacheKey, resolved);
+      results.push(resolved);
+    }
+
+    return results;
+  }
+
+  /**
+   * Ensure all tags exist (create if needed) and apply them to an entity.
+   * Call this during --confirm after entity creation.
+   */
+  async applyToEntity(
+    entityType: string,
+    entityId: number,
+    tags: ParsedTag[],
+  ): Promise<{ applied: number; skipped: number; errors: number }> {
+    let applied = 0;
+    let skipped = 0;
+    let errors = 0;
+
+    for (const tag of tags) {
+      try {
+        // Ensure tag exists (create if needed)
+        await this.ensureTagExists(tag);
+
+        // Apply tag to entity by name (server resolves aliases automatically)
+        await this.client.post(
+          `/entities/${entityType}/${entityId}/tags`,
+          { tag_name: tag.name },
+        );
+        applied++;
+      } catch (err) {
+        if (err instanceof APIError && err.status === 409) {
+          // Already tagged — that's fine
+          skipped++;
+        } else {
+          const msg = err instanceof Error ? err.message : "Unknown error";
+          display.warn(`Failed to apply tag "${tag.name}": ${msg}`);
+          errors++;
+        }
+      }
+    }
+
+    return { applied, skipped, errors };
+  }
+
+  /** Search for an existing tag, create if not found. Idempotent. */
+  private async ensureTagExists(tag: ParsedTag): Promise<number> {
+    const cacheKey = normalizeForComparison(tag.name);
+    const cached = this.cache.get(cacheKey);
+    if (cached && cached.status !== "created") {
+      // Already exists in DB, no need to create
+      return cached.id;
+    }
+
+    // Try to create — 409 means it already exists
+    try {
+      const result = await this.client.post<APITag>("/tags", {
+        name: tag.name,
+        category: tag.category,
+      });
+      const resolved: ResolvedTag = {
+        id: result.id,
+        name: result.name,
+        category: result.category,
+        status: "created",
+      };
+      this.cache.set(cacheKey, resolved);
+      return result.id;
+    } catch (err) {
+      if (err instanceof APIError && err.status === 409) {
+        // Tag already exists — search for it to get the ID
+        const existing = await this.searchExact(tag.name);
+        if (existing) {
+          const resolved: ResolvedTag = {
+            id: existing.id,
+            name: existing.name,
+            category: existing.category,
+            status: "exists",
+          };
+          this.cache.set(cacheKey, resolved);
+          return existing.id;
+        }
+      }
+      throw err;
+    }
+  }
+
+  /** Resolve a single tag against the database. */
+  private async resolveOne(tag: ParsedTag): Promise<ResolvedTag> {
+    // Search for the tag
+    const searchResults = await this.searchTags(tag.name);
+
+    // Check for exact match (case-insensitive)
+    const normalizedInput = normalizeForComparison(tag.name);
+    const exactMatch = searchResults.find(
+      (t) => normalizeForComparison(t.name) === normalizedInput,
+    );
+
+    if (exactMatch) {
+      return {
+        id: exactMatch.id,
+        name: exactMatch.name,
+        category: exactMatch.category,
+        status: "exists",
+      };
+    }
+
+    // Check for fuzzy matches (similar but not exact)
+    const fuzzyMatch = searchResults.find(
+      (t) => similarityScore(t.name, tag.name) >= 0.7,
+    );
+
+    if (fuzzyMatch) {
+      return {
+        id: fuzzyMatch.id,
+        name: fuzzyMatch.name,
+        category: fuzzyMatch.category,
+        status: "fuzzy_match",
+        originalName: tag.name,
+      };
+    }
+
+    // No match — will need to be created
+    return {
+      id: 0,
+      name: tag.name,
+      category: tag.category,
+      status: "created",
+    };
+  }
+
+  private async searchTags(query: string): Promise<APITag[]> {
+    try {
+      const result = await this.client.get<{ tags: APITag[] }>(
+        "/tags/search",
+        { q: query },
+      );
+      return result.tags || [];
+    } catch {
+      return [];
+    }
+  }
+
+  private async searchExact(name: string): Promise<APITag | null> {
+    const results = await this.searchTags(name);
+    const normalized = normalizeForComparison(name);
+    return results.find(
+      (t) => normalizeForComparison(t.name) === normalized,
+    ) || null;
+  }
+}
+
+/** Format tags for preview display. */
+export function formatTagsPreview(resolved: ResolvedTag[]): string {
+  if (resolved.length === 0) return "";
+
+  const parts = resolved.map((t) => {
+    const cat = dim(`(${t.category})`);
+    switch (t.status) {
+      case "exists":
+        return `${t.name} ${cat}`;
+      case "created":
+        return `${t.name} ${cat} ${cyan("NEW")}`;
+      case "fuzzy_match":
+        return `${yellow(t.originalName || t.name)} → ${green(t.name)} ${cat} ${yellow("MATCHED")}`;
+    }
+  });
+
+  return parts.join(", ");
+}
+
+/** Format a fuzzy match warning for display. */
+export function formatFuzzyWarning(resolved: ResolvedTag): string {
+  if (resolved.status !== "fuzzy_match") return "";
+  return `Tag "${resolved.originalName}" is similar to existing "${resolved.name}" — will use "${resolved.name}"`;
+}

--- a/cli/test/submit-show.test.ts
+++ b/cli/test/submit-show.test.ts
@@ -207,7 +207,7 @@ describe("buildShowPayload", () => {
     };
 
     const payload = buildShowPayload(plan);
-    expect(payload.event_date).toBe("2026-04-15");
+    expect(payload.event_date).toBe("2026-04-15T20:00:00Z");
     expect(payload.city).toBe("Phoenix");
 
     const artists = payload.artists as Array<Record<string, unknown>>;

--- a/cli/test/tags.test.ts
+++ b/cli/test/tags.test.ts
@@ -1,0 +1,132 @@
+import { describe, test, expect } from "bun:test";
+import { TagResolver, formatTagsPreview, formatFuzzyWarning } from "../src/lib/tags";
+import type { ResolvedTag, TagInput } from "../src/lib/tags";
+
+describe("TagResolver.parseTags", () => {
+  test("parses string tags as genre", () => {
+    const result = TagResolver.parseTags(["punk", "noise rock"]);
+    expect(result).toEqual([
+      { name: "punk", category: "genre" },
+      { name: "noise rock", category: "genre" },
+    ]);
+  });
+
+  test("parses object tags with category", () => {
+    const result = TagResolver.parseTags([
+      { name: "Japanese", category: "locale" },
+      { name: "industrial" },
+    ]);
+    expect(result).toEqual([
+      { name: "Japanese", category: "locale" },
+      { name: "industrial", category: "genre" },
+    ]);
+  });
+
+  test("handles mixed string and object tags", () => {
+    const result = TagResolver.parseTags([
+      "punk",
+      { name: "Japanese", category: "locale" },
+      "noise rock",
+    ]);
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual({ name: "punk", category: "genre" });
+    expect(result[1]).toEqual({ name: "Japanese", category: "locale" });
+    expect(result[2]).toEqual({ name: "noise rock", category: "genre" });
+  });
+
+  test("trims whitespace from tag names", () => {
+    const result = TagResolver.parseTags(["  punk  ", "  noise rock "]);
+    expect(result[0].name).toBe("punk");
+    expect(result[1].name).toBe("noise rock");
+  });
+
+  test("filters out empty tags", () => {
+    const result = TagResolver.parseTags(["punk", "", "  ", "rock"]);
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toBe("punk");
+    expect(result[1].name).toBe("rock");
+  });
+
+  test("returns empty array for undefined", () => {
+    expect(TagResolver.parseTags(undefined)).toEqual([]);
+  });
+
+  test("returns empty array for empty array", () => {
+    expect(TagResolver.parseTags([])).toEqual([]);
+  });
+});
+
+describe("formatTagsPreview", () => {
+  test("formats existing tags", () => {
+    const tags: ResolvedTag[] = [
+      { id: 1, name: "punk", category: "genre", status: "exists" },
+    ];
+    const result = formatTagsPreview(tags);
+    expect(result).toContain("punk");
+    expect(result).toContain("genre");
+  });
+
+  test("formats new tags with NEW marker", () => {
+    const tags: ResolvedTag[] = [
+      { id: 0, name: "lukthung", category: "genre", status: "created" },
+    ];
+    const result = formatTagsPreview(tags);
+    expect(result).toContain("lukthung");
+    expect(result).toContain("NEW");
+  });
+
+  test("formats fuzzy matches with arrow", () => {
+    const tags: ResolvedTag[] = [
+      {
+        id: 5,
+        name: "post-punk",
+        category: "genre",
+        status: "fuzzy_match",
+        originalName: "post punk",
+      },
+    ];
+    const result = formatTagsPreview(tags);
+    expect(result).toContain("post punk");
+    expect(result).toContain("post-punk");
+    expect(result).toContain("MATCHED");
+  });
+
+  test("returns empty string for no tags", () => {
+    expect(formatTagsPreview([])).toBe("");
+  });
+});
+
+describe("formatFuzzyWarning", () => {
+  test("returns warning for fuzzy match", () => {
+    const tag: ResolvedTag = {
+      id: 5,
+      name: "post-punk",
+      category: "genre",
+      status: "fuzzy_match",
+      originalName: "post punk",
+    };
+    const warning = formatFuzzyWarning(tag);
+    expect(warning).toContain("post punk");
+    expect(warning).toContain("post-punk");
+  });
+
+  test("returns empty for non-fuzzy match", () => {
+    const tag: ResolvedTag = {
+      id: 1,
+      name: "punk",
+      category: "genre",
+      status: "exists",
+    };
+    expect(formatFuzzyWarning(tag)).toBe("");
+  });
+
+  test("returns empty for new tag", () => {
+    const tag: ResolvedTag = {
+      id: 0,
+      name: "lukthung",
+      category: "genre",
+      status: "created",
+    };
+    expect(formatFuzzyWarning(tag)).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary
- **Tag integration**: All 6 submit commands now accept inline `tags` on entities. TagResolver handles session-cached search, fuzzy duplicate detection, auto-creation, and alias resolution. Tags shown in dry-run preview (EXISTS/NEW/MATCHED), applied after entity creation/update/skip.
- **`/ingest` skill**: Claude Code skill for the full screenshot-to-knowledge-graph workflow — extract from WFMU playlists, show flyers, tour posters, festival lineups → batch JSON → dry-run → confirm
- **`gen-api-token` utility**: `go run ./cmd/gen-api-token --make-admin` — generates phk_ tokens directly against the DB, eliminating the auth bootstrap problem
- **CLI README**: Full usage guide with entity schemas, tag format, agent usage guidelines, and common mistakes to avoid
- **Show date fix**: `YYYY-MM-DD` auto-normalized to `YYYY-MM-DDT20:00:00Z`
- 14 new tests (232 total), zero type errors

## Test plan
- [x] Tag preview shows EXISTS/NEW/MATCHED status in dry-run
- [x] Fuzzy tag matching flags similar tags (e.g., "post punk" → "post-punk")
- [x] Tags created and applied on --confirm
- [x] Tags applied even on skipped entities (entity exists, but new tags)
- [x] gen-api-token creates valid phk_ tokens
- [x] Show date normalization works
- [x] All 232 tests pass, tsc --noEmit clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)