### PR TITLE
Dynamic breadcrumb navigation — replace static 'Back to' links

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -11,6 +11,7 @@ import {
   SidebarLayout,
 } from '@/components/layout'
 import { CookieConsentProvider } from '@/lib/context/CookieConsentContext'
+import { NavigationBreadcrumbProvider } from '@/lib/context/NavigationBreadcrumbContext'
 import { JsonLd } from '@/components/seo/JsonLd'
 import { generateOrganizationSchema } from '@/lib/seo/jsonld'
 import { Analytics } from '@vercel/analytics/react'
@@ -75,10 +76,12 @@ export default function RootLayout({
           >
             <CookieConsentProvider>
               <PostHogProvider>
-                <SidebarLayout>
-                  <main className="flex-1">{children}</main>
-                  <Footer />
-                </SidebarLayout>
+                <NavigationBreadcrumbProvider>
+                  <SidebarLayout>
+                    <main className="flex-1">{children}</main>
+                    <Footer />
+                  </SidebarLayout>
+                </NavigationBreadcrumbProvider>
                 <CookieConsentBanner />
                 <Analytics />
                 <SpeedInsights />

--- a/frontend/components/shared/Breadcrumb.test.tsx
+++ b/frontend/components/shared/Breadcrumb.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Breadcrumb } from './Breadcrumb'
+
+// Mock next/link
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode; [key: string]: unknown }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}))
+
+// Track mock breadcrumbs
+let mockBreadcrumbs: Array<{ label: string; href: string }> = []
+
+vi.mock('@/lib/context/NavigationBreadcrumbContext', () => ({
+  useNavigationBreadcrumbs: () => ({
+    breadcrumbs: mockBreadcrumbs,
+    pushBreadcrumb: vi.fn(),
+  }),
+}))
+
+describe('Breadcrumb', () => {
+  it('renders fallback when no navigation history', () => {
+    mockBreadcrumbs = []
+    render(
+      <Breadcrumb
+        fallback={{ href: '/artists', label: 'Artists' }}
+        currentPage="Macie Stewart"
+      />
+    )
+
+    const nav = screen.getByRole('navigation', { name: /Breadcrumb/ })
+    expect(nav).toBeInTheDocument()
+
+    const link = screen.getByRole('link', { name: 'Artists' })
+    expect(link).toHaveAttribute('href', '/artists')
+
+    expect(screen.getByText('Macie Stewart')).toBeInTheDocument()
+  })
+
+  it('renders navigation history when breadcrumbs exist', () => {
+    mockBreadcrumbs = [
+      { label: 'Shows', href: '/shows' },
+      { label: 'Jeff Tweedy at Van Buren', href: '/shows/jeff-tweedy' },
+    ]
+    render(
+      <Breadcrumb
+        fallback={{ href: '/artists', label: 'Artists' }}
+        currentPage="Macie Stewart"
+      />
+    )
+
+    expect(screen.getByRole('link', { name: 'Shows' })).toHaveAttribute('href', '/shows')
+    expect(screen.getByRole('link', { name: 'Jeff Tweedy at Van Buren' })).toHaveAttribute('href', '/shows/jeff-tweedy')
+    expect(screen.getByText('Macie Stewart')).toBeInTheDocument()
+  })
+
+  it('current page is not a link', () => {
+    mockBreadcrumbs = []
+    render(
+      <Breadcrumb
+        fallback={{ href: '/artists', label: 'Artists' }}
+        currentPage="Macie Stewart"
+      />
+    )
+
+    const currentPageElement = screen.getByText('Macie Stewart')
+    expect(currentPageElement.tagName).toBe('SPAN')
+    expect(currentPageElement.closest('a')).toBeNull()
+  })
+
+  it('renders separator between crumbs', () => {
+    mockBreadcrumbs = [
+      { label: 'Shows', href: '/shows' },
+    ]
+    render(
+      <Breadcrumb
+        fallback={{ href: '/artists', label: 'Artists' }}
+        currentPage="Artist Name"
+      />
+    )
+
+    // Check for separator characters (rsaquo)
+    const separators = screen.getAllByText((_, element) =>
+      element?.getAttribute('aria-hidden') === 'true' && element?.textContent === '\u203A'
+    )
+    expect(separators.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('renders as an ordered list for accessibility', () => {
+    mockBreadcrumbs = []
+    render(
+      <Breadcrumb
+        fallback={{ href: '/artists', label: 'Artists' }}
+        currentPage="Test"
+      />
+    )
+
+    const list = screen.getByRole('list')
+    expect(list).toBeInTheDocument()
+    const items = screen.getAllByRole('listitem')
+    expect(items).toHaveLength(2) // fallback + current page
+  })
+})

--- a/frontend/components/shared/Breadcrumb.tsx
+++ b/frontend/components/shared/Breadcrumb.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import Link from 'next/link'
+import { useNavigationBreadcrumbs, type BreadcrumbEntry } from '@/lib/context/NavigationBreadcrumbContext'
+
+interface BreadcrumbProps {
+  /** Fallback breadcrumb shown when there is no navigation history (direct landing).
+   *  For example: { href: '/artists', label: 'Artists' } */
+  fallback: BreadcrumbEntry
+  /** Label for the current page (last crumb, rendered as plain text) */
+  currentPage: string
+}
+
+/**
+ * Renders a breadcrumb trail reflecting the user's navigation path.
+ *
+ * When the user has navigated across entity pages, it shows:
+ *   Shows > Jeff Tweedy at Van Buren > Macie Stewart
+ *
+ * When landed directly (no history), it shows a sensible fallback:
+ *   Artists > Macie Stewart
+ */
+export function Breadcrumb({ fallback, currentPage }: BreadcrumbProps) {
+  const { breadcrumbs } = useNavigationBreadcrumbs()
+
+  // Build the trail: either navigation history or the fallback
+  // Exclude the current page from the clickable trail (it will be appended as plain text)
+  const trail: BreadcrumbEntry[] = breadcrumbs.length > 0
+    ? breadcrumbs.filter(b => b.label !== currentPage || b.href !== fallback.href)
+    : [fallback]
+
+  return (
+    <nav aria-label="Breadcrumb" className="mb-6">
+      <ol className="flex items-center gap-1 text-sm text-muted-foreground">
+        {trail.map((crumb, index) => (
+          <li key={crumb.href + index} className="flex items-center gap-1">
+            {index > 0 && (
+              <span className="text-muted-foreground/50" aria-hidden="true">&rsaquo;</span>
+            )}
+            <Link
+              href={crumb.href}
+              className="hover:text-foreground transition-colors truncate max-w-[200px]"
+              title={crumb.label}
+            >
+              {crumb.label}
+            </Link>
+          </li>
+        ))}
+        <li className="flex items-center gap-1">
+          <span className="text-muted-foreground/50" aria-hidden="true">&rsaquo;</span>
+          <span className="text-foreground font-medium truncate max-w-[200px]" title={currentPage}>
+            {currentPage}
+          </span>
+        </li>
+      </ol>
+    </nav>
+  )
+}

--- a/frontend/components/shared/EntityDetailLayout.test.tsx
+++ b/frontend/components/shared/EntityDetailLayout.test.tsx
@@ -10,8 +10,17 @@ vi.mock('next/link', () => ({
   ),
 }))
 
+// Mock NavigationBreadcrumbContext
+vi.mock('@/lib/context/NavigationBreadcrumbContext', () => ({
+  useNavigationBreadcrumbs: () => ({
+    breadcrumbs: [],
+    pushBreadcrumb: vi.fn(),
+  }),
+}))
+
 const defaultProps = {
-  backLink: { href: '/releases', label: 'Back to Releases' },
+  fallback: { href: '/releases', label: 'Releases' },
+  entityName: 'Album Name',
   header: <div data-testid="test-header">Album Name</div>,
   tabs: [
     { value: 'overview', label: 'Overview' },
@@ -23,17 +32,24 @@ const defaultProps = {
 }
 
 describe('EntityDetailLayout', () => {
-  it('renders back link with correct href and label', () => {
+  it('renders breadcrumb with fallback link and entity name', () => {
     render(<EntityDetailLayout {...defaultProps} />)
-    const link = screen.getByRole('link', { name: /Back to Releases/ })
+    const link = screen.getByRole('link', { name: /Releases/ })
     expect(link).toBeInTheDocument()
     expect(link).toHaveAttribute('href', '/releases')
+    // Entity name appears in both breadcrumb and header
+    const matches = screen.getAllByText('Album Name')
+    expect(matches.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('renders breadcrumb navigation', () => {
+    render(<EntityDetailLayout {...defaultProps} />)
+    expect(screen.getByRole('navigation', { name: /Breadcrumb/ })).toBeInTheDocument()
   })
 
   it('renders header content', () => {
     render(<EntityDetailLayout {...defaultProps} />)
     expect(screen.getByTestId('test-header')).toBeInTheDocument()
-    expect(screen.getByText('Album Name')).toBeInTheDocument()
   })
 
   it('renders tab triggers for each tab', () => {

--- a/frontend/components/shared/EntityDetailLayout.tsx
+++ b/frontend/components/shared/EntityDetailLayout.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import Link from 'next/link'
-import { ArrowLeft } from 'lucide-react'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { cn } from '@/lib/utils'
+import { Breadcrumb } from './Breadcrumb'
+import type { BreadcrumbEntry } from '@/lib/context/NavigationBreadcrumbContext'
 
 export interface EntityDetailTab {
   value: string
@@ -16,8 +16,12 @@ export interface EntityDetailBackLink {
 }
 
 interface EntityDetailLayoutProps {
-  /** Back navigation link */
-  backLink: EntityDetailBackLink
+  /** Fallback breadcrumb entry for direct landings (e.g., { href: '/artists', label: 'Artists' }) */
+  fallback: BreadcrumbEntry
+  /** Name of the current entity (shown as the last breadcrumb) */
+  entityName: string
+  /** @deprecated Use `fallback` and `entityName` instead. Kept for backward compat. */
+  backLink?: EntityDetailBackLink
   /** Header content (typically an EntityHeader) */
   header: React.ReactNode
   /** Tab definitions */
@@ -37,12 +41,13 @@ interface EntityDetailLayoutProps {
 }
 
 /**
- * Reusable entity detail page layout with back link, header, tabs, and optional sidebar.
+ * Reusable entity detail page layout with breadcrumb navigation, header, tabs, and optional sidebar.
  *
  * Usage:
  * ```tsx
  * <EntityDetailLayout
- *   backLink={{ href: '/releases', label: 'Back to Releases' }}
+ *   fallback={{ href: '/releases', label: 'Releases' }}
+ *   entityName="Album Name"
  *   header={<EntityHeader title="Album Name" subtitle="2024" />}
  *   tabs={[{ value: 'overview', label: 'Overview' }, { value: 'links', label: 'Listen/Buy' }]}
  *   activeTab={activeTab}
@@ -55,6 +60,8 @@ interface EntityDetailLayoutProps {
  * ```
  */
 export function EntityDetailLayout({
+  fallback,
+  entityName,
   backLink,
   header,
   tabs,
@@ -64,18 +71,14 @@ export function EntityDetailLayout({
   children,
   className,
 }: EntityDetailLayoutProps) {
+  // Support deprecated backLink prop as fallback
+  const resolvedFallback = fallback ?? (backLink ? { href: backLink.href, label: backLink.label.replace(/^Back to /, '') } : { href: '/', label: 'Home' })
+  const resolvedEntityName = entityName ?? ''
+
   return (
     <div className={cn('container max-w-6xl mx-auto px-4 py-6', className)}>
-      {/* Back Navigation */}
-      <div className="mb-6">
-        <Link
-          href={backLink.href}
-          className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground transition-colors"
-        >
-          <ArrowLeft className="h-4 w-4 mr-1" />
-          {backLink.label}
-        </Link>
-      </div>
+      {/* Breadcrumb Navigation */}
+      <Breadcrumb fallback={resolvedFallback} currentPage={resolvedEntityName} />
 
       {/* Header */}
       <header className="mb-6">{header}</header>

--- a/frontend/components/shared/index.ts
+++ b/frontend/components/shared/index.ts
@@ -14,3 +14,4 @@ export type { EntityDetailTab, EntityDetailBackLink } from './EntityDetailLayout
 export { EntityHeader } from './EntityHeader'
 export { RevisionHistory } from './RevisionHistory'
 export { FollowButton } from './FollowButton'
+export { Breadcrumb } from './Breadcrumb'

--- a/frontend/features/artists/components/ArtistDetail.test.tsx
+++ b/frontend/features/artists/components/ArtistDetail.test.tsx
@@ -94,6 +94,19 @@ vi.mock('@/components/forms/ArtistEditForm', () => ({
   }) => (open ? <div data-testid="edit-form">Edit Form</div> : null),
 }))
 
+// Mock NavigationBreadcrumbContext
+vi.mock('@/lib/context/NavigationBreadcrumbContext', () => ({
+  useNavigationBreadcrumbs: () => ({
+    breadcrumbs: [],
+    pushBreadcrumb: vi.fn(),
+  }),
+}))
+
+// Mock next/navigation
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/artists/test-artist',
+}))
+
 vi.mock('@/components/shared', () => ({
   SocialLinks: () => <div data-testid="social-links">Social Links</div>,
   MusicEmbed: () => <div data-testid="music-embed">Music Embed</div>,
@@ -104,7 +117,8 @@ vi.mock('@/components/shared', () => ({
     tabs,
     activeTab,
     onTabChange,
-    backLink,
+    fallback,
+    entityName,
   }: {
     children: React.ReactNode
     sidebar: React.ReactNode
@@ -112,10 +126,12 @@ vi.mock('@/components/shared', () => ({
     tabs: { value: string; label: string }[]
     activeTab: string
     onTabChange: (tab: string) => void
-    backLink: { href: string; label: string }
+    fallback: { href: string; label: string }
+    entityName: string
   }) => (
     <div data-testid="entity-layout">
-      <a href={backLink.href}>{backLink.label}</a>
+      <a href={fallback.href}>{fallback.label}</a>
+      <span data-testid="entity-name">{entityName}</span>
       <div data-testid="header-slot">{header}</div>
       <div data-testid="tabs">
         {tabs.map(tab => (
@@ -274,13 +290,15 @@ describe('ArtistDetail', () => {
 
     it('renders artist name in header', () => {
       renderWithProviders(<ArtistDetail artistId="test-artist" />)
-      expect(screen.getByText('Test Artist')).toBeInTheDocument()
+      const headerSlot = screen.getByTestId('header-slot')
+      expect(headerSlot).toHaveTextContent('Test Artist')
     })
 
-    it('renders entity layout with back link', () => {
+    it('renders entity layout with breadcrumb fallback', () => {
       renderWithProviders(<ArtistDetail artistId="test-artist" />)
       expect(screen.getByTestId('entity-layout')).toBeInTheDocument()
-      expect(screen.getByText('Back to Artists')).toBeInTheDocument()
+      expect(screen.getByText('Artists')).toBeInTheDocument()
+      expect(screen.getByTestId('entity-name')).toHaveTextContent('Test Artist')
     })
 
     it('renders tabs for overview, discography, and labels', () => {

--- a/frontend/features/artists/components/ArtistDetail.tsx
+++ b/frontend/features/artists/components/ArtistDetail.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import {
   ArrowLeft,
   Loader2,
@@ -31,6 +31,8 @@ import {
   type MusicPlatform,
 } from '@/lib/hooks/admin/useAdminArtists'
 import { SocialLinks, MusicEmbed, EntityDetailLayout, EntityHeader, RevisionHistory, FollowButton } from '@/components/shared'
+import { useNavigationBreadcrumbs } from '@/lib/context/NavigationBreadcrumbContext'
+import { usePathname } from 'next/navigation'
 import { ArtistTrajectoryChart } from '@/features/festivals/components/ArtistTrajectoryChart'
 import { EntityTagList } from '@/features/tags'
 import { ArtistEditForm } from '@/components/forms/ArtistEditForm'
@@ -830,6 +832,15 @@ export function ArtistDetail({ artistId }: ArtistDetailProps) {
 
   const [activeTab, setActiveTab] = useState('overview')
   const [isEditing, setIsEditing] = useState(false)
+  const pathname = usePathname()
+  const { pushBreadcrumb } = useNavigationBreadcrumbs()
+
+  // Push breadcrumb when artist data is loaded
+  useEffect(() => {
+    if (artist) {
+      pushBreadcrumb(artist.name, pathname)
+    }
+  }, [artist, pathname, pushBreadcrumb])
 
   // Fetch labels for sidebar
   const { data: labelsData, isLoading: labelsLoading } = useArtistLabels({
@@ -928,7 +939,8 @@ export function ArtistDetail({ artistId }: ArtistDetailProps) {
   return (
     <>
       <EntityDetailLayout
-        backLink={{ href: '/artists', label: 'Back to Artists' }}
+        fallback={{ href: '/artists', label: 'Artists' }}
+        entityName={artist.name}
         header={
           <EntityHeader
             title={artist.name}

--- a/frontend/features/collections/components/CollectionDetail.tsx
+++ b/frontend/features/collections/components/CollectionDetail.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import Link from 'next/link'
 import {
   Loader2,
@@ -34,8 +34,10 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { Badge } from '@/components/ui/badge'
+import { Breadcrumb } from '@/components/shared'
 import { useAuthContext } from '@/lib/context/AuthContext'
-import { useRouter } from 'next/navigation'
+import { useNavigationBreadcrumbs } from '@/lib/context/NavigationBreadcrumbContext'
+import { useRouter, usePathname } from 'next/navigation'
 
 interface CollectionDetailProps {
   slug: string
@@ -52,13 +54,22 @@ const ENTITY_ICONS: Record<string, React.ElementType> = {
 
 export function CollectionDetail({ slug }: CollectionDetailProps) {
   const router = useRouter()
+  const pathname = usePathname()
   const { user, isAuthenticated } = useAuthContext()
+  const { pushBreadcrumb } = useNavigationBreadcrumbs()
   const { data: collection, isLoading, error } = useCollection(slug)
   const subscribeMutation = useSubscribeCollection()
   const unsubscribeMutation = useUnsubscribeCollection()
   const deleteMutation = useDeleteCollection()
 
   const [isEditing, setIsEditing] = useState(false)
+
+  // Push breadcrumb when collection data is loaded
+  useEffect(() => {
+    if (collection) {
+      pushBreadcrumb(collection.title, pathname)
+    }
+  }, [collection, pathname, pushBreadcrumb])
 
   if (isLoading) {
     return (
@@ -134,15 +145,11 @@ export function CollectionDetail({ slug }: CollectionDetailProps) {
 
   return (
     <div className="container max-w-6xl mx-auto px-4 py-6">
-      {/* Back link */}
-      <div className="mb-6">
-        <Link
-          href="/collections"
-          className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground transition-colors"
-        >
-          &larr; Back to Collections
-        </Link>
-      </div>
+      {/* Breadcrumb Navigation */}
+      <Breadcrumb
+        fallback={{ href: '/collections', label: 'Collections' }}
+        currentPage={collection.title}
+      />
 
       {/* Header */}
       <header className="mb-8">

--- a/frontend/features/festivals/components/FestivalDetail.tsx
+++ b/frontend/features/festivals/components/FestivalDetail.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useEffect } from 'react'
 import Link from 'next/link'
 import {
   Loader2,
@@ -17,7 +17,9 @@ import {
   useFestivalVenues,
   useFestivals,
 } from '../hooks/useFestivals'
+import { usePathname } from 'next/navigation'
 import { EntityDetailLayout, EntityHeader, SocialLinks, FollowButton } from '@/components/shared'
+import { useNavigationBreadcrumbs } from '@/lib/context/NavigationBreadcrumbContext'
 import { TabsContent } from '@/components/ui/tabs'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -59,6 +61,15 @@ export function FestivalDetail({ idOrSlug }: FestivalDetailProps) {
   const hasSeriesHistory = seriesEditions.length >= 2
 
   const [activeTab, setActiveTab] = useState('lineup')
+  const pathname = usePathname()
+  const { pushBreadcrumb } = useNavigationBreadcrumbs()
+
+  // Push breadcrumb when festival data is loaded
+  useEffect(() => {
+    if (festival) {
+      pushBreadcrumb(festival.name, pathname)
+    }
+  }, [festival, pathname, pushBreadcrumb])
 
   // Determine if this is a multi-day festival with day assignments
   const hasMultipleDays = useMemo(() => {
@@ -250,7 +261,8 @@ export function FestivalDetail({ idOrSlug }: FestivalDetailProps) {
 
   return (
     <EntityDetailLayout
-      backLink={{ href: '/festivals', label: 'Back to Festivals' }}
+      fallback={{ href: '/festivals', label: 'Festivals' }}
+      entityName={festival.name}
       header={
         <EntityHeader
           title={festival.name}

--- a/frontend/features/labels/components/LabelDetail.tsx
+++ b/frontend/features/labels/components/LabelDetail.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import Link from 'next/link'
 import {
   Loader2,
@@ -12,7 +12,9 @@ import {
   Music,
 } from 'lucide-react'
 import { useLabel, useLabelRoster, useLabelCatalog } from '../hooks/useLabels'
+import { usePathname } from 'next/navigation'
 import { EntityDetailLayout, EntityHeader, SocialLinks, FollowButton } from '@/components/shared'
+import { useNavigationBreadcrumbs } from '@/lib/context/NavigationBreadcrumbContext'
 import { TabsContent } from '@/components/ui/tabs'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -38,6 +40,15 @@ export function LabelDetail({ idOrSlug }: LabelDetailProps) {
     enabled: !!label,
   })
   const [activeTab, setActiveTab] = useState('overview')
+  const pathname = usePathname()
+  const { pushBreadcrumb } = useNavigationBreadcrumbs()
+
+  // Push breadcrumb when label data is loaded
+  useEffect(() => {
+    if (label) {
+      pushBreadcrumb(label.name, pathname)
+    }
+  }, [label, pathname, pushBreadcrumb])
 
   if (isLoading) {
     return (
@@ -163,7 +174,8 @@ export function LabelDetail({ idOrSlug }: LabelDetailProps) {
 
   return (
     <EntityDetailLayout
-      backLink={{ href: '/labels', label: 'Back to Labels' }}
+      fallback={{ href: '/labels', label: 'Labels' }}
+      entityName={label.name}
       header={
         <EntityHeader
           title={label.name}

--- a/frontend/features/releases/components/ReleaseDetail.tsx
+++ b/frontend/features/releases/components/ReleaseDetail.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import Link from 'next/link'
 import {
   Loader2,
@@ -11,7 +11,9 @@ import {
   Users,
 } from 'lucide-react'
 import { useRelease } from '../hooks/useReleases'
+import { usePathname } from 'next/navigation'
 import { EntityDetailLayout, EntityHeader } from '@/components/shared'
+import { useNavigationBreadcrumbs } from '@/lib/context/NavigationBreadcrumbContext'
 import { TabsContent } from '@/components/ui/tabs'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -51,6 +53,15 @@ interface ReleaseDetailProps {
 export function ReleaseDetail({ idOrSlug }: ReleaseDetailProps) {
   const { data: release, isLoading, error } = useRelease({ idOrSlug })
   const [activeTab, setActiveTab] = useState('overview')
+  const pathname = usePathname()
+  const { pushBreadcrumb } = useNavigationBreadcrumbs()
+
+  // Push breadcrumb when release data is loaded
+  useEffect(() => {
+    if (release) {
+      pushBreadcrumb(release.title, pathname)
+    }
+  }, [release, pathname, pushBreadcrumb])
 
   if (isLoading) {
     return (
@@ -178,7 +189,8 @@ export function ReleaseDetail({ idOrSlug }: ReleaseDetailProps) {
 
   return (
     <EntityDetailLayout
-      backLink={{ href: '/releases', label: 'Back to Releases' }}
+      fallback={{ href: '/releases', label: 'Releases' }}
+      entityName={release.title}
       header={
         <EntityHeader
           title={release.title}

--- a/frontend/features/requests/components/RequestDetail.tsx
+++ b/frontend/features/requests/components/RequestDetail.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import Link from 'next/link'
-import { useRouter } from 'next/navigation'
+import { useRouter, usePathname } from 'next/navigation'
 import {
   Loader2,
   ThumbsUp,
@@ -19,7 +19,9 @@ import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
+import { Breadcrumb } from '@/components/shared'
 import { useAuthContext } from '@/lib/context/AuthContext'
+import { useNavigationBreadcrumbs } from '@/lib/context/NavigationBreadcrumbContext'
 import {
   useRequest,
   useUpdateRequest,
@@ -45,7 +47,9 @@ interface RequestDetailProps {
 
 export function RequestDetail({ requestId }: RequestDetailProps) {
   const router = useRouter()
+  const pathname = usePathname()
   const { user, isAuthenticated } = useAuthContext()
+  const { pushBreadcrumb } = useNavigationBreadcrumbs()
   const { data: request, isLoading, error } = useRequest(requestId)
   const deleteMutation = useDeleteRequest()
   const voteMutation = useVoteRequest()
@@ -54,6 +58,13 @@ export function RequestDetail({ requestId }: RequestDetailProps) {
   const closeMutation = useCloseRequest()
 
   const [isEditing, setIsEditing] = useState(false)
+
+  // Push breadcrumb when request data is loaded
+  useEffect(() => {
+    if (request) {
+      pushBreadcrumb(request.title, pathname)
+    }
+  }, [request, pathname, pushBreadcrumb])
 
   if (isLoading) {
     return (
@@ -160,15 +171,11 @@ export function RequestDetail({ requestId }: RequestDetailProps) {
 
   return (
     <div className="container max-w-4xl mx-auto px-4 py-6">
-      {/* Back link */}
-      <div className="mb-6">
-        <Link
-          href="/requests"
-          className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground transition-colors"
-        >
-          &larr; Back to Requests
-        </Link>
-      </div>
+      {/* Breadcrumb Navigation */}
+      <Breadcrumb
+        fallback={{ href: '/requests', label: 'Requests' }}
+        currentPage={request.title}
+      />
 
       {/* Header */}
       <header className="mb-8">

--- a/frontend/features/shows/components/ShowDetail.test.tsx
+++ b/frontend/features/shows/components/ShowDetail.test.tsx
@@ -42,11 +42,27 @@ vi.mock('@/lib/hooks/admin/useAdminShows', () => ({
   }),
 }))
 
+// Mock NavigationBreadcrumbContext
+vi.mock('@/lib/context/NavigationBreadcrumbContext', () => ({
+  useNavigationBreadcrumbs: () => ({
+    breadcrumbs: [],
+    pushBreadcrumb: vi.fn(),
+  }),
+}))
+
+// Mock next/navigation
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/shows/test-show',
+}))
+
 // Mock child components
 vi.mock('@/components/shared', () => ({
   SaveButton: () => <button data-testid="save-button">Save</button>,
   SocialLinks: () => <div data-testid="social-links" />,
   MusicEmbed: () => <div data-testid="music-embed" />,
+  Breadcrumb: ({ fallback, currentPage }: { fallback: { href: string; label: string }; currentPage: string }) => (
+    <nav aria-label="Breadcrumb"><a href={fallback.href}>{fallback.label}</a><span>{currentPage}</span></nav>
+  ),
 }))
 
 vi.mock('@/components/forms', () => ({
@@ -240,10 +256,12 @@ describe('ShowDetail', () => {
       expect(screen.queryByText('A great show description.')).not.toBeInTheDocument()
     })
 
-    it('renders back to shows link', () => {
+    it('renders breadcrumb with link to shows', () => {
       render(<ShowDetail showId="1" />)
-      const links = screen.getAllByText('Back to Shows')
-      expect(links[0].closest('a')).toHaveAttribute('href', '/shows')
+      const breadcrumbNav = screen.getByRole('navigation', { name: /Breadcrumb/ })
+      expect(breadcrumbNav).toBeInTheDocument()
+      const link = breadcrumbNav.querySelector('a')
+      expect(link).toHaveAttribute('href', '/shows')
     })
 
     it('renders save button', () => {

--- a/frontend/features/shows/components/ShowDetail.tsx
+++ b/frontend/features/shows/components/ShowDetail.tsx
@@ -1,16 +1,18 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import Link from 'next/link'
+import { usePathname } from 'next/navigation'
 import { ArrowLeft, Loader2, MapPin, Pencil, X, Trash2 } from 'lucide-react'
 import { useShow } from '../hooks/useShows'
 import type { ApiError } from '@/lib/api'
 import { useSetShowSoldOut, useSetShowCancelled } from '@/lib/hooks/admin/useAdminShows'
 import { useAuthContext } from '@/lib/context/AuthContext'
+import { useNavigationBreadcrumbs } from '@/lib/context/NavigationBreadcrumbContext'
 import type { ArtistResponse } from '../types'
 import { formatShowDate, formatShowTime, formatPrice } from '@/lib/utils/formatters'
 import { Button } from '@/components/ui/button'
-import { SocialLinks, MusicEmbed, SaveButton } from '@/components/shared'
+import { SocialLinks, MusicEmbed, SaveButton, Breadcrumb } from '@/components/shared'
 import { ShowForm } from '@/components/forms'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
@@ -37,6 +39,18 @@ export function ShowDetail({ showId }: ShowDetailProps) {
 
   const [isEditing, setIsEditing] = useState(false)
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
+  const pathname = usePathname()
+  const { pushBreadcrumb } = useNavigationBreadcrumbs()
+
+  // Push breadcrumb when show data is loaded
+  useEffect(() => {
+    if (show) {
+      const showTitle = show.title || show.artists.map(a => a.name).join(', ')
+      const venue = show.venues[0]
+      const label = venue ? `${showTitle} at ${venue.name}` : showTitle
+      pushBreadcrumb(label, pathname)
+    }
+  }, [show, pathname, pushBreadcrumb])
 
   // Admin mutations for status flags
   const setSoldOutMutation = useSetShowSoldOut()
@@ -129,16 +143,11 @@ export function ShowDetail({ showId }: ShowDetailProps) {
 
   return (
     <div className="container max-w-6xl mx-auto px-4 py-6">
-      {/* Back Navigation */}
-      <div className="mb-6">
-        <Link
-          href="/shows"
-          className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground transition-colors"
-        >
-          <ArrowLeft className="h-4 w-4 mr-1" />
-          Back to Shows
-        </Link>
-      </div>
+      {/* Breadcrumb Navigation */}
+      <Breadcrumb
+        fallback={{ href: '/shows', label: 'Shows' }}
+        currentPage={show.title || artists.map(a => a.name).join(', ')}
+      />
 
       {/* Cancelled Alert Banner */}
       {show.is_cancelled && (

--- a/frontend/features/tags/components/TagDetail.tsx
+++ b/frontend/features/tags/components/TagDetail.tsx
@@ -1,10 +1,14 @@
 'use client'
 
+import { useEffect } from 'react'
 import Link from 'next/link'
+import { usePathname } from 'next/navigation'
 import { ArrowLeft, Hash, Loader2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
+import { Breadcrumb } from '@/components/shared'
+import { useNavigationBreadcrumbs } from '@/lib/context/NavigationBreadcrumbContext'
 import { useTag } from '../hooks'
 import { getCategoryColor, getCategoryLabel } from '../types'
 
@@ -14,6 +18,15 @@ interface TagDetailProps {
 
 export function TagDetail({ slug }: TagDetailProps) {
   const { data: tag, isLoading, error } = useTag(slug)
+  const pathname = usePathname()
+  const { pushBreadcrumb } = useNavigationBreadcrumbs()
+
+  // Push breadcrumb when tag data is loaded
+  useEffect(() => {
+    if (tag) {
+      pushBreadcrumb(tag.name, pathname)
+    }
+  }, [tag, pathname, pushBreadcrumb])
 
   if (isLoading) {
     return (
@@ -72,16 +85,11 @@ export function TagDetail({ slug }: TagDetailProps) {
 
   return (
     <div className="container max-w-4xl mx-auto px-4 py-6">
-      {/* Back link */}
-      <div className="mb-6">
-        <Link
-          href="/tags"
-          className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground transition-colors"
-        >
-          <ArrowLeft className="h-4 w-4 mr-1" />
-          Back to Tags
-        </Link>
-      </div>
+      {/* Breadcrumb Navigation */}
+      <Breadcrumb
+        fallback={{ href: '/tags', label: 'Tags' }}
+        currentPage={tag.name}
+      />
 
       {/* Header */}
       <header className="mb-8">

--- a/frontend/features/venues/components/VenueDetail.tsx
+++ b/frontend/features/venues/components/VenueDetail.tsx
@@ -1,15 +1,16 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import Link from 'next/link'
-import { useRouter } from 'next/navigation'
+import { useRouter, usePathname } from 'next/navigation'
 import { ArrowLeft, BadgeCheck, Pencil, Trash2, Loader2, ExternalLink } from 'lucide-react'
 import { useVenue } from '../hooks/useVenues'
 import type { ApiError } from '@/lib/api'
 import { useAuthContext } from '@/lib/context/AuthContext'
+import { useNavigationBreadcrumbs } from '@/lib/context/NavigationBreadcrumbContext'
 import { useQueryClient } from '@tanstack/react-query'
 import { queryKeys } from '@/lib/queryClient'
-import { SocialLinks, RevisionHistory, FollowButton } from '@/components/shared'
+import { SocialLinks, RevisionHistory, FollowButton, Breadcrumb } from '@/components/shared'
 import { VenueLocationCard } from './VenueLocationCard'
 import { VenueShowsList } from './VenueShowsList'
 import { VenueEditForm } from '@/components/forms/VenueEditForm'
@@ -50,6 +51,8 @@ export function VenueDetail({ venueId }: VenueDetailProps) {
   const { isAuthenticated, user } = useAuthContext()
   const queryClient = useQueryClient()
   const router = useRouter()
+  const pathname = usePathname()
+  const { pushBreadcrumb } = useNavigationBreadcrumbs()
 
   const { data: venue, isLoading, error } = useVenue({ venueId })
 
@@ -59,6 +62,13 @@ export function VenueDetail({ venueId }: VenueDetailProps) {
     venue &&
     (user?.is_admin ||
       (venue.submitted_by != null && venue.submitted_by === Number(user?.id)))
+
+  // Push breadcrumb when venue data is loaded
+  useEffect(() => {
+    if (venue) {
+      pushBreadcrumb(venue.name, pathname)
+    }
+  }, [venue, pathname, pushBreadcrumb])
 
   const handleVenueUpdated = () => {
     // Invalidate venue detail query
@@ -130,16 +140,11 @@ export function VenueDetail({ venueId }: VenueDetailProps) {
 
   return (
     <div className="container max-w-5xl mx-auto px-4 py-6">
-      {/* Back Navigation */}
-      <div className="mb-6">
-        <Link
-          href="/venues"
-          className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground transition-colors"
-        >
-          <ArrowLeft className="h-4 w-4 mr-1" />
-          Back to Venues
-        </Link>
-      </div>
+      {/* Breadcrumb Navigation */}
+      <Breadcrumb
+        fallback={{ href: '/venues', label: 'Venues' }}
+        currentPage={venue.name}
+      />
 
       {/* Main Content - Two Column Layout */}
       <div className="grid grid-cols-1 lg:grid-cols-[1fr_400px] gap-8">

--- a/frontend/lib/context/NavigationBreadcrumbContext.test.tsx
+++ b/frontend/lib/context/NavigationBreadcrumbContext.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { NavigationBreadcrumbProvider, useNavigationBreadcrumbs } from './NavigationBreadcrumbContext'
+
+// Mock sessionStorage
+const sessionStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => { store[key] = value }),
+    removeItem: vi.fn((key: string) => { delete store[key] }),
+    clear: vi.fn(() => { store = {} }),
+  }
+})()
+Object.defineProperty(window, 'sessionStorage', { value: sessionStorageMock })
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <NavigationBreadcrumbProvider>{children}</NavigationBreadcrumbProvider>
+}
+
+describe('NavigationBreadcrumbContext', () => {
+  beforeEach(() => {
+    sessionStorageMock.clear()
+    vi.clearAllMocks()
+  })
+
+  it('starts with empty breadcrumbs', () => {
+    const { result } = renderHook(() => useNavigationBreadcrumbs(), { wrapper })
+    expect(result.current.breadcrumbs).toEqual([])
+  })
+
+  it('pushes a breadcrumb entry', () => {
+    const { result } = renderHook(() => useNavigationBreadcrumbs(), { wrapper })
+
+    act(() => {
+      result.current.pushBreadcrumb('Artists', '/artists')
+    })
+
+    expect(result.current.breadcrumbs).toEqual([
+      { label: 'Artists', href: '/artists' },
+    ])
+  })
+
+  it('pushes multiple breadcrumb entries', () => {
+    const { result } = renderHook(() => useNavigationBreadcrumbs(), { wrapper })
+
+    act(() => {
+      result.current.pushBreadcrumb('Shows', '/shows')
+    })
+    act(() => {
+      result.current.pushBreadcrumb('Jeff Tweedy at Van Buren', '/shows/jeff-tweedy')
+    })
+    act(() => {
+      result.current.pushBreadcrumb('Macie Stewart', '/artists/macie-stewart')
+    })
+
+    expect(result.current.breadcrumbs).toHaveLength(3)
+    expect(result.current.breadcrumbs[0].label).toBe('Shows')
+    expect(result.current.breadcrumbs[1].label).toBe('Jeff Tweedy at Van Buren')
+    expect(result.current.breadcrumbs[2].label).toBe('Macie Stewart')
+  })
+
+  it('pops back to existing entry when href already in stack', () => {
+    const { result } = renderHook(() => useNavigationBreadcrumbs(), { wrapper })
+
+    act(() => {
+      result.current.pushBreadcrumb('Shows', '/shows')
+    })
+    act(() => {
+      result.current.pushBreadcrumb('Artist A', '/artists/a')
+    })
+    act(() => {
+      result.current.pushBreadcrumb('Venue B', '/venues/b')
+    })
+
+    // Navigate back to /shows - should pop back
+    act(() => {
+      result.current.pushBreadcrumb('Shows', '/shows')
+    })
+
+    expect(result.current.breadcrumbs).toHaveLength(1)
+    expect(result.current.breadcrumbs[0]).toEqual({ label: 'Shows', href: '/shows' })
+  })
+
+  it('limits stack to 4 entries', () => {
+    const { result } = renderHook(() => useNavigationBreadcrumbs(), { wrapper })
+
+    act(() => {
+      result.current.pushBreadcrumb('Entry 1', '/1')
+    })
+    act(() => {
+      result.current.pushBreadcrumb('Entry 2', '/2')
+    })
+    act(() => {
+      result.current.pushBreadcrumb('Entry 3', '/3')
+    })
+    act(() => {
+      result.current.pushBreadcrumb('Entry 4', '/4')
+    })
+    act(() => {
+      result.current.pushBreadcrumb('Entry 5', '/5')
+    })
+
+    expect(result.current.breadcrumbs).toHaveLength(4)
+    expect(result.current.breadcrumbs[0].label).toBe('Entry 2')
+    expect(result.current.breadcrumbs[3].label).toBe('Entry 5')
+  })
+
+  it('persists to sessionStorage', () => {
+    const { result } = renderHook(() => useNavigationBreadcrumbs(), { wrapper })
+
+    act(() => {
+      result.current.pushBreadcrumb('Shows', '/shows')
+    })
+
+    expect(sessionStorageMock.setItem).toHaveBeenCalledWith(
+      'ph-breadcrumbs',
+      JSON.stringify([{ label: 'Shows', href: '/shows' }])
+    )
+  })
+
+  it('throws when used outside provider', () => {
+    expect(() => {
+      renderHook(() => useNavigationBreadcrumbs())
+    }).toThrow('useNavigationBreadcrumbs must be used within NavigationBreadcrumbProvider')
+  })
+})

--- a/frontend/lib/context/NavigationBreadcrumbContext.tsx
+++ b/frontend/lib/context/NavigationBreadcrumbContext.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import { createContext, useContext, useState, useCallback, useEffect, type ReactNode } from 'react'
+
+export interface BreadcrumbEntry {
+  label: string
+  href: string
+}
+
+interface NavigationBreadcrumbContextValue {
+  breadcrumbs: BreadcrumbEntry[]
+  pushBreadcrumb: (label: string, href: string) => void
+}
+
+const STORAGE_KEY = 'ph-breadcrumbs'
+const MAX_ENTRIES = 4
+
+const NavigationBreadcrumbContext = createContext<NavigationBreadcrumbContextValue | null>(null)
+
+function loadFromSession(): BreadcrumbEntry[] {
+  if (typeof window === 'undefined') return []
+  try {
+    const stored = sessionStorage.getItem(STORAGE_KEY)
+    if (stored) {
+      const parsed = JSON.parse(stored)
+      if (Array.isArray(parsed)) return parsed.slice(0, MAX_ENTRIES)
+    }
+  } catch {
+    // Ignore parse errors
+  }
+  return []
+}
+
+function saveToSession(entries: BreadcrumbEntry[]) {
+  if (typeof window === 'undefined') return
+  try {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(entries))
+  } catch {
+    // Ignore storage errors
+  }
+}
+
+export function NavigationBreadcrumbProvider({ children }: { children: ReactNode }) {
+  const [breadcrumbs, setBreadcrumbs] = useState<BreadcrumbEntry[]>([])
+
+  // Load from sessionStorage on mount
+  useEffect(() => {
+    setBreadcrumbs(loadFromSession())
+  }, [])
+
+  const pushBreadcrumb = useCallback((label: string, href: string) => {
+    setBreadcrumbs(prev => {
+      // If the href already exists in the stack, pop back to it
+      const existingIndex = prev.findIndex(entry => entry.href === href)
+      if (existingIndex !== -1) {
+        // Update the label at that position (entity name may differ) and truncate
+        const updated = prev.slice(0, existingIndex + 1)
+        updated[existingIndex] = { label, href }
+        saveToSession(updated)
+        return updated
+      }
+
+      // Push new entry, keeping max entries
+      const next = [...prev, { label, href }].slice(-MAX_ENTRIES)
+      saveToSession(next)
+      return next
+    })
+  }, [])
+
+  return (
+    <NavigationBreadcrumbContext.Provider value={{ breadcrumbs, pushBreadcrumb }}>
+      {children}
+    </NavigationBreadcrumbContext.Provider>
+  )
+}
+
+export function useNavigationBreadcrumbs() {
+  const context = useContext(NavigationBreadcrumbContext)
+  if (!context) {
+    throw new Error('useNavigationBreadcrumbs must be used within NavigationBreadcrumbProvider')
+  }
+  return context
+}


### PR DESCRIPTION
## Summary
- Replaced static "Back to [Entity Type]" links with dynamic breadcrumb trails reflecting actual navigation path
- New `NavigationBreadcrumbContext` stores crumb stack in React state + sessionStorage (per-tab, max 4 entries)
- New `Breadcrumb` component renders `Shows › Jeff Tweedy at Van Buren › Macie Stewart`
- All 9 entity detail pages updated: Artists, Shows, Venues, Releases, Labels, Festivals, Tags, Collections, Requests
- Fallback for direct landing: `Artists › Macie Stewart` (entity type list → entity name)
- 12 new tests (7 context + 5 component), 1468 total passing

## Test plan
- [ ] Navigate Show → Artist → see `Shows › [show] › [artist]`
- [ ] Navigate Artist → Venue → see `Artists › [artist] › [venue]`  
- [ ] Click a breadcrumb crumb → navigates back to that page
- [ ] Direct URL landing → shows `[Entity Type] › [Entity Name]`
- [ ] Refresh page → breadcrumbs persist (sessionStorage)
- [ ] Open same page in new tab → fresh breadcrumbs (sessionStorage is per-tab)
- [ ] All 1468 frontend tests pass

Closes PSY-170

🤖 Generated with [Claude Code](https://claude.com/claude-code)