### PR TITLE
Fix CLI matching and bypass rate limit for API tokens

### DIFF
--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -239,12 +240,11 @@ func setupShowRoutes(router *chi.Mux, api huma.API, protected *huma.Group, sc *s
 
 	// Rate-limited show creation: 10 requests per hour per IP
 	// Prevents flooding the admin approval queue
+	// API token requests (phk_ prefix) bypass the rate limit — they're trusted admin clients
 	router.Group(func(r chi.Router) {
-		r.Use(httprate.Limit(
+		r.Use(rateLimitUnlessAPIToken(
 			middleware.ShowCreateRequestsPerHour,
 			time.Hour,
-			httprate.WithKeyFuncs(httprate.KeyByIP),
-			httprate.WithLimitHandler(rateLimitHandler),
 		))
 		showCreateAPI := humachi.New(r, huma.DefaultConfig("Psychic Homily Show Create", "1.0.0"))
 		showCreateAPI.UseMiddleware(middleware.HumaRequestIDMiddleware)
@@ -803,6 +803,30 @@ func setupChartsRoutes(api huma.API, sc *services.ServiceContainer) {
 	huma.Get(api, "/charts/active-venues", chartsHandler.GetActiveVenuesHandler)
 	huma.Get(api, "/charts/hot-releases", chartsHandler.GetHotReleasesHandler)
 	huma.Get(api, "/charts/overview", chartsHandler.GetChartsOverviewHandler)
+}
+
+// rateLimitUnlessAPIToken wraps httprate.Limit but skips rate limiting for
+// requests authenticated with an API token (phk_ prefix). API tokens are
+// admin-only and trusted — they shouldn't be throttled during batch imports.
+func rateLimitUnlessAPIToken(requestLimit int, windowLength time.Duration) func(http.Handler) http.Handler {
+	limiter := httprate.Limit(
+		requestLimit,
+		windowLength,
+		httprate.WithKeyFuncs(httprate.KeyByIP),
+		httprate.WithLimitHandler(rateLimitHandler),
+	)
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			auth := r.Header.Get("Authorization")
+			if strings.HasPrefix(auth, "Bearer phk_") {
+				// API token — bypass rate limit
+				next.ServeHTTP(w, r)
+				return
+			}
+			// Normal request — apply rate limit
+			limiter(next).ServeHTTP(w, r)
+		})
+	}
 }
 
 // rateLimitHandler handles rate limit exceeded responses with JSON

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -77,7 +77,8 @@ program
   .command("submit <entity-type> [json]")
   .description("Submit entities for creation/update (artist, venue, show, release, label, festival)")
   .option("--confirm", "Actually submit (default is dry-run)")
-  .action(async (entityType: string, json: string | undefined, opts: { confirm?: boolean }) => {
+  .option("--force", "Skip duplicate checking (force create)")
+  .action(async (entityType: string, json: string | undefined, opts: { confirm?: boolean; force?: boolean }) => {
     if (!SUBMIT_TYPES.includes(entityType)) {
       display.error(
         `Invalid entity type "${entityType}". Must be one of: ${SUBMIT_TYPES.join(", ")}`,
@@ -89,7 +90,7 @@ program
 
     switch (entityType) {
       case "artist":
-        await runSubmitArtist(json, env, { confirm: opts.confirm });
+        await runSubmitArtist(json, env, { confirm: opts.confirm, force: opts.force });
         break;
       case "venue":
         await runSubmitVenue(json, opts, env);

--- a/cli/src/commands/submit-artist.ts
+++ b/cli/src/commands/submit-artist.ts
@@ -17,6 +17,7 @@ export interface SubmitArtistResult {
 
 export interface SubmitArtistsOptions {
   confirm?: boolean;
+  force?: boolean;
 }
 
 /**
@@ -150,13 +151,19 @@ export async function submitArtists(
     }));
   }
 
-  // Phase 2: Check duplicates for all artists
-  display.info("Checking for duplicates...");
-
+  // Phase 2: Check duplicates for all artists (skip with --force)
   const dupResults: DuplicateCheckResult[] = [];
-  for (let i = 0; i < artists.length; i++) {
-    const result = await checkDuplicate(client, "artist", artists[i]);
-    dupResults.push(result);
+  if (options.force) {
+    display.info("Skipping duplicate check (--force)");
+    for (const artist of artists) {
+      dupResults.push({ action: "create" as const, match: "none" as const, fields: [], confidence: 0 });
+    }
+  } else {
+    display.info("Checking for duplicates...");
+    for (let i = 0; i < artists.length; i++) {
+      const result = await checkDuplicate(client, "artist", artists[i]);
+      dupResults.push(result);
+    }
   }
 
   // Phase 2b: Resolve tags for all artists

--- a/cli/src/commands/submit-show.ts
+++ b/cli/src/commands/submit-show.ts
@@ -1,7 +1,7 @@
 import { APIClient } from "../lib/api";
 import type { EnvironmentConfig } from "../lib/types";
 import { validateShow } from "../lib/schemas";
-import { searchArtistsByName, searchVenuesByName } from "../lib/duplicates";
+import { searchArtistsByName, searchVenuesByName, similarityScore } from "../lib/duplicates";
 import { TagResolver, formatTagsPreview, formatFuzzyWarning } from "../lib/tags";
 import type { TagInput, ResolvedTag } from "../lib/tags";
 import * as display from "../lib/display";
@@ -100,11 +100,16 @@ export async function resolveArtists(
   for (const artist of artists) {
     try {
       const results = await searchArtistsByName(client, artist.name);
-      if (results.length > 0) {
-        // Use the best match (first result from search)
+      // Find best match by similarity score, require >= 0.7
+      const best = results
+        .map((r) => ({ ...r, score: similarityScore(artist.name, r.name) }))
+        .filter((r) => r.score >= 0.7)
+        .sort((a, b) => b.score - a.score)[0];
+
+      if (best) {
         resolved.push({
-          id: results[0].id,
-          name: results[0].name,
+          id: best.id,
+          name: best.name,
           is_headliner: artist.is_headliner,
           status: "existing",
         });
@@ -138,10 +143,16 @@ export async function resolveVenues(
   for (const venue of venues) {
     try {
       const results = await searchVenuesByName(client, venue.name);
-      if (results.length > 0) {
+      // Find best match by similarity score, require >= 0.7
+      const best = results
+        .map((r) => ({ ...r, score: similarityScore(venue.name, r.name) }))
+        .filter((r) => r.score >= 0.7)
+        .sort((a, b) => b.score - a.score)[0];
+
+      if (best) {
         resolved.push({
-          id: results[0].id,
-          name: results[0].name,
+          id: best.id,
+          name: best.name,
           city: venue.city,
           state: venue.state,
           address: venue.address,

--- a/cli/src/lib/duplicates.ts
+++ b/cli/src/lib/duplicates.ts
@@ -51,8 +51,15 @@ export function similarityScore(a: string, b: string): number {
   const shorter = na.length < nb.length ? na : nb;
 
   if (longer.includes(shorter)) {
-    // Scale by how much of the longer string the shorter covers
-    return 0.8 + 0.2 * (shorter.length / longer.length);
+    const coverage = shorter.length / longer.length;
+    // Require at least 60% coverage for substring match to count
+    // "house" in "houseofvivian" = 38% → not a match
+    // "national" in "the national" = 67% → match
+    if (coverage >= 0.6) {
+      return 0.8 + 0.2 * coverage;
+    }
+    // Low coverage substring: treat as weak signal, not a match
+    return 0.4 + 0.3 * coverage;
   }
 
   // Common prefix scoring


### PR DESCRIPTION
## Summary
- Fix `similarityScore` substring matching to require ≥60% coverage, preventing false positives like "house" matching "houseofvivian"
- Add `--force` flag to `ph submit artist` to skip duplicate checking during trusted batch imports
- Use similarity scoring (≥0.7 threshold) in show submit resolver instead of blindly accepting first search result
- Bypass rate limit on `POST /shows` for API token (`phk_` prefix) requests — admin clients shouldn't be throttled during batch imports

## Test plan
- [x] Backend compiles (`go build ./...`)
- [x] CLI type-checks (`npx tsc --noEmit`)
- [ ] Manual: `ph submit artist --force` skips duplicate check
- [ ] Manual: `ph submit show` correctly matches artists/venues by similarity
- [ ] Manual: API token requests bypass show creation rate limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)