### PR TITLE
Notification filter frontend — management UI and Notify Me buttons

### DIFF
--- a/frontend/app/settings/notifications/page.tsx
+++ b/frontend/app/settings/notifications/page.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { useAuthContext } from '@/lib/context/AuthContext'
+import { redirect } from 'next/navigation'
+import { Loader2 } from 'lucide-react'
+import { FilterList } from '@/features/notifications'
+
+export default function NotificationSettingsPage() {
+  const { isAuthenticated, isLoading } = useAuthContext()
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  if (!isAuthenticated) {
+    redirect('/auth')
+  }
+
+  return (
+    <div className="container max-w-3xl mx-auto px-4 py-6">
+      <FilterList />
+    </div>
+  )
+}

--- a/frontend/components/layout/CommandPalette.tsx
+++ b/frontend/components/layout/CommandPalette.tsx
@@ -15,7 +15,7 @@ import {
   Calendar, CalendarCheck, Mic2, MapPin, Disc3, Tag, Tags, Tent, BookOpen, Headphones, Send,
   Library, LayoutList, MessageSquarePlus, Settings, Search, Clock, X, Globe, UserCheck,
   TrendingUp, LayoutDashboard, Upload, BadgeCheck, Flag, ScrollText, Users, Workflow,
-  ClipboardCheck, BarChart3, Music,
+  ClipboardCheck, BarChart3, Music, Bell,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import { useAuthContext } from '@/lib/context/AuthContext'
@@ -134,6 +134,13 @@ const routes: RouteItem[] = [
     href: '/collection',
     icon: Library,
     keywords: ['collection', 'saved', 'my list', 'favorites', 'bookmarks'],
+    requireAuth: true,
+  },
+  {
+    label: 'Notification Filters',
+    href: '/settings/notifications',
+    icon: Bell,
+    keywords: ['notifications', 'notify', 'filters', 'alerts', 'bell', 'subscribe'],
     requireAuth: true,
   },
   {

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -5,7 +5,7 @@ import { usePathname } from 'next/navigation'
 import {
   Calendar, CalendarCheck, Mic2, MapPin, Disc3, Tag, Tags, Tent, BookOpen, Headphones, Newspaper,
   Send, Library, LayoutList, MessageSquarePlus, Settings, Shield, PanelLeftClose, PanelLeft,
-  ExternalLink, Globe, UserCheck, TrendingUp,
+  ExternalLink, Globe, UserCheck, TrendingUp, Bell,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import { cn } from '@/lib/utils'
@@ -134,6 +134,7 @@ export function Sidebar({ collapsed, onToggleCollapse }: SidebarProps) {
                 {renderItem({ href: '/my-shows', label: 'My Shows', icon: CalendarCheck })}
                 {renderItem({ href: '/following', label: 'Following', icon: UserCheck })}
                 {renderItem({ href: '/collection', label: 'Collection', icon: Library })}
+                {renderItem({ href: '/settings/notifications', label: 'Notifications', icon: Bell })}
                 {renderItem({ href: '/profile', label: 'Settings', icon: Settings })}
                 {user?.is_admin && renderItem({ href: '/admin', label: 'Admin', icon: Shield })}
               </div>

--- a/frontend/features/artists/components/ArtistDetail.test.tsx
+++ b/frontend/features/artists/components/ArtistDetail.test.tsx
@@ -105,6 +105,14 @@ vi.mock('@/lib/context/NavigationBreadcrumbContext', () => ({
 // Mock next/navigation
 vi.mock('next/navigation', () => ({
   usePathname: () => '/artists/test-artist',
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+// Mock NotifyMeButton to avoid deep notification hooks dependency
+vi.mock('@/features/notifications', () => ({
+  NotifyMeButton: ({ entityName }: { entityType: string; entityId: number; entityName: string }) => (
+    <button data-testid="notify-me-button">Notify {entityName}</button>
+  ),
 }))
 
 vi.mock('@/components/shared', () => ({

--- a/frontend/features/artists/components/ArtistDetail.tsx
+++ b/frontend/features/artists/components/ArtistDetail.tsx
@@ -36,6 +36,7 @@ import { usePathname } from 'next/navigation'
 import { ArtistTrajectoryChart } from '@/features/festivals/components/ArtistTrajectoryChart'
 import { EntityTagList } from '@/features/tags'
 import { ArtistEditForm } from '@/components/forms/ArtistEditForm'
+import { NotifyMeButton } from '@/features/notifications'
 import { ArtistShowsList } from './ArtistShowsList'
 import { RelatedArtists } from './RelatedArtists'
 import { ReportArtistButton } from './ReportArtistButton'
@@ -921,6 +922,7 @@ export function ArtistDetail({ artistId }: ArtistDetailProps) {
 
   const headerActions = (
     <div className="flex items-center gap-2">
+      <NotifyMeButton entityType="artist" entityId={artist.id} entityName={artist.name} />
       <FollowButton entityType="artists" entityId={artist.id} />
       {isAdmin && (
         <Button

--- a/frontend/features/labels/components/LabelDetail.tsx
+++ b/frontend/features/labels/components/LabelDetail.tsx
@@ -14,6 +14,7 @@ import {
 import { useLabel, useLabelRoster, useLabelCatalog } from '../hooks/useLabels'
 import { usePathname } from 'next/navigation'
 import { EntityDetailLayout, EntityHeader, SocialLinks, FollowButton } from '@/components/shared'
+import { NotifyMeButton } from '@/features/notifications'
 import { useNavigationBreadcrumbs } from '@/lib/context/NavigationBreadcrumbContext'
 import { TabsContent } from '@/components/ui/tabs'
 import { Badge } from '@/components/ui/badge'
@@ -193,7 +194,12 @@ export function LabelDetail({ idOrSlug }: LabelDetailProps) {
               {label.founded_year && <span>Est. {label.founded_year}</span>}
             </>
           }
-          actions={<FollowButton entityType="labels" entityId={label.id} />}
+          actions={
+            <div className="flex items-center gap-2">
+              <NotifyMeButton entityType="label" entityId={label.id} entityName={label.name} />
+              <FollowButton entityType="labels" entityId={label.id} />
+            </div>
+          }
         />
       }
       tabs={tabs}

--- a/frontend/features/notifications/components/FilterCard.tsx
+++ b/frontend/features/notifications/components/FilterCard.tsx
@@ -1,0 +1,153 @@
+'use client'
+
+import { useState } from 'react'
+import { Bell, BellOff, Pencil, Trash2, Loader2, MoreHorizontal } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Switch } from '@/components/ui/switch'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { useUpdateFilter, useDeleteFilter } from '../hooks'
+import type { NotificationFilter } from '../types'
+import { getFilterSummary, formatTimeAgo } from '../types'
+
+interface FilterCardProps {
+  filter: NotificationFilter
+  onEdit: (filter: NotificationFilter) => void
+}
+
+export function FilterCard({ filter, onEdit }: FilterCardProps) {
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+
+  const updateFilter = useUpdateFilter()
+  const deleteFilter = useDeleteFilter()
+
+  const isMutating = updateFilter.isPending || deleteFilter.isPending
+
+  const handleToggleActive = () => {
+    updateFilter.mutate({
+      id: filter.id,
+      is_active: !filter.is_active,
+    })
+  }
+
+  const handleDelete = () => {
+    deleteFilter.mutate(filter.id, {
+      onSuccess: () => setShowDeleteConfirm(false),
+    })
+  }
+
+  return (
+    <div className="rounded-lg border border-border/50 bg-card p-4">
+      <div className="flex items-start gap-3">
+        {/* Active toggle */}
+        <div className="pt-0.5">
+          <Switch
+            checked={filter.is_active}
+            onCheckedChange={handleToggleActive}
+            disabled={isMutating}
+            aria-label={filter.is_active ? 'Pause filter' : 'Activate filter'}
+          />
+        </div>
+
+        {/* Filter details */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            {filter.is_active ? (
+              <Bell className="h-4 w-4 text-primary shrink-0" />
+            ) : (
+              <BellOff className="h-4 w-4 text-muted-foreground shrink-0" />
+            )}
+            <h3 className="font-medium text-sm truncate">
+              {filter.name}
+            </h3>
+          </div>
+
+          <p className="text-xs text-muted-foreground mt-1 line-clamp-2">
+            {getFilterSummary(filter)}
+          </p>
+
+          <div className="flex items-center gap-3 mt-2 text-xs text-muted-foreground">
+            <span>
+              {filter.match_count} {filter.match_count === 1 ? 'match' : 'matches'}
+            </span>
+            {filter.last_matched_at && (
+              <span>Last: {formatTimeAgo(filter.last_matched_at)}</span>
+            )}
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="flex items-center gap-1 shrink-0">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => onEdit(filter)}
+            className="h-8 w-8 p-0"
+            title="Edit filter"
+          >
+            <Pencil className="h-3.5 w-3.5" />
+          </Button>
+
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-8 w-8 p-0"
+              >
+                <MoreHorizontal className="h-3.5 w-3.5" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onClick={() => onEdit(filter)}>
+                <Pencil className="h-3.5 w-3.5 mr-2" />
+                Edit
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={() => setShowDeleteConfirm(true)}
+                className="text-destructive focus:text-destructive"
+              >
+                <Trash2 className="h-3.5 w-3.5 mr-2" />
+                Delete
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </div>
+
+      {/* Delete confirmation */}
+      {showDeleteConfirm && (
+        <div className="mt-3 pt-3 border-t border-border/50 flex items-center justify-between">
+          <p className="text-xs text-muted-foreground">
+            Delete this filter? This cannot be undone.
+          </p>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setShowDeleteConfirm(false)}
+              disabled={deleteFilter.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={handleDelete}
+              disabled={deleteFilter.isPending}
+            >
+              {deleteFilter.isPending ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin mr-1" />
+              ) : null}
+              Delete
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/features/notifications/components/FilterForm.tsx
+++ b/frontend/features/notifications/components/FilterForm.tsx
@@ -1,0 +1,466 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { Loader2, X, Search, Plus } from 'lucide-react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Switch } from '@/components/ui/switch'
+import { Badge } from '@/components/ui/badge'
+import { useCreateFilter, useUpdateFilter } from '../hooks'
+import type { NotificationFilter, CreateFilterInput } from '../types'
+import { useArtistSearch } from '@/features/artists/hooks/useArtistSearch'
+import { useVenueSearch } from '@/features/venues/hooks/useVenueSearch'
+import { useSearchTags } from '@/features/tags/hooks'
+import { apiRequest, API_ENDPOINTS } from '@/lib/api'
+import { useQuery } from '@tanstack/react-query'
+
+// ──────────────────────────────────────────────
+// Multi-select search combobox
+// ──────────────────────────────────────────────
+
+interface SearchableItem {
+  id: number
+  name: string
+}
+
+interface MultiSelectSearchProps {
+  label: string
+  placeholder: string
+  selectedIds: number[]
+  onSelectionChange: (ids: number[]) => void
+  searchHook: (query: string) => { data: SearchableItem[] | undefined; isLoading: boolean }
+}
+
+function MultiSelectSearch({
+  label,
+  placeholder,
+  selectedIds,
+  onSelectionChange,
+  searchHook,
+}: MultiSelectSearchProps) {
+  const [query, setQuery] = useState('')
+  const [isOpen, setIsOpen] = useState(false)
+  const [selectedItems, setSelectedItems] = useState<SearchableItem[]>([])
+  const { data: results, isLoading } = searchHook(query)
+
+  const handleSelect = useCallback(
+    (item: SearchableItem) => {
+      if (!selectedIds.includes(item.id)) {
+        const newIds = [...selectedIds, item.id]
+        onSelectionChange(newIds)
+        setSelectedItems(prev => [...prev, item])
+      }
+      setQuery('')
+      setIsOpen(false)
+    },
+    [selectedIds, onSelectionChange]
+  )
+
+  const handleRemove = useCallback(
+    (id: number) => {
+      onSelectionChange(selectedIds.filter(sid => sid !== id))
+      setSelectedItems(prev => prev.filter(item => item.id !== id))
+    },
+    [selectedIds, onSelectionChange]
+  )
+
+  // Filter out already-selected items from results
+  const filteredResults = results?.filter(r => !selectedIds.includes(r.id)) ?? []
+
+  return (
+    <div className="space-y-2">
+      <Label className="text-sm font-medium">{label}</Label>
+
+      {/* Selected items */}
+      {selectedItems.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {selectedItems.map(item => (
+            <Badge
+              key={item.id}
+              variant="secondary"
+              className="gap-1 pr-1"
+            >
+              {item.name}
+              <button
+                type="button"
+                onClick={() => handleRemove(item.id)}
+                className="ml-0.5 rounded-sm hover:bg-muted-foreground/20 p-0.5"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </Badge>
+          ))}
+        </div>
+      )}
+
+      {/* Search input */}
+      <div className="relative">
+        <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+        <Input
+          placeholder={placeholder}
+          value={query}
+          onChange={e => {
+            setQuery(e.target.value)
+            setIsOpen(e.target.value.length > 0)
+          }}
+          onFocus={() => {
+            if (query.length > 0) setIsOpen(true)
+          }}
+          onBlur={() => {
+            // Delay to allow click on results
+            setTimeout(() => setIsOpen(false), 200)
+          }}
+          className="pl-9"
+        />
+
+        {/* Dropdown results */}
+        {isOpen && query.length > 0 && (
+          <div className="absolute z-50 top-full left-0 right-0 mt-1 max-h-48 overflow-y-auto rounded-md border border-border bg-popover shadow-md">
+            {isLoading ? (
+              <div className="flex items-center justify-center py-4">
+                <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+              </div>
+            ) : filteredResults.length === 0 ? (
+              <div className="py-3 text-center text-xs text-muted-foreground">
+                No results found
+              </div>
+            ) : (
+              filteredResults.map(item => (
+                <button
+                  key={item.id}
+                  type="button"
+                  onClick={() => handleSelect(item)}
+                  className="flex w-full items-center gap-2 px-3 py-2 text-sm hover:bg-muted/50 transition-colors text-left"
+                >
+                  <Plus className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                  {item.name}
+                </button>
+              ))
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ──────────────────────────────────────────────
+// Search hook adapters
+// ──────────────────────────────────────────────
+
+function useArtistSearchAdapter(query: string) {
+  const { data, isLoading } = useArtistSearch({ query })
+  return {
+    data: data?.artists?.map(a => ({ id: a.id, name: a.name })),
+    isLoading,
+  }
+}
+
+function useVenueSearchAdapter(query: string) {
+  const { data, isLoading } = useVenueSearch({ query })
+  return {
+    data: data?.venues?.map(v => ({ id: v.id, name: v.name })),
+    isLoading,
+  }
+}
+
+function useTagSearchAdapter(query: string) {
+  const { data, isLoading } = useSearchTags(query)
+  return {
+    data: data?.tags?.map(t => ({ id: t.id, name: t.name })),
+    isLoading,
+  }
+}
+
+function useLabelSearchAdapter(query: string) {
+  const { data, isLoading } = useQuery({
+    queryKey: ['labels', 'search', query.toLowerCase()],
+    queryFn: () =>
+      apiRequest<{ labels: Array<{ id: number; name: string; slug: string }> }>(
+        `${API_ENDPOINTS.LABELS.LIST}?search=${encodeURIComponent(query)}&limit=10`
+      ),
+    enabled: query.length > 0,
+    staleTime: 5 * 60 * 1000,
+  })
+  return {
+    data: data?.labels?.map(l => ({ id: l.id, name: l.name })),
+    isLoading,
+  }
+}
+
+// ──────────────────────────────────────────────
+// FilterForm component
+// ──────────────────────────────────────────────
+
+interface FilterFormProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** If editing, pass the existing filter; for create, pass undefined */
+  filter?: NotificationFilter
+}
+
+export function FilterForm({ open, onOpenChange, filter }: FilterFormProps) {
+  const isEditing = !!filter
+
+  // Form state
+  const [name, setName] = useState('')
+  const [artistIds, setArtistIds] = useState<number[]>([])
+  const [venueIds, setVenueIds] = useState<number[]>([])
+  const [labelIds, setLabelIds] = useState<number[]>([])
+  const [tagIds, setTagIds] = useState<number[]>([])
+  const [excludeTagIds, setExcludeTagIds] = useState<number[]>([])
+  const [priceMaxCents, setPriceMaxCents] = useState<string>('')
+  const [notifyEmail, setNotifyEmail] = useState(true)
+  const [notifyInApp, setNotifyInApp] = useState(true)
+
+  const createFilter = useCreateFilter()
+  const updateFilter = useUpdateFilter()
+
+  const isMutating = createFilter.isPending || updateFilter.isPending
+
+  // Populate form when editing
+  useEffect(() => {
+    if (filter) {
+      setName(filter.name)
+      setArtistIds(filter.artist_ids ?? [])
+      setVenueIds(filter.venue_ids ?? [])
+      setLabelIds(filter.label_ids ?? [])
+      setTagIds(filter.tag_ids ?? [])
+      setExcludeTagIds(filter.exclude_tag_ids ?? [])
+      setPriceMaxCents(
+        filter.price_max_cents != null
+          ? String(filter.price_max_cents / 100)
+          : ''
+      )
+      setNotifyEmail(filter.notify_email)
+      setNotifyInApp(filter.notify_in_app)
+    } else {
+      // Reset for create
+      setName('')
+      setArtistIds([])
+      setVenueIds([])
+      setLabelIds([])
+      setTagIds([])
+      setExcludeTagIds([])
+      setPriceMaxCents('')
+      setNotifyEmail(true)
+      setNotifyInApp(true)
+    }
+  }, [filter, open])
+
+  const hasCriteria =
+    artistIds.length > 0 ||
+    venueIds.length > 0 ||
+    labelIds.length > 0 ||
+    tagIds.length > 0 ||
+    excludeTagIds.length > 0 ||
+    priceMaxCents !== ''
+
+  const canSubmit = name.trim().length > 0 && hasCriteria && !isMutating
+
+  const handleSubmit = () => {
+    if (!canSubmit) return
+
+    const priceValue = priceMaxCents.trim()
+      ? Math.round(parseFloat(priceMaxCents) * 100)
+      : undefined
+
+    if (isEditing && filter) {
+      updateFilter.mutate(
+        {
+          id: filter.id,
+          name: name.trim(),
+          artist_ids: artistIds.length > 0 ? artistIds : undefined,
+          venue_ids: venueIds.length > 0 ? venueIds : undefined,
+          label_ids: labelIds.length > 0 ? labelIds : undefined,
+          tag_ids: tagIds.length > 0 ? tagIds : undefined,
+          exclude_tag_ids: excludeTagIds.length > 0 ? excludeTagIds : undefined,
+          price_max_cents: priceValue ?? null,
+          notify_email: notifyEmail,
+          notify_in_app: notifyInApp,
+        },
+        {
+          onSuccess: () => onOpenChange(false),
+        }
+      )
+    } else {
+      const input: CreateFilterInput = {
+        name: name.trim(),
+        notify_email: notifyEmail,
+        notify_in_app: notifyInApp,
+      }
+      if (artistIds.length > 0) input.artist_ids = artistIds
+      if (venueIds.length > 0) input.venue_ids = venueIds
+      if (labelIds.length > 0) input.label_ids = labelIds
+      if (tagIds.length > 0) input.tag_ids = tagIds
+      if (excludeTagIds.length > 0) input.exclude_tag_ids = excludeTagIds
+      if (priceValue != null) input.price_max_cents = priceValue
+
+      createFilter.mutate(input, {
+        onSuccess: () => onOpenChange(false),
+      })
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg max-h-[85vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>
+            {isEditing ? 'Edit Notification Filter' : 'New Notification Filter'}
+          </DialogTitle>
+          <DialogDescription>
+            {isEditing
+              ? 'Update the criteria for this notification filter.'
+              : 'Create a filter to get notified when matching shows are approved. At least one criteria is required.'}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-5 py-4">
+          {/* Name */}
+          <div className="space-y-2">
+            <Label htmlFor="filter-name" className="text-sm font-medium">
+              Filter Name
+            </Label>
+            <Input
+              id="filter-name"
+              placeholder="e.g., PHX punk shows"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              maxLength={128}
+            />
+          </div>
+
+          {/* Artists */}
+          <MultiSelectSearch
+            label="Artists"
+            placeholder="Search artists..."
+            selectedIds={artistIds}
+            onSelectionChange={setArtistIds}
+            searchHook={useArtistSearchAdapter}
+          />
+
+          {/* Venues */}
+          <MultiSelectSearch
+            label="Venues"
+            placeholder="Search venues..."
+            selectedIds={venueIds}
+            onSelectionChange={setVenueIds}
+            searchHook={useVenueSearchAdapter}
+          />
+
+          {/* Labels */}
+          <MultiSelectSearch
+            label="Labels"
+            placeholder="Search labels..."
+            selectedIds={labelIds}
+            onSelectionChange={setLabelIds}
+            searchHook={useLabelSearchAdapter}
+          />
+
+          {/* Tags (include) */}
+          <MultiSelectSearch
+            label="Tags (match any)"
+            placeholder="Search tags..."
+            selectedIds={tagIds}
+            onSelectionChange={setTagIds}
+            searchHook={useTagSearchAdapter}
+          />
+
+          {/* Tags (exclude) */}
+          <MultiSelectSearch
+            label="Exclude Tags"
+            placeholder="Search tags to exclude..."
+            selectedIds={excludeTagIds}
+            onSelectionChange={setExcludeTagIds}
+            searchHook={useTagSearchAdapter}
+          />
+
+          {/* Max price */}
+          <div className="space-y-2">
+            <Label htmlFor="filter-price" className="text-sm font-medium">
+              Max Price
+            </Label>
+            <div className="relative">
+              <span className="absolute left-3 top-2.5 text-sm text-muted-foreground">$</span>
+              <Input
+                id="filter-price"
+                type="number"
+                min="0"
+                step="1"
+                placeholder="Leave blank for any price"
+                value={priceMaxCents}
+                onChange={e => setPriceMaxCents(e.target.value)}
+                className="pl-7"
+              />
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Enter 0 for free shows only, or leave blank for any price.
+            </p>
+          </div>
+
+          {/* Notification channels */}
+          <div className="space-y-3">
+            <Label className="text-sm font-medium">Notify via</Label>
+            <div className="flex items-center justify-between">
+              <span className="text-sm">Email</span>
+              <Switch
+                checked={notifyEmail}
+                onCheckedChange={setNotifyEmail}
+              />
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-muted-foreground">
+                In-app <span className="text-xs">(coming soon)</span>
+              </span>
+              <Switch
+                checked={notifyInApp}
+                onCheckedChange={setNotifyInApp}
+              />
+            </div>
+          </div>
+
+          {!hasCriteria && name.trim().length > 0 && (
+            <p className="text-xs text-amber-600 dark:text-amber-400">
+              Add at least one criteria (artist, venue, label, tag, or price) to create this filter.
+            </p>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex justify-end gap-2 pt-2">
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isMutating}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+          >
+            {isMutating ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                {isEditing ? 'Saving...' : 'Creating...'}
+              </>
+            ) : isEditing ? (
+              'Save Changes'
+            ) : (
+              'Create Filter'
+            )}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/features/notifications/components/FilterList.tsx
+++ b/frontend/features/notifications/components/FilterList.tsx
@@ -1,0 +1,100 @@
+'use client'
+
+import { useState } from 'react'
+import { Bell, Plus, Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { useNotificationFilters } from '../hooks'
+import { FilterCard } from './FilterCard'
+import { FilterForm } from './FilterForm'
+import type { NotificationFilter } from '../types'
+
+export function FilterList() {
+  const { data, isLoading, error } = useNotificationFilters()
+  const [showCreateForm, setShowCreateForm] = useState(false)
+  const [editingFilter, setEditingFilter] = useState<NotificationFilter | undefined>()
+
+  const filters = data?.filters ?? []
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-12">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="py-12 text-center">
+        <p className="text-sm text-destructive">
+          Failed to load notification filters. Please try again.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      {/* Header */}
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Notification Filters</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Get notified when new shows matching your criteria are approved.
+          </p>
+        </div>
+        <Button onClick={() => setShowCreateForm(true)} className="gap-1.5">
+          <Plus className="h-4 w-4" />
+          New Filter
+        </Button>
+      </div>
+
+      {/* Filter list */}
+      {filters.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-muted-foreground/25 bg-muted/30 py-12 text-center">
+          <Bell className="h-10 w-10 text-muted-foreground/40 mx-auto mb-3" />
+          <h3 className="text-sm font-medium mb-1">No notification filters</h3>
+          <p className="text-xs text-muted-foreground mb-4 max-w-sm mx-auto">
+            Create a filter to be notified when shows matching your interests are
+            added. You can also use the &quot;Notify me&quot; button on artist, venue, label, or
+            tag pages for quick setup.
+          </p>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setShowCreateForm(true)}
+            className="gap-1.5"
+          >
+            <Plus className="h-4 w-4" />
+            Create your first filter
+          </Button>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {filters.map(filter => (
+            <FilterCard
+              key={filter.id}
+              filter={filter}
+              onEdit={f => setEditingFilter(f)}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Create dialog */}
+      <FilterForm
+        open={showCreateForm}
+        onOpenChange={setShowCreateForm}
+      />
+
+      {/* Edit dialog */}
+      <FilterForm
+        open={!!editingFilter}
+        onOpenChange={open => {
+          if (!open) setEditingFilter(undefined)
+        }}
+        filter={editingFilter}
+      />
+    </div>
+  )
+}

--- a/frontend/features/notifications/components/NotifyMeButton.tsx
+++ b/frontend/features/notifications/components/NotifyMeButton.tsx
@@ -1,0 +1,170 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Bell, BellRing, Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { useAuthContext } from '@/lib/context/AuthContext'
+import {
+  useNotificationFilterCheck,
+  useQuickCreateFilter,
+  useDeleteFilter,
+} from '../hooks'
+import type { NotifyEntityType } from '../types'
+import { cn } from '@/lib/utils'
+
+interface NotifyMeButtonProps {
+  entityType: NotifyEntityType
+  entityId: number
+  entityName: string
+  /** Compact mode for tighter layouts */
+  compact?: boolean
+}
+
+const entityLabels: Record<NotifyEntityType, string> = {
+  artist: 'Notify me about',
+  venue: 'Notify me about shows at',
+  label: 'Notify me about',
+  tag: 'Notify me about',
+}
+
+export function NotifyMeButton({
+  entityType,
+  entityId,
+  entityName,
+  compact = false,
+}: NotifyMeButtonProps) {
+  const router = useRouter()
+  const { isAuthenticated } = useAuthContext()
+  const [isHovering, setIsHovering] = useState(false)
+
+  const { data: matchingFilter, hasFilter, isLoading: checkLoading } =
+    useNotificationFilterCheck(entityType, entityId)
+
+  const quickCreate = useQuickCreateFilter()
+  const deleteFilter = useDeleteFilter()
+
+  const isMutating = quickCreate.isPending || deleteFilter.isPending
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+
+    if (!isAuthenticated) {
+      router.push('/auth')
+      return
+    }
+
+    if (isMutating) return
+
+    if (hasFilter && matchingFilter) {
+      deleteFilter.mutate(matchingFilter.id)
+    } else {
+      quickCreate.mutate({ entityType, entityId })
+    }
+  }
+
+  // Don't render for unauthenticated users in loading state
+  if (!isAuthenticated) {
+    if (compact) {
+      return (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => router.push('/auth')}
+          className="h-7 px-2 gap-1 text-xs"
+          title="Sign in to get notifications"
+        >
+          <Bell className="h-3.5 w-3.5" />
+        </Button>
+      )
+    }
+    return (
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => router.push('/auth')}
+        className="gap-1.5"
+      >
+        <Bell className="h-4 w-4" />
+        <span>Notify me</span>
+      </Button>
+    )
+  }
+
+  if (checkLoading) {
+    if (compact) {
+      return (
+        <Button variant="ghost" size="sm" disabled className="h-7 px-2 gap-1">
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+        </Button>
+      )
+    }
+    return (
+      <Button variant="outline" size="sm" disabled className="gap-1.5">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        <span>Notify me</span>
+      </Button>
+    )
+  }
+
+  const showRemove = hasFilter && isHovering
+
+  if (compact) {
+    return (
+      <Button
+        variant={hasFilter ? 'secondary' : 'ghost'}
+        size="sm"
+        onClick={handleClick}
+        onMouseEnter={() => setIsHovering(true)}
+        onMouseLeave={() => setIsHovering(false)}
+        disabled={isMutating}
+        className={cn(
+          'h-7 px-2 gap-1 text-xs',
+          showRemove && 'text-destructive hover:text-destructive'
+        )}
+        title={
+          hasFilter
+            ? `Notifications on for ${entityName}`
+            : `${entityLabels[entityType]} ${entityName}`
+        }
+        aria-label={hasFilter ? 'Remove notification' : 'Notify me'}
+      >
+        {isMutating ? (
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+        ) : hasFilter ? (
+          <BellRing className="h-3.5 w-3.5" />
+        ) : (
+          <Bell className="h-3.5 w-3.5" />
+        )}
+      </Button>
+    )
+  }
+
+  return (
+    <Button
+      variant={hasFilter ? (showRemove ? 'destructive' : 'secondary') : 'outline'}
+      size="sm"
+      onClick={handleClick}
+      onMouseEnter={() => setIsHovering(true)}
+      onMouseLeave={() => setIsHovering(false)}
+      disabled={isMutating}
+      className="gap-1.5"
+    >
+      {isMutating ? (
+        <Loader2 className="h-4 w-4 animate-spin" />
+      ) : hasFilter ? (
+        <BellRing className="h-4 w-4" />
+      ) : (
+        <Bell className="h-4 w-4" />
+      )}
+      <span>
+        {showRemove
+          ? 'Remove notification'
+          : hasFilter
+            ? 'Notifications on'
+            : 'Notify me'}
+      </span>
+    </Button>
+  )
+}

--- a/frontend/features/notifications/components/index.ts
+++ b/frontend/features/notifications/components/index.ts
@@ -1,0 +1,4 @@
+export { FilterList } from './FilterList'
+export { FilterCard } from './FilterCard'
+export { FilterForm } from './FilterForm'
+export { NotifyMeButton } from './NotifyMeButton'

--- a/frontend/features/notifications/hooks/index.ts
+++ b/frontend/features/notifications/hooks/index.ts
@@ -1,0 +1,160 @@
+'use client'
+
+/**
+ * Notification Filter Hooks
+ *
+ * TanStack Query hooks for notification filter CRUD, quick-create, and filter checking.
+ */
+
+import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query'
+import { apiRequest, API_BASE_URL } from '@/lib/api'
+import { queryKeys } from '@/lib/queryClient'
+import type {
+  NotificationFilter,
+  CreateFilterInput,
+  UpdateFilterInput,
+  NotifyEntityType,
+} from '../types'
+
+// ──────────────────────────────────────────────
+// API endpoints (not in central API_ENDPOINTS yet)
+// ──────────────────────────────────────────────
+
+const FILTER_ENDPOINTS = {
+  LIST: `${API_BASE_URL}/me/notification-filters`,
+  CREATE: `${API_BASE_URL}/me/notification-filters`,
+  UPDATE: (id: number) => `${API_BASE_URL}/me/notification-filters/${id}`,
+  DELETE: (id: number) => `${API_BASE_URL}/me/notification-filters/${id}`,
+  QUICK: `${API_BASE_URL}/me/notification-filters/quick`,
+}
+
+// ──────────────────────────────────────────────
+// Queries
+// ──────────────────────────────────────────────
+
+/** Fetch all notification filters for the current user */
+export function useNotificationFilters() {
+  return useQuery({
+    queryKey: queryKeys.notificationFilters.all,
+    queryFn: () =>
+      apiRequest<{ filters: NotificationFilter[] }>(FILTER_ENDPOINTS.LIST),
+    staleTime: 5 * 60 * 1000,
+    placeholderData: keepPreviousData,
+  })
+}
+
+/**
+ * Check if the current user has an active notification filter
+ * matching a specific entity (artist/venue/label/tag).
+ * Returns the matching filter, or undefined if none.
+ */
+export function useNotificationFilterCheck(
+  entityType: NotifyEntityType,
+  entityId: number
+) {
+  const { data, ...rest } = useNotificationFilters()
+
+  // Find a filter that includes this entity in its criteria
+  const matchingFilter = data?.filters?.find(filter => {
+    if (!filter.is_active) return false
+
+    switch (entityType) {
+      case 'artist':
+        return filter.artist_ids?.includes(entityId) ?? false
+      case 'venue':
+        return filter.venue_ids?.includes(entityId) ?? false
+      case 'label':
+        return filter.label_ids?.includes(entityId) ?? false
+      case 'tag':
+        return filter.tag_ids?.includes(entityId) ?? false
+      default:
+        return false
+    }
+  })
+
+  return {
+    ...rest,
+    data: matchingFilter,
+    hasFilter: !!matchingFilter,
+  }
+}
+
+// ──────────────────────────────────────────────
+// Mutations
+// ──────────────────────────────────────────────
+
+/** Create a new notification filter */
+export function useCreateFilter() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (input: CreateFilterInput) =>
+      apiRequest<NotificationFilter>(FILTER_ENDPOINTS.CREATE, {
+        method: 'POST',
+        body: JSON.stringify(input),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.notificationFilters.all,
+      })
+    },
+  })
+}
+
+/** Update an existing notification filter */
+export function useUpdateFilter() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, ...input }: UpdateFilterInput & { id: number }) =>
+      apiRequest<NotificationFilter>(FILTER_ENDPOINTS.UPDATE(id), {
+        method: 'PATCH',
+        body: JSON.stringify(input),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.notificationFilters.all,
+      })
+    },
+  })
+}
+
+/** Delete a notification filter */
+export function useDeleteFilter() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (id: number) =>
+      apiRequest<void>(FILTER_ENDPOINTS.DELETE(id), {
+        method: 'DELETE',
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.notificationFilters.all,
+      })
+    },
+  })
+}
+
+/** Quick-create a notification filter from an entity shortcut */
+export function useQuickCreateFilter() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      entityType,
+      entityId,
+    }: {
+      entityType: NotifyEntityType
+      entityId: number
+    }) =>
+      apiRequest<NotificationFilter>(FILTER_ENDPOINTS.QUICK, {
+        method: 'POST',
+        body: JSON.stringify({
+          entity_type: entityType,
+          entity_id: entityId,
+        }),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.notificationFilters.all,
+      })
+    },
+  })
+}

--- a/frontend/features/notifications/index.ts
+++ b/frontend/features/notifications/index.ts
@@ -1,0 +1,34 @@
+// Public API for the notifications feature module.
+// Other features should import from '@/features/notifications', not from internal paths.
+
+export type {
+  NotificationFilter,
+  NotificationLogEntry,
+  CreateFilterInput,
+  UpdateFilterInput,
+  QuickCreateFilterInput,
+  NotifyEntityType,
+  FilterCity,
+} from './types'
+
+export {
+  NOTIFY_ENTITY_TYPES,
+  formatTimeAgo,
+  getFilterSummary,
+} from './types'
+
+export {
+  useNotificationFilters,
+  useNotificationFilterCheck,
+  useCreateFilter,
+  useUpdateFilter,
+  useDeleteFilter,
+  useQuickCreateFilter,
+} from './hooks'
+
+export {
+  FilterList,
+  FilterCard,
+  FilterForm,
+  NotifyMeButton,
+} from './components'

--- a/frontend/features/notifications/types.ts
+++ b/frontend/features/notifications/types.ts
@@ -1,0 +1,151 @@
+// Notification filter types — aligned with backend contracts/notification_filter.go response types.
+
+/** City criteria for notification filter */
+export interface FilterCity {
+  city: string
+  state: string
+}
+
+/** Notification filter response from the API */
+export interface NotificationFilter {
+  id: number
+  name: string
+  is_active: boolean
+  artist_ids?: number[] | null
+  venue_ids?: number[] | null
+  label_ids?: number[] | null
+  tag_ids?: number[] | null
+  exclude_tag_ids?: number[] | null
+  cities?: FilterCity[] | null
+  price_max_cents?: number | null
+  notify_email: boolean
+  notify_in_app: boolean
+  notify_push: boolean
+  match_count: number
+  last_matched_at?: string | null
+  created_at: string
+  updated_at: string
+}
+
+/** Notification log entry from the API */
+export interface NotificationLogEntry {
+  id: number
+  filter_id?: number | null
+  filter_name?: string
+  entity_type: string
+  entity_id: number
+  channel: string
+  sent_at: string
+  read_at?: string | null
+}
+
+/** Create filter request body */
+export interface CreateFilterInput {
+  name: string
+  artist_ids?: number[]
+  venue_ids?: number[]
+  label_ids?: number[]
+  tag_ids?: number[]
+  exclude_tag_ids?: number[]
+  cities?: FilterCity[]
+  price_max_cents?: number | null
+  notify_email?: boolean
+  notify_in_app?: boolean
+}
+
+/** Update filter request body (all fields optional) */
+export interface UpdateFilterInput {
+  name?: string
+  is_active?: boolean
+  artist_ids?: number[]
+  venue_ids?: number[]
+  label_ids?: number[]
+  tag_ids?: number[]
+  exclude_tag_ids?: number[]
+  cities?: FilterCity[]
+  price_max_cents?: number | null
+  notify_email?: boolean
+  notify_in_app?: boolean
+}
+
+/** Quick-create filter request body */
+export interface QuickCreateFilterInput {
+  entity_type: 'artist' | 'venue' | 'label' | 'tag'
+  entity_id: number
+}
+
+/** Entity types that support quick-create notification filters */
+export const NOTIFY_ENTITY_TYPES = ['artist', 'venue', 'label', 'tag'] as const
+export type NotifyEntityType = (typeof NOTIFY_ENTITY_TYPES)[number]
+
+/** Helper: format relative time for last_matched_at */
+export function formatTimeAgo(dateString: string): string {
+  const date = new Date(dateString)
+  const now = new Date()
+  const diffMs = now.getTime() - date.getTime()
+  const diffSeconds = Math.floor(diffMs / 1000)
+  const diffMinutes = Math.floor(diffSeconds / 60)
+  const diffHours = Math.floor(diffMinutes / 60)
+  const diffDays = Math.floor(diffHours / 24)
+  const diffWeeks = Math.floor(diffDays / 7)
+
+  if (diffSeconds < 60) return 'just now'
+  if (diffMinutes === 1) return '1 minute ago'
+  if (diffMinutes < 60) return `${diffMinutes} minutes ago`
+  if (diffHours === 1) return '1 hour ago'
+  if (diffHours < 24) return `${diffHours} hours ago`
+  if (diffDays === 1) return '1 day ago'
+  if (diffDays < 7) return `${diffDays} days ago`
+  if (diffWeeks === 1) return '1 week ago'
+  if (diffWeeks < 5) return `${diffWeeks} weeks ago`
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+
+/** Helper: build a human-readable summary of filter criteria */
+export function getFilterSummary(filter: NotificationFilter): string {
+  const parts: string[] = []
+
+  if (filter.artist_ids?.length) {
+    parts.push(
+      `${filter.artist_ids.length} ${filter.artist_ids.length === 1 ? 'artist' : 'artists'}`
+    )
+  }
+  if (filter.venue_ids?.length) {
+    parts.push(
+      `${filter.venue_ids.length} ${filter.venue_ids.length === 1 ? 'venue' : 'venues'}`
+    )
+  }
+  if (filter.label_ids?.length) {
+    parts.push(
+      `${filter.label_ids.length} ${filter.label_ids.length === 1 ? 'label' : 'labels'}`
+    )
+  }
+  if (filter.tag_ids?.length) {
+    parts.push(
+      `${filter.tag_ids.length} ${filter.tag_ids.length === 1 ? 'tag' : 'tags'}`
+    )
+  }
+  if (filter.exclude_tag_ids?.length) {
+    parts.push(
+      `excluding ${filter.exclude_tag_ids.length} ${filter.exclude_tag_ids.length === 1 ? 'tag' : 'tags'}`
+    )
+  }
+  if (filter.cities?.length) {
+    parts.push(
+      filter.cities.map(c => `${c.city}, ${c.state}`).join('; ')
+    )
+  }
+  if (filter.price_max_cents != null) {
+    if (filter.price_max_cents === 0) {
+      parts.push('free only')
+    } else {
+      parts.push(`max $${(filter.price_max_cents / 100).toFixed(0)}`)
+    }
+  }
+
+  return parts.length > 0 ? parts.join(' / ') : 'No criteria set'
+}

--- a/frontend/features/tags/components/TagDetail.tsx
+++ b/frontend/features/tags/components/TagDetail.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { ArrowLeft, Hash, Loader2 } from 'lucide-react'
+import { NotifyMeButton } from '@/features/notifications'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
@@ -103,6 +104,7 @@ export function TagDetail({ slug }: TagDetailProps) {
               {tag.is_official && (
                 <Badge variant="secondary">Official</Badge>
               )}
+              <NotifyMeButton entityType="tag" entityId={tag.id} entityName={tag.name} />
             </div>
 
             <div className="flex items-center gap-3 mb-4">

--- a/frontend/features/venues/components/VenueDetail.tsx
+++ b/frontend/features/venues/components/VenueDetail.tsx
@@ -11,6 +11,7 @@ import { useNavigationBreadcrumbs } from '@/lib/context/NavigationBreadcrumbCont
 import { useQueryClient } from '@tanstack/react-query'
 import { queryKeys } from '@/lib/queryClient'
 import { SocialLinks, RevisionHistory, FollowButton, Breadcrumb } from '@/components/shared'
+import { NotifyMeButton } from '@/features/notifications'
 import { VenueLocationCard } from './VenueLocationCard'
 import { VenueShowsList } from './VenueShowsList'
 import { VenueEditForm } from '@/components/forms/VenueEditForm'
@@ -164,6 +165,7 @@ export function VenueDetail({ venueId }: VenueDetailProps) {
                   )}
                   <FavoriteVenueButton venueId={venue.id} size="md" />
                   <FollowButton entityType="venues" entityId={venue.id} />
+                  <NotifyMeButton entityType="venue" entityId={venue.id} entityName={venue.name} />
                 </div>
                 <p className="text-muted-foreground mt-1">
                   {venue.city}, {venue.state}

--- a/frontend/lib/hooks/common/useSearch.test.tsx
+++ b/frontend/lib/hooks/common/useSearch.test.tsx
@@ -9,6 +9,7 @@ const mockApiRequest = vi.fn()
 // Mock the api module
 vi.mock('../../api', () => ({
   apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_BASE_URL: '',
   API_ENDPOINTS: {
     ARTISTS: {
       SEARCH: '/artists/search',

--- a/frontend/lib/queryClient.ts
+++ b/frontend/lib/queryClient.ts
@@ -371,6 +371,11 @@ export const queryKeys = {
       ['revisions', 'user', String(userId)] as const,
   },
 
+  // Notification filter queries
+  notificationFilters: {
+    all: ['notificationFilters'] as const,
+  },
+
   // System queries
   system: {
     health: ['system', 'health'] as const,
@@ -479,4 +484,8 @@ export const createInvalidateQueries = (queryClient: QueryClient) => ({
   // Invalidate revision queries
   revisions: () =>
     queryClient.invalidateQueries({ queryKey: ['revisions'] }),
+
+  // Invalidate notification filter queries
+  notificationFilters: () =>
+    queryClient.invalidateQueries({ queryKey: ['notificationFilters'] }),
 })


### PR DESCRIPTION
## Summary
- New `features/notifications/` module with types, 6 TanStack Query hooks, and 4 components (FilterList, FilterCard, FilterForm, NotifyMeButton)
- Filter management page at `/settings/notifications` with full CRUD, multi-select autocomplete for all criteria types (artists, venues, labels, tags), active/paused toggle, and delete confirmation
- "Notify Me" quick-create buttons on artist, venue, label, and tag detail pages — shows "Notifications on" if a matching filter already exists
- Sidebar nav entry and Cmd+K command palette entry for notification settings

Closes PSY-107

## Test plan
- [ ] Navigate to `/settings/notifications` — verify empty state with create button
- [ ] Create a filter with multiple criteria — verify multi-select autocomplete works
- [ ] Toggle filter active/paused — verify switch updates immediately
- [ ] Edit and delete a filter — verify dialogs and confirmation work
- [ ] Visit artist/venue/label/tag detail pages — verify "Notify me" button appears
- [ ] Click "Notify me" — verify filter is created and button changes to "Notifications on"
- [ ] Click "Notifications on" — verify it removes the filter
- [ ] Check sidebar nav and Cmd+K — verify "Notifications" entry appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)