### PR TITLE
Radio entities data model and migration

### DIFF
--- a/backend/db/migrations/000055_create_radio_entities.down.sql
+++ b/backend/db/migrations/000055_create_radio_entities.down.sql
@@ -1,0 +1,5 @@
+DROP TABLE IF EXISTS radio_artist_affinity;
+DROP TABLE IF EXISTS radio_plays;
+DROP TABLE IF EXISTS radio_episodes;
+DROP TABLE IF EXISTS radio_shows;
+DROP TABLE IF EXISTS radio_stations;

--- a/backend/db/migrations/000055_create_radio_entities.up.sql
+++ b/backend/db/migrations/000055_create_radio_entities.up.sql
@@ -1,0 +1,127 @@
+-- Radio entities: stations, shows, episodes, plays, and artist affinity
+
+CREATE TABLE radio_stations (
+    id BIGSERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    slug VARCHAR(255) NOT NULL UNIQUE,
+    description TEXT,
+    city VARCHAR(100),
+    state VARCHAR(100),
+    country VARCHAR(100) DEFAULT 'US',
+    timezone VARCHAR(50),
+    stream_url TEXT,
+    stream_urls JSONB DEFAULT '{}',
+    website VARCHAR(500),
+    donation_url VARCHAR(500),
+    donation_embed_url VARCHAR(500),
+    logo_url VARCHAR(500),
+    social JSONB DEFAULT '{}',
+    broadcast_type VARCHAR(20) NOT NULL DEFAULT 'both',
+    frequency_mhz DECIMAL(5,1),
+    playlist_source VARCHAR(50),
+    playlist_config JSONB,
+    last_playlist_fetch_at TIMESTAMPTZ,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE radio_shows (
+    id BIGSERIAL PRIMARY KEY,
+    station_id BIGINT NOT NULL REFERENCES radio_stations(id) ON DELETE CASCADE,
+    name VARCHAR(255) NOT NULL,
+    slug VARCHAR(255) NOT NULL UNIQUE,
+    host_name VARCHAR(255),
+    description TEXT,
+    schedule_display VARCHAR(255),
+    schedule JSONB,
+    genre_tags JSONB DEFAULT '[]',
+    archive_url VARCHAR(500),
+    image_url VARCHAR(500),
+    external_id VARCHAR(255),
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(station_id, external_id)
+);
+
+CREATE INDEX idx_radio_shows_station ON radio_shows(station_id);
+CREATE INDEX idx_radio_shows_active ON radio_shows(station_id) WHERE is_active = TRUE;
+
+CREATE TABLE radio_episodes (
+    id BIGSERIAL PRIMARY KEY,
+    show_id BIGINT NOT NULL REFERENCES radio_shows(id) ON DELETE CASCADE,
+    title VARCHAR(255),
+    air_date DATE NOT NULL,
+    air_time TIME,
+    duration_minutes INT,
+    description TEXT,
+    archive_url VARCHAR(500),
+    mixcloud_url VARCHAR(500),
+    external_id VARCHAR(255),
+    genre_tags JSONB,
+    mood_tags JSONB,
+    play_count INT NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(show_id, air_date, COALESCE(external_id, ''))
+);
+
+CREATE INDEX idx_radio_episodes_show ON radio_episodes(show_id, air_date DESC);
+CREATE INDEX idx_radio_episodes_date ON radio_episodes(air_date DESC);
+
+CREATE TABLE radio_plays (
+    id BIGSERIAL PRIMARY KEY,
+    episode_id BIGINT NOT NULL REFERENCES radio_episodes(id) ON DELETE CASCADE,
+    position INT NOT NULL DEFAULT 0,
+
+    -- Raw metadata from source (always stored, never overwritten)
+    artist_name VARCHAR(500) NOT NULL,
+    track_title VARCHAR(500),
+    album_title VARCHAR(500),
+    label_name VARCHAR(500),
+    release_year INT,
+
+    -- Curation signals
+    is_new BOOLEAN NOT NULL DEFAULT FALSE,
+    rotation_status VARCHAR(50),
+    dj_comment TEXT,
+    is_live_performance BOOLEAN NOT NULL DEFAULT FALSE,
+    is_request BOOLEAN NOT NULL DEFAULT FALSE,
+
+    -- Linked to our knowledge graph (populated by matching engine, nullable)
+    artist_id INT REFERENCES artists(id) ON DELETE SET NULL,
+    release_id INT REFERENCES releases(id) ON DELETE SET NULL,
+    label_id INT REFERENCES labels(id) ON DELETE SET NULL,
+
+    -- External IDs for cross-referencing and deduplication
+    musicbrainz_recording_id VARCHAR(36),
+    musicbrainz_artist_id VARCHAR(36),
+    musicbrainz_release_id VARCHAR(36),
+
+    -- Timing
+    air_timestamp TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_radio_plays_episode ON radio_plays(episode_id, position);
+CREATE INDEX idx_radio_plays_artist_id ON radio_plays(artist_id) WHERE artist_id IS NOT NULL;
+CREATE INDEX idx_radio_plays_release_id ON radio_plays(release_id) WHERE release_id IS NOT NULL;
+CREATE INDEX idx_radio_plays_label_id ON radio_plays(label_id) WHERE label_id IS NOT NULL;
+CREATE INDEX idx_radio_plays_artist_name ON radio_plays(artist_name);
+CREATE INDEX idx_radio_plays_is_new ON radio_plays(episode_id) WHERE is_new = TRUE;
+CREATE INDEX idx_radio_plays_mb_artist ON radio_plays(musicbrainz_artist_id) WHERE musicbrainz_artist_id IS NOT NULL;
+
+CREATE TABLE radio_artist_affinity (
+    artist_a_id INT NOT NULL REFERENCES artists(id) ON DELETE CASCADE,
+    artist_b_id INT NOT NULL REFERENCES artists(id) ON DELETE CASCADE,
+    co_occurrence_count INT NOT NULL DEFAULT 0,
+    show_count INT NOT NULL DEFAULT 0,
+    station_count INT NOT NULL DEFAULT 0,
+    last_co_occurrence DATE,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (artist_a_id, artist_b_id),
+    CHECK (artist_a_id < artist_b_id)
+);
+
+CREATE INDEX idx_radio_affinity_a ON radio_artist_affinity(artist_a_id);
+CREATE INDEX idx_radio_affinity_b ON radio_artist_affinity(artist_b_id);

--- a/backend/db/migrations/000055_create_radio_entities.up.sql
+++ b/backend/db/migrations/000055_create_radio_entities.up.sql
@@ -62,9 +62,10 @@ CREATE TABLE radio_episodes (
     genre_tags JSONB,
     mood_tags JSONB,
     play_count INT NOT NULL DEFAULT 0,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    UNIQUE(show_id, air_date, COALESCE(external_id, ''))
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
+
+CREATE UNIQUE INDEX idx_radio_episodes_unique ON radio_episodes(show_id, air_date, COALESCE(external_id, ''));
 
 CREATE INDEX idx_radio_episodes_show ON radio_episodes(show_id, air_date DESC);
 CREATE INDEX idx_radio_episodes_date ON radio_episodes(air_date DESC);

--- a/backend/internal/models/radio.go
+++ b/backend/internal/models/radio.go
@@ -1,0 +1,205 @@
+package models
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// Broadcast type constants for radio stations
+const (
+	BroadcastTypeTerrestrial = "terrestrial"
+	BroadcastTypeInternet    = "internet"
+	BroadcastTypeBoth        = "both"
+)
+
+// Playlist source constants for radio stations
+const (
+	PlaylistSourceKEXP      = "kexp_api"
+	PlaylistSourceNTS       = "nts_api"
+	PlaylistSourceWFMU      = "wfmu_scrape"
+	PlaylistSourceManual    = "manual"
+)
+
+// Rotation status constants for radio plays (KEXP)
+const (
+	RotationStatusHeavy          = "heavy"
+	RotationStatusMedium         = "medium"
+	RotationStatusLight          = "light"
+	RotationStatusRecommendedNew = "recommended_new"
+	RotationStatusLibrary        = "library"
+)
+
+// BroadcastTypes is the list of valid broadcast types
+var BroadcastTypes = []string{
+	BroadcastTypeTerrestrial,
+	BroadcastTypeInternet,
+	BroadcastTypeBoth,
+}
+
+// IsValidBroadcastType checks whether a string is a valid broadcast type
+func IsValidBroadcastType(s string) bool {
+	for _, bt := range BroadcastTypes {
+		if bt == s {
+			return true
+		}
+	}
+	return false
+}
+
+// RadioStation represents a radio station entity in the knowledge graph
+type RadioStation struct {
+	ID                  uint             `gorm:"primaryKey"`
+	Name                string           `gorm:"not null"`
+	Slug                string           `gorm:"not null;uniqueIndex"`
+	Description         *string          `gorm:"column:description"`
+	City                *string          `gorm:"column:city"`
+	State               *string          `gorm:"column:state"`
+	Country             *string          `gorm:"column:country;default:'US'"`
+	Timezone            *string          `gorm:"column:timezone"`
+	StreamURL           *string          `gorm:"column:stream_url"`
+	StreamURLs          *json.RawMessage `gorm:"column:stream_urls;type:jsonb;default:'{}'"`
+	Website             *string          `gorm:"column:website"`
+	DonationURL         *string          `gorm:"column:donation_url"`
+	DonationEmbedURL    *string          `gorm:"column:donation_embed_url"`
+	LogoURL             *string          `gorm:"column:logo_url"`
+	Social              *json.RawMessage `gorm:"column:social;type:jsonb;default:'{}'"`
+	BroadcastType       string           `gorm:"column:broadcast_type;not null;default:'both'"`
+	FrequencyMHz        *float64         `gorm:"column:frequency_mhz;type:decimal(5,1)"`
+	PlaylistSource      *string          `gorm:"column:playlist_source"`
+	PlaylistConfig      *json.RawMessage `gorm:"column:playlist_config;type:jsonb"`
+	LastPlaylistFetchAt *time.Time       `gorm:"column:last_playlist_fetch_at"`
+	IsActive            bool             `gorm:"column:is_active;not null;default:true"`
+	CreatedAt           time.Time        `gorm:"not null"`
+	UpdatedAt           time.Time        `gorm:"not null"`
+
+	// Relationships
+	Shows []RadioShow `gorm:"foreignKey:StationID"`
+}
+
+// TableName specifies the table name for RadioStation
+func (RadioStation) TableName() string {
+	return "radio_stations"
+}
+
+// RadioShow represents a recurring radio program on a station
+type RadioShow struct {
+	ID              uint             `gorm:"primaryKey"`
+	StationID       uint             `gorm:"column:station_id;not null"`
+	Name            string           `gorm:"not null"`
+	Slug            string           `gorm:"not null;uniqueIndex"`
+	HostName        *string          `gorm:"column:host_name"`
+	Description     *string          `gorm:"column:description"`
+	ScheduleDisplay *string          `gorm:"column:schedule_display"`
+	Schedule        *json.RawMessage `gorm:"column:schedule;type:jsonb"`
+	GenreTags       *json.RawMessage `gorm:"column:genre_tags;type:jsonb;default:'[]'"`
+	ArchiveURL      *string          `gorm:"column:archive_url"`
+	ImageURL        *string          `gorm:"column:image_url"`
+	ExternalID      *string          `gorm:"column:external_id"`
+	IsActive        bool             `gorm:"column:is_active;not null;default:true"`
+	CreatedAt       time.Time        `gorm:"not null"`
+	UpdatedAt       time.Time        `gorm:"not null"`
+
+	// Relationships
+	Station  RadioStation  `gorm:"foreignKey:StationID"`
+	Episodes []RadioEpisode `gorm:"foreignKey:ShowID"`
+}
+
+// TableName specifies the table name for RadioShow
+func (RadioShow) TableName() string {
+	return "radio_shows"
+}
+
+// RadioEpisode represents a single broadcast of a radio show
+type RadioEpisode struct {
+	ID              uint             `gorm:"primaryKey"`
+	ShowID          uint             `gorm:"column:show_id;not null"`
+	Title           *string          `gorm:"column:title"`
+	AirDate         string           `gorm:"column:air_date;type:date;not null"`
+	AirTime         *string          `gorm:"column:air_time;type:time"`
+	DurationMinutes *int             `gorm:"column:duration_minutes"`
+	Description     *string          `gorm:"column:description"`
+	ArchiveURL      *string          `gorm:"column:archive_url"`
+	MixcloudURL     *string          `gorm:"column:mixcloud_url"`
+	ExternalID      *string          `gorm:"column:external_id"`
+	GenreTags       *json.RawMessage `gorm:"column:genre_tags;type:jsonb"`
+	MoodTags        *json.RawMessage `gorm:"column:mood_tags;type:jsonb"`
+	PlayCount       int              `gorm:"column:play_count;not null;default:0"`
+	CreatedAt       time.Time        `gorm:"not null"`
+
+	// Relationships
+	Show  RadioShow   `gorm:"foreignKey:ShowID"`
+	Plays []RadioPlay `gorm:"foreignKey:EpisodeID"`
+}
+
+// TableName specifies the table name for RadioEpisode
+func (RadioEpisode) TableName() string {
+	return "radio_episodes"
+}
+
+// RadioPlay represents a single track played in a radio episode
+type RadioPlay struct {
+	ID       uint `gorm:"primaryKey"`
+	EpisodeID uint `gorm:"column:episode_id;not null"`
+	Position  int  `gorm:"column:position;not null;default:0"`
+
+	// Raw metadata from source (always stored, never overwritten)
+	ArtistName  string  `gorm:"column:artist_name;not null"`
+	TrackTitle  *string `gorm:"column:track_title"`
+	AlbumTitle  *string `gorm:"column:album_title"`
+	LabelName   *string `gorm:"column:label_name"`
+	ReleaseYear *int    `gorm:"column:release_year"`
+
+	// Curation signals
+	IsNew             bool    `gorm:"column:is_new;not null;default:false"`
+	RotationStatus    *string `gorm:"column:rotation_status"`
+	DJComment         *string `gorm:"column:dj_comment"`
+	IsLivePerformance bool    `gorm:"column:is_live_performance;not null;default:false"`
+	IsRequest         bool    `gorm:"column:is_request;not null;default:false"`
+
+	// Linked to our knowledge graph (populated by matching engine, nullable)
+	ArtistID  *uint `gorm:"column:artist_id"`
+	ReleaseID *uint `gorm:"column:release_id"`
+	LabelID   *uint `gorm:"column:label_id"`
+
+	// External IDs for cross-referencing and deduplication
+	MusicBrainzRecordingID *string `gorm:"column:musicbrainz_recording_id"`
+	MusicBrainzArtistID    *string `gorm:"column:musicbrainz_artist_id"`
+	MusicBrainzReleaseID   *string `gorm:"column:musicbrainz_release_id"`
+
+	// Timing
+	AirTimestamp *time.Time `gorm:"column:air_timestamp"`
+	CreatedAt    time.Time  `gorm:"not null"`
+
+	// Relationships
+	Episode RadioEpisode `gorm:"foreignKey:EpisodeID"`
+	Artist  *Artist      `gorm:"foreignKey:ArtistID"`
+	Release *Release     `gorm:"foreignKey:ReleaseID"`
+	Label   *Label       `gorm:"foreignKey:LabelID"`
+}
+
+// TableName specifies the table name for RadioPlay
+func (RadioPlay) TableName() string {
+	return "radio_plays"
+}
+
+// RadioArtistAffinity represents co-occurrence of two artists across radio playlists.
+// The composite primary key is (artist_a_id, artist_b_id).
+// A CHECK constraint ensures artist_a_id < artist_b_id (canonical ordering).
+type RadioArtistAffinity struct {
+	ArtistAID         uint       `gorm:"column:artist_a_id;primaryKey"`
+	ArtistBID         uint       `gorm:"column:artist_b_id;primaryKey"`
+	CoOccurrenceCount int        `gorm:"column:co_occurrence_count;not null;default:0"`
+	ShowCount         int        `gorm:"column:show_count;not null;default:0"`
+	StationCount      int        `gorm:"column:station_count;not null;default:0"`
+	LastCoOccurrence  *string    `gorm:"column:last_co_occurrence;type:date"`
+	UpdatedAt         time.Time  `gorm:"not null"`
+
+	// Relationships
+	ArtistA Artist `gorm:"foreignKey:ArtistAID"`
+	ArtistB Artist `gorm:"foreignKey:ArtistBID"`
+}
+
+// TableName specifies the table name for RadioArtistAffinity
+func (RadioArtistAffinity) TableName() string {
+	return "radio_artist_affinity"
+}

--- a/backend/internal/models/radio_test.go
+++ b/backend/internal/models/radio_test.go
@@ -1,0 +1,83 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// =============================================================================
+// TableName Tests
+// =============================================================================
+
+func TestRadioStationTableName(t *testing.T) {
+	assert.Equal(t, "radio_stations", RadioStation{}.TableName())
+}
+
+func TestRadioShowTableName(t *testing.T) {
+	assert.Equal(t, "radio_shows", RadioShow{}.TableName())
+}
+
+func TestRadioEpisodeTableName(t *testing.T) {
+	assert.Equal(t, "radio_episodes", RadioEpisode{}.TableName())
+}
+
+func TestRadioPlayTableName(t *testing.T) {
+	assert.Equal(t, "radio_plays", RadioPlay{}.TableName())
+}
+
+func TestRadioArtistAffinityTableName(t *testing.T) {
+	assert.Equal(t, "radio_artist_affinity", RadioArtistAffinity{}.TableName())
+}
+
+// =============================================================================
+// Broadcast Type Validation Tests
+// =============================================================================
+
+func TestIsValidBroadcastType_Valid(t *testing.T) {
+	for _, bt := range BroadcastTypes {
+		assert.True(t, IsValidBroadcastType(bt), "expected %q to be valid", bt)
+	}
+}
+
+func TestIsValidBroadcastType_Invalid(t *testing.T) {
+	assert.False(t, IsValidBroadcastType(""))
+	assert.False(t, IsValidBroadcastType("invalid"))
+	assert.False(t, IsValidBroadcastType("Both"))       // case-sensitive
+	assert.False(t, IsValidBroadcastType("TERRESTRIAL")) // case-sensitive
+	assert.False(t, IsValidBroadcastType("satellite"))
+}
+
+// =============================================================================
+// Broadcast Type Constants Tests
+// =============================================================================
+
+func TestBroadcastTypeConstants(t *testing.T) {
+	assert.Equal(t, "terrestrial", BroadcastTypeTerrestrial)
+	assert.Equal(t, "internet", BroadcastTypeInternet)
+	assert.Equal(t, "both", BroadcastTypeBoth)
+	assert.Len(t, BroadcastTypes, 3)
+}
+
+// =============================================================================
+// Playlist Source Constants Tests
+// =============================================================================
+
+func TestPlaylistSourceConstants(t *testing.T) {
+	assert.Equal(t, "kexp_api", PlaylistSourceKEXP)
+	assert.Equal(t, "nts_api", PlaylistSourceNTS)
+	assert.Equal(t, "wfmu_scrape", PlaylistSourceWFMU)
+	assert.Equal(t, "manual", PlaylistSourceManual)
+}
+
+// =============================================================================
+// Rotation Status Constants Tests
+// =============================================================================
+
+func TestRotationStatusConstants(t *testing.T) {
+	assert.Equal(t, "heavy", RotationStatusHeavy)
+	assert.Equal(t, "medium", RotationStatusMedium)
+	assert.Equal(t, "light", RotationStatusLight)
+	assert.Equal(t, "recommended_new", RotationStatusRecommendedNew)
+	assert.Equal(t, "library", RotationStatusLibrary)
+}


### PR DESCRIPTION
## Summary
- Migration 000055: five new tables — `radio_stations`, `radio_shows`, `radio_episodes`, `radio_plays`, `radio_artist_affinity` — with all constraints, indexes, and FKs per the design doc
- GORM models in `models/radio.go` with `*json.RawMessage` for JSONB columns, `TableName()` methods, relationship definitions, and validation helpers
- 10 model tests passing, `go vet` and `go build` clean

Closes PSY-160

## Test plan
- [ ] Run migration 000055 up — verify all 5 tables created with correct columns and constraints
- [ ] Run migration 000055 down — verify clean teardown in reverse dependency order
- [ ] `go test ./internal/models/` — verify all 10 radio model tests pass
- [ ] `go vet ./...` — verify no warnings
- [ ] Verify UNIQUE constraints: (station_id, external_id) on radio_shows, (show_id, air_date, external_id) on radio_episodes
- [ ] Verify CHECK constraint on radio_artist_affinity (artist_a_id < artist_b_id)

🤖 Generated with [Claude Code](https://claude.com/claude-code)