### PR TITLE
Add stat card trend indicators to admin dashboard

### DIFF
--- a/backend/internal/services/admin/stats.go
+++ b/backend/internal/services/admin/stats.go
@@ -71,5 +71,45 @@ func (s *AdminStatsService) GetDashboardStats() (*contracts.AdminDashboardStats,
 		return nil, err
 	}
 
+	// Period-over-period trends (current 7 days vs previous 7 days)
+	fourteenDaysAgo := time.Now().AddDate(0, 0, -14)
+
+	var showsCurrent, showsPrevious int64
+	if err := s.db.Model(&models.Show{}).Where("status = ? AND created_at > ?", models.ShowStatusApproved, sevenDaysAgo).Count(&showsCurrent).Error; err != nil {
+		// Log but don't fail — trends are non-critical
+		showsCurrent = 0
+	}
+	if err := s.db.Model(&models.Show{}).Where("status = ? AND created_at > ? AND created_at <= ?", models.ShowStatusApproved, fourteenDaysAgo, sevenDaysAgo).Count(&showsPrevious).Error; err != nil {
+		showsPrevious = 0
+	}
+	stats.TotalShowsTrend = showsCurrent - showsPrevious
+
+	var venuesCurrent, venuesPrevious int64
+	if err := s.db.Model(&models.Venue{}).Where("verified = ? AND created_at > ?", true, sevenDaysAgo).Count(&venuesCurrent).Error; err != nil {
+		venuesCurrent = 0
+	}
+	if err := s.db.Model(&models.Venue{}).Where("verified = ? AND created_at > ? AND created_at <= ?", true, fourteenDaysAgo, sevenDaysAgo).Count(&venuesPrevious).Error; err != nil {
+		venuesPrevious = 0
+	}
+	stats.TotalVenuesTrend = venuesCurrent - venuesPrevious
+
+	var artistsCurrent, artistsPrevious int64
+	if err := s.db.Model(&models.Artist{}).Where("created_at > ?", sevenDaysAgo).Count(&artistsCurrent).Error; err != nil {
+		artistsCurrent = 0
+	}
+	if err := s.db.Model(&models.Artist{}).Where("created_at > ? AND created_at <= ?", fourteenDaysAgo, sevenDaysAgo).Count(&artistsPrevious).Error; err != nil {
+		artistsPrevious = 0
+	}
+	stats.TotalArtistsTrend = artistsCurrent - artistsPrevious
+
+	var usersCurrent, usersPrevious int64
+	if err := s.db.Model(&models.User{}).Where("created_at > ?", sevenDaysAgo).Count(&usersCurrent).Error; err != nil {
+		usersCurrent = 0
+	}
+	if err := s.db.Model(&models.User{}).Where("created_at > ? AND created_at <= ?", fourteenDaysAgo, sevenDaysAgo).Count(&usersPrevious).Error; err != nil {
+		usersPrevious = 0
+	}
+	stats.TotalUsersTrend = usersCurrent - usersPrevious
+
 	return stats, nil
 }

--- a/backend/internal/services/admin/stats_test.go
+++ b/backend/internal/services/admin/stats_test.go
@@ -201,6 +201,27 @@ func (suite *AdminStatsServiceIntegrationTestSuite) createUserWithTime(email str
 	return user
 }
 
+func (suite *AdminStatsServiceIntegrationTestSuite) createVenueWithTime(name, city, state string, verified bool, createdAt time.Time) *models.Venue {
+	venue := &models.Venue{
+		Name:     name,
+		City:     city,
+		State:    state,
+		Verified: verified,
+	}
+	err := suite.db.Create(venue).Error
+	suite.Require().NoError(err)
+	suite.db.Exec("UPDATE venues SET created_at = ? WHERE id = ?", createdAt, venue.ID)
+	return venue
+}
+
+func (suite *AdminStatsServiceIntegrationTestSuite) createArtistWithTime(name string, createdAt time.Time) *models.Artist {
+	artist := &models.Artist{Name: name}
+	err := suite.db.Create(artist).Error
+	suite.Require().NoError(err)
+	suite.db.Exec("UPDATE artists SET created_at = ? WHERE id = ?", createdAt, artist.ID)
+	return artist
+}
+
 // =============================================================================
 // TESTS
 // =============================================================================
@@ -381,4 +402,57 @@ func (suite *AdminStatsServiceIntegrationTestSuite) TestGetDashboardStats_FullSc
 	suite.Equal(int64(3), stats.TotalUsers)
 	suite.Equal(int64(2), stats.ShowsSubmittedLast7Days) // Recent approved + pending
 	suite.Equal(int64(2), stats.UsersRegisteredLast7Days)
+}
+
+func (suite *AdminStatsServiceIntegrationTestSuite) TestGetDashboardStats_Trends() {
+	now := time.Now()
+	threeDaysAgo := now.AddDate(0, 0, -3)   // within current 7 days
+	tenDaysAgo := now.AddDate(0, 0, -10)    // within previous 7 days (14-7 days ago)
+	twentyDaysAgo := now.AddDate(0, 0, -20) // older than 14 days (should not count)
+
+	// Shows: 2 approved in current week, 1 approved in previous week => trend = +1
+	suite.createShowWithTime("Current Show 1", models.ShowStatusApproved, threeDaysAgo)
+	suite.createShowWithTime("Current Show 2", models.ShowStatusApproved, now)
+	suite.createShowWithTime("Previous Show", models.ShowStatusApproved, tenDaysAgo)
+	suite.createShowWithTime("Old Show", models.ShowStatusApproved, twentyDaysAgo)
+	// Pending shows should not count for trend
+	suite.createShowWithTime("Pending Current", models.ShowStatusPending, threeDaysAgo)
+
+	// Venues: 1 verified in current week, 2 verified in previous week => trend = -1
+	suite.createVenueWithTime("Current Venue", "NYC", "NY", true, threeDaysAgo)
+	suite.createVenueWithTime("Previous Venue 1", "LA", "CA", true, tenDaysAgo)
+	suite.createVenueWithTime("Previous Venue 2", "CHI", "IL", true, tenDaysAgo)
+	// Unverified venue should not count
+	suite.createVenueWithTime("Unverified Current", "SF", "CA", false, threeDaysAgo)
+
+	// Artists: 3 in current week, 1 in previous week => trend = +2
+	suite.createArtistWithTime("Current Artist 1", threeDaysAgo)
+	suite.createArtistWithTime("Current Artist 2", now)
+	suite.createArtistWithTime("Current Artist 3", now)
+	suite.createArtistWithTime("Previous Artist", tenDaysAgo)
+	suite.createArtistWithTime("Old Artist", twentyDaysAgo)
+
+	// Users: 1 in current week, 1 in previous week => trend = 0
+	suite.createUserWithTime("current@test.com", threeDaysAgo)
+	suite.createUserWithTime("previous@test.com", tenDaysAgo)
+	suite.createUserWithTime("old@test.com", twentyDaysAgo)
+
+	stats, err := suite.service.GetDashboardStats()
+	suite.Require().NoError(err)
+
+	suite.Equal(int64(1), stats.TotalShowsTrend, "shows trend: 2 current - 1 previous = +1")
+	suite.Equal(int64(-1), stats.TotalVenuesTrend, "venues trend: 1 current - 2 previous = -1")
+	suite.Equal(int64(2), stats.TotalArtistsTrend, "artists trend: 3 current - 1 previous = +2")
+	suite.Equal(int64(0), stats.TotalUsersTrend, "users trend: 1 current - 1 previous = 0")
+}
+
+func (suite *AdminStatsServiceIntegrationTestSuite) TestGetDashboardStats_TrendsEmpty() {
+	// With no data, all trends should be 0
+	stats, err := suite.service.GetDashboardStats()
+	suite.Require().NoError(err)
+
+	suite.Equal(int64(0), stats.TotalShowsTrend)
+	suite.Equal(int64(0), stats.TotalVenuesTrend)
+	suite.Equal(int64(0), stats.TotalArtistsTrend)
+	suite.Equal(int64(0), stats.TotalUsersTrend)
 }

--- a/backend/internal/services/contracts/admin.go
+++ b/backend/internal/services/contracts/admin.go
@@ -26,6 +26,12 @@ type AdminDashboardStats struct {
 	// Recent activity (last 7 days)
 	ShowsSubmittedLast7Days  int64 `json:"shows_submitted_last_7_days"`
 	UsersRegisteredLast7Days int64 `json:"users_registered_last_7_days"`
+
+	// Period-over-period trends (current 7 days vs previous 7 days)
+	TotalShowsTrend   int64 `json:"total_shows_trend"`   // delta: current - previous
+	TotalVenuesTrend  int64 `json:"total_venues_trend"`
+	TotalArtistsTrend int64 `json:"total_artists_trend"`
+	TotalUsersTrend   int64 `json:"total_users_trend"`
 }
 
 // ──────────────────────────────────────────────

--- a/frontend/app/admin/dashboard/_components/AdminDashboard.tsx
+++ b/frontend/app/admin/dashboard/_components/AdminDashboard.tsx
@@ -10,6 +10,7 @@ import {
   Mic2,
   Users,
   TrendingUp,
+  TrendingDown,
   UserPlus,
   CircleCheck,
   type LucideIcon,
@@ -23,10 +24,11 @@ interface StatCardProps {
   value: number
   icon: LucideIcon
   highlight?: boolean
+  trend?: number
   onClick?: () => void
 }
 
-function StatCard({ label, value, icon: Icon, highlight, onClick }: StatCardProps) {
+function StatCard({ label, value, icon: Icon, highlight, trend, onClick }: StatCardProps) {
   const isZeroHighlight = highlight && value === 0
   return (
     <Card
@@ -57,6 +59,14 @@ function StatCard({ label, value, icon: Icon, highlight, onClick }: StatCardProp
             {value.toLocaleString()}
           </p>
           <p className="text-sm text-muted-foreground leading-tight">{label}</p>
+          {trend !== undefined && trend !== 0 && (
+            <span className={`flex items-center gap-1 text-xs ${
+              trend > 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-500 dark:text-red-400'
+            }`}>
+              {trend > 0 ? <TrendingUp className="h-3 w-3" /> : <TrendingDown className="h-3 w-3" />}
+              {trend > 0 ? '+' : ''}{trend} this week
+            </span>
+          )}
         </div>
       </CardContent>
     </Card>
@@ -171,24 +181,28 @@ export function AdminDashboard({ onNavigate }: AdminDashboardProps) {
             label="Approved Shows"
             value={stats.total_shows}
             icon={Music}
+            trend={stats.total_shows_trend}
             onClick={onNavigate ? () => onNavigate('pending-shows') : undefined}
           />
           <StatCard
             label="Verified Venues"
             value={stats.total_venues}
             icon={Building2}
+            trend={stats.total_venues_trend}
             onClick={onNavigate ? () => onNavigate('unverified-venues') : undefined}
           />
           <StatCard
             label="Artists"
             value={stats.total_artists}
             icon={Mic2}
+            trend={stats.total_artists_trend}
             onClick={onNavigate ? () => onNavigate('artists-admin') : undefined}
           />
           <StatCard
             label="Users"
             value={stats.total_users}
             icon={Users}
+            trend={stats.total_users_trend}
             onClick={onNavigate ? () => onNavigate('users') : undefined}
           />
         </div>

--- a/frontend/lib/types/adminStats.ts
+++ b/frontend/lib/types/adminStats.ts
@@ -9,4 +9,8 @@ export interface AdminDashboardStats {
   total_users: number
   shows_submitted_last_7_days: number
   users_registered_last_7_days: number
+  total_shows_trend: number
+  total_venues_trend: number
+  total_artists_trend: number
+  total_users_trend: number
 }


### PR DESCRIPTION
## Summary
- Extends `GET /admin/stats` with period-over-period trend data (current 7 days vs previous 7 days) for shows, venues, artists, and users
- Platform stat cards now display subtle trend badges: green "+N this week" for growth, red "N this week" for decline, hidden when zero
- 2 new integration tests verifying trend calculations with data spanning multiple time periods

Closes PSY-42

## Test plan
- [ ] Verify trend values are correct in API response (compare 7-day windows)
- [ ] Verify trend badges appear on Platform stat cards with correct colors
- [ ] Verify zero trends show no badge
- [ ] Verify trend query failures don't break the overall stats response
- [ ] Backend tests pass: `go test ./internal/services/admin/ -run TestAdminStats`

🤖 Generated with [Claude Code](https://claude.com/claude-code)