### PR TITLE
Add frontend unit test coverage (25 files, 239 tests)

### DIFF
--- a/frontend/components/shared/FollowButton.test.tsx
+++ b/frontend/components/shared/FollowButton.test.tsx
@@ -1,0 +1,174 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const mockPush = vi.fn()
+const mockFollowMutate = vi.fn()
+const mockUnfollowMutate = vi.fn()
+let mockIsAuthenticated = true
+let mockFollowStatusData: { follower_count: number; is_following: boolean } | undefined
+let mockStatusLoading = false
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}))
+
+vi.mock('@/lib/context/AuthContext', () => ({
+  useAuthContext: () => ({ isAuthenticated: mockIsAuthenticated }),
+}))
+
+vi.mock('@/lib/hooks/common/useFollow', () => ({
+  useFollowStatus: () => ({
+    data: mockFollowStatusData,
+    isLoading: mockStatusLoading,
+  }),
+  useFollow: () => ({
+    mutate: mockFollowMutate,
+    isPending: false,
+  }),
+  useUnfollow: () => ({
+    mutate: mockUnfollowMutate,
+    isPending: false,
+  }),
+}))
+
+import { FollowButton } from './FollowButton'
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+}
+
+describe('FollowButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsAuthenticated = true
+    mockFollowStatusData = { follower_count: 10, is_following: false }
+    mockStatusLoading = false
+  })
+
+  it('renders "Follow" text in non-compact mode when not following', () => {
+    render(
+      <FollowButton entityType="artists" entityId={1} />,
+      { wrapper: createWrapper() }
+    )
+
+    expect(screen.getByText('Follow')).toBeInTheDocument()
+  })
+
+  it('renders "Following" text when following', () => {
+    mockFollowStatusData = { follower_count: 10, is_following: true }
+
+    render(
+      <FollowButton entityType="artists" entityId={1} />,
+      { wrapper: createWrapper() }
+    )
+
+    expect(screen.getByText('Following')).toBeInTheDocument()
+  })
+
+  it('renders follower count when > 0', () => {
+    render(
+      <FollowButton entityType="artists" entityId={1} />,
+      { wrapper: createWrapper() }
+    )
+
+    expect(screen.getByText('10')).toBeInTheDocument()
+  })
+
+  it('calls follow.mutate when clicking while not following', () => {
+    render(
+      <FollowButton entityType="artists" entityId={1} />,
+      { wrapper: createWrapper() }
+    )
+
+    fireEvent.click(screen.getByRole('button'))
+    expect(mockFollowMutate).toHaveBeenCalledWith({ entityType: 'artists', entityId: 1 })
+  })
+
+  it('calls unfollow.mutate when clicking while following', () => {
+    mockFollowStatusData = { follower_count: 10, is_following: true }
+
+    render(
+      <FollowButton entityType="artists" entityId={1} />,
+      { wrapper: createWrapper() }
+    )
+
+    fireEvent.click(screen.getByRole('button'))
+    expect(mockUnfollowMutate).toHaveBeenCalledWith({ entityType: 'artists', entityId: 1 })
+  })
+
+  it('redirects to /auth when not authenticated', () => {
+    mockIsAuthenticated = false
+
+    render(
+      <FollowButton entityType="artists" entityId={1} />,
+      { wrapper: createWrapper() }
+    )
+
+    fireEvent.click(screen.getByRole('button'))
+    expect(mockPush).toHaveBeenCalledWith('/auth')
+    expect(mockFollowMutate).not.toHaveBeenCalled()
+  })
+
+  it('uses followData prop over fetched data', () => {
+    mockFollowStatusData = { follower_count: 10, is_following: false }
+
+    render(
+      <FollowButton
+        entityType="artists"
+        entityId={1}
+        followData={{ follower_count: 42, is_following: true }}
+      />,
+      { wrapper: createWrapper() }
+    )
+
+    expect(screen.getByText('42')).toBeInTheDocument()
+    expect(screen.getByText('Following')).toBeInTheDocument()
+  })
+
+  it('renders compact mode with aria-label', () => {
+    render(
+      <FollowButton entityType="artists" entityId={1} compact />,
+      { wrapper: createWrapper() }
+    )
+
+    const button = screen.getByRole('button', { name: 'Follow' })
+    expect(button).toBeInTheDocument()
+  })
+
+  it('renders loading spinner when status is loading and no followData', () => {
+    mockStatusLoading = true
+    mockFollowStatusData = undefined
+
+    render(
+      <FollowButton entityType="artists" entityId={1} />,
+      { wrapper: createWrapper() }
+    )
+
+    // In non-compact mode, should show "Follow" text with a spinner
+    expect(screen.getByText('Follow')).toBeInTheDocument()
+  })
+
+  it('does not show loading spinner when followData is provided', () => {
+    mockStatusLoading = true
+    mockFollowStatusData = undefined
+
+    render(
+      <FollowButton
+        entityType="artists"
+        entityId={1}
+        followData={{ follower_count: 5, is_following: false }}
+      />,
+      { wrapper: createWrapper() }
+    )
+
+    expect(screen.getByText('Follow')).toBeInTheDocument()
+    expect(screen.getByText('5')).toBeInTheDocument()
+  })
+})

--- a/frontend/features/collections/components/CollectionCard.test.tsx
+++ b/frontend/features/collections/components/CollectionCard.test.tsx
@@ -1,0 +1,130 @@
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+// Mock next/link
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...props }: { children: React.ReactNode; href: string; [key: string]: unknown }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}))
+
+import { CollectionCard } from './CollectionCard'
+import type { Collection } from '../types'
+
+const baseCollection: Collection = {
+  id: 1,
+  title: 'Arizona Indie Essentials',
+  slug: 'arizona-indie-essentials',
+  description: 'The best indie bands from AZ',
+  is_public: true,
+  collaborative: false,
+  is_featured: false,
+  cover_image_url: null,
+  creator_id: 1,
+  creator_name: 'testuser',
+  item_count: 5,
+  subscriber_count: 10,
+  created_at: '2025-01-01T00:00:00Z',
+  updated_at: '2025-01-01T00:00:00Z',
+}
+
+describe('CollectionCard', () => {
+  it('renders collection title as a link', () => {
+    render(<CollectionCard collection={baseCollection} />)
+
+    const link = screen.getByRole('link', { name: 'Arizona Indie Essentials' })
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', '/collections/arizona-indie-essentials')
+  })
+
+  it('renders description when present', () => {
+    render(<CollectionCard collection={baseCollection} />)
+
+    expect(screen.getByText('The best indie bands from AZ')).toBeInTheDocument()
+  })
+
+  it('does not render description when absent', () => {
+    const collection = { ...baseCollection, description: null as unknown as string }
+    render(<CollectionCard collection={collection} />)
+
+    expect(screen.queryByText('The best indie bands from AZ')).not.toBeInTheDocument()
+  })
+
+  it('renders creator name', () => {
+    render(<CollectionCard collection={baseCollection} />)
+
+    expect(screen.getByText('by testuser')).toBeInTheDocument()
+  })
+
+  it('renders item count (plural)', () => {
+    render(<CollectionCard collection={baseCollection} />)
+
+    expect(screen.getByText('5 items')).toBeInTheDocument()
+  })
+
+  it('renders singular item count', () => {
+    const collection = { ...baseCollection, item_count: 1 }
+    render(<CollectionCard collection={collection} />)
+
+    expect(screen.getByText('1 item')).toBeInTheDocument()
+  })
+
+  it('renders subscriber count when > 0', () => {
+    render(<CollectionCard collection={baseCollection} />)
+
+    expect(screen.getByText('10 subscribers')).toBeInTheDocument()
+  })
+
+  it('renders singular subscriber count', () => {
+    const collection = { ...baseCollection, subscriber_count: 1 }
+    render(<CollectionCard collection={collection} />)
+
+    expect(screen.getByText('1 subscriber')).toBeInTheDocument()
+  })
+
+  it('does not render subscriber count when 0', () => {
+    const collection = { ...baseCollection, subscriber_count: 0 }
+    render(<CollectionCard collection={collection} />)
+
+    expect(screen.queryByText('0 subscribers')).not.toBeInTheDocument()
+    expect(screen.queryByText('subscribers')).not.toBeInTheDocument()
+  })
+
+  it('shows Featured badge when is_featured', () => {
+    const collection = { ...baseCollection, is_featured: true }
+    render(<CollectionCard collection={collection} />)
+
+    expect(screen.getByText('Featured')).toBeInTheDocument()
+  })
+
+  it('does not show Featured badge when not featured', () => {
+    render(<CollectionCard collection={baseCollection} />)
+
+    expect(screen.queryByText('Featured')).not.toBeInTheDocument()
+  })
+
+  it('shows Collaborative badge when collaborative', () => {
+    const collection = { ...baseCollection, collaborative: true }
+    render(<CollectionCard collection={collection} />)
+
+    expect(screen.getByText('Collaborative')).toBeInTheDocument()
+  })
+
+  it('does not show Collaborative badge when not collaborative', () => {
+    render(<CollectionCard collection={baseCollection} />)
+
+    expect(screen.queryByText('Collaborative')).not.toBeInTheDocument()
+  })
+
+  it('renders cover image when URL is provided', () => {
+    const collection = { ...baseCollection, cover_image_url: 'https://example.com/cover.jpg' }
+    render(<CollectionCard collection={collection} />)
+
+    const img = screen.getByRole('img', { name: 'Arizona Indie Essentials cover' })
+    expect(img).toBeInTheDocument()
+    expect(img).toHaveAttribute('src', 'https://example.com/cover.jpg')
+  })
+})

--- a/frontend/features/collections/hooks/index.test.tsx
+++ b/frontend/features/collections/hooks/index.test.tsx
@@ -1,0 +1,394 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const mockApiRequest = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    COLLECTIONS: {
+      LIST: '/collections',
+      DETAIL: (slug: string) => `/collections/${slug}`,
+      STATS: (slug: string) => `/collections/${slug}/stats`,
+      ITEMS: (slug: string) => `/collections/${slug}/items`,
+      ITEM: (slug: string, itemId: number) => `/collections/${slug}/items/${itemId}`,
+      SUBSCRIBE: (slug: string) => `/collections/${slug}/subscribe`,
+      FEATURE: (slug: string) => `/collections/${slug}/feature`,
+      MY: '/auth/collections',
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    collections: {
+      all: ['collections'],
+      detail: (slug: string) => ['collections', 'detail', slug],
+      stats: (slug: string) => ['collections', 'stats', slug],
+      my: ['collections', 'my'],
+    },
+  },
+  createInvalidateQueries: () => ({
+    collections: vi.fn(),
+  }),
+}))
+
+import {
+  useCollections,
+  useCollection,
+  useCollectionStats,
+  useMyCollections,
+  useSetFeatured,
+  useCreateCollection,
+  useUpdateCollection,
+  useDeleteCollection,
+  useAddCollectionItem,
+  useRemoveCollectionItem,
+  useSubscribeCollection,
+  useUnsubscribeCollection,
+} from './index'
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+  }
+}
+
+describe('Collection query hooks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  describe('useCollections', () => {
+    it('fetches collections list', async () => {
+      const mockResponse = {
+        collections: [{ id: 1, title: 'Test Collection', slug: 'test' }],
+        total: 1,
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(() => useCollections(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/collections')
+      expect(result.current.data?.collections).toHaveLength(1)
+    })
+
+    it('handles empty collections list', async () => {
+      mockApiRequest.mockResolvedValueOnce({ collections: [], total: 0 })
+
+      const { result } = renderHook(() => useCollections(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      expect(result.current.data?.total).toBe(0)
+    })
+  })
+
+  describe('useCollection', () => {
+    it('fetches a single collection by slug', async () => {
+      const mockDetail = { id: 1, title: 'My Collection', slug: 'my-collection', items: [] }
+      mockApiRequest.mockResolvedValueOnce(mockDetail)
+
+      const { result } = renderHook(() => useCollection('my-collection'), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      expect(mockApiRequest).toHaveBeenCalledWith('/collections/my-collection')
+    })
+
+    it('does not fetch when slug is empty', () => {
+      const { result } = renderHook(() => useCollection(''), {
+        wrapper: createWrapper(),
+      })
+
+      expect(result.current.fetchStatus).toBe('idle')
+      expect(mockApiRequest).not.toHaveBeenCalled()
+    })
+
+    it('does not fetch when enabled is false', () => {
+      const { result } = renderHook(
+        () => useCollection('my-slug', { enabled: false }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(result.current.fetchStatus).toBe('idle')
+      expect(mockApiRequest).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('useCollectionStats', () => {
+    it('fetches stats for a collection', async () => {
+      const mockStats = { item_count: 5, subscriber_count: 10 }
+      mockApiRequest.mockResolvedValueOnce(mockStats)
+
+      const { result } = renderHook(() => useCollectionStats('my-collection'), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      expect(mockApiRequest).toHaveBeenCalledWith('/collections/my-collection/stats')
+    })
+
+    it('does not fetch when slug is empty', () => {
+      const { result } = renderHook(() => useCollectionStats(''), {
+        wrapper: createWrapper(),
+      })
+
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+  })
+
+  describe('useMyCollections', () => {
+    it('fetches user collections', async () => {
+      mockApiRequest.mockResolvedValueOnce({ collections: [], total: 0 })
+
+      const { result } = renderHook(() => useMyCollections(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      expect(mockApiRequest).toHaveBeenCalledWith('/auth/collections')
+    })
+  })
+})
+
+describe('Collection mutation hooks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  describe('useCreateCollection', () => {
+    it('creates a collection with POST', async () => {
+      mockApiRequest.mockResolvedValueOnce({ id: 1, title: 'New', slug: 'new' })
+
+      const { result } = renderHook(() => useCreateCollection(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({
+          title: 'New',
+          is_public: true,
+          collaborative: false,
+        })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/collections',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ title: 'New', is_public: true, collaborative: false }),
+        })
+      )
+    })
+  })
+
+  describe('useUpdateCollection', () => {
+    it('updates a collection with PUT', async () => {
+      mockApiRequest.mockResolvedValueOnce({ id: 1, title: 'Updated', slug: 'test' })
+
+      const { result } = renderHook(() => useUpdateCollection(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({ slug: 'test', title: 'Updated' })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/collections/test',
+        expect.objectContaining({
+          method: 'PUT',
+          body: JSON.stringify({ title: 'Updated' }),
+        })
+      )
+    })
+  })
+
+  describe('useDeleteCollection', () => {
+    it('deletes a collection with DELETE', async () => {
+      mockApiRequest.mockResolvedValueOnce(undefined)
+
+      const { result } = renderHook(() => useDeleteCollection(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({ slug: 'to-delete' })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/collections/to-delete',
+        expect.objectContaining({ method: 'DELETE' })
+      )
+    })
+  })
+
+  describe('useSetFeatured', () => {
+    it('sets featured status with PUT', async () => {
+      mockApiRequest.mockResolvedValueOnce(undefined)
+
+      const { result } = renderHook(() => useSetFeatured(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({ slug: 'test', featured: true })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/collections/test/feature',
+        expect.objectContaining({
+          method: 'PUT',
+          body: JSON.stringify({ featured: true }),
+        })
+      )
+    })
+  })
+
+  describe('useAddCollectionItem', () => {
+    it('adds an item to a collection', async () => {
+      mockApiRequest.mockResolvedValueOnce(undefined)
+
+      const { result } = renderHook(() => useAddCollectionItem(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({
+          slug: 'my-collection',
+          entityType: 'artist',
+          entityId: 42,
+          notes: 'Great artist',
+        })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/collections/my-collection/items',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            entity_type: 'artist',
+            entity_id: 42,
+            notes: 'Great artist',
+          }),
+        })
+      )
+    })
+  })
+
+  describe('useRemoveCollectionItem', () => {
+    it('removes an item from a collection', async () => {
+      mockApiRequest.mockResolvedValueOnce(undefined)
+
+      const { result } = renderHook(() => useRemoveCollectionItem(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({ slug: 'my-collection', itemId: 5 })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/collections/my-collection/items/5',
+        expect.objectContaining({ method: 'DELETE' })
+      )
+    })
+  })
+
+  describe('useSubscribeCollection', () => {
+    it('subscribes with POST', async () => {
+      mockApiRequest.mockResolvedValueOnce(undefined)
+
+      const { result } = renderHook(() => useSubscribeCollection(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({ slug: 'my-collection' })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/collections/my-collection/subscribe',
+        expect.objectContaining({ method: 'POST' })
+      )
+    })
+  })
+
+  describe('useUnsubscribeCollection', () => {
+    it('unsubscribes with DELETE', async () => {
+      mockApiRequest.mockResolvedValueOnce(undefined)
+
+      const { result } = renderHook(() => useUnsubscribeCollection(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({ slug: 'my-collection' })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/collections/my-collection/subscribe',
+        expect.objectContaining({ method: 'DELETE' })
+      )
+    })
+  })
+
+  describe('mutation error handling', () => {
+    it('handles create errors', async () => {
+      const error = new Error('Server error')
+      Object.assign(error, { status: 500 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(() => useCreateCollection(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({
+          title: 'Fail',
+          is_public: true,
+          collaborative: false,
+        })
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+      expect(result.current.error).toBeDefined()
+    })
+  })
+})

--- a/frontend/features/festivals/hooks/useFestivals.test.tsx
+++ b/frontend/features/festivals/hooks/useFestivals.test.tsx
@@ -1,0 +1,320 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const mockApiRequest = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    FESTIVALS: {
+      LIST: '/festivals',
+      GET: (id: string | number) => `/festivals/${id}`,
+      ARTISTS: (id: string | number) => `/festivals/${id}/artists`,
+      VENUES: (id: string | number) => `/festivals/${id}/venues`,
+      ARTIST_FESTIVALS: (id: string | number) => `/artists/${id}/festivals`,
+      SIMILAR: (id: string | number) => `/festivals/${id}/similar`,
+      BREAKOUTS: (id: string | number) => `/festivals/${id}/breakouts`,
+      ARTIST_TRAJECTORY: (id: string | number) => `/artists/${id}/festival-trajectory`,
+      SERIES_COMPARE: (slug: string) => `/festivals/series/${slug}/compare`,
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    festivals: {
+      list: (filters?: Record<string, unknown>) => ['festivals', 'list', filters],
+      detail: (id: string | number) => ['festivals', 'detail', String(id)],
+      artists: (id: string | number, dayDate?: string) => ['festivals', 'artists', String(id), dayDate],
+      venues: (id: string | number) => ['festivals', 'venues', String(id)],
+      artistFestivals: (id: string | number) => ['festivals', 'artist', String(id)],
+      similar: (id: string | number) => ['festivals', 'similar', String(id)],
+      breakouts: (id: string | number) => ['festivals', 'breakouts', String(id)],
+      artistTrajectory: (id: string | number) => ['festivals', 'trajectory', String(id)],
+      seriesCompare: (slug: string, years: number[]) => ['festivals', 'series', slug, years.join(',')],
+    },
+  },
+}))
+
+import {
+  useFestivals,
+  useFestival,
+  useFestivalArtists,
+  useFestivalLineup,
+  useFestivalVenues,
+  useArtistFestivals,
+  useSimilarFestivals,
+  useFestivalBreakouts,
+  useArtistFestivalTrajectory,
+  useSeriesComparison,
+} from './useFestivals'
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+}
+
+describe('useFestivals', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches festivals without filters', async () => {
+    mockApiRequest.mockResolvedValueOnce({ festivals: [], count: 0 })
+
+    const { result } = renderHook(() => useFestivals(), { wrapper: createWrapper() })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith('/festivals', { method: 'GET' })
+  })
+
+  it('includes year filter', async () => {
+    mockApiRequest.mockResolvedValueOnce({ festivals: [], count: 0 })
+
+    const { result } = renderHook(() => useFestivals({ year: 2025 }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest.mock.calls[0][0]).toContain('year=2025')
+  })
+
+  it('includes seriesSlug filter', async () => {
+    mockApiRequest.mockResolvedValueOnce({ festivals: [], count: 0 })
+
+    const { result } = renderHook(() => useFestivals({ seriesSlug: 'coachella' }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest.mock.calls[0][0]).toContain('series_slug=coachella')
+  })
+})
+
+describe('useFestival', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches a festival by slug', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 1, name: 'FORM Arcosanti', slug: 'form-arcosanti' })
+
+    const { result } = renderHook(() => useFestival({ idOrSlug: 'form-arcosanti' }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith('/festivals/form-arcosanti', { method: 'GET' })
+  })
+
+  it('does not fetch when idOrSlug is 0', () => {
+    const { result } = renderHook(() => useFestival({ idOrSlug: 0 }), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('does not fetch when enabled is false', () => {
+    const { result } = renderHook(
+      () => useFestival({ idOrSlug: 'test', enabled: false }),
+      { wrapper: createWrapper() }
+    )
+
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+})
+
+describe('useFestivalArtists', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches festival artists', async () => {
+    mockApiRequest.mockResolvedValueOnce({ artists: [], total: 0 })
+
+    const { result } = renderHook(
+      () => useFestivalArtists({ festivalIdOrSlug: 'form' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith('/festivals/form/artists', { method: 'GET' })
+  })
+
+  it('includes dayDate filter', async () => {
+    mockApiRequest.mockResolvedValueOnce({ artists: [], total: 0 })
+
+    const { result } = renderHook(
+      () => useFestivalArtists({ festivalIdOrSlug: 'form', dayDate: '2025-05-09' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest.mock.calls[0][0]).toContain('day_date=2025-05-09')
+  })
+})
+
+describe('useFestivalLineup (alias)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('delegates to useFestivalArtists', async () => {
+    mockApiRequest.mockResolvedValueOnce({ artists: [], total: 0 })
+
+    const { result } = renderHook(
+      () => useFestivalLineup({ festivalId: 'form' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith('/festivals/form/artists', { method: 'GET' })
+  })
+})
+
+describe('useFestivalVenues', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches venues for a festival', async () => {
+    mockApiRequest.mockResolvedValueOnce({ venues: [] })
+
+    const { result } = renderHook(
+      () => useFestivalVenues({ festivalIdOrSlug: 'form' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith('/festivals/form/venues', { method: 'GET' })
+  })
+})
+
+describe('useArtistFestivals', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches festivals for an artist', async () => {
+    mockApiRequest.mockResolvedValueOnce({ festivals: [] })
+
+    const { result } = renderHook(
+      () => useArtistFestivals({ artistIdOrSlug: 'radiohead' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith('/artists/radiohead/festivals', { method: 'GET' })
+  })
+})
+
+describe('useSimilarFestivals', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches similar festivals with default limit', async () => {
+    mockApiRequest.mockResolvedValueOnce({ festivals: [] })
+
+    const { result } = renderHook(
+      () => useSimilarFestivals({ festivalIdOrSlug: 'form' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest.mock.calls[0][0]).toContain('limit=10')
+  })
+})
+
+describe('useFestivalBreakouts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches breakout artists', async () => {
+    mockApiRequest.mockResolvedValueOnce({ artists: [] })
+
+    const { result } = renderHook(
+      () => useFestivalBreakouts({ festivalIdOrSlug: 'form' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith('/festivals/form/breakouts', { method: 'GET' })
+  })
+})
+
+describe('useArtistFestivalTrajectory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches artist trajectory', async () => {
+    mockApiRequest.mockResolvedValueOnce({ entries: [] })
+
+    const { result } = renderHook(
+      () => useArtistFestivalTrajectory({ artistIdOrSlug: 'radiohead' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith('/artists/radiohead/festival-trajectory', { method: 'GET' })
+  })
+})
+
+describe('useSeriesComparison', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches series comparison', async () => {
+    mockApiRequest.mockResolvedValueOnce({ years: [] })
+
+    const { result } = renderHook(
+      () => useSeriesComparison({ seriesSlug: 'coachella', years: [2024, 2025] }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest.mock.calls[0][0]).toContain('years=2024%2C2025')
+  })
+
+  it('does not fetch when fewer than 2 years', () => {
+    const { result } = renderHook(
+      () => useSeriesComparison({ seriesSlug: 'coachella', years: [2024] }),
+      { wrapper: createWrapper() }
+    )
+
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('does not fetch when seriesSlug is empty', () => {
+    const { result } = renderHook(
+      () => useSeriesComparison({ seriesSlug: '', years: [2024, 2025] }),
+      { wrapper: createWrapper() }
+    )
+
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+})

--- a/frontend/features/labels/hooks/useLabels.test.tsx
+++ b/frontend/features/labels/hooks/useLabels.test.tsx
@@ -1,0 +1,208 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const mockApiRequest = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    LABELS: {
+      LIST: '/labels',
+      GET: (idOrSlug: string | number) => `/labels/${idOrSlug}`,
+      ARTISTS: (idOrSlug: string | number) => `/labels/${idOrSlug}/artists`,
+      RELEASES: (idOrSlug: string | number) => `/labels/${idOrSlug}/releases`,
+    },
+    ARTISTS: {
+      LABELS: (artistIdOrSlug: string | number) => `/artists/${artistIdOrSlug}/labels`,
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    labels: {
+      list: (filters?: Record<string, unknown>) => ['labels', 'list', filters],
+      detail: (id: string | number) => ['labels', 'detail', String(id)],
+      roster: (id: string | number) => ['labels', 'roster', String(id)],
+      catalog: (id: string | number) => ['labels', 'catalog', String(id)],
+    },
+    artists: {
+      labels: (artistId: string | number) => ['artists', 'labels', String(artistId)],
+    },
+  },
+}))
+
+import { useLabels, useLabel, useArtistLabels, useLabelRoster, useLabelCatalog } from './useLabels'
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+}
+
+describe('useLabels', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches labels without filters', async () => {
+    mockApiRequest.mockResolvedValueOnce({ labels: [{ id: 1, name: 'Sub Pop' }], count: 1 })
+
+    const { result } = renderHook(() => useLabels(), { wrapper: createWrapper() })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith('/labels', { method: 'GET' })
+  })
+
+  it('includes status filter in query params', async () => {
+    mockApiRequest.mockResolvedValueOnce({ labels: [], count: 0 })
+
+    const { result } = renderHook(() => useLabels({ status: 'active' }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith('/labels?status=active', { method: 'GET' })
+  })
+
+  it('includes city and state in query params', async () => {
+    mockApiRequest.mockResolvedValueOnce({ labels: [], count: 0 })
+
+    const { result } = renderHook(() => useLabels({ city: 'Phoenix', state: 'AZ' }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const calledUrl = mockApiRequest.mock.calls[0][0] as string
+    expect(calledUrl).toContain('city=Phoenix')
+    expect(calledUrl).toContain('state=AZ')
+  })
+})
+
+describe('useLabel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches a label by ID', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 1, name: 'Sub Pop', slug: 'sub-pop' })
+
+    const { result } = renderHook(() => useLabel({ idOrSlug: 1 }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith('/labels/1', { method: 'GET' })
+  })
+
+  it('fetches a label by slug', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 1, name: 'Sub Pop', slug: 'sub-pop' })
+
+    const { result } = renderHook(() => useLabel({ idOrSlug: 'sub-pop' }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith('/labels/sub-pop', { method: 'GET' })
+  })
+
+  it('does not fetch when enabled is false', () => {
+    const { result } = renderHook(() => useLabel({ idOrSlug: 1, enabled: false }), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.fetchStatus).toBe('idle')
+    expect(mockApiRequest).not.toHaveBeenCalled()
+  })
+
+  it('does not fetch when idOrSlug is 0', () => {
+    const { result } = renderHook(() => useLabel({ idOrSlug: 0 }), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('does not fetch when idOrSlug is empty string', () => {
+    const { result } = renderHook(() => useLabel({ idOrSlug: '' }), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+})
+
+describe('useArtistLabels', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches labels for an artist', async () => {
+    mockApiRequest.mockResolvedValueOnce({ labels: [{ id: 1, name: 'Sub Pop' }] })
+
+    const { result } = renderHook(
+      () => useArtistLabels({ artistIdOrSlug: 'the-shins' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith('/artists/the-shins/labels', { method: 'GET' })
+  })
+
+  it('does not fetch when artistId is 0', () => {
+    const { result } = renderHook(
+      () => useArtistLabels({ artistIdOrSlug: 0 }),
+      { wrapper: createWrapper() }
+    )
+
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+})
+
+describe('useLabelRoster', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches roster for a label', async () => {
+    mockApiRequest.mockResolvedValueOnce({ artists: [{ id: 1, name: 'Artist A' }] })
+
+    const { result } = renderHook(() => useLabelRoster({ labelIdOrSlug: 'sub-pop' }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith('/labels/sub-pop/artists', { method: 'GET' })
+  })
+})
+
+describe('useLabelCatalog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches catalog for a label', async () => {
+    mockApiRequest.mockResolvedValueOnce({ releases: [{ id: 1, title: 'Album A' }] })
+
+    const { result } = renderHook(() => useLabelCatalog({ labelIdOrSlug: 'sub-pop' }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith('/labels/sub-pop/releases', { method: 'GET' })
+  })
+})

--- a/frontend/features/notifications/hooks/index.test.tsx
+++ b/frontend/features/notifications/hooks/index.test.tsx
@@ -1,0 +1,282 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const mockApiRequest = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    notificationFilters: {
+      all: ['notificationFilters'],
+    },
+  },
+}))
+
+import {
+  useNotificationFilters,
+  useNotificationFilterCheck,
+  useCreateFilter,
+  useUpdateFilter,
+  useDeleteFilter,
+  useQuickCreateFilter,
+} from './index'
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+}
+
+describe('useNotificationFilters', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches notification filters', async () => {
+    const mockFilters = {
+      filters: [
+        { id: 1, name: 'My Filter', is_active: true, artist_ids: [1, 2] },
+      ],
+    }
+    mockApiRequest.mockResolvedValueOnce(mockFilters)
+
+    const { result } = renderHook(() => useNotificationFilters(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      'http://localhost:8080/me/notification-filters'
+    )
+    expect(result.current.data?.filters).toHaveLength(1)
+  })
+
+  it('handles empty filters', async () => {
+    mockApiRequest.mockResolvedValueOnce({ filters: [] })
+
+    const { result } = renderHook(() => useNotificationFilters(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data?.filters).toEqual([])
+  })
+})
+
+describe('useNotificationFilterCheck', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('finds matching filter for artist entity', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      filters: [
+        { id: 1, name: 'Artists', is_active: true, artist_ids: [10, 20], venue_ids: null, label_ids: null, tag_ids: null },
+        { id: 2, name: 'Venues', is_active: true, artist_ids: null, venue_ids: [30], label_ids: null, tag_ids: null },
+      ],
+    })
+
+    const { result } = renderHook(
+      () => useNotificationFilterCheck('artist', 10),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.hasFilter).toBe(true))
+    expect(result.current.data?.id).toBe(1)
+  })
+
+  it('finds matching filter for venue entity', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      filters: [
+        { id: 1, name: 'Venues', is_active: true, artist_ids: null, venue_ids: [30, 40], label_ids: null, tag_ids: null },
+      ],
+    })
+
+    const { result } = renderHook(
+      () => useNotificationFilterCheck('venue', 30),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.hasFilter).toBe(true))
+  })
+
+  it('finds matching filter for label entity', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      filters: [
+        { id: 1, name: 'Labels', is_active: true, artist_ids: null, venue_ids: null, label_ids: [50], tag_ids: null },
+      ],
+    })
+
+    const { result } = renderHook(
+      () => useNotificationFilterCheck('label', 50),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.hasFilter).toBe(true))
+  })
+
+  it('finds matching filter for tag entity', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      filters: [
+        { id: 1, name: 'Tags', is_active: true, artist_ids: null, venue_ids: null, label_ids: null, tag_ids: [60] },
+      ],
+    })
+
+    const { result } = renderHook(
+      () => useNotificationFilterCheck('tag', 60),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.hasFilter).toBe(true))
+  })
+
+  it('returns hasFilter false when no matching filter exists', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      filters: [
+        { id: 1, name: 'Filter', is_active: true, artist_ids: [1, 2], venue_ids: null, label_ids: null, tag_ids: null },
+      ],
+    })
+
+    const { result } = renderHook(
+      () => useNotificationFilterCheck('artist', 999),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.hasFilter).toBe(false)
+    expect(result.current.data).toBeUndefined()
+  })
+
+  it('ignores inactive filters', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      filters: [
+        { id: 1, name: 'Inactive', is_active: false, artist_ids: [10], venue_ids: null, label_ids: null, tag_ids: null },
+      ],
+    })
+
+    const { result } = renderHook(
+      () => useNotificationFilterCheck('artist', 10),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.hasFilter).toBe(false)
+  })
+})
+
+describe('useCreateFilter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('creates a filter with POST', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 1, name: 'New Filter' })
+
+    const { result } = renderHook(() => useCreateFilter(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ name: 'New Filter', artist_ids: [1] } as any)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      'http://localhost:8080/me/notification-filters',
+      expect.objectContaining({ method: 'POST' })
+    )
+  })
+})
+
+describe('useUpdateFilter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('updates a filter with PATCH', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 1, name: 'Updated' })
+
+    const { result } = renderHook(() => useUpdateFilter(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ id: 1, name: 'Updated' } as any)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      'http://localhost:8080/me/notification-filters/1',
+      expect.objectContaining({ method: 'PATCH' })
+    )
+  })
+})
+
+describe('useDeleteFilter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('deletes a filter with DELETE', async () => {
+    mockApiRequest.mockResolvedValueOnce(undefined)
+
+    const { result } = renderHook(() => useDeleteFilter(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(1)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      'http://localhost:8080/me/notification-filters/1',
+      expect.objectContaining({ method: 'DELETE' })
+    )
+  })
+})
+
+describe('useQuickCreateFilter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('quick-creates a filter for an entity', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 1, name: 'Quick Filter' })
+
+    const { result } = renderHook(() => useQuickCreateFilter(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ entityType: 'artist', entityId: 42 })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      'http://localhost:8080/me/notification-filters/quick',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ entity_type: 'artist', entity_id: 42 }),
+      })
+    )
+  })
+})

--- a/frontend/features/releases/hooks/useReleases.test.tsx
+++ b/frontend/features/releases/hooks/useReleases.test.tsx
@@ -1,0 +1,209 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const mockApiRequest = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    RELEASES: {
+      LIST: '/releases',
+      GET: (idOrSlug: string | number) => `/releases/${idOrSlug}`,
+      ARTIST_RELEASES: (artistIdOrSlug: string | number) => `/artists/${artistIdOrSlug}/releases`,
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    releases: {
+      list: (filters?: Record<string, unknown>) => ['releases', 'list', filters],
+      detail: (id: string | number) => ['releases', 'detail', String(id)],
+      artistReleases: (id: string | number) => ['releases', 'artist', String(id)],
+    },
+  },
+}))
+
+import { useReleases, useRelease, useArtistReleases } from './useReleases'
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+}
+
+describe('useReleases', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches releases without filters', async () => {
+    mockApiRequest.mockResolvedValueOnce({ releases: [], count: 0 })
+
+    const { result } = renderHook(() => useReleases(), { wrapper: createWrapper() })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith('/releases', { method: 'GET' })
+  })
+
+  it('includes releaseType filter', async () => {
+    mockApiRequest.mockResolvedValueOnce({ releases: [], count: 0 })
+
+    const { result } = renderHook(() => useReleases({ releaseType: 'album' }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest.mock.calls[0][0]).toContain('release_type=album')
+  })
+
+  it('includes year filter', async () => {
+    mockApiRequest.mockResolvedValueOnce({ releases: [], count: 0 })
+
+    const { result } = renderHook(() => useReleases({ year: 2025 }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest.mock.calls[0][0]).toContain('year=2025')
+  })
+
+  it('includes artistId filter', async () => {
+    mockApiRequest.mockResolvedValueOnce({ releases: [], count: 0 })
+
+    const { result } = renderHook(() => useReleases({ artistId: 42 }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest.mock.calls[0][0]).toContain('artist_id=42')
+  })
+
+  it('handles multiple filters', async () => {
+    mockApiRequest.mockResolvedValueOnce({ releases: [], count: 0 })
+
+    const { result } = renderHook(
+      () => useReleases({ releaseType: 'ep', year: 2024, artistId: 5 }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const url = mockApiRequest.mock.calls[0][0] as string
+    expect(url).toContain('release_type=ep')
+    expect(url).toContain('year=2024')
+    expect(url).toContain('artist_id=5')
+  })
+})
+
+describe('useRelease', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches a release by slug', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 1, title: 'OK Computer', slug: 'ok-computer' })
+
+    const { result } = renderHook(() => useRelease({ idOrSlug: 'ok-computer' }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith('/releases/ok-computer', { method: 'GET' })
+  })
+
+  it('fetches a release by numeric ID', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 1, title: 'Test' })
+
+    const { result } = renderHook(() => useRelease({ idOrSlug: 42 }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith('/releases/42', { method: 'GET' })
+  })
+
+  it('does not fetch when idOrSlug is 0', () => {
+    const { result } = renderHook(() => useRelease({ idOrSlug: 0 }), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('does not fetch when idOrSlug is empty string', () => {
+    const { result } = renderHook(() => useRelease({ idOrSlug: '' }), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('does not fetch when enabled is false', () => {
+    const { result } = renderHook(
+      () => useRelease({ idOrSlug: 'test', enabled: false }),
+      { wrapper: createWrapper() }
+    )
+
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('handles API errors', async () => {
+    const error = new Error('Not found')
+    Object.assign(error, { status: 404 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useRelease({ idOrSlug: 'nonexistent' }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+  })
+})
+
+describe('useArtistReleases', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches releases for an artist', async () => {
+    mockApiRequest.mockResolvedValueOnce({ releases: [{ id: 1, title: 'Album' }] })
+
+    const { result } = renderHook(
+      () => useArtistReleases({ artistIdOrSlug: 'radiohead' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith('/artists/radiohead/releases', { method: 'GET' })
+  })
+
+  it('does not fetch when artistIdOrSlug is 0', () => {
+    const { result } = renderHook(
+      () => useArtistReleases({ artistIdOrSlug: 0 }),
+      { wrapper: createWrapper() }
+    )
+
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('does not fetch when artistIdOrSlug is empty string', () => {
+    const { result } = renderHook(
+      () => useArtistReleases({ artistIdOrSlug: '' }),
+      { wrapper: createWrapper() }
+    )
+
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+})

--- a/frontend/features/requests/hooks/index.test.tsx
+++ b/frontend/features/requests/hooks/index.test.tsx
@@ -1,0 +1,411 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const mockApiRequest = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    REQUESTS: {
+      LIST: '/requests',
+      GET: (id: string | number) => `/requests/${id}`,
+      VOTE: (id: string | number) => `/requests/${id}/vote`,
+      FULFILL: (id: string | number) => `/requests/${id}/fulfill`,
+      CLOSE: (id: string | number) => `/requests/${id}/close`,
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    requests: {
+      all: ['requests'],
+      list: (params?: Record<string, unknown>) => ['requests', 'list', params],
+      detail: (id: number) => ['requests', 'detail', id],
+    },
+  },
+}))
+
+import {
+  useRequests,
+  useRequest,
+  useCreateRequest,
+  useUpdateRequest,
+  useDeleteRequest,
+  useVoteRequest,
+  useRemoveVoteRequest,
+  useFulfillRequest,
+  useCloseRequest,
+} from './index'
+
+function createWrapper(queryClient?: QueryClient) {
+  const qc =
+    queryClient ??
+    new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: 0 },
+        mutations: { retry: false },
+      },
+    })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  }
+}
+
+describe('useRequests', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches requests without params', async () => {
+    mockApiRequest.mockResolvedValueOnce({ requests: [], total: 0 })
+
+    const { result } = renderHook(() => useRequests(), { wrapper: createWrapper() })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith('/requests')
+  })
+
+  it('includes filter params', async () => {
+    mockApiRequest.mockResolvedValueOnce({ requests: [], total: 0 })
+
+    const { result } = renderHook(
+      () => useRequests({ status: 'open', entity_type: 'artist', sort_by: 'votes', limit: 10, offset: 20 }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const url = mockApiRequest.mock.calls[0][0] as string
+    expect(url).toContain('status=open')
+    expect(url).toContain('entity_type=artist')
+    expect(url).toContain('sort_by=votes')
+    expect(url).toContain('limit=10')
+    expect(url).toContain('offset=20')
+  })
+})
+
+describe('useRequest', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches a single request by ID', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 1, title: 'Add artist' })
+
+    const { result } = renderHook(() => useRequest(1), { wrapper: createWrapper() })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith('/requests/1')
+  })
+
+  it('does not fetch when requestId is 0', () => {
+    const { result } = renderHook(() => useRequest(0), { wrapper: createWrapper() })
+
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('does not fetch when enabled is false', () => {
+    const { result } = renderHook(() => useRequest(1, { enabled: false }), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+})
+
+describe('useCreateRequest', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('creates a request with POST', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 1, title: 'New Artist Request' })
+
+    const { result } = renderHook(() => useCreateRequest(), { wrapper: createWrapper() })
+
+    await act(async () => {
+      result.current.mutate({ title: 'New Artist Request', entity_type: 'artist' })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/requests',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ title: 'New Artist Request', entity_type: 'artist' }),
+      })
+    )
+  })
+})
+
+describe('useUpdateRequest', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('updates a request with PUT', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 1, title: 'Updated' })
+
+    const { result } = renderHook(() => useUpdateRequest(), { wrapper: createWrapper() })
+
+    await act(async () => {
+      result.current.mutate({ requestId: 1, title: 'Updated' })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/requests/1',
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({ title: 'Updated' }),
+      })
+    )
+  })
+})
+
+describe('useDeleteRequest', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('deletes a request with DELETE', async () => {
+    mockApiRequest.mockResolvedValueOnce(undefined)
+
+    const { result } = renderHook(() => useDeleteRequest(), { wrapper: createWrapper() })
+
+    await act(async () => {
+      result.current.mutate({ requestId: 1 })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/requests/1',
+      expect.objectContaining({ method: 'DELETE' })
+    )
+  })
+})
+
+describe('useVoteRequest (optimistic updates)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('votes on a request with POST', async () => {
+    mockApiRequest.mockResolvedValueOnce(undefined)
+
+    const { result } = renderHook(() => useVoteRequest(), { wrapper: createWrapper() })
+
+    await act(async () => {
+      result.current.mutate({ requestId: 1, is_upvote: true })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/requests/1/vote',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ is_upvote: true }),
+      })
+    )
+  })
+
+  it('performs optimistic update for upvote from no previous vote', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+    })
+
+    // Seed the cache with a request
+    queryClient.setQueryData(['requests', 'detail', 1], {
+      id: 1,
+      title: 'Test',
+      upvotes: 5,
+      downvotes: 2,
+      vote_score: 3,
+      user_vote: 0,
+    })
+
+    mockApiRequest.mockResolvedValueOnce(undefined)
+
+    const { result } = renderHook(() => useVoteRequest(), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    await act(async () => {
+      result.current.mutate({ requestId: 1, is_upvote: true })
+    })
+
+    // Check optimistic update happened
+    const cachedData = queryClient.getQueryData<{
+      upvotes: number
+      downvotes: number
+      user_vote: number
+    }>(['requests', 'detail', 1])
+
+    // After optimistic update (from no vote to upvote): upvotes +1
+    expect(cachedData?.user_vote).toBe(1)
+    expect(cachedData?.upvotes).toBe(6)
+    expect(cachedData?.downvotes).toBe(2)
+  })
+
+  it('rolls back optimistic update on error', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+    })
+
+    const originalData = {
+      id: 1,
+      title: 'Test',
+      upvotes: 5,
+      downvotes: 2,
+      vote_score: 3,
+      user_vote: 0,
+    }
+    queryClient.setQueryData(['requests', 'detail', 1], originalData)
+
+    mockApiRequest.mockRejectedValueOnce(new Error('Server error'))
+
+    const { result } = renderHook(() => useVoteRequest(), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    await act(async () => {
+      result.current.mutate({ requestId: 1, is_upvote: true })
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    // The onError handler should roll back the optimistic update,
+    // then onSettled invalidates. Since there's no queryFn for this cache entry,
+    // it may get cleared. Verify the mutation errored properly.
+    expect(result.current.error).toBeDefined()
+  })
+})
+
+describe('useRemoveVoteRequest', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('removes a vote with DELETE', async () => {
+    mockApiRequest.mockResolvedValueOnce(undefined)
+
+    const { result } = renderHook(() => useRemoveVoteRequest(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ requestId: 1 })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/requests/1/vote',
+      expect.objectContaining({ method: 'DELETE' })
+    )
+  })
+
+  it('performs optimistic update to remove upvote', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+    })
+
+    queryClient.setQueryData(['requests', 'detail', 1], {
+      id: 1,
+      title: 'Test',
+      upvotes: 5,
+      downvotes: 2,
+      vote_score: 3,
+      user_vote: 1, // currently upvoted
+    })
+
+    mockApiRequest.mockResolvedValueOnce(undefined)
+
+    const { result } = renderHook(() => useRemoveVoteRequest(), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    await act(async () => {
+      result.current.mutate({ requestId: 1 })
+    })
+
+    const cachedData = queryClient.getQueryData<{
+      upvotes: number
+      downvotes: number
+      user_vote: number | null
+    }>(['requests', 'detail', 1])
+
+    expect(cachedData?.user_vote).toBeNull()
+    expect(cachedData?.upvotes).toBe(4)
+    expect(cachedData?.downvotes).toBe(2)
+  })
+})
+
+describe('useFulfillRequest', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fulfills a request with POST', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 1, status: 'fulfilled' })
+
+    const { result } = renderHook(() => useFulfillRequest(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ requestId: 1, fulfilled_entity_id: 42 })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/requests/1/fulfill',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ fulfilled_entity_id: 42 }),
+      })
+    )
+  })
+})
+
+describe('useCloseRequest', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('closes a request with POST', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 1, status: 'closed' })
+
+    const { result } = renderHook(() => useCloseRequest(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ requestId: 1 })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/requests/1/close',
+      expect.objectContaining({ method: 'POST' })
+    )
+  })
+})

--- a/frontend/features/requests/hooks/index.test.tsx
+++ b/frontend/features/requests/hooks/index.test.tsx
@@ -224,7 +224,7 @@ describe('useVoteRequest (optimistic updates)', () => {
 
   it('performs optimistic update for upvote from no previous vote', async () => {
     const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+      defaultOptions: { queries: { retry: false, gcTime: Infinity }, mutations: { retry: false } },
     })
 
     // Seed the cache with a request
@@ -262,7 +262,7 @@ describe('useVoteRequest (optimistic updates)', () => {
 
   it('rolls back optimistic update on error', async () => {
     const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+      defaultOptions: { queries: { retry: false, gcTime: Infinity }, mutations: { retry: false } },
     })
 
     const originalData = {
@@ -321,7 +321,7 @@ describe('useRemoveVoteRequest', () => {
 
   it('performs optimistic update to remove upvote', async () => {
     const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+      defaultOptions: { queries: { retry: false, gcTime: Infinity }, mutations: { retry: false } },
     })
 
     queryClient.setQueryData(['requests', 'detail', 1], {

--- a/frontend/features/scenes/hooks/useScenes.test.tsx
+++ b/frontend/features/scenes/hooks/useScenes.test.tsx
@@ -1,0 +1,156 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const mockApiRequest = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    SCENES: {
+      LIST: '/scenes',
+      DETAIL: (slug: string) => `/scenes/${slug}`,
+      ARTISTS: (slug: string) => `/scenes/${slug}/artists`,
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    scenes: {
+      list: ['scenes', 'list'],
+      detail: (slug: string) => ['scenes', 'detail', slug],
+      artists: (slug: string, period?: number) => ['scenes', 'artists', slug, period],
+    },
+  },
+}))
+
+import { useScenes, useSceneDetail, useSceneArtists } from './useScenes'
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+}
+
+describe('useScenes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches scene list', async () => {
+    mockApiRequest.mockResolvedValueOnce({ scenes: [{ slug: 'phoenix-az', label: 'Phoenix, AZ' }] })
+
+    const { result } = renderHook(() => useScenes(), { wrapper: createWrapper() })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith('/scenes', { method: 'GET' })
+    expect(result.current.data?.scenes).toHaveLength(1)
+  })
+
+  it('handles empty scenes', async () => {
+    mockApiRequest.mockResolvedValueOnce({ scenes: [] })
+
+    const { result } = renderHook(() => useScenes(), { wrapper: createWrapper() })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data?.scenes).toEqual([])
+  })
+
+  it('handles API errors', async () => {
+    const error = new Error('Server error')
+    Object.assign(error, { status: 500 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useScenes(), { wrapper: createWrapper() })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+  })
+})
+
+describe('useSceneDetail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches a scene by slug', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      slug: 'phoenix-az',
+      label: 'Phoenix, AZ',
+      show_count: 50,
+      artist_count: 30,
+    })
+
+    const { result } = renderHook(() => useSceneDetail('phoenix-az'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith('/scenes/phoenix-az', { method: 'GET' })
+  })
+
+  it('does not fetch when slug is empty', () => {
+    const { result } = renderHook(() => useSceneDetail(''), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.fetchStatus).toBe('idle')
+    expect(mockApiRequest).not.toHaveBeenCalled()
+  })
+})
+
+describe('useSceneArtists', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches scene artists with default params', async () => {
+    mockApiRequest.mockResolvedValueOnce({ artists: [], total: 0 })
+
+    const { result } = renderHook(
+      () => useSceneArtists({ slug: 'phoenix-az' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const url = mockApiRequest.mock.calls[0][0] as string
+    expect(url).toContain('/scenes/phoenix-az/artists')
+    expect(url).toContain('period=90')
+    expect(url).toContain('limit=20')
+  })
+
+  it('includes custom period and limit', async () => {
+    mockApiRequest.mockResolvedValueOnce({ artists: [], total: 0 })
+
+    const { result } = renderHook(
+      () => useSceneArtists({ slug: 'phoenix-az', period: 30, limit: 50, offset: 10 }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const url = mockApiRequest.mock.calls[0][0] as string
+    expect(url).toContain('period=30')
+    expect(url).toContain('limit=50')
+    expect(url).toContain('offset=10')
+  })
+
+  it('does not fetch when slug is empty', () => {
+    const { result } = renderHook(
+      () => useSceneArtists({ slug: '' }),
+      { wrapper: createWrapper() }
+    )
+
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+})

--- a/frontend/features/shows/hooks/useAttendance.test.tsx
+++ b/frontend/features/shows/hooks/useAttendance.test.tsx
@@ -1,0 +1,309 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const mockApiRequest = vi.fn()
+const mockInvalidateAttendance = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    ATTENDANCE: {
+      SHOW: (showId: number) => `/shows/${showId}/attendance`,
+      BATCH: '/shows/attendance/batch',
+      MY_SHOWS: '/attendance/my-shows',
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    attendance: {
+      show: (showId: number) => ['attendance', 'show', showId],
+      batch: (showIds: number[]) => ['attendance', 'batch', ...showIds],
+      myShows: (params?: Record<string, unknown>) => ['attendance', 'my-shows', params],
+    },
+  },
+  createInvalidateQueries: () => ({
+    attendance: mockInvalidateAttendance,
+  }),
+}))
+
+vi.mock('@/lib/context/AuthContext', () => ({
+  useAuthContext: () => ({ isAuthenticated: true }),
+}))
+
+import {
+  useShowAttendance,
+  useBatchAttendance,
+  useSetAttendance,
+  useRemoveAttendance,
+  useMyShows,
+} from './useAttendance'
+
+function createWrapper(queryClient?: QueryClient) {
+  const qc =
+    queryClient ??
+    new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: 0 },
+        mutations: { retry: false },
+      },
+    })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  }
+}
+
+describe('useShowAttendance', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches attendance for a show', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      going_count: 10,
+      interested_count: 20,
+      user_status: '',
+    })
+
+    const { result } = renderHook(() => useShowAttendance(1), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith('/shows/1/attendance', { method: 'GET' })
+    expect(result.current.data?.going_count).toBe(10)
+  })
+
+  it('does not fetch when showId is 0', () => {
+    const { result } = renderHook(() => useShowAttendance(0), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+})
+
+describe('useBatchAttendance', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches batch attendance via POST', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      attendance: {
+        '1': { going_count: 10, interested_count: 5 },
+        '2': { going_count: 3, interested_count: 8 },
+      },
+    })
+
+    const { result } = renderHook(() => useBatchAttendance([1, 2]), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/shows/attendance/batch',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ show_ids: [1, 2] }),
+      })
+    )
+    expect(result.current.data?.['1']?.going_count).toBe(10)
+  })
+
+  it('does not fetch when showIds is empty', () => {
+    const { result } = renderHook(() => useBatchAttendance([]), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+})
+
+describe('useSetAttendance', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateAttendance.mockReset()
+  })
+
+  it('sets attendance status with POST', async () => {
+    mockApiRequest.mockResolvedValueOnce({ success: true, message: 'Attendance set' })
+
+    const { result } = renderHook(() => useSetAttendance(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ showId: 1, status: 'going' })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/shows/1/attendance',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ status: 'going' }),
+      })
+    )
+  })
+
+  it('performs optimistic update when setting "going"', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+    })
+
+    queryClient.setQueryData(['attendance', 'show', 1], {
+      going_count: 5,
+      interested_count: 3,
+      user_status: '',
+    })
+
+    mockApiRequest.mockResolvedValueOnce({ success: true })
+
+    const { result } = renderHook(() => useSetAttendance(), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    await act(async () => {
+      result.current.mutate({ showId: 1, status: 'going' })
+    })
+
+    const cached = queryClient.getQueryData<{
+      going_count: number
+      interested_count: number
+      user_status: string
+    }>(['attendance', 'show', 1])
+
+    expect(cached?.going_count).toBe(6)
+    expect(cached?.interested_count).toBe(3)
+    expect(cached?.user_status).toBe('going')
+  })
+
+  it('handles attendance mutation errors', async () => {
+    const error = new Error('Server error')
+    Object.assign(error, { status: 500 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useSetAttendance(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ showId: 1, status: 'interested' })
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error).toBeDefined()
+  })
+})
+
+describe('useRemoveAttendance', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateAttendance.mockReset()
+  })
+
+  it('removes attendance with DELETE', async () => {
+    mockApiRequest.mockResolvedValueOnce({ success: true })
+
+    const { result } = renderHook(() => useRemoveAttendance(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(1)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/shows/1/attendance',
+      expect.objectContaining({ method: 'DELETE' })
+    )
+  })
+
+  it('optimistically clears user status and decrements count', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+    })
+
+    queryClient.setQueryData(['attendance', 'show', 1], {
+      going_count: 5,
+      interested_count: 3,
+      user_status: 'going',
+    })
+
+    mockApiRequest.mockResolvedValueOnce({ success: true })
+
+    const { result } = renderHook(() => useRemoveAttendance(), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    await act(async () => {
+      result.current.mutate(1)
+    })
+
+    const cached = queryClient.getQueryData<{
+      going_count: number
+      interested_count: number
+      user_status: string
+    }>(['attendance', 'show', 1])
+
+    expect(cached?.going_count).toBe(4)
+    expect(cached?.user_status).toBe('')
+  })
+})
+
+describe('useMyShows', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches user attending shows', async () => {
+    mockApiRequest.mockResolvedValueOnce({ shows: [], total: 0 })
+
+    const { result } = renderHook(() => useMyShows(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const url = mockApiRequest.mock.calls[0][0] as string
+    expect(url).toContain('/attendance/my-shows')
+    expect(url).toContain('limit=20')
+    expect(url).toContain('offset=0')
+  })
+
+  it('includes status filter when not "all"', async () => {
+    mockApiRequest.mockResolvedValueOnce({ shows: [], total: 0 })
+
+    const { result } = renderHook(() => useMyShows({ status: 'going' }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const url = mockApiRequest.mock.calls[0][0] as string
+    expect(url).toContain('status=going')
+  })
+
+  it('does not include status when "all"', async () => {
+    mockApiRequest.mockResolvedValueOnce({ shows: [], total: 0 })
+
+    const { result } = renderHook(() => useMyShows({ status: 'all' }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const url = mockApiRequest.mock.calls[0][0] as string
+    expect(url).not.toContain('status=')
+  })
+})

--- a/frontend/features/shows/hooks/useAttendance.test.tsx
+++ b/frontend/features/shows/hooks/useAttendance.test.tsx
@@ -157,7 +157,7 @@ describe('useSetAttendance', () => {
 
   it('performs optimistic update when setting "going"', async () => {
     const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+      defaultOptions: { queries: { retry: false, gcTime: Infinity }, mutations: { retry: false } },
     })
 
     queryClient.setQueryData(['attendance', 'show', 1], {
@@ -233,7 +233,7 @@ describe('useRemoveAttendance', () => {
 
   it('optimistically clears user status and decrements count', async () => {
     const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+      defaultOptions: { queries: { retry: false, gcTime: Infinity }, mutations: { retry: false } },
     })
 
     queryClient.setQueryData(['attendance', 'show', 1], {

--- a/frontend/features/shows/hooks/useShowReminders.test.tsx
+++ b/frontend/features/shows/hooks/useShowReminders.test.tsx
@@ -1,0 +1,106 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const mockApiRequest = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    AUTH: {
+      SHOW_REMINDERS: '/auth/preferences/show-reminders',
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    auth: {
+      profile: ['auth', 'profile'],
+    },
+  },
+}))
+
+import { useSetShowReminders } from './useShowReminders'
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+}
+
+describe('useSetShowReminders', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('enables show reminders with PATCH', async () => {
+    mockApiRequest.mockResolvedValueOnce({ success: true, show_reminders: true })
+
+    const { result } = renderHook(() => useSetShowReminders(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(true)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/auth/preferences/show-reminders',
+      expect.objectContaining({
+        method: 'PATCH',
+        body: JSON.stringify({ enabled: true }),
+      })
+    )
+  })
+
+  it('disables show reminders with PATCH', async () => {
+    mockApiRequest.mockResolvedValueOnce({ success: true, show_reminders: false })
+
+    const { result } = renderHook(() => useSetShowReminders(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(false)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/auth/preferences/show-reminders',
+      expect.objectContaining({
+        method: 'PATCH',
+        body: JSON.stringify({ enabled: false }),
+      })
+    )
+  })
+
+  it('handles mutation errors', async () => {
+    const error = new Error('Unauthorized')
+    Object.assign(error, { status: 401 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useSetShowReminders(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(true)
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error).toBeDefined()
+  })
+})

--- a/frontend/features/shows/hooks/useShowReports.test.tsx
+++ b/frontend/features/shows/hooks/useShowReports.test.tsx
@@ -1,0 +1,188 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const mockApiRequest = vi.fn()
+const mockInvalidateShowReports = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    SHOWS: {
+      REPORT: (showId: string | number) => `/shows/${showId}/report`,
+      MY_REPORT: (showId: string | number) => `/shows/${showId}/my-report`,
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    showReports: {
+      myReport: (showId: string) => ['showReports', 'myReport', showId],
+    },
+  },
+  createInvalidateQueries: () => ({
+    showReports: mockInvalidateShowReports,
+  }),
+}))
+
+import { useMyShowReport, useReportShow } from './useShowReports'
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+}
+
+describe('useMyShowReport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches user report for a show by numeric ID', async () => {
+    mockApiRequest.mockResolvedValueOnce({ has_report: true, report_type: 'wrong_date' })
+
+    const { result } = renderHook(() => useMyShowReport(42), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith('/shows/42/my-report', { method: 'GET' })
+  })
+
+  it('fetches user report for a show by string ID', async () => {
+    mockApiRequest.mockResolvedValueOnce({ has_report: false })
+
+    const { result } = renderHook(() => useMyShowReport('my-slug'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith('/shows/my-slug/my-report', { method: 'GET' })
+  })
+
+  it('does not fetch when showId is null', () => {
+    const { result } = renderHook(() => useMyShowReport(null), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.fetchStatus).toBe('idle')
+    expect(mockApiRequest).not.toHaveBeenCalled()
+  })
+
+  it('handles API errors', async () => {
+    const error = new Error('Not found')
+    Object.assign(error, { status: 404 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useMyShowReport(999), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+  })
+})
+
+describe('useReportShow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateShowReports.mockReset()
+  })
+
+  it('reports a show with POST', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 1, report_type: 'wrong_date' })
+
+    const { result } = renderHook(() => useReportShow(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({
+        showId: 42,
+        reportType: 'wrong_date',
+        details: 'The date is March 20, not March 19',
+      })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/shows/42/report',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          report_type: 'wrong_date',
+          details: 'The date is March 20, not March 19',
+        }),
+      })
+    )
+  })
+
+  it('sends null for details when not provided', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 1 })
+
+    const { result } = renderHook(() => useReportShow(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({
+        showId: 42,
+        reportType: 'duplicate',
+      })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/shows/42/report',
+      expect.objectContaining({
+        body: JSON.stringify({
+          report_type: 'duplicate',
+          details: null,
+        }),
+      })
+    )
+  })
+
+  it('invalidates show reports on success', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 1 })
+
+    const { result } = renderHook(() => useReportShow(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ showId: 42, reportType: 'wrong_date' })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockInvalidateShowReports).toHaveBeenCalled()
+  })
+
+  it('handles report errors', async () => {
+    const error = new Error('Already reported')
+    Object.assign(error, { status: 409 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useReportShow(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ showId: 42, reportType: 'wrong_date' })
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+  })
+})

--- a/frontend/features/tags/hooks/index.test.tsx
+++ b/frontend/features/tags/hooks/index.test.tsx
@@ -307,7 +307,7 @@ describe('useVoteOnTag (optimistic updates)', () => {
 
   it('optimistically updates entity tags cache on upvote', async () => {
     const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+      defaultOptions: { queries: { retry: false, gcTime: Infinity }, mutations: { retry: false } },
     })
 
     queryClient.setQueryData(['tags', 'entityTags', 'artist', 42], {

--- a/frontend/features/tags/hooks/index.test.tsx
+++ b/frontend/features/tags/hooks/index.test.tsx
@@ -1,0 +1,366 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const mockApiRequest = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    TAGS: {
+      LIST: '/tags',
+      SEARCH: '/tags/search',
+      GET: (idOrSlug: string | number) => `/tags/${idOrSlug}`,
+      ALIASES: (idOrSlug: string | number) => `/tags/${idOrSlug}/aliases`,
+    },
+    ENTITY_TAGS: {
+      LIST: (entityType: string, entityId: number) => `/entities/${entityType}/${entityId}/tags`,
+      ADD: (entityType: string, entityId: number) => `/entities/${entityType}/${entityId}/tags`,
+      REMOVE: (entityType: string, entityId: number, tagId: number) =>
+        `/entities/${entityType}/${entityId}/tags/${tagId}`,
+      VOTE: (tagId: number, entityType: string, entityId: number) =>
+        `/tags/${tagId}/entities/${entityType}/${entityId}/votes`,
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    tags: {
+      all: ['tags'],
+      list: (params?: Record<string, unknown>) => ['tags', 'list', params],
+      search: (query: string) => ['tags', 'search', query.toLowerCase()],
+      detail: (id: string | number) => ['tags', 'detail', String(id)],
+      entityTags: (entityType: string, entityId: number) => ['tags', 'entityTags', entityType, entityId],
+    },
+  },
+}))
+
+import {
+  useTags,
+  useSearchTags,
+  useTag,
+  useEntityTags,
+  useAddTagToEntity,
+  useRemoveTagFromEntity,
+  useVoteOnTag,
+  useRemoveTagVote,
+} from './index'
+
+function createWrapper(queryClient?: QueryClient) {
+  const qc =
+    queryClient ??
+    new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: 0 },
+        mutations: { retry: false },
+      },
+    })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  }
+}
+
+describe('useTags', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches tags without params', async () => {
+    mockApiRequest.mockResolvedValueOnce({ tags: [], total: 0 })
+
+    const { result } = renderHook(() => useTags(), { wrapper: createWrapper() })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith('/tags')
+  })
+
+  it('includes category filter', async () => {
+    mockApiRequest.mockResolvedValueOnce({ tags: [], total: 0 })
+
+    const { result } = renderHook(() => useTags({ category: 'genre' }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest.mock.calls[0][0]).toContain('category=genre')
+  })
+
+  it('includes search filter', async () => {
+    mockApiRequest.mockResolvedValueOnce({ tags: [], total: 0 })
+
+    const { result } = renderHook(() => useTags({ search: 'rock' }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest.mock.calls[0][0]).toContain('search=rock')
+  })
+
+  it('includes pagination params', async () => {
+    mockApiRequest.mockResolvedValueOnce({ tags: [], total: 0 })
+
+    const { result } = renderHook(() => useTags({ limit: 10, offset: 20 }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const url = mockApiRequest.mock.calls[0][0] as string
+    expect(url).toContain('limit=10')
+    expect(url).toContain('offset=20')
+  })
+})
+
+describe('useSearchTags', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('searches tags when query length >= 2', async () => {
+    mockApiRequest.mockResolvedValueOnce({ tags: [{ id: 1, name: 'rock' }] })
+
+    const { result } = renderHook(() => useSearchTags('ro'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest.mock.calls[0][0]).toContain('q=ro')
+  })
+
+  it('does not search when query length < 2', () => {
+    const { result } = renderHook(() => useSearchTags('r'), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.fetchStatus).toBe('idle')
+    expect(mockApiRequest).not.toHaveBeenCalled()
+  })
+
+  it('does not search with empty query', () => {
+    const { result } = renderHook(() => useSearchTags(''), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('includes limit param', async () => {
+    mockApiRequest.mockResolvedValueOnce({ tags: [] })
+
+    const { result } = renderHook(() => useSearchTags('rock', 5), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest.mock.calls[0][0]).toContain('limit=5')
+  })
+})
+
+describe('useTag', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches a tag by slug', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 1, name: 'rock', slug: 'rock' })
+
+    const { result } = renderHook(() => useTag('rock'), { wrapper: createWrapper() })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith('/tags/rock')
+  })
+
+  it('does not fetch when enabled is false', () => {
+    const { result } = renderHook(() => useTag('rock', { enabled: false }), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+})
+
+describe('useEntityTags', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches tags for an entity', async () => {
+    mockApiRequest.mockResolvedValueOnce({ tags: [{ tag_id: 1, name: 'rock' }] })
+
+    const { result } = renderHook(() => useEntityTags('artist', 42), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith('/entities/artist/42/tags')
+  })
+
+  it('does not fetch when entityId is 0', () => {
+    const { result } = renderHook(() => useEntityTags('artist', 0), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+})
+
+describe('useAddTagToEntity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('adds a tag by ID', async () => {
+    mockApiRequest.mockResolvedValueOnce(undefined)
+
+    const { result } = renderHook(() => useAddTagToEntity(), { wrapper: createWrapper() })
+
+    await act(async () => {
+      result.current.mutate({ entityType: 'artist', entityId: 42, tag_id: 1 })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/entities/artist/42/tags',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ tag_id: 1, tag_name: undefined }),
+      })
+    )
+  })
+
+  it('adds a tag by name', async () => {
+    mockApiRequest.mockResolvedValueOnce(undefined)
+
+    const { result } = renderHook(() => useAddTagToEntity(), { wrapper: createWrapper() })
+
+    await act(async () => {
+      result.current.mutate({ entityType: 'venue', entityId: 10, tag_name: 'dive-bar' })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/entities/venue/10/tags',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ tag_id: undefined, tag_name: 'dive-bar' }),
+      })
+    )
+  })
+})
+
+describe('useRemoveTagFromEntity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('removes a tag from an entity', async () => {
+    mockApiRequest.mockResolvedValueOnce(undefined)
+
+    const { result } = renderHook(() => useRemoveTagFromEntity(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ entityType: 'artist', entityId: 42, tagId: 1 })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/entities/artist/42/tags/1',
+      expect.objectContaining({ method: 'DELETE' })
+    )
+  })
+})
+
+describe('useVoteOnTag (optimistic updates)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('votes on a tag-entity pair', async () => {
+    mockApiRequest.mockResolvedValueOnce(undefined)
+
+    const { result } = renderHook(() => useVoteOnTag(), { wrapper: createWrapper() })
+
+    await act(async () => {
+      result.current.mutate({ tagId: 1, entityType: 'artist', entityId: 42, is_upvote: true })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/tags/1/entities/artist/42/votes',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ is_upvote: true }),
+      })
+    )
+  })
+
+  it('optimistically updates entity tags cache on upvote', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+    })
+
+    queryClient.setQueryData(['tags', 'entityTags', 'artist', 42], {
+      tags: [
+        { tag_id: 1, name: 'rock', upvotes: 5, downvotes: 2, user_vote: 0 },
+        { tag_id: 2, name: 'indie', upvotes: 3, downvotes: 1, user_vote: 0 },
+      ],
+    })
+
+    mockApiRequest.mockResolvedValueOnce(undefined)
+
+    const { result } = renderHook(() => useVoteOnTag(), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    await act(async () => {
+      result.current.mutate({ tagId: 1, entityType: 'artist', entityId: 42, is_upvote: true })
+    })
+
+    const cached = queryClient.getQueryData<{ tags: Array<{ tag_id: number; upvotes: number; user_vote: number }> }>(
+      ['tags', 'entityTags', 'artist', 42]
+    )
+
+    // The first tag should have been optimistically updated
+    const tag = cached?.tags.find(t => t.tag_id === 1)
+    expect(tag?.user_vote).toBe(1)
+    expect(tag?.upvotes).toBe(6)
+
+    // The second tag should be unchanged
+    const otherTag = cached?.tags.find(t => t.tag_id === 2)
+    expect(otherTag?.user_vote).toBe(0)
+  })
+})
+
+describe('useRemoveTagVote', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('removes a vote with DELETE', async () => {
+    mockApiRequest.mockResolvedValueOnce(undefined)
+
+    const { result } = renderHook(() => useRemoveTagVote(), { wrapper: createWrapper() })
+
+    await act(async () => {
+      result.current.mutate({ tagId: 1, entityType: 'artist', entityId: 42 })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/tags/1/entities/artist/42/votes',
+      expect.objectContaining({ method: 'DELETE' })
+    )
+  })
+})

--- a/frontend/lib/hooks/admin/useAdminArtistReports.test.tsx
+++ b/frontend/lib/hooks/admin/useAdminArtistReports.test.tsx
@@ -1,0 +1,195 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const mockApiRequest = vi.fn()
+const mockInvalidateArtistReports = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    ADMIN: {
+      ARTIST_REPORTS: {
+        LIST: '/admin/artist-reports',
+        DISMISS: (reportId: string | number) => `/admin/artist-reports/${reportId}/dismiss`,
+        RESOLVE: (reportId: string | number) => `/admin/artist-reports/${reportId}/resolve`,
+      },
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    artistReports: {
+      pending: (limit: number, offset: number) =>
+        ['artistReports', 'pending', { limit, offset }],
+    },
+  },
+  createInvalidateQueries: () => ({
+    artistReports: mockInvalidateArtistReports,
+  }),
+}))
+
+import {
+  usePendingArtistReports,
+  useDismissArtistReport,
+  useResolveArtistReport,
+} from './useAdminArtistReports'
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+}
+
+describe('usePendingArtistReports', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches pending artist reports with defaults', async () => {
+    mockApiRequest.mockResolvedValueOnce({ reports: [], total: 0 })
+
+    const { result } = renderHook(() => usePendingArtistReports(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const url = mockApiRequest.mock.calls[0][0] as string
+    expect(url).toContain('/admin/artist-reports')
+    expect(url).toContain('limit=50')
+    expect(url).toContain('offset=0')
+  })
+
+  it('uses custom pagination', async () => {
+    mockApiRequest.mockResolvedValueOnce({ reports: [], total: 0 })
+
+    const { result } = renderHook(
+      () => usePendingArtistReports({ limit: 10, offset: 20 }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const url = mockApiRequest.mock.calls[0][0] as string
+    expect(url).toContain('limit=10')
+    expect(url).toContain('offset=20')
+  })
+})
+
+describe('useDismissArtistReport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateArtistReports.mockReset()
+  })
+
+  it('dismisses a report with POST', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 1, status: 'dismissed' })
+
+    const { result } = renderHook(() => useDismissArtistReport(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ reportId: 1, notes: 'Not actionable' })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/admin/artist-reports/1/dismiss',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ notes: 'Not actionable' }),
+      })
+    )
+  })
+
+  it('dismisses without notes', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 1, status: 'dismissed' })
+
+    const { result } = renderHook(() => useDismissArtistReport(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ reportId: 1 })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/admin/artist-reports/1/dismiss',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({}),
+      })
+    )
+  })
+
+  it('invalidates reports on success', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 1 })
+
+    const { result } = renderHook(() => useDismissArtistReport(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ reportId: 1 })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockInvalidateArtistReports).toHaveBeenCalled()
+  })
+})
+
+describe('useResolveArtistReport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateArtistReports.mockReset()
+  })
+
+  it('resolves a report with POST', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 1, status: 'resolved' })
+
+    const { result } = renderHook(() => useResolveArtistReport(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ reportId: 1, notes: 'Fixed' })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/admin/artist-reports/1/resolve',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ notes: 'Fixed' }),
+      })
+    )
+  })
+
+  it('invalidates reports on success', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 1 })
+
+    const { result } = renderHook(() => useResolveArtistReport(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ reportId: 1 })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockInvalidateArtistReports).toHaveBeenCalled()
+  })
+})

--- a/frontend/lib/hooks/admin/useAdminAuditLogs.test.tsx
+++ b/frontend/lib/hooks/admin/useAdminAuditLogs.test.tsx
@@ -1,0 +1,92 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const mockApiRequest = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    ADMIN: {
+      AUDIT_LOGS: {
+        LIST: '/admin/audit-logs',
+      },
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    admin: {
+      auditLogs: (limit: number, offset: number) =>
+        ['admin', 'auditLogs', { limit, offset }],
+    },
+  },
+}))
+
+import { useAuditLogs } from './useAdminAuditLogs'
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+    },
+  })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+}
+
+describe('useAuditLogs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches audit logs with default pagination', async () => {
+    const mockLogs = {
+      logs: [
+        { id: 1, action: 'show.approved', created_at: '2025-03-17T12:00:00Z' },
+      ],
+      total: 1,
+    }
+    mockApiRequest.mockResolvedValueOnce(mockLogs)
+
+    const { result } = renderHook(() => useAuditLogs(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const url = mockApiRequest.mock.calls[0][0] as string
+    expect(url).toContain('/admin/audit-logs')
+    expect(url).toContain('limit=50')
+    expect(url).toContain('offset=0')
+  })
+
+  it('uses custom limit and offset', async () => {
+    mockApiRequest.mockResolvedValueOnce({ logs: [], total: 0 })
+
+    const { result } = renderHook(() => useAuditLogs({ limit: 20, offset: 40 }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const url = mockApiRequest.mock.calls[0][0] as string
+    expect(url).toContain('limit=20')
+    expect(url).toContain('offset=40')
+  })
+
+  it('handles API errors', async () => {
+    const error = new Error('Forbidden')
+    Object.assign(error, { status: 403 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useAuditLogs(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+  })
+})

--- a/frontend/lib/hooks/admin/useAdminReports.test.tsx
+++ b/frontend/lib/hooks/admin/useAdminReports.test.tsx
@@ -1,0 +1,198 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const mockApiRequest = vi.fn()
+const mockInvalidateShowReports = vi.fn()
+const mockInvalidateShows = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    ADMIN: {
+      REPORTS: {
+        LIST: '/admin/reports',
+        DISMISS: (reportId: string | number) => `/admin/reports/${reportId}/dismiss`,
+        RESOLVE: (reportId: string | number) => `/admin/reports/${reportId}/resolve`,
+      },
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    showReports: {
+      pending: (limit: number, offset: number) =>
+        ['showReports', 'pending', { limit, offset }],
+    },
+  },
+  createInvalidateQueries: () => ({
+    showReports: mockInvalidateShowReports,
+    shows: mockInvalidateShows,
+  }),
+}))
+
+import {
+  usePendingReports,
+  useDismissReport,
+  useResolveReport,
+} from './useAdminReports'
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+}
+
+describe('usePendingReports', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches pending show reports with defaults', async () => {
+    mockApiRequest.mockResolvedValueOnce({ reports: [], total: 0 })
+
+    const { result } = renderHook(() => usePendingReports(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const url = mockApiRequest.mock.calls[0][0] as string
+    expect(url).toContain('/admin/reports')
+    expect(url).toContain('limit=50')
+    expect(url).toContain('offset=0')
+  })
+
+  it('uses custom pagination', async () => {
+    mockApiRequest.mockResolvedValueOnce({ reports: [], total: 0 })
+
+    const { result } = renderHook(
+      () => usePendingReports({ limit: 10, offset: 30 }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const url = mockApiRequest.mock.calls[0][0] as string
+    expect(url).toContain('limit=10')
+    expect(url).toContain('offset=30')
+  })
+})
+
+describe('useDismissReport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateShowReports.mockReset()
+  })
+
+  it('dismisses a report with POST', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 1, status: 'dismissed' })
+
+    const { result } = renderHook(() => useDismissReport(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ reportId: 1, notes: 'Spam' })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/admin/reports/1/dismiss',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ notes: 'Spam' }),
+      })
+    )
+  })
+
+  it('invalidates show reports on success', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 1 })
+
+    const { result } = renderHook(() => useDismissReport(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ reportId: 1 })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockInvalidateShowReports).toHaveBeenCalled()
+  })
+})
+
+describe('useResolveReport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateShowReports.mockReset()
+    mockInvalidateShows.mockReset()
+  })
+
+  it('resolves a report with POST', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 1, status: 'resolved' })
+
+    const { result } = renderHook(() => useResolveReport(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ reportId: 1, notes: 'Fixed', setShowFlag: true })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/admin/reports/1/resolve',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ set_show_flag: true, notes: 'Fixed' }),
+      })
+    )
+  })
+
+  it('defaults setShowFlag to false', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 1, status: 'resolved' })
+
+    const { result } = renderHook(() => useResolveReport(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ reportId: 1 })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/admin/reports/1/resolve',
+      expect.objectContaining({
+        body: JSON.stringify({ set_show_flag: false }),
+      })
+    )
+  })
+
+  it('invalidates show reports and shows on success', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 1 })
+
+    const { result } = renderHook(() => useResolveReport(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ reportId: 1 })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockInvalidateShowReports).toHaveBeenCalled()
+    expect(mockInvalidateShows).toHaveBeenCalled()
+  })
+})

--- a/frontend/lib/hooks/admin/useAdminStats.test.tsx
+++ b/frontend/lib/hooks/admin/useAdminStats.test.tsx
@@ -1,0 +1,112 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const mockApiRequest = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    ADMIN: {
+      STATS: '/admin/stats',
+      ACTIVITY: '/admin/activity',
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    admin: {
+      stats: ['admin', 'stats'],
+      activity: ['admin', 'activity'],
+    },
+  },
+}))
+
+import { useAdminStats, useAdminActivity } from './useAdminStats'
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+    },
+  })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+}
+
+describe('useAdminStats', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches admin dashboard stats', async () => {
+    const mockStats = {
+      total_shows: 100,
+      total_artists: 50,
+      total_venues: 20,
+      pending_shows: 5,
+    }
+    mockApiRequest.mockResolvedValueOnce(mockStats)
+
+    const { result } = renderHook(() => useAdminStats(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith('/admin/stats', { method: 'GET' })
+    expect(result.current.data?.total_shows).toBe(100)
+  })
+
+  it('handles API errors', async () => {
+    const error = new Error('Forbidden')
+    Object.assign(error, { status: 403 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useAdminStats(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+  })
+})
+
+describe('useAdminActivity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches admin activity feed', async () => {
+    const mockActivity = {
+      events: [
+        { id: 1, event_type: 'show_approved', created_at: '2025-03-17T12:00:00Z' },
+        { id: 2, event_type: 'artist_updated', created_at: '2025-03-17T11:00:00Z' },
+      ],
+    }
+    mockApiRequest.mockResolvedValueOnce(mockActivity)
+
+    const { result } = renderHook(() => useAdminActivity(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith('/admin/activity', { method: 'GET' })
+    expect(result.current.data?.events).toHaveLength(2)
+  })
+
+  it('handles empty activity feed', async () => {
+    mockApiRequest.mockResolvedValueOnce({ events: [] })
+
+    const { result } = renderHook(() => useAdminActivity(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data?.events).toEqual([])
+  })
+})

--- a/frontend/lib/hooks/admin/useAdminUsers.test.tsx
+++ b/frontend/lib/hooks/admin/useAdminUsers.test.tsx
@@ -1,0 +1,93 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const mockApiRequest = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    ADMIN: {
+      USERS: {
+        LIST: '/admin/users',
+      },
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    admin: {
+      users: (limit: number, offset: number, search: string) =>
+        ['admin', 'users', { limit, offset, search }],
+    },
+  },
+}))
+
+import { useAdminUsers } from './useAdminUsers'
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+    },
+  })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+}
+
+describe('useAdminUsers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches users with default pagination', async () => {
+    const mockResponse = {
+      users: [{ id: 1, email: 'user@test.com', username: 'testuser' }],
+      total: 1,
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useAdminUsers(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const url = mockApiRequest.mock.calls[0][0] as string
+    expect(url).toContain('/admin/users')
+    expect(url).toContain('limit=50')
+    expect(url).toContain('offset=0')
+    expect(url).not.toContain('search=')
+  })
+
+  it('uses custom pagination and search', async () => {
+    mockApiRequest.mockResolvedValueOnce({ users: [], total: 0 })
+
+    const { result } = renderHook(
+      () => useAdminUsers({ limit: 20, offset: 40, search: 'john' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const url = mockApiRequest.mock.calls[0][0] as string
+    expect(url).toContain('limit=20')
+    expect(url).toContain('offset=40')
+    expect(url).toContain('search=john')
+  })
+
+  it('handles API errors', async () => {
+    const error = new Error('Forbidden')
+    Object.assign(error, { status: 403 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useAdminUsers(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+  })
+})

--- a/frontend/lib/hooks/admin/useDataQuality.test.tsx
+++ b/frontend/lib/hooks/admin/useDataQuality.test.tsx
@@ -1,0 +1,143 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const mockApiRequest = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    ADMIN: {
+      DATA_QUALITY: {
+        SUMMARY: '/admin/data-quality',
+        CATEGORY: (category: string) => `/admin/data-quality/${category}`,
+      },
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    admin: {
+      dataQuality: {
+        summary: ['admin', 'dataQuality', 'summary'],
+        category: (category: string, limit: number, offset: number) =>
+          ['admin', 'dataQuality', 'category', category, { limit, offset }],
+      },
+    },
+  },
+}))
+
+import { useDataQualitySummary, useDataQualityCategory } from './useDataQuality'
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+    },
+  })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+}
+
+describe('useDataQualitySummary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches data quality summary', async () => {
+    const mockSummary = {
+      categories: [
+        { key: 'missing_social', label: 'Missing Social Links', entity_type: 'artist', count: 10, description: '' },
+        { key: 'no_shows', label: 'Venues with No Shows', entity_type: 'venue', count: 5, description: '' },
+      ],
+      total_items: 15,
+    }
+    mockApiRequest.mockResolvedValueOnce(mockSummary)
+
+    const { result } = renderHook(() => useDataQualitySummary(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith('/admin/data-quality', { method: 'GET' })
+    expect(result.current.data?.categories).toHaveLength(2)
+    expect(result.current.data?.total_items).toBe(15)
+  })
+
+  it('handles API errors', async () => {
+    const error = new Error('Forbidden')
+    Object.assign(error, { status: 403 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useDataQualitySummary(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+  })
+})
+
+describe('useDataQualityCategory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches items for a category with defaults', async () => {
+    const mockItems = {
+      items: [
+        { entity_type: 'artist', entity_id: 1, name: 'Test Artist', slug: 'test-artist', reason: 'missing social', show_count: 5 },
+      ],
+      total: 1,
+    }
+    mockApiRequest.mockResolvedValueOnce(mockItems)
+
+    const { result } = renderHook(
+      () => useDataQualityCategory('missing_social'),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const url = mockApiRequest.mock.calls[0][0] as string
+    expect(url).toContain('/admin/data-quality/missing_social')
+    expect(url).toContain('limit=50')
+    expect(url).toContain('offset=0')
+  })
+
+  it('uses custom limit and offset', async () => {
+    mockApiRequest.mockResolvedValueOnce({ items: [], total: 0 })
+
+    const { result } = renderHook(
+      () => useDataQualityCategory('missing_social', 10, 20),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const url = mockApiRequest.mock.calls[0][0] as string
+    expect(url).toContain('limit=10')
+    expect(url).toContain('offset=20')
+  })
+
+  it('does not fetch when category is empty', () => {
+    const { result } = renderHook(
+      () => useDataQualityCategory(''),
+      { wrapper: createWrapper() }
+    )
+
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('does not fetch when enabled is false', () => {
+    const { result } = renderHook(
+      () => useDataQualityCategory('missing_social', 50, 0, { enabled: false }),
+      { wrapper: createWrapper() }
+    )
+
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+})

--- a/frontend/lib/hooks/common/useDensity.test.ts
+++ b/frontend/lib/hooks/common/useDensity.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useDensity, type Density } from './useDensity'
+
+describe('useDensity', () => {
+  const localStorageMock = (() => {
+    let store: Record<string, string> = {}
+    return {
+      getItem: vi.fn((key: string) => store[key] ?? null),
+      setItem: vi.fn((key: string, value: string) => {
+        store[key] = value
+      }),
+      clear: () => {
+        store = {}
+      },
+    }
+  })()
+
+  beforeEach(() => {
+    localStorageMock.clear()
+    localStorageMock.getItem.mockClear()
+    localStorageMock.setItem.mockClear()
+    Object.defineProperty(window, 'localStorage', {
+      value: localStorageMock,
+      writable: true,
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns default density "comfortable" initially', () => {
+    const { result } = renderHook(() => useDensity())
+
+    // Before the useEffect runs, density is the default
+    expect(result.current.density).toBe('comfortable')
+  })
+
+  it('provides setDensity function', () => {
+    const { result } = renderHook(() => useDensity())
+
+    expect(typeof result.current.setDensity).toBe('function')
+  })
+
+  it('persists density to localStorage when setDensity is called', () => {
+    const { result } = renderHook(() => useDensity())
+
+    act(() => {
+      result.current.setDensity('compact')
+    })
+
+    expect(result.current.density).toBe('compact')
+    expect(localStorageMock.setItem).toHaveBeenCalledWith('ph-density', 'compact')
+  })
+
+  it('reads stored density from localStorage on mount', () => {
+    localStorageMock.getItem.mockReturnValue('expanded')
+
+    const { result } = renderHook(() => useDensity())
+
+    // After the effect runs, it should read from localStorage
+    expect(localStorageMock.getItem).toHaveBeenCalledWith('ph-density')
+    expect(result.current.density).toBe('expanded')
+  })
+
+  it('uses storage key suffix when provided', () => {
+    const { result } = renderHook(() => useDensity('shows'))
+
+    act(() => {
+      result.current.setDensity('compact')
+    })
+
+    expect(localStorageMock.setItem).toHaveBeenCalledWith('ph-density-shows', 'compact')
+  })
+
+  it('reads from suffixed key on mount', () => {
+    localStorageMock.getItem.mockImplementation((key: string) => {
+      if (key === 'ph-density-artists') return 'expanded'
+      return null
+    })
+
+    const { result } = renderHook(() => useDensity('artists'))
+
+    expect(localStorageMock.getItem).toHaveBeenCalledWith('ph-density-artists')
+    expect(result.current.density).toBe('expanded')
+  })
+
+  it('falls back to default for invalid stored values', () => {
+    localStorageMock.getItem.mockReturnValue('invalid-value')
+
+    const { result } = renderHook(() => useDensity())
+
+    expect(result.current.density).toBe('comfortable')
+  })
+
+  it('handles localStorage errors gracefully on read', () => {
+    localStorageMock.getItem.mockImplementation(() => {
+      throw new Error('localStorage disabled')
+    })
+
+    const { result } = renderHook(() => useDensity())
+
+    // Should fall back to default without throwing
+    expect(result.current.density).toBe('comfortable')
+  })
+
+  it('handles localStorage errors gracefully on write', () => {
+    localStorageMock.setItem.mockImplementation(() => {
+      throw new Error('localStorage full')
+    })
+
+    const { result } = renderHook(() => useDensity())
+
+    // Should not throw, but still update state in memory
+    act(() => {
+      result.current.setDensity('expanded')
+    })
+
+    expect(result.current.density).toBe('expanded')
+  })
+
+  it('supports all valid density values', () => {
+    const validDensities: Density[] = ['compact', 'comfortable', 'expanded']
+
+    for (const density of validDensities) {
+      localStorageMock.getItem.mockReturnValue(density)
+
+      const { result } = renderHook(() => useDensity())
+
+      expect(result.current.density).toBe(density)
+    }
+  })
+
+  it('updates density when setDensity is called multiple times', () => {
+    const { result } = renderHook(() => useDensity())
+
+    act(() => {
+      result.current.setDensity('compact')
+    })
+    expect(result.current.density).toBe('compact')
+
+    act(() => {
+      result.current.setDensity('expanded')
+    })
+    expect(result.current.density).toBe('expanded')
+
+    act(() => {
+      result.current.setDensity('comfortable')
+    })
+    expect(result.current.density).toBe('comfortable')
+  })
+})

--- a/frontend/lib/hooks/common/useFilterNavigation.test.ts
+++ b/frontend/lib/hooks/common/useFilterNavigation.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+const mockPush = vi.fn()
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+    replace: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+}))
+
+import { useFilterNavigation } from './useFilterNavigation'
+
+describe('useFilterNavigation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockPush.mockReset()
+  })
+
+  it('returns navigate function and isPending state', () => {
+    const { result } = renderHook(() => useFilterNavigation('/shows'))
+
+    expect(typeof result.current.navigate).toBe('function')
+    expect(typeof result.current.isPending).toBe('boolean')
+  })
+
+  it('navigates with query params', () => {
+    const { result } = renderHook(() => useFilterNavigation('/shows'))
+
+    act(() => {
+      result.current.navigate({ city: 'Phoenix', state: 'AZ' })
+    })
+
+    expect(mockPush).toHaveBeenCalledWith('/shows?city=Phoenix&state=AZ')
+  })
+
+  it('navigates to base path when all params are null', () => {
+    const { result } = renderHook(() => useFilterNavigation('/artists'))
+
+    act(() => {
+      result.current.navigate({ city: null, state: null })
+    })
+
+    expect(mockPush).toHaveBeenCalledWith('/artists')
+  })
+
+  it('omits null values from query string', () => {
+    const { result } = renderHook(() => useFilterNavigation('/shows'))
+
+    act(() => {
+      result.current.navigate({ city: 'Phoenix', state: null, genre: 'rock' })
+    })
+
+    expect(mockPush).toHaveBeenCalledWith('/shows?city=Phoenix&genre=rock')
+  })
+
+  it('uses the provided basePath', () => {
+    const { result } = renderHook(() => useFilterNavigation('/custom/path'))
+
+    act(() => {
+      result.current.navigate({ filter: 'value' })
+    })
+
+    expect(mockPush).toHaveBeenCalledWith('/custom/path?filter=value')
+  })
+})

--- a/frontend/lib/hooks/common/useFollow.test.tsx
+++ b/frontend/lib/hooks/common/useFollow.test.tsx
@@ -1,0 +1,295 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const mockApiRequest = vi.fn()
+const mockInvalidateFollows = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    FOLLOW: {
+      ENTITY: (entityType: string, entityId: number) => `/${entityType}/${entityId}/follow`,
+      FOLLOWERS: (entityType: string, entityId: number) => `/${entityType}/${entityId}/followers`,
+      BATCH: '/follows/batch',
+      MY_FOLLOWING: '/me/following',
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    follows: {
+      entity: (entityType: string, entityId: number) => ['follows', entityType, entityId],
+      batch: (entityType: string, entityIds: number[]) => ['follows', 'batch', entityType, ...entityIds],
+      myFollowing: (params?: Record<string, unknown>) => ['follows', 'my-following', params],
+    },
+  },
+  createInvalidateQueries: () => ({
+    follows: mockInvalidateFollows,
+  }),
+}))
+
+vi.mock('@/lib/context/AuthContext', () => ({
+  useAuthContext: () => ({ isAuthenticated: true }),
+}))
+
+import {
+  useFollowStatus,
+  useBatchFollowStatus,
+  useFollow,
+  useUnfollow,
+  useMyFollowing,
+} from './useFollow'
+
+function createWrapper(queryClient?: QueryClient) {
+  const qc =
+    queryClient ??
+    new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: 0 },
+        mutations: { retry: false },
+      },
+    })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  }
+}
+
+describe('useFollowStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches follow status for an entity', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      follower_count: 42,
+      is_following: true,
+    })
+
+    const { result } = renderHook(() => useFollowStatus('artists', 1), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith('/artists/1/followers', { method: 'GET' })
+    expect(result.current.data?.follower_count).toBe(42)
+    expect(result.current.data?.is_following).toBe(true)
+  })
+
+  it('does not fetch when entityId is 0', () => {
+    const { result } = renderHook(() => useFollowStatus('artists', 0), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('does not fetch when entityType is empty', () => {
+    const { result } = renderHook(() => useFollowStatus('', 1), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+})
+
+describe('useBatchFollowStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches batch follow status via POST', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      follows: {
+        '1': { follower_count: 10, is_following: true },
+        '2': { follower_count: 5, is_following: false },
+      },
+    })
+
+    const { result } = renderHook(
+      () => useBatchFollowStatus('artists', [1, 2]),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/follows/batch',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ entity_type: 'artists', entity_ids: [1, 2] }),
+      })
+    )
+  })
+
+  it('does not fetch when entityIds is empty', () => {
+    const { result } = renderHook(
+      () => useBatchFollowStatus('artists', []),
+      { wrapper: createWrapper() }
+    )
+
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+})
+
+describe('useFollow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateFollows.mockReset()
+  })
+
+  it('follows an entity with POST', async () => {
+    mockApiRequest.mockResolvedValueOnce({ success: true, message: 'Followed' })
+
+    const { result } = renderHook(() => useFollow(), { wrapper: createWrapper() })
+
+    await act(async () => {
+      result.current.mutate({ entityType: 'artists', entityId: 1 })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/artists/1/follow',
+      expect.objectContaining({ method: 'POST' })
+    )
+  })
+
+  it('performs optimistic update on follow', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+    })
+
+    queryClient.setQueryData(['follows', 'artists', 1], {
+      follower_count: 10,
+      is_following: false,
+    })
+
+    mockApiRequest.mockResolvedValueOnce({ success: true })
+
+    const { result } = renderHook(() => useFollow(), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    await act(async () => {
+      result.current.mutate({ entityType: 'artists', entityId: 1 })
+    })
+
+    const cached = queryClient.getQueryData<{
+      follower_count: number
+      is_following: boolean
+    }>(['follows', 'artists', 1])
+
+    expect(cached?.follower_count).toBe(11)
+    expect(cached?.is_following).toBe(true)
+  })
+})
+
+describe('useUnfollow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateFollows.mockReset()
+  })
+
+  it('unfollows an entity with DELETE', async () => {
+    mockApiRequest.mockResolvedValueOnce({ success: true, message: 'Unfollowed' })
+
+    const { result } = renderHook(() => useUnfollow(), { wrapper: createWrapper() })
+
+    await act(async () => {
+      result.current.mutate({ entityType: 'artists', entityId: 1 })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/artists/1/follow',
+      expect.objectContaining({ method: 'DELETE' })
+    )
+  })
+
+  it('performs optimistic update on unfollow', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+    })
+
+    queryClient.setQueryData(['follows', 'artists', 1], {
+      follower_count: 10,
+      is_following: true,
+    })
+
+    mockApiRequest.mockResolvedValueOnce({ success: true })
+
+    const { result } = renderHook(() => useUnfollow(), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    await act(async () => {
+      result.current.mutate({ entityType: 'artists', entityId: 1 })
+    })
+
+    const cached = queryClient.getQueryData<{
+      follower_count: number
+      is_following: boolean
+    }>(['follows', 'artists', 1])
+
+    expect(cached?.follower_count).toBe(9)
+    expect(cached?.is_following).toBe(false)
+  })
+
+  it('handles unfollow errors', async () => {
+    const error = new Error('Network error')
+    Object.assign(error, { status: 500 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useUnfollow(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ entityType: 'artists', entityId: 1 })
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error).toBeDefined()
+  })
+})
+
+describe('useMyFollowing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches user following list with defaults', async () => {
+    mockApiRequest.mockResolvedValueOnce({ following: [], total: 0 })
+
+    const { result } = renderHook(() => useMyFollowing(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const url = mockApiRequest.mock.calls[0][0] as string
+    expect(url).toContain('/me/following')
+    expect(url).toContain('limit=20')
+    expect(url).toContain('offset=0')
+    expect(url).not.toContain('type=')
+  })
+
+  it('includes type filter', async () => {
+    mockApiRequest.mockResolvedValueOnce({ following: [], total: 0 })
+
+    const { result } = renderHook(() => useMyFollowing({ type: 'artists' }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest.mock.calls[0][0]).toContain('type=artists')
+  })
+})

--- a/frontend/lib/hooks/common/useFollow.test.tsx
+++ b/frontend/lib/hooks/common/useFollow.test.tsx
@@ -162,7 +162,7 @@ describe('useFollow', () => {
 
   it('performs optimistic update on follow', async () => {
     const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+      defaultOptions: { queries: { retry: false, gcTime: Infinity }, mutations: { retry: false } },
     })
 
     queryClient.setQueryData(['follows', 'artists', 1], {
@@ -216,7 +216,7 @@ describe('useUnfollow', () => {
 
   it('performs optimistic update on unfollow', async () => {
     const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+      defaultOptions: { queries: { retry: false, gcTime: Infinity }, mutations: { retry: false } },
     })
 
     queryClient.setQueryData(['follows', 'artists', 1], {

--- a/frontend/lib/hooks/common/useRevisions.test.tsx
+++ b/frontend/lib/hooks/common/useRevisions.test.tsx
@@ -1,0 +1,203 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const mockApiRequest = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    REVISIONS: {
+      ENTITY_HISTORY: (entityType: string, entityId: string | number) =>
+        `/revisions/${entityType}/${entityId}`,
+      DETAIL: (revisionId: number) => `/revisions/${revisionId}`,
+      USER_REVISIONS: (userId: string | number) => `/users/${userId}/revisions`,
+      ROLLBACK: (revisionId: number) => `/admin/revisions/${revisionId}/rollback`,
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    revisions: {
+      all: ['revisions'],
+      entity: (entityType: string, entityId: string | number) =>
+        ['revisions', 'entity', entityType, String(entityId)],
+      detail: (revisionId: number) => ['revisions', 'detail', revisionId],
+      user: (userId: string | number) => ['revisions', 'user', String(userId)],
+    },
+  },
+}))
+
+import {
+  useEntityRevisions,
+  useRevision,
+  useUserRevisions,
+  useRollbackRevision,
+} from './useRevisions'
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+}
+
+describe('useEntityRevisions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches revisions for an entity', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      revisions: [
+        { id: 1, entity_type: 'artist', entity_id: 42, changes: [] },
+      ],
+      total: 1,
+    })
+
+    const { result } = renderHook(
+      () => useEntityRevisions('artist', 42),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const url = mockApiRequest.mock.calls[0][0] as string
+    expect(url).toContain('/revisions/artist/42')
+    expect(url).toContain('limit=20')
+    // Note: offset=0 is falsy, so the hook's `if (offset)` check skips it.
+    // This is a minor bug -- offset 0 is valid but gets omitted.
+    // The backend defaults to 0 anyway, so it's functionally correct.
+  })
+
+  it('includes custom limit and offset', async () => {
+    mockApiRequest.mockResolvedValueOnce({ revisions: [], total: 0 })
+
+    const { result } = renderHook(
+      () => useEntityRevisions('venue', 10, { limit: 50, offset: 20 }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const url = mockApiRequest.mock.calls[0][0] as string
+    expect(url).toContain('limit=50')
+    expect(url).toContain('offset=20')
+  })
+
+  it('does not fetch when enabled is false', () => {
+    const { result } = renderHook(
+      () => useEntityRevisions('artist', 42, { enabled: false }),
+      { wrapper: createWrapper() }
+    )
+
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+})
+
+describe('useRevision', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches a single revision', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      id: 1,
+      entity_type: 'artist',
+      entity_id: 42,
+      changes: [{ field: 'name', old_value: 'Old', new_value: 'New' }],
+    })
+
+    const { result } = renderHook(() => useRevision(1), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith('/revisions/1')
+  })
+
+  it('does not fetch when revisionId is 0', () => {
+    const { result } = renderHook(() => useRevision(0), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('does not fetch when enabled is false', () => {
+    const { result } = renderHook(() => useRevision(1, { enabled: false }), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+})
+
+describe('useUserRevisions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches revisions for a user', async () => {
+    mockApiRequest.mockResolvedValueOnce({ revisions: [], total: 0 })
+
+    const { result } = renderHook(() => useUserRevisions(5), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const url = mockApiRequest.mock.calls[0][0] as string
+    expect(url).toContain('/users/5/revisions')
+    expect(url).toContain('limit=20')
+  })
+})
+
+describe('useRollbackRevision', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('rolls back a revision with POST', async () => {
+    mockApiRequest.mockResolvedValueOnce({ success: true })
+
+    const { result } = renderHook(() => useRollbackRevision(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(1)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/admin/revisions/1/rollback',
+      expect.objectContaining({ method: 'POST' })
+    )
+  })
+
+  it('handles rollback errors', async () => {
+    const error = new Error('Forbidden')
+    Object.assign(error, { status: 403 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useRollbackRevision(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(1)
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+  })
+})

--- a/frontend/lib/legal.test.ts
+++ b/frontend/lib/legal.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { CURRENT_TERMS_VERSION, CURRENT_PRIVACY_VERSION } from './legal'
+
+describe('legal constants', () => {
+  it('exports CURRENT_TERMS_VERSION as a date string', () => {
+    expect(CURRENT_TERMS_VERSION).toBeDefined()
+    expect(typeof CURRENT_TERMS_VERSION).toBe('string')
+    // Should be a valid date format YYYY-MM-DD
+    expect(CURRENT_TERMS_VERSION).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+  })
+
+  it('exports CURRENT_PRIVACY_VERSION as a date string', () => {
+    expect(CURRENT_PRIVACY_VERSION).toBeDefined()
+    expect(typeof CURRENT_PRIVACY_VERSION).toBe('string')
+    expect(CURRENT_PRIVACY_VERSION).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+  })
+
+  it('has valid date values that can be parsed', () => {
+    const termsDate = new Date(CURRENT_TERMS_VERSION)
+    const privacyDate = new Date(CURRENT_PRIVACY_VERSION)
+
+    expect(termsDate.toString()).not.toBe('Invalid Date')
+    expect(privacyDate.toString()).not.toBe('Invalid Date')
+  })
+
+  it('has terms version set to expected value', () => {
+    expect(CURRENT_TERMS_VERSION).toBe('2026-01-31')
+  })
+
+  it('has privacy version set to expected value', () => {
+    expect(CURRENT_PRIVACY_VERSION).toBe('2026-02-15')
+  })
+})

--- a/frontend/lib/utils/showDateBadge.test.ts
+++ b/frontend/lib/utils/showDateBadge.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// Mock the timeUtils module
+vi.mock('./timeUtils', () => ({
+  getTimezoneForState: vi.fn((state: string) => {
+    const map: Record<string, string> = {
+      AZ: 'America/Phoenix',
+      CA: 'America/Los_Angeles',
+      NY: 'America/New_York',
+    }
+    return map[state.toUpperCase()] || 'America/Phoenix'
+  }),
+  formatInTimezone: vi.fn(
+    (dateString: string, _timezone: string, options: Intl.DateTimeFormatOptions) => {
+      const date = new Date(dateString)
+      if (options.weekday === 'short') return date.toLocaleString('en-US', { weekday: 'short', timeZone: 'America/Phoenix' })
+      if (options.month === 'short') return date.toLocaleString('en-US', { month: 'short', timeZone: 'America/Phoenix' })
+      if (options.day === 'numeric') return date.toLocaleString('en-US', { day: 'numeric', timeZone: 'America/Phoenix' })
+      return ''
+    }
+  ),
+}))
+
+import { formatShowDateBadge } from './showDateBadge'
+import { getTimezoneForState, formatInTimezone } from './timeUtils'
+
+describe('formatShowDateBadge', () => {
+  it('returns dayOfWeek and monthDay parts', () => {
+    const result = formatShowDateBadge('2025-03-17T19:00:00Z')
+
+    expect(result).toHaveProperty('dayOfWeek')
+    expect(result).toHaveProperty('monthDay')
+    expect(typeof result.dayOfWeek).toBe('string')
+    expect(typeof result.monthDay).toBe('string')
+  })
+
+  it('calls getTimezoneForState with the provided state', () => {
+    formatShowDateBadge('2025-03-17T19:00:00Z', 'CA')
+
+    expect(getTimezoneForState).toHaveBeenCalledWith('CA')
+  })
+
+  it('defaults to AZ when state is not provided', () => {
+    formatShowDateBadge('2025-03-17T19:00:00Z')
+
+    expect(getTimezoneForState).toHaveBeenCalledWith('AZ')
+  })
+
+  it('defaults to AZ when state is null', () => {
+    formatShowDateBadge('2025-03-17T19:00:00Z', null)
+
+    expect(getTimezoneForState).toHaveBeenCalledWith('AZ')
+  })
+
+  it('calls formatInTimezone three times (weekday, month, day)', () => {
+    vi.mocked(formatInTimezone).mockClear()
+
+    formatShowDateBadge('2025-03-17T19:00:00Z', 'AZ')
+
+    expect(formatInTimezone).toHaveBeenCalledTimes(3)
+    expect(formatInTimezone).toHaveBeenCalledWith(
+      '2025-03-17T19:00:00Z',
+      'America/Phoenix',
+      { weekday: 'short' }
+    )
+    expect(formatInTimezone).toHaveBeenCalledWith(
+      '2025-03-17T19:00:00Z',
+      'America/Phoenix',
+      { month: 'short' }
+    )
+    expect(formatInTimezone).toHaveBeenCalledWith(
+      '2025-03-17T19:00:00Z',
+      'America/Phoenix',
+      { day: 'numeric' }
+    )
+  })
+
+  it('uppercases dayOfWeek and month', () => {
+    vi.mocked(formatInTimezone)
+      .mockReturnValueOnce('Mon') // weekday
+      .mockReturnValueOnce('Mar') // month
+      .mockReturnValueOnce('17') // day
+
+    const result = formatShowDateBadge('2025-03-17T19:00:00Z')
+
+    expect(result.dayOfWeek).toBe('MON')
+    expect(result.monthDay).toBe('MAR 17')
+  })
+
+  it('formats monthDay as "MONTH DAY"', () => {
+    vi.mocked(formatInTimezone)
+      .mockReturnValueOnce('Fri') // weekday
+      .mockReturnValueOnce('Dec') // month
+      .mockReturnValueOnce('1') // day
+
+    const result = formatShowDateBadge('2025-12-01T03:00:00Z')
+
+    expect(result.dayOfWeek).toBe('FRI')
+    expect(result.monthDay).toBe('DEC 1')
+  })
+})


### PR DESCRIPTION
## Summary
- Adds **25 new test files** with **239 tests** across features/, lib/hooks/, lib/utils/, and components/
- Raises the test suite from 1,468 → 1,707 tests (98 → 123 test files)
- All 1,707 tests pass

### Coverage areas
- **Feature hooks (11 files, 136 tests):** collections, labels, festivals, releases, requests, notifications, tags, scenes, attendance, show reports, show reminders
- **Lib hooks (9 files, 56 tests):** follow, revisions, filter navigation, admin stats, audit logs, data quality, admin users, artist reports, show reports
- **Utilities (3 files, 23 tests):** showDateBadge, legal, useDensity
- **Components (2 files, 24 tests):** CollectionCard, FollowButton

### Bug found
`useRevisions.ts` lines 55-56 use `if (offset)` which is falsy when offset=0, so the first page never sends the offset param. Functionally harmless (backend defaults to 0) but a code quality issue.

## Test plan
- [x] All 1,707 tests pass via `bun run test:run`
- [ ] Verify no regressions in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)