### PR TITLE
Add venue genre profiles and scene genre distribution

### DIFF
--- a/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
+++ b/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
@@ -771,6 +771,7 @@ type mockVenueService struct {
 	cancelPendingVenueEditFn   func(editID uint, userID uint) error
 	getVenueModelFn            func(venueID uint) (*models.Venue, error)
 	getUnverifiedVenuesFn      func(limit, offset int) ([]*services.UnverifiedVenueResponse, int64, error)
+	getVenueGenreProfileFn     func(venueID uint) ([]services.GenreCount, error)
 }
 
 func (m *mockVenueService) CreateVenue(req *services.CreateVenueRequest, isAdmin bool) (*services.VenueDetailResponse, error) {
@@ -904,6 +905,12 @@ func (m *mockVenueService) GetUnverifiedVenues(limit, offset int) ([]*services.U
 		return m.getUnverifiedVenuesFn(limit, offset)
 	}
 	return nil, 0, nil
+}
+func (m *mockVenueService) GetVenueGenreProfile(venueID uint) ([]services.GenreCount, error) {
+	if m.getVenueGenreProfileFn != nil {
+		return m.getVenueGenreProfileFn(venueID)
+	}
+	return []services.GenreCount{}, nil
 }
 
 // ============================================================================

--- a/backend/internal/api/handlers/scene.go
+++ b/backend/internal/api/handlers/scene.go
@@ -6,6 +6,7 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 
 	"psychic-homily-backend/internal/services"
+	"psychic-homily-backend/internal/services/catalog"
 )
 
 // SceneHandler handles scene (city aggregation) endpoints.
@@ -136,6 +137,51 @@ func (h *SceneHandler) GetSceneActiveArtistsHandler(ctx context.Context, req *Ge
 	resp := &GetSceneActiveArtistsResponse{}
 	resp.Body.Artists = artists
 	resp.Body.Total = total
+
+	return resp, nil
+}
+
+// ============================================================================
+// Get Scene Genres
+// ============================================================================
+
+// GetSceneGenresRequest represents the request for getting scene genre distribution.
+type GetSceneGenresRequest struct {
+	Slug string `path:"slug" doc:"Scene slug (e.g. phoenix-az)" example:"phoenix-az"`
+}
+
+// GetSceneGenresResponse represents the response for scene genre distribution.
+type GetSceneGenresResponse struct {
+	Body *services.SceneGenreResponse
+}
+
+// GetSceneGenresHandler handles GET /scenes/{slug}/genres — returns genre distribution and diversity index.
+func (h *SceneHandler) GetSceneGenresHandler(ctx context.Context, req *GetSceneGenresRequest) (*GetSceneGenresResponse, error) {
+	city, state, err := h.sceneService.ParseSceneSlug(req.Slug)
+	if err != nil {
+		return nil, huma.Error404NotFound("Scene not found")
+	}
+
+	genres, err := h.sceneService.GetSceneGenreDistribution(city, state)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Failed to get scene genre distribution", err)
+	}
+	if genres == nil {
+		genres = []services.GenreCount{}
+	}
+
+	diversityIndex, err := h.sceneService.GetGenreDiversityIndex(city, state)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Failed to get genre diversity index", err)
+	}
+
+	resp := &GetSceneGenresResponse{
+		Body: &services.SceneGenreResponse{
+			Genres:         genres,
+			DiversityIndex: diversityIndex,
+			DiversityLabel: catalog.DiversityLabel(diversityIndex),
+		},
+	}
 
 	return resp, nil
 }

--- a/backend/internal/api/handlers/scene_test.go
+++ b/backend/internal/api/handlers/scene_test.go
@@ -17,6 +17,8 @@ type mockSceneService struct {
 	getSceneDetailFn func(city, state string) (*services.SceneDetailResponse, error)
 	getActiveArtistsFn func(city, state string, periodDays, limit, offset int) ([]*services.SceneArtistResponse, int64, error)
 	parseSceneSlugFn func(slug string) (string, string, error)
+	getSceneGenreDistributionFn func(city, state string) ([]services.GenreCount, error)
+	getGenreDiversityIndexFn func(city, state string) (float64, error)
 }
 
 func (m *mockSceneService) ListScenes() ([]*services.SceneListResponse, error) {
@@ -45,6 +47,20 @@ func (m *mockSceneService) ParseSceneSlug(slug string) (string, string, error) {
 		return m.parseSceneSlugFn(slug)
 	}
 	return "", "", fmt.Errorf("scene not found for slug: %s", slug)
+}
+
+func (m *mockSceneService) GetSceneGenreDistribution(city, state string) ([]services.GenreCount, error) {
+	if m.getSceneGenreDistributionFn != nil {
+		return m.getSceneGenreDistributionFn(city, state)
+	}
+	return []services.GenreCount{}, nil
+}
+
+func (m *mockSceneService) GetGenreDiversityIndex(city, state string) (float64, error) {
+	if m.getGenreDiversityIndexFn != nil {
+		return m.getGenreDiversityIndexFn(city, state)
+	}
+	return -1, nil
 }
 
 // ============================================================================
@@ -312,4 +328,96 @@ func TestIsSceneNotFoundErr(t *testing.T) {
 	if isSceneNotFoundErr(nil) {
 		t.Error("expected false for nil error")
 	}
+}
+
+// ============================================================================
+// GetSceneGenresHandler Tests
+// ============================================================================
+
+func TestGetSceneGenres_Success(t *testing.T) {
+	mock := &mockSceneService{
+		parseSceneSlugFn: func(slug string) (string, string, error) {
+			return "Phoenix", "AZ", nil
+		},
+		getSceneGenreDistributionFn: func(city, state string) ([]services.GenreCount, error) {
+			return []services.GenreCount{
+				{TagID: 1, Name: "punk", Slug: "punk", Count: 20},
+				{TagID: 2, Name: "indie rock", Slug: "indie-rock", Count: 15},
+			}, nil
+		},
+		getGenreDiversityIndexFn: func(city, state string) (float64, error) {
+			return 0.85, nil
+		},
+	}
+	h := NewSceneHandler(mock)
+	req := &GetSceneGenresRequest{Slug: "phoenix-az"}
+	resp, err := h.GetSceneGenresHandler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Body.Genres) != 2 {
+		t.Errorf("expected 2 genres, got %d", len(resp.Body.Genres))
+	}
+	if resp.Body.DiversityIndex != 0.85 {
+		t.Errorf("expected diversity index 0.85, got %f", resp.Body.DiversityIndex)
+	}
+	if resp.Body.DiversityLabel != "Highly diverse" {
+		t.Errorf("expected 'Highly diverse', got '%s'", resp.Body.DiversityLabel)
+	}
+}
+
+func TestGetSceneGenres_SlugNotFound(t *testing.T) {
+	mock := &mockSceneService{
+		parseSceneSlugFn: func(slug string) (string, string, error) {
+			return "", "", fmt.Errorf("scene not found for slug: %s", slug)
+		},
+	}
+	h := NewSceneHandler(mock)
+	req := &GetSceneGenresRequest{Slug: "nonexistent-xx"}
+	_, err := h.GetSceneGenresHandler(context.Background(), req)
+	assertHumaError(t, err, 404)
+}
+
+func TestGetSceneGenres_Empty(t *testing.T) {
+	mock := &mockSceneService{
+		parseSceneSlugFn: func(slug string) (string, string, error) {
+			return "Phoenix", "AZ", nil
+		},
+		getSceneGenreDistributionFn: func(city, state string) ([]services.GenreCount, error) {
+			return nil, nil
+		},
+		getGenreDiversityIndexFn: func(city, state string) (float64, error) {
+			return -1, nil
+		},
+	}
+	h := NewSceneHandler(mock)
+	req := &GetSceneGenresRequest{Slug: "phoenix-az"}
+	resp, err := h.GetSceneGenresHandler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Body.Genres) != 0 {
+		t.Errorf("expected 0 genres, got %d", len(resp.Body.Genres))
+	}
+	if resp.Body.DiversityIndex != -1 {
+		t.Errorf("expected diversity index -1, got %f", resp.Body.DiversityIndex)
+	}
+	if resp.Body.DiversityLabel != "" {
+		t.Errorf("expected empty diversity label, got '%s'", resp.Body.DiversityLabel)
+	}
+}
+
+func TestGetSceneGenres_ServiceError(t *testing.T) {
+	mock := &mockSceneService{
+		parseSceneSlugFn: func(slug string) (string, string, error) {
+			return "Phoenix", "AZ", nil
+		},
+		getSceneGenreDistributionFn: func(city, state string) ([]services.GenreCount, error) {
+			return nil, fmt.Errorf("database error")
+		},
+	}
+	h := NewSceneHandler(mock)
+	req := &GetSceneGenresRequest{Slug: "phoenix-az"}
+	_, err := h.GetSceneGenresHandler(context.Background(), req)
+	assertHumaError(t, err, 500)
 }

--- a/backend/internal/api/handlers/venue.go
+++ b/backend/internal/api/handlers/venue.go
@@ -824,6 +824,50 @@ func (h *VenueHandler) DeleteVenueHandler(ctx context.Context, req *DeleteVenueR
 	}, nil
 }
 
+// ============================================================================
+// Get Venue Genres
+// ============================================================================
+
+// GetVenueGenresRequest represents the request for getting a venue's genre profile.
+type GetVenueGenresRequest struct {
+	VenueID string `path:"venue_id" doc:"Venue ID or slug" example:"the-rebel-lounge-phoenix-az"`
+}
+
+// GetVenueGenresResponse represents the response for venue genre profile.
+type GetVenueGenresResponse struct {
+	Body *services.VenueGenreResponse
+}
+
+// GetVenueGenresHandler handles GET /venues/{venue_id}/genres — returns top genre tags for a venue.
+func (h *VenueHandler) GetVenueGenresHandler(ctx context.Context, req *GetVenueGenresRequest) (*GetVenueGenresResponse, error) {
+	// Resolve venue by ID or slug
+	var venueID uint
+	if id, err := strconv.ParseUint(req.VenueID, 10, 32); err == nil {
+		venueID = uint(id)
+	} else {
+		// Try slug lookup
+		venue, err := h.venueService.GetVenueBySlug(req.VenueID)
+		if err != nil {
+			return nil, huma.Error404NotFound("Venue not found")
+		}
+		venueID = venue.ID
+	}
+
+	genres, err := h.venueService.GetVenueGenreProfile(venueID)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Failed to get venue genre profile", err)
+	}
+	if genres == nil {
+		genres = []services.GenreCount{}
+	}
+
+	return &GetVenueGenresResponse{
+		Body: &services.VenueGenreResponse{
+			Genres: genres,
+		},
+	}, nil
+}
+
 // computeVenueChanges compares old and new venue detail responses and returns field-level diffs.
 func computeVenueChanges(old, new *services.VenueDetailResponse) []models.FieldChange {
 	var changes []models.FieldChange

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -376,6 +376,7 @@ func setupVenueRoutes(api huma.API, protected *huma.Group, sc *services.ServiceC
 	huma.Get(api, "/venues/search", venueHandler.SearchVenuesHandler)
 	huma.Get(api, "/venues/{venue_id}", venueHandler.GetVenueHandler)
 	huma.Get(api, "/venues/{venue_id}/shows", venueHandler.GetVenueShowsHandler)
+	huma.Get(api, "/venues/{venue_id}/genres", venueHandler.GetVenueGenresHandler)
 
 	// Protected venue endpoints - require authentication
 	huma.Post(protected, "/admin/venues", venueHandler.AdminCreateVenueHandler)
@@ -728,6 +729,7 @@ func setupSceneRoutes(api huma.API, sc *services.ServiceContainer) {
 	huma.Get(api, "/scenes", sceneHandler.ListScenesHandler)
 	huma.Get(api, "/scenes/{slug}", sceneHandler.GetSceneDetailHandler)
 	huma.Get(api, "/scenes/{slug}/artists", sceneHandler.GetSceneActiveArtistsHandler)
+	huma.Get(api, "/scenes/{slug}/genres", sceneHandler.GetSceneGenresHandler)
 }
 
 // setupAttendanceRoutes configures show attendance (going/interested) endpoints.

--- a/backend/internal/services/aliases.go
+++ b/backend/internal/services/aliases.go
@@ -128,6 +128,9 @@ type SceneDetailResponse = contracts.SceneDetailResponse
 type SceneStats = contracts.SceneStats
 type ScenePulse = contracts.ScenePulse
 type SceneArtistResponse = contracts.SceneArtistResponse
+type GenreCount = contracts.GenreCount
+type SceneGenreResponse = contracts.SceneGenreResponse
+type VenueGenreResponse = contracts.VenueGenreResponse
 
 // ──────────────────────────────────────────────
 // Label types

--- a/backend/internal/services/catalog/scene.go
+++ b/backend/internal/services/catalog/scene.go
@@ -2,6 +2,7 @@ package catalog
 
 import (
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -387,4 +388,155 @@ func buildSceneSlug(city, state string) string {
 	slug = strings.ReplaceAll(slug, " ", "-")
 	slug = slug + "-" + strings.ToLower(state)
 	return slug
+}
+
+// Thresholds for genre intelligence.
+const (
+	sceneGenreMinTaggedArtists    = 30
+	sceneDiversityMinTaggedArtists = 50
+	sceneDiversityMinGenres        = 5
+	venueGenreMinShows             = 10
+)
+
+// GetSceneGenreDistribution returns genre tags ranked by the number of distinct
+// artists who play approved shows in this city and carry that genre tag.
+// Returns empty if fewer than 30 tagged artists exist for the scene.
+func (s *SceneService) GetSceneGenreDistribution(city, state string) ([]contracts.GenreCount, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	type genreRow struct {
+		TagID uint   `gorm:"column:tag_id"`
+		Name  string `gorm:"column:name"`
+		Slug  string `gorm:"column:slug"`
+		Count int    `gorm:"column:count"`
+	}
+
+	var rows []genreRow
+	err := s.db.Raw(`
+		SELECT t.id AS tag_id, t.name, t.slug, COUNT(DISTINCT sa.artist_id) AS count
+		FROM show_artists sa
+		JOIN show_venues sv ON sv.show_id = sa.show_id
+		JOIN shows s ON s.id = sa.show_id
+		JOIN venues v ON v.id = sv.venue_id
+		JOIN entity_tags et ON et.entity_type = 'artist' AND et.entity_id = sa.artist_id
+		JOIN tags t ON t.id = et.tag_id AND t.category = 'genre'
+		WHERE v.city = ? AND v.state = ?
+		  AND s.status = ?
+		GROUP BY t.id, t.name, t.slug
+		ORDER BY count DESC
+	`, city, state, models.ShowStatusApproved).Scan(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to get scene genre distribution: %w", err)
+	}
+
+	// Check if total tagged artists meets threshold
+	totalTagged := 0
+	for _, r := range rows {
+		totalTagged += r.Count
+	}
+	if totalTagged < sceneGenreMinTaggedArtists {
+		return []contracts.GenreCount{}, nil
+	}
+
+	result := make([]contracts.GenreCount, len(rows))
+	for i, r := range rows {
+		result[i] = contracts.GenreCount{
+			TagID: r.TagID,
+			Name:  r.Name,
+			Slug:  r.Slug,
+			Count: r.Count,
+		}
+	}
+
+	return result, nil
+}
+
+// GetGenreDiversityIndex computes the normalized Shannon entropy of the genre
+// distribution for a city scene. Returns a value in [0, 1] where higher values
+// indicate more genre diversity. Returns -1 when there is insufficient data
+// (fewer than 50 tagged artists or fewer than 5 genres).
+func (s *SceneService) GetGenreDiversityIndex(city, state string) (float64, error) {
+	if s.db == nil {
+		return 0, fmt.Errorf("database not initialized")
+	}
+
+	type genreRow struct {
+		Count int `gorm:"column:count"`
+	}
+
+	var rows []genreRow
+	err := s.db.Raw(`
+		SELECT COUNT(DISTINCT sa.artist_id) AS count
+		FROM show_artists sa
+		JOIN show_venues sv ON sv.show_id = sa.show_id
+		JOIN shows s ON s.id = sa.show_id
+		JOIN venues v ON v.id = sv.venue_id
+		JOIN entity_tags et ON et.entity_type = 'artist' AND et.entity_id = sa.artist_id
+		JOIN tags t ON t.id = et.tag_id AND t.category = 'genre'
+		WHERE v.city = ? AND v.state = ?
+		  AND s.status = ?
+		GROUP BY t.id
+		ORDER BY count DESC
+	`, city, state, models.ShowStatusApproved).Scan(&rows).Error
+	if err != nil {
+		return 0, fmt.Errorf("failed to get genre diversity index: %w", err)
+	}
+
+	// Check thresholds
+	totalTagged := 0
+	counts := make([]int, len(rows))
+	for i, r := range rows {
+		totalTagged += r.Count
+		counts[i] = r.Count
+	}
+
+	if totalTagged < sceneDiversityMinTaggedArtists || len(counts) < sceneDiversityMinGenres {
+		return -1, nil
+	}
+
+	return NormalizedShannonEntropy(counts), nil
+}
+
+// NormalizedShannonEntropy computes normalized Shannon entropy in [0, 1].
+// Exported for testing.
+func NormalizedShannonEntropy(counts []int) float64 {
+	total := 0
+	for _, c := range counts {
+		total += c
+	}
+	if total == 0 {
+		return 0
+	}
+	entropy := 0.0
+	for _, c := range counts {
+		if c == 0 {
+			continue
+		}
+		p := float64(c) / float64(total)
+		entropy -= p * math.Log2(p)
+	}
+	maxEntropy := math.Log2(float64(len(counts)))
+	if maxEntropy == 0 {
+		return 0
+	}
+	return entropy / maxEntropy
+}
+
+// DiversityLabel returns a human-readable label for a diversity index value.
+func DiversityLabel(index float64) string {
+	if index < 0 {
+		return ""
+	}
+	if index >= 0.8 {
+		return "Highly diverse"
+	}
+	if index >= 0.5 {
+		return "Mixed"
+	}
+	if index >= 0.2 {
+		return "Genre-focused"
+	}
+	return ""
 }

--- a/backend/internal/services/catalog/scene_test.go
+++ b/backend/internal/services/catalog/scene_test.go
@@ -59,6 +59,20 @@ func TestSceneService_NilDatabase(t *testing.T) {
 		assert.Empty(t, city)
 		assert.Empty(t, state)
 	})
+
+	t.Run("GetSceneGenreDistribution", func(t *testing.T) {
+		resp, err := svc.GetSceneGenreDistribution("Phoenix", "AZ")
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
+
+	t.Run("GetGenreDiversityIndex", func(t *testing.T) {
+		resp, err := svc.GetGenreDiversityIndex("Phoenix", "AZ")
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Zero(t, resp)
+	})
 }
 
 func TestBuildSceneSlug(t *testing.T) {
@@ -149,6 +163,10 @@ func (suite *SceneServiceIntegrationTestSuite) TearDownTest() {
 	sqlDB, err := suite.db.DB()
 	suite.Require().NoError(err)
 	// Delete in FK-safe order
+	_, _ = sqlDB.Exec("DELETE FROM entity_tags")
+	_, _ = sqlDB.Exec("DELETE FROM tag_aliases")
+	_, _ = sqlDB.Exec("DELETE FROM tag_votes")
+	_, _ = sqlDB.Exec("DELETE FROM tags")
 	_, _ = sqlDB.Exec("DELETE FROM show_artists")
 	_, _ = sqlDB.Exec("DELETE FROM show_venues")
 	_, _ = sqlDB.Exec("DELETE FROM shows")
@@ -664,4 +682,239 @@ func (suite *SceneServiceIntegrationTestSuite) TestParseSceneSlug_IgnoresUnverif
 	suite.Contains(err.Error(), "scene not found")
 	suite.Empty(city)
 	suite.Empty(state)
+}
+
+// =============================================================================
+// NormalizedShannonEntropy Unit Tests
+// =============================================================================
+
+func TestNormalizedShannonEntropy_Empty(t *testing.T) {
+	assert.Equal(t, 0.0, NormalizedShannonEntropy([]int{}))
+}
+
+func TestNormalizedShannonEntropy_SingleGenre(t *testing.T) {
+	// Only 1 genre => max entropy = log2(1) = 0, so we return 0 (avoid div-by-zero)
+	assert.Equal(t, 0.0, NormalizedShannonEntropy([]int{100}))
+}
+
+func TestNormalizedShannonEntropy_EqualDistribution(t *testing.T) {
+	// Perfectly even distribution of 4 genres => normalized entropy = 1.0
+	result := NormalizedShannonEntropy([]int{25, 25, 25, 25})
+	assert.InDelta(t, 1.0, result, 0.001)
+}
+
+func TestNormalizedShannonEntropy_UnevenDistribution(t *testing.T) {
+	// One dominant genre => low entropy
+	result := NormalizedShannonEntropy([]int{90, 5, 3, 2})
+	assert.Greater(t, result, 0.0)
+	assert.Less(t, result, 0.6) // should be low
+}
+
+func TestNormalizedShannonEntropy_TwoGenres(t *testing.T) {
+	// 50/50 split with 2 genres => normalized entropy = 1.0
+	result := NormalizedShannonEntropy([]int{50, 50})
+	assert.InDelta(t, 1.0, result, 0.001)
+}
+
+func TestNormalizedShannonEntropy_AllZeros(t *testing.T) {
+	assert.Equal(t, 0.0, NormalizedShannonEntropy([]int{0, 0, 0}))
+}
+
+// =============================================================================
+// DiversityLabel Unit Tests
+// =============================================================================
+
+func TestDiversityLabel(t *testing.T) {
+	tests := []struct {
+		index    float64
+		expected string
+	}{
+		{-1, ""},
+		{0.1, ""},
+		{0.19, ""},
+		{0.2, "Genre-focused"},
+		{0.4, "Genre-focused"},
+		{0.5, "Mixed"},
+		{0.7, "Mixed"},
+		{0.8, "Highly diverse"},
+		{0.95, "Highly diverse"},
+		{1.0, "Highly diverse"},
+	}
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("%.2f", tc.index), func(t *testing.T) {
+			assert.Equal(t, tc.expected, DiversityLabel(tc.index))
+		})
+	}
+}
+
+// =============================================================================
+// Genre Distribution Integration Tests
+// =============================================================================
+
+// createGenreTag creates a genre tag for testing
+func (suite *SceneServiceIntegrationTestSuite) createGenreTag(name, slug string) uint {
+	sqlDB, err := suite.db.DB()
+	suite.Require().NoError(err)
+	var tagID uint
+	err = sqlDB.QueryRow(`
+		INSERT INTO tags (name, slug, category, is_official, usage_count, created_at, updated_at)
+		VALUES ($1, $2, 'genre', true, 0, NOW(), NOW())
+		RETURNING id
+	`, name, slug).Scan(&tagID)
+	suite.Require().NoError(err)
+	return tagID
+}
+
+// tagArtist tags an artist with a genre tag
+func (suite *SceneServiceIntegrationTestSuite) tagArtist(artistID, tagID, userID uint) {
+	sqlDB, err := suite.db.DB()
+	suite.Require().NoError(err)
+	_, err = sqlDB.Exec(`
+		INSERT INTO entity_tags (entity_type, entity_id, tag_id, added_by_user_id, created_at)
+		VALUES ('artist', $1, $2, $3, NOW())
+	`, artistID, tagID, userID)
+	suite.Require().NoError(err)
+}
+
+func (suite *SceneServiceIntegrationTestSuite) TestGetSceneGenreDistribution_InsufficientData() {
+	// Seed scene with 3 venues and 5 shows (3 artists), no tags
+	suite.seedSceneData()
+
+	genres, err := suite.sceneService.GetSceneGenreDistribution("Phoenix", "AZ")
+	suite.Require().NoError(err)
+	suite.Empty(genres) // No tagged artists at all
+}
+
+func (suite *SceneServiceIntegrationTestSuite) TestGetSceneGenreDistribution_BelowThreshold() {
+	// Create scene data with a few tagged artists (below 30 threshold)
+	venues, artists := suite.seedSceneData()
+	_ = venues
+	user := suite.createUser()
+
+	punkTag := suite.createGenreTag("punk", "punk")
+	suite.tagArtist(artists[0].ID, punkTag, user.ID) // 1 tagged artist, well below 30
+
+	genres, err := suite.sceneService.GetSceneGenreDistribution("Phoenix", "AZ")
+	suite.Require().NoError(err)
+	suite.Empty(genres) // Below threshold
+}
+
+func (suite *SceneServiceIntegrationTestSuite) TestGetSceneGenreDistribution_Success() {
+	user := suite.createUser()
+	v1 := suite.createVerifiedVenue("G-V1", "Phoenix", "AZ")
+	v2 := suite.createVerifiedVenue("G-V2", "Phoenix", "AZ")
+	v3 := suite.createVerifiedVenue("G-V3", "Phoenix", "AZ")
+
+	punkTag := suite.createGenreTag("punk", "punk")
+	indieTag := suite.createGenreTag("indie rock", "indie-rock")
+	metalTag := suite.createGenreTag("metal", "metal")
+
+	future := time.Now().UTC().AddDate(0, 0, 7)
+
+	// Create 35 artists with shows, tag them with genres
+	// This ensures we meet the 30 tagged artist threshold
+	venues := []*models.Venue{v1, v2, v3}
+	tags := []uint{punkTag, punkTag, indieTag, indieTag, indieTag, metalTag}
+	for i := 0; i < 35; i++ {
+		a := suite.createArtist(fmt.Sprintf("Genre Artist %d", i))
+		suite.createApprovedShow(
+			fmt.Sprintf("Genre Show %d", i),
+			venues[i%3].ID, a.ID, user.ID,
+			future.AddDate(0, 0, i),
+		)
+		tagIdx := i % len(tags)
+		suite.tagArtist(a.ID, tags[tagIdx], user.ID)
+	}
+
+	genres, err := suite.sceneService.GetSceneGenreDistribution("Phoenix", "AZ")
+	suite.Require().NoError(err)
+	suite.NotEmpty(genres)
+
+	// Should be sorted by count DESC
+	suite.GreaterOrEqual(genres[0].Count, genres[len(genres)-1].Count)
+
+	// All genres should have tag_id, name, and slug
+	for _, g := range genres {
+		suite.NotZero(g.TagID)
+		suite.NotEmpty(g.Name)
+		suite.NotEmpty(g.Slug)
+		suite.Greater(g.Count, 0)
+	}
+}
+
+// =============================================================================
+// Genre Diversity Index Integration Tests
+// =============================================================================
+
+func (suite *SceneServiceIntegrationTestSuite) TestGetGenreDiversityIndex_InsufficientArtists() {
+	suite.seedSceneData()
+	// No tags => insufficient data
+	index, err := suite.sceneService.GetGenreDiversityIndex("Phoenix", "AZ")
+	suite.Require().NoError(err)
+	suite.Equal(-1.0, index)
+}
+
+func (suite *SceneServiceIntegrationTestSuite) TestGetGenreDiversityIndex_InsufficientGenres() {
+	user := suite.createUser()
+	v1 := suite.createVerifiedVenue("DI-V1", "Phoenix", "AZ")
+	v2 := suite.createVerifiedVenue("DI-V2", "Phoenix", "AZ")
+	v3 := suite.createVerifiedVenue("DI-V3", "Phoenix", "AZ")
+
+	punkTag := suite.createGenreTag("di-punk", "di-punk")
+
+	future := time.Now().UTC().AddDate(0, 0, 7)
+	venues := []*models.Venue{v1, v2, v3}
+
+	// 55 artists all tagged with one genre => only 1 genre, below 5 minimum
+	for i := 0; i < 55; i++ {
+		a := suite.createArtist(fmt.Sprintf("DI Artist %d", i))
+		suite.createApprovedShow(
+			fmt.Sprintf("DI Show %d", i),
+			venues[i%3].ID, a.ID, user.ID,
+			future.AddDate(0, 0, i),
+		)
+		suite.tagArtist(a.ID, punkTag, user.ID)
+	}
+
+	index, err := suite.sceneService.GetGenreDiversityIndex("Phoenix", "AZ")
+	suite.Require().NoError(err)
+	suite.Equal(-1.0, index) // Insufficient genres (only 1)
+}
+
+func (suite *SceneServiceIntegrationTestSuite) TestGetGenreDiversityIndex_Success() {
+	user := suite.createUser()
+	v1 := suite.createVerifiedVenue("DIX-V1", "Phoenix", "AZ")
+	v2 := suite.createVerifiedVenue("DIX-V2", "Phoenix", "AZ")
+	v3 := suite.createVerifiedVenue("DIX-V3", "Phoenix", "AZ")
+
+	// Create 6 genres to meet the 5-genre minimum
+	genreTags := []uint{
+		suite.createGenreTag("dix-punk", "dix-punk"),
+		suite.createGenreTag("dix-indie", "dix-indie"),
+		suite.createGenreTag("dix-metal", "dix-metal"),
+		suite.createGenreTag("dix-jazz", "dix-jazz"),
+		suite.createGenreTag("dix-electronic", "dix-electronic"),
+		suite.createGenreTag("dix-folk", "dix-folk"),
+	}
+
+	future := time.Now().UTC().AddDate(0, 0, 7)
+	venues := []*models.Venue{v1, v2, v3}
+
+	// Create 55 artists evenly distributed across genres
+	for i := 0; i < 55; i++ {
+		a := suite.createArtist(fmt.Sprintf("DIX Artist %d", i))
+		suite.createApprovedShow(
+			fmt.Sprintf("DIX Show %d", i),
+			venues[i%3].ID, a.ID, user.ID,
+			future.AddDate(0, 0, i),
+		)
+		suite.tagArtist(a.ID, genreTags[i%len(genreTags)], user.ID)
+	}
+
+	index, err := suite.sceneService.GetGenreDiversityIndex("Phoenix", "AZ")
+	suite.Require().NoError(err)
+	suite.Greater(index, 0.0)
+	suite.LessOrEqual(index, 1.0)
+	// With nearly even distribution across 6 genres, expect high diversity
+	suite.Greater(index, 0.8)
 }

--- a/backend/internal/services/catalog/venue.go
+++ b/backend/internal/services/catalog/venue.go
@@ -1120,6 +1120,70 @@ func (s *VenueService) CancelPendingVenueEdit(editID uint, userID uint) error {
 	return nil
 }
 
+// GetVenueGenreProfile returns genre tags derived from artists who have played approved
+// shows at this venue. Returns the top 5 genres ranked by distinct artist count.
+// Returns empty if the venue has fewer than 10 shows with tagged artists.
+func (s *VenueService) GetVenueGenreProfile(venueID uint) ([]contracts.GenreCount, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	// First check if venue has enough shows with tagged artists
+	var showCount int64
+	err := s.db.Raw(`
+		SELECT COUNT(DISTINCT sa.show_id)
+		FROM show_artists sa
+		JOIN show_venues sv ON sv.show_id = sa.show_id
+		JOIN shows s ON s.id = sa.show_id
+		JOIN entity_tags et ON et.entity_type = 'artist' AND et.entity_id = sa.artist_id
+		JOIN tags t ON t.id = et.tag_id AND t.category = 'genre'
+		WHERE sv.venue_id = ? AND s.status = ?
+	`, venueID, models.ShowStatusApproved).Scan(&showCount).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to count tagged shows for venue: %w", err)
+	}
+
+	if showCount < 10 {
+		return []contracts.GenreCount{}, nil
+	}
+
+	type genreRow struct {
+		TagID uint   `gorm:"column:tag_id"`
+		Name  string `gorm:"column:name"`
+		Slug  string `gorm:"column:slug"`
+		Count int    `gorm:"column:count"`
+	}
+
+	var rows []genreRow
+	err = s.db.Raw(`
+		SELECT t.id AS tag_id, t.name, t.slug, COUNT(DISTINCT sa.artist_id) AS count
+		FROM show_artists sa
+		JOIN show_venues sv ON sv.show_id = sa.show_id
+		JOIN shows s ON s.id = sa.show_id
+		JOIN entity_tags et ON et.entity_type = 'artist' AND et.entity_id = sa.artist_id
+		JOIN tags t ON t.id = et.tag_id AND t.category = 'genre'
+		WHERE sv.venue_id = ? AND s.status = ?
+		GROUP BY t.id, t.name, t.slug
+		ORDER BY count DESC
+		LIMIT 5
+	`, venueID, models.ShowStatusApproved).Scan(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to get venue genre profile: %w", err)
+	}
+
+	result := make([]contracts.GenreCount, len(rows))
+	for i, r := range rows {
+		result[i] = contracts.GenreCount{
+			TagID: r.TagID,
+			Name:  r.Name,
+			Slug:  r.Slug,
+			Count: r.Count,
+		}
+	}
+
+	return result, nil
+}
+
 // GetVenueModel retrieves a raw venue model (used by handlers to check ownership)
 func (s *VenueService) GetVenueModel(venueID uint) (*models.Venue, error) {
 	if s.db == nil {

--- a/backend/internal/services/catalog/venue_test.go
+++ b/backend/internal/services/catalog/venue_test.go
@@ -189,6 +189,13 @@ func TestVenueService_NilDatabase(t *testing.T) {
 		assert.Nil(t, resp)
 		assert.Zero(t, total)
 	})
+
+	t.Run("GetVenueGenreProfile", func(t *testing.T) {
+		resp, err := svc.GetVenueGenreProfile(1)
+		assert.Error(t, err)
+		assert.Equal(t, "database not initialized", err.Error())
+		assert.Nil(t, resp)
+	})
 }
 
 // =============================================================================
@@ -265,6 +272,10 @@ func (suite *VenueServiceIntegrationTestSuite) TearDownTest() {
 	sqlDB, err := suite.db.DB()
 	suite.Require().NoError(err)
 	// Delete in FK-safe order
+	_, _ = sqlDB.Exec("DELETE FROM entity_tags")
+	_, _ = sqlDB.Exec("DELETE FROM tag_aliases")
+	_, _ = sqlDB.Exec("DELETE FROM tag_votes")
+	_, _ = sqlDB.Exec("DELETE FROM tags")
 	_, _ = sqlDB.Exec("DELETE FROM pending_venue_edits")
 	_, _ = sqlDB.Exec("DELETE FROM show_artists")
 	_, _ = sqlDB.Exec("DELETE FROM show_venues")
@@ -1388,4 +1399,127 @@ func (suite *VenueServiceIntegrationTestSuite) TestGetVenueModel_NotFound() {
 	var venueErr *apperrors.VenueError
 	suite.ErrorAs(err, &venueErr)
 	suite.Equal(apperrors.CodeVenueNotFound, venueErr.Code)
+}
+
+// =============================================================================
+// Group: GetVenueGenreProfile
+// =============================================================================
+
+func (suite *VenueServiceIntegrationTestSuite) createArtist(name string) *models.Artist {
+	artist := &models.Artist{Name: name}
+	err := suite.db.Create(artist).Error
+	suite.Require().NoError(err)
+	return artist
+}
+
+func (suite *VenueServiceIntegrationTestSuite) createApprovedShowWithArtist(venueID, artistID, userID uint) *models.Show {
+	show := &models.Show{
+		Title:       fmt.Sprintf("Show-%d", time.Now().UnixNano()),
+		EventDate:   time.Now().UTC().AddDate(0, 0, 7),
+		City:        stringPtr("Phoenix"),
+		State:       stringPtr("AZ"),
+		Status:      models.ShowStatusApproved,
+		SubmittedBy: &userID,
+	}
+	err := suite.db.Create(show).Error
+	suite.Require().NoError(err)
+
+	err = suite.db.Create(&models.ShowVenue{ShowID: show.ID, VenueID: venueID}).Error
+	suite.Require().NoError(err)
+
+	err = suite.db.Create(&models.ShowArtist{ShowID: show.ID, ArtistID: artistID, Position: 0}).Error
+	suite.Require().NoError(err)
+
+	return show
+}
+
+func (suite *VenueServiceIntegrationTestSuite) createGenreTag(name, slug string) uint {
+	sqlDB, err := suite.db.DB()
+	suite.Require().NoError(err)
+	var tagID uint
+	err = sqlDB.QueryRow(`
+		INSERT INTO tags (name, slug, category, is_official, usage_count, created_at, updated_at)
+		VALUES ($1, $2, 'genre', true, 0, NOW(), NOW())
+		RETURNING id
+	`, name, slug).Scan(&tagID)
+	suite.Require().NoError(err)
+	return tagID
+}
+
+func (suite *VenueServiceIntegrationTestSuite) tagArtist(artistID, tagID, userID uint) {
+	sqlDB, err := suite.db.DB()
+	suite.Require().NoError(err)
+	_, err = sqlDB.Exec(`
+		INSERT INTO entity_tags (entity_type, entity_id, tag_id, added_by_user_id, created_at)
+		VALUES ('artist', $1, $2, $3, NOW())
+	`, artistID, tagID, userID)
+	suite.Require().NoError(err)
+}
+
+func (suite *VenueServiceIntegrationTestSuite) TestGetVenueGenreProfile_InsufficientShows() {
+	venue := suite.createTestVenue("Genre Test Venue", "Phoenix", "AZ", true)
+	user := suite.createTestUser()
+	punkTag := suite.createGenreTag("vgp-punk", "vgp-punk")
+
+	// Create only 5 shows (below 10 threshold)
+	for i := 0; i < 5; i++ {
+		a := suite.createArtist(fmt.Sprintf("VGP Artist %d", i))
+		suite.createApprovedShowWithArtist(venue.ID, a.ID, user.ID)
+		suite.tagArtist(a.ID, punkTag, user.ID)
+	}
+
+	genres, err := suite.venueService.GetVenueGenreProfile(venue.ID)
+	suite.Require().NoError(err)
+	suite.Empty(genres) // Below 10-show threshold
+}
+
+func (suite *VenueServiceIntegrationTestSuite) TestGetVenueGenreProfile_NoTags() {
+	venue := suite.createTestVenue("No Tag Venue", "Phoenix", "AZ", true)
+	user := suite.createTestUser()
+
+	// Create 15 shows with artists but no genre tags
+	for i := 0; i < 15; i++ {
+		a := suite.createArtist(fmt.Sprintf("NT Artist %d", i))
+		suite.createApprovedShowWithArtist(venue.ID, a.ID, user.ID)
+	}
+
+	genres, err := suite.venueService.GetVenueGenreProfile(venue.ID)
+	suite.Require().NoError(err)
+	suite.Empty(genres) // No tags at all
+}
+
+func (suite *VenueServiceIntegrationTestSuite) TestGetVenueGenreProfile_Success() {
+	venue := suite.createTestVenue("Genre Profile Venue", "Phoenix", "AZ", true)
+	user := suite.createTestUser()
+
+	punkTag := suite.createGenreTag("vgps-punk", "vgps-punk")
+	indieTag := suite.createGenreTag("vgps-indie", "vgps-indie")
+	metalTag := suite.createGenreTag("vgps-metal", "vgps-metal")
+
+	tags := []uint{punkTag, punkTag, indieTag, indieTag, indieTag, metalTag}
+
+	// Create 12 shows with tagged artists
+	for i := 0; i < 12; i++ {
+		a := suite.createArtist(fmt.Sprintf("VGP-S Artist %d", i))
+		suite.createApprovedShowWithArtist(venue.ID, a.ID, user.ID)
+		suite.tagArtist(a.ID, tags[i%len(tags)], user.ID)
+	}
+
+	genres, err := suite.venueService.GetVenueGenreProfile(venue.ID)
+	suite.Require().NoError(err)
+	suite.NotEmpty(genres)
+	suite.LessOrEqual(len(genres), 5) // Top 5 limit
+
+	// Should be sorted by count DESC
+	for i := 1; i < len(genres); i++ {
+		suite.GreaterOrEqual(genres[i-1].Count, genres[i].Count)
+	}
+
+	// All should have valid fields
+	for _, g := range genres {
+		suite.NotZero(g.TagID)
+		suite.NotEmpty(g.Name)
+		suite.NotEmpty(g.Slug)
+		suite.Greater(g.Count, 0)
+	}
 }

--- a/backend/internal/services/contracts/catalog.go
+++ b/backend/internal/services/contracts/catalog.go
@@ -577,3 +577,27 @@ type SceneArtistResponse struct {
 	State     *string `json:"state"`
 	ShowCount int     `json:"show_count"`
 }
+
+// ──────────────────────────────────────────────
+// Genre profile types (for scene and venue intelligence)
+// ──────────────────────────────────────────────
+
+// GenreCount represents a genre tag with its associated artist count
+type GenreCount struct {
+	TagID uint   `json:"tag_id"`
+	Name  string `json:"name"`
+	Slug  string `json:"slug"`
+	Count int    `json:"count"`
+}
+
+// SceneGenreResponse represents the genre distribution for a scene (city)
+type SceneGenreResponse struct {
+	Genres         []GenreCount `json:"genres"`
+	DiversityIndex float64      `json:"diversity_index"` // -1 if insufficient data
+	DiversityLabel string       `json:"diversity_label"` // "Highly diverse", "Mixed", "Genre-focused", ""
+}
+
+// VenueGenreResponse represents the genre profile for a venue
+type VenueGenreResponse struct {
+	Genres []GenreCount `json:"genres"`
+}

--- a/backend/internal/services/contracts/interfaces.go
+++ b/backend/internal/services/contracts/interfaces.go
@@ -67,6 +67,7 @@ type VenueServiceInterface interface {
 	CancelPendingVenueEdit(editID uint, userID uint) error
 	GetVenueModel(venueID uint) (*models.Venue, error)
 	GetUnverifiedVenues(limit, offset int) ([]*UnverifiedVenueResponse, int64, error)
+	GetVenueGenreProfile(venueID uint) ([]GenreCount, error)
 }
 
 // ArtistServiceInterface defines the contract for artist operations.
@@ -439,6 +440,8 @@ type SceneServiceInterface interface {
 	GetSceneDetail(city, state string) (*SceneDetailResponse, error)
 	GetActiveArtists(city, state string, periodDays, limit, offset int) ([]*SceneArtistResponse, int64, error)
 	ParseSceneSlug(slug string) (string, string, error)
+	GetSceneGenreDistribution(city, state string) ([]GenreCount, error)
+	GetGenreDiversityIndex(city, state string) (float64, error)
 }
 
 // DataQualityServiceInterface defines the contract for data quality dashboard operations.

--- a/backend/internal/services/pipeline/orchestrator_test.go
+++ b/backend/internal/services/pipeline/orchestrator_test.go
@@ -221,6 +221,9 @@ func (s *stubVenueService) GetVenueModel(venueID uint) (*models.Venue, error) {
 func (s *stubVenueService) GetUnverifiedVenues(limit, offset int) ([]*contracts.UnverifiedVenueResponse, int64, error) {
 	panic("not implemented")
 }
+func (s *stubVenueService) GetVenueGenreProfile(venueID uint) ([]contracts.GenreCount, error) {
+	panic("not implemented")
+}
 
 // ============================================================================
 // Helper to build PipelineService with stubs

--- a/frontend/features/scenes/components/SceneDetail.tsx
+++ b/frontend/features/scenes/components/SceneDetail.tsx
@@ -2,11 +2,12 @@
 
 import Link from 'next/link'
 import {
-  MapPin, Building2, Mic2, Calendar, Tent, ArrowRight, Loader2,
+  MapPin, Building2, Mic2, Calendar, Tent, ArrowRight, Loader2, Music,
 } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
-import { useSceneDetail, useSceneArtists } from '../hooks'
+import { TagPill } from '@/components/shared'
+import { useSceneDetail, useSceneArtists, useSceneGenres } from '../hooks'
 import { ScenePulse } from './ScenePulse'
 
 interface SceneDetailProps {
@@ -55,6 +56,50 @@ function SceneArtistsList({ slug }: { slug: string }) {
         </p>
       )}
     </div>
+  )
+}
+
+function SceneGenreDistribution({ slug }: { slug: string }) {
+  const { data, isLoading } = useSceneGenres(slug)
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-4">
+        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  if (!data?.genres || data.genres.length === 0) {
+    return null
+  }
+
+  return (
+    <Card className="lg:col-span-2">
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Music className="h-4 w-4 text-muted-foreground" />
+          Genre Distribution
+          {data.diversity_label && (
+            <Badge variant="secondary" className="ml-1 text-xs font-normal">
+              {data.diversity_label}
+            </Badge>
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex flex-wrap gap-2">
+          {data.genres.map((genre) => (
+            <TagPill
+              key={genre.tag_id}
+              label={genre.name}
+              voteCount={genre.count}
+              href={`/tags/${genre.slug}`}
+            />
+          ))}
+        </div>
+      </CardContent>
+    </Card>
   )
 }
 
@@ -183,6 +228,9 @@ export function SceneDetailView({ slug }: SceneDetailProps) {
             <SceneArtistsList slug={slug} />
           </CardContent>
         </Card>
+
+        {/* Genre Distribution */}
+        <SceneGenreDistribution slug={slug} />
 
         {/* Festivals (only show if there are festivals) */}
         {stats.festival_count > 0 && (

--- a/frontend/features/scenes/hooks/index.ts
+++ b/frontend/features/scenes/hooks/index.ts
@@ -2,4 +2,5 @@ export {
   useScenes,
   useSceneDetail,
   useSceneArtists,
+  useSceneGenres,
 } from './useScenes'

--- a/frontend/features/scenes/hooks/useScenes.ts
+++ b/frontend/features/scenes/hooks/useScenes.ts
@@ -13,6 +13,7 @@ import type {
   SceneListResponse,
   SceneDetail,
   SceneArtistsResponse,
+  SceneGenreResponse,
 } from '../types'
 
 /**
@@ -78,5 +79,21 @@ export function useSceneArtists(options: UseSceneArtistsOptions) {
     },
     enabled: Boolean(slug),
     staleTime: 5 * 60 * 1000, // 5 minutes
+  })
+}
+
+/**
+ * Hook to fetch genre distribution for a scene
+ */
+export function useSceneGenres(slug: string) {
+  return useQuery({
+    queryKey: queryKeys.scenes.genres(slug),
+    queryFn: async (): Promise<SceneGenreResponse> => {
+      return apiRequest<SceneGenreResponse>(API_ENDPOINTS.SCENES.GENRES(slug), {
+        method: 'GET',
+      })
+    },
+    enabled: Boolean(slug),
+    staleTime: 10 * 60 * 1000, // 10 minutes — genre data changes infrequently
   })
 }

--- a/frontend/features/scenes/index.ts
+++ b/frontend/features/scenes/index.ts
@@ -10,6 +10,8 @@ export type {
   SceneDetail,
   SceneArtist,
   SceneArtistsResponse,
+  GenreCount,
+  SceneGenreResponse,
 } from './types'
 
 // Hooks
@@ -17,6 +19,7 @@ export {
   useScenes,
   useSceneDetail,
   useSceneArtists,
+  useSceneGenres,
 } from './hooks'
 
 // Components

--- a/frontend/features/scenes/types.ts
+++ b/frontend/features/scenes/types.ts
@@ -56,3 +56,16 @@ export interface SceneArtistsResponse {
   artists: SceneArtist[]
   total: number
 }
+
+export interface GenreCount {
+  tag_id: number
+  name: string
+  slug: string
+  count: number
+}
+
+export interface SceneGenreResponse {
+  genres: GenreCount[]
+  diversity_index: number
+  diversity_label: string
+}

--- a/frontend/features/venues/components/VenueDetail.tsx
+++ b/frontend/features/venues/components/VenueDetail.tsx
@@ -4,13 +4,13 @@ import { useState, useEffect } from 'react'
 import Link from 'next/link'
 import { useRouter, usePathname } from 'next/navigation'
 import { ArrowLeft, BadgeCheck, Pencil, Trash2, Loader2, ExternalLink } from 'lucide-react'
-import { useVenue } from '../hooks/useVenues'
+import { useVenue, useVenueGenres } from '../hooks/useVenues'
 import type { ApiError } from '@/lib/api'
 import { useAuthContext } from '@/lib/context/AuthContext'
 import { useNavigationBreadcrumbs } from '@/lib/context/NavigationBreadcrumbContext'
 import { useQueryClient } from '@tanstack/react-query'
 import { queryKeys } from '@/lib/queryClient'
-import { SocialLinks, RevisionHistory, FollowButton, Breadcrumb } from '@/components/shared'
+import { SocialLinks, RevisionHistory, FollowButton, Breadcrumb, TagPill } from '@/components/shared'
 import { NotifyMeButton } from '@/features/notifications'
 import { VenueLocationCard } from './VenueLocationCard'
 import { VenueShowsList } from './VenueShowsList'
@@ -44,6 +44,29 @@ function normalizeUrl(url: string): string {
     return url
   }
   return `https://${url}`
+}
+
+function VenueGenreProfile({ venueId }: { venueId: number }) {
+  const { data } = useVenueGenres(venueId)
+
+  if (!data?.genres || data.genres.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="rounded-lg border bg-card p-4 mt-4">
+      <h3 className="text-sm font-semibold mb-3">Genre Profile</h3>
+      <div className="flex flex-wrap gap-1.5">
+        {data.genres.map((genre) => (
+          <TagPill
+            key={genre.tag_id}
+            label={genre.name}
+            href={`/tags/${genre.slug}`}
+          />
+        ))}
+      </div>
+    </div>
+  )
 }
 
 export function VenueDetail({ venueId }: VenueDetailProps) {
@@ -225,7 +248,7 @@ export function VenueDetail({ venueId }: VenueDetailProps) {
           />
         </div>
 
-        {/* Sidebar - Location Card */}
+        {/* Sidebar - Location Card + Genre Profile */}
         <div className="order-1 lg:order-2">
           <VenueLocationCard
             name={venue.name}
@@ -235,6 +258,7 @@ export function VenueDetail({ venueId }: VenueDetailProps) {
             zipcode={venue.zipcode}
             verified={venue.verified}
           />
+          <VenueGenreProfile venueId={venue.id} />
         </div>
       </div>
 

--- a/frontend/features/venues/hooks/index.ts
+++ b/frontend/features/venues/hooks/index.ts
@@ -4,6 +4,7 @@ export {
   type TimeFilter,
   useVenueShows,
   useVenueCities,
+  useVenueGenres,
 } from './useVenues'
 
 export { useVenueSearch } from './useVenueSearch'

--- a/frontend/features/venues/hooks/useVenues.ts
+++ b/frontend/features/venues/hooks/useVenues.ts
@@ -14,6 +14,7 @@ import type {
   VenuesListResponse,
   VenueShowsResponse,
   VenueCitiesResponse,
+  VenueGenreResponse,
 } from '../types'
 
 interface CityState {
@@ -146,5 +147,22 @@ export const useVenueCities = () => {
     },
     staleTime: 10 * 60 * 1000, // 10 minutes - cities don't change often
     placeholderData: keepPreviousData, // Keep old data visible while fetching
+  })
+}
+
+/**
+ * Hook to fetch a venue's genre profile (top 5 genres derived from artist tags)
+ */
+export const useVenueGenres = (venueIdOrSlug: string | number) => {
+  return useQuery({
+    queryKey: queryKeys.venues.genres(venueIdOrSlug),
+    queryFn: async (): Promise<VenueGenreResponse> => {
+      return apiRequest<VenueGenreResponse>(
+        API_ENDPOINTS.VENUES.GENRES(venueIdOrSlug),
+        { method: 'GET' }
+      )
+    },
+    enabled: typeof venueIdOrSlug === 'string' ? Boolean(venueIdOrSlug) : venueIdOrSlug > 0,
+    staleTime: 10 * 60 * 1000, // 10 minutes — genre profiles change infrequently
   })
 }

--- a/frontend/features/venues/index.ts
+++ b/frontend/features/venues/index.ts
@@ -25,6 +25,8 @@ export type {
   FavoriteVenueActionResponse,
   FavoriteVenueShow,
   FavoriteVenueShowsResponse,
+  VenueGenreCount,
+  VenueGenreResponse,
 } from './types'
 
 export { getVenueLocation } from './types'
@@ -36,6 +38,7 @@ export {
   type TimeFilter,
   useVenueShows,
   useVenueCities,
+  useVenueGenres,
 } from './hooks'
 
 export { useVenueSearch } from './hooks'

--- a/frontend/features/venues/types.ts
+++ b/frontend/features/venues/types.ts
@@ -295,3 +295,18 @@ export interface FavoriteVenueShowsResponse {
   offset: number
   timezone: string
 }
+
+// ============================================================================
+// Venue Genre Profile Types
+// ============================================================================
+
+export interface VenueGenreCount {
+  tag_id: number
+  name: string
+  slug: string
+  count: number
+}
+
+export interface VenueGenreResponse {
+  genres: VenueGenreCount[]
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -136,6 +136,7 @@ export const API_ENDPOINTS = {
     SEARCH: `${API_BASE_URL}/venues/search`,
     GET: (venueIdOrSlug: string | number) => `${API_BASE_URL}/venues/${venueIdOrSlug}`,
     SHOWS: (venueIdOrSlug: string | number) => `${API_BASE_URL}/venues/${venueIdOrSlug}/shows`,
+    GENRES: (venueIdOrSlug: string | number) => `${API_BASE_URL}/venues/${venueIdOrSlug}/genres`,
     UPDATE: (venueIdOrSlug: string | number) => `${API_BASE_URL}/venues/${venueIdOrSlug}`,
     DELETE: (venueIdOrSlug: string | number) => `${API_BASE_URL}/venues/${venueIdOrSlug}`,
     MY_PENDING_EDIT: (venueIdOrSlug: string | number) =>
@@ -430,6 +431,7 @@ export const API_ENDPOINTS = {
     LIST: `${API_BASE_URL}/scenes`,
     DETAIL: (slug: string) => `${API_BASE_URL}/scenes/${slug}`,
     ARTISTS: (slug: string) => `${API_BASE_URL}/scenes/${slug}/artists`,
+    GENRES: (slug: string) => `${API_BASE_URL}/scenes/${slug}/genres`,
   },
 
   // Charts endpoints (public)

--- a/frontend/lib/queryClient.ts
+++ b/frontend/lib/queryClient.ts
@@ -137,6 +137,7 @@ export const queryKeys = {
     search: (query: string) =>
       ['venues', 'search', query.toLowerCase()] as const,
     shows: (venueIdOrSlug: string | number) => ['venues', 'shows', String(venueIdOrSlug)] as const,
+    genres: (venueIdOrSlug: string | number) => ['venues', 'genres', String(venueIdOrSlug)] as const,
     myPendingEdit: (venueIdOrSlug: string | number) =>
       ['venues', 'myPendingEdit', String(venueIdOrSlug)] as const,
   },
@@ -349,6 +350,7 @@ export const queryKeys = {
     list: ['scenes', 'list'] as const,
     detail: (slug: string) => ['scenes', 'detail', slug] as const,
     artists: (slug: string, period?: number) => ['scenes', 'artists', slug, period] as const,
+    genres: (slug: string) => ['scenes', 'genres', slug] as const,
   },
 
   // Charts queries (public)


### PR DESCRIPTION
## Summary
- New `GET /scenes/{slug}/genres` endpoint returning genre distribution + Shannon entropy diversity index for a city's music scene
- New `GET /venues/{slug}/genres` endpoint returning top 5 genre tags from artists at a venue
- Frontend: genre tag pills on scene pages with diversity label badge, genre profile section in venue detail sidebar
- Data thresholds enforced: 30+ tagged artists for scene, 10+ shows for venue, 50+ artists & 5+ genres for diversity index
- 25 backend tests (unit + integration + handler)

Closes PSY-61

## Test plan
- [ ] Verify scene genre distribution returns correct tag counts from artist tags
- [ ] Verify diversity index computed correctly (Shannon entropy)
- [ ] Verify venue genre profile shows top 5 genre tags
- [ ] Verify threshold enforcement (sections hidden below minimums)
- [ ] Verify frontend renders genre pills and diversity labels
- [ ] Backend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)