### PR TITLE
Consolidate discovery UI into admin Data Pipeline tab

### DIFF
--- a/backend/internal/api/handlers/pipeline.go
+++ b/backend/internal/api/handlers/pipeline.go
@@ -372,6 +372,43 @@ func (h *PipelineHandler) GetVenueRunsHandler(ctx context.Context, req *GetVenue
 	return resp, nil
 }
 
+// --- Import History (cross-venue) ---
+
+// GetImportHistoryRequest is the Huma request for GET /admin/pipeline/imports
+type GetImportHistoryRequest struct {
+	Limit  int `query:"limit" doc:"Max entries to return (default 20, max 100)"`
+	Offset int `query:"offset" doc:"Number of entries to skip for pagination"`
+}
+
+// GetImportHistoryResponse is the Huma response for GET /admin/pipeline/imports
+type GetImportHistoryResponse struct {
+	Body struct {
+		Imports []services.ImportHistoryEntry `json:"imports"`
+		Total   int64                        `json:"total"`
+	}
+}
+
+// GetImportHistoryHandler handles GET /admin/pipeline/imports
+func (h *PipelineHandler) GetImportHistoryHandler(ctx context.Context, req *GetImportHistoryRequest) (*GetImportHistoryResponse, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil || !user.IsAdmin {
+		return nil, huma.Error403Forbidden("Admin access required")
+	}
+
+	imports, total, err := h.venueConfigService.GetAllRecentRuns(req.Limit, req.Offset)
+	if err != nil {
+		logger.FromContext(ctx).Error("pipeline_get_import_history_failed",
+			"error", err.Error(),
+		)
+		return nil, huma.Error500InternalServerError("Failed to get import history")
+	}
+
+	resp := &GetImportHistoryResponse{}
+	resp.Body.Imports = imports
+	resp.Body.Total = total
+	return resp, nil
+}
+
 // --- Reset Render Method ---
 
 // ResetRenderMethodRequest is the Huma request for POST /admin/pipeline/venues/{venue_id}/reset-render-method

--- a/backend/internal/api/handlers/pipeline_test.go
+++ b/backend/internal/api/handlers/pipeline_test.go
@@ -43,6 +43,7 @@ type mockVenueSourceConfigService struct {
 	incrementFailuresFn     func(venueID uint) error
 	recordRunFn             func(run *models.VenueExtractionRun) error
 	getRecentRunsFn         func(venueID uint, limit int) ([]models.VenueExtractionRun, error)
+	getAllRecentRunsFn      func(limit, offset int) ([]services.ImportHistoryEntry, int64, error)
 	listConfiguredFn        func() ([]models.VenueSourceConfig, error)
 	getRejectionStatsFn     func(venueID uint) (*services.VenueRejectionStats, error)
 	updateExtractionNotesFn func(venueID uint, notes *string) error
@@ -84,6 +85,12 @@ func (m *mockVenueSourceConfigService) GetRecentRuns(venueID uint, limit int) ([
 		return m.getRecentRunsFn(venueID, limit)
 	}
 	return nil, nil
+}
+func (m *mockVenueSourceConfigService) GetAllRecentRuns(limit, offset int) ([]services.ImportHistoryEntry, int64, error) {
+	if m.getAllRecentRunsFn != nil {
+		return m.getAllRecentRunsFn(limit, offset)
+	}
+	return nil, 0, nil
 }
 func (m *mockVenueSourceConfigService) ListConfigured() ([]models.VenueSourceConfig, error) {
 	if m.listConfiguredFn != nil {
@@ -174,6 +181,10 @@ func TestPipelineHandler_RequiresAdmin(t *testing.T) {
 		}},
 		{"ResetRenderMethod", func(ctx context.Context) error {
 			_, err := h.ResetRenderMethodHandler(ctx, &ResetRenderMethodRequest{VenueID: "1"})
+			return err
+		}},
+		{"GetImportHistory", func(ctx context.Context) error {
+			_, err := h.GetImportHistoryHandler(ctx, &GetImportHistoryRequest{})
 			return err
 		}},
 	}
@@ -681,4 +692,123 @@ func TestPipelineHandler_ResetRenderMethod_ServiceError(t *testing.T) {
 
 	_, err := h.ResetRenderMethodHandler(pipelineAdminCtx(), &ResetRenderMethodRequest{VenueID: "999"})
 	assertHumaError(t, err, 422)
+}
+
+// ============================================================================
+// Tests: GetImportHistoryHandler
+// ============================================================================
+
+func TestPipelineHandler_GetImportHistory_Success(t *testing.T) {
+	rm := "dynamic"
+	h := NewPipelineHandler(
+		&mockPipelineService{},
+		&mockVenueSourceConfigService{
+			getAllRecentRunsFn: func(limit, offset int) ([]services.ImportHistoryEntry, int64, error) {
+				return []services.ImportHistoryEntry{
+					{
+						ID:              1,
+						VenueID:         10,
+						VenueName:       "Test Venue",
+						VenueSlug:       "test-venue",
+						SourceType:      "ai",
+						RenderMethod:    &rm,
+						EventsExtracted: 8,
+						EventsImported:  6,
+						DurationMs:      1500,
+					},
+					{
+						ID:              2,
+						VenueID:         20,
+						VenueName:       "Other Venue",
+						VenueSlug:       "other-venue",
+						SourceType:      "ical",
+						EventsExtracted: 12,
+						EventsImported:  12,
+						DurationMs:      300,
+					},
+				}, 2, nil
+			},
+		},
+	)
+
+	resp, err := h.GetImportHistoryHandler(pipelineAdminCtx(), &GetImportHistoryRequest{Limit: 20})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Total != 2 {
+		t.Errorf("expected total=2, got %d", resp.Body.Total)
+	}
+	if len(resp.Body.Imports) != 2 {
+		t.Fatalf("expected 2 imports, got %d", len(resp.Body.Imports))
+	}
+	if resp.Body.Imports[0].VenueName != "Test Venue" {
+		t.Errorf("expected venue_name=Test Venue, got %s", resp.Body.Imports[0].VenueName)
+	}
+	if resp.Body.Imports[0].SourceType != "ai" {
+		t.Errorf("expected source_type=ai, got %s", resp.Body.Imports[0].SourceType)
+	}
+	if resp.Body.Imports[1].SourceType != "ical" {
+		t.Errorf("expected source_type=ical, got %s", resp.Body.Imports[1].SourceType)
+	}
+}
+
+func TestPipelineHandler_GetImportHistory_Empty(t *testing.T) {
+	h := NewPipelineHandler(
+		&mockPipelineService{},
+		&mockVenueSourceConfigService{
+			getAllRecentRunsFn: func(limit, offset int) ([]services.ImportHistoryEntry, int64, error) {
+				return []services.ImportHistoryEntry{}, 0, nil
+			},
+		},
+	)
+
+	resp, err := h.GetImportHistoryHandler(pipelineAdminCtx(), &GetImportHistoryRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Total != 0 {
+		t.Errorf("expected total=0, got %d", resp.Body.Total)
+	}
+	if len(resp.Body.Imports) != 0 {
+		t.Errorf("expected 0 imports, got %d", len(resp.Body.Imports))
+	}
+}
+
+func TestPipelineHandler_GetImportHistory_PaginationPassedThrough(t *testing.T) {
+	var receivedLimit, receivedOffset int
+	h := NewPipelineHandler(
+		&mockPipelineService{},
+		&mockVenueSourceConfigService{
+			getAllRecentRunsFn: func(limit, offset int) ([]services.ImportHistoryEntry, int64, error) {
+				receivedLimit = limit
+				receivedOffset = offset
+				return nil, 0, nil
+			},
+		},
+	)
+
+	_, err := h.GetImportHistoryHandler(pipelineAdminCtx(), &GetImportHistoryRequest{Limit: 50, Offset: 10})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if receivedLimit != 50 {
+		t.Errorf("expected limit=50, got %d", receivedLimit)
+	}
+	if receivedOffset != 10 {
+		t.Errorf("expected offset=10, got %d", receivedOffset)
+	}
+}
+
+func TestPipelineHandler_GetImportHistory_ServiceError(t *testing.T) {
+	h := NewPipelineHandler(
+		&mockPipelineService{},
+		&mockVenueSourceConfigService{
+			getAllRecentRunsFn: func(limit, offset int) ([]services.ImportHistoryEntry, int64, error) {
+				return nil, 0, fmt.Errorf("database error")
+			},
+		},
+	)
+
+	_, err := h.GetImportHistoryHandler(pipelineAdminCtx(), &GetImportHistoryRequest{})
+	assertHumaError(t, err, 500)
 }

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -592,6 +592,7 @@ func setupPipelineRoutes(protected *huma.Group, sc *services.ServiceContainer) {
 	pipelineHandler := handlers.NewPipelineHandler(sc.Pipeline, sc.VenueSourceConfig)
 
 	huma.Post(protected, "/admin/pipeline/extract/{venue_id}", pipelineHandler.ExtractVenueHandler)
+	huma.Get(protected, "/admin/pipeline/imports", pipelineHandler.GetImportHistoryHandler)
 	huma.Get(protected, "/admin/pipeline/venues", pipelineHandler.ListPipelineVenuesHandler)
 	huma.Get(protected, "/admin/pipeline/venues/{venue_id}/stats", pipelineHandler.VenueRejectionStatsHandler)
 	huma.Patch(protected, "/admin/pipeline/venues/{venue_id}/notes", pipelineHandler.UpdateExtractionNotesHandler)

--- a/backend/internal/services/aliases.go
+++ b/backend/internal/services/aliases.go
@@ -348,6 +348,7 @@ type FetchError = contracts.FetchError
 
 type PipelineResult = contracts.PipelineResult
 type VenueRejectionStats = contracts.VenueRejectionStats
+type ImportHistoryEntry = contracts.ImportHistoryEntry
 
 type DiscoveredEvent = contracts.DiscoveredEvent
 type ImportResult = contracts.ImportResult

--- a/backend/internal/services/contracts/interfaces.go
+++ b/backend/internal/services/contracts/interfaces.go
@@ -412,6 +412,7 @@ type VenueSourceConfigServiceInterface interface {
 	IncrementFailures(venueID uint) error
 	RecordRun(run *models.VenueExtractionRun) error
 	GetRecentRuns(venueID uint, limit int) ([]models.VenueExtractionRun, error)
+	GetAllRecentRuns(limit, offset int) ([]ImportHistoryEntry, int64, error)
 	ListConfigured() ([]models.VenueSourceConfig, error)
 	GetRejectionStats(venueID uint) (*VenueRejectionStats, error)
 	UpdateExtractionNotes(venueID uint, notes *string) error

--- a/backend/internal/services/contracts/pipeline.go
+++ b/backend/internal/services/contracts/pipeline.go
@@ -1,6 +1,9 @@
 package contracts
 
-import "errors"
+import (
+	"errors"
+	"time"
+)
 
 // ──────────────────────────────────────────────
 // Extraction types
@@ -181,6 +184,22 @@ type VenueRejectionStats struct {
 	RejectionBreakdown   map[string]int64 `json:"rejection_breakdown"`
 	ApprovalRate         float64          `json:"approval_rate"`
 	SuggestedAutoApprove bool             `json:"suggested_auto_approve"`
+}
+
+// ImportHistoryEntry represents a single extraction run enriched with venue info,
+// used for the cross-venue import history view.
+type ImportHistoryEntry struct {
+	ID              uint      `json:"id"`
+	VenueID         uint      `json:"venue_id"`
+	VenueName       string    `json:"venue_name"`
+	VenueSlug       string    `json:"venue_slug"`
+	SourceType      string    `json:"source_type"`
+	RenderMethod    *string   `json:"render_method"`
+	EventsExtracted int       `json:"events_extracted"`
+	EventsImported  int       `json:"events_imported"`
+	DurationMs      int       `json:"duration_ms"`
+	Error           *string   `json:"error"`
+	RunAt           time.Time `json:"run_at"`
 }
 
 // ──────────────────────────────────────────────

--- a/backend/internal/services/pipeline/orchestrator_test.go
+++ b/backend/internal/services/pipeline/orchestrator_test.go
@@ -132,6 +132,9 @@ func (s *stubVenueConfig) GetRecentRuns(venueID uint, limit int) ([]models.Venue
 	}
 	return nil, nil
 }
+func (s *stubVenueConfig) GetAllRecentRuns(limit, offset int) ([]contracts.ImportHistoryEntry, int64, error) {
+	return nil, 0, nil
+}
 func (s *stubVenueConfig) ListConfigured() ([]models.VenueSourceConfig, error) {
 	if s.listConfiguredFn != nil {
 		return s.listConfiguredFn()

--- a/backend/internal/services/pipeline/scheduler_test.go
+++ b/backend/internal/services/pipeline/scheduler_test.go
@@ -102,6 +102,10 @@ func (s *stubVenueConfigService) GetRecentRuns(venueID uint, limit int) ([]model
 	return nil, nil
 }
 
+func (s *stubVenueConfigService) GetAllRecentRuns(limit, offset int) ([]contracts.ImportHistoryEntry, int64, error) {
+	return nil, 0, nil
+}
+
 func (s *stubVenueConfigService) GetRejectionStats(venueID uint) (*contracts.VenueRejectionStats, error) {
 	return nil, nil
 }

--- a/backend/internal/services/pipeline/venue_source_config.go
+++ b/backend/internal/services/pipeline/venue_source_config.go
@@ -289,6 +289,84 @@ func (s *VenueSourceConfigService) ResetRenderMethod(venueID uint) error {
 	return nil
 }
 
+// ImportHistoryEntry is an alias to the canonical type in contracts.
+type ImportHistoryEntry = contracts.ImportHistoryEntry
+
+// GetAllRecentRuns returns extraction runs across ALL venues, ordered by run_at desc,
+// with venue name, slug, and source type info. Supports pagination via limit/offset.
+func (s *VenueSourceConfigService) GetAllRecentRuns(limit, offset int) ([]ImportHistoryEntry, int64, error) {
+	if s.db == nil {
+		return nil, 0, fmt.Errorf("database not initialized")
+	}
+
+	if limit <= 0 {
+		limit = 20
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	// Count total runs
+	var total int64
+	if err := s.db.Model(&models.VenueExtractionRun{}).Count(&total).Error; err != nil {
+		return nil, 0, fmt.Errorf("failed to count extraction runs: %w", err)
+	}
+
+	// Fetch runs with venue info
+	var runs []models.VenueExtractionRun
+	err := s.db.Preload("Venue").
+		Order("run_at DESC").
+		Limit(limit).
+		Offset(offset).
+		Find(&runs).Error
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to get import history: %w", err)
+	}
+
+	// Build a map of venue_id -> preferred_source from configs
+	configMap := make(map[uint]string)
+	var configs []models.VenueSourceConfig
+	if err := s.db.Select("venue_id, preferred_source").Find(&configs).Error; err == nil {
+		for _, cfg := range configs {
+			configMap[cfg.VenueID] = cfg.PreferredSource
+		}
+	}
+
+	entries := make([]ImportHistoryEntry, 0, len(runs))
+	for _, run := range runs {
+		entry := ImportHistoryEntry{
+			ID:              run.ID,
+			VenueID:         run.VenueID,
+			VenueName:       run.Venue.Name,
+			RenderMethod:    run.RenderMethod,
+			EventsExtracted: run.EventsExtracted,
+			EventsImported:  run.EventsImported,
+			DurationMs:      run.DurationMs,
+			Error:           run.Error,
+			RunAt:           run.RunAt,
+		}
+		if run.Venue.Slug != nil {
+			entry.VenueSlug = *run.Venue.Slug
+		}
+
+		// Source type: prefer the run's preferred_source field, then fall back to config
+		if run.PreferredSource != nil && *run.PreferredSource != "" {
+			entry.SourceType = *run.PreferredSource
+		} else if src, ok := configMap[run.VenueID]; ok {
+			entry.SourceType = src
+		} else {
+			entry.SourceType = "ai"
+		}
+
+		entries = append(entries, entry)
+	}
+
+	return entries, total, nil
+}
+
 // ListConfigured returns all venue source configs, preloading the venue association.
 func (s *VenueSourceConfigService) ListConfigured() ([]models.VenueSourceConfig, error) {
 	if s.db == nil {

--- a/discovery/DEPRECATED.md
+++ b/discovery/DEPRECATED.md
@@ -1,0 +1,36 @@
+# Deprecated
+
+This standalone discovery app (Bun + Playwright) is **deprecated** in favor of the API-first data pipeline built into the main application.
+
+## Why
+
+The Playwright-based scrapers in this app were brittle, slow, and required per-venue provider code. The new pipeline uses:
+
+- **Tiered rendering** (static HTTP, chromedp dynamic, screenshot) with automatic detection
+- **AI extraction** (Claude Haiku) that works on any venue page without per-venue code
+- **iCal/RSS feed parsing** as the cheapest extraction tier
+- **Change detection** to skip unchanged pages and reduce costs
+- **Automated scheduling** with circuit breakers and anomaly detection
+
+## What to use instead
+
+All pipeline management is now in the **Admin Console > Data Pipeline** tab:
+
+- Per-venue configuration (calendar URL, render method, source type, extraction notes)
+- Manual extraction triggers (dry run and live import)
+- Cross-venue import history with source type, event counts, and status
+- Rejection stats and approval rate tracking
+- Run history per venue
+
+Access it at `/admin?tab=pipeline` when logged in as an admin.
+
+## Backend endpoints
+
+The pipeline is powered by these admin API endpoints:
+
+- `GET /admin/pipeline/venues` - List configured venues
+- `GET /admin/pipeline/imports` - Cross-venue import history
+- `POST /admin/pipeline/extract/{venue_id}` - Trigger extraction
+- `GET /admin/pipeline/venues/{venue_id}/stats` - Rejection stats
+- `GET /admin/pipeline/venues/{venue_id}/runs` - Per-venue run history
+- `PUT /admin/pipeline/venues/{venue_id}/config` - Update venue config

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -308,7 +308,7 @@ function AdminPageContent() {
             </TabsTrigger>
             <TabsTrigger value="pipeline" className="gap-2">
               <Workflow className="h-4 w-4" />
-              Pipeline
+              Data Pipeline
             </TabsTrigger>
             <TabsTrigger value="collections" className="gap-2">
               <Library className="h-4 w-4" />

--- a/frontend/components/admin/PipelineVenues.tsx
+++ b/frontend/components/admin/PipelineVenues.tsx
@@ -8,8 +8,10 @@ import {
   useVenueExtractionRuns,
   useResetRenderMethod,
   useExtractVenue,
+  useImportHistory,
   type PipelineVenueInfo,
   type VenueExtractionRun,
+  type ImportHistoryEntry,
 } from '@/lib/hooks/usePipeline'
 import { useVenueSearch } from '@/features/venues'
 import { Switch } from '@/components/ui/switch'
@@ -541,10 +543,119 @@ function VenueDetailPanel({
   )
 }
 
+function SourceTypeBadge({ sourceType }: { sourceType: string }) {
+  const colors: Record<string, string> = {
+    ai: 'bg-purple-500/20 text-purple-400',
+    ical: 'bg-blue-500/20 text-blue-400',
+    rss: 'bg-orange-500/20 text-orange-400',
+  }
+  const color = colors[sourceType] ?? 'bg-muted text-muted-foreground'
+  return (
+    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${color}`}>
+      {sourceType.toUpperCase()}
+    </span>
+  )
+}
+
+function ImportHistorySection() {
+  const PAGE_SIZE = 20
+  const [offset, setOffset] = useState(0)
+  const { data, isLoading, error } = useImportHistory(PAGE_SIZE, offset)
+
+  if (isLoading) return <p className="text-muted-foreground text-sm">Loading import history...</p>
+  if (error) return <p className="text-red-400 text-sm">Failed to load import history</p>
+
+  const imports = data?.imports ?? []
+  const total = data?.total ?? 0
+  const hasMore = offset + PAGE_SIZE < total
+  const hasPrev = offset > 0
+
+  if (imports.length === 0 && offset === 0) {
+    return <p className="text-muted-foreground text-sm">No extraction runs recorded yet.</p>
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="border border-border rounded-lg overflow-hidden">
+        <table className="w-full text-sm">
+          <thead className="bg-muted/50">
+            <tr>
+              <th className="text-left p-3 font-medium">Date</th>
+              <th className="text-left p-3 font-medium">Venue</th>
+              <th className="text-center p-3 font-medium">Source</th>
+              <th className="text-center p-3 font-medium">Extracted</th>
+              <th className="text-center p-3 font-medium">Imported</th>
+              <th className="text-right p-3 font-medium">Duration</th>
+              <th className="text-center p-3 font-medium">Status</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {imports.map((entry: ImportHistoryEntry) => (
+              <tr key={entry.id}>
+                <td className="p-3 text-muted-foreground text-xs">
+                  {new Date(entry.run_at).toLocaleString()}
+                </td>
+                <td className="p-3">
+                  <span className="font-medium">{entry.venue_name}</span>
+                </td>
+                <td className="p-3 text-center">
+                  <SourceTypeBadge sourceType={entry.source_type} />
+                </td>
+                <td className="p-3 text-center">{entry.events_extracted}</td>
+                <td className="p-3 text-center">{entry.events_imported}</td>
+                <td className="p-3 text-right text-muted-foreground text-xs">
+                  {entry.duration_ms >= 1000
+                    ? `${(entry.duration_ms / 1000).toFixed(1)}s`
+                    : `${entry.duration_ms}ms`}
+                </td>
+                <td className="p-3 text-center">
+                  {entry.error ? (
+                    <span className="text-red-400 text-xs" title={entry.error}>
+                      Error
+                    </span>
+                  ) : (
+                    <span className="text-green-400 text-xs">OK</span>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pagination */}
+      {(hasPrev || hasMore) && (
+        <div className="flex items-center justify-between text-sm">
+          <span className="text-muted-foreground">
+            Showing {offset + 1}–{Math.min(offset + PAGE_SIZE, total)} of {total}
+          </span>
+          <div className="flex gap-2">
+            <button
+              onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+              disabled={!hasPrev}
+              className="px-3 py-1 border border-border rounded text-sm hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Previous
+            </button>
+            <button
+              onClick={() => setOffset(offset + PAGE_SIZE)}
+              disabled={!hasMore}
+              className="px-3 py-1 border border-border rounded text-sm hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
 export function PipelineVenues() {
   const { data, isLoading, error } = usePipelineVenues()
   const [selectedVenueId, setSelectedVenueId] = useState<number | null>(null)
   const [showAddVenue, setShowAddVenue] = useState(false)
+  const [activeView, setActiveView] = useState<'venues' | 'history'>('venues')
 
   if (isLoading) return <p className="text-muted-foreground">Loading pipeline venues...</p>
   if (error) return <p className="text-red-400">Failed to load pipeline venues</p>
@@ -555,6 +666,34 @@ export function PipelineVenues() {
 
   return (
     <div className="space-y-4">
+      {/* View toggle */}
+      <div className="flex items-center gap-2 border-b border-border pb-3">
+        <button
+          onClick={() => setActiveView('venues')}
+          className={`px-3 py-1.5 rounded text-sm font-medium transition-colors ${
+            activeView === 'venues'
+              ? 'bg-primary text-primary-foreground'
+              : 'text-muted-foreground hover:text-foreground hover:bg-muted'
+          }`}
+        >
+          Venue Status
+        </button>
+        <button
+          onClick={() => setActiveView('history')}
+          className={`px-3 py-1.5 rounded text-sm font-medium transition-colors ${
+            activeView === 'history'
+              ? 'bg-primary text-primary-foreground'
+              : 'text-muted-foreground hover:text-foreground hover:bg-muted'
+          }`}
+        >
+          Import History
+        </button>
+      </div>
+
+      {activeView === 'history' ? (
+        <ImportHistorySection />
+      ) : (
+      <>
       <div className="flex items-center justify-between">
         <h2 className="text-lg font-semibold">Pipeline Venues</h2>
         <button
@@ -654,6 +793,8 @@ export function PipelineVenues() {
             />
           )}
         </>
+      )}
+      </>
       )}
     </div>
   )

--- a/frontend/components/layout/CommandPalette.tsx
+++ b/frontend/components/layout/CommandPalette.tsx
@@ -217,10 +217,10 @@ const adminRoutes: RouteItem[] = [
     requireAdmin: true,
   },
   {
-    label: 'Admin: Pipeline',
+    label: 'Admin: Data Pipeline',
     href: '/admin?tab=pipeline',
     icon: Workflow,
-    keywords: ['admin', 'pipeline', 'extraction', 'scraping', 'venues'],
+    keywords: ['admin', 'pipeline', 'extraction', 'scraping', 'venues', 'data', 'import'],
     requireAdmin: true,
   },
   {

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -311,6 +311,7 @@ export const API_ENDPOINTS = {
     },
     PIPELINE: {
       VENUES: `${API_BASE_URL}/admin/pipeline/venues`,
+      IMPORTS: `${API_BASE_URL}/admin/pipeline/imports`,
       EXTRACT: (venueId: string | number) =>
         `${API_BASE_URL}/admin/pipeline/extract/${venueId}`,
       VENUE_STATS: (venueId: string | number) =>

--- a/frontend/lib/hooks/usePipeline.ts
+++ b/frontend/lib/hooks/usePipeline.ts
@@ -78,6 +78,36 @@ export function useVenueRejectionStats(venueId: number, options?: { enabled?: bo
   })
 }
 
+export interface ImportHistoryEntry {
+  id: number
+  venue_id: number
+  venue_name: string
+  venue_slug: string
+  source_type: string
+  render_method?: string
+  events_extracted: number
+  events_imported: number
+  duration_ms: number
+  error?: string
+  run_at: string
+}
+
+export function useImportHistory(
+  limit: number = 20,
+  offset: number = 0,
+  options?: { enabled?: boolean }
+) {
+  return useQuery({
+    queryKey: queryKeys.pipeline.imports(limit, offset),
+    queryFn: async () => {
+      const url = `${API_ENDPOINTS.ADMIN.PIPELINE.IMPORTS}?limit=${limit}&offset=${offset}`
+      const data = await apiRequest<{ imports: ImportHistoryEntry[]; total: number }>(url)
+      return data
+    },
+    enabled: options?.enabled ?? true,
+  })
+}
+
 // --- Mutations ---
 
 export function useUpdateExtractionNotes() {

--- a/frontend/lib/queryClient.ts
+++ b/frontend/lib/queryClient.ts
@@ -279,6 +279,8 @@ export const queryKeys = {
   // Pipeline queries
   pipeline: {
     venues: ['pipeline', 'venues'] as const,
+    imports: (limit: number, offset: number) =>
+      ['pipeline', 'imports', String(limit), String(offset)] as const,
     venueStats: (venueId: string | number) =>
       ['pipeline', 'venueStats', String(venueId)] as const,
     venueRuns: (venueId: string | number) =>


### PR DESCRIPTION
## Summary

Closes PSY-33

- Add `GET /admin/pipeline/imports` endpoint returning paginated, cross-venue extraction run history with venue names, source types (AI/iCal/RSS), event counts, duration, and status
- Add Import History sub-view in the admin Data Pipeline tab with source type badges, pagination controls, and human-friendly duration formatting
- Rename admin tab from "Pipeline" to "Data Pipeline" (tab value + Cmd+K label)
- Mark standalone `/discovery` app as deprecated with `DEPRECATED.md` explaining migration to the API-first pipeline

## Backend changes
- `VenueSourceConfigService.GetAllRecentRuns()` -- queries extraction runs across all venues with venue preloading and source type resolution from config
- `ImportHistoryEntry` type in contracts, aliased through services package
- `PipelineHandler.GetImportHistoryHandler` with admin guard
- New route registered at `/admin/pipeline/imports`
- 4 new handler tests (success, empty, pagination passthrough, service error)
- Updated interface + 3 test stubs to satisfy new method

## Frontend changes
- `useImportHistory` hook with limit/offset pagination
- `ImportHistorySection` component with table, `SourceTypeBadge`, and Previous/Next pagination
- View toggle in `PipelineVenues` (Venue Status / Import History)
- API endpoint + query key additions

## Test plan
- [x] All 30 pipeline handler tests pass (including 4 new)
- [x] All pipeline service tests pass
- [x] Full backend compiles cleanly
- [x] No new TypeScript errors introduced
- [ ] Manual: verify Data Pipeline tab loads with both sub-views
- [ ] Manual: verify Import History pagination works
- [ ] Manual: verify source type badges display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)