### PR TITLE
Add 417 frontend unit tests across 25 files

### DIFF
--- a/frontend/features/artists/hooks/useArtistReports.test.tsx
+++ b/frontend/features/artists/hooks/useArtistReports.test.tsx
@@ -1,0 +1,289 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createWrapper, createTestQueryClient } from '@/test/utils'
+
+// Create mocks
+const mockApiRequest = vi.fn()
+const mockInvalidateArtistReports = vi.fn()
+
+// Mock the api module
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    ARTISTS: {
+      REPORT: (artistId: string | number) => `/artists/${artistId}/report`,
+      MY_REPORT: (artistId: string | number) => `/artists/${artistId}/my-report`,
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+// Mock queryClient module
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    artistReports: {
+      myReport: (artistId: string | number) =>
+        ['artistReports', 'myReport', String(artistId)],
+    },
+  },
+  createInvalidateQueries: () => ({
+    artistReports: mockInvalidateArtistReports,
+  }),
+}))
+
+// Import hooks after mocks are set up
+import { useMyArtistReport, useReportArtist } from './useArtistReports'
+
+describe('useMyArtistReport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches the user\'s existing report for an artist', async () => {
+    const mockResponse = {
+      report: {
+        id: 1,
+        artist_id: 42,
+        report_type: 'inaccurate',
+        details: 'Wrong city listed',
+        status: 'pending',
+        created_at: '2025-03-01T00:00:00Z',
+        updated_at: '2025-03-01T00:00:00Z',
+      },
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useMyArtistReport(42), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/artists/42/my-report', {
+      method: 'GET',
+    })
+    expect(result.current.data?.report?.report_type).toBe('inaccurate')
+    expect(result.current.data?.report?.status).toBe('pending')
+  })
+
+  it('returns null report when user has not reported', async () => {
+    mockApiRequest.mockResolvedValueOnce({ report: null })
+
+    const { result } = renderHook(() => useMyArtistReport(42), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data?.report).toBeNull()
+  })
+
+  it('does not fetch when artistId is null', () => {
+    const { result } = renderHook(() => useMyArtistReport(null), {
+      wrapper: createWrapper(),
+    })
+
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('accepts string artistId', async () => {
+    mockApiRequest.mockResolvedValueOnce({ report: null })
+
+    const { result } = renderHook(() => useMyArtistReport('42'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/artists/42/my-report', {
+      method: 'GET',
+    })
+  })
+
+  it('handles API errors', async () => {
+    const error = new Error('Unauthorized')
+    Object.assign(error, { status: 401 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useMyArtistReport(42), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect((result.current.error as Error).message).toBe('Unauthorized')
+  })
+
+  it('accepts numeric artistId 0 as falsy — does not fetch', () => {
+    const { result } = renderHook(() => useMyArtistReport(0), {
+      wrapper: createWrapper(),
+    })
+
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+})
+
+describe('useReportArtist', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateArtistReports.mockReset()
+  })
+
+  it('creates a report and invalidates queries', async () => {
+    const mockResponse = {
+      id: 10,
+      artist_id: 42,
+      report_type: 'inaccurate',
+      details: 'Wrong social links',
+      status: 'pending',
+      created_at: '2025-03-15T00:00:00Z',
+      updated_at: '2025-03-15T00:00:00Z',
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useReportArtist(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      const data = await result.current.mutateAsync({
+        artistId: 42,
+        reportType: 'inaccurate',
+        details: 'Wrong social links',
+      })
+      expect(data.id).toBe(10)
+      expect(data.report_type).toBe('inaccurate')
+      expect(data.status).toBe('pending')
+    })
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/artists/42/report', {
+      method: 'POST',
+      body: JSON.stringify({
+        report_type: 'inaccurate',
+        details: 'Wrong social links',
+      }),
+    })
+    expect(mockInvalidateArtistReports).toHaveBeenCalled()
+  })
+
+  it('creates a report without details', async () => {
+    const mockResponse = {
+      id: 11,
+      artist_id: 42,
+      report_type: 'removal_request',
+      details: null,
+      status: 'pending',
+      created_at: '2025-03-15T00:00:00Z',
+      updated_at: '2025-03-15T00:00:00Z',
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useReportArtist(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        artistId: 42,
+        reportType: 'removal_request',
+      })
+    })
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/artists/42/report', {
+      method: 'POST',
+      body: JSON.stringify({
+        report_type: 'removal_request',
+        details: null,
+      }),
+    })
+  })
+
+  it('handles duplicate report error', async () => {
+    const error = new Error('You have already reported this artist')
+    Object.assign(error, { status: 409 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useReportArtist(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({
+          artistId: 42,
+          reportType: 'inaccurate',
+          details: 'Test',
+        })
+      } catch (e) {
+        expect((e as Error).message).toBe(
+          'You have already reported this artist'
+        )
+      }
+    })
+
+    expect(mockInvalidateArtistReports).not.toHaveBeenCalled()
+  })
+
+  it('handles server errors', async () => {
+    const error = new Error('Internal server error')
+    Object.assign(error, { status: 500 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useReportArtist(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({
+          artistId: 42,
+          reportType: 'inaccurate',
+        })
+      } catch (e) {
+        expect((e as Error).message).toBe('Internal server error')
+      }
+    })
+
+    expect(mockInvalidateArtistReports).not.toHaveBeenCalled()
+  })
+
+  it('handles empty string details as null', async () => {
+    const mockResponse = {
+      id: 12,
+      artist_id: 42,
+      report_type: 'inaccurate',
+      details: null,
+      status: 'pending',
+      created_at: '2025-03-15T00:00:00Z',
+      updated_at: '2025-03-15T00:00:00Z',
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useReportArtist(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        artistId: 42,
+        reportType: 'inaccurate',
+        details: '',
+      })
+    })
+
+    // The hook sends `details || null`, so empty string becomes null
+    expect(mockApiRequest).toHaveBeenCalledWith('/artists/42/report', {
+      method: 'POST',
+      body: JSON.stringify({
+        report_type: 'inaccurate',
+        details: null,
+      }),
+    })
+  })
+})

--- a/frontend/features/artists/hooks/useArtistSearch.test.tsx
+++ b/frontend/features/artists/hooks/useArtistSearch.test.tsx
@@ -1,0 +1,196 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createWrapper, createTestQueryClient } from '@/test/utils'
+
+// Create mocks
+const mockApiRequest = vi.fn()
+
+// Mock the api module
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    ARTISTS: {
+      SEARCH: '/artists/search',
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+// Mock queryClient module
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    artists: {
+      search: (query: string) => ['artists', 'search', query.toLowerCase()],
+    },
+  },
+}))
+
+// Mock use-debounce to make tests synchronous
+vi.mock('use-debounce', () => ({
+  useDebounce: (value: string, _delay: number) => [value],
+}))
+
+// Import hooks after mocks are set up
+import { useArtistSearch } from './useArtistSearch'
+
+describe('useArtistSearch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches artists matching the search query', async () => {
+    const mockResponse = {
+      artists: [
+        {
+          id: 1,
+          slug: 'test-artist',
+          name: 'Test Artist',
+          city: 'Phoenix',
+          state: 'AZ',
+          social: {},
+        },
+        {
+          id: 2,
+          slug: 'test-band',
+          name: 'Test Band',
+          city: 'Tempe',
+          state: 'AZ',
+          social: {},
+        },
+      ],
+      count: 2,
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(
+      () => useArtistSearch({ query: 'test' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/artists/search?q=test')
+    expect(result.current.data?.artists).toHaveLength(2)
+    expect(result.current.data?.count).toBe(2)
+  })
+
+  it('does not fetch when query is empty', () => {
+    const { result } = renderHook(
+      () => useArtistSearch({ query: '' }),
+      { wrapper: createWrapper() }
+    )
+
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('URL-encodes special characters in query', async () => {
+    mockApiRequest.mockResolvedValueOnce({ artists: [], count: 0 })
+
+    const { result } = renderHook(
+      () => useArtistSearch({ query: 'AT&T Center' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/artists/search?q=AT%26T%20Center'
+    )
+  })
+
+  it('handles API errors', async () => {
+    const error = new Error('Server error')
+    Object.assign(error, { status: 500 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(
+      () => useArtistSearch({ query: 'test' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect(result.current.error).toBeDefined()
+  })
+
+  it('returns empty results for no matches', async () => {
+    mockApiRequest.mockResolvedValueOnce({ artists: [], count: 0 })
+
+    const { result } = renderHook(
+      () => useArtistSearch({ query: 'zzzznonexistent' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data?.artists).toHaveLength(0)
+    expect(result.current.data?.count).toBe(0)
+  })
+
+  it('accepts custom debounce delay', async () => {
+    mockApiRequest.mockResolvedValueOnce({ artists: [], count: 0 })
+
+    const { result } = renderHook(
+      () => useArtistSearch({ query: 'test', debounceMs: 500 }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    // Since use-debounce is mocked, it resolves immediately regardless of delay
+    expect(mockApiRequest).toHaveBeenCalledWith('/artists/search?q=test')
+  })
+
+  it('returns loading state while fetching', () => {
+    // Make the request hang
+    mockApiRequest.mockReturnValue(new Promise(() => {}))
+
+    const { result } = renderHook(
+      () => useArtistSearch({ query: 'loading' }),
+      { wrapper: createWrapper() }
+    )
+
+    expect(result.current.isLoading).toBe(true)
+    expect(result.current.data).toBeUndefined()
+  })
+
+  it('returns artist details in response', async () => {
+    const mockResponse = {
+      artists: [
+        {
+          id: 5,
+          slug: 'sonic-youth',
+          name: 'Sonic Youth',
+          city: 'New York',
+          state: 'NY',
+          bandcamp_embed_url: null,
+          social: {
+            bandcamp: 'https://sonicyouth.bandcamp.com',
+            spotify: null,
+            instagram: null,
+          },
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-06-01T00:00:00Z',
+        },
+      ],
+      count: 1,
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(
+      () => useArtistSearch({ query: 'sonic' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const artist = result.current.data?.artists[0]
+    expect(artist?.name).toBe('Sonic Youth')
+    expect(artist?.slug).toBe('sonic-youth')
+    expect(artist?.social.bandcamp).toBe('https://sonicyouth.bandcamp.com')
+  })
+})

--- a/frontend/features/auth/hooks/useCalendarFeed.test.tsx
+++ b/frontend/features/auth/hooks/useCalendarFeed.test.tsx
@@ -1,0 +1,222 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createWrapper, createTestQueryClient } from '@/test/utils'
+
+// Create mocks
+const mockApiRequest = vi.fn()
+const mockInvalidateCalendar = vi.fn()
+
+// Mock the api module
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    CALENDAR: {
+      TOKEN: '/calendar/token',
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+// Mock queryClient module
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    calendar: {
+      all: ['calendar'],
+      tokenStatus: ['calendar', 'tokenStatus'],
+    },
+  },
+  createInvalidateQueries: () => ({
+    calendar: mockInvalidateCalendar,
+  }),
+}))
+
+// Import hooks after mocks are set up
+import {
+  useCalendarTokenStatus,
+  useCreateCalendarToken,
+  useDeleteCalendarToken,
+} from './useCalendarFeed'
+
+describe('useCalendarTokenStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches token status when enabled', async () => {
+    const mockResponse = {
+      has_token: true,
+      created_at: '2025-03-01T12:00:00Z',
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useCalendarTokenStatus(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/calendar/token', {
+      method: 'GET',
+    })
+    expect(result.current.data?.has_token).toBe(true)
+    expect(result.current.data?.created_at).toBe('2025-03-01T12:00:00Z')
+  })
+
+  it('fetches when enabled is true explicitly', async () => {
+    mockApiRequest.mockResolvedValueOnce({ has_token: false })
+
+    const { result } = renderHook(() => useCalendarTokenStatus(true), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/calendar/token', {
+      method: 'GET',
+    })
+    expect(result.current.data?.has_token).toBe(false)
+  })
+
+  it('does not fetch when enabled is false', () => {
+    const { result } = renderHook(() => useCalendarTokenStatus(false), {
+      wrapper: createWrapper(),
+    })
+
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('handles API errors', async () => {
+    const error = new Error('Unauthorized')
+    Object.assign(error, { status: 401 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useCalendarTokenStatus(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect((result.current.error as Error).message).toBe('Unauthorized')
+  })
+
+  it('returns no created_at when user has no token', async () => {
+    mockApiRequest.mockResolvedValueOnce({ has_token: false })
+
+    const { result } = renderHook(() => useCalendarTokenStatus(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data?.has_token).toBe(false)
+    expect(result.current.data?.created_at).toBeUndefined()
+  })
+})
+
+describe('useCreateCalendarToken', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateCalendar.mockReset()
+  })
+
+  it('creates a calendar token and invalidates queries', async () => {
+    const mockResponse = {
+      token: 'abc123token',
+      feed_url: 'https://api.psychichomily.com/calendar/feed/abc123token',
+      created_at: '2025-03-15T10:00:00Z',
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useCreateCalendarToken(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      const data = await result.current.mutateAsync()
+      expect(data.token).toBe('abc123token')
+      expect(data.feed_url).toContain('abc123token')
+      expect(data.created_at).toBe('2025-03-15T10:00:00Z')
+    })
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/calendar/token', {
+      method: 'POST',
+    })
+    expect(mockInvalidateCalendar).toHaveBeenCalled()
+  })
+
+  it('handles creation errors', async () => {
+    const error = new Error('Server error')
+    Object.assign(error, { status: 500 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useCreateCalendarToken(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync()
+      } catch (e) {
+        expect((e as Error).message).toBe('Server error')
+      }
+    })
+
+    expect(mockInvalidateCalendar).not.toHaveBeenCalled()
+  })
+})
+
+describe('useDeleteCalendarToken', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateCalendar.mockReset()
+  })
+
+  it('deletes the calendar token and invalidates queries', async () => {
+    const mockResponse = {
+      success: true,
+      message: 'Calendar feed token deleted',
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useDeleteCalendarToken(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      const data = await result.current.mutateAsync()
+      expect(data.success).toBe(true)
+      expect(data.message).toBe('Calendar feed token deleted')
+    })
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/calendar/token', {
+      method: 'DELETE',
+    })
+    expect(mockInvalidateCalendar).toHaveBeenCalled()
+  })
+
+  it('handles deletion errors', async () => {
+    const error = new Error('Not found')
+    Object.assign(error, { status: 404 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useDeleteCalendarToken(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync()
+      } catch (e) {
+        expect((e as Error).message).toBe('Not found')
+      }
+    })
+
+    expect(mockInvalidateCalendar).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/features/auth/hooks/useContributorProfile.test.tsx
+++ b/frontend/features/auth/hooks/useContributorProfile.test.tsx
@@ -1,0 +1,674 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createWrapper, createTestQueryClient } from '@/test/utils'
+
+// Create mocks
+const mockApiRequest = vi.fn()
+const mockInvalidateOwnContributor = vi.fn()
+const mockInvalidateContributor = vi.fn()
+
+// Mock the api module
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    USERS: {
+      PROFILE: (username: string) => `/users/${username}`,
+      CONTRIBUTIONS: (username: string) => `/users/${username}/contributions`,
+    },
+    CONTRIBUTOR: {
+      OWN_PROFILE: '/auth/profile/contributor',
+      OWN_CONTRIBUTIONS: '/auth/profile/contributions',
+      VISIBILITY: '/auth/profile/visibility',
+      PRIVACY: '/auth/profile/privacy',
+      OWN_SECTIONS: '/auth/profile/sections',
+      SECTION: (sectionId: number) => `/auth/profile/sections/${sectionId}`,
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+// Mock queryClient module
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    contributor: {
+      profile: (username: string) => ['contributor', 'profile', username],
+      ownProfile: ['contributor', 'ownProfile'],
+      contributions: (username: string) => ['contributor', 'contributions', username],
+      ownContributions: ['contributor', 'ownContributions'],
+      ownSections: ['contributor', 'ownSections'],
+    },
+  },
+  createInvalidateQueries: () => ({
+    ownContributor: mockInvalidateOwnContributor,
+    contributor: mockInvalidateContributor,
+  }),
+}))
+
+// Import hooks after mocks are set up
+import {
+  usePublicProfile,
+  usePublicContributions,
+  useOwnContributorProfile,
+  useOwnContributions,
+  useOwnSections,
+  useUpdateVisibility,
+  useUpdatePrivacy,
+  useCreateSection,
+  useUpdateSection,
+  useDeleteSection,
+} from './useContributorProfile'
+
+// ============================================================================
+// Public Profile Queries
+// ============================================================================
+
+describe('usePublicProfile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches a public profile by username', async () => {
+    const mockProfile = {
+      username: 'testuser',
+      bio: 'Music enthusiast',
+      profile_visibility: 'public',
+      user_tier: 'contributor',
+      joined_at: '2024-01-15T00:00:00Z',
+      stats: {
+        shows_submitted: 42,
+        venues_submitted: 5,
+        total_contributions: 50,
+      },
+    }
+    mockApiRequest.mockResolvedValueOnce(mockProfile)
+
+    const { result } = renderHook(() => usePublicProfile('testuser'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/users/testuser', {
+      method: 'GET',
+    })
+    expect(result.current.data?.username).toBe('testuser')
+    expect(result.current.data?.stats?.shows_submitted).toBe(42)
+  })
+
+  it('does not fetch when username is empty', () => {
+    const { result } = renderHook(() => usePublicProfile(''), {
+      wrapper: createWrapper(),
+    })
+
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('handles user not found error', async () => {
+    const error = new Error('User not found')
+    Object.assign(error, { status: 404 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => usePublicProfile('nonexistent'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect((result.current.error as Error).message).toBe('User not found')
+  })
+})
+
+describe('usePublicContributions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches contributions with default options', async () => {
+    const mockResponse = {
+      contributions: [
+        {
+          id: 1,
+          action: 'created',
+          entity_type: 'show',
+          entity_id: 100,
+          entity_name: 'Cool Show',
+          created_at: '2025-03-01T00:00:00Z',
+          source: 'web',
+        },
+      ],
+      total: 1,
+      limit: 20,
+      offset: 0,
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(
+      () => usePublicContributions('testuser'),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const calledUrl = mockApiRequest.mock.calls[0][0]
+    expect(calledUrl).toContain('/users/testuser/contributions')
+    expect(calledUrl).toContain('limit=20')
+    expect(calledUrl).toContain('offset=0')
+    expect(result.current.data?.contributions).toHaveLength(1)
+  })
+
+  it('passes custom limit and offset', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      contributions: [],
+      total: 0,
+      limit: 10,
+      offset: 20,
+    })
+
+    const { result } = renderHook(
+      () => usePublicContributions('testuser', { limit: 10, offset: 20 }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const calledUrl = mockApiRequest.mock.calls[0][0]
+    expect(calledUrl).toContain('limit=10')
+    expect(calledUrl).toContain('offset=20')
+  })
+
+  it('passes entity_type filter', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      contributions: [],
+      total: 0,
+      limit: 20,
+      offset: 0,
+    })
+
+    const { result } = renderHook(
+      () =>
+        usePublicContributions('testuser', { entity_type: 'show' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const calledUrl = mockApiRequest.mock.calls[0][0]
+    expect(calledUrl).toContain('entity_type=show')
+  })
+
+  it('does not fetch when username is empty', () => {
+    const { result } = renderHook(
+      () => usePublicContributions(''),
+      { wrapper: createWrapper() }
+    )
+
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('handles API errors', async () => {
+    const error = new Error('Server error')
+    Object.assign(error, { status: 500 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(
+      () => usePublicContributions('testuser'),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+  })
+})
+
+// ============================================================================
+// Own Profile Queries
+// ============================================================================
+
+describe('useOwnContributorProfile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches the authenticated user\'s contributor profile', async () => {
+    const mockProfile = {
+      username: 'myuser',
+      bio: 'My bio',
+      profile_visibility: 'public',
+      user_tier: 'trusted_contributor',
+      joined_at: '2024-06-01T00:00:00Z',
+      privacy_settings: {
+        contributions: 'visible',
+        saved_shows: 'count_only',
+        attendance: 'visible',
+        following: 'hidden',
+        collections: 'visible',
+        last_active: 'visible',
+        profile_sections: 'visible',
+      },
+    }
+    mockApiRequest.mockResolvedValueOnce(mockProfile)
+
+    const { result } = renderHook(() => useOwnContributorProfile(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/auth/profile/contributor', {
+      method: 'GET',
+    })
+    expect(result.current.data?.username).toBe('myuser')
+    expect(result.current.data?.privacy_settings?.saved_shows).toBe('count_only')
+  })
+
+  it('handles unauthorized error', async () => {
+    const error = new Error('Unauthorized')
+    Object.assign(error, { status: 401 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useOwnContributorProfile(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+  })
+})
+
+describe('useOwnContributions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches own contributions with default options', async () => {
+    const mockResponse = {
+      contributions: [
+        {
+          id: 1,
+          action: 'created',
+          entity_type: 'venue',
+          entity_id: 10,
+          entity_name: 'New Venue',
+          created_at: '2025-02-01T00:00:00Z',
+          source: 'web',
+        },
+      ],
+      total: 1,
+      limit: 20,
+      offset: 0,
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useOwnContributions(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const calledUrl = mockApiRequest.mock.calls[0][0]
+    expect(calledUrl).toContain('/auth/profile/contributions')
+    expect(calledUrl).toContain('limit=20')
+    expect(calledUrl).toContain('offset=0')
+  })
+
+  it('passes entity_type filter', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      contributions: [],
+      total: 0,
+      limit: 20,
+      offset: 0,
+    })
+
+    const { result } = renderHook(
+      () => useOwnContributions({ entity_type: 'artist' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const calledUrl = mockApiRequest.mock.calls[0][0]
+    expect(calledUrl).toContain('entity_type=artist')
+  })
+})
+
+describe('useOwnSections', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches own profile sections', async () => {
+    const mockResponse = {
+      sections: [
+        {
+          id: 1,
+          title: 'About Me',
+          content: 'I love live music',
+          position: 0,
+          is_visible: true,
+          created_at: '2025-01-01T00:00:00Z',
+          updated_at: '2025-01-01T00:00:00Z',
+        },
+        {
+          id: 2,
+          title: 'Favorite Genres',
+          content: 'Punk, post-punk, shoegaze',
+          position: 1,
+          is_visible: true,
+          created_at: '2025-01-02T00:00:00Z',
+          updated_at: '2025-01-02T00:00:00Z',
+        },
+      ],
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useOwnSections(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/auth/profile/sections', {
+      method: 'GET',
+    })
+    expect(result.current.data?.sections).toHaveLength(2)
+    expect(result.current.data?.sections[0].title).toBe('About Me')
+  })
+})
+
+// ============================================================================
+// Mutations
+// ============================================================================
+
+describe('useUpdateVisibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateOwnContributor.mockReset()
+    mockInvalidateContributor.mockReset()
+  })
+
+  it('updates profile visibility and invalidates queries', async () => {
+    const mockResponse = {
+      username: 'testuser',
+      profile_visibility: 'private',
+      user_tier: 'contributor',
+      joined_at: '2024-01-01T00:00:00Z',
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useUpdateVisibility(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      const data = await result.current.mutateAsync({ visibility: 'private' })
+      expect(data.profile_visibility).toBe('private')
+    })
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/auth/profile/visibility', {
+      method: 'PATCH',
+      body: JSON.stringify({ visibility: 'private' }),
+    })
+    expect(mockInvalidateOwnContributor).toHaveBeenCalled()
+    expect(mockInvalidateContributor).toHaveBeenCalled()
+  })
+
+  it('handles update errors', async () => {
+    const error = new Error('Forbidden')
+    Object.assign(error, { status: 403 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useUpdateVisibility(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({ visibility: 'public' })
+      } catch (e) {
+        expect((e as Error).message).toBe('Forbidden')
+      }
+    })
+
+    expect(mockInvalidateOwnContributor).not.toHaveBeenCalled()
+    expect(mockInvalidateContributor).not.toHaveBeenCalled()
+  })
+})
+
+describe('useUpdatePrivacy', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateOwnContributor.mockReset()
+    mockInvalidateContributor.mockReset()
+  })
+
+  it('updates privacy settings and invalidates queries', async () => {
+    const mockResponse = {
+      username: 'testuser',
+      profile_visibility: 'public',
+      user_tier: 'contributor',
+      joined_at: '2024-01-01T00:00:00Z',
+      privacy_settings: {
+        contributions: 'visible',
+        saved_shows: 'hidden',
+        attendance: 'count_only',
+        following: 'hidden',
+        collections: 'visible',
+        last_active: 'hidden',
+        profile_sections: 'visible',
+      },
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useUpdatePrivacy(), {
+      wrapper: createWrapper(),
+    })
+
+    const privacyInput = {
+      saved_shows: 'hidden' as const,
+      attendance: 'count_only' as const,
+      last_active: 'hidden' as const,
+    }
+
+    await act(async () => {
+      const data = await result.current.mutateAsync(privacyInput)
+      expect(data.privacy_settings?.saved_shows).toBe('hidden')
+      expect(data.privacy_settings?.last_active).toBe('hidden')
+    })
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/auth/profile/privacy', {
+      method: 'PATCH',
+      body: JSON.stringify(privacyInput),
+    })
+    expect(mockInvalidateOwnContributor).toHaveBeenCalled()
+    expect(mockInvalidateContributor).toHaveBeenCalled()
+  })
+})
+
+describe('useCreateSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateOwnContributor.mockReset()
+    mockInvalidateContributor.mockReset()
+  })
+
+  it('creates a new section and invalidates queries', async () => {
+    const mockResponse = {
+      id: 3,
+      title: 'New Section',
+      content: 'Some content',
+      position: 2,
+      is_visible: true,
+      created_at: '2025-03-15T00:00:00Z',
+      updated_at: '2025-03-15T00:00:00Z',
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useCreateSection(), {
+      wrapper: createWrapper(),
+    })
+
+    const input = {
+      title: 'New Section',
+      content: 'Some content',
+      position: 2,
+    }
+
+    await act(async () => {
+      const data = await result.current.mutateAsync(input)
+      expect(data.id).toBe(3)
+      expect(data.title).toBe('New Section')
+    })
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/auth/profile/sections', {
+      method: 'POST',
+      body: JSON.stringify(input),
+    })
+    expect(mockInvalidateOwnContributor).toHaveBeenCalled()
+    expect(mockInvalidateContributor).toHaveBeenCalled()
+  })
+
+  it('handles creation errors', async () => {
+    const error = new Error('Validation failed')
+    Object.assign(error, { status: 422 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useCreateSection(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({
+          title: '',
+          content: '',
+          position: 0,
+        })
+      } catch (e) {
+        expect((e as Error).message).toBe('Validation failed')
+      }
+    })
+
+    expect(mockInvalidateOwnContributor).not.toHaveBeenCalled()
+  })
+})
+
+describe('useUpdateSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateOwnContributor.mockReset()
+    mockInvalidateContributor.mockReset()
+  })
+
+  it('updates a section and invalidates queries', async () => {
+    const mockResponse = {
+      id: 1,
+      title: 'Updated Title',
+      content: 'Updated content',
+      position: 0,
+      is_visible: true,
+      created_at: '2025-01-01T00:00:00Z',
+      updated_at: '2025-03-15T00:00:00Z',
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useUpdateSection(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      const data = await result.current.mutateAsync({
+        sectionId: 1,
+        data: { title: 'Updated Title', content: 'Updated content' },
+      })
+      expect(data.title).toBe('Updated Title')
+    })
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/auth/profile/sections/1', {
+      method: 'PUT',
+      body: JSON.stringify({ title: 'Updated Title', content: 'Updated content' }),
+    })
+    expect(mockInvalidateOwnContributor).toHaveBeenCalled()
+    expect(mockInvalidateContributor).toHaveBeenCalled()
+  })
+
+  it('handles section not found error', async () => {
+    const error = new Error('Section not found')
+    Object.assign(error, { status: 404 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useUpdateSection(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({
+          sectionId: 999,
+          data: { title: 'Test' },
+        })
+      } catch (e) {
+        expect((e as Error).message).toBe('Section not found')
+      }
+    })
+
+    expect(mockInvalidateOwnContributor).not.toHaveBeenCalled()
+  })
+})
+
+describe('useDeleteSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateOwnContributor.mockReset()
+    mockInvalidateContributor.mockReset()
+  })
+
+  it('deletes a section and invalidates queries', async () => {
+    mockApiRequest.mockResolvedValueOnce(undefined)
+
+    const { result } = renderHook(() => useDeleteSection(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      await result.current.mutateAsync(5)
+    })
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/auth/profile/sections/5', {
+      method: 'DELETE',
+    })
+    expect(mockInvalidateOwnContributor).toHaveBeenCalled()
+    expect(mockInvalidateContributor).toHaveBeenCalled()
+  })
+
+  it('handles deletion errors', async () => {
+    const error = new Error('Forbidden')
+    Object.assign(error, { status: 403 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useDeleteSection(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync(999)
+      } catch (e) {
+        expect((e as Error).message).toBe('Forbidden')
+      }
+    })
+
+    expect(mockInvalidateOwnContributor).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/features/auth/hooks/useFavoriteCities.test.tsx
+++ b/frontend/features/auth/hooks/useFavoriteCities.test.tsx
@@ -1,0 +1,188 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createWrapper, createTestQueryClient } from '@/test/utils'
+
+// Create mocks
+const mockApiRequest = vi.fn()
+
+// Mock the api module
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    AUTH: {
+      FAVORITE_CITIES: '/auth/preferences/favorite-cities',
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+// Mock queryClient module
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    auth: {
+      profile: ['auth', 'profile'],
+    },
+  },
+}))
+
+// Import hooks after mocks are set up
+import { useSetFavoriteCities } from './useFavoriteCities'
+
+describe('useSetFavoriteCities', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('saves favorite cities and invalidates profile query', async () => {
+    const mockResponse = {
+      success: true,
+      message: 'Favorite cities updated',
+      cities: [
+        { city: 'Phoenix', state: 'AZ' },
+        { city: 'Tempe', state: 'AZ' },
+      ],
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useSetFavoriteCities(), {
+      wrapper: createWrapper(),
+    })
+
+    const cities = [
+      { city: 'Phoenix', state: 'AZ' },
+      { city: 'Tempe', state: 'AZ' },
+    ]
+
+    await act(async () => {
+      const data = await result.current.mutateAsync(cities)
+      expect(data.success).toBe(true)
+      expect(data.cities).toHaveLength(2)
+    })
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/auth/preferences/favorite-cities',
+      {
+        method: 'PUT',
+        body: JSON.stringify({ cities }),
+      }
+    )
+  })
+
+  it('sends empty array to clear favorite cities', async () => {
+    const mockResponse = {
+      success: true,
+      message: 'Favorite cities cleared',
+      cities: [],
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useSetFavoriteCities(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      const data = await result.current.mutateAsync([])
+      expect(data.cities).toHaveLength(0)
+    })
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/auth/preferences/favorite-cities',
+      {
+        method: 'PUT',
+        body: JSON.stringify({ cities: [] }),
+      }
+    )
+  })
+
+  it('handles API errors', async () => {
+    const error = new Error('Unauthorized')
+    Object.assign(error, { status: 401 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useSetFavoriteCities(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync([{ city: 'Phoenix', state: 'AZ' }])
+      } catch (e) {
+        expect((e as Error).message).toBe('Unauthorized')
+      }
+    })
+  })
+
+  it('handles validation errors', async () => {
+    const error = new Error('Invalid city data')
+    Object.assign(error, { status: 422 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useSetFavoriteCities(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync([{ city: '', state: '' }])
+      } catch (e) {
+        expect((e as Error).message).toBe('Invalid city data')
+      }
+    })
+  })
+
+  it('saves a single city', async () => {
+    const mockResponse = {
+      success: true,
+      message: 'Favorite cities updated',
+      cities: [{ city: 'Chicago', state: 'IL' }],
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useSetFavoriteCities(), {
+      wrapper: createWrapper(),
+    })
+
+    const cities = [{ city: 'Chicago', state: 'IL' }]
+
+    await act(async () => {
+      const data = await result.current.mutateAsync(cities)
+      expect(data.cities).toHaveLength(1)
+      expect(data.cities[0].city).toBe('Chicago')
+      expect(data.cities[0].state).toBe('IL')
+    })
+  })
+
+  it('isLoading reflects mutation state', async () => {
+    let resolveMutation: (v: unknown) => void
+    mockApiRequest.mockReturnValueOnce(
+      new Promise(resolve => {
+        resolveMutation = resolve
+      })
+    )
+
+    const { result } = renderHook(() => useSetFavoriteCities(), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.isPending).toBe(false)
+
+    act(() => {
+      result.current.mutate([{ city: 'Phoenix', state: 'AZ' }])
+    })
+
+    await waitFor(() => expect(result.current.isPending).toBe(true))
+
+    await act(async () => {
+      resolveMutation!({
+        success: true,
+        message: 'Updated',
+        cities: [{ city: 'Phoenix', state: 'AZ' }],
+      })
+    })
+
+    await waitFor(() => expect(result.current.isPending).toBe(false))
+  })
+})

--- a/frontend/features/collections/hooks/index.test.tsx
+++ b/frontend/features/collections/hooks/index.test.tsx
@@ -1,0 +1,521 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createWrapper, createTestQueryClient } from '@/test/utils'
+
+// Create mocks
+const mockApiRequest = vi.fn()
+
+// Mock the api module
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    COLLECTIONS: {
+      LIST: '/collections',
+      DETAIL: (slug: string) => `/collections/${slug}`,
+      STATS: (slug: string) => `/collections/${slug}/stats`,
+      ITEMS: (slug: string) => `/collections/${slug}/items`,
+      ITEM: (slug: string, itemId: number) =>
+        `/collections/${slug}/items/${itemId}`,
+      SUBSCRIBE: (slug: string) => `/collections/${slug}/subscribe`,
+      FEATURE: (slug: string) => `/collections/${slug}/feature`,
+      MY: '/auth/collections',
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+// Mock queryClient module
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    collections: {
+      all: ['collections'],
+      detail: (slug: string) => ['collections', 'detail', slug],
+      stats: (slug: string) => ['collections', 'stats', slug],
+      my: ['collections', 'my'],
+    },
+  },
+}))
+
+// Import hooks after mocks are set up
+import {
+  useCollections,
+  useCollection,
+  useCollectionStats,
+  useMyCollections,
+  useSetFeatured,
+  useCreateCollection,
+  useUpdateCollection,
+  useDeleteCollection,
+  useAddCollectionItem,
+  useRemoveCollectionItem,
+  useSubscribeCollection,
+  useUnsubscribeCollection,
+} from './index'
+
+describe('Collection Hooks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  // ──────────────────────────────────────────────
+  // Query hooks
+  // ──────────────────────────────────────────────
+
+  describe('useCollections', () => {
+    it('fetches the public collections list', async () => {
+      const mockResponse = {
+        collections: [
+          { id: 1, title: 'Best Of', slug: 'best-of' },
+          { id: 2, title: 'New Finds', slug: 'new-finds' },
+        ],
+        total: 2,
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(() => useCollections(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/collections')
+      expect(result.current.data?.collections).toHaveLength(2)
+      expect(result.current.data?.total).toBe(2)
+    })
+
+    it('handles API errors', async () => {
+      const error = new Error('Server error')
+      Object.assign(error, { status: 500 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(() => useCollections(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+      expect(result.current.error).toBeDefined()
+    })
+
+    it('returns empty collections list', async () => {
+      mockApiRequest.mockResolvedValueOnce({ collections: [], total: 0 })
+
+      const { result } = renderHook(() => useCollections(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(result.current.data?.collections).toHaveLength(0)
+      expect(result.current.data?.total).toBe(0)
+    })
+  })
+
+  describe('useCollection', () => {
+    it('fetches a single collection by slug', async () => {
+      const mockDetail = {
+        id: 1,
+        title: 'Best Of',
+        slug: 'best-of',
+        items: [{ id: 1, entity_type: 'artist', entity_id: 10 }],
+      }
+      mockApiRequest.mockResolvedValueOnce(mockDetail)
+
+      const { result } = renderHook(() => useCollection('best-of'), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/collections/best-of')
+      expect(result.current.data?.title).toBe('Best Of')
+    })
+
+    it('does not fetch when slug is empty', async () => {
+      const { result } = renderHook(() => useCollection(''), {
+        wrapper: createWrapper(),
+      })
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('does not fetch when enabled is false', async () => {
+      const { result } = renderHook(
+        () => useCollection('best-of', { enabled: false }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('handles collection not found error', async () => {
+      const error = new Error('Collection not found')
+      Object.assign(error, { status: 404 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(() => useCollection('nonexistent'), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+      expect((result.current.error as Error).message).toBe(
+        'Collection not found'
+      )
+    })
+  })
+
+  describe('useCollectionStats', () => {
+    it('fetches collection stats by slug', async () => {
+      const mockStats = {
+        item_count: 10,
+        subscriber_count: 5,
+        entity_type_counts: { artist: 6, release: 4 },
+      }
+      mockApiRequest.mockResolvedValueOnce(mockStats)
+
+      const { result } = renderHook(() => useCollectionStats('best-of'), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/collections/best-of/stats')
+      expect(result.current.data?.item_count).toBe(10)
+    })
+
+    it('does not fetch when slug is empty', async () => {
+      const { result } = renderHook(() => useCollectionStats(''), {
+        wrapper: createWrapper(),
+      })
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('does not fetch when enabled is false', async () => {
+      const { result } = renderHook(
+        () => useCollectionStats('best-of', { enabled: false }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('handles API errors', async () => {
+      const error = new Error('Server error')
+      Object.assign(error, { status: 500 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(() => useCollectionStats('best-of'), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+    })
+  })
+
+  describe('useMyCollections', () => {
+    it('fetches authenticated user collections', async () => {
+      const mockResponse = {
+        collections: [
+          { id: 1, title: 'My Faves', slug: 'my-faves' },
+        ],
+        total: 1,
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(() => useMyCollections(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/auth/collections')
+      expect(result.current.data?.collections).toHaveLength(1)
+    })
+
+    it('handles unauthorized error', async () => {
+      const error = new Error('Unauthorized')
+      Object.assign(error, { status: 401 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(() => useMyCollections(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+    })
+  })
+
+  // ──────────────────────────────────────────────
+  // Mutation hooks
+  // ──────────────────────────────────────────────
+
+  describe('useSetFeatured', () => {
+    it('sets featured status on a collection', async () => {
+      mockApiRequest.mockResolvedValueOnce(undefined)
+
+      const queryClient = createTestQueryClient()
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      )
+
+      const { result } = renderHook(() => useSetFeatured(), { wrapper })
+
+      await act(async () => {
+        await result.current.mutateAsync({ slug: 'best-of', featured: true })
+      })
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/collections/best-of/feature', {
+        method: 'PUT',
+        body: JSON.stringify({ featured: true }),
+      })
+    })
+
+    it('handles mutation errors', async () => {
+      const error = new Error('Forbidden')
+      Object.assign(error, { status: 403 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const queryClient = createTestQueryClient()
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      )
+
+      const { result } = renderHook(() => useSetFeatured(), { wrapper })
+
+      await expect(
+        act(async () => {
+          await result.current.mutateAsync({ slug: 'best-of', featured: true })
+        })
+      ).rejects.toThrow('Forbidden')
+    })
+  })
+
+  describe('useCreateCollection', () => {
+    it('creates a new collection', async () => {
+      const mockCreated = {
+        id: 3,
+        title: 'New Collection',
+        slug: 'new-collection',
+        is_public: true,
+        collaborative: false,
+      }
+      mockApiRequest.mockResolvedValueOnce(mockCreated)
+
+      const queryClient = createTestQueryClient()
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      )
+
+      const { result } = renderHook(() => useCreateCollection(), { wrapper })
+
+      let data: unknown
+      await act(async () => {
+        data = await result.current.mutateAsync({
+          title: 'New Collection',
+          description: 'A great collection',
+          is_public: true,
+          collaborative: false,
+        })
+      })
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/collections', {
+        method: 'POST',
+        body: JSON.stringify({
+          title: 'New Collection',
+          description: 'A great collection',
+          is_public: true,
+          collaborative: false,
+        }),
+      })
+      expect(data).toEqual(mockCreated)
+    })
+  })
+
+  describe('useUpdateCollection', () => {
+    it('updates an existing collection', async () => {
+      const mockUpdated = {
+        id: 1,
+        title: 'Updated Title',
+        slug: 'best-of',
+      }
+      mockApiRequest.mockResolvedValueOnce(mockUpdated)
+
+      const queryClient = createTestQueryClient()
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      )
+
+      const { result } = renderHook(() => useUpdateCollection(), { wrapper })
+
+      await act(async () => {
+        await result.current.mutateAsync({
+          slug: 'best-of',
+          title: 'Updated Title',
+        })
+      })
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/collections/best-of', {
+        method: 'PUT',
+        body: JSON.stringify({ title: 'Updated Title' }),
+      })
+    })
+  })
+
+  describe('useDeleteCollection', () => {
+    it('deletes a collection', async () => {
+      mockApiRequest.mockResolvedValueOnce(undefined)
+
+      const queryClient = createTestQueryClient()
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      )
+
+      const { result } = renderHook(() => useDeleteCollection(), { wrapper })
+
+      await act(async () => {
+        await result.current.mutateAsync({ slug: 'old-collection' })
+      })
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/collections/old-collection', {
+        method: 'DELETE',
+      })
+    })
+  })
+
+  describe('useAddCollectionItem', () => {
+    it('adds an item to a collection', async () => {
+      mockApiRequest.mockResolvedValueOnce(undefined)
+
+      const queryClient = createTestQueryClient()
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      )
+
+      const { result } = renderHook(() => useAddCollectionItem(), { wrapper })
+
+      await act(async () => {
+        await result.current.mutateAsync({
+          slug: 'best-of',
+          entityType: 'artist',
+          entityId: 42,
+          notes: 'Great artist',
+        })
+      })
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/collections/best-of/items', {
+        method: 'POST',
+        body: JSON.stringify({
+          entity_type: 'artist',
+          entity_id: 42,
+          notes: 'Great artist',
+        }),
+      })
+    })
+
+    it('adds an item without notes', async () => {
+      mockApiRequest.mockResolvedValueOnce(undefined)
+
+      const queryClient = createTestQueryClient()
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      )
+
+      const { result } = renderHook(() => useAddCollectionItem(), { wrapper })
+
+      await act(async () => {
+        await result.current.mutateAsync({
+          slug: 'best-of',
+          entityType: 'release',
+          entityId: 7,
+        })
+      })
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/collections/best-of/items', {
+        method: 'POST',
+        body: JSON.stringify({
+          entity_type: 'release',
+          entity_id: 7,
+        }),
+      })
+    })
+  })
+
+  describe('useRemoveCollectionItem', () => {
+    it('removes an item from a collection', async () => {
+      mockApiRequest.mockResolvedValueOnce(undefined)
+
+      const queryClient = createTestQueryClient()
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      )
+
+      const { result } = renderHook(() => useRemoveCollectionItem(), {
+        wrapper,
+      })
+
+      await act(async () => {
+        await result.current.mutateAsync({ slug: 'best-of', itemId: 5 })
+      })
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/collections/best-of/items/5',
+        { method: 'DELETE' }
+      )
+    })
+  })
+
+  describe('useSubscribeCollection', () => {
+    it('subscribes to a collection', async () => {
+      mockApiRequest.mockResolvedValueOnce(undefined)
+
+      const queryClient = createTestQueryClient()
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      )
+
+      const { result } = renderHook(() => useSubscribeCollection(), {
+        wrapper,
+      })
+
+      await act(async () => {
+        await result.current.mutateAsync({ slug: 'best-of' })
+      })
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/collections/best-of/subscribe',
+        { method: 'POST' }
+      )
+    })
+  })
+
+  describe('useUnsubscribeCollection', () => {
+    it('unsubscribes from a collection', async () => {
+      mockApiRequest.mockResolvedValueOnce(undefined)
+
+      const queryClient = createTestQueryClient()
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      )
+
+      const { result } = renderHook(() => useUnsubscribeCollection(), {
+        wrapper,
+      })
+
+      await act(async () => {
+        await result.current.mutateAsync({ slug: 'best-of' })
+      })
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/collections/best-of/subscribe',
+        { method: 'DELETE' }
+      )
+    })
+  })
+})

--- a/frontend/features/festivals/hooks/useFestivals.test.tsx
+++ b/frontend/features/festivals/hooks/useFestivals.test.tsx
@@ -1,0 +1,903 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { createWrapper } from '@/test/utils'
+
+// Create mocks
+const mockApiRequest = vi.fn()
+
+// Mock the api module
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    FESTIVALS: {
+      LIST: '/festivals',
+      GET: (idOrSlug: string | number) => `/festivals/${idOrSlug}`,
+      ARTISTS: (festivalId: string | number) =>
+        `/festivals/${festivalId}/artists`,
+      VENUES: (festivalId: string | number) =>
+        `/festivals/${festivalId}/venues`,
+      ARTIST_FESTIVALS: (artistIdOrSlug: string | number) =>
+        `/artists/${artistIdOrSlug}/festivals`,
+      SIMILAR: (festivalId: string | number) =>
+        `/festivals/${festivalId}/similar`,
+      BREAKOUTS: (festivalId: string | number) =>
+        `/festivals/${festivalId}/breakouts`,
+      ARTIST_TRAJECTORY: (artistIdOrSlug: string | number) =>
+        `/artists/${artistIdOrSlug}/festival-trajectory`,
+      SERIES_COMPARE: (seriesSlug: string) =>
+        `/festivals/series/${seriesSlug}/compare`,
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+// Mock queryClient module
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    festivals: {
+      list: (filters?: Record<string, unknown>) => ['festivals', 'list', filters],
+      detail: (idOrSlug: string | number) => ['festivals', 'detail', String(idOrSlug)],
+      artists: (idOrSlug: string | number, dayDate?: string) =>
+        ['festivals', 'artists', String(idOrSlug), dayDate],
+      venues: (idOrSlug: string | number) =>
+        ['festivals', 'venues', String(idOrSlug)],
+      artistFestivals: (artistIdOrSlug: string | number) =>
+        ['festivals', 'artist', String(artistIdOrSlug)],
+      similar: (idOrSlug: string | number) =>
+        ['festivals', 'similar', String(idOrSlug)],
+      breakouts: (idOrSlug: string | number) =>
+        ['festivals', 'breakouts', String(idOrSlug)],
+      artistTrajectory: (artistIdOrSlug: string | number) =>
+        ['festivals', 'trajectory', String(artistIdOrSlug)],
+      seriesCompare: (seriesSlug: string, years: number[]) =>
+        ['festivals', 'series', seriesSlug, years.join(',')],
+    },
+  },
+}))
+
+// Import hooks after mocks are set up
+import {
+  useFestivals,
+  useFestival,
+  useFestivalArtists,
+  useFestivalLineup,
+  useFestivalVenues,
+  useArtistFestivals,
+  useSimilarFestivals,
+  useFestivalBreakouts,
+  useArtistFestivalTrajectory,
+  useSeriesComparison,
+} from './useFestivals'
+
+describe('Festival Hooks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  // ──────────────────────────────────────────────
+  // useFestivals
+  // ──────────────────────────────────────────────
+
+  describe('useFestivals', () => {
+    it('fetches festivals list without filters', async () => {
+      const mockResponse = {
+        festivals: [
+          { id: 1, name: 'Festival A', slug: 'festival-a' },
+          { id: 2, name: 'Festival B', slug: 'festival-b' },
+        ],
+        total: 2,
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(() => useFestivals(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/festivals', {
+        method: 'GET',
+      })
+      expect(result.current.data?.festivals).toHaveLength(2)
+    })
+
+    it('includes status filter in query params', async () => {
+      mockApiRequest.mockResolvedValueOnce({ festivals: [], total: 0 })
+
+      const { result } = renderHook(
+        () => useFestivals({ status: 'upcoming' }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/festivals?status=upcoming',
+        { method: 'GET' }
+      )
+    })
+
+    it('includes city and state filters', async () => {
+      mockApiRequest.mockResolvedValueOnce({ festivals: [], total: 0 })
+
+      const { result } = renderHook(
+        () => useFestivals({ city: 'Phoenix', state: 'AZ' }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      const calledUrl = mockApiRequest.mock.calls[0][0]
+      expect(calledUrl).toContain('city=Phoenix')
+      expect(calledUrl).toContain('state=AZ')
+    })
+
+    it('includes year filter', async () => {
+      mockApiRequest.mockResolvedValueOnce({ festivals: [], total: 0 })
+
+      const { result } = renderHook(
+        () => useFestivals({ year: 2026 }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/festivals?year=2026', {
+        method: 'GET',
+      })
+    })
+
+    it('includes series_slug filter', async () => {
+      mockApiRequest.mockResolvedValueOnce({ festivals: [], total: 0 })
+
+      const { result } = renderHook(
+        () => useFestivals({ seriesSlug: 'coachella' }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/festivals?series_slug=coachella',
+        { method: 'GET' }
+      )
+    })
+
+    it('combines multiple filters', async () => {
+      mockApiRequest.mockResolvedValueOnce({ festivals: [], total: 0 })
+
+      const { result } = renderHook(
+        () =>
+          useFestivals({
+            status: 'upcoming',
+            city: 'Phoenix',
+            state: 'AZ',
+            year: 2026,
+          }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      const calledUrl = mockApiRequest.mock.calls[0][0]
+      expect(calledUrl).toContain('status=upcoming')
+      expect(calledUrl).toContain('city=Phoenix')
+      expect(calledUrl).toContain('state=AZ')
+      expect(calledUrl).toContain('year=2026')
+    })
+
+    it('handles API errors', async () => {
+      const error = new Error('Server error')
+      Object.assign(error, { status: 500 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(() => useFestivals(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+    })
+  })
+
+  // ──────────────────────────────────────────────
+  // useFestival
+  // ──────────────────────────────────────────────
+
+  describe('useFestival', () => {
+    it('fetches a single festival by slug', async () => {
+      const mockFestival = {
+        id: 1,
+        name: 'Desert Daze',
+        slug: 'desert-daze',
+        start_date: '2026-10-10',
+        end_date: '2026-10-12',
+      }
+      mockApiRequest.mockResolvedValueOnce(mockFestival)
+
+      const { result } = renderHook(
+        () => useFestival({ idOrSlug: 'desert-daze' }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/festivals/desert-daze', {
+        method: 'GET',
+      })
+      expect(result.current.data?.name).toBe('Desert Daze')
+    })
+
+    it('fetches a single festival by numeric ID', async () => {
+      mockApiRequest.mockResolvedValueOnce({ id: 5, name: 'Fest' })
+
+      const { result } = renderHook(
+        () => useFestival({ idOrSlug: 5 }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/festivals/5', {
+        method: 'GET',
+      })
+    })
+
+    it('does not fetch when enabled is false', async () => {
+      const { result } = renderHook(
+        () => useFestival({ idOrSlug: 'desert-daze', enabled: false }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('does not fetch when idOrSlug is empty string', async () => {
+      const { result } = renderHook(
+        () => useFestival({ idOrSlug: '' }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('does not fetch when numeric ID is 0 or negative', async () => {
+      const { result: result0 } = renderHook(
+        () => useFestival({ idOrSlug: 0 }),
+        { wrapper: createWrapper() }
+      )
+
+      const { result: resultNeg } = renderHook(
+        () => useFestival({ idOrSlug: -1 }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result0.current.fetchStatus).toBe('idle')
+      expect(resultNeg.current.fetchStatus).toBe('idle')
+    })
+
+    it('handles not found error', async () => {
+      const error = new Error('Festival not found')
+      Object.assign(error, { status: 404 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(
+        () => useFestival({ idOrSlug: 'nonexistent' }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+      expect((result.current.error as Error).message).toBe(
+        'Festival not found'
+      )
+    })
+  })
+
+  // ──────────────────────────────────────────────
+  // useFestivalArtists
+  // ──────────────────────────────────────────────
+
+  describe('useFestivalArtists', () => {
+    it('fetches the lineup for a festival', async () => {
+      const mockResponse = {
+        artists: [
+          { id: 1, name: 'Artist A', billing_tier: 'headliner' },
+          { id: 2, name: 'Artist B', billing_tier: 'undercard' },
+        ],
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(
+        () => useFestivalArtists({ festivalIdOrSlug: 'desert-daze' }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/festivals/desert-daze/artists',
+        { method: 'GET' }
+      )
+      expect(result.current.data?.artists).toHaveLength(2)
+    })
+
+    it('includes day_date filter', async () => {
+      mockApiRequest.mockResolvedValueOnce({ artists: [] })
+
+      const { result } = renderHook(
+        () =>
+          useFestivalArtists({
+            festivalIdOrSlug: 'desert-daze',
+            dayDate: '2026-10-11',
+          }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/festivals/desert-daze/artists?day_date=2026-10-11',
+        { method: 'GET' }
+      )
+    })
+
+    it('does not fetch when enabled is false', async () => {
+      const { result } = renderHook(
+        () =>
+          useFestivalArtists({
+            festivalIdOrSlug: 'desert-daze',
+            enabled: false,
+          }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('does not fetch when festivalIdOrSlug is empty string', async () => {
+      const { result } = renderHook(
+        () => useFestivalArtists({ festivalIdOrSlug: '' }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('does not fetch when numeric ID is 0 or negative', async () => {
+      const { result } = renderHook(
+        () => useFestivalArtists({ festivalIdOrSlug: 0 }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('handles API errors', async () => {
+      const error = new Error('Server error')
+      Object.assign(error, { status: 500 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(
+        () => useFestivalArtists({ festivalIdOrSlug: 'desert-daze' }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+    })
+  })
+
+  // ──────────────────────────────────────────────
+  // useFestivalLineup (alias)
+  // ──────────────────────────────────────────────
+
+  describe('useFestivalLineup', () => {
+    it('delegates to useFestivalArtists', async () => {
+      mockApiRequest.mockResolvedValueOnce({ artists: [] })
+
+      const { result } = renderHook(
+        () => useFestivalLineup({ festivalId: 'desert-daze' }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/festivals/desert-daze/artists',
+        { method: 'GET' }
+      )
+    })
+
+    it('passes dayDate through', async () => {
+      mockApiRequest.mockResolvedValueOnce({ artists: [] })
+
+      const { result } = renderHook(
+        () =>
+          useFestivalLineup({
+            festivalId: 'desert-daze',
+            dayDate: '2026-10-10',
+          }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/festivals/desert-daze/artists?day_date=2026-10-10',
+        { method: 'GET' }
+      )
+    })
+  })
+
+  // ──────────────────────────────────────────────
+  // useFestivalVenues
+  // ──────────────────────────────────────────────
+
+  describe('useFestivalVenues', () => {
+    it('fetches venues for a festival', async () => {
+      const mockResponse = {
+        venues: [
+          { id: 1, name: 'Main Stage' },
+          { id: 2, name: 'Side Stage' },
+        ],
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(
+        () => useFestivalVenues({ festivalIdOrSlug: 'desert-daze' }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/festivals/desert-daze/venues',
+        { method: 'GET' }
+      )
+      expect(result.current.data?.venues).toHaveLength(2)
+    })
+
+    it('does not fetch when enabled is false', async () => {
+      const { result } = renderHook(
+        () =>
+          useFestivalVenues({
+            festivalIdOrSlug: 'desert-daze',
+            enabled: false,
+          }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('does not fetch when festivalIdOrSlug is empty string', async () => {
+      const { result } = renderHook(
+        () => useFestivalVenues({ festivalIdOrSlug: '' }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('handles API errors', async () => {
+      const error = new Error('Server error')
+      Object.assign(error, { status: 500 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(
+        () => useFestivalVenues({ festivalIdOrSlug: 1 }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+    })
+  })
+
+  // ──────────────────────────────────────────────
+  // useArtistFestivals
+  // ──────────────────────────────────────────────
+
+  describe('useArtistFestivals', () => {
+    it('fetches festivals for an artist by slug', async () => {
+      const mockResponse = {
+        festivals: [
+          { id: 1, name: 'Fest A', billing_tier: 'headliner' },
+        ],
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(
+        () => useArtistFestivals({ artistIdOrSlug: 'the-smile' }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/artists/the-smile/festivals',
+        { method: 'GET' }
+      )
+    })
+
+    it('fetches festivals for an artist by numeric ID', async () => {
+      mockApiRequest.mockResolvedValueOnce({ festivals: [] })
+
+      const { result } = renderHook(
+        () => useArtistFestivals({ artistIdOrSlug: 42 }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/artists/42/festivals', {
+        method: 'GET',
+      })
+    })
+
+    it('does not fetch when enabled is false', async () => {
+      const { result } = renderHook(
+        () => useArtistFestivals({ artistIdOrSlug: 'the-smile', enabled: false }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('does not fetch when artistIdOrSlug is empty string', async () => {
+      const { result } = renderHook(
+        () => useArtistFestivals({ artistIdOrSlug: '' }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('does not fetch when numeric ID is 0', async () => {
+      const { result } = renderHook(
+        () => useArtistFestivals({ artistIdOrSlug: 0 }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('handles API errors', async () => {
+      const error = new Error('Server error')
+      Object.assign(error, { status: 500 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(
+        () => useArtistFestivals({ artistIdOrSlug: 'the-smile' }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+    })
+  })
+
+  // ──────────────────────────────────────────────
+  // Festival Intelligence hooks
+  // ──────────────────────────────────────────────
+
+  describe('useSimilarFestivals', () => {
+    it('fetches similar festivals with default limit', async () => {
+      const mockResponse = {
+        festivals: [
+          { id: 2, name: 'Similar Fest', overlap_score: 0.75 },
+        ],
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(
+        () => useSimilarFestivals({ festivalIdOrSlug: 'desert-daze' }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      const calledUrl = mockApiRequest.mock.calls[0][0]
+      expect(calledUrl).toContain('/festivals/desert-daze/similar')
+      expect(calledUrl).toContain('limit=10')
+    })
+
+    it('fetches similar festivals with custom limit', async () => {
+      mockApiRequest.mockResolvedValueOnce({ festivals: [] })
+
+      const { result } = renderHook(
+        () =>
+          useSimilarFestivals({
+            festivalIdOrSlug: 'desert-daze',
+            limit: 5,
+          }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      const calledUrl = mockApiRequest.mock.calls[0][0]
+      expect(calledUrl).toContain('limit=5')
+    })
+
+    it('does not fetch when enabled is false', async () => {
+      const { result } = renderHook(
+        () =>
+          useSimilarFestivals({
+            festivalIdOrSlug: 'desert-daze',
+            enabled: false,
+          }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('does not fetch when festivalIdOrSlug is empty', async () => {
+      const { result } = renderHook(
+        () => useSimilarFestivals({ festivalIdOrSlug: '' }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('handles API errors', async () => {
+      const error = new Error('Server error')
+      Object.assign(error, { status: 500 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(
+        () => useSimilarFestivals({ festivalIdOrSlug: 1 }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+    })
+  })
+
+  describe('useFestivalBreakouts', () => {
+    it('fetches breakout artists for a festival', async () => {
+      const mockResponse = {
+        breakouts: [
+          { artist_id: 1, artist_name: 'Rising Star', tier_change: 2 },
+        ],
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(
+        () => useFestivalBreakouts({ festivalIdOrSlug: 'desert-daze' }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/festivals/desert-daze/breakouts',
+        { method: 'GET' }
+      )
+    })
+
+    it('does not fetch when enabled is false', async () => {
+      const { result } = renderHook(
+        () =>
+          useFestivalBreakouts({
+            festivalIdOrSlug: 'desert-daze',
+            enabled: false,
+          }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('does not fetch when festivalIdOrSlug is empty', async () => {
+      const { result } = renderHook(
+        () => useFestivalBreakouts({ festivalIdOrSlug: '' }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('handles API errors', async () => {
+      const error = new Error('Server error')
+      Object.assign(error, { status: 500 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(
+        () => useFestivalBreakouts({ festivalIdOrSlug: 1 }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+    })
+  })
+
+  describe('useArtistFestivalTrajectory', () => {
+    it('fetches trajectory for an artist', async () => {
+      const mockResponse = {
+        artist_id: 1,
+        trajectory: [
+          { festival: 'Fest A', year: 2024, tier: 'undercard' },
+          { festival: 'Fest A', year: 2025, tier: 'mid_card' },
+        ],
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(
+        () => useArtistFestivalTrajectory({ artistIdOrSlug: 'the-smile' }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/artists/the-smile/festival-trajectory',
+        { method: 'GET' }
+      )
+    })
+
+    it('does not fetch when enabled is false', async () => {
+      const { result } = renderHook(
+        () =>
+          useArtistFestivalTrajectory({
+            artistIdOrSlug: 'the-smile',
+            enabled: false,
+          }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('does not fetch when artistIdOrSlug is empty', async () => {
+      const { result } = renderHook(
+        () => useArtistFestivalTrajectory({ artistIdOrSlug: '' }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('does not fetch when numeric ID is 0', async () => {
+      const { result } = renderHook(
+        () => useArtistFestivalTrajectory({ artistIdOrSlug: 0 }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('handles API errors', async () => {
+      const error = new Error('Server error')
+      Object.assign(error, { status: 500 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(
+        () => useArtistFestivalTrajectory({ artistIdOrSlug: 42 }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+    })
+  })
+
+  describe('useSeriesComparison', () => {
+    it('fetches year-over-year comparison', async () => {
+      const mockResponse = {
+        series_slug: 'coachella',
+        comparisons: [
+          { year: 2025, artist_count: 100 },
+          { year: 2026, artist_count: 110 },
+        ],
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(
+        () =>
+          useSeriesComparison({
+            seriesSlug: 'coachella',
+            years: [2025, 2026],
+          }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      const calledUrl = mockApiRequest.mock.calls[0][0]
+      expect(calledUrl).toContain('/festivals/series/coachella/compare')
+      expect(calledUrl).toContain('years=2025%2C2026')
+    })
+
+    it('does not fetch when enabled is false', async () => {
+      const { result } = renderHook(
+        () =>
+          useSeriesComparison({
+            seriesSlug: 'coachella',
+            years: [2025, 2026],
+            enabled: false,
+          }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('does not fetch when seriesSlug is empty', async () => {
+      const { result } = renderHook(
+        () =>
+          useSeriesComparison({
+            seriesSlug: '',
+            years: [2025, 2026],
+          }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('does not fetch when fewer than 2 years provided', async () => {
+      const { result } = renderHook(
+        () =>
+          useSeriesComparison({
+            seriesSlug: 'coachella',
+            years: [2025],
+          }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('does not fetch when years array is empty', async () => {
+      const { result } = renderHook(
+        () =>
+          useSeriesComparison({
+            seriesSlug: 'coachella',
+            years: [],
+          }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('handles API errors', async () => {
+      const error = new Error('Server error')
+      Object.assign(error, { status: 500 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(
+        () =>
+          useSeriesComparison({
+            seriesSlug: 'coachella',
+            years: [2025, 2026],
+          }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+    })
+  })
+})

--- a/frontend/features/labels/hooks/useLabels.test.tsx
+++ b/frontend/features/labels/hooks/useLabels.test.tsx
@@ -1,0 +1,502 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { createWrapper } from '@/test/utils'
+
+// Create mocks
+const mockApiRequest = vi.fn()
+
+// Mock the api module
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    LABELS: {
+      LIST: '/labels',
+      GET: (idOrSlug: string | number) => `/labels/${idOrSlug}`,
+      ARTISTS: (idOrSlug: string | number) => `/labels/${idOrSlug}/artists`,
+      RELEASES: (idOrSlug: string | number) => `/labels/${idOrSlug}/releases`,
+    },
+    ARTISTS: {
+      LABELS: (artistIdOrSlug: string | number) =>
+        `/artists/${artistIdOrSlug}/labels`,
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+// Mock queryClient module
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    labels: {
+      list: (filters?: Record<string, unknown>) => ['labels', 'list', filters],
+      detail: (idOrSlug: string | number) => ['labels', 'detail', String(idOrSlug)],
+      roster: (idOrSlug: string | number) => ['labels', 'roster', String(idOrSlug)],
+      catalog: (idOrSlug: string | number) => ['labels', 'catalog', String(idOrSlug)],
+    },
+    artists: {
+      labels: (artistIdOrSlug: string | number) =>
+        ['artists', 'labels', String(artistIdOrSlug)],
+    },
+  },
+}))
+
+// Import hooks after mocks are set up
+import {
+  useLabels,
+  useLabel,
+  useArtistLabels,
+  useLabelRoster,
+  useLabelCatalog,
+} from './useLabels'
+
+describe('Label Hooks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  // ──────────────────────────────────────────────
+  // useLabels
+  // ──────────────────────────────────────────────
+
+  describe('useLabels', () => {
+    it('fetches labels list without filters', async () => {
+      const mockResponse = {
+        labels: [
+          { id: 1, name: 'Label A', slug: 'label-a' },
+          { id: 2, name: 'Label B', slug: 'label-b' },
+        ],
+        total: 2,
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(() => useLabels(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/labels', {
+        method: 'GET',
+      })
+      expect(result.current.data?.labels).toHaveLength(2)
+    })
+
+    it('includes status filter in query params', async () => {
+      mockApiRequest.mockResolvedValueOnce({ labels: [], total: 0 })
+
+      const { result } = renderHook(
+        () => useLabels({ status: 'active' }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/labels?status=active', {
+        method: 'GET',
+      })
+    })
+
+    it('includes city and state filters', async () => {
+      mockApiRequest.mockResolvedValueOnce({ labels: [], total: 0 })
+
+      const { result } = renderHook(
+        () => useLabels({ city: 'Phoenix', state: 'AZ' }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      const calledUrl = mockApiRequest.mock.calls[0][0]
+      expect(calledUrl).toContain('city=Phoenix')
+      expect(calledUrl).toContain('state=AZ')
+    })
+
+    it('combines multiple filters', async () => {
+      mockApiRequest.mockResolvedValueOnce({ labels: [], total: 0 })
+
+      const { result } = renderHook(
+        () => useLabels({ status: 'active', city: 'Mesa', state: 'AZ' }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      const calledUrl = mockApiRequest.mock.calls[0][0]
+      expect(calledUrl).toContain('status=active')
+      expect(calledUrl).toContain('city=Mesa')
+      expect(calledUrl).toContain('state=AZ')
+    })
+
+    it('handles API errors', async () => {
+      const error = new Error('Server error')
+      Object.assign(error, { status: 500 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(() => useLabels(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+    })
+
+    it('returns empty labels list', async () => {
+      mockApiRequest.mockResolvedValueOnce({ labels: [], total: 0 })
+
+      const { result } = renderHook(() => useLabels(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(result.current.data?.labels).toHaveLength(0)
+    })
+  })
+
+  // ──────────────────────────────────────────────
+  // useLabel
+  // ──────────────────────────────────────────────
+
+  describe('useLabel', () => {
+    it('fetches a single label by slug', async () => {
+      const mockLabel = {
+        id: 1,
+        name: 'Sub Pop',
+        slug: 'sub-pop',
+        city: 'Seattle',
+        state: 'WA',
+      }
+      mockApiRequest.mockResolvedValueOnce(mockLabel)
+
+      const { result } = renderHook(
+        () => useLabel({ idOrSlug: 'sub-pop' }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/labels/sub-pop', {
+        method: 'GET',
+      })
+      expect(result.current.data?.name).toBe('Sub Pop')
+    })
+
+    it('fetches a single label by numeric ID', async () => {
+      mockApiRequest.mockResolvedValueOnce({ id: 5, name: 'Label' })
+
+      const { result } = renderHook(
+        () => useLabel({ idOrSlug: 5 }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/labels/5', {
+        method: 'GET',
+      })
+    })
+
+    it('does not fetch when enabled is false', async () => {
+      const { result } = renderHook(
+        () => useLabel({ idOrSlug: 'sub-pop', enabled: false }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('does not fetch when idOrSlug is empty string', async () => {
+      const { result } = renderHook(
+        () => useLabel({ idOrSlug: '' }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('does not fetch when numeric ID is 0 or negative', async () => {
+      const { result: result0 } = renderHook(
+        () => useLabel({ idOrSlug: 0 }),
+        { wrapper: createWrapper() }
+      )
+      const { result: resultNeg } = renderHook(
+        () => useLabel({ idOrSlug: -1 }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result0.current.fetchStatus).toBe('idle')
+      expect(resultNeg.current.fetchStatus).toBe('idle')
+    })
+
+    it('handles label not found error', async () => {
+      const error = new Error('Label not found')
+      Object.assign(error, { status: 404 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(
+        () => useLabel({ idOrSlug: 'nonexistent' }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+      expect((result.current.error as Error).message).toBe('Label not found')
+    })
+  })
+
+  // ──────────────────────────────────────────────
+  // useArtistLabels
+  // ──────────────────────────────────────────────
+
+  describe('useArtistLabels', () => {
+    it('fetches labels for an artist by slug', async () => {
+      const mockResponse = {
+        labels: [{ id: 1, name: 'Label A' }],
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(
+        () => useArtistLabels({ artistIdOrSlug: 'the-smile' }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/artists/the-smile/labels', {
+        method: 'GET',
+      })
+    })
+
+    it('fetches labels for an artist by numeric ID', async () => {
+      mockApiRequest.mockResolvedValueOnce({ labels: [] })
+
+      const { result } = renderHook(
+        () => useArtistLabels({ artistIdOrSlug: 42 }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/artists/42/labels', {
+        method: 'GET',
+      })
+    })
+
+    it('does not fetch when enabled is false', async () => {
+      const { result } = renderHook(
+        () => useArtistLabels({ artistIdOrSlug: 'the-smile', enabled: false }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('does not fetch when artistIdOrSlug is empty string', async () => {
+      const { result } = renderHook(
+        () => useArtistLabels({ artistIdOrSlug: '' }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('does not fetch when numeric ID is 0', async () => {
+      const { result } = renderHook(
+        () => useArtistLabels({ artistIdOrSlug: 0 }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('handles API errors', async () => {
+      const error = new Error('Server error')
+      Object.assign(error, { status: 500 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(
+        () => useArtistLabels({ artistIdOrSlug: 'the-smile' }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+    })
+  })
+
+  // ──────────────────────────────────────────────
+  // useLabelRoster
+  // ──────────────────────────────────────────────
+
+  describe('useLabelRoster', () => {
+    it('fetches artists on a label by slug', async () => {
+      const mockResponse = {
+        artists: [
+          { id: 1, name: 'Artist A' },
+          { id: 2, name: 'Artist B' },
+        ],
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(
+        () => useLabelRoster({ labelIdOrSlug: 'sub-pop' }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/labels/sub-pop/artists', {
+        method: 'GET',
+      })
+      expect(result.current.data?.artists).toHaveLength(2)
+    })
+
+    it('fetches artists on a label by numeric ID', async () => {
+      mockApiRequest.mockResolvedValueOnce({ artists: [] })
+
+      const { result } = renderHook(
+        () => useLabelRoster({ labelIdOrSlug: 10 }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/labels/10/artists', {
+        method: 'GET',
+      })
+    })
+
+    it('does not fetch when enabled is false', async () => {
+      const { result } = renderHook(
+        () => useLabelRoster({ labelIdOrSlug: 'sub-pop', enabled: false }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('does not fetch when labelIdOrSlug is empty string', async () => {
+      const { result } = renderHook(
+        () => useLabelRoster({ labelIdOrSlug: '' }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('does not fetch when numeric ID is 0 or negative', async () => {
+      const { result } = renderHook(
+        () => useLabelRoster({ labelIdOrSlug: 0 }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('handles API errors', async () => {
+      const error = new Error('Server error')
+      Object.assign(error, { status: 500 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(
+        () => useLabelRoster({ labelIdOrSlug: 'sub-pop' }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+    })
+  })
+
+  // ──────────────────────────────────────────────
+  // useLabelCatalog
+  // ──────────────────────────────────────────────
+
+  describe('useLabelCatalog', () => {
+    it('fetches releases on a label by slug', async () => {
+      const mockResponse = {
+        releases: [
+          { id: 1, title: 'Album A' },
+          { id: 2, title: 'Album B' },
+        ],
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(
+        () => useLabelCatalog({ labelIdOrSlug: 'sub-pop' }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/labels/sub-pop/releases', {
+        method: 'GET',
+      })
+      expect(result.current.data?.releases).toHaveLength(2)
+    })
+
+    it('fetches releases on a label by numeric ID', async () => {
+      mockApiRequest.mockResolvedValueOnce({ releases: [] })
+
+      const { result } = renderHook(
+        () => useLabelCatalog({ labelIdOrSlug: 10 }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/labels/10/releases', {
+        method: 'GET',
+      })
+    })
+
+    it('does not fetch when enabled is false', async () => {
+      const { result } = renderHook(
+        () => useLabelCatalog({ labelIdOrSlug: 'sub-pop', enabled: false }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('does not fetch when labelIdOrSlug is empty string', async () => {
+      const { result } = renderHook(
+        () => useLabelCatalog({ labelIdOrSlug: '' }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('does not fetch when numeric ID is 0 or negative', async () => {
+      const { result } = renderHook(
+        () => useLabelCatalog({ labelIdOrSlug: 0 }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('handles API errors', async () => {
+      const error = new Error('Server error')
+      Object.assign(error, { status: 500 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(
+        () => useLabelCatalog({ labelIdOrSlug: 'sub-pop' }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+    })
+  })
+})

--- a/frontend/features/releases/hooks/useReleases.test.tsx
+++ b/frontend/features/releases/hooks/useReleases.test.tsx
@@ -1,0 +1,366 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { createWrapper } from '@/test/utils'
+
+// Create mocks
+const mockApiRequest = vi.fn()
+
+// Mock the api module
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    RELEASES: {
+      LIST: '/releases',
+      GET: (idOrSlug: string | number) => `/releases/${idOrSlug}`,
+      ARTIST_RELEASES: (artistIdOrSlug: string | number) =>
+        `/artists/${artistIdOrSlug}/releases`,
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+// Mock queryClient module
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    releases: {
+      list: (filters?: Record<string, unknown>) => ['releases', 'list', filters],
+      detail: (idOrSlug: string | number) => ['releases', 'detail', String(idOrSlug)],
+      artistReleases: (artistIdOrSlug: string | number) =>
+        ['releases', 'artist', String(artistIdOrSlug)],
+    },
+  },
+}))
+
+// Import hooks after mocks are set up
+import { useReleases, useRelease, useArtistReleases } from './useReleases'
+
+describe('Release Hooks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  // ──────────────────────────────────────────────
+  // useReleases
+  // ──────────────────────────────────────────────
+
+  describe('useReleases', () => {
+    it('fetches releases list without filters', async () => {
+      const mockResponse = {
+        releases: [
+          { id: 1, title: 'Album A', slug: 'album-a' },
+          { id: 2, title: 'Album B', slug: 'album-b' },
+        ],
+        total: 2,
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(() => useReleases(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/releases', {
+        method: 'GET',
+      })
+      expect(result.current.data?.releases).toHaveLength(2)
+    })
+
+    it('includes release_type filter', async () => {
+      mockApiRequest.mockResolvedValueOnce({ releases: [], total: 0 })
+
+      const { result } = renderHook(
+        () => useReleases({ releaseType: 'album' }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/releases?release_type=album',
+        { method: 'GET' }
+      )
+    })
+
+    it('includes year filter', async () => {
+      mockApiRequest.mockResolvedValueOnce({ releases: [], total: 0 })
+
+      const { result } = renderHook(
+        () => useReleases({ year: 2025 }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/releases?year=2025', {
+        method: 'GET',
+      })
+    })
+
+    it('includes artist_id filter', async () => {
+      mockApiRequest.mockResolvedValueOnce({ releases: [], total: 0 })
+
+      const { result } = renderHook(
+        () => useReleases({ artistId: 42 }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/releases?artist_id=42', {
+        method: 'GET',
+      })
+    })
+
+    it('includes string artist_id filter', async () => {
+      mockApiRequest.mockResolvedValueOnce({ releases: [], total: 0 })
+
+      const { result } = renderHook(
+        () => useReleases({ artistId: 'the-smile' }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/releases?artist_id=the-smile',
+        { method: 'GET' }
+      )
+    })
+
+    it('combines multiple filters', async () => {
+      mockApiRequest.mockResolvedValueOnce({ releases: [], total: 0 })
+
+      const { result } = renderHook(
+        () => useReleases({ releaseType: 'ep', year: 2026, artistId: 10 }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      const calledUrl = mockApiRequest.mock.calls[0][0]
+      expect(calledUrl).toContain('release_type=ep')
+      expect(calledUrl).toContain('year=2026')
+      expect(calledUrl).toContain('artist_id=10')
+    })
+
+    it('handles API errors', async () => {
+      const error = new Error('Server error')
+      Object.assign(error, { status: 500 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(() => useReleases(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+    })
+
+    it('returns empty releases list', async () => {
+      mockApiRequest.mockResolvedValueOnce({ releases: [], total: 0 })
+
+      const { result } = renderHook(() => useReleases(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(result.current.data?.releases).toHaveLength(0)
+    })
+  })
+
+  // ──────────────────────────────────────────────
+  // useRelease
+  // ──────────────────────────────────────────────
+
+  describe('useRelease', () => {
+    it('fetches a single release by slug', async () => {
+      const mockRelease = {
+        id: 1,
+        title: 'Cutouts',
+        slug: 'cutouts',
+        release_type: 'album',
+        release_date: '2024-10-04',
+      }
+      mockApiRequest.mockResolvedValueOnce(mockRelease)
+
+      const { result } = renderHook(
+        () => useRelease({ idOrSlug: 'cutouts' }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/releases/cutouts', {
+        method: 'GET',
+      })
+      expect(result.current.data?.title).toBe('Cutouts')
+    })
+
+    it('fetches a single release by numeric ID', async () => {
+      mockApiRequest.mockResolvedValueOnce({ id: 5, title: 'Release' })
+
+      const { result } = renderHook(
+        () => useRelease({ idOrSlug: 5 }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/releases/5', {
+        method: 'GET',
+      })
+    })
+
+    it('does not fetch when enabled is false', async () => {
+      const { result } = renderHook(
+        () => useRelease({ idOrSlug: 'cutouts', enabled: false }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('does not fetch when idOrSlug is empty string', async () => {
+      const { result } = renderHook(
+        () => useRelease({ idOrSlug: '' }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('does not fetch when numeric ID is 0 or negative', async () => {
+      const { result: result0 } = renderHook(
+        () => useRelease({ idOrSlug: 0 }),
+        { wrapper: createWrapper() }
+      )
+      const { result: resultNeg } = renderHook(
+        () => useRelease({ idOrSlug: -1 }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result0.current.fetchStatus).toBe('idle')
+      expect(resultNeg.current.fetchStatus).toBe('idle')
+    })
+
+    it('handles release not found error', async () => {
+      const error = new Error('Release not found')
+      Object.assign(error, { status: 404 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(
+        () => useRelease({ idOrSlug: 'nonexistent' }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+      expect((result.current.error as Error).message).toBe(
+        'Release not found'
+      )
+    })
+  })
+
+  // ──────────────────────────────────────────────
+  // useArtistReleases
+  // ──────────────────────────────────────────────
+
+  describe('useArtistReleases', () => {
+    it('fetches releases for an artist by slug', async () => {
+      const mockResponse = {
+        releases: [
+          { id: 1, title: 'Album A' },
+          { id: 2, title: 'Album B' },
+        ],
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(
+        () => useArtistReleases({ artistIdOrSlug: 'the-smile' }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/artists/the-smile/releases',
+        { method: 'GET' }
+      )
+      expect(result.current.data?.releases).toHaveLength(2)
+    })
+
+    it('fetches releases for an artist by numeric ID', async () => {
+      mockApiRequest.mockResolvedValueOnce({ releases: [] })
+
+      const { result } = renderHook(
+        () => useArtistReleases({ artistIdOrSlug: 42 }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/artists/42/releases', {
+        method: 'GET',
+      })
+    })
+
+    it('does not fetch when enabled is false', async () => {
+      const { result } = renderHook(
+        () =>
+          useArtistReleases({ artistIdOrSlug: 'the-smile', enabled: false }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('does not fetch when artistIdOrSlug is empty string', async () => {
+      const { result } = renderHook(
+        () => useArtistReleases({ artistIdOrSlug: '' }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('does not fetch when numeric ID is 0', async () => {
+      const { result } = renderHook(
+        () => useArtistReleases({ artistIdOrSlug: 0 }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('does not fetch when numeric ID is negative', async () => {
+      const { result } = renderHook(
+        () => useArtistReleases({ artistIdOrSlug: -3 }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('handles API errors', async () => {
+      const error = new Error('Server error')
+      Object.assign(error, { status: 500 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(
+        () => useArtistReleases({ artistIdOrSlug: 'the-smile' }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+    })
+  })
+})

--- a/frontend/features/scenes/hooks/useScenes.test.tsx
+++ b/frontend/features/scenes/hooks/useScenes.test.tsx
@@ -1,0 +1,262 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { createWrapper } from '@/test/utils'
+
+// Create mocks
+const mockApiRequest = vi.fn()
+
+// Mock the api module
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    SCENES: {
+      LIST: '/scenes',
+      DETAIL: (slug: string) => `/scenes/${slug}`,
+      ARTISTS: (slug: string) => `/scenes/${slug}/artists`,
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+// Mock queryClient module
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    scenes: {
+      list: ['scenes', 'list'],
+      detail: (slug: string) => ['scenes', 'detail', slug],
+      artists: (slug: string, period?: number) =>
+        ['scenes', 'artists', slug, period],
+    },
+  },
+}))
+
+// Import hooks after mocks are set up
+import { useScenes, useSceneDetail, useSceneArtists } from './useScenes'
+
+describe('Scene Hooks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  // ──────────────────────────────────────────────
+  // useScenes
+  // ──────────────────────────────────────────────
+
+  describe('useScenes', () => {
+    it('fetches the list of scenes', async () => {
+      const mockResponse = {
+        scenes: [
+          { slug: 'phoenix-az', city: 'Phoenix', state: 'AZ', artist_count: 50 },
+          { slug: 'mesa-az', city: 'Mesa', state: 'AZ', artist_count: 20 },
+        ],
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(() => useScenes(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/scenes', {
+        method: 'GET',
+      })
+      expect(result.current.data?.scenes).toHaveLength(2)
+    })
+
+    it('handles API errors', async () => {
+      const error = new Error('Server error')
+      Object.assign(error, { status: 500 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(() => useScenes(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+    })
+
+    it('returns empty scenes list', async () => {
+      mockApiRequest.mockResolvedValueOnce({ scenes: [] })
+
+      const { result } = renderHook(() => useScenes(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(result.current.data?.scenes).toHaveLength(0)
+    })
+  })
+
+  // ──────────────────────────────────────────────
+  // useSceneDetail
+  // ──────────────────────────────────────────────
+
+  describe('useSceneDetail', () => {
+    it('fetches scene detail by slug', async () => {
+      const mockDetail = {
+        slug: 'phoenix-az',
+        city: 'Phoenix',
+        state: 'AZ',
+        artist_count: 50,
+        venue_count: 12,
+        upcoming_show_count: 30,
+      }
+      mockApiRequest.mockResolvedValueOnce(mockDetail)
+
+      const { result } = renderHook(() => useSceneDetail('phoenix-az'), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/scenes/phoenix-az', {
+        method: 'GET',
+      })
+      expect(result.current.data?.city).toBe('Phoenix')
+    })
+
+    it('does not fetch when slug is empty', async () => {
+      const { result } = renderHook(() => useSceneDetail(''), {
+        wrapper: createWrapper(),
+      })
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('handles scene not found error', async () => {
+      const error = new Error('Scene not found')
+      Object.assign(error, { status: 404 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(() => useSceneDetail('nonexistent'), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+      expect((result.current.error as Error).message).toBe('Scene not found')
+    })
+  })
+
+  // ──────────────────────────────────────────────
+  // useSceneArtists
+  // ──────────────────────────────────────────────
+
+  describe('useSceneArtists', () => {
+    it('fetches scene artists with default options', async () => {
+      const mockResponse = {
+        artists: [
+          { id: 1, name: 'Artist A', show_count: 5 },
+          { id: 2, name: 'Artist B', show_count: 3 },
+        ],
+        total: 2,
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(
+        () => useSceneArtists({ slug: 'phoenix-az' }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      // Default period=90, limit=20, offset=0
+      const calledUrl = mockApiRequest.mock.calls[0][0]
+      expect(calledUrl).toContain('/scenes/phoenix-az/artists')
+      expect(calledUrl).toContain('period=90')
+      expect(calledUrl).toContain('limit=20')
+      expect(result.current.data?.artists).toHaveLength(2)
+    })
+
+    it('includes custom period in query params', async () => {
+      mockApiRequest.mockResolvedValueOnce({ artists: [], total: 0 })
+
+      const { result } = renderHook(
+        () => useSceneArtists({ slug: 'phoenix-az', period: 180 }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      const calledUrl = mockApiRequest.mock.calls[0][0]
+      expect(calledUrl).toContain('period=180')
+    })
+
+    it('includes custom limit in query params', async () => {
+      mockApiRequest.mockResolvedValueOnce({ artists: [], total: 0 })
+
+      const { result } = renderHook(
+        () => useSceneArtists({ slug: 'phoenix-az', limit: 50 }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      const calledUrl = mockApiRequest.mock.calls[0][0]
+      expect(calledUrl).toContain('limit=50')
+    })
+
+    it('includes offset in query params', async () => {
+      mockApiRequest.mockResolvedValueOnce({ artists: [], total: 0 })
+
+      const { result } = renderHook(
+        () => useSceneArtists({ slug: 'phoenix-az', offset: 20 }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      const calledUrl = mockApiRequest.mock.calls[0][0]
+      expect(calledUrl).toContain('offset=20')
+    })
+
+    it('combines multiple query params', async () => {
+      mockApiRequest.mockResolvedValueOnce({ artists: [], total: 0 })
+
+      const { result } = renderHook(
+        () =>
+          useSceneArtists({
+            slug: 'phoenix-az',
+            period: 365,
+            limit: 10,
+            offset: 30,
+          }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      const calledUrl = mockApiRequest.mock.calls[0][0]
+      expect(calledUrl).toContain('period=365')
+      expect(calledUrl).toContain('limit=10')
+      expect(calledUrl).toContain('offset=30')
+    })
+
+    it('does not fetch when slug is empty', async () => {
+      const { result } = renderHook(
+        () => useSceneArtists({ slug: '' }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('handles API errors', async () => {
+      const error = new Error('Server error')
+      Object.assign(error, { status: 500 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(
+        () => useSceneArtists({ slug: 'phoenix-az' }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+    })
+  })
+})

--- a/frontend/features/shows/hooks/useAttendance.test.tsx
+++ b/frontend/features/shows/hooks/useAttendance.test.tsx
@@ -1,0 +1,728 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { AttendanceCounts } from '../types'
+
+// Create mocks
+const mockApiRequest = vi.fn()
+const mockInvalidateAttendance = vi.fn()
+const mockIsAuthenticated = vi.fn(() => true)
+
+// Mock the api module
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    ATTENDANCE: {
+      SHOW: (showId: number) => `/shows/${showId}/attendance`,
+      BATCH: '/shows/attendance/batch',
+      MY_SHOWS: '/attendance/my-shows',
+    },
+  },
+}))
+
+// Mock queryClient module
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    attendance: {
+      show: (showId: number) => ['attendance', 'show', showId],
+      batch: (showIds: number[]) => ['attendance', 'batch', ...showIds],
+      myShows: (params?: Record<string, unknown>) => ['attendance', 'my-shows', params],
+    },
+  },
+  createInvalidateQueries: () => ({
+    attendance: mockInvalidateAttendance,
+  }),
+}))
+
+// Mock AuthContext
+vi.mock('@/lib/context/AuthContext', () => ({
+  useAuthContext: () => ({
+    isAuthenticated: mockIsAuthenticated(),
+  }),
+}))
+
+// Import hooks after mocks are set up
+import {
+  useShowAttendance,
+  useBatchAttendance,
+  useSetAttendance,
+  useRemoveAttendance,
+  useMyShows,
+} from './useAttendance'
+
+// Helper to create wrapper with a fresh query client
+function createWrapper(queryClient?: QueryClient) {
+  const qc = queryClient ?? new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    )
+  }
+}
+
+describe('useShowAttendance', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches attendance counts for a show', async () => {
+    const mockData: AttendanceCounts = {
+      show_id: 1,
+      going_count: 5,
+      interested_count: 10,
+      user_status: 'going',
+    }
+    mockApiRequest.mockResolvedValueOnce(mockData)
+
+    const { result } = renderHook(() => useShowAttendance(1), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/shows/1/attendance', {
+      method: 'GET',
+    })
+    expect(result.current.data?.going_count).toBe(5)
+    expect(result.current.data?.interested_count).toBe(10)
+    expect(result.current.data?.user_status).toBe('going')
+  })
+
+  it('does not fetch when showId is 0', () => {
+    const { result } = renderHook(() => useShowAttendance(0), {
+      wrapper: createWrapper(),
+    })
+
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('does not fetch when showId is negative', () => {
+    const { result } = renderHook(() => useShowAttendance(-1), {
+      wrapper: createWrapper(),
+    })
+
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('handles API errors', async () => {
+    const error = new Error('Server error')
+    Object.assign(error, { status: 500 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useShowAttendance(1), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect(result.current.error).toBeDefined()
+  })
+
+  it('returns empty user_status for unauthenticated users', async () => {
+    const mockData: AttendanceCounts = {
+      show_id: 1,
+      going_count: 3,
+      interested_count: 7,
+      user_status: '',
+    }
+    mockApiRequest.mockResolvedValueOnce(mockData)
+
+    const { result } = renderHook(() => useShowAttendance(1), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data?.user_status).toBe('')
+  })
+})
+
+describe('useBatchAttendance', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches batch attendance for multiple shows', async () => {
+    const mockResponse = {
+      attendance: {
+        '1': { show_id: 1, going_count: 5, interested_count: 10, user_status: '' },
+        '2': { show_id: 2, going_count: 3, interested_count: 8, user_status: 'going' },
+      },
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useBatchAttendance([1, 2]), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/shows/attendance/batch', {
+      method: 'POST',
+      body: JSON.stringify({ show_ids: [1, 2] }),
+    })
+    expect(result.current.data?.['1'].going_count).toBe(5)
+    expect(result.current.data?.['2'].user_status).toBe('going')
+  })
+
+  it('does not fetch when showIds is empty', () => {
+    const { result } = renderHook(() => useBatchAttendance([]), {
+      wrapper: createWrapper(),
+    })
+
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('handles API errors', async () => {
+    mockApiRequest.mockRejectedValueOnce(new Error('Network error'))
+
+    const { result } = renderHook(() => useBatchAttendance([1, 2]), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+  })
+})
+
+describe('useSetAttendance', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateAttendance.mockReset()
+  })
+
+  it('sets going status with correct endpoint and method', async () => {
+    mockApiRequest.mockResolvedValueOnce({ success: true, message: 'Status set' })
+
+    const { result } = renderHook(() => useSetAttendance(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ showId: 1, status: 'going' })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/shows/1/attendance', {
+      method: 'POST',
+      body: JSON.stringify({ status: 'going' }),
+    })
+  })
+
+  it('sets interested status with correct endpoint and method', async () => {
+    mockApiRequest.mockResolvedValueOnce({ success: true, message: 'Status set' })
+
+    const { result } = renderHook(() => useSetAttendance(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ showId: 5, status: 'interested' })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/shows/5/attendance', {
+      method: 'POST',
+      body: JSON.stringify({ status: 'interested' }),
+    })
+  })
+
+  it('optimistically updates going count from no status', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: 0 },
+        mutations: { retry: false },
+      },
+    })
+
+    // Seed cache with initial attendance data
+    const initialData: AttendanceCounts = {
+      show_id: 1,
+      going_count: 3,
+      interested_count: 5,
+      user_status: '',
+    }
+    queryClient.setQueryData(['attendance', 'show', 1], initialData)
+
+    // Delay API response to observe optimistic update
+    mockApiRequest.mockImplementation(
+      () => new Promise(resolve => setTimeout(() => resolve({ success: true, message: 'ok' }), 100))
+    )
+
+    const { result } = renderHook(() => useSetAttendance(), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    await act(async () => {
+      result.current.mutate({ showId: 1, status: 'going' })
+    })
+
+    // Check optimistic update was applied
+    const optimisticData = queryClient.getQueryData<AttendanceCounts>(['attendance', 'show', 1])
+    expect(optimisticData?.going_count).toBe(4)
+    expect(optimisticData?.interested_count).toBe(5)
+    expect(optimisticData?.user_status).toBe('going')
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+  })
+
+  it('optimistically updates when switching from interested to going', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: 0 },
+        mutations: { retry: false },
+      },
+    })
+
+    const initialData: AttendanceCounts = {
+      show_id: 2,
+      going_count: 3,
+      interested_count: 5,
+      user_status: 'interested',
+    }
+    queryClient.setQueryData(['attendance', 'show', 2], initialData)
+
+    mockApiRequest.mockImplementation(
+      () => new Promise(resolve => setTimeout(() => resolve({ success: true, message: 'ok' }), 100))
+    )
+
+    const { result } = renderHook(() => useSetAttendance(), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    await act(async () => {
+      result.current.mutate({ showId: 2, status: 'going' })
+    })
+
+    const optimisticData = queryClient.getQueryData<AttendanceCounts>(['attendance', 'show', 2])
+    expect(optimisticData?.going_count).toBe(4)       // incremented
+    expect(optimisticData?.interested_count).toBe(4)   // decremented
+    expect(optimisticData?.user_status).toBe('going')
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+  })
+
+  it('calls rollback with previous data on error', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: Infinity },
+        mutations: { retry: false },
+      },
+    })
+
+    const initialData: AttendanceCounts = {
+      show_id: 3,
+      going_count: 2,
+      interested_count: 4,
+      user_status: '',
+    }
+    queryClient.setQueryData(['attendance', 'show', 3], initialData)
+
+    // Track setQueryData calls to verify rollback happens
+    const setQueryDataSpy = vi.spyOn(queryClient, 'setQueryData')
+
+    mockApiRequest.mockRejectedValueOnce(new Error('Server error'))
+
+    const { result } = renderHook(() => useSetAttendance(), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    await act(async () => {
+      result.current.mutate({ showId: 3, status: 'going' })
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    // Verify that setQueryData was called with the original data for rollback
+    // First call is optimistic update, second call is rollback
+    const rollbackCall = setQueryDataSpy.mock.calls.find(
+      call => {
+        const data = call[1] as AttendanceCounts | undefined
+        return data?.going_count === 2 && data?.user_status === ''
+      }
+    )
+    expect(rollbackCall).toBeDefined()
+
+    setQueryDataSpy.mockRestore()
+  })
+
+  it('invalidates attendance queries on settled', async () => {
+    mockApiRequest.mockResolvedValueOnce({ success: true, message: 'ok' })
+
+    const { result } = renderHook(() => useSetAttendance(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ showId: 1, status: 'going' })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockInvalidateAttendance).toHaveBeenCalled()
+  })
+
+  it('handles API errors', async () => {
+    const error = new Error('Unauthorized')
+    Object.assign(error, { status: 401 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useSetAttendance(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ showId: 1, status: 'going' })
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect((result.current.error as Error).message).toBe('Unauthorized')
+  })
+})
+
+describe('useRemoveAttendance', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateAttendance.mockReset()
+  })
+
+  it('removes attendance with correct endpoint and method', async () => {
+    mockApiRequest.mockResolvedValueOnce({ success: true, message: 'Removed' })
+
+    const { result } = renderHook(() => useRemoveAttendance(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(1)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/shows/1/attendance', {
+      method: 'DELETE',
+    })
+  })
+
+  it('optimistically clears going status', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: 0 },
+        mutations: { retry: false },
+      },
+    })
+
+    const initialData: AttendanceCounts = {
+      show_id: 1,
+      going_count: 5,
+      interested_count: 3,
+      user_status: 'going',
+    }
+    queryClient.setQueryData(['attendance', 'show', 1], initialData)
+
+    mockApiRequest.mockImplementation(
+      () => new Promise(resolve => setTimeout(() => resolve({ success: true, message: 'ok' }), 100))
+    )
+
+    const { result } = renderHook(() => useRemoveAttendance(), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    await act(async () => {
+      result.current.mutate(1)
+    })
+
+    const optimisticData = queryClient.getQueryData<AttendanceCounts>(['attendance', 'show', 1])
+    expect(optimisticData?.going_count).toBe(4)       // decremented
+    expect(optimisticData?.interested_count).toBe(3)   // unchanged
+    expect(optimisticData?.user_status).toBe('')
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+  })
+
+  it('optimistically clears interested status', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: 0 },
+        mutations: { retry: false },
+      },
+    })
+
+    const initialData: AttendanceCounts = {
+      show_id: 2,
+      going_count: 5,
+      interested_count: 3,
+      user_status: 'interested',
+    }
+    queryClient.setQueryData(['attendance', 'show', 2], initialData)
+
+    mockApiRequest.mockImplementation(
+      () => new Promise(resolve => setTimeout(() => resolve({ success: true, message: 'ok' }), 100))
+    )
+
+    const { result } = renderHook(() => useRemoveAttendance(), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    await act(async () => {
+      result.current.mutate(2)
+    })
+
+    const optimisticData = queryClient.getQueryData<AttendanceCounts>(['attendance', 'show', 2])
+    expect(optimisticData?.going_count).toBe(5)        // unchanged
+    expect(optimisticData?.interested_count).toBe(2)    // decremented
+    expect(optimisticData?.user_status).toBe('')
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+  })
+
+  it('does not decrement below zero', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: 0 },
+        mutations: { retry: false },
+      },
+    })
+
+    const initialData: AttendanceCounts = {
+      show_id: 3,
+      going_count: 0,
+      interested_count: 0,
+      user_status: 'going',
+    }
+    queryClient.setQueryData(['attendance', 'show', 3], initialData)
+
+    mockApiRequest.mockImplementation(
+      () => new Promise(resolve => setTimeout(() => resolve({ success: true, message: 'ok' }), 100))
+    )
+
+    const { result } = renderHook(() => useRemoveAttendance(), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    await act(async () => {
+      result.current.mutate(3)
+    })
+
+    const optimisticData = queryClient.getQueryData<AttendanceCounts>(['attendance', 'show', 3])
+    expect(optimisticData?.going_count).toBe(0)   // clamped at 0
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+  })
+
+  it('calls rollback with previous data on error', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: Infinity },
+        mutations: { retry: false },
+      },
+    })
+
+    const initialData: AttendanceCounts = {
+      show_id: 4,
+      going_count: 10,
+      interested_count: 5,
+      user_status: 'going',
+    }
+    queryClient.setQueryData(['attendance', 'show', 4], initialData)
+
+    // Track setQueryData calls to verify rollback happens
+    const setQueryDataSpy = vi.spyOn(queryClient, 'setQueryData')
+
+    mockApiRequest.mockRejectedValueOnce(new Error('Failed'))
+
+    const { result } = renderHook(() => useRemoveAttendance(), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    await act(async () => {
+      result.current.mutate(4)
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    // Verify that setQueryData was called with the original data for rollback
+    // First call is optimistic update, second call is rollback
+    const rollbackCall = setQueryDataSpy.mock.calls.find(
+      call => {
+        const data = call[1] as AttendanceCounts | undefined
+        return data?.going_count === 10 && data?.user_status === 'going'
+      }
+    )
+    expect(rollbackCall).toBeDefined()
+
+    setQueryDataSpy.mockRestore()
+  })
+
+  it('invalidates attendance queries on settled', async () => {
+    mockApiRequest.mockResolvedValueOnce({ success: true, message: 'ok' })
+
+    const { result } = renderHook(() => useRemoveAttendance(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(1)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockInvalidateAttendance).toHaveBeenCalled()
+  })
+
+  it('handles network errors', async () => {
+    mockApiRequest.mockRejectedValueOnce(new TypeError('Failed to fetch'))
+
+    const { result } = renderHook(() => useRemoveAttendance(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(1)
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect(result.current.error).toBeInstanceOf(TypeError)
+  })
+})
+
+describe('useMyShows', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockIsAuthenticated.mockReturnValue(true)
+  })
+
+  it('fetches my shows when authenticated', async () => {
+    const mockResponse = {
+      shows: [
+        {
+          show_id: 1,
+          title: 'Show 1',
+          slug: 'show-1',
+          event_date: '2025-06-15T20:00:00Z',
+          status: 'going',
+          venue_name: 'The Venue',
+          venue_slug: 'the-venue',
+          city: 'Phoenix',
+          state: 'AZ',
+        },
+      ],
+      total: 1,
+      limit: 20,
+      offset: 0,
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useMyShows(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/attendance/my-shows?limit=20&offset=0',
+      { method: 'GET' }
+    )
+    expect(result.current.data?.shows).toHaveLength(1)
+    expect(result.current.data?.total).toBe(1)
+  })
+
+  it('does not fetch when not authenticated', () => {
+    mockIsAuthenticated.mockReturnValue(false)
+
+    const { result } = renderHook(() => useMyShows(), {
+      wrapper: createWrapper(),
+    })
+
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('includes status filter when not "all"', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      shows: [],
+      total: 0,
+      limit: 20,
+      offset: 0,
+    })
+
+    const { result } = renderHook(() => useMyShows({ status: 'going' }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/attendance/my-shows?status=going&limit=20&offset=0',
+      { method: 'GET' }
+    )
+  })
+
+  it('does not include status filter when "all"', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      shows: [],
+      total: 0,
+      limit: 20,
+      offset: 0,
+    })
+
+    const { result } = renderHook(() => useMyShows({ status: 'all' }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const calledUrl = mockApiRequest.mock.calls[0][0]
+    expect(calledUrl).not.toContain('status=')
+  })
+
+  it('supports custom limit and offset', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      shows: [],
+      total: 0,
+      limit: 10,
+      offset: 20,
+    })
+
+    const { result } = renderHook(
+      () => useMyShows({ limit: 10, offset: 20 }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/attendance/my-shows?limit=10&offset=20',
+      { method: 'GET' }
+    )
+  })
+
+  it('handles API errors', async () => {
+    mockApiRequest.mockRejectedValueOnce(new Error('Unauthorized'))
+
+    const { result } = renderHook(() => useMyShows(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect(result.current.error).toBeDefined()
+  })
+})

--- a/frontend/features/shows/hooks/useShowDelete.test.tsx
+++ b/frontend/features/shows/hooks/useShowDelete.test.tsx
@@ -1,0 +1,244 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+// Create mocks
+const mockApiRequest = vi.fn()
+const mockInvalidateShows = vi.fn()
+const mockInvalidateSavedShows = vi.fn()
+
+// Mock the api module
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    SHOWS: {
+      DELETE: (showId: string | number) => `/shows/${showId}`,
+    },
+  },
+}))
+
+// Mock queryClient module
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {},
+  createInvalidateQueries: () => ({
+    shows: mockInvalidateShows,
+    savedShows: mockInvalidateSavedShows,
+  }),
+}))
+
+// Mock showLogger
+vi.mock('@/lib/utils/showLogger', () => ({
+  showLogger: {
+    deleteAttempt: vi.fn(),
+    deleteSuccess: vi.fn(),
+    deleteFailed: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+// Mock errors module
+vi.mock('@/lib/errors', () => ({
+  ShowError: {
+    fromUnknown: (error: unknown) => ({
+      code: 'UNKNOWN',
+      message: error instanceof Error ? error.message : String(error),
+      requestId: undefined,
+    }),
+  },
+  ShowErrorCode: {
+    UNKNOWN: 'UNKNOWN',
+  },
+}))
+
+// Import hooks after mocks are set up
+import { useShowDelete } from './useShowDelete'
+
+// Helper to create wrapper with query client
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+  }
+}
+
+describe('useShowDelete', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateShows.mockReset()
+    mockInvalidateSavedShows.mockReset()
+  })
+
+  it('deletes a show with correct endpoint and method', async () => {
+    mockApiRequest.mockResolvedValueOnce(undefined)
+
+    const { result } = renderHook(() => useShowDelete(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(42)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/shows/42', {
+      method: 'DELETE',
+    })
+  })
+
+  it('invalidates shows and savedShows on success', async () => {
+    mockApiRequest.mockResolvedValueOnce(undefined)
+
+    const { result } = renderHook(() => useShowDelete(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(1)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockInvalidateShows).toHaveBeenCalled()
+    expect(mockInvalidateSavedShows).toHaveBeenCalled()
+  })
+
+  it('returns void on success (no response body)', async () => {
+    mockApiRequest.mockResolvedValueOnce(undefined)
+
+    const { result } = renderHook(() => useShowDelete(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(1)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data).toBeUndefined()
+  })
+
+  it('handles 404 not found errors', async () => {
+    const error = new Error('Show not found')
+    Object.assign(error, { status: 404 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useShowDelete(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(999)
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect((result.current.error as Error).message).toBe('Show not found')
+  })
+
+  it('handles 403 unauthorized errors', async () => {
+    const error = new Error('You are not authorized to delete this show')
+    Object.assign(error, { status: 403 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useShowDelete(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(50)
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect((result.current.error as Error).message).toBe(
+      'You are not authorized to delete this show'
+    )
+  })
+
+  it('does not invalidate queries on error', async () => {
+    mockApiRequest.mockRejectedValueOnce(new Error('Server error'))
+
+    const { result } = renderHook(() => useShowDelete(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(1)
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect(mockInvalidateShows).not.toHaveBeenCalled()
+    expect(mockInvalidateSavedShows).not.toHaveBeenCalled()
+  })
+
+  it('handles network errors', async () => {
+    mockApiRequest.mockRejectedValueOnce(new TypeError('Failed to fetch'))
+
+    const { result } = renderHook(() => useShowDelete(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(1)
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect(result.current.error).toBeInstanceOf(TypeError)
+  })
+
+  it('handles 401 unauthorized errors', async () => {
+    const error = new Error('Unauthorized')
+    Object.assign(error, { status: 401 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useShowDelete(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(1)
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect((result.current.error as Error).message).toBe('Unauthorized')
+  })
+
+  it('can be called multiple times sequentially', async () => {
+    mockApiRequest.mockResolvedValue(undefined)
+
+    const { result } = renderHook(() => useShowDelete(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(1)
+    })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    await act(async () => {
+      result.current.mutate(2)
+    })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledTimes(2)
+    expect(mockApiRequest).toHaveBeenCalledWith('/shows/1', { method: 'DELETE' })
+    expect(mockApiRequest).toHaveBeenCalledWith('/shows/2', { method: 'DELETE' })
+  })
+})

--- a/frontend/features/shows/hooks/useShowReports.test.tsx
+++ b/frontend/features/shows/hooks/useShowReports.test.tsx
@@ -1,0 +1,447 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+// Create mocks
+const mockApiRequest = vi.fn()
+const mockInvalidateShowReports = vi.fn()
+
+// Mock the api module
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    SHOWS: {
+      REPORT: (showId: string | number) => `/shows/${showId}/report`,
+      MY_REPORT: (showId: string | number) => `/shows/${showId}/my-report`,
+    },
+  },
+}))
+
+// Mock queryClient module
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    showReports: {
+      myReport: (showId: string) => ['showReports', 'myReport', showId],
+    },
+  },
+  createInvalidateQueries: () => ({
+    showReports: mockInvalidateShowReports,
+  }),
+}))
+
+// Import hooks after mocks are set up
+import { useMyShowReport, useReportShow } from './useShowReports'
+
+// Helper to create wrapper with query client
+function createWrapper(queryClient?: QueryClient) {
+  const qc = queryClient ?? new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    )
+  }
+}
+
+describe('useMyShowReport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches the user report for a show when showId is a number', async () => {
+    const mockReport = {
+      report: {
+        id: 1,
+        show_id: 42,
+        report_type: 'cancelled' as const,
+        details: 'Show was cancelled',
+        status: 'pending' as const,
+        created_at: '2025-01-15T00:00:00Z',
+        updated_at: '2025-01-15T00:00:00Z',
+      },
+    }
+    mockApiRequest.mockResolvedValueOnce(mockReport)
+
+    const { result } = renderHook(() => useMyShowReport(42), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/shows/42/my-report', {
+      method: 'GET',
+    })
+    expect(result.current.data?.report?.report_type).toBe('cancelled')
+  })
+
+  it('fetches the user report for a show when showId is a string', async () => {
+    mockApiRequest.mockResolvedValueOnce({ report: null })
+
+    const { result } = renderHook(() => useMyShowReport('123'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/shows/123/my-report', {
+      method: 'GET',
+    })
+  })
+
+  it('does not fetch when showId is null', () => {
+    const { result } = renderHook(() => useMyShowReport(null), {
+      wrapper: createWrapper(),
+    })
+
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('returns null report when user has not reported', async () => {
+    mockApiRequest.mockResolvedValueOnce({ report: null })
+
+    const { result } = renderHook(() => useMyShowReport(10), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data?.report).toBeNull()
+  })
+
+  it('handles API errors', async () => {
+    const error = new Error('Not found')
+    Object.assign(error, { status: 404 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useMyShowReport(999), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect(result.current.error).toBeDefined()
+  })
+
+  it('returns all report fields when present', async () => {
+    const mockReport = {
+      report: {
+        id: 5,
+        show_id: 20,
+        report_type: 'sold_out' as const,
+        details: 'Sold out on Ticketmaster',
+        status: 'resolved' as const,
+        admin_notes: 'Confirmed and updated',
+        reviewed_by: 1,
+        reviewed_at: '2025-01-16T10:00:00Z',
+        created_at: '2025-01-15T00:00:00Z',
+        updated_at: '2025-01-16T10:00:00Z',
+      },
+    }
+    mockApiRequest.mockResolvedValueOnce(mockReport)
+
+    const { result } = renderHook(() => useMyShowReport(20), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const report = result.current.data?.report
+    expect(report?.id).toBe(5)
+    expect(report?.status).toBe('resolved')
+    expect(report?.admin_notes).toBe('Confirmed and updated')
+    expect(report?.reviewed_by).toBe(1)
+  })
+})
+
+describe('useReportShow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateShowReports.mockReset()
+  })
+
+  it('reports a show with cancelled type', async () => {
+    const mockResponse = {
+      id: 1,
+      show_id: 42,
+      report_type: 'cancelled' as const,
+      details: null,
+      status: 'pending' as const,
+      created_at: '2025-01-15T00:00:00Z',
+      updated_at: '2025-01-15T00:00:00Z',
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useReportShow(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ showId: 42, reportType: 'cancelled' })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/shows/42/report', {
+      method: 'POST',
+      body: JSON.stringify({
+        report_type: 'cancelled',
+        details: null,
+      }),
+    })
+  })
+
+  it('reports a show with sold_out type', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      id: 2,
+      show_id: 10,
+      report_type: 'sold_out',
+      details: null,
+      status: 'pending',
+      created_at: '2025-01-15T00:00:00Z',
+      updated_at: '2025-01-15T00:00:00Z',
+    })
+
+    const { result } = renderHook(() => useReportShow(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ showId: 10, reportType: 'sold_out' })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const sentBody = JSON.parse(mockApiRequest.mock.calls[0][1].body)
+    expect(sentBody.report_type).toBe('sold_out')
+  })
+
+  it('reports a show with inaccurate type and details', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      id: 3,
+      show_id: 5,
+      report_type: 'inaccurate',
+      details: 'Wrong venue listed',
+      status: 'pending',
+      created_at: '2025-01-15T00:00:00Z',
+      updated_at: '2025-01-15T00:00:00Z',
+    })
+
+    const { result } = renderHook(() => useReportShow(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({
+        showId: 5,
+        reportType: 'inaccurate',
+        details: 'Wrong venue listed',
+      })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const sentBody = JSON.parse(mockApiRequest.mock.calls[0][1].body)
+    expect(sentBody.report_type).toBe('inaccurate')
+    expect(sentBody.details).toBe('Wrong venue listed')
+  })
+
+  it('sends null for details when not provided', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      id: 4,
+      show_id: 7,
+      report_type: 'cancelled',
+      details: null,
+      status: 'pending',
+      created_at: '2025-01-15T00:00:00Z',
+      updated_at: '2025-01-15T00:00:00Z',
+    })
+
+    const { result } = renderHook(() => useReportShow(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ showId: 7, reportType: 'cancelled' })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const sentBody = JSON.parse(mockApiRequest.mock.calls[0][1].body)
+    expect(sentBody.details).toBeNull()
+  })
+
+  it('sends null for details when details is empty string', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      id: 5,
+      show_id: 8,
+      report_type: 'cancelled',
+      details: null,
+      status: 'pending',
+      created_at: '2025-01-15T00:00:00Z',
+      updated_at: '2025-01-15T00:00:00Z',
+    })
+
+    const { result } = renderHook(() => useReportShow(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ showId: 8, reportType: 'cancelled', details: '' })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const sentBody = JSON.parse(mockApiRequest.mock.calls[0][1].body)
+    expect(sentBody.details).toBeNull()
+  })
+
+  it('invalidates myReport and showReports on success', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: 0 },
+        mutations: { retry: false },
+      },
+    })
+
+    // Spy on invalidateQueries
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    mockApiRequest.mockResolvedValueOnce({
+      id: 6,
+      show_id: 15,
+      report_type: 'cancelled',
+      details: null,
+      status: 'pending',
+      created_at: '2025-01-15T00:00:00Z',
+      updated_at: '2025-01-15T00:00:00Z',
+    })
+
+    const { result } = renderHook(() => useReportShow(), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    await act(async () => {
+      result.current.mutate({ showId: 15, reportType: 'cancelled' })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    // Check that myReport for the specific show was invalidated
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['showReports', 'myReport', '15'],
+    })
+
+    // Check that the general showReports invalidation was called
+    expect(mockInvalidateShowReports).toHaveBeenCalled()
+  })
+
+  it('handles 409 duplicate report error', async () => {
+    const error = new Error('You have already reported this show')
+    Object.assign(error, { status: 409 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useReportShow(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ showId: 42, reportType: 'cancelled' })
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect((result.current.error as Error).message).toBe(
+      'You have already reported this show'
+    )
+  })
+
+  it('handles 401 unauthorized error', async () => {
+    const error = new Error('Unauthorized')
+    Object.assign(error, { status: 401 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useReportShow(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ showId: 1, reportType: 'inaccurate' })
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect((result.current.error as Error).message).toBe('Unauthorized')
+  })
+
+  it('does not invalidate queries on error', async () => {
+    mockApiRequest.mockRejectedValueOnce(new Error('Server error'))
+
+    const { result } = renderHook(() => useReportShow(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ showId: 1, reportType: 'cancelled' })
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect(mockInvalidateShowReports).not.toHaveBeenCalled()
+  })
+
+  it('handles network errors', async () => {
+    mockApiRequest.mockRejectedValueOnce(new TypeError('Failed to fetch'))
+
+    const { result } = renderHook(() => useReportShow(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ showId: 1, reportType: 'cancelled' })
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect(result.current.error).toBeInstanceOf(TypeError)
+  })
+
+  it('returns the report response data on success', async () => {
+    const mockResponse = {
+      id: 10,
+      show_id: 50,
+      report_type: 'inaccurate' as const,
+      details: 'Wrong date',
+      status: 'pending' as const,
+      created_at: '2025-01-15T12:00:00Z',
+      updated_at: '2025-01-15T12:00:00Z',
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useReportShow(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({
+        showId: 50,
+        reportType: 'inaccurate',
+        details: 'Wrong date',
+      })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data?.id).toBe(10)
+    expect(result.current.data?.show_id).toBe(50)
+    expect(result.current.data?.report_type).toBe('inaccurate')
+    expect(result.current.data?.status).toBe('pending')
+  })
+})

--- a/frontend/features/shows/hooks/useShowSubmit.test.tsx
+++ b/frontend/features/shows/hooks/useShowSubmit.test.tsx
@@ -1,0 +1,360 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+// Create mocks
+const mockApiRequest = vi.fn()
+const mockInvalidateShows = vi.fn()
+const mockInvalidateArtists = vi.fn()
+const mockInvalidateSavedShows = vi.fn()
+
+// Mock the api module
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    SHOWS: {
+      SUBMIT: '/shows',
+    },
+  },
+}))
+
+// Mock queryClient module
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {},
+  createInvalidateQueries: () => ({
+    shows: mockInvalidateShows,
+    artists: mockInvalidateArtists,
+    savedShows: mockInvalidateSavedShows,
+  }),
+}))
+
+// Mock showLogger to suppress console output in tests
+vi.mock('@/lib/utils/showLogger', () => ({
+  showLogger: {
+    submitAttempt: vi.fn(),
+    submitSuccess: vi.fn(),
+    submitFailed: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+// Mock errors module
+vi.mock('@/lib/errors', () => ({
+  ShowError: {
+    fromUnknown: (error: unknown) => ({
+      code: 'UNKNOWN',
+      message: error instanceof Error ? error.message : String(error),
+      requestId: undefined,
+    }),
+  },
+  ShowErrorCode: {
+    UNKNOWN: 'UNKNOWN',
+  },
+}))
+
+// Import hooks after mocks are set up
+import { useShowSubmit } from './useShowSubmit'
+import type { ShowSubmission } from './useShowSubmit'
+
+// Helper to create wrapper with query client
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+  }
+}
+
+const validSubmission: ShowSubmission = {
+  event_date: '2025-06-15T20:00:00Z',
+  city: 'Phoenix',
+  state: 'AZ',
+  venues: [{ name: 'The Rebel Lounge', city: 'Phoenix', state: 'AZ' }],
+  artists: [{ name: 'Test Artist' }],
+}
+
+describe('useShowSubmit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateShows.mockReset()
+    mockInvalidateArtists.mockReset()
+    mockInvalidateSavedShows.mockReset()
+  })
+
+  it('submits a show with correct endpoint and method', async () => {
+    const mockResponse = {
+      id: 1,
+      slug: 'test-artist-rebel-lounge-2025-06-15',
+      title: 'Test Artist at The Rebel Lounge',
+      event_date: '2025-06-15T20:00:00Z',
+      status: 'pending',
+      venues: [{ id: 1, name: 'The Rebel Lounge', slug: 'the-rebel-lounge', city: 'Phoenix', state: 'AZ', verified: false }],
+      artists: [{ id: 1, name: 'Test Artist', slug: 'test-artist', set_type: 'performer', position: 0, socials: {} }],
+      created_at: '2025-01-01T00:00:00Z',
+      updated_at: '2025-01-01T00:00:00Z',
+      is_sold_out: false,
+      is_cancelled: false,
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useShowSubmit(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(validSubmission)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/shows', {
+      method: 'POST',
+      body: JSON.stringify(validSubmission),
+    })
+    expect(result.current.data?.id).toBe(1)
+  })
+
+  it('invalidates shows, artists, and savedShows on success', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      id: 2,
+      slug: 'show-2',
+      title: 'Show',
+      event_date: '2025-06-15T20:00:00Z',
+      status: 'pending',
+      venues: [],
+      artists: [],
+      created_at: '2025-01-01T00:00:00Z',
+      updated_at: '2025-01-01T00:00:00Z',
+      is_sold_out: false,
+      is_cancelled: false,
+    })
+
+    const { result } = renderHook(() => useShowSubmit(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(validSubmission)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockInvalidateShows).toHaveBeenCalled()
+    expect(mockInvalidateArtists).toHaveBeenCalled()
+    expect(mockInvalidateSavedShows).toHaveBeenCalled()
+  })
+
+  it('returns the show response data on success', async () => {
+    const mockResponse = {
+      id: 42,
+      slug: 'test-show',
+      title: 'Test Show',
+      event_date: '2025-06-15T20:00:00Z',
+      status: 'approved',
+      venues: [{ id: 5, name: 'Valley Bar', slug: 'valley-bar', city: 'Phoenix', state: 'AZ', verified: true }],
+      artists: [
+        { id: 10, name: 'Band A', slug: 'band-a', is_headliner: true, set_type: 'headliner', position: 0, socials: {} },
+        { id: 11, name: 'Band B', slug: 'band-b', set_type: 'opener', position: 1, socials: {} },
+      ],
+      created_at: '2025-01-01T00:00:00Z',
+      updated_at: '2025-01-01T00:00:00Z',
+      is_sold_out: false,
+      is_cancelled: false,
+      request_id: 'req-abc-123',
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useShowSubmit(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(validSubmission)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data?.id).toBe(42)
+    expect(result.current.data?.title).toBe('Test Show')
+    expect(result.current.data?.venues).toHaveLength(1)
+    expect(result.current.data?.artists).toHaveLength(2)
+  })
+
+  it('handles API errors and sets error state', async () => {
+    const error = new Error('Validation failed')
+    Object.assign(error, { status: 422 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useShowSubmit(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(validSubmission)
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect(result.current.error).toBeDefined()
+    expect((result.current.error as Error).message).toBe('Validation failed')
+  })
+
+  it('does not invalidate queries on error', async () => {
+    mockApiRequest.mockRejectedValueOnce(new Error('Server error'))
+
+    const { result } = renderHook(() => useShowSubmit(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(validSubmission)
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect(mockInvalidateShows).not.toHaveBeenCalled()
+    expect(mockInvalidateArtists).not.toHaveBeenCalled()
+    expect(mockInvalidateSavedShows).not.toHaveBeenCalled()
+  })
+
+  it('sends optional fields when provided', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      id: 3,
+      slug: 'show-3',
+      title: 'Private Show',
+      event_date: '2025-06-15T20:00:00Z',
+      status: 'private',
+      venues: [],
+      artists: [],
+      created_at: '2025-01-01T00:00:00Z',
+      updated_at: '2025-01-01T00:00:00Z',
+      is_sold_out: false,
+      is_cancelled: false,
+    })
+
+    const fullSubmission: ShowSubmission = {
+      title: 'Private Show',
+      event_date: '2025-06-15T20:00:00Z',
+      city: 'Phoenix',
+      state: 'AZ',
+      price: 15,
+      age_requirement: '21+',
+      description: 'A test show',
+      venues: [{ name: 'Valley Bar', city: 'Phoenix', state: 'AZ', address: '130 N Central Ave' }],
+      artists: [
+        { name: 'Headliner', is_headliner: true },
+        { name: 'Opener', is_headliner: false, instagram_handle: '@opener' },
+      ],
+      is_private: true,
+    }
+
+    const { result } = renderHook(() => useShowSubmit(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(fullSubmission)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const sentBody = JSON.parse(mockApiRequest.mock.calls[0][1].body)
+    expect(sentBody.title).toBe('Private Show')
+    expect(sentBody.price).toBe(15)
+    expect(sentBody.age_requirement).toBe('21+')
+    expect(sentBody.description).toBe('A test show')
+    expect(sentBody.is_private).toBe(true)
+    expect(sentBody.artists).toHaveLength(2)
+    expect(sentBody.venues[0].address).toBe('130 N Central Ave')
+  })
+
+  it('submits with multiple venues and artists', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      id: 4,
+      slug: 'show-4',
+      title: 'Multi-venue Show',
+      event_date: '2025-06-15T20:00:00Z',
+      status: 'pending',
+      venues: [],
+      artists: [],
+      created_at: '2025-01-01T00:00:00Z',
+      updated_at: '2025-01-01T00:00:00Z',
+      is_sold_out: false,
+      is_cancelled: false,
+    })
+
+    const multiSubmission: ShowSubmission = {
+      event_date: '2025-06-15T20:00:00Z',
+      city: 'Phoenix',
+      state: 'AZ',
+      venues: [
+        { name: 'Venue A', city: 'Phoenix', state: 'AZ' },
+        { name: 'Venue B', id: 5, city: 'Phoenix', state: 'AZ' },
+      ],
+      artists: [
+        { name: 'Artist A', is_headliner: true },
+        { name: 'Artist B', id: 10 },
+        { name: 'Artist C' },
+      ],
+    }
+
+    const { result } = renderHook(() => useShowSubmit(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(multiSubmission)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const sentBody = JSON.parse(mockApiRequest.mock.calls[0][1].body)
+    expect(sentBody.venues).toHaveLength(2)
+    expect(sentBody.artists).toHaveLength(3)
+  })
+
+  it('handles network errors', async () => {
+    mockApiRequest.mockRejectedValueOnce(new TypeError('Failed to fetch'))
+
+    const { result } = renderHook(() => useShowSubmit(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(validSubmission)
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect(result.current.error).toBeInstanceOf(TypeError)
+  })
+
+  it('handles 401 unauthorized errors', async () => {
+    const error = new Error('Unauthorized')
+    Object.assign(error, { status: 401 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useShowSubmit(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(validSubmission)
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect((result.current.error as Error).message).toBe('Unauthorized')
+  })
+})

--- a/frontend/features/shows/hooks/useShowUpdate.test.tsx
+++ b/frontend/features/shows/hooks/useShowUpdate.test.tsx
@@ -1,0 +1,372 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+// Create mocks
+const mockApiRequest = vi.fn()
+const mockInvalidateShows = vi.fn()
+const mockInvalidateArtists = vi.fn()
+const mockInvalidateVenues = vi.fn()
+
+// Mock the api module
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    SHOWS: {
+      UPDATE: (showId: string | number) => `/shows/${showId}`,
+    },
+  },
+}))
+
+// Mock queryClient module
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {},
+  createInvalidateQueries: () => ({
+    shows: mockInvalidateShows,
+    artists: mockInvalidateArtists,
+    venues: mockInvalidateVenues,
+  }),
+}))
+
+// Mock showLogger
+vi.mock('@/lib/utils/showLogger', () => ({
+  showLogger: {
+    updateAttempt: vi.fn(),
+    updateSuccess: vi.fn(),
+    updateFailed: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+// Mock errors module
+vi.mock('@/lib/errors', () => ({
+  ShowError: {
+    fromUnknown: (error: unknown) => ({
+      code: 'UNKNOWN',
+      message: error instanceof Error ? error.message : String(error),
+      requestId: undefined,
+    }),
+  },
+  ShowErrorCode: {
+    UNKNOWN: 'UNKNOWN',
+  },
+}))
+
+// Import hooks after mocks are set up
+import { useShowUpdate } from './useShowUpdate'
+import type { ShowUpdate } from './useShowUpdate'
+
+// Helper to create wrapper with query client
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+  }
+}
+
+describe('useShowUpdate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateShows.mockReset()
+    mockInvalidateArtists.mockReset()
+    mockInvalidateVenues.mockReset()
+  })
+
+  it('updates a show with correct endpoint and method', async () => {
+    const mockResponse = {
+      id: 1,
+      slug: 'updated-show',
+      title: 'Updated Title',
+      event_date: '2025-06-15T20:00:00Z',
+      status: 'approved',
+      venues: [],
+      artists: [],
+      created_at: '2025-01-01T00:00:00Z',
+      updated_at: '2025-01-02T00:00:00Z',
+      is_sold_out: false,
+      is_cancelled: false,
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const updates: ShowUpdate = { title: 'Updated Title' }
+
+    const { result } = renderHook(() => useShowUpdate(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ showId: 1, updates })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/shows/1', {
+      method: 'PUT',
+      body: JSON.stringify(updates),
+    })
+    expect(result.current.data?.title).toBe('Updated Title')
+  })
+
+  it('invalidates shows, artists, and venues on success', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      id: 1,
+      slug: 'show-1',
+      title: 'Show',
+      event_date: '2025-06-15T20:00:00Z',
+      status: 'approved',
+      venues: [],
+      artists: [],
+      created_at: '2025-01-01T00:00:00Z',
+      updated_at: '2025-01-02T00:00:00Z',
+      is_sold_out: false,
+      is_cancelled: false,
+    })
+
+    const { result } = renderHook(() => useShowUpdate(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ showId: 1, updates: { title: 'New' } })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockInvalidateShows).toHaveBeenCalled()
+    expect(mockInvalidateArtists).toHaveBeenCalled()
+    expect(mockInvalidateVenues).toHaveBeenCalled()
+  })
+
+  it('sends partial updates correctly', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      id: 5,
+      slug: 'show-5',
+      title: 'Show',
+      event_date: '2025-07-01T19:00:00Z',
+      status: 'approved',
+      venues: [],
+      artists: [],
+      created_at: '2025-01-01T00:00:00Z',
+      updated_at: '2025-01-02T00:00:00Z',
+      is_sold_out: false,
+      is_cancelled: false,
+    })
+
+    const partialUpdate: ShowUpdate = {
+      event_date: '2025-07-01T19:00:00Z',
+      price: 20,
+    }
+
+    const { result } = renderHook(() => useShowUpdate(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ showId: 5, updates: partialUpdate })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const sentBody = JSON.parse(mockApiRequest.mock.calls[0][1].body)
+    expect(sentBody.event_date).toBe('2025-07-01T19:00:00Z')
+    expect(sentBody.price).toBe(20)
+    expect(sentBody.title).toBeUndefined()
+  })
+
+  it('sends venue and artist replacements', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      id: 10,
+      slug: 'show-10',
+      title: 'Show',
+      event_date: '2025-06-15T20:00:00Z',
+      status: 'approved',
+      venues: [{ id: 2, name: 'New Venue', slug: 'new-venue', city: 'Phoenix', state: 'AZ', verified: true }],
+      artists: [{ id: 3, name: 'New Artist', slug: 'new-artist', set_type: 'headliner', position: 0, socials: {} }],
+      created_at: '2025-01-01T00:00:00Z',
+      updated_at: '2025-01-02T00:00:00Z',
+      is_sold_out: false,
+      is_cancelled: false,
+    })
+
+    const updates: ShowUpdate = {
+      venues: [{ id: 2, name: 'New Venue' }],
+      artists: [{ id: 3, name: 'New Artist', is_headliner: true }],
+    }
+
+    const { result } = renderHook(() => useShowUpdate(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ showId: 10, updates })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const sentBody = JSON.parse(mockApiRequest.mock.calls[0][1].body)
+    expect(sentBody.venues).toHaveLength(1)
+    expect(sentBody.artists).toHaveLength(1)
+    expect(sentBody.artists[0].is_headliner).toBe(true)
+  })
+
+  it('returns orphaned artists in response', async () => {
+    const mockResponse = {
+      id: 10,
+      slug: 'show-10',
+      title: 'Show',
+      event_date: '2025-06-15T20:00:00Z',
+      status: 'approved',
+      venues: [],
+      artists: [],
+      created_at: '2025-01-01T00:00:00Z',
+      updated_at: '2025-01-02T00:00:00Z',
+      is_sold_out: false,
+      is_cancelled: false,
+      orphaned_artists: [
+        { id: 99, name: 'Orphaned Band', slug: 'orphaned-band' },
+      ],
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useShowUpdate(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ showId: 10, updates: { artists: [] } })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data?.orphaned_artists).toHaveLength(1)
+    expect(result.current.data?.orphaned_artists?.[0].name).toBe('Orphaned Band')
+  })
+
+  it('handles API errors and sets error state', async () => {
+    const error = new Error('Show not found')
+    Object.assign(error, { status: 404 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useShowUpdate(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ showId: 999, updates: { title: 'New' } })
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect((result.current.error as Error).message).toBe('Show not found')
+  })
+
+  it('does not invalidate queries on error', async () => {
+    mockApiRequest.mockRejectedValueOnce(new Error('Server error'))
+
+    const { result } = renderHook(() => useShowUpdate(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ showId: 1, updates: { title: 'New' } })
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect(mockInvalidateShows).not.toHaveBeenCalled()
+    expect(mockInvalidateArtists).not.toHaveBeenCalled()
+    expect(mockInvalidateVenues).not.toHaveBeenCalled()
+  })
+
+  it('handles 422 validation errors', async () => {
+    const error = new Error('expected required property event_date to be present')
+    Object.assign(error, { status: 422 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useShowUpdate(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ showId: 1, updates: {} })
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect(result.current.error).toBeDefined()
+  })
+
+  it('handles network errors', async () => {
+    mockApiRequest.mockRejectedValueOnce(new TypeError('Failed to fetch'))
+
+    const { result } = renderHook(() => useShowUpdate(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ showId: 1, updates: { title: 'New' } })
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect(result.current.error).toBeInstanceOf(TypeError)
+  })
+
+  it('updates all fields simultaneously', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      id: 20,
+      slug: 'show-20',
+      title: 'Full Update',
+      event_date: '2025-08-01T21:00:00Z',
+      status: 'approved',
+      venues: [],
+      artists: [],
+      created_at: '2025-01-01T00:00:00Z',
+      updated_at: '2025-01-02T00:00:00Z',
+      is_sold_out: false,
+      is_cancelled: false,
+    })
+
+    const fullUpdate: ShowUpdate = {
+      title: 'Full Update',
+      event_date: '2025-08-01T21:00:00Z',
+      city: 'Tempe',
+      state: 'AZ',
+      price: 25,
+      age_requirement: '18+',
+      description: 'Updated description',
+      venues: [{ id: 1 }],
+      artists: [{ id: 2, is_headliner: true }],
+    }
+
+    const { result } = renderHook(() => useShowUpdate(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ showId: 20, updates: fullUpdate })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const sentBody = JSON.parse(mockApiRequest.mock.calls[0][1].body)
+    expect(sentBody.title).toBe('Full Update')
+    expect(sentBody.event_date).toBe('2025-08-01T21:00:00Z')
+    expect(sentBody.city).toBe('Tempe')
+    expect(sentBody.price).toBe(25)
+    expect(sentBody.age_requirement).toBe('18+')
+    expect(sentBody.description).toBe('Updated description')
+  })
+})

--- a/frontend/features/venues/hooks/useVenueSearch.test.tsx
+++ b/frontend/features/venues/hooks/useVenueSearch.test.tsx
@@ -1,0 +1,146 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createWrapper, createTestQueryClient } from '@/test/utils'
+
+// Create mocks
+const mockApiRequest = vi.fn()
+
+// Mock the api module
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    VENUES: {
+      SEARCH: '/venues/search',
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+// Mock queryClient module
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    venues: {
+      search: (query: string) => ['venues', 'search', query.toLowerCase()],
+    },
+  },
+}))
+
+// Mock use-debounce to make tests synchronous
+vi.mock('use-debounce', () => ({
+  useDebounce: (value: string, _delay: number) => [value],
+}))
+
+// Import hooks after mocks are set up
+import { useVenueSearch } from './useVenueSearch'
+
+describe('useVenueSearch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches venues matching the search query', async () => {
+    const mockResponse = {
+      venues: [
+        { id: 1, slug: 'the-rebel-lounge', name: 'The Rebel Lounge', city: 'Phoenix', state: 'AZ' },
+        { id: 2, slug: 'rebel-bar', name: 'Rebel Bar', city: 'Tempe', state: 'AZ' },
+      ],
+      count: 2,
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(
+      () => useVenueSearch({ query: 'rebel' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/venues/search?q=rebel')
+    expect(result.current.data?.venues).toHaveLength(2)
+    expect(result.current.data?.count).toBe(2)
+  })
+
+  it('does not fetch when query is empty', () => {
+    const { result } = renderHook(
+      () => useVenueSearch({ query: '' }),
+      { wrapper: createWrapper() }
+    )
+
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('URL-encodes special characters in query', async () => {
+    mockApiRequest.mockResolvedValueOnce({ venues: [], count: 0 })
+
+    const { result } = renderHook(
+      () => useVenueSearch({ query: 'bar & grill' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/venues/search?q=bar%20%26%20grill'
+    )
+  })
+
+  it('handles API errors', async () => {
+    const error = new Error('Server error')
+    Object.assign(error, { status: 500 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(
+      () => useVenueSearch({ query: 'test' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect(result.current.error).toBeDefined()
+  })
+
+  it('returns empty results for no matches', async () => {
+    mockApiRequest.mockResolvedValueOnce({ venues: [], count: 0 })
+
+    const { result } = renderHook(
+      () => useVenueSearch({ query: 'nonexistent' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data?.venues).toHaveLength(0)
+    expect(result.current.data?.count).toBe(0)
+  })
+
+  it('accepts custom debounce delay', async () => {
+    mockApiRequest.mockResolvedValueOnce({ venues: [], count: 0 })
+
+    const { result } = renderHook(
+      () => useVenueSearch({ query: 'test', debounceMs: 300 }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    // Since use-debounce is mocked, it resolves immediately regardless of delay
+    expect(mockApiRequest).toHaveBeenCalledWith('/venues/search?q=test')
+  })
+
+  it('returns loading state while fetching', () => {
+    // Make the request hang
+    mockApiRequest.mockReturnValue(new Promise(() => {}))
+
+    const { result } = renderHook(
+      () => useVenueSearch({ query: 'loading' }),
+      { wrapper: createWrapper() }
+    )
+
+    expect(result.current.isLoading).toBe(true)
+    expect(result.current.data).toBeUndefined()
+  })
+})

--- a/frontend/lib/hooks/admin/useAdminArtistReports.test.tsx
+++ b/frontend/lib/hooks/admin/useAdminArtistReports.test.tsx
@@ -1,0 +1,385 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createWrapper, createTestQueryClient } from '@/test/utils'
+
+// Create mocks
+const mockApiRequest = vi.fn()
+const mockInvalidateArtistReports = vi.fn()
+
+// Mock the api module
+vi.mock('../../api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    ADMIN: {
+      ARTIST_REPORTS: {
+        LIST: '/admin/artist-reports',
+        DISMISS: (reportId: number) =>
+          `/admin/artist-reports/${reportId}/dismiss`,
+        RESOLVE: (reportId: number) =>
+          `/admin/artist-reports/${reportId}/resolve`,
+      },
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+// Mock queryClient module
+vi.mock('../../queryClient', () => ({
+  queryKeys: {
+    artistReports: {
+      pending: (limit: number, offset: number) => [
+        'artistReports',
+        'pending',
+        { limit, offset },
+      ],
+    },
+  },
+  createInvalidateQueries: () => ({
+    artistReports: mockInvalidateArtistReports,
+  }),
+}))
+
+// Import hooks after mocks are set up
+import {
+  usePendingArtistReports,
+  useDismissArtistReport,
+  useResolveArtistReport,
+} from './useAdminArtistReports'
+
+// Helper to create wrapper with specific query client
+function createWrapperWithClient(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+  }
+}
+
+describe('useAdminArtistReports', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateArtistReports.mockReset()
+  })
+
+  describe('usePendingArtistReports', () => {
+    it('fetches pending artist reports with default options', async () => {
+      const mockResponse = {
+        reports: [
+          {
+            id: 1,
+            artist_id: 10,
+            report_type: 'duplicate',
+            status: 'pending',
+            created_at: '2026-03-19T10:00:00Z',
+            updated_at: '2026-03-19T10:00:00Z',
+          },
+          {
+            id: 2,
+            artist_id: 20,
+            report_type: 'incorrect_info',
+            status: 'pending',
+            created_at: '2026-03-18T09:00:00Z',
+            updated_at: '2026-03-18T09:00:00Z',
+          },
+        ],
+        total: 2,
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(() => usePendingArtistReports(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/admin/artist-reports?limit=50&offset=0',
+        { method: 'GET' }
+      )
+      expect(result.current.data?.reports).toHaveLength(2)
+      expect(result.current.data?.total).toBe(2)
+    })
+
+    it('supports custom limit and offset', async () => {
+      mockApiRequest.mockResolvedValueOnce({ reports: [], total: 0 })
+
+      const { result } = renderHook(
+        () => usePendingArtistReports({ limit: 10, offset: 20 }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/admin/artist-reports?limit=10&offset=20',
+        { method: 'GET' }
+      )
+    })
+
+    it('handles empty reports list', async () => {
+      mockApiRequest.mockResolvedValueOnce({ reports: [], total: 0 })
+
+      const { result } = renderHook(() => usePendingArtistReports(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(result.current.data?.reports).toHaveLength(0)
+      expect(result.current.data?.total).toBe(0)
+    })
+
+    it('handles API error', async () => {
+      const error = new Error('Server error')
+      Object.assign(error, { status: 500 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(() => usePendingArtistReports(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+    })
+
+    it('handles authentication error', async () => {
+      const error = new Error('Forbidden')
+      Object.assign(error, { status: 403 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(() => usePendingArtistReports(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+
+      expect((result.current.error as Error).message).toBe('Forbidden')
+    })
+  })
+
+  describe('useDismissArtistReport', () => {
+    it('dismisses a report without notes', async () => {
+      const mockResponse = {
+        id: 1,
+        artist_id: 10,
+        status: 'dismissed',
+        created_at: '2026-03-19T10:00:00Z',
+        updated_at: '2026-03-19T11:00:00Z',
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(() => useDismissArtistReport(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({ reportId: 1 })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/admin/artist-reports/1/dismiss',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({}),
+        })
+      )
+    })
+
+    it('dismisses a report with notes', async () => {
+      const mockResponse = {
+        id: 2,
+        artist_id: 20,
+        status: 'dismissed',
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(() => useDismissArtistReport(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({
+          reportId: 2,
+          notes: 'Not a duplicate, different artist',
+        })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/admin/artist-reports/2/dismiss',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            notes: 'Not a duplicate, different artist',
+          }),
+        })
+      )
+    })
+
+    it('invalidates artist reports on success', async () => {
+      mockApiRequest.mockResolvedValueOnce({ id: 3, status: 'dismissed' })
+
+      const { result } = renderHook(() => useDismissArtistReport(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({ reportId: 3 })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockInvalidateArtistReports).toHaveBeenCalled()
+    })
+
+    it('handles dismiss error', async () => {
+      const error = new Error('Report not found')
+      Object.assign(error, { status: 404 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(() => useDismissArtistReport(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({ reportId: 999 })
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+
+      expect((result.current.error as Error).message).toBe('Report not found')
+    })
+
+    it('handles unauthorized error', async () => {
+      const error = new Error('Forbidden')
+      Object.assign(error, { status: 403 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(() => useDismissArtistReport(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({ reportId: 1 })
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+    })
+  })
+
+  describe('useResolveArtistReport', () => {
+    it('resolves a report without notes', async () => {
+      const mockResponse = {
+        id: 1,
+        artist_id: 10,
+        status: 'resolved',
+        created_at: '2026-03-19T10:00:00Z',
+        updated_at: '2026-03-19T12:00:00Z',
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(() => useResolveArtistReport(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({ reportId: 1 })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/admin/artist-reports/1/resolve',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({}),
+        })
+      )
+    })
+
+    it('resolves a report with notes', async () => {
+      const mockResponse = {
+        id: 2,
+        artist_id: 20,
+        status: 'resolved',
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(() => useResolveArtistReport(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({
+          reportId: 2,
+          notes: 'Merged duplicate entries',
+        })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/admin/artist-reports/2/resolve',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ notes: 'Merged duplicate entries' }),
+        })
+      )
+    })
+
+    it('invalidates artist reports on success', async () => {
+      mockApiRequest.mockResolvedValueOnce({ id: 4, status: 'resolved' })
+
+      const { result } = renderHook(() => useResolveArtistReport(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({ reportId: 4 })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockInvalidateArtistReports).toHaveBeenCalled()
+    })
+
+    it('handles resolve error', async () => {
+      const error = new Error('Report not found')
+      Object.assign(error, { status: 404 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(() => useResolveArtistReport(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({ reportId: 999 })
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+
+      expect((result.current.error as Error).message).toBe('Report not found')
+    })
+
+    it('handles server error', async () => {
+      const error = new Error('Internal server error')
+      Object.assign(error, { status: 500 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(() => useResolveArtistReport(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({ reportId: 1, notes: 'Action taken' })
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+    })
+  })
+})

--- a/frontend/lib/hooks/admin/useAdminReports.test.tsx
+++ b/frontend/lib/hooks/admin/useAdminReports.test.tsx
@@ -1,0 +1,414 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createWrapper, createTestQueryClient } from '@/test/utils'
+
+// Create mocks
+const mockApiRequest = vi.fn()
+const mockInvalidateShowReports = vi.fn()
+const mockInvalidateShows = vi.fn()
+
+// Mock the api module
+vi.mock('../../api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    ADMIN: {
+      REPORTS: {
+        LIST: '/admin/reports',
+        DISMISS: (reportId: number) => `/admin/reports/${reportId}/dismiss`,
+        RESOLVE: (reportId: number) => `/admin/reports/${reportId}/resolve`,
+      },
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+// Mock queryClient module
+vi.mock('../../queryClient', () => ({
+  queryKeys: {
+    showReports: {
+      pending: (limit: number, offset: number) => [
+        'showReports',
+        'pending',
+        { limit, offset },
+      ],
+    },
+  },
+  createInvalidateQueries: () => ({
+    showReports: mockInvalidateShowReports,
+    shows: mockInvalidateShows,
+  }),
+}))
+
+// Import hooks after mocks are set up
+import {
+  usePendingReports,
+  useDismissReport,
+  useResolveReport,
+} from './useAdminReports'
+
+// Helper to create wrapper with specific query client
+function createWrapperWithClient(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+  }
+}
+
+describe('useAdminReports', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateShowReports.mockReset()
+    mockInvalidateShows.mockReset()
+  })
+
+  describe('usePendingReports', () => {
+    it('fetches pending reports with default options', async () => {
+      const mockResponse = {
+        reports: [
+          {
+            id: 1,
+            show_id: 10,
+            report_type: 'cancelled',
+            status: 'pending',
+            created_at: '2026-03-19T10:00:00Z',
+            updated_at: '2026-03-19T10:00:00Z',
+          },
+          {
+            id: 2,
+            show_id: 20,
+            report_type: 'sold_out',
+            status: 'pending',
+            created_at: '2026-03-18T10:00:00Z',
+            updated_at: '2026-03-18T10:00:00Z',
+          },
+        ],
+        total: 2,
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(() => usePendingReports(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/admin/reports?limit=50&offset=0',
+        { method: 'GET' }
+      )
+      expect(result.current.data?.reports).toHaveLength(2)
+      expect(result.current.data?.total).toBe(2)
+    })
+
+    it('supports custom limit and offset', async () => {
+      mockApiRequest.mockResolvedValueOnce({ reports: [], total: 0 })
+
+      const { result } = renderHook(
+        () => usePendingReports({ limit: 25, offset: 50 }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/admin/reports?limit=25&offset=50',
+        { method: 'GET' }
+      )
+    })
+
+    it('handles empty reports list', async () => {
+      mockApiRequest.mockResolvedValueOnce({ reports: [], total: 0 })
+
+      const { result } = renderHook(() => usePendingReports(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(result.current.data?.reports).toHaveLength(0)
+      expect(result.current.data?.total).toBe(0)
+    })
+
+    it('handles API error', async () => {
+      const error = new Error('Server error')
+      Object.assign(error, { status: 500 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(() => usePendingReports(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+    })
+
+    it('handles authentication error', async () => {
+      const error = new Error('Forbidden')
+      Object.assign(error, { status: 403 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(() => usePendingReports(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+
+      expect((result.current.error as Error).message).toBe('Forbidden')
+    })
+  })
+
+  describe('useDismissReport', () => {
+    it('dismisses a report without notes', async () => {
+      const mockResponse = {
+        id: 1,
+        show_id: 10,
+        report_type: 'cancelled',
+        status: 'dismissed',
+        created_at: '2026-03-19T10:00:00Z',
+        updated_at: '2026-03-19T11:00:00Z',
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(() => useDismissReport(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({ reportId: 1 })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/admin/reports/1/dismiss',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({}),
+        })
+      )
+    })
+
+    it('dismisses a report with notes', async () => {
+      const mockResponse = {
+        id: 2,
+        show_id: 20,
+        status: 'dismissed',
+        admin_notes: 'Spam report',
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(() => useDismissReport(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({ reportId: 2, notes: 'Spam report' })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/admin/reports/2/dismiss',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ notes: 'Spam report' }),
+        })
+      )
+    })
+
+    it('invalidates show reports on success', async () => {
+      mockApiRequest.mockResolvedValueOnce({ id: 3, status: 'dismissed' })
+
+      const { result } = renderHook(() => useDismissReport(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({ reportId: 3 })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockInvalidateShowReports).toHaveBeenCalled()
+    })
+
+    it('handles dismiss error', async () => {
+      const error = new Error('Report not found')
+      Object.assign(error, { status: 404 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(() => useDismissReport(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({ reportId: 999 })
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+
+      expect((result.current.error as Error).message).toBe('Report not found')
+    })
+
+    it('handles unauthorized error', async () => {
+      const error = new Error('Forbidden')
+      Object.assign(error, { status: 403 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(() => useDismissReport(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({ reportId: 1 })
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+    })
+  })
+
+  describe('useResolveReport', () => {
+    it('resolves a report without setting show flag', async () => {
+      const mockResponse = {
+        id: 1,
+        show_id: 10,
+        status: 'resolved',
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(() => useResolveReport(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({ reportId: 1 })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/admin/reports/1/resolve',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ set_show_flag: false }),
+        })
+      )
+    })
+
+    it('resolves a report with setShowFlag true', async () => {
+      const mockResponse = {
+        id: 2,
+        show_id: 20,
+        status: 'resolved',
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(() => useResolveReport(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({ reportId: 2, setShowFlag: true })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/admin/reports/2/resolve',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ set_show_flag: true }),
+        })
+      )
+    })
+
+    it('resolves a report with notes and setShowFlag', async () => {
+      const mockResponse = {
+        id: 3,
+        show_id: 30,
+        status: 'resolved',
+        admin_notes: 'Verified cancelled',
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(() => useResolveReport(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({
+          reportId: 3,
+          notes: 'Verified cancelled',
+          setShowFlag: true,
+        })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/admin/reports/3/resolve',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            set_show_flag: true,
+            notes: 'Verified cancelled',
+          }),
+        })
+      )
+    })
+
+    it('invalidates show reports and shows on success', async () => {
+      mockApiRequest.mockResolvedValueOnce({ id: 4, status: 'resolved' })
+
+      const { result } = renderHook(() => useResolveReport(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({ reportId: 4, setShowFlag: true })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockInvalidateShowReports).toHaveBeenCalled()
+      expect(mockInvalidateShows).toHaveBeenCalled()
+    })
+
+    it('handles resolve error', async () => {
+      const error = new Error('Report not found')
+      Object.assign(error, { status: 404 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(() => useResolveReport(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({ reportId: 999 })
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+
+      expect((result.current.error as Error).message).toBe('Report not found')
+    })
+
+    it('handles server error', async () => {
+      const error = new Error('Internal server error')
+      Object.assign(error, { status: 500 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(() => useResolveReport(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({ reportId: 1, setShowFlag: true })
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+    })
+  })
+})

--- a/frontend/lib/hooks/admin/useAdminStats.test.tsx
+++ b/frontend/lib/hooks/admin/useAdminStats.test.tsx
@@ -1,0 +1,273 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createWrapper, createTestQueryClient } from '@/test/utils'
+
+// Create mocks
+const mockApiRequest = vi.fn()
+
+// Mock the api module
+vi.mock('../../api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    ADMIN: {
+      STATS: '/admin/stats',
+      ACTIVITY: '/admin/activity',
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+// Mock queryClient module
+vi.mock('../../queryClient', () => ({
+  queryKeys: {
+    admin: {
+      stats: ['admin', 'stats'],
+      activity: ['admin', 'activity'],
+    },
+  },
+}))
+
+// Import hooks after mocks are set up
+import { useAdminStats, useAdminActivity } from './useAdminStats'
+
+describe('useAdminStats', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  describe('useAdminStats', () => {
+    it('fetches admin dashboard stats successfully', async () => {
+      const mockResponse = {
+        pending_shows: 5,
+        pending_venue_edits: 2,
+        pending_reports: 1,
+        unverified_venues: 3,
+        total_shows: 100,
+        total_venues: 20,
+        total_artists: 50,
+        total_users: 30,
+        shows_submitted_last_7_days: 10,
+        users_registered_last_7_days: 5,
+        total_shows_trend: 3,
+        total_venues_trend: -1,
+        total_artists_trend: 2,
+        total_users_trend: 5,
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(() => useAdminStats(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/admin/stats', {
+        method: 'GET',
+      })
+      expect(result.current.data?.pending_shows).toBe(5)
+      expect(result.current.data?.total_shows).toBe(100)
+      expect(result.current.data?.total_shows_trend).toBe(3)
+    })
+
+    it('returns all stat fields', async () => {
+      const mockResponse = {
+        pending_shows: 0,
+        pending_venue_edits: 0,
+        pending_reports: 0,
+        unverified_venues: 0,
+        total_shows: 250,
+        total_venues: 45,
+        total_artists: 120,
+        total_users: 80,
+        shows_submitted_last_7_days: 0,
+        users_registered_last_7_days: 0,
+        total_shows_trend: 0,
+        total_venues_trend: 0,
+        total_artists_trend: 0,
+        total_users_trend: 0,
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(() => useAdminStats(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(result.current.data?.pending_shows).toBe(0)
+      expect(result.current.data?.pending_venue_edits).toBe(0)
+      expect(result.current.data?.pending_reports).toBe(0)
+      expect(result.current.data?.unverified_venues).toBe(0)
+      expect(result.current.data?.total_shows).toBe(250)
+      expect(result.current.data?.total_venues).toBe(45)
+      expect(result.current.data?.total_artists).toBe(120)
+      expect(result.current.data?.total_users).toBe(80)
+      expect(result.current.data?.shows_submitted_last_7_days).toBe(0)
+      expect(result.current.data?.users_registered_last_7_days).toBe(0)
+    })
+
+    it('handles negative trend values', async () => {
+      const mockResponse = {
+        pending_shows: 0,
+        pending_venue_edits: 0,
+        pending_reports: 0,
+        unverified_venues: 0,
+        total_shows: 100,
+        total_venues: 20,
+        total_artists: 50,
+        total_users: 30,
+        shows_submitted_last_7_days: 3,
+        users_registered_last_7_days: 1,
+        total_shows_trend: -5,
+        total_venues_trend: -2,
+        total_artists_trend: -1,
+        total_users_trend: -3,
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(() => useAdminStats(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(result.current.data?.total_shows_trend).toBe(-5)
+      expect(result.current.data?.total_venues_trend).toBe(-2)
+    })
+
+    it('handles API error', async () => {
+      const error = new Error('Server error')
+      Object.assign(error, { status: 500 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(() => useAdminStats(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+    })
+
+    it('handles authentication error', async () => {
+      const error = new Error('Forbidden')
+      Object.assign(error, { status: 403 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(() => useAdminStats(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+
+      expect((result.current.error as Error).message).toBe('Forbidden')
+    })
+  })
+
+  describe('useAdminActivity', () => {
+    it('fetches activity events successfully', async () => {
+      const mockResponse = {
+        events: [
+          {
+            id: 1,
+            event_type: 'show_approved',
+            description: 'Show "Metal Monday" was approved',
+            entity_type: 'show',
+            entity_slug: 'metal-monday-2026-03-20',
+            timestamp: '2026-03-19T10:30:00Z',
+            actor_name: 'admin',
+          },
+          {
+            id: 2,
+            event_type: 'venue_verified',
+            description: 'Venue "The Rebel Lounge" was verified',
+            entity_type: 'venue',
+            entity_slug: 'the-rebel-lounge',
+            timestamp: '2026-03-19T09:15:00Z',
+            actor_name: 'admin',
+          },
+        ],
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(() => useAdminActivity(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/admin/activity', {
+        method: 'GET',
+      })
+      expect(result.current.data?.events).toHaveLength(2)
+      expect(result.current.data?.events[0].event_type).toBe('show_approved')
+      expect(result.current.data?.events[1].entity_slug).toBe(
+        'the-rebel-lounge'
+      )
+    })
+
+    it('handles empty activity feed', async () => {
+      mockApiRequest.mockResolvedValueOnce({ events: [] })
+
+      const { result } = renderHook(() => useAdminActivity(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(result.current.data?.events).toHaveLength(0)
+    })
+
+    it('handles events with optional fields missing', async () => {
+      const mockResponse = {
+        events: [
+          {
+            id: 3,
+            event_type: 'user_registered',
+            description: 'New user registered',
+            timestamp: '2026-03-19T08:00:00Z',
+            // entity_type, entity_slug, actor_name are optional
+          },
+        ],
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(() => useAdminActivity(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(result.current.data?.events[0].entity_type).toBeUndefined()
+      expect(result.current.data?.events[0].entity_slug).toBeUndefined()
+      expect(result.current.data?.events[0].actor_name).toBeUndefined()
+    })
+
+    it('handles API error', async () => {
+      const error = new Error('Server error')
+      Object.assign(error, { status: 500 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(() => useAdminActivity(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+    })
+
+    it('handles authentication error', async () => {
+      const error = new Error('Forbidden')
+      Object.assign(error, { status: 403 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(() => useAdminActivity(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+
+      expect((result.current.error as Error).message).toBe('Forbidden')
+    })
+  })
+})

--- a/frontend/lib/hooks/admin/useAdminUsers.test.tsx
+++ b/frontend/lib/hooks/admin/useAdminUsers.test.tsx
@@ -1,0 +1,306 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createWrapper, createTestQueryClient } from '@/test/utils'
+
+// Create mocks
+const mockApiRequest = vi.fn()
+
+// Mock the api module
+vi.mock('../../api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    ADMIN: {
+      USERS: {
+        LIST: '/admin/users',
+      },
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+// Mock queryClient module
+vi.mock('../../queryClient', () => ({
+  queryKeys: {
+    admin: {
+      users: (limit: number, offset: number, search: string) => [
+        'admin',
+        'users',
+        { limit, offset, search },
+      ],
+    },
+  },
+}))
+
+// Import hooks after mocks are set up
+import { useAdminUsers } from './useAdminUsers'
+
+describe('useAdminUsers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches users with default options', async () => {
+    const mockResponse = {
+      users: [
+        {
+          id: 1,
+          email: 'user1@example.com',
+          username: 'user1',
+          first_name: 'Alice',
+          last_name: 'Smith',
+          avatar_url: null,
+          is_active: true,
+          is_admin: false,
+          email_verified: true,
+          auth_methods: ['email'],
+          submission_stats: {
+            approved: 5,
+            pending: 1,
+            rejected: 0,
+            total: 6,
+          },
+          created_at: '2026-01-15T10:00:00Z',
+        },
+        {
+          id: 2,
+          email: 'admin@example.com',
+          username: 'admin',
+          first_name: 'Bob',
+          last_name: 'Jones',
+          avatar_url: 'https://example.com/avatar.jpg',
+          is_active: true,
+          is_admin: true,
+          email_verified: true,
+          auth_methods: ['email', 'google'],
+          submission_stats: {
+            approved: 50,
+            pending: 2,
+            rejected: 3,
+            total: 55,
+          },
+          created_at: '2025-12-01T08:00:00Z',
+        },
+      ],
+      total: 2,
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useAdminUsers(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/admin/users?limit=50&offset=0',
+      { method: 'GET' }
+    )
+    expect(result.current.data?.users).toHaveLength(2)
+    expect(result.current.data?.total).toBe(2)
+  })
+
+  it('supports custom limit and offset', async () => {
+    mockApiRequest.mockResolvedValueOnce({ users: [], total: 0 })
+
+    const { result } = renderHook(
+      () => useAdminUsers({ limit: 25, offset: 50 }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/admin/users?limit=25&offset=50',
+      { method: 'GET' }
+    )
+  })
+
+  it('supports search filter', async () => {
+    const mockResponse = {
+      users: [
+        {
+          id: 1,
+          email: 'alice@example.com',
+          username: 'alice',
+          first_name: 'Alice',
+          last_name: null,
+          avatar_url: null,
+          is_active: true,
+          is_admin: false,
+          email_verified: true,
+          auth_methods: ['email'],
+          submission_stats: {
+            approved: 0,
+            pending: 0,
+            rejected: 0,
+            total: 0,
+          },
+          created_at: '2026-03-01T10:00:00Z',
+        },
+      ],
+      total: 1,
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(
+      () => useAdminUsers({ search: 'alice' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const calledUrl = mockApiRequest.mock.calls[0][0]
+    expect(calledUrl).toContain('search=alice')
+    expect(result.current.data?.users).toHaveLength(1)
+  })
+
+  it('does not include search param when search is empty', async () => {
+    mockApiRequest.mockResolvedValueOnce({ users: [], total: 0 })
+
+    const { result } = renderHook(
+      () => useAdminUsers({ search: '' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const calledUrl = mockApiRequest.mock.calls[0][0]
+    expect(calledUrl).not.toContain('search=')
+  })
+
+  it('supports custom limit, offset, and search together', async () => {
+    mockApiRequest.mockResolvedValueOnce({ users: [], total: 0 })
+
+    const { result } = renderHook(
+      () => useAdminUsers({ limit: 10, offset: 20, search: 'admin' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const calledUrl = mockApiRequest.mock.calls[0][0]
+    expect(calledUrl).toContain('limit=10')
+    expect(calledUrl).toContain('offset=20')
+    expect(calledUrl).toContain('search=admin')
+  })
+
+  it('handles empty users list', async () => {
+    mockApiRequest.mockResolvedValueOnce({ users: [], total: 0 })
+
+    const { result } = renderHook(() => useAdminUsers(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data?.users).toHaveLength(0)
+    expect(result.current.data?.total).toBe(0)
+  })
+
+  it('handles users with nullable fields', async () => {
+    const mockResponse = {
+      users: [
+        {
+          id: 3,
+          email: null,
+          username: null,
+          first_name: null,
+          last_name: null,
+          avatar_url: null,
+          is_active: true,
+          is_admin: false,
+          email_verified: false,
+          auth_methods: ['google'],
+          submission_stats: {
+            approved: 0,
+            pending: 0,
+            rejected: 0,
+            total: 0,
+          },
+          created_at: '2026-03-19T10:00:00Z',
+        },
+      ],
+      total: 1,
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useAdminUsers(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data?.users[0].email).toBeNull()
+    expect(result.current.data?.users[0].username).toBeNull()
+    expect(result.current.data?.users[0].first_name).toBeNull()
+  })
+
+  it('handles deleted users', async () => {
+    const mockResponse = {
+      users: [
+        {
+          id: 4,
+          email: 'deleted@example.com',
+          username: 'deleted_user',
+          first_name: 'Deleted',
+          last_name: 'User',
+          avatar_url: null,
+          is_active: false,
+          is_admin: false,
+          email_verified: true,
+          auth_methods: ['email'],
+          submission_stats: {
+            approved: 10,
+            pending: 0,
+            rejected: 2,
+            total: 12,
+          },
+          created_at: '2025-06-01T10:00:00Z',
+          deleted_at: '2026-03-01T10:00:00Z',
+        },
+      ],
+      total: 1,
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useAdminUsers(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data?.users[0].is_active).toBe(false)
+    expect(result.current.data?.users[0].deleted_at).toBe(
+      '2026-03-01T10:00:00Z'
+    )
+  })
+
+  it('handles API error', async () => {
+    const error = new Error('Server error')
+    Object.assign(error, { status: 500 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useAdminUsers(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+  })
+
+  it('handles authentication error', async () => {
+    const error = new Error('Forbidden')
+    Object.assign(error, { status: 403 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useAdminUsers(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect((result.current.error as Error).message).toBe('Forbidden')
+  })
+})

--- a/frontend/lib/hooks/admin/useDataQuality.test.tsx
+++ b/frontend/lib/hooks/admin/useDataQuality.test.tsx
@@ -1,0 +1,349 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createWrapper, createTestQueryClient } from '@/test/utils'
+
+// Create mocks
+const mockApiRequest = vi.fn()
+
+// Mock the api module
+vi.mock('../../api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    ADMIN: {
+      DATA_QUALITY: {
+        SUMMARY: '/admin/data-quality',
+        CATEGORY: (category: string) => `/admin/data-quality/${category}`,
+      },
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+// Mock queryClient module
+vi.mock('../../queryClient', () => ({
+  queryKeys: {
+    admin: {
+      dataQuality: {
+        summary: ['admin', 'dataQuality', 'summary'],
+        category: (category: string, limit: number, offset: number) => [
+          'admin',
+          'dataQuality',
+          'category',
+          category,
+          { limit, offset },
+        ],
+      },
+    },
+  },
+}))
+
+// Import hooks after mocks are set up
+import { useDataQualitySummary, useDataQualityCategory } from './useDataQuality'
+
+describe('useDataQuality', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  describe('useDataQualitySummary', () => {
+    it('fetches data quality summary successfully', async () => {
+      const mockResponse = {
+        categories: [
+          {
+            key: 'artists_no_shows',
+            label: 'Artists with no shows',
+            entity_type: 'artist',
+            count: 15,
+            description: 'Artists that have no associated shows',
+          },
+          {
+            key: 'venues_no_shows',
+            label: 'Venues with no shows',
+            entity_type: 'venue',
+            count: 8,
+            description: 'Venues that have no associated shows',
+          },
+          {
+            key: 'shows_no_artists',
+            label: 'Shows with no artists',
+            entity_type: 'show',
+            count: 3,
+            description: 'Shows that have no associated artists',
+          },
+        ],
+        total_items: 26,
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(() => useDataQualitySummary(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/admin/data-quality', {
+        method: 'GET',
+      })
+      expect(result.current.data?.categories).toHaveLength(3)
+      expect(result.current.data?.total_items).toBe(26)
+    })
+
+    it('handles summary with zero counts', async () => {
+      const mockResponse = {
+        categories: [
+          {
+            key: 'artists_no_shows',
+            label: 'Artists with no shows',
+            entity_type: 'artist',
+            count: 0,
+            description: 'Artists that have no associated shows',
+          },
+        ],
+        total_items: 0,
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(() => useDataQualitySummary(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(result.current.data?.categories[0].count).toBe(0)
+      expect(result.current.data?.total_items).toBe(0)
+    })
+
+    it('handles empty categories list', async () => {
+      mockApiRequest.mockResolvedValueOnce({
+        categories: [],
+        total_items: 0,
+      })
+
+      const { result } = renderHook(() => useDataQualitySummary(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(result.current.data?.categories).toHaveLength(0)
+    })
+
+    it('handles API error', async () => {
+      const error = new Error('Server error')
+      Object.assign(error, { status: 500 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(() => useDataQualitySummary(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+    })
+
+    it('handles authentication error', async () => {
+      const error = new Error('Forbidden')
+      Object.assign(error, { status: 403 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(() => useDataQualitySummary(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+
+      expect((result.current.error as Error).message).toBe('Forbidden')
+    })
+  })
+
+  describe('useDataQualityCategory', () => {
+    it('fetches items for a specific category', async () => {
+      const mockResponse = {
+        items: [
+          {
+            entity_type: 'artist',
+            entity_id: 1,
+            name: 'Unknown Artist',
+            slug: 'unknown-artist',
+            reason: 'No associated shows',
+            show_count: 0,
+          },
+          {
+            entity_type: 'artist',
+            entity_id: 2,
+            name: 'Orphan Band',
+            slug: 'orphan-band',
+            reason: 'No associated shows',
+            show_count: 0,
+          },
+        ],
+        total: 2,
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(
+        () => useDataQualityCategory('artists_no_shows'),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/admin/data-quality/artists_no_shows?limit=50&offset=0',
+        { method: 'GET' }
+      )
+      expect(result.current.data?.items).toHaveLength(2)
+      expect(result.current.data?.total).toBe(2)
+    })
+
+    it('supports custom limit and offset', async () => {
+      mockApiRequest.mockResolvedValueOnce({ items: [], total: 0 })
+
+      const { result } = renderHook(
+        () => useDataQualityCategory('venues_no_shows', 10, 20),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/admin/data-quality/venues_no_shows?limit=10&offset=20',
+        { method: 'GET' }
+      )
+    })
+
+    it('handles empty items list', async () => {
+      mockApiRequest.mockResolvedValueOnce({ items: [], total: 0 })
+
+      const { result } = renderHook(
+        () => useDataQualityCategory('artists_no_shows'),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(result.current.data?.items).toHaveLength(0)
+      expect(result.current.data?.total).toBe(0)
+    })
+
+    it('is disabled when category is empty string', async () => {
+      const { result } = renderHook(
+        () => useDataQualityCategory(''),
+        { wrapper: createWrapper() }
+      )
+
+      // Should not fetch because category is empty
+      expect(result.current.isFetching).toBe(false)
+      expect(mockApiRequest).not.toHaveBeenCalled()
+    })
+
+    it('respects enabled option', async () => {
+      const { result } = renderHook(
+        () =>
+          useDataQualityCategory('artists_no_shows', 50, 0, {
+            enabled: false,
+          }),
+        { wrapper: createWrapper() }
+      )
+
+      // Should not fetch because enabled is false
+      expect(result.current.isFetching).toBe(false)
+      expect(mockApiRequest).not.toHaveBeenCalled()
+    })
+
+    it('is enabled by default when category is provided', async () => {
+      mockApiRequest.mockResolvedValueOnce({ items: [], total: 0 })
+
+      const { result } = renderHook(
+        () => useDataQualityCategory('shows_no_artists'),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalled()
+    })
+
+    it('handles items with various show counts', async () => {
+      const mockResponse = {
+        items: [
+          {
+            entity_type: 'artist',
+            entity_id: 10,
+            name: 'Popular Artist',
+            slug: 'popular-artist',
+            reason: 'Missing genre tags',
+            show_count: 25,
+          },
+          {
+            entity_type: 'artist',
+            entity_id: 11,
+            name: 'New Artist',
+            slug: 'new-artist',
+            reason: 'Missing genre tags',
+            show_count: 1,
+          },
+        ],
+        total: 2,
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(
+        () => useDataQualityCategory('missing_genre_tags'),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(result.current.data?.items[0].show_count).toBe(25)
+      expect(result.current.data?.items[1].show_count).toBe(1)
+    })
+
+    it('handles API error', async () => {
+      const error = new Error('Server error')
+      Object.assign(error, { status: 500 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(
+        () => useDataQualityCategory('artists_no_shows'),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+    })
+
+    it('handles authentication error', async () => {
+      const error = new Error('Forbidden')
+      Object.assign(error, { status: 403 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(
+        () => useDataQualityCategory('artists_no_shows'),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+
+      expect((result.current.error as Error).message).toBe('Forbidden')
+    })
+
+    it('handles 404 for unknown category', async () => {
+      const error = new Error('Category not found')
+      Object.assign(error, { status: 404 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(
+        () => useDataQualityCategory('nonexistent_category'),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+
+      expect((result.current.error as Error).message).toBe(
+        'Category not found'
+      )
+    })
+  })
+})

--- a/frontend/lib/hooks/common/useDensity.test.ts
+++ b/frontend/lib/hooks/common/useDensity.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useDensity, type Density } from './useDensity'
+
+describe('useDensity', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  describe('initial state', () => {
+    it('should default to comfortable density', () => {
+      const { result } = renderHook(() => useDensity())
+      expect(result.current.density).toBe('comfortable')
+    })
+
+    it('should read stored density from localStorage on mount', async () => {
+      localStorage.setItem('ph-density', 'compact')
+
+      const { result } = renderHook(() => useDensity())
+
+      // useEffect reads from localStorage after mount
+      await vi.waitFor(() => {
+        expect(result.current.density).toBe('compact')
+      })
+    })
+
+    it('should read stored density with custom suffix', async () => {
+      localStorage.setItem('ph-density-shows', 'expanded')
+
+      const { result } = renderHook(() => useDensity('shows'))
+
+      await vi.waitFor(() => {
+        expect(result.current.density).toBe('expanded')
+      })
+    })
+
+    it('should fall back to comfortable for invalid stored value', async () => {
+      localStorage.setItem('ph-density', 'invalid-value')
+
+      const { result } = renderHook(() => useDensity())
+
+      // After mount effect runs, it should still be comfortable
+      await vi.waitFor(() => {
+        expect(result.current.density).toBe('comfortable')
+      })
+    })
+
+    it('should fall back to comfortable when localStorage is empty', () => {
+      const { result } = renderHook(() => useDensity())
+      expect(result.current.density).toBe('comfortable')
+    })
+  })
+
+  describe('setDensity', () => {
+    it('should update density to compact', () => {
+      const { result } = renderHook(() => useDensity())
+
+      act(() => {
+        result.current.setDensity('compact')
+      })
+
+      expect(result.current.density).toBe('compact')
+    })
+
+    it('should update density to expanded', () => {
+      const { result } = renderHook(() => useDensity())
+
+      act(() => {
+        result.current.setDensity('expanded')
+      })
+
+      expect(result.current.density).toBe('expanded')
+    })
+
+    it('should persist density to localStorage', () => {
+      const { result } = renderHook(() => useDensity())
+
+      act(() => {
+        result.current.setDensity('compact')
+      })
+
+      expect(localStorage.getItem('ph-density')).toBe('compact')
+    })
+
+    it('should persist density with custom suffix', () => {
+      const { result } = renderHook(() => useDensity('artists'))
+
+      act(() => {
+        result.current.setDensity('expanded')
+      })
+
+      expect(localStorage.getItem('ph-density-artists')).toBe('expanded')
+    })
+
+    it('should allow cycling through all density values', () => {
+      const { result } = renderHook(() => useDensity())
+
+      const densities: Density[] = ['compact', 'comfortable', 'expanded']
+      for (const d of densities) {
+        act(() => {
+          result.current.setDensity(d)
+        })
+        expect(result.current.density).toBe(d)
+        expect(localStorage.getItem('ph-density')).toBe(d)
+      }
+    })
+  })
+
+  describe('storage key isolation', () => {
+    it('should use different storage keys for different suffixes', () => {
+      const { result: showsResult } = renderHook(() => useDensity('shows'))
+      const { result: artistsResult } = renderHook(() => useDensity('artists'))
+
+      act(() => {
+        showsResult.current.setDensity('compact')
+      })
+      act(() => {
+        artistsResult.current.setDensity('expanded')
+      })
+
+      expect(localStorage.getItem('ph-density-shows')).toBe('compact')
+      expect(localStorage.getItem('ph-density-artists')).toBe('expanded')
+      expect(showsResult.current.density).toBe('compact')
+      expect(artistsResult.current.density).toBe('expanded')
+    })
+
+    it('should not interfere between suffixed and unsuffixed keys', () => {
+      const { result: globalResult } = renderHook(() => useDensity())
+      const { result: showsResult } = renderHook(() => useDensity('shows'))
+
+      act(() => {
+        globalResult.current.setDensity('compact')
+      })
+      act(() => {
+        showsResult.current.setDensity('expanded')
+      })
+
+      expect(localStorage.getItem('ph-density')).toBe('compact')
+      expect(localStorage.getItem('ph-density-shows')).toBe('expanded')
+    })
+  })
+
+  describe('localStorage error handling', () => {
+    it('should handle localStorage.getItem throwing', async () => {
+      vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+        throw new Error('localStorage disabled')
+      })
+
+      const { result } = renderHook(() => useDensity())
+
+      // Should fall back to default without throwing
+      await vi.waitFor(() => {
+        expect(result.current.density).toBe('comfortable')
+      })
+    })
+
+    it('should handle localStorage.setItem throwing', () => {
+      vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new Error('QuotaExceededError')
+      })
+
+      const { result } = renderHook(() => useDensity())
+
+      // Should update state even if localStorage write fails
+      act(() => {
+        result.current.setDensity('compact')
+      })
+
+      expect(result.current.density).toBe('compact')
+    })
+  })
+
+  describe('return value stability', () => {
+    it('should return a stable setDensity callback', () => {
+      const { result, rerender } = renderHook(() => useDensity())
+
+      const firstSetDensity = result.current.setDensity
+      rerender()
+      const secondSetDensity = result.current.setDensity
+
+      expect(firstSetDensity).toBe(secondSetDensity)
+    })
+  })
+})

--- a/frontend/lib/hooks/common/useFollow.test.tsx
+++ b/frontend/lib/hooks/common/useFollow.test.tsx
@@ -1,0 +1,624 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createWrapper, createTestQueryClient } from '@/test/utils'
+
+/**
+ * Create a test query client that retains cache data (gcTime > 0).
+ * Needed for optimistic update tests where we seed cache data without an active observer.
+ */
+function createRetainingQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: 5 * 60 * 1000, // 5 minutes
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+  })
+}
+
+// Create mocks
+const mockApiRequest = vi.fn()
+const mockIsAuthenticated = vi.fn().mockReturnValue(true)
+
+// Mock the api module
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    FOLLOW: {
+      ENTITY: (entityType: string, entityId: number) =>
+        `/api/${entityType}/${entityId}/follow`,
+      FOLLOWERS: (entityType: string, entityId: number) =>
+        `/api/${entityType}/${entityId}/followers`,
+      BATCH: '/api/follows/batch',
+      MY_FOLLOWING: '/api/me/following',
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+// Mock queryClient module
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    follows: {
+      all: ['follows'] as const,
+      entity: (entityType: string, entityId: number) =>
+        ['follows', entityType, entityId] as const,
+      batch: (entityType: string, entityIds: number[]) =>
+        ['follows', 'batch', entityType, ...entityIds] as const,
+      myFollowing: (params?: Record<string, unknown>) =>
+        ['follows', 'my-following', params] as const,
+    },
+  },
+  createInvalidateQueries: (queryClient: QueryClient) => ({
+    follows: () => queryClient.invalidateQueries({ queryKey: ['follows'] }),
+  }),
+}))
+
+// Mock AuthContext
+vi.mock('@/lib/context/AuthContext', () => ({
+  useAuthContext: () => ({
+    isAuthenticated: mockIsAuthenticated(),
+  }),
+}))
+
+// Import hooks after mocks are set up
+import {
+  useFollowStatus,
+  useBatchFollowStatus,
+  useFollow,
+  useUnfollow,
+  useMyFollowing,
+} from './useFollow'
+
+describe('useFollow hooks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockIsAuthenticated.mockReturnValue(true)
+  })
+
+  describe('useFollowStatus', () => {
+    it('fetches follow status for an entity', async () => {
+      const mockStatus = {
+        entity_type: 'artists',
+        entity_id: 1,
+        follower_count: 42,
+        is_following: true,
+      }
+      mockApiRequest.mockResolvedValueOnce(mockStatus)
+
+      const { result } = renderHook(() => useFollowStatus('artists', 1), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/api/artists/1/followers',
+        { method: 'GET' }
+      )
+      expect(result.current.data?.follower_count).toBe(42)
+      expect(result.current.data?.is_following).toBe(true)
+    })
+
+    it('does not fetch when entityId is 0', () => {
+      const { result } = renderHook(() => useFollowStatus('artists', 0), {
+        wrapper: createWrapper(),
+      })
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('does not fetch when entityId is negative', () => {
+      const { result } = renderHook(() => useFollowStatus('artists', -1), {
+        wrapper: createWrapper(),
+      })
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('does not fetch when entityType is empty', () => {
+      const { result } = renderHook(() => useFollowStatus('', 1), {
+        wrapper: createWrapper(),
+      })
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('handles API errors', async () => {
+      const error = new Error('Server error')
+      Object.assign(error, { status: 500 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(() => useFollowStatus('artists', 1), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+      expect(result.current.error).toBeDefined()
+    })
+
+    it('works with different entity types', async () => {
+      const mockStatus = {
+        entity_type: 'venues',
+        entity_id: 5,
+        follower_count: 10,
+        is_following: false,
+      }
+      mockApiRequest.mockResolvedValueOnce(mockStatus)
+
+      const { result } = renderHook(() => useFollowStatus('venues', 5), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/api/venues/5/followers',
+        { method: 'GET' }
+      )
+      expect(result.current.data?.is_following).toBe(false)
+    })
+  })
+
+  describe('useBatchFollowStatus', () => {
+    it('fetches batch follow status for multiple entities', async () => {
+      const mockResponse = {
+        follows: {
+          '1': { follower_count: 10, is_following: true },
+          '2': { follower_count: 5, is_following: false },
+          '3': { follower_count: 20, is_following: true },
+        },
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(
+        () => useBatchFollowStatus('artists', [1, 2, 3]),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/api/follows/batch', {
+        method: 'POST',
+        body: JSON.stringify({
+          entity_type: 'artists',
+          entity_ids: [1, 2, 3],
+        }),
+      })
+      expect(result.current.data?.['1'].follower_count).toBe(10)
+      expect(result.current.data?.['2'].is_following).toBe(false)
+    })
+
+    it('does not fetch when entityIds is empty', () => {
+      const { result } = renderHook(
+        () => useBatchFollowStatus('artists', []),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('does not fetch when entityType is empty', () => {
+      const { result } = renderHook(
+        () => useBatchFollowStatus('', [1, 2]),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('handles API errors', async () => {
+      const error = new Error('Server error')
+      Object.assign(error, { status: 500 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(
+        () => useBatchFollowStatus('artists', [1, 2]),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+    })
+  })
+
+  describe('useFollow', () => {
+    it('sends POST to follow an entity', async () => {
+      mockApiRequest.mockResolvedValueOnce({ success: true, message: 'Followed' })
+
+      const { result } = renderHook(() => useFollow(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({ entityType: 'artists', entityId: 1 })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/api/artists/1/follow', {
+        method: 'POST',
+      })
+    })
+
+    it('optimistically updates follow status', async () => {
+      const queryClient = createRetainingQueryClient()
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      )
+
+      // Seed the cache with initial follow status
+      queryClient.setQueryData(['follows', 'artists', 1], {
+        entity_type: 'artists',
+        entity_id: 1,
+        follower_count: 10,
+        is_following: false,
+      })
+
+      // Use a deferred promise so the mutation stays in-flight while we check
+      let resolveApi!: (value: unknown) => void
+      mockApiRequest.mockImplementation(
+        () => new Promise((resolve) => { resolveApi = resolve })
+      )
+
+      const { result } = renderHook(() => useFollow(), { wrapper })
+
+      act(() => {
+        result.current.mutate({ entityType: 'artists', entityId: 1 })
+      })
+
+      // Check optimistic update was applied while mutation is still pending
+      await waitFor(() => {
+        const data = queryClient.getQueryData(['follows', 'artists', 1]) as {
+          follower_count: number
+          is_following: boolean
+        }
+        expect(data).toBeDefined()
+        expect(data.follower_count).toBe(11)
+        expect(data.is_following).toBe(true)
+      })
+
+      // Resolve the API call to clean up
+      await act(async () => {
+        resolveApi({ success: true, message: 'Followed' })
+      })
+    })
+
+    it('rolls back optimistic update on error', async () => {
+      const queryClient = createRetainingQueryClient()
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      )
+
+      // Seed cache
+      const originalData = {
+        entity_type: 'artists',
+        entity_id: 1,
+        follower_count: 10,
+        is_following: false,
+      }
+      queryClient.setQueryData(['follows', 'artists', 1], originalData)
+
+      // First call rejects (the mutation), second call returns original data (the refetch from onSettled)
+      mockApiRequest
+        .mockRejectedValueOnce(new Error('Network error'))
+        .mockResolvedValueOnce(originalData)
+
+      const { result } = renderHook(() => useFollow(), { wrapper })
+
+      await act(async () => {
+        result.current.mutate({ entityType: 'artists', entityId: 1 })
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+
+      // Should have rolled back via onError
+      const data = queryClient.getQueryData(['follows', 'artists', 1]) as {
+        follower_count: number
+        is_following: boolean
+      }
+      expect(data.follower_count).toBe(10)
+      expect(data.is_following).toBe(false)
+    })
+
+    it('handles mutation error gracefully', async () => {
+      const error = new Error('Unauthorized')
+      Object.assign(error, { status: 401 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(() => useFollow(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({ entityType: 'artists', entityId: 1 })
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+      expect((result.current.error as Error).message).toBe('Unauthorized')
+    })
+  })
+
+  describe('useUnfollow', () => {
+    it('sends DELETE to unfollow an entity', async () => {
+      mockApiRequest.mockResolvedValueOnce({
+        success: true,
+        message: 'Unfollowed',
+      })
+
+      const { result } = renderHook(() => useUnfollow(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({ entityType: 'artists', entityId: 1 })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/api/artists/1/follow', {
+        method: 'DELETE',
+      })
+    })
+
+    it('optimistically updates unfollow status', async () => {
+      const queryClient = createRetainingQueryClient()
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      )
+
+      // Seed the cache with following status
+      queryClient.setQueryData(['follows', 'artists', 1], {
+        entity_type: 'artists',
+        entity_id: 1,
+        follower_count: 10,
+        is_following: true,
+      })
+
+      // Use a deferred promise so the mutation stays in-flight
+      let resolveApi!: (value: unknown) => void
+      mockApiRequest.mockImplementation(
+        () => new Promise((resolve) => { resolveApi = resolve })
+      )
+
+      const { result } = renderHook(() => useUnfollow(), { wrapper })
+
+      act(() => {
+        result.current.mutate({ entityType: 'artists', entityId: 1 })
+      })
+
+      // Check optimistic update was applied while mutation is still pending
+      await waitFor(() => {
+        const data = queryClient.getQueryData(['follows', 'artists', 1]) as {
+          follower_count: number
+          is_following: boolean
+        }
+        expect(data).toBeDefined()
+        expect(data.follower_count).toBe(9)
+        expect(data.is_following).toBe(false)
+      })
+
+      // Resolve to clean up
+      await act(async () => {
+        resolveApi({ success: true, message: 'Unfollowed' })
+      })
+    })
+
+    it('does not decrement follower_count below zero', async () => {
+      const queryClient = createRetainingQueryClient()
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      )
+
+      // Seed cache with follower_count of 0
+      queryClient.setQueryData(['follows', 'artists', 1], {
+        entity_type: 'artists',
+        entity_id: 1,
+        follower_count: 0,
+        is_following: true,
+      })
+
+      // Use a deferred promise so the mutation stays in-flight
+      let resolveApi!: (value: unknown) => void
+      mockApiRequest.mockImplementation(
+        () => new Promise((resolve) => { resolveApi = resolve })
+      )
+
+      const { result } = renderHook(() => useUnfollow(), { wrapper })
+
+      act(() => {
+        result.current.mutate({ entityType: 'artists', entityId: 1 })
+      })
+
+      await waitFor(() => {
+        const data = queryClient.getQueryData(['follows', 'artists', 1]) as {
+          follower_count: number
+          is_following: boolean
+        }
+        expect(data).toBeDefined()
+        expect(data.follower_count).toBe(0)
+        expect(data.is_following).toBe(false)
+      })
+
+      // Resolve to clean up
+      await act(async () => {
+        resolveApi({ success: true, message: 'Unfollowed' })
+      })
+    })
+
+    it('rolls back optimistic update on error', async () => {
+      const queryClient = createRetainingQueryClient()
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      )
+
+      const originalData = {
+        entity_type: 'artists',
+        entity_id: 1,
+        follower_count: 10,
+        is_following: true,
+      }
+      queryClient.setQueryData(['follows', 'artists', 1], originalData)
+
+      // First call rejects (the mutation), second call returns original data (the refetch from onSettled)
+      mockApiRequest
+        .mockRejectedValueOnce(new Error('Network error'))
+        .mockResolvedValueOnce(originalData)
+
+      const { result } = renderHook(() => useUnfollow(), { wrapper })
+
+      await act(async () => {
+        result.current.mutate({ entityType: 'artists', entityId: 1 })
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+
+      const data = queryClient.getQueryData(['follows', 'artists', 1]) as {
+        follower_count: number
+        is_following: boolean
+      }
+      expect(data.follower_count).toBe(10)
+      expect(data.is_following).toBe(true)
+    })
+  })
+
+  describe('useMyFollowing', () => {
+    it('fetches the authenticated user following list', async () => {
+      const mockResponse = {
+        following: [
+          {
+            entity_type: 'artists',
+            entity_id: 1,
+            name: 'Test Artist',
+            slug: 'test-artist',
+            followed_at: '2026-01-01T00:00:00Z',
+          },
+        ],
+        total: 1,
+        limit: 20,
+        offset: 0,
+      }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(() => useMyFollowing(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(result.current.data?.following).toHaveLength(1)
+      expect(result.current.data?.following[0].name).toBe('Test Artist')
+    })
+
+    it('does not fetch when user is not authenticated', () => {
+      mockIsAuthenticated.mockReturnValue(false)
+
+      const { result } = renderHook(() => useMyFollowing(), {
+        wrapper: createWrapper(),
+      })
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('includes type filter in query params', async () => {
+      mockApiRequest.mockResolvedValueOnce({
+        following: [],
+        total: 0,
+        limit: 20,
+        offset: 0,
+      })
+
+      const { result } = renderHook(
+        () => useMyFollowing({ type: 'artists' }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      const calledUrl = mockApiRequest.mock.calls[0][0] as string
+      expect(calledUrl).toContain('type=artists')
+    })
+
+    it('does not include type param when type is all', async () => {
+      mockApiRequest.mockResolvedValueOnce({
+        following: [],
+        total: 0,
+        limit: 20,
+        offset: 0,
+      })
+
+      const { result } = renderHook(
+        () => useMyFollowing({ type: 'all' }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      const calledUrl = mockApiRequest.mock.calls[0][0] as string
+      expect(calledUrl).not.toContain('type=')
+    })
+
+    it('includes limit and offset in query params', async () => {
+      mockApiRequest.mockResolvedValueOnce({
+        following: [],
+        total: 0,
+        limit: 10,
+        offset: 20,
+      })
+
+      const { result } = renderHook(
+        () => useMyFollowing({ limit: 10, offset: 20 }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      const calledUrl = mockApiRequest.mock.calls[0][0] as string
+      expect(calledUrl).toContain('limit=10')
+      expect(calledUrl).toContain('offset=20')
+    })
+
+    it('uses default limit and offset', async () => {
+      mockApiRequest.mockResolvedValueOnce({
+        following: [],
+        total: 0,
+        limit: 20,
+        offset: 0,
+      })
+
+      const { result } = renderHook(() => useMyFollowing(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      const calledUrl = mockApiRequest.mock.calls[0][0] as string
+      expect(calledUrl).toContain('limit=20')
+      expect(calledUrl).toContain('offset=0')
+    })
+
+    it('handles API errors', async () => {
+      const error = new Error('Unauthorized')
+      Object.assign(error, { status: 401 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(() => useMyFollowing(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+    })
+  })
+})

--- a/frontend/lib/hooks/common/useRevisions.test.tsx
+++ b/frontend/lib/hooks/common/useRevisions.test.tsx
@@ -1,0 +1,420 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createWrapper, createTestQueryClient } from '@/test/utils'
+
+// Create mocks
+const mockApiRequest = vi.fn()
+
+// Mock the api module
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    REVISIONS: {
+      ENTITY_HISTORY: (entityType: string, entityId: string | number) =>
+        `/api/revisions/${entityType}/${entityId}`,
+      DETAIL: (revisionId: number) => `/api/revisions/${revisionId}`,
+      USER_REVISIONS: (userId: string | number) =>
+        `/api/users/${userId}/revisions`,
+      ROLLBACK: (revisionId: number) =>
+        `/api/admin/revisions/${revisionId}/rollback`,
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+// Mock queryClient module
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    revisions: {
+      all: ['revisions'] as const,
+      entity: (entityType: string, entityId: string | number) =>
+        ['revisions', 'entity', entityType, String(entityId)] as const,
+      detail: (revisionId: number) =>
+        ['revisions', 'detail', revisionId] as const,
+      user: (userId: string | number) =>
+        ['revisions', 'user', String(userId)] as const,
+    },
+  },
+}))
+
+// Import hooks after mocks are set up
+import {
+  useEntityRevisions,
+  useRevision,
+  useUserRevisions,
+  useRollbackRevision,
+} from './useRevisions'
+
+const mockRevisions = [
+  {
+    id: 1,
+    entity_type: 'artist',
+    entity_id: 42,
+    user_id: 10,
+    user_name: 'admin',
+    changes: [
+      { field: 'name', old_value: 'Old Name', new_value: 'New Name' },
+    ],
+    summary: 'Updated artist name',
+    created_at: '2026-03-01T12:00:00Z',
+  },
+  {
+    id: 2,
+    entity_type: 'artist',
+    entity_id: 42,
+    user_id: 11,
+    user_name: 'contributor',
+    changes: [
+      { field: 'city', old_value: 'Phoenix', new_value: 'Tempe' },
+      { field: 'state', old_value: 'AZ', new_value: 'AZ' },
+    ],
+    summary: 'Updated location',
+    created_at: '2026-03-02T14:00:00Z',
+  },
+]
+
+describe('useRevisions hooks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  describe('useEntityRevisions', () => {
+    it('fetches revision history for an entity', async () => {
+      const mockResponse = { revisions: mockRevisions, total: 2 }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(
+        () => useEntityRevisions('artist', 42),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/api/revisions/artist/42?limit=20'
+      )
+      expect(result.current.data?.revisions).toHaveLength(2)
+      expect(result.current.data?.total).toBe(2)
+    })
+
+    it('accepts string entity ID', async () => {
+      mockApiRequest.mockResolvedValueOnce({ revisions: [], total: 0 })
+
+      const { result } = renderHook(
+        () => useEntityRevisions('venue', 'the-rebel-lounge'),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/api/revisions/venue/the-rebel-lounge?limit=20'
+      )
+    })
+
+    it('includes custom limit and offset in query params', async () => {
+      mockApiRequest.mockResolvedValueOnce({ revisions: [], total: 0 })
+
+      const { result } = renderHook(
+        () => useEntityRevisions('artist', 42, { limit: 10, offset: 5 }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      const calledUrl = mockApiRequest.mock.calls[0][0] as string
+      expect(calledUrl).toContain('limit=10')
+      expect(calledUrl).toContain('offset=5')
+    })
+
+    it('uses default limit of 20 and offset of 0', async () => {
+      mockApiRequest.mockResolvedValueOnce({ revisions: [], total: 0 })
+
+      const { result } = renderHook(
+        () => useEntityRevisions('artist', 42),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      const calledUrl = mockApiRequest.mock.calls[0][0] as string
+      expect(calledUrl).toContain('limit=20')
+      // offset=0 is falsy, so it won't be in the URL
+      expect(calledUrl).not.toContain('offset=')
+    })
+
+    it('can be disabled via enabled option', () => {
+      const { result } = renderHook(
+        () => useEntityRevisions('artist', 42, { enabled: false }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('is enabled by default when enabled is not specified', async () => {
+      mockApiRequest.mockResolvedValueOnce({ revisions: [], total: 0 })
+
+      const { result } = renderHook(
+        () => useEntityRevisions('artist', 42),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      expect(mockApiRequest).toHaveBeenCalled()
+    })
+
+    it('handles API errors', async () => {
+      const error = new Error('Server error')
+      Object.assign(error, { status: 500 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(
+        () => useEntityRevisions('artist', 42),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+      expect(result.current.error).toBeDefined()
+    })
+
+    it('returns revision data with field changes', async () => {
+      const mockResponse = { revisions: mockRevisions, total: 2 }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(
+        () => useEntityRevisions('artist', 42),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      const firstRevision = result.current.data?.revisions[0]
+      expect(firstRevision?.changes).toHaveLength(1)
+      expect(firstRevision?.changes[0].field).toBe('name')
+      expect(firstRevision?.changes[0].old_value).toBe('Old Name')
+      expect(firstRevision?.changes[0].new_value).toBe('New Name')
+      expect(firstRevision?.user_name).toBe('admin')
+    })
+  })
+
+  describe('useRevision', () => {
+    it('fetches a single revision by ID', async () => {
+      const mockRevision = mockRevisions[0]
+      mockApiRequest.mockResolvedValueOnce(mockRevision)
+
+      const { result } = renderHook(() => useRevision(1), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/api/revisions/1'
+      )
+      expect(result.current.data?.id).toBe(1)
+      expect(result.current.data?.summary).toBe('Updated artist name')
+    })
+
+    it('does not fetch when revisionId is 0', () => {
+      const { result } = renderHook(() => useRevision(0), {
+        wrapper: createWrapper(),
+      })
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('does not fetch when revisionId is negative', () => {
+      const { result } = renderHook(() => useRevision(-1), {
+        wrapper: createWrapper(),
+      })
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('can be disabled via enabled option', () => {
+      const { result } = renderHook(
+        () => useRevision(1, { enabled: false }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('handles not found error', async () => {
+      const error = new Error('Revision not found')
+      Object.assign(error, { status: 404 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(() => useRevision(999), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+      expect((result.current.error as Error).message).toBe(
+        'Revision not found'
+      )
+    })
+  })
+
+  describe('useUserRevisions', () => {
+    it('fetches revisions for a specific user', async () => {
+      const mockResponse = { revisions: mockRevisions, total: 2 }
+      mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+      const { result } = renderHook(() => useUserRevisions(10), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/api/users/10/revisions?limit=20'
+      )
+      expect(result.current.data?.revisions).toHaveLength(2)
+    })
+
+    it('accepts string user ID', async () => {
+      mockApiRequest.mockResolvedValueOnce({ revisions: [], total: 0 })
+
+      const { result } = renderHook(() => useUserRevisions('42'), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/api/users/42/revisions?limit=20'
+      )
+    })
+
+    it('includes custom limit and offset in query params', async () => {
+      mockApiRequest.mockResolvedValueOnce({ revisions: [], total: 0 })
+
+      const { result } = renderHook(
+        () => useUserRevisions(10, { limit: 5, offset: 10 }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      const calledUrl = mockApiRequest.mock.calls[0][0] as string
+      expect(calledUrl).toContain('limit=5')
+      expect(calledUrl).toContain('offset=10')
+    })
+
+    it('can be disabled via enabled option', () => {
+      const { result } = renderHook(
+        () => useUserRevisions(10, { enabled: false }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('handles API errors', async () => {
+      const error = new Error('Forbidden')
+      Object.assign(error, { status: 403 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(() => useUserRevisions(10), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+    })
+  })
+
+  describe('useRollbackRevision', () => {
+    it('sends POST to rollback a revision', async () => {
+      mockApiRequest.mockResolvedValueOnce({ success: true })
+
+      const { result } = renderHook(() => useRollbackRevision(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate(1)
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/api/admin/revisions/1/rollback',
+        { method: 'POST' }
+      )
+    })
+
+    it('invalidates revision queries on success', async () => {
+      const queryClient = createTestQueryClient()
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      )
+
+      const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+      mockApiRequest.mockResolvedValueOnce({ success: true })
+
+      const { result } = renderHook(() => useRollbackRevision(), { wrapper })
+
+      await act(async () => {
+        result.current.mutate(1)
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ['revisions'],
+      })
+    })
+
+    it('handles rollback error', async () => {
+      const error = new Error('Forbidden')
+      Object.assign(error, { status: 403 })
+      mockApiRequest.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(() => useRollbackRevision(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate(999)
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+      expect((result.current.error as Error).message).toBe('Forbidden')
+    })
+
+    it('does not invalidate queries on error', async () => {
+      const queryClient = createTestQueryClient()
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      )
+
+      const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+      mockApiRequest.mockRejectedValueOnce(new Error('Server error'))
+
+      const { result } = renderHook(() => useRollbackRevision(), { wrapper })
+
+      await act(async () => {
+        result.current.mutate(1)
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+
+      // onSuccess should not have been called, so no invalidation
+      expect(invalidateSpy).not.toHaveBeenCalledWith({
+        queryKey: ['revisions'],
+      })
+    })
+  })
+})

--- a/frontend/lib/utils/showDateBadge.test.ts
+++ b/frontend/lib/utils/showDateBadge.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest'
+import { formatShowDateBadge } from './showDateBadge'
+
+describe('formatShowDateBadge', () => {
+  it('formats a date string into badge parts for Arizona (default)', () => {
+    // 2026-03-17T03:00:00Z in America/Phoenix (UTC-7, no DST) = March 16 at 8:00 PM
+    // Use a date that maps cleanly to avoid cross-day issues
+    const result = formatShowDateBadge('2026-03-17T19:00:00Z')
+    // In Phoenix (UTC-7): March 17 at 12:00 PM
+    expect(result.dayOfWeek).toMatch(/^[A-Z]{3}$/) // e.g. "TUE"
+    expect(result.monthDay).toMatch(/^[A-Z]{3} \d{1,2}$/) // e.g. "MAR 17"
+  })
+
+  it('returns uppercase day of week', () => {
+    const result = formatShowDateBadge('2026-01-05T20:00:00Z', 'AZ')
+    // Jan 5 2026 at 20:00 UTC = Jan 5 at 13:00 Phoenix time = Monday
+    expect(result.dayOfWeek).toBe('MON')
+  })
+
+  it('returns uppercase month in monthDay', () => {
+    const result = formatShowDateBadge('2026-06-15T03:00:00Z', 'AZ')
+    // June 14 in Phoenix (UTC-7)
+    expect(result.monthDay).toMatch(/^JUN/)
+  })
+
+  it('uses Arizona timezone by default when state is not provided', () => {
+    const result = formatShowDateBadge('2026-03-20T02:00:00Z')
+    // In Phoenix: March 19 at 7:00 PM
+    expect(result.dayOfWeek).toBe('THU')
+    expect(result.monthDay).toBe('MAR 19')
+  })
+
+  it('uses Arizona timezone when state is null', () => {
+    const result = formatShowDateBadge('2026-03-20T02:00:00Z', null)
+    // Same as default — should use AZ
+    expect(result.dayOfWeek).toBe('THU')
+    expect(result.monthDay).toBe('MAR 19')
+  })
+
+  it('handles California timezone', () => {
+    // March 2026: CA is on PDT (UTC-7), same as AZ (no DST)
+    // Actually, DST starts March 8 2026 in CA, so PDT = UTC-7
+    const result = formatShowDateBadge('2026-03-20T02:00:00Z', 'CA')
+    // In LA (PDT, UTC-7): March 19 at 7:00 PM
+    expect(result.dayOfWeek).toBe('THU')
+    expect(result.monthDay).toBe('MAR 19')
+  })
+
+  it('handles New York timezone', () => {
+    // March 2026: NY is on EDT (UTC-4), DST starts March 8 2026
+    const result = formatShowDateBadge('2026-03-20T02:00:00Z', 'NY')
+    // In NY (EDT, UTC-4): March 19 at 10:00 PM
+    expect(result.dayOfWeek).toBe('THU')
+    expect(result.monthDay).toBe('MAR 19')
+  })
+
+  it('handles Texas timezone', () => {
+    // March 2026: TX is on CDT (UTC-5)
+    const result = formatShowDateBadge('2026-03-20T02:00:00Z', 'TX')
+    // In TX (CDT, UTC-5): March 19 at 9:00 PM
+    expect(result.dayOfWeek).toBe('THU')
+    expect(result.monthDay).toBe('MAR 19')
+  })
+
+  it('handles date crossing midnight in venue timezone', () => {
+    // A show at 6:00 AM UTC in Phoenix (UTC-7) would be March 19 at 11:00 PM
+    const result = formatShowDateBadge('2026-03-20T06:00:00Z', 'AZ')
+    // Phoenix: March 19 at 11:00 PM
+    expect(result.dayOfWeek).toBe('THU')
+    expect(result.monthDay).toBe('MAR 19')
+  })
+
+  it('handles date not crossing midnight', () => {
+    // A show at 8:00 PM UTC in Phoenix (UTC-7) would be March 20 at 1:00 PM
+    const result = formatShowDateBadge('2026-03-20T20:00:00Z', 'AZ')
+    // Phoenix: March 20 at 1:00 PM
+    expect(result.dayOfWeek).toBe('FRI')
+    expect(result.monthDay).toBe('MAR 20')
+  })
+
+  it('defaults to AZ for unknown state codes', () => {
+    // Unknown state should fall back to America/Phoenix
+    const resultUnknown = formatShowDateBadge('2026-03-20T20:00:00Z', 'XX')
+    const resultAZ = formatShowDateBadge('2026-03-20T20:00:00Z', 'AZ')
+
+    expect(resultUnknown.dayOfWeek).toBe(resultAZ.dayOfWeek)
+    expect(resultUnknown.monthDay).toBe(resultAZ.monthDay)
+  })
+
+  it('handles winter dates (no DST difference for AZ)', () => {
+    // December 15 2026 at 3:00 AM UTC in Phoenix (UTC-7) = Dec 14 at 8:00 PM
+    const result = formatShowDateBadge('2026-12-15T03:00:00Z', 'AZ')
+    expect(result.dayOfWeek).toBe('MON')
+    expect(result.monthDay).toBe('DEC 14')
+  })
+
+  it('handles New Year boundary', () => {
+    // January 1 2026 at 10:00 UTC in Phoenix = Dec 31 at 3:00 AM... actually
+    // Jan 1 at 10:00 UTC = Jan 1 at 3:00 AM Phoenix
+    const result = formatShowDateBadge('2026-01-01T10:00:00Z', 'AZ')
+    expect(result.dayOfWeek).toBe('THU')
+    expect(result.monthDay).toBe('JAN 1')
+  })
+
+  it('returns correct structure shape', () => {
+    const result = formatShowDateBadge('2026-07-04T19:00:00Z', 'AZ')
+
+    expect(result).toHaveProperty('dayOfWeek')
+    expect(result).toHaveProperty('monthDay')
+    expect(typeof result.dayOfWeek).toBe('string')
+    expect(typeof result.monthDay).toBe('string')
+  })
+
+  it('formats single-digit days without leading zero', () => {
+    // March 5 2026
+    const result = formatShowDateBadge('2026-03-05T20:00:00Z', 'AZ')
+    // Phoenix: March 5 at 1:00 PM
+    expect(result.monthDay).toBe('MAR 5')
+  })
+})


### PR DESCRIPTION
## Summary
- Adds **417 new frontend unit tests** across **25 test files**, raising the total from ~1,468 to 1,885
- Covers previously untested hooks and utilities across 6 areas:
  - **Core common hooks**: `useDensity`, `useFollow` (with optimistic updates), `useRevisions`
  - **Show mutations**: `useShowSubmit`, `useShowUpdate`, `useShowDelete`, `useAttendance` (optimistic updates + rollback), `useShowReports`
  - **Feature modules** (all previously at 0%): collections, festivals, labels, releases, scenes
  - **Admin hooks**: `useAdminStats`, `useAdminReports`, `useAdminArtistReports`, `useAdminUsers`, `useDataQuality`
  - **Auth/venue hooks**: `useCalendarFeed`, `useContributorProfile` (22 tests), `useFavoriteCities`, `useArtistSearch`, `useArtistReports`, `useVenueSearch`
  - **Utility**: `showDateBadge` (timezone-aware date formatting)

## Test plan
- [x] All 1,885 tests pass (`bun run test:run`)
- [x] No existing tests broken
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)