### PR TITLE
Fix show date timezone normalization in CLI

### DIFF
--- a/cli/src/commands/submit-show.ts
+++ b/cli/src/commands/submit-show.ts
@@ -7,10 +7,14 @@ import type { TagInput, ResolvedTag } from "../lib/tags";
 import * as display from "../lib/display";
 import { green, yellow, dim, gray } from "../lib/ansi";
 
-/** Normalize a date string to ISO 8601. Adds T20:00:00Z if only YYYY-MM-DD. */
+/** Normalize a date string to ISO 8601. Adds T20:00:00Z if only YYYY-MM-DD, appends Z if missing timezone. */
 function normalizeDate(date: string): string {
   if (/^\d{4}-\d{2}-\d{2}$/.test(date)) {
     return `${date}T20:00:00Z`;
+  }
+  // If has time but no timezone suffix (Z or +/-offset), append Z
+  if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2})?$/.test(date)) {
+    return `${date}Z`;
   }
   return date;
 }


### PR DESCRIPTION
## Summary
- `normalizeDate()` now appends `Z` to naive datetimes (e.g. `2026-04-04T19:00:00` → `2026-04-04T19:00:00Z`)
- Previously only handled bare `YYYY-MM-DD` dates, passing through datetimes without timezone suffix unchanged
- Backend requires ISO 8601 with timezone and returned 422 for naive datetimes

Closes PSY-177

## Test plan
- [ ] `ph --env stage submit show '[{"event_date": "2026-05-01T20:00:00", ...}]'` no longer returns 422
- [ ] Bare dates (`2026-05-01`) still normalize to `T20:00:00Z`
- [ ] Dates with timezone (`2026-05-01T20:00:00Z`, `2026-05-01T20:00:00-07:00`) pass through unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)