### PR TITLE
Add 91 frontend unit tests across 9 files

### DIFF
--- a/frontend/features/artists/hooks/useArtistReports.test.tsx
+++ b/frontend/features/artists/hooks/useArtistReports.test.tsx
@@ -1,0 +1,289 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createWrapper, createTestQueryClient } from '@/test/utils'
+
+// Create mocks
+const mockApiRequest = vi.fn()
+const mockInvalidateArtistReports = vi.fn()
+
+// Mock the api module
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    ARTISTS: {
+      REPORT: (artistId: string | number) => `/artists/${artistId}/report`,
+      MY_REPORT: (artistId: string | number) => `/artists/${artistId}/my-report`,
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+// Mock queryClient module
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    artistReports: {
+      myReport: (artistId: string | number) =>
+        ['artistReports', 'myReport', String(artistId)],
+    },
+  },
+  createInvalidateQueries: () => ({
+    artistReports: mockInvalidateArtistReports,
+  }),
+}))
+
+// Import hooks after mocks are set up
+import { useMyArtistReport, useReportArtist } from './useArtistReports'
+
+describe('useMyArtistReport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches the user\'s existing report for an artist', async () => {
+    const mockResponse = {
+      report: {
+        id: 1,
+        artist_id: 42,
+        report_type: 'inaccurate',
+        details: 'Wrong city listed',
+        status: 'pending',
+        created_at: '2025-03-01T00:00:00Z',
+        updated_at: '2025-03-01T00:00:00Z',
+      },
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useMyArtistReport(42), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/artists/42/my-report', {
+      method: 'GET',
+    })
+    expect(result.current.data?.report?.report_type).toBe('inaccurate')
+    expect(result.current.data?.report?.status).toBe('pending')
+  })
+
+  it('returns null report when user has not reported', async () => {
+    mockApiRequest.mockResolvedValueOnce({ report: null })
+
+    const { result } = renderHook(() => useMyArtistReport(42), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data?.report).toBeNull()
+  })
+
+  it('does not fetch when artistId is null', () => {
+    const { result } = renderHook(() => useMyArtistReport(null), {
+      wrapper: createWrapper(),
+    })
+
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('accepts string artistId', async () => {
+    mockApiRequest.mockResolvedValueOnce({ report: null })
+
+    const { result } = renderHook(() => useMyArtistReport('42'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/artists/42/my-report', {
+      method: 'GET',
+    })
+  })
+
+  it('handles API errors', async () => {
+    const error = new Error('Unauthorized')
+    Object.assign(error, { status: 401 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useMyArtistReport(42), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect((result.current.error as Error).message).toBe('Unauthorized')
+  })
+
+  it('accepts numeric artistId 0 as falsy — does not fetch', () => {
+    const { result } = renderHook(() => useMyArtistReport(0), {
+      wrapper: createWrapper(),
+    })
+
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+})
+
+describe('useReportArtist', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateArtistReports.mockReset()
+  })
+
+  it('creates a report and invalidates queries', async () => {
+    const mockResponse = {
+      id: 10,
+      artist_id: 42,
+      report_type: 'inaccurate',
+      details: 'Wrong social links',
+      status: 'pending',
+      created_at: '2025-03-15T00:00:00Z',
+      updated_at: '2025-03-15T00:00:00Z',
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useReportArtist(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      const data = await result.current.mutateAsync({
+        artistId: 42,
+        reportType: 'inaccurate',
+        details: 'Wrong social links',
+      })
+      expect(data.id).toBe(10)
+      expect(data.report_type).toBe('inaccurate')
+      expect(data.status).toBe('pending')
+    })
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/artists/42/report', {
+      method: 'POST',
+      body: JSON.stringify({
+        report_type: 'inaccurate',
+        details: 'Wrong social links',
+      }),
+    })
+    expect(mockInvalidateArtistReports).toHaveBeenCalled()
+  })
+
+  it('creates a report without details', async () => {
+    const mockResponse = {
+      id: 11,
+      artist_id: 42,
+      report_type: 'removal_request',
+      details: null,
+      status: 'pending',
+      created_at: '2025-03-15T00:00:00Z',
+      updated_at: '2025-03-15T00:00:00Z',
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useReportArtist(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        artistId: 42,
+        reportType: 'removal_request',
+      })
+    })
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/artists/42/report', {
+      method: 'POST',
+      body: JSON.stringify({
+        report_type: 'removal_request',
+        details: null,
+      }),
+    })
+  })
+
+  it('handles duplicate report error', async () => {
+    const error = new Error('You have already reported this artist')
+    Object.assign(error, { status: 409 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useReportArtist(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({
+          artistId: 42,
+          reportType: 'inaccurate',
+          details: 'Test',
+        })
+      } catch (e) {
+        expect((e as Error).message).toBe(
+          'You have already reported this artist'
+        )
+      }
+    })
+
+    expect(mockInvalidateArtistReports).not.toHaveBeenCalled()
+  })
+
+  it('handles server errors', async () => {
+    const error = new Error('Internal server error')
+    Object.assign(error, { status: 500 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useReportArtist(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({
+          artistId: 42,
+          reportType: 'inaccurate',
+        })
+      } catch (e) {
+        expect((e as Error).message).toBe('Internal server error')
+      }
+    })
+
+    expect(mockInvalidateArtistReports).not.toHaveBeenCalled()
+  })
+
+  it('handles empty string details as null', async () => {
+    const mockResponse = {
+      id: 12,
+      artist_id: 42,
+      report_type: 'inaccurate',
+      details: null,
+      status: 'pending',
+      created_at: '2025-03-15T00:00:00Z',
+      updated_at: '2025-03-15T00:00:00Z',
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useReportArtist(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        artistId: 42,
+        reportType: 'inaccurate',
+        details: '',
+      })
+    })
+
+    // The hook sends `details || null`, so empty string becomes null
+    expect(mockApiRequest).toHaveBeenCalledWith('/artists/42/report', {
+      method: 'POST',
+      body: JSON.stringify({
+        report_type: 'inaccurate',
+        details: null,
+      }),
+    })
+  })
+})

--- a/frontend/features/artists/hooks/useArtistSearch.test.tsx
+++ b/frontend/features/artists/hooks/useArtistSearch.test.tsx
@@ -1,0 +1,196 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createWrapper, createTestQueryClient } from '@/test/utils'
+
+// Create mocks
+const mockApiRequest = vi.fn()
+
+// Mock the api module
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    ARTISTS: {
+      SEARCH: '/artists/search',
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+// Mock queryClient module
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    artists: {
+      search: (query: string) => ['artists', 'search', query.toLowerCase()],
+    },
+  },
+}))
+
+// Mock use-debounce to make tests synchronous
+vi.mock('use-debounce', () => ({
+  useDebounce: (value: string, _delay: number) => [value],
+}))
+
+// Import hooks after mocks are set up
+import { useArtistSearch } from './useArtistSearch'
+
+describe('useArtistSearch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches artists matching the search query', async () => {
+    const mockResponse = {
+      artists: [
+        {
+          id: 1,
+          slug: 'test-artist',
+          name: 'Test Artist',
+          city: 'Phoenix',
+          state: 'AZ',
+          social: {},
+        },
+        {
+          id: 2,
+          slug: 'test-band',
+          name: 'Test Band',
+          city: 'Tempe',
+          state: 'AZ',
+          social: {},
+        },
+      ],
+      count: 2,
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(
+      () => useArtistSearch({ query: 'test' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/artists/search?q=test')
+    expect(result.current.data?.artists).toHaveLength(2)
+    expect(result.current.data?.count).toBe(2)
+  })
+
+  it('does not fetch when query is empty', () => {
+    const { result } = renderHook(
+      () => useArtistSearch({ query: '' }),
+      { wrapper: createWrapper() }
+    )
+
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('URL-encodes special characters in query', async () => {
+    mockApiRequest.mockResolvedValueOnce({ artists: [], count: 0 })
+
+    const { result } = renderHook(
+      () => useArtistSearch({ query: 'AT&T Center' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/artists/search?q=AT%26T%20Center'
+    )
+  })
+
+  it('handles API errors', async () => {
+    const error = new Error('Server error')
+    Object.assign(error, { status: 500 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(
+      () => useArtistSearch({ query: 'test' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect(result.current.error).toBeDefined()
+  })
+
+  it('returns empty results for no matches', async () => {
+    mockApiRequest.mockResolvedValueOnce({ artists: [], count: 0 })
+
+    const { result } = renderHook(
+      () => useArtistSearch({ query: 'zzzznonexistent' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data?.artists).toHaveLength(0)
+    expect(result.current.data?.count).toBe(0)
+  })
+
+  it('accepts custom debounce delay', async () => {
+    mockApiRequest.mockResolvedValueOnce({ artists: [], count: 0 })
+
+    const { result } = renderHook(
+      () => useArtistSearch({ query: 'test', debounceMs: 500 }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    // Since use-debounce is mocked, it resolves immediately regardless of delay
+    expect(mockApiRequest).toHaveBeenCalledWith('/artists/search?q=test')
+  })
+
+  it('returns loading state while fetching', () => {
+    // Make the request hang
+    mockApiRequest.mockReturnValue(new Promise(() => {}))
+
+    const { result } = renderHook(
+      () => useArtistSearch({ query: 'loading' }),
+      { wrapper: createWrapper() }
+    )
+
+    expect(result.current.isLoading).toBe(true)
+    expect(result.current.data).toBeUndefined()
+  })
+
+  it('returns artist details in response', async () => {
+    const mockResponse = {
+      artists: [
+        {
+          id: 5,
+          slug: 'sonic-youth',
+          name: 'Sonic Youth',
+          city: 'New York',
+          state: 'NY',
+          bandcamp_embed_url: null,
+          social: {
+            bandcamp: 'https://sonicyouth.bandcamp.com',
+            spotify: null,
+            instagram: null,
+          },
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-06-01T00:00:00Z',
+        },
+      ],
+      count: 1,
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(
+      () => useArtistSearch({ query: 'sonic' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const artist = result.current.data?.artists[0]
+    expect(artist?.name).toBe('Sonic Youth')
+    expect(artist?.slug).toBe('sonic-youth')
+    expect(artist?.social.bandcamp).toBe('https://sonicyouth.bandcamp.com')
+  })
+})

--- a/frontend/features/auth/hooks/useCalendarFeed.test.tsx
+++ b/frontend/features/auth/hooks/useCalendarFeed.test.tsx
@@ -1,0 +1,222 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createWrapper, createTestQueryClient } from '@/test/utils'
+
+// Create mocks
+const mockApiRequest = vi.fn()
+const mockInvalidateCalendar = vi.fn()
+
+// Mock the api module
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    CALENDAR: {
+      TOKEN: '/calendar/token',
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+// Mock queryClient module
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    calendar: {
+      all: ['calendar'],
+      tokenStatus: ['calendar', 'tokenStatus'],
+    },
+  },
+  createInvalidateQueries: () => ({
+    calendar: mockInvalidateCalendar,
+  }),
+}))
+
+// Import hooks after mocks are set up
+import {
+  useCalendarTokenStatus,
+  useCreateCalendarToken,
+  useDeleteCalendarToken,
+} from './useCalendarFeed'
+
+describe('useCalendarTokenStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches token status when enabled', async () => {
+    const mockResponse = {
+      has_token: true,
+      created_at: '2025-03-01T12:00:00Z',
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useCalendarTokenStatus(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/calendar/token', {
+      method: 'GET',
+    })
+    expect(result.current.data?.has_token).toBe(true)
+    expect(result.current.data?.created_at).toBe('2025-03-01T12:00:00Z')
+  })
+
+  it('fetches when enabled is true explicitly', async () => {
+    mockApiRequest.mockResolvedValueOnce({ has_token: false })
+
+    const { result } = renderHook(() => useCalendarTokenStatus(true), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/calendar/token', {
+      method: 'GET',
+    })
+    expect(result.current.data?.has_token).toBe(false)
+  })
+
+  it('does not fetch when enabled is false', () => {
+    const { result } = renderHook(() => useCalendarTokenStatus(false), {
+      wrapper: createWrapper(),
+    })
+
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('handles API errors', async () => {
+    const error = new Error('Unauthorized')
+    Object.assign(error, { status: 401 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useCalendarTokenStatus(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect((result.current.error as Error).message).toBe('Unauthorized')
+  })
+
+  it('returns no created_at when user has no token', async () => {
+    mockApiRequest.mockResolvedValueOnce({ has_token: false })
+
+    const { result } = renderHook(() => useCalendarTokenStatus(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data?.has_token).toBe(false)
+    expect(result.current.data?.created_at).toBeUndefined()
+  })
+})
+
+describe('useCreateCalendarToken', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateCalendar.mockReset()
+  })
+
+  it('creates a calendar token and invalidates queries', async () => {
+    const mockResponse = {
+      token: 'abc123token',
+      feed_url: 'https://api.psychichomily.com/calendar/feed/abc123token',
+      created_at: '2025-03-15T10:00:00Z',
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useCreateCalendarToken(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      const data = await result.current.mutateAsync()
+      expect(data.token).toBe('abc123token')
+      expect(data.feed_url).toContain('abc123token')
+      expect(data.created_at).toBe('2025-03-15T10:00:00Z')
+    })
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/calendar/token', {
+      method: 'POST',
+    })
+    expect(mockInvalidateCalendar).toHaveBeenCalled()
+  })
+
+  it('handles creation errors', async () => {
+    const error = new Error('Server error')
+    Object.assign(error, { status: 500 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useCreateCalendarToken(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync()
+      } catch (e) {
+        expect((e as Error).message).toBe('Server error')
+      }
+    })
+
+    expect(mockInvalidateCalendar).not.toHaveBeenCalled()
+  })
+})
+
+describe('useDeleteCalendarToken', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateCalendar.mockReset()
+  })
+
+  it('deletes the calendar token and invalidates queries', async () => {
+    const mockResponse = {
+      success: true,
+      message: 'Calendar feed token deleted',
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useDeleteCalendarToken(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      const data = await result.current.mutateAsync()
+      expect(data.success).toBe(true)
+      expect(data.message).toBe('Calendar feed token deleted')
+    })
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/calendar/token', {
+      method: 'DELETE',
+    })
+    expect(mockInvalidateCalendar).toHaveBeenCalled()
+  })
+
+  it('handles deletion errors', async () => {
+    const error = new Error('Not found')
+    Object.assign(error, { status: 404 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useDeleteCalendarToken(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync()
+      } catch (e) {
+        expect((e as Error).message).toBe('Not found')
+      }
+    })
+
+    expect(mockInvalidateCalendar).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/features/auth/hooks/useContributorProfile.test.tsx
+++ b/frontend/features/auth/hooks/useContributorProfile.test.tsx
@@ -1,0 +1,674 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createWrapper, createTestQueryClient } from '@/test/utils'
+
+// Create mocks
+const mockApiRequest = vi.fn()
+const mockInvalidateOwnContributor = vi.fn()
+const mockInvalidateContributor = vi.fn()
+
+// Mock the api module
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    USERS: {
+      PROFILE: (username: string) => `/users/${username}`,
+      CONTRIBUTIONS: (username: string) => `/users/${username}/contributions`,
+    },
+    CONTRIBUTOR: {
+      OWN_PROFILE: '/auth/profile/contributor',
+      OWN_CONTRIBUTIONS: '/auth/profile/contributions',
+      VISIBILITY: '/auth/profile/visibility',
+      PRIVACY: '/auth/profile/privacy',
+      OWN_SECTIONS: '/auth/profile/sections',
+      SECTION: (sectionId: number) => `/auth/profile/sections/${sectionId}`,
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+// Mock queryClient module
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    contributor: {
+      profile: (username: string) => ['contributor', 'profile', username],
+      ownProfile: ['contributor', 'ownProfile'],
+      contributions: (username: string) => ['contributor', 'contributions', username],
+      ownContributions: ['contributor', 'ownContributions'],
+      ownSections: ['contributor', 'ownSections'],
+    },
+  },
+  createInvalidateQueries: () => ({
+    ownContributor: mockInvalidateOwnContributor,
+    contributor: mockInvalidateContributor,
+  }),
+}))
+
+// Import hooks after mocks are set up
+import {
+  usePublicProfile,
+  usePublicContributions,
+  useOwnContributorProfile,
+  useOwnContributions,
+  useOwnSections,
+  useUpdateVisibility,
+  useUpdatePrivacy,
+  useCreateSection,
+  useUpdateSection,
+  useDeleteSection,
+} from './useContributorProfile'
+
+// ============================================================================
+// Public Profile Queries
+// ============================================================================
+
+describe('usePublicProfile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches a public profile by username', async () => {
+    const mockProfile = {
+      username: 'testuser',
+      bio: 'Music enthusiast',
+      profile_visibility: 'public',
+      user_tier: 'contributor',
+      joined_at: '2024-01-15T00:00:00Z',
+      stats: {
+        shows_submitted: 42,
+        venues_submitted: 5,
+        total_contributions: 50,
+      },
+    }
+    mockApiRequest.mockResolvedValueOnce(mockProfile)
+
+    const { result } = renderHook(() => usePublicProfile('testuser'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/users/testuser', {
+      method: 'GET',
+    })
+    expect(result.current.data?.username).toBe('testuser')
+    expect(result.current.data?.stats?.shows_submitted).toBe(42)
+  })
+
+  it('does not fetch when username is empty', () => {
+    const { result } = renderHook(() => usePublicProfile(''), {
+      wrapper: createWrapper(),
+    })
+
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('handles user not found error', async () => {
+    const error = new Error('User not found')
+    Object.assign(error, { status: 404 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => usePublicProfile('nonexistent'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect((result.current.error as Error).message).toBe('User not found')
+  })
+})
+
+describe('usePublicContributions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches contributions with default options', async () => {
+    const mockResponse = {
+      contributions: [
+        {
+          id: 1,
+          action: 'created',
+          entity_type: 'show',
+          entity_id: 100,
+          entity_name: 'Cool Show',
+          created_at: '2025-03-01T00:00:00Z',
+          source: 'web',
+        },
+      ],
+      total: 1,
+      limit: 20,
+      offset: 0,
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(
+      () => usePublicContributions('testuser'),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const calledUrl = mockApiRequest.mock.calls[0][0]
+    expect(calledUrl).toContain('/users/testuser/contributions')
+    expect(calledUrl).toContain('limit=20')
+    expect(calledUrl).toContain('offset=0')
+    expect(result.current.data?.contributions).toHaveLength(1)
+  })
+
+  it('passes custom limit and offset', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      contributions: [],
+      total: 0,
+      limit: 10,
+      offset: 20,
+    })
+
+    const { result } = renderHook(
+      () => usePublicContributions('testuser', { limit: 10, offset: 20 }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const calledUrl = mockApiRequest.mock.calls[0][0]
+    expect(calledUrl).toContain('limit=10')
+    expect(calledUrl).toContain('offset=20')
+  })
+
+  it('passes entity_type filter', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      contributions: [],
+      total: 0,
+      limit: 20,
+      offset: 0,
+    })
+
+    const { result } = renderHook(
+      () =>
+        usePublicContributions('testuser', { entity_type: 'show' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const calledUrl = mockApiRequest.mock.calls[0][0]
+    expect(calledUrl).toContain('entity_type=show')
+  })
+
+  it('does not fetch when username is empty', () => {
+    const { result } = renderHook(
+      () => usePublicContributions(''),
+      { wrapper: createWrapper() }
+    )
+
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('handles API errors', async () => {
+    const error = new Error('Server error')
+    Object.assign(error, { status: 500 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(
+      () => usePublicContributions('testuser'),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+  })
+})
+
+// ============================================================================
+// Own Profile Queries
+// ============================================================================
+
+describe('useOwnContributorProfile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches the authenticated user\'s contributor profile', async () => {
+    const mockProfile = {
+      username: 'myuser',
+      bio: 'My bio',
+      profile_visibility: 'public',
+      user_tier: 'trusted_contributor',
+      joined_at: '2024-06-01T00:00:00Z',
+      privacy_settings: {
+        contributions: 'visible',
+        saved_shows: 'count_only',
+        attendance: 'visible',
+        following: 'hidden',
+        collections: 'visible',
+        last_active: 'visible',
+        profile_sections: 'visible',
+      },
+    }
+    mockApiRequest.mockResolvedValueOnce(mockProfile)
+
+    const { result } = renderHook(() => useOwnContributorProfile(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/auth/profile/contributor', {
+      method: 'GET',
+    })
+    expect(result.current.data?.username).toBe('myuser')
+    expect(result.current.data?.privacy_settings?.saved_shows).toBe('count_only')
+  })
+
+  it('handles unauthorized error', async () => {
+    const error = new Error('Unauthorized')
+    Object.assign(error, { status: 401 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useOwnContributorProfile(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+  })
+})
+
+describe('useOwnContributions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches own contributions with default options', async () => {
+    const mockResponse = {
+      contributions: [
+        {
+          id: 1,
+          action: 'created',
+          entity_type: 'venue',
+          entity_id: 10,
+          entity_name: 'New Venue',
+          created_at: '2025-02-01T00:00:00Z',
+          source: 'web',
+        },
+      ],
+      total: 1,
+      limit: 20,
+      offset: 0,
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useOwnContributions(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const calledUrl = mockApiRequest.mock.calls[0][0]
+    expect(calledUrl).toContain('/auth/profile/contributions')
+    expect(calledUrl).toContain('limit=20')
+    expect(calledUrl).toContain('offset=0')
+  })
+
+  it('passes entity_type filter', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      contributions: [],
+      total: 0,
+      limit: 20,
+      offset: 0,
+    })
+
+    const { result } = renderHook(
+      () => useOwnContributions({ entity_type: 'artist' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const calledUrl = mockApiRequest.mock.calls[0][0]
+    expect(calledUrl).toContain('entity_type=artist')
+  })
+})
+
+describe('useOwnSections', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches own profile sections', async () => {
+    const mockResponse = {
+      sections: [
+        {
+          id: 1,
+          title: 'About Me',
+          content: 'I love live music',
+          position: 0,
+          is_visible: true,
+          created_at: '2025-01-01T00:00:00Z',
+          updated_at: '2025-01-01T00:00:00Z',
+        },
+        {
+          id: 2,
+          title: 'Favorite Genres',
+          content: 'Punk, post-punk, shoegaze',
+          position: 1,
+          is_visible: true,
+          created_at: '2025-01-02T00:00:00Z',
+          updated_at: '2025-01-02T00:00:00Z',
+        },
+      ],
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useOwnSections(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/auth/profile/sections', {
+      method: 'GET',
+    })
+    expect(result.current.data?.sections).toHaveLength(2)
+    expect(result.current.data?.sections[0].title).toBe('About Me')
+  })
+})
+
+// ============================================================================
+// Mutations
+// ============================================================================
+
+describe('useUpdateVisibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateOwnContributor.mockReset()
+    mockInvalidateContributor.mockReset()
+  })
+
+  it('updates profile visibility and invalidates queries', async () => {
+    const mockResponse = {
+      username: 'testuser',
+      profile_visibility: 'private',
+      user_tier: 'contributor',
+      joined_at: '2024-01-01T00:00:00Z',
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useUpdateVisibility(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      const data = await result.current.mutateAsync({ visibility: 'private' })
+      expect(data.profile_visibility).toBe('private')
+    })
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/auth/profile/visibility', {
+      method: 'PATCH',
+      body: JSON.stringify({ visibility: 'private' }),
+    })
+    expect(mockInvalidateOwnContributor).toHaveBeenCalled()
+    expect(mockInvalidateContributor).toHaveBeenCalled()
+  })
+
+  it('handles update errors', async () => {
+    const error = new Error('Forbidden')
+    Object.assign(error, { status: 403 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useUpdateVisibility(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({ visibility: 'public' })
+      } catch (e) {
+        expect((e as Error).message).toBe('Forbidden')
+      }
+    })
+
+    expect(mockInvalidateOwnContributor).not.toHaveBeenCalled()
+    expect(mockInvalidateContributor).not.toHaveBeenCalled()
+  })
+})
+
+describe('useUpdatePrivacy', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateOwnContributor.mockReset()
+    mockInvalidateContributor.mockReset()
+  })
+
+  it('updates privacy settings and invalidates queries', async () => {
+    const mockResponse = {
+      username: 'testuser',
+      profile_visibility: 'public',
+      user_tier: 'contributor',
+      joined_at: '2024-01-01T00:00:00Z',
+      privacy_settings: {
+        contributions: 'visible',
+        saved_shows: 'hidden',
+        attendance: 'count_only',
+        following: 'hidden',
+        collections: 'visible',
+        last_active: 'hidden',
+        profile_sections: 'visible',
+      },
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useUpdatePrivacy(), {
+      wrapper: createWrapper(),
+    })
+
+    const privacyInput = {
+      saved_shows: 'hidden' as const,
+      attendance: 'count_only' as const,
+      last_active: 'hidden' as const,
+    }
+
+    await act(async () => {
+      const data = await result.current.mutateAsync(privacyInput)
+      expect(data.privacy_settings?.saved_shows).toBe('hidden')
+      expect(data.privacy_settings?.last_active).toBe('hidden')
+    })
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/auth/profile/privacy', {
+      method: 'PATCH',
+      body: JSON.stringify(privacyInput),
+    })
+    expect(mockInvalidateOwnContributor).toHaveBeenCalled()
+    expect(mockInvalidateContributor).toHaveBeenCalled()
+  })
+})
+
+describe('useCreateSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateOwnContributor.mockReset()
+    mockInvalidateContributor.mockReset()
+  })
+
+  it('creates a new section and invalidates queries', async () => {
+    const mockResponse = {
+      id: 3,
+      title: 'New Section',
+      content: 'Some content',
+      position: 2,
+      is_visible: true,
+      created_at: '2025-03-15T00:00:00Z',
+      updated_at: '2025-03-15T00:00:00Z',
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useCreateSection(), {
+      wrapper: createWrapper(),
+    })
+
+    const input = {
+      title: 'New Section',
+      content: 'Some content',
+      position: 2,
+    }
+
+    await act(async () => {
+      const data = await result.current.mutateAsync(input)
+      expect(data.id).toBe(3)
+      expect(data.title).toBe('New Section')
+    })
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/auth/profile/sections', {
+      method: 'POST',
+      body: JSON.stringify(input),
+    })
+    expect(mockInvalidateOwnContributor).toHaveBeenCalled()
+    expect(mockInvalidateContributor).toHaveBeenCalled()
+  })
+
+  it('handles creation errors', async () => {
+    const error = new Error('Validation failed')
+    Object.assign(error, { status: 422 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useCreateSection(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({
+          title: '',
+          content: '',
+          position: 0,
+        })
+      } catch (e) {
+        expect((e as Error).message).toBe('Validation failed')
+      }
+    })
+
+    expect(mockInvalidateOwnContributor).not.toHaveBeenCalled()
+  })
+})
+
+describe('useUpdateSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateOwnContributor.mockReset()
+    mockInvalidateContributor.mockReset()
+  })
+
+  it('updates a section and invalidates queries', async () => {
+    const mockResponse = {
+      id: 1,
+      title: 'Updated Title',
+      content: 'Updated content',
+      position: 0,
+      is_visible: true,
+      created_at: '2025-01-01T00:00:00Z',
+      updated_at: '2025-03-15T00:00:00Z',
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useUpdateSection(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      const data = await result.current.mutateAsync({
+        sectionId: 1,
+        data: { title: 'Updated Title', content: 'Updated content' },
+      })
+      expect(data.title).toBe('Updated Title')
+    })
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/auth/profile/sections/1', {
+      method: 'PUT',
+      body: JSON.stringify({ title: 'Updated Title', content: 'Updated content' }),
+    })
+    expect(mockInvalidateOwnContributor).toHaveBeenCalled()
+    expect(mockInvalidateContributor).toHaveBeenCalled()
+  })
+
+  it('handles section not found error', async () => {
+    const error = new Error('Section not found')
+    Object.assign(error, { status: 404 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useUpdateSection(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({
+          sectionId: 999,
+          data: { title: 'Test' },
+        })
+      } catch (e) {
+        expect((e as Error).message).toBe('Section not found')
+      }
+    })
+
+    expect(mockInvalidateOwnContributor).not.toHaveBeenCalled()
+  })
+})
+
+describe('useDeleteSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateOwnContributor.mockReset()
+    mockInvalidateContributor.mockReset()
+  })
+
+  it('deletes a section and invalidates queries', async () => {
+    mockApiRequest.mockResolvedValueOnce(undefined)
+
+    const { result } = renderHook(() => useDeleteSection(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      await result.current.mutateAsync(5)
+    })
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/auth/profile/sections/5', {
+      method: 'DELETE',
+    })
+    expect(mockInvalidateOwnContributor).toHaveBeenCalled()
+    expect(mockInvalidateContributor).toHaveBeenCalled()
+  })
+
+  it('handles deletion errors', async () => {
+    const error = new Error('Forbidden')
+    Object.assign(error, { status: 403 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useDeleteSection(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync(999)
+      } catch (e) {
+        expect((e as Error).message).toBe('Forbidden')
+      }
+    })
+
+    expect(mockInvalidateOwnContributor).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/features/auth/hooks/useFavoriteCities.test.tsx
+++ b/frontend/features/auth/hooks/useFavoriteCities.test.tsx
@@ -1,0 +1,188 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createWrapper, createTestQueryClient } from '@/test/utils'
+
+// Create mocks
+const mockApiRequest = vi.fn()
+
+// Mock the api module
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    AUTH: {
+      FAVORITE_CITIES: '/auth/preferences/favorite-cities',
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+// Mock queryClient module
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    auth: {
+      profile: ['auth', 'profile'],
+    },
+  },
+}))
+
+// Import hooks after mocks are set up
+import { useSetFavoriteCities } from './useFavoriteCities'
+
+describe('useSetFavoriteCities', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('saves favorite cities and invalidates profile query', async () => {
+    const mockResponse = {
+      success: true,
+      message: 'Favorite cities updated',
+      cities: [
+        { city: 'Phoenix', state: 'AZ' },
+        { city: 'Tempe', state: 'AZ' },
+      ],
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useSetFavoriteCities(), {
+      wrapper: createWrapper(),
+    })
+
+    const cities = [
+      { city: 'Phoenix', state: 'AZ' },
+      { city: 'Tempe', state: 'AZ' },
+    ]
+
+    await act(async () => {
+      const data = await result.current.mutateAsync(cities)
+      expect(data.success).toBe(true)
+      expect(data.cities).toHaveLength(2)
+    })
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/auth/preferences/favorite-cities',
+      {
+        method: 'PUT',
+        body: JSON.stringify({ cities }),
+      }
+    )
+  })
+
+  it('sends empty array to clear favorite cities', async () => {
+    const mockResponse = {
+      success: true,
+      message: 'Favorite cities cleared',
+      cities: [],
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useSetFavoriteCities(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      const data = await result.current.mutateAsync([])
+      expect(data.cities).toHaveLength(0)
+    })
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/auth/preferences/favorite-cities',
+      {
+        method: 'PUT',
+        body: JSON.stringify({ cities: [] }),
+      }
+    )
+  })
+
+  it('handles API errors', async () => {
+    const error = new Error('Unauthorized')
+    Object.assign(error, { status: 401 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useSetFavoriteCities(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync([{ city: 'Phoenix', state: 'AZ' }])
+      } catch (e) {
+        expect((e as Error).message).toBe('Unauthorized')
+      }
+    })
+  })
+
+  it('handles validation errors', async () => {
+    const error = new Error('Invalid city data')
+    Object.assign(error, { status: 422 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useSetFavoriteCities(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync([{ city: '', state: '' }])
+      } catch (e) {
+        expect((e as Error).message).toBe('Invalid city data')
+      }
+    })
+  })
+
+  it('saves a single city', async () => {
+    const mockResponse = {
+      success: true,
+      message: 'Favorite cities updated',
+      cities: [{ city: 'Chicago', state: 'IL' }],
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useSetFavoriteCities(), {
+      wrapper: createWrapper(),
+    })
+
+    const cities = [{ city: 'Chicago', state: 'IL' }]
+
+    await act(async () => {
+      const data = await result.current.mutateAsync(cities)
+      expect(data.cities).toHaveLength(1)
+      expect(data.cities[0].city).toBe('Chicago')
+      expect(data.cities[0].state).toBe('IL')
+    })
+  })
+
+  it('isLoading reflects mutation state', async () => {
+    let resolveMutation: (v: unknown) => void
+    mockApiRequest.mockReturnValueOnce(
+      new Promise(resolve => {
+        resolveMutation = resolve
+      })
+    )
+
+    const { result } = renderHook(() => useSetFavoriteCities(), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.isPending).toBe(false)
+
+    act(() => {
+      result.current.mutate([{ city: 'Phoenix', state: 'AZ' }])
+    })
+
+    await waitFor(() => expect(result.current.isPending).toBe(true))
+
+    await act(async () => {
+      resolveMutation!({
+        success: true,
+        message: 'Updated',
+        cities: [{ city: 'Phoenix', state: 'AZ' }],
+      })
+    })
+
+    await waitFor(() => expect(result.current.isPending).toBe(false))
+  })
+})

--- a/frontend/features/shows/hooks/useShowDelete.test.tsx
+++ b/frontend/features/shows/hooks/useShowDelete.test.tsx
@@ -1,0 +1,244 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+// Create mocks
+const mockApiRequest = vi.fn()
+const mockInvalidateShows = vi.fn()
+const mockInvalidateSavedShows = vi.fn()
+
+// Mock the api module
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    SHOWS: {
+      DELETE: (showId: string | number) => `/shows/${showId}`,
+    },
+  },
+}))
+
+// Mock queryClient module
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {},
+  createInvalidateQueries: () => ({
+    shows: mockInvalidateShows,
+    savedShows: mockInvalidateSavedShows,
+  }),
+}))
+
+// Mock showLogger
+vi.mock('@/lib/utils/showLogger', () => ({
+  showLogger: {
+    deleteAttempt: vi.fn(),
+    deleteSuccess: vi.fn(),
+    deleteFailed: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+// Mock errors module
+vi.mock('@/lib/errors', () => ({
+  ShowError: {
+    fromUnknown: (error: unknown) => ({
+      code: 'UNKNOWN',
+      message: error instanceof Error ? error.message : String(error),
+      requestId: undefined,
+    }),
+  },
+  ShowErrorCode: {
+    UNKNOWN: 'UNKNOWN',
+  },
+}))
+
+// Import hooks after mocks are set up
+import { useShowDelete } from './useShowDelete'
+
+// Helper to create wrapper with query client
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+  }
+}
+
+describe('useShowDelete', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateShows.mockReset()
+    mockInvalidateSavedShows.mockReset()
+  })
+
+  it('deletes a show with correct endpoint and method', async () => {
+    mockApiRequest.mockResolvedValueOnce(undefined)
+
+    const { result } = renderHook(() => useShowDelete(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(42)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/shows/42', {
+      method: 'DELETE',
+    })
+  })
+
+  it('invalidates shows and savedShows on success', async () => {
+    mockApiRequest.mockResolvedValueOnce(undefined)
+
+    const { result } = renderHook(() => useShowDelete(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(1)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockInvalidateShows).toHaveBeenCalled()
+    expect(mockInvalidateSavedShows).toHaveBeenCalled()
+  })
+
+  it('returns void on success (no response body)', async () => {
+    mockApiRequest.mockResolvedValueOnce(undefined)
+
+    const { result } = renderHook(() => useShowDelete(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(1)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data).toBeUndefined()
+  })
+
+  it('handles 404 not found errors', async () => {
+    const error = new Error('Show not found')
+    Object.assign(error, { status: 404 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useShowDelete(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(999)
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect((result.current.error as Error).message).toBe('Show not found')
+  })
+
+  it('handles 403 unauthorized errors', async () => {
+    const error = new Error('You are not authorized to delete this show')
+    Object.assign(error, { status: 403 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useShowDelete(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(50)
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect((result.current.error as Error).message).toBe(
+      'You are not authorized to delete this show'
+    )
+  })
+
+  it('does not invalidate queries on error', async () => {
+    mockApiRequest.mockRejectedValueOnce(new Error('Server error'))
+
+    const { result } = renderHook(() => useShowDelete(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(1)
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect(mockInvalidateShows).not.toHaveBeenCalled()
+    expect(mockInvalidateSavedShows).not.toHaveBeenCalled()
+  })
+
+  it('handles network errors', async () => {
+    mockApiRequest.mockRejectedValueOnce(new TypeError('Failed to fetch'))
+
+    const { result } = renderHook(() => useShowDelete(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(1)
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect(result.current.error).toBeInstanceOf(TypeError)
+  })
+
+  it('handles 401 unauthorized errors', async () => {
+    const error = new Error('Unauthorized')
+    Object.assign(error, { status: 401 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useShowDelete(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(1)
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect((result.current.error as Error).message).toBe('Unauthorized')
+  })
+
+  it('can be called multiple times sequentially', async () => {
+    mockApiRequest.mockResolvedValue(undefined)
+
+    const { result } = renderHook(() => useShowDelete(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(1)
+    })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    await act(async () => {
+      result.current.mutate(2)
+    })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledTimes(2)
+    expect(mockApiRequest).toHaveBeenCalledWith('/shows/1', { method: 'DELETE' })
+    expect(mockApiRequest).toHaveBeenCalledWith('/shows/2', { method: 'DELETE' })
+  })
+})

--- a/frontend/features/shows/hooks/useShowSubmit.test.tsx
+++ b/frontend/features/shows/hooks/useShowSubmit.test.tsx
@@ -1,0 +1,360 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+// Create mocks
+const mockApiRequest = vi.fn()
+const mockInvalidateShows = vi.fn()
+const mockInvalidateArtists = vi.fn()
+const mockInvalidateSavedShows = vi.fn()
+
+// Mock the api module
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    SHOWS: {
+      SUBMIT: '/shows',
+    },
+  },
+}))
+
+// Mock queryClient module
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {},
+  createInvalidateQueries: () => ({
+    shows: mockInvalidateShows,
+    artists: mockInvalidateArtists,
+    savedShows: mockInvalidateSavedShows,
+  }),
+}))
+
+// Mock showLogger to suppress console output in tests
+vi.mock('@/lib/utils/showLogger', () => ({
+  showLogger: {
+    submitAttempt: vi.fn(),
+    submitSuccess: vi.fn(),
+    submitFailed: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+// Mock errors module
+vi.mock('@/lib/errors', () => ({
+  ShowError: {
+    fromUnknown: (error: unknown) => ({
+      code: 'UNKNOWN',
+      message: error instanceof Error ? error.message : String(error),
+      requestId: undefined,
+    }),
+  },
+  ShowErrorCode: {
+    UNKNOWN: 'UNKNOWN',
+  },
+}))
+
+// Import hooks after mocks are set up
+import { useShowSubmit } from './useShowSubmit'
+import type { ShowSubmission } from './useShowSubmit'
+
+// Helper to create wrapper with query client
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+  }
+}
+
+const validSubmission: ShowSubmission = {
+  event_date: '2025-06-15T20:00:00Z',
+  city: 'Phoenix',
+  state: 'AZ',
+  venues: [{ name: 'The Rebel Lounge', city: 'Phoenix', state: 'AZ' }],
+  artists: [{ name: 'Test Artist' }],
+}
+
+describe('useShowSubmit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateShows.mockReset()
+    mockInvalidateArtists.mockReset()
+    mockInvalidateSavedShows.mockReset()
+  })
+
+  it('submits a show with correct endpoint and method', async () => {
+    const mockResponse = {
+      id: 1,
+      slug: 'test-artist-rebel-lounge-2025-06-15',
+      title: 'Test Artist at The Rebel Lounge',
+      event_date: '2025-06-15T20:00:00Z',
+      status: 'pending',
+      venues: [{ id: 1, name: 'The Rebel Lounge', slug: 'the-rebel-lounge', city: 'Phoenix', state: 'AZ', verified: false }],
+      artists: [{ id: 1, name: 'Test Artist', slug: 'test-artist', set_type: 'performer', position: 0, socials: {} }],
+      created_at: '2025-01-01T00:00:00Z',
+      updated_at: '2025-01-01T00:00:00Z',
+      is_sold_out: false,
+      is_cancelled: false,
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useShowSubmit(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(validSubmission)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/shows', {
+      method: 'POST',
+      body: JSON.stringify(validSubmission),
+    })
+    expect(result.current.data?.id).toBe(1)
+  })
+
+  it('invalidates shows, artists, and savedShows on success', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      id: 2,
+      slug: 'show-2',
+      title: 'Show',
+      event_date: '2025-06-15T20:00:00Z',
+      status: 'pending',
+      venues: [],
+      artists: [],
+      created_at: '2025-01-01T00:00:00Z',
+      updated_at: '2025-01-01T00:00:00Z',
+      is_sold_out: false,
+      is_cancelled: false,
+    })
+
+    const { result } = renderHook(() => useShowSubmit(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(validSubmission)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockInvalidateShows).toHaveBeenCalled()
+    expect(mockInvalidateArtists).toHaveBeenCalled()
+    expect(mockInvalidateSavedShows).toHaveBeenCalled()
+  })
+
+  it('returns the show response data on success', async () => {
+    const mockResponse = {
+      id: 42,
+      slug: 'test-show',
+      title: 'Test Show',
+      event_date: '2025-06-15T20:00:00Z',
+      status: 'approved',
+      venues: [{ id: 5, name: 'Valley Bar', slug: 'valley-bar', city: 'Phoenix', state: 'AZ', verified: true }],
+      artists: [
+        { id: 10, name: 'Band A', slug: 'band-a', is_headliner: true, set_type: 'headliner', position: 0, socials: {} },
+        { id: 11, name: 'Band B', slug: 'band-b', set_type: 'opener', position: 1, socials: {} },
+      ],
+      created_at: '2025-01-01T00:00:00Z',
+      updated_at: '2025-01-01T00:00:00Z',
+      is_sold_out: false,
+      is_cancelled: false,
+      request_id: 'req-abc-123',
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useShowSubmit(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(validSubmission)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data?.id).toBe(42)
+    expect(result.current.data?.title).toBe('Test Show')
+    expect(result.current.data?.venues).toHaveLength(1)
+    expect(result.current.data?.artists).toHaveLength(2)
+  })
+
+  it('handles API errors and sets error state', async () => {
+    const error = new Error('Validation failed')
+    Object.assign(error, { status: 422 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useShowSubmit(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(validSubmission)
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect(result.current.error).toBeDefined()
+    expect((result.current.error as Error).message).toBe('Validation failed')
+  })
+
+  it('does not invalidate queries on error', async () => {
+    mockApiRequest.mockRejectedValueOnce(new Error('Server error'))
+
+    const { result } = renderHook(() => useShowSubmit(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(validSubmission)
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect(mockInvalidateShows).not.toHaveBeenCalled()
+    expect(mockInvalidateArtists).not.toHaveBeenCalled()
+    expect(mockInvalidateSavedShows).not.toHaveBeenCalled()
+  })
+
+  it('sends optional fields when provided', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      id: 3,
+      slug: 'show-3',
+      title: 'Private Show',
+      event_date: '2025-06-15T20:00:00Z',
+      status: 'private',
+      venues: [],
+      artists: [],
+      created_at: '2025-01-01T00:00:00Z',
+      updated_at: '2025-01-01T00:00:00Z',
+      is_sold_out: false,
+      is_cancelled: false,
+    })
+
+    const fullSubmission: ShowSubmission = {
+      title: 'Private Show',
+      event_date: '2025-06-15T20:00:00Z',
+      city: 'Phoenix',
+      state: 'AZ',
+      price: 15,
+      age_requirement: '21+',
+      description: 'A test show',
+      venues: [{ name: 'Valley Bar', city: 'Phoenix', state: 'AZ', address: '130 N Central Ave' }],
+      artists: [
+        { name: 'Headliner', is_headliner: true },
+        { name: 'Opener', is_headliner: false, instagram_handle: '@opener' },
+      ],
+      is_private: true,
+    }
+
+    const { result } = renderHook(() => useShowSubmit(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(fullSubmission)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const sentBody = JSON.parse(mockApiRequest.mock.calls[0][1].body)
+    expect(sentBody.title).toBe('Private Show')
+    expect(sentBody.price).toBe(15)
+    expect(sentBody.age_requirement).toBe('21+')
+    expect(sentBody.description).toBe('A test show')
+    expect(sentBody.is_private).toBe(true)
+    expect(sentBody.artists).toHaveLength(2)
+    expect(sentBody.venues[0].address).toBe('130 N Central Ave')
+  })
+
+  it('submits with multiple venues and artists', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      id: 4,
+      slug: 'show-4',
+      title: 'Multi-venue Show',
+      event_date: '2025-06-15T20:00:00Z',
+      status: 'pending',
+      venues: [],
+      artists: [],
+      created_at: '2025-01-01T00:00:00Z',
+      updated_at: '2025-01-01T00:00:00Z',
+      is_sold_out: false,
+      is_cancelled: false,
+    })
+
+    const multiSubmission: ShowSubmission = {
+      event_date: '2025-06-15T20:00:00Z',
+      city: 'Phoenix',
+      state: 'AZ',
+      venues: [
+        { name: 'Venue A', city: 'Phoenix', state: 'AZ' },
+        { name: 'Venue B', id: 5, city: 'Phoenix', state: 'AZ' },
+      ],
+      artists: [
+        { name: 'Artist A', is_headliner: true },
+        { name: 'Artist B', id: 10 },
+        { name: 'Artist C' },
+      ],
+    }
+
+    const { result } = renderHook(() => useShowSubmit(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(multiSubmission)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const sentBody = JSON.parse(mockApiRequest.mock.calls[0][1].body)
+    expect(sentBody.venues).toHaveLength(2)
+    expect(sentBody.artists).toHaveLength(3)
+  })
+
+  it('handles network errors', async () => {
+    mockApiRequest.mockRejectedValueOnce(new TypeError('Failed to fetch'))
+
+    const { result } = renderHook(() => useShowSubmit(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(validSubmission)
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect(result.current.error).toBeInstanceOf(TypeError)
+  })
+
+  it('handles 401 unauthorized errors', async () => {
+    const error = new Error('Unauthorized')
+    Object.assign(error, { status: 401 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useShowSubmit(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(validSubmission)
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect((result.current.error as Error).message).toBe('Unauthorized')
+  })
+})

--- a/frontend/features/shows/hooks/useShowUpdate.test.tsx
+++ b/frontend/features/shows/hooks/useShowUpdate.test.tsx
@@ -1,0 +1,372 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+// Create mocks
+const mockApiRequest = vi.fn()
+const mockInvalidateShows = vi.fn()
+const mockInvalidateArtists = vi.fn()
+const mockInvalidateVenues = vi.fn()
+
+// Mock the api module
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    SHOWS: {
+      UPDATE: (showId: string | number) => `/shows/${showId}`,
+    },
+  },
+}))
+
+// Mock queryClient module
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {},
+  createInvalidateQueries: () => ({
+    shows: mockInvalidateShows,
+    artists: mockInvalidateArtists,
+    venues: mockInvalidateVenues,
+  }),
+}))
+
+// Mock showLogger
+vi.mock('@/lib/utils/showLogger', () => ({
+  showLogger: {
+    updateAttempt: vi.fn(),
+    updateSuccess: vi.fn(),
+    updateFailed: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+// Mock errors module
+vi.mock('@/lib/errors', () => ({
+  ShowError: {
+    fromUnknown: (error: unknown) => ({
+      code: 'UNKNOWN',
+      message: error instanceof Error ? error.message : String(error),
+      requestId: undefined,
+    }),
+  },
+  ShowErrorCode: {
+    UNKNOWN: 'UNKNOWN',
+  },
+}))
+
+// Import hooks after mocks are set up
+import { useShowUpdate } from './useShowUpdate'
+import type { ShowUpdate } from './useShowUpdate'
+
+// Helper to create wrapper with query client
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+  }
+}
+
+describe('useShowUpdate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateShows.mockReset()
+    mockInvalidateArtists.mockReset()
+    mockInvalidateVenues.mockReset()
+  })
+
+  it('updates a show with correct endpoint and method', async () => {
+    const mockResponse = {
+      id: 1,
+      slug: 'updated-show',
+      title: 'Updated Title',
+      event_date: '2025-06-15T20:00:00Z',
+      status: 'approved',
+      venues: [],
+      artists: [],
+      created_at: '2025-01-01T00:00:00Z',
+      updated_at: '2025-01-02T00:00:00Z',
+      is_sold_out: false,
+      is_cancelled: false,
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const updates: ShowUpdate = { title: 'Updated Title' }
+
+    const { result } = renderHook(() => useShowUpdate(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ showId: 1, updates })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/shows/1', {
+      method: 'PUT',
+      body: JSON.stringify(updates),
+    })
+    expect(result.current.data?.title).toBe('Updated Title')
+  })
+
+  it('invalidates shows, artists, and venues on success', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      id: 1,
+      slug: 'show-1',
+      title: 'Show',
+      event_date: '2025-06-15T20:00:00Z',
+      status: 'approved',
+      venues: [],
+      artists: [],
+      created_at: '2025-01-01T00:00:00Z',
+      updated_at: '2025-01-02T00:00:00Z',
+      is_sold_out: false,
+      is_cancelled: false,
+    })
+
+    const { result } = renderHook(() => useShowUpdate(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ showId: 1, updates: { title: 'New' } })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockInvalidateShows).toHaveBeenCalled()
+    expect(mockInvalidateArtists).toHaveBeenCalled()
+    expect(mockInvalidateVenues).toHaveBeenCalled()
+  })
+
+  it('sends partial updates correctly', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      id: 5,
+      slug: 'show-5',
+      title: 'Show',
+      event_date: '2025-07-01T19:00:00Z',
+      status: 'approved',
+      venues: [],
+      artists: [],
+      created_at: '2025-01-01T00:00:00Z',
+      updated_at: '2025-01-02T00:00:00Z',
+      is_sold_out: false,
+      is_cancelled: false,
+    })
+
+    const partialUpdate: ShowUpdate = {
+      event_date: '2025-07-01T19:00:00Z',
+      price: 20,
+    }
+
+    const { result } = renderHook(() => useShowUpdate(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ showId: 5, updates: partialUpdate })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const sentBody = JSON.parse(mockApiRequest.mock.calls[0][1].body)
+    expect(sentBody.event_date).toBe('2025-07-01T19:00:00Z')
+    expect(sentBody.price).toBe(20)
+    expect(sentBody.title).toBeUndefined()
+  })
+
+  it('sends venue and artist replacements', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      id: 10,
+      slug: 'show-10',
+      title: 'Show',
+      event_date: '2025-06-15T20:00:00Z',
+      status: 'approved',
+      venues: [{ id: 2, name: 'New Venue', slug: 'new-venue', city: 'Phoenix', state: 'AZ', verified: true }],
+      artists: [{ id: 3, name: 'New Artist', slug: 'new-artist', set_type: 'headliner', position: 0, socials: {} }],
+      created_at: '2025-01-01T00:00:00Z',
+      updated_at: '2025-01-02T00:00:00Z',
+      is_sold_out: false,
+      is_cancelled: false,
+    })
+
+    const updates: ShowUpdate = {
+      venues: [{ id: 2, name: 'New Venue' }],
+      artists: [{ id: 3, name: 'New Artist', is_headliner: true }],
+    }
+
+    const { result } = renderHook(() => useShowUpdate(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ showId: 10, updates })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const sentBody = JSON.parse(mockApiRequest.mock.calls[0][1].body)
+    expect(sentBody.venues).toHaveLength(1)
+    expect(sentBody.artists).toHaveLength(1)
+    expect(sentBody.artists[0].is_headliner).toBe(true)
+  })
+
+  it('returns orphaned artists in response', async () => {
+    const mockResponse = {
+      id: 10,
+      slug: 'show-10',
+      title: 'Show',
+      event_date: '2025-06-15T20:00:00Z',
+      status: 'approved',
+      venues: [],
+      artists: [],
+      created_at: '2025-01-01T00:00:00Z',
+      updated_at: '2025-01-02T00:00:00Z',
+      is_sold_out: false,
+      is_cancelled: false,
+      orphaned_artists: [
+        { id: 99, name: 'Orphaned Band', slug: 'orphaned-band' },
+      ],
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useShowUpdate(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ showId: 10, updates: { artists: [] } })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data?.orphaned_artists).toHaveLength(1)
+    expect(result.current.data?.orphaned_artists?.[0].name).toBe('Orphaned Band')
+  })
+
+  it('handles API errors and sets error state', async () => {
+    const error = new Error('Show not found')
+    Object.assign(error, { status: 404 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useShowUpdate(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ showId: 999, updates: { title: 'New' } })
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect((result.current.error as Error).message).toBe('Show not found')
+  })
+
+  it('does not invalidate queries on error', async () => {
+    mockApiRequest.mockRejectedValueOnce(new Error('Server error'))
+
+    const { result } = renderHook(() => useShowUpdate(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ showId: 1, updates: { title: 'New' } })
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect(mockInvalidateShows).not.toHaveBeenCalled()
+    expect(mockInvalidateArtists).not.toHaveBeenCalled()
+    expect(mockInvalidateVenues).not.toHaveBeenCalled()
+  })
+
+  it('handles 422 validation errors', async () => {
+    const error = new Error('expected required property event_date to be present')
+    Object.assign(error, { status: 422 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useShowUpdate(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ showId: 1, updates: {} })
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect(result.current.error).toBeDefined()
+  })
+
+  it('handles network errors', async () => {
+    mockApiRequest.mockRejectedValueOnce(new TypeError('Failed to fetch'))
+
+    const { result } = renderHook(() => useShowUpdate(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ showId: 1, updates: { title: 'New' } })
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect(result.current.error).toBeInstanceOf(TypeError)
+  })
+
+  it('updates all fields simultaneously', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      id: 20,
+      slug: 'show-20',
+      title: 'Full Update',
+      event_date: '2025-08-01T21:00:00Z',
+      status: 'approved',
+      venues: [],
+      artists: [],
+      created_at: '2025-01-01T00:00:00Z',
+      updated_at: '2025-01-02T00:00:00Z',
+      is_sold_out: false,
+      is_cancelled: false,
+    })
+
+    const fullUpdate: ShowUpdate = {
+      title: 'Full Update',
+      event_date: '2025-08-01T21:00:00Z',
+      city: 'Tempe',
+      state: 'AZ',
+      price: 25,
+      age_requirement: '18+',
+      description: 'Updated description',
+      venues: [{ id: 1 }],
+      artists: [{ id: 2, is_headliner: true }],
+    }
+
+    const { result } = renderHook(() => useShowUpdate(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ showId: 20, updates: fullUpdate })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const sentBody = JSON.parse(mockApiRequest.mock.calls[0][1].body)
+    expect(sentBody.title).toBe('Full Update')
+    expect(sentBody.event_date).toBe('2025-08-01T21:00:00Z')
+    expect(sentBody.city).toBe('Tempe')
+    expect(sentBody.price).toBe(25)
+    expect(sentBody.age_requirement).toBe('18+')
+    expect(sentBody.description).toBe('Updated description')
+  })
+})

--- a/frontend/features/venues/hooks/useVenueSearch.test.tsx
+++ b/frontend/features/venues/hooks/useVenueSearch.test.tsx
@@ -1,0 +1,146 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createWrapper, createTestQueryClient } from '@/test/utils'
+
+// Create mocks
+const mockApiRequest = vi.fn()
+
+// Mock the api module
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    VENUES: {
+      SEARCH: '/venues/search',
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+// Mock queryClient module
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    venues: {
+      search: (query: string) => ['venues', 'search', query.toLowerCase()],
+    },
+  },
+}))
+
+// Mock use-debounce to make tests synchronous
+vi.mock('use-debounce', () => ({
+  useDebounce: (value: string, _delay: number) => [value],
+}))
+
+// Import hooks after mocks are set up
+import { useVenueSearch } from './useVenueSearch'
+
+describe('useVenueSearch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches venues matching the search query', async () => {
+    const mockResponse = {
+      venues: [
+        { id: 1, slug: 'the-rebel-lounge', name: 'The Rebel Lounge', city: 'Phoenix', state: 'AZ' },
+        { id: 2, slug: 'rebel-bar', name: 'Rebel Bar', city: 'Tempe', state: 'AZ' },
+      ],
+      count: 2,
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(
+      () => useVenueSearch({ query: 'rebel' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/venues/search?q=rebel')
+    expect(result.current.data?.venues).toHaveLength(2)
+    expect(result.current.data?.count).toBe(2)
+  })
+
+  it('does not fetch when query is empty', () => {
+    const { result } = renderHook(
+      () => useVenueSearch({ query: '' }),
+      { wrapper: createWrapper() }
+    )
+
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('URL-encodes special characters in query', async () => {
+    mockApiRequest.mockResolvedValueOnce({ venues: [], count: 0 })
+
+    const { result } = renderHook(
+      () => useVenueSearch({ query: 'bar & grill' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/venues/search?q=bar%20%26%20grill'
+    )
+  })
+
+  it('handles API errors', async () => {
+    const error = new Error('Server error')
+    Object.assign(error, { status: 500 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(
+      () => useVenueSearch({ query: 'test' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect(result.current.error).toBeDefined()
+  })
+
+  it('returns empty results for no matches', async () => {
+    mockApiRequest.mockResolvedValueOnce({ venues: [], count: 0 })
+
+    const { result } = renderHook(
+      () => useVenueSearch({ query: 'nonexistent' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data?.venues).toHaveLength(0)
+    expect(result.current.data?.count).toBe(0)
+  })
+
+  it('accepts custom debounce delay', async () => {
+    mockApiRequest.mockResolvedValueOnce({ venues: [], count: 0 })
+
+    const { result } = renderHook(
+      () => useVenueSearch({ query: 'test', debounceMs: 300 }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    // Since use-debounce is mocked, it resolves immediately regardless of delay
+    expect(mockApiRequest).toHaveBeenCalledWith('/venues/search?q=test')
+  })
+
+  it('returns loading state while fetching', () => {
+    // Make the request hang
+    mockApiRequest.mockReturnValue(new Promise(() => {}))
+
+    const { result } = renderHook(
+      () => useVenueSearch({ query: 'loading' }),
+      { wrapper: createWrapper() }
+    )
+
+    expect(result.current.isLoading).toBe(true)
+    expect(result.current.data).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary
- Adds **91 new frontend unit tests** across **9 test files** (complements PR #160 which added the first batch)
- Covers previously untested hooks:
  - **Artist hooks**: `useArtistReports` (11 tests), `useArtistSearch` (8 tests)
  - **Auth hooks**: `useCalendarFeed` (9 tests), `useContributorProfile` (22 tests), `useFavoriteCities` (6 tests)
  - **Show mutations**: `useShowSubmit` (9 tests), `useShowUpdate` (10 tests), `useShowDelete` (9 tests)
  - **Venue hooks**: `useVenueSearch` (7 tests)

## Test plan
- [x] All 1,798 tests pass (`bun run test:run`)
- [x] No conflicts with main
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)