### PR TITLE
Refactor: shared Postgres testcontainer helper — remove ~1900 lines of boilerplate

### DIFF
--- a/backend/internal/api/handlers/admin_integration_test.go
+++ b/backend/internal/api/handlers/admin_integration_test.go
@@ -39,9 +39,7 @@ func (s *AdminHandlerIntegrationSuite) TearDownTest() {
 }
 
 func (s *AdminHandlerIntegrationSuite) TearDownSuite() {
-	if s.deps.container != nil {
-		s.deps.container.Terminate(s.deps.ctx)
-	}
+	s.deps.testDB.Cleanup()
 }
 
 func TestAdminHandlerIntegration(t *testing.T) {

--- a/backend/internal/api/handlers/artist_integration_test.go
+++ b/backend/internal/api/handlers/artist_integration_test.go
@@ -27,9 +27,7 @@ func (s *ArtistHandlerIntegrationSuite) TearDownTest() {
 }
 
 func (s *ArtistHandlerIntegrationSuite) TearDownSuite() {
-	if s.deps.container != nil {
-		s.deps.container.Terminate(s.deps.ctx)
-	}
+	s.deps.testDB.Cleanup()
 }
 
 func TestArtistHandlerIntegration(t *testing.T) {

--- a/backend/internal/api/handlers/auth_integration_test.go
+++ b/backend/internal/api/handlers/auth_integration_test.go
@@ -55,9 +55,7 @@ func (s *AuthHandlerIntegrationSuite) TearDownTest() {
 }
 
 func (s *AuthHandlerIntegrationSuite) TearDownSuite() {
-	if s.deps.container != nil {
-		s.deps.container.Terminate(s.deps.ctx)
-	}
+	s.deps.testDB.Cleanup()
 }
 
 // --- Helpers ---

--- a/backend/internal/api/handlers/collection_integration_test.go
+++ b/backend/internal/api/handlers/collection_integration_test.go
@@ -27,9 +27,7 @@ func (s *CollectionHandlerIntegrationSuite) TearDownTest() {
 }
 
 func (s *CollectionHandlerIntegrationSuite) TearDownSuite() {
-	if s.deps.container != nil {
-		s.deps.container.Terminate(s.deps.ctx)
-	}
+	s.deps.testDB.Cleanup()
 }
 
 func TestCollectionHandlerIntegration(t *testing.T) {

--- a/backend/internal/api/handlers/contributor_profile_integration_test.go
+++ b/backend/internal/api/handlers/contributor_profile_integration_test.go
@@ -33,9 +33,7 @@ func (s *ContributorProfileHandlerIntegrationSuite) TearDownTest() {
 }
 
 func (s *ContributorProfileHandlerIntegrationSuite) TearDownSuite() {
-	if s.deps.container != nil {
-		s.deps.container.Terminate(s.deps.ctx)
-	}
+	s.deps.testDB.Cleanup()
 }
 
 func TestContributorProfileHandlerIntegration(t *testing.T) {

--- a/backend/internal/api/handlers/favorite_venue_integration_test.go
+++ b/backend/internal/api/handlers/favorite_venue_integration_test.go
@@ -26,9 +26,7 @@ func (s *FavoriteVenueHandlerIntegrationSuite) TearDownTest() {
 }
 
 func (s *FavoriteVenueHandlerIntegrationSuite) TearDownSuite() {
-	if s.deps.container != nil {
-		s.deps.container.Terminate(s.deps.ctx)
-	}
+	s.deps.testDB.Cleanup()
 }
 
 func TestFavoriteVenueHandlerIntegration(t *testing.T) {

--- a/backend/internal/api/handlers/festival_integration_test.go
+++ b/backend/internal/api/handlers/festival_integration_test.go
@@ -27,9 +27,7 @@ func (s *FestivalHandlerIntegrationSuite) TearDownTest() {
 }
 
 func (s *FestivalHandlerIntegrationSuite) TearDownSuite() {
-	if s.deps.container != nil {
-		s.deps.container.Terminate(s.deps.ctx)
-	}
+	s.deps.testDB.Cleanup()
 }
 
 func TestFestivalHandlerIntegration(t *testing.T) {

--- a/backend/internal/api/handlers/festival_intelligence_test.go
+++ b/backend/internal/api/handlers/festival_intelligence_test.go
@@ -28,9 +28,7 @@ func (s *FestivalIntelligenceHandlerSuite) TearDownTest() {
 }
 
 func (s *FestivalIntelligenceHandlerSuite) TearDownSuite() {
-	if s.deps.container != nil {
-		s.deps.container.Terminate(s.deps.ctx)
-	}
+	s.deps.testDB.Cleanup()
 }
 
 func TestFestivalIntelligenceHandler(t *testing.T) {
@@ -105,7 +103,7 @@ func (s *FestivalIntelligenceHandlerSuite) TestGetSimilarFestivals_LimitParamete
 	for j := 0; j < 3; j++ {
 		other := s.createFestival(fmt.Sprintf("Limit Target %d", j), fmt.Sprintf("lt%d", j), 2026)
 		for i := 0; i < 3; i++ {
-			a := createArtist(s.deps.db,fmt.Sprintf("LimitShared %d-%d", j, i))
+			a := createArtist(s.deps.db, fmt.Sprintf("LimitShared %d-%d", j, i))
 			_, _ = s.deps.festivalService.AddFestivalArtist(f1.ID, &services.AddFestivalArtistRequest{ArtistID: a.ID, BillingTier: "mid_card"})
 			_, _ = s.deps.festivalService.AddFestivalArtist(other.ID, &services.AddFestivalArtistRequest{ArtistID: a.ID, BillingTier: "mid_card"})
 		}
@@ -132,7 +130,7 @@ func (s *FestivalIntelligenceHandlerSuite) TestGetFestivalOverlap_Success() {
 	f1 := s.createFestival("Overlap A", "oa", 2026)
 	f2 := s.createFestival("Overlap B", "ob", 2026)
 
-	a := createArtist(s.deps.db,"Overlap Shared")
+	a := createArtist(s.deps.db, "Overlap Shared")
 	_, _ = s.deps.festivalService.AddFestivalArtist(f1.ID, &services.AddFestivalArtistRequest{ArtistID: a.ID, BillingTier: "headliner"})
 	_, _ = s.deps.festivalService.AddFestivalArtist(f2.ID, &services.AddFestivalArtistRequest{ArtistID: a.ID, BillingTier: "mid_card"})
 
@@ -161,7 +159,7 @@ func (s *FestivalIntelligenceHandlerSuite) TestGetFestivalBreakouts_Success() {
 	f1 := s.createFestival("Breakout Early", "be", 2024)
 	f2 := s.createFestival("Breakout Late", "bl", 2026)
 
-	a := createArtist(s.deps.db,"Rising Handler Star")
+	a := createArtist(s.deps.db, "Rising Handler Star")
 	_, _ = s.deps.festivalService.AddFestivalArtist(f1.ID, &services.AddFestivalArtistRequest{ArtistID: a.ID, BillingTier: "undercard"})
 	_, _ = s.deps.festivalService.AddFestivalArtist(f2.ID, &services.AddFestivalArtistRequest{ArtistID: a.ID, BillingTier: "headliner"})
 

--- a/backend/internal/api/handlers/handler_integration_helpers_test.go
+++ b/backend/internal/api/handlers/handler_integration_helpers_test.go
@@ -3,13 +3,9 @@ package handlers
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/internal/config"
@@ -27,7 +23,7 @@ import (
 // handlerIntegrationDeps holds all services + DB for handler integration tests
 type handlerIntegrationDeps struct {
 	db                    *gorm.DB
-	container             testcontainers.Container
+	testDB                *testutil.TestDatabase
 	ctx                   context.Context
 	showService           *catalog.ShowService
 	venueService          *catalog.VenueService
@@ -55,58 +51,16 @@ type handlerIntegrationDeps struct {
 func setupHandlerIntegrationDeps(t *testing.T) *handlerIntegrationDeps {
 	t.Helper()
 
-	ctx := context.Background()
-
-	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "postgres:18",
-			ExposedPorts: []string{"5432/tcp"},
-			Env: map[string]string{
-				"POSTGRES_DB":       "test_db",
-				"POSTGRES_USER":     "test_user",
-				"POSTGRES_PASSWORD": "test_password",
-			},
-			WaitingFor: wait.ForLog("database system is ready to accept connections").
-				WithOccurrence(2).
-				WithStartupTimeout(120 * time.Second),
-		},
-		Started: true,
-	})
-	if err != nil {
-		t.Fatalf("failed to start postgres container: %v", err)
-	}
-
-	host, err := container.Host(ctx)
-	if err != nil {
-		t.Fatalf("failed to get host: %v", err)
-	}
-	port, err := container.MappedPort(ctx, "5432")
-	if err != nil {
-		t.Fatalf("failed to get port: %v", err)
-	}
-
-	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
-		host, port.Port())
-
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	if err != nil {
-		t.Fatalf("failed to connect to test database: %v", err)
-	}
-
-	sqlDB, err := db.DB()
-	if err != nil {
-		t.Fatalf("failed to get sql.DB: %v", err)
-	}
-
-	testutil.RunAllMigrations(t, sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
+	testDB := testutil.SetupTestPostgres(t)
+	db := testDB.DB
 
 	// Construct services
 	emptyCfg := &config.Config{}
 
 	deps := &handlerIntegrationDeps{
 		db:                    db,
-		container:             container,
-		ctx:                   ctx,
+		testDB:                testDB,
+		ctx:                   context.Background(),
 		showService:           catalog.NewShowService(db),
 		venueService:          catalog.NewVenueService(db),
 		savedShowService:      engagement.NewSavedShowService(db),

--- a/backend/internal/api/handlers/label_integration_test.go
+++ b/backend/internal/api/handlers/label_integration_test.go
@@ -26,9 +26,7 @@ func (s *LabelHandlerIntegrationSuite) TearDownTest() {
 }
 
 func (s *LabelHandlerIntegrationSuite) TearDownSuite() {
-	if s.deps.container != nil {
-		s.deps.container.Terminate(s.deps.ctx)
-	}
+	s.deps.testDB.Cleanup()
 }
 
 func TestLabelHandlerIntegration(t *testing.T) {

--- a/backend/internal/api/handlers/oauth_handlers_integration_test.go
+++ b/backend/internal/api/handlers/oauth_handlers_integration_test.go
@@ -59,9 +59,7 @@ func (s *OAuthHandlerIntegrationSuite) TearDownTest() {
 }
 
 func (s *OAuthHandlerIntegrationSuite) TearDownSuite() {
-	if s.deps.container != nil {
-		s.deps.container.Terminate(s.deps.ctx)
-	}
+	s.deps.testDB.Cleanup()
 }
 
 func TestOAuthHandlerIntegration(t *testing.T) {

--- a/backend/internal/api/handlers/release_integration_test.go
+++ b/backend/internal/api/handlers/release_integration_test.go
@@ -25,9 +25,7 @@ func (s *ReleaseHandlerIntegrationSuite) TearDownTest() {
 }
 
 func (s *ReleaseHandlerIntegrationSuite) TearDownSuite() {
-	if s.deps.container != nil {
-		s.deps.container.Terminate(s.deps.ctx)
-	}
+	s.deps.testDB.Cleanup()
 }
 
 func TestReleaseHandlerIntegration(t *testing.T) {

--- a/backend/internal/api/handlers/saved_show_integration_test.go
+++ b/backend/internal/api/handlers/saved_show_integration_test.go
@@ -23,9 +23,7 @@ func (s *SavedShowHandlerIntegrationSuite) TearDownTest() {
 }
 
 func (s *SavedShowHandlerIntegrationSuite) TearDownSuite() {
-	if s.deps.container != nil {
-		s.deps.container.Terminate(s.deps.ctx)
-	}
+	s.deps.testDB.Cleanup()
 }
 
 func TestSavedShowHandlerIntegration(t *testing.T) {
@@ -201,4 +199,3 @@ func (s *SavedShowHandlerIntegrationSuite) TestCheckSaved_False() {
 	s.NotNil(resp)
 	s.False(resp.Body.IsSaved)
 }
-

--- a/backend/internal/api/handlers/show_integration_test.go
+++ b/backend/internal/api/handlers/show_integration_test.go
@@ -33,9 +33,7 @@ func (s *ShowHandlerIntegrationSuite) TearDownTest() {
 }
 
 func (s *ShowHandlerIntegrationSuite) TearDownSuite() {
-	if s.deps.container != nil {
-		s.deps.container.Terminate(s.deps.ctx)
-	}
+	s.deps.testDB.Cleanup()
 }
 
 func TestShowHandlerIntegration(t *testing.T) {

--- a/backend/internal/api/handlers/show_report_integration_test.go
+++ b/backend/internal/api/handlers/show_report_integration_test.go
@@ -28,9 +28,7 @@ func (s *ShowReportHandlerIntegrationSuite) TearDownTest() {
 }
 
 func (s *ShowReportHandlerIntegrationSuite) TearDownSuite() {
-	if s.deps.container != nil {
-		s.deps.container.Terminate(s.deps.ctx)
-	}
+	s.deps.testDB.Cleanup()
 }
 
 func TestShowReportHandlerIntegration(t *testing.T) {

--- a/backend/internal/api/handlers/tag_integration_test.go
+++ b/backend/internal/api/handlers/tag_integration_test.go
@@ -30,9 +30,7 @@ func (s *TagHandlerIntegrationSuite) TearDownTest() {
 }
 
 func (s *TagHandlerIntegrationSuite) TearDownSuite() {
-	if s.deps.container != nil {
-		s.deps.container.Terminate(s.deps.ctx)
-	}
+	s.deps.testDB.Cleanup()
 }
 
 func TestTagHandlerIntegration(t *testing.T) {

--- a/backend/internal/api/handlers/venue_integration_test.go
+++ b/backend/internal/api/handlers/venue_integration_test.go
@@ -25,9 +25,7 @@ func (s *VenueHandlerIntegrationSuite) TearDownTest() {
 }
 
 func (s *VenueHandlerIntegrationSuite) TearDownSuite() {
-	if s.deps.container != nil {
-		s.deps.container.Terminate(s.deps.ctx)
-	}
+	s.deps.testDB.Cleanup()
 }
 
 func TestVenueHandlerIntegration(t *testing.T) {

--- a/backend/internal/api/middleware/jwt_integration_test.go
+++ b/backend/internal/api/middleware/jwt_integration_test.go
@@ -1,20 +1,14 @@
 package middleware
 
 import (
-	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/stretchr/testify/suite"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/internal/config"
@@ -27,8 +21,7 @@ import (
 type JWTMiddlewareIntegrationSuite struct {
 	suite.Suite
 	db         *gorm.DB
-	container  testcontainers.Container
-	ctx        context.Context
+	testDB     *testutil.TestDatabase
 	cfg        *config.Config
 	jwtService *services.JWTService
 }
@@ -41,42 +34,8 @@ func TestJWTMiddlewareIntegration(t *testing.T) {
 }
 
 func (s *JWTMiddlewareIntegrationSuite) SetupSuite() {
-	s.ctx = context.Background()
-
-	container, err := testcontainers.GenericContainer(s.ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "postgres:18",
-			ExposedPorts: []string{"5432/tcp"},
-			Env: map[string]string{
-				"POSTGRES_DB":       "test_db",
-				"POSTGRES_USER":     "test_user",
-				"POSTGRES_PASSWORD": "test_password",
-			},
-			WaitingFor: wait.ForLog("database system is ready to accept connections").
-				WithOccurrence(2).
-				WithStartupTimeout(120 * time.Second),
-		},
-		Started: true,
-	})
-	s.Require().NoError(err, "failed to start postgres container")
-	s.container = container
-
-	host, err := container.Host(s.ctx)
-	s.Require().NoError(err, "failed to get host")
-	port, err := container.MappedPort(s.ctx, "5432")
-	s.Require().NoError(err, "failed to get port")
-
-	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
-		host, port.Port())
-
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	s.Require().NoError(err, "failed to connect to test database")
-	s.db = db
-
-	sqlDB, err := db.DB()
-	s.Require().NoError(err, "failed to get sql.DB")
-
-	testutil.RunAllMigrations(s.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
+	s.testDB = testutil.SetupTestPostgres(s.T())
+	s.db = s.testDB.DB
 
 	// Set up config and JWT service with real DB
 	s.cfg = &config.Config{
@@ -96,9 +55,7 @@ func (s *JWTMiddlewareIntegrationSuite) TearDownTest() {
 }
 
 func (s *JWTMiddlewareIntegrationSuite) TearDownSuite() {
-	if s.container != nil {
-		_ = s.container.Terminate(s.ctx)
-	}
+	s.testDB.Cleanup()
 }
 
 // --- Helpers ---

--- a/backend/internal/services/admin/analytics_test.go
+++ b/backend/internal/services/admin/analytics_test.go
@@ -1,18 +1,13 @@
 package admin
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/internal/models"
@@ -87,67 +82,20 @@ func TestGenerateMonthKeys(t *testing.T) {
 
 type AnalyticsServiceIntegrationTestSuite struct {
 	suite.Suite
-	container testcontainers.Container
-	db        *gorm.DB
-	service   *AnalyticsService
-	ctx       context.Context
+	testDB  *testutil.TestDatabase
+	db      *gorm.DB
+	service *AnalyticsService
 }
 
 func (suite *AnalyticsServiceIntegrationTestSuite) SetupSuite() {
-	suite.ctx = context.Background()
+	suite.testDB = testutil.SetupTestPostgres(suite.T())
+	suite.db = suite.testDB.DB
 
-	container, err := testcontainers.GenericContainer(suite.ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "postgres:18",
-			ExposedPorts: []string{"5432/tcp"},
-			Env: map[string]string{
-				"POSTGRES_DB":       "test_db",
-				"POSTGRES_USER":     "test_user",
-				"POSTGRES_PASSWORD": "test_password",
-			},
-			WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(120 * time.Second),
-		},
-		Started: true,
-	})
-	if err != nil {
-		suite.T().Fatalf("failed to start postgres container: %v", err)
-	}
-	suite.container = container
-
-	host, err := container.Host(suite.ctx)
-	if err != nil {
-		suite.T().Fatalf("failed to get host: %v", err)
-	}
-	port, err := container.MappedPort(suite.ctx, "5432")
-	if err != nil {
-		suite.T().Fatalf("failed to get port: %v", err)
-	}
-
-	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
-		host, port.Port())
-
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	if err != nil {
-		suite.T().Fatalf("failed to connect to test database: %v", err)
-	}
-	suite.db = db
-
-	sqlDB, err := db.DB()
-	if err != nil {
-		suite.T().Fatalf("failed to get sql.DB: %v", err)
-	}
-
-	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
-
-	suite.service = &AnalyticsService{db: db}
+	suite.service = &AnalyticsService{db: suite.testDB.DB}
 }
 
 func (suite *AnalyticsServiceIntegrationTestSuite) TearDownSuite() {
-	if suite.container != nil {
-		if err := suite.container.Terminate(suite.ctx); err != nil {
-			suite.T().Logf("failed to terminate container: %v", err)
-		}
-	}
+	suite.testDB.Cleanup()
 }
 
 func (suite *AnalyticsServiceIntegrationTestSuite) TearDownTest() {

--- a/backend/internal/services/admin/api_token_test.go
+++ b/backend/internal/services/admin/api_token_test.go
@@ -1,18 +1,13 @@
 package admin
 
 import (
-	"context"
 	"fmt"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/internal/models"
@@ -109,67 +104,20 @@ func TestGenerateToken_Unique(t *testing.T) {
 
 type APITokenIntegrationTestSuite struct {
 	suite.Suite
-	container testcontainers.Container
-	db        *gorm.DB
-	svc       *APITokenService
-	ctx       context.Context
+	testDB *testutil.TestDatabase
+	db     *gorm.DB
+	svc    *APITokenService
 }
 
 func (suite *APITokenIntegrationTestSuite) SetupSuite() {
-	suite.ctx = context.Background()
+	suite.testDB = testutil.SetupTestPostgres(suite.T())
+	suite.db = suite.testDB.DB
 
-	container, err := testcontainers.GenericContainer(suite.ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "postgres:18",
-			ExposedPorts: []string{"5432/tcp"},
-			Env: map[string]string{
-				"POSTGRES_DB":       "test_db",
-				"POSTGRES_USER":     "test_user",
-				"POSTGRES_PASSWORD": "test_password",
-			},
-			WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(120 * time.Second),
-		},
-		Started: true,
-	})
-	if err != nil {
-		suite.T().Fatalf("failed to start postgres container: %v", err)
-	}
-	suite.container = container
-
-	host, err := container.Host(suite.ctx)
-	if err != nil {
-		suite.T().Fatalf("failed to get host: %v", err)
-	}
-	port, err := container.MappedPort(suite.ctx, "5432")
-	if err != nil {
-		suite.T().Fatalf("failed to get port: %v", err)
-	}
-
-	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
-		host, port.Port())
-
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	if err != nil {
-		suite.T().Fatalf("failed to connect to test database: %v", err)
-	}
-	suite.db = db
-
-	sqlDB, err := db.DB()
-	if err != nil {
-		suite.T().Fatalf("failed to get sql.DB: %v", err)
-	}
-
-	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
-
-	suite.svc = &APITokenService{db: db}
+	suite.svc = &APITokenService{db: suite.testDB.DB}
 }
 
 func (suite *APITokenIntegrationTestSuite) TearDownSuite() {
-	if suite.container != nil {
-		if err := suite.container.Terminate(suite.ctx); err != nil {
-			suite.T().Logf("failed to terminate container: %v", err)
-		}
-	}
+	suite.testDB.Cleanup()
 }
 
 func (suite *APITokenIntegrationTestSuite) TearDownTest() {

--- a/backend/internal/services/admin/artist_report_test.go
+++ b/backend/internal/services/admin/artist_report_test.go
@@ -1,17 +1,12 @@
 package admin
 
 import (
-	"context"
 	"fmt"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/internal/models"
@@ -80,67 +75,20 @@ func TestArtistReportService_NilDatabase(t *testing.T) {
 
 type ArtistReportServiceIntegrationTestSuite struct {
 	suite.Suite
-	container     testcontainers.Container
+	testDB        *testutil.TestDatabase
 	db            *gorm.DB
 	reportService *ArtistReportService
-	ctx           context.Context
 }
 
 func (suite *ArtistReportServiceIntegrationTestSuite) SetupSuite() {
-	suite.ctx = context.Background()
+	suite.testDB = testutil.SetupTestPostgres(suite.T())
+	suite.db = suite.testDB.DB
 
-	container, err := testcontainers.GenericContainer(suite.ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "postgres:18",
-			ExposedPorts: []string{"5432/tcp"},
-			Env: map[string]string{
-				"POSTGRES_DB":       "test_db",
-				"POSTGRES_USER":     "test_user",
-				"POSTGRES_PASSWORD": "test_password",
-			},
-			WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(120 * time.Second),
-		},
-		Started: true,
-	})
-	if err != nil {
-		suite.T().Fatalf("failed to start postgres container: %v", err)
-	}
-	suite.container = container
-
-	host, err := container.Host(suite.ctx)
-	if err != nil {
-		suite.T().Fatalf("failed to get host: %v", err)
-	}
-	port, err := container.MappedPort(suite.ctx, "5432")
-	if err != nil {
-		suite.T().Fatalf("failed to get port: %v", err)
-	}
-
-	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
-		host, port.Port())
-
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	if err != nil {
-		suite.T().Fatalf("failed to connect to test database: %v", err)
-	}
-	suite.db = db
-
-	sqlDB, err := db.DB()
-	if err != nil {
-		suite.T().Fatalf("failed to get sql.DB: %v", err)
-	}
-
-	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
-
-	suite.reportService = &ArtistReportService{db: db}
+	suite.reportService = &ArtistReportService{db: suite.testDB.DB}
 }
 
 func (suite *ArtistReportServiceIntegrationTestSuite) TearDownSuite() {
-	if suite.container != nil {
-		if err := suite.container.Terminate(suite.ctx); err != nil {
-			suite.T().Logf("failed to terminate container: %v", err)
-		}
-	}
+	suite.testDB.Cleanup()
 }
 
 func (suite *ArtistReportServiceIntegrationTestSuite) TearDownTest() {

--- a/backend/internal/services/admin/audit_log_test.go
+++ b/backend/internal/services/admin/audit_log_test.go
@@ -1,17 +1,12 @@
 package admin
 
 import (
-	"context"
 	"fmt"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/internal/models"
@@ -54,67 +49,20 @@ func TestAuditLogService_NilDatabase(t *testing.T) {
 
 type AuditLogServiceIntegrationTestSuite struct {
 	suite.Suite
-	container       testcontainers.Container
+	testDB          *testutil.TestDatabase
 	db              *gorm.DB
 	auditLogService *AuditLogService
-	ctx             context.Context
 }
 
 func (suite *AuditLogServiceIntegrationTestSuite) SetupSuite() {
-	suite.ctx = context.Background()
+	suite.testDB = testutil.SetupTestPostgres(suite.T())
+	suite.db = suite.testDB.DB
 
-	container, err := testcontainers.GenericContainer(suite.ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "postgres:18",
-			ExposedPorts: []string{"5432/tcp"},
-			Env: map[string]string{
-				"POSTGRES_DB":       "test_db",
-				"POSTGRES_USER":     "test_user",
-				"POSTGRES_PASSWORD": "test_password",
-			},
-			WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(120 * time.Second),
-		},
-		Started: true,
-	})
-	if err != nil {
-		suite.T().Fatalf("failed to start postgres container: %v", err)
-	}
-	suite.container = container
-
-	host, err := container.Host(suite.ctx)
-	if err != nil {
-		suite.T().Fatalf("failed to get host: %v", err)
-	}
-	port, err := container.MappedPort(suite.ctx, "5432")
-	if err != nil {
-		suite.T().Fatalf("failed to get port: %v", err)
-	}
-
-	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
-		host, port.Port())
-
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	if err != nil {
-		suite.T().Fatalf("failed to connect to test database: %v", err)
-	}
-	suite.db = db
-
-	sqlDB, err := db.DB()
-	if err != nil {
-		suite.T().Fatalf("failed to get sql.DB: %v", err)
-	}
-
-	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
-
-	suite.auditLogService = &AuditLogService{db: db}
+	suite.auditLogService = &AuditLogService{db: suite.testDB.DB}
 }
 
 func (suite *AuditLogServiceIntegrationTestSuite) TearDownSuite() {
-	if suite.container != nil {
-		if err := suite.container.Terminate(suite.ctx); err != nil {
-			suite.T().Logf("failed to terminate container: %v", err)
-		}
-	}
+	suite.testDB.Cleanup()
 }
 
 func (suite *AuditLogServiceIntegrationTestSuite) TearDownTest() {

--- a/backend/internal/services/admin/data_quality_test.go
+++ b/backend/internal/services/admin/data_quality_test.go
@@ -1,17 +1,12 @@
 package admin
 
 import (
-	"context"
 	"fmt"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/internal/models"
@@ -55,67 +50,20 @@ func TestDataQualityService_InvalidCategory(t *testing.T) {
 
 type DataQualityServiceIntegrationTestSuite struct {
 	suite.Suite
-	container testcontainers.Container
-	db        *gorm.DB
-	service   *DataQualityService
-	ctx       context.Context
+	testDB  *testutil.TestDatabase
+	db      *gorm.DB
+	service *DataQualityService
 }
 
 func (suite *DataQualityServiceIntegrationTestSuite) SetupSuite() {
-	suite.ctx = context.Background()
+	suite.testDB = testutil.SetupTestPostgres(suite.T())
+	suite.db = suite.testDB.DB
 
-	container, err := testcontainers.GenericContainer(suite.ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "postgres:18",
-			ExposedPorts: []string{"5432/tcp"},
-			Env: map[string]string{
-				"POSTGRES_DB":       "test_db",
-				"POSTGRES_USER":     "test_user",
-				"POSTGRES_PASSWORD": "test_password",
-			},
-			WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(120 * time.Second),
-		},
-		Started: true,
-	})
-	if err != nil {
-		suite.T().Fatalf("failed to start postgres container: %v", err)
-	}
-	suite.container = container
-
-	host, err := container.Host(suite.ctx)
-	if err != nil {
-		suite.T().Fatalf("failed to get host: %v", err)
-	}
-	port, err := container.MappedPort(suite.ctx, "5432")
-	if err != nil {
-		suite.T().Fatalf("failed to get port: %v", err)
-	}
-
-	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
-		host, port.Port())
-
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	if err != nil {
-		suite.T().Fatalf("failed to connect to test database: %v", err)
-	}
-	suite.db = db
-
-	sqlDB, err := db.DB()
-	if err != nil {
-		suite.T().Fatalf("failed to get sql.DB: %v", err)
-	}
-
-	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
-
-	suite.service = &DataQualityService{db: db}
+	suite.service = &DataQualityService{db: suite.testDB.DB}
 }
 
 func (suite *DataQualityServiceIntegrationTestSuite) TearDownSuite() {
-	if suite.container != nil {
-		if err := suite.container.Terminate(suite.ctx); err != nil {
-			suite.T().Logf("failed to terminate container: %v", err)
-		}
-	}
+	suite.testDB.Cleanup()
 }
 
 func (suite *DataQualityServiceIntegrationTestSuite) TearDownTest() {

--- a/backend/internal/services/admin/data_sync_test.go
+++ b/backend/internal/services/admin/data_sync_test.go
@@ -1,18 +1,13 @@
 package admin
 
 import (
-	"context"
 	"fmt"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/internal/models"
@@ -75,67 +70,20 @@ func TestDataSyncService_NilDB(t *testing.T) {
 
 type DataSyncServiceIntegrationTestSuite struct {
 	suite.Suite
-	container testcontainers.Container
-	db        *gorm.DB
-	service   *DataSyncService
-	ctx       context.Context
+	testDB  *testutil.TestDatabase
+	db      *gorm.DB
+	service *DataSyncService
 }
 
 func (suite *DataSyncServiceIntegrationTestSuite) SetupSuite() {
-	suite.ctx = context.Background()
+	suite.testDB = testutil.SetupTestPostgres(suite.T())
+	suite.db = suite.testDB.DB
 
-	container, err := testcontainers.GenericContainer(suite.ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "postgres:18",
-			ExposedPorts: []string{"5432/tcp"},
-			Env: map[string]string{
-				"POSTGRES_DB":       "test_db",
-				"POSTGRES_USER":     "test_user",
-				"POSTGRES_PASSWORD": "test_password",
-			},
-			WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(120 * time.Second),
-		},
-		Started: true,
-	})
-	if err != nil {
-		suite.T().Fatalf("failed to start postgres container: %v", err)
-	}
-	suite.container = container
-
-	host, err := container.Host(suite.ctx)
-	if err != nil {
-		suite.T().Fatalf("failed to get host: %v", err)
-	}
-	port, err := container.MappedPort(suite.ctx, "5432")
-	if err != nil {
-		suite.T().Fatalf("failed to get port: %v", err)
-	}
-
-	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
-		host, port.Port())
-
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	if err != nil {
-		suite.T().Fatalf("failed to connect to test database: %v", err)
-	}
-	suite.db = db
-
-	sqlDB, err := db.DB()
-	if err != nil {
-		suite.T().Fatalf("failed to get sql.DB: %v", err)
-	}
-
-	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
-
-	suite.service = NewDataSyncService(db)
+	suite.service = NewDataSyncService(suite.testDB.DB)
 }
 
 func (suite *DataSyncServiceIntegrationTestSuite) TearDownSuite() {
-	if suite.container != nil {
-		if err := suite.container.Terminate(suite.ctx); err != nil {
-			suite.T().Logf("failed to terminate container: %v", err)
-		}
-	}
+	suite.testDB.Cleanup()
 }
 
 func (suite *DataSyncServiceIntegrationTestSuite) TearDownTest() {

--- a/backend/internal/services/admin/revision_test.go
+++ b/backend/internal/services/admin/revision_test.go
@@ -1,18 +1,13 @@
 package admin
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/internal/models"
@@ -74,67 +69,20 @@ func TestRevisionService_NilDatabase(t *testing.T) {
 
 type RevisionServiceIntegrationTestSuite struct {
 	suite.Suite
-	container testcontainers.Container
-	db        *gorm.DB
-	svc       *RevisionService
-	ctx       context.Context
+	testDB *testutil.TestDatabase
+	db     *gorm.DB
+	svc    *RevisionService
 }
 
 func (s *RevisionServiceIntegrationTestSuite) SetupSuite() {
-	s.ctx = context.Background()
+	s.testDB = testutil.SetupTestPostgres(s.T())
+	s.db = s.testDB.DB
 
-	container, err := testcontainers.GenericContainer(s.ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "postgres:18",
-			ExposedPorts: []string{"5432/tcp"},
-			Env: map[string]string{
-				"POSTGRES_DB":       "test_db",
-				"POSTGRES_USER":     "test_user",
-				"POSTGRES_PASSWORD": "test_password",
-			},
-			WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(120 * time.Second),
-		},
-		Started: true,
-	})
-	if err != nil {
-		s.T().Fatalf("failed to start postgres container: %v", err)
-	}
-	s.container = container
-
-	host, err := container.Host(s.ctx)
-	if err != nil {
-		s.T().Fatalf("failed to get host: %v", err)
-	}
-	port, err := container.MappedPort(s.ctx, "5432")
-	if err != nil {
-		s.T().Fatalf("failed to get port: %v", err)
-	}
-
-	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
-		host, port.Port())
-
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	if err != nil {
-		s.T().Fatalf("failed to connect to test database: %v", err)
-	}
-	s.db = db
-
-	sqlDB, err := db.DB()
-	if err != nil {
-		s.T().Fatalf("failed to get sql.DB: %v", err)
-	}
-
-	testutil.RunAllMigrations(s.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
-
-	s.svc = NewRevisionService(db)
+	s.svc = NewRevisionService(s.testDB.DB)
 }
 
 func (s *RevisionServiceIntegrationTestSuite) TearDownSuite() {
-	if s.container != nil {
-		if err := s.container.Terminate(s.ctx); err != nil {
-			s.T().Logf("failed to terminate container: %v", err)
-		}
-	}
+	s.testDB.Cleanup()
 }
 
 func (s *RevisionServiceIntegrationTestSuite) TearDownTest() {

--- a/backend/internal/services/admin/show_report_test.go
+++ b/backend/internal/services/admin/show_report_test.go
@@ -1,17 +1,12 @@
 package admin
 
 import (
-	"context"
 	"fmt"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/internal/models"
@@ -87,67 +82,20 @@ func TestShowReportService_NilDatabase(t *testing.T) {
 
 type ShowReportServiceIntegrationTestSuite struct {
 	suite.Suite
-	container     testcontainers.Container
+	testDB        *testutil.TestDatabase
 	db            *gorm.DB
 	reportService *ShowReportService
-	ctx           context.Context
 }
 
 func (suite *ShowReportServiceIntegrationTestSuite) SetupSuite() {
-	suite.ctx = context.Background()
+	suite.testDB = testutil.SetupTestPostgres(suite.T())
+	suite.db = suite.testDB.DB
 
-	container, err := testcontainers.GenericContainer(suite.ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "postgres:18",
-			ExposedPorts: []string{"5432/tcp"},
-			Env: map[string]string{
-				"POSTGRES_DB":       "test_db",
-				"POSTGRES_USER":     "test_user",
-				"POSTGRES_PASSWORD": "test_password",
-			},
-			WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(120 * time.Second),
-		},
-		Started: true,
-	})
-	if err != nil {
-		suite.T().Fatalf("failed to start postgres container: %v", err)
-	}
-	suite.container = container
-
-	host, err := container.Host(suite.ctx)
-	if err != nil {
-		suite.T().Fatalf("failed to get host: %v", err)
-	}
-	port, err := container.MappedPort(suite.ctx, "5432")
-	if err != nil {
-		suite.T().Fatalf("failed to get port: %v", err)
-	}
-
-	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
-		host, port.Port())
-
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	if err != nil {
-		suite.T().Fatalf("failed to connect to test database: %v", err)
-	}
-	suite.db = db
-
-	sqlDB, err := db.DB()
-	if err != nil {
-		suite.T().Fatalf("failed to get sql.DB: %v", err)
-	}
-
-	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
-
-	suite.reportService = &ShowReportService{db: db}
+	suite.reportService = &ShowReportService{db: suite.testDB.DB}
 }
 
 func (suite *ShowReportServiceIntegrationTestSuite) TearDownSuite() {
-	if suite.container != nil {
-		if err := suite.container.Terminate(suite.ctx); err != nil {
-			suite.T().Logf("failed to terminate container: %v", err)
-		}
-	}
+	suite.testDB.Cleanup()
 }
 
 func (suite *ShowReportServiceIntegrationTestSuite) TearDownTest() {

--- a/backend/internal/services/admin/stats_test.go
+++ b/backend/internal/services/admin/stats_test.go
@@ -1,17 +1,12 @@
 package admin
 
 import (
-	"context"
 	"fmt"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/internal/models"
@@ -55,67 +50,20 @@ func TestAdminStatsService_NilDB_GetRecentActivity(t *testing.T) {
 
 type AdminStatsServiceIntegrationTestSuite struct {
 	suite.Suite
-	container testcontainers.Container
-	db        *gorm.DB
-	service   *AdminStatsService
-	ctx       context.Context
+	testDB  *testutil.TestDatabase
+	db      *gorm.DB
+	service *AdminStatsService
 }
 
 func (suite *AdminStatsServiceIntegrationTestSuite) SetupSuite() {
-	suite.ctx = context.Background()
+	suite.testDB = testutil.SetupTestPostgres(suite.T())
+	suite.db = suite.testDB.DB
 
-	container, err := testcontainers.GenericContainer(suite.ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "postgres:18",
-			ExposedPorts: []string{"5432/tcp"},
-			Env: map[string]string{
-				"POSTGRES_DB":       "test_db",
-				"POSTGRES_USER":     "test_user",
-				"POSTGRES_PASSWORD": "test_password",
-			},
-			WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(120 * time.Second),
-		},
-		Started: true,
-	})
-	if err != nil {
-		suite.T().Fatalf("failed to start postgres container: %v", err)
-	}
-	suite.container = container
-
-	host, err := container.Host(suite.ctx)
-	if err != nil {
-		suite.T().Fatalf("failed to get host: %v", err)
-	}
-	port, err := container.MappedPort(suite.ctx, "5432")
-	if err != nil {
-		suite.T().Fatalf("failed to get port: %v", err)
-	}
-
-	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
-		host, port.Port())
-
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	if err != nil {
-		suite.T().Fatalf("failed to connect to test database: %v", err)
-	}
-	suite.db = db
-
-	sqlDB, err := db.DB()
-	if err != nil {
-		suite.T().Fatalf("failed to get sql.DB: %v", err)
-	}
-
-	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
-
-	suite.service = &AdminStatsService{db: db}
+	suite.service = &AdminStatsService{db: suite.testDB.DB}
 }
 
 func (suite *AdminStatsServiceIntegrationTestSuite) TearDownSuite() {
-	if suite.container != nil {
-		if err := suite.container.Terminate(suite.ctx); err != nil {
-			suite.T().Logf("failed to terminate container: %v", err)
-		}
-	}
+	suite.testDB.Cleanup()
 }
 
 func (suite *AdminStatsServiceIntegrationTestSuite) TearDownTest() {

--- a/backend/internal/services/auth/apple_test.go
+++ b/backend/internal/services/auth/apple_test.go
@@ -1,15 +1,12 @@
 package auth
 
 import (
-	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/base64"
-	"fmt"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -17,9 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/internal/config"
@@ -331,55 +325,14 @@ func createAppleIdentityToken(t *testing.T, privateKey *rsa.PrivateKey, kid, aud
 
 type AppleAuthIntegrationTestSuite struct {
 	suite.Suite
-	container testcontainers.Container
-	db        *gorm.DB
-	ctx       context.Context
-	cfg       *config.Config
+	testDB *testutil.TestDatabase
+	db     *gorm.DB
+	cfg    *config.Config
 }
 
 func (s *AppleAuthIntegrationTestSuite) SetupSuite() {
-	s.ctx = context.Background()
-
-	container, err := testcontainers.GenericContainer(s.ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "postgres:18",
-			ExposedPorts: []string{"5432/tcp"},
-			Env: map[string]string{
-				"POSTGRES_DB":       "test_db",
-				"POSTGRES_USER":     "test_user",
-				"POSTGRES_PASSWORD": "test_password",
-			},
-			WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(120 * time.Second),
-		},
-		Started: true,
-	})
-	if err != nil {
-		s.T().Fatalf("failed to start postgres container: %v", err)
-	}
-	s.container = container
-
-	host, err := container.Host(s.ctx)
-	if err != nil {
-		s.T().Fatalf("failed to get host: %v", err)
-	}
-	port, err := container.MappedPort(s.ctx, "5432")
-	if err != nil {
-		s.T().Fatalf("failed to get port: %v", err)
-	}
-
-	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
-		host, port.Port())
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	if err != nil {
-		s.T().Fatalf("failed to connect to test database: %v", err)
-	}
-	s.db = db
-
-	sqlDB, err := db.DB()
-	if err != nil {
-		s.T().Fatalf("failed to get sql.DB: %v", err)
-	}
-	testutil.RunAllMigrations(s.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
+	s.testDB = testutil.SetupTestPostgres(s.T())
+	s.db = s.testDB.DB
 
 	s.cfg = &config.Config{
 		Apple: config.AppleConfig{BundleID: "com.test.app"},
@@ -388,11 +341,7 @@ func (s *AppleAuthIntegrationTestSuite) SetupSuite() {
 }
 
 func (s *AppleAuthIntegrationTestSuite) TearDownSuite() {
-	if s.container != nil {
-		if err := s.container.Terminate(s.ctx); err != nil {
-			s.T().Logf("failed to terminate container: %v", err)
-		}
-	}
+	s.testDB.Cleanup()
 }
 
 func (s *AppleAuthIntegrationTestSuite) TearDownTest() {

--- a/backend/internal/services/auth/webauthn_test.go
+++ b/backend/internal/services/auth/webauthn_test.go
@@ -1,9 +1,7 @@
 package auth
 
 import (
-	"context"
 	"fmt"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -11,9 +9,6 @@ import (
 	"github.com/go-webauthn/webauthn/webauthn"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/internal/config"
@@ -74,57 +69,14 @@ func TestNewWebAuthnService_DefaultOrigins(t *testing.T) {
 
 type WebAuthnServiceIntegrationTestSuite struct {
 	suite.Suite
-	container testcontainers.Container
-	db        *gorm.DB
-	service   *WebAuthnService
-	ctx       context.Context
+	testDB  *testutil.TestDatabase
+	db      *gorm.DB
+	service *WebAuthnService
 }
 
 func (suite *WebAuthnServiceIntegrationTestSuite) SetupSuite() {
-	suite.ctx = context.Background()
-
-	container, err := testcontainers.GenericContainer(suite.ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "postgres:18",
-			ExposedPorts: []string{"5432/tcp"},
-			Env: map[string]string{
-				"POSTGRES_DB":       "test_db",
-				"POSTGRES_USER":     "test_user",
-				"POSTGRES_PASSWORD": "test_password",
-			},
-			WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(120 * time.Second),
-		},
-		Started: true,
-	})
-	if err != nil {
-		suite.T().Fatalf("failed to start postgres container: %v", err)
-	}
-	suite.container = container
-
-	host, err := container.Host(suite.ctx)
-	if err != nil {
-		suite.T().Fatalf("failed to get host: %v", err)
-	}
-	port, err := container.MappedPort(suite.ctx, "5432")
-	if err != nil {
-		suite.T().Fatalf("failed to get port: %v", err)
-	}
-
-	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
-		host, port.Port())
-
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	if err != nil {
-		suite.T().Fatalf("failed to connect to test database: %v", err)
-	}
-	suite.db = db
-
-	sqlDB, err := db.DB()
-	if err != nil {
-		suite.T().Fatalf("failed to get sql.DB: %v", err)
-	}
-
-	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
+	suite.testDB = testutil.SetupTestPostgres(suite.T())
+	suite.db = suite.testDB.DB
 
 	cfg := &config.Config{
 		WebAuthn: config.WebAuthnConfig{
@@ -135,7 +87,7 @@ func (suite *WebAuthnServiceIntegrationTestSuite) SetupSuite() {
 		Email: config.EmailConfig{FrontendURL: "http://localhost:3000"},
 	}
 
-	svc, err := NewWebAuthnService(db, cfg)
+	svc, err := NewWebAuthnService(suite.testDB.DB, cfg)
 	if err != nil {
 		suite.T().Fatalf("failed to create webauthn service: %v", err)
 	}
@@ -143,11 +95,7 @@ func (suite *WebAuthnServiceIntegrationTestSuite) SetupSuite() {
 }
 
 func (suite *WebAuthnServiceIntegrationTestSuite) TearDownSuite() {
-	if suite.container != nil {
-		if err := suite.container.Terminate(suite.ctx); err != nil {
-			suite.T().Logf("failed to terminate container: %v", err)
-		}
-	}
+	suite.testDB.Cleanup()
 }
 
 func (suite *WebAuthnServiceIntegrationTestSuite) TearDownTest() {

--- a/backend/internal/services/catalog/artist_relationship_service_test.go
+++ b/backend/internal/services/catalog/artist_relationship_service_test.go
@@ -1,17 +1,12 @@
 package catalog
 
 import (
-	"context"
 	"fmt"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/internal/models"
@@ -91,56 +86,21 @@ func TestArtistRelationshipService_NilDatabase(t *testing.T) {
 
 type ArtistRelationshipServiceIntegrationTestSuite struct {
 	suite.Suite
-	container testcontainers.Container
-	db        *gorm.DB
-	svc       *ArtistRelationshipService
-	ctx       context.Context
+	testDB *testutil.TestDatabase
+	db     *gorm.DB
+	svc    *ArtistRelationshipService
 }
 
 func (suite *ArtistRelationshipServiceIntegrationTestSuite) SetupSuite() {
-	suite.ctx = context.Background()
+	suite.testDB = testutil.SetupTestPostgres(suite.T())
+	suite.db = suite.testDB.DB
 
-	container, err := testcontainers.GenericContainer(suite.ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "postgres:18",
-			ExposedPorts: []string{"5432/tcp"},
-			Env: map[string]string{
-				"POSTGRES_DB":       "test_db",
-				"POSTGRES_USER":     "test_user",
-				"POSTGRES_PASSWORD": "test_password",
-			},
-			WaitingFor: wait.ForLog("database system is ready to accept connections").
-				WithOccurrence(2).
-				WithStartupTimeout(120 * time.Second),
-		},
-		Started: true,
-	})
-	suite.Require().NoError(err)
-	suite.container = container
-
-	host, err := container.Host(suite.ctx)
-	suite.Require().NoError(err)
-	port, err := container.MappedPort(suite.ctx, "5432")
-	suite.Require().NoError(err)
-
-	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
-		host, port.Port())
-
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	suite.Require().NoError(err)
-
-	sqlDB, err := db.DB()
-	suite.Require().NoError(err)
-	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
-
-	suite.db = db
-	suite.svc = NewArtistRelationshipService(db)
+	suite.db = suite.testDB.DB
+	suite.svc = NewArtistRelationshipService(suite.testDB.DB)
 }
 
 func (suite *ArtistRelationshipServiceIntegrationTestSuite) TearDownSuite() {
-	if suite.container != nil {
-		_ = suite.container.Terminate(suite.ctx)
-	}
+	suite.testDB.Cleanup()
 }
 
 func (suite *ArtistRelationshipServiceIntegrationTestSuite) SetupTest() {

--- a/backend/internal/services/catalog/artist_test.go
+++ b/backend/internal/services/catalog/artist_test.go
@@ -1,22 +1,17 @@
 package catalog
 
 import (
-	"context"
 	"fmt"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	apperrors "psychic-homily-backend/internal/errors"
-	"psychic-homily-backend/internal/services/contracts"
 	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
 	"psychic-homily-backend/internal/testutil"
 )
 
@@ -143,67 +138,20 @@ func TestArtistService_NilDatabase(t *testing.T) {
 
 type ArtistServiceIntegrationTestSuite struct {
 	suite.Suite
-	container     testcontainers.Container
+	testDB        *testutil.TestDatabase
 	db            *gorm.DB
 	artistService *ArtistService
-	ctx           context.Context
 }
 
 func (suite *ArtistServiceIntegrationTestSuite) SetupSuite() {
-	suite.ctx = context.Background()
+	suite.testDB = testutil.SetupTestPostgres(suite.T())
+	suite.db = suite.testDB.DB
 
-	// Start PostgreSQL container
-	container, err := testcontainers.GenericContainer(suite.ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "postgres:18",
-			ExposedPorts: []string{"5432/tcp"},
-			Env: map[string]string{
-				"POSTGRES_DB":       "test_db",
-				"POSTGRES_USER":     "test_user",
-				"POSTGRES_PASSWORD": "test_password",
-			},
-			WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(120 * time.Second),
-		},
-		Started: true,
-	})
-	if err != nil {
-		suite.T().Fatalf("failed to start postgres container: %v", err)
-	}
-	suite.container = container
-
-	host, err := container.Host(suite.ctx)
-	if err != nil {
-		suite.T().Fatalf("failed to get host: %v", err)
-	}
-	port, err := container.MappedPort(suite.ctx, "5432")
-	if err != nil {
-		suite.T().Fatalf("failed to get port: %v", err)
-	}
-
-	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
-		host, port.Port())
-
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	if err != nil {
-		suite.T().Fatalf("failed to connect to test database: %v", err)
-	}
-	suite.db = db
-
-	sqlDB, err := db.DB()
-	if err != nil {
-		suite.T().Fatalf("failed to get sql.DB: %v", err)
-	}
-	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
-
-	suite.artistService = &ArtistService{db: db}
+	suite.artistService = &ArtistService{db: suite.testDB.DB}
 }
 
 func (suite *ArtistServiceIntegrationTestSuite) TearDownSuite() {
-	if suite.container != nil {
-		if err := suite.container.Terminate(suite.ctx); err != nil {
-			suite.T().Logf("failed to terminate container: %v", err)
-		}
-	}
+	suite.testDB.Cleanup()
 }
 
 // TearDownTest cleans up data between tests for isolation

--- a/backend/internal/services/catalog/charts_service_test.go
+++ b/backend/internal/services/catalog/charts_service_test.go
@@ -1,17 +1,12 @@
 package catalog
 
 import (
-	"context"
 	"fmt"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/internal/models"
@@ -72,66 +67,20 @@ func TestChartsService_NilDatabase(t *testing.T) {
 
 type ChartsServiceIntegrationTestSuite struct {
 	suite.Suite
-	container     testcontainers.Container
+	testDB        *testutil.TestDatabase
 	db            *gorm.DB
 	chartsService *ChartsService
-	ctx           context.Context
 }
 
 func (suite *ChartsServiceIntegrationTestSuite) SetupSuite() {
-	suite.ctx = context.Background()
+	suite.testDB = testutil.SetupTestPostgres(suite.T())
+	suite.db = suite.testDB.DB
 
-	container, err := testcontainers.GenericContainer(suite.ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "postgres:18",
-			ExposedPorts: []string{"5432/tcp"},
-			Env: map[string]string{
-				"POSTGRES_DB":       "test_db",
-				"POSTGRES_USER":     "test_user",
-				"POSTGRES_PASSWORD": "test_password",
-			},
-			WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(120 * time.Second),
-		},
-		Started: true,
-	})
-	if err != nil {
-		suite.T().Fatalf("failed to start postgres container: %v", err)
-	}
-	suite.container = container
-
-	host, err := container.Host(suite.ctx)
-	if err != nil {
-		suite.T().Fatalf("failed to get host: %v", err)
-	}
-	port, err := container.MappedPort(suite.ctx, "5432")
-	if err != nil {
-		suite.T().Fatalf("failed to get port: %v", err)
-	}
-
-	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
-		host, port.Port())
-
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	if err != nil {
-		suite.T().Fatalf("failed to connect to test database: %v", err)
-	}
-	suite.db = db
-
-	sqlDB, err := db.DB()
-	if err != nil {
-		suite.T().Fatalf("failed to get sql.DB: %v", err)
-	}
-	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
-
-	suite.chartsService = &ChartsService{db: db}
+	suite.chartsService = &ChartsService{db: suite.testDB.DB}
 }
 
 func (suite *ChartsServiceIntegrationTestSuite) TearDownSuite() {
-	if suite.container != nil {
-		if err := suite.container.Terminate(suite.ctx); err != nil {
-			suite.T().Logf("failed to terminate container: %v", err)
-		}
-	}
+	suite.testDB.Cleanup()
 }
 
 func (suite *ChartsServiceIntegrationTestSuite) TearDownTest() {

--- a/backend/internal/services/catalog/festival_intelligence_test.go
+++ b/backend/internal/services/catalog/festival_intelligence_test.go
@@ -1,17 +1,11 @@
 package catalog
 
 import (
-	"context"
 	"fmt"
-	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/internal/models"
@@ -99,68 +93,22 @@ func TestRankToTier(t *testing.T) {
 
 type FestivalIntelligenceTestSuite struct {
 	suite.Suite
-	container  testcontainers.Container
-	db         *gorm.DB
-	svc        *FestivalIntelligenceService
-	festSvc    *FestivalService
-	ctx        context.Context
+	testDB  *testutil.TestDatabase
+	db      *gorm.DB
+	svc     *FestivalIntelligenceService
+	festSvc *FestivalService
 }
 
 func (suite *FestivalIntelligenceTestSuite) SetupSuite() {
-	suite.ctx = context.Background()
+	suite.testDB = testutil.SetupTestPostgres(suite.T())
+	suite.db = suite.testDB.DB
 
-	container, err := testcontainers.GenericContainer(suite.ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "postgres:18",
-			ExposedPorts: []string{"5432/tcp"},
-			Env: map[string]string{
-				"POSTGRES_DB":       "test_db",
-				"POSTGRES_USER":     "test_user",
-				"POSTGRES_PASSWORD": "test_password",
-			},
-			WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(120 * time.Second),
-		},
-		Started: true,
-	})
-	if err != nil {
-		suite.T().Fatalf("failed to start postgres container: %v", err)
-	}
-	suite.container = container
-
-	host, err := container.Host(suite.ctx)
-	if err != nil {
-		suite.T().Fatalf("failed to get host: %v", err)
-	}
-	port, err := container.MappedPort(suite.ctx, "5432")
-	if err != nil {
-		suite.T().Fatalf("failed to get port: %v", err)
-	}
-
-	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
-		host, port.Port())
-
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	if err != nil {
-		suite.T().Fatalf("failed to connect to test database: %v", err)
-	}
-	suite.db = db
-
-	sqlDB, err := db.DB()
-	if err != nil {
-		suite.T().Fatalf("failed to get sql.DB: %v", err)
-	}
-	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
-
-	suite.svc = &FestivalIntelligenceService{db: db}
-	suite.festSvc = &FestivalService{db: db}
+	suite.svc = &FestivalIntelligenceService{db: suite.testDB.DB}
+	suite.festSvc = &FestivalService{db: suite.testDB.DB}
 }
 
 func (suite *FestivalIntelligenceTestSuite) TearDownSuite() {
-	if suite.container != nil {
-		if err := suite.container.Terminate(suite.ctx); err != nil {
-			suite.T().Logf("failed to terminate container: %v", err)
-		}
-	}
+	suite.testDB.Cleanup()
 }
 
 func (suite *FestivalIntelligenceTestSuite) TearDownTest() {
@@ -631,6 +579,6 @@ func (suite *FestivalIntelligenceTestSuite) TestGetSeriesComparison_LineupGrowth
 	comparison, err := suite.svc.GetSeriesComparison("growth", []int{2024, 2025})
 
 	suite.Require().NoError(err)
-	suite.Equal(1.0, comparison.LineupGrowth) // (4-2)/2 = 1.0
+	suite.Equal(1.0, comparison.LineupGrowth)  // (4-2)/2 = 1.0
 	suite.Equal(1.0, comparison.RetentionRate) // Both returned
 }

--- a/backend/internal/services/catalog/festival_test.go
+++ b/backend/internal/services/catalog/festival_test.go
@@ -1,22 +1,15 @@
 package catalog
 
 import (
-	"context"
-	"fmt"
-	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	apperrors "psychic-homily-backend/internal/errors"
-	"psychic-homily-backend/internal/services/contracts"
 	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
 	"psychic-homily-backend/internal/testutil"
 	"psychic-homily-backend/internal/utils"
 )
@@ -135,71 +128,24 @@ func TestFestivalService_NilDatabase(t *testing.T) {
 
 type FestivalServiceIntegrationTestSuite struct {
 	suite.Suite
-	container       testcontainers.Container
+	testDB          *testutil.TestDatabase
 	db              *gorm.DB
 	festivalService *FestivalService
 	artistService   *ArtistService
 	venueService    *VenueService
-	ctx             context.Context
 }
 
 func (suite *FestivalServiceIntegrationTestSuite) SetupSuite() {
-	suite.ctx = context.Background()
+	suite.testDB = testutil.SetupTestPostgres(suite.T())
+	suite.db = suite.testDB.DB
 
-	// Start PostgreSQL container
-	container, err := testcontainers.GenericContainer(suite.ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "postgres:18",
-			ExposedPorts: []string{"5432/tcp"},
-			Env: map[string]string{
-				"POSTGRES_DB":       "test_db",
-				"POSTGRES_USER":     "test_user",
-				"POSTGRES_PASSWORD": "test_password",
-			},
-			WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(120 * time.Second),
-		},
-		Started: true,
-	})
-	if err != nil {
-		suite.T().Fatalf("failed to start postgres container: %v", err)
-	}
-	suite.container = container
-
-	host, err := container.Host(suite.ctx)
-	if err != nil {
-		suite.T().Fatalf("failed to get host: %v", err)
-	}
-	port, err := container.MappedPort(suite.ctx, "5432")
-	if err != nil {
-		suite.T().Fatalf("failed to get port: %v", err)
-	}
-
-	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
-		host, port.Port())
-
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	if err != nil {
-		suite.T().Fatalf("failed to connect to test database: %v", err)
-	}
-	suite.db = db
-
-	sqlDB, err := db.DB()
-	if err != nil {
-		suite.T().Fatalf("failed to get sql.DB: %v", err)
-	}
-	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
-
-	suite.festivalService = &FestivalService{db: db}
-	suite.artistService = &ArtistService{db: db}
-	suite.venueService = &VenueService{db: db}
+	suite.festivalService = &FestivalService{db: suite.testDB.DB}
+	suite.artistService = &ArtistService{db: suite.testDB.DB}
+	suite.venueService = &VenueService{db: suite.testDB.DB}
 }
 
 func (suite *FestivalServiceIntegrationTestSuite) TearDownSuite() {
-	if suite.container != nil {
-		if err := suite.container.Terminate(suite.ctx); err != nil {
-			suite.T().Logf("failed to terminate container: %v", err)
-		}
-	}
+	suite.testDB.Cleanup()
 }
 
 // TearDownTest cleans up data between tests for isolation

--- a/backend/internal/services/catalog/label_test.go
+++ b/backend/internal/services/catalog/label_test.go
@@ -1,22 +1,15 @@
 package catalog
 
 import (
-	"context"
-	"fmt"
-	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	apperrors "psychic-homily-backend/internal/errors"
-	"psychic-homily-backend/internal/services/contracts"
 	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
 	"psychic-homily-backend/internal/testutil"
 )
 
@@ -94,71 +87,24 @@ func TestLabelService_NilDatabase(t *testing.T) {
 
 type LabelServiceIntegrationTestSuite struct {
 	suite.Suite
-	container      testcontainers.Container
+	testDB         *testutil.TestDatabase
 	db             *gorm.DB
 	labelService   *LabelService
 	artistService  *ArtistService
 	releaseService *ReleaseService
-	ctx            context.Context
 }
 
 func (suite *LabelServiceIntegrationTestSuite) SetupSuite() {
-	suite.ctx = context.Background()
+	suite.testDB = testutil.SetupTestPostgres(suite.T())
+	suite.db = suite.testDB.DB
 
-	// Start PostgreSQL container
-	container, err := testcontainers.GenericContainer(suite.ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "postgres:18",
-			ExposedPorts: []string{"5432/tcp"},
-			Env: map[string]string{
-				"POSTGRES_DB":       "test_db",
-				"POSTGRES_USER":     "test_user",
-				"POSTGRES_PASSWORD": "test_password",
-			},
-			WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(120 * time.Second),
-		},
-		Started: true,
-	})
-	if err != nil {
-		suite.T().Fatalf("failed to start postgres container: %v", err)
-	}
-	suite.container = container
-
-	host, err := container.Host(suite.ctx)
-	if err != nil {
-		suite.T().Fatalf("failed to get host: %v", err)
-	}
-	port, err := container.MappedPort(suite.ctx, "5432")
-	if err != nil {
-		suite.T().Fatalf("failed to get port: %v", err)
-	}
-
-	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
-		host, port.Port())
-
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	if err != nil {
-		suite.T().Fatalf("failed to connect to test database: %v", err)
-	}
-	suite.db = db
-
-	sqlDB, err := db.DB()
-	if err != nil {
-		suite.T().Fatalf("failed to get sql.DB: %v", err)
-	}
-	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
-
-	suite.labelService = &LabelService{db: db}
-	suite.artistService = &ArtistService{db: db}
-	suite.releaseService = &ReleaseService{db: db}
+	suite.labelService = &LabelService{db: suite.testDB.DB}
+	suite.artistService = &ArtistService{db: suite.testDB.DB}
+	suite.releaseService = &ReleaseService{db: suite.testDB.DB}
 }
 
 func (suite *LabelServiceIntegrationTestSuite) TearDownSuite() {
-	if suite.container != nil {
-		if err := suite.container.Terminate(suite.ctx); err != nil {
-			suite.T().Logf("failed to terminate container: %v", err)
-		}
-	}
+	suite.testDB.Cleanup()
 }
 
 // TearDownTest cleans up data between tests for isolation

--- a/backend/internal/services/catalog/release_test.go
+++ b/backend/internal/services/catalog/release_test.go
@@ -1,22 +1,15 @@
 package catalog
 
 import (
-	"context"
-	"fmt"
-	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	apperrors "psychic-homily-backend/internal/errors"
-	"psychic-homily-backend/internal/services/contracts"
 	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
 	"psychic-homily-backend/internal/testutil"
 )
 
@@ -100,69 +93,22 @@ func TestReleaseService_NilDatabase(t *testing.T) {
 
 type ReleaseServiceIntegrationTestSuite struct {
 	suite.Suite
-	container      testcontainers.Container
+	testDB         *testutil.TestDatabase
 	db             *gorm.DB
 	releaseService *ReleaseService
 	artistService  *ArtistService
-	ctx            context.Context
 }
 
 func (suite *ReleaseServiceIntegrationTestSuite) SetupSuite() {
-	suite.ctx = context.Background()
+	suite.testDB = testutil.SetupTestPostgres(suite.T())
+	suite.db = suite.testDB.DB
 
-	// Start PostgreSQL container
-	container, err := testcontainers.GenericContainer(suite.ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "postgres:18",
-			ExposedPorts: []string{"5432/tcp"},
-			Env: map[string]string{
-				"POSTGRES_DB":       "test_db",
-				"POSTGRES_USER":     "test_user",
-				"POSTGRES_PASSWORD": "test_password",
-			},
-			WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(120 * time.Second),
-		},
-		Started: true,
-	})
-	if err != nil {
-		suite.T().Fatalf("failed to start postgres container: %v", err)
-	}
-	suite.container = container
-
-	host, err := container.Host(suite.ctx)
-	if err != nil {
-		suite.T().Fatalf("failed to get host: %v", err)
-	}
-	port, err := container.MappedPort(suite.ctx, "5432")
-	if err != nil {
-		suite.T().Fatalf("failed to get port: %v", err)
-	}
-
-	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
-		host, port.Port())
-
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	if err != nil {
-		suite.T().Fatalf("failed to connect to test database: %v", err)
-	}
-	suite.db = db
-
-	sqlDB, err := db.DB()
-	if err != nil {
-		suite.T().Fatalf("failed to get sql.DB: %v", err)
-	}
-	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
-
-	suite.releaseService = &ReleaseService{db: db}
-	suite.artistService = &ArtistService{db: db}
+	suite.releaseService = &ReleaseService{db: suite.testDB.DB}
+	suite.artistService = &ArtistService{db: suite.testDB.DB}
 }
 
 func (suite *ReleaseServiceIntegrationTestSuite) TearDownSuite() {
-	if suite.container != nil {
-		if err := suite.container.Terminate(suite.ctx); err != nil {
-			suite.T().Logf("failed to terminate container: %v", err)
-		}
-	}
+	suite.testDB.Cleanup()
 }
 
 // TearDownTest cleans up data between tests for isolation

--- a/backend/internal/services/catalog/scene_test.go
+++ b/backend/internal/services/catalog/scene_test.go
@@ -1,17 +1,12 @@
 package catalog
 
 import (
-	"context"
 	"fmt"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/internal/models"
@@ -97,66 +92,20 @@ func TestBuildSceneSlug(t *testing.T) {
 
 type SceneServiceIntegrationTestSuite struct {
 	suite.Suite
-	container    testcontainers.Container
+	testDB       *testutil.TestDatabase
 	db           *gorm.DB
 	sceneService *SceneService
-	ctx          context.Context
 }
 
 func (suite *SceneServiceIntegrationTestSuite) SetupSuite() {
-	suite.ctx = context.Background()
+	suite.testDB = testutil.SetupTestPostgres(suite.T())
+	suite.db = suite.testDB.DB
 
-	container, err := testcontainers.GenericContainer(suite.ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "postgres:18",
-			ExposedPorts: []string{"5432/tcp"},
-			Env: map[string]string{
-				"POSTGRES_DB":       "test_db",
-				"POSTGRES_USER":     "test_user",
-				"POSTGRES_PASSWORD": "test_password",
-			},
-			WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(120 * time.Second),
-		},
-		Started: true,
-	})
-	if err != nil {
-		suite.T().Fatalf("failed to start postgres container: %v", err)
-	}
-	suite.container = container
-
-	host, err := container.Host(suite.ctx)
-	if err != nil {
-		suite.T().Fatalf("failed to get host: %v", err)
-	}
-	port, err := container.MappedPort(suite.ctx, "5432")
-	if err != nil {
-		suite.T().Fatalf("failed to get port: %v", err)
-	}
-
-	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
-		host, port.Port())
-
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	if err != nil {
-		suite.T().Fatalf("failed to connect to test database: %v", err)
-	}
-	suite.db = db
-
-	sqlDB, err := db.DB()
-	if err != nil {
-		suite.T().Fatalf("failed to get sql.DB: %v", err)
-	}
-	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
-
-	suite.sceneService = &SceneService{db: db}
+	suite.sceneService = &SceneService{db: suite.testDB.DB}
 }
 
 func (suite *SceneServiceIntegrationTestSuite) TearDownSuite() {
-	if suite.container != nil {
-		if err := suite.container.Terminate(suite.ctx); err != nil {
-			suite.T().Logf("failed to terminate container: %v", err)
-		}
-	}
+	suite.testDB.Cleanup()
 }
 
 func (suite *SceneServiceIntegrationTestSuite) TearDownTest() {

--- a/backend/internal/services/catalog/show_test.go
+++ b/backend/internal/services/catalog/show_test.go
@@ -1,23 +1,18 @@
 package catalog
 
 import (
-	"context"
 	"fmt"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	apperrors "psychic-homily-backend/internal/errors"
-	"psychic-homily-backend/internal/services/contracts"
 	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
 	"psychic-homily-backend/internal/testutil"
 )
 
@@ -207,67 +202,20 @@ func TestShowService_NilDatabase(t *testing.T) {
 
 type ShowServiceIntegrationTestSuite struct {
 	suite.Suite
-	container   testcontainers.Container
+	testDB      *testutil.TestDatabase
 	db          *gorm.DB
 	showService *ShowService
-	ctx         context.Context
 }
 
 func (suite *ShowServiceIntegrationTestSuite) SetupSuite() {
-	suite.ctx = context.Background()
+	suite.testDB = testutil.SetupTestPostgres(suite.T())
+	suite.db = suite.testDB.DB
 
-	// Start PostgreSQL container
-	container, err := testcontainers.GenericContainer(suite.ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "postgres:18",
-			ExposedPorts: []string{"5432/tcp"},
-			Env: map[string]string{
-				"POSTGRES_DB":       "test_db",
-				"POSTGRES_USER":     "test_user",
-				"POSTGRES_PASSWORD": "test_password",
-			},
-			WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(120 * time.Second),
-		},
-		Started: true,
-	})
-	if err != nil {
-		suite.T().Fatalf("failed to start postgres container: %v", err)
-	}
-	suite.container = container
-
-	host, err := container.Host(suite.ctx)
-	if err != nil {
-		suite.T().Fatalf("failed to get host: %v", err)
-	}
-	port, err := container.MappedPort(suite.ctx, "5432")
-	if err != nil {
-		suite.T().Fatalf("failed to get port: %v", err)
-	}
-
-	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
-		host, port.Port())
-
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	if err != nil {
-		suite.T().Fatalf("failed to connect to test database: %v", err)
-	}
-	suite.db = db
-
-	sqlDB, err := db.DB()
-	if err != nil {
-		suite.T().Fatalf("failed to get sql.DB: %v", err)
-	}
-	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
-
-	suite.showService = &ShowService{db: db}
+	suite.showService = &ShowService{db: suite.testDB.DB}
 }
 
 func (suite *ShowServiceIntegrationTestSuite) TearDownSuite() {
-	if suite.container != nil {
-		if err := suite.container.Terminate(suite.ctx); err != nil {
-			suite.T().Logf("failed to terminate container: %v", err)
-		}
-	}
+	suite.testDB.Cleanup()
 }
 
 // TearDownTest cleans up data between tests for isolation

--- a/backend/internal/services/catalog/tag_service_test.go
+++ b/backend/internal/services/catalog/tag_service_test.go
@@ -1,17 +1,12 @@
 package catalog
 
 import (
-	"context"
 	"fmt"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	apperrors "psychic-homily-backend/internal/errors"
@@ -191,56 +186,21 @@ func TestWilsonScore(t *testing.T) {
 
 type TagServiceIntegrationTestSuite struct {
 	suite.Suite
-	container  testcontainers.Container
+	testDB     *testutil.TestDatabase
 	db         *gorm.DB
 	tagService *TagService
-	ctx        context.Context
 }
 
 func (suite *TagServiceIntegrationTestSuite) SetupSuite() {
-	suite.ctx = context.Background()
+	suite.testDB = testutil.SetupTestPostgres(suite.T())
+	suite.db = suite.testDB.DB
 
-	container, err := testcontainers.GenericContainer(suite.ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "postgres:18",
-			ExposedPorts: []string{"5432/tcp"},
-			Env: map[string]string{
-				"POSTGRES_DB":       "test_db",
-				"POSTGRES_USER":     "test_user",
-				"POSTGRES_PASSWORD": "test_password",
-			},
-			WaitingFor: wait.ForLog("database system is ready to accept connections").
-				WithOccurrence(2).
-				WithStartupTimeout(120 * time.Second),
-		},
-		Started: true,
-	})
-	suite.Require().NoError(err)
-	suite.container = container
-
-	host, err := container.Host(suite.ctx)
-	suite.Require().NoError(err)
-	port, err := container.MappedPort(suite.ctx, "5432")
-	suite.Require().NoError(err)
-
-	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
-		host, port.Port())
-
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	suite.Require().NoError(err)
-
-	sqlDB, err := db.DB()
-	suite.Require().NoError(err)
-	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
-
-	suite.db = db
-	suite.tagService = NewTagService(db)
+	suite.db = suite.testDB.DB
+	suite.tagService = NewTagService(suite.testDB.DB)
 }
 
 func (suite *TagServiceIntegrationTestSuite) TearDownSuite() {
-	if suite.container != nil {
-		_ = suite.container.Terminate(suite.ctx)
-	}
+	suite.testDB.Cleanup()
 }
 
 func (suite *TagServiceIntegrationTestSuite) SetupTest() {

--- a/backend/internal/services/catalog/venue_test.go
+++ b/backend/internal/services/catalog/venue_test.go
@@ -1,22 +1,17 @@
 package catalog
 
 import (
-	"context"
 	"fmt"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	apperrors "psychic-homily-backend/internal/errors"
-	"psychic-homily-backend/internal/services/contracts"
 	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
 	"psychic-homily-backend/internal/testutil"
 )
 
@@ -204,67 +199,20 @@ func TestVenueService_NilDatabase(t *testing.T) {
 
 type VenueServiceIntegrationTestSuite struct {
 	suite.Suite
-	container    testcontainers.Container
+	testDB       *testutil.TestDatabase
 	db           *gorm.DB
 	venueService *VenueService
-	ctx          context.Context
 }
 
 func (suite *VenueServiceIntegrationTestSuite) SetupSuite() {
-	suite.ctx = context.Background()
+	suite.testDB = testutil.SetupTestPostgres(suite.T())
+	suite.db = suite.testDB.DB
 
-	// Start PostgreSQL container
-	container, err := testcontainers.GenericContainer(suite.ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "postgres:18",
-			ExposedPorts: []string{"5432/tcp"},
-			Env: map[string]string{
-				"POSTGRES_DB":       "test_db",
-				"POSTGRES_USER":     "test_user",
-				"POSTGRES_PASSWORD": "test_password",
-			},
-			WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(120 * time.Second),
-		},
-		Started: true,
-	})
-	if err != nil {
-		suite.T().Fatalf("failed to start postgres container: %v", err)
-	}
-	suite.container = container
-
-	host, err := container.Host(suite.ctx)
-	if err != nil {
-		suite.T().Fatalf("failed to get host: %v", err)
-	}
-	port, err := container.MappedPort(suite.ctx, "5432")
-	if err != nil {
-		suite.T().Fatalf("failed to get port: %v", err)
-	}
-
-	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
-		host, port.Port())
-
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	if err != nil {
-		suite.T().Fatalf("failed to connect to test database: %v", err)
-	}
-	suite.db = db
-
-	sqlDB, err := db.DB()
-	if err != nil {
-		suite.T().Fatalf("failed to get sql.DB: %v", err)
-	}
-	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
-
-	suite.venueService = &VenueService{db: db}
+	suite.venueService = &VenueService{db: suite.testDB.DB}
 }
 
 func (suite *VenueServiceIntegrationTestSuite) TearDownSuite() {
-	if suite.container != nil {
-		if err := suite.container.Terminate(suite.ctx); err != nil {
-			suite.T().Logf("failed to terminate container: %v", err)
-		}
-	}
+	suite.testDB.Cleanup()
 }
 
 // TearDownTest cleans up data between tests for isolation

--- a/backend/internal/services/collection_test.go
+++ b/backend/internal/services/collection_test.go
@@ -1,17 +1,12 @@
 package services
 
 import (
-	"context"
 	"fmt"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	apperrors "psychic-homily-backend/internal/errors"
@@ -131,66 +126,20 @@ func TestCollectionService_NilDatabase(t *testing.T) {
 
 type CollectionServiceIntegrationTestSuite struct {
 	suite.Suite
-	container         testcontainers.Container
+	testDB            *testutil.TestDatabase
 	db                *gorm.DB
 	collectionService *CollectionService
-	ctx               context.Context
 }
 
 func (suite *CollectionServiceIntegrationTestSuite) SetupSuite() {
-	suite.ctx = context.Background()
+	suite.testDB = testutil.SetupTestPostgres(suite.T())
+	suite.db = suite.testDB.DB
 
-	container, err := testcontainers.GenericContainer(suite.ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "postgres:18",
-			ExposedPorts: []string{"5432/tcp"},
-			Env: map[string]string{
-				"POSTGRES_DB":       "test_db",
-				"POSTGRES_USER":     "test_user",
-				"POSTGRES_PASSWORD": "test_password",
-			},
-			WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(120 * time.Second),
-		},
-		Started: true,
-	})
-	if err != nil {
-		suite.T().Fatalf("failed to start postgres container: %v", err)
-	}
-	suite.container = container
-
-	host, err := container.Host(suite.ctx)
-	if err != nil {
-		suite.T().Fatalf("failed to get host: %v", err)
-	}
-	port, err := container.MappedPort(suite.ctx, "5432")
-	if err != nil {
-		suite.T().Fatalf("failed to get port: %v", err)
-	}
-
-	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
-		host, port.Port())
-
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	if err != nil {
-		suite.T().Fatalf("failed to connect to test database: %v", err)
-	}
-	suite.db = db
-
-	sqlDB, err := db.DB()
-	if err != nil {
-		suite.T().Fatalf("failed to get sql.DB: %v", err)
-	}
-	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "db", "migrations"))
-
-	suite.collectionService = &CollectionService{db: db}
+	suite.collectionService = &CollectionService{db: suite.testDB.DB}
 }
 
 func (suite *CollectionServiceIntegrationTestSuite) TearDownSuite() {
-	if suite.container != nil {
-		if err := suite.container.Terminate(suite.ctx); err != nil {
-			suite.T().Logf("failed to terminate container: %v", err)
-		}
-	}
+	suite.testDB.Cleanup()
 }
 
 func (suite *CollectionServiceIntegrationTestSuite) TearDownTest() {

--- a/backend/internal/services/engagement/attendance_test.go
+++ b/backend/internal/services/engagement/attendance_test.go
@@ -1,17 +1,12 @@
 package engagement
 
 import (
-	"context"
 	"fmt"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/internal/models"
@@ -85,67 +80,20 @@ func TestAttendanceService_NilDatabase(t *testing.T) {
 
 type AttendanceServiceIntegrationTestSuite struct {
 	suite.Suite
-	container         testcontainers.Container
+	testDB            *testutil.TestDatabase
 	db                *gorm.DB
 	attendanceService *AttendanceService
-	ctx               context.Context
 }
 
 func (suite *AttendanceServiceIntegrationTestSuite) SetupSuite() {
-	suite.ctx = context.Background()
+	suite.testDB = testutil.SetupTestPostgres(suite.T())
+	suite.db = suite.testDB.DB
 
-	container, err := testcontainers.GenericContainer(suite.ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "postgres:18",
-			ExposedPorts: []string{"5432/tcp"},
-			Env: map[string]string{
-				"POSTGRES_DB":       "test_db",
-				"POSTGRES_USER":     "test_user",
-				"POSTGRES_PASSWORD": "test_password",
-			},
-			WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(120 * time.Second),
-		},
-		Started: true,
-	})
-	if err != nil {
-		suite.T().Fatalf("failed to start postgres container: %v", err)
-	}
-	suite.container = container
-
-	host, err := container.Host(suite.ctx)
-	if err != nil {
-		suite.T().Fatalf("failed to get host: %v", err)
-	}
-	port, err := container.MappedPort(suite.ctx, "5432")
-	if err != nil {
-		suite.T().Fatalf("failed to get port: %v", err)
-	}
-
-	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
-		host, port.Port())
-
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	if err != nil {
-		suite.T().Fatalf("failed to connect to test database: %v", err)
-	}
-	suite.db = db
-
-	sqlDB, err := db.DB()
-	if err != nil {
-		suite.T().Fatalf("failed to get sql.DB: %v", err)
-	}
-
-	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
-
-	suite.attendanceService = NewAttendanceService(db)
+	suite.attendanceService = NewAttendanceService(suite.testDB.DB)
 }
 
 func (suite *AttendanceServiceIntegrationTestSuite) TearDownSuite() {
-	if suite.container != nil {
-		if err := suite.container.Terminate(suite.ctx); err != nil {
-			suite.T().Logf("failed to terminate container: %v", err)
-		}
-	}
+	suite.testDB.Cleanup()
 }
 
 func (suite *AttendanceServiceIntegrationTestSuite) TearDownTest() {

--- a/backend/internal/services/engagement/bookmark_test.go
+++ b/backend/internal/services/engagement/bookmark_test.go
@@ -1,17 +1,12 @@
 package engagement
 
 import (
-	"context"
 	"fmt"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/internal/models"
@@ -85,67 +80,20 @@ func TestBookmarkService_NilDatabase(t *testing.T) {
 
 type BookmarkServiceIntegrationTestSuite struct {
 	suite.Suite
-	container       testcontainers.Container
+	testDB          *testutil.TestDatabase
 	db              *gorm.DB
 	bookmarkService *BookmarkService
-	ctx             context.Context
 }
 
 func (suite *BookmarkServiceIntegrationTestSuite) SetupSuite() {
-	suite.ctx = context.Background()
+	suite.testDB = testutil.SetupTestPostgres(suite.T())
+	suite.db = suite.testDB.DB
 
-	container, err := testcontainers.GenericContainer(suite.ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "postgres:18",
-			ExposedPorts: []string{"5432/tcp"},
-			Env: map[string]string{
-				"POSTGRES_DB":       "test_db",
-				"POSTGRES_USER":     "test_user",
-				"POSTGRES_PASSWORD": "test_password",
-			},
-			WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(120 * time.Second),
-		},
-		Started: true,
-	})
-	if err != nil {
-		suite.T().Fatalf("failed to start postgres container: %v", err)
-	}
-	suite.container = container
-
-	host, err := container.Host(suite.ctx)
-	if err != nil {
-		suite.T().Fatalf("failed to get host: %v", err)
-	}
-	port, err := container.MappedPort(suite.ctx, "5432")
-	if err != nil {
-		suite.T().Fatalf("failed to get port: %v", err)
-	}
-
-	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
-		host, port.Port())
-
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	if err != nil {
-		suite.T().Fatalf("failed to connect to test database: %v", err)
-	}
-	suite.db = db
-
-	sqlDB, err := db.DB()
-	if err != nil {
-		suite.T().Fatalf("failed to get sql.DB: %v", err)
-	}
-
-	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
-
-	suite.bookmarkService = &BookmarkService{db: db}
+	suite.bookmarkService = &BookmarkService{db: suite.testDB.DB}
 }
 
 func (suite *BookmarkServiceIntegrationTestSuite) TearDownSuite() {
-	if suite.container != nil {
-		if err := suite.container.Terminate(suite.ctx); err != nil {
-			suite.T().Logf("failed to terminate container: %v", err)
-		}
-	}
+	suite.testDB.Cleanup()
 }
 
 func (suite *BookmarkServiceIntegrationTestSuite) TearDownTest() {

--- a/backend/internal/services/engagement/calendar_test.go
+++ b/backend/internal/services/engagement/calendar_test.go
@@ -1,18 +1,13 @@
 package engagement
 
 import (
-	"context"
 	"fmt"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/internal/models"
@@ -260,7 +255,7 @@ type mockSavedShowSvc struct {
 	err   error
 }
 
-func (m *mockSavedShowSvc) SaveShow(_, _ uint) error { return nil }
+func (m *mockSavedShowSvc) SaveShow(_, _ uint) error   { return nil }
 func (m *mockSavedShowSvc) UnsaveShow(_, _ uint) error { return nil }
 func (m *mockSavedShowSvc) GetUserSavedShows(_ uint, _, _ int) ([]*contracts.SavedShowResponse, int64, error) {
 	return m.shows, m.total, m.err
@@ -278,68 +273,21 @@ func ptrString(s string) *string { return &s }
 
 type CalendarIntegrationTestSuite struct {
 	suite.Suite
-	container testcontainers.Container
-	db        *gorm.DB
-	svc       *CalendarService
-	ctx       context.Context
+	testDB *testutil.TestDatabase
+	db     *gorm.DB
+	svc    *CalendarService
 }
 
 func (suite *CalendarIntegrationTestSuite) SetupSuite() {
-	suite.ctx = context.Background()
-
-	container, err := testcontainers.GenericContainer(suite.ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "postgres:18",
-			ExposedPorts: []string{"5432/tcp"},
-			Env: map[string]string{
-				"POSTGRES_DB":       "test_db",
-				"POSTGRES_USER":     "test_user",
-				"POSTGRES_PASSWORD": "test_password",
-			},
-			WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(120 * time.Second),
-		},
-		Started: true,
-	})
-	if err != nil {
-		suite.T().Fatalf("failed to start postgres container: %v", err)
-	}
-	suite.container = container
-
-	host, err := container.Host(suite.ctx)
-	if err != nil {
-		suite.T().Fatalf("failed to get host: %v", err)
-	}
-	port, err := container.MappedPort(suite.ctx, "5432")
-	if err != nil {
-		suite.T().Fatalf("failed to get port: %v", err)
-	}
-
-	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
-		host, port.Port())
-
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	if err != nil {
-		suite.T().Fatalf("failed to connect to test database: %v", err)
-	}
-	suite.db = db
-
-	sqlDB, err := db.DB()
-	if err != nil {
-		suite.T().Fatalf("failed to get sql.DB: %v", err)
-	}
-
-	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
+	suite.testDB = testutil.SetupTestPostgres(suite.T())
+	suite.db = suite.testDB.DB
 
 	mockSavedShows := &mockSavedShowSvc{shows: []*contracts.SavedShowResponse{}, total: 0}
-	suite.svc = &CalendarService{db: db, savedShowSvc: mockSavedShows}
+	suite.svc = &CalendarService{db: suite.testDB.DB, savedShowSvc: mockSavedShows}
 }
 
 func (suite *CalendarIntegrationTestSuite) TearDownSuite() {
-	if suite.container != nil {
-		if err := suite.container.Terminate(suite.ctx); err != nil {
-			suite.T().Logf("failed to terminate container: %v", err)
-		}
-	}
+	suite.testDB.Cleanup()
 }
 
 func (suite *CalendarIntegrationTestSuite) TearDownTest() {

--- a/backend/internal/services/engagement/favorite_venue_test.go
+++ b/backend/internal/services/engagement/favorite_venue_test.go
@@ -1,17 +1,12 @@
 package engagement
 
 import (
-	"context"
 	"fmt"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	apperrors "psychic-homily-backend/internal/errors"
@@ -80,67 +75,20 @@ func TestFavoriteVenueService_NilDatabase(t *testing.T) {
 
 type FavoriteVenueServiceIntegrationTestSuite struct {
 	suite.Suite
-	container            testcontainers.Container
+	testDB               *testutil.TestDatabase
 	db                   *gorm.DB
 	favoriteVenueService *FavoriteVenueService
-	ctx                  context.Context
 }
 
 func (suite *FavoriteVenueServiceIntegrationTestSuite) SetupSuite() {
-	suite.ctx = context.Background()
+	suite.testDB = testutil.SetupTestPostgres(suite.T())
+	suite.db = suite.testDB.DB
 
-	container, err := testcontainers.GenericContainer(suite.ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "postgres:18",
-			ExposedPorts: []string{"5432/tcp"},
-			Env: map[string]string{
-				"POSTGRES_DB":       "test_db",
-				"POSTGRES_USER":     "test_user",
-				"POSTGRES_PASSWORD": "test_password",
-			},
-			WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(120 * time.Second),
-		},
-		Started: true,
-	})
-	if err != nil {
-		suite.T().Fatalf("failed to start postgres container: %v", err)
-	}
-	suite.container = container
-
-	host, err := container.Host(suite.ctx)
-	if err != nil {
-		suite.T().Fatalf("failed to get host: %v", err)
-	}
-	port, err := container.MappedPort(suite.ctx, "5432")
-	if err != nil {
-		suite.T().Fatalf("failed to get port: %v", err)
-	}
-
-	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
-		host, port.Port())
-
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	if err != nil {
-		suite.T().Fatalf("failed to connect to test database: %v", err)
-	}
-	suite.db = db
-
-	sqlDB, err := db.DB()
-	if err != nil {
-		suite.T().Fatalf("failed to get sql.DB: %v", err)
-	}
-
-	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
-
-	suite.favoriteVenueService = NewFavoriteVenueService(db)
+	suite.favoriteVenueService = NewFavoriteVenueService(suite.testDB.DB)
 }
 
 func (suite *FavoriteVenueServiceIntegrationTestSuite) TearDownSuite() {
-	if suite.container != nil {
-		if err := suite.container.Terminate(suite.ctx); err != nil {
-			suite.T().Logf("failed to terminate container: %v", err)
-		}
-	}
+	suite.testDB.Cleanup()
 }
 
 func (suite *FavoriteVenueServiceIntegrationTestSuite) TearDownTest() {

--- a/backend/internal/services/engagement/follow_test.go
+++ b/backend/internal/services/engagement/follow_test.go
@@ -1,17 +1,12 @@
 package engagement
 
 import (
-	"context"
 	"fmt"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/internal/models"
@@ -151,67 +146,20 @@ func TestFollowService_InvalidEntityType(t *testing.T) {
 
 type FollowServiceIntegrationTestSuite struct {
 	suite.Suite
-	container     testcontainers.Container
+	testDB        *testutil.TestDatabase
 	db            *gorm.DB
 	followService *FollowService
-	ctx           context.Context
 }
 
 func (suite *FollowServiceIntegrationTestSuite) SetupSuite() {
-	suite.ctx = context.Background()
+	suite.testDB = testutil.SetupTestPostgres(suite.T())
+	suite.db = suite.testDB.DB
 
-	container, err := testcontainers.GenericContainer(suite.ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "postgres:18",
-			ExposedPorts: []string{"5432/tcp"},
-			Env: map[string]string{
-				"POSTGRES_DB":       "test_db",
-				"POSTGRES_USER":     "test_user",
-				"POSTGRES_PASSWORD": "test_password",
-			},
-			WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(120 * time.Second),
-		},
-		Started: true,
-	})
-	if err != nil {
-		suite.T().Fatalf("failed to start postgres container: %v", err)
-	}
-	suite.container = container
-
-	host, err := container.Host(suite.ctx)
-	if err != nil {
-		suite.T().Fatalf("failed to get host: %v", err)
-	}
-	port, err := container.MappedPort(suite.ctx, "5432")
-	if err != nil {
-		suite.T().Fatalf("failed to get port: %v", err)
-	}
-
-	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
-		host, port.Port())
-
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	if err != nil {
-		suite.T().Fatalf("failed to connect to test database: %v", err)
-	}
-	suite.db = db
-
-	sqlDB, err := db.DB()
-	if err != nil {
-		suite.T().Fatalf("failed to get sql.DB: %v", err)
-	}
-
-	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
-
-	suite.followService = NewFollowService(db)
+	suite.followService = NewFollowService(suite.testDB.DB)
 }
 
 func (suite *FollowServiceIntegrationTestSuite) TearDownSuite() {
-	if suite.container != nil {
-		if err := suite.container.Terminate(suite.ctx); err != nil {
-			suite.T().Logf("failed to terminate container: %v", err)
-		}
-	}
+	suite.testDB.Cleanup()
 }
 
 func (suite *FollowServiceIntegrationTestSuite) TearDownTest() {

--- a/backend/internal/services/engagement/reminder_test.go
+++ b/backend/internal/services/engagement/reminder_test.go
@@ -5,15 +5,11 @@ import (
 	"fmt"
 	"log/slog"
 	"net/url"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/internal/config"
@@ -190,59 +186,16 @@ func (m *mockReminderEmailService) SendFilterNotificationEmail(_, _, _, _ string
 // ReminderServiceIntegrationTestSuite tests the reminder service with a real database
 type ReminderServiceIntegrationTestSuite struct {
 	suite.Suite
-	container       testcontainers.Container
+	testDB          *testutil.TestDatabase
 	db              *gorm.DB
 	emailMock       *mockReminderEmailService
 	reminderService *ReminderService
 	cfg             *config.Config
-	ctx             context.Context
 }
 
 func (s *ReminderServiceIntegrationTestSuite) SetupSuite() {
-	s.ctx = context.Background()
-
-	container, err := testcontainers.GenericContainer(s.ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "postgres:18",
-			ExposedPorts: []string{"5432/tcp"},
-			Env: map[string]string{
-				"POSTGRES_DB":       "test_db",
-				"POSTGRES_USER":     "test_user",
-				"POSTGRES_PASSWORD": "test_password",
-			},
-			WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(120 * time.Second),
-		},
-		Started: true,
-	})
-	if err != nil {
-		s.T().Fatalf("failed to start postgres container: %v", err)
-	}
-	s.container = container
-
-	host, err := container.Host(s.ctx)
-	if err != nil {
-		s.T().Fatalf("failed to get host: %v", err)
-	}
-	port, err := container.MappedPort(s.ctx, "5432")
-	if err != nil {
-		s.T().Fatalf("failed to get port: %v", err)
-	}
-
-	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
-		host, port.Port())
-
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	if err != nil {
-		s.T().Fatalf("failed to connect to test database: %v", err)
-	}
-	s.db = db
-
-	sqlDB, err := db.DB()
-	if err != nil {
-		s.T().Fatalf("failed to get sql.DB: %v", err)
-	}
-
-	testutil.RunAllMigrations(s.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
+	s.testDB = testutil.SetupTestPostgres(s.T())
+	s.db = s.testDB.DB
 
 	s.cfg = &config.Config{
 		Email: config.EmailConfig{
@@ -257,22 +210,18 @@ func (s *ReminderServiceIntegrationTestSuite) SetupSuite() {
 func (s *ReminderServiceIntegrationTestSuite) SetupTest() {
 	s.emailMock = &mockReminderEmailService{}
 	s.reminderService = &ReminderService{
-		db:          s.db,
+		db:           s.db,
 		emailService: s.emailMock,
-		interval:    1 * time.Second,
-		stopCh:      make(chan struct{}),
-		logger:      testLogger(),
-		frontendURL: s.cfg.Email.FrontendURL,
-		jwtSecret:   s.cfg.JWT.SecretKey,
+		interval:     1 * time.Second,
+		stopCh:       make(chan struct{}),
+		logger:       testLogger(),
+		frontendURL:  s.cfg.Email.FrontendURL,
+		jwtSecret:    s.cfg.JWT.SecretKey,
 	}
 }
 
 func (s *ReminderServiceIntegrationTestSuite) TearDownSuite() {
-	if s.container != nil {
-		if err := s.container.Terminate(s.ctx); err != nil {
-			s.T().Logf("failed to terminate container: %v", err)
-		}
-	}
+	s.testDB.Cleanup()
 }
 
 func (s *ReminderServiceIntegrationTestSuite) TearDownTest() {
@@ -584,7 +533,7 @@ func (s *ReminderServiceIntegrationTestSuite) TestStartStop_NoError() {
 		jwtSecret:    s.cfg.JWT.SecretKey,
 	}
 
-	svc.Start(s.ctx)
+	svc.Start(context.Background())
 
 	// Let it run for a brief moment
 	time.Sleep(50 * time.Millisecond)

--- a/backend/internal/services/engagement/saved_show_test.go
+++ b/backend/internal/services/engagement/saved_show_test.go
@@ -1,17 +1,12 @@
 package engagement
 
 import (
-	"context"
 	"fmt"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	apperrors "psychic-homily-backend/internal/errors"
@@ -72,67 +67,20 @@ func TestSavedShowService_NilDatabase(t *testing.T) {
 
 type SavedShowServiceIntegrationTestSuite struct {
 	suite.Suite
-	container        testcontainers.Container
+	testDB           *testutil.TestDatabase
 	db               *gorm.DB
 	savedShowService *SavedShowService
-	ctx              context.Context
 }
 
 func (suite *SavedShowServiceIntegrationTestSuite) SetupSuite() {
-	suite.ctx = context.Background()
+	suite.testDB = testutil.SetupTestPostgres(suite.T())
+	suite.db = suite.testDB.DB
 
-	container, err := testcontainers.GenericContainer(suite.ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "postgres:18",
-			ExposedPorts: []string{"5432/tcp"},
-			Env: map[string]string{
-				"POSTGRES_DB":       "test_db",
-				"POSTGRES_USER":     "test_user",
-				"POSTGRES_PASSWORD": "test_password",
-			},
-			WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(120 * time.Second),
-		},
-		Started: true,
-	})
-	if err != nil {
-		suite.T().Fatalf("failed to start postgres container: %v", err)
-	}
-	suite.container = container
-
-	host, err := container.Host(suite.ctx)
-	if err != nil {
-		suite.T().Fatalf("failed to get host: %v", err)
-	}
-	port, err := container.MappedPort(suite.ctx, "5432")
-	if err != nil {
-		suite.T().Fatalf("failed to get port: %v", err)
-	}
-
-	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
-		host, port.Port())
-
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	if err != nil {
-		suite.T().Fatalf("failed to connect to test database: %v", err)
-	}
-	suite.db = db
-
-	sqlDB, err := db.DB()
-	if err != nil {
-		suite.T().Fatalf("failed to get sql.DB: %v", err)
-	}
-
-	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
-
-	suite.savedShowService = NewSavedShowService(db)
+	suite.savedShowService = NewSavedShowService(suite.testDB.DB)
 }
 
 func (suite *SavedShowServiceIntegrationTestSuite) TearDownSuite() {
-	if suite.container != nil {
-		if err := suite.container.Terminate(suite.ctx); err != nil {
-			suite.T().Logf("failed to terminate container: %v", err)
-		}
-	}
+	suite.testDB.Cleanup()
 }
 
 func (suite *SavedShowServiceIntegrationTestSuite) TearDownTest() {

--- a/backend/internal/services/notification/filter_service_test.go
+++ b/backend/internal/services/notification/filter_service_test.go
@@ -1,19 +1,14 @@
 package notification
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/lib/pq"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/internal/models"
@@ -182,9 +177,9 @@ func TestMatchAndNotify_NilShow(t *testing.T) {
 
 type NotificationFilterSuite struct {
 	suite.Suite
-	db        *gorm.DB
-	container testcontainers.Container
-	svc       *NotificationFilterService
+	db     *gorm.DB
+	testDB *testutil.TestDatabase
+	svc    *NotificationFilterService
 }
 
 func TestNotificationFilterSuite(t *testing.T) {
@@ -195,43 +190,11 @@ func TestNotificationFilterSuite(t *testing.T) {
 }
 
 func (s *NotificationFilterSuite) SetupSuite() {
-	ctx := context.Background()
-
-	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "postgres:18",
-			ExposedPorts: []string{"5432/tcp"},
-			Env: map[string]string{
-				"POSTGRES_DB":       "test_db",
-				"POSTGRES_USER":     "test_user",
-				"POSTGRES_PASSWORD": "test_password",
-			},
-			WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(120 * time.Second),
-		},
-		Started: true,
-	})
-	s.Require().NoError(err)
-	s.container = container
-
-	host, err := container.Host(ctx)
-	s.Require().NoError(err)
-	port, err := container.MappedPort(ctx, "5432")
-	s.Require().NoError(err)
-
-	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable", host, port.Port())
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	s.Require().NoError(err)
-	s.db = db
-
-	// Run migrations
-	sqlDB, err := db.DB()
-	s.Require().NoError(err)
-	migrationDir, err := filepath.Abs("../../../db/migrations")
-	s.Require().NoError(err)
-	testutil.RunAllMigrations(s.T(), sqlDB, migrationDir)
+	s.testDB = testutil.SetupTestPostgres(s.T())
+	s.db = s.testDB.DB
 
 	// Use a mock email service
-	s.svc = NewNotificationFilterService(db, &mockEmailService{}, "test-secret", "http://localhost:3000")
+	s.svc = NewNotificationFilterService(s.testDB.DB, &mockEmailService{}, "test-secret", "http://localhost:3000")
 }
 
 func (s *NotificationFilterSuite) TearDownTest() {
@@ -247,9 +210,7 @@ func (s *NotificationFilterSuite) TearDownTest() {
 }
 
 func (s *NotificationFilterSuite) TearDownSuite() {
-	if s.container != nil {
-		s.container.Terminate(context.Background())
-	}
+	s.testDB.Cleanup()
 }
 
 // createTestUser creates a user for testing.
@@ -867,7 +828,7 @@ type mockEmailService struct {
 	sendCalls int
 }
 
-func (m *mockEmailService) IsConfigured() bool                    { return true }
+func (m *mockEmailService) IsConfigured() bool                      { return true }
 func (m *mockEmailService) SendVerificationEmail(_, _ string) error { return nil }
 func (m *mockEmailService) SendMagicLinkEmail(_, _ string) error    { return nil }
 func (m *mockEmailService) SendAccountRecoveryEmail(_ string, _ string, _ int) error {

--- a/backend/internal/services/pipeline/discovery_test.go
+++ b/backend/internal/services/pipeline/discovery_test.go
@@ -1,17 +1,12 @@
 package pipeline
 
 import (
-	"context"
 	"fmt"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/internal/models"
@@ -262,17 +257,17 @@ func TestNormalizeSetType(t *testing.T) {
 		{"headliner", "headliner"},
 		{"Headliner", "headliner"},
 		{"HEADLINER", "headliner"},
-		{"support", "opener"},     // support maps to opener
+		{"support", "opener"}, // support maps to opener
 		{"Support", "opener"},
 		{"opener", "opener"},
 		{"special_guest", "special_guest"},
 		{"performer", "performer"},
-		{"dj", "performer"},       // dj maps to performer
+		{"dj", "performer"}, // dj maps to performer
 		{"DJ", "performer"},
-		{"host", "performer"},     // host maps to performer
+		{"host", "performer"}, // host maps to performer
 		{"Host", "performer"},
-		{"", ""},                  // empty returns empty
-		{"unknown", ""},           // unknown returns empty
+		{"", ""},                       // empty returns empty
+		{"unknown", ""},                // unknown returns empty
 		{"  headliner  ", "headliner"}, // whitespace trimmed
 		{"  support ", "opener"},
 	}
@@ -379,68 +374,21 @@ func (v *testVenueFinderCreator) FindOrCreateVenue(name, city, state string, add
 
 type DiscoveryIntegrationTestSuite struct {
 	suite.Suite
-	container testcontainers.Container
-	db        *gorm.DB
-	svc       *DiscoveryService
-	ctx       context.Context
+	testDB *testutil.TestDatabase
+	db     *gorm.DB
+	svc    *DiscoveryService
 }
 
 func (suite *DiscoveryIntegrationTestSuite) SetupSuite() {
-	suite.ctx = context.Background()
+	suite.testDB = testutil.SetupTestPostgres(suite.T())
+	suite.db = suite.testDB.DB
 
-	container, err := testcontainers.GenericContainer(suite.ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "postgres:18",
-			ExposedPorts: []string{"5432/tcp"},
-			Env: map[string]string{
-				"POSTGRES_DB":       "test_db",
-				"POSTGRES_USER":     "test_user",
-				"POSTGRES_PASSWORD": "test_password",
-			},
-			WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(120 * time.Second),
-		},
-		Started: true,
-	})
-	if err != nil {
-		suite.T().Fatalf("failed to start postgres container: %v", err)
-	}
-	suite.container = container
-
-	host, err := container.Host(suite.ctx)
-	if err != nil {
-		suite.T().Fatalf("failed to get host: %v", err)
-	}
-	port, err := container.MappedPort(suite.ctx, "5432")
-	if err != nil {
-		suite.T().Fatalf("failed to get port: %v", err)
-	}
-
-	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
-		host, port.Port())
-
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	if err != nil {
-		suite.T().Fatalf("failed to connect to test database: %v", err)
-	}
-	suite.db = db
-
-	sqlDB, err := db.DB()
-	if err != nil {
-		suite.T().Fatalf("failed to get sql.DB: %v", err)
-	}
-
-	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
-
-	venueSvc := &testVenueFinderCreator{db: db}
-	suite.svc = NewDiscoveryService(db, venueSvc)
+	venueSvc := &testVenueFinderCreator{db: suite.testDB.DB}
+	suite.svc = NewDiscoveryService(suite.testDB.DB, venueSvc)
 }
 
 func (suite *DiscoveryIntegrationTestSuite) TearDownSuite() {
-	if suite.container != nil {
-		if err := suite.container.Terminate(suite.ctx); err != nil {
-			suite.T().Logf("failed to terminate container: %v", err)
-		}
-	}
+	suite.testDB.Cleanup()
 }
 
 func (suite *DiscoveryIntegrationTestSuite) TearDownTest() {

--- a/backend/internal/services/pipeline/extraction_test.go
+++ b/backend/internal/services/pipeline/extraction_test.go
@@ -1,13 +1,11 @@
 package pipeline
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -15,9 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/internal/config"
@@ -900,70 +895,24 @@ func TestMatchVenue(t *testing.T) {
 
 type ExtractionIntegrationTestSuite struct {
 	suite.Suite
-	container         testcontainers.Container
+	testDB            *testutil.TestDatabase
 	db                *gorm.DB
 	extractionService *ExtractionService
-	ctx               context.Context
 }
 
 func (s *ExtractionIntegrationTestSuite) SetupSuite() {
-	s.ctx = context.Background()
-
-	container, err := testcontainers.GenericContainer(s.ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "postgres:18",
-			ExposedPorts: []string{"5432/tcp"},
-			Env: map[string]string{
-				"POSTGRES_DB":       "test_db",
-				"POSTGRES_USER":     "test_user",
-				"POSTGRES_PASSWORD": "test_password",
-			},
-			WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(120 * time.Second),
-		},
-		Started: true,
-	})
-	if err != nil {
-		s.T().Fatalf("failed to start postgres container: %v", err)
-	}
-	s.container = container
-
-	host, err := container.Host(s.ctx)
-	if err != nil {
-		s.T().Fatalf("failed to get host: %v", err)
-	}
-	port, err := container.MappedPort(s.ctx, "5432")
-	if err != nil {
-		s.T().Fatalf("failed to get port: %v", err)
-	}
-
-	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
-		host, port.Port())
-
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	if err != nil {
-		s.T().Fatalf("failed to connect to test database: %v", err)
-	}
-	s.db = db
-
-	sqlDB, err := db.DB()
-	if err != nil {
-		s.T().Fatalf("failed to get sql.DB: %v", err)
-	}
-	testutil.RunAllMigrations(s.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
+	s.testDB = testutil.SetupTestPostgres(s.T())
+	s.db = s.testDB.DB
 
 	s.extractionService = &ExtractionService{
 		config:        &config.Config{},
-		artistService: &testArtistSearcher{db: db},
-		venueService:  &testVenueSearcher{db: db},
+		artistService: &testArtistSearcher{db: s.testDB.DB},
+		venueService:  &testVenueSearcher{db: s.testDB.DB},
 	}
 }
 
 func (s *ExtractionIntegrationTestSuite) TearDownSuite() {
-	if s.container != nil {
-		if err := s.container.Terminate(s.ctx); err != nil {
-			s.T().Logf("failed to terminate container: %v", err)
-		}
-	}
+	s.testDB.Cleanup()
 }
 
 func (s *ExtractionIntegrationTestSuite) TearDownTest() {

--- a/backend/internal/services/pipeline/venue_source_config_test.go
+++ b/backend/internal/services/pipeline/venue_source_config_test.go
@@ -1,17 +1,11 @@
 package pipeline
 
 import (
-	"context"
-	"fmt"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/internal/models"
@@ -89,53 +83,21 @@ func TestVenueSourceConfigService_NilDatabase(t *testing.T) {
 
 type VenueSourceConfigIntegrationTestSuite struct {
 	suite.Suite
-	container testcontainers.Container
-	db        *gorm.DB
-	svc       *VenueSourceConfigService
-	ctx       context.Context
-	venueID   uint
+	testDB  *testutil.TestDatabase
+	db      *gorm.DB
+	svc     *VenueSourceConfigService
+	venueID uint
 }
 
 func (s *VenueSourceConfigIntegrationTestSuite) SetupSuite() {
-	s.ctx = context.Background()
+	s.testDB = testutil.SetupTestPostgres(s.T())
+	s.db = s.testDB.DB
 
-	container, err := testcontainers.GenericContainer(s.ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "postgres:18",
-			ExposedPorts: []string{"5432/tcp"},
-			Env: map[string]string{
-				"POSTGRES_DB":       "test_db",
-				"POSTGRES_USER":     "test_user",
-				"POSTGRES_PASSWORD": "test_password",
-			},
-			WaitingFor: wait.ForListeningPort("5432/tcp").WithStartupTimeout(60 * time.Second),
-		},
-		Started: true,
-	})
-	s.Require().NoError(err)
-	s.container = container
-
-	host, _ := container.Host(s.ctx)
-	port, _ := container.MappedPort(s.ctx, "5432")
-
-	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable", host, port.Port())
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	s.Require().NoError(err)
-	s.db = db
-
-	sqlDB, err := db.DB()
-	s.Require().NoError(err)
-
-	migrationDir, _ := filepath.Abs("../../../db/migrations")
-	testutil.RunAllMigrations(s.T(), sqlDB, migrationDir)
-
-	s.svc = NewVenueSourceConfigService(db)
+	s.svc = NewVenueSourceConfigService(s.testDB.DB)
 }
 
 func (s *VenueSourceConfigIntegrationTestSuite) TearDownSuite() {
-	if s.container != nil {
-		s.container.Terminate(s.ctx)
-	}
+	s.testDB.Cleanup()
 }
 
 func (s *VenueSourceConfigIntegrationTestSuite) SetupTest() {

--- a/backend/internal/services/request_test.go
+++ b/backend/internal/services/request_test.go
@@ -1,17 +1,12 @@
 package services
 
 import (
-	"context"
 	"fmt"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	apperrors "psychic-homily-backend/internal/errors"
@@ -105,56 +100,21 @@ func TestRequestService_NilDatabase(t *testing.T) {
 
 type RequestServiceIntegrationTestSuite struct {
 	suite.Suite
-	container      testcontainers.Container
+	testDB         *testutil.TestDatabase
 	db             *gorm.DB
 	requestService *RequestService
-	ctx            context.Context
 }
 
 func (suite *RequestServiceIntegrationTestSuite) SetupSuite() {
-	suite.ctx = context.Background()
+	suite.testDB = testutil.SetupTestPostgres(suite.T())
+	suite.db = suite.testDB.DB
 
-	container, err := testcontainers.GenericContainer(suite.ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "postgres:18",
-			ExposedPorts: []string{"5432/tcp"},
-			Env: map[string]string{
-				"POSTGRES_DB":       "test_db",
-				"POSTGRES_USER":     "test_user",
-				"POSTGRES_PASSWORD": "test_password",
-			},
-			WaitingFor: wait.ForLog("database system is ready to accept connections").
-				WithOccurrence(2).
-				WithStartupTimeout(120 * time.Second),
-		},
-		Started: true,
-	})
-	suite.Require().NoError(err)
-	suite.container = container
-
-	host, err := container.Host(suite.ctx)
-	suite.Require().NoError(err)
-	port, err := container.MappedPort(suite.ctx, "5432")
-	suite.Require().NoError(err)
-
-	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
-		host, port.Port())
-
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	suite.Require().NoError(err)
-
-	sqlDB, err := db.DB()
-	suite.Require().NoError(err)
-	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "db", "migrations"))
-
-	suite.db = db
-	suite.requestService = NewRequestService(db)
+	suite.db = suite.testDB.DB
+	suite.requestService = NewRequestService(suite.testDB.DB)
 }
 
 func (suite *RequestServiceIntegrationTestSuite) TearDownSuite() {
-	if suite.container != nil {
-		_ = suite.container.Terminate(suite.ctx)
-	}
+	suite.testDB.Cleanup()
 }
 
 func (suite *RequestServiceIntegrationTestSuite) SetupTest() {

--- a/backend/internal/services/user/contributor_profile_test.go
+++ b/backend/internal/services/user/contributor_profile_test.go
@@ -1,18 +1,13 @@
 package user
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	"psychic-homily-backend/internal/models"
@@ -173,69 +168,22 @@ func TestValidatePrivacySettings(t *testing.T) {
 
 type ContributorProfileServiceIntegrationTestSuite struct {
 	suite.Suite
-	container      testcontainers.Container
+	testDB         *testutil.TestDatabase
 	db             *gorm.DB
 	profileService *ContributorProfileService
 	auditLog       *adminsvc.AuditLogService
-	ctx            context.Context
 }
 
 func (suite *ContributorProfileServiceIntegrationTestSuite) SetupSuite() {
-	suite.ctx = context.Background()
+	suite.testDB = testutil.SetupTestPostgres(suite.T())
+	suite.db = suite.testDB.DB
 
-	container, err := testcontainers.GenericContainer(suite.ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "postgres:18",
-			ExposedPorts: []string{"5432/tcp"},
-			Env: map[string]string{
-				"POSTGRES_DB":       "test_db",
-				"POSTGRES_USER":     "test_user",
-				"POSTGRES_PASSWORD": "test_password",
-			},
-			WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(120 * time.Second),
-		},
-		Started: true,
-	})
-	if err != nil {
-		suite.T().Fatalf("failed to start postgres container: %v", err)
-	}
-	suite.container = container
-
-	host, err := container.Host(suite.ctx)
-	if err != nil {
-		suite.T().Fatalf("failed to get host: %v", err)
-	}
-	port, err := container.MappedPort(suite.ctx, "5432")
-	if err != nil {
-		suite.T().Fatalf("failed to get port: %v", err)
-	}
-
-	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
-		host, port.Port())
-
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	if err != nil {
-		suite.T().Fatalf("failed to connect to test database: %v", err)
-	}
-	suite.db = db
-
-	sqlDB, err := db.DB()
-	if err != nil {
-		suite.T().Fatalf("failed to get sql.DB: %v", err)
-	}
-
-	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
-
-	suite.profileService = &ContributorProfileService{db: db}
-	suite.auditLog = adminsvc.NewAuditLogService(db)
+	suite.profileService = &ContributorProfileService{db: suite.testDB.DB}
+	suite.auditLog = adminsvc.NewAuditLogService(suite.testDB.DB)
 }
 
 func (suite *ContributorProfileServiceIntegrationTestSuite) TearDownSuite() {
-	if suite.container != nil {
-		if err := suite.container.Terminate(suite.ctx); err != nil {
-			suite.T().Logf("failed to terminate container: %v", err)
-		}
-	}
+	suite.testDB.Cleanup()
 }
 
 func (suite *ContributorProfileServiceIntegrationTestSuite) TearDownTest() {

--- a/backend/internal/services/user/user_test.go
+++ b/backend/internal/services/user/user_test.go
@@ -1,19 +1,14 @@
 package user
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/markbates/goth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	apperrors "psychic-homily-backend/internal/errors"
@@ -382,72 +377,21 @@ func TestGetDaysUntilPermanentDeletion(t *testing.T) {
 // UserServiceIntegrationTestSuite tests UserService with real PostgreSQL database
 type UserServiceIntegrationTestSuite struct {
 	suite.Suite
-	container   testcontainers.Container
+	testDB      *testutil.TestDatabase
 	db          *gorm.DB
 	userService *UserService
-	ctx         context.Context
 }
 
 func (suite *UserServiceIntegrationTestSuite) SetupSuite() {
-	suite.ctx = context.Background()
-
-	// Start PostgreSQL container
-	container, err := testcontainers.GenericContainer(suite.ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "postgres:18",
-			ExposedPorts: []string{"5432/tcp"},
-			Env: map[string]string{
-				"POSTGRES_DB":       "test_db",
-				"POSTGRES_USER":     "test_user",
-				"POSTGRES_PASSWORD": "test_password",
-			},
-			WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(120 * time.Second),
-		},
-		Started: true,
-	})
-
-	if err != nil {
-		suite.T().Fatalf("failed to start postgres container: %v", err)
-	}
-	suite.container = container
-
-	// Get container host and port
-	host, err := container.Host(suite.ctx)
-	if err != nil {
-		suite.T().Fatalf("failed to get host: %v", err)
-	}
-
-	port, err := container.MappedPort(suite.ctx, "5432")
-	if err != nil {
-		suite.T().Fatalf("failed to get port: %v", err)
-	}
-
-	// Connect to database
-	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
-		host, port.Port())
-
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	if err != nil {
-		suite.T().Fatalf("failed to connect to test database: %v", err)
-	}
-	suite.db = db
-
-	sqlDB, err := db.DB()
-	if err != nil {
-		suite.T().Fatalf("failed to get sql.DB: %v", err)
-	}
-	testutil.RunAllMigrations(suite.T(), sqlDB, filepath.Join("..", "..", "..", "db", "migrations"))
+	suite.testDB = testutil.SetupTestPostgres(suite.T())
+	suite.db = suite.testDB.DB
 
 	// Create UserService
-	suite.userService = &UserService{db: db}
+	suite.userService = &UserService{db: suite.testDB.DB}
 }
 
 func (suite *UserServiceIntegrationTestSuite) TearDownSuite() {
-	if suite.container != nil {
-		if err := suite.container.Terminate(suite.ctx); err != nil {
-			suite.T().Logf("failed to terminate container: %v", err)
-		}
-	}
+	suite.testDB.Cleanup()
 }
 
 // ---- Existing tests (GetUserByID, GetUserByEmail, UpdateUser, etc.) --------

--- a/backend/internal/testutil/postgres.go
+++ b/backend/internal/testutil/postgres.go
@@ -1,0 +1,89 @@
+package testutil
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+// TestDatabase holds the database connection and cleanup function for a test container.
+type TestDatabase struct {
+	DB        *gorm.DB
+	Container testcontainers.Container
+	ctx       context.Context
+}
+
+// Cleanup terminates the test container.
+func (td *TestDatabase) Cleanup() {
+	if td.Container != nil {
+		td.Container.Terminate(td.ctx)
+	}
+}
+
+// SetupTestPostgres creates a Postgres testcontainer, runs all migrations, and returns
+// a GORM DB connection. Call Cleanup() in TearDownSuite to terminate the container.
+func SetupTestPostgres(t *testing.T) *TestDatabase {
+	t.Helper()
+	ctx := context.Background()
+
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "postgres:18",
+			ExposedPorts: []string{"5432/tcp"},
+			Env: map[string]string{
+				"POSTGRES_DB":       "test_db",
+				"POSTGRES_USER":     "test_user",
+				"POSTGRES_PASSWORD": "test_password",
+			},
+			WaitingFor: wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(120 * time.Second),
+		},
+		Started: true,
+	})
+	if err != nil {
+		t.Fatalf("failed to start postgres container: %v", err)
+	}
+
+	host, err := container.Host(ctx)
+	if err != nil {
+		t.Fatalf("failed to get container host: %v", err)
+	}
+
+	port, err := container.MappedPort(ctx, "5432")
+	if err != nil {
+		t.Fatalf("failed to get container port: %v", err)
+	}
+
+	dsn := fmt.Sprintf("host=%s port=%s user=test_user password=test_password dbname=test_db sslmode=disable",
+		host, port.Port())
+
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to connect to test database: %v", err)
+	}
+
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("failed to get sql.DB: %v", err)
+	}
+
+	// Find migration directory relative to this file
+	_, filename, _, _ := runtime.Caller(0)
+	migrationDir := filepath.Join(filepath.Dir(filename), "..", "..", "db", "migrations")
+	RunAllMigrations(t, sqlDB, migrationDir)
+
+	return &TestDatabase{
+		DB:        db,
+		Container: container,
+		ctx:       ctx,
+	}
+}


### PR DESCRIPTION
## Summary
- New `testutil.SetupTestPostgres(t)` helper creates a Postgres 18 testcontainer, runs all migrations, and returns a `*TestDatabase` with DB connection and cleanup function
- Refactored 56 test files across all service packages and handler integration tests
- Removed ~1900 lines of duplicated container setup/teardown boilerplate
- Uses `runtime.Caller(0)` to resolve migration directory relative to the helper, so it works from any test package
- Consistent wait strategy everywhere: `ForLog("database system is ready to accept connections").WithOccurrence(2)`

## Test plan
- [ ] All backend tests pass: `go test ./...`
- [ ] No compile errors: `go build ./...`
- [ ] Verify testcontainer cleanup works (no orphaned containers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)