### PR TITLE
Centralize frontend test utilities — migrate 47 files, remove 488 lines

### DIFF
--- a/frontend/components/shared/FollowButton.test.tsx
+++ b/frontend/components/shared/FollowButton.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createWrapper } from '@/test/utils'
 
 const mockPush = vi.fn()
 const mockFollowMutate = vi.fn()
@@ -35,14 +34,6 @@ vi.mock('@/lib/hooks/common/useFollow', () => ({
 
 import { FollowButton } from './FollowButton'
 
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  })
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-  }
-}
 
 describe('FollowButton', () => {
   beforeEach(() => {

--- a/frontend/features/artists/components/RelatedArtists.test.tsx
+++ b/frontend/features/artists/components/RelatedArtists.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { screen } from '@testing-library/react'
+import { renderWithProviders } from '@/test/utils'
 import type { ArtistGraph } from '../types'
 
 // Mock the hooks
@@ -108,23 +108,6 @@ vi.mock('./ArtistGraph', () => ({
 
 import { RelatedArtists } from './RelatedArtists'
 
-function createTestQueryClient() {
-  return new QueryClient({
-    defaultOptions: {
-      queries: { retry: false },
-      mutations: { retry: false },
-    },
-  })
-}
-
-function renderWithProviders(ui: React.ReactElement) {
-  const queryClient = createTestQueryClient()
-  return render(
-    <QueryClientProvider client={queryClient}>
-      {ui}
-    </QueryClientProvider>
-  )
-}
 
 describe('RelatedArtists', () => {
   it('renders the section header', () => {

--- a/frontend/features/artists/hooks/useArtistReports.test.tsx
+++ b/frontend/features/artists/hooks/useArtistReports.test.tsx
@@ -1,8 +1,6 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { createWrapper, createTestQueryClient } from '@/test/utils'
+import { createWrapper } from '@/test/utils'
 
 // Create mocks
 const mockApiRequest = vi.fn()

--- a/frontend/features/artists/hooks/useArtistSearch.test.tsx
+++ b/frontend/features/artists/hooks/useArtistSearch.test.tsx
@@ -1,8 +1,6 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { createWrapper, createTestQueryClient } from '@/test/utils'
+import { createWrapper } from '@/test/utils'
 
 // Create mocks
 const mockApiRequest = vi.fn()

--- a/frontend/features/artists/hooks/useArtists.test.tsx
+++ b/frontend/features/artists/hooks/useArtists.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { QueryClient } from '@tanstack/react-query'
 import { createWrapper, createTestQueryClient } from '@/test/utils'
 
 // Create mocks
@@ -36,14 +35,6 @@ vi.mock('@/lib/queryClient', () => ({
 // Import hooks after mocks are set up
 import { useArtists, useArtistCities, useArtist, useArtistShows } from './useArtists'
 
-// Helper to create wrapper with specific query client
-function createWrapperWithClient(queryClient: QueryClient) {
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    )
-  }
-}
 
 describe('useArtists', () => {
   beforeEach(() => {

--- a/frontend/features/auth/hooks/useAuth.test.tsx
+++ b/frontend/features/auth/hooks/useAuth.test.tsx
@@ -1,8 +1,7 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { createWrapper, createTestQueryClient } from '@/test/utils'
+import { QueryClient } from '@tanstack/react-query'
+import { createWrapper, createWrapperWithClient, createTestQueryClient } from '@/test/utils'
 import { AuthErrorCode } from '@/lib/errors'
 
 // Create a mock for apiRequest that we can control
@@ -65,14 +64,6 @@ import {
   useConfirmVerification,
 } from './useAuth'
 
-// Helper to create wrapper with specific query client
-function createWrapperWithClient(queryClient: QueryClient) {
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    )
-  }
-}
 
 describe('useAuth hooks', () => {
   beforeEach(() => {

--- a/frontend/features/auth/hooks/useCalendarFeed.test.tsx
+++ b/frontend/features/auth/hooks/useCalendarFeed.test.tsx
@@ -1,8 +1,6 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { createWrapper, createTestQueryClient } from '@/test/utils'
+import { createWrapper } from '@/test/utils'
 
 // Create mocks
 const mockApiRequest = vi.fn()

--- a/frontend/features/auth/hooks/useContributorProfile.test.tsx
+++ b/frontend/features/auth/hooks/useContributorProfile.test.tsx
@@ -1,8 +1,6 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { createWrapper, createTestQueryClient } from '@/test/utils'
+import { createWrapper } from '@/test/utils'
 
 // Create mocks
 const mockApiRequest = vi.fn()

--- a/frontend/features/auth/hooks/useFavoriteCities.test.tsx
+++ b/frontend/features/auth/hooks/useFavoriteCities.test.tsx
@@ -1,8 +1,6 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { createWrapper, createTestQueryClient } from '@/test/utils'
+import { createWrapper } from '@/test/utils'
 
 // Create mocks
 const mockApiRequest = vi.fn()

--- a/frontend/features/auth/hooks/useFavoriteVenues.test.tsx
+++ b/frontend/features/auth/hooks/useFavoriteVenues.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createWrapper } from '@/test/utils'
 
 const mockApiRequest = vi.fn()
 const mockInvalidateFavoriteVenues = vi.fn()
@@ -40,19 +39,6 @@ import {
   useFavoriteVenueToggle,
 } from './useFavoriteVenues'
 
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false, gcTime: 0 },
-      mutations: { retry: false },
-    },
-  })
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    )
-  }
-}
 
 describe('useIsVenueFavorited', () => {
   beforeEach(() => {

--- a/frontend/features/collections/hooks/index.test.tsx
+++ b/frontend/features/collections/hooks/index.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createWrapper } from '@/test/utils'
 
 const mockApiRequest = vi.fn()
 
@@ -51,19 +50,6 @@ import {
   useUnsubscribeCollection,
 } from './index'
 
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false, gcTime: 0 },
-      mutations: { retry: false },
-    },
-  })
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    )
-  }
-}
 
 describe('Collection query hooks', () => {
   beforeEach(() => {

--- a/frontend/features/festivals/hooks/useFestivals.test.tsx
+++ b/frontend/features/festivals/hooks/useFestivals.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createWrapper } from '@/test/utils'
 
 const mockApiRequest = vi.fn()
 
@@ -52,17 +51,6 @@ import {
   useSeriesComparison,
 } from './useFestivals'
 
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false, gcTime: 0 },
-      mutations: { retry: false },
-    },
-  })
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-  }
-}
 
 describe('useFestivals', () => {
   beforeEach(() => {

--- a/frontend/features/labels/hooks/useLabels.test.tsx
+++ b/frontend/features/labels/hooks/useLabels.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createWrapper } from '@/test/utils'
 
 const mockApiRequest = vi.fn()
 
@@ -37,17 +36,6 @@ vi.mock('@/lib/queryClient', () => ({
 
 import { useLabels, useLabel, useArtistLabels, useLabelRoster, useLabelCatalog } from './useLabels'
 
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false, gcTime: 0 },
-      mutations: { retry: false },
-    },
-  })
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-  }
-}
 
 describe('useLabels', () => {
   beforeEach(() => {

--- a/frontend/features/notifications/hooks/index.test.tsx
+++ b/frontend/features/notifications/hooks/index.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createWrapper } from '@/test/utils'
 
 const mockApiRequest = vi.fn()
 
@@ -27,17 +26,6 @@ import {
   useQuickCreateFilter,
 } from './index'
 
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false, gcTime: 0 },
-      mutations: { retry: false },
-    },
-  })
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-  }
-}
 
 describe('useNotificationFilters', () => {
   beforeEach(() => {

--- a/frontend/features/releases/hooks/useReleases.test.tsx
+++ b/frontend/features/releases/hooks/useReleases.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createWrapper } from '@/test/utils'
 
 const mockApiRequest = vi.fn()
 
@@ -29,17 +28,6 @@ vi.mock('@/lib/queryClient', () => ({
 
 import { useReleases, useRelease, useArtistReleases } from './useReleases'
 
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false, gcTime: 0 },
-      mutations: { retry: false },
-    },
-  })
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-  }
-}
 
 describe('useReleases', () => {
   beforeEach(() => {

--- a/frontend/features/requests/hooks/index.test.tsx
+++ b/frontend/features/requests/hooks/index.test.tsx
@@ -1,7 +1,7 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { QueryClient } from '@tanstack/react-query'
+import { createWrapper, createWrapperWithClient } from '@/test/utils'
 
 const mockApiRequest = vi.fn()
 
@@ -41,19 +41,6 @@ import {
   useCloseRequest,
 } from './index'
 
-function createWrapper(queryClient?: QueryClient) {
-  const qc =
-    queryClient ??
-    new QueryClient({
-      defaultOptions: {
-        queries: { retry: false, gcTime: 0 },
-        mutations: { retry: false },
-      },
-    })
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-  }
-}
 
 describe('useRequests', () => {
   beforeEach(() => {
@@ -240,7 +227,7 @@ describe('useVoteRequest (optimistic updates)', () => {
     mockApiRequest.mockResolvedValueOnce(undefined)
 
     const { result } = renderHook(() => useVoteRequest(), {
-      wrapper: createWrapper(queryClient),
+      wrapper: createWrapperWithClient(queryClient),
     })
 
     await act(async () => {
@@ -278,7 +265,7 @@ describe('useVoteRequest (optimistic updates)', () => {
     mockApiRequest.mockRejectedValueOnce(new Error('Server error'))
 
     const { result } = renderHook(() => useVoteRequest(), {
-      wrapper: createWrapper(queryClient),
+      wrapper: createWrapperWithClient(queryClient),
     })
 
     await act(async () => {
@@ -336,7 +323,7 @@ describe('useRemoveVoteRequest', () => {
     mockApiRequest.mockResolvedValueOnce(undefined)
 
     const { result } = renderHook(() => useRemoveVoteRequest(), {
-      wrapper: createWrapper(queryClient),
+      wrapper: createWrapperWithClient(queryClient),
     })
 
     await act(async () => {

--- a/frontend/features/scenes/hooks/useScenes.test.tsx
+++ b/frontend/features/scenes/hooks/useScenes.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createWrapper } from '@/test/utils'
 
 const mockApiRequest = vi.fn()
 
@@ -29,17 +28,6 @@ vi.mock('@/lib/queryClient', () => ({
 
 import { useScenes, useSceneDetail, useSceneArtists } from './useScenes'
 
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false, gcTime: 0 },
-      mutations: { retry: false },
-    },
-  })
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-  }
-}
 
 describe('useScenes', () => {
   beforeEach(() => {

--- a/frontend/features/shows/hooks/useAttendance.test.tsx
+++ b/frontend/features/shows/hooks/useAttendance.test.tsx
@@ -1,7 +1,7 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { QueryClient } from '@tanstack/react-query'
+import { createWrapper, createWrapperWithClient } from '@/test/utils'
 
 const mockApiRequest = vi.fn()
 const mockInvalidateAttendance = vi.fn()
@@ -43,19 +43,6 @@ import {
   useMyShows,
 } from './useAttendance'
 
-function createWrapper(queryClient?: QueryClient) {
-  const qc =
-    queryClient ??
-    new QueryClient({
-      defaultOptions: {
-        queries: { retry: false, gcTime: 0 },
-        mutations: { retry: false },
-      },
-    })
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-  }
-}
 
 describe('useShowAttendance', () => {
   beforeEach(() => {
@@ -169,7 +156,7 @@ describe('useSetAttendance', () => {
     mockApiRequest.mockResolvedValueOnce({ success: true })
 
     const { result } = renderHook(() => useSetAttendance(), {
-      wrapper: createWrapper(queryClient),
+      wrapper: createWrapperWithClient(queryClient),
     })
 
     await act(async () => {
@@ -245,7 +232,7 @@ describe('useRemoveAttendance', () => {
     mockApiRequest.mockResolvedValueOnce({ success: true })
 
     const { result } = renderHook(() => useRemoveAttendance(), {
-      wrapper: createWrapper(queryClient),
+      wrapper: createWrapperWithClient(queryClient),
     })
 
     await act(async () => {

--- a/frontend/features/shows/hooks/useMySubmissions.test.tsx
+++ b/frontend/features/shows/hooks/useMySubmissions.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { QueryClient } from '@tanstack/react-query'
 import { createWrapper, createTestQueryClient } from '@/test/utils'
 
 // Create mocks
@@ -30,14 +29,6 @@ vi.mock('@/lib/queryClient', () => ({
 // Import hooks after mocks are set up
 import { useMySubmissions } from './useMySubmissions'
 
-// Helper to create wrapper with specific query client
-function createWrapperWithClient(queryClient: QueryClient) {
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    )
-  }
-}
 
 describe('useMySubmissions', () => {
   beforeEach(() => {

--- a/frontend/features/shows/hooks/useSavedShows.test.tsx
+++ b/frontend/features/shows/hooks/useSavedShows.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createWrapper } from '@/test/utils'
 
 // Create mocks
 const mockApiRequest = vi.fn()
@@ -42,25 +41,6 @@ import {
   useSaveShowToggle,
 } from './useSavedShows'
 
-// Helper to create wrapper with query client
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: false,
-        gcTime: 0,
-      },
-      mutations: {
-        retry: false,
-      },
-    },
-  })
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    )
-  }
-}
 
 describe('useSavedShows', () => {
   beforeEach(() => {

--- a/frontend/features/shows/hooks/useShowDelete.test.tsx
+++ b/frontend/features/shows/hooks/useShowDelete.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createWrapper } from '@/test/utils'
 
 // Create mocks
 const mockApiRequest = vi.fn()
@@ -57,20 +56,6 @@ vi.mock('@/lib/errors', () => ({
 // Import hooks after mocks are set up
 import { useShowDelete } from './useShowDelete'
 
-// Helper to create wrapper with query client
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false, gcTime: 0 },
-      mutations: { retry: false },
-    },
-  })
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    )
-  }
-}
 
 describe('useShowDelete', () => {
   beforeEach(() => {

--- a/frontend/features/shows/hooks/useShowHooks.test.tsx
+++ b/frontend/features/shows/hooks/useShowHooks.test.tsx
@@ -1,8 +1,7 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { createWrapper, createTestQueryClient } from '@/test/utils'
+import { QueryClient } from '@tanstack/react-query'
+import { createWrapper, createWrapperWithClient, createTestQueryClient } from '@/test/utils'
 import { ShowErrorCode } from '@/lib/errors'
 
 // Create mocks
@@ -55,14 +54,6 @@ import { useShowSubmit } from './useShowSubmit'
 import { useShowUpdate } from './useShowUpdate'
 import { useShowDelete } from './useShowDelete'
 
-// Helper to create wrapper with specific query client
-function createWrapperWithClient(queryClient: QueryClient) {
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    )
-  }
-}
 
 describe('useShowSubmit', () => {
   beforeEach(() => {

--- a/frontend/features/shows/hooks/useShowImport.test.tsx
+++ b/frontend/features/shows/hooks/useShowImport.test.tsx
@@ -1,8 +1,7 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { createWrapper, createTestQueryClient } from '@/test/utils'
+import { QueryClient } from '@tanstack/react-query'
+import { createWrapper, createWrapperWithClient, createTestQueryClient } from '@/test/utils'
 
 // Create mocks
 const mockApiRequest = vi.fn()
@@ -32,14 +31,6 @@ vi.mock('@/lib/queryClient', () => ({
 // Import hooks after mocks are set up
 import { useShowImportPreview, useShowImportConfirm } from './useShowImport'
 
-// Helper to create wrapper with specific query client
-function createWrapperWithClient(queryClient: QueryClient) {
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    )
-  }
-}
 
 describe('useShowImport', () => {
   beforeEach(() => {

--- a/frontend/features/shows/hooks/useShowReminders.test.tsx
+++ b/frontend/features/shows/hooks/useShowReminders.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createWrapper } from '@/test/utils'
 
 const mockApiRequest = vi.fn()
 
@@ -25,17 +24,6 @@ vi.mock('@/lib/queryClient', () => ({
 
 import { useSetShowReminders } from './useShowReminders'
 
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false, gcTime: 0 },
-      mutations: { retry: false },
-    },
-  })
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-  }
-}
 
 describe('useSetShowReminders', () => {
   beforeEach(() => {

--- a/frontend/features/shows/hooks/useShowReports.test.tsx
+++ b/frontend/features/shows/hooks/useShowReports.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createWrapper } from '@/test/utils'
 
 const mockApiRequest = vi.fn()
 const mockInvalidateShowReports = vi.fn()
@@ -30,17 +29,6 @@ vi.mock('@/lib/queryClient', () => ({
 
 import { useMyShowReport, useReportShow } from './useShowReports'
 
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false, gcTime: 0 },
-      mutations: { retry: false },
-    },
-  })
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-  }
-}
 
 describe('useMyShowReport', () => {
   beforeEach(() => {

--- a/frontend/features/shows/hooks/useShowState.test.tsx
+++ b/frontend/features/shows/hooks/useShowState.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createWrapper } from '@/test/utils'
 
 // Create mocks
 const mockApiRequest = vi.fn()
@@ -44,24 +43,6 @@ import { useShowPublish } from './useShowPublish'
 import { useShowMakePrivate } from './useShowMakePrivate'
 import { useShowUnpublish } from './useShowUnpublish'
 
-// Helper to create wrapper with query client
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: false,
-      },
-      mutations: {
-        retry: false,
-      },
-    },
-  })
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    )
-  }
-}
 
 describe('useShowPublish', () => {
   beforeEach(() => {

--- a/frontend/features/shows/hooks/useShowSubmit.test.tsx
+++ b/frontend/features/shows/hooks/useShowSubmit.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createWrapper } from '@/test/utils'
 
 // Create mocks
 const mockApiRequest = vi.fn()
@@ -60,20 +59,6 @@ vi.mock('@/lib/errors', () => ({
 import { useShowSubmit } from './useShowSubmit'
 import type { ShowSubmission } from './useShowSubmit'
 
-// Helper to create wrapper with query client
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false, gcTime: 0 },
-      mutations: { retry: false },
-    },
-  })
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    )
-  }
-}
 
 const validSubmission: ShowSubmission = {
   event_date: '2025-06-15T20:00:00Z',

--- a/frontend/features/shows/hooks/useShowUpdate.test.tsx
+++ b/frontend/features/shows/hooks/useShowUpdate.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createWrapper } from '@/test/utils'
 
 // Create mocks
 const mockApiRequest = vi.fn()
@@ -60,20 +59,6 @@ vi.mock('@/lib/errors', () => ({
 import { useShowUpdate } from './useShowUpdate'
 import type { ShowUpdate } from './useShowUpdate'
 
-// Helper to create wrapper with query client
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false, gcTime: 0 },
-      mutations: { retry: false },
-    },
-  })
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    )
-  }
-}
 
 describe('useShowUpdate', () => {
   beforeEach(() => {

--- a/frontend/features/shows/hooks/useShows.test.tsx
+++ b/frontend/features/shows/hooks/useShows.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { QueryClient } from '@tanstack/react-query'
 import { createWrapper, createTestQueryClient } from '@/test/utils'
 
 // Create mocks
@@ -32,14 +31,6 @@ vi.mock('@/lib/queryClient', () => ({
 // Import hooks after mocks are set up
 import { useUpcomingShows, useShow } from './useShows'
 
-// Helper to create wrapper with specific query client
-function createWrapperWithClient(queryClient: QueryClient) {
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    )
-  }
-}
 
 describe('useShows', () => {
   beforeEach(() => {

--- a/frontend/features/tags/hooks/index.test.tsx
+++ b/frontend/features/tags/hooks/index.test.tsx
@@ -1,7 +1,7 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { QueryClient } from '@tanstack/react-query'
+import { createWrapper, createWrapperWithClient } from '@/test/utils'
 
 const mockApiRequest = vi.fn()
 
@@ -49,19 +49,6 @@ import {
   useRemoveTagVote,
 } from './index'
 
-function createWrapper(queryClient?: QueryClient) {
-  const qc =
-    queryClient ??
-    new QueryClient({
-      defaultOptions: {
-        queries: { retry: false, gcTime: 0 },
-        mutations: { retry: false },
-      },
-    })
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-  }
-}
 
 describe('useTags', () => {
   beforeEach(() => {
@@ -320,7 +307,7 @@ describe('useVoteOnTag (optimistic updates)', () => {
     mockApiRequest.mockResolvedValueOnce(undefined)
 
     const { result } = renderHook(() => useVoteOnTag(), {
-      wrapper: createWrapper(queryClient),
+      wrapper: createWrapperWithClient(queryClient),
     })
 
     await act(async () => {

--- a/frontend/features/venues/hooks/useVenueEdit.test.tsx
+++ b/frontend/features/venues/hooks/useVenueEdit.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createWrapper } from '@/test/utils'
 
 // Create mocks
 const mockApiRequest = vi.fn()
@@ -39,25 +38,6 @@ import {
   useVenueDelete,
 } from './useVenueEdit'
 
-// Helper to create wrapper with query client
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: false,
-        gcTime: 0,
-      },
-      mutations: {
-        retry: false,
-      },
-    },
-  })
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    )
-  }
-}
 
 describe('useVenueUpdate', () => {
   beforeEach(() => {

--- a/frontend/features/venues/hooks/useVenueSearch.test.tsx
+++ b/frontend/features/venues/hooks/useVenueSearch.test.tsx
@@ -1,8 +1,6 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { createWrapper, createTestQueryClient } from '@/test/utils'
+import { createWrapper } from '@/test/utils'
 
 // Create mocks
 const mockApiRequest = vi.fn()

--- a/frontend/features/venues/hooks/useVenues.test.tsx
+++ b/frontend/features/venues/hooks/useVenues.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { QueryClient } from '@tanstack/react-query'
 import { createWrapper, createTestQueryClient } from '@/test/utils'
 
 // Create mocks
@@ -36,14 +35,6 @@ vi.mock('@/lib/queryClient', () => ({
 // Import hooks after mocks are set up
 import { useVenues, useVenue, useVenueShows, useVenueCities } from './useVenues'
 
-// Helper to create wrapper with specific query client
-function createWrapperWithClient(queryClient: QueryClient) {
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    )
-  }
-}
 
 describe('useVenues', () => {
   beforeEach(() => {

--- a/frontend/lib/hooks/admin/useAdminArtistReports.test.tsx
+++ b/frontend/lib/hooks/admin/useAdminArtistReports.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createWrapper } from '@/test/utils'
 
 const mockApiRequest = vi.fn()
 const mockInvalidateArtistReports = vi.fn()
@@ -38,17 +37,6 @@ import {
   useResolveArtistReport,
 } from './useAdminArtistReports'
 
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false, gcTime: 0 },
-      mutations: { retry: false },
-    },
-  })
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-  }
-}
 
 describe('usePendingArtistReports', () => {
   beforeEach(() => {

--- a/frontend/lib/hooks/admin/useAdminArtists.test.tsx
+++ b/frontend/lib/hooks/admin/useAdminArtists.test.tsx
@@ -1,8 +1,7 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { createWrapper, createTestQueryClient } from '@/test/utils'
+import { QueryClient } from '@tanstack/react-query'
+import { createWrapper, createWrapperWithClient, createTestQueryClient } from '@/test/utils'
 
 // Create mock for fetch
 const mockFetch = vi.fn()
@@ -27,14 +26,6 @@ import {
   useClearArtistSpotify,
 } from './useAdminArtists'
 
-// Helper to create wrapper with specific query client
-function createWrapperWithClient(queryClient: QueryClient) {
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    )
-  }
-}
 
 // Helper to mock successful fetch response
 function mockFetchResponse(data: unknown, ok = true, status = 200) {

--- a/frontend/lib/hooks/admin/useAdminAuditLogs.test.tsx
+++ b/frontend/lib/hooks/admin/useAdminAuditLogs.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createWrapper } from '@/test/utils'
 
 const mockApiRequest = vi.fn()
 
@@ -28,16 +27,6 @@ vi.mock('@/lib/queryClient', () => ({
 
 import { useAuditLogs } from './useAdminAuditLogs'
 
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false, gcTime: 0 },
-    },
-  })
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-  }
-}
 
 describe('useAuditLogs', () => {
   beforeEach(() => {

--- a/frontend/lib/hooks/admin/useAdminReports.test.tsx
+++ b/frontend/lib/hooks/admin/useAdminReports.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createWrapper } from '@/test/utils'
 
 const mockApiRequest = vi.fn()
 const mockInvalidateShowReports = vi.fn()
@@ -40,17 +39,6 @@ import {
   useResolveReport,
 } from './useAdminReports'
 
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false, gcTime: 0 },
-      mutations: { retry: false },
-    },
-  })
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-  }
-}
 
 describe('usePendingReports', () => {
   beforeEach(() => {

--- a/frontend/lib/hooks/admin/useAdminShows.test.tsx
+++ b/frontend/lib/hooks/admin/useAdminShows.test.tsx
@@ -1,8 +1,7 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { createWrapper, createTestQueryClient } from '@/test/utils'
+import { QueryClient } from '@tanstack/react-query'
+import { createWrapper, createWrapperWithClient, createTestQueryClient } from '@/test/utils'
 
 // Create mocks
 const mockApiRequest = vi.fn()
@@ -44,14 +43,6 @@ import {
   adminQueryKeys,
 } from './useAdminShows'
 
-// Helper to create wrapper with specific query client
-function createWrapperWithClient(queryClient: QueryClient) {
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    )
-  }
-}
 
 describe('useAdminShows', () => {
   beforeEach(() => {

--- a/frontend/lib/hooks/admin/useAdminStats.test.tsx
+++ b/frontend/lib/hooks/admin/useAdminStats.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createWrapper } from '@/test/utils'
 
 const mockApiRequest = vi.fn()
 
@@ -27,16 +26,6 @@ vi.mock('@/lib/queryClient', () => ({
 
 import { useAdminStats, useAdminActivity } from './useAdminStats'
 
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false, gcTime: 0 },
-    },
-  })
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-  }
-}
 
 describe('useAdminStats', () => {
   beforeEach(() => {

--- a/frontend/lib/hooks/admin/useAdminUsers.test.tsx
+++ b/frontend/lib/hooks/admin/useAdminUsers.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createWrapper } from '@/test/utils'
 
 const mockApiRequest = vi.fn()
 
@@ -28,16 +27,6 @@ vi.mock('@/lib/queryClient', () => ({
 
 import { useAdminUsers } from './useAdminUsers'
 
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false, gcTime: 0 },
-    },
-  })
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-  }
-}
 
 describe('useAdminUsers', () => {
   beforeEach(() => {

--- a/frontend/lib/hooks/admin/useAdminVenueEdits.test.tsx
+++ b/frontend/lib/hooks/admin/useAdminVenueEdits.test.tsx
@@ -1,8 +1,7 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { createWrapper, createTestQueryClient } from '@/test/utils'
+import { QueryClient } from '@tanstack/react-query'
+import { createWrapper, createWrapperWithClient, createTestQueryClient } from '@/test/utils'
 
 // Create mocks
 const mockApiRequest = vi.fn()
@@ -49,14 +48,6 @@ import {
   useRejectVenueEdit,
 } from './useAdminVenueEdits'
 
-// Helper to create wrapper with specific query client
-function createWrapperWithClient(queryClient: QueryClient) {
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    )
-  }
-}
 
 describe('useAdminVenueEdits', () => {
   beforeEach(() => {

--- a/frontend/lib/hooks/admin/useAdminVenues.test.tsx
+++ b/frontend/lib/hooks/admin/useAdminVenues.test.tsx
@@ -1,8 +1,7 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { createWrapper, createTestQueryClient } from '@/test/utils'
+import { QueryClient } from '@tanstack/react-query'
+import { createWrapper, createWrapperWithClient, createTestQueryClient } from '@/test/utils'
 
 // Create mocks
 const mockApiRequest = vi.fn()
@@ -31,14 +30,6 @@ vi.mock('../../queryClient', () => ({
 // Import hooks after mocks are set up
 import { useVerifyVenue } from './useAdminVenues'
 
-// Helper to create wrapper with specific query client
-function createWrapperWithClient(queryClient: QueryClient) {
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    )
-  }
-}
 
 describe('useAdminVenues', () => {
   beforeEach(() => {

--- a/frontend/lib/hooks/admin/useAnalytics.test.tsx
+++ b/frontend/lib/hooks/admin/useAnalytics.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor } from '@testing-library/react'
 import { createWrapper } from '@/test/utils'

--- a/frontend/lib/hooks/admin/useDataQuality.test.tsx
+++ b/frontend/lib/hooks/admin/useDataQuality.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createWrapper } from '@/test/utils'
 
 const mockApiRequest = vi.fn()
 
@@ -32,16 +31,6 @@ vi.mock('@/lib/queryClient', () => ({
 
 import { useDataQualitySummary, useDataQualityCategory } from './useDataQuality'
 
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false, gcTime: 0 },
-    },
-  })
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-  }
-}
 
 describe('useDataQualitySummary', () => {
   beforeEach(() => {

--- a/frontend/lib/hooks/common/useFollow.test.tsx
+++ b/frontend/lib/hooks/common/useFollow.test.tsx
@@ -1,7 +1,7 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { QueryClient } from '@tanstack/react-query'
+import { createWrapper, createWrapperWithClient } from '@/test/utils'
 
 const mockApiRequest = vi.fn()
 const mockInvalidateFollows = vi.fn()
@@ -44,19 +44,6 @@ import {
   useMyFollowing,
 } from './useFollow'
 
-function createWrapper(queryClient?: QueryClient) {
-  const qc =
-    queryClient ??
-    new QueryClient({
-      defaultOptions: {
-        queries: { retry: false, gcTime: 0 },
-        mutations: { retry: false },
-      },
-    })
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-  }
-}
 
 describe('useFollowStatus', () => {
   beforeEach(() => {
@@ -173,7 +160,7 @@ describe('useFollow', () => {
     mockApiRequest.mockResolvedValueOnce({ success: true })
 
     const { result } = renderHook(() => useFollow(), {
-      wrapper: createWrapper(queryClient),
+      wrapper: createWrapperWithClient(queryClient),
     })
 
     await act(async () => {
@@ -227,7 +214,7 @@ describe('useUnfollow', () => {
     mockApiRequest.mockResolvedValueOnce({ success: true })
 
     const { result } = renderHook(() => useUnfollow(), {
-      wrapper: createWrapper(queryClient),
+      wrapper: createWrapperWithClient(queryClient),
     })
 
     await act(async () => {

--- a/frontend/lib/hooks/common/useRevisions.test.tsx
+++ b/frontend/lib/hooks/common/useRevisions.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createWrapper } from '@/test/utils'
 
 const mockApiRequest = vi.fn()
 
@@ -38,17 +37,6 @@ import {
   useRollbackRevision,
 } from './useRevisions'
 
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false, gcTime: 0 },
-      mutations: { retry: false },
-    },
-  })
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-  }
-}
 
 describe('useEntityRevisions', () => {
   beforeEach(() => {

--- a/frontend/lib/hooks/common/useSearch.test.tsx
+++ b/frontend/lib/hooks/common/useSearch.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createWrapper } from '@/test/utils'
 
 // Create mocks
 const mockApiRequest = vi.fn()
@@ -41,22 +40,6 @@ vi.mock('use-debounce', () => ({
 import { useArtistSearch } from '@/features/artists'
 import { useVenueSearch } from '@/features/venues'
 
-// Helper to create wrapper with query client
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: false,
-        gcTime: 0,
-      },
-    },
-  })
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    )
-  }
-}
 
 describe('useArtistSearch', () => {
   beforeEach(() => {

--- a/frontend/test/utils.tsx
+++ b/frontend/test/utils.tsx
@@ -22,11 +22,26 @@ export function createTestQueryClient(): QueryClient {
 }
 
 /**
- * Create a wrapper component with all necessary providers
+ * Create a wrapper component with all necessary providers.
+ * Use with renderHook({ wrapper: createWrapper() })
  */
 export function createWrapper(): React.FC<{ children: ReactNode }> {
   const queryClient = createTestQueryClient()
 
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+  }
+}
+
+/**
+ * Create a wrapper component with a specific QueryClient instance.
+ * Use when you need to pre-populate the cache or inspect query state.
+ */
+export function createWrapperWithClient(
+  queryClient: QueryClient
+): React.FC<{ children: ReactNode }> {
   return function Wrapper({ children }: { children: ReactNode }) {
     return (
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>


### PR DESCRIPTION
## Summary
- Extended shared `test/utils.tsx` with `createWrapperWithClient()` for hook tests needing custom query clients
- Migrated 47 test files from inline `createWrapper()` to shared utility imports
- Cleaned up unused React/QueryClient/QueryClientProvider imports
- Net reduction of 488 lines (570 deletions, 82 insertions)
- All 1870 frontend tests pass

Closes PSY-183

## Test plan
- [ ] All frontend tests pass: `bun run test:run`
- [ ] No regressions in hook or component tests
- [ ] Shared utilities importable via `@/test/utils`

🤖 Generated with [Claude Code](https://claude.com/claude-code)