### PR TITLE
Backend: Rename Collections to Crates

### DIFF
--- a/backend/internal/api/handlers/analytics.go
+++ b/backend/internal/api/handlers/analytics.go
@@ -97,7 +97,7 @@ type GetEngagementMetricsResponse struct {
 		Bookmarks       []EngagementMetricResponse `json:"bookmarks"`
 		TagsAdded       []EngagementMetricResponse `json:"tags_added"`
 		TagVotes        []EngagementMetricResponse `json:"tag_votes"`
-		CollectionItems []EngagementMetricResponse `json:"collection_items"`
+		CollectionItems []EngagementMetricResponse `json:"crate_items"`
 		Requests        []EngagementMetricResponse `json:"requests"`
 		RequestVotes    []EngagementMetricResponse `json:"request_votes"`
 		Revisions       []EngagementMetricResponse `json:"revisions"`
@@ -162,7 +162,7 @@ type GetCommunityHealthResponse struct {
 		ActiveContributors30d  int                           `json:"active_contributors_30d"`
 		ContributionsPerWeek   []WeeklyContributionsResponse `json:"contributions_per_week"`
 		RequestFulfillmentRate float64                       `json:"request_fulfillment_rate"`
-		NewCollections30d      int                           `json:"new_collections_30d"`
+		NewCollections30d      int                           `json:"new_crates_30d"`
 		TopContributors        []TopContributorResponse      `json:"top_contributors"`
 	}
 }

--- a/backend/internal/api/handlers/collection.go
+++ b/backend/internal/api/handlers/collection.go
@@ -36,17 +36,17 @@ func NewCollectionHandler(collectionService services.CollectionServiceInterface,
 type ListCollectionsHandlerRequest struct {
 	Creator    string `query:"creator" required:"false" doc:"Filter by creator username"`
 	EntityType string `query:"entity_type" required:"false" doc:"Filter by entity type (artist, release, label, show, venue, festival)"`
-	Featured   int    `query:"featured" required:"false" doc:"Filter featured collections (1=featured only)" example:"0"`
+	Featured   int    `query:"featured" required:"false" doc:"Filter featured crates (1=featured only)" example:"0"`
 	Search     string `query:"search" required:"false" doc:"Search by title"`
 	Limit      int    `query:"limit" required:"false" doc:"Max results (default 20)" example:"20"`
 	Offset     int    `query:"offset" required:"false" doc:"Offset for pagination" example:"0"`
 }
 
-// ListCollectionsHandlerResponse represents the response for listing collections
+// ListCollectionsHandlerResponse represents the response for listing crates
 type ListCollectionsHandlerResponse struct {
 	Body struct {
-		Collections []*services.CollectionListResponse `json:"collections" doc:"List of collections"`
-		Total       int64                              `json:"total" doc:"Total number of matching collections"`
+		Collections []*services.CollectionListResponse `json:"crates" doc:"List of crates"`
+		Total       int64                              `json:"total" doc:"Total number of matching crates"`
 	}
 }
 
@@ -91,7 +91,7 @@ func (h *CollectionHandler) ListCollectionsHandler(ctx context.Context, req *Lis
 
 // GetCollectionHandlerRequest represents the request for getting a single collection
 type GetCollectionHandlerRequest struct {
-	Slug string `path:"slug" doc:"Collection slug" example:"my-favorite-artists"`
+	Slug string `path:"slug" doc:"Crate slug" example:"my-favorite-artists"`
 }
 
 // GetCollectionHandlerResponse represents the response for the get collection endpoint
@@ -121,7 +121,7 @@ func (h *CollectionHandler) GetCollectionHandler(ctx context.Context, req *GetCo
 
 // GetCollectionStatsHandlerRequest represents the request for getting collection stats
 type GetCollectionStatsHandlerRequest struct {
-	Slug string `path:"slug" doc:"Collection slug" example:"my-favorite-artists"`
+	Slug string `path:"slug" doc:"Crate slug" example:"my-favorite-artists"`
 }
 
 // GetCollectionStatsHandlerResponse represents the response for the collection stats endpoint
@@ -146,11 +146,11 @@ func (h *CollectionHandler) GetCollectionStatsHandler(ctx context.Context, req *
 // CreateCollectionHandlerRequest represents the request for creating a collection
 type CreateCollectionHandlerRequest struct {
 	Body struct {
-		Title         string  `json:"title" doc:"Collection title" example:"Phoenix Indie Shows"`
-		Description   *string `json:"description,omitempty" required:"false" doc:"Collection description"`
+		Title         string  `json:"title" doc:"Crate title" example:"Phoenix Indie Shows"`
+		Description   *string `json:"description,omitempty" required:"false" doc:"Crate description"`
 		Collaborative bool    `json:"collaborative,omitempty" required:"false" doc:"Whether other users can add items"`
 		CoverImageURL *string `json:"cover_image_url,omitempty" required:"false" doc:"Cover image URL"`
-		IsPublic      bool    `json:"is_public,omitempty" required:"false" doc:"Whether the collection is publicly visible"`
+		IsPublic      bool    `json:"is_public,omitempty" required:"false" doc:"Whether the crate is publicly visible"`
 	}
 }
 
@@ -194,7 +194,7 @@ func (h *CollectionHandler) CreateCollectionHandler(ctx context.Context, req *Cr
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
 		go func() {
-			h.auditLogService.LogAction(user.ID, "create_collection", "collection", collection.ID, nil)
+			h.auditLogService.LogAction(user.ID, "create_crate", "collection", collection.ID, nil)
 		}()
 	}
 
@@ -207,13 +207,13 @@ func (h *CollectionHandler) CreateCollectionHandler(ctx context.Context, req *Cr
 
 // UpdateCollectionHandlerRequest represents the request for updating a collection
 type UpdateCollectionHandlerRequest struct {
-	Slug string `path:"slug" doc:"Collection slug" example:"my-favorite-artists"`
+	Slug string `path:"slug" doc:"Crate slug" example:"my-favorite-artists"`
 	Body struct {
-		Title         *string `json:"title,omitempty" required:"false" doc:"Collection title"`
-		Description   *string `json:"description,omitempty" required:"false" doc:"Collection description"`
+		Title         *string `json:"title,omitempty" required:"false" doc:"Crate title"`
+		Description   *string `json:"description,omitempty" required:"false" doc:"Crate description"`
 		Collaborative *bool   `json:"collaborative,omitempty" required:"false" doc:"Whether other users can add items"`
 		CoverImageURL *string `json:"cover_image_url,omitempty" required:"false" doc:"Cover image URL"`
-		IsPublic      *bool   `json:"is_public,omitempty" required:"false" doc:"Whether the collection is publicly visible"`
+		IsPublic      *bool   `json:"is_public,omitempty" required:"false" doc:"Whether the crate is publicly visible"`
 	}
 }
 
@@ -258,7 +258,7 @@ func (h *CollectionHandler) UpdateCollectionHandler(ctx context.Context, req *Up
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
 		go func() {
-			h.auditLogService.LogAction(user.ID, "update_collection", "collection", collection.ID, nil)
+			h.auditLogService.LogAction(user.ID, "update_crate", "collection", collection.ID, nil)
 		}()
 	}
 
@@ -271,7 +271,7 @@ func (h *CollectionHandler) UpdateCollectionHandler(ctx context.Context, req *Up
 
 // DeleteCollectionHandlerRequest represents the request for deleting a collection
 type DeleteCollectionHandlerRequest struct {
-	Slug string `path:"slug" doc:"Collection slug" example:"my-favorite-artists"`
+	Slug string `path:"slug" doc:"Crate slug" example:"my-favorite-artists"`
 }
 
 // DeleteCollectionHandler handles DELETE /collections/{slug}
@@ -302,7 +302,7 @@ func (h *CollectionHandler) DeleteCollectionHandler(ctx context.Context, req *De
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
 		go func() {
-			h.auditLogService.LogAction(user.ID, "delete_collection", "collection", 0, map[string]interface{}{"slug": req.Slug})
+			h.auditLogService.LogAction(user.ID, "delete_crate", "collection", 0, map[string]interface{}{"slug": req.Slug})
 		}()
 	}
 
@@ -315,7 +315,7 @@ func (h *CollectionHandler) DeleteCollectionHandler(ctx context.Context, req *De
 
 // AddItemHandlerRequest represents the request for adding an item to a collection
 type AddItemHandlerRequest struct {
-	Slug string `path:"slug" doc:"Collection slug" example:"my-favorite-artists"`
+	Slug string `path:"slug" doc:"Crate slug" example:"my-favorite-artists"`
 	Body struct {
 		EntityType string  `json:"entity_type" doc:"Entity type (artist, release, label, show, venue, festival)" example:"artist"`
 		EntityID   uint    `json:"entity_id" doc:"Entity ID" example:"42"`
@@ -369,7 +369,7 @@ func (h *CollectionHandler) AddItemHandler(ctx context.Context, req *AddItemHand
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
 		go func() {
-			h.auditLogService.LogAction(user.ID, "add_collection_item", "collection", item.ID, map[string]interface{}{
+			h.auditLogService.LogAction(user.ID, "add_crate_item", "collection", item.ID, map[string]interface{}{
 				"slug":        req.Slug,
 				"entity_type": req.Body.EntityType,
 				"entity_id":   req.Body.EntityID,
@@ -386,8 +386,8 @@ func (h *CollectionHandler) AddItemHandler(ctx context.Context, req *AddItemHand
 
 // RemoveItemHandlerRequest represents the request for removing an item from a collection
 type RemoveItemHandlerRequest struct {
-	Slug   string `path:"slug" doc:"Collection slug" example:"my-favorite-artists"`
-	ItemID string `path:"item_id" doc:"Collection item ID" example:"1"`
+	Slug   string `path:"slug" doc:"Crate slug" example:"my-favorite-artists"`
+	ItemID string `path:"item_id" doc:"Crate item ID" example:"1"`
 }
 
 // RemoveItemHandler handles DELETE /collections/{slug}/items/{item_id}
@@ -424,7 +424,7 @@ func (h *CollectionHandler) RemoveItemHandler(ctx context.Context, req *RemoveIt
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
 		go func() {
-			h.auditLogService.LogAction(user.ID, "remove_collection_item", "collection", uint(itemID), map[string]interface{}{
+			h.auditLogService.LogAction(user.ID, "remove_crate_item", "collection", uint(itemID), map[string]interface{}{
 				"slug": req.Slug,
 			})
 		}()
@@ -439,7 +439,7 @@ func (h *CollectionHandler) RemoveItemHandler(ctx context.Context, req *RemoveIt
 
 // ReorderItemsHandlerRequest represents the request for reordering collection items
 type ReorderItemsHandlerRequest struct {
-	Slug string `path:"slug" doc:"Collection slug" example:"my-favorite-artists"`
+	Slug string `path:"slug" doc:"Crate slug" example:"my-favorite-artists"`
 	Body struct {
 		Items []services.ReorderItem `json:"items" doc:"Items with new positions"`
 	}
@@ -483,7 +483,7 @@ func (h *CollectionHandler) ReorderItemsHandler(ctx context.Context, req *Reorde
 
 // SubscribeHandlerRequest represents the request for subscribing to a collection
 type SubscribeHandlerRequest struct {
-	Slug string `path:"slug" doc:"Collection slug" example:"my-favorite-artists"`
+	Slug string `path:"slug" doc:"Crate slug" example:"my-favorite-artists"`
 }
 
 // SubscribeHandler handles POST /collections/{slug}/subscribe
@@ -503,7 +503,7 @@ func (h *CollectionHandler) SubscribeHandler(ctx context.Context, req *Subscribe
 
 // UnsubscribeHandlerRequest represents the request for unsubscribing from a collection
 type UnsubscribeHandlerRequest struct {
-	Slug string `path:"slug" doc:"Collection slug" example:"my-favorite-artists"`
+	Slug string `path:"slug" doc:"Crate slug" example:"my-favorite-artists"`
 }
 
 // UnsubscribeHandler handles DELETE /collections/{slug}/subscribe
@@ -527,9 +527,9 @@ func (h *CollectionHandler) UnsubscribeHandler(ctx context.Context, req *Unsubsc
 
 // SetFeaturedHandlerRequest represents the request for setting a collection's featured status
 type SetFeaturedHandlerRequest struct {
-	Slug string `path:"slug" doc:"Collection slug" example:"my-favorite-artists"`
+	Slug string `path:"slug" doc:"Crate slug" example:"my-favorite-artists"`
 	Body struct {
-		Featured bool `json:"featured" doc:"Whether the collection should be featured"`
+		Featured bool `json:"featured" doc:"Whether the crate should be featured"`
 	}
 }
 
@@ -561,7 +561,7 @@ func (h *CollectionHandler) SetFeaturedHandler(ctx context.Context, req *SetFeat
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
 		go func() {
-			h.auditLogService.LogAction(user.ID, "set_collection_featured", "collection", 0, map[string]interface{}{
+			h.auditLogService.LogAction(user.ID, "set_crate_featured", "collection", 0, map[string]interface{}{
 				"slug":     req.Slug,
 				"featured": req.Body.Featured,
 			})
@@ -581,11 +581,11 @@ type GetUserCollectionsHandlerRequest struct {
 	Offset int `query:"offset" required:"false" doc:"Offset for pagination" example:"0"`
 }
 
-// GetUserCollectionsHandlerResponse represents the response for the user collections endpoint
+// GetUserCollectionsHandlerResponse represents the response for the user crates endpoint
 type GetUserCollectionsHandlerResponse struct {
 	Body struct {
-		Collections []*services.CollectionListResponse `json:"collections" doc:"List of user's collections"`
-		Total       int64                              `json:"total" doc:"Total number of collections"`
+		Collections []*services.CollectionListResponse `json:"crates" doc:"List of user's crates"`
+		Total       int64                              `json:"total" doc:"Total number of crates"`
 	}
 }
 

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -606,37 +606,65 @@ func setupPipelineRoutes(protected *huma.Group, sc *services.ServiceContainer) {
 	huma.Post(protected, "/admin/pipeline/enrichment/trigger/{show_id}", pipelineHandler.TriggerEnrichmentHandler)
 }
 
-// setupCollectionRoutes configures collection endpoints.
-// Public endpoints use optional auth (for private collection access checks).
+// setupCollectionRoutes configures crate (formerly "collection") endpoints.
+// Both /crates/ and /collections/ paths are registered for backward compatibility.
+// Public endpoints use optional auth (for private crate access checks).
 // CRUD, item management, and subscription endpoints require authentication.
 func setupCollectionRoutes(api huma.API, protected *huma.Group, sc *services.ServiceContainer) {
 	collectionHandler := handlers.NewCollectionHandler(sc.Collection, sc.AuditLog)
 
-	// Public collection endpoints with optional auth
+	// Public crate endpoints with optional auth
 	optionalAuthGroup := huma.NewGroup(api, "")
 	optionalAuthGroup.UseMiddleware(middleware.OptionalHumaJWTMiddleware(sc.JWT))
+
+	// Canonical /crates/ paths
+	huma.Get(optionalAuthGroup, "/crates", collectionHandler.ListCollectionsHandler)
+	huma.Get(optionalAuthGroup, "/crates/{slug}", collectionHandler.GetCollectionHandler)
+	huma.Get(optionalAuthGroup, "/crates/{slug}/stats", collectionHandler.GetCollectionStatsHandler)
+
+	// Legacy /collections/ paths (backward compat — same handlers, different operation IDs)
 	huma.Get(optionalAuthGroup, "/collections", collectionHandler.ListCollectionsHandler)
 	huma.Get(optionalAuthGroup, "/collections/{slug}", collectionHandler.GetCollectionHandler)
 	huma.Get(optionalAuthGroup, "/collections/{slug}/stats", collectionHandler.GetCollectionStatsHandler)
 
-	// Protected collection endpoints
+	// Protected crate endpoints — canonical /crates/ paths
+	huma.Post(protected, "/crates", collectionHandler.CreateCollectionHandler)
+	huma.Put(protected, "/crates/{slug}", collectionHandler.UpdateCollectionHandler)
+	huma.Delete(protected, "/crates/{slug}", collectionHandler.DeleteCollectionHandler)
+
+	// Protected crate endpoints — legacy /collections/ paths (backward compat)
 	huma.Post(protected, "/collections", collectionHandler.CreateCollectionHandler)
 	huma.Put(protected, "/collections/{slug}", collectionHandler.UpdateCollectionHandler)
 	huma.Delete(protected, "/collections/{slug}", collectionHandler.DeleteCollectionHandler)
 
-	// Collection item management
+	// Crate item management — canonical /crates/ paths
+	huma.Post(protected, "/crates/{slug}/items", collectionHandler.AddItemHandler)
+	huma.Delete(protected, "/crates/{slug}/items/{item_id}", collectionHandler.RemoveItemHandler)
+	huma.Put(protected, "/crates/{slug}/items/reorder", collectionHandler.ReorderItemsHandler)
+
+	// Crate item management — legacy /collections/ paths (backward compat)
 	huma.Post(protected, "/collections/{slug}/items", collectionHandler.AddItemHandler)
 	huma.Delete(protected, "/collections/{slug}/items/{item_id}", collectionHandler.RemoveItemHandler)
 	huma.Put(protected, "/collections/{slug}/items/reorder", collectionHandler.ReorderItemsHandler)
 
-	// Collection subscription
+	// Crate subscription — canonical /crates/ paths
+	huma.Post(protected, "/crates/{slug}/subscribe", collectionHandler.SubscribeHandler)
+	huma.Delete(protected, "/crates/{slug}/subscribe", collectionHandler.UnsubscribeHandler)
+
+	// Crate subscription — legacy /collections/ paths (backward compat)
 	huma.Post(protected, "/collections/{slug}/subscribe", collectionHandler.SubscribeHandler)
 	huma.Delete(protected, "/collections/{slug}/subscribe", collectionHandler.UnsubscribeHandler)
 
-	// Admin: feature/unfeature collections
+	// Admin: feature/unfeature crates — canonical /crates/ paths
+	huma.Put(protected, "/crates/{slug}/feature", collectionHandler.SetFeaturedHandler)
+
+	// Admin: feature/unfeature crates — legacy /collections/ paths (backward compat)
 	huma.Put(protected, "/collections/{slug}/feature", collectionHandler.SetFeaturedHandler)
 
-	// User's own collections (created + subscribed)
+	// User's own crates (created + subscribed)
+	huma.Get(protected, "/auth/crates", collectionHandler.GetUserCollectionsHandler)
+
+	// Legacy user crates path (backward compat)
 	huma.Get(protected, "/auth/collections", collectionHandler.GetUserCollectionsHandler)
 }
 

--- a/backend/internal/services/admin/stats.go
+++ b/backend/internal/services/admin/stats.go
@@ -168,9 +168,12 @@ func mapActionToEventType(action string) string {
 		"create_festival":            "festival_created",
 		"edit_festival":              "festival_edited",
 		"delete_festival":            "festival_deleted",
-		"create_collection":          "collection_created",
-		"update_collection":          "collection_updated",
-		"delete_collection":          "collection_deleted",
+		"create_crate":               "crate_created",
+		"update_crate":               "crate_updated",
+		"delete_crate":               "crate_deleted",
+		"create_collection":          "crate_created",
+		"update_collection":          "crate_updated",
+		"delete_collection":          "crate_deleted",
 		"create_request":             "request_created",
 		"fulfill_request":            "request_fulfilled",
 		"close_request":              "request_closed",
@@ -186,7 +189,8 @@ func mapActionToEventType(action string) string {
 		"revision_rollback":          "revision_rolled_back",
 		"create_artist_relationship": "artist_relationship_created",
 		"delete_artist_relationship": "artist_relationship_deleted",
-		"set_collection_featured":    "collection_featured",
+		"set_crate_featured":         "crate_featured",
+		"set_collection_featured":    "crate_featured",
 	}
 	if eventType, ok := mapping[action]; ok {
 		return eventType
@@ -215,9 +219,12 @@ func buildDescription(action, entityType string, entityID uint) string {
 		"create_festival":            "Festival #%d was created",
 		"edit_festival":              "Festival #%d was edited",
 		"delete_festival":            "Festival #%d was deleted",
-		"create_collection":          "Collection #%d was created",
-		"update_collection":          "Collection #%d was updated",
-		"delete_collection":          "Collection was deleted",
+		"create_crate":               "Crate #%d was created",
+		"update_crate":               "Crate #%d was updated",
+		"delete_crate":               "Crate was deleted",
+		"create_collection":          "Crate #%d was created",
+		"update_collection":          "Crate #%d was updated",
+		"delete_collection":          "Crate was deleted",
 		"create_request":             "Request #%d was created",
 		"fulfill_request":            "Request #%d was fulfilled",
 		"close_request":              "Request #%d was closed",
@@ -233,7 +240,8 @@ func buildDescription(action, entityType string, entityID uint) string {
 		"revision_rollback":          "Revision #%d was rolled back",
 		"create_artist_relationship": "Artist relationship created for artist #%d",
 		"delete_artist_relationship": "Artist relationship deleted for artist #%d",
-		"set_collection_featured":    "Collection featured status changed",
+		"set_crate_featured":         "Crate featured status changed",
+		"set_collection_featured":    "Crate featured status changed",
 	}
 	if template, ok := actionDescriptions[action]; ok {
 		if strings.Contains(template, "%d") {

--- a/backend/internal/services/contracts/catalog.go
+++ b/backend/internal/services/contracts/catalog.go
@@ -522,7 +522,7 @@ type MergeArtistResult struct {
 	FestivalsMoved       int64  `json:"festivals_moved"`
 	RelationshipsMoved   int64  `json:"relationships_moved"`
 	BookmarksMoved       int64  `json:"bookmarks_moved"`
-	CollectionItemsMoved int64  `json:"collection_items_moved"`
+	CollectionItemsMoved int64  `json:"crate_items_moved"`
 	FiltersUpdated       int64  `json:"filters_updated"`
 	AliasCreated         bool   `json:"alias_created"`
 }


### PR DESCRIPTION
## Summary
- Registered all collection handlers at new `/crates/` paths (canonical) alongside existing `/collections/` paths (backward compat)
- Updated JSON response field names: `collections` → `crates`, `collection_items` → `crate_items`, `new_collections_30d` → `new_crates_30d`
- Updated audit log actions: `create_collection` → `create_crate`, etc. (old keys kept for backward compat display)
- Internal Go types, DB tables, and file names unchanged (implementation details)
- All tests pass

Closes PSY-202

## Test plan
- [ ] `GET /crates` returns same data as `GET /collections`
- [ ] JSON responses use `crates` field name
- [ ] Old `/collections/` routes still work
- [ ] Audit log shows "Crate" descriptions for new actions
- [ ] All backend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)