### PR TITLE
Fix admin tags pluralization: '1 use' not '1 uses'

### DIFF
--- a/frontend/features/tags/admin/TagManagement.tsx
+++ b/frontend/features/tags/admin/TagManagement.tsx
@@ -684,7 +684,7 @@ export function TagManagement() {
                     )}
                   </div>
                   <div className="flex items-center gap-3 text-xs text-muted-foreground mt-0.5">
-                    <span>{tag.usage_count} uses</span>
+                    <span>{tag.usage_count} {tag.usage_count === 1 ? 'use' : 'uses'}</span>
                     <span className="text-muted-foreground/50">
                       /{tag.slug}
                     </span>


### PR DESCRIPTION
## Summary
- Fix incorrect pluralization in the admin Tags tab where tags with 1 usage showed "1 uses" instead of "1 use"
- One-line fix in `TagManagement.tsx`, matching the pattern already used on public tag pages

Closes PSY-207

## Test plan
- [ ] Navigate to `/admin?tab=tags`
- [ ] Verify tags with 1 usage show "1 use" (singular)
- [ ] Verify tags with 2+ usages still show "uses" (plural)

🤖 Generated with [Claude Code](https://claude.com/claude-code)