### PR TITLE
Split ShowServiceInterface into 4 focused interfaces

### DIFF
--- a/backend/internal/api/handlers/admin_integration_test.go
+++ b/backend/internal/api/handlers/admin_integration_test.go
@@ -26,6 +26,8 @@ func (s *AdminHandlerIntegrationSuite) SetupSuite() {
 	s.deps = setupHandlerIntegrationDeps(s.T())
 	s.showHandler = NewAdminShowHandler(
 		s.deps.showService,
+		s.deps.showService,
+		s.deps.showService,
 		s.deps.discordService,
 		s.deps.auditLogService,
 		nil, // notificationFilterService

--- a/backend/internal/api/handlers/admin_shows.go
+++ b/backend/internal/api/handlers/admin_shows.go
@@ -16,6 +16,8 @@ import (
 // AdminShowHandler handles admin show management
 type AdminShowHandler struct {
 	showService               contracts.ShowServiceInterface
+	showAdminService          contracts.ShowAdminServiceInterface
+	showImportService         contracts.ShowImportServiceInterface
 	discordService            contracts.DiscordServiceInterface
 	auditLogService           contracts.AuditLogServiceInterface
 	notificationFilterService contracts.NotificationFilterServiceInterface
@@ -25,6 +27,8 @@ type AdminShowHandler struct {
 // NewAdminShowHandler creates a new admin show handler
 func NewAdminShowHandler(
 	showService contracts.ShowServiceInterface,
+	showAdminService contracts.ShowAdminServiceInterface,
+	showImportService contracts.ShowImportServiceInterface,
 	discordService contracts.DiscordServiceInterface,
 	auditLogService contracts.AuditLogServiceInterface,
 	notificationFilterService contracts.NotificationFilterServiceInterface,
@@ -32,6 +36,8 @@ func NewAdminShowHandler(
 ) *AdminShowHandler {
 	return &AdminShowHandler{
 		showService:               showService,
+		showAdminService:          showAdminService,
+		showImportService:         showImportService,
 		discordService:            discordService,
 		auditLogService:           auditLogService,
 		notificationFilterService: notificationFilterService,
@@ -180,7 +186,7 @@ func (h *AdminShowHandler) GetPendingShowsHandler(ctx context.Context, req *GetP
 	)
 
 	// Get pending shows
-	shows, total, err := h.showService.GetPendingShows(limit, offset, filters)
+	shows, total, err := h.showAdminService.GetPendingShows(limit, offset, filters)
 	if err != nil {
 		logger.FromContext(ctx).Error("admin_pending_shows_failed",
 			"error", err.Error(),
@@ -237,7 +243,7 @@ func (h *AdminShowHandler) GetRejectedShowsHandler(ctx context.Context, req *Get
 	)
 
 	// Get rejected shows
-	shows, total, err := h.showService.GetRejectedShows(limit, offset, req.Search)
+	shows, total, err := h.showAdminService.GetRejectedShows(limit, offset, req.Search)
 	if err != nil {
 		logger.FromContext(ctx).Error("admin_rejected_shows_failed",
 			"error", err.Error(),
@@ -286,7 +292,7 @@ func (h *AdminShowHandler) ApproveShowHandler(ctx context.Context, req *ApproveS
 	)
 
 	// Approve the show
-	show, err := h.showService.ApproveShow(uint(showID), req.Body.VerifyVenues)
+	show, err := h.showAdminService.ApproveShow(uint(showID), req.Body.VerifyVenues)
 	if err != nil {
 		logger.FromContext(ctx).Error("admin_approve_show_failed",
 			"show_id", showID,
@@ -361,7 +367,7 @@ func (h *AdminShowHandler) RejectShowHandler(ctx context.Context, req *RejectSho
 	)
 
 	// Reject the show
-	show, err := h.showService.RejectShow(uint(showID), req.Body.Reason)
+	show, err := h.showAdminService.RejectShow(uint(showID), req.Body.Reason)
 	if err != nil {
 		logger.FromContext(ctx).Error("admin_reject_show_failed",
 			"show_id", showID,
@@ -397,7 +403,7 @@ func (h *AdminShowHandler) BatchApproveShowsHandler(ctx context.Context, req *Ba
 		return nil, err
 	}
 
-	result, err := h.showService.BatchApproveShows(req.Body.ShowIDs)
+	result, err := h.showAdminService.BatchApproveShows(req.Body.ShowIDs)
 	if err != nil {
 		return nil, huma.Error500InternalServerError("Failed to batch approve shows")
 	}
@@ -463,7 +469,7 @@ func (h *AdminShowHandler) BatchRejectShowsHandler(ctx context.Context, req *Bat
 		return nil, huma.Error400BadRequest("Rejection reason is required")
 	}
 
-	result, err := h.showService.BatchRejectShows(req.Body.ShowIDs, req.Body.Reason, req.Body.Category)
+	result, err := h.showAdminService.BatchRejectShows(req.Body.ShowIDs, req.Body.Reason, req.Body.Category)
 	if err != nil {
 		return nil, huma.Error500InternalServerError("Failed to batch reject shows")
 	}
@@ -536,7 +542,7 @@ func (h *AdminShowHandler) ImportShowPreviewHandler(ctx context.Context, req *Im
 	)
 
 	// Preview the import
-	preview, err := h.showService.PreviewShowImport(content)
+	preview, err := h.showImportService.PreviewShowImport(content)
 	if err != nil {
 		logger.FromContext(ctx).Error("admin_import_preview_failed",
 			"error", err.Error(),
@@ -595,7 +601,7 @@ func (h *AdminShowHandler) ImportShowConfirmHandler(ctx context.Context, req *Im
 	)
 
 	// Confirm the import (admin imports auto-verify venues)
-	show, err := h.showService.ConfirmShowImport(content, true)
+	show, err := h.showImportService.ConfirmShowImport(content, true)
 	if err != nil {
 		logger.FromContext(ctx).Error("admin_import_confirm_failed",
 			"error", err.Error(),
@@ -690,7 +696,7 @@ func (h *AdminShowHandler) GetAdminShowsHandler(ctx context.Context, req *GetAdm
 	}
 
 	// Get shows
-	shows, total, err := h.showService.GetAdminShows(limit, offset, filters)
+	shows, total, err := h.showAdminService.GetAdminShows(limit, offset, filters)
 	if err != nil {
 		logger.FromContext(ctx).Error("admin_shows_list_failed",
 			"error", err.Error(),
@@ -757,7 +763,7 @@ func (h *AdminShowHandler) BulkExportShowsHandler(ctx context.Context, req *Bulk
 	// Export each show
 	exports := make([]string, 0, len(req.Body.ShowIDs))
 	for _, showID := range req.Body.ShowIDs {
-		content, _, err := h.showService.ExportShowToMarkdown(showID)
+		content, _, err := h.showImportService.ExportShowToMarkdown(showID)
 		if err != nil {
 			logger.FromContext(ctx).Error("admin_bulk_export_show_failed",
 				"show_id", showID,
@@ -853,7 +859,7 @@ func (h *AdminShowHandler) BulkImportPreviewHandler(ctx context.Context, req *Bu
 			return nil, huma.Error400BadRequest(fmt.Sprintf("Invalid base64 content for show %d", i+1))
 		}
 
-		preview, err := h.showService.PreviewShowImport(content)
+		preview, err := h.showImportService.PreviewShowImport(content)
 		if err != nil {
 			logger.FromContext(ctx).Error("admin_bulk_import_preview_failed",
 				"show_index", i,
@@ -968,7 +974,7 @@ func (h *AdminShowHandler) BulkImportConfirmHandler(ctx context.Context, req *Bu
 			continue
 		}
 
-		show, err := h.showService.ConfirmShowImport(content, true)
+		show, err := h.showImportService.ConfirmShowImport(content, true)
 		if err != nil {
 			results = append(results, BulkImportResult{
 				Success: false,

--- a/backend/internal/api/handlers/admin_test.go
+++ b/backend/internal/api/handlers/admin_test.go
@@ -16,7 +16,7 @@ import (
 // ============================================================================
 
 func testAdminShowHandler() *AdminShowHandler {
-	return NewAdminShowHandler(nil, nil, nil, nil, nil)
+	return NewAdminShowHandler(nil, nil, nil, nil, nil, nil, nil)
 }
 
 func testAdminDiscoveryHandler() *AdminDiscoveryHandler {
@@ -543,7 +543,7 @@ func adminStatsHandler(opts ...func(*AdminStatsHandler)) *AdminStatsHandler {
 
 func TestGetPendingShowsHandler_Success(t *testing.T) {
 	h := adminShowHandler(func(ah *AdminShowHandler) {
-		ah.showService = &mockShowService{
+		ah.showAdminService = &mockShowAdminService{
 			getPendingShowsFn: func(limit, offset int, filters *contracts.PendingShowsFilter) ([]*contracts.ShowResponse, int64, error) {
 				return []*contracts.ShowResponse{{ID: 1}}, 1, nil
 			},
@@ -560,7 +560,7 @@ func TestGetPendingShowsHandler_Success(t *testing.T) {
 
 func TestGetPendingShowsHandler_ServiceError(t *testing.T) {
 	h := adminShowHandler(func(ah *AdminShowHandler) {
-		ah.showService = &mockShowService{
+		ah.showAdminService = &mockShowAdminService{
 			getPendingShowsFn: func(_, _ int, _ *contracts.PendingShowsFilter) ([]*contracts.ShowResponse, int64, error) {
 				return nil, 0, fmt.Errorf("db error")
 			},
@@ -572,7 +572,7 @@ func TestGetPendingShowsHandler_ServiceError(t *testing.T) {
 
 func TestGetRejectedShowsHandler_Success(t *testing.T) {
 	h := adminShowHandler(func(ah *AdminShowHandler) {
-		ah.showService = &mockShowService{
+		ah.showAdminService = &mockShowAdminService{
 			getRejectedShowsFn: func(limit, offset int, search string) ([]*contracts.ShowResponse, int64, error) {
 				return []*contracts.ShowResponse{{ID: 1}}, 1, nil
 			},
@@ -589,7 +589,7 @@ func TestGetRejectedShowsHandler_Success(t *testing.T) {
 
 func TestGetRejectedShowsHandler_ServiceError(t *testing.T) {
 	h := adminShowHandler(func(ah *AdminShowHandler) {
-		ah.showService = &mockShowService{
+		ah.showAdminService = &mockShowAdminService{
 			getRejectedShowsFn: func(_, _ int, _ string) ([]*contracts.ShowResponse, int64, error) {
 				return nil, 0, fmt.Errorf("db error")
 			},
@@ -659,7 +659,7 @@ func TestGetPendingVenueEditsHandler_ServiceError(t *testing.T) {
 
 func TestGetAdminShowsHandler_Success(t *testing.T) {
 	h := adminShowHandler(func(ah *AdminShowHandler) {
-		ah.showService = &mockShowService{
+		ah.showAdminService = &mockShowAdminService{
 			getAdminShowsFn: func(limit, offset int, filters contracts.AdminShowFilters) ([]*contracts.ShowResponse, int64, error) {
 				return []*contracts.ShowResponse{{ID: 1}}, 1, nil
 			},
@@ -676,7 +676,7 @@ func TestGetAdminShowsHandler_Success(t *testing.T) {
 
 func TestGetAdminShowsHandler_ServiceError(t *testing.T) {
 	h := adminShowHandler(func(ah *AdminShowHandler) {
-		ah.showService = &mockShowService{
+		ah.showAdminService = &mockShowAdminService{
 			getAdminShowsFn: func(_, _ int, _ contracts.AdminShowFilters) ([]*contracts.ShowResponse, int64, error) {
 				return nil, 0, fmt.Errorf("db error")
 			},
@@ -864,7 +864,7 @@ func TestGetAdminStatsHandler_ServiceError(t *testing.T) {
 func TestApproveShowHandler_Success(t *testing.T) {
 	var auditCalled bool
 	h := adminShowHandler(func(ah *AdminShowHandler) {
-		ah.showService = &mockShowService{
+		ah.showAdminService = &mockShowAdminService{
 			approveShowFn: func(showID uint, verifyVenues bool) (*contracts.ShowResponse, error) {
 				return &contracts.ShowResponse{ID: showID, Status: "approved"}, nil
 			},
@@ -892,7 +892,7 @@ func TestApproveShowHandler_Success(t *testing.T) {
 
 func TestApproveShowHandler_ServiceError(t *testing.T) {
 	h := adminShowHandler(func(ah *AdminShowHandler) {
-		ah.showService = &mockShowService{
+		ah.showAdminService = &mockShowAdminService{
 			approveShowFn: func(_ uint, _ bool) (*contracts.ShowResponse, error) {
 				return nil, fmt.Errorf("not found")
 			},
@@ -905,7 +905,7 @@ func TestApproveShowHandler_ServiceError(t *testing.T) {
 func TestRejectShowHandler_Success(t *testing.T) {
 	var auditCalled bool
 	h := adminShowHandler(func(ah *AdminShowHandler) {
-		ah.showService = &mockShowService{
+		ah.showAdminService = &mockShowAdminService{
 			rejectShowFn: func(showID uint, reason string) (*contracts.ShowResponse, error) {
 				if reason != "duplicate" {
 					t.Errorf("expected reason='duplicate', got %q", reason)
@@ -938,7 +938,7 @@ func TestRejectShowHandler_Success(t *testing.T) {
 
 func TestRejectShowHandler_ServiceError(t *testing.T) {
 	h := adminShowHandler(func(ah *AdminShowHandler) {
-		ah.showService = &mockShowService{
+		ah.showAdminService = &mockShowAdminService{
 			rejectShowFn: func(_ uint, _ string) (*contracts.ShowResponse, error) {
 				return nil, fmt.Errorf("not found")
 			},
@@ -1236,7 +1236,7 @@ func TestDiscoveryCheckHandler_ServiceError(t *testing.T) {
 
 func TestImportShowPreviewHandler_Success(t *testing.T) {
 	h := adminShowHandler(func(ah *AdminShowHandler) {
-		ah.showService = &mockShowService{
+		ah.showImportService = &mockShowImportService{
 			previewShowImportFn: func(content []byte) (*contracts.ImportPreviewResponse, error) {
 				return &contracts.ImportPreviewResponse{CanImport: true}, nil
 			},
@@ -1255,7 +1255,7 @@ func TestImportShowPreviewHandler_Success(t *testing.T) {
 
 func TestImportShowPreviewHandler_ServiceError(t *testing.T) {
 	h := adminShowHandler(func(ah *AdminShowHandler) {
-		ah.showService = &mockShowService{
+		ah.showImportService = &mockShowImportService{
 			previewShowImportFn: func(_ []byte) (*contracts.ImportPreviewResponse, error) {
 				return nil, fmt.Errorf("parse error")
 			},
@@ -1269,7 +1269,7 @@ func TestImportShowPreviewHandler_ServiceError(t *testing.T) {
 
 func TestImportShowConfirmHandler_Success(t *testing.T) {
 	h := adminShowHandler(func(ah *AdminShowHandler) {
-		ah.showService = &mockShowService{
+		ah.showImportService = &mockShowImportService{
 			confirmShowImportFn: func(content []byte, verifyVenues bool) (*contracts.ShowResponse, error) {
 				return &contracts.ShowResponse{ID: 100, Title: "Imported Show"}, nil
 			},
@@ -1288,7 +1288,7 @@ func TestImportShowConfirmHandler_Success(t *testing.T) {
 
 func TestImportShowConfirmHandler_ServiceError(t *testing.T) {
 	h := adminShowHandler(func(ah *AdminShowHandler) {
-		ah.showService = &mockShowService{
+		ah.showImportService = &mockShowImportService{
 			confirmShowImportFn: func(_ []byte, _ bool) (*contracts.ShowResponse, error) {
 				return nil, fmt.Errorf("import failed")
 			},
@@ -1302,7 +1302,7 @@ func TestImportShowConfirmHandler_ServiceError(t *testing.T) {
 
 func TestBulkExportShowsHandler_Success(t *testing.T) {
 	h := adminShowHandler(func(ah *AdminShowHandler) {
-		ah.showService = &mockShowService{
+		ah.showImportService = &mockShowImportService{
 			exportShowToMarkdownFn: func(showID uint) ([]byte, string, error) {
 				return []byte("# Show"), "show.md", nil
 			},
@@ -1322,7 +1322,7 @@ func TestBulkExportShowsHandler_Success(t *testing.T) {
 func TestBulkExportShowsHandler_PartialFail(t *testing.T) {
 	callCount := 0
 	h := adminShowHandler(func(ah *AdminShowHandler) {
-		ah.showService = &mockShowService{
+		ah.showImportService = &mockShowImportService{
 			exportShowToMarkdownFn: func(showID uint) ([]byte, string, error) {
 				callCount++
 				if callCount == 2 {
@@ -1340,7 +1340,7 @@ func TestBulkExportShowsHandler_PartialFail(t *testing.T) {
 
 func TestBulkImportPreviewHandler_Success(t *testing.T) {
 	h := adminShowHandler(func(ah *AdminShowHandler) {
-		ah.showService = &mockShowService{
+		ah.showImportService = &mockShowImportService{
 			previewShowImportFn: func(_ []byte) (*contracts.ImportPreviewResponse, error) {
 				return &contracts.ImportPreviewResponse{CanImport: true}, nil
 			},
@@ -1362,7 +1362,7 @@ func TestBulkImportPreviewHandler_Success(t *testing.T) {
 
 func TestBulkImportConfirmHandler_Success(t *testing.T) {
 	h := adminShowHandler(func(ah *AdminShowHandler) {
-		ah.showService = &mockShowService{
+		ah.showImportService = &mockShowImportService{
 			confirmShowImportFn: func(_ []byte, _ bool) (*contracts.ShowResponse, error) {
 				return &contracts.ShowResponse{ID: 1}, nil
 			},
@@ -1382,7 +1382,7 @@ func TestBulkImportConfirmHandler_Success(t *testing.T) {
 func TestBulkImportConfirmHandler_MixedResults(t *testing.T) {
 	callCount := 0
 	h := adminShowHandler(func(ah *AdminShowHandler) {
-		ah.showService = &mockShowService{
+		ah.showImportService = &mockShowImportService{
 			confirmShowImportFn: func(_ []byte, _ bool) (*contracts.ShowResponse, error) {
 				callCount++
 				if callCount == 2 {
@@ -1416,7 +1416,7 @@ func TestBulkImportConfirmHandler_MixedResults(t *testing.T) {
 
 func TestBatchApproveShowsHandler_Success(t *testing.T) {
 	h := adminShowHandler(func(ah *AdminShowHandler) {
-		ah.showService = &mockShowService{
+		ah.showAdminService = &mockShowAdminService{
 			batchApproveShowsFn: func(showIDs []uint) (*contracts.BatchShowResult, error) {
 				return &contracts.BatchShowResult{
 					Succeeded: showIDs,
@@ -1457,7 +1457,7 @@ func TestBatchApproveShowsHandler_AdminRequired(t *testing.T) {
 
 func TestBatchRejectShowsHandler_Success(t *testing.T) {
 	h := adminShowHandler(func(ah *AdminShowHandler) {
-		ah.showService = &mockShowService{
+		ah.showAdminService = &mockShowAdminService{
 			batchRejectShowsFn: func(showIDs []uint, reason string, category string) (*contracts.BatchShowResult, error) {
 				return &contracts.BatchShowResult{
 					Succeeded: showIDs,
@@ -1501,7 +1501,7 @@ func TestBatchRejectShowsHandler_AdminRequired(t *testing.T) {
 
 func TestBatchRejectShowsHandler_RequiresReason(t *testing.T) {
 	h := adminShowHandler(func(ah *AdminShowHandler) {
-		ah.showService = &mockShowService{}
+		ah.showAdminService = &mockShowAdminService{}
 	})
 
 	req := &BatchRejectShowsRequest{}
@@ -1519,7 +1519,7 @@ func TestBatchRejectShowsHandler_RequiresReason(t *testing.T) {
 func TestGetPendingShowsHandler_WithVenueIDFilter(t *testing.T) {
 	var capturedFilter *contracts.PendingShowsFilter
 	h := adminShowHandler(func(ah *AdminShowHandler) {
-		ah.showService = &mockShowService{
+		ah.showAdminService = &mockShowAdminService{
 			getPendingShowsFn: func(limit, offset int, filters *contracts.PendingShowsFilter) ([]*contracts.ShowResponse, int64, error) {
 				capturedFilter = filters
 				return []*contracts.ShowResponse{}, 0, nil
@@ -1545,7 +1545,7 @@ func TestGetPendingShowsHandler_WithVenueIDFilter(t *testing.T) {
 func TestGetPendingShowsHandler_WithSourceFilter(t *testing.T) {
 	var capturedFilter *contracts.PendingShowsFilter
 	h := adminShowHandler(func(ah *AdminShowHandler) {
-		ah.showService = &mockShowService{
+		ah.showAdminService = &mockShowAdminService{
 			getPendingShowsFn: func(limit, offset int, filters *contracts.PendingShowsFilter) ([]*contracts.ShowResponse, int64, error) {
 				capturedFilter = filters
 				return []*contracts.ShowResponse{}, 0, nil
@@ -1567,7 +1567,7 @@ func TestGetPendingShowsHandler_WithSourceFilter(t *testing.T) {
 func TestGetPendingShowsHandler_WithBothFilters(t *testing.T) {
 	var capturedFilter *contracts.PendingShowsFilter
 	h := adminShowHandler(func(ah *AdminShowHandler) {
-		ah.showService = &mockShowService{
+		ah.showAdminService = &mockShowAdminService{
 			getPendingShowsFn: func(limit, offset int, filters *contracts.PendingShowsFilter) ([]*contracts.ShowResponse, int64, error) {
 				capturedFilter = filters
 				return []*contracts.ShowResponse{}, 0, nil
@@ -1592,7 +1592,7 @@ func TestGetPendingShowsHandler_WithBothFilters(t *testing.T) {
 func TestGetPendingShowsHandler_NoFilters(t *testing.T) {
 	var capturedFilter *contracts.PendingShowsFilter
 	h := adminShowHandler(func(ah *AdminShowHandler) {
-		ah.showService = &mockShowService{
+		ah.showAdminService = &mockShowAdminService{
 			getPendingShowsFn: func(limit, offset int, filters *contracts.PendingShowsFilter) ([]*contracts.ShowResponse, int64, error) {
 				capturedFilter = filters
 				return []*contracts.ShowResponse{}, 0, nil
@@ -1615,7 +1615,7 @@ func TestGetPendingShowsHandler_NoFilters(t *testing.T) {
 func TestGetPendingShowsHandler_LimitClamping(t *testing.T) {
 	var capturedLimit, capturedOffset int
 	h := adminShowHandler(func(ah *AdminShowHandler) {
-		ah.showService = &mockShowService{
+		ah.showAdminService = &mockShowAdminService{
 			getPendingShowsFn: func(limit, offset int, _ *contracts.PendingShowsFilter) ([]*contracts.ShowResponse, int64, error) {
 				capturedLimit = limit
 				capturedOffset = offset
@@ -1655,7 +1655,7 @@ func TestGetPendingShowsHandler_LimitClamping(t *testing.T) {
 func TestGetRejectedShowsHandler_LimitClamping(t *testing.T) {
 	var capturedLimit, capturedOffset int
 	h := adminShowHandler(func(ah *AdminShowHandler) {
-		ah.showService = &mockShowService{
+		ah.showAdminService = &mockShowAdminService{
 			getRejectedShowsFn: func(limit, offset int, _ string) ([]*contracts.ShowResponse, int64, error) {
 				capturedLimit = limit
 				capturedOffset = offset
@@ -1695,7 +1695,7 @@ func TestGetRejectedShowsHandler_LimitClamping(t *testing.T) {
 func TestGetAdminShowsHandler_LimitClamping(t *testing.T) {
 	var capturedLimit, capturedOffset int
 	h := adminShowHandler(func(ah *AdminShowHandler) {
-		ah.showService = &mockShowService{
+		ah.showAdminService = &mockShowAdminService{
 			getAdminShowsFn: func(limit, offset int, _ contracts.AdminShowFilters) ([]*contracts.ShowResponse, int64, error) {
 				capturedLimit = limit
 				capturedOffset = offset
@@ -1735,7 +1735,7 @@ func TestGetAdminShowsHandler_LimitClamping(t *testing.T) {
 
 func TestBatchApproveShowsHandler_ServiceError(t *testing.T) {
 	h := adminShowHandler(func(ah *AdminShowHandler) {
-		ah.showService = &mockShowService{
+		ah.showAdminService = &mockShowAdminService{
 			batchApproveShowsFn: func(_ []uint) (*contracts.BatchShowResult, error) {
 				return nil, fmt.Errorf("db error")
 			},
@@ -1749,7 +1749,7 @@ func TestBatchApproveShowsHandler_ServiceError(t *testing.T) {
 
 func TestBatchRejectShowsHandler_ServiceError(t *testing.T) {
 	h := adminShowHandler(func(ah *AdminShowHandler) {
-		ah.showService = &mockShowService{
+		ah.showAdminService = &mockShowAdminService{
 			batchRejectShowsFn: func(_ []uint, _ string, _ string) (*contracts.BatchShowResult, error) {
 				return nil, fmt.Errorf("db error")
 			},
@@ -1768,7 +1768,7 @@ func TestBatchRejectShowsHandler_ServiceError(t *testing.T) {
 
 func TestBulkImportPreviewHandler_InvalidBase64(t *testing.T) {
 	h := adminShowHandler(func(ah *AdminShowHandler) {
-		ah.showService = &mockShowService{}
+		ah.showImportService = &mockShowImportService{}
 	})
 	req := &BulkImportPreviewRequest{}
 	req.Body.Shows = []string{"not-valid-base64!!!"}
@@ -1778,7 +1778,7 @@ func TestBulkImportPreviewHandler_InvalidBase64(t *testing.T) {
 
 func TestBulkImportPreviewHandler_ServiceError(t *testing.T) {
 	h := adminShowHandler(func(ah *AdminShowHandler) {
-		ah.showService = &mockShowService{
+		ah.showImportService = &mockShowImportService{
 			previewShowImportFn: func(_ []byte) (*contracts.ImportPreviewResponse, error) {
 				return nil, fmt.Errorf("parse error")
 			},
@@ -1793,7 +1793,7 @@ func TestBulkImportPreviewHandler_ServiceError(t *testing.T) {
 func TestBulkImportPreviewHandler_SummaryAccumulation(t *testing.T) {
 	callCount := 0
 	h := adminShowHandler(func(ah *AdminShowHandler) {
-		ah.showService = &mockShowService{
+		ah.showImportService = &mockShowImportService{
 			previewShowImportFn: func(_ []byte) (*contracts.ImportPreviewResponse, error) {
 				callCount++
 				if callCount == 1 {
@@ -1851,7 +1851,7 @@ func TestBulkImportPreviewHandler_SummaryAccumulation(t *testing.T) {
 
 func TestBulkImportConfirmHandler_InvalidBase64InArray(t *testing.T) {
 	h := adminShowHandler(func(ah *AdminShowHandler) {
-		ah.showService = &mockShowService{
+		ah.showImportService = &mockShowImportService{
 			confirmShowImportFn: func(_ []byte, _ bool) (*contracts.ShowResponse, error) {
 				return &contracts.ShowResponse{ID: 1}, nil
 			},

--- a/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
+++ b/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
@@ -555,36 +555,20 @@ func (m *mockUserService) SetShowReminders(userID uint, enabled bool) error {
 }
 
 // ============================================================================
-// Mock: ShowServiceInterface
+// Mock: ShowServiceInterface (core CRUD)
 // ============================================================================
 
 type mockShowService struct {
-	createShowFn            func(req *contracts.CreateShowRequest) (*contracts.ShowResponse, error)
-	getShowFn               func(showID uint) (*contracts.ShowResponse, error)
-	getShowBySlugFn         func(slug string) (*contracts.ShowResponse, error)
-	getShowsFn              func(filters map[string]interface{}) ([]*contracts.ShowResponse, error)
-	getUserSubmissionsFn    func(userID uint, limit, offset int) ([]contracts.ShowResponse, int, error)
-	updateShowFn            func(showID uint, updates map[string]interface{}) (*contracts.ShowResponse, error)
+	createShowFn              func(req *contracts.CreateShowRequest) (*contracts.ShowResponse, error)
+	getShowFn                 func(showID uint) (*contracts.ShowResponse, error)
+	getShowBySlugFn           func(slug string) (*contracts.ShowResponse, error)
+	getShowsFn                func(filters map[string]interface{}) ([]*contracts.ShowResponse, error)
+	getUserSubmissionsFn      func(userID uint, limit, offset int) ([]contracts.ShowResponse, int, error)
+	updateShowFn              func(showID uint, updates map[string]interface{}) (*contracts.ShowResponse, error)
 	updateShowWithRelationsFn func(showID uint, updates map[string]interface{}, venues []contracts.CreateShowVenue, artists []contracts.CreateShowArtist, isAdmin bool) (*contracts.ShowResponse, []contracts.OrphanedArtist, error)
-	getUpcomingShowsFn      func(timezone string, cursor string, limit int, includeNonApproved bool, filters *contracts.UpcomingShowsFilter) ([]*contracts.ShowResponse, *string, error)
-	getShowCitiesFn         func(timezone string) ([]contracts.ShowCityResponse, error)
-	deleteShowFn            func(showID uint) error
-	getPendingShowsFn       func(limit, offset int, filters *contracts.PendingShowsFilter) ([]*contracts.ShowResponse, int64, error)
-	getRejectedShowsFn      func(limit, offset int, search string) ([]*contracts.ShowResponse, int64, error)
-	approveShowFn           func(showID uint, verifyVenues bool) (*contracts.ShowResponse, error)
-	rejectShowFn            func(showID uint, reason string) (*contracts.ShowResponse, error)
-	unpublishShowFn         func(showID uint, userID uint, isAdmin bool) (*contracts.ShowResponse, error)
-	makePrivateShowFn       func(showID uint, userID uint, isAdmin bool) (*contracts.ShowResponse, error)
-	publishShowFn           func(showID uint, userID uint, isAdmin bool) (*contracts.ShowResponse, error)
-	exportShowToMarkdownFn  func(showID uint) ([]byte, string, error)
-	parseShowMarkdownFn     func(content []byte) (*contracts.ParsedShowImport, error)
-	previewShowImportFn     func(content []byte) (*contracts.ImportPreviewResponse, error)
-	confirmShowImportFn     func(content []byte, isAdmin bool) (*contracts.ShowResponse, error)
-	getAdminShowsFn         func(limit, offset int, filters contracts.AdminShowFilters) ([]*contracts.ShowResponse, int64, error)
-	setShowSoldOutFn        func(showID uint, isSoldOut bool) (*contracts.ShowResponse, error)
-	setShowCancelledFn      func(showID uint, isCancelled bool) (*contracts.ShowResponse, error)
-	batchApproveShowsFn     func(showIDs []uint) (*contracts.BatchShowResult, error)
-	batchRejectShowsFn      func(showIDs []uint, reason string, category string) (*contracts.BatchShowResult, error)
+	getUpcomingShowsFn        func(timezone string, cursor string, limit int, includeNonApproved bool, filters *contracts.UpcomingShowsFilter) ([]*contracts.ShowResponse, *string, error)
+	getShowCitiesFn           func(timezone string) ([]contracts.ShowCityResponse, error)
+	deleteShowFn              func(showID uint) error
 }
 
 func (m *mockShowService) CreateShow(req *contracts.CreateShowRequest) (*contracts.ShowResponse, error) {
@@ -647,101 +631,141 @@ func (m *mockShowService) DeleteShow(showID uint) error {
 	}
 	return nil
 }
-func (m *mockShowService) GetPendingShows(limit, offset int, filters *contracts.PendingShowsFilter) ([]*contracts.ShowResponse, int64, error) {
+
+// ============================================================================
+// Mock: ShowAdminServiceInterface
+// ============================================================================
+
+type mockShowAdminService struct {
+	getPendingShowsFn   func(limit, offset int, filters *contracts.PendingShowsFilter) ([]*contracts.ShowResponse, int64, error)
+	getRejectedShowsFn  func(limit, offset int, search string) ([]*contracts.ShowResponse, int64, error)
+	approveShowFn       func(showID uint, verifyVenues bool) (*contracts.ShowResponse, error)
+	rejectShowFn        func(showID uint, reason string) (*contracts.ShowResponse, error)
+	batchApproveShowsFn func(showIDs []uint) (*contracts.BatchShowResult, error)
+	batchRejectShowsFn  func(showIDs []uint, reason string, category string) (*contracts.BatchShowResult, error)
+	getAdminShowsFn     func(limit, offset int, filters contracts.AdminShowFilters) ([]*contracts.ShowResponse, int64, error)
+}
+
+func (m *mockShowAdminService) GetPendingShows(limit, offset int, filters *contracts.PendingShowsFilter) ([]*contracts.ShowResponse, int64, error) {
 	if m.getPendingShowsFn != nil {
 		return m.getPendingShowsFn(limit, offset, filters)
 	}
 	return nil, 0, nil
 }
-func (m *mockShowService) GetRejectedShows(limit, offset int, search string) ([]*contracts.ShowResponse, int64, error) {
+func (m *mockShowAdminService) GetRejectedShows(limit, offset int, search string) ([]*contracts.ShowResponse, int64, error) {
 	if m.getRejectedShowsFn != nil {
 		return m.getRejectedShowsFn(limit, offset, search)
 	}
 	return nil, 0, nil
 }
-func (m *mockShowService) ApproveShow(showID uint, verifyVenues bool) (*contracts.ShowResponse, error) {
+func (m *mockShowAdminService) ApproveShow(showID uint, verifyVenues bool) (*contracts.ShowResponse, error) {
 	if m.approveShowFn != nil {
 		return m.approveShowFn(showID, verifyVenues)
 	}
 	return nil, nil
 }
-func (m *mockShowService) RejectShow(showID uint, reason string) (*contracts.ShowResponse, error) {
+func (m *mockShowAdminService) RejectShow(showID uint, reason string) (*contracts.ShowResponse, error) {
 	if m.rejectShowFn != nil {
 		return m.rejectShowFn(showID, reason)
 	}
 	return nil, nil
 }
-func (m *mockShowService) UnpublishShow(showID uint, userID uint, isAdmin bool) (*contracts.ShowResponse, error) {
-	if m.unpublishShowFn != nil {
-		return m.unpublishShowFn(showID, userID, isAdmin)
-	}
-	return nil, nil
-}
-func (m *mockShowService) MakePrivateShow(showID uint, userID uint, isAdmin bool) (*contracts.ShowResponse, error) {
-	if m.makePrivateShowFn != nil {
-		return m.makePrivateShowFn(showID, userID, isAdmin)
-	}
-	return nil, nil
-}
-func (m *mockShowService) PublishShow(showID uint, userID uint, isAdmin bool) (*contracts.ShowResponse, error) {
-	if m.publishShowFn != nil {
-		return m.publishShowFn(showID, userID, isAdmin)
-	}
-	return nil, nil
-}
-func (m *mockShowService) ExportShowToMarkdown(showID uint) ([]byte, string, error) {
-	if m.exportShowToMarkdownFn != nil {
-		return m.exportShowToMarkdownFn(showID)
-	}
-	return nil, "", nil
-}
-func (m *mockShowService) ParseShowMarkdown(content []byte) (*contracts.ParsedShowImport, error) {
-	if m.parseShowMarkdownFn != nil {
-		return m.parseShowMarkdownFn(content)
-	}
-	return nil, nil
-}
-func (m *mockShowService) PreviewShowImport(content []byte) (*contracts.ImportPreviewResponse, error) {
-	if m.previewShowImportFn != nil {
-		return m.previewShowImportFn(content)
-	}
-	return nil, nil
-}
-func (m *mockShowService) ConfirmShowImport(content []byte, isAdmin bool) (*contracts.ShowResponse, error) {
-	if m.confirmShowImportFn != nil {
-		return m.confirmShowImportFn(content, isAdmin)
-	}
-	return nil, nil
-}
-func (m *mockShowService) GetAdminShows(limit, offset int, filters contracts.AdminShowFilters) ([]*contracts.ShowResponse, int64, error) {
-	if m.getAdminShowsFn != nil {
-		return m.getAdminShowsFn(limit, offset, filters)
-	}
-	return nil, 0, nil
-}
-func (m *mockShowService) SetShowSoldOut(showID uint, isSoldOut bool) (*contracts.ShowResponse, error) {
-	if m.setShowSoldOutFn != nil {
-		return m.setShowSoldOutFn(showID, isSoldOut)
-	}
-	return nil, nil
-}
-func (m *mockShowService) SetShowCancelled(showID uint, isCancelled bool) (*contracts.ShowResponse, error) {
-	if m.setShowCancelledFn != nil {
-		return m.setShowCancelledFn(showID, isCancelled)
-	}
-	return nil, nil
-}
-func (m *mockShowService) BatchApproveShows(showIDs []uint) (*contracts.BatchShowResult, error) {
+func (m *mockShowAdminService) BatchApproveShows(showIDs []uint) (*contracts.BatchShowResult, error) {
 	if m.batchApproveShowsFn != nil {
 		return m.batchApproveShowsFn(showIDs)
 	}
 	return &contracts.BatchShowResult{Succeeded: showIDs, Errors: []contracts.BatchShowError{}}, nil
 }
-func (m *mockShowService) BatchRejectShows(showIDs []uint, reason string, category string) (*contracts.BatchShowResult, error) {
+func (m *mockShowAdminService) BatchRejectShows(showIDs []uint, reason string, category string) (*contracts.BatchShowResult, error) {
 	if m.batchRejectShowsFn != nil {
 		return m.batchRejectShowsFn(showIDs, reason, category)
 	}
 	return &contracts.BatchShowResult{Succeeded: showIDs, Errors: []contracts.BatchShowError{}}, nil
+}
+func (m *mockShowAdminService) GetAdminShows(limit, offset int, filters contracts.AdminShowFilters) ([]*contracts.ShowResponse, int64, error) {
+	if m.getAdminShowsFn != nil {
+		return m.getAdminShowsFn(limit, offset, filters)
+	}
+	return nil, 0, nil
+}
+
+// ============================================================================
+// Mock: ShowImportServiceInterface
+// ============================================================================
+
+type mockShowImportService struct {
+	exportShowToMarkdownFn func(showID uint) ([]byte, string, error)
+	parseShowMarkdownFn    func(content []byte) (*contracts.ParsedShowImport, error)
+	previewShowImportFn    func(content []byte) (*contracts.ImportPreviewResponse, error)
+	confirmShowImportFn    func(content []byte, isAdmin bool) (*contracts.ShowResponse, error)
+}
+
+func (m *mockShowImportService) ExportShowToMarkdown(showID uint) ([]byte, string, error) {
+	if m.exportShowToMarkdownFn != nil {
+		return m.exportShowToMarkdownFn(showID)
+	}
+	return nil, "", nil
+}
+func (m *mockShowImportService) ParseShowMarkdown(content []byte) (*contracts.ParsedShowImport, error) {
+	if m.parseShowMarkdownFn != nil {
+		return m.parseShowMarkdownFn(content)
+	}
+	return nil, nil
+}
+func (m *mockShowImportService) PreviewShowImport(content []byte) (*contracts.ImportPreviewResponse, error) {
+	if m.previewShowImportFn != nil {
+		return m.previewShowImportFn(content)
+	}
+	return nil, nil
+}
+func (m *mockShowImportService) ConfirmShowImport(content []byte, isAdmin bool) (*contracts.ShowResponse, error) {
+	if m.confirmShowImportFn != nil {
+		return m.confirmShowImportFn(content, isAdmin)
+	}
+	return nil, nil
+}
+
+// ============================================================================
+// Mock: ShowStateServiceInterface
+// ============================================================================
+
+type mockShowStateService struct {
+	unpublishShowFn    func(showID uint, userID uint, isAdmin bool) (*contracts.ShowResponse, error)
+	makePrivateShowFn  func(showID uint, userID uint, isAdmin bool) (*contracts.ShowResponse, error)
+	publishShowFn      func(showID uint, userID uint, isAdmin bool) (*contracts.ShowResponse, error)
+	setShowSoldOutFn   func(showID uint, isSoldOut bool) (*contracts.ShowResponse, error)
+	setShowCancelledFn func(showID uint, isCancelled bool) (*contracts.ShowResponse, error)
+}
+
+func (m *mockShowStateService) UnpublishShow(showID uint, userID uint, isAdmin bool) (*contracts.ShowResponse, error) {
+	if m.unpublishShowFn != nil {
+		return m.unpublishShowFn(showID, userID, isAdmin)
+	}
+	return nil, nil
+}
+func (m *mockShowStateService) MakePrivateShow(showID uint, userID uint, isAdmin bool) (*contracts.ShowResponse, error) {
+	if m.makePrivateShowFn != nil {
+		return m.makePrivateShowFn(showID, userID, isAdmin)
+	}
+	return nil, nil
+}
+func (m *mockShowStateService) PublishShow(showID uint, userID uint, isAdmin bool) (*contracts.ShowResponse, error) {
+	if m.publishShowFn != nil {
+		return m.publishShowFn(showID, userID, isAdmin)
+	}
+	return nil, nil
+}
+func (m *mockShowStateService) SetShowSoldOut(showID uint, isSoldOut bool) (*contracts.ShowResponse, error) {
+	if m.setShowSoldOutFn != nil {
+		return m.setShowSoldOutFn(showID, isSoldOut)
+	}
+	return nil, nil
+}
+func (m *mockShowStateService) SetShowCancelled(showID uint, isCancelled bool) (*contracts.ShowResponse, error) {
+	if m.setShowCancelledFn != nil {
+		return m.setShowCancelledFn(showID, isCancelled)
+	}
+	return nil, nil
 }
 
 // ============================================================================
@@ -1570,6 +1594,9 @@ var _ contracts.ArtistReportServiceInterface = (*mockArtistReportService)(nil)
 var _ contracts.DiscordServiceInterface = (*mockDiscordService)(nil)
 var _ contracts.UserServiceInterface = (*mockUserService)(nil)
 var _ contracts.ShowServiceInterface = (*mockShowService)(nil)
+var _ contracts.ShowAdminServiceInterface = (*mockShowAdminService)(nil)
+var _ contracts.ShowImportServiceInterface = (*mockShowImportService)(nil)
+var _ contracts.ShowStateServiceInterface = (*mockShowStateService)(nil)
 var _ contracts.VenueServiceInterface = (*mockVenueService)(nil)
 var _ contracts.ArtistServiceInterface = (*mockArtistService)(nil)
 var _ contracts.MusicDiscoveryServiceInterface = (*mockMusicDiscoveryService)(nil)

--- a/backend/internal/api/handlers/show.go
+++ b/backend/internal/api/handlers/show.go
@@ -19,7 +19,9 @@ import (
 
 // ShowHandler handles show-related HTTP requests
 type ShowHandler struct {
-	showService           contracts.ShowServiceInterface
+	showService      contracts.ShowServiceInterface
+	showStateService contracts.ShowStateServiceInterface
+	showImportService contracts.ShowImportServiceInterface
 	savedShowService      contracts.SavedShowServiceInterface
 	discordService        contracts.DiscordServiceInterface
 	musicDiscoveryService contracts.MusicDiscoveryServiceInterface
@@ -29,6 +31,8 @@ type ShowHandler struct {
 // NewShowHandler creates a new show handler
 func NewShowHandler(
 	showService contracts.ShowServiceInterface,
+	showStateService contracts.ShowStateServiceInterface,
+	showImportService contracts.ShowImportServiceInterface,
 	savedShowService contracts.SavedShowServiceInterface,
 	discordService contracts.DiscordServiceInterface,
 	musicDiscoveryService contracts.MusicDiscoveryServiceInterface,
@@ -36,6 +40,8 @@ func NewShowHandler(
 ) *ShowHandler {
 	return &ShowHandler{
 		showService:           showService,
+		showStateService:      showStateService,
+		showImportService:     showImportService,
 		savedShowService:      savedShowService,
 		discordService:        discordService,
 		musicDiscoveryService: musicDiscoveryService,
@@ -1016,7 +1022,7 @@ func (h *ShowHandler) UnpublishShowHandler(ctx context.Context, req *UnpublishSh
 	)
 
 	// Unpublish show using service (service handles authorization check)
-	show, err := h.showService.UnpublishShow(uint(showID), user.ID, user.IsAdmin)
+	show, err := h.showStateService.UnpublishShow(uint(showID), user.ID, user.IsAdmin)
 	if err != nil {
 		logger.FromContext(ctx).Warn("show_unpublish_failed",
 			"show_id", showID,
@@ -1101,7 +1107,7 @@ func (h *ShowHandler) MakePrivateShowHandler(ctx context.Context, req *MakePriva
 	)
 
 	// Make show private using service (service handles authorization check)
-	show, err := h.showService.MakePrivateShow(uint(showID), user.ID, user.IsAdmin)
+	show, err := h.showStateService.MakePrivateShow(uint(showID), user.ID, user.IsAdmin)
 	if err != nil {
 		logger.FromContext(ctx).Warn("show_make_private_failed",
 			"show_id", showID,
@@ -1188,7 +1194,7 @@ func (h *ShowHandler) PublishShowHandler(ctx context.Context, req *PublishShowRe
 	)
 
 	// Publish show using service (service handles authorization check)
-	show, err := h.showService.PublishShow(uint(showID), user.ID, user.IsAdmin)
+	show, err := h.showStateService.PublishShow(uint(showID), user.ID, user.IsAdmin)
 	if err != nil {
 		logger.FromContext(ctx).Warn("show_publish_failed",
 			"show_id", showID,
@@ -1330,7 +1336,7 @@ func (h *ShowHandler) ExportShowHandler(ctx context.Context, req *ExportShowRequ
 	)
 
 	// Export show to markdown
-	content, filename, err := h.showService.ExportShowToMarkdown(uint(showID))
+	content, filename, err := h.showImportService.ExportShowToMarkdown(uint(showID))
 	if err != nil {
 		logger.FromContext(ctx).Error("show_export_failed",
 			"show_id", showID,
@@ -1441,7 +1447,7 @@ func (h *ShowHandler) SetShowSoldOutHandler(ctx context.Context, req *SetShowSol
 	)
 
 	// Set sold out status
-	updatedShow, err := h.showService.SetShowSoldOut(uint(showID), req.Body.Value)
+	updatedShow, err := h.showStateService.SetShowSoldOut(uint(showID), req.Body.Value)
 	if err != nil {
 		logger.FromContext(ctx).Error("set_show_sold_out_failed",
 			"show_id", showID,
@@ -1524,7 +1530,7 @@ func (h *ShowHandler) SetShowCancelledHandler(ctx context.Context, req *SetShowC
 	)
 
 	// Set cancelled status
-	updatedShow, err := h.showService.SetShowCancelled(uint(showID), req.Body.Value)
+	updatedShow, err := h.showStateService.SetShowCancelled(uint(showID), req.Body.Value)
 	if err != nil {
 		logger.FromContext(ctx).Error("set_show_cancelled_failed",
 			"show_id", showID,

--- a/backend/internal/api/handlers/show_integration_test.go
+++ b/backend/internal/api/handlers/show_integration_test.go
@@ -21,6 +21,8 @@ func (s *ShowHandlerIntegrationSuite) SetupSuite() {
 	s.deps = setupHandlerIntegrationDeps(s.T())
 	s.handler = NewShowHandler(
 		s.deps.showService,
+		s.deps.showService,
+		s.deps.showService,
 		s.deps.savedShowService,
 		s.deps.discordService,
 		s.deps.musicDiscoveryService,

--- a/backend/internal/api/handlers/show_test.go
+++ b/backend/internal/api/handlers/show_test.go
@@ -31,7 +31,7 @@ func assertHumaError(t *testing.T, err error, expectedStatus int) {
 }
 
 func testShowHandler() *ShowHandler {
-	return NewShowHandler(nil, nil, nil, nil, nil)
+	return NewShowHandler(nil, nil, nil, nil, nil, nil, nil)
 }
 
 // --- NewShowHandler ---
@@ -273,7 +273,7 @@ func TestGetShowHandler_ByID(t *testing.T) {
 			return &contracts.ShowResponse{ID: showID, Status: "approved"}, nil
 		},
 	}
-	h := NewShowHandler(mock, nil, nil, nil, nil)
+	h := NewShowHandler(mock, nil, nil, nil, nil, nil, nil)
 
 	resp, err := h.GetShowHandler(context.Background(), &GetShowRequest{ShowID: "42"})
 	if err != nil {
@@ -290,7 +290,7 @@ func TestGetShowHandler_BySlug(t *testing.T) {
 			return &contracts.ShowResponse{ID: 10, Slug: slug, Status: "approved"}, nil
 		},
 	}
-	h := NewShowHandler(mock, nil, nil, nil, nil)
+	h := NewShowHandler(mock, nil, nil, nil, nil, nil, nil)
 
 	resp, err := h.GetShowHandler(context.Background(), &GetShowRequest{ShowID: "cool-show"})
 	if err != nil {
@@ -307,7 +307,7 @@ func TestGetShowHandler_NotFound(t *testing.T) {
 			return nil, fmt.Errorf("not found")
 		},
 	}
-	h := NewShowHandler(mock, nil, nil, nil, nil)
+	h := NewShowHandler(mock, nil, nil, nil, nil, nil, nil)
 
 	_, err := h.GetShowHandler(context.Background(), &GetShowRequest{ShowID: "99"})
 	assertHumaError(t, err, 404)
@@ -319,7 +319,7 @@ func TestGetShowHandler_NonApproved_Admin(t *testing.T) {
 			return &contracts.ShowResponse{ID: 1, Status: "pending"}, nil
 		},
 	}
-	h := NewShowHandler(mock, nil, nil, nil, nil)
+	h := NewShowHandler(mock, nil, nil, nil, nil, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
 
 	resp, err := h.GetShowHandler(ctx, &GetShowRequest{ShowID: "1"})
@@ -338,7 +338,7 @@ func TestGetShowHandler_NonApproved_Submitter(t *testing.T) {
 			return &contracts.ShowResponse{ID: 1, Status: "pending", SubmittedBy: &userID}, nil
 		},
 	}
-	h := NewShowHandler(mock, nil, nil, nil, nil)
+	h := NewShowHandler(mock, nil, nil, nil, nil, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 5})
 
 	resp, err := h.GetShowHandler(ctx, &GetShowRequest{ShowID: "1"})
@@ -357,7 +357,7 @@ func TestGetShowHandler_NonApproved_Denied(t *testing.T) {
 			return &contracts.ShowResponse{ID: 1, Status: "pending", SubmittedBy: &otherUser}, nil
 		},
 	}
-	h := NewShowHandler(mock, nil, nil, nil, nil)
+	h := NewShowHandler(mock, nil, nil, nil, nil, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 5})
 
 	_, err := h.GetShowHandler(ctx, &GetShowRequest{ShowID: "1"})
@@ -374,7 +374,7 @@ func TestGetShowsHandler_Success(t *testing.T) {
 			return []*contracts.ShowResponse{{ID: 1}, {ID: 2}}, nil
 		},
 	}
-	h := NewShowHandler(mock, nil, nil, nil, nil)
+	h := NewShowHandler(mock, nil, nil, nil, nil, nil, nil)
 
 	resp, err := h.GetShowsHandler(context.Background(), &GetShowsRequest{})
 	if err != nil {
@@ -391,7 +391,7 @@ func TestGetShowsHandler_ServiceError(t *testing.T) {
 			return nil, fmt.Errorf("db error")
 		},
 	}
-	h := NewShowHandler(mock, nil, nil, nil, nil)
+	h := NewShowHandler(mock, nil, nil, nil, nil, nil, nil)
 
 	_, err := h.GetShowsHandler(context.Background(), &GetShowsRequest{})
 	assertHumaError(t, err, 500)
@@ -407,7 +407,7 @@ func TestGetShowCitiesHandler_Success(t *testing.T) {
 			return []contracts.ShowCityResponse{{City: "Phoenix", State: "AZ", ShowCount: 5}}, nil
 		},
 	}
-	h := NewShowHandler(mock, nil, nil, nil, nil)
+	h := NewShowHandler(mock, nil, nil, nil, nil, nil, nil)
 
 	resp, err := h.GetShowCitiesHandler(context.Background(), &GetShowCitiesRequest{Timezone: "America/Phoenix"})
 	if err != nil {
@@ -424,7 +424,7 @@ func TestGetShowCitiesHandler_ServiceError(t *testing.T) {
 			return nil, fmt.Errorf("db error")
 		},
 	}
-	h := NewShowHandler(mock, nil, nil, nil, nil)
+	h := NewShowHandler(mock, nil, nil, nil, nil, nil, nil)
 
 	_, err := h.GetShowCitiesHandler(context.Background(), &GetShowCitiesRequest{})
 	assertHumaError(t, err, 500)
@@ -441,7 +441,7 @@ func TestGetUpcomingShowsHandler_Success(t *testing.T) {
 			return []*contracts.ShowResponse{{ID: 1}}, &nextCursor, nil
 		},
 	}
-	h := NewShowHandler(mock, nil, nil, nil, nil)
+	h := NewShowHandler(mock, nil, nil, nil, nil, nil, nil)
 
 	resp, err := h.GetUpcomingShowsHandler(context.Background(), &GetUpcomingShowsRequest{Limit: 50})
 	if err != nil {
@@ -461,7 +461,7 @@ func TestGetUpcomingShowsHandler_ServiceError(t *testing.T) {
 			return nil, nil, fmt.Errorf("db error")
 		},
 	}
-	h := NewShowHandler(mock, nil, nil, nil, nil)
+	h := NewShowHandler(mock, nil, nil, nil, nil, nil, nil)
 
 	_, err := h.GetUpcomingShowsHandler(context.Background(), &GetUpcomingShowsRequest{Limit: 50})
 	assertHumaError(t, err, 500)
@@ -477,7 +477,7 @@ func TestCreateShowHandler_Success(t *testing.T) {
 			return &contracts.ShowResponse{ID: 100, Title: req.Title, Status: "pending"}, nil
 		},
 	}
-	h := NewShowHandler(showMock, &mockSavedShowService{}, &mockDiscordService{}, &mockMusicDiscoveryService{}, nil)
+	h := NewShowHandler(showMock, nil, nil, &mockSavedShowService{}, &mockDiscordService{}, &mockMusicDiscoveryService{}, nil)
 	ctx := ctxWithUser(&models.User{ID: 1, EmailVerified: true})
 
 	venueID := uint(1)
@@ -512,7 +512,7 @@ func TestCreateShowHandler_AutoSave(t *testing.T) {
 			return nil
 		},
 	}
-	h := NewShowHandler(showMock, savedShowMock, &mockDiscordService{}, &mockMusicDiscoveryService{}, nil)
+	h := NewShowHandler(showMock, nil, nil, savedShowMock, &mockDiscordService{}, &mockMusicDiscoveryService{}, nil)
 	ctx := ctxWithUser(&models.User{ID: 7, EmailVerified: true})
 
 	venueID := uint(1)
@@ -542,7 +542,7 @@ func TestCreateShowHandler_ServiceError(t *testing.T) {
 			return nil, fmt.Errorf("db error")
 		},
 	}
-	h := NewShowHandler(showMock, nil, &mockDiscordService{}, &mockMusicDiscoveryService{}, nil)
+	h := NewShowHandler(showMock, nil, nil, nil, &mockDiscordService{}, &mockMusicDiscoveryService{}, nil)
 	ctx := ctxWithUser(&models.User{ID: 1, EmailVerified: true})
 
 	venueID := uint(1)
@@ -572,7 +572,7 @@ func TestUpdateShowHandler_OwnerSuccess(t *testing.T) {
 			return &contracts.ShowResponse{ID: showID, Title: "Updated"}, nil, nil
 		},
 	}
-	h := NewShowHandler(showMock, nil, nil, nil, nil)
+	h := NewShowHandler(showMock, nil, nil, nil, nil, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 5})
 	title := "Updated"
 	req := &UpdateShowRequest{ShowID: "1"}
@@ -597,7 +597,7 @@ func TestUpdateShowHandler_AdminSuccess(t *testing.T) {
 			return &contracts.ShowResponse{ID: showID}, nil, nil
 		},
 	}
-	h := NewShowHandler(showMock, nil, nil, nil, nil)
+	h := NewShowHandler(showMock, nil, nil, nil, nil, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
 	title := "Admin Update"
 	req := &UpdateShowRequest{ShowID: "1"}
@@ -615,7 +615,7 @@ func TestUpdateShowHandler_NotFound(t *testing.T) {
 			return nil, fmt.Errorf("not found")
 		},
 	}
-	h := NewShowHandler(showMock, nil, nil, nil, nil)
+	h := NewShowHandler(showMock, nil, nil, nil, nil, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1})
 
 	_, err := h.UpdateShowHandler(ctx, &UpdateShowRequest{ShowID: "99"})
@@ -629,7 +629,7 @@ func TestUpdateShowHandler_Unauthorized(t *testing.T) {
 			return &contracts.ShowResponse{ID: 1, SubmittedBy: &otherUser}, nil
 		},
 	}
-	h := NewShowHandler(showMock, nil, nil, nil, nil)
+	h := NewShowHandler(showMock, nil, nil, nil, nil, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 5})
 
 	_, err := h.UpdateShowHandler(ctx, &UpdateShowRequest{ShowID: "1"})
@@ -646,7 +646,7 @@ func TestUpdateShowHandler_ServiceError(t *testing.T) {
 			return nil, nil, fmt.Errorf("update failed")
 		},
 	}
-	h := NewShowHandler(showMock, nil, nil, nil, nil)
+	h := NewShowHandler(showMock, nil, nil, nil, nil, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1})
 	title := "New"
 	req := &UpdateShowRequest{ShowID: "1"}
@@ -673,7 +673,7 @@ func TestDeleteShowHandler_OwnerSuccess(t *testing.T) {
 			return nil
 		},
 	}
-	h := NewShowHandler(showMock, nil, nil, nil, nil)
+	h := NewShowHandler(showMock, nil, nil, nil, nil, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 5})
 
 	_, err := h.DeleteShowHandler(ctx, &DeleteShowRequest{ShowID: "1"})
@@ -690,7 +690,7 @@ func TestDeleteShowHandler_AdminSuccess(t *testing.T) {
 		},
 		deleteShowFn: func(_ uint) error { return nil },
 	}
-	h := NewShowHandler(showMock, nil, nil, nil, nil)
+	h := NewShowHandler(showMock, nil, nil, nil, nil, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
 
 	_, err := h.DeleteShowHandler(ctx, &DeleteShowRequest{ShowID: "1"})
@@ -705,7 +705,7 @@ func TestDeleteShowHandler_NotFound(t *testing.T) {
 			return nil, fmt.Errorf("not found")
 		},
 	}
-	h := NewShowHandler(showMock, nil, nil, nil, nil)
+	h := NewShowHandler(showMock, nil, nil, nil, nil, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1})
 
 	_, err := h.DeleteShowHandler(ctx, &DeleteShowRequest{ShowID: "99"})
@@ -719,7 +719,7 @@ func TestDeleteShowHandler_Unauthorized(t *testing.T) {
 			return &contracts.ShowResponse{ID: 1, SubmittedBy: &otherUser}, nil
 		},
 	}
-	h := NewShowHandler(showMock, nil, nil, nil, nil)
+	h := NewShowHandler(showMock, nil, nil, nil, nil, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 5})
 
 	_, err := h.DeleteShowHandler(ctx, &DeleteShowRequest{ShowID: "1"})
@@ -734,7 +734,7 @@ func TestDeleteShowHandler_ServiceError(t *testing.T) {
 		},
 		deleteShowFn: func(_ uint) error { return fmt.Errorf("delete failed") },
 	}
-	h := NewShowHandler(showMock, nil, nil, nil, nil)
+	h := NewShowHandler(showMock, nil, nil, nil, nil, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1})
 
 	_, err := h.DeleteShowHandler(ctx, &DeleteShowRequest{ShowID: "1"})
@@ -746,12 +746,12 @@ func TestDeleteShowHandler_ServiceError(t *testing.T) {
 // ============================================================================
 
 func TestUnpublishShowHandler_Success(t *testing.T) {
-	showMock := &mockShowService{
+	stateMock := &mockShowStateService{
 		unpublishShowFn: func(showID, userID uint, isAdmin bool) (*contracts.ShowResponse, error) {
 			return &contracts.ShowResponse{ID: showID, Status: "pending", Title: "Test"}, nil
 		},
 	}
-	h := NewShowHandler(showMock, nil, &mockDiscordService{}, nil, nil)
+	h := NewShowHandler(nil, stateMock, nil, nil, &mockDiscordService{}, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1})
 
 	resp, err := h.UnpublishShowHandler(ctx, &UnpublishShowRequest{ShowID: "42"})
@@ -764,12 +764,12 @@ func TestUnpublishShowHandler_Success(t *testing.T) {
 }
 
 func TestUnpublishShowHandler_NotFound(t *testing.T) {
-	showMock := &mockShowService{
+	stateMock := &mockShowStateService{
 		unpublishShowFn: func(_, _ uint, _ bool) (*contracts.ShowResponse, error) {
 			return nil, apperrors.ErrShowNotFound(42)
 		},
 	}
-	h := NewShowHandler(showMock, nil, &mockDiscordService{}, nil, nil)
+	h := NewShowHandler(nil, stateMock, nil, nil, &mockDiscordService{}, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1})
 
 	_, err := h.UnpublishShowHandler(ctx, &UnpublishShowRequest{ShowID: "42"})
@@ -777,12 +777,12 @@ func TestUnpublishShowHandler_NotFound(t *testing.T) {
 }
 
 func TestUnpublishShowHandler_Unauthorized(t *testing.T) {
-	showMock := &mockShowService{
+	stateMock := &mockShowStateService{
 		unpublishShowFn: func(_, _ uint, _ bool) (*contracts.ShowResponse, error) {
 			return nil, apperrors.ErrShowUnpublishUnauthorized(42)
 		},
 	}
-	h := NewShowHandler(showMock, nil, &mockDiscordService{}, nil, nil)
+	h := NewShowHandler(nil, stateMock, nil, nil, &mockDiscordService{}, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 5})
 
 	_, err := h.UnpublishShowHandler(ctx, &UnpublishShowRequest{ShowID: "42"})
@@ -794,12 +794,12 @@ func TestUnpublishShowHandler_Unauthorized(t *testing.T) {
 // ============================================================================
 
 func TestMakePrivateShowHandler_Success(t *testing.T) {
-	showMock := &mockShowService{
+	stateMock := &mockShowStateService{
 		makePrivateShowFn: func(showID, userID uint, isAdmin bool) (*contracts.ShowResponse, error) {
 			return &contracts.ShowResponse{ID: showID, Status: "private", Title: "Test"}, nil
 		},
 	}
-	h := NewShowHandler(showMock, nil, &mockDiscordService{}, nil, nil)
+	h := NewShowHandler(nil, stateMock, nil, nil, &mockDiscordService{}, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1})
 
 	resp, err := h.MakePrivateShowHandler(ctx, &MakePrivateShowRequest{ShowID: "42"})
@@ -812,12 +812,12 @@ func TestMakePrivateShowHandler_Success(t *testing.T) {
 }
 
 func TestMakePrivateShowHandler_NotFound(t *testing.T) {
-	showMock := &mockShowService{
+	stateMock := &mockShowStateService{
 		makePrivateShowFn: func(_, _ uint, _ bool) (*contracts.ShowResponse, error) {
 			return nil, apperrors.ErrShowNotFound(42)
 		},
 	}
-	h := NewShowHandler(showMock, nil, &mockDiscordService{}, nil, nil)
+	h := NewShowHandler(nil, stateMock, nil, nil, &mockDiscordService{}, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1})
 
 	_, err := h.MakePrivateShowHandler(ctx, &MakePrivateShowRequest{ShowID: "42"})
@@ -825,12 +825,12 @@ func TestMakePrivateShowHandler_NotFound(t *testing.T) {
 }
 
 func TestMakePrivateShowHandler_Unauthorized(t *testing.T) {
-	showMock := &mockShowService{
+	stateMock := &mockShowStateService{
 		makePrivateShowFn: func(_, _ uint, _ bool) (*contracts.ShowResponse, error) {
 			return nil, apperrors.ErrShowMakePrivateUnauthorized(42)
 		},
 	}
-	h := NewShowHandler(showMock, nil, &mockDiscordService{}, nil, nil)
+	h := NewShowHandler(nil, stateMock, nil, nil, &mockDiscordService{}, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 5})
 
 	_, err := h.MakePrivateShowHandler(ctx, &MakePrivateShowRequest{ShowID: "42"})
@@ -842,12 +842,12 @@ func TestMakePrivateShowHandler_Unauthorized(t *testing.T) {
 // ============================================================================
 
 func TestPublishShowHandler_Success(t *testing.T) {
-	showMock := &mockShowService{
+	stateMock := &mockShowStateService{
 		publishShowFn: func(showID, userID uint, isAdmin bool) (*contracts.ShowResponse, error) {
 			return &contracts.ShowResponse{ID: showID, Status: "approved", Title: "Test"}, nil
 		},
 	}
-	h := NewShowHandler(showMock, nil, &mockDiscordService{}, nil, nil)
+	h := NewShowHandler(nil, stateMock, nil, nil, &mockDiscordService{}, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1})
 
 	resp, err := h.PublishShowHandler(ctx, &PublishShowRequest{ShowID: "42"})
@@ -860,12 +860,12 @@ func TestPublishShowHandler_Success(t *testing.T) {
 }
 
 func TestPublishShowHandler_NotFound(t *testing.T) {
-	showMock := &mockShowService{
+	stateMock := &mockShowStateService{
 		publishShowFn: func(_, _ uint, _ bool) (*contracts.ShowResponse, error) {
 			return nil, apperrors.ErrShowNotFound(42)
 		},
 	}
-	h := NewShowHandler(showMock, nil, &mockDiscordService{}, nil, nil)
+	h := NewShowHandler(nil, stateMock, nil, nil, &mockDiscordService{}, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1})
 
 	_, err := h.PublishShowHandler(ctx, &PublishShowRequest{ShowID: "42"})
@@ -873,12 +873,12 @@ func TestPublishShowHandler_NotFound(t *testing.T) {
 }
 
 func TestPublishShowHandler_Unauthorized(t *testing.T) {
-	showMock := &mockShowService{
+	stateMock := &mockShowStateService{
 		publishShowFn: func(_, _ uint, _ bool) (*contracts.ShowResponse, error) {
 			return nil, apperrors.ErrShowPublishUnauthorized(42)
 		},
 	}
-	h := NewShowHandler(showMock, nil, &mockDiscordService{}, nil, nil)
+	h := NewShowHandler(nil, stateMock, nil, nil, &mockDiscordService{}, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 5})
 
 	_, err := h.PublishShowHandler(ctx, &PublishShowRequest{ShowID: "42"})
@@ -895,11 +895,13 @@ func TestSetShowSoldOutHandler_Success(t *testing.T) {
 		getShowFn: func(_ uint) (*contracts.ShowResponse, error) {
 			return &contracts.ShowResponse{ID: 1, SubmittedBy: &userID}, nil
 		},
+	}
+	stateMock := &mockShowStateService{
 		setShowSoldOutFn: func(showID uint, value bool) (*contracts.ShowResponse, error) {
 			return &contracts.ShowResponse{ID: showID, IsSoldOut: value}, nil
 		},
 	}
-	h := NewShowHandler(showMock, nil, nil, nil, nil)
+	h := NewShowHandler(showMock, stateMock, nil, nil, nil, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 5})
 	req := &SetShowSoldOutRequest{ShowID: "1"}
 	req.Body.Value = true
@@ -920,7 +922,7 @@ func TestSetShowSoldOutHandler_NotOwner(t *testing.T) {
 			return &contracts.ShowResponse{ID: 1, SubmittedBy: &otherUser}, nil
 		},
 	}
-	h := NewShowHandler(showMock, nil, nil, nil, nil)
+	h := NewShowHandler(showMock, nil, nil, nil, nil, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 5})
 	req := &SetShowSoldOutRequest{ShowID: "1"}
 	req.Body.Value = true
@@ -939,11 +941,13 @@ func TestSetShowCancelledHandler_Success(t *testing.T) {
 		getShowFn: func(_ uint) (*contracts.ShowResponse, error) {
 			return &contracts.ShowResponse{ID: 1, SubmittedBy: &userID}, nil
 		},
+	}
+	stateMock := &mockShowStateService{
 		setShowCancelledFn: func(showID uint, value bool) (*contracts.ShowResponse, error) {
 			return &contracts.ShowResponse{ID: showID, IsCancelled: value}, nil
 		},
 	}
-	h := NewShowHandler(showMock, nil, nil, nil, nil)
+	h := NewShowHandler(showMock, stateMock, nil, nil, nil, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 5})
 	req := &SetShowCancelledRequest{ShowID: "1"}
 	req.Body.Value = true
@@ -964,7 +968,7 @@ func TestSetShowCancelledHandler_NotOwner(t *testing.T) {
 			return &contracts.ShowResponse{ID: 1, SubmittedBy: &otherUser}, nil
 		},
 	}
-	h := NewShowHandler(showMock, nil, nil, nil, nil)
+	h := NewShowHandler(showMock, nil, nil, nil, nil, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 5})
 	req := &SetShowCancelledRequest{ShowID: "1"}
 	req.Body.Value = true
@@ -983,7 +987,7 @@ func TestGetMySubmissionsHandler_Success(t *testing.T) {
 			return []contracts.ShowResponse{{ID: 1}, {ID: 2}}, 2, nil
 		},
 	}
-	h := NewShowHandler(showMock, nil, nil, nil, nil)
+	h := NewShowHandler(showMock, nil, nil, nil, nil, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1})
 
 	resp, err := h.GetMySubmissionsHandler(ctx, &GetMySubmissionsRequest{Limit: 50})
@@ -1001,7 +1005,7 @@ func TestGetMySubmissionsHandler_ServiceError(t *testing.T) {
 			return nil, 0, fmt.Errorf("db error")
 		},
 	}
-	h := NewShowHandler(showMock, nil, nil, nil, nil)
+	h := NewShowHandler(showMock, nil, nil, nil, nil, nil, nil)
 	ctx := ctxWithUser(&models.User{ID: 1})
 
 	_, err := h.GetMySubmissionsHandler(ctx, &GetMySubmissionsRequest{Limit: 50})
@@ -1018,7 +1022,7 @@ func TestAIProcessShowHandler_Success(t *testing.T) {
 			return &contracts.ExtractShowResponse{Success: true}, nil
 		},
 	}
-	h := NewShowHandler(nil, nil, nil, nil, extractMock)
+	h := NewShowHandler(nil, nil, nil, nil, nil, nil, extractMock)
 
 	req := &AIProcessShowRequest{}
 	req.Body.Type = "text"
@@ -1039,7 +1043,7 @@ func TestAIProcessShowHandler_ServiceError(t *testing.T) {
 			return nil, fmt.Errorf("AI service down")
 		},
 	}
-	h := NewShowHandler(nil, nil, nil, nil, extractMock)
+	h := NewShowHandler(nil, nil, nil, nil, nil, nil, extractMock)
 
 	req := &AIProcessShowRequest{}
 	req.Body.Type = "text"

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -220,7 +220,7 @@ func setupPasskeyRoutes(router *chi.Mux, api huma.API, protected *huma.Group, sc
 
 // setupShowRoutes configures all show-related endpoints
 func setupShowRoutes(router *chi.Mux, api huma.API, protected *huma.Group, sc *services.ServiceContainer, cfg *config.Config) {
-	showHandler := handlers.NewShowHandler(sc.Show, sc.SavedShow, sc.Discord, sc.MusicDiscovery, sc.Extraction)
+	showHandler := handlers.NewShowHandler(sc.Show, sc.Show, sc.Show, sc.SavedShow, sc.Discord, sc.MusicDiscovery, sc.Extraction)
 
 	// Public show endpoints - registered on main API without middleware
 	// Note: Static routes must come before parameterized routes
@@ -489,7 +489,7 @@ func setupAdminRoutes(protected *huma.Group, sc *services.ServiceContainer) {
 	// Domain-specific admin handlers
 	statsHandler := handlers.NewAdminStatsHandler(sc.AdminStats)
 	showHandler := handlers.NewAdminShowHandler(
-		sc.Show, sc.Discord, sc.AuditLog, sc.NotificationFilter,
+		sc.Show, sc.Show, sc.Show, sc.Discord, sc.AuditLog, sc.NotificationFilter,
 		sc.MusicDiscovery,
 	)
 	venueHandler := handlers.NewAdminVenueHandler(sc.Venue, sc.AuditLog)

--- a/backend/internal/services/contracts/interfaces.go
+++ b/backend/internal/services/contracts/interfaces.go
@@ -13,7 +13,7 @@ import (
 	"psychic-homily-backend/internal/models"
 )
 
-// ShowServiceInterface defines the contract for show operations.
+// ShowServiceInterface defines the contract for core show CRUD and search operations.
 type ShowServiceInterface interface {
 	CreateShow(req *CreateShowRequest) (*ShowResponse, error)
 	GetShow(showID uint) (*ShowResponse, error)
@@ -25,22 +25,46 @@ type ShowServiceInterface interface {
 	GetUpcomingShows(timezone string, cursor string, limit int, includeNonApproved bool, filters *UpcomingShowsFilter) ([]*ShowResponse, *string, error)
 	GetShowCities(timezone string) ([]ShowCityResponse, error)
 	DeleteShow(showID uint) error
+}
+
+// ShowAdminServiceInterface defines the contract for admin show management operations
+// including pending/rejected queries, approval flows, and batch operations.
+type ShowAdminServiceInterface interface {
 	GetPendingShows(limit, offset int, filters *PendingShowsFilter) ([]*ShowResponse, int64, error)
 	GetRejectedShows(limit, offset int, search string) ([]*ShowResponse, int64, error)
 	ApproveShow(showID uint, verifyVenues bool) (*ShowResponse, error)
 	RejectShow(showID uint, reason string) (*ShowResponse, error)
 	BatchApproveShows(showIDs []uint) (*BatchShowResult, error)
 	BatchRejectShows(showIDs []uint, reason string, category string) (*BatchShowResult, error)
-	UnpublishShow(showID uint, userID uint, isAdmin bool) (*ShowResponse, error)
-	MakePrivateShow(showID uint, userID uint, isAdmin bool) (*ShowResponse, error)
-	PublishShow(showID uint, userID uint, isAdmin bool) (*ShowResponse, error)
+	GetAdminShows(limit, offset int, filters AdminShowFilters) ([]*ShowResponse, int64, error)
+}
+
+// ShowImportServiceInterface defines the contract for show import/export operations.
+type ShowImportServiceInterface interface {
 	ExportShowToMarkdown(showID uint) ([]byte, string, error)
 	ParseShowMarkdown(content []byte) (*ParsedShowImport, error)
 	PreviewShowImport(content []byte) (*ImportPreviewResponse, error)
 	ConfirmShowImport(content []byte, isAdmin bool) (*ShowResponse, error)
-	GetAdminShows(limit, offset int, filters AdminShowFilters) ([]*ShowResponse, int64, error)
+}
+
+// ShowStateServiceInterface defines the contract for show state mutation operations
+// such as publishing, unpublishing, and setting sold-out/cancelled flags.
+type ShowStateServiceInterface interface {
+	UnpublishShow(showID uint, userID uint, isAdmin bool) (*ShowResponse, error)
+	MakePrivateShow(showID uint, userID uint, isAdmin bool) (*ShowResponse, error)
+	PublishShow(showID uint, userID uint, isAdmin bool) (*ShowResponse, error)
 	SetShowSoldOut(showID uint, isSoldOut bool) (*ShowResponse, error)
 	SetShowCancelled(showID uint, isCancelled bool) (*ShowResponse, error)
+}
+
+// ShowFullServiceInterface is the composite interface that embeds all show service
+// concerns. The concrete ShowService satisfies this. Useful for the service container
+// and backward compatibility where a single reference to all methods is needed.
+type ShowFullServiceInterface interface {
+	ShowServiceInterface
+	ShowAdminServiceInterface
+	ShowImportServiceInterface
+	ShowStateServiceInterface
 }
 
 // VenueServiceInterface defines the contract for venue operations.

--- a/backend/internal/services/interfaces.go
+++ b/backend/internal/services/interfaces.go
@@ -16,6 +16,10 @@ import (
 // Admin services:      internal/services/admin/interfaces.go
 var (
 	_ contracts.ShowServiceInterface                = (*catalog.ShowService)(nil)
+	_ contracts.ShowAdminServiceInterface           = (*catalog.ShowService)(nil)
+	_ contracts.ShowImportServiceInterface          = (*catalog.ShowService)(nil)
+	_ contracts.ShowStateServiceInterface           = (*catalog.ShowService)(nil)
+	_ contracts.ShowFullServiceInterface            = (*catalog.ShowService)(nil)
 	_ contracts.VenueServiceInterface               = (*catalog.VenueService)(nil)
 	_ contracts.ArtistServiceInterface              = (*catalog.ArtistService)(nil)
 	_ contracts.FestivalServiceInterface            = (*catalog.FestivalService)(nil)


### PR DESCRIPTION
## Summary
- Split the monolithic `ShowServiceInterface` (28 methods) into 4 focused interfaces by concern:
  - `ShowServiceInterface` (10 methods) — core CRUD + search
  - `ShowAdminServiceInterface` (7 methods) — admin queries + approval flows
  - `ShowImportServiceInterface` (4 methods) — import/export
  - `ShowStateServiceInterface` (5 methods) — state mutations (publish, unpublish, etc.)
- Added composite `ShowFullServiceInterface` embedding all 4 for backward compat
- Updated `ShowHandler` and `AdminShowHandler` to accept specific interfaces
- Split monolithic `mockShowService` into 4 focused mock structs
- Updated all handler tests (unit + integration) for new constructor signatures
- Evaluated `VenueServiceInterface` — deferred (concerns too interleaved for clean split)

Closes PSY-189

## Test plan
- [x] `go build ./...` passes
- [x] All handler tests pass (unit + integration)
- [x] All service tests pass
- [x] Route registration verified
- [x] Compile-time interface checks added for all 5 interfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)