### PR TITLE
Standardize route setup function signatures with RouteContext

### DIFF
--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -19,6 +19,16 @@ import (
 	"psychic-homily-backend/internal/services"
 )
 
+// RouteContext holds the shared dependencies passed to every route setup function.
+// Each function uses only what it needs from the struct.
+type RouteContext struct {
+	Router    *chi.Mux                  // The chi mux (for Chi-level middleware groups and raw HTTP routes)
+	API       huma.API                  // The public Huma API wrapper
+	Protected *huma.Group               // Protected (auth-required) Huma API group
+	SC        *services.ServiceContainer // All instantiated services
+	Cfg       *config.Config            // Application configuration
+}
+
 // SetupRoutes configures all API routes
 func SetupRoutes(router *chi.Mux, sc *services.ServiceContainer, cfg *config.Config) huma.API {
 	api := humachi.New(router, huma.DefaultConfig("Psychic Homily", "1.0.0"))
@@ -29,15 +39,24 @@ func SetupRoutes(router *chi.Mux, sc *services.ServiceContainer, cfg *config.Con
 	// Enrich Sentry scope with request ID and HTTP metadata on all routes
 	api.UseMiddleware(middleware.HumaSentryContextMiddleware)
 
-	// Setup domain-specific routes
-	setupSystemRoutes(router, api)
-	setupAuthRoutes(router, api, sc, cfg)
-
 	// Create a protected group that will require authentication
 	protectedGroup := huma.NewGroup(api, "")
 	protectedGroup.UseMiddleware(middleware.HumaJWTMiddleware(sc.JWT, cfg.Session))
 	// Enrich Sentry scope with authenticated user context (runs after JWT middleware)
 	protectedGroup.UseMiddleware(middleware.HumaSentryContextMiddleware)
+
+	// Build the shared RouteContext once, pass to all setup functions
+	rc := RouteContext{
+		Router:    router,
+		API:       api,
+		Protected: protectedGroup,
+		SC:        sc,
+		Cfg:       cfg,
+	}
+
+	// Setup domain-specific routes
+	setupSystemRoutes(rc)
+	setupAuthRoutes(rc)
 
 	// Add protected auth routes
 	authHandler := handlers.NewAuthHandler(sc.Auth, sc.JWT, sc.User, sc.Email, sc.Discord, sc.PasswordValidator, cfg)
@@ -80,40 +99,40 @@ func SetupRoutes(router *chi.Mux, sc *services.ServiceContainer, cfg *config.Con
 	// These are registered in setupAuthRoutes with rate limiting
 
 	// Setup passkey routes (some public, some protected) - with rate limiting
-	setupPasskeyRoutes(router, api, protectedGroup, sc, cfg)
+	setupPasskeyRoutes(rc)
 
-	setupShowRoutes(router, api, protectedGroup, sc, cfg)
-	setupArtistRoutes(api, protectedGroup, sc)
-	setupReleaseRoutes(api, protectedGroup, sc)
-	setupLabelRoutes(api, protectedGroup, sc)
-	setupFestivalRoutes(api, protectedGroup, sc)
-	setupVenueRoutes(api, protectedGroup, sc)
-	setupCalendarRoutes(router, protectedGroup, sc, cfg)
-	setupSavedShowRoutes(protectedGroup, sc)
-	setupFavoriteVenueRoutes(protectedGroup, sc)
-	setupShowReportRoutes(router, protectedGroup, sc, cfg)
-	setupArtistReportRoutes(router, protectedGroup, sc, cfg)
-	setupAdminRoutes(protectedGroup, sc)
-	setupPipelineRoutes(protectedGroup, sc)
-	setupContributorProfileRoutes(api, protectedGroup, sc)
-	setupCollectionRoutes(api, protectedGroup, sc)
-	setupRequestRoutes(api, protectedGroup, sc)
-	setupRevisionRoutes(api, protectedGroup, sc)
-	setupTagRoutes(api, protectedGroup, sc)
-	setupArtistRelationshipRoutes(api, protectedGroup, sc)
-	setupSceneRoutes(api, sc)
-	setupAttendanceRoutes(api, protectedGroup, sc)
-	setupFollowRoutes(api, protectedGroup, sc)
-	setupNotificationFilterRoutes(api, protectedGroup, sc, cfg)
-	setupChartsRoutes(api, sc)
+	setupShowRoutes(rc)
+	setupArtistRoutes(rc)
+	setupReleaseRoutes(rc)
+	setupLabelRoutes(rc)
+	setupFestivalRoutes(rc)
+	setupVenueRoutes(rc)
+	setupCalendarRoutes(rc)
+	setupSavedShowRoutes(rc)
+	setupFavoriteVenueRoutes(rc)
+	setupShowReportRoutes(rc)
+	setupArtistReportRoutes(rc)
+	setupAdminRoutes(rc)
+	setupPipelineRoutes(rc)
+	setupContributorProfileRoutes(rc)
+	setupCollectionRoutes(rc)
+	setupRequestRoutes(rc)
+	setupRevisionRoutes(rc)
+	setupTagRoutes(rc)
+	setupArtistRelationshipRoutes(rc)
+	setupSceneRoutes(rc)
+	setupAttendanceRoutes(rc)
+	setupFollowRoutes(rc)
+	setupNotificationFilterRoutes(rc)
+	setupChartsRoutes(rc)
 
 	return api
 }
 
 // setupAuthRoutes configures all authentication-related endpoints
-func setupAuthRoutes(router *chi.Mux, api huma.API, sc *services.ServiceContainer, cfg *config.Config) {
-	authHandler := handlers.NewAuthHandler(sc.Auth, sc.JWT, sc.User, sc.Email, sc.Discord, sc.PasswordValidator, cfg)
-	oauthHTTPHandler := handlers.NewOAuthHTTPHandler(sc.Auth, cfg)
+func setupAuthRoutes(rc RouteContext) {
+	authHandler := handlers.NewAuthHandler(rc.SC.Auth, rc.SC.JWT, rc.SC.User, rc.SC.Email, rc.SC.Discord, rc.SC.PasswordValidator, rc.Cfg)
+	oauthHTTPHandler := handlers.NewOAuthHTTPHandler(rc.SC.Auth, rc.Cfg)
 
 	// Create rate limiter for auth endpoints: 10 requests per minute per IP
 	// This helps prevent:
@@ -129,7 +148,7 @@ func setupAuthRoutes(router *chi.Mux, api huma.API, sc *services.ServiceContaine
 	)
 
 	// Rate-limited OAuth routes
-	router.Group(func(r chi.Router) {
+	rc.Router.Group(func(r chi.Router) {
 		r.Use(authRateLimiter)
 		r.Get("/auth/login/{provider}", oauthHTTPHandler.OAuthLoginHTTPHandler)
 		r.Get("/auth/callback/{provider}", oauthHTTPHandler.OAuthCallbackHTTPHandler)
@@ -137,7 +156,7 @@ func setupAuthRoutes(router *chi.Mux, api huma.API, sc *services.ServiceContaine
 
 	// Rate-limited auth API endpoints using Chi middleware wrapper
 	// We register these directly on the router with rate limiting, then Huma picks them up
-	router.Group(func(r chi.Router) {
+	rc.Router.Group(func(r chi.Router) {
 		r.Use(authRateLimiter)
 
 		// Create a sub-API for rate-limited routes
@@ -150,7 +169,7 @@ func setupAuthRoutes(router *chi.Mux, api huma.API, sc *services.ServiceContaine
 		huma.Post(rateLimitedAPI, "/auth/magic-link/verify", authHandler.VerifyMagicLinkHandler)
 
 		// Sign in with Apple (public, rate-limited)
-		appleAuthHandler := handlers.NewAppleAuthHandler(sc.AppleAuth, sc.Discord, cfg)
+		appleAuthHandler := handlers.NewAppleAuthHandler(rc.SC.AppleAuth, rc.SC.Discord, rc.Cfg)
 		huma.Post(rateLimitedAPI, "/auth/apple/callback", appleAuthHandler.AppleCallbackHandler)
 
 		// Account recovery endpoints (public, rate-limited)
@@ -160,29 +179,30 @@ func setupAuthRoutes(router *chi.Mux, api huma.API, sc *services.ServiceContaine
 	})
 
 	// Logout doesn't need strict rate limiting (already requires valid session)
-	huma.Post(api, "/auth/logout", authHandler.LogoutHandler)
+	huma.Post(rc.API, "/auth/logout", authHandler.LogoutHandler)
 }
 
 // setupSystemRoutes configures system/infrastructure endpoints
-func setupSystemRoutes(router *chi.Mux, api huma.API) {
+func setupSystemRoutes(rc RouteContext) {
 	// Health check endpoint
-	huma.Get(api, "/health", handlers.HealthHandler)
+	huma.Get(rc.API, "/health", handlers.HealthHandler)
 
 	// OpenAPI specification endpoint
-	router.Get("/openapi.json", func(w http.ResponseWriter, r *http.Request) {
+	api := rc.API
+	rc.Router.Get("/openapi.json", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(api.OpenAPI())
 	})
 }
 
 // setupPasskeyRoutes configures WebAuthn/passkey endpoints
-func setupPasskeyRoutes(router *chi.Mux, api huma.API, protected *huma.Group, sc *services.ServiceContainer, cfg *config.Config) {
-	if sc.WebAuthn == nil {
+func setupPasskeyRoutes(rc RouteContext) {
+	if rc.SC.WebAuthn == nil {
 		// WebAuthn service failed to initialize - passkeys are optional
 		return
 	}
 
-	passkeyHandler := handlers.NewPasskeyHandler(sc.WebAuthn, sc.JWT, sc.User, cfg)
+	passkeyHandler := handlers.NewPasskeyHandler(rc.SC.WebAuthn, rc.SC.JWT, rc.SC.User, rc.Cfg)
 
 	// Create rate limiter for passkey endpoints: 20 requests per minute per IP
 	// Slightly more lenient than auth due to multi-step WebAuthn flow
@@ -194,7 +214,7 @@ func setupPasskeyRoutes(router *chi.Mux, api huma.API, protected *huma.Group, sc
 	)
 
 	// Rate-limited public passkey endpoints
-	router.Group(func(r chi.Router) {
+	rc.Router.Group(func(r chi.Router) {
 		r.Use(passkeyRateLimiter)
 
 		passkeyAPI := humachi.New(r, huma.DefaultConfig("Psychic Homily Passkey", "1.0.0"))
@@ -210,51 +230,51 @@ func setupPasskeyRoutes(router *chi.Mux, api huma.API, protected *huma.Group, sc
 	})
 
 	// Protected passkey registration endpoints (user must be logged in)
-	huma.Post(protected, "/auth/passkey/register/begin", passkeyHandler.BeginRegisterHandler)
-	huma.Post(protected, "/auth/passkey/register/finish", passkeyHandler.FinishRegisterHandler)
+	huma.Post(rc.Protected, "/auth/passkey/register/begin", passkeyHandler.BeginRegisterHandler)
+	huma.Post(rc.Protected, "/auth/passkey/register/finish", passkeyHandler.FinishRegisterHandler)
 
 	// Protected passkey management endpoints
-	huma.Get(protected, "/auth/passkey/credentials", passkeyHandler.ListCredentialsHandler)
-	huma.Delete(protected, "/auth/passkey/credentials/{credential_id}", passkeyHandler.DeleteCredentialHandler)
+	huma.Get(rc.Protected, "/auth/passkey/credentials", passkeyHandler.ListCredentialsHandler)
+	huma.Delete(rc.Protected, "/auth/passkey/credentials/{credential_id}", passkeyHandler.DeleteCredentialHandler)
 }
 
 // setupShowRoutes configures all show-related endpoints
-func setupShowRoutes(router *chi.Mux, api huma.API, protected *huma.Group, sc *services.ServiceContainer, cfg *config.Config) {
-	showHandler := handlers.NewShowHandler(sc.Show, sc.Show, sc.Show, sc.SavedShow, sc.Discord, sc.MusicDiscovery, sc.Extraction)
+func setupShowRoutes(rc RouteContext) {
+	showHandler := handlers.NewShowHandler(rc.SC.Show, rc.SC.Show, rc.SC.Show, rc.SC.SavedShow, rc.SC.Discord, rc.SC.MusicDiscovery, rc.SC.Extraction)
 
 	// Public show endpoints - registered on main API without middleware
 	// Note: Static routes must come before parameterized routes
-	huma.Get(api, "/shows", showHandler.GetShowsHandler)
-	huma.Get(api, "/shows/cities", showHandler.GetShowCitiesHandler)
-	huma.Get(api, "/shows/upcoming", showHandler.GetUpcomingShowsHandler)
+	huma.Get(rc.API, "/shows", showHandler.GetShowsHandler)
+	huma.Get(rc.API, "/shows/cities", showHandler.GetShowCitiesHandler)
+	huma.Get(rc.API, "/shows/upcoming", showHandler.GetUpcomingShowsHandler)
 
 	// Show detail with optional auth for access control on non-approved shows
-	optionalAuthGroup := huma.NewGroup(api, "")
-	optionalAuthGroup.UseMiddleware(middleware.OptionalHumaJWTMiddleware(sc.JWT))
+	optionalAuthGroup := huma.NewGroup(rc.API, "")
+	optionalAuthGroup.UseMiddleware(middleware.OptionalHumaJWTMiddleware(rc.SC.JWT))
 	huma.Get(optionalAuthGroup, "/shows/{show_id}", showHandler.GetShowHandler)
 
 	// Export endpoint - only register in development environment
 	if os.Getenv("ENVIRONMENT") == "development" {
-		huma.Get(api, "/shows/{show_id}/export", showHandler.ExportShowHandler)
+		huma.Get(rc.API, "/shows/{show_id}/export", showHandler.ExportShowHandler)
 	}
 
 	// Rate-limited show creation: 10 requests per hour per IP
 	// Prevents flooding the admin approval queue
 	// API token requests (phk_ prefix) bypass the rate limit — they're trusted admin clients
-	router.Group(func(r chi.Router) {
+	rc.Router.Group(func(r chi.Router) {
 		r.Use(rateLimitUnlessAPIToken(
 			middleware.ShowCreateRequestsPerHour,
 			time.Hour,
 		))
 		showCreateAPI := humachi.New(r, huma.DefaultConfig("Psychic Homily Show Create", "1.0.0"))
 		showCreateAPI.UseMiddleware(middleware.HumaRequestIDMiddleware)
-		showCreateAPI.UseMiddleware(middleware.HumaJWTMiddleware(sc.JWT, cfg.Session))
+		showCreateAPI.UseMiddleware(middleware.HumaJWTMiddleware(rc.SC.JWT, rc.Cfg.Session))
 		huma.Post(showCreateAPI, "/shows", showHandler.CreateShowHandler)
 	})
 
 	// Rate-limited AI processing: 5 requests per minute per IP
 	// Calls external Anthropic API — expensive operation
-	router.Group(func(r chi.Router) {
+	rc.Router.Group(func(r chi.Router) {
 		r.Use(httprate.Limit(
 			middleware.AIProcessRequestsPerMinute,
 			time.Minute,
@@ -263,178 +283,178 @@ func setupShowRoutes(router *chi.Mux, api huma.API, protected *huma.Group, sc *s
 		))
 		aiProcessAPI := humachi.New(r, huma.DefaultConfig("Psychic Homily AI Process", "1.0.0"))
 		aiProcessAPI.UseMiddleware(middleware.HumaRequestIDMiddleware)
-		aiProcessAPI.UseMiddleware(middleware.HumaJWTMiddleware(sc.JWT, cfg.Session))
+		aiProcessAPI.UseMiddleware(middleware.HumaJWTMiddleware(rc.SC.JWT, rc.Cfg.Session))
 		huma.Post(aiProcessAPI, "/shows/ai-process", showHandler.AIProcessShowHandler)
 	})
 
 	// Protected show endpoints (no additional rate limiting needed)
-	huma.Put(protected, "/shows/{show_id}", showHandler.UpdateShowHandler)
-	huma.Delete(protected, "/shows/{show_id}", showHandler.DeleteShowHandler)
-	huma.Post(protected, "/shows/{show_id}/unpublish", showHandler.UnpublishShowHandler)
-	huma.Post(protected, "/shows/{show_id}/make-private", showHandler.MakePrivateShowHandler)
-	huma.Post(protected, "/shows/{show_id}/publish", showHandler.PublishShowHandler)
-	huma.Post(protected, "/shows/{show_id}/sold-out", showHandler.SetShowSoldOutHandler)
-	huma.Post(protected, "/shows/{show_id}/cancelled", showHandler.SetShowCancelledHandler)
-	huma.Get(protected, "/shows/my-submissions", showHandler.GetMySubmissionsHandler)
+	huma.Put(rc.Protected, "/shows/{show_id}", showHandler.UpdateShowHandler)
+	huma.Delete(rc.Protected, "/shows/{show_id}", showHandler.DeleteShowHandler)
+	huma.Post(rc.Protected, "/shows/{show_id}/unpublish", showHandler.UnpublishShowHandler)
+	huma.Post(rc.Protected, "/shows/{show_id}/make-private", showHandler.MakePrivateShowHandler)
+	huma.Post(rc.Protected, "/shows/{show_id}/publish", showHandler.PublishShowHandler)
+	huma.Post(rc.Protected, "/shows/{show_id}/sold-out", showHandler.SetShowSoldOutHandler)
+	huma.Post(rc.Protected, "/shows/{show_id}/cancelled", showHandler.SetShowCancelledHandler)
+	huma.Get(rc.Protected, "/shows/my-submissions", showHandler.GetMySubmissionsHandler)
 }
 
-func setupArtistRoutes(api huma.API, protected *huma.Group, sc *services.ServiceContainer) {
-	artistHandler := handlers.NewArtistHandler(sc.Artist, sc.AuditLog, sc.Revision)
+func setupArtistRoutes(rc RouteContext) {
+	artistHandler := handlers.NewArtistHandler(rc.SC.Artist, rc.SC.AuditLog, rc.SC.Revision)
 
 	// Public artist endpoints - registered on main API without middleware
 	// Note: Static routes must come before parameterized routes
-	huma.Get(api, "/artists", artistHandler.ListArtistsHandler)
-	huma.Get(api, "/artists/cities", artistHandler.GetArtistCitiesHandler)
-	huma.Get(api, "/artists/search", artistHandler.SearchArtistsHandler)
-	huma.Get(api, "/artists/{artist_id}", artistHandler.GetArtistHandler)
-	huma.Get(api, "/artists/{artist_id}/shows", artistHandler.GetArtistShowsHandler)
-	huma.Get(api, "/artists/{artist_id}/labels", artistHandler.GetArtistLabelsHandler)
-	huma.Get(api, "/artists/{artist_id}/aliases", artistHandler.GetArtistAliasesHandler)
+	huma.Get(rc.API, "/artists", artistHandler.ListArtistsHandler)
+	huma.Get(rc.API, "/artists/cities", artistHandler.GetArtistCitiesHandler)
+	huma.Get(rc.API, "/artists/search", artistHandler.SearchArtistsHandler)
+	huma.Get(rc.API, "/artists/{artist_id}", artistHandler.GetArtistHandler)
+	huma.Get(rc.API, "/artists/{artist_id}/shows", artistHandler.GetArtistShowsHandler)
+	huma.Get(rc.API, "/artists/{artist_id}/labels", artistHandler.GetArtistLabelsHandler)
+	huma.Get(rc.API, "/artists/{artist_id}/aliases", artistHandler.GetArtistAliasesHandler)
 
 	// Protected artist endpoints
-	huma.Delete(protected, "/artists/{artist_id}", artistHandler.DeleteArtistHandler)
-	huma.Post(protected, "/admin/artists", artistHandler.AdminCreateArtistHandler)
-	huma.Patch(protected, "/admin/artists/{artist_id}", artistHandler.AdminUpdateArtistHandler)
-	huma.Post(protected, "/admin/artists/{artist_id}/aliases", artistHandler.AddArtistAliasHandler)
-	huma.Delete(protected, "/admin/artists/{artist_id}/aliases/{alias_id}", artistHandler.DeleteArtistAliasHandler)
-	huma.Post(protected, "/admin/artists/merge", artistHandler.MergeArtistsHandler)
+	huma.Delete(rc.Protected, "/artists/{artist_id}", artistHandler.DeleteArtistHandler)
+	huma.Post(rc.Protected, "/admin/artists", artistHandler.AdminCreateArtistHandler)
+	huma.Patch(rc.Protected, "/admin/artists/{artist_id}", artistHandler.AdminUpdateArtistHandler)
+	huma.Post(rc.Protected, "/admin/artists/{artist_id}/aliases", artistHandler.AddArtistAliasHandler)
+	huma.Delete(rc.Protected, "/admin/artists/{artist_id}/aliases/{alias_id}", artistHandler.DeleteArtistAliasHandler)
+	huma.Post(rc.Protected, "/admin/artists/merge", artistHandler.MergeArtistsHandler)
 }
 
-func setupReleaseRoutes(api huma.API, protected *huma.Group, sc *services.ServiceContainer) {
-	releaseHandler := handlers.NewReleaseHandler(sc.Release, sc.Artist, sc.AuditLog)
+func setupReleaseRoutes(rc RouteContext) {
+	releaseHandler := handlers.NewReleaseHandler(rc.SC.Release, rc.SC.Artist, rc.SC.AuditLog)
 
 	// Public release endpoints
 	// Note: Static routes must come before parameterized routes
-	huma.Get(api, "/releases", releaseHandler.ListReleasesHandler)
-	huma.Get(api, "/releases/search", releaseHandler.SearchReleasesHandler)
-	huma.Get(api, "/releases/{release_id}", releaseHandler.GetReleaseHandler)
-	huma.Get(api, "/artists/{artist_id}/releases", releaseHandler.GetArtistReleasesHandler)
+	huma.Get(rc.API, "/releases", releaseHandler.ListReleasesHandler)
+	huma.Get(rc.API, "/releases/search", releaseHandler.SearchReleasesHandler)
+	huma.Get(rc.API, "/releases/{release_id}", releaseHandler.GetReleaseHandler)
+	huma.Get(rc.API, "/artists/{artist_id}/releases", releaseHandler.GetArtistReleasesHandler)
 
 	// Protected release endpoints (admin-only checks inside handlers)
-	huma.Post(protected, "/releases", releaseHandler.CreateReleaseHandler)
-	huma.Put(protected, "/releases/{release_id}", releaseHandler.UpdateReleaseHandler)
-	huma.Delete(protected, "/releases/{release_id}", releaseHandler.DeleteReleaseHandler)
-	huma.Post(protected, "/releases/{release_id}/links", releaseHandler.AddExternalLinkHandler)
-	huma.Delete(protected, "/releases/{release_id}/links/{link_id}", releaseHandler.RemoveExternalLinkHandler)
+	huma.Post(rc.Protected, "/releases", releaseHandler.CreateReleaseHandler)
+	huma.Put(rc.Protected, "/releases/{release_id}", releaseHandler.UpdateReleaseHandler)
+	huma.Delete(rc.Protected, "/releases/{release_id}", releaseHandler.DeleteReleaseHandler)
+	huma.Post(rc.Protected, "/releases/{release_id}/links", releaseHandler.AddExternalLinkHandler)
+	huma.Delete(rc.Protected, "/releases/{release_id}/links/{link_id}", releaseHandler.RemoveExternalLinkHandler)
 }
 
-func setupLabelRoutes(api huma.API, protected *huma.Group, sc *services.ServiceContainer) {
-	labelHandler := handlers.NewLabelHandler(sc.Label, sc.AuditLog)
+func setupLabelRoutes(rc RouteContext) {
+	labelHandler := handlers.NewLabelHandler(rc.SC.Label, rc.SC.AuditLog)
 
 	// Public label endpoints
 	// Note: Static routes must come before parameterized routes
-	huma.Get(api, "/labels", labelHandler.ListLabelsHandler)
-	huma.Get(api, "/labels/search", labelHandler.SearchLabelsHandler)
-	huma.Get(api, "/labels/{label_id}", labelHandler.GetLabelHandler)
-	huma.Get(api, "/labels/{label_id}/artists", labelHandler.GetLabelRosterHandler)
-	huma.Get(api, "/labels/{label_id}/releases", labelHandler.GetLabelCatalogHandler)
+	huma.Get(rc.API, "/labels", labelHandler.ListLabelsHandler)
+	huma.Get(rc.API, "/labels/search", labelHandler.SearchLabelsHandler)
+	huma.Get(rc.API, "/labels/{label_id}", labelHandler.GetLabelHandler)
+	huma.Get(rc.API, "/labels/{label_id}/artists", labelHandler.GetLabelRosterHandler)
+	huma.Get(rc.API, "/labels/{label_id}/releases", labelHandler.GetLabelCatalogHandler)
 
 	// Protected label endpoints (admin-only checks inside handlers)
-	huma.Post(protected, "/labels", labelHandler.CreateLabelHandler)
-	huma.Put(protected, "/labels/{label_id}", labelHandler.UpdateLabelHandler)
-	huma.Delete(protected, "/labels/{label_id}", labelHandler.DeleteLabelHandler)
-	huma.Post(protected, "/admin/labels/{label_id}/artists", labelHandler.AddArtistToLabelHandler)
-	huma.Post(protected, "/admin/labels/{label_id}/releases", labelHandler.AddReleaseToLabelHandler)
+	huma.Post(rc.Protected, "/labels", labelHandler.CreateLabelHandler)
+	huma.Put(rc.Protected, "/labels/{label_id}", labelHandler.UpdateLabelHandler)
+	huma.Delete(rc.Protected, "/labels/{label_id}", labelHandler.DeleteLabelHandler)
+	huma.Post(rc.Protected, "/admin/labels/{label_id}/artists", labelHandler.AddArtistToLabelHandler)
+	huma.Post(rc.Protected, "/admin/labels/{label_id}/releases", labelHandler.AddReleaseToLabelHandler)
 }
 
-func setupFestivalRoutes(api huma.API, protected *huma.Group, sc *services.ServiceContainer) {
-	festivalHandler := handlers.NewFestivalHandler(sc.Festival, sc.Artist, sc.AuditLog, sc.Revision)
+func setupFestivalRoutes(rc RouteContext) {
+	festivalHandler := handlers.NewFestivalHandler(rc.SC.Festival, rc.SC.Artist, rc.SC.AuditLog, rc.SC.Revision)
 
 	// Public festival endpoints
 	// Note: Static routes must come before parameterized routes
-	huma.Get(api, "/festivals", festivalHandler.ListFestivalsHandler)
-	huma.Get(api, "/festivals/search", festivalHandler.SearchFestivalsHandler)
-	huma.Get(api, "/festivals/{festival_id}", festivalHandler.GetFestivalHandler)
-	huma.Get(api, "/festivals/{festival_id}/artists", festivalHandler.GetFestivalArtistsHandler)
-	huma.Get(api, "/festivals/{festival_id}/venues", festivalHandler.GetFestivalVenuesHandler)
-	huma.Get(api, "/artists/{artist_id}/festivals", festivalHandler.GetArtistFestivalsHandler)
+	huma.Get(rc.API, "/festivals", festivalHandler.ListFestivalsHandler)
+	huma.Get(rc.API, "/festivals/search", festivalHandler.SearchFestivalsHandler)
+	huma.Get(rc.API, "/festivals/{festival_id}", festivalHandler.GetFestivalHandler)
+	huma.Get(rc.API, "/festivals/{festival_id}/artists", festivalHandler.GetFestivalArtistsHandler)
+	huma.Get(rc.API, "/festivals/{festival_id}/venues", festivalHandler.GetFestivalVenuesHandler)
+	huma.Get(rc.API, "/artists/{artist_id}/festivals", festivalHandler.GetArtistFestivalsHandler)
 
 	// Festival intelligence endpoints (public, computed from existing data)
-	intelHandler := handlers.NewFestivalIntelligenceHandler(sc.FestivalIntelligence, sc.Festival, sc.Artist)
-	huma.Get(api, "/festivals/{festival_id}/similar", intelHandler.GetSimilarFestivalsHandler)
-	huma.Get(api, "/festivals/{festival_a_id}/overlap/{festival_b_id}", intelHandler.GetFestivalOverlapHandler)
-	huma.Get(api, "/festivals/{festival_id}/breakouts", intelHandler.GetFestivalBreakoutsHandler)
-	huma.Get(api, "/artists/{artist_id}/festival-trajectory", intelHandler.GetArtistFestivalTrajectoryHandler)
-	huma.Get(api, "/festivals/series/{series_slug}/compare", intelHandler.GetSeriesComparisonHandler)
+	intelHandler := handlers.NewFestivalIntelligenceHandler(rc.SC.FestivalIntelligence, rc.SC.Festival, rc.SC.Artist)
+	huma.Get(rc.API, "/festivals/{festival_id}/similar", intelHandler.GetSimilarFestivalsHandler)
+	huma.Get(rc.API, "/festivals/{festival_a_id}/overlap/{festival_b_id}", intelHandler.GetFestivalOverlapHandler)
+	huma.Get(rc.API, "/festivals/{festival_id}/breakouts", intelHandler.GetFestivalBreakoutsHandler)
+	huma.Get(rc.API, "/artists/{artist_id}/festival-trajectory", intelHandler.GetArtistFestivalTrajectoryHandler)
+	huma.Get(rc.API, "/festivals/series/{series_slug}/compare", intelHandler.GetSeriesComparisonHandler)
 
 	// Protected festival endpoints (admin-only checks inside handlers)
-	huma.Post(protected, "/festivals", festivalHandler.CreateFestivalHandler)
-	huma.Put(protected, "/festivals/{festival_id}", festivalHandler.UpdateFestivalHandler)
-	huma.Delete(protected, "/festivals/{festival_id}", festivalHandler.DeleteFestivalHandler)
-	huma.Post(protected, "/festivals/{festival_id}/artists", festivalHandler.AddFestivalArtistHandler)
-	huma.Put(protected, "/festivals/{festival_id}/artists/{artist_id}", festivalHandler.UpdateFestivalArtistHandler)
-	huma.Delete(protected, "/festivals/{festival_id}/artists/{artist_id}", festivalHandler.RemoveFestivalArtistHandler)
-	huma.Post(protected, "/festivals/{festival_id}/venues", festivalHandler.AddFestivalVenueHandler)
-	huma.Delete(protected, "/festivals/{festival_id}/venues/{venue_id}", festivalHandler.RemoveFestivalVenueHandler)
+	huma.Post(rc.Protected, "/festivals", festivalHandler.CreateFestivalHandler)
+	huma.Put(rc.Protected, "/festivals/{festival_id}", festivalHandler.UpdateFestivalHandler)
+	huma.Delete(rc.Protected, "/festivals/{festival_id}", festivalHandler.DeleteFestivalHandler)
+	huma.Post(rc.Protected, "/festivals/{festival_id}/artists", festivalHandler.AddFestivalArtistHandler)
+	huma.Put(rc.Protected, "/festivals/{festival_id}/artists/{artist_id}", festivalHandler.UpdateFestivalArtistHandler)
+	huma.Delete(rc.Protected, "/festivals/{festival_id}/artists/{artist_id}", festivalHandler.RemoveFestivalArtistHandler)
+	huma.Post(rc.Protected, "/festivals/{festival_id}/venues", festivalHandler.AddFestivalVenueHandler)
+	huma.Delete(rc.Protected, "/festivals/{festival_id}/venues/{venue_id}", festivalHandler.RemoveFestivalVenueHandler)
 }
 
-func setupVenueRoutes(api huma.API, protected *huma.Group, sc *services.ServiceContainer) {
-	venueHandler := handlers.NewVenueHandler(sc.Venue, sc.Discord, sc.AuditLog, sc.Revision)
+func setupVenueRoutes(rc RouteContext) {
+	venueHandler := handlers.NewVenueHandler(rc.SC.Venue, rc.SC.Discord, rc.SC.AuditLog, rc.SC.Revision)
 
 	// Public venue endpoints - registered on main API without middleware
 	// Note: Static routes must come before parameterized routes
-	huma.Get(api, "/venues", venueHandler.ListVenuesHandler)
-	huma.Get(api, "/venues/cities", venueHandler.GetVenueCitiesHandler)
-	huma.Get(api, "/venues/search", venueHandler.SearchVenuesHandler)
-	huma.Get(api, "/venues/{venue_id}", venueHandler.GetVenueHandler)
-	huma.Get(api, "/venues/{venue_id}/shows", venueHandler.GetVenueShowsHandler)
-	huma.Get(api, "/venues/{venue_id}/genres", venueHandler.GetVenueGenresHandler)
+	huma.Get(rc.API, "/venues", venueHandler.ListVenuesHandler)
+	huma.Get(rc.API, "/venues/cities", venueHandler.GetVenueCitiesHandler)
+	huma.Get(rc.API, "/venues/search", venueHandler.SearchVenuesHandler)
+	huma.Get(rc.API, "/venues/{venue_id}", venueHandler.GetVenueHandler)
+	huma.Get(rc.API, "/venues/{venue_id}/shows", venueHandler.GetVenueShowsHandler)
+	huma.Get(rc.API, "/venues/{venue_id}/genres", venueHandler.GetVenueGenresHandler)
 
 	// Protected venue endpoints - require authentication
-	huma.Post(protected, "/admin/venues", venueHandler.AdminCreateVenueHandler)
-	huma.Put(protected, "/venues/{venue_id}", venueHandler.UpdateVenueHandler)
-	huma.Delete(protected, "/venues/{venue_id}", venueHandler.DeleteVenueHandler)
-	huma.Get(protected, "/venues/{venue_id}/my-pending-edit", venueHandler.GetMyPendingEditHandler)
-	huma.Delete(protected, "/venues/{venue_id}/my-pending-edit", venueHandler.CancelMyPendingEditHandler)
+	huma.Post(rc.Protected, "/admin/venues", venueHandler.AdminCreateVenueHandler)
+	huma.Put(rc.Protected, "/venues/{venue_id}", venueHandler.UpdateVenueHandler)
+	huma.Delete(rc.Protected, "/venues/{venue_id}", venueHandler.DeleteVenueHandler)
+	huma.Get(rc.Protected, "/venues/{venue_id}/my-pending-edit", venueHandler.GetMyPendingEditHandler)
+	huma.Delete(rc.Protected, "/venues/{venue_id}/my-pending-edit", venueHandler.CancelMyPendingEditHandler)
 }
 
 // setupCalendarRoutes configures calendar feed and token management endpoints
-func setupCalendarRoutes(router *chi.Mux, protected *huma.Group, sc *services.ServiceContainer, cfg *config.Config) {
-	calendarHandler := handlers.NewCalendarHandler(sc.Calendar, cfg)
+func setupCalendarRoutes(rc RouteContext) {
+	calendarHandler := handlers.NewCalendarHandler(rc.SC.Calendar, rc.Cfg)
 
 	// Public Chi route for ICS feed (token-authenticated, not JWT)
-	router.Get("/calendar/{token}", calendarHandler.GetCalendarFeedHandler)
+	rc.Router.Get("/calendar/{token}", calendarHandler.GetCalendarFeedHandler)
 
 	// Protected Huma routes for token CRUD
-	huma.Post(protected, "/calendar/token", calendarHandler.CreateCalendarTokenHandler)
-	huma.Get(protected, "/calendar/token", calendarHandler.GetCalendarTokenStatusHandler)
-	huma.Delete(protected, "/calendar/token", calendarHandler.DeleteCalendarTokenHandler)
+	huma.Post(rc.Protected, "/calendar/token", calendarHandler.CreateCalendarTokenHandler)
+	huma.Get(rc.Protected, "/calendar/token", calendarHandler.GetCalendarTokenStatusHandler)
+	huma.Delete(rc.Protected, "/calendar/token", calendarHandler.DeleteCalendarTokenHandler)
 }
 
 // setupSavedShowRoutes configures saved show endpoints (user's personal "My List")
 // All endpoints require authentication via protected group
-func setupSavedShowRoutes(protected *huma.Group, sc *services.ServiceContainer) {
-	savedShowHandler := handlers.NewSavedShowHandler(sc.SavedShow)
+func setupSavedShowRoutes(rc RouteContext) {
+	savedShowHandler := handlers.NewSavedShowHandler(rc.SC.SavedShow)
 
 	// Protected saved show endpoints
-	huma.Post(protected, "/saved-shows/{show_id}", savedShowHandler.SaveShowHandler)
-	huma.Delete(protected, "/saved-shows/{show_id}", savedShowHandler.UnsaveShowHandler)
-	huma.Get(protected, "/saved-shows", savedShowHandler.GetSavedShowsHandler)
-	huma.Get(protected, "/saved-shows/{show_id}/check", savedShowHandler.CheckSavedHandler)
-	huma.Post(protected, "/saved-shows/check-batch", savedShowHandler.CheckBatchSavedHandler)
+	huma.Post(rc.Protected, "/saved-shows/{show_id}", savedShowHandler.SaveShowHandler)
+	huma.Delete(rc.Protected, "/saved-shows/{show_id}", savedShowHandler.UnsaveShowHandler)
+	huma.Get(rc.Protected, "/saved-shows", savedShowHandler.GetSavedShowsHandler)
+	huma.Get(rc.Protected, "/saved-shows/{show_id}/check", savedShowHandler.CheckSavedHandler)
+	huma.Post(rc.Protected, "/saved-shows/check-batch", savedShowHandler.CheckBatchSavedHandler)
 }
 
 // setupFavoriteVenueRoutes configures favorite venue endpoints
 // All endpoints require authentication via protected group
-func setupFavoriteVenueRoutes(protected *huma.Group, sc *services.ServiceContainer) {
-	favoriteVenueHandler := handlers.NewFavoriteVenueHandler(sc.FavoriteVenue)
+func setupFavoriteVenueRoutes(rc RouteContext) {
+	favoriteVenueHandler := handlers.NewFavoriteVenueHandler(rc.SC.FavoriteVenue)
 
 	// Protected favorite venue endpoints
-	huma.Post(protected, "/favorite-venues/{venue_id}", favoriteVenueHandler.FavoriteVenueHandler)
-	huma.Delete(protected, "/favorite-venues/{venue_id}", favoriteVenueHandler.UnfavoriteVenueHandler)
-	huma.Get(protected, "/favorite-venues", favoriteVenueHandler.GetFavoriteVenuesHandler)
-	huma.Get(protected, "/favorite-venues/{venue_id}/check", favoriteVenueHandler.CheckFavoritedHandler)
-	huma.Get(protected, "/favorite-venues/shows", favoriteVenueHandler.GetFavoriteVenueShowsHandler)
+	huma.Post(rc.Protected, "/favorite-venues/{venue_id}", favoriteVenueHandler.FavoriteVenueHandler)
+	huma.Delete(rc.Protected, "/favorite-venues/{venue_id}", favoriteVenueHandler.UnfavoriteVenueHandler)
+	huma.Get(rc.Protected, "/favorite-venues", favoriteVenueHandler.GetFavoriteVenuesHandler)
+	huma.Get(rc.Protected, "/favorite-venues/{venue_id}/check", favoriteVenueHandler.CheckFavoritedHandler)
+	huma.Get(rc.Protected, "/favorite-venues/shows", favoriteVenueHandler.GetFavoriteVenueShowsHandler)
 }
 
 // setupShowReportRoutes configures show report endpoints
 // All endpoints require authentication via protected group
-func setupShowReportRoutes(router *chi.Mux, protected *huma.Group, sc *services.ServiceContainer, cfg *config.Config) {
-	showReportHandler := handlers.NewShowReportHandler(sc.ShowReport, sc.Discord, sc.User, sc.AuditLog)
+func setupShowReportRoutes(rc RouteContext) {
+	showReportHandler := handlers.NewShowReportHandler(rc.SC.ShowReport, rc.SC.Discord, rc.SC.User, rc.SC.AuditLog)
 
 	// Rate-limited report submission: 5 requests per minute per IP
 	// Prevents spamming admins with reports
-	router.Group(func(r chi.Router) {
+	rc.Router.Group(func(r chi.Router) {
 		r.Use(httprate.Limit(
 			middleware.ReportRequestsPerMinute,
 			time.Minute,
@@ -443,25 +463,25 @@ func setupShowReportRoutes(router *chi.Mux, protected *huma.Group, sc *services.
 		))
 		reportAPI := humachi.New(r, huma.DefaultConfig("Psychic Homily Reports", "1.0.0"))
 		reportAPI.UseMiddleware(middleware.HumaRequestIDMiddleware)
-		reportAPI.UseMiddleware(middleware.HumaJWTMiddleware(sc.JWT, cfg.Session))
+		reportAPI.UseMiddleware(middleware.HumaJWTMiddleware(rc.SC.JWT, rc.Cfg.Session))
 		huma.Post(reportAPI, "/shows/{show_id}/report", showReportHandler.ReportShowHandler)
 	})
 
 	// Protected report endpoints (no additional rate limiting)
-	huma.Get(protected, "/shows/{show_id}/my-report", showReportHandler.GetMyReportHandler)
+	huma.Get(rc.Protected, "/shows/{show_id}/my-report", showReportHandler.GetMyReportHandler)
 
 	// Admin endpoints for managing reports
-	huma.Get(protected, "/admin/reports", showReportHandler.GetPendingReportsHandler)
-	huma.Post(protected, "/admin/reports/{report_id}/dismiss", showReportHandler.DismissReportHandler)
-	huma.Post(protected, "/admin/reports/{report_id}/resolve", showReportHandler.ResolveReportHandler)
+	huma.Get(rc.Protected, "/admin/reports", showReportHandler.GetPendingReportsHandler)
+	huma.Post(rc.Protected, "/admin/reports/{report_id}/dismiss", showReportHandler.DismissReportHandler)
+	huma.Post(rc.Protected, "/admin/reports/{report_id}/resolve", showReportHandler.ResolveReportHandler)
 }
 
 // setupArtistReportRoutes configures artist report endpoints
-func setupArtistReportRoutes(router *chi.Mux, protected *huma.Group, sc *services.ServiceContainer, cfg *config.Config) {
-	artistReportHandler := handlers.NewArtistReportHandler(sc.ArtistReport, sc.Discord, sc.User, sc.AuditLog)
+func setupArtistReportRoutes(rc RouteContext) {
+	artistReportHandler := handlers.NewArtistReportHandler(rc.SC.ArtistReport, rc.SC.Discord, rc.SC.User, rc.SC.AuditLog)
 
 	// Rate-limited report submission: 5 requests per minute per IP
-	router.Group(func(r chi.Router) {
+	rc.Router.Group(func(r chi.Router) {
 		r.Use(httprate.Limit(
 			middleware.ReportRequestsPerMinute,
 			time.Minute,
@@ -470,159 +490,159 @@ func setupArtistReportRoutes(router *chi.Mux, protected *huma.Group, sc *service
 		))
 		reportAPI := humachi.New(r, huma.DefaultConfig("Psychic Homily Artist Reports", "1.0.0"))
 		reportAPI.UseMiddleware(middleware.HumaRequestIDMiddleware)
-		reportAPI.UseMiddleware(middleware.HumaJWTMiddleware(sc.JWT, cfg.Session))
+		reportAPI.UseMiddleware(middleware.HumaJWTMiddleware(rc.SC.JWT, rc.Cfg.Session))
 		huma.Post(reportAPI, "/artists/{artist_id}/report", artistReportHandler.ReportArtistHandler)
 	})
 
 	// Protected report endpoints (no additional rate limiting)
-	huma.Get(protected, "/artists/{artist_id}/my-report", artistReportHandler.GetMyArtistReportHandler)
+	huma.Get(rc.Protected, "/artists/{artist_id}/my-report", artistReportHandler.GetMyArtistReportHandler)
 
 	// Admin endpoints for managing artist reports
-	huma.Get(protected, "/admin/artist-reports", artistReportHandler.GetPendingArtistReportsHandler)
-	huma.Post(protected, "/admin/artist-reports/{report_id}/dismiss", artistReportHandler.DismissArtistReportHandler)
-	huma.Post(protected, "/admin/artist-reports/{report_id}/resolve", artistReportHandler.ResolveArtistReportHandler)
+	huma.Get(rc.Protected, "/admin/artist-reports", artistReportHandler.GetPendingArtistReportsHandler)
+	huma.Post(rc.Protected, "/admin/artist-reports/{report_id}/dismiss", artistReportHandler.DismissArtistReportHandler)
+	huma.Post(rc.Protected, "/admin/artist-reports/{report_id}/resolve", artistReportHandler.ResolveArtistReportHandler)
 }
 
 // setupAdminRoutes configures admin-only endpoints
 // Note: Admin check is performed inside handlers, JWT auth is required via protected group
-func setupAdminRoutes(protected *huma.Group, sc *services.ServiceContainer) {
+func setupAdminRoutes(rc RouteContext) {
 	// Domain-specific admin handlers
-	statsHandler := handlers.NewAdminStatsHandler(sc.AdminStats)
+	statsHandler := handlers.NewAdminStatsHandler(rc.SC.AdminStats)
 	showHandler := handlers.NewAdminShowHandler(
-		sc.Show, sc.Show, sc.Show, sc.Discord, sc.AuditLog, sc.NotificationFilter,
-		sc.MusicDiscovery,
+		rc.SC.Show, rc.SC.Show, rc.SC.Show, rc.SC.Discord, rc.SC.AuditLog, rc.SC.NotificationFilter,
+		rc.SC.MusicDiscovery,
 	)
-	venueHandler := handlers.NewAdminVenueHandler(sc.Venue, sc.AuditLog)
-	userHandler := handlers.NewAdminUserHandler(sc.User)
-	tokenHandler := handlers.NewAdminTokenHandler(sc.APIToken)
-	dataHandler := handlers.NewAdminDataHandler(sc.DataSync)
-	discoveryHandler := handlers.NewAdminDiscoveryHandler(sc.Discovery)
+	venueHandler := handlers.NewAdminVenueHandler(rc.SC.Venue, rc.SC.AuditLog)
+	userHandler := handlers.NewAdminUserHandler(rc.SC.User)
+	tokenHandler := handlers.NewAdminTokenHandler(rc.SC.APIToken)
+	dataHandler := handlers.NewAdminDataHandler(rc.SC.DataSync)
+	discoveryHandler := handlers.NewAdminDiscoveryHandler(rc.SC.Discovery)
 
-	artistHandler := handlers.NewArtistHandler(sc.Artist, sc.AuditLog, sc.Revision)
-	auditLogHandler := handlers.NewAuditLogHandler(sc.AuditLog)
+	artistHandler := handlers.NewArtistHandler(rc.SC.Artist, rc.SC.AuditLog, rc.SC.Revision)
+	auditLogHandler := handlers.NewAuditLogHandler(rc.SC.AuditLog)
 
 	// Admin dashboard stats endpoint
-	huma.Get(protected, "/admin/stats", statsHandler.GetAdminStatsHandler)
-	huma.Get(protected, "/admin/activity", statsHandler.GetActivityFeedHandler)
+	huma.Get(rc.Protected, "/admin/stats", statsHandler.GetAdminStatsHandler)
+	huma.Get(rc.Protected, "/admin/activity", statsHandler.GetActivityFeedHandler)
 
 	// Admin show listing endpoint (for CLI export)
-	huma.Get(protected, "/admin/shows", showHandler.GetAdminShowsHandler)
+	huma.Get(rc.Protected, "/admin/shows", showHandler.GetAdminShowsHandler)
 
 	// Admin show management endpoints
-	huma.Get(protected, "/admin/shows/pending", showHandler.GetPendingShowsHandler)
-	huma.Get(protected, "/admin/shows/rejected", showHandler.GetRejectedShowsHandler)
-	huma.Post(protected, "/admin/shows/{show_id}/approve", showHandler.ApproveShowHandler)
-	huma.Post(protected, "/admin/shows/{show_id}/reject", showHandler.RejectShowHandler)
-	huma.Post(protected, "/admin/shows/batch-approve", showHandler.BatchApproveShowsHandler)
-	huma.Post(protected, "/admin/shows/batch-reject", showHandler.BatchRejectShowsHandler)
+	huma.Get(rc.Protected, "/admin/shows/pending", showHandler.GetPendingShowsHandler)
+	huma.Get(rc.Protected, "/admin/shows/rejected", showHandler.GetRejectedShowsHandler)
+	huma.Post(rc.Protected, "/admin/shows/{show_id}/approve", showHandler.ApproveShowHandler)
+	huma.Post(rc.Protected, "/admin/shows/{show_id}/reject", showHandler.RejectShowHandler)
+	huma.Post(rc.Protected, "/admin/shows/batch-approve", showHandler.BatchApproveShowsHandler)
+	huma.Post(rc.Protected, "/admin/shows/batch-reject", showHandler.BatchRejectShowsHandler)
 
 	// Admin show import endpoints (single)
-	huma.Post(protected, "/admin/shows/import/preview", showHandler.ImportShowPreviewHandler)
-	huma.Post(protected, "/admin/shows/import/confirm", showHandler.ImportShowConfirmHandler)
+	huma.Post(rc.Protected, "/admin/shows/import/preview", showHandler.ImportShowPreviewHandler)
+	huma.Post(rc.Protected, "/admin/shows/import/confirm", showHandler.ImportShowConfirmHandler)
 
 	// Admin show export/import endpoints (bulk - for CLI)
-	huma.Post(protected, "/admin/shows/export/bulk", showHandler.BulkExportShowsHandler)
-	huma.Post(protected, "/admin/shows/import/bulk/preview", showHandler.BulkImportPreviewHandler)
-	huma.Post(protected, "/admin/shows/import/bulk/confirm", showHandler.BulkImportConfirmHandler)
+	huma.Post(rc.Protected, "/admin/shows/export/bulk", showHandler.BulkExportShowsHandler)
+	huma.Post(rc.Protected, "/admin/shows/import/bulk/preview", showHandler.BulkImportPreviewHandler)
+	huma.Post(rc.Protected, "/admin/shows/import/bulk/confirm", showHandler.BulkImportConfirmHandler)
 
 	// Admin venue management endpoints
-	huma.Get(protected, "/admin/venues/unverified", venueHandler.GetUnverifiedVenuesHandler)
-	huma.Post(protected, "/admin/venues/{venue_id}/verify", venueHandler.VerifyVenueHandler)
+	huma.Get(rc.Protected, "/admin/venues/unverified", venueHandler.GetUnverifiedVenuesHandler)
+	huma.Post(rc.Protected, "/admin/venues/{venue_id}/verify", venueHandler.VerifyVenueHandler)
 
 	// Admin pending venue edit endpoints
-	huma.Get(protected, "/admin/venues/pending-edits", venueHandler.GetPendingVenueEditsHandler)
-	huma.Post(protected, "/admin/venues/pending-edits/{edit_id}/approve", venueHandler.ApproveVenueEditHandler)
-	huma.Post(protected, "/admin/venues/pending-edits/{edit_id}/reject", venueHandler.RejectVenueEditHandler)
+	huma.Get(rc.Protected, "/admin/venues/pending-edits", venueHandler.GetPendingVenueEditsHandler)
+	huma.Post(rc.Protected, "/admin/venues/pending-edits/{edit_id}/approve", venueHandler.ApproveVenueEditHandler)
+	huma.Post(rc.Protected, "/admin/venues/pending-edits/{edit_id}/reject", venueHandler.RejectVenueEditHandler)
 
 	// Admin artist management endpoints
-	huma.Patch(protected, "/admin/artists/{artist_id}/bandcamp", artistHandler.UpdateArtistBandcampHandler)
-	huma.Patch(protected, "/admin/artists/{artist_id}/spotify", artistHandler.UpdateArtistSpotifyHandler)
+	huma.Patch(rc.Protected, "/admin/artists/{artist_id}/bandcamp", artistHandler.UpdateArtistBandcampHandler)
+	huma.Patch(rc.Protected, "/admin/artists/{artist_id}/spotify", artistHandler.UpdateArtistSpotifyHandler)
 
 	// Admin discovery endpoints (for local discovery app)
-	huma.Post(protected, "/admin/discovery/import", discoveryHandler.DiscoveryImportHandler)
-	huma.Post(protected, "/admin/discovery/check", discoveryHandler.DiscoveryCheckHandler)
+	huma.Post(rc.Protected, "/admin/discovery/import", discoveryHandler.DiscoveryImportHandler)
+	huma.Post(rc.Protected, "/admin/discovery/check", discoveryHandler.DiscoveryCheckHandler)
 
 	// Admin API token management endpoints
-	huma.Post(protected, "/admin/tokens", tokenHandler.CreateAPITokenHandler)
-	huma.Get(protected, "/admin/tokens", tokenHandler.ListAPITokensHandler)
-	huma.Delete(protected, "/admin/tokens/{token_id}", tokenHandler.RevokeAPITokenHandler)
+	huma.Post(rc.Protected, "/admin/tokens", tokenHandler.CreateAPITokenHandler)
+	huma.Get(rc.Protected, "/admin/tokens", tokenHandler.ListAPITokensHandler)
+	huma.Delete(rc.Protected, "/admin/tokens/{token_id}", tokenHandler.RevokeAPITokenHandler)
 
 	// Admin data export endpoints (for syncing local data to Stage/Production)
-	huma.Get(protected, "/admin/export/shows", dataHandler.ExportShowsHandler)
-	huma.Get(protected, "/admin/export/artists", dataHandler.ExportArtistsHandler)
-	huma.Get(protected, "/admin/export/venues", dataHandler.ExportVenuesHandler)
+	huma.Get(rc.Protected, "/admin/export/shows", dataHandler.ExportShowsHandler)
+	huma.Get(rc.Protected, "/admin/export/artists", dataHandler.ExportArtistsHandler)
+	huma.Get(rc.Protected, "/admin/export/venues", dataHandler.ExportVenuesHandler)
 
 	// Admin data import endpoint (for syncing local data to Stage/Production)
-	huma.Post(protected, "/admin/data/import", dataHandler.DataImportHandler)
+	huma.Post(rc.Protected, "/admin/data/import", dataHandler.DataImportHandler)
 
 	// Admin audit log endpoint
-	huma.Get(protected, "/admin/audit-logs", auditLogHandler.GetAuditLogsHandler)
+	huma.Get(rc.Protected, "/admin/audit-logs", auditLogHandler.GetAuditLogsHandler)
 
 	// Admin user list endpoint
-	huma.Get(protected, "/admin/users", userHandler.GetAdminUsersHandler)
+	huma.Get(rc.Protected, "/admin/users", userHandler.GetAdminUsersHandler)
 
 	// Admin data quality endpoints
-	dataQualityHandler := handlers.NewDataQualityHandler(sc.DataQuality)
-	huma.Get(protected, "/admin/data-quality", dataQualityHandler.GetDataQualitySummaryHandler)
-	huma.Get(protected, "/admin/data-quality/{category}", dataQualityHandler.GetDataQualityCategoryHandler)
+	dataQualityHandler := handlers.NewDataQualityHandler(rc.SC.DataQuality)
+	huma.Get(rc.Protected, "/admin/data-quality", dataQualityHandler.GetDataQualitySummaryHandler)
+	huma.Get(rc.Protected, "/admin/data-quality/{category}", dataQualityHandler.GetDataQualityCategoryHandler)
 
 	// Admin analytics endpoints
-	analyticsHandler := handlers.NewAnalyticsHandler(sc.Analytics)
-	huma.Get(protected, "/admin/analytics/growth", analyticsHandler.GetGrowthMetricsHandler)
-	huma.Get(protected, "/admin/analytics/engagement", analyticsHandler.GetEngagementMetricsHandler)
-	huma.Get(protected, "/admin/analytics/community", analyticsHandler.GetCommunityHealthHandler)
-	huma.Get(protected, "/admin/analytics/data-quality", analyticsHandler.GetDataQualityTrendsHandler)
+	analyticsHandler := handlers.NewAnalyticsHandler(rc.SC.Analytics)
+	huma.Get(rc.Protected, "/admin/analytics/growth", analyticsHandler.GetGrowthMetricsHandler)
+	huma.Get(rc.Protected, "/admin/analytics/engagement", analyticsHandler.GetEngagementMetricsHandler)
+	huma.Get(rc.Protected, "/admin/analytics/community", analyticsHandler.GetCommunityHealthHandler)
+	huma.Get(rc.Protected, "/admin/analytics/data-quality", analyticsHandler.GetDataQualityTrendsHandler)
 }
 
 // setupContributorProfileRoutes configures contributor profile endpoints
-func setupContributorProfileRoutes(api huma.API, protected *huma.Group, sc *services.ServiceContainer) {
-	profileHandler := handlers.NewContributorProfileHandler(sc.ContributorProfile, sc.User)
+func setupContributorProfileRoutes(rc RouteContext) {
+	profileHandler := handlers.NewContributorProfileHandler(rc.SC.ContributorProfile, rc.SC.User)
 
 	// Public profile endpoints with optional auth (so profile owner can see their own private profile)
-	optionalAuthGroup := huma.NewGroup(api, "")
-	optionalAuthGroup.UseMiddleware(middleware.OptionalHumaJWTMiddleware(sc.JWT))
+	optionalAuthGroup := huma.NewGroup(rc.API, "")
+	optionalAuthGroup.UseMiddleware(middleware.OptionalHumaJWTMiddleware(rc.SC.JWT))
 	huma.Get(optionalAuthGroup, "/users/{username}", profileHandler.GetPublicProfileHandler)
 	huma.Get(optionalAuthGroup, "/users/{username}/contributions", profileHandler.GetContributionHistoryHandler)
 	huma.Get(optionalAuthGroup, "/users/{username}/sections", profileHandler.GetUserSectionsHandler)
 
 	// Protected endpoints for authenticated user's own profile
-	huma.Get(protected, "/auth/profile/contributor", profileHandler.GetOwnProfileHandler)
-	huma.Get(protected, "/auth/profile/contributions", profileHandler.GetOwnContributionsHandler)
-	huma.Patch(protected, "/auth/profile/visibility", profileHandler.UpdateProfileVisibilityHandler)
-	huma.Patch(protected, "/auth/profile/privacy", profileHandler.UpdatePrivacySettingsHandler)
-	huma.Get(protected, "/auth/profile/sections", profileHandler.GetOwnSectionsHandler)
-	huma.Post(protected, "/auth/profile/sections", profileHandler.CreateSectionHandler)
-	huma.Put(protected, "/auth/profile/sections/{section_id}", profileHandler.UpdateSectionHandler)
-	huma.Delete(protected, "/auth/profile/sections/{section_id}", profileHandler.DeleteSectionHandler)
+	huma.Get(rc.Protected, "/auth/profile/contributor", profileHandler.GetOwnProfileHandler)
+	huma.Get(rc.Protected, "/auth/profile/contributions", profileHandler.GetOwnContributionsHandler)
+	huma.Patch(rc.Protected, "/auth/profile/visibility", profileHandler.UpdateProfileVisibilityHandler)
+	huma.Patch(rc.Protected, "/auth/profile/privacy", profileHandler.UpdatePrivacySettingsHandler)
+	huma.Get(rc.Protected, "/auth/profile/sections", profileHandler.GetOwnSectionsHandler)
+	huma.Post(rc.Protected, "/auth/profile/sections", profileHandler.CreateSectionHandler)
+	huma.Put(rc.Protected, "/auth/profile/sections/{section_id}", profileHandler.UpdateSectionHandler)
+	huma.Delete(rc.Protected, "/auth/profile/sections/{section_id}", profileHandler.DeleteSectionHandler)
 }
 
 // setupPipelineRoutes configures AI extraction pipeline admin endpoints.
 // Admin check is performed inside handlers, JWT auth is required via protected group.
-func setupPipelineRoutes(protected *huma.Group, sc *services.ServiceContainer) {
-	pipelineHandler := handlers.NewPipelineHandler(sc.Pipeline, sc.VenueSourceConfig, sc.Enrichment)
+func setupPipelineRoutes(rc RouteContext) {
+	pipelineHandler := handlers.NewPipelineHandler(rc.SC.Pipeline, rc.SC.VenueSourceConfig, rc.SC.Enrichment)
 
-	huma.Post(protected, "/admin/pipeline/extract/{venue_id}", pipelineHandler.ExtractVenueHandler)
-	huma.Get(protected, "/admin/pipeline/imports", pipelineHandler.GetImportHistoryHandler)
-	huma.Get(protected, "/admin/pipeline/venues", pipelineHandler.ListPipelineVenuesHandler)
-	huma.Get(protected, "/admin/pipeline/venues/{venue_id}/stats", pipelineHandler.VenueRejectionStatsHandler)
-	huma.Patch(protected, "/admin/pipeline/venues/{venue_id}/notes", pipelineHandler.UpdateExtractionNotesHandler)
-	huma.Put(protected, "/admin/pipeline/venues/{venue_id}/config", pipelineHandler.UpdateVenueConfigHandler)
-	huma.Get(protected, "/admin/pipeline/venues/{venue_id}/runs", pipelineHandler.GetVenueRunsHandler)
-	huma.Post(protected, "/admin/pipeline/venues/{venue_id}/reset-render-method", pipelineHandler.ResetRenderMethodHandler)
-	huma.Get(protected, "/admin/pipeline/enrichment/status", pipelineHandler.EnrichmentStatusHandler)
-	huma.Post(protected, "/admin/pipeline/enrichment/trigger/{show_id}", pipelineHandler.TriggerEnrichmentHandler)
+	huma.Post(rc.Protected, "/admin/pipeline/extract/{venue_id}", pipelineHandler.ExtractVenueHandler)
+	huma.Get(rc.Protected, "/admin/pipeline/imports", pipelineHandler.GetImportHistoryHandler)
+	huma.Get(rc.Protected, "/admin/pipeline/venues", pipelineHandler.ListPipelineVenuesHandler)
+	huma.Get(rc.Protected, "/admin/pipeline/venues/{venue_id}/stats", pipelineHandler.VenueRejectionStatsHandler)
+	huma.Patch(rc.Protected, "/admin/pipeline/venues/{venue_id}/notes", pipelineHandler.UpdateExtractionNotesHandler)
+	huma.Put(rc.Protected, "/admin/pipeline/venues/{venue_id}/config", pipelineHandler.UpdateVenueConfigHandler)
+	huma.Get(rc.Protected, "/admin/pipeline/venues/{venue_id}/runs", pipelineHandler.GetVenueRunsHandler)
+	huma.Post(rc.Protected, "/admin/pipeline/venues/{venue_id}/reset-render-method", pipelineHandler.ResetRenderMethodHandler)
+	huma.Get(rc.Protected, "/admin/pipeline/enrichment/status", pipelineHandler.EnrichmentStatusHandler)
+	huma.Post(rc.Protected, "/admin/pipeline/enrichment/trigger/{show_id}", pipelineHandler.TriggerEnrichmentHandler)
 }
 
 // setupCollectionRoutes configures crate (formerly "collection") endpoints.
 // Both /crates/ and /collections/ paths are registered for backward compatibility.
 // Public endpoints use optional auth (for private crate access checks).
 // CRUD, item management, and subscription endpoints require authentication.
-func setupCollectionRoutes(api huma.API, protected *huma.Group, sc *services.ServiceContainer) {
-	collectionHandler := handlers.NewCollectionHandler(sc.Collection, sc.AuditLog)
+func setupCollectionRoutes(rc RouteContext) {
+	collectionHandler := handlers.NewCollectionHandler(rc.SC.Collection, rc.SC.AuditLog)
 
 	// Public crate endpoints with optional auth
-	optionalAuthGroup := huma.NewGroup(api, "")
-	optionalAuthGroup.UseMiddleware(middleware.OptionalHumaJWTMiddleware(sc.JWT))
+	optionalAuthGroup := huma.NewGroup(rc.API, "")
+	optionalAuthGroup.UseMiddleware(middleware.OptionalHumaJWTMiddleware(rc.SC.JWT))
 
 	// Canonical /crates/ paths
 	huma.Get(optionalAuthGroup, "/crates", collectionHandler.ListCollectionsHandler)
@@ -635,174 +655,174 @@ func setupCollectionRoutes(api huma.API, protected *huma.Group, sc *services.Ser
 	huma.Get(optionalAuthGroup, "/collections/{slug}/stats", collectionHandler.GetCollectionStatsHandler)
 
 	// Protected crate endpoints — canonical /crates/ paths
-	huma.Post(protected, "/crates", collectionHandler.CreateCollectionHandler)
-	huma.Put(protected, "/crates/{slug}", collectionHandler.UpdateCollectionHandler)
-	huma.Delete(protected, "/crates/{slug}", collectionHandler.DeleteCollectionHandler)
+	huma.Post(rc.Protected, "/crates", collectionHandler.CreateCollectionHandler)
+	huma.Put(rc.Protected, "/crates/{slug}", collectionHandler.UpdateCollectionHandler)
+	huma.Delete(rc.Protected, "/crates/{slug}", collectionHandler.DeleteCollectionHandler)
 
 	// Protected crate endpoints — legacy /collections/ paths (backward compat)
-	huma.Post(protected, "/collections", collectionHandler.CreateCollectionHandler)
-	huma.Put(protected, "/collections/{slug}", collectionHandler.UpdateCollectionHandler)
-	huma.Delete(protected, "/collections/{slug}", collectionHandler.DeleteCollectionHandler)
+	huma.Post(rc.Protected, "/collections", collectionHandler.CreateCollectionHandler)
+	huma.Put(rc.Protected, "/collections/{slug}", collectionHandler.UpdateCollectionHandler)
+	huma.Delete(rc.Protected, "/collections/{slug}", collectionHandler.DeleteCollectionHandler)
 
 	// Crate item management — canonical /crates/ paths
-	huma.Post(protected, "/crates/{slug}/items", collectionHandler.AddItemHandler)
-	huma.Delete(protected, "/crates/{slug}/items/{item_id}", collectionHandler.RemoveItemHandler)
-	huma.Put(protected, "/crates/{slug}/items/reorder", collectionHandler.ReorderItemsHandler)
+	huma.Post(rc.Protected, "/crates/{slug}/items", collectionHandler.AddItemHandler)
+	huma.Delete(rc.Protected, "/crates/{slug}/items/{item_id}", collectionHandler.RemoveItemHandler)
+	huma.Put(rc.Protected, "/crates/{slug}/items/reorder", collectionHandler.ReorderItemsHandler)
 
 	// Crate item management — legacy /collections/ paths (backward compat)
-	huma.Post(protected, "/collections/{slug}/items", collectionHandler.AddItemHandler)
-	huma.Delete(protected, "/collections/{slug}/items/{item_id}", collectionHandler.RemoveItemHandler)
-	huma.Put(protected, "/collections/{slug}/items/reorder", collectionHandler.ReorderItemsHandler)
+	huma.Post(rc.Protected, "/collections/{slug}/items", collectionHandler.AddItemHandler)
+	huma.Delete(rc.Protected, "/collections/{slug}/items/{item_id}", collectionHandler.RemoveItemHandler)
+	huma.Put(rc.Protected, "/collections/{slug}/items/reorder", collectionHandler.ReorderItemsHandler)
 
 	// Crate subscription — canonical /crates/ paths
-	huma.Post(protected, "/crates/{slug}/subscribe", collectionHandler.SubscribeHandler)
-	huma.Delete(protected, "/crates/{slug}/subscribe", collectionHandler.UnsubscribeHandler)
+	huma.Post(rc.Protected, "/crates/{slug}/subscribe", collectionHandler.SubscribeHandler)
+	huma.Delete(rc.Protected, "/crates/{slug}/subscribe", collectionHandler.UnsubscribeHandler)
 
 	// Crate subscription — legacy /collections/ paths (backward compat)
-	huma.Post(protected, "/collections/{slug}/subscribe", collectionHandler.SubscribeHandler)
-	huma.Delete(protected, "/collections/{slug}/subscribe", collectionHandler.UnsubscribeHandler)
+	huma.Post(rc.Protected, "/collections/{slug}/subscribe", collectionHandler.SubscribeHandler)
+	huma.Delete(rc.Protected, "/collections/{slug}/subscribe", collectionHandler.UnsubscribeHandler)
 
 	// Admin: feature/unfeature crates — canonical /crates/ paths
-	huma.Put(protected, "/crates/{slug}/feature", collectionHandler.SetFeaturedHandler)
+	huma.Put(rc.Protected, "/crates/{slug}/feature", collectionHandler.SetFeaturedHandler)
 
 	// Admin: feature/unfeature crates — legacy /collections/ paths (backward compat)
-	huma.Put(protected, "/collections/{slug}/feature", collectionHandler.SetFeaturedHandler)
+	huma.Put(rc.Protected, "/collections/{slug}/feature", collectionHandler.SetFeaturedHandler)
 
 	// User's own crates (created + subscribed)
-	huma.Get(protected, "/auth/crates", collectionHandler.GetUserCollectionsHandler)
+	huma.Get(rc.Protected, "/auth/crates", collectionHandler.GetUserCollectionsHandler)
 
 	// Legacy user crates path (backward compat)
-	huma.Get(protected, "/auth/collections", collectionHandler.GetUserCollectionsHandler)
+	huma.Get(rc.Protected, "/auth/collections", collectionHandler.GetUserCollectionsHandler)
 }
 
 // setupRequestRoutes configures community request endpoints.
 // Public endpoints use optional auth (so authenticated users see their vote).
 // CRUD, voting, fulfillment, and closing require authentication.
-func setupRequestRoutes(api huma.API, protected *huma.Group, sc *services.ServiceContainer) {
-	requestHandler := handlers.NewRequestHandler(sc.Request, sc.AuditLog)
+func setupRequestRoutes(rc RouteContext) {
+	requestHandler := handlers.NewRequestHandler(rc.SC.Request, rc.SC.AuditLog)
 
 	// Public request endpoints with optional auth (to include user's vote)
-	optionalAuthGroup := huma.NewGroup(api, "")
-	optionalAuthGroup.UseMiddleware(middleware.OptionalHumaJWTMiddleware(sc.JWT))
+	optionalAuthGroup := huma.NewGroup(rc.API, "")
+	optionalAuthGroup.UseMiddleware(middleware.OptionalHumaJWTMiddleware(rc.SC.JWT))
 	huma.Get(optionalAuthGroup, "/requests", requestHandler.ListRequestsHandler)
 	huma.Get(optionalAuthGroup, "/requests/{request_id}", requestHandler.GetRequestHandler)
 
 	// Protected request endpoints
-	huma.Post(protected, "/requests", requestHandler.CreateRequestHandler)
-	huma.Put(protected, "/requests/{request_id}", requestHandler.UpdateRequestHandler)
-	huma.Delete(protected, "/requests/{request_id}", requestHandler.DeleteRequestHandler)
-	huma.Post(protected, "/requests/{request_id}/vote", requestHandler.VoteRequestHandler)
-	huma.Delete(protected, "/requests/{request_id}/vote", requestHandler.RemoveVoteRequestHandler)
-	huma.Post(protected, "/requests/{request_id}/fulfill", requestHandler.FulfillRequestHandler)
-	huma.Post(protected, "/requests/{request_id}/close", requestHandler.CloseRequestHandler)
+	huma.Post(rc.Protected, "/requests", requestHandler.CreateRequestHandler)
+	huma.Put(rc.Protected, "/requests/{request_id}", requestHandler.UpdateRequestHandler)
+	huma.Delete(rc.Protected, "/requests/{request_id}", requestHandler.DeleteRequestHandler)
+	huma.Post(rc.Protected, "/requests/{request_id}/vote", requestHandler.VoteRequestHandler)
+	huma.Delete(rc.Protected, "/requests/{request_id}/vote", requestHandler.RemoveVoteRequestHandler)
+	huma.Post(rc.Protected, "/requests/{request_id}/fulfill", requestHandler.FulfillRequestHandler)
+	huma.Post(rc.Protected, "/requests/{request_id}/close", requestHandler.CloseRequestHandler)
 }
 
 // setupRevisionRoutes configures revision history endpoints.
 // Public endpoints for viewing history; admin endpoint for rollback.
-func setupRevisionRoutes(api huma.API, protected *huma.Group, sc *services.ServiceContainer) {
-	revisionHandler := handlers.NewRevisionHandler(sc.Revision, sc.AuditLog)
+func setupRevisionRoutes(rc RouteContext) {
+	revisionHandler := handlers.NewRevisionHandler(rc.SC.Revision, rc.SC.AuditLog)
 
 	// Public revision endpoints
-	huma.Get(api, "/revisions/{entity_type}/{entity_id}", revisionHandler.GetEntityHistoryHandler)
-	huma.Get(api, "/revisions/{revision_id}", revisionHandler.GetRevisionHandler)
-	huma.Get(api, "/users/{user_id}/revisions", revisionHandler.GetUserRevisionsHandler)
+	huma.Get(rc.API, "/revisions/{entity_type}/{entity_id}", revisionHandler.GetEntityHistoryHandler)
+	huma.Get(rc.API, "/revisions/{revision_id}", revisionHandler.GetRevisionHandler)
+	huma.Get(rc.API, "/users/{user_id}/revisions", revisionHandler.GetUserRevisionsHandler)
 
 	// Admin rollback endpoint
-	huma.Post(protected, "/admin/revisions/{revision_id}/rollback", revisionHandler.RollbackRevisionHandler)
+	huma.Post(rc.Protected, "/admin/revisions/{revision_id}/rollback", revisionHandler.RollbackRevisionHandler)
 }
 
 // setupTagRoutes configures tag, entity tagging, and tag voting endpoints.
 // Public endpoints for browsing tags. Optional auth for entity tags (user's vote).
 // Protected endpoints for tagging and voting. Admin endpoints for tag CRUD and aliases.
-func setupTagRoutes(api huma.API, protected *huma.Group, sc *services.ServiceContainer) {
-	tagHandler := handlers.NewTagHandler(sc.Tag, sc.AuditLog)
+func setupTagRoutes(rc RouteContext) {
+	tagHandler := handlers.NewTagHandler(rc.SC.Tag, rc.SC.AuditLog)
 
 	// Public tag endpoints
-	huma.Get(api, "/tags", tagHandler.ListTagsHandler)
-	huma.Get(api, "/tags/search", tagHandler.SearchTagsHandler)
-	huma.Get(api, "/tags/{tag_id}", tagHandler.GetTagHandler)
-	huma.Get(api, "/tags/{tag_id}/aliases", tagHandler.ListAliasesHandler)
+	huma.Get(rc.API, "/tags", tagHandler.ListTagsHandler)
+	huma.Get(rc.API, "/tags/search", tagHandler.SearchTagsHandler)
+	huma.Get(rc.API, "/tags/{tag_id}", tagHandler.GetTagHandler)
+	huma.Get(rc.API, "/tags/{tag_id}/aliases", tagHandler.ListAliasesHandler)
 
 	// Entity tags with optional auth (includes user's vote if authenticated)
-	optionalAuthGroup := huma.NewGroup(api, "")
-	optionalAuthGroup.UseMiddleware(middleware.OptionalHumaJWTMiddleware(sc.JWT))
+	optionalAuthGroup := huma.NewGroup(rc.API, "")
+	optionalAuthGroup.UseMiddleware(middleware.OptionalHumaJWTMiddleware(rc.SC.JWT))
 	huma.Get(optionalAuthGroup, "/entities/{entity_type}/{entity_id}/tags", tagHandler.ListEntityTagsHandler)
 
 	// Protected: tagging and voting
-	huma.Post(protected, "/entities/{entity_type}/{entity_id}/tags", tagHandler.AddTagToEntityHandler)
-	huma.Delete(protected, "/entities/{entity_type}/{entity_id}/tags/{tag_id}", tagHandler.RemoveTagFromEntityHandler)
-	huma.Post(protected, "/tags/{tag_id}/entities/{entity_type}/{entity_id}/votes", tagHandler.VoteTagHandler)
-	huma.Delete(protected, "/tags/{tag_id}/entities/{entity_type}/{entity_id}/votes", tagHandler.RemoveTagVoteHandler)
+	huma.Post(rc.Protected, "/entities/{entity_type}/{entity_id}/tags", tagHandler.AddTagToEntityHandler)
+	huma.Delete(rc.Protected, "/entities/{entity_type}/{entity_id}/tags/{tag_id}", tagHandler.RemoveTagFromEntityHandler)
+	huma.Post(rc.Protected, "/tags/{tag_id}/entities/{entity_type}/{entity_id}/votes", tagHandler.VoteTagHandler)
+	huma.Delete(rc.Protected, "/tags/{tag_id}/entities/{entity_type}/{entity_id}/votes", tagHandler.RemoveTagVoteHandler)
 
 	// Admin: tag CRUD and alias management
-	huma.Post(protected, "/tags", tagHandler.CreateTagHandler)
-	huma.Put(protected, "/tags/{tag_id}", tagHandler.UpdateTagHandler)
-	huma.Delete(protected, "/tags/{tag_id}", tagHandler.DeleteTagHandler)
-	huma.Post(protected, "/tags/{tag_id}/aliases", tagHandler.CreateAliasHandler)
-	huma.Delete(protected, "/tags/{tag_id}/aliases/{alias_id}", tagHandler.DeleteAliasHandler)
+	huma.Post(rc.Protected, "/tags", tagHandler.CreateTagHandler)
+	huma.Put(rc.Protected, "/tags/{tag_id}", tagHandler.UpdateTagHandler)
+	huma.Delete(rc.Protected, "/tags/{tag_id}", tagHandler.DeleteTagHandler)
+	huma.Post(rc.Protected, "/tags/{tag_id}/aliases", tagHandler.CreateAliasHandler)
+	huma.Delete(rc.Protected, "/tags/{tag_id}/aliases/{alias_id}", tagHandler.DeleteAliasHandler)
 }
 
 // setupArtistRelationshipRoutes configures artist relationship and similar artist endpoints.
-func setupArtistRelationshipRoutes(api huma.API, protected *huma.Group, sc *services.ServiceContainer) {
-	relHandler := handlers.NewArtistRelationshipHandler(sc.ArtistRelationship, sc.AuditLog)
+func setupArtistRelationshipRoutes(rc RouteContext) {
+	relHandler := handlers.NewArtistRelationshipHandler(rc.SC.ArtistRelationship, rc.SC.AuditLog)
 
 	// Public: get related artists with optional auth (for user's votes)
-	optionalAuthGroup := huma.NewGroup(api, "")
-	optionalAuthGroup.UseMiddleware(middleware.OptionalHumaJWTMiddleware(sc.JWT))
+	optionalAuthGroup := huma.NewGroup(rc.API, "")
+	optionalAuthGroup.UseMiddleware(middleware.OptionalHumaJWTMiddleware(rc.SC.JWT))
 	huma.Get(optionalAuthGroup, "/artists/{artist_id}/related", relHandler.GetRelatedArtistsHandler)
 	huma.Get(optionalAuthGroup, "/artists/{artist_id}/graph", relHandler.GetArtistGraphHandler)
 
 	// Protected: create relationships and vote
-	huma.Post(protected, "/artists/relationships", relHandler.CreateRelationshipHandler)
-	huma.Post(protected, "/artists/relationships/{source_id}/{target_id}/vote", relHandler.VoteHandler)
-	huma.Delete(protected, "/artists/relationships/{source_id}/{target_id}/vote", relHandler.RemoveVoteHandler)
+	huma.Post(rc.Protected, "/artists/relationships", relHandler.CreateRelationshipHandler)
+	huma.Post(rc.Protected, "/artists/relationships/{source_id}/{target_id}/vote", relHandler.VoteHandler)
+	huma.Delete(rc.Protected, "/artists/relationships/{source_id}/{target_id}/vote", relHandler.RemoveVoteHandler)
 
 	// Admin: delete relationships
-	huma.Delete(protected, "/artists/relationships/{source_id}/{target_id}", relHandler.DeleteRelationshipHandler)
+	huma.Delete(rc.Protected, "/artists/relationships/{source_id}/{target_id}", relHandler.DeleteRelationshipHandler)
 }
 
 // setupSceneRoutes configures scene (city aggregation) endpoints.
 // All endpoints are public — no authentication required.
-func setupSceneRoutes(api huma.API, sc *services.ServiceContainer) {
-	sceneHandler := handlers.NewSceneHandler(sc.Scene)
+func setupSceneRoutes(rc RouteContext) {
+	sceneHandler := handlers.NewSceneHandler(rc.SC.Scene)
 
-	huma.Get(api, "/scenes", sceneHandler.ListScenesHandler)
-	huma.Get(api, "/scenes/{slug}", sceneHandler.GetSceneDetailHandler)
-	huma.Get(api, "/scenes/{slug}/artists", sceneHandler.GetSceneActiveArtistsHandler)
-	huma.Get(api, "/scenes/{slug}/genres", sceneHandler.GetSceneGenresHandler)
+	huma.Get(rc.API, "/scenes", sceneHandler.ListScenesHandler)
+	huma.Get(rc.API, "/scenes/{slug}", sceneHandler.GetSceneDetailHandler)
+	huma.Get(rc.API, "/scenes/{slug}/artists", sceneHandler.GetSceneActiveArtistsHandler)
+	huma.Get(rc.API, "/scenes/{slug}/genres", sceneHandler.GetSceneGenresHandler)
 }
 
 // setupAttendanceRoutes configures show attendance (going/interested) endpoints.
 // Public endpoints use optional auth (counts always available; user status if authenticated).
 // Set/remove attendance requires authentication.
-func setupAttendanceRoutes(api huma.API, protected *huma.Group, sc *services.ServiceContainer) {
-	attendanceHandler := handlers.NewAttendanceHandler(sc.Attendance)
+func setupAttendanceRoutes(rc RouteContext) {
+	attendanceHandler := handlers.NewAttendanceHandler(rc.SC.Attendance)
 
 	// Public endpoints with optional auth (counts + user status if authenticated)
-	optionalAuthGroup := huma.NewGroup(api, "")
-	optionalAuthGroup.UseMiddleware(middleware.OptionalHumaJWTMiddleware(sc.JWT))
+	optionalAuthGroup := huma.NewGroup(rc.API, "")
+	optionalAuthGroup.UseMiddleware(middleware.OptionalHumaJWTMiddleware(rc.SC.JWT))
 	huma.Get(optionalAuthGroup, "/shows/{show_id}/attendance", attendanceHandler.GetAttendanceHandler)
 	huma.Post(optionalAuthGroup, "/shows/attendance/batch", attendanceHandler.BatchAttendanceHandler)
 
 	// Protected endpoints (require authentication)
-	huma.Post(protected, "/shows/{show_id}/attendance", attendanceHandler.SetAttendanceHandler)
-	huma.Delete(protected, "/shows/{show_id}/attendance", attendanceHandler.RemoveAttendanceHandler)
-	huma.Get(protected, "/attendance/my-shows", attendanceHandler.GetMyShowsHandler)
+	huma.Post(rc.Protected, "/shows/{show_id}/attendance", attendanceHandler.SetAttendanceHandler)
+	huma.Delete(rc.Protected, "/shows/{show_id}/attendance", attendanceHandler.RemoveAttendanceHandler)
+	huma.Get(rc.Protected, "/attendance/my-shows", attendanceHandler.GetMyShowsHandler)
 }
 
 // setupFollowRoutes configures follow/unfollow endpoints for entities.
 // Follow/unfollow requires authentication. Follower counts use optional auth
 // (counts always available; user follow status if authenticated).
-func setupFollowRoutes(api huma.API, protected *huma.Group, sc *services.ServiceContainer) {
-	followHandler := handlers.NewFollowHandler(sc.Follow)
+func setupFollowRoutes(rc RouteContext) {
+	followHandler := handlers.NewFollowHandler(rc.SC.Follow)
 
 	// Optional auth group for public follower counts/lists
-	optionalAuthGroup := huma.NewGroup(api, "")
-	optionalAuthGroup.UseMiddleware(middleware.OptionalHumaJWTMiddleware(sc.JWT))
+	optionalAuthGroup := huma.NewGroup(rc.API, "")
+	optionalAuthGroup.UseMiddleware(middleware.OptionalHumaJWTMiddleware(rc.SC.JWT))
 
 	// Follow/unfollow (protected): entity_type is a path param (artists, venues, labels, festivals)
-	huma.Post(protected, "/{entity_type}/{entity_id}/follow", followHandler.FollowEntityHandler)
-	huma.Delete(protected, "/{entity_type}/{entity_id}/follow", followHandler.UnfollowEntityHandler)
+	huma.Post(rc.Protected, "/{entity_type}/{entity_id}/follow", followHandler.FollowEntityHandler)
+	huma.Delete(rc.Protected, "/{entity_type}/{entity_id}/follow", followHandler.UnfollowEntityHandler)
 
 	// Public with optional auth: follower count + user follow status
 	huma.Get(optionalAuthGroup, "/{entity_type}/{entity_id}/followers", followHandler.GetFollowersHandler)
@@ -814,38 +834,38 @@ func setupFollowRoutes(api huma.API, protected *huma.Group, sc *services.Service
 	huma.Post(optionalAuthGroup, "/follows/batch", followHandler.BatchFollowHandler)
 
 	// User's following list (protected)
-	huma.Get(protected, "/me/following", followHandler.GetMyFollowingHandler)
+	huma.Get(rc.Protected, "/me/following", followHandler.GetMyFollowingHandler)
 }
 
 // setupNotificationFilterRoutes configures notification filter and notification log endpoints.
 // CRUD and notifications require authentication. Unsubscribe is public (HMAC-signed).
-func setupNotificationFilterRoutes(api huma.API, protected *huma.Group, sc *services.ServiceContainer, cfg *config.Config) {
-	filterHandler := handlers.NewNotificationFilterHandler(sc.NotificationFilter, cfg.JWT.SecretKey)
+func setupNotificationFilterRoutes(rc RouteContext) {
+	filterHandler := handlers.NewNotificationFilterHandler(rc.SC.NotificationFilter, rc.Cfg.JWT.SecretKey)
 
 	// Protected: filter CRUD
-	huma.Get(protected, "/me/notification-filters", filterHandler.ListFiltersHandler)
-	huma.Post(protected, "/me/notification-filters", filterHandler.CreateFilterHandler)
-	huma.Patch(protected, "/me/notification-filters/{id}", filterHandler.UpdateFilterHandler)
-	huma.Delete(protected, "/me/notification-filters/{id}", filterHandler.DeleteFilterHandler)
-	huma.Post(protected, "/me/notification-filters/quick", filterHandler.QuickCreateFilterHandler)
+	huma.Get(rc.Protected, "/me/notification-filters", filterHandler.ListFiltersHandler)
+	huma.Post(rc.Protected, "/me/notification-filters", filterHandler.CreateFilterHandler)
+	huma.Patch(rc.Protected, "/me/notification-filters/{id}", filterHandler.UpdateFilterHandler)
+	huma.Delete(rc.Protected, "/me/notification-filters/{id}", filterHandler.DeleteFilterHandler)
+	huma.Post(rc.Protected, "/me/notification-filters/quick", filterHandler.QuickCreateFilterHandler)
 
 	// Protected: notification log
-	huma.Get(protected, "/me/notifications", filterHandler.GetNotificationsHandler)
+	huma.Get(rc.Protected, "/me/notifications", filterHandler.GetNotificationsHandler)
 
 	// Public: HMAC-signed unsubscribe
-	huma.Post(api, "/unsubscribe/filter/{id}", filterHandler.UnsubscribeFilterHandler)
+	huma.Post(rc.API, "/unsubscribe/filter/{id}", filterHandler.UnsubscribeFilterHandler)
 }
 
 // setupChartsRoutes configures public top charts endpoints.
 // All endpoints are public — no authentication required.
-func setupChartsRoutes(api huma.API, sc *services.ServiceContainer) {
-	chartsHandler := handlers.NewChartsHandler(sc.Charts)
+func setupChartsRoutes(rc RouteContext) {
+	chartsHandler := handlers.NewChartsHandler(rc.SC.Charts)
 
-	huma.Get(api, "/charts/trending-shows", chartsHandler.GetTrendingShowsHandler)
-	huma.Get(api, "/charts/popular-artists", chartsHandler.GetPopularArtistsHandler)
-	huma.Get(api, "/charts/active-venues", chartsHandler.GetActiveVenuesHandler)
-	huma.Get(api, "/charts/hot-releases", chartsHandler.GetHotReleasesHandler)
-	huma.Get(api, "/charts/overview", chartsHandler.GetChartsOverviewHandler)
+	huma.Get(rc.API, "/charts/trending-shows", chartsHandler.GetTrendingShowsHandler)
+	huma.Get(rc.API, "/charts/popular-artists", chartsHandler.GetPopularArtistsHandler)
+	huma.Get(rc.API, "/charts/active-venues", chartsHandler.GetActiveVenuesHandler)
+	huma.Get(rc.API, "/charts/hot-releases", chartsHandler.GetHotReleasesHandler)
+	huma.Get(rc.API, "/charts/overview", chartsHandler.GetChartsOverviewHandler)
 }
 
 // rateLimitUnlessAPIToken wraps httprate.Limit but skips rate limiting for

--- a/backend/internal/api/routes/routes_test.go
+++ b/backend/internal/api/routes/routes_test.go
@@ -75,7 +75,7 @@ func TestSetupAuthRoutes(t *testing.T) {
 	router := chi.NewRouter()
 	api := humachi.New(router, huma.DefaultConfig("Test", "1.0.0"))
 
-	setupAuthRoutes(router, api, sc, cfg)
+	setupAuthRoutes(RouteContext{Router: router, API: api, SC: sc, Cfg: cfg})
 
 	// Test OAuth login route
 	t.Run("OAuth Login Route", func(t *testing.T) {
@@ -133,7 +133,7 @@ func TestSetupSystemRoutes(t *testing.T) {
 	router := chi.NewRouter()
 	api := humachi.New(router, huma.DefaultConfig("Test", "1.0.0"))
 
-	setupSystemRoutes(router, api)
+	setupSystemRoutes(RouteContext{Router: router, API: api})
 
 	// Test health check route
 	t.Run("Health Check Route", func(t *testing.T) {
@@ -247,7 +247,7 @@ func TestRouteMiddleware(t *testing.T) {
 	router := chi.NewRouter()
 	api := humachi.New(router, huma.DefaultConfig("Test", "1.0.0"))
 
-	setupAuthRoutes(router, api, sc, cfg)
+	setupAuthRoutes(RouteContext{Router: router, API: api, SC: sc, Cfg: cfg})
 
 	// Test that CORS headers are set (if middleware is configured)
 	t.Run("CORS Headers", func(t *testing.T) {
@@ -271,7 +271,7 @@ func TestRouteErrorHandling(t *testing.T) {
 	router := chi.NewRouter()
 	api := humachi.New(router, huma.DefaultConfig("Test", "1.0.0"))
 
-	setupAuthRoutes(router, api, sc, cfg)
+	setupAuthRoutes(RouteContext{Router: router, API: api, SC: sc, Cfg: cfg})
 
 	// Test OAuth callback with error (this will fail due to missing OAuth setup)
 	t.Run("OAuth Callback With Error", func(t *testing.T) {
@@ -300,7 +300,7 @@ func TestRouteParameterExtraction(t *testing.T) {
 	router := chi.NewRouter()
 	api := humachi.New(router, huma.DefaultConfig("Test", "1.0.0"))
 
-	setupAuthRoutes(router, api, sc, cfg)
+	setupAuthRoutes(RouteContext{Router: router, API: api, SC: sc, Cfg: cfg})
 
 	// Test different provider parameters
 	providers := []string{"google", "github"}
@@ -333,7 +333,7 @@ func TestRouteRegistration(t *testing.T) {
 	router := chi.NewRouter()
 	api := humachi.New(router, huma.DefaultConfig("Test", "1.0.0"))
 
-	setupAuthRoutes(router, api, sc, cfg)
+	setupAuthRoutes(RouteContext{Router: router, API: api, SC: sc, Cfg: cfg})
 
 	// Test that routes are registered by checking if they respond
 	// (even if they fail due to missing OAuth configuration)


### PR DESCRIPTION
## Summary
- Added `RouteContext` struct with `Router`, `API`, `Protected`, `SC`, and `Cfg` fields
- Refactored all 27 route setup functions from 3 different parameter signatures to a uniform `(rc RouteContext)` pattern
- `SetupRoutes` external signature unchanged — creates `RouteContext` once internally
- Updated 5 test call sites in `routes_test.go`

Closes PSY-193

## Test plan
- [x] `go build ./...` passes
- [x] All route tests pass
- [x] Full backend test suite passes
- [x] No behavior changes — purely mechanical signature standardization

🤖 Generated with [Claude Code](https://claude.com/claude-code)