### PR TITLE
Update navigation: Crates + Library

### DIFF
--- a/frontend/components/layout/CommandPalette.tsx
+++ b/frontend/components/layout/CommandPalette.tsx
@@ -12,8 +12,8 @@ import {
   CommandSeparator,
 } from '@/components/ui/command'
 import {
-  Calendar, CalendarCheck, Mic2, MapPin, Disc3, Tag, Tags, Tent, BookOpen, Headphones, Send,
-  Library, LayoutList, MessageSquarePlus, Settings, Search, Clock, X, Globe, UserCheck,
+  Calendar, Mic2, MapPin, Disc3, Tag, Tags, Tent, BookOpen, Headphones, Send,
+  Library, LayoutList, MessageSquarePlus, Settings, Search, Clock, X, Globe,
   TrendingUp, LayoutDashboard, Upload, BadgeCheck, Flag, ScrollText, Users, Workflow,
   ClipboardCheck, BarChart3, Music, Bell,
 } from 'lucide-react'
@@ -118,28 +118,14 @@ const routes: RouteItem[] = [
   {
     label: 'Library',
     href: '/library',
-    icon: BookOpen,
-    keywords: ['library', 'saved', 'bookmarks', 'favorites', 'following', 'my stuff', 'personal'],
-    requireAuth: true,
-  },
-  {
-    label: 'My Shows',
-    href: '/my-shows',
-    icon: CalendarCheck,
-    keywords: ['my shows', 'going', 'interested', 'attending', 'rsvp'],
-    requireAuth: true,
-  },
-  {
-    label: 'Following',
-    href: '/following',
-    icon: UserCheck,
-    keywords: ['following', 'follow', 'followed', 'artists', 'venues', 'labels', 'festivals'],
+    icon: Library,
+    keywords: ['library', 'saved', 'bookmarks', 'favorites', 'following', 'my stuff', 'personal', 'my shows', 'going', 'interested', 'attending'],
     requireAuth: true,
   },
   {
     label: 'Collection',
     href: '/collection',
-    icon: Library,
+    icon: BookOpen,
     keywords: ['collection', 'saved', 'my list', 'favorites', 'bookmarks'],
     requireAuth: true,
   },

--- a/frontend/components/layout/Sidebar.test.tsx
+++ b/frontend/components/layout/Sidebar.test.tsx
@@ -116,13 +116,14 @@ describe('Sidebar', () => {
     expect(onToggleCollapse).toHaveBeenCalledOnce()
   })
 
-  it('does not show Collection/Settings when unauthenticated', () => {
+  it('does not show Library/Collection/Settings when unauthenticated', () => {
     render(<Sidebar collapsed={false} onToggleCollapse={onToggleCollapse} />)
+    expect(screen.queryByText('Library')).not.toBeInTheDocument()
     expect(screen.queryByText('Collection')).not.toBeInTheDocument()
     expect(screen.queryByText('Settings')).not.toBeInTheDocument()
   })
 
-  it('shows Collection/Settings when authenticated', () => {
+  it('shows Library/Collection/Settings when authenticated', () => {
     mockAuthContext.mockReturnValue({
       user: { email: 'test@test.com', is_admin: false },
       isAuthenticated: true,
@@ -130,8 +131,21 @@ describe('Sidebar', () => {
       logout: vi.fn(),
     })
     render(<Sidebar collapsed={false} onToggleCollapse={onToggleCollapse} />)
+    expect(screen.getByText('Library')).toBeInTheDocument()
     expect(screen.getByText('Collection')).toBeInTheDocument()
     expect(screen.getByText('Settings')).toBeInTheDocument()
+  })
+
+  it('does not show My Shows or Following entries', () => {
+    mockAuthContext.mockReturnValue({
+      user: { email: 'test@test.com', is_admin: false },
+      isAuthenticated: true,
+      isLoading: false,
+      logout: vi.fn(),
+    })
+    render(<Sidebar collapsed={false} onToggleCollapse={onToggleCollapse} />)
+    expect(screen.queryByText('My Shows')).not.toBeInTheDocument()
+    expect(screen.queryByText('Following')).not.toBeInTheDocument()
   })
 
   it('shows Admin link for admin users', () => {

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -3,9 +3,9 @@
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import {
-  Calendar, CalendarCheck, Mic2, MapPin, Disc3, Tag, Tags, Tent, BookOpen, Headphones, Newspaper,
+  Calendar, Mic2, MapPin, Disc3, Tag, Tags, Tent, BookOpen, Headphones, Newspaper,
   Send, Library, LayoutList, MessageSquarePlus, Settings, Shield, PanelLeftClose, PanelLeft,
-  ExternalLink, Globe, UserCheck, TrendingUp, Bell,
+  ExternalLink, Globe, TrendingUp, Bell,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import { cn } from '@/lib/utils'
@@ -131,10 +131,8 @@ export function Sidebar({ collapsed, onToggleCollapse }: SidebarProps) {
             <div>
               <div className={cn('mb-2 border-t border-sidebar-border', collapsed ? 'mx-2' : 'mx-3')} />
               <div className="space-y-0.5">
-                {renderItem({ href: '/library', label: 'Library', icon: BookOpen })}
-                {renderItem({ href: '/my-shows', label: 'My Shows', icon: CalendarCheck })}
-                {renderItem({ href: '/following', label: 'Following', icon: UserCheck })}
-                {renderItem({ href: '/collection', label: 'Collection', icon: Library })}
+                {renderItem({ href: '/library', label: 'Library', icon: Library })}
+                {renderItem({ href: '/collection', label: 'Collection', icon: BookOpen })}
                 {renderItem({ href: '/settings/notifications', label: 'Notifications', icon: Bell })}
                 {renderItem({ href: '/profile', label: 'Settings', icon: Settings })}
                 {user?.is_admin && renderItem({ href: '/admin', label: 'Admin', icon: Shield })}

--- a/frontend/components/layout/TopBar.test.tsx
+++ b/frontend/components/layout/TopBar.test.tsx
@@ -258,7 +258,7 @@ describe('TopBar', () => {
         logout: mockLogout,
       })
       render(<TopBar mobileOpen={true} onMobileOpenChange={onMobileOpenChange} />)
-      expect(screen.getByText('My Shows')).toBeInTheDocument()
+      expect(screen.getByText('Library')).toBeInTheDocument()
       expect(screen.getByText('Collection')).toBeInTheDocument()
       expect(screen.getByText('Settings')).toBeInTheDocument()
     })

--- a/frontend/components/layout/TopBar.tsx
+++ b/frontend/components/layout/TopBar.tsx
@@ -6,7 +6,7 @@ import { usePathname } from 'next/navigation'
 import { useTheme } from 'next-themes'
 import {
   Menu, LogOut, Loader2, Shield, Settings, Moon, Sun, Search,
-  Library, CalendarCheck, ExternalLink,
+  Library, BookOpen, ExternalLink,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
@@ -109,17 +109,17 @@ export function TopBar({ mobileOpen, onMobileOpenChange, onSearchClick }: TopBar
                   <>
                     <div className="mx-3 mb-2 border-t border-border/30" />
                     <Link
-                      href="/my-shows"
+                      href="/library"
                       onClick={() => onMobileOpenChange(false)}
                       className={cn(
                         'flex items-center gap-3 rounded-md px-3 py-2.5 text-sm font-medium transition-colors',
-                        isActive('/my-shows')
+                        isActive('/library')
                           ? 'bg-accent text-accent-foreground'
                           : 'text-foreground/70 hover:bg-accent/50 hover:text-accent-foreground'
                       )}
                     >
-                      <CalendarCheck className="h-4 w-4" />
-                      My Shows
+                      <Library className="h-4 w-4" />
+                      Library
                     </Link>
                     <Link
                       href="/collection"
@@ -131,7 +131,7 @@ export function TopBar({ mobileOpen, onMobileOpenChange, onSearchClick }: TopBar
                           : 'text-foreground/70 hover:bg-accent/50 hover:text-accent-foreground'
                       )}
                     >
-                      <Library className="h-4 w-4" />
+                      <BookOpen className="h-4 w-4" />
                       Collection
                     </Link>
                     <Link
@@ -275,6 +275,12 @@ export function TopBar({ mobileOpen, onMobileOpenChange, onSearchClick }: TopBar
                   </DropdownMenuLabel>
                   <DropdownMenuSeparator />
                   <DropdownMenuGroup>
+                    <DropdownMenuItem asChild>
+                      <Link href="/library">
+                        <Library className="mr-2 h-4 w-4" />
+                        My Library
+                      </Link>
+                    </DropdownMenuItem>
                     <DropdownMenuItem asChild>
                       <Link href="/profile">
                         <Settings className="mr-2 h-4 w-4" />

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -53,6 +53,17 @@ const nextConfig: NextConfig = {
         destination: '/crates/:slug',
         permanent: true,
       },
+      // "my-shows" and "following" consolidated into Library
+      {
+        source: '/my-shows',
+        destination: '/library',
+        permanent: false,
+      },
+      {
+        source: '/following',
+        destination: '/library',
+        permanent: false,
+      },
     ]
   },
   async headers() {


### PR DESCRIPTION
## Summary
- Removed "My Shows" and "Following" from sidebar (consolidated into Library)
- Added "My Library" to desktop profile dropdown menu
- Replaced "My Shows" with "Library" in mobile nav
- Updated Cmd+K: removed My Shows/Following commands, added their keywords to Library entry
- Added temporary redirects `/my-shows` → `/library` and `/following` → `/library`
- Updated sidebar tests (20 pass, +1 new test verifying old entries removed)

Closes PSY-205

## Test plan
- [x] All sidebar tests pass (20/20)
- [x] Library appears in sidebar for authenticated users
- [x] My Shows and Following no longer in sidebar
- [x] Cmd+K searches for "my shows", "going", "following" resolve to Library
- [x] Old URLs redirect to `/library`

🤖 Generated with [Claude Code](https://claude.com/claude-code)