### PR TITLE
Admin: Complete Collection → Crate rename

### DIFF
--- a/frontend/app/admin/analytics/_components/AnalyticsDashboard.test.tsx
+++ b/frontend/app/admin/analytics/_components/AnalyticsDashboard.test.tsx
@@ -75,7 +75,7 @@ const mockEngagementData = {
   bookmarks: [{ month: '2025-10', count: 30 }],
   tags_added: [{ month: '2025-10', count: 20 }],
   tag_votes: [{ month: '2025-10', count: 50 }],
-  collection_items: [{ month: '2025-10', count: 10 }],
+  collection_items: [{ month: '2025-10', count: 10 }], // API field name; displayed as "Crate Items"
   requests: [{ month: '2025-10', count: 5 }],
   request_votes: [{ month: '2025-10', count: 15 }],
   revisions: [{ month: '2025-10', count: 8 }],
@@ -90,7 +90,7 @@ const mockCommunityData = {
     { week: '2026-W11', count: 20 },
   ],
   request_fulfillment_rate: 0.72,
-  new_collections_30d: 8,
+  new_collections_30d: 8, // API field name; displayed as "New Crates (30d)"
   top_contributors: [
     { user_id: 1, username: 'alice', display_name: 'Alice M.', count: 50 },
     { user_id: 2, username: 'bob', count: 35 },

--- a/frontend/app/admin/analytics/_components/AnalyticsDashboard.tsx
+++ b/frontend/app/admin/analytics/_components/AnalyticsDashboard.tsx
@@ -48,7 +48,7 @@ const COLORS = {
   bookmarks: '#3b82f6',
   tags_added: '#8b5cf6',
   tag_votes: '#a78bfa',
-  collection_items: '#f97316',
+  crate_items: '#f97316',
   requests: '#10b981',
   request_votes: '#34d399',
   revisions: '#ec4899',
@@ -287,7 +287,7 @@ function EngagementSection({ months }: { months: MonthRange }) {
   const curationData = mergeMonthlyData({
     tags_added: data.tags_added,
     tag_votes: data.tag_votes,
-    collection_items: data.collection_items,
+    crate_items: data.collection_items, // API field is collection_items
   })
 
   // Group 2: Requests & voting
@@ -345,9 +345,9 @@ function EngagementSection({ months }: { months: MonthRange }) {
             />
             <Area
               type="monotone"
-              dataKey="collection_items"
-              stroke={COLORS.collection_items}
-              fill={COLORS.collection_items}
+              dataKey="crate_items"
+              stroke={COLORS.crate_items}
+              fill={COLORS.crate_items}
               fillOpacity={0.15}
               strokeWidth={2}
               name="Crate Items"

--- a/frontend/lib/hooks/admin/useAnalytics.ts
+++ b/frontend/lib/hooks/admin/useAnalytics.ts
@@ -24,7 +24,7 @@ export interface EngagementMetrics {
   bookmarks: MonthlyCount[]
   tags_added: MonthlyCount[]
   tag_votes: MonthlyCount[]
-  collection_items: MonthlyCount[]
+  collection_items: MonthlyCount[] // backend API field; displayed as "Crate Items"
   requests: MonthlyCount[]
   request_votes: MonthlyCount[]
   revisions: MonthlyCount[]
@@ -48,7 +48,7 @@ export interface CommunityHealth {
   active_contributors_30d: number
   contributions_per_week: WeeklyContribution[]
   request_fulfillment_rate: number
-  new_collections_30d: number
+  new_collections_30d: number // backend API field; displayed as "New Crates (30d)"
   top_contributors: TopContributor[]
 }
 


### PR DESCRIPTION
## Summary
- Renamed internal chart data keys from `collection_items` → `crate_items` in AnalyticsDashboard (COLORS, merge keys, Area component props)
- Added clarifying comments on backend API field names (`collection_items`, `new_collections_30d`) that can't be renamed without backend changes
- PSY-203 already handled: admin tab label, CrateManagement component, Cmd+K commands

Closes PSY-206

## Test plan
- [x] All 2429 frontend tests pass
- [x] Analytics chart still renders correctly (data key mapping preserved)
- [x] No remaining "Collection" references in admin UI text

🤖 Generated with [Claude Code](https://claude.com/claude-code)