### PR TITLE
Fix auth redirect: preserve return URL from /submissions

### DIFF
--- a/frontend/app/submissions/page.tsx
+++ b/frontend/app/submissions/page.tsx
@@ -93,7 +93,7 @@ export default function SubmissionsPage() {
   // Redirect unauthenticated users to login
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
-      router.push('/auth')
+      router.push('/auth?returnTo=%2Fsubmissions')
     }
   }, [isAuthenticated, isLoading, router])
 


### PR DESCRIPTION
## Summary
- Fix `/submissions` page not preserving return URL when redirecting to login
- Root cause: `router.push('/auth')` was missing the `returnTo` query parameter
- Changed to `router.push('/auth?returnTo=%2Fsubmissions')` matching the pattern used by `LoginPromptDialog`
- One-line fix in `submissions/page.tsx`

**Note:** Several other components (`FollowButton`, `NotifyMeButton`, `AttendanceButton`) have the same missing `returnTo` pattern — worth a follow-up ticket.

Closes PSY-218

## Test plan
- [ ] Navigate to `/submissions` while logged out — login form appears
- [ ] Log in — redirected back to `/submissions` (not homepage)
- [ ] Verify submissions form loads correctly after redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)