### PR TITLE
Improve accessibility: ARIA roles and keyboard support for interactive elements

### DIFF
--- a/frontend/app/admin/dashboard/_components/AdminDashboard.tsx
+++ b/frontend/app/admin/dashboard/_components/AdminDashboard.tsx
@@ -45,7 +45,7 @@ function StatCard({ label, value, icon: Icon, highlight, trend, onClick }: StatC
   const isZeroHighlight = highlight && value === 0
   return (
     <Card
-      className={`py-4${isZeroHighlight ? ' opacity-50' : ''}${onClick ? ' cursor-pointer transition-shadow hover:shadow-md hover:bg-muted/50' : ''}`}
+      className={`py-4${isZeroHighlight ? ' opacity-50' : ''}${onClick ? ' cursor-pointer transition-shadow hover:shadow-md hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2' : ''}`}
       onClick={onClick}
       role={onClick ? 'button' : undefined}
       tabIndex={onClick ? 0 : undefined}

--- a/frontend/app/admin/data-quality/_components/DataQualityDashboard.tsx
+++ b/frontend/app/admin/data-quality/_components/DataQualityDashboard.tsx
@@ -63,8 +63,16 @@ function CategoryCard({
 
   return (
     <Card
-      className="cursor-pointer transition-colors hover:bg-muted/50"
+      className="cursor-pointer transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
       onClick={onClick}
+      role="button"
+      tabIndex={0}
+      onKeyDown={e => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          onClick()
+        }
+      }}
     >
       <CardContent className="flex items-center gap-4 py-4">
         <div

--- a/frontend/components/forms/AIFormFiller.tsx
+++ b/frontend/components/forms/AIFormFiller.tsx
@@ -271,8 +271,17 @@ export function AIFormFiller({ onExtracted }: AIFormFillerProps) {
   return (
     <Card className="border-border/50 bg-card/50 backdrop-blur-sm mb-4 py-0">
       <CardHeader
-        className="cursor-pointer py-3 flex flex-row items-center justify-between"
+        className="cursor-pointer py-3 flex flex-row items-center justify-between focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-t-xl"
         onClick={() => setIsExpanded(!isExpanded)}
+        role="button"
+        tabIndex={0}
+        onKeyDown={e => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            setIsExpanded(!isExpanded)
+          }
+        }}
+        aria-expanded={isExpanded}
       >
         <CardTitle className="flex items-center gap-2 text-base">
           <Sparkles className="h-4 w-4 text-primary" />
@@ -312,10 +321,19 @@ export function AIFormFiller({ onExtracted }: AIFormFillerProps) {
             </div>
           ) : (
             <div
-              className="border-2 border-dashed border-input rounded-md p-4 text-center hover:border-primary/50 transition-colors cursor-pointer"
+              className="border-2 border-dashed border-input rounded-md p-4 text-center hover:border-primary/50 transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
               onDrop={handleDrop}
               onDragOver={handleDragOver}
               onClick={() => fileInputRef.current?.click()}
+              role="button"
+              tabIndex={0}
+              onKeyDown={e => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault()
+                  fileInputRef.current?.click()
+                }
+              }}
+              aria-label="Upload a flyer image"
             >
               <div className="flex flex-col sm:flex-row items-center justify-center gap-2 sm:gap-3">
                 <div className="flex items-center justify-center h-10 w-10 rounded-full bg-muted">

--- a/frontend/features/venues/components/FavoriteVenuesTab.tsx
+++ b/frontend/features/venues/components/FavoriteVenuesTab.tsx
@@ -54,6 +54,7 @@ function VenueCardExpandable({ venue }: VenueCardExpandableProps) {
             setIsExpanded(!isExpanded)
           }
         }}
+        aria-expanded={hasShows ? isExpanded : undefined}
         className={`w-full px-4 py-4 text-left transition-colors ${
           hasShows
             ? 'hover:bg-muted/30 cursor-pointer'

--- a/frontend/features/venues/components/VenueCard.tsx
+++ b/frontend/features/venues/components/VenueCard.tsx
@@ -63,6 +63,7 @@ export function VenueCard({ venue }: VenueCardProps) {
             setIsExpanded(!isExpanded)
           }
         }}
+        aria-expanded={hasShows ? isExpanded : undefined}
         className={`w-full px-4 py-4 text-left transition-colors duration-75 ${
           hasShows
             ? 'hover:bg-muted/30 cursor-pointer'


### PR DESCRIPTION
## Summary
Audit and fix interactive elements that lacked proper ARIA roles, keyboard support, or focus indicators.

**Fixed (5 files):**
- **AIFormFiller.tsx** — CardHeader collapsible: added `role="button"`, `tabIndex={0}`, `onKeyDown` (Enter/Space), `aria-expanded`, focus-visible ring. Also fixed image drop zone with same pattern + `aria-label`.
- **DataQualityDashboard.tsx** — CategoryCard: added `role="button"`, `tabIndex={0}`, `onKeyDown`, focus-visible ring
- **AdminDashboard.tsx** — StatCard: already had role/tabIndex/onKeyDown, added focus-visible ring
- **VenueCard.tsx** — added `aria-expanded` to existing collapsible header
- **FavoriteVenuesTab.tsx** — added `aria-expanded` to existing collapsible header

**Verified as already accessible (no changes needed):**
- All Shadcn UI primitives, nav links, buttons, dropdown menus, filter chips
- ImportDropZone (uses positioned `<input type="file">`)

All 2430 tests pass.

Closes PSY-220

## Test plan
- [ ] AI Form Filler on `/submissions` — Tab to header, press Enter/Space to expand/collapse
- [ ] Data Quality dashboard cards — Tab to card, press Enter to select category
- [ ] Admin stat cards — focus ring visible on Tab
- [ ] VenueCard collapsible — screen reader announces expanded/collapsed state
- [ ] Verify agent-browser can now detect AI Form Filler as interactive (`snapshot -i` shows button role)

🤖 Generated with [Claude Code](https://claude.com/claude-code)