### PR TITLE
Fix show deduplication: block duplicates instead of flagging for review

### DIFF
--- a/backend/internal/services/catalog/show.go
+++ b/backend/internal/services/catalog/show.go
@@ -210,7 +210,8 @@ func (s *ShowService) checkDuplicateHeadlinerConflicts(tx *gorm.DB, req *contrac
 		}
 	}
 
-	// Check for conflicts: same headliner + same venue + same day (case-insensitive)
+	// Check for conflicts: same headliner + same venue + same day (case-insensitive).
+	// Matches headliner by explicit set_type='headliner' OR position=0 (first billed artist).
 	for _, headlinerName := range headlinerNames {
 		for _, venueName := range venueNames {
 			var existingShows []models.Show
@@ -221,8 +222,9 @@ func (s *ShowService) checkDuplicateHeadlinerConflicts(tx *gorm.DB, req *contrac
 				Joins("JOIN artists ON show_artists.artist_id = artists.id").
 				Joins("JOIN show_venues ON shows.id = show_venues.show_id").
 				Joins("JOIN venues ON show_venues.venue_id = venues.id").
-				Where("LOWER(artists.name) = LOWER(?) AND LOWER(venues.name) = LOWER(?) AND show_artists.set_type = ?",
-					headlinerName, venueName, "headliner").
+				Where("LOWER(artists.name) = LOWER(?) AND LOWER(venues.name) = LOWER(?)",
+					headlinerName, venueName).
+				Where("(show_artists.set_type = ? OR show_artists.position = 0)", "headliner").
 				Where("shows.event_date >= ? AND shows.event_date < ?", startOfDay, endOfDay).
 				Find(&existingShows).Error
 

--- a/backend/internal/services/pipeline/discovery.go
+++ b/backend/internal/services/pipeline/discovery.go
@@ -187,7 +187,8 @@ func (s *DiscoveryService) checkHeadlinerDuplicate(headlinerName, venueName stri
 		Joins("JOIN artists ON show_artists.artist_id = artists.id").
 		Joins("JOIN show_venues ON shows.id = show_venues.show_id").
 		Joins("JOIN venues ON show_venues.venue_id = venues.id").
-		Where("LOWER(artists.name) = LOWER(?) AND show_artists.set_type = ?", headlinerName, "headliner").
+		Where("LOWER(artists.name) = LOWER(?)", headlinerName).
+		Where("(show_artists.set_type = ? OR show_artists.position = 0)", "headliner").
 		Where("LOWER(venues.name) = LOWER(?)", venueName).
 		Where("shows.event_date >= ? AND shows.event_date < ?", startOfDay, endOfDay).
 		Where("shows.status NOT IN ?", []models.ShowStatus{models.ShowStatusRejected, models.ShowStatusPrivate}).
@@ -196,6 +197,37 @@ func (s *DiscoveryService) checkHeadlinerDuplicate(headlinerName, venueName stri
 		return nil
 	}
 	return &existingShow
+}
+
+// resolveHeadlinerName determines the headliner artist name for duplicate checking.
+// Prefers BillingArtists data (with explicit set_type/billing_order) over the plain Artists list.
+// Falls back to the first artist in the list, which the import logic treats as headliner.
+func (s *DiscoveryService) resolveHeadlinerName(event *contracts.DiscoveredEvent) string {
+	// Check BillingArtists first — these have explicit set_type from AI extraction
+	if len(event.BillingArtists) > 0 {
+		// Look for an explicit headliner
+		for _, ba := range event.BillingArtists {
+			if normalizeSetType(ba.SetType) == "headliner" {
+				return ba.Name
+			}
+		}
+		// If no explicit headliner, use billing_order=1 or first entry
+		lowest := event.BillingArtists[0]
+		for _, ba := range event.BillingArtists[1:] {
+			if ba.BillingOrder > 0 && (lowest.BillingOrder == 0 || ba.BillingOrder < lowest.BillingOrder) {
+				lowest = ba
+			}
+		}
+		return lowest.Name
+	}
+
+	// Fall back to plain Artists list — first entry is treated as headliner during import
+	if len(event.Artists) > 0 {
+		return event.Artists[0]
+	}
+
+	// No artist info — can't check for headliner duplicates
+	return ""
 }
 
 // importEvent imports a single scraped event
@@ -246,15 +278,13 @@ func (s *DiscoveryService) importEvent(event *contracts.DiscoveredEvent, dryRun 
 			event.Title, rejectedShow.ID, venueConfig.Name, eventDate.Format("2006-01-02")), "rejected"
 	}
 
-	// Check for potential duplicate (same headliner + venue + date as an existing show)
-	var duplicateOfShowID *uint
-	if len(event.Artists) > 0 {
-		if dupShow := s.checkHeadlinerDuplicate(event.Artists[0], venueConfig.Name, eventDate); dupShow != nil {
-			duplicateOfShowID = &dupShow.ID
-			if dryRun {
-				return fmt.Sprintf("WOULD FLAG FOR REVIEW: %s at %s on %s (potential duplicate of show #%d: %s)",
-					event.Title, venueConfig.Name, eventDate.Format("2006-01-02 15:04"), dupShow.ID, dupShow.Title), "pending_review"
-			}
+	// Check for duplicate: same headliner + venue + date as an existing show.
+	// Determine the headliner name from billing data (preferred) or artist list.
+	headlinerName := s.resolveHeadlinerName(event)
+	if headlinerName != "" {
+		if dupShow := s.checkHeadlinerDuplicate(headlinerName, venueConfig.Name, eventDate); dupShow != nil {
+			return fmt.Sprintf("DUPLICATE: %s at %s on %s (matches existing show #%d: %s)",
+				event.Title, venueConfig.Name, eventDate.Format("2006-01-02 15:04"), dupShow.ID, dupShow.Title), "duplicate"
 		}
 	}
 
@@ -263,13 +293,9 @@ func (s *DiscoveryService) importEvent(event *contracts.DiscoveredEvent, dryRun 
 	}
 
 	// Create the show
-	err = s.createShowFromEvent(event, eventDate, venueConfig, duplicateOfShowID, initialStatus)
+	err = s.createShowFromEvent(event, eventDate, venueConfig, nil, initialStatus)
 	if err != nil {
 		return fmt.Sprintf("ERROR: Failed to create show: %v", err), "error"
-	}
-
-	if duplicateOfShowID != nil {
-		return fmt.Sprintf("FLAGGED FOR REVIEW: %s at %s on %s", event.Title, venueConfig.Name, eventDate.Format("2006-01-02 15:04")), "pending_review"
 	}
 
 	return fmt.Sprintf("IMPORTED: %s at %s on %s", event.Title, venueConfig.Name, eventDate.Format("2006-01-02 15:04")), "imported"

--- a/backend/internal/services/pipeline/discovery_test.go
+++ b/backend/internal/services/pipeline/discovery_test.go
@@ -484,20 +484,18 @@ func (suite *DiscoveryIntegrationTestSuite) TestImportEvents_HeadlinerDuplicate(
 	suite.Equal(1, result1.Imported)
 
 	// Import another event with the same headliner at the same venue on the same date
-	// but different source_event_id
+	// but different source_event_id — should be blocked as duplicate
 	events2 := []contracts.DiscoveredEvent{
 		suite.makeEvent("evt-004b", "Bon Iver (Late Show)", "valley-bar", "2026-09-01", []string{"Bon Iver"}),
 	}
 	result2, err := suite.svc.ImportEvents(events2, false, false, models.ShowStatusApproved)
 	suite.Require().NoError(err)
-	suite.Equal(1, result2.PendingReview)
+	suite.Equal(1, result2.Duplicates)
 
-	// Verify the second show is pending
-	var show models.Show
-	err = suite.db.Where("source_event_id = ?", "evt-004b").First(&show).Error
-	suite.Require().NoError(err)
-	suite.Equal(models.ShowStatusPending, show.Status)
-	suite.NotNil(show.DuplicateOfShowID)
+	// Verify the second show was NOT created
+	var count int64
+	suite.db.Model(&models.Show{}).Where("source_event_id = ?", "evt-004b").Count(&count)
+	suite.Equal(int64(0), count)
 }
 
 func (suite *DiscoveryIntegrationTestSuite) TestImportEvents_RejectedShowSkipped() {
@@ -723,4 +721,139 @@ func (suite *DiscoveryIntegrationTestSuite) TestImportEvents_WithSpecialGuestAnd
 	suite.Equal("headliner", showArtists[0].SetType)
 	suite.Equal("special_guest", showArtists[1].SetType)
 	suite.Equal("performer", showArtists[2].SetType) // dj normalized to performer
+}
+
+func (suite *DiscoveryIntegrationTestSuite) TestImportEvents_HeadlinerDuplicate_WithBillingArtists() {
+	// Import a show with billing data
+	events1 := []contracts.DiscoveredEvent{
+		{
+			ID:        "evt-billing-001",
+			Title:     "Big Show Night",
+			Date:      "2026-11-01",
+			Venue:     "Valley Bar",
+			VenueSlug: "valley-bar",
+			Artists:   []string{"Star Band", "Opener"},
+			BillingArtists: []contracts.DiscoveredArtist{
+				{Name: "Star Band", SetType: "headliner", BillingOrder: 1},
+				{Name: "Opener", SetType: "opener", BillingOrder: 2},
+			},
+			ScrapedAt: time.Now().UTC().Format(time.RFC3339),
+		},
+	}
+	result1, err := suite.svc.ImportEvents(events1, false, false, models.ShowStatusApproved)
+	suite.Require().NoError(err)
+	suite.Equal(1, result1.Imported)
+
+	// Import another event with the same headliner via billing data but different source_event_id
+	events2 := []contracts.DiscoveredEvent{
+		{
+			ID:        "evt-billing-002",
+			Title:     "Big Show Night (Late)",
+			Date:      "2026-11-01",
+			Venue:     "Valley Bar",
+			VenueSlug: "valley-bar",
+			Artists:   []string{"Star Band"},
+			BillingArtists: []contracts.DiscoveredArtist{
+				{Name: "Star Band", SetType: "headliner", BillingOrder: 1},
+			},
+			ScrapedAt: time.Now().UTC().Format(time.RFC3339),
+		},
+	}
+	result2, err := suite.svc.ImportEvents(events2, false, false, models.ShowStatusApproved)
+	suite.Require().NoError(err)
+	suite.Equal(1, result2.Duplicates)
+
+	// Verify the second show was NOT created
+	var count int64
+	suite.db.Model(&models.Show{}).Where("source_event_id = ?", "evt-billing-002").Count(&count)
+	suite.Equal(int64(0), count)
+}
+
+func (suite *DiscoveryIntegrationTestSuite) TestImportEvents_HeadlinerDuplicate_Position0Match() {
+	// Import a show where the headliner is assigned position=0 but set_type is just "performer"
+	// This simulates shows created without explicit headliner tagging
+	venue := &models.Venue{Name: "Valley Bar", City: "Phoenix", State: "AZ"}
+	suite.Require().NoError(suite.db.Create(venue).Error)
+
+	artist := &models.Artist{Name: "Position Zero Band"}
+	slug := utils.GenerateArtistSlug(artist.Name)
+	artist.Slug = &slug
+	suite.Require().NoError(suite.db.Create(artist).Error)
+
+	show := &models.Show{
+		Title:     "Existing Show",
+		EventDate: time.Date(2026, 11, 15, 2, 0, 0, 0, time.UTC),
+		Status:    models.ShowStatusApproved,
+		Source:    models.ShowSourceUser,
+	}
+	suite.Require().NoError(suite.db.Create(show).Error)
+
+	suite.Require().NoError(suite.db.Exec(
+		"INSERT INTO show_venues (show_id, venue_id) VALUES (?, ?)", show.ID, venue.ID).Error)
+	suite.Require().NoError(suite.db.Exec(
+		"INSERT INTO show_artists (show_id, artist_id, position, set_type) VALUES (?, ?, 0, 'performer')",
+		show.ID, artist.ID).Error)
+
+	// Now try to import an event with the same artist at the same venue on the same date
+	events := []contracts.DiscoveredEvent{
+		suite.makeEvent("evt-pos0-001", "Position Zero Band Live", "valley-bar", "2026-11-15", []string{"Position Zero Band"}),
+	}
+	result, err := suite.svc.ImportEvents(events, false, false, models.ShowStatusApproved)
+	suite.Require().NoError(err)
+	suite.Equal(1, result.Duplicates)
+	suite.Contains(result.Messages[0], "DUPLICATE")
+}
+
+// =============================================================================
+// UNIT TESTS — resolveHeadlinerName
+// =============================================================================
+
+func TestResolveHeadlinerName_BillingArtists_ExplicitHeadliner(t *testing.T) {
+	svc := &DiscoveryService{}
+	event := &contracts.DiscoveredEvent{
+		BillingArtists: []contracts.DiscoveredArtist{
+			{Name: "Opener", SetType: "opener", BillingOrder: 2},
+			{Name: "Headliner Band", SetType: "headliner", BillingOrder: 1},
+		},
+		Artists: []string{"Opener", "Headliner Band"},
+	}
+	assert.Equal(t, "Headliner Band", svc.resolveHeadlinerName(event))
+}
+
+func TestResolveHeadlinerName_BillingArtists_ByBillingOrder(t *testing.T) {
+	svc := &DiscoveryService{}
+	event := &contracts.DiscoveredEvent{
+		BillingArtists: []contracts.DiscoveredArtist{
+			{Name: "Second Act", SetType: "performer", BillingOrder: 2},
+			{Name: "First Act", SetType: "performer", BillingOrder: 1},
+		},
+	}
+	// Should return the one with lowest billing order
+	assert.Equal(t, "First Act", svc.resolveHeadlinerName(event))
+}
+
+func TestResolveHeadlinerName_BillingArtists_NoHeadlinerNoOrder(t *testing.T) {
+	svc := &DiscoveryService{}
+	event := &contracts.DiscoveredEvent{
+		BillingArtists: []contracts.DiscoveredArtist{
+			{Name: "First Entry", SetType: "performer"},
+			{Name: "Second Entry", SetType: "performer"},
+		},
+	}
+	// Should return first entry when no explicit headliner or billing order
+	assert.Equal(t, "First Entry", svc.resolveHeadlinerName(event))
+}
+
+func TestResolveHeadlinerName_FallbackToArtistsList(t *testing.T) {
+	svc := &DiscoveryService{}
+	event := &contracts.DiscoveredEvent{
+		Artists: []string{"Main Band", "Support Band"},
+	}
+	assert.Equal(t, "Main Band", svc.resolveHeadlinerName(event))
+}
+
+func TestResolveHeadlinerName_NoArtists(t *testing.T) {
+	svc := &DiscoveryService{}
+	event := &contracts.DiscoveredEvent{}
+	assert.Equal(t, "", svc.resolveHeadlinerName(event))
 }


### PR DESCRIPTION
## Summary
Fix duplicate shows appearing in the show list by changing the pipeline's headliner duplicate detection from a "flag for review" approach (which still created the show) to a **hard block** that skips duplicates entirely.

**Root cause:** The discovery pipeline's `importEvent` detected headliner duplicates but still created the show with `pending` status and `duplicate_of_show_id`. When admins batch-approved pending shows, these duplicates got approved and appeared in the public list.

**Changes:**
- **discovery.go** — Duplicates are now skipped entirely (reported as `"duplicate"`, not `"pending_review"`). Added `resolveHeadlinerName()` for better name matching. Broadened `checkHeadlinerDuplicate()` to match `set_type = 'headliner'` OR `position = 0`.
- **show.go** — Same broadened matching in `checkDuplicateHeadlinerConflicts()` for consistency across all show creation paths.
- **discovery_test.go** — Updated existing test + added 7 new tests (2 integration, 5 unit) covering billing artist dedup, position-0 matching, and `resolveHeadlinerName()` edge cases.

All 97 tests pass (20 pipeline + 77 show service).

**Note:** Existing duplicate shows in the database should be cleaned up separately via a one-time SQL script or admin action.

Closes PSY-217

## Test plan
- [ ] Import a show via pipeline that already exists (same venue + date + headliner) — should be skipped
- [ ] Import a show with a different headliner at same venue + date — should be created
- [ ] Verify position=0 artists are detected as headliners for dedup
- [ ] All pipeline and show service tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)