### PR TITLE
Fix auth-gated buttons: add returnTo to all auth redirects

### DIFF
--- a/frontend/app/admin/admin-guard.tsx
+++ b/frontend/app/admin/admin-guard.tsx
@@ -16,7 +16,7 @@ export default function AdminGuard({
   useEffect(() => {
     // Redirect non-authenticated users to login
     if (!isLoading && !isAuthenticated) {
-      router.push('/auth')
+      router.push('/auth?returnTo=%2Fadmin')
       return
     }
 

--- a/frontend/components/shared/FollowButton.test.tsx
+++ b/frontend/components/shared/FollowButton.test.tsx
@@ -11,6 +11,7 @@ let mockStatusLoading = false
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: mockPush }),
+  usePathname: () => '/artists/test-artist',
 }))
 
 vi.mock('@/lib/context/AuthContext', () => ({
@@ -103,7 +104,7 @@ describe('FollowButton', () => {
     )
 
     fireEvent.click(screen.getByRole('button'))
-    expect(mockPush).toHaveBeenCalledWith('/auth')
+    expect(mockPush).toHaveBeenCalledWith('/auth?returnTo=%2Fartists%2Ftest-artist')
     expect(mockFollowMutate).not.toHaveBeenCalled()
   })
 

--- a/frontend/components/shared/FollowButton.tsx
+++ b/frontend/components/shared/FollowButton.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { useRouter, usePathname } from 'next/navigation'
 import { UserPlus, UserCheck, UserMinus, Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useAuthContext } from '@/lib/context/AuthContext'
@@ -29,6 +29,7 @@ export function FollowButton({
   followData,
 }: FollowButtonProps) {
   const router = useRouter()
+  const pathname = usePathname()
   const { isAuthenticated } = useAuthContext()
   const [isHovering, setIsHovering] = useState(false)
 
@@ -52,7 +53,7 @@ export function FollowButton({
     e.stopPropagation()
 
     if (!isAuthenticated) {
-      router.push('/auth')
+      router.push(`/auth?returnTo=${encodeURIComponent(pathname)}`)
       return
     }
 

--- a/frontend/features/notifications/components/NotifyMeButton.test.tsx
+++ b/frontend/features/notifications/components/NotifyMeButton.test.tsx
@@ -8,6 +8,7 @@ import { NotifyMeButton } from './NotifyMeButton'
 const mockPush = vi.fn()
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: mockPush }),
+  usePathname: () => '/artists/test-artist',
 }))
 
 // Mock AuthContext
@@ -96,7 +97,7 @@ describe('NotifyMeButton', () => {
       />
     )
     await user.click(screen.getByText('Notify me'))
-    expect(mockPush).toHaveBeenCalledWith('/auth')
+    expect(mockPush).toHaveBeenCalledWith('/auth?returnTo=%2Fartists%2Ftest-artist')
   })
 
   it('calls quickCreate.mutate when clicking notify without filter', async () => {

--- a/frontend/features/notifications/components/NotifyMeButton.tsx
+++ b/frontend/features/notifications/components/NotifyMeButton.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { useRouter, usePathname } from 'next/navigation'
 import { AlertCircle, Bell, BellRing, Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useAuthContext } from '@/lib/context/AuthContext'
@@ -35,6 +35,7 @@ export function NotifyMeButton({
   compact = false,
 }: NotifyMeButtonProps) {
   const router = useRouter()
+  const pathname = usePathname()
   const { isAuthenticated } = useAuthContext()
   const [isHovering, setIsHovering] = useState(false)
 
@@ -51,7 +52,7 @@ export function NotifyMeButton({
     e.stopPropagation()
 
     if (!isAuthenticated) {
-      router.push('/auth')
+      router.push(`/auth?returnTo=${encodeURIComponent(pathname)}`)
       return
     }
 
@@ -71,7 +72,7 @@ export function NotifyMeButton({
         <Button
           variant="ghost"
           size="sm"
-          onClick={() => router.push('/auth')}
+          onClick={() => router.push(`/auth?returnTo=${encodeURIComponent(pathname)}`)}
           className="h-7 px-2 gap-1 text-xs"
           title="Sign in to get notifications"
         >
@@ -83,7 +84,7 @@ export function NotifyMeButton({
       <Button
         variant="outline"
         size="sm"
-        onClick={() => router.push('/auth')}
+        onClick={() => router.push(`/auth?returnTo=${encodeURIComponent(pathname)}`)}
         className="gap-1.5"
       >
         <Bell className="h-4 w-4" />

--- a/frontend/features/shows/components/AttendanceButton.test.tsx
+++ b/frontend/features/shows/components/AttendanceButton.test.tsx
@@ -19,6 +19,7 @@ vi.mock('@/lib/context/AuthContext', () => ({
 const mockPush = vi.fn()
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: mockPush }),
+  usePathname: () => '/shows/test-show',
 }))
 
 // Mock attendance hooks
@@ -248,7 +249,7 @@ describe('AttendanceButton', () => {
       const user = userEvent.setup()
       render(<AttendanceButton showId={1} compact />)
       await user.click(screen.getByLabelText('Going'))
-      expect(mockPush).toHaveBeenCalledWith('/auth')
+      expect(mockPush).toHaveBeenCalledWith('/auth?returnTo=%2Fshows%2Ftest-show')
       expect(mockSetAttendanceMutate).not.toHaveBeenCalled()
     })
 
@@ -256,7 +257,7 @@ describe('AttendanceButton', () => {
       const user = userEvent.setup()
       render(<AttendanceButton showId={1} />)
       await user.click(screen.getByText('Going'))
-      expect(mockPush).toHaveBeenCalledWith('/auth')
+      expect(mockPush).toHaveBeenCalledWith('/auth?returnTo=%2Fshows%2Ftest-show')
       expect(mockSetAttendanceMutate).not.toHaveBeenCalled()
     })
 

--- a/frontend/features/shows/components/AttendanceButton.tsx
+++ b/frontend/features/shows/components/AttendanceButton.tsx
@@ -10,7 +10,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 import { useAuthContext } from '@/lib/context/AuthContext'
-import { useRouter } from 'next/navigation'
+import { useRouter, usePathname } from 'next/navigation'
 import { useShowAttendance, useSetAttendance, useRemoveAttendance } from '../hooks/useAttendance'
 import type { AttendanceCounts } from '../types'
 
@@ -29,6 +29,7 @@ export function AttendanceButton({
 }: AttendanceButtonProps) {
   const { isAuthenticated } = useAuthContext()
   const router = useRouter()
+  const pathname = usePathname()
 
   // Only fetch individual attendance if no batch data provided
   const { data: fetchedData } = useShowAttendance(
@@ -49,7 +50,7 @@ export function AttendanceButton({
 
   const handleClick = (status: 'going' | 'interested') => {
     if (!isAuthenticated) {
-      router.push('/auth')
+      router.push(`/auth?returnTo=${encodeURIComponent(pathname)}`)
       return
     }
 


### PR DESCRIPTION
## Summary
Add `returnTo` parameter to all auth-gated button redirects so users return to the page they were on after login, instead of landing on the homepage.

**4 components fixed:**
- **FollowButton** — uses `usePathname()` for dynamic returnTo
- **NotifyMeButton** — uses `usePathname()`, 3 call sites updated
- **AttendanceButton** — uses `usePathname()` for dynamic returnTo
- **admin-guard** — hardcoded `returnTo=%2Fadmin`

**3 test files updated** to match new redirect URLs.

Follows the same pattern established by `LoginPromptDialog` and the PSY-218 fix for `/submissions`.

Closes PSY-223

## Test plan
- [ ] Click "Follow" on an artist page while logged out → login → redirected back to artist page
- [ ] Click "Notify me" on a venue page while logged out → login → redirected back to venue page
- [ ] Click "Going" on a show while logged out → login → redirected back to shows page
- [ ] Access `/admin` while logged out → login → redirected to admin
- [ ] All 42 related tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)