### PR TITLE
Add data-testid attributes to key interactive elements

### DIFF
--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -340,71 +340,71 @@ function AdminPageContent() {
             </TabsTrigger>
           </TabsList>
 
-          <TabsContent value="dashboard" className="space-y-4">
+          <TabsContent value="dashboard" className="space-y-4" data-testid="admin-tab-dashboard">
             <DashboardPage onNavigate={setActiveTab} />
           </TabsContent>
 
-          <TabsContent value="pending-shows" className="space-y-4">
+          <TabsContent value="pending-shows" className="space-y-4" data-testid="admin-tab-pending-shows">
             <PendingShowsPage />
           </TabsContent>
 
-          <TabsContent value="pending-venue-edits" className="space-y-4">
+          <TabsContent value="pending-venue-edits" className="space-y-4" data-testid="admin-tab-pending-venue-edits">
             <VenueEditsPage />
           </TabsContent>
 
-          <TabsContent value="unverified-venues" className="space-y-4">
+          <TabsContent value="unverified-venues" className="space-y-4" data-testid="admin-tab-unverified-venues">
             <UnverifiedVenuesPage />
           </TabsContent>
 
-          <TabsContent value="reports" className="space-y-4">
+          <TabsContent value="reports" className="space-y-4" data-testid="admin-tab-reports">
             <ReportsPage />
           </TabsContent>
 
-          <TabsContent value="import-show" className="space-y-4">
+          <TabsContent value="import-show" className="space-y-4" data-testid="admin-tab-import-show">
             <ShowImportPanel />
           </TabsContent>
 
-          <TabsContent value="releases" className="space-y-4">
+          <TabsContent value="releases" className="space-y-4" data-testid="admin-tab-releases">
             <ReleasesPage />
           </TabsContent>
 
-          <TabsContent value="labels" className="space-y-4">
+          <TabsContent value="labels" className="space-y-4" data-testid="admin-tab-labels">
             <LabelsPage />
           </TabsContent>
 
-          <TabsContent value="festivals" className="space-y-4">
+          <TabsContent value="festivals" className="space-y-4" data-testid="admin-tab-festivals">
             <FestivalsPage />
           </TabsContent>
 
-          <TabsContent value="pipeline" className="space-y-4">
+          <TabsContent value="pipeline" className="space-y-4" data-testid="admin-tab-pipeline">
             <PipelineVenuesComponent />
           </TabsContent>
 
-          <TabsContent value="crates" className="space-y-4">
+          <TabsContent value="crates" className="space-y-4" data-testid="admin-tab-crates">
             <CrateManagementComponent />
           </TabsContent>
 
-          <TabsContent value="tags" className="space-y-4">
+          <TabsContent value="tags" className="space-y-4" data-testid="admin-tab-tags">
             <TagsPage />
           </TabsContent>
 
-          <TabsContent value="data-quality" className="space-y-4">
+          <TabsContent value="data-quality" className="space-y-4" data-testid="admin-tab-data-quality">
             <DataQualityPage />
           </TabsContent>
 
-          <TabsContent value="analytics" className="space-y-4">
+          <TabsContent value="analytics" className="space-y-4" data-testid="admin-tab-analytics">
             <AnalyticsPage />
           </TabsContent>
 
-          <TabsContent value="artists-admin" className="space-y-4">
+          <TabsContent value="artists-admin" className="space-y-4" data-testid="admin-tab-artists-admin">
             <ArtistsPage />
           </TabsContent>
 
-          <TabsContent value="users" className="space-y-4">
+          <TabsContent value="users" className="space-y-4" data-testid="admin-tab-users">
             <UsersPage />
           </TabsContent>
 
-          <TabsContent value="audit-log" className="space-y-4">
+          <TabsContent value="audit-log" className="space-y-4" data-testid="admin-tab-audit-log">
             <AuditLogPage />
           </TabsContent>
         </Tabs>

--- a/frontend/components/filters/CityFilters.tsx
+++ b/frontend/components/filters/CityFilters.tsx
@@ -63,10 +63,12 @@ export function CityFilters({
         label={allLabel}
         isActive={isAllSelected}
         onClick={() => onFilterChange([])}
+        data-testid="city-filter-all"
       />
       {cities.map(city => {
         const isActive = selectedSet.has(cityKey(city))
         const label = `${city.city}, ${city.state}`
+        const slug = `${city.city}-${city.state}`.toLowerCase().replace(/\s+/g, '-')
 
         return (
           <FilterChip
@@ -75,6 +77,7 @@ export function CityFilters({
             isActive={isActive}
             onClick={(e) => handleToggle(city.city, city.state, e)}
             count={city.count}
+            data-testid={`city-filter-${slug}`}
           />
         )
       })}

--- a/frontend/components/filters/FilterChip.tsx
+++ b/frontend/components/filters/FilterChip.tsx
@@ -3,12 +3,14 @@ interface FilterChipProps {
   isActive: boolean
   onClick: (e: React.MouseEvent) => void
   count?: number
+  'data-testid'?: string
 }
 
-export function FilterChip({ label, isActive, onClick, count }: FilterChipProps) {
+export function FilterChip({ label, isActive, onClick, count, 'data-testid': testId }: FilterChipProps) {
   return (
     <button
       onClick={onClick}
+      data-testid={testId}
       className={`px-3 py-1.5 rounded-full text-sm font-medium transition-colors duration-[50ms] ${
         isActive
           ? 'bg-primary text-primary-foreground'

--- a/frontend/components/forms/AIFormFiller.tsx
+++ b/frontend/components/forms/AIFormFiller.tsx
@@ -282,6 +282,7 @@ export function AIFormFiller({ onExtracted }: AIFormFillerProps) {
           }
         }}
         aria-expanded={isExpanded}
+        data-testid="ai-form-filler-trigger"
       >
         <CardTitle className="flex items-center gap-2 text-base">
           <Sparkles className="h-4 w-4 text-primary" />

--- a/frontend/components/forms/ArtistInput.tsx
+++ b/frontend/components/forms/ArtistInput.tsx
@@ -149,6 +149,7 @@ export function ArtistInput({
                         type="button"
                         role="option"
                         key={artist.id}
+                        data-testid="search-result-artist"
                         className="relative flex w-full cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground"
                         onMouseDown={e => {
                           e.preventDefault()

--- a/frontend/components/forms/VenueInput.tsx
+++ b/frontend/components/forms/VenueInput.tsx
@@ -152,6 +152,7 @@ export function VenueInput({
                       type="button"
                       role="option"
                       key={venue.id}
+                      data-testid="search-result-venue"
                       className="relative flex w-full cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground"
                       onMouseDown={e => {
                         e.preventDefault()

--- a/frontend/components/shared/DensityToggle.tsx
+++ b/frontend/components/shared/DensityToggle.tsx
@@ -41,6 +41,7 @@ export function DensityToggle({ density, onDensityChange, className }: DensityTo
           role="radio"
           aria-checked={density === option.value}
           onClick={() => onDensityChange(option.value)}
+          data-testid={`density-${option.value}`}
           className={cn(
             'px-2.5 py-1 text-xs font-medium rounded-md transition-colors duration-100',
             density === option.value


### PR DESCRIPTION
## Summary
Add `data-testid` attributes to elements that were hard to target reliably during automated dogfooding and testing.

**5 target areas (7 files):**

| Area | Testid | File |
|------|--------|------|
| AI Form Filler trigger | `ai-form-filler-trigger` | `AIFormFiller.tsx` |
| City filter pills | `city-filter-all`, `city-filter-phoenix-az`, etc. | `CityFilters.tsx`, `FilterChip.tsx` |
| Density toggle | `density-compact`, `density-comfortable`, `density-expanded` | `DensityToggle.tsx` |
| Search dropdowns | `search-result-artist`, `search-result-venue` | `ArtistInput.tsx`, `VenueInput.tsx` |
| Admin tabs | `admin-tab-dashboard`, `admin-tab-pending-shows`, etc. (17 tabs) | `admin/page.tsx` |

All 49 related tests pass.

Closes PSY-221

## Test plan
- [ ] Verify testids appear in DOM via browser DevTools
- [ ] agent-browser can target elements by testid for dogfooding
- [ ] No visual changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)