### PR TITLE
Fix show cost: parse first dollar amount from free-text input

### DIFF
--- a/frontend/components/forms/show-form-utils.test.ts
+++ b/frontend/components/forms/show-form-utils.test.ts
@@ -179,8 +179,20 @@ describe('parseCost', () => {
     expect(parseCost('15')).toBe(15)
   })
 
-  it('returns undefined for "Free"', () => {
-    expect(parseCost('Free')).toBeUndefined()
+  it('returns 0 for "Free"', () => {
+    expect(parseCost('Free')).toBe(0)
+  })
+
+  it('returns 0 for "free" (case-insensitive)', () => {
+    expect(parseCost('free')).toBe(0)
+  })
+
+  it('returns 0 for "FREE"', () => {
+    expect(parseCost('FREE')).toBe(0)
+  })
+
+  it('returns 0 for " Free " (with whitespace)', () => {
+    expect(parseCost(' Free ')).toBe(0)
   })
 
   it('returns undefined for empty string', () => {
@@ -193,6 +205,26 @@ describe('parseCost', () => {
 
   it('parses "$5 suggested donation" to 5', () => {
     expect(parseCost('$5 suggested donation')).toBe(5)
+  })
+
+  it('parses "$12 adv / $18 day of" to 12 (first price)', () => {
+    expect(parseCost('$12 adv / $18 day of')).toBe(12)
+  })
+
+  it('parses "$15/$20" to 15 (first price)', () => {
+    expect(parseCost('$15/$20')).toBe(15)
+  })
+
+  it('parses "$10 - $15" to 10 (first price)', () => {
+    expect(parseCost('$10 - $15')).toBe(10)
+  })
+
+  it('parses "$ 25" with space after dollar sign', () => {
+    expect(parseCost('$ 25')).toBe(25)
+  })
+
+  it('returns undefined for text with no numbers', () => {
+    expect(parseCost('donation')).toBeUndefined()
   })
 })
 

--- a/frontend/components/forms/show-form-utils.ts
+++ b/frontend/components/forms/show-form-utils.ts
@@ -70,11 +70,24 @@ export function showToFormValues(show: ShowResponse): FormValues {
 }
 
 /**
- * Parse a cost string (e.g. "$20", "Free", "$12.50") into a number or undefined.
+ * Parse a cost string (e.g. "$20", "Free", "$12.50", "$12 adv / $18 day of")
+ * into a number or undefined.
+ *
+ * Extracts the first dollar amount from the string. For compound prices like
+ * "$12 adv / $18 day of", returns the first price (12). Recognizes "free"
+ * (case-insensitive) as 0.
  */
 export function parseCost(cost: string): number | undefined {
   if (!cost) return undefined
-  const parsed = parseFloat(cost.replace(/[^0-9.]/g, ''))
+
+  // "Free" (case-insensitive) means $0
+  if (/^\s*free\s*$/i.test(cost)) return 0
+
+  // Match the first dollar amount: optional "$", then digits with optional decimal
+  const match = cost.match(/\$?\s*(\d+(?:\.\d+)?)/)
+  if (!match) return undefined
+
+  const parsed = parseFloat(match[1])
   return isNaN(parsed) ? undefined : parsed
 }
 

--- a/frontend/lib/utils/formatters.test.ts
+++ b/frontend/lib/utils/formatters.test.ts
@@ -102,8 +102,8 @@ describe('formatPrice', () => {
     expect(formatPrice(15.5)).toBe('$15.50')
   })
 
-  it('formats zero', () => {
-    expect(formatPrice(0)).toBe('$0.00')
+  it('formats zero as Free', () => {
+    expect(formatPrice(0)).toBe('Free')
   })
 
   it('formats large price', () => {

--- a/frontend/lib/utils/formatters.ts
+++ b/frontend/lib/utils/formatters.ts
@@ -31,9 +31,10 @@ export function formatShowTime(
 }
 
 /**
- * Format price as "$XX.XX"
+ * Format price for display. Shows "Free" for $0, otherwise "$XX.XX".
  */
 export function formatPrice(price: number): string {
+  if (price === 0) return 'Free'
   return `$${price.toFixed(2)}`
 }
 


### PR DESCRIPTION
## Summary
Fix free-text show cost not being saved correctly. Entering "$12 adv / $18 day of" in the cost field was producing a bogus price of $1218 because `parseCost()` stripped all non-numeric characters first, concatenating the digits.

**Root cause:** `cost.replace(/[^0-9.]/g, '')` turned `"$12 adv / $18 day of"` into `"1218"`.

**Fix:** Rewrote `parseCost()` to use regex matching (`/\$?\s*(\d+(?:\.\d+)?)/`) that extracts the first dollar amount. Also added "Free" → price=0 mapping, and updated `formatPrice()` to display "Free" when price is 0.

**8 new test cases** covering:
- `"$12 adv / $18 day of"` → 12
- `"$15/$20"` → 15
- `"$10 - $15"` → 10
- `"Free"` / `"free"` → 0
- `"$ 25"` (space after $) → 25
- Pure text with no numbers → null

All 205 tests pass.

Closes PSY-219

## Test plan
- [ ] Submit a show with cost "$12 adv / $18 day of" → show detail displays "$12.00"
- [ ] Submit with cost "Free" → show detail displays "Free"
- [ ] Submit with cost "$25" → displays "$25.00" (unchanged behavior)
- [ ] Submit with no cost → no price displayed (unchanged behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)