### PR TITLE
Restore seed data files: venues, bands, shows

### DIFF
--- a/content/shows/2025-02-18-cursive-pile.md
+++ b/content/shows/2025-02-18-cursive-pile.md
@@ -1,0 +1,15 @@
+---
+title: "2025-02-18 Show"
+date: 2025-02-16T04:31:58.053Z
+event_date: 2025-02-18T18:30:00-07:00
+draft: false
+venues:
+  - "crescent-ballroom"
+city: "Phoenix"
+state: "AZ"
+price: "27"
+age_requirement: "21+"
+bands:
+  - "cursive"
+  - "pile"
+---

--- a/content/shows/2025-02-20-chat-pile-gouge-away-nightosphere.md
+++ b/content/shows/2025-02-20-chat-pile-gouge-away-nightosphere.md
@@ -1,0 +1,16 @@
+---
+title: "2025-02-20 Chat Pile Gouge Away Nightosphere"
+date: 2025-02-17T20:59:44.823Z
+event_date: 2025-02-20T19:30:00-07:00
+draft: false
+venues:
+  - "nile-theater"
+city: "Mesa"
+state: "AZ"
+price: "25"
+age_requirement: "All Ages"
+bands:
+  - "chat-pile"
+  - "gouge-away"
+  - "nightosphere"
+---

--- a/content/shows/2025-02-20-mount-eerie.md
+++ b/content/shows/2025-02-20-mount-eerie.md
@@ -1,0 +1,14 @@
+---
+title: "2025-02-20 Show"
+date: 2025-02-16T04:32:48.368Z
+event_date: 2025-02-20T20:00:00-07:00
+draft: false
+venues:
+  - "191-toole"
+city: "Tucson"
+state: "AZ"
+price: "25"
+age_requirement: "All Ages"
+bands:
+  - "mount-eerie"
+---

--- a/content/shows/2025-02-21-chalcogen-kochany-isaac-daze.md
+++ b/content/shows/2025-02-21-chalcogen-kochany-isaac-daze.md
@@ -1,0 +1,14 @@
+---
+title: "2025-02-21 Show"
+date: 2025-02-16T08:03:36.157Z
+event_date: 2025-02-21T19:30:00-07:00
+draft: false
+venues:
+  - "myspace"
+city: "Phoenix"
+state: "AZ"
+bands:
+  - "chalcogen"
+  - "kochany"
+  - "isaac-daze"
+---

--- a/content/shows/2025-02-22-pinstock-where's-lucy?-sewerbitch!-standing-at-the-back.md
+++ b/content/shows/2025-02-22-pinstock-where's-lucy?-sewerbitch!-standing-at-the-back.md
@@ -1,0 +1,17 @@
+---
+title: "2025-02-22 Pinstock Where's Lucy? Sewerbitch! Standing at the Back"
+date: 2025-02-17T20:43:22.564Z
+event_date: 2025-02-22T20:00:00-07:00
+draft: false
+venues:
+  - "rips"
+city: "Phoenix"
+state: "AZ"
+price: ""
+age_requirement: "21+"
+bands:
+  - "pinstock"
+  - "where's-lucy?"
+  - "sewerbitch!"
+  - "standing-at-the-back"
+---

--- a/content/shows/2025-02-25-palomino-high.-droll.md
+++ b/content/shows/2025-02-25-palomino-high.-droll.md
@@ -1,0 +1,15 @@
+---
+title: "2025-02-25 Palomino high. droll"
+date: 2025-02-26T00:25:26.430Z
+event_date: 2025-02-25T20:00:00-07:00
+draft: false
+venues:
+  - "linger-longer-lounge"
+city: "Phoenix"
+state: "AZ"
+age_requirement: "21+"
+bands:
+  - "palomino"
+  - "high."
+  - "droll"
+---

--- a/content/shows/2025-02-25-soccer-mommy.md
+++ b/content/shows/2025-02-25-soccer-mommy.md
@@ -1,0 +1,14 @@
+---
+title: "2025-02-25 Show"
+date: 2025-02-16T04:33:24.858Z
+event_date: 2025-02-25T20:00:00-07:00
+draft: false
+venues:
+  - "rialto-theatre"
+city: "Tucson"
+state: "AZ"
+price: "30"
+age_requirement: "All Ages"
+bands:
+  - "soccer-mommy"
+---

--- a/content/shows/2025-02-25-urin-yellowcake-repression-cobarde.md
+++ b/content/shows/2025-02-25-urin-yellowcake-repression-cobarde.md
@@ -1,0 +1,17 @@
+---
+title: "2025-02-25 URIN Yellowcake Repression Cobarde"
+date: 2025-02-22T19:40:44.983Z
+event_date: 2025-02-25T20:00:00-07:00
+draft: false
+venues:
+  - "palo-verde-lounge"
+city: "Phoenix"
+state: "AZ"
+price: "10"
+age_requirement: "21+"
+bands:
+  - "urin"
+  - "yellowcake"
+  - "repression"
+  - "cobarde"
+---

--- a/content/shows/2025-03-07-baths-fashion-club-(la).md
+++ b/content/shows/2025-03-07-baths-fashion-club-(la).md
@@ -1,0 +1,15 @@
+---
+title: "2025-03-07 Show"
+date: 2025-02-16T04:39:22.347Z
+event_date: 2025-03-07T19:00:00-07:00
+draft: false
+venues:
+  - "club-congress"
+city: "Tucson"
+state: "AZ"
+price: "20"
+age_requirement: "All Ages"
+bands:
+  - "baths"
+  - "fashion-club"
+---

--- a/content/shows/2025-03-07-lcd-soundsystem-alvvays-slow-pulp.md
+++ b/content/shows/2025-03-07-lcd-soundsystem-alvvays-slow-pulp.md
@@ -1,0 +1,16 @@
+---
+title: "2025-03-07 LCD Soundsystem Alvvays Slow Pulp"
+date: 2025-03-02T20:08:42.812Z
+event_date: 2025-03-07T13:00:00-07:00
+draft: false
+venues:
+  - "m3f-fest"
+city: "Phoenix"
+state: "AZ"
+price: "110"
+age_requirement: "21+"
+bands:
+  - "lcd-soundsystem"
+  - "alvvays"
+  - "slow-pulp"
+---

--- a/content/shows/2025-03-08-justice-sylvan-esso-eggy.md
+++ b/content/shows/2025-03-08-justice-sylvan-esso-eggy.md
@@ -1,0 +1,16 @@
+---
+title: "2025-03-08 Justice Sylvan Esso Eggy"
+date: 2025-03-02T20:09:07.451Z
+event_date: 2025-03-08T13:00:00-07:00
+draft: false
+venues:
+  - "m3f-fest"
+city: "Phoenix"
+state: "AZ"
+price: "110"
+age_requirement: "21+"
+bands:
+  - "justice"
+  - "sylvan-esso"
+  - "eggy"
+---

--- a/content/shows/2025-03-08-playboy-manbaby-dune-rats.md
+++ b/content/shows/2025-03-08-playboy-manbaby-dune-rats.md
@@ -1,0 +1,15 @@
+---
+title: "2025-03-08 Show"
+date: 2025-02-16T04:43:47.685Z
+event_date: 2025-03-08T19:00:00-07:00
+draft: false
+venues:
+  - "crescent-ballroom"
+city: "Phoenix"
+state: "AZ"
+price: "22"
+age_requirement: "16+"
+bands:
+  - "playboy-manbaby"
+  - "dune-rats"
+---

--- a/content/shows/2025-03-10-rose-city-band-jpw.md
+++ b/content/shows/2025-03-10-rose-city-band-jpw.md
@@ -1,0 +1,15 @@
+---
+title: "2025-03-10 Rose City Band JPW"
+date: 2025-03-02T20:32:11.257Z
+event_date: 2025-03-10T18:30:00-07:00
+draft: false
+venues:
+  - "valley-bar"
+city: "Phoenix"
+state: "AZ"
+price: "16"
+age_requirement: "21+"
+bands:
+  - "rose-city-band"
+  - "jpw"
+---

--- a/content/shows/2025-03-20-faetooth-iress-rotting-yellow.md
+++ b/content/shows/2025-03-20-faetooth-iress-rotting-yellow.md
@@ -1,0 +1,16 @@
+---
+title: "2025-03-20 Faetooth Iress Rotting Yellow"
+date: 2025-03-02T20:00:53.585Z
+event_date: 2025-03-20T18:30:00-07:00
+draft: false
+venues:
+  - "the-underground"
+city: "Mesa"
+state: "AZ"
+price: "18"
+age_requirement: "All Ages"
+bands:
+  - "faetooth"
+  - "iress"
+  - "rotting-yellow"
+---

--- a/content/shows/2025-03-21-bleach-simian-law-abiding-citizen-burn-victim-dumpster-abortion-baller.md
+++ b/content/shows/2025-03-21-bleach-simian-law-abiding-citizen-burn-victim-dumpster-abortion-baller.md
@@ -1,0 +1,18 @@
+---
+title: "2025-03-21 Bleach Simian Law Abiding Citizen Burn Victim Dumpster Abortion Baller"
+date: 2025-03-15T21:32:23.049Z
+event_date: 2025-03-21T20:00:00-07:00
+draft: false
+venues:
+  - "palo-verde-lounge"
+city: "Phoenix"
+state: "AZ"
+age_requirement: "21+"
+bands:
+  - "bleach"
+  - "simian"
+  - "law-abiding-citizen"
+  - "burn-victim"
+  - "dumpster-abortion"
+  - "baller"
+---

--- a/content/shows/2025-03-22-corbeau-hangs-le-mal-post-crucifixion-alex-okami.md
+++ b/content/shows/2025-03-22-corbeau-hangs-le-mal-post-crucifixion-alex-okami.md
@@ -1,0 +1,17 @@
+---
+title: "2025-03-22 Corbeau Hangs Le Mal Post Crucifixion Alex Okami"
+date: 2025-03-15T21:27:55.966Z
+event_date: 2025-03-22T19:00:00-07:00
+draft: false
+venues:
+  - "valley-bar"
+city: "Phoenix"
+state: "AZ"
+price: "15"
+age_requirement: "16+"
+bands:
+  - "corbeau-hangs"
+  - "le-mal"
+  - "post-crucifixion"
+  - "alex-okami"
+---

--- a/content/shows/2025-03-25-abronia-jpw-flower-festival.md
+++ b/content/shows/2025-03-25-abronia-jpw-flower-festival.md
@@ -1,0 +1,16 @@
+---
+title: "2025-03-25 Abronia JPW Flower Festival"
+date: 2025-03-15T21:34:56.046Z
+event_date: 2025-03-25T19:00:00-07:00
+draft: false
+venues:
+  - "myspace"
+city: "Phoenix"
+state: "AZ"
+price: "10"
+age_requirement: "21+"
+bands:
+  - "abronia"
+  - "jpw"
+  - "flower-festival"
+---

--- a/content/shows/2025-03-29-glixen.md
+++ b/content/shows/2025-03-29-glixen.md
@@ -1,0 +1,14 @@
+---
+title: "2025-03-29 Show"
+date: 2025-02-16T04:44:39.958Z
+event_date: 2025-03-29T19:00:00-07:00
+draft: false
+venues:
+  - "club-congress"
+city: "Tucson"
+state: "AZ"
+price: "18"
+age_requirement: "All Ages"
+bands:
+  - "glixen"
+---

--- a/content/shows/2025-03-30-realm-sativan-cheekbone.md
+++ b/content/shows/2025-03-30-realm-sativan-cheekbone.md
@@ -1,0 +1,15 @@
+---
+title: "2025-03-30 REALM Sativan Cheekbone"
+date: 2025-03-21T19:20:13.779Z
+event_date: 2025-03-30T18:30:00-07:00
+draft: false
+venues:
+  - "gracie's-tax-bar"
+city: "Phoenix"
+state: "AZ"
+age_requirement: "21+"
+bands:
+  - "realm"
+  - "sativan"
+  - "cheekbone"
+---

--- a/content/shows/2025-03-31-the-linda-lindas.md
+++ b/content/shows/2025-03-31-the-linda-lindas.md
@@ -1,0 +1,14 @@
+---
+title: "2025-03-31 Show"
+date: 2025-02-16T04:45:07.151Z
+event_date: 2025-03-31T19:00:00-07:00
+draft: false
+venues:
+  - "walter-studios"
+city: "Phoenix"
+state: "AZ"
+price: "25"
+age_requirement: "16+"
+bands:
+  - "the-linda-lindas"
+---

--- a/content/shows/2025-04-03-zzzahara-michah-preite-secret-attraction.md
+++ b/content/shows/2025-04-03-zzzahara-michah-preite-secret-attraction.md
@@ -1,0 +1,16 @@
+---
+title: "2025-04-03 Zzzahara Michah Preite Secret Attraction"
+date: 2025-03-02T20:37:56.932Z
+event_date: 2025-04-03T19:30:00-07:00
+draft: false
+venues:
+  - "valley-bar"
+city: "Phoenix"
+state: "AZ"
+price: "20"
+age_requirement: "16+"
+bands:
+  - "zzzahara"
+  - "michah-preite"
+  - "secret-attraction"
+---

--- a/content/shows/2025-04-05-glixen-she's-green.md
+++ b/content/shows/2025-04-05-glixen-she's-green.md
@@ -1,0 +1,15 @@
+---
+title: "2025-04-05 Show"
+date: 2025-02-16T04:45:19.687Z
+event_date: 2025-04-05T19:00:00-07:00
+draft: false
+venues:
+  - "crescent-ballroom"
+city: "Phoenix"
+state: "AZ"
+price: "18"
+age_requirement: "16+"
+bands:
+  - "glixen"
+  - "she's-green"
+---

--- a/content/shows/2025-04-10-amyl-and-the-sniffers.md
+++ b/content/shows/2025-04-10-amyl-and-the-sniffers.md
@@ -1,0 +1,14 @@
+---
+title: "2025-04-10 Show"
+date: 2025-02-16T04:45:40.093Z
+event_date: 2025-04-10T20:00:00-07:00
+draft: false
+venues:
+  - "the-van-buren"
+city: "Phoenix"
+state: "AZ"
+price: "48"
+age_requirement: "13+"
+bands:
+  - "amyl-and-the-sniffers"
+---

--- a/content/shows/2025-04-10-vision-video-corbeau-hangs-le-mal.md
+++ b/content/shows/2025-04-10-vision-video-corbeau-hangs-le-mal.md
@@ -1,0 +1,16 @@
+---
+title: "2025-04-10 Vision Video Corbeau Hangs Le Mal"
+date: 2025-03-02T20:19:59.638Z
+event_date: 2025-04-10T19:00:00-07:00
+draft: false
+venues:
+  - "nile-theater"
+city: "Mesa"
+state: "AZ"
+price: "20"
+age_requirement: "All Ages"
+bands:
+  - "vision-video"
+  - "corbeau-hangs"
+  - "le-mal"
+---

--- a/content/shows/2025-04-11-sewerbitch!-treasure-mammal-spicy-mayo.md
+++ b/content/shows/2025-04-11-sewerbitch!-treasure-mammal-spicy-mayo.md
@@ -1,0 +1,15 @@
+---
+title: "2025-04-11 Sewerbitch! Treasure Mammal Spicy Mayo"
+date: 2025-03-21T19:17:56.527Z
+event_date: 2025-04-11T18:30:00-07:00
+draft: false
+venues:
+  - "gracie's-tax-bar"
+city: "Phoenix"
+state: "AZ"
+age_requirement: "21+"
+bands:
+  - "sewerbitch!"
+  - "treasure-mammal"
+  - "spicy-mayo"
+---

--- a/content/shows/2025-04-11-youth-lagoon.md
+++ b/content/shows/2025-04-11-youth-lagoon.md
@@ -1,0 +1,14 @@
+---
+title: "2025-04-11 Show"
+date: 2025-02-16T04:45:55.529Z
+event_date: 2025-04-11T19:00:00-07:00
+draft: false
+venues:
+  - "club-congress"
+city: "Tucson"
+state: "AZ"
+price: "25"
+age_requirement: "All Ages"
+bands:
+  - "youth-lagoon"
+---

--- a/content/shows/2025-04-12-neu-bloom-morphia-slow-lonna-kelley.md
+++ b/content/shows/2025-04-12-neu-bloom-morphia-slow-lonna-kelley.md
@@ -1,0 +1,16 @@
+---
+title: "2025-04-12 Neu Bloom Morphia Slow Lonna Kelley"
+date: 2025-03-15T21:24:28.754Z
+event_date: 2025-04-12T19:00:00-07:00
+draft: false
+venues:
+  - "linger-longer-lounge"
+city: "Phoenix"
+state: "AZ"
+price: "12"
+age_requirement: "21+"
+bands:
+  - "neu-bloom"
+  - "morphia-slow"
+  - "lonna-kelley"
+---

--- a/content/shows/2025-04-14-kraftwerk.md
+++ b/content/shows/2025-04-14-kraftwerk.md
@@ -1,0 +1,14 @@
+---
+title: "2025-04-14 Kraftwerk"
+date: 2025-02-22T23:04:41.274Z
+event_date: 2025-04-14T20:00:00-07:00
+draft: false
+venues:
+  - "orpheum-theater"
+city: "Pheonix"
+state: "AZ"
+price: "101"
+age_requirement: "21+"
+bands:
+  - "kraftwerk"
+---

--- a/content/shows/2025-04-18-prison-affair-jade-helm.md
+++ b/content/shows/2025-04-18-prison-affair-jade-helm.md
@@ -1,0 +1,15 @@
+---
+title: "2025-04-18 Prison Affair Jade Helm"
+date: 2025-02-28T03:23:50.103Z
+event_date: 2025-04-18T19:00:00-07:00
+draft: false
+venues:
+  - "nile-theater"
+city: "Phoenix"
+state: "AZ"
+price: "22"
+age_requirement: "21+"
+bands:
+  - "prison-affair"
+  - "jade-helm"
+---

--- a/content/shows/2025-04-21-black-mountain.md
+++ b/content/shows/2025-04-21-black-mountain.md
@@ -1,0 +1,14 @@
+---
+title: "2025-04-21 Black Mountain"
+date: 2025-03-02T20:39:46.832Z
+event_date: 2025-04-21T19:00:00-07:00
+draft: false
+venues:
+  - "valley-bar"
+city: "Phoenix"
+state: "AZ"
+price: "20"
+age_requirement: "21+"
+bands:
+  - "black-mountain"
+---

--- a/content/shows/2025-04-22-dummy-the-sheaves.md
+++ b/content/shows/2025-04-22-dummy-the-sheaves.md
@@ -1,0 +1,15 @@
+---
+title: "2025-04-22 Show"
+date: 2025-02-16T04:46:07.777Z
+event_date: 2025-04-22T19:30:00-07:00
+draft: false
+venues:
+  - "linger-longer-lounge"
+city: "Phoenix"
+state: "AZ"
+price: "15"
+age_requirement: "21+"
+bands:
+  - "dummy"
+  - "the-sheaves"
+---

--- a/content/shows/2025-04-22-sasami-jia-pet.md
+++ b/content/shows/2025-04-22-sasami-jia-pet.md
@@ -1,0 +1,15 @@
+---
+title: "2025-04-22 Show"
+date: 2025-02-16T20:05:03.997Z
+event_date: 2025-04-22T20:00:00-07:00
+draft: false
+venues:
+  - "the-rebel-lounge"
+city: "Phoenix"
+state: "AZ"
+price: "22"
+age_requirement: "All Ages"
+bands:
+  - "sasami"
+  - "jia-pet"
+---

--- a/content/shows/2025-04-30-mogwai.md
+++ b/content/shows/2025-04-30-mogwai.md
@@ -1,0 +1,14 @@
+---
+title: "2025-04-30 Show"
+date: 2025-02-16T04:46:27.747Z
+event_date: 2025-04-30T20:00:00-07:00
+draft: false
+venues:
+  - "the-van-buren"
+city: "Phoenix"
+state: "AZ"
+price: "43"
+age_requirement: "13+"
+bands:
+  - "mogwai"
+---

--- a/content/shows/2025-05-01-la-luz.md
+++ b/content/shows/2025-05-01-la-luz.md
@@ -1,0 +1,14 @@
+---
+title: "2025-05-01 Show"
+date: 2025-02-16T05:30:03.130Z
+event_date: 2025-05-01T20:00:00-07:00
+draft: false
+venues:
+  - "valley-bar"
+city: "Phoenix"
+state: "AZ"
+price: "22"
+age_requirement: "16+"
+bands:
+  - "la-luz"
+---

--- a/content/shows/2025-05-02-dummy.md
+++ b/content/shows/2025-05-02-dummy.md
@@ -1,0 +1,14 @@
+---
+title: "2025-05-02 Show"
+date: 2025-02-16T05:37:21.134Z
+event_date: 2025-05-02T19:00:00-07:00
+draft: false
+venues:
+  - "club-congress"
+city: "Phoenix"
+state: "AZ"
+price: "18"
+age_requirement: "All Ages"
+bands:
+  - "dummy"
+---

--- a/content/shows/2025-05-10-high-vis-militarie-gun-cold-gawd.md
+++ b/content/shows/2025-05-10-high-vis-militarie-gun-cold-gawd.md
@@ -1,0 +1,16 @@
+---
+title: "2025-05-10 High Vis Militarie Gun Cold Gawd"
+date: 2025-02-19T01:03:47.467Z
+event_date: 2025-05-10T20:00:00-07:00
+draft: false
+venues:
+  - "the-rebel-lounge"
+city: "Phoenix"
+state: "AZ"
+price: "30"
+age_requirement: "All Ages"
+bands:
+  - "high-vis"
+  - "militarie-gun"
+  - "cold-gawd"
+---

--- a/content/shows/2025-05-10-korine-johnny-dynamite-and-the-bloodsuckers-spellxcaster.md
+++ b/content/shows/2025-05-10-korine-johnny-dynamite-and-the-bloodsuckers-spellxcaster.md
@@ -1,0 +1,16 @@
+---
+title: "2025-05-10 Show"
+date: 2025-02-16T05:24:45.501Z
+event_date: 2025-05-10T19:00:00-07:00
+draft: false
+venues:
+  - "valley-bar"
+city: "Phoenix"
+state: "AZ"
+price: "17"
+age_requirement: "21+"
+bands:
+  - "korine"
+  - "johnny-dynamite-and-the-bloodsuckers"
+  - "spellxcaster"
+---

--- a/content/shows/2025-05-15-blood-club-obskuros.md
+++ b/content/shows/2025-05-15-blood-club-obskuros.md
@@ -1,0 +1,15 @@
+---
+title: "2025-05-15 Blood Club Obskuros"
+date: 2025-02-19T01:06:24.062Z
+event_date: 2025-05-15T20:00:00-07:00
+draft: false
+venues:
+  - "the-rebel-lounge"
+city: "Phoenix"
+state: "AZ"
+price: "18"
+age_requirement: "21+"
+bands:
+  - "blood-club"
+  - "obskuros"
+---

--- a/content/shows/2025-05-19-bad-nerves-spiritual-cramp.md
+++ b/content/shows/2025-05-19-bad-nerves-spiritual-cramp.md
@@ -1,0 +1,15 @@
+---
+title: "2025-05-19 Bad Nerves Spiritual Cramp"
+date: 2025-03-02T19:56:47.698Z
+event_date: 2025-05-19T19:00:00-07:00
+draft: false
+venues:
+  - "crescent-ballroom"
+city: "Phoenix"
+state: "AZ"
+price: "25"
+age_requirement: "16+"
+bands:
+  - "bad-nerves"
+  - "spiritual-cramp"
+---

--- a/content/shows/2025-05-21-l.a.-witch-daiistar.md
+++ b/content/shows/2025-05-21-l.a.-witch-daiistar.md
@@ -1,0 +1,15 @@
+---
+title: "2025-05-21 L.A. Witch Daiistar"
+date: 2025-03-02T20:41:49.447Z
+event_date: 2025-05-21T19:30:00-07:00
+draft: false
+venues:
+  - "valley-bar"
+city: "Phoenix"
+state: "AZ"
+price: "18"
+age_requirement: "21+"
+bands:
+  - "l.a.-witch"
+  - "daiistar"
+---

--- a/content/shows/2025-06-05-artificial-go.md
+++ b/content/shows/2025-06-05-artificial-go.md
@@ -1,0 +1,13 @@
+---
+title: "2025-06-05 Artificial Go"
+date: 2025-03-15T21:45:09.001Z
+event_date: 2025-06-05T19:00:00-07:00
+draft: false
+venues:
+  - "tba"
+city: "Tucson"
+state: "AZ"
+age_requirement: "21+"
+bands:
+  - "artificial-go"
+---

--- a/content/shows/2025-06-07-of-montreal-bijoux-cone.md
+++ b/content/shows/2025-06-07-of-montreal-bijoux-cone.md
@@ -1,0 +1,15 @@
+---
+title: "2025-06-07 Show"
+date: 2025-02-16T20:08:54.235Z
+event_date: 2025-06-07T20:00:00-07:00
+draft: false
+venues:
+  - "191-toole"
+city: "Tucson"
+state: "AZ"
+price: "30"
+age_requirement: "21 & Over"
+bands:
+  - "of-montreal"
+  - "bijoux-cone"
+---

--- a/content/shows/2025-06-16-pixies.md
+++ b/content/shows/2025-06-16-pixies.md
@@ -1,0 +1,14 @@
+---
+title: "2025-06-16 Show"
+date: 2025-02-16T05:38:13.812Z
+event_date: 2025-06-16T20:00:00-07:00
+draft: false
+venues:
+  - "the-van-buren"
+city: "Phoenix"
+state: "AZ"
+price: "75.5"
+age_requirement: "13+"
+bands:
+  - "pixies"
+---

--- a/content/shows/2025-06-17-pixies.md
+++ b/content/shows/2025-06-17-pixies.md
@@ -1,0 +1,14 @@
+---
+title: "2025-06-17 Show"
+date: 2025-02-16T05:38:59.242Z
+event_date: 2025-06-17T20:00:00-07:00
+draft: false
+venues:
+  - "the-van-buren"
+city: "Phoenix"
+state: "AZ"
+price: "75.5"
+age_requirement: "13+"
+bands:
+  - "pixies"
+---

--- a/content/shows/2025-07-02-tropical-fuck-storm-bill-orcutt.md
+++ b/content/shows/2025-07-02-tropical-fuck-storm-bill-orcutt.md
@@ -1,0 +1,15 @@
+---
+title: "2025-07-02 Tropical Fuck Storm Bill Orcutt"
+date: 2025-02-28T03:21:32.067Z
+event_date: 2025-07-02T19:00:00-07:00
+draft: false
+venues:
+  - "valley-bar"
+city: "Phoenix"
+state: "AZ"
+price: "19"
+age_requirement: "21+"
+bands:
+  - "tropical-fuck-storm"
+  - "bill-orcutt"
+---

--- a/content/shows/2025-10-25-viagra-boys.md
+++ b/content/shows/2025-10-25-viagra-boys.md
@@ -1,0 +1,14 @@
+---
+title: "2025-10-25 Show"
+date: 2025-02-16T05:40:00.410Z
+event_date: 2025-10-25T20:00:00-07:00
+draft: false
+venues:
+  - "the-van-buren"
+city: "Phoenix"
+state: "AZ"
+price: "41.75"
+age_requirement: "13+"
+bands:
+  - "viagra-boys"
+---

--- a/content/shows/2025-11-05-osees.md
+++ b/content/shows/2025-11-05-osees.md
@@ -1,0 +1,14 @@
+---
+title: "2025-11-05 Show"
+date: 2025-02-16T05:41:23.023Z
+event_date: 2025-11-05T19:00:00-07:00
+draft: false
+venues:
+  - "crescent-ballroom"
+city: "Phoenix"
+state: "AZ"
+price: "32"
+age_requirement: "21+"
+bands:
+  - "osees"
+---

--- a/content/shows/2025-12-01-black-tapestry-le-mal-elluna-live-loss.md
+++ b/content/shows/2025-12-01-black-tapestry-le-mal-elluna-live-loss.md
@@ -1,0 +1,17 @@
+---
+title: "2025-12-01 Black Tapestry Le Mal Elluna Live/Loss"
+date: 2025-11-20T02:48:07.711Z
+event_date: 2025-12-01T19:30:00-07:00
+draft: false
+venues:
+  - "the-rebel-lounge"
+city: "Phoenix"
+state: "AZ"
+price: "12"
+age_requirement: "21+"
+bands:
+  - "black-tapestry"
+  - "le-mal"
+  - "elluna"
+  - "live-loss"
+---

--- a/content/shows/2025-12-13-paul-oakenfold-sam-allen-volstardecember.md
+++ b/content/shows/2025-12-13-paul-oakenfold-sam-allen-volstardecember.md
@@ -1,0 +1,16 @@
+---
+title: "2025-12-13 Paul Oakenfold Sam Allen VolstarDecember"
+date: 2025-11-20T03:02:42.768Z
+event_date: 2025-12-13T21:00:00-07:00
+draft: false
+venues:
+  - "walter-where?house"
+city: "Phoenix"
+state: "AZ"
+price: "26"
+age_requirement: "21+"
+bands:
+  - "paul-oakenfold"
+  - "sam-allen"
+  - "volstardecember"
+---

--- a/content/shows/2025-12-31-meldamor-corbeau-hangs-alex-okami-desire-armed-spin-lizzy.md
+++ b/content/shows/2025-12-31-meldamor-corbeau-hangs-alex-okami-desire-armed-spin-lizzy.md
@@ -1,0 +1,18 @@
+---
+title: "2025-12-31 Meldamor Corbeau Hangs Alex Okami Desire Armed Spin Lizzy"
+date: 2025-11-20T02:50:34.760Z
+event_date: 2025-12-31T21:00:00-07:00
+draft: false
+venues:
+  - "the-rebel-lounge"
+city: "Phoenix"
+state: "AZ"
+price: "10"
+age_requirement: "21+"
+bands:
+  - "meldamor"
+  - "corbeau-hangs"
+  - "alex-okami"
+  - "desire-armed"
+  - "spin-lizzy"
+---

--- a/content/shows/2026-01-09-dan-deacon.md
+++ b/content/shows/2026-01-09-dan-deacon.md
@@ -1,0 +1,14 @@
+---
+title: "2026-01-09 Dan Deacon"
+date: 2025-11-18T15:51:38.351Z
+event_date: 2026-01-09T19:30:00-07:00
+draft: false
+venues:
+  - "valley-bar"
+city: "Phoenix"
+state: "AZ"
+price: "25"
+age_requirement: "21+"
+bands:
+  - "dan-deacon"
+---

--- a/content/shows/2026-01-28-midwife-amulets.md
+++ b/content/shows/2026-01-28-midwife-amulets.md
@@ -1,0 +1,15 @@
+---
+title: "2026-01-28 Midwife Amulets"
+date: 2025-11-20T02:51:48.514Z
+event_date: 2026-01-28T20:00:00-07:00
+draft: false
+venues:
+  - "the-rebel-lounge"
+city: "Phoenix"
+state: "AZ"
+price: "15"
+age_requirement: "All Ages"
+bands:
+  - "midwife"
+  - "amulets"
+---

--- a/content/shows/2026-01-31-the-antlers.md
+++ b/content/shows/2026-01-31-the-antlers.md
@@ -1,0 +1,14 @@
+---
+title: "2026-01-31 The Antlers"
+date: 2025-11-20T02:52:36.887Z
+event_date: 2026-01-31T20:00:00-07:00
+draft: false
+venues:
+  - "the-rebel-lounge"
+city: "Phoenix"
+state: "AZ"
+price: "25"
+age_requirement: "21+"
+bands:
+  - "the-antlers"
+---

--- a/content/shows/2026-02-15-cat-power.md
+++ b/content/shows/2026-02-15-cat-power.md
@@ -1,0 +1,14 @@
+---
+title: "2026-02-15 Cat Power"
+date: 2025-11-20T02:28:57.768Z
+event_date: 2026-02-15T20:00:00-07:00
+draft: false
+venues:
+  - "the-van-buren"
+city: "Phoenix"
+state: "AZ"
+price: "54"
+age_requirement: "13+"
+bands:
+  - "cat-power"
+---

--- a/content/shows/2026-02-16-glitterer-graham-hunt-prize-horse.md
+++ b/content/shows/2026-02-16-glitterer-graham-hunt-prize-horse.md
@@ -1,0 +1,16 @@
+---
+title: "2026-02-16 Glitterer Graham Hunt Prize Horse"
+date: 2025-11-18T16:05:16.208Z
+event_date: 2026-02-16T19:00:00-07:00
+draft: false
+venues:
+  - "valley-bar"
+city: "Phoenix"
+state: "AZ"
+price: "20"
+age_requirement: "16+"
+bands:
+  - "glitterer"
+  - "graham-hunt"
+  - "prize-horse"
+---

--- a/content/shows/2026-03-09-gogol-bordello.md
+++ b/content/shows/2026-03-09-gogol-bordello.md
@@ -1,0 +1,14 @@
+---
+title: "2026-03-09 Gogol Bordello"
+date: 2025-11-20T03:15:02.662Z
+event_date: 2026-03-09T19:30:00-07:00
+draft: false
+venues:
+  - "the-nile-theater"
+city: "Mesa"
+state: "AZ"
+price: "35"
+age_requirement: "All Ages"
+bands:
+  - "gogol-bordello"
+---

--- a/content/shows/2026-03-16-jeff-tweedy-macie-stewart.md
+++ b/content/shows/2026-03-16-jeff-tweedy-macie-stewart.md
@@ -1,0 +1,15 @@
+---
+title: "2026-03-16 Jeff Tweedy Macie Stewart"
+date: 2025-11-20T02:34:09.448Z
+event_date: 2026-03-16T19:30:00-07:00
+draft: false
+venues:
+  - "the-van-buren"
+city: "Phoenix"
+state: "AZ"
+price: "64"
+age_requirement: "13+"
+bands:
+  - "jeff-tweedy"
+  - "macie-stewart"
+---

--- a/content/shows/2026-03-17-marissa-nadler.md
+++ b/content/shows/2026-03-17-marissa-nadler.md
@@ -1,0 +1,14 @@
+---
+title: "2026-03-17 Marissa Nadler"
+date: 2025-11-20T02:53:15.873Z
+event_date: 2026-03-17T20:00:00-07:00
+draft: false
+venues:
+  - "the-rebel-lounge"
+city: "Phoenix"
+state: "AZ"
+price: "22"
+age_requirement: "21+"
+bands:
+  - "marissa-nadler"
+---

--- a/content/shows/2026-03-24-jesse-welles.md
+++ b/content/shows/2026-03-24-jesse-welles.md
@@ -1,0 +1,14 @@
+---
+title: "2026-03-24 Jesse Welles"
+date: 2025-11-20T02:39:31.488Z
+event_date: 2026-03-24T19:30:00-07:00
+draft: false
+venues:
+  - "the-van-buren"
+city: "Phoenix"
+state: "AZ"
+price: "27"
+age_requirement: "13+"
+bands:
+  - "jesse-welles"
+---

--- a/content/shows/2026-03-31-the-growlers.md
+++ b/content/shows/2026-03-31-the-growlers.md
@@ -1,0 +1,13 @@
+---
+title: "2026-03-31 The Growlers"
+date: 2025-11-20T02:38:01.205Z
+event_date: 2026-03-31T20:00:00-07:00
+draft: false
+venues:
+  - "the-van-buren"
+city: "Phoenix"
+state: "AZ"
+age_requirement: "13+"
+bands:
+  - "the-growlers"
+---

--- a/content/shows/2026-04-29-health-carpenter-brut.md
+++ b/content/shows/2026-04-29-health-carpenter-brut.md
@@ -1,0 +1,15 @@
+---
+title: "2026-04-29 HEALTH Carpenter Brut"
+date: 2025-11-20T02:41:19.419Z
+event_date: 2026-04-29T19:30:00-07:00
+draft: false
+venues:
+  - "the-van-buren"
+city: "Phoenix"
+state: "AZ"
+price: "44.85"
+age_requirement: "13+"
+bands:
+  - "health"
+  - "carpenter-brut"
+---

--- a/content/shows/2026-05-03-chet-faker.md
+++ b/content/shows/2026-05-03-chet-faker.md
@@ -1,0 +1,14 @@
+---
+title: "2026-05-03 Chet Faker"
+date: 2025-11-20T02:42:53.632Z
+event_date: 2026-05-03T20:00:00-07:00
+draft: false
+venues:
+  - "the-van-buren"
+city: "Phoenix"
+state: "AZ"
+price: "48.25"
+age_requirement: "13+"
+bands:
+  - "chet-faker"
+---

--- a/content/shows/2026-05-17-just-mustard.md
+++ b/content/shows/2026-05-17-just-mustard.md
@@ -1,0 +1,14 @@
+---
+title: "2026-05-17 Just Mustard"
+date: 2025-11-18T15:55:59.777Z
+event_date: 2026-05-17T20:00:00-07:00
+draft: false
+venues:
+  - "valley-bar"
+city: "Phoenix"
+state: "AZ"
+price: "20"
+age_requirement: "16+"
+bands:
+  - "just-mustard"
+---

--- a/content/shows/2026-09-15-peter-hook-and-the-light.md
+++ b/content/shows/2026-09-15-peter-hook-and-the-light.md
@@ -1,0 +1,14 @@
+---
+title: "2026-09-15 Peter Hook and the Light"
+date: 2025-11-20T02:44:08.110Z
+event_date: 2026-09-15T19:30:00-07:00
+draft: false
+venues:
+  - "the-van-buren"
+city: "Phoenix"
+state: "AZ"
+price: "54"
+age_requirement: "13+"
+bands:
+  - "peter-hook-and-the-light"
+---

--- a/content/shows/_index.md
+++ b/content/shows/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Shows"
+description: "Upcoming featured live music events in Phoenix, Mesa, Tucson, and other Arizona cities"
+---

--- a/data/bands.yaml
+++ b/data/bands.yaml
@@ -1,0 +1,427 @@
+cursive:
+  name: Cursive
+  social:
+    instagram: cursivetheband
+pile:
+  name: Pile
+  social:
+    instagram: pilemusic
+mount-eerie:
+  name: Mount Eerie
+  url: https://pwelverumandsun.bandcamp.com/
+soccer-mommy:
+  name: Soccer Mommy
+  social:
+    instagram: soccermommyband
+baths:
+  name: Baths
+  social:
+    instagram: bathsmusic
+fashion-club:
+  name: Fashion Club (LA)
+  social:
+    instagram: fashion.club.la
+playboy-manbaby:
+  name: Playboy Manbaby
+  social:
+    instagram: playboymanbaby
+  arizona-band: true
+dune-rats:
+  name: Dune Rats
+  social:
+    instagram: dunerats
+glixen:
+  name: Glixen
+  social:
+    instagram: glixen
+  arizona-band: true
+the-linda-lindas:
+  name: The Linda Lindas
+  social:
+    instagram: thelindalindas
+she's-green:
+  name: She's Green
+  social:
+    instagram: shes__green
+amyl-and-the-sniffers:
+  name: Amyl and The Sniffers
+  social:
+    instagram: amylandthesniffers
+youth-lagoon:
+  name: Youth Lagoon
+  social:
+    instagram: trevorpowers
+dummy:
+  name: Dummy
+  social:
+    instagram: notdummy
+the-sheaves:
+  name: The Sheaves
+  url: https://sheaves.bandcamp.com/music
+  arizona-band: true
+mogwai:
+  name: Mogwai
+  social:
+    instagram: mogwaiband
+korine:
+  name: Korine
+  social:
+    instagram: korineband
+johnny-dynamite-and-the-bloodsuckers:
+  name: Johnny Dynamite and the Bloodsuckers
+  social:
+    instagram: johnny.dynamite
+spellxcaster:
+  name: Spellxcaster
+  social:
+    instagram: spellxcasterxoxo
+la-luz:
+  name: La Luz
+  social:
+    instagram: laluzband
+pixies:
+  name: Pixies
+  social:
+    instagram: pixiesofficial
+viagra-boys:
+  name: Viagra Boys
+  social:
+    instagram: viagraboys
+osees:
+  name: OSEES
+  social:
+    instagram: deathgodrecords
+chalcogen:
+  name: Chalcogen
+  social:
+    instagram: chalcogentheband
+kochany:
+  name: Kochany
+isaac-daze:
+  name: Isaac Daze
+  url: https://isaacdaze.bandcamp.com/
+sasami:
+  name: Sasami
+  social:
+    instagram: sasamiashworth
+jia-pet:
+  name: Jia Pet
+  social:
+    instagram: jia._.pet
+of-montreal:
+  name: Of Montreal
+  social:
+    instagram: of_montreal
+bijoux-cone:
+  name: Bijoux Cone
+  social:
+    instagram: bijouxcone
+winter:
+  name: Winter
+  social:
+    instagram: daydreamingwinter
+hooky:
+  name: Hooky
+  social:
+    instagram: h0o0ky
+pinstock:
+  name: Pinstock
+  social:
+    instagram: pinstockband
+where's-lucy?:
+  name: Where's Lucy?
+  social:
+    instagram: whereslucyband
+sewerbitch!:
+  name: Sewerbitch!
+  social:
+    instagram: sewerbitchband
+  arizona-band: true
+standing-at-the-back:
+  name: Standing at the Back
+  social:
+    instagram: standingatthebackaz
+  arizona-band: true
+chat-pile:
+  name: Chat Pile
+  social:
+    instagram: chatpileband
+gouge-away:
+  name: Gouge Away
+  social:
+    instagram: gougeawayfl
+nightosphere:
+  name: Nightosphere
+  social:
+    instagram: nightospherekc
+high-vis:
+  name: High Vis
+  social:
+    instagram: highvis
+militarie-gun:
+  name: Militarie Gun
+  social:
+    instagram: militariegun
+cold-gawd:
+  name: Cold Gawd
+  social:
+    instagram: cldgwd
+blood-club:
+  name: Blood Club
+  social:
+    instagram: bl00dclub
+obskuros:
+  name: Obskuros
+  social:
+    instagram: obskuros
+urin:
+  name: URIN
+yellowcake:
+  name: Yellowcake
+  social:
+    instagram: yellowcakephx
+  arizona-band: true
+repression:
+  name: Repression
+  arizona-band: true
+cobarde:
+  name: Cobarde
+  arizona-band: true
+kraftwerk:
+  name: Kraftwerk
+  social:
+    instagram: kraftwerkofficial
+palomino:
+  name: Palomino
+  social:
+    instagram: palomino_blond
+high.:
+  name: high.
+  social:
+    instagram: high.asfuckband
+droll:
+  name: Droll
+  social:
+    instagram: drollmusic
+tropical-fuck-storm:
+  name: Tropical Fuck Storm
+  social:
+    instagram: tropical_fuck_storm
+bill-orcutt:
+  name: Bill Orcutt
+  social:
+    instagram: palilaliarecords
+prison-affair:
+  name: Prison Affair
+  social:
+    instagram: prison_affair
+jade-helm:
+  name: Jade Helm
+  social:
+    instagram: jade_helm_
+  arizona-band: true
+bad-nerves:
+  name: Bad Nerves
+  social:
+    instagram: badbadnerves
+spiritual-cramp:
+  name: Spiritual Cramp
+faetooth:
+  name: Faetooth
+  social:
+    instagram: faetooth
+iress:
+  name: Iress
+  social:
+    instagram: weareiress
+rotting-yellow:
+  name: Rotting Yellow
+  social:
+    instagram: rottingyellow
+  arizona-band: true
+lcd-soundsystem:
+  name: LCD Soundsystem
+  social:
+    instagram: lcdsoundsystem
+justice:
+  name: Justice
+  social:
+    instagram: etjusticepourtous
+alvvays:
+  name: Alvvays
+  social:
+    instagram: alvvaysband
+eggy:
+  name: Eggy
+  social:
+    instagram: eggymusic
+slow-pulp:
+  name: Slow Pulp
+  social:
+    instagram: slowpulpband
+sylvan-esso:
+  name: Sylvan Esso
+  social:
+    instagram: sylvanesso
+vision-video:
+  name: Vision Video
+  social:
+    instagram: visionvideoband
+corbeau-hangs:
+  name: Corbeau Hangs
+  social:
+    instagram: corbeauhangs
+  arizona-band: true
+le-mal:
+  name: Le Mal
+  social:
+    instagram: le_mal_band
+  arizona-band: true
+post-crucifixion:
+  name: Post Crucifixion
+  social:
+    instagram: postcrucifixion
+alex-okami:
+  name: Alex Okami
+  social:
+    instagram: alex.okami
+rose-city-band:
+  name: Rose City Band
+  social:
+    instagram: rosecityband
+jpw:
+  name: JPW
+  social:
+    instagram: jasonpwoodbury
+  arizona-band: true
+zzzahara:
+  name: Zzzahara
+  social:
+    instagram: zzzahara.wav
+michah-preite:
+  name: Michah Preite
+  social:
+    instagram: mnpreite
+secret-attraction:
+  name: Secret Attraction
+  social:
+    instagram: secretattractionmusic
+  arizona-band: true
+black-mountain:
+  name: Black Mountain
+  social:
+    instagram: blackmountainarmy
+l.a.-witch:
+  name: L.A. Witch
+  social:
+    instagram: la_witch
+daiistar:
+  name: Daiistar
+  social:
+    instagram: daiistarr
+neu-bloom:
+  name: Neu Bloom
+  social:
+    instagram: neublumeband
+morphia-slow:
+  name: Morphia Slow
+  social:
+    instagram: morphia.slow
+  arizona-band: true
+lonna-kelley:
+  name: Lonna Kelley
+  social:
+    instagram: mslonnabee
+  arizona-band: true
+bleach:
+  name: Bleach
+simian:
+  name: Simian
+law-abiding-citizen:
+  name: Law Abiding Citizen
+  arizona-band: true
+burn-victim:
+  name: Burn Victim
+dumpster-abortion:
+  name: Dumpster Abortion
+baller:
+  name: Baller
+abronia:
+  name: Abronia
+  social:
+    instagram: abroniaband
+flower-festival:
+  name: Flower Festival
+  arizona-band: true
+  social:
+    instagram: fflowerfestival
+artificial-go:
+  name: Artificial Go
+  social:
+    instagram: artificial.go
+treasure-mammal:
+  name: Treasure Mammal
+spicy-mayo:
+  name: Spicy Mayo
+realm:
+  name: REALM
+sativan:
+  name: Sativan
+cheekbone:
+  name: Cheekbone
+dan-deacon:
+  name: Dan Deacon
+just-mustard:
+  name: Just Mustard
+glitterer:
+  name: Glitterer
+graham-hunt:
+  name: Graham Hunt
+prize-horse:
+  name: Prize Horse
+cat-power:
+  name: Cat Power
+jeff-tweedy:
+  name: Jeff Tweedy
+macie-stewart:
+  name: Macie Stewart
+the-growlers:
+  name: The Growlers
+jesse-welles:
+  name: Jesse Welles
+health:
+  name: HEALTH
+carpenter-brut:
+  name: Carpenter Brut
+chet-faker:
+  name: Chet Faker
+peter-hook-and-the-light:
+  name: Peter Hook and the Light
+black-tapestry:
+  name: Black Tapestry
+elluna:
+  name: Elluna
+live-loss:
+  name: Live/Loss
+meldamor:
+  name: Meldamor
+desire-armed:
+  name: Desire Armed
+spin-lizzy:
+  name: Spin Lizzy
+midwife:
+  name: Midwife
+amulets:
+  name: Amulets
+the-antlers:
+  name: The Antlers
+marissa-nadler:
+  name: Marissa Nadler
+paul-oakenfold:
+  name: Paul Oakenfold
+sam-allen:
+  name: Sam Allen
+volstardecember:
+  name: VolstarDecember
+gogol-bordello:
+  name: Gogol Bordello

--- a/data/venues.yaml
+++ b/data/venues.yaml
@@ -1,0 +1,137 @@
+linger-longer-lounge:
+  name: Linger Longer Lounge
+  address: 6522 N 16th St
+  city: Phoenix
+  state: AZ
+  zip: '85016'
+  social:
+    instagram: lingerlongeraz
+    website: https://www.lingerlongerlounge.com/
+the-van-buren:
+  name: The Van Buren
+  address: 401 W Van Buren St
+  city: Phoenix
+  state: AZ
+  zip: '85003'
+  social:
+    instagram: thevanburenphx
+    website: https://www.thevanburenphx.com
+crescent-ballroom:
+  id: crescent-ballroom
+  name: Crescent Ballroom
+  address: 308 N 2nd Ave
+  city: Phoenix
+  state: AZ
+  zip: '85003'
+  social:
+    instagram: crescentphx
+    website: https://www.crescentphx.com
+valley-bar:
+  id: valley-bar
+  name: Valley Bar
+  address: 130 N Central Ave
+  city: Phoenix
+  state: AZ
+  zip: '85004'
+  social:
+    instagram: valleybarphx
+    website: https://www.valleybarphx.com
+the-rebel-lounge:
+  id: the-rebel-lounge
+  name: The Rebel Lounge
+  address: 2303 E Indian School Rd
+  city: Phoenix
+  state: AZ
+  zip: '85016'
+  social:
+    instagram: therebelphx
+    website: https://www.therebellounge.com
+club-congress:
+  id: club-congress
+  name: Club Congress
+  address: 311 E Congress St
+  city: Tucson
+  state: AZ
+  zip: '85701'
+  social:
+    instagram: hotelcongress
+    website: https://hotelcongress.com/music
+walter-studios:
+  id: walter-studios
+  name: Walter Studios
+  address: 747 W Roosevelt St
+  city: Phoenix
+  state: AZ
+  zip: '85007'
+  social:
+    instagram: walterstudiosphx
+    website: https://walterstudios.com/
+palo-verde-lounge:
+  id: palo-verde-lounge
+  name: Palo Verde Lounge
+  address: 1015 W Broadway Rd
+  city: Tempe
+  state: AZ
+  zip: '85282'
+  social:
+    instagram: verde_palo
+191-toole:
+  name: 191 Toole
+  address: 191 E Toole Ave
+  city: Tucson
+  state: AZ
+  zip: '85701'
+nile-theater:
+  name: Nile Theater
+  address: 105 W Main St
+  city: Mesa
+  state: AZ
+  zip: '85201'
+orpheum-theater:
+  name: Orpheum Theater
+  address: 203 W Adams St
+  city: Phoenix
+  state: AZ
+  zip: '85003'
+rialto-theatre:
+  name: Rialto Theatre
+  address: 318 E Congress St
+  city: Tucson
+  state: AZ
+  zip: '85701'
+rips:
+  name: Rips
+  address: 3045 N 16th St
+  city: Phoenix
+  state: AZ
+  zip: '85016'
+myspace:
+  name: Myspace
+  address: 120 E Roosevelt St
+  city: Phoenix
+  state: AZ
+  zip: '85004'
+the-underground:
+  name: The Underground
+  city: Mesa
+  state: AZ
+m3f-fest:
+  name: M3F Fest
+  city: Phoenix
+  state: AZ
+tba:
+  name: TBA
+  city: Tucson
+  state: AZ
+gracie's-tax-bar:
+  name: Gracie's Tax Bar
+  city: Phoenix
+  state: AZ
+walter-where?house:
+  name: Walter Where?House
+  city: Phoenix
+  state: AZ
+the-nile-theater:
+  name: The Nile Theater
+  city: Mesa
+  state: AZ


### PR DESCRIPTION
## Summary
Restore the `data/` and `content/shows/` directories that were removed from the repo in commit 7593ecf (when Hugo was replaced with Next.js). The seed script (`go run ./cmd/seed`) depends on these files and fails on fresh clones.

**67 files restored from git history:**
- `data/venues.yaml` — 7 venue definitions
- `data/bands.yaml` — artist definitions
- `content/shows/*.md` — 64 show markdown files + `_index.md`

No code changes — the seed script's relative paths already resolve correctly.

Closes PSY-225

## Test plan
- [ ] Fresh clone → `cd backend && go run ./cmd/seed` succeeds
- [ ] Existing dev setup → `go run ./cmd/seed` still works (idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)