### PR TITLE
Add --verbose flag to CLI for request/response debugging

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -22,6 +22,7 @@ program
   .description("CLI for rapid knowledge graph data entry into Psychic Homily")
   .version(version, "-V, --version")
   .option("--env <environment>", "Target environment (default: from config)")
+  .option("-v, --verbose", "Log full HTTP request/response details to stderr")
   .showHelpAfterError();
 
 // ─── ph init ───────────────────────────────────────────────────────────────────
@@ -132,14 +133,14 @@ program
   .command("status")
   .description("Show CLI configuration, API connectivity, and auth status")
   .action(async () => {
-    await runStatus(program.opts().env);
+    await runStatus(program.opts().env, program.opts().verbose);
   });
 
 // ─── Helpers ───────────────────────────────────────────────────────────────────
 
 async function resolveEnvOrExit(
   envOverride?: string,
-): Promise<{ url: string; token: string }> {
+): Promise<{ url: string; token: string; verbose?: boolean }> {
   const config = await readConfig();
   const resolved = resolveEnvironment(config, envOverride);
 
@@ -151,7 +152,8 @@ async function resolveEnvOrExit(
     process.exit(1);
   }
 
-  return resolved.env;
+  const verbose = program.opts().verbose ?? false;
+  return { ...resolved.env, verbose };
 }
 
 // ─── Run ───────────────────────────────────────────────────────────────────────

--- a/cli/src/commands/status.ts
+++ b/cli/src/commands/status.ts
@@ -7,7 +7,7 @@ import { green, red, dim, gray } from "../lib/ansi";
  * CLI entry point for `ph status`.
  * Shows current configuration, API reachability, and auth status.
  */
-export async function runStatus(envOverride?: string): Promise<void> {
+export async function runStatus(envOverride?: string, verbose?: boolean): Promise<void> {
   const config = await readConfig();
   const resolved = resolveEnvironment(config, envOverride);
 
@@ -30,7 +30,7 @@ export async function runStatus(envOverride?: string): Promise<void> {
   display.kv("Token", maskToken(resolved.env.token));
 
   // Check API reachability
-  const client = new APIClient(resolved.env);
+  const client = new APIClient({ ...resolved.env, verbose });
 
   const healthy = await client.healthCheck();
   if (!healthy) {

--- a/cli/src/lib/api.ts
+++ b/cli/src/lib/api.ts
@@ -1,4 +1,5 @@
 import type { EnvironmentConfig } from "./types";
+import { dim, gray, cyan, yellow } from "./ansi";
 
 export class APIError extends Error {
   constructor(
@@ -16,11 +17,13 @@ export class APIError extends Error {
 export class APIClient {
   private baseUrl: string;
   private token: string;
+  private verbose: boolean;
 
   constructor(env: EnvironmentConfig) {
     // Strip trailing slash
     this.baseUrl = env.url.replace(/\/+$/, "");
     this.token = env.token;
+    this.verbose = env.verbose ?? false;
   }
 
   /** Make an authenticated GET request. */
@@ -94,6 +97,61 @@ export class APIClient {
     return url.toString();
   }
 
+  private logVerbose(text: string): void {
+    process.stderr.write(text);
+  }
+
+  private logRequest(method: string, url: string, headers: Record<string, string>, body?: unknown): void {
+    if (!this.verbose) return;
+
+    this.logVerbose(`\n${dim("───── Request ─────")}\n`);
+    this.logVerbose(`${cyan(method)} ${url}\n`);
+
+    this.logVerbose(`${gray("Headers:")}\n`);
+    for (const [key, value] of Object.entries(headers)) {
+      const displayValue = key === "Authorization" ? `Bearer ${this.token.slice(0, 8)}...` : value;
+      this.logVerbose(`  ${dim(key + ":")} ${displayValue}\n`);
+    }
+
+    if (body !== undefined) {
+      this.logVerbose(`${gray("Body:")}\n`);
+      try {
+        this.logVerbose(`${JSON.stringify(body, null, 2)}\n`);
+      } catch {
+        this.logVerbose(`  ${dim("(unable to serialize body)")}\n`);
+      }
+    }
+  }
+
+  private logResponse(status: number, statusText: string, headers: Headers, body: string): void {
+    if (!this.verbose) return;
+
+    this.logVerbose(`\n${dim("───── Response ─────")}\n`);
+
+    const statusColor = status >= 400 ? yellow : cyan;
+    this.logVerbose(`${statusColor(`${status} ${statusText}`)}\n`);
+
+    this.logVerbose(`${gray("Headers:")}\n`);
+    headers.forEach((value, key) => {
+      this.logVerbose(`  ${dim(key + ":")} ${value}\n`);
+    });
+
+    if (body) {
+      this.logVerbose(`${gray("Body:")}\n`);
+      try {
+        const parsed = JSON.parse(body);
+        this.logVerbose(`${JSON.stringify(parsed, null, 2)}\n`);
+      } catch {
+        // Not JSON — print raw (truncated if very long)
+        const maxLen = 2000;
+        const truncated = body.length > maxLen ? body.slice(0, maxLen) + `\n${dim(`... (${body.length - maxLen} more bytes)`)}` : body;
+        this.logVerbose(`${truncated}\n`);
+      }
+    }
+
+    this.logVerbose(`${dim("────────────────────")}\n`);
+  }
+
   private async request<T>(
     method: string,
     url: string,
@@ -108,6 +166,8 @@ export class APIClient {
       headers["Content-Type"] = "application/json";
     }
 
+    this.logRequest(method, url, headers, body);
+
     const response = await fetch(url, {
       method,
       headers,
@@ -116,6 +176,8 @@ export class APIClient {
     });
 
     const text = await response.text();
+
+    this.logResponse(response.status, response.statusText, response.headers, text);
 
     if (!response.ok) {
       let message = `HTTP ${response.status}: ${response.statusText}`;

--- a/cli/src/lib/types.ts
+++ b/cli/src/lib/types.ts
@@ -2,6 +2,8 @@
 export interface EnvironmentConfig {
   url: string;
   token: string;
+  /** Runtime-only flag for verbose request/response logging. Not persisted. */
+  verbose?: boolean;
 }
 
 /** Top-level configuration stored at ~/.psychic-homily/config.json */


### PR DESCRIPTION
## Summary
- Adds `-v` / `--verbose` global flag to PH CLI that logs full HTTP request/response details
- Shows method, URL, headers (with masked auth token), and pretty-printed JSON bodies
- Response body is logged before error checking, so Huma 422 validation error details are visible
- All verbose output goes to stderr

## Test plan
- [x] All 232 CLI tests pass
- [ ] Manual: `ph --verbose status` shows request/response details
- [ ] Manual: `ph --verbose submit artist '{"name":"Test"}'` shows POST body and response
- [ ] Manual: verify auth token is masked in verbose output

Closes PSY-176

🤖 Generated with [Claude Code](https://claude.com/claude-code)