### PR TITLE
Tighten fuzzy artist name matching to prevent false positives

### DIFF
--- a/cli/src/commands/submit-festival.ts
+++ b/cli/src/commands/submit-festival.ts
@@ -5,6 +5,7 @@ import { green, yellow, gray, dim, cyan } from "../lib/ansi";
 import { validateFestival } from "../lib/schemas";
 import {
   checkDuplicate,
+  similarityScore,
   type DuplicateCheckResult,
   type FieldComparison,
 } from "../lib/duplicates";
@@ -90,12 +91,13 @@ const VALID_BILLING_TIERS = [
 
 /**
  * Resolve an artist name to an ID via GET /artists/search.
- * Returns the best match's ID, or null if not found.
+ * Returns the best match's ID and confidence score, or null if not found.
+ * Uses similarityScore to prevent false positives on short/ambiguous names.
  */
 async function resolveArtistId(
   client: APIClient,
   name: string,
-): Promise<{ id: number; name: string } | null> {
+): Promise<{ id: number; name: string; confidence: number } | null> {
   try {
     const result = await client.get<{
       artists: Array<{ id: number; name: string; slug: string }>;
@@ -107,10 +109,19 @@ async function resolveArtistId(
     const exact = result.artists.find(
       (a) => a.name.toLowerCase() === name.toLowerCase(),
     );
-    if (exact) return { id: exact.id, name: exact.name };
+    if (exact) return { id: exact.id, name: exact.name, confidence: 1.0 };
 
-    // Fall back to first result if it's a close enough match
-    return { id: result.artists[0].id, name: result.artists[0].name };
+    // Find best match by similarity score, require >= 0.7
+    const scored = result.artists
+      .map((a) => ({ ...a, score: similarityScore(name, a.name) }))
+      .filter((a) => a.score >= 0.7)
+      .sort((a, b) => b.score - a.score);
+
+    if (scored.length > 0) {
+      return { id: scored[0].id, name: scored[0].name, confidence: scored[0].score };
+    }
+
+    return null;
   } catch {
     return null;
   }
@@ -118,12 +129,13 @@ async function resolveArtistId(
 
 /**
  * Resolve a venue name to an ID via GET /venues/search.
- * Returns the best match's ID, or null if not found.
+ * Returns the best match's ID and confidence score, or null if not found.
+ * Uses similarityScore to prevent false positives.
  */
 async function resolveVenueId(
   client: APIClient,
   name: string,
-): Promise<{ id: number; name: string } | null> {
+): Promise<{ id: number; name: string; confidence: number } | null> {
   try {
     const result = await client.get<{
       venues: Array<{ id: number; name: string; slug: string }>;
@@ -134,9 +146,20 @@ async function resolveVenueId(
     const exact = result.venues.find(
       (v) => v.name.toLowerCase() === name.toLowerCase(),
     );
-    if (exact) return { id: exact.id, name: exact.name };
+    if (exact) return { id: exact.id, name: exact.name, confidence: 1.0 };
 
-    return { id: result.venues[0].id, name: result.venues[0].name };
+    // Find best match by similarity score, require >= 0.5
+    // (lower threshold for venues since formal names often include prefixes like "Margaret T.")
+    const scored = result.venues
+      .map((v) => ({ ...v, score: similarityScore(name, v.name) }))
+      .filter((v) => v.score >= 0.5)
+      .sort((a, b) => b.score - a.score);
+
+    if (scored.length > 0) {
+      return { id: scored[0].id, name: scored[0].name, confidence: scored[0].score };
+    }
+
+    return null;
   } catch {
     return null;
   }
@@ -268,6 +291,20 @@ export async function submitFestivals(
     }
   }
 
+  // --- Phase 2c: Pre-resolve artists for preview ---
+  const preResolvedArtists: Map<number, Array<{ input: string; resolved: { id: number; name: string; confidence: number } | null }>> = new Map();
+  for (let i = 0; i < planned.length; i++) {
+    const p = planned[i];
+    if (p.input.artists?.length) {
+      const resolved: Array<{ input: string; resolved: { id: number; name: string; confidence: number } | null }> = [];
+      for (const artist of p.input.artists) {
+        const match = await resolveArtistId(client, artist.name);
+        resolved.push({ input: artist.name, resolved: match });
+      }
+      preResolvedArtists.set(i, resolved);
+    }
+  }
+
   // --- Phase 3: Preview ---
   display.header("Preview");
 
@@ -283,8 +320,21 @@ export async function submitFestivals(
     );
     display.kv("Dates", `${f.start_date} to ${f.end_date}`);
     if (f.city) display.kv("Location", `${f.city}${f.state ? `, ${f.state}` : ""}`);
-    if (f.artists?.length) {
-      display.kv("Artists", `${f.artists.length} to resolve`);
+    // Show resolved artists with confidence
+    const artistResolutions = preResolvedArtists.get(planIdx);
+    if (artistResolutions?.length) {
+      display.kv("Artists", "");
+      for (const a of artistResolutions) {
+        if (a.resolved) {
+          const conf = `${(a.resolved.confidence * 100).toFixed(0)}%`;
+          const matchLabel = a.resolved.confidence >= 1.0
+            ? green(`EXACT → "${a.resolved.name}" (ID: ${a.resolved.id})`)
+            : yellow(`FUZZY ${conf} → "${a.resolved.name}" (ID: ${a.resolved.id})`);
+          display.info(`    ${a.input} ${matchLabel}`);
+        } else {
+          display.warn(`    ${a.input} — not found`);
+        }
+      }
     }
     if (f.venues?.length) {
       display.kv("Venues", `${f.venues.length} to resolve`);
@@ -312,8 +362,21 @@ export async function submitFestivals(
     for (const field of newFields) {
       display.fieldDiff(field.field, field.existing, field.proposed);
     }
-    if (f.artists?.length) {
-      display.kv("Artists", `${f.artists.length} to resolve & link`);
+    // Show resolved artists with confidence
+    const artistResolutions = preResolvedArtists.get(planIdx);
+    if (artistResolutions?.length) {
+      display.kv("Artists", "");
+      for (const a of artistResolutions) {
+        if (a.resolved) {
+          const conf = `${(a.resolved.confidence * 100).toFixed(0)}%`;
+          const matchLabel = a.resolved.confidence >= 1.0
+            ? green(`EXACT → "${a.resolved.name}" (ID: ${a.resolved.id})`)
+            : yellow(`FUZZY ${conf} → "${a.resolved.name}" (ID: ${a.resolved.id})`);
+          display.info(`    ${a.input} ${matchLabel}`);
+        } else {
+          display.warn(`    ${a.input} — not found`);
+        }
+      }
     }
     if (f.venues?.length) {
       display.kv("Venues", `${f.venues.length} to resolve & link`);
@@ -549,8 +612,11 @@ async function linkArtists(
       if (artist.set_time) body.set_time = artist.set_time;
 
       await client.post(`/festivals/${festivalId}/artists`, body);
+      const confidenceStr = resolved.confidence < 1.0
+        ? ` (${(resolved.confidence * 100).toFixed(0)}% match)`
+        : "";
       display.success(
-        `  Linked artist "${resolved.name}" (ID: ${resolved.id})${artist.billing_tier ? ` as ${artist.billing_tier}` : ""}`,
+        `  Linked artist "${resolved.name}" (ID: ${resolved.id})${confidenceStr}${artist.billing_tier ? ` as ${artist.billing_tier}` : ""}`,
       );
       linkResults.push({
         name: artist.name,

--- a/cli/src/commands/submit-show.ts
+++ b/cli/src/commands/submit-show.ts
@@ -51,6 +51,7 @@ interface ResolvedArtist {
   name: string;
   is_headliner?: boolean;
   status: "existing" | "new";
+  confidence?: number;
 }
 
 interface ResolvedVenue {
@@ -60,6 +61,7 @@ interface ResolvedVenue {
   state?: string;
   address?: string;
   status: "existing" | "new";
+  confidence?: number;
 }
 
 export interface ShowPlan {
@@ -116,6 +118,7 @@ export async function resolveArtists(
           name: best.name,
           is_headliner: artist.is_headliner,
           status: "existing",
+          confidence: best.score,
         });
       } else {
         resolved.push({
@@ -161,6 +164,7 @@ export async function resolveVenues(
           state: venue.state,
           address: venue.address,
           status: "existing",
+          confidence: best.score,
         });
       } else {
         resolved.push({
@@ -352,8 +356,11 @@ function displayPreview(plans: ShowPlan[], resolvedTags?: ResolvedTag[][]): void
     // Artists
     process.stderr.write(`\n  ${gray("Artists:")}\n`);
     for (const artist of plan.artists) {
+      const confidenceStr = artist.confidence !== undefined && artist.confidence < 1.0
+        ? ` ${(artist.confidence * 100).toFixed(0)}%`
+        : "";
       const tag = artist.status === "existing"
-        ? green(`EXISTING (ID: ${artist.id})`)
+        ? green(`EXISTING (ID: ${artist.id})${confidenceStr ? yellow(` [${confidenceStr} match]`) : ""}`)
         : yellow("NEW");
       const headliner = artist.is_headliner ? dim(" [headliner]") : "";
       process.stderr.write(`    ${artist.name} ${tag}${headliner}\n`);
@@ -362,8 +369,11 @@ function displayPreview(plans: ShowPlan[], resolvedTags?: ResolvedTag[][]): void
     // Venues
     process.stderr.write(`\n  ${gray("Venues:")}\n`);
     for (const venue of plan.venues) {
+      const confidenceStr = venue.confidence !== undefined && venue.confidence < 1.0
+        ? ` ${(venue.confidence * 100).toFixed(0)}%`
+        : "";
       const tag = venue.status === "existing"
-        ? green(`EXISTING (ID: ${venue.id})`)
+        ? green(`EXISTING (ID: ${venue.id})${confidenceStr ? yellow(` [${confidenceStr} match]`) : ""}`)
         : yellow("NEW");
       process.stderr.write(`    ${venue.name} ${tag}\n`);
     }

--- a/cli/src/lib/duplicates.ts
+++ b/cli/src/lib/duplicates.ts
@@ -38,6 +38,46 @@ export function normalizeForComparison(s: string): string {
     .replace(/\s+/g, " ");
 }
 
+/**
+ * Check if the shorter string is embedded inside a longer word in the other string,
+ * creating a false positive risk.
+ *
+ * E.g., "dram" inside "dream" — "dram" is a substring of the word "dream", which is
+ * a completely different word. Returns true (trap).
+ *
+ * But "the shin" inside "the shins" — the only difference is a trailing 's' (plural).
+ * We allow this because it's a minor suffix variation. Returns false (not a trap).
+ *
+ * Heuristic: if the non-matching portion on either side is just 1 character, it's likely
+ * a typo, plural, or minor variant — not a trap. If 2+ extra characters, it's a trap.
+ */
+function isSubstringTrap(shorter: string, longer: string): boolean {
+  const idx = longer.indexOf(shorter);
+  if (idx === -1) return false;
+
+  // Check character boundaries
+  const charsBefore = idx;
+  const charsAfter = longer.length - (idx + shorter.length);
+
+  const startsAtWordBoundary = idx === 0 || /\W/.test(longer[idx - 1]);
+  const endsAtWordBoundary = (idx + shorter.length === longer.length) || /\W/.test(longer[idx + shorter.length]);
+
+  // If both ends are at word boundaries, not a trap (e.g., "national" in "the national")
+  if (startsAtWordBoundary && endsAtWordBoundary) {
+    return false;
+  }
+
+  // If the non-matching part is just 1 trailing character (like plural 's'), allow it
+  // "the shin" in "the shins" — only 1 char after, not a trap
+  // But only when the start is aligned to a word boundary (avoid "dram" in "drama")
+  if (!endsAtWordBoundary && charsAfter === 1 && startsAtWordBoundary) {
+    return false;
+  }
+
+  // More than 1 extra character on a non-word-boundary side, or both sides misaligned
+  return true;
+}
+
 /** Simple similarity score between two strings (0-1). Uses normalized comparison. */
 export function similarityScore(a: string, b: string): number {
   const na = normalizeForComparison(a);
@@ -46,10 +86,39 @@ export function similarityScore(a: string, b: string): number {
   if (na === nb) return 1.0;
   if (na.length === 0 || nb.length === 0) return 0;
 
-  // One contains the other
   const longer = na.length >= nb.length ? na : nb;
   const shorter = na.length < nb.length ? na : nb;
 
+  // Short name guard: names with 3 or fewer chars require exact match
+  if (shorter.length <= 3) {
+    return 0;
+  }
+
+  // Short name guard: names with 4 chars get heavily penalized for non-exact matches
+  // Only a very close match (like a single accent difference already handled above) should pass
+  if (shorter.length <= 4) {
+    // Only allow if the shorter appears as a complete word (both boundaries aligned)
+    if (longer.includes(shorter)) {
+      const idx = longer.indexOf(shorter);
+      const startOk = idx === 0 || /\W/.test(longer[idx - 1]);
+      const endOk = (idx + shorter.length === longer.length) || /\W/.test(longer[idx + shorter.length]);
+      if (startOk && endOk) {
+        const coverage = shorter.length / longer.length;
+        if (coverage >= 0.6) {
+          return 0.8 + 0.2 * coverage;
+        }
+      }
+    }
+    // For 4-char names, prefix/suffix overlap rarely indicates a real match
+    return 0;
+  }
+
+  // Substring trap: if shorter is embedded inside a longer word, reject
+  if (longer.includes(shorter) && isSubstringTrap(shorter, longer)) {
+    return 0.3; // Low score — not a match
+  }
+
+  // One contains the other (word-boundary aligned)
   if (longer.includes(shorter)) {
     const coverage = shorter.length / longer.length;
     // Require at least 60% coverage for substring match to count
@@ -58,7 +127,8 @@ export function similarityScore(a: string, b: string): number {
     if (coverage >= 0.6) {
       return 0.8 + 0.2 * coverage;
     }
-    // Low coverage substring: treat as weak signal, not a match
+    // Low coverage substring: penalize heavily to prevent false matches
+    // "langhorne slim" in "viva phx: langhorne slim" = 58% → not a match
     return 0.4 + 0.3 * coverage;
   }
 

--- a/cli/test/duplicates.test.ts
+++ b/cli/test/duplicates.test.ts
@@ -92,6 +92,66 @@ describe("similarityScore", () => {
     const score = similarityScore("The Shins", "The Shin");
     expect(score).toBeGreaterThan(0.6);
   });
+
+  // --- False positive prevention (PSY-174) ---
+
+  test("DRAM does NOT match DREAM (substring trap)", () => {
+    const score = similarityScore("DRAM", "DREAM");
+    expect(score).toBeLessThan(0.6);
+  });
+
+  test("SAMNX does NOT match Sasami", () => {
+    const score = similarityScore("SAMNX", "Sasami");
+    expect(score).toBeLessThan(0.6);
+  });
+
+  test("Langhorne Slim does NOT match VIVA PHX: LANGHORNE SLIM (low coverage)", () => {
+    const score = similarityScore("Langhorne Slim", "VIVA PHX: LANGHORNE SLIM");
+    expect(score).toBeLessThan(0.6);
+  });
+
+  test("short names (<=3 chars) require exact match", () => {
+    // "MIA" should not match "MIJA" or "Miami"
+    expect(similarityScore("MIA", "MIJA")).toBe(0);
+    expect(similarityScore("MIA", "Miami")).toBe(0);
+    // But exact case-insensitive match should work
+    expect(similarityScore("MIA", "mia")).toBe(1.0);
+    expect(similarityScore("DJ", "dj")).toBe(1.0);
+    // Non-exact 3-char names should score 0
+    expect(similarityScore("DJ", "DJs")).toBe(0);
+  });
+
+  test("short names (4 chars) require very close match", () => {
+    // "DRAM" should not match "DREAM" (substring trap)
+    expect(similarityScore("DRAM", "DREAM")).toBeLessThan(0.6);
+    // "DRAM" should not match "Drama" (different word)
+    expect(similarityScore("DRAM", "Drama")).toBeLessThan(0.6);
+    // But exact 4-char match works
+    expect(similarityScore("DRAM", "dram")).toBe(1.0);
+  });
+
+  test("correct matches still work", () => {
+    // Exact matches (case-insensitive)
+    expect(similarityScore("Pavement", "Pavement")).toBe(1.0);
+    expect(similarityScore("the national", "The National")).toBe(1.0);
+    // "National" in "The National" — substring with good coverage
+    const score = similarityScore("National", "The National");
+    expect(score).toBeGreaterThan(0.8);
+  });
+
+  test("word-boundary substring matches work correctly", () => {
+    // "Slim" in "Langhorne Slim" — word-boundary aligned but low coverage
+    const score1 = similarityScore("Slim", "Langhorne Slim");
+    // "Slim" is 4 chars, so short name guard applies — requires exact or substring in word boundary
+    // "slim" in "langhorne slim" — at word boundary, coverage 4/14 = 0.29 < 0.6
+    expect(score1).toBeLessThan(0.6);
+  });
+
+  test("plural/singular variations still match", () => {
+    // "The Shin" vs "The Shins" — just a trailing 's', should still score high
+    const score = similarityScore("The Shins", "The Shin");
+    expect(score).toBeGreaterThan(0.6);
+  });
 });
 
 describe("compareFields", () => {


### PR DESCRIPTION
## Summary
- Short names (≤3 chars) now require exact case-insensitive match — no fuzzy matching
- Short names (4 chars) require word-boundary alignment, rejecting substring traps
- Substring trap detection: "DRAM" no longer matches "DREAM" (embedded in longer word)
- Festival artist resolution now uses `similarityScore()` with 0.7 threshold instead of blindly returning first search result
- Dry-run output shows match confidence (EXACT/FUZZY labels with percentages) for artist and venue resolution

## Test plan
- [x] 8 new test cases covering all false positive scenarios
- [x] All 99 affected tests pass (43 duplicates + 14 festival + 28 show + 14 artist)
- [x] "DRAM" does NOT match "DREAM"
- [x] "SAMNX" does NOT match "Sasami"
- [x] "Langhorne Slim" does NOT match "VIVA PHX: LANGHORNE SLIM"
- [x] Correct matches still work (Pavement, The National, The Shins/The Shin)

Closes PSY-174

🤖 Generated with [Claude Code](https://claude.com/claude-code)