### PR TITLE
Add ticket_url field to shows

### DIFF
--- a/.claude/skills/ingest/SKILL.md
+++ b/.claude/skills/ingest/SKILL.md
@@ -69,7 +69,7 @@ Create a JSON file at `/tmp/ph-ingest.json` with the extracted data. Use this fo
 
 **artist**: `name` (required), `city`, `state`, `instagram`, `bandcamp`, `spotify`, `website`, `tags`
 **venue**: `name` (required), `city` (required), `state` (required), `address`, `website`, `tags`
-**show**: `event_date` (required, YYYY-MM-DD), `city` (required), `state` (required), `title`, `price`, `artists` (required, array of `{name, is_headliner?}`), `venues` (required, array of `{name, city, state}`)
+**show**: `event_date` (required, YYYY-MM-DD), `city` (required), `state` (required), `title`, `price`, `ticket_url` (URL for ticket purchase -- extract from flyers when visible), `artists` (required, array of `{name, is_headliner?}`), `venues` (required, array of `{name, city, state}`)
 **release**: `title` (required), `release_type` (lp/ep/single/compilation/live/remix/demo), `release_year`, `artists` (required), `external_links` ([{platform, url}]), `tags`
 **label**: `name` (required), `city`, `state`, `country`, `website`, `bandcamp`, `tags`
 **festival**: `name` (required), `series_slug` (required), `edition_year` (required), `start_date` (required), `end_date` (required), `city`, `state`, `artists` ([{name, billing_tier}]), `tags`

--- a/backend/db/migrations/000058_add_show_ticket_url.down.sql
+++ b/backend/db/migrations/000058_add_show_ticket_url.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE shows DROP COLUMN IF EXISTS ticket_url;

--- a/backend/db/migrations/000058_add_show_ticket_url.up.sql
+++ b/backend/db/migrations/000058_add_show_ticket_url.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE shows ADD COLUMN ticket_url VARCHAR(500);

--- a/backend/internal/api/handlers/show.go
+++ b/backend/internal/api/handlers/show.go
@@ -88,6 +88,7 @@ type CreateShowRequestBody struct {
 	Price          *float64  `json:"price,omitempty" doc:"Ticket price"`
 	AgeRequirement *string   `json:"age_requirement,omitempty" doc:"Age requirement (e.g., '21+', 'All Ages')"`
 	Description    *string   `json:"description,omitempty" doc:"Show description"`
+	TicketURL      *string   `json:"ticket_url,omitempty" doc:"Ticket purchase URL" required:"false"`
 	Venues         []Venue   `json:"venues" validate:"required,min=1" doc:"List of venues for the show"`
 	Artists        []Artist  `json:"artists" validate:"required,min=1" doc:"List of artists in the show"`
 	IsPrivate      *bool     `json:"is_private,omitempty" doc:"If true, show is private and only visible to submitter"`
@@ -117,6 +118,14 @@ func (r *CreateShowRequestBody) Resolve(ctx huma.Context) []error {
 			Location: "body.age_requirement",
 			Message:  "Age requirement must be 50 characters or fewer",
 			Value:    len(*r.AgeRequirement),
+		})
+	}
+
+	if r.TicketURL != nil && len(*r.TicketURL) > 500 {
+		errors = append(errors, &huma.ErrorDetail{
+			Location: "body.ticket_url",
+			Message:  "Ticket URL must be 500 characters or fewer",
+			Value:    len(*r.TicketURL),
 		})
 	}
 
@@ -262,6 +271,7 @@ type UpdateShowRequest struct {
 		Price          *float64   `json:"price,omitempty" doc:"Ticket price"`
 		AgeRequirement *string    `json:"age_requirement,omitempty" doc:"Age requirement"`
 		Description    *string    `json:"description,omitempty" doc:"Show description"`
+		TicketURL      *string    `json:"ticket_url,omitempty" doc:"Ticket purchase URL" required:"false"`
 		Venues         []Venue    `json:"venues,omitempty" doc:"List of venues for the show"`
 		Artists        []Artist   `json:"artists,omitempty" doc:"List of artists for the show"`
 	}
@@ -382,6 +392,11 @@ func (h *ShowHandler) CreateShowHandler(ctx context.Context, req *CreateShowRequ
 		ageRequirement = *req.Body.AgeRequirement
 	}
 
+	ticketURL := ""
+	if req.Body.TicketURL != nil {
+		ticketURL = *req.Body.TicketURL
+	}
+
 	// Check if show should be private
 	isPrivate := false
 	if req.Body.IsPrivate != nil && *req.Body.IsPrivate {
@@ -397,6 +412,7 @@ func (h *ShowHandler) CreateShowHandler(ctx context.Context, req *CreateShowRequ
 		Price:             req.Body.Price,
 		AgeRequirement:    ageRequirement,
 		Description:       description,
+		TicketURL:         ticketURL,
 		Venues:            serviceVenues,
 		Artists:           serviceArtists,
 		SubmittedByUserID: submittedByUserID,
@@ -785,6 +801,9 @@ func (h *ShowHandler) UpdateShowHandler(ctx context.Context, req *UpdateShowRequ
 	if req.Body.Price != nil && (*req.Body.Price < 0 || *req.Body.Price > 10000) {
 		return nil, huma.Error400BadRequest("Price must be between 0 and 10000")
 	}
+	if req.Body.TicketURL != nil && len(*req.Body.TicketURL) > 500 {
+		return nil, huma.Error400BadRequest("Ticket URL must be 500 characters or fewer")
+	}
 
 	// Build updates map for basic show fields
 	updates := make(map[string]interface{})
@@ -808,6 +827,9 @@ func (h *ShowHandler) UpdateShowHandler(ctx context.Context, req *UpdateShowRequ
 	}
 	if req.Body.Description != nil {
 		updates["description"] = *req.Body.Description
+	}
+	if req.Body.TicketURL != nil {
+		updates["ticket_url"] = *req.Body.TicketURL
 	}
 
 	// Convert venues to service format (nil if not provided)

--- a/backend/internal/models/show.go
+++ b/backend/internal/models/show.go
@@ -65,6 +65,9 @@ type Show struct {
 	// Duplicate detection (for discovery imports flagged as potential duplicates)
 	DuplicateOfShowID *uint `gorm:"column:duplicate_of_show_id"`
 
+	// Ticket URL (optional)
+	TicketURL *string `json:"ticket_url,omitempty" gorm:"type:varchar(500)"`
+
 	// Status flags (admin-controlled)
 	IsSoldOut   bool `gorm:"column:is_sold_out;not null;default:false"`
 	IsCancelled bool `gorm:"column:is_cancelled;not null;default:false"`

--- a/backend/internal/services/catalog/show.go
+++ b/backend/internal/services/catalog/show.go
@@ -77,6 +77,9 @@ func (s *ShowService) CreateShow(req *contracts.CreateShowRequest) (*contracts.S
 			Status:         status,
 			SubmittedBy:    req.SubmittedByUserID,
 		}
+		if req.TicketURL != "" {
+			show.TicketURL = &req.TicketURL
+		}
 
 		if err := tx.Create(show).Error; err != nil {
 			return fmt.Errorf("failed to create show: %w", err)
@@ -138,6 +141,7 @@ func (s *ShowService) CreateShow(req *contracts.CreateShowRequest) (*contracts.S
 			Price:           show.Price,
 			AgeRequirement:  show.AgeRequirement,
 			Description:     show.Description,
+			TicketURL:       show.TicketURL,
 			Status:          string(show.Status),
 			SubmittedBy:     show.SubmittedBy,
 			RejectionReason: show.RejectionReason,
@@ -589,6 +593,7 @@ func (s *ShowService) UpdateShowWithRelations(
 			Price:           show.Price,
 			AgeRequirement:  show.AgeRequirement,
 			Description:     show.Description,
+			TicketURL:       show.TicketURL,
 			Status:          string(show.Status),
 			SubmittedBy:     show.SubmittedBy,
 			RejectionReason: show.RejectionReason,
@@ -1520,6 +1525,7 @@ func (s *ShowService) buildShowResponse(show *models.Show) *contracts.ShowRespon
 		Price:           show.Price,
 		AgeRequirement:  show.AgeRequirement,
 		Description:     show.Description,
+		TicketURL:       show.TicketURL,
 		Status:          string(show.Status),
 		SubmittedBy:     show.SubmittedBy,
 		RejectionReason:   show.RejectionReason,

--- a/backend/internal/services/contracts/catalog.go
+++ b/backend/internal/services/contracts/catalog.go
@@ -41,6 +41,7 @@ type CreateShowRequest struct {
 	Price          *float64           `json:"price"`
 	AgeRequirement string             `json:"age_requirement"`
 	Description    string             `json:"description"`
+	TicketURL      string             `json:"ticket_url"`
 	Venues         []CreateShowVenue  `json:"venues" validate:"required,min=1"`
 	Artists        []CreateShowArtist `json:"artists" validate:"required,min=1"`
 
@@ -61,6 +62,7 @@ type ShowResponse struct {
 	Price           *float64         `json:"price"`
 	AgeRequirement  *string          `json:"age_requirement"`
 	Description     *string          `json:"description"`
+	TicketURL       *string          `json:"ticket_url,omitempty"`
 	Status          string           `json:"status"`
 	SubmittedBy     *uint            `json:"submitted_by,omitempty"`
 	RejectionReason   *string          `json:"rejection_reason,omitempty"`

--- a/backend/internal/services/engagement/saved_show.go
+++ b/backend/internal/services/engagement/saved_show.go
@@ -225,6 +225,7 @@ func (s *SavedShowService) buildShowResponse(show *models.Show, artistsByShow ma
 		Price:             show.Price,
 		AgeRequirement:    show.AgeRequirement,
 		Description:       show.Description,
+		TicketURL:         show.TicketURL,
 		Status:            string(show.Status),
 		SubmittedBy:       show.SubmittedBy,
 		RejectionReason:   show.RejectionReason,

--- a/cli/src/commands/submit-show.ts
+++ b/cli/src/commands/submit-show.ts
@@ -41,6 +41,7 @@ interface ShowInput {
   price?: number;
   age_requirement?: string;
   description?: string;
+  ticket_url?: string;
   artists: ShowArtistInput[];
   venues: ShowVenueInput[];
   tags?: TagInput[];
@@ -215,6 +216,7 @@ export function buildShowPayload(plan: ShowPlan): Record<string, unknown> {
   if (plan.input.price !== undefined) payload.price = plan.input.price;
   if (plan.input.age_requirement) payload.age_requirement = plan.input.age_requirement;
   if (plan.input.description) payload.description = plan.input.description;
+  if (plan.input.ticket_url) payload.ticket_url = plan.input.ticket_url;
 
   return payload;
 }
@@ -347,6 +349,9 @@ function displayPreview(plans: ShowPlan[], resolvedTags?: ResolvedTag[][]): void
     }
     if (plan.input.age_requirement) {
       display.kv("Ages", plan.input.age_requirement);
+    }
+    if (plan.input.ticket_url) {
+      display.kv("Tickets", plan.input.ticket_url);
     }
 
     // Artists

--- a/cli/src/lib/schemas.ts
+++ b/cli/src/lib/schemas.ts
@@ -83,6 +83,14 @@ export function validateShow(data: unknown): ValidationResult {
     errors.push({ field: "venues", message: "At least one venue is required" });
   }
 
+  // Optional ticket_url validation
+  if (d.ticket_url !== undefined && d.ticket_url !== null && d.ticket_url !== "") {
+    const url = String(d.ticket_url);
+    if (!url.startsWith("http://") && !url.startsWith("https://")) {
+      errors.push({ field: "ticket_url", message: "ticket_url must be a valid URL (http:// or https://)" });
+    }
+  }
+
   return { valid: errors.length === 0, errors };
 }
 

--- a/frontend/features/shows/components/ShowDetail.tsx
+++ b/frontend/features/shows/components/ShowDetail.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import Link from 'next/link'
-import { ArrowLeft, Loader2, MapPin, Pencil, X, Trash2 } from 'lucide-react'
+import { ArrowLeft, ExternalLink, Loader2, MapPin, Pencil, X, Trash2 } from 'lucide-react'
 import { useShow } from '../hooks/useShows'
 import type { ApiError } from '@/lib/api'
 import { useSetShowSoldOut, useSetShowCancelled } from '@/lib/hooks/admin/useAdminShows'
@@ -249,6 +249,21 @@ export function ShowDetail({ showId }: ShowDetailProps) {
               {show.price != null && <span>{formatPrice(show.price)}</span>}
               {show.age_requirement && <span>{show.age_requirement}</span>}
             </div>
+
+            {/* Ticket URL */}
+            {show.ticket_url && (
+              <div className="mt-3">
+                <a
+                  href={show.ticket_url.startsWith('http') ? show.ticket_url : `https://${show.ticket_url}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
+                >
+                  Buy Tickets
+                  <ExternalLink className="h-3.5 w-3.5" />
+                </a>
+              </div>
+            )}
 
             {/* Description */}
             {show.description && (

--- a/frontend/features/shows/types.ts
+++ b/frontend/features/shows/types.ts
@@ -61,6 +61,7 @@ export interface ShowResponse {
   price?: number | null
   age_requirement?: string | null
   description?: string | null
+  ticket_url?: string | null
   status: ShowStatus
   submitted_by?: number
   rejection_reason?: string | null


### PR DESCRIPTION
## Summary
- Adds nullable `ticket_url` (VARCHAR 500) column to shows table (migration 000058)
- Backend: accepts `ticket_url` on create/update, includes in all show API responses
- Frontend: displays "Buy Tickets" external link on show detail page when present
- CLI: accepts `ticket_url` in show JSON input, validates URL format
- Ingest skill: updated to extract ticket URLs from flyers

## Test plan
- [x] Backend handler tests pass
- [x] All 2438 frontend tests pass
- [x] All 232 CLI tests pass
- [ ] Manual: create show with ticket_url via API, verify it appears on detail page
- [ ] Manual: create show without ticket_url, verify no ticket link shown

Closes PSY-181

🤖 Generated with [Claude Code](https://claude.com/claude-code)