### PR TITLE
Strip non-API fields from CLI submit POST bodies

### DIFF
--- a/cli/src/commands/submit-label.ts
+++ b/cli/src/commands/submit-label.ts
@@ -202,10 +202,24 @@ export async function submitLabels(
     try {
       switch (dupResult.action) {
         case "create": {
+          // Build POST payload with only API-accepted fields.
+          // Strip tags (applied separately), entity_type (batch routing only),
+          // label_name (not part of label API).
+          const labelApiFields = [
+            "name", "city", "state", "country", "website",
+            "description", "bandcamp_url",
+          ];
+          const labelPayload: Record<string, unknown> = {};
+          for (const field of labelApiFields) {
+            if (label[field] !== undefined) {
+              labelPayload[field] = label[field];
+            }
+          }
+
           const response = await client.post<{
             label?: { id: number };
             id?: number;
-          }>("/labels", label);
+          }>("/labels", labelPayload);
           const labelId = response.label?.id ?? response.id;
           display.success(`Created: ${label.name}`);
           // Apply tags if any

--- a/cli/src/commands/submit-venue.ts
+++ b/cli/src/commands/submit-venue.ts
@@ -217,10 +217,24 @@ export async function submitVenues(
 
     try {
       if (dupResult.action === "create") {
+        // Build POST payload with only API-accepted fields.
+        // Strip tags (applied separately), entity_type (batch routing only),
+        // label/label_name (not part of venue API).
+        const venueApiFields = [
+          "name", "city", "state", "country", "address", "zip_code",
+          "website", "capacity", "description",
+        ];
+        const venuePayload: Record<string, unknown> = {};
+        for (const field of venueApiFields) {
+          if (venue[field] !== undefined) {
+            venuePayload[field] = venue[field];
+          }
+        }
+
         const response = await client.post<{
           venue?: { id: number };
           id?: number;
-        }>("/admin/venues", venue);
+        }>("/admin/venues", venuePayload);
         const venueId = response.venue?.id ?? response.id;
         display.success(`Created venue: ${venueName}`);
         // Apply tags if any

--- a/cli/test/submit-label.test.ts
+++ b/cli/test/submit-label.test.ts
@@ -59,6 +59,7 @@ describe("submitLabels", () => {
     // Verify the POST payload
     const postCall = (client.post as ReturnType<typeof mock>).mock.calls[0];
     expect(postCall[0]).toBe("/labels");
+    // Payload should contain only API-accepted fields (tags, entity_type, etc. stripped)
     expect(postCall[1]).toEqual({ name: "Numero", city: "Chicago", state: "IL" });
   });
 

--- a/cli/test/submit-venue.test.ts
+++ b/cli/test/submit-venue.test.ts
@@ -71,7 +71,12 @@ describe("submitVenues", () => {
     expect(result.creates).toBe(1);
     expect(result.errors).toBe(0);
     expect(postMock).toHaveBeenCalledTimes(1);
-    expect(postMock).toHaveBeenCalledWith("/admin/venues", venues[0]);
+    // Payload should contain only API-accepted fields (tags, entity_type, etc. stripped)
+    expect(postMock).toHaveBeenCalledWith("/admin/venues", {
+      name: "Crescent Ballroom",
+      city: "Phoenix",
+      state: "AZ",
+    });
     expect(result.results[0].action).toBe("create");
     expect(result.results[0].message).toBe("Created successfully");
   });


### PR DESCRIPTION
## Summary
- Venue and label submit commands now use explicit allowlists to build POST payloads
- Non-API fields (`tags`, `entity_type`, `label`, `label_name`) are excluded from POST bodies
- Release and festival commands already used allowlist construction — no changes needed
- Fixes Huma 422 "unexpected property" errors during batch imports with tags

## Test plan
- [x] All 95 submit/batch unit tests pass
- [x] Venue test updated to assert allowlisted payload
- [ ] Manual: batch import with tags on venues/labels succeeds without 422 errors

Closes PSY-172

🤖 Generated with [Claude Code](https://claude.com/claude-code)