### PR TITLE
Festival batch: retry artist linking on existing festivals

### DIFF
--- a/cli/src/commands/submit-festival.ts
+++ b/cli/src/commands/submit-festival.ts
@@ -1,4 +1,4 @@
-import { APIClient } from "../lib/api";
+import { APIClient, APIError } from "../lib/api";
 import type { EnvironmentConfig } from "../lib/types";
 import * as display from "../lib/display";
 import { green, yellow, gray, dim, cyan } from "../lib/ansi";
@@ -60,14 +60,14 @@ export interface FestivalResult {
 
 interface ArtistLinkResult {
   name: string;
-  action: "linked" | "not_found" | "error";
+  action: "linked" | "already_linked" | "not_found" | "error";
   artistId?: number;
   error?: string;
 }
 
 interface VenueLinkResult {
   name: string;
-  action: "linked" | "not_found" | "error";
+  action: "linked" | "already_linked" | "not_found" | "error";
   venueId?: number;
   error?: string;
 }
@@ -333,6 +333,12 @@ export async function submitFestivals(
     display.info(
       `${dim("SKIP")} ${p.input.name} → already exists as "${p.dupResult.existingName}" (ID: ${p.dupResult.existingId})`,
     );
+    if (p.input.artists?.length) {
+      display.kv("Artists", `${p.input.artists.length} to resolve & link`);
+    }
+    if (p.input.venues?.length) {
+      display.kv("Venues", `${p.input.venues.length} to resolve & link`);
+    }
     // Show tags if any
     if (resolvedTags[planIdx].length > 0) {
       display.kv("tags", formatTagsPreview(resolvedTags[planIdx]));
@@ -359,21 +365,43 @@ export async function submitFestivals(
     return results;
   }
 
-  // Add skip results and apply tags for skipped festivals
+  // Process skipped festivals — still link artists/venues and apply tags
   for (const p of skips) {
-    const parsedTags = TagResolver.parseTags(p.input.tags as TagInput[] | undefined);
-    // Still apply tags even on skip
-    if (p.dupResult.existingId && parsedTags.length > 0) {
-      const tagResult = await tagResolver.applyToEntity("festival", p.dupResult.existingId, parsedTags);
+    const f = p.input;
+    const festivalId = p.dupResult.existingId!;
+    const parsedTags = TagResolver.parseTags(f.tags as TagInput[] | undefined);
+
+    display.info(
+      `Festival already exists: "${p.dupResult.existingName}" (ID: ${festivalId}), linking artists/venues...`,
+    );
+
+    const result: FestivalResult = {
+      name: f.name,
+      action: "skipped",
+      id: festivalId,
+      artistResults: [],
+      venueResults: [],
+    };
+
+    // Link artists
+    if (f.artists?.length) {
+      result.artistResults = await linkArtists(client, festivalId, f.artists);
+    }
+
+    // Link venues
+    if (f.venues?.length) {
+      result.venueResults = await linkVenues(client, festivalId, f.venues);
+    }
+
+    // Apply tags
+    if (festivalId && parsedTags.length > 0) {
+      const tagResult = await tagResolver.applyToEntity("festival", festivalId, parsedTags);
       if (tagResult.applied > 0) {
-        display.info(`  Applied ${tagResult.applied} tag(s) to "${p.input.name}"`);
+        display.info(`  Applied ${tagResult.applied} tag(s) to "${f.name}"`);
       }
     }
-    results.push({
-      name: p.input.name,
-      action: "skipped",
-      id: p.dupResult.existingId,
-    });
+
+    results.push(result);
   }
 
   display.header("Submitting...");
@@ -558,16 +586,28 @@ async function linkArtists(
         artistId: resolved.id,
       });
     } catch (err) {
-      const message = err instanceof Error ? err.message : "Unknown error";
-      display.error(
-        `  Failed to link artist "${resolved.name}": ${message}`,
-      );
-      linkResults.push({
-        name: artist.name,
-        action: "error",
-        artistId: resolved.id,
-        error: message,
-      });
+      // Treat 409 Conflict as "already linked" — not an error
+      if (err instanceof APIError && err.status === 409) {
+        display.info(
+          `  Already linked: "${resolved.name}" (ID: ${resolved.id})`,
+        );
+        linkResults.push({
+          name: artist.name,
+          action: "already_linked",
+          artistId: resolved.id,
+        });
+      } else {
+        const message = err instanceof Error ? err.message : "Unknown error";
+        display.error(
+          `  Failed to link artist "${resolved.name}": ${message}`,
+        );
+        linkResults.push({
+          name: artist.name,
+          action: "error",
+          artistId: resolved.id,
+          error: message,
+        });
+      }
     }
   }
 
@@ -613,16 +653,28 @@ async function linkVenues(
         venueId: resolved.id,
       });
     } catch (err) {
-      const message = err instanceof Error ? err.message : "Unknown error";
-      display.error(
-        `  Failed to link venue "${resolved.name}": ${message}`,
-      );
-      linkResults.push({
-        name: venue.name,
-        action: "error",
-        venueId: resolved.id,
-        error: message,
-      });
+      // Treat 409 Conflict as "already linked" — not an error
+      if (err instanceof APIError && err.status === 409) {
+        display.info(
+          `  Already linked: "${resolved.name}" (ID: ${resolved.id})`,
+        );
+        linkResults.push({
+          name: venue.name,
+          action: "already_linked",
+          venueId: resolved.id,
+        });
+      } else {
+        const message = err instanceof Error ? err.message : "Unknown error";
+        display.error(
+          `  Failed to link venue "${resolved.name}": ${message}`,
+        );
+        linkResults.push({
+          name: venue.name,
+          action: "error",
+          venueId: resolved.id,
+          error: message,
+        });
+      }
     }
   }
 

--- a/cli/test/submit-festival.test.ts
+++ b/cli/test/submit-festival.test.ts
@@ -289,7 +289,7 @@ describe("submitFestivals", () => {
     expect(putCalls[0].body).toMatchObject({ website: "https://m3ffest.com" });
   });
 
-  test("skips a festival when no new info", async () => {
+  test("skips a festival when no new info (no artists)", async () => {
     setupExistingFestivalMock();
 
     const festivals = [validFestival()] as any[];
@@ -298,8 +298,10 @@ describe("submitFestivals", () => {
     expect(results).toHaveLength(1);
     expect(results[0].action).toBe("skipped");
     expect(results[0].id).toBe(42);
+    expect(results[0].artistResults).toEqual([]);
+    expect(results[0].venueResults).toEqual([]);
 
-    // Verify no PUT or POST was called
+    // Verify no PUT or POST was called (no artists/venues to link)
     const mutationCalls = fetchCalls.filter(
       (c) => c.method === "PUT" || (c.method === "POST" && /\/festivals/.test(c.url)),
     );
@@ -429,6 +431,199 @@ describe("submitFestivals", () => {
     // Dry-run should produce no results (only skips are added in dry-run)
     // Creates/updates only happen with --confirm
     expect(results).toHaveLength(0);
+
+    // No POST or PUT calls (only GET for duplicate check)
+    const mutationCalls = fetchCalls.filter(
+      (c) => c.method === "POST" || c.method === "PUT",
+    );
+    expect(mutationCalls).toHaveLength(0);
+  });
+
+  test("skipped festival still links artists and venues", async () => {
+    setupExistingFestivalMock();
+
+    // GET /artists/search resolves artist names
+    addMockRoute("GET", /\/artists\/search/, (url) => {
+      const urlObj = new URL(url);
+      const q = urlObj.searchParams.get("q") || "";
+      if (q.toLowerCase().includes("khruangbin")) {
+        return {
+          artists: [{ id: 10, name: "Khruangbin", slug: "khruangbin" }],
+        };
+      }
+      if (q.toLowerCase().includes("japanese breakfast")) {
+        return {
+          artists: [
+            { id: 20, name: "Japanese Breakfast", slug: "japanese-breakfast" },
+          ],
+        };
+      }
+      return { artists: [] };
+    });
+
+    // GET /venues/search resolves venue names
+    addMockRoute("GET", /\/venues\/search/, (url) => {
+      const urlObj = new URL(url);
+      const q = urlObj.searchParams.get("q") || "";
+      if (q.toLowerCase().includes("hance park")) {
+        return {
+          venues: [{ id: 5, name: "Margaret T. Hance Park", slug: "hance-park" }],
+        };
+      }
+      return { venues: [] };
+    });
+
+    // POST /festivals/{id}/artists links artists
+    addMockRoute("POST", /\/festivals\/\d+\/artists$/, () => ({ id: 1 }));
+
+    // POST /festivals/{id}/venues links venues
+    addMockRoute("POST", /\/festivals\/\d+\/venues$/, () => ({ id: 1 }));
+
+    const festivals = [
+      validFestival({
+        artists: [
+          { name: "Khruangbin", billing_tier: "headliner" },
+          { name: "Japanese Breakfast", billing_tier: "sub_headliner" },
+          { name: "Unknown Band", billing_tier: "undercard" },
+        ],
+        venues: [{ name: "Hance Park", is_primary: true }],
+      }),
+    ] as any[];
+
+    const results = await submitFestivals(festivals, TEST_ENV, true);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].action).toBe("skipped");
+    expect(results[0].id).toBe(42);
+
+    // Artists should be processed
+    expect(results[0].artistResults).toHaveLength(3);
+    expect(results[0].artistResults![0]).toMatchObject({
+      name: "Khruangbin",
+      action: "linked",
+      artistId: 10,
+    });
+    expect(results[0].artistResults![1]).toMatchObject({
+      name: "Japanese Breakfast",
+      action: "linked",
+      artistId: 20,
+    });
+    expect(results[0].artistResults![2]).toMatchObject({
+      name: "Unknown Band",
+      action: "not_found",
+    });
+
+    // Venues should be processed
+    expect(results[0].venueResults).toHaveLength(1);
+    expect(results[0].venueResults![0]).toMatchObject({
+      name: "Hance Park",
+      action: "linked",
+      venueId: 5,
+    });
+
+    // Verify artist link API calls were made
+    const artistLinkCalls = fetchCalls.filter(
+      (c) => c.method === "POST" && /\/festivals\/42\/artists$/.test(c.url),
+    );
+    expect(artistLinkCalls).toHaveLength(2); // Only 2 — Unknown Band was not found
+
+    // Verify venue link API calls were made
+    const venueLinkCalls = fetchCalls.filter(
+      (c) => c.method === "POST" && /\/festivals\/42\/venues$/.test(c.url),
+    );
+    expect(venueLinkCalls).toHaveLength(1);
+  });
+
+  test("already-linked artists are handled gracefully (409)", async () => {
+    setupExistingFestivalMock();
+
+    // Artist search resolves the artist
+    addMockRoute("GET", /\/artists\/search/, () => ({
+      artists: [{ id: 10, name: "Khruangbin", slug: "khruangbin" }],
+    }));
+
+    // POST /festivals/{id}/artists returns 409 Conflict (already linked)
+    mockRoutes.push({
+      method: "POST",
+      pattern: /\/festivals\/\d+\/artists$/,
+      handler: () => {
+        // This handler won't be used because we override fetch for 409
+        return {};
+      },
+    });
+
+    // Override: we need the POST to /festivals/{id}/artists to return 409
+    // Remove the generic mock we just added and handle it in fetch directly
+    mockRoutes.pop();
+
+    const savedFetch = globalThis.fetch;
+    globalThis.fetch = (async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const method = init?.method || "GET";
+      const body = init?.body ? JSON.parse(init.body as string) : undefined;
+
+      fetchCalls.push({ method, url, body });
+
+      // Return 409 for artist linking
+      if (method === "POST" && /\/festivals\/\d+\/artists$/.test(url)) {
+        return new Response(
+          JSON.stringify({ message: "Artist already linked to festival" }),
+          { status: 409, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      // Fall through to normal mock routes
+      for (const route of mockRoutes) {
+        if (route.method === method && route.pattern.test(url)) {
+          const responseBody = route.handler(url, body);
+          return new Response(JSON.stringify(responseBody), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+      }
+
+      return new Response(
+        JSON.stringify({ message: "Not found" }),
+        { status: 404 },
+      );
+    }) as typeof fetch;
+
+    const festivals = [
+      validFestival({
+        artists: [{ name: "Khruangbin", billing_tier: "headliner" }],
+      }),
+    ] as any[];
+
+    const results = await submitFestivals(festivals, TEST_ENV, true);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].action).toBe("skipped");
+    expect(results[0].artistResults).toHaveLength(1);
+    expect(results[0].artistResults![0]).toMatchObject({
+      name: "Khruangbin",
+      action: "already_linked",
+      artistId: 10,
+    });
+
+    // Restore fetch
+    globalThis.fetch = savedFetch;
+  });
+
+  test("skipped festival without artists/venues makes no mutation calls", async () => {
+    setupExistingFestivalMock();
+
+    const festivals = [validFestival()] as any[];
+    const results = await submitFestivals(festivals, TEST_ENV, true);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].action).toBe("skipped");
+    expect(results[0].id).toBe(42);
+    expect(results[0].artistResults).toEqual([]);
+    expect(results[0].venueResults).toEqual([]);
 
     // No POST or PUT calls (only GET for duplicate check)
     const mutationCalls = fetchCalls.filter(


### PR DESCRIPTION
## Summary
- When batch import encounters an existing festival, it now still processes artist and venue links instead of skipping entirely
- 409 Conflict responses from the backend are handled gracefully as "already linked" (not errors)
- Preview output shows artist/venue counts for skipped festivals
- Fixes the scenario where a failed first attempt creates the festival but a retry skips all artist linking

## Test plan
- [x] 3 new tests: skip-with-links, 409 handling, skip-without-links
- [x] All 17 submit-festival tests pass
- [x] All 204 unit tests pass across 12 test files
- [ ] Manual: run batch twice with same festival — second run links missing artists

Closes PSY-173

🤖 Generated with [Claude Code](https://claude.com/claude-code)