### PR TITLE
Add show deduplication in CLI batch ingest

### DIFF
--- a/cli/src/commands/submit-show.ts
+++ b/cli/src/commands/submit-show.ts
@@ -1,7 +1,8 @@
 import { APIClient } from "../lib/api";
 import type { EnvironmentConfig } from "../lib/types";
 import { validateShow } from "../lib/schemas";
-import { searchArtistsByName, searchVenuesByName, similarityScore } from "../lib/duplicates";
+import { searchArtistsByName, searchVenuesByName, similarityScore, checkShowDuplicate } from "../lib/duplicates";
+import type { ShowDuplicateResult } from "../lib/duplicates";
 import { TagResolver, formatTagsPreview, formatFuzzyWarning } from "../lib/tags";
 import type { TagInput, ResolvedTag } from "../lib/tags";
 import * as display from "../lib/display";
@@ -71,6 +72,7 @@ export interface ShowPlan {
   venues: ResolvedVenue[];
   valid: boolean;
   errors: string[];
+  duplicate?: ShowDuplicateResult;
 }
 
 export interface SubmitShowsResult {
@@ -254,12 +256,26 @@ export async function submitShows(
     const artists = await resolveArtists(client, show.artists);
     const venues = await resolveVenues(client, show.venues);
 
+    // Check for duplicate shows (same date + venue + overlapping artist)
+    const resolvedVenueIds = venues.filter((v) => v.id !== undefined).map((v) => v.id!);
+    const resolvedArtistIds = artists.filter((a) => a.id !== undefined).map((a) => a.id!);
+    const resolvedArtistNames = artists.map((a) => a.name);
+
+    const duplicate = await checkShowDuplicate(
+      client,
+      show.event_date,
+      resolvedVenueIds,
+      resolvedArtistIds,
+      resolvedArtistNames,
+    );
+
     plans.push({
       input: show,
       artists,
       venues,
       valid: true,
       errors: [],
+      duplicate,
     });
   }
 
@@ -280,27 +296,42 @@ export async function submitShows(
 
   // 4. Summary
   const validPlans = plans.filter((p) => p.valid);
+  const duplicatePlans = validPlans.filter((p) => p.duplicate?.isDuplicate);
+  const creatablePlans = validPlans.filter((p) => !p.duplicate?.isDuplicate);
   const invalidCount = plans.length - validPlans.length;
+  const duplicateCount = duplicatePlans.length;
 
   if (invalidCount > 0) {
     display.warn(`${invalidCount} show${invalidCount !== 1 ? "s" : ""} failed validation and will be skipped.`);
   }
 
-  if (validPlans.length === 0) {
+  if (duplicateCount > 0) {
+    for (const plan of duplicatePlans) {
+      const label = plan.input.title || `${plan.input.event_date} show`;
+      display.info(`EXISTING: ${label} (ID: ${plan.duplicate!.existingShowId}) — skipping`);
+    }
+  }
+
+  if (creatablePlans.length === 0 && duplicateCount === 0) {
     display.error("No valid shows to submit.");
     return { plans, created: 0, failed: 0, skipped: plans.length };
   }
 
+  if (creatablePlans.length === 0) {
+    display.info(`All ${duplicateCount} valid show${duplicateCount !== 1 ? "s" : ""} already exist. Nothing to create.`);
+    return { plans, created: 0, failed: 0, skipped: invalidCount + duplicateCount };
+  }
+
   // 5. Submit if confirmed
   if (!confirm) {
-    display.info(`Dry run: ${validPlans.length} show${validPlans.length !== 1 ? "s" : ""} would be created. Use --confirm to submit.`);
-    return { plans, created: 0, failed: 0, skipped: validPlans.length };
+    display.info(`Dry run: ${creatablePlans.length} show${creatablePlans.length !== 1 ? "s" : ""} would be created. Use --confirm to submit.`);
+    return { plans, created: 0, failed: 0, skipped: creatablePlans.length + duplicateCount };
   }
 
   let created = 0;
   let failed = 0;
 
-  for (const plan of validPlans) {
+  for (const plan of creatablePlans) {
     const payload = buildShowPayload(plan);
     try {
       const result = await client.post<{ id: number; slug?: string }>("/shows", payload);
@@ -323,9 +354,9 @@ export async function submitShows(
     }
   }
 
-  display.summary(created, 0, failed + invalidCount);
+  display.summary(created, 0, failed + invalidCount + duplicateCount);
 
-  return { plans, created, failed, skipped: invalidCount };
+  return { plans, created, failed, skipped: invalidCount + duplicateCount };
 }
 
 // -- Display helpers ---------------------------------------------------------
@@ -344,7 +375,10 @@ function displayPreview(plans: ShowPlan[], resolvedTags?: ResolvedTag[][]): void
     }
 
     const label = plan.input.title || `${plan.input.event_date} in ${plan.input.city}, ${plan.input.state}`;
-    display.header(`Show${idx}: ${label}`);
+    const dupTag = plan.duplicate?.isDuplicate
+      ? ` ${green(`DUPLICATE (ID: ${plan.duplicate.existingShowId})`)}`
+      : "";
+    display.header(`Show${idx}: ${label}${dupTag}`);
     display.kv("Date", plan.input.event_date);
     display.kv("Location", `${plan.input.city}, ${plan.input.state}`);
 
@@ -417,7 +451,8 @@ export async function runSubmitShow(
   const client = new APIClient(env);
   const result = await submitShows(client, jsonStr, confirm);
 
-  if (result.failed > 0 || (result.created === 0 && confirm)) {
+  const hasDuplicates = result.plans.some((p) => p.duplicate?.isDuplicate);
+  if (result.failed > 0 || (result.created === 0 && confirm && !hasDuplicates)) {
     process.exit(1);
   }
 }

--- a/cli/src/lib/duplicates.ts
+++ b/cli/src/lib/duplicates.ts
@@ -593,3 +593,94 @@ export async function searchVenuesByName(
 ): Promise<EntitySearchResult[]> {
   return searchVenues(client, name);
 }
+
+// -- Show deduplication -------------------------------------------------------
+
+export interface ShowDuplicateResult {
+  isDuplicate: boolean;
+  existingShowId?: number;
+  existingShowSlug?: string;
+}
+
+interface ShowResponseForDedup {
+  id: number;
+  slug?: string;
+  event_date: string;
+  venues?: Array<{ id: number; name: string }>;
+  artists?: Array<{ id: number; name: string }>;
+}
+
+/**
+ * Extract the calendar date (YYYY-MM-DD) from a date string.
+ * Handles full ISO timestamps, date-only strings, etc.
+ */
+function extractCalendarDate(dateStr: string): string {
+  return dateStr.slice(0, 10);
+}
+
+/**
+ * Check if a show is a duplicate by searching for existing shows on the same
+ * date with the same venue and at least one overlapping artist.
+ *
+ * Requires at least one resolved venue ID and one resolved artist ID/name to check.
+ */
+export async function checkShowDuplicate(
+  client: APIClient,
+  eventDate: string,
+  resolvedVenueIds: number[],
+  resolvedArtistIds: number[],
+  resolvedArtistNames: string[],
+): Promise<ShowDuplicateResult> {
+  const noMatch: ShowDuplicateResult = { isDuplicate: false };
+
+  // Need at least one venue ID to check
+  if (resolvedVenueIds.length === 0) return noMatch;
+
+  // Need at least one artist identifier to compare
+  if (resolvedArtistIds.length === 0 && resolvedArtistNames.length === 0) return noMatch;
+
+  const calendarDate = extractCalendarDate(eventDate);
+
+  try {
+    // Query shows on the same day using from_date and to_date
+    // Set to_date to the next day to get all shows on calendarDate
+    const fromDate = `${calendarDate}T00:00:00Z`;
+    const toDate = `${calendarDate}T23:59:59Z`;
+
+    const result = await client.get<ShowResponseForDedup[]>("/shows", {
+      from_date: fromDate,
+      to_date: toDate,
+    });
+
+    const shows = Array.isArray(result) ? result : [];
+
+    for (const show of shows) {
+      // Check if any venue matches
+      const showVenueIds = (show.venues || []).map((v) => v.id);
+      const venueOverlap = resolvedVenueIds.some((vid) => showVenueIds.includes(vid));
+      if (!venueOverlap) continue;
+
+      // Check if any artist matches (by ID or fuzzy name)
+      const showArtistIds = (show.artists || []).map((a) => a.id);
+      const showArtistNames = (show.artists || []).map((a) => a.name);
+
+      const artistIdOverlap = resolvedArtistIds.some((aid) => showArtistIds.includes(aid));
+      const artistNameOverlap = resolvedArtistNames.some((name) =>
+        showArtistNames.some((existingName) => similarityScore(name, existingName) >= 0.7),
+      );
+
+      if (artistIdOverlap || artistNameOverlap) {
+        return {
+          isDuplicate: true,
+          existingShowId: show.id,
+          existingShowSlug: show.slug,
+        };
+      }
+    }
+  } catch {
+    // If the search fails, don't block creation
+    return noMatch;
+  }
+
+  return noMatch;
+}

--- a/cli/test/submit-show.test.ts
+++ b/cli/test/submit-show.test.ts
@@ -8,6 +8,7 @@ import {
   type ShowPlan,
 } from "../src/commands/submit-show";
 import { APIClient } from "../src/lib/api";
+import { checkShowDuplicate } from "../src/lib/duplicates";
 
 // -- Mock helpers ------------------------------------------------------------
 
@@ -506,5 +507,347 @@ describe("submitShows", () => {
     expect(result.created).toBe(1);
     expect(result.plans[0].valid).toBe(true);
     expect(result.plans[1].valid).toBe(false);
+  });
+});
+
+// -- checkShowDuplicate ------------------------------------------------------
+
+describe("checkShowDuplicate", () => {
+  test("returns no match when no venue IDs provided", async () => {
+    const client = createMockClient();
+    const result = await checkShowDuplicate(client, "2026-04-15", [], [42], ["Nina Hagen"]);
+    expect(result.isDuplicate).toBe(false);
+  });
+
+  test("returns no match when no artist IDs or names provided", async () => {
+    const client = createMockClient();
+    const result = await checkShowDuplicate(client, "2026-04-15", [10], [], []);
+    expect(result.isDuplicate).toBe(false);
+  });
+
+  test("detects duplicate by matching venue ID and artist ID", async () => {
+    const client = createMockClient({
+      get: async (path: string) => {
+        if (path.includes("/shows")) {
+          return [
+            {
+              id: 500,
+              slug: "2026-04-15-crescent-ballroom",
+              event_date: "2026-04-15T20:00:00Z",
+              venues: [{ id: 10, name: "Crescent Ballroom" }],
+              artists: [{ id: 42, name: "Nina Hagen" }],
+            },
+          ];
+        }
+        return {};
+      },
+    });
+
+    const result = await checkShowDuplicate(client, "2026-04-15", [10], [42], ["Nina Hagen"]);
+    expect(result.isDuplicate).toBe(true);
+    expect(result.existingShowId).toBe(500);
+    expect(result.existingShowSlug).toBe("2026-04-15-crescent-ballroom");
+  });
+
+  test("detects duplicate by matching venue ID and artist name (fuzzy)", async () => {
+    const client = createMockClient({
+      get: async (path: string) => {
+        if (path.includes("/shows")) {
+          return [
+            {
+              id: 501,
+              slug: "2026-04-15-crescent-ballroom",
+              event_date: "2026-04-15T20:00:00Z",
+              venues: [{ id: 10, name: "Crescent Ballroom" }],
+              artists: [{ id: 99, name: "Nina Hagen" }],
+            },
+          ];
+        }
+        return {};
+      },
+    });
+
+    // Artist IDs don't match (different ID), but names match
+    const result = await checkShowDuplicate(client, "2026-04-15", [10], [200], ["Nina Hagen"]);
+    expect(result.isDuplicate).toBe(true);
+    expect(result.existingShowId).toBe(501);
+  });
+
+  test("returns no match when venue does not match", async () => {
+    const client = createMockClient({
+      get: async (path: string) => {
+        if (path.includes("/shows")) {
+          return [
+            {
+              id: 502,
+              event_date: "2026-04-15T20:00:00Z",
+              venues: [{ id: 99, name: "Different Venue" }],
+              artists: [{ id: 42, name: "Nina Hagen" }],
+            },
+          ];
+        }
+        return {};
+      },
+    });
+
+    const result = await checkShowDuplicate(client, "2026-04-15", [10], [42], ["Nina Hagen"]);
+    expect(result.isDuplicate).toBe(false);
+  });
+
+  test("returns no match when artist does not match", async () => {
+    const client = createMockClient({
+      get: async (path: string) => {
+        if (path.includes("/shows")) {
+          return [
+            {
+              id: 503,
+              event_date: "2026-04-15T20:00:00Z",
+              venues: [{ id: 10, name: "Crescent Ballroom" }],
+              artists: [{ id: 99, name: "Totally Different Band" }],
+            },
+          ];
+        }
+        return {};
+      },
+    });
+
+    const result = await checkShowDuplicate(client, "2026-04-15", [10], [42], ["Nina Hagen"]);
+    expect(result.isDuplicate).toBe(false);
+  });
+
+  test("returns no match when no shows exist on that date", async () => {
+    const client = createMockClient({
+      get: async (path: string) => {
+        if (path.includes("/shows")) {
+          return [];
+        }
+        return {};
+      },
+    });
+
+    const result = await checkShowDuplicate(client, "2026-04-15", [10], [42], ["Nina Hagen"]);
+    expect(result.isDuplicate).toBe(false);
+  });
+
+  test("returns no match when API call fails", async () => {
+    const client = createMockClient({
+      get: async () => { throw new Error("Network error"); },
+    });
+
+    const result = await checkShowDuplicate(client, "2026-04-15", [10], [42], ["Nina Hagen"]);
+    expect(result.isDuplicate).toBe(false);
+  });
+
+  test("handles full ISO date strings", async () => {
+    const client = createMockClient({
+      get: async (path: string) => {
+        if (path.includes("/shows")) {
+          return [
+            {
+              id: 504,
+              event_date: "2026-04-15T20:00:00Z",
+              venues: [{ id: 10, name: "Crescent Ballroom" }],
+              artists: [{ id: 42, name: "Nina Hagen" }],
+            },
+          ];
+        }
+        return {};
+      },
+    });
+
+    const result = await checkShowDuplicate(client, "2026-04-15T20:00:00Z", [10], [42], ["Nina Hagen"]);
+    expect(result.isDuplicate).toBe(true);
+    expect(result.existingShowId).toBe(504);
+  });
+});
+
+// -- submitShows with deduplication ------------------------------------------
+
+describe("submitShows deduplication", () => {
+  test("skips duplicate show in confirm mode", async () => {
+    let postCalled = false;
+    const getMock = async (path: string) => {
+      if (path.includes("/artists/search")) {
+        return { artists: [{ id: 42, name: "Nina Hagen", slug: "nina-hagen" }] };
+      }
+      if (path.includes("/venues/search")) {
+        return {
+          venues: [
+            { id: 10, name: "Crescent Ballroom", slug: "crescent-ballroom", city: "Phoenix", state: "AZ" },
+          ],
+        };
+      }
+      if (path.includes("/shows")) {
+        return [
+          {
+            id: 500,
+            slug: "2026-04-15-crescent-ballroom",
+            event_date: "2026-04-15T20:00:00Z",
+            venues: [{ id: 10, name: "Crescent Ballroom" }],
+            artists: [{ id: 42, name: "Nina Hagen" }],
+          },
+        ];
+      }
+      return {};
+    };
+
+    const client = createMockClient({
+      get: getMock,
+      post: async () => {
+        postCalled = true;
+        return { id: 999 };
+      },
+    });
+
+    const json = JSON.stringify({
+      event_date: "2026-04-15",
+      city: "Phoenix",
+      state: "AZ",
+      artists: [{ name: "Nina Hagen" }],
+      venues: [{ name: "Crescent Ballroom", city: "Phoenix", state: "AZ" }],
+    });
+
+    const result = await submitShows(client, json, true);
+    expect(result.created).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.plans[0].duplicate?.isDuplicate).toBe(true);
+    expect(result.plans[0].duplicate?.existingShowId).toBe(500);
+    expect(postCalled).toBe(false);
+  });
+
+  test("skips duplicate show in dry-run mode", async () => {
+    const getMock = async (path: string) => {
+      if (path.includes("/artists/search")) {
+        return { artists: [{ id: 42, name: "Nina Hagen", slug: "nina-hagen" }] };
+      }
+      if (path.includes("/venues/search")) {
+        return {
+          venues: [
+            { id: 10, name: "Crescent Ballroom", slug: "crescent-ballroom", city: "Phoenix", state: "AZ" },
+          ],
+        };
+      }
+      if (path.includes("/shows")) {
+        return [
+          {
+            id: 500,
+            slug: "2026-04-15-crescent-ballroom",
+            event_date: "2026-04-15T20:00:00Z",
+            venues: [{ id: 10, name: "Crescent Ballroom" }],
+            artists: [{ id: 42, name: "Nina Hagen" }],
+          },
+        ];
+      }
+      return {};
+    };
+
+    const client = createMockClient({ get: getMock });
+
+    const json = JSON.stringify({
+      event_date: "2026-04-15",
+      city: "Phoenix",
+      state: "AZ",
+      artists: [{ name: "Nina Hagen" }],
+      venues: [{ name: "Crescent Ballroom", city: "Phoenix", state: "AZ" }],
+    });
+
+    const result = await submitShows(client, json, false);
+    expect(result.created).toBe(0);
+    expect(result.plans[0].duplicate?.isDuplicate).toBe(true);
+  });
+
+  test("creates new show when no duplicate found", async () => {
+    const getMock = async (path: string) => {
+      if (path.includes("/artists/search")) {
+        return { artists: [{ id: 42, name: "Nina Hagen", slug: "nina-hagen" }] };
+      }
+      if (path.includes("/venues/search")) {
+        return {
+          venues: [
+            { id: 10, name: "Crescent Ballroom", slug: "crescent-ballroom", city: "Phoenix", state: "AZ" },
+          ],
+        };
+      }
+      if (path.includes("/shows")) {
+        return []; // No existing shows on this date
+      }
+      return {};
+    };
+
+    const client = createMockClient({
+      get: getMock,
+      post: async () => ({ id: 100 }),
+    });
+
+    const json = JSON.stringify({
+      event_date: "2026-04-15",
+      city: "Phoenix",
+      state: "AZ",
+      artists: [{ name: "Nina Hagen" }],
+      venues: [{ name: "Crescent Ballroom", city: "Phoenix", state: "AZ" }],
+    });
+
+    const result = await submitShows(client, json, true);
+    expect(result.created).toBe(1);
+    expect(result.plans[0].duplicate?.isDuplicate).toBe(false);
+  });
+
+  test("mixed batch: one duplicate, one new", async () => {
+    const getMock = async (path: string, params?: Record<string, string>) => {
+      if (path.includes("/artists/search")) {
+        return { artists: [{ id: 42, name: "Nina Hagen", slug: "nina-hagen" }] };
+      }
+      if (path.includes("/venues/search")) {
+        return {
+          venues: [
+            { id: 10, name: "Crescent Ballroom", slug: "crescent-ballroom", city: "Phoenix", state: "AZ" },
+          ],
+        };
+      }
+      if (path.includes("/shows")) {
+        // Only return existing show for April 15
+        if (params?.from_date?.includes("2026-04-15")) {
+          return [
+            {
+              id: 500,
+              event_date: "2026-04-15T20:00:00Z",
+              venues: [{ id: 10, name: "Crescent Ballroom" }],
+              artists: [{ id: 42, name: "Nina Hagen" }],
+            },
+          ];
+        }
+        return []; // No shows on April 16
+      }
+      return {};
+    };
+
+    let postCount = 0;
+    const client = createMockClient({
+      get: getMock,
+      post: async () => ({ id: 200 + ++postCount }),
+    });
+
+    const json = JSON.stringify([
+      {
+        event_date: "2026-04-15",
+        city: "Phoenix",
+        state: "AZ",
+        artists: [{ name: "Nina Hagen" }],
+        venues: [{ name: "Crescent Ballroom", city: "Phoenix", state: "AZ" }],
+      },
+      {
+        event_date: "2026-04-16",
+        city: "Phoenix",
+        state: "AZ",
+        artists: [{ name: "Nina Hagen" }],
+        venues: [{ name: "Crescent Ballroom", city: "Phoenix", state: "AZ" }],
+      },
+    ]);
+
+    const result = await submitShows(client, json, true);
+    expect(result.created).toBe(1);
+    expect(result.skipped).toBe(1);
+    expect(result.plans[0].duplicate?.isDuplicate).toBe(true);
+    expect(result.plans[1].duplicate?.isDuplicate).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Before creating a show, checks if one already exists with the same date + venue + overlapping artist
- Queries `GET /shows?from_date=...&to_date=...` for same-day shows, matches by venue ID and artist (by ID or fuzzy name at 0.7 threshold)
- Duplicate shows show `DUPLICATE (ID: N)` in preview and are skipped during creation
- Gracefully handles API errors and missing identifiers (falls through to create)

## Test plan
- [x] 12 new tests: 8 for `checkShowDuplicate` + 4 for dedup integration in `submitShows`
- [x] All 34 submit-show tests pass
- [ ] Manual: `/ingest` same flyer twice — second run shows "EXISTING" and skips creation

Closes PSY-178

🤖 Generated with [Claude Code](https://claude.com/claude-code)