### PR TITLE
Add CLI command to link/unlink artists to existing festivals

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -14,6 +14,7 @@ import { runSubmitLabel } from "./commands/submit-label";
 import { runSubmitFestival } from "./commands/submit-festival";
 import { runBatch } from "./commands/batch";
 import { runStatus } from "./commands/status";
+import { runFestivalLinkArtists, runFestivalUnlinkArtist } from "./commands/festival";
 
 const program = new Command();
 
@@ -125,6 +126,32 @@ program
   .action(async (file: string, opts: { confirm?: boolean }) => {
     const env = await resolveEnvOrExit(program.opts().env);
     await runBatch(file, env, !!opts.confirm);
+  });
+
+// ─── ph festival ─────────────────────────────────────────────────────────────
+
+const festivalCmd = program
+  .command("festival")
+  .description("Manage festival artist links");
+
+festivalCmd
+  .command("link-artists <festival> [json]")
+  .description("Link artists to an existing festival by slug or ID")
+  .option("--file <path>", "Read artist JSON from file")
+  .option("--replace", "Remove existing artist links first")
+  .option("--confirm", "Execute changes (default is dry-run)")
+  .action(async (festival: string, json: string | undefined, opts: { file?: string; replace?: boolean; confirm?: boolean }) => {
+    const env = await resolveEnvOrExit(program.opts().env);
+    await runFestivalLinkArtists(festival, json, env, opts);
+  });
+
+festivalCmd
+  .command("unlink-artist <festival> <artist>")
+  .description("Remove an artist link from a festival")
+  .option("--confirm", "Execute changes (default is dry-run)")
+  .action(async (festival: string, artist: string, opts: { confirm?: boolean }) => {
+    const env = await resolveEnvOrExit(program.opts().env);
+    await runFestivalUnlinkArtist(festival, artist, env, !!opts.confirm);
   });
 
 // ─── ph status ───────────────────────────────────────────────────────────────

--- a/cli/src/commands/festival.ts
+++ b/cli/src/commands/festival.ts
@@ -1,0 +1,507 @@
+import { APIClient, APIError } from "../lib/api";
+import type { EnvironmentConfig } from "../lib/types";
+import * as display from "../lib/display";
+import { green, yellow, gray, dim, cyan } from "../lib/ansi";
+import { similarityScore } from "../lib/duplicates";
+
+/** Festival artist entry from the input JSON. */
+export interface FestivalArtistInput {
+  name: string;
+  billing_tier?: string;
+  position?: number;
+  day_date?: string;
+  stage?: string;
+  set_time?: string;
+}
+
+/** Result of linking a single artist. */
+export interface ArtistLinkResult {
+  name: string;
+  action: "linked" | "already_linked" | "not_found" | "error";
+  artistId?: number;
+  error?: string;
+}
+
+/** Result of unlinking a single artist. */
+export interface ArtistUnlinkResult {
+  name: string;
+  action: "unlinked" | "not_found" | "error";
+  artistId?: number;
+  error?: string;
+}
+
+const VALID_BILLING_TIERS = [
+  "headliner",
+  "sub_headliner",
+  "mid_card",
+  "undercard",
+  "local",
+  "dj",
+  "host",
+];
+
+/**
+ * Resolve an artist name to an ID via GET /artists/search.
+ * Returns the best match's ID and confidence score, or null if not found.
+ */
+export async function resolveArtistId(
+  client: APIClient,
+  name: string,
+): Promise<{ id: number; name: string; confidence: number } | null> {
+  try {
+    const result = await client.get<{
+      artists: Array<{ id: number; name: string; slug: string }>;
+    }>("/artists/search", { q: name });
+
+    if (!result.artists?.length) return null;
+
+    // Look for exact match first (case-insensitive)
+    const exact = result.artists.find(
+      (a) => a.name.toLowerCase() === name.toLowerCase(),
+    );
+    if (exact) return { id: exact.id, name: exact.name, confidence: 1.0 };
+
+    // Find best match by similarity score, require >= 0.7
+    const scored = result.artists
+      .map((a) => ({ ...a, score: similarityScore(name, a.name) }))
+      .filter((a) => a.score >= 0.7)
+      .sort((a, b) => b.score - a.score);
+
+    if (scored.length > 0) {
+      return { id: scored[0].id, name: scored[0].name, confidence: scored[0].score };
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve a festival slug or numeric ID to a festival object via the API.
+ * Returns { id, name, slug } or null if not found.
+ */
+export async function resolveFestival(
+  client: APIClient,
+  festivalRef: string,
+): Promise<{ id: number; name: string; slug: string } | null> {
+  try {
+    const result = await client.get<{
+      id: number;
+      name: string;
+      slug: string;
+    }>(`/festivals/${festivalRef}`);
+
+    if (result?.id) {
+      return { id: result.id, name: result.name, slug: result.slug };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get the list of artists currently linked to a festival.
+ */
+export async function getFestivalArtists(
+  client: APIClient,
+  festivalId: number,
+): Promise<Array<{ artist_id: number; artist_name: string }>> {
+  try {
+    const result = await client.get<{
+      artists: Array<{ artist_id: number; artist_name: string }>;
+    }>(`/festivals/${festivalId}/artists`);
+    return result.artists || [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Link a single artist to a festival. Returns the link result.
+ */
+async function linkSingleArtist(
+  client: APIClient,
+  festivalId: number,
+  artist: FestivalArtistInput,
+  resolved: { id: number; name: string; confidence: number },
+): Promise<ArtistLinkResult> {
+  try {
+    const body: Record<string, unknown> = {
+      artist_id: resolved.id,
+    };
+    if (artist.billing_tier) body.billing_tier = artist.billing_tier;
+    if (artist.position !== undefined) body.position = artist.position;
+    if (artist.day_date) body.day_date = artist.day_date;
+    if (artist.stage) body.stage = artist.stage;
+    if (artist.set_time) body.set_time = artist.set_time;
+
+    await client.post(`/festivals/${festivalId}/artists`, body);
+    const confidenceStr = resolved.confidence < 1.0
+      ? ` (${(resolved.confidence * 100).toFixed(0)}% match)`
+      : "";
+    display.success(
+      `  Linked artist "${resolved.name}" (ID: ${resolved.id})${confidenceStr}${artist.billing_tier ? ` as ${artist.billing_tier}` : ""}`,
+    );
+    return {
+      name: artist.name,
+      action: "linked",
+      artistId: resolved.id,
+    };
+  } catch (err) {
+    if (err instanceof APIError && err.status === 409) {
+      display.info(
+        `  Already linked: "${resolved.name}" (ID: ${resolved.id})`,
+      );
+      return {
+        name: artist.name,
+        action: "already_linked",
+        artistId: resolved.id,
+      };
+    }
+    const message = err instanceof Error ? err.message : "Unknown error";
+    display.error(
+      `  Failed to link artist "${resolved.name}": ${message}`,
+    );
+    return {
+      name: artist.name,
+      action: "error",
+      artistId: resolved.id,
+      error: message,
+    };
+  }
+}
+
+/**
+ * Parse JSON input for artist entries.
+ * Accepts a JSON array of FestivalArtistInput objects.
+ */
+export function parseArtistInput(jsonStr: string): FestivalArtistInput[] {
+  const parsed = JSON.parse(jsonStr);
+
+  if (Array.isArray(parsed)) {
+    return parsed;
+  }
+
+  // Single object — wrap in array
+  return [parsed];
+}
+
+/**
+ * Link artists to an existing festival.
+ *
+ * @param festivalRef - Festival slug or numeric ID
+ * @param artists - Array of artist inputs to link
+ * @param env - API environment config
+ * @param options - Options: confirm (execute), replace (clear existing first)
+ * @returns Array of link results
+ */
+export async function linkArtistsToFestival(
+  festivalRef: string,
+  artists: FestivalArtistInput[],
+  env: EnvironmentConfig,
+  options: { confirm: boolean; replace: boolean },
+): Promise<ArtistLinkResult[]> {
+  const client = new APIClient(env);
+  const results: ArtistLinkResult[] = [];
+
+  // --- Step 1: Resolve festival ---
+  display.header("Resolving festival...");
+  const festival = await resolveFestival(client, festivalRef);
+  if (!festival) {
+    display.error(`Festival "${festivalRef}" not found.`);
+    return [];
+  }
+  display.success(`Found festival: "${festival.name}" (ID: ${festival.id}, slug: ${festival.slug})`);
+
+  // --- Step 2: Validate billing tiers ---
+  for (const artist of artists) {
+    if (artist.billing_tier && !VALID_BILLING_TIERS.includes(artist.billing_tier)) {
+      display.error(
+        `Artist "${artist.name}" has invalid billing_tier "${artist.billing_tier}". ` +
+          `Must be one of: ${VALID_BILLING_TIERS.join(", ")}`,
+      );
+      return [];
+    }
+  }
+
+  // --- Step 3: Resolve artist names ---
+  display.header("Resolving artists...");
+  const resolutions: Array<{
+    input: FestivalArtistInput;
+    resolved: { id: number; name: string; confidence: number } | null;
+  }> = [];
+
+  for (const artist of artists) {
+    const match = await resolveArtistId(client, artist.name);
+    resolutions.push({ input: artist, resolved: match });
+  }
+
+  // --- Step 4: Get existing artists (for replace mode preview) ---
+  let existingArtists: Array<{ artist_id: number; artist_name: string }> = [];
+  if (options.replace) {
+    existingArtists = await getFestivalArtists(client, festival.id);
+  }
+
+  // --- Step 5: Preview ---
+  display.header("Preview");
+
+  if (options.replace && existingArtists.length > 0) {
+    display.info(
+      `${yellow("REPLACE")} Will remove ${existingArtists.length} existing artist(s) first:`,
+    );
+    for (const ea of existingArtists) {
+      display.info(`    ${dim("UNLINK")} "${ea.artist_name}" (ID: ${ea.artist_id})`);
+    }
+    display.info("");
+  }
+
+  let linkCount = 0;
+  let notFoundCount = 0;
+
+  for (const r of resolutions) {
+    if (r.resolved) {
+      const conf = `${(r.resolved.confidence * 100).toFixed(0)}%`;
+      const matchLabel = r.resolved.confidence >= 1.0
+        ? green(`EXACT -> "${r.resolved.name}" (ID: ${r.resolved.id})`)
+        : yellow(`FUZZY ${conf} -> "${r.resolved.name}" (ID: ${r.resolved.id})`);
+      const tierLabel = r.input.billing_tier ? ` [${r.input.billing_tier}]` : "";
+      display.info(`  ${green("LINK")} ${r.input.name} ${matchLabel}${tierLabel}`);
+      linkCount++;
+    } else {
+      display.warn(`  ${r.input.name} — not found in database`);
+      notFoundCount++;
+    }
+  }
+
+  display.info("");
+  const parts: string[] = [];
+  if (linkCount > 0) parts.push(green(`${linkCount} to link`));
+  if (notFoundCount > 0) parts.push(yellow(`${notFoundCount} not found`));
+  display.info(`Summary: ${parts.join(", ")}`);
+
+  // --- Step 6: Execute (if --confirm) ---
+  if (!options.confirm) {
+    display.warn("Dry run. Pass --confirm to execute.");
+    return [];
+  }
+
+  // Replace: remove all existing artists first
+  if (options.replace && existingArtists.length > 0) {
+    display.header("Removing existing artists...");
+    for (const ea of existingArtists) {
+      try {
+        await client.delete(`/festivals/${festival.id}/artists/${ea.artist_id}`);
+        display.success(`  Removed "${ea.artist_name}" (ID: ${ea.artist_id})`);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Unknown error";
+        display.error(`  Failed to remove "${ea.artist_name}": ${message}`);
+      }
+    }
+  }
+
+  // Link new artists
+  display.header("Linking artists...");
+  for (const r of resolutions) {
+    if (!r.resolved) {
+      display.warn(`  Artist "${r.input.name}" not found — skipping`);
+      results.push({
+        name: r.input.name,
+        action: "not_found",
+      });
+      continue;
+    }
+
+    const linkResult = await linkSingleArtist(client, festival.id, r.input, r.resolved);
+    results.push(linkResult);
+  }
+
+  // --- Step 7: Final report ---
+  display.header("Results");
+  const linked = results.filter((r) => r.action === "linked").length;
+  const alreadyLinked = results.filter((r) => r.action === "already_linked").length;
+  const notFound = results.filter((r) => r.action === "not_found").length;
+  const errors = results.filter((r) => r.action === "error").length;
+
+  const reportParts: string[] = [];
+  if (linked > 0) reportParts.push(green(`${linked} linked`));
+  if (alreadyLinked > 0) reportParts.push(gray(`${alreadyLinked} already linked`));
+  if (notFound > 0) reportParts.push(yellow(`${notFound} not found`));
+  if (errors > 0) reportParts.push(`${errors} error(s)`);
+  display.info(`Summary: ${reportParts.join(", ")}`);
+
+  return results;
+}
+
+/**
+ * Unlink a single artist from a festival.
+ *
+ * @param festivalRef - Festival slug or numeric ID
+ * @param artistRef - Artist name or numeric ID
+ * @param env - API environment config
+ * @param confirm - Whether to execute (default: dry-run)
+ * @returns The unlink result
+ */
+export async function unlinkArtistFromFestival(
+  festivalRef: string,
+  artistRef: string,
+  env: EnvironmentConfig,
+  confirm: boolean,
+): Promise<ArtistUnlinkResult> {
+  const client = new APIClient(env);
+
+  // --- Step 1: Resolve festival ---
+  display.header("Resolving festival...");
+  const festival = await resolveFestival(client, festivalRef);
+  if (!festival) {
+    display.error(`Festival "${festivalRef}" not found.`);
+    return { name: artistRef, action: "not_found" };
+  }
+  display.success(`Found festival: "${festival.name}" (ID: ${festival.id}, slug: ${festival.slug})`);
+
+  // --- Step 2: Resolve artist ---
+  display.header("Resolving artist...");
+  let artistId: number;
+  let artistName: string;
+
+  // Check if it's a numeric ID
+  const numericId = parseInt(artistRef, 10);
+  if (!isNaN(numericId) && String(numericId) === artistRef) {
+    artistId = numericId;
+    artistName = `ID:${numericId}`;
+    display.info(`Using artist ID: ${numericId}`);
+  } else {
+    // Resolve by name
+    const resolved = await resolveArtistId(client, artistRef);
+    if (!resolved) {
+      display.error(`Artist "${artistRef}" not found in database.`);
+      return { name: artistRef, action: "not_found" };
+    }
+    artistId = resolved.id;
+    artistName = resolved.name;
+    const confidenceStr = resolved.confidence < 1.0
+      ? ` (${(resolved.confidence * 100).toFixed(0)}% match)`
+      : "";
+    display.success(`Found artist: "${resolved.name}" (ID: ${resolved.id})${confidenceStr}`);
+  }
+
+  // --- Step 3: Preview ---
+  display.header("Preview");
+  display.info(`Will unlink "${artistName}" (ID: ${artistId}) from "${festival.name}"`);
+
+  if (!confirm) {
+    display.warn("Dry run. Pass --confirm to execute.");
+    return { name: artistRef, action: "unlinked", artistId };
+  }
+
+  // --- Step 4: Execute ---
+  display.header("Unlinking artist...");
+  try {
+    await client.delete(`/festivals/${festival.id}/artists/${artistId}`);
+    display.success(`Unlinked "${artistName}" (ID: ${artistId}) from "${festival.name}"`);
+    return { name: artistRef, action: "unlinked", artistId };
+  } catch (err) {
+    if (err instanceof APIError && err.status === 404) {
+      display.warn(`Artist "${artistName}" is not linked to "${festival.name}"`);
+      return { name: artistRef, action: "not_found", artistId };
+    }
+    const message = err instanceof Error ? err.message : "Unknown error";
+    display.error(`Failed to unlink: ${message}`);
+    return { name: artistRef, action: "error", artistId, error: message };
+  }
+}
+
+/**
+ * Entry point for `ph festival link-artists`.
+ */
+export async function runFestivalLinkArtists(
+  festivalRef: string,
+  json: string | undefined,
+  env: EnvironmentConfig,
+  options: { confirm?: boolean; replace?: boolean; file?: string },
+): Promise<void> {
+  let jsonStr = json;
+
+  // Read from file if --file provided
+  if (options.file) {
+    try {
+      const file = Bun.file(options.file);
+      jsonStr = await file.text();
+    } catch (err) {
+      display.error(
+        `Failed to read file "${options.file}": ${err instanceof Error ? err.message : "unknown error"}`,
+      );
+      process.exit(1);
+    }
+  }
+
+  // Read from stdin if no JSON argument and no file
+  if (!jsonStr) {
+    const chunks: string[] = [];
+    const reader = process.stdin;
+    reader.resume();
+    reader.setEncoding("utf-8");
+
+    jsonStr = await new Promise<string>((resolve, reject) => {
+      reader.on("data", (chunk: string) => chunks.push(chunk));
+      reader.on("end", () => resolve(chunks.join("")));
+      reader.on("error", reject);
+    });
+  }
+
+  if (!jsonStr?.trim()) {
+    display.error(
+      "No JSON provided. Pass as argument, use --file, or pipe to stdin.",
+    );
+    process.exit(1);
+  }
+
+  let artists: FestivalArtistInput[];
+  try {
+    artists = parseArtistInput(jsonStr);
+  } catch (err) {
+    display.error(
+      `Invalid JSON: ${err instanceof Error ? err.message : "parse error"}`,
+    );
+    process.exit(1);
+  }
+
+  if (artists.length === 0) {
+    display.warn("Empty array — nothing to link.");
+    return;
+  }
+
+  display.info(`Processing ${artists.length} artist(s)...`);
+
+  const results = await linkArtistsToFestival(festivalRef, artists, env, {
+    confirm: !!options.confirm,
+    replace: !!options.replace,
+  });
+
+  const hasErrors = results.some((r) => r.action === "error");
+  if (hasErrors) {
+    process.exit(1);
+  }
+}
+
+/**
+ * Entry point for `ph festival unlink-artist`.
+ */
+export async function runFestivalUnlinkArtist(
+  festivalRef: string,
+  artistRef: string,
+  env: EnvironmentConfig,
+  confirm: boolean,
+): Promise<void> {
+  const result = await unlinkArtistFromFestival(
+    festivalRef,
+    artistRef,
+    env,
+    confirm,
+  );
+
+  if (result.action === "error") {
+    process.exit(1);
+  }
+}

--- a/cli/test/festival.test.ts
+++ b/cli/test/festival.test.ts
@@ -1,0 +1,552 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import {
+  linkArtistsToFestival,
+  unlinkArtistFromFestival,
+  parseArtistInput,
+  resolveFestival,
+  resolveArtistId,
+  getFestivalArtists,
+  type ArtistLinkResult,
+  type ArtistUnlinkResult,
+} from "../src/commands/festival";
+
+// --- Mock fetch for API calls ---
+
+type MockRoute = {
+  method: string;
+  pattern: RegExp;
+  handler: (url: string, body?: unknown) => { status?: number; body: unknown };
+};
+
+let mockRoutes: MockRoute[] = [];
+let fetchCalls: { method: string; url: string; body?: unknown }[] = [];
+
+function addMockRoute(
+  method: string,
+  pattern: RegExp,
+  handler: (url: string, body?: unknown) => unknown,
+): void {
+  mockRoutes.push({
+    method,
+    pattern,
+    handler: (url, body) => ({ status: 200, body: handler(url, body) }),
+  });
+}
+
+function addMockRouteWithStatus(
+  method: string,
+  pattern: RegExp,
+  status: number,
+  handler: (url: string, body?: unknown) => unknown,
+): void {
+  mockRoutes.push({
+    method,
+    pattern,
+    handler: (url, body) => ({ status, body: handler(url, body) }),
+  });
+}
+
+function resetMocks(): void {
+  mockRoutes = [];
+  fetchCalls = [];
+}
+
+// Install global fetch mock
+beforeEach(() => {
+  resetMocks();
+
+  globalThis.fetch = (async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const method = init?.method || "GET";
+    const body = init?.body ? JSON.parse(init.body as string) : undefined;
+
+    fetchCalls.push({ method, url, body });
+
+    for (const route of mockRoutes) {
+      if (route.method === method && route.pattern.test(url)) {
+        const response = route.handler(url, body);
+        return new Response(JSON.stringify(response.body), {
+          status: response.status ?? 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+    }
+
+    // Default: 404
+    return new Response(
+      JSON.stringify({ message: "Not found" }),
+      { status: 404 },
+    );
+  }) as typeof fetch;
+});
+
+const TEST_ENV = { url: "http://localhost:8080", token: "phk_test_token" };
+
+// --- Helper to set up a festival that can be resolved ---
+function setupFestivalMock(festival?: Record<string, unknown>): void {
+  const defaultFestival = {
+    id: 42,
+    name: "Viva PHX 2026",
+    slug: "viva-phx-2026",
+    series_slug: "viva-phx",
+    edition_year: 2026,
+    ...festival,
+  };
+
+  addMockRoute("GET", /\/festivals\/[^/]+$/, () => defaultFestival);
+}
+
+// --- Helper to set up artist search ---
+function setupArtistSearchMock(
+  artists: Record<string, { id: number; name: string; slug: string }>,
+): void {
+  addMockRoute("GET", /\/artists\/search/, (url) => {
+    const urlObj = new URL(url);
+    const q = (urlObj.searchParams.get("q") || "").toLowerCase();
+    for (const [key, artist] of Object.entries(artists)) {
+      if (q.includes(key.toLowerCase()) || key.toLowerCase().includes(q)) {
+        return { artists: [artist] };
+      }
+    }
+    return { artists: [] };
+  });
+}
+
+// --- Helper to set up festival artist listing ---
+function setupFestivalArtistsMock(
+  artists: Array<{ artist_id: number; artist_name: string }>,
+): void {
+  addMockRoute("GET", /\/festivals\/\d+\/artists$/, () => ({
+    artists,
+    count: artists.length,
+  }));
+}
+
+describe("parseArtistInput", () => {
+  test("parses array of artist objects", () => {
+    const input = JSON.stringify([
+      { name: "Pavement", billing_tier: "headliner" },
+      { name: "Yo La Tengo" },
+    ]);
+    const result = parseArtistInput(input);
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toBe("Pavement");
+    expect(result[0].billing_tier).toBe("headliner");
+    expect(result[1].name).toBe("Yo La Tengo");
+  });
+
+  test("wraps a single object in array", () => {
+    const input = JSON.stringify({ name: "Pavement" });
+    const result = parseArtistInput(input);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("Pavement");
+  });
+
+  test("throws on invalid JSON", () => {
+    expect(() => parseArtistInput("not json")).toThrow();
+  });
+
+  test("handles all optional fields", () => {
+    const input = JSON.stringify([{
+      name: "Khruangbin",
+      billing_tier: "headliner",
+      position: 0,
+      day_date: "2026-03-07",
+      stage: "Main Stage",
+      set_time: "21:00:00",
+    }]);
+    const result = parseArtistInput(input);
+    expect(result[0]).toMatchObject({
+      name: "Khruangbin",
+      billing_tier: "headliner",
+      position: 0,
+      day_date: "2026-03-07",
+      stage: "Main Stage",
+      set_time: "21:00:00",
+    });
+  });
+});
+
+describe("resolveFestival", () => {
+  test("resolves festival by slug", async () => {
+    setupFestivalMock();
+    const { APIClient } = await import("../src/lib/api");
+    const client = new APIClient(TEST_ENV);
+    const result = await resolveFestival(client, "viva-phx-2026");
+    expect(result).toEqual({ id: 42, name: "Viva PHX 2026", slug: "viva-phx-2026" });
+  });
+
+  test("returns null for unknown festival", async () => {
+    // No mock set up — will get 404
+    const { APIClient } = await import("../src/lib/api");
+    const client = new APIClient(TEST_ENV);
+    const result = await resolveFestival(client, "unknown-fest");
+    expect(result).toBeNull();
+  });
+});
+
+describe("resolveArtistId", () => {
+  test("resolves exact match", async () => {
+    setupArtistSearchMock({
+      "Pavement": { id: 10, name: "Pavement", slug: "pavement" },
+    });
+    const { APIClient } = await import("../src/lib/api");
+    const client = new APIClient(TEST_ENV);
+    const result = await resolveArtistId(client, "Pavement");
+    expect(result).toEqual({ id: 10, name: "Pavement", confidence: 1.0 });
+  });
+
+  test("returns null for no match", async () => {
+    addMockRoute("GET", /\/artists\/search/, () => ({ artists: [] }));
+    const { APIClient } = await import("../src/lib/api");
+    const client = new APIClient(TEST_ENV);
+    const result = await resolveArtistId(client, "Nonexistent Band");
+    expect(result).toBeNull();
+  });
+});
+
+describe("linkArtistsToFestival", () => {
+  test("links artists in dry-run mode (no mutations)", async () => {
+    setupFestivalMock();
+    setupArtistSearchMock({
+      "Pavement": { id: 10, name: "Pavement", slug: "pavement" },
+    });
+
+    const artists = [{ name: "Pavement", billing_tier: "headliner" }];
+    const results = await linkArtistsToFestival("viva-phx-2026", artists, TEST_ENV, {
+      confirm: false,
+      replace: false,
+    });
+
+    // Dry-run returns empty results
+    expect(results).toHaveLength(0);
+
+    // No POST or DELETE calls should have been made
+    const mutationCalls = fetchCalls.filter(
+      (c) => c.method === "POST" || c.method === "DELETE",
+    );
+    expect(mutationCalls).toHaveLength(0);
+  });
+
+  test("links artists with --confirm", async () => {
+    setupFestivalMock();
+    setupArtistSearchMock({
+      "Pavement": { id: 10, name: "Pavement", slug: "pavement" },
+      "Yo La Tengo": { id: 20, name: "Yo La Tengo", slug: "yo-la-tengo" },
+    });
+
+    // POST to link artists
+    addMockRoute("POST", /\/festivals\/42\/artists$/, () => ({ id: 1 }));
+
+    const artists = [
+      { name: "Pavement", billing_tier: "headliner" },
+      { name: "Yo La Tengo", billing_tier: "sub_headliner" },
+    ];
+    const results = await linkArtistsToFestival("viva-phx-2026", artists, TEST_ENV, {
+      confirm: true,
+      replace: false,
+    });
+
+    expect(results).toHaveLength(2);
+    expect(results[0]).toMatchObject({
+      name: "Pavement",
+      action: "linked",
+      artistId: 10,
+    });
+    expect(results[1]).toMatchObject({
+      name: "Yo La Tengo",
+      action: "linked",
+      artistId: 20,
+    });
+
+    // Verify POST calls
+    const postCalls = fetchCalls.filter(
+      (c) => c.method === "POST" && /\/festivals\/42\/artists$/.test(c.url),
+    );
+    expect(postCalls).toHaveLength(2);
+    expect(postCalls[0].body).toMatchObject({
+      artist_id: 10,
+      billing_tier: "headliner",
+    });
+    expect(postCalls[1].body).toMatchObject({
+      artist_id: 20,
+      billing_tier: "sub_headliner",
+    });
+  });
+
+  test("handles artist not found gracefully", async () => {
+    setupFestivalMock();
+    addMockRoute("GET", /\/artists\/search/, () => ({ artists: [] }));
+
+    const artists = [{ name: "Unknown Band" }];
+    const results = await linkArtistsToFestival("viva-phx-2026", artists, TEST_ENV, {
+      confirm: true,
+      replace: false,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      name: "Unknown Band",
+      action: "not_found",
+    });
+  });
+
+  test("handles 409 already linked gracefully", async () => {
+    setupFestivalMock();
+    setupArtistSearchMock({
+      "Pavement": { id: 10, name: "Pavement", slug: "pavement" },
+    });
+
+    // POST returns 409
+    addMockRouteWithStatus("POST", /\/festivals\/42\/artists$/, 409, () => ({
+      message: "Artist already linked to festival",
+    }));
+
+    const artists = [{ name: "Pavement" }];
+    const results = await linkArtistsToFestival("viva-phx-2026", artists, TEST_ENV, {
+      confirm: true,
+      replace: false,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      name: "Pavement",
+      action: "already_linked",
+      artistId: 10,
+    });
+  });
+
+  test("returns empty when festival not found", async () => {
+    // No festival mock — will get 404
+    const artists = [{ name: "Pavement" }];
+    const results = await linkArtistsToFestival("unknown-fest", artists, TEST_ENV, {
+      confirm: true,
+      replace: false,
+    });
+
+    expect(results).toHaveLength(0);
+  });
+
+  test("returns empty on invalid billing tier", async () => {
+    setupFestivalMock();
+
+    const artists = [{ name: "Pavement", billing_tier: "mega_star" }];
+    const results = await linkArtistsToFestival("viva-phx-2026", artists, TEST_ENV, {
+      confirm: true,
+      replace: false,
+    });
+
+    expect(results).toHaveLength(0);
+  });
+
+  test("replace mode removes existing artists first", async () => {
+    setupFestivalMock();
+
+    // Existing artists on the festival
+    setupFestivalArtistsMock([
+      { artist_id: 5, artist_name: "Old Artist" },
+      { artist_id: 6, artist_name: "Another Old" },
+    ]);
+
+    setupArtistSearchMock({
+      "Pavement": { id: 10, name: "Pavement", slug: "pavement" },
+    });
+
+    // DELETE to remove existing artists
+    addMockRoute("DELETE", /\/festivals\/42\/artists\/\d+$/, () => ({}));
+
+    // POST to link new artists
+    addMockRoute("POST", /\/festivals\/42\/artists$/, () => ({ id: 1 }));
+
+    const artists = [{ name: "Pavement", billing_tier: "headliner" }];
+    const results = await linkArtistsToFestival("viva-phx-2026", artists, TEST_ENV, {
+      confirm: true,
+      replace: true,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      name: "Pavement",
+      action: "linked",
+      artistId: 10,
+    });
+
+    // Verify DELETE calls were made for existing artists
+    const deleteCalls = fetchCalls.filter(
+      (c) => c.method === "DELETE" && /\/festivals\/42\/artists\/\d+$/.test(c.url),
+    );
+    expect(deleteCalls).toHaveLength(2);
+
+    // Verify POST call was made for new artist
+    const postCalls = fetchCalls.filter(
+      (c) => c.method === "POST" && /\/festivals\/42\/artists$/.test(c.url),
+    );
+    expect(postCalls).toHaveLength(1);
+  });
+
+  test("replace mode with no existing artists still links new ones", async () => {
+    setupFestivalMock();
+
+    // No existing artists
+    setupFestivalArtistsMock([]);
+
+    setupArtistSearchMock({
+      "Pavement": { id: 10, name: "Pavement", slug: "pavement" },
+    });
+
+    addMockRoute("POST", /\/festivals\/42\/artists$/, () => ({ id: 1 }));
+
+    const artists = [{ name: "Pavement" }];
+    const results = await linkArtistsToFestival("viva-phx-2026", artists, TEST_ENV, {
+      confirm: true,
+      replace: true,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      name: "Pavement",
+      action: "linked",
+    });
+
+    // No DELETE calls (no existing artists)
+    const deleteCalls = fetchCalls.filter((c) => c.method === "DELETE");
+    expect(deleteCalls).toHaveLength(0);
+  });
+
+  test("passes all optional fields to POST body", async () => {
+    setupFestivalMock();
+    setupArtistSearchMock({
+      "Khruangbin": { id: 10, name: "Khruangbin", slug: "khruangbin" },
+    });
+    addMockRoute("POST", /\/festivals\/42\/artists$/, () => ({ id: 1 }));
+
+    const artists = [{
+      name: "Khruangbin",
+      billing_tier: "headliner",
+      position: 0,
+      day_date: "2026-03-07",
+      stage: "Main Stage",
+      set_time: "21:00:00",
+    }];
+    await linkArtistsToFestival("viva-phx-2026", artists, TEST_ENV, {
+      confirm: true,
+      replace: false,
+    });
+
+    const postCalls = fetchCalls.filter(
+      (c) => c.method === "POST" && /\/festivals\/42\/artists$/.test(c.url),
+    );
+    expect(postCalls).toHaveLength(1);
+    expect(postCalls[0].body).toMatchObject({
+      artist_id: 10,
+      billing_tier: "headliner",
+      position: 0,
+      day_date: "2026-03-07",
+      stage: "Main Stage",
+      set_time: "21:00:00",
+    });
+  });
+});
+
+describe("unlinkArtistFromFestival", () => {
+  test("unlinks artist by name in dry-run mode (no mutations)", async () => {
+    setupFestivalMock();
+    setupArtistSearchMock({
+      "Pavement": { id: 10, name: "Pavement", slug: "pavement" },
+    });
+
+    const result = await unlinkArtistFromFestival("viva-phx-2026", "Pavement", TEST_ENV, false);
+
+    // Dry-run still returns the planned action
+    expect(result.action).toBe("unlinked");
+    expect(result.artistId).toBe(10);
+
+    // No DELETE calls should have been made
+    const deleteCalls = fetchCalls.filter((c) => c.method === "DELETE");
+    expect(deleteCalls).toHaveLength(0);
+  });
+
+  test("unlinks artist by name with --confirm", async () => {
+    setupFestivalMock();
+    setupArtistSearchMock({
+      "Pavement": { id: 10, name: "Pavement", slug: "pavement" },
+    });
+    addMockRoute("DELETE", /\/festivals\/42\/artists\/10$/, () => ({}));
+
+    const result = await unlinkArtistFromFestival("viva-phx-2026", "Pavement", TEST_ENV, true);
+
+    expect(result).toMatchObject({
+      name: "Pavement",
+      action: "unlinked",
+      artistId: 10,
+    });
+
+    const deleteCalls = fetchCalls.filter(
+      (c) => c.method === "DELETE" && /\/festivals\/42\/artists\/10$/.test(c.url),
+    );
+    expect(deleteCalls).toHaveLength(1);
+  });
+
+  test("unlinks artist by numeric ID", async () => {
+    setupFestivalMock();
+    addMockRoute("DELETE", /\/festivals\/42\/artists\/99$/, () => ({}));
+
+    const result = await unlinkArtistFromFestival("viva-phx-2026", "99", TEST_ENV, true);
+
+    expect(result).toMatchObject({
+      name: "99",
+      action: "unlinked",
+      artistId: 99,
+    });
+  });
+
+  test("returns not_found when festival not found", async () => {
+    // No festival mock — 404
+    const result = await unlinkArtistFromFestival("unknown-fest", "Pavement", TEST_ENV, true);
+    expect(result.action).toBe("not_found");
+  });
+
+  test("returns not_found when artist name not resolved", async () => {
+    setupFestivalMock();
+    addMockRoute("GET", /\/artists\/search/, () => ({ artists: [] }));
+
+    const result = await unlinkArtistFromFestival("viva-phx-2026", "Unknown Band", TEST_ENV, true);
+    expect(result.action).toBe("not_found");
+  });
+
+  test("handles 404 when artist is not linked to festival", async () => {
+    setupFestivalMock();
+    setupArtistSearchMock({
+      "Pavement": { id: 10, name: "Pavement", slug: "pavement" },
+    });
+    addMockRouteWithStatus("DELETE", /\/festivals\/42\/artists\/10$/, 404, () => ({
+      message: "Artist not found in festival lineup",
+    }));
+
+    const result = await unlinkArtistFromFestival("viva-phx-2026", "Pavement", TEST_ENV, true);
+
+    expect(result).toMatchObject({
+      name: "Pavement",
+      action: "not_found",
+      artistId: 10,
+    });
+  });
+
+  test("handles API error gracefully", async () => {
+    setupFestivalMock();
+    setupArtistSearchMock({
+      "Pavement": { id: 10, name: "Pavement", slug: "pavement" },
+    });
+    addMockRouteWithStatus("DELETE", /\/festivals\/42\/artists\/10$/, 500, () => ({
+      message: "Internal server error",
+    }));
+
+    const result = await unlinkArtistFromFestival("viva-phx-2026", "Pavement", TEST_ENV, true);
+
+    expect(result.action).toBe("error");
+    expect(result.error).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- New `ph festival link-artists <festival> [json]` command — resolves artist names and links them to an existing festival
- New `ph festival unlink-artist <festival> <artist>` command — surgically removes a single artist link
- Supports `--file` flag for reading artist JSON from file, `--replace` to clear existing links first
- Dry-run by default, `--confirm` to execute
- Handles 409 (already linked) and 404 (not linked) gracefully
- Validates billing tiers, supports all optional fields (position, day_date, stage, set_time)

## Test plan
- [x] 24 new tests covering all scenarios (dry-run, confirm, replace, errors, edge cases)
- [x] All 267 tests pass (24 new + 243 existing)
- [ ] Manual: `ph festival link-artists viva-phx-2026 '[{"name":"Pavement"}]' --confirm`
- [ ] Manual: `ph festival unlink-artist viva-phx-2026 "Wrong Artist" --confirm`

Closes PSY-175

🤖 Generated with [Claude Code](https://claude.com/claude-code)