### PR TITLE
Add country field to artist and venue update endpoints

### DIFF
--- a/backend/internal/api/handlers/artist.go
+++ b/backend/internal/api/handlers/artist.go
@@ -720,6 +720,7 @@ type AdminUpdateArtistRequest struct {
 		Name       *string `json:"name,omitempty" required:"false" doc:"Artist name"`
 		City       *string `json:"city,omitempty" required:"false" doc:"City"`
 		State      *string `json:"state,omitempty" required:"false" doc:"State"`
+		Country    *string `json:"country,omitempty" required:"false" doc:"Country"`
 		Instagram  *string `json:"instagram,omitempty" required:"false" doc:"Instagram URL"`
 		Facebook   *string `json:"facebook,omitempty" required:"false" doc:"Facebook URL"`
 		Twitter    *string `json:"twitter,omitempty" required:"false" doc:"Twitter/X URL"`
@@ -781,6 +782,9 @@ func (h *ArtistHandler) AdminUpdateArtistHandler(ctx context.Context, req *Admin
 	}
 	if req.Body.State != nil {
 		updates["state"] = nilIfEmpty(*req.Body.State)
+	}
+	if req.Body.Country != nil {
+		updates["country"] = nilIfEmpty(*req.Body.Country)
 	}
 	if req.Body.Instagram != nil {
 		updates["instagram"] = nilIfEmpty(*req.Body.Instagram)

--- a/backend/internal/api/handlers/venue.go
+++ b/backend/internal/api/handlers/venue.go
@@ -347,6 +347,7 @@ type UpdateVenueRequest struct {
 		Address    *string `json:"address,omitempty" required:"false" doc:"Venue address"`
 		City       *string `json:"city,omitempty" required:"false" doc:"Venue city"`
 		State      *string `json:"state,omitempty" required:"false" doc:"Venue state"`
+		Country    *string `json:"country,omitempty" required:"false" doc:"Venue country"`
 		Zipcode    *string `json:"zipcode,omitempty" required:"false" doc:"Venue zipcode"`
 		Instagram  *string `json:"instagram,omitempty" required:"false" doc:"Instagram handle or URL"`
 		Facebook   *string `json:"facebook,omitempty" required:"false" doc:"Facebook URL"`
@@ -408,6 +409,7 @@ func (h *VenueHandler) UpdateVenueHandler(ctx context.Context, req *UpdateVenueR
 		Address:     req.Body.Address,
 		City:        req.Body.City,
 		State:       req.Body.State,
+		Country:     req.Body.Country,
 		Zipcode:     req.Body.Zipcode,
 		Instagram:   req.Body.Instagram,
 		Facebook:    req.Body.Facebook,
@@ -462,6 +464,9 @@ func (h *VenueHandler) UpdateVenueHandler(ctx context.Context, req *UpdateVenueR
 		}
 		if editReq.State != nil {
 			updates["state"] = *editReq.State
+		}
+		if editReq.Country != nil {
+			updates["country"] = *editReq.Country
 		}
 		if editReq.Zipcode != nil {
 			updates["zipcode"] = *editReq.Zipcode

--- a/backend/internal/services/contracts/catalog.go
+++ b/backend/internal/services/contracts/catalog.go
@@ -352,6 +352,7 @@ type VenueEditRequest struct {
 	Address     *string `json:"address"`
 	City        *string `json:"city"`
 	State       *string `json:"state"`
+	Country     *string `json:"country"`
 	Zipcode     *string `json:"zipcode"`
 	Instagram   *string `json:"instagram"`
 	Facebook    *string `json:"facebook"`


### PR DESCRIPTION
## Summary
- `PATCH /admin/artists/{id}` now accepts `country` field
- `PUT /venues/{id}` now accepts `country` field
- Also added `country` to `VenueEditRequest` contract (used by pending edits flow)
- Fixes Huma 422 "unexpected property" errors when CLI tries to update country

## Test plan
- [x] Backend builds clean
- [x] Artist and venue handler tests pass
- [ ] Manual: `ph submit artist --confirm '[{"name": "Just Mustard", "country": "Ireland"}]'` succeeds

Closes PSY-227

🤖 Generated with [Claude Code](https://claude.com/claude-code)