### PR TITLE
Fix venue/label CLI allowlists to include social fields

### DIFF
--- a/cli/src/commands/submit-label.ts
+++ b/cli/src/commands/submit-label.ts
@@ -207,7 +207,10 @@ export async function submitLabels(
           // label_name (not part of label API).
           const labelApiFields = [
             "name", "city", "state", "country", "website",
-            "description", "bandcamp_url",
+            "description", "bandcamp_url", "bandcamp",
+            "founded_year", "status",
+            "instagram", "facebook", "twitter", "youtube",
+            "spotify", "soundcloud",
           ];
           const labelPayload: Record<string, unknown> = {};
           for (const field of labelApiFields) {

--- a/cli/src/commands/submit-venue.ts
+++ b/cli/src/commands/submit-venue.ts
@@ -13,9 +13,17 @@ interface VenueInput {
   country?: string;
   address?: string;
   zip_code?: string;
+  zipcode?: string;
   website?: string;
   capacity?: number;
   description?: string;
+  instagram?: string;
+  facebook?: string;
+  twitter?: string;
+  youtube?: string;
+  spotify?: string;
+  soundcloud?: string;
+  bandcamp?: string;
 }
 
 export interface SubmitVenuesResult {
@@ -222,7 +230,9 @@ export async function submitVenues(
         // label/label_name (not part of venue API).
         const venueApiFields = [
           "name", "city", "state", "country", "address", "zip_code",
-          "website", "capacity", "description",
+          "zipcode", "website", "capacity", "description",
+          "instagram", "facebook", "twitter", "youtube",
+          "spotify", "soundcloud", "bandcamp",
         ];
         const venuePayload: Record<string, unknown> = {};
         for (const field of venueApiFields) {

--- a/cli/src/lib/duplicates.ts
+++ b/cli/src/lib/duplicates.ts
@@ -227,7 +227,9 @@ const ARTIST_FIELDS = [
 
 const VENUE_FIELDS = [
   "name", "city", "state", "country", "address", "zip_code",
-  "website", "capacity", "description",
+  "zipcode", "website", "capacity", "description",
+  "instagram", "facebook", "twitter", "youtube",
+  "spotify", "soundcloud", "bandcamp",
 ];
 
 const RELEASE_FIELDS = [
@@ -237,7 +239,9 @@ const RELEASE_FIELDS = [
 
 const LABEL_FIELDS = [
   "name", "city", "state", "country", "website", "description",
-  "bandcamp_url",
+  "bandcamp_url", "bandcamp", "founded_year", "status",
+  "instagram", "facebook", "twitter", "youtube",
+  "spotify", "soundcloud",
 ];
 
 const FESTIVAL_FIELDS = [

--- a/cli/test/submit-venue.test.ts
+++ b/cli/test/submit-venue.test.ts
@@ -81,6 +81,53 @@ describe("submitVenues", () => {
     expect(result.results[0].message).toBe("Created successfully");
   });
 
+  test("create with --confirm includes social fields and strips non-API fields", async () => {
+    const postMock = mock(() =>
+      Promise.resolve({ id: 6, name: "Test Venue", slug: "test-venue" }),
+    );
+    const client = createMockClient({
+      get: mock(() => Promise.resolve({ venues: [] })),
+      post: postMock,
+    });
+
+    const venues = [
+      {
+        name: "Test Venue",
+        city: "Phoenix",
+        state: "AZ",
+        instagram: "@testvenue",
+        facebook: "https://facebook.com/testvenue",
+        twitter: "@testvenue",
+        youtube: "https://youtube.com/testvenue",
+        spotify: "https://open.spotify.com/testvenue",
+        soundcloud: "https://soundcloud.com/testvenue",
+        bandcamp: "https://testvenue.bandcamp.com",
+        entity_type: "venue",
+        label_name: "Some Label",
+      },
+    ];
+
+    const result = await submitVenues(client, venues, true);
+    restoreStderr();
+
+    expect(result.creates).toBe(1);
+    expect(result.errors).toBe(0);
+    expect(postMock).toHaveBeenCalledTimes(1);
+    // Social fields should be included, non-API fields (entity_type, tags, label_name) stripped
+    expect(postMock).toHaveBeenCalledWith("/admin/venues", {
+      name: "Test Venue",
+      city: "Phoenix",
+      state: "AZ",
+      instagram: "@testvenue",
+      facebook: "https://facebook.com/testvenue",
+      twitter: "@testvenue",
+      youtube: "https://youtube.com/testvenue",
+      spotify: "https://open.spotify.com/testvenue",
+      soundcloud: "https://soundcloud.com/testvenue",
+      bandcamp: "https://testvenue.bandcamp.com",
+    });
+  });
+
   test("single venue update — existing match with new address info", async () => {
     const client = createMockClient({
       get: mock(() =>


### PR DESCRIPTION
## Summary
- Venue allowlist now includes `instagram`, `facebook`, `twitter`, `youtube`, `spotify`, `soundcloud`, `bandcamp`, `zipcode`
- Label allowlist now includes social fields and `founded_year`, `status`
- Duplicate detection field lists updated to match (enables update detection for social fields)
- New test verifies social fields pass through while non-API fields are stripped

Audit: artist (PSY-228 ✓), release (manual construction ✓), festival (manual construction ✓)

## Test plan
- [x] New test: venue create with social fields passes through correctly
- [x] 167 relevant tests pass
- [ ] Manual: `/ingest dev` with Instagram @handles → venue instagram field persists

Closes PSY-230

🤖 Generated with [Claude Code](https://claude.com/claude-code)