### PR TITLE
Redesign city filter: combobox + chips replacing pill cloud

### DIFF
--- a/frontend/components/filters/CityFilters.test.tsx
+++ b/frontend/components/filters/CityFilters.test.tsx
@@ -1,7 +1,12 @@
-import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeAll } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { CityFilters, type CityWithCount, type CityState } from './CityFilters'
+
+// jsdom does not implement scrollIntoView (required by cmdk)
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+})
 
 const cities: CityWithCount[] = [
   { city: 'Phoenix', state: 'AZ', count: 8 },
@@ -9,33 +14,72 @@ const cities: CityWithCount[] = [
   { city: 'Tempe', state: 'AZ', count: 2 },
 ]
 
+// Large city list for popular cities tests
+const manyCities: CityWithCount[] = [
+  { city: 'Phoenix', state: 'AZ', count: 15 },
+  { city: 'Denver', state: 'CO', count: 5 },
+  { city: 'Chicago', state: 'IL', count: 4 },
+  { city: 'Mesa', state: 'AZ', count: 3 },
+  { city: 'Tempe', state: 'AZ', count: 2 },
+  { city: 'Flagstaff', state: 'AZ', count: 1 },
+]
+
 describe('CityFilters', () => {
-  it('renders "All Cities" chip and city chips with counts', () => {
+  it('renders the combobox trigger', () => {
     render(
       <CityFilters cities={cities} selectedCities={[]} onFilterChange={vi.fn()} />
     )
 
-    expect(screen.getByText('All Cities')).toBeInTheDocument()
-    expect(screen.getByText(/Phoenix, AZ/)).toBeInTheDocument()
-    expect(screen.getByText('(8)')).toBeInTheDocument()
-    expect(screen.getByText(/Mesa, AZ/)).toBeInTheDocument()
-    expect(screen.getByText(/Tempe, AZ/)).toBeInTheDocument()
+    expect(screen.getByTestId('city-filter-combobox')).toBeInTheDocument()
+    expect(screen.getByText('Filter by city...')).toBeInTheDocument()
   })
 
-  it('uses custom allLabel', () => {
+  it('opens the dropdown when combobox is clicked', async () => {
+    const user = userEvent.setup()
     render(
-      <CityFilters
-        cities={cities}
-        selectedCities={[]}
-        onFilterChange={vi.fn()}
-        allLabel="All Venues"
-      />
+      <CityFilters cities={cities} selectedCities={[]} onFilterChange={vi.fn()} />
     )
 
-    expect(screen.getByText('All Venues')).toBeInTheDocument()
+    await user.click(screen.getByTestId('city-filter-combobox'))
+
+    // City options should be visible in the dropdown
+    expect(screen.getByText('Phoenix, AZ')).toBeInTheDocument()
+    expect(screen.getByText('Mesa, AZ')).toBeInTheDocument()
+    expect(screen.getByText('Tempe, AZ')).toBeInTheDocument()
   })
 
-  it('clicking "All Cities" calls onFilterChange with empty array', async () => {
+  it('shows cities sorted by count descending in dropdown', async () => {
+    const user = userEvent.setup()
+    render(
+      <CityFilters cities={cities} selectedCities={[]} onFilterChange={vi.fn()} />
+    )
+
+    await user.click(screen.getByTestId('city-filter-combobox'))
+
+    const items = screen.getAllByRole('option')
+    expect(items[0]).toHaveTextContent('Phoenix, AZ')
+    expect(items[0]).toHaveTextContent('(8)')
+    expect(items[1]).toHaveTextContent('Mesa, AZ')
+    expect(items[1]).toHaveTextContent('(3)')
+    expect(items[2]).toHaveTextContent('Tempe, AZ')
+    expect(items[2]).toHaveTextContent('(2)')
+  })
+
+  it('selecting a city from dropdown calls onFilterChange', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(
+      <CityFilters cities={cities} selectedCities={[]} onFilterChange={onChange} />
+    )
+
+    await user.click(screen.getByTestId('city-filter-combobox'))
+    await user.click(screen.getByText('Phoenix, AZ'))
+
+    expect(onChange).toHaveBeenCalledWith([{ city: 'Phoenix', state: 'AZ' }])
+  })
+
+  it('selecting an already-selected city removes it', async () => {
+    const user = userEvent.setup()
     const onChange = vi.fn()
     render(
       <CityFilters
@@ -45,50 +89,52 @@ describe('CityFilters', () => {
       />
     )
 
-    await userEvent.click(screen.getByText('All Cities'))
+    await user.click(screen.getByTestId('city-filter-combobox'))
+    // Use testid to target the dropdown option (not the chip)
+    await user.click(screen.getByTestId('city-option-phoenix-az'))
+
     expect(onChange).toHaveBeenCalledWith([])
   })
 
-  describe('single click (no shift)', () => {
-    it('selects only the clicked city', async () => {
-      const onChange = vi.fn()
-      render(
-        <CityFilters cities={cities} selectedCities={[]} onFilterChange={onChange} />
-      )
+  it('multi-select: adds a second city', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(
+      <CityFilters
+        cities={cities}
+        selectedCities={[{ city: 'Phoenix', state: 'AZ' }]}
+        onFilterChange={onChange}
+      />
+    )
 
-      await userEvent.click(screen.getByText(/Phoenix, AZ/))
-      expect(onChange).toHaveBeenCalledWith([{ city: 'Phoenix', state: 'AZ' }])
-    })
+    await user.click(screen.getByTestId('city-filter-combobox'))
+    await user.click(screen.getByText('Mesa, AZ'))
 
-    it('replaces current selection with clicked city', async () => {
-      const onChange = vi.fn()
-      render(
-        <CityFilters
-          cities={cities}
-          selectedCities={[{ city: 'Phoenix', state: 'AZ' }]}
-          onFilterChange={onChange}
-        />
-      )
+    expect(onChange).toHaveBeenCalledWith([
+      { city: 'Phoenix', state: 'AZ' },
+      { city: 'Mesa', state: 'AZ' },
+    ])
+  })
 
-      await userEvent.click(screen.getByText(/Mesa, AZ/))
-      expect(onChange).toHaveBeenCalledWith([{ city: 'Mesa', state: 'AZ' }])
-    })
-
-    it('deselects to "All Cities" when clicking the sole selected city', async () => {
-      const onChange = vi.fn()
+  describe('active filter chips', () => {
+    it('shows dismissible chips for selected cities', () => {
       render(
         <CityFilters
           cities={cities}
-          selectedCities={[{ city: 'Phoenix', state: 'AZ' }]}
-          onFilterChange={onChange}
+          selectedCities={[
+            { city: 'Phoenix', state: 'AZ' },
+            { city: 'Mesa', state: 'AZ' },
+          ]}
+          onFilterChange={vi.fn()}
         />
       )
 
-      await userEvent.click(screen.getByText(/Phoenix, AZ/))
-      expect(onChange).toHaveBeenCalledWith([])
+      expect(screen.getByTestId('city-chip-phoenix-az')).toBeInTheDocument()
+      expect(screen.getByTestId('city-chip-mesa-az')).toBeInTheDocument()
     })
 
-    it('single-selects when clicking one of multiple selected cities', async () => {
+    it('removes a city when chip dismiss button is clicked', async () => {
+      const user = userEvent.setup()
       const onChange = vi.fn()
       render(
         <CityFilters
@@ -101,34 +147,41 @@ describe('CityFilters', () => {
         />
       )
 
-      await userEvent.click(screen.getByText(/Phoenix, AZ/))
-      expect(onChange).toHaveBeenCalledWith([{ city: 'Phoenix', state: 'AZ' }])
+      await user.click(screen.getByTestId('city-chip-remove-phoenix-az'))
+
+      expect(onChange).toHaveBeenCalledWith([{ city: 'Mesa', state: 'AZ' }])
     })
   })
 
-  describe('shift+click (multi-select)', () => {
-    it('adds a city to the selection', async () => {
-      const user = userEvent.setup()
-      const onChange = vi.fn()
+  describe('clear all / all cities button', () => {
+    it('shows "All Cities" when one city is selected', () => {
       render(
         <CityFilters
           cities={cities}
           selectedCities={[{ city: 'Phoenix', state: 'AZ' }]}
-          onFilterChange={onChange}
+          onFilterChange={vi.fn()}
         />
       )
 
-      await user.keyboard('{Shift>}')
-      await user.click(screen.getByText(/Mesa, AZ/))
-      await user.keyboard('{/Shift}')
-
-      expect(onChange).toHaveBeenCalledWith([
-        { city: 'Phoenix', state: 'AZ' },
-        { city: 'Mesa', state: 'AZ' },
-      ])
+      expect(screen.getByTestId('city-filter-all')).toHaveTextContent('All Cities')
     })
 
-    it('removes a city from the selection', async () => {
+    it('shows "Clear all" when 2+ cities are selected', () => {
+      render(
+        <CityFilters
+          cities={cities}
+          selectedCities={[
+            { city: 'Phoenix', state: 'AZ' },
+            { city: 'Mesa', state: 'AZ' },
+          ]}
+          onFilterChange={vi.fn()}
+        />
+      )
+
+      expect(screen.getByTestId('city-filter-all')).toHaveTextContent('Clear all')
+    })
+
+    it('clears all filters when clicked', async () => {
       const user = userEvent.setup()
       const onChange = vi.fn()
       render(
@@ -142,26 +195,94 @@ describe('CityFilters', () => {
         />
       )
 
-      await user.keyboard('{Shift>}')
-      await user.click(screen.getByText(/Mesa, AZ/))
-      await user.keyboard('{/Shift}')
-
-      expect(onChange).toHaveBeenCalledWith([{ city: 'Phoenix', state: 'AZ' }])
+      await user.click(screen.getByTestId('city-filter-all'))
+      expect(onChange).toHaveBeenCalledWith([])
     })
 
-    it('adds a city when nothing is selected', async () => {
+    it('does not show clear button when no cities are selected', () => {
+      render(
+        <CityFilters cities={cities} selectedCities={[]} onFilterChange={vi.fn()} />
+      )
+
+      expect(screen.queryByTestId('city-filter-all')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('popular cities row', () => {
+    it('shows popular cities when none are selected', () => {
+      render(
+        <CityFilters cities={manyCities} selectedCities={[]} onFilterChange={vi.fn()} />
+      )
+
+      expect(screen.getByTestId('popular-cities')).toBeInTheDocument()
+      expect(screen.getByText('Popular:')).toBeInTheDocument()
+      // Top 5 with count >= 2
+      expect(screen.getByTestId('popular-city-phoenix-az')).toBeInTheDocument()
+      expect(screen.getByTestId('popular-city-denver-co')).toBeInTheDocument()
+      expect(screen.getByTestId('popular-city-chicago-il')).toBeInTheDocument()
+      expect(screen.getByTestId('popular-city-mesa-az')).toBeInTheDocument()
+      expect(screen.getByTestId('popular-city-tempe-az')).toBeInTheDocument()
+    })
+
+    it('hides popular cities row when cities are selected', () => {
+      render(
+        <CityFilters
+          cities={manyCities}
+          selectedCities={[{ city: 'Phoenix', state: 'AZ' }]}
+          onFilterChange={vi.fn()}
+        />
+      )
+
+      expect(screen.queryByTestId('popular-cities')).not.toBeInTheDocument()
+    })
+
+    it('clicking a popular city selects it', async () => {
       const user = userEvent.setup()
       const onChange = vi.fn()
       render(
-        <CityFilters cities={cities} selectedCities={[]} onFilterChange={onChange} />
+        <CityFilters cities={manyCities} selectedCities={[]} onFilterChange={onChange} />
       )
 
-      await user.keyboard('{Shift>}')
-      await user.click(screen.getByText(/Tempe, AZ/))
-      await user.keyboard('{/Shift}')
-
-      expect(onChange).toHaveBeenCalledWith([{ city: 'Tempe', state: 'AZ' }])
+      await user.click(screen.getByTestId('popular-city-denver-co'))
+      expect(onChange).toHaveBeenCalledWith([{ city: 'Denver', state: 'CO' }])
     })
+
+    it('does not show popular cities when fewer than 3 cities have 2+ count', () => {
+      const fewCities: CityWithCount[] = [
+        { city: 'Phoenix', state: 'AZ', count: 5 },
+        { city: 'Mesa', state: 'AZ', count: 2 },
+        { city: 'Tempe', state: 'AZ', count: 1 },
+      ]
+
+      render(
+        <CityFilters cities={fewCities} selectedCities={[]} onFilterChange={vi.fn()} />
+      )
+
+      expect(screen.queryByTestId('popular-cities')).not.toBeInTheDocument()
+    })
+  })
+
+  it('shows checkmark for selected cities in dropdown', async () => {
+    const user = userEvent.setup()
+    render(
+      <CityFilters
+        cities={cities}
+        selectedCities={[{ city: 'Phoenix', state: 'AZ' }]}
+        onFilterChange={vi.fn()}
+      />
+    )
+
+    await user.click(screen.getByTestId('city-filter-combobox'))
+
+    // The Phoenix option should have a visible checkmark
+    const phoenixOption = screen.getByTestId('city-option-phoenix-az')
+    const checkIcon = phoenixOption.querySelector('svg')
+    expect(checkIcon).not.toHaveClass('opacity-0')
+
+    // Mesa should have an invisible checkmark
+    const mesaOption = screen.getByTestId('city-option-mesa-az')
+    const mesaCheckIcon = mesaOption.querySelector('svg')
+    expect(mesaCheckIcon).toHaveClass('opacity-0')
   })
 
   it('renders children', () => {
@@ -172,5 +293,18 @@ describe('CityFilters', () => {
     )
 
     expect(screen.getByTestId('child')).toBeInTheDocument()
+  })
+
+  it('uses custom allLabel', () => {
+    render(
+      <CityFilters
+        cities={cities}
+        selectedCities={[{ city: 'Phoenix', state: 'AZ' }]}
+        onFilterChange={vi.fn()}
+        allLabel="All Venues"
+      />
+    )
+
+    expect(screen.getByTestId('city-filter-all')).toHaveTextContent('All Venues')
   })
 })

--- a/frontend/components/filters/CityFilters.tsx
+++ b/frontend/components/filters/CityFilters.tsx
@@ -1,4 +1,11 @@
-import { FilterChip } from './FilterChip'
+'use client'
+
+import { useState, useMemo } from 'react'
+import { Search, X, Check, ChevronsUpDown } from 'lucide-react'
+import { Command, CommandInput, CommandList, CommandEmpty, CommandGroup, CommandItem } from '@/components/ui/command'
+import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover'
+import { Badge } from '@/components/ui/badge'
+import { cn } from '@/lib/utils'
 
 /**
  * Generic interface for city data with a count.
@@ -28,6 +35,17 @@ function cityKey(c: CityState): string {
   return `${c.city}|${c.state}`
 }
 
+function cityLabel(c: CityState): string {
+  return `${c.city}, ${c.state}`
+}
+
+/** Minimum number of cities with 2+ items to show the popular row */
+const MIN_POPULAR_CITIES = 3
+/** Maximum popular cities to show */
+const MAX_POPULAR_CITIES = 5
+/** Minimum count for a city to be "popular" */
+const MIN_POPULAR_COUNT = 2
+
 export function CityFilters({
   cities,
   selectedCities,
@@ -35,53 +53,162 @@ export function CityFilters({
   allLabel = 'All Cities',
   children,
 }: CityFiltersProps) {
-  const isAllSelected = selectedCities.length === 0
-  const selectedSet = new Set(selectedCities.map(cityKey))
+  const [open, setOpen] = useState(false)
+  const selectedSet = useMemo(
+    () => new Set(selectedCities.map(cityKey)),
+    [selectedCities]
+  )
 
-  const handleToggle = (city: string, state: string, e: React.MouseEvent) => {
-    const key = cityKey({ city, state })
-    if (e.shiftKey) {
-      // Shift+click: toggle this city in the multi-selection
-      if (selectedSet.has(key)) {
-        onFilterChange(selectedCities.filter(c => cityKey(c) !== key))
-      } else {
-        onFilterChange([...selectedCities, { city, state }])
-      }
+  // Cities sorted by count descending for the dropdown
+  const sortedCities = useMemo(
+    () => [...cities].sort((a, b) => b.count - a.count),
+    [cities]
+  )
+
+  // Popular cities: top N with count >= threshold
+  const popularCities = useMemo(() => {
+    const eligible = sortedCities.filter(c => c.count >= MIN_POPULAR_COUNT)
+    if (eligible.length < MIN_POPULAR_CITIES) return []
+    return eligible.slice(0, MAX_POPULAR_CITIES)
+  }, [sortedCities])
+
+  const handleToggleCity = (city: CityWithCount) => {
+    const key = cityKey(city)
+    if (selectedSet.has(key)) {
+      onFilterChange(selectedCities.filter(c => cityKey(c) !== key))
     } else {
-      // Single click: select only this city, or deselect if already the sole selection
-      if (selectedSet.has(key) && selectedCities.length === 1) {
-        onFilterChange([])
-      } else {
-        onFilterChange([{ city, state }])
-      }
+      onFilterChange([...selectedCities, { city: city.city, state: city.state }])
     }
   }
 
-  return (
-    <div className="flex flex-wrap items-center gap-2">
-      <FilterChip
-        label={allLabel}
-        isActive={isAllSelected}
-        onClick={() => onFilterChange([])}
-        data-testid="city-filter-all"
-      />
-      {cities.map(city => {
-        const isActive = selectedSet.has(cityKey(city))
-        const label = `${city.city}, ${city.state}`
-        const slug = `${city.city}-${city.state}`.toLowerCase().replace(/\s+/g, '-')
+  const handleRemoveCity = (city: CityState) => {
+    onFilterChange(selectedCities.filter(c => cityKey(c) !== cityKey(city)))
+  }
 
-        return (
-          <FilterChip
-            key={`${city.city}-${city.state}`}
-            label={label}
-            isActive={isActive}
-            onClick={(e) => handleToggle(city.city, city.state, e)}
-            count={city.count}
-            data-testid={`city-filter-${slug}`}
-          />
-        )
-      })}
-      {children}
+  const handleClearAll = () => {
+    onFilterChange([])
+  }
+
+  const handlePopularClick = (city: CityWithCount) => {
+    handleToggleCity(city)
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {/* Filter bar: combobox + active chips + children */}
+      <div className="flex flex-wrap items-center gap-2">
+        {/* Searchable combobox */}
+        <Popover open={open} onOpenChange={setOpen}>
+          <PopoverTrigger asChild>
+            <button
+              role="combobox"
+              aria-expanded={open}
+              aria-label="Filter by city"
+              data-testid="city-filter-combobox"
+              className={cn(
+                'flex items-center gap-2 rounded-md border border-border/50 bg-muted/50 px-3 py-1.5 text-sm transition-colors',
+                'hover:bg-muted hover:border-border',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                open && 'border-border bg-muted',
+                selectedCities.length === 0 && 'text-muted-foreground',
+                selectedCities.length > 0 && 'text-foreground'
+              )}
+            >
+              <Search className="h-3.5 w-3.5 shrink-0 opacity-50" />
+              <span className="whitespace-nowrap">Filter by city...</span>
+              <ChevronsUpDown className="h-3.5 w-3.5 shrink-0 opacity-50" />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent className="w-[240px] p-0" align="start">
+            <Command>
+              <CommandInput placeholder="Search cities..." />
+              <CommandList>
+                <CommandEmpty>No cities found.</CommandEmpty>
+                <CommandGroup>
+                  {sortedCities.map(city => {
+                    const key = cityKey(city)
+                    const isSelected = selectedSet.has(key)
+                    return (
+                      <CommandItem
+                        key={key}
+                        value={cityLabel(city)}
+                        onSelect={() => handleToggleCity(city)}
+                        data-testid={`city-option-${city.city}-${city.state}`.toLowerCase().replace(/\s+/g, '-')}
+                      >
+                        <Check
+                          className={cn(
+                            'mr-2 h-4 w-4 shrink-0',
+                            isSelected ? 'opacity-100' : 'opacity-0'
+                          )}
+                        />
+                        <span className="flex-1 truncate">
+                          {cityLabel(city)}
+                        </span>
+                        <span className="ml-2 text-xs text-muted-foreground">
+                          ({city.count})
+                        </span>
+                      </CommandItem>
+                    )
+                  })}
+                </CommandGroup>
+              </CommandList>
+            </Command>
+          </PopoverContent>
+        </Popover>
+
+        {/* Active filter chips */}
+        {selectedCities.map(city => (
+          <Badge
+            key={cityKey(city)}
+            variant="secondary"
+            className="flex items-center gap-1 px-2.5 py-1 text-xs font-medium cursor-default"
+            data-testid={`city-chip-${city.city}-${city.state}`.toLowerCase().replace(/\s+/g, '-')}
+          >
+            {cityLabel(city)}
+            <button
+              onClick={() => handleRemoveCity(city)}
+              className="ml-0.5 rounded-full hover:bg-foreground/10 p-0.5 transition-colors"
+              aria-label={`Remove ${cityLabel(city)} filter`}
+              data-testid={`city-chip-remove-${city.city}-${city.state}`.toLowerCase().replace(/\s+/g, '-')}
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </Badge>
+        ))}
+
+        {/* "All Cities" button when cities are selected */}
+        {selectedCities.length > 0 && (
+          <button
+            onClick={handleClearAll}
+            className="text-xs text-muted-foreground hover:text-foreground transition-colors whitespace-nowrap"
+            data-testid="city-filter-all"
+          >
+            {selectedCities.length >= 2 ? 'Clear all' : allLabel}
+          </button>
+        )}
+
+        {/* Children slot (e.g., SaveDefaultsButton) */}
+        {children}
+      </div>
+
+      {/* Popular cities row */}
+      {popularCities.length > 0 && selectedCities.length === 0 && (
+        <div className="flex items-center gap-1 text-xs text-muted-foreground" data-testid="popular-cities">
+          <span className="shrink-0">Popular:</span>
+          {popularCities.map((city, i) => (
+            <span key={cityKey(city)} className="inline-flex items-center">
+              {i > 0 && <span className="mx-0.5">&middot;</span>}
+              <button
+                onClick={() => handlePopularClick(city)}
+                className="hover:text-foreground transition-colors whitespace-nowrap"
+                data-testid={`popular-city-${city.city}-${city.state}`.toLowerCase().replace(/\s+/g, '-')}
+              >
+                {cityLabel(city)} ({city.count})
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/components/ui/popover.tsx
+++ b/frontend/components/ui/popover.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import * as React from "react"
+import { Popover as PopoverPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+const Popover = PopoverPrimitive.Root
+
+const PopoverTrigger = PopoverPrimitive.Trigger
+
+const PopoverAnchor = PopoverPrimitive.Anchor
+
+const PopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({ className, align = "start", sideOffset = 4, ...props }, ref) => (
+  <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 w-72 rounded-md border bg-popover p-0 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      {...props}
+    />
+  </PopoverPrimitive.Portal>
+))
+PopoverContent.displayName = PopoverPrimitive.Content.displayName
+
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor }

--- a/frontend/e2e/pages/city-filter.spec.ts
+++ b/frontend/e2e/pages/city-filter.spec.ts
@@ -2,7 +2,7 @@ import { test } from '../fixtures/error-detection'
 import { expect } from '@playwright/test'
 
 test.describe('City filter on shows list', () => {
-  test('city filter chips are visible', async ({ page }) => {
+  test('city filter combobox and popular cities are visible', async ({ page }) => {
     await page.goto('/shows')
 
     // Wait for shows to load first
@@ -10,18 +10,21 @@ test.describe('City filter on shows list', () => {
       timeout: 10_000,
     })
 
-    // "All Cities" button should be visible
+    // Combobox trigger should be visible
     await expect(
-      page.getByRole('button', { name: /all cities/i })
+      page.getByTestId('city-filter-combobox')
     ).toBeVisible({ timeout: 5_000 })
 
-    // At least one city chip should be visible (shows count in parens)
+    // Popular cities row should be visible with Phoenix
+    await expect(
+      page.getByTestId('popular-cities')
+    ).toBeVisible()
     await expect(
       page.getByRole('button', { name: /Phoenix/i })
     ).toBeVisible()
   })
 
-  test('clicking a city filter updates URL and filters shows', async ({
+  test('clicking a city in combobox updates URL and filters shows', async ({
     page,
   }) => {
     await page.goto('/shows')
@@ -34,8 +37,9 @@ test.describe('City filter on shows list', () => {
     const initialCount = await page.locator('article').count()
     expect(initialCount).toBe(50)
 
-    // Click "Tucson" city filter (18 shows — fewer than the 50 page limit)
-    await page.getByRole('button', { name: /Tucson/i }).click()
+    // Open the combobox and click Tucson
+    await page.getByTestId('city-filter-combobox').click()
+    await page.getByRole('option', { name: /Tucson/i }).click()
 
     // URL should update with cities param
     await expect(page).toHaveURL(/cities=Tucson/)
@@ -74,7 +78,7 @@ test.describe('City filter on shows list', () => {
           !resp.url().includes('cities='),
         { timeout: 10_000 }
       ),
-      page.getByRole('button', { name: /all cities/i }).click(),
+      page.getByTestId('city-filter-all').click(),
     ])
     expect(response.status()).toBeLessThan(400)
 
@@ -96,8 +100,9 @@ test.describe('City filter on shows list', () => {
       timeout: 10_000,
     })
 
-    // Apply Tucson filter
-    await page.getByRole('button', { name: /Tucson/i }).click()
+    // Open combobox and select Tucson
+    await page.getByTestId('city-filter-combobox').click()
+    await page.getByRole('option', { name: /Tucson/i }).click()
     await expect(page).toHaveURL(/cities=Tucson/)
 
     // Navigate to a show detail and back

--- a/frontend/features/shows/components/ShowListSkeleton.test.tsx
+++ b/frontend/features/shows/components/ShowListSkeleton.test.tsx
@@ -18,8 +18,8 @@ describe('ShowListSkeleton', () => {
 
   it('renders city filter skeletons', () => {
     const { container } = render(<ShowListSkeleton />)
-    // City filter skeleton area has 3 rounded-full skeleton pills
-    const filterSkeletons = container.querySelectorAll('.rounded-full')
-    expect(filterSkeletons).toHaveLength(3)
+    // City filter skeleton: a rounded-md combobox skeleton + a popular cities line skeleton
+    const comboboxSkeleton = container.querySelectorAll('.rounded-md')
+    expect(comboboxSkeleton.length).toBeGreaterThanOrEqual(1)
   })
 })

--- a/frontend/features/shows/components/ShowListSkeleton.tsx
+++ b/frontend/features/shows/components/ShowListSkeleton.tsx
@@ -2,10 +2,11 @@ import { Skeleton } from '@/components/ui/skeleton'
 
 function CityFiltersSkeleton() {
   return (
-    <div className="flex flex-wrap gap-2 mb-6">
-      <Skeleton className="h-8 w-20 rounded-full" />
-      <Skeleton className="h-8 w-28 rounded-full" />
-      <Skeleton className="h-8 w-24 rounded-full" />
+    <div className="flex flex-col gap-2 mb-6">
+      <div className="flex items-center gap-2">
+        <Skeleton className="h-8 w-36 rounded-md" />
+      </div>
+      <Skeleton className="h-4 w-64" />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
Replaces the pill cloud city filter (which didn't scale past ~10 cities) with a compact filter bar:

- **Searchable combobox** (cmdk + Popover): type to narrow, click to toggle, cities sorted by count
- **Dismissible chips**: selected cities shown as badges with × to remove
- **Popular cities shortcuts**: top 5 cities with 2+ items shown as quick-select links
- **Clear all / All Cities**: reset buttons adapt based on selection count

The `CityFilters` component interface is unchanged — all 4 consumers (Shows, Home, Artists, Venues) get the upgrade automatically with zero changes.

Inspired by Bandcamp's tag combiner, What.cd's compact filter bar, and Discogs' faceted filtering with counts.

## Test plan
- [x] 19 component tests (combobox, multi-select, chips, popular cities, clear)
- [x] All 2446 frontend tests pass
- [x] E2E tests updated for new UI selectors
- [x] Skeleton updated to match new layout
- [ ] Manual: verify on `/shows`, `/artists`, `/venues` pages
- [ ] Manual: verify URL state persistence (`?cities=...`)
- [ ] Manual: verify mobile responsiveness

Closes PSY-232

🤖 Generated with [Claude Code](https://claude.com/claude-code)