### PR TITLE
Simplify tag categories to genre/locale/other following Gazelle model

### DIFF
--- a/.claude/skills/ingest/SKILL.md
+++ b/.claude/skills/ingest/SKILL.md
@@ -129,7 +129,7 @@ Tags can be strings (defaults to genre) or objects with category:
 "tags": ["punk", "noise rock", {"name": "Japanese", "category": "locale"}]
 ```
 
-Categories: `genre`, `locale`, `mood`, `era`, `style`, `instrument`, `other`
+Categories: `genre`, `locale`, `other`. String tags default to genre. Use `locale` for nationality/origin tags (e.g., Japanese, Irish). Use `other` for non-genre descriptors.
 
 #### Processing order
 

--- a/backend/db/migrations/000060_simplify_tag_categories.down.sql
+++ b/backend/db/migrations/000060_simplify_tag_categories.down.sql
@@ -1,0 +1,3 @@
+-- No-op: we can't know what the original categories were
+-- Tags will remain as 'other'
+SELECT 1;

--- a/backend/db/migrations/000060_simplify_tag_categories.up.sql
+++ b/backend/db/migrations/000060_simplify_tag_categories.up.sql
@@ -1,0 +1,2 @@
+-- Migrate unused categories to 'other'
+UPDATE tags SET category = 'other' WHERE category IN ('mood', 'era', 'style', 'instrument');

--- a/backend/internal/api/handlers/tag.go
+++ b/backend/internal/api/handlers/tag.go
@@ -34,7 +34,7 @@ func NewTagHandler(tagService contracts.TagServiceInterface, auditLog contracts.
 // ============================================================================
 
 type ListTagsRequest struct {
-	Category string `query:"category" required:"false" doc:"Filter by category (genre, mood, era, style, instrument, locale, other)"`
+	Category string `query:"category" required:"false" doc:"Filter by category (genre, locale, other)"`
 	Search   string `query:"search" required:"false" doc:"Search tags by name"`
 	ParentID uint   `query:"parent_id" required:"false" doc:"Filter by parent tag ID"`
 	Sort     string `query:"sort" required:"false" doc:"Sort by: usage, name, created (default: usage)"`
@@ -343,7 +343,7 @@ type CreateTagRequest struct {
 		Name        string  `json:"name" doc:"Tag name" example:"post-punk"`
 		Description *string `json:"description" required:"false" doc:"Tag description"`
 		ParentID    *uint   `json:"parent_id" required:"false" doc:"Parent tag ID for hierarchy"`
-		Category    string  `json:"category" doc:"Tag category (genre, mood, era, style, instrument, locale, other)" example:"genre"`
+		Category    string  `json:"category" doc:"Tag category (genre, locale, other)" example:"genre"`
 		IsOfficial  bool    `json:"is_official" required:"false" doc:"Whether this is an official/canonical tag"`
 	}
 }

--- a/backend/internal/api/handlers/tag_integration_test.go
+++ b/backend/internal/api/handlers/tag_integration_test.go
@@ -216,7 +216,7 @@ func (s *TagHandlerIntegrationSuite) TestListTags_Success() {
 	admin := createAdminUser(s.deps.db)
 	s.createTagViaHandler(admin, "post-punk", models.TagCategoryGenre)
 	s.createTagViaHandler(admin, "shoegaze", models.TagCategoryGenre)
-	s.createTagViaHandler(admin, "melancholy", models.TagCategoryMood)
+	s.createTagViaHandler(admin, "melancholy", models.TagCategoryOther)
 
 	req := &ListTagsRequest{}
 	resp, err := s.handler.ListTagsHandler(s.deps.ctx, req)
@@ -230,7 +230,7 @@ func (s *TagHandlerIntegrationSuite) TestListTags_FilterByCategory() {
 	admin := createAdminUser(s.deps.db)
 	s.createTagViaHandler(admin, "post-punk", models.TagCategoryGenre)
 	s.createTagViaHandler(admin, "shoegaze", models.TagCategoryGenre)
-	s.createTagViaHandler(admin, "melancholy", models.TagCategoryMood)
+	s.createTagViaHandler(admin, "melancholy", models.TagCategoryOther)
 
 	req := &ListTagsRequest{Category: models.TagCategoryGenre}
 	resp, err := s.handler.ListTagsHandler(s.deps.ctx, req)
@@ -352,17 +352,17 @@ func (s *TagHandlerIntegrationSuite) TestUpdateTag_Success() {
 
 func (s *TagHandlerIntegrationSuite) TestUpdateTag_ChangeCategory() {
 	admin := createAdminUser(s.deps.db)
-	created := s.createTagViaHandler(admin, "dark", models.TagCategoryMood)
+	created := s.createTagViaHandler(admin, "dark", models.TagCategoryOther)
 
 	ctx := ctxWithUser(admin)
-	newCat := models.TagCategoryStyle
+	newCat := models.TagCategoryLocale
 	req := &UpdateTagRequest{TagID: fmt.Sprintf("%d", created.Body.ID)}
 	req.Body.Category = &newCat
 
 	resp, err := s.handler.UpdateTagHandler(ctx, req)
 	s.NoError(err)
 	s.NotNil(resp)
-	s.Equal("style", resp.Body.Category)
+	s.Equal("locale", resp.Body.Category)
 }
 
 func (s *TagHandlerIntegrationSuite) TestUpdateTag_NonAdmin() {
@@ -607,8 +607,8 @@ func (s *TagHandlerIntegrationSuite) TestListEntityTags_Empty() {
 func (s *TagHandlerIntegrationSuite) TestListEntityTags_MultipleTags() {
 	admin := createAdminUser(s.deps.db)
 	tag1 := s.createTagViaHandler(admin, "post-punk", models.TagCategoryGenre)
-	tag2 := s.createTagViaHandler(admin, "dark", models.TagCategoryMood)
-	tag3 := s.createTagViaHandler(admin, "80s", models.TagCategoryEra)
+	tag2 := s.createTagViaHandler(admin, "dark", models.TagCategoryOther)
+	tag3 := s.createTagViaHandler(admin, "80s", models.TagCategoryLocale)
 	artist := createArtist(s.deps.db, "Bauhaus")
 
 	user := createTestUser(s.deps.db)

--- a/backend/internal/models/tag.go
+++ b/backend/internal/models/tag.go
@@ -4,22 +4,14 @@ import "time"
 
 // Tag category constants
 const (
-	TagCategoryGenre      = "genre"
-	TagCategoryMood       = "mood"
-	TagCategoryEra        = "era"
-	TagCategoryStyle      = "style"
-	TagCategoryInstrument = "instrument"
-	TagCategoryLocale     = "locale"
-	TagCategoryOther      = "other"
+	TagCategoryGenre  = "genre"
+	TagCategoryLocale = "locale"
+	TagCategoryOther  = "other"
 )
 
 // TagCategories is the set of valid tag categories.
 var TagCategories = []string{
 	TagCategoryGenre,
-	TagCategoryMood,
-	TagCategoryEra,
-	TagCategoryStyle,
-	TagCategoryInstrument,
 	TagCategoryLocale,
 	TagCategoryOther,
 }

--- a/backend/internal/models/tag_test.go
+++ b/backend/internal/models/tag_test.go
@@ -66,13 +66,9 @@ func TestIsValidTagEntityType_Invalid(t *testing.T) {
 
 func TestTagCategoryConstants(t *testing.T) {
 	assert.Equal(t, "genre", TagCategoryGenre)
-	assert.Equal(t, "mood", TagCategoryMood)
-	assert.Equal(t, "era", TagCategoryEra)
-	assert.Equal(t, "style", TagCategoryStyle)
-	assert.Equal(t, "instrument", TagCategoryInstrument)
 	assert.Equal(t, "locale", TagCategoryLocale)
 	assert.Equal(t, "other", TagCategoryOther)
-	assert.Len(t, TagCategories, 7)
+	assert.Len(t, TagCategories, 3)
 }
 
 func TestTagEntityTypeConstants(t *testing.T) {

--- a/backend/internal/services/catalog/tag_service_test.go
+++ b/backend/internal/services/catalog/tag_service_test.go
@@ -306,7 +306,7 @@ func (suite *TagServiceIntegrationTestSuite) TestGetTagBySlug_NotFound() {
 func (suite *TagServiceIntegrationTestSuite) TestListTags_All() {
 	suite.createTag("rock", "genre")
 	suite.createTag("jazz", "genre")
-	suite.createTag("1990s", "era")
+	suite.createTag("1990s", "other")
 
 	tags, total, err := suite.tagService.ListTags("", "", nil, "name", 50, 0)
 	suite.Require().NoError(err)
@@ -317,7 +317,7 @@ func (suite *TagServiceIntegrationTestSuite) TestListTags_All() {
 func (suite *TagServiceIntegrationTestSuite) TestListTags_FilterByCategory() {
 	suite.createTag("rock", "genre")
 	suite.createTag("jazz", "genre")
-	suite.createTag("1990s", "era")
+	suite.createTag("1990s", "other")
 
 	tags, total, err := suite.tagService.ListTags("genre", "", nil, "name", 50, 0)
 	suite.Require().NoError(err)
@@ -353,11 +353,11 @@ func (suite *TagServiceIntegrationTestSuite) TestUpdateTag_Success() {
 	tag := suite.createTag("typo-tag", "genre")
 
 	newName := "corrected-tag"
-	newCategory := "style"
+	newCategory := "locale"
 	updated, err := suite.tagService.UpdateTag(tag.ID, &newName, nil, nil, &newCategory, nil)
 	suite.Require().NoError(err)
 	suite.Assert().Equal("corrected-tag", updated.Name)
-	suite.Assert().Equal("style", updated.Category)
+	suite.Assert().Equal("locale", updated.Category)
 }
 
 func (suite *TagServiceIntegrationTestSuite) TestUpdateTag_NotFound() {
@@ -482,7 +482,7 @@ func (suite *TagServiceIntegrationTestSuite) TestRemoveTagFromEntity_NotFound() 
 func (suite *TagServiceIntegrationTestSuite) TestListEntityTags() {
 	user := suite.createTestUser("tagger")
 	tag1 := suite.createTag("indie", "genre")
-	tag2 := suite.createTag("lo-fi", "style")
+	tag2 := suite.createTag("lo-fi", "other")
 	artistID := suite.createArtist("Indie Lo-Fi Band")
 
 	suite.tagService.AddTagToEntity(tag1.ID, "", "artist", artistID, user.ID)
@@ -693,14 +693,14 @@ func (suite *TagServiceIntegrationTestSuite) TestGetTrendingTags() {
 func (suite *TagServiceIntegrationTestSuite) TestGetTrendingTags_FilterByCategory() {
 	user := suite.createTestUser("tagger")
 	tag1 := suite.createTag("rock", "genre")
-	tag2 := suite.createTag("1990s", "era")
+	tag2 := suite.createTag("1990s", "other")
 	artistID := suite.createArtist("Band")
 
 	suite.tagService.AddTagToEntity(tag1.ID, "", "artist", artistID, user.ID)
 	artist2 := suite.createArtist("Band2")
 	suite.tagService.AddTagToEntity(tag2.ID, "", "artist", artist2, user.ID)
 
-	tags, err := suite.tagService.GetTrendingTags(10, "era")
+	tags, err := suite.tagService.GetTrendingTags(10, "other")
 	suite.Require().NoError(err)
 	suite.Assert().Len(tags, 1)
 	suite.Assert().Equal("1990s", tags[0].Name)

--- a/frontend/features/tags/components/TagBrowse.test.tsx
+++ b/frontend/features/tags/components/TagBrowse.test.tsx
@@ -139,7 +139,7 @@ describe('TagBrowse', () => {
   it('renders tag cards as links', () => {
     const tags = [
       makeTag({ id: 1, name: 'rock', slug: 'rock' }),
-      makeTag({ id: 2, name: 'punk', slug: 'punk', category: 'style' }),
+      makeTag({ id: 2, name: 'punk', slug: 'punk', category: 'other' }),
     ]
     mockUseTags.mockReturnValue({
       data: { tags, total: 2 },
@@ -229,10 +229,6 @@ describe('TagBrowse', () => {
 
     expect(screen.getByText('All')).toBeInTheDocument()
     expect(screen.getByText('Genre')).toBeInTheDocument()
-    expect(screen.getByText('Mood')).toBeInTheDocument()
-    expect(screen.getByText('Era')).toBeInTheDocument()
-    expect(screen.getByText('Style')).toBeInTheDocument()
-    expect(screen.getByText('Instrument')).toBeInTheDocument()
     expect(screen.getByText('Locale')).toBeInTheDocument()
     expect(screen.getByText('Other')).toBeInTheDocument()
   })

--- a/frontend/features/tags/types.ts
+++ b/frontend/features/tags/types.ts
@@ -1,7 +1,7 @@
 // Tag types — aligned with backend contracts/tag.go response types.
 
 export const TAG_CATEGORIES = [
-  'genre', 'mood', 'era', 'style', 'instrument', 'locale', 'other'
+  'genre', 'locale', 'other'
 ] as const
 export type TagCategory = typeof TAG_CATEGORIES[number]
 
@@ -67,10 +67,6 @@ export interface TagAliasesResponse {
 export function getCategoryColor(category: string): string {
   const colors: Record<string, string> = {
     genre: 'bg-blue-500/10 text-blue-400 border-blue-500/20',
-    mood: 'bg-purple-500/10 text-purple-400 border-purple-500/20',
-    era: 'bg-amber-500/10 text-amber-400 border-amber-500/20',
-    style: 'bg-emerald-500/10 text-emerald-400 border-emerald-500/20',
-    instrument: 'bg-red-500/10 text-red-400 border-red-500/20',
     locale: 'bg-cyan-500/10 text-cyan-400 border-cyan-500/20',
     other: 'bg-zinc-500/10 text-zinc-400 border-zinc-500/20',
   }


### PR DESCRIPTION
## Summary
Reduces tag categories from 7 (`genre`, `mood`, `era`, `style`, `instrument`, `locale`, `other`) to 3 (`genre`, `locale`, `other`), following What.cd/Gazelle's proven approach of letting community usage and voting curate the taxonomy rather than admin-imposed categories.

**Why:** Only `genre` and `locale` saw real usage. Mood/era/style/instrument added cognitive overhead without discovery value. Gazelle powered one of the most obsessively curated music databases ever with just `genre` and `other`.

### Changes
- **Backend model:** Removed 4 unused category constants, reduced validation set
- **Backend migration (000060):** Migrates existing mood/era/style/instrument tags to `other`
- **Backend handlers:** Updated API docs to list 3 categories
- **Frontend types:** Reduced `TAG_CATEGORIES` to 3, simplified color mapping with fallback
- **Ingest skill:** Simplified category documentation
- **Tests:** Updated across all layers (105 backend tag tests pass, 2438 frontend tests pass)

## Test plan
- [x] 43 tag service tests pass
- [x] 62 tag handler tests pass
- [x] Model tests pass
- [x] 2438 frontend tests pass
- [x] `/tags` browse page shows 3 category tabs + All
- [ ] Manual: verify existing tags display correctly after migration

Closes PSY-233

🤖 Generated with [Claude Code](https://claude.com/claude-code)