### PR TITLE
Add CLI commands to add/remove artists on existing shows

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -15,6 +15,7 @@ import { runSubmitFestival } from "./commands/submit-festival";
 import { runBatch } from "./commands/batch";
 import { runStatus } from "./commands/status";
 import { runFestivalLinkArtists, runFestivalUnlinkArtist } from "./commands/festival";
+import { runShowAddArtist, runShowRemoveArtist } from "./commands/show";
 
 const program = new Command();
 
@@ -152,6 +153,31 @@ festivalCmd
   .action(async (festival: string, artist: string, opts: { confirm?: boolean }) => {
     const env = await resolveEnvOrExit(program.opts().env);
     await runFestivalUnlinkArtist(festival, artist, env, !!opts.confirm);
+  });
+
+// ─── ph show ─────────────────────────────────────────────────────────────────
+
+const showCmd = program
+  .command("show")
+  .description("Manage show artist links");
+
+showCmd
+  .command("add-artist <show-id> [json]")
+  .description("Add artists to an existing show by ID")
+  .option("--file <path>", "Read artist JSON from file")
+  .option("--confirm", "Execute changes (default is dry-run)")
+  .action(async (showId: string, json: string | undefined, opts: { file?: string; confirm?: boolean }) => {
+    const env = await resolveEnvOrExit(program.opts().env);
+    await runShowAddArtist(showId, json, env, opts);
+  });
+
+showCmd
+  .command("remove-artist <show-id> <artist>")
+  .description("Remove an artist from a show")
+  .option("--confirm", "Execute changes (default is dry-run)")
+  .action(async (showId: string, artist: string, opts: { confirm?: boolean }) => {
+    const env = await resolveEnvOrExit(program.opts().env);
+    await runShowRemoveArtist(showId, artist, env, !!opts.confirm);
   });
 
 // ─── ph status ───────────────────────────────────────────────────────────────

--- a/cli/src/commands/show.ts
+++ b/cli/src/commands/show.ts
@@ -1,0 +1,487 @@
+import { APIClient, APIError } from "../lib/api";
+import type { EnvironmentConfig } from "../lib/types";
+import * as display from "../lib/display";
+import { green, yellow, gray, dim } from "../lib/ansi";
+import { resolveArtistId } from "./festival";
+
+/** Show artist entry from the input JSON. */
+export interface ShowArtistInput {
+  name: string;
+  is_headliner?: boolean;
+}
+
+/** Result of adding a single artist. */
+export interface ArtistAddResult {
+  name: string;
+  action: "added" | "already_linked" | "not_found" | "error";
+  artistId?: number;
+  error?: string;
+}
+
+/** Result of removing a single artist. */
+export interface ArtistRemoveResult {
+  name: string;
+  action: "removed" | "not_found" | "error";
+  artistId?: number;
+  error?: string;
+}
+
+/** Artist as returned in the show response. */
+interface ShowArtistResponse {
+  id: number;
+  name: string;
+  slug: string;
+  is_headliner?: boolean | null;
+}
+
+/** Minimal show response shape for our needs. */
+interface ShowResponse {
+  id: number;
+  title: string;
+  slug: string;
+  artists: ShowArtistResponse[];
+}
+
+/**
+ * Fetch a show by numeric ID.
+ * Returns the show object or null if not found.
+ */
+export async function getShow(
+  client: APIClient,
+  showId: string,
+): Promise<ShowResponse | null> {
+  try {
+    const result = await client.get<ShowResponse>(`/shows/${showId}`);
+    if (result?.id) {
+      return result;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse JSON input for show artist entries.
+ * Accepts a JSON array of ShowArtistInput objects.
+ */
+export function parseShowArtistInput(jsonStr: string): ShowArtistInput[] {
+  const parsed = JSON.parse(jsonStr);
+
+  if (Array.isArray(parsed)) {
+    return parsed;
+  }
+
+  // Single object — wrap in array
+  return [parsed];
+}
+
+/**
+ * Add artists to an existing show.
+ *
+ * Strategy: GET the show to get current artists, merge new ones in,
+ * PUT back the full artist list via the show update endpoint.
+ *
+ * @param showId - Numeric show ID
+ * @param artists - Array of artist inputs to add
+ * @param env - API environment config
+ * @param confirm - Whether to execute (default: dry-run)
+ * @returns Array of add results
+ */
+export async function addArtistsToShow(
+  showId: string,
+  artists: ShowArtistInput[],
+  env: EnvironmentConfig,
+  confirm: boolean,
+): Promise<ArtistAddResult[]> {
+  const client = new APIClient(env);
+  const results: ArtistAddResult[] = [];
+
+  // --- Step 1: Fetch the show ---
+  display.header("Resolving show...");
+  const show = await getShow(client, showId);
+  if (!show) {
+    display.error(`Show "${showId}" not found.`);
+    return [];
+  }
+  display.success(
+    `Found show: "${show.title || "(untitled)"}" (ID: ${show.id}, slug: ${show.slug})`,
+  );
+
+  // --- Step 2: Resolve artist names ---
+  display.header("Resolving artists...");
+  const resolutions: Array<{
+    input: ShowArtistInput;
+    resolved: { id: number; name: string; confidence: number } | null;
+  }> = [];
+
+  for (const artist of artists) {
+    const match = await resolveArtistId(client, artist.name);
+    resolutions.push({ input: artist, resolved: match });
+  }
+
+  // --- Step 3: Check which are already linked ---
+  const existingArtistIds = new Set(show.artists.map((a) => a.id));
+
+  // --- Step 4: Preview ---
+  display.header("Preview");
+
+  display.info(
+    `Show currently has ${show.artists.length} artist(s): ${show.artists.map((a) => `"${a.name}"`).join(", ") || "(none)"}`,
+  );
+  display.info("");
+
+  let addCount = 0;
+  let alreadyLinkedCount = 0;
+  let notFoundCount = 0;
+
+  for (const r of resolutions) {
+    if (r.resolved) {
+      if (existingArtistIds.has(r.resolved.id)) {
+        display.info(
+          `  ${gray("SKIP")} "${r.input.name}" -> "${r.resolved.name}" (ID: ${r.resolved.id}) — already linked`,
+        );
+        alreadyLinkedCount++;
+      } else {
+        const conf = `${(r.resolved.confidence * 100).toFixed(0)}%`;
+        const matchLabel =
+          r.resolved.confidence >= 1.0
+            ? green(
+                `EXACT -> "${r.resolved.name}" (ID: ${r.resolved.id})`,
+              )
+            : yellow(
+                `FUZZY ${conf} -> "${r.resolved.name}" (ID: ${r.resolved.id})`,
+              );
+        const headlinerLabel = r.input.is_headliner ? " [headliner]" : "";
+        display.info(`  ${green("ADD")} ${r.input.name} ${matchLabel}${headlinerLabel}`);
+        addCount++;
+      }
+    } else {
+      display.warn(`  ${r.input.name} — not found in database`);
+      notFoundCount++;
+    }
+  }
+
+  display.info("");
+  const parts: string[] = [];
+  if (addCount > 0) parts.push(green(`${addCount} to add`));
+  if (alreadyLinkedCount > 0) parts.push(gray(`${alreadyLinkedCount} already linked`));
+  if (notFoundCount > 0) parts.push(yellow(`${notFoundCount} not found`));
+  display.info(`Summary: ${parts.join(", ")}`);
+
+  // --- Step 5: Execute (if --confirm) ---
+  if (!confirm) {
+    display.warn("Dry run. Pass --confirm to execute.");
+    return [];
+  }
+
+  if (addCount === 0) {
+    display.info("Nothing to add.");
+    // Still report already-linked and not-found
+    for (const r of resolutions) {
+      if (r.resolved && existingArtistIds.has(r.resolved.id)) {
+        results.push({
+          name: r.input.name,
+          action: "already_linked",
+          artistId: r.resolved.id,
+        });
+      } else if (!r.resolved) {
+        results.push({
+          name: r.input.name,
+          action: "not_found",
+        });
+      }
+    }
+    return results;
+  }
+
+  // Build the merged artist list: keep existing + add new
+  const updatedArtists: Array<{ id: number; is_headliner?: boolean }> = [];
+
+  // Keep all existing artists
+  for (const existing of show.artists) {
+    updatedArtists.push({
+      id: existing.id,
+      is_headliner: existing.is_headliner ?? false,
+    });
+  }
+
+  // Add new artists
+  for (const r of resolutions) {
+    if (!r.resolved) {
+      results.push({ name: r.input.name, action: "not_found" });
+      continue;
+    }
+
+    if (existingArtistIds.has(r.resolved.id)) {
+      results.push({
+        name: r.input.name,
+        action: "already_linked",
+        artistId: r.resolved.id,
+      });
+      continue;
+    }
+
+    updatedArtists.push({
+      id: r.resolved.id,
+      is_headliner: r.input.is_headliner ?? false,
+    });
+  }
+
+  // PUT the updated artist list
+  display.header("Updating show artists...");
+  try {
+    await client.put(`/shows/${show.id}`, {
+      artists: updatedArtists,
+    });
+
+    // Mark all new artists as added
+    for (const r of resolutions) {
+      if (r.resolved && !existingArtistIds.has(r.resolved.id)) {
+        const headlinerStr = r.input.is_headliner ? " as headliner" : "";
+        display.success(
+          `  Added "${r.resolved.name}" (ID: ${r.resolved.id})${headlinerStr}`,
+        );
+        results.push({
+          name: r.input.name,
+          action: "added",
+          artistId: r.resolved.id,
+        });
+      }
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    display.error(`Failed to update show: ${message}`);
+
+    // Mark all pending adds as errors
+    for (const r of resolutions) {
+      if (r.resolved && !existingArtistIds.has(r.resolved.id)) {
+        results.push({
+          name: r.input.name,
+          action: "error",
+          artistId: r.resolved.id,
+          error: message,
+        });
+      }
+    }
+  }
+
+  // --- Step 6: Final report ---
+  display.header("Results");
+  const added = results.filter((r) => r.action === "added").length;
+  const alreadyLinked = results.filter((r) => r.action === "already_linked").length;
+  const notFound = results.filter((r) => r.action === "not_found").length;
+  const errors = results.filter((r) => r.action === "error").length;
+
+  const reportParts: string[] = [];
+  if (added > 0) reportParts.push(green(`${added} added`));
+  if (alreadyLinked > 0) reportParts.push(gray(`${alreadyLinked} already linked`));
+  if (notFound > 0) reportParts.push(yellow(`${notFound} not found`));
+  if (errors > 0) reportParts.push(`${errors} error(s)`);
+  display.info(`Summary: ${reportParts.join(", ")}`);
+
+  return results;
+}
+
+/**
+ * Remove an artist from an existing show.
+ *
+ * Strategy: GET the show to get current artists, filter out the target,
+ * PUT back the remaining artist list via the show update endpoint.
+ *
+ * @param showId - Numeric show ID
+ * @param artistRef - Artist name or numeric ID
+ * @param env - API environment config
+ * @param confirm - Whether to execute (default: dry-run)
+ * @returns The remove result
+ */
+export async function removeArtistFromShow(
+  showId: string,
+  artistRef: string,
+  env: EnvironmentConfig,
+  confirm: boolean,
+): Promise<ArtistRemoveResult> {
+  const client = new APIClient(env);
+
+  // --- Step 1: Fetch the show ---
+  display.header("Resolving show...");
+  const show = await getShow(client, showId);
+  if (!show) {
+    display.error(`Show "${showId}" not found.`);
+    return { name: artistRef, action: "not_found" };
+  }
+  display.success(
+    `Found show: "${show.title || "(untitled)"}" (ID: ${show.id}, slug: ${show.slug})`,
+  );
+
+  // --- Step 2: Resolve artist ---
+  display.header("Resolving artist...");
+  let artistId: number;
+  let artistName: string;
+
+  // Check if it's a numeric ID
+  const numericId = parseInt(artistRef, 10);
+  if (!isNaN(numericId) && String(numericId) === artistRef) {
+    artistId = numericId;
+    artistName = `ID:${numericId}`;
+    display.info(`Using artist ID: ${numericId}`);
+  } else {
+    // Resolve by name
+    const resolved = await resolveArtistId(client, artistRef);
+    if (!resolved) {
+      display.error(`Artist "${artistRef}" not found in database.`);
+      return { name: artistRef, action: "not_found" };
+    }
+    artistId = resolved.id;
+    artistName = resolved.name;
+    const confidenceStr =
+      resolved.confidence < 1.0
+        ? ` (${(resolved.confidence * 100).toFixed(0)}% match)`
+        : "";
+    display.success(
+      `Found artist: "${resolved.name}" (ID: ${resolved.id})${confidenceStr}`,
+    );
+  }
+
+  // --- Step 3: Check if artist is on this show ---
+  const existingArtist = show.artists.find((a) => a.id === artistId);
+  if (!existingArtist) {
+    display.warn(
+      `Artist "${artistName}" (ID: ${artistId}) is not linked to this show.`,
+    );
+    display.info(
+      `Current artists: ${show.artists.map((a) => `"${a.name}" (ID: ${a.id})`).join(", ") || "(none)"}`,
+    );
+    return { name: artistRef, action: "not_found", artistId };
+  }
+
+  // Use the real name from the show if we only had an ID
+  if (artistName.startsWith("ID:")) {
+    artistName = existingArtist.name;
+  }
+
+  // --- Step 4: Preview ---
+  display.header("Preview");
+  display.info(
+    `Will remove "${artistName}" (ID: ${artistId}) from "${show.title || "(untitled)"}"`,
+  );
+  display.info(
+    `Show will have ${show.artists.length - 1} artist(s) after removal.`,
+  );
+
+  if (!confirm) {
+    display.warn("Dry run. Pass --confirm to execute.");
+    return { name: artistRef, action: "removed", artistId };
+  }
+
+  // --- Step 5: Execute ---
+  display.header("Removing artist...");
+
+  // Build the artist list without the target artist
+  const remainingArtists = show.artists
+    .filter((a) => a.id !== artistId)
+    .map((a) => ({
+      id: a.id,
+      is_headliner: a.is_headliner ?? false,
+    }));
+
+  try {
+    await client.put(`/shows/${show.id}`, {
+      artists: remainingArtists,
+    });
+    display.success(
+      `Removed "${artistName}" (ID: ${artistId}) from "${show.title || "(untitled)"}"`,
+    );
+    return { name: artistRef, action: "removed", artistId };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    display.error(`Failed to update show: ${message}`);
+    return { name: artistRef, action: "error", artistId, error: message };
+  }
+}
+
+/**
+ * Entry point for `ph show add-artist`.
+ */
+export async function runShowAddArtist(
+  showId: string,
+  json: string | undefined,
+  env: EnvironmentConfig,
+  options: { confirm?: boolean; file?: string },
+): Promise<void> {
+  let jsonStr = json;
+
+  // Read from file if --file provided
+  if (options.file) {
+    try {
+      const file = Bun.file(options.file);
+      jsonStr = await file.text();
+    } catch (err) {
+      display.error(
+        `Failed to read file "${options.file}": ${err instanceof Error ? err.message : "unknown error"}`,
+      );
+      process.exit(1);
+    }
+  }
+
+  // Read from stdin if no JSON argument and no file
+  if (!jsonStr) {
+    const chunks: string[] = [];
+    const reader = process.stdin;
+    reader.resume();
+    reader.setEncoding("utf-8");
+
+    jsonStr = await new Promise<string>((resolve, reject) => {
+      reader.on("data", (chunk: string) => chunks.push(chunk));
+      reader.on("end", () => resolve(chunks.join("")));
+      reader.on("error", reject);
+    });
+  }
+
+  if (!jsonStr?.trim()) {
+    display.error(
+      "No JSON provided. Pass as argument, use --file, or pipe to stdin.",
+    );
+    process.exit(1);
+  }
+
+  let artists: ShowArtistInput[];
+  try {
+    artists = parseShowArtistInput(jsonStr);
+  } catch (err) {
+    display.error(
+      `Invalid JSON: ${err instanceof Error ? err.message : "parse error"}`,
+    );
+    process.exit(1);
+  }
+
+  if (artists.length === 0) {
+    display.warn("Empty array — nothing to add.");
+    return;
+  }
+
+  display.info(`Processing ${artists.length} artist(s)...`);
+
+  const results = await addArtistsToShow(showId, artists, env, !!options.confirm);
+
+  const hasErrors = results.some((r) => r.action === "error");
+  if (hasErrors) {
+    process.exit(1);
+  }
+}
+
+/**
+ * Entry point for `ph show remove-artist`.
+ */
+export async function runShowRemoveArtist(
+  showId: string,
+  artistRef: string,
+  env: EnvironmentConfig,
+  confirm: boolean,
+): Promise<void> {
+  const result = await removeArtistFromShow(showId, artistRef, env, confirm);
+
+  if (result.action === "error") {
+    process.exit(1);
+  }
+}

--- a/cli/test/show.test.ts
+++ b/cli/test/show.test.ts
@@ -1,0 +1,497 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import {
+  addArtistsToShow,
+  removeArtistFromShow,
+  parseShowArtistInput,
+  getShow,
+  type ArtistAddResult,
+  type ArtistRemoveResult,
+} from "../src/commands/show";
+
+// --- Mock fetch for API calls ---
+
+type MockRoute = {
+  method: string;
+  pattern: RegExp;
+  handler: (url: string, body?: unknown) => { status?: number; body: unknown };
+};
+
+let mockRoutes: MockRoute[] = [];
+let fetchCalls: { method: string; url: string; body?: unknown }[] = [];
+
+function addMockRoute(
+  method: string,
+  pattern: RegExp,
+  handler: (url: string, body?: unknown) => unknown,
+): void {
+  mockRoutes.push({
+    method,
+    pattern,
+    handler: (url, body) => ({ status: 200, body: handler(url, body) }),
+  });
+}
+
+function addMockRouteWithStatus(
+  method: string,
+  pattern: RegExp,
+  status: number,
+  handler: (url: string, body?: unknown) => unknown,
+): void {
+  mockRoutes.push({
+    method,
+    pattern,
+    handler: (url, body) => ({ status, body: handler(url, body) }),
+  });
+}
+
+function resetMocks(): void {
+  mockRoutes = [];
+  fetchCalls = [];
+}
+
+// Install global fetch mock
+beforeEach(() => {
+  resetMocks();
+
+  globalThis.fetch = (async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const method = init?.method || "GET";
+    const body = init?.body ? JSON.parse(init.body as string) : undefined;
+
+    fetchCalls.push({ method, url, body });
+
+    for (const route of mockRoutes) {
+      if (route.method === method && route.pattern.test(url)) {
+        const response = route.handler(url, body);
+        return new Response(JSON.stringify(response.body), {
+          status: response.status ?? 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+    }
+
+    // Default: 404
+    return new Response(
+      JSON.stringify({ message: "Not found" }),
+      { status: 404 },
+    );
+  }) as typeof fetch;
+});
+
+const TEST_ENV = { url: "http://localhost:8080", token: "phk_test_token" };
+
+// --- Helper to set up a show that can be resolved ---
+function setupShowMock(show?: Record<string, unknown>): void {
+  const defaultShow = {
+    id: 668,
+    title: "Pavement @ Valley Bar",
+    slug: "pavement-valley-bar-2026-03-15",
+    artists: [
+      { id: 10, name: "Pavement", slug: "pavement", is_headliner: true },
+    ],
+  };
+
+  const merged = { ...defaultShow, ...show };
+
+  addMockRoute("GET", /\/shows\/\d+$/, () => merged);
+}
+
+// --- Helper to set up artist search ---
+function setupArtistSearchMock(
+  artists: Record<string, { id: number; name: string; slug: string }>,
+): void {
+  addMockRoute("GET", /\/artists\/search/, (url) => {
+    const urlObj = new URL(url);
+    const q = (urlObj.searchParams.get("q") || "").toLowerCase();
+    for (const [key, artist] of Object.entries(artists)) {
+      if (q.includes(key.toLowerCase()) || key.toLowerCase().includes(q)) {
+        return { artists: [artist] };
+      }
+    }
+    return { artists: [] };
+  });
+}
+
+describe("parseShowArtistInput", () => {
+  test("parses array of artist objects", () => {
+    const input = JSON.stringify([
+      { name: "Soapbox Derby", is_headliner: false },
+      { name: "Bosses Band" },
+    ]);
+    const result = parseShowArtistInput(input);
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toBe("Soapbox Derby");
+    expect(result[0].is_headliner).toBe(false);
+    expect(result[1].name).toBe("Bosses Band");
+  });
+
+  test("wraps a single object in array", () => {
+    const input = JSON.stringify({ name: "Soapbox Derby" });
+    const result = parseShowArtistInput(input);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("Soapbox Derby");
+  });
+
+  test("throws on invalid JSON", () => {
+    expect(() => parseShowArtistInput("not json")).toThrow();
+  });
+
+  test("handles is_headliner field", () => {
+    const input = JSON.stringify([{ name: "Pavement", is_headliner: true }]);
+    const result = parseShowArtistInput(input);
+    expect(result[0]).toMatchObject({
+      name: "Pavement",
+      is_headliner: true,
+    });
+  });
+});
+
+describe("getShow", () => {
+  test("resolves show by numeric ID", async () => {
+    setupShowMock();
+    const { APIClient } = await import("../src/lib/api");
+    const client = new APIClient(TEST_ENV);
+    const result = await getShow(client, "668");
+    expect(result).toMatchObject({ id: 668, title: "Pavement @ Valley Bar" });
+    expect(result?.artists).toHaveLength(1);
+  });
+
+  test("returns null for unknown show", async () => {
+    // No mock set up — will get 404
+    const { APIClient } = await import("../src/lib/api");
+    const client = new APIClient(TEST_ENV);
+    const result = await getShow(client, "99999");
+    expect(result).toBeNull();
+  });
+});
+
+describe("addArtistsToShow", () => {
+  test("adds artists in dry-run mode (no mutations)", async () => {
+    setupShowMock();
+    setupArtistSearchMock({
+      "Soapbox Derby": { id: 20, name: "Soapbox Derby", slug: "soapbox-derby" },
+    });
+
+    const artists = [{ name: "Soapbox Derby" }];
+    const results = await addArtistsToShow("668", artists, TEST_ENV, false);
+
+    // Dry-run returns empty results
+    expect(results).toHaveLength(0);
+
+    // No PUT calls should have been made
+    const mutationCalls = fetchCalls.filter(
+      (c) => c.method === "PUT" || c.method === "POST" || c.method === "DELETE",
+    );
+    expect(mutationCalls).toHaveLength(0);
+  });
+
+  test("adds artists with --confirm", async () => {
+    setupShowMock();
+    setupArtistSearchMock({
+      "Soapbox Derby": { id: 20, name: "Soapbox Derby", slug: "soapbox-derby" },
+      "Bosses Band": { id: 30, name: "Bosses Band", slug: "bosses-band" },
+    });
+
+    // PUT to update show
+    addMockRoute("PUT", /\/shows\/668$/, () => ({ id: 668 }));
+
+    const artists = [
+      { name: "Soapbox Derby" },
+      { name: "Bosses Band" },
+    ];
+    const results = await addArtistsToShow("668", artists, TEST_ENV, true);
+
+    expect(results).toHaveLength(2);
+    expect(results[0]).toMatchObject({
+      name: "Soapbox Derby",
+      action: "added",
+      artistId: 20,
+    });
+    expect(results[1]).toMatchObject({
+      name: "Bosses Band",
+      action: "added",
+      artistId: 30,
+    });
+
+    // Verify PUT call was made with merged artist list
+    const putCalls = fetchCalls.filter(
+      (c) => c.method === "PUT" && /\/shows\/668$/.test(c.url),
+    );
+    expect(putCalls).toHaveLength(1);
+    // Should include existing artist (Pavement, ID 10) + new ones
+    expect(putCalls[0].body).toMatchObject({
+      artists: [
+        { id: 10, is_headliner: true },
+        { id: 20, is_headliner: false },
+        { id: 30, is_headliner: false },
+      ],
+    });
+  });
+
+  test("handles artist not found gracefully", async () => {
+    setupShowMock();
+    addMockRoute("GET", /\/artists\/search/, () => ({ artists: [] }));
+
+    // PUT for the remaining valid artists (if any)
+    addMockRoute("PUT", /\/shows\/668$/, () => ({ id: 668 }));
+
+    const artists = [{ name: "Unknown Band" }];
+    const results = await addArtistsToShow("668", artists, TEST_ENV, true);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      name: "Unknown Band",
+      action: "not_found",
+    });
+
+    // No PUT call should have been made (nothing to add)
+    const putCalls = fetchCalls.filter(
+      (c) => c.method === "PUT" && /\/shows\/668$/.test(c.url),
+    );
+    expect(putCalls).toHaveLength(0);
+  });
+
+  test("handles already-linked artist gracefully", async () => {
+    setupShowMock(); // Has Pavement (ID: 10) already
+    setupArtistSearchMock({
+      "Pavement": { id: 10, name: "Pavement", slug: "pavement" },
+    });
+
+    const artists = [{ name: "Pavement" }];
+    const results = await addArtistsToShow("668", artists, TEST_ENV, true);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      name: "Pavement",
+      action: "already_linked",
+      artistId: 10,
+    });
+
+    // No PUT call should have been made (nothing new to add)
+    const putCalls = fetchCalls.filter(
+      (c) => c.method === "PUT" && /\/shows\/668$/.test(c.url),
+    );
+    expect(putCalls).toHaveLength(0);
+  });
+
+  test("returns empty when show not found", async () => {
+    // No show mock — will get 404
+    const artists = [{ name: "Pavement" }];
+    const results = await addArtistsToShow("99999", artists, TEST_ENV, true);
+
+    expect(results).toHaveLength(0);
+  });
+
+  test("handles PUT error gracefully", async () => {
+    setupShowMock();
+    setupArtistSearchMock({
+      "Soapbox Derby": { id: 20, name: "Soapbox Derby", slug: "soapbox-derby" },
+    });
+
+    // PUT returns 500
+    addMockRouteWithStatus("PUT", /\/shows\/668$/, 500, () => ({
+      message: "Internal server error",
+    }));
+
+    const artists = [{ name: "Soapbox Derby" }];
+    const results = await addArtistsToShow("668", artists, TEST_ENV, true);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      name: "Soapbox Derby",
+      action: "error",
+      artistId: 20,
+    });
+    expect(results[0].error).toBeDefined();
+  });
+
+  test("adds artist with is_headliner flag", async () => {
+    setupShowMock();
+    setupArtistSearchMock({
+      "New Headliner": { id: 50, name: "New Headliner", slug: "new-headliner" },
+    });
+
+    addMockRoute("PUT", /\/shows\/668$/, () => ({ id: 668 }));
+
+    const artists = [{ name: "New Headliner", is_headliner: true }];
+    const results = await addArtistsToShow("668", artists, TEST_ENV, true);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      name: "New Headliner",
+      action: "added",
+      artistId: 50,
+    });
+
+    // Verify PUT body includes is_headliner
+    const putCalls = fetchCalls.filter(
+      (c) => c.method === "PUT" && /\/shows\/668$/.test(c.url),
+    );
+    expect(putCalls).toHaveLength(1);
+    const newArtist = putCalls[0].body.artists.find(
+      (a: { id: number }) => a.id === 50,
+    );
+    expect(newArtist).toMatchObject({ id: 50, is_headliner: true });
+  });
+
+  test("mix of new, already-linked, and not-found artists", async () => {
+    setupShowMock(); // Has Pavement (ID: 10) already
+    setupArtistSearchMock({
+      "Pavement": { id: 10, name: "Pavement", slug: "pavement" },
+      "Soapbox Derby": { id: 20, name: "Soapbox Derby", slug: "soapbox-derby" },
+    });
+
+    addMockRoute("PUT", /\/shows\/668$/, () => ({ id: 668 }));
+
+    const artists = [
+      { name: "Pavement" },       // already linked
+      { name: "Soapbox Derby" },   // new
+      { name: "Unknown Band" },    // not found
+    ];
+    const results = await addArtistsToShow("668", artists, TEST_ENV, true);
+
+    expect(results).toHaveLength(3);
+    expect(results.find((r) => r.name === "Pavement")?.action).toBe("already_linked");
+    expect(results.find((r) => r.name === "Soapbox Derby")?.action).toBe("added");
+    expect(results.find((r) => r.name === "Unknown Band")?.action).toBe("not_found");
+  });
+});
+
+describe("removeArtistFromShow", () => {
+  test("removes artist by name in dry-run mode (no mutations)", async () => {
+    setupShowMock();
+    setupArtistSearchMock({
+      "Pavement": { id: 10, name: "Pavement", slug: "pavement" },
+    });
+
+    const result = await removeArtistFromShow("668", "Pavement", TEST_ENV, false);
+
+    // Dry-run still returns the planned action
+    expect(result.action).toBe("removed");
+    expect(result.artistId).toBe(10);
+
+    // No PUT calls should have been made
+    const putCalls = fetchCalls.filter((c) => c.method === "PUT");
+    expect(putCalls).toHaveLength(0);
+  });
+
+  test("removes artist by name with --confirm", async () => {
+    setupShowMock({
+      artists: [
+        { id: 10, name: "Pavement", slug: "pavement", is_headliner: true },
+        { id: 20, name: "Soapbox Derby", slug: "soapbox-derby", is_headliner: false },
+      ],
+    });
+    setupArtistSearchMock({
+      "Pavement": { id: 10, name: "Pavement", slug: "pavement" },
+    });
+    addMockRoute("PUT", /\/shows\/668$/, () => ({ id: 668 }));
+
+    const result = await removeArtistFromShow("668", "Pavement", TEST_ENV, true);
+
+    expect(result).toMatchObject({
+      name: "Pavement",
+      action: "removed",
+      artistId: 10,
+    });
+
+    // Verify PUT was called with remaining artist only
+    const putCalls = fetchCalls.filter(
+      (c) => c.method === "PUT" && /\/shows\/668$/.test(c.url),
+    );
+    expect(putCalls).toHaveLength(1);
+    expect(putCalls[0].body).toMatchObject({
+      artists: [{ id: 20, is_headliner: false }],
+    });
+  });
+
+  test("removes artist by numeric ID", async () => {
+    setupShowMock({
+      artists: [
+        { id: 10, name: "Pavement", slug: "pavement", is_headliner: true },
+        { id: 20, name: "Soapbox Derby", slug: "soapbox-derby", is_headliner: false },
+      ],
+    });
+    addMockRoute("PUT", /\/shows\/668$/, () => ({ id: 668 }));
+
+    const result = await removeArtistFromShow("668", "10", TEST_ENV, true);
+
+    expect(result).toMatchObject({
+      name: "10",
+      action: "removed",
+      artistId: 10,
+    });
+
+    // Verify PUT was called with remaining artist only
+    const putCalls = fetchCalls.filter(
+      (c) => c.method === "PUT" && /\/shows\/668$/.test(c.url),
+    );
+    expect(putCalls).toHaveLength(1);
+    expect(putCalls[0].body).toMatchObject({
+      artists: [{ id: 20, is_headliner: false }],
+    });
+  });
+
+  test("returns not_found when show not found", async () => {
+    // No show mock — 404
+    const result = await removeArtistFromShow("99999", "Pavement", TEST_ENV, true);
+    expect(result.action).toBe("not_found");
+  });
+
+  test("returns not_found when artist name not resolved", async () => {
+    setupShowMock();
+    addMockRoute("GET", /\/artists\/search/, () => ({ artists: [] }));
+
+    const result = await removeArtistFromShow("668", "Unknown Band", TEST_ENV, true);
+    expect(result.action).toBe("not_found");
+  });
+
+  test("returns not_found when artist is not on the show", async () => {
+    setupShowMock(); // Only has Pavement (ID: 10)
+    setupArtistSearchMock({
+      "Soapbox Derby": { id: 20, name: "Soapbox Derby", slug: "soapbox-derby" },
+    });
+
+    const result = await removeArtistFromShow("668", "Soapbox Derby", TEST_ENV, true);
+
+    expect(result).toMatchObject({
+      name: "Soapbox Derby",
+      action: "not_found",
+      artistId: 20,
+    });
+
+    // No PUT calls should have been made
+    const putCalls = fetchCalls.filter((c) => c.method === "PUT");
+    expect(putCalls).toHaveLength(0);
+  });
+
+  test("handles PUT error gracefully", async () => {
+    setupShowMock();
+    setupArtistSearchMock({
+      "Pavement": { id: 10, name: "Pavement", slug: "pavement" },
+    });
+    addMockRouteWithStatus("PUT", /\/shows\/668$/, 500, () => ({
+      message: "Internal server error",
+    }));
+
+    const result = await removeArtistFromShow("668", "Pavement", TEST_ENV, true);
+
+    expect(result.action).toBe("error");
+    expect(result.error).toBeDefined();
+  });
+
+  test("returns not_found when numeric ID is not on the show", async () => {
+    setupShowMock(); // Only has Pavement (ID: 10)
+
+    const result = await removeArtistFromShow("668", "99", TEST_ENV, true);
+
+    expect(result).toMatchObject({
+      name: "99",
+      action: "not_found",
+      artistId: 99,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
New `ph show` commands for managing artists on existing shows:

- **`ph show add-artist <show-id> [json]`** — resolves artist names and adds them to a show
  - Supports `--file` for reading from file, `--confirm` to execute
  - Handles already-linked artists gracefully (skips, doesn't error)
  - Supports `is_headliner` flag
- **`ph show remove-artist <show-id> <artist>`** — removes a single artist by name or numeric ID
  - Requires `--confirm` to execute

Uses read-modify-write pattern via `PUT /shows/{id}` since shows don't have dedicated artist link/unlink endpoints. No backend changes needed.

## Test plan
- [x] 22 new tests covering both commands (parsing, dry-run, confirm, errors, edge cases)
- [x] All CLI tests pass
- [ ] Manual: `ph show add-artist 668 '[{"name": "Soapbox Derby"}]' --confirm`
- [ ] Manual: `ph show remove-artist 668 "Wrong Artist" --confirm`

Closes PSY-231

🤖 Generated with [Claude Code](https://claude.com/claude-code)