### PR TITLE
Strengthen show dedup: check first-billed artist when no headliner set

### DIFF
--- a/backend/internal/services/catalog/show.go
+++ b/backend/internal/services/catalog/show.go
@@ -187,9 +187,13 @@ func (s *ShowService) checkDuplicateHeadlinerConflicts(tx *gorm.DB, req *contrac
 		}
 	}
 
-	// If no headliners, no conflicts possible
+	// If no headliners marked, fall back to first-billed artist
 	if len(headlinerNames) == 0 {
-		return nil
+		if len(req.Artists) > 0 {
+			headlinerNames = []string{req.Artists[0].Name}
+		} else {
+			return nil
+		}
 	}
 
 	// Get all venue names from the request

--- a/backend/internal/services/catalog/show_test.go
+++ b/backend/internal/services/catalog/show_test.go
@@ -1082,12 +1082,11 @@ func (suite *ShowServiceIntegrationTestSuite) TestCreateShow_DuplicateHeadliner_
 	suite.NotNil(resp)
 }
 
-func (suite *ShowServiceIntegrationTestSuite) TestCreateShow_NoHeadliner_NoDuplicateCheck() {
+func (suite *ShowServiceIntegrationTestSuite) TestCreateShow_NoHeadliner_DifferentFirstArtist_OK() {
 	user := suite.createTestUser()
 	eventDate := time.Date(2026, 11, 6, 20, 0, 0, 0, time.UTC)
 
-	// First show with no explicit headliner (first artist defaults to headliner)
-	// We need both artists to be explicitly non-headliner for this test
+	// First show with no explicit headliner — first artist used for dedup
 	req := &contracts.CreateShowRequest{
 		Title:     "No Headliner 1",
 		EventDate: eventDate,
@@ -1103,7 +1102,7 @@ func (suite *ShowServiceIntegrationTestSuite) TestCreateShow_NoHeadliner_NoDupli
 	_, err := suite.showService.CreateShow(req)
 	suite.Require().NoError(err)
 
-	// Same details, should succeed (no headliner means no dup check)
+	// Different first artist, same venue and date — should succeed
 	req2 := &contracts.CreateShowRequest{
 		Title:     "No Headliner 2",
 		EventDate: eventDate,
@@ -1120,6 +1119,45 @@ func (suite *ShowServiceIntegrationTestSuite) TestCreateShow_NoHeadliner_NoDupli
 
 	suite.Require().NoError(err)
 	suite.NotNil(resp)
+}
+
+func (suite *ShowServiceIntegrationTestSuite) TestCreateShow_NoHeadliner_SameFirstArtist_SameVenue_Fails() {
+	user := suite.createTestUser()
+	eventDate := time.Date(2026, 11, 7, 20, 0, 0, 0, time.UTC)
+
+	// First show — no headliner flag, first artist is "The Growlers"
+	req := &contracts.CreateShowRequest{
+		Title:     "Growlers Show 1",
+		EventDate: eventDate,
+		City:      "Phoenix",
+		State:     "AZ",
+		Venues:    []contracts.CreateShowVenue{{Name: "Fallback Dedup Venue", City: "Phoenix", State: "AZ"}},
+		Artists: []contracts.CreateShowArtist{
+			{Name: "The Growlers"},
+		},
+		SubmittedByUserID: &user.ID,
+		SubmitterIsAdmin:  true,
+	}
+	_, err := suite.showService.CreateShow(req)
+	suite.Require().NoError(err)
+
+	// Duplicate — same first artist, same venue, same day, no headliner
+	req2 := &contracts.CreateShowRequest{
+		Title:     "Growlers Show 2 (duplicate)",
+		EventDate: eventDate,
+		City:      "Phoenix",
+		State:     "AZ",
+		Venues:    []contracts.CreateShowVenue{{Name: "Fallback Dedup Venue", City: "Phoenix", State: "AZ"}},
+		Artists: []contracts.CreateShowArtist{
+			{Name: "The Growlers"},
+		},
+		SubmittedByUserID: &user.ID,
+		SubmitterIsAdmin:  true,
+	}
+	_, err = suite.showService.CreateShow(req2)
+
+	suite.Require().Error(err)
+	suite.Contains(err.Error(), "already performing")
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
When no artist is marked as `is_headliner`, the duplicate check now falls back to the first artist in the array instead of skipping entirely. This prevents duplicates like "The Growlers @ The Van Buren" appearing twice when neither listing has a headliner flag.

The fix is a 4-line change in `checkDuplicateHeadlinerConflicts()` — if `headlinerNames` is empty after scanning for `is_headliner: true`, use `req.Artists[0].Name` as the fallback.

## Test plan
- [x] New test: same first-billed artist + same venue + same day → rejected as duplicate
- [x] Renamed test: different first-billed artists + same venue → allowed (not duplicate)
- [x] All existing dedup tests still pass (headliner, case-insensitive, different day, different venue)
- [x] Full catalog test suite passes (17.7s)

Closes PSY-234

🤖 Generated with [Claude Code](https://claude.com/claude-code)