### PR TITLE
Generic pending entity edits — model, service, handlers, API (PSY-125, PSY-126)

### DIFF
--- a/backend/db/migrations/000061_create_pending_entity_edits.down.sql
+++ b/backend/db/migrations/000061_create_pending_entity_edits.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS pending_entity_edits;

--- a/backend/db/migrations/000061_create_pending_entity_edits.up.sql
+++ b/backend/db/migrations/000061_create_pending_entity_edits.up.sql
@@ -1,0 +1,34 @@
+-- Generic pending entity edits table.
+-- Replaces the per-entity-type approach (pending_venue_edits) with a single
+-- table using JSONB field_changes — same format as the revisions table.
+CREATE TABLE pending_entity_edits (
+    id BIGSERIAL PRIMARY KEY,
+    entity_type VARCHAR(50) NOT NULL,
+    entity_id BIGINT NOT NULL,
+    submitted_by BIGINT NOT NULL REFERENCES users(id),
+    field_changes JSONB NOT NULL,
+    summary TEXT NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'pending',
+    reviewed_by BIGINT REFERENCES users(id),
+    reviewed_at TIMESTAMPTZ,
+    rejection_reason TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- One pending edit per user per entity (only enforced for pending status)
+CREATE UNIQUE INDEX idx_pending_entity_edits_unique
+    ON pending_entity_edits (entity_type, entity_id, submitted_by)
+    WHERE status = 'pending';
+
+-- Fast lookup for the admin review queue (oldest pending first)
+CREATE INDEX idx_pending_entity_edits_status
+    ON pending_entity_edits (status, created_at);
+
+-- Fast lookup for a user's own edits
+CREATE INDEX idx_pending_entity_edits_user
+    ON pending_entity_edits (submitted_by, status);
+
+-- Fast lookup for edits on a specific entity
+CREATE INDEX idx_pending_entity_edits_entity
+    ON pending_entity_edits (entity_type, entity_id);

--- a/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
+++ b/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
@@ -1662,6 +1662,70 @@ func (m *mockPasswordValidator) IsCommonPassword(password string) (bool) {
 }
 
 // ============================================================================
+// Mock: PendingEditServiceInterface
+// ============================================================================
+
+type mockPendingEditService struct {
+	createPendingEditFn func(*contracts.CreatePendingEditRequest) (*contracts.PendingEditResponse, error)
+	getPendingEditFn func(uint) (*contracts.PendingEditResponse, error)
+	getPendingEditsForEntityFn func(string, uint) ([]contracts.PendingEditResponse, error)
+	getUserPendingEditsFn func(uint, int, int) ([]contracts.PendingEditResponse, int64, error)
+	listPendingEditsFn func(*contracts.PendingEditFilters) ([]contracts.PendingEditResponse, int64, error)
+	approvePendingEditFn func(uint, uint) (*contracts.PendingEditResponse, error)
+	rejectPendingEditFn func(uint, uint, string) (*contracts.PendingEditResponse, error)
+	cancelPendingEditFn func(uint, uint) (error)
+}
+
+func (m *mockPendingEditService) CreatePendingEdit(req *contracts.CreatePendingEditRequest) (*contracts.PendingEditResponse, error) {
+	if m.createPendingEditFn != nil {
+		return m.createPendingEditFn(req)
+	}
+	return nil, nil
+}
+func (m *mockPendingEditService) GetPendingEdit(editID uint) (*contracts.PendingEditResponse, error) {
+	if m.getPendingEditFn != nil {
+		return m.getPendingEditFn(editID)
+	}
+	return nil, nil
+}
+func (m *mockPendingEditService) GetPendingEditsForEntity(entityType string, entityID uint) ([]contracts.PendingEditResponse, error) {
+	if m.getPendingEditsForEntityFn != nil {
+		return m.getPendingEditsForEntityFn(entityType, entityID)
+	}
+	return nil, nil
+}
+func (m *mockPendingEditService) GetUserPendingEdits(userID uint, limit int, offset int) ([]contracts.PendingEditResponse, int64, error) {
+	if m.getUserPendingEditsFn != nil {
+		return m.getUserPendingEditsFn(userID, limit, offset)
+	}
+	return nil, 0, nil
+}
+func (m *mockPendingEditService) ListPendingEdits(filters *contracts.PendingEditFilters) ([]contracts.PendingEditResponse, int64, error) {
+	if m.listPendingEditsFn != nil {
+		return m.listPendingEditsFn(filters)
+	}
+	return nil, 0, nil
+}
+func (m *mockPendingEditService) ApprovePendingEdit(editID uint, reviewerID uint) (*contracts.PendingEditResponse, error) {
+	if m.approvePendingEditFn != nil {
+		return m.approvePendingEditFn(editID, reviewerID)
+	}
+	return nil, nil
+}
+func (m *mockPendingEditService) RejectPendingEdit(editID uint, reviewerID uint, reason string) (*contracts.PendingEditResponse, error) {
+	if m.rejectPendingEditFn != nil {
+		return m.rejectPendingEditFn(editID, reviewerID, reason)
+	}
+	return nil, nil
+}
+func (m *mockPendingEditService) CancelPendingEdit(editID uint, userID uint) (error) {
+	if m.cancelPendingEditFn != nil {
+		return m.cancelPendingEditFn(editID, userID)
+	}
+	return nil
+}
+
+// ============================================================================
 // Mock: PipelineServiceInterface
 // ============================================================================
 
@@ -3079,6 +3143,7 @@ var _ contracts.LabelServiceInterface = (*mockLabelService)(nil)
 var _ contracts.MusicDiscoveryServiceInterface = (*mockMusicDiscoveryService)(nil)
 var _ contracts.NotificationFilterServiceInterface = (*mockNotificationFilterService)(nil)
 var _ contracts.PasswordValidatorInterface = (*mockPasswordValidator)(nil)
+var _ contracts.PendingEditServiceInterface = (*mockPendingEditService)(nil)
 var _ contracts.PipelineServiceInterface = (*mockPipelineService)(nil)
 var _ contracts.ReleaseServiceInterface = (*mockReleaseService)(nil)
 var _ contracts.RequestServiceInterface = (*mockRequestService)(nil)

--- a/backend/internal/api/handlers/pending_edit.go
+++ b/backend/internal/api/handlers/pending_edit.go
@@ -1,0 +1,534 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"psychic-homily-backend/internal/api/middleware"
+	"psychic-homily-backend/internal/logger"
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// PendingEditHandler handles pending entity edit API endpoints.
+type PendingEditHandler struct {
+	pendingEditService contracts.PendingEditServiceInterface
+	auditLogService    contracts.AuditLogServiceInterface
+}
+
+// NewPendingEditHandler creates a new pending edit handler.
+func NewPendingEditHandler(
+	pendingEditService contracts.PendingEditServiceInterface,
+	auditLogService contracts.AuditLogServiceInterface,
+) *PendingEditHandler {
+	return &PendingEditHandler{
+		pendingEditService: pendingEditService,
+		auditLogService:    auditLogService,
+	}
+}
+
+// Allowed fields per entity type for user-submitted edits.
+// Admin-only fields (status, verified, auto_approve, etc.) are excluded.
+var allowedEditFields = map[string]map[string]bool{
+	"artist": {
+		"name": true, "city": true, "state": true, "country": true,
+		"description": true, "bandcamp_embed_url": true,
+		"instagram": true, "facebook": true, "twitter": true,
+		"youtube": true, "spotify": true, "soundcloud": true,
+		"bandcamp": true, "website": true,
+	},
+	"venue": {
+		"name": true, "address": true, "city": true, "state": true,
+		"country": true, "zipcode": true, "description": true,
+		"instagram": true, "facebook": true, "twitter": true,
+		"youtube": true, "spotify": true, "soundcloud": true,
+		"bandcamp": true, "website": true,
+	},
+	"festival": {
+		"name": true, "description": true, "location_name": true,
+		"city": true, "state": true, "country": true,
+		"website": true, "ticket_url": true, "flyer_url": true,
+	},
+}
+
+// canEditDirectly returns true if the user can bypass the pending queue.
+func canEditDirectly(user *models.User) bool {
+	if user.IsAdmin {
+		return true
+	}
+	switch user.UserTier {
+	case "trusted_contributor", "local_ambassador":
+		return true
+	}
+	return false
+}
+
+// --- Suggest Edit ---
+
+// SuggestEntityEditRequest is the Huma request for PUT /{entity_type}/{entity_id}/suggest-edit
+type SuggestEntityEditRequest struct {
+	EntityID string `path:"entity_id" doc:"Entity ID"`
+	Body     struct {
+		Changes []models.FieldChange `json:"changes" doc:"Field changes to propose"`
+		Summary string               `json:"summary" doc:"Why you are making this change"`
+	}
+}
+
+// SuggestEntityEditResponse is the Huma response for suggest-edit endpoints.
+type SuggestEntityEditResponse struct {
+	Body struct {
+		PendingEdit *contracts.PendingEditResponse `json:"pending_edit,omitempty"`
+		Applied     bool                           `json:"applied"`
+		Message     string                         `json:"message"`
+	}
+}
+
+// SuggestArtistEditHandler handles PUT /artists/{entity_id}/suggest-edit
+func (h *PendingEditHandler) SuggestArtistEditHandler(ctx context.Context, req *SuggestEntityEditRequest) (*SuggestEntityEditResponse, error) {
+	return h.suggestEdit(ctx, "artist", req)
+}
+
+// SuggestVenueEditHandler handles PUT /venues/{entity_id}/suggest-edit
+func (h *PendingEditHandler) SuggestVenueEditHandler(ctx context.Context, req *SuggestEntityEditRequest) (*SuggestEntityEditResponse, error) {
+	return h.suggestEdit(ctx, "venue", req)
+}
+
+// SuggestFestivalEditHandler handles PUT /festivals/{entity_id}/suggest-edit
+func (h *PendingEditHandler) SuggestFestivalEditHandler(ctx context.Context, req *SuggestEntityEditRequest) (*SuggestEntityEditResponse, error) {
+	return h.suggestEdit(ctx, "festival", req)
+}
+
+// suggestEdit is the shared implementation for all suggest-edit endpoints.
+func (h *PendingEditHandler) suggestEdit(ctx context.Context, entityType string, req *SuggestEntityEditRequest) (*SuggestEntityEditResponse, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	entityID, err := strconv.ParseUint(req.EntityID, 10, 64)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid entity ID")
+	}
+
+	if len(req.Body.Changes) == 0 {
+		return nil, huma.Error400BadRequest("No changes provided")
+	}
+
+	summary := strings.TrimSpace(req.Body.Summary)
+	if summary == "" {
+		return nil, huma.Error400BadRequest("Summary is required — explain why you are making this change")
+	}
+
+	// Validate fields against allowed list
+	allowed := allowedEditFields[entityType]
+	for _, change := range req.Body.Changes {
+		if !allowed[change.Field] {
+			return nil, huma.Error400BadRequest(fmt.Sprintf("Field '%s' is not editable on %s entities", change.Field, entityType))
+		}
+	}
+
+	// Create the pending edit
+	resp, err := h.pendingEditService.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: entityType,
+		EntityID:   uint(entityID),
+		UserID:     user.ID,
+		Changes:    req.Body.Changes,
+		Summary:    summary,
+	})
+	if err != nil {
+		if strings.Contains(err.Error(), "entity not found") {
+			return nil, huma.Error404NotFound(err.Error())
+		}
+		if strings.Contains(err.Error(), "duplicate key") || strings.Contains(err.Error(), "unique constraint") {
+			return nil, huma.Error409Conflict("You already have a pending edit for this entity")
+		}
+		logger.FromContext(ctx).Error("pending_edit_create_failed",
+			"user_id", user.ID,
+			"entity_type", entityType,
+			"entity_id", entityID,
+			"error", err.Error(),
+		)
+		return nil, huma.Error500InternalServerError("Failed to create pending edit")
+	}
+
+	// If trusted user, auto-approve immediately
+	if canEditDirectly(user) {
+		approved, approveErr := h.pendingEditService.ApprovePendingEdit(resp.ID, user.ID)
+		if approveErr != nil {
+			logger.FromContext(ctx).Error("pending_edit_auto_approve_failed",
+				"edit_id", resp.ID,
+				"user_id", user.ID,
+				"error", approveErr.Error(),
+			)
+			// Fall through — the pending edit was still created
+		} else {
+			// Fire-and-forget audit log
+			if h.auditLogService != nil {
+				go h.auditLogService.LogAction(user.ID, "edit_"+entityType, entityType, uint(entityID), map[string]interface{}{
+					"edit_id": approved.ID,
+					"direct":  true,
+					"summary": summary,
+				})
+			}
+
+			out := &SuggestEntityEditResponse{}
+			out.Body.PendingEdit = approved
+			out.Body.Applied = true
+			out.Body.Message = "Changes applied directly"
+			return out, nil
+		}
+	}
+
+	// Fire-and-forget audit log for pending edit
+	if h.auditLogService != nil {
+		go h.auditLogService.LogAction(user.ID, "suggest_edit_"+entityType, entityType, uint(entityID), map[string]interface{}{
+			"edit_id": resp.ID,
+			"summary": summary,
+		})
+	}
+
+	out := &SuggestEntityEditResponse{}
+	out.Body.PendingEdit = resp
+	out.Body.Applied = false
+	out.Body.Message = "Edit submitted for review"
+	return out, nil
+}
+
+// --- User's Own Edits ---
+
+// GetMyPendingEditsRequest is the Huma request for GET /my/pending-edits
+type GetMyPendingEditsRequest struct {
+	Limit  int `query:"limit" required:"false" doc:"Max results (default 20, max 100)"`
+	Offset int `query:"offset" required:"false" doc:"Offset for pagination"`
+}
+
+// GetMyPendingEditsResponse is the Huma response for GET /my/pending-edits
+type GetMyPendingEditsResponse struct {
+	Body struct {
+		Edits []contracts.PendingEditResponse `json:"edits"`
+		Total int64                           `json:"total"`
+	}
+}
+
+// GetMyPendingEditsHandler handles GET /my/pending-edits
+func (h *PendingEditHandler) GetMyPendingEditsHandler(ctx context.Context, req *GetMyPendingEditsRequest) (*GetMyPendingEditsResponse, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	edits, total, err := h.pendingEditService.GetUserPendingEdits(user.ID, req.Limit, req.Offset)
+	if err != nil {
+		logger.FromContext(ctx).Error("pending_edit_get_user_edits_failed",
+			"user_id", user.ID,
+			"error", err.Error(),
+		)
+		return nil, huma.Error500InternalServerError("Failed to get your pending edits")
+	}
+
+	resp := &GetMyPendingEditsResponse{}
+	resp.Body.Edits = edits
+	resp.Body.Total = total
+	return resp, nil
+}
+
+// --- Cancel Own Edit ---
+
+// CancelMyPendingEntityEditRequest is the Huma request for DELETE /my/pending-edits/{edit_id}
+type CancelMyPendingEntityEditRequest struct {
+	EditID string `path:"edit_id" doc:"Pending edit ID to cancel"`
+}
+
+// CancelMyPendingEntityEditResponse is the Huma response for DELETE /my/pending-edits/{edit_id}
+type CancelMyPendingEntityEditResponse struct {
+	Body struct {
+		Success bool `json:"success"`
+	}
+}
+
+// CancelMyPendingEditHandler handles DELETE /my/pending-edits/{edit_id}
+func (h *PendingEditHandler) CancelMyPendingEditHandler(ctx context.Context, req *CancelMyPendingEntityEditRequest) (*CancelMyPendingEntityEditResponse, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	editID, err := strconv.ParseUint(req.EditID, 10, 64)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid edit ID")
+	}
+
+	if err := h.pendingEditService.CancelPendingEdit(uint(editID), user.ID); err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return nil, huma.Error404NotFound("Pending edit not found")
+		}
+		if strings.Contains(err.Error(), "only the submitter") {
+			return nil, huma.Error403Forbidden("You can only cancel your own pending edits")
+		}
+		if strings.Contains(err.Error(), "not pending") {
+			return nil, huma.Error409Conflict("This edit has already been reviewed")
+		}
+		logger.FromContext(ctx).Error("pending_edit_cancel_failed",
+			"user_id", user.ID,
+			"edit_id", editID,
+			"error", err.Error(),
+		)
+		return nil, huma.Error500InternalServerError("Failed to cancel pending edit")
+	}
+
+	resp := &CancelMyPendingEntityEditResponse{}
+	resp.Body.Success = true
+	return resp, nil
+}
+
+// --- Admin: List Pending Edits ---
+
+// AdminListPendingEditsRequest is the Huma request for GET /admin/pending-edits
+type AdminListPendingEditsRequest struct {
+	Status     string `query:"status" required:"false" doc:"Filter by status (pending, approved, rejected)"`
+	EntityType string `query:"entity_type" required:"false" doc:"Filter by entity type (artist, venue, festival)"`
+	Limit      int    `query:"limit" required:"false" doc:"Max results (default 20, max 100)"`
+	Offset     int    `query:"offset" required:"false" doc:"Offset for pagination"`
+}
+
+// AdminListPendingEditsResponse is the Huma response for GET /admin/pending-edits
+type AdminListPendingEditsResponse struct {
+	Body struct {
+		Edits []contracts.PendingEditResponse `json:"edits"`
+		Total int64                           `json:"total"`
+	}
+}
+
+// AdminListPendingEditsHandler handles GET /admin/pending-edits
+func (h *PendingEditHandler) AdminListPendingEditsHandler(ctx context.Context, req *AdminListPendingEditsRequest) (*AdminListPendingEditsResponse, error) {
+	if _, err := requireAdmin(ctx); err != nil {
+		return nil, err
+	}
+
+	edits, total, err := h.pendingEditService.ListPendingEdits(&contracts.PendingEditFilters{
+		Status:     req.Status,
+		EntityType: req.EntityType,
+		Limit:      req.Limit,
+		Offset:     req.Offset,
+	})
+	if err != nil {
+		logger.FromContext(ctx).Error("pending_edit_list_failed", "error", err.Error())
+		return nil, huma.Error500InternalServerError("Failed to list pending edits")
+	}
+
+	resp := &AdminListPendingEditsResponse{}
+	resp.Body.Edits = edits
+	resp.Body.Total = total
+	return resp, nil
+}
+
+// --- Admin: Get Single Pending Edit ---
+
+// AdminGetPendingEditRequest is the Huma request for GET /admin/pending-edits/{edit_id}
+type AdminGetPendingEditRequest struct {
+	EditID string `path:"edit_id" doc:"Pending edit ID"`
+}
+
+// AdminGetPendingEditResponse is the Huma response for GET /admin/pending-edits/{edit_id}
+type AdminGetPendingEditResponse struct {
+	Body *contracts.PendingEditResponse
+}
+
+// AdminGetPendingEditHandler handles GET /admin/pending-edits/{edit_id}
+func (h *PendingEditHandler) AdminGetPendingEditHandler(ctx context.Context, req *AdminGetPendingEditRequest) (*AdminGetPendingEditResponse, error) {
+	if _, err := requireAdmin(ctx); err != nil {
+		return nil, err
+	}
+
+	editID, err := strconv.ParseUint(req.EditID, 10, 64)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid edit ID")
+	}
+
+	edit, err := h.pendingEditService.GetPendingEdit(uint(editID))
+	if err != nil {
+		logger.FromContext(ctx).Error("pending_edit_get_failed", "edit_id", editID, "error", err.Error())
+		return nil, huma.Error500InternalServerError("Failed to get pending edit")
+	}
+	if edit == nil {
+		return nil, huma.Error404NotFound("Pending edit not found")
+	}
+
+	return &AdminGetPendingEditResponse{Body: edit}, nil
+}
+
+// --- Admin: Approve ---
+
+// AdminApprovePendingEditRequest is the Huma request for POST /admin/pending-edits/{edit_id}/approve
+type AdminApprovePendingEditRequest struct {
+	EditID string `path:"edit_id" doc:"Pending edit ID to approve"`
+}
+
+// AdminApprovePendingEditResponse is the Huma response for POST /admin/pending-edits/{edit_id}/approve
+type AdminApprovePendingEditResponse struct {
+	Body *contracts.PendingEditResponse
+}
+
+// AdminApprovePendingEditHandler handles POST /admin/pending-edits/{edit_id}/approve
+func (h *PendingEditHandler) AdminApprovePendingEditHandler(ctx context.Context, req *AdminApprovePendingEditRequest) (*AdminApprovePendingEditResponse, error) {
+	user, err := requireAdmin(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	editID, err := strconv.ParseUint(req.EditID, 10, 64)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid edit ID")
+	}
+
+	approved, err := h.pendingEditService.ApprovePendingEdit(uint(editID), user.ID)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return nil, huma.Error404NotFound("Pending edit not found")
+		}
+		if strings.Contains(err.Error(), "not pending") {
+			return nil, huma.Error409Conflict(err.Error())
+		}
+		if strings.Contains(err.Error(), "entity not found") {
+			return nil, huma.Error422UnprocessableEntity("Entity no longer exists — cannot apply edit")
+		}
+		logger.FromContext(ctx).Error("pending_edit_approve_failed",
+			"edit_id", editID,
+			"admin_id", user.ID,
+			"error", err.Error(),
+		)
+		return nil, huma.Error500InternalServerError("Failed to approve pending edit")
+	}
+
+	logger.FromContext(ctx).Info("pending_edit_approved",
+		"edit_id", editID,
+		"admin_id", user.ID,
+		"entity_type", approved.EntityType,
+		"entity_id", approved.EntityID,
+	)
+
+	// Fire-and-forget audit log
+	if h.auditLogService != nil {
+		go h.auditLogService.LogAction(user.ID, "approve_edit_"+approved.EntityType, approved.EntityType, approved.EntityID, map[string]interface{}{
+			"edit_id":      approved.ID,
+			"submitted_by": approved.SubmittedBy,
+		})
+	}
+
+	return &AdminApprovePendingEditResponse{Body: approved}, nil
+}
+
+// --- Admin: Reject ---
+
+// AdminRejectPendingEditRequest is the Huma request for POST /admin/pending-edits/{edit_id}/reject
+type AdminRejectPendingEditRequest struct {
+	EditID string `path:"edit_id" doc:"Pending edit ID to reject"`
+	Body   struct {
+		Reason string `json:"reason" doc:"Specific rejection reason (educational — explain the standard)"`
+	}
+}
+
+// AdminRejectPendingEditResponse is the Huma response for POST /admin/pending-edits/{edit_id}/reject
+type AdminRejectPendingEditResponse struct {
+	Body *contracts.PendingEditResponse
+}
+
+// AdminRejectPendingEditHandler handles POST /admin/pending-edits/{edit_id}/reject
+func (h *PendingEditHandler) AdminRejectPendingEditHandler(ctx context.Context, req *AdminRejectPendingEditRequest) (*AdminRejectPendingEditResponse, error) {
+	user, err := requireAdmin(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	editID, err := strconv.ParseUint(req.EditID, 10, 64)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid edit ID")
+	}
+
+	reason := strings.TrimSpace(req.Body.Reason)
+	if reason == "" {
+		return nil, huma.Error400BadRequest("Rejection reason is required — be specific to help the contributor learn")
+	}
+
+	rejected, err := h.pendingEditService.RejectPendingEdit(uint(editID), user.ID, reason)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return nil, huma.Error404NotFound("Pending edit not found")
+		}
+		if strings.Contains(err.Error(), "not pending") {
+			return nil, huma.Error409Conflict(err.Error())
+		}
+		logger.FromContext(ctx).Error("pending_edit_reject_failed",
+			"edit_id", editID,
+			"admin_id", user.ID,
+			"error", err.Error(),
+		)
+		return nil, huma.Error500InternalServerError("Failed to reject pending edit")
+	}
+
+	logger.FromContext(ctx).Info("pending_edit_rejected",
+		"edit_id", editID,
+		"admin_id", user.ID,
+		"reason", reason,
+	)
+
+	// Fire-and-forget audit log
+	if h.auditLogService != nil {
+		go h.auditLogService.LogAction(user.ID, "reject_edit_"+rejected.EntityType, rejected.EntityType, rejected.EntityID, map[string]interface{}{
+			"edit_id":      rejected.ID,
+			"submitted_by": rejected.SubmittedBy,
+			"reason":       reason,
+		})
+	}
+
+	return &AdminRejectPendingEditResponse{Body: rejected}, nil
+}
+
+// --- Admin: Get Pending Edits for Entity ---
+
+// AdminGetEntityPendingEditsRequest is the Huma request for GET /admin/pending-edits/entity/{entity_type}/{entity_id}
+type AdminGetEntityPendingEditsRequest struct {
+	EntityType string `path:"entity_type" doc:"Entity type (artist, venue, festival)"`
+	EntityID   string `path:"entity_id" doc:"Entity ID"`
+}
+
+// AdminGetEntityPendingEditsResponse is the Huma response
+type AdminGetEntityPendingEditsResponse struct {
+	Body struct {
+		Edits []contracts.PendingEditResponse `json:"edits"`
+	}
+}
+
+// AdminGetEntityPendingEditsHandler handles GET /admin/pending-edits/entity/{entity_type}/{entity_id}
+func (h *PendingEditHandler) AdminGetEntityPendingEditsHandler(ctx context.Context, req *AdminGetEntityPendingEditsRequest) (*AdminGetEntityPendingEditsResponse, error) {
+	if _, err := requireAdmin(ctx); err != nil {
+		return nil, err
+	}
+
+	if !models.IsValidPendingEditEntityType(req.EntityType) {
+		return nil, huma.Error400BadRequest(fmt.Sprintf("Invalid entity type: %s", req.EntityType))
+	}
+
+	entityID, err := strconv.ParseUint(req.EntityID, 10, 64)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid entity ID")
+	}
+
+	edits, err := h.pendingEditService.GetPendingEditsForEntity(req.EntityType, uint(entityID))
+	if err != nil {
+		logger.FromContext(ctx).Error("pending_edit_get_entity_edits_failed",
+			"entity_type", req.EntityType,
+			"entity_id", entityID,
+			"error", err.Error(),
+		)
+		return nil, huma.Error500InternalServerError("Failed to get pending edits for entity")
+	}
+
+	resp := &AdminGetEntityPendingEditsResponse{}
+	resp.Body.Edits = edits
+	return resp, nil
+}

--- a/backend/internal/api/handlers/pending_edit_test.go
+++ b/backend/internal/api/handlers/pending_edit_test.go
@@ -1,0 +1,776 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// ============================================================================
+// Test helpers
+// ============================================================================
+
+func testPendingEditHandler() *PendingEditHandler {
+	return NewPendingEditHandler(nil, nil)
+}
+
+func pendingEditAdminCtx() context.Context {
+	return ctxWithUser(&models.User{ID: 1, IsAdmin: true, UserTier: "new_user"})
+}
+
+func pendingEditTrustedCtx() context.Context {
+	return ctxWithUser(&models.User{ID: 2, IsAdmin: false, UserTier: "trusted_contributor"})
+}
+
+func pendingEditNewUserCtx() context.Context {
+	return ctxWithUser(&models.User{ID: 3, IsAdmin: false, UserTier: "new_user"})
+}
+
+func pendingEditContributorCtx() context.Context {
+	return ctxWithUser(&models.User{ID: 4, IsAdmin: false, UserTier: "contributor"})
+}
+
+func pendingEditLocalAmbassadorCtx() context.Context {
+	return ctxWithUser(&models.User{ID: 5, IsAdmin: false, UserTier: "local_ambassador"})
+}
+
+func makePendingEditResponse(id uint) *contracts.PendingEditResponse {
+	now := time.Now()
+	return &contracts.PendingEditResponse{
+		ID:          id,
+		EntityType:  "artist",
+		EntityID:    10,
+		SubmittedBy: 3,
+		SubmitterName: "testuser",
+		FieldChanges: []models.FieldChange{
+			{Field: "name", OldValue: "Old", NewValue: "New"},
+		},
+		Summary:   "Fix name",
+		Status:    models.PendingEditStatusPending,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+}
+
+// ============================================================================
+// Tests: NewPendingEditHandler
+// ============================================================================
+
+func TestNewPendingEditHandler(t *testing.T) {
+	h := testPendingEditHandler()
+	if h == nil {
+		t.Fatal("expected non-nil PendingEditHandler")
+	}
+}
+
+// ============================================================================
+// Tests: SuggestEdit — Auth & Validation
+// ============================================================================
+
+func TestSuggestEdit_NoUser(t *testing.T) {
+	h := testPendingEditHandler()
+	_, err := h.SuggestArtistEditHandler(context.Background(), &SuggestEntityEditRequest{
+		EntityID: "1",
+	})
+	assertHumaError(t, err, 401)
+}
+
+func TestSuggestEdit_InvalidEntityID(t *testing.T) {
+	h := testPendingEditHandler()
+	_, err := h.SuggestArtistEditHandler(pendingEditNewUserCtx(), &SuggestEntityEditRequest{
+		EntityID: "abc",
+	})
+	assertHumaError(t, err, 400)
+}
+
+func TestSuggestEdit_NoChanges(t *testing.T) {
+	h := testPendingEditHandler()
+	req := &SuggestEntityEditRequest{EntityID: "1"}
+	req.Body.Changes = []models.FieldChange{}
+	req.Body.Summary = "test"
+	_, err := h.SuggestArtistEditHandler(pendingEditNewUserCtx(), req)
+	assertHumaError(t, err, 400)
+}
+
+func TestSuggestEdit_NoSummary(t *testing.T) {
+	h := testPendingEditHandler()
+	req := &SuggestEntityEditRequest{EntityID: "1"}
+	req.Body.Changes = []models.FieldChange{{Field: "name", OldValue: "a", NewValue: "b"}}
+	req.Body.Summary = ""
+	_, err := h.SuggestArtistEditHandler(pendingEditNewUserCtx(), req)
+	assertHumaError(t, err, 400)
+}
+
+func TestSuggestEdit_DisallowedField(t *testing.T) {
+	h := testPendingEditHandler()
+	req := &SuggestEntityEditRequest{EntityID: "1"}
+	req.Body.Changes = []models.FieldChange{{Field: "is_active", OldValue: true, NewValue: false}}
+	req.Body.Summary = "hack"
+	_, err := h.SuggestArtistEditHandler(pendingEditNewUserCtx(), req)
+	assertHumaError(t, err, 400)
+}
+
+func TestSuggestEdit_VenueDisallowedField(t *testing.T) {
+	h := testPendingEditHandler()
+	req := &SuggestEntityEditRequest{EntityID: "1"}
+	req.Body.Changes = []models.FieldChange{{Field: "verified", OldValue: false, NewValue: true}}
+	req.Body.Summary = "verify"
+	_, err := h.SuggestVenueEditHandler(pendingEditNewUserCtx(), req)
+	assertHumaError(t, err, 400)
+}
+
+func TestSuggestEdit_FestivalDisallowedField(t *testing.T) {
+	h := testPendingEditHandler()
+	req := &SuggestEntityEditRequest{EntityID: "1"}
+	req.Body.Changes = []models.FieldChange{{Field: "status", OldValue: "announced", NewValue: "cancelled"}}
+	req.Body.Summary = "cancel"
+	_, err := h.SuggestFestivalEditHandler(pendingEditNewUserCtx(), req)
+	assertHumaError(t, err, 400)
+}
+
+// ============================================================================
+// Tests: SuggestEdit — New User (creates pending)
+// ============================================================================
+
+func TestSuggestEdit_NewUser_CreatesPending(t *testing.T) {
+	expected := makePendingEditResponse(1)
+	h := NewPendingEditHandler(
+		&mockPendingEditService{
+			createPendingEditFn: func(req *contracts.CreatePendingEditRequest) (*contracts.PendingEditResponse, error) {
+				if req.EntityType != "artist" || req.EntityID != 10 || req.UserID != 3 {
+					t.Errorf("unexpected params: %+v", req)
+				}
+				return expected, nil
+			},
+		},
+		nil,
+	)
+
+	req := &SuggestEntityEditRequest{EntityID: "10"}
+	req.Body.Changes = []models.FieldChange{{Field: "name", OldValue: "Old", NewValue: "New"}}
+	req.Body.Summary = "Fix name"
+
+	resp, err := h.SuggestArtistEditHandler(pendingEditNewUserCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Applied {
+		t.Error("expected applied=false for new_user")
+	}
+	if resp.Body.PendingEdit == nil {
+		t.Fatal("expected pending edit in response")
+	}
+	if resp.Body.PendingEdit.ID != 1 {
+		t.Errorf("expected edit ID=1, got %d", resp.Body.PendingEdit.ID)
+	}
+}
+
+func TestSuggestEdit_Contributor_CreatesPending(t *testing.T) {
+	expected := makePendingEditResponse(2)
+	expected.SubmittedBy = 4
+	h := NewPendingEditHandler(
+		&mockPendingEditService{
+			createPendingEditFn: func(req *contracts.CreatePendingEditRequest) (*contracts.PendingEditResponse, error) {
+				return expected, nil
+			},
+		},
+		nil,
+	)
+
+	req := &SuggestEntityEditRequest{EntityID: "10"}
+	req.Body.Changes = []models.FieldChange{{Field: "city", OldValue: "", NewValue: "Phoenix"}}
+	req.Body.Summary = "Add city"
+
+	resp, err := h.SuggestVenueEditHandler(pendingEditContributorCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Applied {
+		t.Error("expected applied=false for contributor")
+	}
+}
+
+// ============================================================================
+// Tests: SuggestEdit — Trusted User (auto-applies)
+// ============================================================================
+
+func TestSuggestEdit_TrustedContributor_AutoApplies(t *testing.T) {
+	created := makePendingEditResponse(3)
+	approved := makePendingEditResponse(3)
+	approved.Status = models.PendingEditStatusApproved
+
+	h := NewPendingEditHandler(
+		&mockPendingEditService{
+			createPendingEditFn: func(req *contracts.CreatePendingEditRequest) (*contracts.PendingEditResponse, error) {
+				return created, nil
+			},
+			approvePendingEditFn: func(editID, reviewerID uint) (*contracts.PendingEditResponse, error) {
+				if editID != 3 {
+					t.Errorf("expected approve editID=3, got %d", editID)
+				}
+				return approved, nil
+			},
+		},
+		nil,
+	)
+
+	req := &SuggestEntityEditRequest{EntityID: "10"}
+	req.Body.Changes = []models.FieldChange{{Field: "name", OldValue: "Old", NewValue: "New"}}
+	req.Body.Summary = "Fix name"
+
+	resp, err := h.SuggestArtistEditHandler(pendingEditTrustedCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.Body.Applied {
+		t.Error("expected applied=true for trusted_contributor")
+	}
+	if resp.Body.Message != "Changes applied directly" {
+		t.Errorf("expected direct apply message, got: %s", resp.Body.Message)
+	}
+}
+
+func TestSuggestEdit_LocalAmbassador_AutoApplies(t *testing.T) {
+	created := makePendingEditResponse(4)
+	approved := makePendingEditResponse(4)
+	approved.Status = models.PendingEditStatusApproved
+
+	h := NewPendingEditHandler(
+		&mockPendingEditService{
+			createPendingEditFn: func(req *contracts.CreatePendingEditRequest) (*contracts.PendingEditResponse, error) {
+				return created, nil
+			},
+			approvePendingEditFn: func(editID, reviewerID uint) (*contracts.PendingEditResponse, error) {
+				return approved, nil
+			},
+		},
+		nil,
+	)
+
+	req := &SuggestEntityEditRequest{EntityID: "10"}
+	req.Body.Changes = []models.FieldChange{{Field: "name", OldValue: "Old", NewValue: "New"}}
+	req.Body.Summary = "Fix name"
+
+	resp, err := h.SuggestArtistEditHandler(pendingEditLocalAmbassadorCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.Body.Applied {
+		t.Error("expected applied=true for local_ambassador")
+	}
+}
+
+func TestSuggestEdit_Admin_AutoApplies(t *testing.T) {
+	created := makePendingEditResponse(5)
+	approved := makePendingEditResponse(5)
+	approved.Status = models.PendingEditStatusApproved
+
+	h := NewPendingEditHandler(
+		&mockPendingEditService{
+			createPendingEditFn: func(req *contracts.CreatePendingEditRequest) (*contracts.PendingEditResponse, error) {
+				return created, nil
+			},
+			approvePendingEditFn: func(editID, reviewerID uint) (*contracts.PendingEditResponse, error) {
+				return approved, nil
+			},
+		},
+		nil,
+	)
+
+	req := &SuggestEntityEditRequest{EntityID: "10"}
+	req.Body.Changes = []models.FieldChange{{Field: "name", OldValue: "Old", NewValue: "New"}}
+	req.Body.Summary = "Fix name"
+
+	resp, err := h.SuggestArtistEditHandler(pendingEditAdminCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.Body.Applied {
+		t.Error("expected applied=true for admin")
+	}
+}
+
+// ============================================================================
+// Tests: SuggestEdit — Error Cases
+// ============================================================================
+
+func TestSuggestEdit_EntityNotFound(t *testing.T) {
+	h := NewPendingEditHandler(
+		&mockPendingEditService{
+			createPendingEditFn: func(req *contracts.CreatePendingEditRequest) (*contracts.PendingEditResponse, error) {
+				return nil, fmt.Errorf("entity not found: artist 99999")
+			},
+		},
+		nil,
+	)
+
+	req := &SuggestEntityEditRequest{EntityID: "99999"}
+	req.Body.Changes = []models.FieldChange{{Field: "name", OldValue: "a", NewValue: "b"}}
+	req.Body.Summary = "test"
+
+	_, err := h.SuggestArtistEditHandler(pendingEditNewUserCtx(), req)
+	assertHumaError(t, err, 404)
+}
+
+func TestSuggestEdit_DuplicatePending(t *testing.T) {
+	h := NewPendingEditHandler(
+		&mockPendingEditService{
+			createPendingEditFn: func(req *contracts.CreatePendingEditRequest) (*contracts.PendingEditResponse, error) {
+				return nil, fmt.Errorf("failed to create pending edit: duplicate key value violates unique constraint")
+			},
+		},
+		nil,
+	)
+
+	req := &SuggestEntityEditRequest{EntityID: "10"}
+	req.Body.Changes = []models.FieldChange{{Field: "name", OldValue: "a", NewValue: "b"}}
+	req.Body.Summary = "test"
+
+	_, err := h.SuggestArtistEditHandler(pendingEditNewUserCtx(), req)
+	assertHumaError(t, err, 409)
+}
+
+// ============================================================================
+// Tests: GetMyPendingEdits
+// ============================================================================
+
+func TestGetMyPendingEdits_NoUser(t *testing.T) {
+	h := testPendingEditHandler()
+	_, err := h.GetMyPendingEditsHandler(context.Background(), &GetMyPendingEditsRequest{})
+	assertHumaError(t, err, 401)
+}
+
+func TestGetMyPendingEdits_Success(t *testing.T) {
+	edits := []contracts.PendingEditResponse{*makePendingEditResponse(1), *makePendingEditResponse(2)}
+	h := NewPendingEditHandler(
+		&mockPendingEditService{
+			getUserPendingEditsFn: func(userID uint, limit, offset int) ([]contracts.PendingEditResponse, int64, error) {
+				if userID != 3 {
+					t.Errorf("expected userID=3, got %d", userID)
+				}
+				return edits, 2, nil
+			},
+		},
+		nil,
+	)
+
+	resp, err := h.GetMyPendingEditsHandler(pendingEditNewUserCtx(), &GetMyPendingEditsRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Total != 2 {
+		t.Errorf("expected total=2, got %d", resp.Body.Total)
+	}
+	if len(resp.Body.Edits) != 2 {
+		t.Errorf("expected 2 edits, got %d", len(resp.Body.Edits))
+	}
+}
+
+// ============================================================================
+// Tests: CancelMyPendingEdit
+// ============================================================================
+
+func TestCancelMyPendingEdit_NoUser(t *testing.T) {
+	h := testPendingEditHandler()
+	_, err := h.CancelMyPendingEditHandler(context.Background(), &CancelMyPendingEntityEditRequest{EditID: "1"})
+	assertHumaError(t, err, 401)
+}
+
+func TestCancelMyPendingEdit_InvalidID(t *testing.T) {
+	h := testPendingEditHandler()
+	_, err := h.CancelMyPendingEditHandler(pendingEditNewUserCtx(), &CancelMyPendingEntityEditRequest{EditID: "abc"})
+	assertHumaError(t, err, 400)
+}
+
+func TestCancelMyPendingEdit_Success(t *testing.T) {
+	h := NewPendingEditHandler(
+		&mockPendingEditService{
+			cancelPendingEditFn: func(editID, userID uint) error {
+				if editID != 5 || userID != 3 {
+					t.Errorf("unexpected params: editID=%d, userID=%d", editID, userID)
+				}
+				return nil
+			},
+		},
+		nil,
+	)
+
+	resp, err := h.CancelMyPendingEditHandler(pendingEditNewUserCtx(), &CancelMyPendingEntityEditRequest{EditID: "5"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.Body.Success {
+		t.Error("expected success=true")
+	}
+}
+
+func TestCancelMyPendingEdit_NotFound(t *testing.T) {
+	h := NewPendingEditHandler(
+		&mockPendingEditService{
+			cancelPendingEditFn: func(editID, userID uint) error {
+				return fmt.Errorf("pending edit not found")
+			},
+		},
+		nil,
+	)
+
+	_, err := h.CancelMyPendingEditHandler(pendingEditNewUserCtx(), &CancelMyPendingEntityEditRequest{EditID: "99"})
+	assertHumaError(t, err, 404)
+}
+
+func TestCancelMyPendingEdit_WrongUser(t *testing.T) {
+	h := NewPendingEditHandler(
+		&mockPendingEditService{
+			cancelPendingEditFn: func(editID, userID uint) error {
+				return fmt.Errorf("only the submitter can cancel")
+			},
+		},
+		nil,
+	)
+
+	_, err := h.CancelMyPendingEditHandler(pendingEditNewUserCtx(), &CancelMyPendingEntityEditRequest{EditID: "5"})
+	assertHumaError(t, err, 403)
+}
+
+// ============================================================================
+// Tests: Admin — List Pending Edits
+// ============================================================================
+
+func TestAdminListPendingEdits_RequiresAdmin(t *testing.T) {
+	h := testPendingEditHandler()
+
+	t.Run("NoUser", func(t *testing.T) {
+		_, err := h.AdminListPendingEditsHandler(context.Background(), &AdminListPendingEditsRequest{})
+		assertHumaError(t, err, 403)
+	})
+	t.Run("NonAdmin", func(t *testing.T) {
+		_, err := h.AdminListPendingEditsHandler(pendingEditNewUserCtx(), &AdminListPendingEditsRequest{})
+		assertHumaError(t, err, 403)
+	})
+}
+
+func TestAdminListPendingEdits_Success(t *testing.T) {
+	edits := []contracts.PendingEditResponse{*makePendingEditResponse(1)}
+	h := NewPendingEditHandler(
+		&mockPendingEditService{
+			listPendingEditsFn: func(filters *contracts.PendingEditFilters) ([]contracts.PendingEditResponse, int64, error) {
+				if filters.Status != "pending" {
+					t.Errorf("expected status=pending, got %s", filters.Status)
+				}
+				return edits, 1, nil
+			},
+		},
+		nil,
+	)
+
+	resp, err := h.AdminListPendingEditsHandler(pendingEditAdminCtx(), &AdminListPendingEditsRequest{
+		Status: "pending",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Total != 1 {
+		t.Errorf("expected total=1, got %d", resp.Body.Total)
+	}
+}
+
+// ============================================================================
+// Tests: Admin — Get Pending Edit
+// ============================================================================
+
+func TestAdminGetPendingEdit_RequiresAdmin(t *testing.T) {
+	h := testPendingEditHandler()
+	_, err := h.AdminGetPendingEditHandler(pendingEditNewUserCtx(), &AdminGetPendingEditRequest{EditID: "1"})
+	assertHumaError(t, err, 403)
+}
+
+func TestAdminGetPendingEdit_NotFound(t *testing.T) {
+	h := NewPendingEditHandler(
+		&mockPendingEditService{
+			getPendingEditFn: func(editID uint) (*contracts.PendingEditResponse, error) {
+				return nil, nil
+			},
+		},
+		nil,
+	)
+
+	_, err := h.AdminGetPendingEditHandler(pendingEditAdminCtx(), &AdminGetPendingEditRequest{EditID: "99"})
+	assertHumaError(t, err, 404)
+}
+
+func TestAdminGetPendingEdit_Success(t *testing.T) {
+	expected := makePendingEditResponse(1)
+	h := NewPendingEditHandler(
+		&mockPendingEditService{
+			getPendingEditFn: func(editID uint) (*contracts.PendingEditResponse, error) {
+				if editID != 1 {
+					t.Errorf("expected editID=1, got %d", editID)
+				}
+				return expected, nil
+			},
+		},
+		nil,
+	)
+
+	resp, err := h.AdminGetPendingEditHandler(pendingEditAdminCtx(), &AdminGetPendingEditRequest{EditID: "1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.ID != 1 {
+		t.Errorf("expected ID=1, got %d", resp.Body.ID)
+	}
+}
+
+// ============================================================================
+// Tests: Admin — Approve
+// ============================================================================
+
+func TestAdminApprove_RequiresAdmin(t *testing.T) {
+	h := testPendingEditHandler()
+	_, err := h.AdminApprovePendingEditHandler(pendingEditNewUserCtx(), &AdminApprovePendingEditRequest{EditID: "1"})
+	assertHumaError(t, err, 403)
+}
+
+func TestAdminApprove_Success(t *testing.T) {
+	approved := makePendingEditResponse(1)
+	approved.Status = models.PendingEditStatusApproved
+	reviewerID := uint(1)
+	approved.ReviewedBy = &reviewerID
+
+	h := NewPendingEditHandler(
+		&mockPendingEditService{
+			approvePendingEditFn: func(editID, rID uint) (*contracts.PendingEditResponse, error) {
+				if editID != 1 || rID != 1 {
+					t.Errorf("unexpected params: editID=%d, reviewerID=%d", editID, rID)
+				}
+				return approved, nil
+			},
+		},
+		&mockAuditLogService{},
+	)
+
+	resp, err := h.AdminApprovePendingEditHandler(pendingEditAdminCtx(), &AdminApprovePendingEditRequest{EditID: "1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Status != models.PendingEditStatusApproved {
+		t.Errorf("expected approved status, got %s", resp.Body.Status)
+	}
+}
+
+func TestAdminApprove_NotFound(t *testing.T) {
+	h := NewPendingEditHandler(
+		&mockPendingEditService{
+			approvePendingEditFn: func(editID, rID uint) (*contracts.PendingEditResponse, error) {
+				return nil, fmt.Errorf("pending edit not found")
+			},
+		},
+		nil,
+	)
+
+	_, err := h.AdminApprovePendingEditHandler(pendingEditAdminCtx(), &AdminApprovePendingEditRequest{EditID: "99"})
+	assertHumaError(t, err, 404)
+}
+
+func TestAdminApprove_AlreadyReviewed(t *testing.T) {
+	h := NewPendingEditHandler(
+		&mockPendingEditService{
+			approvePendingEditFn: func(editID, rID uint) (*contracts.PendingEditResponse, error) {
+				return nil, fmt.Errorf("edit is not pending (status: approved)")
+			},
+		},
+		nil,
+	)
+
+	_, err := h.AdminApprovePendingEditHandler(pendingEditAdminCtx(), &AdminApprovePendingEditRequest{EditID: "1"})
+	assertHumaError(t, err, 409)
+}
+
+// ============================================================================
+// Tests: Admin — Reject
+// ============================================================================
+
+func TestAdminReject_RequiresAdmin(t *testing.T) {
+	h := testPendingEditHandler()
+	req := &AdminRejectPendingEditRequest{EditID: "1"}
+	req.Body.Reason = "bad"
+	_, err := h.AdminRejectPendingEditHandler(pendingEditNewUserCtx(), req)
+	assertHumaError(t, err, 403)
+}
+
+func TestAdminReject_EmptyReason(t *testing.T) {
+	h := testPendingEditHandler()
+	req := &AdminRejectPendingEditRequest{EditID: "1"}
+	req.Body.Reason = ""
+	_, err := h.AdminRejectPendingEditHandler(pendingEditAdminCtx(), req)
+	assertHumaError(t, err, 400)
+}
+
+func TestAdminReject_Success(t *testing.T) {
+	rejected := makePendingEditResponse(1)
+	rejected.Status = models.PendingEditStatusRejected
+	reason := "Name should be 'The Rebel Lounge' not 'Rebel Lounge'"
+	rejected.RejectionReason = &reason
+
+	h := NewPendingEditHandler(
+		&mockPendingEditService{
+			rejectPendingEditFn: func(editID, rID uint, r string) (*contracts.PendingEditResponse, error) {
+				if r != reason {
+					t.Errorf("expected reason=%q, got %q", reason, r)
+				}
+				return rejected, nil
+			},
+		},
+		&mockAuditLogService{},
+	)
+
+	req := &AdminRejectPendingEditRequest{EditID: "1"}
+	req.Body.Reason = reason
+
+	resp, err := h.AdminRejectPendingEditHandler(pendingEditAdminCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Status != models.PendingEditStatusRejected {
+		t.Errorf("expected rejected status, got %s", resp.Body.Status)
+	}
+	if resp.Body.RejectionReason == nil || *resp.Body.RejectionReason != reason {
+		t.Errorf("expected rejection reason")
+	}
+}
+
+func TestAdminReject_NotFound(t *testing.T) {
+	h := NewPendingEditHandler(
+		&mockPendingEditService{
+			rejectPendingEditFn: func(editID, rID uint, r string) (*contracts.PendingEditResponse, error) {
+				return nil, fmt.Errorf("pending edit not found")
+			},
+		},
+		nil,
+	)
+
+	req := &AdminRejectPendingEditRequest{EditID: "99"}
+	req.Body.Reason = "bad"
+	_, err := h.AdminRejectPendingEditHandler(pendingEditAdminCtx(), req)
+	assertHumaError(t, err, 404)
+}
+
+// ============================================================================
+// Tests: Admin — Get Entity Pending Edits
+// ============================================================================
+
+func TestAdminGetEntityPendingEdits_RequiresAdmin(t *testing.T) {
+	h := testPendingEditHandler()
+	_, err := h.AdminGetEntityPendingEditsHandler(pendingEditNewUserCtx(), &AdminGetEntityPendingEditsRequest{
+		EntityType: "artist", EntityID: "1",
+	})
+	assertHumaError(t, err, 403)
+}
+
+func TestAdminGetEntityPendingEdits_InvalidEntityType(t *testing.T) {
+	h := testPendingEditHandler()
+	_, err := h.AdminGetEntityPendingEditsHandler(pendingEditAdminCtx(), &AdminGetEntityPendingEditsRequest{
+		EntityType: "show", EntityID: "1",
+	})
+	assertHumaError(t, err, 400)
+}
+
+func TestAdminGetEntityPendingEdits_Success(t *testing.T) {
+	edits := []contracts.PendingEditResponse{*makePendingEditResponse(1)}
+	h := NewPendingEditHandler(
+		&mockPendingEditService{
+			getPendingEditsForEntityFn: func(entityType string, entityID uint) ([]contracts.PendingEditResponse, error) {
+				if entityType != "artist" || entityID != 10 {
+					t.Errorf("unexpected params: type=%s, id=%d", entityType, entityID)
+				}
+				return edits, nil
+			},
+		},
+		nil,
+	)
+
+	resp, err := h.AdminGetEntityPendingEditsHandler(pendingEditAdminCtx(), &AdminGetEntityPendingEditsRequest{
+		EntityType: "artist", EntityID: "10",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Body.Edits) != 1 {
+		t.Errorf("expected 1 edit, got %d", len(resp.Body.Edits))
+	}
+}
+
+// ============================================================================
+// Tests: canEditDirectly
+// ============================================================================
+
+func TestCanEditDirectly(t *testing.T) {
+	tests := []struct {
+		name     string
+		user     *models.User
+		expected bool
+	}{
+		{"admin", &models.User{IsAdmin: true, UserTier: "new_user"}, true},
+		{"trusted_contributor", &models.User{IsAdmin: false, UserTier: "trusted_contributor"}, true},
+		{"local_ambassador", &models.User{IsAdmin: false, UserTier: "local_ambassador"}, true},
+		{"new_user", &models.User{IsAdmin: false, UserTier: "new_user"}, false},
+		{"contributor", &models.User{IsAdmin: false, UserTier: "contributor"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := canEditDirectly(tt.user); got != tt.expected {
+				t.Errorf("canEditDirectly(%s) = %v, want %v", tt.name, got, tt.expected)
+			}
+		})
+	}
+}
+
+// ============================================================================
+// Tests: Allowed fields validation
+// ============================================================================
+
+func TestAllowedEditFields(t *testing.T) {
+	// Artist allowed
+	for _, f := range []string{"name", "city", "state", "instagram", "bandcamp", "description"} {
+		if !allowedEditFields["artist"][f] {
+			t.Errorf("expected %s to be allowed for artist", f)
+		}
+	}
+	// Artist disallowed
+	for _, f := range []string{"slug", "is_active", "data_source", "created_at"} {
+		if allowedEditFields["artist"][f] {
+			t.Errorf("expected %s to be disallowed for artist", f)
+		}
+	}
+
+	// Venue allowed
+	for _, f := range []string{"name", "address", "city", "zipcode", "website"} {
+		if !allowedEditFields["venue"][f] {
+			t.Errorf("expected %s to be allowed for venue", f)
+		}
+	}
+	// Venue disallowed
+	for _, f := range []string{"verified", "submitted_by", "auto_approve"} {
+		if allowedEditFields["venue"][f] {
+			t.Errorf("expected %s to be disallowed for venue", f)
+		}
+	}
+
+	// Festival allowed
+	for _, f := range []string{"name", "description", "website", "ticket_url", "flyer_url"} {
+		if !allowedEditFields["festival"][f] {
+			t.Errorf("expected %s to be allowed for festival", f)
+		}
+	}
+	// Festival disallowed
+	for _, f := range []string{"status", "slug", "series_slug", "edition_year"} {
+		if allowedEditFields["festival"][f] {
+			t.Errorf("expected %s to be disallowed for festival", f)
+		}
+	}
+}

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -125,6 +125,7 @@ func SetupRoutes(router *chi.Mux, sc *services.ServiceContainer, cfg *config.Con
 	setupFollowRoutes(rc)
 	setupNotificationFilterRoutes(rc)
 	setupChartsRoutes(rc)
+	setupPendingEditRoutes(rc)
 
 	return api
 }
@@ -909,4 +910,27 @@ func rateLimitHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Retry-After", "60")
 	w.WriteHeader(http.StatusTooManyRequests)
 	w.Write([]byte(`{"success":false,"error":"too_many_requests","message":"Rate limit exceeded. Please try again in 60 seconds."}`))
+}
+
+// setupPendingEditRoutes configures pending entity edit endpoints.
+// Protected endpoints for suggesting edits and managing own edits.
+// Admin endpoints for reviewing, approving, and rejecting edits.
+func setupPendingEditRoutes(rc RouteContext) {
+	pendingEditHandler := handlers.NewPendingEditHandler(rc.SC.PendingEdit, rc.SC.AuditLog)
+
+	// Protected: suggest edits (creates pending or auto-applies for trusted users)
+	huma.Put(rc.Protected, "/artists/{entity_id}/suggest-edit", pendingEditHandler.SuggestArtistEditHandler)
+	huma.Put(rc.Protected, "/venues/{entity_id}/suggest-edit", pendingEditHandler.SuggestVenueEditHandler)
+	huma.Put(rc.Protected, "/festivals/{entity_id}/suggest-edit", pendingEditHandler.SuggestFestivalEditHandler)
+
+	// Protected: user's own pending edits
+	huma.Get(rc.Protected, "/my/pending-edits", pendingEditHandler.GetMyPendingEditsHandler)
+	huma.Delete(rc.Protected, "/my/pending-edits/{edit_id}", pendingEditHandler.CancelMyPendingEditHandler)
+
+	// Admin: review queue
+	huma.Get(rc.Protected, "/admin/pending-edits", pendingEditHandler.AdminListPendingEditsHandler)
+	huma.Get(rc.Protected, "/admin/pending-edits/{edit_id}", pendingEditHandler.AdminGetPendingEditHandler)
+	huma.Post(rc.Protected, "/admin/pending-edits/{edit_id}/approve", pendingEditHandler.AdminApprovePendingEditHandler)
+	huma.Post(rc.Protected, "/admin/pending-edits/{edit_id}/reject", pendingEditHandler.AdminRejectPendingEditHandler)
+	huma.Get(rc.Protected, "/admin/pending-edits/entity/{entity_type}/{entity_id}", pendingEditHandler.AdminGetEntityPendingEditsHandler)
 }

--- a/backend/internal/models/pending_entity_edit.go
+++ b/backend/internal/models/pending_entity_edit.go
@@ -1,0 +1,60 @@
+package models
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// PendingEditStatus represents the status of a pending entity edit.
+type PendingEditStatus string
+
+const (
+	PendingEditStatusPending  PendingEditStatus = "pending"
+	PendingEditStatusApproved PendingEditStatus = "approved"
+	PendingEditStatusRejected PendingEditStatus = "rejected"
+)
+
+// Supported entity types for pending edits.
+const (
+	PendingEditEntityArtist   = "artist"
+	PendingEditEntityVenue    = "venue"
+	PendingEditEntityFestival = "festival"
+)
+
+// PendingEntityEdit represents a proposed edit to an entity awaiting review.
+// Uses JSONB field_changes (same format as revisions) instead of per-entity nullable columns.
+type PendingEntityEdit struct {
+	ID              uint              `json:"id" gorm:"primaryKey"`
+	EntityType      string            `json:"entity_type" gorm:"column:entity_type;not null;size:50"`
+	EntityID        uint              `json:"entity_id" gorm:"column:entity_id;not null"`
+	SubmittedBy     uint              `json:"submitted_by" gorm:"column:submitted_by;not null"`
+	FieldChanges    *json.RawMessage  `json:"field_changes" gorm:"column:field_changes;type:jsonb;not null"`
+	Summary         string            `json:"summary" gorm:"column:summary;not null"`
+	Status          PendingEditStatus `json:"status" gorm:"column:status;not null;default:'pending'"`
+	ReviewedBy      *uint             `json:"reviewed_by,omitempty" gorm:"column:reviewed_by"`
+	ReviewedAt      *time.Time        `json:"reviewed_at,omitempty" gorm:"column:reviewed_at"`
+	RejectionReason *string           `json:"rejection_reason,omitempty" gorm:"column:rejection_reason"`
+	CreatedAt       time.Time         `json:"created_at"`
+	UpdatedAt       time.Time         `json:"updated_at"`
+
+	Submitter User  `json:"-" gorm:"foreignKey:SubmittedBy"`
+	Reviewer  *User `json:"-" gorm:"foreignKey:ReviewedBy"`
+}
+
+// TableName specifies the table name for PendingEntityEdit.
+func (PendingEntityEdit) TableName() string { return "pending_entity_edits" }
+
+// ValidEntityTypes returns the set of entity types that support pending edits.
+func ValidPendingEditEntityTypes() []string {
+	return []string{PendingEditEntityArtist, PendingEditEntityVenue, PendingEditEntityFestival}
+}
+
+// IsValidPendingEditEntityType checks if the given entity type supports pending edits.
+func IsValidPendingEditEntityType(entityType string) bool {
+	for _, t := range ValidPendingEditEntityTypes() {
+		if t == entityType {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/services/admin/interfaces.go
+++ b/backend/internal/services/admin/interfaces.go
@@ -13,5 +13,6 @@ var (
 	_ contracts.RevisionServiceInterface      = (*RevisionService)(nil)
 	_ contracts.DataQualityServiceInterface  = (*DataQualityService)(nil)
 	_ contracts.AnalyticsServiceInterface   = (*AnalyticsService)(nil)
+	_ contracts.PendingEditServiceInterface = (*PendingEditService)(nil)
 	// CleanupService has no interface in contracts — it's a lifecycle service.
 )

--- a/backend/internal/services/admin/pending_edit.go
+++ b/backend/internal/services/admin/pending_edit.go
@@ -1,0 +1,382 @@
+package admin
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/db"
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// PendingEditService handles business logic for generic pending entity edits.
+type PendingEditService struct {
+	db              *gorm.DB
+	revisionService contracts.RevisionServiceInterface
+}
+
+// NewPendingEditService creates a new PendingEditService.
+func NewPendingEditService(database *gorm.DB, revisionService contracts.RevisionServiceInterface) *PendingEditService {
+	if database == nil {
+		database = db.GetDB()
+	}
+	return &PendingEditService{db: database, revisionService: revisionService}
+}
+
+// CreatePendingEdit submits a new pending edit for an entity.
+func (s *PendingEditService) CreatePendingEdit(req *contracts.CreatePendingEditRequest) (*contracts.PendingEditResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	if !models.IsValidPendingEditEntityType(req.EntityType) {
+		return nil, fmt.Errorf("invalid entity type: %s", req.EntityType)
+	}
+	if len(req.Changes) == 0 {
+		return nil, fmt.Errorf("no changes provided")
+	}
+	if req.Summary == "" {
+		return nil, fmt.Errorf("summary is required")
+	}
+
+	// Verify the entity exists
+	tableName := req.EntityType + "s"
+	var count int64
+	if err := s.db.Table(tableName).Where("id = ?", req.EntityID).Count(&count).Error; err != nil {
+		return nil, fmt.Errorf("failed to verify entity: %w", err)
+	}
+	if count == 0 {
+		return nil, fmt.Errorf("entity not found: %s %d", req.EntityType, req.EntityID)
+	}
+
+	changesJSON, err := json.Marshal(req.Changes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal changes: %w", err)
+	}
+	raw := json.RawMessage(changesJSON)
+
+	edit := &models.PendingEntityEdit{
+		EntityType:   req.EntityType,
+		EntityID:     req.EntityID,
+		SubmittedBy:  req.UserID,
+		FieldChanges: &raw,
+		Summary:      req.Summary,
+		Status:       models.PendingEditStatusPending,
+	}
+
+	if err := s.db.Create(edit).Error; err != nil {
+		return nil, fmt.Errorf("failed to create pending edit: %w", err)
+	}
+
+	// Reload with relationships
+	return s.GetPendingEdit(edit.ID)
+}
+
+// GetPendingEdit returns a single pending edit by ID.
+func (s *PendingEditService) GetPendingEdit(editID uint) (*contracts.PendingEditResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var edit models.PendingEntityEdit
+	err := s.db.Preload("Submitter").Preload("Reviewer").First(&edit, editID).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get pending edit: %w", err)
+	}
+
+	return s.toResponse(&edit), nil
+}
+
+// GetPendingEditsForEntity returns all pending edits for a specific entity.
+func (s *PendingEditService) GetPendingEditsForEntity(entityType string, entityID uint) ([]contracts.PendingEditResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var edits []models.PendingEntityEdit
+	err := s.db.Where("entity_type = ? AND entity_id = ? AND status = ?", entityType, entityID, models.PendingEditStatusPending).
+		Preload("Submitter").
+		Order("created_at ASC").
+		Find(&edits).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to get pending edits for entity: %w", err)
+	}
+
+	return s.toResponses(edits), nil
+}
+
+// GetUserPendingEdits returns all pending edits submitted by a user.
+func (s *PendingEditService) GetUserPendingEdits(userID uint, limit, offset int) ([]contracts.PendingEditResponse, int64, error) {
+	if s.db == nil {
+		return nil, 0, fmt.Errorf("database not initialized")
+	}
+
+	if limit <= 0 {
+		limit = 20
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	var total int64
+	s.db.Model(&models.PendingEntityEdit{}).Where("submitted_by = ?", userID).Count(&total)
+
+	var edits []models.PendingEntityEdit
+	err := s.db.Where("submitted_by = ?", userID).
+		Preload("Submitter").
+		Preload("Reviewer").
+		Order("created_at DESC").
+		Limit(limit).
+		Offset(offset).
+		Find(&edits).Error
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to get user pending edits: %w", err)
+	}
+
+	return s.toResponses(edits), total, nil
+}
+
+// ListPendingEdits returns pending edits for the admin review queue.
+func (s *PendingEditService) ListPendingEdits(filters *contracts.PendingEditFilters) ([]contracts.PendingEditResponse, int64, error) {
+	if s.db == nil {
+		return nil, 0, fmt.Errorf("database not initialized")
+	}
+
+	limit := 20
+	offset := 0
+	if filters != nil {
+		if filters.Limit > 0 && filters.Limit <= 100 {
+			limit = filters.Limit
+		}
+		if filters.Offset > 0 {
+			offset = filters.Offset
+		}
+	}
+
+	query := s.db.Model(&models.PendingEntityEdit{})
+
+	if filters != nil {
+		if filters.Status != "" {
+			query = query.Where("status = ?", filters.Status)
+		}
+		if filters.EntityType != "" {
+			query = query.Where("entity_type = ?", filters.EntityType)
+		}
+	}
+
+	var total int64
+	query.Count(&total)
+
+	var edits []models.PendingEntityEdit
+	err := query.
+		Preload("Submitter").
+		Preload("Reviewer").
+		Order("created_at ASC").
+		Limit(limit).
+		Offset(offset).
+		Find(&edits).Error
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to list pending edits: %w", err)
+	}
+
+	return s.toResponses(edits), total, nil
+}
+
+// ApprovePendingEdit approves a pending edit, applying changes to the entity
+// and recording a revision.
+func (s *PendingEditService) ApprovePendingEdit(editID uint, reviewerID uint) (*contracts.PendingEditResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var edit models.PendingEntityEdit
+	if err := s.db.First(&edit, editID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, fmt.Errorf("pending edit not found")
+		}
+		return nil, fmt.Errorf("failed to get pending edit: %w", err)
+	}
+
+	if edit.Status != models.PendingEditStatusPending {
+		return nil, fmt.Errorf("edit is not pending (status: %s)", edit.Status)
+	}
+
+	// Parse field changes
+	var changes []models.FieldChange
+	if err := json.Unmarshal(*edit.FieldChanges, &changes); err != nil {
+		return nil, fmt.Errorf("failed to parse field changes: %w", err)
+	}
+
+	// Build update map from new values
+	updates := make(map[string]interface{})
+	for _, c := range changes {
+		updates[c.Field] = c.NewValue
+	}
+	updates["updated_at"] = time.Now()
+
+	// Apply changes to entity within a transaction
+	err := s.db.Transaction(func(tx *gorm.DB) error {
+		tableName := edit.EntityType + "s"
+		result := tx.Table(tableName).Where("id = ?", edit.EntityID).Updates(updates)
+		if result.Error != nil {
+			return fmt.Errorf("failed to apply changes: %w", result.Error)
+		}
+		if result.RowsAffected == 0 {
+			return fmt.Errorf("entity not found: %s %d", edit.EntityType, edit.EntityID)
+		}
+
+		// Mark edit as approved
+		now := time.Now()
+		if err := tx.Model(&edit).Updates(map[string]interface{}{
+			"status":      models.PendingEditStatusApproved,
+			"reviewed_by": reviewerID,
+			"reviewed_at": now,
+			"updated_at":  now,
+		}).Error; err != nil {
+			return fmt.Errorf("failed to update edit status: %w", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Record revision (fire-and-forget — don't fail the approval if this errors)
+	if s.revisionService != nil {
+		_ = s.revisionService.RecordRevision(edit.EntityType, edit.EntityID, edit.SubmittedBy, changes, edit.Summary)
+	}
+
+	return s.GetPendingEdit(editID)
+}
+
+// RejectPendingEdit rejects a pending edit with a reason.
+func (s *PendingEditService) RejectPendingEdit(editID uint, reviewerID uint, reason string) (*contracts.PendingEditResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	if reason == "" {
+		return nil, fmt.Errorf("rejection reason is required")
+	}
+
+	var edit models.PendingEntityEdit
+	if err := s.db.First(&edit, editID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, fmt.Errorf("pending edit not found")
+		}
+		return nil, fmt.Errorf("failed to get pending edit: %w", err)
+	}
+
+	if edit.Status != models.PendingEditStatusPending {
+		return nil, fmt.Errorf("edit is not pending (status: %s)", edit.Status)
+	}
+
+	now := time.Now()
+	if err := s.db.Model(&edit).Updates(map[string]interface{}{
+		"status":           models.PendingEditStatusRejected,
+		"reviewed_by":      reviewerID,
+		"reviewed_at":      now,
+		"rejection_reason": reason,
+		"updated_at":       now,
+	}).Error; err != nil {
+		return nil, fmt.Errorf("failed to reject pending edit: %w", err)
+	}
+
+	return s.GetPendingEdit(editID)
+}
+
+// CancelPendingEdit allows the submitter to cancel their own pending edit.
+func (s *PendingEditService) CancelPendingEdit(editID uint, userID uint) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	var edit models.PendingEntityEdit
+	if err := s.db.First(&edit, editID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return fmt.Errorf("pending edit not found")
+		}
+		return fmt.Errorf("failed to get pending edit: %w", err)
+	}
+
+	if edit.SubmittedBy != userID {
+		return fmt.Errorf("only the submitter can cancel their own edit")
+	}
+
+	if edit.Status != models.PendingEditStatusPending {
+		return fmt.Errorf("edit is not pending (status: %s)", edit.Status)
+	}
+
+	return s.db.Delete(&edit).Error
+}
+
+// toResponse converts a PendingEntityEdit model to a response DTO.
+func (s *PendingEditService) toResponse(edit *models.PendingEntityEdit) *contracts.PendingEditResponse {
+	resp := &contracts.PendingEditResponse{
+		ID:              edit.ID,
+		EntityType:      edit.EntityType,
+		EntityID:        edit.EntityID,
+		SubmittedBy:     edit.SubmittedBy,
+		Summary:         edit.Summary,
+		Status:          edit.Status,
+		ReviewedBy:      edit.ReviewedBy,
+		ReviewedAt:      edit.ReviewedAt,
+		RejectionReason: edit.RejectionReason,
+		CreatedAt:       edit.CreatedAt,
+		UpdatedAt:       edit.UpdatedAt,
+	}
+
+	// Parse field changes
+	if edit.FieldChanges != nil {
+		var changes []models.FieldChange
+		if err := json.Unmarshal(*edit.FieldChanges, &changes); err == nil {
+			resp.FieldChanges = changes
+		}
+	}
+
+	// Resolve submitter name
+	if edit.Submitter.ID != 0 {
+		resp.SubmitterName = displayName(&edit.Submitter)
+	}
+
+	// Resolve reviewer name
+	if edit.Reviewer != nil && edit.Reviewer.ID != 0 {
+		resp.ReviewerName = displayName(edit.Reviewer)
+	}
+
+	return resp
+}
+
+// toResponses converts a slice of models to response DTOs.
+func (s *PendingEditService) toResponses(edits []models.PendingEntityEdit) []contracts.PendingEditResponse {
+	responses := make([]contracts.PendingEditResponse, len(edits))
+	for i := range edits {
+		responses[i] = *s.toResponse(&edits[i])
+	}
+	return responses
+}
+
+// displayName returns a display name from a user, preferring username > first+last > email.
+func displayName(u *models.User) string {
+	if u.Username != nil && *u.Username != "" {
+		return *u.Username
+	}
+	if u.FirstName != nil && *u.FirstName != "" {
+		name := *u.FirstName
+		if u.LastName != nil && *u.LastName != "" {
+			name += " " + *u.LastName
+		}
+		return name
+	}
+	if u.Email != nil {
+		return *u.Email
+	}
+	return ""
+}

--- a/backend/internal/services/admin/pending_edit_test.go
+++ b/backend/internal/services/admin/pending_edit_test.go
@@ -1,0 +1,894 @@
+package admin
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/testutil"
+)
+
+// =============================================================================
+// UNIT TESTS (No Database Required)
+// =============================================================================
+
+func TestNewPendingEditService(t *testing.T) {
+	svc := NewPendingEditService(nil, nil)
+	assert.NotNil(t, svc)
+}
+
+func TestPendingEditService_NilDatabase(t *testing.T) {
+	svc := &PendingEditService{db: nil}
+
+	t.Run("CreatePendingEdit", func(t *testing.T) {
+		testutil.AssertNilDBErrorWithResult(t, func() (interface{}, error) {
+			return svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+				EntityType: "artist", EntityID: 1, UserID: 1,
+				Changes: []models.FieldChange{{Field: "name", OldValue: "a", NewValue: "b"}},
+				Summary: "test",
+			})
+		})
+	})
+
+	t.Run("GetPendingEdit", func(t *testing.T) {
+		testutil.AssertNilDBErrorWithResult(t, func() (interface{}, error) {
+			return svc.GetPendingEdit(1)
+		})
+	})
+
+	t.Run("GetPendingEditsForEntity", func(t *testing.T) {
+		testutil.AssertNilDBError(t, func() error {
+			_, err := svc.GetPendingEditsForEntity("artist", 1)
+			return err
+		})
+	})
+
+	t.Run("GetUserPendingEdits", func(t *testing.T) {
+		testutil.AssertNilDBError(t, func() error {
+			_, _, err := svc.GetUserPendingEdits(1, 10, 0)
+			return err
+		})
+	})
+
+	t.Run("ListPendingEdits", func(t *testing.T) {
+		testutil.AssertNilDBError(t, func() error {
+			_, _, err := svc.ListPendingEdits(nil)
+			return err
+		})
+	})
+
+	t.Run("ApprovePendingEdit", func(t *testing.T) {
+		testutil.AssertNilDBErrorWithResult(t, func() (interface{}, error) {
+			return svc.ApprovePendingEdit(1, 1)
+		})
+	})
+
+	t.Run("RejectPendingEdit", func(t *testing.T) {
+		testutil.AssertNilDBErrorWithResult(t, func() (interface{}, error) {
+			return svc.RejectPendingEdit(1, 1, "reason")
+		})
+	})
+
+	t.Run("CancelPendingEdit", func(t *testing.T) {
+		testutil.AssertNilDBError(t, func() error {
+			return svc.CancelPendingEdit(1, 1)
+		})
+	})
+}
+
+func TestIsValidPendingEditEntityType(t *testing.T) {
+	assert.True(t, models.IsValidPendingEditEntityType("artist"))
+	assert.True(t, models.IsValidPendingEditEntityType("venue"))
+	assert.True(t, models.IsValidPendingEditEntityType("festival"))
+	assert.False(t, models.IsValidPendingEditEntityType("show"))
+	assert.False(t, models.IsValidPendingEditEntityType(""))
+	assert.False(t, models.IsValidPendingEditEntityType("release"))
+}
+
+// =============================================================================
+// INTEGRATION TESTS (With Real Database)
+// =============================================================================
+
+type PendingEditServiceIntegrationTestSuite struct {
+	suite.Suite
+	testDB     *testutil.TestDatabase
+	db         *gorm.DB
+	svc        *PendingEditService
+	revisionSvc *RevisionService
+}
+
+func (s *PendingEditServiceIntegrationTestSuite) SetupSuite() {
+	s.testDB = testutil.SetupTestPostgres(s.T())
+	s.db = s.testDB.DB
+	s.revisionSvc = NewRevisionService(s.db)
+	s.svc = NewPendingEditService(s.db, s.revisionSvc)
+}
+
+func (s *PendingEditServiceIntegrationTestSuite) TearDownSuite() {
+	s.testDB.Cleanup()
+}
+
+func (s *PendingEditServiceIntegrationTestSuite) TearDownTest() {
+	sqlDB, err := s.db.DB()
+	s.Require().NoError(err)
+	_, _ = sqlDB.Exec("DELETE FROM pending_entity_edits")
+	_, _ = sqlDB.Exec("DELETE FROM revisions")
+	_, _ = sqlDB.Exec("DELETE FROM artists")
+	_, _ = sqlDB.Exec("DELETE FROM venues")
+	_, _ = sqlDB.Exec("DELETE FROM festivals")
+	_, _ = sqlDB.Exec("DELETE FROM users")
+}
+
+func TestPendingEditServiceIntegrationSuite(t *testing.T) {
+	suite.Run(t, new(PendingEditServiceIntegrationTestSuite))
+}
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+func (s *PendingEditServiceIntegrationTestSuite) createTestUser() *models.User {
+	user := &models.User{
+		Email:         stringPtr(fmt.Sprintf("pe-user-%d@test.com", time.Now().UnixNano())),
+		Username:      stringPtr(fmt.Sprintf("pe-user-%d", time.Now().UnixNano())),
+		FirstName:     stringPtr("Test"),
+		LastName:      stringPtr("User"),
+		IsActive:      true,
+		EmailVerified: true,
+	}
+	err := s.db.Create(user).Error
+	s.Require().NoError(err)
+	return user
+}
+
+func (s *PendingEditServiceIntegrationTestSuite) createTestArtist(name string) *models.Artist {
+	slug := fmt.Sprintf("test-artist-%d", time.Now().UnixNano())
+	artist := &models.Artist{
+		Name: name,
+		Slug: &slug,
+	}
+	err := s.db.Create(artist).Error
+	s.Require().NoError(err)
+	return artist
+}
+
+func (s *PendingEditServiceIntegrationTestSuite) createTestVenue(name string) *models.Venue {
+	slug := fmt.Sprintf("test-venue-%d", time.Now().UnixNano())
+	venue := &models.Venue{
+		Name:  name,
+		Slug:  &slug,
+		City:  "Phoenix",
+		State: "AZ",
+	}
+	err := s.db.Create(venue).Error
+	s.Require().NoError(err)
+	return venue
+}
+
+func (s *PendingEditServiceIntegrationTestSuite) createTestFestival(name string) *models.Festival {
+	slug := fmt.Sprintf("test-festival-%d", time.Now().UnixNano())
+	festival := &models.Festival{
+		Name:        name,
+		Slug:        slug,
+		SeriesSlug:  slug,
+		EditionYear: 2026,
+		StartDate:   "2026-06-01",
+		EndDate:     "2026-06-03",
+	}
+	err := s.db.Create(festival).Error
+	s.Require().NoError(err)
+	return festival
+}
+
+func makeChanges(field, oldVal, newVal string) []models.FieldChange {
+	return []models.FieldChange{{Field: field, OldValue: oldVal, NewValue: newVal}}
+}
+
+// =============================================================================
+// CreatePendingEdit tests
+// =============================================================================
+
+func (s *PendingEditServiceIntegrationTestSuite) TestCreatePendingEdit_ArtistSuccess() {
+	user := s.createTestUser()
+	artist := s.createTestArtist("Old Name")
+
+	resp, err := s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "artist",
+		EntityID:   artist.ID,
+		UserID:     user.ID,
+		Changes:    makeChanges("name", "Old Name", "New Name"),
+		Summary:    "Fix artist name",
+	})
+
+	s.NoError(err)
+	s.Require().NotNil(resp)
+	s.Equal("artist", resp.EntityType)
+	s.Equal(artist.ID, resp.EntityID)
+	s.Equal(user.ID, resp.SubmittedBy)
+	s.Equal(models.PendingEditStatusPending, resp.Status)
+	s.Equal("Fix artist name", resp.Summary)
+	s.Len(resp.FieldChanges, 1)
+	s.Equal("name", resp.FieldChanges[0].Field)
+	s.NotEmpty(resp.SubmitterName)
+}
+
+func (s *PendingEditServiceIntegrationTestSuite) TestCreatePendingEdit_VenueSuccess() {
+	user := s.createTestUser()
+	venue := s.createTestVenue("Test Venue")
+
+	resp, err := s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "venue",
+		EntityID:   venue.ID,
+		UserID:     user.ID,
+		Changes: []models.FieldChange{
+			{Field: "name", OldValue: "Test Venue", NewValue: "The Test Venue"},
+			{Field: "city", OldValue: "Phoenix", NewValue: "Tempe"},
+		},
+		Summary: "Correct venue name and city",
+	})
+
+	s.NoError(err)
+	s.Require().NotNil(resp)
+	s.Equal("venue", resp.EntityType)
+	s.Len(resp.FieldChanges, 2)
+}
+
+func (s *PendingEditServiceIntegrationTestSuite) TestCreatePendingEdit_FestivalSuccess() {
+	user := s.createTestUser()
+	festival := s.createTestFestival("Fest 2026")
+
+	resp, err := s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "festival",
+		EntityID:   festival.ID,
+		UserID:     user.ID,
+		Changes:    makeChanges("description", "", "A great music festival"),
+		Summary:    "Add festival description",
+	})
+
+	s.NoError(err)
+	s.Require().NotNil(resp)
+	s.Equal("festival", resp.EntityType)
+}
+
+func (s *PendingEditServiceIntegrationTestSuite) TestCreatePendingEdit_InvalidEntityType() {
+	user := s.createTestUser()
+
+	_, err := s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "show",
+		EntityID:   1,
+		UserID:     user.ID,
+		Changes:    makeChanges("name", "a", "b"),
+		Summary:    "test",
+	})
+
+	s.Error(err)
+	s.Contains(err.Error(), "invalid entity type")
+}
+
+func (s *PendingEditServiceIntegrationTestSuite) TestCreatePendingEdit_EntityNotFound() {
+	user := s.createTestUser()
+
+	_, err := s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "artist",
+		EntityID:   99999,
+		UserID:     user.ID,
+		Changes:    makeChanges("name", "a", "b"),
+		Summary:    "test",
+	})
+
+	s.Error(err)
+	s.Contains(err.Error(), "entity not found")
+}
+
+func (s *PendingEditServiceIntegrationTestSuite) TestCreatePendingEdit_EmptyChanges() {
+	user := s.createTestUser()
+	artist := s.createTestArtist("Test")
+
+	_, err := s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "artist",
+		EntityID:   artist.ID,
+		UserID:     user.ID,
+		Changes:    []models.FieldChange{},
+		Summary:    "test",
+	})
+
+	s.Error(err)
+	s.Contains(err.Error(), "no changes provided")
+}
+
+func (s *PendingEditServiceIntegrationTestSuite) TestCreatePendingEdit_EmptySummary() {
+	user := s.createTestUser()
+	artist := s.createTestArtist("Test")
+
+	_, err := s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "artist",
+		EntityID:   artist.ID,
+		UserID:     user.ID,
+		Changes:    makeChanges("name", "a", "b"),
+		Summary:    "",
+	})
+
+	s.Error(err)
+	s.Contains(err.Error(), "summary is required")
+}
+
+func (s *PendingEditServiceIntegrationTestSuite) TestCreatePendingEdit_DuplicatePending() {
+	user := s.createTestUser()
+	artist := s.createTestArtist("Test")
+
+	// First edit succeeds
+	_, err := s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "artist",
+		EntityID:   artist.ID,
+		UserID:     user.ID,
+		Changes:    makeChanges("name", "Test", "Test2"),
+		Summary:    "First edit",
+	})
+	s.NoError(err)
+
+	// Second pending edit for same entity by same user fails
+	_, err = s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "artist",
+		EntityID:   artist.ID,
+		UserID:     user.ID,
+		Changes:    makeChanges("name", "Test", "Test3"),
+		Summary:    "Second edit",
+	})
+	s.Error(err)
+}
+
+func (s *PendingEditServiceIntegrationTestSuite) TestCreatePendingEdit_DifferentUsersSameEntity() {
+	user1 := s.createTestUser()
+	user2 := s.createTestUser()
+	artist := s.createTestArtist("Test")
+
+	// User 1 creates edit
+	_, err := s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "artist",
+		EntityID:   artist.ID,
+		UserID:     user1.ID,
+		Changes:    makeChanges("name", "Test", "Test2"),
+		Summary:    "User 1 edit",
+	})
+	s.NoError(err)
+
+	// User 2 can also create edit for same entity
+	_, err = s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "artist",
+		EntityID:   artist.ID,
+		UserID:     user2.ID,
+		Changes:    makeChanges("name", "Test", "Test3"),
+		Summary:    "User 2 edit",
+	})
+	s.NoError(err)
+}
+
+// =============================================================================
+// GetPendingEdit tests
+// =============================================================================
+
+func (s *PendingEditServiceIntegrationTestSuite) TestGetPendingEdit_Found() {
+	user := s.createTestUser()
+	artist := s.createTestArtist("Test")
+
+	created, err := s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "artist",
+		EntityID:   artist.ID,
+		UserID:     user.ID,
+		Changes:    makeChanges("name", "Test", "New"),
+		Summary:    "test",
+	})
+	s.Require().NoError(err)
+
+	resp, err := s.svc.GetPendingEdit(created.ID)
+	s.NoError(err)
+	s.Require().NotNil(resp)
+	s.Equal(created.ID, resp.ID)
+	s.Equal("artist", resp.EntityType)
+	s.NotEmpty(resp.SubmitterName)
+}
+
+func (s *PendingEditServiceIntegrationTestSuite) TestGetPendingEdit_NotFound() {
+	resp, err := s.svc.GetPendingEdit(99999)
+	s.NoError(err)
+	s.Nil(resp)
+}
+
+// =============================================================================
+// GetPendingEditsForEntity tests
+// =============================================================================
+
+func (s *PendingEditServiceIntegrationTestSuite) TestGetPendingEditsForEntity_Success() {
+	user1 := s.createTestUser()
+	user2 := s.createTestUser()
+	artist := s.createTestArtist("Test")
+
+	// Two users submit edits for the same artist
+	_, err := s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "artist", EntityID: artist.ID, UserID: user1.ID,
+		Changes: makeChanges("name", "Test", "A"), Summary: "edit 1",
+	})
+	s.Require().NoError(err)
+
+	_, err = s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "artist", EntityID: artist.ID, UserID: user2.ID,
+		Changes: makeChanges("name", "Test", "B"), Summary: "edit 2",
+	})
+	s.Require().NoError(err)
+
+	edits, err := s.svc.GetPendingEditsForEntity("artist", artist.ID)
+	s.NoError(err)
+	s.Len(edits, 2)
+}
+
+func (s *PendingEditServiceIntegrationTestSuite) TestGetPendingEditsForEntity_ExcludesNonPending() {
+	user := s.createTestUser()
+	reviewer := s.createTestUser()
+	artist := s.createTestArtist("Test")
+
+	created, err := s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "artist", EntityID: artist.ID, UserID: user.ID,
+		Changes: makeChanges("name", "Test", "Approved"), Summary: "will be approved",
+	})
+	s.Require().NoError(err)
+
+	// Approve the edit
+	_, err = s.svc.ApprovePendingEdit(created.ID, reviewer.ID)
+	s.Require().NoError(err)
+
+	// Only pending edits returned
+	edits, err := s.svc.GetPendingEditsForEntity("artist", artist.ID)
+	s.NoError(err)
+	s.Len(edits, 0)
+}
+
+// =============================================================================
+// GetUserPendingEdits tests
+// =============================================================================
+
+func (s *PendingEditServiceIntegrationTestSuite) TestGetUserPendingEdits_Success() {
+	user := s.createTestUser()
+	artist1 := s.createTestArtist("Artist 1")
+	artist2 := s.createTestArtist("Artist 2")
+
+	_, _ = s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "artist", EntityID: artist1.ID, UserID: user.ID,
+		Changes: makeChanges("name", "Artist 1", "A1"), Summary: "edit 1",
+	})
+	_, _ = s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "artist", EntityID: artist2.ID, UserID: user.ID,
+		Changes: makeChanges("name", "Artist 2", "A2"), Summary: "edit 2",
+	})
+
+	edits, total, err := s.svc.GetUserPendingEdits(user.ID, 10, 0)
+	s.NoError(err)
+	s.Equal(int64(2), total)
+	s.Len(edits, 2)
+}
+
+func (s *PendingEditServiceIntegrationTestSuite) TestGetUserPendingEdits_Pagination() {
+	user := s.createTestUser()
+	for i := 0; i < 5; i++ {
+		artist := s.createTestArtist(fmt.Sprintf("Artist %d", i))
+		_, _ = s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+			EntityType: "artist", EntityID: artist.ID, UserID: user.ID,
+			Changes: makeChanges("name", artist.Name, "new"), Summary: fmt.Sprintf("edit %d", i),
+		})
+	}
+
+	edits, total, err := s.svc.GetUserPendingEdits(user.ID, 2, 0)
+	s.NoError(err)
+	s.Equal(int64(5), total)
+	s.Len(edits, 2)
+
+	edits2, _, err := s.svc.GetUserPendingEdits(user.ID, 2, 2)
+	s.NoError(err)
+	s.Len(edits2, 2)
+	s.NotEqual(edits[0].ID, edits2[0].ID)
+}
+
+// =============================================================================
+// ListPendingEdits tests
+// =============================================================================
+
+func (s *PendingEditServiceIntegrationTestSuite) TestListPendingEdits_DefaultFilters() {
+	user := s.createTestUser()
+	artist := s.createTestArtist("Test")
+	venue := s.createTestVenue("Test Venue")
+
+	_, _ = s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "artist", EntityID: artist.ID, UserID: user.ID,
+		Changes: makeChanges("name", "Test", "A"), Summary: "artist edit",
+	})
+	_, _ = s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "venue", EntityID: venue.ID, UserID: user.ID,
+		Changes: makeChanges("name", "Test Venue", "V"), Summary: "venue edit",
+	})
+
+	edits, total, err := s.svc.ListPendingEdits(nil)
+	s.NoError(err)
+	s.Equal(int64(2), total)
+	s.Len(edits, 2)
+}
+
+func (s *PendingEditServiceIntegrationTestSuite) TestListPendingEdits_FilterByStatus() {
+	user := s.createTestUser()
+	reviewer := s.createTestUser()
+	artist := s.createTestArtist("Test")
+
+	created, _ := s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "artist", EntityID: artist.ID, UserID: user.ID,
+		Changes: makeChanges("name", "Test", "Approved"), Summary: "will approve",
+	})
+	_, _ = s.svc.ApprovePendingEdit(created.ID, reviewer.ID)
+
+	// Only pending
+	edits, total, err := s.svc.ListPendingEdits(&contracts.PendingEditFilters{Status: "pending"})
+	s.NoError(err)
+	s.Equal(int64(0), total)
+	s.Len(edits, 0)
+
+	// Only approved
+	edits, total, err = s.svc.ListPendingEdits(&contracts.PendingEditFilters{Status: "approved"})
+	s.NoError(err)
+	s.Equal(int64(1), total)
+	s.Len(edits, 1)
+}
+
+func (s *PendingEditServiceIntegrationTestSuite) TestListPendingEdits_FilterByEntityType() {
+	user := s.createTestUser()
+	artist := s.createTestArtist("Test")
+	venue := s.createTestVenue("Test Venue")
+
+	_, _ = s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "artist", EntityID: artist.ID, UserID: user.ID,
+		Changes: makeChanges("name", "Test", "A"), Summary: "artist",
+	})
+	_, _ = s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "venue", EntityID: venue.ID, UserID: user.ID,
+		Changes: makeChanges("name", "Test Venue", "V"), Summary: "venue",
+	})
+
+	edits, total, err := s.svc.ListPendingEdits(&contracts.PendingEditFilters{EntityType: "artist"})
+	s.NoError(err)
+	s.Equal(int64(1), total)
+	s.Len(edits, 1)
+	s.Equal("artist", edits[0].EntityType)
+}
+
+// =============================================================================
+// ApprovePendingEdit tests
+// =============================================================================
+
+func (s *PendingEditServiceIntegrationTestSuite) TestApprovePendingEdit_AppliesChangesToArtist() {
+	user := s.createTestUser()
+	reviewer := s.createTestUser()
+	artist := s.createTestArtist("Old Name")
+
+	created, err := s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "artist", EntityID: artist.ID, UserID: user.ID,
+		Changes: []models.FieldChange{
+			{Field: "name", OldValue: "Old Name", NewValue: "New Name"},
+			{Field: "city", OldValue: nil, NewValue: "Phoenix"},
+		},
+		Summary: "Update artist info",
+	})
+	s.Require().NoError(err)
+
+	resp, err := s.svc.ApprovePendingEdit(created.ID, reviewer.ID)
+	s.NoError(err)
+	s.Require().NotNil(resp)
+	s.Equal(models.PendingEditStatusApproved, resp.Status)
+	s.Require().NotNil(resp.ReviewedBy)
+	s.Equal(reviewer.ID, *resp.ReviewedBy)
+	s.NotNil(resp.ReviewedAt)
+
+	// Verify entity was updated
+	var updated models.Artist
+	s.db.First(&updated, artist.ID)
+	s.Equal("New Name", updated.Name)
+	s.Require().NotNil(updated.City)
+	s.Equal("Phoenix", *updated.City)
+}
+
+func (s *PendingEditServiceIntegrationTestSuite) TestApprovePendingEdit_AppliesChangesToVenue() {
+	user := s.createTestUser()
+	reviewer := s.createTestUser()
+	venue := s.createTestVenue("Old Venue")
+
+	created, err := s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "venue", EntityID: venue.ID, UserID: user.ID,
+		Changes: makeChanges("name", "Old Venue", "New Venue"),
+		Summary: "Fix venue name",
+	})
+	s.Require().NoError(err)
+
+	_, err = s.svc.ApprovePendingEdit(created.ID, reviewer.ID)
+	s.NoError(err)
+
+	var updated models.Venue
+	s.db.First(&updated, venue.ID)
+	s.Equal("New Venue", updated.Name)
+}
+
+func (s *PendingEditServiceIntegrationTestSuite) TestApprovePendingEdit_RecordsRevision() {
+	user := s.createTestUser()
+	reviewer := s.createTestUser()
+	artist := s.createTestArtist("Test")
+
+	created, _ := s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "artist", EntityID: artist.ID, UserID: user.ID,
+		Changes: makeChanges("name", "Test", "Updated"), Summary: "Update name",
+	})
+
+	_, err := s.svc.ApprovePendingEdit(created.ID, reviewer.ID)
+	s.NoError(err)
+
+	// Verify revision was created
+	var revision models.Revision
+	err = s.db.Where("entity_type = ? AND entity_id = ?", "artist", artist.ID).First(&revision).Error
+	s.NoError(err)
+	s.Equal(user.ID, revision.UserID) // Attributed to submitter, not reviewer
+	s.Require().NotNil(revision.Summary)
+	s.Equal("Update name", *revision.Summary)
+
+	var changes []models.FieldChange
+	s.Require().NoError(json.Unmarshal(*revision.FieldChanges, &changes))
+	s.Len(changes, 1)
+	s.Equal("name", changes[0].Field)
+}
+
+func (s *PendingEditServiceIntegrationTestSuite) TestApprovePendingEdit_NotFound() {
+	_, err := s.svc.ApprovePendingEdit(99999, 1)
+	s.Error(err)
+	s.Contains(err.Error(), "pending edit not found")
+}
+
+func (s *PendingEditServiceIntegrationTestSuite) TestApprovePendingEdit_AlreadyApproved() {
+	user := s.createTestUser()
+	reviewer := s.createTestUser()
+	artist := s.createTestArtist("Test")
+
+	created, _ := s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "artist", EntityID: artist.ID, UserID: user.ID,
+		Changes: makeChanges("name", "Test", "New"), Summary: "test",
+	})
+
+	_, _ = s.svc.ApprovePendingEdit(created.ID, reviewer.ID)
+
+	// Try to approve again
+	_, err := s.svc.ApprovePendingEdit(created.ID, reviewer.ID)
+	s.Error(err)
+	s.Contains(err.Error(), "not pending")
+}
+
+func (s *PendingEditServiceIntegrationTestSuite) TestApprovePendingEdit_EntityDeleted() {
+	user := s.createTestUser()
+	reviewer := s.createTestUser()
+	artist := s.createTestArtist("Will Delete")
+
+	created, _ := s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "artist", EntityID: artist.ID, UserID: user.ID,
+		Changes: makeChanges("name", "Will Delete", "New"), Summary: "test",
+	})
+
+	// Delete the entity
+	s.db.Delete(&artist)
+
+	// Approve should fail because entity is gone
+	_, err := s.svc.ApprovePendingEdit(created.ID, reviewer.ID)
+	s.Error(err)
+	s.Contains(err.Error(), "entity not found")
+}
+
+func (s *PendingEditServiceIntegrationTestSuite) TestApprovePendingEdit_AllowsNewPendingAfter() {
+	user := s.createTestUser()
+	reviewer := s.createTestUser()
+	artist := s.createTestArtist("Test")
+
+	// Create and approve first edit
+	created, _ := s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "artist", EntityID: artist.ID, UserID: user.ID,
+		Changes: makeChanges("name", "Test", "V2"), Summary: "first edit",
+	})
+	_, _ = s.svc.ApprovePendingEdit(created.ID, reviewer.ID)
+
+	// User can now submit another pending edit for same entity
+	resp, err := s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "artist", EntityID: artist.ID, UserID: user.ID,
+		Changes: makeChanges("name", "V2", "V3"), Summary: "second edit",
+	})
+	s.NoError(err)
+	s.NotNil(resp)
+}
+
+// =============================================================================
+// RejectPendingEdit tests
+// =============================================================================
+
+func (s *PendingEditServiceIntegrationTestSuite) TestRejectPendingEdit_Success() {
+	user := s.createTestUser()
+	reviewer := s.createTestUser()
+	artist := s.createTestArtist("Test")
+
+	created, _ := s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "artist", EntityID: artist.ID, UserID: user.ID,
+		Changes: makeChanges("name", "Test", "Bad Name"), Summary: "bad edit",
+	})
+
+	resp, err := s.svc.RejectPendingEdit(created.ID, reviewer.ID, "Name doesn't follow our naming conventions")
+	s.NoError(err)
+	s.Require().NotNil(resp)
+	s.Equal(models.PendingEditStatusRejected, resp.Status)
+	s.Require().NotNil(resp.RejectionReason)
+	s.Equal("Name doesn't follow our naming conventions", *resp.RejectionReason)
+	s.Require().NotNil(resp.ReviewedBy)
+	s.Equal(reviewer.ID, *resp.ReviewedBy)
+
+	// Verify entity was NOT changed
+	var artist2 models.Artist
+	s.db.First(&artist2, artist.ID)
+	s.Equal("Test", artist2.Name)
+}
+
+func (s *PendingEditServiceIntegrationTestSuite) TestRejectPendingEdit_EmptyReason() {
+	user := s.createTestUser()
+	reviewer := s.createTestUser()
+	artist := s.createTestArtist("Test")
+
+	created, _ := s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "artist", EntityID: artist.ID, UserID: user.ID,
+		Changes: makeChanges("name", "Test", "X"), Summary: "test",
+	})
+
+	_, err := s.svc.RejectPendingEdit(created.ID, reviewer.ID, "")
+	s.Error(err)
+	s.Contains(err.Error(), "rejection reason is required")
+}
+
+func (s *PendingEditServiceIntegrationTestSuite) TestRejectPendingEdit_NotFound() {
+	_, err := s.svc.RejectPendingEdit(99999, 1, "reason")
+	s.Error(err)
+	s.Contains(err.Error(), "pending edit not found")
+}
+
+func (s *PendingEditServiceIntegrationTestSuite) TestRejectPendingEdit_AllowsNewPendingAfter() {
+	user := s.createTestUser()
+	reviewer := s.createTestUser()
+	artist := s.createTestArtist("Test")
+
+	created, _ := s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "artist", EntityID: artist.ID, UserID: user.ID,
+		Changes: makeChanges("name", "Test", "Bad"), Summary: "bad edit",
+	})
+	_, _ = s.svc.RejectPendingEdit(created.ID, reviewer.ID, "bad name")
+
+	// User can submit a new edit after rejection
+	resp, err := s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "artist", EntityID: artist.ID, UserID: user.ID,
+		Changes: makeChanges("name", "Test", "Better"), Summary: "improved edit",
+	})
+	s.NoError(err)
+	s.NotNil(resp)
+}
+
+// =============================================================================
+// CancelPendingEdit tests
+// =============================================================================
+
+func (s *PendingEditServiceIntegrationTestSuite) TestCancelPendingEdit_Success() {
+	user := s.createTestUser()
+	artist := s.createTestArtist("Test")
+
+	created, _ := s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "artist", EntityID: artist.ID, UserID: user.ID,
+		Changes: makeChanges("name", "Test", "New"), Summary: "will cancel",
+	})
+
+	err := s.svc.CancelPendingEdit(created.ID, user.ID)
+	s.NoError(err)
+
+	// Verify it's deleted
+	resp, err := s.svc.GetPendingEdit(created.ID)
+	s.NoError(err)
+	s.Nil(resp)
+}
+
+func (s *PendingEditServiceIntegrationTestSuite) TestCancelPendingEdit_WrongUser() {
+	user := s.createTestUser()
+	otherUser := s.createTestUser()
+	artist := s.createTestArtist("Test")
+
+	created, _ := s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "artist", EntityID: artist.ID, UserID: user.ID,
+		Changes: makeChanges("name", "Test", "New"), Summary: "test",
+	})
+
+	err := s.svc.CancelPendingEdit(created.ID, otherUser.ID)
+	s.Error(err)
+	s.Contains(err.Error(), "only the submitter")
+}
+
+func (s *PendingEditServiceIntegrationTestSuite) TestCancelPendingEdit_NotFound() {
+	err := s.svc.CancelPendingEdit(99999, 1)
+	s.Error(err)
+	s.Contains(err.Error(), "pending edit not found")
+}
+
+func (s *PendingEditServiceIntegrationTestSuite) TestCancelPendingEdit_AlreadyApproved() {
+	user := s.createTestUser()
+	reviewer := s.createTestUser()
+	artist := s.createTestArtist("Test")
+
+	created, _ := s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "artist", EntityID: artist.ID, UserID: user.ID,
+		Changes: makeChanges("name", "Test", "New"), Summary: "test",
+	})
+	_, _ = s.svc.ApprovePendingEdit(created.ID, reviewer.ID)
+
+	err := s.svc.CancelPendingEdit(created.ID, user.ID)
+	s.Error(err)
+	s.Contains(err.Error(), "not pending")
+}
+
+func (s *PendingEditServiceIntegrationTestSuite) TestCancelPendingEdit_AllowsNewPendingAfter() {
+	user := s.createTestUser()
+	artist := s.createTestArtist("Test")
+
+	created, _ := s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "artist", EntityID: artist.ID, UserID: user.ID,
+		Changes: makeChanges("name", "Test", "V1"), Summary: "will cancel",
+	})
+	_ = s.svc.CancelPendingEdit(created.ID, user.ID)
+
+	// User can create a new pending edit
+	resp, err := s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "artist", EntityID: artist.ID, UserID: user.ID,
+		Changes: makeChanges("name", "Test", "V2"), Summary: "new edit",
+	})
+	s.NoError(err)
+	s.NotNil(resp)
+}
+
+// =============================================================================
+// displayName helper tests
+// =============================================================================
+
+func TestDisplayName(t *testing.T) {
+	username := "testuser"
+	first := "John"
+	last := "Doe"
+	email := "john@test.com"
+
+	t.Run("PreferUsername", func(t *testing.T) {
+		u := &models.User{Username: &username, FirstName: &first, Email: &email}
+		assert.Equal(t, "testuser", displayName(u))
+	})
+
+	t.Run("FallbackToFirstLast", func(t *testing.T) {
+		u := &models.User{FirstName: &first, LastName: &last, Email: &email}
+		assert.Equal(t, "John Doe", displayName(u))
+	})
+
+	t.Run("FallbackToFirstOnly", func(t *testing.T) {
+		u := &models.User{FirstName: &first, Email: &email}
+		assert.Equal(t, "John", displayName(u))
+	})
+
+	t.Run("FallbackToEmail", func(t *testing.T) {
+		u := &models.User{Email: &email}
+		assert.Equal(t, "john@test.com", displayName(u))
+	})
+
+	t.Run("EmptyUser", func(t *testing.T) {
+		u := &models.User{}
+		assert.Equal(t, "", displayName(u))
+	})
+}

--- a/backend/internal/services/container.go
+++ b/backend/internal/services/container.go
@@ -25,6 +25,7 @@ type ServiceContainer struct {
 	APIToken           *adminsvc.APITokenService
 	DataQuality        *adminsvc.DataQualityService
 	Revision           *adminsvc.RevisionService
+	PendingEdit        *adminsvc.PendingEditService
 	Charts             *catalog.ChartsService
 	Artist             *catalog.ArtistService
 	ContributorProfile *usersvc.ContributorProfileService
@@ -120,13 +121,16 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 	// Wire enrichment queuing into discovery service (fire-and-forget after imports)
 	discovery.SetEnrichmentService(enrichmentSvc)
 
+	revisionSvc := adminsvc.NewRevisionService(database)
+
 	return &ServiceContainer{
 		// DB-only leaf services
 		AdminStats:         adminsvc.NewAdminStatsService(database),
 		Analytics:          adminsvc.NewAnalyticsService(database),
 		APIToken:           adminsvc.NewAPITokenService(database),
 		DataQuality:        adminsvc.NewDataQualityService(database),
-		Revision:           adminsvc.NewRevisionService(database),
+		Revision:           revisionSvc,
+		PendingEdit:        adminsvc.NewPendingEditService(database, revisionSvc),
 		Charts:             catalog.NewChartsService(database),
 		Artist:             artist,
 		ContributorProfile: usersvc.NewContributorProfileService(database),

--- a/backend/internal/services/contracts/pending_edit.go
+++ b/backend/internal/services/contracts/pending_edit.go
@@ -1,0 +1,77 @@
+package contracts
+
+import (
+	"time"
+
+	"psychic-homily-backend/internal/models"
+)
+
+// ──────────────────────────────────────────────
+// Pending Edit Service Interface
+// ──────────────────────────────────────────────
+
+// PendingEditServiceInterface defines the contract for managing pending entity edits.
+type PendingEditServiceInterface interface {
+	// CreatePendingEdit submits a new pending edit for an entity.
+	CreatePendingEdit(req *CreatePendingEditRequest) (*PendingEditResponse, error)
+
+	// GetPendingEdit returns a single pending edit by ID.
+	GetPendingEdit(editID uint) (*PendingEditResponse, error)
+
+	// GetPendingEditsForEntity returns all pending edits for a specific entity.
+	GetPendingEditsForEntity(entityType string, entityID uint) ([]PendingEditResponse, error)
+
+	// GetUserPendingEdits returns all pending edits submitted by a user.
+	GetUserPendingEdits(userID uint, limit, offset int) ([]PendingEditResponse, int64, error)
+
+	// ListPendingEdits returns pending edits for the admin review queue.
+	ListPendingEdits(filters *PendingEditFilters) ([]PendingEditResponse, int64, error)
+
+	// ApprovePendingEdit approves a pending edit, applying changes to the entity.
+	ApprovePendingEdit(editID uint, reviewerID uint) (*PendingEditResponse, error)
+
+	// RejectPendingEdit rejects a pending edit with a reason.
+	RejectPendingEdit(editID uint, reviewerID uint, reason string) (*PendingEditResponse, error)
+
+	// CancelPendingEdit allows the submitter to cancel their own pending edit.
+	CancelPendingEdit(editID uint, userID uint) error
+}
+
+// ──────────────────────────────────────────────
+// Request / Response Types
+// ──────────────────────────────────────────────
+
+// CreatePendingEditRequest contains the data needed to submit a pending edit.
+type CreatePendingEditRequest struct {
+	EntityType string               `json:"entity_type"`
+	EntityID   uint                 `json:"entity_id"`
+	UserID     uint                 `json:"-"`
+	Changes    []models.FieldChange `json:"changes"`
+	Summary    string               `json:"summary"`
+}
+
+// PendingEditFilters contains filters for listing pending edits.
+type PendingEditFilters struct {
+	Status     string `json:"status,omitempty"`      // "pending", "approved", "rejected"
+	EntityType string `json:"entity_type,omitempty"` // "artist", "venue", "festival"
+	Limit      int    `json:"limit,omitempty"`
+	Offset     int    `json:"offset,omitempty"`
+}
+
+// PendingEditResponse is the API response for a pending entity edit.
+type PendingEditResponse struct {
+	ID              uint                   `json:"id"`
+	EntityType      string                 `json:"entity_type"`
+	EntityID        uint                   `json:"entity_id"`
+	SubmittedBy     uint                   `json:"submitted_by"`
+	SubmitterName   string                 `json:"submitter_name,omitempty"`
+	FieldChanges    []models.FieldChange   `json:"field_changes"`
+	Summary         string                 `json:"summary"`
+	Status          models.PendingEditStatus `json:"status"`
+	ReviewedBy      *uint                  `json:"reviewed_by,omitempty"`
+	ReviewerName    string                 `json:"reviewer_name,omitempty"`
+	ReviewedAt      *time.Time             `json:"reviewed_at,omitempty"`
+	RejectionReason *string                `json:"rejection_reason,omitempty"`
+	CreatedAt       time.Time              `json:"created_at"`
+	UpdatedAt       time.Time              `json:"updated_at"`
+}


### PR DESCRIPTION
## Summary

- **PSY-125**: Generic `pending_entity_edits` table (migration 000061) with JSONB `field_changes`, replacing the per-entity approach. `PendingEditService` with Create, Get, List, Approve, Reject, Cancel. Approve applies changes transactionally and records revision (fire-and-forget). 52 tests.
- **PSY-126**: 10 API endpoints — 3 suggest-edit (artist/venue/festival), 2 user self-service (list/cancel), 5 admin (list/get/approve/reject/entity). Trust-tiered auto-approve for `trusted_contributor`+. Field validation rejects admin-only fields. 35+ handler tests.

## Test plan

- [x] Service integration tests pass (52 tests with testcontainers)
- [x] Handler unit tests pass (35+ tests)
- [x] Full `go build ./...` compiles clean
- [ ] Manual test: new_user submits edit → goes to pending queue
- [ ] Manual test: trusted_contributor submits edit → auto-applied
- [ ] Manual test: admin approves/rejects pending edit
- [ ] Manual test: user cancels own pending edit

Closes PSY-125
Closes PSY-126

🤖 Generated with [Claude Code](https://claude.com/claude-code)