### PR TITLE
"Last edited by" attribution on entity detail pages (PSY-136)

### DIFF
--- a/frontend/features/artists/components/ArtistDetail.tsx
+++ b/frontend/features/artists/components/ArtistDetail.tsx
@@ -35,7 +35,7 @@ import { SocialLinks, MusicEmbed, EntityDetailLayout, EntityHeader, RevisionHist
 import { ArtistTrajectoryChart } from '@/features/festivals/components/ArtistTrajectoryChart'
 import { EntityTagList } from '@/features/tags'
 import { ArtistEditForm } from '@/components/forms/ArtistEditForm'
-import { EntityEditDrawer } from '@/features/contributions'
+import { EntityEditDrawer, AttributionLine } from '@/features/contributions'
 import { NotifyMeButton } from '@/features/notifications'
 import { ArtistShowsList } from './ArtistShowsList'
 import { RelatedArtists } from './RelatedArtists'
@@ -938,11 +938,14 @@ export function ArtistDetail({ artistId }: ArtistDetailProps) {
         fallback={{ href: '/artists', label: 'Artists' }}
         entityName={artist.name}
         header={
-          <EntityHeader
-            title={artist.name}
-            subtitle={headerSubtitle}
-            actions={headerActions}
-          />
+          <>
+            <EntityHeader
+              title={artist.name}
+              subtitle={headerSubtitle}
+              actions={headerActions}
+            />
+            <AttributionLine entityType="artist" entityId={artist.id} />
+          </>
         }
         tabs={tabs}
         activeTab={activeTab}

--- a/frontend/features/contributions/components/AttributionLine.test.tsx
+++ b/frontend/features/contributions/components/AttributionLine.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { AttributionLine } from './AttributionLine'
+
+// --- Mocks ---
+
+const mockUseEntityAttribution = vi.fn()
+
+vi.mock('../hooks/useEntityAttribution', () => ({
+  useEntityAttribution: (...args: unknown[]) => mockUseEntityAttribution(...args),
+}))
+
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...props }: { children: React.ReactNode; href: string; [key: string]: unknown }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}))
+
+describe('AttributionLine', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders nothing when no attribution data', () => {
+    mockUseEntityAttribution.mockReturnValue({ data: null })
+    const { container } = render(
+      <AttributionLine entityType="artist" entityId={42} />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders "Last edited by" with username', () => {
+    mockUseEntityAttribution.mockReturnValue({
+      data: {
+        userName: 'alice',
+        createdAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+      },
+    })
+    render(<AttributionLine entityType="artist" entityId={42} />)
+    expect(screen.getByText('alice')).toBeInTheDocument()
+    expect(screen.getByText(/Last edited by/)).toBeInTheDocument()
+  })
+
+  it('links username to profile page', () => {
+    mockUseEntityAttribution.mockReturnValue({
+      data: {
+        userName: 'alice',
+        createdAt: new Date().toISOString(),
+      },
+    })
+    render(<AttributionLine entityType="artist" entityId={42} />)
+    const link = screen.getByText('alice').closest('a')
+    expect(link).toHaveAttribute('href', '/users/alice')
+  })
+
+  it('shows relative time for recent edits', () => {
+    mockUseEntityAttribution.mockReturnValue({
+      data: {
+        userName: 'bob',
+        createdAt: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
+      },
+    })
+    render(<AttributionLine entityType="venue" entityId={10} />)
+    expect(screen.getByText(/3 days ago/)).toBeInTheDocument()
+  })
+
+  it('shows "just now" for very recent edits', () => {
+    mockUseEntityAttribution.mockReturnValue({
+      data: {
+        userName: 'carol',
+        createdAt: new Date(Date.now() - 10 * 1000).toISOString(),
+      },
+    })
+    render(<AttributionLine entityType="festival" entityId={5} />)
+    expect(screen.getByText(/just now/)).toBeInTheDocument()
+  })
+
+  it('shows hours for edits a few hours ago', () => {
+    mockUseEntityAttribution.mockReturnValue({
+      data: {
+        userName: 'dave',
+        createdAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+      },
+    })
+    render(<AttributionLine entityType="artist" entityId={1} />)
+    expect(screen.getByText(/2 hours ago/)).toBeInTheDocument()
+  })
+
+  it('shows date for edits older than 30 days', () => {
+    mockUseEntityAttribution.mockReturnValue({
+      data: {
+        userName: 'eve',
+        createdAt: '2025-01-15T12:00:00Z',
+      },
+    })
+    render(<AttributionLine entityType="artist" entityId={1} />)
+    // Should show a formatted date like "Jan 15, 2025"
+    expect(screen.getByText(/Jan 15, 2025/)).toBeInTheDocument()
+  })
+
+  it('passes entity type and id to hook', () => {
+    mockUseEntityAttribution.mockReturnValue({ data: null })
+    render(<AttributionLine entityType="venue" entityId={99} />)
+    expect(mockUseEntityAttribution).toHaveBeenCalledWith('venue', 99)
+  })
+
+  it('has muted styling', () => {
+    mockUseEntityAttribution.mockReturnValue({
+      data: {
+        userName: 'testuser',
+        createdAt: new Date().toISOString(),
+      },
+    })
+    const { container } = render(
+      <AttributionLine entityType="artist" entityId={1} />
+    )
+    const p = container.querySelector('p')
+    expect(p).toHaveClass('text-xs', 'text-muted-foreground')
+  })
+})

--- a/frontend/features/contributions/components/AttributionLine.tsx
+++ b/frontend/features/contributions/components/AttributionLine.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import Link from 'next/link'
+import { useEntityAttribution } from '../hooks/useEntityAttribution'
+
+interface AttributionLineProps {
+  entityType: string
+  entityId: string | number
+}
+
+/**
+ * Format a timestamp into a relative time string.
+ */
+function formatRelativeTime(dateStr: string): string {
+  const date = new Date(dateStr)
+  const now = new Date()
+  const diffMs = now.getTime() - date.getTime()
+  const diffSec = Math.floor(diffMs / 1000)
+  const diffMin = Math.floor(diffSec / 60)
+  const diffHr = Math.floor(diffMin / 60)
+  const diffDays = Math.floor(diffHr / 24)
+
+  if (diffSec < 60) return 'just now'
+  if (diffMin < 60) return `${diffMin} minute${diffMin === 1 ? '' : 's'} ago`
+  if (diffHr < 24) return `${diffHr} hour${diffHr === 1 ? '' : 's'} ago`
+  if (diffDays < 30) return `${diffDays} day${diffDays === 1 ? '' : 's'} ago`
+
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+}
+
+/**
+ * Displays "Last edited by [username] · [relative time]" for an entity.
+ * Fetches the most recent revision and renders a small attribution line.
+ * Returns null if no revisions exist or data is still loading.
+ */
+export function AttributionLine({ entityType, entityId }: AttributionLineProps) {
+  const { data: attribution } = useEntityAttribution(entityType, entityId)
+
+  if (!attribution) {
+    return null
+  }
+
+  return (
+    <p className="text-xs text-muted-foreground">
+      Last edited by{' '}
+      <Link
+        href={`/users/${attribution.userName}`}
+        className="hover:underline"
+      >
+        {attribution.userName}
+      </Link>
+      {' '}&middot;{' '}
+      {formatRelativeTime(attribution.createdAt)}
+    </p>
+  )
+}

--- a/frontend/features/contributions/hooks/index.ts
+++ b/frontend/features/contributions/hooks/index.ts
@@ -1,3 +1,5 @@
 export { useSuggestEdit } from './useSuggestEdit'
 export { useMyPendingEdits } from './useMyPendingEdits'
 export { useCancelPendingEdit } from './useCancelPendingEdit'
+export { useEntityAttribution } from './useEntityAttribution'
+export type { EntityAttribution } from './useEntityAttribution'

--- a/frontend/features/contributions/hooks/useEntityAttribution.ts
+++ b/frontend/features/contributions/hooks/useEntityAttribution.ts
@@ -1,0 +1,48 @@
+import { useQuery } from '@tanstack/react-query'
+import { apiRequest, API_ENDPOINTS } from '@/lib/api'
+import { queryKeys } from '@/lib/queryClient'
+
+interface RevisionItem {
+  id: number
+  user_id: number
+  user_name?: string
+  created_at: string
+}
+
+interface EntityHistoryResponse {
+  revisions: RevisionItem[]
+  total: number
+}
+
+export interface EntityAttribution {
+  userName: string
+  createdAt: string
+}
+
+/**
+ * Fetches the most recent revision for an entity to show "Last edited by" attribution.
+ * Returns the most recent editor's username and timestamp.
+ * Returns null data if no revisions exist.
+ */
+export function useEntityAttribution(
+  entityType: string,
+  entityId: string | number,
+  options?: { enabled?: boolean }
+) {
+  return useQuery({
+    queryKey: [...queryKeys.revisions.entity(entityType, entityId), { attribution: true }],
+    queryFn: async (): Promise<EntityAttribution | null> => {
+      const url = `${API_ENDPOINTS.REVISIONS.ENTITY_HISTORY(entityType, entityId)}?limit=1&offset=0`
+      const data = await apiRequest<EntityHistoryResponse>(url)
+      if (!data.revisions || data.revisions.length === 0) {
+        return null
+      }
+      const revision = data.revisions[0]
+      return {
+        userName: revision.user_name || `User #${revision.user_id}`,
+        createdAt: revision.created_at,
+      }
+    },
+    enabled: options?.enabled !== false,
+  })
+}

--- a/frontend/features/contributions/index.ts
+++ b/frontend/features/contributions/index.ts
@@ -11,7 +11,9 @@ export type {
 export { EDITABLE_FIELDS } from './types'
 
 // Hooks
-export { useSuggestEdit, useMyPendingEdits, useCancelPendingEdit } from './hooks'
+export { useSuggestEdit, useMyPendingEdits, useCancelPendingEdit, useEntityAttribution } from './hooks'
+export type { EntityAttribution } from './hooks'
 
 // Components
 export { EntityEditDrawer } from './components/EntityEditDrawer'
+export { AttributionLine } from './components/AttributionLine'

--- a/frontend/features/festivals/components/FestivalDetail.tsx
+++ b/frontend/features/festivals/components/FestivalDetail.tsx
@@ -33,7 +33,7 @@ import {
   formatFestivalDateRange,
 } from '../types'
 import { useIsAuthenticated } from '@/features/auth'
-import { EntityEditDrawer } from '@/features/contributions'
+import { EntityEditDrawer, AttributionLine } from '@/features/contributions'
 import { useQueryClient } from '@tanstack/react-query'
 
 interface FestivalDetailProps {
@@ -266,42 +266,45 @@ export function FestivalDetail({ idOrSlug }: FestivalDetailProps) {
       fallback={{ href: '/festivals', label: 'Festivals' }}
       entityName={festival.name}
       header={
-        <EntityHeader
-          title={festival.name}
-          subtitle={
-            <>
-              <Badge variant={getFestivalStatusVariant(festival.status)}>
-                {getFestivalStatusLabel(festival.status)}
-              </Badge>
-              <span className="flex items-center gap-1">
-                <Calendar className="h-3.5 w-3.5" />
-                {dateRange}
-              </span>
-              {location && (
+        <>
+          <EntityHeader
+            title={festival.name}
+            subtitle={
+              <>
+                <Badge variant={getFestivalStatusVariant(festival.status)}>
+                  {getFestivalStatusLabel(festival.status)}
+                </Badge>
                 <span className="flex items-center gap-1">
-                  <MapPin className="h-3.5 w-3.5" />
-                  {location}
+                  <Calendar className="h-3.5 w-3.5" />
+                  {dateRange}
                 </span>
-              )}
-            </>
-          }
-          actions={
-            <div className="flex items-center gap-2">
-              {isAuthenticated && (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setIsEditing(true)}
-                  className="text-muted-foreground hover:text-foreground"
-                  title={canEditDirectly ? 'Edit' : 'Suggest Edit'}
-                >
-                  <Edit2 className="h-4 w-4" />
-                </Button>
-              )}
-              <FollowButton entityType="festivals" entityId={festival.id} />
-            </div>
-          }
-        />
+                {location && (
+                  <span className="flex items-center gap-1">
+                    <MapPin className="h-3.5 w-3.5" />
+                    {location}
+                  </span>
+                )}
+              </>
+            }
+            actions={
+              <div className="flex items-center gap-2">
+                {isAuthenticated && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setIsEditing(true)}
+                    className="text-muted-foreground hover:text-foreground"
+                    title={canEditDirectly ? 'Edit' : 'Suggest Edit'}
+                  >
+                    <Edit2 className="h-4 w-4" />
+                  </Button>
+                )}
+                <FollowButton entityType="festivals" entityId={festival.id} />
+              </div>
+            }
+          />
+          <AttributionLine entityType="festival" entityId={festival.id} />
+        </>
       }
       tabs={tabs}
       activeTab={activeTab}

--- a/frontend/features/venues/components/VenueDetail.test.tsx
+++ b/frontend/features/venues/components/VenueDetail.test.tsx
@@ -115,6 +115,7 @@ vi.mock('@/components/forms/VenueEditForm', () => ({
 vi.mock('@/features/contributions', () => ({
   EntityEditDrawer: ({ open }: { open: boolean }) =>
     open ? <div data-testid="edit-drawer">Edit Drawer</div> : null,
+  AttributionLine: () => null,
 }))
 
 vi.mock('./DeleteVenueDialog', () => ({

--- a/frontend/features/venues/components/VenueDetail.tsx
+++ b/frontend/features/venues/components/VenueDetail.tsx
@@ -15,7 +15,7 @@ import { NotifyMeButton } from '@/features/notifications'
 import { VenueLocationCard } from './VenueLocationCard'
 import { VenueShowsList } from './VenueShowsList'
 import { VenueEditForm } from '@/components/forms/VenueEditForm'
-import { EntityEditDrawer } from '@/features/contributions'
+import { EntityEditDrawer, AttributionLine } from '@/features/contributions'
 import { DeleteVenueDialog } from './DeleteVenueDialog'
 import { FavoriteVenueButton } from './FavoriteVenueButton'
 import { Button } from '@/components/ui/button'
@@ -200,6 +200,9 @@ export function VenueDetail({ venueId }: VenueDetailProps) {
                     <ExternalLink className="h-3 w-3" />
                   </a>
                 )}
+                <div className="mt-1">
+                  <AttributionLine entityType="venue" entityId={venue.id} />
+                </div>
               </div>
 
               {isAuthenticated && (


### PR DESCRIPTION
## Summary

- New `AttributionLine` component showing "Last edited by [username] · [time ago]" on entity detail pages
- New `useEntityAttribution` hook that fetches the most recent revision via the existing revisions endpoint (`limit=1`)
- Integrated into ArtistDetail, VenueDetail, and FestivalDetail header areas
- Username links to contributor profile (`/users/[username]`)
- Gracefully renders nothing when no revisions exist
- 9 component tests covering display, linking, and relative time formatting

## Test plan

- [ ] Artist detail shows "Last edited by [name] · [time]" after an edit
- [ ] Venue detail shows attribution
- [ ] Festival detail shows attribution
- [ ] No attribution shown for entities with no revision history
- [ ] Username links to `/users/[username]`

Closes PSY-136

🤖 Generated with [Claude Code](https://claude.com/claude-code)