### PR TITLE
Generalized entity reports — model, service, handlers (PSY-130)

### DIFF
--- a/backend/db/migrations/000062_create_entity_reports.down.sql
+++ b/backend/db/migrations/000062_create_entity_reports.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS entity_reports;

--- a/backend/db/migrations/000062_create_entity_reports.up.sql
+++ b/backend/db/migrations/000062_create_entity_reports.up.sql
@@ -1,0 +1,22 @@
+-- Create the generic entity_reports table.
+-- Replaces the need for per-entity report tables (show_reports, artist_reports, etc.)
+-- by using entity_type + entity_id polymorphism — same pattern as pending_entity_edits.
+
+CREATE TABLE entity_reports (
+    id BIGSERIAL PRIMARY KEY,
+    entity_type VARCHAR(50) NOT NULL,
+    entity_id BIGINT NOT NULL,
+    reported_by BIGINT NOT NULL REFERENCES users(id),
+    report_type VARCHAR(50) NOT NULL,
+    details TEXT,
+    status VARCHAR(20) NOT NULL DEFAULT 'pending',
+    admin_notes TEXT,
+    reviewed_by BIGINT REFERENCES users(id),
+    reviewed_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Indexes
+CREATE INDEX idx_entity_reports_entity ON entity_reports (entity_type, entity_id);
+CREATE INDEX idx_entity_reports_status_created ON entity_reports (status, created_at);
+CREATE INDEX idx_entity_reports_reported_by ON entity_reports (reported_by);

--- a/backend/internal/api/handlers/entity_report.go
+++ b/backend/internal/api/handlers/entity_report.go
@@ -1,0 +1,336 @@
+package handlers
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"psychic-homily-backend/internal/api/middleware"
+	"psychic-homily-backend/internal/logger"
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// EntityReportHandler handles entity report API endpoints.
+type EntityReportHandler struct {
+	entityReportService contracts.EntityReportServiceInterface
+	auditLogService     contracts.AuditLogServiceInterface
+}
+
+// NewEntityReportHandler creates a new entity report handler.
+func NewEntityReportHandler(
+	entityReportService contracts.EntityReportServiceInterface,
+	auditLogService contracts.AuditLogServiceInterface,
+) *EntityReportHandler {
+	return &EntityReportHandler{
+		entityReportService: entityReportService,
+		auditLogService:     auditLogService,
+	}
+}
+
+// ============================================================================
+// User: Report an entity — POST /{entity_type}/{entity_id}/report
+// ============================================================================
+
+// ReportEntityRequest is the Huma request for POST /{entity_type}/{entity_id}/report
+type ReportEntityRequest struct {
+	EntityID string `path:"entity_id" doc:"Entity ID"`
+	Body     struct {
+		ReportType string  `json:"report_type" doc:"Type of report"`
+		Details    *string `json:"details" required:"false" doc:"Optional details about the issue"`
+	}
+}
+
+// ReportEntityResponse is the Huma response for POST /{entity_type}/{entity_id}/report
+type ReportEntityResponse struct {
+	Body *contracts.EntityReportResponse
+}
+
+// ReportArtistHandler handles POST /artists/{entity_id}/report
+func (h *EntityReportHandler) ReportArtistHandler(ctx context.Context, req *ReportEntityRequest) (*ReportEntityResponse, error) {
+	return h.reportEntity(ctx, "artist", req)
+}
+
+// ReportVenueHandler handles POST /venues/{entity_id}/report
+func (h *EntityReportHandler) ReportVenueHandler(ctx context.Context, req *ReportEntityRequest) (*ReportEntityResponse, error) {
+	return h.reportEntity(ctx, "venue", req)
+}
+
+// ReportFestivalHandler handles POST /festivals/{entity_id}/report
+func (h *EntityReportHandler) ReportFestivalHandler(ctx context.Context, req *ReportEntityRequest) (*ReportEntityResponse, error) {
+	return h.reportEntity(ctx, "festival", req)
+}
+
+// ReportShowHandler handles POST /shows/{entity_id}/report
+func (h *EntityReportHandler) ReportShowHandler(ctx context.Context, req *ReportEntityRequest) (*ReportEntityResponse, error) {
+	return h.reportEntity(ctx, "show", req)
+}
+
+// reportEntity is the shared implementation for all report endpoints.
+func (h *EntityReportHandler) reportEntity(ctx context.Context, entityType string, req *ReportEntityRequest) (*ReportEntityResponse, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	entityID, err := strconv.ParseUint(req.EntityID, 10, 64)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid entity ID")
+	}
+
+	reportType := strings.TrimSpace(req.Body.ReportType)
+	if reportType == "" {
+		return nil, huma.Error400BadRequest("Report type is required")
+	}
+
+	if !models.IsValidReportType(entityType, reportType) {
+		return nil, huma.Error400BadRequest("Invalid report type '" + reportType + "' for " + entityType)
+	}
+
+	report, err := h.entityReportService.CreateEntityReport(&contracts.CreateEntityReportRequest{
+		EntityType: entityType,
+		EntityID:   uint(entityID),
+		UserID:     user.ID,
+		ReportType: reportType,
+		Details:    req.Body.Details,
+	})
+	if err != nil {
+		if strings.Contains(err.Error(), "entity not found") {
+			return nil, huma.Error404NotFound(err.Error())
+		}
+		if strings.Contains(err.Error(), "already have a pending report") {
+			return nil, huma.Error409Conflict(err.Error())
+		}
+		logger.FromContext(ctx).Error("entity_report_create_failed",
+			"user_id", user.ID,
+			"entity_type", entityType,
+			"entity_id", entityID,
+			"error", err.Error(),
+		)
+		return nil, huma.Error500InternalServerError("Failed to create report")
+	}
+
+	// Fire-and-forget audit log
+	if h.auditLogService != nil {
+		go h.auditLogService.LogAction(user.ID, "report_"+entityType, entityType, uint(entityID), map[string]interface{}{
+			"report_id":   report.ID,
+			"report_type": reportType,
+		})
+	}
+
+	return &ReportEntityResponse{Body: report}, nil
+}
+
+// ============================================================================
+// Admin: List Entity Reports — GET /admin/entity-reports
+// ============================================================================
+
+// AdminListEntityReportsRequest is the Huma request for GET /admin/entity-reports
+type AdminListEntityReportsRequest struct {
+	Status     string `query:"status" required:"false" doc:"Filter by status (pending, resolved, dismissed)"`
+	EntityType string `query:"entity_type" required:"false" doc:"Filter by entity type (artist, venue, festival, show)"`
+	Limit      int    `query:"limit" required:"false" doc:"Max results (default 20, max 100)"`
+	Offset     int    `query:"offset" required:"false" doc:"Offset for pagination"`
+}
+
+// AdminListEntityReportsResponse is the Huma response for GET /admin/entity-reports
+type AdminListEntityReportsResponse struct {
+	Body struct {
+		Reports []contracts.EntityReportResponse `json:"reports"`
+		Total   int64                            `json:"total"`
+	}
+}
+
+// AdminListEntityReportsHandler handles GET /admin/entity-reports
+func (h *EntityReportHandler) AdminListEntityReportsHandler(ctx context.Context, req *AdminListEntityReportsRequest) (*AdminListEntityReportsResponse, error) {
+	if _, err := requireAdmin(ctx); err != nil {
+		return nil, err
+	}
+
+	reports, total, err := h.entityReportService.ListEntityReports(&contracts.EntityReportFilters{
+		Status:     req.Status,
+		EntityType: req.EntityType,
+		Limit:      req.Limit,
+		Offset:     req.Offset,
+	})
+	if err != nil {
+		logger.FromContext(ctx).Error("entity_report_list_failed", "error", err.Error())
+		return nil, huma.Error500InternalServerError("Failed to list entity reports")
+	}
+
+	resp := &AdminListEntityReportsResponse{}
+	resp.Body.Reports = reports
+	resp.Body.Total = total
+	return resp, nil
+}
+
+// ============================================================================
+// Admin: Get Single Entity Report — GET /admin/entity-reports/{report_id}
+// ============================================================================
+
+// AdminGetEntityReportRequest is the Huma request for GET /admin/entity-reports/{report_id}
+type AdminGetEntityReportRequest struct {
+	ReportID string `path:"report_id" doc:"Report ID"`
+}
+
+// AdminGetEntityReportResponse is the Huma response for GET /admin/entity-reports/{report_id}
+type AdminGetEntityReportResponse struct {
+	Body *contracts.EntityReportResponse
+}
+
+// AdminGetEntityReportHandler handles GET /admin/entity-reports/{report_id}
+func (h *EntityReportHandler) AdminGetEntityReportHandler(ctx context.Context, req *AdminGetEntityReportRequest) (*AdminGetEntityReportResponse, error) {
+	if _, err := requireAdmin(ctx); err != nil {
+		return nil, err
+	}
+
+	reportID, err := strconv.ParseUint(req.ReportID, 10, 64)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid report ID")
+	}
+
+	report, err := h.entityReportService.GetEntityReport(uint(reportID))
+	if err != nil {
+		logger.FromContext(ctx).Error("entity_report_get_failed", "report_id", reportID, "error", err.Error())
+		return nil, huma.Error500InternalServerError("Failed to get entity report")
+	}
+	if report == nil {
+		return nil, huma.Error404NotFound("Entity report not found")
+	}
+
+	return &AdminGetEntityReportResponse{Body: report}, nil
+}
+
+// ============================================================================
+// Admin: Resolve Entity Report — POST /admin/entity-reports/{report_id}/resolve
+// ============================================================================
+
+// AdminResolveEntityReportRequest is the Huma request for POST /admin/entity-reports/{report_id}/resolve
+type AdminResolveEntityReportRequest struct {
+	ReportID string `path:"report_id" doc:"Report ID to resolve"`
+	Body     struct {
+		Notes string `json:"notes" required:"false" doc:"Optional admin notes about the resolution"`
+	}
+}
+
+// AdminResolveEntityReportResponse is the Huma response for POST /admin/entity-reports/{report_id}/resolve
+type AdminResolveEntityReportResponse struct {
+	Body *contracts.EntityReportResponse
+}
+
+// AdminResolveEntityReportHandler handles POST /admin/entity-reports/{report_id}/resolve
+func (h *EntityReportHandler) AdminResolveEntityReportHandler(ctx context.Context, req *AdminResolveEntityReportRequest) (*AdminResolveEntityReportResponse, error) {
+	user, err := requireAdmin(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	reportID, err := strconv.ParseUint(req.ReportID, 10, 64)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid report ID")
+	}
+
+	notes := strings.TrimSpace(req.Body.Notes)
+
+	resolved, err := h.entityReportService.ResolveEntityReport(uint(reportID), user.ID, notes)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return nil, huma.Error404NotFound("Report not found")
+		}
+		if strings.Contains(err.Error(), "already been reviewed") {
+			return nil, huma.Error409Conflict(err.Error())
+		}
+		logger.FromContext(ctx).Error("entity_report_resolve_failed",
+			"report_id", reportID,
+			"admin_id", user.ID,
+			"error", err.Error(),
+		)
+		return nil, huma.Error500InternalServerError("Failed to resolve report")
+	}
+
+	logger.FromContext(ctx).Info("entity_report_resolved",
+		"report_id", reportID,
+		"admin_id", user.ID,
+		"entity_type", resolved.EntityType,
+		"entity_id", resolved.EntityID,
+	)
+
+	// Fire-and-forget audit log
+	if h.auditLogService != nil {
+		go h.auditLogService.LogAction(user.ID, "resolve_entity_report", resolved.EntityType, resolved.EntityID, map[string]interface{}{
+			"report_id":   resolved.ID,
+			"report_type": resolved.ReportType,
+			"notes":       notes,
+		})
+	}
+
+	return &AdminResolveEntityReportResponse{Body: resolved}, nil
+}
+
+// ============================================================================
+// Admin: Dismiss Entity Report — POST /admin/entity-reports/{report_id}/dismiss
+// ============================================================================
+
+// AdminDismissEntityReportRequest is the Huma request for POST /admin/entity-reports/{report_id}/dismiss
+type AdminDismissEntityReportRequest struct {
+	ReportID string `path:"report_id" doc:"Report ID to dismiss"`
+	Body     struct {
+		Notes string `json:"notes" required:"false" doc:"Optional admin notes about the dismissal"`
+	}
+}
+
+// AdminDismissEntityReportResponse is the Huma response for POST /admin/entity-reports/{report_id}/dismiss
+type AdminDismissEntityReportResponse struct {
+	Body *contracts.EntityReportResponse
+}
+
+// AdminDismissEntityReportHandler handles POST /admin/entity-reports/{report_id}/dismiss
+func (h *EntityReportHandler) AdminDismissEntityReportHandler(ctx context.Context, req *AdminDismissEntityReportRequest) (*AdminDismissEntityReportResponse, error) {
+	user, err := requireAdmin(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	reportID, err := strconv.ParseUint(req.ReportID, 10, 64)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid report ID")
+	}
+
+	notes := strings.TrimSpace(req.Body.Notes)
+
+	dismissed, err := h.entityReportService.DismissEntityReport(uint(reportID), user.ID, notes)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return nil, huma.Error404NotFound("Report not found")
+		}
+		if strings.Contains(err.Error(), "already been reviewed") {
+			return nil, huma.Error409Conflict(err.Error())
+		}
+		logger.FromContext(ctx).Error("entity_report_dismiss_failed",
+			"report_id", reportID,
+			"admin_id", user.ID,
+			"error", err.Error(),
+		)
+		return nil, huma.Error500InternalServerError("Failed to dismiss report")
+	}
+
+	logger.FromContext(ctx).Info("entity_report_dismissed",
+		"report_id", reportID,
+		"admin_id", user.ID,
+		"entity_type", dismissed.EntityType,
+		"entity_id", dismissed.EntityID,
+	)
+
+	// Fire-and-forget audit log
+	if h.auditLogService != nil {
+		go h.auditLogService.LogAction(user.ID, "dismiss_entity_report", dismissed.EntityType, dismissed.EntityID, map[string]interface{}{
+			"report_id":   dismissed.ID,
+			"report_type": dismissed.ReportType,
+			"notes":       notes,
+		})
+	}
+
+	return &AdminDismissEntityReportResponse{Body: dismissed}, nil
+}

--- a/backend/internal/api/handlers/entity_report_test.go
+++ b/backend/internal/api/handlers/entity_report_test.go
@@ -1,0 +1,525 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// ============================================================================
+// Test helpers
+// ============================================================================
+
+func testEntityReportHandler() *EntityReportHandler {
+	return NewEntityReportHandler(nil, nil)
+}
+
+func entityReportAdminCtx() context.Context {
+	return ctxWithUser(&models.User{ID: 1, IsAdmin: true})
+}
+
+func entityReportUserCtx() context.Context {
+	return ctxWithUser(&models.User{ID: 2, IsAdmin: false})
+}
+
+func makeEntityReportResponse(id uint, entityType, reportType string) *contracts.EntityReportResponse {
+	return &contracts.EntityReportResponse{
+		ID:           id,
+		EntityType:   entityType,
+		EntityID:     10,
+		ReportedBy:   2,
+		ReporterName: "testuser",
+		ReportType:   reportType,
+		Status:       "pending",
+		CreatedAt:    time.Now(),
+	}
+}
+
+// ============================================================================
+// Tests: NewEntityReportHandler
+// ============================================================================
+
+func TestNewEntityReportHandler(t *testing.T) {
+	h := testEntityReportHandler()
+	if h == nil {
+		t.Fatal("expected non-nil EntityReportHandler")
+	}
+}
+
+// ============================================================================
+// Tests: Report Entity — Auth & Validation
+// ============================================================================
+
+func TestReportEntity_NoUser(t *testing.T) {
+	h := testEntityReportHandler()
+	_, err := h.ReportArtistHandler(context.Background(), &ReportEntityRequest{EntityID: "1"})
+	assertHumaError(t, err, 401)
+}
+
+func TestReportEntity_InvalidEntityID(t *testing.T) {
+	h := testEntityReportHandler()
+	req := &ReportEntityRequest{EntityID: "abc"}
+	req.Body.ReportType = "inaccurate"
+	_, err := h.ReportArtistHandler(entityReportUserCtx(), req)
+	assertHumaError(t, err, 400)
+}
+
+func TestReportEntity_EmptyReportType(t *testing.T) {
+	h := testEntityReportHandler()
+	req := &ReportEntityRequest{EntityID: "1"}
+	req.Body.ReportType = ""
+	_, err := h.ReportArtistHandler(entityReportUserCtx(), req)
+	assertHumaError(t, err, 400)
+}
+
+func TestReportEntity_InvalidReportType(t *testing.T) {
+	h := testEntityReportHandler()
+	req := &ReportEntityRequest{EntityID: "1"}
+	req.Body.ReportType = "cancelled" // not valid for artist
+	_, err := h.ReportArtistHandler(entityReportUserCtx(), req)
+	assertHumaError(t, err, 400)
+}
+
+// ============================================================================
+// Tests: Report Entity — Success
+// ============================================================================
+
+func TestReportArtist_Success(t *testing.T) {
+	expected := makeEntityReportResponse(1, "artist", "inaccurate")
+	h := NewEntityReportHandler(
+		&mockEntityReportService{
+			createEntityReportFn: func(req *contracts.CreateEntityReportRequest) (*contracts.EntityReportResponse, error) {
+				if req.EntityType != "artist" || req.EntityID != 10 || req.UserID != 2 {
+					t.Errorf("unexpected params: %+v", req)
+				}
+				if req.ReportType != "inaccurate" {
+					t.Errorf("expected report_type=inaccurate, got %s", req.ReportType)
+				}
+				return expected, nil
+			},
+		},
+		nil,
+	)
+
+	req := &ReportEntityRequest{EntityID: "10"}
+	req.Body.ReportType = "inaccurate"
+
+	resp, err := h.ReportArtistHandler(entityReportUserCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.ID != 1 {
+		t.Errorf("expected ID=1, got %d", resp.Body.ID)
+	}
+}
+
+func TestReportVenue_Success(t *testing.T) {
+	expected := makeEntityReportResponse(2, "venue", "closed_permanently")
+	h := NewEntityReportHandler(
+		&mockEntityReportService{
+			createEntityReportFn: func(req *contracts.CreateEntityReportRequest) (*contracts.EntityReportResponse, error) {
+				if req.EntityType != "venue" {
+					t.Errorf("expected entity_type=venue, got %s", req.EntityType)
+				}
+				return expected, nil
+			},
+		},
+		nil,
+	)
+
+	req := &ReportEntityRequest{EntityID: "10"}
+	req.Body.ReportType = "closed_permanently"
+
+	resp, err := h.ReportVenueHandler(entityReportUserCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.EntityType != "venue" {
+		t.Errorf("expected entity_type=venue, got %s", resp.Body.EntityType)
+	}
+}
+
+func TestReportFestival_Success(t *testing.T) {
+	expected := makeEntityReportResponse(3, "festival", "cancelled")
+	h := NewEntityReportHandler(
+		&mockEntityReportService{
+			createEntityReportFn: func(req *contracts.CreateEntityReportRequest) (*contracts.EntityReportResponse, error) {
+				return expected, nil
+			},
+		},
+		nil,
+	)
+
+	req := &ReportEntityRequest{EntityID: "10"}
+	req.Body.ReportType = "cancelled"
+
+	resp, err := h.ReportFestivalHandler(entityReportUserCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.EntityType != "festival" {
+		t.Errorf("expected entity_type=festival, got %s", resp.Body.EntityType)
+	}
+}
+
+func TestReportShow_Success(t *testing.T) {
+	expected := makeEntityReportResponse(4, "show", "wrong_venue")
+	h := NewEntityReportHandler(
+		&mockEntityReportService{
+			createEntityReportFn: func(req *contracts.CreateEntityReportRequest) (*contracts.EntityReportResponse, error) {
+				return expected, nil
+			},
+		},
+		nil,
+	)
+
+	req := &ReportEntityRequest{EntityID: "10"}
+	req.Body.ReportType = "wrong_venue"
+
+	resp, err := h.ReportShowHandler(entityReportUserCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.EntityType != "show" {
+		t.Errorf("expected entity_type=show, got %s", resp.Body.EntityType)
+	}
+}
+
+// ============================================================================
+// Tests: Report Entity — Error Cases
+// ============================================================================
+
+func TestReportEntity_EntityNotFound(t *testing.T) {
+	h := NewEntityReportHandler(
+		&mockEntityReportService{
+			createEntityReportFn: func(req *contracts.CreateEntityReportRequest) (*contracts.EntityReportResponse, error) {
+				return nil, fmt.Errorf("entity not found: artist 99999")
+			},
+		},
+		nil,
+	)
+
+	req := &ReportEntityRequest{EntityID: "99999"}
+	req.Body.ReportType = "inaccurate"
+
+	_, err := h.ReportArtistHandler(entityReportUserCtx(), req)
+	assertHumaError(t, err, 404)
+}
+
+func TestReportEntity_DuplicatePending(t *testing.T) {
+	h := NewEntityReportHandler(
+		&mockEntityReportService{
+			createEntityReportFn: func(req *contracts.CreateEntityReportRequest) (*contracts.EntityReportResponse, error) {
+				return nil, fmt.Errorf("you already have a pending report for this entity")
+			},
+		},
+		nil,
+	)
+
+	req := &ReportEntityRequest{EntityID: "10"}
+	req.Body.ReportType = "inaccurate"
+
+	_, err := h.ReportArtistHandler(entityReportUserCtx(), req)
+	assertHumaError(t, err, 409)
+}
+
+func TestReportEntity_ServiceError(t *testing.T) {
+	h := NewEntityReportHandler(
+		&mockEntityReportService{
+			createEntityReportFn: func(req *contracts.CreateEntityReportRequest) (*contracts.EntityReportResponse, error) {
+				return nil, fmt.Errorf("database error")
+			},
+		},
+		nil,
+	)
+
+	req := &ReportEntityRequest{EntityID: "10"}
+	req.Body.ReportType = "inaccurate"
+
+	_, err := h.ReportArtistHandler(entityReportUserCtx(), req)
+	assertHumaError(t, err, 500)
+}
+
+// ============================================================================
+// Tests: Admin — List Entity Reports
+// ============================================================================
+
+func TestAdminListEntityReports_RequiresAdmin(t *testing.T) {
+	h := testEntityReportHandler()
+
+	t.Run("NoUser", func(t *testing.T) {
+		_, err := h.AdminListEntityReportsHandler(context.Background(), &AdminListEntityReportsRequest{})
+		assertHumaError(t, err, 403)
+	})
+	t.Run("NonAdmin", func(t *testing.T) {
+		_, err := h.AdminListEntityReportsHandler(entityReportUserCtx(), &AdminListEntityReportsRequest{})
+		assertHumaError(t, err, 403)
+	})
+}
+
+func TestAdminListEntityReports_Success(t *testing.T) {
+	reports := []contracts.EntityReportResponse{*makeEntityReportResponse(1, "artist", "inaccurate")}
+	h := NewEntityReportHandler(
+		&mockEntityReportService{
+			listEntityReportsFn: func(filters *contracts.EntityReportFilters) ([]contracts.EntityReportResponse, int64, error) {
+				if filters.Status != "pending" {
+					t.Errorf("expected status=pending, got %s", filters.Status)
+				}
+				return reports, 1, nil
+			},
+		},
+		nil,
+	)
+
+	resp, err := h.AdminListEntityReportsHandler(entityReportAdminCtx(), &AdminListEntityReportsRequest{
+		Status: "pending",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Total != 1 {
+		t.Errorf("expected total=1, got %d", resp.Body.Total)
+	}
+	if len(resp.Body.Reports) != 1 {
+		t.Errorf("expected 1 report, got %d", len(resp.Body.Reports))
+	}
+}
+
+func TestAdminListEntityReports_WithEntityTypeFilter(t *testing.T) {
+	reports := []contracts.EntityReportResponse{*makeEntityReportResponse(1, "venue", "wrong_address")}
+	h := NewEntityReportHandler(
+		&mockEntityReportService{
+			listEntityReportsFn: func(filters *contracts.EntityReportFilters) ([]contracts.EntityReportResponse, int64, error) {
+				if filters.EntityType != "venue" {
+					t.Errorf("expected entity_type=venue, got %s", filters.EntityType)
+				}
+				return reports, 1, nil
+			},
+		},
+		nil,
+	)
+
+	resp, err := h.AdminListEntityReportsHandler(entityReportAdminCtx(), &AdminListEntityReportsRequest{
+		EntityType: "venue",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Total != 1 {
+		t.Errorf("expected total=1, got %d", resp.Body.Total)
+	}
+}
+
+// ============================================================================
+// Tests: Admin — Get Single Entity Report
+// ============================================================================
+
+func TestAdminGetEntityReport_RequiresAdmin(t *testing.T) {
+	h := testEntityReportHandler()
+	_, err := h.AdminGetEntityReportHandler(entityReportUserCtx(), &AdminGetEntityReportRequest{ReportID: "1"})
+	assertHumaError(t, err, 403)
+}
+
+func TestAdminGetEntityReport_InvalidID(t *testing.T) {
+	h := testEntityReportHandler()
+	_, err := h.AdminGetEntityReportHandler(entityReportAdminCtx(), &AdminGetEntityReportRequest{ReportID: "abc"})
+	assertHumaError(t, err, 400)
+}
+
+func TestAdminGetEntityReport_NotFound(t *testing.T) {
+	h := NewEntityReportHandler(
+		&mockEntityReportService{
+			getEntityReportFn: func(reportID uint) (*contracts.EntityReportResponse, error) {
+				return nil, nil
+			},
+		},
+		nil,
+	)
+
+	_, err := h.AdminGetEntityReportHandler(entityReportAdminCtx(), &AdminGetEntityReportRequest{ReportID: "99"})
+	assertHumaError(t, err, 404)
+}
+
+func TestAdminGetEntityReport_Success(t *testing.T) {
+	expected := makeEntityReportResponse(1, "artist", "inaccurate")
+	h := NewEntityReportHandler(
+		&mockEntityReportService{
+			getEntityReportFn: func(reportID uint) (*contracts.EntityReportResponse, error) {
+				if reportID != 1 {
+					t.Errorf("expected reportID=1, got %d", reportID)
+				}
+				return expected, nil
+			},
+		},
+		nil,
+	)
+
+	resp, err := h.AdminGetEntityReportHandler(entityReportAdminCtx(), &AdminGetEntityReportRequest{ReportID: "1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.ID != 1 {
+		t.Errorf("expected ID=1, got %d", resp.Body.ID)
+	}
+}
+
+// ============================================================================
+// Tests: Admin — Resolve Entity Report
+// ============================================================================
+
+func TestAdminResolveEntityReport_RequiresAdmin(t *testing.T) {
+	h := testEntityReportHandler()
+	req := &AdminResolveEntityReportRequest{ReportID: "1"}
+	_, err := h.AdminResolveEntityReportHandler(entityReportUserCtx(), req)
+	assertHumaError(t, err, 403)
+}
+
+func TestAdminResolveEntityReport_InvalidID(t *testing.T) {
+	h := testEntityReportHandler()
+	_, err := h.AdminResolveEntityReportHandler(entityReportAdminCtx(), &AdminResolveEntityReportRequest{ReportID: "abc"})
+	assertHumaError(t, err, 400)
+}
+
+func TestAdminResolveEntityReport_Success(t *testing.T) {
+	resolved := makeEntityReportResponse(1, "artist", "inaccurate")
+	resolved.Status = "resolved"
+	reviewerID := uint(1)
+	resolved.ReviewedBy = &reviewerID
+	notes := "Fixed the issue"
+	resolved.AdminNotes = &notes
+
+	h := NewEntityReportHandler(
+		&mockEntityReportService{
+			resolveEntityReportFn: func(reportID, rID uint, n string) (*contracts.EntityReportResponse, error) {
+				if reportID != 1 || rID != 1 {
+					t.Errorf("unexpected params: reportID=%d, reviewerID=%d", reportID, rID)
+				}
+				if n != "Fixed the issue" {
+					t.Errorf("unexpected notes: %s", n)
+				}
+				return resolved, nil
+			},
+		},
+		&mockAuditLogService{},
+	)
+
+	req := &AdminResolveEntityReportRequest{ReportID: "1"}
+	req.Body.Notes = "Fixed the issue"
+
+	resp, err := h.AdminResolveEntityReportHandler(entityReportAdminCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Status != "resolved" {
+		t.Errorf("expected resolved status, got %s", resp.Body.Status)
+	}
+}
+
+func TestAdminResolveEntityReport_NotFound(t *testing.T) {
+	h := NewEntityReportHandler(
+		&mockEntityReportService{
+			resolveEntityReportFn: func(reportID, rID uint, n string) (*contracts.EntityReportResponse, error) {
+				return nil, fmt.Errorf("report not found")
+			},
+		},
+		nil,
+	)
+
+	_, err := h.AdminResolveEntityReportHandler(entityReportAdminCtx(), &AdminResolveEntityReportRequest{ReportID: "99"})
+	assertHumaError(t, err, 404)
+}
+
+func TestAdminResolveEntityReport_AlreadyReviewed(t *testing.T) {
+	h := NewEntityReportHandler(
+		&mockEntityReportService{
+			resolveEntityReportFn: func(reportID, rID uint, n string) (*contracts.EntityReportResponse, error) {
+				return nil, fmt.Errorf("report has already been reviewed (status: resolved)")
+			},
+		},
+		nil,
+	)
+
+	_, err := h.AdminResolveEntityReportHandler(entityReportAdminCtx(), &AdminResolveEntityReportRequest{ReportID: "1"})
+	assertHumaError(t, err, 409)
+}
+
+// ============================================================================
+// Tests: Admin — Dismiss Entity Report
+// ============================================================================
+
+func TestAdminDismissEntityReport_RequiresAdmin(t *testing.T) {
+	h := testEntityReportHandler()
+	req := &AdminDismissEntityReportRequest{ReportID: "1"}
+	_, err := h.AdminDismissEntityReportHandler(entityReportUserCtx(), req)
+	assertHumaError(t, err, 403)
+}
+
+func TestAdminDismissEntityReport_InvalidID(t *testing.T) {
+	h := testEntityReportHandler()
+	_, err := h.AdminDismissEntityReportHandler(entityReportAdminCtx(), &AdminDismissEntityReportRequest{ReportID: "abc"})
+	assertHumaError(t, err, 400)
+}
+
+func TestAdminDismissEntityReport_Success(t *testing.T) {
+	dismissed := makeEntityReportResponse(1, "venue", "wrong_address")
+	dismissed.Status = "dismissed"
+	reviewerID := uint(1)
+	dismissed.ReviewedBy = &reviewerID
+	notes := "Not valid"
+	dismissed.AdminNotes = &notes
+
+	h := NewEntityReportHandler(
+		&mockEntityReportService{
+			dismissEntityReportFn: func(reportID, rID uint, n string) (*contracts.EntityReportResponse, error) {
+				if reportID != 1 || rID != 1 {
+					t.Errorf("unexpected params: reportID=%d, reviewerID=%d", reportID, rID)
+				}
+				return dismissed, nil
+			},
+		},
+		&mockAuditLogService{},
+	)
+
+	req := &AdminDismissEntityReportRequest{ReportID: "1"}
+	req.Body.Notes = "Not valid"
+
+	resp, err := h.AdminDismissEntityReportHandler(entityReportAdminCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Status != "dismissed" {
+		t.Errorf("expected dismissed status, got %s", resp.Body.Status)
+	}
+}
+
+func TestAdminDismissEntityReport_NotFound(t *testing.T) {
+	h := NewEntityReportHandler(
+		&mockEntityReportService{
+			dismissEntityReportFn: func(reportID, rID uint, n string) (*contracts.EntityReportResponse, error) {
+				return nil, fmt.Errorf("report not found")
+			},
+		},
+		nil,
+	)
+
+	_, err := h.AdminDismissEntityReportHandler(entityReportAdminCtx(), &AdminDismissEntityReportRequest{ReportID: "99"})
+	assertHumaError(t, err, 404)
+}
+
+func TestAdminDismissEntityReport_AlreadyReviewed(t *testing.T) {
+	h := NewEntityReportHandler(
+		&mockEntityReportService{
+			dismissEntityReportFn: func(reportID, rID uint, n string) (*contracts.EntityReportResponse, error) {
+				return nil, fmt.Errorf("report has already been reviewed (status: dismissed)")
+			},
+		},
+		nil,
+	)
+
+	_, err := h.AdminDismissEntityReportHandler(entityReportAdminCtx(), &AdminDismissEntityReportRequest{ReportID: "1"})
+	assertHumaError(t, err, 409)
+}

--- a/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
+++ b/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
@@ -1068,6 +1068,56 @@ func (m *mockEnrichmentService) GetQueueStats() (*contracts.EnrichmentQueueStats
 }
 
 // ============================================================================
+// Mock: EntityReportServiceInterface
+// ============================================================================
+
+type mockEntityReportService struct {
+	createEntityReportFn func(*contracts.CreateEntityReportRequest) (*contracts.EntityReportResponse, error)
+	getEntityReportFn func(uint) (*contracts.EntityReportResponse, error)
+	getEntityReportsFn func(string, uint) ([]contracts.EntityReportResponse, error)
+	listEntityReportsFn func(*contracts.EntityReportFilters) ([]contracts.EntityReportResponse, int64, error)
+	resolveEntityReportFn func(uint, uint, string) (*contracts.EntityReportResponse, error)
+	dismissEntityReportFn func(uint, uint, string) (*contracts.EntityReportResponse, error)
+}
+
+func (m *mockEntityReportService) CreateEntityReport(req *contracts.CreateEntityReportRequest) (*contracts.EntityReportResponse, error) {
+	if m.createEntityReportFn != nil {
+		return m.createEntityReportFn(req)
+	}
+	return nil, nil
+}
+func (m *mockEntityReportService) GetEntityReport(reportID uint) (*contracts.EntityReportResponse, error) {
+	if m.getEntityReportFn != nil {
+		return m.getEntityReportFn(reportID)
+	}
+	return nil, nil
+}
+func (m *mockEntityReportService) GetEntityReports(entityType string, entityID uint) ([]contracts.EntityReportResponse, error) {
+	if m.getEntityReportsFn != nil {
+		return m.getEntityReportsFn(entityType, entityID)
+	}
+	return nil, nil
+}
+func (m *mockEntityReportService) ListEntityReports(filters *contracts.EntityReportFilters) ([]contracts.EntityReportResponse, int64, error) {
+	if m.listEntityReportsFn != nil {
+		return m.listEntityReportsFn(filters)
+	}
+	return nil, 0, nil
+}
+func (m *mockEntityReportService) ResolveEntityReport(reportID uint, reviewerID uint, notes string) (*contracts.EntityReportResponse, error) {
+	if m.resolveEntityReportFn != nil {
+		return m.resolveEntityReportFn(reportID, reviewerID, notes)
+	}
+	return nil, nil
+}
+func (m *mockEntityReportService) DismissEntityReport(reportID uint, reviewerID uint, notes string) (*contracts.EntityReportResponse, error) {
+	if m.dismissEntityReportFn != nil {
+		return m.dismissEntityReportFn(reportID, reviewerID, notes)
+	}
+	return nil, nil
+}
+
+// ============================================================================
 // Mock: ExtractionServiceInterface
 // ============================================================================
 
@@ -3133,6 +3183,7 @@ var _ contracts.DiscordServiceInterface = (*mockDiscordService)(nil)
 var _ contracts.DiscoveryServiceInterface = (*mockDiscoveryService)(nil)
 var _ contracts.EmailServiceInterface = (*mockEmailService)(nil)
 var _ contracts.EnrichmentServiceInterface = (*mockEnrichmentService)(nil)
+var _ contracts.EntityReportServiceInterface = (*mockEntityReportService)(nil)
 var _ contracts.ExtractionServiceInterface = (*mockExtractionService)(nil)
 var _ contracts.FavoriteVenueServiceInterface = (*mockFavoriteVenueService)(nil)
 var _ contracts.FestivalIntelligenceServiceInterface = (*mockFestivalIntelligenceService)(nil)

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -126,6 +126,7 @@ func SetupRoutes(router *chi.Mux, sc *services.ServiceContainer, cfg *config.Con
 	setupNotificationFilterRoutes(rc)
 	setupChartsRoutes(rc)
 	setupPendingEditRoutes(rc)
+	setupEntityReportRoutes(rc)
 
 	return api
 }
@@ -933,4 +934,37 @@ func setupPendingEditRoutes(rc RouteContext) {
 	huma.Post(rc.Protected, "/admin/pending-edits/{edit_id}/approve", pendingEditHandler.AdminApprovePendingEditHandler)
 	huma.Post(rc.Protected, "/admin/pending-edits/{edit_id}/reject", pendingEditHandler.AdminRejectPendingEditHandler)
 	huma.Get(rc.Protected, "/admin/pending-edits/entity/{entity_type}/{entity_id}", pendingEditHandler.AdminGetEntityPendingEditsHandler)
+}
+
+// setupEntityReportRoutes configures entity report endpoints.
+// Protected endpoints for submitting reports.
+// Admin endpoints for reviewing, resolving, and dismissing reports.
+func setupEntityReportRoutes(rc RouteContext) {
+	entityReportHandler := handlers.NewEntityReportHandler(rc.SC.EntityReport, rc.SC.AuditLog)
+
+	// Rate-limited report submission: 5 requests per minute per IP
+	rc.Router.Group(func(r chi.Router) {
+		r.Use(httprate.Limit(
+			middleware.ReportRequestsPerMinute,
+			time.Minute,
+			httprate.WithKeyFuncs(httprate.KeyByIP),
+			httprate.WithLimitHandler(rateLimitHandler),
+		))
+		reportAPI := humachi.New(r, huma.DefaultConfig("Psychic Homily Entity Reports", "1.0.0"))
+		reportAPI.UseMiddleware(middleware.HumaRequestIDMiddleware)
+		reportAPI.UseMiddleware(middleware.HumaJWTMiddleware(rc.SC.JWT, rc.Cfg.Session))
+		huma.Post(reportAPI, "/artists/{entity_id}/report", entityReportHandler.ReportArtistHandler)
+		huma.Post(reportAPI, "/venues/{entity_id}/report", entityReportHandler.ReportVenueHandler)
+		huma.Post(reportAPI, "/festivals/{entity_id}/report", entityReportHandler.ReportFestivalHandler)
+		// Note: shows already have /shows/{show_id}/report in setupShowReportRoutes.
+		// The generic entity report handler + service support shows, so the admin queue
+		// can display show reports submitted through the existing endpoint or this one.
+		huma.Post(reportAPI, "/shows/{entity_id}/entity-report", entityReportHandler.ReportShowHandler)
+	})
+
+	// Admin: entity report management
+	huma.Get(rc.Protected, "/admin/entity-reports", entityReportHandler.AdminListEntityReportsHandler)
+	huma.Get(rc.Protected, "/admin/entity-reports/{report_id}", entityReportHandler.AdminGetEntityReportHandler)
+	huma.Post(rc.Protected, "/admin/entity-reports/{report_id}/resolve", entityReportHandler.AdminResolveEntityReportHandler)
+	huma.Post(rc.Protected, "/admin/entity-reports/{report_id}/dismiss", entityReportHandler.AdminDismissEntityReportHandler)
 }

--- a/backend/internal/models/entity_report.go
+++ b/backend/internal/models/entity_report.go
@@ -1,0 +1,106 @@
+package models
+
+import "time"
+
+// EntityReportStatus represents the status of an entity report.
+type EntityReportStatus string
+
+const (
+	EntityReportStatusPending   EntityReportStatus = "pending"
+	EntityReportStatusResolved  EntityReportStatus = "resolved"
+	EntityReportStatusDismissed EntityReportStatus = "dismissed"
+)
+
+// Supported entity types for entity reports.
+const (
+	EntityReportEntityArtist   = "artist"
+	EntityReportEntityVenue    = "venue"
+	EntityReportEntityFestival = "festival"
+	EntityReportEntityShow     = "show"
+)
+
+// Valid report types per entity type.
+var validReportTypes = map[string]map[string]bool{
+	EntityReportEntityArtist: {
+		"inaccurate":      true,
+		"duplicate":       true,
+		"wrong_image":     true,
+		"removal_request": true,
+		"missing_info":    true,
+	},
+	EntityReportEntityVenue: {
+		"closed_permanently": true,
+		"wrong_address":      true,
+		"duplicate":          true,
+		"inaccurate":         true,
+		"missing_info":       true,
+	},
+	EntityReportEntityFestival: {
+		"cancelled":  true,
+		"wrong_dates": true,
+		"duplicate":  true,
+		"inaccurate": true,
+	},
+	EntityReportEntityShow: {
+		"cancelled":   true,
+		"sold_out":    true,
+		"inaccurate":  true,
+		"wrong_venue": true,
+		"wrong_date":  true,
+	},
+}
+
+// EntityReport represents a user report about an entity issue.
+// Uses entity_type + entity_id polymorphism instead of per-entity tables.
+type EntityReport struct {
+	ID         uint               `json:"id" gorm:"primaryKey"`
+	EntityType string             `json:"entity_type" gorm:"column:entity_type;not null;size:50"`
+	EntityID   uint               `json:"entity_id" gorm:"column:entity_id;not null"`
+	ReportedBy uint               `json:"reported_by" gorm:"column:reported_by;not null"`
+	ReportType string             `json:"report_type" gorm:"column:report_type;not null;size:50"`
+	Details    *string            `json:"details,omitempty" gorm:"column:details"`
+	Status     EntityReportStatus `json:"status" gorm:"column:status;not null;default:'pending'"`
+	AdminNotes *string            `json:"admin_notes,omitempty" gorm:"column:admin_notes"`
+	ReviewedBy *uint              `json:"reviewed_by,omitempty" gorm:"column:reviewed_by"`
+	ReviewedAt *time.Time         `json:"reviewed_at,omitempty" gorm:"column:reviewed_at"`
+	CreatedAt  time.Time          `json:"created_at"`
+
+	Reporter User  `json:"-" gorm:"foreignKey:ReportedBy"`
+	Reviewer *User `json:"-" gorm:"foreignKey:ReviewedBy"`
+}
+
+// TableName specifies the table name for EntityReport.
+func (EntityReport) TableName() string { return "entity_reports" }
+
+// ValidEntityReportEntityTypes returns the set of entity types that support reports.
+func ValidEntityReportEntityTypes() []string {
+	return []string{EntityReportEntityArtist, EntityReportEntityVenue, EntityReportEntityFestival, EntityReportEntityShow}
+}
+
+// IsValidEntityReportEntityType checks if the given entity type supports reports.
+func IsValidEntityReportEntityType(entityType string) bool {
+	_, ok := validReportTypes[entityType]
+	return ok
+}
+
+// IsValidReportType checks if the given report type is valid for the entity type.
+func IsValidReportType(entityType, reportType string) bool {
+	types, ok := validReportTypes[entityType]
+	if !ok {
+		return false
+	}
+	return types[reportType]
+}
+
+// ValidReportTypesForEntity returns the valid report types for a given entity type.
+func ValidReportTypesForEntity(entityType string) []string {
+	types, ok := validReportTypes[entityType]
+	if !ok {
+		return nil
+	}
+	result := make([]string, 0, len(types))
+	for t := range types {
+		result = append(result, t)
+	}
+	return result
+}

--- a/backend/internal/services/admin/entity_report.go
+++ b/backend/internal/services/admin/entity_report.go
@@ -1,0 +1,268 @@
+package admin
+
+import (
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/db"
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// EntityReportService handles business logic for generalized entity reports.
+type EntityReportService struct {
+	db *gorm.DB
+}
+
+// NewEntityReportService creates a new EntityReportService.
+func NewEntityReportService(database *gorm.DB) *EntityReportService {
+	if database == nil {
+		database = db.GetDB()
+	}
+	return &EntityReportService{db: database}
+}
+
+// CreateEntityReport submits a new report for an entity.
+func (s *EntityReportService) CreateEntityReport(req *contracts.CreateEntityReportRequest) (*contracts.EntityReportResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	if !models.IsValidEntityReportEntityType(req.EntityType) {
+		return nil, fmt.Errorf("invalid entity type: %s", req.EntityType)
+	}
+	if !models.IsValidReportType(req.EntityType, req.ReportType) {
+		return nil, fmt.Errorf("invalid report type '%s' for entity type '%s'", req.ReportType, req.EntityType)
+	}
+
+	// Verify the entity exists
+	tableName := req.EntityType + "s"
+	var count int64
+	if err := s.db.Table(tableName).Where("id = ?", req.EntityID).Count(&count).Error; err != nil {
+		return nil, fmt.Errorf("failed to verify entity: %w", err)
+	}
+	if count == 0 {
+		return nil, fmt.Errorf("entity not found: %s %d", req.EntityType, req.EntityID)
+	}
+
+	// Check for existing pending report from this user for this entity
+	var existingCount int64
+	if err := s.db.Model(&models.EntityReport{}).
+		Where("entity_type = ? AND entity_id = ? AND reported_by = ? AND status = ?",
+			req.EntityType, req.EntityID, req.UserID, models.EntityReportStatusPending).
+		Count(&existingCount).Error; err != nil {
+		return nil, fmt.Errorf("failed to check existing report: %w", err)
+	}
+	if existingCount > 0 {
+		return nil, fmt.Errorf("you already have a pending report for this entity")
+	}
+
+	report := &models.EntityReport{
+		EntityType: req.EntityType,
+		EntityID:   req.EntityID,
+		ReportedBy: req.UserID,
+		ReportType: req.ReportType,
+		Details:    req.Details,
+		Status:     models.EntityReportStatusPending,
+	}
+
+	if err := s.db.Create(report).Error; err != nil {
+		return nil, fmt.Errorf("failed to create entity report: %w", err)
+	}
+
+	// Reload with relationships
+	return s.GetEntityReport(report.ID)
+}
+
+// GetEntityReport returns a single report by ID.
+func (s *EntityReportService) GetEntityReport(reportID uint) (*contracts.EntityReportResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var report models.EntityReport
+	err := s.db.Preload("Reporter").Preload("Reviewer").First(&report, reportID).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get entity report: %w", err)
+	}
+
+	return s.toResponse(&report), nil
+}
+
+// GetEntityReports returns all reports for a specific entity.
+func (s *EntityReportService) GetEntityReports(entityType string, entityID uint) ([]contracts.EntityReportResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var reports []models.EntityReport
+	err := s.db.Where("entity_type = ? AND entity_id = ?", entityType, entityID).
+		Preload("Reporter").
+		Preload("Reviewer").
+		Order("created_at DESC").
+		Find(&reports).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to get entity reports: %w", err)
+	}
+
+	return s.toResponses(reports), nil
+}
+
+// ListEntityReports returns reports for the admin review queue.
+func (s *EntityReportService) ListEntityReports(filters *contracts.EntityReportFilters) ([]contracts.EntityReportResponse, int64, error) {
+	if s.db == nil {
+		return nil, 0, fmt.Errorf("database not initialized")
+	}
+
+	limit := 20
+	offset := 0
+	if filters != nil {
+		if filters.Limit > 0 && filters.Limit <= 100 {
+			limit = filters.Limit
+		}
+		if filters.Offset > 0 {
+			offset = filters.Offset
+		}
+	}
+
+	query := s.db.Model(&models.EntityReport{})
+
+	if filters != nil {
+		if filters.Status != "" {
+			query = query.Where("status = ?", filters.Status)
+		}
+		if filters.EntityType != "" {
+			query = query.Where("entity_type = ?", filters.EntityType)
+		}
+	}
+
+	var total int64
+	query.Count(&total)
+
+	var reports []models.EntityReport
+	err := query.
+		Preload("Reporter").
+		Preload("Reviewer").
+		Order("created_at ASC").
+		Limit(limit).
+		Offset(offset).
+		Find(&reports).Error
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to list entity reports: %w", err)
+	}
+
+	return s.toResponses(reports), total, nil
+}
+
+// ResolveEntityReport marks a report as resolved (action was taken).
+func (s *EntityReportService) ResolveEntityReport(reportID uint, reviewerID uint, notes string) (*contracts.EntityReportResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var report models.EntityReport
+	if err := s.db.First(&report, reportID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, fmt.Errorf("report not found")
+		}
+		return nil, fmt.Errorf("failed to get report: %w", err)
+	}
+
+	if report.Status != models.EntityReportStatusPending {
+		return nil, fmt.Errorf("report has already been reviewed (status: %s)", report.Status)
+	}
+
+	now := time.Now()
+	updates := map[string]interface{}{
+		"status":      models.EntityReportStatusResolved,
+		"reviewed_by": reviewerID,
+		"reviewed_at": now,
+	}
+	if notes != "" {
+		updates["admin_notes"] = notes
+	}
+
+	if err := s.db.Model(&report).Updates(updates).Error; err != nil {
+		return nil, fmt.Errorf("failed to resolve report: %w", err)
+	}
+
+	return s.GetEntityReport(reportID)
+}
+
+// DismissEntityReport marks a report as dismissed (spam/invalid).
+func (s *EntityReportService) DismissEntityReport(reportID uint, reviewerID uint, notes string) (*contracts.EntityReportResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var report models.EntityReport
+	if err := s.db.First(&report, reportID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, fmt.Errorf("report not found")
+		}
+		return nil, fmt.Errorf("failed to get report: %w", err)
+	}
+
+	if report.Status != models.EntityReportStatusPending {
+		return nil, fmt.Errorf("report has already been reviewed (status: %s)", report.Status)
+	}
+
+	now := time.Now()
+	updates := map[string]interface{}{
+		"status":      models.EntityReportStatusDismissed,
+		"reviewed_by": reviewerID,
+		"reviewed_at": now,
+	}
+	if notes != "" {
+		updates["admin_notes"] = notes
+	}
+
+	if err := s.db.Model(&report).Updates(updates).Error; err != nil {
+		return nil, fmt.Errorf("failed to dismiss report: %w", err)
+	}
+
+	return s.GetEntityReport(reportID)
+}
+
+// toResponse converts an EntityReport model to a response DTO.
+func (s *EntityReportService) toResponse(report *models.EntityReport) *contracts.EntityReportResponse {
+	resp := &contracts.EntityReportResponse{
+		ID:         report.ID,
+		EntityType: report.EntityType,
+		EntityID:   report.EntityID,
+		ReportedBy: report.ReportedBy,
+		ReportType: report.ReportType,
+		Details:    report.Details,
+		Status:     string(report.Status),
+		AdminNotes: report.AdminNotes,
+		ReviewedBy: report.ReviewedBy,
+		ReviewedAt: report.ReviewedAt,
+		CreatedAt:  report.CreatedAt,
+	}
+
+	// Resolve reporter name
+	if report.Reporter.ID != 0 {
+		resp.ReporterName = displayName(&report.Reporter)
+	}
+
+	// Resolve reviewer name
+	if report.Reviewer != nil && report.Reviewer.ID != 0 {
+		resp.ReviewerName = displayName(report.Reviewer)
+	}
+
+	return resp
+}
+
+// toResponses converts a slice of models to response DTOs.
+func (s *EntityReportService) toResponses(reports []models.EntityReport) []contracts.EntityReportResponse {
+	responses := make([]contracts.EntityReportResponse, len(reports))
+	for i := range reports {
+		responses[i] = *s.toResponse(&reports[i])
+	}
+	return responses
+}

--- a/backend/internal/services/admin/entity_report_test.go
+++ b/backend/internal/services/admin/entity_report_test.go
@@ -1,0 +1,685 @@
+package admin
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/testutil"
+)
+
+// =============================================================================
+// UNIT TESTS (No Database Required)
+// =============================================================================
+
+func TestNewEntityReportService(t *testing.T) {
+	svc := NewEntityReportService(nil)
+	assert.NotNil(t, svc)
+}
+
+func TestEntityReportService_NilDatabase(t *testing.T) {
+	svc := &EntityReportService{db: nil}
+
+	t.Run("CreateEntityReport", func(t *testing.T) {
+		testutil.AssertNilDBErrorWithResult(t, func() (interface{}, error) {
+			return svc.CreateEntityReport(&contracts.CreateEntityReportRequest{
+				EntityType: "artist", EntityID: 1, UserID: 1, ReportType: "inaccurate",
+			})
+		})
+	})
+
+	t.Run("GetEntityReport", func(t *testing.T) {
+		testutil.AssertNilDBErrorWithResult(t, func() (interface{}, error) {
+			return svc.GetEntityReport(1)
+		})
+	})
+
+	t.Run("GetEntityReports", func(t *testing.T) {
+		testutil.AssertNilDBError(t, func() error {
+			_, err := svc.GetEntityReports("artist", 1)
+			return err
+		})
+	})
+
+	t.Run("ListEntityReports", func(t *testing.T) {
+		testutil.AssertNilDBError(t, func() error {
+			_, _, err := svc.ListEntityReports(nil)
+			return err
+		})
+	})
+
+	t.Run("ResolveEntityReport", func(t *testing.T) {
+		testutil.AssertNilDBErrorWithResult(t, func() (interface{}, error) {
+			return svc.ResolveEntityReport(1, 1, "notes")
+		})
+	})
+
+	t.Run("DismissEntityReport", func(t *testing.T) {
+		testutil.AssertNilDBErrorWithResult(t, func() (interface{}, error) {
+			return svc.DismissEntityReport(1, 1, "notes")
+		})
+	})
+}
+
+func TestEntityReportModel_Validation(t *testing.T) {
+	// Valid entity types
+	assert.True(t, models.IsValidEntityReportEntityType("artist"))
+	assert.True(t, models.IsValidEntityReportEntityType("venue"))
+	assert.True(t, models.IsValidEntityReportEntityType("festival"))
+	assert.True(t, models.IsValidEntityReportEntityType("show"))
+	assert.False(t, models.IsValidEntityReportEntityType(""))
+	assert.False(t, models.IsValidEntityReportEntityType("release"))
+	assert.False(t, models.IsValidEntityReportEntityType("label"))
+
+	// Valid report types per entity
+	assert.True(t, models.IsValidReportType("artist", "inaccurate"))
+	assert.True(t, models.IsValidReportType("artist", "duplicate"))
+	assert.True(t, models.IsValidReportType("artist", "wrong_image"))
+	assert.True(t, models.IsValidReportType("artist", "removal_request"))
+	assert.True(t, models.IsValidReportType("artist", "missing_info"))
+	assert.False(t, models.IsValidReportType("artist", "cancelled"))
+
+	assert.True(t, models.IsValidReportType("venue", "closed_permanently"))
+	assert.True(t, models.IsValidReportType("venue", "wrong_address"))
+	assert.True(t, models.IsValidReportType("venue", "duplicate"))
+	assert.False(t, models.IsValidReportType("venue", "cancelled"))
+
+	assert.True(t, models.IsValidReportType("festival", "cancelled"))
+	assert.True(t, models.IsValidReportType("festival", "wrong_dates"))
+	assert.False(t, models.IsValidReportType("festival", "sold_out"))
+
+	assert.True(t, models.IsValidReportType("show", "cancelled"))
+	assert.True(t, models.IsValidReportType("show", "sold_out"))
+	assert.True(t, models.IsValidReportType("show", "wrong_venue"))
+	assert.True(t, models.IsValidReportType("show", "wrong_date"))
+	assert.False(t, models.IsValidReportType("show", "removal_request"))
+
+	// Invalid entity type
+	assert.False(t, models.IsValidReportType("release", "inaccurate"))
+}
+
+func TestValidReportTypesForEntity(t *testing.T) {
+	artistTypes := models.ValidReportTypesForEntity("artist")
+	assert.Len(t, artistTypes, 5)
+
+	venueTypes := models.ValidReportTypesForEntity("venue")
+	assert.Len(t, venueTypes, 5)
+
+	festivalTypes := models.ValidReportTypesForEntity("festival")
+	assert.Len(t, festivalTypes, 4)
+
+	showTypes := models.ValidReportTypesForEntity("show")
+	assert.Len(t, showTypes, 5)
+
+	unknownTypes := models.ValidReportTypesForEntity("release")
+	assert.Nil(t, unknownTypes)
+}
+
+func TestValidEntityReportEntityTypes(t *testing.T) {
+	types := models.ValidEntityReportEntityTypes()
+	assert.Len(t, types, 4)
+	assert.Contains(t, types, "artist")
+	assert.Contains(t, types, "venue")
+	assert.Contains(t, types, "festival")
+	assert.Contains(t, types, "show")
+}
+
+// =============================================================================
+// INTEGRATION TESTS (With Real Database)
+// =============================================================================
+
+type EntityReportServiceIntegrationTestSuite struct {
+	suite.Suite
+	testDB *testutil.TestDatabase
+	db     *gorm.DB
+	svc    *EntityReportService
+}
+
+func (s *EntityReportServiceIntegrationTestSuite) SetupSuite() {
+	s.testDB = testutil.SetupTestPostgres(s.T())
+	s.db = s.testDB.DB
+	s.svc = NewEntityReportService(s.db)
+}
+
+func (s *EntityReportServiceIntegrationTestSuite) TearDownSuite() {
+	s.testDB.Cleanup()
+}
+
+func (s *EntityReportServiceIntegrationTestSuite) TearDownTest() {
+	sqlDB, err := s.db.DB()
+	s.Require().NoError(err)
+	_, _ = sqlDB.Exec("DELETE FROM entity_reports")
+	_, _ = sqlDB.Exec("DELETE FROM artists")
+	_, _ = sqlDB.Exec("DELETE FROM venues")
+	_, _ = sqlDB.Exec("DELETE FROM festivals")
+	_, _ = sqlDB.Exec("DELETE FROM shows")
+	_, _ = sqlDB.Exec("DELETE FROM users")
+}
+
+func TestEntityReportServiceIntegrationSuite(t *testing.T) {
+	suite.Run(t, new(EntityReportServiceIntegrationTestSuite))
+}
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+func (s *EntityReportServiceIntegrationTestSuite) createTestUser() *models.User {
+	user := &models.User{
+		Email:         stringPtr(fmt.Sprintf("er-user-%d@test.com", time.Now().UnixNano())),
+		Username:      stringPtr(fmt.Sprintf("er-user-%d", time.Now().UnixNano())),
+		FirstName:     stringPtr("Test"),
+		LastName:      stringPtr("User"),
+		IsActive:      true,
+		EmailVerified: true,
+	}
+	err := s.db.Create(user).Error
+	s.Require().NoError(err)
+	return user
+}
+
+func (s *EntityReportServiceIntegrationTestSuite) createTestArtist(name string) *models.Artist {
+	slug := fmt.Sprintf("test-artist-%d", time.Now().UnixNano())
+	artist := &models.Artist{
+		Name: name,
+		Slug: &slug,
+	}
+	err := s.db.Create(artist).Error
+	s.Require().NoError(err)
+	return artist
+}
+
+func (s *EntityReportServiceIntegrationTestSuite) createTestVenue(name string) *models.Venue {
+	slug := fmt.Sprintf("test-venue-%d", time.Now().UnixNano())
+	venue := &models.Venue{
+		Name:  name,
+		Slug:  &slug,
+		City:  "Phoenix",
+		State: "AZ",
+	}
+	err := s.db.Create(venue).Error
+	s.Require().NoError(err)
+	return venue
+}
+
+func (s *EntityReportServiceIntegrationTestSuite) createTestFestival(name string) *models.Festival {
+	slug := fmt.Sprintf("test-festival-%d", time.Now().UnixNano())
+	festival := &models.Festival{
+		Name:        name,
+		Slug:        slug,
+		SeriesSlug:  slug,
+		EditionYear: 2026,
+		StartDate:   "2026-06-01",
+		EndDate:     "2026-06-03",
+	}
+	err := s.db.Create(festival).Error
+	s.Require().NoError(err)
+	return festival
+}
+
+func (s *EntityReportServiceIntegrationTestSuite) createTestShow() *models.Show {
+	show := &models.Show{
+		Title:     "Test Show",
+		EventDate: time.Date(2026, 6, 15, 20, 0, 0, 0, time.UTC),
+		Status:    "approved",
+	}
+	err := s.db.Create(show).Error
+	s.Require().NoError(err)
+	return show
+}
+
+func (s *EntityReportServiceIntegrationTestSuite) createReport(entityType string, entityID, userID uint, reportType string) *contracts.EntityReportResponse {
+	resp, err := s.svc.CreateEntityReport(&contracts.CreateEntityReportRequest{
+		EntityType: entityType,
+		EntityID:   entityID,
+		UserID:     userID,
+		ReportType: reportType,
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+	return resp
+}
+
+// =============================================================================
+// CreateEntityReport tests
+// =============================================================================
+
+func (s *EntityReportServiceIntegrationTestSuite) TestCreateEntityReport_ArtistSuccess() {
+	user := s.createTestUser()
+	artist := s.createTestArtist("Test Artist")
+
+	details := "This artist profile has wrong bio info"
+	resp, err := s.svc.CreateEntityReport(&contracts.CreateEntityReportRequest{
+		EntityType: "artist",
+		EntityID:   artist.ID,
+		UserID:     user.ID,
+		ReportType: "inaccurate",
+		Details:    &details,
+	})
+
+	s.NoError(err)
+	s.Require().NotNil(resp)
+	s.Equal("artist", resp.EntityType)
+	s.Equal(artist.ID, resp.EntityID)
+	s.Equal(user.ID, resp.ReportedBy)
+	s.Equal("inaccurate", resp.ReportType)
+	s.Equal("pending", resp.Status)
+	s.Require().NotNil(resp.Details)
+	s.Equal(details, *resp.Details)
+	s.NotEmpty(resp.ReporterName)
+}
+
+func (s *EntityReportServiceIntegrationTestSuite) TestCreateEntityReport_VenueSuccess() {
+	user := s.createTestUser()
+	venue := s.createTestVenue("Test Venue")
+
+	resp, err := s.svc.CreateEntityReport(&contracts.CreateEntityReportRequest{
+		EntityType: "venue",
+		EntityID:   venue.ID,
+		UserID:     user.ID,
+		ReportType: "closed_permanently",
+	})
+
+	s.NoError(err)
+	s.Require().NotNil(resp)
+	s.Equal("venue", resp.EntityType)
+	s.Equal("closed_permanently", resp.ReportType)
+}
+
+func (s *EntityReportServiceIntegrationTestSuite) TestCreateEntityReport_FestivalSuccess() {
+	user := s.createTestUser()
+	festival := s.createTestFestival("Test Fest")
+
+	resp, err := s.svc.CreateEntityReport(&contracts.CreateEntityReportRequest{
+		EntityType: "festival",
+		EntityID:   festival.ID,
+		UserID:     user.ID,
+		ReportType: "cancelled",
+	})
+
+	s.NoError(err)
+	s.Require().NotNil(resp)
+	s.Equal("festival", resp.EntityType)
+	s.Equal("cancelled", resp.ReportType)
+}
+
+func (s *EntityReportServiceIntegrationTestSuite) TestCreateEntityReport_ShowSuccess() {
+	user := s.createTestUser()
+	show := s.createTestShow()
+
+	resp, err := s.svc.CreateEntityReport(&contracts.CreateEntityReportRequest{
+		EntityType: "show",
+		EntityID:   show.ID,
+		UserID:     user.ID,
+		ReportType: "wrong_venue",
+	})
+
+	s.NoError(err)
+	s.Require().NotNil(resp)
+	s.Equal("show", resp.EntityType)
+	s.Equal("wrong_venue", resp.ReportType)
+}
+
+func (s *EntityReportServiceIntegrationTestSuite) TestCreateEntityReport_InvalidEntityType() {
+	user := s.createTestUser()
+
+	_, err := s.svc.CreateEntityReport(&contracts.CreateEntityReportRequest{
+		EntityType: "release",
+		EntityID:   1,
+		UserID:     user.ID,
+		ReportType: "inaccurate",
+	})
+
+	s.Error(err)
+	s.Contains(err.Error(), "invalid entity type")
+}
+
+func (s *EntityReportServiceIntegrationTestSuite) TestCreateEntityReport_InvalidReportType() {
+	user := s.createTestUser()
+	artist := s.createTestArtist("Test Artist")
+
+	_, err := s.svc.CreateEntityReport(&contracts.CreateEntityReportRequest{
+		EntityType: "artist",
+		EntityID:   artist.ID,
+		UserID:     user.ID,
+		ReportType: "cancelled",
+	})
+
+	s.Error(err)
+	s.Contains(err.Error(), "invalid report type")
+}
+
+func (s *EntityReportServiceIntegrationTestSuite) TestCreateEntityReport_EntityNotFound() {
+	user := s.createTestUser()
+
+	_, err := s.svc.CreateEntityReport(&contracts.CreateEntityReportRequest{
+		EntityType: "artist",
+		EntityID:   99999,
+		UserID:     user.ID,
+		ReportType: "inaccurate",
+	})
+
+	s.Error(err)
+	s.Contains(err.Error(), "entity not found")
+}
+
+func (s *EntityReportServiceIntegrationTestSuite) TestCreateEntityReport_DuplicatePendingReport() {
+	user := s.createTestUser()
+	artist := s.createTestArtist("Test Artist")
+
+	// First report succeeds
+	_, err := s.svc.CreateEntityReport(&contracts.CreateEntityReportRequest{
+		EntityType: "artist",
+		EntityID:   artist.ID,
+		UserID:     user.ID,
+		ReportType: "inaccurate",
+	})
+	s.NoError(err)
+
+	// Second report from same user fails
+	_, err = s.svc.CreateEntityReport(&contracts.CreateEntityReportRequest{
+		EntityType: "artist",
+		EntityID:   artist.ID,
+		UserID:     user.ID,
+		ReportType: "duplicate",
+	})
+	s.Error(err)
+	s.Contains(err.Error(), "already have a pending report")
+}
+
+func (s *EntityReportServiceIntegrationTestSuite) TestCreateEntityReport_AllowAfterResolved() {
+	user := s.createTestUser()
+	admin := s.createTestUser()
+	artist := s.createTestArtist("Test Artist")
+
+	// First report
+	report := s.createReport("artist", artist.ID, user.ID, "inaccurate")
+
+	// Resolve it
+	_, err := s.svc.ResolveEntityReport(report.ID, admin.ID, "fixed")
+	s.NoError(err)
+
+	// New report from same user should succeed
+	resp, err := s.svc.CreateEntityReport(&contracts.CreateEntityReportRequest{
+		EntityType: "artist",
+		EntityID:   artist.ID,
+		UserID:     user.ID,
+		ReportType: "missing_info",
+	})
+	s.NoError(err)
+	s.NotNil(resp)
+}
+
+// =============================================================================
+// GetEntityReport tests
+// =============================================================================
+
+func (s *EntityReportServiceIntegrationTestSuite) TestGetEntityReport_Success() {
+	user := s.createTestUser()
+	artist := s.createTestArtist("Test Artist")
+	report := s.createReport("artist", artist.ID, user.ID, "inaccurate")
+
+	resp, err := s.svc.GetEntityReport(report.ID)
+	s.NoError(err)
+	s.Require().NotNil(resp)
+	s.Equal(report.ID, resp.ID)
+	s.Equal("artist", resp.EntityType)
+}
+
+func (s *EntityReportServiceIntegrationTestSuite) TestGetEntityReport_NotFound() {
+	resp, err := s.svc.GetEntityReport(99999)
+	s.NoError(err)
+	s.Nil(resp)
+}
+
+// =============================================================================
+// GetEntityReports tests
+// =============================================================================
+
+func (s *EntityReportServiceIntegrationTestSuite) TestGetEntityReports_Success() {
+	user1 := s.createTestUser()
+	user2 := s.createTestUser()
+	artist := s.createTestArtist("Test Artist")
+
+	s.createReport("artist", artist.ID, user1.ID, "inaccurate")
+	s.createReport("artist", artist.ID, user2.ID, "duplicate")
+
+	reports, err := s.svc.GetEntityReports("artist", artist.ID)
+	s.NoError(err)
+	s.Len(reports, 2)
+}
+
+func (s *EntityReportServiceIntegrationTestSuite) TestGetEntityReports_Empty() {
+	reports, err := s.svc.GetEntityReports("artist", 99999)
+	s.NoError(err)
+	s.Empty(reports)
+}
+
+// =============================================================================
+// ListEntityReports tests
+// =============================================================================
+
+func (s *EntityReportServiceIntegrationTestSuite) TestListEntityReports_DefaultFilters() {
+	user := s.createTestUser()
+	artist := s.createTestArtist("Test Artist")
+	venue := s.createTestVenue("Test Venue")
+
+	s.createReport("artist", artist.ID, user.ID, "inaccurate")
+	s.createReport("venue", venue.ID, user.ID, "wrong_address")
+
+	reports, total, err := s.svc.ListEntityReports(nil)
+	s.NoError(err)
+	s.Equal(int64(2), total)
+	s.Len(reports, 2)
+}
+
+func (s *EntityReportServiceIntegrationTestSuite) TestListEntityReports_FilterByStatus() {
+	user := s.createTestUser()
+	admin := s.createTestUser()
+	artist := s.createTestArtist("Test Artist")
+	venue := s.createTestVenue("Test Venue")
+
+	s.createReport("artist", artist.ID, user.ID, "inaccurate")
+	venueReport := s.createReport("venue", venue.ID, user.ID, "wrong_address")
+
+	// Resolve one report
+	_, err := s.svc.ResolveEntityReport(venueReport.ID, admin.ID, "fixed")
+	s.NoError(err)
+
+	// Filter by pending
+	reports, total, err := s.svc.ListEntityReports(&contracts.EntityReportFilters{
+		Status: "pending",
+	})
+	s.NoError(err)
+	s.Equal(int64(1), total)
+	s.Len(reports, 1)
+	s.Equal("artist", reports[0].EntityType)
+}
+
+func (s *EntityReportServiceIntegrationTestSuite) TestListEntityReports_FilterByEntityType() {
+	user := s.createTestUser()
+	artist := s.createTestArtist("Test Artist")
+	venue := s.createTestVenue("Test Venue")
+
+	s.createReport("artist", artist.ID, user.ID, "inaccurate")
+	s.createReport("venue", venue.ID, user.ID, "wrong_address")
+
+	reports, total, err := s.svc.ListEntityReports(&contracts.EntityReportFilters{
+		EntityType: "venue",
+	})
+	s.NoError(err)
+	s.Equal(int64(1), total)
+	s.Len(reports, 1)
+	s.Equal("venue", reports[0].EntityType)
+}
+
+func (s *EntityReportServiceIntegrationTestSuite) TestListEntityReports_Pagination() {
+	user := s.createTestUser()
+	artist := s.createTestArtist("Test Artist")
+
+	// Create 3 reports from different users
+	user2 := s.createTestUser()
+	user3 := s.createTestUser()
+	s.createReport("artist", artist.ID, user.ID, "inaccurate")
+	s.createReport("artist", artist.ID, user2.ID, "duplicate")
+	s.createReport("artist", artist.ID, user3.ID, "missing_info")
+
+	// Page 1: limit 2
+	reports, total, err := s.svc.ListEntityReports(&contracts.EntityReportFilters{
+		Limit:  2,
+		Offset: 0,
+	})
+	s.NoError(err)
+	s.Equal(int64(3), total)
+	s.Len(reports, 2)
+
+	// Page 2: offset 2
+	reports, total, err = s.svc.ListEntityReports(&contracts.EntityReportFilters{
+		Limit:  2,
+		Offset: 2,
+	})
+	s.NoError(err)
+	s.Equal(int64(3), total)
+	s.Len(reports, 1)
+}
+
+// =============================================================================
+// ResolveEntityReport tests
+// =============================================================================
+
+func (s *EntityReportServiceIntegrationTestSuite) TestResolveEntityReport_Success() {
+	user := s.createTestUser()
+	admin := s.createTestUser()
+	artist := s.createTestArtist("Test Artist")
+	report := s.createReport("artist", artist.ID, user.ID, "inaccurate")
+
+	resolved, err := s.svc.ResolveEntityReport(report.ID, admin.ID, "Fixed the bio")
+	s.NoError(err)
+	s.Require().NotNil(resolved)
+	s.Equal("resolved", resolved.Status)
+	s.Require().NotNil(resolved.ReviewedBy)
+	s.Equal(admin.ID, *resolved.ReviewedBy)
+	s.NotNil(resolved.ReviewedAt)
+	s.Require().NotNil(resolved.AdminNotes)
+	s.Equal("Fixed the bio", *resolved.AdminNotes)
+}
+
+func (s *EntityReportServiceIntegrationTestSuite) TestResolveEntityReport_NoNotes() {
+	user := s.createTestUser()
+	admin := s.createTestUser()
+	artist := s.createTestArtist("Test Artist")
+	report := s.createReport("artist", artist.ID, user.ID, "inaccurate")
+
+	resolved, err := s.svc.ResolveEntityReport(report.ID, admin.ID, "")
+	s.NoError(err)
+	s.Require().NotNil(resolved)
+	s.Equal("resolved", resolved.Status)
+	s.Nil(resolved.AdminNotes)
+}
+
+func (s *EntityReportServiceIntegrationTestSuite) TestResolveEntityReport_NotFound() {
+	_, err := s.svc.ResolveEntityReport(99999, 1, "notes")
+	s.Error(err)
+	s.Contains(err.Error(), "not found")
+}
+
+func (s *EntityReportServiceIntegrationTestSuite) TestResolveEntityReport_AlreadyReviewed() {
+	user := s.createTestUser()
+	admin := s.createTestUser()
+	artist := s.createTestArtist("Test Artist")
+	report := s.createReport("artist", artist.ID, user.ID, "inaccurate")
+
+	_, err := s.svc.ResolveEntityReport(report.ID, admin.ID, "fixed")
+	s.NoError(err)
+
+	_, err = s.svc.ResolveEntityReport(report.ID, admin.ID, "again")
+	s.Error(err)
+	s.Contains(err.Error(), "already been reviewed")
+}
+
+// =============================================================================
+// DismissEntityReport tests
+// =============================================================================
+
+func (s *EntityReportServiceIntegrationTestSuite) TestDismissEntityReport_Success() {
+	user := s.createTestUser()
+	admin := s.createTestUser()
+	artist := s.createTestArtist("Test Artist")
+	report := s.createReport("artist", artist.ID, user.ID, "inaccurate")
+
+	dismissed, err := s.svc.DismissEntityReport(report.ID, admin.ID, "Not a valid report")
+	s.NoError(err)
+	s.Require().NotNil(dismissed)
+	s.Equal("dismissed", dismissed.Status)
+	s.Require().NotNil(dismissed.ReviewedBy)
+	s.Equal(admin.ID, *dismissed.ReviewedBy)
+	s.NotNil(dismissed.ReviewedAt)
+	s.Require().NotNil(dismissed.AdminNotes)
+	s.Equal("Not a valid report", *dismissed.AdminNotes)
+}
+
+func (s *EntityReportServiceIntegrationTestSuite) TestDismissEntityReport_NoNotes() {
+	user := s.createTestUser()
+	admin := s.createTestUser()
+	artist := s.createTestArtist("Test Artist")
+	report := s.createReport("artist", artist.ID, user.ID, "inaccurate")
+
+	dismissed, err := s.svc.DismissEntityReport(report.ID, admin.ID, "")
+	s.NoError(err)
+	s.Require().NotNil(dismissed)
+	s.Equal("dismissed", dismissed.Status)
+	s.Nil(dismissed.AdminNotes)
+}
+
+func (s *EntityReportServiceIntegrationTestSuite) TestDismissEntityReport_NotFound() {
+	_, err := s.svc.DismissEntityReport(99999, 1, "notes")
+	s.Error(err)
+	s.Contains(err.Error(), "not found")
+}
+
+func (s *EntityReportServiceIntegrationTestSuite) TestDismissEntityReport_AlreadyReviewed() {
+	user := s.createTestUser()
+	admin := s.createTestUser()
+	artist := s.createTestArtist("Test Artist")
+	report := s.createReport("artist", artist.ID, user.ID, "inaccurate")
+
+	_, err := s.svc.DismissEntityReport(report.ID, admin.ID, "spam")
+	s.NoError(err)
+
+	_, err = s.svc.DismissEntityReport(report.ID, admin.ID, "spam again")
+	s.Error(err)
+	s.Contains(err.Error(), "already been reviewed")
+}
+
+// =============================================================================
+// Relationships and reporter name tests
+// =============================================================================
+
+func (s *EntityReportServiceIntegrationTestSuite) TestReporterName_Included() {
+	user := s.createTestUser()
+	artist := s.createTestArtist("Test Artist")
+	report := s.createReport("artist", artist.ID, user.ID, "inaccurate")
+
+	resp, err := s.svc.GetEntityReport(report.ID)
+	s.NoError(err)
+	s.Require().NotNil(resp)
+	s.NotEmpty(resp.ReporterName)
+}
+
+func (s *EntityReportServiceIntegrationTestSuite) TestReviewerName_Included() {
+	user := s.createTestUser()
+	admin := s.createTestUser()
+	artist := s.createTestArtist("Test Artist")
+	report := s.createReport("artist", artist.ID, user.ID, "inaccurate")
+
+	resolved, err := s.svc.ResolveEntityReport(report.ID, admin.ID, "fixed")
+	s.NoError(err)
+	s.Require().NotNil(resolved)
+	s.NotEmpty(resolved.ReviewerName)
+}

--- a/backend/internal/services/admin/interfaces.go
+++ b/backend/internal/services/admin/interfaces.go
@@ -13,6 +13,7 @@ var (
 	_ contracts.RevisionServiceInterface      = (*RevisionService)(nil)
 	_ contracts.DataQualityServiceInterface  = (*DataQualityService)(nil)
 	_ contracts.AnalyticsServiceInterface   = (*AnalyticsService)(nil)
-	_ contracts.PendingEditServiceInterface = (*PendingEditService)(nil)
+	_ contracts.PendingEditServiceInterface    = (*PendingEditService)(nil)
+	_ contracts.EntityReportServiceInterface  = (*EntityReportService)(nil)
 	// CleanupService has no interface in contracts — it's a lifecycle service.
 )

--- a/backend/internal/services/container.go
+++ b/backend/internal/services/container.go
@@ -48,6 +48,7 @@ type ServiceContainer struct {
 	SavedShow     *engagement.SavedShowService
 	Show          *catalog.ShowService
 	ShowReport    *adminsvc.ShowReportService
+	EntityReport  *adminsvc.EntityReportService
 	User              *usersvc.UserService
 	Venue             *catalog.VenueService
 	VenueSourceConfig *pipeline.VenueSourceConfigService
@@ -153,6 +154,7 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 		SavedShow:     savedShow,
 		Show:          catalog.NewShowService(database),
 		ShowReport:    adminsvc.NewShowReportService(database),
+		EntityReport:  adminsvc.NewEntityReportService(database),
 		User:          userService,
 		Venue:             venue,
 		VenueSourceConfig: venueSourceConfig,

--- a/backend/internal/services/contracts/entity_report.go
+++ b/backend/internal/services/contracts/entity_report.go
@@ -1,0 +1,68 @@
+package contracts
+
+import (
+	"time"
+)
+
+// ──────────────────────────────────────────────
+// Entity Report Service Interface
+// ──────────────────────────────────────────────
+
+// EntityReportServiceInterface defines the contract for managing generalized entity reports.
+type EntityReportServiceInterface interface {
+	// CreateEntityReport submits a new report for an entity.
+	CreateEntityReport(req *CreateEntityReportRequest) (*EntityReportResponse, error)
+
+	// GetEntityReport returns a single report by ID.
+	GetEntityReport(reportID uint) (*EntityReportResponse, error)
+
+	// GetEntityReports returns all reports for a specific entity.
+	GetEntityReports(entityType string, entityID uint) ([]EntityReportResponse, error)
+
+	// ListEntityReports returns reports for the admin review queue.
+	ListEntityReports(filters *EntityReportFilters) ([]EntityReportResponse, int64, error)
+
+	// ResolveEntityReport marks a report as resolved (action was taken).
+	ResolveEntityReport(reportID uint, reviewerID uint, notes string) (*EntityReportResponse, error)
+
+	// DismissEntityReport marks a report as dismissed (spam/invalid).
+	DismissEntityReport(reportID uint, reviewerID uint, notes string) (*EntityReportResponse, error)
+}
+
+// ──────────────────────────────────────────────
+// Request / Response Types
+// ──────────────────────────────────────────────
+
+// CreateEntityReportRequest contains the data needed to submit an entity report.
+type CreateEntityReportRequest struct {
+	EntityType string  `json:"entity_type"`
+	EntityID   uint    `json:"entity_id"`
+	UserID     uint    `json:"-"`
+	ReportType string  `json:"report_type"`
+	Details    *string `json:"details,omitempty"`
+}
+
+// EntityReportFilters contains filters for listing entity reports.
+type EntityReportFilters struct {
+	Status     string `json:"status,omitempty"`      // "pending", "resolved", "dismissed"
+	EntityType string `json:"entity_type,omitempty"` // "artist", "venue", "festival", "show"
+	Limit      int    `json:"limit,omitempty"`
+	Offset     int    `json:"offset,omitempty"`
+}
+
+// EntityReportResponse is the API response for an entity report.
+type EntityReportResponse struct {
+	ID           uint       `json:"id"`
+	EntityType   string     `json:"entity_type"`
+	EntityID     uint       `json:"entity_id"`
+	ReportedBy   uint       `json:"reported_by"`
+	ReporterName string     `json:"reporter_name,omitempty"`
+	ReportType   string     `json:"report_type"`
+	Details      *string    `json:"details,omitempty"`
+	Status       string     `json:"status"`
+	AdminNotes   *string    `json:"admin_notes,omitempty"`
+	ReviewedBy   *uint      `json:"reviewed_by,omitempty"`
+	ReviewerName string     `json:"reviewer_name,omitempty"`
+	ReviewedAt   *time.Time `json:"reviewed_at,omitempty"`
+	CreatedAt    time.Time  `json:"created_at"`
+}


### PR DESCRIPTION
## Summary

- Migration 000062: `entity_reports` table with JSONB-free design (report_type VARCHAR), indexes for review queue and entity lookups
- GORM model with per-entity-type report categories (artist: 5, venue: 5, festival: 4, show: 5) and validation helpers
- `EntityReportService`: Create (with entity existence check + duplicate prevention), Get, List (filterable), Resolve, Dismiss
- 8 API endpoints: 4 per-entity report submission (rate-limited) + 4 admin review (list/get/resolve/dismiss)
- Show reports use `/shows/{id}/entity-report` to avoid conflict with existing `/shows/{id}/report`
- Fire-and-forget audit logging on resolve/dismiss
- 69 tests total (38 service integration + 31 handler unit)

## Test plan

- [x] Service integration tests pass (38 tests with testcontainers)
- [x] Handler unit tests pass (31 tests)
- [x] `go build ./...` compiles clean
- [ ] Manual test: submit artist/venue/festival/show report
- [ ] Manual test: admin lists, resolves, and dismisses reports
- [ ] Manual test: duplicate pending report rejected

Closes PSY-130

🤖 Generated with [Claude Code](https://claude.com/claude-code)