### PR TITLE
Fix missing assertion in AuthContext logout test (PSY-247)

### DIFF
--- a/frontend/lib/context/AuthContext.test.tsx
+++ b/frontend/lib/context/AuthContext.test.tsx
@@ -371,8 +371,9 @@ describe('AuthContext', () => {
         result.current.logout()
       })
 
-      // User override should be cleared (null)
-      // Profile data would determine the final user state
+      // User override should be cleared — with no profile data, user is null
+      expect(result.current.user).toBeNull()
+      expect(result.current.isAuthenticated).toBe(false)
     })
 
     it('clears error override on logout', async () => {


### PR DESCRIPTION
## Summary
- The "clears user override on logout" test in `AuthContext.test.tsx` set a user override, called `logout()`, but ended with only a comment describing what should be asserted — no actual assertion
- Added `expect(result.current.user).toBeNull()` and `expect(result.current.isAuthenticated).toBe(false)` to verify logout properly clears the user override

## Test plan
- [x] All 21 AuthContext tests pass (`bun run test -- lib/context/AuthContext`)
- [x] Verified the implementation already clears the override (`setUserOverride(null)` on line 99 of `AuthContext.tsx`) — only the test assertion was missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)