### PR TITLE
Fix useRevisions offset=0 skipped by falsy check (PSY-246)

### DIFF
--- a/frontend/lib/hooks/common/useRevisions.test.tsx
+++ b/frontend/lib/hooks/common/useRevisions.test.tsx
@@ -61,9 +61,21 @@ describe('useEntityRevisions', () => {
     const url = mockApiRequest.mock.calls[0][0] as string
     expect(url).toContain('/revisions/artist/42')
     expect(url).toContain('limit=20')
-    // Note: offset=0 is falsy, so the hook's `if (offset)` check skips it.
-    // This is a minor bug -- offset 0 is valid but gets omitted.
-    // The backend defaults to 0 anyway, so it's functionally correct.
+    expect(url).toContain('offset=0')
+  })
+
+  it('includes offset=0 in query params (regression: falsy check skipped offset 0)', async () => {
+    mockApiRequest.mockResolvedValueOnce({ revisions: [], total: 0 })
+
+    const { result } = renderHook(
+      () => useEntityRevisions('artist', 42, { offset: 0 }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const url = mockApiRequest.mock.calls[0][0] as string
+    expect(url).toContain('offset=0')
+    expect(url).toContain('limit=20')
   })
 
   it('includes custom limit and offset', async () => {

--- a/frontend/lib/hooks/common/useRevisions.ts
+++ b/frontend/lib/hooks/common/useRevisions.ts
@@ -52,8 +52,8 @@ export function useEntityRevisions(
     queryKey: [...queryKeys.revisions.entity(entityType, entityId), { limit, offset }],
     queryFn: () => {
       const params = new URLSearchParams()
-      if (limit) params.set('limit', String(limit))
-      if (offset) params.set('offset', String(offset))
+      if (limit != null) params.set('limit', String(limit))
+      if (offset != null) params.set('offset', String(offset))
       const qs = params.toString()
       const url = `${API_ENDPOINTS.REVISIONS.ENTITY_HISTORY(entityType, entityId)}${qs ? `?${qs}` : ''}`
       return apiRequest<EntityHistoryResponse>(url)
@@ -91,8 +91,8 @@ export function useUserRevisions(
     queryKey: [...queryKeys.revisions.user(userId), { limit, offset }],
     queryFn: () => {
       const params = new URLSearchParams()
-      if (limit) params.set('limit', String(limit))
-      if (offset) params.set('offset', String(offset))
+      if (limit != null) params.set('limit', String(limit))
+      if (offset != null) params.set('offset', String(offset))
       const qs = params.toString()
       const url = `${API_ENDPOINTS.REVISIONS.USER_REVISIONS(userId)}${qs ? `?${qs}` : ''}`
       return apiRequest<UserRevisionsResponse>(url)


### PR DESCRIPTION
## Summary
- Fixed `if (offset)` / `if (limit)` guards in `useEntityRevisions` and `useUserRevisions` that incorrectly skipped `offset=0` (and hypothetically `limit=0`) because `0` is falsy in JavaScript
- Changed to `if (offset != null)` / `if (limit != null)` null checks so that `0` is correctly included as a query parameter
- Added regression test that explicitly passes `offset: 0` and asserts it appears in the URL
- Removed the comment documenting the known bug, updated the default-offset test to assert `offset=0` is present

## Test plan
- [x] All 10 existing + new useRevisions tests pass (`bun run test -- lib/hooks/common/useRevisions`)
- [x] New regression test: `includes offset=0 in query params (regression: falsy check skipped offset 0)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)