### PR TITLE
PSY-245: Strengthen weak test assertions in formatters and LoadingSpinner

### DIFF
--- a/frontend/components/shared/LoadingSpinner.test.tsx
+++ b/frontend/components/shared/LoadingSpinner.test.tsx
@@ -3,9 +3,14 @@ import { render, screen } from '@testing-library/react'
 import { LoadingSpinner } from './LoadingSpinner'
 
 describe('LoadingSpinner', () => {
-  it('renders a div element', () => {
+  it('renders a div element with spinner styling', () => {
     const { container } = render(<LoadingSpinner />)
-    expect(container.firstChild).toBeInTheDocument()
+    const spinner = container.firstChild as HTMLElement
+    expect(spinner).toBeInTheDocument()
+    expect(spinner.tagName).toBe('DIV')
+    expect(spinner.className).toContain('animate-spin')
+    expect(spinner.className).toContain('rounded-full')
+    expect(spinner.className).toContain('border-b-2')
   })
 
   it('defaults to medium size', () => {

--- a/frontend/lib/utils/formatters.test.ts
+++ b/frontend/lib/utils/formatters.test.ts
@@ -79,17 +79,18 @@ describe('formatShowTime', () => {
   const utcDate = '2026-03-15T02:30:00Z'
 
   it('defaults to AZ timezone', () => {
+    // 02:30 UTC = 7:30 PM in America/Phoenix (UTC-7, no DST)
     const result = formatShowTime(utcDate)
-    expect(result).toMatch(/PM|AM/)
+    expect(result).toBe('7:30 PM')
   })
 
   it('respects explicit state timezone', () => {
     const resultAZ = formatShowTime(utcDate, 'AZ')
     const resultNY = formatShowTime(utcDate, 'NY')
-    // Different timezones should produce different times
-    // AZ = 7:30 PM, NY = 10:30 PM (or 9:30 PM depending on DST)
-    expect(resultAZ).toMatch(/PM|AM/)
-    expect(resultNY).toMatch(/PM|AM/)
+    // 02:30 UTC on Mar 15 = 7:30 PM in Phoenix (UTC-7), 10:30 PM in New York (UTC-4 DST)
+    expect(resultAZ).toBe('7:30 PM')
+    expect(resultNY).toBe('10:30 PM')
+    expect(resultAZ).not.toBe(resultNY)
   })
 })
 
@@ -142,9 +143,18 @@ describe('formatAdminDate', () => {
 })
 
 describe('formatAdminTime', () => {
-  it('formats time with AM/PM', () => {
-    const result = formatAdminTime('2026-01-15T19:30:00Z')
-    expect(result).toMatch(/\d{1,2}:\d{2}\s*(AM|PM)/)
+  it('formats time with AM/PM matching local timezone', () => {
+    const input = '2026-01-15T19:30:00Z'
+    const result = formatAdminTime(input)
+    // Verify minutes are preserved (invariant across timezones)
+    expect(result).toContain(':30')
+    // Verify it matches the expected local-timezone conversion
+    const expected = new Date(input).toLocaleTimeString('en-US', {
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true,
+    })
+    expect(result).toBe(expected)
   })
 })
 


### PR DESCRIPTION
## Summary
- **formatShowTime tests**: Replace weak `/PM|AM/` regex assertions with exact value checks (`7:30 PM`, `10:30 PM`), and verify AZ vs NY timezones produce different results
- **formatAdminTime test**: Replace format-only regex with actual value verification against expected local-timezone conversion, plus invariant minutes check
- **LoadingSpinner test**: Replace bare `toBeInTheDocument()` existence check with assertions verifying element is a `DIV` with spinner-specific classes (`animate-spin`, `rounded-full`, `border-b-2`)
- **useRevisions**: Skipped -- already fixed by PSY-246

## Test plan
- [x] `bun run test -- lib/utils/formatters` passes (17 tests)
- [x] `bun run test -- components/shared/LoadingSpinner` passes (7 tests)
- [x] `bun run test:run` full suite passes (2456 tests, 178 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)