### PR TITLE
PSY-240: Remove trivial constructor tests

### DIFF
--- a/backend/internal/api/handlers/admin_test.go
+++ b/backend/internal/api/handlers/admin_test.go
@@ -51,48 +51,6 @@ func adminCtx() context.Context {
 // Constructor tests
 // ============================================================================
 
-func TestNewAdminShowHandler(t *testing.T) {
-	h := testAdminShowHandler()
-	if h == nil {
-		t.Fatal("expected non-nil AdminShowHandler")
-	}
-}
-
-func TestNewAdminVenueHandler(t *testing.T) {
-	h := testAdminVenueHandler()
-	if h == nil {
-		t.Fatal("expected non-nil AdminVenueHandler")
-	}
-}
-
-func TestNewAdminTokenHandler(t *testing.T) {
-	h := testAdminTokenHandler()
-	if h == nil {
-		t.Fatal("expected non-nil AdminTokenHandler")
-	}
-}
-
-func TestNewAdminDataHandler(t *testing.T) {
-	h := testAdminDataHandler()
-	if h == nil {
-		t.Fatal("expected non-nil AdminDataHandler")
-	}
-}
-
-func TestNewAdminUserHandler(t *testing.T) {
-	h := testAdminUserHandler()
-	if h == nil {
-		t.Fatal("expected non-nil AdminUserHandler")
-	}
-}
-
-func TestNewAdminStatsHandler(t *testing.T) {
-	h := testAdminStatsHandler()
-	if h == nil {
-		t.Fatal("expected non-nil AdminStatsHandler")
-	}
-}
-
 // ============================================================================
 // Admin Guard: all handlers require admin access
 // Tests both nil-user and non-admin user scenarios for every admin handler.

--- a/backend/internal/api/handlers/analytics_test.go
+++ b/backend/internal/api/handlers/analytics_test.go
@@ -29,13 +29,6 @@ func analyticsNonAdminCtx() context.Context {
 // Tests: NewAnalyticsHandler
 // ============================================================================
 
-func TestNewAnalyticsHandler(t *testing.T) {
-	h := testAnalyticsHandler()
-	if h == nil {
-		t.Fatal("expected non-nil AnalyticsHandler")
-	}
-}
-
 // ============================================================================
 // Tests: Admin Guard - Growth
 // ============================================================================

--- a/backend/internal/api/handlers/apple_auth_test.go
+++ b/backend/internal/api/handlers/apple_auth_test.go
@@ -13,13 +13,6 @@ func testAppleAuthHandler() *AppleAuthHandler {
 
 // --- NewAppleAuthHandler ---
 
-func TestNewAppleAuthHandler(t *testing.T) {
-	h := testAppleAuthHandler()
-	if h == nil {
-		t.Fatal("expected non-nil AppleAuthHandler")
-	}
-}
-
 // --- AppleCallbackHandler ---
 
 func TestAppleCallbackHandler_EmptyToken(t *testing.T) {

--- a/backend/internal/api/handlers/artist_report_test.go
+++ b/backend/internal/api/handlers/artist_report_test.go
@@ -15,13 +15,6 @@ func testArtistReportHandler() *ArtistReportHandler {
 
 // --- NewArtistReportHandler ---
 
-func TestNewArtistReportHandler(t *testing.T) {
-	h := testArtistReportHandler()
-	if h == nil {
-		t.Fatal("expected non-nil ArtistReportHandler")
-	}
-}
-
 // --- ReportArtistHandler ---
 
 func TestReportArtistHandler_NoAuth(t *testing.T) {

--- a/backend/internal/api/handlers/artist_test.go
+++ b/backend/internal/api/handlers/artist_test.go
@@ -16,13 +16,6 @@ func testArtistHandler() *ArtistHandler {
 
 // --- NewArtistHandler ---
 
-func TestNewArtistHandler(t *testing.T) {
-	h := testArtistHandler()
-	if h == nil {
-		t.Fatal("expected non-nil ArtistHandler")
-	}
-}
-
 // --- DeleteArtistHandler ---
 
 func TestDeleteArtist_NoAuth(t *testing.T) {

--- a/backend/internal/api/handlers/attendance_test.go
+++ b/backend/internal/api/handlers/attendance_test.go
@@ -16,13 +16,6 @@ func testAttendanceHandler() *AttendanceHandler {
 
 // --- NewAttendanceHandler ---
 
-func TestNewAttendanceHandler(t *testing.T) {
-	h := testAttendanceHandler()
-	if h == nil {
-		t.Fatal("expected non-nil AttendanceHandler")
-	}
-}
-
 // --- SetAttendanceHandler ---
 
 func TestSetAttendanceHandler_NoAuth(t *testing.T) {

--- a/backend/internal/api/handlers/audit_log_test.go
+++ b/backend/internal/api/handlers/audit_log_test.go
@@ -15,13 +15,6 @@ func testAuditLogHandler() *AuditLogHandler {
 
 // --- NewAuditLogHandler ---
 
-func TestNewAuditLogHandler(t *testing.T) {
-	h := testAuditLogHandler()
-	if h == nil {
-		t.Fatal("expected non-nil AuditLogHandler")
-	}
-}
-
 // --- GetAuditLogsHandler ---
 
 func TestGetAuditLogsHandler_NoAuth(t *testing.T) {

--- a/backend/internal/api/handlers/auth_test.go
+++ b/backend/internal/api/handlers/auth_test.go
@@ -52,13 +52,6 @@ func testJWTService() *auth.JWTService {
 
 // --- TestNewAuthHandler ---
 
-func TestNewAuthHandler(t *testing.T) {
-	h := NewAuthHandler(nil, nil, nil, nil, nil, nil, testConfig())
-	if h == nil {
-		t.Fatal("expected non-nil AuthHandler")
-	}
-}
-
 // --- LoginHandler ---
 
 func TestLoginHandler_EmptyCredentials(t *testing.T) {

--- a/backend/internal/api/handlers/charts_test.go
+++ b/backend/internal/api/handlers/charts_test.go
@@ -21,13 +21,6 @@ func testChartsHandler() *ChartsHandler {
 // Tests: NewChartsHandler
 // ============================================================================
 
-func TestNewChartsHandler(t *testing.T) {
-	h := testChartsHandler()
-	if h == nil {
-		t.Fatal("expected non-nil ChartsHandler")
-	}
-}
-
 // ============================================================================
 // Tests: normalizeChartsLimit
 // ============================================================================

--- a/backend/internal/api/handlers/data_quality_test.go
+++ b/backend/internal/api/handlers/data_quality_test.go
@@ -29,13 +29,6 @@ func dataQualityNonAdminCtx() context.Context {
 // Tests: NewDataQualityHandler
 // ============================================================================
 
-func TestNewDataQualityHandler(t *testing.T) {
-	h := testDataQualityHandler()
-	if h == nil {
-		t.Fatal("expected non-nil DataQualityHandler")
-	}
-}
-
 // ============================================================================
 // Tests: Admin Guard
 // ============================================================================

--- a/backend/internal/api/handlers/entity_report_test.go
+++ b/backend/internal/api/handlers/entity_report_test.go
@@ -43,13 +43,6 @@ func makeEntityReportResponse(id uint, entityType, reportType string) *contracts
 // Tests: NewEntityReportHandler
 // ============================================================================
 
-func TestNewEntityReportHandler(t *testing.T) {
-	h := testEntityReportHandler()
-	if h == nil {
-		t.Fatal("expected non-nil EntityReportHandler")
-	}
-}
-
 // ============================================================================
 // Tests: Report Entity — Auth & Validation
 // ============================================================================

--- a/backend/internal/api/handlers/favorite_venue_test.go
+++ b/backend/internal/api/handlers/favorite_venue_test.go
@@ -15,13 +15,6 @@ func testFavoriteVenueHandler() *FavoriteVenueHandler {
 
 // --- NewFavoriteVenueHandler ---
 
-func TestNewFavoriteVenueHandler(t *testing.T) {
-	h := testFavoriteVenueHandler()
-	if h == nil {
-		t.Fatal("expected non-nil FavoriteVenueHandler")
-	}
-}
-
 // --- FavoriteVenueHandler (method) ---
 
 func TestFavoriteVenueHandler_FavoriteVenue_NoAuth(t *testing.T) {

--- a/backend/internal/api/handlers/follow_test.go
+++ b/backend/internal/api/handlers/follow_test.go
@@ -16,13 +16,6 @@ func testFollowHandler() *FollowHandler {
 
 // --- NewFollowHandler ---
 
-func TestNewFollowHandler(t *testing.T) {
-	h := testFollowHandler()
-	if h == nil {
-		t.Fatal("expected non-nil FollowHandler")
-	}
-}
-
 // --- FollowEntityHandler ---
 
 func TestFollowEntityHandler_NoAuth(t *testing.T) {

--- a/backend/internal/api/handlers/notification_filter_test.go
+++ b/backend/internal/api/handlers/notification_filter_test.go
@@ -20,13 +20,6 @@ func testNotificationFilterHandler() *NotificationFilterHandler {
 
 // --- NewNotificationFilterHandler ---
 
-func TestNewNotificationFilterHandler(t *testing.T) {
-	h := testNotificationFilterHandler()
-	if h == nil {
-		t.Fatal("expected non-nil NotificationFilterHandler")
-	}
-}
-
 // --- ListFiltersHandler ---
 
 func TestListFiltersHandler_NoAuth(t *testing.T) {

--- a/backend/internal/api/handlers/oauth_account_test.go
+++ b/backend/internal/api/handlers/oauth_account_test.go
@@ -13,13 +13,6 @@ func testOAuthAccountHandler() *OAuthAccountHandler {
 
 // --- NewOAuthAccountHandler ---
 
-func TestNewOAuthAccountHandler(t *testing.T) {
-	h := testOAuthAccountHandler()
-	if h == nil {
-		t.Fatal("expected non-nil OAuthAccountHandler")
-	}
-}
-
 // --- GetOAuthAccountsHandler ---
 
 func TestGetOAuthAccountsHandler_NoAuth(t *testing.T) {

--- a/backend/internal/api/handlers/oauth_handlers_test.go
+++ b/backend/internal/api/handlers/oauth_handlers_test.go
@@ -121,13 +121,6 @@ func TestCLICallbackStore_CleansExpiredOnStore(t *testing.T) {
 
 // --- NewOAuthHTTPHandler ---
 
-func TestNewOAuthHTTPHandler(t *testing.T) {
-	handler := NewOAuthHTTPHandler(nil, nil)
-	if handler == nil {
-		t.Fatal("expected non-nil handler")
-	}
-}
-
 // --- OAuthLoginHTTPHandler (real handler, validation paths) ---
 
 func oauthLoginRequest(provider string) (*httptest.ResponseRecorder, *http.Request) {

--- a/backend/internal/api/handlers/passkey_test.go
+++ b/backend/internal/api/handlers/passkey_test.go
@@ -26,13 +26,6 @@ func testPasskeyHandlerWithMocks(wa *mockWebAuthnService, jwt *mockJWTService, u
 
 // --- NewPasskeyHandler ---
 
-func TestNewPasskeyHandler(t *testing.T) {
-	h := testPasskeyHandler()
-	if h == nil {
-		t.Fatal("expected non-nil PasskeyHandler")
-	}
-}
-
 // ============================================================================
 // BeginRegisterHandler
 // ============================================================================

--- a/backend/internal/api/handlers/pending_edit_test.go
+++ b/backend/internal/api/handlers/pending_edit_test.go
@@ -60,13 +60,6 @@ func makePendingEditResponse(id uint) *contracts.PendingEditResponse {
 // Tests: NewPendingEditHandler
 // ============================================================================
 
-func TestNewPendingEditHandler(t *testing.T) {
-	h := testPendingEditHandler()
-	if h == nil {
-		t.Fatal("expected non-nil PendingEditHandler")
-	}
-}
-
 // ============================================================================
 // Tests: SuggestEdit — Auth & Validation
 // ============================================================================

--- a/backend/internal/api/handlers/pipeline_test.go
+++ b/backend/internal/api/handlers/pipeline_test.go
@@ -29,13 +29,6 @@ func pipelineNonAdminCtx() context.Context {
 // Tests: NewPipelineHandler
 // ============================================================================
 
-func TestNewPipelineHandler(t *testing.T) {
-	h := testPipelineHandler()
-	if h == nil {
-		t.Fatal("expected non-nil PipelineHandler")
-	}
-}
-
 // ============================================================================
 // Tests: Admin Guard
 // ============================================================================

--- a/backend/internal/api/handlers/request_test.go
+++ b/backend/internal/api/handlers/request_test.go
@@ -28,13 +28,6 @@ func requestAdminCtx() context.Context {
 // Tests: NewRequestHandler
 // ============================================================================
 
-func TestNewRequestHandler(t *testing.T) {
-	h := testRequestHandler()
-	if h == nil {
-		t.Fatal("expected non-nil RequestHandler")
-	}
-}
-
 // ============================================================================
 // Tests: Auth Guard — all mutating endpoints require auth
 // ============================================================================

--- a/backend/internal/api/handlers/revision_test.go
+++ b/backend/internal/api/handlers/revision_test.go
@@ -54,13 +54,6 @@ func makeTestRevision(id uint) models.Revision {
 // Tests: NewRevisionHandler
 // ============================================================================
 
-func TestNewRevisionHandler(t *testing.T) {
-	h := testRevisionHandler()
-	if h == nil {
-		t.Fatal("expected non-nil RevisionHandler")
-	}
-}
-
 // ============================================================================
 // Tests: Admin Guard (Rollback only)
 // ============================================================================

--- a/backend/internal/api/handlers/saved_show_test.go
+++ b/backend/internal/api/handlers/saved_show_test.go
@@ -15,13 +15,6 @@ func testSavedShowHandler() *SavedShowHandler {
 
 // --- NewSavedShowHandler ---
 
-func TestNewSavedShowHandler(t *testing.T) {
-	h := testSavedShowHandler()
-	if h == nil {
-		t.Fatal("expected non-nil SavedShowHandler")
-	}
-}
-
 // --- SaveShowHandler ---
 
 func TestSaveShowHandler_NoAuth(t *testing.T) {

--- a/backend/internal/api/handlers/scene_test.go
+++ b/backend/internal/api/handlers/scene_test.go
@@ -12,13 +12,6 @@ import (
 // Constructor
 // ============================================================================
 
-func TestNewSceneHandler(t *testing.T) {
-	h := NewSceneHandler(nil)
-	if h == nil {
-		t.Fatal("expected non-nil SceneHandler")
-	}
-}
-
 // ============================================================================
 // ListScenesHandler Tests
 // ============================================================================

--- a/backend/internal/api/handlers/show_report_test.go
+++ b/backend/internal/api/handlers/show_report_test.go
@@ -15,13 +15,6 @@ func testShowReportHandler() *ShowReportHandler {
 
 // --- NewShowReportHandler ---
 
-func TestNewShowReportHandler(t *testing.T) {
-	h := testShowReportHandler()
-	if h == nil {
-		t.Fatal("expected non-nil ShowReportHandler")
-	}
-}
-
 // --- ReportShowHandler ---
 
 func TestReportShowHandler_NoAuth(t *testing.T) {

--- a/backend/internal/api/handlers/show_test.go
+++ b/backend/internal/api/handlers/show_test.go
@@ -36,13 +36,6 @@ func testShowHandler() *ShowHandler {
 
 // --- NewShowHandler ---
 
-func TestNewShowHandler(t *testing.T) {
-	h := testShowHandler()
-	if h == nil {
-		t.Fatal("expected non-nil ShowHandler")
-	}
-}
-
 // --- CreateShowHandler ---
 
 func TestCreateShowHandler_UnverifiedEmail(t *testing.T) {

--- a/backend/internal/api/handlers/user_preferences_test.go
+++ b/backend/internal/api/handlers/user_preferences_test.go
@@ -11,13 +11,6 @@ import (
 
 // --- Constructor ---
 
-func TestNewUserPreferencesHandler(t *testing.T) {
-	h := NewUserPreferencesHandler(nil, "test-secret")
-	if h == nil {
-		t.Fatal("expected non-nil handler")
-	}
-}
-
 // --- SetFavoriteCitiesHandler ---
 
 func TestSetFavoriteCitiesHandler_NoAuth(t *testing.T) {

--- a/backend/internal/api/handlers/venue_test.go
+++ b/backend/internal/api/handlers/venue_test.go
@@ -13,13 +13,6 @@ func testVenueHandler() *VenueHandler {
 
 // --- NewVenueHandler ---
 
-func TestNewVenueHandler(t *testing.T) {
-	h := testVenueHandler()
-	if h == nil {
-		t.Fatal("expected non-nil VenueHandler")
-	}
-}
-
 // --- AdminCreateVenueHandler ---
 
 func TestAdminCreateVenueHandler_NoAuth(t *testing.T) {

--- a/backend/internal/services/admin/analytics_test.go
+++ b/backend/internal/services/admin/analytics_test.go
@@ -18,19 +18,6 @@ import (
 // UNIT TESTS (No Database Required)
 // =============================================================================
 
-func TestNewAnalyticsService(t *testing.T) {
-	t.Run("NilDB", func(t *testing.T) {
-		svc := NewAnalyticsService(nil)
-		assert.NotNil(t, svc)
-	})
-
-	t.Run("ExplicitDB", func(t *testing.T) {
-		db := &gorm.DB{}
-		svc := NewAnalyticsService(db)
-		assert.NotNil(t, svc)
-	})
-}
-
 func TestAnalyticsService_NilDB(t *testing.T) {
 	svc := &AnalyticsService{db: nil}
 

--- a/backend/internal/services/admin/api_token_test.go
+++ b/backend/internal/services/admin/api_token_test.go
@@ -18,11 +18,6 @@ import (
 // UNIT TESTS (No Database Required)
 // =============================================================================
 
-func TestNewAPITokenService(t *testing.T) {
-	svc := NewAPITokenService(nil)
-	assert.NotNil(t, svc)
-}
-
 func TestAPITokenService_NilDatabase(t *testing.T) {
 	svc := &APITokenService{db: nil}
 

--- a/backend/internal/services/admin/artist_report_test.go
+++ b/backend/internal/services/admin/artist_report_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"gorm.io/gorm"
 
@@ -16,11 +15,6 @@ import (
 // =============================================================================
 // UNIT TESTS (No Database Required)
 // =============================================================================
-
-func TestNewArtistReportService(t *testing.T) {
-	svc := NewArtistReportService(nil)
-	assert.NotNil(t, svc)
-}
 
 func TestArtistReportService_NilDatabase(t *testing.T) {
 	svc := &ArtistReportService{db: nil}

--- a/backend/internal/services/admin/audit_log_test.go
+++ b/backend/internal/services/admin/audit_log_test.go
@@ -18,11 +18,6 @@ import (
 // UNIT TESTS (No Database Required)
 // =============================================================================
 
-func TestNewAuditLogService(t *testing.T) {
-	svc := NewAuditLogService(nil)
-	assert.NotNil(t, svc)
-}
-
 func TestAuditLogService_NilDatabase(t *testing.T) {
 	svc := &AuditLogService{db: nil}
 

--- a/backend/internal/services/admin/data_quality_test.go
+++ b/backend/internal/services/admin/data_quality_test.go
@@ -17,19 +17,6 @@ import (
 // UNIT TESTS (No Database Required)
 // =============================================================================
 
-func TestNewDataQualityService(t *testing.T) {
-	t.Run("NilDB", func(t *testing.T) {
-		svc := NewDataQualityService(nil)
-		assert.NotNil(t, svc)
-	})
-
-	t.Run("ExplicitDB", func(t *testing.T) {
-		db := &gorm.DB{}
-		svc := NewDataQualityService(db)
-		assert.NotNil(t, svc)
-	})
-}
-
 func TestDataQualityService_NilDB(t *testing.T) {
 	svc := &DataQualityService{db: nil}
 	assert.Panics(t, func() {

--- a/backend/internal/services/admin/data_sync_test.go
+++ b/backend/internal/services/admin/data_sync_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"gorm.io/gorm"
 
@@ -18,19 +17,6 @@ import (
 // =============================================================================
 // UNIT TESTS (No Database Required)
 // =============================================================================
-
-func TestNewDataSyncService(t *testing.T) {
-	t.Run("NilDB", func(t *testing.T) {
-		svc := NewDataSyncService(nil)
-		assert.NotNil(t, svc)
-	})
-
-	t.Run("ExplicitDB", func(t *testing.T) {
-		db := &gorm.DB{}
-		svc := NewDataSyncService(db)
-		assert.NotNil(t, svc)
-	})
-}
 
 func TestDataSyncService_NilDB(t *testing.T) {
 	svc := &DataSyncService{db: nil}

--- a/backend/internal/services/admin/entity_report_test.go
+++ b/backend/internal/services/admin/entity_report_test.go
@@ -18,11 +18,6 @@ import (
 // UNIT TESTS (No Database Required)
 // =============================================================================
 
-func TestNewEntityReportService(t *testing.T) {
-	svc := NewEntityReportService(nil)
-	assert.NotNil(t, svc)
-}
-
 func TestEntityReportService_NilDatabase(t *testing.T) {
 	svc := &EntityReportService{db: nil}
 

--- a/backend/internal/services/admin/pending_edit_test.go
+++ b/backend/internal/services/admin/pending_edit_test.go
@@ -19,11 +19,6 @@ import (
 // UNIT TESTS (No Database Required)
 // =============================================================================
 
-func TestNewPendingEditService(t *testing.T) {
-	svc := NewPendingEditService(nil, nil)
-	assert.NotNil(t, svc)
-}
-
 func TestPendingEditService_NilDatabase(t *testing.T) {
 	svc := &PendingEditService{db: nil}
 

--- a/backend/internal/services/admin/revision_test.go
+++ b/backend/internal/services/admin/revision_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"gorm.io/gorm"
 
@@ -17,11 +16,6 @@ import (
 // =============================================================================
 // UNIT TESTS (No Database Required)
 // =============================================================================
-
-func TestNewRevisionService(t *testing.T) {
-	svc := NewRevisionService(nil)
-	assert.NotNil(t, svc)
-}
 
 func TestRevisionService_NilDatabase(t *testing.T) {
 	svc := &RevisionService{db: nil}

--- a/backend/internal/services/admin/show_report_test.go
+++ b/backend/internal/services/admin/show_report_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"gorm.io/gorm"
 
@@ -16,11 +15,6 @@ import (
 // =============================================================================
 // UNIT TESTS (No Database Required)
 // =============================================================================
-
-func TestNewShowReportService(t *testing.T) {
-	svc := NewShowReportService(nil)
-	assert.NotNil(t, svc)
-}
 
 func TestShowReportService_NilDatabase(t *testing.T) {
 	svc := &ShowReportService{db: nil}

--- a/backend/internal/services/admin/stats_test.go
+++ b/backend/internal/services/admin/stats_test.go
@@ -17,19 +17,6 @@ import (
 // UNIT TESTS (No Database Required)
 // =============================================================================
 
-func TestNewAdminStatsService(t *testing.T) {
-	t.Run("NilDB", func(t *testing.T) {
-		svc := NewAdminStatsService(nil)
-		assert.NotNil(t, svc)
-	})
-
-	t.Run("ExplicitDB", func(t *testing.T) {
-		db := &gorm.DB{}
-		svc := NewAdminStatsService(db)
-		assert.NotNil(t, svc)
-	})
-}
-
 func TestAdminStatsService_NilDB(t *testing.T) {
 	svc := &AdminStatsService{db: nil}
 	assert.Panics(t, func() {

--- a/backend/internal/services/catalog/artist_relationship_service_test.go
+++ b/backend/internal/services/catalog/artist_relationship_service_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"gorm.io/gorm"
 
@@ -16,11 +15,6 @@ import (
 // =============================================================================
 // UNIT TESTS
 // =============================================================================
-
-func TestNewArtistRelationshipService(t *testing.T) {
-	svc := NewArtistRelationshipService(nil)
-	assert.NotNil(t, svc)
-}
 
 func TestArtistRelationshipService_NilDatabase(t *testing.T) {
 	svc := &ArtistRelationshipService{db: nil}

--- a/backend/internal/services/catalog/artist_test.go
+++ b/backend/internal/services/catalog/artist_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"gorm.io/gorm"
 
@@ -18,11 +17,6 @@ import (
 // =============================================================================
 // UNIT TESTS (No Database Required)
 // =============================================================================
-
-func TestNewArtistService(t *testing.T) {
-	artistService := NewArtistService(nil)
-	assert.NotNil(t, artistService)
-}
 
 func TestArtistService_NilDatabase(t *testing.T) {
 	svc := &ArtistService{db: nil}

--- a/backend/internal/services/catalog/charts_service_test.go
+++ b/backend/internal/services/catalog/charts_service_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"gorm.io/gorm"
 
@@ -16,11 +15,6 @@ import (
 // =============================================================================
 // UNIT TESTS (No Database Required)
 // =============================================================================
-
-func TestNewChartsService(t *testing.T) {
-	svc := NewChartsService(nil)
-	assert.NotNil(t, svc)
-}
 
 func TestChartsService_NilDatabase(t *testing.T) {
 	svc := &ChartsService{db: nil}

--- a/backend/internal/services/catalog/festival_intelligence_test.go
+++ b/backend/internal/services/catalog/festival_intelligence_test.go
@@ -17,11 +17,6 @@ import (
 // UNIT TESTS (No Database Required)
 // =============================================================================
 
-func TestNewFestivalIntelligenceService(t *testing.T) {
-	svc := NewFestivalIntelligenceService(nil)
-	assert.NotNil(t, svc)
-}
-
 func TestFestivalIntelligenceService_NilDatabase(t *testing.T) {
 	svc := &FestivalIntelligenceService{db: nil}
 

--- a/backend/internal/services/catalog/festival_test.go
+++ b/backend/internal/services/catalog/festival_test.go
@@ -3,7 +3,6 @@ package catalog
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"gorm.io/gorm"
 
@@ -17,11 +16,6 @@ import (
 // =============================================================================
 // UNIT TESTS (No Database Required)
 // =============================================================================
-
-func TestNewFestivalService(t *testing.T) {
-	festivalService := NewFestivalService(nil)
-	assert.NotNil(t, festivalService)
-}
 
 func TestFestivalService_NilDatabase(t *testing.T) {
 	svc := &FestivalService{db: nil}

--- a/backend/internal/services/catalog/label_test.go
+++ b/backend/internal/services/catalog/label_test.go
@@ -3,7 +3,6 @@ package catalog
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"gorm.io/gorm"
 
@@ -16,11 +15,6 @@ import (
 // =============================================================================
 // UNIT TESTS (No Database Required)
 // =============================================================================
-
-func TestNewLabelService(t *testing.T) {
-	labelService := NewLabelService(nil)
-	assert.NotNil(t, labelService)
-}
 
 func TestLabelService_NilDatabase(t *testing.T) {
 	svc := &LabelService{db: nil}

--- a/backend/internal/services/catalog/release_test.go
+++ b/backend/internal/services/catalog/release_test.go
@@ -3,7 +3,6 @@ package catalog
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"gorm.io/gorm"
 
@@ -16,11 +15,6 @@ import (
 // =============================================================================
 // UNIT TESTS (No Database Required)
 // =============================================================================
-
-func TestNewReleaseService(t *testing.T) {
-	releaseService := NewReleaseService(nil)
-	assert.NotNil(t, releaseService)
-}
 
 func TestReleaseService_NilDatabase(t *testing.T) {
 	svc := &ReleaseService{db: nil}

--- a/backend/internal/services/catalog/scene_test.go
+++ b/backend/internal/services/catalog/scene_test.go
@@ -17,11 +17,6 @@ import (
 // UNIT TESTS (No Database Required)
 // =============================================================================
 
-func TestNewSceneService(t *testing.T) {
-	svc := NewSceneService(nil)
-	assert.NotNil(t, svc)
-}
-
 func TestSceneService_NilDatabase(t *testing.T) {
 	svc := &SceneService{db: nil}
 

--- a/backend/internal/services/catalog/show_test.go
+++ b/backend/internal/services/catalog/show_test.go
@@ -20,11 +20,6 @@ import (
 // UNIT TESTS (No Database Required)
 // =============================================================================
 
-func TestNewShowService(t *testing.T) {
-	showService := NewShowService(nil)
-	assert.NotNil(t, showService)
-}
-
 func TestShowService_NilDatabase(t *testing.T) {
 	svc := &ShowService{db: nil}
 

--- a/backend/internal/services/catalog/tag_service_test.go
+++ b/backend/internal/services/catalog/tag_service_test.go
@@ -18,11 +18,6 @@ import (
 // UNIT TESTS (No Database Required)
 // =============================================================================
 
-func TestNewTagService(t *testing.T) {
-	svc := NewTagService(nil)
-	assert.NotNil(t, svc)
-}
-
 func TestTagService_NilDatabase(t *testing.T) {
 	svc := &TagService{db: nil}
 

--- a/backend/internal/services/catalog/venue_test.go
+++ b/backend/internal/services/catalog/venue_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"gorm.io/gorm"
 
@@ -18,11 +17,6 @@ import (
 // =============================================================================
 // UNIT TESTS (No Database Required)
 // =============================================================================
-
-func TestNewVenueService(t *testing.T) {
-	venueService := NewVenueService(nil)
-	assert.NotNil(t, venueService)
-}
 
 func TestVenueService_NilDatabase(t *testing.T) {
 	svc := &VenueService{db: nil}

--- a/backend/internal/services/collection_test.go
+++ b/backend/internal/services/collection_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"gorm.io/gorm"
 
@@ -18,11 +17,6 @@ import (
 // =============================================================================
 // UNIT TESTS (No Database Required)
 // =============================================================================
-
-func TestNewCollectionService(t *testing.T) {
-	svc := NewCollectionService(nil)
-	assert.NotNil(t, svc)
-}
 
 func TestCollectionService_NilDatabase(t *testing.T) {
 	svc := &CollectionService{db: nil}

--- a/backend/internal/services/engagement/attendance_test.go
+++ b/backend/internal/services/engagement/attendance_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"gorm.io/gorm"
 
@@ -16,11 +15,6 @@ import (
 // =============================================================================
 // UNIT TESTS (No Database Required)
 // =============================================================================
-
-func TestNewAttendanceService(t *testing.T) {
-	svc := NewAttendanceService(nil)
-	assert.NotNil(t, svc)
-}
 
 func TestAttendanceService_NilDatabase(t *testing.T) {
 	svc := &AttendanceService{db: nil}

--- a/backend/internal/services/engagement/bookmark_test.go
+++ b/backend/internal/services/engagement/bookmark_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"gorm.io/gorm"
 
@@ -16,11 +15,6 @@ import (
 // =============================================================================
 // UNIT TESTS (No Database Required)
 // =============================================================================
-
-func TestNewBookmarkService(t *testing.T) {
-	svc := NewBookmarkService(nil)
-	assert.NotNil(t, svc)
-}
 
 func TestBookmarkService_NilDatabase(t *testing.T) {
 	svc := &BookmarkService{db: nil}

--- a/backend/internal/services/engagement/calendar_test.go
+++ b/backend/internal/services/engagement/calendar_test.go
@@ -19,11 +19,6 @@ import (
 // UNIT TESTS (No Database Required)
 // =============================================================================
 
-func TestNewCalendarService(t *testing.T) {
-	svc := NewCalendarService(nil, nil)
-	assert.NotNil(t, svc)
-}
-
 func TestCalendarService_NilDatabase(t *testing.T) {
 	svc := &CalendarService{db: nil}
 

--- a/backend/internal/services/engagement/favorite_venue_test.go
+++ b/backend/internal/services/engagement/favorite_venue_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"gorm.io/gorm"
 
@@ -17,11 +16,6 @@ import (
 // =============================================================================
 // UNIT TESTS (No Database Required)
 // =============================================================================
-
-func TestNewFavoriteVenueService(t *testing.T) {
-	svc := NewFavoriteVenueService(nil)
-	assert.NotNil(t, svc)
-}
 
 func TestFavoriteVenueService_NilDatabase(t *testing.T) {
 	svc := &FavoriteVenueService{db: nil}

--- a/backend/internal/services/engagement/follow_test.go
+++ b/backend/internal/services/engagement/follow_test.go
@@ -17,11 +17,6 @@ import (
 // UNIT TESTS (No Database Required)
 // =============================================================================
 
-func TestNewFollowService(t *testing.T) {
-	svc := NewFollowService(nil)
-	assert.NotNil(t, svc)
-}
-
 func TestFollowService_NilDatabase(t *testing.T) {
 	svc := &FollowService{db: nil}
 

--- a/backend/internal/services/engagement/saved_show_test.go
+++ b/backend/internal/services/engagement/saved_show_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"gorm.io/gorm"
 
@@ -17,11 +16,6 @@ import (
 // =============================================================================
 // UNIT TESTS (No Database Required)
 // =============================================================================
-
-func TestNewSavedShowService(t *testing.T) {
-	svc := NewSavedShowService(nil)
-	assert.NotNil(t, svc)
-}
 
 func TestSavedShowService_NilDatabase(t *testing.T) {
 	svc := &SavedShowService{db: nil}

--- a/backend/internal/services/notification/filter_service_test.go
+++ b/backend/internal/services/notification/filter_service_test.go
@@ -20,11 +20,6 @@ import (
 // UNIT TESTS (No Database Required)
 // =============================================================================
 
-func TestNewNotificationFilterService(t *testing.T) {
-	svc := NewNotificationFilterService(nil, nil, "secret", "http://localhost:3000")
-	assert.NotNil(t, svc)
-}
-
 func TestNotificationFilterService_NilDatabase(t *testing.T) {
 	svc := &NotificationFilterService{db: nil}
 

--- a/backend/internal/services/pipeline/discovery_test.go
+++ b/backend/internal/services/pipeline/discovery_test.go
@@ -284,11 +284,6 @@ func TestNormalizeSetType(t *testing.T) {
 // UNIT TESTS — Constructor + nil DB
 // =============================================================================
 
-func TestNewDiscoveryService(t *testing.T) {
-	svc := NewDiscoveryService(nil, nil)
-	assert.NotNil(t, svc)
-}
-
 func TestImportEvents_NilDB(t *testing.T) {
 	svc := &DiscoveryService{db: nil}
 	testutil.AssertNilDBErrorWithResult(t, func() (interface{}, error) {

--- a/backend/internal/services/pipeline/venue_source_config_test.go
+++ b/backend/internal/services/pipeline/venue_source_config_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"gorm.io/gorm"
 
@@ -15,11 +14,6 @@ import (
 // =============================================================================
 // UNIT TESTS (No Database Required)
 // =============================================================================
-
-func TestNewVenueSourceConfigService(t *testing.T) {
-	svc := NewVenueSourceConfigService(nil)
-	assert.NotNil(t, svc)
-}
 
 func TestVenueSourceConfigService_NilDatabase(t *testing.T) {
 	svc := &VenueSourceConfigService{db: nil}

--- a/backend/internal/services/request_test.go
+++ b/backend/internal/services/request_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"gorm.io/gorm"
 
@@ -17,11 +16,6 @@ import (
 // =============================================================================
 // UNIT TESTS (No Database Required)
 // =============================================================================
-
-func TestNewRequestService(t *testing.T) {
-	svc := NewRequestService(nil)
-	assert.NotNil(t, svc)
-}
 
 func TestRequestService_NilDatabase(t *testing.T) {
 	svc := &RequestService{db: nil}

--- a/backend/internal/services/user/contributor_profile_test.go
+++ b/backend/internal/services/user/contributor_profile_test.go
@@ -20,11 +20,6 @@ import (
 // UNIT TESTS (No Database Required)
 // =============================================================================
 
-func TestNewContributorProfileService(t *testing.T) {
-	svc := NewContributorProfileService(nil)
-	assert.NotNil(t, svc)
-}
-
 func TestContributorProfileService_NilDatabase(t *testing.T) {
 	svc := &ContributorProfileService{db: nil}
 

--- a/backend/internal/services/user/user_test.go
+++ b/backend/internal/services/user/user_test.go
@@ -22,16 +22,6 @@ import (
 // =============================================================================
 
 // TestNewUserService tests the creation of a new UserService
-func TestNewUserService(t *testing.T) {
-	userService := NewUserService(nil)
-
-	assert.NotNil(t, userService)
-	// In test environment, database may be nil
-	if userService.db == nil {
-		t.Log("Database is nil in test environment (expected)")
-	}
-}
-
 // TestUserService_NilDatabase tests all methods with nil database
 func TestUserService_NilDatabase(t *testing.T) {
 	userService := &UserService{db: nil}


### PR DESCRIPTION
## Summary
- Removed 62 trivial constructor tests (27 handler + 35 service) that only asserted `!= nil` on simple struct literal constructors
- These constructors are plain struct assignments that cannot fail -- the compiler guarantees non-nil returns
- Cleaned up 18 now-unused `testify/assert` imports across service test files
- Net deletion: 454 lines across 62 test files

## What was kept
Constructor tests that verify actual logic were preserved:
- `auth/webauthn_test.go` -- tests default RPID and Origins fallback
- `auth/jwt_test.go` -- asserts config is stored
- `auth/oauth_test.go` -- asserts sub-services initialized
- `auth/apple_test.go` -- asserts config, jwtService, empty keys map
- `notification/email_test.go` -- tests conditional Resend client creation
- `notification/discord_test.go` -- tests conditional webhook configuration
- `admin/cleanup_test.go` -- tests env variable overrides and defaults
- `pipeline/extraction_test.go` -- asserts config and service dependencies stored

## Test plan
- [x] `go test ./internal/... -short` passes (all packages OK, no build failures)
- [x] No remaining `TestNewX` tests that only assert non-nil
- [x] No unused imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)