### PR TITLE
PSY-251: Add boundary condition tests for critical paths

### DIFF
--- a/backend/internal/api/handlers/artist_test.go
+++ b/backend/internal/api/handlers/artist_test.go
@@ -1296,6 +1296,69 @@ func TestAdminCreateArtist_AuditLogCalled(t *testing.T) {
 	}
 }
 
+// ============================================================================
+// ID Parsing Boundary Tests
+// ============================================================================
+
+func TestDeleteArtist_ZeroID(t *testing.T) {
+	mock := &mockArtistService{
+		deleteArtistFn: func(id uint) error {
+			return apperrors.ErrArtistNotFound(id)
+		},
+	}
+	h := NewArtistHandler(mock, nil, nil)
+	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
+	_, err := h.DeleteArtistHandler(ctx, &DeleteArtistRequest{ArtistID: "0"})
+	assertHumaError(t, err, 404)
+}
+
+func TestDeleteArtist_OverflowID(t *testing.T) {
+	h := testArtistHandler()
+	ctx := ctxWithUser(&models.User{ID: 1})
+	_, err := h.DeleteArtistHandler(ctx, &DeleteArtistRequest{ArtistID: "99999999999"})
+	assertHumaError(t, err, 400)
+}
+
+func TestAdminUpdateArtist_ZeroID(t *testing.T) {
+	mock := &mockArtistService{
+		updateArtistFn: func(id uint, updates map[string]interface{}) (*contracts.ArtistDetailResponse, error) {
+			return nil, apperrors.ErrArtistNotFound(id)
+		},
+	}
+	h := NewArtistHandler(mock, nil, nil)
+	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
+	req := &AdminUpdateArtistRequest{ArtistID: "0"}
+	name := "Test Name"
+	req.Body.Name = &name
+	_, err := h.AdminUpdateArtistHandler(ctx, req)
+	assertHumaError(t, err, 404)
+}
+
+func TestAdminUpdateArtist_VeryLargeID(t *testing.T) {
+	mock := &mockArtistService{
+		updateArtistFn: func(id uint, updates map[string]interface{}) (*contracts.ArtistDetailResponse, error) {
+			return nil, apperrors.ErrArtistNotFound(id)
+		},
+	}
+	h := NewArtistHandler(mock, nil, nil)
+	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
+	req := &AdminUpdateArtistRequest{ArtistID: "4294967295"}
+	name := "Test Name"
+	req.Body.Name = &name
+	_, err := h.AdminUpdateArtistHandler(ctx, req)
+	assertHumaError(t, err, 404)
+}
+
+func TestAdminUpdateArtist_OverflowID(t *testing.T) {
+	h := testArtistHandler()
+	ctx := ctxWithUser(&models.User{ID: 1, IsAdmin: true})
+	req := &AdminUpdateArtistRequest{ArtistID: "99999999999"}
+	name := "Test"
+	req.Body.Name = &name
+	_, err := h.AdminUpdateArtistHandler(ctx, req)
+	assertHumaError(t, err, 400)
+}
+
 func TestAdminCreateArtist_NameTrimmed(t *testing.T) {
 	mock := &mockArtistService{
 		createArtistFn: func(req *contracts.CreateArtistRequest) (*contracts.ArtistDetailResponse, error) {

--- a/backend/internal/api/handlers/show_test.go
+++ b/backend/internal/api/handlers/show_test.go
@@ -1028,6 +1028,77 @@ func TestAIProcessShowHandler_Success(t *testing.T) {
 	}
 }
 
+// ============================================================================
+// ID Parsing Boundary Tests
+// ============================================================================
+
+func TestGetShowHandler_ZeroID(t *testing.T) {
+	mock := &mockShowService{
+		getShowFn: func(showID uint) (*contracts.ShowResponse, error) {
+			if showID != 0 {
+				t.Errorf("expected showID=0, got %d", showID)
+			}
+			return nil, fmt.Errorf("not found")
+		},
+	}
+	h := NewShowHandler(mock, nil, nil, nil, nil, nil, nil)
+	_, err := h.GetShowHandler(context.Background(), &GetShowRequest{ShowID: "0"})
+	assertHumaError(t, err, 404)
+}
+
+func TestGetShowHandler_VeryLargeID(t *testing.T) {
+	mock := &mockShowService{
+		getShowFn: func(showID uint) (*contracts.ShowResponse, error) {
+			return nil, fmt.Errorf("not found")
+		},
+	}
+	h := NewShowHandler(mock, nil, nil, nil, nil, nil, nil)
+	_, err := h.GetShowHandler(context.Background(), &GetShowRequest{ShowID: "4294967295"})
+	assertHumaError(t, err, 404)
+}
+
+func TestGetShowHandler_OverflowID(t *testing.T) {
+	mock := &mockShowService{
+		getShowBySlugFn: func(slug string) (*contracts.ShowResponse, error) {
+			return nil, fmt.Errorf("not found")
+		},
+	}
+	h := NewShowHandler(mock, nil, nil, nil, nil, nil, nil)
+	_, err := h.GetShowHandler(context.Background(), &GetShowRequest{ShowID: "99999999999"})
+	assertHumaError(t, err, 404)
+}
+
+func TestUpdateShowHandler_ZeroID(t *testing.T) {
+	mock := &mockShowService{
+		getShowFn: func(showID uint) (*contracts.ShowResponse, error) {
+			return nil, fmt.Errorf("not found")
+		},
+	}
+	h := NewShowHandler(mock, nil, nil, nil, nil, nil, nil)
+	ctx := ctxWithUser(&models.User{ID: 1})
+	_, err := h.UpdateShowHandler(ctx, &UpdateShowRequest{ShowID: "0"})
+	assertHumaError(t, err, 404)
+}
+
+func TestDeleteShowHandler_ZeroID(t *testing.T) {
+	mock := &mockShowService{
+		getShowFn: func(showID uint) (*contracts.ShowResponse, error) {
+			return nil, fmt.Errorf("not found")
+		},
+	}
+	h := NewShowHandler(mock, nil, nil, nil, nil, nil, nil)
+	ctx := ctxWithUser(&models.User{ID: 1})
+	_, err := h.DeleteShowHandler(ctx, &DeleteShowRequest{ShowID: "0"})
+	assertHumaError(t, err, 404)
+}
+
+func TestDeleteShowHandler_OverflowID(t *testing.T) {
+	h := testShowHandler()
+	ctx := ctxWithUser(&models.User{ID: 1})
+	_, err := h.DeleteShowHandler(ctx, &DeleteShowRequest{ShowID: "99999999999"})
+	assertHumaError(t, err, 400)
+}
+
 func TestAIProcessShowHandler_ServiceError(t *testing.T) {
 	extractMock := &mockExtractionService{
 		extractShowFn: func(_ *contracts.ExtractShowRequest) (*contracts.ExtractShowResponse, error) {

--- a/backend/internal/api/handlers/venue_test.go
+++ b/backend/internal/api/handlers/venue_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"testing"
 
+	apperrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
 )
 
 func testVenueHandler() *VenueHandler {
@@ -109,5 +111,73 @@ func TestDeleteVenueHandler_InvalidID(t *testing.T) {
 	req := &DeleteVenueRequest{VenueID: "abc"}
 
 	_, err := h.DeleteVenueHandler(ctx, req)
+	assertHumaError(t, err, 400)
+}
+
+// ============================================================================
+// ID Parsing Boundary Tests
+// ============================================================================
+
+func TestGetVenueHandler_ZeroID(t *testing.T) {
+	mock := &mockVenueService{
+		getVenueFn: func(venueID uint) (*contracts.VenueDetailResponse, error) {
+			return nil, apperrors.ErrVenueNotFound(0)
+		},
+	}
+	h := NewVenueHandler(mock, nil, nil, nil)
+	_, err := h.GetVenueHandler(context.Background(), &GetVenueRequest{VenueID: "0"})
+	assertHumaError(t, err, 404)
+}
+
+func TestGetVenueHandler_VeryLargeID(t *testing.T) {
+	mock := &mockVenueService{
+		getVenueFn: func(venueID uint) (*contracts.VenueDetailResponse, error) {
+			return nil, apperrors.ErrVenueNotFound(venueID)
+		},
+	}
+	h := NewVenueHandler(mock, nil, nil, nil)
+	_, err := h.GetVenueHandler(context.Background(), &GetVenueRequest{VenueID: "4294967295"})
+	assertHumaError(t, err, 404)
+}
+
+func TestGetVenueHandler_OverflowID(t *testing.T) {
+	mock := &mockVenueService{
+		getVenueBySlugFn: func(slug string) (*contracts.VenueDetailResponse, error) {
+			return nil, apperrors.ErrVenueNotFound(0)
+		},
+	}
+	h := NewVenueHandler(mock, nil, nil, nil)
+	_, err := h.GetVenueHandler(context.Background(), &GetVenueRequest{VenueID: "99999999999"})
+	assertHumaError(t, err, 404)
+}
+
+func TestUpdateVenueHandler_ZeroID(t *testing.T) {
+	mock := &mockVenueService{
+		getVenueModelFn: func(venueID uint) (*models.Venue, error) {
+			return nil, apperrors.ErrVenueNotFound(venueID)
+		},
+	}
+	h := NewVenueHandler(mock, nil, nil, nil)
+	ctx := ctxWithUser(&models.User{ID: 1})
+	_, err := h.UpdateVenueHandler(ctx, &UpdateVenueRequest{VenueID: "0"})
+	assertHumaError(t, err, 404)
+}
+
+func TestDeleteVenueHandler_ZeroID(t *testing.T) {
+	mock := &mockVenueService{
+		getVenueModelFn: func(venueID uint) (*models.Venue, error) {
+			return nil, apperrors.ErrVenueNotFound(venueID)
+		},
+	}
+	h := NewVenueHandler(mock, nil, nil, nil)
+	ctx := ctxWithUser(&models.User{ID: 1})
+	_, err := h.DeleteVenueHandler(ctx, &DeleteVenueRequest{VenueID: "0"})
+	assertHumaError(t, err, 404)
+}
+
+func TestDeleteVenueHandler_OverflowID(t *testing.T) {
+	h := testVenueHandler()
+	ctx := ctxWithUser(&models.User{ID: 1})
+	_, err := h.DeleteVenueHandler(ctx, &DeleteVenueRequest{VenueID: "99999999999"})
 	assertHumaError(t, err, 400)
 }

--- a/backend/internal/services/catalog/artist_test.go
+++ b/backend/internal/services/catalog/artist_test.go
@@ -2,6 +2,7 @@ package catalog
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -1155,6 +1156,163 @@ func (suite *ArtistServiceIntegrationTestSuite) TestMergeArtists_CollectionItemC
 	var count int64
 	suite.db.Raw("SELECT COUNT(*) FROM collection_items WHERE entity_type = 'artist' AND collection_id = ?", collectionID).Scan(&count)
 	suite.Equal(int64(1), count)
+}
+
+// =============================================================================
+// Group 10: Boundary Conditions — Pagination
+// =============================================================================
+
+func (suite *ArtistServiceIntegrationTestSuite) TestGetShowsForArtist_LimitZero() {
+	artist := suite.createTestArtist("LZ Artist")
+	venue := suite.createTestVenue("LZ Venue", "Phoenix", "AZ")
+	user := suite.createTestUser()
+	suite.createApprovedShowWithArtist(artist.ID, venue.ID, user.ID, time.Now().UTC().AddDate(0, 0, 7))
+	shows, total, err := suite.artistService.GetShowsForArtist(artist.ID, "UTC", 0, "upcoming")
+	suite.Require().NoError(err)
+	suite.GreaterOrEqual(total, int64(1), "total should reflect show count")
+	suite.Empty(shows, "limit=0 should return no shows")
+}
+
+func (suite *ArtistServiceIntegrationTestSuite) TestGetShowsForArtist_LimitOne() {
+	artist := suite.createTestArtist("L1 Artist")
+	venue := suite.createTestVenue("L1 Venue", "Phoenix", "AZ")
+	user := suite.createTestUser()
+	for i := 0; i < 3; i++ {
+		suite.createApprovedShowWithArtist(artist.ID, venue.ID, user.ID, time.Now().UTC().AddDate(0, 0, i+1))
+	}
+	shows, total, err := suite.artistService.GetShowsForArtist(artist.ID, "UTC", 1, "upcoming")
+	suite.Require().NoError(err)
+	suite.GreaterOrEqual(total, int64(3))
+	suite.Len(shows, 1, "limit=1 should return exactly 1 show")
+}
+
+func (suite *ArtistServiceIntegrationTestSuite) TestGetShowsForArtist_LargeLimit() {
+	artist := suite.createTestArtist("LargeLimit Artist")
+	venue := suite.createTestVenue("LargeLimit Venue", "Phoenix", "AZ")
+	user := suite.createTestUser()
+	suite.createApprovedShowWithArtist(artist.ID, venue.ID, user.ID, time.Now().UTC().AddDate(0, 0, 7))
+	shows, total, err := suite.artistService.GetShowsForArtist(artist.ID, "UTC", 1000, "upcoming")
+	suite.Require().NoError(err)
+	suite.Equal(int64(1), total)
+	suite.Len(shows, 1, "large limit should return all available results")
+}
+
+func (suite *ArtistServiceIntegrationTestSuite) TestGetShowsForArtist_EmptyResult() {
+	artist := suite.createTestArtist("EmptyResult Artist")
+	shows, total, err := suite.artistService.GetShowsForArtist(artist.ID, "UTC", 10, "upcoming")
+	suite.Require().NoError(err)
+	suite.Equal(int64(0), total)
+	suite.Empty(shows)
+}
+
+func (suite *ArtistServiceIntegrationTestSuite) TestGetShowsForArtist_ShowAtExactMidnight() {
+	artist := suite.createTestArtist("Midnight Artist")
+	venue := suite.createTestVenue("Midnight Venue", "Phoenix", "AZ")
+	user := suite.createTestUser()
+	now := time.Now().UTC()
+	midnight := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	suite.createApprovedShowWithArtist(artist.ID, venue.ID, user.ID, midnight)
+	shows, _, err := suite.artistService.GetShowsForArtist(artist.ID, "UTC", 50, "upcoming")
+	suite.Require().NoError(err)
+	suite.NotEmpty(shows, "show at exact midnight today should appear in upcoming")
+}
+
+func (suite *ArtistServiceIntegrationTestSuite) TestGetShowsForArtist_PastShowExcluded() {
+	artist := suite.createTestArtist("PastExcl Artist")
+	venue := suite.createTestVenue("PastExcl Venue", "Phoenix", "AZ")
+	user := suite.createTestUser()
+	yesterday := time.Now().UTC().AddDate(0, 0, -1)
+	suite.createApprovedShowWithArtist(artist.ID, venue.ID, user.ID, yesterday)
+	shows, total, err := suite.artistService.GetShowsForArtist(artist.ID, "UTC", 50, "upcoming")
+	suite.Require().NoError(err)
+	suite.Equal(int64(0), total, "past show should not appear in upcoming filter")
+	suite.Empty(shows)
+}
+
+// =============================================================================
+// Group 11: Boundary Conditions — IDs
+// =============================================================================
+
+func (suite *ArtistServiceIntegrationTestSuite) TestGetArtist_ZeroID() {
+	resp, err := suite.artistService.GetArtist(0)
+	suite.Require().Error(err)
+	suite.Nil(resp)
+}
+
+func (suite *ArtistServiceIntegrationTestSuite) TestGetArtist_VeryLargeID() {
+	resp, err := suite.artistService.GetArtist(4294967295)
+	suite.Require().Error(err)
+	suite.Nil(resp)
+}
+
+func (suite *ArtistServiceIntegrationTestSuite) TestDeleteArtist_ZeroID() {
+	err := suite.artistService.DeleteArtist(0)
+	suite.Require().Error(err)
+}
+
+// =============================================================================
+// Group 12: Boundary Conditions — Strings
+// =============================================================================
+
+func (suite *ArtistServiceIntegrationTestSuite) TestCreateArtist_VeryLongName() {
+	longName := strings.Repeat("A", 500)
+	req := &contracts.CreateArtistRequest{Name: longName}
+	resp, err := suite.artistService.CreateArtist(req)
+	if err == nil {
+		suite.Equal(longName, resp.Name)
+	}
+}
+
+func (suite *ArtistServiceIntegrationTestSuite) TestCreateArtist_EmptyName() {
+	req := &contracts.CreateArtistRequest{Name: ""}
+	resp, err := suite.artistService.CreateArtist(req)
+	if err != nil {
+		suite.Contains(err.Error(), "name", "error should mention name validation")
+	} else {
+		suite.NotNil(resp)
+	}
+}
+
+func (suite *ArtistServiceIntegrationTestSuite) TestCreateArtist_WhitespaceOnlyName() {
+	req := &contracts.CreateArtistRequest{Name: "   "}
+	resp, err := suite.artistService.CreateArtist(req)
+	if err != nil {
+		suite.NotNil(err)
+	} else {
+		suite.NotNil(resp)
+	}
+}
+
+func (suite *ArtistServiceIntegrationTestSuite) TestGetArtistBySlug_EmptySlug() {
+	resp, err := suite.artistService.GetArtistBySlug("")
+	suite.Require().Error(err, "empty slug should return an error")
+	suite.Nil(resp)
+}
+
+func (suite *ArtistServiceIntegrationTestSuite) TestGetArtistByName_EmptyName() {
+	resp, err := suite.artistService.GetArtistByName("")
+	suite.Require().Error(err, "empty name should return not found")
+	suite.Nil(resp)
+}
+
+func (suite *ArtistServiceIntegrationTestSuite) TestSearchArtists_EmptyString() {
+	results, err := suite.artistService.SearchArtists("")
+	suite.Require().NoError(err)
+	suite.NotNil(results)
+}
+
+func (suite *ArtistServiceIntegrationTestSuite) TestGetArtists_EmptyFilters() {
+	suite.createTestArtist("EF Artist")
+	resp, err := suite.artistService.GetArtists(map[string]interface{}{})
+	suite.Require().NoError(err)
+	suite.NotEmpty(resp, "empty filters should return all artists")
+}
+
+func (suite *ArtistServiceIntegrationTestSuite) TestGetArtists_NilFilters() {
+	suite.createTestArtist("NF Artist")
+	resp, err := suite.artistService.GetArtists(nil)
+	suite.Require().NoError(err)
+	suite.NotEmpty(resp, "nil filters should return all artists")
 }
 
 func (suite *ArtistServiceIntegrationTestSuite) TestMergeArtists_UpdatesNotificationFilters() {

--- a/backend/internal/services/catalog/show_test.go
+++ b/backend/internal/services/catalog/show_test.go
@@ -2390,6 +2390,389 @@ func (suite *ShowServiceIntegrationTestSuite) TestConfirmShowImport_InvalidMarkd
 	suite.Nil(resp)
 }
 
+// =============================================================================
+// Group 12: Pagination Boundary Conditions
+// =============================================================================
+
+func (suite *ShowServiceIntegrationTestSuite) TestGetPendingShows_ZeroLimitZeroOffset() {
+	user := suite.createTestUser()
+	req := &contracts.CreateShowRequest{
+		Title:             "Pending Boundary",
+		EventDate:         time.Date(2026, 12, 1, 20, 0, 0, 0, time.UTC),
+		City:              "Phoenix",
+		State:             "AZ",
+		Venues:            []contracts.CreateShowVenue{{Name: "PB Venue", City: "Phoenix", State: "AZ"}},
+		Artists:           []contracts.CreateShowArtist{{Name: "PB Artist", IsHeadliner: boolPtr(true)}},
+		SubmittedByUserID: &user.ID,
+		SubmitterIsAdmin:  true,
+	}
+	show, err := suite.showService.CreateShow(req)
+	suite.Require().NoError(err)
+	suite.db.Model(&models.Show{}).Where("id = ?", show.ID).Update("status", models.ShowStatusPending)
+
+	shows, total, err := suite.showService.GetPendingShows(0, 0, nil)
+	suite.Require().NoError(err)
+	suite.Equal(int64(1), total, "total count should reflect all pending shows regardless of limit")
+	suite.Empty(shows)
+}
+
+func (suite *ShowServiceIntegrationTestSuite) TestGetPendingShows_LargeLimit() {
+	user := suite.createTestUser()
+	req := &contracts.CreateShowRequest{
+		Title:             "Large Limit Pending",
+		EventDate:         time.Date(2026, 12, 1, 20, 0, 0, 0, time.UTC),
+		City:              "Phoenix",
+		State:             "AZ",
+		Venues:            []contracts.CreateShowVenue{{Name: "LLP Venue", City: "Phoenix", State: "AZ"}},
+		Artists:           []contracts.CreateShowArtist{{Name: "LLP Artist", IsHeadliner: boolPtr(true)}},
+		SubmittedByUserID: &user.ID,
+		SubmitterIsAdmin:  true,
+	}
+	show, err := suite.showService.CreateShow(req)
+	suite.Require().NoError(err)
+	suite.db.Model(&models.Show{}).Where("id = ?", show.ID).Update("status", models.ShowStatusPending)
+
+	shows, total, err := suite.showService.GetPendingShows(1000, 0, nil)
+	suite.Require().NoError(err)
+	suite.Equal(int64(1), total)
+	suite.Len(shows, 1)
+}
+
+func (suite *ShowServiceIntegrationTestSuite) TestGetPendingShows_OffsetBeyondResults() {
+	user := suite.createTestUser()
+	req := &contracts.CreateShowRequest{
+		Title:             "Offset Beyond Pending",
+		EventDate:         time.Date(2026, 12, 1, 20, 0, 0, 0, time.UTC),
+		City:              "Phoenix",
+		State:             "AZ",
+		Venues:            []contracts.CreateShowVenue{{Name: "OBP Venue", City: "Phoenix", State: "AZ"}},
+		Artists:           []contracts.CreateShowArtist{{Name: "OBP Artist", IsHeadliner: boolPtr(true)}},
+		SubmittedByUserID: &user.ID,
+		SubmitterIsAdmin:  true,
+	}
+	show, err := suite.showService.CreateShow(req)
+	suite.Require().NoError(err)
+	suite.db.Model(&models.Show{}).Where("id = ?", show.ID).Update("status", models.ShowStatusPending)
+
+	shows, total, err := suite.showService.GetPendingShows(10, 100, nil)
+	suite.Require().NoError(err)
+	suite.Equal(int64(1), total, "total should still be 1")
+	suite.Empty(shows, "should return no shows when offset exceeds total")
+}
+
+func (suite *ShowServiceIntegrationTestSuite) TestGetPendingShows_EmptyResultSet() {
+	shows, total, err := suite.showService.GetPendingShows(10, 0, nil)
+	suite.Require().NoError(err)
+	suite.Equal(int64(0), total)
+	suite.Empty(shows)
+}
+
+func (suite *ShowServiceIntegrationTestSuite) TestGetPendingShows_LimitOne() {
+	user := suite.createTestUser()
+	for i := 0; i < 3; i++ {
+		req := &contracts.CreateShowRequest{
+			Title:             fmt.Sprintf("Limit1 Pending %d", i),
+			EventDate:         time.Date(2026, 12, 1+i, 20, 0, 0, 0, time.UTC),
+			City:              "Phoenix",
+			State:             "AZ",
+			Venues:            []contracts.CreateShowVenue{{Name: fmt.Sprintf("L1P Venue %d", i), City: "Phoenix", State: "AZ"}},
+			Artists:           []contracts.CreateShowArtist{{Name: fmt.Sprintf("L1P Artist %d", i), IsHeadliner: boolPtr(true)}},
+			SubmittedByUserID: &user.ID,
+			SubmitterIsAdmin:  true,
+		}
+		show, err := suite.showService.CreateShow(req)
+		suite.Require().NoError(err)
+		suite.db.Model(&models.Show{}).Where("id = ?", show.ID).Update("status", models.ShowStatusPending)
+	}
+
+	shows, total, err := suite.showService.GetPendingShows(1, 0, nil)
+	suite.Require().NoError(err)
+	suite.Equal(int64(3), total)
+	suite.Len(shows, 1, "limit=1 should return exactly 1 result")
+}
+
+func (suite *ShowServiceIntegrationTestSuite) TestGetUserSubmissions_ZeroLimitZeroOffset() {
+	user := suite.createTestUser()
+	req := &contracts.CreateShowRequest{
+		Title:             "UserSub Boundary",
+		EventDate:         time.Date(2026, 12, 1, 20, 0, 0, 0, time.UTC),
+		City:              "Phoenix",
+		State:             "AZ",
+		Venues:            []contracts.CreateShowVenue{{Name: "USB Venue", City: "Phoenix", State: "AZ"}},
+		Artists:           []contracts.CreateShowArtist{{Name: "USB Artist", IsHeadliner: boolPtr(true)}},
+		SubmittedByUserID: &user.ID,
+		SubmitterIsAdmin:  true,
+	}
+	_, err := suite.showService.CreateShow(req)
+	suite.Require().NoError(err)
+
+	shows, total, err := suite.showService.GetUserSubmissions(user.ID, 0, 0)
+	suite.Require().NoError(err)
+	suite.Equal(1, total, "total should reflect all submissions")
+	suite.Empty(shows, "limit=0 should return no results")
+}
+
+func (suite *ShowServiceIntegrationTestSuite) TestGetUserSubmissions_OffsetBeyondResults() {
+	user := suite.createTestUser()
+	req := &contracts.CreateShowRequest{
+		Title:             "UserSub Offset",
+		EventDate:         time.Date(2026, 12, 1, 20, 0, 0, 0, time.UTC),
+		City:              "Phoenix",
+		State:             "AZ",
+		Venues:            []contracts.CreateShowVenue{{Name: "USO Venue", City: "Phoenix", State: "AZ"}},
+		Artists:           []contracts.CreateShowArtist{{Name: "USO Artist", IsHeadliner: boolPtr(true)}},
+		SubmittedByUserID: &user.ID,
+		SubmitterIsAdmin:  true,
+	}
+	_, err := suite.showService.CreateShow(req)
+	suite.Require().NoError(err)
+
+	shows, total, err := suite.showService.GetUserSubmissions(user.ID, 10, 500)
+	suite.Require().NoError(err)
+	suite.Equal(1, total)
+	suite.Empty(shows, "offset beyond results should return empty slice")
+}
+
+func (suite *ShowServiceIntegrationTestSuite) TestGetUserSubmissions_NonExistentUser() {
+	shows, total, err := suite.showService.GetUserSubmissions(999999, 10, 0)
+	suite.Require().NoError(err)
+	suite.Equal(0, total)
+	suite.Empty(shows)
+}
+
+func (suite *ShowServiceIntegrationTestSuite) TestGetAdminShows_ZeroLimitZeroOffset() {
+	user := suite.createTestUser()
+	req := &contracts.CreateShowRequest{
+		Title:             "AdminBoundary Show",
+		EventDate:         time.Date(2026, 12, 1, 20, 0, 0, 0, time.UTC),
+		City:              "Phoenix",
+		State:             "AZ",
+		Venues:            []contracts.CreateShowVenue{{Name: "AB Venue", City: "Phoenix", State: "AZ"}},
+		Artists:           []contracts.CreateShowArtist{{Name: "AB Artist", IsHeadliner: boolPtr(true)}},
+		SubmittedByUserID: &user.ID,
+		SubmitterIsAdmin:  true,
+	}
+	_, err := suite.showService.CreateShow(req)
+	suite.Require().NoError(err)
+
+	shows, total, err := suite.showService.GetAdminShows(0, 0, contracts.AdminShowFilters{})
+	suite.Require().NoError(err)
+	suite.Equal(int64(1), total, "total should reflect all shows")
+	suite.Empty(shows, "limit=0 should return no results")
+}
+
+func (suite *ShowServiceIntegrationTestSuite) TestGetAdminShows_OffsetBeyondResults() {
+	user := suite.createTestUser()
+	req := &contracts.CreateShowRequest{
+		Title:             "AdminOffset Show",
+		EventDate:         time.Date(2026, 12, 1, 20, 0, 0, 0, time.UTC),
+		City:              "Phoenix",
+		State:             "AZ",
+		Venues:            []contracts.CreateShowVenue{{Name: "AO Venue", City: "Phoenix", State: "AZ"}},
+		Artists:           []contracts.CreateShowArtist{{Name: "AO Artist", IsHeadliner: boolPtr(true)}},
+		SubmittedByUserID: &user.ID,
+		SubmitterIsAdmin:  true,
+	}
+	_, err := suite.showService.CreateShow(req)
+	suite.Require().NoError(err)
+
+	shows, total, err := suite.showService.GetAdminShows(10, 1000, contracts.AdminShowFilters{})
+	suite.Require().NoError(err)
+	suite.Equal(int64(1), total)
+	suite.Empty(shows, "offset beyond results should return empty slice")
+}
+
+func (suite *ShowServiceIntegrationTestSuite) TestGetAdminShows_LargeLimit() {
+	user := suite.createTestUser()
+	req := &contracts.CreateShowRequest{
+		Title:             "AdminLargeLimit Show",
+		EventDate:         time.Date(2026, 12, 1, 20, 0, 0, 0, time.UTC),
+		City:              "Phoenix",
+		State:             "AZ",
+		Venues:            []contracts.CreateShowVenue{{Name: "ALL Venue", City: "Phoenix", State: "AZ"}},
+		Artists:           []contracts.CreateShowArtist{{Name: "ALL Artist", IsHeadliner: boolPtr(true)}},
+		SubmittedByUserID: &user.ID,
+		SubmitterIsAdmin:  true,
+	}
+	_, err := suite.showService.CreateShow(req)
+	suite.Require().NoError(err)
+
+	shows, total, err := suite.showService.GetAdminShows(1000, 0, contracts.AdminShowFilters{})
+	suite.Require().NoError(err)
+	suite.Equal(int64(1), total)
+	suite.Len(shows, 1, "large limit should return all available without error")
+}
+
+func (suite *ShowServiceIntegrationTestSuite) TestGetUpcomingShows_LimitOne() {
+	user := suite.createTestUser()
+	baseDate := time.Date(2027, 7, 1, 20, 0, 0, 0, time.UTC)
+	for i := 0; i < 3; i++ {
+		req := &contracts.CreateShowRequest{
+			Title:             fmt.Sprintf("UpLim1 %d", i),
+			EventDate:         baseDate.AddDate(0, 0, i),
+			City:              "Phoenix",
+			State:             "AZ",
+			Venues:            []contracts.CreateShowVenue{{Name: fmt.Sprintf("UL1 Venue %d", i), City: "Phoenix", State: "AZ"}},
+			Artists:           []contracts.CreateShowArtist{{Name: fmt.Sprintf("UL1 Artist %d", i), IsHeadliner: boolPtr(true)}},
+			SubmittedByUserID: &user.ID,
+			SubmitterIsAdmin:  true,
+		}
+		_, err := suite.showService.CreateShow(req)
+		suite.Require().NoError(err)
+	}
+
+	shows, cursor, err := suite.showService.GetUpcomingShows("UTC", "", 1, false, nil)
+	suite.Require().NoError(err)
+	suite.Len(shows, 1, "limit=1 should return exactly 1 show")
+	suite.NotNil(cursor, "should have cursor when more results exist")
+}
+
+func (suite *ShowServiceIntegrationTestSuite) TestGetUpcomingShows_EmptyResult() {
+	shows, cursor, err := suite.showService.GetUpcomingShows("UTC", "", 10, false, nil)
+	suite.Require().NoError(err)
+	suite.Empty(shows)
+	suite.Nil(cursor, "no cursor when no results")
+}
+
+func (suite *ShowServiceIntegrationTestSuite) TestGetUpcomingShows_ShowAtExactMidnight() {
+	user := suite.createTestUser()
+	now := time.Now().UTC()
+	midnight := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+
+	req := &contracts.CreateShowRequest{
+		Title:             "Midnight Show",
+		EventDate:         midnight,
+		City:              "Phoenix",
+		State:             "AZ",
+		Venues:            []contracts.CreateShowVenue{{Name: "Midnight Venue", City: "Phoenix", State: "AZ"}},
+		Artists:           []contracts.CreateShowArtist{{Name: "Midnight Artist", IsHeadliner: boolPtr(true)}},
+		SubmittedByUserID: &user.ID,
+		SubmitterIsAdmin:  true,
+	}
+	_, err := suite.showService.CreateShow(req)
+	suite.Require().NoError(err)
+
+	shows, _, err := suite.showService.GetUpcomingShows("UTC", "", 50, false, nil)
+	suite.Require().NoError(err)
+
+	found := false
+	for _, s := range shows {
+		if s.Title == "Midnight Show" {
+			found = true
+			break
+		}
+	}
+	suite.True(found, "show at exact midnight today should be included in upcoming shows")
+}
+
+func (suite *ShowServiceIntegrationTestSuite) TestGetUpcomingShows_ShowAtExactBoundary_Yesterday() {
+	user := suite.createTestUser()
+	now := time.Now().UTC()
+	yesterdayEnd := time.Date(now.Year(), now.Month(), now.Day()-1, 23, 59, 59, 0, time.UTC)
+
+	req := &contracts.CreateShowRequest{
+		Title:             "Yesterday Late Show",
+		EventDate:         yesterdayEnd,
+		City:              "Phoenix",
+		State:             "AZ",
+		Venues:            []contracts.CreateShowVenue{{Name: "YLS Venue", City: "Phoenix", State: "AZ"}},
+		Artists:           []contracts.CreateShowArtist{{Name: "YLS Artist", IsHeadliner: boolPtr(true)}},
+		SubmittedByUserID: &user.ID,
+		SubmitterIsAdmin:  true,
+	}
+	_, err := suite.showService.CreateShow(req)
+	suite.Require().NoError(err)
+
+	shows, _, err := suite.showService.GetUpcomingShows("UTC", "", 50, false, nil)
+	suite.Require().NoError(err)
+
+	for _, s := range shows {
+		suite.NotEqual("Yesterday Late Show", s.Title, "show from yesterday should not appear in upcoming")
+	}
+}
+
+func (suite *ShowServiceIntegrationTestSuite) TestGetRejectedShows_EmptyResult() {
+	shows, total, err := suite.showService.GetRejectedShows(10, 0, "")
+	suite.Require().NoError(err)
+	suite.Equal(int64(0), total)
+	suite.Empty(shows)
+}
+
+func (suite *ShowServiceIntegrationTestSuite) TestGetRejectedShows_ZeroLimit() {
+	user := suite.createTestUser()
+	req := &contracts.CreateShowRequest{
+		Title:             "RejZeroLimit",
+		EventDate:         time.Date(2026, 12, 1, 20, 0, 0, 0, time.UTC),
+		City:              "Phoenix",
+		State:             "AZ",
+		Venues:            []contracts.CreateShowVenue{{Name: "RZL Venue", City: "Phoenix", State: "AZ"}},
+		Artists:           []contracts.CreateShowArtist{{Name: "RZL Artist", IsHeadliner: boolPtr(true)}},
+		SubmittedByUserID: &user.ID,
+		SubmitterIsAdmin:  true,
+	}
+	show, err := suite.showService.CreateShow(req)
+	suite.Require().NoError(err)
+	suite.db.Model(&models.Show{}).Where("id = ?", show.ID).Update("status", models.ShowStatusPending)
+	_, err = suite.showService.RejectShow(show.ID, "test reason")
+	suite.Require().NoError(err)
+
+	shows, total, err := suite.showService.GetRejectedShows(0, 0, "")
+	suite.Require().NoError(err)
+	suite.Equal(int64(1), total, "total should be 1")
+	suite.Empty(shows, "limit=0 should return no results")
+}
+
+// =============================================================================
+// Group 13: ID Boundary Conditions
+// =============================================================================
+
+func (suite *ShowServiceIntegrationTestSuite) TestGetShow_ZeroID() {
+	resp, err := suite.showService.GetShow(0)
+	suite.Require().Error(err)
+	suite.Nil(resp)
+}
+
+func (suite *ShowServiceIntegrationTestSuite) TestGetShow_VeryLargeID() {
+	resp, err := suite.showService.GetShow(4294967295)
+	suite.Require().Error(err)
+	suite.Nil(resp)
+}
+
+func (suite *ShowServiceIntegrationTestSuite) TestDeleteShow_ZeroID() {
+	err := suite.showService.DeleteShow(0)
+	// GORM Delete with ID=0 silently affects zero rows — no error returned.
+	suite.NoError(err)
+}
+
+// =============================================================================
+// Group 14: String Boundary Conditions
+// =============================================================================
+
+func (suite *ShowServiceIntegrationTestSuite) TestCreateShow_VeryLongTitle() {
+	user := suite.createTestUser()
+	longTitle := strings.Repeat("A", 500)
+	req := &contracts.CreateShowRequest{
+		Title:             longTitle,
+		EventDate:         time.Date(2026, 12, 1, 20, 0, 0, 0, time.UTC),
+		City:              "Phoenix",
+		State:             "AZ",
+		Venues:            []contracts.CreateShowVenue{{Name: "Long Title Venue", City: "Phoenix", State: "AZ"}},
+		Artists:           []contracts.CreateShowArtist{{Name: "Long Title Artist", IsHeadliner: boolPtr(true)}},
+		SubmittedByUserID: &user.ID,
+		SubmitterIsAdmin:  true,
+	}
+	resp, err := suite.showService.CreateShow(req)
+	if err == nil {
+		suite.Equal(longTitle, resp.Title)
+	}
+}
+
+func (suite *ShowServiceIntegrationTestSuite) TestGetShowBySlug_EmptySlug() {
+	resp, err := suite.showService.GetShowBySlug("")
+	suite.Require().Error(err, "empty slug should return an error")
+	suite.Nil(resp)
+}
+
 func (suite *ShowServiceIntegrationTestSuite) TestConfirmShowImport_CreatesVenueAndArtist() {
 	content := []byte(`---
 show:

--- a/backend/internal/services/catalog/venue_test.go
+++ b/backend/internal/services/catalog/venue_test.go
@@ -2,6 +2,7 @@ package catalog
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -1240,6 +1241,131 @@ func (suite *VenueServiceIntegrationTestSuite) TestGetVenueGenreProfile_Insuffic
 	genres, err := suite.venueService.GetVenueGenreProfile(venue.ID)
 	suite.Require().NoError(err)
 	suite.Empty(genres) // Below 10-show threshold
+}
+
+// =============================================================================
+// Group 15: Pagination Boundary Conditions
+// =============================================================================
+
+func (suite *VenueServiceIntegrationTestSuite) TestGetVenuesWithShowCounts_ZeroLimitZeroOffset() {
+	suite.createTestVenue("ZeroLimit Venue", "Phoenix", "AZ", true)
+	resp, total, err := suite.venueService.GetVenuesWithShowCounts(contracts.VenueListFilters{}, 0, 0)
+	suite.Require().NoError(err)
+	suite.GreaterOrEqual(total, int64(1), "total should reflect venue count")
+	suite.Empty(resp, "limit=0 should return no results")
+}
+
+func (suite *VenueServiceIntegrationTestSuite) TestGetVenuesWithShowCounts_LargeLimit() {
+	suite.createTestVenue("LargeLimit Venue", "Phoenix", "AZ", true)
+	resp, total, err := suite.venueService.GetVenuesWithShowCounts(contracts.VenueListFilters{}, 1000, 0)
+	suite.Require().NoError(err)
+	suite.GreaterOrEqual(total, int64(1))
+	suite.NotEmpty(resp, "should return all venues with a large limit")
+}
+
+func (suite *VenueServiceIntegrationTestSuite) TestGetVenuesWithShowCounts_OffsetBeyondResults() {
+	suite.createTestVenue("OffBeyond Venue", "Phoenix", "AZ", true)
+	resp, total, err := suite.venueService.GetVenuesWithShowCounts(contracts.VenueListFilters{}, 10, 10000)
+	suite.Require().NoError(err)
+	suite.GreaterOrEqual(total, int64(1), "total should still reflect venue count")
+	suite.Empty(resp, "offset beyond results should return empty slice")
+}
+
+func (suite *VenueServiceIntegrationTestSuite) TestGetVenuesWithShowCounts_EmptyResultSet() {
+	resp, total, err := suite.venueService.GetVenuesWithShowCounts(contracts.VenueListFilters{}, 10, 0)
+	suite.Require().NoError(err)
+	suite.Equal(int64(0), total)
+	suite.Empty(resp)
+}
+
+func (suite *VenueServiceIntegrationTestSuite) TestGetVenuesWithShowCounts_LimitOne() {
+	suite.createTestVenue("L1 Venue A", "Phoenix", "AZ", true)
+	suite.createTestVenue("L1 Venue B", "Phoenix", "AZ", true)
+	suite.createTestVenue("L1 Venue C", "Phoenix", "AZ", true)
+	resp, total, err := suite.venueService.GetVenuesWithShowCounts(contracts.VenueListFilters{}, 1, 0)
+	suite.Require().NoError(err)
+	suite.GreaterOrEqual(total, int64(3))
+	suite.Len(resp, 1, "limit=1 should return exactly 1 result")
+}
+
+func (suite *VenueServiceIntegrationTestSuite) TestGetShowsForVenue_LimitZero() {
+	venue := suite.createTestVenue("ZeroLimit ShowVenue", "Phoenix", "AZ", true)
+	user := suite.createTestUser()
+	futureShow := &models.Show{Title: "ZL Future Show", EventDate: time.Now().UTC().AddDate(0, 0, 7), City: stringPtr("Phoenix"), State: stringPtr("AZ"), Status: models.ShowStatusApproved, SubmittedBy: &user.ID}
+	suite.db.Create(futureShow)
+	suite.db.Create(&models.ShowVenue{ShowID: futureShow.ID, VenueID: venue.ID})
+	shows, total, err := suite.venueService.GetShowsForVenue(venue.ID, "UTC", 0, "upcoming")
+	suite.Require().NoError(err)
+	suite.GreaterOrEqual(total, int64(1), "total should reflect shows")
+	suite.Empty(shows, "limit=0 should return no results")
+}
+
+func (suite *VenueServiceIntegrationTestSuite) TestGetShowsForVenue_ShowAtExactMidnight() {
+	venue := suite.createTestVenue("Midnight ShowVenue", "Phoenix", "AZ", true)
+	user := suite.createTestUser()
+	now := time.Now().UTC()
+	midnight := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	midnightShow := &models.Show{Title: "Venue Midnight Show", EventDate: midnight, City: stringPtr("Phoenix"), State: stringPtr("AZ"), Status: models.ShowStatusApproved, SubmittedBy: &user.ID}
+	suite.db.Create(midnightShow)
+	suite.db.Create(&models.ShowVenue{ShowID: midnightShow.ID, VenueID: venue.ID})
+	shows, _, err := suite.venueService.GetShowsForVenue(venue.ID, "UTC", 50, "upcoming")
+	suite.Require().NoError(err)
+	found := false
+	for _, s := range shows {
+		if s.Title == "Venue Midnight Show" {
+			found = true
+			break
+		}
+	}
+	suite.True(found, "show at exact midnight today should appear in upcoming")
+}
+
+func (suite *VenueServiceIntegrationTestSuite) TestGetShowsForVenue_EmptyVenue() {
+	venue := suite.createTestVenue("Empty ShowVenue", "Phoenix", "AZ", true)
+	shows, total, err := suite.venueService.GetShowsForVenue(venue.ID, "UTC", 10, "upcoming")
+	suite.Require().NoError(err)
+	suite.Equal(int64(0), total)
+	suite.Empty(shows)
+}
+
+// =============================================================================
+// Group 16: ID Boundary Conditions
+// =============================================================================
+
+func (suite *VenueServiceIntegrationTestSuite) TestGetVenue_ZeroID() {
+	resp, err := suite.venueService.GetVenue(0)
+	suite.Require().Error(err)
+	suite.Nil(resp)
+}
+
+func (suite *VenueServiceIntegrationTestSuite) TestGetVenue_VeryLargeID() {
+	resp, err := suite.venueService.GetVenue(4294967295)
+	suite.Require().Error(err)
+	suite.Nil(resp)
+}
+
+func (suite *VenueServiceIntegrationTestSuite) TestDeleteVenue_ZeroID() {
+	err := suite.venueService.DeleteVenue(0)
+	suite.Require().Error(err)
+}
+
+// =============================================================================
+// Group 17: String Boundary Conditions
+// =============================================================================
+
+func (suite *VenueServiceIntegrationTestSuite) TestCreateVenue_VeryLongName() {
+	longName := strings.Repeat("V", 500)
+	req := &contracts.CreateVenueRequest{Name: longName, City: "Phoenix", State: "AZ"}
+	resp, err := suite.venueService.CreateVenue(req, true)
+	if err == nil {
+		suite.Equal(longName, resp.Name)
+	}
+}
+
+func (suite *VenueServiceIntegrationTestSuite) TestGetVenueBySlug_EmptySlug() {
+	resp, err := suite.venueService.GetVenueBySlug("")
+	suite.Require().Error(err, "empty slug should return an error")
+	suite.Nil(resp)
 }
 
 func (suite *VenueServiceIntegrationTestSuite) TestGetVenueGenreProfile_NoTags() {


### PR DESCRIPTION
## Summary
- Add 871 lines of boundary condition tests across 6 backend test files
- Cover pagination boundaries (zero limit, large limit, offset beyond results, empty result sets, limit=1) for show, venue, and artist services
- Cover ID parsing boundaries (zero ID, max uint32, overflow) for show, venue, and artist handlers
- Cover string field boundaries (empty slug, very long names, whitespace-only names) for artist and venue services
- Cover time/date boundaries (exact midnight, yesterday cutoff) for upcoming show queries across show, venue, and artist services

## Test plan
- [x] All new tests pass (`go test ./internal/... -short`)
- [x] No regressions in existing tests (all 14 packages pass)
- [x] Service integration tests use testcontainers pattern
- [x] Handler unit tests use mock pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)