### PR TITLE
Add tier change notifications for auto-promotion (PSY-199)

### DIFF
--- a/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
+++ b/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
@@ -544,6 +544,28 @@ func (m *mockAuthService) SetOAuthCompleter(completer contracts.OAuthCompleter) 
 }
 
 // ============================================================================
+// Mock: AutoPromotionServiceInterface
+// ============================================================================
+
+type mockAutoPromotionService struct {
+	evaluateAllUsersFn func() (*contracts.AutoPromotionResult, error)
+	evaluateUserFn func(uint) (*contracts.UserEvaluationResult, error)
+}
+
+func (m *mockAutoPromotionService) EvaluateAllUsers() (*contracts.AutoPromotionResult, error) {
+	if m.evaluateAllUsersFn != nil {
+		return m.evaluateAllUsersFn()
+	}
+	return nil, nil
+}
+func (m *mockAutoPromotionService) EvaluateUser(userID uint) (*contracts.UserEvaluationResult, error) {
+	if m.evaluateUserFn != nil {
+		return m.evaluateUserFn(userID)
+	}
+	return nil, nil
+}
+
+// ============================================================================
 // Mock: CalendarServiceInterface
 // ============================================================================
 
@@ -992,6 +1014,9 @@ type mockEmailService struct {
 	sendAccountRecoveryEmailFn func(string, string, int) (error)
 	sendShowReminderEmailFn func(string, string, string, string, time.Time, []string) (error)
 	sendFilterNotificationEmailFn func(string, string, string, string) (error)
+	sendTierPromotionEmailFn func(string, string, string, string, string, []string) (error)
+	sendTierDemotionEmailFn func(string, string, string, string, string) (error)
+	sendTierDemotionWarningEmailFn func(string, string, string, float64, float64) (error)
 }
 
 func (m *mockEmailService) IsConfigured() (bool) {
@@ -1027,6 +1052,24 @@ func (m *mockEmailService) SendShowReminderEmail(toEmail string, showTitle strin
 func (m *mockEmailService) SendFilterNotificationEmail(toEmail string, subject string, htmlBody string, unsubscribeURL string) (error) {
 	if m.sendFilterNotificationEmailFn != nil {
 		return m.sendFilterNotificationEmailFn(toEmail, subject, htmlBody, unsubscribeURL)
+	}
+	return nil
+}
+func (m *mockEmailService) SendTierPromotionEmail(toEmail string, username string, oldTier string, newTier string, reason string, newPermissions []string) (error) {
+	if m.sendTierPromotionEmailFn != nil {
+		return m.sendTierPromotionEmailFn(toEmail, username, oldTier, newTier, reason, newPermissions)
+	}
+	return nil
+}
+func (m *mockEmailService) SendTierDemotionEmail(toEmail string, username string, oldTier string, newTier string, reason string) (error) {
+	if m.sendTierDemotionEmailFn != nil {
+		return m.sendTierDemotionEmailFn(toEmail, username, oldTier, newTier, reason)
+	}
+	return nil
+}
+func (m *mockEmailService) SendTierDemotionWarningEmail(toEmail string, username string, currentTier string, currentRate float64, threshold float64) (error) {
+	if m.sendTierDemotionWarningEmailFn != nil {
+		return m.sendTierDemotionWarningEmailFn(toEmail, username, currentTier, currentRate, threshold)
 	}
 	return nil
 }
@@ -3173,6 +3216,7 @@ var _ contracts.ArtistServiceInterface = (*mockArtistService)(nil)
 var _ contracts.AttendanceServiceInterface = (*mockAttendanceService)(nil)
 var _ contracts.AuditLogServiceInterface = (*mockAuditLogService)(nil)
 var _ contracts.AuthServiceInterface = (*mockAuthService)(nil)
+var _ contracts.AutoPromotionServiceInterface = (*mockAutoPromotionService)(nil)
 var _ contracts.CalendarServiceInterface = (*mockCalendarService)(nil)
 var _ contracts.ChartsServiceInterface = (*mockChartsService)(nil)
 var _ contracts.CollectionServiceInterface = (*mockCollectionService)(nil)

--- a/backend/internal/services/admin/auto_promotion.go
+++ b/backend/internal/services/admin/auto_promotion.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
@@ -14,6 +15,7 @@ import (
 	"psychic-homily-backend/db"
 	"psychic-homily-backend/internal/models"
 	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/services/notification"
 )
 
 // User tier constants.
@@ -59,15 +61,16 @@ var tierByOrder = map[int]string{
 
 // AutoPromotionService evaluates users for tier promotion and demotion.
 type AutoPromotionService struct {
-	db       *gorm.DB
-	interval time.Duration
-	stopCh   chan struct{}
-	wg       sync.WaitGroup
-	logger   *slog.Logger
+	db           *gorm.DB
+	emailService contracts.EmailServiceInterface
+	interval     time.Duration
+	stopCh       chan struct{}
+	wg           sync.WaitGroup
+	logger       *slog.Logger
 }
 
 // NewAutoPromotionService creates a new auto-promotion service.
-func NewAutoPromotionService(database *gorm.DB) *AutoPromotionService {
+func NewAutoPromotionService(database *gorm.DB, emailService contracts.EmailServiceInterface) *AutoPromotionService {
 	if database == nil {
 		database = db.GetDB()
 	}
@@ -80,10 +83,11 @@ func NewAutoPromotionService(database *gorm.DB) *AutoPromotionService {
 	}
 
 	return &AutoPromotionService{
-		db:       database,
-		interval: interval,
-		stopCh:   make(chan struct{}),
-		logger:   slog.Default(),
+		db:           database,
+		emailService: emailService,
+		interval:     interval,
+		stopCh:       make(chan struct{}),
+		logger:       slog.Default(),
 	}
 }
 
@@ -227,14 +231,98 @@ func (s *AutoPromotionService) EvaluateAllUsers() (*contracts.AutoPromotionResul
 			continue
 		}
 
-		if tierOrder[evalResult.NewTier] > tierOrder[evalResult.CurrentTier] {
+		isPromotion := tierOrder[evalResult.NewTier] > tierOrder[evalResult.CurrentTier]
+		if isPromotion {
 			result.Promoted = append(result.Promoted, change)
 		} else {
 			result.Demoted = append(result.Demoted, change)
 		}
+
+		// Fire-and-forget: send email notification
+		s.sendTierChangeEmail(&user, change, isPromotion)
+
+		// Fire-and-forget: write audit log
+		s.writeTierChangeAuditLog(&user, change, isPromotion)
 	}
 
 	return result, nil
+}
+
+// sendTierChangeEmail sends a promotion or demotion email for a tier change.
+// Errors are logged but never fail the parent operation.
+func (s *AutoPromotionService) sendTierChangeEmail(user *models.User, change contracts.UserTierChange, isPromotion bool) {
+	if s.emailService == nil || !s.emailService.IsConfigured() {
+		return
+	}
+
+	if user.Email == nil || *user.Email == "" {
+		return
+	}
+
+	email := *user.Email
+	username := change.Username
+
+	if isPromotion {
+		newPermissions := notification.TierPermissions(change.NewTier)
+		if err := s.emailService.SendTierPromotionEmail(email, username, change.OldTier, change.NewTier, change.Reason, newPermissions); err != nil {
+			s.logger.Error("failed to send tier promotion email",
+				"user_id", user.ID,
+				"error", err,
+			)
+		}
+	} else {
+		if err := s.emailService.SendTierDemotionEmail(email, username, change.OldTier, change.NewTier, change.Reason); err != nil {
+			s.logger.Error("failed to send tier demotion email",
+				"user_id", user.ID,
+				"error", err,
+			)
+		}
+	}
+}
+
+// writeTierChangeAuditLog records a tier change in the audit log.
+// Errors are logged but never fail the parent operation.
+func (s *AutoPromotionService) writeTierChangeAuditLog(user *models.User, change contracts.UserTierChange, isPromotion bool) {
+	if s.db == nil {
+		return
+	}
+
+	action := "tier_promotion"
+	if !isPromotion {
+		action = "tier_demotion"
+	}
+
+	metadata := map[string]interface{}{
+		"old_tier": change.OldTier,
+		"new_tier": change.NewTier,
+		"reason":   change.Reason,
+		"username": change.Username,
+	}
+	metadataJSON, err := json.Marshal(metadata)
+	if err != nil {
+		s.logger.Error("failed to marshal audit log metadata",
+			"user_id", user.ID,
+			"error", err,
+		)
+		return
+	}
+
+	raw := json.RawMessage(metadataJSON)
+	auditLog := models.AuditLog{
+		ActorID:    nil, // system action, no actor
+		Action:     action,
+		EntityType: "user",
+		EntityID:   user.ID,
+		Metadata:   &raw,
+		CreatedAt:  time.Now().UTC(),
+	}
+
+	if err := s.db.Create(&auditLog).Error; err != nil {
+		s.logger.Error("failed to write tier change audit log",
+			"user_id", user.ID,
+			"error", err,
+		)
+	}
 }
 
 // EvaluateUser checks a single user for promotion/demotion eligibility.

--- a/backend/internal/services/admin/auto_promotion_email_test.go
+++ b/backend/internal/services/admin/auto_promotion_email_test.go
@@ -1,0 +1,339 @@
+package admin
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/testutil"
+)
+
+// mockEmailService is a simple mock for testing tier change email notifications.
+type mockEmailService struct {
+	configured             bool
+	promotionCalls         []promotionCall
+	demotionCalls          []demotionCall
+	demotionWarningCalls   []demotionWarningCall
+	promotionError         error
+	demotionError          error
+	demotionWarningError   error
+}
+
+type promotionCall struct {
+	toEmail        string
+	username       string
+	oldTier        string
+	newTier        string
+	reason         string
+	newPermissions []string
+}
+
+type demotionCall struct {
+	toEmail  string
+	username string
+	oldTier  string
+	newTier  string
+	reason   string
+}
+
+type demotionWarningCall struct {
+	toEmail     string
+	username    string
+	currentTier string
+	currentRate float64
+	threshold   float64
+}
+
+func (m *mockEmailService) IsConfigured() bool { return m.configured }
+func (m *mockEmailService) SendVerificationEmail(_, _ string) error { return nil }
+func (m *mockEmailService) SendMagicLinkEmail(_, _ string) error { return nil }
+func (m *mockEmailService) SendAccountRecoveryEmail(_, _ string, _ int) error { return nil }
+func (m *mockEmailService) SendShowReminderEmail(_, _, _, _ string, _ time.Time, _ []string) error {
+	return nil
+}
+func (m *mockEmailService) SendFilterNotificationEmail(_, _, _, _ string) error { return nil }
+
+func (m *mockEmailService) SendTierPromotionEmail(toEmail, username, oldTier, newTier, reason string, newPermissions []string) error {
+	m.promotionCalls = append(m.promotionCalls, promotionCall{toEmail, username, oldTier, newTier, reason, newPermissions})
+	return m.promotionError
+}
+
+func (m *mockEmailService) SendTierDemotionEmail(toEmail, username, oldTier, newTier, reason string) error {
+	m.demotionCalls = append(m.demotionCalls, demotionCall{toEmail, username, oldTier, newTier, reason})
+	return m.demotionError
+}
+
+func (m *mockEmailService) SendTierDemotionWarningEmail(toEmail, username, currentTier string, currentRate float64, threshold float64) error {
+	m.demotionWarningCalls = append(m.demotionWarningCalls, demotionWarningCall{toEmail, username, currentTier, currentRate, threshold})
+	return m.demotionWarningError
+}
+
+// =============================================================================
+// INTEGRATION TESTS — EMAIL NOTIFICATIONS
+// =============================================================================
+
+type AutoPromotionEmailTestSuite struct {
+	suite.Suite
+	testDB *testutil.TestDatabase
+	db     *gorm.DB
+}
+
+func (s *AutoPromotionEmailTestSuite) SetupSuite() {
+	s.testDB = testutil.SetupTestPostgres(s.T())
+	s.db = s.testDB.DB
+}
+
+func (s *AutoPromotionEmailTestSuite) TearDownSuite() {
+	s.testDB.Cleanup()
+}
+
+func (s *AutoPromotionEmailTestSuite) TearDownTest() {
+	sqlDB, err := s.db.DB()
+	s.Require().NoError(err)
+	_, _ = sqlDB.Exec("DELETE FROM audit_logs")
+	_, _ = sqlDB.Exec("DELETE FROM pending_entity_edits")
+	_, _ = sqlDB.Exec("DELETE FROM revisions")
+	_, _ = sqlDB.Exec("DELETE FROM artists")
+	_, _ = sqlDB.Exec("DELETE FROM venues")
+	_, _ = sqlDB.Exec("DELETE FROM users")
+}
+
+func TestAutoPromotionEmailSuite(t *testing.T) {
+	suite.Run(t, new(AutoPromotionEmailTestSuite))
+}
+
+func (s *AutoPromotionEmailTestSuite) createUserWithEmail(tier string, emailVerified bool, createdAt time.Time, email string) *models.User {
+	username := fmt.Sprintf("user-%d", time.Now().UnixNano())
+	user := &models.User{
+		Email:         &email,
+		Username:      &username,
+		FirstName:     stringPtr("Test"),
+		LastName:      stringPtr("User"),
+		IsActive:      true,
+		IsAdmin:       false,
+		EmailVerified: emailVerified,
+		UserTier:      tier,
+	}
+	err := s.db.Create(user).Error
+	s.Require().NoError(err)
+
+	err = s.db.Model(user).Update("created_at", createdAt).Error
+	s.Require().NoError(err)
+
+	return user
+}
+
+func (s *AutoPromotionEmailTestSuite) createApprovedEdit(userID uint, entityType string, entityID uint) {
+	raw := testRawJSON()
+	edit := &models.PendingEntityEdit{
+		EntityType:   entityType,
+		EntityID:     entityID,
+		SubmittedBy:  userID,
+		FieldChanges: raw,
+		Summary:      "test edit",
+		Status:       models.PendingEditStatusApproved,
+	}
+	err := s.db.Create(edit).Error
+	s.Require().NoError(err)
+}
+
+func (s *AutoPromotionEmailTestSuite) createRejectedEditWithTime(userID uint, entityType string, entityID uint, createdAt time.Time) {
+	raw := testRawJSON()
+	edit := &models.PendingEntityEdit{
+		EntityType:   entityType,
+		EntityID:     entityID,
+		SubmittedBy:  userID,
+		FieldChanges: raw,
+		Summary:      "test edit",
+		Status:       models.PendingEditStatusRejected,
+	}
+	err := s.db.Create(edit).Error
+	s.Require().NoError(err)
+
+	err = s.db.Model(edit).Update("created_at", createdAt).Error
+	s.Require().NoError(err)
+}
+
+func (s *AutoPromotionEmailTestSuite) createTestArtist(name string) *models.Artist {
+	slug := fmt.Sprintf("test-artist-%d", time.Now().UnixNano())
+	artist := &models.Artist{
+		Name: name,
+		Slug: &slug,
+	}
+	err := s.db.Create(artist).Error
+	s.Require().NoError(err)
+	return artist
+}
+
+// TestPromotionSendsEmail verifies that a promotion triggers a promotion email.
+func (s *AutoPromotionEmailTestSuite) TestPromotionSendsEmail() {
+	emailSvc := &mockEmailService{configured: true}
+	svc := NewAutoPromotionService(s.db, emailSvc)
+
+	user := s.createUserWithEmail(TierNewUser, true, time.Now().Add(-15*24*time.Hour), "promo@test.com")
+	artist := s.createTestArtist("Promo Artist")
+
+	for i := 0; i < 5; i++ {
+		s.createApprovedEdit(user.ID, "artist", artist.ID)
+	}
+
+	result, err := svc.EvaluateAllUsers()
+	s.Require().NoError(err)
+	s.Require().Len(result.Promoted, 1)
+
+	// Verify promotion email was sent
+	s.Require().Len(emailSvc.promotionCalls, 1)
+	call := emailSvc.promotionCalls[0]
+	s.Equal("promo@test.com", call.toEmail)
+	s.Equal(TierNewUser, call.oldTier)
+	s.Equal(TierContributor, call.newTier)
+	s.NotEmpty(call.newPermissions)
+}
+
+// TestDemotionSendsEmail verifies that a demotion triggers a demotion email.
+func (s *AutoPromotionEmailTestSuite) TestDemotionSendsEmail() {
+	emailSvc := &mockEmailService{configured: true}
+	svc := NewAutoPromotionService(s.db, emailSvc)
+
+	user := s.createUserWithEmail(TierContributor, true, time.Now().Add(-60*24*time.Hour), "demote@test.com")
+	artist := s.createTestArtist("Demote Artist")
+
+	// 1 approved, 3 rejected in last 30 days (25% approval — below 80%)
+	s.createApprovedEdit(user.ID, "artist", artist.ID)
+	for i := 0; i < 3; i++ {
+		s.createRejectedEditWithTime(user.ID, "artist", artist.ID, time.Now().Add(-time.Duration(i+1)*24*time.Hour))
+	}
+
+	result, err := svc.EvaluateAllUsers()
+	s.Require().NoError(err)
+	s.Require().Len(result.Demoted, 1)
+
+	// Verify demotion email was sent
+	s.Require().Len(emailSvc.demotionCalls, 1)
+	call := emailSvc.demotionCalls[0]
+	s.Equal("demote@test.com", call.toEmail)
+	s.Equal(TierContributor, call.oldTier)
+	s.Equal(TierNewUser, call.newTier)
+}
+
+// TestEmailErrorDoesNotFailPromotion verifies fire-and-forget behavior.
+func (s *AutoPromotionEmailTestSuite) TestEmailErrorDoesNotFailPromotion() {
+	emailSvc := &mockEmailService{
+		configured:     true,
+		promotionError: fmt.Errorf("email send failed"),
+	}
+	svc := NewAutoPromotionService(s.db, emailSvc)
+
+	user := s.createUserWithEmail(TierNewUser, true, time.Now().Add(-15*24*time.Hour), "fail@test.com")
+	artist := s.createTestArtist("Error Artist")
+
+	for i := 0; i < 5; i++ {
+		s.createApprovedEdit(user.ID, "artist", artist.ID)
+	}
+
+	// Email error should not prevent the tier change
+	result, err := svc.EvaluateAllUsers()
+	s.Require().NoError(err)
+	s.Require().Len(result.Promoted, 1)
+
+	// Verify the tier was still updated in the DB
+	var updatedUser models.User
+	s.Require().NoError(s.db.First(&updatedUser, user.ID).Error)
+	s.Equal(TierContributor, updatedUser.UserTier)
+
+	// Email was attempted
+	s.Require().Len(emailSvc.promotionCalls, 1)
+}
+
+// TestNilEmailServiceDoesNotPanic verifies that nil email service is handled gracefully.
+func (s *AutoPromotionEmailTestSuite) TestNilEmailServiceDoesNotPanic() {
+	svc := NewAutoPromotionService(s.db, nil)
+
+	user := s.createUserWithEmail(TierNewUser, true, time.Now().Add(-15*24*time.Hour), "nil@test.com")
+	artist := s.createTestArtist("Nil Artist")
+
+	for i := 0; i < 5; i++ {
+		s.createApprovedEdit(user.ID, "artist", artist.ID)
+	}
+
+	// Should not panic with nil email service
+	result, err := svc.EvaluateAllUsers()
+	s.Require().NoError(err)
+	s.Require().Len(result.Promoted, 1)
+}
+
+// TestUnconfiguredEmailServiceSkipsEmail verifies that unconfigured email service is handled.
+func (s *AutoPromotionEmailTestSuite) TestUnconfiguredEmailServiceSkipsEmail() {
+	emailSvc := &mockEmailService{configured: false}
+	svc := NewAutoPromotionService(s.db, emailSvc)
+
+	user := s.createUserWithEmail(TierNewUser, true, time.Now().Add(-15*24*time.Hour), "unconfig@test.com")
+	artist := s.createTestArtist("Unconfig Artist")
+
+	for i := 0; i < 5; i++ {
+		s.createApprovedEdit(user.ID, "artist", artist.ID)
+	}
+
+	result, err := svc.EvaluateAllUsers()
+	s.Require().NoError(err)
+	s.Require().Len(result.Promoted, 1)
+
+	// No email should have been attempted
+	s.Empty(emailSvc.promotionCalls)
+}
+
+// TestAuditLogWrittenOnPromotion verifies that an audit log entry is created for promotions.
+func (s *AutoPromotionEmailTestSuite) TestAuditLogWrittenOnPromotion() {
+	svc := NewAutoPromotionService(s.db, nil)
+
+	user := s.createUserWithEmail(TierNewUser, true, time.Now().Add(-15*24*time.Hour), "audit@test.com")
+	artist := s.createTestArtist("Audit Artist")
+
+	for i := 0; i < 5; i++ {
+		s.createApprovedEdit(user.ID, "artist", artist.ID)
+	}
+
+	result, err := svc.EvaluateAllUsers()
+	s.Require().NoError(err)
+	s.Require().Len(result.Promoted, 1)
+
+	// Verify audit log was written
+	var auditLog models.AuditLog
+	err = s.db.Where("entity_type = ? AND entity_id = ? AND action = ?", "user", user.ID, "tier_promotion").
+		First(&auditLog).Error
+	s.Require().NoError(err)
+	s.Equal("tier_promotion", auditLog.Action)
+	s.Equal("user", auditLog.EntityType)
+	s.Equal(user.ID, auditLog.EntityID)
+	s.Nil(auditLog.ActorID) // system action
+	s.NotNil(auditLog.Metadata)
+}
+
+// TestAuditLogWrittenOnDemotion verifies that an audit log entry is created for demotions.
+func (s *AutoPromotionEmailTestSuite) TestAuditLogWrittenOnDemotion() {
+	svc := NewAutoPromotionService(s.db, nil)
+
+	user := s.createUserWithEmail(TierContributor, true, time.Now().Add(-60*24*time.Hour), "audit-demote@test.com")
+	artist := s.createTestArtist("Audit Demote Artist")
+
+	s.createApprovedEdit(user.ID, "artist", artist.ID)
+	for i := 0; i < 3; i++ {
+		s.createRejectedEditWithTime(user.ID, "artist", artist.ID, time.Now().Add(-time.Duration(i+1)*24*time.Hour))
+	}
+
+	result, err := svc.EvaluateAllUsers()
+	s.Require().NoError(err)
+	s.Require().Len(result.Demoted, 1)
+
+	// Verify audit log was written
+	var auditLog models.AuditLog
+	err = s.db.Where("entity_type = ? AND entity_id = ? AND action = ?", "user", user.ID, "tier_demotion").
+		First(&auditLog).Error
+	s.Require().NoError(err)
+	s.Equal("tier_demotion", auditLog.Action)
+	s.Nil(auditLog.ActorID)
+}

--- a/backend/internal/services/admin/auto_promotion_test.go
+++ b/backend/internal/services/admin/auto_promotion_test.go
@@ -20,7 +20,7 @@ import (
 // =============================================================================
 
 func TestNewAutoPromotionService(t *testing.T) {
-	svc := NewAutoPromotionService(nil)
+	svc := NewAutoPromotionService(nil, nil)
 	assert.NotNil(t, svc)
 	assert.Equal(t, DefaultAutoPromotionInterval, svc.interval)
 	assert.NotNil(t, svc.stopCh)
@@ -29,19 +29,19 @@ func TestNewAutoPromotionService(t *testing.T) {
 
 func TestNewAutoPromotionService_EnvOverride(t *testing.T) {
 	t.Setenv("AUTO_PROMOTION_INTERVAL_HOURS", "12")
-	svc := NewAutoPromotionService(nil)
+	svc := NewAutoPromotionService(nil, nil)
 	assert.Equal(t, 12*time.Hour, svc.interval)
 }
 
 func TestNewAutoPromotionService_InvalidEnvIgnored(t *testing.T) {
 	t.Setenv("AUTO_PROMOTION_INTERVAL_HOURS", "not-a-number")
-	svc := NewAutoPromotionService(nil)
+	svc := NewAutoPromotionService(nil, nil)
 	assert.Equal(t, DefaultAutoPromotionInterval, svc.interval)
 }
 
 func TestNewAutoPromotionService_ZeroEnvIgnored(t *testing.T) {
 	t.Setenv("AUTO_PROMOTION_INTERVAL_HOURS", "0")
-	svc := NewAutoPromotionService(nil)
+	svc := NewAutoPromotionService(nil, nil)
 	assert.Equal(t, DefaultAutoPromotionInterval, svc.interval)
 }
 
@@ -62,7 +62,7 @@ func TestAutoPromotionService_EvaluateUser_NilDB(t *testing.T) {
 }
 
 func TestAutoPromotionService_StartStop(t *testing.T) {
-	svc := NewAutoPromotionService(nil)
+	svc := NewAutoPromotionService(nil, nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -108,7 +108,7 @@ type AutoPromotionIntegrationTestSuite struct {
 func (s *AutoPromotionIntegrationTestSuite) SetupSuite() {
 	s.testDB = testutil.SetupTestPostgres(s.T())
 	s.db = s.testDB.DB
-	s.svc = NewAutoPromotionService(s.db)
+	s.svc = NewAutoPromotionService(s.db, nil)
 }
 
 func (s *AutoPromotionIntegrationTestSuite) TearDownSuite() {

--- a/backend/internal/services/container.go
+++ b/backend/internal/services/container.go
@@ -184,6 +184,6 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 		Scheduler:        pipeline.NewSchedulerService(database, pipelineSvc, venueSourceConfig, discord),
 		Enrichment:       enrichmentSvc,
 		EnrichmentWorker: enrichmentWorker,
-		AutoPromotion:    adminsvc.NewAutoPromotionService(database),
+		AutoPromotion:    adminsvc.NewAutoPromotionService(database, email),
 	}
 }

--- a/backend/internal/services/contracts/interfaces.go
+++ b/backend/internal/services/contracts/interfaces.go
@@ -243,6 +243,9 @@ type EmailServiceInterface interface {
 	SendAccountRecoveryEmail(toEmail, token string, daysRemaining int) error
 	SendShowReminderEmail(toEmail, showTitle, showURL, unsubscribeURL string, eventDate time.Time, venues []string) error
 	SendFilterNotificationEmail(toEmail, subject, htmlBody, unsubscribeURL string) error
+	SendTierPromotionEmail(toEmail, username, oldTier, newTier, reason string, newPermissions []string) error
+	SendTierDemotionEmail(toEmail, username, oldTier, newTier, reason string) error
+	SendTierDemotionWarningEmail(toEmail, username, currentTier string, currentRate float64, threshold float64) error
 }
 
 // ReminderServiceInterface defines the contract for the show reminder background service.

--- a/backend/internal/services/engagement/reminder_test.go
+++ b/backend/internal/services/engagement/reminder_test.go
@@ -182,6 +182,13 @@ func (m *mockReminderEmailService) SendShowReminderEmail(toEmail, showTitle, sho
 func (m *mockReminderEmailService) SendFilterNotificationEmail(_, _, _, _ string) error {
 	return nil
 }
+func (m *mockReminderEmailService) SendTierPromotionEmail(_, _, _, _, _ string, _ []string) error {
+	return nil
+}
+func (m *mockReminderEmailService) SendTierDemotionEmail(_, _, _, _, _ string) error { return nil }
+func (m *mockReminderEmailService) SendTierDemotionWarningEmail(_, _, _ string, _, _ float64) error {
+	return nil
+}
 
 // ReminderServiceIntegrationTestSuite tests the reminder service with a real database
 type ReminderServiceIntegrationTestSuite struct {

--- a/backend/internal/services/notification/email.go
+++ b/backend/internal/services/notification/email.go
@@ -306,3 +306,253 @@ func (s *EmailService) SendFilterNotificationEmail(toEmail, subject, htmlBody, u
 
 	return nil
 }
+
+// TierDisplayName maps tier constants to human-readable display names.
+func TierDisplayName(tier string) string {
+	switch tier {
+	case "new_user":
+		return "New User"
+	case "contributor":
+		return "Contributor"
+	case "trusted_contributor":
+		return "Trusted Contributor"
+	case "local_ambassador":
+		return "Local Ambassador"
+	default:
+		return tier
+	}
+}
+
+// TierPermissions returns the list of permissions unlocked at a given tier.
+func TierPermissions(tier string) []string {
+	switch tier {
+	case "contributor":
+		return []string{
+			"Submit edits for review",
+			"Vote on tags and relationships",
+			"Create collections",
+		}
+	case "trusted_contributor":
+		return []string{
+			"Edit entities directly (no review needed)",
+			"Higher daily edit limit",
+		}
+	case "local_ambassador":
+		return []string{
+			"All Trusted Contributor permissions",
+			"Featured on city pages",
+		}
+	default:
+		return nil
+	}
+}
+
+// SendTierPromotionEmail sends a congratulatory email when a user is promoted to a higher tier.
+func (s *EmailService) SendTierPromotionEmail(toEmail, username, oldTier, newTier, reason string, newPermissions []string) error {
+	if !s.IsConfigured() {
+		return fmt.Errorf("email service is not configured")
+	}
+
+	displayName := TierDisplayName(newTier)
+	oldDisplayName := TierDisplayName(oldTier)
+
+	permissionsHTML := ""
+	if len(newPermissions) > 0 {
+		permissionsHTML = `<h3 style="color: #1a1a1a; margin-bottom: 8px;">New permissions unlocked:</h3><ul style="padding-left: 20px; color: #444;">`
+		for _, perm := range newPermissions {
+			permissionsHTML += fmt.Sprintf(`<li style="margin-bottom: 4px;">%s</li>`, perm)
+		}
+		permissionsHTML += `</ul>`
+	}
+
+	nextTierHTML := ""
+	switch newTier {
+	case "contributor":
+		nextTierHTML = `<p style="font-size: 14px; color: #666; margin-top: 20px;">Keep contributing quality edits to reach <strong>Trusted Contributor</strong> status (25 approved edits with 95%+ approval rate).</p>`
+	case "trusted_contributor":
+		nextTierHTML = `<p style="font-size: 14px; color: #666; margin-top: 20px;">Keep contributing to your local scene to reach <strong>Local Ambassador</strong> status (50 approved edits with 10+ city edits).</p>`
+	case "local_ambassador":
+		nextTierHTML = `<p style="font-size: 14px; color: #666; margin-top: 20px;">You've reached the highest contributor tier. Thank you for your dedication to the community!</p>`
+	}
+
+	greeting := "there"
+	if username != "" {
+		greeting = username
+	}
+
+	html := fmt.Sprintf(`
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+    <div style="text-align: center; margin-bottom: 30px;">
+        <h1 style="color: #1a1a1a; margin: 0;">Psychic Homily</h1>
+    </div>
+
+    <div style="background: #f0fdf4; border-radius: 8px; padding: 30px; margin-bottom: 20px; border: 1px solid #bbf7d0;">
+        <h2 style="margin-top: 0; color: #166534;">Congratulations, %s!</h2>
+        <p style="font-size: 16px;">You've been promoted from <strong>%s</strong> to <strong>%s</strong>.</p>
+        <p style="color: #444;">%s</p>
+        %s
+        %s
+    </div>
+
+    <div style="text-align: center; font-size: 12px; color: #999;">
+        <p>Thank you for contributing to the Psychic Homily community.</p>
+    </div>
+</body>
+</html>
+`, greeting, oldDisplayName, displayName, reason, permissionsHTML, nextTierHTML)
+
+	params := &resend.SendEmailRequest{
+		From:    fmt.Sprintf("Psychic Homily <%s>", s.fromEmail),
+		To:      []string{toEmail},
+		Subject: fmt.Sprintf("You've been promoted to %s!", displayName),
+		Html:    html,
+	}
+
+	_, err := s.client.Emails.Send(params)
+	if err != nil {
+		sentry.WithScope(func(scope *sentry.Scope) {
+			scope.SetTag("service", "email")
+			scope.SetTag("email_type", "tier_promotion")
+			sentry.CaptureException(err)
+		})
+		return fmt.Errorf("failed to send tier promotion email: %w", err)
+	}
+
+	return nil
+}
+
+// SendTierDemotionEmail sends a notification when a user is demoted to a lower tier.
+func (s *EmailService) SendTierDemotionEmail(toEmail, username, oldTier, newTier, reason string) error {
+	if !s.IsConfigured() {
+		return fmt.Errorf("email service is not configured")
+	}
+
+	oldDisplayName := TierDisplayName(oldTier)
+	newDisplayName := TierDisplayName(newTier)
+
+	greeting := "there"
+	if username != "" {
+		greeting = username
+	}
+
+	html := fmt.Sprintf(`
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+    <div style="text-align: center; margin-bottom: 30px;">
+        <h1 style="color: #1a1a1a; margin: 0;">Psychic Homily</h1>
+    </div>
+
+    <div style="background: #fef9f9; border-radius: 8px; padding: 30px; margin-bottom: 20px; border: 1px solid #fecaca;">
+        <h2 style="margin-top: 0; color: #991b1b;">Your contributor tier has changed</h2>
+        <p>Hi %s,</p>
+        <p>Your tier has changed from <strong>%s</strong> to <strong>%s</strong>.</p>
+        <p style="color: #444;"><strong>Reason:</strong> %s</p>
+        <h3 style="color: #1a1a1a; margin-bottom: 8px;">How to recover your tier:</h3>
+        <ul style="padding-left: 20px; color: #444;">
+            <li style="margin-bottom: 4px;">Focus on submitting accurate, high-quality edits</li>
+            <li style="margin-bottom: 4px;">Double-check your information before submitting</li>
+            <li style="margin-bottom: 4px;">Review the contribution guidelines for best practices</li>
+        </ul>
+    </div>
+
+    <div style="text-align: center; font-size: 12px; color: #999;">
+        <p>Your contributions are valued. Keep at it and you'll regain your tier.</p>
+    </div>
+</body>
+</html>
+`, greeting, oldDisplayName, newDisplayName, reason)
+
+	params := &resend.SendEmailRequest{
+		From:    fmt.Sprintf("Psychic Homily <%s>", s.fromEmail),
+		To:      []string{toEmail},
+		Subject: "Your contributor tier has changed",
+		Html:    html,
+	}
+
+	_, err := s.client.Emails.Send(params)
+	if err != nil {
+		sentry.WithScope(func(scope *sentry.Scope) {
+			scope.SetTag("service", "email")
+			scope.SetTag("email_type", "tier_demotion")
+			sentry.CaptureException(err)
+		})
+		return fmt.Errorf("failed to send tier demotion email: %w", err)
+	}
+
+	return nil
+}
+
+// SendTierDemotionWarningEmail sends a warning when a user's approval rate is approaching the demotion threshold.
+func (s *EmailService) SendTierDemotionWarningEmail(toEmail, username, currentTier string, currentRate float64, threshold float64) error {
+	if !s.IsConfigured() {
+		return fmt.Errorf("email service is not configured")
+	}
+
+	displayName := TierDisplayName(currentTier)
+
+	greeting := "there"
+	if username != "" {
+		greeting = username
+	}
+
+	html := fmt.Sprintf(`
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+    <div style="text-align: center; margin-bottom: 30px;">
+        <h1 style="color: #1a1a1a; margin: 0;">Psychic Homily</h1>
+    </div>
+
+    <div style="background: #fffbeb; border-radius: 8px; padding: 30px; margin-bottom: 20px; border: 1px solid #fde68a;">
+        <h2 style="margin-top: 0; color: #92400e;">Your contributor status is at risk</h2>
+        <p>Hi %s,</p>
+        <p>Your current approval rate of <strong>%.0f%%</strong> is approaching the <strong>%.0f%%</strong> threshold required to maintain your <strong>%s</strong> status.</p>
+        <h3 style="color: #1a1a1a; margin-bottom: 8px;">Tips to improve your approval rate:</h3>
+        <ul style="padding-left: 20px; color: #444;">
+            <li style="margin-bottom: 4px;">Verify information from multiple sources before submitting</li>
+            <li style="margin-bottom: 4px;">Pay attention to formatting and data accuracy</li>
+            <li style="margin-bottom: 4px;">Review feedback on previously rejected edits</li>
+        </ul>
+    </div>
+
+    <div style="text-align: center; font-size: 12px; color: #999;">
+        <p>This is a friendly heads-up to help you maintain your contributor status.</p>
+    </div>
+</body>
+</html>
+`, greeting, currentRate*100, threshold*100, displayName)
+
+	params := &resend.SendEmailRequest{
+		From:    fmt.Sprintf("Psychic Homily <%s>", s.fromEmail),
+		To:      []string{toEmail},
+		Subject: "Your contributor status is at risk",
+		Html:    html,
+	}
+
+	_, err := s.client.Emails.Send(params)
+	if err != nil {
+		sentry.WithScope(func(scope *sentry.Scope) {
+			scope.SetTag("service", "email")
+			scope.SetTag("email_type", "tier_demotion_warning")
+			sentry.CaptureException(err)
+		})
+		return fmt.Errorf("failed to send tier demotion warning email: %w", err)
+	}
+
+	return nil
+}

--- a/backend/internal/services/notification/email_tier_test.go
+++ b/backend/internal/services/notification/email_tier_test.go
@@ -1,0 +1,82 @@
+package notification
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTierDisplayName(t *testing.T) {
+	tests := []struct {
+		tier     string
+		expected string
+	}{
+		{"new_user", "New User"},
+		{"contributor", "Contributor"},
+		{"trusted_contributor", "Trusted Contributor"},
+		{"local_ambassador", "Local Ambassador"},
+		{"unknown_tier", "unknown_tier"},
+		{"", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.tier, func(t *testing.T) {
+			assert.Equal(t, tc.expected, TierDisplayName(tc.tier))
+		})
+	}
+}
+
+func TestTierPermissions(t *testing.T) {
+	t.Run("new_user has no permissions", func(t *testing.T) {
+		perms := TierPermissions("new_user")
+		assert.Nil(t, perms)
+	})
+
+	t.Run("contributor has 3 permissions", func(t *testing.T) {
+		perms := TierPermissions("contributor")
+		assert.Len(t, perms, 3)
+		assert.Contains(t, perms, "Submit edits for review")
+		assert.Contains(t, perms, "Vote on tags and relationships")
+		assert.Contains(t, perms, "Create collections")
+	})
+
+	t.Run("trusted_contributor has 2 permissions", func(t *testing.T) {
+		perms := TierPermissions("trusted_contributor")
+		assert.Len(t, perms, 2)
+		assert.Contains(t, perms, "Edit entities directly (no review needed)")
+		assert.Contains(t, perms, "Higher daily edit limit")
+	})
+
+	t.Run("local_ambassador has 2 permissions", func(t *testing.T) {
+		perms := TierPermissions("local_ambassador")
+		assert.Len(t, perms, 2)
+		assert.Contains(t, perms, "All Trusted Contributor permissions")
+		assert.Contains(t, perms, "Featured on city pages")
+	})
+
+	t.Run("unknown tier returns nil", func(t *testing.T) {
+		perms := TierPermissions("unknown")
+		assert.Nil(t, perms)
+	})
+}
+
+func TestSendTierPromotionEmail_NotConfigured(t *testing.T) {
+	svc := &EmailService{}
+	err := svc.SendTierPromotionEmail("test@example.com", "testuser", "new_user", "contributor", "5 approved edits", []string{"Submit edits"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "email service is not configured")
+}
+
+func TestSendTierDemotionEmail_NotConfigured(t *testing.T) {
+	svc := &EmailService{}
+	err := svc.SendTierDemotionEmail("test@example.com", "testuser", "contributor", "new_user", "low approval rate")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "email service is not configured")
+}
+
+func TestSendTierDemotionWarningEmail_NotConfigured(t *testing.T) {
+	svc := &EmailService{}
+	err := svc.SendTierDemotionWarningEmail("test@example.com", "testuser", "contributor", 0.82, 0.80)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "email service is not configured")
+}

--- a/backend/internal/services/notification/filter_service_test.go
+++ b/backend/internal/services/notification/filter_service_test.go
@@ -762,3 +762,10 @@ func (m *mockEmailService) SendFilterNotificationEmail(_, _, _, _ string) error 
 	m.sendCalls++
 	return nil
 }
+func (m *mockEmailService) SendTierPromotionEmail(_, _, _, _, _ string, _ []string) error {
+	return nil
+}
+func (m *mockEmailService) SendTierDemotionEmail(_, _, _, _, _ string) error { return nil }
+func (m *mockEmailService) SendTierDemotionWarningEmail(_, _, _ string, _, _ float64) error {
+	return nil
+}


### PR DESCRIPTION
## Summary
- Added 3 email methods: `SendTierPromotionEmail`, `SendTierDemotionEmail`, `SendTierDemotionWarningEmail` with styled HTML templates
- Wired `AutoPromotionService` to send emails on tier changes (fire-and-forget)
- Added audit log entries for all tier changes (system actor)
- Tier display name + permission helpers for email content
- 17 new tests (10 unit + 7 integration)

## Test plan
- [ ] Backend builds cleanly (`go build ./...`)
- [ ] Auto-promotion tests pass (`go test ./internal/services/admin/ -run TestAutoPromotion`)
- [ ] Email tier tests pass (`go test ./internal/services/notification/ -run TestTier`)
- [ ] Existing mock-dependent tests still pass after regeneration

Closes PSY-199

🤖 Generated with [Claude Code](https://claude.com/claude-code)