### PR TITLE
Fix relative timestamps showing wrong time due to UTC parsing

### DIFF
--- a/frontend/app/admin/dashboard/_components/AdminDashboard.tsx
+++ b/frontend/app/admin/dashboard/_components/AdminDashboard.tsx
@@ -31,6 +31,7 @@ import { Card, CardContent } from '@/components/ui/card'
 import { useAdminStats, useAdminActivity } from '@/lib/hooks/admin/useAdminStats'
 import { Loader2 } from 'lucide-react'
 import type { ActivityEvent } from '@/lib/types/adminStats'
+import { formatRelativeTime } from '@/lib/formatRelativeTime'
 
 interface StatCardProps {
   label: string
@@ -152,22 +153,6 @@ function getEntityUrl(entityType: string | undefined, entitySlug: string | undef
   }
 }
 
-function formatRelativeTime(timestamp: string): string {
-  const date = new Date(timestamp)
-  const now = new Date()
-  const diffMs = now.getTime() - date.getTime()
-  const diffSec = Math.floor(diffMs / 1000)
-  const diffMin = Math.floor(diffSec / 60)
-  const diffHr = Math.floor(diffMin / 60)
-  const diffDays = Math.floor(diffHr / 24)
-
-  if (diffSec < 60) return 'just now'
-  if (diffMin < 60) return `${diffMin}m ago`
-  if (diffHr < 24) return `${diffHr}h ago`
-  if (diffDays < 7) return `${diffDays}d ago`
-  return date.toLocaleDateString()
-}
-
 function ActivityFeedItem({ event }: { event: ActivityEvent }) {
   const Icon = getEventIcon(event.event_type)
   const iconColor = getEventIconColor(event.event_type)
@@ -190,7 +175,7 @@ function ActivityFeedItem({ event }: { event: ActivityEvent }) {
         </p>
         <p className="text-xs text-muted-foreground mt-0.5">
           {event.actor_name && <span>{event.actor_name} &middot; </span>}
-          {formatRelativeTime(event.timestamp)}
+          {formatRelativeTime(event.timestamp, { short: true })}
         </p>
       </div>
     </div>

--- a/frontend/components/contributor/ContributionTimeline.tsx
+++ b/frontend/components/contributor/ContributionTimeline.tsx
@@ -12,6 +12,7 @@ import {
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import type { ContributionEntry } from '@/features/auth'
+import { formatRelativeTime } from '@/lib/formatRelativeTime'
 
 const entityTypeIcons: Record<string, LucideIcon> = {
   show: Calendar,
@@ -48,27 +49,6 @@ function formatAction(action: string): string {
   return action
     .replace(/_/g, ' ')
     .replace(/\b\w/g, c => c.toUpperCase())
-}
-
-function formatRelativeTime(dateString: string): string {
-  const date = new Date(dateString)
-  const now = new Date()
-  const diffMs = now.getTime() - date.getTime()
-  const diffMins = Math.floor(diffMs / (1000 * 60))
-  const diffHours = Math.floor(diffMs / (1000 * 60 * 60))
-  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24))
-
-  if (diffMins < 1) return 'just now'
-  if (diffMins < 60) return `${diffMins}m ago`
-  if (diffHours < 24) return `${diffHours}h ago`
-  if (diffDays < 7) return `${diffDays}d ago`
-  if (diffDays < 30) return `${Math.floor(diffDays / 7)}w ago`
-
-  return date.toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: date.getFullYear() !== now.getFullYear() ? 'numeric' : undefined,
-  })
 }
 
 interface ContributionTimelineProps {
@@ -119,7 +99,7 @@ export function ContributionTimeline({ contributions }: ContributionTimelineProp
                 )}
               </p>
               <p className="text-xs text-muted-foreground mt-0.5">
-                {formatRelativeTime(entry.created_at)}
+                {formatRelativeTime(entry.created_at, { short: true })}
                 {entry.source && entry.source !== 'web' && (
                   <span> &middot; via {entry.source}</span>
                 )}

--- a/frontend/components/shared/RevisionHistory.tsx
+++ b/frontend/components/shared/RevisionHistory.tsx
@@ -7,6 +7,7 @@ import { useEntityRevisions, useRollbackRevision } from '@/lib/hooks/common/useR
 import type { RevisionItem, FieldChange } from '@/lib/hooks/common/useRevisions'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
+import { formatRelativeTime } from '@/lib/formatRelativeTime'
 
 interface RevisionHistoryProps {
   entityType: string
@@ -23,30 +24,6 @@ function formatValue(value: unknown): string {
   if (typeof value === 'boolean') return value ? 'true' : 'false'
   if (typeof value === 'number') return String(value)
   return JSON.stringify(value)
-}
-
-/**
- * Format a timestamp into a relative time string.
- */
-function formatRelativeTime(dateStr: string): string {
-  const date = new Date(dateStr)
-  const now = new Date()
-  const diffMs = now.getTime() - date.getTime()
-  const diffSec = Math.floor(diffMs / 1000)
-  const diffMin = Math.floor(diffSec / 60)
-  const diffHr = Math.floor(diffMin / 60)
-  const diffDays = Math.floor(diffHr / 24)
-
-  if (diffSec < 60) return 'just now'
-  if (diffMin < 60) return `${diffMin} minute${diffMin === 1 ? '' : 's'} ago`
-  if (diffHr < 24) return `${diffHr} hour${diffHr === 1 ? '' : 's'} ago`
-  if (diffDays < 30) return `${diffDays} day${diffDays === 1 ? '' : 's'} ago`
-
-  return date.toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-  })
 }
 
 /**

--- a/frontend/features/contributions/components/AttributionLine.tsx
+++ b/frontend/features/contributions/components/AttributionLine.tsx
@@ -2,34 +2,11 @@
 
 import Link from 'next/link'
 import { useEntityAttribution } from '../hooks/useEntityAttribution'
+import { formatRelativeTime } from '@/lib/formatRelativeTime'
 
 interface AttributionLineProps {
   entityType: string
   entityId: string | number
-}
-
-/**
- * Format a timestamp into a relative time string.
- */
-function formatRelativeTime(dateStr: string): string {
-  const date = new Date(dateStr)
-  const now = new Date()
-  const diffMs = now.getTime() - date.getTime()
-  const diffSec = Math.floor(diffMs / 1000)
-  const diffMin = Math.floor(diffSec / 60)
-  const diffHr = Math.floor(diffMin / 60)
-  const diffDays = Math.floor(diffHr / 24)
-
-  if (diffSec < 60) return 'just now'
-  if (diffMin < 60) return `${diffMin} minute${diffMin === 1 ? '' : 's'} ago`
-  if (diffHr < 24) return `${diffHr} hour${diffHr === 1 ? '' : 's'} ago`
-  if (diffDays < 30) return `${diffDays} day${diffDays === 1 ? '' : 's'} ago`
-
-  return date.toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-  })
 }
 
 /**

--- a/frontend/lib/formatRelativeTime.test.ts
+++ b/frontend/lib/formatRelativeTime.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { formatRelativeTime } from './formatRelativeTime'
+
+describe('formatRelativeTime', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns "just now" for timestamps less than 60 seconds ago', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-03-30T12:00:30Z'))
+
+    expect(formatRelativeTime('2026-03-30T12:00:00Z')).toBe('just now')
+  })
+
+  it('returns minutes ago for timestamps within the last hour', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-03-30T12:05:00Z'))
+
+    expect(formatRelativeTime('2026-03-30T12:00:00Z')).toBe('5 minutes ago')
+  })
+
+  it('returns singular minute', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-03-30T12:01:30Z'))
+
+    expect(formatRelativeTime('2026-03-30T12:00:00Z')).toBe('1 minute ago')
+  })
+
+  it('returns hours ago for timestamps within the last day', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-03-30T15:00:00Z'))
+
+    expect(formatRelativeTime('2026-03-30T12:00:00Z')).toBe('3 hours ago')
+  })
+
+  it('returns singular hour', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-03-30T13:00:00Z'))
+
+    expect(formatRelativeTime('2026-03-30T12:00:00Z')).toBe('1 hour ago')
+  })
+
+  it('returns days ago for timestamps within the last month', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-02T12:00:00Z'))
+
+    expect(formatRelativeTime('2026-03-30T12:00:00Z')).toBe('3 days ago')
+  })
+
+  it('returns a formatted date for timestamps older than 30 days', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-15T12:00:00Z'))
+
+    const result = formatRelativeTime('2026-03-30T12:00:00Z')
+    expect(result).toContain('Mar')
+    expect(result).toContain('30')
+    expect(result).toContain('2026')
+  })
+
+  // The core bug fix: timestamps without timezone suffix must be treated as UTC
+  it('treats timestamps without Z suffix as UTC (the core timezone fix)', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-03-30T12:00:30Z'))
+
+    // Without the fix, this would be parsed as local time, causing a
+    // multi-hour offset for users in non-UTC timezones
+    expect(formatRelativeTime('2026-03-30T12:00:00')).toBe('just now')
+  })
+
+  it('handles timestamps with +00:00 offset', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-03-30T12:00:30Z'))
+
+    expect(formatRelativeTime('2026-03-30T12:00:00+00:00')).toBe('just now')
+  })
+
+  // Short format tests
+  describe('short format', () => {
+    it('returns "just now" for very recent timestamps', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-03-30T12:00:30Z'))
+
+      expect(formatRelativeTime('2026-03-30T12:00:00Z', { short: true })).toBe('just now')
+    })
+
+    it('returns abbreviated minutes', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-03-30T12:05:00Z'))
+
+      expect(formatRelativeTime('2026-03-30T12:00:00Z', { short: true })).toBe('5m ago')
+    })
+
+    it('returns abbreviated hours', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-03-30T15:00:00Z'))
+
+      expect(formatRelativeTime('2026-03-30T12:00:00Z', { short: true })).toBe('3h ago')
+    })
+
+    it('returns abbreviated days', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-04-02T12:00:00Z'))
+
+      expect(formatRelativeTime('2026-03-30T12:00:00Z', { short: true })).toBe('3d ago')
+    })
+
+    it('returns abbreviated weeks', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-04-13T12:00:00Z'))
+
+      expect(formatRelativeTime('2026-03-30T12:00:00Z', { short: true })).toBe('2w ago')
+    })
+
+    it('treats timestamps without Z suffix as UTC in short format', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-03-30T12:00:30Z'))
+
+      expect(formatRelativeTime('2026-03-30T12:00:00', { short: true })).toBe('just now')
+    })
+  })
+})

--- a/frontend/lib/formatRelativeTime.ts
+++ b/frontend/lib/formatRelativeTime.ts
@@ -1,0 +1,64 @@
+/**
+ * Ensures a date string is treated as UTC.
+ *
+ * The backend formats timestamps with a literal "Z" suffix (e.g.
+ * "2026-03-30T10:00:00Z"), which `new Date()` correctly interprets
+ * as UTC.  However, if a timestamp ever arrives without a timezone
+ * indicator, `new Date()` treats it as *local* time, which introduces
+ * an offset equal to the user's UTC difference (e.g. 7 hours in
+ * Arizona / MST).
+ *
+ * This helper appends "Z" when the string lacks any timezone suffix
+ * so the value is always parsed as UTC.
+ */
+function ensureUTC(dateStr: string): Date {
+  // Already has a timezone indicator: ends with "Z", or has a +/-HH:MM / +/-HHMM offset
+  if (/Z$|[+-]\d{2}:\d{2}$|[+-]\d{4}$/.test(dateStr)) {
+    return new Date(dateStr)
+  }
+  return new Date(dateStr + 'Z')
+}
+
+/**
+ * Format a UTC timestamp string into a human-friendly relative time.
+ *
+ * Handles both short-form ("2m ago") and long-form ("2 minutes ago")
+ * output via the `short` option (default: false).
+ */
+export function formatRelativeTime(
+  dateStr: string,
+  options?: { short?: boolean }
+): string {
+  const date = ensureUTC(dateStr)
+  const now = new Date()
+  const diffMs = now.getTime() - date.getTime()
+  const diffSec = Math.floor(diffMs / 1000)
+  const diffMin = Math.floor(diffSec / 60)
+  const diffHr = Math.floor(diffMin / 60)
+  const diffDays = Math.floor(diffHr / 24)
+
+  if (options?.short) {
+    if (diffMin < 1) return 'just now'
+    if (diffMin < 60) return `${diffMin}m ago`
+    if (diffHr < 24) return `${diffHr}h ago`
+    if (diffDays < 7) return `${diffDays}d ago`
+    if (diffDays < 30) return `${Math.floor(diffDays / 7)}w ago`
+
+    return date.toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: date.getFullYear() !== now.getFullYear() ? 'numeric' : undefined,
+    })
+  }
+
+  if (diffSec < 60) return 'just now'
+  if (diffMin < 60) return `${diffMin} minute${diffMin === 1 ? '' : 's'} ago`
+  if (diffHr < 24) return `${diffHr} hour${diffHr === 1 ? '' : 's'} ago`
+  if (diffDays < 30) return `${diffDays} day${diffDays === 1 ? '' : 's'} ago`
+
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+}


### PR DESCRIPTION
## Summary

- Fix attribution line and revision history showing "7 hours ago" for edits made seconds ago
- Root cause: `new Date(dateStr)` treated timestamps without `Z` suffix as local time (MST = UTC-7)
- Created shared `formatRelativeTime` utility with `ensureUTC` helper, replacing 4 duplicate implementations
- 15 new tests covering timezone fix, relative time formatting, and edge cases

Closes PSY-255

## Test plan

- [ ] Make an edit via entity edit drawer, reload page — attribution shows "just now" not "7 hours ago"
- [ ] Check revision history timestamps are accurate
- [ ] Run `bun run test -- formatRelativeTime` — 15 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)