### PR TITLE
Fix scene chart showing duplicate March and missing February

### DIFF
--- a/frontend/features/scenes/components/ScenePulse.tsx
+++ b/frontend/features/scenes/components/ScenePulse.tsx
@@ -9,10 +9,13 @@ interface ScenePulseProps {
 }
 
 /**
- * Get abbreviated month label for N months ago from today
+ * Get abbreviated month label for N months ago from today.
+ * Sets day to 1 before subtracting to avoid month overflow
+ * (e.g., March 31 minus 1 month would overflow Feb 28 back to March).
  */
 function getMonthLabel(monthsAgo: number): string {
   const date = new Date()
+  date.setDate(1)
   date.setMonth(date.getMonth() - monthsAgo)
   return date.toLocaleString('default', { month: 'short' })
 }


### PR DESCRIPTION
## Summary

- Fix "Shows per month" chart on scene detail pages showing "Mar" twice and skipping "Feb"
- Root cause: `date.setMonth(date.getMonth() - monthsAgo)` on March 30 produces "February 30" which JS overflows to March 2
- Fix: normalize to `date.setDate(1)` before month arithmetic

Closes PSY-258

## Test plan

- [ ] Navigate to `/scenes/phoenix-az` — chart shows Oct, Nov, Dec, Jan, Feb, Mar (no duplicates)
- [ ] Check on different dates (especially month boundaries like the 29th, 30th, 31st)

🤖 Generated with [Claude Code](https://claude.com/claude-code)