### PR TITLE
Add profile edit form and fix missing username display

### DIFF
--- a/backend/internal/api/handlers/auth.go
+++ b/backend/internal/api/handlers/auth.go
@@ -1806,3 +1806,119 @@ func (h *AuthHandler) GenerateCLITokenHandler(ctx context.Context, input *struct
 
 	return resp, nil
 }
+
+// --- Update Profile Identity ---
+
+// UpdateProfileRequest represents the request for updating profile identity fields.
+type UpdateProfileRequest struct {
+	Body struct {
+		Username  *string `json:"username,omitempty" required:"false" doc:"Username (3-30 chars, alphanumeric, underscores, hyphens)"`
+		FirstName *string `json:"first_name,omitempty" required:"false" doc:"First name"`
+		LastName  *string `json:"last_name,omitempty" required:"false" doc:"Last name"`
+		Bio       *string `json:"bio,omitempty" required:"false" doc:"Short bio (max 500 chars)"`
+	}
+}
+
+// UpdateProfileResponse represents the response for updating profile identity fields.
+type UpdateProfileResponse struct {
+	Body struct {
+		Success   bool         `json:"success"`
+		User      *models.User `json:"user,omitempty"`
+		Message   string       `json:"message"`
+		ErrorCode string       `json:"error_code,omitempty"`
+		RequestID string       `json:"request_id,omitempty"`
+	}
+}
+
+// UpdateProfileHandler handles PATCH /auth/profile — updates identity fields (username, name, bio).
+func (h *AuthHandler) UpdateProfileHandler(ctx context.Context, req *UpdateProfileRequest) (*UpdateProfileResponse, error) {
+	resp := &UpdateProfileResponse{}
+	requestID := logger.GetRequestID(ctx)
+	resp.Body.RequestID = requestID
+
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		resp.Body.Success = false
+		resp.Body.Message = "Authentication required"
+		resp.Body.ErrorCode = autherrors.CodeUnauthorized
+		return resp, nil
+	}
+
+	updates := map[string]any{}
+
+	if req.Body.Username != nil {
+		username := strings.TrimSpace(*req.Body.Username)
+		if len(username) < 3 || len(username) > 30 {
+			resp.Body.Success = false
+			resp.Body.Message = "Username must be between 3 and 30 characters"
+			resp.Body.ErrorCode = autherrors.CodeValidationFailed
+			return resp, nil
+		}
+		// Only allow alphanumeric, underscores, and hyphens
+		for _, c := range username {
+			if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' || c == '-') {
+				resp.Body.Success = false
+				resp.Body.Message = "Username may only contain letters, numbers, underscores, and hyphens"
+				resp.Body.ErrorCode = autherrors.CodeValidationFailed
+				return resp, nil
+			}
+		}
+		updates["username"] = username
+	}
+
+	if req.Body.FirstName != nil {
+		updates["first_name"] = strings.TrimSpace(*req.Body.FirstName)
+	}
+
+	if req.Body.LastName != nil {
+		updates["last_name"] = strings.TrimSpace(*req.Body.LastName)
+	}
+
+	if req.Body.Bio != nil {
+		bio := strings.TrimSpace(*req.Body.Bio)
+		if len(bio) > 500 {
+			resp.Body.Success = false
+			resp.Body.Message = "Bio must be 500 characters or fewer"
+			resp.Body.ErrorCode = autherrors.CodeValidationFailed
+			return resp, nil
+		}
+		updates["bio"] = bio
+	}
+
+	if len(updates) == 0 {
+		resp.Body.Success = false
+		resp.Body.Message = "No fields to update"
+		resp.Body.ErrorCode = autherrors.CodeValidationFailed
+		return resp, nil
+	}
+
+	updatedUser, err := h.userService.UpdateUser(user.ID, updates)
+	if err != nil {
+		logger.FromContext(ctx).Error("update_profile_failed",
+			"user_id", user.ID,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		// Check for unique constraint violation (username taken)
+		if strings.Contains(err.Error(), "duplicate key") || strings.Contains(err.Error(), "unique") {
+			resp.Body.Success = false
+			resp.Body.Message = "Username is already taken"
+			resp.Body.ErrorCode = autherrors.CodeValidationFailed
+			return resp, nil
+		}
+		resp.Body.Success = false
+		resp.Body.Message = "Failed to update profile"
+		resp.Body.ErrorCode = autherrors.CodeServiceUnavailable
+		return resp, nil
+	}
+
+	logger.FromContext(ctx).Info("profile_updated",
+		"user_id", user.ID,
+		"request_id", requestID,
+	)
+
+	resp.Body.Success = true
+	resp.Body.User = updatedUser
+	resp.Body.Message = "Profile updated"
+	return resp, nil
+}

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -61,6 +61,7 @@ func SetupRoutes(router *chi.Mux, sc *services.ServiceContainer, cfg *config.Con
 	// Add protected auth routes
 	authHandler := handlers.NewAuthHandler(sc.Auth, sc.JWT, sc.User, sc.Email, sc.Discord, sc.PasswordValidator, cfg)
 	huma.Get(protectedGroup, "/auth/profile", authHandler.GetProfileHandler)
+	huma.Patch(protectedGroup, "/auth/profile", authHandler.UpdateProfileHandler)
 	huma.Post(protectedGroup, "/auth/verify-email/send", authHandler.SendVerificationEmailHandler)
 	huma.Post(protectedGroup, "/auth/change-password", authHandler.ChangePasswordHandler)
 

--- a/frontend/app/profile/page.tsx
+++ b/frontend/app/profile/page.tsx
@@ -1,24 +1,166 @@
 'use client'
 
-import { Suspense } from 'react'
+import { Suspense, useState, useEffect } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useAuthContext } from '@/lib/context/AuthContext'
+import { useUpdateProfile } from '@/features/auth'
 import { redirect } from 'next/navigation'
-import { Loader2, User, Settings, Shield, LayoutList } from 'lucide-react'
+import { Loader2, User, Settings, Shield, LayoutList, Check } from 'lucide-react'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
 import { SettingsPanel } from '@/components/settings'
 import { ContributorProfilePreview, PrivacySettingsPanel, ProfileSectionsEditor } from '@/components/contributor'
 
 function ProfileTab() {
   const { user } = useAuthContext()
+  const updateProfile = useUpdateProfile()
+
+  const [username, setUsername] = useState('')
+  const [firstName, setFirstName] = useState('')
+  const [lastName, setLastName] = useState('')
+  const [bio, setBio] = useState('')
+  const [saved, setSaved] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Initialize form values from user data
+  useEffect(() => {
+    if (user) {
+      setUsername(user.username || '')
+      setFirstName(user.first_name || '')
+      setLastName(user.last_name || '')
+      setBio(user.bio || '')
+    }
+  }, [user])
+
+  const handleSave = async () => {
+    setError(null)
+    setSaved(false)
+
+    try {
+      await updateProfile.mutateAsync({
+        username: username.trim() || undefined,
+        first_name: firstName.trim(),
+        last_name: lastName.trim(),
+        bio: bio.trim(),
+      })
+      setSaved(true)
+      setTimeout(() => setSaved(false), 3000)
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        setError(err.message)
+      } else {
+        setError('Failed to update profile')
+      }
+    }
+  }
+
+  // Check if form has changes compared to current user data
+  const hasChanges =
+    (username.trim() !== (user?.username || '')) ||
+    (firstName.trim() !== (user?.first_name || '')) ||
+    (lastName.trim() !== (user?.last_name || '')) ||
+    (bio.trim() !== (user?.bio || ''))
 
   return (
     <div className="space-y-6">
       {/* Contributor profile preview */}
       <ContributorProfilePreview />
 
-      {/* Account details */}
+      {/* Identity edit form */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">Edit Profile</CardTitle>
+          <CardDescription>
+            Set your username, display name, and bio. Your username appears in
+            attributions and on your public profile.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="username">Username</Label>
+              <Input
+                id="username"
+                placeholder="your_username"
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+                maxLength={30}
+              />
+              <p className="text-xs text-muted-foreground">
+                3-30 characters. Letters, numbers, underscores, and hyphens only.
+              </p>
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="first_name">First Name</Label>
+                <Input
+                  id="first_name"
+                  placeholder="First name"
+                  value={firstName}
+                  onChange={(e) => setFirstName(e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="last_name">Last Name</Label>
+                <Input
+                  id="last_name"
+                  placeholder="Last name"
+                  value={lastName}
+                  onChange={(e) => setLastName(e.target.value)}
+                />
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="bio">Bio</Label>
+              <Textarea
+                id="bio"
+                placeholder="Tell others a bit about yourself..."
+                value={bio}
+                onChange={(e) => setBio(e.target.value)}
+                maxLength={500}
+                rows={3}
+              />
+              <p className="text-xs text-muted-foreground">
+                {bio.length}/500 characters
+              </p>
+            </div>
+          </div>
+
+          {error && (
+            <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+          )}
+
+          <div className="flex items-center gap-3">
+            <Button
+              onClick={handleSave}
+              disabled={updateProfile.isPending || !hasChanges}
+            >
+              {updateProfile.isPending ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Saving...
+                </>
+              ) : (
+                'Save Changes'
+              )}
+            </Button>
+            {saved && (
+              <span className="flex items-center gap-1 text-sm text-green-600 dark:text-green-400">
+                <Check className="h-4 w-4" />
+                Profile updated
+              </span>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Account details (read-only) */}
       <Card>
         <CardHeader>
           <CardTitle className="text-lg">Account Details</CardTitle>
@@ -30,18 +172,6 @@ function ProfileTab() {
               <p className="text-sm font-medium text-muted-foreground">Email</p>
               <p className="text-sm">{user?.email}</p>
             </div>
-            {user?.first_name && (
-              <div className="space-y-1">
-                <p className="text-sm font-medium text-muted-foreground">First Name</p>
-                <p className="text-sm">{user.first_name}</p>
-              </div>
-            )}
-            {user?.last_name && (
-              <div className="space-y-1">
-                <p className="text-sm font-medium text-muted-foreground">Last Name</p>
-                <p className="text-sm">{user.last_name}</p>
-              </div>
-            )}
           </div>
         </CardContent>
       </Card>

--- a/frontend/features/auth/hooks/index.ts
+++ b/frontend/features/auth/hooks/index.ts
@@ -3,6 +3,7 @@ export {
   useRegister,
   useLogout,
   useProfile,
+  useUpdateProfile,
   useRefreshToken,
   useIsAuthenticated,
   useSendVerificationEmail,

--- a/frontend/features/auth/hooks/useAuth.ts
+++ b/frontend/features/auth/hooks/useAuth.ts
@@ -68,9 +68,11 @@ interface UserProfile {
   user?: {
     id: string
     email: string
+    username?: string
     name?: string
     first_name?: string
     last_name?: string
+    bio?: string
     is_admin?: boolean
     email_verified?: boolean
     user_tier?: string
@@ -273,6 +275,61 @@ export const useProfile = () => {
       }
 
       return failureCount < 2
+    },
+  })
+}
+
+// Update profile identity fields (username, name, bio)
+interface UpdateProfileInput {
+  username?: string
+  first_name?: string
+  last_name?: string
+  bio?: string
+}
+
+interface UpdateProfileResponse {
+  success: boolean
+  message: string
+  error_code?: AuthErrorCodeType
+  request_id?: string
+  user?: UserProfile['user']
+}
+
+export const useUpdateProfile = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (
+      input: UpdateProfileInput
+    ): Promise<UpdateProfileResponse> => {
+      authLogger.debug('Updating profile')
+
+      const response = await apiRequest<UpdateProfileResponse>(
+        API_ENDPOINTS.AUTH.PROFILE,
+        {
+          method: 'PATCH',
+          body: JSON.stringify(input),
+          credentials: 'include',
+        }
+      )
+
+      if (!response.success) {
+        throw new AuthError(
+          response.message || 'Failed to update profile',
+          response.error_code || AuthErrorCode.UNKNOWN,
+          {
+            requestId: response.request_id,
+            status: 400,
+          }
+        )
+      }
+
+      return response
+    },
+    onSuccess: async () => {
+      authLogger.info('Profile updated successfully')
+      // Refetch profile to get updated user data
+      await queryClient.refetchQueries({ queryKey: queryKeys.auth.profile })
     },
   })
 }

--- a/frontend/features/auth/index.ts
+++ b/frontend/features/auth/index.ts
@@ -25,6 +25,7 @@ export {
   useRegister,
   useLogout,
   useProfile,
+  useUpdateProfile,
   useRefreshToken,
   useIsAuthenticated,
   useSendVerificationEmail,

--- a/frontend/features/requests/components/RequestCard.tsx
+++ b/frontend/features/requests/components/RequestCard.tsx
@@ -132,7 +132,12 @@ export function RequestCard({ request }: RequestCardProps) {
           )}
 
           <div className="mt-1.5 flex items-center gap-3 text-xs text-muted-foreground">
-            <span>by {request.requester_name}</span>
+            <span>
+              by{' '}
+              {request.requester_name && request.requester_name !== 'Unknown'
+                ? request.requester_name
+                : `User #${request.requester_id}`}
+            </span>
             <span>{formatTimeAgo(request.created_at)}</span>
           </div>
         </div>

--- a/frontend/features/requests/components/RequestDetail.tsx
+++ b/frontend/features/requests/components/RequestDetail.tsx
@@ -256,12 +256,18 @@ export function RequestDetail({ requestId }: RequestDetailProps) {
 
                   <p className="text-sm text-muted-foreground mt-2">
                     Requested by{' '}
-                    <Link
-                      href={`/users/${request.requester_name}`}
-                      className="text-foreground hover:text-primary transition-colors"
-                    >
-                      {request.requester_name}
-                    </Link>{' '}
+                    {request.requester_name && request.requester_name !== 'Unknown' ? (
+                      <Link
+                        href={`/users/${request.requester_name}`}
+                        className="text-foreground hover:text-primary transition-colors"
+                      >
+                        {request.requester_name}
+                      </Link>
+                    ) : (
+                      <span className="text-foreground">
+                        User #{request.requester_id}
+                      </span>
+                    )}{' '}
                     {formatTimeAgo(request.created_at)}
                   </p>
 

--- a/frontend/lib/context/AuthContext.tsx
+++ b/frontend/lib/context/AuthContext.tsx
@@ -13,8 +13,10 @@ import { useProfile, useLogout } from '@/features/auth'
 interface User {
   id: string
   email: string
+  username?: string
   first_name?: string
   last_name?: string
+  bio?: string
   email_verified: boolean
   is_admin?: boolean
 }
@@ -63,8 +65,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
       return {
         id: profileData.user.id,
         email: profileData.user.email,
+        username: profileData.user.username,
         first_name: profileData.user.first_name,
         last_name: profileData.user.last_name,
+        bio: profileData.user.bio,
         email_verified: profileData.user.email_verified ?? false,
         is_admin: profileData.user.is_admin,
       }


### PR DESCRIPTION
## Summary

- **PSY-261**: Add `PATCH /auth/profile` endpoint for username/name/bio editing with validation (3-30 chars, alphanumeric/underscores/hyphens, unique constraint). Replace read-only profile tab with edit form.
- **PSY-254**: Attribution "User #N" fallback now resolves once users set usernames via the new form
- **PSY-259**: Fix request cards showing "by Unknown" — now shows "User #N" as consistent fallback, avoids broken `/users/Unknown` links

Closes PSY-261
Closes PSY-254
Closes PSY-259

## Test plan

- [ ] Navigate to `/profile` — see editable username, first/last name, bio fields
- [ ] Set a username, save — success message, profile URL updates in Privacy tab
- [ ] Create a request — author shows username instead of "Unknown"
- [ ] Edit an entity, reload — attribution shows username instead of "User #N"
- [ ] Try duplicate username — see friendly error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)