### PR TITLE
Add entity search to Cmd+K command palette

### DIFF
--- a/frontend/components/layout/CommandPalette.test.tsx
+++ b/frontend/components/layout/CommandPalette.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest'
-import { render, screen, act } from '@testing-library/react'
+import { screen, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { renderWithProviders } from '@/test/utils'
 import { CommandPalette } from './CommandPalette'
 
 // jsdom does not implement scrollIntoView
@@ -34,6 +35,22 @@ vi.mock('@/lib/context/AuthContext', () => ({
   useAuthContext: () => mockAuthContext,
 }))
 
+// Mock the entity search hook to avoid real API calls in basic tests
+vi.mock('@/lib/hooks/common/useEntitySearch', () => ({
+  useEntitySearch: () => ({
+    data: {
+      artists: [],
+      venues: [],
+      releases: [],
+      labels: [],
+      festivals: [],
+    },
+    isSearching: false,
+    totalResults: 0,
+    isFetching: false,
+  }),
+}))
+
 describe('CommandPalette', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -43,10 +60,10 @@ describe('CommandPalette', () => {
   })
 
   it('should open on Cmd+K', async () => {
-    render(<CommandPalette />)
+    renderWithProviders(<CommandPalette />)
 
     // Dialog should not be visible initially
-    expect(screen.queryByPlaceholderText('Go to page...')).not.toBeInTheDocument()
+    expect(screen.queryByPlaceholderText('Search entities or go to page...')).not.toBeInTheDocument()
 
     // Press Cmd+K
     act(() => {
@@ -56,11 +73,11 @@ describe('CommandPalette', () => {
     })
 
     // Dialog should be visible
-    expect(screen.getByPlaceholderText('Go to page...')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Search entities or go to page...')).toBeInTheDocument()
   })
 
   it('should show public pages for unauthenticated users', async () => {
-    render(<CommandPalette />)
+    renderWithProviders(<CommandPalette />)
 
     act(() => {
       document.dispatchEvent(
@@ -86,7 +103,7 @@ describe('CommandPalette', () => {
     mockAuthContext.user = { id: '1', email: 'test@test.com' }
     mockAuthContext.isAuthenticated = true
 
-    render(<CommandPalette />)
+    renderWithProviders(<CommandPalette />)
 
     act(() => {
       document.dispatchEvent(
@@ -104,7 +121,7 @@ describe('CommandPalette', () => {
     mockAuthContext.user = { id: '1', email: 'admin@test.com', is_admin: true }
     mockAuthContext.isAuthenticated = true
 
-    render(<CommandPalette />)
+    renderWithProviders(<CommandPalette />)
 
     act(() => {
       document.dispatchEvent(
@@ -117,7 +134,7 @@ describe('CommandPalette', () => {
 
   it('should navigate on item selection', async () => {
     const user = userEvent.setup()
-    render(<CommandPalette />)
+    renderWithProviders(<CommandPalette />)
 
     act(() => {
       document.dispatchEvent(
@@ -133,7 +150,7 @@ describe('CommandPalette', () => {
 
   it('should show recent searches after selection', async () => {
     const user = userEvent.setup()
-    render(<CommandPalette />)
+    renderWithProviders(<CommandPalette />)
 
     // Open and select Shows
     act(() => {
@@ -156,7 +173,7 @@ describe('CommandPalette', () => {
 
   it('should close on Escape', async () => {
     const user = userEvent.setup()
-    render(<CommandPalette />)
+    renderWithProviders(<CommandPalette />)
 
     act(() => {
       document.dispatchEvent(
@@ -164,15 +181,15 @@ describe('CommandPalette', () => {
       )
     })
 
-    expect(screen.getByPlaceholderText('Go to page...')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Search entities or go to page...')).toBeInTheDocument()
 
     await user.keyboard('{Escape}')
 
-    expect(screen.queryByPlaceholderText('Go to page...')).not.toBeInTheDocument()
+    expect(screen.queryByPlaceholderText('Search entities or go to page...')).not.toBeInTheDocument()
   })
 
   it('should show keyboard navigation hints', async () => {
-    render(<CommandPalette />)
+    renderWithProviders(<CommandPalette />)
 
     act(() => {
       document.dispatchEvent(
@@ -186,12 +203,12 @@ describe('CommandPalette', () => {
   })
 
   it('should open via custom event (openCommandPalette)', async () => {
-    render(<CommandPalette />)
+    renderWithProviders(<CommandPalette />)
 
     act(() => {
       window.dispatchEvent(new Event('open-command-palette'))
     })
 
-    expect(screen.getByPlaceholderText('Go to page...')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Search entities or go to page...')).toBeInTheDocument()
   })
 })

--- a/frontend/components/layout/CommandPalette.tsx
+++ b/frontend/components/layout/CommandPalette.tsx
@@ -15,11 +15,13 @@ import {
   Calendar, Mic2, MapPin, Disc3, Tag, Tags, Tent, BookOpen, Headphones, Send,
   Library, LayoutList, MessageSquarePlus, Settings, Search, Clock, X, Globe,
   TrendingUp, LayoutDashboard, Upload, BadgeCheck, Flag, ScrollText, Users, Workflow,
-  ClipboardCheck, BarChart3, Music, Bell, HeartHandshake, ShieldCheck,
+  ClipboardCheck, BarChart3, Music, Bell, HeartHandshake, ShieldCheck, Loader2,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import { useAuthContext } from '@/lib/context/AuthContext'
 import { useCommandPalette } from '@/lib/hooks/common/useCommandPalette'
+import { useEntitySearch } from '@/lib/hooks/common/useEntitySearch'
+import type { EntitySearchResult } from '@/lib/hooks/common/useEntitySearch'
 
 interface RouteItem {
   label: string
@@ -282,6 +284,24 @@ const adminRoutes: RouteItem[] = [
 
 const allRoutes = [...routes, ...adminRoutes]
 
+/** Map entity type to an icon */
+const entityTypeIcons: Record<EntitySearchResult['entityType'], LucideIcon> = {
+  artist: Mic2,
+  venue: MapPin,
+  release: Disc3,
+  label: Tag,
+  festival: Tent,
+}
+
+/** Map entity type to display label for grouping */
+const entityTypeLabels: Record<EntitySearchResult['entityType'], string> = {
+  artist: 'Artists',
+  venue: 'Venues',
+  release: 'Releases',
+  label: 'Labels',
+  festival: 'Festivals',
+}
+
 export function CommandPalette() {
   const router = useRouter()
   const { user, isAuthenticated } = useAuthContext()
@@ -295,6 +315,12 @@ export function CommandPalette() {
 
   const [recentSearches, setRecentSearches] = useState<string[]>([])
   const [search, setSearch] = useState('')
+
+  // Entity search — only active when palette is open and query is 2+ chars
+  const { data: entityResults, isSearching, totalResults } = useEntitySearch({
+    query: search,
+    enabled: open,
+  })
 
   useEffect(() => {
     if (open) {
@@ -324,6 +350,15 @@ export function CommandPalette() {
     [router, setOpen, addRecentSearch]
   )
 
+  const handleEntitySelect = useCallback(
+    (result: EntitySearchResult) => {
+      addRecentSearch(result.name)
+      setOpen(false)
+      router.push(result.href)
+    },
+    [router, setOpen, addRecentSearch]
+  )
+
   const handleRecentSelect = useCallback(
     (label: string) => {
       const route = allRoutes.find(
@@ -342,18 +377,38 @@ export function CommandPalette() {
   }, [clearRecentSearches])
 
   const showRecent = !search && recentSearches.length > 0
+  const hasEntityResults = totalResults > 0
+  const showEntityResults = search.trim().length >= 2
+
+  // Collect entity result groups that have results, in display order
+  const entityGroups = useMemo(() => {
+    if (!entityResults) return []
+    const types = ['artist', 'venue', 'release', 'label', 'festival'] as const
+    const groups: { type: EntitySearchResult['entityType']; results: EntitySearchResult[] }[] = []
+    for (const type of types) {
+      const key = `${type}s` as keyof typeof entityResults
+      const results = entityResults[key]
+      if (results && results.length > 0) {
+        groups.push({ type, results })
+      }
+    }
+    return groups
+  }, [entityResults])
 
   return (
     <CommandDialog open={open} onOpenChange={setOpen}>
       <div className="flex items-center border-b border-border/50 px-3">
         <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
         <CommandPrimitive.Input
-          placeholder="Go to page..."
+          placeholder="Search entities or go to page..."
           className="flex h-11 w-full bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground"
           value={search}
           onValueChange={setSearch}
         />
-        {search && (
+        {isSearching && (
+          <Loader2 className="ml-2 h-3.5 w-3.5 animate-spin text-muted-foreground" />
+        )}
+        {search && !isSearching && (
           <button
             onClick={() => setSearch('')}
             className="ml-2 rounded-sm p-1 text-muted-foreground hover:text-foreground"
@@ -364,8 +419,12 @@ export function CommandPalette() {
         )}
       </div>
 
-      <CommandList className="max-h-[320px] p-2">
-        <CommandEmpty>No matching pages.</CommandEmpty>
+      <CommandList className="max-h-[400px] p-2">
+        <CommandEmpty>
+          {showEntityResults && !hasEntityResults && !isSearching
+            ? 'No matching entities or pages.'
+            : 'No matching pages.'}
+        </CommandEmpty>
 
         {showRecent && (
           <CommandGroup
@@ -407,6 +466,42 @@ export function CommandPalette() {
         )}
 
         {showRecent && <CommandSeparator className="mx-2 my-1" />}
+
+        {/* Entity search results — shown when user types 2+ characters */}
+        {showEntityResults && entityGroups.map(({ type, results }) => {
+          const Icon = entityTypeIcons[type]
+          const groupLabel = entityTypeLabels[type]
+          return (
+            <CommandGroup key={type} heading={groupLabel}>
+              {results.map(result => (
+                <CommandItem
+                  key={`entity-${type}-${result.id}`}
+                  value={`entity-${type}-${result.id}-${result.name}`}
+                  onSelect={() => handleEntitySelect(result)}
+                  className="cursor-pointer gap-3 rounded-lg px-2 py-2.5"
+                  keywords={[result.name]}
+                >
+                  <Icon className="h-4 w-4 text-muted-foreground" />
+                  <div className="flex flex-col gap-0.5 min-w-0">
+                    <span className="truncate">{result.name}</span>
+                    {result.subtitle && (
+                      <span className="text-xs text-muted-foreground truncate">
+                        {result.subtitle}
+                      </span>
+                    )}
+                  </div>
+                  <span className="ml-auto shrink-0 text-xs text-muted-foreground">
+                    {result.href}
+                  </span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          )
+        })}
+
+        {showEntityResults && hasEntityResults && (
+          <CommandSeparator className="mx-2 my-1" />
+        )}
 
         <CommandGroup heading="Pages">
           {availableRoutes.map(route => {

--- a/frontend/features/festivals/api.ts
+++ b/frontend/features/festivals/api.ts
@@ -14,6 +14,7 @@ import { API_BASE_URL } from '@/lib/api-base'
 
 export const festivalEndpoints = {
   LIST: `${API_BASE_URL}/festivals`,
+  SEARCH: `${API_BASE_URL}/festivals/search`,
   GET: (idOrSlug: string | number) => `${API_BASE_URL}/festivals/${idOrSlug}`,
   CREATE: `${API_BASE_URL}/festivals`,
   UPDATE: (festivalId: string | number) =>
@@ -57,6 +58,8 @@ export const festivalQueryKeys = {
   all: ['festivals'] as const,
   list: (filters?: Record<string, unknown>) =>
     ['festivals', 'list', filters] as const,
+  search: (query: string) =>
+    ['festivals', 'search', query.toLowerCase()] as const,
   detail: (idOrSlug: string | number) => ['festivals', 'detail', String(idOrSlug)] as const,
   artists: (idOrSlug: string | number, dayDate?: string) =>
     ['festivals', 'artists', String(idOrSlug), dayDate] as const,

--- a/frontend/features/labels/api.ts
+++ b/frontend/features/labels/api.ts
@@ -14,6 +14,7 @@ import { API_BASE_URL } from '@/lib/api-base'
 
 export const labelEndpoints = {
   LIST: `${API_BASE_URL}/labels`,
+  SEARCH: `${API_BASE_URL}/labels/search`,
   GET: (idOrSlug: string | number) => `${API_BASE_URL}/labels/${idOrSlug}`,
   CREATE: `${API_BASE_URL}/labels`,
   UPDATE: (labelId: string | number) => `${API_BASE_URL}/labels/${labelId}`,
@@ -32,6 +33,8 @@ export const labelQueryKeys = {
   all: ['labels'] as const,
   list: (filters?: Record<string, unknown>) =>
     ['labels', 'list', filters] as const,
+  search: (query: string) =>
+    ['labels', 'search', query.toLowerCase()] as const,
   detail: (idOrSlug: string | number) => ['labels', 'detail', String(idOrSlug)] as const,
   roster: (idOrSlug: string | number) => ['labels', 'roster', String(idOrSlug)] as const,
   catalog: (idOrSlug: string | number) => ['labels', 'catalog', String(idOrSlug)] as const,

--- a/frontend/features/releases/api.ts
+++ b/frontend/features/releases/api.ts
@@ -14,6 +14,7 @@ import { API_BASE_URL } from '@/lib/api-base'
 
 export const releaseEndpoints = {
   LIST: `${API_BASE_URL}/releases`,
+  SEARCH: `${API_BASE_URL}/releases/search`,
   GET: (idOrSlug: string | number) => `${API_BASE_URL}/releases/${idOrSlug}`,
   CREATE: `${API_BASE_URL}/releases`,
   UPDATE: (releaseId: string | number) => `${API_BASE_URL}/releases/${releaseId}`,
@@ -34,6 +35,8 @@ export const releaseQueryKeys = {
   all: ['releases'] as const,
   list: (filters?: Record<string, unknown>) =>
     ['releases', 'list', filters] as const,
+  search: (query: string) =>
+    ['releases', 'search', query.toLowerCase()] as const,
   detail: (idOrSlug: string | number) => ['releases', 'detail', String(idOrSlug)] as const,
   artistReleases: (artistIdOrSlug: string | number) =>
     ['releases', 'artist', String(artistIdOrSlug)] as const,

--- a/frontend/lib/hooks/common/index.ts
+++ b/frontend/lib/hooks/common/index.ts
@@ -27,3 +27,9 @@ export {
   useUnfollow,
   useMyFollowing,
 } from './useFollow'
+
+export {
+  useEntitySearch,
+  type EntitySearchResult,
+  type EntitySearchResults,
+} from './useEntitySearch'

--- a/frontend/lib/hooks/common/useEntitySearch.test.tsx
+++ b/frontend/lib/hooks/common/useEntitySearch.test.tsx
@@ -1,0 +1,371 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { createWrapper } from '@/test/utils'
+
+// Mock apiRequest
+const mockApiRequest = vi.fn()
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+}))
+
+// Mock use-debounce to return the value immediately for testing
+vi.mock('use-debounce', () => ({
+  useDebounce: (value: string) => [value],
+}))
+
+import { useEntitySearch } from './useEntitySearch'
+
+describe('useEntitySearch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Default: all endpoints return empty
+    mockApiRequest.mockResolvedValue({ artists: [], venues: [], releases: [], labels: [], festivals: [], count: 0 })
+  })
+
+  it('should not fetch when query is less than 2 characters', () => {
+    const { result } = renderHook(
+      () => useEntitySearch({ query: 'a' }),
+      { wrapper: createWrapper() }
+    )
+
+    expect(result.current.totalResults).toBe(0)
+    expect(mockApiRequest).not.toHaveBeenCalled()
+  })
+
+  it('should not fetch when query is empty', () => {
+    const { result } = renderHook(
+      () => useEntitySearch({ query: '' }),
+      { wrapper: createWrapper() }
+    )
+
+    expect(result.current.totalResults).toBe(0)
+    expect(mockApiRequest).not.toHaveBeenCalled()
+  })
+
+  it('should not fetch when disabled', () => {
+    renderHook(
+      () => useEntitySearch({ query: 'test', enabled: false }),
+      { wrapper: createWrapper() }
+    )
+
+    expect(mockApiRequest).not.toHaveBeenCalled()
+  })
+
+  it('should fetch all 5 entity types when query is 2+ characters', async () => {
+    mockApiRequest.mockImplementation((url: string) => {
+      if (url.includes('/artists/search')) {
+        return Promise.resolve({
+          artists: [{ id: 1, slug: 'the-growlers', name: 'The Growlers', city: 'Dana Point', state: 'CA' }],
+          count: 1,
+        })
+      }
+      if (url.includes('/venues/search')) {
+        return Promise.resolve({ venues: [], count: 0 })
+      }
+      if (url.includes('/releases/search')) {
+        return Promise.resolve({ releases: [], count: 0 })
+      }
+      if (url.includes('/labels/search')) {
+        return Promise.resolve({ labels: [], count: 0 })
+      }
+      if (url.includes('/festivals/search')) {
+        return Promise.resolve({ festivals: [], count: 0 })
+      }
+      return Promise.resolve({ count: 0 })
+    })
+
+    const { result } = renderHook(
+      () => useEntitySearch({ query: 'growlers' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => {
+      expect(result.current.totalResults).toBe(1)
+    })
+
+    // All 5 endpoints should be called
+    expect(mockApiRequest).toHaveBeenCalledTimes(5)
+    expect(mockApiRequest).toHaveBeenCalledWith(expect.stringContaining('/artists/search?q=growlers'))
+    expect(mockApiRequest).toHaveBeenCalledWith(expect.stringContaining('/venues/search?q=growlers'))
+    expect(mockApiRequest).toHaveBeenCalledWith(expect.stringContaining('/releases/search?q=growlers'))
+    expect(mockApiRequest).toHaveBeenCalledWith(expect.stringContaining('/labels/search?q=growlers'))
+    expect(mockApiRequest).toHaveBeenCalledWith(expect.stringContaining('/festivals/search?q=growlers'))
+  })
+
+  it('should map artist results correctly', async () => {
+    mockApiRequest.mockImplementation((url: string) => {
+      if (url.includes('/artists/search')) {
+        return Promise.resolve({
+          artists: [
+            { id: 1, slug: 'the-growlers', name: 'The Growlers', city: 'Dana Point', state: 'CA' },
+            { id: 2, slug: 'eraser', name: 'Eraser', city: null, state: null },
+          ],
+          count: 2,
+        })
+      }
+      return Promise.resolve({ venues: [], releases: [], labels: [], festivals: [], count: 0 })
+    })
+
+    const { result } = renderHook(
+      () => useEntitySearch({ query: 'test' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => {
+      expect(result.current.data?.artists.length).toBe(2)
+    })
+
+    const artists = result.current.data!.artists
+    expect(artists[0]).toEqual({
+      id: 1,
+      slug: 'the-growlers',
+      name: 'The Growlers',
+      subtitle: 'Dana Point, CA',
+      entityType: 'artist',
+      href: '/artists/the-growlers',
+    })
+    expect(artists[1]).toEqual({
+      id: 2,
+      slug: 'eraser',
+      name: 'Eraser',
+      subtitle: null,
+      entityType: 'artist',
+      href: '/artists/eraser',
+    })
+  })
+
+  it('should map venue results correctly', async () => {
+    mockApiRequest.mockImplementation((url: string) => {
+      if (url.includes('/venues/search')) {
+        return Promise.resolve({
+          venues: [{ id: 10, slug: 'crescent-ballroom', name: 'Crescent Ballroom', city: 'Phoenix', state: 'AZ' }],
+          count: 1,
+        })
+      }
+      return Promise.resolve({ artists: [], releases: [], labels: [], festivals: [], count: 0 })
+    })
+
+    const { result } = renderHook(
+      () => useEntitySearch({ query: 'crescent' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => {
+      expect(result.current.data?.venues.length).toBe(1)
+    })
+
+    expect(result.current.data!.venues[0]).toEqual({
+      id: 10,
+      slug: 'crescent-ballroom',
+      name: 'Crescent Ballroom',
+      subtitle: 'Phoenix, AZ',
+      entityType: 'venue',
+      href: '/venues/crescent-ballroom',
+    })
+  })
+
+  it('should map release results correctly', async () => {
+    mockApiRequest.mockImplementation((url: string) => {
+      if (url.includes('/releases/search')) {
+        return Promise.resolve({
+          releases: [{ id: 5, slug: 'nevermind', title: 'Nevermind', release_type: 'album', release_year: 1991 }],
+          count: 1,
+        })
+      }
+      return Promise.resolve({ artists: [], venues: [], labels: [], festivals: [], count: 0 })
+    })
+
+    const { result } = renderHook(
+      () => useEntitySearch({ query: 'nevermind' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => {
+      expect(result.current.data?.releases.length).toBe(1)
+    })
+
+    expect(result.current.data!.releases[0]).toEqual({
+      id: 5,
+      slug: 'nevermind',
+      name: 'Nevermind',
+      subtitle: 'album · 1991',
+      entityType: 'release',
+      href: '/releases/nevermind',
+    })
+  })
+
+  it('should map label results correctly', async () => {
+    mockApiRequest.mockImplementation((url: string) => {
+      if (url.includes('/labels/search')) {
+        return Promise.resolve({
+          labels: [{ id: 3, slug: 'sub-pop', name: 'Sub Pop', city: 'Seattle', state: 'WA' }],
+          count: 1,
+        })
+      }
+      return Promise.resolve({ artists: [], venues: [], releases: [], festivals: [], count: 0 })
+    })
+
+    const { result } = renderHook(
+      () => useEntitySearch({ query: 'sub pop' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => {
+      expect(result.current.data?.labels.length).toBe(1)
+    })
+
+    expect(result.current.data!.labels[0]).toEqual({
+      id: 3,
+      slug: 'sub-pop',
+      name: 'Sub Pop',
+      subtitle: 'Seattle, WA',
+      entityType: 'label',
+      href: '/labels/sub-pop',
+    })
+  })
+
+  it('should map festival results correctly', async () => {
+    mockApiRequest.mockImplementation((url: string) => {
+      if (url.includes('/festivals/search')) {
+        return Promise.resolve({
+          festivals: [{ id: 7, slug: 'm3f-2026', name: 'M3F 2026', city: 'Phoenix', state: 'AZ', edition_year: 2026 }],
+          count: 1,
+        })
+      }
+      return Promise.resolve({ artists: [], venues: [], releases: [], labels: [], count: 0 })
+    })
+
+    const { result } = renderHook(
+      () => useEntitySearch({ query: 'm3f' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => {
+      expect(result.current.data?.festivals.length).toBe(1)
+    })
+
+    expect(result.current.data!.festivals[0]).toEqual({
+      id: 7,
+      slug: 'm3f-2026',
+      name: 'M3F 2026',
+      subtitle: 'Phoenix, AZ · 2026',
+      entityType: 'festival',
+      href: '/festivals/m3f-2026',
+    })
+  })
+
+  it('should limit results to 5 per type', async () => {
+    const manyArtists = Array.from({ length: 10 }, (_, i) => ({
+      id: i + 1,
+      slug: `artist-${i + 1}`,
+      name: `Artist ${i + 1}`,
+      city: null,
+      state: null,
+    }))
+
+    mockApiRequest.mockImplementation((url: string) => {
+      if (url.includes('/artists/search')) {
+        return Promise.resolve({ artists: manyArtists, count: 10 })
+      }
+      return Promise.resolve({ venues: [], releases: [], labels: [], festivals: [], count: 0 })
+    })
+
+    const { result } = renderHook(
+      () => useEntitySearch({ query: 'artist' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => {
+      expect(result.current.data?.artists.length).toBe(5)
+    })
+  })
+
+  it('should handle individual endpoint failures gracefully', async () => {
+    mockApiRequest.mockImplementation((url: string) => {
+      if (url.includes('/artists/search')) {
+        return Promise.reject(new Error('Network error'))
+      }
+      if (url.includes('/venues/search')) {
+        return Promise.resolve({
+          venues: [{ id: 1, slug: 'test-venue', name: 'Test Venue', city: 'Phoenix', state: 'AZ' }],
+          count: 1,
+        })
+      }
+      return Promise.resolve({ releases: [], labels: [], festivals: [], count: 0 })
+    })
+
+    const { result } = renderHook(
+      () => useEntitySearch({ query: 'test' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => {
+      expect(result.current.totalResults).toBe(1)
+    })
+
+    // Artists should be empty (failed), venues should have results
+    expect(result.current.data!.artists).toEqual([])
+    expect(result.current.data!.venues.length).toBe(1)
+  })
+
+  it('should calculate totalResults across all entity types', async () => {
+    mockApiRequest.mockImplementation((url: string) => {
+      if (url.includes('/artists/search')) {
+        return Promise.resolve({
+          artists: [{ id: 1, slug: 'a1', name: 'Artist 1' }],
+          count: 1,
+        })
+      }
+      if (url.includes('/venues/search')) {
+        return Promise.resolve({
+          venues: [{ id: 2, slug: 'v1', name: 'Venue 1', city: 'Phoenix', state: 'AZ' }],
+          count: 1,
+        })
+      }
+      if (url.includes('/releases/search')) {
+        return Promise.resolve({
+          releases: [
+            { id: 3, slug: 'r1', title: 'Release 1' },
+            { id: 4, slug: 'r2', title: 'Release 2' },
+          ],
+          count: 2,
+        })
+      }
+      return Promise.resolve({ labels: [], festivals: [], count: 0 })
+    })
+
+    const { result } = renderHook(
+      () => useEntitySearch({ query: 'test' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => {
+      expect(result.current.totalResults).toBe(4) // 1 artist + 1 venue + 2 releases
+    })
+  })
+
+  it('should trim whitespace from query', async () => {
+    mockApiRequest.mockResolvedValue({ artists: [], venues: [], releases: [], labels: [], festivals: [], count: 0 })
+
+    renderHook(
+      () => useEntitySearch({ query: '  ab  ' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => {
+      expect(mockApiRequest).toHaveBeenCalled()
+    })
+
+    // Should search for "ab" (trimmed)
+    expect(mockApiRequest).toHaveBeenCalledWith(expect.stringContaining('q=ab'))
+  })
+
+  it('should not fetch when trimmed query is less than 2 characters', () => {
+    renderHook(
+      () => useEntitySearch({ query: '  a  ' }),
+      { wrapper: createWrapper() }
+    )
+
+    expect(mockApiRequest).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/lib/hooks/common/useEntitySearch.ts
+++ b/frontend/lib/hooks/common/useEntitySearch.ts
@@ -1,0 +1,235 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import { useDebounce } from 'use-debounce'
+import { apiRequest } from '@/lib/api'
+import { artistEndpoints } from '@/features/artists/api'
+import { venueEndpoints } from '@/features/venues/api'
+import { releaseEndpoints } from '@/features/releases/api'
+import { labelEndpoints } from '@/features/labels/api'
+import { festivalEndpoints } from '@/features/festivals/api'
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface EntitySearchResult {
+  id: number
+  slug: string
+  name: string
+  /** Subtitle info (e.g., city/state, release type, year) */
+  subtitle: string | null
+  entityType: 'artist' | 'venue' | 'release' | 'label' | 'festival'
+  href: string
+}
+
+export interface EntitySearchResults {
+  artists: EntitySearchResult[]
+  venues: EntitySearchResult[]
+  releases: EntitySearchResult[]
+  labels: EntitySearchResult[]
+  festivals: EntitySearchResult[]
+}
+
+// Response shapes from the backend search endpoints
+interface ArtistSearchItem {
+  id: number
+  slug: string
+  name: string
+  city?: string | null
+  state?: string | null
+}
+
+interface VenueSearchItem {
+  id: number
+  slug: string
+  name: string
+  city?: string
+  state?: string
+}
+
+interface ReleaseSearchItem {
+  id: number
+  slug: string
+  title: string
+  release_type?: string
+  release_year?: number | null
+}
+
+interface LabelSearchItem {
+  id: number
+  slug: string
+  name: string
+  city?: string | null
+  state?: string | null
+}
+
+interface FestivalSearchItem {
+  id: number
+  slug: string
+  name: string
+  city?: string | null
+  state?: string | null
+  edition_year?: number
+}
+
+// ============================================================================
+// Mappers
+// ============================================================================
+
+function mapArtist(a: ArtistSearchItem): EntitySearchResult {
+  const parts: string[] = []
+  if (a.city && a.state) parts.push(`${a.city}, ${a.state}`)
+  else if (a.city) parts.push(a.city)
+  else if (a.state) parts.push(a.state)
+
+  return {
+    id: a.id,
+    slug: a.slug,
+    name: a.name,
+    subtitle: parts.length > 0 ? parts.join(' ') : null,
+    entityType: 'artist',
+    href: `/artists/${a.slug}`,
+  }
+}
+
+function mapVenue(v: VenueSearchItem): EntitySearchResult {
+  const loc = v.city && v.state ? `${v.city}, ${v.state}` : v.city || v.state || null
+  return {
+    id: v.id,
+    slug: v.slug,
+    name: v.name,
+    subtitle: loc,
+    entityType: 'venue',
+    href: `/venues/${v.slug}`,
+  }
+}
+
+function mapRelease(r: ReleaseSearchItem): EntitySearchResult {
+  const parts: string[] = []
+  if (r.release_type) parts.push(r.release_type)
+  if (r.release_year) parts.push(String(r.release_year))
+  return {
+    id: r.id,
+    slug: r.slug,
+    name: r.title,
+    subtitle: parts.length > 0 ? parts.join(' · ') : null,
+    entityType: 'release',
+    href: `/releases/${r.slug}`,
+  }
+}
+
+function mapLabel(l: LabelSearchItem): EntitySearchResult {
+  const loc = l.city && l.state ? `${l.city}, ${l.state}` : l.city || l.state || null
+  return {
+    id: l.id,
+    slug: l.slug,
+    name: l.name,
+    subtitle: loc,
+    entityType: 'label',
+    href: `/labels/${l.slug}`,
+  }
+}
+
+function mapFestival(f: FestivalSearchItem): EntitySearchResult {
+  const parts: string[] = []
+  if (f.city && f.state) parts.push(`${f.city}, ${f.state}`)
+  if (f.edition_year) parts.push(String(f.edition_year))
+  return {
+    id: f.id,
+    slug: f.slug,
+    name: f.name,
+    subtitle: parts.length > 0 ? parts.join(' · ') : null,
+    entityType: 'festival',
+    href: `/festivals/${f.slug}`,
+  }
+}
+
+// ============================================================================
+// Query function
+// ============================================================================
+
+const MAX_RESULTS_PER_TYPE = 5
+
+async function fetchEntitySearch(query: string): Promise<EntitySearchResults> {
+  const encoded = encodeURIComponent(query)
+
+  // Fire all requests in parallel; if individual ones fail, return empty arrays
+  const [artists, venues, releases, labels, festivals] = await Promise.all([
+    apiRequest<{ artists: ArtistSearchItem[]; count: number }>(
+      `${artistEndpoints.SEARCH}?q=${encoded}`
+    ).catch(() => ({ artists: [], count: 0 })),
+    apiRequest<{ venues: VenueSearchItem[]; count: number }>(
+      `${venueEndpoints.SEARCH}?q=${encoded}`
+    ).catch(() => ({ venues: [], count: 0 })),
+    apiRequest<{ releases: ReleaseSearchItem[]; count: number }>(
+      `${releaseEndpoints.SEARCH}?q=${encoded}`
+    ).catch(() => ({ releases: [], count: 0 })),
+    apiRequest<{ labels: LabelSearchItem[]; count: number }>(
+      `${labelEndpoints.SEARCH}?q=${encoded}`
+    ).catch(() => ({ labels: [], count: 0 })),
+    apiRequest<{ festivals: FestivalSearchItem[]; count: number }>(
+      `${festivalEndpoints.SEARCH}?q=${encoded}`
+    ).catch(() => ({ festivals: [], count: 0 })),
+  ])
+
+  return {
+    artists: (artists.artists || []).slice(0, MAX_RESULTS_PER_TYPE).map(mapArtist),
+    venues: (venues.venues || []).slice(0, MAX_RESULTS_PER_TYPE).map(mapVenue),
+    releases: (releases.releases || []).slice(0, MAX_RESULTS_PER_TYPE).map(mapRelease),
+    labels: (labels.labels || []).slice(0, MAX_RESULTS_PER_TYPE).map(mapLabel),
+    festivals: (festivals.festivals || []).slice(0, MAX_RESULTS_PER_TYPE).map(mapFestival),
+  }
+}
+
+// ============================================================================
+// Hook
+// ============================================================================
+
+const EMPTY_RESULTS: EntitySearchResults = {
+  artists: [],
+  venues: [],
+  releases: [],
+  labels: [],
+  festivals: [],
+}
+
+/**
+ * Hook for searching entities across all types (artists, venues, releases, labels, festivals).
+ * Used in the Cmd+K command palette to provide entity results alongside page navigation.
+ *
+ * Returns results grouped by entity type, limited to 5 per type.
+ * Debounces input by default (300ms) and requires at least 2 characters.
+ */
+export function useEntitySearch(options: {
+  query: string
+  enabled?: boolean
+  debounceMs?: number
+}) {
+  const { query, enabled = true, debounceMs = 300 } = options
+  const [debouncedQuery] = useDebounce(query.trim(), debounceMs)
+
+  const isQueryLongEnough = debouncedQuery.length >= 2
+
+  const result = useQuery({
+    queryKey: ['entity-search', debouncedQuery],
+    queryFn: () => fetchEntitySearch(debouncedQuery),
+    enabled: enabled && isQueryLongEnough,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
+    placeholderData: EMPTY_RESULTS,
+  })
+
+  const totalResults =
+    (result.data?.artists.length ?? 0) +
+    (result.data?.venues.length ?? 0) +
+    (result.data?.releases.length ?? 0) +
+    (result.data?.labels.length ?? 0) +
+    (result.data?.festivals.length ?? 0)
+
+  return {
+    ...result,
+    totalResults,
+    isSearching: isQueryLongEnough && result.isFetching,
+  }
+}


### PR DESCRIPTION
## Summary

- Add debounced entity search to Cmd+K palette across artists, venues, releases, labels, and festivals
- Fires 5 parallel search requests when user types 2+ characters, with 300ms debounce
- Results grouped by entity type with icons, displayed above Pages section
- Error isolation: one failing endpoint doesn't block others
- 14 new tests, placeholder updated to "Search entities or go to page..."

Closes PSY-257

## Test plan

- [ ] Open Cmd+K, type "eraser" — see Eraser artist in results
- [ ] Type "growlers" — see The Growlers artist
- [ ] Type "van buren" — see The Van Buren venue
- [ ] Click a result — navigates to entity detail page
- [ ] Type 1 char — no API search (only page filter)
- [ ] Run `bun run test -- useEntitySearch` — 14 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)