### PR TITLE
Add tagged entities listing to tag detail page

### DIFF
--- a/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
+++ b/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
@@ -2448,6 +2448,7 @@ type mockTagService struct {
 	deleteAliasFn func(uint) (error)
 	listAliasesFn func(uint) ([]models.TagAlias, error)
 	resolveAliasFn func(string) (*models.Tag, error)
+	getTagEntitiesFn func(uint, string, int, int) ([]contracts.TaggedEntityItem, int64, error)
 	searchTagsFn func(string, int) ([]models.Tag, error)
 	getTrendingTagsFn func(int, string) ([]models.Tag, error)
 	pruneDownvotedTagsFn func() (int64, error)
@@ -2542,6 +2543,12 @@ func (m *mockTagService) ResolveAlias(alias string) (*models.Tag, error) {
 		return m.resolveAliasFn(alias)
 	}
 	return nil, nil
+}
+func (m *mockTagService) GetTagEntities(tagID uint, entityType string, limit int, offset int) ([]contracts.TaggedEntityItem, int64, error) {
+	if m.getTagEntitiesFn != nil {
+		return m.getTagEntitiesFn(tagID, entityType, limit, offset)
+	}
+	return nil, 0, nil
 }
 func (m *mockTagService) SearchTags(query string, limit int) ([]models.Tag, error) {
 	if m.searchTagsFn != nil {

--- a/backend/internal/api/handlers/tag.go
+++ b/backend/internal/api/handlers/tag.go
@@ -102,6 +102,41 @@ func (h *TagHandler) GetTagHandler(ctx context.Context, req *GetTagRequest) (*Ge
 }
 
 // ============================================================================
+// List Tagged Entities (public)
+// ============================================================================
+
+type ListTagEntitiesRequest struct {
+	TagID      string `path:"tag_id" doc:"Tag ID or slug" example:"post-punk"`
+	EntityType string `query:"entity_type" required:"false" doc:"Filter by entity type (artist, release, label, show, venue, festival)"`
+	Limit      int    `query:"limit" required:"false" doc:"Max results (default 50)" example:"50"`
+	Offset     int    `query:"offset" required:"false" doc:"Offset for pagination" example:"0"`
+}
+
+type ListTagEntitiesResponse struct {
+	Body struct {
+		Entities []contracts.TaggedEntityItem `json:"entities"`
+		Total    int64                        `json:"total"`
+	}
+}
+
+func (h *TagHandler) ListTagEntitiesHandler(ctx context.Context, req *ListTagEntitiesRequest) (*ListTagEntitiesResponse, error) {
+	tag := h.resolveTag(req.TagID)
+	if tag == nil {
+		return nil, huma.Error404NotFound("Tag not found")
+	}
+
+	entities, total, err := h.tagService.GetTagEntities(tag.ID, req.EntityType, req.Limit, req.Offset)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Failed to list tagged entities")
+	}
+
+	resp := &ListTagEntitiesResponse{}
+	resp.Body.Entities = entities
+	resp.Body.Total = total
+	return resp, nil
+}
+
+// ============================================================================
 // Search Tags (public, autocomplete)
 // ============================================================================
 

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -750,6 +750,7 @@ func setupTagRoutes(rc RouteContext) {
 	huma.Get(rc.API, "/tags/search", tagHandler.SearchTagsHandler)
 	huma.Get(rc.API, "/tags/{tag_id}", tagHandler.GetTagHandler)
 	huma.Get(rc.API, "/tags/{tag_id}/aliases", tagHandler.ListAliasesHandler)
+	huma.Get(rc.API, "/tags/{tag_id}/entities", tagHandler.ListTagEntitiesHandler)
 
 	// Entity tags with optional auth (includes user's vote if authenticated)
 	optionalAuthGroup := huma.NewGroup(rc.API, "")

--- a/backend/internal/services/catalog/tag_service.go
+++ b/backend/internal/services/catalog/tag_service.go
@@ -653,6 +653,112 @@ func (s *TagService) PruneDownvotedTags() (int64, error) {
 	return totalPruned, nil
 }
 
+// ──────────────────────────────────────────────
+// Tag entities
+// ──────────────────────────────────────────────
+
+// entityTableMap maps entity type strings to their DB table name and name column.
+var entityTableMap = map[string]struct {
+	table     string
+	nameCol   string
+}{
+	"artist":   {table: "artists", nameCol: "name"},
+	"venue":    {table: "venues", nameCol: "name"},
+	"label":    {table: "labels", nameCol: "name"},
+	"show":     {table: "shows", nameCol: "title"},
+	"release":  {table: "releases", nameCol: "title"},
+	"festival": {table: "festivals", nameCol: "name"},
+}
+
+// GetTagEntities returns entities tagged with a given tag, optionally filtered by entity type.
+func (s *TagService) GetTagEntities(tagID uint, entityType string, limit, offset int) ([]contracts.TaggedEntityItem, int64, error) {
+	if s.db == nil {
+		return nil, 0, fmt.Errorf("database not initialized")
+	}
+
+	query := s.db.Model(&models.EntityTag{}).Where("tag_id = ?", tagID)
+	if entityType != "" {
+		if !models.IsValidTagEntityType(entityType) {
+			return nil, 0, fmt.Errorf("invalid entity type: %s", entityType)
+		}
+		query = query.Where("entity_type = ?", entityType)
+	}
+
+	var total int64
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, fmt.Errorf("failed to count tagged entities: %w", err)
+	}
+
+	if total == 0 {
+		return []contracts.TaggedEntityItem{}, 0, nil
+	}
+
+	// Fetch entity_tag rows
+	if limit <= 0 {
+		limit = 50
+	}
+
+	var entityTags []models.EntityTag
+	if err := query.Order("created_at DESC").Limit(limit).Offset(offset).Find(&entityTags).Error; err != nil {
+		return nil, 0, fmt.Errorf("failed to list tagged entities: %w", err)
+	}
+
+	// Group entity IDs by type for batch resolution
+	byType := make(map[string][]uint)
+	for _, et := range entityTags {
+		byType[et.EntityType] = append(byType[et.EntityType], et.EntityID)
+	}
+
+	// Resolve names and slugs per entity type
+	type entityInfo struct {
+		ID   uint
+		Name string
+		Slug string
+	}
+	infoMap := make(map[string]map[uint]entityInfo) // entityType -> entityID -> info
+
+	for eType, ids := range byType {
+		meta, ok := entityTableMap[eType]
+		if !ok {
+			continue
+		}
+
+		var results []entityInfo
+		err := s.db.Raw(
+			fmt.Sprintf("SELECT id, %s AS name, COALESCE(slug, '') AS slug FROM %s WHERE id IN ?", meta.nameCol, meta.table),
+			ids,
+		).Scan(&results).Error
+		if err != nil {
+			continue // skip if table doesn't exist or query fails
+		}
+
+		m := make(map[uint]entityInfo, len(results))
+		for _, r := range results {
+			m[r.ID] = r
+		}
+		infoMap[eType] = m
+	}
+
+	// Build response
+	items := make([]contracts.TaggedEntityItem, 0, len(entityTags))
+	for _, et := range entityTags {
+		info := entityInfo{}
+		if m, ok := infoMap[et.EntityType]; ok {
+			if i, ok := m[et.EntityID]; ok {
+				info = i
+			}
+		}
+		items = append(items, contracts.TaggedEntityItem{
+			EntityType: et.EntityType,
+			EntityID:   et.EntityID,
+			Name:       info.Name,
+			Slug:       info.Slug,
+		})
+	}
+
+	return items, total, nil
+}
+
 // wilsonScore computes the Wilson score lower bound for a binomial proportion.
 // This is the same algorithm used for request voting.
 func wilsonScore(upvotes, downvotes int) float64 {

--- a/backend/internal/services/contracts/tag.go
+++ b/backend/internal/services/contracts/tag.go
@@ -51,6 +51,14 @@ type EntityTagResponse struct {
 	AddedByUsername string  `json:"added_by_username,omitempty"`
 }
 
+// TaggedEntityItem represents a single entity tagged with a given tag.
+type TaggedEntityItem struct {
+	EntityType string `json:"entity_type"`
+	EntityID   uint   `json:"entity_id"`
+	Name       string `json:"name"`
+	Slug       string `json:"slug"`
+}
+
 // TagAliasResponse represents a tag alias returned to clients.
 type TagAliasResponse struct {
 	ID        uint      `json:"id"`
@@ -82,6 +90,9 @@ type TagServiceInterface interface {
 	DeleteAlias(aliasID uint) error
 	ListAliases(tagID uint) ([]models.TagAlias, error)
 	ResolveAlias(alias string) (*models.Tag, error)
+
+	// Tag entities
+	GetTagEntities(tagID uint, entityType string, limit, offset int) ([]TaggedEntityItem, int64, error)
 
 	// Utility
 	SearchTags(query string, limit int) ([]models.Tag, error)

--- a/frontend/features/tags/components/TagDetail.test.tsx
+++ b/frontend/features/tags/components/TagDetail.test.tsx
@@ -7,8 +7,10 @@ import type { TagDetailResponse } from '../types'
 // ── Mocks ──────────────────────────────────────────
 
 const mockUseTag = vi.fn()
+const mockUseTagEntities = vi.fn()
 vi.mock('../hooks', () => ({
   useTag: (...args: unknown[]) => mockUseTag(...args),
+  useTagEntities: (...args: unknown[]) => mockUseTagEntities(...args),
 }))
 
 vi.mock('next/link', () => ({
@@ -90,6 +92,11 @@ function makeTagDetail(overrides: Partial<TagDetailResponse> = {}): TagDetailRes
 describe('TagDetail', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // Default: no entities loaded
+    mockUseTagEntities.mockReturnValue({
+      data: { entities: [], total: 0 },
+      isLoading: false,
+    })
   })
 
   // ── Loading state ──
@@ -377,5 +384,65 @@ describe('TagDetail', () => {
     // "Jazz" appears in both the heading and breadcrumb
     const jazzElements = screen.getAllByText('Jazz')
     expect(jazzElements.length).toBeGreaterThanOrEqual(2)
+  })
+
+  // ── Tagged Entities ──
+
+  it('renders tagged entities grouped by type', () => {
+    mockUseTag.mockReturnValue({
+      data: makeTagDetail({ usage_count: 3 }),
+      isLoading: false,
+      error: null,
+    })
+    mockUseTagEntities.mockReturnValue({
+      data: {
+        entities: [
+          { entity_type: 'artist', entity_id: 1, name: 'Radiohead', slug: 'radiohead' },
+          { entity_type: 'artist', entity_id: 2, name: 'Portishead', slug: 'portishead' },
+          { entity_type: 'venue', entity_id: 10, name: 'The Rebel Lounge', slug: 'the-rebel-lounge' },
+        ],
+        total: 3,
+      },
+      isLoading: false,
+    })
+
+    renderWithProviders(<TagDetail slug="rock" />)
+
+    expect(screen.getByText('Tagged Entities')).toBeInTheDocument()
+    expect(screen.getByText('Artists')).toBeInTheDocument()
+    expect(screen.getByText('Venues')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Radiohead' })).toHaveAttribute('href', '/artists/radiohead')
+    expect(screen.getByRole('link', { name: 'Portishead' })).toHaveAttribute('href', '/artists/portishead')
+    expect(screen.getByRole('link', { name: 'The Rebel Lounge' })).toHaveAttribute('href', '/venues/the-rebel-lounge')
+  })
+
+  it('does not render tagged entities section when usage_count is 0', () => {
+    mockUseTag.mockReturnValue({
+      data: makeTagDetail({ usage_count: 0 }),
+      isLoading: false,
+      error: null,
+    })
+
+    renderWithProviders(<TagDetail slug="rock" />)
+
+    expect(screen.queryByText('Tagged Entities')).not.toBeInTheDocument()
+  })
+
+  it('shows loading spinner while entities are loading', () => {
+    mockUseTag.mockReturnValue({
+      data: makeTagDetail({ usage_count: 5 }),
+      isLoading: false,
+      error: null,
+    })
+    mockUseTagEntities.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    })
+
+    renderWithProviders(<TagDetail slug="rock" />)
+
+    // There should be a spinner in the entities section (separate from the main loading state)
+    const spinners = document.querySelectorAll('.animate-spin')
+    expect(spinners.length).toBeGreaterThanOrEqual(1)
   })
 })

--- a/frontend/features/tags/components/TagDetail.tsx
+++ b/frontend/features/tags/components/TagDetail.tsx
@@ -1,14 +1,16 @@
 'use client'
 
+import { useMemo } from 'react'
 import Link from 'next/link'
-import { ArrowLeft, Hash, Loader2 } from 'lucide-react'
+import { ArrowLeft, Hash, Loader2, Music, MapPin, Calendar, Disc3, Tag, Tent } from 'lucide-react'
 import { NotifyMeButton } from '@/features/notifications'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Breadcrumb } from '@/components/shared'
-import { useTag } from '../hooks'
-import { getCategoryColor, getCategoryLabel } from '../types'
+import { useTag, useTagEntities } from '../hooks'
+import { getCategoryColor, getCategoryLabel, getEntityUrl, getEntityTypePluralLabel } from '../types'
+import type { TaggedEntityItem } from '../types'
 
 interface TagDetailProps {
   slug: string
@@ -164,6 +166,94 @@ export function TagDetail({ slug }: TagDetailProps) {
           </div>
         </section>
       )}
+
+      {/* Tagged Entities */}
+      {tag.usage_count > 0 && (
+        <TaggedEntitiesSection slug={slug} />
+      )}
     </div>
+  )
+}
+
+// ──────────────────────────────────────────────
+// Tagged entities section
+// ──────────────────────────────────────────────
+
+const ENTITY_TYPE_ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
+  artist: Music,
+  venue: MapPin,
+  show: Calendar,
+  release: Disc3,
+  label: Tag,
+  festival: Tent,
+}
+
+/** Display order for entity type groups */
+const ENTITY_TYPE_ORDER = ['artist', 'venue', 'show', 'release', 'label', 'festival']
+
+function TaggedEntitiesSection({ slug }: { slug: string }) {
+  const { data, isLoading } = useTagEntities(slug, { limit: 200 })
+
+  const grouped = useMemo(() => {
+    if (!data?.entities) return {}
+    const groups: Record<string, TaggedEntityItem[]> = {}
+    for (const entity of data.entities) {
+      if (!groups[entity.entity_type]) {
+        groups[entity.entity_type] = []
+      }
+      groups[entity.entity_type].push(entity)
+    }
+    return groups
+  }, [data?.entities])
+
+  const sortedTypes = useMemo(() => {
+    return ENTITY_TYPE_ORDER.filter((t) => grouped[t]?.length)
+  }, [grouped])
+
+  if (isLoading) {
+    return (
+      <section className="mt-8 border-t border-border/50 pt-6">
+        <div className="flex items-center justify-center py-8">
+          <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+        </div>
+      </section>
+    )
+  }
+
+  if (sortedTypes.length === 0) {
+    return null
+  }
+
+  return (
+    <section className="mt-8 border-t border-border/50 pt-6">
+      <h2 className="text-lg font-semibold mb-4">Tagged Entities</h2>
+      <div className="space-y-6">
+        {sortedTypes.map((entityType) => {
+          const entities = grouped[entityType]
+          const Icon = ENTITY_TYPE_ICONS[entityType] || Hash
+          return (
+            <div key={entityType}>
+              <h3 className="flex items-center gap-2 text-sm font-medium text-muted-foreground mb-2">
+                <Icon className="h-4 w-4" />
+                {getEntityTypePluralLabel(entityType)}
+                <span className="text-xs">({entities.length})</span>
+              </h3>
+              <ul className="grid gap-1">
+                {entities.map((entity) => (
+                  <li key={`${entity.entity_type}-${entity.entity_id}`}>
+                    <Link
+                      href={getEntityUrl(entity.entity_type, entity.slug)}
+                      className="inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm hover:bg-muted/50 transition-colors"
+                    >
+                      {entity.name}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )
+        })}
+      </div>
+    </section>
   )
 }

--- a/frontend/features/tags/hooks/index.ts
+++ b/frontend/features/tags/hooks/index.ts
@@ -15,6 +15,7 @@ import type {
   TagSearchResponse,
   EntityTagsResponse,
   EntityTag,
+  TagEntitiesResponse,
 } from '../types'
 
 // ──────────────────────────────────────────────
@@ -92,6 +93,31 @@ export function useEntityTags(
       apiRequest<EntityTagsResponse>(API_ENDPOINTS.ENTITY_TAGS.LIST(entityType, entityId)),
     enabled: (options?.enabled ?? true) && entityId > 0,
     staleTime: 5 * 60 * 1000,
+  })
+}
+
+/** Fetch entities tagged with a given tag */
+export function useTagEntities(
+  idOrSlug: string | number,
+  params?: { entity_type?: string; limit?: number; offset?: number },
+  options?: { enabled?: boolean }
+) {
+  const searchParams = new URLSearchParams()
+  if (params?.entity_type) searchParams.set('entity_type', params.entity_type)
+  if (params?.limit) searchParams.set('limit', String(params.limit))
+  if (params?.offset) searchParams.set('offset', String(params.offset))
+
+  const queryString = searchParams.toString()
+  const url = queryString
+    ? `${API_ENDPOINTS.TAGS.ENTITIES(idOrSlug)}?${queryString}`
+    : API_ENDPOINTS.TAGS.ENTITIES(idOrSlug)
+
+  return useQuery({
+    queryKey: queryKeys.tags.tagEntities(idOrSlug, params as Record<string, unknown> | undefined),
+    queryFn: () => apiRequest<TagEntitiesResponse>(url),
+    enabled: options?.enabled ?? true,
+    staleTime: 5 * 60 * 1000,
+    placeholderData: keepPreviousData,
   })
 }
 

--- a/frontend/features/tags/index.ts
+++ b/frontend/features/tags/index.ts
@@ -12,6 +12,8 @@ export type {
   TagSearchResponse,
   EntityTagsResponse,
   TagAliasesResponse,
+  TaggedEntityItem,
+  TagEntitiesResponse,
 } from './types'
 
 export {
@@ -26,6 +28,7 @@ export {
   useSearchTags,
   useTag,
   useEntityTags,
+  useTagEntities,
   useAddTagToEntity,
   useRemoveTagFromEntity,
   useVoteOnTag,

--- a/frontend/features/tags/types.ts
+++ b/frontend/features/tags/types.ts
@@ -60,6 +60,18 @@ export interface EntityTagsResponse {
   tags: EntityTag[]
 }
 
+export interface TaggedEntityItem {
+  entity_type: string
+  entity_id: number
+  name: string
+  slug: string
+}
+
+export interface TagEntitiesResponse {
+  entities: TaggedEntityItem[]
+  total: number
+}
+
 export interface TagAliasesResponse {
   aliases: TagAlias[]
 }
@@ -75,4 +87,44 @@ export function getCategoryColor(category: string): string {
 
 export function getCategoryLabel(category: string): string {
   return category.charAt(0).toUpperCase() + category.slice(1)
+}
+
+/** Build entity URL from entity type and slug */
+export function getEntityUrl(entityType: string, entitySlug: string): string {
+  switch (entityType) {
+    case 'artist':
+      return `/artists/${entitySlug}`
+    case 'venue':
+      return `/venues/${entitySlug}`
+    case 'show':
+      return `/shows/${entitySlug}`
+    case 'release':
+      return `/releases/${entitySlug}`
+    case 'label':
+      return `/labels/${entitySlug}`
+    case 'festival':
+      return `/festivals/${entitySlug}`
+    default:
+      return '#'
+  }
+}
+
+/** Get a plural display label for an entity type */
+export function getEntityTypePluralLabel(entityType: string): string {
+  switch (entityType) {
+    case 'artist':
+      return 'Artists'
+    case 'venue':
+      return 'Venues'
+    case 'show':
+      return 'Shows'
+    case 'release':
+      return 'Releases'
+    case 'label':
+      return 'Labels'
+    case 'festival':
+      return 'Festivals'
+    default:
+      return entityType
+  }
 }

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -274,6 +274,7 @@ export const API_ENDPOINTS = {
     GET: (idOrSlug: string | number) => `${API_BASE_URL}/tags/${idOrSlug}`,
     ALIASES: (idOrSlug: string | number) => `${API_BASE_URL}/tags/${idOrSlug}/aliases`,
     DELETE_ALIAS: (tagId: number, aliasId: number) => `${API_BASE_URL}/tags/${tagId}/aliases/${aliasId}`,
+    ENTITIES: (idOrSlug: string | number) => `${API_BASE_URL}/tags/${idOrSlug}/entities`,
   },
 
   // Entity tag endpoints

--- a/frontend/lib/queryClient.ts
+++ b/frontend/lib/queryClient.ts
@@ -266,6 +266,7 @@ export const queryKeys = {
     detail: (idOrSlug: string | number) => ['tags', 'detail', String(idOrSlug)] as const,
     aliases: (tagId: number) => ['tags', 'aliases', tagId] as const,
     entityTags: (entityType: string, entityId: number) => ['tags', 'entityTags', entityType, entityId] as const,
+    tagEntities: (idOrSlug: string | number, params?: Record<string, unknown>) => ['tags', 'tagEntities', String(idOrSlug), params] as const,
   },
 
   // Attendance (going/interested) queries


### PR DESCRIPTION
## Summary

- Add `GET /tags/{tag_id}/entities` backend endpoint with entity type filter and pagination
- Service batch-resolves entity names/slugs across artists, venues, shows, releases, labels, festivals
- Frontend: `TaggedEntitiesSection` component groups entities by type with icons and clickable links
- Appears below tag metadata when usage_count > 0
- 3 new frontend tests, all existing backend tests pass

Closes PSY-260

## Test plan

- [ ] Navigate to `/tags/rock` — see list of tagged entities grouped by type
- [ ] Click an entity — navigates to its detail page
- [ ] Check a tag with 0 uses — no entities section shown
- [ ] Run `bun run test -- TagDetail` — 24 tests pass (21 existing + 3 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)