### PR TITLE
Add edit review notification emails (PSY-135)

### DIFF
--- a/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
+++ b/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
@@ -1017,6 +1017,8 @@ type mockEmailService struct {
 	sendTierPromotionEmailFn func(string, string, string, string, string, []string) (error)
 	sendTierDemotionEmailFn func(string, string, string, string, string) (error)
 	sendTierDemotionWarningEmailFn func(string, string, string, float64, float64) (error)
+	sendEditApprovedEmailFn func(string, string, string, string, string) (error)
+	sendEditRejectedEmailFn func(string, string, string, string, string) (error)
 }
 
 func (m *mockEmailService) IsConfigured() (bool) {
@@ -1070,6 +1072,18 @@ func (m *mockEmailService) SendTierDemotionEmail(toEmail string, username string
 func (m *mockEmailService) SendTierDemotionWarningEmail(toEmail string, username string, currentTier string, currentRate float64, threshold float64) (error) {
 	if m.sendTierDemotionWarningEmailFn != nil {
 		return m.sendTierDemotionWarningEmailFn(toEmail, username, currentTier, currentRate, threshold)
+	}
+	return nil
+}
+func (m *mockEmailService) SendEditApprovedEmail(toEmail string, username string, entityType string, entityName string, entityURL string) (error) {
+	if m.sendEditApprovedEmailFn != nil {
+		return m.sendEditApprovedEmailFn(toEmail, username, entityType, entityName, entityURL)
+	}
+	return nil
+}
+func (m *mockEmailService) SendEditRejectedEmail(toEmail string, username string, entityType string, entityName string, rejectionReason string) (error) {
+	if m.sendEditRejectedEmailFn != nil {
+		return m.sendEditRejectedEmailFn(toEmail, username, entityType, entityName, rejectionReason)
 	}
 	return nil
 }

--- a/backend/internal/services/admin/auto_promotion_email_test.go
+++ b/backend/internal/services/admin/auto_promotion_email_test.go
@@ -72,6 +72,9 @@ func (m *mockEmailService) SendTierDemotionWarningEmail(toEmail, username, curre
 	return m.demotionWarningError
 }
 
+func (m *mockEmailService) SendEditApprovedEmail(_, _, _, _, _ string) error { return nil }
+func (m *mockEmailService) SendEditRejectedEmail(_, _, _, _, _ string) error { return nil }
+
 // =============================================================================
 // INTEGRATION TESTS — EMAIL NOTIFICATIONS
 // =============================================================================

--- a/backend/internal/services/admin/pending_edit.go
+++ b/backend/internal/services/admin/pending_edit.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"time"
 
 	"gorm.io/gorm"
@@ -16,14 +17,21 @@ import (
 type PendingEditService struct {
 	db              *gorm.DB
 	revisionService contracts.RevisionServiceInterface
+	emailService    contracts.EmailServiceInterface
+	frontendURL     string
 }
 
 // NewPendingEditService creates a new PendingEditService.
-func NewPendingEditService(database *gorm.DB, revisionService contracts.RevisionServiceInterface) *PendingEditService {
+func NewPendingEditService(database *gorm.DB, revisionService contracts.RevisionServiceInterface, emailService contracts.EmailServiceInterface, frontendURL string) *PendingEditService {
 	if database == nil {
 		database = db.GetDB()
 	}
-	return &PendingEditService{db: database, revisionService: revisionService}
+	return &PendingEditService{
+		db:              database,
+		revisionService: revisionService,
+		emailService:    emailService,
+		frontendURL:     frontendURL,
+	}
 }
 
 // CreatePendingEdit submits a new pending edit for an entity.
@@ -253,6 +261,9 @@ func (s *PendingEditService) ApprovePendingEdit(editID uint, reviewerID uint) (*
 		_ = s.revisionService.RecordRevision(edit.EntityType, edit.EntityID, edit.SubmittedBy, changes, edit.Summary)
 	}
 
+	// Send approval notification email (fire-and-forget)
+	s.sendApprovalEmail(&edit)
+
 	return s.GetPendingEdit(editID)
 }
 
@@ -288,6 +299,9 @@ func (s *PendingEditService) RejectPendingEdit(editID uint, reviewerID uint, rea
 	}).Error; err != nil {
 		return nil, fmt.Errorf("failed to reject pending edit: %w", err)
 	}
+
+	// Send rejection notification email (fire-and-forget)
+	s.sendRejectionEmail(&edit, reason)
 
 	return s.GetPendingEdit(editID)
 }
@@ -379,4 +393,98 @@ func displayName(u *models.User) string {
 		return *u.Email
 	}
 	return ""
+}
+
+// sendApprovalEmail looks up the submitter and entity, then sends an approval notification.
+// Fire-and-forget: errors are logged but never fail the parent operation.
+func (s *PendingEditService) sendApprovalEmail(edit *models.PendingEntityEdit) {
+	if s.emailService == nil || !s.emailService.IsConfigured() {
+		return
+	}
+
+	// Look up submitter
+	var user models.User
+	if err := s.db.First(&user, edit.SubmittedBy).Error; err != nil {
+		log.Printf("sendApprovalEmail: failed to look up submitter %d: %v", edit.SubmittedBy, err)
+		return
+	}
+	if user.Email == nil || *user.Email == "" {
+		return
+	}
+
+	entityName, entityURL := s.resolveEntityInfo(edit.EntityType, edit.EntityID)
+	username := displayName(&user)
+
+	if err := s.emailService.SendEditApprovedEmail(*user.Email, username, edit.EntityType, entityName, entityURL); err != nil {
+		log.Printf("sendApprovalEmail: failed to send email to %s: %v", *user.Email, err)
+	}
+}
+
+// sendRejectionEmail looks up the submitter and entity, then sends a rejection notification.
+// Fire-and-forget: errors are logged but never fail the parent operation.
+func (s *PendingEditService) sendRejectionEmail(edit *models.PendingEntityEdit, reason string) {
+	if s.emailService == nil || !s.emailService.IsConfigured() {
+		return
+	}
+
+	// Look up submitter
+	var user models.User
+	if err := s.db.First(&user, edit.SubmittedBy).Error; err != nil {
+		log.Printf("sendRejectionEmail: failed to look up submitter %d: %v", edit.SubmittedBy, err)
+		return
+	}
+	if user.Email == nil || *user.Email == "" {
+		return
+	}
+
+	entityName, _ := s.resolveEntityInfo(edit.EntityType, edit.EntityID)
+	username := displayName(&user)
+
+	if err := s.emailService.SendEditRejectedEmail(*user.Email, username, edit.EntityType, entityName, reason); err != nil {
+		log.Printf("sendRejectionEmail: failed to send email to %s: %v", *user.Email, err)
+	}
+}
+
+// resolveEntityInfo looks up an entity's name and builds its frontend URL.
+func (s *PendingEditService) resolveEntityInfo(entityType string, entityID uint) (name string, url string) {
+	name = fmt.Sprintf("%s #%d", entityType, entityID)
+	url = s.frontendURL
+
+	switch entityType {
+	case "artist":
+		var artist struct {
+			Name string
+			Slug *string
+		}
+		if err := s.db.Table("artists").Select("name, slug").Where("id = ?", entityID).Scan(&artist).Error; err == nil {
+			name = artist.Name
+			if artist.Slug != nil && *artist.Slug != "" {
+				url = fmt.Sprintf("%s/artists/%s", s.frontendURL, *artist.Slug)
+			}
+		}
+	case "venue":
+		var venue struct {
+			Name string
+			Slug *string
+		}
+		if err := s.db.Table("venues").Select("name, slug").Where("id = ?", entityID).Scan(&venue).Error; err == nil {
+			name = venue.Name
+			if venue.Slug != nil && *venue.Slug != "" {
+				url = fmt.Sprintf("%s/venues/%s", s.frontendURL, *venue.Slug)
+			}
+		}
+	case "festival":
+		var festival struct {
+			Name string
+			Slug string
+		}
+		if err := s.db.Table("festivals").Select("name, slug").Where("id = ?", entityID).Scan(&festival).Error; err == nil {
+			name = festival.Name
+			if festival.Slug != "" {
+				url = fmt.Sprintf("%s/festivals/%s", s.frontendURL, festival.Slug)
+			}
+		}
+	}
+
+	return name, url
 }

--- a/backend/internal/services/admin/pending_edit_test.go
+++ b/backend/internal/services/admin/pending_edit_test.go
@@ -32,19 +32,82 @@ func TestIsValidPendingEditEntityType(t *testing.T) {
 // INTEGRATION TESTS (With Real Database)
 // =============================================================================
 
+// mockEmailServiceForPendingEdit implements contracts.EmailServiceInterface for testing.
+type mockEmailServiceForPendingEdit struct {
+	configured             bool
+	editApprovedCalls      []editApprovedCall
+	editRejectedCalls      []editRejectedCall
+	editApprovedErr        error
+	editRejectedErr        error
+}
+
+type editApprovedCall struct {
+	ToEmail    string
+	Username   string
+	EntityType string
+	EntityName string
+	EntityURL  string
+}
+
+type editRejectedCall struct {
+	ToEmail         string
+	Username        string
+	EntityType      string
+	EntityName      string
+	RejectionReason string
+}
+
+func (m *mockEmailServiceForPendingEdit) IsConfigured() bool { return m.configured }
+func (m *mockEmailServiceForPendingEdit) SendVerificationEmail(_, _ string) error { return nil }
+func (m *mockEmailServiceForPendingEdit) SendMagicLinkEmail(_, _ string) error { return nil }
+func (m *mockEmailServiceForPendingEdit) SendAccountRecoveryEmail(_, _ string, _ int) error {
+	return nil
+}
+func (m *mockEmailServiceForPendingEdit) SendShowReminderEmail(_, _, _, _ string, _ time.Time, _ []string) error {
+	return nil
+}
+func (m *mockEmailServiceForPendingEdit) SendFilterNotificationEmail(_, _, _, _ string) error {
+	return nil
+}
+func (m *mockEmailServiceForPendingEdit) SendTierPromotionEmail(_, _, _, _, _ string, _ []string) error {
+	return nil
+}
+func (m *mockEmailServiceForPendingEdit) SendTierDemotionEmail(_, _, _, _, _ string) error {
+	return nil
+}
+func (m *mockEmailServiceForPendingEdit) SendTierDemotionWarningEmail(_, _, _ string, _, _ float64) error {
+	return nil
+}
+func (m *mockEmailServiceForPendingEdit) SendEditApprovedEmail(toEmail, username, entityType, entityName, entityURL string) error {
+	m.editApprovedCalls = append(m.editApprovedCalls, editApprovedCall{
+		ToEmail: toEmail, Username: username, EntityType: entityType,
+		EntityName: entityName, EntityURL: entityURL,
+	})
+	return m.editApprovedErr
+}
+func (m *mockEmailServiceForPendingEdit) SendEditRejectedEmail(toEmail, username, entityType, entityName, rejectionReason string) error {
+	m.editRejectedCalls = append(m.editRejectedCalls, editRejectedCall{
+		ToEmail: toEmail, Username: username, EntityType: entityType,
+		EntityName: entityName, RejectionReason: rejectionReason,
+	})
+	return m.editRejectedErr
+}
+
 type PendingEditServiceIntegrationTestSuite struct {
 	suite.Suite
-	testDB     *testutil.TestDatabase
-	db         *gorm.DB
-	svc        *PendingEditService
-	revisionSvc *RevisionService
+	testDB       *testutil.TestDatabase
+	db           *gorm.DB
+	svc          *PendingEditService
+	revisionSvc  *RevisionService
+	mockEmail    *mockEmailServiceForPendingEdit
 }
 
 func (s *PendingEditServiceIntegrationTestSuite) SetupSuite() {
 	s.testDB = testutil.SetupTestPostgres(s.T())
 	s.db = s.testDB.DB
 	s.revisionSvc = NewRevisionService(s.db)
-	s.svc = NewPendingEditService(s.db, s.revisionSvc)
+	s.mockEmail = &mockEmailServiceForPendingEdit{configured: true}
+	s.svc = NewPendingEditService(s.db, s.revisionSvc, s.mockEmail, "http://localhost:3000")
 }
 
 func (s *PendingEditServiceIntegrationTestSuite) TearDownSuite() {
@@ -60,6 +123,11 @@ func (s *PendingEditServiceIntegrationTestSuite) TearDownTest() {
 	_, _ = sqlDB.Exec("DELETE FROM venues")
 	_, _ = sqlDB.Exec("DELETE FROM festivals")
 	_, _ = sqlDB.Exec("DELETE FROM users")
+	// Reset mock email state between tests
+	s.mockEmail.editApprovedCalls = nil
+	s.mockEmail.editRejectedCalls = nil
+	s.mockEmail.editApprovedErr = nil
+	s.mockEmail.editRejectedErr = nil
 }
 
 func TestPendingEditServiceIntegrationSuite(t *testing.T) {
@@ -827,4 +895,163 @@ func TestDisplayName(t *testing.T) {
 		u := &models.User{}
 		assert.Equal(t, "", displayName(u))
 	})
+}
+
+// =============================================================================
+// Email notification tests
+// =============================================================================
+
+func (s *PendingEditServiceIntegrationTestSuite) TestApprovePendingEdit_SendsApprovalEmail() {
+	user := s.createTestUser()
+	reviewer := s.createTestUser()
+	artist := s.createTestArtist("Cool Band")
+
+	created, err := s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "artist", EntityID: artist.ID, UserID: user.ID,
+		Changes: makeChanges("name", "Cool Band", "The Cool Band"), Summary: "Add 'The'",
+	})
+	s.Require().NoError(err)
+
+	_, err = s.svc.ApprovePendingEdit(created.ID, reviewer.ID)
+	s.NoError(err)
+
+	// Verify approval email was sent
+	s.Require().Len(s.mockEmail.editApprovedCalls, 1)
+	call := s.mockEmail.editApprovedCalls[0]
+	s.Equal(*user.Email, call.ToEmail)
+	s.Equal("artist", call.EntityType)
+	s.Equal("The Cool Band", call.EntityName) // Entity was updated, so name should reflect the update
+	s.Contains(call.EntityURL, "/artists/")
+	s.Contains(call.EntityURL, "http://localhost:3000")
+}
+
+func (s *PendingEditServiceIntegrationTestSuite) TestApprovePendingEdit_EmailErrorDoesNotFail() {
+	user := s.createTestUser()
+	reviewer := s.createTestUser()
+	artist := s.createTestArtist("Test Band")
+
+	created, err := s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "artist", EntityID: artist.ID, UserID: user.ID,
+		Changes: makeChanges("name", "Test Band", "Better Name"), Summary: "improve name",
+	})
+	s.Require().NoError(err)
+
+	// Make email service return an error
+	s.mockEmail.editApprovedErr = fmt.Errorf("email API is down")
+
+	// Approval should still succeed despite email error
+	resp, err := s.svc.ApprovePendingEdit(created.ID, reviewer.ID)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal(models.PendingEditStatusApproved, resp.Status)
+	s.Len(s.mockEmail.editApprovedCalls, 1) // Email was attempted
+}
+
+func (s *PendingEditServiceIntegrationTestSuite) TestRejectPendingEdit_SendsRejectionEmail() {
+	user := s.createTestUser()
+	reviewer := s.createTestUser()
+	venue := s.createTestVenue("Great Venue")
+
+	created, err := s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "venue", EntityID: venue.ID, UserID: user.ID,
+		Changes: makeChanges("name", "Great Venue", "Bad Name"), Summary: "rename",
+	})
+	s.Require().NoError(err)
+
+	_, err = s.svc.RejectPendingEdit(created.ID, reviewer.ID, "Name does not match official venue name")
+	s.NoError(err)
+
+	// Verify rejection email was sent
+	s.Require().Len(s.mockEmail.editRejectedCalls, 1)
+	call := s.mockEmail.editRejectedCalls[0]
+	s.Equal(*user.Email, call.ToEmail)
+	s.Equal("venue", call.EntityType)
+	s.Equal("Great Venue", call.EntityName) // Entity was NOT updated on rejection
+	s.Equal("Name does not match official venue name", call.RejectionReason)
+}
+
+func (s *PendingEditServiceIntegrationTestSuite) TestRejectPendingEdit_EmailErrorDoesNotFail() {
+	user := s.createTestUser()
+	reviewer := s.createTestUser()
+	artist := s.createTestArtist("Test Artist")
+
+	created, err := s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "artist", EntityID: artist.ID, UserID: user.ID,
+		Changes: makeChanges("name", "Test Artist", "Wrong"), Summary: "bad edit",
+	})
+	s.Require().NoError(err)
+
+	// Make email service return an error
+	s.mockEmail.editRejectedErr = fmt.Errorf("email API is down")
+
+	// Rejection should still succeed despite email error
+	resp, err := s.svc.RejectPendingEdit(created.ID, reviewer.ID, "incorrect info")
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal(models.PendingEditStatusRejected, resp.Status)
+	s.Len(s.mockEmail.editRejectedCalls, 1) // Email was attempted
+}
+
+func (s *PendingEditServiceIntegrationTestSuite) TestApprovePendingEdit_VenueEmailHasCorrectURL() {
+	user := s.createTestUser()
+	reviewer := s.createTestUser()
+	venue := s.createTestVenue("The Rebel Lounge")
+
+	created, err := s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "venue", EntityID: venue.ID, UserID: user.ID,
+		Changes: makeChanges("city", "Phoenix", "Tempe"), Summary: "fix city",
+	})
+	s.Require().NoError(err)
+
+	_, err = s.svc.ApprovePendingEdit(created.ID, reviewer.ID)
+	s.NoError(err)
+
+	s.Require().Len(s.mockEmail.editApprovedCalls, 1)
+	call := s.mockEmail.editApprovedCalls[0]
+	s.Contains(call.EntityURL, "/venues/")
+}
+
+func (s *PendingEditServiceIntegrationTestSuite) TestApprovePendingEdit_FestivalEmailHasCorrectURL() {
+	user := s.createTestUser()
+	reviewer := s.createTestUser()
+	festival := s.createTestFestival("Fest 2026")
+
+	created, err := s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "festival", EntityID: festival.ID, UserID: user.ID,
+		Changes: makeChanges("description", "", "Great festival"), Summary: "add desc",
+	})
+	s.Require().NoError(err)
+
+	_, err = s.svc.ApprovePendingEdit(created.ID, reviewer.ID)
+	s.NoError(err)
+
+	s.Require().Len(s.mockEmail.editApprovedCalls, 1)
+	call := s.mockEmail.editApprovedCalls[0]
+	s.Contains(call.EntityURL, "/festivals/")
+}
+
+// =============================================================================
+// Nil email service tests (unit tests, no DB)
+// =============================================================================
+
+func TestPendingEditService_NilEmailServiceDoesNotPanic(t *testing.T) {
+	// Constructor with nil email service should work fine
+	svc := NewPendingEditService(nil, nil, nil, "")
+	assert.NotNil(t, svc)
+
+	// sendApprovalEmail and sendRejectionEmail should not panic with nil email service
+	svc.sendApprovalEmail(&models.PendingEntityEdit{SubmittedBy: 1, EntityType: "artist", EntityID: 1})
+	svc.sendRejectionEmail(&models.PendingEntityEdit{SubmittedBy: 1, EntityType: "artist", EntityID: 1}, "reason")
+}
+
+func TestPendingEditService_UnconfiguredEmailServiceDoesNotPanic(t *testing.T) {
+	mockEmail := &mockEmailServiceForPendingEdit{configured: false}
+	svc := NewPendingEditService(nil, nil, mockEmail, "http://localhost:3000")
+
+	// Should return early without attempting to send
+	svc.sendApprovalEmail(&models.PendingEntityEdit{SubmittedBy: 1, EntityType: "artist", EntityID: 1})
+	svc.sendRejectionEmail(&models.PendingEntityEdit{SubmittedBy: 1, EntityType: "artist", EntityID: 1}, "reason")
+
+	assert.Len(t, mockEmail.editApprovedCalls, 0)
+	assert.Len(t, mockEmail.editRejectedCalls, 0)
 }

--- a/backend/internal/services/container.go
+++ b/backend/internal/services/container.go
@@ -132,7 +132,7 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 		APIToken:           adminsvc.NewAPITokenService(database),
 		DataQuality:        adminsvc.NewDataQualityService(database),
 		Revision:           revisionSvc,
-		PendingEdit:        adminsvc.NewPendingEditService(database, revisionSvc),
+		PendingEdit:        adminsvc.NewPendingEditService(database, revisionSvc, email, cfg.Email.FrontendURL),
 		Charts:             catalog.NewChartsService(database),
 		Artist:             artist,
 		ContributorProfile: usersvc.NewContributorProfileService(database),

--- a/backend/internal/services/contracts/interfaces.go
+++ b/backend/internal/services/contracts/interfaces.go
@@ -246,6 +246,8 @@ type EmailServiceInterface interface {
 	SendTierPromotionEmail(toEmail, username, oldTier, newTier, reason string, newPermissions []string) error
 	SendTierDemotionEmail(toEmail, username, oldTier, newTier, reason string) error
 	SendTierDemotionWarningEmail(toEmail, username, currentTier string, currentRate float64, threshold float64) error
+	SendEditApprovedEmail(toEmail, username, entityType, entityName, entityURL string) error
+	SendEditRejectedEmail(toEmail, username, entityType, entityName, rejectionReason string) error
 }
 
 // ReminderServiceInterface defines the contract for the show reminder background service.

--- a/backend/internal/services/engagement/reminder_test.go
+++ b/backend/internal/services/engagement/reminder_test.go
@@ -189,6 +189,8 @@ func (m *mockReminderEmailService) SendTierDemotionEmail(_, _, _, _, _ string) e
 func (m *mockReminderEmailService) SendTierDemotionWarningEmail(_, _, _ string, _, _ float64) error {
 	return nil
 }
+func (m *mockReminderEmailService) SendEditApprovedEmail(_, _, _, _, _ string) error { return nil }
+func (m *mockReminderEmailService) SendEditRejectedEmail(_, _, _, _, _ string) error { return nil }
 
 // ReminderServiceIntegrationTestSuite tests the reminder service with a real database
 type ReminderServiceIntegrationTestSuite struct {

--- a/backend/internal/services/notification/email.go
+++ b/backend/internal/services/notification/email.go
@@ -556,3 +556,129 @@ func (s *EmailService) SendTierDemotionWarningEmail(toEmail, username, currentTi
 
 	return nil
 }
+
+// SendEditApprovedEmail sends a notification when a user's pending edit is approved.
+func (s *EmailService) SendEditApprovedEmail(toEmail, username, entityType, entityName, entityURL string) error {
+	if !s.IsConfigured() {
+		return fmt.Errorf("email service is not configured")
+	}
+
+	greeting := "there"
+	if username != "" {
+		greeting = username
+	}
+
+	// Capitalize first letter for CTA button text (e.g. "artist" -> "Artist")
+	entityTypeTitle := strings.ToUpper(entityType[:1]) + entityType[1:]
+
+	html := fmt.Sprintf(`
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+    <div style="text-align: center; margin-bottom: 30px;">
+        <h1 style="color: #1a1a1a; margin: 0;">Psychic Homily</h1>
+    </div>
+
+    <div style="background: #f0fdf4; border-radius: 8px; padding: 30px; margin-bottom: 20px; border: 1px solid #bbf7d0;">
+        <h2 style="margin-top: 0; color: #166534;">Your edit was approved!</h2>
+        <p>Hi %s,</p>
+        <p>Your edit to the %s <strong>%s</strong> has been reviewed and approved. Your changes are now live!</p>
+        <p style="text-align: center; margin: 30px 0;">
+            <a href="%s" style="display: inline-block; background: #16a34a; color: white; text-decoration: none; padding: 12px 30px; border-radius: 6px; font-weight: 600;">View %s</a>
+        </p>
+        <p style="font-size: 14px; color: #444;">Thank you for improving the Psychic Homily database. Every contribution helps the community discover great music.</p>
+    </div>
+
+    <div style="text-align: center; font-size: 12px; color: #999;">
+        <p>Keep contributing to build your reputation and unlock new permissions.</p>
+    </div>
+</body>
+</html>
+`, greeting, entityType, entityName, entityURL, entityTypeTitle)
+
+	params := &resend.SendEmailRequest{
+		From:    fmt.Sprintf("Psychic Homily <%s>", s.fromEmail),
+		To:      []string{toEmail},
+		Subject: fmt.Sprintf("Your edit to %s was approved!", entityName),
+		Html:    html,
+	}
+
+	_, err := s.client.Emails.Send(params)
+	if err != nil {
+		sentry.WithScope(func(scope *sentry.Scope) {
+			scope.SetTag("service", "email")
+			scope.SetTag("email_type", "edit_approved")
+			sentry.CaptureException(err)
+		})
+		return fmt.Errorf("failed to send edit approved email: %w", err)
+	}
+
+	return nil
+}
+
+// SendEditRejectedEmail sends a notification when a user's pending edit is rejected.
+func (s *EmailService) SendEditRejectedEmail(toEmail, username, entityType, entityName, rejectionReason string) error {
+	if !s.IsConfigured() {
+		return fmt.Errorf("email service is not configured")
+	}
+
+	greeting := "there"
+	if username != "" {
+		greeting = username
+	}
+
+	html := fmt.Sprintf(`
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+    <div style="text-align: center; margin-bottom: 30px;">
+        <h1 style="color: #1a1a1a; margin: 0;">Psychic Homily</h1>
+    </div>
+
+    <div style="background: #f9f9f9; border-radius: 8px; padding: 30px; margin-bottom: 20px; border: 1px solid #e5e7eb;">
+        <h2 style="margin-top: 0; color: #1a1a1a;">Update on your edit to %s</h2>
+        <p>Hi %s,</p>
+        <p>Your edit to the %s <strong>%s</strong> was not accepted this time.</p>
+        <p style="background: #fef3c7; border-radius: 6px; padding: 12px 16px; color: #92400e;"><strong>Reason:</strong> %s</p>
+        <h3 style="color: #1a1a1a; margin-bottom: 8px;">Tips for future edits:</h3>
+        <ul style="padding-left: 20px; color: #444;">
+            <li style="margin-bottom: 4px;">Double-check facts against official sources (venue websites, artist pages)</li>
+            <li style="margin-bottom: 4px;">Include a clear summary explaining why you are making the change</li>
+            <li style="margin-bottom: 4px;">Ensure spelling and formatting are accurate</li>
+        </ul>
+    </div>
+
+    <div style="text-align: center; font-size: 12px; color: #999;">
+        <p>Don't be discouraged — your contributions are valued. Feel free to submit a revised edit.</p>
+    </div>
+</body>
+</html>
+`, entityName, greeting, entityType, entityName, rejectionReason)
+
+	params := &resend.SendEmailRequest{
+		From:    fmt.Sprintf("Psychic Homily <%s>", s.fromEmail),
+		To:      []string{toEmail},
+		Subject: fmt.Sprintf("Update on your edit to %s", entityName),
+		Html:    html,
+	}
+
+	_, err := s.client.Emails.Send(params)
+	if err != nil {
+		sentry.WithScope(func(scope *sentry.Scope) {
+			scope.SetTag("service", "email")
+			scope.SetTag("email_type", "edit_rejected")
+			sentry.CaptureException(err)
+		})
+		return fmt.Errorf("failed to send edit rejected email: %w", err)
+	}
+
+	return nil
+}

--- a/backend/internal/services/notification/email_edit_test.go
+++ b/backend/internal/services/notification/email_edit_test.go
@@ -1,0 +1,158 @@
+package notification
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// SendEditApprovedEmail
+// =============================================================================
+
+func TestSendEditApprovedEmail_Success(t *testing.T) {
+	svc, emails, _ := setupEmailTest(t)
+
+	err := svc.SendEditApprovedEmail(
+		"user@test.com",
+		"cooluser",
+		"artist",
+		"The Cool Band",
+		"http://localhost:3000/artists/the-cool-band",
+	)
+
+	require.NoError(t, err)
+	email := <-emails
+	assert.Contains(t, email.From, "noreply@test.com")
+	assert.Equal(t, []string{"user@test.com"}, email.To)
+	assert.Contains(t, email.Subject, "The Cool Band")
+	assert.Contains(t, email.Subject, "approved")
+	assert.Contains(t, email.Html, "cooluser")
+	assert.Contains(t, email.Html, "The Cool Band")
+	assert.Contains(t, email.Html, "http://localhost:3000/artists/the-cool-band")
+	assert.Contains(t, email.Html, "artist")
+	assert.Contains(t, email.Html, "approved")
+}
+
+func TestSendEditApprovedEmail_NotConfigured(t *testing.T) {
+	svc := &EmailService{client: nil, fromEmail: ""}
+
+	err := svc.SendEditApprovedEmail("user@test.com", "user", "artist", "Band", "http://example.com")
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not configured")
+}
+
+func TestSendEditApprovedEmail_APIError(t *testing.T) {
+	svc := setupEmailTestError(t)
+
+	err := svc.SendEditApprovedEmail("user@test.com", "user", "artist", "Band", "http://example.com")
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to send edit approved email")
+}
+
+func TestSendEditApprovedEmail_EmptyUsername(t *testing.T) {
+	svc, emails, _ := setupEmailTest(t)
+
+	err := svc.SendEditApprovedEmail("user@test.com", "", "venue", "Valley Bar", "http://localhost:3000/venues/valley-bar")
+
+	require.NoError(t, err)
+	email := <-emails
+	// Should use "there" as greeting when username is empty
+	assert.Contains(t, email.Html, "Hi there")
+}
+
+func TestSendEditApprovedEmail_VenueEntity(t *testing.T) {
+	svc, emails, _ := setupEmailTest(t)
+
+	err := svc.SendEditApprovedEmail("user@test.com", "admin", "venue", "Crescent Ballroom", "http://localhost:3000/venues/crescent-ballroom")
+
+	require.NoError(t, err)
+	email := <-emails
+	assert.Contains(t, email.Subject, "Crescent Ballroom")
+	assert.Contains(t, email.Html, "venue")
+	assert.Contains(t, email.Html, "Crescent Ballroom")
+	assert.Contains(t, email.Html, "View Venue")
+}
+
+func TestSendEditApprovedEmail_FestivalEntity(t *testing.T) {
+	svc, emails, _ := setupEmailTest(t)
+
+	err := svc.SendEditApprovedEmail("user@test.com", "testuser", "festival", "M3F Fest 2026", "http://localhost:3000/festivals/m3f-fest-2026")
+
+	require.NoError(t, err)
+	email := <-emails
+	assert.Contains(t, email.Html, "festival")
+	assert.Contains(t, email.Html, "M3F Fest 2026")
+	assert.Contains(t, email.Html, "View Festival")
+}
+
+// =============================================================================
+// SendEditRejectedEmail
+// =============================================================================
+
+func TestSendEditRejectedEmail_Success(t *testing.T) {
+	svc, emails, _ := setupEmailTest(t)
+
+	err := svc.SendEditRejectedEmail(
+		"user@test.com",
+		"testuser",
+		"artist",
+		"Some Artist",
+		"The name does not match the artist's official spelling",
+	)
+
+	require.NoError(t, err)
+	email := <-emails
+	assert.Contains(t, email.From, "noreply@test.com")
+	assert.Equal(t, []string{"user@test.com"}, email.To)
+	assert.Contains(t, email.Subject, "Some Artist")
+	assert.Contains(t, email.Subject, "Update on your edit")
+	assert.Contains(t, email.Html, "testuser")
+	assert.Contains(t, email.Html, "Some Artist")
+	assert.Contains(t, email.Html, "not accepted")
+	assert.Contains(t, email.Html, "The name does not match the artist's official spelling")
+	assert.Contains(t, email.Html, "Tips for future edits")
+}
+
+func TestSendEditRejectedEmail_NotConfigured(t *testing.T) {
+	svc := &EmailService{client: nil, fromEmail: ""}
+
+	err := svc.SendEditRejectedEmail("user@test.com", "user", "artist", "Band", "reason")
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not configured")
+}
+
+func TestSendEditRejectedEmail_APIError(t *testing.T) {
+	svc := setupEmailTestError(t)
+
+	err := svc.SendEditRejectedEmail("user@test.com", "user", "artist", "Band", "reason")
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to send edit rejected email")
+}
+
+func TestSendEditRejectedEmail_EmptyUsername(t *testing.T) {
+	svc, emails, _ := setupEmailTest(t)
+
+	err := svc.SendEditRejectedEmail("user@test.com", "", "venue", "Valley Bar", "incorrect info")
+
+	require.NoError(t, err)
+	email := <-emails
+	// Should use "there" as greeting when username is empty
+	assert.Contains(t, email.Html, "Hi there")
+}
+
+func TestSendEditRejectedEmail_ContainsEncouragement(t *testing.T) {
+	svc, emails, _ := setupEmailTest(t)
+
+	err := svc.SendEditRejectedEmail("user@test.com", "testuser", "artist", "Band", "wrong info")
+
+	require.NoError(t, err)
+	email := <-emails
+	assert.Contains(t, email.Html, "discouraged")
+	assert.Contains(t, email.Html, "contributions are valued")
+}

--- a/backend/internal/services/notification/filter_service_test.go
+++ b/backend/internal/services/notification/filter_service_test.go
@@ -769,3 +769,5 @@ func (m *mockEmailService) SendTierDemotionEmail(_, _, _, _, _ string) error { r
 func (m *mockEmailService) SendTierDemotionWarningEmail(_, _, _ string, _, _ float64) error {
 	return nil
 }
+func (m *mockEmailService) SendEditApprovedEmail(_, _, _, _, _ string) error { return nil }
+func (m *mockEmailService) SendEditRejectedEmail(_, _, _, _, _ string) error { return nil }


### PR DESCRIPTION
## Summary
- `SendEditApprovedEmail` and `SendEditRejectedEmail` on EmailService with styled HTML templates
- Wired into PendingEditService: fire-and-forget emails sent on approve/reject
- Entity URL resolution (artist/venue/festival slug lookup) for email links
- 19 new tests (11 email template + 8 notification integration)

## Test plan
- [ ] Backend builds cleanly
- [ ] Pending edit tests pass (42 total)
- [ ] Email edit tests pass (11 total)
- [ ] Fire-and-forget: email failures don't block approval/rejection

Closes PSY-135

🤖 Generated with [Claude Code](https://claude.com/claude-code)