### PR TITLE
Add activity heatmap to user profiles (PSY-198)

### DIFF
--- a/backend/internal/api/handlers/contributor_profile.go
+++ b/backend/internal/api/handlers/contributor_profile.go
@@ -141,6 +141,14 @@ type UpdateSectionResponse struct {
 	Body *contracts.ProfileSectionResponse
 }
 
+type GetActivityHeatmapRequest struct {
+	Username string `path:"username" doc:"Username of the contributor"`
+}
+
+type GetActivityHeatmapResponse struct {
+	Body *contracts.ActivityHeatmapResponse
+}
+
 type DeleteSectionRequest struct {
 	SectionID string `path:"section_id" doc:"Section ID to delete"`
 }
@@ -588,6 +596,62 @@ func (h *ContributorProfileHandler) UpdateSectionHandler(ctx context.Context, re
 	)
 
 	return &UpdateSectionResponse{Body: section}, nil
+}
+
+// GetActivityHeatmapHandler handles GET /users/{username}/activity-heatmap.
+func (h *ContributorProfileHandler) GetActivityHeatmapHandler(ctx context.Context, req *GetActivityHeatmapRequest) (*GetActivityHeatmapResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	targetUser, err := h.userService.GetUserByUsername(req.Username)
+	if err != nil {
+		logger.FromContext(ctx).Error("get_activity_heatmap_user_lookup_failed",
+			"username", req.Username,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to look up user (request_id: %s)", requestID),
+		)
+	}
+	if targetUser == nil {
+		return nil, huma.Error404NotFound("User not found")
+	}
+
+	viewer := middleware.GetUserFromContext(ctx)
+	isOwner := viewer != nil && viewer.ID == targetUser.ID
+
+	// Master privacy check
+	if targetUser.ProfileVisibility == "private" && !isOwner {
+		return nil, huma.Error404NotFound("User not found")
+	}
+
+	// Granular privacy check for contributions
+	if !isOwner {
+		privacy := contracts.DefaultPrivacySettings()
+		if targetUser.PrivacySettings != nil {
+			_ = json.Unmarshal(*targetUser.PrivacySettings, &privacy)
+		}
+
+		if privacy.Contributions == contracts.PrivacyHidden {
+			return &GetActivityHeatmapResponse{
+				Body: &contracts.ActivityHeatmapResponse{Days: []contracts.ActivityDay{}},
+			}, nil
+		}
+	}
+
+	heatmap, err := h.profileService.GetActivityHeatmap(targetUser.ID)
+	if err != nil {
+		logger.FromContext(ctx).Error("get_activity_heatmap_failed",
+			"user_id", targetUser.ID,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to get activity heatmap (request_id: %s)", requestID),
+		)
+	}
+
+	return &GetActivityHeatmapResponse{Body: heatmap}, nil
 }
 
 // DeleteSectionHandler handles DELETE /auth/profile/sections/{section_id}.

--- a/backend/internal/api/handlers/contributor_profile_integration_test.go
+++ b/backend/internal/api/handlers/contributor_profile_integration_test.go
@@ -853,3 +853,98 @@ func (s *ContributorProfileHandlerIntegrationSuite) TestGetUserSections_PrivacyS
 	s.NotNil(resp)
 	s.Empty(resp.Body.Sections, "sections should be empty when privacy is hidden")
 }
+
+// =============================================================================
+// GetActivityHeatmapHandler
+// =============================================================================
+
+func (s *ContributorProfileHandlerIntegrationSuite) TestGetActivityHeatmap_Success() {
+	user := s.createUserWithUsername("heatmapuser")
+	createApprovedShow(s.deps.db, user.ID, "Heatmap Show")
+
+	req := &GetActivityHeatmapRequest{Username: "heatmapuser"}
+	resp, err := s.handler.GetActivityHeatmapHandler(s.deps.ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.NotEmpty(resp.Body.Days)
+}
+
+func (s *ContributorProfileHandlerIntegrationSuite) TestGetActivityHeatmap_UserNotFound() {
+	req := &GetActivityHeatmapRequest{Username: "ghostheatmap"}
+	_, err := s.handler.GetActivityHeatmapHandler(s.deps.ctx, req)
+	assertHumaError(s.T(), err, 404)
+}
+
+func (s *ContributorProfileHandlerIntegrationSuite) TestGetActivityHeatmap_PrivateProfile_NotOwner() {
+	s.createPrivateUser("privateheatmap")
+
+	req := &GetActivityHeatmapRequest{Username: "privateheatmap"}
+	_, err := s.handler.GetActivityHeatmapHandler(s.deps.ctx, req)
+	assertHumaError(s.T(), err, 404)
+}
+
+func (s *ContributorProfileHandlerIntegrationSuite) TestGetActivityHeatmap_PrivateProfile_AsOwner() {
+	user := s.createPrivateUser("privateheatmapowner")
+	ctx := ctxWithUser(user)
+
+	req := &GetActivityHeatmapRequest{Username: "privateheatmapowner"}
+	resp, err := s.handler.GetActivityHeatmapHandler(ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+}
+
+func (s *ContributorProfileHandlerIntegrationSuite) TestGetActivityHeatmap_PrivacyHidden_ReturnsEmpty() {
+	user := s.createUserWithUsername("hiddenheatmap")
+	createApprovedShow(s.deps.db, user.ID, "Hidden Heatmap Show")
+	s.setPrivacySettings(user, contracts.PrivacySettings{
+		Contributions:   contracts.PrivacyHidden,
+		SavedShows:      contracts.PrivacyHidden,
+		Attendance:      contracts.PrivacyHidden,
+		Following:       contracts.PrivacyHidden,
+		Collections:     contracts.PrivacyHidden,
+		LastActive:      contracts.PrivacyHidden,
+		ProfileSections: contracts.PrivacyHidden,
+	})
+
+	viewer := s.createUserWithUsername("heatmapviewer")
+	ctx := ctxWithUser(viewer)
+
+	req := &GetActivityHeatmapRequest{Username: "hiddenheatmap"}
+	resp, err := s.handler.GetActivityHeatmapHandler(ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Empty(resp.Body.Days, "hidden privacy should return empty days")
+}
+
+func (s *ContributorProfileHandlerIntegrationSuite) TestGetActivityHeatmap_PrivacyCountOnly_StillReturnsData() {
+	user := s.createUserWithUsername("countheatmap")
+	createApprovedShow(s.deps.db, user.ID, "Count Heatmap Show")
+	s.setPrivacySettings(user, contracts.PrivacySettings{
+		Contributions:   contracts.PrivacyCountOnly,
+		SavedShows:      contracts.PrivacyHidden,
+		Attendance:      contracts.PrivacyHidden,
+		Following:       contracts.PrivacyHidden,
+		Collections:     contracts.PrivacyHidden,
+		LastActive:      contracts.PrivacyHidden,
+		ProfileSections: contracts.PrivacyHidden,
+	})
+
+	viewer := s.createUserWithUsername("countheatmapviewer")
+	ctx := ctxWithUser(viewer)
+
+	req := &GetActivityHeatmapRequest{Username: "countheatmap"}
+	resp, err := s.handler.GetActivityHeatmapHandler(ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.NotEmpty(resp.Body.Days, "count_only should still return heatmap data")
+}
+
+func (s *ContributorProfileHandlerIntegrationSuite) TestGetActivityHeatmap_NoActivity() {
+	s.createUserWithUsername("noactheatmap")
+
+	req := &GetActivityHeatmapRequest{Username: "noactheatmap"}
+	resp, err := s.handler.GetActivityHeatmapHandler(s.deps.ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Empty(resp.Body.Days)
+}

--- a/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
+++ b/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
@@ -777,6 +777,7 @@ type mockContributorProfileService struct {
 	createSectionFn func(uint, string, string, int) (*contracts.ProfileSectionResponse, error)
 	updateSectionFn func(uint, uint, map[string]interface{}) (*contracts.ProfileSectionResponse, error)
 	deleteSectionFn func(uint, uint) (error)
+	getActivityHeatmapFn func(uint) (*contracts.ActivityHeatmapResponse, error)
 }
 
 func (m *mockContributorProfileService) GetPublicProfile(username string, viewerID *uint) (*contracts.PublicProfileResponse, error) {
@@ -838,6 +839,12 @@ func (m *mockContributorProfileService) DeleteSection(userID uint, sectionID uin
 		return m.deleteSectionFn(userID, sectionID)
 	}
 	return nil
+}
+func (m *mockContributorProfileService) GetActivityHeatmap(userID uint) (*contracts.ActivityHeatmapResponse, error) {
+	if m.getActivityHeatmapFn != nil {
+		return m.getActivityHeatmapFn(userID)
+	}
+	return nil, nil
 }
 
 // ============================================================================

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -613,6 +613,7 @@ func setupContributorProfileRoutes(rc RouteContext) {
 	huma.Get(optionalAuthGroup, "/users/{username}", profileHandler.GetPublicProfileHandler)
 	huma.Get(optionalAuthGroup, "/users/{username}/contributions", profileHandler.GetContributionHistoryHandler)
 	huma.Get(optionalAuthGroup, "/users/{username}/sections", profileHandler.GetUserSectionsHandler)
+	huma.Get(optionalAuthGroup, "/users/{username}/activity-heatmap", profileHandler.GetActivityHeatmapHandler)
 
 	// Protected endpoints for authenticated user's own profile
 	huma.Get(rc.Protected, "/auth/profile/contributor", profileHandler.GetOwnProfileHandler)

--- a/backend/internal/services/contracts/interfaces.go
+++ b/backend/internal/services/contracts/interfaces.go
@@ -418,6 +418,7 @@ type ContributorProfileServiceInterface interface {
 	CreateSection(userID uint, title string, content string, position int) (*ProfileSectionResponse, error)
 	UpdateSection(userID uint, sectionID uint, updates map[string]interface{}) (*ProfileSectionResponse, error)
 	DeleteSection(userID uint, sectionID uint) error
+	GetActivityHeatmap(userID uint) (*ActivityHeatmapResponse, error)
 }
 
 // CalendarServiceInterface defines the contract for calendar feed operations.

--- a/backend/internal/services/contracts/user.go
+++ b/backend/internal/services/contracts/user.go
@@ -218,6 +218,17 @@ type ProfileSectionResponse struct {
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
+// ActivityDay represents a single day's contribution count for the activity heatmap.
+type ActivityDay struct {
+	Date  string `json:"date"`  // "2026-03-31"
+	Count int    `json:"count"`
+}
+
+// ActivityHeatmapResponse contains daily contribution counts for the activity heatmap.
+type ActivityHeatmapResponse struct {
+	Days []ActivityDay `json:"days"`
+}
+
 // ContributionEntry represents a single contribution in the history.
 type ContributionEntry struct {
 	ID         uint                   `json:"id"`

--- a/backend/internal/services/user/contributor_profile.go
+++ b/backend/internal/services/user/contributor_profile.go
@@ -447,6 +447,80 @@ func (s *ContributorProfileService) GetContributionHistory(userID uint, limit, o
 }
 
 // =============================================================================
+// Activity Heatmap
+// =============================================================================
+
+// GetActivityHeatmap returns daily contribution counts for the last 365 days.
+// It aggregates activity across audit_logs, shows, venues, pending_entity_edits, and revisions.
+// Only days with count > 0 are returned; the frontend fills in gaps.
+func (s *ContributorProfileService) GetActivityHeatmap(userID uint) (*contracts.ActivityHeatmapResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	query := `
+		SELECT activity_date, SUM(cnt) AS total_count
+		FROM (
+			SELECT DATE(created_at) AS activity_date, COUNT(*) AS cnt
+			FROM audit_logs
+			WHERE actor_id = ? AND created_at >= NOW() - INTERVAL '365 days'
+			GROUP BY DATE(created_at)
+
+			UNION ALL
+
+			SELECT DATE(created_at) AS activity_date, COUNT(*) AS cnt
+			FROM shows
+			WHERE submitted_by = ? AND created_at >= NOW() - INTERVAL '365 days'
+			GROUP BY DATE(created_at)
+
+			UNION ALL
+
+			SELECT DATE(created_at) AS activity_date, COUNT(*) AS cnt
+			FROM venues
+			WHERE submitted_by = ? AND created_at >= NOW() - INTERVAL '365 days'
+			GROUP BY DATE(created_at)
+
+			UNION ALL
+
+			SELECT DATE(created_at) AS activity_date, COUNT(*) AS cnt
+			FROM pending_entity_edits
+			WHERE submitted_by = ? AND created_at >= NOW() - INTERVAL '365 days'
+			GROUP BY DATE(created_at)
+
+			UNION ALL
+
+			SELECT DATE(created_at) AS activity_date, COUNT(*) AS cnt
+			FROM revisions
+			WHERE user_id = ? AND created_at >= NOW() - INTERVAL '365 days'
+			GROUP BY DATE(created_at)
+		) AS combined
+		GROUP BY activity_date
+		ORDER BY activity_date ASC
+	`
+
+	type dayRow struct {
+		ActivityDate time.Time `gorm:"column:activity_date"`
+		TotalCount   int       `gorm:"column:total_count"`
+	}
+
+	var rows []dayRow
+	err := s.db.Raw(query, userID, userID, userID, userID, userID).Scan(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to get activity heatmap: %w", err)
+	}
+
+	days := make([]contracts.ActivityDay, len(rows))
+	for i, row := range rows {
+		days[i] = contracts.ActivityDay{
+			Date:  row.ActivityDate.Format("2006-01-02"),
+			Count: row.TotalCount,
+		}
+	}
+
+	return &contracts.ActivityHeatmapResponse{Days: days}, nil
+}
+
+// =============================================================================
 // Profile Sections
 // =============================================================================
 

--- a/backend/internal/services/user/contributor_profile_test.go
+++ b/backend/internal/services/user/contributor_profile_test.go
@@ -1313,3 +1313,182 @@ func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetSections_Orde
 	suite.Equal("Second", sections[1].Title)
 	suite.Equal("Third", sections[2].Title)
 }
+
+// =============================================================================
+// Group 8: GetActivityHeatmap
+// =============================================================================
+
+func TestGetActivityHeatmap_NilDB(t *testing.T) {
+	svc := &ContributorProfileService{db: nil}
+	result, err := svc.GetActivityHeatmap(1)
+	assert.Nil(t, result)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "database not initialized")
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetActivityHeatmap_NoActivity() {
+	user := suite.createTestUser("heatmap_empty")
+
+	resp, err := suite.profileService.GetActivityHeatmap(user.ID)
+
+	suite.Require().NoError(err)
+	suite.Require().NotNil(resp)
+	suite.Empty(resp.Days)
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetActivityHeatmap_ShowSubmissions() {
+	user := suite.createTestUser("heatmap_shows")
+	suite.createShow(user.ID, "Show 1")
+	suite.createShow(user.ID, "Show 2")
+
+	resp, err := suite.profileService.GetActivityHeatmap(user.ID)
+
+	suite.Require().NoError(err)
+	suite.Require().NotNil(resp)
+	suite.Require().Len(resp.Days, 1)
+	suite.Equal(2, resp.Days[0].Count)
+	// Date should be today
+	suite.Equal(time.Now().UTC().Format("2006-01-02"), resp.Days[0].Date)
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetActivityHeatmap_VenueSubmissions() {
+	user := suite.createTestUser("heatmap_venues")
+	suite.createVenue(user.ID, "Venue 1")
+
+	resp, err := suite.profileService.GetActivityHeatmap(user.ID)
+
+	suite.Require().NoError(err)
+	suite.Require().NotNil(resp)
+	suite.Require().Len(resp.Days, 1)
+	suite.Equal(1, resp.Days[0].Count)
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetActivityHeatmap_AuditLogEntries() {
+	user := suite.createTestUser("heatmap_audit")
+	helper := &testAuditLogHelper{db: suite.db}
+	helper.LogAction(user.ID, "create_release", "release", 1, nil)
+	helper.LogAction(user.ID, "edit_artist", "artist", 1, nil)
+
+	resp, err := suite.profileService.GetActivityHeatmap(user.ID)
+
+	suite.Require().NoError(err)
+	suite.Require().NotNil(resp)
+	suite.Require().Len(resp.Days, 1)
+	suite.Equal(2, resp.Days[0].Count)
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetActivityHeatmap_Revisions() {
+	user := suite.createTestUser("heatmap_revisions")
+	fieldChanges := json.RawMessage(`[{"field":"name","old_value":"Old","new_value":"New"}]`)
+	suite.Require().NoError(suite.db.Create(&models.Revision{
+		EntityType: "artist", EntityID: 1, UserID: user.ID,
+		FieldChanges: &fieldChanges,
+	}).Error)
+
+	resp, err := suite.profileService.GetActivityHeatmap(user.ID)
+
+	suite.Require().NoError(err)
+	suite.Require().NotNil(resp)
+	suite.Require().Len(resp.Days, 1)
+	suite.Equal(1, resp.Days[0].Count)
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetActivityHeatmap_PendingEdits() {
+	user := suite.createTestUser("heatmap_edits")
+	fieldChanges := json.RawMessage(`[{"field":"name","old_value":"Old","new_value":"New"}]`)
+	suite.Require().NoError(suite.db.Create(&models.PendingEntityEdit{
+		EntityType:   "venue",
+		EntityID:     1,
+		SubmittedBy:  user.ID,
+		Status:       models.PendingEditStatusPending,
+		FieldChanges: &fieldChanges,
+	}).Error)
+
+	resp, err := suite.profileService.GetActivityHeatmap(user.ID)
+
+	suite.Require().NoError(err)
+	suite.Require().NotNil(resp)
+	suite.Require().Len(resp.Days, 1)
+	suite.Equal(1, resp.Days[0].Count)
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetActivityHeatmap_MultipleTablesAggregated() {
+	user := suite.createTestUser("heatmap_multi")
+
+	// Create entries across multiple tables (all today)
+	suite.createShow(user.ID, "Heatmap Show")
+	suite.createVenue(user.ID, "Heatmap Venue")
+	helper := &testAuditLogHelper{db: suite.db}
+	helper.LogAction(user.ID, "edit_artist", "artist", 1, nil)
+	fieldChanges := json.RawMessage(`[{"field":"name","old_value":"Old","new_value":"New"}]`)
+	suite.Require().NoError(suite.db.Create(&models.Revision{
+		EntityType: "artist", EntityID: 1, UserID: user.ID,
+		FieldChanges: &fieldChanges,
+	}).Error)
+	suite.Require().NoError(suite.db.Create(&models.PendingEntityEdit{
+		EntityType:   "venue",
+		EntityID:     1,
+		SubmittedBy:  user.ID,
+		Status:       models.PendingEditStatusPending,
+		FieldChanges: &fieldChanges,
+	}).Error)
+
+	resp, err := suite.profileService.GetActivityHeatmap(user.ID)
+
+	suite.Require().NoError(err)
+	suite.Require().NotNil(resp)
+	suite.Require().Len(resp.Days, 1)
+	// 1 show + 1 venue + 1 audit + 1 revision + 1 pending edit = 5
+	suite.Equal(5, resp.Days[0].Count)
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetActivityHeatmap_DoesNotCountOtherUsers() {
+	user1 := suite.createTestUser("heatmap_user1")
+	user2 := suite.createTestUser("heatmap_user2")
+
+	suite.createShow(user1.ID, "User 1 Show")
+	suite.createShow(user2.ID, "User 2 Show")
+
+	resp, err := suite.profileService.GetActivityHeatmap(user1.ID)
+
+	suite.Require().NoError(err)
+	suite.Require().NotNil(resp)
+	suite.Require().Len(resp.Days, 1)
+	suite.Equal(1, resp.Days[0].Count, "Should only count user1's activity")
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetActivityHeatmap_OldDataExcluded() {
+	user := suite.createTestUser("heatmap_old")
+
+	// Create a show dated today (should be included)
+	suite.createShow(user.ID, "Recent Show")
+
+	// Directly insert a show with an old created_at (>365 days ago)
+	oldDate := time.Now().UTC().AddDate(0, 0, -400)
+	suite.Require().NoError(suite.db.Exec(
+		"INSERT INTO shows (title, submitted_by, status, event_date, created_at, updated_at) VALUES (?, ?, 'approved', ?, ?, ?)",
+		"Old Show", user.ID, oldDate, oldDate, oldDate,
+	).Error)
+
+	resp, err := suite.profileService.GetActivityHeatmap(user.ID)
+
+	suite.Require().NoError(err)
+	suite.Require().NotNil(resp)
+	// Should only have 1 day (today's show), not the old one
+	suite.Require().Len(resp.Days, 1)
+	suite.Equal(1, resp.Days[0].Count)
+}
+
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetActivityHeatmap_DateFormat() {
+	user := suite.createTestUser("heatmap_format")
+	suite.createShow(user.ID, "Date Format Show")
+
+	resp, err := suite.profileService.GetActivityHeatmap(user.ID)
+
+	suite.Require().NoError(err)
+	suite.Require().NotNil(resp)
+	suite.Require().Len(resp.Days, 1)
+	// Verify date format is YYYY-MM-DD
+	_, err = time.Parse("2006-01-02", resp.Days[0].Date)
+	suite.NoError(err, "Date should be in YYYY-MM-DD format")
+}

--- a/frontend/components/contributor/ActivityHeatmap.test.tsx
+++ b/frontend/components/contributor/ActivityHeatmap.test.tsx
@@ -1,0 +1,208 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ActivityHeatmap } from './ActivityHeatmap'
+
+// Mock the hook
+const mockUseActivityHeatmap = vi.fn()
+
+vi.mock('@/features/auth', () => ({
+  useActivityHeatmap: (username: string) => mockUseActivityHeatmap(username),
+}))
+
+describe('ActivityHeatmap', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-03-31T12:00:00Z'))
+    // Default mock: set window width to desktop
+    Object.defineProperty(window, 'innerWidth', { value: 1024, writable: true })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('shows loading skeleton while fetching', () => {
+    mockUseActivityHeatmap.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    })
+
+    render(<ActivityHeatmap username="alice" />)
+    expect(screen.getByTestId('activity-heatmap-skeleton')).toBeInTheDocument()
+  })
+
+  it('renders empty state with 0 contributions', () => {
+    mockUseActivityHeatmap.mockReturnValue({
+      data: { days: [] },
+      isLoading: false,
+    })
+
+    render(<ActivityHeatmap username="alice" />)
+    expect(screen.getByTestId('activity-heatmap')).toBeInTheDocument()
+    expect(screen.getByText(/0 contributions/)).toBeInTheDocument()
+  })
+
+  it('renders grid with correct number of cells for active days', () => {
+    mockUseActivityHeatmap.mockReturnValue({
+      data: {
+        days: [
+          { date: '2026-03-31', count: 5 },
+          { date: '2026-03-30', count: 2 },
+          { date: '2026-01-15', count: 1 },
+        ],
+      },
+      isLoading: false,
+    })
+
+    render(<ActivityHeatmap username="alice" />)
+    expect(screen.getByTestId('activity-heatmap')).toBeInTheDocument()
+    expect(screen.getByText(/8 contributions/)).toBeInTheDocument()
+
+    // Verify specific cells exist with correct data attributes
+    const cell1 = screen.getByTestId('heatmap-cell-2026-03-31')
+    expect(cell1).toBeInTheDocument()
+    expect(cell1.getAttribute('data-count')).toBe('5')
+
+    const cell2 = screen.getByTestId('heatmap-cell-2026-03-30')
+    expect(cell2).toBeInTheDocument()
+    expect(cell2.getAttribute('data-count')).toBe('2')
+  })
+
+  it('shows tooltip on hover', async () => {
+    mockUseActivityHeatmap.mockReturnValue({
+      data: {
+        days: [{ date: '2026-03-31', count: 3 }],
+      },
+      isLoading: false,
+    })
+
+    render(<ActivityHeatmap username="alice" />)
+
+    const cell = screen.getByTestId('heatmap-cell-2026-03-31')
+    fireEvent.mouseEnter(cell)
+
+    const tooltip = screen.getByTestId('heatmap-tooltip')
+    expect(tooltip).toBeInTheDocument()
+    expect(tooltip.textContent).toContain('3 contributions on')
+    expect(tooltip.textContent).toContain('March 31, 2026')
+
+    fireEvent.mouseLeave(cell)
+    expect(screen.queryByTestId('heatmap-tooltip')).not.toBeInTheDocument()
+  })
+
+  it('tooltip shows singular "contribution" for count of 1', () => {
+    mockUseActivityHeatmap.mockReturnValue({
+      data: {
+        days: [{ date: '2026-03-31', count: 1 }],
+      },
+      isLoading: false,
+    })
+
+    render(<ActivityHeatmap username="alice" />)
+
+    const cell = screen.getByTestId('heatmap-cell-2026-03-31')
+    fireEvent.mouseEnter(cell)
+
+    const tooltip = screen.getByTestId('heatmap-tooltip')
+    expect(tooltip.textContent).toContain('1 contribution on')
+    expect(tooltip.textContent).not.toContain('1 contributions')
+  })
+
+  it('tooltip shows "No contributions" for zero-count cell', () => {
+    mockUseActivityHeatmap.mockReturnValue({
+      data: { days: [] },
+      isLoading: false,
+    })
+
+    render(<ActivityHeatmap username="alice" />)
+
+    // Find a cell that should have count=0
+    const cell = screen.getByTestId('heatmap-cell-2026-03-31')
+    fireEvent.mouseEnter(cell)
+
+    const tooltip = screen.getByTestId('heatmap-tooltip')
+    expect(tooltip.textContent).toContain('No contributions on')
+  })
+
+  it('renders color intensity scaled to max count', () => {
+    mockUseActivityHeatmap.mockReturnValue({
+      data: {
+        days: [
+          { date: '2026-03-31', count: 10 },  // max => level 4
+          { date: '2026-03-30', count: 2 },   // 2/10 = 0.2 => level 1
+          { date: '2026-03-29', count: 5 },   // 5/10 = 0.5 => level 2
+          { date: '2026-03-28', count: 8 },   // 8/10 = 0.8 => level 4
+        ],
+      },
+      isLoading: false,
+    })
+
+    render(<ActivityHeatmap username="alice" />)
+
+    // Max cell should have emerald-700 (level 4 dark)
+    const maxCell = screen.getByTestId('heatmap-cell-2026-03-31')
+    expect(maxCell.className).toContain('emerald-700')
+
+    // Low cell should have emerald-200 (level 1)
+    const lowCell = screen.getByTestId('heatmap-cell-2026-03-30')
+    expect(lowCell.className).toContain('emerald-200')
+  })
+
+  it('renders legend with Less/More labels', () => {
+    mockUseActivityHeatmap.mockReturnValue({
+      data: { days: [] },
+      isLoading: false,
+    })
+
+    render(<ActivityHeatmap username="alice" />)
+    expect(screen.getByText('Less')).toBeInTheDocument()
+    expect(screen.getByText('More')).toBeInTheDocument()
+  })
+
+  it('renders day-of-week labels', () => {
+    mockUseActivityHeatmap.mockReturnValue({
+      data: { days: [] },
+      isLoading: false,
+    })
+
+    render(<ActivityHeatmap username="alice" />)
+    expect(screen.getByText('Mon')).toBeInTheDocument()
+    expect(screen.getByText('Wed')).toBeInTheDocument()
+    expect(screen.getByText('Fri')).toBeInTheDocument()
+  })
+
+  it('renders month labels', () => {
+    mockUseActivityHeatmap.mockReturnValue({
+      data: { days: [] },
+      isLoading: false,
+    })
+
+    render(<ActivityHeatmap username="alice" />)
+    // March 2026 should be shown in the month labels
+    expect(screen.getByText('Mar')).toBeInTheDocument()
+  })
+
+  it('passes username to the hook', () => {
+    mockUseActivityHeatmap.mockReturnValue({
+      data: { days: [] },
+      isLoading: false,
+    })
+
+    render(<ActivityHeatmap username="bob" />)
+    expect(mockUseActivityHeatmap).toHaveBeenCalledWith('bob')
+  })
+
+  it('uses 26 weeks on mobile viewport', () => {
+    Object.defineProperty(window, 'innerWidth', { value: 400, writable: true })
+
+    mockUseActivityHeatmap.mockReturnValue({
+      data: { days: [] },
+      isLoading: false,
+    })
+
+    render(<ActivityHeatmap username="alice" />)
+    expect(screen.getByText(/26 weeks/)).toBeInTheDocument()
+  })
+})

--- a/frontend/components/contributor/ActivityHeatmap.tsx
+++ b/frontend/components/contributor/ActivityHeatmap.tsx
@@ -1,0 +1,286 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { Skeleton } from '@/components/ui/skeleton'
+import { useActivityHeatmap } from '@/features/auth'
+import type { ActivityDay } from '@/features/auth'
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function getWeeksToShow(): number {
+  if (typeof window === 'undefined') return 52
+  return window.innerWidth < 640 ? 26 : 52
+}
+
+/**
+ * Generate the array of dates for the heatmap grid.
+ * Starts from a Sunday that gives us `weeksCount` complete weeks ending on today's week.
+ */
+function generateDayGrid(weeksCount: number): Date[] {
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+
+  // Find the Saturday of this week (end of grid)
+  const endDate = new Date(today)
+
+  // Go back weeksCount weeks from this Sunday
+  const startDate = new Date(endDate)
+  startDate.setDate(startDate.getDate() - startDate.getDay() - (weeksCount - 1) * 7)
+
+  const days: Date[] = []
+  const current = new Date(startDate)
+  while (current <= today) {
+    days.push(new Date(current))
+    current.setDate(current.getDate() + 1)
+  }
+
+  return days
+}
+
+function formatDateKey(date: Date): string {
+  const y = date.getFullYear()
+  const m = String(date.getMonth() + 1).padStart(2, '0')
+  const d = String(date.getDate()).padStart(2, '0')
+  return `${y}-${m}-${d}`
+}
+
+function formatTooltipDate(date: Date): string {
+  return date.toLocaleDateString('en-US', {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+
+/**
+ * Map intensity level (0-4) to a Tailwind class for the cell background.
+ * Uses emerald shades with dark mode variants.
+ */
+const INTENSITY_CLASSES = [
+  'bg-muted/40',                                          // 0: no activity
+  'bg-emerald-200 dark:bg-emerald-900/70',                // level 1
+  'bg-emerald-300 dark:bg-emerald-700',                   // level 2
+  'bg-emerald-500 dark:bg-emerald-500',                   // level 3
+  'bg-emerald-700 dark:bg-emerald-300',                   // level 4: max
+]
+
+function getIntensityLevel(count: number, maxCount: number): number {
+  if (count === 0 || maxCount === 0) return 0
+  const ratio = count / maxCount
+  if (ratio <= 0.25) return 1
+  if (ratio <= 0.50) return 2
+  if (ratio <= 0.75) return 3
+  return 4
+}
+
+const DAY_LABELS = ['', 'Mon', '', 'Wed', '', 'Fri', ''] // Sun, Mon, ..., Sat
+const MONTH_NAMES = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+]
+
+// ============================================================================
+// Component
+// ============================================================================
+
+interface ActivityHeatmapProps {
+  username: string
+}
+
+export function ActivityHeatmap({ username }: ActivityHeatmapProps) {
+  const { data, isLoading } = useActivityHeatmap(username)
+  const [tooltip, setTooltip] = useState<{
+    text: string
+    x: number
+    y: number
+  } | null>(null)
+
+  const weeksCount = useMemo(() => getWeeksToShow(), [])
+  const days = useMemo(() => generateDayGrid(weeksCount), [weeksCount])
+
+  const countMap = useMemo(() => {
+    const map = new Map<string, number>()
+    if (data?.days) {
+      for (const day of data.days) {
+        map.set(day.date, day.count)
+      }
+    }
+    return map
+  }, [data])
+
+  const maxCount = useMemo(() => {
+    if (!data?.days || data.days.length === 0) return 0
+    return Math.max(...data.days.map((d: ActivityDay) => d.count))
+  }, [data])
+
+  const totalContributions = useMemo(() => {
+    if (!data?.days) return 0
+    return data.days.reduce((sum: number, d: ActivityDay) => sum + d.count, 0)
+  }, [data])
+
+  // Group days into weeks (columns), where each week starts on Sunday
+  const weeks = useMemo(() => {
+    const result: Date[][] = []
+    let currentWeek: Date[] = []
+
+    for (const day of days) {
+      if (day.getDay() === 0 && currentWeek.length > 0) {
+        result.push(currentWeek)
+        currentWeek = []
+      }
+      currentWeek.push(day)
+    }
+    if (currentWeek.length > 0) {
+      result.push(currentWeek)
+    }
+
+    return result
+  }, [days])
+
+  // Month labels with column positions
+  const monthLabels = useMemo(() => {
+    const labels: { label: string; col: number }[] = []
+    let lastMonth = -1
+
+    for (let w = 0; w < weeks.length; w++) {
+      const firstDay = weeks[w][0]
+      const month = firstDay.getMonth()
+      if (month !== lastMonth) {
+        labels.push({ label: MONTH_NAMES[month], col: w })
+        lastMonth = month
+      }
+    }
+
+    return labels
+  }, [weeks])
+
+  if (isLoading) {
+    return (
+      <div className="space-y-2" data-testid="activity-heatmap-skeleton">
+        <Skeleton className="h-4 w-48" />
+        <Skeleton className="h-[100px] w-full" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-2" data-testid="activity-heatmap">
+      {/* Header: total + legend */}
+      <div className="flex items-center justify-between flex-wrap gap-2">
+        <p className="text-xs text-muted-foreground">
+          {totalContributions} contribution{totalContributions !== 1 ? 's' : ''} in the last{' '}
+          {weeksCount === 52 ? 'year' : `${weeksCount} weeks`}
+        </p>
+        <div className="flex items-center gap-1 text-xs text-muted-foreground">
+          <span>Less</span>
+          {INTENSITY_CLASSES.map((cls, i) => (
+            <div
+              key={i}
+              className={`w-[11px] h-[11px] rounded-[2px] ${cls}`}
+            />
+          ))}
+          <span>More</span>
+        </div>
+      </div>
+
+      {/* Grid container */}
+      <div className="relative overflow-x-auto" role="img" aria-label={`Activity heatmap showing ${totalContributions} contributions`}>
+        {/* Month labels row */}
+        <div className="flex" style={{ paddingLeft: 28 }}>
+          {weeks.map((_week, wIdx) => {
+            const label = monthLabels.find((m) => m.col === wIdx)
+            return (
+              <div
+                key={`month-${wIdx}`}
+                className="text-[9px] text-muted-foreground leading-none"
+                style={{ width: 13, flexShrink: 0 }}
+              >
+                {label ? label.label : ''}
+              </div>
+            )
+          })}
+        </div>
+
+        {/* Grid: day labels + cells */}
+        <div className="flex gap-0">
+          {/* Day-of-week labels column */}
+          <div className="flex flex-col" style={{ width: 28, flexShrink: 0 }}>
+            {DAY_LABELS.map((label, i) => (
+              <div
+                key={`day-label-${i}`}
+                className="text-[9px] text-muted-foreground flex items-center"
+                style={{ height: 13 }}
+              >
+                {label}
+              </div>
+            ))}
+          </div>
+
+          {/* Weeks (columns) */}
+          <div className="flex gap-0">
+            {weeks.map((week, weekIndex) => (
+              <div key={`week-${weekIndex}`} className="flex flex-col">
+                {/* Pad the first week if it doesn't start on Sunday */}
+                {weekIndex === 0 &&
+                  Array.from({ length: week[0].getDay() }).map((_, i) => (
+                    <div key={`pad-${i}`} style={{ width: 11, height: 11, margin: 1 }} />
+                  ))}
+                {week.map((day) => {
+                  const dateKey = formatDateKey(day)
+                  const count = countMap.get(dateKey) || 0
+                  const level = getIntensityLevel(count, maxCount)
+
+                  return (
+                    <div
+                      key={dateKey}
+                      className={`rounded-[2px] cursor-pointer ${INTENSITY_CLASSES[level]}`}
+                      style={{ width: 11, height: 11, margin: 1 }}
+                      data-testid={`heatmap-cell-${dateKey}`}
+                      data-count={count}
+                      data-date={dateKey}
+                      onMouseEnter={(e) => {
+                        const rect = e.currentTarget.getBoundingClientRect()
+                        const containerRect = e.currentTarget
+                          .closest('[data-testid="activity-heatmap"]')
+                          ?.getBoundingClientRect()
+                        if (containerRect) {
+                          setTooltip({
+                            text:
+                              count === 0
+                                ? `No contributions on ${formatTooltipDate(day)}`
+                                : `${count} contribution${count !== 1 ? 's' : ''} on ${formatTooltipDate(day)}`,
+                            x: rect.left - containerRect.left + rect.width / 2,
+                            y: rect.top - containerRect.top - 4,
+                          })
+                        }
+                      }}
+                      onMouseLeave={() => setTooltip(null)}
+                    />
+                  )
+                })}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Tooltip */}
+        {tooltip && (
+          <div
+            className="absolute z-10 pointer-events-none px-2 py-1 text-xs bg-popover text-popover-foreground border border-border rounded shadow-md whitespace-nowrap"
+            style={{
+              left: tooltip.x,
+              top: tooltip.y,
+              transform: 'translate(-50%, -100%)',
+            }}
+            data-testid="heatmap-tooltip"
+          >
+            {tooltip.text}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/components/contributor/PublicProfile.test.tsx
+++ b/frontend/components/contributor/PublicProfile.test.tsx
@@ -56,6 +56,12 @@ vi.mock('./ProfileSections', () => ({
   ),
 }))
 
+vi.mock('./ActivityHeatmap', () => ({
+  ActivityHeatmap: ({ username }: { username: string }) => (
+    <div data-testid="activity-heatmap">Heatmap for {username}</div>
+  ),
+}))
+
 function makeProfile(
   overrides: Partial<PublicProfileResponse> = {}
 ): PublicProfileResponse {

--- a/frontend/components/contributor/PublicProfile.tsx
+++ b/frontend/components/contributor/PublicProfile.tsx
@@ -3,6 +3,7 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Lock, CalendarDays, Clock } from 'lucide-react'
+import { ActivityHeatmap } from './ActivityHeatmap'
 import { UserTierBadge } from './UserTierBadge'
 import { ContributionStatsGrid } from './ContributionStatsGrid'
 import { ContributionTimeline } from './ContributionTimeline'
@@ -191,6 +192,14 @@ export function PublicProfile({ username }: PublicProfileProps) {
         <section className="mb-8">
           <h2 className="text-lg font-semibold mb-4">Contributions</h2>
           <ContributionStatsGrid stats={profile.stats} />
+        </section>
+      )}
+
+      {/* Activity Heatmap */}
+      {(showStats || (profile.stats_count !== undefined && profile.stats_count > 0)) && (
+        <section className="mb-8">
+          <h2 className="text-lg font-semibold mb-4">Activity</h2>
+          <ActivityHeatmap username={username} />
         </section>
       )}
 

--- a/frontend/components/contributor/index.ts
+++ b/frontend/components/contributor/index.ts
@@ -1,3 +1,4 @@
+export { ActivityHeatmap } from './ActivityHeatmap'
 export { UserTierBadge } from './UserTierBadge'
 export { ContributionStatsGrid } from './ContributionStatsGrid'
 export { ContributionTimeline } from './ContributionTimeline'

--- a/frontend/features/auth/hooks/index.ts
+++ b/frontend/features/auth/hooks/index.ts
@@ -46,6 +46,7 @@ export {
 export {
   usePublicProfile,
   usePublicContributions,
+  useActivityHeatmap,
   useOwnContributorProfile,
   useOwnContributions,
   useOwnSections,

--- a/frontend/features/auth/hooks/useContributorProfile.ts
+++ b/frontend/features/auth/hooks/useContributorProfile.ts
@@ -20,6 +20,7 @@ import type {
   UpdateSectionInput,
   UpdateVisibilityInput,
   UpdatePrivacyInput,
+  ActivityHeatmapResponse,
 } from '../types'
 
 // ============================================================================
@@ -72,6 +73,23 @@ export function usePublicContributions(
     },
     enabled: Boolean(username),
     staleTime: 5 * 60 * 1000,
+  })
+}
+
+/**
+ * Hook to fetch a user's activity heatmap (daily contribution counts for last 365 days)
+ */
+export function useActivityHeatmap(username: string) {
+  return useQuery({
+    queryKey: queryKeys.contributor.activityHeatmap(username),
+    queryFn: async (): Promise<ActivityHeatmapResponse> => {
+      return apiRequest<ActivityHeatmapResponse>(
+        API_ENDPOINTS.USERS.ACTIVITY_HEATMAP(username),
+        { method: 'GET' }
+      )
+    },
+    enabled: Boolean(username),
+    staleTime: 10 * 60 * 1000, // 10 minutes — heatmap data doesn't change often
   })
 }
 

--- a/frontend/features/auth/index.ts
+++ b/frontend/features/auth/index.ts
@@ -17,6 +17,8 @@ export type {
   UpdateVisibilityInput,
   UpdatePrivacyInput,
   APIToken,
+  ActivityDay,
+  ActivityHeatmapResponse,
 } from './types'
 
 // Hooks — Auth
@@ -71,6 +73,7 @@ export {
 export {
   usePublicProfile,
   usePublicContributions,
+  useActivityHeatmap,
   useOwnContributorProfile,
   useOwnContributions,
   useOwnSections,

--- a/frontend/features/auth/types.ts
+++ b/frontend/features/auth/types.ts
@@ -95,6 +95,15 @@ export interface ContributionsResponse {
   offset: number
 }
 
+export interface ActivityDay {
+  date: string  // "2026-03-31"
+  count: number
+}
+
+export interface ActivityHeatmapResponse {
+  days: ActivityDay[]
+}
+
 export interface ProfileSectionResponse {
   id: number
   title: string

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -227,6 +227,8 @@ export const API_ENDPOINTS = {
       `${API_BASE_URL}/users/${username}/contributions`,
     SECTIONS: (username: string) =>
       `${API_BASE_URL}/users/${username}/sections`,
+    ACTIVITY_HEATMAP: (username: string) =>
+      `${API_BASE_URL}/users/${username}/activity-heatmap`,
   },
 
   // Contributor profile endpoints (authenticated)

--- a/frontend/lib/queryClient.ts
+++ b/frontend/lib/queryClient.ts
@@ -239,6 +239,7 @@ export const queryKeys = {
     ownContributions: ['contributor', 'ownContributions'] as const,
     sections: (username: string) => ['contributor', 'sections', username] as const,
     ownSections: ['contributor', 'ownSections'] as const,
+    activityHeatmap: (username: string) => ['contributor', 'activityHeatmap', username] as const,
   },
 
   // Crate queries


### PR DESCRIPTION
## Summary
- Backend: `GET /users/{username}/activity-heatmap` returning 365 days of daily contribution counts aggregated across 5 tables via UNION ALL
- Frontend: GitHub-style div-based heatmap grid with emerald color scale, hover tooltips, month/day labels
- Responsive: 52 weeks desktop, 26 weeks mobile
- Privacy-gated (respects contributions visibility setting)
- 18 backend tests (11 service + 7 handler) + 12 frontend tests

## Test plan
- [ ] Backend builds cleanly
- [ ] Service tests pass (`go test ./internal/services/user/ -run TestActivity`)
- [ ] Handler tests pass
- [ ] Frontend tests pass (`bun run test -- ActivityHeatmap`)
- [ ] Heatmap renders on profile page with correct color scaling

Closes PSY-198

🤖 Generated with [Claude Code](https://claude.com/claude-code)