### PR TITLE
Add contributor leaderboard page (PSY-197, PSY-134)

### DIFF
--- a/backend/internal/api/handlers/leaderboard.go
+++ b/backend/internal/api/handlers/leaderboard.go
@@ -1,0 +1,116 @@
+package handlers
+
+import (
+	"context"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"psychic-homily-backend/internal/api/middleware"
+	"psychic-homily-backend/internal/logger"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// LeaderboardHandler handles public leaderboard endpoints.
+type LeaderboardHandler struct {
+	leaderboardService contracts.LeaderboardServiceInterface
+}
+
+// NewLeaderboardHandler creates a new leaderboard handler.
+func NewLeaderboardHandler(
+	leaderboardService contracts.LeaderboardServiceInterface,
+) *LeaderboardHandler {
+	return &LeaderboardHandler{
+		leaderboardService: leaderboardService,
+	}
+}
+
+// --- GetLeaderboard ---
+
+// GetLeaderboardRequest is the Huma request for GET /community/leaderboard
+type GetLeaderboardRequest struct {
+	Dimension string `query:"dimension" required:"false" doc:"Leaderboard dimension: overall, shows, venues, tags, edits, requests (default: overall)"`
+	Period    string `query:"period" required:"false" doc:"Time period: all_time, month, week (default: all_time)"`
+	Limit     int    `query:"limit" required:"false" doc:"Number of results (default 25, max 100)"`
+}
+
+// LeaderboardEntryResponse is a single entry in the leaderboard response.
+type LeaderboardEntryResponse struct {
+	Rank      int     `json:"rank"`
+	UserID    uint    `json:"user_id"`
+	Username  string  `json:"username"`
+	AvatarURL *string `json:"avatar_url,omitempty"`
+	UserTier  string  `json:"user_tier"`
+	Count     int64   `json:"count"`
+}
+
+// GetLeaderboardResponse is the Huma response for GET /community/leaderboard
+type GetLeaderboardResponse struct {
+	Body struct {
+		Entries   []LeaderboardEntryResponse `json:"entries"`
+		Dimension string                     `json:"dimension"`
+		Period    string                     `json:"period"`
+		UserRank  *int                       `json:"user_rank,omitempty"`
+	}
+}
+
+// GetLeaderboardHandler handles GET /community/leaderboard
+func (h *LeaderboardHandler) GetLeaderboardHandler(ctx context.Context, req *GetLeaderboardRequest) (*GetLeaderboardResponse, error) {
+	dimension := req.Dimension
+	if dimension == "" {
+		dimension = "overall"
+	}
+
+	period := req.Period
+	if period == "" {
+		period = "all_time"
+	}
+
+	limit := req.Limit
+	if limit <= 0 {
+		limit = 25
+	}
+
+	entries, err := h.leaderboardService.GetLeaderboard(dimension, period, limit)
+	if err != nil {
+		if err.Error() == "invalid dimension: "+dimension {
+			return nil, huma.Error400BadRequest("Invalid dimension: " + dimension)
+		}
+		if err.Error() == "invalid period: "+period {
+			return nil, huma.Error400BadRequest("Invalid period: " + period)
+		}
+		logger.FromContext(ctx).Error("leaderboard_failed", "error", err.Error())
+		return nil, huma.Error500InternalServerError("Failed to get leaderboard")
+	}
+
+	resp := &GetLeaderboardResponse{}
+	resp.Body.Dimension = dimension
+	resp.Body.Period = period
+	resp.Body.Entries = make([]LeaderboardEntryResponse, len(entries))
+	for i, e := range entries {
+		resp.Body.Entries[i] = LeaderboardEntryResponse{
+			Rank:      e.Rank,
+			UserID:    e.UserID,
+			Username:  e.Username,
+			AvatarURL: e.AvatarURL,
+			UserTier:  e.UserTier,
+			Count:     e.Count,
+		}
+	}
+
+	// If the user is authenticated, compute their rank
+	user := middleware.GetUserFromContext(ctx)
+	if user != nil {
+		rank, err := h.leaderboardService.GetUserRank(user.ID, dimension, period)
+		if err != nil {
+			// Non-fatal — log and continue without user rank
+			logger.FromContext(ctx).Warn("leaderboard_user_rank_failed",
+				"user_id", user.ID,
+				"error", err.Error(),
+			)
+		} else {
+			resp.Body.UserRank = rank
+		}
+	}
+
+	return resp, nil
+}

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -129,6 +129,7 @@ func SetupRoutes(router *chi.Mux, sc *services.ServiceContainer, cfg *config.Con
 	setupPendingEditRoutes(rc)
 	setupEntityReportRoutes(rc)
 	setupContributeRoutes(rc)
+	setupLeaderboardRoutes(rc)
 
 	return api
 }
@@ -984,4 +985,15 @@ func setupContributeRoutes(rc RouteContext) {
 	contributeHandler := handlers.NewContributeHandler(rc.SC.DataQuality)
 	huma.Get(rc.API, "/contribute/opportunities", contributeHandler.GetOpportunitiesHandler)
 	huma.Get(rc.API, "/contribute/opportunities/{category}", contributeHandler.GetOpportunityCategoryHandler)
+}
+
+// setupLeaderboardRoutes configures public contributor leaderboard endpoints.
+// Uses optional auth to include the requesting user's rank when authenticated.
+func setupLeaderboardRoutes(rc RouteContext) {
+	leaderboardHandler := handlers.NewLeaderboardHandler(rc.SC.Leaderboard)
+
+	optionalAuthGroup := huma.NewGroup(rc.API, "")
+	optionalAuthGroup.UseMiddleware(middleware.OptionalHumaJWTMiddleware(rc.SC.JWT))
+
+	huma.Get(optionalAuthGroup, "/community/leaderboard", leaderboardHandler.GetLeaderboardHandler)
 }

--- a/backend/internal/services/container.go
+++ b/backend/internal/services/container.go
@@ -50,6 +50,7 @@ type ServiceContainer struct {
 	ShowReport    *adminsvc.ShowReportService
 	EntityReport  *adminsvc.EntityReportService
 	User              *usersvc.UserService
+	Leaderboard       *usersvc.LeaderboardService
 	Venue             *catalog.VenueService
 	VenueSourceConfig *pipeline.VenueSourceConfigService
 
@@ -157,6 +158,7 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 		ShowReport:    adminsvc.NewShowReportService(database),
 		EntityReport:  adminsvc.NewEntityReportService(database),
 		User:          userService,
+		Leaderboard:   usersvc.NewLeaderboardService(database),
 		Venue:             venue,
 		VenueSourceConfig: venueSourceConfig,
 

--- a/backend/internal/services/contracts/interfaces.go
+++ b/backend/internal/services/contracts/interfaces.go
@@ -424,6 +424,12 @@ type ContributorProfileServiceInterface interface {
 	GetPercentileRankings(userID uint) (*PercentileRankings, error)
 }
 
+// LeaderboardServiceInterface defines the contract for contributor leaderboard operations.
+type LeaderboardServiceInterface interface {
+	GetLeaderboard(dimension string, period string, limit int) ([]LeaderboardEntry, error)
+	GetUserRank(userID uint, dimension string, period string) (*int, error)
+}
+
 // CalendarServiceInterface defines the contract for calendar feed operations.
 type CalendarServiceInterface interface {
 	CreateToken(userID uint, apiBaseURL string) (*CalendarTokenCreateResponse, error)

--- a/backend/internal/services/contracts/user.go
+++ b/backend/internal/services/contracts/user.go
@@ -243,6 +243,28 @@ type PercentileRankings struct {
 	OverallScore int                 `json:"overall_score"`
 }
 
+// ──────────────────────────────────────────────
+// Leaderboard types
+// ──────────────────────────────────────────────
+
+// LeaderboardEntry represents a single ranked user in the leaderboard.
+type LeaderboardEntry struct {
+	Rank      int     `json:"rank"`
+	UserID    uint    `json:"user_id"`
+	Username  string  `json:"username"`
+	AvatarURL *string `json:"avatar_url,omitempty"`
+	UserTier  string  `json:"user_tier"`
+	Count     int64   `json:"count"`
+}
+
+// LeaderboardResponse is the full leaderboard response including optional user rank.
+type LeaderboardResponse struct {
+	Entries   []LeaderboardEntry `json:"entries"`
+	Dimension string             `json:"dimension"`
+	Period    string             `json:"period"`
+	UserRank  *int               `json:"user_rank,omitempty"`
+}
+
 // ContributionEntry represents a single contribution in the history.
 type ContributionEntry struct {
 	ID         uint                   `json:"id"`

--- a/backend/internal/services/user/interfaces.go
+++ b/backend/internal/services/user/interfaces.go
@@ -6,4 +6,5 @@ import "psychic-homily-backend/internal/services/contracts"
 var (
 	_ contracts.UserServiceInterface               = (*UserService)(nil)
 	_ contracts.ContributorProfileServiceInterface = (*ContributorProfileService)(nil)
+	_ contracts.LeaderboardServiceInterface        = (*LeaderboardService)(nil)
 )

--- a/backend/internal/services/user/leaderboard.go
+++ b/backend/internal/services/user/leaderboard.go
@@ -1,0 +1,281 @@
+package user
+
+import (
+	"fmt"
+
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/db"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// LeaderboardService computes contributor leaderboards across multiple dimensions.
+type LeaderboardService struct {
+	db *gorm.DB
+}
+
+// NewLeaderboardService creates a new leaderboard service.
+func NewLeaderboardService(database *gorm.DB) *LeaderboardService {
+	if database == nil {
+		database = db.GetDB()
+	}
+	return &LeaderboardService{
+		db: database,
+	}
+}
+
+// validDimensions lists all supported leaderboard dimensions.
+var validDimensions = map[string]bool{
+	"overall":  true,
+	"shows":    true,
+	"venues":   true,
+	"tags":     true,
+	"edits":    true,
+	"requests": true,
+}
+
+// validPeriods lists all supported time periods.
+var validPeriods = map[string]bool{
+	"all_time": true,
+	"month":    true,
+	"week":     true,
+}
+
+// dimensionWeights are used for the "overall" dimension weighted sum.
+var dimensionWeights = map[string]int{
+	"shows":    25,
+	"venues":   15,
+	"tags":     10,
+	"edits":    25,
+	"requests": 10,
+}
+
+// GetLeaderboard returns ranked contributor entries for a given dimension and period.
+func (s *LeaderboardService) GetLeaderboard(dimension string, period string, limit int) ([]contracts.LeaderboardEntry, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	if !validDimensions[dimension] {
+		return nil, fmt.Errorf("invalid dimension: %s", dimension)
+	}
+	if !validPeriods[period] {
+		return nil, fmt.Errorf("invalid period: %s", period)
+	}
+
+	if limit <= 0 {
+		limit = 25
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	query, args := s.buildLeaderboardQuery(dimension, period, limit)
+
+	type leaderboardRow struct {
+		UserID    uint    `gorm:"column:user_id"`
+		Username  string  `gorm:"column:username"`
+		AvatarURL *string `gorm:"column:avatar_url"`
+		UserTier  string  `gorm:"column:user_tier"`
+		Count     int64   `gorm:"column:count"`
+	}
+
+	var rows []leaderboardRow
+	if err := s.db.Raw(query, args...).Scan(&rows).Error; err != nil {
+		return nil, fmt.Errorf("failed to get leaderboard: %w", err)
+	}
+
+	entries := make([]contracts.LeaderboardEntry, len(rows))
+	for i, row := range rows {
+		entries[i] = contracts.LeaderboardEntry{
+			Rank:      i + 1,
+			UserID:    row.UserID,
+			Username:  row.Username,
+			AvatarURL: row.AvatarURL,
+			UserTier:  row.UserTier,
+			Count:     row.Count,
+		}
+	}
+
+	return entries, nil
+}
+
+// GetUserRank returns the requesting user's rank for a given dimension and period.
+// Returns nil if the user has no contributions or their contributions are hidden.
+func (s *LeaderboardService) GetUserRank(userID uint, dimension string, period string) (*int, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	if !validDimensions[dimension] {
+		return nil, fmt.Errorf("invalid dimension: %s", dimension)
+	}
+	if !validPeriods[period] {
+		return nil, fmt.Errorf("invalid period: %s", period)
+	}
+
+	// Get the full leaderboard (uncapped) to find the user's position
+	query, args := s.buildLeaderboardQuery(dimension, period, 10000)
+
+	type rankRow struct {
+		UserID uint  `gorm:"column:user_id"`
+		Count  int64 `gorm:"column:count"`
+	}
+
+	var rows []rankRow
+	if err := s.db.Raw(query, args...).Scan(&rows).Error; err != nil {
+		return nil, fmt.Errorf("failed to compute user rank: %w", err)
+	}
+
+	for i, row := range rows {
+		if row.UserID == userID {
+			rank := i + 1
+			return &rank, nil
+		}
+	}
+
+	return nil, nil
+}
+
+// buildLeaderboardQuery constructs the SQL query for a given dimension and period.
+func (s *LeaderboardService) buildLeaderboardQuery(dimension string, period string, limit int) (string, []interface{}) {
+	periodFilter := buildPeriodFilter(period)
+
+	if dimension == "overall" {
+		return s.buildOverallQuery(periodFilter, limit)
+	}
+
+	countSubquery := buildCountSubquery(dimension, periodFilter)
+
+	query := fmt.Sprintf(`
+		SELECT sub.user_id, u.username, u.avatar_url, u.user_tier, sub.count
+		FROM (%s) sub
+		JOIN users u ON u.id = sub.user_id
+		WHERE u.is_active = true
+		  AND u.username IS NOT NULL
+		  AND (u.privacy_settings IS NULL OR u.privacy_settings->>'contributions' != 'hidden')
+		  AND sub.count > 0
+		ORDER BY sub.count DESC, u.username ASC
+		LIMIT ?
+	`, countSubquery)
+
+	return query, []interface{}{limit}
+}
+
+// buildOverallQuery constructs the weighted overall leaderboard query.
+func (s *LeaderboardService) buildOverallQuery(periodFilter string, limit int) (string, []interface{}) {
+	showsSubquery := buildCountSubquery("shows", periodFilter)
+	venuesSubquery := buildCountSubquery("venues", periodFilter)
+	tagsSubquery := buildCountSubquery("tags", periodFilter)
+	editsSubquery := buildCountSubquery("edits", periodFilter)
+	requestsSubquery := buildCountSubquery("requests", periodFilter)
+
+	query := fmt.Sprintf(`
+		SELECT
+			u.id AS user_id,
+			u.username,
+			u.avatar_url,
+			u.user_tier,
+			COALESCE(shows.count, 0) * %d +
+			COALESCE(venues.count, 0) * %d +
+			COALESCE(tags.count, 0) * %d +
+			COALESCE(edits.count, 0) * %d +
+			COALESCE(requests.count, 0) * %d AS count
+		FROM users u
+		LEFT JOIN (%s) shows ON shows.user_id = u.id
+		LEFT JOIN (%s) venues ON venues.user_id = u.id
+		LEFT JOIN (%s) tags ON tags.user_id = u.id
+		LEFT JOIN (%s) edits ON edits.user_id = u.id
+		LEFT JOIN (%s) requests ON requests.user_id = u.id
+		WHERE u.is_active = true
+		  AND u.username IS NOT NULL
+		  AND (u.privacy_settings IS NULL OR u.privacy_settings->>'contributions' != 'hidden')
+		  AND (
+		    COALESCE(shows.count, 0) +
+		    COALESCE(venues.count, 0) +
+		    COALESCE(tags.count, 0) +
+		    COALESCE(edits.count, 0) +
+		    COALESCE(requests.count, 0)
+		  ) > 0
+		ORDER BY count DESC, u.username ASC
+		LIMIT ?
+	`,
+		dimensionWeights["shows"],
+		dimensionWeights["venues"],
+		dimensionWeights["tags"],
+		dimensionWeights["edits"],
+		dimensionWeights["requests"],
+		showsSubquery,
+		venuesSubquery,
+		tagsSubquery,
+		editsSubquery,
+		requestsSubquery,
+	)
+
+	return query, []interface{}{limit}
+}
+
+// buildCountSubquery returns a SQL subquery that counts contributions for a dimension.
+func buildCountSubquery(dimension string, periodFilter string) string {
+	switch dimension {
+	case "shows":
+		return fmt.Sprintf(`
+			SELECT submitted_by AS user_id, COUNT(*) AS count
+			FROM shows
+			WHERE submitted_by IS NOT NULL %s
+			GROUP BY submitted_by
+		`, periodFilter)
+	case "venues":
+		return fmt.Sprintf(`
+			SELECT submitted_by AS user_id, COUNT(*) AS count
+			FROM venues
+			WHERE submitted_by IS NOT NULL %s
+			GROUP BY submitted_by
+		`, periodFilter)
+	case "tags":
+		return fmt.Sprintf(`
+			SELECT added_by_user_id AS user_id, COUNT(*) AS count
+			FROM entity_tags
+			WHERE 1=1 %s
+			GROUP BY added_by_user_id
+		`, periodFilter)
+	case "edits":
+		// Combine approved pending edits + revisions
+		return fmt.Sprintf(`
+			SELECT user_id, SUM(count) AS count FROM (
+				SELECT submitted_by AS user_id, COUNT(*) AS count
+				FROM pending_entity_edits
+				WHERE status = 'approved' %s
+				GROUP BY submitted_by
+				UNION ALL
+				SELECT user_id, COUNT(*) AS count
+				FROM revisions
+				WHERE 1=1 %s
+				GROUP BY user_id
+			) combined
+			GROUP BY user_id
+		`, periodFilter, periodFilter)
+	case "requests":
+		return fmt.Sprintf(`
+			SELECT fulfiller_id AS user_id, COUNT(*) AS count
+			FROM requests
+			WHERE fulfiller_id IS NOT NULL %s
+			GROUP BY fulfiller_id
+		`, periodFilter)
+	default:
+		// Should never happen — validated before call
+		return "SELECT 0 AS user_id, 0 AS count WHERE 1=0"
+	}
+}
+
+// buildPeriodFilter returns a SQL AND clause for date filtering.
+func buildPeriodFilter(period string) string {
+	switch period {
+	case "month":
+		return "AND created_at >= date_trunc('month', NOW())"
+	case "week":
+		return "AND created_at >= date_trunc('week', NOW())"
+	default:
+		return ""
+	}
+}

--- a/backend/internal/services/user/leaderboard_test.go
+++ b/backend/internal/services/user/leaderboard_test.go
@@ -1,0 +1,429 @@
+package user
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/testutil"
+)
+
+// =============================================================================
+// UNIT TESTS (No Database Required)
+// =============================================================================
+
+func TestLeaderboardService_NilDB(t *testing.T) {
+	svc := &LeaderboardService{db: nil}
+
+	t.Run("GetLeaderboard", func(t *testing.T) {
+		_, err := svc.GetLeaderboard("overall", "all_time", 25)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "database not initialized")
+	})
+
+	t.Run("GetUserRank", func(t *testing.T) {
+		_, err := svc.GetUserRank(1, "overall", "all_time")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "database not initialized")
+	})
+}
+
+func TestLeaderboardService_ValidDimensions(t *testing.T) {
+	svc := &LeaderboardService{db: nil} // nil db, validation happens first
+
+	for _, dim := range []string{"overall", "shows", "venues", "tags", "edits", "requests"} {
+		t.Run(dim, func(t *testing.T) {
+			assert.True(t, validDimensions[dim], "dimension should be valid: %s", dim)
+		})
+	}
+
+	t.Run("invalid_dimension", func(t *testing.T) {
+		_, err := svc.GetLeaderboard("invalid", "all_time", 25)
+		// With nil db, validation returns before db access
+		assert.Error(t, err)
+	})
+}
+
+func TestLeaderboardService_ValidPeriods(t *testing.T) {
+	for _, p := range []string{"all_time", "month", "week"} {
+		t.Run(p, func(t *testing.T) {
+			assert.True(t, validPeriods[p], "period should be valid: %s", p)
+		})
+	}
+}
+
+func TestBuildPeriodFilter(t *testing.T) {
+	t.Run("all_time", func(t *testing.T) {
+		assert.Equal(t, "", buildPeriodFilter("all_time"))
+	})
+	t.Run("month", func(t *testing.T) {
+		assert.Contains(t, buildPeriodFilter("month"), "date_trunc('month'")
+	})
+	t.Run("week", func(t *testing.T) {
+		assert.Contains(t, buildPeriodFilter("week"), "date_trunc('week'")
+	})
+}
+
+// =============================================================================
+// INTEGRATION TESTS (With Real Database)
+// =============================================================================
+
+type LeaderboardServiceIntegrationTestSuite struct {
+	suite.Suite
+	testDB             *testutil.TestDatabase
+	db                 *gorm.DB
+	leaderboardService *LeaderboardService
+}
+
+func (suite *LeaderboardServiceIntegrationTestSuite) SetupSuite() {
+	suite.testDB = testutil.SetupTestPostgres(suite.T())
+	suite.db = suite.testDB.DB
+	suite.leaderboardService = &LeaderboardService{db: suite.testDB.DB}
+}
+
+func (suite *LeaderboardServiceIntegrationTestSuite) TearDownSuite() {
+	suite.testDB.Cleanup()
+}
+
+func (suite *LeaderboardServiceIntegrationTestSuite) TearDownTest() {
+	sqlDB, err := suite.db.DB()
+	suite.Require().NoError(err)
+	_, _ = sqlDB.Exec("DELETE FROM pending_entity_edits")
+	_, _ = sqlDB.Exec("DELETE FROM revisions")
+	_, _ = sqlDB.Exec("DELETE FROM entity_tags")
+	_, _ = sqlDB.Exec("DELETE FROM tags")
+	_, _ = sqlDB.Exec("DELETE FROM requests")
+	_, _ = sqlDB.Exec("DELETE FROM show_artists")
+	_, _ = sqlDB.Exec("DELETE FROM show_venues")
+	_, _ = sqlDB.Exec("DELETE FROM shows")
+	_, _ = sqlDB.Exec("DELETE FROM venues")
+	_, _ = sqlDB.Exec("DELETE FROM users")
+}
+
+func TestLeaderboardServiceIntegrationTestSuite(t *testing.T) {
+	suite.Run(t, new(LeaderboardServiceIntegrationTestSuite))
+}
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+func (suite *LeaderboardServiceIntegrationTestSuite) createTestUser(username string) *models.User {
+	user := &models.User{
+		Email:             stringPtr(fmt.Sprintf("%s-%d@test.com", username, time.Now().UnixNano())),
+		Username:          stringPtr(username),
+		ProfileVisibility: "public",
+		IsActive:          true,
+		UserTier:          "contributor",
+	}
+	err := suite.db.Create(user).Error
+	suite.Require().NoError(err)
+	return user
+}
+
+func (suite *LeaderboardServiceIntegrationTestSuite) createUserWithHiddenContributions(username string) *models.User {
+	privJSON := `{"contributions":"hidden","saved_shows":"hidden","attendance":"hidden","following":"count_only","collections":"visible","last_active":"visible","profile_sections":"visible"}`
+	raw := json.RawMessage(privJSON)
+	user := &models.User{
+		Email:             stringPtr(fmt.Sprintf("%s-%d@test.com", username, time.Now().UnixNano())),
+		Username:          stringPtr(username),
+		ProfileVisibility: "public",
+		IsActive:          true,
+		UserTier:          "contributor",
+		PrivacySettings:   &raw,
+	}
+	err := suite.db.Create(user).Error
+	suite.Require().NoError(err)
+	return user
+}
+
+func (suite *LeaderboardServiceIntegrationTestSuite) createShow(submittedBy uint, title string) {
+	show := &models.Show{
+		Title:       title,
+		SubmittedBy: &submittedBy,
+		Status:      "approved",
+		EventDate:   time.Now(),
+	}
+	err := suite.db.Create(show).Error
+	suite.Require().NoError(err)
+}
+
+func (suite *LeaderboardServiceIntegrationTestSuite) createVenue(submittedBy uint, name string) {
+	slug := fmt.Sprintf("%s-%d", name, time.Now().UnixNano())
+	venue := &models.Venue{
+		Name:        name,
+		SubmittedBy: &submittedBy,
+		City:        "Phoenix",
+		State:       "AZ",
+		Slug:        &slug,
+	}
+	err := suite.db.Create(venue).Error
+	suite.Require().NoError(err)
+}
+
+func (suite *LeaderboardServiceIntegrationTestSuite) createTag(addedByUserID uint) {
+	// Create the tag first
+	tag := &models.Tag{
+		Name:     fmt.Sprintf("tag-%d", time.Now().UnixNano()),
+		Slug:     fmt.Sprintf("tag-%d", time.Now().UnixNano()),
+		Category: "genre",
+	}
+	err := suite.db.Create(tag).Error
+	suite.Require().NoError(err)
+
+	// Create the entity tag
+	entityTag := &models.EntityTag{
+		TagID:         tag.ID,
+		EntityType:    "artist",
+		EntityID:      1, // doesn't need to exist for count
+		AddedByUserID: addedByUserID,
+	}
+	err = suite.db.Create(entityTag).Error
+	suite.Require().NoError(err)
+}
+
+func (suite *LeaderboardServiceIntegrationTestSuite) createRevision(userID uint) {
+	rev := &models.Revision{
+		EntityType: "artist",
+		EntityID:   1,
+		UserID:     userID,
+		FieldChanges: func() *json.RawMessage {
+			raw := json.RawMessage(`[{"field":"name","old_value":"old","new_value":"new"}]`)
+			return &raw
+		}(),
+	}
+	err := suite.db.Create(rev).Error
+	suite.Require().NoError(err)
+}
+
+// =============================================================================
+// TESTS
+// =============================================================================
+
+func (suite *LeaderboardServiceIntegrationTestSuite) TestGetLeaderboard_ReturnsRankedUsers() {
+	alice := suite.createTestUser("alice")
+	bob := suite.createTestUser("bob")
+
+	// Alice submits 3 shows, Bob submits 1
+	suite.createShow(alice.ID, "Show 1")
+	suite.createShow(alice.ID, "Show 2")
+	suite.createShow(alice.ID, "Show 3")
+	suite.createShow(bob.ID, "Show 4")
+
+	entries, err := suite.leaderboardService.GetLeaderboard("shows", "all_time", 25)
+	suite.Require().NoError(err)
+	suite.Require().Len(entries, 2)
+
+	// Alice should be rank 1
+	suite.Equal(1, entries[0].Rank)
+	suite.Equal("alice", entries[0].Username)
+	suite.Equal(int64(3), entries[0].Count)
+
+	// Bob should be rank 2
+	suite.Equal(2, entries[1].Rank)
+	suite.Equal("bob", entries[1].Username)
+	suite.Equal(int64(1), entries[1].Count)
+}
+
+func (suite *LeaderboardServiceIntegrationTestSuite) TestGetLeaderboard_VenueDimension() {
+	alice := suite.createTestUser("alice-venues")
+
+	suite.createVenue(alice.ID, "Venue A")
+	suite.createVenue(alice.ID, "Venue B")
+
+	entries, err := suite.leaderboardService.GetLeaderboard("venues", "all_time", 25)
+	suite.Require().NoError(err)
+	suite.Require().Len(entries, 1)
+	suite.Equal("alice-venues", entries[0].Username)
+	suite.Equal(int64(2), entries[0].Count)
+}
+
+func (suite *LeaderboardServiceIntegrationTestSuite) TestGetLeaderboard_TagsDimension() {
+	alice := suite.createTestUser("alice-tags")
+
+	suite.createTag(alice.ID)
+	suite.createTag(alice.ID)
+
+	entries, err := suite.leaderboardService.GetLeaderboard("tags", "all_time", 25)
+	suite.Require().NoError(err)
+	suite.Require().Len(entries, 1)
+	suite.Equal("alice-tags", entries[0].Username)
+	suite.Equal(int64(2), entries[0].Count)
+}
+
+func (suite *LeaderboardServiceIntegrationTestSuite) TestGetLeaderboard_EditsDimension() {
+	alice := suite.createTestUser("alice-edits")
+
+	suite.createRevision(alice.ID)
+	suite.createRevision(alice.ID)
+	suite.createRevision(alice.ID)
+
+	entries, err := suite.leaderboardService.GetLeaderboard("edits", "all_time", 25)
+	suite.Require().NoError(err)
+	suite.Require().Len(entries, 1)
+	suite.Equal("alice-edits", entries[0].Username)
+	suite.Equal(int64(3), entries[0].Count)
+}
+
+func (suite *LeaderboardServiceIntegrationTestSuite) TestGetLeaderboard_RequestsDimension() {
+	alice := suite.createTestUser("alice-requests")
+
+	// Create a fulfilled request
+	desc := "Looking for setlist"
+	req := &models.Request{
+		Title:       "Find setlist",
+		Description: &desc,
+		EntityType:  "show",
+		Status:      "fulfilled",
+		RequesterID: alice.ID,
+		FulfillerID: &alice.ID,
+	}
+	err := suite.db.Create(req).Error
+	suite.Require().NoError(err)
+
+	entries, err := suite.leaderboardService.GetLeaderboard("requests", "all_time", 25)
+	suite.Require().NoError(err)
+	suite.Require().Len(entries, 1)
+	suite.Equal("alice-requests", entries[0].Username)
+	suite.Equal(int64(1), entries[0].Count)
+}
+
+func (suite *LeaderboardServiceIntegrationTestSuite) TestGetLeaderboard_OverallDimension() {
+	alice := suite.createTestUser("alice-overall")
+
+	// Alice submits shows and venues
+	suite.createShow(alice.ID, "Show Overall")
+	suite.createVenue(alice.ID, "Venue Overall")
+
+	entries, err := suite.leaderboardService.GetLeaderboard("overall", "all_time", 25)
+	suite.Require().NoError(err)
+	suite.Require().Len(entries, 1)
+
+	// Expected: 1 show * 25 + 1 venue * 15 = 40
+	suite.Equal(int64(40), entries[0].Count)
+	suite.Equal("alice-overall", entries[0].Username)
+}
+
+func (suite *LeaderboardServiceIntegrationTestSuite) TestGetLeaderboard_PeriodFiltering() {
+	alice := suite.createTestUser("alice-period")
+
+	// Create a show right now (should appear in week/month)
+	suite.createShow(alice.ID, "Recent Show")
+
+	// Week period
+	entries, err := suite.leaderboardService.GetLeaderboard("shows", "week", 25)
+	suite.Require().NoError(err)
+	suite.Require().Len(entries, 1)
+	suite.Equal("alice-period", entries[0].Username)
+
+	// Month period
+	entries, err = suite.leaderboardService.GetLeaderboard("shows", "month", 25)
+	suite.Require().NoError(err)
+	suite.Require().Len(entries, 1)
+	suite.Equal("alice-period", entries[0].Username)
+}
+
+func (suite *LeaderboardServiceIntegrationTestSuite) TestGetLeaderboard_PrivacyGating() {
+	visible := suite.createTestUser("visible-user")
+	hidden := suite.createUserWithHiddenContributions("hidden-user")
+
+	suite.createShow(visible.ID, "Visible Show")
+	suite.createShow(hidden.ID, "Hidden Show")
+
+	entries, err := suite.leaderboardService.GetLeaderboard("shows", "all_time", 25)
+	suite.Require().NoError(err)
+
+	// Only the visible user should appear
+	suite.Require().Len(entries, 1)
+	suite.Equal("visible-user", entries[0].Username)
+}
+
+func (suite *LeaderboardServiceIntegrationTestSuite) TestGetLeaderboard_DefaultLimit() {
+	// Should not error with default limit
+	entries, err := suite.leaderboardService.GetLeaderboard("overall", "all_time", 0)
+	suite.Require().NoError(err)
+	suite.NotNil(entries)
+	suite.Len(entries, 0) // empty database
+}
+
+func (suite *LeaderboardServiceIntegrationTestSuite) TestGetLeaderboard_EmptyReturnsEmptyArray() {
+	entries, err := suite.leaderboardService.GetLeaderboard("shows", "all_time", 25)
+	suite.Require().NoError(err)
+	suite.NotNil(entries)
+	suite.Len(entries, 0)
+}
+
+func (suite *LeaderboardServiceIntegrationTestSuite) TestGetLeaderboard_InvalidDimension() {
+	_, err := suite.leaderboardService.GetLeaderboard("invalid", "all_time", 25)
+	suite.Error(err)
+	suite.Contains(err.Error(), "invalid dimension")
+}
+
+func (suite *LeaderboardServiceIntegrationTestSuite) TestGetLeaderboard_InvalidPeriod() {
+	_, err := suite.leaderboardService.GetLeaderboard("overall", "invalid", 25)
+	suite.Error(err)
+	suite.Contains(err.Error(), "invalid period")
+}
+
+func (suite *LeaderboardServiceIntegrationTestSuite) TestGetUserRank() {
+	alice := suite.createTestUser("alice-rank")
+	bob := suite.createTestUser("bob-rank")
+
+	// Alice has more shows than Bob
+	suite.createShow(alice.ID, "Alice Show 1")
+	suite.createShow(alice.ID, "Alice Show 2")
+	suite.createShow(bob.ID, "Bob Show 1")
+
+	// Alice should be rank 1
+	rank, err := suite.leaderboardService.GetUserRank(alice.ID, "shows", "all_time")
+	suite.Require().NoError(err)
+	suite.Require().NotNil(rank)
+	suite.Equal(1, *rank)
+
+	// Bob should be rank 2
+	rank, err = suite.leaderboardService.GetUserRank(bob.ID, "shows", "all_time")
+	suite.Require().NoError(err)
+	suite.Require().NotNil(rank)
+	suite.Equal(2, *rank)
+}
+
+func (suite *LeaderboardServiceIntegrationTestSuite) TestGetUserRank_NotOnLeaderboard() {
+	alice := suite.createTestUser("alice-norank")
+
+	// Alice has no contributions
+	rank, err := suite.leaderboardService.GetUserRank(alice.ID, "shows", "all_time")
+	suite.Require().NoError(err)
+	suite.Nil(rank)
+}
+
+func (suite *LeaderboardServiceIntegrationTestSuite) TestGetLeaderboard_ExcludesInactiveUsers() {
+	active := suite.createTestUser("active-user")
+	inactive := suite.createTestUser("inactive-user")
+
+	suite.createShow(active.ID, "Active Show")
+	suite.createShow(inactive.ID, "Inactive Show")
+
+	// Deactivate user
+	suite.db.Model(inactive).Update("is_active", false)
+
+	entries, err := suite.leaderboardService.GetLeaderboard("shows", "all_time", 25)
+	suite.Require().NoError(err)
+	suite.Require().Len(entries, 1)
+	suite.Equal("active-user", entries[0].Username)
+}
+
+func (suite *LeaderboardServiceIntegrationTestSuite) TestGetLeaderboard_LimitClamped() {
+	alice := suite.createTestUser("alice-limit")
+	suite.createShow(alice.ID, "Show Limit")
+
+	// Request limit over max (100) — should be clamped
+	entries, err := suite.leaderboardService.GetLeaderboard("shows", "all_time", 200)
+	suite.Require().NoError(err)
+	suite.Require().Len(entries, 1) // Only one user in the db
+}

--- a/frontend/app/community/leaderboard/page.tsx
+++ b/frontend/app/community/leaderboard/page.tsx
@@ -1,0 +1,39 @@
+import { Suspense } from 'react'
+import { LoadingSpinner } from '@/components/shared'
+import { LeaderboardPage } from '@/features/community'
+
+export const metadata = {
+  title: 'Leaderboard',
+  description: 'Top contributors to the Psychic Homily music knowledge graph.',
+  alternates: {
+    canonical: 'https://psychichomily.com/community/leaderboard',
+  },
+  openGraph: {
+    title: 'Leaderboard | Psychic Homily',
+    description: 'Top contributors to the Psychic Homily music knowledge graph.',
+    url: '/community/leaderboard',
+    type: 'website',
+  },
+}
+
+export default function LeaderboardRoute() {
+  return (
+    <div className="flex min-h-screen items-start justify-center">
+      <main className="w-full max-w-3xl px-4 py-8 md:px-8">
+        <h1 className="text-3xl font-bold text-center mb-2">Leaderboard</h1>
+        <p className="text-center text-muted-foreground mb-8 max-w-lg mx-auto">
+          Top contributors building the music knowledge graph.
+        </p>
+        <Suspense
+          fallback={
+            <div className="flex justify-center items-center py-12">
+              <LoadingSpinner />
+            </div>
+          }
+        >
+          <LeaderboardPage />
+        </Suspense>
+      </main>
+    </div>
+  )
+}

--- a/frontend/components/layout/CommandPalette.tsx
+++ b/frontend/components/layout/CommandPalette.tsx
@@ -15,7 +15,7 @@ import {
   Calendar, Mic2, MapPin, Disc3, Tag, Tags, Tent, BookOpen, Headphones, Send,
   Library, LayoutList, MessageSquarePlus, Settings, Search, Clock, X, Globe,
   TrendingUp, LayoutDashboard, Upload, BadgeCheck, Flag, ScrollText, Users, Workflow,
-  ClipboardCheck, BarChart3, Music, Bell, HeartHandshake, ShieldCheck, Loader2,
+  ClipboardCheck, BarChart3, Music, Bell, HeartHandshake, ShieldCheck, Loader2, Trophy,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import { useAuthContext } from '@/lib/context/AuthContext'
@@ -98,6 +98,12 @@ const routes: RouteItem[] = [
     href: '/contribute',
     icon: HeartHandshake,
     keywords: ['contribute', 'help', 'data quality', 'missing', 'opportunities', 'improve'],
+  },
+  {
+    label: 'Leaderboard',
+    href: '/community/leaderboard',
+    icon: Trophy,
+    keywords: ['leaderboard', 'top', 'contributors', 'rankings', 'community', 'competition'],
   },
   {
     label: 'Requests',

--- a/frontend/components/layout/Sidebar.test.tsx
+++ b/frontend/components/layout/Sidebar.test.tsx
@@ -30,7 +30,7 @@ describe('sidebarGroups', () => {
 
   it('Community contains Contribute, Requests, Blog, DJ Sets, Substack, Submissions', () => {
     const community = sidebarGroups.find(g => g.label === 'Community')!
-    expect(community.items.map(i => i.label)).toEqual(['Contribute', 'Requests', 'Blog', 'DJ Sets', 'Substack', 'Submissions'])
+    expect(community.items.map(i => i.label)).toEqual(['Contribute', 'Leaderboard', 'Requests', 'Blog', 'DJ Sets', 'Substack', 'Submissions'])
   })
 
   it('only Substack is marked external', () => {

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -5,7 +5,7 @@ import { usePathname } from 'next/navigation'
 import {
   Calendar, Mic2, MapPin, Disc3, Tag, Tags, Tent, BookOpen, Headphones, Newspaper,
   Send, Library, LayoutList, MessageSquarePlus, Settings, Shield, PanelLeftClose, PanelLeft,
-  ExternalLink, Globe, TrendingUp, Bell, HeartHandshake,
+  ExternalLink, Globe, TrendingUp, Bell, HeartHandshake, Trophy,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import { cn } from '@/lib/utils'
@@ -46,6 +46,7 @@ export const sidebarGroups: SidebarGroup[] = [
     label: 'Community',
     items: [
       { href: '/contribute', label: 'Contribute', icon: HeartHandshake },
+      { href: '/community/leaderboard', label: 'Leaderboard', icon: Trophy },
       { href: '/requests', label: 'Requests', icon: MessageSquarePlus },
       { href: '/blog', label: 'Blog', icon: BookOpen },
       { href: '/dj-sets', label: 'DJ Sets', icon: Headphones },

--- a/frontend/features/community/components/LeaderboardPage.test.tsx
+++ b/frontend/features/community/components/LeaderboardPage.test.tsx
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders } from '@/test/utils'
+
+const mockApiRequest = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    COMMUNITY: {
+      LEADERBOARD: '/community/leaderboard',
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    community: {
+      leaderboard: (dimension: string, period: string, limit?: number) =>
+        ['community', 'leaderboard', dimension, period, limit],
+    },
+  },
+}))
+
+vi.mock('@/lib/context/AuthContext', () => ({
+  useAuthContext: () => ({
+    user: { id: 1, username: 'currentuser' },
+    isAuthenticated: true,
+  }),
+}))
+
+// Mock next/navigation
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
+  usePathname: () => '/community/leaderboard',
+  useSearchParams: () => new URLSearchParams(),
+}))
+
+import { LeaderboardPage } from './LeaderboardPage'
+
+const mockLeaderboardData = {
+  entries: [
+    {
+      rank: 1,
+      user_id: 2,
+      username: 'alice',
+      avatar_url: null,
+      user_tier: 'trusted_contributor',
+      count: 150,
+    },
+    {
+      rank: 2,
+      user_id: 1,
+      username: 'currentuser',
+      avatar_url: null,
+      user_tier: 'contributor',
+      count: 100,
+    },
+    {
+      rank: 3,
+      user_id: 3,
+      username: 'bob',
+      avatar_url: null,
+      user_tier: 'new_user',
+      count: 50,
+    },
+  ],
+  dimension: 'overall',
+  period: 'all_time',
+}
+
+describe('LeaderboardPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('renders leaderboard table with entries', async () => {
+    mockApiRequest.mockResolvedValueOnce(mockLeaderboardData)
+
+    renderWithProviders(<LeaderboardPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('alice')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('currentuser')).toBeInTheDocument()
+    expect(screen.getByText('bob')).toBeInTheDocument()
+    expect(screen.getByText('150')).toBeInTheDocument()
+    expect(screen.getByText('100')).toBeInTheDocument()
+    expect(screen.getByText('50')).toBeInTheDocument()
+  })
+
+  it('highlights current user row', async () => {
+    mockApiRequest.mockResolvedValueOnce(mockLeaderboardData)
+
+    renderWithProviders(<LeaderboardPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('currentuser')).toBeInTheDocument()
+    })
+
+    // Current user should have "(you)" indicator
+    expect(screen.getByText('(you)')).toBeInTheDocument()
+  })
+
+  it('shows tier badges', async () => {
+    mockApiRequest.mockResolvedValueOnce(mockLeaderboardData)
+
+    renderWithProviders(<LeaderboardPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Trusted')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('Contributor')).toBeInTheDocument()
+    expect(screen.getByText('New')).toBeInTheDocument()
+  })
+
+  it('tab switching changes dimension', async () => {
+    const user = userEvent.setup()
+    mockApiRequest.mockResolvedValue(mockLeaderboardData)
+
+    renderWithProviders(<LeaderboardPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('alice')).toBeInTheDocument()
+    })
+
+    // Click the "Shows" tab
+    await user.click(screen.getByRole('tab', { name: 'Shows' }))
+
+    // Should refetch with new dimension
+    await waitFor(() => {
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        expect.stringContaining('dimension=shows'),
+        expect.any(Object),
+      )
+    })
+  })
+
+  it('period filter works', async () => {
+    const user = userEvent.setup()
+    mockApiRequest.mockResolvedValue(mockLeaderboardData)
+
+    renderWithProviders(<LeaderboardPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('alice')).toBeInTheDocument()
+    })
+
+    // Change period to "This Week"
+    const select = screen.getByRole('combobox')
+    await user.selectOptions(select, 'week')
+
+    await waitFor(() => {
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        expect.stringContaining('period=week'),
+        expect.any(Object),
+      )
+    })
+  })
+
+  it('shows empty state when no entries', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      entries: [],
+      dimension: 'overall',
+      period: 'all_time',
+    })
+
+    renderWithProviders(<LeaderboardPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('No contributions yet')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText(/Be the first/)).toBeInTheDocument()
+  })
+
+  it('shows loading skeleton', () => {
+    // Never resolve the request to keep loading state
+    mockApiRequest.mockReturnValueOnce(new Promise(() => {}))
+
+    renderWithProviders(<LeaderboardPage />)
+
+    // Skeleton items should be visible (animated pulse divs)
+    const skeletons = document.querySelectorAll('.animate-pulse')
+    expect(skeletons.length).toBeGreaterThan(0)
+  })
+
+  it('links to user profiles', async () => {
+    mockApiRequest.mockResolvedValueOnce(mockLeaderboardData)
+
+    renderWithProviders(<LeaderboardPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('alice')).toBeInTheDocument()
+    })
+
+    const aliceLink = screen.getByText('alice').closest('a')
+    expect(aliceLink).toHaveAttribute('href', '/users/alice')
+
+    const bobLink = screen.getByText('bob').closest('a')
+    expect(bobLink).toHaveAttribute('href', '/users/bob')
+  })
+
+  it('renders all dimension tabs', async () => {
+    mockApiRequest.mockResolvedValueOnce(mockLeaderboardData)
+
+    renderWithProviders(<LeaderboardPage />)
+
+    expect(screen.getByRole('tab', { name: 'Overall' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Shows' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Venues' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Tags' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Edits' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Requests' })).toBeInTheDocument()
+  })
+})

--- a/frontend/features/community/components/LeaderboardPage.tsx
+++ b/frontend/features/community/components/LeaderboardPage.tsx
@@ -176,7 +176,7 @@ export function LeaderboardPage() {
             <LeaderboardRow
               key={entry.user_id}
               entry={entry}
-              isCurrentUser={user?.id === entry.user_id}
+              isCurrentUser={Number(user?.id) === entry.user_id}
             />
           ))}
         </div>

--- a/frontend/features/community/components/LeaderboardPage.tsx
+++ b/frontend/features/community/components/LeaderboardPage.tsx
@@ -1,0 +1,203 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { Trophy, Medal, Award, Crown } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { useAuthContext } from '@/lib/context/AuthContext'
+import { useLeaderboard } from '../hooks/useLeaderboard'
+import type { LeaderboardDimension, LeaderboardPeriod, LeaderboardEntry } from '../types'
+import { DIMENSION_LABELS, PERIOD_LABELS } from '../types'
+
+const dimensions: LeaderboardDimension[] = ['overall', 'shows', 'venues', 'tags', 'edits', 'requests']
+const periods: LeaderboardPeriod[] = ['all_time', 'month', 'week']
+
+function RankIcon({ rank }: { rank: number }) {
+  if (rank === 1) return <Trophy className="h-5 w-5 text-yellow-500" />
+  if (rank === 2) return <Medal className="h-5 w-5 text-gray-400" />
+  if (rank === 3) return <Award className="h-5 w-5 text-amber-600" />
+  return <span className="text-sm font-mono text-muted-foreground w-5 text-center">{rank}</span>
+}
+
+function TierBadge({ tier }: { tier: string }) {
+  const labels: Record<string, string> = {
+    new_user: 'New',
+    contributor: 'Contributor',
+    trusted_contributor: 'Trusted',
+    moderator: 'Moderator',
+    admin: 'Admin',
+  }
+  const colors: Record<string, string> = {
+    new_user: 'bg-muted text-muted-foreground',
+    contributor: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
+    trusted_contributor: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300',
+    moderator: 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300',
+    admin: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300',
+  }
+  return (
+    <span className={cn('inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium', colors[tier] || colors.new_user)}>
+      {labels[tier] || tier}
+    </span>
+  )
+}
+
+function LeaderboardSkeleton() {
+  return (
+    <div className="space-y-2">
+      {Array.from({ length: 10 }).map((_, i) => (
+        <div key={i} className="flex items-center gap-4 rounded-lg border border-border p-3 animate-pulse">
+          <div className="w-5 h-5 rounded-full bg-muted" />
+          <div className="w-8 h-8 rounded-full bg-muted" />
+          <div className="flex-1 space-y-1">
+            <div className="h-4 w-32 rounded bg-muted" />
+          </div>
+          <div className="h-4 w-16 rounded bg-muted" />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function LeaderboardRow({ entry, isCurrentUser }: { entry: LeaderboardEntry; isCurrentUser: boolean }) {
+  return (
+    <div
+      className={cn(
+        'flex items-center gap-4 rounded-lg border p-3 transition-colors',
+        isCurrentUser
+          ? 'border-primary/50 bg-primary/5'
+          : 'border-border hover:bg-muted/50'
+      )}
+    >
+      <div className="flex items-center justify-center w-8">
+        <RankIcon rank={entry.rank} />
+      </div>
+
+      <div className="flex h-8 w-8 items-center justify-center rounded-full bg-muted text-sm font-medium">
+        {entry.avatar_url ? (
+          <img
+            src={entry.avatar_url}
+            alt={entry.username}
+            className="h-8 w-8 rounded-full object-cover"
+          />
+        ) : (
+          entry.username.charAt(0).toUpperCase()
+        )}
+      </div>
+
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <Link
+            href={`/users/${entry.username}`}
+            className="text-sm font-medium hover:underline truncate"
+          >
+            {entry.username}
+          </Link>
+          <TierBadge tier={entry.user_tier} />
+          {isCurrentUser && (
+            <span className="text-xs text-primary font-medium">(you)</span>
+          )}
+        </div>
+      </div>
+
+      <div className="text-sm font-semibold tabular-nums">
+        {entry.count.toLocaleString()}
+      </div>
+    </div>
+  )
+}
+
+export function LeaderboardPage() {
+  const [dimension, setDimension] = useState<LeaderboardDimension>('overall')
+  const [period, setPeriod] = useState<LeaderboardPeriod>('all_time')
+  const { user } = useAuthContext()
+
+  const { data, isLoading, isError } = useLeaderboard(dimension, period)
+
+  return (
+    <div className="space-y-6">
+      {/* Dimension tabs */}
+      <div className="flex flex-wrap gap-1 rounded-lg bg-muted p-1" role="tablist">
+        {dimensions.map((dim) => (
+          <button
+            key={dim}
+            role="tab"
+            aria-selected={dimension === dim}
+            onClick={() => setDimension(dim)}
+            className={cn(
+              'rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
+              dimension === dim
+                ? 'bg-background text-foreground shadow-sm'
+                : 'text-muted-foreground hover:text-foreground'
+            )}
+          >
+            {DIMENSION_LABELS[dim]}
+          </button>
+        ))}
+      </div>
+
+      {/* Period filter */}
+      <div className="flex items-center gap-2">
+        <span className="text-sm text-muted-foreground">Period:</span>
+        <select
+          value={period}
+          onChange={(e) => setPeriod(e.target.value as LeaderboardPeriod)}
+          className="rounded-md border border-input bg-background px-3 py-1.5 text-sm"
+        >
+          {periods.map((p) => (
+            <option key={p} value={p}>
+              {PERIOD_LABELS[p]}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Leaderboard content */}
+      {isLoading ? (
+        <LeaderboardSkeleton />
+      ) : isError ? (
+        <div className="text-center py-12 text-muted-foreground">
+          Failed to load leaderboard. Please try again.
+        </div>
+      ) : data && data.entries.length === 0 ? (
+        <div className="text-center py-12">
+          <Crown className="mx-auto h-12 w-12 text-muted-foreground/50 mb-4" />
+          <h3 className="text-lg font-medium text-foreground mb-1">No contributions yet</h3>
+          <p className="text-sm text-muted-foreground">
+            Be the first! Start by{' '}
+            <Link href="/contribute" className="text-primary hover:underline">
+              contributing
+            </Link>{' '}
+            to the knowledge graph.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {data?.entries.map((entry) => (
+            <LeaderboardRow
+              key={entry.user_id}
+              entry={entry}
+              isCurrentUser={user?.id === entry.user_id}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Current user's rank */}
+      {data?.user_rank && !data.entries.some((e) => e.user_id === user?.id) && (
+        <div className="border-t border-border pt-4">
+          <p className="text-sm text-muted-foreground mb-2">Your rank</p>
+          <div className="flex items-center gap-4 rounded-lg border border-primary/50 bg-primary/5 p-3">
+            <div className="flex items-center justify-center w-8">
+              <span className="text-sm font-mono text-muted-foreground w-5 text-center">
+                {data.user_rank}
+              </span>
+            </div>
+            <span className="text-sm font-medium">
+              You are ranked #{data.user_rank}
+            </span>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/features/community/components/LeaderboardPage.tsx
+++ b/frontend/features/community/components/LeaderboardPage.tsx
@@ -183,7 +183,7 @@ export function LeaderboardPage() {
       )}
 
       {/* Current user's rank */}
-      {data?.user_rank && !data.entries.some((e) => e.user_id === user?.id) && (
+      {data?.user_rank && !data.entries.some((e) => e.user_id === Number(user?.id)) && (
         <div className="border-t border-border pt-4">
           <p className="text-sm text-muted-foreground mb-2">Your rank</p>
           <div className="flex items-center gap-4 rounded-lg border border-primary/50 bg-primary/5 p-3">

--- a/frontend/features/community/components/index.ts
+++ b/frontend/features/community/components/index.ts
@@ -1,0 +1,1 @@
+export { LeaderboardPage } from './LeaderboardPage'

--- a/frontend/features/community/hooks/index.ts
+++ b/frontend/features/community/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useLeaderboard } from './useLeaderboard'

--- a/frontend/features/community/hooks/useLeaderboard.test.tsx
+++ b/frontend/features/community/hooks/useLeaderboard.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { createWrapper } from '@/test/utils'
+
+const mockApiRequest = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    COMMUNITY: {
+      LEADERBOARD: '/community/leaderboard',
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    community: {
+      leaderboard: (dimension: string, period: string, limit?: number) =>
+        ['community', 'leaderboard', dimension, period, limit],
+    },
+  },
+}))
+
+import { useLeaderboard } from './useLeaderboard'
+
+describe('useLeaderboard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches leaderboard with default params', async () => {
+    const mockData = {
+      entries: [
+        {
+          rank: 1,
+          user_id: 1,
+          username: 'alice',
+          user_tier: 'contributor',
+          count: 42,
+        },
+      ],
+      dimension: 'overall',
+      period: 'all_time',
+    }
+    mockApiRequest.mockResolvedValueOnce(mockData)
+
+    const { result } = renderHook(() => useLeaderboard(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/community/leaderboard?dimension=overall&period=all_time',
+      { method: 'GET' },
+    )
+    expect(result.current.data?.entries).toHaveLength(1)
+    expect(result.current.data?.entries[0].username).toBe('alice')
+  })
+
+  it('passes dimension and period params', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      entries: [],
+      dimension: 'shows',
+      period: 'week',
+    })
+
+    const { result } = renderHook(() => useLeaderboard('shows', 'week'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/community/leaderboard?dimension=shows&period=week',
+      { method: 'GET' },
+    )
+  })
+
+  it('passes limit param when provided', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      entries: [],
+      dimension: 'overall',
+      period: 'all_time',
+    })
+
+    const { result } = renderHook(() => useLeaderboard('overall', 'all_time', 10), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/community/leaderboard?dimension=overall&period=all_time&limit=10',
+      { method: 'GET' },
+    )
+  })
+
+  it('includes user_rank in response when available', async () => {
+    const mockData = {
+      entries: [
+        {
+          rank: 1,
+          user_id: 2,
+          username: 'top-user',
+          user_tier: 'trusted_contributor',
+          count: 100,
+        },
+      ],
+      dimension: 'overall',
+      period: 'all_time',
+      user_rank: 5,
+    }
+    mockApiRequest.mockResolvedValueOnce(mockData)
+
+    const { result } = renderHook(() => useLeaderboard(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data?.user_rank).toBe(5)
+  })
+})

--- a/frontend/features/community/hooks/useLeaderboard.ts
+++ b/frontend/features/community/hooks/useLeaderboard.ts
@@ -1,0 +1,39 @@
+'use client'
+
+/**
+ * Leaderboard Hook
+ *
+ * TanStack Query hook for fetching contributor leaderboard data.
+ */
+
+import { useQuery } from '@tanstack/react-query'
+import { apiRequest, API_ENDPOINTS } from '@/lib/api'
+import { queryKeys } from '@/lib/queryClient'
+import type { LeaderboardResponse, LeaderboardDimension, LeaderboardPeriod } from '../types'
+
+/**
+ * Hook to fetch the contributor leaderboard.
+ */
+export function useLeaderboard(
+  dimension: LeaderboardDimension = 'overall',
+  period: LeaderboardPeriod = 'all_time',
+  limit?: number,
+) {
+  const params = new URLSearchParams()
+  params.set('dimension', dimension)
+  params.set('period', period)
+  if (limit) {
+    params.set('limit', String(limit))
+  }
+
+  return useQuery({
+    queryKey: queryKeys.community.leaderboard(dimension, period, limit),
+    queryFn: async (): Promise<LeaderboardResponse> => {
+      return apiRequest<LeaderboardResponse>(
+        `${API_ENDPOINTS.COMMUNITY.LEADERBOARD}?${params.toString()}`,
+        { method: 'GET' },
+      )
+    },
+    staleTime: 2 * 60 * 1000, // 2 minutes
+  })
+}

--- a/frontend/features/community/index.ts
+++ b/frontend/features/community/index.ts
@@ -1,0 +1,17 @@
+// Public API for the community feature module.
+// Other features should import from '@/features/community', not from internal paths.
+
+// Types
+export type {
+  LeaderboardDimension,
+  LeaderboardPeriod,
+  LeaderboardEntry,
+  LeaderboardResponse,
+} from './types'
+export { DIMENSION_LABELS, PERIOD_LABELS } from './types'
+
+// Hooks
+export { useLeaderboard } from './hooks'
+
+// Components
+export { LeaderboardPage } from './components'

--- a/frontend/features/community/types.ts
+++ b/frontend/features/community/types.ts
@@ -1,0 +1,35 @@
+// Leaderboard types
+
+export type LeaderboardDimension = 'overall' | 'shows' | 'venues' | 'tags' | 'edits' | 'requests'
+export type LeaderboardPeriod = 'all_time' | 'month' | 'week'
+
+export interface LeaderboardEntry {
+  rank: number
+  user_id: number
+  username: string
+  avatar_url?: string
+  user_tier: string
+  count: number
+}
+
+export interface LeaderboardResponse {
+  entries: LeaderboardEntry[]
+  dimension: string
+  period: string
+  user_rank?: number
+}
+
+export const DIMENSION_LABELS: Record<LeaderboardDimension, string> = {
+  overall: 'Overall',
+  shows: 'Shows',
+  venues: 'Venues',
+  tags: 'Tags',
+  edits: 'Edits',
+  requests: 'Requests',
+}
+
+export const PERIOD_LABELS: Record<LeaderboardPeriod, string> = {
+  all_time: 'All Time',
+  month: 'This Month',
+  week: 'This Week',
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -332,6 +332,11 @@ export const API_ENDPOINTS = {
     GENRES: (slug: string) => `${API_BASE_URL}/scenes/${slug}/genres`,
   },
 
+  // Community endpoints (public)
+  COMMUNITY: {
+    LEADERBOARD: `${API_BASE_URL}/community/leaderboard`,
+  },
+
   // Charts endpoints (public)
   CHARTS: {
     OVERVIEW: `${API_BASE_URL}/charts/overview`,

--- a/frontend/lib/queryClient.ts
+++ b/frontend/lib/queryClient.ts
@@ -301,6 +301,12 @@ export const queryKeys = {
     genres: (slug: string) => ['scenes', 'genres', slug] as const,
   },
 
+  // Community queries (public)
+  community: {
+    leaderboard: (dimension: string, period: string, limit?: number) =>
+      ['community', 'leaderboard', dimension, period, limit] as const,
+  },
+
   // Charts queries (public)
   charts: {
     all: ['charts'] as const,


### PR DESCRIPTION
## Summary
- Backend: `LeaderboardService` with `GetLeaderboard()` — 6 dimensions (overall, shows, venues, tags, edits, requests), 3 time periods (all_time, month, week), privacy-gated, default top 25
- Handler: `GET /community/leaderboard` with optional auth for user's own rank
- Frontend: `/community/leaderboard` page with dimension tabs, time filter, ranked contributor cards with avatars + tier badges
- Sidebar nav + Cmd+K integration
- `features/community/` module with hooks and types

## Test plan
- [ ] Backend builds cleanly
- [ ] Leaderboard service tests pass
- [ ] Frontend page renders with tabs and time filter
- [ ] Privacy settings respected (hidden users excluded)
- [ ] Sidebar and Cmd+K entries work

Closes PSY-197
Closes PSY-134

🤖 Generated with [Claude Code](https://claude.com/claude-code)