### PR TITLE
Extend saved city filter defaults to Artists and Venues pages (PSY-214)

### DIFF
--- a/frontend/features/artists/components/ArtistList.test.tsx
+++ b/frontend/features/artists/components/ArtistList.test.tsx
@@ -6,9 +6,10 @@ import type { ArtistListItem } from '../types'
 
 // Mock next/navigation
 const mockPush = vi.fn()
+const mockReplace = vi.fn()
 const mockGet = vi.fn()
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({ push: mockPush }),
+  useRouter: () => ({ push: mockPush, replace: mockReplace }),
   useSearchParams: () => ({
     get: mockGet,
   }),
@@ -27,6 +28,19 @@ vi.mock('@/lib/hooks/common/useDensity', () => ({
   useDensity: (key: string) => mockUseDensity(key),
 }))
 
+// Mock auth hooks
+const mockUseProfile = vi.fn()
+const mockUseIsAuthenticated = vi.fn()
+vi.mock('@/features/auth', () => ({
+  useProfile: () => mockUseProfile(),
+  useIsAuthenticated: () => mockUseIsAuthenticated(),
+}))
+
+// Mock SaveDefaultsButton
+vi.mock('@/components/filters/SaveDefaultsButton', () => ({
+  SaveDefaultsButton: () => <div data-testid="save-defaults-button">SaveDefaultsButton</div>,
+}))
+
 // Mock child components that are complex
 vi.mock('./ArtistSearch', () => ({
   ArtistSearch: () => <div data-testid="artist-search">ArtistSearch</div>,
@@ -36,10 +50,12 @@ vi.mock('@/components/filters', () => ({
   CityFilters: ({
     onFilterChange,
     selectedCities,
+    children,
   }: {
     onFilterChange: (cities: { city: string; state: string }[]) => void
     selectedCities: { city: string; state: string }[]
     cities: unknown[]
+    children?: React.ReactNode
   }) => (
     <div data-testid="city-filters">
       <span data-testid="selected-count">{selectedCities.length}</span>
@@ -49,6 +65,7 @@ vi.mock('@/components/filters', () => ({
       >
         Clear
       </button>
+      {children}
     </div>
   ),
 }))
@@ -92,6 +109,8 @@ describe('ArtistList', () => {
     vi.clearAllMocks()
     mockGet.mockReturnValue(null)
     mockUseDensity.mockReturnValue({ density: 'comfortable', setDensity: vi.fn() })
+    mockUseProfile.mockReturnValue({ data: null })
+    mockUseIsAuthenticated.mockReturnValue({ isAuthenticated: false })
     mockUseArtistCities.mockReturnValue({
       data: { cities: [] },
       isLoading: false,

--- a/frontend/features/artists/components/ArtistList.tsx
+++ b/frontend/features/artists/components/ArtistList.tsx
@@ -1,11 +1,13 @@
 'use client'
 
-import { useMemo, useTransition } from 'react'
+import { useMemo, useTransition, useRef, useEffect } from 'react'
 import { useSearchParams, useRouter } from 'next/navigation'
 import { useArtists, useArtistCities } from '../hooks/useArtists'
+import { useProfile, useIsAuthenticated } from '@/features/auth'
 import { ArtistCard } from './ArtistCard'
 import { ArtistSearch } from './ArtistSearch'
 import { CityFilters, type CityWithCount, type CityState } from '@/components/filters'
+import { SaveDefaultsButton } from '@/components/filters/SaveDefaultsButton'
 import { LoadingSpinner, DensityToggle } from '@/components/shared'
 import { useDensity } from '@/lib/hooks/common/useDensity'
 import { Button } from '@/components/ui/button'
@@ -27,10 +29,20 @@ function buildCitiesParam(cities: CityState[]): string {
   return cities.map(c => `${c.city},${c.state}`).join('|')
 }
 
+/** Compare two city arrays for equality (order-insensitive) */
+function citiesEqual(a: CityState[], b: CityState[]): boolean {
+  if (a.length !== b.length) return false
+  const setA = new Set(a.map(c => `${c.city}|${c.state}`))
+  return b.every(c => setA.has(`${c.city}|${c.state}`))
+}
+
 export function ArtistList() {
   const router = useRouter()
   const searchParams = useSearchParams()
+  const { isAuthenticated } = useIsAuthenticated()
   const [isPending, startTransition] = useTransition()
+  const { data: profileData } = useProfile()
+  const hasAppliedDefaults = useRef(false)
   const { density, setDensity } = useDensity('artists')
 
   // Parse multi-city from URL
@@ -38,6 +50,29 @@ export function ArtistList() {
   const selectedCities: CityState[] = useMemo(() => {
     return parseCitiesParam(citiesParam)
   }, [citiesParam])
+
+  // Read favorites from profile
+  const favoriteCities: CityState[] = useMemo(() => {
+    const prefs = profileData?.user?.preferences
+    if (!prefs?.favorite_cities) return []
+    return prefs.favorite_cities
+  }, [profileData?.user?.preferences])
+
+  // Apply favorites as default URL params on initial load (no URL params + not yet applied)
+  useEffect(() => {
+    if (
+      !hasAppliedDefaults.current &&
+      favoriteCities.length > 0 &&
+      !citiesParam
+    ) {
+      hasAppliedDefaults.current = true
+      const params = new URLSearchParams()
+      params.set('cities', buildCitiesParam(favoriteCities))
+      startTransition(() => {
+        router.replace(`/artists?${params.toString()}`, { scroll: false })
+      })
+    }
+  }, [favoriteCities, citiesParam, router])
 
   const { data: citiesData, isLoading: citiesLoading, isFetching: citiesFetching } = useArtistCities()
   const { data, isLoading, isFetching, error, refetch } = useArtists({
@@ -78,6 +113,9 @@ export function ArtistList() {
     )
   }
 
+  // Determine if "Save as default" / "Clear defaults" should show
+  const selectionDiffersFromFavorites = !citiesEqual(selectedCities, favoriteCities)
+
   // Map ArtistCity to CityWithCount
   const cities: CityWithCount[] = citiesData?.cities?.map(c => ({
     city: c.city,
@@ -96,7 +134,14 @@ export function ArtistList() {
             cities={cities}
             selectedCities={selectedCities}
             onFilterChange={handleFilterChange}
-          />
+          >
+            {isAuthenticated && selectionDiffersFromFavorites && (
+              <SaveDefaultsButton
+                selectedCities={selectedCities}
+                favoriteCities={favoriteCities}
+              />
+            )}
+          </CityFilters>
         )}
       </div>
 

--- a/frontend/features/venues/components/VenueList.tsx
+++ b/frontend/features/venues/components/VenueList.tsx
@@ -1,12 +1,14 @@
 'use client'
 
-import { useState, useCallback, useMemo, useTransition } from 'react'
+import { useState, useCallback, useMemo, useTransition, useRef, useEffect } from 'react'
 import { useSearchParams, useRouter } from 'next/navigation'
 import { useVenues, useVenueCities } from '../hooks/useVenues'
+import { useProfile, useIsAuthenticated } from '@/features/auth'
 import type { VenueWithShowCount } from '../types'
 import { VenueCard } from './VenueCard'
 import { VenueSearch } from './VenueSearch'
 import { CityFilters, type CityWithCount, type CityState } from '@/components/filters'
+import { SaveDefaultsButton } from '@/components/filters/SaveDefaultsButton'
 import { LoadingSpinner } from '@/components/shared'
 import { Button } from '@/components/ui/button'
 
@@ -29,10 +31,20 @@ function buildCitiesParam(cities: CityState[]): string {
   return cities.map(c => `${c.city},${c.state}`).join('|')
 }
 
+/** Compare two city arrays for equality (order-insensitive) */
+function citiesEqual(a: CityState[], b: CityState[]): boolean {
+  if (a.length !== b.length) return false
+  const setA = new Set(a.map(c => `${c.city}|${c.state}`))
+  return b.every(c => setA.has(`${c.city}|${c.state}`))
+}
+
 export function VenueList() {
   const router = useRouter()
   const searchParams = useSearchParams()
+  const { isAuthenticated } = useIsAuthenticated()
   const [isPending, startTransition] = useTransition()
+  const { data: profileData } = useProfile()
+  const hasAppliedDefaults = useRef(false)
   const [offset, setOffset] = useState(0)
   const [accumulatedVenues, setAccumulatedVenues] = useState<VenueWithShowCount[]>([])
 
@@ -41,6 +53,29 @@ export function VenueList() {
   const selectedCities: CityState[] = useMemo(() => {
     return parseCitiesParam(citiesParam)
   }, [citiesParam])
+
+  // Read favorites from profile
+  const favoriteCities: CityState[] = useMemo(() => {
+    const prefs = profileData?.user?.preferences
+    if (!prefs?.favorite_cities) return []
+    return prefs.favorite_cities
+  }, [profileData?.user?.preferences])
+
+  // Apply favorites as default URL params on initial load (no URL params + not yet applied)
+  useEffect(() => {
+    if (
+      !hasAppliedDefaults.current &&
+      favoriteCities.length > 0 &&
+      !citiesParam
+    ) {
+      hasAppliedDefaults.current = true
+      const params = new URLSearchParams()
+      params.set('cities', buildCitiesParam(favoriteCities))
+      startTransition(() => {
+        router.replace(`/venues?${params.toString()}`, { scroll: false })
+      })
+    }
+  }, [favoriteCities, citiesParam, router])
 
   const { data: citiesData, isLoading: citiesLoading, isFetching: citiesFetching } = useVenueCities()
   const { data, isLoading, isFetching, error, refetch } = useVenues({
@@ -95,6 +130,9 @@ export function VenueList() {
     )
   }
 
+  // Determine if "Save as default" / "Clear defaults" should show
+  const selectionDiffersFromFavorites = !citiesEqual(selectedCities, favoriteCities)
+
   // Map VenueCity to CityWithCount
   const cities: CityWithCount[] = citiesData?.cities?.map(c => ({
     city: c.city,
@@ -111,7 +149,14 @@ export function VenueList() {
             cities={cities}
             selectedCities={selectedCities}
             onFilterChange={handleFilterChange}
-          />
+          >
+            {isAuthenticated && selectionDiffersFromFavorites && (
+              <SaveDefaultsButton
+                selectedCities={selectedCities}
+                favoriteCities={favoriteCities}
+              />
+            )}
+          </CityFilters>
         )}
       </div>
 


### PR DESCRIPTION
## Summary
- Artists and Venues browse pages now auto-apply saved city defaults from user profile on first load (when no URL params present)
- SaveDefaultsButton rendered inside CityFilters on both pages (save/clear defaults)
- Same pattern as Shows page: `hasAppliedDefaults` ref, `router.replace()`, `citiesEqual()` helper
- No backend changes — reuses existing favorite cities API

## Test plan
- [ ] Frontend build passes (`bun run build`)
- [ ] ArtistList tests pass (18 tests)
- [ ] Visit /artists with saved Phoenix defaults → auto-filters to Phoenix artists
- [ ] Change city filter → "Save as default" button appears
- [ ] Visit /venues → same behavior
- [ ] No saved cities → pages load unfiltered (no change from before)

Closes PSY-214

🤖 Generated with [Claude Code](https://claude.com/claude-code)