### PR TITLE
Add RadioService with contracts and aggregation queries (PSY-161)

### DIFF
--- a/backend/internal/errors/radio.go
+++ b/backend/internal/errors/radio.go
@@ -1,0 +1,56 @@
+package errors
+
+import (
+	"fmt"
+)
+
+// Radio error codes
+const (
+	CodeRadioStationNotFound = "RADIO_STATION_NOT_FOUND"
+	CodeRadioShowNotFound    = "RADIO_SHOW_NOT_FOUND"
+	CodeRadioEpisodeNotFound = "RADIO_EPISODE_NOT_FOUND"
+)
+
+// RadioError represents a radio-related error with additional context.
+type RadioError struct {
+	Code     string
+	Message  string
+	Internal error
+}
+
+// Error implements the error interface.
+func (e *RadioError) Error() string {
+	if e.Internal != nil {
+		return fmt.Sprintf("%s: %s (internal: %v)", e.Code, e.Message, e.Internal)
+	}
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
+// Unwrap returns the internal error for errors.Is/As compatibility.
+func (e *RadioError) Unwrap() error {
+	return e.Internal
+}
+
+// ErrRadioStationNotFound creates a radio station not found error.
+func ErrRadioStationNotFound(stationID uint) *RadioError {
+	return &RadioError{
+		Code:    CodeRadioStationNotFound,
+		Message: fmt.Sprintf("Radio station %d not found", stationID),
+	}
+}
+
+// ErrRadioShowNotFound creates a radio show not found error.
+func ErrRadioShowNotFound(showID uint) *RadioError {
+	return &RadioError{
+		Code:    CodeRadioShowNotFound,
+		Message: fmt.Sprintf("Radio show %d not found", showID),
+	}
+}
+
+// ErrRadioEpisodeNotFound creates a radio episode not found error.
+func ErrRadioEpisodeNotFound(episodeID uint) *RadioError {
+	return &RadioError{
+		Code:    CodeRadioEpisodeNotFound,
+		Message: fmt.Sprintf("Radio episode %d not found", episodeID),
+	}
+}

--- a/backend/internal/services/catalog/radio.go
+++ b/backend/internal/services/catalog/radio.go
@@ -1,0 +1,1049 @@
+package catalog
+
+import (
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/db"
+	apperrors "psychic-homily-backend/internal/errors"
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/utils"
+)
+
+// RadioService handles radio station, show, episode, and play operations
+type RadioService struct {
+	db *gorm.DB
+}
+
+// NewRadioService creates a new radio service
+func NewRadioService(database *gorm.DB) *RadioService {
+	if database == nil {
+		database = db.GetDB()
+	}
+	return &RadioService{db: database}
+}
+
+// =============================================================================
+// Station CRUD
+// =============================================================================
+
+// CreateStation creates a new radio station
+func (s *RadioService) CreateStation(req *contracts.CreateRadioStationRequest) (*contracts.RadioStationDetailResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	slug := req.Slug
+	if slug == "" {
+		baseSlug := utils.GenerateArtistSlug(req.Name)
+		slug = utils.GenerateUniqueSlug(baseSlug, func(candidate string) bool {
+			var count int64
+			s.db.Model(&models.RadioStation{}).Where("slug = ?", candidate).Count(&count)
+			return count > 0
+		})
+	}
+
+	if !models.IsValidBroadcastType(req.BroadcastType) {
+		return nil, fmt.Errorf("invalid broadcast type: %s", req.BroadcastType)
+	}
+
+	station := &models.RadioStation{
+		Name:             req.Name,
+		Slug:             slug,
+		Description:      req.Description,
+		City:             req.City,
+		State:            req.State,
+		Country:          req.Country,
+		Timezone:         req.Timezone,
+		StreamURL:        req.StreamURL,
+		StreamURLs:       req.StreamURLs,
+		Website:          req.Website,
+		DonationURL:      req.DonationURL,
+		DonationEmbedURL: req.DonationEmbedURL,
+		LogoURL:          req.LogoURL,
+		Social:           req.Social,
+		BroadcastType:    req.BroadcastType,
+		FrequencyMHz:     req.FrequencyMHz,
+		PlaylistSource:   req.PlaylistSource,
+		PlaylistConfig:   req.PlaylistConfig,
+	}
+
+	if err := s.db.Create(station).Error; err != nil {
+		return nil, fmt.Errorf("failed to create radio station: %w", err)
+	}
+
+	return s.GetStation(station.ID)
+}
+
+// GetStation retrieves a radio station by ID
+func (s *RadioService) GetStation(stationID uint) (*contracts.RadioStationDetailResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var station models.RadioStation
+	err := s.db.First(&station, stationID).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, apperrors.ErrRadioStationNotFound(stationID)
+		}
+		return nil, fmt.Errorf("failed to get radio station: %w", err)
+	}
+
+	return s.buildStationDetailResponse(&station)
+}
+
+// GetStationBySlug retrieves a radio station by slug
+func (s *RadioService) GetStationBySlug(slug string) (*contracts.RadioStationDetailResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var station models.RadioStation
+	err := s.db.Where("slug = ?", slug).First(&station).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, apperrors.ErrRadioStationNotFound(0)
+		}
+		return nil, fmt.Errorf("failed to get radio station: %w", err)
+	}
+
+	return s.buildStationDetailResponse(&station)
+}
+
+// ListStations retrieves radio stations with optional filtering
+func (s *RadioService) ListStations(filters map[string]interface{}) ([]*contracts.RadioStationListResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	query := s.db.Model(&models.RadioStation{})
+
+	if isActive, ok := filters["is_active"].(bool); ok {
+		query = query.Where("is_active = ?", isActive)
+	}
+	if city, ok := filters["city"].(string); ok && city != "" {
+		query = query.Where("city = ?", city)
+	}
+
+	query = query.Order("name ASC")
+
+	var stations []models.RadioStation
+	if err := query.Find(&stations).Error; err != nil {
+		return nil, fmt.Errorf("failed to list radio stations: %w", err)
+	}
+
+	// Batch-load show counts
+	stationIDs := make([]uint, len(stations))
+	for i, st := range stations {
+		stationIDs[i] = st.ID
+	}
+
+	showCounts := make(map[uint]int)
+	if len(stationIDs) > 0 {
+		type countResult struct {
+			StationID uint
+			Count     int
+		}
+		var counts []countResult
+		s.db.Model(&models.RadioShow{}).
+			Select("station_id, COUNT(*) as count").
+			Where("station_id IN ?", stationIDs).
+			Group("station_id").
+			Find(&counts)
+
+		for _, c := range counts {
+			showCounts[c.StationID] = c.Count
+		}
+	}
+
+	responses := make([]*contracts.RadioStationListResponse, len(stations))
+	for i, st := range stations {
+		responses[i] = &contracts.RadioStationListResponse{
+			ID:            st.ID,
+			Name:          st.Name,
+			Slug:          st.Slug,
+			City:          st.City,
+			State:         st.State,
+			Country:       st.Country,
+			BroadcastType: st.BroadcastType,
+			FrequencyMHz:  st.FrequencyMHz,
+			LogoURL:       st.LogoURL,
+			IsActive:      st.IsActive,
+			ShowCount:     showCounts[st.ID],
+		}
+	}
+
+	return responses, nil
+}
+
+// UpdateStation updates a radio station
+func (s *RadioService) UpdateStation(stationID uint, req *contracts.UpdateRadioStationRequest) (*contracts.RadioStationDetailResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var station models.RadioStation
+	if err := s.db.First(&station, stationID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, apperrors.ErrRadioStationNotFound(stationID)
+		}
+		return nil, fmt.Errorf("failed to get radio station: %w", err)
+	}
+
+	updates := make(map[string]interface{})
+	if req.Name != nil {
+		updates["name"] = *req.Name
+	}
+	if req.Description != nil {
+		updates["description"] = *req.Description
+	}
+	if req.City != nil {
+		updates["city"] = *req.City
+	}
+	if req.State != nil {
+		updates["state"] = *req.State
+	}
+	if req.Country != nil {
+		updates["country"] = *req.Country
+	}
+	if req.Timezone != nil {
+		updates["timezone"] = *req.Timezone
+	}
+	if req.StreamURL != nil {
+		updates["stream_url"] = *req.StreamURL
+	}
+	if req.StreamURLs != nil {
+		updates["stream_urls"] = req.StreamURLs
+	}
+	if req.Website != nil {
+		updates["website"] = *req.Website
+	}
+	if req.DonationURL != nil {
+		updates["donation_url"] = *req.DonationURL
+	}
+	if req.DonationEmbedURL != nil {
+		updates["donation_embed_url"] = *req.DonationEmbedURL
+	}
+	if req.LogoURL != nil {
+		updates["logo_url"] = *req.LogoURL
+	}
+	if req.Social != nil {
+		updates["social"] = req.Social
+	}
+	if req.BroadcastType != nil {
+		if !models.IsValidBroadcastType(*req.BroadcastType) {
+			return nil, fmt.Errorf("invalid broadcast type: %s", *req.BroadcastType)
+		}
+		updates["broadcast_type"] = *req.BroadcastType
+	}
+	if req.FrequencyMHz != nil {
+		updates["frequency_mhz"] = *req.FrequencyMHz
+	}
+	if req.PlaylistSource != nil {
+		updates["playlist_source"] = *req.PlaylistSource
+	}
+	if req.PlaylistConfig != nil {
+		updates["playlist_config"] = req.PlaylistConfig
+	}
+	if req.IsActive != nil {
+		updates["is_active"] = *req.IsActive
+	}
+
+	if len(updates) > 0 {
+		if err := s.db.Model(&station).Updates(updates).Error; err != nil {
+			return nil, fmt.Errorf("failed to update radio station: %w", err)
+		}
+	}
+
+	return s.GetStation(stationID)
+}
+
+// DeleteStation deletes a radio station
+func (s *RadioService) DeleteStation(stationID uint) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	result := s.db.Delete(&models.RadioStation{}, stationID)
+	if result.Error != nil {
+		return fmt.Errorf("failed to delete radio station: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return apperrors.ErrRadioStationNotFound(stationID)
+	}
+	return nil
+}
+
+// =============================================================================
+// Show CRUD
+// =============================================================================
+
+// CreateShow creates a new radio show for a station
+func (s *RadioService) CreateShow(stationID uint, req *contracts.CreateRadioShowRequest) (*contracts.RadioShowDetailResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	// Verify station exists
+	var station models.RadioStation
+	if err := s.db.First(&station, stationID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, apperrors.ErrRadioStationNotFound(stationID)
+		}
+		return nil, fmt.Errorf("failed to get radio station: %w", err)
+	}
+
+	slug := req.Slug
+	if slug == "" {
+		baseSlug := utils.GenerateArtistSlug(req.Name)
+		slug = utils.GenerateUniqueSlug(baseSlug, func(candidate string) bool {
+			var count int64
+			s.db.Model(&models.RadioShow{}).Where("slug = ?", candidate).Count(&count)
+			return count > 0
+		})
+	}
+
+	show := &models.RadioShow{
+		StationID:       stationID,
+		Name:            req.Name,
+		Slug:            slug,
+		HostName:        req.HostName,
+		Description:     req.Description,
+		ScheduleDisplay: req.ScheduleDisplay,
+		Schedule:        req.Schedule,
+		GenreTags:       req.GenreTags,
+		ArchiveURL:      req.ArchiveURL,
+		ImageURL:        req.ImageURL,
+		ExternalID:      req.ExternalID,
+	}
+
+	if err := s.db.Create(show).Error; err != nil {
+		return nil, fmt.Errorf("failed to create radio show: %w", err)
+	}
+
+	return s.GetShow(show.ID)
+}
+
+// GetShow retrieves a radio show by ID
+func (s *RadioService) GetShow(showID uint) (*contracts.RadioShowDetailResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var show models.RadioShow
+	err := s.db.Preload("Station").First(&show, showID).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, apperrors.ErrRadioShowNotFound(showID)
+		}
+		return nil, fmt.Errorf("failed to get radio show: %w", err)
+	}
+
+	return s.buildShowDetailResponse(&show)
+}
+
+// GetShowBySlug retrieves a radio show by slug
+func (s *RadioService) GetShowBySlug(slug string) (*contracts.RadioShowDetailResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var show models.RadioShow
+	err := s.db.Preload("Station").Where("slug = ?", slug).First(&show).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, apperrors.ErrRadioShowNotFound(0)
+		}
+		return nil, fmt.Errorf("failed to get radio show: %w", err)
+	}
+
+	return s.buildShowDetailResponse(&show)
+}
+
+// ListShows retrieves all shows for a station
+func (s *RadioService) ListShows(stationID uint) ([]*contracts.RadioShowListResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var shows []models.RadioShow
+	err := s.db.Preload("Station").
+		Where("station_id = ?", stationID).
+		Order("name ASC").
+		Find(&shows).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to list radio shows: %w", err)
+	}
+
+	// Batch-load episode counts
+	showIDs := make([]uint, len(shows))
+	for i, sh := range shows {
+		showIDs[i] = sh.ID
+	}
+
+	episodeCounts := make(map[uint]int64)
+	if len(showIDs) > 0 {
+		type countResult struct {
+			ShowID uint
+			Count  int64
+		}
+		var counts []countResult
+		s.db.Model(&models.RadioEpisode{}).
+			Select("show_id, COUNT(*) as count").
+			Where("show_id IN ?", showIDs).
+			Group("show_id").
+			Find(&counts)
+
+		for _, c := range counts {
+			episodeCounts[c.ShowID] = c.Count
+		}
+	}
+
+	responses := make([]*contracts.RadioShowListResponse, len(shows))
+	for i, sh := range shows {
+		responses[i] = &contracts.RadioShowListResponse{
+			ID:           sh.ID,
+			StationID:    sh.StationID,
+			StationName:  sh.Station.Name,
+			Name:         sh.Name,
+			Slug:         sh.Slug,
+			HostName:     sh.HostName,
+			GenreTags:    sh.GenreTags,
+			ImageURL:     sh.ImageURL,
+			IsActive:     sh.IsActive,
+			EpisodeCount: episodeCounts[sh.ID],
+		}
+	}
+
+	return responses, nil
+}
+
+// UpdateShow updates a radio show
+func (s *RadioService) UpdateShow(showID uint, req *contracts.UpdateRadioShowRequest) (*contracts.RadioShowDetailResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var show models.RadioShow
+	if err := s.db.First(&show, showID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, apperrors.ErrRadioShowNotFound(showID)
+		}
+		return nil, fmt.Errorf("failed to get radio show: %w", err)
+	}
+
+	updates := make(map[string]interface{})
+	if req.Name != nil {
+		updates["name"] = *req.Name
+	}
+	if req.HostName != nil {
+		updates["host_name"] = *req.HostName
+	}
+	if req.Description != nil {
+		updates["description"] = *req.Description
+	}
+	if req.ScheduleDisplay != nil {
+		updates["schedule_display"] = *req.ScheduleDisplay
+	}
+	if req.Schedule != nil {
+		updates["schedule"] = req.Schedule
+	}
+	if req.GenreTags != nil {
+		updates["genre_tags"] = req.GenreTags
+	}
+	if req.ArchiveURL != nil {
+		updates["archive_url"] = *req.ArchiveURL
+	}
+	if req.ImageURL != nil {
+		updates["image_url"] = *req.ImageURL
+	}
+	if req.IsActive != nil {
+		updates["is_active"] = *req.IsActive
+	}
+
+	if len(updates) > 0 {
+		if err := s.db.Model(&show).Updates(updates).Error; err != nil {
+			return nil, fmt.Errorf("failed to update radio show: %w", err)
+		}
+	}
+
+	return s.GetShow(showID)
+}
+
+// DeleteShow deletes a radio show
+func (s *RadioService) DeleteShow(showID uint) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	result := s.db.Delete(&models.RadioShow{}, showID)
+	if result.Error != nil {
+		return fmt.Errorf("failed to delete radio show: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return apperrors.ErrRadioShowNotFound(showID)
+	}
+	return nil
+}
+
+// =============================================================================
+// Episodes
+// =============================================================================
+
+// GetEpisodes retrieves paginated episodes for a show
+func (s *RadioService) GetEpisodes(showID uint, limit, offset int) ([]*contracts.RadioEpisodeResponse, int64, error) {
+	if s.db == nil {
+		return nil, 0, fmt.Errorf("database not initialized")
+	}
+
+	var total int64
+	s.db.Model(&models.RadioEpisode{}).Where("show_id = ?", showID).Count(&total)
+
+	var episodes []models.RadioEpisode
+	err := s.db.Where("show_id = ?", showID).
+		Order("air_date DESC").
+		Limit(limit).
+		Offset(offset).
+		Find(&episodes).Error
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to get episodes: %w", err)
+	}
+
+	responses := make([]*contracts.RadioEpisodeResponse, len(episodes))
+	for i, ep := range episodes {
+		responses[i] = &contracts.RadioEpisodeResponse{
+			ID:              ep.ID,
+			ShowID:          ep.ShowID,
+			Title:           ep.Title,
+			AirDate:         normalizeDate(ep.AirDate),
+			AirTime:         ep.AirTime,
+			DurationMinutes: ep.DurationMinutes,
+			ArchiveURL:      ep.ArchiveURL,
+			PlayCount:       ep.PlayCount,
+			CreatedAt:       ep.CreatedAt,
+		}
+	}
+
+	return responses, total, nil
+}
+
+// GetEpisodeByShowAndDate retrieves an episode by show ID and air date, with full playlist
+func (s *RadioService) GetEpisodeByShowAndDate(showID uint, airDate string) (*contracts.RadioEpisodeDetailResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var episode models.RadioEpisode
+	err := s.db.Preload("Show.Station").
+		Where("show_id = ? AND air_date = ?", showID, airDate).
+		First(&episode).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, apperrors.ErrRadioEpisodeNotFound(0)
+		}
+		return nil, fmt.Errorf("failed to get episode: %w", err)
+	}
+
+	return s.buildEpisodeDetailResponse(&episode)
+}
+
+// GetEpisodeDetail retrieves a full episode detail by ID, with playlist
+func (s *RadioService) GetEpisodeDetail(episodeID uint) (*contracts.RadioEpisodeDetailResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var episode models.RadioEpisode
+	err := s.db.Preload("Show.Station").First(&episode, episodeID).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, apperrors.ErrRadioEpisodeNotFound(episodeID)
+		}
+		return nil, fmt.Errorf("failed to get episode: %w", err)
+	}
+
+	return s.buildEpisodeDetailResponse(&episode)
+}
+
+// =============================================================================
+// Aggregation queries
+// =============================================================================
+
+// GetTopArtistsForShow returns the most-played artists for a show over a time period
+func (s *RadioService) GetTopArtistsForShow(showID uint, periodDays, limit int) ([]*contracts.RadioTopArtistResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	query := s.db.Table("radio_plays rp").
+		Select(`
+			rp.artist_name,
+			rp.artist_id,
+			a.slug as artist_slug,
+			COUNT(*) as play_count,
+			COUNT(DISTINCT rp.episode_id) as episode_count
+		`).
+		Joins("JOIN radio_episodes re ON re.id = rp.episode_id").
+		Joins("LEFT JOIN artists a ON a.id = rp.artist_id").
+		Where("re.show_id = ?", showID).
+		Group("rp.artist_name, rp.artist_id, a.slug").
+		Order("play_count DESC").
+		Limit(limit)
+
+	if periodDays > 0 {
+		cutoff := time.Now().AddDate(0, 0, -periodDays)
+		query = query.Where("re.air_date >= ?", cutoff.Format("2006-01-02"))
+	}
+
+	type result struct {
+		ArtistName   string  `gorm:"column:artist_name"`
+		ArtistID     *uint   `gorm:"column:artist_id"`
+		ArtistSlug   *string `gorm:"column:artist_slug"`
+		PlayCount    int     `gorm:"column:play_count"`
+		EpisodeCount int     `gorm:"column:episode_count"`
+	}
+
+	var results []result
+	if err := query.Find(&results).Error; err != nil {
+		return nil, fmt.Errorf("failed to get top artists: %w", err)
+	}
+
+	responses := make([]*contracts.RadioTopArtistResponse, len(results))
+	for i, r := range results {
+		responses[i] = &contracts.RadioTopArtistResponse{
+			ArtistName:   r.ArtistName,
+			ArtistID:     r.ArtistID,
+			ArtistSlug:   r.ArtistSlug,
+			PlayCount:    r.PlayCount,
+			EpisodeCount: r.EpisodeCount,
+		}
+	}
+
+	return responses, nil
+}
+
+// GetTopLabelsForShow returns the most-featured labels for a show over a time period
+func (s *RadioService) GetTopLabelsForShow(showID uint, periodDays, limit int) ([]*contracts.RadioTopLabelResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	query := s.db.Table("radio_plays rp").
+		Select(`
+			rp.label_name,
+			rp.label_id,
+			l.slug as label_slug,
+			COUNT(*) as play_count
+		`).
+		Joins("JOIN radio_episodes re ON re.id = rp.episode_id").
+		Joins("LEFT JOIN labels l ON l.id = rp.label_id").
+		Where("re.show_id = ? AND rp.label_name IS NOT NULL AND rp.label_name != ''", showID).
+		Group("rp.label_name, rp.label_id, l.slug").
+		Order("play_count DESC").
+		Limit(limit)
+
+	if periodDays > 0 {
+		cutoff := time.Now().AddDate(0, 0, -periodDays)
+		query = query.Where("re.air_date >= ?", cutoff.Format("2006-01-02"))
+	}
+
+	type result struct {
+		LabelName string  `gorm:"column:label_name"`
+		LabelID   *uint   `gorm:"column:label_id"`
+		LabelSlug *string `gorm:"column:label_slug"`
+		PlayCount int     `gorm:"column:play_count"`
+	}
+
+	var results []result
+	if err := query.Find(&results).Error; err != nil {
+		return nil, fmt.Errorf("failed to get top labels: %w", err)
+	}
+
+	responses := make([]*contracts.RadioTopLabelResponse, len(results))
+	for i, r := range results {
+		responses[i] = &contracts.RadioTopLabelResponse{
+			LabelName: r.LabelName,
+			LabelID:   r.LabelID,
+			LabelSlug: r.LabelSlug,
+			PlayCount: r.PlayCount,
+		}
+	}
+
+	return responses, nil
+}
+
+// GetAsHeardOnForArtist returns stations/shows where an artist has been played
+func (s *RadioService) GetAsHeardOnForArtist(artistID uint) ([]*contracts.RadioAsHeardOnResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	type result struct {
+		StationID   uint   `gorm:"column:station_id"`
+		StationName string `gorm:"column:station_name"`
+		StationSlug string `gorm:"column:station_slug"`
+		ShowID      uint   `gorm:"column:show_id"`
+		ShowName    string `gorm:"column:show_name"`
+		ShowSlug    string `gorm:"column:show_slug"`
+		PlayCount   int    `gorm:"column:play_count"`
+		LastPlayed  string `gorm:"column:last_played"`
+	}
+
+	var results []result
+	err := s.db.Table("radio_plays rp").
+		Select(`
+			rs.id as station_id,
+			rs.name as station_name,
+			rs.slug as station_slug,
+			rsh.id as show_id,
+			rsh.name as show_name,
+			rsh.slug as show_slug,
+			COUNT(*) as play_count,
+			MAX(re.air_date) as last_played
+		`).
+		Joins("JOIN radio_episodes re ON re.id = rp.episode_id").
+		Joins("JOIN radio_shows rsh ON rsh.id = re.show_id").
+		Joins("JOIN radio_stations rs ON rs.id = rsh.station_id").
+		Where("rp.artist_id = ?", artistID).
+		Group("rs.id, rs.name, rs.slug, rsh.id, rsh.name, rsh.slug").
+		Order("play_count DESC").
+		Find(&results).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to get as-heard-on for artist: %w", err)
+	}
+
+	responses := make([]*contracts.RadioAsHeardOnResponse, len(results))
+	for i, r := range results {
+		responses[i] = &contracts.RadioAsHeardOnResponse{
+			StationID:   r.StationID,
+			StationName: r.StationName,
+			StationSlug: r.StationSlug,
+			ShowID:      r.ShowID,
+			ShowName:    r.ShowName,
+			ShowSlug:    r.ShowSlug,
+			PlayCount:   r.PlayCount,
+			LastPlayed:  r.LastPlayed,
+		}
+	}
+
+	return responses, nil
+}
+
+// GetAsHeardOnForRelease returns stations/shows where a release has been played
+func (s *RadioService) GetAsHeardOnForRelease(releaseID uint) ([]*contracts.RadioAsHeardOnResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	type result struct {
+		StationID   uint   `gorm:"column:station_id"`
+		StationName string `gorm:"column:station_name"`
+		StationSlug string `gorm:"column:station_slug"`
+		ShowID      uint   `gorm:"column:show_id"`
+		ShowName    string `gorm:"column:show_name"`
+		ShowSlug    string `gorm:"column:show_slug"`
+		PlayCount   int    `gorm:"column:play_count"`
+		LastPlayed  string `gorm:"column:last_played"`
+	}
+
+	var results []result
+	err := s.db.Table("radio_plays rp").
+		Select(`
+			rs.id as station_id,
+			rs.name as station_name,
+			rs.slug as station_slug,
+			rsh.id as show_id,
+			rsh.name as show_name,
+			rsh.slug as show_slug,
+			COUNT(*) as play_count,
+			MAX(re.air_date) as last_played
+		`).
+		Joins("JOIN radio_episodes re ON re.id = rp.episode_id").
+		Joins("JOIN radio_shows rsh ON rsh.id = re.show_id").
+		Joins("JOIN radio_stations rs ON rs.id = rsh.station_id").
+		Where("rp.release_id = ?", releaseID).
+		Group("rs.id, rs.name, rs.slug, rsh.id, rsh.name, rsh.slug").
+		Order("play_count DESC").
+		Find(&results).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to get as-heard-on for release: %w", err)
+	}
+
+	responses := make([]*contracts.RadioAsHeardOnResponse, len(results))
+	for i, r := range results {
+		responses[i] = &contracts.RadioAsHeardOnResponse{
+			StationID:   r.StationID,
+			StationName: r.StationName,
+			StationSlug: r.StationSlug,
+			ShowID:      r.ShowID,
+			ShowName:    r.ShowName,
+			ShowSlug:    r.ShowSlug,
+			PlayCount:   r.PlayCount,
+			LastPlayed:  r.LastPlayed,
+		}
+	}
+
+	return responses, nil
+}
+
+// GetNewReleaseRadar returns aggregated new releases played across radio stations.
+// If stationID is 0, aggregates across all stations. Minimum 2+ station threshold for
+// cross-station aggregation; no threshold for single-station filter.
+func (s *RadioService) GetNewReleaseRadar(stationID uint, limit int) ([]*contracts.RadioNewReleaseRadarEntry, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	query := s.db.Table("radio_plays rp").
+		Select(`
+			rp.artist_name,
+			rp.artist_id,
+			a.slug as artist_slug,
+			rp.album_title,
+			rp.label_name,
+			rp.release_id,
+			r.slug as release_slug,
+			rp.label_id,
+			l.slug as label_slug,
+			COUNT(*) as play_count,
+			COUNT(DISTINCT rs.id) as station_count
+		`).
+		Joins("JOIN radio_episodes re ON re.id = rp.episode_id").
+		Joins("JOIN radio_shows rsh ON rsh.id = re.show_id").
+		Joins("JOIN radio_stations rs ON rs.id = rsh.station_id").
+		Joins("LEFT JOIN artists a ON a.id = rp.artist_id").
+		Joins("LEFT JOIN releases r ON r.id = rp.release_id").
+		Joins("LEFT JOIN labels l ON l.id = rp.label_id").
+		Where("rp.is_new = TRUE").
+		Group("rp.artist_name, rp.artist_id, a.slug, rp.album_title, rp.label_name, rp.release_id, r.slug, rp.label_id, l.slug").
+		Order("station_count DESC, play_count DESC").
+		Limit(limit)
+
+	if stationID > 0 {
+		query = query.Where("rs.id = ?", stationID)
+	} else {
+		// Cross-station: require 2+ stations
+		query = query.Having("COUNT(DISTINCT rs.id) >= 2")
+	}
+
+	type result struct {
+		ArtistName   string  `gorm:"column:artist_name"`
+		ArtistID     *uint   `gorm:"column:artist_id"`
+		ArtistSlug   *string `gorm:"column:artist_slug"`
+		AlbumTitle   *string `gorm:"column:album_title"`
+		LabelName    *string `gorm:"column:label_name"`
+		ReleaseID    *uint   `gorm:"column:release_id"`
+		ReleaseSlug  *string `gorm:"column:release_slug"`
+		LabelID      *uint   `gorm:"column:label_id"`
+		LabelSlug    *string `gorm:"column:label_slug"`
+		PlayCount    int     `gorm:"column:play_count"`
+		StationCount int     `gorm:"column:station_count"`
+	}
+
+	var results []result
+	if err := query.Find(&results).Error; err != nil {
+		return nil, fmt.Errorf("failed to get new release radar: %w", err)
+	}
+
+	responses := make([]*contracts.RadioNewReleaseRadarEntry, len(results))
+	for i, r := range results {
+		responses[i] = &contracts.RadioNewReleaseRadarEntry{
+			ArtistName:   r.ArtistName,
+			ArtistID:     r.ArtistID,
+			ArtistSlug:   r.ArtistSlug,
+			AlbumTitle:   r.AlbumTitle,
+			LabelName:    r.LabelName,
+			ReleaseID:    r.ReleaseID,
+			ReleaseSlug:  r.ReleaseSlug,
+			LabelID:      r.LabelID,
+			LabelSlug:    r.LabelSlug,
+			PlayCount:    r.PlayCount,
+			StationCount: r.StationCount,
+		}
+	}
+
+	return responses, nil
+}
+
+// =============================================================================
+// Stats
+// =============================================================================
+
+// GetRadioStats returns overall radio stats
+func (s *RadioService) GetRadioStats() (*contracts.RadioStatsResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var stats contracts.RadioStatsResponse
+
+	var stationCount int64
+	s.db.Model(&models.RadioStation{}).Where("is_active = TRUE").Count(&stationCount)
+	stats.TotalStations = int(stationCount)
+
+	var showCount int64
+	s.db.Model(&models.RadioShow{}).Where("is_active = TRUE").Count(&showCount)
+	stats.TotalShows = int(showCount)
+
+	var episodeCount int64
+	s.db.Model(&models.RadioEpisode{}).Count(&episodeCount)
+	stats.TotalEpisodes = int(episodeCount)
+
+	s.db.Model(&models.RadioPlay{}).Count(&stats.TotalPlays)
+
+	var matchedPlays int64
+	s.db.Model(&models.RadioPlay{}).Where("artist_id IS NOT NULL").Count(&matchedPlays)
+	stats.MatchedPlays = matchedPlays
+
+	var uniqueArtists int64
+	s.db.Model(&models.RadioPlay{}).Where("artist_id IS NOT NULL").Distinct("artist_id").Count(&uniqueArtists)
+	stats.UniqueArtists = int(uniqueArtists)
+
+	return &stats, nil
+}
+
+// =============================================================================
+// Response builders
+// =============================================================================
+
+func (s *RadioService) buildStationDetailResponse(station *models.RadioStation) (*contracts.RadioStationDetailResponse, error) {
+	var showCount int64
+	s.db.Model(&models.RadioShow{}).Where("station_id = ?", station.ID).Count(&showCount)
+
+	return &contracts.RadioStationDetailResponse{
+		ID:                  station.ID,
+		Name:                station.Name,
+		Slug:                station.Slug,
+		Description:         station.Description,
+		City:                station.City,
+		State:               station.State,
+		Country:             station.Country,
+		Timezone:            station.Timezone,
+		StreamURL:           station.StreamURL,
+		StreamURLs:          station.StreamURLs,
+		Website:             station.Website,
+		DonationURL:         station.DonationURL,
+		DonationEmbedURL:    station.DonationEmbedURL,
+		LogoURL:             station.LogoURL,
+		Social:              station.Social,
+		BroadcastType:       station.BroadcastType,
+		FrequencyMHz:        station.FrequencyMHz,
+		PlaylistSource:      station.PlaylistSource,
+		PlaylistConfig:      station.PlaylistConfig,
+		LastPlaylistFetchAt: station.LastPlaylistFetchAt,
+		IsActive:            station.IsActive,
+		ShowCount:           int(showCount),
+		CreatedAt:           station.CreatedAt,
+		UpdatedAt:           station.UpdatedAt,
+	}, nil
+}
+
+func (s *RadioService) buildShowDetailResponse(show *models.RadioShow) (*contracts.RadioShowDetailResponse, error) {
+	var episodeCount int64
+	s.db.Model(&models.RadioEpisode{}).Where("show_id = ?", show.ID).Count(&episodeCount)
+
+	return &contracts.RadioShowDetailResponse{
+		ID:              show.ID,
+		StationID:       show.StationID,
+		StationName:     show.Station.Name,
+		StationSlug:     show.Station.Slug,
+		Name:            show.Name,
+		Slug:            show.Slug,
+		HostName:        show.HostName,
+		Description:     show.Description,
+		ScheduleDisplay: show.ScheduleDisplay,
+		Schedule:        show.Schedule,
+		GenreTags:       show.GenreTags,
+		ArchiveURL:      show.ArchiveURL,
+		ImageURL:        show.ImageURL,
+		IsActive:        show.IsActive,
+		EpisodeCount:    episodeCount,
+		CreatedAt:       show.CreatedAt,
+		UpdatedAt:       show.UpdatedAt,
+	}, nil
+}
+
+// normalizeDate strips any time component from a date string (e.g. "2026-01-01T00:00:00Z" → "2026-01-01")
+func normalizeDate(d string) string {
+	if t, err := time.Parse(time.RFC3339, d); err == nil {
+		return t.Format("2006-01-02")
+	}
+	if len(d) >= 10 {
+		return d[:10]
+	}
+	return d
+}
+
+func (s *RadioService) buildEpisodeDetailResponse(episode *models.RadioEpisode) (*contracts.RadioEpisodeDetailResponse, error) {
+	// Load plays with linked entity data
+	var plays []models.RadioPlay
+	err := s.db.Where("episode_id = ?", episode.ID).
+		Preload("Artist").
+		Preload("Release").
+		Preload("Label").
+		Order("position ASC").
+		Find(&plays).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to load plays: %w", err)
+	}
+
+	playResponses := make([]contracts.RadioPlayResponse, len(plays))
+	for i, p := range plays {
+		playResponses[i] = contracts.RadioPlayResponse{
+			ID:                     p.ID,
+			EpisodeID:              p.EpisodeID,
+			Position:               p.Position,
+			ArtistName:             p.ArtistName,
+			TrackTitle:             p.TrackTitle,
+			AlbumTitle:             p.AlbumTitle,
+			LabelName:              p.LabelName,
+			ReleaseYear:            p.ReleaseYear,
+			IsNew:                  p.IsNew,
+			RotationStatus:         p.RotationStatus,
+			DJComment:              p.DJComment,
+			IsLivePerformance:      p.IsLivePerformance,
+			IsRequest:              p.IsRequest,
+			ArtistID:               p.ArtistID,
+			ReleaseID:              p.ReleaseID,
+			LabelID:                p.LabelID,
+			MusicBrainzArtistID:    p.MusicBrainzArtistID,
+			MusicBrainzRecordingID: p.MusicBrainzRecordingID,
+			MusicBrainzReleaseID:   p.MusicBrainzReleaseID,
+			AirTimestamp:           p.AirTimestamp,
+		}
+		if p.Artist != nil {
+			playResponses[i].ArtistSlug = p.Artist.Slug
+		}
+		if p.Release != nil {
+			playResponses[i].ReleaseSlug = p.Release.Slug
+		}
+		if p.Label != nil {
+			playResponses[i].LabelSlug = p.Label.Slug
+		}
+	}
+
+	return &contracts.RadioEpisodeDetailResponse{
+		ID:              episode.ID,
+		ShowID:          episode.ShowID,
+		ShowName:        episode.Show.Name,
+		ShowSlug:        episode.Show.Slug,
+		StationName:     episode.Show.Station.Name,
+		StationSlug:     episode.Show.Station.Slug,
+		Title:           episode.Title,
+		AirDate:         normalizeDate(episode.AirDate),
+		AirTime:         episode.AirTime,
+		DurationMinutes: episode.DurationMinutes,
+		Description:     episode.Description,
+		ArchiveURL:      episode.ArchiveURL,
+		MixcloudURL:     episode.MixcloudURL,
+		GenreTags:       episode.GenreTags,
+		MoodTags:        episode.MoodTags,
+		PlayCount:       episode.PlayCount,
+		Plays:           playResponses,
+		CreatedAt:       episode.CreatedAt,
+	}, nil
+}

--- a/backend/internal/services/catalog/radio_test.go
+++ b/backend/internal/services/catalog/radio_test.go
@@ -1,0 +1,811 @@
+package catalog
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"gorm.io/gorm"
+
+	apperrors "psychic-homily-backend/internal/errors"
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/testutil"
+	"psychic-homily-backend/internal/utils"
+)
+
+// =============================================================================
+// UNIT TESTS (No Database Required)
+// =============================================================================
+
+func assertNilDBError(t *testing.T, fn func() error) {
+	t.Helper()
+	err := fn()
+	if err == nil {
+		t.Fatal("expected error for nil db, got nil")
+	}
+	if err.Error() != "database not initialized" {
+		t.Fatalf("expected 'database not initialized', got %q", err.Error())
+	}
+}
+
+func TestRadioService_NilDB_Station(t *testing.T) {
+	svc := &RadioService{db: nil}
+	assertNilDBError(t, func() error {
+		_, err := svc.CreateStation(&contracts.CreateRadioStationRequest{Name: "x", BroadcastType: "internet"})
+		return err
+	})
+	assertNilDBError(t, func() error { _, err := svc.GetStation(1); return err })
+	assertNilDBError(t, func() error { _, err := svc.GetStationBySlug("x"); return err })
+	assertNilDBError(t, func() error { _, err := svc.ListStations(nil); return err })
+	assertNilDBError(t, func() error {
+		_, err := svc.UpdateStation(1, &contracts.UpdateRadioStationRequest{})
+		return err
+	})
+	assertNilDBError(t, func() error { return svc.DeleteStation(1) })
+}
+
+func TestRadioService_NilDB_Show(t *testing.T) {
+	svc := &RadioService{db: nil}
+	assertNilDBError(t, func() error {
+		_, err := svc.CreateShow(1, &contracts.CreateRadioShowRequest{Name: "x"})
+		return err
+	})
+	assertNilDBError(t, func() error { _, err := svc.GetShow(1); return err })
+	assertNilDBError(t, func() error { _, err := svc.GetShowBySlug("x"); return err })
+	assertNilDBError(t, func() error { _, err := svc.ListShows(1); return err })
+	assertNilDBError(t, func() error {
+		_, err := svc.UpdateShow(1, &contracts.UpdateRadioShowRequest{})
+		return err
+	})
+	assertNilDBError(t, func() error { return svc.DeleteShow(1) })
+}
+
+func TestRadioService_NilDB_Episode(t *testing.T) {
+	svc := &RadioService{db: nil}
+	assertNilDBError(t, func() error { _, _, err := svc.GetEpisodes(1, 10, 0); return err })
+	assertNilDBError(t, func() error { _, err := svc.GetEpisodeByShowAndDate(1, "2026-01-01"); return err })
+	assertNilDBError(t, func() error { _, err := svc.GetEpisodeDetail(1); return err })
+}
+
+func TestRadioService_NilDB_Aggregation(t *testing.T) {
+	svc := &RadioService{db: nil}
+	assertNilDBError(t, func() error { _, err := svc.GetTopArtistsForShow(1, 90, 10); return err })
+	assertNilDBError(t, func() error { _, err := svc.GetTopLabelsForShow(1, 90, 10); return err })
+	assertNilDBError(t, func() error { _, err := svc.GetAsHeardOnForArtist(1); return err })
+	assertNilDBError(t, func() error { _, err := svc.GetAsHeardOnForRelease(1); return err })
+	assertNilDBError(t, func() error { _, err := svc.GetNewReleaseRadar(0, 10); return err })
+	assertNilDBError(t, func() error { _, err := svc.GetRadioStats(); return err })
+}
+
+// =============================================================================
+// INTEGRATION TESTS (With Real Database)
+// =============================================================================
+
+type RadioServiceIntegrationTestSuite struct {
+	suite.Suite
+	testDB       *testutil.TestDatabase
+	db           *gorm.DB
+	radioService *RadioService
+}
+
+func (suite *RadioServiceIntegrationTestSuite) SetupSuite() {
+	suite.testDB = testutil.SetupTestPostgres(suite.T())
+	suite.db = suite.testDB.DB
+
+	suite.radioService = &RadioService{db: suite.testDB.DB}
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TearDownSuite() {
+	suite.testDB.Cleanup()
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TearDownTest() {
+	sqlDB, err := suite.db.DB()
+	suite.Require().NoError(err)
+	// Delete in FK-safe order
+	_, _ = sqlDB.Exec("DELETE FROM radio_artist_affinity")
+	_, _ = sqlDB.Exec("DELETE FROM radio_plays")
+	_, _ = sqlDB.Exec("DELETE FROM radio_episodes")
+	_, _ = sqlDB.Exec("DELETE FROM radio_shows")
+	_, _ = sqlDB.Exec("DELETE FROM radio_stations")
+	_, _ = sqlDB.Exec("DELETE FROM artists")
+	_, _ = sqlDB.Exec("DELETE FROM releases")
+	_, _ = sqlDB.Exec("DELETE FROM labels")
+}
+
+func TestRadioServiceIntegrationTestSuite(t *testing.T) {
+	suite.Run(t, new(RadioServiceIntegrationTestSuite))
+}
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+func (suite *RadioServiceIntegrationTestSuite) createStation(name string) *contracts.RadioStationDetailResponse {
+	resp, err := suite.radioService.CreateStation(&contracts.CreateRadioStationRequest{
+		Name:          name,
+		BroadcastType: models.BroadcastTypeBoth,
+	})
+	suite.Require().NoError(err)
+	return resp
+}
+
+func (suite *RadioServiceIntegrationTestSuite) createShow(stationID uint, name string) *contracts.RadioShowDetailResponse {
+	resp, err := suite.radioService.CreateShow(stationID, &contracts.CreateRadioShowRequest{
+		Name: name,
+	})
+	suite.Require().NoError(err)
+	return resp
+}
+
+func (suite *RadioServiceIntegrationTestSuite) createEpisode(showID uint, airDate string) *models.RadioEpisode {
+	ep := &models.RadioEpisode{
+		ShowID:  showID,
+		AirDate: airDate,
+	}
+	err := suite.db.Create(ep).Error
+	suite.Require().NoError(err)
+	return ep
+}
+
+func (suite *RadioServiceIntegrationTestSuite) createPlay(episodeID uint, position int, artistName string) *models.RadioPlay {
+	play := &models.RadioPlay{
+		EpisodeID:  episodeID,
+		Position:   position,
+		ArtistName: artistName,
+	}
+	err := suite.db.Create(play).Error
+	suite.Require().NoError(err)
+	return play
+}
+
+func (suite *RadioServiceIntegrationTestSuite) createArtist(name string) *models.Artist {
+	slug := utils.GenerateArtistSlug(name)
+	artist := &models.Artist{Name: name, Slug: &slug}
+	err := suite.db.Create(artist).Error
+	suite.Require().NoError(err)
+	return artist
+}
+
+func (suite *RadioServiceIntegrationTestSuite) createRelease(title string) *models.Release {
+	release := &models.Release{Title: title}
+	err := suite.db.Create(release).Error
+	suite.Require().NoError(err)
+	return release
+}
+
+func (suite *RadioServiceIntegrationTestSuite) createLabel(name string) *models.Label {
+	label := &models.Label{Name: name, Status: models.LabelStatusActive}
+	err := suite.db.Create(label).Error
+	suite.Require().NoError(err)
+	return label
+}
+
+// =============================================================================
+// STATION CRUD TESTS
+// =============================================================================
+
+func (suite *RadioServiceIntegrationTestSuite) TestCreateStation_Success() {
+	city := "Seattle"
+	state := "WA"
+	freq := 90.3
+	resp, err := suite.radioService.CreateStation(&contracts.CreateRadioStationRequest{
+		Name:          "KEXP",
+		BroadcastType: models.BroadcastTypeBoth,
+		City:          &city,
+		State:         &state,
+		FrequencyMHz:  &freq,
+	})
+
+	suite.Require().NoError(err)
+	suite.NotZero(resp.ID)
+	suite.Equal("KEXP", resp.Name)
+	suite.Equal("kexp", resp.Slug)
+	suite.Equal("both", resp.BroadcastType)
+	suite.Equal(&city, resp.City)
+	suite.Equal(&state, resp.State)
+	suite.Equal(&freq, resp.FrequencyMHz)
+	suite.True(resp.IsActive)
+	suite.Equal(0, resp.ShowCount)
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TestCreateStation_CustomSlug() {
+	resp, err := suite.radioService.CreateStation(&contracts.CreateRadioStationRequest{
+		Name:          "KEXP",
+		Slug:          "kexp-seattle",
+		BroadcastType: models.BroadcastTypeInternet,
+	})
+
+	suite.Require().NoError(err)
+	suite.Equal("kexp-seattle", resp.Slug)
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TestCreateStation_InvalidBroadcastType() {
+	_, err := suite.radioService.CreateStation(&contracts.CreateRadioStationRequest{
+		Name:          "Bad Station",
+		BroadcastType: "satellite",
+	})
+
+	suite.Error(err)
+	suite.Contains(err.Error(), "invalid broadcast type")
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TestCreateStation_UniqueSlugCollision() {
+	suite.createStation("KEXP")
+
+	resp, err := suite.radioService.CreateStation(&contracts.CreateRadioStationRequest{
+		Name:          "KEXP",
+		BroadcastType: models.BroadcastTypeInternet,
+	})
+
+	suite.Require().NoError(err)
+	suite.Contains(resp.Slug, "kexp-") // should get a suffix
+	suite.NotEqual("kexp", resp.Slug)
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TestGetStation_Success() {
+	created := suite.createStation("KEXP")
+
+	resp, err := suite.radioService.GetStation(created.ID)
+
+	suite.Require().NoError(err)
+	suite.Equal(created.ID, resp.ID)
+	suite.Equal("KEXP", resp.Name)
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TestGetStation_NotFound() {
+	_, err := suite.radioService.GetStation(99999)
+
+	suite.Error(err)
+	var radioErr *apperrors.RadioError
+	suite.ErrorAs(err, &radioErr)
+	suite.Equal(apperrors.CodeRadioStationNotFound, radioErr.Code)
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TestGetStationBySlug_Success() {
+	suite.createStation("KEXP")
+
+	resp, err := suite.radioService.GetStationBySlug("kexp")
+
+	suite.Require().NoError(err)
+	suite.Equal("KEXP", resp.Name)
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TestGetStationBySlug_NotFound() {
+	_, err := suite.radioService.GetStationBySlug("nonexistent")
+
+	suite.Error(err)
+	var radioErr *apperrors.RadioError
+	suite.ErrorAs(err, &radioErr)
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TestListStations_All() {
+	suite.createStation("KEXP")
+	suite.createStation("WFMU")
+
+	resp, err := suite.radioService.ListStations(map[string]interface{}{})
+
+	suite.Require().NoError(err)
+	suite.Len(resp, 2)
+	// Ordered by name ASC
+	suite.Equal("KEXP", resp[0].Name)
+	suite.Equal("WFMU", resp[1].Name)
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TestListStations_WithShowCounts() {
+	station := suite.createStation("KEXP")
+	suite.createShow(station.ID, "Morning Show")
+	suite.createShow(station.ID, "Afternoon Show")
+
+	resp, err := suite.radioService.ListStations(map[string]interface{}{})
+
+	suite.Require().NoError(err)
+	suite.Len(resp, 1)
+	suite.Equal(2, resp[0].ShowCount)
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TestUpdateStation_Success() {
+	station := suite.createStation("KEXP")
+
+	newName := "KEXP 90.3"
+	city := "Seattle"
+	resp, err := suite.radioService.UpdateStation(station.ID, &contracts.UpdateRadioStationRequest{
+		Name: &newName,
+		City: &city,
+	})
+
+	suite.Require().NoError(err)
+	suite.Equal("KEXP 90.3", resp.Name)
+	suite.Equal(&city, resp.City)
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TestUpdateStation_InvalidBroadcastType() {
+	station := suite.createStation("KEXP")
+
+	bad := "satellite"
+	_, err := suite.radioService.UpdateStation(station.ID, &contracts.UpdateRadioStationRequest{
+		BroadcastType: &bad,
+	})
+
+	suite.Error(err)
+	suite.Contains(err.Error(), "invalid broadcast type")
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TestUpdateStation_NotFound() {
+	newName := "Gone"
+	_, err := suite.radioService.UpdateStation(99999, &contracts.UpdateRadioStationRequest{Name: &newName})
+
+	suite.Error(err)
+	var radioErr *apperrors.RadioError
+	suite.ErrorAs(err, &radioErr)
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TestDeleteStation_Success() {
+	station := suite.createStation("KEXP")
+
+	err := suite.radioService.DeleteStation(station.ID)
+
+	suite.NoError(err)
+	_, err = suite.radioService.GetStation(station.ID)
+	suite.Error(err)
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TestDeleteStation_NotFound() {
+	err := suite.radioService.DeleteStation(99999)
+
+	suite.Error(err)
+	var radioErr *apperrors.RadioError
+	suite.ErrorAs(err, &radioErr)
+}
+
+// =============================================================================
+// SHOW CRUD TESTS
+// =============================================================================
+
+func (suite *RadioServiceIntegrationTestSuite) TestCreateShow_Success() {
+	station := suite.createStation("KEXP")
+
+	hostName := "John Richards"
+	resp, err := suite.radioService.CreateShow(station.ID, &contracts.CreateRadioShowRequest{
+		Name:     "The Morning Show",
+		HostName: &hostName,
+	})
+
+	suite.Require().NoError(err)
+	suite.NotZero(resp.ID)
+	suite.Equal("The Morning Show", resp.Name)
+	suite.Equal("the-morning-show", resp.Slug)
+	suite.Equal(&hostName, resp.HostName)
+	suite.Equal(station.ID, resp.StationID)
+	suite.Equal("KEXP", resp.StationName)
+	suite.True(resp.IsActive)
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TestCreateShow_StationNotFound() {
+	_, err := suite.radioService.CreateShow(99999, &contracts.CreateRadioShowRequest{
+		Name: "Orphan Show",
+	})
+
+	suite.Error(err)
+	var radioErr *apperrors.RadioError
+	suite.ErrorAs(err, &radioErr)
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TestGetShow_Success() {
+	station := suite.createStation("KEXP")
+	show := suite.createShow(station.ID, "Morning Show")
+
+	resp, err := suite.radioService.GetShow(show.ID)
+
+	suite.Require().NoError(err)
+	suite.Equal("Morning Show", resp.Name)
+	suite.Equal("KEXP", resp.StationName)
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TestGetShow_NotFound() {
+	_, err := suite.radioService.GetShow(99999)
+
+	suite.Error(err)
+	var radioErr *apperrors.RadioError
+	suite.ErrorAs(err, &radioErr)
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TestGetShowBySlug_Success() {
+	station := suite.createStation("KEXP")
+	suite.createShow(station.ID, "Morning Show")
+
+	resp, err := suite.radioService.GetShowBySlug("morning-show")
+
+	suite.Require().NoError(err)
+	suite.Equal("Morning Show", resp.Name)
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TestListShows_WithEpisodeCounts() {
+	station := suite.createStation("KEXP")
+	show := suite.createShow(station.ID, "Morning Show")
+	suite.createEpisode(show.ID, "2026-01-01")
+	suite.createEpisode(show.ID, "2026-01-02")
+	suite.createShow(station.ID, "Afternoon Show") // no episodes
+
+	resp, err := suite.radioService.ListShows(station.ID)
+
+	suite.Require().NoError(err)
+	suite.Len(resp, 2)
+	// Ordered by name ASC
+	suite.Equal("Afternoon Show", resp[0].Name)
+	suite.Equal(int64(0), resp[0].EpisodeCount)
+	suite.Equal("Morning Show", resp[1].Name)
+	suite.Equal(int64(2), resp[1].EpisodeCount)
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TestUpdateShow_Success() {
+	station := suite.createStation("KEXP")
+	show := suite.createShow(station.ID, "Morning Show")
+
+	newName := "KEXP Morning Show"
+	host := "John Richards"
+	resp, err := suite.radioService.UpdateShow(show.ID, &contracts.UpdateRadioShowRequest{
+		Name:     &newName,
+		HostName: &host,
+	})
+
+	suite.Require().NoError(err)
+	suite.Equal("KEXP Morning Show", resp.Name)
+	suite.Equal(&host, resp.HostName)
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TestUpdateShow_NotFound() {
+	newName := "Gone"
+	_, err := suite.radioService.UpdateShow(99999, &contracts.UpdateRadioShowRequest{Name: &newName})
+
+	suite.Error(err)
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TestDeleteShow_Success() {
+	station := suite.createStation("KEXP")
+	show := suite.createShow(station.ID, "Morning Show")
+
+	err := suite.radioService.DeleteShow(show.ID)
+
+	suite.NoError(err)
+	_, err = suite.radioService.GetShow(show.ID)
+	suite.Error(err)
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TestDeleteShow_NotFound() {
+	err := suite.radioService.DeleteShow(99999)
+
+	suite.Error(err)
+}
+
+// =============================================================================
+// EPISODE TESTS
+// =============================================================================
+
+func (suite *RadioServiceIntegrationTestSuite) TestGetEpisodes_Paginated() {
+	station := suite.createStation("KEXP")
+	show := suite.createShow(station.ID, "Morning Show")
+	suite.createEpisode(show.ID, "2026-01-01")
+	suite.createEpisode(show.ID, "2026-01-02")
+	suite.createEpisode(show.ID, "2026-01-03")
+
+	// First page
+	episodes, total, err := suite.radioService.GetEpisodes(show.ID, 2, 0)
+	suite.Require().NoError(err)
+	suite.Equal(int64(3), total)
+	suite.Len(episodes, 2)
+	// Ordered by air_date DESC
+	suite.Equal("2026-01-03", episodes[0].AirDate)
+	suite.Equal("2026-01-02", episodes[1].AirDate)
+
+	// Second page
+	episodes, _, err = suite.radioService.GetEpisodes(show.ID, 2, 2)
+	suite.Require().NoError(err)
+	suite.Len(episodes, 1)
+	suite.Equal("2026-01-01", episodes[0].AirDate)
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TestGetEpisodeByShowAndDate_Success() {
+	station := suite.createStation("KEXP")
+	show := suite.createShow(station.ID, "Morning Show")
+	suite.createEpisode(show.ID, "2026-01-15")
+
+	resp, err := suite.radioService.GetEpisodeByShowAndDate(show.ID, "2026-01-15")
+
+	suite.Require().NoError(err)
+	suite.Equal("2026-01-15", resp.AirDate)
+	suite.Equal("Morning Show", resp.ShowName)
+	suite.Equal("KEXP", resp.StationName)
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TestGetEpisodeByShowAndDate_NotFound() {
+	station := suite.createStation("KEXP")
+	show := suite.createShow(station.ID, "Morning Show")
+
+	_, err := suite.radioService.GetEpisodeByShowAndDate(show.ID, "2099-12-31")
+
+	suite.Error(err)
+	var radioErr *apperrors.RadioError
+	suite.ErrorAs(err, &radioErr)
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TestGetEpisodeDetail_WithPlays() {
+	station := suite.createStation("KEXP")
+	show := suite.createShow(station.ID, "Morning Show")
+	ep := suite.createEpisode(show.ID, "2026-01-15")
+
+	artist := suite.createArtist("Radiohead")
+	suite.createPlay(ep.ID, 0, "Radiohead")
+	// Play linked to our artist
+	linkedPlay := &models.RadioPlay{
+		EpisodeID:  ep.ID,
+		Position:   1,
+		ArtistName: "Radiohead",
+		ArtistID:   &artist.ID,
+	}
+	suite.Require().NoError(suite.db.Create(linkedPlay).Error)
+
+	resp, err := suite.radioService.GetEpisodeDetail(ep.ID)
+
+	suite.Require().NoError(err)
+	suite.Equal("2026-01-15", resp.AirDate)
+	suite.Len(resp.Plays, 2)
+	// Ordered by position ASC
+	suite.Equal(0, resp.Plays[0].Position)
+	suite.Nil(resp.Plays[0].ArtistID)
+	suite.Equal(1, resp.Plays[1].Position)
+	suite.NotNil(resp.Plays[1].ArtistID)
+	suite.Equal(artist.ID, *resp.Plays[1].ArtistID)
+	suite.NotNil(resp.Plays[1].ArtistSlug)
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TestGetEpisodeDetail_NotFound() {
+	_, err := suite.radioService.GetEpisodeDetail(99999)
+
+	suite.Error(err)
+	var radioErr *apperrors.RadioError
+	suite.ErrorAs(err, &radioErr)
+}
+
+// =============================================================================
+// TOP ARTISTS / LABELS TESTS
+// =============================================================================
+
+func (suite *RadioServiceIntegrationTestSuite) TestGetTopArtistsForShow_Success() {
+	station := suite.createStation("KEXP")
+	show := suite.createShow(station.ID, "Morning Show")
+	ep1 := suite.createEpisode(show.ID, "2026-01-01")
+	ep2 := suite.createEpisode(show.ID, "2026-01-02")
+
+	// Radiohead played 3 times, Deerhunter 1 time
+	suite.createPlay(ep1.ID, 0, "Radiohead")
+	suite.createPlay(ep1.ID, 1, "Radiohead")
+	suite.createPlay(ep2.ID, 0, "Radiohead")
+	suite.createPlay(ep2.ID, 1, "Deerhunter")
+
+	resp, err := suite.radioService.GetTopArtistsForShow(show.ID, 0, 10)
+
+	suite.Require().NoError(err)
+	suite.Len(resp, 2)
+	suite.Equal("Radiohead", resp[0].ArtistName)
+	suite.Equal(3, resp[0].PlayCount)
+	suite.Equal(2, resp[0].EpisodeCount)
+	suite.Equal("Deerhunter", resp[1].ArtistName)
+	suite.Equal(1, resp[1].PlayCount)
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TestGetTopArtistsForShow_WithPeriod() {
+	station := suite.createStation("KEXP")
+	show := suite.createShow(station.ID, "Morning Show")
+
+	// Recent episode
+	recentDate := time.Now().AddDate(0, 0, -10).Format("2006-01-02")
+	ep1 := suite.createEpisode(show.ID, recentDate)
+	suite.createPlay(ep1.ID, 0, "NewBand")
+
+	// Old episode (>90 days)
+	oldDate := time.Now().AddDate(0, 0, -100).Format("2006-01-02")
+	ep2 := suite.createEpisode(show.ID, oldDate)
+	suite.createPlay(ep2.ID, 0, "OldBand")
+
+	resp, err := suite.radioService.GetTopArtistsForShow(show.ID, 90, 10)
+
+	suite.Require().NoError(err)
+	suite.Len(resp, 1)
+	suite.Equal("NewBand", resp[0].ArtistName)
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TestGetTopLabelsForShow_Success() {
+	station := suite.createStation("KEXP")
+	show := suite.createShow(station.ID, "Morning Show")
+	ep := suite.createEpisode(show.ID, "2026-01-01")
+
+	labelName := "Sub Pop"
+	play1 := &models.RadioPlay{EpisodeID: ep.ID, Position: 0, ArtistName: "A", LabelName: &labelName}
+	play2 := &models.RadioPlay{EpisodeID: ep.ID, Position: 1, ArtistName: "B", LabelName: &labelName}
+	suite.Require().NoError(suite.db.Create(play1).Error)
+	suite.Require().NoError(suite.db.Create(play2).Error)
+
+	resp, err := suite.radioService.GetTopLabelsForShow(show.ID, 0, 10)
+
+	suite.Require().NoError(err)
+	suite.Len(resp, 1)
+	suite.Equal("Sub Pop", resp[0].LabelName)
+	suite.Equal(2, resp[0].PlayCount)
+}
+
+// =============================================================================
+// AS HEARD ON TESTS
+// =============================================================================
+
+func (suite *RadioServiceIntegrationTestSuite) TestGetAsHeardOnForArtist_Success() {
+	station := suite.createStation("KEXP")
+	show := suite.createShow(station.ID, "Morning Show")
+	ep := suite.createEpisode(show.ID, "2026-01-01")
+
+	artist := suite.createArtist("Radiohead")
+	play := &models.RadioPlay{
+		EpisodeID:  ep.ID,
+		Position:   0,
+		ArtistName: "Radiohead",
+		ArtistID:   &artist.ID,
+	}
+	suite.Require().NoError(suite.db.Create(play).Error)
+
+	resp, err := suite.radioService.GetAsHeardOnForArtist(artist.ID)
+
+	suite.Require().NoError(err)
+	suite.Len(resp, 1)
+	suite.Equal("KEXP", resp[0].StationName)
+	suite.Equal("Morning Show", resp[0].ShowName)
+	suite.Equal(1, resp[0].PlayCount)
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TestGetAsHeardOnForArtist_NoResults() {
+	artist := suite.createArtist("Nobody")
+
+	resp, err := suite.radioService.GetAsHeardOnForArtist(artist.ID)
+
+	suite.Require().NoError(err)
+	suite.Empty(resp)
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TestGetAsHeardOnForRelease_Success() {
+	station := suite.createStation("KEXP")
+	show := suite.createShow(station.ID, "Morning Show")
+	ep := suite.createEpisode(show.ID, "2026-01-01")
+
+	release := suite.createRelease("OK Computer")
+	play := &models.RadioPlay{
+		EpisodeID:  ep.ID,
+		Position:   0,
+		ArtistName: "Radiohead",
+		ReleaseID:  &release.ID,
+	}
+	suite.Require().NoError(suite.db.Create(play).Error)
+
+	resp, err := suite.radioService.GetAsHeardOnForRelease(release.ID)
+
+	suite.Require().NoError(err)
+	suite.Len(resp, 1)
+	suite.Equal("KEXP", resp[0].StationName)
+}
+
+// =============================================================================
+// NEW RELEASE RADAR TESTS
+// =============================================================================
+
+func (suite *RadioServiceIntegrationTestSuite) TestGetNewReleaseRadar_SingleStation() {
+	station := suite.createStation("KEXP")
+	show := suite.createShow(station.ID, "Morning Show")
+	ep := suite.createEpisode(show.ID, "2026-01-01")
+
+	album := "Moon Shaped Pool"
+	play := &models.RadioPlay{
+		EpisodeID:  ep.ID,
+		Position:   0,
+		ArtistName: "Radiohead",
+		AlbumTitle: &album,
+		IsNew:      true,
+	}
+	suite.Require().NoError(suite.db.Create(play).Error)
+
+	resp, err := suite.radioService.GetNewReleaseRadar(station.ID, 10)
+
+	suite.Require().NoError(err)
+	suite.Len(resp, 1)
+	suite.Equal("Radiohead", resp[0].ArtistName)
+	suite.Equal(&album, resp[0].AlbumTitle)
+	suite.Equal(1, resp[0].StationCount)
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TestGetNewReleaseRadar_CrossStation_RequiresTwo() {
+	station1 := suite.createStation("KEXP")
+	show1 := suite.createShow(station1.ID, "KEXP Morning")
+	ep1 := suite.createEpisode(show1.ID, "2026-01-01")
+
+	album := "Moon Shaped Pool"
+	play1 := &models.RadioPlay{EpisodeID: ep1.ID, Position: 0, ArtistName: "Radiohead", AlbumTitle: &album, IsNew: true}
+	suite.Require().NoError(suite.db.Create(play1).Error)
+
+	// Only one station, cross-station query should return nothing
+	resp, err := suite.radioService.GetNewReleaseRadar(0, 10)
+	suite.Require().NoError(err)
+	suite.Empty(resp)
+
+	// Add second station playing same new release
+	station2 := suite.createStation("WFMU")
+	show2 := suite.createShow(station2.ID, "WFMU Show")
+	ep2 := suite.createEpisode(show2.ID, "2026-01-02")
+	play2 := &models.RadioPlay{EpisodeID: ep2.ID, Position: 0, ArtistName: "Radiohead", AlbumTitle: &album, IsNew: true}
+	suite.Require().NoError(suite.db.Create(play2).Error)
+
+	resp, err = suite.radioService.GetNewReleaseRadar(0, 10)
+	suite.Require().NoError(err)
+	suite.Len(resp, 1)
+	suite.Equal(2, resp[0].StationCount)
+}
+
+// =============================================================================
+// STATS TESTS
+// =============================================================================
+
+func (suite *RadioServiceIntegrationTestSuite) TestGetRadioStats_Empty() {
+	resp, err := suite.radioService.GetRadioStats()
+
+	suite.Require().NoError(err)
+	suite.Equal(0, resp.TotalStations)
+	suite.Equal(0, resp.TotalShows)
+	suite.Equal(0, resp.TotalEpisodes)
+	suite.Equal(int64(0), resp.TotalPlays)
+}
+
+func (suite *RadioServiceIntegrationTestSuite) TestGetRadioStats_WithData() {
+	station := suite.createStation("KEXP")
+	show := suite.createShow(station.ID, "Morning Show")
+	ep := suite.createEpisode(show.ID, "2026-01-01")
+
+	artist := suite.createArtist("Radiohead")
+	linked := &models.RadioPlay{EpisodeID: ep.ID, Position: 0, ArtistName: "Radiohead", ArtistID: &artist.ID}
+	unlinked := &models.RadioPlay{EpisodeID: ep.ID, Position: 1, ArtistName: "Unknown"}
+	suite.Require().NoError(suite.db.Create(linked).Error)
+	suite.Require().NoError(suite.db.Create(unlinked).Error)
+
+	resp, err := suite.radioService.GetRadioStats()
+
+	suite.Require().NoError(err)
+	suite.Equal(1, resp.TotalStations)
+	suite.Equal(1, resp.TotalShows)
+	suite.Equal(1, resp.TotalEpisodes)
+	suite.Equal(int64(2), resp.TotalPlays)
+	suite.Equal(int64(1), resp.MatchedPlays)
+	suite.Equal(1, resp.UniqueArtists)
+}
+
+// =============================================================================
+// CASCADE DELETE TESTS
+// =============================================================================
+
+func (suite *RadioServiceIntegrationTestSuite) TestDeleteStation_CascadesShows() {
+	station := suite.createStation("KEXP")
+	show := suite.createShow(station.ID, "Morning Show")
+	ep := suite.createEpisode(show.ID, "2026-01-01")
+	suite.createPlay(ep.ID, 0, "Radiohead")
+
+	err := suite.radioService.DeleteStation(station.ID)
+	suite.Require().NoError(err)
+
+	// Verify cascade — shows, episodes, and plays should all be gone
+	var showCount int64
+	suite.db.Model(&models.RadioShow{}).Where("station_id = ?", station.ID).Count(&showCount)
+	suite.Equal(int64(0), showCount)
+
+	var epCount int64
+	suite.db.Model(&models.RadioEpisode{}).Where("show_id = ?", show.ID).Count(&epCount)
+	suite.Equal(int64(0), epCount)
+
+	var playCount int64
+	suite.db.Model(&models.RadioPlay{}).Where("episode_id = ?", ep.ID).Count(&playCount)
+	suite.Equal(int64(0), playCount)
+}

--- a/backend/internal/services/container.go
+++ b/backend/internal/services/container.go
@@ -51,6 +51,7 @@ type ServiceContainer struct {
 	EntityReport  *adminsvc.EntityReportService
 	User              *usersvc.UserService
 	Leaderboard       *usersvc.LeaderboardService
+	Radio             *catalog.RadioService
 	Venue             *catalog.VenueService
 	VenueSourceConfig *pipeline.VenueSourceConfigService
 
@@ -159,6 +160,7 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 		EntityReport:  adminsvc.NewEntityReportService(database),
 		User:          userService,
 		Leaderboard:   usersvc.NewLeaderboardService(database),
+		Radio:             catalog.NewRadioService(database),
 		Venue:             venue,
 		VenueSourceConfig: venueSourceConfig,
 

--- a/backend/internal/services/contracts/interfaces.go
+++ b/backend/internal/services/contracts/interfaces.go
@@ -543,3 +543,37 @@ type FollowServiceInterface interface {
 	GetUserFollowing(userID uint, entityType string, limit, offset int) ([]*FollowingEntityResponse, int64, error)
 	GetFollowers(entityType string, entityID uint, limit, offset int) ([]*FollowerResponse, int64, error)
 }
+
+// RadioServiceInterface defines the contract for radio station, show, episode, and play operations.
+type RadioServiceInterface interface {
+	// Station CRUD
+	CreateStation(req *CreateRadioStationRequest) (*RadioStationDetailResponse, error)
+	GetStation(stationID uint) (*RadioStationDetailResponse, error)
+	GetStationBySlug(slug string) (*RadioStationDetailResponse, error)
+	ListStations(filters map[string]interface{}) ([]*RadioStationListResponse, error)
+	UpdateStation(stationID uint, req *UpdateRadioStationRequest) (*RadioStationDetailResponse, error)
+	DeleteStation(stationID uint) error
+
+	// Show CRUD
+	CreateShow(stationID uint, req *CreateRadioShowRequest) (*RadioShowDetailResponse, error)
+	GetShow(showID uint) (*RadioShowDetailResponse, error)
+	GetShowBySlug(slug string) (*RadioShowDetailResponse, error)
+	ListShows(stationID uint) ([]*RadioShowListResponse, error)
+	UpdateShow(showID uint, req *UpdateRadioShowRequest) (*RadioShowDetailResponse, error)
+	DeleteShow(showID uint) error
+
+	// Episodes
+	GetEpisodes(showID uint, limit, offset int) ([]*RadioEpisodeResponse, int64, error)
+	GetEpisodeByShowAndDate(showID uint, airDate string) (*RadioEpisodeDetailResponse, error)
+	GetEpisodeDetail(episodeID uint) (*RadioEpisodeDetailResponse, error)
+
+	// Aggregation queries
+	GetTopArtistsForShow(showID uint, periodDays, limit int) ([]*RadioTopArtistResponse, error)
+	GetTopLabelsForShow(showID uint, periodDays, limit int) ([]*RadioTopLabelResponse, error)
+	GetAsHeardOnForArtist(artistID uint) ([]*RadioAsHeardOnResponse, error)
+	GetAsHeardOnForRelease(releaseID uint) ([]*RadioAsHeardOnResponse, error)
+	GetNewReleaseRadar(stationID uint, limit int) ([]*RadioNewReleaseRadarEntry, error)
+
+	// Stats
+	GetRadioStats() (*RadioStatsResponse, error)
+}

--- a/backend/internal/services/contracts/radio.go
+++ b/backend/internal/services/contracts/radio.go
@@ -1,0 +1,291 @@
+package contracts
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// ──────────────────────────────────────────────
+// Radio Station types
+// ──────────────────────────────────────────────
+
+// CreateRadioStationRequest represents the data needed to create a new radio station
+type CreateRadioStationRequest struct {
+	Name             string           `json:"name" validate:"required"`
+	Slug             string           `json:"slug"`
+	Description      *string          `json:"description"`
+	City             *string          `json:"city"`
+	State            *string          `json:"state"`
+	Country          *string          `json:"country"`
+	Timezone         *string          `json:"timezone"`
+	StreamURL        *string          `json:"stream_url"`
+	StreamURLs       *json.RawMessage `json:"stream_urls,omitempty"`
+	Website          *string          `json:"website"`
+	DonationURL      *string          `json:"donation_url"`
+	DonationEmbedURL *string          `json:"donation_embed_url"`
+	LogoURL          *string          `json:"logo_url"`
+	Social           *json.RawMessage `json:"social,omitempty"`
+	BroadcastType    string           `json:"broadcast_type" validate:"required"`
+	FrequencyMHz     *float64         `json:"frequency_mhz"`
+	PlaylistSource   *string          `json:"playlist_source"`
+	PlaylistConfig   *json.RawMessage `json:"playlist_config,omitempty"`
+}
+
+// UpdateRadioStationRequest represents the data that can be updated on a radio station
+type UpdateRadioStationRequest struct {
+	Name             *string          `json:"name"`
+	Description      *string          `json:"description"`
+	City             *string          `json:"city"`
+	State            *string          `json:"state"`
+	Country          *string          `json:"country"`
+	Timezone         *string          `json:"timezone"`
+	StreamURL        *string          `json:"stream_url"`
+	StreamURLs       *json.RawMessage `json:"stream_urls,omitempty"`
+	Website          *string          `json:"website"`
+	DonationURL      *string          `json:"donation_url"`
+	DonationEmbedURL *string          `json:"donation_embed_url"`
+	LogoURL          *string          `json:"logo_url"`
+	Social           *json.RawMessage `json:"social,omitempty"`
+	BroadcastType    *string          `json:"broadcast_type"`
+	FrequencyMHz     *float64         `json:"frequency_mhz"`
+	PlaylistSource   *string          `json:"playlist_source"`
+	PlaylistConfig   *json.RawMessage `json:"playlist_config,omitempty"`
+	IsActive         *bool            `json:"is_active"`
+}
+
+// RadioStationDetailResponse represents the full radio station data returned to clients
+type RadioStationDetailResponse struct {
+	ID                  uint             `json:"id"`
+	Name                string           `json:"name"`
+	Slug                string           `json:"slug"`
+	Description         *string          `json:"description"`
+	City                *string          `json:"city"`
+	State               *string          `json:"state"`
+	Country             *string          `json:"country"`
+	Timezone            *string          `json:"timezone"`
+	StreamURL           *string          `json:"stream_url"`
+	StreamURLs          *json.RawMessage `json:"stream_urls"`
+	Website             *string          `json:"website"`
+	DonationURL         *string          `json:"donation_url"`
+	DonationEmbedURL    *string          `json:"donation_embed_url"`
+	LogoURL             *string          `json:"logo_url"`
+	Social              *json.RawMessage `json:"social"`
+	BroadcastType       string           `json:"broadcast_type"`
+	FrequencyMHz        *float64         `json:"frequency_mhz"`
+	PlaylistSource      *string          `json:"playlist_source"`
+	PlaylistConfig      *json.RawMessage `json:"playlist_config"`
+	LastPlaylistFetchAt *time.Time       `json:"last_playlist_fetch_at"`
+	IsActive            bool             `json:"is_active"`
+	ShowCount           int              `json:"show_count"`
+	CreatedAt           time.Time        `json:"created_at"`
+	UpdatedAt           time.Time        `json:"updated_at"`
+}
+
+// RadioStationListResponse represents a radio station in list views
+type RadioStationListResponse struct {
+	ID            uint     `json:"id"`
+	Name          string   `json:"name"`
+	Slug          string   `json:"slug"`
+	City          *string  `json:"city"`
+	State         *string  `json:"state"`
+	Country       *string  `json:"country"`
+	BroadcastType string   `json:"broadcast_type"`
+	FrequencyMHz  *float64 `json:"frequency_mhz"`
+	LogoURL       *string  `json:"logo_url"`
+	IsActive      bool     `json:"is_active"`
+	ShowCount     int      `json:"show_count"`
+}
+
+// ──────────────────────────────────────────────
+// Radio Show types
+// ──────────────────────────────────────────────
+
+// CreateRadioShowRequest represents the data needed to create a new radio show
+type CreateRadioShowRequest struct {
+	Name            string           `json:"name" validate:"required"`
+	Slug            string           `json:"slug"`
+	HostName        *string          `json:"host_name"`
+	Description     *string          `json:"description"`
+	ScheduleDisplay *string          `json:"schedule_display"`
+	Schedule        *json.RawMessage `json:"schedule,omitempty"`
+	GenreTags       *json.RawMessage `json:"genre_tags,omitempty"`
+	ArchiveURL      *string          `json:"archive_url"`
+	ImageURL        *string          `json:"image_url"`
+	ExternalID      *string          `json:"external_id"`
+}
+
+// UpdateRadioShowRequest represents the data that can be updated on a radio show
+type UpdateRadioShowRequest struct {
+	Name            *string          `json:"name"`
+	HostName        *string          `json:"host_name"`
+	Description     *string          `json:"description"`
+	ScheduleDisplay *string          `json:"schedule_display"`
+	Schedule        *json.RawMessage `json:"schedule,omitempty"`
+	GenreTags       *json.RawMessage `json:"genre_tags,omitempty"`
+	ArchiveURL      *string          `json:"archive_url"`
+	ImageURL        *string          `json:"image_url"`
+	IsActive        *bool            `json:"is_active"`
+}
+
+// RadioShowDetailResponse represents the full radio show data returned to clients
+type RadioShowDetailResponse struct {
+	ID              uint             `json:"id"`
+	StationID       uint             `json:"station_id"`
+	StationName     string           `json:"station_name"`
+	StationSlug     string           `json:"station_slug"`
+	Name            string           `json:"name"`
+	Slug            string           `json:"slug"`
+	HostName        *string          `json:"host_name"`
+	Description     *string          `json:"description"`
+	ScheduleDisplay *string          `json:"schedule_display"`
+	Schedule        *json.RawMessage `json:"schedule"`
+	GenreTags       *json.RawMessage `json:"genre_tags"`
+	ArchiveURL      *string          `json:"archive_url"`
+	ImageURL        *string          `json:"image_url"`
+	IsActive        bool             `json:"is_active"`
+	EpisodeCount    int64            `json:"episode_count"`
+	CreatedAt       time.Time        `json:"created_at"`
+	UpdatedAt       time.Time        `json:"updated_at"`
+}
+
+// RadioShowListResponse represents a radio show in list views
+type RadioShowListResponse struct {
+	ID              uint             `json:"id"`
+	StationID       uint             `json:"station_id"`
+	StationName     string           `json:"station_name"`
+	Name            string           `json:"name"`
+	Slug            string           `json:"slug"`
+	HostName        *string          `json:"host_name"`
+	GenreTags       *json.RawMessage `json:"genre_tags"`
+	ImageURL        *string          `json:"image_url"`
+	IsActive        bool             `json:"is_active"`
+	EpisodeCount    int64            `json:"episode_count"`
+}
+
+// ──────────────────────────────────────────────
+// Radio Episode types
+// ──────────────────────────────────────────────
+
+// RadioEpisodeResponse represents a radio episode in list views
+type RadioEpisodeResponse struct {
+	ID              uint      `json:"id"`
+	ShowID          uint      `json:"show_id"`
+	Title           *string   `json:"title"`
+	AirDate         string    `json:"air_date"`
+	AirTime         *string   `json:"air_time"`
+	DurationMinutes *int      `json:"duration_minutes"`
+	ArchiveURL      *string   `json:"archive_url"`
+	PlayCount       int       `json:"play_count"`
+	CreatedAt       time.Time `json:"created_at"`
+}
+
+// RadioEpisodeDetailResponse represents the full radio episode data
+type RadioEpisodeDetailResponse struct {
+	ID              uint             `json:"id"`
+	ShowID          uint             `json:"show_id"`
+	ShowName        string           `json:"show_name"`
+	ShowSlug        string           `json:"show_slug"`
+	StationName     string           `json:"station_name"`
+	StationSlug     string           `json:"station_slug"`
+	Title           *string          `json:"title"`
+	AirDate         string           `json:"air_date"`
+	AirTime         *string          `json:"air_time"`
+	DurationMinutes *int             `json:"duration_minutes"`
+	Description     *string          `json:"description"`
+	ArchiveURL      *string          `json:"archive_url"`
+	MixcloudURL     *string          `json:"mixcloud_url"`
+	GenreTags       *json.RawMessage `json:"genre_tags"`
+	MoodTags        *json.RawMessage `json:"mood_tags"`
+	PlayCount       int              `json:"play_count"`
+	Plays           []RadioPlayResponse `json:"plays"`
+	CreatedAt       time.Time        `json:"created_at"`
+}
+
+// ──────────────────────────────────────────────
+// Radio Play types
+// ──────────────────────────────────────────────
+
+// RadioPlayResponse represents a single track played in a radio episode
+type RadioPlayResponse struct {
+	ID                     uint       `json:"id"`
+	EpisodeID              uint       `json:"episode_id"`
+	Position               int        `json:"position"`
+	ArtistName             string     `json:"artist_name"`
+	TrackTitle             *string    `json:"track_title"`
+	AlbumTitle             *string    `json:"album_title"`
+	LabelName              *string    `json:"label_name"`
+	ReleaseYear            *int       `json:"release_year"`
+	IsNew                  bool       `json:"is_new"`
+	RotationStatus         *string    `json:"rotation_status"`
+	DJComment              *string    `json:"dj_comment"`
+	IsLivePerformance      bool       `json:"is_live_performance"`
+	IsRequest              bool       `json:"is_request"`
+	ArtistID               *uint      `json:"artist_id"`
+	ArtistSlug             *string    `json:"artist_slug"`
+	ReleaseID              *uint      `json:"release_id"`
+	ReleaseSlug            *string    `json:"release_slug"`
+	LabelID                *uint      `json:"label_id"`
+	LabelSlug              *string    `json:"label_slug"`
+	MusicBrainzArtistID    *string    `json:"musicbrainz_artist_id"`
+	MusicBrainzRecordingID *string    `json:"musicbrainz_recording_id"`
+	MusicBrainzReleaseID   *string    `json:"musicbrainz_release_id"`
+	AirTimestamp           *time.Time `json:"air_timestamp"`
+}
+
+// ──────────────────────────────────────────────
+// Aggregation / stats types
+// ──────────────────────────────────────────────
+
+// RadioTopArtistResponse represents a top-played artist for a show
+type RadioTopArtistResponse struct {
+	ArtistName   string  `json:"artist_name"`
+	ArtistID     *uint   `json:"artist_id"`
+	ArtistSlug   *string `json:"artist_slug"`
+	PlayCount    int     `json:"play_count"`
+	EpisodeCount int     `json:"episode_count"`
+}
+
+// RadioTopLabelResponse represents a top-featured label for a show
+type RadioTopLabelResponse struct {
+	LabelName string  `json:"label_name"`
+	LabelID   *uint   `json:"label_id"`
+	LabelSlug *string `json:"label_slug"`
+	PlayCount int     `json:"play_count"`
+}
+
+// RadioAsHeardOnResponse represents a station/show where an entity was played
+type RadioAsHeardOnResponse struct {
+	StationID   uint   `json:"station_id"`
+	StationName string `json:"station_name"`
+	StationSlug string `json:"station_slug"`
+	ShowID      uint   `json:"show_id"`
+	ShowName    string `json:"show_name"`
+	ShowSlug    string `json:"show_slug"`
+	PlayCount   int    `json:"play_count"`
+	LastPlayed  string `json:"last_played"`
+}
+
+// RadioNewReleaseRadarEntry represents a new release discovered across radio stations
+type RadioNewReleaseRadarEntry struct {
+	ArtistName  string  `json:"artist_name"`
+	ArtistID    *uint   `json:"artist_id"`
+	ArtistSlug  *string `json:"artist_slug"`
+	AlbumTitle  *string `json:"album_title"`
+	LabelName   *string `json:"label_name"`
+	ReleaseID   *uint   `json:"release_id"`
+	ReleaseSlug *string `json:"release_slug"`
+	LabelID     *uint   `json:"label_id"`
+	LabelSlug   *string `json:"label_slug"`
+	PlayCount   int     `json:"play_count"`
+	StationCount int    `json:"station_count"`
+}
+
+// RadioStatsResponse represents overall radio stats
+type RadioStatsResponse struct {
+	TotalStations int   `json:"total_stations"`
+	TotalShows    int   `json:"total_shows"`
+	TotalEpisodes int   `json:"total_episodes"`
+	TotalPlays    int64 `json:"total_plays"`
+	MatchedPlays  int64 `json:"matched_plays"`
+	UniqueArtists int   `json:"unique_artists"`
+}

--- a/backend/internal/services/interfaces.go
+++ b/backend/internal/services/interfaces.go
@@ -32,4 +32,5 @@ var (
 	_ contracts.SceneServiceInterface               = (*catalog.SceneService)(nil)
 	_ contracts.FestivalIntelligenceServiceInterface = (*catalog.FestivalIntelligenceService)(nil)
 	_ contracts.ChartsServiceInterface              = (*catalog.ChartsService)(nil)
+	_ contracts.RadioServiceInterface               = (*catalog.RadioService)(nil)
 )


### PR DESCRIPTION
## Summary
- **RadioService** with 21 methods: full CRUD for stations/shows, paginated episode listing, episode detail with linked playlist, top artists/labels per show, "as heard on" for artists/releases, new release radar, stats
- **Contracts**: `RadioServiceInterface` + 14 request/response types in `contracts/radio.go`
- **Error types**: Station/show/episode not found errors in `errors/radio.go`
- **Wired** into `ServiceContainer` with compile-time interface check
- **46 tests** (4 nil-DB unit + 41 integration with testcontainers)

Closes PSY-161

## Test plan
- [x] All 46 tests pass (`go test ./internal/services/catalog/ -run TestRadioService`)
- [x] Full build compiles cleanly (`go build ./...`)
- [x] Station CRUD with slug generation and broadcast type validation
- [x] Show CRUD with station FK verification
- [x] Episode pagination and detail with linked entity slugs
- [x] Top artists/labels aggregation with time period filtering
- [x] As-heard-on queries for artists and releases
- [x] New release radar with 2+ station cross-station threshold
- [x] Cascade delete (station → shows → episodes → plays)
- [x] Nil-DB error paths for all methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)