### PR TITLE
Add KEXP provider, matching engine, and import pipeline (PSY-163)

### DIFF
--- a/backend/internal/services/catalog/radio_import.go
+++ b/backend/internal/services/catalog/radio_import.go
@@ -1,0 +1,380 @@
+package catalog
+
+import (
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/utils"
+)
+
+// getProvider returns the appropriate RadioPlaylistProvider for a station's playlist_source.
+func (s *RadioService) getProvider(source string) (RadioPlaylistProvider, error) {
+	switch source {
+	case models.PlaylistSourceKEXP:
+		return NewKEXPProvider(), nil
+	default:
+		return nil, fmt.Errorf("unsupported playlist source: %s", source)
+	}
+}
+
+// ImportStation runs a full import: discover shows + fetch episodes for the last N days.
+func (s *RadioService) ImportStation(stationID uint, backfillDays int) (*contracts.RadioImportResult, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var station models.RadioStation
+	if err := s.db.First(&station, stationID).Error; err != nil {
+		return nil, fmt.Errorf("station not found: %w", err)
+	}
+
+	if station.PlaylistSource == nil || *station.PlaylistSource == "" {
+		return nil, fmt.Errorf("station %d has no playlist source configured", stationID)
+	}
+
+	provider, err := s.getProvider(*station.PlaylistSource)
+	if err != nil {
+		return nil, err
+	}
+	defer closeProvider(provider)
+
+	result := &contracts.RadioImportResult{}
+
+	// 1. Discover shows
+	importedShows, err := provider.DiscoverShows()
+	if err != nil {
+		result.Errors = append(result.Errors, fmt.Sprintf("discover shows: %v", err))
+		return result, nil
+	}
+
+	showMap := make(map[string]uint) // external_id → our show ID
+	for _, importShow := range importedShows {
+		showID, err := s.upsertRadioShow(stationID, importShow)
+		if err != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("upsert show %s: %v", importShow.Name, err))
+			continue
+		}
+		showMap[importShow.ExternalID] = showID
+		result.ShowsDiscovered++
+	}
+
+	// 2. Fetch episodes for each show
+	since := time.Now().AddDate(0, 0, -backfillDays)
+	for extID, showID := range showMap {
+		episodes, err := provider.FetchNewEpisodes(extID, since)
+		if err != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("fetch episodes for show %s: %v", extID, err))
+			continue
+		}
+
+		for _, ep := range episodes {
+			epResult, err := s.importEpisode(showID, ep, provider)
+			if err != nil {
+				result.Errors = append(result.Errors, fmt.Sprintf("import episode %s: %v", ep.ExternalID, err))
+				continue
+			}
+			result.EpisodesImported++
+			result.PlaysImported += epResult.PlaysImported
+			result.PlaysMatched += epResult.PlaysMatched
+		}
+	}
+
+	// Update last fetch timestamp
+	now := time.Now()
+	s.db.Model(&station).Update("last_playlist_fetch_at", now)
+
+	return result, nil
+}
+
+// FetchNewEpisodes does an incremental fetch since last_playlist_fetch_at.
+func (s *RadioService) FetchNewEpisodes(stationID uint) (*contracts.RadioImportResult, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var station models.RadioStation
+	if err := s.db.First(&station, stationID).Error; err != nil {
+		return nil, fmt.Errorf("station not found: %w", err)
+	}
+
+	if station.PlaylistSource == nil || *station.PlaylistSource == "" {
+		return nil, fmt.Errorf("station %d has no playlist source configured", stationID)
+	}
+
+	provider, err := s.getProvider(*station.PlaylistSource)
+	if err != nil {
+		return nil, err
+	}
+	defer closeProvider(provider)
+
+	// Determine since time: last fetch or 7 days ago
+	since := time.Now().AddDate(0, 0, -7)
+	if station.LastPlaylistFetchAt != nil {
+		since = *station.LastPlaylistFetchAt
+	}
+
+	result := &contracts.RadioImportResult{}
+
+	// Get all shows for this station
+	var shows []models.RadioShow
+	if err := s.db.Where("station_id = ?", stationID).Find(&shows).Error; err != nil {
+		return nil, fmt.Errorf("loading shows: %w", err)
+	}
+
+	for _, show := range shows {
+		if show.ExternalID == nil || *show.ExternalID == "" {
+			continue
+		}
+
+		episodes, err := provider.FetchNewEpisodes(*show.ExternalID, since)
+		if err != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("fetch episodes for show %s: %v", show.Name, err))
+			continue
+		}
+
+		for _, ep := range episodes {
+			epResult, err := s.importEpisode(show.ID, ep, provider)
+			if err != nil {
+				result.Errors = append(result.Errors, fmt.Sprintf("import episode %s: %v", ep.ExternalID, err))
+				continue
+			}
+			result.EpisodesImported++
+			result.PlaysImported += epResult.PlaysImported
+			result.PlaysMatched += epResult.PlaysMatched
+		}
+	}
+
+	// Update last fetch timestamp
+	now := time.Now()
+	s.db.Model(&station).Update("last_playlist_fetch_at", now)
+
+	return result, nil
+}
+
+// ImportEpisodePlaylist fetches and imports a single episode's playlist by external ID.
+func (s *RadioService) ImportEpisodePlaylist(showID uint, episodeExternalID string) (*contracts.EpisodeImportResult, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	// Look up show and station to get the provider
+	var show models.RadioShow
+	if err := s.db.Preload("Station").First(&show, showID).Error; err != nil {
+		return nil, fmt.Errorf("show not found: %w", err)
+	}
+
+	if show.Station.PlaylistSource == nil || *show.Station.PlaylistSource == "" {
+		return nil, fmt.Errorf("station has no playlist source configured")
+	}
+
+	provider, err := s.getProvider(*show.Station.PlaylistSource)
+	if err != nil {
+		return nil, err
+	}
+	defer closeProvider(provider)
+
+	// Find the episode by external_id
+	var episode models.RadioEpisode
+	err = s.db.Where("show_id = ? AND external_id = ?", showID, episodeExternalID).First(&episode).Error
+	if err != nil {
+		return nil, fmt.Errorf("episode not found: %w", err)
+	}
+
+	// Fetch and import the playlist
+	plays, err := provider.FetchPlaylist(episodeExternalID)
+	if err != nil {
+		return nil, fmt.Errorf("fetching playlist: %w", err)
+	}
+
+	imported, err := s.importPlays(episode.ID, plays)
+	if err != nil {
+		return nil, fmt.Errorf("importing plays: %w", err)
+	}
+
+	// Run matching
+	matcher := NewRadioMatchingEngine(s.db)
+	matchResult, err := matcher.MatchPlaysForEpisode(episode.ID)
+	if err != nil {
+		return &contracts.EpisodeImportResult{PlaysImported: imported}, nil
+	}
+
+	return &contracts.EpisodeImportResult{
+		PlaysImported: imported,
+		PlaysMatched:  matchResult.Matched,
+	}, nil
+}
+
+// MatchPlays runs the matching engine on unmatched plays for an episode.
+func (s *RadioService) MatchPlays(episodeID uint) (*contracts.MatchResult, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	matcher := NewRadioMatchingEngine(s.db)
+	return matcher.MatchPlaysForEpisode(episodeID)
+}
+
+// =============================================================================
+// Internal import helpers
+// =============================================================================
+
+// upsertRadioShow creates or updates a radio show from import data.
+// Returns the internal show ID.
+func (s *RadioService) upsertRadioShow(stationID uint, importShow RadioShowImport) (uint, error) {
+	var existing models.RadioShow
+	err := s.db.Where("station_id = ? AND external_id = ?", stationID, importShow.ExternalID).First(&existing).Error
+	if err == nil {
+		// Update existing show
+		updates := map[string]interface{}{
+			"name": importShow.Name,
+		}
+		if importShow.HostName != nil {
+			updates["host_name"] = *importShow.HostName
+		}
+		if importShow.Description != nil {
+			updates["description"] = *importShow.Description
+		}
+		if importShow.ImageURL != nil {
+			updates["image_url"] = *importShow.ImageURL
+		}
+		if importShow.ArchiveURL != nil {
+			updates["archive_url"] = *importShow.ArchiveURL
+		}
+
+		s.db.Model(&existing).Updates(updates)
+		return existing.ID, nil
+	}
+
+	if err != gorm.ErrRecordNotFound {
+		return 0, fmt.Errorf("checking existing show: %w", err)
+	}
+
+	// Create new show
+	baseSlug := utils.GenerateArtistSlug(importShow.Name)
+	slug := utils.GenerateUniqueSlug(baseSlug, func(candidate string) bool {
+		var count int64
+		s.db.Model(&models.RadioShow{}).Where("slug = ?", candidate).Count(&count)
+		return count > 0
+	})
+
+	show := &models.RadioShow{
+		StationID:   stationID,
+		Name:        importShow.Name,
+		Slug:        slug,
+		HostName:    importShow.HostName,
+		Description: importShow.Description,
+		ImageURL:    importShow.ImageURL,
+		ArchiveURL:  importShow.ArchiveURL,
+		ExternalID:  &importShow.ExternalID,
+	}
+
+	if err := s.db.Create(show).Error; err != nil {
+		return 0, fmt.Errorf("creating show: %w", err)
+	}
+
+	return show.ID, nil
+}
+
+// importEpisode imports a single episode and its playlist.
+func (s *RadioService) importEpisode(showID uint, ep RadioEpisodeImport, provider RadioPlaylistProvider) (*contracts.EpisodeImportResult, error) {
+	// Check for existing episode (dedup by show_id + external_id)
+	var existing models.RadioEpisode
+	err := s.db.Where("show_id = ? AND external_id = ?", showID, ep.ExternalID).First(&existing).Error
+	if err == nil {
+		// Episode already exists — skip to avoid duplicates
+		return &contracts.EpisodeImportResult{}, nil
+	}
+	if err != gorm.ErrRecordNotFound {
+		return nil, fmt.Errorf("checking existing episode: %w", err)
+	}
+
+	// Create episode
+	episode := &models.RadioEpisode{
+		ShowID:          showID,
+		Title:           ep.Title,
+		AirDate:         ep.AirDate,
+		AirTime:         ep.AirTime,
+		DurationMinutes: ep.DurationMinutes,
+		ArchiveURL:      ep.ArchiveURL,
+		ExternalID:      &ep.ExternalID,
+	}
+
+	if err := s.db.Create(episode).Error; err != nil {
+		return nil, fmt.Errorf("creating episode: %w", err)
+	}
+
+	// Fetch and import playlist
+	plays, err := provider.FetchPlaylist(ep.ExternalID)
+	if err != nil {
+		return &contracts.EpisodeImportResult{}, nil // non-fatal: episode created but no plays
+	}
+
+	imported, err := s.importPlays(episode.ID, plays)
+	if err != nil {
+		return &contracts.EpisodeImportResult{PlaysImported: imported}, nil
+	}
+
+	// Update play count on episode
+	s.db.Model(episode).Update("play_count", imported)
+
+	// Run matching
+	matcher := NewRadioMatchingEngine(s.db)
+	matchResult, err := matcher.MatchPlaysForEpisode(episode.ID)
+	if err != nil {
+		return &contracts.EpisodeImportResult{PlaysImported: imported}, nil
+	}
+
+	return &contracts.EpisodeImportResult{
+		PlaysImported: imported,
+		PlaysMatched:  matchResult.Matched,
+	}, nil
+}
+
+// importPlays batch-creates play records for an episode.
+func (s *RadioService) importPlays(episodeID uint, plays []RadioPlayImport) (int, error) {
+	if len(plays) == 0 {
+		return 0, nil
+	}
+
+	records := make([]models.RadioPlay, 0, len(plays))
+	for _, p := range plays {
+		record := models.RadioPlay{
+			EpisodeID:              episodeID,
+			Position:               p.Position,
+			ArtistName:             p.ArtistName,
+			TrackTitle:             p.TrackTitle,
+			AlbumTitle:             p.AlbumTitle,
+			LabelName:              p.LabelName,
+			ReleaseYear:            p.ReleaseYear,
+			IsNew:                  p.IsNew,
+			RotationStatus:         p.RotationStatus,
+			DJComment:              p.DJComment,
+			IsLivePerformance:      p.IsLivePerformance,
+			IsRequest:              p.IsRequest,
+			MusicBrainzArtistID:    p.MusicBrainzArtistID,
+			MusicBrainzRecordingID: p.MusicBrainzRecordingID,
+			MusicBrainzReleaseID:   p.MusicBrainzReleaseID,
+			AirTimestamp:           p.AirTimestamp,
+		}
+		records = append(records, record)
+	}
+
+	// Batch insert
+	if err := s.db.CreateInBatches(records, 100).Error; err != nil {
+		return 0, fmt.Errorf("batch inserting plays: %w", err)
+	}
+
+	return len(records), nil
+}
+
+// closeProvider closes a provider if it implements a Close method.
+func closeProvider(provider RadioPlaylistProvider) {
+	if closer, ok := provider.(interface{ Close() }); ok {
+		closer.Close()
+	}
+}
+

--- a/backend/internal/services/catalog/radio_matching.go
+++ b/backend/internal/services/catalog/radio_matching.go
@@ -1,0 +1,167 @@
+package catalog
+
+import (
+	"fmt"
+	"strings"
+
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// RadioMatchingEngine handles matching radio plays to entities in our knowledge graph.
+// It is provider-agnostic and runs after plays are imported.
+type RadioMatchingEngine struct {
+	db *gorm.DB
+}
+
+// NewRadioMatchingEngine creates a new matching engine.
+func NewRadioMatchingEngine(db *gorm.DB) *RadioMatchingEngine {
+	return &RadioMatchingEngine{db: db}
+}
+
+// MatchPlaysForEpisode runs the matching engine on all unmatched plays for an episode.
+// Returns a MatchResult summarizing how many were matched.
+func (m *RadioMatchingEngine) MatchPlaysForEpisode(episodeID uint) (*contracts.MatchResult, error) {
+	if m.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var plays []models.RadioPlay
+	err := m.db.Where("episode_id = ? AND artist_id IS NULL", episodeID).Find(&plays).Error
+	if err != nil {
+		return nil, fmt.Errorf("loading unmatched plays: %w", err)
+	}
+
+	result := &contracts.MatchResult{
+		Total: len(plays),
+	}
+
+	for i := range plays {
+		matched := m.matchPlay(&plays[i])
+		if matched {
+			result.Matched++
+		} else {
+			result.Unmatched++
+		}
+	}
+
+	return result, nil
+}
+
+// MatchAllUnmatched runs the matching engine on all unmatched plays in the database.
+func (m *RadioMatchingEngine) MatchAllUnmatched() (*contracts.MatchResult, error) {
+	if m.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var plays []models.RadioPlay
+	err := m.db.Where("artist_id IS NULL").Find(&plays).Error
+	if err != nil {
+		return nil, fmt.Errorf("loading unmatched plays: %w", err)
+	}
+
+	result := &contracts.MatchResult{
+		Total: len(plays),
+	}
+
+	for i := range plays {
+		matched := m.matchPlay(&plays[i])
+		if matched {
+			result.Matched++
+		} else {
+			result.Unmatched++
+		}
+	}
+
+	return result, nil
+}
+
+// matchPlay attempts to match a single play to entities in our knowledge graph.
+// Returns true if at least the artist was matched. Updates the play record in the DB.
+func (m *RadioMatchingEngine) matchPlay(play *models.RadioPlay) bool {
+	updates := make(map[string]interface{})
+	artistMatched := false
+
+	// 1. Match artist
+	if artistID := m.matchArtist(play.ArtistName, play.MusicBrainzArtistID); artistID != nil {
+		updates["artist_id"] = *artistID
+		artistMatched = true
+	}
+
+	// 2. Match release (by MB ID or exact title match)
+	if releaseID := m.matchRelease(play.AlbumTitle, play.MusicBrainzReleaseID); releaseID != nil {
+		updates["release_id"] = *releaseID
+	}
+
+	// 3. Match label (exact name match)
+	if labelID := m.matchLabel(play.LabelName); labelID != nil {
+		updates["label_id"] = *labelID
+	}
+
+	if len(updates) > 0 {
+		m.db.Model(play).Updates(updates)
+	}
+
+	return artistMatched
+}
+
+// matchArtist tries to match an artist name to our knowledge graph.
+// Priority: MusicBrainz ID → exact name → alias match.
+func (m *RadioMatchingEngine) matchArtist(name string, mbID *string) *uint {
+	// 1. MusicBrainz ID match (highest confidence)
+	// Note: Artists table doesn't have a musicbrainz_id column yet,
+	// so we skip this path. When the column exists, uncomment:
+	// if mbID != nil && *mbID != "" {
+	// 	var artist models.Artist
+	// 	if err := m.db.Where("musicbrainz_id = ?", *mbID).First(&artist).Error; err == nil {
+	// 		return &artist.ID
+	// 	}
+	// }
+
+	// 2. Exact name match (case-insensitive)
+	var artist models.Artist
+	if err := m.db.Where("LOWER(name) = LOWER(?)", strings.TrimSpace(name)).First(&artist).Error; err == nil {
+		return &artist.ID
+	}
+
+	// 3. Alias match (case-insensitive)
+	var alias models.ArtistAlias
+	if err := m.db.Where("LOWER(alias) = LOWER(?)", strings.TrimSpace(name)).First(&alias).Error; err == nil {
+		return &alias.ArtistID
+	}
+
+	return nil
+}
+
+// matchRelease tries to match a release by MusicBrainz ID or exact title.
+func (m *RadioMatchingEngine) matchRelease(title *string, mbID *string) *uint {
+	// Note: Releases table doesn't have a musicbrainz_id column yet.
+	// When it exists, add MB ID matching here.
+
+	if title == nil || *title == "" {
+		return nil
+	}
+
+	var release models.Release
+	if err := m.db.Where("LOWER(title) = LOWER(?)", strings.TrimSpace(*title)).First(&release).Error; err == nil {
+		return &release.ID
+	}
+
+	return nil
+}
+
+// matchLabel tries to match a label by exact name (case-insensitive).
+func (m *RadioMatchingEngine) matchLabel(name *string) *uint {
+	if name == nil || *name == "" {
+		return nil
+	}
+
+	var label models.Label
+	if err := m.db.Where("LOWER(name) = LOWER(?)", strings.TrimSpace(*name)).First(&label).Error; err == nil {
+		return &label.ID
+	}
+
+	return nil
+}

--- a/backend/internal/services/catalog/radio_provider.go
+++ b/backend/internal/services/catalog/radio_provider.go
@@ -1,0 +1,59 @@
+package catalog
+
+import (
+	"time"
+)
+
+// RadioPlaylistProvider is the interface all radio providers must implement.
+// Each provider knows how to discover shows, fetch episodes, and fetch playlists
+// from a specific radio station's API or data source.
+type RadioPlaylistProvider interface {
+	// DiscoverShows returns all available shows/programs from the station.
+	DiscoverShows() ([]RadioShowImport, error)
+
+	// FetchNewEpisodes returns episodes for a given show since the specified time.
+	FetchNewEpisodes(showExternalID string, since time.Time) ([]RadioEpisodeImport, error)
+
+	// FetchPlaylist returns the track plays for a specific episode.
+	FetchPlaylist(episodeExternalID string) ([]RadioPlayImport, error)
+}
+
+// RadioShowImport is the intermediate DTO for importing a radio show from a provider.
+type RadioShowImport struct {
+	ExternalID  string  `json:"external_id"`
+	Name        string  `json:"name"`
+	HostName    *string `json:"host_name,omitempty"`
+	Description *string `json:"description,omitempty"`
+	ImageURL    *string `json:"image_url,omitempty"`
+	ArchiveURL  *string `json:"archive_url,omitempty"`
+}
+
+// RadioEpisodeImport is the intermediate DTO for importing a radio episode from a provider.
+type RadioEpisodeImport struct {
+	ExternalID      string  `json:"external_id"`
+	ShowExternalID  string  `json:"show_external_id"`
+	Title           *string `json:"title,omitempty"`
+	AirDate         string  `json:"air_date"` // YYYY-MM-DD
+	AirTime         *string `json:"air_time,omitempty"`
+	DurationMinutes *int    `json:"duration_minutes,omitempty"`
+	ArchiveURL      *string `json:"archive_url,omitempty"`
+}
+
+// RadioPlayImport is the intermediate DTO for importing a track play from a provider.
+type RadioPlayImport struct {
+	Position               int        `json:"position"`
+	ArtistName             string     `json:"artist_name"`
+	TrackTitle             *string    `json:"track_title,omitempty"`
+	AlbumTitle             *string    `json:"album_title,omitempty"`
+	LabelName              *string    `json:"label_name,omitempty"`
+	ReleaseYear            *int       `json:"release_year,omitempty"`
+	IsNew                  bool       `json:"is_new"`
+	RotationStatus         *string    `json:"rotation_status,omitempty"`
+	DJComment              *string    `json:"dj_comment,omitempty"`
+	IsLivePerformance      bool       `json:"is_live_performance"`
+	IsRequest              bool       `json:"is_request"`
+	MusicBrainzArtistID    *string    `json:"musicbrainz_artist_id,omitempty"`
+	MusicBrainzRecordingID *string    `json:"musicbrainz_recording_id,omitempty"`
+	MusicBrainzReleaseID   *string    `json:"musicbrainz_release_id,omitempty"`
+	AirTimestamp           *time.Time `json:"air_timestamp,omitempty"`
+}

--- a/backend/internal/services/catalog/radio_provider_kexp.go
+++ b/backend/internal/services/catalog/radio_provider_kexp.go
@@ -1,0 +1,424 @@
+package catalog
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	kexpBaseURL        = "https://api.kexp.org"
+	kexpUserAgent      = "PsychicHomily/1.0 (radio-playlist-indexer)"
+	kexpDefaultTimeout = 30 * time.Second
+	kexpRateLimit      = 1 * time.Second
+)
+
+// KEXPProvider implements RadioPlaylistProvider for KEXP's v2 REST API.
+type KEXPProvider struct {
+	httpClient  *http.Client
+	baseURL     string
+	rateLimiter *time.Ticker
+}
+
+// NewKEXPProvider creates a new KEXP provider with rate limiting.
+func NewKEXPProvider() *KEXPProvider {
+	return &KEXPProvider{
+		httpClient: &http.Client{
+			Timeout: kexpDefaultTimeout,
+		},
+		baseURL:     kexpBaseURL,
+		rateLimiter: time.NewTicker(kexpRateLimit),
+	}
+}
+
+// NewKEXPProviderWithClient creates a KEXP provider with a custom HTTP client and base URL.
+// Exported for testing with httptest servers.
+func NewKEXPProviderWithClient(client *http.Client, baseURL string) *KEXPProvider {
+	return &KEXPProvider{
+		httpClient:  client,
+		baseURL:     baseURL,
+		rateLimiter: time.NewTicker(1 * time.Millisecond), // fast for tests
+	}
+}
+
+// Close stops the rate limiter ticker. Should be called when the provider is no longer needed.
+func (p *KEXPProvider) Close() {
+	if p.rateLimiter != nil {
+		p.rateLimiter.Stop()
+	}
+}
+
+// DiscoverShows returns all KEXP programs (shows).
+func (p *KEXPProvider) DiscoverShows() ([]RadioShowImport, error) {
+	var allShows []RadioShowImport
+
+	// Fetch all hosts for name mapping
+	hosts, err := p.fetchAllHosts()
+	if err != nil {
+		// Non-fatal: host names will be nil
+		hosts = make(map[int]string)
+	}
+
+	url := fmt.Sprintf("%s/v2/programs/?limit=100", p.baseURL)
+	for url != "" {
+		<-p.rateLimiter.C
+
+		resp, err := p.doGet(url)
+		if err != nil {
+			return nil, fmt.Errorf("fetching programs: %w", err)
+		}
+
+		var page kexpProgramsResponse
+		if err := json.Unmarshal(resp, &page); err != nil {
+			return nil, fmt.Errorf("parsing programs response: %w", err)
+		}
+
+		for _, prog := range page.Results {
+			show := RadioShowImport{
+				ExternalID: strconv.Itoa(prog.ID),
+				Name:       prog.Name,
+			}
+			if prog.Description != "" {
+				desc := prog.Description
+				show.Description = &desc
+			}
+			if prog.ImageURI != "" {
+				img := prog.ImageURI
+				show.ImageURL = &img
+			}
+			// Map host IDs to names
+			if len(prog.HostIDs) > 0 {
+				var hostNames []string
+				for _, hid := range prog.HostIDs {
+					if name, ok := hosts[hid]; ok {
+						hostNames = append(hostNames, name)
+					}
+				}
+				if len(hostNames) > 0 {
+					joined := strings.Join(hostNames, ", ")
+					show.HostName = &joined
+				}
+			}
+
+			allShows = append(allShows, show)
+		}
+
+		url = page.Next
+	}
+
+	return allShows, nil
+}
+
+// FetchNewEpisodes returns KEXP "shows" (broadcasts) for a program since the given time.
+func (p *KEXPProvider) FetchNewEpisodes(showExternalID string, since time.Time) ([]RadioEpisodeImport, error) {
+	var allEpisodes []RadioEpisodeImport
+
+	sinceStr := since.UTC().Format(time.RFC3339)
+	url := fmt.Sprintf("%s/v2/shows/?program_id=%s&start_time_after=%s&limit=100&ordering=start_time",
+		p.baseURL, showExternalID, sinceStr)
+
+	for url != "" {
+		<-p.rateLimiter.C
+
+		resp, err := p.doGet(url)
+		if err != nil {
+			return nil, fmt.Errorf("fetching episodes: %w", err)
+		}
+
+		var page kexpShowsResponse
+		if err := json.Unmarshal(resp, &page); err != nil {
+			return nil, fmt.Errorf("parsing shows response: %w", err)
+		}
+
+		for _, show := range page.Results {
+			ep := parseKEXPEpisode(show, showExternalID)
+			allEpisodes = append(allEpisodes, ep)
+		}
+
+		url = page.Next
+	}
+
+	return allEpisodes, nil
+}
+
+// FetchPlaylist returns track plays for a KEXP "show" (episode).
+func (p *KEXPProvider) FetchPlaylist(episodeExternalID string) ([]RadioPlayImport, error) {
+	var allPlays []RadioPlayImport
+	position := 0
+
+	url := fmt.Sprintf("%s/v2/plays/?show_id=%s&limit=100&ordering=airdate",
+		p.baseURL, episodeExternalID)
+
+	for url != "" {
+		<-p.rateLimiter.C
+
+		resp, err := p.doGet(url)
+		if err != nil {
+			return nil, fmt.Errorf("fetching plays: %w", err)
+		}
+
+		var page kexpPlaysResponse
+		if err := json.Unmarshal(resp, &page); err != nil {
+			return nil, fmt.Errorf("parsing plays response: %w", err)
+		}
+
+		for _, kPlay := range page.Results {
+			// Only import track plays, skip airbreaks, station IDs, etc.
+			if kPlay.PlayType != "trackplay" {
+				continue
+			}
+
+			play := parseKEXPPlay(kPlay, position)
+			allPlays = append(allPlays, play)
+			position++
+		}
+
+		url = page.Next
+	}
+
+	return allPlays, nil
+}
+
+// =============================================================================
+// Internal helpers
+// =============================================================================
+
+// doGet performs an HTTP GET with the KEXP user agent and returns the response body.
+func (p *KEXPProvider) doGet(url string) ([]byte, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("User-Agent", kexpUserAgent)
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("executing request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("KEXP API returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response body: %w", err)
+	}
+
+	return body, nil
+}
+
+// fetchAllHosts fetches all KEXP hosts and returns a map of ID → display name.
+func (p *KEXPProvider) fetchAllHosts() (map[int]string, error) {
+	hosts := make(map[int]string)
+	url := fmt.Sprintf("%s/v2/hosts/?limit=100", p.baseURL)
+
+	for url != "" {
+		<-p.rateLimiter.C
+
+		resp, err := p.doGet(url)
+		if err != nil {
+			return hosts, fmt.Errorf("fetching hosts: %w", err)
+		}
+
+		var page kexpHostsResponse
+		if err := json.Unmarshal(resp, &page); err != nil {
+			return hosts, fmt.Errorf("parsing hosts response: %w", err)
+		}
+
+		for _, h := range page.Results {
+			hosts[h.ID] = h.Name
+		}
+
+		url = page.Next
+	}
+
+	return hosts, nil
+}
+
+// parseKEXPEpisode converts a KEXP show (broadcast) into our episode import DTO.
+func parseKEXPEpisode(show kexpShow, programExternalID string) RadioEpisodeImport {
+	ep := RadioEpisodeImport{
+		ExternalID:     strconv.Itoa(show.ID),
+		ShowExternalID: programExternalID,
+	}
+
+	// Parse start_time to extract air_date and air_time
+	if show.StartTime != "" {
+		if t, err := time.Parse(time.RFC3339, show.StartTime); err == nil {
+			airDate := t.Format("2006-01-02")
+			airTime := t.Format("15:04:05")
+			ep.AirDate = airDate
+			ep.AirTime = &airTime
+
+			// Calculate duration if end_time is available
+			if show.EndTime != "" {
+				if end, err := time.Parse(time.RFC3339, show.EndTime); err == nil {
+					dur := int(end.Sub(t).Minutes())
+					if dur > 0 {
+						ep.DurationMinutes = &dur
+					}
+				}
+			}
+		}
+	}
+
+	if show.ProgramName != "" {
+		name := show.ProgramName
+		ep.Title = &name
+	}
+
+	if show.ArchiveURL != "" {
+		archive := show.ArchiveURL
+		ep.ArchiveURL = &archive
+	}
+
+	return ep
+}
+
+// parseKEXPPlay converts a KEXP play into our play import DTO.
+func parseKEXPPlay(kPlay kexpPlay, position int) RadioPlayImport {
+	play := RadioPlayImport{
+		Position:          position,
+		ArtistName:        kPlay.Artist,
+		IsLivePerformance: kPlay.IsLive,
+		IsRequest:         kPlay.IsRequest,
+	}
+
+	if kPlay.Song != "" {
+		play.TrackTitle = &kPlay.Song
+	}
+	if kPlay.Album != "" {
+		play.AlbumTitle = &kPlay.Album
+	}
+	if kPlay.Label != "" {
+		play.LabelName = &kPlay.Label
+	}
+	if kPlay.ReleaseDate != "" {
+		if year := parseReleaseYear(kPlay.ReleaseDate); year > 0 {
+			play.ReleaseYear = &year
+		}
+	}
+	if kPlay.RotationStatus != "" {
+		play.RotationStatus = &kPlay.RotationStatus
+	}
+	if kPlay.Comment != "" {
+		play.DJComment = &kPlay.Comment
+	}
+	if kPlay.IsNew {
+		play.IsNew = true
+	}
+
+	// MusicBrainz IDs
+	if kPlay.MusicBrainzArtistID != "" {
+		play.MusicBrainzArtistID = &kPlay.MusicBrainzArtistID
+	}
+	if kPlay.MusicBrainzReleaseID != "" {
+		play.MusicBrainzReleaseID = &kPlay.MusicBrainzReleaseID
+	}
+	if kPlay.MusicBrainzRecordingID != "" {
+		play.MusicBrainzRecordingID = &kPlay.MusicBrainzRecordingID
+	}
+
+	// Parse air timestamp
+	if kPlay.Airdate != "" {
+		if t, err := time.Parse(time.RFC3339, kPlay.Airdate); err == nil {
+			play.AirTimestamp = &t
+		}
+	}
+
+	return play
+}
+
+// parseReleaseYear extracts a year from a date string.
+// Handles: "2026", "2026-01-15", "2026-01-15T00:00:00Z", etc.
+func parseReleaseYear(dateStr string) int {
+	if len(dateStr) < 4 {
+		return 0
+	}
+	year, err := strconv.Atoi(dateStr[:4])
+	if err != nil {
+		return 0
+	}
+	if year < 1900 || year > 2100 {
+		return 0
+	}
+	return year
+}
+
+// =============================================================================
+// KEXP API response types (not exported — internal to provider)
+// =============================================================================
+
+type kexpPaginatedResponse struct {
+	Next    string `json:"next"`
+	Count   int    `json:"count"`
+}
+
+type kexpProgramsResponse struct {
+	kexpPaginatedResponse
+	Results []kexpProgram `json:"results"`
+}
+
+type kexpProgram struct {
+	ID          int    `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	ImageURI    string `json:"image_uri"`
+	HostIDs     []int  `json:"host_ids"`
+	IsActive    bool   `json:"is_active"`
+}
+
+type kexpHostsResponse struct {
+	kexpPaginatedResponse
+	Results []kexpHost `json:"results"`
+}
+
+type kexpHost struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+type kexpShowsResponse struct {
+	kexpPaginatedResponse
+	Results []kexpShow `json:"results"`
+}
+
+type kexpShow struct {
+	ID          int    `json:"id"`
+	ProgramID   int    `json:"program_id"`
+	ProgramName string `json:"program_name"`
+	StartTime   string `json:"start_time"`
+	EndTime     string `json:"end_time"`
+	ArchiveURL  string `json:"archive_url"`
+}
+
+type kexpPlaysResponse struct {
+	kexpPaginatedResponse
+	Results []kexpPlay `json:"results"`
+}
+
+type kexpPlay struct {
+	ID                     int    `json:"id"`
+	PlayType               string `json:"play_type"`
+	Airdate                string `json:"airdate"`
+	Artist                 string `json:"artist"`
+	Song                   string `json:"song"`
+	Album                  string `json:"album"`
+	Label                  string `json:"label_name"`
+	ReleaseDate            string `json:"release_date"`
+	RotationStatus         string `json:"rotation_status"`
+	IsNew                  bool   `json:"is_new"`
+	IsLive                 bool   `json:"is_live"`
+	IsRequest              bool   `json:"is_request"`
+	Comment                string `json:"comment"`
+	MusicBrainzArtistID    string `json:"musicbrainz_artist_id"`
+	MusicBrainzReleaseID   string `json:"musicbrainz_release_id"`
+	MusicBrainzRecordingID string `json:"musicbrainz_recording_id"`
+}

--- a/backend/internal/services/catalog/radio_provider_test.go
+++ b/backend/internal/services/catalog/radio_provider_test.go
@@ -1,0 +1,1094 @@
+package catalog
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/testutil"
+	"psychic-homily-backend/internal/utils"
+)
+
+// =============================================================================
+// UNIT TESTS: KEXP response parsing
+// =============================================================================
+
+func TestParseReleaseYear(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected int
+	}{
+		{"2026", 2026},
+		{"2026-01-15", 2026},
+		{"2026-01-15T00:00:00Z", 2026},
+		{"1998", 1998},
+		{"", 0},
+		{"abc", 0},
+		{"12", 0},        // too short
+		{"0000", 0},      // out of range
+		{"9999", 0},      // out of range
+		{"1899", 0},      // out of range (< 1900)
+		{"2101", 0},      // out of range (> 2100)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := parseReleaseYear(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestParseKEXPPlay_FullFields(t *testing.T) {
+	kPlay := kexpPlay{
+		ID:                     12345,
+		PlayType:               "trackplay",
+		Airdate:                "2026-01-15T10:30:00Z",
+		Artist:                 "Radiohead",
+		Song:                   "Everything In Its Right Place",
+		Album:                  "Kid A",
+		Label:                  "Parlophone",
+		ReleaseDate:            "2000-10-02",
+		RotationStatus:         "heavy",
+		IsNew:                  true,
+		IsLive:                 false,
+		IsRequest:              true,
+		Comment:                "Classic album opener",
+		MusicBrainzArtistID:    "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+		MusicBrainzReleaseID:   "b95ce3ff-3d05-4e87-9e01-c97b66af13d4",
+		MusicBrainzRecordingID: "c22af0e6-1e3c-4b6c-aa83-42a2de43b84c",
+	}
+
+	play := parseKEXPPlay(kPlay, 5)
+
+	assert.Equal(t, 5, play.Position)
+	assert.Equal(t, "Radiohead", play.ArtistName)
+	assert.Equal(t, "Everything In Its Right Place", *play.TrackTitle)
+	assert.Equal(t, "Kid A", *play.AlbumTitle)
+	assert.Equal(t, "Parlophone", *play.LabelName)
+	assert.Equal(t, 2000, *play.ReleaseYear)
+	assert.Equal(t, "heavy", *play.RotationStatus)
+	assert.True(t, play.IsNew)
+	assert.False(t, play.IsLivePerformance)
+	assert.True(t, play.IsRequest)
+	assert.Equal(t, "Classic album opener", *play.DJComment)
+	assert.Equal(t, "a74b1b7f-71a5-4011-9441-d0b5e4122711", *play.MusicBrainzArtistID)
+	assert.Equal(t, "b95ce3ff-3d05-4e87-9e01-c97b66af13d4", *play.MusicBrainzReleaseID)
+	assert.Equal(t, "c22af0e6-1e3c-4b6c-aa83-42a2de43b84c", *play.MusicBrainzRecordingID)
+	assert.NotNil(t, play.AirTimestamp)
+	assert.Equal(t, "2026-01-15T10:30:00Z", play.AirTimestamp.Format(time.RFC3339))
+}
+
+func TestParseKEXPPlay_MinimalFields(t *testing.T) {
+	kPlay := kexpPlay{
+		PlayType: "trackplay",
+		Artist:   "Sonic Youth",
+	}
+
+	play := parseKEXPPlay(kPlay, 0)
+
+	assert.Equal(t, 0, play.Position)
+	assert.Equal(t, "Sonic Youth", play.ArtistName)
+	assert.Nil(t, play.TrackTitle)
+	assert.Nil(t, play.AlbumTitle)
+	assert.Nil(t, play.LabelName)
+	assert.Nil(t, play.ReleaseYear)
+	assert.Nil(t, play.RotationStatus)
+	assert.Nil(t, play.DJComment)
+	assert.False(t, play.IsNew)
+	assert.False(t, play.IsLivePerformance)
+	assert.False(t, play.IsRequest)
+	assert.Nil(t, play.MusicBrainzArtistID)
+	assert.Nil(t, play.AirTimestamp)
+}
+
+func TestParseKEXPEpisode(t *testing.T) {
+	show := kexpShow{
+		ID:          5678,
+		ProgramID:   42,
+		ProgramName: "The Morning Show",
+		StartTime:   "2026-01-15T06:00:00-08:00",
+		EndTime:     "2026-01-15T10:00:00-08:00",
+		ArchiveURL:  "https://kexp.org/archive/2026-01-15",
+	}
+
+	ep := parseKEXPEpisode(show, "42")
+
+	assert.Equal(t, "5678", ep.ExternalID)
+	assert.Equal(t, "42", ep.ShowExternalID)
+	assert.Equal(t, "2026-01-15", ep.AirDate)
+	assert.NotNil(t, ep.AirTime)
+	assert.Equal(t, "06:00:00", *ep.AirTime)
+	assert.NotNil(t, ep.DurationMinutes)
+	assert.Equal(t, 240, *ep.DurationMinutes)
+	assert.NotNil(t, ep.Title)
+	assert.Equal(t, "The Morning Show", *ep.Title)
+	assert.NotNil(t, ep.ArchiveURL)
+	assert.Equal(t, "https://kexp.org/archive/2026-01-15", *ep.ArchiveURL)
+}
+
+func TestParseKEXPEpisode_NoEndTime(t *testing.T) {
+	show := kexpShow{
+		ID:        9999,
+		StartTime: "2026-01-15T06:00:00-08:00",
+	}
+
+	ep := parseKEXPEpisode(show, "1")
+
+	assert.Equal(t, "9999", ep.ExternalID)
+	assert.Equal(t, "2026-01-15", ep.AirDate)
+	assert.Nil(t, ep.DurationMinutes)
+}
+
+// =============================================================================
+// UNIT TESTS: KEXP provider with mock HTTP server
+// =============================================================================
+
+func TestKEXPProvider_DiscoverShows(t *testing.T) {
+	mux := http.NewServeMux()
+
+	// Mock hosts endpoint
+	mux.HandleFunc("/v2/hosts/", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"next":  nil,
+			"count": 2,
+			"results": []map[string]interface{}{
+				{"id": 1, "name": "John Richards"},
+				{"id": 2, "name": "Cheryl Waters"},
+			},
+		})
+	})
+
+	// Mock programs endpoint
+	mux.HandleFunc("/v2/programs/", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"next":  nil,
+			"count": 2,
+			"results": []map[string]interface{}{
+				{
+					"id":          42,
+					"name":        "The Morning Show",
+					"description": "Wake up with KEXP",
+					"image_uri":   "https://kexp.org/morning.jpg",
+					"host_ids":    []int{1},
+					"is_active":   true,
+				},
+				{
+					"id":        43,
+					"name":      "The Midday Show",
+					"host_ids":  []int{2},
+					"is_active": true,
+				},
+			},
+		})
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	provider := NewKEXPProviderWithClient(server.Client(), server.URL)
+	defer provider.Close()
+
+	shows, err := provider.DiscoverShows()
+
+	require.NoError(t, err)
+	assert.Len(t, shows, 2)
+
+	assert.Equal(t, "42", shows[0].ExternalID)
+	assert.Equal(t, "The Morning Show", shows[0].Name)
+	assert.Equal(t, "Wake up with KEXP", *shows[0].Description)
+	assert.Equal(t, "https://kexp.org/morning.jpg", *shows[0].ImageURL)
+	assert.Equal(t, "John Richards", *shows[0].HostName)
+
+	assert.Equal(t, "43", shows[1].ExternalID)
+	assert.Equal(t, "The Midday Show", shows[1].Name)
+	assert.Equal(t, "Cheryl Waters", *shows[1].HostName)
+}
+
+func TestKEXPProvider_DiscoverShows_Pagination(t *testing.T) {
+	callCount := 0
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/v2/hosts/", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"next": nil, "count": 0, "results": []interface{}{},
+		})
+	})
+
+	var server *httptest.Server
+	mux.HandleFunc("/v2/programs/", func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount == 1 {
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"next":  fmt.Sprintf("%s/v2/programs/?offset=1", server.URL),
+				"count": 2,
+				"results": []map[string]interface{}{
+					{"id": 1, "name": "Show One", "host_ids": []int{}},
+				},
+			})
+		} else {
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"next":  nil,
+				"count": 2,
+				"results": []map[string]interface{}{
+					{"id": 2, "name": "Show Two", "host_ids": []int{}},
+				},
+			})
+		}
+	})
+
+	server = httptest.NewServer(mux)
+	defer server.Close()
+
+	provider := NewKEXPProviderWithClient(server.Client(), server.URL)
+	defer provider.Close()
+
+	shows, err := provider.DiscoverShows()
+
+	require.NoError(t, err)
+	assert.Len(t, shows, 2)
+	assert.Equal(t, "Show One", shows[0].Name)
+	assert.Equal(t, "Show Two", shows[1].Name)
+	assert.Equal(t, 2, callCount) // Two program pages fetched
+}
+
+func TestKEXPProvider_FetchNewEpisodes(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/shows/", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"next":  nil,
+			"count": 1,
+			"results": []map[string]interface{}{
+				{
+					"id":           5678,
+					"program_id":   42,
+					"program_name": "The Morning Show",
+					"start_time":   "2026-01-15T06:00:00-08:00",
+					"end_time":     "2026-01-15T10:00:00-08:00",
+					"archive_url":  "https://kexp.org/archive/5678",
+				},
+			},
+		})
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	provider := NewKEXPProviderWithClient(server.Client(), server.URL)
+	defer provider.Close()
+
+	since := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	episodes, err := provider.FetchNewEpisodes("42", since)
+
+	require.NoError(t, err)
+	assert.Len(t, episodes, 1)
+	assert.Equal(t, "5678", episodes[0].ExternalID)
+	assert.Equal(t, "42", episodes[0].ShowExternalID)
+	assert.Equal(t, "2026-01-15", episodes[0].AirDate)
+	assert.NotNil(t, episodes[0].DurationMinutes)
+	assert.Equal(t, 240, *episodes[0].DurationMinutes)
+}
+
+func TestKEXPProvider_FetchPlaylist(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/plays/", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"next":  nil,
+			"count": 3,
+			"results": []map[string]interface{}{
+				{
+					"id":                      1,
+					"play_type":               "trackplay",
+					"airdate":                 "2026-01-15T06:05:00-08:00",
+					"artist":                  "Radiohead",
+					"song":                    "Everything In Its Right Place",
+					"album":                   "Kid A",
+					"label_name":              "Parlophone",
+					"release_date":            "2000-10-02",
+					"rotation_status":         "library",
+					"is_new":                  false,
+					"is_live":                 false,
+					"is_request":              false,
+					"musicbrainz_artist_id":   "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+				},
+				{
+					"id":        2,
+					"play_type": "airbreak", // Should be skipped
+					"airdate":   "2026-01-15T06:10:00-08:00",
+				},
+				{
+					"id":         3,
+					"play_type":  "trackplay",
+					"airdate":    "2026-01-15T06:15:00-08:00",
+					"artist":     "Deerhunter",
+					"song":       "Desire Lines",
+					"is_new":     true,
+					"is_live":    true,
+					"is_request": false,
+				},
+			},
+		})
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	provider := NewKEXPProviderWithClient(server.Client(), server.URL)
+	defer provider.Close()
+
+	plays, err := provider.FetchPlaylist("5678")
+
+	require.NoError(t, err)
+	assert.Len(t, plays, 2) // Airbreak skipped
+
+	// First play
+	assert.Equal(t, 0, plays[0].Position)
+	assert.Equal(t, "Radiohead", plays[0].ArtistName)
+	assert.Equal(t, "Everything In Its Right Place", *plays[0].TrackTitle)
+	assert.Equal(t, "Kid A", *plays[0].AlbumTitle)
+	assert.Equal(t, "Parlophone", *plays[0].LabelName)
+	assert.Equal(t, 2000, *plays[0].ReleaseYear)
+	assert.Equal(t, "library", *plays[0].RotationStatus)
+	assert.False(t, plays[0].IsNew)
+	assert.Equal(t, "a74b1b7f-71a5-4011-9441-d0b5e4122711", *plays[0].MusicBrainzArtistID)
+
+	// Second play
+	assert.Equal(t, 1, plays[1].Position)
+	assert.Equal(t, "Deerhunter", plays[1].ArtistName)
+	assert.True(t, plays[1].IsNew)
+	assert.True(t, plays[1].IsLivePerformance)
+}
+
+func TestKEXPProvider_FetchPlaylist_OnlyTrackPlays(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/plays/", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"next":  nil,
+			"count": 3,
+			"results": []map[string]interface{}{
+				{"id": 1, "play_type": "airbreak", "artist": ""},
+				{"id": 2, "play_type": "stationid", "artist": ""},
+				{"id": 3, "play_type": "trackplay", "artist": "The National", "airdate": "2026-01-15T06:00:00Z"},
+			},
+		})
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	provider := NewKEXPProviderWithClient(server.Client(), server.URL)
+	defer provider.Close()
+
+	plays, err := provider.FetchPlaylist("1234")
+
+	require.NoError(t, err)
+	assert.Len(t, plays, 1) // Only the trackplay
+	assert.Equal(t, "The National", plays[0].ArtistName)
+}
+
+func TestKEXPProvider_HTTPError(t *testing.T) {
+	mux := http.NewServeMux()
+	// Hosts can succeed (non-fatal)
+	mux.HandleFunc("/v2/hosts/", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"next": nil, "count": 0, "results": []interface{}{},
+		})
+	})
+	// Programs returns 500
+	mux.HandleFunc("/v2/programs/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("internal error"))
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	provider := NewKEXPProviderWithClient(server.Client(), server.URL)
+	defer provider.Close()
+
+	_, err := provider.DiscoverShows()
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+// =============================================================================
+// UNIT TESTS: NilDB for new import/matching methods
+// =============================================================================
+
+func TestRadioService_NilDB_Import(t *testing.T) {
+	svc := &RadioService{db: nil}
+	assertNilDBError(t, func() error { _, err := svc.ImportStation(1, 7); return err })
+	assertNilDBError(t, func() error { _, err := svc.FetchNewEpisodes(1); return err })
+	assertNilDBError(t, func() error { _, err := svc.ImportEpisodePlaylist(1, "ext-1"); return err })
+	assertNilDBError(t, func() error { _, err := svc.MatchPlays(1); return err })
+}
+
+func TestRadioMatchingEngine_NilDB(t *testing.T) {
+	engine := NewRadioMatchingEngine(nil)
+
+	_, err := engine.MatchPlaysForEpisode(1)
+	assert.Error(t, err)
+	assert.Equal(t, "database not initialized", err.Error())
+
+	_, err = engine.MatchAllUnmatched()
+	assert.Error(t, err)
+	assert.Equal(t, "database not initialized", err.Error())
+}
+
+// =============================================================================
+// INTEGRATION TESTS: Matching engine with real database
+// =============================================================================
+
+type RadioImportIntegrationTestSuite struct {
+	suite.Suite
+	testDB       *testutil.TestDatabase
+	db           *gorm.DB
+	radioService *RadioService
+}
+
+func (suite *RadioImportIntegrationTestSuite) SetupSuite() {
+	suite.testDB = testutil.SetupTestPostgres(suite.T())
+	suite.db = suite.testDB.DB
+	suite.radioService = &RadioService{db: suite.testDB.DB}
+}
+
+func (suite *RadioImportIntegrationTestSuite) TearDownSuite() {
+	suite.testDB.Cleanup()
+}
+
+func (suite *RadioImportIntegrationTestSuite) TearDownTest() {
+	sqlDB, err := suite.db.DB()
+	suite.Require().NoError(err)
+	// Delete in FK-safe order
+	_, _ = sqlDB.Exec("DELETE FROM radio_artist_affinity")
+	_, _ = sqlDB.Exec("DELETE FROM radio_plays")
+	_, _ = sqlDB.Exec("DELETE FROM radio_episodes")
+	_, _ = sqlDB.Exec("DELETE FROM radio_shows")
+	_, _ = sqlDB.Exec("DELETE FROM radio_stations")
+	_, _ = sqlDB.Exec("DELETE FROM artist_aliases")
+	_, _ = sqlDB.Exec("DELETE FROM artists")
+	_, _ = sqlDB.Exec("DELETE FROM releases")
+	_, _ = sqlDB.Exec("DELETE FROM labels")
+}
+
+func TestRadioImportIntegrationTestSuite(t *testing.T) {
+	suite.Run(t, new(RadioImportIntegrationTestSuite))
+}
+
+// =============================================================================
+// Matching engine integration tests
+// =============================================================================
+
+func (suite *RadioImportIntegrationTestSuite) TestMatchPlays_ExactNameMatch() {
+	// Create station, show, episode, play
+	station := suite.createStation("KEXP")
+	show := suite.createShow(station.ID, "Morning Show")
+	ep := suite.createEpisode(show.ID, "2026-01-15")
+	suite.createPlay(ep.ID, 0, "Radiohead")
+
+	// Create the artist in our knowledge graph
+	suite.createArtist("Radiohead")
+
+	// Run matching
+	result, err := suite.radioService.MatchPlays(ep.ID)
+
+	suite.Require().NoError(err)
+	suite.Equal(1, result.Total)
+	suite.Equal(1, result.Matched)
+	suite.Equal(0, result.Unmatched)
+
+	// Verify play is now linked
+	var play models.RadioPlay
+	suite.db.Where("episode_id = ?", ep.ID).First(&play)
+	suite.NotNil(play.ArtistID)
+}
+
+func (suite *RadioImportIntegrationTestSuite) TestMatchPlays_CaseInsensitiveMatch() {
+	station := suite.createStation("KEXP")
+	show := suite.createShow(station.ID, "Morning Show")
+	ep := suite.createEpisode(show.ID, "2026-01-15")
+	suite.createPlay(ep.ID, 0, "RADIOHEAD") // uppercase in play
+
+	suite.createArtist("Radiohead") // mixed case in DB
+
+	result, err := suite.radioService.MatchPlays(ep.ID)
+
+	suite.Require().NoError(err)
+	suite.Equal(1, result.Matched)
+}
+
+func (suite *RadioImportIntegrationTestSuite) TestMatchPlays_AliasMatch() {
+	station := suite.createStation("KEXP")
+	show := suite.createShow(station.ID, "Morning Show")
+	ep := suite.createEpisode(show.ID, "2026-01-15")
+	suite.createPlay(ep.ID, 0, "Thom Yorke") // Alias name
+
+	// Create artist with alias
+	artist := suite.createArtist("Radiohead")
+	alias := &models.ArtistAlias{
+		ArtistID: artist.ID,
+		Alias:    "Thom Yorke",
+	}
+	suite.Require().NoError(suite.db.Create(alias).Error)
+
+	result, err := suite.radioService.MatchPlays(ep.ID)
+
+	suite.Require().NoError(err)
+	suite.Equal(1, result.Matched)
+
+	// Verify linked to the canonical artist
+	var play models.RadioPlay
+	suite.db.Where("episode_id = ?", ep.ID).First(&play)
+	suite.NotNil(play.ArtistID)
+	suite.Equal(artist.ID, *play.ArtistID)
+}
+
+func (suite *RadioImportIntegrationTestSuite) TestMatchPlays_Unmatched() {
+	station := suite.createStation("KEXP")
+	show := suite.createShow(station.ID, "Morning Show")
+	ep := suite.createEpisode(show.ID, "2026-01-15")
+	suite.createPlay(ep.ID, 0, "Totally Unknown Band")
+
+	result, err := suite.radioService.MatchPlays(ep.ID)
+
+	suite.Require().NoError(err)
+	suite.Equal(1, result.Total)
+	suite.Equal(0, result.Matched)
+	suite.Equal(1, result.Unmatched)
+
+	// Verify play still has no artist_id
+	var play models.RadioPlay
+	suite.db.Where("episode_id = ?", ep.ID).First(&play)
+	suite.Nil(play.ArtistID)
+}
+
+func (suite *RadioImportIntegrationTestSuite) TestMatchPlays_LabelMatch() {
+	station := suite.createStation("KEXP")
+	show := suite.createShow(station.ID, "Morning Show")
+	ep := suite.createEpisode(show.ID, "2026-01-15")
+
+	labelName := "Sub Pop"
+	play := &models.RadioPlay{
+		EpisodeID:  ep.ID,
+		Position:   0,
+		ArtistName: "Fleet Foxes",
+		LabelName:  &labelName,
+	}
+	suite.Require().NoError(suite.db.Create(play).Error)
+
+	// Create artist and label in our graph
+	suite.createArtist("Fleet Foxes")
+	suite.createLabel("Sub Pop")
+
+	result, err := suite.radioService.MatchPlays(ep.ID)
+
+	suite.Require().NoError(err)
+	suite.Equal(1, result.Matched) // Artist matched
+
+	// Verify label also matched
+	var updated models.RadioPlay
+	suite.db.First(&updated, play.ID)
+	suite.NotNil(updated.ArtistID)
+	suite.NotNil(updated.LabelID)
+}
+
+func (suite *RadioImportIntegrationTestSuite) TestMatchPlays_ReleaseMatch() {
+	station := suite.createStation("KEXP")
+	show := suite.createShow(station.ID, "Morning Show")
+	ep := suite.createEpisode(show.ID, "2026-01-15")
+
+	albumTitle := "Kid A"
+	play := &models.RadioPlay{
+		EpisodeID:  ep.ID,
+		Position:   0,
+		ArtistName: "Radiohead",
+		AlbumTitle: &albumTitle,
+	}
+	suite.Require().NoError(suite.db.Create(play).Error)
+
+	suite.createArtist("Radiohead")
+	suite.createRelease("Kid A")
+
+	result, err := suite.radioService.MatchPlays(ep.ID)
+
+	suite.Require().NoError(err)
+	suite.Equal(1, result.Matched)
+
+	var updated models.RadioPlay
+	suite.db.First(&updated, play.ID)
+	suite.NotNil(updated.ArtistID)
+	suite.NotNil(updated.ReleaseID)
+}
+
+func (suite *RadioImportIntegrationTestSuite) TestMatchPlays_SkipsAlreadyMatched() {
+	station := suite.createStation("KEXP")
+	show := suite.createShow(station.ID, "Morning Show")
+	ep := suite.createEpisode(show.ID, "2026-01-15")
+
+	artist := suite.createArtist("Radiohead")
+
+	// Create a play that's already matched
+	play := &models.RadioPlay{
+		EpisodeID:  ep.ID,
+		Position:   0,
+		ArtistName: "Radiohead",
+		ArtistID:   &artist.ID,
+	}
+	suite.Require().NoError(suite.db.Create(play).Error)
+
+	// MatchPlays only operates on unmatched plays (artist_id IS NULL)
+	result, err := suite.radioService.MatchPlays(ep.ID)
+
+	suite.Require().NoError(err)
+	suite.Equal(0, result.Total) // Already matched play not included
+}
+
+func (suite *RadioImportIntegrationTestSuite) TestMatchPlays_MultiplePlaysMixed() {
+	station := suite.createStation("KEXP")
+	show := suite.createShow(station.ID, "Morning Show")
+	ep := suite.createEpisode(show.ID, "2026-01-15")
+
+	suite.createPlay(ep.ID, 0, "Radiohead")
+	suite.createPlay(ep.ID, 1, "Unknown Band XYZ")
+	suite.createPlay(ep.ID, 2, "Deerhunter")
+
+	suite.createArtist("Radiohead")
+	suite.createArtist("Deerhunter")
+
+	result, err := suite.radioService.MatchPlays(ep.ID)
+
+	suite.Require().NoError(err)
+	suite.Equal(3, result.Total)
+	suite.Equal(2, result.Matched)
+	suite.Equal(1, result.Unmatched)
+}
+
+// =============================================================================
+// Import pipeline integration tests
+// =============================================================================
+
+func (suite *RadioImportIntegrationTestSuite) TestImportStation_Success() {
+	// Create a station with KEXP source pointing at mock server
+	mux := http.NewServeMux()
+	var server *httptest.Server
+
+	// Mock hosts
+	mux.HandleFunc("/v2/hosts/", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"next": nil, "count": 1,
+			"results": []map[string]interface{}{
+				{"id": 1, "name": "John Richards"},
+			},
+		})
+	})
+
+	// Mock programs
+	mux.HandleFunc("/v2/programs/", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"next": nil, "count": 1,
+			"results": []map[string]interface{}{
+				{"id": 42, "name": "The Morning Show", "host_ids": []int{1}},
+			},
+		})
+	})
+
+	// Mock shows (episodes)
+	mux.HandleFunc("/v2/shows/", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"next": nil, "count": 1,
+			"results": []map[string]interface{}{
+				{
+					"id":           100,
+					"program_id":   42,
+					"program_name": "The Morning Show",
+					"start_time":   "2026-01-15T06:00:00-08:00",
+					"end_time":     "2026-01-15T10:00:00-08:00",
+				},
+			},
+		})
+	})
+
+	// Mock plays
+	mux.HandleFunc("/v2/plays/", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"next": nil, "count": 2,
+			"results": []map[string]interface{}{
+				{
+					"id":        1,
+					"play_type": "trackplay",
+					"artist":    "Radiohead",
+					"song":      "Idioteque",
+					"album":     "Kid A",
+					"airdate":   "2026-01-15T06:05:00-08:00",
+				},
+				{
+					"id":        2,
+					"play_type": "trackplay",
+					"artist":    "Deerhunter",
+					"song":      "Desire Lines",
+					"airdate":   "2026-01-15T06:10:00-08:00",
+				},
+			},
+		})
+	})
+
+	server = httptest.NewServer(mux)
+	defer server.Close()
+
+	// Create station with a temporary provider override
+	source := models.PlaylistSourceKEXP
+	stationResp, err := suite.radioService.CreateStation(&contracts.CreateRadioStationRequest{
+		Name:           "KEXP",
+		BroadcastType:  models.BroadcastTypeBoth,
+		PlaylistSource: &source,
+	})
+	suite.Require().NoError(err)
+
+	// Create a mock provider and test the import pipeline directly
+	provider := NewKEXPProviderWithClient(server.Client(), server.URL)
+	defer provider.Close()
+
+	// Run the import directly using the provider (since getProvider returns the real KEXP URL)
+	result := suite.runImportWithProvider(stationResp.ID, 30, provider)
+
+	suite.Equal(1, result.ShowsDiscovered)
+	suite.Equal(1, result.EpisodesImported)
+	suite.Equal(2, result.PlaysImported)
+	suite.Empty(result.Errors)
+}
+
+func (suite *RadioImportIntegrationTestSuite) TestImportStation_NoPlaylistSource() {
+	stationResp, err := suite.radioService.CreateStation(&contracts.CreateRadioStationRequest{
+		Name:          "No Source",
+		BroadcastType: models.BroadcastTypeBoth,
+	})
+	suite.Require().NoError(err)
+
+	_, err = suite.radioService.ImportStation(stationResp.ID, 7)
+	suite.Error(err)
+	suite.Contains(err.Error(), "no playlist source configured")
+}
+
+func (suite *RadioImportIntegrationTestSuite) TestImportStation_StationNotFound() {
+	_, err := suite.radioService.ImportStation(99999, 7)
+	suite.Error(err)
+	suite.Contains(err.Error(), "station not found")
+}
+
+func (suite *RadioImportIntegrationTestSuite) TestUpsertRadioShow_CreateNew() {
+	station := suite.createStation("KEXP")
+
+	importShow := RadioShowImport{
+		ExternalID: "42",
+		Name:       "The Morning Show",
+		HostName:   stringPtr("John Richards"),
+	}
+
+	showID, err := suite.radioService.upsertRadioShow(station.ID, importShow)
+	suite.Require().NoError(err)
+	suite.NotZero(showID)
+
+	// Verify show was created
+	var show models.RadioShow
+	suite.db.First(&show, showID)
+	suite.Equal("The Morning Show", show.Name)
+	suite.Equal("John Richards", *show.HostName)
+	suite.Equal("42", *show.ExternalID)
+}
+
+func (suite *RadioImportIntegrationTestSuite) TestUpsertRadioShow_UpdateExisting() {
+	station := suite.createStation("KEXP")
+
+	// Create initial show
+	extID := "42"
+	show := &models.RadioShow{
+		StationID:  station.ID,
+		Name:       "Old Name",
+		Slug:       "old-name",
+		ExternalID: &extID,
+	}
+	suite.Require().NoError(suite.db.Create(show).Error)
+
+	// Upsert with new name
+	importShow := RadioShowImport{
+		ExternalID: "42",
+		Name:       "New Name",
+		HostName:   stringPtr("New Host"),
+	}
+
+	showID, err := suite.radioService.upsertRadioShow(station.ID, importShow)
+	suite.Require().NoError(err)
+	suite.Equal(show.ID, showID)
+
+	// Verify update
+	var updated models.RadioShow
+	suite.db.First(&updated, showID)
+	suite.Equal("New Name", updated.Name)
+	suite.Equal("New Host", *updated.HostName)
+}
+
+func (suite *RadioImportIntegrationTestSuite) TestImportEpisode_DeduplicatesByExternalID() {
+	station := suite.createStation("KEXP")
+	show := suite.createShow(station.ID, "Morning Show")
+
+	// Create a mock provider
+	mockProvider := &mockPlaylistProvider{
+		fetchPlaylistFn: func(epExtID string) ([]RadioPlayImport, error) {
+			return []RadioPlayImport{
+				{Position: 0, ArtistName: "Radiohead"},
+			}, nil
+		},
+	}
+
+	ep := RadioEpisodeImport{
+		ExternalID:     "100",
+		ShowExternalID: "42",
+		AirDate:        "2026-01-15",
+	}
+
+	// First import
+	result1, err := suite.radioService.importEpisode(show.ID, ep, mockProvider)
+	suite.Require().NoError(err)
+	suite.Equal(1, result1.PlaysImported)
+
+	// Second import — should be skipped (deduplication)
+	result2, err := suite.radioService.importEpisode(show.ID, ep, mockProvider)
+	suite.Require().NoError(err)
+	suite.Equal(0, result2.PlaysImported)
+
+	// Verify only one episode exists
+	var count int64
+	suite.db.Model(&models.RadioEpisode{}).Where("show_id = ?", show.ID).Count(&count)
+	suite.Equal(int64(1), count)
+}
+
+func (suite *RadioImportIntegrationTestSuite) TestImportPlays_BatchInsert() {
+	station := suite.createStation("KEXP")
+	show := suite.createShow(station.ID, "Morning Show")
+	ep := suite.createEpisode(show.ID, "2026-01-15")
+
+	plays := []RadioPlayImport{
+		{Position: 0, ArtistName: "Radiohead", IsNew: true},
+		{Position: 1, ArtistName: "Deerhunter", IsLivePerformance: true},
+		{Position: 2, ArtistName: "Sonic Youth"},
+	}
+
+	count, err := suite.radioService.importPlays(ep.ID, plays)
+
+	suite.Require().NoError(err)
+	suite.Equal(3, count)
+
+	// Verify plays in DB
+	var dbPlays []models.RadioPlay
+	suite.db.Where("episode_id = ?", ep.ID).Order("position ASC").Find(&dbPlays)
+	suite.Len(dbPlays, 3)
+	suite.Equal("Radiohead", dbPlays[0].ArtistName)
+	suite.True(dbPlays[0].IsNew)
+	suite.Equal("Deerhunter", dbPlays[1].ArtistName)
+	suite.True(dbPlays[1].IsLivePerformance)
+	suite.Equal("Sonic Youth", dbPlays[2].ArtistName)
+}
+
+func (suite *RadioImportIntegrationTestSuite) TestImportPlays_Empty() {
+	station := suite.createStation("KEXP")
+	show := suite.createShow(station.ID, "Morning Show")
+	ep := suite.createEpisode(show.ID, "2026-01-15")
+
+	count, err := suite.radioService.importPlays(ep.ID, []RadioPlayImport{})
+
+	suite.Require().NoError(err)
+	suite.Equal(0, count)
+}
+
+func (suite *RadioImportIntegrationTestSuite) TestMatchPlays_LabelCaseInsensitive() {
+	station := suite.createStation("KEXP")
+	show := suite.createShow(station.ID, "Morning Show")
+	ep := suite.createEpisode(show.ID, "2026-01-15")
+
+	labelName := "sub pop" // lowercase
+	play := &models.RadioPlay{
+		EpisodeID:  ep.ID,
+		Position:   0,
+		ArtistName: "Fleet Foxes",
+		LabelName:  &labelName,
+	}
+	suite.Require().NoError(suite.db.Create(play).Error)
+
+	suite.createArtist("Fleet Foxes")
+	suite.createLabel("Sub Pop") // mixed case in DB
+
+	result, err := suite.radioService.MatchPlays(ep.ID)
+
+	suite.Require().NoError(err)
+	suite.Equal(1, result.Matched)
+
+	var updated models.RadioPlay
+	suite.db.First(&updated, play.ID)
+	suite.NotNil(updated.LabelID) // Case-insensitive match
+}
+
+func (suite *RadioImportIntegrationTestSuite) TestGetProvider_Unsupported() {
+	_, err := suite.radioService.getProvider("unsupported_source")
+	suite.Error(err)
+	suite.Contains(err.Error(), "unsupported playlist source")
+}
+
+func (suite *RadioImportIntegrationTestSuite) TestGetProvider_KEXP() {
+	provider, err := suite.radioService.getProvider(models.PlaylistSourceKEXP)
+	suite.Require().NoError(err)
+	suite.NotNil(provider)
+	closeProvider(provider)
+}
+
+// =============================================================================
+// Test helpers
+// =============================================================================
+
+func (suite *RadioImportIntegrationTestSuite) createStation(name string) *contracts.RadioStationDetailResponse {
+	resp, err := suite.radioService.CreateStation(&contracts.CreateRadioStationRequest{
+		Name:          name,
+		BroadcastType: models.BroadcastTypeBoth,
+	})
+	suite.Require().NoError(err)
+	return resp
+}
+
+func (suite *RadioImportIntegrationTestSuite) createShow(stationID uint, name string) *contracts.RadioShowDetailResponse {
+	resp, err := suite.radioService.CreateShow(stationID, &contracts.CreateRadioShowRequest{
+		Name: name,
+	})
+	suite.Require().NoError(err)
+	return resp
+}
+
+func (suite *RadioImportIntegrationTestSuite) createEpisode(showID uint, airDate string) *models.RadioEpisode {
+	ep := &models.RadioEpisode{
+		ShowID:  showID,
+		AirDate: airDate,
+	}
+	err := suite.db.Create(ep).Error
+	suite.Require().NoError(err)
+	return ep
+}
+
+func (suite *RadioImportIntegrationTestSuite) createPlay(episodeID uint, position int, artistName string) *models.RadioPlay {
+	play := &models.RadioPlay{
+		EpisodeID:  episodeID,
+		Position:   position,
+		ArtistName: artistName,
+	}
+	err := suite.db.Create(play).Error
+	suite.Require().NoError(err)
+	return play
+}
+
+func (suite *RadioImportIntegrationTestSuite) createArtist(name string) *models.Artist {
+	slug := utils.GenerateArtistSlug(name)
+	artist := &models.Artist{Name: name, Slug: &slug}
+	err := suite.db.Create(artist).Error
+	suite.Require().NoError(err)
+	return artist
+}
+
+func (suite *RadioImportIntegrationTestSuite) createRelease(title string) *models.Release {
+	release := &models.Release{Title: title}
+	err := suite.db.Create(release).Error
+	suite.Require().NoError(err)
+	return release
+}
+
+func (suite *RadioImportIntegrationTestSuite) createLabel(name string) *models.Label {
+	label := &models.Label{Name: name, Status: models.LabelStatusActive}
+	err := suite.db.Create(label).Error
+	suite.Require().NoError(err)
+	return label
+}
+
+// runImportWithProvider runs the import pipeline with a specific provider (bypassing getProvider).
+func (suite *RadioImportIntegrationTestSuite) runImportWithProvider(stationID uint, backfillDays int, provider RadioPlaylistProvider) *contracts.RadioImportResult {
+	var station models.RadioStation
+	suite.Require().NoError(suite.db.First(&station, stationID).Error)
+
+	result := &contracts.RadioImportResult{}
+
+	importedShows, err := provider.DiscoverShows()
+	if err != nil {
+		result.Errors = append(result.Errors, fmt.Sprintf("discover shows: %v", err))
+		return result
+	}
+
+	showMap := make(map[string]uint)
+	for _, importShow := range importedShows {
+		showID, err := suite.radioService.upsertRadioShow(stationID, importShow)
+		if err != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("upsert show: %v", err))
+			continue
+		}
+		showMap[importShow.ExternalID] = showID
+		result.ShowsDiscovered++
+	}
+
+	since := time.Now().AddDate(0, 0, -backfillDays)
+	for extID, showID := range showMap {
+		episodes, err := provider.FetchNewEpisodes(extID, since)
+		if err != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("fetch episodes: %v", err))
+			continue
+		}
+
+		for _, ep := range episodes {
+			epResult, err := suite.radioService.importEpisode(showID, ep, provider)
+			if err != nil {
+				result.Errors = append(result.Errors, fmt.Sprintf("import episode: %v", err))
+				continue
+			}
+			result.EpisodesImported++
+			result.PlaysImported += epResult.PlaysImported
+			result.PlaysMatched += epResult.PlaysMatched
+		}
+	}
+
+	return result
+}
+
+// =============================================================================
+// Mock provider
+// =============================================================================
+
+type mockPlaylistProvider struct {
+	discoverShowsFn    func() ([]RadioShowImport, error)
+	fetchNewEpisodesFn func(showExternalID string, since time.Time) ([]RadioEpisodeImport, error)
+	fetchPlaylistFn    func(episodeExternalID string) ([]RadioPlayImport, error)
+}
+
+func (m *mockPlaylistProvider) DiscoverShows() ([]RadioShowImport, error) {
+	if m.discoverShowsFn != nil {
+		return m.discoverShowsFn()
+	}
+	return nil, nil
+}
+
+func (m *mockPlaylistProvider) FetchNewEpisodes(showExternalID string, since time.Time) ([]RadioEpisodeImport, error) {
+	if m.fetchNewEpisodesFn != nil {
+		return m.fetchNewEpisodesFn(showExternalID, since)
+	}
+	return nil, nil
+}
+
+func (m *mockPlaylistProvider) FetchPlaylist(episodeExternalID string) ([]RadioPlayImport, error) {
+	if m.fetchPlaylistFn != nil {
+		return m.fetchPlaylistFn(episodeExternalID)
+	}
+	return nil, nil
+}

--- a/backend/internal/services/contracts/interfaces.go
+++ b/backend/internal/services/contracts/interfaces.go
@@ -576,4 +576,12 @@ type RadioServiceInterface interface {
 
 	// Stats
 	GetRadioStats() (*RadioStatsResponse, error)
+
+	// Import pipeline
+	ImportStation(stationID uint, backfillDays int) (*RadioImportResult, error)
+	FetchNewEpisodes(stationID uint) (*RadioImportResult, error)
+	ImportEpisodePlaylist(showID uint, episodeExternalID string) (*EpisodeImportResult, error)
+
+	// Matching
+	MatchPlays(episodeID uint) (*MatchResult, error)
 }

--- a/backend/internal/services/contracts/radio.go
+++ b/backend/internal/services/contracts/radio.go
@@ -289,3 +289,29 @@ type RadioStatsResponse struct {
 	MatchedPlays  int64 `json:"matched_plays"`
 	UniqueArtists int   `json:"unique_artists"`
 }
+
+// ──────────────────────────────────────────────
+// Import pipeline types
+// ──────────────────────────────────────────────
+
+// RadioImportResult summarizes the result of a station or incremental import operation.
+type RadioImportResult struct {
+	ShowsDiscovered  int      `json:"shows_discovered"`
+	EpisodesImported int      `json:"episodes_imported"`
+	PlaysImported    int      `json:"plays_imported"`
+	PlaysMatched     int      `json:"plays_matched"`
+	Errors           []string `json:"errors,omitempty"`
+}
+
+// EpisodeImportResult summarizes the result of importing a single episode's playlist.
+type EpisodeImportResult struct {
+	PlaysImported int `json:"plays_imported"`
+	PlaysMatched  int `json:"plays_matched"`
+}
+
+// MatchResult summarizes the result of running the matching engine.
+type MatchResult struct {
+	Total     int `json:"total"`
+	Matched   int `json:"matched"`
+	Unmatched int `json:"unmatched"`
+}


### PR DESCRIPTION
## Summary
- **Provider interface** (`RadioPlaylistProvider`): DiscoverShows, FetchNewEpisodes, FetchPlaylist with import DTOs
- **KEXP v2 API provider**: cursor-based pagination, 1 req/sec rate limiting, trackplay filtering, full field mapping including MusicBrainz IDs and rotation status
- **Artist matching engine** (provider-agnostic): exact name match → alias match → unmatched (MB ID matching stubbed pending artists table column)
- **Import pipeline**: `ImportStation` (full backfill), `FetchNewEpisodes` (incremental), `ImportEpisodePlaylist`, `MatchPlays` with deduplication
- **44 tests**: KEXP response parsing, mock server tests, nil-DB, integration tests with testcontainers (matching, import pipeline, dedup)

Closes PSY-163

## Test plan
- [x] 44 tests pass (unit + integration)
- [x] All 41 existing radio service tests still pass
- [x] Full build compiles cleanly (`go build ./...`, `go vet ./...`)
- [x] KEXP shows discovered via mock API
- [x] Pagination handling with cursor-based next URLs
- [x] Play type filtering (only trackplay)
- [x] Matching: exact name, case-insensitive, alias, unmatched
- [x] Import pipeline: full station import + incremental fetch
- [x] Deduplication by external_id on shows and episodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)