### PR TITLE
Add radio co-occurrence as artist similarity signal (PSY-169)

### DIFF
--- a/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
+++ b/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
@@ -1922,9 +1922,10 @@ type mockRadioService struct {
 	importEpisodePlaylistFn func(uint, string) (*contracts.EpisodeImportResult, error)
 	matchPlaysFn func(uint) (*contracts.MatchResult, error)
 	getUnmatchedPlaysFn func(uint, int, int) ([]*contracts.UnmatchedPlayGroup, int64, error)
-	linkPlayFn func(uint, *contracts.LinkPlayRequest) error
+	linkPlayFn func(uint, *contracts.LinkPlayRequest) (error)
 	bulkLinkPlaysFn func(*contracts.BulkLinkRequest) (*contracts.BulkLinkResult, error)
-	computeAffinityFn func() error
+	computeAffinityFn func() (error)
+	syncAffinityToRelationshipsFn func() (*contracts.SyncAffinityResult, error)
 	reMatchUnmatchedFn func() (*contracts.MatchResult, error)
 }
 
@@ -2084,7 +2085,7 @@ func (m *mockRadioService) GetUnmatchedPlays(stationID uint, limit int, offset i
 	}
 	return nil, 0, nil
 }
-func (m *mockRadioService) LinkPlay(playID uint, req *contracts.LinkPlayRequest) error {
+func (m *mockRadioService) LinkPlay(playID uint, req *contracts.LinkPlayRequest) (error) {
 	if m.linkPlayFn != nil {
 		return m.linkPlayFn(playID, req)
 	}
@@ -2096,11 +2097,17 @@ func (m *mockRadioService) BulkLinkPlays(req *contracts.BulkLinkRequest) (*contr
 	}
 	return nil, nil
 }
-func (m *mockRadioService) ComputeAffinity() error {
+func (m *mockRadioService) ComputeAffinity() (error) {
 	if m.computeAffinityFn != nil {
 		return m.computeAffinityFn()
 	}
 	return nil
+}
+func (m *mockRadioService) SyncAffinityToRelationships() (*contracts.SyncAffinityResult, error) {
+	if m.syncAffinityToRelationshipsFn != nil {
+		return m.syncAffinityToRelationshipsFn()
+	}
+	return nil, nil
 }
 func (m *mockRadioService) ReMatchUnmatched() (*contracts.MatchResult, error) {
 	if m.reMatchUnmatchedFn != nil {

--- a/backend/internal/models/artist_relationship.go
+++ b/backend/internal/models/artist_relationship.go
@@ -8,11 +8,12 @@ import (
 
 // Relationship type constants
 const (
-	RelationshipTypeSimilar    = "similar"
-	RelationshipTypeSharedBills = "shared_bills"
-	RelationshipTypeSharedLabel = "shared_label"
-	RelationshipTypeSideProject = "side_project"
-	RelationshipTypeMemberOf    = "member_of"
+	RelationshipTypeSimilar          = "similar"
+	RelationshipTypeSharedBills      = "shared_bills"
+	RelationshipTypeSharedLabel      = "shared_label"
+	RelationshipTypeSideProject      = "side_project"
+	RelationshipTypeMemberOf         = "member_of"
+	RelationshipTypeRadioCooccurrence = "radio_cooccurrence"
 )
 
 // ArtistRelationship represents a relationship between two artists.

--- a/backend/internal/services/catalog/radio_affinity_sync_test.go
+++ b/backend/internal/services/catalog/radio_affinity_sync_test.go
@@ -1,0 +1,434 @@
+package catalog
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/testutil"
+)
+
+// =============================================================================
+// UNIT TESTS (No Database Required)
+// =============================================================================
+
+func TestRadioService_NilDB_SyncAffinityToRelationships(t *testing.T) {
+	svc := &RadioService{db: nil}
+	assertNilDBError(t, func() error {
+		_, err := svc.SyncAffinityToRelationships()
+		return err
+	})
+}
+
+// =============================================================================
+// INTEGRATION TESTS (Require Database)
+// =============================================================================
+
+type RadioAffinitySyncSuite struct {
+	suite.Suite
+	testDB *testutil.TestDatabase
+	db     *gorm.DB
+	svc    *RadioService
+}
+
+func TestRadioAffinitySyncSuite(t *testing.T) {
+	suite.Run(t, new(RadioAffinitySyncSuite))
+}
+
+func (s *RadioAffinitySyncSuite) SetupSuite() {
+	s.testDB = testutil.SetupTestPostgres(s.T())
+	s.db = s.testDB.DB
+	s.svc = &RadioService{db: s.db}
+}
+
+func (s *RadioAffinitySyncSuite) TearDownSuite() {
+	s.testDB.Cleanup()
+}
+
+func (s *RadioAffinitySyncSuite) TearDownTest() {
+	sqlDB, err := s.db.DB()
+	s.Require().NoError(err)
+	// Delete in FK-safe order
+	_, _ = sqlDB.Exec("DELETE FROM artist_relationship_votes")
+	_, _ = sqlDB.Exec("DELETE FROM artist_relationships")
+	_, _ = sqlDB.Exec("DELETE FROM radio_artist_affinity")
+	_, _ = sqlDB.Exec("DELETE FROM radio_plays")
+	_, _ = sqlDB.Exec("DELETE FROM radio_episodes")
+	_, _ = sqlDB.Exec("DELETE FROM radio_shows")
+	_, _ = sqlDB.Exec("DELETE FROM radio_stations")
+	_, _ = sqlDB.Exec("DELETE FROM artists")
+}
+
+// createArtist creates an artist for testing.
+func (s *RadioAffinitySyncSuite) createArtist(name, slug string) *models.Artist {
+	artist := &models.Artist{
+		Name: name,
+		Slug: &slug,
+	}
+	s.Require().NoError(s.db.Create(artist).Error)
+	return artist
+}
+
+// insertAffinity directly inserts a radio_artist_affinity row.
+func (s *RadioAffinitySyncSuite) insertAffinity(artistAID, artistBID uint, coOccurrenceCount, showCount, stationCount int) {
+	aff := &models.RadioArtistAffinity{
+		ArtistAID:         artistAID,
+		ArtistBID:         artistBID,
+		CoOccurrenceCount: coOccurrenceCount,
+		ShowCount:         showCount,
+		StationCount:      stationCount,
+	}
+	s.Require().NoError(s.db.Create(aff).Error)
+}
+
+// ── SyncAffinityToRelationships ──
+
+func (s *RadioAffinitySyncSuite) TestSync_CreatesNewRelationships() {
+	artist1 := s.createArtist("Artist A", "artist-a-sync1")
+	artist2 := s.createArtist("Artist B", "artist-b-sync1")
+
+	lowID, highID := artist1.ID, artist2.ID
+	if lowID > highID {
+		lowID, highID = highID, lowID
+	}
+
+	s.insertAffinity(lowID, highID, 5, 3, 1)
+
+	result, err := s.svc.SyncAffinityToRelationships()
+	s.Require().NoError(err)
+	s.Equal(1, result.Created)
+	s.Equal(0, result.Updated)
+	s.Equal(0, result.Deleted)
+
+	// Verify the relationship was created
+	var rel models.ArtistRelationship
+	err = s.db.Where("source_artist_id = ? AND target_artist_id = ? AND relationship_type = ?",
+		lowID, highID, models.RelationshipTypeRadioCooccurrence).First(&rel).Error
+	s.Require().NoError(err)
+	s.True(rel.AutoDerived)
+	s.Equal(models.RelationshipTypeRadioCooccurrence, rel.RelationshipType)
+}
+
+func (s *RadioAffinitySyncSuite) TestSync_UpdatesExistingRelationships() {
+	artist1 := s.createArtist("Artist A", "artist-a-sync2")
+	artist2 := s.createArtist("Artist B", "artist-b-sync2")
+
+	lowID, highID := artist1.ID, artist2.ID
+	if lowID > highID {
+		lowID, highID = highID, lowID
+	}
+
+	// Insert an existing radio_cooccurrence relationship
+	existingRel := &models.ArtistRelationship{
+		SourceArtistID:   lowID,
+		TargetArtistID:   highID,
+		RelationshipType: models.RelationshipTypeRadioCooccurrence,
+		Score:            0.1,
+		AutoDerived:      true,
+	}
+	s.Require().NoError(s.db.Create(existingRel).Error)
+
+	// Now insert an affinity with higher counts
+	s.insertAffinity(lowID, highID, 25, 10, 2)
+
+	result, err := s.svc.SyncAffinityToRelationships()
+	s.Require().NoError(err)
+	s.Equal(0, result.Created)
+	s.Equal(1, result.Updated)
+	s.Equal(0, result.Deleted)
+
+	// Verify the score was updated
+	var rel models.ArtistRelationship
+	err = s.db.Where("source_artist_id = ? AND target_artist_id = ? AND relationship_type = ?",
+		lowID, highID, models.RelationshipTypeRadioCooccurrence).First(&rel).Error
+	s.Require().NoError(err)
+	// 25/50 = 0.5 * 1.5 (cross-station) = 0.75
+	s.InDelta(0.75, float64(rel.Score), 0.01)
+}
+
+func (s *RadioAffinitySyncSuite) TestSync_DeletesStaleRelationships() {
+	artist1 := s.createArtist("Artist A", "artist-a-sync3")
+	artist2 := s.createArtist("Artist B", "artist-b-sync3")
+
+	lowID, highID := artist1.ID, artist2.ID
+	if lowID > highID {
+		lowID, highID = highID, lowID
+	}
+
+	// Insert an existing radio_cooccurrence relationship but NO affinity data
+	staleRel := &models.ArtistRelationship{
+		SourceArtistID:   lowID,
+		TargetArtistID:   highID,
+		RelationshipType: models.RelationshipTypeRadioCooccurrence,
+		Score:            0.5,
+		AutoDerived:      true,
+	}
+	s.Require().NoError(s.db.Create(staleRel).Error)
+
+	result, err := s.svc.SyncAffinityToRelationships()
+	s.Require().NoError(err)
+	s.Equal(0, result.Created)
+	s.Equal(0, result.Updated)
+	s.Equal(1, result.Deleted)
+
+	// Verify the relationship was deleted
+	var count int64
+	s.db.Model(&models.ArtistRelationship{}).
+		Where("source_artist_id = ? AND target_artist_id = ? AND relationship_type = ?",
+			lowID, highID, models.RelationshipTypeRadioCooccurrence).
+		Count(&count)
+	s.Equal(int64(0), count)
+}
+
+func (s *RadioAffinitySyncSuite) TestSync_ScoreNormalization_CappedAt1() {
+	artist1 := s.createArtist("Artist A", "artist-a-sync4")
+	artist2 := s.createArtist("Artist B", "artist-b-sync4")
+
+	lowID, highID := artist1.ID, artist2.ID
+	if lowID > highID {
+		lowID, highID = highID, lowID
+	}
+
+	// 100 co-occurrences => 100/50 = 2.0 => capped at 1.0
+	s.insertAffinity(lowID, highID, 100, 50, 1)
+
+	result, err := s.svc.SyncAffinityToRelationships()
+	s.Require().NoError(err)
+	s.Equal(1, result.Created)
+
+	var rel models.ArtistRelationship
+	err = s.db.Where("source_artist_id = ? AND target_artist_id = ? AND relationship_type = ?",
+		lowID, highID, models.RelationshipTypeRadioCooccurrence).First(&rel).Error
+	s.Require().NoError(err)
+	s.InDelta(1.0, float64(rel.Score), 0.01)
+}
+
+func (s *RadioAffinitySyncSuite) TestSync_CrossStationMultiplier() {
+	artist1 := s.createArtist("Artist A", "artist-a-sync5")
+	artist2 := s.createArtist("Artist B", "artist-b-sync5")
+
+	lowID, highID := artist1.ID, artist2.ID
+	if lowID > highID {
+		lowID, highID = highID, lowID
+	}
+
+	// 10 co-occurrences, 1 station => 10/50 = 0.2 (no multiplier)
+	s.insertAffinity(lowID, highID, 10, 5, 1)
+
+	result, err := s.svc.SyncAffinityToRelationships()
+	s.Require().NoError(err)
+	s.Equal(1, result.Created)
+
+	var rel models.ArtistRelationship
+	err = s.db.Where("source_artist_id = ? AND target_artist_id = ? AND relationship_type = ?",
+		lowID, highID, models.RelationshipTypeRadioCooccurrence).First(&rel).Error
+	s.Require().NoError(err)
+	s.InDelta(0.2, float64(rel.Score), 0.01)
+}
+
+func (s *RadioAffinitySyncSuite) TestSync_CrossStationMultiplier_Applied() {
+	artist1 := s.createArtist("Artist A", "artist-a-sync6")
+	artist2 := s.createArtist("Artist B", "artist-b-sync6")
+
+	lowID, highID := artist1.ID, artist2.ID
+	if lowID > highID {
+		lowID, highID = highID, lowID
+	}
+
+	// 10 co-occurrences, 2 stations => 10/50 = 0.2 * 1.5 = 0.3
+	s.insertAffinity(lowID, highID, 10, 5, 2)
+
+	result, err := s.svc.SyncAffinityToRelationships()
+	s.Require().NoError(err)
+	s.Equal(1, result.Created)
+
+	var rel models.ArtistRelationship
+	err = s.db.Where("source_artist_id = ? AND target_artist_id = ? AND relationship_type = ?",
+		lowID, highID, models.RelationshipTypeRadioCooccurrence).First(&rel).Error
+	s.Require().NoError(err)
+	s.InDelta(0.3, float64(rel.Score), 0.01)
+}
+
+func (s *RadioAffinitySyncSuite) TestSync_CrossStationMultiplier_CappedAt1() {
+	artist1 := s.createArtist("Artist A", "artist-a-sync7")
+	artist2 := s.createArtist("Artist B", "artist-b-sync7")
+
+	lowID, highID := artist1.ID, artist2.ID
+	if lowID > highID {
+		lowID, highID = highID, lowID
+	}
+
+	// 40 co-occurrences, 3 stations => 40/50 = 0.8 * 1.5 = 1.2 => capped at 1.0
+	s.insertAffinity(lowID, highID, 40, 20, 3)
+
+	result, err := s.svc.SyncAffinityToRelationships()
+	s.Require().NoError(err)
+	s.Equal(1, result.Created)
+
+	var rel models.ArtistRelationship
+	err = s.db.Where("source_artist_id = ? AND target_artist_id = ? AND relationship_type = ?",
+		lowID, highID, models.RelationshipTypeRadioCooccurrence).First(&rel).Error
+	s.Require().NoError(err)
+	s.InDelta(1.0, float64(rel.Score), 0.01)
+}
+
+func (s *RadioAffinitySyncSuite) TestSync_SkipsBelowMinimumThreshold() {
+	artist1 := s.createArtist("Artist A", "artist-a-sync8")
+	artist2 := s.createArtist("Artist B", "artist-b-sync8")
+
+	lowID, highID := artist1.ID, artist2.ID
+	if lowID > highID {
+		lowID, highID = highID, lowID
+	}
+
+	// 1 co-occurrence (below threshold of 2, but inserted directly — ComputeAffinity
+	// already filters >= 2. SyncAffinityToRelationships also checks >= 2.)
+	aff := &models.RadioArtistAffinity{
+		ArtistAID:         lowID,
+		ArtistBID:         highID,
+		CoOccurrenceCount: 1,
+		ShowCount:         1,
+		StationCount:      1,
+	}
+	s.Require().NoError(s.db.Create(aff).Error)
+
+	result, err := s.svc.SyncAffinityToRelationships()
+	s.Require().NoError(err)
+	s.Equal(0, result.Created)
+
+	// No relationship should exist
+	var count int64
+	s.db.Model(&models.ArtistRelationship{}).
+		Where("relationship_type = ?", models.RelationshipTypeRadioCooccurrence).
+		Count(&count)
+	s.Equal(int64(0), count)
+}
+
+func (s *RadioAffinitySyncSuite) TestSync_CanonicalOrderPreserved() {
+	artist1 := s.createArtist("Artist A", "artist-a-sync9")
+	artist2 := s.createArtist("Artist B", "artist-b-sync9")
+
+	lowID, highID := artist1.ID, artist2.ID
+	if lowID > highID {
+		lowID, highID = highID, lowID
+	}
+
+	// The affinity table already stores canonical order (artist_a_id < artist_b_id)
+	s.insertAffinity(lowID, highID, 5, 3, 1)
+
+	result, err := s.svc.SyncAffinityToRelationships()
+	s.Require().NoError(err)
+	s.Equal(1, result.Created)
+
+	// Verify the relationship preserves canonical ordering
+	var rel models.ArtistRelationship
+	err = s.db.Where("source_artist_id = ? AND target_artist_id = ? AND relationship_type = ?",
+		lowID, highID, models.RelationshipTypeRadioCooccurrence).First(&rel).Error
+	s.Require().NoError(err)
+	s.Equal(lowID, rel.SourceArtistID)
+	s.Equal(highID, rel.TargetArtistID)
+}
+
+func (s *RadioAffinitySyncSuite) TestSync_JSONBDetailContent() {
+	artist1 := s.createArtist("Artist A", "artist-a-sync10")
+	artist2 := s.createArtist("Artist B", "artist-b-sync10")
+
+	lowID, highID := artist1.ID, artist2.ID
+	if lowID > highID {
+		lowID, highID = highID, lowID
+	}
+
+	s.insertAffinity(lowID, highID, 12, 8, 3)
+
+	result, err := s.svc.SyncAffinityToRelationships()
+	s.Require().NoError(err)
+	s.Equal(1, result.Created)
+
+	var rel models.ArtistRelationship
+	err = s.db.Where("source_artist_id = ? AND target_artist_id = ? AND relationship_type = ?",
+		lowID, highID, models.RelationshipTypeRadioCooccurrence).First(&rel).Error
+	s.Require().NoError(err)
+	s.Require().NotNil(rel.Detail)
+
+	var detail map[string]interface{}
+	err = json.Unmarshal(*rel.Detail, &detail)
+	s.Require().NoError(err)
+	s.Equal(float64(12), detail["co_occurrence_count"])
+	s.Equal(float64(3), detail["station_count"])
+	s.Equal(float64(8), detail["show_count"])
+}
+
+func (s *RadioAffinitySyncSuite) TestSync_MultiplePairs() {
+	artist1 := s.createArtist("Artist A", "artist-a-sync11")
+	artist2 := s.createArtist("Artist B", "artist-b-sync11")
+	artist3 := s.createArtist("Artist C", "artist-c-sync11")
+
+	// Sort pairs for canonical ordering
+	ids := []uint{artist1.ID, artist2.ID, artist3.ID}
+	// Pairs: (1,2), (1,3), (2,3)
+	pairs := [][2]uint{}
+	for i := 0; i < len(ids); i++ {
+		for j := i + 1; j < len(ids); j++ {
+			low, high := ids[i], ids[j]
+			if low > high {
+				low, high = high, low
+			}
+			pairs = append(pairs, [2]uint{low, high})
+		}
+	}
+
+	for i, pair := range pairs {
+		s.insertAffinity(pair[0], pair[1], (i+1)*5, (i+1)*3, 1)
+	}
+
+	result, err := s.svc.SyncAffinityToRelationships()
+	s.Require().NoError(err)
+	s.Equal(3, result.Created)
+	s.Equal(0, result.Updated)
+	s.Equal(0, result.Deleted)
+
+	// Verify all 3 relationships exist
+	var count int64
+	s.db.Model(&models.ArtistRelationship{}).
+		Where("relationship_type = ?", models.RelationshipTypeRadioCooccurrence).
+		Count(&count)
+	s.Equal(int64(3), count)
+}
+
+func (s *RadioAffinitySyncSuite) TestSync_DoesNotDeleteOtherRelationshipTypes() {
+	artist1 := s.createArtist("Artist A", "artist-a-sync12")
+	artist2 := s.createArtist("Artist B", "artist-b-sync12")
+
+	lowID, highID := artist1.ID, artist2.ID
+	if lowID > highID {
+		lowID, highID = highID, lowID
+	}
+
+	// Create a shared_bills relationship (should NOT be deleted)
+	sharedBillsRel := &models.ArtistRelationship{
+		SourceArtistID:   lowID,
+		TargetArtistID:   highID,
+		RelationshipType: models.RelationshipTypeSharedBills,
+		Score:            0.5,
+		AutoDerived:      true,
+	}
+	s.Require().NoError(s.db.Create(sharedBillsRel).Error)
+
+	// No affinity data — sync should not touch the shared_bills relationship
+	result, err := s.svc.SyncAffinityToRelationships()
+	s.Require().NoError(err)
+	s.Equal(0, result.Created)
+	s.Equal(0, result.Updated)
+	s.Equal(0, result.Deleted)
+
+	// Verify shared_bills relationship still exists
+	var count int64
+	s.db.Model(&models.ArtistRelationship{}).
+		Where("source_artist_id = ? AND target_artist_id = ? AND relationship_type = ?",
+			lowID, highID, models.RelationshipTypeSharedBills).
+		Count(&count)
+	s.Equal(int64(1), count)
+}

--- a/backend/internal/services/catalog/radio_fetch_service.go
+++ b/backend/internal/services/catalog/radio_fetch_service.go
@@ -275,7 +275,7 @@ func (s *RadioFetchService) runFetchCycle() {
 	)
 }
 
-// runAffinityCycle computes the artist affinity table.
+// runAffinityCycle computes the artist affinity table and syncs to artist relationships.
 func (s *RadioFetchService) runAffinityCycle() {
 	start := time.Now()
 	s.logger.Info("starting affinity computation")
@@ -286,6 +286,23 @@ func (s *RadioFetchService) runAffinityCycle() {
 	}
 
 	s.logger.Info("affinity computation complete", "duration", time.Since(start))
+
+	// Sync affinity data to artist_relationships as radio_cooccurrence type
+	syncStart := time.Now()
+	s.logger.Info("starting affinity-to-relationship sync")
+
+	syncResult, err := s.radioService.SyncAffinityToRelationships()
+	if err != nil {
+		s.logger.Error("affinity-to-relationship sync failed", "error", err)
+		return
+	}
+
+	s.logger.Info("affinity-to-relationship sync complete",
+		"created", syncResult.Created,
+		"updated", syncResult.Updated,
+		"deleted", syncResult.Deleted,
+		"duration", time.Since(syncStart),
+	)
 }
 
 // runReMatchCycle re-matches unmatched plays against current artists.

--- a/backend/internal/services/catalog/radio_unmatched.go
+++ b/backend/internal/services/catalog/radio_unmatched.go
@@ -1,9 +1,12 @@
 package catalog
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
+
+	"gorm.io/gorm"
 
 	"psychic-homily-backend/internal/models"
 	"psychic-homily-backend/internal/services/contracts"
@@ -290,6 +293,98 @@ func (s *RadioService) ComputeAffinity() error {
 	}
 
 	return nil
+}
+
+// SyncAffinityToRelationships syncs radio_artist_affinity rows into artist_relationships
+// as radio_cooccurrence relationships. Creates new, updates existing, and deletes stale relationships.
+func (s *RadioService) SyncAffinityToRelationships() (*contracts.SyncAffinityResult, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	result := &contracts.SyncAffinityResult{}
+
+	// 1. Query all affinity pairs with co_occurrence_count >= 2
+	//    (the ComputeAffinity query already filters >= 2, but be safe)
+	var affinities []models.RadioArtistAffinity
+	if err := s.db.Where("co_occurrence_count >= 2").Find(&affinities).Error; err != nil {
+		return nil, fmt.Errorf("querying affinity data: %w", err)
+	}
+
+	// Build a set of affinity pairs for stale detection
+	affinityPairs := make(map[[2]uint]bool, len(affinities))
+
+	for _, aff := range affinities {
+		// artist_a_id < artist_b_id is enforced by the affinity table CHECK constraint
+		pair := [2]uint{aff.ArtistAID, aff.ArtistBID}
+		affinityPairs[pair] = true
+
+		// Compute normalized score: min(1.0, co_occurrence_count / 50.0)
+		score := float32(aff.CoOccurrenceCount) / 50.0
+		if score > 1.0 {
+			score = 1.0
+		}
+
+		// Cross-station multiplier: if station_count > 1, multiply by 1.5 (cap at 1.0)
+		if aff.StationCount > 1 {
+			score *= 1.5
+			if score > 1.0 {
+				score = 1.0
+			}
+		}
+
+		// Build JSONB detail
+		detail, _ := json.Marshal(map[string]interface{}{
+			"co_occurrence_count": aff.CoOccurrenceCount,
+			"station_count":      aff.StationCount,
+			"show_count":         aff.ShowCount,
+		})
+		detailRaw := json.RawMessage(detail)
+
+		// Upsert into artist_relationships
+		var existing models.ArtistRelationship
+		err := s.db.Where("source_artist_id = ? AND target_artist_id = ? AND relationship_type = ?",
+			aff.ArtistAID, aff.ArtistBID, models.RelationshipTypeRadioCooccurrence).
+			First(&existing).Error
+
+		if err == gorm.ErrRecordNotFound {
+			rel := &models.ArtistRelationship{
+				SourceArtistID:   aff.ArtistAID,
+				TargetArtistID:   aff.ArtistBID,
+				RelationshipType: models.RelationshipTypeRadioCooccurrence,
+				Score:            score,
+				AutoDerived:      true,
+				Detail:           &detailRaw,
+			}
+			if err := s.db.Create(rel).Error; err == nil {
+				result.Created++
+			}
+		} else if err == nil {
+			s.db.Model(&existing).Updates(map[string]interface{}{
+				"score":  score,
+				"detail": &detailRaw,
+			})
+			result.Updated++
+		}
+	}
+
+	// 2. Delete stale radio_cooccurrence relationships that no longer exist in affinity table
+	var staleRels []models.ArtistRelationship
+	s.db.Where("relationship_type = ? AND auto_derived = TRUE", models.RelationshipTypeRadioCooccurrence).
+		Find(&staleRels)
+
+	for _, rel := range staleRels {
+		pair := [2]uint{rel.SourceArtistID, rel.TargetArtistID}
+		if !affinityPairs[pair] {
+			if err := s.db.Where("source_artist_id = ? AND target_artist_id = ? AND relationship_type = ?",
+				rel.SourceArtistID, rel.TargetArtistID, models.RelationshipTypeRadioCooccurrence).
+				Delete(&models.ArtistRelationship{}).Error; err == nil {
+				result.Deleted++
+			}
+		}
+	}
+
+	return result, nil
 }
 
 // ReMatchUnmatched re-runs the matching engine on all plays where artist_id IS NULL.

--- a/backend/internal/services/contracts/interfaces.go
+++ b/backend/internal/services/contracts/interfaces.go
@@ -592,6 +592,7 @@ type RadioServiceInterface interface {
 
 	// Affinity
 	ComputeAffinity() error
+	SyncAffinityToRelationships() (*SyncAffinityResult, error)
 
 	// Re-matching
 	ReMatchUnmatched() (*MatchResult, error)

--- a/backend/internal/services/contracts/radio.go
+++ b/backend/internal/services/contracts/radio.go
@@ -362,3 +362,11 @@ type RadioFetchCycleResult struct {
 	Failures          int      `json:"failures"`
 	Errors            []string `json:"errors,omitempty"`
 }
+
+// SyncAffinityResult summarizes the result of syncing radio affinity data
+// to artist relationships.
+type SyncAffinityResult struct {
+	Created int `json:"created"`
+	Updated int `json:"updated"`
+	Deleted int `json:"deleted"`
+}

--- a/frontend/features/artists/components/ArtistGraph.tsx
+++ b/frontend/features/artists/components/ArtistGraph.tsx
@@ -24,11 +24,12 @@ const ForceGraph2D = dynamic(() => import('react-force-graph-2d'), {
 
 // Edge type colors
 const EDGE_COLORS: Record<string, string> = {
-  similar: '#a1a1aa',       // zinc-400 (neutral)
-  shared_bills: '#60a5fa',  // blue-400
-  shared_label: '#c084fc',  // purple-400
-  side_project: '#4ade80',  // green-400
-  member_of: '#fbbf24',     // amber-400
+  similar: '#a1a1aa',              // zinc-400 (neutral)
+  shared_bills: '#60a5fa',         // blue-400
+  shared_label: '#c084fc',         // purple-400
+  side_project: '#4ade80',         // green-400
+  member_of: '#fbbf24',            // amber-400
+  radio_cooccurrence: '#2dd4bf',   // teal-400
 }
 
 const EDGE_LABELS: Record<string, string> = {
@@ -37,6 +38,7 @@ const EDGE_LABELS: Record<string, string> = {
   shared_label: 'Shared Label',
   side_project: 'Side Project',
   member_of: 'Member Of',
+  radio_cooccurrence: 'Radio Co-occurrence',
 }
 
 // Convert API data to graph format needed by react-force-graph-2d
@@ -237,6 +239,9 @@ export function ArtistGraphVisualization({ data, activeTypes, containerWidth }: 
       if (link.type === 'shared_bills') {
         return Math.max(1, link.score * 3)
       }
+      if (link.type === 'radio_cooccurrence') {
+        return Math.max(1, link.score * 3)
+      }
       return 1
     },
     []
@@ -246,6 +251,7 @@ export function ArtistGraphVisualization({ data, activeTypes, containerWidth }: 
     (link: GraphLink) => {
       if (link.type === 'shared_label') return [5, 5]
       if (link.type === 'side_project' || link.type === 'member_of') return [2, 4]
+      if (link.type === 'radio_cooccurrence') return [8, 3]
       return []
     },
     []

--- a/frontend/features/artists/components/RelatedArtists.tsx
+++ b/frontend/features/artists/components/RelatedArtists.tsx
@@ -24,9 +24,10 @@ const RELATIONSHIP_BADGES: Record<string, { label: string; className: string }> 
   shared_label: { label: 'Shared Label', className: 'bg-purple-900/30 text-purple-300 border-purple-700/50' },
   side_project: { label: 'Side Project', className: 'bg-green-900/30 text-green-300 border-green-700/50' },
   member_of: { label: 'Member Of', className: 'bg-amber-900/30 text-amber-300 border-amber-700/50' },
+  radio_cooccurrence: { label: 'Radio Co-occurrence', className: 'bg-teal-900/30 text-teal-300 border-teal-700/50' },
 }
 
-const ALL_TYPES = ['similar', 'shared_bills', 'shared_label', 'side_project', 'member_of']
+const ALL_TYPES = ['similar', 'shared_bills', 'shared_label', 'side_project', 'member_of', 'radio_cooccurrence']
 
 interface RelatedArtistsProps {
   artistId: number
@@ -222,6 +223,7 @@ function RelatedArtistRow({
   // Primary display info
   const similarLink = links.find(l => l.type === 'similar')
   const sharedBillsLink = links.find(l => l.type === 'shared_bills')
+  const radioLink = links.find(l => l.type === 'radio_cooccurrence')
 
   // Format score display
   const getScoreDisplay = () => {
@@ -234,6 +236,17 @@ function RelatedArtistRow({
       const count = (sharedBillsLink.detail as Record<string, unknown>).shared_count
       if (count) {
         parts.push(`${count} shared ${Number(count) === 1 ? 'show' : 'shows'}`)
+      }
+    }
+    if (radioLink && radioLink.detail) {
+      const detail = radioLink.detail as Record<string, unknown>
+      const coCount = detail.co_occurrence_count
+      const stationCount = detail.station_count
+      if (coCount) {
+        const stationPart = stationCount && Number(stationCount) > 1
+          ? ` across ${stationCount} stations`
+          : ''
+        parts.push(`${coCount}x on radio${stationPart}`)
       }
     }
     return parts.join(' \u00b7 ')


### PR DESCRIPTION
## Summary
- **New relationship type** `radio_cooccurrence` added to artist_relationships system
- **Affinity sync**: `SyncAffinityToRelationships()` converts `radio_artist_affinity` rows into artist relationships with normalized scoring
- **Scoring**: `min(1.0, co_occurrence_count / 50.0)` with 1.5x cross-station multiplier (2+ stations = independent curatorial confirmation)
- **Stale cleanup**: removes radio_cooccurrence relationships no longer in affinity table
- **Wired into daily cycle**: runs automatically after `ComputeAffinity()` in RadioFetchService
- **Frontend**: teal edges with distinct dash pattern in ArtistGraph, teal badges in RelatedArtists with "12x on radio across 3 stations" detail
- **13 tests** covering scoring, thresholds, cross-station weighting, stale cleanup, canonical ordering

Closes PSY-169

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `bun run build` compiles cleanly
- [x] 13 tests pass
- [x] Score normalization capped at 1.0
- [x] Cross-station multiplier applied correctly
- [x] Below-threshold pairs skipped
- [x] Stale relationships deleted without affecting other types
- [x] JSONB detail contains co_occurrence_count, station_count, show_count
- [x] Frontend graph shows radio co-occurrence with distinct teal style

🤖 Generated with [Claude Code](https://claude.com/claude-code)