### PR TITLE
Fix radio UI pluralization bugs (PSY-263)

### DIFF
--- a/frontend/app/admin/radio/_components/RadioManagement.tsx
+++ b/frontend/app/admin/radio/_components/RadioManagement.tsx
@@ -985,7 +985,7 @@ function RadioMatchingTab() {
             {/* TODO: A dedicated unmatched plays endpoint (grouped by artist_name with play counts)
                 will be needed for full functionality. For now, showing aggregate stats from /radio/stats. */}
             Unmatched plays will be listed here grouped by artist name once a dedicated
-            endpoint is available. Currently {unmatchedPlays.toLocaleString()} plays are unmatched.
+            endpoint is available. Currently {unmatchedPlays.toLocaleString()} {unmatchedPlays === 1 ? 'play is' : 'plays are'} unmatched.
           </p>
         </div>
       </div>

--- a/frontend/app/radio/[station-slug]/[show-slug]/[date]/page.tsx
+++ b/frontend/app/radio/[station-slug]/[show-slug]/[date]/page.tsx
@@ -200,7 +200,7 @@ export default function EpisodeDatePage({ params }: EpisodeDatePageProps) {
             <Music className="h-5 w-5" />
             Playlist
             <span className="text-sm font-normal text-muted-foreground">
-              ({plays.length} tracks)
+              ({plays.length} {plays.length === 1 ? 'track' : 'tracks'})
             </span>
           </h2>
 

--- a/frontend/app/radio/[station-slug]/page.tsx
+++ b/frontend/app/radio/[station-slug]/page.tsx
@@ -94,7 +94,7 @@ function NewReleaseRadarSection({ stationId }: { stationId: number }) {
               )}
             </div>
             <div className="shrink-0 text-xs text-muted-foreground tabular-nums">
-              {entry.play_count} plays
+              {entry.play_count} {entry.play_count === 1 ? 'play' : 'plays'}
               {entry.station_count > 1 && ` / ${entry.station_count} stations`}
             </div>
           </div>
@@ -187,7 +187,7 @@ export default function StationPage({ params }: StationPageProps) {
               {station.show_count > 0 && (
                 <span className="flex items-center gap-1 text-sm text-muted-foreground">
                   <Music className="h-3.5 w-3.5" />
-                  {station.show_count} shows
+                  {station.show_count} {station.show_count === 1 ? 'show' : 'shows'}
                 </span>
               )}
             </div>

--- a/frontend/app/radio/page.tsx
+++ b/frontend/app/radio/page.tsx
@@ -21,10 +21,10 @@ export default function RadioPage() {
 
           {stats && (
             <div className="flex items-center justify-center gap-6 mt-4 text-sm text-muted-foreground">
-              <span>{stats.total_stations} stations</span>
-              <span>{stats.total_shows} shows</span>
-              <span>{stats.total_episodes.toLocaleString()} episodes</span>
-              <span>{stats.total_plays.toLocaleString()} plays tracked</span>
+              <span>{stats.total_stations} {stats.total_stations === 1 ? 'station' : 'stations'}</span>
+              <span>{stats.total_shows} {stats.total_shows === 1 ? 'show' : 'shows'}</span>
+              <span>{stats.total_episodes.toLocaleString()} {stats.total_episodes === 1 ? 'episode' : 'episodes'}</span>
+              <span>{stats.total_plays.toLocaleString()} {stats.total_plays === 1 ? 'play' : 'plays'} tracked</span>
             </div>
           )}
         </div>

--- a/frontend/features/radio/components/AsHeardOn.tsx
+++ b/frontend/features/radio/components/AsHeardOn.tsx
@@ -31,7 +31,7 @@ function AsHeardOnList({ items }: { items: RadioAsHeardOn[] }) {
             <div className="flex-1 min-w-0">
               <span className="truncate block">{item.show_name}</span>
               <span className="text-xs text-muted-foreground/60">
-                {item.station_name} - {item.play_count} plays
+                {item.station_name} - {item.play_count} {item.play_count === 1 ? 'play' : 'plays'}
               </span>
             </div>
           </Link>

--- a/frontend/features/radio/components/RadioShowCard.tsx
+++ b/frontend/features/radio/components/RadioShowCard.tsx
@@ -53,7 +53,7 @@ export function RadioShowCard({ show, stationSlug }: RadioShowCardProps) {
             {show.episode_count > 0 && (
               <span className="flex items-center gap-1 text-xs text-muted-foreground">
                 <ListMusic className="h-3 w-3" />
-                {show.episode_count} episodes
+                {show.episode_count} {show.episode_count === 1 ? 'episode' : 'episodes'}
               </span>
             )}
           </div>


### PR DESCRIPTION
## Summary
- Fix 9 pluralization issues across 6 radio frontend files
- "1 episodes" → "1 episode", "1 plays" → "1 play", "1 tracks" → "1 track"
- Fix subject-verb agreement in admin matching tab ("1 play is unmatched")
- Uses existing codebase pattern `count === 1 ? 'singular' : 'plural'`

## Test plan
- [ ] Visit /radio/kexp — show cards display correct singular/plural for episode counts
- [ ] Visit an artist with radio plays — "As Heard On" shows "1 play" not "1 plays"
- [ ] Admin > Radio > Matching — unmatched count uses correct grammar
- [ ] Radio browse page stats use correct plurals

Closes PSY-263

🤖 Generated with [Claude Code](https://claude.com/claude-code)