### PR TITLE
Fix user profile activity: hide internal labels, add entity links (PSY-265)

### DIFF
--- a/backend/internal/services/user/contributor_profile.go
+++ b/backend/internal/services/user/contributor_profile.go
@@ -911,6 +911,24 @@ func (s *ContributorProfileService) enrichEntityNames(entries []*contracts.Contr
 			for _, r := range results {
 				names[r.ID] = r.Name
 			}
+		case "request":
+			var results []struct {
+				ID    uint
+				Title string
+			}
+			s.db.Table("requests").Select("id, title").Where("id IN ?", ids).Scan(&results)
+			for _, r := range results {
+				names[r.ID] = r.Title
+			}
+		case "collection":
+			var results []struct {
+				ID    uint
+				Title string
+			}
+			s.db.Table("collections").Select("id, title").Where("id IN ?", ids).Scan(&results)
+			for _, r := range results {
+				names[r.ID] = r.Title
+			}
 		}
 		nameMap[entityType] = names
 	}

--- a/frontend/components/contributor/ContributionTimeline.test.tsx
+++ b/frontend/components/contributor/ContributionTimeline.test.tsx
@@ -58,13 +58,31 @@ describe('ContributionTimeline', () => {
     expect(screen.getByText('Valley Bar')).toBeInTheDocument()
   })
 
-  it('formats action text with capitalization', () => {
+  it('formats unknown action text with capitalization', () => {
     render(
       <ContributionTimeline
         contributions={[makeEntry({ action: 'venue_edit_submitted' })]}
       />
     )
     expect(screen.getByText('Venue Edit Submitted')).toBeInTheDocument()
+  })
+
+  it('uses friendly labels for known actions', () => {
+    render(
+      <ContributionTimeline
+        contributions={[makeEntry({ action: 'submit_show' })]}
+      />
+    )
+    expect(screen.getByText('Submitted show')).toBeInTheDocument()
+  })
+
+  it('maps suggest_edit to user-friendly label', () => {
+    render(
+      <ContributionTimeline
+        contributions={[makeEntry({ action: 'suggest_edit' })]}
+      />
+    )
+    expect(screen.getByText('Suggested edit')).toBeInTheDocument()
   })
 
   it('links to entity for known entity types', () => {
@@ -104,7 +122,39 @@ describe('ContributionTimeline', () => {
     expect(entityText.tagName).toBe('SPAN')
   })
 
-  it('shows entity type and id when entity_name is missing', () => {
+  it('links requests to /requests/:id', () => {
+    render(
+      <ContributionTimeline
+        contributions={[
+          makeEntry({
+            entity_type: 'request',
+            entity_id: 5,
+            entity_name: 'Add artist Foo',
+          }),
+        ]}
+      />
+    )
+    const link = screen.getByText('Add artist Foo')
+    expect(link.closest('a')).toHaveAttribute('href', '/requests/5')
+  })
+
+  it('links collections to /collection/:id', () => {
+    render(
+      <ContributionTimeline
+        contributions={[
+          makeEntry({
+            entity_type: 'collection',
+            entity_id: 8,
+            entity_name: 'My Favorites',
+          }),
+        ]}
+      />
+    )
+    const link = screen.getByText('My Favorites')
+    expect(link.closest('a')).toHaveAttribute('href', '/collection/8')
+  })
+
+  it('shows fallback label with link when entity_name is missing for a known type', () => {
     render(
       <ContributionTimeline
         contributions={[
@@ -116,7 +166,24 @@ describe('ContributionTimeline', () => {
         ]}
       />
     )
-    expect(screen.getByText('show #55')).toBeInTheDocument()
+    const fallback = screen.getByText('a show')
+    expect(fallback).toBeInTheDocument()
+    expect(fallback.closest('a')).toHaveAttribute('href', '/shows/55')
+  })
+
+  it('shows raw entity type when entity_name is missing for an unknown type', () => {
+    render(
+      <ContributionTimeline
+        contributions={[
+          makeEntry({
+            entity_name: undefined,
+            entity_type: 'something_else',
+            entity_id: 99,
+          }),
+        ]}
+      />
+    )
+    expect(screen.getByText('something_else')).toBeInTheDocument()
   })
 
   it('formats "just now" for very recent timestamps', () => {
@@ -216,6 +283,28 @@ describe('ContributionTimeline', () => {
       />
     )
     expect(screen.queryByText(/via web/)).not.toBeInTheDocument()
+  })
+
+  it('does not show source when source is "audit_log"', () => {
+    render(
+      <ContributionTimeline
+        contributions={[
+          makeEntry({ source: 'audit_log', created_at: '2026-03-19T11:00:00Z' }),
+        ]}
+      />
+    )
+    expect(screen.queryByText(/via audit_log/)).not.toBeInTheDocument()
+  })
+
+  it('does not show source when source is "submission"', () => {
+    render(
+      <ContributionTimeline
+        contributions={[
+          makeEntry({ source: 'submission', created_at: '2026-03-19T11:00:00Z' }),
+        ]}
+      />
+    )
+    expect(screen.queryByText(/via submission/)).not.toBeInTheDocument()
   })
 
   it('renders multiple entries', () => {

--- a/frontend/components/contributor/ContributionTimeline.tsx
+++ b/frontend/components/contributor/ContributionTimeline.tsx
@@ -28,10 +28,6 @@ function getEntityIcon(entityType: string): LucideIcon {
 }
 
 function getEntityLink(entry: ContributionEntry): string | null {
-  // Build a link to the entity if possible
-  const entityName = entry.entity_name
-  if (!entityName) return null
-
   switch (entry.entity_type) {
     case 'show':
     case 'venue':
@@ -40,16 +36,72 @@ function getEntityLink(entry: ContributionEntry): string | null {
     case 'label':
     case 'festival':
       return `/${entry.entity_type}s/${entry.entity_id}`
+    case 'request':
+      return `/requests/${entry.entity_id}`
+    case 'collection':
+      return `/collection/${entry.entity_id}`
+    case 'venue_edit':
+      return `/venues/${entry.entity_id}`
     default:
       return null
   }
 }
 
+/**
+ * Returns a human-readable label for the entity type, used as a fallback
+ * when the backend doesn't return an entity name.
+ */
+const entityTypeLabels: Record<string, string> = {
+  show: 'a show',
+  venue: 'a venue',
+  artist: 'an artist',
+  release: 'a release',
+  label: 'a label',
+  festival: 'a festival',
+  request: 'a request',
+  collection: 'a collection',
+  venue_edit: 'a venue',
+}
+
+function getFallbackEntityLabel(entry: ContributionEntry): string {
+  return entityTypeLabels[entry.entity_type] || entry.entity_type
+}
+
+/**
+ * Maps raw action strings from the API into user-friendly display labels.
+ * Actions come from audit_logs (e.g., "create", "report") and submission
+ * sources (e.g., "submit_show", "submit_venue_edit").
+ */
+const actionLabels: Record<string, string> = {
+  submit_show: 'Submitted show',
+  submit_venue: 'Submitted venue',
+  submit_venue_edit: 'Suggested venue edit',
+  create: 'Created',
+  update: 'Updated',
+  delete: 'Deleted',
+  report: 'Reported',
+  suggest_edit: 'Suggested edit',
+  approve: 'Approved',
+  reject: 'Rejected',
+  vote: 'Voted on',
+  create_request: 'Created request',
+  fulfill_request: 'Fulfilled request',
+  create_collection: 'Created collection',
+}
+
 function formatAction(action: string): string {
+  if (actionLabels[action]) return actionLabels[action]
+  // Fallback: title-case with underscores replaced
   return action
     .replace(/_/g, ' ')
     .replace(/\b\w/g, c => c.toUpperCase())
 }
+
+/**
+ * Sources that should not be displayed to users.
+ * "web" is the default, "audit_log" and "submission" are internal labels.
+ */
+const hiddenSources = new Set(['web', 'audit_log', 'submission'])
 
 interface ContributionTimelineProps {
   contributions: ContributionEntry[]
@@ -83,24 +135,33 @@ export function ContributionTimeline({ contributions }: ContributionTimelineProp
                 <span className="text-muted-foreground">
                   {formatAction(entry.action)}
                 </span>{' '}
-                {entry.entity_name && link ? (
+                {entry.entity_name ? (
+                  link ? (
+                    <Link
+                      href={link}
+                      className="font-medium hover:underline"
+                    >
+                      {entry.entity_name}
+                    </Link>
+                  ) : (
+                    <span className="font-medium">{entry.entity_name}</span>
+                  )
+                ) : link ? (
                   <Link
                     href={link}
-                    className="font-medium hover:underline"
+                    className="text-muted-foreground hover:underline"
                   >
-                    {entry.entity_name}
+                    {getFallbackEntityLabel(entry)}
                   </Link>
-                ) : entry.entity_name ? (
-                  <span className="font-medium">{entry.entity_name}</span>
                 ) : (
                   <span className="text-muted-foreground">
-                    {entry.entity_type} #{entry.entity_id}
+                    {getFallbackEntityLabel(entry)}
                   </span>
                 )}
               </p>
               <p className="text-xs text-muted-foreground mt-0.5">
                 {formatRelativeTime(entry.created_at, { short: true })}
-                {entry.source && entry.source !== 'web' && (
+                {entry.source && !hiddenSources.has(entry.source) && (
                   <span> &middot; via {entry.source}</span>
                 )}
               </p>


### PR DESCRIPTION
## Summary
- Hide internal source labels ("via audit_log", "via submission") from activity feed
- Map raw action strings to user-friendly labels ("submit_show" → "Submitted show")
- Enrich entity names for requests and collections in backend
- Add link support for requests, collections, and venue edits
- Show "a show", "a request" fallback instead of "show #77" when name unavailable
- 7 new tests added (23 total, all passing)

## Test plan
- [ ] Visit /users/testuser2 — activity entries no longer show "via audit_log"
- [ ] Show submissions display as "Submitted show" with entity links when available
- [ ] Request entries show request title and link to /requests/:id
- [ ] All 23 ContributionTimeline tests pass

Closes PSY-265

🤖 Generated with [Claude Code](https://claude.com/claude-code)