### PR TITLE
Scroll edit drawer to relevant field from contribution prompt (PSY-266)

### DIFF
--- a/frontend/features/artists/components/ArtistDetail.tsx
+++ b/frontend/features/artists/components/ArtistDetail.tsx
@@ -840,6 +840,7 @@ export function ArtistDetail({ artistId }: ArtistDetailProps) {
 
   const [activeTab, setActiveTab] = useState('overview')
   const [isEditing, setIsEditing] = useState(false)
+  const [editFocusField, setEditFocusField] = useState<string | undefined>()
   const [isReportOpen, setIsReportOpen] = useState(false)
 
   // Fetch labels for sidebar
@@ -966,7 +967,10 @@ export function ArtistDetail({ artistId }: ArtistDetailProps) {
               entityId={artist.id}
               entitySlug={artist.slug}
               isAuthenticated={!!isAuthenticated}
-              onEditClick={() => setIsEditing(true)}
+              onEditClick={(focusField) => {
+                setEditFocusField(focusField)
+                setIsEditing(true)
+              }}
             />
           </>
         }
@@ -1050,12 +1054,16 @@ export function ArtistDetail({ artistId }: ArtistDetailProps) {
       {isAuthenticated && (
         <EntityEditDrawer
           open={isEditing}
-          onOpenChange={setIsEditing}
+          onOpenChange={(open) => {
+            setIsEditing(open)
+            if (!open) setEditFocusField(undefined)
+          }}
           entityType="artist"
           entityId={artist.id}
           entityName={artist.name}
           entity={artist as unknown as Record<string, unknown>}
           canEditDirectly={!!canEditDirectly}
+          focusField={editFocusField}
           onSuccess={() => {
             queryClient.invalidateQueries({
               queryKey: queryKeys.artists.detail(artistId),

--- a/frontend/features/contributions/components/ContributionPrompt.test.tsx
+++ b/frontend/features/contributions/components/ContributionPrompt.test.tsx
@@ -148,7 +148,7 @@ describe('ContributionPrompt', () => {
     expect(screen.queryByText('Can you write a description?')).not.toBeInTheDocument()
   })
 
-  it('calls onEditClick when action button is clicked', () => {
+  it('calls onEditClick with the gap field when action button is clicked', () => {
     mockUseDataGaps.mockReturnValue({
       data: {
         gaps: [{ field: 'website', label: 'Website', priority: 1 }],
@@ -160,6 +160,7 @@ describe('ContributionPrompt', () => {
 
     fireEvent.click(screen.getByText('Add it'))
     expect(defaultProps.onEditClick).toHaveBeenCalledTimes(1)
+    expect(defaultProps.onEditClick).toHaveBeenCalledWith('website')
   })
 
   it('renders nothing while loading', () => {

--- a/frontend/features/contributions/components/ContributionPrompt.tsx
+++ b/frontend/features/contributions/components/ContributionPrompt.tsx
@@ -43,8 +43,8 @@ interface ContributionPromptProps {
   entitySlug: string
   /** Whether the user is authenticated. If false, renders nothing. */
   isAuthenticated: boolean
-  /** Called when user clicks the action button. Opens the edit drawer. */
-  onEditClick: () => void
+  /** Called when user clicks the action button. Opens the edit drawer. Receives the field key of the top data gap. */
+  onEditClick: (focusField?: string) => void
 }
 
 export function ContributionPrompt({
@@ -97,7 +97,7 @@ export function ContributionPrompt({
       <Lightbulb className="h-4 w-4 text-primary shrink-0" />
       <span className="text-muted-foreground flex-1">{promptText}</span>
       <button
-        onClick={onEditClick}
+        onClick={() => onEditClick(topGap.field)}
         className="inline-flex items-center gap-1 text-primary hover:text-primary/80 font-medium whitespace-nowrap transition-colors"
       >
         Add it

--- a/frontend/features/contributions/components/EntityEditDrawer.tsx
+++ b/frontend/features/contributions/components/EntityEditDrawer.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useEffect, useRef } from 'react'
 import { Pencil, Check, Loader2 } from 'lucide-react'
 import {
   Sheet,
@@ -44,6 +44,8 @@ interface EntityEditDrawerProps {
   canEditDirectly: boolean
   /** Called after a successful edit (direct or pending). */
   onSuccess?: () => void
+  /** When set, the drawer will scroll to and focus this field after opening. */
+  focusField?: string
 }
 
 export function EntityEditDrawer({
@@ -55,6 +57,7 @@ export function EntityEditDrawer({
   entity,
   canEditDirectly,
   onSuccess,
+  focusField,
 }: EntityEditDrawerProps) {
   const fields = EDITABLE_FIELDS[entityType]
   const suggestEdit = useSuggestEdit()
@@ -73,6 +76,9 @@ export function EntityEditDrawer({
     return values
   }, [entity, fields])
 
+  // Track whether we need to focus a field after drawer opens
+  const pendingFocusField = useRef<string | undefined>(undefined)
+
   // Reset form when drawer opens
   const handleOpenChange = (isOpen: boolean) => {
     if (isOpen) {
@@ -80,9 +86,30 @@ export function EntityEditDrawer({
       setSummary('')
       setSubmitted(false)
       suggestEdit.reset()
+      pendingFocusField.current = focusField
+    } else {
+      pendingFocusField.current = undefined
     }
     onOpenChange(isOpen)
   }
+
+  // Scroll to and focus the target field after the drawer opens and animates in
+  useEffect(() => {
+    if (!open || !pendingFocusField.current) return
+
+    const fieldKey = pendingFocusField.current
+    // Delay to allow the sheet open animation to complete
+    const timer = setTimeout(() => {
+      const input = document.getElementById(`edit-${fieldKey}`)
+      if (input) {
+        input.scrollIntoView({ behavior: 'smooth', block: 'center' })
+        input.focus()
+        pendingFocusField.current = undefined
+      }
+    }, 300)
+
+    return () => clearTimeout(timer)
+  }, [open])
 
   // Get current value (edited or initial)
   const getValue = (key: string) => formValues[key] ?? initialValues[key] ?? ''

--- a/frontend/features/festivals/components/FestivalDetail.tsx
+++ b/frontend/features/festivals/components/FestivalDetail.tsx
@@ -51,6 +51,7 @@ export function FestivalDetail({ idOrSlug }: FestivalDetailProps) {
     user?.user_tier === 'local_ambassador'
   )
   const [isEditing, setIsEditing] = useState(false)
+  const [editFocusField, setEditFocusField] = useState<string | undefined>()
   const [isReportOpen, setIsReportOpen] = useState(false)
   const { data: artistsData, isLoading: artistsLoading } = useFestivalArtists({
     festivalIdOrSlug: idOrSlug,
@@ -322,7 +323,10 @@ export function FestivalDetail({ idOrSlug }: FestivalDetailProps) {
             entityId={festival.id}
             entitySlug={festival.slug}
             isAuthenticated={!!isAuthenticated}
-            onEditClick={() => setIsEditing(true)}
+            onEditClick={(focusField) => {
+              setEditFocusField(focusField)
+              setIsEditing(true)
+            }}
           />
         </>
       }
@@ -477,12 +481,16 @@ export function FestivalDetail({ idOrSlug }: FestivalDetailProps) {
     {festival && isAuthenticated && (
       <EntityEditDrawer
         open={isEditing}
-        onOpenChange={setIsEditing}
+        onOpenChange={(open) => {
+          setIsEditing(open)
+          if (!open) setEditFocusField(undefined)
+        }}
         entityType="festival"
         entityId={festival.id}
         entityName={festival.name}
         entity={festival as unknown as Record<string, unknown>}
         canEditDirectly={!!canEditDirectly}
+        focusField={editFocusField}
         onSuccess={() => {
           queryClient.invalidateQueries({
             queryKey: ['festivals', 'detail'],

--- a/frontend/features/venues/components/VenueDetail.tsx
+++ b/frontend/features/venues/components/VenueDetail.tsx
@@ -72,6 +72,7 @@ function VenueGenreProfile({ venueId }: { venueId: number }) {
 
 export function VenueDetail({ venueId }: VenueDetailProps) {
   const [isEditingVenue, setIsEditingVenue] = useState(false)
+  const [editFocusField, setEditFocusField] = useState<string | undefined>()
   const [isDeleteVenueOpen, setIsDeleteVenueOpen] = useState(false)
   const [isReportOpen, setIsReportOpen] = useState(false)
   const { isAuthenticated, user } = useAuthContext()
@@ -253,7 +254,10 @@ export function VenueDetail({ venueId }: VenueDetailProps) {
               entityId={venue.id}
               entitySlug={venue.slug}
               isAuthenticated={!!isAuthenticated}
-              onEditClick={() => setIsEditingVenue(true)}
+              onEditClick={(focusField) => {
+                setEditFocusField(focusField)
+                setIsEditingVenue(true)
+              }}
             />
           </div>
 
@@ -319,12 +323,16 @@ export function VenueDetail({ venueId }: VenueDetailProps) {
       {venue && isAuthenticated && (
         <EntityEditDrawer
           open={isEditingVenue}
-          onOpenChange={setIsEditingVenue}
+          onOpenChange={(open) => {
+            setIsEditingVenue(open)
+            if (!open) setEditFocusField(undefined)
+          }}
           entityType="venue"
           entityId={venue.id}
           entityName={venue.name}
           entity={venue as unknown as Record<string, unknown>}
           canEditDirectly={!!canEditDirectly}
+          focusField={editFocusField}
           onSuccess={handleVenueUpdated}
         />
       )}


### PR DESCRIPTION
## Summary
- ContributionPrompt now passes the data gap's field key when "Add it" is clicked
- EntityEditDrawer accepts a `focusField` prop and scrolls to + focuses the target input after the sheet animation completes (300ms delay)
- Updated ArtistDetail, VenueDetail, and FestivalDetail to wire up the focus field state
- "Edit" button in header still opens drawer without focus (scrolled to top, as before)

## Test plan
- [ ] On an artist page, click "Know this artist's Bandcamp? Add it" — drawer opens and scrolls to Bandcamp field
- [ ] On a venue page, click "Can you write a description? Add it" — drawer opens and scrolls to description field
- [ ] Clicking the "Edit" button still opens the drawer at the top
- [ ] ContributionPrompt tests pass (11 tests)

Closes PSY-266

🤖 Generated with [Claude Code](https://claude.com/claude-code)