### PR TITLE
Show entity names instead of IDs in moderation queue (PSY-267)

### DIFF
--- a/backend/internal/services/admin/entity_name.go
+++ b/backend/internal/services/admin/entity_name.go
@@ -1,0 +1,40 @@
+package admin
+
+import (
+	"fmt"
+
+	"gorm.io/gorm"
+)
+
+// resolveEntityName looks up an entity's display name by type and ID.
+// Returns the entity's name/title, or a fallback like "artist #123" if the lookup fails.
+func resolveEntityName(db *gorm.DB, entityType string, entityID uint) string {
+	if db == nil {
+		return fmt.Sprintf("%s #%d", entityType, entityID)
+	}
+
+	switch entityType {
+	case "artist":
+		var result struct{ Name string }
+		if err := db.Table("artists").Select("name").Where("id = ?", entityID).Scan(&result).Error; err == nil && result.Name != "" {
+			return result.Name
+		}
+	case "venue":
+		var result struct{ Name string }
+		if err := db.Table("venues").Select("name").Where("id = ?", entityID).Scan(&result).Error; err == nil && result.Name != "" {
+			return result.Name
+		}
+	case "festival":
+		var result struct{ Name string }
+		if err := db.Table("festivals").Select("name").Where("id = ?", entityID).Scan(&result).Error; err == nil && result.Name != "" {
+			return result.Name
+		}
+	case "show":
+		var result struct{ Title string }
+		if err := db.Table("shows").Select("title").Where("id = ?", entityID).Scan(&result).Error; err == nil && result.Title != "" {
+			return result.Title
+		}
+	}
+
+	return fmt.Sprintf("%s #%d", entityType, entityID)
+}

--- a/backend/internal/services/admin/entity_report.go
+++ b/backend/internal/services/admin/entity_report.go
@@ -235,6 +235,7 @@ func (s *EntityReportService) toResponse(report *models.EntityReport) *contracts
 		ID:         report.ID,
 		EntityType: report.EntityType,
 		EntityID:   report.EntityID,
+		EntityName: resolveEntityName(s.db, report.EntityType, report.EntityID),
 		ReportedBy: report.ReportedBy,
 		ReportType: report.ReportType,
 		Details:    report.Details,

--- a/backend/internal/services/admin/pending_edit.go
+++ b/backend/internal/services/admin/pending_edit.go
@@ -337,6 +337,7 @@ func (s *PendingEditService) toResponse(edit *models.PendingEntityEdit) *contrac
 		ID:              edit.ID,
 		EntityType:      edit.EntityType,
 		EntityID:        edit.EntityID,
+		EntityName:      resolveEntityName(s.db, edit.EntityType, edit.EntityID),
 		SubmittedBy:     edit.SubmittedBy,
 		Summary:         edit.Summary,
 		Status:          edit.Status,

--- a/backend/internal/services/contracts/entity_report.go
+++ b/backend/internal/services/contracts/entity_report.go
@@ -55,6 +55,7 @@ type EntityReportResponse struct {
 	ID           uint       `json:"id"`
 	EntityType   string     `json:"entity_type"`
 	EntityID     uint       `json:"entity_id"`
+	EntityName   string     `json:"entity_name,omitempty"`
 	ReportedBy   uint       `json:"reported_by"`
 	ReporterName string     `json:"reporter_name,omitempty"`
 	ReportType   string     `json:"report_type"`

--- a/backend/internal/services/contracts/pending_edit.go
+++ b/backend/internal/services/contracts/pending_edit.go
@@ -63,6 +63,7 @@ type PendingEditResponse struct {
 	ID              uint                   `json:"id"`
 	EntityType      string                 `json:"entity_type"`
 	EntityID        uint                   `json:"entity_id"`
+	EntityName      string                 `json:"entity_name,omitempty"`
 	SubmittedBy     uint                   `json:"submitted_by"`
 	SubmitterName   string                 `json:"submitter_name,omitempty"`
 	FieldChanges    []models.FieldChange   `json:"field_changes"`

--- a/frontend/app/admin/moderation/_components/ModerationQueue.tsx
+++ b/frontend/app/admin/moderation/_components/ModerationQueue.tsx
@@ -131,7 +131,7 @@ function PendingEditCard({ edit }: { edit: PendingEditResponse }) {
               target="_blank"
               rel="noopener noreferrer"
             >
-              {entityTypeLabel(edit.entity_type)} #{edit.entity_id}
+              {edit.entity_name || `${entityTypeLabel(edit.entity_type)} #${edit.entity_id}`}
               <ExternalLink className="h-3 w-3 inline ml-1 opacity-50" />
             </a>
           </div>
@@ -303,7 +303,7 @@ function EntityReportCard({ report }: { report: EntityReportResponse }) {
               target="_blank"
               rel="noopener noreferrer"
             >
-              {entityTypeLabel(report.entity_type)} #{report.entity_id}
+              {report.entity_name || `${entityTypeLabel(report.entity_type)} #${report.entity_id}`}
               <ExternalLink className="h-3 w-3 inline ml-1 opacity-50" />
             </a>
           </div>

--- a/frontend/lib/hooks/admin/useAdminEntityReports.ts
+++ b/frontend/lib/hooks/admin/useAdminEntityReports.ts
@@ -16,6 +16,7 @@ export interface EntityReportResponse {
   id: number
   entity_type: string
   entity_id: number
+  entity_name?: string
   reported_by: number
   reporter_name?: string
   report_type: string

--- a/frontend/lib/hooks/admin/useAdminPendingEdits.ts
+++ b/frontend/lib/hooks/admin/useAdminPendingEdits.ts
@@ -20,6 +20,7 @@ export interface PendingEditResponse {
   id: number
   entity_type: string
   entity_id: number
+  entity_name?: string
   submitted_by: number
   submitter_name?: string
   field_changes: FieldChange[]


### PR DESCRIPTION
## Summary
- **Backend**: Add `entity_name` field to `PendingEditResponse` and `EntityReportResponse`
- New shared `resolveEntityName()` helper queries artists/venues/festivals/shows tables
- Falls back to "{type} #{id}" if lookup fails
- **Frontend**: ModerationQueue displays entity names in link text with graceful fallback
- All 34 pending edit integration tests + handler tests pass

## Test plan
- [ ] Admin > Moderation — pending edits show "Eraser" instead of "Artist #793"
- [ ] Reports show "The Van Buren" instead of "Venue #12"
- [ ] Clicking entity name links navigates to correct detail page
- [ ] Backend tests pass (`go test ./internal/services/admin/...`)

Closes PSY-267

🤖 Generated with [Claude Code](https://claude.com/claude-code)