### PR TITLE
Open WFMU Listen Live in popup player window (PSY-268)

### DIFF
--- a/frontend/app/radio/[station-slug]/page.tsx
+++ b/frontend/app/radio/[station-slug]/page.tsx
@@ -200,7 +200,21 @@ export default function StationPage({ params }: StationPageProps) {
 
             {/* Action buttons */}
             <div className="flex items-center gap-2 mt-4">
-              {station.stream_url && (
+              {station.slug === 'wfmu' ? (
+                <Button
+                  size="sm"
+                  onClick={() => {
+                    window.open(
+                      'https://www.radiorethink.com/tuner/?stationCode=wfmu&stream=hi',
+                      'wfmu-player',
+                      'width=400,height=700,scrollbars=yes,resizable=yes'
+                    )
+                  }}
+                >
+                  <Radio className="h-4 w-4 mr-2" />
+                  Listen Live
+                </Button>
+              ) : station.stream_url ? (
                 <Button asChild size="sm">
                   <a
                     href={station.stream_url}
@@ -211,7 +225,7 @@ export default function StationPage({ params }: StationPageProps) {
                     Listen Live
                   </a>
                 </Button>
-              )}
+              ) : null}
               {station.donation_url && (
                 <Button asChild variant="outline" size="sm">
                   <a


### PR DESCRIPTION
## Summary
- WFMU "Listen Live" button now opens the radiorethink popup player (`radiorethink.com/tuner/?stationCode=wfmu&stream=hi`) in a 400x700 popup window
- Popup reuses the same `wfmu-player` window on repeated clicks
- All other stations retain existing behavior (new tab to stream_url)

Closes PSY-268

## Test plan
- [x] `bun run build` compiles cleanly
- [x] WFMU station page: "Listen Live" opens popup player
- [x] Other stations: "Listen Live" opens stream URL in new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)