### PR TITLE
Show artist names and label on release browse cards (PSY-269)

### DIFF
--- a/backend/internal/services/catalog/release.go
+++ b/backend/internal/services/catalog/release.go
@@ -168,48 +168,7 @@ func (s *ReleaseService) ListReleases(filters map[string]interface{}) ([]*contra
 		return nil, fmt.Errorf("failed to list releases: %w", err)
 	}
 
-	// Batch-load artist counts
-	releaseIDs := make([]uint, len(releases))
-	for i, r := range releases {
-		releaseIDs[i] = r.ID
-	}
-
-	artistCounts := make(map[uint]int)
-	if len(releaseIDs) > 0 {
-		type CountResult struct {
-			ReleaseID uint
-			Count     int
-		}
-		var counts []CountResult
-		s.db.Table("artist_releases").
-			Select("release_id, COUNT(DISTINCT artist_id) as count").
-			Where("release_id IN ?", releaseIDs).
-			Group("release_id").
-			Find(&counts)
-		for _, c := range counts {
-			artistCounts[c.ReleaseID] = c.Count
-		}
-	}
-
-	// Build responses
-	responses := make([]*contracts.ReleaseListResponse, len(releases))
-	for i, release := range releases {
-		slug := ""
-		if release.Slug != nil {
-			slug = *release.Slug
-		}
-		responses[i] = &contracts.ReleaseListResponse{
-			ID:          release.ID,
-			Title:       release.Title,
-			Slug:        slug,
-			ReleaseType: string(release.ReleaseType),
-			ReleaseYear: release.ReleaseYear,
-			CoverArtURL: release.CoverArtURL,
-			ArtistCount: artistCounts[release.ID],
-		}
-	}
-
-	return responses, nil
+	return s.buildListResponses(releases)
 }
 
 // SearchReleases searches for releases by title using ILIKE matching
@@ -246,48 +205,7 @@ func (s *ReleaseService) SearchReleases(query string) ([]*contracts.ReleaseListR
 		return nil, fmt.Errorf("failed to search releases: %w", err)
 	}
 
-	// Batch-load artist counts
-	releaseIDs := make([]uint, len(releases))
-	for i, r := range releases {
-		releaseIDs[i] = r.ID
-	}
-
-	artistCounts := make(map[uint]int)
-	if len(releaseIDs) > 0 {
-		type CountResult struct {
-			ReleaseID uint
-			Count     int
-		}
-		var counts []CountResult
-		s.db.Table("artist_releases").
-			Select("release_id, COUNT(DISTINCT artist_id) as count").
-			Where("release_id IN ?", releaseIDs).
-			Group("release_id").
-			Find(&counts)
-		for _, c := range counts {
-			artistCounts[c.ReleaseID] = c.Count
-		}
-	}
-
-	// Build responses
-	responses := make([]*contracts.ReleaseListResponse, len(releases))
-	for i, release := range releases {
-		slug := ""
-		if release.Slug != nil {
-			slug = *release.Slug
-		}
-		responses[i] = &contracts.ReleaseListResponse{
-			ID:          release.ID,
-			Title:       release.Title,
-			Slug:        slug,
-			ReleaseType: string(release.ReleaseType),
-			ReleaseYear: release.ReleaseYear,
-			CoverArtURL: release.CoverArtURL,
-			ArtistCount: artistCounts[release.ID],
-		}
-	}
-
-	return responses, nil
+	return s.buildListResponses(releases)
 }
 
 // UpdateRelease updates an existing release
@@ -430,42 +348,18 @@ func (s *ReleaseService) GetReleasesForArtistWithRoles(artistID uint) ([]*contra
 		return nil, fmt.Errorf("failed to get releases: %w", err)
 	}
 
-	// Batch-load artist counts
-	artistCounts := make(map[uint]int)
-	if len(releaseIDs) > 0 {
-		type CountResult struct {
-			ReleaseID uint
-			Count     int
-		}
-		var counts []CountResult
-		s.db.Table("artist_releases").
-			Select("release_id, COUNT(DISTINCT artist_id) as count").
-			Where("release_id IN ?", releaseIDs).
-			Group("release_id").
-			Find(&counts)
-		for _, c := range counts {
-			artistCounts[c.ReleaseID] = c.Count
-		}
+	// Build base list responses (includes artist names, counts, labels)
+	listResponses, err := s.buildListResponses(releases)
+	if err != nil {
+		return nil, err
 	}
 
-	// Build responses
-	responses := make([]*contracts.ArtistReleaseListResponse, len(releases))
-	for i, release := range releases {
-		slug := ""
-		if release.Slug != nil {
-			slug = *release.Slug
-		}
+	// Wrap with role info
+	responses := make([]*contracts.ArtistReleaseListResponse, len(listResponses))
+	for i, lr := range listResponses {
 		responses[i] = &contracts.ArtistReleaseListResponse{
-			ReleaseListResponse: contracts.ReleaseListResponse{
-				ID:          release.ID,
-				Title:       release.Title,
-				Slug:        slug,
-				ReleaseType: string(release.ReleaseType),
-				ReleaseYear: release.ReleaseYear,
-				CoverArtURL: release.CoverArtURL,
-				ArtistCount: artistCounts[release.ID],
-			},
-			Role: roleMap[release.ID],
+			ReleaseListResponse: *lr,
+			Role:                roleMap[lr.ID],
 		}
 	}
 
@@ -519,6 +413,132 @@ func (s *ReleaseService) RemoveExternalLink(linkID uint) error {
 	}
 
 	return nil
+}
+
+// buildListResponses converts a slice of Release models to ReleaseListResponse, batch-loading
+// artist counts, artist names, and primary label info.
+func (s *ReleaseService) buildListResponses(releases []models.Release) ([]*contracts.ReleaseListResponse, error) {
+	if len(releases) == 0 {
+		return []*contracts.ReleaseListResponse{}, nil
+	}
+
+	releaseIDs := make([]uint, len(releases))
+	for i, r := range releases {
+		releaseIDs[i] = r.ID
+	}
+
+	// Batch-load artist counts
+	artistCounts := make(map[uint]int)
+	{
+		type CountResult struct {
+			ReleaseID uint
+			Count     int
+		}
+		var counts []CountResult
+		s.db.Table("artist_releases").
+			Select("release_id, COUNT(DISTINCT artist_id) as count").
+			Where("release_id IN ?", releaseIDs).
+			Group("release_id").
+			Find(&counts)
+		for _, c := range counts {
+			artistCounts[c.ReleaseID] = c.Count
+		}
+	}
+
+	// Batch-load artist details (id, name, slug) per release via artist_releases + artists join
+	releaseArtists := make(map[uint][]contracts.ReleaseListArtist)
+	{
+		type ArtistRow struct {
+			ReleaseID uint
+			ArtistID  uint
+			Name      string
+			Slug      *string
+			Position  int
+		}
+		var rows []ArtistRow
+		s.db.Table("artist_releases").
+			Select("artist_releases.release_id, artist_releases.artist_id, artists.name, artists.slug, artist_releases.position").
+			Joins("JOIN artists ON artists.id = artist_releases.artist_id").
+			Where("artist_releases.release_id IN ?", releaseIDs).
+			Order("artist_releases.position ASC").
+			Find(&rows)
+		for _, row := range rows {
+			slug := ""
+			if row.Slug != nil {
+				slug = *row.Slug
+			}
+			releaseArtists[row.ReleaseID] = append(releaseArtists[row.ReleaseID], contracts.ReleaseListArtist{
+				ID:   row.ArtistID,
+				Name: row.Name,
+				Slug: slug,
+			})
+		}
+	}
+
+	// Batch-load primary label (first label) per release via release_labels + labels join
+	type LabelInfo struct {
+		Name string
+		Slug *string
+	}
+	releaseLabels := make(map[uint]*LabelInfo)
+	{
+		type LabelRow struct {
+			ReleaseID uint
+			Name      string
+			Slug      *string
+		}
+		var rows []LabelRow
+		s.db.Table("release_labels").
+			Select("release_labels.release_id, labels.name, labels.slug").
+			Joins("JOIN labels ON labels.id = release_labels.label_id").
+			Where("release_labels.release_id IN ?", releaseIDs).
+			Find(&rows)
+		for _, row := range rows {
+			// Use the first label found for each release
+			if _, exists := releaseLabels[row.ReleaseID]; !exists {
+				releaseLabels[row.ReleaseID] = &LabelInfo{
+					Name: row.Name,
+					Slug: row.Slug,
+				}
+			}
+		}
+	}
+
+	// Build responses
+	responses := make([]*contracts.ReleaseListResponse, len(releases))
+	for i, release := range releases {
+		slug := ""
+		if release.Slug != nil {
+			slug = *release.Slug
+		}
+
+		resp := &contracts.ReleaseListResponse{
+			ID:          release.ID,
+			Title:       release.Title,
+			Slug:        slug,
+			ReleaseType: string(release.ReleaseType),
+			ReleaseYear: release.ReleaseYear,
+			CoverArtURL: release.CoverArtURL,
+			ArtistCount: artistCounts[release.ID],
+			Artists:     releaseArtists[release.ID],
+		}
+
+		// Ensure Artists is never nil (always an empty slice for JSON)
+		if resp.Artists == nil {
+			resp.Artists = []contracts.ReleaseListArtist{}
+		}
+
+		if label, ok := releaseLabels[release.ID]; ok {
+			resp.LabelName = &label.Name
+			if label.Slug != nil {
+				resp.LabelSlug = label.Slug
+			}
+		}
+
+		responses[i] = resp
+	}
+
+	return responses, nil
 }
 
 // buildDetailResponse converts a Release model to contracts.ReleaseDetailResponse

--- a/backend/internal/services/catalog/release_test.go
+++ b/backend/internal/services/catalog/release_test.go
@@ -42,8 +42,11 @@ func (suite *ReleaseServiceIntegrationTestSuite) TearDownTest() {
 	suite.Require().NoError(err)
 	// Delete in FK-safe order
 	_, _ = sqlDB.Exec("DELETE FROM release_external_links")
+	_, _ = sqlDB.Exec("DELETE FROM release_labels")
 	_, _ = sqlDB.Exec("DELETE FROM artist_releases")
 	_, _ = sqlDB.Exec("DELETE FROM releases")
+	_, _ = sqlDB.Exec("DELETE FROM artist_labels")
+	_, _ = sqlDB.Exec("DELETE FROM labels")
 	_, _ = sqlDB.Exec("DELETE FROM show_artists")
 	_, _ = sqlDB.Exec("DELETE FROM show_venues")
 	_, _ = sqlDB.Exec("DELETE FROM shows")
@@ -65,6 +68,26 @@ func (suite *ReleaseServiceIntegrationTestSuite) createTestArtist(name string) *
 	err := suite.db.Create(artist).Error
 	suite.Require().NoError(err)
 	return artist
+}
+
+func (suite *ReleaseServiceIntegrationTestSuite) createTestLabel(name string) *models.Label {
+	slug := name // simplified slug for tests
+	label := &models.Label{
+		Name: name,
+		Slug: &slug,
+	}
+	err := suite.db.Create(label).Error
+	suite.Require().NoError(err)
+	return label
+}
+
+func (suite *ReleaseServiceIntegrationTestSuite) linkReleaseToLabel(releaseID, labelID uint) {
+	rl := &models.ReleaseLabel{
+		ReleaseID: releaseID,
+		LabelID:   labelID,
+	}
+	err := suite.db.Create(rl).Error
+	suite.Require().NoError(err)
 }
 
 // =============================================================================
@@ -287,6 +310,91 @@ func (suite *ReleaseServiceIntegrationTestSuite) TestListReleases_ArtistCount() 
 	suite.Require().NoError(err)
 	suite.Require().Len(resp, 1)
 	suite.Equal(2, resp[0].ArtistCount)
+}
+
+func (suite *ReleaseServiceIntegrationTestSuite) TestListReleases_ArtistNames() {
+	artist1 := suite.createTestArtist("Alvvays")
+	artist2 := suite.createTestArtist("Snail Mail")
+
+	suite.releaseService.CreateRelease(&contracts.CreateReleaseRequest{
+		Title: "Split EP",
+		Artists: []contracts.CreateReleaseArtistEntry{
+			{ArtistID: artist1.ID, Role: "main"},
+			{ArtistID: artist2.ID, Role: "main"},
+		},
+	})
+
+	resp, err := suite.releaseService.ListReleases(map[string]interface{}{})
+
+	suite.Require().NoError(err)
+	suite.Require().Len(resp, 1)
+	suite.Require().Len(resp[0].Artists, 2)
+	suite.Equal("Alvvays", resp[0].Artists[0].Name)
+	suite.NotZero(resp[0].Artists[0].ID)
+	suite.Equal("Snail Mail", resp[0].Artists[1].Name)
+	suite.NotZero(resp[0].Artists[1].ID)
+}
+
+func (suite *ReleaseServiceIntegrationTestSuite) TestListReleases_ArtistsEmptySlice() {
+	// Release with no artists should have empty artists slice (not nil)
+	suite.releaseService.CreateRelease(&contracts.CreateReleaseRequest{
+		Title: "No Artist Album",
+	})
+
+	resp, err := suite.releaseService.ListReleases(map[string]interface{}{})
+
+	suite.Require().NoError(err)
+	suite.Require().Len(resp, 1)
+	suite.NotNil(resp[0].Artists)
+	suite.Empty(resp[0].Artists)
+}
+
+func (suite *ReleaseServiceIntegrationTestSuite) TestListReleases_LabelInfo() {
+	label := suite.createTestLabel("sub-pop")
+
+	created, err := suite.releaseService.CreateRelease(&contracts.CreateReleaseRequest{
+		Title: "Labeled Album",
+	})
+	suite.Require().NoError(err)
+	suite.linkReleaseToLabel(created.ID, label.ID)
+
+	resp, err := suite.releaseService.ListReleases(map[string]interface{}{})
+
+	suite.Require().NoError(err)
+	suite.Require().Len(resp, 1)
+	suite.Require().NotNil(resp[0].LabelName)
+	suite.Equal("sub-pop", *resp[0].LabelName)
+	suite.Require().NotNil(resp[0].LabelSlug)
+	suite.Equal("sub-pop", *resp[0].LabelSlug)
+}
+
+func (suite *ReleaseServiceIntegrationTestSuite) TestListReleases_NoLabel() {
+	suite.releaseService.CreateRelease(&contracts.CreateReleaseRequest{
+		Title: "Unlabeled Album",
+	})
+
+	resp, err := suite.releaseService.ListReleases(map[string]interface{}{})
+
+	suite.Require().NoError(err)
+	suite.Require().Len(resp, 1)
+	suite.Nil(resp[0].LabelName)
+	suite.Nil(resp[0].LabelSlug)
+}
+
+func (suite *ReleaseServiceIntegrationTestSuite) TestSearchReleases_ArtistNames() {
+	artist := suite.createTestArtist("Radiohead")
+
+	suite.releaseService.CreateRelease(&contracts.CreateReleaseRequest{
+		Title:   "OK Computer",
+		Artists: []contracts.CreateReleaseArtistEntry{{ArtistID: artist.ID, Role: "main"}},
+	})
+
+	resp, err := suite.releaseService.SearchReleases("OK Computer")
+
+	suite.Require().NoError(err)
+	suite.Require().Len(resp, 1)
+	suite.Require().Len(resp[0].Artists, 1)
+	suite.Equal("Radiohead", resp[0].Artists[0].Name)
 }
 
 // =============================================================================

--- a/backend/internal/services/contracts/release.go
+++ b/backend/internal/services/contracts/release.go
@@ -71,15 +71,25 @@ type ReleaseExternalLinkResponse struct {
 	URL      string `json:"url"`
 }
 
+// ReleaseListArtist represents an artist in release list views (minimal info for display)
+type ReleaseListArtist struct {
+	ID   uint   `json:"id"`
+	Name string `json:"name"`
+	Slug string `json:"slug"`
+}
+
 // ReleaseListResponse represents a release in list views
 type ReleaseListResponse struct {
-	ID          uint    `json:"id"`
-	Title       string  `json:"title"`
-	Slug        string  `json:"slug"`
-	ReleaseType string  `json:"release_type"`
-	ReleaseYear *int    `json:"release_year"`
-	CoverArtURL *string `json:"cover_art_url"`
-	ArtistCount int     `json:"artist_count"`
+	ID          uint                `json:"id"`
+	Title       string              `json:"title"`
+	Slug        string              `json:"slug"`
+	ReleaseType string              `json:"release_type"`
+	ReleaseYear *int                `json:"release_year"`
+	CoverArtURL *string             `json:"cover_art_url"`
+	ArtistCount int                 `json:"artist_count"`
+	Artists     []ReleaseListArtist `json:"artists"`
+	LabelName   *string             `json:"label_name"`
+	LabelSlug   *string             `json:"label_slug"`
 }
 
 // ArtistReleaseListResponse extends ReleaseListResponse with the artist's role on that release

--- a/frontend/features/releases/components/ReleaseCard.tsx
+++ b/frontend/features/releases/components/ReleaseCard.tsx
@@ -13,12 +13,57 @@ interface ReleaseCardProps {
   density?: ReleaseCardDensity
 }
 
+/**
+ * Format artist names for display.
+ * - 0 artists: returns null
+ * - 1-3 artists: comma-separated names
+ * - 4+ artists: "Various Artists"
+ */
+function formatArtistNames(release: ReleaseListItem): string | null {
+  const artists = release.artists
+  if (!artists || artists.length === 0) return null
+  if (artists.length > 3) return 'Various Artists'
+  return artists.map((a) => a.name).join(', ')
+}
+
+/**
+ * Render artist names as linked spans (for comfortable/expanded modes)
+ */
+function ArtistLinks({ release }: { release: ReleaseListItem }) {
+  const artists = release.artists
+  if (!artists || artists.length === 0) return null
+
+  if (artists.length > 3) {
+    return <span className="text-muted-foreground">Various Artists</span>
+  }
+
+  return (
+    <>
+      {artists.map((artist, i) => (
+        <span key={artist.id}>
+          <Link
+            href={`/artists/${artist.slug}`}
+            className="text-muted-foreground hover:text-primary transition-colors"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {artist.name}
+          </Link>
+          {i < artists.length - 1 && (
+            <span className="text-muted-foreground">, </span>
+          )}
+        </span>
+      ))}
+    </>
+  )
+}
+
 export function ReleaseCard({
   release,
   density = 'comfortable',
 }: ReleaseCardProps) {
   const releaseUrl = `/releases/${release.slug}`
   const typeLabel = getReleaseTypeLabel(release.release_type)
+  const artistDisplay = formatArtistNames(release)
 
   if (density === 'compact') {
     return (
@@ -36,7 +81,7 @@ export function ReleaseCard({
           href={releaseUrl}
           className="font-medium text-sm truncate flex-1 hover:text-primary transition-colors"
         >
-          {release.title}
+          {artistDisplay ? `${artistDisplay} — ${release.title}` : release.title}
         </Link>
         <Badge variant="secondary" className="text-[10px] shrink-0">
           {typeLabel}
@@ -75,6 +120,12 @@ export function ReleaseCard({
               </h3>
             </Link>
 
+            {artistDisplay && (
+              <div className="mt-1 text-sm truncate">
+                <ArtistLinks release={release} />
+              </div>
+            )}
+
             <div className="flex items-center gap-3 mt-2">
               <Badge variant="secondary" className="text-xs px-2 py-0.5">
                 {typeLabel}
@@ -86,11 +137,18 @@ export function ReleaseCard({
               )}
             </div>
 
-            {release.artist_count > 0 && (
+            {release.label_name && (
               <div className="mt-2 text-sm text-muted-foreground">
-                {release.artist_count === 1
-                  ? '1 artist'
-                  : `${release.artist_count} artists`}
+                {release.label_slug ? (
+                  <Link
+                    href={`/labels/${release.label_slug}`}
+                    className="hover:text-primary transition-colors"
+                  >
+                    {release.label_name}
+                  </Link>
+                ) : (
+                  release.label_name
+                )}
               </div>
             )}
           </div>
@@ -124,6 +182,12 @@ export function ReleaseCard({
             </h3>
           </Link>
 
+          {artistDisplay && (
+            <div className="text-sm truncate mt-0.5">
+              <ArtistLinks release={release} />
+            </div>
+          )}
+
           <div className="flex items-center gap-2 flex-wrap mt-1">
             <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
               {typeLabel}
@@ -133,15 +197,25 @@ export function ReleaseCard({
                 {release.release_year}
               </span>
             )}
+            {release.label_name && (
+              <>
+                <span className="text-muted-foreground/50">·</span>
+                <span className="text-sm text-muted-foreground truncate">
+                  {release.label_slug ? (
+                    <Link
+                      href={`/labels/${release.label_slug}`}
+                      className="hover:text-primary transition-colors"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      {release.label_name}
+                    </Link>
+                  ) : (
+                    release.label_name
+                  )}
+                </span>
+              </>
+            )}
           </div>
-
-          {release.artist_count > 0 && (
-            <div className="mt-1 text-sm text-muted-foreground">
-              {release.artist_count === 1
-                ? '1 artist'
-                : `${release.artist_count} artists`}
-            </div>
-          )}
         </div>
       </div>
     </article>

--- a/frontend/features/releases/index.ts
+++ b/frontend/features/releases/index.ts
@@ -9,6 +9,7 @@ export type {
   ReleaseArtist,
   ReleaseExternalLink,
   ReleaseDetail,
+  ReleaseListArtist,
   ReleaseListItem,
   ReleasesListResponse,
   ArtistReleaseListItem,

--- a/frontend/features/releases/types.ts
+++ b/frontend/features/releases/types.ts
@@ -64,6 +64,12 @@ export interface ReleaseDetail {
   updated_at: string
 }
 
+export interface ReleaseListArtist {
+  id: number
+  name: string
+  slug: string
+}
+
 export interface ReleaseListItem {
   id: number
   title: string
@@ -72,6 +78,9 @@ export interface ReleaseListItem {
   release_year: number | null
   cover_art_url: string | null
   artist_count: number
+  artists: ReleaseListArtist[]
+  label_name: string | null
+  label_slug: string | null
 }
 
 export interface ReleasesListResponse {


### PR DESCRIPTION
## Summary
- **Backend**: Extended `ReleaseListResponse` with `artists []ReleaseListArtist` (id/name/slug) and `label_name`/`label_slug`. Batch-loads artist details + primary label in `ListReleases` and `SearchReleases`.
- **Frontend**: `ReleaseCard` now shows clickable artist name links and label name across all 3 density modes. Compilations (>3 artists) show "Various Artists".
- **5 new backend tests** for artist names and label info in list responses

Closes PSY-269

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `bun run build` compiles cleanly
- [x] 34 backend release service tests pass (5 new)
- [x] Artist names displayed on browse cards (all density modes)
- [x] Artist names link to artist pages
- [x] Label name shown when available
- [x] Compilations show "Various Artists"

🤖 Generated with [Claude Code](https://claude.com/claude-code)