### PR TITLE
Add admin radio show discovery and show-level episode import

### DIFF
--- a/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
+++ b/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
@@ -1920,6 +1920,8 @@ type mockRadioService struct {
 	importStationFn func(uint, int) (*contracts.RadioImportResult, error)
 	fetchNewEpisodesFn func(uint) (*contracts.RadioImportResult, error)
 	importEpisodePlaylistFn func(uint, string) (*contracts.EpisodeImportResult, error)
+	discoverStationShowsFn func(uint) (*contracts.RadioDiscoverResult, error)
+	importShowEpisodesFn func(uint, string, string) (*contracts.RadioImportResult, error)
 	matchPlaysFn func(uint) (*contracts.MatchResult, error)
 	getUnmatchedPlaysFn func(uint, int, int) ([]*contracts.UnmatchedPlayGroup, int64, error)
 	linkPlayFn func(uint, *contracts.LinkPlayRequest) (error)
@@ -2070,6 +2072,18 @@ func (m *mockRadioService) FetchNewEpisodes(stationID uint) (*contracts.RadioImp
 func (m *mockRadioService) ImportEpisodePlaylist(showID uint, episodeExternalID string) (*contracts.EpisodeImportResult, error) {
 	if m.importEpisodePlaylistFn != nil {
 		return m.importEpisodePlaylistFn(showID, episodeExternalID)
+	}
+	return nil, nil
+}
+func (m *mockRadioService) DiscoverStationShows(stationID uint) (*contracts.RadioDiscoverResult, error) {
+	if m.discoverStationShowsFn != nil {
+		return m.discoverStationShowsFn(stationID)
+	}
+	return nil, nil
+}
+func (m *mockRadioService) ImportShowEpisodes(showID uint, since string, until string) (*contracts.RadioImportResult, error) {
+	if m.importShowEpisodesFn != nil {
+		return m.importShowEpisodesFn(showID, since, until)
 	}
 	return nil, nil
 }

--- a/backend/internal/api/handlers/radio.go
+++ b/backend/internal/api/handlers/radio.go
@@ -69,6 +69,12 @@ type RadioShowWriter interface {
 	DeleteShow(showID uint) error
 }
 
+// RadioImporter handles radio show discovery and episode import.
+type RadioImporter interface {
+	DiscoverStationShows(stationID uint) (*contracts.RadioDiscoverResult, error)
+	ImportShowEpisodes(showID uint, since string, until string) (*contracts.RadioImportResult, error)
+}
+
 // ArtistSlugResolver resolves artist slugs to IDs.
 type ArtistSlugResolver interface {
 	GetArtistBySlug(slug string) (*contracts.ArtistDetailResponse, error)
@@ -92,6 +98,7 @@ type RadioHandler struct {
 	stationWriter      RadioStationWriter
 	showWriter         RadioShowWriter
 	unmatchedManager   RadioUnmatchedManager
+	importer           RadioImporter
 	artistResolver     ArtistSlugResolver
 	releaseResolver    ReleaseSlugResolver
 	auditLogService    contracts.AuditLogServiceInterface
@@ -112,6 +119,7 @@ func NewRadioHandler(
 		stationWriter:      radioService,
 		showWriter:         radioService,
 		unmatchedManager:   radioService,
+		importer:           radioService,
 		artistResolver:     artistResolver,
 		releaseResolver:    releaseResolver,
 		auditLogService:    auditLogService,
@@ -1012,7 +1020,36 @@ func (h *RadioHandler) AdminDeleteRadioShowHandler(ctx context.Context, req *Adm
 }
 
 // ============================================================================
-// Admin: Trigger Playlist Fetch (stub)
+// Admin: Discover Shows for Station
+// ============================================================================
+
+// AdminDiscoverShowsRequest represents the request for discovering shows for a station.
+type AdminDiscoverShowsRequest struct {
+	StationID uint `path:"id" doc:"Radio station ID" example:"1"`
+}
+
+// AdminDiscoverShowsResponse represents the response for discovering shows.
+type AdminDiscoverShowsResponse struct {
+	Body contracts.RadioDiscoverResult
+}
+
+// AdminDiscoverShowsHandler handles POST /admin/radio-stations/{id}/discover
+func (h *RadioHandler) AdminDiscoverShowsHandler(ctx context.Context, req *AdminDiscoverShowsRequest) (*AdminDiscoverShowsResponse, error) {
+	_, err := requireAdmin(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := h.importer.DiscoverStationShows(req.StationID)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Failed to discover shows", err)
+	}
+
+	return &AdminDiscoverShowsResponse{Body: *result}, nil
+}
+
+// ============================================================================
+// Admin: Trigger Playlist Fetch (redirects to discover)
 // ============================================================================
 
 // AdminTriggerFetchRequest represents the request for triggering a playlist fetch.
@@ -1021,14 +1058,52 @@ type AdminTriggerFetchRequest struct {
 }
 
 // AdminTriggerFetchHandler handles POST /admin/radio-stations/{id}/fetch
-// This is a stub that returns 501 Not Implemented until the KEXP provider is built.
-func (h *RadioHandler) AdminTriggerFetchHandler(ctx context.Context, req *AdminTriggerFetchRequest) (*struct{}, error) {
+// Repurposed to call DiscoverStationShows.
+func (h *RadioHandler) AdminTriggerFetchHandler(ctx context.Context, req *AdminTriggerFetchRequest) (*AdminDiscoverShowsResponse, error) {
 	_, err := requireAdmin(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	return nil, huma.Error501NotImplemented("Playlist fetch not yet implemented")
+	result, err := h.importer.DiscoverStationShows(req.StationID)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Failed to discover shows", err)
+	}
+
+	return &AdminDiscoverShowsResponse{Body: *result}, nil
+}
+
+// ============================================================================
+// Admin: Import Show Episodes
+// ============================================================================
+
+// AdminImportShowEpisodesRequest represents the request for importing episodes for a show.
+type AdminImportShowEpisodesRequest struct {
+	ShowID uint `path:"id" doc:"Radio show ID" example:"1"`
+	Body   struct {
+		Since string `json:"since" doc:"Start date (YYYY-MM-DD)" example:"2024-01-01"`
+		Until string `json:"until" doc:"End date (YYYY-MM-DD)" example:"2024-12-31"`
+	}
+}
+
+// AdminImportShowEpisodesResponse represents the response for importing show episodes.
+type AdminImportShowEpisodesResponse struct {
+	Body contracts.RadioImportResult
+}
+
+// AdminImportShowEpisodesHandler handles POST /admin/radio-shows/{id}/import
+func (h *RadioHandler) AdminImportShowEpisodesHandler(ctx context.Context, req *AdminImportShowEpisodesRequest) (*AdminImportShowEpisodesResponse, error) {
+	_, err := requireAdmin(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := h.importer.ImportShowEpisodes(req.ShowID, req.Body.Since, req.Body.Until)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Failed to import show episodes", err)
+	}
+
+	return &AdminImportShowEpisodesResponse{Body: *result}, nil
 }
 
 // ============================================================================

--- a/backend/internal/api/handlers/radio_test.go
+++ b/backend/internal/api/handlers/radio_test.go
@@ -925,13 +925,22 @@ func TestAdminDeleteRadioShow_NotFound(t *testing.T) {
 // AdminTriggerFetchHandler Tests
 // ============================================================================
 
-func TestAdminTriggerFetch_Returns501(t *testing.T) {
-	mock := &mockRadioService{}
+func TestAdminTriggerFetch_Success(t *testing.T) {
+	mock := &mockRadioService{
+		discoverStationShowsFn: func(stationID uint) (*contracts.RadioDiscoverResult, error) {
+			return &contracts.RadioDiscoverResult{ShowsDiscovered: 3, ShowNames: []string{"Show A", "Show B", "Show C"}}, nil
+		},
+	}
 	h := testRadioHandler(mock)
 	req := &AdminTriggerFetchRequest{StationID: 1}
 
-	_, err := h.AdminTriggerFetchHandler(radioAdminCtx(), req)
-	assertHumaError(t, err, 501)
+	resp, err := h.AdminTriggerFetchHandler(radioAdminCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.ShowsDiscovered != 3 {
+		t.Fatalf("expected 3 shows discovered, got %d", resp.Body.ShowsDiscovered)
+	}
 }
 
 func TestAdminTriggerFetch_NotAdmin(t *testing.T) {
@@ -941,4 +950,111 @@ func TestAdminTriggerFetch_NotAdmin(t *testing.T) {
 
 	_, err := h.AdminTriggerFetchHandler(context.Background(), req)
 	assertHumaError(t, err, 403)
+}
+
+// ============================================================================
+// AdminDiscoverShowsHandler Tests
+// ============================================================================
+
+func TestAdminDiscoverShows_Success(t *testing.T) {
+	mock := &mockRadioService{
+		discoverStationShowsFn: func(stationID uint) (*contracts.RadioDiscoverResult, error) {
+			return &contracts.RadioDiscoverResult{ShowsDiscovered: 2, ShowNames: []string{"Show X", "Show Y"}}, nil
+		},
+	}
+	h := testRadioHandler(mock)
+	req := &AdminDiscoverShowsRequest{StationID: 1}
+
+	resp, err := h.AdminDiscoverShowsHandler(radioAdminCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.ShowsDiscovered != 2 {
+		t.Fatalf("expected 2 shows discovered, got %d", resp.Body.ShowsDiscovered)
+	}
+	if len(resp.Body.ShowNames) != 2 {
+		t.Fatalf("expected 2 show names, got %d", len(resp.Body.ShowNames))
+	}
+}
+
+func TestAdminDiscoverShows_NotAdmin(t *testing.T) {
+	mock := &mockRadioService{}
+	h := testRadioHandler(mock)
+	req := &AdminDiscoverShowsRequest{StationID: 1}
+
+	_, err := h.AdminDiscoverShowsHandler(context.Background(), req)
+	assertHumaError(t, err, 403)
+}
+
+func TestAdminDiscoverShows_ServiceError(t *testing.T) {
+	mock := &mockRadioService{
+		discoverStationShowsFn: func(stationID uint) (*contracts.RadioDiscoverResult, error) {
+			return nil, fmt.Errorf("station not found")
+		},
+	}
+	h := testRadioHandler(mock)
+	req := &AdminDiscoverShowsRequest{StationID: 999}
+
+	_, err := h.AdminDiscoverShowsHandler(radioAdminCtx(), req)
+	assertHumaError(t, err, 500)
+}
+
+// ============================================================================
+// AdminImportShowEpisodesHandler Tests
+// ============================================================================
+
+func TestAdminImportShowEpisodes_Success(t *testing.T) {
+	mock := &mockRadioService{
+		importShowEpisodesFn: func(showID uint, since string, until string) (*contracts.RadioImportResult, error) {
+			return &contracts.RadioImportResult{
+				EpisodesImported: 5,
+				PlaysImported:    50,
+				PlaysMatched:     30,
+			}, nil
+		},
+	}
+	h := testRadioHandler(mock)
+	req := &AdminImportShowEpisodesRequest{ShowID: 1}
+	req.Body.Since = "2024-01-01"
+	req.Body.Until = "2024-12-31"
+
+	resp, err := h.AdminImportShowEpisodesHandler(radioAdminCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.EpisodesImported != 5 {
+		t.Fatalf("expected 5 episodes imported, got %d", resp.Body.EpisodesImported)
+	}
+	if resp.Body.PlaysImported != 50 {
+		t.Fatalf("expected 50 plays imported, got %d", resp.Body.PlaysImported)
+	}
+	if resp.Body.PlaysMatched != 30 {
+		t.Fatalf("expected 30 plays matched, got %d", resp.Body.PlaysMatched)
+	}
+}
+
+func TestAdminImportShowEpisodes_NotAdmin(t *testing.T) {
+	mock := &mockRadioService{}
+	h := testRadioHandler(mock)
+	req := &AdminImportShowEpisodesRequest{ShowID: 1}
+	req.Body.Since = "2024-01-01"
+	req.Body.Until = "2024-12-31"
+
+	_, err := h.AdminImportShowEpisodesHandler(context.Background(), req)
+	assertHumaError(t, err, 403)
+}
+
+func TestAdminImportShowEpisodes_ServiceError(t *testing.T) {
+	mock := &mockRadioService{
+		importShowEpisodesFn: func(showID uint, since string, until string) (*contracts.RadioImportResult, error) {
+			return nil, fmt.Errorf("show not found")
+		},
+	}
+	h := testRadioHandler(mock)
+	req := &AdminImportShowEpisodesRequest{ShowID: 999}
+	req.Body.Since = "2024-01-01"
+	req.Body.Until = "2024-12-31"
+
+	_, err := h.AdminImportShowEpisodesHandler(radioAdminCtx(), req)
+	assertHumaError(t, err, 500)
 }

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -1036,10 +1036,12 @@ func setupRadioRoutes(rc RouteContext) {
 	huma.Delete(rc.Protected, "/admin/radio-stations/{id}", radioHandler.AdminDeleteRadioStationHandler)
 	huma.Post(rc.Protected, "/admin/radio-stations/{id}/shows", radioHandler.AdminCreateRadioShowHandler)
 	huma.Post(rc.Protected, "/admin/radio-stations/{id}/fetch", radioHandler.AdminTriggerFetchHandler)
+	huma.Post(rc.Protected, "/admin/radio-stations/{id}/discover", radioHandler.AdminDiscoverShowsHandler)
 
 	// Admin radio show endpoints (admin-only checks inside handlers)
 	huma.Put(rc.Protected, "/admin/radio-shows/{id}", radioHandler.AdminUpdateRadioShowHandler)
 	huma.Delete(rc.Protected, "/admin/radio-shows/{id}", radioHandler.AdminDeleteRadioShowHandler)
+	huma.Post(rc.Protected, "/admin/radio-shows/{id}/import", radioHandler.AdminImportShowEpisodesHandler)
 
 	// Admin unmatched play management endpoints
 	huma.Get(rc.Protected, "/admin/radio/unmatched", radioHandler.AdminGetUnmatchedPlaysHandler)

--- a/backend/internal/services/catalog/radio_import.go
+++ b/backend/internal/services/catalog/radio_import.go
@@ -222,6 +222,115 @@ func (s *RadioService) MatchPlays(episodeID uint) (*contracts.MatchResult, error
 	return matcher.MatchPlaysForEpisode(episodeID)
 }
 
+// DiscoverStationShows discovers all shows for a station without importing episodes.
+func (s *RadioService) DiscoverStationShows(stationID uint) (*contracts.RadioDiscoverResult, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var station models.RadioStation
+	if err := s.db.First(&station, stationID).Error; err != nil {
+		return nil, fmt.Errorf("station not found: %w", err)
+	}
+
+	if station.PlaylistSource == nil || *station.PlaylistSource == "" {
+		return nil, fmt.Errorf("station %d has no playlist source configured", stationID)
+	}
+
+	provider, err := s.getProvider(*station.PlaylistSource)
+	if err != nil {
+		return nil, err
+	}
+	defer closeProvider(provider)
+
+	result := &contracts.RadioDiscoverResult{}
+
+	importedShows, err := provider.DiscoverShows()
+	if err != nil {
+		result.Errors = append(result.Errors, fmt.Sprintf("discover shows: %v", err))
+		return result, nil
+	}
+
+	for _, importShow := range importedShows {
+		_, err := s.upsertRadioShow(stationID, importShow)
+		if err != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("upsert show %s: %v", importShow.Name, err))
+			continue
+		}
+		result.ShowsDiscovered++
+		result.ShowNames = append(result.ShowNames, importShow.Name)
+	}
+
+	return result, nil
+}
+
+// ImportShowEpisodes imports episodes for a single show within a date range.
+func (s *RadioService) ImportShowEpisodes(showID uint, since string, until string) (*contracts.RadioImportResult, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	sinceTime, err := time.Parse("2006-01-02", since)
+	if err != nil {
+		return nil, fmt.Errorf("invalid since date %q: %w", since, err)
+	}
+	untilTime, err := time.Parse("2006-01-02", until)
+	if err != nil {
+		return nil, fmt.Errorf("invalid until date %q: %w", until, err)
+	}
+	// Include the entire "until" day
+	untilTime = untilTime.AddDate(0, 0, 1)
+
+	var show models.RadioShow
+	if err := s.db.Preload("Station").First(&show, showID).Error; err != nil {
+		return nil, fmt.Errorf("show not found: %w", err)
+	}
+
+	if show.Station.PlaylistSource == nil || *show.Station.PlaylistSource == "" {
+		return nil, fmt.Errorf("station has no playlist source configured")
+	}
+
+	provider, err := s.getProvider(*show.Station.PlaylistSource)
+	if err != nil {
+		return nil, err
+	}
+	defer closeProvider(provider)
+
+	if show.ExternalID == nil || *show.ExternalID == "" {
+		return nil, fmt.Errorf("show %d has no external ID", showID)
+	}
+
+	episodes, err := provider.FetchNewEpisodes(*show.ExternalID, sinceTime)
+	if err != nil {
+		return nil, fmt.Errorf("fetching episodes: %w", err)
+	}
+
+	result := &contracts.RadioImportResult{}
+
+	for _, ep := range episodes {
+		// Filter episodes by air_date within [since, until)
+		epDate, parseErr := time.Parse("2006-01-02", ep.AirDate)
+		if parseErr != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("parse air_date %q for episode %s: %v", ep.AirDate, ep.ExternalID, parseErr))
+			continue
+		}
+		if epDate.Before(sinceTime) || !epDate.Before(untilTime) {
+			continue
+		}
+
+		epResult, err := s.importEpisode(show.ID, ep, provider)
+		if err != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("import episode %s: %v", ep.ExternalID, err))
+			continue
+		}
+		result.EpisodesImported++
+		result.PlaysImported += epResult.PlaysImported
+		result.PlaysMatched += epResult.PlaysMatched
+	}
+
+	return result, nil
+}
+
 // =============================================================================
 // Internal import helpers
 // =============================================================================

--- a/backend/internal/services/catalog/radio_provider_test.go
+++ b/backend/internal/services/catalog/radio_provider_test.go
@@ -432,6 +432,8 @@ func TestRadioService_NilDB_Import(t *testing.T) {
 	assertNilDBError(t, func() error { _, err := svc.FetchNewEpisodes(1); return err })
 	assertNilDBError(t, func() error { _, err := svc.ImportEpisodePlaylist(1, "ext-1"); return err })
 	assertNilDBError(t, func() error { _, err := svc.MatchPlays(1); return err })
+	assertNilDBError(t, func() error { _, err := svc.DiscoverStationShows(1); return err })
+	assertNilDBError(t, func() error { _, err := svc.ImportShowEpisodes(1, "2024-01-01", "2024-12-31"); return err })
 }
 
 func TestRadioMatchingEngine_NilDB(t *testing.T) {

--- a/backend/internal/services/contracts/interfaces.go
+++ b/backend/internal/services/contracts/interfaces.go
@@ -581,6 +581,8 @@ type RadioServiceInterface interface {
 	ImportStation(stationID uint, backfillDays int) (*RadioImportResult, error)
 	FetchNewEpisodes(stationID uint) (*RadioImportResult, error)
 	ImportEpisodePlaylist(showID uint, episodeExternalID string) (*EpisodeImportResult, error)
+	DiscoverStationShows(stationID uint) (*RadioDiscoverResult, error)
+	ImportShowEpisodes(showID uint, since string, until string) (*RadioImportResult, error)
 
 	// Matching
 	MatchPlays(episodeID uint) (*MatchResult, error)

--- a/backend/internal/services/contracts/radio.go
+++ b/backend/internal/services/contracts/radio.go
@@ -303,6 +303,13 @@ type RadioImportResult struct {
 	Errors           []string `json:"errors,omitempty"`
 }
 
+// RadioDiscoverResult summarizes the result of discovering shows for a station.
+type RadioDiscoverResult struct {
+	ShowsDiscovered int      `json:"shows_discovered"`
+	ShowNames       []string `json:"show_names"`
+	Errors          []string `json:"errors,omitempty"`
+}
+
 // EpisodeImportResult summarizes the result of importing a single episode's playlist.
 type EpisodeImportResult struct {
 	PlaysImported int `json:"plays_imported"`

--- a/frontend/app/admin/radio/_components/RadioManagement.tsx
+++ b/frontend/app/admin/radio/_components/RadioManagement.tsx
@@ -17,6 +17,8 @@ import {
   UserPlus,
   SkipForward,
   BarChart3,
+  Radar,
+  Upload,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -45,9 +47,13 @@ import {
   useUpdateRadioShow,
   useDeleteRadioShow,
   useFetchPlaylists,
+  useDiscoverShows,
+  useImportShowEpisodes,
   type RadioStationListItem,
   type RadioStationDetail,
   type RadioShowListItem,
+  type RadioDiscoverResult,
+  type RadioImportResult,
   type CreateRadioStationInput,
   type UpdateRadioStationInput,
   type CreateRadioShowInput,
@@ -685,6 +691,92 @@ function EditShowForm({
 // Station Detail Panel (with shows management)
 // ============================================================================
 
+// ============================================================================
+// Per-Show Import Controls
+// ============================================================================
+
+function ShowImportControls({ show }: { show: RadioShowListItem }) {
+  const importMutation = useImportShowEpisodes()
+  const [since, setSince] = useState('')
+  const [until, setUntil] = useState('')
+  const [importResult, setImportResult] = useState<RadioImportResult | null>(null)
+  const [importError, setImportError] = useState<string | null>(null)
+
+  const handleImport = useCallback(() => {
+    if (!since || !until) return
+    setImportResult(null)
+    setImportError(null)
+    importMutation.mutate(
+      { showId: show.id, since, until },
+      {
+        onSuccess: (result) => {
+          setImportResult(result)
+        },
+        onError: (err) => {
+          setImportError(err.message)
+        },
+      }
+    )
+  }, [show.id, since, until, importMutation])
+
+  return (
+    <div className="mt-2 space-y-2">
+      <div className="flex items-end gap-2">
+        <div>
+          <Label className="text-xs text-muted-foreground">Since</Label>
+          <Input
+            type="date"
+            value={since}
+            onChange={(e) => setSince(e.target.value)}
+            className="h-8 text-xs w-36"
+          />
+        </div>
+        <div>
+          <Label className="text-xs text-muted-foreground">Until</Label>
+          <Input
+            type="date"
+            value={until}
+            onChange={(e) => setUntil(e.target.value)}
+            className="h-8 text-xs w-36"
+          />
+        </div>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={handleImport}
+          disabled={importMutation.isPending || !since || !until}
+          className="h-8"
+        >
+          {importMutation.isPending ? (
+            <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+          ) : (
+            <Upload className="mr-1 h-3 w-3" />
+          )}
+          Import Episodes
+        </Button>
+      </div>
+      {importResult && (
+        <div className="text-xs rounded-md bg-muted p-2 space-y-0.5">
+          <p>Episodes imported: <strong>{importResult.episodes_imported}</strong></p>
+          <p>Plays imported: <strong>{importResult.plays_imported}</strong></p>
+          <p>Plays matched: <strong>{importResult.plays_matched}</strong></p>
+          {importResult.errors && importResult.errors.length > 0 && (
+            <div className="mt-1 text-destructive">
+              <p className="font-medium">Errors:</p>
+              {importResult.errors.map((e, i) => (
+                <p key={i}>{e}</p>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+      {importError && (
+        <p className="text-xs text-destructive">{importError}</p>
+      )}
+    </div>
+  )
+}
+
 function StationDetailPanel({
   station,
   onBack,
@@ -698,26 +790,29 @@ function StationDetailPanel({
 }) {
   const { data: stationDetail } = useRadioStationDetail(station.id)
   const { data: showsData, isLoading: showsLoading } = useRadioShows(station.id)
-  const fetchMutation = useFetchPlaylists()
+  const discoverMutation = useDiscoverShows()
   const deleteShowMutation = useDeleteRadioShow()
 
   const [dialogMode, setDialogMode] = useState<'create-show' | 'edit-show' | 'delete-show' | null>(null)
   const [selectedShow, setSelectedShow] = useState<RadioShowListItem | null>(null)
-  const [fetchResult, setFetchResult] = useState<string | null>(null)
+  const [discoverResult, setDiscoverResult] = useState<RadioDiscoverResult | null>(null)
+  const [discoverError, setDiscoverError] = useState<string | null>(null)
+  const [expandedShows, setExpandedShows] = useState<Set<number>>(new Set())
 
   const shows = showsData?.shows ?? []
 
-  const handleFetchPlaylists = useCallback(() => {
-    setFetchResult(null)
-    fetchMutation.mutate(station.id, {
-      onSuccess: () => {
-        setFetchResult('Playlist fetch triggered successfully.')
+  const handleDiscoverShows = useCallback(() => {
+    setDiscoverResult(null)
+    setDiscoverError(null)
+    discoverMutation.mutate(station.id, {
+      onSuccess: (result) => {
+        setDiscoverResult(result)
       },
       onError: (err) => {
-        setFetchResult(`Fetch failed: ${err.message}`)
+        setDiscoverError(err.message)
       },
     })
-  }, [station.id, fetchMutation])
+  }, [station.id, discoverMutation])
 
   const handleDeleteShow = useCallback(
     (show: RadioShowListItem) => {
@@ -728,6 +823,18 @@ function StationDetailPanel({
     },
     [deleteShowMutation, station.id]
   )
+
+  const toggleShowExpanded = useCallback((showId: number) => {
+    setExpandedShows((prev) => {
+      const next = new Set(prev)
+      if (next.has(showId)) {
+        next.delete(showId)
+      } else {
+        next.add(showId)
+      }
+      return next
+    })
+  }, [])
 
   const lastFetch = stationDetail?.last_playlist_fetch_at
     ? new Date(stationDetail.last_playlist_fetch_at).toLocaleString()
@@ -787,18 +894,33 @@ function StationDetailPanel({
         </div>
       )}
 
-      {/* Fetch Playlists */}
-      <div className="flex items-center gap-3">
-        <Button onClick={handleFetchPlaylists} disabled={fetchMutation.isPending} size="sm">
-          {fetchMutation.isPending ? (
-            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-          ) : (
-            <Download className="mr-2 h-4 w-4" />
+      {/* Discover Shows */}
+      <div className="space-y-2">
+        <div className="flex items-center gap-3">
+          <Button onClick={handleDiscoverShows} disabled={discoverMutation.isPending} size="sm">
+            {discoverMutation.isPending ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Radar className="mr-2 h-4 w-4" />
+            )}
+            Discover Shows
+          </Button>
+          {discoverResult && (
+            <span className="text-sm text-muted-foreground">
+              Discovered {discoverResult.shows_discovered} show(s)
+              {discoverResult.show_names.length > 0 && `: ${discoverResult.show_names.join(', ')}`}
+            </span>
           )}
-          Fetch Playlists
-        </Button>
-        {fetchResult && (
-          <span className="text-sm text-muted-foreground">{fetchResult}</span>
+          {discoverError && (
+            <span className="text-sm text-destructive">Discovery failed: {discoverError}</span>
+          )}
+        </div>
+        {discoverResult?.errors && discoverResult.errors.length > 0 && (
+          <div className="text-xs text-destructive space-y-0.5">
+            {discoverResult.errors.map((e, i) => (
+              <p key={i}>{e}</p>
+            ))}
+          </div>
         )}
       </div>
 
@@ -823,35 +945,48 @@ function StationDetailPanel({
         ) : (
           <div className="rounded-lg border divide-y">
             {shows.map((show) => (
-              <div key={show.id} className="flex items-center justify-between px-4 py-3">
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-2">
-                    <span className="font-medium">{show.name}</span>
-                    <Badge variant={show.is_active ? 'default' : 'secondary'} className="text-xs">
-                      {show.is_active ? 'Active' : 'Inactive'}
-                    </Badge>
+              <div key={show.id} className="px-4 py-3">
+                <div className="flex items-center justify-between">
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <span className="font-medium">{show.name}</span>
+                      <Badge variant={show.is_active ? 'default' : 'secondary'} className="text-xs">
+                        {show.is_active ? 'Active' : 'Inactive'}
+                      </Badge>
+                    </div>
+                    <p className="text-sm text-muted-foreground">
+                      {show.host_name ? `Hosted by ${show.host_name}` : 'No host'} &middot; {show.episode_count} episode(s)
+                    </p>
                   </div>
-                  <p className="text-sm text-muted-foreground">
-                    {show.host_name ? `Hosted by ${show.host_name}` : 'No host'} &middot; {show.episode_count} episode(s)
-                  </p>
+                  <div className="flex items-center gap-1">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      title="Import episodes"
+                      onClick={() => toggleShowExpanded(show.id)}
+                    >
+                      <Upload className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => { setSelectedShow(show); setDialogMode('edit-show') }}
+                    >
+                      <Pencil className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="text-destructive"
+                      onClick={() => { setSelectedShow(show); setDialogMode('delete-show') }}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
                 </div>
-                <div className="flex items-center gap-1">
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => { setSelectedShow(show); setDialogMode('edit-show') }}
-                  >
-                    <Pencil className="h-4 w-4" />
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="text-destructive"
-                    onClick={() => { setSelectedShow(show); setDialogMode('delete-show') }}
-                  >
-                    <Trash2 className="h-4 w-4" />
-                  </Button>
-                </div>
+                {expandedShows.has(show.id) && (
+                  <ShowImportControls show={show} />
+                )}
               </div>
             ))}
           </div>

--- a/frontend/lib/hooks/admin/index.ts
+++ b/frontend/lib/hooks/admin/index.ts
@@ -116,4 +116,8 @@ export {
   useUpdateRadioShow,
   useDeleteRadioShow,
   useFetchPlaylists,
+  useDiscoverShows,
+  useImportShowEpisodes,
+  type RadioDiscoverResult,
+  type RadioImportResult,
 } from './useAdminRadio'

--- a/frontend/lib/hooks/admin/useAdminRadio.ts
+++ b/frontend/lib/hooks/admin/useAdminRadio.ts
@@ -41,6 +41,8 @@ const RADIO_ENDPOINTS = {
   ADMIN_UPDATE_SHOW: (showId: number) => `${API_BASE_URL}/admin/radio-shows/${showId}`,
   ADMIN_DELETE_SHOW: (showId: number) => `${API_BASE_URL}/admin/radio-shows/${showId}`,
   ADMIN_FETCH_PLAYLISTS: (stationId: number) => `${API_BASE_URL}/admin/radio-stations/${stationId}/fetch`,
+  ADMIN_DISCOVER_SHOWS: (stationId: number) => `${API_BASE_URL}/admin/radio-stations/${stationId}/discover`,
+  ADMIN_IMPORT_SHOW_EPISODES: (showId: number) => `${API_BASE_URL}/admin/radio-shows/${showId}/import`,
 }
 
 // ============================================================================
@@ -187,6 +189,20 @@ export interface UpdateRadioShowInput {
   archive_url?: string | null
   image_url?: string | null
   is_active?: boolean
+}
+
+export interface RadioDiscoverResult {
+  shows_discovered: number
+  show_names: string[]
+  errors?: string[]
+}
+
+export interface RadioImportResult {
+  shows_discovered: number
+  episodes_imported: number
+  plays_imported: number
+  plays_matched: number
+  errors?: string[]
 }
 
 // ============================================================================
@@ -389,6 +405,46 @@ export function useFetchPlaylists() {
     mutationFn: async (stationId: number) => {
       return apiRequest<void>(RADIO_ENDPOINTS.ADMIN_FETCH_PLAYLISTS(stationId), {
         method: 'POST',
+      })
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: radioQueryKeys.stations })
+      queryClient.invalidateQueries({ queryKey: radioQueryKeys.stats })
+    },
+  })
+}
+
+/**
+ * Hook to discover shows for a station
+ */
+export function useDiscoverShows() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (stationId: number) => {
+      return apiRequest<RadioDiscoverResult>(RADIO_ENDPOINTS.ADMIN_DISCOVER_SHOWS(stationId), {
+        method: 'POST',
+      })
+    },
+    onSuccess: (_data, stationId) => {
+      queryClient.invalidateQueries({ queryKey: radioQueryKeys.shows(stationId) })
+      queryClient.invalidateQueries({ queryKey: radioQueryKeys.stations })
+      queryClient.invalidateQueries({ queryKey: radioQueryKeys.stats })
+    },
+  })
+}
+
+/**
+ * Hook to import episodes for a specific radio show
+ */
+export function useImportShowEpisodes() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ showId, since, until }: { showId: number; since: string; until: string }) => {
+      return apiRequest<RadioImportResult>(RADIO_ENDPOINTS.ADMIN_IMPORT_SHOW_EPISODES(showId), {
+        method: 'POST',
+        body: JSON.stringify({ since, until }),
       })
     },
     onSuccess: () => {


### PR DESCRIPTION
## Summary

- New `DiscoverStationShows(stationID)` service method that calls the provider's `DiscoverShows()` and upserts `RadioShow` records without importing any episodes. Lets admins catalog a station's shows independently of playlist import.
- New `ImportShowEpisodes(showID, since, until)` service method that fetches episodes for a single show within a date range and imports their playlists via the existing `importEpisode()` pipeline (dedup, matching, etc.).
- Admin endpoints: `POST /admin/radio-stations/{id}/discover` and `POST /admin/radio-shows/{id}/import` (body: `{since, until}`).
- Repurposed the old `POST /admin/radio-stations/{id}/fetch` 501 stub to call `DiscoverStationShows`.
- Admin UI: "Discover Shows" button per station, expandable per-show import controls with date range pickers, and results display (episodes, plays imported/matched, errors).

## Context

Follows from the PSY-274 provider audit. This is the synchronous, bounded building block for show-level backfill. Large imports that need progress tracking will use the async job system in PSY-273.

## Test plan

- [ ] Backend: all Radio handler and service tests pass
- [ ] Frontend: all existing tests pass (2435 tests)
- [ ] Manual: on the admin page, discover shows for a station, then import a small date range and verify episodes/plays appear
- [ ] Manual: re-running an import with overlapping date range skips already-imported episodes (dedup via `show_id + external_id`)

Closes PSY-272

🤖 Generated with [Claude Code](https://claude.com/claude-code)