### PR TITLE
Add async radio import jobs with progress tracking

### DIFF
--- a/backend/db/migrations/000063_create_radio_import_jobs.down.sql
+++ b/backend/db/migrations/000063_create_radio_import_jobs.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS radio_import_jobs;

--- a/backend/db/migrations/000063_create_radio_import_jobs.up.sql
+++ b/backend/db/migrations/000063_create_radio_import_jobs.up.sql
@@ -1,0 +1,21 @@
+CREATE TABLE radio_import_jobs (
+    id SERIAL PRIMARY KEY,
+    show_id INTEGER NOT NULL REFERENCES radio_shows(id),
+    station_id INTEGER NOT NULL REFERENCES radio_stations(id),
+    since DATE NOT NULL,
+    until DATE NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'pending',
+    episodes_found INTEGER NOT NULL DEFAULT 0,
+    episodes_imported INTEGER NOT NULL DEFAULT 0,
+    plays_imported INTEGER NOT NULL DEFAULT 0,
+    plays_matched INTEGER NOT NULL DEFAULT 0,
+    current_episode_date VARCHAR(10),
+    error_log TEXT,
+    started_at TIMESTAMP WITH TIME ZONE,
+    completed_at TIMESTAMP WITH TIME ZONE,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_radio_import_jobs_show_id ON radio_import_jobs(show_id);
+CREATE INDEX idx_radio_import_jobs_status ON radio_import_jobs(status);

--- a/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
+++ b/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
@@ -1929,6 +1929,11 @@ type mockRadioService struct {
 	computeAffinityFn func() (error)
 	syncAffinityToRelationshipsFn func() (*contracts.SyncAffinityResult, error)
 	reMatchUnmatchedFn func() (*contracts.MatchResult, error)
+	createImportJobFn func(uint, string, string) (*contracts.RadioImportJobResponse, error)
+	startImportJobFn func(uint) (error)
+	cancelImportJobFn func(uint) (error)
+	getImportJobFn func(uint) (*contracts.RadioImportJobResponse, error)
+	listImportJobsFn func(uint) ([]*contracts.RadioImportJobResponse, error)
 }
 
 func (m *mockRadioService) CreateStation(req *contracts.CreateRadioStationRequest) (*contracts.RadioStationDetailResponse, error) {
@@ -2126,6 +2131,36 @@ func (m *mockRadioService) SyncAffinityToRelationships() (*contracts.SyncAffinit
 func (m *mockRadioService) ReMatchUnmatched() (*contracts.MatchResult, error) {
 	if m.reMatchUnmatchedFn != nil {
 		return m.reMatchUnmatchedFn()
+	}
+	return nil, nil
+}
+func (m *mockRadioService) CreateImportJob(showID uint, since string, until string) (*contracts.RadioImportJobResponse, error) {
+	if m.createImportJobFn != nil {
+		return m.createImportJobFn(showID, since, until)
+	}
+	return nil, nil
+}
+func (m *mockRadioService) StartImportJob(jobID uint) (error) {
+	if m.startImportJobFn != nil {
+		return m.startImportJobFn(jobID)
+	}
+	return nil
+}
+func (m *mockRadioService) CancelImportJob(jobID uint) (error) {
+	if m.cancelImportJobFn != nil {
+		return m.cancelImportJobFn(jobID)
+	}
+	return nil
+}
+func (m *mockRadioService) GetImportJob(jobID uint) (*contracts.RadioImportJobResponse, error) {
+	if m.getImportJobFn != nil {
+		return m.getImportJobFn(jobID)
+	}
+	return nil, nil
+}
+func (m *mockRadioService) ListImportJobs(showID uint) ([]*contracts.RadioImportJobResponse, error) {
+	if m.listImportJobsFn != nil {
+		return m.listImportJobsFn(showID)
 	}
 	return nil, nil
 }

--- a/backend/internal/api/handlers/radio.go
+++ b/backend/internal/api/handlers/radio.go
@@ -75,6 +75,19 @@ type RadioImporter interface {
 	ImportShowEpisodes(showID uint, since string, until string) (*contracts.RadioImportResult, error)
 }
 
+// RadioImportJobManager manages radio import jobs (admin endpoints).
+type RadioImportJobManager interface {
+	CreateImportJob(showID uint, since, until string) (*contracts.RadioImportJobResponse, error)
+	CancelImportJob(jobID uint) error
+	GetImportJob(jobID uint) (*contracts.RadioImportJobResponse, error)
+	ListImportJobs(showID uint) ([]*contracts.RadioImportJobResponse, error)
+}
+
+// RadioImportJobStarter can start import jobs (admin endpoints).
+type RadioImportJobStarter interface {
+	StartImportJob(jobID uint) error
+}
+
 // ArtistSlugResolver resolves artist slugs to IDs.
 type ArtistSlugResolver interface {
 	GetArtistBySlug(slug string) (*contracts.ArtistDetailResponse, error)
@@ -99,6 +112,8 @@ type RadioHandler struct {
 	showWriter         RadioShowWriter
 	unmatchedManager   RadioUnmatchedManager
 	importer           RadioImporter
+	importJobManager   RadioImportJobManager
+	importJobStarter   RadioImportJobStarter
 	artistResolver     ArtistSlugResolver
 	releaseResolver    ReleaseSlugResolver
 	auditLogService    contracts.AuditLogServiceInterface
@@ -120,6 +135,8 @@ func NewRadioHandler(
 		showWriter:         radioService,
 		unmatchedManager:   radioService,
 		importer:           radioService,
+		importJobManager:   radioService,
+		importJobStarter:   radioService,
 		artistResolver:     artistResolver,
 		releaseResolver:    releaseResolver,
 		auditLogService:    auditLogService,
@@ -1286,6 +1303,203 @@ func (h *RadioHandler) AdminBulkLinkPlaysHandler(ctx context.Context, req *Admin
 	)
 
 	return &AdminBulkLinkPlaysResponse{Body: result}, nil
+}
+
+// ============================================================================
+// Admin: Create Import Job
+// ============================================================================
+
+// AdminCreateImportJobRequest represents the request for creating an import job.
+type AdminCreateImportJobRequest struct {
+	ShowID uint `path:"id" doc:"Radio show ID" example:"1"`
+	Body   struct {
+		Since string `json:"since" doc:"Start date (YYYY-MM-DD)" example:"2025-01-01"`
+		Until string `json:"until" doc:"End date (YYYY-MM-DD)" example:"2025-12-31"`
+	}
+}
+
+// AdminCreateImportJobResponse represents the response for creating an import job.
+type AdminCreateImportJobResponse struct {
+	Body *contracts.RadioImportJobResponse
+}
+
+// AdminCreateImportJobHandler handles POST /admin/radio-shows/{id}/import-job
+func (h *RadioHandler) AdminCreateImportJobHandler(ctx context.Context, req *AdminCreateImportJobRequest) (*AdminCreateImportJobResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	user, err := requireAdmin(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if req.Body.Since == "" {
+		return nil, huma.Error400BadRequest("since date is required")
+	}
+	if req.Body.Until == "" {
+		return nil, huma.Error400BadRequest("until date is required")
+	}
+
+	job, err := h.importJobManager.CreateImportJob(req.ShowID, req.Body.Since, req.Body.Until)
+	if err != nil {
+		logger.FromContext(ctx).Error("create_import_job_failed",
+			"show_id", req.ShowID,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to create import job (request_id: %s)", requestID),
+		)
+	}
+
+	// Start the job (fire and forget — errors are logged in the job runner)
+	if startErr := h.importJobStarter.StartImportJob(job.ID); startErr != nil {
+		logger.FromContext(ctx).Error("start_import_job_failed",
+			"job_id", job.ID,
+			"error", startErr.Error(),
+			"request_id", requestID,
+		)
+		// Return the job anyway — it was created, just failed to start
+	}
+
+	// Audit log (fire and forget)
+	if h.auditLogService != nil {
+		go func() {
+			h.auditLogService.LogAction(user.ID, "create_radio_import_job", "radio_import_job", job.ID, map[string]interface{}{
+				"show_id": req.ShowID,
+				"since":   req.Body.Since,
+				"until":   req.Body.Until,
+			})
+		}()
+	}
+
+	logger.FromContext(ctx).Info("radio_import_job_created",
+		"job_id", job.ID,
+		"show_id", req.ShowID,
+		"admin_id", user.ID,
+		"request_id", requestID,
+	)
+
+	return &AdminCreateImportJobResponse{Body: job}, nil
+}
+
+// ============================================================================
+// Admin: Get Import Job
+// ============================================================================
+
+// AdminGetImportJobRequest represents the request for getting an import job.
+type AdminGetImportJobRequest struct {
+	JobID uint `path:"id" doc:"Import job ID" example:"1"`
+}
+
+// AdminGetImportJobResponse represents the response for getting an import job.
+type AdminGetImportJobResponse struct {
+	Body *contracts.RadioImportJobResponse
+}
+
+// AdminGetImportJobHandler handles GET /admin/radio/import-jobs/{id}
+func (h *RadioHandler) AdminGetImportJobHandler(ctx context.Context, req *AdminGetImportJobRequest) (*AdminGetImportJobResponse, error) {
+	_, err := requireAdmin(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	job, err := h.importJobManager.GetImportJob(req.JobID)
+	if err != nil {
+		return nil, huma.Error404NotFound("Import job not found")
+	}
+
+	return &AdminGetImportJobResponse{Body: job}, nil
+}
+
+// ============================================================================
+// Admin: Cancel Import Job
+// ============================================================================
+
+// AdminCancelImportJobRequest represents the request for cancelling an import job.
+type AdminCancelImportJobRequest struct {
+	JobID uint `path:"id" doc:"Import job ID" example:"1"`
+}
+
+// AdminCancelImportJobResponse represents the response for cancelling an import job.
+type AdminCancelImportJobResponse struct {
+	Body struct {
+		Success bool `json:"success"`
+	}
+}
+
+// AdminCancelImportJobHandler handles POST /admin/radio/import-jobs/{id}/cancel
+func (h *RadioHandler) AdminCancelImportJobHandler(ctx context.Context, req *AdminCancelImportJobRequest) (*AdminCancelImportJobResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	user, err := requireAdmin(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := h.importJobManager.CancelImportJob(req.JobID); err != nil {
+		logger.FromContext(ctx).Error("cancel_import_job_failed",
+			"job_id", req.JobID,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to cancel import job (request_id: %s)", requestID),
+		)
+	}
+
+	// Audit log (fire and forget)
+	if h.auditLogService != nil {
+		go func() {
+			h.auditLogService.LogAction(user.ID, "cancel_radio_import_job", "radio_import_job", req.JobID, nil)
+		}()
+	}
+
+	logger.FromContext(ctx).Info("radio_import_job_cancelled",
+		"job_id", req.JobID,
+		"admin_id", user.ID,
+		"request_id", requestID,
+	)
+
+	resp := &AdminCancelImportJobResponse{}
+	resp.Body.Success = true
+	return resp, nil
+}
+
+// ============================================================================
+// Admin: List Import Jobs for Show
+// ============================================================================
+
+// AdminListImportJobsRequest represents the request for listing import jobs.
+type AdminListImportJobsRequest struct {
+	ShowID uint `path:"id" doc:"Radio show ID" example:"1"`
+}
+
+// AdminListImportJobsResponse represents the response for listing import jobs.
+type AdminListImportJobsResponse struct {
+	Body struct {
+		Jobs  []*contracts.RadioImportJobResponse `json:"jobs" doc:"Import jobs for this show"`
+		Count int                                 `json:"count" doc:"Number of jobs"`
+	}
+}
+
+// AdminListImportJobsHandler handles GET /admin/radio-shows/{id}/import-jobs
+func (h *RadioHandler) AdminListImportJobsHandler(ctx context.Context, req *AdminListImportJobsRequest) (*AdminListImportJobsResponse, error) {
+	_, err := requireAdmin(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	jobs, err := h.importJobManager.ListImportJobs(req.ShowID)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Failed to list import jobs", err)
+	}
+
+	resp := &AdminListImportJobsResponse{}
+	resp.Body.Jobs = jobs
+	if jobs != nil {
+		resp.Body.Count = len(jobs)
+	}
+	return resp, nil
 }
 
 // ============================================================================

--- a/backend/internal/api/handlers/radio_test.go
+++ b/backend/internal/api/handlers/radio_test.go
@@ -1058,3 +1058,253 @@ func TestAdminImportShowEpisodes_ServiceError(t *testing.T) {
 	_, err := h.AdminImportShowEpisodesHandler(radioAdminCtx(), req)
 	assertHumaError(t, err, 500)
 }
+// ============================================================================
+// AdminCreateImportJobHandler Tests
+// ============================================================================
+
+func TestAdminCreateImportJob_Success(t *testing.T) {
+	now := time.Now()
+	mock := &mockRadioService{
+		createImportJobFn: func(showID uint, since, until string) (*contracts.RadioImportJobResponse, error) {
+			return &contracts.RadioImportJobResponse{
+				ID:          1,
+				ShowID:      showID,
+				ShowName:    "Test Show",
+				StationID:   1,
+				StationName: "Test Station",
+				Since:       since,
+				Until:       until,
+				Status:      "pending",
+				CreatedAt:   now,
+				UpdatedAt:   now,
+			}, nil
+		},
+		startImportJobFn: func(jobID uint) error {
+			return nil
+		},
+	}
+	h := testRadioHandler(mock)
+	req := &AdminCreateImportJobRequest{ShowID: 1}
+	req.Body.Since = "2025-01-01"
+	req.Body.Until = "2025-12-31"
+
+	resp, err := h.AdminCreateImportJobHandler(radioAdminCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.ID != 1 {
+		t.Errorf("expected job ID 1, got %d", resp.Body.ID)
+	}
+	if resp.Body.ShowName != "Test Show" {
+		t.Errorf("expected show name 'Test Show', got %s", resp.Body.ShowName)
+	}
+	if resp.Body.Status != "pending" {
+		t.Errorf("expected status 'pending', got %s", resp.Body.Status)
+	}
+}
+
+func TestAdminCreateImportJob_NotAdmin(t *testing.T) {
+	mock := &mockRadioService{}
+	h := testRadioHandler(mock)
+	req := &AdminCreateImportJobRequest{ShowID: 1}
+	req.Body.Since = "2025-01-01"
+	req.Body.Until = "2025-12-31"
+
+	_, err := h.AdminCreateImportJobHandler(context.Background(), req)
+	assertHumaError(t, err, 403)
+}
+
+func TestAdminCreateImportJob_MissingSince(t *testing.T) {
+	mock := &mockRadioService{}
+	h := testRadioHandler(mock)
+	req := &AdminCreateImportJobRequest{ShowID: 1}
+	req.Body.Since = ""
+	req.Body.Until = "2025-12-31"
+
+	_, err := h.AdminCreateImportJobHandler(radioAdminCtx(), req)
+	assertHumaError(t, err, 400)
+}
+
+func TestAdminCreateImportJob_MissingUntil(t *testing.T) {
+	mock := &mockRadioService{}
+	h := testRadioHandler(mock)
+	req := &AdminCreateImportJobRequest{ShowID: 1}
+	req.Body.Since = "2025-01-01"
+	req.Body.Until = ""
+
+	_, err := h.AdminCreateImportJobHandler(radioAdminCtx(), req)
+	assertHumaError(t, err, 400)
+}
+
+func TestAdminCreateImportJob_ServiceError(t *testing.T) {
+	mock := &mockRadioService{
+		createImportJobFn: func(showID uint, since, until string) (*contracts.RadioImportJobResponse, error) {
+			return nil, fmt.Errorf("an import job is already running")
+		},
+	}
+	h := testRadioHandler(mock)
+	req := &AdminCreateImportJobRequest{ShowID: 1}
+	req.Body.Since = "2025-01-01"
+	req.Body.Until = "2025-12-31"
+
+	_, err := h.AdminCreateImportJobHandler(radioAdminCtx(), req)
+	assertHumaError(t, err, 500)
+}
+
+// ============================================================================
+// AdminGetImportJobHandler Tests
+// ============================================================================
+
+func TestAdminGetImportJob_Success(t *testing.T) {
+	now := time.Now()
+	mock := &mockRadioService{
+		getImportJobFn: func(jobID uint) (*contracts.RadioImportJobResponse, error) {
+			return &contracts.RadioImportJobResponse{
+				ID:          jobID,
+				ShowID:      1,
+				ShowName:    "Test Show",
+				StationID:   1,
+				StationName: "Test Station",
+				Status:      "running",
+				CreatedAt:   now,
+				UpdatedAt:   now,
+			}, nil
+		},
+	}
+	h := testRadioHandler(mock)
+	resp, err := h.AdminGetImportJobHandler(radioAdminCtx(), &AdminGetImportJobRequest{JobID: 1})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.ID != 1 {
+		t.Errorf("expected job ID 1, got %d", resp.Body.ID)
+	}
+	if resp.Body.Status != "running" {
+		t.Errorf("expected status 'running', got %s", resp.Body.Status)
+	}
+}
+
+func TestAdminGetImportJob_NotFound(t *testing.T) {
+	mock := &mockRadioService{
+		getImportJobFn: func(jobID uint) (*contracts.RadioImportJobResponse, error) {
+			return nil, fmt.Errorf("job not found")
+		},
+	}
+	h := testRadioHandler(mock)
+	_, err := h.AdminGetImportJobHandler(radioAdminCtx(), &AdminGetImportJobRequest{JobID: 999})
+	assertHumaError(t, err, 404)
+}
+
+func TestAdminGetImportJob_NotAdmin(t *testing.T) {
+	mock := &mockRadioService{}
+	h := testRadioHandler(mock)
+	_, err := h.AdminGetImportJobHandler(context.Background(), &AdminGetImportJobRequest{JobID: 1})
+	assertHumaError(t, err, 403)
+}
+
+// ============================================================================
+// AdminCancelImportJobHandler Tests
+// ============================================================================
+
+func TestAdminCancelImportJob_Success(t *testing.T) {
+	mock := &mockRadioService{
+		cancelImportJobFn: func(jobID uint) error {
+			return nil
+		},
+	}
+	h := testRadioHandler(mock)
+	resp, err := h.AdminCancelImportJobHandler(radioAdminCtx(), &AdminCancelImportJobRequest{JobID: 1})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.Body.Success {
+		t.Error("expected success=true")
+	}
+}
+
+func TestAdminCancelImportJob_ServiceError(t *testing.T) {
+	mock := &mockRadioService{
+		cancelImportJobFn: func(jobID uint) error {
+			return fmt.Errorf("job cannot be cancelled")
+		},
+	}
+	h := testRadioHandler(mock)
+	_, err := h.AdminCancelImportJobHandler(radioAdminCtx(), &AdminCancelImportJobRequest{JobID: 1})
+	assertHumaError(t, err, 500)
+}
+
+func TestAdminCancelImportJob_NotAdmin(t *testing.T) {
+	mock := &mockRadioService{}
+	h := testRadioHandler(mock)
+	_, err := h.AdminCancelImportJobHandler(context.Background(), &AdminCancelImportJobRequest{JobID: 1})
+	assertHumaError(t, err, 403)
+}
+
+// ============================================================================
+// AdminListImportJobsHandler Tests
+// ============================================================================
+
+func TestAdminListImportJobs_Success(t *testing.T) {
+	now := time.Now()
+	mock := &mockRadioService{
+		listImportJobsFn: func(showID uint) ([]*contracts.RadioImportJobResponse, error) {
+			return []*contracts.RadioImportJobResponse{
+				{
+					ID:          1,
+					ShowID:      showID,
+					ShowName:    "Test Show",
+					StationID:   1,
+					StationName: "Test Station",
+					Status:      "completed",
+					CreatedAt:   now,
+					UpdatedAt:   now,
+				},
+			}, nil
+		},
+	}
+	h := testRadioHandler(mock)
+	resp, err := h.AdminListImportJobsHandler(radioAdminCtx(), &AdminListImportJobsRequest{ShowID: 1})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Count != 1 {
+		t.Errorf("expected count 1, got %d", resp.Body.Count)
+	}
+	if resp.Body.Jobs[0].Status != "completed" {
+		t.Errorf("expected status 'completed', got %s", resp.Body.Jobs[0].Status)
+	}
+}
+
+func TestAdminListImportJobs_Empty(t *testing.T) {
+	mock := &mockRadioService{
+		listImportJobsFn: func(showID uint) ([]*contracts.RadioImportJobResponse, error) {
+			return []*contracts.RadioImportJobResponse{}, nil
+		},
+	}
+	h := testRadioHandler(mock)
+	resp, err := h.AdminListImportJobsHandler(radioAdminCtx(), &AdminListImportJobsRequest{ShowID: 1})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Count != 0 {
+		t.Errorf("expected count 0, got %d", resp.Body.Count)
+	}
+}
+
+func TestAdminListImportJobs_ServiceError(t *testing.T) {
+	mock := &mockRadioService{
+		listImportJobsFn: func(showID uint) ([]*contracts.RadioImportJobResponse, error) {
+			return nil, fmt.Errorf("database error")
+		},
+	}
+	h := testRadioHandler(mock)
+	_, err := h.AdminListImportJobsHandler(radioAdminCtx(), &AdminListImportJobsRequest{ShowID: 1})
+	assertHumaError(t, err, 500)
+}
+
+func TestAdminListImportJobs_NotAdmin(t *testing.T) {
+	mock := &mockRadioService{}
+	h := testRadioHandler(mock)
+	_, err := h.AdminListImportJobsHandler(context.Background(), &AdminListImportJobsRequest{ShowID: 1})
+	assertHumaError(t, err, 403)
+}

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -1043,6 +1043,12 @@ func setupRadioRoutes(rc RouteContext) {
 	huma.Delete(rc.Protected, "/admin/radio-shows/{id}", radioHandler.AdminDeleteRadioShowHandler)
 	huma.Post(rc.Protected, "/admin/radio-shows/{id}/import", radioHandler.AdminImportShowEpisodesHandler)
 
+	// Admin import job endpoints
+	huma.Post(rc.Protected, "/admin/radio-shows/{id}/import-job", radioHandler.AdminCreateImportJobHandler)
+	huma.Get(rc.Protected, "/admin/radio/import-jobs/{id}", radioHandler.AdminGetImportJobHandler)
+	huma.Post(rc.Protected, "/admin/radio/import-jobs/{id}/cancel", radioHandler.AdminCancelImportJobHandler)
+	huma.Get(rc.Protected, "/admin/radio-shows/{id}/import-jobs", radioHandler.AdminListImportJobsHandler)
+
 	// Admin unmatched play management endpoints
 	huma.Get(rc.Protected, "/admin/radio/unmatched", radioHandler.AdminGetUnmatchedPlaysHandler)
 	huma.Post(rc.Protected, "/admin/radio/plays/{id}/link", radioHandler.AdminLinkPlayHandler)

--- a/backend/internal/models/radio.go
+++ b/backend/internal/models/radio.go
@@ -182,6 +182,40 @@ func (RadioPlay) TableName() string {
 	return "radio_plays"
 }
 
+// Import job status constants
+const (
+	RadioImportJobStatusPending   = "pending"
+	RadioImportJobStatusRunning   = "running"
+	RadioImportJobStatusCompleted = "completed"
+	RadioImportJobStatusFailed    = "failed"
+	RadioImportJobStatusCancelled = "cancelled"
+)
+
+// RadioImportJob represents an async import job for a radio show's episodes.
+type RadioImportJob struct {
+	ID                 uint          `gorm:"primaryKey" json:"id"`
+	ShowID             uint          `gorm:"not null" json:"show_id"`
+	Show               RadioShow     `gorm:"foreignKey:ShowID" json:"-"`
+	StationID          uint          `gorm:"not null" json:"station_id"`
+	Station            RadioStation  `gorm:"foreignKey:StationID" json:"-"`
+	Since              string        `gorm:"type:date;not null" json:"since"`
+	Until              string        `gorm:"type:date;not null" json:"until"`
+	Status             string        `gorm:"type:varchar(20);not null;default:pending" json:"status"`
+	EpisodesFound      int           `gorm:"not null;default:0" json:"episodes_found"`
+	EpisodesImported   int           `gorm:"not null;default:0" json:"episodes_imported"`
+	PlaysImported      int           `gorm:"not null;default:0" json:"plays_imported"`
+	PlaysMatched       int           `gorm:"not null;default:0" json:"plays_matched"`
+	CurrentEpisodeDate *string       `json:"current_episode_date,omitempty"`
+	ErrorLog           *string       `gorm:"type:text" json:"error_log,omitempty"`
+	StartedAt          *time.Time    `json:"started_at,omitempty"`
+	CompletedAt        *time.Time    `json:"completed_at,omitempty"`
+	CreatedAt          time.Time     `json:"created_at"`
+	UpdatedAt          time.Time     `json:"updated_at"`
+}
+
+// TableName specifies the table name for RadioImportJob
+func (RadioImportJob) TableName() string { return "radio_import_jobs" }
+
 // RadioArtistAffinity represents co-occurrence of two artists across radio playlists.
 // The composite primary key is (artist_a_id, artist_b_id).
 // A CHECK constraint ensures artist_a_id < artist_b_id (canonical ordering).

--- a/backend/internal/services/catalog/radio_import_job.go
+++ b/backend/internal/services/catalog/radio_import_job.go
@@ -1,0 +1,363 @@
+package catalog
+
+import (
+	"fmt"
+	"log/slog"
+	"time"
+
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// CreateImportJob creates a new pending import job for a radio show.
+// Validates that no other job is currently running for the same show.
+func (s *RadioService) CreateImportJob(showID uint, since, until string) (*contracts.RadioImportJobResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	// Validate show exists and get station ID
+	var show models.RadioShow
+	if err := s.db.Preload("Station").First(&show, showID).Error; err != nil {
+		return nil, fmt.Errorf("show not found: %w", err)
+	}
+
+	// Validate date format
+	if _, err := time.Parse("2006-01-02", since); err != nil {
+		return nil, fmt.Errorf("invalid since date format (expected YYYY-MM-DD): %w", err)
+	}
+	if _, err := time.Parse("2006-01-02", until); err != nil {
+		return nil, fmt.Errorf("invalid until date format (expected YYYY-MM-DD): %w", err)
+	}
+
+	// Check for existing running/pending job
+	var activeCount int64
+	s.db.Model(&models.RadioImportJob{}).
+		Where("show_id = ? AND status IN ?", showID, []string{
+			models.RadioImportJobStatusPending,
+			models.RadioImportJobStatusRunning,
+		}).
+		Count(&activeCount)
+	if activeCount > 0 {
+		return nil, fmt.Errorf("an import job is already running or pending for this show")
+	}
+
+	job := &models.RadioImportJob{
+		ShowID:    showID,
+		StationID: show.StationID,
+		Since:     since,
+		Until:     until,
+		Status:    models.RadioImportJobStatusPending,
+	}
+
+	if err := s.db.Create(job).Error; err != nil {
+		return nil, fmt.Errorf("creating import job: %w", err)
+	}
+
+	return s.jobToResponse(job, show.Name, show.Station.Name), nil
+}
+
+// StartImportJob transitions a pending job to running and launches the background goroutine.
+func (s *RadioService) StartImportJob(jobID uint) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	var job models.RadioImportJob
+	if err := s.db.First(&job, jobID).Error; err != nil {
+		return fmt.Errorf("job not found: %w", err)
+	}
+
+	if job.Status != models.RadioImportJobStatusPending {
+		return fmt.Errorf("job is not in pending status (current: %s)", job.Status)
+	}
+
+	now := time.Now()
+	s.db.Model(&job).Updates(map[string]interface{}{
+		"status":     models.RadioImportJobStatusRunning,
+		"started_at": now,
+	})
+
+	// Launch the import goroutine
+	go s.runImportJob(job.ID)
+
+	return nil
+}
+
+// CancelImportJob sets a running or pending job to cancelled.
+// If the job is running, the goroutine will check status periodically and stop.
+func (s *RadioService) CancelImportJob(jobID uint) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	var job models.RadioImportJob
+	if err := s.db.First(&job, jobID).Error; err != nil {
+		return fmt.Errorf("job not found: %w", err)
+	}
+
+	if job.Status != models.RadioImportJobStatusRunning && job.Status != models.RadioImportJobStatusPending {
+		return fmt.Errorf("job cannot be cancelled (current status: %s)", job.Status)
+	}
+
+	now := time.Now()
+	s.db.Model(&job).Updates(map[string]interface{}{
+		"status":       models.RadioImportJobStatusCancelled,
+		"completed_at": now,
+	})
+
+	return nil
+}
+
+// GetImportJob returns a single import job by ID with show/station names.
+func (s *RadioService) GetImportJob(jobID uint) (*contracts.RadioImportJobResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var job models.RadioImportJob
+	if err := s.db.Preload("Show").Preload("Station").First(&job, jobID).Error; err != nil {
+		return nil, fmt.Errorf("job not found: %w", err)
+	}
+
+	return s.jobToResponse(&job, job.Show.Name, job.Station.Name), nil
+}
+
+// ListImportJobs returns all import jobs for a given show, ordered by newest first.
+func (s *RadioService) ListImportJobs(showID uint) ([]*contracts.RadioImportJobResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var jobs []models.RadioImportJob
+	if err := s.db.Preload("Show").Preload("Station").
+		Where("show_id = ?", showID).
+		Order("created_at DESC").
+		Find(&jobs).Error; err != nil {
+		return nil, fmt.Errorf("listing import jobs: %w", err)
+	}
+
+	results := make([]*contracts.RadioImportJobResponse, len(jobs))
+	for i, job := range jobs {
+		results[i] = s.jobToResponse(&job, job.Show.Name, job.Station.Name)
+	}
+
+	return results, nil
+}
+
+// runImportJob is the background goroutine that performs the actual import work.
+func (s *RadioService) runImportJob(jobID uint) {
+	logger := slog.Default().With("job_id", jobID)
+	logger.Info("radio_import_job_started")
+
+	// Reload job from DB
+	var job models.RadioImportJob
+	if err := s.db.Preload("Show").Preload("Show.Station").First(&job, jobID).Error; err != nil {
+		logger.Error("radio_import_job_load_failed", "error", err.Error())
+		return
+	}
+
+	station := job.Show.Station
+	if station.PlaylistSource == nil || *station.PlaylistSource == "" {
+		s.failJob(jobID, "station has no playlist source configured")
+		return
+	}
+
+	provider, err := s.getProvider(*station.PlaylistSource)
+	if err != nil {
+		s.failJob(jobID, fmt.Sprintf("getting provider: %v", err))
+		return
+	}
+	defer closeProvider(provider)
+
+	// Parse date range
+	sinceTime, err := time.Parse("2006-01-02", job.Since)
+	if err != nil {
+		s.failJob(jobID, fmt.Sprintf("parsing since date: %v", err))
+		return
+	}
+	untilTime, err := time.Parse("2006-01-02", job.Until)
+	if err != nil {
+		s.failJob(jobID, fmt.Sprintf("parsing until date: %v", err))
+		return
+	}
+
+	// Get external ID for the show
+	if job.Show.ExternalID == nil || *job.Show.ExternalID == "" {
+		s.failJob(jobID, "show has no external ID")
+		return
+	}
+
+	// Fetch episodes from provider
+	episodes, err := provider.FetchNewEpisodes(*job.Show.ExternalID, sinceTime)
+	if err != nil {
+		s.failJob(jobID, fmt.Sprintf("fetching episodes: %v", err))
+		return
+	}
+
+	// Filter episodes to the date range
+	var filtered []RadioEpisodeImport
+	for _, ep := range episodes {
+		epDate, parseErr := time.Parse("2006-01-02", ep.AirDate)
+		if parseErr != nil {
+			continue
+		}
+		if !epDate.Before(sinceTime) && !epDate.After(untilTime) {
+			filtered = append(filtered, ep)
+		}
+	}
+
+	// Update episodes found count
+	s.db.Model(&models.RadioImportJob{}).Where("id = ?", jobID).
+		Update("episodes_found", len(filtered))
+
+	logger.Info("radio_import_job_episodes_found",
+		"total_from_provider", len(episodes),
+		"in_date_range", len(filtered),
+	)
+
+	var (
+		totalPlaysImported int
+		totalPlaysMatched  int
+		episodesImported   int
+		errorMessages      []string
+	)
+
+	for i, ep := range filtered {
+		// Check for cancellation every 5 episodes
+		if i > 0 && i%5 == 0 {
+			var currentJob models.RadioImportJob
+			if err := s.db.Select("status").First(&currentJob, jobID).Error; err == nil {
+				if currentJob.Status == models.RadioImportJobStatusCancelled {
+					logger.Info("radio_import_job_cancelled", "episodes_processed", i)
+					return
+				}
+			}
+		}
+
+		// Import the episode
+		epResult, importErr := s.importEpisode(job.ShowID, ep, provider)
+		if importErr != nil {
+			errorMessages = append(errorMessages, fmt.Sprintf("episode %s: %v", ep.AirDate, importErr))
+			continue
+		}
+
+		episodesImported++
+		totalPlaysImported += epResult.PlaysImported
+		totalPlaysMatched += epResult.PlaysMatched
+
+		// Batch update progress every 10 episodes
+		if i > 0 && i%10 == 0 {
+			currentDate := ep.AirDate
+			s.db.Model(&models.RadioImportJob{}).Where("id = ?", jobID).
+				Updates(map[string]interface{}{
+					"episodes_imported":    episodesImported,
+					"plays_imported":       totalPlaysImported,
+					"plays_matched":        totalPlaysMatched,
+					"current_episode_date": currentDate,
+				})
+		}
+	}
+
+	// Final update: mark completed
+	now := time.Now()
+	updates := map[string]interface{}{
+		"status":            models.RadioImportJobStatusCompleted,
+		"episodes_imported": episodesImported,
+		"plays_imported":    totalPlaysImported,
+		"plays_matched":     totalPlaysMatched,
+		"completed_at":      now,
+	}
+
+	if len(errorMessages) > 0 {
+		errorLog := ""
+		for _, msg := range errorMessages {
+			errorLog += msg + "\n"
+		}
+		updates["error_log"] = errorLog
+	}
+
+	// Set current_episode_date to the last processed episode
+	if len(filtered) > 0 {
+		updates["current_episode_date"] = filtered[len(filtered)-1].AirDate
+	}
+
+	s.db.Model(&models.RadioImportJob{}).Where("id = ?", jobID).Updates(updates)
+
+	logger.Info("radio_import_job_completed",
+		"episodes_imported", episodesImported,
+		"plays_imported", totalPlaysImported,
+		"plays_matched", totalPlaysMatched,
+		"errors", len(errorMessages),
+	)
+}
+
+// failJob marks a job as failed with an error message.
+func (s *RadioService) failJob(jobID uint, errMsg string) {
+	now := time.Now()
+	s.db.Model(&models.RadioImportJob{}).Where("id = ?", jobID).Updates(map[string]interface{}{
+		"status":       models.RadioImportJobStatusFailed,
+		"error_log":    errMsg,
+		"completed_at": now,
+	})
+	slog.Default().Error("radio_import_job_failed", "job_id", jobID, "error", errMsg)
+}
+
+// jobToResponse maps a model to a DTO response.
+func (s *RadioService) jobToResponse(job *models.RadioImportJob, showName, stationName string) *contracts.RadioImportJobResponse {
+	return &contracts.RadioImportJobResponse{
+		ID:                 job.ID,
+		ShowID:             job.ShowID,
+		ShowName:           showName,
+		StationID:          job.StationID,
+		StationName:        stationName,
+		Since:              job.Since,
+		Until:              job.Until,
+		Status:             job.Status,
+		EpisodesFound:      job.EpisodesFound,
+		EpisodesImported:   job.EpisodesImported,
+		PlaysImported:      job.PlaysImported,
+		PlaysMatched:       job.PlaysMatched,
+		CurrentEpisodeDate: job.CurrentEpisodeDate,
+		ErrorLog:           job.ErrorLog,
+		StartedAt:          job.StartedAt,
+		CompletedAt:        job.CompletedAt,
+		CreatedAt:          job.CreatedAt,
+		UpdatedAt:          job.UpdatedAt,
+	}
+}
+
+// ListAllActiveJobs returns all running and pending import jobs.
+func (s *RadioService) ListAllActiveJobs() ([]*contracts.RadioImportJobResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var jobs []models.RadioImportJob
+	if err := s.db.Preload("Show").Preload("Station").
+		Where("status IN ?", []string{
+			models.RadioImportJobStatusPending,
+			models.RadioImportJobStatusRunning,
+		}).
+		Order("created_at DESC").
+		Find(&jobs).Error; err != nil {
+		return nil, fmt.Errorf("listing active import jobs: %w", err)
+	}
+
+	results := make([]*contracts.RadioImportJobResponse, len(jobs))
+	for i, job := range jobs {
+		results[i] = s.jobToResponse(&job, job.Show.Name, job.Station.Name)
+	}
+
+	return results, nil
+}
+
+// isJobCancelled checks if a job has been cancelled.
+func (s *RadioService) isJobCancelled(jobID uint) bool {
+	var job models.RadioImportJob
+	if err := s.db.Select("status").First(&job, jobID).Error; err != nil {
+		return false
+	}
+	return job.Status == models.RadioImportJobStatusCancelled
+}
+

--- a/backend/internal/services/catalog/radio_import_job.go
+++ b/backend/internal/services/catalog/radio_import_job.go
@@ -303,6 +303,17 @@ func (s *RadioService) failJob(jobID uint, errMsg string) {
 	slog.Default().Error("radio_import_job_failed", "job_id", jobID, "error", errMsg)
 }
 
+// normalizeDateString strips any time component from a date string so the
+// response always returns YYYY-MM-DD. Postgres DATE columns round-trip through
+// GORM into Go strings as "2025-04-01T00:00:00Z" even though the column only
+// holds a date, so we trim it back to the 10-char form the API expects.
+func normalizeDateString(s string) string {
+	if len(s) >= 10 {
+		return s[:10]
+	}
+	return s
+}
+
 // jobToResponse maps a model to a DTO response.
 func (s *RadioService) jobToResponse(job *models.RadioImportJob, showName, stationName string) *contracts.RadioImportJobResponse {
 	return &contracts.RadioImportJobResponse{
@@ -311,8 +322,8 @@ func (s *RadioService) jobToResponse(job *models.RadioImportJob, showName, stati
 		ShowName:           showName,
 		StationID:          job.StationID,
 		StationName:        stationName,
-		Since:              job.Since,
-		Until:              job.Until,
+		Since:              normalizeDateString(job.Since),
+		Until:              normalizeDateString(job.Until),
 		Status:             job.Status,
 		EpisodesFound:      job.EpisodesFound,
 		EpisodesImported:   job.EpisodesImported,

--- a/backend/internal/services/catalog/radio_import_job_test.go
+++ b/backend/internal/services/catalog/radio_import_job_test.go
@@ -1,0 +1,294 @@
+package catalog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/testutil"
+)
+
+// =============================================================================
+// UNIT TESTS (No Database Required)
+// =============================================================================
+
+func TestRadioService_NilDB_ImportJob(t *testing.T) {
+	svc := &RadioService{db: nil}
+
+	assertNilDBErr := func(fn func() error) {
+		t.Helper()
+		err := fn()
+		if err == nil {
+			t.Fatal("expected error for nil db, got nil")
+		}
+		if err.Error() != "database not initialized" {
+			t.Fatalf("expected 'database not initialized', got %q", err.Error())
+		}
+	}
+
+	assertNilDBErr(func() error {
+		_, err := svc.CreateImportJob(1, "2025-01-01", "2025-12-31")
+		return err
+	})
+	assertNilDBErr(func() error { return svc.StartImportJob(1) })
+	assertNilDBErr(func() error { return svc.CancelImportJob(1) })
+	assertNilDBErr(func() error {
+		_, err := svc.GetImportJob(1)
+		return err
+	})
+	assertNilDBErr(func() error {
+		_, err := svc.ListImportJobs(1)
+		return err
+	})
+	assertNilDBErr(func() error {
+		_, err := svc.ListAllActiveJobs()
+		return err
+	})
+}
+
+// =============================================================================
+// INTEGRATION TESTS (With Real Database)
+// =============================================================================
+
+type RadioImportJobIntegrationTestSuite struct {
+	suite.Suite
+	testDB       *testutil.TestDatabase
+	db           *gorm.DB
+	radioService *RadioService
+}
+
+func (suite *RadioImportJobIntegrationTestSuite) SetupSuite() {
+	suite.testDB = testutil.SetupTestPostgres(suite.T())
+	suite.db = suite.testDB.DB
+	suite.radioService = NewRadioService(suite.db)
+}
+
+func (suite *RadioImportJobIntegrationTestSuite) TearDownSuite() {
+	suite.testDB.Cleanup()
+}
+
+func (suite *RadioImportJobIntegrationTestSuite) TearDownTest() {
+	// Clean up tables in reverse dependency order
+	suite.db.Exec("DELETE FROM radio_import_jobs")
+	suite.db.Exec("DELETE FROM radio_plays")
+	suite.db.Exec("DELETE FROM radio_episodes")
+	suite.db.Exec("DELETE FROM radio_shows")
+	suite.db.Exec("DELETE FROM radio_stations")
+}
+
+func TestRadioImportJobIntegrationTestSuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration tests in short mode")
+	}
+	suite.Run(t, new(RadioImportJobIntegrationTestSuite))
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+func (suite *RadioImportJobIntegrationTestSuite) createStation(name string) *contracts.RadioStationDetailResponse {
+	station, err := suite.radioService.CreateStation(&contracts.CreateRadioStationRequest{
+		Name: name, BroadcastType: "both",
+	})
+	suite.Require().NoError(err)
+	return station
+}
+
+func (suite *RadioImportJobIntegrationTestSuite) createShow(stationID uint, name string) *contracts.RadioShowDetailResponse {
+	show, err := suite.radioService.CreateShow(stationID, &contracts.CreateRadioShowRequest{Name: name})
+	suite.Require().NoError(err)
+	return show
+}
+
+// ─── CreateImportJob Tests ──────────────────────────────────────────────────
+
+func (suite *RadioImportJobIntegrationTestSuite) TestCreateImportJob_Success() {
+	station := suite.createStation("Test Station")
+	show := suite.createShow(station.ID, "Test Show")
+
+	job, err := suite.radioService.CreateImportJob(show.ID, "2025-01-01", "2025-06-30")
+	suite.Require().NoError(err)
+	suite.Require().NotNil(job)
+	suite.Equal(show.ID, job.ShowID)
+	suite.Equal(station.ID, job.StationID)
+	suite.Equal("2025-01-01", job.Since)
+	suite.Equal("2025-06-30", job.Until)
+	suite.Equal(models.RadioImportJobStatusPending, job.Status)
+	suite.Equal(0, job.EpisodesFound)
+	suite.Equal(0, job.EpisodesImported)
+	suite.Equal(0, job.PlaysImported)
+	suite.Equal(0, job.PlaysMatched)
+	suite.Equal("Test Show", job.ShowName)
+	suite.Equal("Test Station", job.StationName)
+}
+
+func (suite *RadioImportJobIntegrationTestSuite) TestCreateImportJob_DuplicateRunning() {
+	station := suite.createStation("Test Station")
+	show := suite.createShow(station.ID, "Test Show")
+
+	// Create first job
+	_, err := suite.radioService.CreateImportJob(show.ID, "2025-01-01", "2025-06-30")
+	suite.Require().NoError(err)
+
+	// Attempt to create a second job — should fail
+	_, err = suite.radioService.CreateImportJob(show.ID, "2025-07-01", "2025-12-31")
+	suite.Require().Error(err)
+	suite.Contains(err.Error(), "already running or pending")
+}
+
+func (suite *RadioImportJobIntegrationTestSuite) TestCreateImportJob_ShowNotFound() {
+	_, err := suite.radioService.CreateImportJob(99999, "2025-01-01", "2025-12-31")
+	suite.Require().Error(err)
+	suite.Contains(err.Error(), "show not found")
+}
+
+func (suite *RadioImportJobIntegrationTestSuite) TestCreateImportJob_InvalidSinceDate() {
+	station := suite.createStation("Test Station")
+	show := suite.createShow(station.ID, "Test Show")
+
+	_, err := suite.radioService.CreateImportJob(show.ID, "not-a-date", "2025-12-31")
+	suite.Require().Error(err)
+	suite.Contains(err.Error(), "invalid since date")
+}
+
+func (suite *RadioImportJobIntegrationTestSuite) TestCreateImportJob_InvalidUntilDate() {
+	station := suite.createStation("Test Station")
+	show := suite.createShow(station.ID, "Test Show")
+
+	_, err := suite.radioService.CreateImportJob(show.ID, "2025-01-01", "not-a-date")
+	suite.Require().Error(err)
+	suite.Contains(err.Error(), "invalid until date")
+}
+
+// ─── CancelImportJob Tests ─────────────────────────────────────────────────
+
+func (suite *RadioImportJobIntegrationTestSuite) TestCancelImportJob_Success() {
+	station := suite.createStation("Test Station")
+	show := suite.createShow(station.ID, "Test Show")
+
+	job, err := suite.radioService.CreateImportJob(show.ID, "2025-01-01", "2025-06-30")
+	suite.Require().NoError(err)
+
+	err = suite.radioService.CancelImportJob(job.ID)
+	suite.Require().NoError(err)
+
+	// Verify status changed
+	updated, err := suite.radioService.GetImportJob(job.ID)
+	suite.Require().NoError(err)
+	suite.Equal(models.RadioImportJobStatusCancelled, updated.Status)
+	suite.NotNil(updated.CompletedAt)
+}
+
+func (suite *RadioImportJobIntegrationTestSuite) TestCancelImportJob_NotFound() {
+	err := suite.radioService.CancelImportJob(99999)
+	suite.Require().Error(err)
+	suite.Contains(err.Error(), "job not found")
+}
+
+func (suite *RadioImportJobIntegrationTestSuite) TestCancelImportJob_AlreadyCompleted() {
+	station := suite.createStation("Test Station")
+	show := suite.createShow(station.ID, "Test Show")
+
+	job, err := suite.radioService.CreateImportJob(show.ID, "2025-01-01", "2025-06-30")
+	suite.Require().NoError(err)
+
+	// Manually set to completed
+	suite.db.Model(&models.RadioImportJob{}).Where("id = ?", job.ID).
+		Update("status", models.RadioImportJobStatusCompleted)
+
+	err = suite.radioService.CancelImportJob(job.ID)
+	suite.Require().Error(err)
+	suite.Contains(err.Error(), "cannot be cancelled")
+}
+
+// ─── GetImportJob Tests ────────────────────────────────────────────────────
+
+func (suite *RadioImportJobIntegrationTestSuite) TestGetImportJob_Success() {
+	station := suite.createStation("Test Station")
+	show := suite.createShow(station.ID, "Test Show")
+
+	created, err := suite.radioService.CreateImportJob(show.ID, "2025-01-01", "2025-06-30")
+	suite.Require().NoError(err)
+
+	job, err := suite.radioService.GetImportJob(created.ID)
+	suite.Require().NoError(err)
+	suite.Equal(created.ID, job.ID)
+	suite.Equal("Test Show", job.ShowName)
+	suite.Equal("Test Station", job.StationName)
+}
+
+func (suite *RadioImportJobIntegrationTestSuite) TestGetImportJob_NotFound() {
+	_, err := suite.radioService.GetImportJob(99999)
+	suite.Require().Error(err)
+	suite.Contains(err.Error(), "job not found")
+}
+
+// ─── ListImportJobs Tests ──────────────────────────────────────────────────
+
+func (suite *RadioImportJobIntegrationTestSuite) TestListImportJobs_Success() {
+	station := suite.createStation("Test Station")
+	show := suite.createShow(station.ID, "Test Show")
+
+	// Create a job, cancel it, then create another
+	job1, err := suite.radioService.CreateImportJob(show.ID, "2025-01-01", "2025-03-31")
+	suite.Require().NoError(err)
+
+	err = suite.radioService.CancelImportJob(job1.ID)
+	suite.Require().NoError(err)
+
+	_, err = suite.radioService.CreateImportJob(show.ID, "2025-04-01", "2025-06-30")
+	suite.Require().NoError(err)
+
+	jobs, err := suite.radioService.ListImportJobs(show.ID)
+	suite.Require().NoError(err)
+	suite.Len(jobs, 2)
+	// Most recent first
+	suite.Equal("2025-04-01", jobs[0].Since)
+	suite.Equal("2025-01-01", jobs[1].Since)
+}
+
+func (suite *RadioImportJobIntegrationTestSuite) TestListImportJobs_Empty() {
+	station := suite.createStation("Test Station")
+	show := suite.createShow(station.ID, "Test Show")
+
+	jobs, err := suite.radioService.ListImportJobs(show.ID)
+	suite.Require().NoError(err)
+	suite.Len(jobs, 0)
+}
+
+// ─── ListAllActiveJobs Tests ───────────────────────────────────────────────
+
+func (suite *RadioImportJobIntegrationTestSuite) TestListAllActiveJobs_Success() {
+	station := suite.createStation("Test Station")
+	show1 := suite.createShow(station.ID, "Show 1")
+	show2 := suite.createShow(station.ID, "Show 2")
+
+	// Create one pending job for each show
+	_, err := suite.radioService.CreateImportJob(show1.ID, "2025-01-01", "2025-06-30")
+	suite.Require().NoError(err)
+	_, err = suite.radioService.CreateImportJob(show2.ID, "2025-01-01", "2025-06-30")
+	suite.Require().NoError(err)
+
+	jobs, err := suite.radioService.ListAllActiveJobs()
+	suite.Require().NoError(err)
+	suite.Len(jobs, 2)
+}
+
+// ─── CreateImportJob allows after cancellation ─────────────────────────────
+
+func (suite *RadioImportJobIntegrationTestSuite) TestCreateImportJob_AllowedAfterCancellation() {
+	station := suite.createStation("Test Station")
+	show := suite.createShow(station.ID, "Test Show")
+
+	// Create and cancel
+	job, err := suite.radioService.CreateImportJob(show.ID, "2025-01-01", "2025-06-30")
+	suite.Require().NoError(err)
+	err = suite.radioService.CancelImportJob(job.ID)
+	suite.Require().NoError(err)
+
+	// Now creating a new job should succeed
+	_, err = suite.radioService.CreateImportJob(show.ID, "2025-07-01", "2025-12-31")
+	suite.Require().NoError(err)
+}

--- a/backend/internal/services/contracts/interfaces.go
+++ b/backend/internal/services/contracts/interfaces.go
@@ -598,4 +598,11 @@ type RadioServiceInterface interface {
 
 	// Re-matching
 	ReMatchUnmatched() (*MatchResult, error)
+
+	// Import jobs
+	CreateImportJob(showID uint, since, until string) (*RadioImportJobResponse, error)
+	StartImportJob(jobID uint) error
+	CancelImportJob(jobID uint) error
+	GetImportJob(jobID uint) (*RadioImportJobResponse, error)
+	ListImportJobs(showID uint) ([]*RadioImportJobResponse, error)
 }

--- a/backend/internal/services/contracts/radio.go
+++ b/backend/internal/services/contracts/radio.go
@@ -360,6 +360,39 @@ type BulkLinkResult struct {
 	Updated int `json:"updated"`
 }
 
+// ──────────────────────────────────────────────
+// Import job types
+// ──────────────────────────────────────────────
+
+// RadioImportJobResponse is the DTO for a radio import job.
+type RadioImportJobResponse struct {
+	ID                 uint       `json:"id"`
+	ShowID             uint       `json:"show_id"`
+	ShowName           string     `json:"show_name"`
+	StationID          uint       `json:"station_id"`
+	StationName        string     `json:"station_name"`
+	Since              string     `json:"since"`
+	Until              string     `json:"until"`
+	Status             string     `json:"status"`
+	EpisodesFound      int        `json:"episodes_found"`
+	EpisodesImported   int        `json:"episodes_imported"`
+	PlaysImported      int        `json:"plays_imported"`
+	PlaysMatched       int        `json:"plays_matched"`
+	CurrentEpisodeDate *string    `json:"current_episode_date,omitempty"`
+	ErrorLog           *string    `json:"error_log,omitempty"`
+	StartedAt          *time.Time `json:"started_at,omitempty"`
+	CompletedAt        *time.Time `json:"completed_at,omitempty"`
+	CreatedAt          time.Time  `json:"created_at"`
+	UpdatedAt          time.Time  `json:"updated_at"`
+}
+
+// CreateImportJobRequest represents a request to create a radio import job.
+type CreateImportJobRequest struct {
+	ShowID uint   `json:"show_id"`
+	Since  string `json:"since"`
+	Until  string `json:"until"`
+}
+
 // RadioFetchCycleResult summarizes the result of a radio fetch cycle.
 type RadioFetchCycleResult struct {
 	StationsProcessed int      `json:"stations_processed"`

--- a/frontend/app/admin/radio/_components/RadioManagement.tsx
+++ b/frontend/app/admin/radio/_components/RadioManagement.tsx
@@ -19,6 +19,11 @@ import {
   BarChart3,
   Radar,
   Upload,
+  Clock,
+  PlayCircle,
+  XCircle,
+  CheckCircle2,
+  History,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -49,11 +54,16 @@ import {
   useFetchPlaylists,
   useDiscoverShows,
   useImportShowEpisodes,
+  useCreateImportJob,
+  useImportJob,
+  useCancelImportJob,
+  useShowImportJobs,
   type RadioStationListItem,
   type RadioStationDetail,
   type RadioShowListItem,
   type RadioDiscoverResult,
   type RadioImportResult,
+  type RadioImportJob,
   type CreateRadioStationInput,
   type UpdateRadioStationInput,
   type CreateRadioShowInput,
@@ -777,6 +787,246 @@ function ShowImportControls({ show }: { show: RadioShowListItem }) {
   )
 }
 
+// ============================================================================
+// Import Job Progress Row
+// ============================================================================
+
+function ImportJobRow({ job }: { job: RadioImportJob }) {
+  const cancelMutation = useCancelImportJob()
+
+  const isActive = job.status === 'running' || job.status === 'pending'
+  const progress = job.episodes_found > 0
+    ? Math.round((job.episodes_imported / job.episodes_found) * 100)
+    : 0
+
+  const statusIcon = {
+    pending: <Clock className="h-4 w-4 text-muted-foreground" />,
+    running: <Loader2 className="h-4 w-4 animate-spin text-blue-500" />,
+    completed: <CheckCircle2 className="h-4 w-4 text-green-500" />,
+    failed: <AlertCircle className="h-4 w-4 text-destructive" />,
+    cancelled: <XCircle className="h-4 w-4 text-muted-foreground" />,
+  }[job.status]
+
+  const statusColor = {
+    pending: 'bg-muted text-muted-foreground',
+    running: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+    completed: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
+    failed: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
+    cancelled: 'bg-muted text-muted-foreground',
+  }[job.status]
+
+  return (
+    <div className="rounded-lg border p-4 space-y-2">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          {statusIcon}
+          <Badge className={statusColor}>{job.status}</Badge>
+          <span className="text-sm text-muted-foreground">
+            {job.since} to {job.until}
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          {job.started_at && (
+            <span className="text-xs text-muted-foreground">
+              Started {new Date(job.started_at).toLocaleString()}
+            </span>
+          )}
+          {isActive && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="text-destructive"
+              disabled={cancelMutation.isPending}
+              onClick={() => cancelMutation.mutate(job.id)}
+            >
+              {cancelMutation.isPending ? (
+                <Loader2 className="h-3 w-3 animate-spin mr-1" />
+              ) : (
+                <XCircle className="h-3 w-3 mr-1" />
+              )}
+              Cancel
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {/* Progress bar for running/completed jobs */}
+      {(job.status === 'running' || job.status === 'completed') && job.episodes_found > 0 && (
+        <div className="space-y-1">
+          <div className="h-2 rounded-full bg-muted overflow-hidden">
+            <div
+              className={`h-full rounded-full transition-all ${
+                job.status === 'completed' ? 'bg-green-500' : 'bg-blue-500'
+              }`}
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+          <div className="flex items-center justify-between text-xs text-muted-foreground">
+            <span>
+              {job.episodes_imported.toLocaleString()} / {job.episodes_found.toLocaleString()} episodes
+              {job.current_episode_date && job.status === 'running' && (
+                <> &mdash; processing {job.current_episode_date}</>
+              )}
+            </span>
+            <span>
+              {job.plays_imported.toLocaleString()} plays &mdash;{' '}
+              {job.plays_imported > 0
+                ? Math.round((job.plays_matched / job.plays_imported) * 100)
+                : 0}% matched
+            </span>
+          </div>
+        </div>
+      )}
+
+      {/* Error log for failed jobs */}
+      {job.status === 'failed' && job.error_log && (
+        <div className="rounded-md bg-destructive/10 p-2 text-xs text-destructive whitespace-pre-wrap max-h-24 overflow-y-auto">
+          {job.error_log}
+        </div>
+      )}
+
+      {/* Completed summary */}
+      {job.status === 'completed' && (
+        <div className="text-xs text-muted-foreground">
+          Completed {job.completed_at ? new Date(job.completed_at).toLocaleString() : ''} &mdash;{' '}
+          {job.episodes_imported.toLocaleString()} episodes, {job.plays_imported.toLocaleString()} plays, {job.plays_matched.toLocaleString()} matched
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ============================================================================
+// Show Import Section (per-show import history + active job tracking)
+// ============================================================================
+
+function ShowImportSection({
+  show,
+  stationId,
+}: {
+  show: RadioShowListItem
+  stationId: number
+}) {
+  const { data: jobsData, isLoading } = useShowImportJobs(show.id)
+  const createMutation = useCreateImportJob()
+  const [showCreateForm, setShowCreateForm] = useState(false)
+  const [since, setSince] = useState('')
+  const [until, setUntil] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  const jobs = jobsData?.jobs ?? []
+  const hasActiveJob = jobs.some(j => j.status === 'running' || j.status === 'pending')
+
+  // Track the most recent active job for live polling
+  const activeJob = jobs.find(j => j.status === 'running' || j.status === 'pending')
+  const { data: liveJob } = useImportJob(activeJob?.id ?? 0, !!activeJob)
+
+  const handleCreate = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault()
+      setError(null)
+
+      if (!since) { setError('Start date is required'); return }
+      if (!until) { setError('End date is required'); return }
+      if (since > until) { setError('Start date must be before end date'); return }
+
+      createMutation.mutate(
+        { showId: show.id, since, until },
+        {
+          onSuccess: () => {
+            setShowCreateForm(false)
+            setSince('')
+            setUntil('')
+          },
+          onError: (err) => setError(err.message),
+        }
+      )
+    },
+    [since, until, show.id, createMutation]
+  )
+
+  return (
+    <div className="mt-3 space-y-3">
+      {/* Active job with live progress */}
+      {liveJob && (liveJob.status === 'running' || liveJob.status === 'pending') && (
+        <ImportJobRow job={liveJob} />
+      )}
+
+      {/* Create import form */}
+      {showCreateForm ? (
+        <form onSubmit={handleCreate} className="rounded-lg border border-dashed p-4 space-y-3">
+          {error && (
+            <div className="rounded-md bg-destructive/10 p-2 text-sm text-destructive">{error}</div>
+          )}
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <Label htmlFor={`since-${show.id}`}>From</Label>
+              <Input
+                id={`since-${show.id}`}
+                type="date"
+                value={since}
+                onChange={(e) => setSince(e.target.value)}
+              />
+            </div>
+            <div>
+              <Label htmlFor={`until-${show.id}`}>To</Label>
+              <Input
+                id={`until-${show.id}`}
+                type="date"
+                value={until}
+                onChange={(e) => setUntil(e.target.value)}
+              />
+            </div>
+          </div>
+          <div className="flex gap-2">
+            <Button type="submit" size="sm" disabled={createMutation.isPending}>
+              {createMutation.isPending ? (
+                <Loader2 className="h-4 w-4 animate-spin mr-1" />
+              ) : (
+                <PlayCircle className="h-4 w-4 mr-1" />
+              )}
+              Start Import
+            </Button>
+            <Button type="button" variant="outline" size="sm" onClick={() => setShowCreateForm(false)}>
+              Cancel
+            </Button>
+          </div>
+        </form>
+      ) : (
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setShowCreateForm(true)}
+          disabled={hasActiveJob}
+        >
+          <Download className="h-4 w-4 mr-1" />
+          {hasActiveJob ? 'Import Running...' : 'Import Episodes'}
+        </Button>
+      )}
+
+      {/* Job history (non-active) */}
+      {!isLoading && jobs.filter(j => j.status !== 'running' && j.status !== 'pending').length > 0 && (
+        <details className="text-sm">
+          <summary className="cursor-pointer text-muted-foreground hover:text-foreground flex items-center gap-1">
+            <History className="h-3 w-3" />
+            Import History ({jobs.filter(j => j.status !== 'running' && j.status !== 'pending').length})
+          </summary>
+          <div className="mt-2 space-y-2">
+            {jobs
+              .filter(j => j.status !== 'running' && j.status !== 'pending')
+              .map(job => (
+                <ImportJobRow key={job.id} job={job} />
+              ))
+            }
+          </div>
+        </details>
+      )}
+    </div>
+  )
+}
+
+
+
 function StationDetailPanel({
   station,
   onBack,
@@ -985,7 +1235,10 @@ function StationDetailPanel({
                   </div>
                 </div>
                 {expandedShows.has(show.id) && (
-                  <ShowImportControls show={show} />
+                  <>
+                    <ShowImportControls show={show} />
+                    <ShowImportSection show={show} stationId={station.id} />
+                  </>
                 )}
               </div>
             ))}

--- a/frontend/lib/hooks/admin/useAdminRadio.ts
+++ b/frontend/lib/hooks/admin/useAdminRadio.ts
@@ -21,6 +21,8 @@ export const radioQueryKeys = {
   stationDetail: (id: number) => ['radio', 'stations', id] as const,
   shows: (stationId: number) => ['radio', 'shows', stationId] as const,
   stats: ['radio', 'stats'] as const,
+  importJob: (jobId: number) => ['radio', 'import-jobs', jobId] as const,
+  showImportJobs: (showId: number) => ['radio', 'show-import-jobs', showId] as const,
 }
 
 // ============================================================================
@@ -43,6 +45,10 @@ const RADIO_ENDPOINTS = {
   ADMIN_FETCH_PLAYLISTS: (stationId: number) => `${API_BASE_URL}/admin/radio-stations/${stationId}/fetch`,
   ADMIN_DISCOVER_SHOWS: (stationId: number) => `${API_BASE_URL}/admin/radio-stations/${stationId}/discover`,
   ADMIN_IMPORT_SHOW_EPISODES: (showId: number) => `${API_BASE_URL}/admin/radio-shows/${showId}/import`,
+  ADMIN_CREATE_IMPORT_JOB: (showId: number) => `${API_BASE_URL}/admin/radio-shows/${showId}/import-job`,
+  ADMIN_GET_IMPORT_JOB: (jobId: number) => `${API_BASE_URL}/admin/radio/import-jobs/${jobId}`,
+  ADMIN_CANCEL_IMPORT_JOB: (jobId: number) => `${API_BASE_URL}/admin/radio/import-jobs/${jobId}/cancel`,
+  ADMIN_LIST_IMPORT_JOBS: (showId: number) => `${API_BASE_URL}/admin/radio-shows/${showId}/import-jobs`,
 }
 
 // ============================================================================
@@ -203,6 +209,32 @@ export interface RadioImportResult {
   plays_imported: number
   plays_matched: number
   errors?: string[]
+}
+
+export interface RadioImportJob {
+  id: number
+  show_id: number
+  show_name: string
+  station_id: number
+  station_name: string
+  since: string
+  until: string
+  status: 'pending' | 'running' | 'completed' | 'failed' | 'cancelled'
+  episodes_found: number
+  episodes_imported: number
+  plays_imported: number
+  plays_matched: number
+  current_episode_date: string | null
+  error_log: string | null
+  started_at: string | null
+  completed_at: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface CreateImportJobInput {
+  since: string
+  until: string
 }
 
 // ============================================================================
@@ -451,5 +483,87 @@ export function useImportShowEpisodes() {
       queryClient.invalidateQueries({ queryKey: radioQueryKeys.stations })
       queryClient.invalidateQueries({ queryKey: radioQueryKeys.stats })
     },
+  })
+}
+
+// ============================================================================
+// Import Job Hooks
+// ============================================================================
+
+/**
+ * Hook to create and start an import job for a radio show.
+ */
+export function useCreateImportJob() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ showId, ...input }: CreateImportJobInput & { showId: number }) => {
+      return apiRequest<RadioImportJob>(RADIO_ENDPOINTS.ADMIN_CREATE_IMPORT_JOB(showId), {
+        method: 'POST',
+        body: JSON.stringify(input),
+      })
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: radioQueryKeys.showImportJobs(variables.showId) })
+    },
+  })
+}
+
+/**
+ * Hook to get a single import job's status. Polls every 3 seconds while running.
+ */
+export function useImportJob(jobId: number, enabled = true) {
+  return useQuery({
+    queryKey: radioQueryKeys.importJob(jobId),
+    queryFn: async () => {
+      const data = await apiRequest<RadioImportJob>(
+        RADIO_ENDPOINTS.ADMIN_GET_IMPORT_JOB(jobId)
+      )
+      return data
+    },
+    enabled: enabled && jobId > 0,
+    refetchInterval: (query) => {
+      const status = query.state.data?.status
+      if (status === 'running' || status === 'pending') {
+        return 3000
+      }
+      return false
+    },
+  })
+}
+
+/**
+ * Hook to cancel a running import job.
+ */
+export function useCancelImportJob() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (jobId: number) => {
+      return apiRequest<{ success: boolean }>(RADIO_ENDPOINTS.ADMIN_CANCEL_IMPORT_JOB(jobId), {
+        method: 'POST',
+      })
+    },
+    onSuccess: (_data, jobId) => {
+      queryClient.invalidateQueries({ queryKey: radioQueryKeys.importJob(jobId) })
+      // Also invalidate show-level lists
+      queryClient.invalidateQueries({ queryKey: radioQueryKeys.all })
+    },
+  })
+}
+
+/**
+ * Hook to list import jobs for a show.
+ */
+export function useShowImportJobs(showId: number, enabled = true) {
+  return useQuery({
+    queryKey: radioQueryKeys.showImportJobs(showId),
+    queryFn: async () => {
+      const data = await apiRequest<{ jobs: RadioImportJob[]; count: number }>(
+        RADIO_ENDPOINTS.ADMIN_LIST_IMPORT_JOBS(showId)
+      )
+      return data
+    },
+    enabled: enabled && showId > 0,
   })
 }


### PR DESCRIPTION
## Summary

Background job infrastructure for large radio playlist imports:

- **Migration 000063**: `radio_import_jobs` table with status enum (pending/running/completed/failed/cancelled), progress counters, current episode checkpoint, error log
- **Model**: `RadioImportJob` with status constants
- **Service**: `CreateImportJob`, `StartImportJob`, `CancelImportJob`, `GetImportJob`, `ListImportJobs`, and a background `runImportJob` goroutine with periodic cancellation checks and batched progress updates
- **Handlers**: 4 admin endpoints (create+start, get, cancel, list per show)
- **Frontend hooks**: `useCreateImportJob`, `useImportJob` (3s polling while running), `useCancelImportJob`, `useShowImportJobs`
- **Admin UI**: Per-show import section with date range form, progress bar, current episode checkpoint, cancel button, collapsible history
- Enforces max 1 active job per show; cancellation is respected within 5 episodes

## Dependency on PSY-272

This PR is conceptually complementary to #280 (PSY-272 show-level import). Both work with the same `RadioService.importEpisode()` internal helper. Note that there's duplicated date-range filtering logic between this PR's `runImportJob` and PSY-272's `ImportShowEpisodes`. Post-merge, `runImportJob` could call `ImportShowEpisodes` with a progress callback to deduplicate.

## Context

Follows from the PSY-274 audit which estimated 76-103 hours of wall-clock time for a full historical backfill at 1 req/sec. Synchronous imports from PSY-272 are fine for weeks/months; anything larger needs this async system.

## Test plan

- [ ] Backend: job lifecycle tests (create, start, cancel, list) pass
- [ ] Backend: existing Radio tests pass (no regression)
- [ ] Frontend: all existing tests pass
- [ ] Manual: kick off an import job, observe progress updates in the admin UI, cancel mid-run
- [ ] Manual: confirm max-1-job-per-show enforcement (second create for same show fails)

Closes PSY-273

🤖 Generated with [Claude Code](https://claude.com/claude-code)