### PR TITLE
Fix NTS FetchPlaylist to use /tracklist sub-endpoint

### DIFF
--- a/backend/internal/services/catalog/radio_provider_nts.go
+++ b/backend/internal/services/catalog/radio_provider_nts.go
@@ -2,6 +2,7 @@ package catalog
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -9,12 +10,22 @@ import (
 	"time"
 )
 
+// errNTSNotFound is returned by doGet when the NTS API responds with 404.
+// FetchPlaylist uses it to distinguish "no tracklist for this episode"
+// (which is normal for DJ mixes) from actual HTTP failures.
+var errNTSNotFound = errors.New("NTS API returned 404")
+
 const (
 	ntsBaseURL        = "https://www.nts.live/api"
 	ntsUserAgent      = "PsychicHomily/1.0 (radio-playlist-indexer)"
 	ntsDefaultTimeout = 30 * time.Second
 	ntsRateLimit      = 1 * time.Second
-	ntsPageLimit      = 100
+	// ntsPageLimit is the max page size NTS will actually honor.
+	// The /v2/shows/{alias}/episodes endpoint silently caps results at 12
+	// regardless of the requested limit, so anything higher just wastes
+	// API calls. The /v2/shows endpoint respects larger limits, but using
+	// a single constant keeps the provider simple.
+	ntsPageLimit = 12
 )
 
 // NTSProvider implements RadioPlaylistProvider for NTS Radio's v2 REST API.
@@ -137,10 +148,20 @@ func (p *NTSProvider) FetchNewEpisodes(showExternalID string, since time.Time) (
 
 // FetchPlaylist returns the track plays for a specific NTS episode.
 // The episodeExternalID should be in the format "show-alias/episode-alias".
+//
+// NTS serves tracklists from a separate sub-endpoint:
+//
+//	GET /v2/shows/{show-alias}/episodes/{ep-alias}/tracklist
+//
+// The episode detail endpoint does NOT include tracklist data. Many NTS
+// episodes (DJ mixes, ambient sets) have no tracklist at all -- the
+// tracklist endpoint may return 200 with an empty results array, or 404.
+// Both cases are treated as "no tracks" and return an empty slice, not an
+// error.
 func (p *NTSProvider) FetchPlaylist(episodeExternalID string) ([]RadioPlayImport, error) {
 	// episodeExternalID is "show-alias/episode-alias"
 	parts := strings.SplitN(episodeExternalID, "/", 2)
-	if len(parts) != 2 {
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 		return nil, fmt.Errorf("invalid episode external ID format (expected show-alias/episode-alias): %s", episodeExternalID)
 	}
 	showAlias := parts[0]
@@ -148,30 +169,33 @@ func (p *NTSProvider) FetchPlaylist(episodeExternalID string) ([]RadioPlayImport
 
 	<-p.rateLimiter.C
 
-	url := fmt.Sprintf("%s/v2/shows/%s/episodes/%s", p.baseURL, showAlias, episodeAlias)
+	url := fmt.Sprintf("%s/v2/shows/%s/episodes/%s/tracklist", p.baseURL, showAlias, episodeAlias)
 	resp, err := p.doGet(url)
 	if err != nil {
-		return nil, fmt.Errorf("fetching episode detail: %w", err)
+		// Episodes without tracklists may 404 -- treat as empty, not an error.
+		if errors.Is(err, errNTSNotFound) {
+			return []RadioPlayImport{}, nil
+		}
+		return nil, fmt.Errorf("fetching tracklist: %w", err)
 	}
 
-	var detail ntsEpisodeDetail
-	if err := json.Unmarshal(resp, &detail); err != nil {
-		return nil, fmt.Errorf("parsing episode detail: %w", err)
+	var tracklist ntsTracklistResponse
+	if err := json.Unmarshal(resp, &tracklist); err != nil {
+		return nil, fmt.Errorf("parsing tracklist response: %w", err)
 	}
 
 	// Many NTS episodes have no tracklist (DJ mixes, ambient sets) — return empty slice
-	if len(detail.Tracklist) == 0 {
+	if len(tracklist.Results) == 0 {
 		return []RadioPlayImport{}, nil
 	}
 
 	var plays []RadioPlayImport
-	for i, track := range detail.Tracklist {
+	for _, track := range tracklist.Results {
 		if track.Artist == "" {
 			continue
 		}
 
 		play := RadioPlayImport{
-			Position:   i,
 			ArtistName: track.Artist,
 		}
 
@@ -179,15 +203,11 @@ func (p *NTSProvider) FetchPlaylist(episodeExternalID string) ([]RadioPlayImport
 			title := track.Title
 			play.TrackTitle = &title
 		}
-		if track.Album != "" {
-			album := track.Album
-			play.AlbumTitle = &album
-		}
 
 		plays = append(plays, play)
 	}
 
-	// Re-number positions sequentially after any skipped entries
+	// Number positions sequentially (0-based) to match other providers.
 	for i := range plays {
 		plays[i].Position = i
 	}
@@ -213,6 +233,9 @@ func (p *NTSProvider) doGet(url string) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, errNTSNotFound
+	}
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("NTS API returned status %d: %s", resp.StatusCode, string(body))
@@ -361,19 +384,19 @@ type ntsEpisode struct {
 	DurationMinutes int      `json:"duration"`
 }
 
-type ntsEpisodeDetail struct {
-	Name            string          `json:"name"`
-	EpisodeAlias    string          `json:"episode_alias"`
-	Broadcast       string          `json:"broadcast"`
-	Mixcloud        string          `json:"mixcloud"`
-	GenreTags       []string        `json:"genre_tags"`
-	MoodTags        []string        `json:"mood_tags"`
-	DurationMinutes int             `json:"duration"`
-	Tracklist       []ntsTrackEntry `json:"tracklist"`
+// ntsTracklistResponse matches the JSON returned by
+// GET /v2/shows/{alias}/episodes/{ep_alias}/tracklist. NTS wraps the track
+// list in a "results" array with a metadata/resultset envelope.
+type ntsTracklistResponse struct {
+	Results []ntsTrackEntry `json:"results"`
 }
 
+// ntsTrackEntry represents a single track in an NTS episode tracklist.
+// Only artist and title are actually used -- offset/duration are seconds
+// within the episode (not wall-clock air times) so we don't populate
+// AirTimestamp from them. Album, label, and release year are not
+// available from the NTS tracklist endpoint.
 type ntsTrackEntry struct {
 	Artist string `json:"artist"`
 	Title  string `json:"title"`
-	Album  string `json:"album"`
 }

--- a/backend/internal/services/catalog/radio_provider_nts_test.go
+++ b/backend/internal/services/catalog/radio_provider_nts_test.go
@@ -115,42 +115,30 @@ const ntsEpisodeOlderJSON = `{
   ]
 }`
 
-const ntsEpisodeDetailWithTracklistJSON = `{
-  "name": "Huerco S. - March 2026",
-  "episode_alias": "march-2026",
-  "broadcast": "2026-03-15T20:00:00Z",
-  "mixcloud": "https://www.mixcloud.com/NTSRadio/huerco-s-15th-march-2026/",
-  "genre_tags": ["ambient", "experimental"],
-  "mood_tags": ["meditative", "nocturnal"],
-  "duration": 120,
-  "tracklist": [
-    {"artist": "Grouper", "title": "Holding", "album": "Dragging a Dead Deer Up a Hill"},
-    {"artist": "Stars of the Lid", "title": "Requiem for Dying Mothers, Part 2", "album": "The Tired Sounds of Stars of the Lid"},
-    {"artist": "Midori Takada", "title": "Mr. Henri Rousseau's Dream", "album": "Through the Looking Glass"},
-    {"artist": "Pauline Anna Strom", "title": "Trans-Millenia Consort", "album": "Trans-Millenia Music"},
-    {"artist": "Hiroshi Yoshimura", "title": "Creek", "album": "GREEN"}
+// ntsTracklistJSON is a realistic response from
+// GET /v2/shows/{alias}/episodes/{ep_alias}/tracklist. The real NTS API
+// wraps tracks in a `results` array under a metadata/resultset envelope.
+const ntsTracklistJSON = `{
+  "metadata": {
+    "resultset": {"count": 5}
+  },
+  "results": [
+    {"artist": "Grouper", "title": "Holding", "uid": "uid-1", "offset": 0, "duration": 240},
+    {"artist": "Stars of the Lid", "title": "Requiem for Dying Mothers, Part 2", "uid": "uid-2", "offset": 241, "duration": 600},
+    {"artist": "Midori Takada", "title": "Mr. Henri Rousseau's Dream", "uid": "uid-3", "offset": 842, "duration": 420},
+    {"artist": "Pauline Anna Strom", "title": "Trans-Millenia Consort", "uid": "uid-4", "offset": 1263, "duration": 360},
+    {"artist": "Hiroshi Yoshimura", "title": "Creek", "uid": "uid-5", "offset": 1624, "duration": 300}
   ]
 }`
 
-const ntsEpisodeDetailEmptyTracklistJSON = `{
-  "name": "Scratcha DVA - March 2026",
-  "episode_alias": "march-2026-mix",
-  "broadcast": "2026-03-20T22:00:00Z",
-  "mixcloud": "https://www.mixcloud.com/NTSRadio/scratcha-dva-20th-march-2026/",
-  "genre_tags": ["grime", "bass", "club"],
-  "mood_tags": ["energetic", "dark"],
-  "duration": 120,
-  "tracklist": []
-}`
-
-const ntsEpisodeDetailNoTracklistJSON = `{
-  "name": "Ambient Mix Session",
-  "episode_alias": "ambient-session",
-  "broadcast": "2026-03-10T18:00:00Z",
-  "mixcloud": "https://www.mixcloud.com/NTSRadio/ambient-session/",
-  "genre_tags": ["ambient"],
-  "mood_tags": ["meditative"],
-  "duration": 180
+// ntsEmptyTracklistJSON is what the tracklist endpoint returns for episodes
+// that have no tracklist entered (common for DJ mixes). It's a 200 response
+// with an empty results array.
+const ntsEmptyTracklistJSON = `{
+  "metadata": {
+    "resultset": {"count": 0}
+  },
+  "results": []
 }`
 
 const ntsEmptyShowsJSON = `{"results": []}`
@@ -335,7 +323,7 @@ func TestNTS_FetchNewEpisodes_StopsAtOldEpisodes(t *testing.T) {
 	since := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	episodes, err := provider.FetchNewEpisodes("huerco-s", since)
 	require.NoError(t, err)
-	// Should have 100 from page 1, and 0 from page 2 (old episode filtered)
+	// Should have ntsPageLimit from page 1, and 0 from page 2 (old episode filtered)
 	assert.Equal(t, ntsPageLimit, len(episodes))
 }
 
@@ -360,9 +348,12 @@ func TestNTS_FetchNewEpisodes_Empty(t *testing.T) {
 
 func TestNTS_FetchPlaylist_WithTracklist(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// FetchPlaylist must call the /tracklist sub-endpoint, not the
+		// episode detail endpoint — the latter does not include tracklist
+		// data and every import was coming back empty because of it.
+		assert.Equal(t, "/v2/shows/huerco-s/episodes/march-2026/tracklist", r.URL.Path)
 		w.Header().Set("Content-Type", "application/json")
-		assert.Equal(t, "/v2/shows/huerco-s/episodes/march-2026", r.URL.Path)
-		fmt.Fprint(w, ntsEpisodeDetailWithTracklistJSON)
+		fmt.Fprint(w, ntsTracklistJSON)
 	}))
 	defer server.Close()
 
@@ -379,17 +370,24 @@ func TestNTS_FetchPlaylist_WithTracklist(t *testing.T) {
 	assert.Equal(t, "Grouper", p0.ArtistName)
 	require.NotNil(t, p0.TrackTitle)
 	assert.Equal(t, "Holding", *p0.TrackTitle)
-	require.NotNil(t, p0.AlbumTitle)
-	assert.Equal(t, "Dragging a Dead Deer Up a Hill", *p0.AlbumTitle)
 
-	// No MusicBrainz IDs for NTS
+	// NTS tracklist endpoint exposes only artist + title -- no album, label,
+	// MusicBrainz IDs, release year, or wall-clock air timestamp. `offset`
+	// and `duration` are seconds within the episode audio, not times of day.
+	assert.Nil(t, p0.AlbumTitle)
+	assert.Nil(t, p0.LabelName)
+	assert.Nil(t, p0.ReleaseYear)
 	assert.Nil(t, p0.MusicBrainzArtistID)
 	assert.Nil(t, p0.MusicBrainzRecordingID)
 	assert.Nil(t, p0.MusicBrainzReleaseID)
+	assert.Nil(t, p0.AirTimestamp)
 
-	// No label or year data from NTS
-	assert.Nil(t, p0.LabelName)
-	assert.Nil(t, p0.ReleaseYear)
+	// Check middle track — verify position numbering
+	p2 := plays[2]
+	assert.Equal(t, 2, p2.Position)
+	assert.Equal(t, "Midori Takada", p2.ArtistName)
+	require.NotNil(t, p2.TrackTitle)
+	assert.Equal(t, "Mr. Henri Rousseau's Dream", *p2.TrackTitle)
 
 	// Check last track
 	p4 := plays[4]
@@ -397,14 +395,13 @@ func TestNTS_FetchPlaylist_WithTracklist(t *testing.T) {
 	assert.Equal(t, "Hiroshi Yoshimura", p4.ArtistName)
 	require.NotNil(t, p4.TrackTitle)
 	assert.Equal(t, "Creek", *p4.TrackTitle)
-	require.NotNil(t, p4.AlbumTitle)
-	assert.Equal(t, "GREEN", *p4.AlbumTitle)
 }
 
 func TestNTS_FetchPlaylist_EmptyTracklist(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v2/shows/scratcha-dva/episodes/march-2026-mix/tracklist", r.URL.Path)
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, ntsEpisodeDetailEmptyTracklistJSON)
+		fmt.Fprint(w, ntsEmptyTracklistJSON)
 	}))
 	defer server.Close()
 
@@ -417,10 +414,13 @@ func TestNTS_FetchPlaylist_EmptyTracklist(t *testing.T) {
 	assert.Len(t, plays, 0, "DJ mix episodes should return 0 plays")
 }
 
-func TestNTS_FetchPlaylist_NoTracklistField(t *testing.T) {
+// NTS returns 404 for episodes that have no tracklist at all (not just an
+// empty array). This is the normal case for DJ mixes and should not be
+// treated as an error.
+func TestNTS_FetchPlaylist_TracklistNotFound(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, ntsEpisodeDetailNoTracklistJSON)
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"detail": "Not found."}`)
 	}))
 	defer server.Close()
 
@@ -428,8 +428,8 @@ func TestNTS_FetchPlaylist_NoTracklistField(t *testing.T) {
 	defer provider.Close()
 
 	plays, err := provider.FetchPlaylist("ambient-show/ambient-session")
-	require.NoError(t, err)
-	assert.NotNil(t, plays, "missing tracklist field should return non-nil empty slice")
+	require.NoError(t, err, "404 on tracklist endpoint should not be an error")
+	assert.NotNil(t, plays, "404 should return non-nil empty slice")
 	assert.Len(t, plays, 0)
 }
 
@@ -437,20 +437,28 @@ func TestNTS_FetchPlaylist_InvalidExternalID(t *testing.T) {
 	provider := NewNTSProviderWithClient(&http.Client{}, "http://localhost")
 	defer provider.Close()
 
-	_, err := provider.FetchPlaylist("invalid-no-slash")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid episode external ID format")
+	cases := []string{
+		"invalid-no-slash",
+		"",
+		"show-only/",
+		"/ep-only",
+	}
+	for _, id := range cases {
+		_, err := provider.FetchPlaylist(id)
+		assert.Error(t, err, "expected error for %q", id)
+		if err != nil {
+			assert.Contains(t, err.Error(), "invalid episode external ID format")
+		}
+	}
 }
 
 func TestNTS_FetchPlaylist_SkipsEmptyArtist(t *testing.T) {
 	tracklistJSON := `{
-		"name": "Test Episode",
-		"episode_alias": "test",
-		"broadcast": "2026-03-15T20:00:00Z",
-		"tracklist": [
-			{"artist": "Grouper", "title": "Holding", "album": ""},
-			{"artist": "", "title": "Unknown Track", "album": ""},
-			{"artist": "Stars of the Lid", "title": "Requiem", "album": ""}
+		"metadata": {"resultset": {"count": 3}},
+		"results": [
+			{"artist": "Grouper", "title": "Holding"},
+			{"artist": "", "title": "Unknown Track"},
+			{"artist": "Stars of the Lid", "title": "Requiem"}
 		]
 	}`
 
@@ -655,7 +663,7 @@ func TestNTS_MalformedJSON_FetchPlaylist(t *testing.T) {
 
 	_, err := provider.FetchPlaylist("show/ep")
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "parsing episode detail")
+	assert.Contains(t, err.Error(), "parsing tracklist response")
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

**Critical bug fix**: Every NTS episode currently imported has zero plays. `FetchPlaylist` was reading `detail.Tracklist` from the episode detail endpoint, but that field is never populated — NTS serves tracklists from a separate sub-endpoint:

\`\`\`
GET /v2/shows/{show-alias}/episodes/{ep-alias}/tracklist
\`\`\`

## Changes

- `FetchPlaylist` now calls the correct `/tracklist` sub-endpoint
- Added `errNTSNotFound` sentinel; 404 responses (common for DJ mix episodes) return an empty slice, not an error
- Tightened external-ID validation to reject `\"\"`, `\"show/\"`, `\"/ep\"` in addition to the no-slash case
- Tracks now map only `artist` → `ArtistName` and `title` → `TrackTitle`. Album, label, year, and MusicBrainz IDs are not exposed by the tracklist endpoint and are left nil
- Dropped unused `ntsEpisodeDetail` type, added `ntsTracklistResponse` envelope type matching the real API
- `ntsPageLimit` changed from `100` to `12` — the `/episodes` endpoint silently caps at 12 regardless of requested limit

## Follow-up needed

Existing NTS plays in the database are all empty (zero tracks). After this merges, re-importing via the PSY-273 async job system will populate them correctly.

## Verification

- `go build ./...` clean
- `go vet ./internal/services/catalog/...` clean
- `go test ./internal/services/catalog/ -run NTS -count=1` — all 27 NTS tests pass
- Live API sanity check: `https://www.nts.live/api/v2/shows/foodman/episodes/foodman-1st-january-2026/tracklist` returned 25 real tracks matching the envelope schema

## Test plan

- [ ] Unit tests pass (27 NTS tests)
- [ ] Manual: import an NTS episode and verify non-zero tracks
- [ ] Verify 404-on-tracklist returns empty slice without error

Closes PSY-276

🤖 Generated with [Claude Code](https://claude.com/claude-code)