### PR TITLE
Fix KEXP FetchPlaylist to use time-range filtering

### DIFF
--- a/backend/internal/services/catalog/radio_provider_kexp.go
+++ b/backend/internal/services/catalog/radio_provider_kexp.go
@@ -145,13 +145,65 @@ func (p *KEXPProvider) FetchNewEpisodes(showExternalID string, since time.Time) 
 	return allEpisodes, nil
 }
 
+// kexpPlaylistWindow is the upper bound added to a broadcast's start_time when
+// querying the KEXP plays endpoint. KEXP "shows" (broadcasts) expose start_time
+// but no end_time, and programs are typically 1–4 hours long. 5 hours gives a
+// small safety buffer for shows that run long without encroaching far into the
+// next broadcast's playlist.
+const kexpPlaylistWindow = 5 * time.Hour
+
 // FetchPlaylist returns track plays for a KEXP "show" (episode).
+//
+// KEXP's /v2/plays endpoint does NOT support a show_id filter — passing one is
+// silently ignored and every request returns the global plays list. Instead we
+// filter by broadcast time window using airdate_after/airdate_before:
+//
+//  1. GET /v2/shows/{id}/ to resolve the broadcast's start_time.
+//  2. Compute [start_time, start_time + kexpPlaylistWindow] as the bounds.
+//  3. GET /v2/plays/?airdate_after=...&airdate_before=...&play_type=trackplay
+//     and paginate via the `next` cursor.
+//
+// If the broadcast is not found (404) we return an empty playlist rather than
+// an error so callers can continue processing other episodes.
 func (p *KEXPProvider) FetchPlaylist(episodeExternalID string) ([]RadioPlayImport, error) {
+	// Step 1: fetch the broadcast to get its start_time.
+	showDetailURL := fmt.Sprintf("%s/v2/shows/%s/", p.baseURL, episodeExternalID)
+
+	<-p.rateLimiter.C
+	resp, err := p.doGet(showDetailURL)
+	if err != nil {
+		// KEXP returned a non-200 (including 404 for missing broadcasts) —
+		// treat as "no plays" so the import pipeline can continue.
+		if strings.Contains(err.Error(), "status 404") {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("fetching show detail: %w", err)
+	}
+
+	var show kexpShow
+	if err := json.Unmarshal(resp, &show); err != nil {
+		return nil, fmt.Errorf("parsing show detail response: %w", err)
+	}
+
+	if show.StartTime == "" {
+		return nil, nil
+	}
+
+	startTime, err := time.Parse(time.RFC3339, show.StartTime)
+	if err != nil {
+		return nil, fmt.Errorf("parsing show start_time %q: %w", show.StartTime, err)
+	}
+	endTime := startTime.Add(kexpPlaylistWindow)
+
+	// Step 2: fetch plays filtered by the broadcast's time window.
 	var allPlays []RadioPlayImport
 	position := 0
 
-	url := fmt.Sprintf("%s/v2/plays/?show_id=%s&limit=100&ordering=airdate",
-		p.baseURL, episodeExternalID)
+	url := fmt.Sprintf("%s/v2/plays/?airdate_after=%s&airdate_before=%s&play_type=trackplay&limit=100&ordering=airdate",
+		p.baseURL,
+		startTime.UTC().Format(time.RFC3339),
+		endTime.UTC().Format(time.RFC3339),
+	)
 
 	for url != "" {
 		<-p.rateLimiter.C
@@ -167,7 +219,8 @@ func (p *KEXPProvider) FetchPlaylist(episodeExternalID string) ([]RadioPlayImpor
 		}
 
 		for _, kPlay := range page.Results {
-			// Only import track plays, skip airbreaks, station IDs, etc.
+			// Defensive: filter again even though the API was asked to return
+			// only trackplays, in case future API changes relax that filter.
 			if kPlay.PlayType != "trackplay" {
 				continue
 			}

--- a/backend/internal/services/catalog/radio_provider_test.go
+++ b/backend/internal/services/catalog/radio_provider_test.go
@@ -300,26 +300,38 @@ func TestKEXPProvider_FetchNewEpisodes(t *testing.T) {
 }
 
 func TestKEXPProvider_FetchPlaylist(t *testing.T) {
+	var playsRequestQuery string
+
 	mux := http.NewServeMux()
+	// Show detail endpoint — called first to resolve start_time.
+	mux.HandleFunc("/v2/shows/5678/", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"id":           5678,
+			"program_id":   42,
+			"program_name": "The Morning Show",
+			"start_time":   "2026-01-15T06:00:00-08:00",
+		})
+	})
 	mux.HandleFunc("/v2/plays/", func(w http.ResponseWriter, r *http.Request) {
+		playsRequestQuery = r.URL.RawQuery
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"next":  nil,
 			"count": 3,
 			"results": []map[string]interface{}{
 				{
-					"id":                      1,
-					"play_type":               "trackplay",
-					"airdate":                 "2026-01-15T06:05:00-08:00",
-					"artist":                  "Radiohead",
-					"song":                    "Everything In Its Right Place",
-					"album":                   "Kid A",
-					"label_name":              "Parlophone",
-					"release_date":            "2000-10-02",
-					"rotation_status":         "library",
-					"is_new":                  false,
-					"is_live":                 false,
-					"is_request":              false,
-					"musicbrainz_artist_id":   "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+					"id":                    1,
+					"play_type":             "trackplay",
+					"airdate":               "2026-01-15T06:05:00-08:00",
+					"artist":                "Radiohead",
+					"song":                  "Everything In Its Right Place",
+					"album":                 "Kid A",
+					"label_name":            "Parlophone",
+					"release_date":          "2000-10-02",
+					"rotation_status":       "library",
+					"is_new":                false,
+					"is_live":               false,
+					"is_request":            false,
+					"musicbrainz_artist_id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
 				},
 				{
 					"id":        2,
@@ -351,6 +363,23 @@ func TestKEXPProvider_FetchPlaylist(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, plays, 2) // Airbreak skipped
 
+	// Verify the plays request used time-range filtering instead of show_id.
+	assert.NotContains(t, playsRequestQuery, "show_id",
+		"plays request must not include show_id (silently ignored by KEXP)")
+	assert.NotContains(t, playsRequestQuery, "show=",
+		"plays request must not include show= (silently ignored by KEXP)")
+	assert.Contains(t, playsRequestQuery, "airdate_after=",
+		"plays request must filter by airdate_after")
+	assert.Contains(t, playsRequestQuery, "airdate_before=",
+		"plays request must filter by airdate_before")
+	assert.Contains(t, playsRequestQuery, "play_type=trackplay",
+		"plays request must filter to trackplay entries only")
+	// airdate_after should match the show start_time (UTC). The broadcast
+	// starts at 2026-01-15T06:00:00-08:00 which is 2026-01-15T14:00:00Z.
+	assert.Contains(t, playsRequestQuery, "airdate_after=2026-01-15T14:00:00Z")
+	// airdate_before should be 5 hours later: 2026-01-15T19:00:00Z.
+	assert.Contains(t, playsRequestQuery, "airdate_before=2026-01-15T19:00:00Z")
+
 	// First play
 	assert.Equal(t, 0, plays[0].Position)
 	assert.Equal(t, "Radiohead", plays[0].ArtistName)
@@ -371,6 +400,12 @@ func TestKEXPProvider_FetchPlaylist(t *testing.T) {
 
 func TestKEXPProvider_FetchPlaylist_OnlyTrackPlays(t *testing.T) {
 	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/shows/1234/", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"id":         1234,
+			"start_time": "2026-01-15T06:00:00Z",
+		})
+	})
 	mux.HandleFunc("/v2/plays/", func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"next":  nil,
@@ -394,6 +429,125 @@ func TestKEXPProvider_FetchPlaylist_OnlyTrackPlays(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, plays, 1) // Only the trackplay
 	assert.Equal(t, "The National", plays[0].ArtistName)
+}
+
+func TestKEXPProvider_FetchPlaylist_EmptyPlays(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/shows/9999/", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"id":         9999,
+			"start_time": "2026-01-15T06:00:00Z",
+		})
+	})
+	mux.HandleFunc("/v2/plays/", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"next":    nil,
+			"count":   0,
+			"results": []map[string]interface{}{},
+		})
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	provider := NewKEXPProviderWithClient(server.Client(), server.URL)
+	defer provider.Close()
+
+	plays, err := provider.FetchPlaylist("9999")
+
+	require.NoError(t, err)
+	assert.Empty(t, plays)
+}
+
+func TestKEXPProvider_FetchPlaylist_ShowNotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/shows/404/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"detail":"Not found."}`))
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	provider := NewKEXPProviderWithClient(server.Client(), server.URL)
+	defer provider.Close()
+
+	plays, err := provider.FetchPlaylist("404")
+
+	require.NoError(t, err, "404 on show detail should return empty slice, not error")
+	assert.Empty(t, plays)
+}
+
+func TestKEXPProvider_FetchPlaylist_Pagination(t *testing.T) {
+	playsCallCount := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/shows/5678/", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"id":         5678,
+			"start_time": "2026-01-15T06:00:00Z",
+		})
+	})
+
+	var server *httptest.Server
+	mux.HandleFunc("/v2/plays/", func(w http.ResponseWriter, r *http.Request) {
+		playsCallCount++
+		if playsCallCount == 1 {
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"next":  fmt.Sprintf("%s/v2/plays/?cursor=page2", server.URL),
+				"count": 3,
+				"results": []map[string]interface{}{
+					{
+						"id":        1,
+						"play_type": "trackplay",
+						"airdate":   "2026-01-15T06:05:00Z",
+						"artist":    "Radiohead",
+						"song":      "Idioteque",
+					},
+					{
+						"id":        2,
+						"play_type": "trackplay",
+						"airdate":   "2026-01-15T06:10:00Z",
+						"artist":    "Deerhunter",
+						"song":      "Desire Lines",
+					},
+				},
+			})
+		} else {
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"next":  nil,
+				"count": 3,
+				"results": []map[string]interface{}{
+					{
+						"id":        3,
+						"play_type": "trackplay",
+						"airdate":   "2026-01-15T06:15:00Z",
+						"artist":    "The National",
+						"song":      "Bloodbuzz Ohio",
+					},
+				},
+			})
+		}
+	})
+
+	server = httptest.NewServer(mux)
+	defer server.Close()
+
+	provider := NewKEXPProviderWithClient(server.Client(), server.URL)
+	defer provider.Close()
+
+	plays, err := provider.FetchPlaylist("5678")
+
+	require.NoError(t, err)
+	assert.Len(t, plays, 3)
+	assert.Equal(t, 2, playsCallCount, "should follow pagination cursor")
+
+	// Positions should be sequential across pages.
+	assert.Equal(t, 0, plays[0].Position)
+	assert.Equal(t, "Radiohead", plays[0].ArtistName)
+	assert.Equal(t, 1, plays[1].Position)
+	assert.Equal(t, "Deerhunter", plays[1].ArtistName)
+	assert.Equal(t, 2, plays[2].Position)
+	assert.Equal(t, "The National", plays[2].ArtistName)
 }
 
 func TestKEXPProvider_HTTPError(t *testing.T) {
@@ -703,8 +857,20 @@ func (suite *RadioImportIntegrationTestSuite) TestImportStation_Success() {
 		})
 	})
 
-	// Mock shows (episodes)
+	// Mock shows (episodes) — handles both list and detail-by-ID requests.
 	mux.HandleFunc("/v2/shows/", func(w http.ResponseWriter, r *http.Request) {
+		// Detail-by-ID: /v2/shows/100/ used by FetchPlaylist.
+		if r.URL.Path == "/v2/shows/100/" {
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":           100,
+				"program_id":   42,
+				"program_name": "The Morning Show",
+				"start_time":   "2026-01-15T06:00:00-08:00",
+				"end_time":     "2026-01-15T10:00:00-08:00",
+			})
+			return
+		}
+		// List: /v2/shows/?program_id=... used by FetchNewEpisodes.
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"next": nil, "count": 1,
 			"results": []map[string]interface{}{


### PR DESCRIPTION
## Summary

**Critical bug fix**: KEXP's `FetchPlaylist` was passing a `show_id=` query parameter which is **silently ignored by the KEXP API**. Every call returned the same global plays list, not the plays for the requested broadcast. Every KEXP episode currently has incorrect play data.

## Fix approach

KEXP's `/v2/plays/` endpoint supports filtering by time range via `airdate_after` and `airdate_before`. The fix:

1. First fetch the show (broadcast) via `/v2/shows/{id}/` to get its `start_time`
2. Compute a window `[start_time, start_time + 5h]` — KEXP programs are typically 1-4 hours; 5h gives a safety buffer without leaking into the next broadcast
3. Query plays with `airdate_after` + `airdate_before` + `play_type=trackplay`
4. Follow the `next` cursor for pagination

The 5-hour window is documented in a block comment in `FetchPlaylist` explaining the choice and tradeoff. A 404 on show detail returns an empty slice (not an error) so the import pipeline keeps going.

## Follow-up needed

Existing KEXP plays in the database are all wrong (contain the global plays list, not per-episode data). After this merges, re-importing via the PSY-273 async job system will populate them correctly.

## Verification

- `go build ./...` clean
- `go vet ./internal/services/catalog/...` clean
- `go test ./internal/services/catalog/ -run KEXP -count=1` — all 13 KEXP tests pass
- Full catalog test suite passes (21.5s, includes testcontainers)

New tests verify:
- Request does NOT contain `show_id` or `show=`
- Request DOES contain `airdate_after`, `airdate_before`, `play_type=trackplay`
- Empty plays response returns empty slice
- 404 on show detail returns empty slice
- Pagination follows `next` cursor correctly

## Test plan

- [ ] Unit tests pass (13 KEXP tests)
- [ ] Integration tests pass (testcontainer-based)
- [ ] Manual: import a KEXP episode and verify tracks are per-episode, not global

Closes PSY-277

🤖 Generated with [Claude Code](https://claude.com/claude-code)