### PR TITLE
Surface collections on entity detail pages and user profiles

### DIFF
--- a/backend/internal/api/handlers/collection.go
+++ b/backend/internal/api/handlers/collection.go
@@ -679,6 +679,93 @@ func (h *CollectionHandler) GetUserCollectionsHandler(ctx context.Context, req *
 }
 
 // ============================================================================
+// Get Entity Collections
+// ============================================================================
+
+// GetEntityCollectionsHandlerRequest represents the request for getting collections containing an entity
+type GetEntityCollectionsHandlerRequest struct {
+	EntityType string `path:"entity_type" doc:"Entity type (artist, release, label, show, venue, festival)" example:"artist"`
+	EntityID   string `path:"entity_id" doc:"Entity ID" example:"42"`
+	Limit      int    `query:"limit" required:"false" doc:"Max results (default 10)" example:"10"`
+}
+
+// GetEntityCollectionsHandlerResponse represents the response for entity collections
+type GetEntityCollectionsHandlerResponse struct {
+	Body struct {
+		Collections []*contracts.CollectionListResponse `json:"crates" doc:"List of crates containing this entity"`
+	}
+}
+
+// GetEntityCollectionsHandler handles GET /collections/entity/{entity_type}/{entity_id}
+func (h *CollectionHandler) GetEntityCollectionsHandler(ctx context.Context, req *GetEntityCollectionsHandlerRequest) (*GetEntityCollectionsHandlerResponse, error) {
+	entityID, err := strconv.ParseUint(req.EntityID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid entity ID")
+	}
+
+	validTypes := map[string]bool{
+		"artist": true, "release": true, "label": true,
+		"show": true, "venue": true, "festival": true,
+	}
+	if !validTypes[req.EntityType] {
+		return nil, huma.Error400BadRequest("Invalid entity type")
+	}
+
+	limit := req.Limit
+	if limit <= 0 {
+		limit = 10
+	}
+
+	collections, err := h.collectionService.GetEntityCollections(req.EntityType, uint(entityID), limit)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Failed to fetch entity collections", err)
+	}
+
+	resp := &GetEntityCollectionsHandlerResponse{}
+	resp.Body.Collections = collections
+
+	return resp, nil
+}
+
+// ============================================================================
+// Get User Public Collections
+// ============================================================================
+
+// GetUserPublicCollectionsHandlerRequest represents the request for getting a user's public collections
+type GetUserPublicCollectionsHandlerRequest struct {
+	Username string `path:"username" doc:"Username" example:"johndoe"`
+	Limit    int    `query:"limit" required:"false" doc:"Max results (default 20)" example:"20"`
+	Offset   int    `query:"offset" required:"false" doc:"Offset for pagination" example:"0"`
+}
+
+// GetUserPublicCollectionsHandlerResponse represents the response for user public collections
+type GetUserPublicCollectionsHandlerResponse struct {
+	Body struct {
+		Collections []*contracts.CollectionListResponse `json:"crates" doc:"List of user's public crates"`
+		Total       int64                              `json:"total" doc:"Total number of public crates"`
+	}
+}
+
+// GetUserPublicCollectionsHandler handles GET /users/{username}/collections
+func (h *CollectionHandler) GetUserPublicCollectionsHandler(ctx context.Context, req *GetUserPublicCollectionsHandlerRequest) (*GetUserPublicCollectionsHandlerResponse, error) {
+	limit := req.Limit
+	if limit <= 0 {
+		limit = 20
+	}
+
+	collections, total, err := h.collectionService.GetUserPublicCollectionsByUsername(req.Username, limit, req.Offset)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Failed to fetch user collections", err)
+	}
+
+	resp := &GetUserPublicCollectionsHandlerResponse{}
+	resp.Body.Collections = collections
+	resp.Body.Total = total
+
+	return resp, nil
+}
+
+// ============================================================================
 // Helpers
 // ============================================================================
 

--- a/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
+++ b/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
@@ -675,6 +675,9 @@ type mockCollectionService struct {
 	markVisitedFn func(string, uint) (error)
 	getStatsFn func(string) (*contracts.CollectionStatsResponse, error)
 	getUserCollectionsFn func(uint, int, int) ([]*contracts.CollectionListResponse, int64, error)
+	getEntityCollectionsFn func(string, uint, int) ([]*contracts.CollectionListResponse, error)
+	getUserPublicCollectionsFn func(uint, int, int) ([]*contracts.CollectionListResponse, int64, error)
+	getUserPublicCollectionsByUsernameFn func(string, int, int) ([]*contracts.CollectionListResponse, int64, error)
 	setFeaturedFn func(string, bool) (error)
 }
 
@@ -759,6 +762,24 @@ func (m *mockCollectionService) GetStats(slug string) (*contracts.CollectionStat
 func (m *mockCollectionService) GetUserCollections(userID uint, limit int, offset int) ([]*contracts.CollectionListResponse, int64, error) {
 	if m.getUserCollectionsFn != nil {
 		return m.getUserCollectionsFn(userID, limit, offset)
+	}
+	return nil, 0, nil
+}
+func (m *mockCollectionService) GetEntityCollections(entityType string, entityID uint, limit int) ([]*contracts.CollectionListResponse, error) {
+	if m.getEntityCollectionsFn != nil {
+		return m.getEntityCollectionsFn(entityType, entityID, limit)
+	}
+	return nil, nil
+}
+func (m *mockCollectionService) GetUserPublicCollections(userID uint, limit int, offset int) ([]*contracts.CollectionListResponse, int64, error) {
+	if m.getUserPublicCollectionsFn != nil {
+		return m.getUserPublicCollectionsFn(userID, limit, offset)
+	}
+	return nil, 0, nil
+}
+func (m *mockCollectionService) GetUserPublicCollectionsByUsername(username string, limit int, offset int) ([]*contracts.CollectionListResponse, int64, error) {
+	if m.getUserPublicCollectionsByUsernameFn != nil {
+		return m.getUserPublicCollectionsByUsernameFn(username, limit, offset)
 	}
 	return nil, 0, nil
 }

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -704,6 +704,14 @@ func setupCollectionRoutes(rc RouteContext) {
 	// Admin: feature/unfeature crates — legacy /collections/ paths (backward compat)
 	huma.Put(rc.Protected, "/collections/{slug}/feature", collectionHandler.SetFeaturedHandler)
 
+	// Entity collections — public, find collections containing a given entity
+	huma.Get(optionalAuthGroup, "/crates/entity/{entity_type}/{entity_id}", collectionHandler.GetEntityCollectionsHandler)
+	huma.Get(optionalAuthGroup, "/collections/entity/{entity_type}/{entity_id}", collectionHandler.GetEntityCollectionsHandler)
+
+	// User's public collections — public, for profile pages
+	huma.Get(optionalAuthGroup, "/users/{username}/crates", collectionHandler.GetUserPublicCollectionsHandler)
+	huma.Get(optionalAuthGroup, "/users/{username}/collections", collectionHandler.GetUserPublicCollectionsHandler)
+
 	// User's own crates (created + subscribed)
 	huma.Get(rc.Protected, "/auth/crates", collectionHandler.GetUserCollectionsHandler)
 

--- a/backend/internal/services/collection.go
+++ b/backend/internal/services/collection.go
@@ -755,6 +755,160 @@ func (s *CollectionService) GetUserCollections(userID uint, limit, offset int) (
 	return responses, total, nil
 }
 
+// GetEntityCollections returns public collections that contain the given entity
+func (s *CollectionService) GetEntityCollections(entityType string, entityID uint, limit int) ([]*contracts.CollectionListResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	if limit <= 0 {
+		limit = 10
+	}
+
+	// Find collection IDs that contain this entity (public collections only)
+	var collectionIDs []uint
+	err := s.db.Model(&models.CollectionItem{}).
+		Select("DISTINCT collection_items.collection_id").
+		Joins("JOIN collections ON collections.id = collection_items.collection_id").
+		Where("collection_items.entity_type = ? AND collection_items.entity_id = ? AND collections.is_public = ?", entityType, entityID, true).
+		Limit(limit).
+		Pluck("collection_items.collection_id", &collectionIDs).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to find entity collections: %w", err)
+	}
+
+	if len(collectionIDs) == 0 {
+		return []*contracts.CollectionListResponse{}, nil
+	}
+
+	var collections []models.Collection
+	if err := s.db.Where("id IN ?", collectionIDs).Order("updated_at DESC").Find(&collections).Error; err != nil {
+		return nil, fmt.Errorf("failed to load entity collections: %w", err)
+	}
+
+	// Batch-load counts and creator names
+	creatorIDs := make([]uint, 0)
+	creatorIDSet := make(map[uint]bool)
+	for _, c := range collections {
+		if !creatorIDSet[c.CreatorID] {
+			creatorIDs = append(creatorIDs, c.CreatorID)
+			creatorIDSet[c.CreatorID] = true
+		}
+	}
+
+	itemCounts := s.batchCountItems(collectionIDs)
+	subscriberCounts := s.batchCountSubscribers(collectionIDs)
+	contributorCounts := s.batchCountContributors(collectionIDs)
+	creatorNames := s.batchResolveUserNames(creatorIDs)
+
+	responses := make([]*contracts.CollectionListResponse, len(collections))
+	for i, c := range collections {
+		responses[i] = &contracts.CollectionListResponse{
+			ID:               c.ID,
+			Title:            c.Title,
+			Slug:             c.Slug,
+			Description:      c.Description,
+			CreatorID:        c.CreatorID,
+			CreatorName:      creatorNames[c.CreatorID],
+			Collaborative:    c.Collaborative,
+			CoverImageURL:    c.CoverImageURL,
+			IsPublic:         c.IsPublic,
+			IsFeatured:       c.IsFeatured,
+			ItemCount:        itemCounts[c.ID],
+			SubscriberCount:  subscriberCounts[c.ID],
+			ContributorCount: contributorCounts[c.ID],
+			CreatedAt:        c.CreatedAt,
+			UpdatedAt:        c.UpdatedAt,
+		}
+	}
+
+	return responses, nil
+}
+
+// GetUserPublicCollections returns public collections created by a specific user
+func (s *CollectionService) GetUserPublicCollections(userID uint, limit, offset int) ([]*contracts.CollectionListResponse, int64, error) {
+	if s.db == nil {
+		return nil, 0, fmt.Errorf("database not initialized")
+	}
+
+	if limit <= 0 {
+		limit = 20
+	}
+
+	query := s.db.Model(&models.Collection{}).
+		Where("creator_id = ? AND is_public = ?", userID, true)
+
+	var total int64
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, fmt.Errorf("failed to count user public collections: %w", err)
+	}
+
+	var collections []models.Collection
+	if err := query.Order("updated_at DESC").Limit(limit).Offset(offset).Find(&collections).Error; err != nil {
+		return nil, 0, fmt.Errorf("failed to get user public collections: %w", err)
+	}
+
+	if len(collections) == 0 {
+		return []*contracts.CollectionListResponse{}, total, nil
+	}
+
+	collectionIDs := make([]uint, len(collections))
+	creatorIDs := make([]uint, 0)
+	creatorIDSet := make(map[uint]bool)
+	for i, c := range collections {
+		collectionIDs[i] = c.ID
+		if !creatorIDSet[c.CreatorID] {
+			creatorIDs = append(creatorIDs, c.CreatorID)
+			creatorIDSet[c.CreatorID] = true
+		}
+	}
+
+	itemCounts := s.batchCountItems(collectionIDs)
+	subscriberCounts := s.batchCountSubscribers(collectionIDs)
+	contributorCounts := s.batchCountContributors(collectionIDs)
+	creatorNames := s.batchResolveUserNames(creatorIDs)
+
+	responses := make([]*contracts.CollectionListResponse, len(collections))
+	for i, c := range collections {
+		responses[i] = &contracts.CollectionListResponse{
+			ID:               c.ID,
+			Title:            c.Title,
+			Slug:             c.Slug,
+			Description:      c.Description,
+			CreatorID:        c.CreatorID,
+			CreatorName:      creatorNames[c.CreatorID],
+			Collaborative:    c.Collaborative,
+			CoverImageURL:    c.CoverImageURL,
+			IsPublic:         c.IsPublic,
+			IsFeatured:       c.IsFeatured,
+			ItemCount:        itemCounts[c.ID],
+			SubscriberCount:  subscriberCounts[c.ID],
+			ContributorCount: contributorCounts[c.ID],
+			CreatedAt:        c.CreatedAt,
+			UpdatedAt:        c.UpdatedAt,
+		}
+	}
+
+	return responses, total, nil
+}
+
+// GetUserPublicCollectionsByUsername returns public collections by username lookup
+func (s *CollectionService) GetUserPublicCollectionsByUsername(username string, limit, offset int) ([]*contracts.CollectionListResponse, int64, error) {
+	if s.db == nil {
+		return nil, 0, fmt.Errorf("database not initialized")
+	}
+
+	// Look up user by username
+	var user models.User
+	err := s.db.Where("username = ?", username).First(&user).Error
+	if err != nil {
+		// User not found - return empty
+		return []*contracts.CollectionListResponse{}, 0, nil
+	}
+
+	return s.GetUserPublicCollections(user.ID, limit, offset)
+}
+
 // SetFeatured sets or unsets the featured flag on a collection
 func (s *CollectionService) SetFeatured(slug string, featured bool) error {
 	if s.db == nil {

--- a/backend/internal/services/contracts/collection.go
+++ b/backend/internal/services/contracts/collection.go
@@ -134,5 +134,8 @@ type CollectionServiceInterface interface {
 	MarkVisited(slug string, userID uint) error
 	GetStats(slug string) (*CollectionStatsResponse, error)
 	GetUserCollections(userID uint, limit, offset int) ([]*CollectionListResponse, int64, error)
+	GetEntityCollections(entityType string, entityID uint, limit int) ([]*CollectionListResponse, error)
+	GetUserPublicCollections(userID uint, limit, offset int) ([]*CollectionListResponse, int64, error)
+	GetUserPublicCollectionsByUsername(username string, limit, offset int) ([]*CollectionListResponse, int64, error)
 	SetFeatured(slug string, featured bool) error
 }

--- a/frontend/components/contributor/PublicProfile.tsx
+++ b/frontend/components/contributor/PublicProfile.tsx
@@ -13,6 +13,7 @@ import {
   usePublicProfile,
   usePublicContributions,
 } from '@/features/auth'
+import { UserCollections } from '@/features/collections'
 
 function formatDate(dateString: string): string {
   return new Date(dateString).toLocaleDateString('en-US', {
@@ -227,6 +228,12 @@ export function PublicProfile({ username }: PublicProfileProps) {
           <ProfileSections sections={profile.sections} />
         </section>
       )}
+
+      {/* Collections */}
+      <section className="mb-8">
+        <h2 className="text-lg font-semibold mb-4">Collections</h2>
+        <UserCollections username={username} />
+      </section>
 
       {/* Empty state when profile is public but has no content */}
       {!showStats && !showContributions && !showSections && profile.stats_count === undefined && (

--- a/frontend/features/artists/components/ArtistDetail.tsx
+++ b/frontend/features/artists/components/ArtistDetail.tsx
@@ -38,6 +38,7 @@ import { EntityTagList } from '@/features/tags'
 import { ArtistEditForm } from '@/components/forms/ArtistEditForm'
 import { EntityEditDrawer, AttributionLine, ReportEntityDialog, ContributionPrompt } from '@/features/contributions'
 import { AsHeardOn } from '@/features/radio'
+import { EntityCollections } from '@/features/collections'
 import { NotifyMeButton } from '@/features/notifications'
 import { ArtistShowsList } from './ArtistShowsList'
 import { RelatedArtists } from './RelatedArtists'
@@ -402,6 +403,9 @@ function ArtistSidebar({
 
       {/* As Heard On (radio) */}
       <AsHeardOn entityType="artist" entitySlug={artist.slug} />
+
+      {/* In Collections */}
+      <EntityCollections entityType="artist" entityId={artist.id} />
     </div>
   )
 }

--- a/frontend/features/collections/components/EntityCollections.tsx
+++ b/frontend/features/collections/components/EntityCollections.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import Link from 'next/link'
+import { Library, Users } from 'lucide-react'
+import { useEntityCollections } from '../hooks'
+import type { Collection } from '../types'
+
+interface EntityCollectionsProps {
+  entityType: string
+  entityId: number
+  enabled?: boolean
+}
+
+function CollectionsList({ collections }: { collections: Collection[] }) {
+  if (collections.length === 0) return null
+
+  return (
+    <div>
+      <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+        In Collections
+      </h3>
+      <div className="space-y-2">
+        {collections.map(collection => (
+          <Link
+            key={collection.id}
+            href={`/collections/${collection.slug}`}
+            className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors py-0.5 group"
+          >
+            <Library className="h-3.5 w-3.5 shrink-0 text-muted-foreground/60 group-hover:text-foreground" />
+            <div className="flex-1 min-w-0">
+              <span className="truncate block">{collection.title}</span>
+              <span className="text-xs text-muted-foreground/60">
+                by {collection.creator_name}
+                {collection.subscriber_count > 0 && (
+                  <>
+                    {' '}&middot; {collection.subscriber_count}{' '}
+                    {collection.subscriber_count === 1 ? 'subscriber' : 'subscribers'}
+                  </>
+                )}
+              </span>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export function EntityCollections({
+  entityType,
+  entityId,
+  enabled = true,
+}: EntityCollectionsProps) {
+  const { data, isLoading } = useEntityCollections(entityType, entityId, {
+    enabled,
+  })
+
+  const collections = data?.collections ?? []
+
+  if (isLoading || collections.length === 0) return null
+
+  return <CollectionsList collections={collections} />
+}

--- a/frontend/features/collections/components/UserCollections.tsx
+++ b/frontend/features/collections/components/UserCollections.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import { Library } from 'lucide-react'
+import { useUserPublicCollections } from '../hooks'
+import { CollectionCard } from './CollectionCard'
+import { Card, CardContent } from '@/components/ui/card'
+
+interface UserCollectionsProps {
+  username: string
+}
+
+export function UserCollections({ username }: UserCollectionsProps) {
+  const { data, isLoading } = useUserPublicCollections(username)
+
+  const collections = data?.collections ?? []
+
+  if (isLoading) return null
+
+  if (collections.length === 0) {
+    return (
+      <Card className="bg-muted/30 border-border/50">
+        <CardContent className="p-6 text-center">
+          <Library className="h-8 w-8 text-muted-foreground/40 mx-auto mb-2" />
+          <p className="text-sm text-muted-foreground">
+            No collections yet
+          </p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      {collections.map(collection => (
+        <CollectionCard key={collection.id} collection={collection} />
+      ))}
+    </div>
+  )
+}

--- a/frontend/features/collections/components/index.ts
+++ b/frontend/features/collections/components/index.ts
@@ -1,3 +1,5 @@
 export { CollectionCard } from './CollectionCard'
 export { CollectionDetail } from './CollectionDetail'
 export { CollectionList } from './CollectionList'
+export { EntityCollections } from './EntityCollections'
+export { UserCollections } from './UserCollections'

--- a/frontend/features/collections/hooks/index.ts
+++ b/frontend/features/collections/hooks/index.ts
@@ -295,3 +295,41 @@ export function useUnsubscribeCollection() {
     },
   })
 }
+
+/** Fetch public collections containing a specific entity */
+export function useEntityCollections(
+  entityType: string,
+  entityId: number,
+  options?: { enabled?: boolean }
+) {
+  return useQuery({
+    queryKey: queryKeys.collections.entity(entityType, entityId),
+    queryFn: () =>
+      apiRequest<{ crates: Collection[]; }>(
+        API_ENDPOINTS.COLLECTIONS.ENTITY(entityType, entityId)
+      ).then((data) => ({
+        collections: data.crates ?? [],
+      })),
+    enabled: (options?.enabled ?? true) && entityId > 0,
+    staleTime: 5 * 60 * 1000,
+  })
+}
+
+/** Fetch a user's public collections (for profile pages) */
+export function useUserPublicCollections(
+  username: string,
+  options?: { enabled?: boolean }
+) {
+  return useQuery({
+    queryKey: queryKeys.collections.userPublic(username),
+    queryFn: () =>
+      apiRequest<{ crates: Collection[]; total: number }>(
+        API_ENDPOINTS.COLLECTIONS.USER_PUBLIC(username)
+      ).then((data) => ({
+        collections: data.crates ?? [],
+        total: data.total,
+      })),
+    enabled: (options?.enabled ?? true) && username.length > 0,
+    staleTime: 5 * 60 * 1000,
+  })
+}

--- a/frontend/features/collections/index.ts
+++ b/frontend/features/collections/index.ts
@@ -24,4 +24,8 @@ export {
   useRemoveCollectionItem,
   useReorderCollectionItems,
   useUpdateCollectionItem,
+  useEntityCollections,
+  useUserPublicCollections,
 } from './hooks'
+
+export { EntityCollections, UserCollections } from './components'

--- a/frontend/features/festivals/components/FestivalDetail.tsx
+++ b/frontend/features/festivals/components/FestivalDetail.tsx
@@ -20,6 +20,7 @@ import {
   useFestivals,
 } from '../hooks/useFestivals'
 import { EntityDetailLayout, EntityHeader, SocialLinks, FollowButton, AddToCollectionButton } from '@/components/shared'
+import { EntityCollections } from '@/features/collections'
 import { TabsContent } from '@/components/ui/tabs'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -260,6 +261,9 @@ export function FestivalDetail({ idOrSlug }: FestivalDetailProps) {
           {festival.social && <SocialLinks social={festival.social} />}
         </div>
       </div>
+
+      {/* In Collections */}
+      <EntityCollections entityType="festival" entityId={festival.id} />
     </div>
   )
 

--- a/frontend/features/labels/components/LabelDetail.tsx
+++ b/frontend/features/labels/components/LabelDetail.tsx
@@ -13,6 +13,7 @@ import {
 } from 'lucide-react'
 import { useLabel, useLabelRoster, useLabelCatalog } from '../hooks/useLabels'
 import { EntityDetailLayout, EntityHeader, SocialLinks, FollowButton, AddToCollectionButton } from '@/components/shared'
+import { EntityCollections } from '@/features/collections'
 import { NotifyMeButton } from '@/features/notifications'
 import { TabsContent } from '@/components/ui/tabs'
 import { Badge } from '@/components/ui/badge'
@@ -159,6 +160,9 @@ export function LabelDetail({ idOrSlug }: LabelDetailProps) {
           </div>
         </div>
       </div>
+
+      {/* In Collections */}
+      <EntityCollections entityType="label" entityId={label.id} />
     </div>
   )
 

--- a/frontend/features/releases/components/ReleaseDetail.tsx
+++ b/frontend/features/releases/components/ReleaseDetail.tsx
@@ -23,6 +23,7 @@ import {
 import { AttributionLine } from '@/features/contributions'
 import { EntityTagList } from '@/features/tags'
 import { AsHeardOn } from '@/features/radio'
+import { EntityCollections } from '@/features/collections'
 import { TabsContent } from '@/components/ui/tabs'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -216,6 +217,9 @@ export function ReleaseDetail({ idOrSlug }: ReleaseDetailProps) {
 
       {/* As Heard On (radio) */}
       <AsHeardOn entityType="release" entitySlug={release.slug} />
+
+      {/* In Collections */}
+      <EntityCollections entityType="release" entityId={release.id} />
     </div>
   )
 

--- a/frontend/features/shows/components/ShowDetail.test.tsx
+++ b/frontend/features/shows/components/ShowDetail.test.tsx
@@ -81,6 +81,10 @@ vi.mock('./AttendanceButton', () => ({
   ),
 }))
 
+vi.mock('@/features/collections', () => ({
+  EntityCollections: () => <div data-testid="entity-collections" />,
+}))
+
 function makeArtist(overrides: Partial<ArtistResponse> = {}): ArtistResponse {
   return {
     id: 1,

--- a/frontend/features/shows/components/ShowDetail.tsx
+++ b/frontend/features/shows/components/ShowDetail.tsx
@@ -11,6 +11,7 @@ import type { ArtistResponse } from '../types'
 import { formatShowDate, formatShowTime, formatPrice } from '@/lib/utils/formatters'
 import { Button } from '@/components/ui/button'
 import { SocialLinks, MusicEmbed, SaveButton, Breadcrumb, AddToCollectionButton } from '@/components/shared'
+import { EntityCollections } from '@/features/collections'
 import { ShowForm } from '@/components/forms'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
@@ -407,6 +408,11 @@ export function ShowDetail({ showId }: ShowDetailProps) {
           </div>
         </section>
       )}
+
+      {/* In Collections */}
+      <section className="mb-8">
+        <EntityCollections entityType="show" entityId={show.id} />
+      </section>
 
       {/* Delete Confirmation Dialog */}
       <DeleteShowDialog

--- a/frontend/features/venues/components/VenueDetail.test.tsx
+++ b/frontend/features/venues/components/VenueDetail.test.tsx
@@ -127,6 +127,10 @@ vi.mock('./DeleteVenueDialog', () => ({
     open ? <div data-testid="delete-dialog">Delete Dialog</div> : null,
 }))
 
+vi.mock('@/features/collections', () => ({
+  EntityCollections: () => <div data-testid="entity-collections" />,
+}))
+
 vi.mock('@/components/ui/button', () => ({
   Button: ({ children, asChild, ...props }: { children: React.ReactNode; asChild?: boolean; [key: string]: unknown }) => {
     if (asChild) return <>{children}</>

--- a/frontend/features/venues/components/VenueDetail.tsx
+++ b/frontend/features/venues/components/VenueDetail.tsx
@@ -11,6 +11,7 @@ import { useAuthContext } from '@/lib/context/AuthContext'
 import { useQueryClient } from '@tanstack/react-query'
 import { queryKeys } from '@/lib/queryClient'
 import { SocialLinks, RevisionHistory, FollowButton, Breadcrumb, TagPill, EntityDescription, AddToCollectionButton } from '@/components/shared'
+import { EntityCollections } from '@/features/collections'
 import { NotifyMeButton } from '@/features/notifications'
 import { VenueLocationCard } from './VenueLocationCard'
 import { VenueShowsList } from './VenueShowsList'
@@ -310,6 +311,9 @@ export function VenueDetail({ venueId }: VenueDetailProps) {
             verified={venue.verified}
           />
           <VenueGenreProfile venueId={venue.id} />
+          <div className="mt-6">
+            <EntityCollections entityType="venue" entityId={venue.id} />
+          </div>
         </div>
       </div>
 

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -259,6 +259,10 @@ export const API_ENDPOINTS = {
     SUBSCRIBE: (slug: string) => `${API_BASE_URL}/collections/${slug}/subscribe`,
     FEATURE: (slug: string) => `${API_BASE_URL}/collections/${slug}/feature`,
     MY: `${API_BASE_URL}/auth/collections`,
+    ENTITY: (entityType: string, entityId: number) =>
+      `${API_BASE_URL}/collections/entity/${entityType}/${entityId}`,
+    USER_PUBLIC: (username: string) =>
+      `${API_BASE_URL}/users/${username}/collections`,
   },
 
   // Request endpoints

--- a/frontend/lib/queryClient.ts
+++ b/frontend/lib/queryClient.ts
@@ -254,6 +254,10 @@ export const queryKeys = {
     detail: (slug: string) => ['collections', 'detail', slug] as const,
     stats: (slug: string) => ['collections', 'stats', slug] as const,
     my: ['collections', 'my'] as const,
+    entity: (entityType: string, entityId: number) =>
+      ['collections', 'entity', entityType, entityId] as const,
+    userPublic: (username: string) =>
+      ['collections', 'userPublic', username] as const,
   },
 
   // Request queries


### PR DESCRIPTION
## Summary

Collections were invisible outside their own pages. This PR adds the discovery chain that makes lists viral.

### Backend (new endpoints)
- `GET /collections/entity/{entity_type}/{entity_id}` — public collections containing a specific entity
- `GET /users/{username}/collections` — user's public collections by username
- New service methods: `GetEntityCollections`, `GetUserPublicCollections`, `GetUserPublicCollectionsByUsername`

### Frontend — Entity Backlinks
- New `EntityCollections` sidebar widget — shows "In Collections" with linked names
- Auto-hides when entity appears in 0 collections
- Added to all 6 entity types: artists, venues, shows, releases, labels, festivals

### Frontend — User Profile
- New `UserCollections` component with `CollectionCard` list
- Added "Collections" section to `PublicProfile.tsx`

### Frontend — Plumbing
- New hooks: `useEntityCollections`, `useUserPublicCollections`
- New API endpoints, query keys, barrel exports

## Test plan

- [ ] All 2444 frontend tests pass, full backend suite passes
- [ ] Manual: add entity to collection, verify "In Collections" appears on detail page
- [ ] Manual: user profile shows collections section
- [ ] Manual: entity in 0 collections — section hidden

Closes PSY-317

🤖 Generated with [Claude Code](https://claude.com/claude-code)