### PR TITLE
Add comments schema, CRUD service, and markdown rendering (Wave 1)

### DIFF
--- a/backend/db/migrations/000064_create_comments.down.sql
+++ b/backend/db/migrations/000064_create_comments.down.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS comment_votes;
+DROP TABLE IF EXISTS comment_edits;
+DROP TABLE IF EXISTS comments;

--- a/backend/db/migrations/000064_create_comments.up.sql
+++ b/backend/db/migrations/000064_create_comments.up.sql
@@ -1,0 +1,57 @@
+-- Comments table: polymorphic discussion system for all entity types
+CREATE TABLE comments (
+  id SERIAL PRIMARY KEY,
+  entity_type VARCHAR(20) NOT NULL,
+  entity_id INTEGER NOT NULL,
+  kind VARCHAR(20) NOT NULL DEFAULT 'comment',
+  user_id INTEGER NOT NULL REFERENCES users(id),
+  parent_id INTEGER REFERENCES comments(id),
+  root_id INTEGER REFERENCES comments(id),
+  depth INTEGER NOT NULL DEFAULT 0,
+  body TEXT NOT NULL,
+  body_html TEXT NOT NULL,
+  structured_data JSONB,
+  visibility VARCHAR(20) NOT NULL DEFAULT 'visible',
+  reply_permission VARCHAR(20) NOT NULL DEFAULT 'anyone',
+  ups INTEGER NOT NULL DEFAULT 0,
+  downs INTEGER NOT NULL DEFAULT 0,
+  score DOUBLE PRECISION NOT NULL DEFAULT 0,
+  edit_count INTEGER NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Primary query: list comments for an entity sorted by score
+CREATE INDEX idx_comments_entity ON comments(entity_type, entity_id);
+
+-- Thread loading: load all replies for a root comment
+CREATE INDEX idx_comments_root ON comments(root_id);
+
+-- Reply loading: load immediate children
+CREATE INDEX idx_comments_parent ON comments(parent_id);
+
+-- User's comments
+CREATE INDEX idx_comments_user ON comments(user_id);
+
+-- Field notes queries: filter by kind on a specific entity
+CREATE INDEX idx_comments_entity_kind ON comments(entity_type, entity_id, kind);
+
+-- Comment edits table: append-only edit history
+CREATE TABLE comment_edits (
+  id SERIAL PRIMARY KEY,
+  comment_id INTEGER NOT NULL REFERENCES comments(id) ON DELETE CASCADE,
+  old_body TEXT NOT NULL,
+  edited_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_comment_edits_comment ON comment_edits(comment_id);
+
+-- Comment votes table: binary up/down votes
+CREATE TABLE comment_votes (
+  comment_id INTEGER NOT NULL REFERENCES comments(id) ON DELETE CASCADE,
+  user_id INTEGER NOT NULL REFERENCES users(id),
+  direction SMALLINT NOT NULL CHECK (direction IN (-1, 1)),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (comment_id, user_id)
+);

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/PuerkitoBio/goquery v1.8.0 // indirect
 	github.com/andybalholm/cascadia v1.3.1 // indirect
+	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/chromedp/cdproto v0.0.0-20250724212937-08a3db8b4327 // indirect
 	github.com/chromedp/sysutil v1.1.0 // indirect
@@ -64,6 +65,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/go-tpm v0.9.6 // indirect
+	github.com/gorilla/css v1.0.1 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
@@ -78,6 +80,7 @@ require (
 	github.com/lib/pq v1.11.2 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.10 // indirect
+	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
 	github.com/mmcdole/goxpp v1.1.1-0.20240225020742-a0c311522b23 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/go-archive v0.1.0 // indirect
@@ -100,6 +103,7 @@ require (
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
+	github.com/yuin/goldmark v1.8.2 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	github.com/zeebo/xxh3 v1.0.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -16,6 +16,8 @@ github.com/andybalholm/cascadia v1.3.1 h1:nhxRkql1kdYCc8Snf7D5/D3spOX+dBgjA6u8x0
 github.com/andybalholm/cascadia v1.3.1/go.mod h1:R4bJ1UQfqADjvDa4P6HZHLh/3OxWWEqc0Sk8XGwHqvA=
 github.com/arran4/golang-ical v0.3.4 h1:Rthe8/0AD6QzF+kx6XFS0g4FZNE7UiSfsOyrJzLotBA=
 github.com/arran4/golang-ical v0.3.4/go.mod h1:OnguFgjN0Hmx8jzpmWcC+AkHio94ujmLHKoaef7xQh8=
+github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
+github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
 github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/chromedp/cdproto v0.0.0-20250724212937-08a3db8b4327 h1:UQ4AU+BGti3Sy/aLU8KVseYKNALcX9UXY6DfpwQ6J8E=
@@ -107,6 +109,8 @@ github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/css v1.0.1 h1:ntNaBIghp6JmvWnxbZKANoLyuXTPZ4cAMlo6RyhlbO8=
+github.com/gorilla/css v1.0.1/go.mod h1:BvnYkspnSzMmwRK+b8/xgNPLiIuNZr6vbZBTPQ2A3b0=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/gorilla/securecookie v1.1.2 h1:YCIWL56dvtr73r6715mJs5ZvhtnY73hBvEF8kXD8ePA=
@@ -151,6 +155,8 @@ github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8S
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/markbates/goth v1.81.0 h1:XVcCkeGWokynPV7MXvgb8pd2s3r7DS40P7931w6kdnE=
 github.com/markbates/goth v1.81.0/go.mod h1:+6z31QyUms84EHmuBY7iuqYSxyoN3njIgg9iCF/lR1k=
+github.com/microcosm-cc/bluemonday v1.0.27 h1:MpEUotklkwCSLeH+Qdx1VJgNqLlpY2KXwXFM08ygZfk=
+github.com/microcosm-cc/bluemonday v1.0.27/go.mod h1:jFi9vgW+H7c3V0lb6nR74Ib/DIB5OBs92Dimizgw2cA=
 github.com/mmcdole/gofeed v1.3.0 h1:5yn+HeqlcvjMeAI4gu6T+crm7d0anY85+M+v6fIFNG4=
 github.com/mmcdole/gofeed v1.3.0/go.mod h1:9TGv2LcJhdXePDzxiuMnukhV2/zb6VtnZt1mS+SjkLE=
 github.com/mmcdole/goxpp v1.1.1-0.20240225020742-a0c311522b23 h1:Zr92CAlFhy2gL+V1F+EyIuzbQNbSgP4xhTODZtrXUtk=
@@ -218,6 +224,8 @@ github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcY
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/goldmark v1.8.2 h1:kEGpgqJXdgbkhcOgBxkC0X0PmoPG1ZyoZ117rDVp4zE=
+github.com/yuin/goldmark v1.8.2/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=

--- a/backend/internal/models/comment.go
+++ b/backend/internal/models/comment.go
@@ -1,0 +1,125 @@
+package models
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// CommentKind represents the type of comment
+type CommentKind string
+
+const (
+	CommentKindComment   CommentKind = "comment"
+	CommentKindFieldNote CommentKind = "field_note"
+)
+
+// CommentVisibility represents the visibility state of a comment
+type CommentVisibility string
+
+const (
+	CommentVisibilityVisible      CommentVisibility = "visible"
+	CommentVisibilityHiddenByUser CommentVisibility = "hidden_by_user"
+	CommentVisibilityHiddenByMod  CommentVisibility = "hidden_by_mod"
+	CommentVisibilityPendingReview CommentVisibility = "pending_review"
+)
+
+// ReplyPermission represents who can reply to a comment
+type ReplyPermission string
+
+const (
+	ReplyPermissionAnyone    ReplyPermission = "anyone"
+	ReplyPermissionAuthorOnly ReplyPermission = "author_only"
+)
+
+// CommentEntityType represents the valid entity types for comments
+type CommentEntityType string
+
+const (
+	CommentEntityArtist     CommentEntityType = "artist"
+	CommentEntityVenue      CommentEntityType = "venue"
+	CommentEntityShow       CommentEntityType = "show"
+	CommentEntityRelease    CommentEntityType = "release"
+	CommentEntityLabel      CommentEntityType = "label"
+	CommentEntityFestival   CommentEntityType = "festival"
+	CommentEntityCollection CommentEntityType = "collection"
+)
+
+// ValidCommentEntityTypes is the set of all valid entity types for comments
+var ValidCommentEntityTypes = map[CommentEntityType]string{
+	CommentEntityArtist:     "artists",
+	CommentEntityVenue:      "venues",
+	CommentEntityShow:       "shows",
+	CommentEntityRelease:    "releases",
+	CommentEntityLabel:      "labels",
+	CommentEntityFestival:   "festivals",
+	CommentEntityCollection: "collections",
+}
+
+// MaxCommentDepth is the maximum nesting depth (0=top-level, 1=reply, 2=reply-to-reply)
+const MaxCommentDepth = 2
+
+// MaxCommentBodyLength is the maximum body length in characters
+const MaxCommentBodyLength = 10000
+
+// MinCommentBodyLength is the minimum body length in characters
+const MinCommentBodyLength = 1
+
+// Comment represents a comment or field note on any entity
+type Comment struct {
+	ID              uint              `gorm:"primaryKey;column:id"`
+	EntityType      CommentEntityType `gorm:"not null;column:entity_type"`
+	EntityID        uint              `gorm:"not null;column:entity_id"`
+	Kind            CommentKind       `gorm:"not null;column:kind;default:'comment'"`
+	UserID          uint              `gorm:"not null;column:user_id"`
+	ParentID        *uint             `gorm:"column:parent_id"`
+	RootID          *uint             `gorm:"column:root_id"`
+	Depth           int               `gorm:"not null;column:depth;default:0"`
+	Body            string            `gorm:"not null;column:body"`
+	BodyHTML        string            `gorm:"not null;column:body_html"`
+	StructuredData  *json.RawMessage  `gorm:"column:structured_data;type:jsonb"`
+	Visibility      CommentVisibility `gorm:"not null;column:visibility;default:'visible'"`
+	ReplyPermission ReplyPermission   `gorm:"not null;column:reply_permission;default:'anyone'"`
+	Ups             int               `gorm:"not null;column:ups;default:0"`
+	Downs           int               `gorm:"not null;column:downs;default:0"`
+	Score           float64           `gorm:"not null;column:score;default:0"`
+	EditCount       int               `gorm:"not null;column:edit_count;default:0"`
+	CreatedAt       time.Time         `gorm:"not null;column:created_at"`
+	UpdatedAt       time.Time         `gorm:"not null;column:updated_at"`
+
+	// Relationships (for preloading)
+	User   User          `gorm:"foreignKey:UserID"`
+	Parent *Comment      `gorm:"foreignKey:ParentID"`
+	Edits  []CommentEdit `gorm:"foreignKey:CommentID"`
+}
+
+// TableName specifies the table name for Comment
+func (Comment) TableName() string {
+	return "comments"
+}
+
+// CommentEdit represents a historical edit of a comment (append-only)
+type CommentEdit struct {
+	ID        uint      `gorm:"primaryKey;column:id"`
+	CommentID uint      `gorm:"not null;column:comment_id"`
+	OldBody   string    `gorm:"not null;column:old_body"`
+	EditedAt  time.Time `gorm:"not null;column:edited_at"`
+}
+
+// TableName specifies the table name for CommentEdit
+func (CommentEdit) TableName() string {
+	return "comment_edits"
+}
+
+// CommentVote represents a user's vote on a comment
+type CommentVote struct {
+	CommentID uint      `gorm:"primaryKey;column:comment_id"`
+	UserID    uint      `gorm:"primaryKey;column:user_id"`
+	Direction int16     `gorm:"not null;column:direction"`
+	CreatedAt time.Time `gorm:"not null;column:created_at"`
+	UpdatedAt time.Time `gorm:"not null;column:updated_at"`
+}
+
+// TableName specifies the table name for CommentVote
+func (CommentVote) TableName() string {
+	return "comment_votes"
+}

--- a/backend/internal/services/container.go
+++ b/backend/internal/services/container.go
@@ -39,6 +39,7 @@ type ServiceContainer struct {
 	ArtistRelationship *catalog.ArtistRelationshipService
 	Scene              *catalog.SceneService
 	Attendance         *engagement.AttendanceService
+	Comment            *engagement.CommentService
 	Follow             *engagement.FollowService
 	FavoriteVenue      *engagement.FavoriteVenueService
 	Festival               *catalog.FestivalService
@@ -150,6 +151,7 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 		ArtistRelationship: catalog.NewArtistRelationshipService(database),
 		Scene:              catalog.NewSceneService(database),
 		Attendance:         engagement.NewAttendanceService(database),
+		Comment:            engagement.NewCommentService(database),
 		Follow:             engagement.NewFollowService(database),
 		FavoriteVenue:      engagement.NewFavoriteVenueService(database),
 		Festival:               catalog.NewFestivalService(database),

--- a/backend/internal/services/contracts/comment.go
+++ b/backend/internal/services/contracts/comment.go
@@ -1,0 +1,82 @@
+package contracts
+
+import "time"
+
+// ──────────────────────────────────────────────
+// Comment request types
+// ──────────────────────────────────────────────
+
+// CreateCommentRequest contains the fields needed to create a comment.
+type CreateCommentRequest struct {
+	EntityType      string  `json:"entity_type"`
+	EntityID        uint    `json:"entity_id"`
+	Body            string  `json:"body"`
+	ParentID        *uint   `json:"parent_id,omitempty"`
+	Kind            string  `json:"kind,omitempty"`             // default "comment"
+	ReplyPermission string  `json:"reply_permission,omitempty"` // default "anyone"
+}
+
+// UpdateCommentRequest contains the fields that can be updated on a comment.
+type UpdateCommentRequest struct {
+	Body string `json:"body"`
+}
+
+// CommentListFilters defines filtering and sorting options for listing comments.
+type CommentListFilters struct {
+	Sort       string // best, new, top, controversial
+	Visibility string // visible, hidden_by_user, hidden_by_mod, pending_review, or empty for visible only
+	Kind       string // comment, field_note, or empty for all
+	Limit      int
+	Offset     int
+}
+
+// ──────────────────────────────────────────────
+// Comment response types
+// ──────────────────────────────────────────────
+
+// CommentResponse represents a comment with author info for API responses.
+type CommentResponse struct {
+	ID              uint       `json:"id"`
+	EntityType      string     `json:"entity_type"`
+	EntityID        uint       `json:"entity_id"`
+	Kind            string     `json:"kind"`
+	UserID          uint       `json:"user_id"`
+	AuthorName      string     `json:"author_name"`
+	AuthorUsername  string     `json:"author_username,omitempty"`
+	ParentID        *uint      `json:"parent_id,omitempty"`
+	RootID          *uint      `json:"root_id,omitempty"`
+	Depth           int        `json:"depth"`
+	Body            string     `json:"body"`
+	BodyHTML        string     `json:"body_html"`
+	Visibility      string     `json:"visibility"`
+	ReplyPermission string     `json:"reply_permission"`
+	Ups             int        `json:"ups"`
+	Downs           int        `json:"downs"`
+	Score           float64    `json:"score"`
+	IsEdited        bool       `json:"is_edited"`
+	EditCount       int        `json:"edit_count"`
+	UserVote        *int       `json:"user_vote,omitempty"` // 1, -1, or nil if no vote
+	CreatedAt       time.Time  `json:"created_at"`
+	UpdatedAt       time.Time  `json:"updated_at"`
+}
+
+// CommentListResponse wraps a list of comments with pagination metadata.
+type CommentListResponse struct {
+	Comments []*CommentResponse `json:"comments"`
+	Total    int64              `json:"total"`
+	HasMore  bool               `json:"has_more"`
+}
+
+// ──────────────────────────────────────────────
+// Comment service interface
+// ──────────────────────────────────────────────
+
+// CommentServiceInterface defines the contract for comment CRUD and threading.
+type CommentServiceInterface interface {
+	CreateComment(userID uint, req *CreateCommentRequest) (*CommentResponse, error)
+	GetComment(commentID uint) (*CommentResponse, error)
+	ListCommentsForEntity(entityType string, entityID uint, filters CommentListFilters) (*CommentListResponse, error)
+	GetThread(rootID uint) ([]*CommentResponse, error)
+	UpdateComment(userID uint, commentID uint, req *UpdateCommentRequest) (*CommentResponse, error)
+	DeleteComment(userID uint, commentID uint, isAdmin bool) error
+}

--- a/backend/internal/services/engagement/comment_service.go
+++ b/backend/internal/services/engagement/comment_service.go
@@ -1,0 +1,457 @@
+package engagement
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/microcosm-cc/bluemonday"
+	"github.com/yuin/goldmark"
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// CommentService implements CommentServiceInterface for comment CRUD and threading.
+type CommentService struct {
+	db       *gorm.DB
+	md       goldmark.Markdown
+	sanitize *bluemonday.Policy
+}
+
+// NewCommentService creates a new CommentService.
+func NewCommentService(db *gorm.DB) *CommentService {
+	// Create sanitization policy: allow safe formatting, no images/raw HTML/tables
+	policy := bluemonday.NewPolicy()
+	policy.AllowStandardURLs()
+	policy.AllowAttrs("href").OnElements("a")
+	policy.AllowElements("p", "br",
+		"strong", "b", "em", "i",
+		"code", "pre",
+		"ul", "ol", "li",
+		"blockquote",
+		"h3", "h4", "h5", "h6",
+	)
+	policy.RequireNoFollowOnLinks(true)
+	policy.AddTargetBlankToFullyQualifiedLinks(true)
+
+	return &CommentService{
+		db:       db,
+		md:       goldmark.New(),
+		sanitize: policy,
+	}
+}
+
+// renderMarkdown converts markdown body to sanitized HTML.
+func (s *CommentService) renderMarkdown(body string) string {
+	var buf bytes.Buffer
+	if err := s.md.Convert([]byte(body), &buf); err != nil {
+		// Fallback: escape and wrap in <p> tag
+		return "<p>" + s.sanitize.Sanitize(body) + "</p>"
+	}
+	return s.sanitize.Sanitize(buf.String())
+}
+
+// wilsonScore computes the Wilson score lower bound for ranking.
+// Uses 90% confidence interval (z = 1.281728756502709).
+func wilsonScore(ups, downs int) float64 {
+	n := float64(ups + downs)
+	if n == 0 {
+		return 0
+	}
+	z := 1.281728756502709
+	phat := float64(ups) / n
+	return (phat + z*z/(2*n) - z*math.Sqrt((phat*(1-phat)+z*z/(4*n))/n)) / (1 + z*z/n)
+}
+
+// validateCommentEntityType checks if the entity type is supported.
+func validateCommentEntityType(entityType string) (models.CommentEntityType, error) {
+	ct := models.CommentEntityType(entityType)
+	if _, ok := models.ValidCommentEntityTypes[ct]; !ok {
+		return "", fmt.Errorf("unsupported entity type: %s", entityType)
+	}
+	return ct, nil
+}
+
+// validateEntityExists checks that the referenced entity actually exists in the database.
+func (s *CommentService) validateEntityExists(entityType models.CommentEntityType, entityID uint) error {
+	tableName, ok := models.ValidCommentEntityTypes[entityType]
+	if !ok {
+		return fmt.Errorf("unsupported entity type: %s", entityType)
+	}
+
+	var count int64
+	result := s.db.Table(tableName).Where("id = ?", entityID).Count(&count)
+	if result.Error != nil {
+		return fmt.Errorf("failed to validate entity existence: %w", result.Error)
+	}
+	if count == 0 {
+		return fmt.Errorf("%s with ID %d not found", entityType, entityID)
+	}
+	return nil
+}
+
+// commentToResponse maps a Comment model to a CommentResponse.
+func commentToResponse(c *models.Comment) *contracts.CommentResponse {
+	resp := &contracts.CommentResponse{
+		ID:              c.ID,
+		EntityType:      string(c.EntityType),
+		EntityID:        c.EntityID,
+		Kind:            string(c.Kind),
+		UserID:          c.UserID,
+		ParentID:        c.ParentID,
+		RootID:          c.RootID,
+		Depth:           c.Depth,
+		Body:            c.Body,
+		BodyHTML:        c.BodyHTML,
+		Visibility:      string(c.Visibility),
+		ReplyPermission: string(c.ReplyPermission),
+		Ups:             c.Ups,
+		Downs:           c.Downs,
+		Score:           c.Score,
+		IsEdited:        c.EditCount > 0,
+		EditCount:       c.EditCount,
+		CreatedAt:       c.CreatedAt,
+		UpdatedAt:       c.UpdatedAt,
+	}
+
+	// Populate author info from preloaded User
+	if c.User.ID != 0 {
+		if c.User.Username != nil {
+			resp.AuthorUsername = *c.User.Username
+		}
+		if c.User.FirstName != nil {
+			resp.AuthorName = *c.User.FirstName
+		}
+	}
+
+	return resp
+}
+
+// CreateComment creates a new comment or reply.
+func (s *CommentService) CreateComment(userID uint, req *contracts.CreateCommentRequest) (*contracts.CommentResponse, error) {
+	if s.db == nil {
+		return nil, errors.New("database not initialized")
+	}
+
+	// Validate body length
+	body := strings.TrimSpace(req.Body)
+	if len(body) < models.MinCommentBodyLength {
+		return nil, errors.New("comment body is required")
+	}
+	if len(body) > models.MaxCommentBodyLength {
+		return nil, fmt.Errorf("comment body exceeds maximum length of %d characters", models.MaxCommentBodyLength)
+	}
+
+	// Validate entity type
+	entityType, err := validateCommentEntityType(req.EntityType)
+	if err != nil {
+		return nil, err
+	}
+
+	// Validate entity exists
+	if err := s.validateEntityExists(entityType, req.EntityID); err != nil {
+		return nil, err
+	}
+
+	// Determine kind
+	kind := models.CommentKindComment
+	if req.Kind == string(models.CommentKindFieldNote) {
+		kind = models.CommentKindFieldNote
+	}
+
+	// Determine reply permission
+	replyPerm := models.ReplyPermissionAnyone
+	if req.ReplyPermission == string(models.ReplyPermissionAuthorOnly) {
+		replyPerm = models.ReplyPermissionAuthorOnly
+	}
+
+	// Threading: handle parent_id
+	var parentID *uint
+	var rootID *uint
+	depth := 0
+
+	if req.ParentID != nil && *req.ParentID > 0 {
+		// Validate parent exists and belongs to the same entity
+		var parent models.Comment
+		if err := s.db.First(&parent, *req.ParentID).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return nil, errors.New("parent comment not found")
+			}
+			return nil, fmt.Errorf("failed to fetch parent comment: %w", err)
+		}
+
+		// Parent must be on the same entity
+		if parent.EntityType != entityType || parent.EntityID != req.EntityID {
+			return nil, errors.New("parent comment belongs to a different entity")
+		}
+
+		// Enforce max depth
+		depth = parent.Depth + 1
+		if depth > models.MaxCommentDepth {
+			return nil, fmt.Errorf("maximum reply depth of %d exceeded", models.MaxCommentDepth)
+		}
+
+		parentID = req.ParentID
+
+		// Set root_id: if parent is top-level, root is parent; otherwise root is parent's root
+		if parent.RootID != nil {
+			rootID = parent.RootID
+		} else {
+			rootID = &parent.ID
+		}
+	}
+
+	// Render markdown to HTML
+	bodyHTML := s.renderMarkdown(body)
+
+	comment := &models.Comment{
+		EntityType:      entityType,
+		EntityID:        req.EntityID,
+		Kind:            kind,
+		UserID:          userID,
+		ParentID:        parentID,
+		RootID:          rootID,
+		Depth:           depth,
+		Body:            body,
+		BodyHTML:        bodyHTML,
+		Visibility:      models.CommentVisibilityVisible,
+		ReplyPermission: replyPerm,
+	}
+
+	if err := s.db.Create(comment).Error; err != nil {
+		return nil, fmt.Errorf("failed to create comment: %w", err)
+	}
+
+	// Reload with user info
+	if err := s.db.Preload("User").First(comment, comment.ID).Error; err != nil {
+		return nil, fmt.Errorf("failed to reload comment: %w", err)
+	}
+
+	return commentToResponse(comment), nil
+}
+
+// GetComment returns a single comment by ID.
+func (s *CommentService) GetComment(commentID uint) (*contracts.CommentResponse, error) {
+	if s.db == nil {
+		return nil, errors.New("database not initialized")
+	}
+
+	var comment models.Comment
+	if err := s.db.Preload("User").First(&comment, commentID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, errors.New("comment not found")
+		}
+		return nil, fmt.Errorf("failed to fetch comment: %w", err)
+	}
+
+	return commentToResponse(&comment), nil
+}
+
+// ListCommentsForEntity returns paginated top-level comments for an entity with sort options.
+func (s *CommentService) ListCommentsForEntity(entityType string, entityID uint, filters contracts.CommentListFilters) (*contracts.CommentListResponse, error) {
+	if s.db == nil {
+		return nil, errors.New("database not initialized")
+	}
+
+	// Validate entity type
+	et, err := validateCommentEntityType(entityType)
+	if err != nil {
+		return nil, err
+	}
+
+	// Default pagination
+	limit := filters.Limit
+	if limit <= 0 {
+		limit = 20
+	}
+	offset := filters.Offset
+	if offset < 0 {
+		offset = 0
+	}
+
+	// Build base query for top-level comments only
+	query := s.db.Model(&models.Comment{}).
+		Where("entity_type = ? AND entity_id = ? AND parent_id IS NULL", et, entityID)
+
+	// Filter by visibility (default: visible only)
+	if filters.Visibility != "" {
+		query = query.Where("visibility = ?", filters.Visibility)
+	} else {
+		query = query.Where("visibility = ?", models.CommentVisibilityVisible)
+	}
+
+	// Filter by kind
+	if filters.Kind != "" {
+		query = query.Where("kind = ?", filters.Kind)
+	}
+
+	// Count total matching comments
+	var total int64
+	if err := query.Count(&total).Error; err != nil {
+		return nil, fmt.Errorf("failed to count comments: %w", err)
+	}
+
+	// Apply sort order
+	switch filters.Sort {
+	case "new":
+		query = query.Order("created_at DESC")
+	case "top":
+		query = query.Order("(ups - downs) DESC, created_at DESC")
+	case "controversial":
+		query = query.Order("(ups + downs) DESC, ABS(ups - downs) ASC, created_at DESC")
+	default: // "best" or empty
+		query = query.Order("score DESC, created_at DESC")
+	}
+
+	// Fetch comments with user preload
+	var comments []models.Comment
+	if err := query.Preload("User").Limit(limit).Offset(offset).Find(&comments).Error; err != nil {
+		return nil, fmt.Errorf("failed to fetch comments: %w", err)
+	}
+
+	// Map to response
+	responses := make([]*contracts.CommentResponse, len(comments))
+	for i := range comments {
+		responses[i] = commentToResponse(&comments[i])
+	}
+
+	return &contracts.CommentListResponse{
+		Comments: responses,
+		Total:    total,
+		HasMore:  int64(offset+limit) < total,
+	}, nil
+}
+
+// GetThread loads a root comment and all its descendants as a flat list ordered by created_at.
+func (s *CommentService) GetThread(rootID uint) ([]*contracts.CommentResponse, error) {
+	if s.db == nil {
+		return nil, errors.New("database not initialized")
+	}
+
+	// Verify the root comment exists
+	var root models.Comment
+	if err := s.db.First(&root, rootID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, errors.New("thread root comment not found")
+		}
+		return nil, fmt.Errorf("failed to fetch thread root: %w", err)
+	}
+
+	// The root comment must be a top-level comment (no parent)
+	if root.ParentID != nil {
+		return nil, errors.New("comment is not a thread root")
+	}
+
+	// Load root + all descendants
+	var comments []models.Comment
+	if err := s.db.Preload("User").
+		Where("id = ? OR root_id = ?", rootID, rootID).
+		Order("created_at ASC").
+		Find(&comments).Error; err != nil {
+		return nil, fmt.Errorf("failed to fetch thread: %w", err)
+	}
+
+	responses := make([]*contracts.CommentResponse, len(comments))
+	for i := range comments {
+		responses[i] = commentToResponse(&comments[i])
+	}
+
+	return responses, nil
+}
+
+// UpdateComment updates a comment's body. Only the author can update their own comment.
+func (s *CommentService) UpdateComment(userID uint, commentID uint, req *contracts.UpdateCommentRequest) (*contracts.CommentResponse, error) {
+	if s.db == nil {
+		return nil, errors.New("database not initialized")
+	}
+
+	// Validate body
+	body := strings.TrimSpace(req.Body)
+	if len(body) < models.MinCommentBodyLength {
+		return nil, errors.New("comment body is required")
+	}
+	if len(body) > models.MaxCommentBodyLength {
+		return nil, fmt.Errorf("comment body exceeds maximum length of %d characters", models.MaxCommentBodyLength)
+	}
+
+	var comment models.Comment
+	if err := s.db.First(&comment, commentID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, errors.New("comment not found")
+		}
+		return nil, fmt.Errorf("failed to fetch comment: %w", err)
+	}
+
+	// Only the author can edit
+	if comment.UserID != userID {
+		return nil, errors.New("only the comment author can edit this comment")
+	}
+
+	// Store old body in comment_edits (append-only edit history)
+	edit := &models.CommentEdit{
+		CommentID: comment.ID,
+		OldBody:   comment.Body,
+		EditedAt:  time.Now(),
+	}
+	if err := s.db.Create(edit).Error; err != nil {
+		return nil, fmt.Errorf("failed to save edit history: %w", err)
+	}
+
+	// Update the comment
+	bodyHTML := s.renderMarkdown(body)
+	if err := s.db.Model(&comment).Updates(map[string]interface{}{
+		"body":       body,
+		"body_html":  bodyHTML,
+		"edit_count": gorm.Expr("edit_count + 1"),
+		"updated_at": time.Now(),
+	}).Error; err != nil {
+		return nil, fmt.Errorf("failed to update comment: %w", err)
+	}
+
+	// Reload with user info
+	if err := s.db.Preload("User").First(&comment, commentID).Error; err != nil {
+		return nil, fmt.Errorf("failed to reload comment: %w", err)
+	}
+
+	return commentToResponse(&comment), nil
+}
+
+// DeleteComment performs a soft delete by setting visibility.
+// Authors set hidden_by_user; admins set hidden_by_mod.
+func (s *CommentService) DeleteComment(userID uint, commentID uint, isAdmin bool) error {
+	if s.db == nil {
+		return errors.New("database not initialized")
+	}
+
+	var comment models.Comment
+	if err := s.db.First(&comment, commentID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return errors.New("comment not found")
+		}
+		return fmt.Errorf("failed to fetch comment: %w", err)
+	}
+
+	// Non-admin users can only delete their own comments
+	if !isAdmin && comment.UserID != userID {
+		return errors.New("only the comment author or an admin can delete this comment")
+	}
+
+	visibility := models.CommentVisibilityHiddenByUser
+	if isAdmin && comment.UserID != userID {
+		visibility = models.CommentVisibilityHiddenByMod
+	}
+
+	if err := s.db.Model(&comment).Updates(map[string]interface{}{
+		"visibility": visibility,
+		"updated_at": time.Now(),
+	}).Error; err != nil {
+		return fmt.Errorf("failed to delete comment: %w", err)
+	}
+
+	return nil
+}

--- a/backend/internal/services/engagement/comment_service_test.go
+++ b/backend/internal/services/engagement/comment_service_test.go
@@ -1,0 +1,1144 @@
+package engagement
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/testutil"
+)
+
+// =============================================================================
+// UNIT TESTS (No Database Required)
+// =============================================================================
+
+func TestCommentService_NilDB(t *testing.T) {
+	svc := NewCommentService(nil)
+
+	t.Run("CreateComment_NilDB", func(t *testing.T) {
+		_, err := svc.CreateComment(1, &contracts.CreateCommentRequest{
+			EntityType: "artist",
+			EntityID:   1,
+			Body:       "test",
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "database not initialized")
+	})
+
+	t.Run("GetComment_NilDB", func(t *testing.T) {
+		_, err := svc.GetComment(1)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "database not initialized")
+	})
+
+	t.Run("ListCommentsForEntity_NilDB", func(t *testing.T) {
+		_, err := svc.ListCommentsForEntity("artist", 1, contracts.CommentListFilters{})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "database not initialized")
+	})
+
+	t.Run("GetThread_NilDB", func(t *testing.T) {
+		_, err := svc.GetThread(1)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "database not initialized")
+	})
+
+	t.Run("UpdateComment_NilDB", func(t *testing.T) {
+		_, err := svc.UpdateComment(1, 1, &contracts.UpdateCommentRequest{Body: "test"})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "database not initialized")
+	})
+
+	t.Run("DeleteComment_NilDB", func(t *testing.T) {
+		err := svc.DeleteComment(1, 1, false)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "database not initialized")
+	})
+}
+
+func TestCommentService_InvalidEntityType(t *testing.T) {
+	svc := &CommentService{db: &gorm.DB{}}
+
+	t.Run("CreateComment_InvalidEntityType", func(t *testing.T) {
+		_, err := svc.CreateComment(1, &contracts.CreateCommentRequest{
+			EntityType: "banana",
+			EntityID:   1,
+			Body:       "test",
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported entity type")
+	})
+}
+
+func TestCommentService_BodyValidation(t *testing.T) {
+	svc := &CommentService{db: &gorm.DB{}}
+
+	t.Run("CreateComment_EmptyBody", func(t *testing.T) {
+		_, err := svc.CreateComment(1, &contracts.CreateCommentRequest{
+			EntityType: "artist",
+			EntityID:   1,
+			Body:       "",
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "comment body is required")
+	})
+
+	t.Run("CreateComment_WhitespaceBody", func(t *testing.T) {
+		_, err := svc.CreateComment(1, &contracts.CreateCommentRequest{
+			EntityType: "artist",
+			EntityID:   1,
+			Body:       "   \n\t  ",
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "comment body is required")
+	})
+
+	t.Run("CreateComment_TooLongBody", func(t *testing.T) {
+		_, err := svc.CreateComment(1, &contracts.CreateCommentRequest{
+			EntityType: "artist",
+			EntityID:   1,
+			Body:       strings.Repeat("a", models.MaxCommentBodyLength+1),
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "exceeds maximum length")
+	})
+
+	t.Run("UpdateComment_EmptyBody", func(t *testing.T) {
+		_, err := svc.UpdateComment(1, 1, &contracts.UpdateCommentRequest{Body: ""})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "comment body is required")
+	})
+
+	t.Run("UpdateComment_TooLongBody", func(t *testing.T) {
+		_, err := svc.UpdateComment(1, 1, &contracts.UpdateCommentRequest{
+			Body: strings.Repeat("a", models.MaxCommentBodyLength+1),
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "exceeds maximum length")
+	})
+}
+
+func TestMarkdownRendering(t *testing.T) {
+	svc := NewCommentService(nil)
+
+	t.Run("Bold", func(t *testing.T) {
+		html := svc.renderMarkdown("**bold text**")
+		assert.Contains(t, html, "<strong>bold text</strong>")
+	})
+
+	t.Run("Italic", func(t *testing.T) {
+		html := svc.renderMarkdown("*italic text*")
+		assert.Contains(t, html, "<em>italic text</em>")
+	})
+
+	t.Run("Link", func(t *testing.T) {
+		html := svc.renderMarkdown("[click here](https://example.com)")
+		assert.Contains(t, html, `href="https://example.com"`)
+		assert.Contains(t, html, "click here")
+	})
+
+	t.Run("CodeBlock", func(t *testing.T) {
+		html := svc.renderMarkdown("```\ncode block\n```")
+		assert.Contains(t, html, "<pre>")
+		assert.Contains(t, html, "<code>")
+	})
+
+	t.Run("InlineCode", func(t *testing.T) {
+		html := svc.renderMarkdown("`inline code`")
+		assert.Contains(t, html, "<code>inline code</code>")
+	})
+
+	t.Run("Blockquote", func(t *testing.T) {
+		html := svc.renderMarkdown("> quoted text")
+		assert.Contains(t, html, "<blockquote>")
+	})
+
+	t.Run("List", func(t *testing.T) {
+		html := svc.renderMarkdown("- item 1\n- item 2")
+		assert.Contains(t, html, "<ul>")
+		assert.Contains(t, html, "<li>")
+	})
+
+	t.Run("NoImages", func(t *testing.T) {
+		html := svc.renderMarkdown("![alt](https://example.com/img.png)")
+		// bluemonday should strip img tags
+		assert.NotContains(t, html, "<img")
+	})
+
+	t.Run("NoRawHTML", func(t *testing.T) {
+		html := svc.renderMarkdown("<script>alert('xss')</script>")
+		assert.NotContains(t, html, "<script>")
+	})
+
+	t.Run("Heading3Allowed", func(t *testing.T) {
+		html := svc.renderMarkdown("### Heading 3")
+		assert.Contains(t, html, "<h3>")
+	})
+
+	t.Run("Heading1Stripped", func(t *testing.T) {
+		html := svc.renderMarkdown("# Heading 1")
+		// h1 is not in our allowed list, so it should be stripped
+		assert.NotContains(t, html, "<h1>")
+	})
+
+	t.Run("Heading2Stripped", func(t *testing.T) {
+		html := svc.renderMarkdown("## Heading 2")
+		assert.NotContains(t, html, "<h2>")
+	})
+}
+
+func TestWilsonScore(t *testing.T) {
+	t.Run("NoVotes", func(t *testing.T) {
+		score := wilsonScore(0, 0)
+		assert.Equal(t, 0.0, score)
+	})
+
+	t.Run("AllUpvotes", func(t *testing.T) {
+		score := wilsonScore(10, 0)
+		assert.Greater(t, score, 0.0)
+		assert.Less(t, score, 1.0)
+	})
+
+	t.Run("AllDownvotes", func(t *testing.T) {
+		score := wilsonScore(0, 10)
+		assert.Equal(t, 0.0, score)
+	})
+
+	t.Run("MixedVotes", func(t *testing.T) {
+		score := wilsonScore(8, 2)
+		assert.Greater(t, score, 0.0)
+		assert.Less(t, score, 1.0)
+	})
+
+	t.Run("HighConfidenceBeatsLowSample", func(t *testing.T) {
+		highN := wilsonScore(95, 5)
+		lowN := wilsonScore(3, 0)
+		assert.Greater(t, highN, lowN)
+	})
+
+	t.Run("SingleUpvote", func(t *testing.T) {
+		score := wilsonScore(1, 0)
+		assert.Greater(t, score, 0.0)
+		assert.Less(t, score, 1.0)
+	})
+}
+
+// =============================================================================
+// INTEGRATION TESTS (With Real Database)
+// =============================================================================
+
+type CommentServiceIntegrationTestSuite struct {
+	suite.Suite
+	testDB         *testutil.TestDatabase
+	db             *gorm.DB
+	commentService *CommentService
+}
+
+func (suite *CommentServiceIntegrationTestSuite) SetupSuite() {
+	suite.testDB = testutil.SetupTestPostgres(suite.T())
+	suite.db = suite.testDB.DB
+	suite.commentService = NewCommentService(suite.testDB.DB)
+}
+
+func (suite *CommentServiceIntegrationTestSuite) TearDownSuite() {
+	suite.testDB.Cleanup()
+}
+
+func (suite *CommentServiceIntegrationTestSuite) TearDownTest() {
+	sqlDB, err := suite.db.DB()
+	suite.Require().NoError(err)
+	_, _ = sqlDB.Exec("DELETE FROM comment_votes")
+	_, _ = sqlDB.Exec("DELETE FROM comment_edits")
+	_, _ = sqlDB.Exec("DELETE FROM comments")
+	_, _ = sqlDB.Exec("DELETE FROM shows")
+	_, _ = sqlDB.Exec("DELETE FROM releases")
+	_, _ = sqlDB.Exec("DELETE FROM festivals")
+	_, _ = sqlDB.Exec("DELETE FROM labels")
+	_, _ = sqlDB.Exec("DELETE FROM collections")
+	_, _ = sqlDB.Exec("DELETE FROM artists")
+	_, _ = sqlDB.Exec("DELETE FROM venues")
+	_, _ = sqlDB.Exec("DELETE FROM users")
+}
+
+func TestCommentServiceIntegrationTestSuite(t *testing.T) {
+	suite.Run(t, new(CommentServiceIntegrationTestSuite))
+}
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+func (suite *CommentServiceIntegrationTestSuite) createTestUser() *models.User {
+	user := &models.User{
+		Email:         stringPtr(fmt.Sprintf("user-%d@test.com", time.Now().UnixNano())),
+		Username:      stringPtr(fmt.Sprintf("user%d", time.Now().UnixNano())),
+		FirstName:     stringPtr("Test"),
+		LastName:      stringPtr("User"),
+		IsActive:      true,
+		EmailVerified: true,
+	}
+	err := suite.db.Create(user).Error
+	suite.Require().NoError(err)
+	return user
+}
+
+func (suite *CommentServiceIntegrationTestSuite) createTestAdmin() *models.User {
+	user := &models.User{
+		Email:         stringPtr(fmt.Sprintf("admin-%d@test.com", time.Now().UnixNano())),
+		Username:      stringPtr(fmt.Sprintf("admin%d", time.Now().UnixNano())),
+		FirstName:     stringPtr("Admin"),
+		LastName:      stringPtr("User"),
+		IsActive:      true,
+		IsAdmin:       true,
+		EmailVerified: true,
+	}
+	err := suite.db.Create(user).Error
+	suite.Require().NoError(err)
+	return user
+}
+
+func (suite *CommentServiceIntegrationTestSuite) createTestArtist(name string) uint {
+	slug := fmt.Sprintf("%s-%d", name, time.Now().UnixNano())
+	artist := &models.Artist{
+		Name: name,
+		Slug: &slug,
+	}
+	err := suite.db.Create(artist).Error
+	suite.Require().NoError(err)
+	return artist.ID
+}
+
+func (suite *CommentServiceIntegrationTestSuite) createTestVenue(name string) uint {
+	slug := fmt.Sprintf("%s-%d", name, time.Now().UnixNano())
+	venue := &models.Venue{
+		Name:  name,
+		Slug:  &slug,
+		City:  "Phoenix",
+		State: "AZ",
+	}
+	err := suite.db.Create(venue).Error
+	suite.Require().NoError(err)
+	return venue.ID
+}
+
+func (suite *CommentServiceIntegrationTestSuite) createTestShow(title string) uint {
+	slug := fmt.Sprintf("%s-%d", title, time.Now().UnixNano())
+	show := &models.Show{
+		Title:     title,
+		Slug:      &slug,
+		EventDate: time.Now().Add(24 * time.Hour),
+		Status:    models.ShowStatusApproved,
+	}
+	err := suite.db.Create(show).Error
+	suite.Require().NoError(err)
+	return show.ID
+}
+
+// =============================================================================
+// Group 1: CreateComment
+// =============================================================================
+
+func (suite *CommentServiceIntegrationTestSuite) TestCreateComment_TopLevel_Artist() {
+	user := suite.createTestUser()
+	artistID := suite.createTestArtist("Test Artist")
+
+	comment, err := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "Great artist!",
+	})
+	suite.Require().NoError(err)
+	suite.NotZero(comment.ID)
+	suite.Equal("artist", comment.EntityType)
+	suite.Equal(artistID, comment.EntityID)
+	suite.Equal("comment", comment.Kind)
+	suite.Equal(user.ID, comment.UserID)
+	suite.Equal("Great artist!", comment.Body)
+	suite.Contains(comment.BodyHTML, "Great artist!")
+	suite.Equal("visible", comment.Visibility)
+	suite.Equal("anyone", comment.ReplyPermission)
+	suite.Equal(0, comment.Depth)
+	suite.Nil(comment.ParentID)
+	suite.Nil(comment.RootID)
+	suite.Equal(0, comment.Ups)
+	suite.Equal(0, comment.Downs)
+	suite.False(comment.IsEdited)
+	suite.Equal("Test", comment.AuthorName)
+}
+
+func (suite *CommentServiceIntegrationTestSuite) TestCreateComment_TopLevel_Venue() {
+	user := suite.createTestUser()
+	venueID := suite.createTestVenue("The Rebel Lounge")
+
+	comment, err := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "venue",
+		EntityID:   venueID,
+		Body:       "Best venue in town!",
+	})
+	suite.Require().NoError(err)
+	suite.Equal("venue", comment.EntityType)
+	suite.Equal(venueID, comment.EntityID)
+}
+
+func (suite *CommentServiceIntegrationTestSuite) TestCreateComment_TopLevel_Show() {
+	user := suite.createTestUser()
+	showID := suite.createTestShow("Test Show")
+
+	comment, err := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "show",
+		EntityID:   showID,
+		Body:       "Can't wait for this show!",
+	})
+	suite.Require().NoError(err)
+	suite.Equal("show", comment.EntityType)
+	suite.Equal(showID, comment.EntityID)
+}
+
+func (suite *CommentServiceIntegrationTestSuite) TestCreateComment_EntityNotFound() {
+	user := suite.createTestUser()
+
+	_, err := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   999999,
+		Body:       "This won't work",
+	})
+	suite.Error(err)
+	suite.Contains(err.Error(), "not found")
+}
+
+func (suite *CommentServiceIntegrationTestSuite) TestCreateComment_WithReplyPermission() {
+	user := suite.createTestUser()
+	artistID := suite.createTestArtist("Locked Artist")
+
+	comment, err := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType:      "artist",
+		EntityID:        artistID,
+		Body:            "No replies please",
+		ReplyPermission: "author_only",
+	})
+	suite.Require().NoError(err)
+	suite.Equal("author_only", comment.ReplyPermission)
+}
+
+func (suite *CommentServiceIntegrationTestSuite) TestCreateComment_MarkdownRendered() {
+	user := suite.createTestUser()
+	artistID := suite.createTestArtist("Markdown Artist")
+
+	comment, err := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "**bold** and *italic*",
+	})
+	suite.Require().NoError(err)
+	suite.Contains(comment.BodyHTML, "<strong>bold</strong>")
+	suite.Contains(comment.BodyHTML, "<em>italic</em>")
+}
+
+// =============================================================================
+// Group 2: CreateComment — Replies (Threading)
+// =============================================================================
+
+func (suite *CommentServiceIntegrationTestSuite) TestCreateComment_Reply() {
+	user := suite.createTestUser()
+	artistID := suite.createTestArtist("Reply Artist")
+
+	// Create top-level comment
+	root, err := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "Root comment",
+	})
+	suite.Require().NoError(err)
+
+	// Create reply
+	reply, err := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "Reply comment",
+		ParentID:   &root.ID,
+	})
+	suite.Require().NoError(err)
+
+	suite.Equal(1, reply.Depth)
+	suite.NotNil(reply.ParentID)
+	suite.Equal(root.ID, *reply.ParentID)
+	suite.NotNil(reply.RootID)
+	suite.Equal(root.ID, *reply.RootID)
+}
+
+func (suite *CommentServiceIntegrationTestSuite) TestCreateComment_NestedReply() {
+	user := suite.createTestUser()
+	artistID := suite.createTestArtist("Nested Reply Artist")
+
+	// Depth 0: root
+	root, err := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "Depth 0",
+	})
+	suite.Require().NoError(err)
+
+	// Depth 1: reply to root
+	reply1, err := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "Depth 1",
+		ParentID:   &root.ID,
+	})
+	suite.Require().NoError(err)
+	suite.Equal(1, reply1.Depth)
+
+	// Depth 2: reply to reply (max allowed)
+	reply2, err := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "Depth 2",
+		ParentID:   &reply1.ID,
+	})
+	suite.Require().NoError(err)
+	suite.Equal(2, reply2.Depth)
+	suite.Equal(root.ID, *reply2.RootID) // root_id should always point to the thread root
+}
+
+func (suite *CommentServiceIntegrationTestSuite) TestCreateComment_DepthLimitExceeded() {
+	user := suite.createTestUser()
+	artistID := suite.createTestArtist("Deep Artist")
+
+	// Create chain: depth 0 → 1 → 2
+	root, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "Root",
+	})
+	reply1, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "Reply 1",
+		ParentID:   &root.ID,
+	})
+	reply2, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "Reply 2",
+		ParentID:   &reply1.ID,
+	})
+
+	// Attempt depth 3 — should fail
+	_, err := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "Too deep",
+		ParentID:   &reply2.ID,
+	})
+	suite.Error(err)
+	suite.Contains(err.Error(), "maximum reply depth")
+}
+
+func (suite *CommentServiceIntegrationTestSuite) TestCreateComment_ParentNotFound() {
+	user := suite.createTestUser()
+	artistID := suite.createTestArtist("Missing Parent Artist")
+
+	badParent := uint(999999)
+	_, err := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "Orphan reply",
+		ParentID:   &badParent,
+	})
+	suite.Error(err)
+	suite.Contains(err.Error(), "parent comment not found")
+}
+
+func (suite *CommentServiceIntegrationTestSuite) TestCreateComment_ParentOnDifferentEntity() {
+	user := suite.createTestUser()
+	artist1ID := suite.createTestArtist("Artist 1")
+	artist2ID := suite.createTestArtist("Artist 2")
+
+	// Comment on artist 1
+	root, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artist1ID,
+		Body:       "Comment on artist 1",
+	})
+
+	// Try to reply but claim it's on artist 2
+	_, err := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artist2ID,
+		Body:       "Cross-entity reply",
+		ParentID:   &root.ID,
+	})
+	suite.Error(err)
+	suite.Contains(err.Error(), "parent comment belongs to a different entity")
+}
+
+// =============================================================================
+// Group 3: GetComment
+// =============================================================================
+
+func (suite *CommentServiceIntegrationTestSuite) TestGetComment_Success() {
+	user := suite.createTestUser()
+	artistID := suite.createTestArtist("Get Artist")
+
+	created, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "Test get",
+	})
+
+	fetched, err := suite.commentService.GetComment(created.ID)
+	suite.Require().NoError(err)
+	suite.Equal(created.ID, fetched.ID)
+	suite.Equal("Test get", fetched.Body)
+}
+
+func (suite *CommentServiceIntegrationTestSuite) TestGetComment_NotFound() {
+	_, err := suite.commentService.GetComment(999999)
+	suite.Error(err)
+	suite.Contains(err.Error(), "comment not found")
+}
+
+// =============================================================================
+// Group 4: ListCommentsForEntity
+// =============================================================================
+
+func (suite *CommentServiceIntegrationTestSuite) TestListComments_BasicPagination() {
+	user := suite.createTestUser()
+	artistID := suite.createTestArtist("List Artist")
+
+	// Create 5 comments
+	for i := 0; i < 5; i++ {
+		suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+			EntityType: "artist",
+			EntityID:   artistID,
+			Body:       fmt.Sprintf("Comment %d", i),
+		})
+	}
+
+	// Page 1 (limit 2)
+	result, err := suite.commentService.ListCommentsForEntity("artist", artistID, contracts.CommentListFilters{
+		Limit: 2,
+	})
+	suite.Require().NoError(err)
+	suite.Len(result.Comments, 2)
+	suite.Equal(int64(5), result.Total)
+	suite.True(result.HasMore)
+
+	// Page 3 (offset 4, limit 2)
+	result, err = suite.commentService.ListCommentsForEntity("artist", artistID, contracts.CommentListFilters{
+		Limit:  2,
+		Offset: 4,
+	})
+	suite.Require().NoError(err)
+	suite.Len(result.Comments, 1)
+	suite.False(result.HasMore)
+}
+
+func (suite *CommentServiceIntegrationTestSuite) TestListComments_TopLevelOnly() {
+	user := suite.createTestUser()
+	artistID := suite.createTestArtist("Top Level Only Artist")
+
+	// Create a root and a reply
+	root, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "Root comment",
+	})
+	suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "Reply comment",
+		ParentID:   &root.ID,
+	})
+
+	// List should only return top-level
+	result, err := suite.commentService.ListCommentsForEntity("artist", artistID, contracts.CommentListFilters{})
+	suite.Require().NoError(err)
+	suite.Len(result.Comments, 1)
+	suite.Equal("Root comment", result.Comments[0].Body)
+}
+
+func (suite *CommentServiceIntegrationTestSuite) TestListComments_SortByNew() {
+	user := suite.createTestUser()
+	artistID := suite.createTestArtist("Sort New Artist")
+
+	c1, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "First comment",
+	})
+	time.Sleep(10 * time.Millisecond)
+	c2, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "Second comment",
+	})
+
+	result, err := suite.commentService.ListCommentsForEntity("artist", artistID, contracts.CommentListFilters{
+		Sort: "new",
+	})
+	suite.Require().NoError(err)
+	suite.Require().Len(result.Comments, 2)
+	// Newest first
+	suite.Equal(c2.ID, result.Comments[0].ID)
+	suite.Equal(c1.ID, result.Comments[1].ID)
+}
+
+func (suite *CommentServiceIntegrationTestSuite) TestListComments_SortByBest() {
+	user := suite.createTestUser()
+	artistID := suite.createTestArtist("Sort Best Artist")
+
+	// Create two comments, manually set different scores
+	c1, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "Low score",
+	})
+	c2, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "High score",
+	})
+
+	// Manually set scores (simulate voting)
+	suite.db.Model(&models.Comment{}).Where("id = ?", c1.ID).Update("score", 0.1)
+	suite.db.Model(&models.Comment{}).Where("id = ?", c2.ID).Update("score", 0.9)
+
+	result, err := suite.commentService.ListCommentsForEntity("artist", artistID, contracts.CommentListFilters{
+		Sort: "best",
+	})
+	suite.Require().NoError(err)
+	suite.Require().Len(result.Comments, 2)
+	suite.Equal(c2.ID, result.Comments[0].ID) // Higher score first
+	suite.Equal(c1.ID, result.Comments[1].ID)
+}
+
+func (suite *CommentServiceIntegrationTestSuite) TestListComments_FilterByKind() {
+	user := suite.createTestUser()
+	showID := suite.createTestShow("Kind Filter Show")
+
+	// Create one comment and one field_note
+	suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "show",
+		EntityID:   showID,
+		Body:       "Regular comment",
+		Kind:       "comment",
+	})
+	suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "show",
+		EntityID:   showID,
+		Body:       "Field note content",
+		Kind:       "field_note",
+	})
+
+	// Filter for field_notes only
+	result, err := suite.commentService.ListCommentsForEntity("show", showID, contracts.CommentListFilters{
+		Kind: "field_note",
+	})
+	suite.Require().NoError(err)
+	suite.Len(result.Comments, 1)
+	suite.Equal("field_note", result.Comments[0].Kind)
+}
+
+func (suite *CommentServiceIntegrationTestSuite) TestListComments_HiddenNotVisible() {
+	user := suite.createTestUser()
+	artistID := suite.createTestArtist("Hidden Artist")
+
+	// Create a comment then soft-delete it
+	comment, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "Will be hidden",
+	})
+	suite.commentService.DeleteComment(user.ID, comment.ID, false)
+
+	// List should not include hidden comments by default
+	result, err := suite.commentService.ListCommentsForEntity("artist", artistID, contracts.CommentListFilters{})
+	suite.Require().NoError(err)
+	suite.Len(result.Comments, 0)
+}
+
+func (suite *CommentServiceIntegrationTestSuite) TestListComments_InvalidEntityType() {
+	_, err := suite.commentService.ListCommentsForEntity("banana", 1, contracts.CommentListFilters{})
+	suite.Error(err)
+	suite.Contains(err.Error(), "unsupported entity type")
+}
+
+// =============================================================================
+// Group 5: GetThread
+// =============================================================================
+
+func (suite *CommentServiceIntegrationTestSuite) TestGetThread_FullThread() {
+	user := suite.createTestUser()
+	artistID := suite.createTestArtist("Thread Artist")
+
+	root, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "Thread root",
+	})
+	reply1, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "Reply 1",
+		ParentID:   &root.ID,
+	})
+	suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "Reply to reply 1",
+		ParentID:   &reply1.ID,
+	})
+
+	thread, err := suite.commentService.GetThread(root.ID)
+	suite.Require().NoError(err)
+	suite.Len(thread, 3) // root + 2 replies
+
+	// Should be in chronological order
+	suite.Equal("Thread root", thread[0].Body)
+	suite.Equal("Reply 1", thread[1].Body)
+	suite.Equal("Reply to reply 1", thread[2].Body)
+}
+
+func (suite *CommentServiceIntegrationTestSuite) TestGetThread_NotFound() {
+	_, err := suite.commentService.GetThread(999999)
+	suite.Error(err)
+	suite.Contains(err.Error(), "thread root comment not found")
+}
+
+func (suite *CommentServiceIntegrationTestSuite) TestGetThread_NotARoot() {
+	user := suite.createTestUser()
+	artistID := suite.createTestArtist("Not Root Artist")
+
+	root, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "Root",
+	})
+	reply, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "Reply",
+		ParentID:   &root.ID,
+	})
+
+	_, err := suite.commentService.GetThread(reply.ID)
+	suite.Error(err)
+	suite.Contains(err.Error(), "not a thread root")
+}
+
+// =============================================================================
+// Group 6: UpdateComment
+// =============================================================================
+
+func (suite *CommentServiceIntegrationTestSuite) TestUpdateComment_OwnComment() {
+	user := suite.createTestUser()
+	artistID := suite.createTestArtist("Update Artist")
+
+	original, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "Original body",
+	})
+
+	updated, err := suite.commentService.UpdateComment(user.ID, original.ID, &contracts.UpdateCommentRequest{
+		Body: "Updated body",
+	})
+	suite.Require().NoError(err)
+	suite.Equal("Updated body", updated.Body)
+	suite.Contains(updated.BodyHTML, "Updated body")
+	suite.True(updated.IsEdited)
+	suite.Equal(1, updated.EditCount)
+}
+
+func (suite *CommentServiceIntegrationTestSuite) TestUpdateComment_EditHistoryAppended() {
+	user := suite.createTestUser()
+	artistID := suite.createTestArtist("Edit History Artist")
+
+	original, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "Version 1",
+	})
+
+	suite.commentService.UpdateComment(user.ID, original.ID, &contracts.UpdateCommentRequest{
+		Body: "Version 2",
+	})
+	suite.commentService.UpdateComment(user.ID, original.ID, &contracts.UpdateCommentRequest{
+		Body: "Version 3",
+	})
+
+	// Check edit history
+	var edits []models.CommentEdit
+	suite.db.Where("comment_id = ?", original.ID).Order("edited_at ASC").Find(&edits)
+	suite.Len(edits, 2)
+	suite.Equal("Version 1", edits[0].OldBody)
+	suite.Equal("Version 2", edits[1].OldBody)
+}
+
+func (suite *CommentServiceIntegrationTestSuite) TestUpdateComment_OtherUserFails() {
+	user1 := suite.createTestUser()
+	user2 := suite.createTestUser()
+	artistID := suite.createTestArtist("Unauthorized Update Artist")
+
+	comment, _ := suite.commentService.CreateComment(user1.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "User 1's comment",
+	})
+
+	_, err := suite.commentService.UpdateComment(user2.ID, comment.ID, &contracts.UpdateCommentRequest{
+		Body: "User 2 trying to edit",
+	})
+	suite.Error(err)
+	suite.Contains(err.Error(), "only the comment author can edit")
+}
+
+func (suite *CommentServiceIntegrationTestSuite) TestUpdateComment_NotFound() {
+	user := suite.createTestUser()
+
+	_, err := suite.commentService.UpdateComment(user.ID, 999999, &contracts.UpdateCommentRequest{
+		Body: "Update missing comment",
+	})
+	suite.Error(err)
+	suite.Contains(err.Error(), "comment not found")
+}
+
+// =============================================================================
+// Group 7: DeleteComment
+// =============================================================================
+
+func (suite *CommentServiceIntegrationTestSuite) TestDeleteComment_OwnComment() {
+	user := suite.createTestUser()
+	artistID := suite.createTestArtist("Delete Own Artist")
+
+	comment, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "Will delete myself",
+	})
+
+	err := suite.commentService.DeleteComment(user.ID, comment.ID, false)
+	suite.Require().NoError(err)
+
+	// Verify visibility changed
+	var c models.Comment
+	suite.db.First(&c, comment.ID)
+	suite.Equal(models.CommentVisibilityHiddenByUser, c.Visibility)
+}
+
+func (suite *CommentServiceIntegrationTestSuite) TestDeleteComment_AdminDeletesOther() {
+	user := suite.createTestUser()
+	admin := suite.createTestAdmin()
+	artistID := suite.createTestArtist("Admin Delete Artist")
+
+	comment, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "Will be moderated",
+	})
+
+	err := suite.commentService.DeleteComment(admin.ID, comment.ID, true)
+	suite.Require().NoError(err)
+
+	// Verify visibility changed to hidden_by_mod
+	var c models.Comment
+	suite.db.First(&c, comment.ID)
+	suite.Equal(models.CommentVisibilityHiddenByMod, c.Visibility)
+}
+
+func (suite *CommentServiceIntegrationTestSuite) TestDeleteComment_NonAuthorNonAdminFails() {
+	user1 := suite.createTestUser()
+	user2 := suite.createTestUser()
+	artistID := suite.createTestArtist("Unauthorized Delete Artist")
+
+	comment, _ := suite.commentService.CreateComment(user1.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "User 1's comment",
+	})
+
+	err := suite.commentService.DeleteComment(user2.ID, comment.ID, false)
+	suite.Error(err)
+	suite.Contains(err.Error(), "only the comment author or an admin")
+}
+
+func (suite *CommentServiceIntegrationTestSuite) TestDeleteComment_NotFound() {
+	err := suite.commentService.DeleteComment(1, 999999, false)
+	suite.Error(err)
+	suite.Contains(err.Error(), "comment not found")
+}
+
+func (suite *CommentServiceIntegrationTestSuite) TestDeleteComment_AdminDeletesOwnAsUserHidden() {
+	admin := suite.createTestAdmin()
+	artistID := suite.createTestArtist("Admin Self Delete Artist")
+
+	comment, _ := suite.commentService.CreateComment(admin.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "Admin's own comment",
+	})
+
+	// Admin deleting own comment should be hidden_by_user (author=admin)
+	err := suite.commentService.DeleteComment(admin.ID, comment.ID, true)
+	suite.Require().NoError(err)
+
+	var c models.Comment
+	suite.db.First(&c, comment.ID)
+	suite.Equal(models.CommentVisibilityHiddenByUser, c.Visibility)
+}
+
+// =============================================================================
+// Group 8: Sort by "top" and "controversial"
+// =============================================================================
+
+func (suite *CommentServiceIntegrationTestSuite) TestListComments_SortByTop() {
+	user := suite.createTestUser()
+	artistID := suite.createTestArtist("Sort Top Artist")
+
+	c1, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "Low net",
+	})
+	c2, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "High net",
+	})
+
+	// c1: 2 ups, 3 downs = -1 net
+	suite.db.Model(&models.Comment{}).Where("id = ?", c1.ID).Updates(map[string]interface{}{"ups": 2, "downs": 3})
+	// c2: 10 ups, 1 down = 9 net
+	suite.db.Model(&models.Comment{}).Where("id = ?", c2.ID).Updates(map[string]interface{}{"ups": 10, "downs": 1})
+
+	result, err := suite.commentService.ListCommentsForEntity("artist", artistID, contracts.CommentListFilters{
+		Sort: "top",
+	})
+	suite.Require().NoError(err)
+	suite.Require().Len(result.Comments, 2)
+	suite.Equal(c2.ID, result.Comments[0].ID) // Higher net first
+}
+
+func (suite *CommentServiceIntegrationTestSuite) TestListComments_SortByControversial() {
+	user := suite.createTestUser()
+	artistID := suite.createTestArtist("Controversial Artist")
+
+	c1, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "Not controversial",
+	})
+	c2, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "Very controversial",
+	})
+
+	// c1: 1 up, 0 down — 1 total, 1 abs diff
+	suite.db.Model(&models.Comment{}).Where("id = ?", c1.ID).Updates(map[string]interface{}{"ups": 1, "downs": 0})
+	// c2: 50 ups, 50 downs — 100 total, 0 abs diff (most controversial)
+	suite.db.Model(&models.Comment{}).Where("id = ?", c2.ID).Updates(map[string]interface{}{"ups": 50, "downs": 50})
+
+	result, err := suite.commentService.ListCommentsForEntity("artist", artistID, contracts.CommentListFilters{
+		Sort: "controversial",
+	})
+	suite.Require().NoError(err)
+	suite.Require().Len(result.Comments, 2)
+	suite.Equal(c2.ID, result.Comments[0].ID) // Most total votes + smallest diff first
+}
+
+// =============================================================================
+// Group 9: Cross-entity type validation
+// =============================================================================
+
+func (suite *CommentServiceIntegrationTestSuite) TestCreateComment_AllSupportedEntityTypes() {
+	user := suite.createTestUser()
+
+	// Artist
+	artistID := suite.createTestArtist("Entity Test Artist")
+	_, err := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist", EntityID: artistID, Body: "comment on artist",
+	})
+	suite.Require().NoError(err)
+
+	// Venue
+	venueID := suite.createTestVenue("Entity Test Venue")
+	_, err = suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "venue", EntityID: venueID, Body: "comment on venue",
+	})
+	suite.Require().NoError(err)
+
+	// Show
+	showID := suite.createTestShow("Entity Test Show")
+	_, err = suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "show", EntityID: showID, Body: "comment on show",
+	})
+	suite.Require().NoError(err)
+}
+
+// =============================================================================
+// Group 10: Edge cases
+// =============================================================================
+
+func (suite *CommentServiceIntegrationTestSuite) TestCreateComment_MaxLengthBody() {
+	user := suite.createTestUser()
+	artistID := suite.createTestArtist("Max Length Artist")
+
+	body := strings.Repeat("a", models.MaxCommentBodyLength)
+	comment, err := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       body,
+	})
+	suite.Require().NoError(err)
+	suite.Equal(models.MaxCommentBodyLength, len(comment.Body))
+}
+
+func (suite *CommentServiceIntegrationTestSuite) TestCreateComment_TrimsWhitespace() {
+	user := suite.createTestUser()
+	artistID := suite.createTestArtist("Trim Artist")
+
+	comment, err := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "  trimmed body  ",
+	})
+	suite.Require().NoError(err)
+	suite.Equal("trimmed body", comment.Body)
+}
+
+func (suite *CommentServiceIntegrationTestSuite) TestListComments_EmptyResult() {
+	user := suite.createTestUser()
+	artistID := suite.createTestArtist("Empty Artist")
+	_ = user
+
+	result, err := suite.commentService.ListCommentsForEntity("artist", artistID, contracts.CommentListFilters{})
+	suite.Require().NoError(err)
+	suite.Len(result.Comments, 0)
+	suite.Equal(int64(0), result.Total)
+	suite.False(result.HasMore)
+}
+
+func (suite *CommentServiceIntegrationTestSuite) TestGetThread_SingleRootNoReplies() {
+	user := suite.createTestUser()
+	artistID := suite.createTestArtist("Lone Root Artist")
+
+	root, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "Solo root",
+	})
+
+	thread, err := suite.commentService.GetThread(root.ID)
+	suite.Require().NoError(err)
+	suite.Len(thread, 1)
+	suite.Equal("Solo root", thread[0].Body)
+}

--- a/backend/internal/services/engagement/interfaces.go
+++ b/backend/internal/services/engagement/interfaces.go
@@ -11,4 +11,5 @@ var (
 	_ contracts.ReminderServiceInterface      = (*ReminderService)(nil)
 	_ contracts.AttendanceServiceInterface    = (*AttendanceService)(nil)
 	_ contracts.FollowServiceInterface        = (*FollowService)(nil)
+	_ contracts.CommentServiceInterface       = (*CommentService)(nil)
 )


### PR DESCRIPTION
## Summary

Foundation for the entire comment/discussion system. Wave 1 blocker — all other comment tickets depend on it.

### Migration 000064
- `comments` — polymorphic `(entity_type, entity_id)`, bounded nesting (max 3 levels), `body`/`body_html`, Wilson score precomputed, visibility/reply_permission enums
- `comment_edits` — append-only edit history
- `comment_votes` — binary up/down, composite PK

### CommentService (6 methods)
- CreateComment (validates entity existence, threading, depth, markdown), ListCommentsForEntity (4 sort modes), GetThread, UpdateComment (edit history), DeleteComment (soft delete), GetComment

### Markdown: goldmark + bluemonday (bold, italic, links, code, blockquotes, lists — no images/raw HTML)

### 69 tests passing (6 nil-DB, 5 validation, 12 markdown, 6 Wilson score, 39 integration)

Closes PSY-285

🤖 Generated with [Claude Code](https://claude.com/claude-code)