### PR TITLE
Add comment handlers and API routes (Wave 1)

### DIFF
--- a/backend/internal/api/handlers/comment.go
+++ b/backend/internal/api/handlers/comment.go
@@ -1,0 +1,436 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"psychic-homily-backend/internal/api/middleware"
+	"psychic-homily-backend/internal/logger"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// ============================================================================
+// Focused interfaces for dependency injection
+// ============================================================================
+
+// CommentReader defines the read operations for comments.
+type CommentReader interface {
+	GetComment(commentID uint) (*contracts.CommentResponse, error)
+	ListCommentsForEntity(entityType string, entityID uint, filters contracts.CommentListFilters) (*contracts.CommentListResponse, error)
+	GetThread(rootID uint) ([]*contracts.CommentResponse, error)
+}
+
+// CommentWriter defines the write operations for comments.
+type CommentWriter interface {
+	CreateComment(userID uint, req *contracts.CreateCommentRequest) (*contracts.CommentResponse, error)
+	UpdateComment(userID uint, commentID uint, req *contracts.UpdateCommentRequest) (*contracts.CommentResponse, error)
+	DeleteComment(userID uint, commentID uint, isAdmin bool) error
+}
+
+// CommentHandler handles comment-related API requests.
+type CommentHandler struct {
+	reader          CommentReader
+	writer          CommentWriter
+	auditLogService contracts.AuditLogServiceInterface
+}
+
+// NewCommentHandler creates a new CommentHandler.
+func NewCommentHandler(reader CommentReader, writer CommentWriter, auditLogService contracts.AuditLogServiceInterface) *CommentHandler {
+	return &CommentHandler{
+		reader:          reader,
+		writer:          writer,
+		auditLogService: auditLogService,
+	}
+}
+
+// ============================================================================
+// List Comments for Entity (public, optional auth)
+// ============================================================================
+
+// ListCommentsRequest represents the request for listing comments on an entity.
+type ListCommentsRequest struct {
+	EntityType string `path:"entity_type" doc:"Entity type (artist, venue, show, release, label, festival, collection)" example:"show"`
+	EntityID   string `path:"entity_id" doc:"Entity ID" example:"1"`
+	Sort       string `query:"sort" required:"false" doc:"Sort order: best, new, top, controversial (default: best)" example:"best"`
+	Limit      int    `query:"limit" required:"false" doc:"Page size (default 25, max 100)" example:"25"`
+	Offset     int    `query:"offset" required:"false" doc:"Pagination offset" example:"0"`
+}
+
+// ListCommentsResponse represents the response for listing comments.
+type ListCommentsResponse struct {
+	Body *contracts.CommentListResponse
+}
+
+// ListCommentsHandler handles GET /entities/{entity_type}/{entity_id}/comments
+func (h *CommentHandler) ListCommentsHandler(ctx context.Context, req *ListCommentsRequest) (*ListCommentsResponse, error) {
+	entityID, err := strconv.ParseUint(req.EntityID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid entity ID")
+	}
+
+	limit := req.Limit
+	if limit <= 0 {
+		limit = 25
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	offset := req.Offset
+	if offset < 0 {
+		offset = 0
+	}
+
+	filters := contracts.CommentListFilters{
+		Sort:   req.Sort,
+		Limit:  limit,
+		Offset: offset,
+	}
+
+	result, err := h.reader.ListCommentsForEntity(req.EntityType, uint(entityID), filters)
+	if err != nil {
+		if strings.Contains(err.Error(), "unsupported entity type") {
+			return nil, huma.Error400BadRequest(err.Error())
+		}
+		return nil, huma.Error500InternalServerError("Failed to fetch comments")
+	}
+
+	return &ListCommentsResponse{Body: result}, nil
+}
+
+// ============================================================================
+// Get Comment (public)
+// ============================================================================
+
+// GetCommentRequest represents the request for getting a single comment.
+type GetCommentRequest struct {
+	CommentID string `path:"comment_id" doc:"Comment ID" example:"1"`
+}
+
+// GetCommentResponse represents the response for a single comment.
+type GetCommentResponse struct {
+	Body *contracts.CommentResponse
+}
+
+// GetCommentHandler handles GET /comments/{comment_id}
+func (h *CommentHandler) GetCommentHandler(ctx context.Context, req *GetCommentRequest) (*GetCommentResponse, error) {
+	commentID, err := strconv.ParseUint(req.CommentID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid comment ID")
+	}
+
+	comment, err := h.reader.GetComment(uint(commentID))
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return nil, huma.Error404NotFound("Comment not found")
+		}
+		return nil, huma.Error500InternalServerError("Failed to fetch comment")
+	}
+
+	return &GetCommentResponse{Body: comment}, nil
+}
+
+// ============================================================================
+// Get Thread (public)
+// ============================================================================
+
+// GetThreadRequest represents the request for getting a full comment thread.
+type GetThreadRequest struct {
+	CommentID string `path:"comment_id" doc:"Root comment ID" example:"1"`
+}
+
+// GetThreadResponse represents the response for a comment thread.
+type GetThreadResponse struct {
+	Body struct {
+		Comments []*contracts.CommentResponse `json:"comments" doc:"All comments in the thread, ordered by created_at"`
+	}
+}
+
+// GetThreadHandler handles GET /comments/{comment_id}/thread
+func (h *CommentHandler) GetThreadHandler(ctx context.Context, req *GetThreadRequest) (*GetThreadResponse, error) {
+	commentID, err := strconv.ParseUint(req.CommentID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid comment ID")
+	}
+
+	comments, err := h.reader.GetThread(uint(commentID))
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return nil, huma.Error404NotFound("Thread not found")
+		}
+		if strings.Contains(err.Error(), "not a thread root") {
+			return nil, huma.Error400BadRequest("Comment is not a thread root")
+		}
+		return nil, huma.Error500InternalServerError("Failed to fetch thread")
+	}
+
+	resp := &GetThreadResponse{}
+	resp.Body.Comments = comments
+	return resp, nil
+}
+
+// ============================================================================
+// Create Comment (protected)
+// ============================================================================
+
+// CreateCommentRequest represents the request for creating a top-level comment.
+type CreateCommentRequest struct {
+	EntityType string `path:"entity_type" doc:"Entity type (artist, venue, show, release, label, festival, collection)" example:"show"`
+	EntityID   string `path:"entity_id" doc:"Entity ID" example:"1"`
+	Body       struct {
+		Body            string `json:"body" doc:"Comment body (Markdown)" example:"Great show last night!"`
+		ReplyPermission string `json:"reply_permission,omitempty" required:"false" doc:"Who can reply: anyone, author_only (default: anyone)" example:"anyone"`
+	}
+}
+
+// CreateCommentResponse represents the response for creating a comment.
+type CreateCommentResponse struct {
+	Body *contracts.CommentResponse
+}
+
+// CreateCommentHandler handles POST /entities/{entity_type}/{entity_id}/comments
+func (h *CommentHandler) CreateCommentHandler(ctx context.Context, req *CreateCommentRequest) (*CreateCommentResponse, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	entityID, err := strconv.ParseUint(req.EntityID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid entity ID")
+	}
+
+	if strings.TrimSpace(req.Body.Body) == "" {
+		return nil, huma.Error400BadRequest("Comment body is required")
+	}
+
+	serviceReq := &contracts.CreateCommentRequest{
+		EntityType:      req.EntityType,
+		EntityID:        uint(entityID),
+		Body:            req.Body.Body,
+		ReplyPermission: req.Body.ReplyPermission,
+	}
+
+	comment, err := h.writer.CreateComment(user.ID, serviceReq)
+	if err != nil {
+		if strings.Contains(err.Error(), "unsupported entity type") {
+			return nil, huma.Error400BadRequest(err.Error())
+		}
+		if strings.Contains(err.Error(), "not found") {
+			return nil, huma.Error404NotFound(err.Error())
+		}
+		if strings.Contains(err.Error(), "body is required") || strings.Contains(err.Error(), "exceeds maximum length") {
+			return nil, huma.Error400BadRequest(err.Error())
+		}
+		requestID := logger.GetRequestID(ctx)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to create comment (request_id: %s)", requestID),
+		)
+	}
+
+	// Audit log (fire and forget)
+	if h.auditLogService != nil {
+		go func() {
+			h.auditLogService.LogAction(user.ID, "create_comment", req.EntityType, comment.ID, map[string]interface{}{
+				"entity_id": uint(entityID),
+			})
+		}()
+	}
+
+	return &CreateCommentResponse{Body: comment}, nil
+}
+
+// ============================================================================
+// Create Reply (protected)
+// ============================================================================
+
+// CreateReplyRequest represents the request for replying to a comment.
+type CreateReplyRequest struct {
+	CommentID string `path:"comment_id" doc:"Parent comment ID" example:"1"`
+	Body      struct {
+		Body            string `json:"body" doc:"Reply body (Markdown)" example:"I agree, the opener was amazing!"`
+		ReplyPermission string `json:"reply_permission,omitempty" required:"false" doc:"Who can reply: anyone, author_only (default: anyone)" example:"anyone"`
+	}
+}
+
+// CreateReplyResponse represents the response for creating a reply.
+type CreateReplyResponse struct {
+	Body *contracts.CommentResponse
+}
+
+// CreateReplyHandler handles POST /comments/{comment_id}/replies
+func (h *CommentHandler) CreateReplyHandler(ctx context.Context, req *CreateReplyRequest) (*CreateReplyResponse, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	parentID, err := strconv.ParseUint(req.CommentID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid comment ID")
+	}
+
+	if strings.TrimSpace(req.Body.Body) == "" {
+		return nil, huma.Error400BadRequest("Reply body is required")
+	}
+
+	// Look up parent comment to get entity_type and entity_id
+	parent, err := h.reader.GetComment(uint(parentID))
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return nil, huma.Error404NotFound("Parent comment not found")
+		}
+		return nil, huma.Error500InternalServerError("Failed to fetch parent comment")
+	}
+
+	parentIDUint := uint(parentID)
+	serviceReq := &contracts.CreateCommentRequest{
+		EntityType:      parent.EntityType,
+		EntityID:        parent.EntityID,
+		Body:            req.Body.Body,
+		ParentID:        &parentIDUint,
+		ReplyPermission: req.Body.ReplyPermission,
+	}
+
+	comment, err := h.writer.CreateComment(user.ID, serviceReq)
+	if err != nil {
+		if strings.Contains(err.Error(), "maximum reply depth") {
+			return nil, huma.Error400BadRequest(err.Error())
+		}
+		if strings.Contains(err.Error(), "body is required") || strings.Contains(err.Error(), "exceeds maximum length") {
+			return nil, huma.Error400BadRequest(err.Error())
+		}
+		if strings.Contains(err.Error(), "parent comment belongs to a different entity") {
+			return nil, huma.Error400BadRequest(err.Error())
+		}
+		requestID := logger.GetRequestID(ctx)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to create reply (request_id: %s)", requestID),
+		)
+	}
+
+	// Audit log (fire and forget)
+	if h.auditLogService != nil {
+		go func() {
+			h.auditLogService.LogAction(user.ID, "create_comment", parent.EntityType, comment.ID, map[string]interface{}{
+				"entity_id": parent.EntityID,
+				"parent_id": parentIDUint,
+			})
+		}()
+	}
+
+	return &CreateReplyResponse{Body: comment}, nil
+}
+
+// ============================================================================
+// Update Comment (protected)
+// ============================================================================
+
+// UpdateCommentRequest represents the request for updating a comment.
+type UpdateCommentRequest struct {
+	CommentID string `path:"comment_id" doc:"Comment ID" example:"1"`
+	Body      struct {
+		Body string `json:"body" doc:"Updated comment body (Markdown)" example:"Updated: Great show last night!"`
+	}
+}
+
+// UpdateCommentResponse represents the response for updating a comment.
+type UpdateCommentResponse struct {
+	Body *contracts.CommentResponse
+}
+
+// UpdateCommentHandler handles PUT /comments/{comment_id}
+func (h *CommentHandler) UpdateCommentHandler(ctx context.Context, req *UpdateCommentRequest) (*UpdateCommentResponse, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	commentID, err := strconv.ParseUint(req.CommentID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid comment ID")
+	}
+
+	if strings.TrimSpace(req.Body.Body) == "" {
+		return nil, huma.Error400BadRequest("Comment body is required")
+	}
+
+	serviceReq := &contracts.UpdateCommentRequest{
+		Body: req.Body.Body,
+	}
+
+	comment, err := h.writer.UpdateComment(user.ID, uint(commentID), serviceReq)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return nil, huma.Error404NotFound("Comment not found")
+		}
+		if strings.Contains(err.Error(), "only the comment author") {
+			return nil, huma.Error403Forbidden("You can only edit your own comments")
+		}
+		if strings.Contains(err.Error(), "body is required") || strings.Contains(err.Error(), "exceeds maximum length") {
+			return nil, huma.Error400BadRequest(err.Error())
+		}
+		requestID := logger.GetRequestID(ctx)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to update comment (request_id: %s)", requestID),
+		)
+	}
+
+	// Audit log (fire and forget)
+	if h.auditLogService != nil {
+		go func() {
+			h.auditLogService.LogAction(user.ID, "edit_comment", "comment", uint(commentID), nil)
+		}()
+	}
+
+	return &UpdateCommentResponse{Body: comment}, nil
+}
+
+// ============================================================================
+// Delete Comment (protected)
+// ============================================================================
+
+// DeleteCommentRequest represents the request for deleting a comment.
+type DeleteCommentRequest struct {
+	CommentID string `path:"comment_id" doc:"Comment ID" example:"1"`
+}
+
+// DeleteCommentHandler handles DELETE /comments/{comment_id}
+func (h *CommentHandler) DeleteCommentHandler(ctx context.Context, req *DeleteCommentRequest) (*struct{}, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	commentID, err := strconv.ParseUint(req.CommentID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid comment ID")
+	}
+
+	err = h.writer.DeleteComment(user.ID, uint(commentID), user.IsAdmin)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return nil, huma.Error404NotFound("Comment not found")
+		}
+		if strings.Contains(err.Error(), "only the comment author or an admin") {
+			return nil, huma.Error403Forbidden("You can only delete your own comments")
+		}
+		requestID := logger.GetRequestID(ctx)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to delete comment (request_id: %s)", requestID),
+		)
+	}
+
+	// Audit log (fire and forget)
+	if h.auditLogService != nil {
+		go func() {
+			h.auditLogService.LogAction(user.ID, "delete_comment", "comment", uint(commentID), nil)
+		}()
+	}
+
+	return nil, nil
+}

--- a/backend/internal/api/handlers/comment_test.go
+++ b/backend/internal/api/handlers/comment_test.go
@@ -1,0 +1,639 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// ============================================================================
+// Test helpers
+// ============================================================================
+
+func testCommentHandler() *CommentHandler {
+	return NewCommentHandler(nil, nil, nil)
+}
+
+func commentUserCtx() context.Context {
+	return ctxWithUser(&models.User{ID: 10, IsAdmin: false})
+}
+
+func commentAdminCtx() context.Context {
+	return ctxWithUser(&models.User{ID: 1, IsAdmin: true})
+}
+
+func makeCommentResponse(id uint, entityType string, entityID uint, userID uint) *contracts.CommentResponse {
+	return &contracts.CommentResponse{
+		ID:              id,
+		EntityType:      entityType,
+		EntityID:        entityID,
+		Kind:            "comment",
+		UserID:          userID,
+		Depth:           0,
+		Body:            "Test comment body",
+		BodyHTML:        "<p>Test comment body</p>",
+		Visibility:      "visible",
+		ReplyPermission: "anyone",
+		Ups:             0,
+		Downs:           0,
+		Score:           0,
+		CreatedAt:       time.Now(),
+		UpdatedAt:       time.Now(),
+	}
+}
+
+func makeReplyResponse(id uint, parentID uint, rootID uint, entityType string, entityID uint, userID uint) *contracts.CommentResponse {
+	resp := makeCommentResponse(id, entityType, entityID, userID)
+	resp.ParentID = &parentID
+	resp.RootID = &rootID
+	resp.Depth = 1
+	return resp
+}
+
+// ============================================================================
+// Tests: ListComments — Auth & Validation
+// ============================================================================
+
+func TestListComments_InvalidEntityID(t *testing.T) {
+	h := testCommentHandler()
+	_, err := h.ListCommentsHandler(context.Background(), &ListCommentsRequest{
+		EntityType: "show",
+		EntityID:   "abc",
+	})
+	assertHumaError(t, err, 400)
+}
+
+func TestListComments_UnsupportedEntityType(t *testing.T) {
+	mock := &mockCommentService{
+		listCommentsForEntityFn: func(entityType string, entityID uint, filters contracts.CommentListFilters) (*contracts.CommentListResponse, error) {
+			return nil, fmt.Errorf("unsupported entity type: %s", entityType)
+		},
+	}
+	h := NewCommentHandler(mock, mock, nil)
+	_, err := h.ListCommentsHandler(context.Background(), &ListCommentsRequest{
+		EntityType: "invalid_type",
+		EntityID:   "1",
+	})
+	assertHumaError(t, err, 400)
+}
+
+func TestListComments_Success(t *testing.T) {
+	comments := []*contracts.CommentResponse{makeCommentResponse(1, "show", 5, 10)}
+	mock := &mockCommentService{
+		listCommentsForEntityFn: func(entityType string, entityID uint, filters contracts.CommentListFilters) (*contracts.CommentListResponse, error) {
+			if entityType != "show" || entityID != 5 {
+				t.Errorf("unexpected entity: %s/%d", entityType, entityID)
+			}
+			if filters.Sort != "new" {
+				t.Errorf("expected sort=new, got %s", filters.Sort)
+			}
+			if filters.Limit != 25 {
+				t.Errorf("expected limit=25, got %d", filters.Limit)
+			}
+			return &contracts.CommentListResponse{
+				Comments: comments,
+				Total:    1,
+				HasMore:  false,
+			}, nil
+		},
+	}
+	h := NewCommentHandler(mock, mock, nil)
+	resp, err := h.ListCommentsHandler(context.Background(), &ListCommentsRequest{
+		EntityType: "show",
+		EntityID:   "5",
+		Sort:       "new",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Total != 1 {
+		t.Errorf("expected total=1, got %d", resp.Body.Total)
+	}
+	if len(resp.Body.Comments) != 1 {
+		t.Errorf("expected 1 comment, got %d", len(resp.Body.Comments))
+	}
+}
+
+func TestListComments_DefaultLimit(t *testing.T) {
+	mock := &mockCommentService{
+		listCommentsForEntityFn: func(entityType string, entityID uint, filters contracts.CommentListFilters) (*contracts.CommentListResponse, error) {
+			if filters.Limit != 25 {
+				t.Errorf("expected default limit=25, got %d", filters.Limit)
+			}
+			return &contracts.CommentListResponse{Comments: []*contracts.CommentResponse{}, Total: 0}, nil
+		},
+	}
+	h := NewCommentHandler(mock, mock, nil)
+	_, err := h.ListCommentsHandler(context.Background(), &ListCommentsRequest{
+		EntityType: "artist",
+		EntityID:   "1",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestListComments_LimitCap(t *testing.T) {
+	mock := &mockCommentService{
+		listCommentsForEntityFn: func(entityType string, entityID uint, filters contracts.CommentListFilters) (*contracts.CommentListResponse, error) {
+			if filters.Limit != 100 {
+				t.Errorf("expected capped limit=100, got %d", filters.Limit)
+			}
+			return &contracts.CommentListResponse{Comments: []*contracts.CommentResponse{}, Total: 0}, nil
+		},
+	}
+	h := NewCommentHandler(mock, mock, nil)
+	_, err := h.ListCommentsHandler(context.Background(), &ListCommentsRequest{
+		EntityType: "artist",
+		EntityID:   "1",
+		Limit:      500,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestListComments_ServiceError(t *testing.T) {
+	mock := &mockCommentService{
+		listCommentsForEntityFn: func(entityType string, entityID uint, filters contracts.CommentListFilters) (*contracts.CommentListResponse, error) {
+			return nil, fmt.Errorf("database error")
+		},
+	}
+	h := NewCommentHandler(mock, mock, nil)
+	_, err := h.ListCommentsHandler(context.Background(), &ListCommentsRequest{
+		EntityType: "show",
+		EntityID:   "1",
+	})
+	assertHumaError(t, err, 500)
+}
+
+// ============================================================================
+// Tests: GetComment
+// ============================================================================
+
+func TestGetComment_InvalidID(t *testing.T) {
+	h := testCommentHandler()
+	_, err := h.GetCommentHandler(context.Background(), &GetCommentRequest{CommentID: "abc"})
+	assertHumaError(t, err, 400)
+}
+
+func TestGetComment_NotFound(t *testing.T) {
+	mock := &mockCommentService{
+		getCommentFn: func(commentID uint) (*contracts.CommentResponse, error) {
+			return nil, fmt.Errorf("comment not found")
+		},
+	}
+	h := NewCommentHandler(mock, mock, nil)
+	_, err := h.GetCommentHandler(context.Background(), &GetCommentRequest{CommentID: "99"})
+	assertHumaError(t, err, 404)
+}
+
+func TestGetComment_Success(t *testing.T) {
+	expected := makeCommentResponse(1, "show", 5, 10)
+	mock := &mockCommentService{
+		getCommentFn: func(commentID uint) (*contracts.CommentResponse, error) {
+			if commentID != 1 {
+				t.Errorf("expected commentID=1, got %d", commentID)
+			}
+			return expected, nil
+		},
+	}
+	h := NewCommentHandler(mock, mock, nil)
+	resp, err := h.GetCommentHandler(context.Background(), &GetCommentRequest{CommentID: "1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.ID != 1 {
+		t.Errorf("expected ID=1, got %d", resp.Body.ID)
+	}
+}
+
+// ============================================================================
+// Tests: GetThread
+// ============================================================================
+
+func TestGetThread_InvalidID(t *testing.T) {
+	h := testCommentHandler()
+	_, err := h.GetThreadHandler(context.Background(), &GetThreadRequest{CommentID: "abc"})
+	assertHumaError(t, err, 400)
+}
+
+func TestGetThread_NotFound(t *testing.T) {
+	mock := &mockCommentService{
+		getThreadFn: func(rootID uint) ([]*contracts.CommentResponse, error) {
+			return nil, fmt.Errorf("thread root comment not found")
+		},
+	}
+	h := NewCommentHandler(mock, mock, nil)
+	_, err := h.GetThreadHandler(context.Background(), &GetThreadRequest{CommentID: "99"})
+	assertHumaError(t, err, 404)
+}
+
+func TestGetThread_NotARoot(t *testing.T) {
+	mock := &mockCommentService{
+		getThreadFn: func(rootID uint) ([]*contracts.CommentResponse, error) {
+			return nil, fmt.Errorf("comment is not a thread root")
+		},
+	}
+	h := NewCommentHandler(mock, mock, nil)
+	_, err := h.GetThreadHandler(context.Background(), &GetThreadRequest{CommentID: "5"})
+	assertHumaError(t, err, 400)
+}
+
+func TestGetThread_Success(t *testing.T) {
+	root := makeCommentResponse(1, "show", 5, 10)
+	reply := makeReplyResponse(2, 1, 1, "show", 5, 11)
+	mock := &mockCommentService{
+		getThreadFn: func(rootID uint) ([]*contracts.CommentResponse, error) {
+			if rootID != 1 {
+				t.Errorf("expected rootID=1, got %d", rootID)
+			}
+			return []*contracts.CommentResponse{root, reply}, nil
+		},
+	}
+	h := NewCommentHandler(mock, mock, nil)
+	resp, err := h.GetThreadHandler(context.Background(), &GetThreadRequest{CommentID: "1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Body.Comments) != 2 {
+		t.Errorf("expected 2 comments, got %d", len(resp.Body.Comments))
+	}
+}
+
+// ============================================================================
+// Tests: CreateComment — Auth & Validation
+// ============================================================================
+
+func TestCreateComment_NoUser(t *testing.T) {
+	h := testCommentHandler()
+	_, err := h.CreateCommentHandler(context.Background(), &CreateCommentRequest{
+		EntityType: "show",
+		EntityID:   "1",
+	})
+	assertHumaError(t, err, 401)
+}
+
+func TestCreateComment_InvalidEntityID(t *testing.T) {
+	h := testCommentHandler()
+	_, err := h.CreateCommentHandler(commentUserCtx(), &CreateCommentRequest{
+		EntityType: "show",
+		EntityID:   "abc",
+	})
+	assertHumaError(t, err, 400)
+}
+
+func TestCreateComment_EmptyBody(t *testing.T) {
+	h := testCommentHandler()
+	req := &CreateCommentRequest{EntityType: "show", EntityID: "1"}
+	req.Body.Body = "   "
+	_, err := h.CreateCommentHandler(commentUserCtx(), req)
+	assertHumaError(t, err, 400)
+}
+
+func TestCreateComment_UnsupportedEntityType(t *testing.T) {
+	mock := &mockCommentService{
+		createCommentFn: func(userID uint, req *contracts.CreateCommentRequest) (*contracts.CommentResponse, error) {
+			return nil, fmt.Errorf("unsupported entity type: nope")
+		},
+	}
+	h := NewCommentHandler(mock, mock, nil)
+	req := &CreateCommentRequest{EntityType: "nope", EntityID: "1"}
+	req.Body.Body = "Hello"
+	_, err := h.CreateCommentHandler(commentUserCtx(), req)
+	assertHumaError(t, err, 400)
+}
+
+func TestCreateComment_EntityNotFound(t *testing.T) {
+	mock := &mockCommentService{
+		createCommentFn: func(userID uint, req *contracts.CreateCommentRequest) (*contracts.CommentResponse, error) {
+			return nil, fmt.Errorf("show with ID 999 not found")
+		},
+	}
+	h := NewCommentHandler(mock, mock, nil)
+	req := &CreateCommentRequest{EntityType: "show", EntityID: "999"}
+	req.Body.Body = "Hello"
+	_, err := h.CreateCommentHandler(commentUserCtx(), req)
+	assertHumaError(t, err, 404)
+}
+
+func TestCreateComment_Success(t *testing.T) {
+	expected := makeCommentResponse(1, "show", 5, 10)
+	mock := &mockCommentService{
+		createCommentFn: func(userID uint, req *contracts.CreateCommentRequest) (*contracts.CommentResponse, error) {
+			if userID != 10 {
+				t.Errorf("expected userID=10, got %d", userID)
+			}
+			if req.EntityType != "show" || req.EntityID != 5 {
+				t.Errorf("unexpected entity: %s/%d", req.EntityType, req.EntityID)
+			}
+			if req.Body != "Great show!" {
+				t.Errorf("unexpected body: %s", req.Body)
+			}
+			return expected, nil
+		},
+	}
+	h := NewCommentHandler(mock, mock, &mockAuditLogService{})
+	req := &CreateCommentRequest{EntityType: "show", EntityID: "5"}
+	req.Body.Body = "Great show!"
+	resp, err := h.CreateCommentHandler(commentUserCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.ID != 1 {
+		t.Errorf("expected ID=1, got %d", resp.Body.ID)
+	}
+}
+
+func TestCreateComment_WithReplyPermission(t *testing.T) {
+	mock := &mockCommentService{
+		createCommentFn: func(userID uint, req *contracts.CreateCommentRequest) (*contracts.CommentResponse, error) {
+			if req.ReplyPermission != "author_only" {
+				t.Errorf("expected reply_permission=author_only, got %s", req.ReplyPermission)
+			}
+			return makeCommentResponse(1, "show", 5, 10), nil
+		},
+	}
+	h := NewCommentHandler(mock, mock, nil)
+	req := &CreateCommentRequest{EntityType: "show", EntityID: "5"}
+	req.Body.Body = "My thoughts"
+	req.Body.ReplyPermission = "author_only"
+	_, err := h.CreateCommentHandler(commentUserCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCreateComment_ServiceError(t *testing.T) {
+	mock := &mockCommentService{
+		createCommentFn: func(userID uint, req *contracts.CreateCommentRequest) (*contracts.CommentResponse, error) {
+			return nil, fmt.Errorf("database error")
+		},
+	}
+	h := NewCommentHandler(mock, mock, nil)
+	req := &CreateCommentRequest{EntityType: "show", EntityID: "1"}
+	req.Body.Body = "Hello"
+	_, err := h.CreateCommentHandler(commentUserCtx(), req)
+	assertHumaError(t, err, 500)
+}
+
+// ============================================================================
+// Tests: CreateReply — Auth & Validation
+// ============================================================================
+
+func TestCreateReply_NoUser(t *testing.T) {
+	h := testCommentHandler()
+	_, err := h.CreateReplyHandler(context.Background(), &CreateReplyRequest{CommentID: "1"})
+	assertHumaError(t, err, 401)
+}
+
+func TestCreateReply_InvalidCommentID(t *testing.T) {
+	h := testCommentHandler()
+	_, err := h.CreateReplyHandler(commentUserCtx(), &CreateReplyRequest{CommentID: "abc"})
+	assertHumaError(t, err, 400)
+}
+
+func TestCreateReply_EmptyBody(t *testing.T) {
+	h := testCommentHandler()
+	req := &CreateReplyRequest{CommentID: "1"}
+	req.Body.Body = ""
+	_, err := h.CreateReplyHandler(commentUserCtx(), req)
+	assertHumaError(t, err, 400)
+}
+
+func TestCreateReply_ParentNotFound(t *testing.T) {
+	mock := &mockCommentService{
+		getCommentFn: func(commentID uint) (*contracts.CommentResponse, error) {
+			return nil, fmt.Errorf("comment not found")
+		},
+	}
+	h := NewCommentHandler(mock, mock, nil)
+	req := &CreateReplyRequest{CommentID: "99"}
+	req.Body.Body = "Replying..."
+	_, err := h.CreateReplyHandler(commentUserCtx(), req)
+	assertHumaError(t, err, 404)
+}
+
+func TestCreateReply_MaxDepthExceeded(t *testing.T) {
+	parent := makeCommentResponse(1, "show", 5, 10)
+	mock := &mockCommentService{
+		getCommentFn: func(commentID uint) (*contracts.CommentResponse, error) {
+			return parent, nil
+		},
+		createCommentFn: func(userID uint, req *contracts.CreateCommentRequest) (*contracts.CommentResponse, error) {
+			return nil, fmt.Errorf("maximum reply depth of 2 exceeded")
+		},
+	}
+	h := NewCommentHandler(mock, mock, nil)
+	req := &CreateReplyRequest{CommentID: "1"}
+	req.Body.Body = "Deep reply"
+	_, err := h.CreateReplyHandler(commentUserCtx(), req)
+	assertHumaError(t, err, 400)
+}
+
+func TestCreateReply_Success(t *testing.T) {
+	parent := makeCommentResponse(1, "show", 5, 10)
+	reply := makeReplyResponse(2, 1, 1, "show", 5, 10)
+	mock := &mockCommentService{
+		getCommentFn: func(commentID uint) (*contracts.CommentResponse, error) {
+			return parent, nil
+		},
+		createCommentFn: func(userID uint, req *contracts.CreateCommentRequest) (*contracts.CommentResponse, error) {
+			if req.ParentID == nil || *req.ParentID != 1 {
+				t.Errorf("expected parent_id=1")
+			}
+			if req.EntityType != "show" || req.EntityID != 5 {
+				t.Errorf("expected entity_type=show, entity_id=5")
+			}
+			return reply, nil
+		},
+	}
+	h := NewCommentHandler(mock, mock, &mockAuditLogService{})
+	req := &CreateReplyRequest{CommentID: "1"}
+	req.Body.Body = "Nice reply!"
+	resp, err := h.CreateReplyHandler(commentUserCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.ID != 2 {
+		t.Errorf("expected ID=2, got %d", resp.Body.ID)
+	}
+	if resp.Body.ParentID == nil || *resp.Body.ParentID != 1 {
+		t.Errorf("expected parent_id=1")
+	}
+}
+
+// ============================================================================
+// Tests: UpdateComment — Auth & Validation
+// ============================================================================
+
+func TestUpdateComment_NoUser(t *testing.T) {
+	h := testCommentHandler()
+	_, err := h.UpdateCommentHandler(context.Background(), &UpdateCommentRequest{CommentID: "1"})
+	assertHumaError(t, err, 401)
+}
+
+func TestUpdateComment_InvalidID(t *testing.T) {
+	h := testCommentHandler()
+	_, err := h.UpdateCommentHandler(commentUserCtx(), &UpdateCommentRequest{CommentID: "abc"})
+	assertHumaError(t, err, 400)
+}
+
+func TestUpdateComment_EmptyBody(t *testing.T) {
+	h := testCommentHandler()
+	req := &UpdateCommentRequest{CommentID: "1"}
+	req.Body.Body = "  "
+	_, err := h.UpdateCommentHandler(commentUserCtx(), req)
+	assertHumaError(t, err, 400)
+}
+
+func TestUpdateComment_NotFound(t *testing.T) {
+	mock := &mockCommentService{
+		updateCommentFn: func(userID uint, commentID uint, req *contracts.UpdateCommentRequest) (*contracts.CommentResponse, error) {
+			return nil, fmt.Errorf("comment not found")
+		},
+	}
+	h := NewCommentHandler(mock, mock, nil)
+	req := &UpdateCommentRequest{CommentID: "99"}
+	req.Body.Body = "Updated text"
+	_, err := h.UpdateCommentHandler(commentUserCtx(), req)
+	assertHumaError(t, err, 404)
+}
+
+func TestUpdateComment_ForbiddenNotAuthor(t *testing.T) {
+	mock := &mockCommentService{
+		updateCommentFn: func(userID uint, commentID uint, req *contracts.UpdateCommentRequest) (*contracts.CommentResponse, error) {
+			return nil, fmt.Errorf("only the comment author can edit this comment")
+		},
+	}
+	h := NewCommentHandler(mock, mock, nil)
+	req := &UpdateCommentRequest{CommentID: "1"}
+	req.Body.Body = "Trying to edit someone else's comment"
+	_, err := h.UpdateCommentHandler(commentUserCtx(), req)
+	assertHumaError(t, err, 403)
+}
+
+func TestUpdateComment_Success(t *testing.T) {
+	updated := makeCommentResponse(1, "show", 5, 10)
+	updated.Body = "Updated body"
+	updated.IsEdited = true
+	updated.EditCount = 1
+	mock := &mockCommentService{
+		updateCommentFn: func(userID uint, commentID uint, req *contracts.UpdateCommentRequest) (*contracts.CommentResponse, error) {
+			if userID != 10 {
+				t.Errorf("expected userID=10, got %d", userID)
+			}
+			if commentID != 1 {
+				t.Errorf("expected commentID=1, got %d", commentID)
+			}
+			if req.Body != "Updated body" {
+				t.Errorf("unexpected body: %s", req.Body)
+			}
+			return updated, nil
+		},
+	}
+	h := NewCommentHandler(mock, mock, &mockAuditLogService{})
+	req := &UpdateCommentRequest{CommentID: "1"}
+	req.Body.Body = "Updated body"
+	resp, err := h.UpdateCommentHandler(commentUserCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Body != "Updated body" {
+		t.Errorf("expected updated body, got %s", resp.Body.Body)
+	}
+	if !resp.Body.IsEdited {
+		t.Error("expected is_edited=true")
+	}
+}
+
+// ============================================================================
+// Tests: DeleteComment — Auth & Validation
+// ============================================================================
+
+func TestDeleteComment_NoUser(t *testing.T) {
+	h := testCommentHandler()
+	_, err := h.DeleteCommentHandler(context.Background(), &DeleteCommentRequest{CommentID: "1"})
+	assertHumaError(t, err, 401)
+}
+
+func TestDeleteComment_InvalidID(t *testing.T) {
+	h := testCommentHandler()
+	_, err := h.DeleteCommentHandler(commentUserCtx(), &DeleteCommentRequest{CommentID: "abc"})
+	assertHumaError(t, err, 400)
+}
+
+func TestDeleteComment_NotFound(t *testing.T) {
+	mock := &mockCommentService{
+		deleteCommentFn: func(userID uint, commentID uint, isAdmin bool) error {
+			return fmt.Errorf("comment not found")
+		},
+	}
+	h := NewCommentHandler(mock, mock, nil)
+	_, err := h.DeleteCommentHandler(commentUserCtx(), &DeleteCommentRequest{CommentID: "99"})
+	assertHumaError(t, err, 404)
+}
+
+func TestDeleteComment_ForbiddenNotAuthorOrAdmin(t *testing.T) {
+	mock := &mockCommentService{
+		deleteCommentFn: func(userID uint, commentID uint, isAdmin bool) error {
+			return fmt.Errorf("only the comment author or an admin can delete this comment")
+		},
+	}
+	h := NewCommentHandler(mock, mock, nil)
+	_, err := h.DeleteCommentHandler(commentUserCtx(), &DeleteCommentRequest{CommentID: "1"})
+	assertHumaError(t, err, 403)
+}
+
+func TestDeleteComment_SuccessOwn(t *testing.T) {
+	mock := &mockCommentService{
+		deleteCommentFn: func(userID uint, commentID uint, isAdmin bool) error {
+			if userID != 10 {
+				t.Errorf("expected userID=10, got %d", userID)
+			}
+			if commentID != 1 {
+				t.Errorf("expected commentID=1, got %d", commentID)
+			}
+			if isAdmin {
+				t.Error("expected isAdmin=false")
+			}
+			return nil
+		},
+	}
+	h := NewCommentHandler(mock, mock, &mockAuditLogService{})
+	_, err := h.DeleteCommentHandler(commentUserCtx(), &DeleteCommentRequest{CommentID: "1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDeleteComment_SuccessAdmin(t *testing.T) {
+	mock := &mockCommentService{
+		deleteCommentFn: func(userID uint, commentID uint, isAdmin bool) error {
+			if !isAdmin {
+				t.Error("expected isAdmin=true for admin delete")
+			}
+			return nil
+		},
+	}
+	h := NewCommentHandler(mock, mock, &mockAuditLogService{})
+	_, err := h.DeleteCommentHandler(commentAdminCtx(), &DeleteCommentRequest{CommentID: "1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDeleteComment_ServiceError(t *testing.T) {
+	mock := &mockCommentService{
+		deleteCommentFn: func(userID uint, commentID uint, isAdmin bool) error {
+			return fmt.Errorf("database error")
+		},
+	}
+	h := NewCommentHandler(mock, mock, nil)
+	_, err := h.DeleteCommentHandler(commentUserCtx(), &DeleteCommentRequest{CommentID: "1"})
+	assertHumaError(t, err, 500)
+}

--- a/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
+++ b/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
@@ -791,6 +791,56 @@ func (m *mockCollectionService) SetFeatured(slug string, featured bool) (error) 
 }
 
 // ============================================================================
+// Mock: CommentServiceInterface
+// ============================================================================
+
+type mockCommentService struct {
+	createCommentFn func(uint, *contracts.CreateCommentRequest) (*contracts.CommentResponse, error)
+	getCommentFn func(uint) (*contracts.CommentResponse, error)
+	listCommentsForEntityFn func(string, uint, contracts.CommentListFilters) (*contracts.CommentListResponse, error)
+	getThreadFn func(uint) ([]*contracts.CommentResponse, error)
+	updateCommentFn func(uint, uint, *contracts.UpdateCommentRequest) (*contracts.CommentResponse, error)
+	deleteCommentFn func(uint, uint, bool) (error)
+}
+
+func (m *mockCommentService) CreateComment(userID uint, req *contracts.CreateCommentRequest) (*contracts.CommentResponse, error) {
+	if m.createCommentFn != nil {
+		return m.createCommentFn(userID, req)
+	}
+	return nil, nil
+}
+func (m *mockCommentService) GetComment(commentID uint) (*contracts.CommentResponse, error) {
+	if m.getCommentFn != nil {
+		return m.getCommentFn(commentID)
+	}
+	return nil, nil
+}
+func (m *mockCommentService) ListCommentsForEntity(entityType string, entityID uint, filters contracts.CommentListFilters) (*contracts.CommentListResponse, error) {
+	if m.listCommentsForEntityFn != nil {
+		return m.listCommentsForEntityFn(entityType, entityID, filters)
+	}
+	return nil, nil
+}
+func (m *mockCommentService) GetThread(rootID uint) ([]*contracts.CommentResponse, error) {
+	if m.getThreadFn != nil {
+		return m.getThreadFn(rootID)
+	}
+	return nil, nil
+}
+func (m *mockCommentService) UpdateComment(userID uint, commentID uint, req *contracts.UpdateCommentRequest) (*contracts.CommentResponse, error) {
+	if m.updateCommentFn != nil {
+		return m.updateCommentFn(userID, commentID, req)
+	}
+	return nil, nil
+}
+func (m *mockCommentService) DeleteComment(userID uint, commentID uint, isAdmin bool) (error) {
+	if m.deleteCommentFn != nil {
+		return m.deleteCommentFn(userID, commentID, isAdmin)
+	}
+	return nil
+}
+
+// ============================================================================
 // Mock: ContributorProfileServiceInterface
 // ============================================================================
 
@@ -3579,6 +3629,7 @@ var _ contracts.AutoPromotionServiceInterface = (*mockAutoPromotionService)(nil)
 var _ contracts.CalendarServiceInterface = (*mockCalendarService)(nil)
 var _ contracts.ChartsServiceInterface = (*mockChartsService)(nil)
 var _ contracts.CollectionServiceInterface = (*mockCollectionService)(nil)
+var _ contracts.CommentServiceInterface = (*mockCommentService)(nil)
 var _ contracts.ContributorProfileServiceInterface = (*mockContributorProfileService)(nil)
 var _ contracts.DataQualityServiceInterface = (*mockDataQualityService)(nil)
 var _ contracts.DataSyncServiceInterface = (*mockDataSyncService)(nil)

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -132,6 +132,7 @@ func SetupRoutes(router *chi.Mux, sc *services.ServiceContainer, cfg *config.Con
 	setupLeaderboardRoutes(rc)
 	setupDataGapsRoutes(rc)
 	setupRadioRoutes(rc)
+	setupCommentRoutes(rc)
 
 	return api
 }
@@ -1063,4 +1064,24 @@ func setupRadioRoutes(rc RouteContext) {
 	huma.Get(rc.Protected, "/admin/radio/unmatched", radioHandler.AdminGetUnmatchedPlaysHandler)
 	huma.Post(rc.Protected, "/admin/radio/plays/{id}/link", radioHandler.AdminLinkPlayHandler)
 	huma.Post(rc.Protected, "/admin/radio/plays/bulk-link", radioHandler.AdminBulkLinkPlaysHandler)
+}
+
+// setupCommentRoutes configures comment endpoints.
+// Public routes use optional auth (could be used for user vote context in future).
+// Protected routes require authentication.
+func setupCommentRoutes(rc RouteContext) {
+	commentHandler := handlers.NewCommentHandler(rc.SC.Comment, rc.SC.Comment, rc.SC.AuditLog)
+
+	// Public: list comments, get comment, get thread
+	optionalAuthGroup := huma.NewGroup(rc.API, "")
+	optionalAuthGroup.UseMiddleware(middleware.OptionalHumaJWTMiddleware(rc.SC.JWT))
+	huma.Get(optionalAuthGroup, "/entities/{entity_type}/{entity_id}/comments", commentHandler.ListCommentsHandler)
+	huma.Get(optionalAuthGroup, "/comments/{comment_id}", commentHandler.GetCommentHandler)
+	huma.Get(optionalAuthGroup, "/comments/{comment_id}/thread", commentHandler.GetThreadHandler)
+
+	// Protected: create, reply, update, delete
+	huma.Post(rc.Protected, "/entities/{entity_type}/{entity_id}/comments", commentHandler.CreateCommentHandler)
+	huma.Post(rc.Protected, "/comments/{comment_id}/replies", commentHandler.CreateReplyHandler)
+	huma.Put(rc.Protected, "/comments/{comment_id}", commentHandler.UpdateCommentHandler)
+	huma.Delete(rc.Protected, "/comments/{comment_id}", commentHandler.DeleteCommentHandler)
 }


### PR DESCRIPTION
## Summary

HTTP layer for the comment system. Depends on PSY-285 (#294).

### 7 Endpoints
- `GET /entities/{type}/{id}/comments` — list with sort/pagination
- `GET /comments/{id}` — single comment
- `GET /comments/{id}/thread` — full thread
- `POST /entities/{type}/{id}/comments` — create top-level
- `POST /comments/{id}/replies` — create reply
- `PUT /comments/{id}` — edit own
- `DELETE /comments/{id}` — soft delete

Focused interfaces, value-type params, audit logging on mutations. 39 tests.

**Merge PSY-285 (#294) first, then rebase this.**

Closes PSY-286

🤖 Generated with [Claude Code](https://claude.com/claude-code)