### PR TITLE
Add comment voting with Wilson score sort (Wave 1)

### DIFF
--- a/backend/internal/api/handlers/comment_vote.go
+++ b/backend/internal/api/handlers/comment_vote.go
@@ -1,0 +1,139 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"psychic-homily-backend/internal/api/middleware"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// CommentVoteHandler handles comment vote API requests.
+type CommentVoteHandler struct {
+	voteService contracts.CommentVoteServiceInterface
+}
+
+// NewCommentVoteHandler creates a new handler.
+func NewCommentVoteHandler(
+	voteService contracts.CommentVoteServiceInterface,
+) *CommentVoteHandler {
+	return &CommentVoteHandler{
+		voteService: voteService,
+	}
+}
+
+// ============================================================================
+// Vote on Comment (protected)
+// ============================================================================
+
+// VoteCommentRequest is the request for casting a vote on a comment.
+type VoteCommentRequest struct {
+	CommentID string `path:"comment_id" doc:"Comment ID" example:"1"`
+	Body      struct {
+		Direction int `json:"direction" doc:"Vote direction: 1 for upvote, -1 for downvote" example:"1"`
+	}
+}
+
+// VoteCommentResponse contains the updated vote counts after a vote.
+type VoteCommentResponse struct {
+	Body contracts.CommentVoteResponse
+}
+
+// VoteCommentHandler handles upvoting or downvoting a comment.
+func (h *CommentVoteHandler) VoteCommentHandler(ctx context.Context, req *VoteCommentRequest) (*VoteCommentResponse, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	commentID, err := strconv.ParseUint(req.CommentID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid comment ID")
+	}
+
+	if req.Body.Direction != 1 && req.Body.Direction != -1 {
+		return nil, huma.Error400BadRequest("Direction must be 1 (upvote) or -1 (downvote)")
+	}
+
+	err = h.voteService.Vote(user.ID, uint(commentID), req.Body.Direction)
+	if err != nil {
+		if err.Error() == "comment not found" {
+			return nil, huma.Error404NotFound("Comment not found")
+		}
+		return nil, huma.Error500InternalServerError(fmt.Sprintf("Failed to vote: %v", err))
+	}
+
+	return h.buildVoteResponse(user.ID, uint(commentID))
+}
+
+// ============================================================================
+// Remove Vote (protected)
+// ============================================================================
+
+// UnvoteCommentRequest is the request for removing a vote on a comment.
+type UnvoteCommentRequest struct {
+	CommentID string `path:"comment_id" doc:"Comment ID" example:"1"`
+}
+
+// UnvoteCommentResponse contains the updated vote counts after removing a vote.
+type UnvoteCommentResponse struct {
+	Body contracts.CommentVoteResponse
+}
+
+// UnvoteCommentHandler removes a user's vote on a comment.
+func (h *CommentVoteHandler) UnvoteCommentHandler(ctx context.Context, req *UnvoteCommentRequest) (*UnvoteCommentResponse, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	commentID, err := strconv.ParseUint(req.CommentID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid comment ID")
+	}
+
+	err = h.voteService.Unvote(user.ID, uint(commentID))
+	if err != nil {
+		if err.Error() == "comment not found" {
+			return nil, huma.Error404NotFound("Comment not found")
+		}
+		return nil, huma.Error500InternalServerError(fmt.Sprintf("Failed to remove vote: %v", err))
+	}
+
+	return h.buildUnvoteResponse(uint(commentID))
+}
+
+// buildVoteResponse fetches current vote counts and user vote for the response.
+func (h *CommentVoteHandler) buildVoteResponse(userID uint, commentID uint) (*VoteCommentResponse, error) {
+	ups, downs, score, err := h.voteService.GetCommentVoteCounts(commentID)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Failed to get vote counts")
+	}
+
+	userVote, _ := h.voteService.GetUserVote(userID, commentID)
+
+	resp := &VoteCommentResponse{}
+	resp.Body.Ups = ups
+	resp.Body.Downs = downs
+	resp.Body.Score = score
+	resp.Body.UserVote = userVote
+	return resp, nil
+}
+
+// buildUnvoteResponse fetches current vote counts for the unvote response.
+func (h *CommentVoteHandler) buildUnvoteResponse(commentID uint) (*UnvoteCommentResponse, error) {
+	ups, downs, score, err := h.voteService.GetCommentVoteCounts(commentID)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Failed to get vote counts")
+	}
+
+	resp := &UnvoteCommentResponse{}
+	resp.Body.Ups = ups
+	resp.Body.Downs = downs
+	resp.Body.Score = score
+	resp.Body.UserVote = nil
+	return resp, nil
+}

--- a/backend/internal/api/handlers/comment_vote_test.go
+++ b/backend/internal/api/handlers/comment_vote_test.go
@@ -1,0 +1,200 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"psychic-homily-backend/internal/models"
+)
+
+// Uses auto-generated mockCommentVoteService from handler_unit_mock_helpers_test.go
+
+func testCommentVoteHandler() *CommentVoteHandler {
+	return NewCommentVoteHandler(nil)
+}
+
+// ============================================================================
+// VoteCommentHandler Tests
+// ============================================================================
+
+func TestVoteComment_NoAuth(t *testing.T) {
+	h := testCommentVoteHandler()
+	req := &VoteCommentRequest{CommentID: "1"}
+	req.Body.Direction = 1
+
+	_, err := h.VoteCommentHandler(context.Background(), req)
+	assertHumaError(t, err, 401)
+}
+
+func TestVoteComment_InvalidCommentID(t *testing.T) {
+	h := testCommentVoteHandler()
+	ctx := ctxWithUser(&models.User{ID: 1})
+	req := &VoteCommentRequest{CommentID: "abc"}
+	req.Body.Direction = 1
+
+	_, err := h.VoteCommentHandler(ctx, req)
+	assertHumaError(t, err, 400)
+}
+
+func TestVoteComment_InvalidDirectionZero(t *testing.T) {
+	h := testCommentVoteHandler()
+	ctx := ctxWithUser(&models.User{ID: 1})
+	req := &VoteCommentRequest{CommentID: "1"}
+	req.Body.Direction = 0
+
+	_, err := h.VoteCommentHandler(ctx, req)
+	assertHumaError(t, err, 400)
+}
+
+func TestVoteComment_InvalidDirectionTwo(t *testing.T) {
+	h := testCommentVoteHandler()
+	ctx := ctxWithUser(&models.User{ID: 1})
+	req := &VoteCommentRequest{CommentID: "1"}
+	req.Body.Direction = 2
+
+	_, err := h.VoteCommentHandler(ctx, req)
+	assertHumaError(t, err, 400)
+}
+
+func TestVoteComment_Success(t *testing.T) {
+	upvote := 1
+	h := NewCommentVoteHandler(&mockCommentVoteService{
+		voteFn: func(userID uint, commentID uint, direction int) error {
+			if userID != 1 || commentID != 42 || direction != 1 {
+				return fmt.Errorf("unexpected args: %d, %d, %d", userID, commentID, direction)
+			}
+			return nil
+		},
+		getCommentVoteCountsFn: func(commentID uint) (int, int, float64, error) {
+			return 5, 2, 0.55, nil
+		},
+		getUserVoteFn: func(userID uint, commentID uint) (*int, error) {
+			return &upvote, nil
+		},
+	})
+
+	ctx := ctxWithUser(&models.User{ID: 1})
+	req := &VoteCommentRequest{CommentID: "42"}
+	req.Body.Direction = 1
+
+	resp, err := h.VoteCommentHandler(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if resp.Body.Ups != 5 {
+		t.Errorf("expected ups=5, got %d", resp.Body.Ups)
+	}
+	if resp.Body.Downs != 2 {
+		t.Errorf("expected downs=2, got %d", resp.Body.Downs)
+	}
+	if resp.Body.UserVote == nil || *resp.Body.UserVote != 1 {
+		t.Errorf("expected user_vote=1, got %v", resp.Body.UserVote)
+	}
+}
+
+func TestVoteComment_CommentNotFound(t *testing.T) {
+	h := NewCommentVoteHandler(&mockCommentVoteService{
+		voteFn: func(userID uint, commentID uint, direction int) error {
+			return fmt.Errorf("comment not found")
+		},
+	})
+
+	ctx := ctxWithUser(&models.User{ID: 1})
+	req := &VoteCommentRequest{CommentID: "99"}
+	req.Body.Direction = 1
+
+	_, err := h.VoteCommentHandler(ctx, req)
+	assertHumaError(t, err, 404)
+}
+
+func TestVoteComment_ServiceError(t *testing.T) {
+	h := NewCommentVoteHandler(&mockCommentVoteService{
+		voteFn: func(userID uint, commentID uint, direction int) error {
+			return fmt.Errorf("database error")
+		},
+	})
+
+	ctx := ctxWithUser(&models.User{ID: 1})
+	req := &VoteCommentRequest{CommentID: "1"}
+	req.Body.Direction = 1
+
+	_, err := h.VoteCommentHandler(ctx, req)
+	assertHumaError(t, err, 500)
+}
+
+// ============================================================================
+// UnvoteCommentHandler Tests
+// ============================================================================
+
+func TestUnvoteComment_NoAuth(t *testing.T) {
+	h := testCommentVoteHandler()
+	req := &UnvoteCommentRequest{CommentID: "1"}
+
+	_, err := h.UnvoteCommentHandler(context.Background(), req)
+	assertHumaError(t, err, 401)
+}
+
+func TestUnvoteComment_InvalidCommentID(t *testing.T) {
+	h := testCommentVoteHandler()
+	ctx := ctxWithUser(&models.User{ID: 1})
+	req := &UnvoteCommentRequest{CommentID: "abc"}
+
+	_, err := h.UnvoteCommentHandler(ctx, req)
+	assertHumaError(t, err, 400)
+}
+
+func TestUnvoteComment_Success(t *testing.T) {
+	h := NewCommentVoteHandler(&mockCommentVoteService{
+		unvoteFn: func(userID uint, commentID uint) error {
+			return nil
+		},
+		getCommentVoteCountsFn: func(commentID uint) (int, int, float64, error) {
+			return 3, 1, 0.45, nil
+		},
+	})
+
+	ctx := ctxWithUser(&models.User{ID: 1})
+	req := &UnvoteCommentRequest{CommentID: "42"}
+
+	resp, err := h.UnvoteCommentHandler(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if resp.Body.Ups != 3 {
+		t.Errorf("expected ups=3, got %d", resp.Body.Ups)
+	}
+	if resp.Body.UserVote != nil {
+		t.Errorf("expected user_vote=nil, got %v", resp.Body.UserVote)
+	}
+}
+
+func TestUnvoteComment_CommentNotFound(t *testing.T) {
+	h := NewCommentVoteHandler(&mockCommentVoteService{
+		unvoteFn: func(userID uint, commentID uint) error {
+			return fmt.Errorf("comment not found")
+		},
+	})
+
+	ctx := ctxWithUser(&models.User{ID: 1})
+	req := &UnvoteCommentRequest{CommentID: "99"}
+
+	_, err := h.UnvoteCommentHandler(ctx, req)
+	assertHumaError(t, err, 404)
+}
+
+func TestUnvoteComment_ServiceError(t *testing.T) {
+	h := NewCommentVoteHandler(&mockCommentVoteService{
+		unvoteFn: func(userID uint, commentID uint) error {
+			return fmt.Errorf("database error")
+		},
+	})
+
+	ctx := ctxWithUser(&models.User{ID: 1})
+	req := &UnvoteCommentRequest{CommentID: "1"}
+
+	_, err := h.UnvoteCommentHandler(ctx, req)
+	assertHumaError(t, err, 500)
+}

--- a/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
+++ b/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
@@ -841,6 +841,49 @@ func (m *mockCommentService) DeleteComment(userID uint, commentID uint, isAdmin 
 }
 
 // ============================================================================
+// Mock: CommentVoteServiceInterface
+// ============================================================================
+
+type mockCommentVoteService struct {
+	voteFn func(uint, uint, int) (error)
+	unvoteFn func(uint, uint) (error)
+	getUserVoteFn func(uint, uint) (*int, error)
+	getUserVotesForCommentsFn func(uint, []uint) (map[uint]int, error)
+	getCommentVoteCountsFn func(uint) (int, int, float64, error)
+}
+
+func (m *mockCommentVoteService) Vote(userID uint, commentID uint, direction int) (error) {
+	if m.voteFn != nil {
+		return m.voteFn(userID, commentID, direction)
+	}
+	return nil
+}
+func (m *mockCommentVoteService) Unvote(userID uint, commentID uint) (error) {
+	if m.unvoteFn != nil {
+		return m.unvoteFn(userID, commentID)
+	}
+	return nil
+}
+func (m *mockCommentVoteService) GetUserVote(userID uint, commentID uint) (*int, error) {
+	if m.getUserVoteFn != nil {
+		return m.getUserVoteFn(userID, commentID)
+	}
+	return nil, nil
+}
+func (m *mockCommentVoteService) GetUserVotesForComments(userID uint, commentIDs []uint) (map[uint]int, error) {
+	if m.getUserVotesForCommentsFn != nil {
+		return m.getUserVotesForCommentsFn(userID, commentIDs)
+	}
+	return nil, nil
+}
+func (m *mockCommentVoteService) GetCommentVoteCounts(commentID uint) (int, int, float64, error) {
+	if m.getCommentVoteCountsFn != nil {
+		return m.getCommentVoteCountsFn(commentID)
+	}
+	return 0, 0, 0, nil
+}
+
+// ============================================================================
 // Mock: ContributorProfileServiceInterface
 // ============================================================================
 
@@ -3630,6 +3673,7 @@ var _ contracts.CalendarServiceInterface = (*mockCalendarService)(nil)
 var _ contracts.ChartsServiceInterface = (*mockChartsService)(nil)
 var _ contracts.CollectionServiceInterface = (*mockCollectionService)(nil)
 var _ contracts.CommentServiceInterface = (*mockCommentService)(nil)
+var _ contracts.CommentVoteServiceInterface = (*mockCommentVoteService)(nil)
 var _ contracts.ContributorProfileServiceInterface = (*mockContributorProfileService)(nil)
 var _ contracts.DataQualityServiceInterface = (*mockDataQualityService)(nil)
 var _ contracts.DataSyncServiceInterface = (*mockDataSyncService)(nil)

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -133,6 +133,7 @@ func SetupRoutes(router *chi.Mux, sc *services.ServiceContainer, cfg *config.Con
 	setupDataGapsRoutes(rc)
 	setupRadioRoutes(rc)
 	setupCommentRoutes(rc)
+	setupCommentVoteRoutes(rc)
 
 	return api
 }
@@ -1084,4 +1085,13 @@ func setupCommentRoutes(rc RouteContext) {
 	huma.Post(rc.Protected, "/comments/{comment_id}/replies", commentHandler.CreateReplyHandler)
 	huma.Put(rc.Protected, "/comments/{comment_id}", commentHandler.UpdateCommentHandler)
 	huma.Delete(rc.Protected, "/comments/{comment_id}", commentHandler.DeleteCommentHandler)
+}
+
+// setupCommentVoteRoutes configures comment voting endpoints.
+func setupCommentVoteRoutes(rc RouteContext) {
+	commentVoteHandler := handlers.NewCommentVoteHandler(rc.SC.CommentVote)
+
+	// Protected: vote and unvote on comments
+	huma.Post(rc.Protected, "/comments/{comment_id}/vote", commentVoteHandler.VoteCommentHandler)
+	huma.Delete(rc.Protected, "/comments/{comment_id}/vote", commentVoteHandler.UnvoteCommentHandler)
 }

--- a/backend/internal/scoring/wilson.go
+++ b/backend/internal/scoring/wilson.go
@@ -1,0 +1,20 @@
+// Package scoring provides shared scoring utilities used across services.
+package scoring
+
+import "math"
+
+// WilsonScore computes the Wilson score lower bound for ranking.
+// Uses a 90% confidence interval (z = 1.281728756502709).
+// Returns 0 when there are no votes.
+//
+// This is the same formula used by Reddit for "Best" sort and by
+// PH for artist relationships, requests, and comment voting.
+func WilsonScore(upvotes, downvotes int) float64 {
+	n := float64(upvotes + downvotes)
+	if n == 0 {
+		return 0
+	}
+	z := 1.281728756502709
+	phat := float64(upvotes) / n
+	return (phat + z*z/(2*n) - z*math.Sqrt((phat*(1-phat)+z*z/(4*n))/n)) / (1 + z*z/n)
+}

--- a/backend/internal/scoring/wilson_test.go
+++ b/backend/internal/scoring/wilson_test.go
@@ -1,0 +1,67 @@
+package scoring
+
+import (
+	"math"
+	"testing"
+)
+
+func TestWilsonScore_NoVotes(t *testing.T) {
+	score := WilsonScore(0, 0)
+	if score != 0 {
+		t.Errorf("expected 0, got %f", score)
+	}
+}
+
+func TestWilsonScore_AllUpvotes(t *testing.T) {
+	score := WilsonScore(10, 0)
+	if score <= 0.7 || score >= 1.0 {
+		t.Errorf("expected score in (0.7, 1.0), got %f", score)
+	}
+}
+
+func TestWilsonScore_AllDownvotes(t *testing.T) {
+	score := WilsonScore(0, 10)
+	if score >= 0.3 || score < 0 {
+		t.Errorf("expected score in [0, 0.3), got %f", score)
+	}
+}
+
+func TestWilsonScore_MixedVotes(t *testing.T) {
+	score := WilsonScore(8, 2)
+	if score <= 0.5 || score >= 1.0 {
+		t.Errorf("expected score in (0.5, 1.0), got %f", score)
+	}
+}
+
+func TestWilsonScore_HighConfidence_BeatsLowSample(t *testing.T) {
+	highN := WilsonScore(95, 5)
+	lowN := WilsonScore(3, 0)
+	if highN <= lowN {
+		t.Errorf("expected high-N score (%f) > low-N score (%f)", highN, lowN)
+	}
+}
+
+func TestWilsonScore_SingleUpvote(t *testing.T) {
+	score := WilsonScore(1, 0)
+	if score <= 0 || score >= 1.0 {
+		t.Errorf("expected score in (0, 1.0), got %f", score)
+	}
+}
+
+func TestWilsonScore_FiftyFifty(t *testing.T) {
+	score := WilsonScore(50, 50)
+	if math.Abs(score-0.5) > 0.1 {
+		t.Errorf("expected score near 0.5, got %f", score)
+	}
+}
+
+func TestWilsonScore_KnownValue(t *testing.T) {
+	// Known computation: 10 ups, 0 downs
+	// phat = 1.0, z = 1.281728756502709, n = 10
+	score := WilsonScore(10, 0)
+	// Pre-computed expected value (verified via Python)
+	expected := 0.8588978107514387
+	if math.Abs(score-expected) > 0.0001 {
+		t.Errorf("expected score ~%f, got %f", expected, score)
+	}
+}

--- a/backend/internal/services/container.go
+++ b/backend/internal/services/container.go
@@ -40,6 +40,7 @@ type ServiceContainer struct {
 	Scene              *catalog.SceneService
 	Attendance         *engagement.AttendanceService
 	Comment            *engagement.CommentService
+	CommentVote        *engagement.CommentVoteService
 	Follow             *engagement.FollowService
 	FavoriteVenue      *engagement.FavoriteVenueService
 	Festival               *catalog.FestivalService
@@ -152,6 +153,7 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 		Scene:              catalog.NewSceneService(database),
 		Attendance:         engagement.NewAttendanceService(database),
 		Comment:            engagement.NewCommentService(database),
+		CommentVote:        engagement.NewCommentVoteService(database),
 		Follow:             engagement.NewFollowService(database),
 		FavoriteVenue:      engagement.NewFavoriteVenueService(database),
 		Festival:               catalog.NewFestivalService(database),

--- a/backend/internal/services/contracts/comment.go
+++ b/backend/internal/services/contracts/comment.go
@@ -80,3 +80,33 @@ type CommentServiceInterface interface {
 	UpdateComment(userID uint, commentID uint, req *UpdateCommentRequest) (*CommentResponse, error)
 	DeleteComment(userID uint, commentID uint, isAdmin bool) error
 }
+// CommentVoteResponse contains vote counts and the current user's vote.
+type CommentVoteResponse struct {
+	Ups      int      `json:"ups"`
+	Downs    int      `json:"downs"`
+	Score    float64  `json:"score"`
+	UserVote *int     `json:"user_vote"` // 1, -1, or null
+}
+
+// ──────────────────────────────────────────────
+// Comment Vote service interface
+// ──────────────────────────────────────────────
+
+// CommentVoteServiceInterface defines the contract for comment voting operations.
+type CommentVoteServiceInterface interface {
+	// Vote casts or updates a vote on a comment.
+	// direction must be 1 (upvote) or -1 (downvote).
+	Vote(userID uint, commentID uint, direction int) error
+
+	// Unvote removes a user's vote on a comment.
+	Unvote(userID uint, commentID uint) error
+
+	// GetUserVote returns the user's vote direction (1 or -1) or nil if not voted.
+	GetUserVote(userID uint, commentID uint) (*int, error)
+
+	// GetUserVotesForComments returns a map of commentID→direction for batch lookups.
+	GetUserVotesForComments(userID uint, commentIDs []uint) (map[uint]int, error)
+
+	// GetCommentVoteCounts returns the current ups, downs, and Wilson score for a comment.
+	GetCommentVoteCounts(commentID uint) (int, int, float64, error)
+}

--- a/backend/internal/services/engagement/comment_vote_service.go
+++ b/backend/internal/services/engagement/comment_vote_service.go
@@ -1,0 +1,184 @@
+package engagement
+
+import (
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/db"
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/scoring"
+)
+
+// CommentVoteService handles comment voting operations.
+type CommentVoteService struct {
+	db *gorm.DB
+}
+
+// NewCommentVoteService creates a new comment vote service.
+func NewCommentVoteService(database *gorm.DB) *CommentVoteService {
+	if database == nil {
+		database = db.GetDB()
+	}
+	return &CommentVoteService{
+		db: database,
+	}
+}
+
+// Vote casts or updates a vote on a comment.
+// direction must be 1 (upvote) or -1 (downvote).
+func (s *CommentVoteService) Vote(userID uint, commentID uint, direction int) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	if direction != 1 && direction != -1 {
+		return fmt.Errorf("invalid vote direction: must be 1 or -1")
+	}
+
+	// Verify comment exists
+	var comment models.Comment
+	if err := s.db.First(&comment, commentID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return fmt.Errorf("comment not found")
+		}
+		return fmt.Errorf("failed to get comment: %w", err)
+	}
+
+	return s.db.Transaction(func(tx *gorm.DB) error {
+		// Upsert the vote
+		var existingVote models.CommentVote
+		err := tx.Where("comment_id = ? AND user_id = ?", commentID, userID).First(&existingVote).Error
+
+		if err == gorm.ErrRecordNotFound {
+			// New vote
+			vote := models.CommentVote{
+				CommentID: commentID,
+				UserID:    userID,
+				Direction: int16(direction),
+				CreatedAt: time.Now().UTC(),
+			}
+			if err := tx.Create(&vote).Error; err != nil {
+				return fmt.Errorf("failed to create vote: %w", err)
+			}
+		} else if err != nil {
+			return fmt.Errorf("failed to check existing vote: %w", err)
+		} else {
+			// Update existing vote
+			if err := tx.Model(&existingVote).Update("direction", int16(direction)).Error; err != nil {
+				return fmt.Errorf("failed to update vote: %w", err)
+			}
+		}
+
+		// Recompute aggregates
+		return s.recomputeAggregates(tx, commentID)
+	})
+}
+
+// Unvote removes a user's vote on a comment.
+func (s *CommentVoteService) Unvote(userID uint, commentID uint) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	// Verify comment exists
+	var comment models.Comment
+	if err := s.db.First(&comment, commentID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return fmt.Errorf("comment not found")
+		}
+		return fmt.Errorf("failed to get comment: %w", err)
+	}
+
+	return s.db.Transaction(func(tx *gorm.DB) error {
+		result := tx.Where("comment_id = ? AND user_id = ?", commentID, userID).Delete(&models.CommentVote{})
+		if result.Error != nil {
+			return fmt.Errorf("failed to remove vote: %w", result.Error)
+		}
+
+		// Recompute aggregates
+		return s.recomputeAggregates(tx, commentID)
+	})
+}
+
+// GetUserVote returns the user's vote direction (1 or -1) or nil if not voted.
+func (s *CommentVoteService) GetUserVote(userID uint, commentID uint) (*int, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var vote models.CommentVote
+	err := s.db.Where("comment_id = ? AND user_id = ?", commentID, userID).First(&vote).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get user vote: %w", err)
+	}
+
+	dir := int(vote.Direction)
+	return &dir, nil
+}
+
+// GetUserVotesForComments returns a map of commentID→direction for batch lookups.
+func (s *CommentVoteService) GetUserVotesForComments(userID uint, commentIDs []uint) (map[uint]int, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	if len(commentIDs) == 0 {
+		return make(map[uint]int), nil
+	}
+
+	var votes []models.CommentVote
+	err := s.db.Where("user_id = ? AND comment_id IN ?", userID, commentIDs).Find(&votes).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user votes: %w", err)
+	}
+
+	result := make(map[uint]int, len(votes))
+	for _, v := range votes {
+		result[v.CommentID] = int(v.Direction)
+	}
+
+	return result, nil
+}
+
+// GetCommentVoteCounts returns the current ups, downs, and Wilson score for a comment.
+func (s *CommentVoteService) GetCommentVoteCounts(commentID uint) (int, int, float64, error) {
+	if s.db == nil {
+		return 0, 0, 0, fmt.Errorf("database not initialized")
+	}
+
+	var comment models.Comment
+	err := s.db.Select("ups", "downs", "score").First(&comment, commentID).Error
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("failed to get comment: %w", err)
+	}
+	return comment.Ups, comment.Downs, comment.Score, nil
+}
+
+// recomputeAggregates counts ups and downs from comment_votes and updates
+// the denormalized ups, downs, and score on the comments table.
+func (s *CommentVoteService) recomputeAggregates(tx *gorm.DB, commentID uint) error {
+	var ups, downs int64
+
+	tx.Model(&models.CommentVote{}).
+		Where("comment_id = ? AND direction = 1", commentID).
+		Count(&ups)
+
+	tx.Model(&models.CommentVote{}).
+		Where("comment_id = ? AND direction = -1", commentID).
+		Count(&downs)
+
+	score := scoring.WilsonScore(int(ups), int(downs))
+
+	return tx.Model(&models.Comment{}).
+		Where("id = ?", commentID).
+		Updates(map[string]interface{}{
+			"ups":   int(ups),
+			"downs": int(downs),
+			"score": score,
+		}).Error
+}

--- a/backend/internal/services/engagement/comment_vote_service_test.go
+++ b/backend/internal/services/engagement/comment_vote_service_test.go
@@ -1,0 +1,364 @@
+package engagement
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/testutil"
+)
+
+// =============================================================================
+// INTEGRATION TESTS (With Real Database)
+// =============================================================================
+
+type CommentVoteServiceIntegrationTestSuite struct {
+	suite.Suite
+	testDB  *testutil.TestDatabase
+	db      *gorm.DB
+	service *CommentVoteService
+}
+
+func (suite *CommentVoteServiceIntegrationTestSuite) SetupSuite() {
+	suite.testDB = testutil.SetupTestPostgres(suite.T())
+	suite.db = suite.testDB.DB
+	suite.service = NewCommentVoteService(suite.testDB.DB)
+}
+
+func (suite *CommentVoteServiceIntegrationTestSuite) TearDownSuite() {
+	suite.testDB.Cleanup()
+}
+
+func (suite *CommentVoteServiceIntegrationTestSuite) TearDownTest() {
+	sqlDB, err := suite.db.DB()
+	suite.Require().NoError(err)
+	_, _ = sqlDB.Exec("DELETE FROM comment_votes")
+	_, _ = sqlDB.Exec("DELETE FROM comments")
+	_, _ = sqlDB.Exec("DELETE FROM users")
+}
+
+func TestCommentVoteServiceIntegrationTestSuite(t *testing.T) {
+	suite.Run(t, new(CommentVoteServiceIntegrationTestSuite))
+}
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+func (suite *CommentVoteServiceIntegrationTestSuite) createTestUser() *models.User {
+	user := &models.User{
+		Email:         stringPtr(fmt.Sprintf("user-%d@test.com", time.Now().UnixNano())),
+		FirstName:     stringPtr("Test"),
+		LastName:      stringPtr("User"),
+		IsActive:      true,
+		EmailVerified: true,
+	}
+	err := suite.db.Create(user).Error
+	suite.Require().NoError(err)
+	return user
+}
+
+func (suite *CommentVoteServiceIntegrationTestSuite) createTestComment(userID uint) *models.Comment {
+	comment := &models.Comment{
+		Kind:       models.CommentKindComment,
+		EntityType: "show",
+		EntityID:   1,
+		UserID:     userID,
+		Body:       "Test comment",
+		Visibility: models.CommentVisibilityVisible,
+	}
+	err := suite.db.Create(comment).Error
+	suite.Require().NoError(err)
+	return comment
+}
+
+// =============================================================================
+// VOTE TESTS
+// =============================================================================
+
+func (suite *CommentVoteServiceIntegrationTestSuite) TestVoteUp() {
+	user := suite.createTestUser()
+	comment := suite.createTestComment(user.ID)
+
+	err := suite.service.Vote(user.ID, comment.ID, 1)
+	suite.NoError(err)
+
+	// Verify vote was created
+	vote, err := suite.service.GetUserVote(user.ID, comment.ID)
+	suite.NoError(err)
+	suite.NotNil(vote)
+	suite.Equal(1, *vote)
+
+	// Verify aggregates updated
+	var updated models.Comment
+	suite.db.First(&updated, comment.ID)
+	suite.Equal(1, updated.Ups)
+	suite.Equal(0, updated.Downs)
+	suite.Greater(updated.Score, 0.0)
+}
+
+func (suite *CommentVoteServiceIntegrationTestSuite) TestVoteDown() {
+	user := suite.createTestUser()
+	comment := suite.createTestComment(user.ID)
+
+	err := suite.service.Vote(user.ID, comment.ID, -1)
+	suite.NoError(err)
+
+	vote, err := suite.service.GetUserVote(user.ID, comment.ID)
+	suite.NoError(err)
+	suite.NotNil(vote)
+	suite.Equal(-1, *vote)
+
+	var updated models.Comment
+	suite.db.First(&updated, comment.ID)
+	suite.Equal(0, updated.Ups)
+	suite.Equal(1, updated.Downs)
+	// Wilson score for 0 ups / 1 down is effectively 0 (may have floating-point epsilon)
+	suite.InDelta(0.0, updated.Score, 1e-10)
+}
+
+func (suite *CommentVoteServiceIntegrationTestSuite) TestChangeVoteDirection() {
+	user := suite.createTestUser()
+	comment := suite.createTestComment(user.ID)
+
+	// Vote up first
+	err := suite.service.Vote(user.ID, comment.ID, 1)
+	suite.NoError(err)
+
+	var afterUp models.Comment
+	suite.db.First(&afterUp, comment.ID)
+	suite.Equal(1, afterUp.Ups)
+	suite.Equal(0, afterUp.Downs)
+
+	// Change to down
+	err = suite.service.Vote(user.ID, comment.ID, -1)
+	suite.NoError(err)
+
+	vote, err := suite.service.GetUserVote(user.ID, comment.ID)
+	suite.NoError(err)
+	suite.NotNil(vote)
+	suite.Equal(-1, *vote)
+
+	var afterDown models.Comment
+	suite.db.First(&afterDown, comment.ID)
+	suite.Equal(0, afterDown.Ups)
+	suite.Equal(1, afterDown.Downs)
+}
+
+func (suite *CommentVoteServiceIntegrationTestSuite) TestVoteSameDirectionIdempotent() {
+	user := suite.createTestUser()
+	comment := suite.createTestComment(user.ID)
+
+	// Vote up twice
+	err := suite.service.Vote(user.ID, comment.ID, 1)
+	suite.NoError(err)
+	err = suite.service.Vote(user.ID, comment.ID, 1)
+	suite.NoError(err)
+
+	var updated models.Comment
+	suite.db.First(&updated, comment.ID)
+	suite.Equal(1, updated.Ups)
+	suite.Equal(0, updated.Downs)
+}
+
+func (suite *CommentVoteServiceIntegrationTestSuite) TestVoteInvalidDirection() {
+	user := suite.createTestUser()
+	comment := suite.createTestComment(user.ID)
+
+	err := suite.service.Vote(user.ID, comment.ID, 2)
+	suite.Error(err)
+	suite.Contains(err.Error(), "invalid vote direction")
+}
+
+func (suite *CommentVoteServiceIntegrationTestSuite) TestVoteNonexistentComment() {
+	user := suite.createTestUser()
+
+	err := suite.service.Vote(user.ID, 99999, 1)
+	suite.Error(err)
+	suite.Contains(err.Error(), "comment not found")
+}
+
+// =============================================================================
+// UNVOTE TESTS
+// =============================================================================
+
+func (suite *CommentVoteServiceIntegrationTestSuite) TestUnvote() {
+	user := suite.createTestUser()
+	comment := suite.createTestComment(user.ID)
+
+	// Vote first
+	err := suite.service.Vote(user.ID, comment.ID, 1)
+	suite.NoError(err)
+
+	// Verify aggregates
+	var afterVote models.Comment
+	suite.db.First(&afterVote, comment.ID)
+	suite.Equal(1, afterVote.Ups)
+
+	// Unvote
+	err = suite.service.Unvote(user.ID, comment.ID)
+	suite.NoError(err)
+
+	// Vote should be nil
+	vote, err := suite.service.GetUserVote(user.ID, comment.ID)
+	suite.NoError(err)
+	suite.Nil(vote)
+
+	// Aggregates should be zero
+	var afterUnvote models.Comment
+	suite.db.First(&afterUnvote, comment.ID)
+	suite.Equal(0, afterUnvote.Ups)
+	suite.Equal(0, afterUnvote.Downs)
+	suite.Equal(0.0, afterUnvote.Score)
+}
+
+func (suite *CommentVoteServiceIntegrationTestSuite) TestUnvoteNonexistentComment() {
+	user := suite.createTestUser()
+
+	err := suite.service.Unvote(user.ID, 99999)
+	suite.Error(err)
+	suite.Contains(err.Error(), "comment not found")
+}
+
+func (suite *CommentVoteServiceIntegrationTestSuite) TestUnvoteWithoutExistingVote() {
+	user := suite.createTestUser()
+	comment := suite.createTestComment(user.ID)
+
+	// Unvote without having voted — should succeed (no-op delete)
+	err := suite.service.Unvote(user.ID, comment.ID)
+	suite.NoError(err)
+}
+
+// =============================================================================
+// GET USER VOTE TESTS
+// =============================================================================
+
+func (suite *CommentVoteServiceIntegrationTestSuite) TestGetUserVoteNoVote() {
+	user := suite.createTestUser()
+	comment := suite.createTestComment(user.ID)
+
+	vote, err := suite.service.GetUserVote(user.ID, comment.ID)
+	suite.NoError(err)
+	suite.Nil(vote)
+}
+
+// =============================================================================
+// BATCH GET USER VOTES TESTS
+// =============================================================================
+
+func (suite *CommentVoteServiceIntegrationTestSuite) TestGetUserVotesForComments() {
+	user := suite.createTestUser()
+	c1 := suite.createTestComment(user.ID)
+	c2 := suite.createTestComment(user.ID)
+	c3 := suite.createTestComment(user.ID)
+
+	// Vote on c1 (up) and c2 (down), skip c3
+	suite.NoError(suite.service.Vote(user.ID, c1.ID, 1))
+	suite.NoError(suite.service.Vote(user.ID, c2.ID, -1))
+
+	votes, err := suite.service.GetUserVotesForComments(user.ID, []uint{c1.ID, c2.ID, c3.ID})
+	suite.NoError(err)
+	suite.Equal(1, votes[c1.ID])
+	suite.Equal(-1, votes[c2.ID])
+	_, hasC3 := votes[c3.ID]
+	suite.False(hasC3)
+}
+
+func (suite *CommentVoteServiceIntegrationTestSuite) TestGetUserVotesForCommentsEmptyList() {
+	user := suite.createTestUser()
+
+	votes, err := suite.service.GetUserVotesForComments(user.ID, []uint{})
+	suite.NoError(err)
+	suite.NotNil(votes)
+	suite.Len(votes, 0)
+}
+
+// =============================================================================
+// GET COMMENT VOTE COUNTS TESTS
+// =============================================================================
+
+func (suite *CommentVoteServiceIntegrationTestSuite) TestGetCommentVoteCounts() {
+	user1 := suite.createTestUser()
+	user2 := suite.createTestUser()
+	comment := suite.createTestComment(user1.ID)
+
+	// Two upvotes
+	suite.NoError(suite.service.Vote(user1.ID, comment.ID, 1))
+	suite.NoError(suite.service.Vote(user2.ID, comment.ID, 1))
+
+	ups, downs, score, err := suite.service.GetCommentVoteCounts(comment.ID)
+	suite.NoError(err)
+	suite.Equal(2, ups)
+	suite.Equal(0, downs)
+	suite.Greater(score, 0.0)
+}
+
+// =============================================================================
+// WILSON SCORE INTEGRATION TESTS
+// =============================================================================
+
+func (suite *CommentVoteServiceIntegrationTestSuite) TestWilsonScoreComputedCorrectly() {
+	creator := suite.createTestUser()
+	comment := suite.createTestComment(creator.ID)
+
+	// Create multiple users and vote
+	for i := 0; i < 8; i++ {
+		u := suite.createTestUser()
+		suite.NoError(suite.service.Vote(u.ID, comment.ID, 1))
+	}
+	for i := 0; i < 2; i++ {
+		u := suite.createTestUser()
+		suite.NoError(suite.service.Vote(u.ID, comment.ID, -1))
+	}
+
+	var updated models.Comment
+	suite.db.First(&updated, comment.ID)
+	suite.Equal(8, updated.Ups)
+	suite.Equal(2, updated.Downs)
+	// Wilson score should be between 0.5 and 1.0 for 8 up / 2 down
+	suite.Greater(updated.Score, 0.5)
+	suite.Less(updated.Score, 1.0)
+}
+
+// =============================================================================
+// NIL DB TESTS
+// =============================================================================
+
+func (suite *CommentVoteServiceIntegrationTestSuite) TestNilDBVote() {
+	svc := &CommentVoteService{db: nil}
+	err := svc.Vote(1, 1, 1)
+	suite.Error(err)
+	suite.Contains(err.Error(), "database not initialized")
+}
+
+func (suite *CommentVoteServiceIntegrationTestSuite) TestNilDBUnvote() {
+	svc := &CommentVoteService{db: nil}
+	err := svc.Unvote(1, 1)
+	suite.Error(err)
+	suite.Contains(err.Error(), "database not initialized")
+}
+
+func (suite *CommentVoteServiceIntegrationTestSuite) TestNilDBGetUserVote() {
+	svc := &CommentVoteService{db: nil}
+	_, err := svc.GetUserVote(1, 1)
+	suite.Error(err)
+	suite.Contains(err.Error(), "database not initialized")
+}
+
+func (suite *CommentVoteServiceIntegrationTestSuite) TestNilDBGetUserVotesForComments() {
+	svc := &CommentVoteService{db: nil}
+	_, err := svc.GetUserVotesForComments(1, []uint{1, 2, 3})
+	suite.Error(err)
+	suite.Contains(err.Error(), "database not initialized")
+}
+
+func (suite *CommentVoteServiceIntegrationTestSuite) TestNilDBGetCommentVoteCounts() {
+	svc := &CommentVoteService{db: nil}
+	_, _, _, err := svc.GetCommentVoteCounts(1)
+	suite.Error(err)
+	suite.Contains(err.Error(), "database not initialized")
+}

--- a/backend/internal/services/engagement/interfaces.go
+++ b/backend/internal/services/engagement/interfaces.go
@@ -12,4 +12,5 @@ var (
 	_ contracts.AttendanceServiceInterface    = (*AttendanceService)(nil)
 	_ contracts.FollowServiceInterface        = (*FollowService)(nil)
 	_ contracts.CommentServiceInterface       = (*CommentService)(nil)
+	_ contracts.CommentVoteServiceInterface   = (*CommentVoteService)(nil)
 )


### PR DESCRIPTION
## Summary

Binary up/down voting on comments with Wilson score precomputation for the default "Best" sort. Depends on PSY-285 (#294, merged).

### New
- **`scoring/wilson.go`** — shared `WilsonScore(ups, downs)` utility (90% confidence), extracted for reuse
- **CommentVoteService** — Vote (upsert), Unvote, GetUserVote, batch lookup, vote counts. Transactional aggregate recomputation.
- **2 endpoints**: `POST /comments/{id}/vote`, `DELETE /comments/{id}/vote` → returns `{ups, downs, score, user_vote}`
- 8 Wilson tests + 19 service integration tests + 12 handler tests = **39 new tests**

Closes PSY-287

🤖 Generated with [Claude Code](https://claude.com/claude-code)