### PR TITLE
Add comment moderation: trust-tier visibility, rate limiting, admin endpoints (Wave 4)

### DIFF
--- a/backend/db/migrations/000066_add_comment_moderation_fields.down.sql
+++ b/backend/db/migrations/000066_add_comment_moderation_fields.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS idx_comments_visibility;
+ALTER TABLE comments DROP COLUMN IF EXISTS hidden_at;
+ALTER TABLE comments DROP COLUMN IF EXISTS hidden_by_user_id;
+ALTER TABLE comments DROP COLUMN IF EXISTS hidden_reason;

--- a/backend/db/migrations/000066_add_comment_moderation_fields.up.sql
+++ b/backend/db/migrations/000066_add_comment_moderation_fields.up.sql
@@ -1,0 +1,7 @@
+-- Add moderation tracking fields to comments for admin hide/restore
+ALTER TABLE comments ADD COLUMN hidden_reason VARCHAR(255);
+ALTER TABLE comments ADD COLUMN hidden_by_user_id INTEGER REFERENCES users(id);
+ALTER TABLE comments ADD COLUMN hidden_at TIMESTAMPTZ;
+
+-- Index for admin pending review queue
+CREATE INDEX idx_comments_visibility ON comments(visibility) WHERE visibility = 'pending_review';

--- a/backend/internal/api/handlers/comment.go
+++ b/backend/internal/api/handlers/comment.go
@@ -226,6 +226,9 @@ func (h *CommentHandler) CreateCommentHandler(ctx context.Context, req *CreateCo
 		if strings.Contains(err.Error(), "body is required") || strings.Contains(err.Error(), "exceeds maximum length") {
 			return nil, huma.Error400BadRequest(err.Error())
 		}
+		if strings.Contains(err.Error(), "please wait") || strings.Contains(err.Error(), "hourly comment limit") {
+			return nil, huma.Error429TooManyRequests(err.Error())
+		}
 		requestID := logger.GetRequestID(ctx)
 		return nil, huma.Error500InternalServerError(
 			fmt.Sprintf("Failed to create comment (request_id: %s)", requestID),
@@ -306,6 +309,9 @@ func (h *CommentHandler) CreateReplyHandler(ctx context.Context, req *CreateRepl
 		}
 		if strings.Contains(err.Error(), "parent comment belongs to a different entity") {
 			return nil, huma.Error400BadRequest(err.Error())
+		}
+		if strings.Contains(err.Error(), "please wait") || strings.Contains(err.Error(), "hourly comment limit") {
+			return nil, huma.Error429TooManyRequests(err.Error())
 		}
 		requestID := logger.GetRequestID(ctx)
 		return nil, huma.Error500InternalServerError(

--- a/backend/internal/api/handlers/comment_admin.go
+++ b/backend/internal/api/handlers/comment_admin.go
@@ -1,0 +1,284 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"psychic-homily-backend/internal/logger"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// ============================================================================
+// Focused interface for dependency injection
+// ============================================================================
+
+// CommentAdmin defines the admin moderation operations for comments.
+type CommentAdmin interface {
+	HideComment(adminUserID uint, commentID uint, reason string) error
+	RestoreComment(adminUserID uint, commentID uint) error
+	ListPendingComments(limit, offset int) ([]*contracts.CommentResponse, int64, error)
+	ApproveComment(adminUserID uint, commentID uint) error
+	RejectComment(adminUserID uint, commentID uint, reason string) error
+}
+
+// CommentAdminHandler handles admin comment moderation API requests.
+type CommentAdminHandler struct {
+	admin           CommentAdmin
+	auditLogService contracts.AuditLogServiceInterface
+}
+
+// NewCommentAdminHandler creates a new CommentAdminHandler.
+func NewCommentAdminHandler(admin CommentAdmin, auditLogService contracts.AuditLogServiceInterface) *CommentAdminHandler {
+	return &CommentAdminHandler{
+		admin:           admin,
+		auditLogService: auditLogService,
+	}
+}
+
+// ============================================================================
+// Admin: Hide Comment — POST /admin/comments/{comment_id}/hide
+// ============================================================================
+
+// AdminHideCommentRequest represents the request for hiding a comment.
+type AdminHideCommentRequest struct {
+	CommentID string `path:"comment_id" doc:"Comment ID" example:"1"`
+	Body      struct {
+		Reason string `json:"reason" doc:"Reason for hiding the comment" example:"Violates community guidelines"`
+	}
+}
+
+// AdminHideCommentHandler handles POST /admin/comments/{comment_id}/hide
+func (h *CommentAdminHandler) AdminHideCommentHandler(ctx context.Context, req *AdminHideCommentRequest) (*struct{}, error) {
+	user, err := requireAdmin(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	commentID, err := strconv.ParseUint(req.CommentID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid comment ID")
+	}
+
+	reason := strings.TrimSpace(req.Body.Reason)
+	if reason == "" {
+		return nil, huma.Error400BadRequest("Reason is required when hiding a comment")
+	}
+
+	if err := h.admin.HideComment(user.ID, uint(commentID), reason); err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return nil, huma.Error404NotFound("Comment not found")
+		}
+		requestID := logger.GetRequestID(ctx)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to hide comment (request_id: %s)", requestID),
+		)
+	}
+
+	// Audit log (fire and forget)
+	if h.auditLogService != nil {
+		go func() {
+			h.auditLogService.LogAction(user.ID, "hide_comment", "comment", uint(commentID), map[string]interface{}{
+				"reason": reason,
+			})
+		}()
+	}
+
+	return nil, nil
+}
+
+// ============================================================================
+// Admin: Restore Comment — POST /admin/comments/{comment_id}/restore
+// ============================================================================
+
+// AdminRestoreCommentRequest represents the request for restoring a comment.
+type AdminRestoreCommentRequest struct {
+	CommentID string `path:"comment_id" doc:"Comment ID" example:"1"`
+}
+
+// AdminRestoreCommentHandler handles POST /admin/comments/{comment_id}/restore
+func (h *CommentAdminHandler) AdminRestoreCommentHandler(ctx context.Context, req *AdminRestoreCommentRequest) (*struct{}, error) {
+	user, err := requireAdmin(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	commentID, err := strconv.ParseUint(req.CommentID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid comment ID")
+	}
+
+	if err := h.admin.RestoreComment(user.ID, uint(commentID)); err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return nil, huma.Error404NotFound("Comment not found")
+		}
+		if strings.Contains(err.Error(), "already visible") {
+			return nil, huma.Error409Conflict("Comment is already visible")
+		}
+		requestID := logger.GetRequestID(ctx)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to restore comment (request_id: %s)", requestID),
+		)
+	}
+
+	// Audit log (fire and forget)
+	if h.auditLogService != nil {
+		go func() {
+			h.auditLogService.LogAction(user.ID, "restore_comment", "comment", uint(commentID), nil)
+		}()
+	}
+
+	return nil, nil
+}
+
+// ============================================================================
+// Admin: List Pending Comments — GET /admin/comments/pending
+// ============================================================================
+
+// AdminListPendingCommentsRequest represents the request for listing pending comments.
+type AdminListPendingCommentsRequest struct {
+	Limit  int `query:"limit" required:"false" doc:"Page size (default 20, max 100)" example:"20"`
+	Offset int `query:"offset" required:"false" doc:"Pagination offset" example:"0"`
+}
+
+// AdminListPendingCommentsResponse represents the response for listing pending comments.
+type AdminListPendingCommentsResponse struct {
+	Body struct {
+		Comments []*contracts.CommentResponse `json:"comments" doc:"Pending comments awaiting review"`
+		Total    int64                        `json:"total" doc:"Total number of pending comments"`
+	}
+}
+
+// AdminListPendingCommentsHandler handles GET /admin/comments/pending
+func (h *CommentAdminHandler) AdminListPendingCommentsHandler(ctx context.Context, req *AdminListPendingCommentsRequest) (*AdminListPendingCommentsResponse, error) {
+	if _, err := requireAdmin(ctx); err != nil {
+		return nil, err
+	}
+
+	limit := req.Limit
+	if limit <= 0 {
+		limit = 20
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	offset := req.Offset
+	if offset < 0 {
+		offset = 0
+	}
+
+	comments, total, err := h.admin.ListPendingComments(limit, offset)
+	if err != nil {
+		requestID := logger.GetRequestID(ctx)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to list pending comments (request_id: %s)", requestID),
+		)
+	}
+
+	resp := &AdminListPendingCommentsResponse{}
+	resp.Body.Comments = comments
+	resp.Body.Total = total
+	return resp, nil
+}
+
+// ============================================================================
+// Admin: Approve Comment — POST /admin/comments/{comment_id}/approve
+// ============================================================================
+
+// AdminApproveCommentRequest represents the request for approving a pending comment.
+type AdminApproveCommentRequest struct {
+	CommentID string `path:"comment_id" doc:"Comment ID" example:"1"`
+}
+
+// AdminApproveCommentHandler handles POST /admin/comments/{comment_id}/approve
+func (h *CommentAdminHandler) AdminApproveCommentHandler(ctx context.Context, req *AdminApproveCommentRequest) (*struct{}, error) {
+	user, err := requireAdmin(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	commentID, err := strconv.ParseUint(req.CommentID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid comment ID")
+	}
+
+	if err := h.admin.ApproveComment(user.ID, uint(commentID)); err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return nil, huma.Error404NotFound("Comment not found")
+		}
+		if strings.Contains(err.Error(), "not pending review") {
+			return nil, huma.Error409Conflict("Comment is not pending review")
+		}
+		requestID := logger.GetRequestID(ctx)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to approve comment (request_id: %s)", requestID),
+		)
+	}
+
+	// Audit log (fire and forget)
+	if h.auditLogService != nil {
+		go func() {
+			h.auditLogService.LogAction(user.ID, "approve_comment", "comment", uint(commentID), nil)
+		}()
+	}
+
+	return nil, nil
+}
+
+// ============================================================================
+// Admin: Reject Comment — POST /admin/comments/{comment_id}/reject
+// ============================================================================
+
+// AdminRejectCommentRequest represents the request for rejecting a pending comment.
+type AdminRejectCommentRequest struct {
+	CommentID string `path:"comment_id" doc:"Comment ID" example:"1"`
+	Body      struct {
+		Reason string `json:"reason" doc:"Reason for rejecting the comment" example:"Spam content"`
+	}
+}
+
+// AdminRejectCommentHandler handles POST /admin/comments/{comment_id}/reject
+func (h *CommentAdminHandler) AdminRejectCommentHandler(ctx context.Context, req *AdminRejectCommentRequest) (*struct{}, error) {
+	user, err := requireAdmin(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	commentID, err := strconv.ParseUint(req.CommentID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid comment ID")
+	}
+
+	reason := strings.TrimSpace(req.Body.Reason)
+	if reason == "" {
+		return nil, huma.Error400BadRequest("Reason is required when rejecting a comment")
+	}
+
+	if err := h.admin.RejectComment(user.ID, uint(commentID), reason); err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return nil, huma.Error404NotFound("Comment not found")
+		}
+		if strings.Contains(err.Error(), "not pending review") {
+			return nil, huma.Error409Conflict("Comment is not pending review")
+		}
+		requestID := logger.GetRequestID(ctx)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to reject comment (request_id: %s)", requestID),
+		)
+	}
+
+	// Audit log (fire and forget)
+	if h.auditLogService != nil {
+		go func() {
+			h.auditLogService.LogAction(user.ID, "reject_comment", "comment", uint(commentID), map[string]interface{}{
+				"reason": reason,
+			})
+		}()
+	}
+
+	return nil, nil
+}

--- a/backend/internal/api/handlers/comment_admin_test.go
+++ b/backend/internal/api/handlers/comment_admin_test.go
@@ -1,0 +1,417 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// ============================================================================
+// Test helpers
+// ============================================================================
+
+func testCommentAdminHandler() *CommentAdminHandler {
+	return NewCommentAdminHandler(nil, nil)
+}
+
+func commentAdminAdminCtx() context.Context {
+	return ctxWithUser(&models.User{ID: 1, IsAdmin: true})
+}
+
+func commentAdminUserCtx() context.Context {
+	return ctxWithUser(&models.User{ID: 10, IsAdmin: false})
+}
+
+// ============================================================================
+// Tests: Hide Comment — Auth & Validation
+// ============================================================================
+
+func TestAdminHideComment_RequiresAdmin(t *testing.T) {
+	h := testCommentAdminHandler()
+
+	t.Run("NoUser", func(t *testing.T) {
+		req := &AdminHideCommentRequest{CommentID: "1"}
+		req.Body.Reason = "spam"
+		_, err := h.AdminHideCommentHandler(context.Background(), req)
+		assertHumaError(t, err, 403)
+	})
+	t.Run("NonAdmin", func(t *testing.T) {
+		req := &AdminHideCommentRequest{CommentID: "1"}
+		req.Body.Reason = "spam"
+		_, err := h.AdminHideCommentHandler(commentAdminUserCtx(), req)
+		assertHumaError(t, err, 403)
+	})
+}
+
+func TestAdminHideComment_InvalidID(t *testing.T) {
+	h := testCommentAdminHandler()
+	req := &AdminHideCommentRequest{CommentID: "abc"}
+	req.Body.Reason = "spam"
+	_, err := h.AdminHideCommentHandler(commentAdminAdminCtx(), req)
+	assertHumaError(t, err, 400)
+}
+
+func TestAdminHideComment_EmptyReason(t *testing.T) {
+	h := testCommentAdminHandler()
+	req := &AdminHideCommentRequest{CommentID: "1"}
+	req.Body.Reason = ""
+	_, err := h.AdminHideCommentHandler(commentAdminAdminCtx(), req)
+	assertHumaError(t, err, 400)
+}
+
+func TestAdminHideComment_NotFound(t *testing.T) {
+	h := NewCommentAdminHandler(
+		&mockCommentAdminService{
+			hideCommentFn: func(adminUserID, commentID uint, reason string) error {
+				return fmt.Errorf("comment not found")
+			},
+		},
+		nil,
+	)
+	req := &AdminHideCommentRequest{CommentID: "99"}
+	req.Body.Reason = "spam"
+	_, err := h.AdminHideCommentHandler(commentAdminAdminCtx(), req)
+	assertHumaError(t, err, 404)
+}
+
+func TestAdminHideComment_Success(t *testing.T) {
+	h := NewCommentAdminHandler(
+		&mockCommentAdminService{
+			hideCommentFn: func(adminUserID, commentID uint, reason string) error {
+				if adminUserID != 1 || commentID != 5 || reason != "violates guidelines" {
+					t.Errorf("unexpected params: admin=%d, comment=%d, reason=%s", adminUserID, commentID, reason)
+				}
+				return nil
+			},
+		},
+		&mockAuditLogService{},
+	)
+	req := &AdminHideCommentRequest{CommentID: "5"}
+	req.Body.Reason = "violates guidelines"
+	_, err := h.AdminHideCommentHandler(commentAdminAdminCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// ============================================================================
+// Tests: Restore Comment — Auth & Validation
+// ============================================================================
+
+func TestAdminRestoreComment_RequiresAdmin(t *testing.T) {
+	h := testCommentAdminHandler()
+
+	t.Run("NoUser", func(t *testing.T) {
+		_, err := h.AdminRestoreCommentHandler(context.Background(), &AdminRestoreCommentRequest{CommentID: "1"})
+		assertHumaError(t, err, 403)
+	})
+	t.Run("NonAdmin", func(t *testing.T) {
+		_, err := h.AdminRestoreCommentHandler(commentAdminUserCtx(), &AdminRestoreCommentRequest{CommentID: "1"})
+		assertHumaError(t, err, 403)
+	})
+}
+
+func TestAdminRestoreComment_InvalidID(t *testing.T) {
+	h := testCommentAdminHandler()
+	_, err := h.AdminRestoreCommentHandler(commentAdminAdminCtx(), &AdminRestoreCommentRequest{CommentID: "abc"})
+	assertHumaError(t, err, 400)
+}
+
+func TestAdminRestoreComment_NotFound(t *testing.T) {
+	h := NewCommentAdminHandler(
+		&mockCommentAdminService{
+			restoreCommentFn: func(adminUserID, commentID uint) error {
+				return fmt.Errorf("comment not found")
+			},
+		},
+		nil,
+	)
+	_, err := h.AdminRestoreCommentHandler(commentAdminAdminCtx(), &AdminRestoreCommentRequest{CommentID: "99"})
+	assertHumaError(t, err, 404)
+}
+
+func TestAdminRestoreComment_AlreadyVisible(t *testing.T) {
+	h := NewCommentAdminHandler(
+		&mockCommentAdminService{
+			restoreCommentFn: func(adminUserID, commentID uint) error {
+				return fmt.Errorf("comment is already visible")
+			},
+		},
+		nil,
+	)
+	_, err := h.AdminRestoreCommentHandler(commentAdminAdminCtx(), &AdminRestoreCommentRequest{CommentID: "1"})
+	assertHumaError(t, err, 409)
+}
+
+func TestAdminRestoreComment_Success(t *testing.T) {
+	h := NewCommentAdminHandler(
+		&mockCommentAdminService{
+			restoreCommentFn: func(adminUserID, commentID uint) error {
+				if adminUserID != 1 || commentID != 5 {
+					t.Errorf("unexpected params: admin=%d, comment=%d", adminUserID, commentID)
+				}
+				return nil
+			},
+		},
+		&mockAuditLogService{},
+	)
+	_, err := h.AdminRestoreCommentHandler(commentAdminAdminCtx(), &AdminRestoreCommentRequest{CommentID: "5"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// ============================================================================
+// Tests: List Pending Comments — Auth & Pagination
+// ============================================================================
+
+func TestAdminListPendingComments_RequiresAdmin(t *testing.T) {
+	h := testCommentAdminHandler()
+
+	t.Run("NoUser", func(t *testing.T) {
+		_, err := h.AdminListPendingCommentsHandler(context.Background(), &AdminListPendingCommentsRequest{})
+		assertHumaError(t, err, 403)
+	})
+	t.Run("NonAdmin", func(t *testing.T) {
+		_, err := h.AdminListPendingCommentsHandler(commentAdminUserCtx(), &AdminListPendingCommentsRequest{})
+		assertHumaError(t, err, 403)
+	})
+}
+
+func TestAdminListPendingComments_Success(t *testing.T) {
+	pendingComments := []*contracts.CommentResponse{
+		{
+			ID:         1,
+			EntityType: "artist",
+			EntityID:   10,
+			Kind:       "comment",
+			UserID:     5,
+			Body:       "Pending comment",
+			Visibility: "pending_review",
+			CreatedAt:  time.Now(),
+			UpdatedAt:  time.Now(),
+		},
+	}
+	h := NewCommentAdminHandler(
+		&mockCommentAdminService{
+			listPendingCommentsFn: func(limit, offset int) ([]*contracts.CommentResponse, int64, error) {
+				if limit != 20 || offset != 0 {
+					t.Errorf("unexpected pagination: limit=%d, offset=%d", limit, offset)
+				}
+				return pendingComments, 1, nil
+			},
+		},
+		nil,
+	)
+	resp, err := h.AdminListPendingCommentsHandler(commentAdminAdminCtx(), &AdminListPendingCommentsRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Total != 1 {
+		t.Errorf("expected total=1, got %d", resp.Body.Total)
+	}
+	if len(resp.Body.Comments) != 1 {
+		t.Errorf("expected 1 comment, got %d", len(resp.Body.Comments))
+	}
+}
+
+func TestAdminListPendingComments_ServiceError(t *testing.T) {
+	h := NewCommentAdminHandler(
+		&mockCommentAdminService{
+			listPendingCommentsFn: func(limit, offset int) ([]*contracts.CommentResponse, int64, error) {
+				return nil, 0, fmt.Errorf("database error")
+			},
+		},
+		nil,
+	)
+	_, err := h.AdminListPendingCommentsHandler(commentAdminAdminCtx(), &AdminListPendingCommentsRequest{})
+	assertHumaError(t, err, 500)
+}
+
+// ============================================================================
+// Tests: Approve Comment — Auth & Validation
+// ============================================================================
+
+func TestAdminApproveComment_RequiresAdmin(t *testing.T) {
+	h := testCommentAdminHandler()
+
+	t.Run("NoUser", func(t *testing.T) {
+		_, err := h.AdminApproveCommentHandler(context.Background(), &AdminApproveCommentRequest{CommentID: "1"})
+		assertHumaError(t, err, 403)
+	})
+	t.Run("NonAdmin", func(t *testing.T) {
+		_, err := h.AdminApproveCommentHandler(commentAdminUserCtx(), &AdminApproveCommentRequest{CommentID: "1"})
+		assertHumaError(t, err, 403)
+	})
+}
+
+func TestAdminApproveComment_InvalidID(t *testing.T) {
+	h := testCommentAdminHandler()
+	_, err := h.AdminApproveCommentHandler(commentAdminAdminCtx(), &AdminApproveCommentRequest{CommentID: "abc"})
+	assertHumaError(t, err, 400)
+}
+
+func TestAdminApproveComment_NotFound(t *testing.T) {
+	h := NewCommentAdminHandler(
+		&mockCommentAdminService{
+			approveCommentFn: func(adminUserID, commentID uint) error {
+				return fmt.Errorf("comment not found")
+			},
+		},
+		nil,
+	)
+	_, err := h.AdminApproveCommentHandler(commentAdminAdminCtx(), &AdminApproveCommentRequest{CommentID: "99"})
+	assertHumaError(t, err, 404)
+}
+
+func TestAdminApproveComment_NotPending(t *testing.T) {
+	h := NewCommentAdminHandler(
+		&mockCommentAdminService{
+			approveCommentFn: func(adminUserID, commentID uint) error {
+				return fmt.Errorf("comment is not pending review")
+			},
+		},
+		nil,
+	)
+	_, err := h.AdminApproveCommentHandler(commentAdminAdminCtx(), &AdminApproveCommentRequest{CommentID: "1"})
+	assertHumaError(t, err, 409)
+}
+
+func TestAdminApproveComment_Success(t *testing.T) {
+	h := NewCommentAdminHandler(
+		&mockCommentAdminService{
+			approveCommentFn: func(adminUserID, commentID uint) error {
+				if adminUserID != 1 || commentID != 5 {
+					t.Errorf("unexpected params: admin=%d, comment=%d", adminUserID, commentID)
+				}
+				return nil
+			},
+		},
+		&mockAuditLogService{},
+	)
+	_, err := h.AdminApproveCommentHandler(commentAdminAdminCtx(), &AdminApproveCommentRequest{CommentID: "5"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// ============================================================================
+// Tests: Reject Comment — Auth & Validation
+// ============================================================================
+
+func TestAdminRejectComment_RequiresAdmin(t *testing.T) {
+	h := testCommentAdminHandler()
+
+	t.Run("NoUser", func(t *testing.T) {
+		req := &AdminRejectCommentRequest{CommentID: "1"}
+		req.Body.Reason = "spam"
+		_, err := h.AdminRejectCommentHandler(context.Background(), req)
+		assertHumaError(t, err, 403)
+	})
+	t.Run("NonAdmin", func(t *testing.T) {
+		req := &AdminRejectCommentRequest{CommentID: "1"}
+		req.Body.Reason = "spam"
+		_, err := h.AdminRejectCommentHandler(commentAdminUserCtx(), req)
+		assertHumaError(t, err, 403)
+	})
+}
+
+func TestAdminRejectComment_InvalidID(t *testing.T) {
+	h := testCommentAdminHandler()
+	req := &AdminRejectCommentRequest{CommentID: "abc"}
+	req.Body.Reason = "spam"
+	_, err := h.AdminRejectCommentHandler(commentAdminAdminCtx(), req)
+	assertHumaError(t, err, 400)
+}
+
+func TestAdminRejectComment_EmptyReason(t *testing.T) {
+	h := testCommentAdminHandler()
+	req := &AdminRejectCommentRequest{CommentID: "1"}
+	req.Body.Reason = ""
+	_, err := h.AdminRejectCommentHandler(commentAdminAdminCtx(), req)
+	assertHumaError(t, err, 400)
+}
+
+func TestAdminRejectComment_NotFound(t *testing.T) {
+	h := NewCommentAdminHandler(
+		&mockCommentAdminService{
+			rejectCommentFn: func(adminUserID, commentID uint, reason string) error {
+				return fmt.Errorf("comment not found")
+			},
+		},
+		nil,
+	)
+	req := &AdminRejectCommentRequest{CommentID: "99"}
+	req.Body.Reason = "spam"
+	_, err := h.AdminRejectCommentHandler(commentAdminAdminCtx(), req)
+	assertHumaError(t, err, 404)
+}
+
+func TestAdminRejectComment_NotPending(t *testing.T) {
+	h := NewCommentAdminHandler(
+		&mockCommentAdminService{
+			rejectCommentFn: func(adminUserID, commentID uint, reason string) error {
+				return fmt.Errorf("comment is not pending review")
+			},
+		},
+		nil,
+	)
+	req := &AdminRejectCommentRequest{CommentID: "1"}
+	req.Body.Reason = "spam"
+	_, err := h.AdminRejectCommentHandler(commentAdminAdminCtx(), req)
+	assertHumaError(t, err, 409)
+}
+
+func TestAdminRejectComment_Success(t *testing.T) {
+	h := NewCommentAdminHandler(
+		&mockCommentAdminService{
+			rejectCommentFn: func(adminUserID, commentID uint, reason string) error {
+				if adminUserID != 1 || commentID != 5 || reason != "spam" {
+					t.Errorf("unexpected params: admin=%d, comment=%d, reason=%s", adminUserID, commentID, reason)
+				}
+				return nil
+			},
+		},
+		&mockAuditLogService{},
+	)
+	req := &AdminRejectCommentRequest{CommentID: "5"}
+	req.Body.Reason = "spam"
+	_, err := h.AdminRejectCommentHandler(commentAdminAdminCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// ============================================================================
+// Tests: CreateComment — Rate limiting error mapping
+// ============================================================================
+
+func TestCreateComment_RateLimitError(t *testing.T) {
+	mock := &mockCommentService{
+		createCommentFn: func(userID uint, req *contracts.CreateCommentRequest) (*contracts.CommentResponse, error) {
+			return nil, fmt.Errorf("please wait 60 seconds between comments on the same entity")
+		},
+	}
+	h := NewCommentHandler(mock, mock, nil)
+	req := &CreateCommentRequest{EntityType: "show", EntityID: "1"}
+	req.Body.Body = "Hello"
+	_, err := h.CreateCommentHandler(commentUserCtx(), req)
+	assertHumaError(t, err, 429)
+}
+
+func TestCreateComment_HourlyLimitError(t *testing.T) {
+	mock := &mockCommentService{
+		createCommentFn: func(userID uint, req *contracts.CreateCommentRequest) (*contracts.CommentResponse, error) {
+			return nil, fmt.Errorf("you've reached your hourly comment limit (5/hour for new users)")
+		},
+	}
+	h := NewCommentHandler(mock, mock, nil)
+	req := &CreateCommentRequest{EntityType: "show", EntityID: "1"}
+	req.Body.Body = "Hello"
+	_, err := h.CreateCommentHandler(commentUserCtx(), req)
+	assertHumaError(t, err, 429)
+}

--- a/backend/internal/api/handlers/entity_report.go
+++ b/backend/internal/api/handlers/entity_report.go
@@ -68,6 +68,11 @@ func (h *EntityReportHandler) ReportShowHandler(ctx context.Context, req *Report
 	return h.reportEntity(ctx, "show", req)
 }
 
+// ReportCommentHandler handles POST /comments/{entity_id}/report
+func (h *EntityReportHandler) ReportCommentHandler(ctx context.Context, req *ReportEntityRequest) (*ReportEntityResponse, error) {
+	return h.reportEntity(ctx, "comment", req)
+}
+
 // reportEntity is the shared implementation for all report endpoints.
 func (h *EntityReportHandler) reportEntity(ctx context.Context, entityType string, req *ReportEntityRequest) (*ReportEntityResponse, error) {
 	user := middleware.GetUserFromContext(ctx)

--- a/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
+++ b/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
@@ -791,6 +791,49 @@ func (m *mockCollectionService) SetFeatured(slug string, featured bool) (error) 
 }
 
 // ============================================================================
+// Mock: CommentAdminServiceInterface
+// ============================================================================
+
+type mockCommentAdminService struct {
+	hideCommentFn func(uint, uint, string) (error)
+	restoreCommentFn func(uint, uint) (error)
+	listPendingCommentsFn func(int, int) ([]*contracts.CommentResponse, int64, error)
+	approveCommentFn func(uint, uint) (error)
+	rejectCommentFn func(uint, uint, string) (error)
+}
+
+func (m *mockCommentAdminService) HideComment(adminUserID uint, commentID uint, reason string) (error) {
+	if m.hideCommentFn != nil {
+		return m.hideCommentFn(adminUserID, commentID, reason)
+	}
+	return nil
+}
+func (m *mockCommentAdminService) RestoreComment(adminUserID uint, commentID uint) (error) {
+	if m.restoreCommentFn != nil {
+		return m.restoreCommentFn(adminUserID, commentID)
+	}
+	return nil
+}
+func (m *mockCommentAdminService) ListPendingComments(limit int, offset int) ([]*contracts.CommentResponse, int64, error) {
+	if m.listPendingCommentsFn != nil {
+		return m.listPendingCommentsFn(limit, offset)
+	}
+	return nil, 0, nil
+}
+func (m *mockCommentAdminService) ApproveComment(adminUserID uint, commentID uint) (error) {
+	if m.approveCommentFn != nil {
+		return m.approveCommentFn(adminUserID, commentID)
+	}
+	return nil
+}
+func (m *mockCommentAdminService) RejectComment(adminUserID uint, commentID uint, reason string) (error) {
+	if m.rejectCommentFn != nil {
+		return m.rejectCommentFn(adminUserID, commentID, reason)
+	}
+	return nil
+}
+
+// ============================================================================
 // Mock: CommentServiceInterface
 // ============================================================================
 
@@ -3729,6 +3772,7 @@ var _ contracts.AutoPromotionServiceInterface = (*mockAutoPromotionService)(nil)
 var _ contracts.CalendarServiceInterface = (*mockCalendarService)(nil)
 var _ contracts.ChartsServiceInterface = (*mockChartsService)(nil)
 var _ contracts.CollectionServiceInterface = (*mockCollectionService)(nil)
+var _ contracts.CommentAdminServiceInterface = (*mockCommentAdminService)(nil)
 var _ contracts.CommentServiceInterface = (*mockCommentService)(nil)
 var _ contracts.CommentSubscriptionServiceInterface = (*mockCommentSubscriptionService)(nil)
 var _ contracts.CommentVoteServiceInterface = (*mockCommentVoteService)(nil)

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -986,6 +986,7 @@ func setupEntityReportRoutes(rc RouteContext) {
 		// The generic entity report handler + service support shows, so the admin queue
 		// can display show reports submitted through the existing endpoint or this one.
 		huma.Post(reportAPI, "/shows/{entity_id}/entity-report", entityReportHandler.ReportShowHandler)
+		huma.Post(reportAPI, "/comments/{entity_id}/report", entityReportHandler.ReportCommentHandler)
 	})
 
 	// Admin: entity report management
@@ -1071,8 +1072,10 @@ func setupRadioRoutes(rc RouteContext) {
 // setupCommentRoutes configures comment endpoints.
 // Public routes use optional auth (could be used for user vote context in future).
 // Protected routes require authentication.
+// Admin routes require admin privileges.
 func setupCommentRoutes(rc RouteContext) {
 	commentHandler := handlers.NewCommentHandler(rc.SC.Comment, rc.SC.Comment, rc.SC.AuditLog)
+	commentAdminHandler := handlers.NewCommentAdminHandler(rc.SC.Comment, rc.SC.AuditLog)
 
 	// Public: list comments, get comment, get thread
 	optionalAuthGroup := huma.NewGroup(rc.API, "")
@@ -1086,6 +1089,13 @@ func setupCommentRoutes(rc RouteContext) {
 	huma.Post(rc.Protected, "/comments/{comment_id}/replies", commentHandler.CreateReplyHandler)
 	huma.Put(rc.Protected, "/comments/{comment_id}", commentHandler.UpdateCommentHandler)
 	huma.Delete(rc.Protected, "/comments/{comment_id}", commentHandler.DeleteCommentHandler)
+
+	// Admin: comment moderation
+	huma.Post(rc.Protected, "/admin/comments/{comment_id}/hide", commentAdminHandler.AdminHideCommentHandler)
+	huma.Post(rc.Protected, "/admin/comments/{comment_id}/restore", commentAdminHandler.AdminRestoreCommentHandler)
+	huma.Get(rc.Protected, "/admin/comments/pending", commentAdminHandler.AdminListPendingCommentsHandler)
+	huma.Post(rc.Protected, "/admin/comments/{comment_id}/approve", commentAdminHandler.AdminApproveCommentHandler)
+	huma.Post(rc.Protected, "/admin/comments/{comment_id}/reject", commentAdminHandler.AdminRejectCommentHandler)
 }
 
 // setupCommentVoteRoutes configures comment voting endpoints.

--- a/backend/internal/models/comment.go
+++ b/backend/internal/models/comment.go
@@ -78,6 +78,9 @@ type Comment struct {
 	BodyHTML        string            `gorm:"not null;column:body_html"`
 	StructuredData  *json.RawMessage  `gorm:"column:structured_data;type:jsonb"`
 	Visibility      CommentVisibility `gorm:"not null;column:visibility;default:'visible'"`
+	HiddenReason    *string           `gorm:"column:hidden_reason"`
+	HiddenByUserID  *uint             `gorm:"column:hidden_by_user_id"`
+	HiddenAt        *time.Time        `gorm:"column:hidden_at"`
 	ReplyPermission ReplyPermission   `gorm:"not null;column:reply_permission;default:'anyone'"`
 	Ups             int               `gorm:"not null;column:ups;default:0"`
 	Downs           int               `gorm:"not null;column:downs;default:0"`

--- a/backend/internal/models/entity_report.go
+++ b/backend/internal/models/entity_report.go
@@ -17,6 +17,7 @@ const (
 	EntityReportEntityVenue    = "venue"
 	EntityReportEntityFestival = "festival"
 	EntityReportEntityShow     = "show"
+	EntityReportEntityComment  = "comment"
 )
 
 // Valid report types per entity type.
@@ -48,6 +49,13 @@ var validReportTypes = map[string]map[string]bool{
 		"wrong_venue": true,
 		"wrong_date":  true,
 	},
+	EntityReportEntityComment: {
+		"spam":       true,
+		"harassment": true,
+		"off_topic":  true,
+		"inaccurate": true,
+		"other":      true,
+	},
 }
 
 // EntityReport represents a user report about an entity issue.
@@ -74,7 +82,7 @@ func (EntityReport) TableName() string { return "entity_reports" }
 
 // ValidEntityReportEntityTypes returns the set of entity types that support reports.
 func ValidEntityReportEntityTypes() []string {
-	return []string{EntityReportEntityArtist, EntityReportEntityVenue, EntityReportEntityFestival, EntityReportEntityShow}
+	return []string{EntityReportEntityArtist, EntityReportEntityVenue, EntityReportEntityFestival, EntityReportEntityShow, EntityReportEntityComment}
 }
 
 // IsValidEntityReportEntityType checks if the given entity type supports reports.

--- a/backend/internal/services/admin/entity_name.go
+++ b/backend/internal/services/admin/entity_name.go
@@ -34,6 +34,15 @@ func resolveEntityName(db *gorm.DB, entityType string, entityID uint) string {
 		if err := db.Table("shows").Select("title").Where("id = ?", entityID).Scan(&result).Error; err == nil && result.Title != "" {
 			return result.Title
 		}
+	case "comment":
+		// For comments, return a truncated body as the "name"
+		var result struct{ Body string }
+		if err := db.Table("comments").Select("body").Where("id = ?", entityID).Scan(&result).Error; err == nil && result.Body != "" {
+			if len(result.Body) > 60 {
+				return result.Body[:60] + "..."
+			}
+			return result.Body
+		}
 	}
 
 	return fmt.Sprintf("%s #%d", entityType, entityID)

--- a/backend/internal/services/admin/entity_report.go
+++ b/backend/internal/services/admin/entity_report.go
@@ -39,6 +39,10 @@ func (s *EntityReportService) CreateEntityReport(req *contracts.CreateEntityRepo
 
 	// Verify the entity exists
 	tableName := req.EntityType + "s"
+	// Comments table is already plural
+	if req.EntityType == "comment" {
+		tableName = "comments"
+	}
 	var count int64
 	if err := s.db.Table(tableName).Where("id = ?", req.EntityID).Count(&count).Error; err != nil {
 		return nil, fmt.Errorf("failed to verify entity: %w", err)
@@ -70,6 +74,23 @@ func (s *EntityReportService) CreateEntityReport(req *contracts.CreateEntityRepo
 
 	if err := s.db.Create(report).Error; err != nil {
 		return nil, fmt.Errorf("failed to create entity report: %w", err)
+	}
+
+	// Auto-hide comments with 3+ reports
+	if req.EntityType == "comment" {
+		var totalReports int64
+		if err := s.db.Model(&models.EntityReport{}).
+			Where("entity_type = 'comment' AND entity_id = ? AND status = ?",
+				req.EntityID, models.EntityReportStatusPending).
+			Count(&totalReports).Error; err == nil && totalReports >= 3 {
+			// Auto-hide the comment
+			s.db.Table("comments").Where("id = ? AND visibility = 'visible'", req.EntityID).
+				Updates(map[string]interface{}{
+					"visibility":    "hidden_by_mod",
+					"hidden_reason": "auto-hidden: multiple reports",
+					"updated_at":    time.Now(),
+				})
+		}
 	}
 
 	// Reload with relationships

--- a/backend/internal/services/admin/entity_report_test.go
+++ b/backend/internal/services/admin/entity_report_test.go
@@ -74,11 +74,12 @@ func TestValidReportTypesForEntity(t *testing.T) {
 
 func TestValidEntityReportEntityTypes(t *testing.T) {
 	types := models.ValidEntityReportEntityTypes()
-	assert.Len(t, types, 4)
+	assert.Len(t, types, 5)
 	assert.Contains(t, types, "artist")
 	assert.Contains(t, types, "venue")
 	assert.Contains(t, types, "festival")
 	assert.Contains(t, types, "show")
+	assert.Contains(t, types, "comment")
 }
 
 // =============================================================================

--- a/backend/internal/services/contracts/comment.go
+++ b/backend/internal/services/contracts/comment.go
@@ -80,6 +80,28 @@ type CommentServiceInterface interface {
 	UpdateComment(userID uint, commentID uint, req *UpdateCommentRequest) (*CommentResponse, error)
 	DeleteComment(userID uint, commentID uint, isAdmin bool) error
 }
+// ──────────────────────────────────────────────
+// Comment admin service interface
+// ──────────────────────────────────────────────
+
+// CommentAdminServiceInterface defines the contract for comment moderation operations.
+type CommentAdminServiceInterface interface {
+	// HideComment hides a comment with a reason (admin action).
+	HideComment(adminUserID uint, commentID uint, reason string) error
+
+	// RestoreComment restores a hidden comment to visible (admin action).
+	RestoreComment(adminUserID uint, commentID uint) error
+
+	// ListPendingComments returns comments with pending_review visibility.
+	ListPendingComments(limit, offset int) ([]*CommentResponse, int64, error)
+
+	// ApproveComment approves a pending comment (sets visibility to visible).
+	ApproveComment(adminUserID uint, commentID uint) error
+
+	// RejectComment rejects a pending comment (sets visibility to hidden_by_mod).
+	RejectComment(adminUserID uint, commentID uint, reason string) error
+}
+
 // CommentVoteResponse contains vote counts and the current user's vote.
 type CommentVoteResponse struct {
 	Ups      int      `json:"ups"`

--- a/backend/internal/services/engagement/comment_service.go
+++ b/backend/internal/services/engagement/comment_service.go
@@ -135,6 +135,36 @@ func commentToResponse(c *models.Comment) *contracts.CommentResponse {
 	return resp
 }
 
+// userTierHourlyLimit returns the hourly comment limit for a given user tier.
+// Returns -1 for unlimited.
+func userTierHourlyLimit(tier string) int {
+	switch tier {
+	case "new_user", "":
+		return 5
+	case "contributor":
+		return 30
+	case "trusted_contributor":
+		return 100
+	case "local_ambassador", "admin":
+		return -1 // unlimited
+	default:
+		return 5
+	}
+}
+
+// computeInitialVisibility determines the initial visibility based on user trust tier.
+func computeInitialVisibility(user *models.User) models.CommentVisibility {
+	if user.IsAdmin {
+		return models.CommentVisibilityVisible
+	}
+	switch user.UserTier {
+	case "contributor", "trusted_contributor", "local_ambassador":
+		return models.CommentVisibilityVisible
+	default: // "new_user" or empty
+		return models.CommentVisibilityPendingReview
+	}
+}
+
 // CreateComment creates a new comment or reply.
 func (s *CommentService) CreateComment(userID uint, req *contracts.CreateCommentRequest) (*contracts.CommentResponse, error) {
 	if s.db == nil {
@@ -159,6 +189,47 @@ func (s *CommentService) CreateComment(userID uint, req *contracts.CreateComment
 	// Validate entity exists
 	if err := s.validateEntityExists(entityType, req.EntityID); err != nil {
 		return nil, err
+	}
+
+	// Look up user for trust tier and rate limiting
+	var user models.User
+	if err := s.db.First(&user, userID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, errors.New("user not found")
+		}
+		return nil, fmt.Errorf("failed to look up user: %w", err)
+	}
+
+	// Rate limiting: per-entity cooldown (60s between comments on same entity)
+	var recentEntityCount int64
+	if err := s.db.Model(&models.Comment{}).
+		Where("user_id = ? AND entity_type = ? AND entity_id = ? AND created_at > ?",
+			userID, entityType, req.EntityID, time.Now().Add(-60*time.Second)).
+		Count(&recentEntityCount).Error; err != nil {
+		return nil, fmt.Errorf("failed to check rate limit: %w", err)
+	}
+	if recentEntityCount > 0 {
+		return nil, errors.New("please wait 60 seconds between comments on the same entity")
+	}
+
+	// Rate limiting: global hourly limit based on trust tier
+	hourlyLimit := userTierHourlyLimit(user.UserTier)
+	if hourlyLimit >= 0 { // -1 means unlimited
+		var hourlyCount int64
+		if err := s.db.Model(&models.Comment{}).
+			Where("user_id = ? AND created_at > ?", userID, time.Now().Add(-1*time.Hour)).
+			Count(&hourlyCount).Error; err != nil {
+			return nil, fmt.Errorf("failed to check hourly rate limit: %w", err)
+		}
+		if int(hourlyCount) >= hourlyLimit {
+			return nil, fmt.Errorf("you've reached your hourly comment limit (%d/hour for %s users)",
+				hourlyLimit, func() string {
+					if user.UserTier == "" {
+						return "new"
+					}
+					return strings.ReplaceAll(user.UserTier, "_", " ")
+				}())
+		}
 	}
 
 	// Determine kind
@@ -212,6 +283,9 @@ func (s *CommentService) CreateComment(userID uint, req *contracts.CreateComment
 	// Render markdown to HTML
 	bodyHTML := s.renderMarkdown(body)
 
+	// Determine initial visibility based on trust tier
+	visibility := computeInitialVisibility(&user)
+
 	comment := &models.Comment{
 		EntityType:      entityType,
 		EntityID:        req.EntityID,
@@ -222,7 +296,7 @@ func (s *CommentService) CreateComment(userID uint, req *contracts.CreateComment
 		Depth:           depth,
 		Body:            body,
 		BodyHTML:        bodyHTML,
-		Visibility:      models.CommentVisibilityVisible,
+		Visibility:      visibility,
 		ReplyPermission: replyPerm,
 	}
 
@@ -467,6 +541,167 @@ func (s *CommentService) DeleteComment(userID uint, commentID uint, isAdmin bool
 		"updated_at": time.Now(),
 	}).Error; err != nil {
 		return fmt.Errorf("failed to delete comment: %w", err)
+	}
+
+	return nil
+}
+
+// ============================================================================
+// Admin moderation methods
+// ============================================================================
+
+// HideComment hides a comment with a reason (admin action).
+func (s *CommentService) HideComment(adminUserID uint, commentID uint, reason string) error {
+	if s.db == nil {
+		return errors.New("database not initialized")
+	}
+
+	var comment models.Comment
+	if err := s.db.First(&comment, commentID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return errors.New("comment not found")
+		}
+		return fmt.Errorf("failed to fetch comment: %w", err)
+	}
+
+	now := time.Now()
+	if err := s.db.Model(&comment).Updates(map[string]interface{}{
+		"visibility":        models.CommentVisibilityHiddenByMod,
+		"hidden_reason":     reason,
+		"hidden_by_user_id": adminUserID,
+		"hidden_at":         now,
+		"updated_at":        now,
+	}).Error; err != nil {
+		return fmt.Errorf("failed to hide comment: %w", err)
+	}
+
+	return nil
+}
+
+// RestoreComment restores a hidden comment to visible (admin action).
+func (s *CommentService) RestoreComment(adminUserID uint, commentID uint) error {
+	if s.db == nil {
+		return errors.New("database not initialized")
+	}
+
+	var comment models.Comment
+	if err := s.db.First(&comment, commentID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return errors.New("comment not found")
+		}
+		return fmt.Errorf("failed to fetch comment: %w", err)
+	}
+
+	if comment.Visibility == models.CommentVisibilityVisible {
+		return errors.New("comment is already visible")
+	}
+
+	if err := s.db.Model(&comment).Updates(map[string]interface{}{
+		"visibility":        models.CommentVisibilityVisible,
+		"hidden_reason":     nil,
+		"hidden_by_user_id": nil,
+		"hidden_at":         nil,
+		"updated_at":        time.Now(),
+	}).Error; err != nil {
+		return fmt.Errorf("failed to restore comment: %w", err)
+	}
+
+	return nil
+}
+
+// ListPendingComments returns comments with pending_review visibility.
+func (s *CommentService) ListPendingComments(limit, offset int) ([]*contracts.CommentResponse, int64, error) {
+	if s.db == nil {
+		return nil, 0, errors.New("database not initialized")
+	}
+
+	if limit <= 0 {
+		limit = 20
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	var total int64
+	if err := s.db.Model(&models.Comment{}).
+		Where("visibility = ?", models.CommentVisibilityPendingReview).
+		Count(&total).Error; err != nil {
+		return nil, 0, fmt.Errorf("failed to count pending comments: %w", err)
+	}
+
+	var comments []models.Comment
+	if err := s.db.Preload("User").
+		Where("visibility = ?", models.CommentVisibilityPendingReview).
+		Order("created_at ASC").
+		Limit(limit).
+		Offset(offset).
+		Find(&comments).Error; err != nil {
+		return nil, 0, fmt.Errorf("failed to fetch pending comments: %w", err)
+	}
+
+	responses := make([]*contracts.CommentResponse, len(comments))
+	for i := range comments {
+		responses[i] = commentToResponse(&comments[i])
+	}
+
+	return responses, total, nil
+}
+
+// ApproveComment approves a pending comment (sets visibility to visible).
+func (s *CommentService) ApproveComment(adminUserID uint, commentID uint) error {
+	if s.db == nil {
+		return errors.New("database not initialized")
+	}
+
+	var comment models.Comment
+	if err := s.db.First(&comment, commentID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return errors.New("comment not found")
+		}
+		return fmt.Errorf("failed to fetch comment: %w", err)
+	}
+
+	if comment.Visibility != models.CommentVisibilityPendingReview {
+		return errors.New("comment is not pending review")
+	}
+
+	if err := s.db.Model(&comment).Updates(map[string]interface{}{
+		"visibility": models.CommentVisibilityVisible,
+		"updated_at": time.Now(),
+	}).Error; err != nil {
+		return fmt.Errorf("failed to approve comment: %w", err)
+	}
+
+	return nil
+}
+
+// RejectComment rejects a pending comment (sets visibility to hidden_by_mod).
+func (s *CommentService) RejectComment(adminUserID uint, commentID uint, reason string) error {
+	if s.db == nil {
+		return errors.New("database not initialized")
+	}
+
+	var comment models.Comment
+	if err := s.db.First(&comment, commentID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return errors.New("comment not found")
+		}
+		return fmt.Errorf("failed to fetch comment: %w", err)
+	}
+
+	if comment.Visibility != models.CommentVisibilityPendingReview {
+		return errors.New("comment is not pending review")
+	}
+
+	now := time.Now()
+	if err := s.db.Model(&comment).Updates(map[string]interface{}{
+		"visibility":        models.CommentVisibilityHiddenByMod,
+		"hidden_reason":     reason,
+		"hidden_by_user_id": adminUserID,
+		"hidden_at":         now,
+		"updated_at":        now,
+	}).Error; err != nil {
+		return fmt.Errorf("failed to reject comment: %w", err)
 	}
 
 	return nil

--- a/backend/internal/services/engagement/comment_service_test.go
+++ b/backend/internal/services/engagement/comment_service_test.go
@@ -61,6 +61,36 @@ func TestCommentService_NilDB(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "database not initialized")
 	})
+
+	t.Run("HideComment_NilDB", func(t *testing.T) {
+		err := svc.HideComment(1, 1, "reason")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "database not initialized")
+	})
+
+	t.Run("RestoreComment_NilDB", func(t *testing.T) {
+		err := svc.RestoreComment(1, 1)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "database not initialized")
+	})
+
+	t.Run("ListPendingComments_NilDB", func(t *testing.T) {
+		_, _, err := svc.ListPendingComments(20, 0)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "database not initialized")
+	})
+
+	t.Run("ApproveComment_NilDB", func(t *testing.T) {
+		err := svc.ApproveComment(1, 1)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "database not initialized")
+	})
+
+	t.Run("RejectComment_NilDB", func(t *testing.T) {
+		err := svc.RejectComment(1, 1, "reason")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "database not initialized")
+	})
 }
 
 func TestCommentService_InvalidEntityType(t *testing.T) {
@@ -194,6 +224,43 @@ func TestMarkdownRendering(t *testing.T) {
 	})
 }
 
+func TestComputeInitialVisibility(t *testing.T) {
+	t.Run("AdminAlwaysVisible", func(t *testing.T) {
+		user := &models.User{IsAdmin: true, UserTier: "new_user"}
+		assert.Equal(t, models.CommentVisibilityVisible, computeInitialVisibility(user))
+	})
+	t.Run("NewUser_PendingReview", func(t *testing.T) {
+		user := &models.User{UserTier: "new_user"}
+		assert.Equal(t, models.CommentVisibilityPendingReview, computeInitialVisibility(user))
+	})
+	t.Run("EmptyTier_PendingReview", func(t *testing.T) {
+		user := &models.User{UserTier: ""}
+		assert.Equal(t, models.CommentVisibilityPendingReview, computeInitialVisibility(user))
+	})
+	t.Run("Contributor_Visible", func(t *testing.T) {
+		user := &models.User{UserTier: "contributor"}
+		assert.Equal(t, models.CommentVisibilityVisible, computeInitialVisibility(user))
+	})
+	t.Run("TrustedContributor_Visible", func(t *testing.T) {
+		user := &models.User{UserTier: "trusted_contributor"}
+		assert.Equal(t, models.CommentVisibilityVisible, computeInitialVisibility(user))
+	})
+	t.Run("LocalAmbassador_Visible", func(t *testing.T) {
+		user := &models.User{UserTier: "local_ambassador"}
+		assert.Equal(t, models.CommentVisibilityVisible, computeInitialVisibility(user))
+	})
+}
+
+func TestUserTierHourlyLimit(t *testing.T) {
+	assert.Equal(t, 5, userTierHourlyLimit("new_user"))
+	assert.Equal(t, 5, userTierHourlyLimit(""))
+	assert.Equal(t, 30, userTierHourlyLimit("contributor"))
+	assert.Equal(t, 100, userTierHourlyLimit("trusted_contributor"))
+	assert.Equal(t, -1, userTierHourlyLimit("local_ambassador"))
+	assert.Equal(t, -1, userTierHourlyLimit("admin"))
+	assert.Equal(t, 5, userTierHourlyLimit("unknown_tier"))
+}
+
 func TestWilsonScore(t *testing.T) {
 	t.Run("NoVotes", func(t *testing.T) {
 		score := wilsonScore(0, 0)
@@ -283,6 +350,22 @@ func (suite *CommentServiceIntegrationTestSuite) createTestUser() *models.User {
 		LastName:      stringPtr("User"),
 		IsActive:      true,
 		EmailVerified: true,
+		UserTier:      "contributor", // contributor tier auto-publishes comments
+	}
+	err := suite.db.Create(user).Error
+	suite.Require().NoError(err)
+	return user
+}
+
+func (suite *CommentServiceIntegrationTestSuite) createTestNewUser() *models.User {
+	user := &models.User{
+		Email:         stringPtr(fmt.Sprintf("newuser-%d@test.com", time.Now().UnixNano())),
+		Username:      stringPtr(fmt.Sprintf("newuser%d", time.Now().UnixNano())),
+		FirstName:     stringPtr("New"),
+		LastName:      stringPtr("User"),
+		IsActive:      true,
+		EmailVerified: true,
+		UserTier:      "new_user", // new_user tier → pending_review
 	}
 	err := suite.db.Create(user).Error
 	suite.Require().NoError(err)
@@ -326,6 +409,29 @@ func (suite *CommentServiceIntegrationTestSuite) createTestVenue(name string) ui
 	err := suite.db.Create(venue).Error
 	suite.Require().NoError(err)
 	return venue.ID
+}
+
+// insertComment creates a comment directly in the DB, bypassing rate limiting.
+// Used for test setup where we need multiple comments rapidly.
+func (suite *CommentServiceIntegrationTestSuite) insertComment(userID uint, entityType string, entityID uint, body string, parentID *uint, rootID *uint, depth int) *models.Comment {
+	svc := suite.commentService
+	bodyHTML := svc.renderMarkdown(body)
+	comment := &models.Comment{
+		EntityType:      models.CommentEntityType(entityType),
+		EntityID:        entityID,
+		Kind:            models.CommentKindComment,
+		UserID:          userID,
+		ParentID:        parentID,
+		RootID:          rootID,
+		Depth:           depth,
+		Body:            body,
+		BodyHTML:        bodyHTML,
+		Visibility:      models.CommentVisibilityVisible,
+		ReplyPermission: models.ReplyPermissionAnyone,
+	}
+	err := suite.db.Create(comment).Error
+	suite.Require().NoError(err)
+	return comment
 }
 
 func (suite *CommentServiceIntegrationTestSuite) createTestShow(title string) uint {
@@ -447,6 +553,7 @@ func (suite *CommentServiceIntegrationTestSuite) TestCreateComment_MarkdownRende
 
 func (suite *CommentServiceIntegrationTestSuite) TestCreateComment_Reply() {
 	user := suite.createTestUser()
+	user2 := suite.createTestUser()
 	artistID := suite.createTestArtist("Reply Artist")
 
 	// Create top-level comment
@@ -457,8 +564,8 @@ func (suite *CommentServiceIntegrationTestSuite) TestCreateComment_Reply() {
 	})
 	suite.Require().NoError(err)
 
-	// Create reply
-	reply, err := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+	// Create reply from a different user (avoids per-entity cooldown)
+	reply, err := suite.commentService.CreateComment(user2.ID, &contracts.CreateCommentRequest{
 		EntityType: "artist",
 		EntityID:   artistID,
 		Body:       "Reply comment",
@@ -474,19 +581,21 @@ func (suite *CommentServiceIntegrationTestSuite) TestCreateComment_Reply() {
 }
 
 func (suite *CommentServiceIntegrationTestSuite) TestCreateComment_NestedReply() {
-	user := suite.createTestUser()
+	user1 := suite.createTestUser()
+	user2 := suite.createTestUser()
+	user3 := suite.createTestUser()
 	artistID := suite.createTestArtist("Nested Reply Artist")
 
-	// Depth 0: root
-	root, err := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+	// Depth 0: root (user1)
+	root, err := suite.commentService.CreateComment(user1.ID, &contracts.CreateCommentRequest{
 		EntityType: "artist",
 		EntityID:   artistID,
 		Body:       "Depth 0",
 	})
 	suite.Require().NoError(err)
 
-	// Depth 1: reply to root
-	reply1, err := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+	// Depth 1: reply to root (user2)
+	reply1, err := suite.commentService.CreateComment(user2.ID, &contracts.CreateCommentRequest{
 		EntityType: "artist",
 		EntityID:   artistID,
 		Body:       "Depth 1",
@@ -495,8 +604,8 @@ func (suite *CommentServiceIntegrationTestSuite) TestCreateComment_NestedReply()
 	suite.Require().NoError(err)
 	suite.Equal(1, reply1.Depth)
 
-	// Depth 2: reply to reply (max allowed)
-	reply2, err := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+	// Depth 2: reply to reply (user3, max allowed)
+	reply2, err := suite.commentService.CreateComment(user3.ID, &contracts.CreateCommentRequest{
 		EntityType: "artist",
 		EntityID:   artistID,
 		Body:       "Depth 2",
@@ -511,27 +620,14 @@ func (suite *CommentServiceIntegrationTestSuite) TestCreateComment_DepthLimitExc
 	user := suite.createTestUser()
 	artistID := suite.createTestArtist("Deep Artist")
 
-	// Create chain: depth 0 → 1 → 2
-	root, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
-		EntityType: "artist",
-		EntityID:   artistID,
-		Body:       "Root",
-	})
-	reply1, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
-		EntityType: "artist",
-		EntityID:   artistID,
-		Body:       "Reply 1",
-		ParentID:   &root.ID,
-	})
-	reply2, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
-		EntityType: "artist",
-		EntityID:   artistID,
-		Body:       "Reply 2",
-		ParentID:   &reply1.ID,
-	})
+	// Create chain via direct DB insert (bypasses rate limiting)
+	root := suite.insertComment(user.ID, "artist", artistID, "Root", nil, nil, 0)
+	reply1 := suite.insertComment(user.ID, "artist", artistID, "Reply 1", &root.ID, &root.ID, 1)
+	reply2 := suite.insertComment(user.ID, "artist", artistID, "Reply 2", &reply1.ID, &root.ID, 2)
 
-	// Attempt depth 3 — should fail
-	_, err := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+	// Attempt depth 3 via service — should fail due to max depth
+	user2 := suite.createTestUser()
+	_, err := suite.commentService.CreateComment(user2.ID, &contracts.CreateCommentRequest{
 		EntityType: "artist",
 		EntityID:   artistID,
 		Body:       "Too deep",
@@ -613,13 +709,9 @@ func (suite *CommentServiceIntegrationTestSuite) TestListComments_BasicPaginatio
 	user := suite.createTestUser()
 	artistID := suite.createTestArtist("List Artist")
 
-	// Create 5 comments
+	// Create 5 comments via direct insert (bypasses rate limiting)
 	for i := 0; i < 5; i++ {
-		suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
-			EntityType: "artist",
-			EntityID:   artistID,
-			Body:       fmt.Sprintf("Comment %d", i),
-		})
+		suite.insertComment(user.ID, "artist", artistID, fmt.Sprintf("Comment %d", i), nil, nil, 0)
 	}
 
 	// Page 1 (limit 2)
@@ -645,18 +737,9 @@ func (suite *CommentServiceIntegrationTestSuite) TestListComments_TopLevelOnly()
 	user := suite.createTestUser()
 	artistID := suite.createTestArtist("Top Level Only Artist")
 
-	// Create a root and a reply
-	root, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
-		EntityType: "artist",
-		EntityID:   artistID,
-		Body:       "Root comment",
-	})
-	suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
-		EntityType: "artist",
-		EntityID:   artistID,
-		Body:       "Reply comment",
-		ParentID:   &root.ID,
-	})
+	// Create a root and a reply via direct insert (bypasses rate limiting)
+	root := suite.insertComment(user.ID, "artist", artistID, "Root comment", nil, nil, 0)
+	suite.insertComment(user.ID, "artist", artistID, "Reply comment", &root.ID, &root.ID, 1)
 
 	// List should only return top-level
 	result, err := suite.commentService.ListCommentsForEntity("artist", artistID, contracts.CommentListFilters{})
@@ -669,17 +752,10 @@ func (suite *CommentServiceIntegrationTestSuite) TestListComments_SortByNew() {
 	user := suite.createTestUser()
 	artistID := suite.createTestArtist("Sort New Artist")
 
-	c1, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
-		EntityType: "artist",
-		EntityID:   artistID,
-		Body:       "First comment",
-	})
+	// Direct insert to bypass rate limiting
+	c1 := suite.insertComment(user.ID, "artist", artistID, "First comment", nil, nil, 0)
 	time.Sleep(10 * time.Millisecond)
-	c2, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
-		EntityType: "artist",
-		EntityID:   artistID,
-		Body:       "Second comment",
-	})
+	c2 := suite.insertComment(user.ID, "artist", artistID, "Second comment", nil, nil, 0)
 
 	result, err := suite.commentService.ListCommentsForEntity("artist", artistID, contracts.CommentListFilters{
 		Sort: "new",
@@ -695,17 +771,9 @@ func (suite *CommentServiceIntegrationTestSuite) TestListComments_SortByBest() {
 	user := suite.createTestUser()
 	artistID := suite.createTestArtist("Sort Best Artist")
 
-	// Create two comments, manually set different scores
-	c1, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
-		EntityType: "artist",
-		EntityID:   artistID,
-		Body:       "Low score",
-	})
-	c2, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
-		EntityType: "artist",
-		EntityID:   artistID,
-		Body:       "High score",
-	})
+	// Direct insert to bypass rate limiting
+	c1 := suite.insertComment(user.ID, "artist", artistID, "Low score", nil, nil, 0)
+	c2 := suite.insertComment(user.ID, "artist", artistID, "High score", nil, nil, 0)
 
 	// Manually set scores (simulate voting)
 	suite.db.Model(&models.Comment{}).Where("id = ?", c1.ID).Update("score", 0.1)
@@ -724,19 +792,21 @@ func (suite *CommentServiceIntegrationTestSuite) TestListComments_FilterByKind()
 	user := suite.createTestUser()
 	showID := suite.createTestShow("Kind Filter Show")
 
-	// Create one comment and one field_note
-	suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
-		EntityType: "show",
-		EntityID:   showID,
-		Body:       "Regular comment",
-		Kind:       "comment",
-	})
-	suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
-		EntityType: "show",
-		EntityID:   showID,
-		Body:       "Field note content",
-		Kind:       "field_note",
-	})
+	// Direct insert to bypass rate limiting — one comment and one field_note
+	comment := suite.insertComment(user.ID, "show", showID, "Regular comment", nil, nil, 0)
+	// Insert a field_note directly
+	fnComment := &models.Comment{
+		EntityType:      models.CommentEntityShow,
+		EntityID:        showID,
+		Kind:            models.CommentKindFieldNote,
+		UserID:          user.ID,
+		Body:            "Field note content",
+		BodyHTML:        "<p>Field note content</p>",
+		Visibility:      models.CommentVisibilityVisible,
+		ReplyPermission: models.ReplyPermissionAnyone,
+	}
+	suite.Require().NoError(suite.db.Create(fnComment).Error)
+	_ = comment
 
 	// Filter for field_notes only
 	result, err := suite.commentService.ListCommentsForEntity("show", showID, contracts.CommentListFilters{
@@ -779,23 +849,10 @@ func (suite *CommentServiceIntegrationTestSuite) TestGetThread_FullThread() {
 	user := suite.createTestUser()
 	artistID := suite.createTestArtist("Thread Artist")
 
-	root, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
-		EntityType: "artist",
-		EntityID:   artistID,
-		Body:       "Thread root",
-	})
-	reply1, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
-		EntityType: "artist",
-		EntityID:   artistID,
-		Body:       "Reply 1",
-		ParentID:   &root.ID,
-	})
-	suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
-		EntityType: "artist",
-		EntityID:   artistID,
-		Body:       "Reply to reply 1",
-		ParentID:   &reply1.ID,
-	})
+	// Direct insert to bypass rate limiting
+	root := suite.insertComment(user.ID, "artist", artistID, "Thread root", nil, nil, 0)
+	reply1 := suite.insertComment(user.ID, "artist", artistID, "Reply 1", &root.ID, &root.ID, 1)
+	suite.insertComment(user.ID, "artist", artistID, "Reply to reply 1", &reply1.ID, &root.ID, 2)
 
 	thread, err := suite.commentService.GetThread(root.ID)
 	suite.Require().NoError(err)
@@ -817,17 +874,9 @@ func (suite *CommentServiceIntegrationTestSuite) TestGetThread_NotARoot() {
 	user := suite.createTestUser()
 	artistID := suite.createTestArtist("Not Root Artist")
 
-	root, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
-		EntityType: "artist",
-		EntityID:   artistID,
-		Body:       "Root",
-	})
-	reply, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
-		EntityType: "artist",
-		EntityID:   artistID,
-		Body:       "Reply",
-		ParentID:   &root.ID,
-	})
+	// Direct insert to bypass rate limiting
+	root := suite.insertComment(user.ID, "artist", artistID, "Root", nil, nil, 0)
+	reply := suite.insertComment(user.ID, "artist", artistID, "Reply", &root.ID, &root.ID, 1)
 
 	_, err := suite.commentService.GetThread(reply.ID)
 	suite.Error(err)
@@ -1003,16 +1052,9 @@ func (suite *CommentServiceIntegrationTestSuite) TestListComments_SortByTop() {
 	user := suite.createTestUser()
 	artistID := suite.createTestArtist("Sort Top Artist")
 
-	c1, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
-		EntityType: "artist",
-		EntityID:   artistID,
-		Body:       "Low net",
-	})
-	c2, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
-		EntityType: "artist",
-		EntityID:   artistID,
-		Body:       "High net",
-	})
+	// Direct insert to bypass rate limiting
+	c1 := suite.insertComment(user.ID, "artist", artistID, "Low net", nil, nil, 0)
+	c2 := suite.insertComment(user.ID, "artist", artistID, "High net", nil, nil, 0)
 
 	// c1: 2 ups, 3 downs = -1 net
 	suite.db.Model(&models.Comment{}).Where("id = ?", c1.ID).Updates(map[string]interface{}{"ups": 2, "downs": 3})
@@ -1031,16 +1073,9 @@ func (suite *CommentServiceIntegrationTestSuite) TestListComments_SortByControve
 	user := suite.createTestUser()
 	artistID := suite.createTestArtist("Controversial Artist")
 
-	c1, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
-		EntityType: "artist",
-		EntityID:   artistID,
-		Body:       "Not controversial",
-	})
-	c2, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
-		EntityType: "artist",
-		EntityID:   artistID,
-		Body:       "Very controversial",
-	})
+	// Direct insert to bypass rate limiting
+	c1 := suite.insertComment(user.ID, "artist", artistID, "Not controversial", nil, nil, 0)
+	c2 := suite.insertComment(user.ID, "artist", artistID, "Very controversial", nil, nil, 0)
 
 	// c1: 1 up, 0 down — 1 total, 1 abs diff
 	suite.db.Model(&models.Comment{}).Where("id = ?", c1.ID).Updates(map[string]interface{}{"ups": 1, "downs": 0})
@@ -1141,4 +1176,275 @@ func (suite *CommentServiceIntegrationTestSuite) TestGetThread_SingleRootNoRepli
 	suite.Require().NoError(err)
 	suite.Len(thread, 1)
 	suite.Equal("Solo root", thread[0].Body)
+}
+
+// =============================================================================
+// Group 10: Trust-Tier Visibility (PSY-292)
+// =============================================================================
+
+func (suite *CommentServiceIntegrationTestSuite) TestCreateComment_NewUser_PendingReview() {
+	newUser := suite.createTestNewUser()
+	artistID := suite.createTestArtist("Pending Artist")
+
+	comment, err := suite.commentService.CreateComment(newUser.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "New user comment",
+	})
+	suite.Require().NoError(err)
+	suite.Equal("pending_review", comment.Visibility)
+}
+
+func (suite *CommentServiceIntegrationTestSuite) TestCreateComment_Contributor_Visible() {
+	user := suite.createTestUser() // contributor tier
+	artistID := suite.createTestArtist("Contributor Artist")
+
+	comment, err := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "Contributor comment",
+	})
+	suite.Require().NoError(err)
+	suite.Equal("visible", comment.Visibility)
+}
+
+func (suite *CommentServiceIntegrationTestSuite) TestCreateComment_Admin_Visible() {
+	admin := suite.createTestAdmin()
+	artistID := suite.createTestArtist("Admin Artist")
+
+	comment, err := suite.commentService.CreateComment(admin.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "Admin comment",
+	})
+	suite.Require().NoError(err)
+	suite.Equal("visible", comment.Visibility)
+}
+
+// =============================================================================
+// Group 11: Rate Limiting (PSY-292)
+// =============================================================================
+
+func (suite *CommentServiceIntegrationTestSuite) TestRateLimit_PerEntityCooldown() {
+	user := suite.createTestUser()
+	artistID := suite.createTestArtist("Cooldown Artist")
+
+	// First comment succeeds
+	_, err := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "First comment",
+	})
+	suite.Require().NoError(err)
+
+	// Second comment on same entity within 60s fails
+	_, err = suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "Too fast",
+	})
+	suite.Error(err)
+	suite.Contains(err.Error(), "please wait 60 seconds")
+}
+
+func (suite *CommentServiceIntegrationTestSuite) TestRateLimit_DifferentEntityAllowed() {
+	user := suite.createTestUser()
+	artist1ID := suite.createTestArtist("Rate Artist 1")
+	artist2ID := suite.createTestArtist("Rate Artist 2")
+
+	// First comment on entity 1
+	_, err := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artist1ID,
+		Body:       "Comment on artist 1",
+	})
+	suite.Require().NoError(err)
+
+	// Second comment on different entity should succeed
+	_, err = suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artist2ID,
+		Body:       "Comment on artist 2",
+	})
+	suite.Require().NoError(err)
+}
+
+func (suite *CommentServiceIntegrationTestSuite) TestRateLimit_NewUserHourlyLimit() {
+	newUser := suite.createTestNewUser()
+
+	// Insert 5 comments directly to fill the hourly limit
+	for i := 0; i < 5; i++ {
+		artistID := suite.createTestArtist(fmt.Sprintf("Hourly Artist %d", i))
+		suite.insertComment(newUser.ID, "artist", artistID, fmt.Sprintf("Comment %d", i), nil, nil, 0)
+	}
+
+	// 6th comment should fail (hourly limit for new_user is 5)
+	artistID := suite.createTestArtist("Hourly Overflow Artist")
+	_, err := suite.commentService.CreateComment(newUser.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "One too many",
+	})
+	suite.Error(err)
+	suite.Contains(err.Error(), "hourly comment limit")
+}
+
+// =============================================================================
+// Group 12: Admin Moderation (PSY-292)
+// =============================================================================
+
+func (suite *CommentServiceIntegrationTestSuite) TestHideComment_Success() {
+	user := suite.createTestUser()
+	admin := suite.createTestAdmin()
+	artistID := suite.createTestArtist("Hide Artist")
+
+	comment, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "Will be hidden",
+	})
+
+	err := suite.commentService.HideComment(admin.ID, comment.ID, "violates guidelines")
+	suite.Require().NoError(err)
+
+	// Verify it's hidden
+	fetched, err := suite.commentService.GetComment(comment.ID)
+	suite.Require().NoError(err)
+	suite.Equal("hidden_by_mod", fetched.Visibility)
+}
+
+func (suite *CommentServiceIntegrationTestSuite) TestHideComment_NotFound() {
+	err := suite.commentService.HideComment(1, 999999, "reason")
+	suite.Error(err)
+	suite.Contains(err.Error(), "not found")
+}
+
+func (suite *CommentServiceIntegrationTestSuite) TestRestoreComment_Success() {
+	user := suite.createTestUser()
+	admin := suite.createTestAdmin()
+	artistID := suite.createTestArtist("Restore Artist")
+
+	comment, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "Hide then restore",
+	})
+	suite.commentService.HideComment(admin.ID, comment.ID, "temp hide")
+
+	err := suite.commentService.RestoreComment(admin.ID, comment.ID)
+	suite.Require().NoError(err)
+
+	fetched, err := suite.commentService.GetComment(comment.ID)
+	suite.Require().NoError(err)
+	suite.Equal("visible", fetched.Visibility)
+}
+
+func (suite *CommentServiceIntegrationTestSuite) TestRestoreComment_AlreadyVisible() {
+	user := suite.createTestUser()
+	artistID := suite.createTestArtist("Already Visible Artist")
+
+	comment, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "Already visible",
+	})
+
+	err := suite.commentService.RestoreComment(1, comment.ID)
+	suite.Error(err)
+	suite.Contains(err.Error(), "already visible")
+}
+
+func (suite *CommentServiceIntegrationTestSuite) TestListPendingComments() {
+	newUser := suite.createTestNewUser()
+	artistID := suite.createTestArtist("Pending List Artist")
+
+	// Create a pending comment (new_user tier)
+	_, err := suite.commentService.CreateComment(newUser.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "Pending comment",
+	})
+	suite.Require().NoError(err)
+
+	// List pending
+	comments, total, err := suite.commentService.ListPendingComments(20, 0)
+	suite.Require().NoError(err)
+	suite.GreaterOrEqual(total, int64(1))
+	found := false
+	for _, c := range comments {
+		if c.Body == "Pending comment" {
+			found = true
+			suite.Equal("pending_review", c.Visibility)
+		}
+	}
+	suite.True(found, "Expected to find the pending comment")
+}
+
+func (suite *CommentServiceIntegrationTestSuite) TestApproveComment_Success() {
+	newUser := suite.createTestNewUser()
+	admin := suite.createTestAdmin()
+	artistID := suite.createTestArtist("Approve Artist")
+
+	comment, _ := suite.commentService.CreateComment(newUser.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "Needs approval",
+	})
+	suite.Equal("pending_review", comment.Visibility)
+
+	err := suite.commentService.ApproveComment(admin.ID, comment.ID)
+	suite.Require().NoError(err)
+
+	fetched, _ := suite.commentService.GetComment(comment.ID)
+	suite.Equal("visible", fetched.Visibility)
+}
+
+func (suite *CommentServiceIntegrationTestSuite) TestApproveComment_NotPending() {
+	user := suite.createTestUser()
+	artistID := suite.createTestArtist("Not Pending Artist")
+
+	// Contributor comment is auto-visible
+	comment, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "Already approved",
+	})
+
+	err := suite.commentService.ApproveComment(1, comment.ID)
+	suite.Error(err)
+	suite.Contains(err.Error(), "not pending review")
+}
+
+func (suite *CommentServiceIntegrationTestSuite) TestRejectComment_Success() {
+	newUser := suite.createTestNewUser()
+	admin := suite.createTestAdmin()
+	artistID := suite.createTestArtist("Reject Artist")
+
+	comment, _ := suite.commentService.CreateComment(newUser.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "Spam content",
+	})
+	suite.Equal("pending_review", comment.Visibility)
+
+	err := suite.commentService.RejectComment(admin.ID, comment.ID, "spam")
+	suite.Require().NoError(err)
+
+	fetched, _ := suite.commentService.GetComment(comment.ID)
+	suite.Equal("hidden_by_mod", fetched.Visibility)
+}
+
+func (suite *CommentServiceIntegrationTestSuite) TestRejectComment_NotPending() {
+	user := suite.createTestUser()
+	artistID := suite.createTestArtist("Not Pending Reject Artist")
+
+	comment, _ := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "Not pending",
+	})
+
+	err := suite.commentService.RejectComment(1, comment.ID, "reason")
+	suite.Error(err)
+	suite.Contains(err.Error(), "not pending review")
 }

--- a/backend/internal/services/engagement/interfaces.go
+++ b/backend/internal/services/engagement/interfaces.go
@@ -12,6 +12,7 @@ var (
 	_ contracts.AttendanceServiceInterface    = (*AttendanceService)(nil)
 	_ contracts.FollowServiceInterface        = (*FollowService)(nil)
 	_ contracts.CommentServiceInterface              = (*CommentService)(nil)
+	_ contracts.CommentAdminServiceInterface         = (*CommentService)(nil)
 	_ contracts.CommentVoteServiceInterface          = (*CommentVoteService)(nil)
 	_ contracts.CommentSubscriptionServiceInterface  = (*CommentSubscriptionService)(nil)
 )

--- a/docs/llm-context.md
+++ b/docs/llm-context.md
@@ -75,5 +75,5 @@ See `docs/vision.md` for the full north star, What.cd feature mapping, and entit
 - **Fire-and-forget** — Discord notifications and audit logs never fail parent operations
 - **JSONB columns** — use `*json.RawMessage` (not `datatypes.JSON`)
 - **Huma quirks** — all request body fields required by default, even pointers; mark optional explicitly. Query/path/header params must NOT use pointer types (`*uint`, `*string`) — Huma panics; use value types with zero-value checks instead.
-- **Migration numbering** — latest is 000062 (create_entity_reports, PSY-130); next is 000063
+- **Migration numbering** — latest is 000066 (add_comment_moderation_fields, PSY-292); next is 000067
 


### PR DESCRIPTION
## Summary

The most complex comment ticket — adds the moderation layer required before shipping comments to production.

### Trust-Tier Publishing
- `new_user` → `pending_review` (admin approval required)
- `contributor`+ → `visible` immediately
- Pure functions `computeInitialVisibility()` and `userTierHourlyLimit()` for testability

### Rate Limiting
- 60s per-entity cooldown between comments
- Hourly global limits by tier: new_user=5, contributor=30, trusted=100, ambassador/admin=unlimited
- Returns 429 with clear error messages

### 5 Admin Endpoints
- `POST /admin/comments/{id}/hide` — with reason
- `POST /admin/comments/{id}/restore`
- `GET /admin/comments/pending` — paginated list of pending_review comments
- `POST /admin/comments/{id}/approve`
- `POST /admin/comments/{id}/reject` — with reason

### Entity Reports for Comments
- `comment` added to valid report entity types with categories: spam, harassment, off_topic, inaccurate, other
- `POST /comments/{id}/report` endpoint
- **Auto-hide**: 3+ reports auto-hides comment with reason "auto-hidden: multiple reports"

### Migration 000066
- Adds `hidden_reason`, `hidden_by_user_id`, `hidden_at` columns + visibility partial index

### 48+ new tests
- 8 unit (tier visibility + rate limit functions)
- 15 integration (trust tier, rate limiting, admin actions)
- 26 handler unit (all 5 endpoints + rate limit error mapping)

Closes PSY-292

🤖 Generated with [Claude Code](https://claude.com/claude-code)