### PR TITLE
Add field notes UI on show detail pages (Wave 5)

### DIFF
--- a/frontend/features/comments/api.ts
+++ b/frontend/features/comments/api.ts
@@ -27,6 +27,13 @@ export const commentEndpoints = {
     `${API_BASE_URL}/comments/${commentId}/thread`,
 } as const
 
+export const fieldNoteEndpoints = {
+  LIST: (showId: number) =>
+    `${API_BASE_URL}/shows/${showId}/field-notes`,
+  CREATE: (showId: number) =>
+    `${API_BASE_URL}/shows/${showId}/field-notes`,
+} as const
+
 // ============================================================================
 // Query Keys
 // ============================================================================
@@ -37,4 +44,10 @@ export const commentQueryKeys = {
     ['comments', entityType, entityId] as const,
   thread: (commentId: number) =>
     ['comments', 'thread', commentId] as const,
+} as const
+
+export const fieldNoteQueryKeys = {
+  all: ['field-notes'] as const,
+  show: (showId: number) =>
+    ['field-notes', showId] as const,
 } as const

--- a/frontend/features/comments/components/FieldNoteCard.test.tsx
+++ b/frontend/features/comments/components/FieldNoteCard.test.tsx
@@ -1,0 +1,267 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { FieldNoteCard } from './FieldNoteCard'
+import type { Comment } from '../types'
+
+// --- Mocks ---
+
+const mockAuthContext = vi.fn()
+
+vi.mock('@/lib/context/AuthContext', () => ({
+  useAuthContext: () => mockAuthContext(),
+}))
+
+const defaultMutationReturn = { mutate: vi.fn(), isPending: false }
+
+vi.mock('../hooks', () => ({
+  useReplyToComment: () => defaultMutationReturn,
+  useVoteComment: () => defaultMutationReturn,
+  useUnvoteComment: () => defaultMutationReturn,
+  useCommentThread: () => ({ data: undefined }),
+}))
+
+vi.mock('@/features/contributions', () => ({
+  ReportEntityDialog: () => null,
+}))
+
+function makeFieldNote(overrides: Partial<Comment> = {}): Comment {
+  return {
+    id: 1,
+    entity_type: 'show',
+    entity_id: 10,
+    user_id: 2,
+    author_name: 'TestUser',
+    body: 'Amazing show!',
+    body_html: '<p>Amazing show!</p>',
+    parent_id: null,
+    root_id: null,
+    depth: 0,
+    ups: 5,
+    downs: 1,
+    score: 4,
+    visibility: 'visible',
+    reply_permission: 'everyone',
+    edit_count: 0,
+    is_edited: false,
+    created_at: '2026-04-01T00:00:00Z',
+    updated_at: '2026-04-01T00:00:00Z',
+    structured_data: {
+      sound_quality: 4,
+      crowd_energy: 5,
+      notable_moments: 'Played 3 new songs',
+      setlist_spoiler: false,
+      is_verified_attendee: true,
+    },
+    ...overrides,
+  }
+}
+
+describe('FieldNoteCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuthContext.mockReturnValue({
+      user: null,
+      isAuthenticated: false,
+      isLoading: false,
+    })
+  })
+
+  it('renders field note with body', () => {
+    render(<FieldNoteCard comment={makeFieldNote()} showId={10} />)
+
+    expect(screen.getByTestId('field-note-card')).toBeInTheDocument()
+    expect(screen.getByTestId('field-note-body')).toBeInTheDocument()
+    expect(screen.getByText('TestUser')).toBeInTheDocument()
+  })
+
+  it('shows verified attendee badge', () => {
+    render(<FieldNoteCard comment={makeFieldNote()} showId={10} />)
+
+    expect(screen.getByTestId('verified-badge')).toBeInTheDocument()
+    expect(screen.getByText('Verified Attendee')).toBeInTheDocument()
+  })
+
+  it('does not show verified badge when not verified', () => {
+    render(
+      <FieldNoteCard
+        comment={makeFieldNote({
+          structured_data: {
+            setlist_spoiler: false,
+            is_verified_attendee: false,
+          },
+        })}
+        showId={10}
+      />
+    )
+
+    expect(screen.queryByTestId('verified-badge')).not.toBeInTheDocument()
+  })
+
+  it('displays sound quality and crowd energy ratings', () => {
+    render(<FieldNoteCard comment={makeFieldNote()} showId={10} />)
+
+    expect(screen.getByTestId('ratings-display')).toBeInTheDocument()
+    expect(screen.getByTestId('sound-quality-display')).toBeInTheDocument()
+    expect(screen.getByTestId('crowd-energy-display')).toBeInTheDocument()
+  })
+
+  it('does not display ratings when not provided', () => {
+    render(
+      <FieldNoteCard
+        comment={makeFieldNote({
+          structured_data: {
+            setlist_spoiler: false,
+            is_verified_attendee: false,
+          },
+        })}
+        showId={10}
+      />
+    )
+
+    expect(screen.queryByTestId('ratings-display')).not.toBeInTheDocument()
+  })
+
+  it('displays notable moments in highlighted box', () => {
+    render(<FieldNoteCard comment={makeFieldNote()} showId={10} />)
+
+    expect(screen.getByTestId('notable-moments')).toBeInTheDocument()
+    expect(screen.getByText('Played 3 new songs')).toBeInTheDocument()
+  })
+
+  it('hides body behind spoiler gate when setlist_spoiler is true', () => {
+    render(
+      <FieldNoteCard
+        comment={makeFieldNote({
+          structured_data: {
+            setlist_spoiler: true,
+            is_verified_attendee: false,
+          },
+        })}
+        showId={10}
+      />
+    )
+
+    expect(screen.getByTestId('spoiler-gate')).toBeInTheDocument()
+    expect(screen.queryByTestId('field-note-body')).not.toBeInTheDocument()
+    expect(
+      screen.getByText('Contains setlist spoilers — click to reveal')
+    ).toBeInTheDocument()
+  })
+
+  it('reveals body when spoiler gate is clicked', () => {
+    render(
+      <FieldNoteCard
+        comment={makeFieldNote({
+          structured_data: {
+            setlist_spoiler: true,
+            is_verified_attendee: false,
+          },
+        })}
+        showId={10}
+      />
+    )
+
+    fireEvent.click(screen.getByText('Contains setlist spoilers — click to reveal'))
+
+    expect(screen.queryByTestId('spoiler-gate')).not.toBeInTheDocument()
+    expect(screen.getByTestId('field-note-body')).toBeInTheDocument()
+  })
+
+  it('displays artist attribution when show_artist_id matches', () => {
+    render(
+      <FieldNoteCard
+        comment={makeFieldNote({
+          structured_data: {
+            show_artist_id: 42,
+            setlist_spoiler: false,
+            is_verified_attendee: true,
+          },
+        })}
+        showId={10}
+        artists={[
+          { id: 42, name: 'The Band' },
+          { id: 43, name: 'Other Band' },
+        ]}
+      />
+    )
+
+    expect(screen.getByTestId('artist-attribution')).toBeInTheDocument()
+    expect(screen.getByText(/During The Band/)).toBeInTheDocument()
+  })
+
+  it('displays song position when provided', () => {
+    render(
+      <FieldNoteCard
+        comment={makeFieldNote({
+          structured_data: {
+            song_position: 7,
+            setlist_spoiler: false,
+            is_verified_attendee: false,
+          },
+        })}
+        showId={10}
+      />
+    )
+
+    expect(screen.getByTestId('song-position')).toBeInTheDocument()
+    expect(screen.getByText('Song #7')).toBeInTheDocument()
+  })
+
+  it('displays vote score', () => {
+    render(<FieldNoteCard comment={makeFieldNote()} showId={10} />)
+
+    expect(screen.getByTestId('vote-score')).toHaveTextContent('4')
+  })
+
+  it('shows deleted state', () => {
+    render(
+      <FieldNoteCard
+        comment={makeFieldNote({ visibility: 'hidden_by_user' })}
+        showId={10}
+      />
+    )
+
+    expect(screen.getByTestId('field-note-deleted')).toBeInTheDocument()
+    expect(screen.getByText('[deleted]')).toBeInTheDocument()
+  })
+
+  it('shows removed state', () => {
+    render(
+      <FieldNoteCard
+        comment={makeFieldNote({ visibility: 'hidden_by_mod' })}
+        showId={10}
+      />
+    )
+
+    expect(screen.getByTestId('field-note-deleted')).toBeInTheDocument()
+    expect(screen.getByText('[removed]')).toBeInTheDocument()
+  })
+
+  it('hides notable moments behind spoiler gate', () => {
+    render(
+      <FieldNoteCard
+        comment={makeFieldNote({
+          structured_data: {
+            setlist_spoiler: true,
+            is_verified_attendee: false,
+            notable_moments: 'Secret setlist info',
+          },
+        })}
+        showId={10}
+      />
+    )
+
+    expect(screen.queryByTestId('notable-moments')).not.toBeInTheDocument()
+  })
+
+  it('shows edited badge', () => {
+    render(
+      <FieldNoteCard
+        comment={makeFieldNote({ is_edited: true })}
+        showId={10}
+      />
+    )
+
+    expect(screen.getByText('Edited')).toBeInTheDocument()
+  })
+})

--- a/frontend/features/comments/components/FieldNoteCard.tsx
+++ b/frontend/features/comments/components/FieldNoteCard.tsx
@@ -1,0 +1,332 @@
+'use client'
+
+import { useState } from 'react'
+import { ChevronUp, ChevronDown, MessageSquare, Star, CheckCircle, Eye, EyeOff, Flag } from 'lucide-react'
+import { formatRelativeTime } from '@/lib/formatRelativeTime'
+import { useAuthContext } from '@/lib/context/AuthContext'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { CommentForm } from './CommentForm'
+import { ReportEntityDialog } from '@/features/contributions'
+import {
+  useReplyToComment,
+  useVoteComment,
+  useUnvoteComment,
+  useCommentThread,
+} from '../hooks'
+import type { Comment } from '../types'
+
+interface ShowArtist {
+  id: number
+  name: string
+}
+
+interface FieldNoteCardProps {
+  comment: Comment
+  showId: number
+  artists?: ShowArtist[]
+  replies?: Comment[]
+}
+
+function StarDisplay({ value, testId }: { value: number; testId?: string }) {
+  return (
+    <span className="inline-flex items-center gap-0.5" data-testid={testId}>
+      {[1, 2, 3, 4, 5].map((star) => (
+        <Star
+          key={star}
+          className={`h-3.5 w-3.5 ${
+            star <= value
+              ? 'fill-yellow-400 text-yellow-400'
+              : 'text-muted-foreground/30'
+          }`}
+        />
+      ))}
+    </span>
+  )
+}
+
+export function FieldNoteCard({
+  comment,
+  showId,
+  artists = [],
+  replies = [],
+}: FieldNoteCardProps) {
+  const { user, isAuthenticated } = useAuthContext()
+  const currentUserId = user?.id ? Number(user.id) : null
+  const isOwner = currentUserId === comment.user_id
+
+  const [isReplying, setIsReplying] = useState(false)
+  const [showSpoiler, setShowSpoiler] = useState(false)
+  const [showReplies, setShowReplies] = useState(true)
+  const [loadedThread, setLoadedThread] = useState(false)
+  const [isReportOpen, setIsReportOpen] = useState(false)
+
+  const replyMutation = useReplyToComment()
+  const voteMutation = useVoteComment()
+  const unvoteMutation = useUnvoteComment()
+
+  const hasInlineReplies = replies.length > 0
+  const { data: threadData } = useCommentThread(comment.id, loadedThread && !hasInlineReplies)
+  const threadReplies = hasInlineReplies ? replies : (threadData?.replies ?? [])
+
+  const sd = comment.structured_data
+  const isSpoiler = sd?.setlist_spoiler === true
+  const isVerified = sd?.is_verified_attendee === true
+
+  // Find artist name from show_artist_id
+  const artistName = sd?.show_artist_id
+    ? artists.find((a) => a.id === sd.show_artist_id)?.name
+    : null
+
+  const handleVote = (direction: 1 | -1) => {
+    if (!isAuthenticated) return
+    if (comment.user_vote === direction) {
+      unvoteMutation.mutate({ commentId: comment.id, entityType: 'show', entityId: showId })
+    } else {
+      voteMutation.mutate({ commentId: comment.id, direction, entityType: 'show', entityId: showId })
+    }
+  }
+
+  const handleReply = (body: string) => {
+    replyMutation.mutate(
+      { commentId: comment.id, body, entityType: 'show', entityId: showId },
+      { onSuccess: () => setIsReplying(false) }
+    )
+  }
+
+  const isDeleted = comment.visibility === 'hidden_by_user' || comment.visibility === 'hidden_by_mod'
+
+  if (isDeleted) {
+    return (
+      <div className="py-3 text-sm text-muted-foreground italic" data-testid="field-note-deleted">
+        {comment.visibility === 'hidden_by_user' ? '[deleted]' : '[removed]'}
+      </div>
+    )
+  }
+
+  return (
+    <div data-testid="field-note-card" className="rounded-lg border border-border/50 bg-card p-4">
+      {/* Header: author + verified badge + timestamp */}
+      <div className="flex items-center gap-2 text-sm">
+        <span className="font-medium text-foreground">{comment.author_name}</span>
+        {isVerified && (
+          <Badge
+            variant="secondary"
+            className="text-[10px] px-1.5 py-0 bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400"
+            data-testid="verified-badge"
+          >
+            <CheckCircle className="h-3 w-3 mr-0.5" />
+            Verified Attendee
+          </Badge>
+        )}
+        <span className="text-muted-foreground">
+          {formatRelativeTime(comment.created_at)}
+        </span>
+        {comment.is_edited && (
+          <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
+            Edited
+          </Badge>
+        )}
+      </div>
+
+      {/* Artist attribution + song position */}
+      {(artistName || sd?.song_position) && (
+        <div className="flex items-center gap-2 mt-1 text-xs text-muted-foreground">
+          {artistName && (
+            <span data-testid="artist-attribution">
+              During {artistName}&apos;s set
+            </span>
+          )}
+          {artistName && sd?.song_position && <span>&middot;</span>}
+          {sd?.song_position && (
+            <span data-testid="song-position">Song #{sd.song_position}</span>
+          )}
+        </div>
+      )}
+
+      {/* Structured data display: ratings */}
+      {(sd?.sound_quality || sd?.crowd_energy) && (
+        <div className="flex items-center gap-4 mt-2" data-testid="ratings-display">
+          {sd?.sound_quality && (
+            <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <span>Sound:</span>
+              <StarDisplay value={sd.sound_quality} testId="sound-quality-display" />
+            </div>
+          )}
+          {sd?.crowd_energy && (
+            <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <span>Crowd:</span>
+              <StarDisplay value={sd.crowd_energy} testId="crowd-energy-display" />
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Body — with spoiler handling */}
+      {isSpoiler && !showSpoiler ? (
+        <div className="mt-2" data-testid="spoiler-gate">
+          <button
+            onClick={() => setShowSpoiler(true)}
+            className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <EyeOff className="h-4 w-4" />
+            Contains setlist spoilers — click to reveal
+          </button>
+        </div>
+      ) : (
+        <div className="mt-2">
+          {isSpoiler && (
+            <button
+              onClick={() => setShowSpoiler(false)}
+              className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors mb-1"
+              data-testid="spoiler-hide"
+            >
+              <Eye className="h-3.5 w-3.5" />
+              Hide spoilers
+            </button>
+          )}
+          <div
+            className="text-sm prose prose-sm dark:prose-invert max-w-none"
+            dangerouslySetInnerHTML={{ __html: comment.body_html }}
+            data-testid="field-note-body"
+          />
+        </div>
+      )}
+
+      {/* Notable moments */}
+      {sd?.notable_moments && (!isSpoiler || showSpoiler) && (
+        <div
+          className="mt-2 rounded-md bg-primary/5 border border-primary/10 px-3 py-2 text-sm"
+          data-testid="notable-moments"
+        >
+          <span className="font-medium text-xs text-muted-foreground uppercase tracking-wider">
+            Notable:
+          </span>{' '}
+          {sd.notable_moments}
+        </div>
+      )}
+
+      {/* Actions row: votes + reply + report */}
+      <div className="flex items-center gap-1 mt-3">
+        {/* Vote buttons */}
+        <Button
+          variant="ghost"
+          size="sm"
+          className={`h-7 w-7 p-0 ${comment.user_vote === 1 ? 'text-primary' : 'text-muted-foreground'}`}
+          onClick={() => handleVote(1)}
+          disabled={!isAuthenticated}
+          aria-label="Upvote"
+          data-testid="upvote-button"
+        >
+          <ChevronUp className="h-4 w-4" />
+        </Button>
+        <span className="text-xs font-medium min-w-[1.5rem] text-center" data-testid="vote-score">
+          {comment.ups - comment.downs}
+        </span>
+        <Button
+          variant="ghost"
+          size="sm"
+          className={`h-7 w-7 p-0 ${comment.user_vote === -1 ? 'text-destructive' : 'text-muted-foreground'}`}
+          onClick={() => handleVote(-1)}
+          disabled={!isAuthenticated}
+          aria-label="Downvote"
+          data-testid="downvote-button"
+        >
+          <ChevronDown className="h-4 w-4" />
+        </Button>
+
+        {/* Reply button */}
+        {isAuthenticated && comment.depth < 2 && comment.reply_permission === 'everyone' && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 px-2 text-xs text-muted-foreground"
+            onClick={() => setIsReplying(!isReplying)}
+          >
+            <MessageSquare className="h-3.5 w-3.5 mr-1" />
+            Reply
+          </Button>
+        )}
+
+        {/* Report button (non-owner, authenticated) */}
+        {isAuthenticated && !isOwner && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 px-2 text-xs text-muted-foreground"
+            onClick={() => setIsReportOpen(true)}
+            data-testid="report-field-note-button"
+          >
+            <Flag className="h-3.5 w-3.5 mr-1" />
+            Report
+          </Button>
+        )}
+      </div>
+
+      {/* Inline reply form */}
+      {isReplying && (
+        <div className="mt-3 ml-4">
+          <CommentForm
+            onSubmit={handleReply}
+            placeholder={`Reply to ${comment.author_name}...`}
+            submitLabel="Reply"
+            onCancel={() => setIsReplying(false)}
+            isPending={replyMutation.isPending}
+          />
+        </div>
+      )}
+
+      {/* Nested replies */}
+      {threadReplies.length > 0 && (
+        <div className="mt-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 px-1 text-xs text-muted-foreground"
+            onClick={() => setShowReplies(!showReplies)}
+          >
+            {showReplies ? 'Hide' : 'Show'} {threadReplies.length}{' '}
+            {threadReplies.length === 1 ? 'reply' : 'replies'}
+          </Button>
+
+          {showReplies && (
+            <div className="mt-1 space-y-3 border-l-2 border-border/50 pl-3">
+              {threadReplies.map((reply) => (
+                <FieldNoteCard
+                  key={reply.id}
+                  comment={reply}
+                  showId={showId}
+                  artists={artists}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Load replies button */}
+      {!hasInlineReplies && !loadedThread && comment.depth === 0 && (
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-6 px-1 text-xs text-muted-foreground mt-1"
+          onClick={() => setLoadedThread(true)}
+        >
+          <MessageSquare className="h-3.5 w-3.5 mr-1" />
+          Show replies
+        </Button>
+      )}
+
+      {/* Report dialog */}
+      {isAuthenticated && !isOwner && (
+        <ReportEntityDialog
+          open={isReportOpen}
+          onOpenChange={setIsReportOpen}
+          entityType="comment"
+          entityId={comment.id}
+          entityName={`Field note by ${comment.author_name}`}
+        />
+      )}
+    </div>
+  )
+}

--- a/frontend/features/comments/components/FieldNoteForm.test.tsx
+++ b/frontend/features/comments/components/FieldNoteForm.test.tsx
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { FieldNoteForm } from './FieldNoteForm'
+
+describe('FieldNoteForm', () => {
+  it('renders the form with textarea and submit button', () => {
+    render(<FieldNoteForm onSubmit={vi.fn()} />)
+
+    expect(screen.getByTestId('field-note-form')).toBeInTheDocument()
+    expect(screen.getByTestId('field-note-textarea')).toBeInTheDocument()
+    expect(screen.getByTestId('field-note-submit')).toBeInTheDocument()
+  })
+
+  it('renders disabled message when disabled with message', () => {
+    render(
+      <FieldNoteForm
+        onSubmit={vi.fn()}
+        disabled
+        disabledMessage="Field notes are available after the show"
+      />
+    )
+
+    expect(screen.getByTestId('field-note-form-disabled')).toBeInTheDocument()
+    expect(screen.getByText('Field notes are available after the show')).toBeInTheDocument()
+    expect(screen.queryByTestId('field-note-form')).not.toBeInTheDocument()
+  })
+
+  it('submit button is disabled when textarea is empty', () => {
+    render(<FieldNoteForm onSubmit={vi.fn()} />)
+
+    expect(screen.getByTestId('field-note-submit')).toBeDisabled()
+  })
+
+  it('submit button is enabled when textarea has content', () => {
+    render(<FieldNoteForm onSubmit={vi.fn()} />)
+
+    fireEvent.change(screen.getByTestId('field-note-textarea'), {
+      target: { value: 'Great show!' },
+    })
+
+    expect(screen.getByTestId('field-note-submit')).not.toBeDisabled()
+  })
+
+  it('calls onSubmit with body and resets form', () => {
+    const handleSubmit = vi.fn()
+    render(<FieldNoteForm onSubmit={handleSubmit} />)
+
+    fireEvent.change(screen.getByTestId('field-note-textarea'), {
+      target: { value: '  Amazing performance  ' },
+    })
+    fireEvent.click(screen.getByTestId('field-note-submit'))
+
+    expect(handleSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ body: 'Amazing performance' })
+    )
+    expect(screen.getByTestId('field-note-textarea')).toHaveValue('')
+  })
+
+  it('includes sound quality when set', async () => {
+    const user = userEvent.setup()
+    const handleSubmit = vi.fn()
+    render(<FieldNoteForm onSubmit={handleSubmit} />)
+
+    fireEvent.change(screen.getByTestId('field-note-textarea'), {
+      target: { value: 'Good sound' },
+    })
+
+    // Click 4th star for sound quality
+    const soundRating = screen.getByTestId('sound-quality-rating')
+    const stars = soundRating.querySelectorAll('button')
+    await user.click(stars[3]) // 4th star
+
+    fireEvent.click(screen.getByTestId('field-note-submit'))
+
+    expect(handleSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: 'Good sound',
+        sound_quality: 4,
+      })
+    )
+  })
+
+  it('includes crowd energy when set', async () => {
+    const user = userEvent.setup()
+    const handleSubmit = vi.fn()
+    render(<FieldNoteForm onSubmit={handleSubmit} />)
+
+    fireEvent.change(screen.getByTestId('field-note-textarea'), {
+      target: { value: 'Energetic crowd' },
+    })
+
+    const crowdRating = screen.getByTestId('crowd-energy-rating')
+    const stars = crowdRating.querySelectorAll('button')
+    await user.click(stars[4]) // 5th star
+
+    fireEvent.click(screen.getByTestId('field-note-submit'))
+
+    expect(handleSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: 'Energetic crowd',
+        crowd_energy: 5,
+      })
+    )
+  })
+
+  it('includes notable moments when filled', () => {
+    const handleSubmit = vi.fn()
+    render(<FieldNoteForm onSubmit={handleSubmit} />)
+
+    fireEvent.change(screen.getByTestId('field-note-textarea'), {
+      target: { value: 'Great show' },
+    })
+    fireEvent.change(screen.getByTestId('notable-moments-input'), {
+      target: { value: 'Played 3 new songs' },
+    })
+    fireEvent.click(screen.getByTestId('field-note-submit'))
+
+    expect(handleSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: 'Great show',
+        notable_moments: 'Played 3 new songs',
+      })
+    )
+  })
+
+  it('renders artist picker when artists provided', () => {
+    render(
+      <FieldNoteForm
+        onSubmit={vi.fn()}
+        artists={[
+          { id: 1, name: 'Band A' },
+          { id: 2, name: 'Band B' },
+        ]}
+      />
+    )
+
+    const select = screen.getByTestId('artist-select')
+    expect(select).toBeInTheDocument()
+    expect(screen.getByText('Band A')).toBeInTheDocument()
+    expect(screen.getByText('Band B')).toBeInTheDocument()
+  })
+
+  it('does not render artist picker when no artists', () => {
+    render(<FieldNoteForm onSubmit={vi.fn()} />)
+
+    expect(screen.queryByTestId('artist-select')).not.toBeInTheDocument()
+  })
+
+  it('includes setlist_spoiler when checked', async () => {
+    const user = userEvent.setup()
+    const handleSubmit = vi.fn()
+    render(<FieldNoteForm onSubmit={handleSubmit} />)
+
+    fireEvent.change(screen.getByTestId('field-note-textarea'), {
+      target: { value: 'They opened with...' },
+    })
+
+    await user.click(screen.getByTestId('setlist-spoiler-checkbox'))
+    fireEvent.click(screen.getByTestId('field-note-submit'))
+
+    expect(handleSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: 'They opened with...',
+        setlist_spoiler: true,
+      })
+    )
+  })
+
+  it('disables form elements when isPending', () => {
+    render(<FieldNoteForm onSubmit={vi.fn()} isPending />)
+
+    expect(screen.getByTestId('field-note-textarea')).toBeDisabled()
+    expect(screen.getByTestId('field-note-submit')).toBeDisabled()
+  })
+
+  it('renders song position input', () => {
+    render(<FieldNoteForm onSubmit={vi.fn()} />)
+
+    expect(screen.getByTestId('song-position-input')).toBeInTheDocument()
+  })
+
+  it('includes song_position when set', () => {
+    const handleSubmit = vi.fn()
+    render(<FieldNoteForm onSubmit={handleSubmit} />)
+
+    fireEvent.change(screen.getByTestId('field-note-textarea'), {
+      target: { value: 'Amazing solo' },
+    })
+    fireEvent.change(screen.getByTestId('song-position-input'), {
+      target: { value: '7' },
+    })
+    fireEvent.click(screen.getByTestId('field-note-submit'))
+
+    expect(handleSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: 'Amazing solo',
+        song_position: 7,
+      })
+    )
+  })
+
+  it('does not include optional fields when empty', () => {
+    const handleSubmit = vi.fn()
+    render(<FieldNoteForm onSubmit={handleSubmit} />)
+
+    fireEvent.change(screen.getByTestId('field-note-textarea'), {
+      target: { value: 'Simple note' },
+    })
+    fireEvent.click(screen.getByTestId('field-note-submit'))
+
+    const call = handleSubmit.mock.calls[0][0]
+    expect(call).toEqual({ body: 'Simple note' })
+    expect(call).not.toHaveProperty('sound_quality')
+    expect(call).not.toHaveProperty('crowd_energy')
+    expect(call).not.toHaveProperty('notable_moments')
+    expect(call).not.toHaveProperty('setlist_spoiler')
+  })
+})

--- a/frontend/features/comments/components/FieldNoteForm.tsx
+++ b/frontend/features/comments/components/FieldNoteForm.tsx
@@ -1,0 +1,237 @@
+'use client'
+
+import { useState } from 'react'
+import { Loader2, Star } from 'lucide-react'
+import { Textarea } from '@/components/ui/textarea'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Label } from '@/components/ui/label'
+import type { CreateFieldNoteInput } from '../types'
+
+interface ShowArtist {
+  id: number
+  name: string
+}
+
+interface FieldNoteFormProps {
+  onSubmit: (input: CreateFieldNoteInput) => void
+  artists?: ShowArtist[]
+  isPending?: boolean
+  disabled?: boolean
+  disabledMessage?: string
+}
+
+function StarRating({
+  value,
+  onChange,
+  label,
+  testId,
+}: {
+  value: number
+  onChange: (v: number) => void
+  label: string
+  testId: string
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <Label className="text-sm text-muted-foreground min-w-[100px]">{label}</Label>
+      <div className="flex items-center gap-0.5" data-testid={testId}>
+        {[1, 2, 3, 4, 5].map((star) => (
+          <button
+            key={star}
+            type="button"
+            onClick={() => onChange(value === star ? 0 : star)}
+            className="p-0.5 hover:scale-110 transition-transform"
+            aria-label={`${star} star${star !== 1 ? 's' : ''}`}
+          >
+            <Star
+              className={`h-5 w-5 ${
+                star <= value
+                  ? 'fill-yellow-400 text-yellow-400'
+                  : 'text-muted-foreground/40'
+              }`}
+            />
+          </button>
+        ))}
+        {value > 0 && (
+          <span className="text-xs text-muted-foreground ml-1">{value}/5</span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export function FieldNoteForm({
+  onSubmit,
+  artists = [],
+  isPending = false,
+  disabled = false,
+  disabledMessage,
+}: FieldNoteFormProps) {
+  const [body, setBody] = useState('')
+  const [soundQuality, setSoundQuality] = useState(0)
+  const [crowdEnergy, setCrowdEnergy] = useState(0)
+  const [notableMoments, setNotableMoments] = useState('')
+  const [setlistSpoiler, setSetlistSpoiler] = useState(false)
+  const [showArtistId, setShowArtistId] = useState<number | undefined>(undefined)
+  const [songPosition, setSongPosition] = useState('')
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    const trimmed = body.trim()
+    if (!trimmed) return
+
+    const input: CreateFieldNoteInput = { body: trimmed }
+
+    if (soundQuality > 0) input.sound_quality = soundQuality
+    if (crowdEnergy > 0) input.crowd_energy = crowdEnergy
+    if (notableMoments.trim()) input.notable_moments = notableMoments.trim()
+    if (setlistSpoiler) input.setlist_spoiler = true
+    if (showArtistId) input.show_artist_id = showArtistId
+    if (songPosition && parseInt(songPosition, 10) > 0) {
+      input.song_position = parseInt(songPosition, 10)
+    }
+
+    onSubmit(input)
+    // Reset form
+    setBody('')
+    setSoundQuality(0)
+    setCrowdEnergy(0)
+    setNotableMoments('')
+    setSetlistSpoiler(false)
+    setShowArtistId(undefined)
+    setSongPosition('')
+  }
+
+  if (disabled && disabledMessage) {
+    return (
+      <div
+        className="rounded-lg border border-border bg-muted/30 p-4 text-sm text-muted-foreground text-center"
+        data-testid="field-note-form-disabled"
+      >
+        {disabledMessage}
+      </div>
+    )
+  }
+
+  const isSubmitDisabled = !body.trim() || isPending
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4" data-testid="field-note-form">
+      {/* Body */}
+      <Textarea
+        value={body}
+        onChange={(e) => setBody(e.target.value)}
+        placeholder="Share your experience at this show..."
+        rows={3}
+        disabled={isPending}
+        data-testid="field-note-textarea"
+      />
+
+      {/* Structured fields */}
+      <div className="space-y-3 rounded-lg border border-border/50 bg-muted/20 p-3">
+        <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+          Optional Details
+        </p>
+
+        {/* Star ratings */}
+        <StarRating
+          value={soundQuality}
+          onChange={setSoundQuality}
+          label="Sound Quality"
+          testId="sound-quality-rating"
+        />
+        <StarRating
+          value={crowdEnergy}
+          onChange={setCrowdEnergy}
+          label="Crowd Energy"
+          testId="crowd-energy-rating"
+        />
+
+        {/* Notable moments */}
+        <div className="flex items-start gap-2">
+          <Label className="text-sm text-muted-foreground min-w-[100px] mt-2">
+            Notable Moments
+          </Label>
+          <Input
+            value={notableMoments}
+            onChange={(e) => setNotableMoments(e.target.value)}
+            placeholder="e.g. Played 3 new songs, surprise guest"
+            disabled={isPending}
+            data-testid="notable-moments-input"
+          />
+        </div>
+
+        {/* Artist picker */}
+        {artists.length > 0 && (
+          <div className="flex items-center gap-2">
+            <Label className="text-sm text-muted-foreground min-w-[100px]">
+              Artist Set
+            </Label>
+            <select
+              value={showArtistId ?? ''}
+              onChange={(e) =>
+                setShowArtistId(e.target.value ? Number(e.target.value) : undefined)
+              }
+              className="h-9 rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none"
+              disabled={isPending}
+              data-testid="artist-select"
+            >
+              <option value="">Any / General</option>
+              {artists.map((a) => (
+                <option key={a.id} value={a.id}>
+                  {a.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        {/* Song position */}
+        <div className="flex items-center gap-2">
+          <Label className="text-sm text-muted-foreground min-w-[100px]">
+            Song #
+          </Label>
+          <Input
+            type="number"
+            min={1}
+            value={songPosition}
+            onChange={(e) => setSongPosition(e.target.value)}
+            placeholder="Position in setlist"
+            className="w-40"
+            disabled={isPending}
+            data-testid="song-position-input"
+          />
+        </div>
+
+        {/* Setlist spoiler */}
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id="setlist-spoiler"
+            checked={setlistSpoiler}
+            onCheckedChange={(checked) => setSetlistSpoiler(checked === true)}
+            disabled={isPending}
+            data-testid="setlist-spoiler-checkbox"
+          />
+          <Label htmlFor="setlist-spoiler" className="text-sm text-muted-foreground cursor-pointer">
+            Contains setlist spoilers
+          </Label>
+        </div>
+      </div>
+
+      {/* Submit */}
+      <div className="flex items-center gap-2">
+        <Button
+          type="submit"
+          size="sm"
+          disabled={isSubmitDisabled}
+          data-testid="field-note-submit"
+        >
+          {isPending && <Loader2 className="h-4 w-4 mr-1.5 animate-spin" />}
+          Post Field Note
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/frontend/features/comments/components/FieldNotesSection.test.tsx
+++ b/frontend/features/comments/components/FieldNotesSection.test.tsx
@@ -1,0 +1,277 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { FieldNotesSection } from './FieldNotesSection'
+
+// --- Mocks ---
+
+const mockUseFieldNotes = vi.fn()
+const mockUseCreateFieldNote = vi.fn()
+const mockUseAuthContext = vi.fn()
+
+const defaultMutationReturn = { mutate: vi.fn(), isPending: false }
+
+vi.mock('../hooks', () => ({
+  useFieldNotes: (...args: unknown[]) => mockUseFieldNotes(...args),
+  useCreateFieldNote: () => mockUseCreateFieldNote(),
+  useReplyToComment: () => defaultMutationReturn,
+  useVoteComment: () => defaultMutationReturn,
+  useUnvoteComment: () => defaultMutationReturn,
+  useCommentThread: () => ({ data: undefined }),
+}))
+
+vi.mock('@/lib/context/AuthContext', () => ({
+  useAuthContext: () => mockUseAuthContext(),
+}))
+
+vi.mock('@/features/contributions', () => ({
+  ReportEntityDialog: () => null,
+}))
+
+const pastDate = '2025-01-15T20:00:00Z'
+const futureDate = '2099-12-31T20:00:00Z'
+
+const mockArtists = [
+  { id: 1, name: 'Band A' },
+  { id: 2, name: 'Band B' },
+]
+
+describe('FieldNotesSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseCreateFieldNote.mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+    })
+  })
+
+  describe('past show (field notes available)', () => {
+    it('renders empty state when no field notes', () => {
+      mockUseAuthContext.mockReturnValue({
+        isAuthenticated: false,
+        user: null,
+      })
+      mockUseFieldNotes.mockReturnValue({
+        data: { comments: [], total: 0, has_more: false },
+        isLoading: false,
+      })
+
+      render(
+        <FieldNotesSection showId={1} showDate={pastDate} artists={mockArtists} />
+      )
+
+      expect(screen.getByTestId('field-notes-section')).toBeInTheDocument()
+      expect(screen.getByTestId('field-notes-empty')).toBeInTheDocument()
+      expect(
+        screen.getByText('No field notes yet. Attend this show and share your experience!')
+      ).toBeInTheDocument()
+    })
+
+    it('renders auth gate for unauthenticated users', () => {
+      mockUseAuthContext.mockReturnValue({
+        isAuthenticated: false,
+        user: null,
+      })
+      mockUseFieldNotes.mockReturnValue({
+        data: { comments: [], total: 0, has_more: false },
+        isLoading: false,
+      })
+
+      render(
+        <FieldNotesSection showId={1} showDate={pastDate} artists={mockArtists} />
+      )
+
+      expect(screen.getByTestId('field-note-auth-gate')).toBeInTheDocument()
+      expect(screen.getByText('Sign in')).toBeInTheDocument()
+    })
+
+    it('renders form for authenticated users', () => {
+      mockUseAuthContext.mockReturnValue({
+        isAuthenticated: true,
+        user: { id: '1', email: 'test@test.com' },
+      })
+      mockUseFieldNotes.mockReturnValue({
+        data: { comments: [], total: 0, has_more: false },
+        isLoading: false,
+      })
+
+      render(
+        <FieldNotesSection showId={1} showDate={pastDate} artists={mockArtists} />
+      )
+
+      expect(screen.getByTestId('field-note-form')).toBeInTheDocument()
+      expect(screen.getByTestId('field-note-textarea')).toBeInTheDocument()
+    })
+
+    it('renders field note count in heading', () => {
+      mockUseAuthContext.mockReturnValue({
+        isAuthenticated: false,
+        user: null,
+      })
+      mockUseFieldNotes.mockReturnValue({
+        data: {
+          comments: [
+            {
+              id: 1,
+              entity_type: 'show',
+              entity_id: 1,
+              user_id: 2,
+              author_name: 'TestUser',
+              body: 'Great show!',
+              body_html: '<p>Great show!</p>',
+              parent_id: null,
+              root_id: null,
+              depth: 0,
+              ups: 0,
+              downs: 0,
+              score: 0,
+              visibility: 'visible',
+              reply_permission: 'everyone',
+              edit_count: 0,
+              is_edited: false,
+              created_at: '2026-04-01T00:00:00Z',
+              updated_at: '2026-04-01T00:00:00Z',
+              structured_data: {
+                setlist_spoiler: false,
+                is_verified_attendee: false,
+              },
+            },
+          ],
+          total: 1,
+          has_more: false,
+        },
+        isLoading: false,
+      })
+
+      render(
+        <FieldNotesSection showId={1} showDate={pastDate} artists={mockArtists} />
+      )
+
+      expect(screen.getByText('Field Notes')).toBeInTheDocument()
+      expect(screen.getByText('(1)')).toBeInTheDocument()
+    })
+
+    it('renders field note cards', () => {
+      mockUseAuthContext.mockReturnValue({
+        isAuthenticated: false,
+        user: null,
+      })
+      mockUseFieldNotes.mockReturnValue({
+        data: {
+          comments: [
+            {
+              id: 1,
+              entity_type: 'show',
+              entity_id: 1,
+              user_id: 2,
+              author_name: 'TestUser',
+              body: 'Great show!',
+              body_html: '<p>Great show!</p>',
+              parent_id: null,
+              root_id: null,
+              depth: 0,
+              ups: 3,
+              downs: 0,
+              score: 3,
+              visibility: 'visible',
+              reply_permission: 'everyone',
+              edit_count: 0,
+              is_edited: false,
+              created_at: '2026-04-01T00:00:00Z',
+              updated_at: '2026-04-01T00:00:00Z',
+              structured_data: {
+                sound_quality: 4,
+                crowd_energy: 5,
+                setlist_spoiler: false,
+                is_verified_attendee: true,
+              },
+            },
+          ],
+          total: 1,
+          has_more: false,
+        },
+        isLoading: false,
+      })
+
+      render(
+        <FieldNotesSection showId={1} showDate={pastDate} artists={mockArtists} />
+      )
+
+      expect(screen.getByTestId('field-note-card')).toBeInTheDocument()
+      expect(screen.getByText('TestUser')).toBeInTheDocument()
+      expect(screen.getByTestId('verified-badge')).toBeInTheDocument()
+    })
+
+    it('renders loading skeleton', () => {
+      mockUseAuthContext.mockReturnValue({
+        isAuthenticated: false,
+        user: null,
+      })
+      mockUseFieldNotes.mockReturnValue({
+        data: undefined,
+        isLoading: true,
+      })
+
+      render(
+        <FieldNotesSection showId={1} showDate={pastDate} artists={mockArtists} />
+      )
+
+      expect(screen.getByTestId('field-notes-section')).toBeInTheDocument()
+      expect(screen.queryByTestId('field-notes-empty')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('future show (field notes not available)', () => {
+    it('shows future date message', () => {
+      mockUseAuthContext.mockReturnValue({
+        isAuthenticated: true,
+        user: { id: '1', email: 'test@test.com' },
+      })
+      mockUseFieldNotes.mockReturnValue({
+        data: { comments: [], total: 0, has_more: false },
+        isLoading: false,
+      })
+
+      render(
+        <FieldNotesSection showId={1} showDate={futureDate} artists={mockArtists} />
+      )
+
+      expect(screen.getByTestId('future-show-message')).toBeInTheDocument()
+      expect(screen.getByText(/Field notes will be available after/)).toBeInTheDocument()
+    })
+
+    it('does not show form for future show', () => {
+      mockUseAuthContext.mockReturnValue({
+        isAuthenticated: true,
+        user: { id: '1', email: 'test@test.com' },
+      })
+      mockUseFieldNotes.mockReturnValue({
+        data: { comments: [], total: 0, has_more: false },
+        isLoading: false,
+      })
+
+      render(
+        <FieldNotesSection showId={1} showDate={futureDate} artists={mockArtists} />
+      )
+
+      expect(screen.queryByTestId('field-note-form')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('field-notes-empty')).not.toBeInTheDocument()
+    })
+
+    it('does not show auth gate for future show', () => {
+      mockUseAuthContext.mockReturnValue({
+        isAuthenticated: false,
+        user: null,
+      })
+      mockUseFieldNotes.mockReturnValue({
+        data: { comments: [], total: 0, has_more: false },
+        isLoading: false,
+      })
+
+      render(
+        <FieldNotesSection showId={1} showDate={futureDate} artists={mockArtists} />
+      )
+
+      expect(screen.queryByTestId('field-note-auth-gate')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/features/comments/components/FieldNotesSection.tsx
+++ b/frontend/features/comments/components/FieldNotesSection.tsx
@@ -1,0 +1,134 @@
+'use client'
+
+import { ClipboardList } from 'lucide-react'
+import { useAuthContext } from '@/lib/context/AuthContext'
+import { useFieldNotes, useCreateFieldNote } from '../hooks'
+import { FieldNoteForm } from './FieldNoteForm'
+import { FieldNoteCard } from './FieldNoteCard'
+import type { CreateFieldNoteInput } from '../types'
+
+interface ShowArtist {
+  id: number
+  name: string
+}
+
+interface FieldNotesSectionProps {
+  showId: number
+  showDate: string
+  artists?: ShowArtist[]
+}
+
+function isShowInFuture(showDate: string): boolean {
+  const eventDate = new Date(showDate)
+  return eventDate > new Date()
+}
+
+function formatFutureDate(showDate: string): string {
+  const date = new Date(showDate)
+  return date.toLocaleDateString('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+
+export function FieldNotesSection({ showId, showDate, artists = [] }: FieldNotesSectionProps) {
+  const { isAuthenticated } = useAuthContext()
+  const { data, isLoading } = useFieldNotes(showId)
+  const createMutation = useCreateFieldNote()
+
+  const fieldNotes = data?.comments ?? []
+  const total = data?.total ?? 0
+  const isFuture = isShowInFuture(showDate)
+
+  const handleCreate = (input: CreateFieldNoteInput) => {
+    createMutation.mutate({ showId, input })
+  }
+
+  return (
+    <section className="mt-8" data-testid="field-notes-section">
+      {/* Header */}
+      <div className="flex items-center gap-2 mb-4">
+        <h2 className="text-lg font-semibold flex items-center gap-2">
+          <ClipboardList className="h-5 w-5" />
+          Field Notes
+          {total > 0 && (
+            <span className="text-sm font-normal text-muted-foreground">
+              ({total})
+            </span>
+          )}
+        </h2>
+      </div>
+
+      {/* Future show gate */}
+      {isFuture ? (
+        <p
+          className="text-sm text-muted-foreground py-4"
+          data-testid="future-show-message"
+        >
+          Field notes will be available after {formatFutureDate(showDate)}.
+        </p>
+      ) : (
+        <>
+          {/* Field note form */}
+          {isAuthenticated ? (
+            <div className="mb-6">
+              <FieldNoteForm
+                onSubmit={handleCreate}
+                artists={artists}
+                isPending={createMutation.isPending}
+              />
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground mb-6" data-testid="field-note-auth-gate">
+              <a href="/login" className="text-primary hover:underline">
+                Sign in
+              </a>{' '}
+              to share your experience.
+            </p>
+          )}
+
+          {/* Field notes list */}
+          {isLoading ? (
+            <div className="space-y-4">
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="animate-pulse space-y-2 rounded-lg border border-border/50 p-4">
+                  <div className="h-3 w-32 bg-muted rounded" />
+                  <div className="h-4 w-full bg-muted rounded" />
+                  <div className="h-4 w-3/4 bg-muted rounded" />
+                </div>
+              ))}
+            </div>
+          ) : fieldNotes.length === 0 ? (
+            <p
+              className="text-sm text-muted-foreground py-8 text-center"
+              data-testid="field-notes-empty"
+            >
+              No field notes yet. Attend this show and share your experience!
+            </p>
+          ) : (
+            <div className="space-y-4">
+              {fieldNotes.map((note) => (
+                <FieldNoteCard
+                  key={note.id}
+                  comment={note}
+                  showId={showId}
+                  artists={artists}
+                />
+              ))}
+            </div>
+          )}
+
+          {/* Load more */}
+          {data?.has_more && (
+            <div className="mt-4 text-center">
+              <button className="text-sm text-primary hover:underline">
+                Load more field notes
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  )
+}

--- a/frontend/features/comments/components/index.ts
+++ b/frontend/features/comments/components/index.ts
@@ -1,3 +1,6 @@
 export { CommentThread } from './CommentThread'
 export { CommentCard } from './CommentCard'
 export { CommentForm } from './CommentForm'
+export { FieldNoteForm } from './FieldNoteForm'
+export { FieldNoteCard } from './FieldNoteCard'
+export { FieldNotesSection } from './FieldNotesSection'

--- a/frontend/features/comments/hooks/index.ts
+++ b/frontend/features/comments/hooks/index.ts
@@ -2,8 +2,8 @@
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { apiRequest } from '@/lib/api'
-import { commentEndpoints, commentQueryKeys } from '../api'
-import type { Comment, CommentListResponse, CommentThreadResponse } from '../types'
+import { commentEndpoints, commentQueryKeys, fieldNoteEndpoints, fieldNoteQueryKeys } from '../api'
+import type { Comment, CommentListResponse, CommentThreadResponse, CreateFieldNoteInput } from '../types'
 
 // ============================================================================
 // Queries
@@ -279,6 +279,42 @@ export function useUnvoteComment() {
     onSettled: (_data, _err, variables) => {
       queryClient.invalidateQueries({
         queryKey: commentQueryKeys.entity(variables.entityType, variables.entityId),
+      })
+    },
+  })
+}
+
+// ============================================================================
+// Field Note Queries & Mutations
+// ============================================================================
+
+export function useFieldNotes(showId: number, options?: { enabled?: boolean }) {
+  return useQuery<CommentListResponse>({
+    queryKey: fieldNoteQueryKeys.show(showId),
+    queryFn: () =>
+      apiRequest<CommentListResponse>(fieldNoteEndpoints.LIST(showId)),
+    enabled: (options?.enabled ?? true) && showId > 0,
+  })
+}
+
+export function useCreateFieldNote() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({
+      showId,
+      input,
+    }: {
+      showId: number
+      input: CreateFieldNoteInput
+    }) =>
+      apiRequest<Comment>(fieldNoteEndpoints.CREATE(showId), {
+        method: 'POST',
+        body: JSON.stringify(input),
+      }),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: fieldNoteQueryKeys.show(variables.showId),
       })
     },
   })

--- a/frontend/features/comments/index.ts
+++ b/frontend/features/comments/index.ts
@@ -1,13 +1,15 @@
 // Public API for the comments feature module
 
 // API (endpoints + query keys)
-export { commentEndpoints, commentQueryKeys } from './api'
+export { commentEndpoints, commentQueryKeys, fieldNoteEndpoints, fieldNoteQueryKeys } from './api'
 
 // Types
 export type {
   Comment,
   CommentListResponse,
   CommentThreadResponse,
+  FieldNoteStructuredData,
+  CreateFieldNoteInput,
 } from './types'
 
 // Hooks
@@ -20,7 +22,16 @@ export {
   useDeleteComment,
   useVoteComment,
   useUnvoteComment,
+  useFieldNotes,
+  useCreateFieldNote,
 } from './hooks'
 
 // Components
-export { CommentThread, CommentCard, CommentForm } from './components'
+export {
+  CommentThread,
+  CommentCard,
+  CommentForm,
+  FieldNoteForm,
+  FieldNoteCard,
+  FieldNotesSection,
+} from './components'

--- a/frontend/features/comments/types.ts
+++ b/frontend/features/comments/types.ts
@@ -19,6 +19,7 @@ export interface Comment {
   created_at: string
   updated_at: string
   user_vote?: number | null
+  structured_data?: FieldNoteStructuredData | null
 }
 
 export interface CommentListResponse {
@@ -30,4 +31,28 @@ export interface CommentListResponse {
 export interface CommentThreadResponse {
   comment: Comment
   replies: Comment[]
+}
+
+// ============================================================================
+// Field Notes
+// ============================================================================
+
+export interface FieldNoteStructuredData {
+  show_artist_id?: number | null
+  song_position?: number | null
+  sound_quality?: number | null
+  crowd_energy?: number | null
+  notable_moments?: string | null
+  setlist_spoiler: boolean
+  is_verified_attendee: boolean
+}
+
+export interface CreateFieldNoteInput {
+  body: string
+  show_artist_id?: number
+  song_position?: number
+  sound_quality?: number
+  crowd_energy?: number
+  notable_moments?: string
+  setlist_spoiler?: boolean
 }

--- a/frontend/features/shows/components/ShowDetail.test.tsx
+++ b/frontend/features/shows/components/ShowDetail.test.tsx
@@ -89,6 +89,9 @@ vi.mock('@/features/comments', () => ({
   CommentThread: ({ entityType, entityId }: { entityType: string; entityId: number }) => (
     <div data-testid="comment-thread">Comments for {entityType} {entityId}</div>
   ),
+  FieldNotesSection: ({ showId }: { showId: number }) => (
+    <div data-testid="field-notes-section">Field Notes for {showId}</div>
+  ),
 }))
 
 function makeArtist(overrides: Partial<ArtistResponse> = {}): ArtistResponse {

--- a/frontend/features/shows/components/ShowDetail.tsx
+++ b/frontend/features/shows/components/ShowDetail.tsx
@@ -12,7 +12,7 @@ import { formatShowDate, formatShowTime, formatPrice } from '@/lib/utils/formatt
 import { Button } from '@/components/ui/button'
 import { SocialLinks, MusicEmbed, SaveButton, Breadcrumb, AddToCollectionButton } from '@/components/shared'
 import { EntityCollections } from '@/features/collections'
-import { CommentThread } from '@/features/comments'
+import { CommentThread, FieldNotesSection } from '@/features/comments'
 import { ShowForm } from '@/components/forms'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
@@ -413,6 +413,15 @@ export function ShowDetail({ showId }: ShowDetailProps) {
       {/* In Collections */}
       <section className="mb-8">
         <EntityCollections entityType="show" entityId={show.id} />
+      </section>
+
+      {/* Field Notes */}
+      <section className="mb-8">
+        <FieldNotesSection
+          showId={show.id}
+          showDate={show.event_date}
+          artists={artists.map(a => ({ id: a.id, name: a.name }))}
+        />
       </section>
 
       {/* Discussion */}


### PR DESCRIPTION
## Summary

PH's unique differentiator — structured attendee reflections on live shows. Depends on PSY-294 (backend endpoints, in progress).

### New Components
- **FieldNoteForm** — body textarea, 1-5 star ratings (sound quality/crowd energy), notable moments, artist picker, song position, spoiler checkbox. Disabled for future shows.
- **FieldNoteCard** — verified attendee badge, star ratings display, spoiler gate (click-to-reveal), artist attribution, song position, notable moments highlight, voting/replies
- **FieldNotesSection** — container with future-show gating, auth gate, empty state, loading skeletons

### Integration
- Added to ShowDetail.tsx as a "Field Notes" section above general Discussion
- Show pages now have two community sections: Field Notes (experiential) and Discussion (general)

### 39 new tests (2518 total, 193 files)
- FieldNoteForm: 15 tests (render, disabled, submit, ratings, artist picker, spoiler, optional fields)
- FieldNoteCard: 15 tests (body, verified badge, ratings, spoiler reveal, attribution, voting)
- FieldNotesSection: 9 tests (empty state, auth gate, form, count, cards, loading, future gating)

**Note**: Backend endpoints from PSY-294 needed for hooks to work end-to-end.

Closes PSY-295

🤖 Generated with [Claude Code](https://claude.com/claude-code)