### PR TITLE
Add show field notes as comment subtype (Wave 5)

### DIFF
--- a/backend/internal/api/handlers/field_note.go
+++ b/backend/internal/api/handlers/field_note.go
@@ -1,0 +1,176 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"psychic-homily-backend/internal/api/middleware"
+	"psychic-homily-backend/internal/logger"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// ============================================================================
+// Focused interfaces for dependency injection
+// ============================================================================
+
+// FieldNoteWriter defines the write operations for field notes.
+type FieldNoteWriter interface {
+	CreateFieldNote(userID uint, req *contracts.CreateFieldNoteRequest) (*contracts.CommentResponse, error)
+}
+
+// FieldNoteReader defines the read operations for field notes.
+type FieldNoteReader interface {
+	ListFieldNotesForShow(showID uint, limit, offset int) (*contracts.CommentListResponse, error)
+}
+
+// FieldNoteHandler handles field note API requests.
+type FieldNoteHandler struct {
+	writer          FieldNoteWriter
+	reader          FieldNoteReader
+	auditLogService contracts.AuditLogServiceInterface
+}
+
+// NewFieldNoteHandler creates a new FieldNoteHandler.
+func NewFieldNoteHandler(writer FieldNoteWriter, reader FieldNoteReader, auditLogService contracts.AuditLogServiceInterface) *FieldNoteHandler {
+	return &FieldNoteHandler{
+		writer:          writer,
+		reader:          reader,
+		auditLogService: auditLogService,
+	}
+}
+
+// ============================================================================
+// Create Field Note (protected)
+// ============================================================================
+
+// CreateFieldNoteRequest represents the Huma request for creating a field note.
+type CreateFieldNoteRequest struct {
+	ShowID string `path:"show_id" doc:"Show ID" example:"42"`
+	Body   struct {
+		Body           string  `json:"body" doc:"Field note body (Markdown)" example:"The sound was incredible tonight."`
+		ShowArtistID   *uint   `json:"show_artist_id,omitempty" required:"false" doc:"Artist ID on the show bill" example:"5"`
+		SongPosition   *int    `json:"song_position,omitempty" required:"false" doc:"Position in the setlist (1-based)" example:"3"`
+		SoundQuality   *int    `json:"sound_quality,omitempty" required:"false" doc:"Sound quality rating 1-5" example:"4"`
+		CrowdEnergy    *int    `json:"crowd_energy,omitempty" required:"false" doc:"Crowd energy rating 1-5" example:"5"`
+		NotableMoments *string `json:"notable_moments,omitempty" required:"false" doc:"Notable moments description" example:"Surprise cover of Ziggy Stardust"`
+		SetlistSpoiler bool    `json:"setlist_spoiler" required:"false" doc:"Whether this note contains setlist spoilers" example:"false"`
+	}
+}
+
+// CreateFieldNoteResponse represents the response for creating a field note.
+type CreateFieldNoteResponse struct {
+	Body *contracts.CommentResponse
+}
+
+// CreateFieldNoteHandler handles POST /shows/{show_id}/field-notes
+func (h *FieldNoteHandler) CreateFieldNoteHandler(ctx context.Context, req *CreateFieldNoteRequest) (*CreateFieldNoteResponse, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	showID, err := strconv.ParseUint(req.ShowID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid show ID")
+	}
+
+	if strings.TrimSpace(req.Body.Body) == "" {
+		return nil, huma.Error400BadRequest("Field note body is required")
+	}
+
+	serviceReq := &contracts.CreateFieldNoteRequest{
+		ShowID:         uint(showID),
+		Body:           req.Body.Body,
+		ShowArtistID:   req.Body.ShowArtistID,
+		SongPosition:   req.Body.SongPosition,
+		SoundQuality:   req.Body.SoundQuality,
+		CrowdEnergy:    req.Body.CrowdEnergy,
+		NotableMoments: req.Body.NotableMoments,
+		SetlistSpoiler: req.Body.SetlistSpoiler,
+	}
+
+	fieldNote, err := h.writer.CreateFieldNote(user.ID, serviceReq)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return nil, huma.Error404NotFound(err.Error())
+		}
+		if strings.Contains(err.Error(), "body is required") || strings.Contains(err.Error(), "exceeds maximum length") {
+			return nil, huma.Error400BadRequest(err.Error())
+		}
+		if strings.Contains(err.Error(), "field notes can only be added to past shows") {
+			return nil, huma.Error400BadRequest(err.Error())
+		}
+		if strings.Contains(err.Error(), "sound_quality must be") || strings.Contains(err.Error(), "crowd_energy must be") {
+			return nil, huma.Error400BadRequest(err.Error())
+		}
+		if strings.Contains(err.Error(), "artist is not on this show") {
+			return nil, huma.Error400BadRequest(err.Error())
+		}
+		if strings.Contains(err.Error(), "please wait") || strings.Contains(err.Error(), "hourly comment limit") {
+			return nil, huma.Error429TooManyRequests(err.Error())
+		}
+		requestID := logger.GetRequestID(ctx)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to create field note (request_id: %s)", requestID),
+		)
+	}
+
+	// Audit log (fire and forget)
+	if h.auditLogService != nil {
+		go func() {
+			h.auditLogService.LogAction(user.ID, "create_field_note", "show", fieldNote.ID, map[string]interface{}{
+				"show_id": uint(showID),
+			})
+		}()
+	}
+
+	return &CreateFieldNoteResponse{Body: fieldNote}, nil
+}
+
+// ============================================================================
+// List Field Notes (public/optional auth)
+// ============================================================================
+
+// ListFieldNotesRequest represents the Huma request for listing field notes on a show.
+type ListFieldNotesRequest struct {
+	ShowID string `path:"show_id" doc:"Show ID" example:"42"`
+	Limit  int    `query:"limit" required:"false" doc:"Page size (default 25, max 100)" example:"25"`
+	Offset int    `query:"offset" required:"false" doc:"Pagination offset" example:"0"`
+}
+
+// ListFieldNotesResponse represents the response for listing field notes.
+type ListFieldNotesResponse struct {
+	Body *contracts.CommentListResponse
+}
+
+// ListFieldNotesHandler handles GET /shows/{show_id}/field-notes
+func (h *FieldNoteHandler) ListFieldNotesHandler(ctx context.Context, req *ListFieldNotesRequest) (*ListFieldNotesResponse, error) {
+	showID, err := strconv.ParseUint(req.ShowID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid show ID")
+	}
+
+	limit := req.Limit
+	if limit <= 0 {
+		limit = 25
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	offset := req.Offset
+	if offset < 0 {
+		offset = 0
+	}
+
+	result, err := h.reader.ListFieldNotesForShow(uint(showID), limit, offset)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Failed to fetch field notes")
+	}
+
+	return &ListFieldNotesResponse{Body: result}, nil
+}

--- a/backend/internal/api/handlers/field_note_test.go
+++ b/backend/internal/api/handlers/field_note_test.go
@@ -1,0 +1,371 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// ============================================================================
+// Test helpers
+// ============================================================================
+
+func testFieldNoteHandler() *FieldNoteHandler {
+	return NewFieldNoteHandler(nil, nil, nil)
+}
+
+func makeFieldNoteResponse(id uint, showID uint, userID uint) *contracts.CommentResponse {
+	sd := contracts.FieldNoteStructuredData{
+		IsVerifiedAttendee: true,
+	}
+	sdBytes, _ := json.Marshal(sd)
+	raw := json.RawMessage(sdBytes)
+	return &contracts.CommentResponse{
+		ID:              id,
+		EntityType:      "show",
+		EntityID:        showID,
+		Kind:            "field_note",
+		UserID:          userID,
+		Depth:           0,
+		Body:            "Great show!",
+		BodyHTML:        "<p>Great show!</p>",
+		StructuredData:  &raw,
+		Visibility:      "visible",
+		ReplyPermission: "anyone",
+		Ups:             0,
+		Downs:           0,
+		Score:           0,
+		CreatedAt:       time.Now(),
+		UpdatedAt:       time.Now(),
+	}
+}
+
+// ============================================================================
+// Mock field note service
+// ============================================================================
+
+type mockFieldNoteService struct {
+	createFieldNoteFn      func(uint, *contracts.CreateFieldNoteRequest) (*contracts.CommentResponse, error)
+	listFieldNotesForShowFn func(uint, int, int) (*contracts.CommentListResponse, error)
+}
+
+func (m *mockFieldNoteService) CreateFieldNote(userID uint, req *contracts.CreateFieldNoteRequest) (*contracts.CommentResponse, error) {
+	if m.createFieldNoteFn != nil {
+		return m.createFieldNoteFn(userID, req)
+	}
+	return nil, nil
+}
+
+func (m *mockFieldNoteService) ListFieldNotesForShow(showID uint, limit, offset int) (*contracts.CommentListResponse, error) {
+	if m.listFieldNotesForShowFn != nil {
+		return m.listFieldNotesForShowFn(showID, limit, offset)
+	}
+	return nil, nil
+}
+
+// ============================================================================
+// Tests: CreateFieldNote
+// ============================================================================
+
+func TestCreateFieldNote_NoAuth(t *testing.T) {
+	h := testFieldNoteHandler()
+	_, err := h.CreateFieldNoteHandler(context.Background(), &CreateFieldNoteRequest{
+		ShowID: "1",
+	})
+	assertHumaError(t, err, 401)
+}
+
+func TestCreateFieldNote_InvalidShowID(t *testing.T) {
+	h := testFieldNoteHandler()
+	ctx := ctxWithUser(&models.User{ID: 10})
+	_, err := h.CreateFieldNoteHandler(ctx, &CreateFieldNoteRequest{
+		ShowID: "abc",
+	})
+	assertHumaError(t, err, 400)
+}
+
+func TestCreateFieldNote_EmptyBody(t *testing.T) {
+	h := testFieldNoteHandler()
+	ctx := ctxWithUser(&models.User{ID: 10})
+	req := &CreateFieldNoteRequest{ShowID: "1"}
+	req.Body.Body = "   "
+	_, err := h.CreateFieldNoteHandler(ctx, req)
+	assertHumaError(t, err, 400)
+}
+
+func TestCreateFieldNote_ShowNotFound(t *testing.T) {
+	mock := &mockFieldNoteService{
+		createFieldNoteFn: func(userID uint, req *contracts.CreateFieldNoteRequest) (*contracts.CommentResponse, error) {
+			return nil, fmt.Errorf("show not found")
+		},
+	}
+	h := NewFieldNoteHandler(mock, mock, nil)
+	ctx := ctxWithUser(&models.User{ID: 10})
+	req := &CreateFieldNoteRequest{ShowID: "999"}
+	req.Body.Body = "test note"
+	_, err := h.CreateFieldNoteHandler(ctx, req)
+	assertHumaError(t, err, 404)
+}
+
+func TestCreateFieldNote_FutureShow(t *testing.T) {
+	mock := &mockFieldNoteService{
+		createFieldNoteFn: func(userID uint, req *contracts.CreateFieldNoteRequest) (*contracts.CommentResponse, error) {
+			return nil, fmt.Errorf("field notes can only be added to past shows")
+		},
+	}
+	h := NewFieldNoteHandler(mock, mock, nil)
+	ctx := ctxWithUser(&models.User{ID: 10})
+	req := &CreateFieldNoteRequest{ShowID: "1"}
+	req.Body.Body = "test note"
+	_, err := h.CreateFieldNoteHandler(ctx, req)
+	assertHumaError(t, err, 400)
+}
+
+func TestCreateFieldNote_SoundQualityInvalid(t *testing.T) {
+	mock := &mockFieldNoteService{
+		createFieldNoteFn: func(userID uint, req *contracts.CreateFieldNoteRequest) (*contracts.CommentResponse, error) {
+			return nil, fmt.Errorf("sound_quality must be between 1 and 5")
+		},
+	}
+	h := NewFieldNoteHandler(mock, mock, nil)
+	ctx := ctxWithUser(&models.User{ID: 10})
+	req := &CreateFieldNoteRequest{ShowID: "1"}
+	req.Body.Body = "test note"
+	sq := 0
+	req.Body.SoundQuality = &sq
+	_, err := h.CreateFieldNoteHandler(ctx, req)
+	assertHumaError(t, err, 400)
+}
+
+func TestCreateFieldNote_CrowdEnergyInvalid(t *testing.T) {
+	mock := &mockFieldNoteService{
+		createFieldNoteFn: func(userID uint, req *contracts.CreateFieldNoteRequest) (*contracts.CommentResponse, error) {
+			return nil, fmt.Errorf("crowd_energy must be between 1 and 5")
+		},
+	}
+	h := NewFieldNoteHandler(mock, mock, nil)
+	ctx := ctxWithUser(&models.User{ID: 10})
+	req := &CreateFieldNoteRequest{ShowID: "1"}
+	req.Body.Body = "test note"
+	ce := 7
+	req.Body.CrowdEnergy = &ce
+	_, err := h.CreateFieldNoteHandler(ctx, req)
+	assertHumaError(t, err, 400)
+}
+
+func TestCreateFieldNote_ArtistNotOnShow(t *testing.T) {
+	mock := &mockFieldNoteService{
+		createFieldNoteFn: func(userID uint, req *contracts.CreateFieldNoteRequest) (*contracts.CommentResponse, error) {
+			return nil, fmt.Errorf("artist is not on this show's bill")
+		},
+	}
+	h := NewFieldNoteHandler(mock, mock, nil)
+	ctx := ctxWithUser(&models.User{ID: 10})
+	req := &CreateFieldNoteRequest{ShowID: "1"}
+	req.Body.Body = "test note"
+	aid := uint(99)
+	req.Body.ShowArtistID = &aid
+	_, err := h.CreateFieldNoteHandler(ctx, req)
+	assertHumaError(t, err, 400)
+}
+
+func TestCreateFieldNote_RateLimited(t *testing.T) {
+	mock := &mockFieldNoteService{
+		createFieldNoteFn: func(userID uint, req *contracts.CreateFieldNoteRequest) (*contracts.CommentResponse, error) {
+			return nil, fmt.Errorf("please wait 60 seconds between comments on the same entity")
+		},
+	}
+	h := NewFieldNoteHandler(mock, mock, nil)
+	ctx := ctxWithUser(&models.User{ID: 10})
+	req := &CreateFieldNoteRequest{ShowID: "1"}
+	req.Body.Body = "test note"
+	_, err := h.CreateFieldNoteHandler(ctx, req)
+	assertHumaError(t, err, 429)
+}
+
+func TestCreateFieldNote_Success(t *testing.T) {
+	expected := makeFieldNoteResponse(1, 42, 10)
+	mock := &mockFieldNoteService{
+		createFieldNoteFn: func(userID uint, req *contracts.CreateFieldNoteRequest) (*contracts.CommentResponse, error) {
+			if userID != 10 {
+				t.Errorf("expected userID=10, got %d", userID)
+			}
+			if req.ShowID != 42 {
+				t.Errorf("expected showID=42, got %d", req.ShowID)
+			}
+			if req.Body != "Great show!" {
+				t.Errorf("expected body='Great show!', got '%s'", req.Body)
+			}
+			return expected, nil
+		},
+	}
+	h := NewFieldNoteHandler(mock, mock, nil)
+	ctx := ctxWithUser(&models.User{ID: 10})
+	req := &CreateFieldNoteRequest{ShowID: "42"}
+	req.Body.Body = "Great show!"
+	resp, err := h.CreateFieldNoteHandler(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.ID != 1 {
+		t.Errorf("expected ID=1, got %d", resp.Body.ID)
+	}
+	if resp.Body.Kind != "field_note" {
+		t.Errorf("expected kind=field_note, got %s", resp.Body.Kind)
+	}
+}
+
+func TestCreateFieldNote_PassesAllFields(t *testing.T) {
+	sq := 4
+	ce := 5
+	sp := 2
+	nm := "Epic solo"
+	aid := uint(7)
+	mock := &mockFieldNoteService{
+		createFieldNoteFn: func(userID uint, req *contracts.CreateFieldNoteRequest) (*contracts.CommentResponse, error) {
+			if req.ShowArtistID == nil || *req.ShowArtistID != 7 {
+				t.Errorf("expected show_artist_id=7")
+			}
+			if req.SoundQuality == nil || *req.SoundQuality != 4 {
+				t.Errorf("expected sound_quality=4")
+			}
+			if req.CrowdEnergy == nil || *req.CrowdEnergy != 5 {
+				t.Errorf("expected crowd_energy=5")
+			}
+			if req.SongPosition == nil || *req.SongPosition != 2 {
+				t.Errorf("expected song_position=2")
+			}
+			if req.NotableMoments == nil || *req.NotableMoments != "Epic solo" {
+				t.Errorf("expected notable_moments='Epic solo'")
+			}
+			if !req.SetlistSpoiler {
+				t.Errorf("expected setlist_spoiler=true")
+			}
+			return makeFieldNoteResponse(1, 42, 10), nil
+		},
+	}
+	h := NewFieldNoteHandler(mock, mock, nil)
+	ctx := ctxWithUser(&models.User{ID: 10})
+	req := &CreateFieldNoteRequest{ShowID: "42"}
+	req.Body.Body = "note"
+	req.Body.ShowArtistID = &aid
+	req.Body.SoundQuality = &sq
+	req.Body.CrowdEnergy = &ce
+	req.Body.SongPosition = &sp
+	req.Body.NotableMoments = &nm
+	req.Body.SetlistSpoiler = true
+	_, err := h.CreateFieldNoteHandler(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// ============================================================================
+// Tests: ListFieldNotes
+// ============================================================================
+
+func TestListFieldNotes_InvalidShowID(t *testing.T) {
+	h := testFieldNoteHandler()
+	_, err := h.ListFieldNotesHandler(context.Background(), &ListFieldNotesRequest{
+		ShowID: "abc",
+	})
+	assertHumaError(t, err, 400)
+}
+
+func TestListFieldNotes_DefaultPagination(t *testing.T) {
+	mock := &mockFieldNoteService{
+		listFieldNotesForShowFn: func(showID uint, limit, offset int) (*contracts.CommentListResponse, error) {
+			if showID != 42 {
+				t.Errorf("expected showID=42, got %d", showID)
+			}
+			if limit != 25 {
+				t.Errorf("expected default limit=25, got %d", limit)
+			}
+			if offset != 0 {
+				t.Errorf("expected default offset=0, got %d", offset)
+			}
+			return &contracts.CommentListResponse{
+				Comments: []*contracts.CommentResponse{},
+				Total:    0,
+				HasMore:  false,
+			}, nil
+		},
+	}
+	h := NewFieldNoteHandler(mock, mock, nil)
+	resp, err := h.ListFieldNotesHandler(context.Background(), &ListFieldNotesRequest{
+		ShowID: "42",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Total != 0 {
+		t.Errorf("expected total=0")
+	}
+}
+
+func TestListFieldNotes_LimitCapped(t *testing.T) {
+	mock := &mockFieldNoteService{
+		listFieldNotesForShowFn: func(showID uint, limit, offset int) (*contracts.CommentListResponse, error) {
+			if limit != 100 {
+				t.Errorf("expected limit capped at 100, got %d", limit)
+			}
+			return &contracts.CommentListResponse{
+				Comments: []*contracts.CommentResponse{},
+				Total:    0,
+				HasMore:  false,
+			}, nil
+		},
+	}
+	h := NewFieldNoteHandler(mock, mock, nil)
+	_, err := h.ListFieldNotesHandler(context.Background(), &ListFieldNotesRequest{
+		ShowID: "42",
+		Limit:  500,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestListFieldNotes_Success(t *testing.T) {
+	notes := []*contracts.CommentResponse{makeFieldNoteResponse(1, 42, 10), makeFieldNoteResponse(2, 42, 11)}
+	mock := &mockFieldNoteService{
+		listFieldNotesForShowFn: func(showID uint, limit, offset int) (*contracts.CommentListResponse, error) {
+			return &contracts.CommentListResponse{
+				Comments: notes,
+				Total:    2,
+				HasMore:  false,
+			}, nil
+		},
+	}
+	h := NewFieldNoteHandler(mock, mock, nil)
+	resp, err := h.ListFieldNotesHandler(context.Background(), &ListFieldNotesRequest{
+		ShowID: "42",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Total != 2 {
+		t.Errorf("expected total=2, got %d", resp.Body.Total)
+	}
+	if len(resp.Body.Comments) != 2 {
+		t.Errorf("expected 2 comments, got %d", len(resp.Body.Comments))
+	}
+}
+
+func TestListFieldNotes_ServerError(t *testing.T) {
+	mock := &mockFieldNoteService{
+		listFieldNotesForShowFn: func(showID uint, limit, offset int) (*contracts.CommentListResponse, error) {
+			return nil, fmt.Errorf("database error")
+		},
+	}
+	h := NewFieldNoteHandler(mock, mock, nil)
+	_, err := h.ListFieldNotesHandler(context.Background(), &ListFieldNotesRequest{
+		ShowID: "42",
+	})
+	assertHumaError(t, err, 500)
+}

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -135,6 +135,7 @@ func SetupRoutes(router *chi.Mux, sc *services.ServiceContainer, cfg *config.Con
 	setupCommentRoutes(rc)
 	setupCommentVoteRoutes(rc)
 	setupCommentSubscriptionRoutes(rc)
+	setupFieldNoteRoutes(rc)
 
 	return api
 }
@@ -1116,4 +1117,17 @@ func setupCommentSubscriptionRoutes(rc RouteContext) {
 	huma.Delete(rc.Protected, "/entities/{entity_type}/{entity_id}/subscribe", subHandler.UnsubscribeHandler)
 	huma.Get(rc.Protected, "/entities/{entity_type}/{entity_id}/subscribe/status", subHandler.SubscriptionStatusHandler)
 	huma.Post(rc.Protected, "/entities/{entity_type}/{entity_id}/mark-read", subHandler.MarkReadHandler)
+}
+
+// setupFieldNoteRoutes configures field note endpoints on shows.
+func setupFieldNoteRoutes(rc RouteContext) {
+	fieldNoteHandler := handlers.NewFieldNoteHandler(rc.SC.Comment, rc.SC.Comment, rc.SC.AuditLog)
+
+	// Public: list field notes for a show
+	optionalAuthGroup := huma.NewGroup(rc.API, "")
+	optionalAuthGroup.UseMiddleware(middleware.OptionalHumaJWTMiddleware(rc.SC.JWT))
+	huma.Get(optionalAuthGroup, "/shows/{show_id}/field-notes", fieldNoteHandler.ListFieldNotesHandler)
+
+	// Protected: create field note
+	huma.Post(rc.Protected, "/shows/{show_id}/field-notes", fieldNoteHandler.CreateFieldNoteHandler)
 }

--- a/backend/internal/services/contracts/comment.go
+++ b/backend/internal/services/contracts/comment.go
@@ -1,6 +1,9 @@
 package contracts
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 // ──────────────────────────────────────────────
 // Comment request types
@@ -21,6 +24,29 @@ type UpdateCommentRequest struct {
 	Body string `json:"body"`
 }
 
+// CreateFieldNoteRequest contains the fields needed to create a field note on a show.
+type CreateFieldNoteRequest struct {
+	ShowID         uint    `json:"show_id"`
+	Body           string  `json:"body"`
+	ShowArtistID   *uint   `json:"show_artist_id,omitempty"`
+	SongPosition   *int    `json:"song_position,omitempty"`
+	SoundQuality   *int    `json:"sound_quality,omitempty"`
+	CrowdEnergy    *int    `json:"crowd_energy,omitempty"`
+	NotableMoments *string `json:"notable_moments,omitempty"`
+	SetlistSpoiler bool    `json:"setlist_spoiler"`
+}
+
+// FieldNoteStructuredData represents the JSONB structured data stored with field note comments.
+type FieldNoteStructuredData struct {
+	ShowArtistID     *uint   `json:"show_artist_id,omitempty"`
+	SongPosition     *int    `json:"song_position,omitempty"`
+	SoundQuality     *int    `json:"sound_quality,omitempty"`
+	CrowdEnergy      *int    `json:"crowd_energy,omitempty"`
+	NotableMoments   *string `json:"notable_moments,omitempty"`
+	SetlistSpoiler   bool    `json:"setlist_spoiler"`
+	IsVerifiedAttendee bool  `json:"is_verified_attendee"`
+}
+
 // CommentListFilters defines filtering and sorting options for listing comments.
 type CommentListFilters struct {
 	Sort       string // best, new, top, controversial
@@ -36,28 +62,29 @@ type CommentListFilters struct {
 
 // CommentResponse represents a comment with author info for API responses.
 type CommentResponse struct {
-	ID              uint       `json:"id"`
-	EntityType      string     `json:"entity_type"`
-	EntityID        uint       `json:"entity_id"`
-	Kind            string     `json:"kind"`
-	UserID          uint       `json:"user_id"`
-	AuthorName      string     `json:"author_name"`
-	AuthorUsername  string     `json:"author_username,omitempty"`
-	ParentID        *uint      `json:"parent_id,omitempty"`
-	RootID          *uint      `json:"root_id,omitempty"`
-	Depth           int        `json:"depth"`
-	Body            string     `json:"body"`
-	BodyHTML        string     `json:"body_html"`
-	Visibility      string     `json:"visibility"`
-	ReplyPermission string     `json:"reply_permission"`
-	Ups             int        `json:"ups"`
-	Downs           int        `json:"downs"`
-	Score           float64    `json:"score"`
-	IsEdited        bool       `json:"is_edited"`
-	EditCount       int        `json:"edit_count"`
-	UserVote        *int       `json:"user_vote,omitempty"` // 1, -1, or nil if no vote
-	CreatedAt       time.Time  `json:"created_at"`
-	UpdatedAt       time.Time  `json:"updated_at"`
+	ID              uint             `json:"id"`
+	EntityType      string           `json:"entity_type"`
+	EntityID        uint             `json:"entity_id"`
+	Kind            string           `json:"kind"`
+	UserID          uint             `json:"user_id"`
+	AuthorName      string           `json:"author_name"`
+	AuthorUsername  string           `json:"author_username,omitempty"`
+	ParentID        *uint            `json:"parent_id,omitempty"`
+	RootID          *uint            `json:"root_id,omitempty"`
+	Depth           int              `json:"depth"`
+	Body            string           `json:"body"`
+	BodyHTML        string           `json:"body_html"`
+	StructuredData  *json.RawMessage `json:"structured_data,omitempty"`
+	Visibility      string           `json:"visibility"`
+	ReplyPermission string           `json:"reply_permission"`
+	Ups             int              `json:"ups"`
+	Downs           int              `json:"downs"`
+	Score           float64          `json:"score"`
+	IsEdited        bool             `json:"is_edited"`
+	EditCount       int              `json:"edit_count"`
+	UserVote        *int             `json:"user_vote,omitempty"` // 1, -1, or nil if no vote
+	CreatedAt       time.Time        `json:"created_at"`
+	UpdatedAt       time.Time        `json:"updated_at"`
 }
 
 // CommentListResponse wraps a list of comments with pagination metadata.
@@ -79,6 +106,12 @@ type CommentServiceInterface interface {
 	GetThread(rootID uint) ([]*CommentResponse, error)
 	UpdateComment(userID uint, commentID uint, req *UpdateCommentRequest) (*CommentResponse, error)
 	DeleteComment(userID uint, commentID uint, isAdmin bool) error
+}
+
+// FieldNoteServiceInterface defines the contract for field note operations on shows.
+type FieldNoteServiceInterface interface {
+	CreateFieldNote(userID uint, req *CreateFieldNoteRequest) (*CommentResponse, error)
+	ListFieldNotesForShow(showID uint, limit, offset int) (*CommentListResponse, error)
 }
 // ──────────────────────────────────────────────
 // Comment admin service interface

--- a/backend/internal/services/engagement/comment_service.go
+++ b/backend/internal/services/engagement/comment_service.go
@@ -2,6 +2,7 @@ package engagement
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -111,6 +112,7 @@ func commentToResponse(c *models.Comment) *contracts.CommentResponse {
 		Depth:           c.Depth,
 		Body:            c.Body,
 		BodyHTML:        c.BodyHTML,
+		StructuredData:  c.StructuredData,
 		Visibility:      string(c.Visibility),
 		ReplyPermission: string(c.ReplyPermission),
 		Ups:             c.Ups,
@@ -544,6 +546,222 @@ func (s *CommentService) DeleteComment(userID uint, commentID uint, isAdmin bool
 	}
 
 	return nil
+}
+
+// ============================================================================
+// Field Note methods
+// ============================================================================
+
+// CreateFieldNote creates a field note (specialized comment) on a show.
+// Field notes must target past shows and store structured data (sound quality, crowd energy, etc.).
+func (s *CommentService) CreateFieldNote(userID uint, req *contracts.CreateFieldNoteRequest) (*contracts.CommentResponse, error) {
+	if s.db == nil {
+		return nil, errors.New("database not initialized")
+	}
+
+	// Validate body
+	body := strings.TrimSpace(req.Body)
+	if len(body) < models.MinCommentBodyLength {
+		return nil, errors.New("field note body is required")
+	}
+	if len(body) > models.MaxCommentBodyLength {
+		return nil, fmt.Errorf("field note body exceeds maximum length of %d characters", models.MaxCommentBodyLength)
+	}
+
+	// Validate sound_quality range (1-5)
+	if req.SoundQuality != nil && (*req.SoundQuality < 1 || *req.SoundQuality > 5) {
+		return nil, errors.New("sound_quality must be between 1 and 5")
+	}
+
+	// Validate crowd_energy range (1-5)
+	if req.CrowdEnergy != nil && (*req.CrowdEnergy < 1 || *req.CrowdEnergy > 5) {
+		return nil, errors.New("crowd_energy must be between 1 and 5")
+	}
+
+	// Look up the show and verify it's in the past
+	var show models.Show
+	if err := s.db.First(&show, req.ShowID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, errors.New("show not found")
+		}
+		return nil, fmt.Errorf("failed to look up show: %w", err)
+	}
+
+	if show.EventDate.After(time.Now()) {
+		return nil, errors.New("field notes can only be added to past shows")
+	}
+
+	// Validate show_artist_id belongs to this show (if provided)
+	if req.ShowArtistID != nil {
+		var count int64
+		if err := s.db.Model(&models.ShowArtist{}).
+			Where("show_id = ? AND artist_id = ?", req.ShowID, *req.ShowArtistID).
+			Count(&count).Error; err != nil {
+			return nil, fmt.Errorf("failed to validate show artist: %w", err)
+		}
+		if count == 0 {
+			return nil, errors.New("artist is not on this show's bill")
+		}
+	}
+
+	// Look up user for trust tier and rate limiting
+	var user models.User
+	if err := s.db.First(&user, userID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, errors.New("user not found")
+		}
+		return nil, fmt.Errorf("failed to look up user: %w", err)
+	}
+
+	// Rate limiting: per-entity cooldown (60s between comments on same entity)
+	var recentEntityCount int64
+	if err := s.db.Model(&models.Comment{}).
+		Where("user_id = ? AND entity_type = ? AND entity_id = ? AND created_at > ?",
+			userID, models.CommentEntityShow, req.ShowID, time.Now().Add(-60*time.Second)).
+		Count(&recentEntityCount).Error; err != nil {
+		return nil, fmt.Errorf("failed to check rate limit: %w", err)
+	}
+	if recentEntityCount > 0 {
+		return nil, errors.New("please wait 60 seconds between comments on the same entity")
+	}
+
+	// Rate limiting: global hourly limit based on trust tier
+	hourlyLimit := userTierHourlyLimit(user.UserTier)
+	if hourlyLimit >= 0 {
+		var hourlyCount int64
+		if err := s.db.Model(&models.Comment{}).
+			Where("user_id = ? AND created_at > ?", userID, time.Now().Add(-1*time.Hour)).
+			Count(&hourlyCount).Error; err != nil {
+			return nil, fmt.Errorf("failed to check hourly rate limit: %w", err)
+		}
+		if int(hourlyCount) >= hourlyLimit {
+			return nil, fmt.Errorf("you've reached your hourly comment limit (%d/hour for %s users)",
+				hourlyLimit, func() string {
+					if user.UserTier == "" {
+						return "new"
+					}
+					return strings.ReplaceAll(user.UserTier, "_", " ")
+				}())
+		}
+	}
+
+	// Compute verified attendee: user marked "going" before the show date
+	isVerifiedAttendee := false
+	var goingBookmark models.UserBookmark
+	err := s.db.Where(
+		"user_id = ? AND entity_type = ? AND entity_id = ? AND action = ?",
+		userID, models.BookmarkEntityShow, req.ShowID, models.BookmarkActionGoing,
+	).First(&goingBookmark).Error
+	if err == nil {
+		// User has a "going" bookmark — verified if created before the show date
+		if goingBookmark.CreatedAt.Before(show.EventDate) {
+			isVerifiedAttendee = true
+		}
+	}
+
+	// Build structured data
+	structuredData := contracts.FieldNoteStructuredData{
+		ShowArtistID:       req.ShowArtistID,
+		SongPosition:       req.SongPosition,
+		SoundQuality:       req.SoundQuality,
+		CrowdEnergy:        req.CrowdEnergy,
+		NotableMoments:     req.NotableMoments,
+		SetlistSpoiler:     req.SetlistSpoiler,
+		IsVerifiedAttendee: isVerifiedAttendee,
+	}
+	sdJSON, err := json.Marshal(structuredData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal structured data: %w", err)
+	}
+	rawJSON := json.RawMessage(sdJSON)
+
+	// Render markdown to HTML
+	bodyHTML := s.renderMarkdown(body)
+
+	// Determine initial visibility based on trust tier
+	visibility := computeInitialVisibility(&user)
+
+	comment := &models.Comment{
+		EntityType:      models.CommentEntityShow,
+		EntityID:        req.ShowID,
+		Kind:            models.CommentKindFieldNote,
+		UserID:          userID,
+		Body:            body,
+		BodyHTML:        bodyHTML,
+		StructuredData:  &rawJSON,
+		Visibility:      visibility,
+		ReplyPermission: models.ReplyPermissionAnyone,
+	}
+
+	if err := s.db.Create(comment).Error; err != nil {
+		return nil, fmt.Errorf("failed to create field note: %w", err)
+	}
+
+	// Auto-subscribe the user to this show's comments (fire-and-forget)
+	sub := models.CommentSubscription{
+		UserID:       userID,
+		EntityType:   string(models.CommentEntityShow),
+		EntityID:     req.ShowID,
+		SubscribedAt: time.Now().UTC(),
+	}
+	if err := s.db.Clauses(clause.OnConflict{DoNothing: true}).Create(&sub).Error; err != nil {
+		log.Printf("warning: failed to auto-subscribe user %d to show/%d comments: %v", userID, req.ShowID, err)
+	}
+
+	// Reload with user info
+	if err := s.db.Preload("User").First(comment, comment.ID).Error; err != nil {
+		return nil, fmt.Errorf("failed to reload field note: %w", err)
+	}
+
+	return commentToResponse(comment), nil
+}
+
+// ListFieldNotesForShow returns field notes for a show, sorted by song_position ASC (NULLs first),
+// then by score DESC within the same position.
+func (s *CommentService) ListFieldNotesForShow(showID uint, limit, offset int) (*contracts.CommentListResponse, error) {
+	if s.db == nil {
+		return nil, errors.New("database not initialized")
+	}
+
+	if limit <= 0 {
+		limit = 20
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	// Base query: field notes on this show that are visible
+	query := s.db.Model(&models.Comment{}).
+		Where("entity_type = ? AND entity_id = ? AND kind = ? AND visibility = ?",
+			models.CommentEntityShow, showID, models.CommentKindFieldNote, models.CommentVisibilityVisible)
+
+	// Count total
+	var total int64
+	if err := query.Count(&total).Error; err != nil {
+		return nil, fmt.Errorf("failed to count field notes: %w", err)
+	}
+
+	// Sort by song_position ASC (NULLs first), then score DESC
+	// We extract song_position from the JSONB structured_data column.
+	var comments []models.Comment
+	if err := query.Preload("User").
+		Order("(structured_data->>'song_position')::int ASC NULLS FIRST, score DESC").
+		Limit(limit).
+		Offset(offset).
+		Find(&comments).Error; err != nil {
+		return nil, fmt.Errorf("failed to fetch field notes: %w", err)
+	}
+
+	responses := make([]*contracts.CommentResponse, len(comments))
+	for i := range comments {
+		responses[i] = commentToResponse(&comments[i])
+	}
+
+	return &contracts.CommentListResponse{
+		Comments: responses,
+		Total:    total,
+		HasMore:  int64(offset+limit) < total,
+	}, nil
 }
 
 // ============================================================================

--- a/backend/internal/services/engagement/field_note_test.go
+++ b/backend/internal/services/engagement/field_note_test.go
@@ -1,0 +1,785 @@
+package engagement
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/testutil"
+)
+
+// =============================================================================
+// UNIT TESTS (No Database Required)
+// =============================================================================
+
+func TestFieldNote_NilDB(t *testing.T) {
+	svc := NewCommentService(nil)
+
+	t.Run("CreateFieldNote_NilDB", func(t *testing.T) {
+		_, err := svc.CreateFieldNote(1, &contracts.CreateFieldNoteRequest{
+			ShowID: 1,
+			Body:   "test",
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "database not initialized")
+	})
+
+	t.Run("ListFieldNotesForShow_NilDB", func(t *testing.T) {
+		_, err := svc.ListFieldNotesForShow(1, 20, 0)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "database not initialized")
+	})
+}
+
+func TestFieldNote_BodyValidation(t *testing.T) {
+	svc := &CommentService{db: &gorm.DB{}}
+
+	t.Run("CreateFieldNote_EmptyBody", func(t *testing.T) {
+		_, err := svc.CreateFieldNote(1, &contracts.CreateFieldNoteRequest{
+			ShowID: 1,
+			Body:   "",
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "field note body is required")
+	})
+
+	t.Run("CreateFieldNote_WhitespaceBody", func(t *testing.T) {
+		_, err := svc.CreateFieldNote(1, &contracts.CreateFieldNoteRequest{
+			ShowID: 1,
+			Body:   "   \n\t  ",
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "field note body is required")
+	})
+
+	t.Run("CreateFieldNote_TooLongBody", func(t *testing.T) {
+		longBody := make([]byte, models.MaxCommentBodyLength+1)
+		for i := range longBody {
+			longBody[i] = 'a'
+		}
+		_, err := svc.CreateFieldNote(1, &contracts.CreateFieldNoteRequest{
+			ShowID: 1,
+			Body:   string(longBody),
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "exceeds maximum length")
+	})
+}
+
+func TestFieldNote_RatingValidation(t *testing.T) {
+	svc := &CommentService{db: &gorm.DB{}}
+
+	t.Run("SoundQuality_Zero", func(t *testing.T) {
+		val := 0
+		_, err := svc.CreateFieldNote(1, &contracts.CreateFieldNoteRequest{
+			ShowID:       1,
+			Body:         "test note",
+			SoundQuality: &val,
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "sound_quality must be between 1 and 5")
+	})
+
+	t.Run("SoundQuality_Six", func(t *testing.T) {
+		val := 6
+		_, err := svc.CreateFieldNote(1, &contracts.CreateFieldNoteRequest{
+			ShowID:       1,
+			Body:         "test note",
+			SoundQuality: &val,
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "sound_quality must be between 1 and 5")
+	})
+
+	t.Run("SoundQuality_Negative", func(t *testing.T) {
+		val := -1
+		_, err := svc.CreateFieldNote(1, &contracts.CreateFieldNoteRequest{
+			ShowID:       1,
+			Body:         "test note",
+			SoundQuality: &val,
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "sound_quality must be between 1 and 5")
+	})
+
+	t.Run("CrowdEnergy_Zero", func(t *testing.T) {
+		val := 0
+		_, err := svc.CreateFieldNote(1, &contracts.CreateFieldNoteRequest{
+			ShowID:      1,
+			Body:        "test note",
+			CrowdEnergy: &val,
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "crowd_energy must be between 1 and 5")
+	})
+
+	t.Run("CrowdEnergy_Six", func(t *testing.T) {
+		val := 6
+		_, err := svc.CreateFieldNote(1, &contracts.CreateFieldNoteRequest{
+			ShowID:      1,
+			Body:        "test note",
+			CrowdEnergy: &val,
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "crowd_energy must be between 1 and 5")
+	})
+}
+
+// =============================================================================
+// INTEGRATION TESTS (With Real Database)
+// =============================================================================
+
+type FieldNoteIntegrationTestSuite struct {
+	suite.Suite
+	testDB         *testutil.TestDatabase
+	db             *gorm.DB
+	commentService *CommentService
+}
+
+func (suite *FieldNoteIntegrationTestSuite) SetupSuite() {
+	suite.testDB = testutil.SetupTestPostgres(suite.T())
+	suite.db = suite.testDB.DB
+	suite.commentService = NewCommentService(suite.testDB.DB)
+}
+
+func (suite *FieldNoteIntegrationTestSuite) TearDownSuite() {
+	suite.testDB.Cleanup()
+}
+
+func (suite *FieldNoteIntegrationTestSuite) TearDownTest() {
+	sqlDB, err := suite.db.DB()
+	suite.Require().NoError(err)
+	_, _ = sqlDB.Exec("DELETE FROM comment_subscriptions")
+	_, _ = sqlDB.Exec("DELETE FROM comment_votes")
+	_, _ = sqlDB.Exec("DELETE FROM comment_edits")
+	_, _ = sqlDB.Exec("DELETE FROM comments")
+	_, _ = sqlDB.Exec("DELETE FROM user_bookmarks")
+	_, _ = sqlDB.Exec("DELETE FROM show_artists")
+	_, _ = sqlDB.Exec("DELETE FROM shows")
+	_, _ = sqlDB.Exec("DELETE FROM artists")
+	_, _ = sqlDB.Exec("DELETE FROM venues")
+	_, _ = sqlDB.Exec("DELETE FROM users")
+}
+
+func TestFieldNoteIntegrationTestSuite(t *testing.T) {
+	suite.Run(t, new(FieldNoteIntegrationTestSuite))
+}
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+func (suite *FieldNoteIntegrationTestSuite) createTestUser() *models.User {
+	user := &models.User{
+		Email:         stringPtr(fmt.Sprintf("fn-user-%d@test.com", time.Now().UnixNano())),
+		Username:      stringPtr(fmt.Sprintf("fnuser%d", time.Now().UnixNano())),
+		FirstName:     stringPtr("Test"),
+		LastName:      stringPtr("User"),
+		IsActive:      true,
+		EmailVerified: true,
+		UserTier:      "contributor", // contributor tier auto-publishes comments
+	}
+	err := suite.db.Create(user).Error
+	suite.Require().NoError(err)
+	return user
+}
+
+func (suite *FieldNoteIntegrationTestSuite) createTestNewUser() *models.User {
+	user := &models.User{
+		Email:         stringPtr(fmt.Sprintf("fn-newuser-%d@test.com", time.Now().UnixNano())),
+		Username:      stringPtr(fmt.Sprintf("fnnewuser%d", time.Now().UnixNano())),
+		FirstName:     stringPtr("New"),
+		LastName:      stringPtr("User"),
+		IsActive:      true,
+		EmailVerified: true,
+		UserTier:      "new_user",
+	}
+	err := suite.db.Create(user).Error
+	suite.Require().NoError(err)
+	return user
+}
+
+func (suite *FieldNoteIntegrationTestSuite) createPastShow(title string, daysAgo int) uint {
+	slug := fmt.Sprintf("%s-%d", title, time.Now().UnixNano())
+	show := &models.Show{
+		Title:     title,
+		Slug:      &slug,
+		EventDate: time.Now().Add(-time.Duration(daysAgo) * 24 * time.Hour),
+		Status:    models.ShowStatusApproved,
+	}
+	err := suite.db.Create(show).Error
+	suite.Require().NoError(err)
+	return show.ID
+}
+
+func (suite *FieldNoteIntegrationTestSuite) createFutureShow(title string) uint {
+	slug := fmt.Sprintf("%s-%d", title, time.Now().UnixNano())
+	show := &models.Show{
+		Title:     title,
+		Slug:      &slug,
+		EventDate: time.Now().Add(7 * 24 * time.Hour),
+		Status:    models.ShowStatusApproved,
+	}
+	err := suite.db.Create(show).Error
+	suite.Require().NoError(err)
+	return show.ID
+}
+
+func (suite *FieldNoteIntegrationTestSuite) createTestArtist(name string) uint {
+	slug := fmt.Sprintf("%s-%d", name, time.Now().UnixNano())
+	artist := &models.Artist{
+		Name: name,
+		Slug: &slug,
+	}
+	err := suite.db.Create(artist).Error
+	suite.Require().NoError(err)
+	return artist.ID
+}
+
+func (suite *FieldNoteIntegrationTestSuite) addArtistToShow(showID, artistID uint, position int) {
+	sa := &models.ShowArtist{
+		ShowID:   showID,
+		ArtistID: artistID,
+		Position: position,
+		SetType:  "performer",
+	}
+	err := suite.db.Create(sa).Error
+	suite.Require().NoError(err)
+}
+
+func (suite *FieldNoteIntegrationTestSuite) markGoing(userID, showID uint, createdAt time.Time) {
+	bookmark := &models.UserBookmark{
+		UserID:     userID,
+		EntityType: models.BookmarkEntityShow,
+		EntityID:   showID,
+		Action:     models.BookmarkActionGoing,
+		CreatedAt:  createdAt,
+	}
+	err := suite.db.Create(bookmark).Error
+	suite.Require().NoError(err)
+}
+
+// insertFieldNote creates a field note directly in the DB, bypassing rate limiting.
+func (suite *FieldNoteIntegrationTestSuite) insertFieldNote(userID, showID uint, body string, sd *contracts.FieldNoteStructuredData) *models.Comment {
+	svc := suite.commentService
+	bodyHTML := svc.renderMarkdown(body)
+	comment := &models.Comment{
+		EntityType:      models.CommentEntityShow,
+		EntityID:        showID,
+		Kind:            models.CommentKindFieldNote,
+		UserID:          userID,
+		Body:            body,
+		BodyHTML:        bodyHTML,
+		Visibility:      models.CommentVisibilityVisible,
+		ReplyPermission: models.ReplyPermissionAnyone,
+	}
+	if sd != nil {
+		sdJSON, err := json.Marshal(sd)
+		suite.Require().NoError(err)
+		raw := json.RawMessage(sdJSON)
+		comment.StructuredData = &raw
+	}
+	err := suite.db.Create(comment).Error
+	suite.Require().NoError(err)
+	return comment
+}
+
+// =============================================================================
+// Group 1: CreateFieldNote — Basic CRUD
+// =============================================================================
+
+func (suite *FieldNoteIntegrationTestSuite) TestCreateFieldNote_AllFields() {
+	user := suite.createTestUser()
+	showID := suite.createPastShow("Test Show", 3)
+	artistID := suite.createTestArtist("Opener Band")
+	suite.addArtistToShow(showID, artistID, 0)
+
+	soundQuality := 4
+	crowdEnergy := 5
+	songPosition := 2
+	notableMoments := "Surprise cover of Ziggy Stardust"
+
+	fieldNote, err := suite.commentService.CreateFieldNote(user.ID, &contracts.CreateFieldNoteRequest{
+		ShowID:         showID,
+		Body:           "Incredible show tonight. **Best I've seen all year.**",
+		ShowArtistID:   &artistID,
+		SongPosition:   &songPosition,
+		SoundQuality:   &soundQuality,
+		CrowdEnergy:    &crowdEnergy,
+		NotableMoments: &notableMoments,
+		SetlistSpoiler: true,
+	})
+	suite.Require().NoError(err)
+	suite.NotZero(fieldNote.ID)
+	suite.Equal("show", fieldNote.EntityType)
+	suite.Equal(showID, fieldNote.EntityID)
+	suite.Equal("field_note", fieldNote.Kind)
+	suite.Equal(user.ID, fieldNote.UserID)
+	suite.Contains(fieldNote.BodyHTML, "<strong>")
+	suite.Equal("visible", fieldNote.Visibility)
+	suite.Equal(0, fieldNote.Depth)
+	suite.Nil(fieldNote.ParentID)
+	suite.Nil(fieldNote.RootID)
+
+	// Verify structured data
+	suite.NotNil(fieldNote.StructuredData)
+	var sd contracts.FieldNoteStructuredData
+	err = json.Unmarshal(*fieldNote.StructuredData, &sd)
+	suite.Require().NoError(err)
+	suite.Equal(&artistID, sd.ShowArtistID)
+	suite.Equal(&songPosition, sd.SongPosition)
+	suite.Equal(&soundQuality, sd.SoundQuality)
+	suite.Equal(&crowdEnergy, sd.CrowdEnergy)
+	suite.Equal(&notableMoments, sd.NotableMoments)
+	suite.True(sd.SetlistSpoiler)
+}
+
+func (suite *FieldNoteIntegrationTestSuite) TestCreateFieldNote_MinimalFields() {
+	user := suite.createTestUser()
+	showID := suite.createPastShow("Minimal Show", 1)
+
+	fieldNote, err := suite.commentService.CreateFieldNote(user.ID, &contracts.CreateFieldNoteRequest{
+		ShowID: showID,
+		Body:   "Just a brief note about the show.",
+	})
+	suite.Require().NoError(err)
+	suite.NotZero(fieldNote.ID)
+	suite.Equal("field_note", fieldNote.Kind)
+	suite.Equal("show", fieldNote.EntityType)
+
+	// Structured data should still be present but with nil optional fields
+	suite.NotNil(fieldNote.StructuredData)
+	var sd contracts.FieldNoteStructuredData
+	err = json.Unmarshal(*fieldNote.StructuredData, &sd)
+	suite.Require().NoError(err)
+	suite.Nil(sd.ShowArtistID)
+	suite.Nil(sd.SongPosition)
+	suite.Nil(sd.SoundQuality)
+	suite.Nil(sd.CrowdEnergy)
+	suite.Nil(sd.NotableMoments)
+	suite.False(sd.SetlistSpoiler)
+	suite.False(sd.IsVerifiedAttendee)
+}
+
+func (suite *FieldNoteIntegrationTestSuite) TestCreateFieldNote_MarkdownRendered() {
+	user := suite.createTestUser()
+	showID := suite.createPastShow("Markdown Show", 2)
+
+	fieldNote, err := suite.commentService.CreateFieldNote(user.ID, &contracts.CreateFieldNoteRequest{
+		ShowID: showID,
+		Body:   "**bold** and *italic*",
+	})
+	suite.Require().NoError(err)
+	suite.Contains(fieldNote.BodyHTML, "<strong>bold</strong>")
+	suite.Contains(fieldNote.BodyHTML, "<em>italic</em>")
+}
+
+// =============================================================================
+// Group 2: CreateFieldNote — Validation
+// =============================================================================
+
+func (suite *FieldNoteIntegrationTestSuite) TestCreateFieldNote_FutureShow_Rejected() {
+	user := suite.createTestUser()
+	showID := suite.createFutureShow("Future Show")
+
+	_, err := suite.commentService.CreateFieldNote(user.ID, &contracts.CreateFieldNoteRequest{
+		ShowID: showID,
+		Body:   "Can't post field notes for future shows.",
+	})
+	suite.Error(err)
+	suite.Contains(err.Error(), "field notes can only be added to past shows")
+}
+
+func (suite *FieldNoteIntegrationTestSuite) TestCreateFieldNote_ShowNotFound() {
+	user := suite.createTestUser()
+
+	_, err := suite.commentService.CreateFieldNote(user.ID, &contracts.CreateFieldNoteRequest{
+		ShowID: 999999,
+		Body:   "No such show.",
+	})
+	suite.Error(err)
+	suite.Contains(err.Error(), "show not found")
+}
+
+func (suite *FieldNoteIntegrationTestSuite) TestCreateFieldNote_ArtistNotOnShow() {
+	user := suite.createTestUser()
+	showID := suite.createPastShow("Artist Show", 2)
+	unrelatedArtistID := suite.createTestArtist("Unrelated Artist")
+
+	_, err := suite.commentService.CreateFieldNote(user.ID, &contracts.CreateFieldNoteRequest{
+		ShowID:       showID,
+		Body:         "About this artist...",
+		ShowArtistID: &unrelatedArtistID,
+	})
+	suite.Error(err)
+	suite.Contains(err.Error(), "artist is not on this show's bill")
+}
+
+func (suite *FieldNoteIntegrationTestSuite) TestCreateFieldNote_SoundQualityInvalid() {
+	user := suite.createTestUser()
+	showID := suite.createPastShow("Sound Show", 2)
+
+	zero := 0
+	_, err := suite.commentService.CreateFieldNote(user.ID, &contracts.CreateFieldNoteRequest{
+		ShowID:       showID,
+		Body:         "Bad sound quality value",
+		SoundQuality: &zero,
+	})
+	suite.Error(err)
+	suite.Contains(err.Error(), "sound_quality must be between 1 and 5")
+
+	six := 6
+	_, err = suite.commentService.CreateFieldNote(user.ID, &contracts.CreateFieldNoteRequest{
+		ShowID:       showID,
+		Body:         "Bad sound quality value",
+		SoundQuality: &six,
+	})
+	suite.Error(err)
+	suite.Contains(err.Error(), "sound_quality must be between 1 and 5")
+}
+
+func (suite *FieldNoteIntegrationTestSuite) TestCreateFieldNote_CrowdEnergyInvalid() {
+	user := suite.createTestUser()
+	showID := suite.createPastShow("Energy Show", 2)
+
+	zero := 0
+	_, err := suite.commentService.CreateFieldNote(user.ID, &contracts.CreateFieldNoteRequest{
+		ShowID:      showID,
+		Body:        "Bad crowd energy value",
+		CrowdEnergy: &zero,
+	})
+	suite.Error(err)
+	suite.Contains(err.Error(), "crowd_energy must be between 1 and 5")
+
+	six := 6
+	_, err = suite.commentService.CreateFieldNote(user.ID, &contracts.CreateFieldNoteRequest{
+		ShowID:      showID,
+		Body:        "Bad crowd energy value",
+		CrowdEnergy: &six,
+	})
+	suite.Error(err)
+	suite.Contains(err.Error(), "crowd_energy must be between 1 and 5")
+}
+
+func (suite *FieldNoteIntegrationTestSuite) TestCreateFieldNote_ValidSoundQualityRange() {
+	user := suite.createTestUser()
+
+	for _, val := range []int{1, 2, 3, 4, 5} {
+		showID := suite.createPastShow(fmt.Sprintf("SQ-%d", val), 2)
+		sq := val
+		fieldNote, err := suite.commentService.CreateFieldNote(user.ID, &contracts.CreateFieldNoteRequest{
+			ShowID:       showID,
+			Body:         fmt.Sprintf("Sound quality %d", val),
+			SoundQuality: &sq,
+		})
+		suite.Require().NoError(err, "sound_quality=%d should be valid", val)
+		suite.NotZero(fieldNote.ID)
+	}
+}
+
+// =============================================================================
+// Group 3: Verified Attendee Computation
+// =============================================================================
+
+func (suite *FieldNoteIntegrationTestSuite) TestCreateFieldNote_VerifiedAttendee_GoingBeforeShow() {
+	user := suite.createTestUser()
+	showID := suite.createPastShow("Past Show", 7)
+
+	// Mark going 10 days ago (before the show that was 7 days ago)
+	suite.markGoing(user.ID, showID, time.Now().Add(-10*24*time.Hour))
+
+	fieldNote, err := suite.commentService.CreateFieldNote(user.ID, &contracts.CreateFieldNoteRequest{
+		ShowID: showID,
+		Body:   "I was there!",
+	})
+	suite.Require().NoError(err)
+
+	var sd contracts.FieldNoteStructuredData
+	err = json.Unmarshal(*fieldNote.StructuredData, &sd)
+	suite.Require().NoError(err)
+	suite.True(sd.IsVerifiedAttendee, "user who marked going before the show should be verified")
+}
+
+func (suite *FieldNoteIntegrationTestSuite) TestCreateFieldNote_NotVerified_GoingAfterShow() {
+	user := suite.createTestUser()
+	showID := suite.createPastShow("Past Show After", 7)
+
+	// Mark going 2 days ago (AFTER the show that was 7 days ago)
+	suite.markGoing(user.ID, showID, time.Now().Add(-2*24*time.Hour))
+
+	fieldNote, err := suite.commentService.CreateFieldNote(user.ID, &contracts.CreateFieldNoteRequest{
+		ShowID: showID,
+		Body:   "I was definitely there (but marked it late).",
+	})
+	suite.Require().NoError(err)
+
+	var sd contracts.FieldNoteStructuredData
+	err = json.Unmarshal(*fieldNote.StructuredData, &sd)
+	suite.Require().NoError(err)
+	suite.False(sd.IsVerifiedAttendee, "user who marked going after the show should NOT be verified")
+}
+
+func (suite *FieldNoteIntegrationTestSuite) TestCreateFieldNote_NotVerified_NoGoingRecord() {
+	user := suite.createTestUser()
+	showID := suite.createPastShow("No Going Show", 5)
+
+	fieldNote, err := suite.commentService.CreateFieldNote(user.ID, &contracts.CreateFieldNoteRequest{
+		ShowID: showID,
+		Body:   "I was there but never marked going.",
+	})
+	suite.Require().NoError(err)
+
+	var sd contracts.FieldNoteStructuredData
+	err = json.Unmarshal(*fieldNote.StructuredData, &sd)
+	suite.Require().NoError(err)
+	suite.False(sd.IsVerifiedAttendee, "user with no going record should NOT be verified")
+}
+
+func (suite *FieldNoteIntegrationTestSuite) TestCreateFieldNote_NotVerified_InterestedOnly() {
+	user := suite.createTestUser()
+	showID := suite.createPastShow("Interested Show", 5)
+
+	// Mark interested (not going) before the show
+	bookmark := &models.UserBookmark{
+		UserID:     user.ID,
+		EntityType: models.BookmarkEntityShow,
+		EntityID:   showID,
+		Action:     models.BookmarkActionInterested,
+		CreatedAt:  time.Now().Add(-10 * 24 * time.Hour),
+	}
+	err := suite.db.Create(bookmark).Error
+	suite.Require().NoError(err)
+
+	fieldNote, err := suite.commentService.CreateFieldNote(user.ID, &contracts.CreateFieldNoteRequest{
+		ShowID: showID,
+		Body:   "Interested only, not going.",
+	})
+	suite.Require().NoError(err)
+
+	var sd contracts.FieldNoteStructuredData
+	err = json.Unmarshal(*fieldNote.StructuredData, &sd)
+	suite.Require().NoError(err)
+	suite.False(sd.IsVerifiedAttendee, "user who only marked interested (not going) should NOT be verified")
+}
+
+// =============================================================================
+// Group 4: ListFieldNotesForShow
+// =============================================================================
+
+func (suite *FieldNoteIntegrationTestSuite) TestListFieldNotesForShow_Basic() {
+	user := suite.createTestUser()
+	showID := suite.createPastShow("List Show", 2)
+
+	suite.insertFieldNote(user.ID, showID, "First note", nil)
+	suite.insertFieldNote(user.ID, showID, "Second note", nil)
+
+	result, err := suite.commentService.ListFieldNotesForShow(showID, 20, 0)
+	suite.Require().NoError(err)
+	suite.Equal(int64(2), result.Total)
+	suite.Len(result.Comments, 2)
+	suite.False(result.HasMore)
+}
+
+func (suite *FieldNoteIntegrationTestSuite) TestListFieldNotesForShow_SortedBySongPosition() {
+	user := suite.createTestUser()
+	showID := suite.createPastShow("Sorted Show", 2)
+
+	// Insert field notes with varying song positions and no position (NULL)
+	pos3 := 3
+	pos1 := 1
+	suite.insertFieldNote(user.ID, showID, "Song at position 3", &contracts.FieldNoteStructuredData{SongPosition: &pos3})
+	suite.insertFieldNote(user.ID, showID, "Show-wide note (no position)", nil)
+	suite.insertFieldNote(user.ID, showID, "Song at position 1", &contracts.FieldNoteStructuredData{SongPosition: &pos1})
+
+	result, err := suite.commentService.ListFieldNotesForShow(showID, 20, 0)
+	suite.Require().NoError(err)
+	suite.Len(result.Comments, 3)
+
+	// NULLs first (show-wide notes), then position 1, then position 3
+	suite.Equal("Show-wide note (no position)", result.Comments[0].Body)
+	suite.Equal("Song at position 1", result.Comments[1].Body)
+	suite.Equal("Song at position 3", result.Comments[2].Body)
+}
+
+func (suite *FieldNoteIntegrationTestSuite) TestListFieldNotesForShow_OnlyFieldNotes() {
+	user := suite.createTestUser()
+	showID := suite.createPastShow("Mixed Show", 2)
+
+	// Insert a regular comment (not a field note)
+	svc := suite.commentService
+	bodyHTML := svc.renderMarkdown("Regular comment")
+	regularComment := &models.Comment{
+		EntityType:      models.CommentEntityShow,
+		EntityID:        showID,
+		Kind:            models.CommentKindComment,
+		UserID:          user.ID,
+		Body:            "Regular comment",
+		BodyHTML:        bodyHTML,
+		Visibility:      models.CommentVisibilityVisible,
+		ReplyPermission: models.ReplyPermissionAnyone,
+	}
+	err := suite.db.Create(regularComment).Error
+	suite.Require().NoError(err)
+
+	// Insert a field note
+	suite.insertFieldNote(user.ID, showID, "This is a field note", nil)
+
+	result, err := suite.commentService.ListFieldNotesForShow(showID, 20, 0)
+	suite.Require().NoError(err)
+	suite.Equal(int64(1), result.Total)
+	suite.Len(result.Comments, 1)
+	suite.Equal("field_note", result.Comments[0].Kind)
+	suite.Equal("This is a field note", result.Comments[0].Body)
+}
+
+func (suite *FieldNoteIntegrationTestSuite) TestListFieldNotesForShow_ExcludesHiddenNotes() {
+	user := suite.createTestUser()
+	showID := suite.createPastShow("Hidden Show", 2)
+
+	// Insert a visible field note
+	suite.insertFieldNote(user.ID, showID, "Visible note", nil)
+
+	// Insert a hidden field note directly
+	svc := suite.commentService
+	bodyHTML := svc.renderMarkdown("Hidden note")
+	hidden := &models.Comment{
+		EntityType:      models.CommentEntityShow,
+		EntityID:        showID,
+		Kind:            models.CommentKindFieldNote,
+		UserID:          user.ID,
+		Body:            "Hidden note",
+		BodyHTML:        bodyHTML,
+		Visibility:      models.CommentVisibilityHiddenByMod,
+		ReplyPermission: models.ReplyPermissionAnyone,
+	}
+	err := suite.db.Create(hidden).Error
+	suite.Require().NoError(err)
+
+	result, err := suite.commentService.ListFieldNotesForShow(showID, 20, 0)
+	suite.Require().NoError(err)
+	suite.Equal(int64(1), result.Total)
+	suite.Len(result.Comments, 1)
+	suite.Equal("Visible note", result.Comments[0].Body)
+}
+
+func (suite *FieldNoteIntegrationTestSuite) TestListFieldNotesForShow_Pagination() {
+	user := suite.createTestUser()
+	showID := suite.createPastShow("Paginated Show", 2)
+
+	// Insert 5 field notes
+	for i := 0; i < 5; i++ {
+		suite.insertFieldNote(user.ID, showID, fmt.Sprintf("Note %d", i), nil)
+	}
+
+	// Page 1: limit 2, offset 0
+	result, err := suite.commentService.ListFieldNotesForShow(showID, 2, 0)
+	suite.Require().NoError(err)
+	suite.Equal(int64(5), result.Total)
+	suite.Len(result.Comments, 2)
+	suite.True(result.HasMore)
+
+	// Page 3: limit 2, offset 4 (should have 1 item)
+	result, err = suite.commentService.ListFieldNotesForShow(showID, 2, 4)
+	suite.Require().NoError(err)
+	suite.Equal(int64(5), result.Total)
+	suite.Len(result.Comments, 1)
+	suite.False(result.HasMore)
+}
+
+func (suite *FieldNoteIntegrationTestSuite) TestListFieldNotesForShow_EmptyShow() {
+	showID := suite.createPastShow("Empty Show", 2)
+
+	result, err := suite.commentService.ListFieldNotesForShow(showID, 20, 0)
+	suite.Require().NoError(err)
+	suite.Equal(int64(0), result.Total)
+	suite.Len(result.Comments, 0)
+	suite.False(result.HasMore)
+}
+
+func (suite *FieldNoteIntegrationTestSuite) TestListFieldNotesForShow_StructuredDataPreserved() {
+	user := suite.createTestUser()
+	showID := suite.createPastShow("SD Show", 2)
+
+	sq := 4
+	ce := 5
+	moments := "Epic guitar solo"
+	suite.insertFieldNote(user.ID, showID, "Note with SD", &contracts.FieldNoteStructuredData{
+		SoundQuality:       &sq,
+		CrowdEnergy:        &ce,
+		NotableMoments:     &moments,
+		SetlistSpoiler:     true,
+		IsVerifiedAttendee: true,
+	})
+
+	result, err := suite.commentService.ListFieldNotesForShow(showID, 20, 0)
+	suite.Require().NoError(err)
+	suite.Require().Len(result.Comments, 1)
+	suite.NotNil(result.Comments[0].StructuredData)
+
+	var sd contracts.FieldNoteStructuredData
+	err = json.Unmarshal(*result.Comments[0].StructuredData, &sd)
+	suite.Require().NoError(err)
+	suite.Equal(&sq, sd.SoundQuality)
+	suite.Equal(&ce, sd.CrowdEnergy)
+	suite.Require().NotNil(sd.NotableMoments)
+	suite.Equal(moments, *sd.NotableMoments)
+	suite.True(sd.SetlistSpoiler)
+	suite.True(sd.IsVerifiedAttendee)
+}
+
+// =============================================================================
+// Group 5: Trust Tier / Visibility
+// =============================================================================
+
+func (suite *FieldNoteIntegrationTestSuite) TestCreateFieldNote_NewUser_PendingReview() {
+	user := suite.createTestNewUser()
+	showID := suite.createPastShow("New User Show", 2)
+
+	fieldNote, err := suite.commentService.CreateFieldNote(user.ID, &contracts.CreateFieldNoteRequest{
+		ShowID: showID,
+		Body:   "New user field note",
+	})
+	suite.Require().NoError(err)
+	suite.Equal("pending_review", fieldNote.Visibility)
+}
+
+func (suite *FieldNoteIntegrationTestSuite) TestCreateFieldNote_Contributor_Visible() {
+	user := suite.createTestUser() // contributor tier
+	showID := suite.createPastShow("Contributor Show", 2)
+
+	fieldNote, err := suite.commentService.CreateFieldNote(user.ID, &contracts.CreateFieldNoteRequest{
+		ShowID: showID,
+		Body:   "Contributor field note",
+	})
+	suite.Require().NoError(err)
+	suite.Equal("visible", fieldNote.Visibility)
+}
+
+// =============================================================================
+// Group 6: Auto-Subscribe
+// =============================================================================
+
+func (suite *FieldNoteIntegrationTestSuite) TestCreateFieldNote_AutoSubscribes() {
+	user := suite.createTestUser()
+	showID := suite.createPastShow("Subscribe Show", 2)
+
+	_, err := suite.commentService.CreateFieldNote(user.ID, &contracts.CreateFieldNoteRequest{
+		ShowID: showID,
+		Body:   "Should auto-subscribe",
+	})
+	suite.Require().NoError(err)
+
+	// Verify the subscription was created
+	var sub models.CommentSubscription
+	err = suite.db.Where("user_id = ? AND entity_type = ? AND entity_id = ?",
+		user.ID, "show", showID).First(&sub).Error
+	suite.Require().NoError(err)
+	suite.Equal(user.ID, sub.UserID)
+}

--- a/backend/internal/services/engagement/interfaces.go
+++ b/backend/internal/services/engagement/interfaces.go
@@ -13,6 +13,7 @@ var (
 	_ contracts.FollowServiceInterface        = (*FollowService)(nil)
 	_ contracts.CommentServiceInterface              = (*CommentService)(nil)
 	_ contracts.CommentAdminServiceInterface         = (*CommentService)(nil)
+	_ contracts.FieldNoteServiceInterface            = (*CommentService)(nil)
 	_ contracts.CommentVoteServiceInterface          = (*CommentVoteService)(nil)
 	_ contracts.CommentSubscriptionServiceInterface  = (*CommentSubscriptionService)(nil)
 )


### PR DESCRIPTION
## Summary

PH's unique differentiator — structured attendee reflections on live shows, built as a specialized comment subtype.

### Service Methods
- **CreateFieldNote** — validates body, rating ranges (1-5), post-event gating (rejects future shows), artist-on-bill check, verified attendee computation (had "going" status before show date), markdown rendering, trust-tier visibility, rate limiting, auto-subscribe
- **ListFieldNotesForShow** — sorted by song_position ASC (NULLs first), then Wilson score DESC within same position

### Verified Attendee
- Queries user_bookmarks for "going" action on the show
- Verified = bookmark created_at < show event_date
- Cached in structured_data.is_verified_attendee

### 2 Endpoints
- `POST /shows/{id}/field-notes` (protected) — create with structured metadata
- `GET /shows/{id}/field-notes` (public) — list with position-based sort

### structured_data JSONB
```json
{
  "show_artist_id": 42,
  "song_position": 7,
  "sound_quality": 4,
  "crowd_energy": 5,
  "notable_moments": "Played 3 new songs",
  "setlist_spoiler": true,
  "is_verified_attendee": true
}
```

### 53 tests (all backend tests pass)
- 11 unit (validation, nil DB)
- 24 integration (all fields, minimal, future show, verified attendee, sorting, pagination, trust tier)
- 16 handler (auth, validation, rate limit, success paths)

Closes PSY-294

🤖 Generated with [Claude Code](https://claude.com/claude-code)