### PR TITLE
Documentation overhaul: status headers, feature registry, stale fixes

### DIFF
--- a/docs/learnings/ux-gap-analysis.md
+++ b/docs/learnings/ux-gap-analysis.md
@@ -1,0 +1,265 @@
+# UX Gap Analysis — April 2026
+
+> **PARTIALLY STALE (as of April 11, 2026).** Items #1 (comments) and #2 (field notes) from the Tier 1 priority list are now SHIPPED. Collections UX overhaul also shipped. Re-read with that context — many "PH today: not built" claims are now outdated.
+>
+> Comparison of PH's current implementation against proven UX patterns from What.cd/Gazelle, Discogs, Bandcamp, RYM, Setlist.fm, and fandom communities.
+
+## Reference Sources
+
+- **What.cd / Gazelle**: `docs/learnings/gazelle-patterns.md`, `gazelle-user-profiles.md`, `whatcd-user-insights.md`
+- **Discogs**: Master release → versions model, submission guidelines, credit roles, physical format detail
+- **Bandcamp**: Direct artist support, fan collections as social proof, editorial curation (Bandcamp Daily)
+- **RYM (Rate Your Music)**: Community ratings/reviews, user lists, genre classification depth
+- **Setlist.fm**: Structured setlist data, attendee contributions
+
+## Tier 1 — Core Moat Gaps
+
+Features whose absence prevents PH from being *the* authoritative source of truth.
+
+### 1. Edition-Level Release Provenance
+
+**What it is:** A release (e.g., "OK Computer") has multiple editions — original 1997 Parlophone CD, 2017 OKNOTOK remaster, Japanese bonus-track pressing, vinyl reissue. Each edition has distinct: label, catalog number, country, format (CD/LP/digital), year, mastering notes, barcode.
+
+**Who does it well:**
+- What.cd: The Oxygène screenshot shows 14+ editions with full metadata. Users could answer "which remaster sounds best?" — the core use case.
+- Discogs: Master release → versions model. Each version has label, format, country, year, barcode, tracklist variations.
+- MusicBrainz: Release group → releases → mediums → tracks hierarchy.
+
+**PH today:** `Release` is a flat entity — one row per release with single `release_type`, `release_year`, `cover_art_url`. No editions, no catalog numbers, no format detail, no pressing variations.
+
+**Impact:** Without this, PH's release pages are thinner than MusicBrainz. Users can't answer "which version should I buy?" — the question that made What.cd indispensable. Radio plays and show setlists link to a single release entity when the *specific edition* matters for provenance.
+
+**Design considerations:**
+- Add `release_editions` table: release_id, label_id, catalog_number, country, format, year, mastering_notes, barcode, cover_art_url
+- External links (Bandcamp, Spotify, etc.) belong on editions, not releases
+- Matching engine (radio plays) should prefer edition-level links when MusicBrainz release ID is available
+- Migration path: existing releases become the "master" entity; first edition auto-created from current data
+
+### 2. Show Field Notes
+
+**What it is:** Structured qualitative observations from show attendees. Not star ratings — experiential data. "Sound was incredible from the balcony," "they played 3 unreleased songs," "opened with a 20-minute improv," "the opener stole the show."
+
+**Who does it well:** Nobody does this well. Setlist.fm has setlists but not experiential notes. Concert review blogs exist but aren't structured or community-contributed. This is PH's unique contribution.
+
+**PH today:** Not designed. Listed in Phase 3 roadmap as "design as first entity comment type" but no design doc exists. The `Show` model has no comments, notes, or review infrastructure.
+
+**Impact:** Live show intelligence is PH's differentiator. Without field notes, show pages are calendar listings with artist lineups — the same as Bandsintown. Field notes make PH *the* place to understand what the live experience is actually like.
+
+**Design considerations:**
+- Build on top of a polymorphic comment/discussion system (see gap #3)
+- Structured fields beyond freeform text: sound_quality (1-5), crowd_energy (1-5), notable_moments (freeform), personal_highlights (freeform)
+- Visibility: only after show date has passed (no pre-show speculation)
+- Trust-tiered: new users' notes go through moderation; trusted contributors publish immediately
+- Attendee verification: stronger signal if user marked "going" beforehand
+
+### 3. Comments / Discussion on Entities
+
+**What it is:** Threaded discussion attached to any entity — shows, releases, artists, collections, radio episodes. The substrate for community knowledge exchange.
+
+**Who does it well:**
+- Gazelle: Threaded comments on every torrent, collage, and artist page. Comment subscriptions for notifications.
+- Discogs: Reviews on releases. Community discussion on submissions.
+- RYM: Reviews and discussion threads on albums and artists.
+- Reddit/forums: General discussion, but not entity-attached.
+
+**PH today:** Zero discussion infrastructure. No comments on any entity type. The `features/` modules have no comment components. No `comments` table in the data model.
+
+**Impact:** Community knowledge lives in discussion. Without comments, PH is a catalog, not a community. Users can't discuss "is this the right artist?" on an artist page, can't share opinions on releases, can't discuss show experiences. This is the biggest missing social feature.
+
+**Design considerations:**
+- Polymorphic `comments` table: user_id, entity_type, entity_id, parent_id (threading), body (markdown), created_at
+- Comment subscriptions: notify users when new comments appear on entities they follow
+- Moderation: trust-tiered (new users moderated, trusted contributors auto-publish), report button, admin delete
+- Show field notes as a specialized comment type with structured metadata
+- Rate limiting and spam prevention
+
+### 4. User Ratings and Reviews
+
+**What it is:** Community-sourced quality signals on releases and shows. Star ratings, short reviews, aggregate scores.
+
+**Who does it well:**
+- RYM: 0.5–5.0 star ratings with written reviews. Aggregate scores drive discovery ("top albums of 2025").
+- Gazelle: Star ratings on torrents.
+- Bandcamp: Implicit ratings via purchases and collections.
+- Discogs: 1–5 star ratings with reviews.
+
+**PH today:** Wilson-scored voting on tags and requests. No rating/review system for releases, shows, artists, or any other entity.
+
+**Impact:** Discovery through community taste is unbuilt. Users can browse by tag, by relationship graph, by radio co-occurrence — but not by "what do people think is good?" Ratings power charts, recommendations, and the "wisdom of crowds" discovery path.
+
+**Design considerations:**
+- `entity_ratings` table: user_id, entity_type, entity_id, rating (0.5-5.0 scale, half-stars), review_text (optional), created_at
+- Aggregate scores: weighted average displayed on entity pages, updated on write
+- Release ratings: the highest-value target (maps to RYM/What.cd core pattern)
+- Show ratings: post-event only, complementary to field notes
+- Charts integration: "highest rated releases this month" alongside existing trending/popular charts
+- Wilson score for ranking with low vote counts
+
+## Tier 2 — Identity & Engagement Gaps
+
+Features that deepen contributor attachment and long-term retention.
+
+### 5. "Your Impact" Metrics
+
+**What it is:** Showing contributors the downstream effect of their work. Not just "you made 50 edits" but "artists you added have been viewed 12,000 times this month."
+
+**Who does it well:**
+- Gazelle: "Your uploads have been snatched N times" on profiles.
+- Wikipedia: Edit count + article view counts for pages you've edited.
+- GitHub: Contribution graph + "used by N repositories."
+
+**PH today:** 23 contribution stat types — all input metrics (edits, tags voted, reports filed). Zero output metrics showing the impact of those contributions.
+
+**Impact:** The What.cd user insight research found that contributor identity attachment ("part of me died when it shut down") is the strongest retention signal. Impact metrics make abstract contributions feel tangible.
+
+**Design considerations:**
+- Compute periodically (daily): total views on entities the user created/edited, total followers on artists they added, total saves on shows they submitted
+- Display on contributor profile alongside existing stats
+- "Your artists have been viewed 5,200 times this month" — simple, motivating
+
+### 6. Knowledge Graph Export / Data Survivability
+
+**What it is:** An explicit promise and mechanism for community-contributed data to survive. Downloadable exports in standard formats.
+
+**Who does it well:**
+- MusicBrainz: Full database dumps (weekly), JSON-LD API, CC0 licensing.
+- Wikipedia: Full dumps, open license.
+- Discogs: Monthly data dumps (XML/CSV), CC0 for user-contributed data.
+
+**PH today:** GDPR user data export exists. No knowledge graph export. No licensing model for community-contributed data. No design doc.
+
+**Impact:** The What.cd user insights doc ends with: "The treasure is still out there — we have merely lost the map." PH must explicitly address data survivability to earn trust from power contributors. Without it, contributors who remember What.cd will hold back.
+
+**Design considerations:**
+- Export formats: JSON-LD (linked data standard), CSV (spreadsheet-friendly), PostgreSQL dump (developer-friendly)
+- Licensing: CC0 for community-contributed facts (artist names, show dates, setlists). CC-BY for editorial content (reviews, field notes).
+- Frequency: Weekly automated dumps, on-demand via API
+- Scope: All public entity data, relationships, tags, aggregate ratings. Exclude: user accounts, private data, API tokens.
+
+### 7. Ranked Lists
+
+**What it is:** User-created ordered lists. "My top 50 albums of 2025," "Best live shows I've seen," "Essential shoegaze EPs."
+
+**Who does it well:**
+- RYM: User lists are a primary discovery feature. "Top albums of [year]" aggregate lists drive traffic.
+- Letterboxd: Film lists with rankings, descriptions, social sharing.
+- Gazelle: Collages (unranked collections) — PH already has this equivalent.
+
+**PH today:** Collections (crates) exist with full CRUD, items, subscriptions. But items are unordered sets — no position/ranking. No "list" concept distinct from "collection."
+
+**Impact:** Lists are the primary shareable artifact for music communities. "My top 10 of the year" posts drive social media traffic and discovery. An ordered collection is a trivial extension of the existing system.
+
+**Design considerations:**
+- Add `position` field to `collection_items` (nullable — unordered collections remain valid)
+- UI: drag-and-drop reordering, numbered display for ranked lists
+- New collection type flag: `is_ranked` boolean
+- Aggregate lists: "Community top albums of 2025" computed from individual user lists (like RYM's aggregate charts)
+
+## Tier 3 — Discovery Depth Gaps
+
+Features that make the knowledge graph richer and more interconnected.
+
+### 8. Structured Setlists
+
+**What it is:** Per-song data for a show's set — song title linked to release, position in set, encore flag, guest performers, cover song attribution.
+
+**Who does it well:**
+- Setlist.fm: Core feature. Community-contributed setlists for millions of shows.
+- Songkick (defunct): Had setlist data integration.
+
+**PH today:** `Show` model has a `set_list` text field — freeform, unstructured. No linking songs to releases in the knowledge graph. Radio plays already link tracks to artists/releases, but show setlists don't.
+
+**Impact:** Setlists close the loop between live shows and recorded music. "They played 3 songs from their new album" → links show → release → label. Also enables: "how often does this artist play this song live?", "what's their most common opener?", fan-favorite deep cuts.
+
+**Design considerations:**
+- `setlist_items` table: show_id, position, song_title, release_id (nullable), is_encore, is_cover, cover_original_artist_id, notes
+- Community-contributed: attendees add/edit setlists post-show
+- Trust-tiered like other edits
+- Integration with radio plays: if a radio play matches a setlist item, cross-link
+
+### 9. Musician Entity / Scene Family Tree
+
+**What it is:** Tracking individual musicians across multiple bands over time. "Dave Grohl: Nirvana (1990-1994) → Foo Fighters (1994-present) → Them Crooked Vultures (2009-2010)."
+
+**Who does it well:**
+- MusicBrainz: Full artist → member relationships with date ranges.
+- Discogs: Credits at track level include personnel.
+- AllMusic: Band member timelines.
+
+**PH today:** `artist_relationships` has a `member_of` type but no date ranges, no individual musician entity. Artists are bands/projects, not people.
+
+**Impact:** Local scene intelligence — "these 3 bands share a drummer" — is a discovery path unique to PH's live show data. Currently unmapped.
+
+**Design considerations:**
+- `musicians` table: name, slug, instruments, bio
+- `musician_memberships`: musician_id, artist_id, role (guitar/vocals/drums), start_date, end_date, is_active
+- Discovery: "Other bands with members of [artist]" sidebar section
+- Scene family tree visualization: network graph of musicians across bands
+
+### 10. Promoter Entity
+
+**What it is:** The booking agents and promotion companies that organize shows. Maps the business relationships that determine which artists play which venues.
+
+**PH today:** Not modeled. Shows have venues and artists but no promoter attribution.
+
+**Design considerations:**
+- `promoters` table: name, slug, city, state, website, social
+- `show_promoters` junction: show_id, promoter_id
+- Discovery: "Shows by [promoter]", "Venues where [promoter] books", "Artists [promoter] works with"
+- Professional audience: venue managers, booking agents, artists seeking gigs
+
+### 11. Multi-Image Galleries
+
+**What it is:** Multiple community-contributed images per entity — show flyers, venue photos, release artwork variants, festival posters.
+
+**Who does it well:**
+- Discogs: 10+ images per release (front, back, inner sleeve, disc, matrix).
+- Gazelle: Multiple cover images per torrent group.
+
+**PH today:** Single `cover_art_url`/`logo_url` fields on entities. No gallery infrastructure.
+
+**Design considerations:**
+- `entity_images` table: entity_type, entity_id, url, caption, uploaded_by, position, is_primary
+- Community-contributed with moderation
+- Show flyers are particularly valuable — ephemeral artifacts that PH could preserve
+
+## Tier 4 — Engagement Mechanics
+
+Proven patterns not yet applied.
+
+### 12. Collection "New Since Last Visit"
+
+Gazelle showed unread counts on subscribed collages. PH collections have subscriptions but no "new items since you last viewed" indicator. Cheap engagement driver — a badge count on the sidebar.
+
+### 13. Comment/Discussion Subscriptions
+
+When comments ship (gap #3), users need subscription notifications. Gazelle's polymorphic `users_subscriptions_comments` pattern is documented in learnings but not implemented.
+
+### 14. Artist Opt-Out Mechanism
+
+A "do not list" mechanism for artists who request removal. Important for trust-building as PH grows. Staff-maintained exclusion list.
+
+### 15. Editorial Curation Framework
+
+Bandcamp Daily-style featured content — staff picks, themed collections, artist spotlights. PH has a blog feature but no structured editorial framework for surfacing community-curated content.
+
+## What PH Already Exceeds
+
+Areas where PH is ahead of all reference sites:
+
+- **Community contribution infrastructure**: Trust tiers, pending edits, auto-promotion, entity reports, unified moderation — more sophisticated than any reference
+- **Radio integration**: 3 providers, matching engine, co-occurrence → artist similarity — no reference site has this
+- **AI-first data pipeline**: Automated venue calendar extraction — unique to PH
+- **Show-centric knowledge graph**: Live shows as first-class discovery gateway — no reference does this
+- **Tag voting with Wilson score**: Matches Gazelle quality, better than Discogs/RYM
+
+## Recommended Priority Order
+
+1. **Comments/discussion** — prerequisite for #2 and #4, the missing social substrate
+2. **Show field notes** — PH's unique contribution, built on comments
+3. **Edition-level releases** — the What.cd depth that makes PH authoritative for recorded music
+4. **Ratings on releases and shows** — unlock discovery-by-taste
+5. **"Your impact" metrics** — cheap, high-ROI contributor retention
+6. **Ranked lists** — trivial extension of existing collections, high shareability
+7. **Knowledge graph export** — trust-building, data survivability promise
+8. **Structured setlists** — close the live→recorded loop

--- a/docs/llm-context.md
+++ b/docs/llm-context.md
@@ -46,33 +46,48 @@ See `docs/vision.md` for the full north star, What.cd feature mapping, and entit
 - **Radio:** PSY-279 (provider `until` parameter), execute data cleanup runbook
 - **Strategic:** UX gap analysis priorities — edition-level release provenance, ratings, "your impact" metrics, ranked lists, knowledge graph export, structured setlists
 
+## Feature Registry
+
+> Single source of truth for what each feature can actually do. Verified April 11, 2026. If you're unsure whether something works, check here before assuming a Linear "completed" status is accurate.
+
+| Feature | Core User Workflow | Known Gaps |
+|---------|-------------------|------------|
+| **Shows** | Browse, filter by city, detail page, going/interested, save, share | — |
+| **Artists** | Browse, detail with discography/shows/relationships, follow | — |
+| **Venues** | Browse, detail with upcoming shows/genre profile, favorite | — |
+| **Releases** | Browse, detail with artist roles/external links | — |
+| **Labels** | Browse, detail with roster/catalog | — |
+| **Festivals** | Browse, detail with lineup/overlap analysis | — |
+| **Collections** | Create, add/remove items, reorder, per-item notes, browse with tabs/search, entity backlinks, user profile tab, share | No cover art, no clone, "Crate" terminology in activity feed (PSY-319) |
+| **Comments** | Create on 7 entity types, vote (Wilson score), reply (3 levels), edit with history, soft delete, subscribe with auto-subscribe | No radio episode comments, no notifications (PSY-289), no per-author reply permissions (PSY-296) |
+| **Field Notes** | Create on past shows, star ratings (sound/crowd), verified attendee badge, spoiler handling, position sort | — |
+| **Comment Moderation** | Trust-tier publishing, rate limiting, admin hide/restore/approve/reject, pending queue, auto-hide on 3+ reports, entity reports for comments | No edit history viewer (PSY-297) |
+| **Tags** | Browse tag pages, view entities by tag | **NEEDS VERIFICATION** — was marked "completed" but may have UX gaps like Collections did |
+| **Scenes** | Browse, detail with venue/artist/show listings | — |
+| **Charts** | Trending shows, popular artists, active venues, hot releases | — |
+| **Radio** | 3 stations, shows, episodes, playlists, "As Heard On" | Provider bugs fixed but existing DB data needs cleanup (see runbook). Historical import infrastructure built but not yet executed. |
+| **Requests** | Browse, create, vote | **NEEDS VERIFICATION** |
+| **Contributions** | Entity edit drawer, pending edits, attribution, reports, moderation queue, trust tiers, leaderboard, contribution prompts | — |
+| **Admin** | Dashboard, entity CRUD, moderation queue, analytics backend, radio management, comment moderation | Admin nav has too many horizontal tabs requiring scrolling — **known UX issue** |
+| **Library** | Saved shows/artists/venues/releases/labels/festivals tabs | — |
+| **Auth** | Email/password, magic link, OAuth (Google/GitHub), passkeys | — |
+
 ## Task Routing
 
-
-| If your task involves...                                                       | Read these docs                                              |
-| ------------------------------------------------------------------------------ | ------------------------------------------------------------ |
-| Product vision, new entities, strategic direction                              | `docs/vision.md`                                             |
-| What to build next, quarterly priorities                                       | `docs/strategy/ROADMAP.md`                                   |
-| Frontend UI redesign (sidebar, layout, cards, templates)                       | `docs/strategy/ui-redesign.md`                               |
-| Frontend form patterns, component conventions, query patterns                  | `docs/learnings/frontend-patterns.md`                        |
-| Web frontend or Go backend features                                            | `docs/strategy/web.md`                                       |
-| iOS app                                                                        | `docs/strategy/ios.md` + `docs/learnings/ios.md`             |
-| Discovery scrapers or data pipeline                                            | `docs/strategy/discovery.md` + `docs/learnings/discovery.md` |
-| Backend architecture, conventions, test patterns                               | `CLAUDE.md` (Architecture section)                           |
-| Scene pages, venue intelligence, city landing pages                            | `docs/strategy/scene-pages.md`                               |
-| Similar artist visualization, relationship graph, artist voting                | `docs/strategy/similar-artists.md`                           |
-| Notification filters, matching engine, multi-channel notifications             | `docs/strategy/notification-filters.md`                      |
-| Comments, discussion, field notes, voting, subscriptions, moderation           | `docs/strategy/comments-and-field-notes.md`                  |
-| Collections UX, curated lists, prior-art patterns                              | `docs/learnings/curated-list-prior-art.md`                   |
-| Radio stations, radio shows, playlist parsing, "as heard on", co-occurrence    | `docs/strategy/radio-entities.md`                            |
-| Radio data cleanup, re-import after provider fixes                             | `docs/learnings/radio-data-cleanup-runbook.md`               |
-| Radio provider backfill capabilities, API limits, historical data              | `docs/learnings/radio-provider-backfill-audit.md`            |
-| Festival intelligence, lineup overlap, breakout tracking, circuit analysis     | `docs/strategy/festival-intelligence.md`                     |
-| Gazelle/What.cd implementation patterns (voting, tags, notifications, privacy) | `docs/learnings/gazelle-patterns.md`                         |
-| Gazelle user profiles (identity hub, paranoia, ranks, customization, donors)   | `docs/learnings/gazelle-user-profiles.md`                    |
-| What.cd user psychology, contributor motivation, product-market fit lessons     | `docs/learnings/whatcd-user-insights.md`                     |
-| Agent workflow, Linear issues, PR process                                      | `docs/agent-workflow.md`                                     |
-| Dogfooding, QA testing, user journey catalog                                   | `docs/user-journeys.md`                                     |
+| If your task involves... | Read these docs |
+|--------------------------|-----------------|
+| Product vision, strategic direction | `docs/vision.md`, `docs/strategy/ROADMAP.md` |
+| Backend architecture, conventions, test patterns | `CLAUDE.md` (Architecture section) |
+| Comments, discussion, field notes, moderation | `docs/strategy/comments-and-field-notes.md` |
+| Collections UX, curated lists, prior art | `docs/learnings/curated-list-prior-art.md` |
+| Radio entities, providers, backfill | `docs/strategy/radio-entities.md`, `docs/learnings/radio-provider-backfill-audit.md` |
+| Discovery pipeline, scrapers | `docs/strategy/discovery.md`, `docs/learnings/discovery.md` |
+| Frontend patterns, form conventions | `docs/learnings/frontend-patterns.md` |
+| Gazelle/What.cd patterns | `docs/learnings/gazelle-patterns.md`, `gazelle-user-profiles.md`, `whatcd-user-insights.md` |
+| Agent workflow, Linear, PRs | `docs/agent-workflow.md` |
+| Dogfooding, QA testing | `docs/user-journeys.md` |
+| iOS app | `docs/strategy/ios.md` |
+| Any shipped feature's design rationale | Check `docs/strategy/{feature}.md` — each has a STATUS header |
 
 
 ## Guardrails

--- a/docs/strategy/comments-and-field-notes.md
+++ b/docs/strategy/comments-and-field-notes.md
@@ -1,0 +1,697 @@
+# Comments & Field Notes — Design Doc
+
+> **STATUS: SHIPPED (April 2026).** Waves 1-5 complete: schema + CRUD (PSY-285), handlers (PSY-286), voting + Wilson score (PSY-287), subscriptions + auto-subscribe (PSY-288), frontend module + entity integration (PSY-290/291), moderation with trust tiers (PSY-292/293), show field notes with verified attendee (PSY-294/295). Comments live on 7 entity types (artists, venues, shows, releases, labels, festivals, collections). Radio episodes not yet integrated. Remaining: Wave 6 (PSY-296/297 — reply permissions, edit history viewer), notifications (PSY-289).
+>
+> Design doc for PH's community discussion infrastructure and the specialized "show field notes" feature. Retained as architectural reference.
+
+## Problem
+
+PH has zero discussion infrastructure. Users can't:
+- Discuss shows ("the opener stole the show"), releases ("this remaster is the one to buy"), or artists
+- Share experiential observations about live shows (field notes — PH's unique contribution)
+- Add context to collections or radio episodes
+- Subscribe to discussion on entities they follow
+
+This is the **biggest missing social feature** in PH (per `docs/learnings/ux-gap-analysis.md` Tier 1 #3) and **a prerequisite for show field notes** (Tier 1 #2).
+
+## Goals
+
+1. **Unified comment system** across all entity types (shows, artists, venues, releases, labels, festivals, collections, radio episodes)
+2. **Show field notes** as a specialized comment subtype with structured metadata
+3. **Reuse existing PH infrastructure** — trust tiers, entity reports, unified moderation queue, attribution, audit log
+4. **Ship quality from day one** — moderation, rate limiting, spam prevention, reply controls
+5. **Design for mobile** — web-first but API should support iOS/future clients
+
+## Non-goals (v1)
+
+- Nested threading deeper than 3 levels (use "Continue thread" beyond that)
+- Rich text editor (Slate/ProseMirror) — use Markdown
+- Vote fuzzing (PH scale doesn't warrant it)
+- AutoMod DSL (manual moderation + simple keyword filters sufficient at launch)
+- Per-entity forums or multi-topic boards (shoutbox failure mode)
+- Wiki-like collaborative editing of comments (single-author with edit history)
+- Comment counts with precomputed sort-order caches (simple indexes are fine)
+- iOS app support (web-first; iOS post-launch)
+
+## Design Principles
+
+From research synthesis (`docs/learnings/community-discussion-patterns.md`):
+
+1. **Polymorphic by entity_type+entity_id** — matches PH's existing tag/bookmark/report patterns (Gazelle)
+2. **Bounded-depth nesting** — 3 levels max, "Continue thread" beyond (Reddit, avoiding flat-design pitfalls)
+3. **Wilson score "Best" sort** — default, protects quality new comments (Reddit/Evan Miller)
+4. **Trust-tiered publishing** — reuse PSY-126 tier gates
+5. **Soft delete with tombstones** — `[deleted]` vs `[removed]` semantics (Reddit)
+6. **Markdown, not BBCode** — mature libraries, user-familiar, less than Gazelle's 954 lines of BBCode logic
+7. **Verified attendee signal for show field notes** — purchase-gate analog (Bandcamp)
+8. **Per-author reply controls** — critical pressure valve from day one (Letterboxd)
+9. **Field notes as comment subtype** — not a separate table (shared infrastructure for threading/subscriptions/moderation)
+10. **Attribution everywhere** — extends PSY-136 pattern
+11. **Rate limiting from day one** — Gazelle's lack was a failure mode
+12. **Edit history stored but public only to admins by default** — Reddit asterisk pattern, admin diff via PH's existing revision infrastructure
+
+## Schema
+
+### `comments` table
+
+```sql
+CREATE TYPE comment_kind AS ENUM ('comment', 'field_note');
+CREATE TYPE comment_visibility AS ENUM ('visible', 'hidden_by_user', 'hidden_by_mod', 'pending_review');
+CREATE TYPE reply_permission AS ENUM ('everyone', 'followers', 'none');
+
+CREATE TABLE comments (
+  id BIGSERIAL PRIMARY KEY,
+  kind comment_kind NOT NULL DEFAULT 'comment',
+
+  -- Polymorphic entity reference
+  entity_type VARCHAR(50) NOT NULL,  -- show, artist, venue, release, label, festival, collection, radio_episode
+  entity_id BIGINT NOT NULL,
+
+  -- Author
+  user_id BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+
+  -- Threading (bounded-depth nested)
+  parent_id BIGINT NULL REFERENCES comments(id) ON DELETE CASCADE,
+  root_id BIGINT NULL REFERENCES comments(id) ON DELETE CASCADE,  -- top-level comment ID for fast thread queries
+  depth SMALLINT NOT NULL DEFAULT 0,  -- 0 = top-level, 1 = reply, 2 = reply-to-reply, max 2 enforced in service
+
+  -- Content
+  body TEXT NOT NULL,  -- Markdown
+  body_html TEXT NULL,  -- cached rendered HTML (regenerated on edit)
+
+  -- Field note structured data (NULL for kind='comment')
+  -- Contains: {show_artist_id, song_position, sound_quality, crowd_energy, notable_moments, setlist_spoiler}
+  structured_data JSONB NULL,
+
+  -- Reply controls (per author, per-comment override)
+  reply_permission reply_permission NOT NULL DEFAULT 'everyone',
+
+  -- Visibility state
+  visibility comment_visibility NOT NULL DEFAULT 'visible',
+  hidden_reason VARCHAR(255) NULL,
+  hidden_by_user_id BIGINT NULL REFERENCES users(id),
+  hidden_at TIMESTAMPTZ NULL,
+
+  -- Edit tracking (admin-only history via comment_edits)
+  edited_at TIMESTAMPTZ NULL,
+  edited_by_user_id BIGINT NULL REFERENCES users(id),
+  edit_count INT NOT NULL DEFAULT 0,
+
+  -- Vote aggregates (precomputed for Wilson score)
+  ups INT NOT NULL DEFAULT 0,
+  downs INT NOT NULL DEFAULT 0,
+  score DOUBLE PRECISION NOT NULL DEFAULT 0,  -- Wilson score lower bound
+
+  -- Timestamps
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_comments_entity ON comments(entity_type, entity_id, visibility, score DESC);
+CREATE INDEX idx_comments_thread ON comments(root_id, depth, created_at);
+CREATE INDEX idx_comments_user ON comments(user_id, created_at DESC);
+CREATE INDEX idx_comments_kind ON comments(kind) WHERE kind = 'field_note';
+CREATE INDEX idx_comments_parent ON comments(parent_id) WHERE parent_id IS NOT NULL;
+```
+
+**Key decisions:**
+- **`kind` discriminator** — one table for both comments and field notes, different rendering and validation in service layer
+- **`root_id`** — top-level comment ID for all replies in a thread, enables fast "load whole thread" queries
+- **`depth SMALLINT`** — enforced max 2 in service layer (3 total levels: 0, 1, 2)
+- **`structured_data JSONB`** — field note metadata (show_artist_id, song_position, etc.). NULL for regular comments.
+- **`visibility enum`** — separates user-delete from mod-delete (Reddit `[deleted]` vs `[removed]`)
+- **`score DOUBLE PRECISION`** — Wilson score lower bound, precomputed on vote, indexed for "Best" sort
+- **`body_html` cached** — regenerated on edit, not on read
+- **No FK to entity tables** — polymorphic pattern, validation in service layer
+
+### `comment_edits` table (append-only edit history)
+
+```sql
+CREATE TABLE comment_edits (
+  id BIGSERIAL PRIMARY KEY,
+  comment_id BIGINT NOT NULL REFERENCES comments(id) ON DELETE CASCADE,
+  editor_user_id BIGINT NOT NULL REFERENCES users(id),
+  previous_body TEXT NOT NULL,  -- OLD body before this edit
+  edit_reason VARCHAR(255) NULL,  -- optional edit summary
+  edited_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_comment_edits_comment ON comment_edits(comment_id, edited_at);
+```
+
+**Append-only audit log.** Gazelle pattern: every edit appends the OLD body. Admin can walk back through versions. Users see only "edited N times, last by @username 2h ago" — not diffs.
+
+### `comment_votes` table
+
+```sql
+CREATE TYPE vote_direction AS SMALLINT;  -- 1 or -1
+
+CREATE TABLE comment_votes (
+  comment_id BIGINT NOT NULL REFERENCES comments(id) ON DELETE CASCADE,
+  user_id BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  direction SMALLINT NOT NULL CHECK (direction IN (-1, 1)),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (comment_id, user_id)
+);
+
+CREATE INDEX idx_comment_votes_user ON comment_votes(user_id, created_at DESC);
+```
+
+Binary up/down votes. Aggregates (`ups`, `downs`, `score`) stored denormalized on `comments` and updated on write via `ON DUPLICATE KEY UPDATE` pattern.
+
+### `comment_subscriptions` table
+
+```sql
+CREATE TABLE comment_subscriptions (
+  user_id BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  entity_type VARCHAR(50) NOT NULL,
+  entity_id BIGINT NOT NULL,
+  subscribed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (user_id, entity_type, entity_id)
+);
+
+CREATE INDEX idx_comment_subscriptions_entity ON comment_subscriptions(entity_type, entity_id);
+```
+
+**Per-entity subscription** (not per-comment). Gazelle pattern. Smart defaults:
+- Auto-subscribe when user posts a comment (implied interest)
+- Manual subscribe button on entity detail pages
+- One-click unsubscribe in email notifications
+
+### `comment_last_read` table
+
+```sql
+CREATE TABLE comment_last_read (
+  user_id BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  entity_type VARCHAR(50) NOT NULL,
+  entity_id BIGINT NOT NULL,
+  last_read_comment_id BIGINT NULL REFERENCES comments(id) ON DELETE SET NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (user_id, entity_type, entity_id)
+);
+```
+
+Per-user per-entity "last seen comment ID." Unread count = comments on entity with `id > last_read_comment_id`. Updated on page view of entity's comment section.
+
+### `comment_reports` table
+
+**Decision: reuse existing `entity_reports` with `entity_type='comment'`** rather than separate `comment_reports` table.
+
+Rationale:
+- PSY-130/131 entity_reports is already polymorphic
+- Unified moderation queue (PSY-132) already aggregates entity reports
+- One less table to maintain
+- Validation: extend entity_reports to allow `entity_type='comment'` with comment-specific report categories
+
+**Add comment report categories** to existing entity_reports system:
+- `spam` — promotional content, repetitive posting
+- `harassment` — personal attacks, targeted abuse
+- `off_topic` — unrelated to the entity
+- `inaccurate` — factually wrong, should be corrected
+- `other` — free text required
+
+## Service Architecture
+
+### Package structure
+
+```
+backend/internal/services/engagement/
+  comment_service.go           # CRUD, threading, validation
+  comment_vote_service.go      # Voting, Wilson score
+  comment_subscription_service.go  # Subscriptions, unread counts
+  comment_notification.go      # Email notifications on new comments/mentions
+  comment_moderation.go        # Visibility state machine, rate limiting
+```
+
+Place in `engagement/` (alongside bookmarks, attendance, follow, calendar, reminder) since comments are a user engagement primitive.
+
+### Interface (`contracts/comment.go`)
+
+```go
+type CommentServiceInterface interface {
+  // CRUD
+  CreateComment(userID uint, req *CreateCommentRequest) (*CommentResponse, error)
+  GetComment(commentID uint) (*CommentResponse, error)
+  UpdateComment(userID uint, commentID uint, req *UpdateCommentRequest) (*CommentResponse, error)
+  DeleteComment(userID uint, commentID uint, isAdmin bool) error  // soft delete
+
+  // Threading
+  ListCommentsForEntity(entityType string, entityID uint, filters CommentListFilters) (*CommentListResponse, error)
+  GetThread(rootID uint) ([]*CommentResponse, error)  // full thread including nested replies
+
+  // Field notes
+  CreateFieldNote(userID uint, req *CreateFieldNoteRequest) (*CommentResponse, error)
+  ListFieldNotesForShow(showID uint) ([]*CommentResponse, error)
+}
+
+type CommentVoteServiceInterface interface {
+  Vote(userID uint, commentID uint, direction int) error
+  Unvote(userID uint, commentID uint) error
+  GetUserVote(userID uint, commentID uint) (*int, error)
+}
+
+type CommentSubscriptionServiceInterface interface {
+  Subscribe(userID uint, entityType string, entityID uint) error
+  Unsubscribe(userID uint, entityType string, entityID uint) error
+  IsSubscribed(userID uint, entityType string, entityID uint) (bool, error)
+  MarkRead(userID uint, entityType string, entityID uint) error
+  GetUnreadCount(userID uint, entityType string, entityID uint) (int, error)
+}
+```
+
+### Moderation flow
+
+```go
+// CreateComment visibility logic
+func (s *CommentService) computeInitialVisibility(user *User, entityType string, entityID uint) comment_visibility {
+  if user.IsAdmin {
+    return VisibilityVisible
+  }
+
+  // Check rate limit
+  recentCount := s.countRecentCommentsBy(user.ID, 60 * time.Second)
+  if recentCount >= 1 {
+    return VisibilityHiddenByMod // rate-limited, hidden with reason
+  }
+
+  // Trust tier gating
+  switch user.UserTier {
+  case "new_user":
+    // Shadow-publish: visible to self, invisible to others until human review
+    // OR auto-publish with aggressive spam detection flag
+    return VisibilityPendingReview
+  case "contributor":
+    return VisibilityVisible  // auto-publish but flaggable
+  case "trusted_contributor", "local_ambassador":
+    return VisibilityVisible
+  default:
+    return VisibilityPendingReview
+  }
+}
+```
+
+### Rate limiting (per user)
+
+- **Per-entity cooldown**: 60s between comments on same entity by same user
+- **Global rate**: 5 comments per hour for `new_user`, 30 per hour for `contributor`+, 100 per hour for trusted
+- **Duplicate detection**: comment with identical body to user's recent comment on same entity rejected with "You already posted this"
+
+## API Design
+
+### Public endpoints (optional auth)
+
+```
+GET  /entities/{type}/{id}/comments              # list top-level + nested, sort=best|new|top|controversial
+GET  /comments/{id}                              # single comment with replies
+GET  /comments/{id}/thread                       # full thread including all nested replies
+GET  /shows/{id}/field-notes                     # field notes for a show (specialized listing)
+GET  /entities/{type}/{id}/comments/unread-count # authenticated: unread count since last read
+```
+
+### Protected endpoints (auth required)
+
+```
+POST   /entities/{type}/{id}/comments            # create top-level comment
+POST   /comments/{id}/replies                    # create reply to comment
+POST   /shows/{id}/field-notes                   # create field note
+PUT    /comments/{id}                            # edit own comment
+DELETE /comments/{id}                            # soft delete own comment
+POST   /comments/{id}/vote                       # upvote or downvote
+DELETE /comments/{id}/vote                       # remove vote
+POST   /entities/{type}/{id}/subscribe           # subscribe to comments on entity
+DELETE /entities/{type}/{id}/subscribe           # unsubscribe
+POST   /entities/{type}/{id}/mark-read           # mark all comments as read
+POST   /comments/{id}/report                     # report comment (creates entity_report)
+```
+
+### Admin endpoints
+
+```
+POST   /admin/comments/{id}/hide                 # admin hide with reason
+POST   /admin/comments/{id}/restore              # admin unhide
+DELETE /admin/comments/{id}                      # admin hard delete (rare)
+GET    /admin/comments/pending                   # new_user comments awaiting review
+POST   /admin/comments/{id}/approve              # approve pending comment
+POST   /admin/comments/{id}/reject               # reject pending comment
+```
+
+Moderation queue (PSY-132) auto-includes comment reports via entity_reports.
+
+## Frontend Architecture
+
+### Feature module
+
+```
+frontend/features/comments/
+  components/
+    CommentThread.tsx          # list of top-level comments with expand-to-thread
+    CommentCard.tsx            # single comment with vote buttons, reply, report
+    CommentForm.tsx            # markdown editor with preview
+    FieldNoteForm.tsx          # specialized form with structured fields
+    FieldNoteCard.tsx          # field note with song position, sound quality badges
+    SubscribeButton.tsx        # toggle subscription on entity
+    UnreadBadge.tsx            # shows unread count on entity pages
+    ReplyPermissionSelect.tsx  # author controls
+    index.ts
+  hooks/
+    useComments.ts             # list + pagination
+    useComment.ts              # single comment
+    useCreateComment.ts        # create mutation
+    useUpdateComment.ts        # edit mutation
+    useDeleteComment.ts        # delete mutation
+    useVoteComment.ts          # vote with optimistic update
+    useSubscribeEntity.ts      # subscribe mutation
+    useUnreadCount.ts          # unread count query
+    useCreateFieldNote.ts      # specialized field note creation
+    useFieldNotes.ts           # field notes for a show
+    index.ts
+  types.ts
+  index.ts
+```
+
+### Markdown rendering
+
+- **Library**: `react-markdown` with `remark-gfm` (GitHub-flavored markdown)
+- **Sanitization**: `rehype-sanitize` (client) + `bluemonday` (server, for body_html cache)
+- **Whitelist**: bold, italic, links, code blocks, lists, blockquotes, headings h3-h6
+- **NO**: images, raw HTML, tables (can add later if needed)
+
+### Integration points
+
+**Every entity detail page** (artist, venue, show, release, label, festival, collection, radio episode) gets a `<CommentThread entityType={...} entityId={...} />` section below existing content.
+
+**Show detail page additionally** gets `<FieldNotesSection showId={...} />` that overlays on the show_artists list (showing notes anchored to specific performers/songs) plus a "Show Field Note" CTA for attendees.
+
+**Sidebar** (user-only section) gets a "Discussions" entry showing subscribed threads with unread counts.
+
+**Cmd+K** gets comment-related commands: "Subscribe to discussions on [current entity]", "Mark all as read."
+
+## Moderation Model Integration
+
+### Trust tiers (PSY-126)
+
+| Tier | Create | Publish timing | Edit own | Delete own | Vote | Report | Notes |
+|------|--------|---------------|----------|-----------|------|--------|-------|
+| `new_user` | Rate-limited | Pending review | Yes (1h window) | Yes | Yes | Yes | Shadow-published or queued |
+| `contributor` | Rate-limited | Auto-publish | Yes (24h window) | Yes | Yes | Yes | Flagged if 2+ reports |
+| `trusted_contributor` | Rate-limited | Auto-publish | Unlimited | Yes | Yes | Yes | Flagged if 5+ reports |
+| `local_ambassador` | Light rate limit | Auto-publish | Unlimited | Yes | Yes | Yes | Report threshold ignored |
+| `admin` | No rate limit | Auto-publish | Any comment | Any comment | Yes | N/A | Full moderation power |
+
+### Entity reports integration (PSY-130/131)
+
+Extend `entity_reports` to support `entity_type='comment'`. Add report categories: `spam`, `harassment`, `off_topic`, `inaccurate`, `other`.
+
+On report:
+- 1st report: notify admin via Discord (fire-and-forget, existing pattern)
+- 3+ reports from trusted users: auto-hide comment pending review (set `visibility = 'hidden_by_mod'`, `hidden_reason = 'multiple reports'`)
+- Admin resolves via unified moderation queue (PSY-132)
+
+### Unified moderation queue (PSY-132)
+
+Comments appear in the queue as a third item type alongside pending edits and entity reports:
+- **Comment reports** (via entity_reports with `entity_type='comment'`)
+- **Pending comments** (from `new_user` tier) — separate query in the queue UI
+
+Update `ModerationQueue.tsx` component to handle the new types with appropriate cards.
+
+### Audit log (PSY-41)
+
+All comment actions logged as fire-and-forget:
+- `create_comment`, `edit_comment`, `delete_comment` (user or admin)
+- `hide_comment`, `restore_comment` (admin)
+- `vote_comment`, `unvote_comment` (user)
+- `subscribe_entity`, `unsubscribe_entity`
+- `report_comment`, `resolve_comment_report`, `dismiss_comment_report`
+
+### Notification integration (PSY-106/107)
+
+Comment subscriptions are a **separate system** from notification filters, not integrated into `notification_filters` table. Rationale:
+- Different semantics: filters match on criteria (genre, city), subscriptions match on entity identity
+- Simpler implementation: direct query on `comment_subscriptions` table when comment created
+- Future: could unify under a "subscriptions" abstraction if patterns converge
+
+**New comment notification flow:**
+1. Comment created on entity X
+2. `commentNotificationService.NotifySubscribers(entityType, entityID, commentID)` fires (fire-and-forget)
+3. Query subscribers: `SELECT user_id FROM comment_subscriptions WHERE entity_type = ? AND entity_id = ?`
+4. For each subscriber: check notification preferences, queue email via existing EmailService
+5. Record in `notification_log` for dedup (reuse existing table from PSY-106/107)
+
+**Mention notifications:**
+1. On comment create, parse body for `@username` patterns
+2. For each mention, check if user exists AND has `notify_on_mention=true`
+3. Insert into `notification_log` and send email/in-app notification
+
+## Field Notes Specialization
+
+### What makes field notes different from comments
+
+- **Specialized creation form** with structured fields in addition to freeform body
+- **Anchoring to show_artists and song position** via `structured_data` JSONB
+- **"Verified Attendee" badge** if author had `user_bookmarks.action='going'` on this show before event date
+- **Post-event only** — can't create field notes for shows in the future
+- **Displayed differently** — field notes section on show pages, optionally overlaid on setlist timeline
+
+### `structured_data` JSONB schema for field notes
+
+```typescript
+{
+  "show_artist_id": 42,           // which performer the note is about (optional for show-wide notes)
+  "song_position": 7,             // position in setlist (optional, NULL for between-song or overall)
+  "sound_quality": 4,             // 1-5 scale (optional)
+  "crowd_energy": 5,              // 1-5 scale (optional)
+  "notable_moments": "Played 3 new songs from the upcoming album",  // structured highlight (optional)
+  "setlist_spoiler": true,        // flag if note reveals unannounced setlist items
+  "is_verified_attendee": true    // computed at creation time, cached
+}
+```
+
+All fields optional except the body (from the main `comments` table). Field notes can be:
+- **Show-wide**: no show_artist_id, no song_position, body is general observation
+- **Artist-anchored**: show_artist_id set, no song_position, body is about one performer's whole set
+- **Moment-anchored**: both show_artist_id and song_position set, body is about a specific song
+
+### Soft anchoring fallback
+
+If a setlist is edited after a field note is created and `song_position=7` no longer exists (or is a different song), the UI falls back gracefully:
+- Display note under `show_artist_id` instead (artist's whole set)
+- Show warning: "This note was anchored to song position 7, which has changed. Current setlist shows X."
+
+### Attendee verification
+
+When creating a field note:
+```go
+func (s *CommentService) computeAttendeeVerification(userID uint, showID uint) bool {
+  show := s.showRepo.Get(showID)
+  if show.EventDate.After(time.Now()) {
+    return false  // show hasn't happened yet
+  }
+
+  bookmark := s.bookmarkRepo.Find(userID, "show", showID, "going")
+  if bookmark == nil {
+    return false
+  }
+
+  // Must have marked "going" BEFORE show date
+  return bookmark.CreatedAt.Before(show.EventDate)
+}
+```
+
+Result cached in `structured_data.is_verified_attendee`. Displayed as a badge next to author name on field notes.
+
+## Performance & Scaling
+
+### Read performance
+- **Index on `(entity_type, entity_id, visibility, score DESC)`** — for default "Best" sort
+- **Index on `(root_id, depth, created_at)`** — for full-thread queries
+- **No precomputed sort-order caches** — SELECT + ORDER BY is sufficient at PH scale for years
+- **body_html cached** on the comment row, regenerated only on edit
+
+### Write performance
+- Vote aggregates updated inline: `UPDATE comments SET ups=..., downs=..., score=... WHERE id=?`
+- Wilson score computed in Go (reuse existing utility from tag voting)
+- Audit log + Discord notification are fire-and-forget (no impact on request)
+
+### Scalability
+At current PH scale (single-digit k users), single-table polymorphic pattern handles millions of comments without issue. If PH eventually needs to scale:
+- Partition `comments` by `entity_type`
+- Add materialized views for hot entities
+- Move to CQRS with separate read/write paths
+
+These are Year 3+ concerns.
+
+## Build Order (Wave Structure)
+
+### Wave 1: Foundation (3-4 tickets)
+
+**Blocks all other waves.** Minimum viable comments.
+
+1. **Backend: Comments schema + basic CRUD**
+   - Migrations: `comments`, `comment_edits`, `comment_votes`
+   - GORM models
+   - `CommentService` with: create (auto-publish for trusted+), get, list-for-entity, update (own), delete (soft, own/admin)
+   - Markdown rendering server-side (goldmark + bluemonday)
+   - Polymorphic `(entity_type, entity_id)` validation
+   - 20+ tests (service integration + nil-db)
+
+2. **Backend: Comment handlers + API routes**
+   - Public endpoints: list, get, thread
+   - Protected endpoints: create, update, delete
+   - Huma request/response types
+   - Register routes in `routes/routes.go`
+   - 15+ handler tests (mock-based)
+
+3. **Backend: Comment voting + Wilson score**
+   - `CommentVoteService`
+   - Vote/unvote with aggregate updates
+   - Wilson score computation (reuse from tags)
+   - Sort by "best" (default), "new", "top", "controversial"
+   - 15+ tests
+
+### Wave 2: Subscriptions & Notifications (2-3 tickets)
+
+4. **Backend: Comment subscriptions + unread tracking**
+   - Migrations: `comment_subscriptions`, `comment_last_read`
+   - Subscribe/unsubscribe API
+   - Unread count endpoint
+   - Auto-subscribe on first comment by user (smart default)
+   - 10+ tests
+
+5. **Backend: Comment notification integration**
+   - `CommentNotificationService` — fire-and-forget email to subscribers
+   - Integration with existing EmailService (PSY-106/107 email templates)
+   - `notification_log` dedup
+   - Mention parsing (`@username`)
+   - 10+ tests
+
+### Wave 3: Frontend Foundation (2-3 tickets)
+
+6. **Frontend: Comment feature module**
+   - `features/comments/` with components, hooks, types
+   - `CommentThread`, `CommentCard`, `CommentForm`
+   - Markdown rendering with `react-markdown`
+   - Vote UI with optimistic updates
+   - Subscribe button
+   - Unread badge
+   - Feature module tests
+
+7. **Frontend: Entity integration (all 8 entity types)**
+   - Add `<CommentThread />` to: ArtistDetail, VenueDetail, ShowDetail, ReleaseDetail, LabelDetail, FestivalDetail, CollectionDetail, RadioEpisodeDetail
+   - Cmd+K: subscribe command
+   - Sidebar: "Discussions" entry with unread counts
+   - Test updates
+
+### Wave 4: Moderation (2 tickets)
+
+8. **Backend: Comment moderation integration**
+   - Extend `entity_reports` to support `entity_type='comment'` (new category constants)
+   - Trust-tier publishing logic (new_user → pending, contributor+ → auto-publish)
+   - Rate limiting middleware
+   - Admin endpoints: hide, restore, approve pending
+   - Auto-hide on 3+ reports from trusted users
+   - Integration with unified moderation queue (PSY-132)
+   - 15+ tests
+
+9. **Frontend: Admin comment moderation UI**
+   - Add "Comment reports" filter to moderation queue
+   - Pending comments admin tab
+   - Hide/restore actions
+   - Report categories in report dialog
+
+### Wave 5: Field Notes Specialization (2 tickets)
+
+10. **Backend: Field notes as comment subtype**
+    - `kind` enum + `structured_data` JSONB validation for field notes
+    - `CreateFieldNote` service method with attendee verification
+    - Post-event gating (show.event_date < now)
+    - List field notes for show endpoint
+    - 15+ tests
+
+11. **Frontend: Field notes UI**
+    - `FieldNoteForm` with structured fields (show_artist_id picker, song_position, sound_quality, crowd_energy)
+    - `FieldNoteCard` with verified attendee badge
+    - Show detail page integration — separate "Field Notes" section
+    - Setlist spoiler flag
+    - Soft-anchor fallback rendering
+
+### Wave 6: Polish (1-2 tickets)
+
+12. **Per-author reply permission controls**
+    - `reply_permission` enum in model
+    - Author-side UI to change reply permission per comment
+    - Frontend gating (hide reply button if not permitted)
+
+13. **Comment edit history (admin-only)**
+    - Admin diff viewer for `comment_edits` table
+    - Walkback UI per Gazelle pattern
+
+## Design Decisions Summary
+
+| Decision | Choice | Source |
+|----------|--------|--------|
+| Threading model | Bounded nested (3 levels) + "Continue thread" | Reddit minus depth |
+| Markup format | Markdown (goldmark + react-markdown) | Gazelle warning |
+| Default sort | Wilson score "Best" | Reddit |
+| Anti-spam gate | Trust tiers + rate limiting + verified attendee for shows | PSY-126 + Bandcamp |
+| Field notes as subtype | `kind` enum + `structured_data` JSONB on same table | Reduces duplication |
+| Deletion model | Soft delete with `[deleted]`/`[removed]` semantics | Reddit |
+| Edit history | Stored in append-only `comment_edits`, admin-only diff | Gazelle + Reddit |
+| Notifications | Separate `comment_subscriptions` table (not via notification_filters) | Simpler semantics |
+| Reply permissions | Per-author per-comment: everyone / followers / none | Letterboxd |
+| Reactions | None in v1 (up/down votes only) | Simplicity |
+| Comment reports | Reuse `entity_reports` with `entity_type='comment'` | PSY-130/131 |
+| Moderation queue integration | Yes, comments appear alongside pending edits + entity reports | PSY-132 |
+| Voting system | Binary up/down with Wilson score | Gazelle/Reddit |
+| Scope at launch | All 8 entity types (artist/venue/show/release/label/festival/collection/radio_episode) | Comprehensive |
+| iOS support | Web-first, iOS post-launch | Simpler v1 |
+
+## Open Questions (deferred)
+
+- **Should mentions count toward contributor stats?** Probably not — could be abused.
+- **How does comment-voting relate to tier promotion?** Comment karma as a separate signal? Not in v1.
+- **Should we allow pinning top comments per entity?** Nice feature for future, not v1.
+- **What about comments on user profiles (guestbook)?** Defer — different semantics, different spam vectors.
+- **Should field notes have their own URL?** `/shows/{slug}/notes/{id}` — yes, for shareability.
+
+## Reference Mapping
+
+| PH Design Choice | Prior Art Inspiration |
+|-----------------|---------------------|
+| Polymorphic `(entity_type, entity_id)` | Gazelle `(Page, PageID)` |
+| 3-level bounded nesting | Reddit (capped from their 10-level default) |
+| Wilson score "Best" sort | Reddit (Evan Miller algorithm) |
+| Append-only edit history | Gazelle `comments_edits` |
+| `[deleted]` vs `[removed]` | Reddit |
+| Markdown over BBCode | Modern convention, avoid Gazelle complexity |
+| Verified attendee badge | Bandcamp purchase gate analog |
+| Per-author reply permissions | Letterboxd |
+| Field notes structured_data | Genius annotations (structural anchoring) |
+| Setlist spoiler flag | Letterboxd mandatory spoiler flag |
+| Trust-tier publishing gates | Gazelle warning system + PSY-126 tiers |
+| Report-based auto-hide at threshold | Reddit AutoMod-lite |
+| Per-entity subscriptions (not per-comment) | Gazelle `users_subscriptions_comments` |
+| Mandatory source on setlist edits | Setlist.fm editorial pattern |
+| Colored tier badges on author | Setlist.fm role badges |
+| Staff rotation as curation override | RYM hybrid curation model |
+| Private attendee notes escape hatch | Setlist.fm private notes |
+
+## Ticket Breakdown
+
+After this design is approved, create the following tickets in the **Community Discussion & Field Notes** Linear project:
+
+1. **Backend: Comments schema + CRUD service** (Wave 1)
+2. **Backend: Comment handlers + API routes** (Wave 1)
+3. **Backend: Comment voting + Wilson score** (Wave 1)
+4. **Backend: Comment subscriptions + unread tracking** (Wave 2)
+5. **Backend: Comment notification integration** (Wave 2)
+6. **Frontend: Comment feature module** (Wave 3)
+7. **Frontend: Entity integration for comments** (Wave 3)
+8. **Backend: Comment moderation integration** (Wave 4)
+9. **Frontend: Admin comment moderation UI** (Wave 4)
+10. **Backend: Field notes as comment subtype** (Wave 5)
+11. **Frontend: Field notes UI** (Wave 5)
+12. **Per-author reply permission controls** (Wave 6)
+13. **Admin comment edit history viewer** (Wave 6)
+
+Each ticket should be small enough to ship in 1-2 days. Waves have dependencies (1 → 2 → 3 → 4/5 can run in parallel → 6).

--- a/docs/strategy/discovery.md
+++ b/docs/strategy/discovery.md
@@ -1,6 +1,8 @@
 # Discovery Track
 
-> Data ingestion pipeline for the Music Scene Index. Evolving from brittle Playwright venue scrapers toward an AI-first, multi-source pipeline that can scale to hundreds of venues worldwide with zero per-venue code.
+> **STATUS: SHIPPED (March 2026).** AI-first pipeline operational. Scheduler, change detection, iCal/RSS feeds all shipped. Remaining: PSY-33 (consolidate discovery UI), PSY-35 (post-import enrichment).
+>
+> Data ingestion pipeline for the Music Scene Index. Retained as architectural reference.
 
 ## Current Status
 

--- a/docs/strategy/entity-descriptions.md
+++ b/docs/strategy/entity-descriptions.md
@@ -1,0 +1,148 @@
+# Collaborative Entity Descriptions — Design Doc
+
+> **STATUS: SHIPPED (March 2026).** Entity descriptions added to artists and venues (PSY-211–215). Retained as reference.
+
+## Problem
+
+PH entity pages show structured data (name, location, tags, relationships) but no **narrative context**. Users visiting an artist page can see their upcoming shows and genre tags, but not *who this band is* or *why they matter*. Venues have addresses but no *vibe description*. This is a knowledge graph, not just a database — narrative is what makes it a source of truth.
+
+What.cd's artist wikis were community-maintained narratives with full edit history. They were distinct from comments (discussion) and distinct from structured data (year, label, format). PH needs the same layer.
+
+## Decisions
+
+### 1. Treat descriptions as regular entity fields (not separate wiki tables)
+
+**Decision:** Descriptions are a `TEXT` column on each entity table, edited through the same Phase 3 pending edit system as any other field.
+
+**Why not separate wiki tables (Gazelle pattern)?**
+- Gazelle needed separate tables because torrent metadata (format, bitrate) was fundamentally different from free-text descriptions
+- PH's entities are simpler — a description is just another field like `name` or `city`
+- Phase 3's `pending_entity_edits` with JSONB `field_changes` already handles arbitrary field edits
+- RevisionService already tracks per-field changes with old/new values
+- Separate tables would mean separate permissions, separate moderation queue, separate revision history — unnecessary complexity
+
+**What we gain:** Descriptions automatically get pending edit queue, revision history, rollback, attribution, and trust-tiered permissions for free — no new infrastructure needed.
+
+### 2. Content format: Markdown
+
+**Decision:** Descriptions use Markdown (same as profile sections).
+
+**Why:**
+- Already used for profile sections (`UserProfileSection.Content`)
+- Frontend already has Markdown rendering (used in profile, request descriptions, collection descriptions)
+- Richer than plain text, simpler than rich text editor
+- Familiar to the technical/music community PH targets
+- No BBCode (Gazelle's choice was a product of its era)
+
+**Constraints:**
+- Max 5,000 characters (prevents abuse, encourages conciseness)
+- No embedded images in Markdown (security) — use external image URLs only
+- Sanitized on render (XSS prevention)
+
+### 3. Entity scope and priority
+
+| Entity | Has `description` column? | Priority | Rationale |
+|--------|--------------------------|----------|-----------|
+| **Artist** | No — needs migration | **P0** | "Who is this band?" is the #1 missing narrative |
+| **Venue** | No — needs migration | **P0** | "What's the vibe?" — critical for discovery |
+| **Release** | Yes (exists, nullable) | **P1** | "About this album" — valuable for deep dives |
+| **Label** | Yes (exists, nullable) | **P1** | "Label philosophy and roster" — connects the graph |
+| **Festival** | Yes (exists, nullable) | **P1** | "What is this festival?" — already has field |
+| **Show** | Yes (exists, nullable) | **P2** | Individual events are ephemeral — lower value |
+
+**Migration:** Add `description TEXT` to `artists` and `venues` tables. Shows, releases, labels, festivals already have the column.
+
+### 4. Trust model: Follow Phase 3 permissions exactly
+
+| User Tier | Can edit descriptions? | Review required? |
+|-----------|----------------------|-----------------|
+| `new_user` | Yes (suggest) | Yes — enters pending queue |
+| `contributor` | Yes (suggest) | Yes — enters pending queue |
+| `trusted_contributor` | Yes (direct) | No — edit applies immediately |
+| `local_ambassador` | Yes (direct) | No |
+| Admin | Yes (direct) | No |
+
+**Submitter trust override:** If you originally submitted the entity, you can edit its description directly regardless of tier (you know the most about what you submitted).
+
+**Edit summary required:** Every description edit must include a summary ("Added band history", "Fixed venue hours", "Updated bio after name change"). This is mandatory — matches Gazelle's `Summary` field and Phase 3's design principle.
+
+### 5. Edit conflict resolution: Last-write-wins + revision history
+
+**Decision:** No locking, no merge conflicts. Last save wins.
+
+**Why:** At PH's current scale (dozens of contributors, not thousands), edit conflicts are extremely rare. Gazelle used the same approach successfully for years. The revision history provides a safety net — any overwritten content is recoverable via rollback.
+
+**Future consideration:** If conflict frequency increases (100+ active contributors editing the same entities), add optimistic locking with a `revision_number` check. Not needed now.
+
+### 6. Integration with existing systems
+
+**Revision history:** Description changes are tracked as a `FieldChange` in the existing RevisionService:
+```json
+{"field": "description", "old_value": "Previously...", "new_value": "Updated..."}
+```
+No new revision infrastructure needed.
+
+**Audit log:** Description edits logged via existing fire-and-forget audit log (action: `edit_artist`, `edit_venue`, etc.).
+
+**Notification filters:** Followers of an entity can be notified when its description changes (same trigger as any entity edit).
+
+**Dig Deeper integration (PSY-208):** "Artists with no description" becomes a quality gap category on the /contribute page. "This artist has no description — be the first to add one!" prompt on detail pages.
+
+## Implementation Plan
+
+### Migration (1 file)
+
+```sql
+-- 000056_add_entity_descriptions.up.sql
+ALTER TABLE artists ADD COLUMN description TEXT;
+ALTER TABLE venues ADD COLUMN description TEXT;
+-- shows, releases, labels, festivals already have description
+```
+
+### Backend changes (minimal)
+
+1. **Models:** Add `Description *string` to Artist and Venue GORM structs (json tag: `"description,omitempty"`)
+2. **Handlers:** Artist and venue update handlers already accept field maps — description is just another field
+3. **API responses:** Include `description` in artist/venue detail responses (already included for release/label/festival)
+4. **Validation:** Max 5,000 chars check in handler Resolve method
+5. **No new endpoints needed** — uses existing `PUT /artists/{id}`, `PUT /venues/{id}`, etc.
+
+### Frontend changes
+
+1. **Detail pages:** Add description section below header on artist/venue/release/label/festival detail pages
+   - Rendered as Markdown
+   - "Edit" button for authorized users (trust-tier-gated)
+   - Empty state: "No description yet — add one?" with CTA
+
+2. **Edit UI:** Inline edit mode (not separate page)
+   - Textarea with Markdown preview toggle
+   - Edit summary field (required)
+   - "Save" / "Cancel" buttons
+   - For pending-queue users: "Submit for review" instead of "Save"
+
+3. **Revision history:** Existing `RevisionHistory` component already shows field-level diffs — description diffs will appear automatically once RevisionService is wired (PSY-124)
+
+4. **Attribution:** "Last edited by @username, 3 days ago" below description
+
+## What this does NOT include
+
+- **Comments/discussion on entities** — that's a separate feature (show field notes, Phase 3+)
+- **Multiple description sections** — one description per entity is sufficient (unlike profile sections)
+- **Rich text editor** — Markdown textarea is enough for v1
+- **Description templates** — no pre-filled templates ("paste your artist bio here")
+- **AI-generated descriptions** — could be a future enhancement but not in scope
+
+## Gazelle reference
+
+- `~/dev/Gazelle` used `wiki_artists` / `wiki_torrents` tables with full revision rows per edit
+- Mandatory `Summary` field on every edit
+- Permission: `site_edit_wiki` (roughly = PH's `trusted_contributor`)
+- Simple content model: one `Body` text field per entity
+- No merge conflicts — last write wins, revision history is safety net
+
+## Relationship to other tickets
+
+- **PSY-124** (revision wiring) — must merge first for description diffs to appear in revision history
+- **PSY-125** (generic pending edits) — descriptions for `new_user`/`contributor` go through this queue
+- **PSY-208** (Dig Deeper) — "artists without descriptions" becomes a quality gap category
+- **PSY-210** (contextual prompts) — "Add a description" prompt on detail pages

--- a/docs/strategy/ios.md
+++ b/docs/strategy/ios.md
@@ -1,0 +1,70 @@
+# iOS Track
+
+> **STATUS: CODE COMPLETE, NOT SHIPPED.** All Swift code written (41 files), building in simulator. Blocked on Apple Developer Program enrollment.
+>
+> Native iOS companion app (Swift 6, SwiftUI, iOS 18+). Retained as reference.
+
+## Current Status
+
+All Swift code written (39 files), all backend changes complete, building and running in simulator (Xcode 26.2). Phases 1-7 complete. Phases 8-9 (polish, testing, App Store submission) blocked on Apple Developer Program enrollment.
+
+## Next Priorities
+
+1. **Apple Developer enrollment** ($99/year) — unblocks everything below
+2. **Re-enable capabilities** — Sign in with Apple, App Groups, Keychain Sharing
+3. **Polish & error states** — error views, loading skeletons, haptic feedback, retry logic
+4. **Device testing** — physical device testing across screen sizes
+5. **TestFlight → App Store submission**
+
+## Roadmap
+
+### Now: Ship v1 (Phase 1)
+
+- [ ] Apple Developer enrollment
+- [ ] Re-enable capabilities (commented out in `project.yml`)
+- [ ] Error states and retry for all screens
+- [ ] Loading skeletons / spinners
+- [ ] Haptic feedback on save/unsave
+- [ ] Physical device testing (iPhone SE, 15, 16 Pro Max)
+- [ ] VoiceOver accessibility pass
+- [ ] Unit + UI tests
+- [ ] App Store submission
+
+### Post-Launch
+
+- [ ] Push notifications (show reminders, new shows at saved venues)
+- [ ] Offline mode (cached show list)
+- [ ] Widget (upcoming saved shows)
+
+### Knowledge Graph Features (aligns with web Phase 2+)
+
+- [ ] Label browsing
+- [ ] Genre/tag filtering
+- [ ] Scene pages
+- [ ] Feature parity with web as new entities are added
+
+## Architecture
+
+- **Language:** Swift 6 (strict concurrency)
+- **UI:** SwiftUI (iOS 18+, `Tab` API)
+- **Pattern:** MVVM with `@Observable`, `@MainActor` on all ViewModels
+- **Networking:** URLSession async/await, actor-based `APIClient`
+- **Auth:** Bearer token (Keychain), not cookies
+- **Dependencies:** SPM only, zero third-party packages
+
+## Key Files
+
+| Area | Files |
+|------|-------|
+| Xcode project | `ios/project.yml` (XcodeGen) |
+| App entry | `ios/PsychicHomily/App/PsychicHomilyApp.swift` |
+| Auth state | `ios/PsychicHomily/App/AppState.swift` |
+| API client | `ios/PsychicHomily/Networking/APIClient.swift` |
+| ViewModels | `ios/PsychicHomily/ViewModels/*.swift` |
+| Backend auth | `backend/internal/services/apple_auth.go` |
+
+## Open Decisions
+
+- **Distribution:** TestFlight beta vs. direct App Store submission
+- **Long-term mobile strategy:** Continue native iOS or evaluate PWA as the Music Scene Index grows
+- **V2 scope:** Push notifications vs. widget vs. offline — which first?

--- a/docs/strategy/ph-cli.md
+++ b/docs/strategy/ph-cli.md
@@ -1,6 +1,8 @@
 # PH CLI — Knowledge Graph Ingest Tool
 
-> Design doc for the `ph` CLI, a Bun-based command-line tool for rapidly adding entities to the Psychic Homily knowledge graph. Designed for use from Claude Code sessions: Claude extracts structured data from screenshots/text, `ph` validates, detects duplicates, previews changes, and submits to the API.
+> **STATUS: SHIPPED.** All tickets complete. Lives in a separate repo.
+>
+> Design doc for the `ph` CLI. Retained as reference.
 
 ## Problem
 

--- a/docs/strategy/web.md
+++ b/docs/strategy/web.md
@@ -1,10 +1,12 @@
 # Web Track
 
-> Next.js frontend + Go backend. The primary platform for the Music Scene Index — the spiritual successor to What.cd, anchored in live music.
+> **STATUS: ACTIVE.** Primary platform. All phases through 3 complete. ~2500+ frontend tests (190+ files), 69 E2E, 80%+ backend handler coverage.
+>
+> Next.js frontend + Go backend. The primary platform for the Music Scene Index.
 
 ## Current Status
 
-Phase 1.5 complete — knowledge graph vertical slice shipped. 69 E2E tests, 68.5% backend coverage, 897+ frontend unit tests. PostHog + Sentry live.
+All phases through Phase 3 complete. Comments system (Waves 1-5), Collections UX overhaul, Radio provider fixes all shipped (April 2026). ~2500+ frontend unit tests, 69 E2E, 80%+ backend handler coverage. PostHog + Sentry live.
 
 Core entities: Artists, Venues, Shows, **Releases** (with artist roles + external links), **Labels** (with roster + catalog), **Festivals** (with tiered lineups, multi-venue). Enriched artist pages with discography, label affiliations, festival appearances. Generic bookmarks system. **Contributor profiles** (PSY-63): public profiles with contribution stats/history, 3-level granular privacy, user tiers, custom profile sections, 58 tests. Data seeding CLIs (MusicBrainz, Bandcamp, festival entry). Frontend redesign complete (sidebar nav, Cmd+K, entity detail template, card redesigns, visual polish).
 


### PR DESCRIPTION
## Summary

Systemic fix for the class of error that caused Tags and Collections to be marked "completed" while non-functional.

### 1. Feature Registry (new section in llm-context.md)
Single source of truth for what each feature can actually do. Includes "NEEDS VERIFICATION" flags for features not recently dogfood-tested. 18 features cataloged with core workflows and known gaps.

### 2. Status headers on all strategy docs
Every doc in `docs/strategy/` now starts with `STATUS: SHIPPED | DESIGN | PARTIALLY SHIPPED | CODE COMPLETE`. Fixed:
- `comments-and-field-notes.md`: DESIGN → SHIPPED (Waves 1-5)
- `discovery.md`, `entity-descriptions.md`, `ios.md`, `ph-cli.md`: added missing headers

### 3. Stale doc fixes
- `ux-gap-analysis.md`: marked PARTIALLY STALE (still says "zero discussion infrastructure")
- `web.md`: test count 897 → ~2500+

### 4. Task routing table consolidated
18 rows → 12, grouped by frequency. "Check docs/strategy/{feature}.md — each has a STATUS header" as catch-all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)