### PR TITLE
Fix admin moderation tab 404 (route registration order)

### DIFF
--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -1091,9 +1091,11 @@ func setupCommentRoutes(rc RouteContext) {
 	huma.Delete(rc.Protected, "/comments/{comment_id}", commentHandler.DeleteCommentHandler)
 
 	// Admin: comment moderation
+	// NOTE: literal paths MUST be registered before parameterized paths to avoid
+	// {comment_id} consuming "pending" as a value and returning 404.
+	huma.Get(rc.Protected, "/admin/comments/pending", commentAdminHandler.AdminListPendingCommentsHandler)
 	huma.Post(rc.Protected, "/admin/comments/{comment_id}/hide", commentAdminHandler.AdminHideCommentHandler)
 	huma.Post(rc.Protected, "/admin/comments/{comment_id}/restore", commentAdminHandler.AdminRestoreCommentHandler)
-	huma.Get(rc.Protected, "/admin/comments/pending", commentAdminHandler.AdminListPendingCommentsHandler)
 	huma.Post(rc.Protected, "/admin/comments/{comment_id}/approve", commentAdminHandler.AdminApproveCommentHandler)
 	huma.Post(rc.Protected, "/admin/comments/{comment_id}/reject", commentAdminHandler.AdminRejectCommentHandler)
 }


### PR DESCRIPTION
## Summary

One-line fix. `GET /admin/comments/pending` was returning 404 because it was registered AFTER `POST /admin/comments/{comment_id}/hide`. The `{comment_id}` path parameter consumed "pending" as a literal value.

Moved the literal path registration before all parameterized paths. Added a comment explaining why order matters.

Found during feature completeness audit — this completely blocked the comment moderation workflow shipped in Wave 4.

Closes PSY-320

🤖 Generated with [Claude Code](https://claude.com/claude-code)