### PR TITLE
Expand tag categories from 3 to 8 (PSY-299)

### DIFF
--- a/backend/internal/api/handlers/tag.go
+++ b/backend/internal/api/handlers/tag.go
@@ -34,7 +34,7 @@ func NewTagHandler(tagService contracts.TagServiceInterface, auditLog contracts.
 // ============================================================================
 
 type ListTagsRequest struct {
-	Category string `query:"category" required:"false" doc:"Filter by category (genre, locale, other)"`
+	Category string `query:"category" required:"false" doc:"Filter by category (genre, mood, era, instrument, scene, locale, venue-vibe, other)"`
 	Search   string `query:"search" required:"false" doc:"Search tags by name"`
 	ParentID uint   `query:"parent_id" required:"false" doc:"Filter by parent tag ID"`
 	Sort     string `query:"sort" required:"false" doc:"Sort by: usage, name, created (default: usage)"`
@@ -378,7 +378,7 @@ type CreateTagRequest struct {
 		Name        string  `json:"name" doc:"Tag name" example:"post-punk"`
 		Description *string `json:"description" required:"false" doc:"Tag description"`
 		ParentID    *uint   `json:"parent_id" required:"false" doc:"Parent tag ID for hierarchy"`
-		Category    string  `json:"category" doc:"Tag category (genre, locale, other)" example:"genre"`
+		Category    string  `json:"category" doc:"Tag category (genre, mood, era, instrument, scene, locale, venue-vibe, other)" example:"genre"`
 		IsOfficial  bool    `json:"is_official" required:"false" doc:"Whether this is an official/canonical tag"`
 	}
 }

--- a/backend/internal/models/tag.go
+++ b/backend/internal/models/tag.go
@@ -4,15 +4,25 @@ import "time"
 
 // Tag category constants
 const (
-	TagCategoryGenre  = "genre"
-	TagCategoryLocale = "locale"
-	TagCategoryOther  = "other"
+	TagCategoryGenre      = "genre"
+	TagCategoryMood       = "mood"
+	TagCategoryEra        = "era"
+	TagCategoryInstrument = "instrument"
+	TagCategoryScene      = "scene"
+	TagCategoryLocale     = "locale"
+	TagCategoryVenueVibe  = "venue-vibe"
+	TagCategoryOther      = "other"
 )
 
 // TagCategories is the set of valid tag categories.
 var TagCategories = []string{
 	TagCategoryGenre,
+	TagCategoryMood,
+	TagCategoryEra,
+	TagCategoryInstrument,
+	TagCategoryScene,
 	TagCategoryLocale,
+	TagCategoryVenueVibe,
 	TagCategoryOther,
 }
 

--- a/backend/internal/models/tag_test.go
+++ b/backend/internal/models/tag_test.go
@@ -66,9 +66,21 @@ func TestIsValidTagEntityType_Invalid(t *testing.T) {
 
 func TestTagCategoryConstants(t *testing.T) {
 	assert.Equal(t, "genre", TagCategoryGenre)
+	assert.Equal(t, "mood", TagCategoryMood)
+	assert.Equal(t, "era", TagCategoryEra)
+	assert.Equal(t, "instrument", TagCategoryInstrument)
+	assert.Equal(t, "scene", TagCategoryScene)
 	assert.Equal(t, "locale", TagCategoryLocale)
+	assert.Equal(t, "venue-vibe", TagCategoryVenueVibe)
 	assert.Equal(t, "other", TagCategoryOther)
-	assert.Len(t, TagCategories, 3)
+	assert.Len(t, TagCategories, 8)
+}
+
+func TestIsValidTagCategory_AllNewCategories(t *testing.T) {
+	newCategories := []string{"mood", "era", "instrument", "scene", "venue-vibe"}
+	for _, c := range newCategories {
+		assert.True(t, IsValidTagCategory(c), "expected %q to be valid", c)
+	}
 }
 
 func TestTagEntityTypeConstants(t *testing.T) {

--- a/frontend/features/tags/components/TagBrowse.test.tsx
+++ b/frontend/features/tags/components/TagBrowse.test.tsx
@@ -229,7 +229,12 @@ describe('TagBrowse', () => {
 
     expect(screen.getByText('All')).toBeInTheDocument()
     expect(screen.getByText('Genre')).toBeInTheDocument()
+    expect(screen.getByText('Mood')).toBeInTheDocument()
+    expect(screen.getByText('Era')).toBeInTheDocument()
+    expect(screen.getByText('Instrument')).toBeInTheDocument()
+    expect(screen.getByText('Scene')).toBeInTheDocument()
     expect(screen.getByText('Locale')).toBeInTheDocument()
+    expect(screen.getByText('Venue Vibe')).toBeInTheDocument()
     expect(screen.getByText('Other')).toBeInTheDocument()
   })
 

--- a/frontend/features/tags/types.ts
+++ b/frontend/features/tags/types.ts
@@ -1,7 +1,7 @@
 // Tag types — aligned with backend contracts/tag.go response types.
 
 export const TAG_CATEGORIES = [
-  'genre', 'locale', 'other'
+  'genre', 'mood', 'era', 'instrument', 'scene', 'locale', 'venue-vibe', 'other'
 ] as const
 export type TagCategory = typeof TAG_CATEGORIES[number]
 
@@ -79,14 +79,30 @@ export interface TagAliasesResponse {
 export function getCategoryColor(category: string): string {
   const colors: Record<string, string> = {
     genre: 'bg-blue-500/10 text-blue-400 border-blue-500/20',
+    mood: 'bg-purple-500/10 text-purple-400 border-purple-500/20',
+    era: 'bg-amber-500/10 text-amber-400 border-amber-500/20',
+    instrument: 'bg-emerald-500/10 text-emerald-400 border-emerald-500/20',
+    scene: 'bg-rose-500/10 text-rose-400 border-rose-500/20',
     locale: 'bg-cyan-500/10 text-cyan-400 border-cyan-500/20',
+    'venue-vibe': 'bg-orange-500/10 text-orange-400 border-orange-500/20',
     other: 'bg-zinc-500/10 text-zinc-400 border-zinc-500/20',
   }
   return colors[category] || colors.other
 }
 
+const TAG_CATEGORY_LABELS: Record<string, string> = {
+  genre: 'Genre',
+  mood: 'Mood',
+  era: 'Era',
+  instrument: 'Instrument',
+  scene: 'Scene',
+  locale: 'Locale',
+  'venue-vibe': 'Venue Vibe',
+  other: 'Other',
+}
+
 export function getCategoryLabel(category: string): string {
-  return category.charAt(0).toUpperCase() + category.slice(1)
+  return TAG_CATEGORY_LABELS[category] || category.charAt(0).toUpperCase() + category.slice(1)
 }
 
 /** Build entity URL from entity type and slug */


### PR DESCRIPTION
## Summary
- **5 new tag categories**: mood, era, instrument, scene, venue-vibe (alongside existing genre, locale, other)
- **Backend**: expanded constants in `models/tag.go`, validation accepts all 8
- **Frontend**: browse page filter pills expanded from 3+All to 8+All, admin dropdown updated, category display helpers with distinct colors and labels
- No migration needed — DB column is VARCHAR(50) with no CHECK constraint

Closes PSY-299

## Test plan
- [x] Backend validates all 8 categories
- [x] Frontend renders 8 filter pills on /tags
- [x] Admin create form shows 8 options
- [x] `go build ./...` and `bun run build` clean
- [x] All existing tests pass with updated assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)