### PR TITLE
Add created_by_user_id to tags for creation attribution (PSY-300)

### DIFF
--- a/backend/db/migrations/000067_add_tag_created_by.down.sql
+++ b/backend/db/migrations/000067_add_tag_created_by.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_tags_created_by;
+ALTER TABLE tags DROP COLUMN IF EXISTS created_by_user_id;

--- a/backend/db/migrations/000067_add_tag_created_by.up.sql
+++ b/backend/db/migrations/000067_add_tag_created_by.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tags ADD COLUMN created_by_user_id BIGINT NULL REFERENCES users(id) ON DELETE SET NULL;
+CREATE INDEX idx_tags_created_by ON tags(created_by_user_id) WHERE created_by_user_id IS NOT NULL;

--- a/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
+++ b/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
@@ -3000,7 +3000,7 @@ func (m *mockShowStateService) SetShowCancelled(showID uint, isCancelled bool) (
 // ============================================================================
 
 type mockTagService struct {
-	createTagFn func(string, *string, *uint, string, bool) (*models.Tag, error)
+	createTagFn func(string, *string, *uint, string, bool, *uint) (*models.Tag, error)
 	getTagFn func(uint) (*models.Tag, error)
 	getTagBySlugFn func(string) (*models.Tag, error)
 	listTagsFn func(string, string, *uint, string, int, int) ([]models.Tag, int64, error)
@@ -3021,9 +3021,9 @@ type mockTagService struct {
 	pruneDownvotedTagsFn func() (int64, error)
 }
 
-func (m *mockTagService) CreateTag(name string, description *string, parentID *uint, category string, isOfficial bool) (*models.Tag, error) {
+func (m *mockTagService) CreateTag(name string, description *string, parentID *uint, category string, isOfficial bool, userID *uint) (*models.Tag, error) {
 	if m.createTagFn != nil {
-		return m.createTagFn(name, description, parentID, category, isOfficial)
+		return m.createTagFn(name, description, parentID, category, isOfficial, userID)
 	}
 	return nil, nil
 }

--- a/backend/internal/api/handlers/tag.go
+++ b/backend/internal/api/handlers/tag.go
@@ -404,7 +404,7 @@ func (h *TagHandler) CreateTagHandler(ctx context.Context, req *CreateTagRequest
 		return nil, huma.Error400BadRequest("Category is required")
 	}
 
-	tag, err := h.tagService.CreateTag(req.Body.Name, req.Body.Description, req.Body.ParentID, req.Body.Category, req.Body.IsOfficial)
+	tag, err := h.tagService.CreateTag(req.Body.Name, req.Body.Description, req.Body.ParentID, req.Body.Category, req.Body.IsOfficial, &user.ID)
 	if err != nil {
 		mapped := mapTagError(err)
 		if mapped != nil {
@@ -693,21 +693,26 @@ func (h *TagHandler) resolveTag(idOrSlug string) *models.Tag {
 // buildTagResponse converts a models.Tag to a TagResponse.
 func buildTagResponse(tag *models.Tag) *contracts.TagResponse {
 	resp := &contracts.TagResponse{
-		ID:         tag.ID,
-		Name:       tag.Name,
-		Slug:       tag.Slug,
-		Description: tag.Description,
-		ParentID:   tag.ParentID,
-		Category:   tag.Category,
-		IsOfficial: tag.IsOfficial,
-		UsageCount: tag.UsageCount,
-		ChildCount: len(tag.Children),
-		CreatedAt:  tag.CreatedAt,
-		UpdatedAt:  tag.UpdatedAt,
+		ID:              tag.ID,
+		Name:            tag.Name,
+		Slug:            tag.Slug,
+		Description:     tag.Description,
+		ParentID:        tag.ParentID,
+		Category:        tag.Category,
+		IsOfficial:      tag.IsOfficial,
+		UsageCount:      tag.UsageCount,
+		ChildCount:      len(tag.Children),
+		CreatedByUserID: tag.CreatedByUserID,
+		CreatedAt:       tag.CreatedAt,
+		UpdatedAt:       tag.UpdatedAt,
 	}
 
 	if tag.Parent != nil {
 		resp.ParentName = tag.Parent.Name
+	}
+
+	if tag.CreatedBy != nil && tag.CreatedBy.Username != nil && *tag.CreatedBy.Username != "" {
+		resp.CreatedByUsername = tag.CreatedBy.Username
 	}
 
 	if len(tag.Aliases) > 0 {

--- a/backend/internal/api/handlers/tag_integration_test.go
+++ b/backend/internal/api/handlers/tag_integration_test.go
@@ -72,6 +72,26 @@ func (s *TagHandlerIntegrationSuite) TestCreateTag_Success() {
 	s.Equal("genre", resp.Body.Category)
 	s.NotEmpty(resp.Body.Slug)
 	s.NotZero(resp.Body.ID)
+
+	// Verify created_by attribution
+	s.NotNil(resp.Body.CreatedByUserID)
+	s.Equal(admin.ID, *resp.Body.CreatedByUserID)
+	// CreatedByUsername may be nil if test user has no username set
+}
+
+func (s *TagHandlerIntegrationSuite) TestCreateTag_CreatedByIncludedInGetResponse() {
+	admin := createAdminUser(s.deps.db)
+	created := s.createTagViaHandler(admin, "math-rock", models.TagCategoryGenre)
+
+	// Fetch via GetTag and verify attribution persists
+	ctx := ctxWithUser(admin)
+	getReq := &GetTagRequest{TagID: fmt.Sprintf("%d", created.Body.ID)}
+	getResp, err := s.handler.GetTagHandler(ctx, getReq)
+	s.NoError(err)
+	s.NotNil(getResp)
+	s.NotNil(getResp.Body.CreatedByUserID)
+	s.Equal(admin.ID, *getResp.Body.CreatedByUserID)
+	// CreatedByUsername may be nil if test user has no username set
 }
 
 func (s *TagHandlerIntegrationSuite) TestCreateTag_WithDescription() {

--- a/backend/internal/models/tag.go
+++ b/backend/internal/models/tag.go
@@ -44,16 +44,18 @@ type Tag struct {
 	Description *string   `json:"description,omitempty" gorm:"column:description"`
 	ParentID    *uint     `json:"parent_id,omitempty" gorm:"column:parent_id"`
 	Category    string    `json:"category" gorm:"column:category;not null;default:'genre';size:50"`
-	IsOfficial  bool      `json:"is_official" gorm:"column:is_official;not null;default:false"`
-	UsageCount  int       `json:"usage_count" gorm:"column:usage_count;not null;default:0"`
-	CreatedAt   time.Time `json:"created_at"`
-	UpdatedAt   time.Time `json:"updated_at"`
+	IsOfficial      bool      `json:"is_official" gorm:"column:is_official;not null;default:false"`
+	UsageCount      int       `json:"usage_count" gorm:"column:usage_count;not null;default:0"`
+	CreatedByUserID *uint     `json:"created_by_user_id,omitempty" gorm:"column:created_by_user_id"`
+	CreatedAt       time.Time `json:"created_at"`
+	UpdatedAt       time.Time `json:"updated_at"`
 
 	// Relationships
-	Parent   *Tag        `json:"parent,omitempty" gorm:"foreignKey:ParentID"`
-	Children []Tag       `json:"children,omitempty" gorm:"foreignKey:ParentID"`
-	Aliases  []TagAlias  `json:"aliases,omitempty" gorm:"foreignKey:TagID"`
-	Entities []EntityTag `json:"-" gorm:"foreignKey:TagID"`
+	Parent    *Tag        `json:"parent,omitempty" gorm:"foreignKey:ParentID"`
+	Children  []Tag       `json:"children,omitempty" gorm:"foreignKey:ParentID"`
+	Aliases   []TagAlias  `json:"aliases,omitempty" gorm:"foreignKey:TagID"`
+	Entities  []EntityTag `json:"-" gorm:"foreignKey:TagID"`
+	CreatedBy *User       `json:"-" gorm:"foreignKey:CreatedByUserID"`
 }
 
 // TableName specifies the table name for Tag.

--- a/backend/internal/services/catalog/tag_service.go
+++ b/backend/internal/services/catalog/tag_service.go
@@ -32,8 +32,8 @@ func NewTagService(database *gorm.DB) *TagService {
 // CRUD
 // ──────────────────────────────────────────────
 
-// CreateTag creates a new tag.
-func (s *TagService) CreateTag(name string, description *string, parentID *uint, category string, isOfficial bool) (*models.Tag, error) {
+// CreateTag creates a new tag. If userID is non-nil, it records who created the tag.
+func (s *TagService) CreateTag(name string, description *string, parentID *uint, category string, isOfficial bool, userID *uint) (*models.Tag, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
@@ -57,19 +57,21 @@ func (s *TagService) CreateTag(name string, description *string, parentID *uint,
 	})
 
 	tag := &models.Tag{
-		Name:        name,
-		Slug:        slug,
-		Description: description,
-		ParentID:    parentID,
-		Category:    category,
-		IsOfficial:  isOfficial,
+		Name:            name,
+		Slug:            slug,
+		Description:     description,
+		ParentID:        parentID,
+		Category:        category,
+		IsOfficial:      isOfficial,
+		CreatedByUserID: userID,
 	}
 
 	if err := s.db.Create(tag).Error; err != nil {
 		return nil, fmt.Errorf("failed to create tag: %w", err)
 	}
 
-	return tag, nil
+	// Reload with relationships (CreatedBy, Parent, Children, Aliases) for response
+	return s.GetTag(tag.ID)
 }
 
 // GetTag retrieves a tag by ID with relationships.
@@ -79,7 +81,7 @@ func (s *TagService) GetTag(tagID uint) (*models.Tag, error) {
 	}
 
 	var tag models.Tag
-	err := s.db.Preload("Parent").Preload("Children").Preload("Aliases").First(&tag, tagID).Error
+	err := s.db.Preload("Parent").Preload("Children").Preload("Aliases").Preload("CreatedBy").First(&tag, tagID).Error
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return nil, nil
@@ -97,7 +99,7 @@ func (s *TagService) GetTagBySlug(slug string) (*models.Tag, error) {
 	}
 
 	var tag models.Tag
-	err := s.db.Preload("Parent").Preload("Children").Preload("Aliases").
+	err := s.db.Preload("Parent").Preload("Children").Preload("Aliases").Preload("CreatedBy").
 		Where("slug = ?", slug).First(&tag).Error
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {

--- a/backend/internal/services/catalog/tag_service_test.go
+++ b/backend/internal/services/catalog/tag_service_test.go
@@ -98,7 +98,7 @@ func (suite *TagServiceIntegrationTestSuite) createTestUser(name string) *models
 }
 
 func (suite *TagServiceIntegrationTestSuite) createTag(name, category string) *models.Tag {
-	tag, err := suite.tagService.CreateTag(name, nil, nil, category, false)
+	tag, err := suite.tagService.CreateTag(name, nil, nil, category, false, nil)
 	suite.Require().NoError(err)
 	return tag
 }
@@ -118,7 +118,7 @@ func (suite *TagServiceIntegrationTestSuite) createArtist(name string) uint {
 
 func (suite *TagServiceIntegrationTestSuite) TestCreateTag_Success() {
 	desc := "A subgenre of punk rock"
-	tag, err := suite.tagService.CreateTag("Post-Punk", &desc, nil, "genre", true)
+	tag, err := suite.tagService.CreateTag("Post-Punk", &desc, nil, "genre", true, nil)
 	suite.Require().NoError(err)
 	suite.Require().NotNil(tag)
 
@@ -129,10 +129,11 @@ func (suite *TagServiceIntegrationTestSuite) TestCreateTag_Success() {
 	suite.Assert().NotNil(tag.Description)
 	suite.Assert().Equal("A subgenre of punk rock", *tag.Description)
 	suite.Assert().Equal(0, tag.UsageCount)
+	suite.Assert().Nil(tag.CreatedByUserID)
 }
 
 func (suite *TagServiceIntegrationTestSuite) TestCreateTag_InvalidCategory() {
-	tag, err := suite.tagService.CreateTag("Test", nil, nil, "invalid", false)
+	tag, err := suite.tagService.CreateTag("Test", nil, nil, "invalid", false, nil)
 	suite.Assert().Error(err)
 	suite.Assert().Contains(err.Error(), "invalid tag category")
 	suite.Assert().Nil(tag)
@@ -141,7 +142,7 @@ func (suite *TagServiceIntegrationTestSuite) TestCreateTag_InvalidCategory() {
 func (suite *TagServiceIntegrationTestSuite) TestCreateTag_DuplicateName() {
 	suite.createTag("rock", "genre")
 
-	tag, err := suite.tagService.CreateTag("Rock", nil, nil, "genre", false)
+	tag, err := suite.tagService.CreateTag("Rock", nil, nil, "genre", false, nil)
 	suite.Assert().Error(err)
 	var tagErr *apperrors.TagError
 	suite.Assert().ErrorAs(err, &tagErr)
@@ -152,10 +153,35 @@ func (suite *TagServiceIntegrationTestSuite) TestCreateTag_DuplicateName() {
 func (suite *TagServiceIntegrationTestSuite) TestCreateTag_WithParent() {
 	parent := suite.createTag("rock", "genre")
 
-	child, err := suite.tagService.CreateTag("post-punk", nil, &parent.ID, "genre", false)
+	child, err := suite.tagService.CreateTag("post-punk", nil, &parent.ID, "genre", false, nil)
 	suite.Require().NoError(err)
 	suite.Assert().NotNil(child.ParentID)
 	suite.Assert().Equal(parent.ID, *child.ParentID)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestCreateTag_WithUserID() {
+	user := suite.createTestUser("creator")
+
+	tag, err := suite.tagService.CreateTag("Ambient", nil, nil, "genre", false, &user.ID)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(tag)
+	suite.Assert().NotNil(tag.CreatedByUserID)
+	suite.Assert().Equal(user.ID, *tag.CreatedByUserID)
+
+	// Verify persisted and preloaded via GetTag
+	fetched, err := suite.tagService.GetTag(tag.ID)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(fetched)
+	suite.Assert().NotNil(fetched.CreatedByUserID)
+	suite.Assert().Equal(user.ID, *fetched.CreatedByUserID)
+	suite.Assert().NotNil(fetched.CreatedBy)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestCreateTag_NilUserID() {
+	tag, err := suite.tagService.CreateTag("NoCreator", nil, nil, "genre", false, nil)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(tag)
+	suite.Assert().Nil(tag.CreatedByUserID)
 }
 
 func (suite *TagServiceIntegrationTestSuite) TestGetTag_ByID() {
@@ -225,7 +251,7 @@ func (suite *TagServiceIntegrationTestSuite) TestListTags_FilterByParent() {
 	parent := suite.createTag("rock", "genre")
 	suite.createTag("post-punk", "genre")
 	// Make post-rock a child of rock
-	suite.tagService.CreateTag("post-rock", nil, &parent.ID, "genre", false)
+	suite.tagService.CreateTag("post-rock", nil, &parent.ID, "genre", false, nil)
 
 	tags, total, err := suite.tagService.ListTags("", "", &parent.ID, "name", 50, 0)
 	suite.Require().NoError(err)
@@ -614,7 +640,7 @@ func (suite *TagServiceIntegrationTestSuite) TestPruneDownvotedTags() {
 func (suite *TagServiceIntegrationTestSuite) TestPruneDownvotedTags_OfficialImmune() {
 	user1 := suite.createTestUser("voter1")
 	user2 := suite.createTestUser("voter2")
-	tag, _ := suite.tagService.CreateTag("official-tag", nil, nil, "genre", true)
+	tag, _ := suite.tagService.CreateTag("official-tag", nil, nil, "genre", true, nil)
 	artistID := suite.createArtist("Some Official Band")
 
 	suite.tagService.AddTagToEntity(tag.ID, "", "artist", artistID, user1.ID, "")

--- a/backend/internal/services/contracts/tag.go
+++ b/backend/internal/services/contracts/tag.go
@@ -12,19 +12,21 @@ import (
 
 // TagResponse represents a tag returned to clients.
 type TagResponse struct {
-	ID           uint               `json:"id"`
-	Name         string             `json:"name"`
-	Slug         string             `json:"slug"`
-	Description  *string            `json:"description,omitempty"`
-	ParentID     *uint              `json:"parent_id,omitempty"`
-	ParentName   string             `json:"parent_name,omitempty"`
-	Category     string             `json:"category"`
-	IsOfficial   bool               `json:"is_official"`
-	UsageCount   int                `json:"usage_count"`
-	ChildCount   int                `json:"child_count"`
-	Aliases      []string           `json:"aliases,omitempty"`
-	CreatedAt    time.Time          `json:"created_at"`
-	UpdatedAt    time.Time          `json:"updated_at"`
+	ID                uint      `json:"id"`
+	Name              string    `json:"name"`
+	Slug              string    `json:"slug"`
+	Description       *string   `json:"description,omitempty"`
+	ParentID          *uint     `json:"parent_id,omitempty"`
+	ParentName        string    `json:"parent_name,omitempty"`
+	Category          string    `json:"category"`
+	IsOfficial        bool      `json:"is_official"`
+	UsageCount        int       `json:"usage_count"`
+	ChildCount        int       `json:"child_count"`
+	Aliases           []string  `json:"aliases,omitempty"`
+	CreatedByUserID   *uint     `json:"created_by_user_id,omitempty"`
+	CreatedByUsername *string   `json:"created_by_username,omitempty"`
+	CreatedAt         time.Time `json:"created_at"`
+	UpdatedAt         time.Time `json:"updated_at"`
 }
 
 // TagListItem represents a tag in a list response.
@@ -69,7 +71,7 @@ type TagAliasResponse struct {
 // TagServiceInterface defines the contract for tag operations.
 type TagServiceInterface interface {
 	// CRUD
-	CreateTag(name string, description *string, parentID *uint, category string, isOfficial bool) (*models.Tag, error)
+	CreateTag(name string, description *string, parentID *uint, category string, isOfficial bool, userID *uint) (*models.Tag, error)
 	GetTag(tagID uint) (*models.Tag, error)
 	GetTagBySlug(slug string) (*models.Tag, error)
 	ListTags(category string, search string, parentID *uint, sort string, limit, offset int) ([]models.Tag, int64, error)

--- a/docs/llm-context.md
+++ b/docs/llm-context.md
@@ -97,5 +97,5 @@ See `docs/vision.md` for the full north star, What.cd feature mapping, and entit
 - **Fire-and-forget** — Discord notifications and audit logs never fail parent operations
 - **JSONB columns** — use `*json.RawMessage` (not `datatypes.JSON`)
 - **Huma quirks** — all request body fields required by default, even pointers; mark optional explicitly. Query/path/header params must NOT use pointer types (`*uint`, `*string`) — Huma panics; use value types with zero-value checks instead.
-- **Migration numbering** — latest is 000066 (add_comment_moderation_fields); next is 000067
+- **Migration numbering** — latest is 000067 (add_tag_created_by); next is 000068
 

--- a/frontend/features/tags/components/TagDetail.test.tsx
+++ b/frontend/features/tags/components/TagDetail.test.tsx
@@ -356,6 +356,36 @@ describe('TagDetail', () => {
     expect(screen.queryByText('Also known as')).not.toBeInTheDocument()
   })
 
+  // ── Created by ──
+
+  it('renders "Created by @username" when created_by_username is present', () => {
+    mockUseTag.mockReturnValue({
+      data: makeTagDetail({ created_by_username: 'johndoe' }),
+      isLoading: false,
+      error: null,
+    })
+
+    renderWithProviders(<TagDetail slug="rock" />)
+
+    expect(screen.getByText('@johndoe')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: '@johndoe' })).toHaveAttribute(
+      'href',
+      '/users/johndoe'
+    )
+  })
+
+  it('does not render creator when created_by_username is absent', () => {
+    mockUseTag.mockReturnValue({
+      data: makeTagDetail(),
+      isLoading: false,
+      error: null,
+    })
+
+    renderWithProviders(<TagDetail slug="rock" />)
+
+    expect(screen.queryByText(/Created by/)).not.toBeInTheDocument()
+  })
+
   // ── NotifyMeButton ──
 
   it('renders NotifyMeButton with correct props', () => {

--- a/frontend/features/tags/components/TagDetail.tsx
+++ b/frontend/features/tags/components/TagDetail.tsx
@@ -109,6 +109,20 @@ export function TagDetail({ slug }: TagDetailProps) {
               <span className="text-sm text-muted-foreground">
                 {tag.usage_count} {tag.usage_count === 1 ? 'use' : 'uses'}
               </span>
+              {tag.created_by_username && (
+                <>
+                  <span className="text-muted-foreground/40">{'·'}</span>
+                  <span className="text-sm text-muted-foreground">
+                    Created by{' '}
+                    <Link
+                      href={`/users/${tag.created_by_username}`}
+                      className="hover:underline"
+                    >
+                      @{tag.created_by_username}
+                    </Link>
+                  </span>
+                </>
+              )}
             </div>
 
             {tag.description && (

--- a/frontend/features/tags/types.ts
+++ b/frontend/features/tags/types.ts
@@ -26,6 +26,8 @@ export interface TagDetailResponse extends TagListItem {
   parent_name?: string
   child_count: number
   aliases: string[]
+  created_by_user_id?: number
+  created_by_username?: string
   updated_at: string
 }
 


### PR DESCRIPTION
## Summary
- **Migration 000067**: adds nullable `created_by_user_id` column to `tags` table with FK to users
- **Backend**: `CreateTag` sets creator, `GetTag`/`GetTagBySlug` preload the relationship, response includes `created_by_user_id` and `created_by_username`
- **Frontend**: tag detail page shows "Created by @username" linked to profile (gracefully hidden when null)
- **4 new backend tests**: creation with userID, nil userID, response includes creator, GET preserves creator

Closes PSY-300

## Test plan
- [x] Migration applies and rolls back cleanly
- [x] CreateTag persists created_by_user_id
- [x] Tag detail response includes creator info
- [x] Frontend renders "Created by" when present, hides when null
- [x] All existing tests updated for new parameter
- [x] `go build ./...` and `bun run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)