### PR TITLE
Add descriptive SEO titles to radio pages

### DIFF
--- a/frontend/app/radio/[station-slug]/[show-slug]/[date]/_components/EpisodeDateDetail.tsx
+++ b/frontend/app/radio/[station-slug]/[show-slug]/[date]/_components/EpisodeDateDetail.tsx
@@ -1,0 +1,228 @@
+'use client'
+
+import Link from 'next/link'
+import {
+  ArrowLeft,
+  Loader2,
+  Calendar,
+  Clock,
+  Music,
+  ExternalLink,
+  Headphones,
+} from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { useRadioEpisode, RadioPlayRow } from '@/features/radio'
+
+interface EpisodeDateDetailProps {
+  stationSlug: string
+  showSlug: string
+  date: string
+}
+
+function formatDate(dateStr: string): string {
+  const date = new Date(dateStr + 'T00:00:00')
+  return date.toLocaleDateString('en-US', {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+
+/**
+ * Format a time string like "06:00:00" or "21:30:00" into "6:00 AM" or "9:30 PM".
+ */
+function formatAirTime(timeStr: string): string {
+  const [hoursStr, minutesStr] = timeStr.split(':')
+  const hours = parseInt(hoursStr, 10)
+  const minutes = parseInt(minutesStr, 10)
+  if (isNaN(hours) || isNaN(minutes)) return timeStr
+  const period = hours >= 12 ? 'PM' : 'AM'
+  const displayHours = hours === 0 ? 12 : hours > 12 ? hours - 12 : hours
+  const displayMinutes = minutes.toString().padStart(2, '0')
+  return `${displayHours}:${displayMinutes} ${period}`
+}
+
+export default function EpisodeDateDetail({ stationSlug, showSlug, date }: EpisodeDateDetailProps) {
+  const { data: episode, isLoading, error } = useRadioEpisode(showSlug, date)
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  if (error || !episode) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold mb-2">Episode Not Found</h1>
+          <p className="text-muted-foreground mb-4">
+            No episode found for {date}.
+          </p>
+          <Button asChild variant="outline">
+            <Link href={`/radio/${stationSlug}/${showSlug}`}>
+              <ArrowLeft className="h-4 w-4 mr-2" />
+              Back to Show
+            </Link>
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  const title = episode.title || formatDate(episode.air_date)
+  const plays = episode.plays ?? []
+  const genreTags = episode.genre_tags ?? []
+  const moodTags = episode.mood_tags ?? []
+
+  return (
+    <div className="flex min-h-screen items-start justify-center">
+      <main className="w-full max-w-4xl px-4 py-8 md:px-8">
+        {/* Breadcrumb */}
+        <div className="mb-6 flex items-center gap-1.5 text-sm text-muted-foreground">
+          <Link
+            href="/radio"
+            className="hover:text-foreground transition-colors"
+          >
+            Radio
+          </Link>
+          <span>/</span>
+          <Link
+            href={`/radio/${stationSlug}`}
+            className="hover:text-foreground transition-colors"
+          >
+            {episode.station_name}
+          </Link>
+          <span>/</span>
+          <Link
+            href={`/radio/${stationSlug}/${showSlug}`}
+            className="hover:text-foreground transition-colors"
+          >
+            {episode.show_name}
+          </Link>
+        </div>
+
+        {/* Episode header */}
+        <div className="mb-8">
+          <h1 className="text-2xl font-bold">{title}</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            <Link
+              href={`/radio/${stationSlug}/${showSlug}`}
+              className="hover:text-foreground transition-colors"
+            >
+              {episode.show_name}
+            </Link>
+            {' on '}
+            <Link
+              href={`/radio/${stationSlug}`}
+              className="hover:text-foreground transition-colors"
+            >
+              {episode.station_name}
+            </Link>
+          </p>
+
+          <div className="flex items-center gap-3 flex-wrap mt-3">
+            <span className="flex items-center gap-1 text-sm text-muted-foreground">
+              <Calendar className="h-3.5 w-3.5" />
+              {formatDate(episode.air_date)}
+            </span>
+            {episode.air_time && (
+              <span className="flex items-center gap-1 text-sm text-muted-foreground">
+                <Clock className="h-3.5 w-3.5" />
+                {formatAirTime(episode.air_time)}
+              </span>
+            )}
+            {episode.duration_minutes && (
+              <span className="text-sm text-muted-foreground">
+                {episode.duration_minutes} min
+              </span>
+            )}
+            <span className="flex items-center gap-1 text-sm text-muted-foreground">
+              <Music className="h-3.5 w-3.5" />
+              {episode.play_count} tracks
+            </span>
+          </div>
+
+          {/* Tags */}
+          {(genreTags.length > 0 || moodTags.length > 0) && (
+            <div className="flex items-center gap-1.5 flex-wrap mt-3">
+              {genreTags.map(tag => (
+                <Badge key={tag} variant="secondary" className="text-[10px] px-1.5 py-0">
+                  {tag}
+                </Badge>
+              ))}
+              {moodTags.map(tag => (
+                <Badge key={tag} variant="outline" className="text-[10px] px-1.5 py-0">
+                  {tag}
+                </Badge>
+              ))}
+            </div>
+          )}
+
+          {/* External links */}
+          <div className="flex items-center gap-2 mt-4">
+            {episode.archive_url && (
+              <Button asChild variant="outline" size="sm">
+                <a
+                  href={episode.archive_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <Headphones className="h-4 w-4 mr-2" />
+                  Listen to Archive
+                  <ExternalLink className="h-3 w-3 ml-1" />
+                </a>
+              </Button>
+            )}
+            {episode.mixcloud_url && (
+              <Button asChild variant="outline" size="sm">
+                <a
+                  href={episode.mixcloud_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <Headphones className="h-4 w-4 mr-2" />
+                  Mixcloud
+                  <ExternalLink className="h-3 w-3 ml-1" />
+                </a>
+              </Button>
+            )}
+          </div>
+
+          {episode.description && (
+            <p className="text-sm text-muted-foreground leading-relaxed mt-4">
+              {episode.description}
+            </p>
+          )}
+        </div>
+
+        {/* Playlist */}
+        <section>
+          <h2 className="text-lg font-bold mb-3 flex items-center gap-2">
+            <Music className="h-5 w-5" />
+            Playlist
+            <span className="text-sm font-normal text-muted-foreground">
+              ({plays.length} {plays.length === 1 ? 'track' : 'tracks'})
+            </span>
+          </h2>
+
+          {plays.length > 0 ? (
+            <div className="space-y-0.5 border border-border/50 rounded-lg p-2">
+              {plays.map(play => (
+                <RadioPlayRow key={play.id} play={play} />
+              ))}
+            </div>
+          ) : (
+            <div className="py-8 text-center text-sm text-muted-foreground">
+              No playlist data available for this episode
+            </div>
+          )}
+        </section>
+      </main>
+    </div>
+  )
+}

--- a/frontend/app/radio/[station-slug]/[show-slug]/[date]/page.tsx
+++ b/frontend/app/radio/[station-slug]/[show-slug]/[date]/page.tsx
@@ -1,19 +1,12 @@
-'use client'
+import { Metadata } from 'next'
+import * as Sentry from '@sentry/nextjs'
+import EpisodeDateDetail from './_components/EpisodeDateDetail'
 
-import { use } from 'react'
-import Link from 'next/link'
-import {
-  ArrowLeft,
-  Loader2,
-  Calendar,
-  Clock,
-  Music,
-  ExternalLink,
-  Headphones,
-} from 'lucide-react'
-import { Button } from '@/components/ui/button'
-import { Badge } from '@/components/ui/badge'
-import { useRadioEpisode, RadioPlayRow } from '@/features/radio'
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL ||
+  (process.env.NODE_ENV === 'development'
+    ? 'http://localhost:8080'
+    : 'https://api.psychichomily.com')
 
 interface EpisodeDatePageProps {
   params: Promise<{
@@ -23,214 +16,84 @@ interface EpisodeDatePageProps {
   }>
 }
 
-function formatDate(dateStr: string): string {
+interface EpisodeData {
+  show_name: string
+  show_slug?: string
+  station_name: string
+  station_slug?: string
+  title?: string | null
+  air_date: string
+  description?: string | null
+  play_count: number
+}
+
+function formatShortDate(dateStr: string): string {
   const date = new Date(dateStr + 'T00:00:00')
   return date.toLocaleDateString('en-US', {
-    weekday: 'long',
-    month: 'long',
+    month: 'short',
     day: 'numeric',
     year: 'numeric',
   })
 }
 
-/**
- * Format a time string like "06:00:00" or "21:30:00" into "6:00 AM" or "9:30 PM".
- */
-function formatAirTime(timeStr: string): string {
-  const [hoursStr, minutesStr] = timeStr.split(':')
-  const hours = parseInt(hoursStr, 10)
-  const minutes = parseInt(minutesStr, 10)
-  if (isNaN(hours) || isNaN(minutes)) return timeStr
-  const period = hours >= 12 ? 'PM' : 'AM'
-  const displayHours = hours === 0 ? 12 : hours > 12 ? hours - 12 : hours
-  const displayMinutes = minutes.toString().padStart(2, '0')
-  return `${displayHours}:${displayMinutes} ${period}`
+async function getEpisode(showSlug: string, date: string): Promise<EpisodeData | null> {
+  try {
+    const res = await fetch(`${API_BASE_URL}/radio-shows/${showSlug}/episodes/${date}`, {
+      next: { revalidate: 3600 },
+    })
+    if (res.ok) {
+      return res.json()
+    }
+    if (res.status >= 500) {
+      Sentry.captureMessage(`Radio episode page fetch error: ${res.status}`, {
+        level: 'error',
+        tags: { service: 'radio-episode-page' },
+        extra: { showSlug, date, status: res.status },
+      })
+    }
+  } catch (error) {
+    Sentry.captureException(error, {
+      level: 'error',
+      tags: { service: 'radio-episode-page' },
+      extra: { showSlug, date },
+    })
+  }
+  return null
 }
 
-export default function EpisodeDatePage({ params }: EpisodeDatePageProps) {
-  const {
-    'station-slug': stationSlug,
-    'show-slug': showSlug,
-    date,
-  } = use(params)
-  const { data: episode, isLoading, error } = useRadioEpisode(showSlug, date)
+export async function generateMetadata({ params }: EpisodeDatePageProps): Promise<Metadata> {
+  const { 'station-slug': stationSlug, 'show-slug': showSlug, date } = await params
+  const episode = await getEpisode(showSlug, date)
 
-  if (isLoading) {
-    return (
-      <div className="flex min-h-[60vh] items-center justify-center">
-        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-      </div>
-    )
+  if (episode) {
+    const formattedDate = formatShortDate(episode.air_date)
+    const title = `${episode.show_name} — ${formattedDate}`
+    const description = episode.description
+      ? episode.description.slice(0, 155) + (episode.description.length > 155 ? '...' : '')
+      : `${episode.show_name} episode from ${formattedDate} on ${episode.station_name} — ${episode.play_count} tracks`
+
+    return {
+      title,
+      description,
+      alternates: {
+        canonical: `https://psychichomily.com/radio/${stationSlug}/${showSlug}/${date}`,
+      },
+      openGraph: {
+        title,
+        description,
+        type: 'website',
+        url: `/radio/${stationSlug}/${showSlug}/${date}`,
+      },
+    }
   }
 
-  if (error || !episode) {
-    return (
-      <div className="flex min-h-[60vh] items-center justify-center">
-        <div className="text-center">
-          <h1 className="text-2xl font-bold mb-2">Episode Not Found</h1>
-          <p className="text-muted-foreground mb-4">
-            No episode found for {date}.
-          </p>
-          <Button asChild variant="outline">
-            <Link href={`/radio/${stationSlug}/${showSlug}`}>
-              <ArrowLeft className="h-4 w-4 mr-2" />
-              Back to Show
-            </Link>
-          </Button>
-        </div>
-      </div>
-    )
+  return {
+    title: 'Radio Episode',
+    description: 'View radio episode playlist and details',
   }
+}
 
-  const title = episode.title || formatDate(episode.air_date)
-  const plays = episode.plays ?? []
-  const genreTags = episode.genre_tags ?? []
-  const moodTags = episode.mood_tags ?? []
-
-  return (
-    <div className="flex min-h-screen items-start justify-center">
-      <main className="w-full max-w-4xl px-4 py-8 md:px-8">
-        {/* Breadcrumb */}
-        <div className="mb-6 flex items-center gap-1.5 text-sm text-muted-foreground">
-          <Link
-            href="/radio"
-            className="hover:text-foreground transition-colors"
-          >
-            Radio
-          </Link>
-          <span>/</span>
-          <Link
-            href={`/radio/${stationSlug}`}
-            className="hover:text-foreground transition-colors"
-          >
-            {episode.station_name}
-          </Link>
-          <span>/</span>
-          <Link
-            href={`/radio/${stationSlug}/${showSlug}`}
-            className="hover:text-foreground transition-colors"
-          >
-            {episode.show_name}
-          </Link>
-        </div>
-
-        {/* Episode header */}
-        <div className="mb-8">
-          <h1 className="text-2xl font-bold">{title}</h1>
-          <p className="text-sm text-muted-foreground mt-1">
-            <Link
-              href={`/radio/${stationSlug}/${showSlug}`}
-              className="hover:text-foreground transition-colors"
-            >
-              {episode.show_name}
-            </Link>
-            {' on '}
-            <Link
-              href={`/radio/${stationSlug}`}
-              className="hover:text-foreground transition-colors"
-            >
-              {episode.station_name}
-            </Link>
-          </p>
-
-          <div className="flex items-center gap-3 flex-wrap mt-3">
-            <span className="flex items-center gap-1 text-sm text-muted-foreground">
-              <Calendar className="h-3.5 w-3.5" />
-              {formatDate(episode.air_date)}
-            </span>
-            {episode.air_time && (
-              <span className="flex items-center gap-1 text-sm text-muted-foreground">
-                <Clock className="h-3.5 w-3.5" />
-                {formatAirTime(episode.air_time)}
-              </span>
-            )}
-            {episode.duration_minutes && (
-              <span className="text-sm text-muted-foreground">
-                {episode.duration_minutes} min
-              </span>
-            )}
-            <span className="flex items-center gap-1 text-sm text-muted-foreground">
-              <Music className="h-3.5 w-3.5" />
-              {episode.play_count} tracks
-            </span>
-          </div>
-
-          {/* Tags */}
-          {(genreTags.length > 0 || moodTags.length > 0) && (
-            <div className="flex items-center gap-1.5 flex-wrap mt-3">
-              {genreTags.map(tag => (
-                <Badge key={tag} variant="secondary" className="text-[10px] px-1.5 py-0">
-                  {tag}
-                </Badge>
-              ))}
-              {moodTags.map(tag => (
-                <Badge key={tag} variant="outline" className="text-[10px] px-1.5 py-0">
-                  {tag}
-                </Badge>
-              ))}
-            </div>
-          )}
-
-          {/* External links */}
-          <div className="flex items-center gap-2 mt-4">
-            {episode.archive_url && (
-              <Button asChild variant="outline" size="sm">
-                <a
-                  href={episode.archive_url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <Headphones className="h-4 w-4 mr-2" />
-                  Listen to Archive
-                  <ExternalLink className="h-3 w-3 ml-1" />
-                </a>
-              </Button>
-            )}
-            {episode.mixcloud_url && (
-              <Button asChild variant="outline" size="sm">
-                <a
-                  href={episode.mixcloud_url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <Headphones className="h-4 w-4 mr-2" />
-                  Mixcloud
-                  <ExternalLink className="h-3 w-3 ml-1" />
-                </a>
-              </Button>
-            )}
-          </div>
-
-          {episode.description && (
-            <p className="text-sm text-muted-foreground leading-relaxed mt-4">
-              {episode.description}
-            </p>
-          )}
-        </div>
-
-        {/* Playlist */}
-        <section>
-          <h2 className="text-lg font-bold mb-3 flex items-center gap-2">
-            <Music className="h-5 w-5" />
-            Playlist
-            <span className="text-sm font-normal text-muted-foreground">
-              ({plays.length} {plays.length === 1 ? 'track' : 'tracks'})
-            </span>
-          </h2>
-
-          {plays.length > 0 ? (
-            <div className="space-y-0.5 border border-border/50 rounded-lg p-2">
-              {plays.map(play => (
-                <RadioPlayRow key={play.id} play={play} />
-              ))}
-            </div>
-          ) : (
-            <div className="py-8 text-center text-sm text-muted-foreground">
-              No playlist data available for this episode
-            </div>
-          )}
-        </section>
-      </main>
-    </div>
-  )
+export default async function EpisodeDatePage({ params }: EpisodeDatePageProps) {
+  const { 'station-slug': stationSlug, 'show-slug': showSlug, date } = await params
+  return <EpisodeDateDetail stationSlug={stationSlug} showSlug={showSlug} date={date} />
 }

--- a/frontend/app/radio/[station-slug]/[show-slug]/_components/RadioShowDetail.tsx
+++ b/frontend/app/radio/[station-slug]/[show-slug]/_components/RadioShowDetail.tsx
@@ -1,0 +1,312 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import {
+  ArrowLeft,
+  Loader2,
+  Mic2,
+  Calendar,
+  Tag,
+  Music,
+  ChevronLeft,
+  ChevronRight,
+} from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import {
+  useRadioShow,
+  useRadioEpisodes,
+  useRadioTopArtists,
+  useRadioTopLabels,
+  RadioEpisodeRow,
+} from '@/features/radio'
+import type { RadioTopArtist, RadioTopLabel } from '@/features/radio'
+
+interface RadioShowDetailProps {
+  stationSlug: string
+  showSlug: string
+}
+
+function TopArtistsSidebar({ showSlug }: { showSlug: string }) {
+  const { data, isLoading } = useRadioTopArtists({ showSlug, limit: 10 })
+
+  if (isLoading || !data?.artists || data.artists.length === 0) return null
+
+  return (
+    <div>
+      <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+        Top Artists (90d)
+      </h3>
+      <div className="space-y-1">
+        {data.artists.map((artist: RadioTopArtist) => (
+          <div
+            key={artist.artist_name}
+            className="flex items-center justify-between py-0.5"
+          >
+            {artist.artist_slug ? (
+              <Link
+                href={`/artists/${artist.artist_slug}`}
+                className="text-sm text-muted-foreground hover:text-foreground transition-colors truncate mr-2"
+              >
+                {artist.artist_name}
+              </Link>
+            ) : (
+              <span className="text-sm text-muted-foreground truncate mr-2">
+                {artist.artist_name}
+              </span>
+            )}
+            <span className="text-xs text-muted-foreground/60 tabular-nums shrink-0">
+              {artist.play_count}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function TopLabelsSidebar({ showSlug }: { showSlug: string }) {
+  const { data, isLoading } = useRadioTopLabels({ showSlug, limit: 10 })
+
+  if (isLoading || !data?.labels || data.labels.length === 0) return null
+
+  return (
+    <div>
+      <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+        Top Labels (90d)
+      </h3>
+      <div className="space-y-1">
+        {data.labels.map((label: RadioTopLabel) => (
+          <div
+            key={label.label_name}
+            className="flex items-center justify-between py-0.5"
+          >
+            {label.label_slug ? (
+              <Link
+                href={`/labels/${label.label_slug}`}
+                className="text-sm text-muted-foreground hover:text-foreground transition-colors truncate mr-2"
+              >
+                {label.label_name}
+              </Link>
+            ) : (
+              <span className="text-sm text-muted-foreground truncate mr-2">
+                {label.label_name}
+              </span>
+            )}
+            <span className="text-xs text-muted-foreground/60 tabular-nums shrink-0">
+              {label.play_count}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+const PAGE_SIZE = 20
+
+export default function RadioShowDetail({ stationSlug, showSlug }: RadioShowDetailProps) {
+  const { data: show, isLoading, error } = useRadioShow(showSlug)
+  const [offset, setOffset] = useState(0)
+  const { data: episodesData, isLoading: episodesLoading } = useRadioEpisodes({
+    showSlug,
+    limit: PAGE_SIZE,
+    offset,
+    enabled: !!show,
+  })
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  if (error || !show) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold mb-2">Show Not Found</h1>
+          <p className="text-muted-foreground mb-4">
+            The radio show you&apos;re looking for doesn&apos;t exist.
+          </p>
+          <Button asChild variant="outline">
+            <Link href={`/radio/${stationSlug}`}>
+              <ArrowLeft className="h-4 w-4 mr-2" />
+              Back to Station
+            </Link>
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  const genreTags = show.genre_tags ?? []
+  const total = episodesData?.total ?? 0
+  const hasNextPage = offset + PAGE_SIZE < total
+  const hasPrevPage = offset > 0
+
+  return (
+    <div className="flex min-h-screen items-start justify-center">
+      <main className="w-full max-w-6xl px-4 py-8 md:px-8">
+        {/* Breadcrumb */}
+        <div className="mb-6 flex items-center gap-1.5 text-sm text-muted-foreground">
+          <Link
+            href="/radio"
+            className="hover:text-foreground transition-colors"
+          >
+            Radio
+          </Link>
+          <span>/</span>
+          <Link
+            href={`/radio/${stationSlug}`}
+            className="hover:text-foreground transition-colors"
+          >
+            {show.station_name}
+          </Link>
+        </div>
+
+        <div className="flex flex-col lg:flex-row gap-8">
+          {/* Main content */}
+          <div className="flex-1 min-w-0">
+            {/* Show header */}
+            <div className="flex items-start gap-4 mb-6">
+              <div className="shrink-0 rounded-lg bg-muted/50 flex items-center justify-center overflow-hidden h-16 w-16">
+                {show.image_url ? (
+                  <img
+                    src={show.image_url}
+                    alt={show.name}
+                    className="h-full w-full object-cover"
+                  />
+                ) : (
+                  <Mic2 className="h-8 w-8 text-muted-foreground/40" />
+                )}
+              </div>
+
+              <div className="flex-1 min-w-0">
+                <h1 className="text-2xl font-bold">{show.name}</h1>
+                <p className="text-sm text-muted-foreground mt-0.5">
+                  on{' '}
+                  <Link
+                    href={`/radio/${stationSlug}`}
+                    className="hover:text-foreground transition-colors"
+                  >
+                    {show.station_name}
+                  </Link>
+                </p>
+
+                {show.host_name && (
+                  <p className="text-sm text-muted-foreground mt-1">
+                    Hosted by {show.host_name}
+                  </p>
+                )}
+
+                <div className="flex items-center gap-2 flex-wrap mt-2">
+                  {show.schedule_display && (
+                    <span className="flex items-center gap-1 text-sm text-muted-foreground">
+                      <Calendar className="h-3.5 w-3.5" />
+                      {show.schedule_display}
+                    </span>
+                  )}
+                  {genreTags.length > 0 && (
+                    <div className="flex items-center gap-1">
+                      <Tag className="h-3.5 w-3.5 text-muted-foreground" />
+                      {genreTags.map(tag => (
+                        <Badge
+                          key={tag}
+                          variant="secondary"
+                          className="text-[10px] px-1.5 py-0"
+                        >
+                          {tag}
+                        </Badge>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            {show.description && (
+              <p className="text-sm text-muted-foreground leading-relaxed mb-6">
+                {show.description}
+              </p>
+            )}
+
+            {/* Episodes */}
+            <section>
+              <h2 className="text-lg font-bold mb-3 flex items-center gap-2">
+                <Music className="h-5 w-5" />
+                Recent Episodes
+                {total > 0 && (
+                  <span className="text-sm font-normal text-muted-foreground">
+                    ({total})
+                  </span>
+                )}
+              </h2>
+
+              {episodesLoading && (
+                <div className="flex justify-center py-8">
+                  <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+                </div>
+              )}
+
+              {!episodesLoading && episodesData?.episodes && episodesData.episodes.length > 0 ? (
+                <>
+                  <div className="space-y-0.5">
+                    {episodesData.episodes.map(episode => (
+                      <RadioEpisodeRow
+                        key={episode.id}
+                        episode={episode}
+                        stationSlug={stationSlug}
+                        showSlug={showSlug}
+                      />
+                    ))}
+                  </div>
+
+                  {/* Pagination */}
+                  {(hasNextPage || hasPrevPage) && (
+                    <div className="flex items-center justify-between mt-4 pt-4 border-t border-border/50">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+                        disabled={!hasPrevPage}
+                      >
+                        <ChevronLeft className="h-4 w-4 mr-1" />
+                        Newer
+                      </Button>
+                      <span className="text-xs text-muted-foreground">
+                        {offset + 1}-{Math.min(offset + PAGE_SIZE, total)} of {total}
+                      </span>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setOffset(offset + PAGE_SIZE)}
+                        disabled={!hasNextPage}
+                      >
+                        Older
+                        <ChevronRight className="h-4 w-4 ml-1" />
+                      </Button>
+                    </div>
+                  )}
+                </>
+              ) : !episodesLoading ? (
+                <div className="py-8 text-center text-sm text-muted-foreground">
+                  No episodes yet
+                </div>
+              ) : null}
+            </section>
+          </div>
+
+          {/* Sidebar */}
+          <aside className="w-full lg:w-64 shrink-0 space-y-6">
+            <TopArtistsSidebar showSlug={showSlug} />
+            <TopLabelsSidebar showSlug={showSlug} />
+          </aside>
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/frontend/app/radio/[station-slug]/[show-slug]/page.tsx
+++ b/frontend/app/radio/[station-slug]/[show-slug]/page.tsx
@@ -1,312 +1,83 @@
-'use client'
+import { Metadata } from 'next'
+import * as Sentry from '@sentry/nextjs'
+import RadioShowDetail from './_components/RadioShowDetail'
 
-import { use, useState } from 'react'
-import Link from 'next/link'
-import {
-  ArrowLeft,
-  Loader2,
-  Mic2,
-  Calendar,
-  Tag,
-  Music,
-  ChevronLeft,
-  ChevronRight,
-} from 'lucide-react'
-import { Button } from '@/components/ui/button'
-import { Badge } from '@/components/ui/badge'
-import {
-  useRadioShow,
-  useRadioEpisodes,
-  useRadioTopArtists,
-  useRadioTopLabels,
-  RadioEpisodeRow,
-} from '@/features/radio'
-import type { RadioTopArtist, RadioTopLabel } from '@/features/radio'
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL ||
+  (process.env.NODE_ENV === 'development'
+    ? 'http://localhost:8080'
+    : 'https://api.psychichomily.com')
 
 interface ShowPageProps {
   params: Promise<{ 'station-slug': string; 'show-slug': string }>
 }
 
-function TopArtistsSidebar({ showSlug }: { showSlug: string }) {
-  const { data, isLoading } = useRadioTopArtists({ showSlug, limit: 10 })
-
-  if (isLoading || !data?.artists || data.artists.length === 0) return null
-
-  return (
-    <div>
-      <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
-        Top Artists (90d)
-      </h3>
-      <div className="space-y-1">
-        {data.artists.map((artist: RadioTopArtist) => (
-          <div
-            key={artist.artist_name}
-            className="flex items-center justify-between py-0.5"
-          >
-            {artist.artist_slug ? (
-              <Link
-                href={`/artists/${artist.artist_slug}`}
-                className="text-sm text-muted-foreground hover:text-foreground transition-colors truncate mr-2"
-              >
-                {artist.artist_name}
-              </Link>
-            ) : (
-              <span className="text-sm text-muted-foreground truncate mr-2">
-                {artist.artist_name}
-              </span>
-            )}
-            <span className="text-xs text-muted-foreground/60 tabular-nums shrink-0">
-              {artist.play_count}
-            </span>
-          </div>
-        ))}
-      </div>
-    </div>
-  )
+interface RadioShowData {
+  name: string
+  slug?: string
+  station_name: string
+  station_slug?: string
+  host_name?: string | null
+  description?: string | null
 }
 
-function TopLabelsSidebar({ showSlug }: { showSlug: string }) {
-  const { data, isLoading } = useRadioTopLabels({ showSlug, limit: 10 })
-
-  if (isLoading || !data?.labels || data.labels.length === 0) return null
-
-  return (
-    <div>
-      <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
-        Top Labels (90d)
-      </h3>
-      <div className="space-y-1">
-        {data.labels.map((label: RadioTopLabel) => (
-          <div
-            key={label.label_name}
-            className="flex items-center justify-between py-0.5"
-          >
-            {label.label_slug ? (
-              <Link
-                href={`/labels/${label.label_slug}`}
-                className="text-sm text-muted-foreground hover:text-foreground transition-colors truncate mr-2"
-              >
-                {label.label_name}
-              </Link>
-            ) : (
-              <span className="text-sm text-muted-foreground truncate mr-2">
-                {label.label_name}
-              </span>
-            )}
-            <span className="text-xs text-muted-foreground/60 tabular-nums shrink-0">
-              {label.play_count}
-            </span>
-          </div>
-        ))}
-      </div>
-    </div>
-  )
+async function getRadioShow(slug: string): Promise<RadioShowData | null> {
+  try {
+    const res = await fetch(`${API_BASE_URL}/radio-shows/${slug}`, {
+      next: { revalidate: 3600 },
+    })
+    if (res.ok) {
+      return res.json()
+    }
+    if (res.status >= 500) {
+      Sentry.captureMessage(`Radio show page fetch error: ${res.status}`, {
+        level: 'error',
+        tags: { service: 'radio-show-page' },
+        extra: { slug, status: res.status },
+      })
+    }
+  } catch (error) {
+    Sentry.captureException(error, {
+      level: 'error',
+      tags: { service: 'radio-show-page' },
+      extra: { slug },
+    })
+  }
+  return null
 }
 
-const PAGE_SIZE = 20
+export async function generateMetadata({ params }: ShowPageProps): Promise<Metadata> {
+  const { 'station-slug': stationSlug, 'show-slug': showSlug } = await params
+  const show = await getRadioShow(showSlug)
 
-export default function ShowPage({ params }: ShowPageProps) {
-  const { 'station-slug': stationSlug, 'show-slug': showSlug } = use(params)
-  const { data: show, isLoading, error } = useRadioShow(showSlug)
-  const [offset, setOffset] = useState(0)
-  const { data: episodesData, isLoading: episodesLoading } = useRadioEpisodes({
-    showSlug,
-    limit: PAGE_SIZE,
-    offset,
-    enabled: !!show,
-  })
+  if (show) {
+    const description = show.description
+      ? show.description.slice(0, 155) + (show.description.length > 155 ? '...' : '')
+      : `${show.name} on ${show.station_name}${show.host_name ? `, hosted by ${show.host_name}` : ''}`
+    const title = `${show.name} — ${show.station_name}`
 
-  if (isLoading) {
-    return (
-      <div className="flex min-h-[60vh] items-center justify-center">
-        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-      </div>
-    )
+    return {
+      title,
+      description,
+      alternates: {
+        canonical: `https://psychichomily.com/radio/${stationSlug}/${showSlug}`,
+      },
+      openGraph: {
+        title,
+        description,
+        type: 'website',
+        url: `/radio/${stationSlug}/${showSlug}`,
+      },
+    }
   }
 
-  if (error || !show) {
-    return (
-      <div className="flex min-h-[60vh] items-center justify-center">
-        <div className="text-center">
-          <h1 className="text-2xl font-bold mb-2">Show Not Found</h1>
-          <p className="text-muted-foreground mb-4">
-            The radio show you&apos;re looking for doesn&apos;t exist.
-          </p>
-          <Button asChild variant="outline">
-            <Link href={`/radio/${stationSlug}`}>
-              <ArrowLeft className="h-4 w-4 mr-2" />
-              Back to Station
-            </Link>
-          </Button>
-        </div>
-      </div>
-    )
+  return {
+    title: 'Radio Show',
+    description: 'View radio show details, episodes, and playlists',
   }
+}
 
-  const genreTags = show.genre_tags ?? []
-  const total = episodesData?.total ?? 0
-  const hasNextPage = offset + PAGE_SIZE < total
-  const hasPrevPage = offset > 0
-
-  return (
-    <div className="flex min-h-screen items-start justify-center">
-      <main className="w-full max-w-6xl px-4 py-8 md:px-8">
-        {/* Breadcrumb */}
-        <div className="mb-6 flex items-center gap-1.5 text-sm text-muted-foreground">
-          <Link
-            href="/radio"
-            className="hover:text-foreground transition-colors"
-          >
-            Radio
-          </Link>
-          <span>/</span>
-          <Link
-            href={`/radio/${stationSlug}`}
-            className="hover:text-foreground transition-colors"
-          >
-            {show.station_name}
-          </Link>
-        </div>
-
-        <div className="flex flex-col lg:flex-row gap-8">
-          {/* Main content */}
-          <div className="flex-1 min-w-0">
-            {/* Show header */}
-            <div className="flex items-start gap-4 mb-6">
-              <div className="shrink-0 rounded-lg bg-muted/50 flex items-center justify-center overflow-hidden h-16 w-16">
-                {show.image_url ? (
-                  <img
-                    src={show.image_url}
-                    alt={show.name}
-                    className="h-full w-full object-cover"
-                  />
-                ) : (
-                  <Mic2 className="h-8 w-8 text-muted-foreground/40" />
-                )}
-              </div>
-
-              <div className="flex-1 min-w-0">
-                <h1 className="text-2xl font-bold">{show.name}</h1>
-                <p className="text-sm text-muted-foreground mt-0.5">
-                  on{' '}
-                  <Link
-                    href={`/radio/${stationSlug}`}
-                    className="hover:text-foreground transition-colors"
-                  >
-                    {show.station_name}
-                  </Link>
-                </p>
-
-                {show.host_name && (
-                  <p className="text-sm text-muted-foreground mt-1">
-                    Hosted by {show.host_name}
-                  </p>
-                )}
-
-                <div className="flex items-center gap-2 flex-wrap mt-2">
-                  {show.schedule_display && (
-                    <span className="flex items-center gap-1 text-sm text-muted-foreground">
-                      <Calendar className="h-3.5 w-3.5" />
-                      {show.schedule_display}
-                    </span>
-                  )}
-                  {genreTags.length > 0 && (
-                    <div className="flex items-center gap-1">
-                      <Tag className="h-3.5 w-3.5 text-muted-foreground" />
-                      {genreTags.map(tag => (
-                        <Badge
-                          key={tag}
-                          variant="secondary"
-                          className="text-[10px] px-1.5 py-0"
-                        >
-                          {tag}
-                        </Badge>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              </div>
-            </div>
-
-            {show.description && (
-              <p className="text-sm text-muted-foreground leading-relaxed mb-6">
-                {show.description}
-              </p>
-            )}
-
-            {/* Episodes */}
-            <section>
-              <h2 className="text-lg font-bold mb-3 flex items-center gap-2">
-                <Music className="h-5 w-5" />
-                Recent Episodes
-                {total > 0 && (
-                  <span className="text-sm font-normal text-muted-foreground">
-                    ({total})
-                  </span>
-                )}
-              </h2>
-
-              {episodesLoading && (
-                <div className="flex justify-center py-8">
-                  <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-                </div>
-              )}
-
-              {!episodesLoading && episodesData?.episodes && episodesData.episodes.length > 0 ? (
-                <>
-                  <div className="space-y-0.5">
-                    {episodesData.episodes.map(episode => (
-                      <RadioEpisodeRow
-                        key={episode.id}
-                        episode={episode}
-                        stationSlug={stationSlug}
-                        showSlug={showSlug}
-                      />
-                    ))}
-                  </div>
-
-                  {/* Pagination */}
-                  {(hasNextPage || hasPrevPage) && (
-                    <div className="flex items-center justify-between mt-4 pt-4 border-t border-border/50">
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
-                        disabled={!hasPrevPage}
-                      >
-                        <ChevronLeft className="h-4 w-4 mr-1" />
-                        Newer
-                      </Button>
-                      <span className="text-xs text-muted-foreground">
-                        {offset + 1}-{Math.min(offset + PAGE_SIZE, total)} of {total}
-                      </span>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => setOffset(offset + PAGE_SIZE)}
-                        disabled={!hasNextPage}
-                      >
-                        Older
-                        <ChevronRight className="h-4 w-4 ml-1" />
-                      </Button>
-                    </div>
-                  )}
-                </>
-              ) : !episodesLoading ? (
-                <div className="py-8 text-center text-sm text-muted-foreground">
-                  No episodes yet
-                </div>
-              ) : null}
-            </section>
-          </div>
-
-          {/* Sidebar */}
-          <aside className="w-full lg:w-64 shrink-0 space-y-6">
-            <TopArtistsSidebar showSlug={showSlug} />
-            <TopLabelsSidebar showSlug={showSlug} />
-          </aside>
-        </div>
-      </main>
-    </div>
-  )
+export default async function ShowPage({ params }: ShowPageProps) {
+  const { 'station-slug': stationSlug, 'show-slug': showSlug } = await params
+  return <RadioShowDetail stationSlug={stationSlug} showSlug={showSlug} />
 }

--- a/frontend/app/radio/[station-slug]/_components/StationDetail.tsx
+++ b/frontend/app/radio/[station-slug]/_components/StationDetail.tsx
@@ -1,0 +1,292 @@
+'use client'
+
+import { use } from 'react'
+import Link from 'next/link'
+import {
+  ArrowLeft,
+  Loader2,
+  Radio,
+  MapPin,
+  ExternalLink,
+  Heart,
+  Globe,
+  Music,
+  Disc3,
+} from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import {
+  useRadioStation,
+  useRadioShows,
+  useNewReleaseRadar,
+  RadioShowCard,
+  getBroadcastTypeLabel,
+} from '@/features/radio'
+import type { RadioNewReleaseRadarEntry } from '@/features/radio'
+
+interface StationDetailProps {
+  stationSlug: string
+}
+
+function NewReleaseRadarSection({ stationId }: { stationId: number }) {
+  const { data, isLoading } = useNewReleaseRadar({ stationId, limit: 10 })
+
+  if (isLoading || !data?.releases || data.releases.length === 0) return null
+
+  return (
+    <section className="mt-10">
+      <h2 className="text-xl font-bold mb-4 flex items-center gap-2">
+        <Disc3 className="h-5 w-5" />
+        New Release Radar
+      </h2>
+      <div className="space-y-1">
+        {data.releases.map((entry: RadioNewReleaseRadarEntry, i: number) => (
+          <div
+            key={`${entry.artist_name}-${entry.album_title}-${i}`}
+            className="flex items-center gap-3 px-3 py-2 rounded-md hover:bg-muted/50 transition-colors"
+          >
+            <span className="text-xs text-muted-foreground tabular-nums w-5 text-right">
+              {i + 1}
+            </span>
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2">
+                {entry.artist_slug ? (
+                  <Link
+                    href={`/artists/${entry.artist_slug}`}
+                    className="text-sm font-medium hover:text-primary transition-colors"
+                  >
+                    {entry.artist_name}
+                  </Link>
+                ) : (
+                  <span className="text-sm font-medium">{entry.artist_name}</span>
+                )}
+                {entry.album_title && (
+                  <>
+                    <span className="text-muted-foreground">-</span>
+                    {entry.release_slug ? (
+                      <Link
+                        href={`/releases/${entry.release_slug}`}
+                        className="text-sm text-muted-foreground hover:text-foreground transition-colors truncate"
+                      >
+                        {entry.album_title}
+                      </Link>
+                    ) : (
+                      <span className="text-sm text-muted-foreground truncate">
+                        {entry.album_title}
+                      </span>
+                    )}
+                  </>
+                )}
+              </div>
+              {entry.label_name && (
+                <span className="text-xs text-muted-foreground">
+                  {entry.label_slug ? (
+                    <Link
+                      href={`/labels/${entry.label_slug}`}
+                      className="hover:text-foreground transition-colors"
+                    >
+                      {entry.label_name}
+                    </Link>
+                  ) : (
+                    entry.label_name
+                  )}
+                </span>
+              )}
+            </div>
+            <div className="shrink-0 text-xs text-muted-foreground tabular-nums">
+              {entry.play_count} {entry.play_count === 1 ? 'play' : 'plays'}
+              {entry.station_count > 1 && ` / ${entry.station_count} stations`}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+export default function StationDetail({ stationSlug }: StationDetailProps) {
+  const { data: station, isLoading, error } = useRadioStation(stationSlug)
+  const { data: showsData, isLoading: showsLoading } = useRadioShows(station?.id)
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  if (error || !station) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold mb-2">Station Not Found</h1>
+          <p className="text-muted-foreground mb-4">
+            The radio station you&apos;re looking for doesn&apos;t exist.
+          </p>
+          <Button asChild variant="outline">
+            <Link href="/radio">
+              <ArrowLeft className="h-4 w-4 mr-2" />
+              Back to Radio
+            </Link>
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  const location = [station.city, station.state].filter(Boolean).join(', ')
+  const broadcastLabel = getBroadcastTypeLabel(station.broadcast_type)
+
+  return (
+    <div className="flex min-h-screen items-start justify-center">
+      <main className="w-full max-w-6xl px-4 py-8 md:px-8">
+        {/* Breadcrumb */}
+        <div className="mb-6">
+          <Link
+            href="/radio"
+            className="text-sm text-muted-foreground hover:text-foreground transition-colors flex items-center gap-1"
+          >
+            <ArrowLeft className="h-3.5 w-3.5" />
+            Radio
+          </Link>
+        </div>
+
+        {/* Station header */}
+        <div className="flex items-start gap-5 mb-8">
+          {/* Logo */}
+          <div className="shrink-0 rounded-xl bg-muted/50 flex items-center justify-center overflow-hidden h-20 w-20">
+            {station.logo_url ? (
+              <img
+                src={station.logo_url}
+                alt={`${station.name} logo`}
+                className="h-full w-full object-cover"
+              />
+            ) : (
+              <Radio className="h-10 w-10 text-muted-foreground/40" />
+            )}
+          </div>
+
+          <div className="flex-1 min-w-0">
+            <h1 className="text-3xl font-bold">{station.name}</h1>
+
+            <div className="flex items-center gap-3 flex-wrap mt-2">
+              <Badge variant="secondary">{broadcastLabel}</Badge>
+              {station.frequency_mhz && (
+                <span className="text-sm text-muted-foreground tabular-nums">
+                  {station.frequency_mhz} MHz
+                </span>
+              )}
+              {location && (
+                <span className="flex items-center gap-1 text-sm text-muted-foreground">
+                  <MapPin className="h-3.5 w-3.5" />
+                  {location}
+                </span>
+              )}
+              {station.show_count > 0 && (
+                <span className="flex items-center gap-1 text-sm text-muted-foreground">
+                  <Music className="h-3.5 w-3.5" />
+                  {station.show_count} {station.show_count === 1 ? 'show' : 'shows'}
+                </span>
+              )}
+            </div>
+
+            {station.description && (
+              <p className="text-muted-foreground mt-3 text-sm leading-relaxed max-w-3xl">
+                {station.description}
+              </p>
+            )}
+
+            {/* Action buttons */}
+            <div className="flex items-center gap-2 mt-4">
+              {station.slug === 'wfmu' ? (
+                <Button
+                  size="sm"
+                  onClick={() => {
+                    window.open(
+                      'https://www.radiorethink.com/tuner/?stationCode=wfmu&stream=hi',
+                      'wfmu-player',
+                      'width=400,height=700,scrollbars=yes,resizable=yes'
+                    )
+                  }}
+                >
+                  <Radio className="h-4 w-4 mr-2" />
+                  Listen Live
+                </Button>
+              ) : station.stream_url ? (
+                <Button asChild size="sm">
+                  <a
+                    href={station.stream_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <Radio className="h-4 w-4 mr-2" />
+                    Listen Live
+                  </a>
+                </Button>
+              ) : null}
+              {station.donation_url && (
+                <Button asChild variant="outline" size="sm">
+                  <a
+                    href={station.donation_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <Heart className="h-4 w-4 mr-2" />
+                    Donate
+                  </a>
+                </Button>
+              )}
+              {station.website && (
+                <Button asChild variant="ghost" size="sm">
+                  <a
+                    href={station.website}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <Globe className="h-4 w-4 mr-2" />
+                    Website
+                    <ExternalLink className="h-3 w-3 ml-1" />
+                  </a>
+                </Button>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Shows */}
+        <section>
+          <h2 className="text-xl font-bold mb-4 flex items-center gap-2">
+            <Music className="h-5 w-5" />
+            Shows
+          </h2>
+
+          {showsLoading && (
+            <div className="flex justify-center py-8">
+              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+            </div>
+          )}
+
+          {!showsLoading && showsData?.shows && showsData.shows.length > 0 ? (
+            <div className="grid gap-3 md:grid-cols-2">
+              {showsData.shows.map(show => (
+                <RadioShowCard
+                  key={show.id}
+                  show={show}
+                  stationSlug={stationSlug}
+                />
+              ))}
+            </div>
+          ) : !showsLoading ? (
+            <div className="py-8 text-center text-sm text-muted-foreground">
+              No shows yet
+            </div>
+          ) : null}
+        </section>
+
+        {/* New Release Radar */}
+        <NewReleaseRadarSection stationId={station.id} />
+      </main>
+    </div>
+  )
+}

--- a/frontend/app/radio/[station-slug]/page.tsx
+++ b/frontend/app/radio/[station-slug]/page.tsx
@@ -1,293 +1,83 @@
-'use client'
+import { Metadata } from 'next'
+import * as Sentry from '@sentry/nextjs'
+import StationDetail from './_components/StationDetail'
 
-import { use } from 'react'
-import Link from 'next/link'
-import {
-  ArrowLeft,
-  Loader2,
-  Radio,
-  MapPin,
-  ExternalLink,
-  Heart,
-  Globe,
-  Music,
-  Disc3,
-} from 'lucide-react'
-import { Button } from '@/components/ui/button'
-import { Badge } from '@/components/ui/badge'
-import {
-  useRadioStation,
-  useRadioShows,
-  useNewReleaseRadar,
-  RadioShowCard,
-  getBroadcastTypeLabel,
-} from '@/features/radio'
-import type { RadioNewReleaseRadarEntry } from '@/features/radio'
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL ||
+  (process.env.NODE_ENV === 'development'
+    ? 'http://localhost:8080'
+    : 'https://api.psychichomily.com')
 
 interface StationPageProps {
   params: Promise<{ 'station-slug': string }>
 }
 
-function NewReleaseRadarSection({ stationId }: { stationId: number }) {
-  const { data, isLoading } = useNewReleaseRadar({ stationId, limit: 10 })
-
-  if (isLoading || !data?.releases || data.releases.length === 0) return null
-
-  return (
-    <section className="mt-10">
-      <h2 className="text-xl font-bold mb-4 flex items-center gap-2">
-        <Disc3 className="h-5 w-5" />
-        New Release Radar
-      </h2>
-      <div className="space-y-1">
-        {data.releases.map((entry: RadioNewReleaseRadarEntry, i: number) => (
-          <div
-            key={`${entry.artist_name}-${entry.album_title}-${i}`}
-            className="flex items-center gap-3 px-3 py-2 rounded-md hover:bg-muted/50 transition-colors"
-          >
-            <span className="text-xs text-muted-foreground tabular-nums w-5 text-right">
-              {i + 1}
-            </span>
-            <div className="flex-1 min-w-0">
-              <div className="flex items-center gap-2">
-                {entry.artist_slug ? (
-                  <Link
-                    href={`/artists/${entry.artist_slug}`}
-                    className="text-sm font-medium hover:text-primary transition-colors"
-                  >
-                    {entry.artist_name}
-                  </Link>
-                ) : (
-                  <span className="text-sm font-medium">{entry.artist_name}</span>
-                )}
-                {entry.album_title && (
-                  <>
-                    <span className="text-muted-foreground">-</span>
-                    {entry.release_slug ? (
-                      <Link
-                        href={`/releases/${entry.release_slug}`}
-                        className="text-sm text-muted-foreground hover:text-foreground transition-colors truncate"
-                      >
-                        {entry.album_title}
-                      </Link>
-                    ) : (
-                      <span className="text-sm text-muted-foreground truncate">
-                        {entry.album_title}
-                      </span>
-                    )}
-                  </>
-                )}
-              </div>
-              {entry.label_name && (
-                <span className="text-xs text-muted-foreground">
-                  {entry.label_slug ? (
-                    <Link
-                      href={`/labels/${entry.label_slug}`}
-                      className="hover:text-foreground transition-colors"
-                    >
-                      {entry.label_name}
-                    </Link>
-                  ) : (
-                    entry.label_name
-                  )}
-                </span>
-              )}
-            </div>
-            <div className="shrink-0 text-xs text-muted-foreground tabular-nums">
-              {entry.play_count} {entry.play_count === 1 ? 'play' : 'plays'}
-              {entry.station_count > 1 && ` / ${entry.station_count} stations`}
-            </div>
-          </div>
-        ))}
-      </div>
-    </section>
-  )
+interface StationData {
+  name: string
+  slug?: string
+  description?: string | null
+  city?: string | null
+  state?: string | null
 }
 
-export default function StationPage({ params }: StationPageProps) {
-  const { 'station-slug': stationSlug } = use(params)
-  const { data: station, isLoading, error } = useRadioStation(stationSlug)
-  const { data: showsData, isLoading: showsLoading } = useRadioShows(station?.id)
+async function getStation(slug: string): Promise<StationData | null> {
+  try {
+    const res = await fetch(`${API_BASE_URL}/radio-stations/${slug}`, {
+      next: { revalidate: 3600 },
+    })
+    if (res.ok) {
+      return res.json()
+    }
+    if (res.status >= 500) {
+      Sentry.captureMessage(`Radio station page fetch error: ${res.status}`, {
+        level: 'error',
+        tags: { service: 'radio-station-page' },
+        extra: { slug, status: res.status },
+      })
+    }
+  } catch (error) {
+    Sentry.captureException(error, {
+      level: 'error',
+      tags: { service: 'radio-station-page' },
+      extra: { slug },
+    })
+  }
+  return null
+}
 
-  if (isLoading) {
-    return (
-      <div className="flex min-h-[60vh] items-center justify-center">
-        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-      </div>
-    )
+export async function generateMetadata({ params }: StationPageProps): Promise<Metadata> {
+  const { 'station-slug': stationSlug } = await params
+  const station = await getStation(stationSlug)
+
+  if (station) {
+    const location = [station.city, station.state].filter(Boolean).join(', ')
+    const description = station.description
+      ? station.description.slice(0, 155) + (station.description.length > 155 ? '...' : '')
+      : `${station.name} radio station${location ? ` from ${location}` : ''} on Psychic Homily`
+    const title = `${station.name} — Radio`
+
+    return {
+      title,
+      description,
+      alternates: {
+        canonical: `https://psychichomily.com/radio/${stationSlug}`,
+      },
+      openGraph: {
+        title,
+        description,
+        type: 'website',
+        url: `/radio/${stationSlug}`,
+      },
+    }
   }
 
-  if (error || !station) {
-    return (
-      <div className="flex min-h-[60vh] items-center justify-center">
-        <div className="text-center">
-          <h1 className="text-2xl font-bold mb-2">Station Not Found</h1>
-          <p className="text-muted-foreground mb-4">
-            The radio station you&apos;re looking for doesn&apos;t exist.
-          </p>
-          <Button asChild variant="outline">
-            <Link href="/radio">
-              <ArrowLeft className="h-4 w-4 mr-2" />
-              Back to Radio
-            </Link>
-          </Button>
-        </div>
-      </div>
-    )
+  return {
+    title: 'Radio Station',
+    description: 'View radio station details, shows, and playlists',
   }
+}
 
-  const location = [station.city, station.state].filter(Boolean).join(', ')
-  const broadcastLabel = getBroadcastTypeLabel(station.broadcast_type)
-
-  return (
-    <div className="flex min-h-screen items-start justify-center">
-      <main className="w-full max-w-6xl px-4 py-8 md:px-8">
-        {/* Breadcrumb */}
-        <div className="mb-6">
-          <Link
-            href="/radio"
-            className="text-sm text-muted-foreground hover:text-foreground transition-colors flex items-center gap-1"
-          >
-            <ArrowLeft className="h-3.5 w-3.5" />
-            Radio
-          </Link>
-        </div>
-
-        {/* Station header */}
-        <div className="flex items-start gap-5 mb-8">
-          {/* Logo */}
-          <div className="shrink-0 rounded-xl bg-muted/50 flex items-center justify-center overflow-hidden h-20 w-20">
-            {station.logo_url ? (
-              <img
-                src={station.logo_url}
-                alt={`${station.name} logo`}
-                className="h-full w-full object-cover"
-              />
-            ) : (
-              <Radio className="h-10 w-10 text-muted-foreground/40" />
-            )}
-          </div>
-
-          <div className="flex-1 min-w-0">
-            <h1 className="text-3xl font-bold">{station.name}</h1>
-
-            <div className="flex items-center gap-3 flex-wrap mt-2">
-              <Badge variant="secondary">{broadcastLabel}</Badge>
-              {station.frequency_mhz && (
-                <span className="text-sm text-muted-foreground tabular-nums">
-                  {station.frequency_mhz} MHz
-                </span>
-              )}
-              {location && (
-                <span className="flex items-center gap-1 text-sm text-muted-foreground">
-                  <MapPin className="h-3.5 w-3.5" />
-                  {location}
-                </span>
-              )}
-              {station.show_count > 0 && (
-                <span className="flex items-center gap-1 text-sm text-muted-foreground">
-                  <Music className="h-3.5 w-3.5" />
-                  {station.show_count} {station.show_count === 1 ? 'show' : 'shows'}
-                </span>
-              )}
-            </div>
-
-            {station.description && (
-              <p className="text-muted-foreground mt-3 text-sm leading-relaxed max-w-3xl">
-                {station.description}
-              </p>
-            )}
-
-            {/* Action buttons */}
-            <div className="flex items-center gap-2 mt-4">
-              {station.slug === 'wfmu' ? (
-                <Button
-                  size="sm"
-                  onClick={() => {
-                    window.open(
-                      'https://www.radiorethink.com/tuner/?stationCode=wfmu&stream=hi',
-                      'wfmu-player',
-                      'width=400,height=700,scrollbars=yes,resizable=yes'
-                    )
-                  }}
-                >
-                  <Radio className="h-4 w-4 mr-2" />
-                  Listen Live
-                </Button>
-              ) : station.stream_url ? (
-                <Button asChild size="sm">
-                  <a
-                    href={station.stream_url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <Radio className="h-4 w-4 mr-2" />
-                    Listen Live
-                  </a>
-                </Button>
-              ) : null}
-              {station.donation_url && (
-                <Button asChild variant="outline" size="sm">
-                  <a
-                    href={station.donation_url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <Heart className="h-4 w-4 mr-2" />
-                    Donate
-                  </a>
-                </Button>
-              )}
-              {station.website && (
-                <Button asChild variant="ghost" size="sm">
-                  <a
-                    href={station.website}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <Globe className="h-4 w-4 mr-2" />
-                    Website
-                    <ExternalLink className="h-3 w-3 ml-1" />
-                  </a>
-                </Button>
-              )}
-            </div>
-          </div>
-        </div>
-
-        {/* Shows */}
-        <section>
-          <h2 className="text-xl font-bold mb-4 flex items-center gap-2">
-            <Music className="h-5 w-5" />
-            Shows
-          </h2>
-
-          {showsLoading && (
-            <div className="flex justify-center py-8">
-              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-            </div>
-          )}
-
-          {!showsLoading && showsData?.shows && showsData.shows.length > 0 ? (
-            <div className="grid gap-3 md:grid-cols-2">
-              {showsData.shows.map(show => (
-                <RadioShowCard
-                  key={show.id}
-                  show={show}
-                  stationSlug={stationSlug}
-                />
-              ))}
-            </div>
-          ) : !showsLoading ? (
-            <div className="py-8 text-center text-sm text-muted-foreground">
-              No shows yet
-            </div>
-          ) : null}
-        </section>
-
-        {/* New Release Radar */}
-        <NewReleaseRadarSection stationId={station.id} />
-      </main>
-    </div>
-  )
+export default async function StationPage({ params }: StationPageProps) {
+  const { 'station-slug': stationSlug } = await params
+  return <StationDetail stationSlug={stationSlug} />
 }

--- a/frontend/app/radio/_components/RadioHub.tsx
+++ b/frontend/app/radio/_components/RadioHub.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import { Radio, Loader2 } from 'lucide-react'
+import { useRadioStations, useRadioStats, RadioStationCard } from '@/features/radio'
+
+export default function RadioHub() {
+  const { data: stationsData, isLoading, error } = useRadioStations()
+  const { data: stats } = useRadioStats()
+
+  return (
+    <div className="flex min-h-screen items-start justify-center">
+      <main className="w-full max-w-6xl px-4 py-8 md:px-8">
+        <div className="text-center mb-8">
+          <h1 className="text-3xl font-bold flex items-center justify-center gap-3">
+            <Radio className="h-8 w-8" />
+            Radio
+          </h1>
+          <p className="text-muted-foreground mt-2">
+            Explore radio stations, shows, and playlists
+          </p>
+
+          {stats && (
+            <div className="flex items-center justify-center gap-6 mt-4 text-sm text-muted-foreground">
+              <span>{stats.total_stations} {stats.total_stations === 1 ? 'station' : 'stations'}</span>
+              <span>{stats.total_shows} {stats.total_shows === 1 ? 'show' : 'shows'}</span>
+              <span>{stats.total_episodes.toLocaleString()} {stats.total_episodes === 1 ? 'episode' : 'episodes'}</span>
+              <span>{stats.total_plays.toLocaleString()} {stats.total_plays === 1 ? 'play' : 'plays'} tracked</span>
+            </div>
+          )}
+        </div>
+
+        {isLoading && (
+          <div className="flex justify-center items-center py-12">
+            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+          </div>
+        )}
+
+        {error && (
+          <div className="py-12 text-center text-sm text-destructive">
+            Failed to load radio stations
+          </div>
+        )}
+
+        {!isLoading && !error && stationsData && (
+          <>
+            {stationsData.stations && stationsData.stations.length > 0 ? (
+              <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+                {stationsData.stations.map(station => (
+                  <RadioStationCard key={station.id} station={station} />
+                ))}
+              </div>
+            ) : (
+              <div className="py-12 text-center">
+                <Radio className="h-12 w-12 text-muted-foreground/30 mx-auto mb-3" />
+                <p className="text-muted-foreground">No radio stations yet</p>
+                <p className="text-sm text-muted-foreground/60 mt-1">
+                  Radio stations will appear here once they are added.
+                </p>
+              </div>
+            )}
+          </>
+        )}
+      </main>
+    </div>
+  )
+}

--- a/frontend/app/radio/page.tsx
+++ b/frontend/app/radio/page.tsx
@@ -1,66 +1,17 @@
-'use client'
+import { Metadata } from 'next'
+import RadioHub from './_components/RadioHub'
 
-import { Radio, Loader2 } from 'lucide-react'
-import { useRadioStations, useRadioStats, RadioStationCard } from '@/features/radio'
+export const metadata: Metadata = {
+  title: 'Radio',
+  description: 'Explore radio stations, shows, and playlists tracked on Psychic Homily',
+  openGraph: {
+    title: 'Radio',
+    description: 'Explore radio stations, shows, and playlists tracked on Psychic Homily',
+    type: 'website',
+    url: '/radio',
+  },
+}
 
 export default function RadioPage() {
-  const { data: stationsData, isLoading, error } = useRadioStations()
-  const { data: stats } = useRadioStats()
-
-  return (
-    <div className="flex min-h-screen items-start justify-center">
-      <main className="w-full max-w-6xl px-4 py-8 md:px-8">
-        <div className="text-center mb-8">
-          <h1 className="text-3xl font-bold flex items-center justify-center gap-3">
-            <Radio className="h-8 w-8" />
-            Radio
-          </h1>
-          <p className="text-muted-foreground mt-2">
-            Explore radio stations, shows, and playlists
-          </p>
-
-          {stats && (
-            <div className="flex items-center justify-center gap-6 mt-4 text-sm text-muted-foreground">
-              <span>{stats.total_stations} {stats.total_stations === 1 ? 'station' : 'stations'}</span>
-              <span>{stats.total_shows} {stats.total_shows === 1 ? 'show' : 'shows'}</span>
-              <span>{stats.total_episodes.toLocaleString()} {stats.total_episodes === 1 ? 'episode' : 'episodes'}</span>
-              <span>{stats.total_plays.toLocaleString()} {stats.total_plays === 1 ? 'play' : 'plays'} tracked</span>
-            </div>
-          )}
-        </div>
-
-        {isLoading && (
-          <div className="flex justify-center items-center py-12">
-            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-          </div>
-        )}
-
-        {error && (
-          <div className="py-12 text-center text-sm text-destructive">
-            Failed to load radio stations
-          </div>
-        )}
-
-        {!isLoading && !error && stationsData && (
-          <>
-            {stationsData.stations && stationsData.stations.length > 0 ? (
-              <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-                {stationsData.stations.map(station => (
-                  <RadioStationCard key={station.id} station={station} />
-                ))}
-              </div>
-            ) : (
-              <div className="py-12 text-center">
-                <Radio className="h-12 w-12 text-muted-foreground/30 mx-auto mb-3" />
-                <p className="text-muted-foreground">No radio stations yet</p>
-                <p className="text-sm text-muted-foreground/60 mt-1">
-                  Radio stations will appear here once they are added.
-                </p>
-              </div>
-            )}
-          </>
-        )}
-      </main>
-    </div>
-  )
+  return <RadioHub />
 }


### PR DESCRIPTION
## Summary
- Split 4 radio pages into server + client component pairs to enable `generateMetadata()`
- `/radio` → "Radio | Psychic Homily"
- `/radio/[station-slug]` → "KEXP — Radio | Psychic Homily"
- `/radio/.../[show-slug]` → "Morning Show — KEXP | Psychic Homily"
- `/radio/.../[date]` → "Morning Show — Apr 12, 2026 | Psychic Homily"
- Includes OpenGraph metadata, error fallbacks, and 1-hour revalidation

Closes PSY-331

## Test plan
- [ ] Visit `/radio` — check browser tab title is "Radio | Psychic Homily"
- [ ] Visit a station page — title includes station name
- [ ] Visit a show page — title includes show + station name
- [ ] Visit an episode page — title includes show + formatted date
- [ ] Inspect page source for OpenGraph meta tags on each page
- [ ] Verify all interactive functionality still works after server/client split

🤖 Generated with [Claude Code](https://claude.com/claude-code)