### PR TITLE
Fix episode date display hierarchy

### DIFF
--- a/frontend/app/radio/[station-slug]/[show-slug]/[date]/_components/EpisodeDateDetail.tsx
+++ b/frontend/app/radio/[station-slug]/[show-slug]/[date]/_components/EpisodeDateDetail.tsx
@@ -74,7 +74,7 @@ export default function EpisodeDateDetail({ stationSlug, showSlug, date }: Episo
     )
   }
 
-  const title = episode.title || formatDate(episode.air_date)
+  const hasTitle = !!episode.title
   const plays = episode.plays ?? []
   const genreTags = episode.genre_tags ?? []
   const moodTags = episode.mood_tags ?? []
@@ -108,7 +108,32 @@ export default function EpisodeDateDetail({ stationSlug, showSlug, date }: Episo
 
         {/* Episode header */}
         <div className="mb-8">
-          <h1 className="text-2xl font-bold">{title}</h1>
+          {hasTitle ? (
+            <>
+              <h1 className="text-2xl font-bold">{episode.title}</h1>
+              <p className="text-base text-muted-foreground mt-1 flex items-center gap-1.5">
+                <Calendar className="h-4 w-4 shrink-0" />
+                {formatDate(episode.air_date)}
+                {episode.air_time && (
+                  <span className="flex items-center gap-1 ml-1">
+                    <Clock className="h-3.5 w-3.5 shrink-0" />
+                    {formatAirTime(episode.air_time)}
+                  </span>
+                )}
+              </p>
+            </>
+          ) : (
+            <h1 className="text-2xl font-bold flex items-center gap-2">
+              <Calendar className="h-6 w-6 shrink-0" />
+              {formatDate(episode.air_date)}
+              {episode.air_time && (
+                <span className="text-lg font-normal text-muted-foreground flex items-center gap-1 ml-1">
+                  <Clock className="h-4 w-4 shrink-0" />
+                  {formatAirTime(episode.air_time)}
+                </span>
+              )}
+            </h1>
+          )}
           <p className="text-sm text-muted-foreground mt-1">
             <Link
               href={`/radio/${stationSlug}/${showSlug}`}
@@ -126,16 +151,6 @@ export default function EpisodeDateDetail({ stationSlug, showSlug, date }: Episo
           </p>
 
           <div className="flex items-center gap-3 flex-wrap mt-3">
-            <span className="flex items-center gap-1 text-sm text-muted-foreground">
-              <Calendar className="h-3.5 w-3.5" />
-              {formatDate(episode.air_date)}
-            </span>
-            {episode.air_time && (
-              <span className="flex items-center gap-1 text-sm text-muted-foreground">
-                <Clock className="h-3.5 w-3.5" />
-                {formatAirTime(episode.air_time)}
-              </span>
-            )}
             {episode.duration_minutes && (
               <span className="text-sm text-muted-foreground">
                 {episode.duration_minutes} min

--- a/frontend/features/radio/components/RadioEpisodeRow.tsx
+++ b/frontend/features/radio/components/RadioEpisodeRow.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { Calendar, Music, ExternalLink } from 'lucide-react'
+import { Clock, Music, ExternalLink } from 'lucide-react'
 
 import type { RadioEpisodeListItem } from '../types'
 
@@ -14,39 +14,76 @@ interface RadioEpisodeRowProps {
 function formatDate(dateStr: string): string {
   const date = new Date(dateStr + 'T00:00:00')
   return date.toLocaleDateString('en-US', {
-    weekday: 'short',
     month: 'short',
     day: 'numeric',
     year: 'numeric',
   })
 }
 
+/**
+ * Format a time string like "06:00:00" or "21:30:00" into "6:00 AM" or "9:30 PM".
+ */
+function formatAirTime(timeStr: string): string {
+  const [hoursStr, minutesStr] = timeStr.split(':')
+  const hours = parseInt(hoursStr, 10)
+  const minutes = parseInt(minutesStr, 10)
+  if (isNaN(hours) || isNaN(minutes)) return timeStr
+  const period = hours >= 12 ? 'PM' : 'AM'
+  const displayHours = hours === 0 ? 12 : hours > 12 ? hours - 12 : hours
+  const displayMinutes = minutes.toString().padStart(2, '0')
+  return `${displayHours}:${displayMinutes} ${period}`
+}
+
 export function RadioEpisodeRow({ episode, stationSlug, showSlug }: RadioEpisodeRowProps) {
   const episodeUrl = `/radio/${stationSlug}/${showSlug}/${episode.air_date}`
-  const title = episode.title || formatDate(episode.air_date)
+  const hasTitle = !!episode.title
+  const formattedDate = formatDate(episode.air_date)
 
   return (
     <Link
       href={episodeUrl}
       className="flex items-center gap-4 px-3 py-2.5 rounded-md hover:bg-muted/50 transition-colors group"
     >
-      {/* Date */}
-      <div className="shrink-0 text-center w-14">
-        <Calendar className="h-4 w-4 text-muted-foreground mx-auto mb-0.5" />
-        <span className="text-[10px] text-muted-foreground tabular-nums">
-          {episode.air_date}
-        </span>
-      </div>
-
-      {/* Title */}
+      {/* Primary info */}
       <div className="flex-1 min-w-0">
-        <p className="text-sm font-medium group-hover:text-foreground truncate">
-          {title}
-        </p>
-        {episode.duration_minutes && (
-          <p className="text-xs text-muted-foreground">
-            {episode.duration_minutes} min
-          </p>
+        {hasTitle ? (
+          <>
+            <p className="text-sm font-medium group-hover:text-foreground truncate">
+              {episode.title}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {formattedDate}
+              {episode.air_time && (
+                <span className="inline-flex items-center gap-0.5 ml-1.5">
+                  <Clock className="h-2.5 w-2.5 inline" />
+                  {formatAirTime(episode.air_time)}
+                </span>
+              )}
+              {episode.duration_minutes && (
+                <span className="ml-1.5">&middot; {episode.duration_minutes} min</span>
+              )}
+            </p>
+          </>
+        ) : (
+          <>
+            <p className="text-sm font-medium group-hover:text-foreground">
+              {formattedDate}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {episode.air_time && (
+                <span className="inline-flex items-center gap-0.5">
+                  <Clock className="h-2.5 w-2.5 inline" />
+                  {formatAirTime(episode.air_time)}
+                </span>
+              )}
+              {episode.air_time && episode.duration_minutes && (
+                <span className="ml-1.5">&middot; </span>
+              )}
+              {episode.duration_minutes && (
+                <span>{episode.duration_minutes} min</span>
+              )}
+            </p>
+          </>
         )}
       </div>
 


### PR DESCRIPTION
## Summary
- Redesign `RadioEpisodeRow` to show proper hierarchy: title as primary line (when present), formatted date + air time + duration as secondary
- Remove cramped 56px calendar-icon column with raw ISO date
- Add `formatAirTime()` helper for 12-hour time format
- Fix episode detail page to remove duplicate date display

Closes PSY-334

## Test plan
- [ ] Visit a radio show page — episode rows show clear date hierarchy
- [ ] Episodes with titles show title prominently, date/time below
- [ ] Episodes without titles show formatted date as primary line
- [ ] Air time displays in 12-hour format (e.g., "6:00 AM")
- [ ] Episode detail page shows date/time without duplication

🤖 Generated with [Claude Code](https://claude.com/claude-code)