### PR TITLE
Rename admin radio 'Source' column to 'Broadcast Type'

### DIFF
--- a/frontend/app/admin/radio/_components/RadioManagement.tsx
+++ b/frontend/app/admin/radio/_components/RadioManagement.tsx
@@ -1584,7 +1584,7 @@ export function RadioManagement() {
                   <tr className="border-b bg-muted/50">
                     <th className="px-4 py-3 text-left text-sm font-medium text-muted-foreground">Name</th>
                     <th className="px-4 py-3 text-left text-sm font-medium text-muted-foreground">City</th>
-                    <th className="px-4 py-3 text-left text-sm font-medium text-muted-foreground">Source</th>
+                    <th className="px-4 py-3 text-left text-sm font-medium text-muted-foreground">Broadcast Type</th>
                     <th className="px-4 py-3 text-left text-sm font-medium text-muted-foreground">Shows</th>
                     <th className="px-4 py-3 text-left text-sm font-medium text-muted-foreground">Active</th>
                   </tr>


### PR DESCRIPTION
## Summary
- Rename "Source" column header to "Broadcast Type" in the admin radio Stations table
- Column displays `broadcast_type` values (terrestrial, internet, both), not playlist source — label now matches the data

Closes PSY-336

## Test plan
- [ ] Navigate to Admin → Radio → Stations tab
- [ ] Verify column header reads "Broadcast Type" instead of "Source"

🤖 Generated with [Claude Code](https://claude.com/claude-code)