### PR TITLE
Remove redundant 'View Station' button from RadioStationCard

### DIFF
--- a/frontend/features/radio/components/RadioStationCard.tsx
+++ b/frontend/features/radio/components/RadioStationCard.tsx
@@ -1,9 +1,8 @@
 'use client'
 
 import Link from 'next/link'
-import { Radio, MapPin, Music, Headphones } from 'lucide-react'
+import { Radio, MapPin, Music } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
 import { getBroadcastTypeLabel } from '../types'
 import type { RadioStationListItem } from '../types'
 
@@ -68,12 +67,6 @@ export function RadioStationCard({ station }: RadioStationCardProps) {
         </div>
       </div>
 
-      {/* Actions */}
-      <div className="flex items-center gap-2 mt-4">
-        <Button asChild variant="outline" size="sm">
-          <Link href={stationUrl}>View Station</Link>
-        </Button>
-      </div>
     </article>
   )
 }


### PR DESCRIPTION
## Summary
- Remove "View Station" button from `RadioStationCard` — the station name heading is already a clickable link to the same URL
- Clean up unused `Button` and `Headphones` imports

Closes PSY-337

## Test plan
- [ ] Visit `/radio` — station cards no longer show "View Station" button
- [ ] Clicking station name still navigates to station detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)