### PR TITLE
Add hover affordance to clickable admin radio show rows

### DIFF
--- a/frontend/app/admin/radio/_components/RadioManagement.tsx
+++ b/frontend/app/admin/radio/_components/RadioManagement.tsx
@@ -1195,7 +1195,7 @@ function StationDetailPanel({
         ) : (
           <div className="rounded-lg border divide-y">
             {shows.map((show) => (
-              <div key={show.id} className="px-4 py-3">
+              <div key={show.id} className="px-4 py-3 hover:bg-muted/50 transition-colors">
                 <div className="flex items-center justify-between">
                   <div className="min-w-0 flex-1">
                     <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- Add `hover:bg-muted/50 transition-colors` to radio show rows in the StationDetailPanel
- Matches the existing hover pattern already used on station table rows

Closes PSY-338

## Test plan
- [ ] Navigate to Admin → Radio → click a station to expand
- [ ] Hover over show rows — verify background highlight appears
- [ ] Verify smooth transition on hover in/out

🤖 Generated with [Claude Code](https://claude.com/claude-code)