### PR TITLE
Fix CSP to allow external images for station logos and show artwork

### DIFF
--- a/frontend/app/radio/[station-slug]/[show-slug]/_components/RadioShowDetail.tsx
+++ b/frontend/app/radio/[station-slug]/[show-slug]/_components/RadioShowDetail.tsx
@@ -173,7 +173,7 @@ export default function RadioShowDetail({ stationSlug, showSlug }: RadioShowDeta
           <div className="flex-1 min-w-0">
             {/* Show header */}
             <div className="flex items-start gap-4 mb-6">
-              <div className="shrink-0 rounded-lg bg-muted/50 flex items-center justify-center overflow-hidden h-16 w-16">
+              <div className="shrink-0 rounded-xl bg-muted/50 flex items-center justify-center overflow-hidden h-20 w-20">
                 {show.image_url ? (
                   <img
                     src={show.image_url}
@@ -181,7 +181,7 @@ export default function RadioShowDetail({ stationSlug, showSlug }: RadioShowDeta
                     className="h-full w-full object-cover"
                   />
                 ) : (
-                  <Mic2 className="h-8 w-8 text-muted-foreground/40" />
+                  <Mic2 className="h-10 w-10 text-muted-foreground/40" />
                 )}
               </div>
 

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -95,7 +95,7 @@ const nextConfig: NextConfig = {
               "default-src 'self'",
               "script-src 'self' 'unsafe-inline' https://vercel.live https://us-assets.i.posthog.com",
               "style-src 'self' 'unsafe-inline'",
-              "img-src 'self' data: blob: https://vercel.com https://vercel.live",
+              "img-src 'self' data: blob: https:",
               "font-src 'self'",
               "worker-src 'self' blob:",
               "connect-src 'self' https://api.psychichomily.com https://stage.api.psychichomily.com https://app.posthog.com https://us.i.posthog.com https://us-assets.i.posthog.com",


### PR DESCRIPTION
## Summary
- Widen CSP `img-src` from specific domains to `https:` to allow loading external images (station logos, show artwork, release covers)
- The rendering code was already correct — `<img>` tags with fallback icons existed in all radio components
- Increased show detail page artwork size from 64px to 80px for better visibility

Closes PSY-333

## Test plan
- [ ] Visit `/radio` — station cards show logos when `logo_url` is set
- [ ] Visit a station page — station logo displays in header
- [ ] Visit a show page — show artwork displays at 80px
- [ ] Fallback icons still appear when URLs are null
- [ ] No CSP errors in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)