### PR TITLE
Fix invalid broadcast_type values in radio handler and tests

### DIFF
--- a/backend/internal/api/handlers/radio.go
+++ b/backend/internal/api/handlers/radio.go
@@ -599,7 +599,7 @@ type AdminCreateRadioStationRequest struct {
 		DonationEmbedURL *string          `json:"donation_embed_url,omitempty" required:"false" doc:"Embeddable donation URL"`
 		LogoURL          *string          `json:"logo_url,omitempty" required:"false" doc:"Logo image URL"`
 		Social           *json.RawMessage `json:"social,omitempty" required:"false" doc:"Social media links (JSONB)"`
-		BroadcastType    string           `json:"broadcast_type" doc:"Broadcast type" example:"fm"`
+		BroadcastType    string           `json:"broadcast_type" doc:"Broadcast type (terrestrial, internet, both)" example:"both"`
 		FrequencyMHz     *float64         `json:"frequency_mhz,omitempty" required:"false" doc:"FM frequency" example:"90.3"`
 		PlaylistSource   *string          `json:"playlist_source,omitempty" required:"false" doc:"Playlist source"`
 		PlaylistConfig   *json.RawMessage `json:"playlist_config,omitempty" required:"false" doc:"Playlist config (JSONB)"`

--- a/backend/internal/api/handlers/radio_test.go
+++ b/backend/internal/api/handlers/radio_test.go
@@ -57,7 +57,7 @@ func TestListRadioStations_Success(t *testing.T) {
 	mock := &mockRadioService{
 		listStationsFn: func(filters map[string]interface{}) ([]*contracts.RadioStationListResponse, error) {
 			return []*contracts.RadioStationListResponse{
-				{ID: 1, Name: "KEXP", Slug: "kexp", BroadcastType: "fm", IsActive: true, ShowCount: 5},
+				{ID: 1, Name: "KEXP", Slug: "kexp", BroadcastType: "both", IsActive: true, ShowCount: 5},
 			}, nil
 		},
 	}
@@ -110,7 +110,7 @@ func TestListRadioStations_ServiceError(t *testing.T) {
 func TestGetRadioStation_BySlug(t *testing.T) {
 	mock := &mockRadioService{
 		getStationBySlugFn: func(slug string) (*contracts.RadioStationDetailResponse, error) {
-			return &contracts.RadioStationDetailResponse{ID: 1, Name: "KEXP", Slug: "kexp", BroadcastType: "fm"}, nil
+			return &contracts.RadioStationDetailResponse{ID: 1, Name: "KEXP", Slug: "kexp", BroadcastType: "both"}, nil
 		},
 	}
 	h := testRadioHandler(mock)
@@ -126,7 +126,7 @@ func TestGetRadioStation_BySlug(t *testing.T) {
 func TestGetRadioStation_ByID(t *testing.T) {
 	mock := &mockRadioService{
 		getStationFn: func(stationID uint) (*contracts.RadioStationDetailResponse, error) {
-			return &contracts.RadioStationDetailResponse{ID: stationID, Name: "KEXP", Slug: "kexp", BroadcastType: "fm"}, nil
+			return &contracts.RadioStationDetailResponse{ID: stationID, Name: "KEXP", Slug: "kexp", BroadcastType: "both"}, nil
 		},
 	}
 	h := testRadioHandler(mock)
@@ -621,7 +621,7 @@ func TestAdminCreateRadioStation_Success(t *testing.T) {
 	h := testRadioHandler(mock)
 	req := &AdminCreateRadioStationRequest{}
 	req.Body.Name = "KEXP"
-	req.Body.BroadcastType = "fm"
+	req.Body.BroadcastType = "both"
 
 	resp, err := h.AdminCreateRadioStationHandler(radioAdminCtx(), req)
 	if err != nil {
@@ -637,7 +637,7 @@ func TestAdminCreateRadioStation_NotAdmin(t *testing.T) {
 	h := testRadioHandler(mock)
 	req := &AdminCreateRadioStationRequest{}
 	req.Body.Name = "KEXP"
-	req.Body.BroadcastType = "fm"
+	req.Body.BroadcastType = "both"
 
 	_, err := h.AdminCreateRadioStationHandler(context.Background(), req)
 	assertHumaError(t, err, 403)
@@ -647,7 +647,7 @@ func TestAdminCreateRadioStation_MissingName(t *testing.T) {
 	mock := &mockRadioService{}
 	h := testRadioHandler(mock)
 	req := &AdminCreateRadioStationRequest{}
-	req.Body.BroadcastType = "fm"
+	req.Body.BroadcastType = "both"
 
 	_, err := h.AdminCreateRadioStationHandler(radioAdminCtx(), req)
 	assertHumaError(t, err, 400)
@@ -672,7 +672,7 @@ func TestAdminCreateRadioStation_ServiceError(t *testing.T) {
 	h := testRadioHandler(mock)
 	req := &AdminCreateRadioStationRequest{}
 	req.Body.Name = "KEXP"
-	req.Body.BroadcastType = "fm"
+	req.Body.BroadcastType = "both"
 
 	_, err := h.AdminCreateRadioStationHandler(radioAdminCtx(), req)
 	assertHumaError(t, err, 500)


### PR DESCRIPTION
## Summary
- Fixed the `broadcast_type` example tag in `AdminCreateRadioStationRequest` from invalid `"fm"` to valid `"both"`, and improved the doc string to list all valid values
- Updated all 7 test fixtures in `radio_test.go` that used `"fm"` to use the valid value `"both"` (valid values are `terrestrial`, `internet`, `both` per `models/radio.go`)

Closes PSY-332

## Test plan
- [x] All radio handler tests pass (`go test ./internal/api/handlers/ -run "Radio"`)
- [x] No remaining `"fm"` broadcast_type references in handler or test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)