### PR TITLE
Rename sidebar 'Settings' to 'Profile' with UserCircle icon

### DIFF
--- a/frontend/components/layout/Sidebar.test.tsx
+++ b/frontend/components/layout/Sidebar.test.tsx
@@ -116,13 +116,13 @@ describe('Sidebar', () => {
     expect(onToggleCollapse).toHaveBeenCalledOnce()
   })
 
-  it('does not show Library/Settings when unauthenticated', () => {
+  it('does not show Library/Profile when unauthenticated', () => {
     render(<Sidebar collapsed={false} onToggleCollapse={onToggleCollapse} />)
     expect(screen.queryByText('Library')).not.toBeInTheDocument()
-    expect(screen.queryByText('Settings')).not.toBeInTheDocument()
+    expect(screen.queryByText('Profile')).not.toBeInTheDocument()
   })
 
-  it('shows Library/Settings when authenticated', () => {
+  it('shows Library/Profile when authenticated', () => {
     mockAuthContext.mockReturnValue({
       user: { email: 'test@test.com', is_admin: false },
       isAuthenticated: true,
@@ -131,7 +131,7 @@ describe('Sidebar', () => {
     })
     render(<Sidebar collapsed={false} onToggleCollapse={onToggleCollapse} />)
     expect(screen.getByText('Library')).toBeInTheDocument()
-    expect(screen.getByText('Settings')).toBeInTheDocument()
+    expect(screen.getByText('Profile')).toBeInTheDocument()
   })
 
   it('does not show a standalone Collection entry in auth section', () => {

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import {
   Calendar, Mic2, MapPin, Disc3, Tag, Tags, Tent, BookOpen, Headphones, Newspaper,
-  Send, Library, LayoutList, MessageSquarePlus, Settings, Shield, PanelLeftClose, PanelLeft,
+  Send, Library, LayoutList, MessageSquarePlus, UserCircle, Shield, PanelLeftClose, PanelLeft,
   ExternalLink, Globe, TrendingUp, Bell, HeartHandshake, Trophy, Radio,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
@@ -136,7 +136,7 @@ export function Sidebar({ collapsed, onToggleCollapse }: SidebarProps) {
               <div className="space-y-0.5">
                 {renderItem({ href: '/library', label: 'Library', icon: Library })}
                 {renderItem({ href: '/settings/notifications', label: 'Notifications', icon: Bell })}
-                {renderItem({ href: '/profile', label: 'Settings', icon: Settings })}
+                {renderItem({ href: '/profile', label: 'Profile', icon: UserCircle })}
                 {user?.is_admin && renderItem({ href: '/admin', label: 'Admin', icon: Shield })}
               </div>
             </div>


### PR DESCRIPTION
## Summary
- Rename sidebar nav item from "Settings" to "Profile" to match its `/profile` destination
- Swap icon from `Settings` (gear) to `UserCircle` for clarity
- Update 2 Sidebar tests to match new label

Closes PSY-327

## Test plan
- [ ] Sidebar shows "Profile" with user icon instead of "Settings" with gear
- [ ] Clicking navigates to `/profile`
- [ ] All Sidebar tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)