### PR TITLE
Fix admin dashboard quick-links to update URL for deep-linking

### DIFF
--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -384,7 +384,7 @@ function AdminPageContent() {
           </TabsList>
 
           <TabsContent value="dashboard" className="space-y-4" data-testid="admin-tab-dashboard">
-            <DashboardPage onNavigate={setActiveTab} />
+            <DashboardPage onNavigate={handleTabChange} />
           </TabsContent>
 
           <TabsContent value="moderation" className="space-y-4" data-testid="admin-tab-moderation">


### PR DESCRIPTION
## Summary
- Dashboard quick-link buttons (Pending Shows, Venue Edits, Reports, etc.) now update the URL via `handleTabChange` instead of only setting React state
- Makes dashboard navigation bookmarkable and browser back/forward compatible
- 1 line changed in `admin/page.tsx`

Closes PSY-325

## Test plan
- [ ] Click a dashboard quick-link (e.g., "Pending Shows") — URL updates to `?tab=pending-shows`
- [ ] Bookmark the URL, navigate away, return — correct tab is active
- [ ] Browser back button returns to previous tab
- [ ] Direct tab clicks still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)