### PR TITLE
Fix Enter key submission in add-tag dialog

### DIFF
--- a/frontend/features/tags/components/EntityTagList.test.tsx
+++ b/frontend/features/tags/components/EntityTagList.test.tsx
@@ -24,13 +24,15 @@ const mockSearchTags = {
   ],
 }
 
+const mockAddMutate = vi.fn()
+
 vi.mock('../hooks', () => ({
   useEntityTags: () => ({
     data: mockEntityTags,
     isLoading: false,
   }),
   useAddTagToEntity: () => ({
-    mutate: vi.fn(),
+    mutate: mockAddMutate,
     isPending: false,
     error: null,
   }),
@@ -94,5 +96,36 @@ describe('EntityTagList add-tag dialog accessibility', () => {
     // The dialog should NOT have aria-describedby (we passed undefined to suppress it)
     const dialog = screen.getByRole('dialog')
     expect(dialog).not.toHaveAttribute('aria-describedby')
+  })
+
+  it('submits first search result when Enter is pressed with matching tags', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(
+      <EntityTagList entityType="artist" entityId={1} isAuthenticated />
+    )
+
+    // Open the dialog
+    await user.click(screen.getByRole('button', { name: 'Add tag' }))
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+
+    // Type a search query (>= 2 chars to trigger search)
+    const input = screen.getByPlaceholderText('Search tags or type a new one...')
+    await user.type(input, 'punk')
+
+    // Wait for search results to appear
+    await waitFor(() => {
+      expect(screen.getByText('punk')).toBeInTheDocument()
+    })
+
+    // Press Enter
+    await user.keyboard('{Enter}')
+
+    // Should have called the add mutation with the first result (tag id 3)
+    expect(mockAddMutate).toHaveBeenCalledWith(
+      expect.objectContaining({ entityType: 'artist', entityId: 1, tag_id: 3 }),
+      expect.any(Object)
+    )
   })
 })

--- a/frontend/features/tags/components/EntityTagList.tsx
+++ b/frontend/features/tags/components/EntityTagList.tsx
@@ -246,6 +246,22 @@ function AddTagForm({
     tag => !existingTagIds.includes(tag.id)
   ) ?? []
 
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key !== 'Enter') return
+    e.preventDefault()
+
+    if (addMutation.isPending) return
+
+    const query = searchQuery.trim()
+    if (!query || debouncedQuery.length < 2) return
+
+    if (filteredResults.length > 0) {
+      handleSelectTag(filteredResults[0])
+    } else if (!searchLoading) {
+      handleCreateTag()
+    }
+  }
+
   return (
     <div className="space-y-4">
       <div className="relative">
@@ -253,6 +269,7 @@ function AddTagForm({
         <Input
           value={searchQuery}
           onChange={e => setSearchQuery(e.target.value)}
+          onKeyDown={handleKeyDown}
           placeholder="Search tags or type a new one..."
           className="pl-9"
           autoFocus


### PR DESCRIPTION
## Summary
- Add `onKeyDown` handler to tag search input for Enter key submission
- Enter selects first search result, or creates new tag if no results exist
- Prevents dialog from closing prematurely, guards against double-submit
- New test case verifying Enter key behavior

Closes PSY-313

## Test plan
- [ ] Open add-tag dialog on any entity
- [ ] Type a tag name, press Enter — first matching result is selected
- [ ] Type a new tag name with no results, press Enter — creates the tag
- [ ] Enter doesn't close the dialog without submitting
- [ ] All EntityTagList tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)