### PR TITLE
Rename 'Submissions' to 'My Submissions' in sidebar and nav

### DIFF
--- a/frontend/app/nav-utils.ts
+++ b/frontend/app/nav-utils.ts
@@ -10,7 +10,7 @@ export const navLinks = [
     external: true,
     prefetch: false as const,
   },
-  { href: '/submissions', label: 'Submissions', prefetch: false as const },
+  { href: '/submissions', label: 'My Submissions', prefetch: false as const },
 ]
 
 export type NavLink = (typeof navLinks)[number]

--- a/frontend/components/layout/CommandPalette.test.tsx
+++ b/frontend/components/layout/CommandPalette.test.tsx
@@ -91,7 +91,7 @@ describe('CommandPalette', () => {
     expect(screen.getByText('Venues')).toBeInTheDocument()
     expect(screen.getByText('Blog')).toBeInTheDocument()
     expect(screen.getByText('DJ Sets')).toBeInTheDocument()
-    expect(screen.getByText('Submissions')).toBeInTheDocument()
+    expect(screen.getByText('My Submissions')).toBeInTheDocument()
 
     // Auth-only pages hidden
     expect(screen.queryByText('Library')).not.toBeInTheDocument()

--- a/frontend/components/layout/CommandPalette.tsx
+++ b/frontend/components/layout/CommandPalette.tsx
@@ -130,10 +130,10 @@ const routes: RouteItem[] = [
     keywords: ['dj', 'sets', 'mixes', 'electronic'],
   },
   {
-    label: 'Submissions',
+    label: 'My Submissions',
     href: '/submissions',
     icon: Send,
-    keywords: ['submissions', 'submit', 'add', 'new show'],
+    keywords: ['submissions', 'submit', 'add', 'new show', 'my submissions'],
   },
   {
     label: 'Library',

--- a/frontend/components/layout/Sidebar.test.tsx
+++ b/frontend/components/layout/Sidebar.test.tsx
@@ -28,9 +28,9 @@ describe('sidebarGroups', () => {
     expect(discover.items.map(i => i.label)).toEqual(['Shows', 'Festivals', 'Artists', 'Venues', 'Releases', 'Labels', 'Tags', 'Scenes', 'Collections', 'Charts', 'Radio'])
   })
 
-  it('Community contains Contribute, Requests, Blog, DJ Sets, Substack, Submissions', () => {
+  it('Community contains Contribute, Requests, Blog, DJ Sets, Substack, My Submissions', () => {
     const community = sidebarGroups.find(g => g.label === 'Community')!
-    expect(community.items.map(i => i.label)).toEqual(['Contribute', 'Leaderboard', 'Requests', 'Blog', 'DJ Sets', 'Substack', 'Submissions'])
+    expect(community.items.map(i => i.label)).toEqual(['Contribute', 'Leaderboard', 'Requests', 'Blog', 'DJ Sets', 'Substack', 'My Submissions'])
   })
 
   it('only Substack is marked external', () => {
@@ -82,7 +82,7 @@ describe('Sidebar', () => {
     expect(screen.getByText('Blog')).toBeInTheDocument()
     expect(screen.getByText('DJ Sets')).toBeInTheDocument()
     expect(screen.getByText('Substack')).toBeInTheDocument()
-    expect(screen.getByText('Submissions')).toBeInTheDocument()
+    expect(screen.getByText('My Submissions')).toBeInTheDocument()
   })
 
   it('hides group headers when collapsed', () => {

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -52,7 +52,7 @@ export const sidebarGroups: SidebarGroup[] = [
       { href: '/blog', label: 'Blog', icon: BookOpen },
       { href: '/dj-sets', label: 'DJ Sets', icon: Headphones },
       { href: 'https://psychichomily.substack.com/', label: 'Substack', icon: Newspaper, external: true },
-      { href: '/submissions', label: 'Submissions', icon: Send },
+      { href: '/submissions', label: 'My Submissions', icon: Send },
     ],
   },
 ]


### PR DESCRIPTION
## Summary
- Rename "Submissions" to "My Submissions" in sidebar, mobile nav, and command palette
- Add "my submissions" to Cmd+K search keywords
- Update 4 test assertions to match
- Library tab and page heading left as-is (context already implies "my")

Closes PSY-253

## Test plan
- [ ] Sidebar shows "My Submissions" instead of "Submissions"
- [ ] Mobile nav shows "My Submissions"
- [ ] Cmd+K palette shows "My Submissions" and finds it when searching "my submissions"
- [ ] All Sidebar and CommandPalette tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)