### PR TITLE
Add actionable links to Contribute page data quality cards

### DIFF
--- a/frontend/features/contributions/components/ContributeDashboard.tsx
+++ b/frontend/features/contributions/components/ContributeDashboard.tsx
@@ -2,10 +2,21 @@
 
 import { useState } from 'react'
 import Link from 'next/link'
-import { Mic2, MapPin, Calendar, ChevronRight, ExternalLink } from 'lucide-react'
+import {
+  Mic2,
+  MapPin,
+  Calendar,
+  ChevronRight,
+  ExternalLink,
+  Music,
+  ListTodo,
+  Trophy,
+  ArrowRight,
+} from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import { LoadingSpinner } from '@/components/shared'
 import { useContributeOpportunities, useContributeCategory } from '../hooks'
 import type { DataQualityCategory, DataQualityItem } from '../types'
@@ -43,6 +54,20 @@ function formatEntityType(entityType: string): string {
   return entityType.charAt(0).toUpperCase() + entityType.slice(1) + 's'
 }
 
+/** Get browse page URL for an entity type */
+function getBrowseUrl(entityType: string): string {
+  switch (entityType) {
+    case 'artist':
+      return '/artists'
+    case 'venue':
+      return '/venues'
+    case 'show':
+      return '/shows'
+    default:
+      return '/'
+  }
+}
+
 function CategoryCard({
   category,
   isSelected,
@@ -53,6 +78,7 @@ function CategoryCard({
   onClick: () => void
 }) {
   const Icon = getEntityIcon(category.entity_type)
+  const browseUrl = getBrowseUrl(category.entity_type)
   return (
     <Card
       className={`cursor-pointer transition-colors hover:border-primary/50 ${
@@ -75,20 +101,28 @@ function CategoryCard({
         <CardTitle className="text-base">{category.label}</CardTitle>
         <CardDescription className="text-sm">{category.description}</CardDescription>
       </CardHeader>
-      {isSelected && (
-        <CardContent className="pt-0 pb-2">
+      <CardContent className="pt-0 pb-3">
+        <div className="flex items-center justify-between">
           <div className="flex items-center gap-1 text-xs text-primary">
-            <span>View items</span>
+            <span>{isSelected ? 'Viewing items' : 'View items'}</span>
             <ChevronRight className="h-3 w-3" />
           </div>
-        </CardContent>
-      )}
+          <Link
+            href={browseUrl}
+            className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+            onClick={(e) => e.stopPropagation()}
+          >
+            Browse {formatEntityType(category.entity_type).toLowerCase()}
+          </Link>
+        </div>
+      </CardContent>
     </Card>
   )
 }
 
-function CategoryItems({ category }: { category: string }) {
+function CategoryItems({ category, entityType }: { category: string; entityType: string }) {
   const { data, isLoading, error } = useContributeCategory(category)
+  const browseUrl = getBrowseUrl(entityType)
 
   if (isLoading) {
     return (
@@ -112,15 +146,30 @@ function CategoryItems({ category }: { category: string }) {
   if (items.length === 0) {
     return (
       <div className="text-center py-8 text-muted-foreground">
-        No items in this category right now.
+        <p>No items in this category right now.</p>
+        <Button variant="outline" size="sm" asChild className="mt-3">
+          <Link href={browseUrl}>
+            Browse all {formatEntityType(entityType).toLowerCase()}
+            <ArrowRight className="h-3.5 w-3.5" />
+          </Link>
+        </Button>
       </div>
     )
   }
 
   return (
     <div className="space-y-2">
-      <div className="text-sm text-muted-foreground mb-3">
-        Showing {items.length} of {total} items
+      <div className="flex items-center justify-between mb-3">
+        <span className="text-sm text-muted-foreground">
+          Showing {items.length} of {total} items
+        </span>
+        <Link
+          href={browseUrl}
+          className="text-sm text-primary hover:text-primary/80 flex items-center gap-1 transition-colors"
+        >
+          Browse all {formatEntityType(entityType).toLowerCase()}
+          <ArrowRight className="h-3.5 w-3.5" />
+        </Link>
       </div>
       {items.map((item: DataQualityItem) => (
         <ItemRow key={`${item.entity_type}-${item.entity_id}`} item={item} />
@@ -157,6 +206,27 @@ function ItemRow({ item }: { item: DataQualityItem }) {
   )
 }
 
+const quickActions = [
+  {
+    label: 'Submit a Show',
+    description: 'Add an upcoming show to the calendar',
+    href: '/submissions',
+    icon: Music,
+  },
+  {
+    label: 'Browse Requests',
+    description: 'Fill requests from the community',
+    href: '/requests',
+    icon: ListTodo,
+  },
+  {
+    label: 'Leaderboard',
+    description: 'See top contributors',
+    href: '/community/leaderboard',
+    icon: Trophy,
+  },
+]
+
 export function ContributeDashboard() {
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null)
   const { data, isLoading, error } = useContributeOpportunities()
@@ -179,9 +249,33 @@ export function ContributeDashboard() {
 
   const categories = data?.categories ?? []
   const totalItems = data?.total_items ?? 0
+  const selectedCategoryData = categories.find((c) => c.key === selectedCategory)
 
   return (
     <div className="space-y-8">
+      {/* Quick actions */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        {quickActions.map((action) => (
+          <Link
+            key={action.href}
+            href={action.href}
+            className="flex items-center gap-3 rounded-lg border p-3 hover:bg-muted/50 transition-colors group"
+          >
+            <div className="flex h-9 w-9 items-center justify-center rounded-md bg-primary/10 text-primary shrink-0">
+              <action.icon className="h-4.5 w-4.5" />
+            </div>
+            <div className="min-w-0">
+              <div className="text-sm font-medium group-hover:text-primary transition-colors">
+                {action.label}
+              </div>
+              <div className="text-xs text-muted-foreground truncate">
+                {action.description}
+              </div>
+            </div>
+          </Link>
+        ))}
+      </div>
+
       {/* Summary */}
       <div className="text-center space-y-2">
         <p className="text-muted-foreground">
@@ -209,24 +303,53 @@ export function ContributeDashboard() {
       </div>
 
       {/* Selected category items */}
-      {selectedCategory && (
+      {selectedCategory && selectedCategoryData && (
         <div className="mt-6">
           <h2 className="text-lg font-semibold mb-4">
-            {categories.find((c) => c.key === selectedCategory)?.label}
+            {selectedCategoryData.label}
           </h2>
-          <CategoryItems category={selectedCategory} />
+          <CategoryItems
+            category={selectedCategory}
+            entityType={selectedCategoryData.entity_type}
+          />
         </div>
       )}
 
       {/* Empty state */}
       {totalItems === 0 && (
-        <div className="text-center py-12">
+        <div className="text-center py-12 space-y-4">
           <p className="text-lg font-medium text-foreground mb-2">
             Everything looks great!
           </p>
           <p className="text-muted-foreground">
-            No data quality issues found. Check back later for new opportunities.
+            No data quality issues found. Here are other ways to contribute:
           </p>
+          <div className="flex flex-wrap items-center justify-center gap-3 pt-2">
+            <Button variant="outline" size="sm" asChild>
+              <Link href="/submissions">
+                <Music className="h-4 w-4" />
+                Submit a Show
+              </Link>
+            </Button>
+            <Button variant="outline" size="sm" asChild>
+              <Link href="/requests">
+                <ListTodo className="h-4 w-4" />
+                Browse Requests
+              </Link>
+            </Button>
+            <Button variant="outline" size="sm" asChild>
+              <Link href="/artists">
+                <Mic2 className="h-4 w-4" />
+                Browse Artists
+              </Link>
+            </Button>
+            <Button variant="outline" size="sm" asChild>
+              <Link href="/venues">
+                <MapPin className="h-4 w-4" />
+                Browse Venues
+              </Link>
+            </Button>
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Add quick action links at top: Submit a Show, Browse Requests, Leaderboard
- Add "Browse [entity]" links on every data quality category card
- Add "Browse all" link in expanded item lists
- Improve empty states with actionable buttons instead of "Check back later"

Closes PSY-322

## Test plan
- [ ] Visit `/contribute` — quick action cards appear at top
- [ ] Each data quality card has a "Browse" link to the relevant entity page
- [ ] Expanding a card shows "Browse all" link in items header
- [ ] Empty categories show "Browse all" button
- [ ] Fully empty state shows Submit/Browse action buttons
- [ ] Card links don't interfere with expand/collapse

🤖 Generated with [Claude Code](https://claude.com/claude-code)