### PR TITLE
Fix Trending Shows and Hot Releases charts always empty

### DIFF
--- a/backend/internal/services/catalog/charts_service.go
+++ b/backend/internal/services/catalog/charts_service.go
@@ -27,7 +27,8 @@ func NewChartsService(database *gorm.DB) *ChartsService {
 }
 
 // GetTrendingShows returns upcoming shows ranked by total attendance (going + interested).
-// Only includes future shows with approved status.
+// Only includes future shows with approved status. Shows without engagement data are
+// included and ranked by soonest date, so the chart is never empty when shows exist.
 func (s *ChartsService) GetTrendingShows(limit int) ([]contracts.TrendingShow, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
@@ -60,11 +61,11 @@ func (s *ChartsService) GetTrendingShows(limit int) ([]contracts.TrendingShow, e
 			COALESCE(v.city, '') AS city,
 			COALESCE(SUM(CASE WHEN ub.action = 'going' THEN 1 ELSE 0 END), 0) AS going_count,
 			COALESCE(SUM(CASE WHEN ub.action = 'interested' THEN 1 ELSE 0 END), 0) AS interested_count,
-			COUNT(ub.id) AS total_attendance
+			COALESCE(COUNT(ub.id), 0) AS total_attendance
 		FROM shows s
 		LEFT JOIN show_venues sv ON sv.show_id = s.id
 		LEFT JOIN venues v ON v.id = sv.venue_id
-		JOIN user_bookmarks ub ON ub.entity_id = s.id
+		LEFT JOIN user_bookmarks ub ON ub.entity_id = s.id
 			AND ub.entity_type = ?
 			AND ub.action IN (?, ?)
 		WHERE s.status = ?
@@ -236,7 +237,8 @@ func (s *ChartsService) GetActiveVenues(limit int) ([]contracts.ActiveVenue, err
 	return results, nil
 }
 
-// GetHotReleases returns releases ranked by bookmark count in the last 30 days.
+// GetHotReleases returns releases ranked by recent bookmark count, falling back to
+// recently added releases when no bookmarks exist so the chart is never empty.
 func (s *ChartsService) GetHotReleases(limit int) ([]contracts.HotRelease, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
@@ -259,14 +261,14 @@ func (s *ChartsService) GetHotReleases(limit int) ([]contracts.HotRelease, error
 			r.title,
 			COALESCE(r.slug, '') AS slug,
 			r.release_date,
-			COUNT(ub.id) AS bookmark_count
+			COALESCE(COUNT(ub.id), 0) AS bookmark_count
 		FROM releases r
-		JOIN user_bookmarks ub ON ub.entity_id = r.id
+		LEFT JOIN user_bookmarks ub ON ub.entity_id = r.id
 			AND ub.entity_type = ?
 			AND ub.action = ?
 			AND ub.created_at >= ?
 		GROUP BY r.id, r.title, r.slug, r.release_date
-		ORDER BY bookmark_count DESC, r.title ASC
+		ORDER BY bookmark_count DESC, r.created_at DESC
 		LIMIT ?
 	`, models.BookmarkEntityRelease, models.BookmarkActionBookmark, thirtyDaysAgo, limit).Scan(&rows).Error
 	if err != nil {

--- a/backend/internal/services/catalog/charts_service_test.go
+++ b/backend/internal/services/catalog/charts_service_test.go
@@ -228,6 +228,48 @@ func (suite *ChartsServiceIntegrationTestSuite) TestGetTrendingShows_RespectsLim
 	suite.Len(shows, 3)
 }
 
+func (suite *ChartsServiceIntegrationTestSuite) TestGetTrendingShows_WithoutBookmarks() {
+	user := suite.createUser("charts-nobookmark@test.com")
+	venue := suite.createVenue("No Bookmark Venue", "Phoenix", "AZ")
+	artist := suite.createArtist("No Bookmark Band")
+
+	future := time.Now().UTC().AddDate(0, 0, 7)
+	show := suite.createApprovedShow("Unbookmarked Show", venue.ID, artist.ID, user.ID, future)
+
+	shows, err := suite.chartsService.GetTrendingShows(20)
+	suite.Require().NoError(err)
+	suite.Require().Len(shows, 1)
+	suite.Equal(show.ID, shows[0].ShowID)
+	suite.Equal("Unbookmarked Show", shows[0].Title)
+	suite.Equal(0, shows[0].GoingCount)
+	suite.Equal(0, shows[0].InterestedCount)
+	suite.Equal(0, shows[0].TotalAttendance)
+	suite.Equal("No Bookmark Venue", shows[0].VenueName)
+}
+
+func (suite *ChartsServiceIntegrationTestSuite) TestGetTrendingShows_BookmarkedRankedFirst() {
+	user := suite.createUser("charts-rank@test.com")
+	venue := suite.createVenue("Rank Venue", "Phoenix", "AZ")
+	artist := suite.createArtist("Rank Band")
+
+	future := time.Now().UTC().AddDate(0, 0, 7)
+	// Show with no bookmarks (further future date)
+	unbookmarked := suite.createApprovedShow("Unbookmarked", venue.ID, artist.ID, user.ID, future.AddDate(0, 0, 10))
+	// Show with bookmarks (same date)
+	bookmarked := suite.createApprovedShow("Bookmarked", venue.ID, artist.ID, user.ID, future.AddDate(0, 0, 10))
+	suite.createBookmark(user.ID, models.BookmarkEntityShow, bookmarked.ID, models.BookmarkActionGoing)
+
+	shows, err := suite.chartsService.GetTrendingShows(20)
+	suite.Require().NoError(err)
+	suite.Require().Len(shows, 2)
+	// Bookmarked show should be first
+	suite.Equal(bookmarked.ID, shows[0].ShowID)
+	suite.Equal(1, shows[0].TotalAttendance)
+	// Unbookmarked show second
+	suite.Equal(unbookmarked.ID, shows[1].ShowID)
+	suite.Equal(0, shows[1].TotalAttendance)
+}
+
 // =============================================================================
 // GetPopularArtists Tests
 // =============================================================================
@@ -458,6 +500,43 @@ func (suite *ChartsServiceIntegrationTestSuite) TestGetHotReleases_RespectsLimit
 	suite.Len(releases, 3)
 }
 
+func (suite *ChartsServiceIntegrationTestSuite) TestGetHotReleases_WithoutBookmarks() {
+	artist := suite.createArtist("Unbookmarked Artist")
+	release := suite.createRelease("Unbookmarked Album")
+	suite.addArtistToRelease(artist.ID, release.ID)
+
+	releases, err := suite.chartsService.GetHotReleases(20)
+	suite.Require().NoError(err)
+	suite.Require().Len(releases, 1)
+	suite.Equal(release.ID, releases[0].ReleaseID)
+	suite.Equal("Unbookmarked Album", releases[0].Title)
+	suite.Equal(0, releases[0].BookmarkCount)
+	suite.Require().Len(releases[0].ArtistNames, 1)
+	suite.Equal("Unbookmarked Artist", releases[0].ArtistNames[0])
+}
+
+func (suite *ChartsServiceIntegrationTestSuite) TestGetHotReleases_BookmarkedRankedFirst() {
+	user := suite.createUser("hot-rank@test.com")
+	artist := suite.createArtist("Rank Release Artist")
+
+	unbookmarked := suite.createRelease("Unbookmarked Release")
+	suite.addArtistToRelease(artist.ID, unbookmarked.ID)
+
+	bookmarked := suite.createRelease("Bookmarked Release")
+	suite.addArtistToRelease(artist.ID, bookmarked.ID)
+	suite.createBookmark(user.ID, models.BookmarkEntityRelease, bookmarked.ID, models.BookmarkActionBookmark)
+
+	releases, err := suite.chartsService.GetHotReleases(20)
+	suite.Require().NoError(err)
+	suite.Require().Len(releases, 2)
+	// Bookmarked release should be first
+	suite.Equal(bookmarked.ID, releases[0].ReleaseID)
+	suite.Equal(1, releases[0].BookmarkCount)
+	// Unbookmarked release second
+	suite.Equal(unbookmarked.ID, releases[1].ReleaseID)
+	suite.Equal(0, releases[1].BookmarkCount)
+}
+
 func (suite *ChartsServiceIntegrationTestSuite) TestGetHotReleases_Only30Days() {
 	user := suite.createUser("hot-30d@test.com")
 	artist := suite.createArtist("Old Release Artist")
@@ -472,7 +551,10 @@ func (suite *ChartsServiceIntegrationTestSuite) TestGetHotReleases_Only30Days() 
 
 	releases, err := suite.chartsService.GetHotReleases(20)
 	suite.Require().NoError(err)
-	suite.Empty(releases) // Should not include bookmark older than 30 days
+	// Release still appears but with 0 bookmark_count (old bookmark not counted)
+	suite.Require().Len(releases, 1)
+	suite.Equal("Old Bookmarked Release", releases[0].Title)
+	suite.Equal(0, releases[0].BookmarkCount)
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- **Root cause**: `GetTrendingShows` and `GetHotReleases` queries used `INNER JOIN` on `user_bookmarks`, so they returned zero results when no users had clicked going/interested on shows or bookmarked releases. Popular Artists and Active Venues worked fine because they already used `LEFT JOIN` with fallback to show-count signals.
- **Fix**: Changed both queries to `LEFT JOIN user_bookmarks` so shows/releases appear even without engagement data. Items with bookmarks still rank first; items without fill in ranked by date (soonest upcoming shows, most recently created releases).
- Added 4 new integration tests verifying the fallback behavior (shows/releases without bookmarks appear, bookmarked items rank first). Updated 1 existing test (`Only30Days`) to match new semantics.

Closes PSY-323

## Test plan
- [x] All 22 charts service integration tests pass (including 4 new ones)
- [x] All 18 charts handler unit tests pass
- [x] All 19 frontend charts tests pass
- [ ] Manual: visit `/charts` and verify Trending Shows and Hot Releases sections show data
- [ ] Manual: verify shows with going/interested counts still rank above shows without

🤖 Generated with [Claude Code](https://claude.com/claude-code)