### PR TITLE
Add releases missing year to data quality dashboard

### DIFF
--- a/backend/internal/services/admin/data_quality.go
+++ b/backend/internal/services/admin/data_quality.go
@@ -63,6 +63,11 @@ var categoryDefinitions = map[string]struct {
 		EntityType:  "show",
 		Description: "Upcoming approved shows with no price set",
 	},
+	"releases_missing_year": {
+		Label:       "Releases Missing Year",
+		EntityType:  "release",
+		Description: "Releases with no release year set",
+	},
 }
 
 // categoryOrder defines the display order for categories.
@@ -74,6 +79,7 @@ var categoryOrder = []string{
 	"venues_unverified_with_shows",
 	"shows_no_billing_order",
 	"shows_missing_price",
+	"releases_missing_year",
 }
 
 // GetSummary returns counts per data quality category.
@@ -129,6 +135,8 @@ func (s *DataQualityService) GetCategoryItems(category string, limit, offset int
 		return s.getShowsNoBillingOrder(limit, offset)
 	case "shows_missing_price":
 		return s.getShowsMissingPrice(limit, offset)
+	case "releases_missing_year":
+		return s.getReleasesMissingYear(limit, offset)
 	default:
 		return nil, 0, fmt.Errorf("unknown category: %s", category)
 	}
@@ -193,6 +201,12 @@ func (s *DataQualityService) getCategoryCount(category string) (int, error) {
 		err = s.db.Raw(`
 			SELECT COUNT(*) FROM shows
 			WHERE status = 'approved' AND event_date >= NOW() AND price IS NULL
+		`).Scan(&count).Error
+
+	case "releases_missing_year":
+		err = s.db.Raw(`
+			SELECT COUNT(*) FROM releases
+			WHERE release_year IS NULL
 		`).Scan(&count).Error
 	}
 
@@ -554,6 +568,61 @@ func (s *DataQualityService) getShowsMissingPrice(limit, offset int) ([]*contrac
 			Name:       r.Title,
 			Slug:       slug,
 			Reason:     "No price set for upcoming show",
+			ShowCount:  0,
+		})
+	}
+	return items, total, nil
+}
+
+func (s *DataQualityService) getReleasesMissingYear(limit, offset int) ([]*contracts.DataQualityItem, int64, error) {
+	var total int64
+	err := s.db.Raw(`
+		SELECT COUNT(*) FROM releases
+		WHERE release_year IS NULL
+	`).Scan(&total).Error
+	if err != nil {
+		return nil, 0, err
+	}
+
+	type row struct {
+		ID          uint
+		Title       string
+		Slug        *string
+		ReleaseType string
+		ArtistNames string
+	}
+	var rows []row
+	err = s.db.Raw(`
+		SELECT r.id, r.title, r.slug, r.release_type,
+		       COALESCE(string_agg(a.name, ', ' ORDER BY ar.position), '') as artist_names
+		FROM releases r
+		LEFT JOIN artist_releases ar ON ar.release_id = r.id
+		LEFT JOIN artists a ON a.id = ar.artist_id
+		WHERE r.release_year IS NULL
+		GROUP BY r.id
+		ORDER BY r.title ASC
+		LIMIT ? OFFSET ?
+	`, limit, offset).Scan(&rows).Error
+	if err != nil {
+		return nil, 0, err
+	}
+
+	items := make([]*contracts.DataQualityItem, 0, len(rows))
+	for _, r := range rows {
+		slug := ""
+		if r.Slug != nil {
+			slug = *r.Slug
+		}
+		reason := "No release year set"
+		if r.ArtistNames != "" {
+			reason = fmt.Sprintf("No release year set (by %s)", r.ArtistNames)
+		}
+		items = append(items, &contracts.DataQualityItem{
+			EntityType: "release",
+			EntityID:   r.ID,
+			Name:       r.Title,
+			Slug:       slug,
+			Reason:     reason,
 			ShowCount:  0,
 		})
 	}

--- a/backend/internal/services/admin/data_quality_test.go
+++ b/backend/internal/services/admin/data_quality_test.go
@@ -49,10 +49,12 @@ func (suite *DataQualityServiceIntegrationTestSuite) TearDownSuite() {
 func (suite *DataQualityServiceIntegrationTestSuite) TearDownTest() {
 	sqlDB, err := suite.db.DB()
 	suite.Require().NoError(err)
+	_, _ = sqlDB.Exec("DELETE FROM artist_releases")
 	_, _ = sqlDB.Exec("DELETE FROM artist_aliases")
 	_, _ = sqlDB.Exec("DELETE FROM show_artists")
 	_, _ = sqlDB.Exec("DELETE FROM show_venues")
 	_, _ = sqlDB.Exec("DELETE FROM shows")
+	_, _ = sqlDB.Exec("DELETE FROM releases")
 	_, _ = sqlDB.Exec("DELETE FROM artists")
 	_, _ = sqlDB.Exec("DELETE FROM venues")
 }
@@ -166,7 +168,7 @@ func (suite *DataQualityServiceIntegrationTestSuite) TestGetSummary_Empty() {
 	summary, err := suite.service.GetSummary()
 	suite.Require().NoError(err)
 	suite.Equal(0, summary.TotalItems)
-	suite.Len(summary.Categories, 7)
+	suite.Len(summary.Categories, 8)
 
 	// All counts should be 0 in an empty DB
 	for _, cat := range summary.Categories {
@@ -396,6 +398,50 @@ func (suite *DataQualityServiceIntegrationTestSuite) TestShowsMissingPrice() {
 	suite.Equal(int64(1), total)
 	suite.Len(items, 1)
 	suite.Equal("No Price Show", items[0].Name)
+}
+
+// =============================================================================
+// TESTS: GetCategoryItems - Releases Missing Year
+// =============================================================================
+
+func (suite *DataQualityServiceIntegrationTestSuite) TestReleasesMissingYear() {
+	// Release with no year
+	noYear := &models.Release{Title: "Unknown Year Album", ReleaseType: models.ReleaseTypeLP}
+	suite.Require().NoError(suite.db.Create(noYear).Error)
+
+	// Release with a year (should NOT appear)
+	year := 2020
+	withYear := &models.Release{Title: "Dated Album", ReleaseType: models.ReleaseTypeLP, ReleaseYear: &year}
+	suite.Require().NoError(suite.db.Create(withYear).Error)
+
+	// Release with no year but linked to an artist (test artist name in reason)
+	noYearLinked := &models.Release{Title: "Mystery EP", ReleaseType: models.ReleaseTypeEP}
+	suite.Require().NoError(suite.db.Create(noYearLinked).Error)
+	artist := suite.createArtist("Cool Band", nil)
+	suite.Require().NoError(suite.db.Create(&models.ArtistRelease{
+		ArtistID:  artist.ID,
+		ReleaseID: noYearLinked.ID,
+		Role:      models.ArtistReleaseRoleMain,
+		Position:  0,
+	}).Error)
+
+	items, total, err := suite.service.GetCategoryItems("releases_missing_year", 50, 0)
+	suite.Require().NoError(err)
+	suite.Equal(int64(2), total)
+	suite.Len(items, 2)
+
+	// Both items should be releases
+	for _, item := range items {
+		suite.Equal("release", item.EntityType)
+		suite.Contains(item.Reason, "No release year set")
+	}
+
+	// Find the linked release and verify artist name is in the reason
+	for _, item := range items {
+		if item.Name == "Mystery EP" {
+			suite.Contains(item.Reason, "Cool Band")
+		}
+	}
 }
 
 // =============================================================================

--- a/frontend/app/admin/data-quality/_components/DataQualityDashboard.tsx
+++ b/frontend/app/admin/data-quality/_components/DataQualityDashboard.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import {
   AlertTriangle,
+  Calendar,
   ChevronLeft,
   ExternalLink,
   Loader2,
@@ -34,6 +35,7 @@ const categoryIcons: Record<string, LucideIcon> = {
   venues_unverified_with_shows: BadgeCheck,
   shows_no_billing_order: ListOrdered,
   shows_missing_price: DollarSign,
+  releases_missing_year: Calendar,
 }
 
 // Map entity types to base paths for links
@@ -46,6 +48,8 @@ function getEntityUrl(item: DataQualityItem): string {
       return `/venues/${slug}`
     case 'show':
       return `/shows/${slug}`
+    case 'release':
+      return `/releases/${slug}`
     default:
       return '#'
   }


### PR DESCRIPTION
## Summary
- Adds a "Releases Missing Year" category to the admin data quality dashboard, surfacing releases with `release_year IS NULL`
- Includes linked artist names in the reason text for easier identification (e.g., "No release year set (by Cool Band)")
- Adds `release` entity type URL mapping in the frontend dashboard so clicking a release links to its detail page

## Context
PSY-326 reported 2 releases in the database missing year data. Since these were entered via the admin UI (not seed data), the fix is to surface them in the data quality dashboard where an admin can identify and fix them through the existing release edit UI.

Closes PSY-326

## Test plan
- [x] Backend integration test `TestReleasesMissingYear` verifies count, entity type, and artist name in reason
- [x] Summary test updated for 8 categories (was 7)
- [x] TearDownTest cleanup includes `releases` and `artist_releases` tables
- [x] All 13 data quality tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)