### PR TITLE
Add rate limiting to tag creation and voting endpoints

### DIFF
--- a/backend/internal/api/middleware/ratelimit.go
+++ b/backend/internal/api/middleware/ratelimit.go
@@ -34,6 +34,14 @@ const (
 	// ReportRequestsPerMinute is the rate limit for show report submissions
 	// Prevents spamming admins with reports
 	ReportRequestsPerMinute = 5
+
+	// TagCreateRequestsPerHour is the rate limit for tag creation (adding tags to entities).
+	// Prevents spamming entities with tags.
+	TagCreateRequestsPerHour = 20
+
+	// TagVoteRequestsPerMinute is the rate limit for tag voting.
+	// Prevents rapid vote manipulation.
+	TagVoteRequestsPerMinute = 30
 )
 
 // RateLimitAuthEndpoints creates a strict rate limiter for authentication endpoints
@@ -67,6 +75,28 @@ func RateLimitPasskeyEndpoints() func(http.Handler) http.Handler {
 func RateLimitAPIEndpoints() func(http.Handler) http.Handler {
 	return httprate.Limit(
 		APIRequestsPerMinute,
+		time.Minute,
+		httprate.WithKeyFuncs(httprate.KeyByIP),
+		httprate.WithLimitHandler(RateLimitExceededHandler),
+	)
+}
+
+// RateLimitTagCreateEndpoints creates a rate limiter for tag creation endpoints
+// 20 requests per hour per IP - prevents tag spam on entities
+func RateLimitTagCreateEndpoints() func(http.Handler) http.Handler {
+	return httprate.Limit(
+		TagCreateRequestsPerHour,
+		time.Hour,
+		httprate.WithKeyFuncs(httprate.KeyByIP),
+		httprate.WithLimitHandler(RateLimitExceededHandler),
+	)
+}
+
+// RateLimitTagVoteEndpoints creates a rate limiter for tag voting endpoints
+// 30 requests per minute per IP - prevents rapid vote manipulation
+func RateLimitTagVoteEndpoints() func(http.Handler) http.Handler {
+	return httprate.Limit(
+		TagVoteRequestsPerMinute,
 		time.Minute,
 		httprate.WithKeyFuncs(httprate.KeyByIP),
 		httprate.WithLimitHandler(RateLimitExceededHandler),

--- a/backend/internal/api/middleware/ratelimit_test.go
+++ b/backend/internal/api/middleware/ratelimit_test.go
@@ -83,3 +83,17 @@ func TestRateLimitAPIEndpoints_ReturnsMiddleware(t *testing.T) {
 		t.Fatal("RateLimitAPIEndpoints() returned nil")
 	}
 }
+
+func TestRateLimitTagCreateEndpoints_ReturnsMiddleware(t *testing.T) {
+	mw := RateLimitTagCreateEndpoints()
+	if mw == nil {
+		t.Fatal("RateLimitTagCreateEndpoints() returned nil")
+	}
+}
+
+func TestRateLimitTagVoteEndpoints_ReturnsMiddleware(t *testing.T) {
+	mw := RateLimitTagVoteEndpoints()
+	if mw == nil {
+		t.Fatal("RateLimitTagVoteEndpoints() returned nil")
+	}
+}

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -777,11 +777,39 @@ func setupTagRoutes(rc RouteContext) {
 	optionalAuthGroup.UseMiddleware(middleware.OptionalHumaJWTMiddleware(rc.SC.JWT))
 	huma.Get(optionalAuthGroup, "/entities/{entity_type}/{entity_id}/tags", tagHandler.ListEntityTagsHandler)
 
-	// Protected: tagging and voting
-	huma.Post(rc.Protected, "/entities/{entity_type}/{entity_id}/tags", tagHandler.AddTagToEntityHandler)
+	// Rate-limited tag creation: 20 requests per hour per IP
+	// Prevents spamming entities with tags
+	rc.Router.Group(func(r chi.Router) {
+		r.Use(httprate.Limit(
+			middleware.TagCreateRequestsPerHour,
+			time.Hour,
+			httprate.WithKeyFuncs(httprate.KeyByIP),
+			httprate.WithLimitHandler(rateLimitHandler),
+		))
+		tagCreateAPI := humachi.New(r, huma.DefaultConfig("Psychic Homily Tag Create", "1.0.0"))
+		tagCreateAPI.UseMiddleware(middleware.HumaRequestIDMiddleware)
+		tagCreateAPI.UseMiddleware(middleware.HumaJWTMiddleware(rc.SC.JWT, rc.Cfg.Session))
+		huma.Post(tagCreateAPI, "/entities/{entity_type}/{entity_id}/tags", tagHandler.AddTagToEntityHandler)
+	})
+
+	// Protected: remove tag (no additional rate limiting needed)
 	huma.Delete(rc.Protected, "/entities/{entity_type}/{entity_id}/tags/{tag_id}", tagHandler.RemoveTagFromEntityHandler)
-	huma.Post(rc.Protected, "/tags/{tag_id}/entities/{entity_type}/{entity_id}/votes", tagHandler.VoteTagHandler)
-	huma.Delete(rc.Protected, "/tags/{tag_id}/entities/{entity_type}/{entity_id}/votes", tagHandler.RemoveTagVoteHandler)
+
+	// Rate-limited tag voting: 30 requests per minute per IP
+	// Prevents rapid vote manipulation
+	rc.Router.Group(func(r chi.Router) {
+		r.Use(httprate.Limit(
+			middleware.TagVoteRequestsPerMinute,
+			time.Minute,
+			httprate.WithKeyFuncs(httprate.KeyByIP),
+			httprate.WithLimitHandler(rateLimitHandler),
+		))
+		tagVoteAPI := humachi.New(r, huma.DefaultConfig("Psychic Homily Tag Vote", "1.0.0"))
+		tagVoteAPI.UseMiddleware(middleware.HumaRequestIDMiddleware)
+		tagVoteAPI.UseMiddleware(middleware.HumaJWTMiddleware(rc.SC.JWT, rc.Cfg.Session))
+		huma.Post(tagVoteAPI, "/tags/{tag_id}/entities/{entity_type}/{entity_id}/votes", tagHandler.VoteTagHandler)
+		huma.Delete(tagVoteAPI, "/tags/{tag_id}/entities/{entity_type}/{entity_id}/votes", tagHandler.RemoveTagVoteHandler)
+	})
 
 	// Admin: tag CRUD and alias management
 	huma.Post(rc.Protected, "/tags", tagHandler.CreateTagHandler)


### PR DESCRIPTION
## Summary
- Tag creation: 20 requests/hour per IP
- Tag voting: 30 requests/minute per IP
- Uses existing `httprate` middleware pattern (same as show creation, AI processing, reports)
- Rate limit middleware tests + all tag handler/service tests pass

Closes PSY-312

## Test plan
- [ ] Tag creation works normally under limit
- [ ] Tag voting works normally under limit
- [ ] Rapid creation/voting returns 429 after threshold
- [ ] All existing tag tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)