### PR TITLE
Add visual distinction for official vs community tags

### DIFF
--- a/backend/internal/services/catalog/tag_service.go
+++ b/backend/internal/services/catalog/tag_service.go
@@ -456,6 +456,7 @@ func (s *TagService) ListEntityTags(entityType string, entityID uint, userID uin
 			Name:        et.Tag.Name,
 			Slug:        et.Tag.Slug,
 			Category:    et.Tag.Category,
+			IsOfficial:  et.Tag.IsOfficial,
 			Upvotes:     int(upvotes),
 			Downvotes:   int(downvotes),
 			WilsonScore: wilsonScore(int(upvotes), int(downvotes)),

--- a/backend/internal/services/contracts/tag.go
+++ b/backend/internal/services/contracts/tag.go
@@ -46,6 +46,7 @@ type EntityTagResponse struct {
 	Name            string  `json:"name"`
 	Slug            string  `json:"slug"`
 	Category        string  `json:"category"`
+	IsOfficial      bool    `json:"is_official"`
 	Upvotes         int     `json:"upvotes"`
 	Downvotes       int     `json:"downvotes"`
 	WilsonScore     float64 `json:"wilson_score"`

--- a/frontend/features/tags/components/EntityTagList.test.tsx
+++ b/frontend/features/tags/components/EntityTagList.test.tsx
@@ -13,8 +13,8 @@ vi.mock('next/link', () => ({
 
 const mockEntityTags = {
   tags: [
-    { tag_id: 1, name: 'rock', slug: 'rock', category: 'genre', upvotes: 3, downvotes: 0, user_vote: 0 },
-    { tag_id: 2, name: 'indie', slug: 'indie', category: 'genre', upvotes: 1, downvotes: 0, user_vote: 0 },
+    { tag_id: 1, name: 'rock', slug: 'rock', category: 'genre', is_official: true, upvotes: 3, downvotes: 0, user_vote: 0 },
+    { tag_id: 2, name: 'indie', slug: 'indie', category: 'genre', is_official: false, upvotes: 1, downvotes: 0, user_vote: 0 },
   ],
 }
 
@@ -77,6 +77,19 @@ describe('EntityTagList add-tag dialog accessibility', () => {
       <EntityTagList entityType="artist" entityId={1} isAuthenticated={false} />
     )
     expect(screen.queryByRole('button', { name: 'Add tag' })).not.toBeInTheDocument()
+  })
+
+  it('shows official badge icon for official tags and not for community tags', () => {
+    renderWithProviders(
+      <EntityTagList entityType="artist" entityId={1} isAuthenticated={false} />
+    )
+    // The official tag "rock" should have a title tooltip indicating official status
+    const rockLink = screen.getByRole('link', { name: 'rock' })
+    expect(rockLink).toHaveAttribute('title', 'rock (Official)')
+
+    // The community tag "indie" should have a plain title
+    const indieLink = screen.getByRole('link', { name: 'indie' })
+    expect(indieLink).toHaveAttribute('title', 'indie')
   })
 
   it('opens add-tag dialog with title and no aria-describedby attribute', async () => {

--- a/frontend/features/tags/components/EntityTagList.tsx
+++ b/frontend/features/tags/components/EntityTagList.tsx
@@ -140,11 +140,12 @@ function TagWithVotes({
       )}
     >
       {tag.is_official && (
-        <BadgeCheck
-          className="h-3 w-3 text-primary shrink-0"
-          aria-hidden="true"
-          title="Official tag"
-        />
+        <span title="Official tag">
+          <BadgeCheck
+            className="h-3 w-3 text-primary shrink-0"
+            aria-hidden="true"
+          />
+        </span>
       )}
       <Link
         href={`/tags/${tag.slug}`}

--- a/frontend/features/tags/components/EntityTagList.tsx
+++ b/frontend/features/tags/components/EntityTagList.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import Link from 'next/link'
-import { Plus, ThumbsUp, ThumbsDown, X, Search, Loader2 } from 'lucide-react'
+import { Plus, ThumbsUp, ThumbsDown, X, Search, Loader2, BadgeCheck } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -135,12 +135,21 @@ function TagWithVotes({
     <div
       className={cn(
         'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs',
-        getCategoryColor(tag.category)
+        getCategoryColor(tag.category),
+        tag.is_official && 'ring-1 ring-primary/20'
       )}
     >
+      {tag.is_official && (
+        <BadgeCheck
+          className="h-3 w-3 text-primary shrink-0"
+          aria-hidden="true"
+          title="Official tag"
+        />
+      )}
       <Link
         href={`/tags/${tag.slug}`}
         className="font-medium hover:underline"
+        title={tag.is_official ? `${tag.name} (Official)` : tag.name}
       >
         {tag.name}
       </Link>

--- a/frontend/features/tags/types.ts
+++ b/frontend/features/tags/types.ts
@@ -36,6 +36,7 @@ export interface EntityTag {
   name: string
   slug: string
   category: string
+  is_official: boolean
   upvotes: number
   downvotes: number
   wilson_score: number


### PR DESCRIPTION
## Summary
- Add `is_official` to `EntityTagResponse` (was already in model, missing from entity tag API)
- Official tags get BadgeCheck icon, subtle primary ring accent, and "(Official)" tooltip
- Community tags unchanged
- Frontend type updated, test added

Closes PSY-303

## Test plan
- [ ] Official tags show checkmark icon and ring accent on entity pages
- [ ] Community tags render as before (no icon, no ring)
- [ ] Hover tooltip shows "(Official)" for official tags
- [ ] All EntityTagList tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)