### PR TITLE
Expand tag categories from 3 to 8

### DIFF
--- a/backend/internal/models/tag.go
+++ b/backend/internal/models/tag.go
@@ -4,15 +4,25 @@ import "time"
 
 // Tag category constants
 const (
-	TagCategoryGenre  = "genre"
-	TagCategoryLocale = "locale"
-	TagCategoryOther  = "other"
+	TagCategoryGenre      = "genre"
+	TagCategoryLocale     = "locale"
+	TagCategoryMood       = "mood"
+	TagCategoryEra        = "era"
+	TagCategoryInstrument = "instrument"
+	TagCategoryStyle      = "style"
+	TagCategoryDescriptor = "descriptor"
+	TagCategoryOther      = "other"
 )
 
 // TagCategories is the set of valid tag categories.
 var TagCategories = []string{
 	TagCategoryGenre,
 	TagCategoryLocale,
+	TagCategoryMood,
+	TagCategoryEra,
+	TagCategoryInstrument,
+	TagCategoryStyle,
+	TagCategoryDescriptor,
 	TagCategoryOther,
 }
 

--- a/backend/internal/models/tag_test.go
+++ b/backend/internal/models/tag_test.go
@@ -67,8 +67,13 @@ func TestIsValidTagEntityType_Invalid(t *testing.T) {
 func TestTagCategoryConstants(t *testing.T) {
 	assert.Equal(t, "genre", TagCategoryGenre)
 	assert.Equal(t, "locale", TagCategoryLocale)
+	assert.Equal(t, "mood", TagCategoryMood)
+	assert.Equal(t, "era", TagCategoryEra)
+	assert.Equal(t, "instrument", TagCategoryInstrument)
+	assert.Equal(t, "style", TagCategoryStyle)
+	assert.Equal(t, "descriptor", TagCategoryDescriptor)
 	assert.Equal(t, "other", TagCategoryOther)
-	assert.Len(t, TagCategories, 3)
+	assert.Len(t, TagCategories, 8)
 }
 
 func TestTagEntityTypeConstants(t *testing.T) {

--- a/frontend/features/tags/components/EntityTagList.tsx
+++ b/frontend/features/tags/components/EntityTagList.tsx
@@ -340,6 +340,11 @@ function AddTagForm({
                 >
                   <option value="genre">Genre</option>
                   <option value="locale">Locale</option>
+                  <option value="mood">Mood</option>
+                  <option value="era">Era</option>
+                  <option value="instrument">Instrument</option>
+                  <option value="style">Style</option>
+                  <option value="descriptor">Descriptor</option>
                   <option value="other">Other</option>
                 </select>
               </div>

--- a/frontend/features/tags/types.ts
+++ b/frontend/features/tags/types.ts
@@ -1,7 +1,7 @@
 // Tag types — aligned with backend contracts/tag.go response types.
 
 export const TAG_CATEGORIES = [
-  'genre', 'locale', 'other'
+  'genre', 'locale', 'mood', 'era', 'instrument', 'style', 'descriptor', 'other'
 ] as const
 export type TagCategory = typeof TAG_CATEGORIES[number]
 
@@ -82,6 +82,11 @@ export function getCategoryColor(category: string): string {
   const colors: Record<string, string> = {
     genre: 'bg-blue-500/10 text-blue-400 border-blue-500/20',
     locale: 'bg-cyan-500/10 text-cyan-400 border-cyan-500/20',
+    mood: 'bg-purple-500/10 text-purple-400 border-purple-500/20',
+    era: 'bg-amber-500/10 text-amber-400 border-amber-500/20',
+    instrument: 'bg-emerald-500/10 text-emerald-400 border-emerald-500/20',
+    style: 'bg-rose-500/10 text-rose-400 border-rose-500/20',
+    descriptor: 'bg-teal-500/10 text-teal-400 border-teal-500/20',
     other: 'bg-zinc-500/10 text-zinc-400 border-zinc-500/20',
   }
   return colors[category] || colors.other


### PR DESCRIPTION
## Summary
- Add 5 new tag categories: mood, era, instrument, style, descriptor (joining genre, locale, other)
- Backend: new constants in `tag.go`, validation auto-picks them up via `TagCategories` slice
- Frontend: distinct colors per category, new options in create-tag dropdown
- Admin UI and tag browse automatically pick up new categories (loop over `TAG_CATEGORIES`)
- No migration needed — column is VARCHAR(50), validation is app-level

Closes PSY-299

## Test plan
- [ ] Create tags with each new category via admin or add-tag dialog
- [ ] Category colors display correctly on tag badges
- [ ] Tag browse page shows all 8 category filters
- [ ] Admin tag management shows all 8 categories
- [ ] Backend model tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)