### PR TITLE
Add tags to Cmd+K command palette search

### DIFF
--- a/frontend/components/layout/CommandPalette.tsx
+++ b/frontend/components/layout/CommandPalette.tsx
@@ -16,6 +16,7 @@ import {
   Library, LayoutList, MessageSquarePlus, Settings, Search, Clock, X, Globe,
   TrendingUp, LayoutDashboard, Upload, BadgeCheck, Flag, ScrollText, Users, Workflow,
   ClipboardCheck, BarChart3, Music, Bell, HeartHandshake, ShieldCheck, Loader2, Trophy, Radio,
+  Hash,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import { useAuthContext } from '@/lib/context/AuthContext'
@@ -296,6 +297,7 @@ const entityTypeIcons: Record<EntitySearchResult['entityType'], LucideIcon> = {
   release: Disc3,
   label: Tag,
   festival: Tent,
+  tag: Hash,
 }
 
 /** Map entity type to display label for grouping */
@@ -305,6 +307,7 @@ const entityTypeLabels: Record<EntitySearchResult['entityType'], string> = {
   release: 'Releases',
   label: 'Labels',
   festival: 'Festivals',
+  tag: 'Tags',
 }
 
 export function CommandPalette() {
@@ -388,7 +391,7 @@ export function CommandPalette() {
   // Collect entity result groups that have results, in display order
   const entityGroups = useMemo(() => {
     if (!entityResults) return []
-    const types = ['artist', 'venue', 'release', 'label', 'festival'] as const
+    const types = ['artist', 'venue', 'release', 'label', 'festival', 'tag'] as const
     const groups: { type: EntitySearchResult['entityType']; results: EntitySearchResult[] }[] = []
     for (const type of types) {
       const key = `${type}s` as keyof typeof entityResults

--- a/frontend/lib/hooks/common/useEntitySearch.test.tsx
+++ b/frontend/lib/hooks/common/useEntitySearch.test.tsx
@@ -6,6 +6,11 @@ import { createWrapper } from '@/test/utils'
 const mockApiRequest = vi.fn()
 vi.mock('@/lib/api', () => ({
   apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    TAGS: {
+      SEARCH: '/api/tags/search',
+    },
+  },
 }))
 
 // Mock use-debounce to return the value immediately for testing
@@ -19,7 +24,7 @@ describe('useEntitySearch', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     // Default: all endpoints return empty
-    mockApiRequest.mockResolvedValue({ artists: [], venues: [], releases: [], labels: [], festivals: [], count: 0 })
+    mockApiRequest.mockResolvedValue({ artists: [], venues: [], releases: [], labels: [], festivals: [], tags: [], count: 0 })
   })
 
   it('should not fetch when query is less than 2 characters', () => {
@@ -51,7 +56,7 @@ describe('useEntitySearch', () => {
     expect(mockApiRequest).not.toHaveBeenCalled()
   })
 
-  it('should fetch all 5 entity types when query is 2+ characters', async () => {
+  it('should fetch all 6 entity types when query is 2+ characters', async () => {
     mockApiRequest.mockImplementation((url: string) => {
       if (url.includes('/artists/search')) {
         return Promise.resolve({
@@ -71,6 +76,9 @@ describe('useEntitySearch', () => {
       if (url.includes('/festivals/search')) {
         return Promise.resolve({ festivals: [], count: 0 })
       }
+      if (url.includes('/tags/search')) {
+        return Promise.resolve({ tags: [] })
+      }
       return Promise.resolve({ count: 0 })
     })
 
@@ -83,13 +91,55 @@ describe('useEntitySearch', () => {
       expect(result.current.totalResults).toBe(1)
     })
 
-    // All 5 endpoints should be called
-    expect(mockApiRequest).toHaveBeenCalledTimes(5)
+    // All 6 endpoints should be called
+    expect(mockApiRequest).toHaveBeenCalledTimes(6)
     expect(mockApiRequest).toHaveBeenCalledWith(expect.stringContaining('/artists/search?q=growlers'))
     expect(mockApiRequest).toHaveBeenCalledWith(expect.stringContaining('/venues/search?q=growlers'))
     expect(mockApiRequest).toHaveBeenCalledWith(expect.stringContaining('/releases/search?q=growlers'))
     expect(mockApiRequest).toHaveBeenCalledWith(expect.stringContaining('/labels/search?q=growlers'))
     expect(mockApiRequest).toHaveBeenCalledWith(expect.stringContaining('/festivals/search?q=growlers'))
+    expect(mockApiRequest).toHaveBeenCalledWith(expect.stringContaining('/tags/search?q=growlers'))
+  })
+
+  it('should map tag results correctly', async () => {
+    mockApiRequest.mockImplementation((url: string) => {
+      if (url.includes('/tags/search')) {
+        return Promise.resolve({
+          tags: [
+            { id: 1, slug: 'post-punk', name: 'Post-Punk', category: 'genre', usage_count: 42 },
+            { id: 2, slug: 'phoenix', name: 'Phoenix', category: 'locale', usage_count: 15 },
+          ],
+        })
+      }
+      return Promise.resolve({ artists: [], venues: [], releases: [], labels: [], festivals: [], count: 0 })
+    })
+
+    const { result } = renderHook(
+      () => useEntitySearch({ query: 'post' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => {
+      expect(result.current.data?.tags.length).toBe(2)
+    })
+
+    const tags = result.current.data!.tags
+    expect(tags[0]).toEqual({
+      id: 1,
+      slug: 'post-punk',
+      name: 'Post-Punk',
+      subtitle: 'Genre',
+      entityType: 'tag',
+      href: '/tags/post-punk',
+    })
+    expect(tags[1]).toEqual({
+      id: 2,
+      slug: 'phoenix',
+      name: 'Phoenix',
+      subtitle: 'Locale',
+      entityType: 'tag',
+      href: '/tags/phoenix',
+    })
   })
 
   it('should map artist results correctly', async () => {
@@ -103,7 +153,7 @@ describe('useEntitySearch', () => {
           count: 2,
         })
       }
-      return Promise.resolve({ venues: [], releases: [], labels: [], festivals: [], count: 0 })
+      return Promise.resolve({ venues: [], releases: [], labels: [], festivals: [], tags: [], count: 0 })
     })
 
     const { result } = renderHook(
@@ -142,7 +192,7 @@ describe('useEntitySearch', () => {
           count: 1,
         })
       }
-      return Promise.resolve({ artists: [], releases: [], labels: [], festivals: [], count: 0 })
+      return Promise.resolve({ artists: [], releases: [], labels: [], festivals: [], tags: [], count: 0 })
     })
 
     const { result } = renderHook(
@@ -172,7 +222,7 @@ describe('useEntitySearch', () => {
           count: 1,
         })
       }
-      return Promise.resolve({ artists: [], venues: [], labels: [], festivals: [], count: 0 })
+      return Promise.resolve({ artists: [], venues: [], labels: [], festivals: [], tags: [], count: 0 })
     })
 
     const { result } = renderHook(
@@ -202,7 +252,7 @@ describe('useEntitySearch', () => {
           count: 1,
         })
       }
-      return Promise.resolve({ artists: [], venues: [], releases: [], festivals: [], count: 0 })
+      return Promise.resolve({ artists: [], venues: [], releases: [], festivals: [], tags: [], count: 0 })
     })
 
     const { result } = renderHook(
@@ -232,7 +282,7 @@ describe('useEntitySearch', () => {
           count: 1,
         })
       }
-      return Promise.resolve({ artists: [], venues: [], releases: [], labels: [], count: 0 })
+      return Promise.resolve({ artists: [], venues: [], releases: [], labels: [], tags: [], count: 0 })
     })
 
     const { result } = renderHook(
@@ -267,7 +317,7 @@ describe('useEntitySearch', () => {
       if (url.includes('/artists/search')) {
         return Promise.resolve({ artists: manyArtists, count: 10 })
       }
-      return Promise.resolve({ venues: [], releases: [], labels: [], festivals: [], count: 0 })
+      return Promise.resolve({ venues: [], releases: [], labels: [], festivals: [], tags: [], count: 0 })
     })
 
     const { result } = renderHook(
@@ -291,7 +341,7 @@ describe('useEntitySearch', () => {
           count: 1,
         })
       }
-      return Promise.resolve({ releases: [], labels: [], festivals: [], count: 0 })
+      return Promise.resolve({ releases: [], labels: [], festivals: [], tags: [], count: 0 })
     })
 
     const { result } = renderHook(
@@ -331,7 +381,7 @@ describe('useEntitySearch', () => {
           count: 2,
         })
       }
-      return Promise.resolve({ labels: [], festivals: [], count: 0 })
+      return Promise.resolve({ labels: [], festivals: [], tags: [], count: 0 })
     })
 
     const { result } = renderHook(
@@ -345,7 +395,7 @@ describe('useEntitySearch', () => {
   })
 
   it('should trim whitespace from query', async () => {
-    mockApiRequest.mockResolvedValue({ artists: [], venues: [], releases: [], labels: [], festivals: [], count: 0 })
+    mockApiRequest.mockResolvedValue({ artists: [], venues: [], releases: [], labels: [], festivals: [], tags: [], count: 0 })
 
     renderHook(
       () => useEntitySearch({ query: '  ab  ' }),

--- a/frontend/lib/hooks/common/useEntitySearch.ts
+++ b/frontend/lib/hooks/common/useEntitySearch.ts
@@ -2,7 +2,7 @@
 
 import { useQuery } from '@tanstack/react-query'
 import { useDebounce } from 'use-debounce'
-import { apiRequest } from '@/lib/api'
+import { apiRequest, API_ENDPOINTS } from '@/lib/api'
 import { artistEndpoints } from '@/features/artists/api'
 import { venueEndpoints } from '@/features/venues/api'
 import { releaseEndpoints } from '@/features/releases/api'
@@ -19,7 +19,7 @@ export interface EntitySearchResult {
   name: string
   /** Subtitle info (e.g., city/state, release type, year) */
   subtitle: string | null
-  entityType: 'artist' | 'venue' | 'release' | 'label' | 'festival'
+  entityType: 'artist' | 'venue' | 'release' | 'label' | 'festival' | 'tag'
   href: string
 }
 
@@ -29,6 +29,7 @@ export interface EntitySearchResults {
   releases: EntitySearchResult[]
   labels: EntitySearchResult[]
   festivals: EntitySearchResult[]
+  tags: EntitySearchResult[]
 }
 
 // Response shapes from the backend search endpoints
@@ -71,6 +72,14 @@ interface FestivalSearchItem {
   city?: string | null
   state?: string | null
   edition_year?: number
+}
+
+interface TagSearchItem {
+  id: number
+  slug: string
+  name: string
+  category: string
+  usage_count: number
 }
 
 // ============================================================================
@@ -145,6 +154,18 @@ function mapFestival(f: FestivalSearchItem): EntitySearchResult {
   }
 }
 
+function mapTag(t: TagSearchItem): EntitySearchResult {
+  const category = t.category.charAt(0).toUpperCase() + t.category.slice(1)
+  return {
+    id: t.id,
+    slug: t.slug,
+    name: t.name,
+    subtitle: category,
+    entityType: 'tag',
+    href: `/tags/${t.slug}`,
+  }
+}
+
 // ============================================================================
 // Query function
 // ============================================================================
@@ -155,7 +176,7 @@ async function fetchEntitySearch(query: string): Promise<EntitySearchResults> {
   const encoded = encodeURIComponent(query)
 
   // Fire all requests in parallel; if individual ones fail, return empty arrays
-  const [artists, venues, releases, labels, festivals] = await Promise.all([
+  const [artists, venues, releases, labels, festivals, tags] = await Promise.all([
     apiRequest<{ artists: ArtistSearchItem[]; count: number }>(
       `${artistEndpoints.SEARCH}?q=${encoded}`
     ).catch(() => ({ artists: [], count: 0 })),
@@ -171,6 +192,9 @@ async function fetchEntitySearch(query: string): Promise<EntitySearchResults> {
     apiRequest<{ festivals: FestivalSearchItem[]; count: number }>(
       `${festivalEndpoints.SEARCH}?q=${encoded}`
     ).catch(() => ({ festivals: [], count: 0 })),
+    apiRequest<{ tags: TagSearchItem[] }>(
+      `${API_ENDPOINTS.TAGS.SEARCH}?q=${encoded}`
+    ).catch(() => ({ tags: [] })),
   ])
 
   return {
@@ -179,6 +203,7 @@ async function fetchEntitySearch(query: string): Promise<EntitySearchResults> {
     releases: (releases.releases || []).slice(0, MAX_RESULTS_PER_TYPE).map(mapRelease),
     labels: (labels.labels || []).slice(0, MAX_RESULTS_PER_TYPE).map(mapLabel),
     festivals: (festivals.festivals || []).slice(0, MAX_RESULTS_PER_TYPE).map(mapFestival),
+    tags: (tags.tags || []).slice(0, MAX_RESULTS_PER_TYPE).map(mapTag),
   }
 }
 
@@ -192,10 +217,11 @@ const EMPTY_RESULTS: EntitySearchResults = {
   releases: [],
   labels: [],
   festivals: [],
+  tags: [],
 }
 
 /**
- * Hook for searching entities across all types (artists, venues, releases, labels, festivals).
+ * Hook for searching entities across all types (artists, venues, releases, labels, festivals, tags).
  * Used in the Cmd+K command palette to provide entity results alongside page navigation.
  *
  * Returns results grouped by entity type, limited to 5 per type.
@@ -225,7 +251,8 @@ export function useEntitySearch(options: {
     (result.data?.venues.length ?? 0) +
     (result.data?.releases.length ?? 0) +
     (result.data?.labels.length ?? 0) +
-    (result.data?.festivals.length ?? 0)
+    (result.data?.festivals.length ?? 0) +
+    (result.data?.tags.length ?? 0)
 
   return {
     ...result,


### PR DESCRIPTION
## Summary
- Added tags as a searchable entity type in the Cmd+K command palette, using the existing `/tags/search` backend endpoint
- Tag results appear in a "Tags" section with the `Hash` icon, showing the category (Genre, Locale, Other) as a subtitle
- Selecting a tag navigates to `/tags/{slug}`

Closes PSY-305

## Test plan
- [x] All 15 `useEntitySearch` tests pass (updated existing + added new tag mapping test)
- [x] TypeScript compiles without errors in changed files
- [ ] Open Cmd+K palette, type a tag name (e.g., "post-punk", "rock"), verify tags appear under a "Tags" group
- [ ] Click a tag result, verify navigation to `/tags/{slug}`
- [ ] Verify other entity types (artists, venues, etc.) still appear correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)