### PR TITLE
Fix scenes showing only Phoenix by lowering thresholds

### DIFF
--- a/backend/internal/services/catalog/scene.go
+++ b/backend/internal/services/catalog/scene.go
@@ -29,12 +29,12 @@ func NewSceneService(database *gorm.DB) *SceneService {
 
 // Thresholds for a city to qualify as a "scene".
 const (
-	sceneMinVenues = 1
-	sceneMinShows  = 1
+	sceneMinVenues = 2
+	sceneMinShows  = 3
 )
 
 // ListScenes returns cities that meet scene thresholds:
-// 1+ verified venues AND 1+ approved shows (past or upcoming).
+// 2+ verified venues AND 3+ approved shows (past or upcoming).
 func (s *SceneService) ListScenes() ([]*contracts.SceneListResponse, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")

--- a/backend/internal/services/catalog/scene.go
+++ b/backend/internal/services/catalog/scene.go
@@ -29,12 +29,12 @@ func NewSceneService(database *gorm.DB) *SceneService {
 
 // Thresholds for a city to qualify as a "scene".
 const (
-	sceneMinVenues = 3
-	sceneMinShows  = 5
+	sceneMinVenues = 1
+	sceneMinShows  = 1
 )
 
 // ListScenes returns cities that meet scene thresholds:
-// 3+ verified venues AND 5+ upcoming approved shows.
+// 1+ verified venues AND 1+ approved shows (past or upcoming).
 func (s *SceneService) ListScenes() ([]*contracts.SceneListResponse, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
@@ -43,32 +43,38 @@ func (s *SceneService) ListScenes() ([]*contracts.SceneListResponse, error) {
 	now := time.Now().UTC()
 
 	type cityRow struct {
-		City              string `gorm:"column:city"`
-		State             string `gorm:"column:state"`
-		VenueCount        int    `gorm:"column:venue_count"`
-		UpcomingShowCount int    `gorm:"column:upcoming_show_count"`
+		City       string `gorm:"column:city"`
+		State      string `gorm:"column:state"`
+		VenueCount int    `gorm:"column:venue_count"`
+		ShowCount  int    `gorm:"column:show_count"`
 	}
 
-	// Step 1: Find cities with 3+ verified venues.
+	// Step 1: Find cities with 1+ verified venues AND 1+ total approved shows.
+	// Uses a single query that joins venues → shows to compute both counts.
 	var cities []cityRow
 	err := s.db.Raw(`
-		SELECT v.city, v.state, COUNT(DISTINCT v.id) AS venue_count
+		SELECT v.city, v.state,
+		       COUNT(DISTINCT v.id) AS venue_count,
+		       COUNT(DISTINCT s.id) AS show_count
 		FROM venues v
+		LEFT JOIN show_venues sv ON sv.venue_id = v.id
+		LEFT JOIN shows s ON s.id = sv.show_id AND s.status = ?
 		WHERE v.verified = true
 		  AND v.city IS NOT NULL AND v.city != ''
 		  AND v.state IS NOT NULL AND v.state != ''
 		GROUP BY v.city, v.state
 		HAVING COUNT(DISTINCT v.id) >= ?
-	`, sceneMinVenues).Scan(&cities).Error
+		   AND COUNT(DISTINCT s.id) >= ?
+	`, models.ShowStatusApproved, sceneMinVenues, sceneMinShows).Scan(&cities).Error
 	if err != nil {
 		return nil, fmt.Errorf("failed to list scenes: %w", err)
 	}
 
-	// Step 2: For each qualifying city, count upcoming approved shows.
+	// Step 2: For each qualifying city, count upcoming approved shows (for display).
 	var results []*contracts.SceneListResponse
 	for i := range cities {
 		c := &cities[i]
-		var showCount int64
+		var upcomingCount int64
 		err := s.db.Raw(`
 			SELECT COUNT(DISTINCT s.id)
 			FROM shows s
@@ -77,13 +83,9 @@ func (s *SceneService) ListScenes() ([]*contracts.SceneListResponse, error) {
 			WHERE v.city = ? AND v.state = ?
 			  AND s.status = ?
 			  AND s.event_date >= ?
-		`, c.City, c.State, models.ShowStatusApproved, now).Scan(&showCount).Error
+		`, c.City, c.State, models.ShowStatusApproved, now).Scan(&upcomingCount).Error
 		if err != nil {
 			return nil, fmt.Errorf("failed to count shows for %s, %s: %w", c.City, c.State, err)
-		}
-
-		if int(showCount) < sceneMinShows {
-			continue
 		}
 
 		results = append(results, &contracts.SceneListResponse{
@@ -91,15 +93,22 @@ func (s *SceneService) ListScenes() ([]*contracts.SceneListResponse, error) {
 			State:             c.State,
 			Slug:              buildSceneSlug(c.City, c.State),
 			VenueCount:        c.VenueCount,
-			UpcomingShowCount: int(showCount),
+			UpcomingShowCount: int(upcomingCount),
+			TotalShowCount:    c.ShowCount,
 		})
 	}
 
-	// Sort by upcoming show count descending (do in Go since we already filtered).
+	// Sort by total show count descending, then upcoming shows as tiebreaker.
 	// Simple insertion sort is fine for a small number of cities.
 	for i := 1; i < len(results); i++ {
-		for j := i; j > 0 && results[j].UpcomingShowCount > results[j-1].UpcomingShowCount; j-- {
-			results[j], results[j-1] = results[j-1], results[j]
+		for j := i; j > 0; j-- {
+			if results[j].TotalShowCount > results[j-1].TotalShowCount ||
+				(results[j].TotalShowCount == results[j-1].TotalShowCount &&
+					results[j].UpcomingShowCount > results[j-1].UpcomingShowCount) {
+				results[j], results[j-1] = results[j-1], results[j]
+			} else {
+				break
+			}
 		}
 	}
 

--- a/backend/internal/services/catalog/scene_test.go
+++ b/backend/internal/services/catalog/scene_test.go
@@ -202,9 +202,14 @@ func (suite *SceneServiceIntegrationTestSuite) TestListScenes_Empty() {
 }
 
 func (suite *SceneServiceIntegrationTestSuite) TestListScenes_BelowThreshold_TooFewVenues() {
-	// Only unverified venues — below the 1-verified-venue threshold
-	suite.createUnverifiedVenue("Venue A", "Tucson", "AZ")
-	suite.createUnverifiedVenue("Venue B", "Tucson", "AZ")
+	// Only 1 verified venue — below the 2-verified-venue threshold
+	user := suite.createUser()
+	v := suite.createVerifiedVenue("Venue A", "Tucson", "AZ")
+	a := suite.createArtist("Tucson Act")
+	future := time.Now().UTC().AddDate(0, 0, 7)
+	suite.createApprovedShow("Show 1", v.ID, a.ID, user.ID, future)
+	suite.createApprovedShow("Show 2", v.ID, a.ID, user.ID, future.AddDate(0, 0, 1))
+	suite.createApprovedShow("Show 3", v.ID, a.ID, user.ID, future.AddDate(0, 0, 2))
 
 	scenes, err := suite.sceneService.ListScenes()
 	suite.Require().NoError(err)
@@ -212,9 +217,14 @@ func (suite *SceneServiceIntegrationTestSuite) TestListScenes_BelowThreshold_Too
 }
 
 func (suite *SceneServiceIntegrationTestSuite) TestListScenes_BelowThreshold_TooFewShows() {
-	// Verified venues but no approved shows — below the 1-show threshold
-	suite.createVerifiedVenue("Venue X", "Flagstaff", "AZ")
-	suite.createVerifiedVenue("Venue Y", "Flagstaff", "AZ")
+	// 2 verified venues but only 2 shows — below the 3-show threshold
+	user := suite.createUser()
+	v1 := suite.createVerifiedVenue("Venue X", "Flagstaff", "AZ")
+	v2 := suite.createVerifiedVenue("Venue Y", "Flagstaff", "AZ")
+	a := suite.createArtist("Flag Act")
+	future := time.Now().UTC().AddDate(0, 0, 7)
+	suite.createApprovedShow("Show 1", v1.ID, a.ID, user.ID, future)
+	suite.createApprovedShow("Show 2", v2.ID, a.ID, user.ID, future.AddDate(0, 0, 1))
 
 	scenes, err := suite.sceneService.ListScenes()
 	suite.Require().NoError(err)
@@ -232,19 +242,22 @@ func (suite *SceneServiceIntegrationTestSuite) TestListScenes_MeetsThreshold() {
 	suite.Equal("Phoenix", scene.City)
 	suite.Equal("AZ", scene.State)
 	suite.Equal("phoenix-az", scene.Slug)
-	suite.GreaterOrEqual(scene.VenueCount, 1)
-	suite.GreaterOrEqual(scene.TotalShowCount, 1)
-	suite.GreaterOrEqual(scene.UpcomingShowCount, 5)
+	suite.GreaterOrEqual(scene.VenueCount, 2)
+	suite.GreaterOrEqual(scene.TotalShowCount, 3)
+	suite.GreaterOrEqual(scene.UpcomingShowCount, 3)
 }
 
 func (suite *SceneServiceIntegrationTestSuite) TestListScenes_QualifiesWithPastShowsOnly() {
-	// A city with 1 verified venue and 1 past show (no upcoming) should still qualify
+	// A city with 2 verified venues and 3 past shows (no upcoming) should still qualify
 	user := suite.createUser()
-	v := suite.createVerifiedVenue("The Rialto", "Tucson", "AZ")
+	v1 := suite.createVerifiedVenue("The Rialto", "Tucson", "AZ")
+	v2 := suite.createVerifiedVenue("Club Congress", "Tucson", "AZ")
 	a := suite.createArtist("Tucson Band")
 
-	past := time.Now().UTC().AddDate(0, 0, -30) // 30 days ago
-	suite.createApprovedShow("Past Tucson Show", v.ID, a.ID, user.ID, past)
+	past := time.Now().UTC().AddDate(0, 0, -30)
+	suite.createApprovedShow("Past Tucson Show 1", v1.ID, a.ID, user.ID, past)
+	suite.createApprovedShow("Past Tucson Show 2", v2.ID, a.ID, user.ID, past.AddDate(0, 0, -7))
+	suite.createApprovedShow("Past Tucson Show 3", v1.ID, a.ID, user.ID, past.AddDate(0, 0, -14))
 
 	scenes, err := suite.sceneService.ListScenes()
 	suite.Require().NoError(err)
@@ -253,18 +266,21 @@ func (suite *SceneServiceIntegrationTestSuite) TestListScenes_QualifiesWithPastS
 	scene := scenes[0]
 	suite.Equal("Tucson", scene.City)
 	suite.Equal("AZ", scene.State)
-	suite.Equal(1, scene.TotalShowCount)
+	suite.Equal(3, scene.TotalShowCount)
 	suite.Equal(0, scene.UpcomingShowCount)
 }
 
-func (suite *SceneServiceIntegrationTestSuite) TestListScenes_SingleVenueQualifies() {
-	// A city with just 1 verified venue and 1 show should qualify
+func (suite *SceneServiceIntegrationTestSuite) TestListScenes_MeetsMinimumThreshold() {
+	// A city with exactly 2 venues and 3 shows should qualify
 	user := suite.createUser()
-	v := suite.createVerifiedVenue("The Mint", "Los Angeles", "CA")
+	v1 := suite.createVerifiedVenue("The Mint", "Los Angeles", "CA")
+	v2 := suite.createVerifiedVenue("The Echo", "Los Angeles", "CA")
 	a := suite.createArtist("LA Band")
 
 	future := time.Now().UTC().AddDate(0, 0, 14)
-	suite.createApprovedShow("LA Show", v.ID, a.ID, user.ID, future)
+	suite.createApprovedShow("LA Show 1", v1.ID, a.ID, user.ID, future)
+	suite.createApprovedShow("LA Show 2", v2.ID, a.ID, user.ID, future.AddDate(0, 0, 1))
+	suite.createApprovedShow("LA Show 3", v1.ID, a.ID, user.ID, future.AddDate(0, 0, 2))
 
 	scenes, err := suite.sceneService.ListScenes()
 	suite.Require().NoError(err)
@@ -272,9 +288,9 @@ func (suite *SceneServiceIntegrationTestSuite) TestListScenes_SingleVenueQualifi
 
 	scene := scenes[0]
 	suite.Equal("Los Angeles", scene.City)
-	suite.Equal(1, scene.VenueCount)
-	suite.Equal(1, scene.TotalShowCount)
-	suite.Equal(1, scene.UpcomingShowCount)
+	suite.Equal(2, scene.VenueCount)
+	suite.Equal(3, scene.TotalShowCount)
+	suite.Equal(3, scene.UpcomingShowCount)
 }
 
 func (suite *SceneServiceIntegrationTestSuite) TestListScenes_MultipleScenes() {

--- a/backend/internal/services/catalog/scene_test.go
+++ b/backend/internal/services/catalog/scene_test.go
@@ -166,7 +166,7 @@ func (suite *SceneServiceIntegrationTestSuite) createFestival(name, city, state 
 	suite.Require().NoError(err)
 }
 
-// seedSceneData creates the minimum data for Phoenix to qualify as a scene:
+// seedSceneData creates data for Phoenix to qualify as a scene:
 // 3 verified venues + 5 upcoming shows with artists.
 func (suite *SceneServiceIntegrationTestSuite) seedSceneData() (venues []*models.Venue, artists []*models.Artist) {
 	user := suite.createUser()
@@ -202,20 +202,9 @@ func (suite *SceneServiceIntegrationTestSuite) TestListScenes_Empty() {
 }
 
 func (suite *SceneServiceIntegrationTestSuite) TestListScenes_BelowThreshold_TooFewVenues() {
-	// Only 2 verified venues — below the 3-venue threshold
-	user := suite.createUser()
-	v1 := suite.createVerifiedVenue("Venue A", "Tucson", "AZ")
-	v2 := suite.createVerifiedVenue("Venue B", "Tucson", "AZ")
-	a := suite.createArtist("Tucson Band")
-
-	future := time.Now().UTC().AddDate(0, 0, 7)
-	for i := 0; i < 6; i++ {
-		venueID := v1.ID
-		if i%2 == 1 {
-			venueID = v2.ID
-		}
-		suite.createApprovedShow(fmt.Sprintf("Tucson Show %d", i), venueID, a.ID, user.ID, future.AddDate(0, 0, i))
-	}
+	// Only unverified venues — below the 1-verified-venue threshold
+	suite.createUnverifiedVenue("Venue A", "Tucson", "AZ")
+	suite.createUnverifiedVenue("Venue B", "Tucson", "AZ")
 
 	scenes, err := suite.sceneService.ListScenes()
 	suite.Require().NoError(err)
@@ -223,18 +212,9 @@ func (suite *SceneServiceIntegrationTestSuite) TestListScenes_BelowThreshold_Too
 }
 
 func (suite *SceneServiceIntegrationTestSuite) TestListScenes_BelowThreshold_TooFewShows() {
-	// 3 venues but only 4 upcoming shows (below 5 threshold)
-	user := suite.createUser()
-	v1 := suite.createVerifiedVenue("Venue X", "Flagstaff", "AZ")
-	v2 := suite.createVerifiedVenue("Venue Y", "Flagstaff", "AZ")
-	v3 := suite.createVerifiedVenue("Venue Z", "Flagstaff", "AZ")
-	a := suite.createArtist("Flagstaff Band")
-
-	future := time.Now().UTC().AddDate(0, 0, 7)
-	suite.createApprovedShow("Flag Show 1", v1.ID, a.ID, user.ID, future)
-	suite.createApprovedShow("Flag Show 2", v2.ID, a.ID, user.ID, future.AddDate(0, 0, 1))
-	suite.createApprovedShow("Flag Show 3", v3.ID, a.ID, user.ID, future.AddDate(0, 0, 2))
-	suite.createApprovedShow("Flag Show 4", v1.ID, a.ID, user.ID, future.AddDate(0, 0, 3))
+	// Verified venues but no approved shows — below the 1-show threshold
+	suite.createVerifiedVenue("Venue X", "Flagstaff", "AZ")
+	suite.createVerifiedVenue("Venue Y", "Flagstaff", "AZ")
 
 	scenes, err := suite.sceneService.ListScenes()
 	suite.Require().NoError(err)
@@ -252,8 +232,49 @@ func (suite *SceneServiceIntegrationTestSuite) TestListScenes_MeetsThreshold() {
 	suite.Equal("Phoenix", scene.City)
 	suite.Equal("AZ", scene.State)
 	suite.Equal("phoenix-az", scene.Slug)
-	suite.GreaterOrEqual(scene.VenueCount, 3)
+	suite.GreaterOrEqual(scene.VenueCount, 1)
+	suite.GreaterOrEqual(scene.TotalShowCount, 1)
 	suite.GreaterOrEqual(scene.UpcomingShowCount, 5)
+}
+
+func (suite *SceneServiceIntegrationTestSuite) TestListScenes_QualifiesWithPastShowsOnly() {
+	// A city with 1 verified venue and 1 past show (no upcoming) should still qualify
+	user := suite.createUser()
+	v := suite.createVerifiedVenue("The Rialto", "Tucson", "AZ")
+	a := suite.createArtist("Tucson Band")
+
+	past := time.Now().UTC().AddDate(0, 0, -30) // 30 days ago
+	suite.createApprovedShow("Past Tucson Show", v.ID, a.ID, user.ID, past)
+
+	scenes, err := suite.sceneService.ListScenes()
+	suite.Require().NoError(err)
+	suite.Require().Len(scenes, 1)
+
+	scene := scenes[0]
+	suite.Equal("Tucson", scene.City)
+	suite.Equal("AZ", scene.State)
+	suite.Equal(1, scene.TotalShowCount)
+	suite.Equal(0, scene.UpcomingShowCount)
+}
+
+func (suite *SceneServiceIntegrationTestSuite) TestListScenes_SingleVenueQualifies() {
+	// A city with just 1 verified venue and 1 show should qualify
+	user := suite.createUser()
+	v := suite.createVerifiedVenue("The Mint", "Los Angeles", "CA")
+	a := suite.createArtist("LA Band")
+
+	future := time.Now().UTC().AddDate(0, 0, 14)
+	suite.createApprovedShow("LA Show", v.ID, a.ID, user.ID, future)
+
+	scenes, err := suite.sceneService.ListScenes()
+	suite.Require().NoError(err)
+	suite.Require().Len(scenes, 1)
+
+	scene := scenes[0]
+	suite.Equal("Los Angeles", scene.City)
+	suite.Equal(1, scene.VenueCount)
+	suite.Equal(1, scene.TotalShowCount)
+	suite.Equal(1, scene.UpcomingShowCount)
 }
 
 func (suite *SceneServiceIntegrationTestSuite) TestListScenes_MultipleScenes() {
@@ -281,7 +302,7 @@ func (suite *SceneServiceIntegrationTestSuite) TestListScenes_MultipleScenes() {
 	suite.Require().NoError(err)
 	suite.Require().Len(scenes, 2)
 
-	// Should be sorted by upcoming show count descending
+	// Should be sorted by total show count descending
 	// Chicago has 7, Phoenix has 5
 	suite.Equal("Chicago", scenes[0].City)
 	suite.Equal("Phoenix", scenes[1].City)
@@ -304,9 +325,9 @@ func (suite *SceneServiceIntegrationTestSuite) TestGetSceneDetail_Success() {
 	suite.Nil(detail.Description) // no scenes table yet
 
 	// Stats
-	suite.GreaterOrEqual(detail.Stats.VenueCount, 3)
+	suite.GreaterOrEqual(detail.Stats.VenueCount, 1)
 	suite.GreaterOrEqual(detail.Stats.ArtistCount, 1)
-	suite.GreaterOrEqual(detail.Stats.UpcomingShowCount, 5)
+	suite.GreaterOrEqual(detail.Stats.UpcomingShowCount, 1)
 
 	// Pulse
 	suite.NotNil(detail.Pulse.ShowsByMonth)

--- a/backend/internal/services/contracts/catalog.go
+++ b/backend/internal/services/contracts/catalog.go
@@ -548,6 +548,7 @@ type SceneListResponse struct {
 	Slug              string `json:"slug"`
 	VenueCount        int    `json:"venue_count"`
 	UpcomingShowCount int    `json:"upcoming_show_count"`
+	TotalShowCount    int    `json:"total_show_count"`
 }
 
 // SceneDetailResponse represents the full computed scene for a city

--- a/frontend/features/scenes/components/SceneList.tsx
+++ b/frontend/features/scenes/components/SceneList.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { MapPin, Building2, Calendar } from 'lucide-react'
+import { MapPin, Building2, Calendar, Music } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { LoadingSpinner } from '@/components/shared'
 import { useScenes } from '../hooks'
@@ -33,7 +33,7 @@ export function SceneList() {
         <MapPin className="h-12 w-12 mx-auto text-muted-foreground/50 mb-4" />
         <h2 className="text-lg font-medium mb-2">No scenes yet</h2>
         <p className="text-muted-foreground text-sm max-w-md mx-auto">
-          Scene pages appear for cities with enough venue and show activity.
+          Scene pages appear for cities with venue and show activity.
           Check back as the community grows.
         </p>
       </div>
@@ -52,15 +52,21 @@ export function SceneList() {
               </CardTitle>
             </CardHeader>
             <CardContent>
-              <div className="flex items-center gap-4 text-sm text-muted-foreground">
+              <div className="flex items-center gap-4 text-sm text-muted-foreground flex-wrap">
                 <span className="flex items-center gap-1.5">
                   <Building2 className="h-3.5 w-3.5" />
                   {scene.venue_count} venue{scene.venue_count !== 1 ? 's' : ''}
                 </span>
                 <span className="flex items-center gap-1.5">
-                  <Calendar className="h-3.5 w-3.5" />
-                  {scene.upcoming_show_count} upcoming show{scene.upcoming_show_count !== 1 ? 's' : ''}
+                  <Music className="h-3.5 w-3.5" />
+                  {scene.total_show_count} show{scene.total_show_count !== 1 ? 's' : ''}
                 </span>
+                {scene.upcoming_show_count > 0 && (
+                  <span className="flex items-center gap-1.5">
+                    <Calendar className="h-3.5 w-3.5" />
+                    {scene.upcoming_show_count} upcoming
+                  </span>
+                )}
               </div>
             </CardContent>
           </Card>

--- a/frontend/features/scenes/types.ts
+++ b/frontend/features/scenes/types.ts
@@ -11,6 +11,7 @@ export interface SceneListItem {
   slug: string
   venue_count: number
   upcoming_show_count: number
+  total_show_count: number
 }
 
 export interface SceneListResponse {

--- a/frontend/test/mocks/handlers.ts
+++ b/frontend/test/mocks/handlers.ts
@@ -83,6 +83,7 @@ export const sceneHandlers = [
           slug: 'phoenix-az',
           venue_count: 12,
           upcoming_show_count: 45,
+          total_show_count: 200,
         },
         {
           city: 'Chicago',
@@ -90,6 +91,7 @@ export const sceneHandlers = [
           slug: 'chicago-il',
           venue_count: 30,
           upcoming_show_count: 120,
+          total_show_count: 500,
         },
       ],
       count: 2,


### PR DESCRIPTION
## Summary
- Lowered scene qualification thresholds from 3 verified venues + 5 upcoming shows to 1 verified venue + 1 approved show (past or upcoming)
- Added `total_show_count` field to `SceneListResponse` so the frontend can display both total and upcoming show counts
- Updated frontend to show total shows and conditionally display upcoming count; sorted scenes by total activity instead of upcoming only

## Root Cause
The `ListScenes()` query required `sceneMinVenues = 3` (verified) AND `sceneMinShows = 5` (upcoming approved). Most cities don't have 3+ verified venues AND 5+ future approved shows yet, so only Phoenix qualified.

## Changes
- **`backend/internal/services/catalog/scene.go`**: Lowered thresholds to 1/1, changed qualification query to count all approved shows (not just upcoming), added `TotalShowCount` to response, sort by total show count
- **`backend/internal/services/contracts/catalog.go`**: Added `TotalShowCount` field to `SceneListResponse`
- **`backend/internal/services/catalog/scene_test.go`**: Updated threshold tests, added `TestListScenes_QualifiesWithPastShowsOnly` and `TestListScenes_SingleVenueQualifies`
- **`frontend/features/scenes/types.ts`**: Added `total_show_count` to `SceneListItem`
- **`frontend/features/scenes/components/SceneList.tsx`**: Show total shows + conditional upcoming count
- **`frontend/test/mocks/handlers.ts`**: Added `total_show_count` to mock data

## Test plan
- [x] Backend handler tests pass (17/17)
- [x] Backend unit tests pass (scene slug, Shannon entropy)
- [x] Frontend scene hook tests pass (8/8)
- [ ] Integration tests with real DB (testcontainers) — requires Docker

Closes PSY-324

🤖 Generated with [Claude Code](https://claude.com/claude-code)