### PR TITLE
Collections polish: terminology, cover art mosaic, title truncation

### DIFF
--- a/backend/internal/api/handlers/collection.go
+++ b/backend/internal/api/handlers/collection.go
@@ -36,17 +36,17 @@ func NewCollectionHandler(collectionService contracts.CollectionServiceInterface
 type ListCollectionsHandlerRequest struct {
 	Creator    string `query:"creator" required:"false" doc:"Filter by creator username"`
 	EntityType string `query:"entity_type" required:"false" doc:"Filter by entity type (artist, release, label, show, venue, festival)"`
-	Featured   int    `query:"featured" required:"false" doc:"Filter featured crates (1=featured only)" example:"0"`
+	Featured   int    `query:"featured" required:"false" doc:"Filter featured collections (1=featured only)" example:"0"`
 	Search     string `query:"search" required:"false" doc:"Search by title"`
 	Limit      int    `query:"limit" required:"false" doc:"Max results (default 20)" example:"20"`
 	Offset     int    `query:"offset" required:"false" doc:"Offset for pagination" example:"0"`
 }
 
-// ListCollectionsHandlerResponse represents the response for listing crates
+// ListCollectionsHandlerResponse represents the response for listing collections
 type ListCollectionsHandlerResponse struct {
 	Body struct {
-		Collections []*contracts.CollectionListResponse `json:"crates" doc:"List of crates"`
-		Total       int64                              `json:"total" doc:"Total number of matching crates"`
+		Collections []*contracts.CollectionListResponse `json:"collections" doc:"List of collections"`
+		Total       int64                              `json:"total" doc:"Total number of matching collections"`
 	}
 }
 
@@ -92,7 +92,7 @@ func (h *CollectionHandler) ListCollectionsHandler(ctx context.Context, req *Lis
 
 // GetCollectionHandlerRequest represents the request for getting a single collection
 type GetCollectionHandlerRequest struct {
-	Slug string `path:"slug" doc:"Crate slug" example:"my-favorite-artists"`
+	Slug string `path:"slug" doc:"Collection slug" example:"my-favorite-artists"`
 }
 
 // GetCollectionHandlerResponse represents the response for the get collection endpoint
@@ -122,7 +122,7 @@ func (h *CollectionHandler) GetCollectionHandler(ctx context.Context, req *GetCo
 
 // GetCollectionStatsHandlerRequest represents the request for getting collection stats
 type GetCollectionStatsHandlerRequest struct {
-	Slug string `path:"slug" doc:"Crate slug" example:"my-favorite-artists"`
+	Slug string `path:"slug" doc:"Collection slug" example:"my-favorite-artists"`
 }
 
 // GetCollectionStatsHandlerResponse represents the response for the collection stats endpoint
@@ -147,11 +147,11 @@ func (h *CollectionHandler) GetCollectionStatsHandler(ctx context.Context, req *
 // CreateCollectionHandlerRequest represents the request for creating a collection
 type CreateCollectionHandlerRequest struct {
 	Body struct {
-		Title         string  `json:"title" doc:"Crate title" example:"Phoenix Indie Shows"`
-		Description   *string `json:"description,omitempty" required:"false" doc:"Crate description"`
+		Title         string  `json:"title" doc:"Collection title" example:"Phoenix Indie Shows"`
+		Description   *string `json:"description,omitempty" required:"false" doc:"Collection description"`
 		Collaborative bool    `json:"collaborative,omitempty" required:"false" doc:"Whether other users can add items"`
 		CoverImageURL *string `json:"cover_image_url,omitempty" required:"false" doc:"Cover image URL"`
-		IsPublic      bool    `json:"is_public,omitempty" required:"false" doc:"Whether the crate is publicly visible"`
+		IsPublic      bool    `json:"is_public,omitempty" required:"false" doc:"Whether the collection is publicly visible"`
 	}
 }
 
@@ -208,13 +208,13 @@ func (h *CollectionHandler) CreateCollectionHandler(ctx context.Context, req *Cr
 
 // UpdateCollectionHandlerRequest represents the request for updating a collection
 type UpdateCollectionHandlerRequest struct {
-	Slug string `path:"slug" doc:"Crate slug" example:"my-favorite-artists"`
+	Slug string `path:"slug" doc:"Collection slug" example:"my-favorite-artists"`
 	Body struct {
-		Title         *string `json:"title,omitempty" required:"false" doc:"Crate title"`
-		Description   *string `json:"description,omitempty" required:"false" doc:"Crate description"`
+		Title         *string `json:"title,omitempty" required:"false" doc:"Collection title"`
+		Description   *string `json:"description,omitempty" required:"false" doc:"Collection description"`
 		Collaborative *bool   `json:"collaborative,omitempty" required:"false" doc:"Whether other users can add items"`
 		CoverImageURL *string `json:"cover_image_url,omitempty" required:"false" doc:"Cover image URL"`
-		IsPublic      *bool   `json:"is_public,omitempty" required:"false" doc:"Whether the crate is publicly visible"`
+		IsPublic      *bool   `json:"is_public,omitempty" required:"false" doc:"Whether the collection is publicly visible"`
 	}
 }
 
@@ -272,7 +272,7 @@ func (h *CollectionHandler) UpdateCollectionHandler(ctx context.Context, req *Up
 
 // DeleteCollectionHandlerRequest represents the request for deleting a collection
 type DeleteCollectionHandlerRequest struct {
-	Slug string `path:"slug" doc:"Crate slug" example:"my-favorite-artists"`
+	Slug string `path:"slug" doc:"Collection slug" example:"my-favorite-artists"`
 }
 
 // DeleteCollectionHandler handles DELETE /collections/{slug}
@@ -316,7 +316,7 @@ func (h *CollectionHandler) DeleteCollectionHandler(ctx context.Context, req *De
 
 // AddItemHandlerRequest represents the request for adding an item to a collection
 type AddItemHandlerRequest struct {
-	Slug string `path:"slug" doc:"Crate slug" example:"my-favorite-artists"`
+	Slug string `path:"slug" doc:"Collection slug" example:"my-favorite-artists"`
 	Body struct {
 		EntityType string  `json:"entity_type" doc:"Entity type (artist, release, label, show, venue, festival)" example:"artist"`
 		EntityID   uint    `json:"entity_id" doc:"Entity ID" example:"42"`
@@ -387,8 +387,8 @@ func (h *CollectionHandler) AddItemHandler(ctx context.Context, req *AddItemHand
 
 // UpdateItemHandlerRequest represents the request for updating an item in a collection
 type UpdateItemHandlerRequest struct {
-	Slug   string `path:"slug" doc:"Crate slug" example:"my-favorite-artists"`
-	ItemID string `path:"item_id" doc:"Crate item ID" example:"1"`
+	Slug   string `path:"slug" doc:"Collection slug" example:"my-favorite-artists"`
+	ItemID string `path:"item_id" doc:"Collection item ID" example:"1"`
 	Body   struct {
 		Notes *string `json:"notes" required:"false" doc:"Notes about this item"`
 	}
@@ -452,8 +452,8 @@ func (h *CollectionHandler) UpdateItemHandler(ctx context.Context, req *UpdateIt
 
 // RemoveItemHandlerRequest represents the request for removing an item from a collection
 type RemoveItemHandlerRequest struct {
-	Slug   string `path:"slug" doc:"Crate slug" example:"my-favorite-artists"`
-	ItemID string `path:"item_id" doc:"Crate item ID" example:"1"`
+	Slug   string `path:"slug" doc:"Collection slug" example:"my-favorite-artists"`
+	ItemID string `path:"item_id" doc:"Collection item ID" example:"1"`
 }
 
 // RemoveItemHandler handles DELETE /collections/{slug}/items/{item_id}
@@ -505,7 +505,7 @@ func (h *CollectionHandler) RemoveItemHandler(ctx context.Context, req *RemoveIt
 
 // ReorderItemsHandlerRequest represents the request for reordering collection items
 type ReorderItemsHandlerRequest struct {
-	Slug string `path:"slug" doc:"Crate slug" example:"my-favorite-artists"`
+	Slug string `path:"slug" doc:"Collection slug" example:"my-favorite-artists"`
 	Body struct {
 		Items []contracts.ReorderItem `json:"items" doc:"Items with new positions"`
 	}
@@ -549,7 +549,7 @@ func (h *CollectionHandler) ReorderItemsHandler(ctx context.Context, req *Reorde
 
 // SubscribeHandlerRequest represents the request for subscribing to a collection
 type SubscribeHandlerRequest struct {
-	Slug string `path:"slug" doc:"Crate slug" example:"my-favorite-artists"`
+	Slug string `path:"slug" doc:"Collection slug" example:"my-favorite-artists"`
 }
 
 // SubscribeHandler handles POST /collections/{slug}/subscribe
@@ -569,7 +569,7 @@ func (h *CollectionHandler) SubscribeHandler(ctx context.Context, req *Subscribe
 
 // UnsubscribeHandlerRequest represents the request for unsubscribing from a collection
 type UnsubscribeHandlerRequest struct {
-	Slug string `path:"slug" doc:"Crate slug" example:"my-favorite-artists"`
+	Slug string `path:"slug" doc:"Collection slug" example:"my-favorite-artists"`
 }
 
 // UnsubscribeHandler handles DELETE /collections/{slug}/subscribe
@@ -593,9 +593,9 @@ func (h *CollectionHandler) UnsubscribeHandler(ctx context.Context, req *Unsubsc
 
 // SetFeaturedHandlerRequest represents the request for setting a collection's featured status
 type SetFeaturedHandlerRequest struct {
-	Slug string `path:"slug" doc:"Crate slug" example:"my-favorite-artists"`
+	Slug string `path:"slug" doc:"Collection slug" example:"my-favorite-artists"`
 	Body struct {
-		Featured bool `json:"featured" doc:"Whether the crate should be featured"`
+		Featured bool `json:"featured" doc:"Whether the collection should be featured"`
 	}
 }
 
@@ -647,11 +647,11 @@ type GetUserCollectionsHandlerRequest struct {
 	Offset int `query:"offset" required:"false" doc:"Offset for pagination" example:"0"`
 }
 
-// GetUserCollectionsHandlerResponse represents the response for the user crates endpoint
+// GetUserCollectionsHandlerResponse represents the response for the user collections endpoint
 type GetUserCollectionsHandlerResponse struct {
 	Body struct {
-		Collections []*contracts.CollectionListResponse `json:"crates" doc:"List of user's crates"`
-		Total       int64                              `json:"total" doc:"Total number of crates"`
+		Collections []*contracts.CollectionListResponse `json:"collections" doc:"List of user's collections"`
+		Total       int64                              `json:"total" doc:"Total number of collections"`
 	}
 }
 
@@ -693,7 +693,7 @@ type GetEntityCollectionsHandlerRequest struct {
 // GetEntityCollectionsHandlerResponse represents the response for entity collections
 type GetEntityCollectionsHandlerResponse struct {
 	Body struct {
-		Collections []*contracts.CollectionListResponse `json:"crates" doc:"List of crates containing this entity"`
+		Collections []*contracts.CollectionListResponse `json:"collections" doc:"List of collections containing this entity"`
 	}
 }
 
@@ -742,8 +742,8 @@ type GetUserPublicCollectionsHandlerRequest struct {
 // GetUserPublicCollectionsHandlerResponse represents the response for user public collections
 type GetUserPublicCollectionsHandlerResponse struct {
 	Body struct {
-		Collections []*contracts.CollectionListResponse `json:"crates" doc:"List of user's public crates"`
-		Total       int64                              `json:"total" doc:"Total number of public crates"`
+		Collections []*contracts.CollectionListResponse `json:"collections" doc:"List of user's public collections"`
+		Total       int64                              `json:"total" doc:"Total number of public collections"`
 	}
 }
 

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -651,76 +651,76 @@ func setupPipelineRoutes(rc RouteContext) {
 	huma.Post(rc.Protected, "/admin/pipeline/enrichment/trigger/{show_id}", pipelineHandler.TriggerEnrichmentHandler)
 }
 
-// setupCollectionRoutes configures crate (formerly "collection") endpoints.
-// Both /crates/ and /collections/ paths are registered for backward compatibility.
-// Public endpoints use optional auth (for private crate access checks).
+// setupCollectionRoutes configures collection endpoints.
+// Both /collections/ and /crates/ paths are registered for backward compatibility.
+// Public endpoints use optional auth (for private collection access checks).
 // CRUD, item management, and subscription endpoints require authentication.
 func setupCollectionRoutes(rc RouteContext) {
 	collectionHandler := handlers.NewCollectionHandler(rc.SC.Collection, rc.SC.AuditLog)
 
-	// Public crate endpoints with optional auth
+	// Public collection endpoints with optional auth
 	optionalAuthGroup := huma.NewGroup(rc.API, "")
 	optionalAuthGroup.UseMiddleware(middleware.OptionalHumaJWTMiddleware(rc.SC.JWT))
 
-	// Canonical /crates/ paths
-	huma.Get(optionalAuthGroup, "/crates", collectionHandler.ListCollectionsHandler)
-	huma.Get(optionalAuthGroup, "/crates/{slug}", collectionHandler.GetCollectionHandler)
-	huma.Get(optionalAuthGroup, "/crates/{slug}/stats", collectionHandler.GetCollectionStatsHandler)
-
-	// Legacy /collections/ paths (backward compat — same handlers, different operation IDs)
+	// Canonical /collections/ paths
 	huma.Get(optionalAuthGroup, "/collections", collectionHandler.ListCollectionsHandler)
 	huma.Get(optionalAuthGroup, "/collections/{slug}", collectionHandler.GetCollectionHandler)
 	huma.Get(optionalAuthGroup, "/collections/{slug}/stats", collectionHandler.GetCollectionStatsHandler)
 
-	// Protected crate endpoints — canonical /crates/ paths
-	huma.Post(rc.Protected, "/crates", collectionHandler.CreateCollectionHandler)
-	huma.Put(rc.Protected, "/crates/{slug}", collectionHandler.UpdateCollectionHandler)
-	huma.Delete(rc.Protected, "/crates/{slug}", collectionHandler.DeleteCollectionHandler)
+	// Legacy /crates/ paths (backward compat)
+	huma.Get(optionalAuthGroup, "/crates", collectionHandler.ListCollectionsHandler)
+	huma.Get(optionalAuthGroup, "/crates/{slug}", collectionHandler.GetCollectionHandler)
+	huma.Get(optionalAuthGroup, "/crates/{slug}/stats", collectionHandler.GetCollectionStatsHandler)
 
-	// Protected crate endpoints — legacy /collections/ paths (backward compat)
+	// Protected collection endpoints — canonical /collections/ paths
 	huma.Post(rc.Protected, "/collections", collectionHandler.CreateCollectionHandler)
 	huma.Put(rc.Protected, "/collections/{slug}", collectionHandler.UpdateCollectionHandler)
 	huma.Delete(rc.Protected, "/collections/{slug}", collectionHandler.DeleteCollectionHandler)
 
-	// Crate item management — canonical /crates/ paths
-	huma.Post(rc.Protected, "/crates/{slug}/items", collectionHandler.AddItemHandler)
-	huma.Patch(rc.Protected, "/crates/{slug}/items/{item_id}", collectionHandler.UpdateItemHandler)
-	huma.Delete(rc.Protected, "/crates/{slug}/items/{item_id}", collectionHandler.RemoveItemHandler)
-	huma.Put(rc.Protected, "/crates/{slug}/items/reorder", collectionHandler.ReorderItemsHandler)
+	// Protected collection endpoints — legacy /crates/ paths (backward compat)
+	huma.Post(rc.Protected, "/crates", collectionHandler.CreateCollectionHandler)
+	huma.Put(rc.Protected, "/crates/{slug}", collectionHandler.UpdateCollectionHandler)
+	huma.Delete(rc.Protected, "/crates/{slug}", collectionHandler.DeleteCollectionHandler)
 
-	// Crate item management — legacy /collections/ paths (backward compat)
+	// Collection item management — canonical /collections/ paths
 	huma.Post(rc.Protected, "/collections/{slug}/items", collectionHandler.AddItemHandler)
 	huma.Patch(rc.Protected, "/collections/{slug}/items/{item_id}", collectionHandler.UpdateItemHandler)
 	huma.Delete(rc.Protected, "/collections/{slug}/items/{item_id}", collectionHandler.RemoveItemHandler)
 	huma.Put(rc.Protected, "/collections/{slug}/items/reorder", collectionHandler.ReorderItemsHandler)
 
-	// Crate subscription — canonical /crates/ paths
-	huma.Post(rc.Protected, "/crates/{slug}/subscribe", collectionHandler.SubscribeHandler)
-	huma.Delete(rc.Protected, "/crates/{slug}/subscribe", collectionHandler.UnsubscribeHandler)
+	// Collection item management — legacy /crates/ paths (backward compat)
+	huma.Post(rc.Protected, "/crates/{slug}/items", collectionHandler.AddItemHandler)
+	huma.Patch(rc.Protected, "/crates/{slug}/items/{item_id}", collectionHandler.UpdateItemHandler)
+	huma.Delete(rc.Protected, "/crates/{slug}/items/{item_id}", collectionHandler.RemoveItemHandler)
+	huma.Put(rc.Protected, "/crates/{slug}/items/reorder", collectionHandler.ReorderItemsHandler)
 
-	// Crate subscription — legacy /collections/ paths (backward compat)
+	// Collection subscription — canonical /collections/ paths
 	huma.Post(rc.Protected, "/collections/{slug}/subscribe", collectionHandler.SubscribeHandler)
 	huma.Delete(rc.Protected, "/collections/{slug}/subscribe", collectionHandler.UnsubscribeHandler)
 
-	// Admin: feature/unfeature crates — canonical /crates/ paths
-	huma.Put(rc.Protected, "/crates/{slug}/feature", collectionHandler.SetFeaturedHandler)
+	// Collection subscription — legacy /crates/ paths (backward compat)
+	huma.Post(rc.Protected, "/crates/{slug}/subscribe", collectionHandler.SubscribeHandler)
+	huma.Delete(rc.Protected, "/crates/{slug}/subscribe", collectionHandler.UnsubscribeHandler)
 
-	// Admin: feature/unfeature crates — legacy /collections/ paths (backward compat)
+	// Admin: feature/unfeature collections — canonical /collections/ paths
 	huma.Put(rc.Protected, "/collections/{slug}/feature", collectionHandler.SetFeaturedHandler)
 
+	// Admin: feature/unfeature collections — legacy /crates/ paths (backward compat)
+	huma.Put(rc.Protected, "/crates/{slug}/feature", collectionHandler.SetFeaturedHandler)
+
 	// Entity collections — public, find collections containing a given entity
-	huma.Get(optionalAuthGroup, "/crates/entity/{entity_type}/{entity_id}", collectionHandler.GetEntityCollectionsHandler)
 	huma.Get(optionalAuthGroup, "/collections/entity/{entity_type}/{entity_id}", collectionHandler.GetEntityCollectionsHandler)
+	huma.Get(optionalAuthGroup, "/crates/entity/{entity_type}/{entity_id}", collectionHandler.GetEntityCollectionsHandler)
 
 	// User's public collections — public, for profile pages
-	huma.Get(optionalAuthGroup, "/users/{username}/crates", collectionHandler.GetUserPublicCollectionsHandler)
 	huma.Get(optionalAuthGroup, "/users/{username}/collections", collectionHandler.GetUserPublicCollectionsHandler)
+	huma.Get(optionalAuthGroup, "/users/{username}/crates", collectionHandler.GetUserPublicCollectionsHandler)
 
-	// User's own crates (created + subscribed)
-	huma.Get(rc.Protected, "/auth/crates", collectionHandler.GetUserCollectionsHandler)
-
-	// Legacy user crates path (backward compat)
+	// User's own collections (created + subscribed)
 	huma.Get(rc.Protected, "/auth/collections", collectionHandler.GetUserCollectionsHandler)
+
+	// Legacy user collections path (backward compat)
+	huma.Get(rc.Protected, "/auth/crates", collectionHandler.GetUserCollectionsHandler)
 }
 
 // setupRequestRoutes configures community request endpoints.

--- a/frontend/components/layout/CommandPalette.tsx
+++ b/frontend/components/layout/CommandPalette.tsx
@@ -85,7 +85,7 @@ const routes: RouteItem[] = [
     label: 'Collections',
     href: '/collections',
     icon: LayoutList,
-    keywords: ['collections', 'crates', 'curated', 'lists', 'playlists'],
+    keywords: ['collections', 'curated', 'lists', 'playlists'],
   },
   {
     label: 'Charts',
@@ -240,7 +240,7 @@ const adminRoutes: RouteItem[] = [
     label: 'Admin: Collections',
     href: '/admin?tab=collections',
     icon: Library,
-    keywords: ['admin', 'collections', 'crates', 'manage', 'featured'],
+    keywords: ['admin', 'collections', 'manage', 'featured'],
     requireAdmin: true,
   },
   {

--- a/frontend/features/collections/components/CollectionCard.tsx
+++ b/frontend/features/collections/components/CollectionCard.tsx
@@ -1,11 +1,32 @@
 'use client'
 
 import Link from 'next/link'
-import { Library, Users, Star, Clock } from 'lucide-react'
+import {
+  Library,
+  Users,
+  Star,
+  Clock,
+  Mic2,
+  MapPin,
+  Calendar,
+  Disc3,
+  Tag,
+  Tent,
+} from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
 import { formatRelativeTime } from '@/lib/formatRelativeTime'
 import { getEntityTypeLabel, type Collection } from '../types'
+
+const ENTITY_ICONS: Record<string, LucideIcon> = {
+  artist: Mic2,
+  venue: MapPin,
+  show: Calendar,
+  release: Disc3,
+  label: Tag,
+  festival: Tent,
+}
 
 interface CollectionCardProps {
   collection: Collection
@@ -16,10 +37,16 @@ export function CollectionCard({ collection }: CollectionCardProps) {
     .sort((a, b) => b[1] - a[1])
     .slice(0, 2)
 
+  // Get up to 4 entity type icons for the mosaic placeholder
+  const mosaicTypes = Object.entries(collection.entity_type_counts ?? {})
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 4)
+    .map(([type]) => type)
+
   return (
     <article className="rounded-lg border border-border/50 bg-card p-4 transition-shadow hover:shadow-sm">
       <div className="flex gap-3">
-        {/* Icon / cover image placeholder */}
+        {/* Icon / cover image / entity-type mosaic */}
         <div className="h-16 w-16 shrink-0 rounded-md bg-muted/50 flex items-center justify-center overflow-hidden">
           {collection.cover_image_url ? (
             <img
@@ -27,6 +54,32 @@ export function CollectionCard({ collection }: CollectionCardProps) {
               alt={`${collection.title} cover`}
               className="h-full w-full object-cover"
             />
+          ) : mosaicTypes.length > 0 ? (
+            <div
+              className={cn(
+                'grid gap-0.5 p-1.5',
+                mosaicTypes.length === 1
+                  ? 'grid-cols-1'
+                  : 'grid-cols-2'
+              )}
+            >
+              {mosaicTypes.map((type) => {
+                const Icon = ENTITY_ICONS[type] ?? Library
+                return (
+                  <div
+                    key={type}
+                    className="flex items-center justify-center"
+                  >
+                    <Icon
+                      className={cn(
+                        'text-muted-foreground/50',
+                        mosaicTypes.length === 1 ? 'h-7 w-7' : 'h-5 w-5'
+                      )}
+                    />
+                  </div>
+                )
+              })}
+            </div>
           ) : (
             <Library className="h-8 w-8 text-muted-foreground/40" />
           )}
@@ -35,7 +88,10 @@ export function CollectionCard({ collection }: CollectionCardProps) {
         {/* Text content */}
         <div className="flex-1 min-w-0">
           <Link href={`/collections/${collection.slug}`} className="block group">
-            <h3 className="font-bold text-foreground group-hover:text-primary transition-colors line-clamp-2">
+            <h3
+              className="font-bold text-foreground group-hover:text-primary transition-colors line-clamp-1"
+              title={collection.title}
+            >
               {collection.title}
             </h3>
           </Link>

--- a/frontend/features/collections/hooks/index.test.tsx
+++ b/frontend/features/collections/hooks/index.test.tsx
@@ -64,9 +64,8 @@ describe('Collection query hooks', () => {
 
   describe('useCollections', () => {
     it('fetches collections list', async () => {
-      // Backend returns { crates, total }; hook normalizes to { collections, total }
       const mockResponse = {
-        crates: [{ id: 1, title: 'Test Collection', slug: 'test' }],
+        collections: [{ id: 1, title: 'Test Collection', slug: 'test' }],
         total: 1,
       }
       mockApiRequest.mockResolvedValueOnce(mockResponse)
@@ -83,7 +82,7 @@ describe('Collection query hooks', () => {
     })
 
     it('handles empty collections list', async () => {
-      mockApiRequest.mockResolvedValueOnce({ crates: [], total: 0 })
+      mockApiRequest.mockResolvedValueOnce({ collections: [], total: 0 })
 
       const { result } = renderHook(() => useCollections(), {
         wrapper: createWrapper(),
@@ -151,7 +150,7 @@ describe('Collection query hooks', () => {
 
   describe('useMyCollections', () => {
     it('fetches user collections', async () => {
-      mockApiRequest.mockResolvedValueOnce({ crates: [], total: 0 })
+      mockApiRequest.mockResolvedValueOnce({ collections: [], total: 0 })
 
       const { result } = renderHook(() => useMyCollections(), {
         wrapper: createWrapper(),

--- a/frontend/features/collections/hooks/index.ts
+++ b/frontend/features/collections/hooks/index.ts
@@ -37,11 +37,9 @@ export function useCollections(params?: CollectionListParams) {
         ? `${API_ENDPOINTS.COLLECTIONS.LIST}?${qs}`
         : API_ENDPOINTS.COLLECTIONS.LIST
 
-      // Backend currently returns { crates, total } — map to { collections, total }
-      // so the frontend consistently uses "collections" terminology.
-      return apiRequest<{ crates: Collection[]; total: number }>(url).then(
+      return apiRequest<{ collections: Collection[]; total: number }>(url).then(
         (data) => ({
-          collections: data.crates ?? [],
+          collections: data.collections ?? [],
           total: data.total,
         })
       )
@@ -77,11 +75,10 @@ export function useMyCollections() {
   return useQuery({
     queryKey: queryKeys.collections.my,
     queryFn: () =>
-      // Backend currently returns { crates, total } — map to { collections, total }.
-      apiRequest<{ crates: Collection[]; total: number }>(
+      apiRequest<{ collections: Collection[]; total: number }>(
         API_ENDPOINTS.COLLECTIONS.MY
       ).then((data) => ({
-        collections: data.crates ?? [],
+        collections: data.collections ?? [],
         total: data.total,
       })),
     staleTime: 5 * 60 * 1000,
@@ -307,10 +304,10 @@ export function useEntityCollections(
   return useQuery({
     queryKey: queryKeys.collections.entity(entityType, entityId),
     queryFn: () =>
-      apiRequest<{ crates: Collection[]; }>(
+      apiRequest<{ collections: Collection[]; }>(
         API_ENDPOINTS.COLLECTIONS.ENTITY(entityType, entityId)
       ).then((data) => ({
-        collections: data.crates ?? [],
+        collections: data.collections ?? [],
       })),
     enabled: (options?.enabled ?? true) && entityId > 0,
     staleTime: 5 * 60 * 1000,
@@ -325,10 +322,10 @@ export function useUserPublicCollections(
   return useQuery({
     queryKey: queryKeys.collections.userPublic(username),
     queryFn: () =>
-      apiRequest<{ crates: Collection[]; total: number }>(
+      apiRequest<{ collections: Collection[]; total: number }>(
         API_ENDPOINTS.COLLECTIONS.USER_PUBLIC(username)
       ).then((data) => ({
-        collections: data.crates ?? [],
+        collections: data.collections ?? [],
         total: data.total,
       })),
     enabled: (options?.enabled ?? true) && username.length > 0,


### PR DESCRIPTION
## Summary
- **Terminology**: Rename `crates` → `collections` in backend API JSON responses and doc strings; remove frontend mapping workarounds
- **Cover art**: Show entity-type icon mosaic (up to 4 icons based on item types) on collection cards instead of generic Library icon
- **Title truncation**: Single-line clamp with hover tooltip for full name
- Backend `/crates/` path kept as backward-compat alias
- All 62 frontend collection tests pass

Closes PSY-319

## Test plan
- [ ] Collection cards show entity-type icon mosaic when no cover image
- [ ] Long collection names truncate with ellipsis, full name on hover
- [ ] No "crate" terminology visible anywhere in UI
- [ ] API responses use `collections` key (not `crates`)
- [ ] `/crates/` URLs still work (redirect/alias)

🤖 Generated with [Claude Code](https://claude.com/claude-code)