### PR TITLE
Add until parameter to RadioPlaylistProvider.FetchNewEpisodes

### DIFF
--- a/backend/internal/services/catalog/radio_import.go
+++ b/backend/internal/services/catalog/radio_import.go
@@ -69,7 +69,7 @@ func (s *RadioService) ImportStation(stationID uint, backfillDays int) (*contrac
 	// 2. Fetch episodes for each show
 	since := time.Now().AddDate(0, 0, -backfillDays)
 	for extID, showID := range showMap {
-		episodes, err := provider.FetchNewEpisodes(extID, since)
+		episodes, err := provider.FetchNewEpisodes(extID, since, time.Time{})
 		if err != nil {
 			result.Errors = append(result.Errors, fmt.Sprintf("fetch episodes for show %s: %v", extID, err))
 			continue
@@ -134,7 +134,7 @@ func (s *RadioService) FetchNewEpisodes(stationID uint) (*contracts.RadioImportR
 			continue
 		}
 
-		episodes, err := provider.FetchNewEpisodes(*show.ExternalID, since)
+		episodes, err := provider.FetchNewEpisodes(*show.ExternalID, since, time.Time{})
 		if err != nil {
 			result.Errors = append(result.Errors, fmt.Sprintf("fetch episodes for show %s: %v", show.Name, err))
 			continue
@@ -313,12 +313,13 @@ func (s *RadioService) importShowEpisodesWithProgress(
 		return nil, fmt.Errorf("show %d has no external ID", showID)
 	}
 
-	episodes, err := provider.FetchNewEpisodes(*show.ExternalID, sinceTime)
+	episodes, err := provider.FetchNewEpisodes(*show.ExternalID, sinceTime, untilTime)
 	if err != nil {
 		return nil, fmt.Errorf("fetching episodes: %w", err)
 	}
 
 	// Filter episodes by air_date within [since, until] (inclusive both ends)
+	// Providers apply coarse date filtering, but we still apply precise bounds here.
 	var filtered []RadioEpisodeImport
 	for _, ep := range episodes {
 		epDate, parseErr := time.Parse("2006-01-02", ep.AirDate)

--- a/backend/internal/services/catalog/radio_provider.go
+++ b/backend/internal/services/catalog/radio_provider.go
@@ -11,8 +11,9 @@ type RadioPlaylistProvider interface {
 	// DiscoverShows returns all available shows/programs from the station.
 	DiscoverShows() ([]RadioShowImport, error)
 
-	// FetchNewEpisodes returns episodes for a given show since the specified time.
-	FetchNewEpisodes(showExternalID string, since time.Time) ([]RadioEpisodeImport, error)
+	// FetchNewEpisodes returns episodes for a given show within [since, until].
+	// A zero until means no upper bound.
+	FetchNewEpisodes(showExternalID string, since time.Time, until time.Time) ([]RadioEpisodeImport, error)
 
 	// FetchPlaylist returns the track plays for a specific episode.
 	FetchPlaylist(episodeExternalID string) ([]RadioPlayImport, error)

--- a/backend/internal/services/catalog/radio_provider_kexp.go
+++ b/backend/internal/services/catalog/radio_provider_kexp.go
@@ -119,13 +119,19 @@ func (p *KEXPProvider) DiscoverShows() ([]RadioShowImport, error) {
 	return allShows, nil
 }
 
-// FetchNewEpisodes returns KEXP "shows" (broadcasts) for a program since the given time.
-func (p *KEXPProvider) FetchNewEpisodes(showExternalID string, since time.Time) ([]RadioEpisodeImport, error) {
+// FetchNewEpisodes returns KEXP "shows" (broadcasts) for a program within [since, until].
+// A zero until means no upper bound.
+func (p *KEXPProvider) FetchNewEpisodes(showExternalID string, since time.Time, until time.Time) ([]RadioEpisodeImport, error) {
 	var allEpisodes []RadioEpisodeImport
 
 	sinceStr := since.UTC().Format(time.RFC3339)
 	url := fmt.Sprintf("%s/v2/shows/?program_id=%s&start_time_after=%s&limit=100&ordering=start_time",
 		p.baseURL, showExternalID, sinceStr)
+
+	if !until.IsZero() {
+		untilStr := until.UTC().Format(time.RFC3339)
+		url += "&start_time_before=" + untilStr
+	}
 
 	for url != "" {
 		<-p.rateLimiter.C

--- a/backend/internal/services/catalog/radio_provider_nts.go
+++ b/backend/internal/services/catalog/radio_provider_nts.go
@@ -97,8 +97,9 @@ func (p *NTSProvider) DiscoverShows() ([]RadioShowImport, error) {
 	return allShows, nil
 }
 
-// FetchNewEpisodes returns episodes for an NTS show since the given time.
-func (p *NTSProvider) FetchNewEpisodes(showExternalID string, since time.Time) ([]RadioEpisodeImport, error) {
+// FetchNewEpisodes returns episodes for an NTS show within [since, until].
+// A zero until means no upper bound.
+func (p *NTSProvider) FetchNewEpisodes(showExternalID string, since time.Time, until time.Time) ([]RadioEpisodeImport, error) {
 	var allEpisodes []RadioEpisodeImport
 
 	offset := 0
@@ -121,16 +122,22 @@ func (p *NTSProvider) FetchNewEpisodes(showExternalID string, since time.Time) (
 		for _, ntsEp := range page.Results {
 			ep := parseNTSEpisode(ntsEp, showExternalID)
 
-			// Filter by since date
+			// Filter by date range
 			if ntsEp.Broadcast != "" {
 				broadcastTime, err := time.Parse("2006-01-02T15:04:05Z", ntsEp.Broadcast)
 				if err != nil {
 					// Try date-only format
 					broadcastTime, err = time.Parse("2006-01-02", ntsEp.Broadcast)
 				}
-				if err == nil && broadcastTime.Before(since) {
-					reachedOldEpisodes = true
-					break
+				if err == nil {
+					if broadcastTime.Before(since) {
+						reachedOldEpisodes = true
+						break
+					}
+					// Skip episodes after until bound
+					if !until.IsZero() && broadcastTime.After(until) {
+						continue
+					}
 				}
 			}
 

--- a/backend/internal/services/catalog/radio_provider_nts_test.go
+++ b/backend/internal/services/catalog/radio_provider_nts_test.go
@@ -253,7 +253,7 @@ func TestNTS_FetchNewEpisodes_AllFields(t *testing.T) {
 	defer provider.Close()
 
 	since := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
-	episodes, err := provider.FetchNewEpisodes("huerco-s", since)
+	episodes, err := provider.FetchNewEpisodes("huerco-s", since, time.Time{})
 	require.NoError(t, err)
 	assert.Len(t, episodes, 3)
 
@@ -284,7 +284,7 @@ func TestNTS_FetchNewEpisodes_DateFiltering(t *testing.T) {
 
 	// Only get episodes since Feb 1, 2026
 	since := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
-	episodes, err := provider.FetchNewEpisodes("huerco-s", since)
+	episodes, err := provider.FetchNewEpisodes("huerco-s", since, time.Time{})
 	require.NoError(t, err)
 	assert.Len(t, episodes, 2, "should only return episodes after Feb 1, 2026")
 
@@ -321,7 +321,7 @@ func TestNTS_FetchNewEpisodes_StopsAtOldEpisodes(t *testing.T) {
 	defer provider.Close()
 
 	since := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-	episodes, err := provider.FetchNewEpisodes("huerco-s", since)
+	episodes, err := provider.FetchNewEpisodes("huerco-s", since, time.Time{})
 	require.NoError(t, err)
 	// Should have ntsPageLimit from page 1, and 0 from page 2 (old episode filtered)
 	assert.Equal(t, ntsPageLimit, len(episodes))
@@ -337,7 +337,7 @@ func TestNTS_FetchNewEpisodes_Empty(t *testing.T) {
 	provider := NewNTSProviderWithClient(server.Client(), server.URL)
 	defer provider.Close()
 
-	episodes, err := provider.FetchNewEpisodes("nonexistent", time.Now())
+	episodes, err := provider.FetchNewEpisodes("nonexistent", time.Now(), time.Time{})
 	require.NoError(t, err)
 	assert.Empty(t, episodes)
 }
@@ -543,7 +543,7 @@ func TestNTS_MixcloudArchiveURL_Preserved(t *testing.T) {
 	defer provider.Close()
 
 	since := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
-	episodes, err := provider.FetchNewEpisodes("huerco-s", since)
+	episodes, err := provider.FetchNewEpisodes("huerco-s", since, time.Time{})
 	require.NoError(t, err)
 
 	for _, ep := range episodes {
@@ -577,7 +577,7 @@ func TestNTS_RateLimiting(t *testing.T) {
 	start := time.Now()
 
 	_, _ = provider.DiscoverShows()
-	_, _ = provider.FetchNewEpisodes("test", time.Now())
+	_, _ = provider.FetchNewEpisodes("test", time.Now(), time.Time{})
 	_, _ = provider.FetchPlaylist("test/ep1")
 
 	elapsed := time.Since(start)
@@ -616,7 +616,7 @@ func TestNTS_HTTPError_FetchNewEpisodes(t *testing.T) {
 	provider := NewNTSProviderWithClient(server.Client(), server.URL)
 	defer provider.Close()
 
-	_, err := provider.FetchNewEpisodes("nonexistent", time.Now())
+	_, err := provider.FetchNewEpisodes("nonexistent", time.Now(), time.Time{})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "404")
 }

--- a/backend/internal/services/catalog/radio_provider_test.go
+++ b/backend/internal/services/catalog/radio_provider_test.go
@@ -292,7 +292,7 @@ func TestKEXPProvider_FetchNewEpisodes(t *testing.T) {
 	defer provider.Close()
 
 	since := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-	episodes, err := provider.FetchNewEpisodes("42", since)
+	episodes, err := provider.FetchNewEpisodes("42", since, time.Time{})
 
 	require.NoError(t, err)
 	assert.Len(t, episodes, 1)
@@ -1213,7 +1213,7 @@ func (suite *RadioImportIntegrationTestSuite) runImportWithProvider(stationID ui
 
 	since := time.Now().AddDate(0, 0, -backfillDays)
 	for extID, showID := range showMap {
-		episodes, err := provider.FetchNewEpisodes(extID, since)
+		episodes, err := provider.FetchNewEpisodes(extID, since, time.Time{})
 		if err != nil {
 			result.Errors = append(result.Errors, fmt.Sprintf("fetch episodes: %v", err))
 			continue
@@ -1240,7 +1240,7 @@ func (suite *RadioImportIntegrationTestSuite) runImportWithProvider(stationID ui
 
 type mockPlaylistProvider struct {
 	discoverShowsFn    func() ([]RadioShowImport, error)
-	fetchNewEpisodesFn func(showExternalID string, since time.Time) ([]RadioEpisodeImport, error)
+	fetchNewEpisodesFn func(showExternalID string, since time.Time, until time.Time) ([]RadioEpisodeImport, error)
 	fetchPlaylistFn    func(episodeExternalID string) ([]RadioPlayImport, error)
 }
 
@@ -1251,9 +1251,9 @@ func (m *mockPlaylistProvider) DiscoverShows() ([]RadioShowImport, error) {
 	return nil, nil
 }
 
-func (m *mockPlaylistProvider) FetchNewEpisodes(showExternalID string, since time.Time) ([]RadioEpisodeImport, error) {
+func (m *mockPlaylistProvider) FetchNewEpisodes(showExternalID string, since time.Time, until time.Time) ([]RadioEpisodeImport, error) {
 	if m.fetchNewEpisodesFn != nil {
-		return m.fetchNewEpisodesFn(showExternalID, since)
+		return m.fetchNewEpisodesFn(showExternalID, since, until)
 	}
 	return nil, nil
 }

--- a/backend/internal/services/catalog/radio_provider_wfmu.go
+++ b/backend/internal/services/catalog/radio_provider_wfmu.go
@@ -77,7 +77,8 @@ func (p *WFMUProvider) DiscoverShows() ([]RadioShowImport, error) {
 	return shows, nil
 }
 
-// FetchNewEpisodes returns episodes for a WFMU show since the given time.
+// FetchNewEpisodes returns episodes for a WFMU show within [since, until].
+// A zero until means no upper bound.
 //
 // WFMU's RSS feed (/playlistfeed/{CODE}.xml) returns only the most recent 10
 // episodes, which works for incremental fetches but makes historical backfill
@@ -85,18 +86,18 @@ func (p *WFMUProvider) DiscoverShows() ([]RadioShowImport, error) {
 // we use the fast RSS path. For older `since` values we scrape the full show
 // archive page (/playlists/{CODE}), which lists every episode ever aired for
 // the show — up to ~26 years of history.
-func (p *WFMUProvider) FetchNewEpisodes(showExternalID string, since time.Time) ([]RadioEpisodeImport, error) {
+func (p *WFMUProvider) FetchNewEpisodes(showExternalID string, since time.Time, until time.Time) ([]RadioEpisodeImport, error) {
 	// Use RSS for recent windows: fast, sufficient, cheap.
 	// A zero `since` means "all history" — always use the archive page.
 	if !since.IsZero() && time.Since(since) < wfmuRSSFallbackWindow {
-		return p.fetchEpisodesFromRSS(showExternalID, since)
+		return p.fetchEpisodesFromRSS(showExternalID, since, until)
 	}
-	return p.fetchEpisodesFromArchivePage(showExternalID, since)
+	return p.fetchEpisodesFromArchivePage(showExternalID, since, until)
 }
 
 // fetchEpisodesFromRSS fetches recent episodes from the WFMU playlist RSS feed
 // (/playlistfeed/{CODE}.xml). The feed contains the 10 most recent episodes.
-func (p *WFMUProvider) fetchEpisodesFromRSS(showExternalID string, since time.Time) ([]RadioEpisodeImport, error) {
+func (p *WFMUProvider) fetchEpisodesFromRSS(showExternalID string, since time.Time, until time.Time) ([]RadioEpisodeImport, error) {
 	<-p.rateLimiter.C
 
 	feedURL := fmt.Sprintf("%s/playlistfeed/%s.xml", p.baseURL, showExternalID)
@@ -105,7 +106,7 @@ func (p *WFMUProvider) fetchEpisodesFromRSS(showExternalID string, since time.Ti
 		return nil, fmt.Errorf("fetching RSS feed for %s: %w", showExternalID, err)
 	}
 
-	episodes, err := parseWFMURSSFeed(body, showExternalID, since)
+	episodes, err := parseWFMURSSFeed(body, showExternalID, since, until)
 	if err != nil {
 		return nil, fmt.Errorf("parsing RSS feed for %s: %w", showExternalID, err)
 	}
@@ -121,7 +122,7 @@ func (p *WFMUProvider) fetchEpisodesFromRSS(showExternalID string, since time.Ti
 //
 // A 404 from WFMU (unknown show code) is converted to an empty slice rather
 // than an error, consistent with "no episodes" semantics.
-func (p *WFMUProvider) fetchEpisodesFromArchivePage(showExternalID string, since time.Time) ([]RadioEpisodeImport, error) {
+func (p *WFMUProvider) fetchEpisodesFromArchivePage(showExternalID string, since time.Time, until time.Time) ([]RadioEpisodeImport, error) {
 	<-p.rateLimiter.C
 
 	pageURL := fmt.Sprintf("%s/playlists/%s", p.baseURL, showExternalID)
@@ -134,7 +135,7 @@ func (p *WFMUProvider) fetchEpisodesFromArchivePage(showExternalID string, since
 		return nil, fmt.Errorf("fetching archive page for %s: %w", showExternalID, err)
 	}
 
-	episodes, err := parseWFMUArchivePage(body, showExternalID, since)
+	episodes, err := parseWFMUArchivePage(body, showExternalID, since, until)
 	if err != nil {
 		return nil, fmt.Errorf("parsing archive page for %s: %w", showExternalID, err)
 	}
@@ -445,8 +446,9 @@ func getAttr(n *html.Node, key string) string {
 // Matches: /playlists/shows/162230 or http://www.wfmu.org/playlists/shows/162230
 var episodeIDRegex = regexp.MustCompile(`/playlists/shows/(\d+)`)
 
-// parseWFMURSSFeed parses a WFMU playlist RSS feed and returns episodes since the given time.
-func parseWFMURSSFeed(body []byte, showExternalID string, since time.Time) ([]RadioEpisodeImport, error) {
+// parseWFMURSSFeed parses a WFMU playlist RSS feed and returns episodes within [since, until].
+// A zero until means no upper bound.
+func parseWFMURSSFeed(body []byte, showExternalID string, since time.Time, until time.Time) ([]RadioEpisodeImport, error) {
 	fp := gofeed.NewParser()
 	feed, err := fp.ParseString(string(body))
 	if err != nil {
@@ -477,6 +479,11 @@ func parseWFMURSSFeed(body []byte, showExternalID string, since time.Time) ([]Ra
 
 		// Filter by since time
 		if !pubTime.IsZero() && pubTime.Before(since) {
+			continue
+		}
+
+		// Filter by until time
+		if !pubTime.IsZero() && !until.IsZero() && pubTime.After(until) {
 			continue
 		}
 
@@ -580,7 +587,7 @@ var archiveDateRegex = regexp.MustCompile(`(?i)\b(January|February|March|April|M
 
 // parseWFMUArchivePage parses a WFMU show archive page (/playlists/{CODE}) and
 // returns every episode that has a playlist link, filtered to those with an
-// AirDate on or after `since`. A zero `since` returns all parseable episodes.
+// AirDate within [since, until]. A zero `since` or `until` disables that bound.
 //
 // The archive page structure (as emitted by KenzoDB) is:
 //
@@ -603,7 +610,7 @@ var archiveDateRegex = regexp.MustCompile(`(?i)\b(January|February|March|April|M
 // "Playlists/{ShowName}/xxx.html" link format; those are also skipped since
 // their IDs are not addressable via the modern /playlists/shows/{ID} endpoint
 // that FetchPlaylist expects.
-func parseWFMUArchivePage(body []byte, showExternalID string, since time.Time) ([]RadioEpisodeImport, error) {
+func parseWFMUArchivePage(body []byte, showExternalID string, since time.Time, until time.Time) ([]RadioEpisodeImport, error) {
 	doc, err := html.Parse(strings.NewReader(string(body)))
 	if err != nil {
 		return nil, fmt.Errorf("parsing HTML: %w", err)
@@ -643,10 +650,13 @@ func parseWFMUArchivePage(body []byte, showExternalID string, since time.Time) (
 		if seen[ep.ExternalID] {
 			continue
 		}
-		// Apply since filter. A zero since returns everything.
-		if !since.IsZero() && ep.AirDate != "" {
+		// Apply date range filters. Zero since/until disables that bound.
+		if ep.AirDate != "" {
 			if airTime, err := time.Parse("2006-01-02", ep.AirDate); err == nil {
-				if airTime.Before(since) {
+				if !since.IsZero() && airTime.Before(since) {
+					continue
+				}
+				if !until.IsZero() && airTime.After(until) {
 					continue
 				}
 			}

--- a/backend/internal/services/catalog/radio_provider_wfmu_test.go
+++ b/backend/internal/services/catalog/radio_provider_wfmu_test.go
@@ -427,7 +427,7 @@ func TestWFMU_ExtractDJName(t *testing.T) {
 func TestWFMU_ParseRSSFeed_AllEpisodes(t *testing.T) {
 	// Use a "since" time that's before all items
 	since := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
-	episodes, err := parseWFMURSSFeed([]byte(wfmuRSSFeed), "NB", since)
+	episodes, err := parseWFMURSSFeed([]byte(wfmuRSSFeed), "NB", since, time.Time{})
 	require.NoError(t, err)
 	assert.Len(t, episodes, 4, "should parse all 4 episodes")
 
@@ -445,7 +445,7 @@ func TestWFMU_ParseRSSFeed_AllEpisodes(t *testing.T) {
 func TestWFMU_ParseRSSFeed_SinceFilter(t *testing.T) {
 	// Only get episodes since March 1, 2026
 	since := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
-	episodes, err := parseWFMURSSFeed([]byte(wfmuRSSFeed), "NB", since)
+	episodes, err := parseWFMURSSFeed([]byte(wfmuRSSFeed), "NB", since, time.Time{})
 	require.NoError(t, err)
 	assert.Len(t, episodes, 2, "should only return episodes after March 1")
 
@@ -458,13 +458,13 @@ func TestWFMU_ParseRSSFeed_SinceFilter(t *testing.T) {
 
 func TestWFMU_ParseRSSFeed_Empty(t *testing.T) {
 	since := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
-	episodes, err := parseWFMURSSFeed([]byte(wfmuRSSFeedEmpty), "ES", since)
+	episodes, err := parseWFMURSSFeed([]byte(wfmuRSSFeedEmpty), "ES", since, time.Time{})
 	require.NoError(t, err)
 	assert.Empty(t, episodes, "should return empty for feed with no items")
 }
 
 func TestWFMU_ParseRSSFeed_MalformedXML(t *testing.T) {
-	_, err := parseWFMURSSFeed([]byte("this is not xml"), "XX", time.Time{})
+	_, err := parseWFMURSSFeed([]byte("this is not xml"), "XX", time.Time{}, time.Time{})
 	assert.Error(t, err, "should error on malformed XML")
 }
 
@@ -737,7 +737,7 @@ func TestWFMU_FetchNewEpisodes_Integration(t *testing.T) {
 
 	// Recent `since` — should use RSS path.
 	since := time.Now().Add(-7 * 24 * time.Hour)
-	episodes, err := provider.FetchNewEpisodes("NB", since)
+	episodes, err := provider.FetchNewEpisodes("NB", since, time.Time{})
 	require.NoError(t, err)
 	assert.Equal(t, 1, rssHits, "recent since should hit the RSS feed")
 	assert.Equal(t, 0, archiveHits, "recent since should NOT hit the archive page")
@@ -808,7 +808,7 @@ func TestWFMU_HTTPError_FetchNewEpisodes(t *testing.T) {
 	provider := NewWFMUProviderWithClient(server.Client(), server.URL)
 	defer provider.Close()
 
-	_, err := provider.FetchNewEpisodes("INVALID", time.Now())
+	_, err := provider.FetchNewEpisodes("INVALID", time.Now(), time.Time{})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "404")
 }
@@ -859,7 +859,7 @@ func TestWFMU_RateLimiting(t *testing.T) {
 	start := time.Now()
 
 	_, _ = provider.DiscoverShows()
-	_, _ = provider.FetchNewEpisodes("WA", time.Now())
+	_, _ = provider.FetchNewEpisodes("WA", time.Now(), time.Time{})
 	_, _ = provider.FetchPlaylist("12345")
 
 	elapsed := time.Since(start)
@@ -984,7 +984,7 @@ func loadWFMUTestdata(t *testing.T, name string) []byte {
 func TestWFMU_ParseArchivePage_AllEpisodes(t *testing.T) {
 	body := loadWFMUTestdata(t, "wfmu_archive_page_bt.html")
 
-	episodes, err := parseWFMUArchivePage(body, "BT", time.Time{})
+	episodes, err := parseWFMUArchivePage(body, "BT", time.Time{}, time.Time{})
 	require.NoError(t, err)
 
 	// The fixture has 7 <li> rows total:
@@ -1034,7 +1034,7 @@ func TestWFMU_ParseArchivePage_AllEpisodes(t *testing.T) {
 func TestWFMU_ParseArchivePage_Titles(t *testing.T) {
 	body := loadWFMUTestdata(t, "wfmu_archive_page_bt.html")
 
-	episodes, err := parseWFMUArchivePage(body, "BT", time.Time{})
+	episodes, err := parseWFMUArchivePage(body, "BT", time.Time{}, time.Time{})
 	require.NoError(t, err)
 
 	byID := make(map[string]RadioEpisodeImport)
@@ -1064,7 +1064,7 @@ func TestWFMU_ParseArchivePage_SinceFilter(t *testing.T) {
 
 	// Filter to episodes on or after April 20, 2018
 	since := time.Date(2018, 4, 20, 0, 0, 0, 0, time.UTC)
-	episodes, err := parseWFMUArchivePage(body, "BT", since)
+	episodes, err := parseWFMUArchivePage(body, "BT", since, time.Time{})
 	require.NoError(t, err)
 
 	// Should return only episodes from April 24, May 1, May 8 (3 episodes)
@@ -1083,7 +1083,7 @@ func TestWFMU_ParseArchivePage_SinceFilter_AllOld(t *testing.T) {
 
 	// Filter to future — should return nothing
 	since := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
-	episodes, err := parseWFMUArchivePage(body, "BT", since)
+	episodes, err := parseWFMUArchivePage(body, "BT", since, time.Time{})
 	require.NoError(t, err)
 	assert.Empty(t, episodes, "no episodes should match a future since")
 }
@@ -1091,7 +1091,7 @@ func TestWFMU_ParseArchivePage_SinceFilter_AllOld(t *testing.T) {
 func TestWFMU_ParseArchivePage_Empty(t *testing.T) {
 	body := loadWFMUTestdata(t, "wfmu_archive_page_empty.html")
 
-	episodes, err := parseWFMUArchivePage(body, "EMPTY", time.Time{})
+	episodes, err := parseWFMUArchivePage(body, "EMPTY", time.Time{}, time.Time{})
 	require.NoError(t, err)
 	assert.Empty(t, episodes, "empty archive should return empty slice")
 }
@@ -1100,7 +1100,7 @@ func TestWFMU_ParseArchivePage_NoShowlist(t *testing.T) {
 	// HTML with no <div class="showlist"> — should return empty, not error.
 	body := []byte(`<!DOCTYPE html><html><body><p>Nothing here.</p></body></html>`)
 
-	episodes, err := parseWFMUArchivePage(body, "XX", time.Time{})
+	episodes, err := parseWFMUArchivePage(body, "XX", time.Time{}, time.Time{})
 	require.NoError(t, err)
 	assert.Empty(t, episodes, "missing showlist should return empty")
 }
@@ -1141,7 +1141,7 @@ func TestWFMU_ParseArchivePage_MalformedRows(t *testing.T) {
 </div>
 </body></html>`)
 
-	episodes, err := parseWFMUArchivePage(body, "XX", time.Time{})
+	episodes, err := parseWFMUArchivePage(body, "XX", time.Time{}, time.Time{})
 	require.NoError(t, err)
 
 	// Should parse: 100 (valid), 103 (valid). Skip: 101 (no date), 102 (no link), row 2 (nothing).
@@ -1176,7 +1176,7 @@ func TestWFMU_ParseArchivePage_Deduplication(t *testing.T) {
 </div>
 </body></html>`)
 
-	episodes, err := parseWFMUArchivePage(body, "XX", time.Time{})
+	episodes, err := parseWFMUArchivePage(body, "XX", time.Time{}, time.Time{})
 	require.NoError(t, err)
 	assert.Len(t, episodes, 1, "duplicate episode IDs should be deduplicated")
 }
@@ -1235,7 +1235,7 @@ func TestWFMU_FetchNewEpisodes_ArchiveFallback_Integration(t *testing.T) {
 
 	// Old `since` (beyond the 14-day window) triggers the archive page path.
 	since := time.Date(2017, 1, 1, 0, 0, 0, 0, time.UTC)
-	episodes, err := provider.FetchNewEpisodes("BT", since)
+	episodes, err := provider.FetchNewEpisodes("BT", since, time.Time{})
 	require.NoError(t, err)
 
 	assert.Equal(t, 0, rssHits, "historical since should NOT hit RSS")
@@ -1267,7 +1267,7 @@ func TestWFMU_FetchNewEpisodes_ArchiveFallback_ZeroSince(t *testing.T) {
 	defer provider.Close()
 
 	// Zero `since` means "all history" → archive page.
-	episodes, err := provider.FetchNewEpisodes("BT", time.Time{})
+	episodes, err := provider.FetchNewEpisodes("BT", time.Time{}, time.Time{})
 	require.NoError(t, err)
 	assert.Equal(t, 1, archiveHits)
 	assert.Len(t, episodes, 5)
@@ -1285,7 +1285,7 @@ func TestWFMU_FetchNewEpisodes_ArchiveFallback_404(t *testing.T) {
 	defer provider.Close()
 
 	// Old `since` → archive path; 404 → empty slice, no error.
-	episodes, err := provider.FetchNewEpisodes("NOPE", time.Date(2010, 1, 1, 0, 0, 0, 0, time.UTC))
+	episodes, err := provider.FetchNewEpisodes("NOPE", time.Date(2010, 1, 1, 0, 0, 0, 0, time.UTC), time.Time{})
 	require.NoError(t, err, "404 from archive page should become empty slice")
 	assert.Empty(t, episodes)
 }


### PR DESCRIPTION
## Summary
- Add `until time.Time` parameter to `FetchNewEpisodes` in the provider interface
- KEXP: uses `start_time_before` API param
- NTS: filters episodes after `until` bound
- WFMU: filters in both RSS and HTML archive parsers
- Callers pass `time.Time{}` (zero value) for unbounded, or actual time for bounded imports
- All provider tests updated and passing

Closes PSY-279

## Test plan
- [ ] Import jobs with date ranges correctly stop at `until` date
- [ ] Unbounded imports (no `until`) work as before
- [ ] All 3 provider test suites pass
- [ ] `go vet` and `go build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)