### PR TITLE
Fix background radio fetch to respect show is_active flag

### DIFF
--- a/backend/internal/services/catalog/radio_import.go
+++ b/backend/internal/services/catalog/radio_import.go
@@ -123,9 +123,9 @@ func (s *RadioService) FetchNewEpisodes(stationID uint) (*contracts.RadioImportR
 
 	result := &contracts.RadioImportResult{}
 
-	// Get all shows for this station
+	// Get active shows for this station
 	var shows []models.RadioShow
-	if err := s.db.Where("station_id = ?", stationID).Find(&shows).Error; err != nil {
+	if err := s.db.Where("station_id = ? AND is_active = ?", stationID, true).Find(&shows).Error; err != nil {
 		return nil, fmt.Errorf("loading shows: %w", err)
 	}
 


### PR DESCRIPTION
## Summary
- `FetchNewEpisodes()` was querying all shows for a station regardless of `is_active`, so toggling a show off in the admin UI had no effect on the 6-hour background fetch
- Adds `AND is_active = true` filter to the show query in the incremental fetch path
- Manual imports (sync and async) are unaffected — those target a specific show by ID

## Test plan
- [x] All radio tests pass (40+ tests including integration suites)
- [ ] Toggle a show to inactive, verify next fetch cycle skips it
- [ ] Verify manual import still works on an inactive show

Closes PSY-382

🤖 Generated with [Claude Code](https://claude.com/claude-code)