### PR TITLE
Fix KEXP provider to filter plays by show broadcast window

### DIFF
--- a/backend/internal/services/catalog/radio_provider_kexp.go
+++ b/backend/internal/services/catalog/radio_provider_kexp.go
@@ -157,34 +157,34 @@ func (p *KEXPProvider) FetchNewEpisodes(showExternalID string, since time.Time, 
 	return allEpisodes, nil
 }
 
-// kexpPlaylistWindow is the upper bound added to a broadcast's start_time when
-// querying the KEXP plays endpoint. KEXP "shows" (broadcasts) expose start_time
-// but no end_time, and programs are typically 1–4 hours long. 5 hours gives a
-// small safety buffer for shows that run long without encroaching far into the
-// next broadcast's playlist.
-const kexpPlaylistWindow = 5 * time.Hour
+// kexpPlaylistWindowFallback is added to a broadcast's start_time when the
+// show detail response does not include an end_time. Programs are typically
+// 1-4 hours long, so 5 hours gives a safety buffer without encroaching far
+// into the next broadcast's playlist.
+const kexpPlaylistWindowFallback = 5 * time.Hour
 
 // FetchPlaylist returns track plays for a KEXP "show" (episode).
 //
-// KEXP's /v2/plays endpoint does NOT support a show_id filter — passing one is
+// KEXP's /v2/plays endpoint does NOT support a show_id filter -- passing one is
 // silently ignored and every request returns the global plays list. Instead we
 // filter by broadcast time window using airdate_after/airdate_before:
 //
-//  1. GET /v2/shows/{id}/ to resolve the broadcast's start_time.
-//  2. Compute [start_time, start_time + kexpPlaylistWindow] as the bounds.
+//  1. GET /v2/shows/{id}/ to resolve the broadcast's start_time and end_time.
+//  2. Use [start_time, end_time] as the bounds. If end_time is missing, fall
+//     back to start_time + kexpPlaylistWindowFallback.
 //  3. GET /v2/plays/?airdate_after=...&airdate_before=...&play_type=trackplay
 //     and paginate via the `next` cursor.
 //
 // If the broadcast is not found (404) we return an empty playlist rather than
 // an error so callers can continue processing other episodes.
 func (p *KEXPProvider) FetchPlaylist(episodeExternalID string) ([]RadioPlayImport, error) {
-	// Step 1: fetch the broadcast to get its start_time.
+	// Step 1: fetch the broadcast to get its time window.
 	showDetailURL := fmt.Sprintf("%s/v2/shows/%s/", p.baseURL, episodeExternalID)
 
 	<-p.rateLimiter.C
 	resp, err := p.doGet(showDetailURL)
 	if err != nil {
-		// KEXP returned a non-200 (including 404 for missing broadcasts) —
+		// KEXP returned a non-200 (including 404 for missing broadcasts) --
 		// treat as "no plays" so the import pipeline can continue.
 		if strings.Contains(err.Error(), "status 404") {
 			return nil, nil
@@ -205,7 +205,19 @@ func (p *KEXPProvider) FetchPlaylist(episodeExternalID string) ([]RadioPlayImpor
 	if err != nil {
 		return nil, fmt.Errorf("parsing show start_time %q: %w", show.StartTime, err)
 	}
-	endTime := startTime.Add(kexpPlaylistWindow)
+
+	// Use end_time from the broadcast when available for a precise window;
+	// fall back to the fixed fallback duration when the API omits it.
+	var endTime time.Time
+	if show.EndTime != "" {
+		parsed, err := time.Parse(time.RFC3339, show.EndTime)
+		if err == nil && parsed.After(startTime) {
+			endTime = parsed
+		}
+	}
+	if endTime.IsZero() {
+		endTime = startTime.Add(kexpPlaylistWindowFallback)
+	}
 
 	// Step 2: fetch plays filtered by the broadcast's time window.
 	var allPlays []RadioPlayImport

--- a/backend/internal/services/catalog/radio_provider_test.go
+++ b/backend/internal/services/catalog/radio_provider_test.go
@@ -307,13 +307,15 @@ func TestKEXPProvider_FetchPlaylist(t *testing.T) {
 	var playsRequestQuery string
 
 	mux := http.NewServeMux()
-	// Show detail endpoint — called first to resolve start_time.
+	// Show detail endpoint -- returns start_time AND end_time so the provider
+	// should use the actual broadcast window (4 hours) instead of the fallback.
 	mux.HandleFunc("/v2/shows/5678/", func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"id":           5678,
 			"program_id":   42,
 			"program_name": "The Morning Show",
 			"start_time":   "2026-01-15T06:00:00-08:00",
+			"end_time":     "2026-01-15T10:00:00-08:00",
 		})
 	})
 	mux.HandleFunc("/v2/plays/", func(w http.ResponseWriter, r *http.Request) {
@@ -381,8 +383,9 @@ func TestKEXPProvider_FetchPlaylist(t *testing.T) {
 	// airdate_after should match the show start_time (UTC). The broadcast
 	// starts at 2026-01-15T06:00:00-08:00 which is 2026-01-15T14:00:00Z.
 	assert.Contains(t, playsRequestQuery, "airdate_after=2026-01-15T14:00:00Z")
-	// airdate_before should be 5 hours later: 2026-01-15T19:00:00Z.
-	assert.Contains(t, playsRequestQuery, "airdate_before=2026-01-15T19:00:00Z")
+	// airdate_before should match the show end_time (UTC). The broadcast
+	// ends at 2026-01-15T10:00:00-08:00 which is 2026-01-15T18:00:00Z.
+	assert.Contains(t, playsRequestQuery, "airdate_before=2026-01-15T18:00:00Z")
 
 	// First play
 	assert.Equal(t, 0, plays[0].Position)
@@ -400,6 +403,52 @@ func TestKEXPProvider_FetchPlaylist(t *testing.T) {
 	assert.Equal(t, "Deerhunter", plays[1].ArtistName)
 	assert.True(t, plays[1].IsNew)
 	assert.True(t, plays[1].IsLivePerformance)
+}
+
+func TestKEXPProvider_FetchPlaylist_NoEndTimeFallback(t *testing.T) {
+	var playsRequestQuery string
+
+	mux := http.NewServeMux()
+	// Show detail endpoint -- no end_time, so provider should fall back to
+	// kexpPlaylistWindowFallback (5 hours).
+	mux.HandleFunc("/v2/shows/7777/", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"id":         7777,
+			"start_time": "2026-01-15T14:00:00Z",
+		})
+	})
+	mux.HandleFunc("/v2/plays/", func(w http.ResponseWriter, r *http.Request) {
+		playsRequestQuery = r.URL.RawQuery
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"next":  nil,
+			"count": 1,
+			"results": []map[string]interface{}{
+				{
+					"id":        1,
+					"play_type": "trackplay",
+					"airdate":   "2026-01-15T14:05:00Z",
+					"artist":    "Yo La Tengo",
+					"song":      "Tom Courtenay",
+				},
+			},
+		})
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	provider := NewKEXPProviderWithClient(server.Client(), server.URL)
+	defer provider.Close()
+
+	plays, err := provider.FetchPlaylist("7777")
+
+	require.NoError(t, err)
+	assert.Len(t, plays, 1)
+	assert.Equal(t, "Yo La Tengo", plays[0].ArtistName)
+
+	// Without end_time, should fall back to start_time + 5h = 2026-01-15T19:00:00Z
+	assert.Contains(t, playsRequestQuery, "airdate_after=2026-01-15T14:00:00Z")
+	assert.Contains(t, playsRequestQuery, "airdate_before=2026-01-15T19:00:00Z")
 }
 
 func TestKEXPProvider_FetchPlaylist_OnlyTrackPlays(t *testing.T) {


### PR DESCRIPTION
## Summary
- `FetchPlaylist()` was using a fixed 5-hour window from `start_time`, ignoring the show's actual `end_time`
- For shows shorter than 5 hours, this captured plays from subsequent broadcasts
- Now parses `end_time` from the KEXP API response and uses it as `airdate_before`
- Falls back to 5-hour window only when `end_time` is missing

## Test plan
- [x] Updated `TestKEXPProvider_FetchPlaylist` to verify end_time-based window
- [x] Added `TestKEXPProvider_FetchPlaylist_NoEndTimeFallback` for missing end_time
- [x] All radio tests pass
- [ ] Verify KEXP Morning Show now imports 30-50 tracks with correct timestamps

Closes PSY-383

🤖 Generated with [Claude Code](https://claude.com/claude-code)