### PR TITLE
Preserve curated radio show data during background import

### DIFF
--- a/backend/internal/services/catalog/radio_import.go
+++ b/backend/internal/services/catalog/radio_import.go
@@ -374,28 +374,38 @@ func (s *RadioService) ImportShowEpisodes(showID uint, since string, until strin
 
 // upsertRadioShow creates or updates a radio show from import data.
 // Returns the internal show ID.
+//
+// When a show already exists (matched by station_id + external_id), only
+// fields that are currently empty/NULL in the database are populated from
+// the import data. This preserves admin-curated or migration-seeded values
+// (e.g. description, host_name, broadcast_type) that are typically higher
+// quality than what providers return.
 func (s *RadioService) upsertRadioShow(stationID uint, importShow RadioShowImport) (uint, error) {
 	var existing models.RadioShow
 	err := s.db.Where("station_id = ? AND external_id = ?", stationID, importShow.ExternalID).First(&existing).Error
 	if err == nil {
-		// Update existing show
-		updates := map[string]interface{}{
-			"name": importShow.Name,
+		// Only fill in fields that are currently empty — never overwrite curated data.
+		updates := map[string]interface{}{}
+
+		if existing.Name == "" && importShow.Name != "" {
+			updates["name"] = importShow.Name
 		}
-		if importShow.HostName != nil {
+		if existing.HostName == nil && importShow.HostName != nil {
 			updates["host_name"] = *importShow.HostName
 		}
-		if importShow.Description != nil {
+		if existing.Description == nil && importShow.Description != nil {
 			updates["description"] = *importShow.Description
 		}
-		if importShow.ImageURL != nil {
+		if existing.ImageURL == nil && importShow.ImageURL != nil {
 			updates["image_url"] = *importShow.ImageURL
 		}
-		if importShow.ArchiveURL != nil {
+		if existing.ArchiveURL == nil && importShow.ArchiveURL != nil {
 			updates["archive_url"] = *importShow.ArchiveURL
 		}
 
-		s.db.Model(&existing).Updates(updates)
+		if len(updates) > 0 {
+			s.db.Model(&existing).Updates(updates)
+		}
 		return existing.ID, nil
 	}
 

--- a/backend/internal/services/catalog/radio_provider_test.go
+++ b/backend/internal/services/catalog/radio_provider_test.go
@@ -979,35 +979,80 @@ func (suite *RadioImportIntegrationTestSuite) TestUpsertRadioShow_CreateNew() {
 	suite.Equal("42", *show.ExternalID)
 }
 
-func (suite *RadioImportIntegrationTestSuite) TestUpsertRadioShow_UpdateExisting() {
+func (suite *RadioImportIntegrationTestSuite) TestUpsertRadioShow_PreservesCuratedData() {
 	station := suite.createStation("KEXP")
 
-	// Create initial show
+	// Create initial show with curated data
 	extID := "42"
+	curatedDesc := "Curated description by admin"
+	curatedHost := "Kennady Quille"
 	show := &models.RadioShow{
-		StationID:  station.ID,
-		Name:       "Old Name",
-		Slug:       "old-name",
-		ExternalID: &extID,
+		StationID:   station.ID,
+		Name:        "Audioasis",
+		Slug:        "audioasis",
+		HostName:    &curatedHost,
+		Description: &curatedDesc,
+		ExternalID:  &extID,
 	}
 	suite.Require().NoError(suite.db.Create(show).Error)
 
-	// Upsert with new name
+	// Upsert with different API data — curated fields should NOT be overwritten
+	apiDesc := "Short API description"
 	importShow := RadioShowImport{
-		ExternalID: "42",
-		Name:       "New Name",
-		HostName:   stringPtr("New Host"),
+		ExternalID:  "42",
+		Name:        "Audioasis (API)",
+		HostName:    stringPtr("Cheryl Waters"),
+		Description: &apiDesc,
+		ImageURL:    stringPtr("https://example.com/image.jpg"),
 	}
 
 	showID, err := suite.radioService.upsertRadioShow(station.ID, importShow)
 	suite.Require().NoError(err)
 	suite.Equal(show.ID, showID)
 
-	// Verify update
+	// Verify curated values are preserved
 	var updated models.RadioShow
 	suite.db.First(&updated, showID)
-	suite.Equal("New Name", updated.Name)
-	suite.Equal("New Host", *updated.HostName)
+	suite.Equal("Audioasis", updated.Name)              // kept curated name
+	suite.Equal("Kennady Quille", *updated.HostName)    // kept curated host
+	suite.Equal("Curated description by admin", *updated.Description) // kept curated description
+	// ImageURL was NULL, so it gets filled from import data
+	suite.Require().NotNil(updated.ImageURL)
+	suite.Equal("https://example.com/image.jpg", *updated.ImageURL)
+}
+
+func (suite *RadioImportIntegrationTestSuite) TestUpsertRadioShow_FillsEmptyFields() {
+	station := suite.createStation("KEXP")
+
+	// Create initial show with minimal data (no host, no description)
+	extID := "42"
+	show := &models.RadioShow{
+		StationID:  station.ID,
+		Name:       "New Show",
+		Slug:       "new-show",
+		ExternalID: &extID,
+	}
+	suite.Require().NoError(suite.db.Create(show).Error)
+
+	// Upsert with API data — empty fields should be populated
+	importShow := RadioShowImport{
+		ExternalID:  "42",
+		Name:        "New Show (API)",
+		HostName:    stringPtr("DJ Host"),
+		Description: stringPtr("A great show"),
+		ArchiveURL:  stringPtr("https://example.com/archive"),
+	}
+
+	showID, err := suite.radioService.upsertRadioShow(station.ID, importShow)
+	suite.Require().NoError(err)
+	suite.Equal(show.ID, showID)
+
+	var updated models.RadioShow
+	suite.db.First(&updated, showID)
+	suite.Equal("New Show", updated.Name)                // name was non-empty, kept
+	suite.Equal("DJ Host", *updated.HostName)            // was nil, filled
+	suite.Equal("A great show", *updated.Description)    // was nil, filled
+	suite.Equal("https://example.com/archive", *updated.ArchiveURL) // was nil, filled
 }
 
 func (suite *RadioImportIntegrationTestSuite) TestImportEpisode_DeduplicatesByExternalID() {


### PR DESCRIPTION
## Summary
- `upsertRadioShow()` was unconditionally overwriting name, host, description, image_url, and archive_url on every scheduler run
- Changed update logic to only populate fields that are currently NULL/empty in the database
- New shows discovered for the first time still get full API data on creation
- Added two new tests verifying curated data preservation and empty field population

## Test plan
- [x] `TestUpsertRadioShow_PreservesCuratedData` — curated values not overwritten, NULL fields filled
- [x] `TestUpsertRadioShow_FillsEmptyFields` — empty fields populated from import
- [x] All existing radio tests pass
- [ ] Verify seed descriptions survive a scheduler cycle

Closes PSY-384

🤖 Generated with [Claude Code](https://claude.com/claude-code)