### PR TITLE
Fix 'Suggest similar artist' button invisible when no relationships exist

### DIFF
--- a/frontend/features/artists/components/RelatedArtists.test.tsx
+++ b/frontend/features/artists/components/RelatedArtists.test.tsx
@@ -163,7 +163,7 @@ describe('RelatedArtists', () => {
     expect(downvoteButtons.length).toBeGreaterThanOrEqual(2)
   })
 
-  it('hides section when no relationships exist', async () => {
+  it('shows empty state with suggest button when no relationships exist', async () => {
     const hooks = await import('../hooks/useArtistGraph')
     vi.mocked(hooks.useArtistGraph).mockReturnValueOnce({
       data: {
@@ -175,11 +175,14 @@ describe('RelatedArtists', () => {
       error: null,
     } as any) // eslint-disable-line @typescript-eslint/no-explicit-any
 
-    const { container } = renderWithProviders(
+    renderWithProviders(
       <RelatedArtists artistId={1} artistSlug="lonely" />
     )
-    // Should render nothing
-    expect(container.children.length).toBe(0)
+    // Should show the section header and empty state message
+    expect(screen.getByText('Related Artists')).toBeInTheDocument()
+    expect(screen.getByText('No similar artists yet. Be the first to suggest one!')).toBeInTheDocument()
+    // Should show the suggest button for authenticated users
+    expect(screen.getByText('Suggest similar artist')).toBeInTheDocument()
   })
 
   it('hides section while loading', async () => {

--- a/frontend/features/artists/components/RelatedArtists.tsx
+++ b/frontend/features/artists/components/RelatedArtists.tsx
@@ -55,9 +55,42 @@ export function RelatedArtists({ artistId, artistSlug }: RelatedArtistsProps) {
     return () => observer.disconnect()
   }, [])
 
-  // Don't show section if no relationships exist
   if (isLoading) return null
-  if (!data || (data.nodes.length === 0 && data.links.length === 0)) return null
+
+  const hasRelationships = data && (data.nodes.length > 0 || data.links.length > 0)
+
+  // Empty state: show header + message + suggest button for authenticated users
+  if (!hasRelationships) {
+    return (
+      <div ref={containerRef} className="mt-8 px-4 md:px-0">
+        <h2 className="text-lg font-semibold mb-4">Related Artists</h2>
+        <p className="text-sm text-muted-foreground">
+          No similar artists yet. Be the first to suggest one!
+        </p>
+        {isAuthenticated && (
+          <div className="mt-4">
+            {showSuggest ? (
+              <SuggestSimilarArtist
+                centerArtistId={artistId}
+                centerArtistSlug={artistSlug}
+                onClose={() => setShowSuggest(false)}
+              />
+            ) : (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setShowSuggest(true)}
+                className="text-muted-foreground"
+              >
+                <Plus className="h-4 w-4 mr-1.5" />
+                Suggest similar artist
+              </Button>
+            )}
+          </div>
+        )}
+      </div>
+    )
+  }
 
   const toggleType = (type: string) => {
     setActiveTypes(prev => {


### PR DESCRIPTION
## Summary
- Show RelatedArtists section with empty state when no relationships exist, solving the chicken-and-egg problem
- Empty state shows "No similar artists yet. Be the first to suggest one!" with the Suggest button for authenticated users
- Updated test to verify new empty state behavior

Closes PSY-373

## Test plan
- [ ] Visit an artist page with no similar artist relationships
- [ ] Verify the "Related Artists" section renders with empty state message
- [ ] Verify "Suggest similar artist" button is visible for authenticated users
- [ ] Verify button opens the SuggestSimilarArtist form
- [ ] Verify logged-out users don't see the suggest button

🤖 Generated with [Claude Code](https://claude.com/claude-code)