### PR TITLE
Fix Charts 'Trending Shows' blank title with artist name fallback

### DIFF
--- a/backend/internal/api/handlers/charts.go
+++ b/backend/internal/api/handlers/charts.go
@@ -40,6 +40,7 @@ type TrendingShowResponse struct {
 	VenueName       string    `json:"venue_name"`
 	VenueSlug       string    `json:"venue_slug"`
 	City            string    `json:"city"`
+	ArtistNames     []string  `json:"artist_names"`
 	GoingCount      int       `json:"going_count"`
 	InterestedCount int       `json:"interested_count"`
 	TotalAttendance int       `json:"total_attendance"`
@@ -73,6 +74,7 @@ func (h *ChartsHandler) GetTrendingShowsHandler(ctx context.Context, req *GetTre
 			VenueName:       s.VenueName,
 			VenueSlug:       s.VenueSlug,
 			City:            s.City,
+			ArtistNames:     s.ArtistNames,
 			GoingCount:      s.GoingCount,
 			InterestedCount: s.InterestedCount,
 			TotalAttendance: s.TotalAttendance,
@@ -269,6 +271,7 @@ func (h *ChartsHandler) GetChartsOverviewHandler(ctx context.Context, _ *GetChar
 			VenueName:       s.VenueName,
 			VenueSlug:       s.VenueSlug,
 			City:            s.City,
+			ArtistNames:     s.ArtistNames,
 			GoingCount:      s.GoingCount,
 			InterestedCount: s.InterestedCount,
 			TotalAttendance: s.TotalAttendance,

--- a/backend/internal/services/catalog/charts_service.go
+++ b/backend/internal/services/catalog/charts_service.go
@@ -80,6 +80,7 @@ func (s *ChartsService) GetTrendingShows(limit int) ([]contracts.TrendingShow, e
 	}
 
 	results := make([]contracts.TrendingShow, len(rows))
+	showIDs := make([]uint, len(rows))
 	for i, r := range rows {
 		results[i] = contracts.TrendingShow{
 			ShowID:          r.ShowID,
@@ -89,9 +90,43 @@ func (s *ChartsService) GetTrendingShows(limit int) ([]contracts.TrendingShow, e
 			VenueName:       r.VenueName,
 			VenueSlug:       r.VenueSlug,
 			City:            r.City,
+			ArtistNames:     []string{},
 			GoingCount:      r.GoingCount,
 			InterestedCount: r.InterestedCount,
 			TotalAttendance: r.TotalAttendance,
+		}
+		showIDs[i] = r.ShowID
+	}
+
+	// Fetch artist names for all shows in one query
+	if len(showIDs) > 0 {
+		type artistNameRow struct {
+			ShowID uint   `gorm:"column:show_id"`
+			Name   string `gorm:"column:name"`
+		}
+		var artistRows []artistNameRow
+		err := s.db.Raw(`
+			SELECT sa.show_id, a.name
+			FROM show_artists sa
+			JOIN artists a ON a.id = sa.artist_id
+			WHERE sa.show_id IN ?
+			ORDER BY sa.show_id, sa.position
+		`, showIDs).Scan(&artistRows).Error
+		if err != nil {
+			return nil, fmt.Errorf("failed to get show artists: %w", err)
+		}
+
+		// Build map of show_id -> artist names
+		artistMap := make(map[uint][]string)
+		for _, ar := range artistRows {
+			artistMap[ar.ShowID] = append(artistMap[ar.ShowID], ar.Name)
+		}
+
+		// Assign to results
+		for i := range results {
+			if names, ok := artistMap[results[i].ShowID]; ok {
+				results[i].ArtistNames = names
+			}
 		}
 	}
 

--- a/backend/internal/services/contracts/charts.go
+++ b/backend/internal/services/contracts/charts.go
@@ -15,6 +15,7 @@ type TrendingShow struct {
 	VenueName       string    `json:"venue_name"`
 	VenueSlug       string    `json:"venue_slug"`
 	City            string    `json:"city"`
+	ArtistNames     []string  `json:"artist_names"`
 	GoingCount      int       `json:"going_count"`
 	InterestedCount int       `json:"interested_count"`
 	TotalAttendance int       `json:"total_attendance"`

--- a/frontend/features/charts/components/TrendingShowsList.tsx
+++ b/frontend/features/charts/components/TrendingShowsList.tsx
@@ -9,6 +9,15 @@ interface TrendingShowsListProps {
   compact?: boolean
 }
 
+function getShowDisplayTitle(show: TrendingShow): string {
+  if (show.title) return show.title
+  const artistPart = show.artist_names?.length ? show.artist_names.join(', ') : ''
+  if (artistPart && show.venue_name) return `${artistPart} @ ${show.venue_name}`
+  if (artistPart) return artistPart
+  if (show.venue_name) return `Show @ ${show.venue_name}`
+  return 'Untitled Show'
+}
+
 export function TrendingShowsList({ shows, compact = false }: TrendingShowsListProps) {
   if (shows.length === 0) {
     return (
@@ -31,7 +40,7 @@ export function TrendingShowsList({ shows, compact = false }: TrendingShowsListP
             </span>
             <div className="min-w-0 flex-1">
               <p className="text-sm font-medium leading-tight group-hover:text-primary truncate">
-                {show.title}
+                {getShowDisplayTitle(show)}
               </p>
               {!compact && (
                 <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs text-muted-foreground">

--- a/frontend/features/charts/types.ts
+++ b/frontend/features/charts/types.ts
@@ -13,6 +13,7 @@ export interface TrendingShow {
   venue_name: string
   venue_slug: string
   city: string
+  artist_names: string[]
   going_count: number
   interested_count: number
   total_attendance: number


### PR DESCRIPTION
## Summary
- Backend: Enrich trending shows with artist names from show_artists table (single batch query)
- Frontend: Add `getShowDisplayTitle()` fallback chain: title → "Artist1, Artist2 @ Venue" → artists only → "Show @ Venue" → "Untitled Show"
- Every chart entry now always has a visible, meaningful title

Closes PSY-378

## Test plan
- [ ] Visit `/charts` and check Trending Shows section
- [ ] Verify all entries have visible titles
- [ ] Verify shows with no title display "Artist @ Venue" format
- [ ] Verify the overview endpoint also returns artist names

🤖 Generated with [Claude Code](https://claude.com/claude-code)