### PR TITLE
Add city/state label to compact density show cards

### DIFF
--- a/frontend/features/shows/components/ShowCard.tsx
+++ b/frontend/features/shows/components/ShowCard.tsx
@@ -222,20 +222,25 @@ export function ShowCard({ show, isAdmin, userId, isSaved, density = 'comfortabl
           )}
         </Link>
 
-        {/* Venue */}
+        {/* Venue + City */}
         {venue && (
-          venue.slug ? (
-            <Link
-              href={`/venues/${venue.slug}`}
-              className="text-xs text-muted-foreground shrink-0 hover:text-primary transition-colors hidden sm:inline"
-            >
-              {venue.name}
-            </Link>
-          ) : (
-            <span className="text-xs text-muted-foreground shrink-0 hidden sm:inline">
-              {venue.name}
-            </span>
-          )
+          <span className="text-xs text-muted-foreground shrink-0 hidden sm:inline">
+            {venue.slug ? (
+              <Link
+                href={`/venues/${venue.slug}`}
+                className="hover:text-primary transition-colors"
+              >
+                {venue.name}
+              </Link>
+            ) : (
+              venue.name
+            )}
+            {(show.city || show.state) && (
+              <span className="text-muted-foreground/70">
+                {' '}&middot; {[show.city, show.state].filter(Boolean).join(', ')}
+              </span>
+            )}
+          </span>
         )}
 
         {/* Time */}


### PR DESCRIPTION
## Summary
- Show cards in compact density now display city/state after venue name (e.g., "Venue · Phoenix, AZ")
- Uses same middot separator and muted styling as comfortable/expanded density modes
- Comfortable and expanded modes already had this — this closes the gap for compact

Closes PSY-376

## Test plan
- [ ] Browse `/shows` with compact density toggle
- [ ] Verify city/state appears after venue name on show cards
- [ ] Verify formatting matches other density modes (middot separator, muted text)
- [ ] Verify cards with no city/state don't show the separator

🤖 Generated with [Claude Code](https://claude.com/claude-code)