### PR TITLE
Add search input to labels browse page

### DIFF
--- a/frontend/features/labels/components/LabelList.tsx
+++ b/frontend/features/labels/components/LabelList.tsx
@@ -5,6 +5,7 @@ import { useSearchParams, useRouter } from 'next/navigation'
 import { cn } from '@/lib/utils'
 import { useLabels } from '../hooks/useLabels'
 import { LabelCard } from './LabelCard'
+import { LabelSearch } from './LabelSearch'
 import { LoadingSpinner, DensityToggle } from '@/components/shared'
 import { useDensity } from '@/lib/hooks/common/useDensity'
 import { Button } from '@/components/ui/button'
@@ -75,6 +76,7 @@ export function LabelList() {
     <section className="w-full max-w-6xl">
       {/* Filters */}
       <div className="mb-6 space-y-4">
+        <LabelSearch />
         {/* Status Filter */}
         <div className="flex flex-wrap items-center gap-2">
           <span className="text-sm text-muted-foreground mr-1">Status:</span>

--- a/frontend/features/labels/components/LabelSearch.tsx
+++ b/frontend/features/labels/components/LabelSearch.tsx
@@ -1,0 +1,131 @@
+'use client'
+
+import { useState, useRef } from 'react'
+import { useRouter } from 'next/navigation'
+import { Search } from 'lucide-react'
+import { Input } from '@/components/ui/input'
+import { useLabelSearch } from '../hooks/useLabelSearch'
+import { formatLabelLocation } from '../types'
+
+/**
+ * Label search with autocomplete dropdown.
+ * Navigates to the label detail page on selection.
+ */
+export function LabelSearch() {
+  const router = useRouter()
+  const [query, setQuery] = useState('')
+  const [isOpen, setIsOpen] = useState(false)
+  const [activeIndex, setActiveIndex] = useState(-1)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const { data: searchResults } = useLabelSearch({ query })
+  const labels = searchResults?.labels ?? []
+
+  const handleSelect = (slug: string) => {
+    setQuery('')
+    setIsOpen(false)
+    setActiveIndex(-1)
+    router.push(`/labels/${slug}`)
+  }
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value
+    setQuery(value)
+    setIsOpen(value.length > 0)
+    setActiveIndex(-1)
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (!isOpen || labels.length === 0) {
+      if (e.key === 'Escape') {
+        setIsOpen(false)
+        inputRef.current?.blur()
+      }
+      return
+    }
+
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault()
+        setActiveIndex(prev => (prev < labels.length - 1 ? prev + 1 : 0))
+        break
+      case 'ArrowUp':
+        e.preventDefault()
+        setActiveIndex(prev => (prev > 0 ? prev - 1 : labels.length - 1))
+        break
+      case 'Enter':
+        e.preventDefault()
+        if (activeIndex >= 0 && activeIndex < labels.length) {
+          handleSelect(labels[activeIndex].slug)
+        }
+        break
+      case 'Escape':
+        setIsOpen(false)
+        setActiveIndex(-1)
+        inputRef.current?.blur()
+        break
+    }
+  }
+
+  const handleBlur = () => {
+    // Delay to allow click on dropdown items
+    setTimeout(() => {
+      setIsOpen(false)
+      setActiveIndex(-1)
+    }, 150)
+  }
+
+  return (
+    <div className="relative w-full max-w-sm">
+      <div className="relative">
+        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
+        <Input
+          ref={inputRef}
+          type="text"
+          value={query}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          onBlur={handleBlur}
+          placeholder="Search labels..."
+          autoComplete="off"
+          className="pl-8"
+        />
+      </div>
+
+      {isOpen && labels.length > 0 && (
+        <div className="absolute top-full left-0 w-full z-50 mt-1 rounded-md border bg-popover text-popover-foreground shadow-md">
+          <div className="max-h-[300px] overflow-y-auto p-1">
+            {labels.map((label, i) => {
+              const location = formatLabelLocation(label)
+              return (
+                <button
+                  type="button"
+                  key={label.id}
+                  className={`relative flex w-full cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none ${
+                    i === activeIndex
+                      ? 'bg-accent text-accent-foreground'
+                      : 'hover:bg-accent hover:text-accent-foreground'
+                  }`}
+                  onMouseDown={e => {
+                    e.preventDefault()
+                    handleSelect(label.slug)
+                  }}
+                  onMouseEnter={() => setActiveIndex(i)}
+                >
+                  <div className="flex w-full items-center justify-between gap-2">
+                    <span className="truncate">{label.name}</span>
+                    {location && (
+                      <span className="flex-shrink-0 text-xs text-muted-foreground">
+                        {location}
+                      </span>
+                    )}
+                  </div>
+                </button>
+              )
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/features/labels/components/index.ts
+++ b/frontend/features/labels/components/index.ts
@@ -1,3 +1,4 @@
 export { LabelCard } from './LabelCard'
 export { LabelDetail } from './LabelDetail'
 export { LabelList } from './LabelList'
+export { LabelSearch } from './LabelSearch'

--- a/frontend/features/labels/hooks/index.ts
+++ b/frontend/features/labels/hooks/index.ts
@@ -6,6 +6,8 @@ export {
   useLabelCatalog,
 } from './useLabels'
 
+export { useLabelSearch } from './useLabelSearch'
+
 export {
   type CreateLabelInput,
   type UpdateLabelInput,

--- a/frontend/features/labels/hooks/useLabelSearch.ts
+++ b/frontend/features/labels/hooks/useLabelSearch.ts
@@ -1,0 +1,14 @@
+'use client'
+
+import { createSearchHook } from '@/lib/hooks/factories'
+import { labelEndpoints, labelQueryKeys } from '@/features/labels/api'
+import type { LabelsListResponse } from '../types'
+
+/**
+ * Hook for searching labels with debounced input.
+ * Used for autocomplete in the labels browse page.
+ */
+export const useLabelSearch = createSearchHook<LabelsListResponse>(
+  labelEndpoints.SEARCH,
+  labelQueryKeys.search,
+)

--- a/frontend/features/labels/index.ts
+++ b/frontend/features/labels/index.ts
@@ -33,6 +33,7 @@ export {
   useArtistLabels,
   useLabelRoster,
   useLabelCatalog,
+  useLabelSearch,
 } from './hooks'
 
 export {
@@ -44,4 +45,4 @@ export {
 } from './hooks'
 
 // Components
-export { LabelCard, LabelDetail, LabelList } from './components'
+export { LabelCard, LabelDetail, LabelList, LabelSearch } from './components'


### PR DESCRIPTION
## Summary
- Add autocomplete search input to `/labels` browse page, matching the pattern on artist/venue/release browse pages
- New `useLabelSearch` hook using `createSearchHook` factory with existing `/labels/search` backend endpoint
- New `LabelSearch` component with keyboard navigation, debounced input, and label location display
- Labels was the only entity browse page without search

Closes PSY-379

## Test plan
- [ ] Visit `/labels` and verify search input appears above status filter tabs
- [ ] Type a label name and verify autocomplete dropdown shows matching results
- [ ] Verify keyboard navigation (arrow keys, enter, escape) works
- [ ] Verify clicking a result navigates to the label detail page
- [ ] Verify search integrates with existing status filter tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)