### PR TITLE
Add artist relationship derivation: shared labels, admin endpoint, background service

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -176,6 +176,10 @@ func main() {
 	radioFetchCtx, radioFetchCancel := context.WithCancel(context.Background())
 	sc.RadioFetch.Start(radioFetchCtx)
 
+	// Start relationship derivation service (background job for shared_bills + shared_label)
+	relDerivationCtx, relDerivationCancel := context.WithCancel(context.Background())
+	sc.RelationshipDerivation.Start(relDerivationCtx)
+
 	// Create HTTP server
 	srv := &http.Server{
 		Addr:    cfg.Server.Addr,
@@ -223,6 +227,10 @@ func main() {
 	// Stop radio fetch service
 	radioFetchCancel()
 	sc.RadioFetch.Stop()
+
+	// Stop relationship derivation service
+	relDerivationCancel()
+	sc.RelationshipDerivation.Stop()
 
 	// Shut down chromedp browser pool
 	sc.Fetcher.ShutdownChromedp()

--- a/backend/internal/api/handlers/artist_relationship.go
+++ b/backend/internal/api/handlers/artist_relationship.go
@@ -308,3 +308,59 @@ func (h *ArtistRelationshipHandler) DeleteRelationshipHandler(ctx context.Contex
 
 	return nil, nil
 }
+
+// ============================================================================
+// Derive Relationships (admin)
+// ============================================================================
+
+type DeriveRelationshipsRequest struct{}
+
+type DeriveRelationshipsResponse struct {
+	Body struct {
+		Success            bool  `json:"success"`
+		SharedBillsUpserted int64 `json:"shared_bills_upserted"`
+		SharedLabelsUpserted int64 `json:"shared_labels_upserted"`
+	}
+}
+
+func (h *ArtistRelationshipHandler) DeriveRelationshipsHandler(ctx context.Context, req *DeriveRelationshipsRequest) (*DeriveRelationshipsResponse, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+	if !user.IsAdmin {
+		return nil, huma.Error403Forbidden("Admin access required")
+	}
+
+	billsCount, err := h.relService.DeriveSharedBills(2)
+	if err != nil {
+		requestID := logger.GetRequestID(ctx)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to derive shared bills (request_id: %s): %v", requestID, err),
+		)
+	}
+
+	labelsCount, err := h.relService.DeriveSharedLabels(1)
+	if err != nil {
+		requestID := logger.GetRequestID(ctx)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to derive shared labels (request_id: %s): %v", requestID, err),
+		)
+	}
+
+	// Audit log (fire and forget)
+	if h.auditLog != nil {
+		go func() {
+			h.auditLog.LogAction(user.ID, "derive_artist_relationships", "system", 0, map[string]interface{}{
+				"shared_bills_upserted":  billsCount,
+				"shared_labels_upserted": labelsCount,
+			})
+		}()
+	}
+
+	resp := &DeriveRelationshipsResponse{}
+	resp.Body.Success = true
+	resp.Body.SharedBillsUpserted = billsCount
+	resp.Body.SharedLabelsUpserted = labelsCount
+	return resp, nil
+}

--- a/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
+++ b/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
@@ -178,6 +178,7 @@ type mockArtistRelationshipService struct {
 	removeVoteFn func(uint, uint, string, uint) (error)
 	getUserVoteFn func(uint, uint, string, uint) (*models.ArtistRelationshipVote, error)
 	deriveSharedBillsFn func(int) (int64, error)
+	deriveSharedLabelsFn func(int) (int64, error)
 }
 
 func (m *mockArtistRelationshipService) CreateRelationship(sourceID uint, targetID uint, relType string, autoDerived bool) (*models.ArtistRelationship, error) {
@@ -231,6 +232,12 @@ func (m *mockArtistRelationshipService) GetUserVote(artistA uint, artistB uint, 
 func (m *mockArtistRelationshipService) DeriveSharedBills(minShows int) (int64, error) {
 	if m.deriveSharedBillsFn != nil {
 		return m.deriveSharedBillsFn(minShows)
+	}
+	return 0, nil
+}
+func (m *mockArtistRelationshipService) DeriveSharedLabels(minLabels int) (int64, error) {
+	if m.deriveSharedLabelsFn != nil {
+		return m.deriveSharedLabelsFn(minLabels)
 	}
 	return 0, nil
 }

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -836,6 +836,9 @@ func setupArtistRelationshipRoutes(rc RouteContext) {
 
 	// Admin: delete relationships
 	huma.Delete(rc.Protected, "/artists/relationships/{source_id}/{target_id}", relHandler.DeleteRelationshipHandler)
+
+	// Admin: trigger relationship derivation
+	huma.Post(rc.Protected, "/admin/artist-relationships/derive", relHandler.DeriveRelationshipsHandler)
 }
 
 // setupSceneRoutes configures scene (city aggregation) endpoints.

--- a/backend/internal/services/catalog/artist_relationship_service.go
+++ b/backend/internal/services/catalog/artist_relationship_service.go
@@ -578,6 +578,86 @@ func (s *ArtistRelationshipService) DeriveSharedBills(minShows int) (int64, erro
 	return upserted, nil
 }
 
+// sharedLabelRow represents the result of the shared-labels co-occurrence query.
+type sharedLabelRow struct {
+	ArtistA      uint
+	ArtistB      uint
+	SharedCount  int
+	LabelNames   string
+}
+
+// DeriveSharedLabels computes shared_label relationships from the artist_labels join table.
+// Creates or updates relationships where artists share minLabels or more labels.
+func (s *ArtistRelationshipService) DeriveSharedLabels(minLabels int) (int64, error) {
+	if s.db == nil {
+		return 0, fmt.Errorf("database not initialized")
+	}
+
+	if minLabels <= 0 {
+		minLabels = 1
+	}
+
+	var rows []sharedLabelRow
+	err := s.db.Raw(`
+		SELECT
+			al1.artist_id AS artist_a,
+			al2.artist_id AS artist_b,
+			COUNT(DISTINCT al1.label_id) AS shared_count,
+			STRING_AGG(DISTINCT l.name, ', ' ORDER BY l.name) AS label_names
+		FROM artist_labels al1
+		JOIN artist_labels al2 ON al1.label_id = al2.label_id
+			AND al1.artist_id < al2.artist_id
+		JOIN labels l ON l.id = al1.label_id
+		GROUP BY al1.artist_id, al2.artist_id
+		HAVING COUNT(DISTINCT al1.label_id) >= ?
+	`, minLabels).Scan(&rows).Error
+
+	if err != nil {
+		return 0, fmt.Errorf("failed to query shared labels: %w", err)
+	}
+
+	var upserted int64
+
+	for _, row := range rows {
+		// Score: proportion of shared labels (cap at 1.0)
+		// More shared labels = stronger relationship
+		score := float32(math.Min(float64(row.SharedCount)/5.0, 1.0))
+
+		detail, _ := json.Marshal(map[string]interface{}{
+			"shared_count": row.SharedCount,
+			"label_names":  row.LabelNames,
+		})
+		detailRaw := json.RawMessage(detail)
+
+		// Upsert
+		var existing models.ArtistRelationship
+		err := s.db.Where("source_artist_id = ? AND target_artist_id = ? AND relationship_type = ?",
+			row.ArtistA, row.ArtistB, models.RelationshipTypeSharedLabel).First(&existing).Error
+
+		if err == gorm.ErrRecordNotFound {
+			rel := &models.ArtistRelationship{
+				SourceArtistID:   row.ArtistA,
+				TargetArtistID:   row.ArtistB,
+				RelationshipType: models.RelationshipTypeSharedLabel,
+				Score:            score,
+				AutoDerived:      true,
+				Detail:           &detailRaw,
+			}
+			if err := s.db.Create(rel).Error; err == nil {
+				upserted++
+			}
+		} else if err == nil {
+			s.db.Model(&existing).Updates(map[string]interface{}{
+				"score":  score,
+				"detail": &detailRaw,
+			})
+			upserted++
+		}
+	}
+
+	return upserted, nil
+}
+
 // ──────────────────────────────────────────────
 // Helpers
 // ──────────────────────────────────────────────

--- a/backend/internal/services/catalog/relationship_derivation_service.go
+++ b/backend/internal/services/catalog/relationship_derivation_service.go
@@ -1,0 +1,113 @@
+package catalog
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// DefaultDerivationInterval is the default interval for relationship derivation (24 hours).
+const DefaultDerivationInterval = 24 * time.Hour
+
+// RelationshipDerivationService is a background service that periodically derives
+// artist relationships from show co-occurrences (shared_bills) and label
+// co-occurrences (shared_label).
+//
+// It follows the same Start/Stop pattern as RadioFetchService and other background services.
+type RelationshipDerivationService struct {
+	relService *ArtistRelationshipService
+	interval   time.Duration
+
+	stopCh chan struct{}
+	wg     sync.WaitGroup
+	logger *slog.Logger
+}
+
+// NewRelationshipDerivationService creates a new relationship derivation background service.
+// Env vars:
+//   - RELATIONSHIP_DERIVATION_INTERVAL_HOURS (default 24)
+func NewRelationshipDerivationService(relService *ArtistRelationshipService) *RelationshipDerivationService {
+	interval := DefaultDerivationInterval
+	if envVal := os.Getenv("RELATIONSHIP_DERIVATION_INTERVAL_HOURS"); envVal != "" {
+		if hours, err := strconv.Atoi(envVal); err == nil && hours > 0 {
+			interval = time.Duration(hours) * time.Hour
+		}
+	}
+
+	return &RelationshipDerivationService{
+		relService: relService,
+		interval:   interval,
+		stopCh:     make(chan struct{}),
+		logger:     slog.Default(),
+	}
+}
+
+// Start begins the background derivation service.
+func (s *RelationshipDerivationService) Start(ctx context.Context) {
+	s.wg.Add(1)
+	go s.runLoop(ctx)
+
+	s.logger.Info("relationship derivation service started",
+		"interval_hours", s.interval.Hours(),
+	)
+}
+
+// Stop gracefully stops the derivation service.
+func (s *RelationshipDerivationService) Stop() {
+	close(s.stopCh)
+	s.wg.Wait()
+	s.logger.Info("relationship derivation service stopped")
+}
+
+// runLoop runs the periodic derivation cycle.
+func (s *RelationshipDerivationService) runLoop(ctx context.Context) {
+	defer s.wg.Done()
+
+	// Don't run immediately on startup — let the server initialize first.
+	// The admin endpoint can be used for immediate triggering.
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-s.stopCh:
+			return
+		case <-ticker.C:
+			s.RunDerivationCycle()
+		}
+	}
+}
+
+// RunDerivationCycle runs both shared_bills and shared_label derivation.
+// Exported for use by the admin trigger endpoint.
+func (s *RelationshipDerivationService) RunDerivationCycle() {
+	start := time.Now()
+	s.logger.Info("starting relationship derivation cycle")
+
+	// Derive shared bills (artists who share 2+ approved shows)
+	billsCount, err := s.relService.DeriveSharedBills(2)
+	if err != nil {
+		s.logger.Error("shared bills derivation failed", "error", err)
+	} else {
+		s.logger.Info("shared bills derivation complete", "upserted", billsCount)
+	}
+
+	// Derive shared labels (artists who share 1+ labels)
+	labelsCount, err := s.relService.DeriveSharedLabels(1)
+	if err != nil {
+		s.logger.Error("shared labels derivation failed", "error", err)
+	} else {
+		s.logger.Info("shared labels derivation complete", "upserted", labelsCount)
+	}
+
+	s.logger.Info("relationship derivation cycle complete",
+		"shared_bills_upserted", billsCount,
+		"shared_labels_upserted", labelsCount,
+		"duration", time.Since(start),
+	)
+}

--- a/backend/internal/services/container.go
+++ b/backend/internal/services/container.go
@@ -54,8 +54,9 @@ type ServiceContainer struct {
 	EntityReport  *adminsvc.EntityReportService
 	User              *usersvc.UserService
 	Leaderboard       *usersvc.LeaderboardService
-	Radio             *catalog.RadioService
-	RadioFetch        *catalog.RadioFetchService
+	Radio                  *catalog.RadioService
+	RadioFetch             *catalog.RadioFetchService
+	RelationshipDerivation *catalog.RelationshipDerivationService
 	Venue             *catalog.VenueService
 	VenueSourceConfig *pipeline.VenueSourceConfigService
 
@@ -131,6 +132,7 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 
 	revisionSvc := adminsvc.NewRevisionService(database)
 	radioSvc := catalog.NewRadioService(database)
+	artistRelSvc := catalog.NewArtistRelationshipService(database)
 
 	return &ServiceContainer{
 		// DB-only leaf services
@@ -150,7 +152,7 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 		Collection:    NewCollectionService(database),
 		Request:       NewRequestService(database),
 		Tag:                catalog.NewTagService(database),
-		ArtistRelationship: catalog.NewArtistRelationshipService(database),
+		ArtistRelationship: artistRelSvc,
 		Scene:              catalog.NewSceneService(database),
 		Attendance:         engagement.NewAttendanceService(database),
 		Comment:             engagement.NewCommentService(database),
@@ -168,9 +170,10 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 		EntityReport:  adminsvc.NewEntityReportService(database),
 		User:          userService,
 		Leaderboard:   usersvc.NewLeaderboardService(database),
-		Radio:             radioSvc,
-		RadioFetch:        catalog.NewRadioFetchService(radioSvc, discord),
-		Venue:             venue,
+		Radio:                  radioSvc,
+		RadioFetch:             catalog.NewRadioFetchService(radioSvc, discord),
+		RelationshipDerivation: catalog.NewRelationshipDerivationService(artistRelSvc),
+		Venue:                  venue,
 		VenueSourceConfig: venueSourceConfig,
 
 		// Config-only services

--- a/backend/internal/services/contracts/artist_relationship.go
+++ b/backend/internal/services/contracts/artist_relationship.go
@@ -68,4 +68,5 @@ type ArtistRelationshipServiceInterface interface {
 
 	// Auto-derivation
 	DeriveSharedBills(minShows int) (int64, error)
+	DeriveSharedLabels(minLabels int) (int64, error)
 }


### PR DESCRIPTION
## Summary
- Add `DeriveSharedLabels()` method mirroring `DeriveSharedBills()` — computes shared_label relationships from artist_labels join table
- Add admin endpoint `POST /admin/artist-relationships/derive` to trigger both derivations on demand
- Add `RelationshipDerivationService` background service (24h interval, configurable via `RELATIONSHIP_DERIVATION_INTERVAL_HOURS`)
- Wire into service container and server lifecycle

The graph visualization, voting system, and "Suggest similar artist" UI are all already built — this provides the data pipeline to populate them.

Closes PSY-375

## Test plan
- [ ] Run backend: `go build ./...` compiles clean
- [ ] Hit `POST /admin/artist-relationships/derive` as admin — verify it returns upserted counts
- [ ] Verify shared_bills relationships appear for artists sharing 2+ shows
- [ ] Verify shared_label relationships appear for artists sharing labels
- [ ] Verify background service logs derivation cycle after configured interval
- [ ] Verify artist graph visualization renders on artist detail pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)