### PR TITLE
Add venue link and tags display to show detail page

### DIFF
--- a/frontend/features/shows/components/ShowDetail.test.tsx
+++ b/frontend/features/shows/components/ShowDetail.test.tsx
@@ -85,6 +85,10 @@ vi.mock('@/features/collections', () => ({
   EntityCollections: () => <div data-testid="entity-collections" />,
 }))
 
+vi.mock('@/features/tags', () => ({
+  EntityTagList: () => <div data-testid="entity-tag-list" />,
+}))
+
 vi.mock('@/features/comments', () => ({
   CommentThread: ({ entityType, entityId }: { entityType: string; entityId: number }) => (
     <div data-testid="comment-thread">Comments for {entityType} {entityId}</div>

--- a/frontend/features/shows/components/ShowDetail.tsx
+++ b/frontend/features/shows/components/ShowDetail.tsx
@@ -12,6 +12,7 @@ import { formatShowDate, formatShowTime, formatPrice } from '@/lib/utils/formatt
 import { Button } from '@/components/ui/button'
 import { SocialLinks, MusicEmbed, SaveButton, Breadcrumb, AddToCollectionButton } from '@/components/shared'
 import { EntityCollections } from '@/features/collections'
+import { EntityTagList } from '@/features/tags'
 import { CommentThread, FieldNotesSection } from '@/features/comments'
 import { ShowForm } from '@/components/forms'
 import { Alert, AlertDescription } from '@/components/ui/alert'
@@ -242,6 +243,14 @@ export function ShowDetail({ showId }: ShowDetailProps) {
                     {venue.city}, {venue.state}
                   </span>
                 </div>
+                {venue.slug && (
+                  <Link
+                    href={`/venues/${venue.slug}`}
+                    className="inline-block text-sm text-muted-foreground hover:text-primary transition-colors mt-1"
+                  >
+                    See more shows at {venue.name} &rarr;
+                  </Link>
+                )}
               </div>
             )}
 
@@ -409,6 +418,13 @@ export function ShowDetail({ showId }: ShowDetailProps) {
           </div>
         </section>
       )}
+
+      {/* Tags */}
+      <EntityTagList
+        entityType="show"
+        entityId={show.id}
+        isAuthenticated={isAuthenticated}
+      />
 
       {/* In Collections */}
       <section className="mb-8">


### PR DESCRIPTION
## Summary
- Add "See more shows at [Venue Name] →" link below venue city/state on show detail
- Add `EntityTagList` component to show detail page (reuses existing polymorphic tag system)
- Scoped to quick wins — "Add to Collection" and music embeds were already implemented

Closes PSY-374

## Test plan
- [ ] Visit a show detail page with a venue that has a slug
- [ ] Verify "See more shows at [Venue] →" link appears and navigates to venue detail
- [ ] Verify tags section renders (may be empty if no tags applied yet)
- [ ] Verify existing show detail features (comments, field notes, collections) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)