### PR TITLE
Fix miscategorized tags: move non-genre tags to 'other' category

### DIFF
--- a/backend/db/migrations/000071_fix_tag_categories.down.sql
+++ b/backend/db/migrations/000071_fix_tag_categories.down.sql
@@ -1,0 +1,10 @@
+-- Revert tag category fixes: set back to 'genre'.
+
+UPDATE tags SET category = 'genre'
+WHERE name = 'multi-venue' AND category = 'other';
+
+UPDATE tags SET category = 'genre'
+WHERE name = 'urban festival' AND category = 'other';
+
+UPDATE tags SET category = 'genre'
+WHERE name = 'shoegaze-revival-2026' AND category = 'other';

--- a/backend/db/migrations/000071_fix_tag_categories.up.sql
+++ b/backend/db/migrations/000071_fix_tag_categories.up.sql
@@ -1,0 +1,11 @@
+-- Fix miscategorized tags: these were seeded as 'genre' but should be 'other'.
+-- Safe to run in any environment — no-op if the tags don't exist or are already correct.
+
+UPDATE tags SET category = 'other'
+WHERE name = 'multi-venue' AND category = 'genre';
+
+UPDATE tags SET category = 'other'
+WHERE name = 'urban festival' AND category = 'genre';
+
+UPDATE tags SET category = 'other'
+WHERE name = 'shoegaze-revival-2026' AND category = 'genre';


### PR DESCRIPTION
## Summary
- Migration 000071: Update category from 'genre' to 'other' for three miscategorized tags
  - "multi-venue" (not a genre)
  - "urban festival" (not a genre)
  - "shoegaze-revival-2026" (test data)
- Each UPDATE is guarded with `AND category = 'genre'` — safe no-op if tags don't exist or are already fixed

Closes PSY-380

## Test plan
- [ ] Run migration up: verify no errors (even on DBs where tags don't exist)
- [ ] On stage/prod: verify the three tags have category 'other' after migration
- [ ] Run migration down: verify tags revert to 'genre'

🤖 Generated with [Claude Code](https://claude.com/claude-code)