### PR TITLE
Rename misleading chart headings to match actual data (PSY-343)

### DIFF
--- a/frontend/app/charts/page.tsx
+++ b/frontend/app/charts/page.tsx
@@ -4,13 +4,13 @@ import { ChartsPage } from '@/features/charts'
 
 export const metadata = {
   title: 'Charts',
-  description: 'Top charts — trending shows, popular artists, active venues, and hot releases.',
+  description: 'Upcoming shows, popular artists, active venues, and recent releases.',
   alternates: {
     canonical: 'https://psychichomily.com/charts',
   },
   openGraph: {
     title: 'Charts | Psychic Homily',
-    description: 'Top charts — trending shows, popular artists, active venues, and hot releases.',
+    description: 'Upcoming shows, popular artists, active venues, and recent releases.',
     url: '/charts',
     type: 'website',
   },
@@ -22,7 +22,7 @@ export default function ChartsRoute() {
       <main className="w-full max-w-6xl px-4 py-8 md:px-8">
         <h1 className="text-3xl font-bold text-center mb-2">Charts</h1>
         <p className="text-center text-muted-foreground mb-8 max-w-lg mx-auto">
-          Trending shows, popular artists, active venues, and hot releases.
+          Upcoming shows, popular artists, active venues, and recent releases.
         </p>
         <Suspense
           fallback={

--- a/frontend/features/charts/components/ChartsPage.test.tsx
+++ b/frontend/features/charts/components/ChartsPage.test.tsx
@@ -100,10 +100,10 @@ describe('ChartsPage', () => {
     })
 
     // Section headings appear in both tabs and card headers — use getAllByText
-    expect(screen.getAllByText('Trending Shows').length).toBeGreaterThanOrEqual(2)
+    expect(screen.getAllByText('Upcoming Shows').length).toBeGreaterThanOrEqual(2)
     expect(screen.getAllByText('Popular Artists').length).toBeGreaterThanOrEqual(2)
     expect(screen.getAllByText('Active Venues').length).toBeGreaterThanOrEqual(2)
-    expect(screen.getAllByText('Hot Releases').length).toBeGreaterThanOrEqual(2)
+    expect(screen.getAllByText('Recent Releases').length).toBeGreaterThanOrEqual(2)
   })
 
   it('renders entity names as links', async () => {
@@ -155,7 +155,7 @@ describe('ChartsPage', () => {
     })
 
     // Get tab buttons (first match in the tab bar, not the card header)
-    const trendingButtons = screen.getAllByRole('button', { name: /Trending Shows/i })
+    const trendingButtons = screen.getAllByRole('button', { name: /Upcoming Shows/i })
     const tabButton = trendingButtons[0]
 
     mockApiRequest.mockResolvedValueOnce({
@@ -179,7 +179,7 @@ describe('ChartsPage', () => {
     await user.click(tabButton)
 
     await waitFor(() => {
-      expect(screen.getByText('Shows with the most going and interested activity.')).toBeInTheDocument()
+      expect(screen.getByText('Shows coming up soon, ordered by date.')).toBeInTheDocument()
     })
   })
 
@@ -239,7 +239,7 @@ describe('ChartsPage', () => {
       expect(screen.getByText('Eternal Drift')).toBeInTheDocument()
     })
 
-    const releasesTab = screen.getAllByRole('button', { name: /Hot Releases/i })[0]
+    const releasesTab = screen.getAllByRole('button', { name: /Recent Releases/i })[0]
 
     mockApiRequest.mockResolvedValueOnce({
       releases: [mockOverviewData.hot_releases[0]],
@@ -248,7 +248,7 @@ describe('ChartsPage', () => {
     await user.click(releasesTab)
 
     await waitFor(() => {
-      expect(screen.getByText('Most bookmarked releases right now.')).toBeInTheDocument()
+      expect(screen.getByText('Recently added releases.')).toBeInTheDocument()
     })
   })
 
@@ -269,11 +269,11 @@ describe('ChartsPage', () => {
     })
 
     // Switch to trending shows detail
-    const trendingTab = screen.getAllByRole('button', { name: /Trending Shows/i })[0]
+    const trendingTab = screen.getAllByRole('button', { name: /Upcoming Shows/i })[0]
     await user.click(trendingTab)
 
     await waitFor(() => {
-      expect(screen.getByText('Shows with the most going and interested activity.')).toBeInTheDocument()
+      expect(screen.getByText('Shows coming up soon, ordered by date.')).toBeInTheDocument()
     })
 
     // Third call: overview data again when switching back
@@ -300,12 +300,12 @@ describe('ChartsPage', () => {
     renderWithProviders(<ChartsPage />)
 
     await waitFor(() => {
-      expect(screen.getByText('No trending shows right now.')).toBeInTheDocument()
+      expect(screen.getByText('No upcoming shows right now.')).toBeInTheDocument()
     })
 
     expect(screen.getByText('No popular artists right now.')).toBeInTheDocument()
     expect(screen.getByText('No active venues right now.')).toBeInTheDocument()
-    expect(screen.getByText('No hot releases right now.')).toBeInTheDocument()
+    expect(screen.getByText('No recent releases yet.')).toBeInTheDocument()
   })
 
   it('renders all tab buttons', () => {
@@ -315,9 +315,9 @@ describe('ChartsPage', () => {
 
     expect(screen.getByRole('button', { name: /Overview/i })).toBeInTheDocument()
     // Tab buttons exist (may also appear as card headings)
-    expect(screen.getAllByRole('button', { name: /Trending Shows/i }).length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByRole('button', { name: /Upcoming Shows/i }).length).toBeGreaterThanOrEqual(1)
     expect(screen.getAllByRole('button', { name: /Popular Artists/i }).length).toBeGreaterThanOrEqual(1)
     expect(screen.getAllByRole('button', { name: /Active Venues/i }).length).toBeGreaterThanOrEqual(1)
-    expect(screen.getAllByRole('button', { name: /Hot Releases/i }).length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByRole('button', { name: /Recent Releases/i }).length).toBeGreaterThanOrEqual(1)
   })
 })

--- a/frontend/features/charts/components/ChartsPage.tsx
+++ b/frontend/features/charts/components/ChartsPage.tsx
@@ -18,10 +18,10 @@ import type { ChartView } from '../types'
 
 const views: { id: ChartView; label: string; icon: typeof Flame }[] = [
   { id: 'overview', label: 'Overview', icon: Flame },
-  { id: 'trending-shows', label: 'Trending Shows', icon: Flame },
+  { id: 'trending-shows', label: 'Upcoming Shows', icon: Flame },
   { id: 'popular-artists', label: 'Popular Artists', icon: Mic2 },
   { id: 'active-venues', label: 'Active Venues', icon: MapPin },
-  { id: 'hot-releases', label: 'Hot Releases', icon: Disc3 },
+  { id: 'hot-releases', label: 'Recent Releases', icon: Disc3 },
 ]
 
 export function ChartsPage() {
@@ -53,7 +53,7 @@ export function ChartsPage() {
       {activeView === 'overview' ? (
         <OverviewGrid onViewAll={setActiveView} />
       ) : activeView === 'trending-shows' ? (
-        <DetailView title="Trending Shows" description="Shows with the most going and interested activity.">
+        <DetailView title="Upcoming Shows" description="Shows coming up soon, ordered by date.">
           <TrendingShowsDetail />
         </DetailView>
       ) : activeView === 'popular-artists' ? (
@@ -65,7 +65,7 @@ export function ChartsPage() {
           <ActiveVenuesDetail />
         </DetailView>
       ) : (
-        <DetailView title="Hot Releases" description="Most bookmarked releases right now.">
+        <DetailView title="Recent Releases" description="Recently added releases.">
           <HotReleasesDetail />
         </DetailView>
       )}
@@ -99,7 +99,7 @@ function OverviewGrid({ onViewAll }: { onViewAll: (view: ChartView) => void }) {
   return (
     <div className="grid gap-6 md:grid-cols-2">
       <ChartCard
-        title="Trending Shows"
+        title="Upcoming Shows"
         icon={Flame}
         onViewAll={() => onViewAll('trending-shows')}
       >
@@ -120,7 +120,7 @@ function OverviewGrid({ onViewAll }: { onViewAll: (view: ChartView) => void }) {
         <ActiveVenuesList venues={data.active_venues} compact />
       </ChartCard>
       <ChartCard
-        title="Hot Releases"
+        title="Recent Releases"
         icon={Disc3}
         onViewAll={() => onViewAll('hot-releases')}
       >

--- a/frontend/features/charts/components/HotReleasesList.tsx
+++ b/frontend/features/charts/components/HotReleasesList.tsx
@@ -13,7 +13,7 @@ export function HotReleasesList({ releases, compact = false }: HotReleasesListPr
   if (releases.length === 0) {
     return (
       <p className="text-sm text-muted-foreground py-4 text-center">
-        No hot releases right now.
+        No recent releases yet.
       </p>
     )
   }

--- a/frontend/features/charts/components/TrendingShowsList.tsx
+++ b/frontend/features/charts/components/TrendingShowsList.tsx
@@ -13,7 +13,7 @@ export function TrendingShowsList({ shows, compact = false }: TrendingShowsListP
   if (shows.length === 0) {
     return (
       <p className="text-sm text-muted-foreground py-4 text-center">
-        No trending shows right now.
+        No upcoming shows right now.
       </p>
     )
   }


### PR DESCRIPTION
## Summary
- Rename "Trending Shows" → "Upcoming Shows" (sorted by date, not engagement) and "Hot Releases" → "Recent Releases" (sorted by `created_at`, not bookmarks)
- Update section descriptions, tab labels, empty-state copy, page metadata, and test assertions to match
- Backend queries and internal view IDs unchanged — copy-only fix

## Why
PR #327 (PSY-323) switched the bookmark join to `LEFT JOIN` to fix empty sections, which made items with zero engagement appear as "trending" or "hot". Prior-art research in `docs/strategy/charts-and-trending.md` confirmed no platform labels zero-engagement items that way.

## Test plan
- [x] `bun run test:run features/charts/components/ChartsPage.test.tsx` — 10/10 pass
- [x] `bun run build` — clean
- [ ] Visual smoke: load `/charts`, confirm headings + tabs read "Upcoming Shows" / "Recent Releases"

Closes PSY-343

🤖 Generated with [Claude Code](https://claude.com/claude-code)