### PR TITLE
Add CI lint for duplicate migration versions (PSY-410)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,44 @@ on:
     branches: [main]
 
 jobs:
+  migration-lint:
+    name: Migration Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for duplicate migration version numbers
+        run: |
+          DUPS=$(ls backend/db/migrations/*.up.sql \
+                 | sed -E 's|.*/([0-9]+)_.*|\1|' \
+                 | sort | uniq -d)
+          if [ -n "$DUPS" ]; then
+            echo "ERROR: duplicate migration version number(s) detected:"
+            for v in $DUPS; do
+              echo "  version $v:"
+              ls backend/db/migrations/${v}_*.up.sql | sed 's|^|    |'
+            done
+            echo ""
+            echo "golang-migrate refuses to start with duplicate versions."
+            echo "Rename one of the conflicting migrations to a new, higher version."
+            exit 1
+          fi
+
+      - name: Check every up.sql has a matching down.sql
+        run: |
+          MISSING=""
+          for up in backend/db/migrations/*.up.sql; do
+            down="${up%.up.sql}.down.sql"
+            if [ ! -f "$down" ]; then
+              MISSING="$MISSING $up"
+            fi
+          done
+          if [ -n "$MISSING" ]; then
+            echo "ERROR: up migrations without matching down migration:"
+            for m in $MISSING; do echo "  $m"; done
+            exit 1
+          fi
+
   backend-tests:
     name: Backend Tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- New \`migration-lint\` job added to \`.github/workflows/ci.yml\`, runs on every PR and push to main
- Check 1: fails if any version number appears on multiple \`.up.sql\` files (would have caught the 000071 collision)
- Check 2: fails if any \`.up.sql\` lacks a matching \`.down.sql\`

## Why

PR #353 + PR #356 both landed migrations numbered 000071 because:
1. golang-migrate has no built-in duplicate-version detection ([upstream issue #720](https://github.com/golang-migrate/migrate/issues/720))
2. Local test helper runs both dupes alphabetically so tests passed
3. Post-merge E2E (where real migrate CLI runs) wasn't gating merges (see PSY-411)

This ticket plugs the first hole. PSY-411 and PSY-412 plug the others.

## Test plan
- [x] Run lint against current main locally → passes (no duplicates)
- [x] Inject a synthetic duplicate → lint correctly fails
- [x] Inject a missing \`.down.sql\` → lint correctly fails
- [ ] CI passes on this PR
- [ ] Manually confirm via a follow-up synthetic dupe PR that CI fails (deferred, can be done anytime)

Closes PSY-410

🤖 Generated with [Claude Code](https://claude.com/claude-code)