### PR TITLE
PSY-430: pin mutating E2E tests to reserved seeded rows

### DIFF
--- a/frontend/app/library/page.tsx
+++ b/frontend/app/library/page.tsx
@@ -185,7 +185,10 @@ function SavedShowCard({ show }: { show: SavedShowResponse }) {
   const artists = show.artists
 
   return (
-    <article className="border-b border-border/50 py-4 -mx-3 px-3 rounded-lg hover:bg-muted/30 transition-colors duration-200">
+    <article
+      aria-label={show.title}
+      className="border-b border-border/50 py-4 -mx-3 px-3 rounded-lg hover:bg-muted/30 transition-colors duration-200"
+    >
       <div className="flex items-start justify-between gap-3">
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 mb-1">

--- a/frontend/e2e/pages/collection.spec.ts
+++ b/frontend/e2e/pages/collection.spec.ts
@@ -66,21 +66,19 @@ test.describe('Library page (formerly /collection)', () => {
   test('shows saved show after saving one', async ({
     authenticatedPage,
   }) => {
-    // Navigate to shows list and open a show detail
-    await authenticatedPage.goto('/shows')
-    await expect(authenticatedPage.locator('article').first()).toBeVisible({
-      timeout: 10_000,
-    })
+    // PSY-430: pin to a reserved show seeded by setup-db.sh so parallel
+    // mutating tests in other files don't race on the same .first() row.
+    const reservedShowSlug = 'e2e-collection-saved-show'
+    const reservedShowTitle = 'E2E [collection-saved-show]'
+    const showUrl = `/shows/${reservedShowSlug}`
 
-    await authenticatedPage
-      .locator('article')
-      .first()
-      .getByRole('link', { name: 'Details' })
-      .click()
-    await authenticatedPage.waitForURL(/\/shows\//, { timeout: 10_000 })
-
+    await authenticatedPage.goto(showUrl)
+    // Breadcrumb shows the show title; the H1 is the headlining artist name,
+    // so we verify the right show loaded via the breadcrumb.
     await expect(
-      authenticatedPage.getByRole('heading', { level: 1 })
+      authenticatedPage
+        .getByRole('navigation', { name: 'Breadcrumb' })
+        .getByText(reservedShowTitle)
     ).toBeVisible({ timeout: 10_000 })
 
     // Save the show and wait for API response
@@ -105,31 +103,32 @@ test.describe('Library page (formerly /collection)', () => {
       authenticatedPage.getByRole('button', { name: 'Remove from My List' })
     ).toBeVisible({ timeout: 5_000 })
 
-    // Remember the show URL for cleanup
-    const showUrl = authenticatedPage.url()
-
     // Navigate to library
     await authenticatedPage.goto('/library')
     await expect(
       authenticatedPage.getByRole('heading', { name: /^library$/i })
     ).toBeVisible({ timeout: 10_000 })
 
-    // At least one show card should be visible
-    await expect(authenticatedPage.locator('article').first()).toBeVisible({
-      timeout: 5_000,
+    // The reserved show we just saved should appear in the library.
+    // Uses aria-label on <article> (added in this PR for testability + a11y).
+    const savedCard = authenticatedPage.getByRole('article', {
+      name: reservedShowTitle,
     })
+    await expect(savedCard).toBeVisible({ timeout: 5_000 })
+    // The card links to the show detail page via the artist name.
     await expect(
-      authenticatedPage
-        .locator('article')
-        .first()
-        .getByRole('link', { name: 'Details' })
+      savedCard.locator(`a[href="/shows/${reservedShowSlug}"]`)
     ).toBeVisible()
 
     // Clean up: go back to the show and unsave it (wait for API response
     // so the DELETE completes before the test ends and the page closes)
     await authenticatedPage.goto(showUrl)
+    // Breadcrumb shows the show title; the H1 is the headlining artist name,
+    // so we verify the right show loaded via the breadcrumb.
     await expect(
-      authenticatedPage.getByRole('heading', { level: 1 })
+      authenticatedPage
+        .getByRole('navigation', { name: 'Breadcrumb' })
+        .getByText(reservedShowTitle)
     ).toBeVisible({ timeout: 10_000 })
 
     await Promise.all([

--- a/frontend/e2e/pages/favorite-venue.spec.ts
+++ b/frontend/e2e/pages/favorite-venue.spec.ts
@@ -1,5 +1,11 @@
 import { test, expect } from '../fixtures'
 
+// PSY-430: pin to a reserved venue seeded by setup-db.sh so parallel
+// mutating tests in other files don't race on the same .first() row.
+const RESERVED_VENUE_SLUG = 'e2e-favorite-venue-test'
+const RESERVED_VENUE_NAME = 'E2E [favorite-venue-test]'
+const RESERVED_VENUE_URL = `/venues/${RESERVED_VENUE_SLUG}`
+
 test.describe('Favorite venue', () => {
   // Tests share DB state (same user favoriting/unfavoriting the same venue),
   // so they must not run in parallel
@@ -7,19 +13,12 @@ test.describe('Favorite venue', () => {
   test('favorite button is hidden when not authenticated', async ({
     page,
   }) => {
-    // Navigate to a venue detail page
-    await page.goto('/venues')
-    await expect(
-      page.locator('a[href^="/venues/"]').first()
-    ).toBeVisible({ timeout: 10_000 })
-
-    await page.locator('a[href^="/venues/"]').first().click()
-    await page.waitForURL(/\/venues\//, { timeout: 10_000 })
+    await page.goto(RESERVED_VENUE_URL)
 
     // Wait for venue detail to load
-    await expect(page.getByRole('heading', { level: 1 })).toBeVisible({
-      timeout: 10_000,
-    })
+    await expect(
+      page.getByRole('heading', { level: 1, name: RESERVED_VENUE_NAME })
+    ).toBeVisible({ timeout: 10_000 })
 
     // Favorite button should NOT be visible when unauthenticated
     await expect(
@@ -32,21 +31,14 @@ test.describe('Favorite venue', () => {
   test('can favorite and unfavorite a venue from detail page', async ({
     authenticatedPage,
   }) => {
-    // Navigate to a venue detail page
-    await authenticatedPage.goto('/venues')
-    await expect(
-      authenticatedPage.locator('a[href^="/venues/"]').first()
-    ).toBeVisible({ timeout: 10_000 })
-
-    await authenticatedPage
-      .locator('a[href^="/venues/"]')
-      .first()
-      .click()
-    await authenticatedPage.waitForURL(/\/venues\//, { timeout: 10_000 })
+    await authenticatedPage.goto(RESERVED_VENUE_URL)
 
     // Wait for venue detail to load
     await expect(
-      authenticatedPage.getByRole('heading', { level: 1 })
+      authenticatedPage.getByRole('heading', {
+        level: 1,
+        name: RESERVED_VENUE_NAME,
+      })
     ).toBeVisible({ timeout: 10_000 })
 
     // Favorite button should be visible
@@ -96,26 +88,12 @@ test.describe('Favorite venue', () => {
   test('favorited venue appears in library venues tab', async ({
     authenticatedPage,
   }) => {
-    // Navigate to a venue detail page
-    await authenticatedPage.goto('/venues')
+    await authenticatedPage.goto(RESERVED_VENUE_URL)
     await expect(
-      authenticatedPage.locator('a[href^="/venues/"]').first()
-    ).toBeVisible({ timeout: 10_000 })
-
-    // Capture venue name for later assertion
-    const venueName = await authenticatedPage
-      .locator('a[href^="/venues/"]')
-      .first()
-      .textContent()
-
-    await authenticatedPage
-      .locator('a[href^="/venues/"]')
-      .first()
-      .click()
-    await authenticatedPage.waitForURL(/\/venues\//, { timeout: 10_000 })
-
-    await expect(
-      authenticatedPage.getByRole('heading', { level: 1 })
+      authenticatedPage.getByRole('heading', {
+        level: 1,
+        name: RESERVED_VENUE_NAME,
+      })
     ).toBeVisible({ timeout: 10_000 })
 
     // Favorite the venue and wait for API response
@@ -141,24 +119,29 @@ test.describe('Favorite venue', () => {
       })
     ).toBeVisible({ timeout: 5_000 })
 
-    // Remember the venue URL for cleanup
-    const venueUrl = authenticatedPage.url()
-
     // Navigate to library venues tab (PSY-275: favorites merged into venues tab on /library)
     await authenticatedPage.goto('/library?tab=venues')
     await expect(
       authenticatedPage.getByRole('heading', { name: /^library$/i })
     ).toBeVisible({ timeout: 10_000 })
 
-    // The venue name should appear (not the empty state)
+    // The reserved venue name should appear (not the empty state).
+    // .first() because the venue may render in both Favorite and Followed
+    // sections of the venues tab — either is sufficient evidence the favorite
+    // landed.
     await expect(
-      authenticatedPage.getByText(venueName!)
+      authenticatedPage
+        .getByRole('link', { name: RESERVED_VENUE_NAME })
+        .first()
     ).toBeVisible({ timeout: 5_000 })
 
     // Clean up: navigate back to venue and unfavorite
-    await authenticatedPage.goto(venueUrl)
+    await authenticatedPage.goto(RESERVED_VENUE_URL)
     await expect(
-      authenticatedPage.getByRole('heading', { level: 1 })
+      authenticatedPage.getByRole('heading', {
+        level: 1,
+        name: RESERVED_VENUE_NAME,
+      })
     ).toBeVisible({ timeout: 10_000 })
 
     await Promise.all([

--- a/frontend/e2e/pages/save-show.spec.ts
+++ b/frontend/e2e/pages/save-show.spec.ts
@@ -1,27 +1,24 @@
 import { test, expect } from '../fixtures'
 
+// PSY-430: pin to a reserved show seeded by setup-db.sh so parallel
+// mutating tests in other files don't race on the same .first() row.
+const RESERVED_SHOW_SLUG = 'e2e-save-show-test'
+const RESERVED_SHOW_TITLE = 'E2E [save-show-test]'
+const RESERVED_SHOW_URL = `/shows/${RESERVED_SHOW_SLUG}`
+
 test.describe('Save/unsave a show', () => {
   // Tests share DB state (same user saving/unsaving the same show),
   // so they must not run in parallel
   test.describe.configure({ mode: 'serial' })
   test('save button is hidden when not authenticated', async ({ page }) => {
-    await page.goto('/shows')
-    await expect(page.locator('article').first()).toBeVisible({
-      timeout: 10_000,
-    })
+    await page.goto(RESERVED_SHOW_URL)
 
-    await page
-      .locator('article')
-      .first()
-      .locator('a[href^="/shows/"]')
-      .first()
-      .click()
-    await page.waitForURL(/\/shows\//, { timeout: 10_000 })
-
-    // Wait for show detail to load
-    await expect(page.getByRole('heading', { level: 1 })).toBeVisible({
-      timeout: 10_000,
-    })
+    // Wait for show detail to load (breadcrumb confirms the right show)
+    await expect(
+      page
+        .getByRole('navigation', { name: 'Breadcrumb' })
+        .getByText(RESERVED_SHOW_TITLE)
+    ).toBeVisible({ timeout: 10_000 })
 
     // Save button should NOT be visible when unauthenticated
     await expect(
@@ -32,22 +29,15 @@ test.describe('Save/unsave a show', () => {
   test('can save and unsave a show from detail page', async ({
     authenticatedPage,
   }) => {
-    await authenticatedPage.goto('/shows')
-    await expect(authenticatedPage.locator('article').first()).toBeVisible({
-      timeout: 10_000,
-    })
-
-    await authenticatedPage
-      .locator('article')
-      .first()
-      .locator('a[href^="/shows/"]')
-      .first()
-      .click()
-    await authenticatedPage.waitForURL(/\/shows\//, { timeout: 10_000 })
+    await authenticatedPage.goto(RESERVED_SHOW_URL)
 
     // Wait for detail page to load
+    // Breadcrumb shows the show title; the H1 is the headlining artist name,
+    // so we verify the right show loaded via the breadcrumb.
     await expect(
-      authenticatedPage.getByRole('heading', { level: 1 })
+      authenticatedPage
+        .getByRole('navigation', { name: 'Breadcrumb' })
+        .getByText(RESERVED_SHOW_TITLE)
     ).toBeVisible({ timeout: 10_000 })
 
     // Save button should be visible and show "Add to My List"
@@ -88,22 +78,13 @@ test.describe('Save/unsave a show', () => {
   test('save state persists after navigation', async ({
     authenticatedPage,
   }) => {
-    await authenticatedPage.goto('/shows')
-    await expect(authenticatedPage.locator('article').first()).toBeVisible({
-      timeout: 10_000,
-    })
-
-    // Navigate to first show detail
-    await authenticatedPage
-      .locator('article')
-      .first()
-      .locator('a[href^="/shows/"]')
-      .first()
-      .click()
-    await authenticatedPage.waitForURL(/\/shows\//, { timeout: 10_000 })
-
+    await authenticatedPage.goto(RESERVED_SHOW_URL)
+    // Breadcrumb shows the show title; the H1 is the headlining artist name,
+    // so we verify the right show loaded via the breadcrumb.
     await expect(
-      authenticatedPage.getByRole('heading', { level: 1 })
+      authenticatedPage
+        .getByRole('navigation', { name: 'Breadcrumb' })
+        .getByText(RESERVED_SHOW_TITLE)
     ).toBeVisible({ timeout: 10_000 })
 
     // Save the show and wait for the API response to complete
@@ -125,9 +106,6 @@ test.describe('Save/unsave a show', () => {
       authenticatedPage.getByRole('button', { name: 'Remove from My List' })
     ).toBeVisible({ timeout: 5_000 })
 
-    // Remember the URL so we can come back
-    const showUrl = authenticatedPage.url()
-
     // Navigate away via the breadcrumb link
     await authenticatedPage
       .locator('nav[aria-label="Breadcrumb"]')
@@ -136,9 +114,13 @@ test.describe('Save/unsave a show', () => {
     await authenticatedPage.waitForURL(/\/shows$/, { timeout: 10_000 })
 
     // Navigate back to the same show
-    await authenticatedPage.goto(showUrl)
+    await authenticatedPage.goto(RESERVED_SHOW_URL)
+    // Breadcrumb shows the show title; the H1 is the headlining artist name,
+    // so we verify the right show loaded via the breadcrumb.
     await expect(
-      authenticatedPage.getByRole('heading', { level: 1 })
+      authenticatedPage
+        .getByRole('navigation', { name: 'Breadcrumb' })
+        .getByText(RESERVED_SHOW_TITLE)
     ).toBeVisible({ timeout: 10_000 })
 
     // Should still be saved

--- a/frontend/e2e/pages/show-list-actions.spec.ts
+++ b/frontend/e2e/pages/show-list-actions.spec.ts
@@ -19,10 +19,16 @@ test.describe('Show list actions', () => {
   }) => {
     await authenticatedPage.goto('/shows')
 
-    const firstShow = authenticatedPage.locator('article').first()
-    await expect(firstShow).toBeVisible({ timeout: 10_000 })
+    // PSY-430: pin to a reserved show seeded by setup-db.sh so parallel
+    // mutating tests in other files don't race on the same .first() row.
+    // The aria-label on ShowCard's <article> exposes show.title as the
+    // accessible name, so getByRole('article', { name }) finds it directly.
+    const reservedShow = authenticatedPage.getByRole('article', {
+      name: 'E2E [list-actions-test]',
+    })
+    await expect(reservedShow).toBeVisible({ timeout: 10_000 })
 
-    const saveButton = firstShow.locator(
+    const saveButton = reservedShow.locator(
       'button[aria-label="Add to My List"], button[aria-label="Remove from My List"]'
     )
     await expect(saveButton).toBeVisible()
@@ -51,7 +57,7 @@ test.describe('Show list actions', () => {
     ])
     expect(firstToggleResponse.status()).toBeLessThan(400)
     await expect(
-      firstShow.getByRole('button', { name: firstExpectedLabel })
+      reservedShow.getByRole('button', { name: firstExpectedLabel })
     ).toBeVisible({ timeout: 5_000 })
 
     // Cleanup: toggle back so test state is stable.
@@ -63,11 +69,11 @@ test.describe('Show list actions', () => {
           resp.request().method() === secondToggleMethod,
         { timeout: 10_000 }
       ),
-      firstShow.getByRole('button', { name: firstExpectedLabel }).click(),
+      reservedShow.getByRole('button', { name: firstExpectedLabel }).click(),
     ])
     expect(secondToggleResponse.status()).toBeLessThan(400)
     await expect(
-      firstShow.getByRole('button', { name: initialLabel || 'Add to My List' })
+      reservedShow.getByRole('button', { name: initialLabel || 'Add to My List' })
     ).toBeVisible({ timeout: 5_000 })
   })
 

--- a/frontend/e2e/setup-db.sh
+++ b/frontend/e2e/setup-db.sh
@@ -233,6 +233,74 @@ BEGIN
 END $$;
 SQL
 
+echo "==> Inserting reserved E2E rows for mutating tests (PSY-430)..."
+# Reserved rows that mutating E2E tests target by stable title/slug, so
+# parallel workers in different files don't race on the same .first() row.
+# Convention: title prefixed with "E2E [<purpose>]", slug pre-set so the
+# backfill below skips them and the slug is stable across CI runs.
+psql -v ON_ERROR_STOP=1 "$E2E_DB_URL" <<'SQL'
+INSERT INTO venues (name, address, city, state, zipcode, verified, created_at, updated_at, slug)
+VALUES (
+  'E2E [favorite-venue-test]',
+  '100 Reserved Way', 'Phoenix', 'AZ', '85001',
+  true, NOW(), NOW(), 'e2e-favorite-venue-test'
+)
+ON CONFLICT DO NOTHING;
+
+DO $$
+DECLARE
+  v_id INTEGER;
+  a_id INTEGER;
+  s_id INTEGER;
+BEGIN
+  SELECT id INTO v_id FROM venues WHERE slug = 'e2e-favorite-venue-test';
+  SELECT id INTO a_id FROM artists ORDER BY id LIMIT 1;
+
+  -- Plain INSERTs (no ON CONFLICT): the e2e DB is wiped per-run by Docker,
+  -- so duplicates are impossible. The slug unique index is partial
+  -- (WHERE slug IS NOT NULL), which makes ON CONFLICT (slug) awkward.
+
+  -- collection.spec.ts "shows saved show after saving one"
+  INSERT INTO shows (title, event_date, city, state, status, slug, created_at, updated_at)
+  VALUES (
+    'E2E [collection-saved-show]',
+    NOW() + INTERVAL '1 hour',
+    'Phoenix', 'AZ', 'approved',
+    'e2e-collection-saved-show',
+    NOW(), NOW()
+  )
+  RETURNING id INTO s_id;
+  INSERT INTO show_venues (show_id, venue_id) VALUES (s_id, v_id);
+  INSERT INTO show_artists (show_id, artist_id, position, set_type) VALUES (s_id, a_id, 0, 'headliner');
+
+  -- save-show.spec.ts (both mutating tests)
+  INSERT INTO shows (title, event_date, city, state, status, slug, created_at, updated_at)
+  VALUES (
+    'E2E [save-show-test]',
+    NOW() + INTERVAL '2 hours',
+    'Phoenix', 'AZ', 'approved',
+    'e2e-save-show-test',
+    NOW(), NOW()
+  )
+  RETURNING id INTO s_id;
+  INSERT INTO show_venues (show_id, venue_id) VALUES (s_id, v_id);
+  INSERT INTO show_artists (show_id, artist_id, position, set_type) VALUES (s_id, a_id, 0, 'headliner');
+
+  -- show-list-actions.spec.ts "toggle save state from list cards"
+  INSERT INTO shows (title, event_date, city, state, status, slug, created_at, updated_at)
+  VALUES (
+    'E2E [list-actions-test]',
+    NOW() + INTERVAL '3 hours',
+    'Phoenix', 'AZ', 'approved',
+    'e2e-list-actions-test',
+    NOW(), NOW()
+  )
+  RETURNING id INTO s_id;
+  INSERT INTO show_venues (show_id, venue_id) VALUES (s_id, v_id);
+  INSERT INTO show_artists (show_id, artist_id, position, set_type) VALUES (s_id, a_id, 0, 'headliner');
+END $$;
+SQL
+
 echo "==> Verifying seeded venues (public API requires verified=true)..."
 psql -v ON_ERROR_STOP=1 "$E2E_DB_URL" <<'SQL'
 UPDATE venues SET verified = true WHERE verified = false;

--- a/frontend/features/shows/components/ShowCard.tsx
+++ b/frontend/features/shows/components/ShowCard.tsx
@@ -197,6 +197,7 @@ export function ShowCard({ show, isAdmin, userId, isSaved, density = 'comfortabl
 
     return (
       <article
+        aria-label={show.title}
         className={cn(
           'flex items-center gap-3 px-3 py-1.5 hover:bg-muted/50 rounded-md transition-colors',
           show.is_cancelled && 'opacity-60'
@@ -262,6 +263,7 @@ export function ShowCard({ show, isAdmin, userId, isSaved, density = 'comfortabl
   if (density === 'expanded') {
     return (
       <article
+        aria-label={show.title}
         className={cn(
           'border border-border/50 rounded-lg bg-card hover:shadow-sm transition-all duration-100',
           'px-5 py-5 sm:px-6 sm:py-6',
@@ -497,6 +499,7 @@ export function ShowCard({ show, isAdmin, userId, isSaved, density = 'comfortabl
   // ----- Comfortable density (default): current card layout -----
   return (
     <article
+      aria-label={show.title}
       className={cn(
         'border border-border/50 rounded-lg bg-card hover:shadow-sm transition-all duration-100',
         'px-3 py-3 sm:px-4 sm:py-4',


### PR DESCRIPTION
## Summary

- Seed 3 reserved shows + 1 reserved venue with stable slugs in `frontend/e2e/setup-db.sh`
- Pin the 4 previously-flaky mutating tests (collection, favorite-venue, save-show, show-list-actions) to those reserved rows so parallel workers stop racing on `.first()`
- Add `aria-label={show.title}` to `<article>` in `ShowCard` (3 density variants) and `SavedShowCard`, so tests use `getByRole('article', { name })` instead of text filters — improves a11y too

Closes PSY-430. Unblocks PSY-435 for the collection + favorite-venue cases (the submit-show case is a different failure mode and may need its own ticket).

## Test plan

- [x] 3 consecutive local E2E runs of the 4 modified files: 13/13 pass each run
- [x] Full local E2E suite: 69/70 pass (the 1 failure is the pre-existing `submit-show.spec.ts` Valley-Bar context-closed flake explicitly listed as out of scope in PSY-430)
- [x] `ShowCard.test.tsx` unit tests pass (34/34) — aria-label addition didn't break existing tests
- [x] No typecheck regressions in the modified e2e files

🤖 Generated with [Claude Code](https://claude.com/claude-code)