### PR TITLE
PSY-433: gate background services behind DISABLE_* env flags for E2E

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -647,6 +647,27 @@ NODE_ENV=production docker compose up
 | `CORS_ALLOWED_ORIGINS` | `https://psychichomily.com` | Comma-separated CORS origins             |
 | `LOG_LEVEL`            | `debug`                     | Logging level (debug, info, warn, error) |
 
+### Background Service Env Flags
+
+Each scheduled background service in `cmd/server/main.go` can be individually
+disabled at startup by setting the corresponding `DISABLE_*` env var to `"1"`.
+Any other value (including unset) leaves the service enabled, so local
+`go run ./cmd/server` keeps starting everything by default.
+
+The frontend E2E harness (`frontend/e2e/global-setup.ts`) sets all seven flags
+to `"1"` so the E2E backend runs lean — no scheduled tickers, no log spam,
+no nondeterministic DB state changes from ambient background jobs.
+
+| Variable                          | Disables                                                        |
+| --------------------------------- | --------------------------------------------------------------- |
+| `DISABLE_RADIO_FETCH`             | Radio playlist ingestion, affinity computation, re-matching     |
+| `DISABLE_AUTO_PROMOTION`          | Daily user trust-tier evaluation / auto-promotion               |
+| `DISABLE_ENRICHMENT_WORKER`       | Post-import enrichment worker (processes enrichment queue)      |
+| `DISABLE_SCHEDULER`               | Extraction scheduler (automated venue extraction runs)          |
+| `DISABLE_CLEANUP`                 | Account cleanup service (permanent deletion of soft-deleted)    |
+| `DISABLE_REMINDERS`               | Show reminder service (24h-before email reminders)              |
+| `DISABLE_RELATIONSHIP_DERIVATION` | Derived artist relationships (shared_bills + shared_label)      |
+
 ### Security Notes
 
 - **Never commit `.env.production`** to version control

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -152,33 +152,84 @@ func main() {
 	// Setup routes
 	_ = routes.SetupRoutes(router, sc, cfg)
 
+	// Background services can be individually disabled via DISABLE_* env flags.
+	// Defaults preserve current local behavior (flag unset → service starts).
+	// E2E tests set all flags to "1" to get a lean, deterministic backend.
+	//
+	// Each service keeps its own cancel func; a nil cancel signals "not started"
+	// so the shutdown path can skip it without panicking.
+	var (
+		cleanupCancel       context.CancelFunc
+		reminderCancel      context.CancelFunc
+		schedulerCancel     context.CancelFunc
+		enrichmentCancel    context.CancelFunc
+		autoPromotionCancel context.CancelFunc
+		radioFetchCancel    context.CancelFunc
+		relDerivationCancel context.CancelFunc
+	)
+
 	// Start account cleanup service (background job for permanent deletion)
-	cleanupCtx, cleanupCancel := context.WithCancel(context.Background())
-	sc.Cleanup.Start(cleanupCtx)
+	if os.Getenv("DISABLE_CLEANUP") != "1" {
+		var cleanupCtx context.Context
+		cleanupCtx, cleanupCancel = context.WithCancel(context.Background())
+		sc.Cleanup.Start(cleanupCtx)
+	} else {
+		log.Printf("DISABLE_CLEANUP=1: skipping cleanup service startup")
+	}
 
 	// Start show reminder service (background job for 24h-before email reminders)
-	reminderCtx, reminderCancel := context.WithCancel(context.Background())
-	sc.Reminder.Start(reminderCtx)
+	if os.Getenv("DISABLE_REMINDERS") != "1" {
+		var reminderCtx context.Context
+		reminderCtx, reminderCancel = context.WithCancel(context.Background())
+		sc.Reminder.Start(reminderCtx)
+	} else {
+		log.Printf("DISABLE_REMINDERS=1: skipping reminder service startup")
+	}
 
 	// Start extraction scheduler (background job for automated venue extraction)
-	schedulerCtx, schedulerCancel := context.WithCancel(context.Background())
-	sc.Scheduler.Start(schedulerCtx)
+	if os.Getenv("DISABLE_SCHEDULER") != "1" {
+		var schedulerCtx context.Context
+		schedulerCtx, schedulerCancel = context.WithCancel(context.Background())
+		sc.Scheduler.Start(schedulerCtx)
+	} else {
+		log.Printf("DISABLE_SCHEDULER=1: skipping extraction scheduler startup")
+	}
 
 	// Start enrichment worker (background job for post-import enrichment)
-	enrichmentCtx, enrichmentCancel := context.WithCancel(context.Background())
-	sc.EnrichmentWorker.Start(enrichmentCtx)
+	if os.Getenv("DISABLE_ENRICHMENT_WORKER") != "1" {
+		var enrichmentCtx context.Context
+		enrichmentCtx, enrichmentCancel = context.WithCancel(context.Background())
+		sc.EnrichmentWorker.Start(enrichmentCtx)
+	} else {
+		log.Printf("DISABLE_ENRICHMENT_WORKER=1: skipping enrichment worker startup")
+	}
 
 	// Start auto-promotion scheduler (background job for daily user tier evaluation)
-	autoPromotionCtx, autoPromotionCancel := context.WithCancel(context.Background())
-	sc.AutoPromotion.Start(autoPromotionCtx)
+	if os.Getenv("DISABLE_AUTO_PROMOTION") != "1" {
+		var autoPromotionCtx context.Context
+		autoPromotionCtx, autoPromotionCancel = context.WithCancel(context.Background())
+		sc.AutoPromotion.Start(autoPromotionCtx)
+	} else {
+		log.Printf("DISABLE_AUTO_PROMOTION=1: skipping auto-promotion scheduler startup")
+	}
 
 	// Start radio fetch service (background job for playlist ingestion, affinity, re-matching)
-	radioFetchCtx, radioFetchCancel := context.WithCancel(context.Background())
-	sc.RadioFetch.Start(radioFetchCtx)
+	if os.Getenv("DISABLE_RADIO_FETCH") != "1" {
+		var radioFetchCtx context.Context
+		radioFetchCtx, radioFetchCancel = context.WithCancel(context.Background())
+		sc.RadioFetch.Start(radioFetchCtx)
+	} else {
+		log.Printf("DISABLE_RADIO_FETCH=1: skipping radio fetch service startup")
+	}
 
 	// Start relationship derivation service (background job for shared_bills + shared_label)
-	relDerivationCtx, relDerivationCancel := context.WithCancel(context.Background())
-	sc.RelationshipDerivation.Start(relDerivationCtx)
+	if os.Getenv("DISABLE_RELATIONSHIP_DERIVATION") != "1" {
+		var relDerivationCtx context.Context
+		relDerivationCtx, relDerivationCancel = context.WithCancel(context.Background())
+		sc.RelationshipDerivation.Start(relDerivationCtx)
+	} else {
+		log.Printf("DISABLE_RELATIONSHIP_DERIVATION=1: skipping relationship derivation service startup")
+	}
 
 	// Create HTTP server
 	srv := &http.Server{
@@ -204,33 +255,35 @@ func main() {
 
 	log.Println("Shutting down Psychic Homily API...")
 
-	// Stop cleanup service
-	cleanupCancel()
-	sc.Cleanup.Stop()
-
-	// Stop reminder service
-	reminderCancel()
-	sc.Reminder.Stop()
-
-	// Stop extraction scheduler
-	schedulerCancel()
-	sc.Scheduler.Stop()
-
-	// Stop enrichment worker
-	enrichmentCancel()
-	sc.EnrichmentWorker.Stop()
-
-	// Stop auto-promotion scheduler
-	autoPromotionCancel()
-	sc.AutoPromotion.Stop()
-
-	// Stop radio fetch service
-	radioFetchCancel()
-	sc.RadioFetch.Stop()
-
-	// Stop relationship derivation service
-	relDerivationCancel()
-	sc.RelationshipDerivation.Stop()
+	// Stop background services only if they were started (cancel is nil if DISABLE_* was set).
+	if cleanupCancel != nil {
+		cleanupCancel()
+		sc.Cleanup.Stop()
+	}
+	if reminderCancel != nil {
+		reminderCancel()
+		sc.Reminder.Stop()
+	}
+	if schedulerCancel != nil {
+		schedulerCancel()
+		sc.Scheduler.Stop()
+	}
+	if enrichmentCancel != nil {
+		enrichmentCancel()
+		sc.EnrichmentWorker.Stop()
+	}
+	if autoPromotionCancel != nil {
+		autoPromotionCancel()
+		sc.AutoPromotion.Stop()
+	}
+	if radioFetchCancel != nil {
+		radioFetchCancel()
+		sc.RadioFetch.Stop()
+	}
+	if relDerivationCancel != nil {
+		relDerivationCancel()
+		sc.RelationshipDerivation.Stop()
+	}
 
 	// Shut down chromedp browser pool
 	sc.Fetcher.ShutdownChromedp()

--- a/frontend/e2e/global-setup.ts
+++ b/frontend/e2e/global-setup.ts
@@ -113,6 +113,16 @@ function startBackend(): ChildProcess {
       SESSION_SECURE: 'false',
       SESSION_SAME_SITE: 'lax',
       DISCORD_NOTIFICATIONS_ENABLED: 'false',
+      // Disable all scheduled background services for E2E (see PSY-433).
+      // These cause log spam, nondeterministic DB state, and wasted CPU during
+      // tests. Defaults (flag unset) still start everything for local dev.
+      DISABLE_RADIO_FETCH: '1',
+      DISABLE_AUTO_PROMOTION: '1',
+      DISABLE_ENRICHMENT_WORKER: '1',
+      DISABLE_SCHEDULER: '1',
+      DISABLE_CLEANUP: '1',
+      DISABLE_REMINDERS: '1',
+      DISABLE_RELATIONSHIP_DERIVATION: '1',
     },
     stdio: ['ignore', 'pipe', 'pipe'],
     detached: true,


### PR DESCRIPTION
## Summary

- Add seven per-service `DISABLE_*` env flags in `backend/cmd/server/main.go` that gate each scheduled background service's `.Start()` call
- Default preserves current local behavior (flag unset → service starts), so `go run ./cmd/server` keeps working as-is
- `frontend/e2e/global-setup.ts` sets all seven flags to `"1"` when spawning the E2E backend — lean, deterministic, no log spam, no ambient state mutation
- Document the flags in `backend/README.md`

Services gated: `RADIO_FETCH`, `AUTO_PROMOTION`, `ENRICHMENT_WORKER`, `SCHEDULER`, `CLEANUP`, `REMINDERS`, `RELATIONSHIP_DERIVATION`. Each cancel func is declared at outer scope so shutdown skips cleanly when its service was never started (nil-cancel pattern).

Closes PSY-433.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] Full local E2E suite run from this branch: 65 passed, 4 failed, 1 did not run — all 4 failures are pre-existing flakes (`collection:66`, `favorite-venue:96`, `save-show:32` fixed by PSY-430; `submit-show:34` tracked by PSY-437). No new failures caused by the bg-service gating
- [x] No E2E spec targets any disabled service (no radio/promotion/enrichment/reminder specs), so disabling them is safe for the existing suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)