### PR TITLE
Official tag: visible badge on entity tag pills

### DIFF
--- a/frontend/features/tags/components/EntityTagList.test.tsx
+++ b/frontend/features/tags/components/EntityTagList.test.tsx
@@ -106,6 +106,16 @@ describe('EntityTagList add-tag dialog accessibility', () => {
     // The community tag "indie" should have a plain title
     const indieLink = screen.getByRole('link', { name: 'indie' })
     expect(indieLink).toHaveAttribute('title', 'indie')
+
+    // The visible BadgeCheck icon marker is present exactly once (only on
+    // the official tag) so the distinction is not tooltip-only.
+    const officialMarkers = screen.getAllByRole('img', { name: 'Official tag' })
+    expect(officialMarkers).toHaveLength(1)
+
+    // And the official pill wrapper carries the primary-accent background
+    // so it reads as curated at a glance (ISSUE-004 tags-audit-2).
+    const officialPill = officialMarkers[0].closest('div')
+    expect(officialPill?.className).toContain('bg-primary/10')
   })
 
   it('opens add-tag dialog with title and no aria-describedby attribute', async () => {

--- a/frontend/features/tags/components/EntityTagList.tsx
+++ b/frontend/features/tags/components/EntityTagList.tsx
@@ -166,14 +166,18 @@ function TagWithVotes({
     <div
       className={cn(
         'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs',
-        getCategoryColor(tag.category),
-        tag.is_official && 'ring-1 ring-primary/20'
+        // Official tags get a distinct primary-accent background that
+        // overrides the per-category color, making curated tags visibly
+        // different at a glance (ISSUE-004 from tags-audit-2).
+        tag.is_official
+          ? 'border-primary/40 bg-primary/10 text-foreground'
+          : getCategoryColor(tag.category)
       )}
     >
       {tag.is_official && (
-        <span title="Official tag">
+        <span title="Official tag" aria-label="Official tag" role="img">
           <BadgeCheck
-            className="h-3 w-3 text-primary shrink-0"
+            className="h-3.5 w-3.5 text-primary shrink-0"
             aria-hidden="true"
           />
         </span>


### PR DESCRIPTION
Closes PSY-440

Dogfood finding `dogfood-output/tags-audit-2/report.md` ISSUE-004 flagged that on entity detail pages (artist/show/venue/release/label/festival), official tags were still visually indistinguishable from community tags at a glance. The `BadgeCheck` icon shipped in PSY-303 was technically present but too subtle (faint `ring-1 ring-primary/20` on top of the per-category color; a 12 px icon).

## Summary

- Swap the category-colored pill background for a primary-accent treatment (`border-primary/40 bg-primary/10 text-foreground`) when `is_official = true`, so official tags become a clearly different pill at a glance instead of sharing genre/locale colors with community tags.
- Bump the `BadgeCheck` icon from `h-3 w-3` to `h-3.5 w-3.5` and promote the wrapping `<span>` to `role="img"` + `aria-label="Official tag"` so the indicator is no longer tooltip-only for assistive tech.
- **Design choice documented:** went with the ticket's primary directive (icon) plus the optional "distinct background tone" — not the `/tags` browse page's "Official" text Badge, because the entity pill is already tight on space (top-5 cap + 15-tag entities noted in the ticket tradeoffs) and a text label would crowd the vote score and voting buttons. Browse cards keep their text Badge; both surfaces now use the same primary accent color so the signal reads consistently across the app. **No shared primitive extracted** — the two surfaces legitimately diverge by form factor (compact pill vs. card header).

## Test plan

- [x] `bun run test:run` — 2534 tests pass across 193 files.
- [x] `bun run build` — clean, no type errors or warnings.
- [x] `EntityTagList.test.tsx` updated to assert the `role="img"` BadgeCheck marker is present exactly once in the mixed-tag fixture (official `rock` + community `indie`), and that the official pill wrapper carries the `bg-primary/10` class.
- [x] Existing `title="name (Official)"` a11y fallback assertion preserved and still passing.
- [ ] Visual verification on `/artists/l7` with `punk` marked official via `/admin/tags` (per ticket acceptance criteria) — deferred to reviewer; seed data + admin UI path unchanged by this PR.

Reference: `dogfood-output/tags-audit-2/report.md` ISSUE-004 (screenshot `screenshots/l7-tag-pill.png`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)