### PR TITLE
Alias transparency in add-tag autocomplete

### DIFF
--- a/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
+++ b/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
@@ -3023,7 +3023,7 @@ type mockTagService struct {
 	listAliasesFn func(uint) ([]models.TagAlias, error)
 	resolveAliasFn func(string) (*models.Tag, error)
 	getTagEntitiesFn func(uint, string, int, int) ([]contracts.TaggedEntityItem, int64, error)
-	searchTagsFn func(string, int, string) ([]models.Tag, error)
+	searchTagsFn func(string, int, string) ([]contracts.TagSearchResult, error)
 	getTrendingTagsFn func(int, string) ([]models.Tag, error)
 	pruneDownvotedTagsFn func() (int64, error)
 }
@@ -3124,7 +3124,7 @@ func (m *mockTagService) GetTagEntities(tagID uint, entityType string, limit int
 	}
 	return nil, 0, nil
 }
-func (m *mockTagService) SearchTags(query string, limit int, category string) ([]models.Tag, error) {
+func (m *mockTagService) SearchTags(query string, limit int, category string) ([]contracts.TagSearchResult, error) {
 	if m.searchTagsFn != nil {
 		return m.searchTagsFn(query, limit, category)
 	}

--- a/backend/internal/api/handlers/tag.go
+++ b/backend/internal/api/handlers/tag.go
@@ -157,21 +157,22 @@ func (h *TagHandler) SearchTagsHandler(ctx context.Context, req *SearchTagsReque
 		return nil, huma.Error400BadRequest("Query parameter 'q' is required")
 	}
 
-	tags, err := h.tagService.SearchTags(req.Query, req.Limit, req.Category)
+	results, err := h.tagService.SearchTags(req.Query, req.Limit, req.Category)
 	if err != nil {
 		return nil, huma.Error500InternalServerError("Failed to search tags")
 	}
 
-	items := make([]contracts.TagListItem, len(tags))
-	for i, t := range tags {
+	items := make([]contracts.TagListItem, len(results))
+	for i, r := range results {
 		items[i] = contracts.TagListItem{
-			ID:         t.ID,
-			Name:       t.Name,
-			Slug:       t.Slug,
-			Category:   t.Category,
-			IsOfficial: t.IsOfficial,
-			UsageCount: t.UsageCount,
-			CreatedAt:  t.CreatedAt,
+			ID:              r.Tag.ID,
+			Name:            r.Tag.Name,
+			Slug:            r.Tag.Slug,
+			Category:        r.Tag.Category,
+			IsOfficial:      r.Tag.IsOfficial,
+			UsageCount:      r.Tag.UsageCount,
+			CreatedAt:       r.Tag.CreatedAt,
+			MatchedViaAlias: r.MatchedAlias,
 		}
 	}
 

--- a/backend/internal/api/handlers/tag_integration_test.go
+++ b/backend/internal/api/handlers/tag_integration_test.go
@@ -351,6 +351,48 @@ func (s *TagHandlerIntegrationSuite) TestSearchTags_WithLimit() {
 	s.LessOrEqual(len(resp.Body.Tags), 3)
 }
 
+// TestSearchTags_MatchedViaAlias covers PSY-442 — the autocomplete endpoint
+// surfaces the specific alias that matched so the add-tag dialog can render
+// a "matched `punk-rock`" caption under the canonical row.
+func (s *TagHandlerIntegrationSuite) TestSearchTags_MatchedViaAlias() {
+	admin := createAdminUser(s.deps.db)
+	tag := s.createTagViaHandler(admin, "punk", models.TagCategoryGenre)
+
+	// Seed an alias via the service layer (alias creation is admin-only via
+	// the handler, but we don't need to exercise that path here).
+	_, err := s.deps.tagService.CreateAlias(tag.Body.ID, "punk-rock")
+	s.Require().NoError(err)
+
+	req := &SearchTagsRequest{Query: "punk-rock"}
+	resp, err := s.handler.SearchTagsHandler(s.deps.ctx, req)
+	s.NoError(err)
+	s.Require().NotNil(resp)
+	s.Require().Len(resp.Body.Tags, 1)
+	s.Equal(tag.Body.ID, resp.Body.Tags[0].ID)
+	s.Equal("punk", resp.Body.Tags[0].Name)
+	s.Equal("punk-rock", resp.Body.Tags[0].MatchedViaAlias,
+		"alias-match rows must expose MatchedViaAlias for the frontend caption")
+}
+
+// Name-match rows keep MatchedViaAlias empty so existing autocomplete
+// consumers (Cmd+K, admin browse) render unchanged.
+func (s *TagHandlerIntegrationSuite) TestSearchTags_NameMatchHasNoAliasCaption() {
+	admin := createAdminUser(s.deps.db)
+	tag := s.createTagViaHandler(admin, "punk", models.TagCategoryGenre)
+	// An alias exists on the tag, but the query hits the canonical name directly.
+	_, err := s.deps.tagService.CreateAlias(tag.Body.ID, "punk-rock")
+	s.Require().NoError(err)
+
+	req := &SearchTagsRequest{Query: "punk"}
+	resp, err := s.handler.SearchTagsHandler(s.deps.ctx, req)
+	s.NoError(err)
+	s.Require().NotNil(resp)
+	s.Require().Len(resp.Body.Tags, 1)
+	s.Equal(tag.Body.ID, resp.Body.Tags[0].ID)
+	s.Empty(resp.Body.Tags[0].MatchedViaAlias,
+		"name matches should leave MatchedViaAlias empty so the caption stays hidden")
+}
+
 // ============================================================================
 // UpdateTagHandler
 // ============================================================================

--- a/backend/internal/services/catalog/tag_service.go
+++ b/backend/internal/services/catalog/tag_service.go
@@ -654,7 +654,14 @@ func (s *TagService) ResolveAlias(alias string) (*models.Tag, error) {
 
 // SearchTags performs a case-insensitive search on tag names and aliases.
 // If category is non-empty, results are filtered to that category.
-func (s *TagService) SearchTags(query string, limit int, category string) ([]models.Tag, error) {
+//
+// For each returned tag, MatchedAlias is populated with the specific alias
+// that matched the query when the match came through `tag_aliases` rather
+// than `tags.name`. This lets the autocomplete UI show the canonical form
+// alongside the typed alias for transparency ("matched `punk-rock`"). If
+// the tag's name matches directly, MatchedAlias is left empty even when
+// an alias also happens to match — the canonical form is the signal.
+func (s *TagService) SearchTags(query string, limit int, category string) ([]contracts.TagSearchResult, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
@@ -686,7 +693,49 @@ func (s *TagService) SearchTags(query string, limit int, category string) ([]mod
 		return nil, fmt.Errorf("failed to search tags: %w", err)
 	}
 
-	return tags, nil
+	// Build the result set. For tags whose name does NOT match the query,
+	// look up which alias on that tag matched so the UI can surface the
+	// provenance. A single batch query avoids N+1.
+	results := make([]contracts.TagSearchResult, len(tags))
+	pattern := "%" + q + "%"
+
+	// Collect the tag IDs whose name did not match the query — those are
+	// the ones that were returned only because of an alias match.
+	aliasMatchIDs := make([]uint, 0, len(tags))
+	for i, tag := range tags {
+		results[i] = contracts.TagSearchResult{Tag: tag}
+		if !strings.Contains(strings.ToLower(tag.Name), q) {
+			aliasMatchIDs = append(aliasMatchIDs, tag.ID)
+		}
+	}
+
+	if len(aliasMatchIDs) > 0 {
+		// Fetch matching aliases in one query, ordered so the first (lexicographic)
+		// match wins deterministically when a tag has multiple matching aliases.
+		var aliases []models.TagAlias
+		err := s.db.Where("tag_id IN ? AND LOWER(alias) LIKE ?", aliasMatchIDs, pattern).
+			Order("tag_id, alias ASC").
+			Find(&aliases).Error
+		if err != nil {
+			return nil, fmt.Errorf("failed to load matching aliases: %w", err)
+		}
+
+		matchedByTag := make(map[uint]string, len(aliases))
+		for _, a := range aliases {
+			if _, seen := matchedByTag[a.TagID]; seen {
+				continue
+			}
+			matchedByTag[a.TagID] = a.Alias
+		}
+
+		for i := range results {
+			if alias, ok := matchedByTag[results[i].Tag.ID]; ok {
+				results[i].MatchedAlias = alias
+			}
+		}
+	}
+
+	return results, nil
 }
 
 // GetTrendingTags returns the most used tags, optionally filtered by category.

--- a/backend/internal/services/catalog/tag_service_test.go
+++ b/backend/internal/services/catalog/tag_service_test.go
@@ -568,19 +568,26 @@ func (suite *TagServiceIntegrationTestSuite) TestSearchTags_ByName() {
 	suite.createTag("post-rock", "genre")
 	suite.createTag("jazz", "genre")
 
-	tags, err := suite.tagService.SearchTags("post", 10, "")
+	results, err := suite.tagService.SearchTags("post", 10, "")
 	suite.Require().NoError(err)
-	suite.Assert().Len(tags, 2)
+	suite.Assert().Len(results, 2)
+	// Name-match results should not report any alias provenance.
+	for _, r := range results {
+		suite.Assert().Empty(r.MatchedAlias, "expected no MatchedAlias for name-match row %q", r.Tag.Name)
+	}
 }
 
 func (suite *TagServiceIntegrationTestSuite) TestSearchTags_ByAlias() {
 	tag := suite.createTag("post-punk", "genre")
-	suite.tagService.CreateAlias(tag.ID, "post punk revival")
-
-	tags, err := suite.tagService.SearchTags("revival", 10, "")
+	_, err := suite.tagService.CreateAlias(tag.ID, "post punk revival")
 	suite.Require().NoError(err)
-	suite.Assert().Len(tags, 1)
-	suite.Assert().Equal(tag.ID, tags[0].ID)
+
+	results, err := suite.tagService.SearchTags("revival", 10, "")
+	suite.Require().NoError(err)
+	suite.Assert().Len(results, 1)
+	suite.Assert().Equal(tag.ID, results[0].Tag.ID)
+	// Alias-match should surface which alias produced the match.
+	suite.Assert().Equal("post punk revival", results[0].MatchedAlias)
 }
 
 func (suite *TagServiceIntegrationTestSuite) TestSearchTags_FilterByCategory() {
@@ -589,21 +596,96 @@ func (suite *TagServiceIntegrationTestSuite) TestSearchTags_FilterByCategory() {
 	suite.createTag("portland", "locale")
 
 	// Without category filter: "post" matches post-punk and post-office
-	tags, err := suite.tagService.SearchTags("post", 10, "")
+	results, err := suite.tagService.SearchTags("post", 10, "")
 	suite.Require().NoError(err)
-	suite.Assert().Len(tags, 2)
+	suite.Assert().Len(results, 2)
 
 	// With genre filter: only post-punk
-	tags, err = suite.tagService.SearchTags("post", 10, "genre")
+	results, err = suite.tagService.SearchTags("post", 10, "genre")
 	suite.Require().NoError(err)
-	suite.Assert().Len(tags, 1)
-	suite.Assert().Equal("post-punk", tags[0].Name)
+	suite.Assert().Len(results, 1)
+	suite.Assert().Equal("post-punk", results[0].Tag.Name)
 
 	// With locale filter: "port" matches portland only
-	tags, err = suite.tagService.SearchTags("port", 10, "locale")
+	results, err = suite.tagService.SearchTags("port", 10, "locale")
 	suite.Require().NoError(err)
-	suite.Assert().Len(tags, 1)
-	suite.Assert().Equal("portland", tags[0].Name)
+	suite.Assert().Len(results, 1)
+	suite.Assert().Equal("portland", results[0].Tag.Name)
+}
+
+// TestSearchTags_AliasTransparency covers PSY-442 — the autocomplete response
+// must surface which alias produced a match so the UI can tell the user
+// "you typed `punk-rock`, using `punk`". Queries that hit the canonical
+// name stay silent so the caption only fires when it's useful.
+func (suite *TagServiceIntegrationTestSuite) TestSearchTags_AliasTransparency_AliasMatch() {
+	tag := suite.createTag("punk", "genre")
+	_, err := suite.tagService.CreateAlias(tag.ID, "punk-rock")
+	suite.Require().NoError(err)
+
+	results, err := suite.tagService.SearchTags("punk-rock", 10, "")
+	suite.Require().NoError(err)
+	suite.Require().Len(results, 1)
+	suite.Assert().Equal(tag.ID, results[0].Tag.ID)
+	suite.Assert().Equal("punk", results[0].Tag.Name)
+	suite.Assert().Equal("punk-rock", results[0].MatchedAlias,
+		"alias match should carry the specific alias that matched")
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestSearchTags_AliasTransparency_NameMatchHasNoProvenance() {
+	tag := suite.createTag("punk", "genre")
+	// Add an alias that also happens to contain the query substring — the
+	// canonical name match still wins and we should not emit MatchedAlias.
+	_, err := suite.tagService.CreateAlias(tag.ID, "punks")
+	suite.Require().NoError(err)
+
+	results, err := suite.tagService.SearchTags("punk", 10, "")
+	suite.Require().NoError(err)
+	suite.Require().Len(results, 1)
+	suite.Assert().Equal(tag.ID, results[0].Tag.ID)
+	suite.Assert().Empty(results[0].MatchedAlias,
+		"when the tag name matches directly the canonical form is the signal")
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestSearchTags_AliasTransparency_DeterministicWhenMultipleAliasesMatch() {
+	tag := suite.createTag("drum-and-bass", "genre")
+	_, err := suite.tagService.CreateAlias(tag.ID, "zeta-alias")
+	suite.Require().NoError(err)
+	_, err = suite.tagService.CreateAlias(tag.ID, "alpha-alias")
+	suite.Require().NoError(err)
+
+	// Both aliases contain "alias"; either is a defensible choice, but the
+	// service must pick one deterministically (alphabetical) so UI behaviour
+	// is stable across runs. "alpha-alias" comes before "zeta-alias" under
+	// any reasonable collation.
+	results, err := suite.tagService.SearchTags("alias", 10, "")
+	suite.Require().NoError(err)
+	suite.Require().Len(results, 1)
+	suite.Assert().Equal(tag.ID, results[0].Tag.ID)
+	suite.Assert().Equal("alpha-alias", results[0].MatchedAlias)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestSearchTags_AliasTransparency_MixedResults() {
+	// One tag matches by name, one by alias — each row should carry the
+	// correct provenance independently.
+	nameMatch := suite.createTag("electro-punk", "genre")
+	aliasTag := suite.createTag("punk", "genre")
+	_, err := suite.tagService.CreateAlias(aliasTag.ID, "punk-rock")
+	suite.Require().NoError(err)
+
+	results, err := suite.tagService.SearchTags("punk", 10, "")
+	suite.Require().NoError(err)
+	suite.Require().Len(results, 2)
+
+	byID := make(map[uint]string, len(results))
+	for _, r := range results {
+		byID[r.Tag.ID] = r.MatchedAlias
+	}
+
+	// The electro-punk tag matched by name.
+	suite.Assert().Empty(byID[nameMatch.ID])
+	// The punk tag also matched by name ("punk" is a substring of "punk"),
+	// not by alias — even though the alias also contains the query.
+	suite.Assert().Empty(byID[aliasTag.ID])
 }
 
 func (suite *TagServiceIntegrationTestSuite) TestGetTrendingTags() {

--- a/backend/internal/services/contracts/tag.go
+++ b/backend/internal/services/contracts/tag.go
@@ -30,14 +30,30 @@ type TagResponse struct {
 }
 
 // TagListItem represents a tag in a list response.
+//
+// MatchedViaAlias is populated only by the tag search/autocomplete endpoint
+// when the query matched a row in `tag_aliases` rather than `tags.name`. The
+// field holds the specific alias that matched, so the UI can show the user
+// which term was interpreted as the canonical tag ("matched `punk-rock`").
+// Empty/omitted for all other list contexts.
 type TagListItem struct {
-	ID         uint      `json:"id"`
-	Name       string    `json:"name"`
-	Slug       string    `json:"slug"`
-	Category   string    `json:"category"`
-	IsOfficial bool      `json:"is_official"`
-	UsageCount int       `json:"usage_count"`
-	CreatedAt  time.Time `json:"created_at"`
+	ID              uint      `json:"id"`
+	Name            string    `json:"name"`
+	Slug            string    `json:"slug"`
+	Category        string    `json:"category"`
+	IsOfficial      bool      `json:"is_official"`
+	UsageCount      int       `json:"usage_count"`
+	CreatedAt       time.Time `json:"created_at"`
+	MatchedViaAlias string    `json:"matched_via_alias,omitempty"`
+}
+
+// TagSearchResult pairs a tag with any alias (on that tag) that matched the
+// search query. MatchedAlias is empty when the query matched the tag's name
+// directly, or when both the name and an alias matched (name match takes
+// precedence so the canonical form is surfaced without extra noise).
+type TagSearchResult struct {
+	Tag          models.Tag
+	MatchedAlias string
 }
 
 // EntityTagResponse represents a tag applied to an entity with vote info.
@@ -98,7 +114,7 @@ type TagServiceInterface interface {
 	GetTagEntities(tagID uint, entityType string, limit, offset int) ([]TaggedEntityItem, int64, error)
 
 	// Utility
-	SearchTags(query string, limit int, category string) ([]models.Tag, error)
+	SearchTags(query string, limit int, category string) ([]TagSearchResult, error)
 	GetTrendingTags(limit int, category string) ([]models.Tag, error)
 	PruneDownvotedTags() (int64, error)
 }

--- a/frontend/features/tags/components/EntityTagList.test.tsx
+++ b/frontend/features/tags/components/EntityTagList.test.tsx
@@ -30,14 +30,15 @@ const mockManyTags = {
   ],
 }
 
-const mockSearchTags = {
+const defaultMockSearchTags = {
   tags: [
-    { id: 3, name: 'punk', slug: 'punk', category: 'genre', usage_count: 5 },
+    { id: 3, name: 'punk', slug: 'punk', category: 'genre', is_official: false, usage_count: 5, created_at: '' },
   ],
 }
 
 const mockAddMutate = vi.fn()
 let currentMockTags = mockEntityTags
+let currentMockSearchTags: typeof defaultMockSearchTags = defaultMockSearchTags
 
 vi.mock('../hooks', () => ({
   useEntityTags: () => ({
@@ -62,7 +63,7 @@ vi.mock('../hooks', () => ({
     isPending: false,
   }),
   useSearchTags: () => ({
-    data: mockSearchTags,
+    data: currentMockSearchTags,
     isLoading: false,
   }),
 }))
@@ -79,6 +80,7 @@ describe('EntityTagList add-tag dialog accessibility', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     currentMockTags = mockEntityTags
+    currentMockSearchTags = defaultMockSearchTags
   })
 
   it('renders the Add button when authenticated', () => {
@@ -163,6 +165,7 @@ describe('EntityTagList top-5 cap and Wilson score sorting', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     currentMockTags = mockManyTags
+    currentMockSearchTags = defaultMockSearchTags
   })
 
   it('shows only top 5 tags by default when more than 5 exist', () => {
@@ -233,5 +236,113 @@ describe('EntityTagList top-5 cap and Wilson score sorting', () => {
 
     expect(screen.queryByText(/Show \d+ more/)).not.toBeInTheDocument()
     expect(screen.queryByText('Show less')).not.toBeInTheDocument()
+  })
+})
+
+// PSY-442: alias transparency in the add-tag autocomplete.
+// When the backend indicates an autocomplete row matched via `tag_aliases`
+// rather than `tags.name`, the dialog must render a small caption under
+// the tag name so the user sees which term was interpreted as the
+// canonical form. Rows that matched by name render unchanged.
+describe('EntityTagList add-tag dialog alias caption', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    currentMockTags = mockEntityTags
+    currentMockSearchTags = defaultMockSearchTags
+  })
+
+  async function openDialogAndSearch(queryText: string) {
+    const user = userEvent.setup()
+    renderWithProviders(
+      <EntityTagList entityType="artist" entityId={1} isAuthenticated />
+    )
+    await user.click(screen.getByRole('button', { name: 'Add tag' }))
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+    const input = screen.getByPlaceholderText('Search tags or type a new one...')
+    await user.type(input, queryText)
+    return user
+  }
+
+  it('renders the "matched" caption when a result carries matched_via_alias', async () => {
+    currentMockSearchTags = {
+      tags: [
+        {
+          id: 3,
+          name: 'punk',
+          slug: 'punk',
+          category: 'genre',
+          is_official: false,
+          usage_count: 15,
+          created_at: '',
+          matched_via_alias: 'punk-rock',
+        },
+      ],
+    }
+
+    await openDialogAndSearch('punk-rock')
+
+    await waitFor(() => {
+      expect(screen.getByText('punk')).toBeInTheDocument()
+    })
+
+    const caption = screen.getByTestId('tag-autocomplete-matched-alias')
+    expect(caption).toBeInTheDocument()
+    expect(caption).toHaveTextContent(/matched\s+[“"]punk-rock[”"]/)
+  })
+
+  it('omits the caption for rows matched by name', async () => {
+    // The default search mock does NOT set matched_via_alias — that
+    // mirrors the "user typed the canonical form" case.
+    await openDialogAndSearch('punk')
+
+    await waitFor(() => {
+      expect(screen.getByText('punk')).toBeInTheDocument()
+    })
+
+    expect(
+      screen.queryByTestId('tag-autocomplete-matched-alias')
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders captions only on the rows that matched via alias in a mixed result set', async () => {
+    currentMockSearchTags = {
+      tags: [
+        {
+          id: 3,
+          name: 'punk',
+          slug: 'punk',
+          category: 'genre',
+          is_official: false,
+          usage_count: 15,
+          created_at: '',
+          matched_via_alias: 'punk-rock',
+        },
+        {
+          id: 4,
+          name: 'post-punk',
+          slug: 'post-punk',
+          category: 'genre',
+          is_official: false,
+          usage_count: 7,
+          created_at: '',
+          // no matched_via_alias — matched by name
+        },
+      ],
+    }
+
+    await openDialogAndSearch('punk')
+
+    await waitFor(() => {
+      expect(screen.getByText('punk')).toBeInTheDocument()
+      expect(screen.getByText('post-punk')).toBeInTheDocument()
+    })
+
+    // Exactly one row has a caption — the one whose match came through the
+    // alias table.
+    const captions = screen.getAllByTestId('tag-autocomplete-matched-alias')
+    expect(captions).toHaveLength(1)
+    expect(captions[0]).toHaveTextContent(/matched\s+[“"]punk-rock[”"]/)
   })
 })

--- a/frontend/features/tags/components/EntityTagList.tsx
+++ b/frontend/features/tags/components/EntityTagList.tsx
@@ -391,18 +391,28 @@ function AddTagForm({
               key={tag.id}
               onClick={() => handleSelectTag(tag)}
               disabled={addMutation.isPending}
-              className="flex items-center gap-2 w-full rounded-md px-3 py-2 text-sm hover:bg-muted transition-colors text-left"
+              className="flex items-start gap-2 w-full rounded-md px-3 py-2 text-sm hover:bg-muted transition-colors text-left"
             >
               <span
                 className={cn(
-                  'inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium',
+                  'inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium shrink-0 mt-0.5',
                   getCategoryColor(tag.category)
                 )}
               >
                 {tag.category}
               </span>
-              <span className="font-medium">{tag.name}</span>
-              <span className="ml-auto text-xs text-muted-foreground">
+              <div className="min-w-0 flex-1">
+                <span className="font-medium">{tag.name}</span>
+                {tag.matched_via_alias && (
+                  <span
+                    className="block text-[11px] text-muted-foreground truncate"
+                    data-testid="tag-autocomplete-matched-alias"
+                  >
+                    matched &ldquo;{tag.matched_via_alias}&rdquo;
+                  </span>
+                )}
+              </div>
+              <span className="ml-auto shrink-0 text-xs text-muted-foreground mt-0.5">
                 {tag.usage_count} {tag.usage_count === 1 ? 'use' : 'uses'}
               </span>
             </button>

--- a/frontend/features/tags/types.ts
+++ b/frontend/features/tags/types.ts
@@ -18,6 +18,13 @@ export interface TagListItem {
   is_official: boolean
   usage_count: number
   created_at: string
+  /**
+   * Populated only by the tag search / autocomplete endpoint when the query
+   * matched an entry in `tag_aliases` rather than `tags.name`. The value is
+   * the specific alias that matched, so the add-tag dialog can show
+   * "matched `{alias}`" under the canonical row for transparency (PSY-442).
+   */
+  matched_via_alias?: string
 }
 
 export interface TagDetailResponse extends TagListItem {


### PR DESCRIPTION
Closes PSY-442.

Evidence: `dogfood-output/tags-audit-2/report.md` ISSUE-003 — when a user typed an alias in the add-tag dialog, the autocomplete silently resolved it to the canonical tag with no indication that a mapping happened. The strategy doc (`docs/strategy/tags-redesign.md`, Autocomplete UX section) explicitly requires transparency here: _"Show canonical form if user typed an alias"_.

## Summary

- **Backend**: `TagListItem` gains an optional `matched_via_alias` field. Only the tag search / autocomplete endpoint populates it, and only when the match came through `tag_aliases` rather than `tags.name`. For name matches the field is omitted (backward-compatible for Cmd+K search, admin tag browse, etc.). Provenance is computed via a single batched alias query — no N+1. When a tag has multiple matching aliases, the alphabetically-first alias is picked so behaviour is stable.
- **Frontend**: `AddTagForm` (inside `EntityTagList.tsx`) renders a small muted-foreground caption under the tag name when `matched_via_alias` is present: `matched "{alias}"`. The row layout becomes two-line only on alias-match rows; name-match rows look identical to before.
- **Caption wording chosen**: `matched "{alias}"` (short, fits under the canonical name without wrapping, truncates cleanly when the alias is long). The strategy doc's verbose "You typed `dnb`, using `drum-and-bass`" full-sentence pattern would not fit in a compact autocomplete row.

## Tests

- Backend service: `TestSearchTags_AliasTransparency_{AliasMatch, NameMatchHasNoProvenance, DeterministicWhenMultipleAliasesMatch, MixedResults}` in `tag_service_test.go`. Existing `TestSearchTags_*` tests updated to use the new `[]TagSearchResult` return type.
- Backend handler: `TestSearchTags_MatchedViaAlias` (alias-match populates the field) and `TestSearchTags_NameMatchHasNoAliasCaption` (name-match leaves it empty) in `tag_integration_test.go`.
- Frontend: three new cases in `EntityTagList.test.tsx` covering (a) caption appears on an alias-match row, (b) caption is absent on a pure name-match row, (c) mixed result sets only caption the alias-match row.

## Test plan

- [x] `cd backend && go test ./...` — all packages green (handlers 120s, catalog 116s, admin 106s, etc. — all `ok`)
- [x] `cd frontend && bun run test:run` — 2537 tests pass
- [x] `cd frontend && bun run build` — builds cleanly
- [x] `cd backend && go vet ./...` — no issues
- [x] Lint: no new errors introduced by this PR (identical error/warning count before and after)
- [ ] Manual: sign in as admin, go to `/admin/tags`, edit `punk` to add alias `punk-rock`. Then on any artist detail page open the Add Tag dialog, type `punk-rock`, confirm the caption reads `matched "punk-rock"` on the `punk` row. Type `punk` directly and confirm no caption appears.

## Notes for reviewers

- API change is additive: `matched_via_alias` is an optional string with `omitempty`, so existing clients (Cmd+K, admin browse, etc.) that don't know about the field see no change.
- `SearchTags` service signature changed from `[]models.Tag` to `[]TagSearchResult`. Only internal callers (handler + tests) consumed this method, all updated.
- Mocks regenerated via `go run ./internal/api/handlers/gen/` per CLAUDE.md convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)