### PR TITLE
Fix Rules of Hooks violation in TagDetail

### DIFF
--- a/frontend/features/tags/components/TagDetail.test.tsx
+++ b/frontend/features/tags/components/TagDetail.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
@@ -130,6 +130,102 @@ describe('TagDetail', () => {
 
     const spinner = document.querySelector('.animate-spin')
     expect(spinner).toBeInTheDocument()
+  })
+
+  // ── Regression: loading → success transition (PSY-447) ──
+  // Rules of Hooks violation: earlier versions called useMemo below the
+  // early returns for loading/error/!tag, so the hook count changed when
+  // data arrived (tag went from undefined → populated). In production
+  // React logs "change in the order of Hooks" / "Rendered more hooks than
+  // during the previous render" and the error boundary renders a 500.
+  //
+  // The other tests all pass with the broken code because the mocked
+  // `useTagDetail` does not call any real React hooks, so when the
+  // component body goes from "0 hooks (early return)" to "1 hook (useMemo)",
+  // React has nothing to compare against. In production the real
+  // `useTagDetail` (via TanStack Query's `useQuery`) calls several real
+  // hooks before the component's own early return, so the mismatch is
+  // detected.
+  //
+  // This regression test makes the mock call a real React hook (`useState`)
+  // so that the 0-to-1 transition in the component body becomes a
+  // 1-to-2 transition, which is what React's hook-tracker can detect.
+  it('renders without hook-order errors during the loading → success transition', () => {
+    // Custom mock implementation that calls a real React hook. This
+    // mimics TanStack Query's internal hook calls so React's hook-order
+    // tracker sees the true mismatch introduced by hooks below an
+    // early return.
+    let dataState: TagEnrichedDetailResponse | undefined = undefined
+    let isLoadingState = true
+    mockUseTagDetail.mockImplementation(() => {
+      // Real React hook — ensures the number of hooks this "replacement"
+      // contributes is stable across renders.
+      useState(0)
+      return { data: dataState, isLoading: isLoadingState, error: null }
+    })
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    // Initial render: loading
+    const queryClient = createQueryClient()
+    const { rerender } = render(
+      <QueryClientProvider client={queryClient}>
+        <TagDetail slug="shoegaze" />
+      </QueryClientProvider>
+    )
+
+    // Transition to populated data — this is what triggered the
+    // hook-order violation in production.
+    dataState = makeTagDetail({
+      name: 'Shoegaze',
+      usage_count: 18,
+      usage_breakdown: {
+        artist: 15,
+        venue: 0,
+        show: 3,
+        release: 0,
+        label: 0,
+        festival: 0,
+      },
+    })
+    isLoadingState = false
+
+    let threwDuringRerender: Error | null = null
+    try {
+      rerender(
+        <QueryClientProvider client={queryClient}>
+          <TagDetail slug="shoegaze" />
+        </QueryClientProvider>
+      )
+    } catch (e) {
+      threwDuringRerender = e as Error
+    }
+
+    // A hook-order violation throws during render with a message like
+    // "Rendered more hooks than during the previous render." or
+    // "change in the order of Hooks". React also logs a dev-only
+    // console.error about it.
+    const allErrorOutput = [
+      ...(threwDuringRerender ? [threwDuringRerender.message] : []),
+      ...errorSpy.mock.calls.map(([msg]) =>
+        typeof msg === 'string' ? msg : ''
+      ),
+    ]
+    const hookErrors = allErrorOutput.filter(
+      (msg) =>
+        msg.includes('change in the order of Hooks') ||
+        msg.includes('Rendered more hooks than during the previous render') ||
+        msg.includes('Rendered fewer hooks than expected')
+    )
+    expect(hookErrors).toEqual([])
+    expect(threwDuringRerender).toBeNull()
+
+    // Sanity check: populated content actually renders after the transition.
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'Shoegaze' })
+    ).toBeInTheDocument()
+
+    errorSpy.mockRestore()
   })
 
   // ── Error states ──

--- a/frontend/features/tags/components/TagDetail.tsx
+++ b/frontend/features/tags/components/TagDetail.tsx
@@ -52,6 +52,17 @@ function getEntityTypeSingularLabel(entityType: string): string {
 export function TagDetail({ slug }: TagDetailProps) {
   const { data: tag, isLoading, error } = useTagDetail(slug)
 
+  // Usage breakdown: only show non-zero counts. We pad with zeros on the backend
+  // so the object always has all keys, but displaying zero counts is noise.
+  // NOTE: hook must be called unconditionally, above the early returns below.
+  // Guard the logic inside rather than the hook call.
+  const breakdownEntries = useMemo(() => {
+    if (!tag) return []
+    return ENTITY_TYPE_ORDER
+      .map((type) => ({ type, count: tag.usage_breakdown?.[type] ?? 0 }))
+      .filter((e) => e.count > 0)
+  }, [tag])
+
   if (isLoading) {
     return (
       <div className="flex min-h-[60vh] items-center justify-center">
@@ -112,15 +123,6 @@ export function TagDetail({ slug }: TagDetailProps) {
   const isGenre = tag.category === 'genre'
   const hasParent = isGenre && Boolean(tag.parent)
   const hasChildren = isGenre && tag.children && tag.children.length > 0
-
-  // Usage breakdown: only show non-zero counts. We pad with zeros on the backend
-  // so the object always has all keys, but displaying zero counts is noise.
-  const breakdownEntries = useMemo(() => {
-    const order = ENTITY_TYPE_ORDER
-    return order
-      .map((type) => ({ type, count: tag.usage_breakdown?.[type] ?? 0 }))
-      .filter((e) => e.count > 0)
-  }, [tag.usage_breakdown])
 
   return (
     <div className="container max-w-4xl mx-auto px-4 py-6">


### PR DESCRIPTION
Closes PSY-447

## Root cause

`TagDetail` had a Rules of Hooks violation: `useMemo` at
`frontend/features/tags/components/TagDetail.tsx:118` was called AFTER three
early returns (loading / error / !tag) introduced in PSY-438. On the first
render `tag` was undefined so the component hit an early return before
`useMemo` ran. Once the query resolved and the component reached the
`useMemo` line, the hook count jumped — React flagged
`"Rendered more hooks than during the previous render"` and the error
boundary rendered 500 for every `/tags/{slug}` detail page.

Regression introduced by PSY-438 (PR #367). Evidence:
`dogfood-output/tags-audit-3/report.md` ISSUE-001.

## What changed

- Hoist `breakdownEntries = useMemo(...)` above the three early returns.
  Guard the logic inside (`if (!tag) return []`) rather than guarding the
  hook call. The memo now runs during loading/error but computes an empty
  array — negligible cost.
- Swept the rest of the file. The main `TagDetail` component had only the
  one misplaced hook. The `TaggedEntitiesSection` sub-component's `useMemo`
  calls are already above its early returns and remain untouched.
- Added a regression test in `TagDetail.test.tsx` that exercises the
  `undefined → populated` transition within a single mounted component.
  The existing tests all passed against the broken code because mocked
  hooks don't preserve the TanStack Query hook count; the new test makes
  the mock call a real `useState` so the body-hook transition becomes the
  `N → N+1` mismatch React's hook-tracker actually detects. Verified
  locally: reverting the fix makes the new test fail with the exact error
  messages observed in production (`"Rendered more hooks than during the
  previous render."` and `"React has detected a change in the order of
  Hooks called by..."`).

## Test plan

- [x] `bun run test:run` — 2547/2547 pass, including the new regression test
- [x] Reverting the fix makes the new regression test fail with the exact
      production error
- [x] `bun run build` — clean production build
- [ ] Reviewer: load `/tags/shoegaze` (or any tag detail page) in a
      browser — should render the enriched detail page without a 500 and
      without any React hook-order error in the dev console

🤖 Generated with [Claude Code](https://claude.com/claude-code)