### PR TITLE
PSY-418: parallelize E2E via Playwright sharding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,9 +149,19 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   e2e-tests:
-    name: E2E Tests
+    name: E2E Tests (shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    # PSY-418: split the full E2E suite across 4 parallel shards. Each shard
+    # spins its own Docker stack + backend (via global-setup.ts) on an
+    # isolated runner, so there's no cross-shard port / DB contention.
+    # Shard count chosen from the PSY-417 baseline (93s test phase,
+    # 372s cumulative test-time) — 4 shards roughly quarters the test phase.
+    strategy:
+      fail-fast: false
+      matrix:
+        shardIndex: [1, 2, 3, 4]
+        shardTotal: [4]
     steps:
       - uses: actions/checkout@v4
 
@@ -173,14 +183,48 @@ jobs:
       - name: Install PostgreSQL client
         run: sudo apt-get install -y postgresql-client
 
-      - name: Run E2E tests
+      - name: Run E2E tests (shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
         working-directory: ./frontend
-        run: bun run test:e2e
+        run: bunx playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
         env:
           CI: true
 
-      - name: Upload Playwright report
+      - name: Upload blob report
         if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: blob-report-${{ matrix.shardIndex }}
+          path: frontend/blob-report/
+          retention-days: 1
+
+  e2e-report:
+    name: E2E Merged Report
+    # Run after all shards finish, even if some failed — we still want the
+    # merged report artifact for triage.
+    if: ${{ !cancelled() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    needs: [e2e-tests]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install frontend dependencies
+        working-directory: ./frontend
+        run: bun install --frozen-lockfile
+
+      - name: Download blob reports
+        uses: actions/download-artifact@v4
+        with:
+          path: all-blob-reports
+          pattern: blob-report-*
+          merge-multiple: true
+
+      - name: Merge into HTML report
+        working-directory: ./frontend
+        run: bunx playwright merge-reports --reporter html ../all-blob-reports
+
+      - name: Upload merged HTML report
         uses: actions/upload-artifact@v4
         with:
           name: playwright-report

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -8,7 +8,10 @@ export default defineConfig({
   // Cap local workers to the seeded user count (see USER_COUNT in
   // e2e/global-setup.ts). CI stays at 3; headroom lives in the 5 seeded users.
   workers: process.env.CI ? 3 : 5,
-  reporter: 'html',
+  // Blob reporter in CI so sharded runs can be merged via `playwright
+  // merge-reports` (see `.github/workflows/ci.yml`, PSY-418). HTML locally
+  // for dev ergonomics.
+  reporter: process.env.CI ? 'blob' : 'html',
 
   globalSetup: './e2e/global-setup.ts',
   globalTeardown: './e2e/global-teardown.ts',


### PR DESCRIPTION
## Summary

Split the single `e2e-tests` CI job into a **4-shard matrix** + a new `e2e-report` merge job. Each shard runs `bunx playwright test --shard=I/N` on its own GitHub Actions runner (own Docker stack + backend + DB — no cross-shard contention). Blob reports from each shard are downloaded and merged into a single HTML report for triage.

**Expected impact** (from PSY-417 baseline: 93s test phase + 14s setup + 2s teardown on 5 local workers, 372s cumulative test-time):
- Test phase per shard drops from 93s to ~25s
- Per-shard wall clock: 14s setup + ~25s tests + 2s teardown + 5–10s merge overhead ≈ **40–55 s total**
- Roughly 2× reduction in main-CI wall clock — meets PSY-418 acceptance

Changes:
- `frontend/playwright.config.ts` — `reporter: 'blob'` in CI (required by `playwright merge-reports`); HTML stays locally for dev ergonomics
- `.github/workflows/ci.yml` — matrix on `shardIndex: [1..4], shardTotal: [4]` with `fail-fast: false`; new `e2e-report` job with `needs: [e2e-tests]` + `if: !cancelled()` so merged report lands even when a shard flakes

Closes PSY-418.

## Test plan

Can't run E2E locally for this PR — another agent has the backend on port 8080. CI is the validator.

- [x] YAML parses cleanly (`yaml.safe_load`)
- [x] `playwright merge-reports` exists and accepts `--reporter html` + positional dir (Playwright 1.58.2)
- [x] `playwright.config.ts` unchanged for local dev (only CI path is new)
- [ ] CI run confirms 4 shards execute in parallel and the merge job stitches a single `playwright-report` artifact
- [ ] Total `e2e-tests` + `e2e-report` wall clock on main is materially lower than pre-sharding baseline

**Watch-outs on the first CI run:**
- If `frontend/blob-report/` is empty on a shard (setup failed mid-globalSetup), the upload step will fail; that's the intended signal
- The 4-shard Docker stack × 4 runners means 4× the GH Actions minutes compared to before. Acceptable for the wall-clock win; revisit if the bill hurts
- If `fail-fast: false` combined with a widespread flake blows up all four shards, the merge job still runs and we'll see a report with 4× the failures — that's informative, not a problem

🤖 Generated with [Claude Code](https://claude.com/claude-code)