### PR TITLE
PSY-455: backfill E2E coverage for add-to-collection flow

### DIFF
--- a/docs/strategy/testing-layers.md
+++ b/docs/strategy/testing-layers.md
@@ -144,7 +144,7 @@ Journeys are grouped by persona. Each row is a journey a user must be able to co
 | Reply to a comment | Nested reply (depth ≤ 3) | uncovered | component | Thread rendering is component-testable; one E2E smoke adequate. |
 | Vote on a comment | Upvote/downvote, Wilson score update | uncovered | integration | Score math is a Go test; button-flip is component. |
 | Field note on past show | Create field note with ratings/spoiler/verified | uncovered | mixed | Component tests exist for form/card rendering; end-to-end create→display loop uncovered. |
-| Add to collection | Add a show/artist/etc to a collection | uncovered | E2E (stays) | Full-stack flow shipped in PSY-314; zero automated coverage. |
+| Add to collection | Add a show/artist/etc to a collection | E2E (add-to-collection.spec.ts) | E2E (stays) | Full-stack flow shipped in PSY-314; smoke backfilled in PSY-455. |
 | Remove from collection | Remove via collection detail page | uncovered | component | UI assertion after mocked DELETE. |
 | Reorder collection items | Up/down buttons reorder items | uncovered | component | Pure UI; mock backend. |
 | Per-item notes | Add/edit a note on a collection item | uncovered | component | Inline edit; mockable. |
@@ -213,7 +213,7 @@ Flagged below with **[backfill]** for gaps worth filing follow-up tickets. Don't
 
 - **[backfill]** Follow system (artist/venue): PSY-56 shipped, zero E2E coverage — pick one smoke journey.
 - **[backfill]** Going/Interested on shows: PSY-55 shipped, zero automated coverage.
-- **[backfill]** Collections mutation flows: add-to-collection, create-collection — the feature's main value prop has no automated coverage beyond unit/component-level hooks.
+- **[backfill]** Collections mutation flows: create-collection — add-to-collection now covered by `e2e/pages/add-to-collection.spec.ts` (PSY-455); the inline "create new collection from picker" path still has no automated coverage beyond unit/component-level hooks.
 - **[backfill]** Comments: entire feature (create, reply, vote, edit, report) has zero E2E; component tests exist for rendering but not for the full loop.
 - **[backfill]** Field notes: structured-data flow uncovered end-to-end.
 - **[backfill]** Entity edit drawer (PSY-127): community edit suggestions uncovered.
@@ -329,7 +329,7 @@ Nothing was categorized as `→ integration` because the existing specs are all 
 - **PSY-434** (component-migration): the `→ component` rows in the categorization table are the menu. Recommend migrating in **feature-flavored batches** (e.g., all auth→component in one PR, all ai-filler in one PR, all `.tabs switch` tests in one PR) — each batch should delete the E2E spec as its last commit so we never carry both.
 - **PSY-446** (smoke-on-PR): the 13 **Smoke** rows are the starting selection. Budget target: <60 s wall-clock on PR CI. If that's tight, drop down to 6–8 by preferring one smoke per persona (landing, register, login, save-show, favorite-venue, approve-pending-show).
 - **[backfill candidates]** The "Coverage gaps" list names ~13 shipped features with no E2E. The highest-value backfill candidates (real-user-impact × shipped-but-unverified):
-  1. **Collections add-to-collection flow** (PSY-314, shipped, no coverage — PMF-critical feature).
+  1. ~~**Collections add-to-collection flow** (PSY-314, shipped, no coverage — PMF-critical feature).~~ Addressed by PSY-455 (`e2e/pages/add-to-collection.spec.ts`, tagged `@smoke`).
   2. **Comments create + reply + vote** (Wave 1–5, shipped, no coverage — community moat).
   3. **Follow / Going-Interested** (PSY-55, -56, shipped, no coverage — cheap smoke).
 

--- a/frontend/e2e/pages/add-to-collection.spec.ts
+++ b/frontend/e2e/pages/add-to-collection.spec.ts
@@ -1,0 +1,122 @@
+import { test, expect } from '../fixtures'
+
+// PSY-455: E2E coverage for the add-to-collection golden path.
+// Phase 2a shipped the collections UX overhaul without E2E coverage; this
+// smoke exercises the PMF-critical flow from an entity detail page.
+//
+// PSY-430 reserved-row pattern: pin to a dedicated reserved show so parallel
+// mutating specs in other files don't race on the same .first() row.
+//
+// PSY-431 per-worker users: each worker-user has its own pre-seeded
+// "E2E Worker Collection" (see setup-db.sh) so the test doesn't have to
+// create one and doesn't race on shared collection state.
+const RESERVED_SHOW_SLUG = 'e2e-add-to-collection-test'
+const RESERVED_SHOW_TITLE = 'E2E [add-to-collection-test]'
+const RESERVED_SHOW_URL = `/shows/${RESERVED_SHOW_SLUG}`
+const RESERVED_COLLECTION_TITLE = 'E2E Worker Collection'
+
+test.describe('Add to Collection', () => {
+  test(
+    'adds a show to a worker-owned collection from the detail page',
+    { tag: '@smoke' },
+    async ({ authenticatedPage }) => {
+      // 1. Navigate to the reserved show detail page.
+      await authenticatedPage.goto(RESERVED_SHOW_URL)
+      // Breadcrumb shows the show title; the H1 is the headlining artist name,
+      // so we verify the right show loaded via the breadcrumb.
+      await expect(
+        authenticatedPage
+          .getByRole('navigation', { name: 'Breadcrumb' })
+          .getByText(RESERVED_SHOW_TITLE)
+      ).toBeVisible({ timeout: 10_000 })
+
+      // 2. Open the Add to Collection popover.
+      // The trigger button has aria-label="Add to Collection" and visible
+      // text "Collect" (AddToCollectionButton.tsx).
+      const collectButton = authenticatedPage.getByRole('button', {
+        name: 'Add to Collection',
+      })
+      await expect(collectButton).toBeVisible({ timeout: 5_000 })
+      await collectButton.click()
+
+      // 3. Pick the pre-seeded "E2E Worker Collection" from the picker.
+      // The picker renders each collection as a button whose text is the
+      // collection title.
+      const collectionRow = authenticatedPage.getByRole('button', {
+        name: RESERVED_COLLECTION_TITLE,
+      })
+      await expect(collectionRow).toBeVisible({ timeout: 5_000 })
+
+      // PSY-430: waitForResponse wraps the mutation so we don't race on the
+      // optimistic UI state — the popover shows success before the network
+      // request completes.
+      const [addResponse] = await Promise.all([
+        authenticatedPage.waitForResponse(
+          (resp) =>
+            resp.url().includes('/collections/') &&
+            resp.url().includes('/items') &&
+            resp.request().method() === 'POST',
+          { timeout: 10_000 }
+        ),
+        collectionRow.click(),
+      ])
+      expect(addResponse.status()).toBeLessThan(400)
+
+      // Extract the collection slug from the mutation URL so we can navigate
+      // to the exact collection owned by this worker-user.
+      // URL shape: .../collections/<slug>/items
+      const slugMatch = addResponse.url().match(/\/collections\/([^/]+)\/items/)
+      expect(slugMatch).not.toBeNull()
+      const collectionSlug = slugMatch![1]
+
+      // 4. Confirm success feedback rendered in the popover.
+      await expect(
+        authenticatedPage.getByText(`Added to "${RESERVED_COLLECTION_TITLE}"`)
+      ).toBeVisible({ timeout: 5_000 })
+
+      // 5. Navigate to the collection detail page.
+      await authenticatedPage.goto(`/collections/${collectionSlug}`)
+      await expect(
+        authenticatedPage.getByRole('heading', {
+          name: RESERVED_COLLECTION_TITLE,
+        })
+      ).toBeVisible({ timeout: 10_000 })
+
+      // 6. Verify the show appears in the collection's items list.
+      // Each item links to the entity via entity_name as link text.
+      const itemLink = authenticatedPage.getByRole('link', {
+        name: RESERVED_SHOW_TITLE,
+      })
+      await expect(itemLink).toBeVisible({ timeout: 5_000 })
+      await expect(itemLink).toHaveAttribute(
+        'href',
+        `/shows/${RESERVED_SHOW_SLUG}`
+      )
+
+      // 7. Cleanup — remove the item so the test is idempotent across reruns.
+      // The remove flow is two-step: click the X (title="Remove from collection"),
+      // then confirm by clicking the "Remove" button that replaces it. Scope to
+      // the item row so the selectors stay specific even if other items land
+      // in the collection in the future.
+      const itemRow = authenticatedPage
+        .locator('div.rounded-lg')
+        .filter({ has: itemLink })
+        .first()
+
+      await itemRow.getByTitle('Remove from collection').click()
+
+      await Promise.all([
+        authenticatedPage.waitForResponse(
+          (resp) =>
+            resp.url().includes(`/collections/${collectionSlug}/items/`) &&
+            resp.request().method() === 'DELETE',
+          { timeout: 10_000 }
+        ),
+        itemRow.getByRole('button', { name: 'Remove', exact: true }).click(),
+      ])
+
+      // The item should be gone after the DELETE completes.
+      await expect(itemLink).not.toBeVisible({ timeout: 5_000 })
+    }
+  )
+})

--- a/frontend/e2e/setup-db.sh
+++ b/frontend/e2e/setup-db.sh
@@ -298,6 +298,21 @@ BEGIN
   RETURNING id INTO s_id;
   INSERT INTO show_venues (show_id, venue_id) VALUES (s_id, v_id);
   INSERT INTO show_artists (show_id, artist_id, position, set_type) VALUES (s_id, a_id, 0, 'headliner');
+
+  -- add-to-collection.spec.ts "adds a show to a collection from the detail page"
+  -- (PSY-455). Dedicated reserved show so we don't race with save-show or
+  -- collection.spec.ts which both mutate e2e-collection-saved-show.
+  INSERT INTO shows (title, event_date, city, state, status, slug, created_at, updated_at)
+  VALUES (
+    'E2E [add-to-collection-test]',
+    NOW() + INTERVAL '4 hours',
+    'Phoenix', 'AZ', 'approved',
+    'e2e-add-to-collection-test',
+    NOW(), NOW()
+  )
+  RETURNING id INTO s_id;
+  INSERT INTO show_venues (show_id, venue_id) VALUES (s_id, v_id);
+  INSERT INTO show_artists (show_id, artist_id, position, set_type) VALUES (s_id, a_id, 0, 'headliner');
 END $$;
 SQL
 
@@ -411,6 +426,37 @@ BEGIN
       (nts_id, 'Charlie Bones', 'charlie-bones-nts', 'Charlie Bones', 'Eclectic morning show with jazz, soul, funk.', 'Weekdays 10 AM-1 PM GMT', 'https://www.nts.live/shows/charlie-bones', 'charlie-bones', true, NOW(), NOW())
     ON CONFLICT DO NOTHING;
   END IF;
+END $$;
+SQL
+
+echo "==> Seeding reserved per-worker collections (PSY-455)..."
+psql -v ON_ERROR_STOP=1 "$E2E_DB_URL" <<'SQL'
+-- One "E2E Worker Collection" per worker-user so add-to-collection.spec.ts
+-- can target a collection owned by whichever worker-user picks up the test.
+-- Slug = e2e-worker-collection-<user_id>, unique per user per the collections
+-- table's UNIQUE(slug) constraint. The e2e DB is wiped per-run by Docker,
+-- so no ON CONFLICT is needed.
+DO $$
+DECLARE
+  worker_user RECORD;
+BEGIN
+  FOR worker_user IN
+    SELECT id FROM users WHERE email LIKE 'e2e-user%@test.local'
+  LOOP
+    INSERT INTO collections (
+      title, slug, description, creator_id,
+      collaborative, is_public, is_featured,
+      created_at, updated_at
+    )
+    VALUES (
+      'E2E Worker Collection',
+      'e2e-worker-collection-' || worker_user.id,
+      'Reserved collection for add-to-collection E2E smoke tests (PSY-455).',
+      worker_user.id,
+      false, true, false,
+      NOW(), NOW()
+    );
+  END LOOP;
 END $$;
 SQL
 


### PR DESCRIPTION
## Summary
- New E2E spec (`frontend/e2e/pages/add-to-collection.spec.ts`, tagged `@smoke`) covering the add-to-collection golden path: reserved show → Add to Collection popover → reserved per-worker collection → verify membership on `/collections/{slug}` → remove for idempotency. Uses `Promise.all([waitForResponse, click])` per PSY-430 on both the POST (add) and DELETE (cleanup) mutations.
- Reserved rows seeded per worker-user in `frontend/e2e/setup-db.sh` (PSY-430 + PSY-431 patterns): one reserved show `e2e-add-to-collection-test` and one `E2E Worker Collection` per seeded worker-user (slug `e2e-worker-collection-<user_id>`). Collection is owned by the worker-user so `AddItem`'s creator-permission branch succeeds regardless of collaborative flag.
- `docs/strategy/testing-layers.md` coverage catalog updated: row flipped from uncovered → E2E (new spec), backfill note scoped to just create-collection, and the #1 recommended-follow-up entry marked addressed.

## Test plan
- [ ] CI E2E suite passes (local validation skipped — port 8080 held by another agent; static checks only)
- [x] TypeScript clean on the new spec (full-repo `tsc` has pre-existing errors in other `*.test.tsx` files, unchanged)
- [x] ESLint clean on the new spec
- [x] `bash -n e2e/setup-db.sh` passes
- [ ] Spec tagged `@smoke` for PSY-446 selection

Closes PSY-455

🤖 Generated with [Claude Code](https://claude.com/claude-code)