### PR TITLE
Render tags on venue, festival, and label detail pages

### DIFF
--- a/frontend/features/festivals/components/FestivalDetail.tsx
+++ b/frontend/features/festivals/components/FestivalDetail.tsx
@@ -37,6 +37,7 @@ import {
 import { useIsAuthenticated } from '@/features/auth'
 import { EntityEditDrawer, AttributionLine, ReportEntityDialog, ContributionPrompt } from '@/features/contributions'
 import { CommentThread } from '@/features/comments'
+import { EntityTagList } from '@/features/tags'
 import { useQueryClient } from '@tanstack/react-query'
 
 interface FestivalDetailProps {
@@ -482,6 +483,15 @@ export function FestivalDetail({ idOrSlug }: FestivalDetailProps) {
         </div>
       </TabsContent>
     </EntityDetailLayout>
+
+    {/* Tags */}
+    <div className="mt-0 px-4 md:px-0">
+      <EntityTagList
+        entityType="festival"
+        entityId={festival.id}
+        isAuthenticated={isAuthenticated}
+      />
+    </div>
 
     {/* Discussion */}
     <div className="mt-0 px-4 md:px-0">

--- a/frontend/features/labels/components/LabelDetail.tsx
+++ b/frontend/features/labels/components/LabelDetail.tsx
@@ -15,7 +15,9 @@ import { useLabel, useLabelRoster, useLabelCatalog } from '../hooks/useLabels'
 import { EntityDetailLayout, EntityHeader, SocialLinks, FollowButton, AddToCollectionButton } from '@/components/shared'
 import { EntityCollections } from '@/features/collections'
 import { CommentThread } from '@/features/comments'
+import { EntityTagList } from '@/features/tags'
 import { NotifyMeButton } from '@/features/notifications'
+import { useIsAuthenticated } from '@/features/auth'
 import { TabsContent } from '@/components/ui/tabs'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -32,6 +34,7 @@ interface LabelDetailProps {
 
 export function LabelDetail({ idOrSlug }: LabelDetailProps) {
   const { data: label, isLoading, error } = useLabel({ idOrSlug })
+  const { isAuthenticated } = useIsAuthenticated()
   const { data: rosterData, isLoading: rosterLoading } = useLabelRoster({
     labelIdOrSlug: idOrSlug,
     enabled: !!label,
@@ -329,6 +332,15 @@ export function LabelDetail({ idOrSlug }: LabelDetailProps) {
         </div>
       </TabsContent>
     </EntityDetailLayout>
+
+    {/* Tags */}
+    <div className="mt-0 px-4 md:px-0">
+      <EntityTagList
+        entityType="label"
+        entityId={label.id}
+        isAuthenticated={isAuthenticated}
+      />
+    </div>
 
     {/* Discussion */}
     <div className="mt-0 px-4 md:px-0">

--- a/frontend/features/venues/components/VenueDetail.test.tsx
+++ b/frontend/features/venues/components/VenueDetail.test.tsx
@@ -137,6 +137,10 @@ vi.mock('@/features/comments', () => ({
   ),
 }))
 
+vi.mock('@/features/tags', () => ({
+  EntityTagList: () => <div data-testid="entity-tag-list" />,
+}))
+
 vi.mock('@/components/ui/button', () => ({
   Button: ({ children, asChild, ...props }: { children: React.ReactNode; asChild?: boolean; [key: string]: unknown }) => {
     if (asChild) return <>{children}</>

--- a/frontend/features/venues/components/VenueDetail.tsx
+++ b/frontend/features/venues/components/VenueDetail.tsx
@@ -13,6 +13,7 @@ import { queryKeys } from '@/lib/queryClient'
 import { SocialLinks, RevisionHistory, FollowButton, Breadcrumb, TagPill, EntityDescription, AddToCollectionButton } from '@/components/shared'
 import { EntityCollections } from '@/features/collections'
 import { CommentThread } from '@/features/comments'
+import { EntityTagList } from '@/features/tags'
 import { NotifyMeButton } from '@/features/notifications'
 import { VenueLocationCard } from './VenueLocationCard'
 import { VenueShowsList } from './VenueShowsList'
@@ -316,6 +317,15 @@ export function VenueDetail({ venueId }: VenueDetailProps) {
             <EntityCollections entityType="venue" entityId={venue.id} />
           </div>
         </div>
+      </div>
+
+      {/* Tags */}
+      <div className="mt-0 px-4 md:px-0">
+        <EntityTagList
+          entityType="venue"
+          entityId={venue.id}
+          isAuthenticated={isAuthenticated}
+        />
       </div>
 
       {/* Revision History */}


### PR DESCRIPTION
Closes PSY-449

## Root cause

Backend supports tags on all six entity types (artist, show, release, venue, festival, label), but the frontend only rendered `EntityTagList` on three of them. Venue, festival, and label detail pages had no tag UI — dogfood flagged this as a gap (`dogfood-output/tags-audit-3/report.md` ISSUE-009).

## What changed

Added `EntityTagList` to `VenueDetail`, `FestivalDetail`, and `LabelDetail`, following the placement pattern already used by `ArtistDetail` and `ReleaseDetail`:

```tsx
<div className="mt-0 px-4 md:px-0">
  <EntityTagList entityType="..." entityId={entity.id} isAuthenticated={isAuthenticated} />
</div>
```

Placed between the main layout and `RevisionHistory` / `CommentThread`.

- `LabelDetail` had no auth hook; added `useIsAuthenticated` from `@/features/auth` (matches `FestivalDetail`).
- `VenueDetail.test.tsx` gets a `@/features/tags` mock mirroring `ShowDetail.test.tsx`.
- `TAG_ENTITY_TYPES` in `features/tags/types.ts` already includes `venue | festival | label` — no type widening.

**Explicitly scope-limited:** no redesign or header-move — that's PSY-439.

## Known inconsistency (not fixed here)

`ShowDetail.tsx` renders `EntityTagList` without the `mt-0 px-4 md:px-0` wrapper the other 5 now share. Worth a 1-line follow-up if uniformity matters; out of scope for this PR.

## Test plan

- [x] `bun run test:run -- features/tags` — 89 pass
- [x] `bun run test:run -- features/venues/components/VenueDetail` — 28 pass
- [x] `bun run test:run` (full suite) — 2547 pass
- [ ] Reviewer: visit `/venues/{slug}`, `/festivals/{slug}`, `/labels/{slug}` — verify tags render at the bottom and authenticated users can add/remove tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)
