### PR TITLE
Hide anonymous contributors on tag detail page

### DIFF
--- a/frontend/features/tags/components/TagDetail.test.tsx
+++ b/frontend/features/tags/components/TagDetail.test.tsx
@@ -662,7 +662,7 @@ describe('TagDetail', () => {
     expect(screen.getByText('(5)')).toBeInTheDocument()
   })
 
-  it('renders fallback id when contributor has no username', () => {
+  it('hides anonymous contributors and hides the section when all are anonymous (PSY-450)', () => {
     mockUseTagDetail.mockReturnValue({
       data: makeTagDetail({
         top_contributors: [{ user: { id: 99 }, count: 3 }],
@@ -673,7 +673,31 @@ describe('TagDetail', () => {
 
     renderWithProviders(<TagDetail slug="rock" />)
 
-    expect(screen.getByText('user #99')).toBeInTheDocument()
+    // Never leak the internal DB id as a fallback label.
+    expect(screen.queryByText(/user #\d+/)).not.toBeInTheDocument()
+    // When every contributor is anonymous the section must be hidden entirely.
+    expect(screen.queryByTestId('top-contributors')).not.toBeInTheDocument()
+  })
+
+  it('shows only named contributors when the list is mixed (PSY-450)', () => {
+    mockUseTagDetail.mockReturnValue({
+      data: makeTagDetail({
+        top_contributors: [
+          { user: { id: 1, username: 'alice' }, count: 8 },
+          { user: { id: 42 }, count: 6 },
+          { user: { id: 2, username: 'bob' }, count: 2 },
+        ],
+      }),
+      isLoading: false,
+      error: null,
+    })
+
+    renderWithProviders(<TagDetail slug="rock" />)
+
+    expect(screen.getByTestId('top-contributors')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: '@alice' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: '@bob' })).toBeInTheDocument()
+    expect(screen.queryByText(/user #\d+/)).not.toBeInTheDocument()
   })
 
   it('hides top contributors section when empty', () => {

--- a/frontend/features/tags/components/TagDetail.tsx
+++ b/frontend/features/tags/components/TagDetail.tsx
@@ -63,6 +63,15 @@ export function TagDetail({ slug }: TagDetailProps) {
       .filter((e) => e.count > 0)
   }, [tag])
 
+  // Top contributors: hide anonymous contributors (no username). Rendering
+  // `user #{id}` leaks an internal DB row id and reads like placeholder content
+  // (PSY-450). Contributors without a public username haven't opted in to
+  // public attribution anyway.
+  const visibleContributors = useMemo(() => {
+    if (!tag?.top_contributors) return []
+    return tag.top_contributors.filter((c) => Boolean(c.user.username))
+  }, [tag])
+
   if (isLoading) {
     return (
       <div className="flex min-h-[60vh] items-center justify-center">
@@ -269,30 +278,26 @@ export function TagDetail({ slug }: TagDetailProps) {
         </div>
       )}
 
-      {/* Top contributors */}
-      {tag.top_contributors && tag.top_contributors.length > 0 && (
+      {/* Top contributors — anonymous contributors (no username) are hidden;
+          see PSY-450. If every contributor is anonymous, the section is hidden
+          entirely rather than showing an empty header. */}
+      {visibleContributors.length > 0 && (
         <section className="mb-8" data-testid="top-contributors">
           <h2 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
             Top contributors
           </h2>
           <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm">
-            {tag.top_contributors.map((c, idx) => {
-              const handle = c.user.username
+            {visibleContributors.map((c, idx) => {
+              const handle = c.user.username as string
               return (
                 <span key={c.user.id} className="inline-flex items-center gap-1">
                   {idx > 0 && <span className="text-muted-foreground/40">{'·'}</span>}
-                  {handle ? (
-                    <Link
-                      href={`/users/${handle}`}
-                      className="text-foreground hover:underline"
-                    >
-                      @{handle}
-                    </Link>
-                  ) : (
-                    <span className="text-muted-foreground">
-                      user #{c.user.id}
-                    </span>
-                  )}
+                  <Link
+                    href={`/users/${handle}`}
+                    className="text-foreground hover:underline"
+                  >
+                    @{handle}
+                  </Link>
                   <span className="text-muted-foreground">({c.count})</span>
                 </span>
               )


### PR DESCRIPTION
Closes PSY-450

## Root cause

The tag detail page's "Top Contributors" section rendered `user #{id}` for contributors without a public username, leaking internal DB row ids into the UI. Flagged in `dogfood-output/tags-audit-3/report.md` ISSUE-002.

## What changed

- Filter contributors without a `username` out of the rendered list via a new `visibleContributors` useMemo.
- Hide the whole section when every contributor is anonymous — no empty header.
- Tests cover the all-anonymous case (section disappears) and the mixed case (only named contributors render; no `user #N` leaks).

## Test plan

- [x] `bun run test:run -- features/tags` — 90 pass (1 new regression test, 1 existing expectation updated)
- [ ] Reviewer: visit `/tags/{slug}`; "Top Contributors" should render only named users or be hidden entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)
