### PR TITLE
PSY-446: smoke-on-PR + full-suite-post-merge E2E split

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,56 @@ jobs:
           flags: frontend
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  e2e-smoke:
+    name: E2E Smoke (PR)
+    # PSY-446: fast PR feedback. Runs only `@smoke`-tagged Playwright tests
+    # in a single unsharded run (~17 tests) with a <3 min wall-clock budget.
+    # Reuses the same global-setup as `e2e-tests` (Docker Postgres, migrations,
+    # seed, backend). Branch-protection / required-check config is handled
+    # outside this workflow.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    # Safety net against runaway flake; smoke is expected to finish in ~1–2 min.
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.24'
+          cache-dependency-path: backend/go.sum
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install frontend dependencies
+        working-directory: ./frontend
+        run: bun install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        working-directory: ./frontend
+        run: bunx playwright install --with-deps chromium
+
+      - name: Install PostgreSQL client
+        run: sudo apt-get install -y postgresql-client
+
+      - name: Run E2E smoke suite (@smoke)
+        working-directory: ./frontend
+        # `list` reporter gives concise CI output; `html` (written to disk,
+        # never opened) gives a downloadable artifact on failure. 3 workers
+        # matches CI default.
+        run: bunx playwright test --grep @smoke --workers=3 --reporter=list,html
+        env:
+          CI: true
+          PLAYWRIGHT_HTML_OPEN: never
+
+      - name: Upload Playwright HTML report (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-smoke
+          path: frontend/playwright-report/
+          retention-days: 7
+
   e2e-tests:
     name: E2E Tests (shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,7 @@ Global setup starts Docker PostgreSQL (port 5433), runs migrations, seeds data (
 - **Auth fixtures**: `e2e/.auth/user.json`, `e2e/.auth/admin.json`
 - **Error detection**: Auto-fail on console errors/5xx responses (`e2e/fixtures/error-detection.ts`)
 - **API mocking**: `page.route('**/api/...')` intercepts at browser level; use 200+`success:false` (not 5xx) to avoid error fixture
+- **Smoke vs full suite** (PSY-446): `@smoke`-tagged tests gate every PR (`e2e-smoke` CI job, <3 min wall-clock budget). The full sharded suite runs post-merge only (`e2e-tests`, 4 shards). Tag a test `@smoke` when it is the canonical golden path for a persona/flow, cheap (<5s typical), and stable. One smoke per flow is the target — don't tag a second test that exercises the same path. Syntax: `test('name', { tag: '@smoke' }, async ({}) => { ... })`. Rationale + the 2026-04 audit live in `docs/strategy/testing-layers.md`.
 
 ### Discovery App
 

--- a/docs/strategy/testing-layers.md
+++ b/docs/strategy/testing-layers.md
@@ -330,7 +330,7 @@ Nothing was categorized as `→ integration` because the existing specs are all 
 ## Recommended follow-ups
 
 - **PSY-434** (component-migration): the `→ component` rows in the categorization table are the menu. Recommend migrating in **feature-flavored batches** (e.g., all auth→component in one PR, all ai-filler in one PR, all `.tabs switch` tests in one PR) — each batch should delete the E2E spec as its last commit so we never carry both.
-- **PSY-446** (smoke-on-PR): the 13 **Smoke** rows are the starting selection. Budget target: <60 s wall-clock on PR CI. If that's tight, drop down to 6–8 by preferring one smoke per persona (landing, register, login, save-show, favorite-venue, approve-pending-show).
+- **PSY-446** (smoke-on-PR) — **implemented**: 17 tests tagged `@smoke` (12 from this audit's Smoke bucket + 5 from the PSY-455/456/457 backfill specs). Runs on every PR via the `e2e-smoke` CI job (`bunx playwright test --grep @smoke --workers=3`) with a <3 min wall-clock budget; the full sharded suite stays as post-merge signal. `submit-show.spec.ts:34` is deferred with a TODO pending PSY-437 flake resolution.
 - **[backfill candidates]** The "Coverage gaps" list names ~13 shipped features with no E2E. The highest-value backfill candidates (real-user-impact × shipped-but-unverified):
   1. ~~**Collections add-to-collection flow** (PSY-314, shipped, no coverage — PMF-critical feature).~~ Addressed by PSY-455 (`e2e/pages/add-to-collection.spec.ts`, tagged `@smoke`).
   2. ~~**Comments create + reply + vote** (Wave 1–5, shipped, no coverage — community moat).~~ Addressed by PSY-456 (`pages/comments.spec.ts`).

--- a/frontend/e2e/admin/pending-shows.spec.ts
+++ b/frontend/e2e/admin/pending-shows.spec.ts
@@ -29,7 +29,7 @@ test.describe('Admin: Pending Shows', () => {
     ).toBeVisible()
   })
 
-  test('can approve a pending show', async ({ adminPage }) => {
+  test('can approve a pending show', { tag: '@smoke' }, async ({ adminPage }) => {
     await adminPage.goto('/admin/pending-shows')
 
     // Wait for page to load

--- a/frontend/e2e/auth/login.spec.ts
+++ b/frontend/e2e/auth/login.spec.ts
@@ -7,7 +7,7 @@ const TEST_USER = {
 }
 
 test.describe('Login', () => {
-  test('logs in with valid credentials and redirects to home', async ({
+  test('logs in with valid credentials and redirects to home', { tag: '@smoke' }, async ({
     page,
   }) => {
     await page.goto('/auth')
@@ -59,7 +59,7 @@ test.describe('Login', () => {
     expect(page.url()).toContain('/auth')
   })
 
-  test('logout returns to unauthenticated state', async ({ page }) => {
+  test('logout returns to unauthenticated state', { tag: '@smoke' }, async ({ page }) => {
     // Log in first
     await page.goto('/auth')
     await page.getByLabel('Email').fill(TEST_USER.email)

--- a/frontend/e2e/auth/magic-link.spec.ts
+++ b/frontend/e2e/auth/magic-link.spec.ts
@@ -17,7 +17,7 @@ function getUserId(email: string): number {
 }
 
 test.describe('Magic Link Authentication', () => {
-  test('authenticates user with valid magic link', async ({ page }) => {
+  test('authenticates user with valid magic link', { tag: '@smoke' }, async ({ page }) => {
     const userId = getUserId(TEST_USER_EMAIL)
 
     // Generate a valid magic link JWT

--- a/frontend/e2e/auth/register.spec.ts
+++ b/frontend/e2e/auth/register.spec.ts
@@ -7,7 +7,7 @@ const REGISTER_USER = {
 }
 
 test.describe('Registration', () => {
-  test('registers a new account and redirects to home', async ({ page }) => {
+  test('registers a new account and redirects to home', { tag: '@smoke' }, async ({ page }) => {
     await page.goto('/auth')
 
     // Switch to signup tab

--- a/frontend/e2e/pages/city-filter.spec.ts
+++ b/frontend/e2e/pages/city-filter.spec.ts
@@ -24,7 +24,7 @@ test.describe('City filter on shows list', () => {
     ).toBeVisible()
   })
 
-  test('clicking a city in combobox updates URL and filters shows', async ({
+  test('clicking a city in combobox updates URL and filters shows', { tag: '@smoke' }, async ({
     page,
   }) => {
     await page.goto('/shows')

--- a/frontend/e2e/pages/collection.spec.ts
+++ b/frontend/e2e/pages/collection.spec.ts
@@ -63,7 +63,7 @@ test.describe('Library page (formerly /collection)', () => {
     await authenticatedPage.waitForURL('/library')
   })
 
-  test('shows saved show after saving one', async ({
+  test('shows saved show after saving one', { tag: '@smoke' }, async ({
     authenticatedPage,
   }) => {
     // PSY-430: pin to a reserved show seeded by setup-db.sh so parallel

--- a/frontend/e2e/pages/favorite-venue.spec.ts
+++ b/frontend/e2e/pages/favorite-venue.spec.ts
@@ -28,7 +28,7 @@ test.describe('Favorite venue', () => {
     ).not.toBeVisible()
   })
 
-  test('can favorite and unfavorite a venue from detail page', async ({
+  test('can favorite and unfavorite a venue from detail page', { tag: '@smoke' }, async ({
     authenticatedPage,
   }) => {
     await authenticatedPage.goto(RESERVED_VENUE_URL)

--- a/frontend/e2e/pages/home.spec.ts
+++ b/frontend/e2e/pages/home.spec.ts
@@ -2,7 +2,7 @@ import { test } from '../fixtures/error-detection'
 import { expect } from '@playwright/test'
 
 test.describe('Homepage', () => {
-  test('loads and displays upcoming shows', async ({ page }) => {
+  test('loads and displays upcoming shows', { tag: '@smoke' }, async ({ page }) => {
     await page.goto('/')
 
     // Page title

--- a/frontend/e2e/pages/protected-routes.spec.ts
+++ b/frontend/e2e/pages/protected-routes.spec.ts
@@ -2,7 +2,7 @@ import { test } from '../fixtures/error-detection'
 import { expect } from '@playwright/test'
 
 test.describe('Protected route redirects', () => {
-  test('unauthenticated user is redirected from /library to /auth', async ({
+  test('unauthenticated user is redirected from /library to /auth', { tag: '@smoke' }, async ({
     page,
   }) => {
     // /library is the consolidated auth-gated page (was /collection pre-PSY-275).

--- a/frontend/e2e/pages/save-show.spec.ts
+++ b/frontend/e2e/pages/save-show.spec.ts
@@ -26,7 +26,7 @@ test.describe('Save/unsave a show', () => {
     ).not.toBeVisible()
   })
 
-  test('can save and unsave a show from detail page', async ({
+  test('can save and unsave a show from detail page', { tag: '@smoke' }, async ({
     authenticatedPage,
   }) => {
     await authenticatedPage.goto(RESERVED_SHOW_URL)

--- a/frontend/e2e/pages/shows.spec.ts
+++ b/frontend/e2e/pages/shows.spec.ts
@@ -2,7 +2,7 @@ import { test } from '../fixtures/error-detection'
 import { expect } from '@playwright/test'
 
 test.describe('Shows list', () => {
-  test('loads and displays upcoming shows', async ({ page }) => {
+  test('loads and displays upcoming shows', { tag: '@smoke' }, async ({ page }) => {
     await page.goto('/shows')
 
     await expect(page).toHaveTitle(/Upcoming Shows/)

--- a/frontend/e2e/pages/submit-show.spec.ts
+++ b/frontend/e2e/pages/submit-show.spec.ts
@@ -31,6 +31,10 @@ test.describe('Submit a show', () => {
     ).toBeVisible()
   })
 
+  // TODO(PSY-446/PSY-437): add `{ tag: '@smoke' }` once the Valley Bar
+  // autocomplete flake is resolved. Classified as a Smoke candidate by
+  // the PSY-445 audit (docs/strategy/testing-layers.md) — currently
+  // deferred to keep PR CI green. Track in PSY-437.
   test('can submit a show with existing venue', async ({
     authenticatedPage,
   }) => {


### PR DESCRIPTION
## Summary
- New `e2e-smoke` CI job runs on every PR: Playwright `--grep @smoke`, 3 workers, <3 min budget
- 12 existing tests tagged @smoke per the PSY-445 audit's Smoke bucket (PSY-437-flaking submit-show deferred with TODO)
- Existing sharded `e2e-tests` job stays as post-merge signal (no changes to PSY-418 infrastructure)
- CLAUDE.md updated with @smoke tagging guidance

## Smoke set (17 total)
- 12 existing: admin/pending-shows approve, auth/login + logout, auth/magic-link, auth/register, pages/city-filter, pages/collection (saved show), pages/favorite-venue, pages/home, pages/protected-routes, pages/save-show, pages/shows
- 5 new (already tagged in PSY-455/456/457): add-to-collection, comments (create + reply), follow-and-attendance (both)

## Decisions codified
- Mechanism: Playwright @smoke tag (native API)
- Budget: <3 min wall-clock
- Gating: required-check-on-PR (branch-protection config handled separately by human)

## Test plan
- [ ] CI e2e-smoke job runs on this PR itself and passes under budget
- [ ] CI e2e-tests (full sharded) still runs post-merge only
- [ ] Intentional break test deferred — user will validate by breaking a smoke-tagged flow on a follow-up PR

## Notes
- PSY-437 submit-show flake tagging deferred: TODO comment in the spec pointing at PSY-437 for when it's stable
- PSY-411 post-merge signal is separate — required for catching non-smoke regressions that only surface post-merge

Closes PSY-446