### PR TITLE
Move tags into entity header on all 6 detail pages

### DIFF
--- a/frontend/features/artists/components/ArtistDetail.tsx
+++ b/frontend/features/artists/components/ArtistDetail.tsx
@@ -968,6 +968,11 @@ export function ArtistDetail({ artistId }: ArtistDetailProps) {
               actions={headerActions}
             />
             <AttributionLine entityType="artist" entityId={artist.id} />
+            <EntityTagList
+              entityType="artist"
+              entityId={artist.id}
+              isAuthenticated={isAuthenticated}
+            />
             <ContributionPrompt
               entityType="artist"
               entityId={artist.id}
@@ -1037,15 +1042,6 @@ export function ArtistDetail({ artistId }: ArtistDetailProps) {
 
       {/* Related Artists */}
       <RelatedArtists artistId={artist.id} artistSlug={artist.slug} />
-
-      {/* Tags */}
-      <div className="mt-0 px-4 md:px-0">
-        <EntityTagList
-          entityType="artist"
-          entityId={artist.id}
-          isAuthenticated={isAuthenticated}
-        />
-      </div>
 
       {/* Revision History */}
       <div className="mt-0">

--- a/frontend/features/festivals/components/FestivalDetail.tsx
+++ b/frontend/features/festivals/components/FestivalDetail.tsx
@@ -325,6 +325,11 @@ export function FestivalDetail({ idOrSlug }: FestivalDetailProps) {
             }
           />
           <AttributionLine entityType="festival" entityId={festival.id} />
+          <EntityTagList
+            entityType="festival"
+            entityId={festival.id}
+            isAuthenticated={isAuthenticated}
+          />
           <ContributionPrompt
             entityType="festival"
             entityId={festival.id}
@@ -483,15 +488,6 @@ export function FestivalDetail({ idOrSlug }: FestivalDetailProps) {
         </div>
       </TabsContent>
     </EntityDetailLayout>
-
-    {/* Tags */}
-    <div className="mt-0 px-4 md:px-0">
-      <EntityTagList
-        entityType="festival"
-        entityId={festival.id}
-        isAuthenticated={isAuthenticated}
-      />
-    </div>
 
     {/* Discussion */}
     <div className="mt-0 px-4 md:px-0">

--- a/frontend/features/labels/components/LabelDetail.tsx
+++ b/frontend/features/labels/components/LabelDetail.tsx
@@ -176,30 +176,37 @@ export function LabelDetail({ idOrSlug }: LabelDetailProps) {
       fallback={{ href: '/labels', label: 'Labels' }}
       entityName={label.name}
       header={
-        <EntityHeader
-          title={label.name}
-          subtitle={
-            <>
-              <Badge variant={getLabelStatusVariant(label.status)}>
-                {getLabelStatusLabel(label.status)}
-              </Badge>
-              {location && (
-                <span className="flex items-center gap-1">
-                  <MapPin className="h-3.5 w-3.5" />
-                  {location}
-                </span>
-              )}
-              {label.founded_year && <span>Est. {label.founded_year}</span>}
-            </>
-          }
-          actions={
-            <div className="flex items-center gap-2">
-              <NotifyMeButton entityType="label" entityId={label.id} entityName={label.name} />
-              <FollowButton entityType="labels" entityId={label.id} />
-              <AddToCollectionButton entityType="label" entityId={label.id} entityName={label.name} />
-            </div>
-          }
-        />
+        <>
+          <EntityHeader
+            title={label.name}
+            subtitle={
+              <>
+                <Badge variant={getLabelStatusVariant(label.status)}>
+                  {getLabelStatusLabel(label.status)}
+                </Badge>
+                {location && (
+                  <span className="flex items-center gap-1">
+                    <MapPin className="h-3.5 w-3.5" />
+                    {location}
+                  </span>
+                )}
+                {label.founded_year && <span>Est. {label.founded_year}</span>}
+              </>
+            }
+            actions={
+              <div className="flex items-center gap-2">
+                <NotifyMeButton entityType="label" entityId={label.id} entityName={label.name} />
+                <FollowButton entityType="labels" entityId={label.id} />
+                <AddToCollectionButton entityType="label" entityId={label.id} entityName={label.name} />
+              </div>
+            }
+          />
+          <EntityTagList
+            entityType="label"
+            entityId={label.id}
+            isAuthenticated={isAuthenticated}
+          />
+        </>
       }
       tabs={tabs}
       activeTab={activeTab}
@@ -332,15 +339,6 @@ export function LabelDetail({ idOrSlug }: LabelDetailProps) {
         </div>
       </TabsContent>
     </EntityDetailLayout>
-
-    {/* Tags */}
-    <div className="mt-0 px-4 md:px-0">
-      <EntityTagList
-        entityType="label"
-        entityId={label.id}
-        isAuthenticated={isAuthenticated}
-      />
-    </div>
 
     {/* Discussion */}
     <div className="mt-0 px-4 md:px-0">

--- a/frontend/features/releases/components/ReleaseDetail.tsx
+++ b/frontend/features/releases/components/ReleaseDetail.tsx
@@ -246,6 +246,11 @@ export function ReleaseDetail({ idOrSlug }: ReleaseDetailProps) {
               }
             />
             <AttributionLine entityType="release" entityId={release.id} />
+            <EntityTagList
+              entityType="release"
+              entityId={release.id}
+              isAuthenticated={isAuthenticated}
+            />
           </>
         }
         tabs={tabs}
@@ -342,15 +347,6 @@ export function ReleaseDetail({ idOrSlug }: ReleaseDetailProps) {
           </TabsContent>
         )}
       </EntityDetailLayout>
-
-      {/* Tags */}
-      <div className="mt-0 px-4 md:px-0">
-        <EntityTagList
-          entityType="release"
-          entityId={release.id}
-          isAuthenticated={isAuthenticated}
-        />
-      </div>
 
       {/* Revision History */}
       <div className="mt-0">

--- a/frontend/features/shows/components/ShowDetail.tsx
+++ b/frontend/features/shows/components/ShowDetail.tsx
@@ -280,6 +280,13 @@ export function ShowDetail({ showId }: ShowDetailProps) {
             {show.description && (
               <p className="mt-4 text-muted-foreground">{show.description}</p>
             )}
+
+            {/* Tags */}
+            <EntityTagList
+              entityType="show"
+              entityId={show.id}
+              isAuthenticated={isAuthenticated}
+            />
           </div>
 
           {/* Action Buttons */}
@@ -418,13 +425,6 @@ export function ShowDetail({ showId }: ShowDetailProps) {
           </div>
         </section>
       )}
-
-      {/* Tags */}
-      <EntityTagList
-        entityType="show"
-        entityId={show.id}
-        isAuthenticated={isAuthenticated}
-      />
 
       {/* In Collections */}
       <section className="mb-8">

--- a/frontend/features/venues/components/VenueDetail.tsx
+++ b/frontend/features/venues/components/VenueDetail.tsx
@@ -249,6 +249,13 @@ export function VenueDetail({ venueId }: VenueDetailProps) {
             {venue.social && (
               <SocialLinks social={venue.social} className="mt-4" />
             )}
+
+            {/* Tags */}
+            <EntityTagList
+              entityType="venue"
+              entityId={venue.id}
+              isAuthenticated={isAuthenticated}
+            />
           </header>
 
           {/* Contribution Prompt */}
@@ -317,15 +324,6 @@ export function VenueDetail({ venueId }: VenueDetailProps) {
             <EntityCollections entityType="venue" entityId={venue.id} />
           </div>
         </div>
-      </div>
-
-      {/* Tags */}
-      <div className="mt-0 px-4 md:px-0">
-        <EntityTagList
-          entityType="venue"
-          entityId={venue.id}
-          isAuthenticated={isAuthenticated}
-        />
       </div>
 
       {/* Revision History */}


### PR DESCRIPTION
Closes PSY-439

## Root cause

On all 6 entity detail pages, the Tags section rendered at the page bottom — below Related Artists, Field Notes, or Discussion. Users had to scroll deep to reach tags and `+ Add`. For a platform whose strategy calls tags "the discovery gateway," that de-prioritized the primary navigation primitive.

Prior art: Bandcamp, RYM, and What.cd all place tags in the entity header next to primary metadata. Evidence: `dogfood-output/tags-audit-2/report.md` ISSUE-006.

## What changed

`EntityTagList` moved from page-bottom to the entity header on all 6 detail pages:

| Page | Layout | New tag location |
|---|---|---|
| `ArtistDetail` | `EntityDetailLayout` | header, after `AttributionLine`, before `ContributionPrompt` |
| `ShowDetail` | hand-rolled `<header>` + `flex-1` | header left column, after description, alongside date/venue metadata |
| `VenueDetail` | hand-rolled 2-column grid | header left column, after `SocialLinks` |
| `ReleaseDetail` | `EntityDetailLayout` | header, after `AttributionLine` |
| `LabelDetail` | `EntityDetailLayout` | header, after `EntityHeader` |
| `FestivalDetail` | `EntityDetailLayout` | header, after `AttributionLine`, before `ContributionPrompt` |

`EntityDetailLayout` not modified — its `header` prop is already `React.ReactNode`, so the tag component slots into the existing fragment on each consuming page. No new props, no public API change.

Wrapper div (`mt-0 px-4 md:px-0`) previously used on 5 of 6 pages is dropped — the header owns its own spacing.

## Scoped-out per ticket

- **Mobile collapsible "Show all tags":** tracked as [PSY-460](https://linear.app/psychic-homily/issue/PSY-460). This PR ships with flex-wrap only — on narrow viewports the header may get tall.
- **ShowDetail layout refactor** (it's hand-rolled, not on `EntityDetailLayout`): tracked as [PSY-461](https://linear.app/psychic-homily/issue/PSY-461). Scope here was only to relocate the tag call-site inside `ShowDetail`'s existing header — layout structure untouched.

## Noted during research (not fixed here)

Surfaced but left for follow-up — worth knowing for future cleanup:

- **`VenueDetail` is also hand-rolled** (2-column grid), not just `ShowDetail`. PSY-461 is framed around ShowDetail but should probably include `VenueDetail` in its scope. Worth a comment on PSY-461.
- `ContributionPrompt` placement varies across pages: inside the header (Artist/Festival), below the header (Venue), or absent (Release/Label/Show).

## Test plan

- [x] `bun run test:run` — 2552/2552 across 193 files
- [x] `bun run build` — compiles in 9.6s
- [x] `bun run lint` — no new errors (baseline unchanged)
- [ ] Reviewer: visit `/artists/{slug}`, `/shows/{slug}`, `/venues/{slug}`, `/releases/{slug}`, `/labels/{slug}`, `/festivals/{slug}`. Verify:
  - Tags render in the header near other metadata, not at page bottom
  - `+ Add`, upvote, downvote, History affordances work
  - Top-5 cap + "Show more" behaves unchanged
  - Mobile width: header may be tall (authorized per PSY-460 follow-up); just confirm no layout breakage

🤖 Generated with [Claude Code](https://claude.com/claude-code)
