### PR TITLE
PSY-462: fix comments smoke flake + auth-fixture retry ENOENT

### DIFF
--- a/frontend/e2e/fixtures/auth.ts
+++ b/frontend/e2e/fixtures/auth.ts
@@ -1,7 +1,7 @@
 import { test as base } from './error-detection'
 import { type Page, type BrowserContext } from '@playwright/test'
 import * as path from 'path'
-import { userAuthFileForWorker } from '../global-setup'
+import { USER_COUNT, userAuthFileForWorker } from '../global-setup'
 
 const AUTH_DIR = path.resolve(__dirname, '../.auth')
 
@@ -14,6 +14,14 @@ const AUTH_DIR = path.resolve(__dirname, '../.auth')
  * Worker 0 uses the legacy `user.json` / `e2e-user@test.local`; workers
  * 1-4 get `user-N.json` / `e2e-user-N@test.local`.
  *
+ * PSY-462: Playwright retries can spawn workers whose `workerIndex`
+ * exceeds the seeded pool (retry #2 on a 5-worker run yielded
+ * workerIndex=5). Modulo the index over USER_COUNT so retry workers
+ * fall back to an already-seeded auth file instead of ENOENT-ing on
+ * `user-5.json`. This is race-free in practice: the original worker's
+ * test has already finished by the time Playwright spins up a retry
+ * worker, so no two live workers share a user at the same instant.
+ *
  * `adminPage` remains a single shared admin — admin tests are rare and
  * low-race-risk.
  */
@@ -22,7 +30,8 @@ export const test = base.extend<{
   adminPage: Page
 }>({
   authenticatedPage: async ({ browser, errors: _errors }, runFixture, testInfo) => {
-    const authFile = userAuthFileForWorker(testInfo.workerIndex)
+    const seededIndex = testInfo.workerIndex % USER_COUNT
+    const authFile = userAuthFileForWorker(seededIndex)
     const context: BrowserContext = await browser.newContext({
       storageState: path.join(AUTH_DIR, authFile),
     })

--- a/frontend/e2e/pages/comments.spec.ts
+++ b/frontend/e2e/pages/comments.spec.ts
@@ -56,13 +56,15 @@ test.describe('Comments (general)', () => {
       // PSY-430: pair the submit click with waitForResponse so the POST
       // settles before we assert on the rendered list (contributor tier
       // => visibility=visible, so the comment should appear on refetch).
+      // PSY-462: bumped timeout to 30s to absorb CI cold-start cost on the
+      // first backend request of the spec.
       const [createResp] = await Promise.all([
         authenticatedPage.waitForResponse(
           (resp) =>
             resp.url().includes('/entities/venue/') &&
             resp.url().endsWith('/comments') &&
             resp.request().method() === 'POST',
-          { timeout: 10_000 }
+          { timeout: 30_000 }
         ),
         thread.getByTestId('comment-submit').click(),
       ])
@@ -210,9 +212,10 @@ test.describe('Comments (general)', () => {
       expect(replyBody.depth).toBeGreaterThan(0)
       expect(replyBody.depth).toBeLessThanOrEqual(2)
 
-      // The reply renders nested under the parent.
+      // The reply renders nested under the parent. PSY-462: bumped timeout
+      // to 15s to absorb CI cost of invalidation -> refetch -> nested render.
       await expect(parentCard.getByText(uniqueReply)).toBeVisible({
-        timeout: 5_000,
+        timeout: 15_000,
       })
 
       // Cleanup: delete the reply so re-runs are idempotent.


### PR DESCRIPTION
## Summary
- comments.spec.ts: bump waitForResponse on create (10s -> 30s) and nested-reply toBeVisible (5s -> 15s)
- fixtures/auth.ts: modulo workerIndex over seeded user pool so retry workers fall back to existing auth state

## Root cause
First PSY-446 e2e-smoke run (run 24641079989 on PR #381) failed with:
- comments.spec.ts:32 - create POST succeeded (confirmed in backend log + DOM snapshot) but 10s waitForResponse timed out
- comments.spec.ts:154 - reply POST returned 200 (confirmed in trace.zip) but 5s nested-reply toBeVisible timed out
- Retry #2 hit ENOENT opening e2e/.auth/user-5.json - Playwright retry spawned worker index 5, but PSY-431 only seeded 5 users (indices 0-4)

## Test plan
- [ ] e2e-smoke on this PR passes (primary signal)
- [ ] 15 currently-passing smoke tests still pass
- [ ] No new TypeScript / lint errors

Closes PSY-462

Generated with [Claude Code](https://claude.com/claude-code)