### PR TITLE
PSY-464: fix useCommentThread response shape + re-add Show replies click

### DIFF
--- a/frontend/e2e/pages/comments.spec.ts
+++ b/frontend/e2e/pages/comments.spec.ts
@@ -209,9 +209,17 @@ test.describe('Comments (general)', () => {
       expect(replyBody.depth).toBeGreaterThan(0)
       expect(replyBody.depth).toBeLessThanOrEqual(2)
 
-      // The reply renders somewhere in the thread. Nesting correctness is
-      // asserted above via replyBody.parent_id + depth invariants — those
-      // come from the backend response and don't depend on UI refetch timing.
+      // The entity-comments list endpoint only returns top-level comments
+      // (backend/internal/services/engagement/comment_service.go:371 filters
+      // `parent_id IS NULL`). Replies come from a per-comment thread query
+      // that's lazy-loaded behind a "Show replies" button — useCommentThread
+      // is gated on loadedThread=true (CommentCard.tsx). Click the button to
+      // trigger the thread fetch, then assert the new reply rendered.
+      // Nesting correctness is already asserted above via replyBody.parent_id
+      // + depth invariants from the backend response.
+      await parentCard
+        .getByRole('button', { name: /show replies/i })
+        .click()
       await expect(thread.getByText(uniqueReply)).toBeVisible({
         timeout: 15_000,
       })

--- a/frontend/features/comments/hooks/index.ts
+++ b/frontend/features/comments/hooks/index.ts
@@ -25,10 +25,19 @@ export function useComments(
 }
 
 export function useCommentThread(commentId: number, enabled = false) {
+  // Backend returns `{ comments: [root, ...descendants] }` as a flat list;
+  // split here so consumers get the { comment, replies } shape they expect.
   return useQuery<CommentThreadResponse>({
     queryKey: commentQueryKeys.thread(commentId),
-    queryFn: () =>
-      apiRequest<CommentThreadResponse>(commentEndpoints.THREAD(commentId)),
+    queryFn: async () => {
+      const data = await apiRequest<{ comments: Comment[] }>(
+        commentEndpoints.THREAD(commentId)
+      )
+      const comments = data.comments ?? []
+      const root = comments.find((c) => c.id === commentId) ?? comments[0]
+      const replies = comments.filter((c) => c.id !== commentId)
+      return { comment: root, replies }
+    },
     enabled: enabled && commentId > 0,
   })
 }


### PR DESCRIPTION
## Summary

Two layered bugs surfaced by PSY-446 (#381) when smoke-on-PR started running the `@smoke` subset on every PR:

- **`useCommentThread` type/response mismatch** (production bug): hook expects `{ comment, replies }` but backend returns `{ comments: [root, ...descendants] }` flat. `threadData?.replies` was always undefined → `threadReplies` stayed empty → **no replies rendered after clicking "Show replies"**. Any user who replied couldn't see it until a full page reload.
- **E2E reply test missing the expansion click**: asserted reply visibility right after POST, assuming the reply would auto-render under the parent. It never has; the bug above masked it because the full E2E suite only ran post-merge.

## Fixes

- `frontend/features/comments/hooks/index.ts` — transform the flat backend response into `{ comment, replies }` inside the hook's `queryFn`. Root is picked by id; rest become replies.
- `frontend/e2e/pages/comments.spec.ts:153` — re-add the `getByRole('button', { name: /show replies/i }).click()` before the visibility expect, with a comment referencing the backend filter (`parent_id IS NULL`) and the frontend gating (`loadedThread`).

## Test plan

- [x] `comments.spec.ts` "replies to a comment" smoke test passes locally (verified — was hard-failing all 3 attempts on PSY-446 CI)
- [x] All 2 comments smoke tests pass locally
- [x] 55 comments unit tests still pass
- [ ] Smoke-on-PR job passes on this branch's CI
- [ ] After merge + rebase, PSY-446 (#381) smoke passes

## Related

- Unblocks #381 (PSY-446 smoke-on-PR + full-suite-post-merge split)
- Depends on PSY-463's cleanup refactor (already on main)
- Follow-up: PSY-465 — investigate the separate show-detail cold-load flake in `follow-and-attendance.spec.ts`

Closes PSY-464

🤖 Generated with [Claude Code](https://claude.com/claude-code)