### PR TITLE
Fix Rules of Hooks violation in AddToCollectionButton

### DIFF
--- a/frontend/components/shared/AddToCollectionButton.test.tsx
+++ b/frontend/components/shared/AddToCollectionButton.test.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -151,5 +152,100 @@ describe('AddToCollectionButton', () => {
     await user.click(screen.getByRole('button', { name: /add to collection/i }))
 
     expect(screen.getByText('No collections yet')).toBeInTheDocument()
+  })
+
+  // ── Regression: unauthenticated → authenticated transition (PSY-466) ──
+  // Rules of Hooks violation: earlier versions called `useState` for
+  // `recentlyAdded` below the `if (!isAuthenticated) return null` early
+  // return. On first render the auth profile hasn't resolved yet
+  // (isAuthenticated=false) so the component took the early return with N
+  // hooks called. Once /auth/profile resolved and isAuthenticated flipped
+  // to true, the component proceeded past the early return and called one
+  // additional hook — React flagged it as "Rendered more hooks than during
+  // the previous render" and the error boundary rendered 500 for every
+  // entity detail page where this button is rendered (artists, shows,
+  // venues, releases, labels, festivals).
+  //
+  // The other tests all pass with the broken code because the mocked
+  // `useAuthContext` returns the same auth state synchronously on every
+  // render — the transition that triggered the violation never happens.
+  // This regression test makes the mock call a real React hook (`useState`)
+  // so React's hook-tracker has a stable hook anchor to compare against,
+  // making the component-body hook-count transition detectable.
+  it('renders without hook-order errors during the auth loading → authenticated transition', () => {
+    // Force the mock to call a real React hook so React's hook-tracker
+    // treats the auth hook as a stable slot and can actually see the
+    // component body's hook-count change. Without this, the mock calls
+    // zero hooks and React has nothing to anchor the comparison.
+    let authState: {
+      user: { id: string } | null
+      isAuthenticated: boolean
+      isLoading: boolean
+      logout: ReturnType<typeof vi.fn>
+    } = {
+      user: null,
+      isAuthenticated: false,
+      isLoading: true,
+      logout: vi.fn(),
+    }
+    mockAuthContext.mockImplementation(() => {
+      // Real React hook — ensures this mock contributes a stable number
+      // of hooks across renders so the component-body transition is
+      // what React's hook-tracker actually sees.
+      useState(0)
+      return authState
+    })
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    // Initial render: auth profile still loading, user is null, so the
+    // component hits the `if (!isAuthenticated) return null` early return.
+    const { rerender } = render(
+      <AddToCollectionButton entityType="artist" entityId={1} entityName="Test Artist" />
+    )
+
+    // Transition to authenticated — this is what triggered the
+    // hook-order violation in production once /auth/profile resolved.
+    authState = {
+      user: { id: '1' },
+      isAuthenticated: true,
+      isLoading: false,
+      logout: vi.fn(),
+    }
+
+    let threwDuringRerender: Error | null = null
+    try {
+      rerender(
+        <AddToCollectionButton entityType="artist" entityId={1} entityName="Test Artist" />
+      )
+    } catch (e) {
+      threwDuringRerender = e as Error
+    }
+
+    // A hook-order violation throws during render with a message like
+    // "Rendered more hooks than during the previous render." or "change
+    // in the order of Hooks". React also logs a dev-only console.error
+    // about it before throwing.
+    const allErrorOutput = [
+      ...(threwDuringRerender ? [threwDuringRerender.message] : []),
+      ...errorSpy.mock.calls.map(([msg]) =>
+        typeof msg === 'string' ? msg : ''
+      ),
+    ]
+    const hookErrors = allErrorOutput.filter(
+      (msg) =>
+        msg.includes('change in the order of Hooks') ||
+        msg.includes('Rendered more hooks than during the previous render') ||
+        msg.includes('Rendered fewer hooks than expected')
+    )
+    expect(hookErrors).toEqual([])
+    expect(threwDuringRerender).toBeNull()
+
+    // Sanity check: once authenticated, the button actually renders.
+    expect(
+      screen.getByRole('button', { name: /add to collection/i })
+    ).toBeInTheDocument()
+
+    errorSpy.mockRestore()
   })
 })

--- a/frontend/components/shared/AddToCollectionButton.tsx
+++ b/frontend/components/shared/AddToCollectionButton.tsx
@@ -31,16 +31,22 @@ export function AddToCollectionButton({
   const { isAuthenticated } = useAuthContext()
   const [open, setOpen] = useState(false)
   const [addedMessage, setAddedMessage] = useState<string | null>(null)
+  // Check if entity is already in a collection by looking at its items
+  // (We don't have items in the list response, so we track locally what we just added)
+  // NOTE: hook must be called unconditionally, above the early return below.
+  // Previously this sat after the `!isAuthenticated` early return, so once the
+  // auth profile resolved and `isAuthenticated` flipped false → true, this
+  // hook became the N+1th hook on a render that had only called N hooks
+  // previously. React threw "Rendered more hooks than during the previous
+  // render" and the error boundary rendered 500 for every entity detail
+  // page (PSY-466, same class of bug as PSY-447).
+  const [recentlyAdded, setRecentlyAdded] = useState<Set<string>>(new Set())
   const { data: myCollectionsData, isLoading: collectionsLoading } = useMyCollections()
   const addMutation = useAddCollectionItem()
 
   if (!isAuthenticated) return null
 
   const collections = myCollectionsData?.collections ?? []
-
-  // Check if entity is already in a collection by looking at its items
-  // (We don't have items in the list response, so we track locally what we just added)
-  const [recentlyAdded, setRecentlyAdded] = useState<Set<string>>(new Set())
 
   const handleAdd = (collectionSlug: string, collectionTitle: string) => {
     addMutation.mutate(


### PR DESCRIPTION
Closes PSY-466

## Root cause

`AddToCollectionButton` called `useState(recentlyAdded)` **after** an early return on `!isAuthenticated`. On first render (auth loading, `isAuthenticated=false`), the component bailed early after 5 hooks. Once `/auth/profile` resolved and `isAuthenticated` flipped to `true`, the component reached hook #6 — triggering React's *"Rendered more hooks than during the previous render"* → error boundary → **every entity detail page crashed for authenticated users** (artists, shows, venues, releases, labels, festivals).

Same class of bug as PSY-447 (`TagDetail` hook-order fix, PR #369), different component. Surfaced by dogfood round 4 — evidence: `dogfood-output/tags-audit-4/report.md` ISSUE-001.

## What changed

**Fix** (`AddToCollectionButton.tsx`): hoist `useState(recentlyAdded)` above the `if (!isAuthenticated) return null` early return. No internal guard needed — `useState(new Set())` is cheap and state-less-than-auth. Inline comment documents the fix mechanism + PSY-466 reference.

**Regression test** (`AddToCollectionButton.test.tsx`): `renders without hook-order errors during the auth loading → authenticated transition`.

- Mounts with `isAuthenticated=false, isLoading=true`; transitions to `isAuthenticated=true` via `rerender()`
- Auth mock uses a real `useState(0)` so React's hook-tracker has a stable anchor — mocks that don't call real hooks hide this class of bug (a trap the existing tests fell into)
- Asserts no hook-order error logged to `console.error` and no throw during rerender
- **Verified by reverting the fix**: test fails with the exact production errors (`"Rendered more hooks than during the previous render."` + `"React has detected a change in the order of Hooks called by %s."`). With the fix applied, all 8 tests pass.

## Test plan

- [x] `bun run test:run` — 2553/2553 pass (includes new regression test)
- [x] `bun run lint` on changed files — clean
- [x] `bun run build` — production build succeeds
- [x] Reverting the fix makes the new regression test fail with the exact production error
- [ ] Reviewer: load `/artists/{slug}` (or any entity detail page) as an authenticated user. Verify:
  - No error boundary / "Something went wrong" fallback
  - No *"Rendered more hooks than during the previous render"* in dev console
  - `Add to collection` button renders and behaves as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
