### PR TITLE
PSY-468: fix vote mutations' optimistic update queryKey mismatch

### DIFF
--- a/frontend/e2e/pages/comments.spec.ts
+++ b/frontend/e2e/pages/comments.spec.ts
@@ -135,17 +135,18 @@ test.describe('Comments (general)', () => {
       // comment_vote_service_test.go) so we don't assert on those here.
       await expect(upvoteButton).toHaveClass(/text-primary/, { timeout: 5_000 })
 
-      // Cleanup: remove our vote so re-runs start from a clean per-user
-      // state (other workers' votes persist; that's fine).
-      const [unvoteResp] = await Promise.all([
-        authenticatedPage.waitForResponse(
-          (resp) =>
-            /\/comments\/\d+\/vote$/.test(resp.url()) &&
-            resp.request().method() === 'DELETE',
-          { timeout: 10_000 }
-        ),
-        upvoteButton.click(),
-      ])
+      // Cleanup via direct DELETE. We can't toggle via a second UI click
+      // because the list endpoint doesn't populate user_vote for the
+      // authenticated user (separate backend bug); after onSettled's
+      // refetch, the cached user_vote reverts to null, so the next click
+      // would fire POST (vote) instead of DELETE (unvote). Pulling the
+      // comment ID out of the POST URL sidesteps that for test idempotency.
+      const commentIdMatch = voteResp.url().match(/\/comments\/(\d+)\/vote$/)
+      const commentId = commentIdMatch?.[1]
+      expect(commentId).toBeTruthy()
+      const unvoteResp = await authenticatedPage.request.delete(
+        `/api/comments/${commentId}/vote`
+      )
       expect(unvoteResp.status()).toBeLessThan(400)
     }
   )

--- a/frontend/features/comments/hooks/index.ts
+++ b/frontend/features/comments/hooks/index.ts
@@ -164,57 +164,59 @@ export function useVoteComment() {
         body: JSON.stringify({ direction }),
       }),
     onMutate: async (variables) => {
-      // Optimistic update: adjust vote counts in the cached comment list
+      // `useComments` caches under [...entity(type, id), sort], so the exact
+      // entity key is never populated — only prefix-matching via filters sees
+      // the data. Use getQueriesData/setQueriesData consistently; plain
+      // getQueryData(shortKey) would return undefined and skip the update.
       const queryKey = commentQueryKeys.entity(variables.entityType, variables.entityId)
       await queryClient.cancelQueries({ queryKey })
 
-      const previous = queryClient.getQueryData<CommentListResponse>(queryKey)
+      const snapshot = queryClient.getQueriesData<CommentListResponse>({ queryKey })
 
-      if (previous) {
-        const updateComment = (comment: Comment): Comment => {
-          if (comment.id !== variables.commentId) return comment
+      const updateComment = (comment: Comment): Comment => {
+        if (comment.id !== variables.commentId) return comment
 
-          const prevVote = comment.user_vote ?? null
-          let ups = comment.ups
-          let downs = comment.downs
+        const prevVote = comment.user_vote ?? null
+        let ups = comment.ups
+        let downs = comment.downs
 
-          // Remove previous vote
-          if (prevVote === 1) ups--
-          if (prevVote === -1) downs--
+        // Remove previous vote
+        if (prevVote === 1) ups--
+        if (prevVote === -1) downs--
 
-          // Apply new vote
-          if (variables.direction === 1) ups++
-          if (variables.direction === -1) downs++
+        // Apply new vote
+        if (variables.direction === 1) ups++
+        if (variables.direction === -1) downs++
 
-          return {
-            ...comment,
-            ups,
-            downs,
-            score: ups - downs,
-            user_vote: variables.direction,
-          }
+        return {
+          ...comment,
+          ups,
+          downs,
+          score: ups - downs,
+          user_vote: variables.direction,
         }
-
-        // Update all sort variants of this entity's comments
-        queryClient.setQueriesData<CommentListResponse>(
-          { queryKey },
-          (old) => {
-            if (!old) return old
-            return {
-              ...old,
-              comments: old.comments.map(updateComment),
-            }
-          }
-        )
       }
 
-      return { previous }
+      // Update all sort variants of this entity's comments
+      queryClient.setQueriesData<CommentListResponse>(
+        { queryKey },
+        (old) => {
+          if (!old) return old
+          return {
+            ...old,
+            comments: old.comments.map(updateComment),
+          }
+        }
+      )
+
+      return { snapshot }
     },
-    onError: (_err, variables, context) => {
-      // Roll back on error
-      if (context?.previous) {
-        const queryKey = commentQueryKeys.entity(variables.entityType, variables.entityId)
-        queryClient.setQueryData(queryKey, context.previous)
+    onError: (_err, _variables, context) => {
+      // Restore every cached variant we snapshotted.
+      if (context?.snapshot) {
+        for (const [key, data] of context.snapshot) {
+          queryClient.setQueryData(key, data)
+        }
       }
     },
     onSettled: (_data, _err, variables) => {
@@ -243,46 +245,45 @@ export function useUnvoteComment() {
       const queryKey = commentQueryKeys.entity(variables.entityType, variables.entityId)
       await queryClient.cancelQueries({ queryKey })
 
-      const previous = queryClient.getQueryData<CommentListResponse>(queryKey)
+      const snapshot = queryClient.getQueriesData<CommentListResponse>({ queryKey })
 
-      if (previous) {
-        const updateComment = (comment: Comment): Comment => {
-          if (comment.id !== variables.commentId) return comment
+      const updateComment = (comment: Comment): Comment => {
+        if (comment.id !== variables.commentId) return comment
 
-          const prevVote = comment.user_vote ?? null
-          let ups = comment.ups
-          let downs = comment.downs
+        const prevVote = comment.user_vote ?? null
+        let ups = comment.ups
+        let downs = comment.downs
 
-          if (prevVote === 1) ups--
-          if (prevVote === -1) downs--
+        if (prevVote === 1) ups--
+        if (prevVote === -1) downs--
 
-          return {
-            ...comment,
-            ups,
-            downs,
-            score: ups - downs,
-            user_vote: null,
-          }
+        return {
+          ...comment,
+          ups,
+          downs,
+          score: ups - downs,
+          user_vote: null,
         }
-
-        queryClient.setQueriesData<CommentListResponse>(
-          { queryKey },
-          (old) => {
-            if (!old) return old
-            return {
-              ...old,
-              comments: old.comments.map(updateComment),
-            }
-          }
-        )
       }
 
-      return { previous }
+      queryClient.setQueriesData<CommentListResponse>(
+        { queryKey },
+        (old) => {
+          if (!old) return old
+          return {
+            ...old,
+            comments: old.comments.map(updateComment),
+          }
+        }
+      )
+
+      return { snapshot }
     },
-    onError: (_err, variables, context) => {
-      if (context?.previous) {
-        const queryKey = commentQueryKeys.entity(variables.entityType, variables.entityId)
-        queryClient.setQueryData(queryKey, context.previous)
+    onError: (_err, _variables, context) => {
+      if (context?.snapshot) {
+        for (const [key, data] of context.snapshot) {
+          queryClient.setQueryData(key, data)
+        }
       }
     },
     onSettled: (_data, _err, variables) => {


### PR DESCRIPTION
## Summary

`useComments` caches under `[...commentQueryKeys.entity(type, id), sort]`, but `useVoteComment` / `useUnvoteComment` snapshotted `previous` via `getQueryData(shortKey)` — exact-match — which was always `undefined`. The `if (previous)` guard then skipped the entire optimistic update, so the upvote button's `text-primary` class never flipped until the post-`onSettled` refetch (past the 5s E2E assertion window).

The post-merge comments upvote E2E has been failing on shard 2 every run since at least PSY-463.

## Changes

- `frontend/features/comments/hooks/index.ts` — `useVoteComment` + `useUnvoteComment`:
  - `getQueriesData({ queryKey })` instead of `getQueryData(queryKey)` so we snapshot every prefix-matching variant.
  - Dropped the `if (previous)` gate — `setQueriesData` already no-ops when `old` is unset.
  - `onError` rollback now replays the snapshot into each matching key (old code called `setQueryData` on the uncached short key).
- `frontend/e2e/pages/comments.spec.ts:91` — replaced the toggle-via-click cleanup with a direct `page.request.delete('/api/comments/{id}/vote')`, pulling the id out of the POST URL. Avoids a separate backend bug (PSY-469) where the list endpoint doesn't populate `user_vote`, which made the refetch revert the optimistic state and caused the second click to POST instead of DELETE.

## Test plan

- [x] `comments.spec.ts` "upvotes a comment" passes locally (failed on every main CI run before this)
- [x] All 3 comments E2E tests pass locally
- [x] 55 comments unit tests pass
- [ ] Smoke-on-PR job passes on this branch's CI
- [ ] Post-merge full suite shard 2 goes green

## Related

- **PSY-469** (backend follow-up): list endpoint doesn't populate `user_vote` for authenticated requests. Production UX bug: after any vote, the refetch clears the visual state. Should be fixed separately — after it lands, the toggle-via-click cleanup could be restored.

Closes PSY-468

🤖 Generated with [Claude Code](https://claude.com/claude-code)