### PR TITLE
PSY-469: populate user_vote in comment list/get/thread responses

### DIFF
--- a/backend/internal/api/handlers/comment.go
+++ b/backend/internal/api/handlers/comment.go
@@ -10,6 +10,7 @@ import (
 
 	"psychic-homily-backend/internal/api/middleware"
 	"psychic-homily-backend/internal/logger"
+	"psychic-homily-backend/internal/models"
 	"psychic-homily-backend/internal/services/contracts"
 )
 
@@ -31,19 +32,63 @@ type CommentWriter interface {
 	DeleteComment(userID uint, commentID uint, isAdmin bool) error
 }
 
+// CommentVoteReader supplies per-user vote lookups for populating
+// `user_vote` on responses. Nil is acceptable — handlers treat a nil
+// reader or nil user as "anonymous; don't populate".
+type CommentVoteReader interface {
+	GetUserVotesForComments(userID uint, commentIDs []uint) (map[uint]int, error)
+}
+
 // CommentHandler handles comment-related API requests.
 type CommentHandler struct {
 	reader          CommentReader
 	writer          CommentWriter
+	voteReader      CommentVoteReader
 	auditLogService contracts.AuditLogServiceInterface
 }
 
-// NewCommentHandler creates a new CommentHandler.
-func NewCommentHandler(reader CommentReader, writer CommentWriter, auditLogService contracts.AuditLogServiceInterface) *CommentHandler {
+// NewCommentHandler creates a new CommentHandler. voteReader may be nil
+// in tests that don't exercise the authenticated-read path.
+func NewCommentHandler(reader CommentReader, writer CommentWriter, voteReader CommentVoteReader, auditLogService contracts.AuditLogServiceInterface) *CommentHandler {
 	return &CommentHandler{
 		reader:          reader,
 		writer:          writer,
+		voteReader:      voteReader,
 		auditLogService: auditLogService,
+	}
+}
+
+// populateUserVotes mutates the provided responses to set user_vote based
+// on the authenticated user's existing votes. No-op if the user is
+// anonymous, the voteReader is nil, or the response set is empty. Errors
+// from the vote lookup are logged and swallowed — vote state is a
+// decoration, not a critical path.
+func (h *CommentHandler) populateUserVotes(ctx context.Context, user *models.User, responses []*contracts.CommentResponse) {
+	if user == nil || h.voteReader == nil || len(responses) == 0 {
+		return
+	}
+	ids := make([]uint, 0, len(responses))
+	for _, r := range responses {
+		if r != nil {
+			ids = append(ids, r.ID)
+		}
+	}
+	votes, err := h.voteReader.GetUserVotesForComments(user.ID, ids)
+	if err != nil {
+		logger.FromContext(ctx).Warn("failed_to_populate_user_votes",
+			"user_id", user.ID,
+			"error", err.Error(),
+		)
+		return
+	}
+	for _, r := range responses {
+		if r == nil {
+			continue
+		}
+		if dir, ok := votes[r.ID]; ok {
+			d := dir
+			r.UserVote = &d
+		}
 	}
 }
 
@@ -99,6 +144,10 @@ func (h *CommentHandler) ListCommentsHandler(ctx context.Context, req *ListComme
 		return nil, huma.Error500InternalServerError("Failed to fetch comments")
 	}
 
+	// Populate user_vote for the authenticated viewer. Route is on
+	// optionalAuthGroup, so user may be nil for anonymous requests.
+	h.populateUserVotes(ctx, middleware.GetUserFromContext(ctx), result.Comments)
+
 	return &ListCommentsResponse{Body: result}, nil
 }
 
@@ -130,6 +179,8 @@ func (h *CommentHandler) GetCommentHandler(ctx context.Context, req *GetCommentR
 		}
 		return nil, huma.Error500InternalServerError("Failed to fetch comment")
 	}
+
+	h.populateUserVotes(ctx, middleware.GetUserFromContext(ctx), []*contracts.CommentResponse{comment})
 
 	return &GetCommentResponse{Body: comment}, nil
 }
@@ -167,6 +218,8 @@ func (h *CommentHandler) GetThreadHandler(ctx context.Context, req *GetThreadReq
 		}
 		return nil, huma.Error500InternalServerError("Failed to fetch thread")
 	}
+
+	h.populateUserVotes(ctx, middleware.GetUserFromContext(ctx), comments)
 
 	resp := &GetThreadResponse{}
 	resp.Body.Comments = comments

--- a/backend/internal/api/handlers/comment_admin_test.go
+++ b/backend/internal/api/handlers/comment_admin_test.go
@@ -396,7 +396,7 @@ func TestCreateComment_RateLimitError(t *testing.T) {
 			return nil, fmt.Errorf("please wait 60 seconds between comments on the same entity")
 		},
 	}
-	h := NewCommentHandler(mock, mock, nil)
+	h := NewCommentHandler(mock, mock, nil, nil)
 	req := &CreateCommentRequest{EntityType: "show", EntityID: "1"}
 	req.Body.Body = "Hello"
 	_, err := h.CreateCommentHandler(commentUserCtx(), req)
@@ -409,7 +409,7 @@ func TestCreateComment_HourlyLimitError(t *testing.T) {
 			return nil, fmt.Errorf("you've reached your hourly comment limit (5/hour for new users)")
 		},
 	}
-	h := NewCommentHandler(mock, mock, nil)
+	h := NewCommentHandler(mock, mock, nil, nil)
 	req := &CreateCommentRequest{EntityType: "show", EntityID: "1"}
 	req.Body.Body = "Hello"
 	_, err := h.CreateCommentHandler(commentUserCtx(), req)

--- a/backend/internal/api/handlers/comment_test.go
+++ b/backend/internal/api/handlers/comment_test.go
@@ -15,7 +15,7 @@ import (
 // ============================================================================
 
 func testCommentHandler() *CommentHandler {
-	return NewCommentHandler(nil, nil, nil)
+	return NewCommentHandler(nil, nil, nil, nil)
 }
 
 func commentUserCtx() context.Context {
@@ -73,7 +73,7 @@ func TestListComments_UnsupportedEntityType(t *testing.T) {
 			return nil, fmt.Errorf("unsupported entity type: %s", entityType)
 		},
 	}
-	h := NewCommentHandler(mock, mock, nil)
+	h := NewCommentHandler(mock, mock, nil, nil)
 	_, err := h.ListCommentsHandler(context.Background(), &ListCommentsRequest{
 		EntityType: "invalid_type",
 		EntityID:   "1",
@@ -101,7 +101,7 @@ func TestListComments_Success(t *testing.T) {
 			}, nil
 		},
 	}
-	h := NewCommentHandler(mock, mock, nil)
+	h := NewCommentHandler(mock, mock, nil, nil)
 	resp, err := h.ListCommentsHandler(context.Background(), &ListCommentsRequest{
 		EntityType: "show",
 		EntityID:   "5",
@@ -127,7 +127,7 @@ func TestListComments_DefaultLimit(t *testing.T) {
 			return &contracts.CommentListResponse{Comments: []*contracts.CommentResponse{}, Total: 0}, nil
 		},
 	}
-	h := NewCommentHandler(mock, mock, nil)
+	h := NewCommentHandler(mock, mock, nil, nil)
 	_, err := h.ListCommentsHandler(context.Background(), &ListCommentsRequest{
 		EntityType: "artist",
 		EntityID:   "1",
@@ -146,7 +146,7 @@ func TestListComments_LimitCap(t *testing.T) {
 			return &contracts.CommentListResponse{Comments: []*contracts.CommentResponse{}, Total: 0}, nil
 		},
 	}
-	h := NewCommentHandler(mock, mock, nil)
+	h := NewCommentHandler(mock, mock, nil, nil)
 	_, err := h.ListCommentsHandler(context.Background(), &ListCommentsRequest{
 		EntityType: "artist",
 		EntityID:   "1",
@@ -163,12 +163,113 @@ func TestListComments_ServiceError(t *testing.T) {
 			return nil, fmt.Errorf("database error")
 		},
 	}
-	h := NewCommentHandler(mock, mock, nil)
+	h := NewCommentHandler(mock, mock, nil, nil)
 	_, err := h.ListCommentsHandler(context.Background(), &ListCommentsRequest{
 		EntityType: "show",
 		EntityID:   "1",
 	})
 	assertHumaError(t, err, 500)
+}
+
+func TestListComments_PopulatesUserVote_WhenAuthenticated(t *testing.T) {
+	up := 1
+	c1 := makeCommentResponse(1, "show", 5, 10)
+	c2 := makeCommentResponse(2, "show", 5, 11)
+	commentSvc := &mockCommentService{
+		listCommentsForEntityFn: func(_ string, _ uint, _ contracts.CommentListFilters) (*contracts.CommentListResponse, error) {
+			return &contracts.CommentListResponse{
+				Comments: []*contracts.CommentResponse{c1, c2},
+				Total:    2,
+			}, nil
+		},
+	}
+	var receivedUserID uint
+	var receivedIDs []uint
+	voteSvc := &mockCommentVoteService{
+		getUserVotesForCommentsFn: func(userID uint, ids []uint) (map[uint]int, error) {
+			receivedUserID = userID
+			receivedIDs = ids
+			return map[uint]int{1: up}, nil
+		},
+	}
+	h := NewCommentHandler(commentSvc, commentSvc, voteSvc, nil)
+	resp, err := h.ListCommentsHandler(commentUserCtx(), &ListCommentsRequest{
+		EntityType: "show",
+		EntityID:   "5",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if receivedUserID != 10 {
+		t.Errorf("expected voteSvc called with userID=10, got %d", receivedUserID)
+	}
+	if len(receivedIDs) != 2 {
+		t.Errorf("expected voteSvc called with 2 ids, got %d", len(receivedIDs))
+	}
+	if resp.Body.Comments[0].UserVote == nil || *resp.Body.Comments[0].UserVote != 1 {
+		t.Errorf("expected UserVote=1 on comment 1, got %v", resp.Body.Comments[0].UserVote)
+	}
+	if resp.Body.Comments[1].UserVote != nil {
+		t.Errorf("expected UserVote=nil on comment 2 (not voted), got %v", resp.Body.Comments[1].UserVote)
+	}
+}
+
+func TestListComments_DoesNotPopulateUserVote_WhenAnonymous(t *testing.T) {
+	c1 := makeCommentResponse(1, "show", 5, 10)
+	commentSvc := &mockCommentService{
+		listCommentsForEntityFn: func(_ string, _ uint, _ contracts.CommentListFilters) (*contracts.CommentListResponse, error) {
+			return &contracts.CommentListResponse{
+				Comments: []*contracts.CommentResponse{c1},
+				Total:    1,
+			}, nil
+		},
+	}
+	voteCalled := false
+	voteSvc := &mockCommentVoteService{
+		getUserVotesForCommentsFn: func(_ uint, _ []uint) (map[uint]int, error) {
+			voteCalled = true
+			return nil, nil
+		},
+	}
+	h := NewCommentHandler(commentSvc, commentSvc, voteSvc, nil)
+	resp, err := h.ListCommentsHandler(context.Background(), &ListCommentsRequest{
+		EntityType: "show",
+		EntityID:   "5",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if voteCalled {
+		t.Error("expected voteSvc not to be called for anonymous request")
+	}
+	if resp.Body.Comments[0].UserVote != nil {
+		t.Errorf("expected UserVote=nil for anonymous request, got %v", resp.Body.Comments[0].UserVote)
+	}
+}
+
+func TestListComments_SwallowsVoteLookupError(t *testing.T) {
+	c1 := makeCommentResponse(1, "show", 5, 10)
+	commentSvc := &mockCommentService{
+		listCommentsForEntityFn: func(_ string, _ uint, _ contracts.CommentListFilters) (*contracts.CommentListResponse, error) {
+			return &contracts.CommentListResponse{Comments: []*contracts.CommentResponse{c1}, Total: 1}, nil
+		},
+	}
+	voteSvc := &mockCommentVoteService{
+		getUserVotesForCommentsFn: func(_ uint, _ []uint) (map[uint]int, error) {
+			return nil, fmt.Errorf("vote lookup failed")
+		},
+	}
+	h := NewCommentHandler(commentSvc, commentSvc, voteSvc, nil)
+	resp, err := h.ListCommentsHandler(commentUserCtx(), &ListCommentsRequest{
+		EntityType: "show",
+		EntityID:   "5",
+	})
+	if err != nil {
+		t.Fatalf("expected vote-lookup error to be swallowed, got %v", err)
+	}
+	if resp.Body.Comments[0].UserVote != nil {
+		t.Errorf("expected UserVote=nil on vote-lookup failure, got %v", resp.Body.Comments[0].UserVote)
+	}
 }
 
 // ============================================================================
@@ -187,7 +288,7 @@ func TestGetComment_NotFound(t *testing.T) {
 			return nil, fmt.Errorf("comment not found")
 		},
 	}
-	h := NewCommentHandler(mock, mock, nil)
+	h := NewCommentHandler(mock, mock, nil, nil)
 	_, err := h.GetCommentHandler(context.Background(), &GetCommentRequest{CommentID: "99"})
 	assertHumaError(t, err, 404)
 }
@@ -202,7 +303,7 @@ func TestGetComment_Success(t *testing.T) {
 			return expected, nil
 		},
 	}
-	h := NewCommentHandler(mock, mock, nil)
+	h := NewCommentHandler(mock, mock, nil, nil)
 	resp, err := h.GetCommentHandler(context.Background(), &GetCommentRequest{CommentID: "1"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -228,7 +329,7 @@ func TestGetThread_NotFound(t *testing.T) {
 			return nil, fmt.Errorf("thread root comment not found")
 		},
 	}
-	h := NewCommentHandler(mock, mock, nil)
+	h := NewCommentHandler(mock, mock, nil, nil)
 	_, err := h.GetThreadHandler(context.Background(), &GetThreadRequest{CommentID: "99"})
 	assertHumaError(t, err, 404)
 }
@@ -239,7 +340,7 @@ func TestGetThread_NotARoot(t *testing.T) {
 			return nil, fmt.Errorf("comment is not a thread root")
 		},
 	}
-	h := NewCommentHandler(mock, mock, nil)
+	h := NewCommentHandler(mock, mock, nil, nil)
 	_, err := h.GetThreadHandler(context.Background(), &GetThreadRequest{CommentID: "5"})
 	assertHumaError(t, err, 400)
 }
@@ -255,7 +356,7 @@ func TestGetThread_Success(t *testing.T) {
 			return []*contracts.CommentResponse{root, reply}, nil
 		},
 	}
-	h := NewCommentHandler(mock, mock, nil)
+	h := NewCommentHandler(mock, mock, nil, nil)
 	resp, err := h.GetThreadHandler(context.Background(), &GetThreadRequest{CommentID: "1"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -301,7 +402,7 @@ func TestCreateComment_UnsupportedEntityType(t *testing.T) {
 			return nil, fmt.Errorf("unsupported entity type: nope")
 		},
 	}
-	h := NewCommentHandler(mock, mock, nil)
+	h := NewCommentHandler(mock, mock, nil, nil)
 	req := &CreateCommentRequest{EntityType: "nope", EntityID: "1"}
 	req.Body.Body = "Hello"
 	_, err := h.CreateCommentHandler(commentUserCtx(), req)
@@ -314,7 +415,7 @@ func TestCreateComment_EntityNotFound(t *testing.T) {
 			return nil, fmt.Errorf("show with ID 999 not found")
 		},
 	}
-	h := NewCommentHandler(mock, mock, nil)
+	h := NewCommentHandler(mock, mock, nil, nil)
 	req := &CreateCommentRequest{EntityType: "show", EntityID: "999"}
 	req.Body.Body = "Hello"
 	_, err := h.CreateCommentHandler(commentUserCtx(), req)
@@ -337,7 +438,7 @@ func TestCreateComment_Success(t *testing.T) {
 			return expected, nil
 		},
 	}
-	h := NewCommentHandler(mock, mock, &mockAuditLogService{})
+	h := NewCommentHandler(mock, mock, nil, &mockAuditLogService{})
 	req := &CreateCommentRequest{EntityType: "show", EntityID: "5"}
 	req.Body.Body = "Great show!"
 	resp, err := h.CreateCommentHandler(commentUserCtx(), req)
@@ -358,7 +459,7 @@ func TestCreateComment_WithReplyPermission(t *testing.T) {
 			return makeCommentResponse(1, "show", 5, 10), nil
 		},
 	}
-	h := NewCommentHandler(mock, mock, nil)
+	h := NewCommentHandler(mock, mock, nil, nil)
 	req := &CreateCommentRequest{EntityType: "show", EntityID: "5"}
 	req.Body.Body = "My thoughts"
 	req.Body.ReplyPermission = "author_only"
@@ -374,7 +475,7 @@ func TestCreateComment_ServiceError(t *testing.T) {
 			return nil, fmt.Errorf("database error")
 		},
 	}
-	h := NewCommentHandler(mock, mock, nil)
+	h := NewCommentHandler(mock, mock, nil, nil)
 	req := &CreateCommentRequest{EntityType: "show", EntityID: "1"}
 	req.Body.Body = "Hello"
 	_, err := h.CreateCommentHandler(commentUserCtx(), req)
@@ -411,7 +512,7 @@ func TestCreateReply_ParentNotFound(t *testing.T) {
 			return nil, fmt.Errorf("comment not found")
 		},
 	}
-	h := NewCommentHandler(mock, mock, nil)
+	h := NewCommentHandler(mock, mock, nil, nil)
 	req := &CreateReplyRequest{CommentID: "99"}
 	req.Body.Body = "Replying..."
 	_, err := h.CreateReplyHandler(commentUserCtx(), req)
@@ -428,7 +529,7 @@ func TestCreateReply_MaxDepthExceeded(t *testing.T) {
 			return nil, fmt.Errorf("maximum reply depth of 2 exceeded")
 		},
 	}
-	h := NewCommentHandler(mock, mock, nil)
+	h := NewCommentHandler(mock, mock, nil, nil)
 	req := &CreateReplyRequest{CommentID: "1"}
 	req.Body.Body = "Deep reply"
 	_, err := h.CreateReplyHandler(commentUserCtx(), req)
@@ -452,7 +553,7 @@ func TestCreateReply_Success(t *testing.T) {
 			return reply, nil
 		},
 	}
-	h := NewCommentHandler(mock, mock, &mockAuditLogService{})
+	h := NewCommentHandler(mock, mock, nil, &mockAuditLogService{})
 	req := &CreateReplyRequest{CommentID: "1"}
 	req.Body.Body = "Nice reply!"
 	resp, err := h.CreateReplyHandler(commentUserCtx(), req)
@@ -497,7 +598,7 @@ func TestUpdateComment_NotFound(t *testing.T) {
 			return nil, fmt.Errorf("comment not found")
 		},
 	}
-	h := NewCommentHandler(mock, mock, nil)
+	h := NewCommentHandler(mock, mock, nil, nil)
 	req := &UpdateCommentRequest{CommentID: "99"}
 	req.Body.Body = "Updated text"
 	_, err := h.UpdateCommentHandler(commentUserCtx(), req)
@@ -510,7 +611,7 @@ func TestUpdateComment_ForbiddenNotAuthor(t *testing.T) {
 			return nil, fmt.Errorf("only the comment author can edit this comment")
 		},
 	}
-	h := NewCommentHandler(mock, mock, nil)
+	h := NewCommentHandler(mock, mock, nil, nil)
 	req := &UpdateCommentRequest{CommentID: "1"}
 	req.Body.Body = "Trying to edit someone else's comment"
 	_, err := h.UpdateCommentHandler(commentUserCtx(), req)
@@ -536,7 +637,7 @@ func TestUpdateComment_Success(t *testing.T) {
 			return updated, nil
 		},
 	}
-	h := NewCommentHandler(mock, mock, &mockAuditLogService{})
+	h := NewCommentHandler(mock, mock, nil, &mockAuditLogService{})
 	req := &UpdateCommentRequest{CommentID: "1"}
 	req.Body.Body = "Updated body"
 	resp, err := h.UpdateCommentHandler(commentUserCtx(), req)
@@ -573,7 +674,7 @@ func TestDeleteComment_NotFound(t *testing.T) {
 			return fmt.Errorf("comment not found")
 		},
 	}
-	h := NewCommentHandler(mock, mock, nil)
+	h := NewCommentHandler(mock, mock, nil, nil)
 	_, err := h.DeleteCommentHandler(commentUserCtx(), &DeleteCommentRequest{CommentID: "99"})
 	assertHumaError(t, err, 404)
 }
@@ -584,7 +685,7 @@ func TestDeleteComment_ForbiddenNotAuthorOrAdmin(t *testing.T) {
 			return fmt.Errorf("only the comment author or an admin can delete this comment")
 		},
 	}
-	h := NewCommentHandler(mock, mock, nil)
+	h := NewCommentHandler(mock, mock, nil, nil)
 	_, err := h.DeleteCommentHandler(commentUserCtx(), &DeleteCommentRequest{CommentID: "1"})
 	assertHumaError(t, err, 403)
 }
@@ -604,7 +705,7 @@ func TestDeleteComment_SuccessOwn(t *testing.T) {
 			return nil
 		},
 	}
-	h := NewCommentHandler(mock, mock, &mockAuditLogService{})
+	h := NewCommentHandler(mock, mock, nil, &mockAuditLogService{})
 	_, err := h.DeleteCommentHandler(commentUserCtx(), &DeleteCommentRequest{CommentID: "1"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -620,7 +721,7 @@ func TestDeleteComment_SuccessAdmin(t *testing.T) {
 			return nil
 		},
 	}
-	h := NewCommentHandler(mock, mock, &mockAuditLogService{})
+	h := NewCommentHandler(mock, mock, nil, &mockAuditLogService{})
 	_, err := h.DeleteCommentHandler(commentAdminCtx(), &DeleteCommentRequest{CommentID: "1"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -633,7 +734,7 @@ func TestDeleteComment_ServiceError(t *testing.T) {
 			return fmt.Errorf("database error")
 		},
 	}
-	h := NewCommentHandler(mock, mock, nil)
+	h := NewCommentHandler(mock, mock, nil, nil)
 	_, err := h.DeleteCommentHandler(commentUserCtx(), &DeleteCommentRequest{CommentID: "1"})
 	assertHumaError(t, err, 500)
 }

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -1107,7 +1107,7 @@ func setupRadioRoutes(rc RouteContext) {
 // Protected routes require authentication.
 // Admin routes require admin privileges.
 func setupCommentRoutes(rc RouteContext) {
-	commentHandler := handlers.NewCommentHandler(rc.SC.Comment, rc.SC.Comment, rc.SC.AuditLog)
+	commentHandler := handlers.NewCommentHandler(rc.SC.Comment, rc.SC.Comment, rc.SC.CommentVote, rc.SC.AuditLog)
 	commentAdminHandler := handlers.NewCommentAdminHandler(rc.SC.Comment, rc.SC.AuditLog)
 
 	// Public: list comments, get comment, get thread


### PR DESCRIPTION
## Summary

The comment list/get/thread handlers never populated `user_vote` in their responses, so the frontend couldn't tell which comments the current viewer had voted on. Impact:

- After a vote, the frontend's optimistic update flipped the upvote button to `text-primary`, but `onSettled`'s refetch landed with `user_vote: null` — the cache reverted and the button visually snapped back to gray within ~1s.
- On any page reload, all comments appeared un-voted regardless of history.
- Toggle-off (click an active upvote to unvote) was broken: the handler saw `comment.user_vote === null` and fired POST instead of DELETE. PSY-468 worked around this in the E2E test by cleaning up via direct API call; this PR is the real fix.

## Changes

- **`handlers/comment.go`**: new `CommentVoteReader` interface (batch vote lookup, already satisfied by `*engagement.CommentVoteService`). `NewCommentHandler` takes a vote reader as a new argument. New `populateUserVotes` helper fetches the user's votes for returned comment IDs and decorates each response — swallows lookup errors since vote state is decoration, not critical path. Wired into `ListCommentsHandler`, `GetCommentHandler`, and `GetThreadHandler` via `middleware.GetUserFromContext` (routes are already on the optional-auth group).
- **`routes/routes.go`**: pass `rc.SC.CommentVote` to `NewCommentHandler`.
- **`comment_test.go` / `comment_admin_test.go`**: test call sites pass `nil` for the vote reader when they don't exercise the auth-read path. New tests cover:
  - authenticated user with a vote → `user_vote=1` on voted comment, `nil` on others
  - anonymous request → vote reader not called, all `user_vote=nil`
  - vote-lookup error → swallowed, all `user_vote=nil`, handler still returns 200

## Test plan

- [x] All comment handler tests pass
- [x] Full backend suite passes
- [ ] Smoke-on-PR passes on this branch's CI
- [ ] Post-merge full suite passes
- [ ] Verify manually (or in a follow-up) that the upvote/downvote state now persists across page reload

## Follow-ups

- **Restore the toggle-via-click cleanup in `comments.spec.ts`** (PSY-468 worked around this by using direct DELETE; safe to revert now). Happy to do that here or in a separate tiny PR once this lands.
- Field-note vote endpoints may have the same pattern — separate audit/ticket if so.

Closes PSY-469

🤖 Generated with [Claude Code](https://claude.com/claude-code)