### PR TITLE
PSY-467: fix mobile header action cluster shrink-0 collapse

### DIFF
--- a/frontend/components/shared/EntityHeader.test.tsx
+++ b/frontend/components/shared/EntityHeader.test.tsx
@@ -33,8 +33,29 @@ describe('EntityHeader', () => {
 
   it('does not render actions container when actions not provided', () => {
     const { container } = render(<EntityHeader title="Test Album" />)
-    const actionsDiv = container.querySelector('.shrink-0')
+    const actionsDiv = container.querySelector('.sm\\:shrink-0')
     expect(actionsDiv).not.toBeInTheDocument()
+  })
+
+  it('stacks header column vertically on mobile and side-by-side at sm breakpoint', () => {
+    // Structural check: at <sm the outer row is flex-col so the action cluster
+    // drops below the title; at sm+ it becomes flex-row (action cluster sits to the right).
+    const { container } = render(
+      <EntityHeader title="Test Album" actions={<button>Follow</button>} />
+    )
+    const row = container.querySelector('.flex.flex-col.sm\\:flex-row')
+    expect(row).toBeInTheDocument()
+  })
+
+  it('applies sm:shrink-0 (not shrink-0) on actions wrapper so narrow viewports wrap naturally', () => {
+    // Regression guard for PSY-467: shrink-0 at all widths made the action
+    // cluster push the h1 to 0 width on <640px viewports, clipping the title.
+    const { container } = render(
+      <EntityHeader title="Test Album" actions={<button>Follow</button>} />
+    )
+    const actionsDiv = container.querySelector('.sm\\:shrink-0')
+    expect(actionsDiv).toBeInTheDocument()
+    expect(actionsDiv?.className).not.toMatch(/(^|\s)shrink-0(\s|$)/)
   })
 
   it('renders subtitle as ReactNode (JSX)', () => {

--- a/frontend/components/shared/EntityHeader.tsx
+++ b/frontend/components/shared/EntityHeader.tsx
@@ -32,7 +32,7 @@ export function EntityHeader({
 }: EntityHeaderProps) {
   return (
     <div className={cn('space-y-2', className)}>
-      <div className="flex items-start justify-between gap-4">
+      <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
         <div className="flex-1 min-w-0">
           <h1 className="text-2xl md:text-3xl font-bold leading-8 md:leading-9">
             {title}
@@ -44,7 +44,7 @@ export function EntityHeader({
           )}
         </div>
         {actions && (
-          <div className="flex items-center gap-2 shrink-0">{actions}</div>
+          <div className="flex flex-wrap items-center gap-2 sm:shrink-0">{actions}</div>
         )}
       </div>
     </div>

--- a/frontend/features/shows/components/ShowDetail.tsx
+++ b/frontend/features/shows/components/ShowDetail.tsx
@@ -149,8 +149,8 @@ export function ShowDetail({ showId }: ShowDetailProps) {
 
       {/* Header */}
       <header className="mb-8">
-        <div className="flex items-start justify-between gap-4">
-          <div className="flex-1">
+        <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+          <div className="flex-1 min-w-0">
             {/* Date and Status Badges */}
             <div className="flex items-center gap-2 mb-2">
               <span className="text-lg font-bold text-primary">
@@ -290,11 +290,11 @@ export function ShowDetail({ showId }: ShowDetailProps) {
           </div>
 
           {/* Action Buttons */}
-          <div className="flex flex-col items-end gap-2 shrink-0">
+          <div className="flex flex-col items-start sm:items-end gap-2 sm:shrink-0">
             {/* Attendance (Going/Interested) */}
             <AttendanceButton showId={show.id} compact={false} />
 
-            <div className="flex items-center gap-2">
+            <div className="flex flex-wrap items-center gap-2">
               <SaveButton showId={show.id} variant="outline" size="sm" />
               <AddToCollectionButton
                 entityType="show"

--- a/frontend/features/venues/components/VenueDetail.tsx
+++ b/frontend/features/venues/components/VenueDetail.tsx
@@ -177,8 +177,8 @@ export function VenueDetail({ venueId }: VenueDetailProps) {
         <div className="order-2 lg:order-1">
           {/* Header */}
           <header className="mb-8">
-            <div className="flex items-start justify-between gap-4">
-              <div className="flex-1">
+            <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+              <div className="flex-1 min-w-0">
                 <div className="flex items-center gap-2 flex-wrap">
                   <h1 className="text-2xl md:text-3xl font-bold leading-8 md:leading-9">{venue.name}</h1>
                   {venue.verified && (
@@ -212,7 +212,7 @@ export function VenueDetail({ venueId }: VenueDetailProps) {
               </div>
 
               {isAuthenticated && (
-                <div className="flex items-center gap-2 shrink-0">
+                <div className="flex flex-wrap items-center gap-2 sm:shrink-0">
                   <Button
                     variant="outline"
                     size="sm"


### PR DESCRIPTION
## Summary

Regression from PSY-439. On entity detail pages, the outer header row paired a `flex-1 min-w-0` `<h1>` with a `shrink-0` action cluster (Notify / Follow / Collect / Edit / Flag — ~393px wide). At <640px viewports, the cluster was wider than the viewport, so the title was forced to 0 width and re-wrapped character-by-character while the cluster itself overflowed horizontally (`scrollWidth` 425 vs `innerWidth` 375 on a 375px device).

**Fix (Option 2 from the ticket):** scope `shrink-0` and `justify-between` to `>=sm` (640px). Below sm, the header becomes `flex-col` — title on top, action cluster stacked below, no horizontal overflow. Desktop layout unchanged.

## What changed

- `components/shared/EntityHeader.tsx` — shared header used by artist / release / label / festival. Outer wrapper is now `flex flex-col sm:flex-row sm:items-start sm:justify-between`; action wrapper is `flex flex-wrap items-center gap-2 sm:shrink-0`.
- `features/shows/components/ShowDetail.tsx` — matching inline header fix + `flex-wrap` on the inner action row (so Save / Collect / Report / Edit / Delete wrap instead of overflowing when they're still on the same row at sm).
- `features/venues/components/VenueDetail.tsx` — same pattern.
- `components/shared/EntityHeader.test.tsx` — updated the existing `.shrink-0` selector assertion; added two regression guards (one for the `flex-col sm:flex-row` column stack, one asserting the action wrapper never uses un-scoped `shrink-0`).

Also added `min-w-0` to the title columns in ShowDetail and VenueDetail so long artist/venue names can't force horizontal overflow even at sm+.

## Test plan

- [x] `bun run test:run` — 2555 passing (added 2 new tests; existing `shrink-0` assertion updated to `sm:shrink-0`)
- [x] `bun run lint` — same 178 problems as `main` (pre-existing, unrelated to touched files); no new errors introduced by this change
- [ ] **Manual visual verification deferred to reviewer.** Port 8080 on the dev machine is already bound to an unrelated Node process, so the author didn't boot the dev stack to screenshot. Reproduce via DevTools device mode at 320 / 375 / 414 / 640 / 1024 / 1440px on `/artists/<slug>`, `/shows/<slug>`, `/venues/<slug>`, `/releases/<slug>`, `/labels/<slug>`, `/festivals/<slug>`. Assert: title readable, no horizontal scroll, action cluster reachable (on its own row at <640px).

Closes PSY-467