### PR TITLE
PSY-435: fix submit-show existing-venue test via option-role selector

### DIFF
--- a/frontend/e2e/pages/submit-show.spec.ts
+++ b/frontend/e2e/pages/submit-show.spec.ts
@@ -49,27 +49,28 @@ test.describe('Submit a show', () => {
       .locator('[id="artists[0].name"]')
       .fill('E2E Submitted Artist')
 
-    // Fill venue — type to trigger autocomplete, then select from dropdown
-    // pressSequentially keeps focus on the input while typing
+    // Fill venue — type to trigger autocomplete, then select from dropdown.
+    // The combobox input opens the dropdown when its value is non-empty
+    // (VenueInput.tsx:70 setIsOpen). Debounce is 50ms, so a single fill
+    // fires one search rather than the 10 pressSequentially fired.
     const venueInput = authenticatedPage.locator('[id="venue.name"]')
-    await venueInput.click()
-    await venueInput.pressSequentially('Valley Bar', { delay: 30 })
+    await venueInput.focus()
+    await venueInput.fill('Valley Bar')
 
-    // Wait for the Valley Bar button to appear in the autocomplete dropdown.
-    // pressSequentially fires multiple search API calls as each character is typed,
-    // so we wait for the specific button rather than just the "Existing Venues" header
-    // to avoid clicking during a re-render from a later search response.
-    const valleyBarButton = authenticatedPage.getByRole('button', { name: /Valley Bar/ })
-    await expect(valleyBarButton).toBeVisible({ timeout: 10_000 })
+    // Wait for the specific venue option to appear. The dropdown item
+    // has `role="option"` explicitly set on a <button>; match by role to
+    // stay aligned with the computed accessibility tree. Scope to the
+    // listbox so we don't collide with any "Add a show at Valley Bar"
+    // buttons elsewhere in the app.
+    const listbox = authenticatedPage.getByRole('listbox')
+    const valleyBarOption = listbox.getByRole('option', { name: /Valley Bar/ })
+    await expect(valleyBarOption).toBeVisible({ timeout: 10_000 })
 
-    // Wait briefly for any in-flight search responses to settle
-    await authenticatedPage.waitForLoadState('networkidle')
-
-    // The dropdown button's onMouseDown directly calls handleVenueSelect(venue)
+    // The option's onMouseDown directly calls handleVenueSelect(venue)
     // with the full venue object (including city/state), bypassing the
     // filteredVenues lookup in handleConfirm. It also sets justSelectedRef
     // which prevents a duplicate handleConfirm call on blur.
-    await valleyBarButton.click()
+    await valleyBarOption.click()
 
     // Verify city auto-filled from selected venue
     await expect(


### PR DESCRIPTION
## Summary

`submit-show.spec.ts:38` "can submit a show with existing venue" has been the last hard failure on main post-merge since PSY-446 flipped smoke onto PRs. PSY-437 previously tried to fix this and marked itself Done, but the error never actually went away — it was just chasing a misleading symptom.

Root cause: the dropdown item is a `<button>` with explicit `role="option"` (`VenueInput.tsx:153`), so its computed ARIA role is `option`, not `button`. The test used `getByRole('button', { name: /Valley Bar/ })`. Playwright's `expect(...).toBeVisible` somehow matched *something* and returned true, but the subsequent `.click()` entered a lossy wait-for-actionable loop that never resolved against a stable button-role element. On slower runs the test hit its 30s timeout and Playwright tore the context down mid-click — producing the "Target page, context or browser has been closed" error that led PSY-437 to chase a phantom page-crash bug.

## Changes

- `frontend/e2e/pages/submit-show.spec.ts:54-72`:
  - Switch from `getByRole('button', …)` to `listbox.getByRole('option', …)`. Matches the actual computed role and scopes to the listbox so we don't collide with "Add a show at Valley Bar" buttons elsewhere in the app.
  - Replace `pressSequentially('Valley Bar', { delay: 30 })` + `waitForLoadState('networkidle')` with a plain `fill('Valley Bar')`. `createSearchHook` debounces at 50ms, so per-char typing vs atomic fill both fire exactly one search after typing stops — fewer events mean less render churn during the wait.

## Test plan

- [x] 3 consecutive solo local runs pass (was failing every run on main)
- [ ] Smoke-on-PR is green (this test isn't `@smoke`-tagged; full post-merge suite is the real signal)
- [ ] Post-merge full suite goes green on main after merge

## Related

- Closes **PSY-435** — the remaining subcase 3 (submit-show). Subcases 1 & 2 (collection + favorite-venue) were already green from PSY-430's Layer 1 work.
- The existing `TODO(PSY-446/PSY-437)` comment in the test about adding `{ tag: '@smoke' }` can now be revisited; leaving alone here to keep the PR tight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)