### PR TITLE
PSY-453: consolidate Official tag indicator across 5 surfaces

### DIFF
--- a/frontend/components/layout/CommandPalette.test.tsx
+++ b/frontend/components/layout/CommandPalette.test.tsx
@@ -35,20 +35,38 @@ vi.mock('@/lib/context/AuthContext', () => ({
   useAuthContext: () => mockAuthContext,
 }))
 
-// Mock the entity search hook to avoid real API calls in basic tests
+// Mock the entity search hook to avoid real API calls in basic tests.
+// `mockEntitySearchResult` lets individual tests seed tag/entity results
+// without refactoring module-level mocks.
+type MockedEntitySearchData = {
+  artists: unknown[]
+  venues: unknown[]
+  releases: unknown[]
+  labels: unknown[]
+  festivals: unknown[]
+  tags: unknown[]
+}
+const emptyEntityData: MockedEntitySearchData = {
+  artists: [],
+  venues: [],
+  releases: [],
+  labels: [],
+  festivals: [],
+  tags: [],
+}
+let mockEntitySearchResult: {
+  data: MockedEntitySearchData
+  isSearching: boolean
+  totalResults: number
+  isFetching: boolean
+} = {
+  data: emptyEntityData,
+  isSearching: false,
+  totalResults: 0,
+  isFetching: false,
+}
 vi.mock('@/lib/hooks/common/useEntitySearch', () => ({
-  useEntitySearch: () => ({
-    data: {
-      artists: [],
-      venues: [],
-      releases: [],
-      labels: [],
-      festivals: [],
-    },
-    isSearching: false,
-    totalResults: 0,
-    isFetching: false,
-  }),
+  useEntitySearch: () => mockEntitySearchResult,
 }))
 
 describe('CommandPalette', () => {
@@ -57,6 +75,12 @@ describe('CommandPalette', () => {
     localStorage.clear()
     mockAuthContext.user = null
     mockAuthContext.isAuthenticated = false
+    mockEntitySearchResult = {
+      data: emptyEntityData,
+      isSearching: false,
+      totalResults: 0,
+      isFetching: false,
+    }
   })
 
   it('should open on Cmd+K', async () => {
@@ -227,5 +251,65 @@ describe('CommandPalette', () => {
     })
 
     expect(screen.getByPlaceholderText('Search entities or go to page...')).toBeInTheDocument()
+  })
+})
+
+describe('CommandPalette — tag row official indicator (PSY-453)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    mockAuthContext.user = null
+    mockAuthContext.isAuthenticated = false
+  })
+
+  it('renders the shared official indicator on official tag rows only', async () => {
+    const user = userEvent.setup()
+    mockEntitySearchResult = {
+      data: {
+        artists: [],
+        venues: [],
+        releases: [],
+        labels: [],
+        festivals: [],
+        tags: [
+          {
+            id: 1,
+            slug: 'shoegaze',
+            name: 'shoegaze',
+            subtitle: 'Genre',
+            entityType: 'tag',
+            href: '/tags/shoegaze',
+            isOfficial: true,
+          },
+          {
+            id: 2,
+            slug: 'dreampop',
+            name: 'dreampop',
+            subtitle: 'Genre',
+            entityType: 'tag',
+            href: '/tags/dreampop',
+            isOfficial: false,
+          },
+        ],
+      },
+      isSearching: false,
+      totalResults: 2,
+      isFetching: false,
+    }
+
+    renderWithProviders(<CommandPalette />)
+
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'k', metaKey: true, bubbles: true })
+      )
+    })
+
+    const input = screen.getByPlaceholderText('Search entities or go to page...')
+    await user.type(input, 'sho')
+
+    const markers = screen.getAllByRole('img', { name: 'Official tag' })
+    expect(markers).toHaveLength(1)
+    expect(markers[0]).toHaveAttribute('title', 'shoegaze (Official)')
   })
 })

--- a/frontend/components/layout/CommandPalette.tsx
+++ b/frontend/components/layout/CommandPalette.tsx
@@ -23,6 +23,7 @@ import { useAuthContext } from '@/lib/context/AuthContext'
 import { useCommandPalette } from '@/lib/hooks/common/useCommandPalette'
 import { useEntitySearch } from '@/lib/hooks/common/useEntitySearch'
 import type { EntitySearchResult } from '@/lib/hooks/common/useEntitySearch'
+import { TagOfficialIndicator } from '@/features/tags'
 
 interface RouteItem {
   label: string
@@ -490,8 +491,13 @@ export function CommandPalette() {
                   keywords={[result.name]}
                 >
                   <Icon className="h-4 w-4 text-muted-foreground" />
-                  <div className="flex flex-col gap-0.5 min-w-0">
-                    <span className="truncate">{result.name}</span>
+                  <div className="flex min-w-0 flex-col gap-0.5">
+                    <span className="inline-flex items-center gap-1.5 truncate">
+                      <span className="truncate">{result.name}</span>
+                      {result.entityType === 'tag' && result.isOfficial && (
+                        <TagOfficialIndicator size="sm" tagName={result.name} />
+                      )}
+                    </span>
                     {result.subtitle && (
                       <span className="text-xs text-muted-foreground truncate">
                         {result.subtitle}

--- a/frontend/features/tags/admin/TagManagement.test.tsx
+++ b/frontend/features/tags/admin/TagManagement.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import { renderWithProviders } from '@/test/utils'
+import type { TagListItem } from '../types'
+
+const mockUseTags = vi.fn()
+vi.mock('../hooks', () => ({
+  useTags: (...args: unknown[]) => mockUseTags(...args),
+  useTag: vi.fn(),
+}))
+
+vi.mock('./useAdminTags', () => ({
+  useCreateTag: () => ({ mutate: vi.fn(), isPending: false }),
+  useUpdateTag: () => ({ mutate: vi.fn(), isPending: false }),
+  useDeleteTag: () => ({ mutate: vi.fn(), isPending: false }),
+  useTagAliases: () => ({ data: { aliases: [] }, isLoading: false }),
+  useCreateAlias: () => ({ mutate: vi.fn(), isPending: false }),
+  useDeleteAlias: () => ({ mutate: vi.fn(), isPending: false }),
+}))
+
+import { TagManagement } from './TagManagement'
+
+function makeTag(overrides: Partial<TagListItem> = {}): TagListItem {
+  return {
+    id: 1,
+    name: 'rock',
+    slug: 'rock',
+    category: 'genre',
+    is_official: false,
+    usage_count: 42,
+    created_at: '2025-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('TagManagement — official indicator', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the shared TagOfficialIndicator on official rows', () => {
+    mockUseTags.mockReturnValue({
+      data: {
+        tags: [
+          makeTag({ id: 1, name: 'shoegaze', slug: 'shoegaze', is_official: true }),
+          makeTag({ id: 2, name: 'indie', slug: 'indie', is_official: false }),
+        ],
+        total: 2,
+      },
+      isLoading: false,
+      error: null,
+    })
+
+    renderWithProviders(<TagManagement />)
+
+    const markers = screen.getAllByRole('img', { name: 'Official tag' })
+    expect(markers).toHaveLength(1)
+    expect(markers[0]).toHaveAttribute('title', 'shoegaze (Official)')
+  })
+
+  it('does not render the indicator when no tags are official', () => {
+    mockUseTags.mockReturnValue({
+      data: {
+        tags: [makeTag({ is_official: false })],
+        total: 1,
+      },
+      isLoading: false,
+      error: null,
+    })
+
+    renderWithProviders(<TagManagement />)
+
+    expect(screen.queryByRole('img', { name: 'Official tag' })).not.toBeInTheDocument()
+  })
+})

--- a/frontend/features/tags/admin/TagManagement.tsx
+++ b/frontend/features/tags/admin/TagManagement.tsx
@@ -10,7 +10,6 @@ import {
   Inbox,
   Tags,
   X,
-  BadgeCheck,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -26,6 +25,7 @@ import {
   DialogFooter,
 } from '@/components/ui/dialog'
 import { useTags, useTag } from '../hooks'
+import { TagOfficialIndicator } from '../components/TagOfficialIndicator'
 import {
   useCreateTag,
   useUpdateTag,
@@ -680,7 +680,7 @@ export function TagManagement() {
                       {getCategoryLabel(tag.category)}
                     </Badge>
                     {tag.is_official && (
-                      <BadgeCheck className="h-3.5 w-3.5 text-primary flex-shrink-0" />
+                      <TagOfficialIndicator size="sm" tagName={tag.name} />
                     )}
                   </div>
                   <div className="flex items-center gap-3 text-xs text-muted-foreground mt-0.5">

--- a/frontend/features/tags/components/EntityTagList.tsx
+++ b/frontend/features/tags/components/EntityTagList.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useMemo } from 'react'
 import Link from 'next/link'
-import { Plus, ThumbsUp, ThumbsDown, X, Search, Loader2, BadgeCheck, ChevronDown, ChevronUp } from 'lucide-react'
+import { Plus, ThumbsUp, ThumbsDown, X, Search, Loader2, ChevronDown, ChevronUp } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -23,6 +23,7 @@ import {
 } from '../hooks'
 import { getCategoryColor, TAG_CATEGORIES, getCategoryLabel } from '../types'
 import type { EntityTag, TagListItem } from '../types'
+import { TagOfficialIndicator } from './TagOfficialIndicator'
 
 interface EntityTagListProps {
   entityType: string
@@ -175,12 +176,7 @@ function TagWithVotes({
       )}
     >
       {tag.is_official && (
-        <span title="Official tag" aria-label="Official tag" role="img">
-          <BadgeCheck
-            className="h-3.5 w-3.5 text-primary shrink-0"
-            aria-hidden="true"
-          />
-        </span>
+        <TagOfficialIndicator size="sm" tagName={tag.name} />
       )}
       <Link
         href={`/tags/${tag.slug}`}

--- a/frontend/features/tags/components/TagBrowse.tsx
+++ b/frontend/features/tags/components/TagBrowse.tsx
@@ -7,10 +7,10 @@ import { useDebounce } from 'use-debounce'
 import { cn } from '@/lib/utils'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
-import { Badge } from '@/components/ui/badge'
 import { useTags } from '../hooks'
 import { TAG_CATEGORIES, getCategoryColor, getCategoryLabel } from '../types'
 import type { TagListItem } from '../types'
+import { TagOfficialIndicator } from './TagOfficialIndicator'
 
 const PAGE_SIZE = 50
 const SEARCH_DEBOUNCE_MS = 300
@@ -182,9 +182,7 @@ function TagCard({ tag }: { tag: TagListItem }) {
             {tag.name}
           </span>
           {tag.is_official && (
-            <Badge variant="secondary" className="text-[10px] px-1.5 py-0 shrink-0">
-              Official
-            </Badge>
+            <TagOfficialIndicator size="md" tagName={tag.name} />
           )}
         </div>
         <div className="flex items-center gap-2">

--- a/frontend/features/tags/components/TagDetail.tsx
+++ b/frontend/features/tags/components/TagDetail.tsx
@@ -6,12 +6,12 @@ import { ArrowLeft, Hash, Loader2, Music, MapPin, Calendar, Disc3, Tag, Tent, Cl
 import { NotifyMeButton } from '@/features/notifications'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
-import { Badge } from '@/components/ui/badge'
 import { Breadcrumb } from '@/components/shared'
 import { formatRelativeTime } from '@/lib/formatRelativeTime'
 import { useTagDetail, useTagEntities } from '../hooks'
 import { getCategoryColor, getCategoryLabel, getEntityUrl, getEntityTypePluralLabel } from '../types'
 import type { TaggedEntityItem, TagSummary } from '../types'
+import { TagOfficialIndicator } from './TagOfficialIndicator'
 
 interface TagDetailProps {
   slug: string
@@ -156,7 +156,7 @@ export function TagDetail({ slug }: TagDetailProps) {
             <div className="flex items-center gap-3 mb-1">
               <h1 className="text-3xl font-bold tracking-tight">{tag.name}</h1>
               {tag.is_official && (
-                <Badge variant="secondary">Official</Badge>
+                <TagOfficialIndicator size="md" tagName={tag.name} />
               )}
               <NotifyMeButton entityType="tag" entityId={tag.id} entityName={tag.name} />
             </div>

--- a/frontend/features/tags/components/TagOfficialIndicator.test.tsx
+++ b/frontend/features/tags/components/TagOfficialIndicator.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { TagOfficialIndicator } from './TagOfficialIndicator'
+
+describe('TagOfficialIndicator', () => {
+  it('renders the BadgeCheck icon at size="sm" without the "Official" text', () => {
+    render(<TagOfficialIndicator size="sm" />)
+
+    const marker = screen.getByRole('img', { name: 'Official tag' })
+    expect(marker).toBeInTheDocument()
+
+    const icon = marker.querySelector('.lucide-badge-check')
+    expect(icon).not.toBeNull()
+
+    expect(screen.queryByText('Official')).not.toBeInTheDocument()
+  })
+
+  it('renders the BadgeCheck icon and "Official" text at size="md"', () => {
+    render(<TagOfficialIndicator size="md" />)
+
+    const marker = screen.getByRole('img', { name: 'Official tag' })
+    expect(marker).toBeInTheDocument()
+
+    const icon = marker.querySelector('.lucide-badge-check')
+    expect(icon).not.toBeNull()
+
+    expect(screen.getByText('Official')).toBeInTheDocument()
+  })
+
+  it('defaults to size="sm" when size is not provided', () => {
+    render(<TagOfficialIndicator />)
+
+    expect(screen.getByRole('img', { name: 'Official tag' })).toBeInTheDocument()
+    expect(screen.queryByText('Official')).not.toBeInTheDocument()
+  })
+
+  it('uses a tag-specific tooltip when tagName is provided', () => {
+    render(<TagOfficialIndicator tagName="shoegaze" />)
+
+    const marker = screen.getByRole('img', { name: 'Official tag' })
+    expect(marker).toHaveAttribute('title', 'shoegaze (Official)')
+  })
+
+  it('falls back to a generic tooltip without tagName', () => {
+    render(<TagOfficialIndicator />)
+
+    const marker = screen.getByRole('img', { name: 'Official tag' })
+    expect(marker).toHaveAttribute('title', 'Official tag')
+  })
+
+  it('preserves aria-label="Official tag" at both sizes', () => {
+    const { rerender } = render(<TagOfficialIndicator size="sm" />)
+    expect(screen.getByRole('img', { name: 'Official tag' })).toHaveAttribute(
+      'aria-label',
+      'Official tag'
+    )
+
+    rerender(<TagOfficialIndicator size="md" />)
+    expect(screen.getByRole('img', { name: 'Official tag' })).toHaveAttribute(
+      'aria-label',
+      'Official tag'
+    )
+  })
+
+  it('applies additional className while preserving base classes', () => {
+    render(<TagOfficialIndicator className="ml-2" />)
+
+    const marker = screen.getByRole('img', { name: 'Official tag' })
+    expect(marker.className).toContain('ml-2')
+    expect(marker.className).toContain('text-primary')
+  })
+})

--- a/frontend/features/tags/components/TagOfficialIndicator.tsx
+++ b/frontend/features/tags/components/TagOfficialIndicator.tsx
@@ -1,0 +1,45 @@
+import { BadgeCheck } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+type TagOfficialIndicatorSize = 'sm' | 'md'
+
+interface TagOfficialIndicatorProps {
+  /**
+   * Tag name for the tooltip. When provided, the title reads
+   * "{name} (Official)" so users can distinguish official marks
+   * across multiple tags in a row. Omitting it falls back to
+   * the generic "Official tag" label.
+   */
+  tagName?: string
+  size?: TagOfficialIndicatorSize
+  className?: string
+}
+
+export function TagOfficialIndicator({
+  tagName,
+  size = 'sm',
+  className,
+}: TagOfficialIndicatorProps) {
+  const iconSize =
+    size === 'md' ? 'h-4 w-4' : 'h-3.5 w-3.5'
+  const title = tagName ? `${tagName} (Official)` : 'Official tag'
+
+  return (
+    <span
+      title={title}
+      aria-label="Official tag"
+      role="img"
+      className={cn(
+        'inline-flex items-center gap-1 text-primary shrink-0',
+        className
+      )}
+    >
+      <BadgeCheck className={cn(iconSize, 'shrink-0')} aria-hidden="true" />
+      {size === 'md' && (
+        <span className="text-[10px] font-medium uppercase tracking-wider">
+          Official
+        </span>
+      )}
+    </span>
+  )
+}

--- a/frontend/features/tags/components/index.ts
+++ b/frontend/features/tags/components/index.ts
@@ -1,3 +1,4 @@
 export { EntityTagList } from './EntityTagList'
 export { TagBrowse } from './TagBrowse'
 export { TagDetail } from './TagDetail'
+export { TagOfficialIndicator } from './TagOfficialIndicator'

--- a/frontend/features/tags/index.ts
+++ b/frontend/features/tags/index.ts
@@ -40,4 +40,9 @@ export {
   useRemoveTagVote,
 } from './hooks'
 
-export { EntityTagList, TagBrowse, TagDetail } from './components'
+export {
+  EntityTagList,
+  TagBrowse,
+  TagDetail,
+  TagOfficialIndicator,
+} from './components'

--- a/frontend/lib/hooks/common/useEntitySearch.ts
+++ b/frontend/lib/hooks/common/useEntitySearch.ts
@@ -21,6 +21,11 @@ export interface EntitySearchResult {
   subtitle: string | null
   entityType: 'artist' | 'venue' | 'release' | 'label' | 'festival' | 'tag'
   href: string
+  /**
+   * Only populated for tag results — surfaces the curated-tag mark in the
+   * Cmd+K palette so users can distinguish official tags at a glance.
+   */
+  isOfficial?: boolean
 }
 
 export interface EntitySearchResults {
@@ -80,6 +85,7 @@ interface TagSearchItem {
   name: string
   category: string
   usage_count: number
+  is_official: boolean
 }
 
 // ============================================================================
@@ -163,6 +169,7 @@ function mapTag(t: TagSearchItem): EntitySearchResult {
     subtitle: category,
     entityType: 'tag',
     href: `/tags/${t.slug}`,
+    isOfficial: t.is_official,
   }
 }
 


### PR DESCRIPTION
## Summary
- Extracts a shared `<TagOfficialIndicator>` primitive (in `features/tags/components/`) with `size="sm"` (icon only) and `size="md"` (icon + "Official" label).
- Replaces the four divergent renderings of `is_official=true` and fills the one missing surface so every appearance of an official tag now shares the same icon, tooltip, and `aria-label`.
- `title="{name} (Official)"` and `aria-label="Official tag"` are preserved on every surface. The entity-pill primary-accent background (`bg-primary/10`) is unchanged.

## Surfaces updated
| Surface | Before | After |
|---|---|---|
| Entity detail pill (`EntityTagList` `TagWithVotes`) | Inline `BadgeCheck` + pill tone | `<TagOfficialIndicator size="sm" />` inside the existing primary-accent pill |
| Tag browse card (`TagBrowse`) | shadcn `<Badge variant="secondary">Official</Badge>` | `<TagOfficialIndicator size="md" />` |
| Tag detail heading (`TagDetail`) | Same `<Badge>Official</Badge>` | `<TagOfficialIndicator size="md" />` |
| Admin tag list row (`TagManagement`) | Tiny bare `BadgeCheck` (easy to miss) | `<TagOfficialIndicator size="sm" />` with title tooltip |
| Cmd+K palette tag rows (`CommandPalette`) | Nothing — no indicator at all | `<TagOfficialIndicator size="sm" />` (NEW). `useEntitySearch` now carries `isOfficial` through for tag results. |

The hierarchy/related-tag `TagPill` rendering is deliberately left untouched — it's a different shape (inline text inside a link) not listed in the ticket's 5 surfaces.

## Test plan
- [x] `TagOfficialIndicator.test.tsx` — both sizes, icon/text rendering, aria-label, tooltip, className composition (7 tests)
- [x] `TagManagement.test.tsx` (new) — admin list renders the shared indicator on official rows only
- [x] Updated `CommandPalette.test.tsx` (new describe block) — tag rows render the indicator when `isOfficial=true`
- [x] Existing `EntityTagList`, `TagBrowse`, `TagDetail` tests still pass — they check `'Official tag'` role, `bg-primary/10`, and `'Official'` text which the new primitive preserves
- [x] `bun run test:run` — all 114 tests across touched files pass; lint produces no new errors (pre-existing react-compiler warnings are unchanged)
- [ ] Manual smoke: dev env not started during this automated run; visual verification deferred to reviewer

Closes PSY-453

🤖 Generated with [Claude Code](https://claude.com/claude-code)