### PR TITLE
PSY-308: auto-prune downvoted entity_tags (hourly cron)

### DIFF
--- a/backend/internal/services/admin/cleanup.go
+++ b/backend/internal/services/admin/cleanup.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 	"os"
 	"strconv"
@@ -19,6 +20,16 @@ import (
 // Default cleanup interval (24 hours)
 const DefaultCleanupInterval = 24 * time.Hour
 
+// Tag prune defaults (Gazelle-style downvote auto-prune for entity_tags).
+const (
+	DefaultTagPruneInterval = 1 * time.Hour
+	// Strict inequality on downs > ups — ties stay. Gazelle precedent requires ≥2 downs.
+	MinDownvotesToPrune = 2
+)
+
+// Audit log action name for tag prune cycles (system-initiated, ActorID nil).
+const AuditActionPruneDownvotedTags = "prune_downvoted_tags"
+
 // cleanupUserService is the minimal interface CleanupService needs from UserService.
 type cleanupUserService interface {
 	GetExpiredDeletedAccounts() ([]models.User, error)
@@ -27,12 +38,15 @@ type cleanupUserService interface {
 
 // CleanupService handles background cleanup tasks
 type CleanupService struct {
-	db          *gorm.DB
-	userService cleanupUserService
-	interval    time.Duration
-	stopCh      chan struct{}
-	wg          sync.WaitGroup
-	logger      *slog.Logger
+	db               *gorm.DB
+	userService      cleanupUserService
+	interval         time.Duration
+	tagPruneInterval time.Duration
+	tagPruneEnabled  bool
+	tagPruneDryRun   bool
+	stopCh           chan struct{}
+	wg               sync.WaitGroup
+	logger           *slog.Logger
 }
 
 // NewCleanupService creates a new cleanup service.
@@ -43,20 +57,42 @@ func NewCleanupService(database *gorm.DB, userSvc cleanupUserService) *CleanupSe
 	}
 
 	interval := DefaultCleanupInterval
-
-	// Allow override via environment variable (for testing)
 	if envInterval := os.Getenv("CLEANUP_INTERVAL_HOURS"); envInterval != "" {
 		if hours, err := strconv.Atoi(envInterval); err == nil && hours > 0 {
 			interval = time.Duration(hours) * time.Hour
 		}
 	}
 
+	tagPruneInterval := DefaultTagPruneInterval
+	if envInterval := os.Getenv("TAG_PRUNE_INTERVAL_HOURS"); envInterval != "" {
+		if hours, err := strconv.Atoi(envInterval); err == nil && hours > 0 {
+			tagPruneInterval = time.Duration(hours) * time.Hour
+		}
+	}
+
+	tagPruneEnabled := true
+	if v := os.Getenv("TAG_PRUNE_ENABLED"); v != "" {
+		if parsed, err := strconv.ParseBool(v); err == nil {
+			tagPruneEnabled = parsed
+		}
+	}
+
+	tagPruneDryRun := false
+	if v := os.Getenv("TAG_PRUNE_DRY_RUN"); v != "" {
+		if parsed, err := strconv.ParseBool(v); err == nil {
+			tagPruneDryRun = parsed
+		}
+	}
+
 	return &CleanupService{
-		db:          database,
-		userService: userSvc,
-		interval:    interval,
-		stopCh:      make(chan struct{}),
-		logger:      slog.Default(),
+		db:               database,
+		userService:      userSvc,
+		interval:         interval,
+		tagPruneInterval: tagPruneInterval,
+		tagPruneEnabled:  tagPruneEnabled,
+		tagPruneDryRun:   tagPruneDryRun,
+		stopCh:           make(chan struct{}),
+		logger:           slog.Default(),
 	}
 }
 
@@ -66,6 +102,9 @@ func (s *CleanupService) Start(ctx context.Context) {
 	go s.run(ctx)
 	s.logger.Info("account cleanup service started",
 		"interval_hours", s.interval.Hours(),
+		"tag_prune_enabled", s.tagPruneEnabled,
+		"tag_prune_dry_run", s.tagPruneDryRun,
+		"tag_prune_interval_hours", s.tagPruneInterval.Hours(),
 	)
 }
 
@@ -76,15 +115,20 @@ func (s *CleanupService) Stop() {
 	s.logger.Info("account cleanup service stopped")
 }
 
-// run is the main loop for the cleanup service
+// run is the main loop for the cleanup service.
+// Runs account cleanup and tag prune on independent tickers in a single goroutine.
 func (s *CleanupService) run(ctx context.Context) {
 	defer s.wg.Done()
 
 	// Run immediately on startup
 	s.runCleanupCycle()
+	s.runTagPruneCycle(ctx)
 
 	ticker := time.NewTicker(s.interval)
 	defer ticker.Stop()
+
+	tagPruneTicker := time.NewTicker(s.tagPruneInterval)
+	defer tagPruneTicker.Stop()
 
 	for {
 		select {
@@ -96,6 +140,8 @@ func (s *CleanupService) run(ctx context.Context) {
 			return
 		case <-ticker.C:
 			s.runCleanupCycle()
+		case <-tagPruneTicker.C:
+			s.runTagPruneCycle(ctx)
 		}
 	}
 }
@@ -163,6 +209,117 @@ func (s *CleanupService) runCleanupCycle() {
 // RunCleanupNow triggers an immediate cleanup cycle (useful for testing)
 func (s *CleanupService) RunCleanupNow() {
 	s.runCleanupCycle()
+}
+
+// RunTagPruneNow triggers an immediate tag prune cycle (useful for testing).
+// Returns the number of entity_tags rows deleted (0 in dry-run).
+func (s *CleanupService) RunTagPruneNow(ctx context.Context) (int64, error) {
+	return s.pruneDownvotedEntityTags(ctx)
+}
+
+// runTagPruneCycle performs a single tag prune cycle, writing an audit log entry.
+// Audit log errors are logged but never fail the cycle (fire-and-forget).
+func (s *CleanupService) runTagPruneCycle(ctx context.Context) {
+	if !s.tagPruneEnabled {
+		s.logger.Info("tag prune skipped: disabled via TAG_PRUNE_ENABLED")
+		return
+	}
+
+	s.logger.Info("starting tag prune cycle",
+		"dry_run", s.tagPruneDryRun,
+		"threshold_min_downs", MinDownvotesToPrune,
+	)
+
+	deleted, err := s.pruneDownvotedEntityTags(ctx)
+	if err != nil {
+		s.logger.Error("tag prune cycle failed", "error", err)
+		return
+	}
+
+	s.logger.Info("tag prune cycle completed",
+		"deleted_count", deleted,
+		"dry_run", s.tagPruneDryRun,
+	)
+
+	s.writeTagPruneAuditLog(deleted)
+}
+
+// pruneDownvotedEntityTags deletes entity_tags rows whose per-entity vote
+// aggregate has downs > ups AND downs >= MinDownvotesToPrune.
+// In dry-run mode, returns the count of rows that would be deleted without deleting.
+// Only removes the entity-tag application — the tag row in `tags` is untouched.
+func (s *CleanupService) pruneDownvotedEntityTags(ctx context.Context) (int64, error) {
+	if s.db == nil {
+		return 0, nil
+	}
+
+	// Strict `v.downs > v.ups` so ties stay; `v.downs >= ?` enforces the minimum.
+	selectSQL := `
+		SELECT et.id
+		FROM entity_tags et
+		JOIN (
+			SELECT tag_id, entity_type, entity_id,
+			       SUM(CASE WHEN vote = 1 THEN 1 ELSE 0 END) AS ups,
+			       SUM(CASE WHEN vote = -1 THEN 1 ELSE 0 END) AS downs
+			FROM tag_votes
+			GROUP BY tag_id, entity_type, entity_id
+		) v ON v.tag_id = et.tag_id
+		   AND v.entity_type = et.entity_type
+		   AND v.entity_id = et.entity_id
+		WHERE v.downs > v.ups AND v.downs >= ?
+	`
+
+	if s.tagPruneDryRun {
+		var count int64
+		if err := s.db.WithContext(ctx).
+			Raw("SELECT COUNT(*) FROM ("+selectSQL+") sub", MinDownvotesToPrune).
+			Scan(&count).Error; err != nil {
+			return 0, err
+		}
+		return count, nil
+	}
+
+	result := s.db.WithContext(ctx).Exec(
+		"DELETE FROM entity_tags WHERE id IN ("+selectSQL+")",
+		MinDownvotesToPrune,
+	)
+	if result.Error != nil {
+		return 0, result.Error
+	}
+	return result.RowsAffected, nil
+}
+
+// writeTagPruneAuditLog records a tag prune cycle summary in the audit log.
+// Fire-and-forget — errors log but never fail the parent operation.
+func (s *CleanupService) writeTagPruneAuditLog(deleted int64) {
+	if s.db == nil {
+		return
+	}
+
+	metadata := map[string]interface{}{
+		"deleted_count":       deleted,
+		"threshold_min_downs": MinDownvotesToPrune,
+		"dry_run":             s.tagPruneDryRun,
+	}
+	metadataJSON, err := json.Marshal(metadata)
+	if err != nil {
+		s.logger.Error("failed to marshal tag prune audit log metadata", "error", err)
+		return
+	}
+
+	raw := json.RawMessage(metadataJSON)
+	auditLog := models.AuditLog{
+		ActorID:    nil,
+		Action:     AuditActionPruneDownvotedTags,
+		EntityType: "entity_tags",
+		EntityID:   0,
+		Metadata:   &raw,
+		CreatedAt:  time.Now().UTC(),
+	}
+
+	if err := s.db.Create(&auditLog).Error; err != nil {
+		s.logger.Error("failed to write tag prune audit log", "error", err)
+	}
 }
 
 // hashEmail masks an email for privacy (e.g., "jo***@example.com")

--- a/backend/internal/services/admin/cleanup_tag_prune_test.go
+++ b/backend/internal/services/admin/cleanup_tag_prune_test.go
@@ -1,0 +1,386 @@
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/testutil"
+)
+
+// discardLogger returns a slog.Logger that writes nowhere — keeps test output clean.
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// =============================================================================
+// INTEGRATION TESTS — Tag Prune (PSY-308)
+// =============================================================================
+
+type CleanupTagPruneTestSuite struct {
+	suite.Suite
+	testDB  *testutil.TestDatabase
+	db      *gorm.DB
+	service *CleanupService
+}
+
+func (s *CleanupTagPruneTestSuite) SetupSuite() {
+	s.testDB = testutil.SetupTestPostgres(s.T())
+	s.db = s.testDB.DB
+}
+
+func (s *CleanupTagPruneTestSuite) TearDownSuite() {
+	s.testDB.Cleanup()
+}
+
+func (s *CleanupTagPruneTestSuite) SetupTest() {
+	s.service = &CleanupService{
+		db:               s.db,
+		userService:      &stubUserService{},
+		interval:         DefaultCleanupInterval,
+		tagPruneInterval: DefaultTagPruneInterval,
+		tagPruneEnabled:  true,
+		tagPruneDryRun:   false,
+		stopCh:           make(chan struct{}),
+		logger:           discardLogger(),
+	}
+}
+
+func (s *CleanupTagPruneTestSuite) TearDownTest() {
+	sqlDB, err := s.db.DB()
+	s.Require().NoError(err)
+	_, _ = sqlDB.Exec("DELETE FROM audit_logs")
+	_, _ = sqlDB.Exec("DELETE FROM tag_votes")
+	_, _ = sqlDB.Exec("DELETE FROM entity_tags")
+	_, _ = sqlDB.Exec("DELETE FROM tag_aliases")
+	_, _ = sqlDB.Exec("DELETE FROM tags")
+	_, _ = sqlDB.Exec("DELETE FROM users")
+}
+
+func TestCleanupTagPruneTestSuite(t *testing.T) {
+	suite.Run(t, new(CleanupTagPruneTestSuite))
+}
+
+// ------------------------------------------------------------
+// Helpers
+// ------------------------------------------------------------
+
+var userCounter int
+
+func (s *CleanupTagPruneTestSuite) createUser() *models.User {
+	userCounter++
+	email := fmt.Sprintf("prune-%d-%d@test.com", time.Now().UnixNano(), userCounter)
+	user := &models.User{
+		Email:         &email,
+		IsActive:      true,
+		EmailVerified: true,
+	}
+	s.Require().NoError(s.db.Create(user).Error)
+	return user
+}
+
+func (s *CleanupTagPruneTestSuite) createTag(name string) *models.Tag {
+	userCounter++
+	tag := &models.Tag{
+		Name:     name,
+		Slug:     fmt.Sprintf("%s-%d-%d", name, time.Now().UnixNano(), userCounter),
+		Category: models.TagCategoryGenre,
+	}
+	s.Require().NoError(s.db.Create(tag).Error)
+	return tag
+}
+
+// applyTag creates an entity_tag and casts the given up/down votes against it,
+// using unique per-vote users to satisfy the composite primary key.
+func (s *CleanupTagPruneTestSuite) applyTag(tag *models.Tag, entityType string, entityID uint, ups, downs int) *models.EntityTag {
+	adder := s.createUser()
+	et := &models.EntityTag{
+		TagID:         tag.ID,
+		EntityType:    entityType,
+		EntityID:      entityID,
+		AddedByUserID: adder.ID,
+	}
+	s.Require().NoError(s.db.Create(et).Error)
+
+	for i := 0; i < ups; i++ {
+		voter := s.createUser()
+		vote := &models.TagVote{
+			TagID:      tag.ID,
+			EntityType: entityType,
+			EntityID:   entityID,
+			UserID:     voter.ID,
+			Vote:       1,
+		}
+		s.Require().NoError(s.db.Create(vote).Error)
+	}
+	for i := 0; i < downs; i++ {
+		voter := s.createUser()
+		vote := &models.TagVote{
+			TagID:      tag.ID,
+			EntityType: entityType,
+			EntityID:   entityID,
+			UserID:     voter.ID,
+			Vote:       -1,
+		}
+		s.Require().NoError(s.db.Create(vote).Error)
+	}
+	return et
+}
+
+func (s *CleanupTagPruneTestSuite) entityTagExists(id uint) bool {
+	var count int64
+	s.db.Model(&models.EntityTag{}).Where("id = ?", id).Count(&count)
+	return count == 1
+}
+
+func (s *CleanupTagPruneTestSuite) tagRowExists(id uint) bool {
+	var count int64
+	s.db.Model(&models.Tag{}).Where("id = ?", id).Count(&count)
+	return count == 1
+}
+
+// ------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------
+
+// Happy path: downs > ups AND downs >= 2 → pruned.
+func (s *CleanupTagPruneTestSuite) TestPrune_HappyPath_2DownsZeroUps() {
+	tag := s.createTag("noise")
+	et := s.applyTag(tag, "artist", 1, 0, 2)
+
+	deleted, err := s.service.pruneDownvotedEntityTags(context.Background())
+	s.Require().NoError(err)
+	s.Equal(int64(1), deleted)
+	s.False(s.entityTagExists(et.ID))
+	// Tag itself must remain.
+	s.True(s.tagRowExists(tag.ID))
+}
+
+func (s *CleanupTagPruneTestSuite) TestPrune_HappyPath_3DownsOneUp() {
+	tag := s.createTag("bad-fit")
+	et := s.applyTag(tag, "release", 5, 1, 3)
+
+	deleted, err := s.service.pruneDownvotedEntityTags(context.Background())
+	s.Require().NoError(err)
+	s.Equal(int64(1), deleted)
+	s.False(s.entityTagExists(et.ID))
+	s.True(s.tagRowExists(tag.ID))
+}
+
+// Tie: downs == ups should NOT prune (strict inequality required).
+func (s *CleanupTagPruneTestSuite) TestPrune_TiedVotes_NotPruned() {
+	tag := s.createTag("debatable")
+	et := s.applyTag(tag, "artist", 2, 2, 2)
+
+	deleted, err := s.service.pruneDownvotedEntityTags(context.Background())
+	s.Require().NoError(err)
+	s.Equal(int64(0), deleted)
+	s.True(s.entityTagExists(et.ID))
+}
+
+// Below threshold: downs == 1 should NOT prune.
+func (s *CleanupTagPruneTestSuite) TestPrune_SingleDownvote_NotPruned() {
+	tag := s.createTag("maybe")
+	et := s.applyTag(tag, "artist", 3, 0, 1)
+
+	deleted, err := s.service.pruneDownvotedEntityTags(context.Background())
+	s.Require().NoError(err)
+	s.Equal(int64(0), deleted)
+	s.True(s.entityTagExists(et.ID))
+}
+
+// No votes at all: should NOT prune.
+func (s *CleanupTagPruneTestSuite) TestPrune_NoVotes_NotPruned() {
+	tag := s.createTag("fresh")
+	et := s.applyTag(tag, "label", 9, 0, 0)
+
+	deleted, err := s.service.pruneDownvotedEntityTags(context.Background())
+	s.Require().NoError(err)
+	s.Equal(int64(0), deleted)
+	s.True(s.entityTagExists(et.ID))
+}
+
+// ups > downs: should NOT prune, even with many downs.
+func (s *CleanupTagPruneTestSuite) TestPrune_UpsWinMajority_NotPruned() {
+	tag := s.createTag("loved")
+	et := s.applyTag(tag, "show", 11, 5, 3)
+
+	deleted, err := s.service.pruneDownvotedEntityTags(context.Background())
+	s.Require().NoError(err)
+	s.Equal(int64(0), deleted)
+	s.True(s.entityTagExists(et.ID))
+}
+
+// Idempotency: running twice back-to-back must not over-delete.
+func (s *CleanupTagPruneTestSuite) TestPrune_Idempotency() {
+	tag := s.createTag("idem")
+	s.applyTag(tag, "artist", 100, 0, 3)
+	s.applyTag(tag, "artist", 101, 0, 3)
+
+	deleted1, err := s.service.pruneDownvotedEntityTags(context.Background())
+	s.Require().NoError(err)
+	s.Equal(int64(2), deleted1)
+
+	deleted2, err := s.service.pruneDownvotedEntityTags(context.Background())
+	s.Require().NoError(err)
+	s.Equal(int64(0), deleted2)
+}
+
+// Dry-run mode: reports count but deletes nothing.
+func (s *CleanupTagPruneTestSuite) TestPrune_DryRun_NoDelete() {
+	s.service.tagPruneDryRun = true
+
+	tag := s.createTag("dry")
+	et1 := s.applyTag(tag, "artist", 200, 0, 2)
+	et2 := s.applyTag(tag, "release", 200, 1, 4)
+
+	deleted, err := s.service.pruneDownvotedEntityTags(context.Background())
+	s.Require().NoError(err)
+	s.Equal(int64(2), deleted)
+
+	// Neither row was actually deleted.
+	s.True(s.entityTagExists(et1.ID))
+	s.True(s.entityTagExists(et2.ID))
+}
+
+// Feature disabled: cycle is a no-op, no audit log written.
+func (s *CleanupTagPruneTestSuite) TestRunTagPruneCycle_Disabled_NoOp() {
+	s.service.tagPruneEnabled = false
+
+	tag := s.createTag("disabled")
+	et := s.applyTag(tag, "artist", 300, 0, 2)
+
+	s.service.runTagPruneCycle(context.Background())
+
+	// Row still present.
+	s.True(s.entityTagExists(et.ID))
+
+	// No audit log entry.
+	var count int64
+	s.db.Model(&models.AuditLog{}).
+		Where("action = ?", AuditActionPruneDownvotedTags).
+		Count(&count)
+	s.Equal(int64(0), count)
+}
+
+// Audit log: cycle writes a summary entry with count + threshold + dry_run metadata.
+func (s *CleanupTagPruneTestSuite) TestRunTagPruneCycle_WritesAuditLog() {
+	tag := s.createTag("audited")
+	s.applyTag(tag, "artist", 400, 0, 2)
+	s.applyTag(tag, "artist", 401, 0, 3)
+
+	s.service.runTagPruneCycle(context.Background())
+
+	var log models.AuditLog
+	err := s.db.
+		Where("action = ?", AuditActionPruneDownvotedTags).
+		First(&log).Error
+	s.Require().NoError(err)
+	s.Nil(log.ActorID)
+	s.Equal("entity_tags", log.EntityType)
+	s.Equal(uint(0), log.EntityID)
+	s.Require().NotNil(log.Metadata)
+
+	var meta map[string]interface{}
+	s.Require().NoError(json.Unmarshal(*log.Metadata, &meta))
+	s.Equal(float64(2), meta["deleted_count"])
+	s.Equal(float64(MinDownvotesToPrune), meta["threshold_min_downs"])
+	s.Equal(false, meta["dry_run"])
+}
+
+// Multiple entities across entity_types pruned in a single pass.
+func (s *CleanupTagPruneTestSuite) TestPrune_MultipleEntities_MixedOutcomes() {
+	tag := s.createTag("mixed")
+	pruneA := s.applyTag(tag, "artist", 500, 0, 2) // pruned
+	pruneB := s.applyTag(tag, "release", 500, 1, 3) // pruned (downs > ups, downs >= 2)
+	keepTie := s.applyTag(tag, "artist", 501, 2, 2) // tie — keep
+	keepOneDown := s.applyTag(tag, "label", 500, 0, 1) // below threshold — keep
+	keepLoved := s.applyTag(tag, "show", 600, 10, 1) // ups dominate — keep
+
+	deleted, err := s.service.pruneDownvotedEntityTags(context.Background())
+	s.Require().NoError(err)
+	s.Equal(int64(2), deleted)
+
+	s.False(s.entityTagExists(pruneA.ID))
+	s.False(s.entityTagExists(pruneB.ID))
+	s.True(s.entityTagExists(keepTie.ID))
+	s.True(s.entityTagExists(keepOneDown.ID))
+	s.True(s.entityTagExists(keepLoved.ID))
+
+	// Tag row itself is never deleted.
+	s.True(s.tagRowExists(tag.ID))
+}
+
+// Safety: only the downvoted entity_tag is removed; other applications of the
+// same tag on different entities are unaffected.
+func (s *CleanupTagPruneTestSuite) TestPrune_OnlyTargetApplicationRemoved() {
+	tag := s.createTag("selective")
+	bad := s.applyTag(tag, "artist", 700, 0, 2) // pruned
+	goodA := s.applyTag(tag, "artist", 701, 3, 0) // keep
+	goodB := s.applyTag(tag, "release", 700, 0, 0) // keep (no votes)
+
+	deleted, err := s.service.pruneDownvotedEntityTags(context.Background())
+	s.Require().NoError(err)
+	s.Equal(int64(1), deleted)
+
+	s.False(s.entityTagExists(bad.ID))
+	s.True(s.entityTagExists(goodA.ID))
+	s.True(s.entityTagExists(goodB.ID))
+	s.True(s.tagRowExists(tag.ID))
+}
+
+// Constructor env-var parsing: flags are picked up correctly.
+func TestNewCleanupService_TagPruneDefaults(t *testing.T) {
+	svc := NewCleanupService(nil, &stubUserService{})
+	if svc.tagPruneInterval != DefaultTagPruneInterval {
+		t.Errorf("expected default tag prune interval %v, got %v", DefaultTagPruneInterval, svc.tagPruneInterval)
+	}
+	if !svc.tagPruneEnabled {
+		t.Error("expected tag prune enabled by default")
+	}
+	if svc.tagPruneDryRun {
+		t.Error("expected dry-run disabled by default")
+	}
+}
+
+func TestNewCleanupService_TagPruneEnvOverrides(t *testing.T) {
+	t.Setenv("TAG_PRUNE_INTERVAL_HOURS", "6")
+	t.Setenv("TAG_PRUNE_ENABLED", "false")
+	t.Setenv("TAG_PRUNE_DRY_RUN", "true")
+
+	svc := NewCleanupService(nil, &stubUserService{})
+	if svc.tagPruneInterval != 6*time.Hour {
+		t.Errorf("expected 6h interval, got %v", svc.tagPruneInterval)
+	}
+	if svc.tagPruneEnabled {
+		t.Error("expected tag prune disabled")
+	}
+	if !svc.tagPruneDryRun {
+		t.Error("expected dry-run enabled")
+	}
+}
+
+func TestNewCleanupService_TagPruneInvalidEnvIgnored(t *testing.T) {
+	t.Setenv("TAG_PRUNE_INTERVAL_HOURS", "not-a-number")
+	t.Setenv("TAG_PRUNE_ENABLED", "not-a-bool")
+	t.Setenv("TAG_PRUNE_DRY_RUN", "nope")
+
+	svc := NewCleanupService(nil, &stubUserService{})
+	if svc.tagPruneInterval != DefaultTagPruneInterval {
+		t.Errorf("expected default interval on invalid env, got %v", svc.tagPruneInterval)
+	}
+	if !svc.tagPruneEnabled {
+		t.Error("expected tag prune enabled on invalid bool env")
+	}
+	if svc.tagPruneDryRun {
+		t.Error("expected dry-run disabled on invalid bool env")
+	}
+}


### PR DESCRIPTION
## Summary
- Extends `CleanupService` with an hourly ticker that deletes `entity_tags` rows whose per-entity vote aggregate has `downs > ups AND downs >= 2` (Gazelle pattern). Strict inequality keeps ties.
- Only the entity-tag *application* is removed — rows in the `tags` table are never touched, even if a tag becomes orphaned.
- System-initiated audit log entry per cycle (`prune_downvoted_tags` / `entity_tags`) captures count, threshold, and dry_run for observability.

## What changed
- `backend/internal/services/admin/cleanup.go`: new `pruneDownvotedEntityTags` + `runTagPruneCycle` + `writeTagPruneAuditLog`. Second `time.Ticker` added to the existing `run()` loop — no new goroutine, shares lifecycle with account cleanup.
- Env flags (all optional, safe defaults):
  - `TAG_PRUNE_ENABLED` (default `true`) — feature gate
  - `TAG_PRUNE_DRY_RUN` (default `false`) — count without deleting for first-deploy safety
  - `TAG_PRUNE_INTERVAL_HOURS` (default `1`) — cycle interval
- Constants: `DefaultTagPruneInterval = 1h`, `MinDownvotesToPrune = 2`, `AuditActionPruneDownvotedTags = "prune_downvoted_tags"`.
- Wiring in `cmd/server/main.go` is unchanged — the existing `DISABLE_CLEANUP` gate already governs this loop since it's inside `CleanupService.Start()`.

## Test plan
New integration suite `cleanup_tag_prune_test.go` (testcontainers postgres:18), 15 tests:

- [x] Happy path: 2 downs, 0 ups → pruned
- [x] Happy path: 3 downs, 1 up → pruned
- [x] Tie (downs == ups) → kept
- [x] Single downvote (below threshold) → kept
- [x] No votes → kept
- [x] `ups > downs` with downs >= 2 → kept
- [x] Idempotency: second run deletes 0
- [x] Dry-run: reports count, deletes nothing
- [x] Disabled (`tagPruneEnabled=false`): no-op, no audit log written
- [x] Audit log entry has correct count / threshold / dry_run / `ActorID: nil`
- [x] Multiple entities across entity_types: mixed outcomes in a single pass
- [x] Selective removal: other applications of the same tag stay intact
- [x] Constructor env parsing: defaults, overrides, invalid values
- [x] `go test ./...` clean across all backend packages

Closes PSY-308

🤖 Generated with [Claude Code](https://claude.com/claude-code)