### PR TITLE
PSY-307: admin global alias listing + CSV bulk import

### DIFF
--- a/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
+++ b/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
@@ -3022,6 +3022,8 @@ type mockTagService struct {
 	deleteAliasFn func(uint) (error)
 	listAliasesFn func(uint) ([]models.TagAlias, error)
 	resolveAliasFn func(string) (*models.Tag, error)
+	listAllAliasesFn func(string, int, int) ([]contracts.TagAliasListing, int64, error)
+	bulkImportAliasesFn func([]contracts.BulkAliasImportItem) (*contracts.BulkAliasImportResult, error)
 	getTagEntitiesFn func(uint, string, int, int) ([]contracts.TaggedEntityItem, int64, error)
 	getTagDetailFn func(uint) (*contracts.TagDetailResponse, error)
 	searchTagsFn func(string, int, string) ([]contracts.TagSearchResult, error)
@@ -3116,6 +3118,18 @@ func (m *mockTagService) ListAliases(tagID uint) ([]models.TagAlias, error) {
 func (m *mockTagService) ResolveAlias(alias string) (*models.Tag, error) {
 	if m.resolveAliasFn != nil {
 		return m.resolveAliasFn(alias)
+	}
+	return nil, nil
+}
+func (m *mockTagService) ListAllAliases(search string, limit int, offset int) ([]contracts.TagAliasListing, int64, error) {
+	if m.listAllAliasesFn != nil {
+		return m.listAllAliasesFn(search, limit, offset)
+	}
+	return nil, 0, nil
+}
+func (m *mockTagService) BulkImportAliases(items []contracts.BulkAliasImportItem) (*contracts.BulkAliasImportResult, error) {
+	if m.bulkImportAliasesFn != nil {
+		return m.bulkImportAliasesFn(items)
 	}
 	return nil, nil
 }

--- a/backend/internal/api/handlers/tag.go
+++ b/backend/internal/api/handlers/tag.go
@@ -701,6 +701,99 @@ func (h *TagHandler) DeleteAliasHandler(ctx context.Context, req *DeleteAliasReq
 }
 
 // ============================================================================
+// List All Aliases (admin)
+// ============================================================================
+
+type ListAllAliasesRequest struct {
+	Search string `query:"search" required:"false" doc:"Search by alias text or canonical tag name"`
+	Limit  int    `query:"limit" required:"false" doc:"Max results (default 50, max 500)" example:"50"`
+	Offset int    `query:"offset" required:"false" doc:"Offset for pagination" example:"0"`
+}
+
+type ListAllAliasesResponse struct {
+	Body struct {
+		Aliases []contracts.TagAliasListing `json:"aliases"`
+		Total   int64                       `json:"total"`
+	}
+}
+
+func (h *TagHandler) ListAllAliasesHandler(ctx context.Context, req *ListAllAliasesRequest) (*ListAllAliasesResponse, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+	if !user.IsAdmin {
+		return nil, huma.Error403Forbidden("Admin access required")
+	}
+
+	items, total, err := h.tagService.ListAllAliases(req.Search, req.Limit, req.Offset)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Failed to list aliases")
+	}
+
+	resp := &ListAllAliasesResponse{}
+	resp.Body.Aliases = items
+	resp.Body.Total = total
+	return resp, nil
+}
+
+// ============================================================================
+// Bulk Import Aliases (admin)
+// ============================================================================
+
+// Cap the bulk import payload to keep admin mistakes (e.g. pasting a huge
+// CSV) from becoming a DoS. 2000 rows comfortably covers realistic seeding
+// batches while bounding work per request.
+const maxBulkAliasImportRows = 2000
+
+type BulkImportAliasesRequest struct {
+	Body struct {
+		Items []contracts.BulkAliasImportItem `json:"items" doc:"List of alias,canonical pairs to import"`
+	}
+}
+
+type BulkImportAliasesResponse struct {
+	Body *contracts.BulkAliasImportResult
+}
+
+func (h *TagHandler) BulkImportAliasesHandler(ctx context.Context, req *BulkImportAliasesRequest) (*BulkImportAliasesResponse, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+	if !user.IsAdmin {
+		return nil, huma.Error403Forbidden("Admin access required")
+	}
+
+	if len(req.Body.Items) == 0 {
+		return nil, huma.Error400BadRequest("items is required and must not be empty")
+	}
+	if len(req.Body.Items) > maxBulkAliasImportRows {
+		return nil, huma.Error400BadRequest(
+			fmt.Sprintf("items exceeds max of %d rows", maxBulkAliasImportRows),
+		)
+	}
+
+	result, err := h.tagService.BulkImportAliases(req.Body.Items)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Failed to bulk import aliases")
+	}
+
+	if h.auditLog != nil {
+		imported := result.Imported
+		skipped := len(result.Skipped)
+		go func() {
+			h.auditLog.LogAction(user.ID, "bulk_import_tag_aliases", "tag", 0, map[string]interface{}{
+				"imported": imported,
+				"skipped":  skipped,
+			})
+		}()
+	}
+
+	return &BulkImportAliasesResponse{Body: result}, nil
+}
+
+// ============================================================================
 // Helpers
 // ============================================================================
 

--- a/backend/internal/api/handlers/tag_integration_test.go
+++ b/backend/internal/api/handlers/tag_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
 )
 
 type TagHandlerIntegrationSuite struct {
@@ -1391,4 +1392,116 @@ func (s *TagHandlerIntegrationSuite) TestAddTagToEntity_VenueType() {
 	s.NoError(err)
 	s.Len(listResp.Body.Tags, 1)
 	s.Equal("intimate", listResp.Body.Tags[0].Name)
+}
+
+// ============================================================================
+// ListAllAliasesHandler + BulkImportAliasesHandler (PSY-307)
+// ============================================================================
+
+func (s *TagHandlerIntegrationSuite) TestListAllAliases_AdminOnly() {
+	user := createTestUser(s.deps.db)
+	ctx := ctxWithUser(user)
+
+	_, err := s.handler.ListAllAliasesHandler(ctx, &ListAllAliasesRequest{})
+	s.Error(err)
+	s.Contains(err.Error(), "Admin")
+}
+
+func (s *TagHandlerIntegrationSuite) TestListAllAliases_Unauthenticated() {
+	_, err := s.handler.ListAllAliasesHandler(s.deps.ctx, &ListAllAliasesRequest{})
+	s.Error(err)
+}
+
+func (s *TagHandlerIntegrationSuite) TestListAllAliases_ReturnsAllWithCanonicalInfo() {
+	admin := createAdminUser(s.deps.db)
+	ctx := ctxWithUser(admin)
+	tag := s.createTagViaHandler(admin, "post-punk", models.TagCategoryGenre)
+
+	aliasReq := &CreateAliasRequest{TagID: fmt.Sprintf("%d", tag.Body.ID)}
+	aliasReq.Body.Alias = "postpunk"
+	_, err := s.handler.CreateAliasHandler(ctx, aliasReq)
+	s.Require().NoError(err)
+
+	resp, err := s.handler.ListAllAliasesHandler(ctx, &ListAllAliasesRequest{})
+	s.NoError(err)
+	s.Equal(int64(1), resp.Body.Total)
+	s.Require().Len(resp.Body.Aliases, 1)
+	s.Equal("postpunk", resp.Body.Aliases[0].Alias)
+	s.Equal("post-punk", resp.Body.Aliases[0].TagName)
+	s.Equal(tag.Body.ID, resp.Body.Aliases[0].TagID)
+}
+
+func (s *TagHandlerIntegrationSuite) TestListAllAliases_SearchFilter() {
+	admin := createAdminUser(s.deps.db)
+	ctx := ctxWithUser(admin)
+	tagA := s.createTagViaHandler(admin, "post-punk", models.TagCategoryGenre)
+	tagB := s.createTagViaHandler(admin, "hip-hop", models.TagCategoryGenre)
+
+	aliasReqA := &CreateAliasRequest{TagID: fmt.Sprintf("%d", tagA.Body.ID)}
+	aliasReqA.Body.Alias = "postpunk"
+	_, err := s.handler.CreateAliasHandler(ctx, aliasReqA)
+	s.Require().NoError(err)
+
+	aliasReqB := &CreateAliasRequest{TagID: fmt.Sprintf("%d", tagB.Body.ID)}
+	aliasReqB.Body.Alias = "hiphop"
+	_, err = s.handler.CreateAliasHandler(ctx, aliasReqB)
+	s.Require().NoError(err)
+
+	resp, err := s.handler.ListAllAliasesHandler(ctx, &ListAllAliasesRequest{Search: "hip"})
+	s.NoError(err)
+	s.Equal(int64(1), resp.Body.Total)
+	s.Require().Len(resp.Body.Aliases, 1)
+	s.Equal("hiphop", resp.Body.Aliases[0].Alias)
+}
+
+func (s *TagHandlerIntegrationSuite) TestBulkImportAliases_AdminOnly() {
+	user := createTestUser(s.deps.db)
+	ctx := ctxWithUser(user)
+
+	req := &BulkImportAliasesRequest{}
+	req.Body.Items = []contracts.BulkAliasImportItem{{Alias: "x", Canonical: "y"}}
+	_, err := s.handler.BulkImportAliasesHandler(ctx, req)
+	s.Error(err)
+	s.Contains(err.Error(), "Admin")
+}
+
+func (s *TagHandlerIntegrationSuite) TestBulkImportAliases_EmptyRejected() {
+	admin := createAdminUser(s.deps.db)
+	ctx := ctxWithUser(admin)
+
+	req := &BulkImportAliasesRequest{}
+	_, err := s.handler.BulkImportAliasesHandler(ctx, req)
+	s.Error(err)
+}
+
+func (s *TagHandlerIntegrationSuite) TestBulkImportAliases_TooLargeRejected() {
+	admin := createAdminUser(s.deps.db)
+	ctx := ctxWithUser(admin)
+
+	req := &BulkImportAliasesRequest{}
+	req.Body.Items = make([]contracts.BulkAliasImportItem, maxBulkAliasImportRows+1)
+	for i := range req.Body.Items {
+		req.Body.Items[i] = contracts.BulkAliasImportItem{Alias: fmt.Sprintf("a%d", i), Canonical: "x"}
+	}
+	_, err := s.handler.BulkImportAliasesHandler(ctx, req)
+	s.Error(err)
+	s.Contains(err.Error(), "max")
+}
+
+func (s *TagHandlerIntegrationSuite) TestBulkImportAliases_MixedResultSummary() {
+	admin := createAdminUser(s.deps.db)
+	ctx := ctxWithUser(admin)
+	s.createTagViaHandler(admin, "drum-and-bass", models.TagCategoryGenre)
+
+	req := &BulkImportAliasesRequest{}
+	req.Body.Items = []contracts.BulkAliasImportItem{
+		{Alias: "dnb", Canonical: "drum-and-bass"},
+		{Alias: "foo", Canonical: "nonexistent"},
+	}
+	resp, err := s.handler.BulkImportAliasesHandler(ctx, req)
+	s.NoError(err)
+	s.Equal(1, resp.Body.Imported)
+	s.Require().Len(resp.Body.Skipped, 1)
+	s.Equal(2, resp.Body.Skipped[0].Row)
+	s.Equal("foo", resp.Body.Skipped[0].Alias)
 }

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -818,6 +818,9 @@ func setupTagRoutes(rc RouteContext) {
 	huma.Delete(rc.Protected, "/tags/{tag_id}", tagHandler.DeleteTagHandler)
 	huma.Post(rc.Protected, "/tags/{tag_id}/aliases", tagHandler.CreateAliasHandler)
 	huma.Delete(rc.Protected, "/tags/{tag_id}/aliases/{alias_id}", tagHandler.DeleteAliasHandler)
+	// Admin: global alias listing + bulk CSV/JSON import (PSY-307).
+	huma.Get(rc.Protected, "/admin/tags/aliases", tagHandler.ListAllAliasesHandler)
+	huma.Post(rc.Protected, "/admin/tags/aliases/bulk", tagHandler.BulkImportAliasesHandler)
 }
 
 // setupArtistRelationshipRoutes configures artist relationship and similar artist endpoints.

--- a/backend/internal/services/catalog/tag_service.go
+++ b/backend/internal/services/catalog/tag_service.go
@@ -629,6 +629,161 @@ func (s *TagService) ListAliases(tagID uint) ([]models.TagAlias, error) {
 	return aliases, nil
 }
 
+// ListAllAliases returns aliases across all tags paired with their canonical
+// tag info. Supports a case-insensitive substring search against either the
+// alias text or the canonical tag name. Default limit 50, max 500.
+func (s *TagService) ListAllAliases(search string, limit, offset int) ([]contracts.TagAliasListing, int64, error) {
+	if s.db == nil {
+		return nil, 0, fmt.Errorf("database not initialized")
+	}
+
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 500 {
+		limit = 500
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	query := s.db.
+		Table("tag_aliases AS ta").
+		Joins("JOIN tags AS t ON t.id = ta.tag_id")
+
+	if search != "" {
+		pattern := "%" + strings.ToLower(search) + "%"
+		query = query.Where("LOWER(ta.alias) LIKE ? OR LOWER(t.name) LIKE ?", pattern, pattern)
+	}
+
+	var total int64
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, fmt.Errorf("failed to count aliases: %w", err)
+	}
+
+	var items []contracts.TagAliasListing
+	err := query.
+		Select(`ta.id AS id,
+			ta.alias AS alias,
+			ta.tag_id AS tag_id,
+			t.name AS tag_name,
+			t.slug AS tag_slug,
+			t.category AS tag_category,
+			t.is_official AS tag_is_official,
+			ta.created_at AS created_at`).
+		Order("ta.alias ASC").
+		Limit(limit).
+		Offset(offset).
+		Scan(&items).Error
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to list aliases: %w", err)
+	}
+
+	if items == nil {
+		items = []contracts.TagAliasListing{}
+	}
+	return items, total, nil
+}
+
+// BulkImportAliases imports a list of `{alias, canonical}` pairs in one call.
+// `canonical` is resolved by slug or exact name (case-insensitive). Rows with
+// unknown canonicals, empty fields, or aliases that collide with existing
+// aliases/tag-names are skipped and reported so the admin can see what went
+// wrong. Within the same batch, earlier rows take precedence over later rows
+// that would collide with them.
+func (s *TagService) BulkImportAliases(items []contracts.BulkAliasImportItem) (*contracts.BulkAliasImportResult, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	result := &contracts.BulkAliasImportResult{Skipped: []contracts.BulkAliasImportSkipped{}}
+	seenInBatch := map[string]struct{}{}
+
+	for i, item := range items {
+		row := i + 1
+		alias := strings.TrimSpace(item.Alias)
+		canonical := strings.TrimSpace(item.Canonical)
+
+		if alias == "" || canonical == "" {
+			result.Skipped = append(result.Skipped, contracts.BulkAliasImportSkipped{
+				Row:       row,
+				Alias:     alias,
+				Canonical: canonical,
+				Reason:    "alias and canonical are required",
+			})
+			continue
+		}
+
+		aliasLower := strings.ToLower(alias)
+		if _, dup := seenInBatch[aliasLower]; dup {
+			result.Skipped = append(result.Skipped, contracts.BulkAliasImportSkipped{
+				Row:       row,
+				Alias:     alias,
+				Canonical: canonical,
+				Reason:    "duplicate alias in batch",
+			})
+			continue
+		}
+
+		var tag models.Tag
+		err := s.db.Where("LOWER(slug) = LOWER(?) OR LOWER(name) = LOWER(?)", canonical, canonical).
+			First(&tag).Error
+		if err != nil {
+			if err == gorm.ErrRecordNotFound {
+				result.Skipped = append(result.Skipped, contracts.BulkAliasImportSkipped{
+					Row:       row,
+					Alias:     alias,
+					Canonical: canonical,
+					Reason:    fmt.Sprintf("canonical tag '%s' not found", canonical),
+				})
+				continue
+			}
+			return nil, fmt.Errorf("failed to resolve canonical tag: %w", err)
+		}
+
+		var existingAlias models.TagAlias
+		if err := s.db.Where("LOWER(alias) = LOWER(?)", alias).First(&existingAlias).Error; err == nil {
+			reason := fmt.Sprintf("alias already maps to tag ID %d", existingAlias.TagID)
+			if existingAlias.TagID == tag.ID {
+				reason = "alias already exists for this tag"
+			}
+			result.Skipped = append(result.Skipped, contracts.BulkAliasImportSkipped{
+				Row:       row,
+				Alias:     alias,
+				Canonical: canonical,
+				Reason:    reason,
+			})
+			continue
+		}
+
+		var nameConflict models.Tag
+		if err := s.db.Where("LOWER(name) = LOWER(?)", alias).First(&nameConflict).Error; err == nil {
+			result.Skipped = append(result.Skipped, contracts.BulkAliasImportSkipped{
+				Row:       row,
+				Alias:     alias,
+				Canonical: canonical,
+				Reason:    "alias collides with existing tag name",
+			})
+			continue
+		}
+
+		if err := s.db.Create(&models.TagAlias{TagID: tag.ID, Alias: alias}).Error; err != nil {
+			result.Skipped = append(result.Skipped, contracts.BulkAliasImportSkipped{
+				Row:       row,
+				Alias:     alias,
+				Canonical: canonical,
+				Reason:    fmt.Sprintf("create failed: %v", err),
+			})
+			continue
+		}
+
+		seenInBatch[aliasLower] = struct{}{}
+		result.Imported++
+	}
+
+	return result, nil
+}
+
 // ResolveAlias resolves an alias to its canonical tag.
 func (s *TagService) ResolveAlias(alias string) (*models.Tag, error) {
 	if s.db == nil {

--- a/backend/internal/services/catalog/tag_service_test.go
+++ b/backend/internal/services/catalog/tag_service_test.go
@@ -11,6 +11,7 @@ import (
 
 	apperrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
 	"psychic-homily-backend/internal/testutil"
 )
 
@@ -1279,6 +1280,183 @@ func TestNormalizeTagName(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+// ──────────────────────────────────────────────
+// Global Alias Listing / Bulk Import (PSY-307)
+// ──────────────────────────────────────────────
+
+func (suite *TagServiceIntegrationTestSuite) TestListAllAliases_EmptyReturnsEmptySlice() {
+	items, total, err := suite.tagService.ListAllAliases("", 50, 0)
+	suite.Require().NoError(err)
+	suite.Assert().Equal(int64(0), total)
+	suite.Assert().NotNil(items)
+	suite.Assert().Len(items, 0)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestListAllAliases_ReturnsCanonicalInfo() {
+	tag := suite.createTag("post-punk", "genre")
+	_, err := suite.tagService.CreateAlias(tag.ID, "postpunk")
+	suite.Require().NoError(err)
+
+	items, total, err := suite.tagService.ListAllAliases("", 50, 0)
+	suite.Require().NoError(err)
+	suite.Assert().Equal(int64(1), total)
+	suite.Require().Len(items, 1)
+	suite.Assert().Equal("postpunk", items[0].Alias)
+	suite.Assert().Equal(tag.ID, items[0].TagID)
+	suite.Assert().Equal("post-punk", items[0].TagName)
+	suite.Assert().Equal(tag.Slug, items[0].TagSlug)
+	suite.Assert().Equal("genre", items[0].TagCategory)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestListAllAliases_SearchByAlias() {
+	tagA := suite.createTag("post-punk", "genre")
+	tagB := suite.createTag("hip-hop", "genre")
+	suite.tagService.CreateAlias(tagA.ID, "postpunk")
+	suite.tagService.CreateAlias(tagB.ID, "hiphop")
+
+	items, total, err := suite.tagService.ListAllAliases("post", 50, 0)
+	suite.Require().NoError(err)
+	suite.Assert().Equal(int64(1), total)
+	suite.Require().Len(items, 1)
+	suite.Assert().Equal("postpunk", items[0].Alias)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestListAllAliases_SearchByCanonicalName() {
+	tagA := suite.createTag("post-punk", "genre")
+	tagB := suite.createTag("hip-hop", "genre")
+	suite.tagService.CreateAlias(tagA.ID, "xyz")
+	suite.tagService.CreateAlias(tagB.ID, "abc")
+
+	items, total, err := suite.tagService.ListAllAliases("hip", 50, 0)
+	suite.Require().NoError(err)
+	suite.Assert().Equal(int64(1), total)
+	suite.Require().Len(items, 1)
+	suite.Assert().Equal("abc", items[0].Alias)
+	suite.Assert().Equal("hip-hop", items[0].TagName)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestListAllAliases_Pagination() {
+	tag := suite.createTag("punk", "genre")
+	for _, a := range []string{"a-alias", "b-alias", "c-alias", "d-alias", "e-alias"} {
+		_, err := suite.tagService.CreateAlias(tag.ID, a)
+		suite.Require().NoError(err)
+	}
+
+	items, total, err := suite.tagService.ListAllAliases("", 2, 0)
+	suite.Require().NoError(err)
+	suite.Assert().Equal(int64(5), total)
+	suite.Require().Len(items, 2)
+	suite.Assert().Equal("a-alias", items[0].Alias)
+	suite.Assert().Equal("b-alias", items[1].Alias)
+
+	items2, _, err := suite.tagService.ListAllAliases("", 2, 2)
+	suite.Require().NoError(err)
+	suite.Require().Len(items2, 2)
+	suite.Assert().Equal("c-alias", items2[0].Alias)
+	suite.Assert().Equal("d-alias", items2[1].Alias)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestBulkImportAliases_AllValid() {
+	tagA := suite.createTag("drum-and-bass", "genre")
+	tagB := suite.createTag("hip-hop", "genre")
+
+	items := []contracts.BulkAliasImportItem{
+		{Alias: "dnb", Canonical: "drum-and-bass"},
+		{Alias: "d&b", Canonical: "drum-and-bass"},
+		{Alias: "hiphop", Canonical: "hip-hop"},
+	}
+	result, err := suite.tagService.BulkImportAliases(items)
+	suite.Require().NoError(err)
+	suite.Assert().Equal(3, result.Imported)
+	suite.Assert().Len(result.Skipped, 0)
+
+	aliasesA, _ := suite.tagService.ListAliases(tagA.ID)
+	suite.Assert().Len(aliasesA, 2)
+	aliasesB, _ := suite.tagService.ListAliases(tagB.ID)
+	suite.Assert().Len(aliasesB, 1)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestBulkImportAliases_MixedValidAndInvalid() {
+	suite.createTag("drum-and-bass", "genre")
+
+	items := []contracts.BulkAliasImportItem{
+		{Alias: "dnb", Canonical: "drum-and-bass"},
+		{Alias: "cheddar", Canonical: "nonexistent-genre"},
+		{Alias: "d&b", Canonical: "drum-and-bass"},
+		{Alias: "", Canonical: "drum-and-bass"},
+	}
+	result, err := suite.tagService.BulkImportAliases(items)
+	suite.Require().NoError(err)
+	suite.Assert().Equal(2, result.Imported)
+	suite.Require().Len(result.Skipped, 2)
+	suite.Assert().Equal(2, result.Skipped[0].Row)
+	suite.Assert().Contains(result.Skipped[0].Reason, "nonexistent-genre")
+	suite.Assert().Equal(4, result.Skipped[1].Row)
+	suite.Assert().Contains(result.Skipped[1].Reason, "required")
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestBulkImportAliases_DuplicateInBatch() {
+	suite.createTag("drum-and-bass", "genre")
+
+	items := []contracts.BulkAliasImportItem{
+		{Alias: "dnb", Canonical: "drum-and-bass"},
+		{Alias: "DNB", Canonical: "drum-and-bass"},
+	}
+	result, err := suite.tagService.BulkImportAliases(items)
+	suite.Require().NoError(err)
+	suite.Assert().Equal(1, result.Imported)
+	suite.Require().Len(result.Skipped, 1)
+	suite.Assert().Equal(2, result.Skipped[0].Row)
+	suite.Assert().Contains(result.Skipped[0].Reason, "duplicate alias in batch")
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestBulkImportAliases_AliasAlreadyExists() {
+	tagA := suite.createTag("drum-and-bass", "genre")
+	suite.tagService.CreateAlias(tagA.ID, "dnb")
+
+	items := []contracts.BulkAliasImportItem{
+		{Alias: "dnb", Canonical: "drum-and-bass"},
+	}
+	result, err := suite.tagService.BulkImportAliases(items)
+	suite.Require().NoError(err)
+	suite.Assert().Equal(0, result.Imported)
+	suite.Require().Len(result.Skipped, 1)
+	suite.Assert().Contains(result.Skipped[0].Reason, "alias already exists")
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestBulkImportAliases_CollidesWithTagName() {
+	suite.createTag("punk", "genre")
+	suite.createTag("rock", "genre")
+
+	items := []contracts.BulkAliasImportItem{
+		{Alias: "rock", Canonical: "punk"},
+	}
+	result, err := suite.tagService.BulkImportAliases(items)
+	suite.Require().NoError(err)
+	suite.Assert().Equal(0, result.Imported)
+	suite.Require().Len(result.Skipped, 1)
+	suite.Assert().Contains(result.Skipped[0].Reason, "collides with existing tag name")
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestBulkImportAliases_CanonicalBySlug() {
+	tag := suite.createTag("Drum And Bass", "genre")
+	suite.Assert().Equal("drum-and-bass", tag.Slug)
+
+	items := []contracts.BulkAliasImportItem{
+		{Alias: "dnb", Canonical: "drum-and-bass"},
+	}
+	result, err := suite.tagService.BulkImportAliases(items)
+	suite.Require().NoError(err)
+	suite.Assert().Equal(1, result.Imported)
+}
+
+func (suite *TagServiceIntegrationTestSuite) TestBulkImportAliases_EmptyList() {
+	result, err := suite.tagService.BulkImportAliases([]contracts.BulkAliasImportItem{})
+	suite.Require().NoError(err)
+	suite.Assert().Equal(0, result.Imported)
+	suite.Assert().Len(result.Skipped, 0)
 }
 
 // ──────────────────────────────────────────────

--- a/backend/internal/services/contracts/tag.go
+++ b/backend/internal/services/contracts/tag.go
@@ -132,6 +132,42 @@ type TagAliasResponse struct {
 	CreatedAt time.Time `json:"created_at"`
 }
 
+// TagAliasListing represents a global alias listing row, pairing an alias
+// with its canonical tag for the admin-wide alias management UI.
+type TagAliasListing struct {
+	ID             uint      `json:"id"`
+	Alias          string    `json:"alias"`
+	TagID          uint      `json:"tag_id"`
+	TagName        string    `json:"tag_name"`
+	TagSlug        string    `json:"tag_slug"`
+	TagCategory    string    `json:"tag_category"`
+	TagIsOfficial  bool      `json:"tag_is_official"`
+	CreatedAt      time.Time `json:"created_at"`
+}
+
+// BulkAliasImportItem is one row of a bulk alias import request.
+// Admins submit `{alias, canonical}` pairs; canonical can be a tag
+// slug or exact name (case-insensitive match).
+type BulkAliasImportItem struct {
+	Alias     string `json:"alias"`
+	Canonical string `json:"canonical"`
+}
+
+// BulkAliasImportSkipped describes a single row that was rejected
+// during a bulk import so the admin UI can surface per-row errors.
+type BulkAliasImportSkipped struct {
+	Row       int    `json:"row"`
+	Alias     string `json:"alias"`
+	Canonical string `json:"canonical"`
+	Reason    string `json:"reason"`
+}
+
+// BulkAliasImportResult summarizes the outcome of a bulk alias import.
+type BulkAliasImportResult struct {
+	Imported int                      `json:"imported"`
+	Skipped  []BulkAliasImportSkipped `json:"skipped"`
+}
+
 // TagServiceInterface defines the contract for tag operations.
 type TagServiceInterface interface {
 	// CRUD
@@ -156,6 +192,8 @@ type TagServiceInterface interface {
 	DeleteAlias(aliasID uint) error
 	ListAliases(tagID uint) ([]models.TagAlias, error)
 	ResolveAlias(alias string) (*models.Tag, error)
+	ListAllAliases(search string, limit, offset int) ([]TagAliasListing, int64, error)
+	BulkImportAliases(items []BulkAliasImportItem) (*BulkAliasImportResult, error)
 
 	// Tag entities
 	GetTagEntities(tagID uint, entityType string, limit, offset int) ([]TaggedEntityItem, int64, error)

--- a/frontend/features/tags/admin/AliasListing.test.tsx
+++ b/frontend/features/tags/admin/AliasListing.test.tsx
@@ -1,0 +1,227 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders } from '@/test/utils'
+import type {
+  TagAliasListing,
+  BulkAliasImportResult,
+} from '../types'
+
+const mockUseAllTagAliases = vi.fn()
+const mockBulkMutate = vi.fn()
+const mockUseBulkImport = vi.fn()
+
+vi.mock('./useAdminTags', () => ({
+  useAllTagAliases: (...args: unknown[]) => mockUseAllTagAliases(...args),
+  useBulkImportAliases: () => mockUseBulkImport(),
+}))
+
+import { AliasListing, parseCSV } from './AliasListing'
+
+function makeAlias(overrides: Partial<TagAliasListing> = {}): TagAliasListing {
+  return {
+    id: 1,
+    alias: 'dnb',
+    tag_id: 10,
+    tag_name: 'drum-and-bass',
+    tag_slug: 'drum-and-bass',
+    tag_category: 'genre',
+    tag_is_official: false,
+    created_at: '2025-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('parseCSV', () => {
+  it('parses comma-separated rows', () => {
+    const rows = parseCSV('dnb,drum-and-bass\nhiphop,hip-hop')
+    expect(rows).toEqual([
+      { alias: 'dnb', canonical: 'drum-and-bass' },
+      { alias: 'hiphop', canonical: 'hip-hop' },
+    ])
+  })
+
+  it('parses tab-separated rows', () => {
+    const rows = parseCSV('dnb\tdrum-and-bass\nhiphop\thip-hop')
+    expect(rows).toEqual([
+      { alias: 'dnb', canonical: 'drum-and-bass' },
+      { alias: 'hiphop', canonical: 'hip-hop' },
+    ])
+  })
+
+  it('skips a header row with "alias,canonical" columns', () => {
+    const rows = parseCSV('alias,canonical\ndnb,drum-and-bass')
+    expect(rows).toEqual([{ alias: 'dnb', canonical: 'drum-and-bass' }])
+  })
+
+  it('skips comment and blank lines', () => {
+    const rows = parseCSV('# seed file\n\ndnb,drum-and-bass\n\n# end')
+    expect(rows).toEqual([{ alias: 'dnb', canonical: 'drum-and-bass' }])
+  })
+
+  it('trims whitespace around fields', () => {
+    const rows = parseCSV('  dnb  ,  drum-and-bass  ')
+    expect(rows).toEqual([{ alias: 'dnb', canonical: 'drum-and-bass' }])
+  })
+
+  it('drops rows with fewer than 2 fields', () => {
+    const rows = parseCSV('only-one-field\nhip,hop')
+    expect(rows).toEqual([{ alias: 'hip', canonical: 'hop' }])
+  })
+})
+
+describe('AliasListing — rendering', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockBulkMutate.mockReset()
+    mockUseBulkImport.mockReturnValue({
+      mutate: mockBulkMutate,
+      isPending: false,
+    })
+  })
+
+  it('shows loading spinner while loading', () => {
+    mockUseAllTagAliases.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    })
+    const { container } = renderWithProviders(<AliasListing />)
+    expect(container.querySelector('.animate-spin')).toBeTruthy()
+  })
+
+  it('shows empty state when no aliases', () => {
+    mockUseAllTagAliases.mockReturnValue({
+      data: { aliases: [], total: 0 },
+      isLoading: false,
+      error: null,
+    })
+    renderWithProviders(<AliasListing />)
+    expect(screen.getByText(/no aliases found/i)).toBeInTheDocument()
+  })
+
+  it('renders each alias with the arrow and canonical link', () => {
+    mockUseAllTagAliases.mockReturnValue({
+      data: {
+        aliases: [
+          makeAlias({ id: 1, alias: 'dnb', tag_name: 'drum-and-bass', tag_slug: 'drum-and-bass' }),
+          makeAlias({ id: 2, alias: 'hiphop', tag_name: 'hip-hop', tag_slug: 'hip-hop', tag_id: 11 }),
+        ],
+        total: 2,
+      },
+      isLoading: false,
+      error: null,
+    })
+    renderWithProviders(<AliasListing />)
+
+    expect(screen.getByText('dnb')).toBeInTheDocument()
+    expect(screen.getByText('hiphop')).toBeInTheDocument()
+    const canonical = screen.getByRole('link', { name: 'drum-and-bass' })
+    expect(canonical).toHaveAttribute('href', '/tags/drum-and-bass')
+  })
+
+  it('shows official indicator on official canonical tags', () => {
+    mockUseAllTagAliases.mockReturnValue({
+      data: {
+        aliases: [
+          makeAlias({ id: 1, alias: 'dnb', tag_name: 'drum-and-bass', tag_is_official: true }),
+        ],
+        total: 1,
+      },
+      isLoading: false,
+      error: null,
+    })
+    renderWithProviders(<AliasListing />)
+    expect(screen.getByRole('img', { name: 'Official tag' })).toBeInTheDocument()
+  })
+
+  it('debounces search and refetches with the query', async () => {
+    mockUseAllTagAliases.mockReturnValue({
+      data: { aliases: [], total: 0 },
+      isLoading: false,
+      error: null,
+    })
+    renderWithProviders(<AliasListing />)
+
+    const search = screen.getByPlaceholderText(/search aliases/i)
+    fireEvent.change(search, { target: { value: 'dnb' } })
+
+    await waitFor(() => {
+      const calls = mockUseAllTagAliases.mock.calls
+      const lastCall = calls[calls.length - 1]?.[0]
+      expect(lastCall?.search).toBe('dnb')
+    })
+  })
+})
+
+describe('AliasListing — bulk import dialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseAllTagAliases.mockReturnValue({
+      data: { aliases: [], total: 0 },
+      isLoading: false,
+      error: null,
+    })
+    mockBulkMutate.mockReset()
+    mockUseBulkImport.mockReturnValue({
+      mutate: mockBulkMutate,
+      isPending: false,
+    })
+  })
+
+  it('parses pasted CSV and shows the row count', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<AliasListing />)
+
+    await user.click(screen.getByRole('button', { name: /bulk import/i }))
+
+    const textarea = await screen.findByLabelText(/or paste rows/i)
+    await user.type(textarea, 'dnb,drum-and-bass')
+
+    expect(await screen.findByText(/parsed 1 row/i)).toBeInTheDocument()
+  })
+
+  it('disables submit when no rows parsed', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<AliasListing />)
+
+    await user.click(screen.getByRole('button', { name: /bulk import/i }))
+
+    const submit = await screen.findByRole('button', { name: /import 0 rows/i })
+    expect(submit).toBeDisabled()
+  })
+
+  it('submits parsed rows and shows success + skipped summary', async () => {
+    const user = userEvent.setup()
+    const result: BulkAliasImportResult = {
+      imported: 1,
+      skipped: [
+        {
+          row: 2,
+          alias: 'bad',
+          canonical: 'nonexistent',
+          reason: "canonical tag 'nonexistent' not found",
+        },
+      ],
+    }
+    mockBulkMutate.mockImplementation((_items, opts) => opts.onSuccess(result))
+
+    renderWithProviders(<AliasListing />)
+    await user.click(screen.getByRole('button', { name: /bulk import/i }))
+
+    const textarea = await screen.findByLabelText(/or paste rows/i)
+    await user.type(textarea, 'dnb,drum-and-bass\nbad,nonexistent')
+
+    const submit = await screen.findByRole('button', { name: /import 2 rows/i })
+    await user.click(submit)
+
+    expect(mockBulkMutate).toHaveBeenCalled()
+    expect(
+      await screen.findByText(/imported 1 alias\. skipped 1 row\./i)
+    ).toBeInTheDocument()
+    expect(screen.getByText(/rejected rows/i)).toBeInTheDocument()
+    expect(screen.getByText(/row 2/i)).toBeInTheDocument()
+    expect(screen.getByText(/canonical tag 'nonexistent' not found/i)).toBeInTheDocument()
+  })
+})

--- a/frontend/features/tags/admin/AliasListing.tsx
+++ b/frontend/features/tags/admin/AliasListing.tsx
@@ -1,0 +1,399 @@
+'use client'
+
+import { useState, useEffect, useCallback, useMemo } from 'react'
+import Link from 'next/link'
+import {
+  Loader2,
+  Search,
+  Upload,
+  Inbox,
+  ArrowRight,
+  AlertCircle,
+  CheckCircle2,
+  X,
+} from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Badge } from '@/components/ui/badge'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog'
+import { TagOfficialIndicator } from '../components/TagOfficialIndicator'
+import { getCategoryColor, getCategoryLabel } from '../types'
+import type {
+  BulkAliasImportItem,
+  BulkAliasImportResult,
+} from '../types'
+import { useAllTagAliases, useBulkImportAliases } from './useAdminTags'
+
+const PAGE_SIZE = 50
+
+// parseCSV turns a pasted/uploaded blob into `{alias, canonical}` rows.
+// Accepts either comma- or tab-separated values, tolerates a header row if
+// either column literally matches "alias"/"canonical", and skips blank lines
+// and `#` comments so admins can annotate their source files.
+export function parseCSV(raw: string): BulkAliasImportItem[] {
+  const rows: BulkAliasImportItem[] = []
+  const lines = raw.split(/\r?\n/)
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim()
+    if (!line) continue
+    if (line.startsWith('#')) continue
+
+    const parts = line.includes('\t')
+      ? line.split('\t')
+      : line.split(',')
+    if (parts.length < 2) continue
+
+    const alias = parts[0].trim()
+    const canonical = parts[1].trim()
+    if (!alias && !canonical) continue
+
+    // Skip header row if present
+    if (
+      i === 0 &&
+      alias.toLowerCase() === 'alias' &&
+      canonical.toLowerCase() === 'canonical'
+    ) {
+      continue
+    }
+
+    rows.push({ alias, canonical })
+  }
+  return rows
+}
+
+export function AliasListing() {
+  const [searchInput, setSearchInput] = useState('')
+  const [debouncedSearch, setDebouncedSearch] = useState('')
+  const [page, setPage] = useState(0)
+  const [importOpen, setImportOpen] = useState(false)
+
+  useEffect(() => {
+    const t = setTimeout(() => {
+      setDebouncedSearch(searchInput)
+      setPage(0)
+    }, 300)
+    return () => clearTimeout(t)
+  }, [searchInput])
+
+  const { data, isLoading, error } = useAllTagAliases({
+    search: debouncedSearch || undefined,
+    limit: PAGE_SIZE,
+    offset: page * PAGE_SIZE,
+  })
+
+  const aliases = data?.aliases ?? []
+  const total = data?.total ?? 0
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE))
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h3 className="text-lg font-semibold">Global alias listing</h3>
+          <p className="text-sm text-muted-foreground">
+            Every alias across every tag. Search either the alias text or the
+            canonical tag name.
+          </p>
+        </div>
+        <Button onClick={() => setImportOpen(true)}>
+          <Upload className="mr-2 h-4 w-4" />
+          Bulk import
+        </Button>
+      </div>
+
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          placeholder="Search aliases or canonical tag name..."
+          value={searchInput}
+          onChange={(e) => setSearchInput(e.target.value)}
+          className="pl-9"
+        />
+      </div>
+
+      {isLoading && (
+        <div className="flex items-center justify-center py-12">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      )}
+
+      {error && (
+        <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-center">
+          <p className="text-destructive">
+            {error instanceof Error ? error.message : 'Failed to load aliases.'}
+          </p>
+        </div>
+      )}
+
+      {!isLoading && !error && aliases.length === 0 && (
+        <div className="flex flex-col items-center justify-center py-12 text-center">
+          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-muted mb-4">
+            <Inbox className="h-8 w-8 text-muted-foreground" />
+          </div>
+          <h3 className="text-lg font-medium mb-1">No aliases found</h3>
+          <p className="text-sm text-muted-foreground max-w-sm">
+            {debouncedSearch
+              ? 'No aliases match your search.'
+              : 'No aliases yet. Add aliases from each tag, or bulk import a CSV.'}
+          </p>
+        </div>
+      )}
+
+      {!isLoading && !error && aliases.length > 0 && (
+        <>
+          <div className="text-sm text-muted-foreground">
+            {total} alias{total !== 1 ? 'es' : ''}
+            {debouncedSearch && ` matching "${debouncedSearch}"`}
+          </div>
+
+          <div className="rounded-lg border">
+            {aliases.map((a, idx) => (
+              <div
+                key={a.id}
+                className={`flex items-center gap-3 p-3 ${idx > 0 ? 'border-t' : ''}`}
+              >
+                <div className="flex-1 min-w-0 flex items-center gap-3 flex-wrap">
+                  <span className="font-mono text-sm">{a.alias}</span>
+                  <ArrowRight className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+                  <Link
+                    href={`/tags/${a.tag_slug}`}
+                    className="font-medium text-sm hover:underline"
+                  >
+                    {a.tag_name}
+                  </Link>
+                  <Badge
+                    variant="outline"
+                    className={`text-xs ${getCategoryColor(a.tag_category)}`}
+                  >
+                    {getCategoryLabel(a.tag_category)}
+                  </Badge>
+                  {a.tag_is_official && (
+                    <TagOfficialIndicator size="sm" tagName={a.tag_name} />
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {totalPages > 1 && (
+            <div className="flex items-center justify-between">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setPage((p) => Math.max(0, p - 1))}
+                disabled={page === 0}
+              >
+                Previous
+              </Button>
+              <span className="text-sm text-muted-foreground">
+                Page {page + 1} of {totalPages}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+                disabled={page >= totalPages - 1}
+              >
+                Next
+              </Button>
+            </div>
+          )}
+        </>
+      )}
+
+      <BulkImportDialog
+        open={importOpen}
+        onOpenChange={setImportOpen}
+      />
+    </div>
+  )
+}
+
+// ============================================================================
+// Bulk Import Dialog
+// ============================================================================
+
+function BulkImportDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean
+  onOpenChange: (v: boolean) => void
+}) {
+  const [text, setText] = useState('')
+  const [parseError, setParseError] = useState<string | null>(null)
+  const [result, setResult] = useState<BulkAliasImportResult | null>(null)
+  const bulkImport = useBulkImportAliases()
+
+  const parsedRows = useMemo(() => {
+    if (!text.trim()) return []
+    try {
+      return parseCSV(text)
+    } catch {
+      return []
+    }
+  }, [text])
+
+  const handleFileUpload = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0]
+      if (!file) return
+      const reader = new FileReader()
+      reader.onload = () => {
+        setText(String(reader.result ?? ''))
+        setParseError(null)
+        setResult(null)
+      }
+      reader.onerror = () => {
+        setParseError('Failed to read file')
+      }
+      reader.readAsText(file)
+    },
+    []
+  )
+
+  const handleSubmit = useCallback(() => {
+    setParseError(null)
+    setResult(null)
+    if (parsedRows.length === 0) {
+      setParseError('Add at least one alias,canonical row.')
+      return
+    }
+    bulkImport.mutate(parsedRows, {
+      onSuccess: (data) => setResult(data),
+      onError: (err) => {
+        setParseError(err instanceof Error ? err.message : 'Import failed.')
+      },
+    })
+  }, [parsedRows, bulkImport])
+
+  const handleClose = useCallback(() => {
+    setText('')
+    setParseError(null)
+    setResult(null)
+    onOpenChange(false)
+  }, [onOpenChange])
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => (v ? onOpenChange(v) : handleClose())}>
+      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Bulk import aliases</DialogTitle>
+          <DialogDescription>
+            Upload a CSV or paste <code className="font-mono">alias,canonical</code> lines.
+            Canonical can be a tag slug or exact tag name. Comments (<code>#</code>) and blank lines are ignored.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="alias-csv-file">Upload CSV file</Label>
+            <Input
+              id="alias-csv-file"
+              type="file"
+              accept=".csv,.txt,text/csv,text/plain"
+              onChange={handleFileUpload}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="alias-csv-text">Or paste rows</Label>
+            <Textarea
+              id="alias-csv-text"
+              value={text}
+              onChange={(e) => {
+                setText(e.target.value)
+                setResult(null)
+              }}
+              placeholder={`alias,canonical\ndnb,drum-and-bass\nhiphop,hip-hop`}
+              rows={8}
+              className="font-mono text-xs"
+            />
+            <p className="text-xs text-muted-foreground">
+              Parsed {parsedRows.length} row{parsedRows.length === 1 ? '' : 's'}.
+            </p>
+          </div>
+
+          {parseError && (
+            <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive flex items-start gap-2">
+              <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
+              <span>{parseError}</span>
+            </div>
+          )}
+
+          {result && (
+            <div className="space-y-3">
+              <div className="rounded-lg border border-green-500/30 bg-green-500/10 p-3 text-sm text-green-400 flex items-start gap-2">
+                <CheckCircle2 className="h-4 w-4 mt-0.5 flex-shrink-0" />
+                <span>
+                  Imported {result.imported} alias{result.imported === 1 ? '' : 'es'}.
+                  {result.skipped.length > 0 &&
+                    ` Skipped ${result.skipped.length} row${result.skipped.length === 1 ? '' : 's'}.`}
+                </span>
+              </div>
+
+              {result.skipped.length > 0 && (
+                <div className="rounded-lg border border-amber-500/30">
+                  <div className="bg-amber-500/10 px-3 py-2 text-sm font-medium text-amber-400 flex items-center gap-2 border-b border-amber-500/30">
+                    <X className="h-4 w-4" />
+                    Rejected rows
+                  </div>
+                  <div className="max-h-48 overflow-y-auto">
+                    {result.skipped.map((s) => (
+                      <div
+                        key={`${s.row}-${s.alias}`}
+                        className="flex items-start gap-3 px-3 py-2 text-xs border-b last:border-b-0"
+                      >
+                        <span className="font-mono text-muted-foreground flex-shrink-0">
+                          row {s.row}
+                        </span>
+                        <div className="flex-1 min-w-0">
+                          <div className="font-mono">
+                            {s.alias || '(empty)'} → {s.canonical || '(empty)'}
+                          </div>
+                          <div className="text-amber-400 mt-0.5">{s.reason}</div>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={handleClose} disabled={bulkImport.isPending}>
+            {result ? 'Close' : 'Cancel'}
+          </Button>
+          {!result && (
+            <Button
+              onClick={handleSubmit}
+              disabled={bulkImport.isPending || parsedRows.length === 0}
+            >
+              {bulkImport.isPending ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Importing...
+                </>
+              ) : (
+                `Import ${parsedRows.length} row${parsedRows.length === 1 ? '' : 's'}`
+              )}
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default AliasListing

--- a/frontend/features/tags/admin/TagManagement.test.tsx
+++ b/frontend/features/tags/admin/TagManagement.test.tsx
@@ -17,6 +17,8 @@ vi.mock('./useAdminTags', () => ({
   useTagAliases: () => ({ data: { aliases: [] }, isLoading: false }),
   useCreateAlias: () => ({ mutate: vi.fn(), isPending: false }),
   useDeleteAlias: () => ({ mutate: vi.fn(), isPending: false }),
+  useAllTagAliases: () => ({ data: { aliases: [], total: 0 }, isLoading: false, error: null }),
+  useBulkImportAliases: () => ({ mutate: vi.fn(), isPending: false }),
 }))
 
 import { TagManagement } from './TagManagement'

--- a/frontend/features/tags/admin/TagManagement.tsx
+++ b/frontend/features/tags/admin/TagManagement.tsx
@@ -16,6 +16,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { Badge } from '@/components/ui/badge'
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
 import {
   Dialog,
   DialogContent,
@@ -25,6 +26,7 @@ import {
   DialogFooter,
 } from '@/components/ui/dialog'
 import { useTags, useTag } from '../hooks'
+import { AliasListing } from './AliasListing'
 import { TagOfficialIndicator } from '../components/TagOfficialIndicator'
 import {
   useCreateTag,
@@ -575,7 +577,6 @@ export function TagManagement() {
 
   return (
     <div className="space-y-4">
-      {/* Header */}
       <div className="flex items-center justify-between">
         <div>
           <h2 className="text-xl font-semibold flex items-center gap-2">
@@ -586,11 +587,21 @@ export function TagManagement() {
             Create, edit, and manage tags and aliases.
           </p>
         </div>
-        <Button onClick={openCreate}>
-          <Plus className="mr-2 h-4 w-4" />
-          New Tag
-        </Button>
       </div>
+
+      <Tabs defaultValue="tags" className="space-y-4">
+        <TabsList>
+          <TabsTrigger value="tags">Tags</TabsTrigger>
+          <TabsTrigger value="aliases">Aliases</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="tags" className="space-y-4">
+          <div className="flex items-center justify-end">
+            <Button onClick={openCreate}>
+              <Plus className="mr-2 h-4 w-4" />
+              New Tag
+            </Button>
+          </div>
 
       {/* Filters */}
       <div className="flex items-center gap-3">
@@ -715,6 +726,12 @@ export function TagManagement() {
           </div>
         </>
       )}
+        </TabsContent>
+
+        <TabsContent value="aliases">
+          <AliasListing />
+        </TabsContent>
+      </Tabs>
 
       {/* Create Dialog */}
       <Dialog

--- a/frontend/features/tags/admin/index.ts
+++ b/frontend/features/tags/admin/index.ts
@@ -1,4 +1,5 @@
 export { TagManagement } from './TagManagement'
+export { AliasListing } from './AliasListing'
 export {
   useCreateTag,
   useUpdateTag,
@@ -6,4 +7,6 @@ export {
   useTagAliases,
   useCreateAlias,
   useDeleteAlias,
+  useAllTagAliases,
+  useBulkImportAliases,
 } from './useAdminTags'

--- a/frontend/features/tags/admin/useAdminTags.ts
+++ b/frontend/features/tags/admin/useAdminTags.ts
@@ -3,7 +3,13 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { apiRequest, API_ENDPOINTS } from '@/lib/api'
 import { queryKeys } from '@/lib/queryClient'
-import type { TagDetailResponse, TagAliasesResponse } from '../types'
+import type {
+  TagDetailResponse,
+  TagAliasesResponse,
+  TagAliasListingResponse,
+  BulkAliasImportItem,
+  BulkAliasImportResult,
+} from '../types'
 
 // ──────────────────────────────────────────────
 // Queries
@@ -135,6 +141,48 @@ export function useDeleteAlias() {
       queryClient.invalidateQueries({
         queryKey: queryKeys.tags.detail(variables.tagId),
       })
+    },
+  })
+}
+
+interface ListAllAliasesParams {
+  search?: string
+  limit?: number
+  offset?: number
+}
+
+/** Fetch all aliases across all tags (admin global listing) */
+export function useAllTagAliases(params: ListAllAliasesParams = {}) {
+  const qs = new URLSearchParams()
+  if (params.search) qs.set('search', params.search)
+  if (params.limit !== undefined) qs.set('limit', String(params.limit))
+  if (params.offset !== undefined) qs.set('offset', String(params.offset))
+  const url = `${API_ENDPOINTS.TAGS.ADMIN_ALIASES_ALL}${qs.toString() ? `?${qs.toString()}` : ''}`
+
+  const keyParams: Record<string, unknown> = { ...params }
+
+  return useQuery({
+    queryKey: queryKeys.tags.allAliases(keyParams),
+    queryFn: () => apiRequest<TagAliasListingResponse>(url),
+    staleTime: 30 * 1000,
+  })
+}
+
+/** Bulk import aliases (admin only). Input is already-parsed rows. */
+export function useBulkImportAliases() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (items: BulkAliasImportItem[]) =>
+      apiRequest<BulkAliasImportResult>(
+        API_ENDPOINTS.TAGS.ADMIN_ALIASES_BULK,
+        {
+          method: 'POST',
+          body: JSON.stringify({ items }),
+        }
+      ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['tags', 'aliases'] })
+      queryClient.invalidateQueries({ queryKey: queryKeys.tags.all })
     },
   })
 }

--- a/frontend/features/tags/types.ts
+++ b/frontend/features/tags/types.ts
@@ -134,6 +134,40 @@ export interface TagAliasesResponse {
   aliases: TagAlias[]
 }
 
+/** Global alias listing row — alias paired with its canonical tag (admin view). */
+export interface TagAliasListing {
+  id: number
+  alias: string
+  tag_id: number
+  tag_name: string
+  tag_slug: string
+  tag_category: string
+  tag_is_official: boolean
+  created_at: string
+}
+
+export interface TagAliasListingResponse {
+  aliases: TagAliasListing[]
+  total: number
+}
+
+export interface BulkAliasImportItem {
+  alias: string
+  canonical: string
+}
+
+export interface BulkAliasImportSkipped {
+  row: number
+  alias: string
+  canonical: string
+  reason: string
+}
+
+export interface BulkAliasImportResult {
+  imported: number
+  skipped: BulkAliasImportSkipped[]
+}
+
 export function getCategoryColor(category: string): string {
   const colors: Record<string, string> = {
     genre: 'bg-blue-500/10 text-blue-400 border-blue-500/20',

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -286,6 +286,8 @@ export const API_ENDPOINTS = {
     ALIASES: (idOrSlug: string | number) => `${API_BASE_URL}/tags/${idOrSlug}/aliases`,
     DELETE_ALIAS: (tagId: number, aliasId: number) => `${API_BASE_URL}/tags/${tagId}/aliases/${aliasId}`,
     ENTITIES: (idOrSlug: string | number) => `${API_BASE_URL}/tags/${idOrSlug}/entities`,
+    ADMIN_ALIASES_ALL: `${API_BASE_URL}/admin/tags/aliases`,
+    ADMIN_ALIASES_BULK: `${API_BASE_URL}/admin/tags/aliases/bulk`,
   },
 
   // Entity tag endpoints

--- a/frontend/lib/queryClient.ts
+++ b/frontend/lib/queryClient.ts
@@ -277,6 +277,7 @@ export const queryKeys = {
     detail: (idOrSlug: string | number) => ['tags', 'detail', String(idOrSlug)] as const,
     enrichedDetail: (idOrSlug: string | number) => ['tags', 'detail', 'enriched', String(idOrSlug)] as const,
     aliases: (tagId: number) => ['tags', 'aliases', tagId] as const,
+    allAliases: (params?: Record<string, unknown>) => ['tags', 'aliases', 'all', params] as const,
     entityTags: (entityType: string, entityId: number) => ['tags', 'entityTags', entityType, entityId] as const,
     tagEntities: (idOrSlug: string | number, params?: Record<string, unknown>) => ['tags', 'tagEntities', String(idOrSlug), params] as const,
   },


### PR DESCRIPTION
## Summary

Per-tag alias CRUD already ships in the Edit Tag modal (verified — the `AliasManager` sub-component in `TagManagement.tsx` handles add/remove per tag). Per the ticket's own re-scope comment from 2026-04-18, this PR delivers only the two remaining gaps:

- A workspace-wide listing of every `alias -> canonical` pair with search and pagination
- A CSV bulk-import path with per-row error reporting

Closes PSY-307.

## Scope change

Original ticket asked for a full alias editor (list, add, delete, bulk). The user's own follow-up comment on the ticket confirmed per-tag add/delete already works in the Edit Tag modal and asked to drop those from scope. This PR follows that direction.

## Changes

### Backend (Go)
- `TagService.ListAllAliases(search, limit, offset)` — joins `tag_aliases` with `tags` for alias + canonical info in one query; case-insensitive search across both columns.
- `TagService.BulkImportAliases(items)` — resolves `canonical` by slug or exact name, validates against existing aliases and tag-name collisions, deduplicates within the batch, returns `{imported, skipped: [{row, alias, canonical, reason}]}`.
- New routes (admin-only via `user.IsAdmin` check):
  - `GET /admin/tags/aliases`
  - `POST /admin/tags/aliases/bulk`
- Max import size: 2000 rows per request (rejected as 400 above that).
- Audit log entry on bulk import (imported count + skipped count).
- Tests added in `tag_service_test.go` (10 new service tests) and `tag_integration_test.go` (6 new handler tests).

### Frontend (Next.js)
- New `AliasListing` component (in `features/tags/admin/`) mounted as an "Aliases" tab in the existing `TagManagement` UI via `Tabs`.
- Debounced search, 50-per-page pagination.
- Bulk import dialog: file upload OR paste; client-side CSV parser (comma or tab separated; header and `#` comments ignored; whitespace trimmed); submits as JSON array so we avoid multipart on the Huma side.
- Result panel lists each rejected row with its reason.
- Canonical tag links to `/tags/{slug}`.
- 14 new Vitest tests covering CSV parsing, listing rendering, empty/loading states, debounced search, and the submit/result flow.

## Design choice: JSON array over multipart

Huma v2 has no existing multipart handler in this codebase. Parsing CSV on the client is a few lines, keeps the server payload a plain JSON array, and lets us reuse the normal `apiRequest` path. Flagging here because the ticket text listed both options.

## Test plan

- [x] `go test ./... -timeout 300s` — all pass (catalog: 86s, handlers: 93s, everything green)
- [x] `bun run test:run` — 198 files, 2592 tests, all pass
- [x] `bunx tsc --noEmit` — no new errors in my files
- [x] Per-tag alias CRUD confirmed still present in Edit Tag modal (`AliasManager` sub-component untouched)
- [ ] Visual verification skipped — did not start dev servers (backend worktree port would conflict with any running dev backend). Reviewer to spot-check `/admin/tags` -> Aliases tab manually.

## Notes

- If per-tag CRUD regresses it is not from this PR — `AliasManager` and its hooks (`useTagAliases`, `useCreateAlias`, `useDeleteAlias`) are unchanged.
- Query key `['tags', 'aliases', 'all', params]` invalidated after bulk import; per-tag alias queries use `['tags', 'aliases', tagId]` and remain independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)