### PR TITLE
PSY-468 follow-up: restore toggle-via-click cleanup in upvote E2E

### DIFF
--- a/frontend/e2e/pages/comments.spec.ts
+++ b/frontend/e2e/pages/comments.spec.ts
@@ -135,18 +135,20 @@ test.describe('Comments (general)', () => {
       // comment_vote_service_test.go) so we don't assert on those here.
       await expect(upvoteButton).toHaveClass(/text-primary/, { timeout: 5_000 })
 
-      // Cleanup via direct DELETE. We can't toggle via a second UI click
-      // because the list endpoint doesn't populate user_vote for the
-      // authenticated user (separate backend bug); after onSettled's
-      // refetch, the cached user_vote reverts to null, so the next click
-      // would fire POST (vote) instead of DELETE (unvote). Pulling the
-      // comment ID out of the POST URL sidesteps that for test idempotency.
-      const commentIdMatch = voteResp.url().match(/\/comments\/(\d+)\/vote$/)
-      const commentId = commentIdMatch?.[1]
-      expect(commentId).toBeTruthy()
-      const unvoteResp = await authenticatedPage.request.delete(
-        `/api/comments/${commentId}/vote`
-      )
+      // Cleanup: click the active upvote button to toggle the vote off.
+      // PSY-469 populates `user_vote` on the list refetch, so the cached
+      // state survives and the handler fires DELETE on this second click.
+      // PSY-468's direct-DELETE workaround (which bypassed the UI while
+      // the backend bug was open) is no longer necessary.
+      const [unvoteResp] = await Promise.all([
+        authenticatedPage.waitForResponse(
+          (resp) =>
+            /\/comments\/\d+\/vote$/.test(resp.url()) &&
+            resp.request().method() === 'DELETE',
+          { timeout: 10_000 }
+        ),
+        upvoteButton.click(),
+      ])
       expect(unvoteResp.status()).toBeLessThan(400)
     }
   )


### PR DESCRIPTION
## Summary

PSY-468 worked around the backend bug (PSY-469: list endpoint not populating `user_vote`) by replacing the UI toggle-off cleanup with a direct DELETE call. With PSY-469 now merged, the refetch returns `user_vote=1` and the cached state survives, so the second click fires DELETE as the `handleVote` branch intends.

Restoring the toggle-via-click cleanup keeps the test exercising the production flow end-to-end.

## Test plan

- [x] `bunx playwright test e2e/pages/comments.spec.ts --grep "upvotes a comment"` passes locally
- [ ] Smoke on this PR passes

## Related

- Companion to #387 (PSY-468) and #388 (PSY-469).

🤖 Generated with [Claude Code](https://claude.com/claude-code)