### PR TITLE
PSY-441: tag pill creator attribution (hover card + mobile popover)

### DIFF
--- a/frontend/components/ui/hover-card.tsx
+++ b/frontend/components/ui/hover-card.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import * as React from "react"
+import { HoverCard as HoverCardPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+const HoverCard = HoverCardPrimitive.Root
+
+const HoverCardTrigger = HoverCardPrimitive.Trigger
+
+const HoverCardContent = React.forwardRef<
+  React.ElementRef<typeof HoverCardPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content>
+>(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
+  <HoverCardPrimitive.Portal>
+    <HoverCardPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      {...props}
+    />
+  </HoverCardPrimitive.Portal>
+))
+HoverCardContent.displayName = HoverCardPrimitive.Content.displayName
+
+export { HoverCard, HoverCardTrigger, HoverCardContent }

--- a/frontend/features/tags/components/EntityTagList.test.tsx
+++ b/frontend/features/tags/components/EntityTagList.test.tsx
@@ -11,7 +11,25 @@ vi.mock('next/link', () => ({
   ),
 }))
 
-const mockEntityTags = {
+// Shape mirrors EntityTagsResponse from features/tags/types.ts. Spelled out
+// locally (rather than importing the type) so test fixtures keep working if
+// the module under test is re-exported differently.
+type MockEntityTag = {
+  tag_id: number
+  name: string
+  slug: string
+  category: string
+  is_official: boolean
+  upvotes: number
+  downvotes: number
+  wilson_score: number
+  user_vote: number
+  added_by_username?: string
+  added_at?: string
+}
+type MockEntityTags = { tags: MockEntityTag[] }
+
+const mockEntityTags: MockEntityTags = {
   tags: [
     { tag_id: 1, name: 'rock', slug: 'rock', category: 'genre', is_official: true, upvotes: 3, downvotes: 0, wilson_score: 0.56, user_vote: 0 },
     { tag_id: 2, name: 'indie', slug: 'indie', category: 'genre', is_official: false, upvotes: 1, downvotes: 0, wilson_score: 0.21, user_vote: 0 },
@@ -49,7 +67,7 @@ const defaultMockSearchTags: MockSearchTags = {
 }
 
 const mockAddMutate = vi.fn()
-let currentMockTags = mockEntityTags
+let currentMockTags: MockEntityTags = mockEntityTags
 let currentMockSearchTags: MockSearchTags = defaultMockSearchTags
 let mockAddMutationError: Error | null = null
 
@@ -679,5 +697,173 @@ describe('EntityTagList add-tag dialog create-tag tier gating', () => {
     const learnMore = errorText.querySelector('a')
     expect(learnMore).not.toBeNull()
     expect(learnMore).toHaveAttribute('href', '/help/tiers')
+  })
+})
+
+// PSY-441: tag pill hover card exposes creator attribution (username + when
+// the tag was applied) and vote counts. The card is backed by Radix
+// HoverCard; this suite drives it through the controlled click/keyboard
+// toggle that composes on top of hover — pointer hover is well-covered by
+// Radix's own tests, so we focus on the pieces we added (attribution body
+// rendering, graceful skipping when backend data is missing, vote/link
+// regressions).
+describe('EntityTagList tag pill attribution hover card', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    currentMockTags = {
+      tags: [
+        {
+          tag_id: 10,
+          name: 'post-punk',
+          slug: 'post-punk',
+          category: 'genre',
+          is_official: false,
+          upvotes: 3,
+          downvotes: 1,
+          wilson_score: 0.34,
+          user_vote: 0,
+          added_by_username: 'testuser2',
+        },
+        {
+          tag_id: 11,
+          name: 'noise',
+          slug: 'noise',
+          category: 'genre',
+          is_official: false,
+          upvotes: 0,
+          downvotes: 0,
+          wilson_score: 0,
+          user_vote: 0,
+          // added_by_username deliberately omitted to exercise the skip path
+        },
+      ],
+    }
+    currentMockSearchTags = defaultMockSearchTags
+    mockAuthUser = { user_tier: 'contributor' }
+    mockAddMutationError = null
+  })
+
+  it('opens the attribution card on click and shows username, vote counts, and tag link', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(
+      <EntityTagList entityType="artist" entityId={1} isAuthenticated={false} />
+    )
+
+    // The pill wrapper carries the aria-label we wired on the HoverCardTrigger.
+    const trigger = screen.getByRole('group', { name: /post-punk tag details/i })
+    await user.click(trigger)
+
+    const card = await screen.findByTestId('tag-attribution-card-10')
+    expect(card).toBeInTheDocument()
+
+    // Username link points to the user profile slug.
+    const userLink = screen.getByRole('link', { name: /@testuser2/ })
+    expect(userLink).toHaveAttribute('href', '/users/testuser2')
+
+    // Vote counts render with the correct singular/plural agreement.
+    expect(card).toHaveTextContent(/3\s+upvotes/)
+    // Use a negative lookahead instead of \b — jest-dom normalises whitespace
+    // so a trailing "downvote" (singular) is immediately followed by the next
+    // block's "View tag details", not a word boundary.
+    expect(card).toHaveTextContent(/1\s+downvote(?!s)/)
+
+    // The "View tag details" action links to the canonical tag detail page.
+    const detailLink = screen.getByRole('link', { name: /view tag details/i })
+    expect(detailLink).toHaveAttribute('href', '/tags/post-punk')
+  })
+
+  it('opens the attribution card via keyboard (Enter on the focused pill wrapper)', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(
+      <EntityTagList entityType="artist" entityId={1} isAuthenticated={false} />
+    )
+
+    const trigger = screen.getByRole('group', { name: /post-punk tag details/i })
+    trigger.focus()
+    expect(trigger).toHaveFocus()
+
+    await user.keyboard('{Enter}')
+
+    const card = await screen.findByTestId('tag-attribution-card-10')
+    expect(card).toBeInTheDocument()
+    expect(card).toHaveTextContent('@testuser2')
+  })
+
+  it('omits the "Added by" line when the backend did not return a username', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(
+      <EntityTagList entityType="artist" entityId={1} isAuthenticated={false} />
+    )
+
+    // Open the hover card for the "noise" tag (no added_by_username).
+    const trigger = screen.getByRole('group', { name: /noise tag details/i })
+    await user.click(trigger)
+
+    const card = await screen.findByTestId('tag-attribution-card-11')
+    expect(card).toBeInTheDocument()
+
+    // No "Added by" copy AND no anonymous/undefined leak.
+    expect(card).not.toHaveTextContent(/Added by/i)
+    expect(card).not.toHaveTextContent(/undefined/i)
+
+    // Vote counts + detail link still render — graceful degradation, not a
+    // blank card.
+    expect(card).toHaveTextContent(/0\s+upvotes/)
+    expect(card).toHaveTextContent(/0\s+downvotes/)
+    const detailLink = screen.getByRole('link', { name: /view tag details/i })
+    expect(detailLink).toHaveAttribute('href', '/tags/noise')
+  })
+
+  it('renders relative time alongside the username when added_at is present', async () => {
+    const recent = new Date(Date.now() - 5 * 60 * 1000).toISOString()
+    currentMockTags = {
+      tags: [
+        {
+          tag_id: 20,
+          name: 'shoegaze',
+          slug: 'shoegaze',
+          category: 'genre',
+          is_official: false,
+          upvotes: 1,
+          downvotes: 0,
+          wilson_score: 0.2,
+          user_vote: 0,
+          added_by_username: 'testuser3',
+          added_at: recent,
+        },
+      ],
+    }
+
+    const user = userEvent.setup()
+    renderWithProviders(
+      <EntityTagList entityType="artist" entityId={1} isAuthenticated={false} />
+    )
+
+    await user.click(screen.getByRole('group', { name: /shoegaze tag details/i }))
+
+    const card = await screen.findByTestId('tag-attribution-card-20')
+    // formatRelativeTime output for a timestamp ~5 minutes ago.
+    expect(card).toHaveTextContent(/minutes? ago/i)
+  })
+
+  it('does not regress the inner tag link or vote buttons when the pill is clicked', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(
+      <EntityTagList entityType="artist" entityId={1} isAuthenticated />
+    )
+
+    // The inline tag-name link still points to the canonical detail page.
+    const tagLink = screen.getByRole('link', { name: 'post-punk' })
+    expect(tagLink).toHaveAttribute('href', '/tags/post-punk')
+
+    // Vote buttons are still present and independently clickable (the hover
+    // card wrapper guards against its own toggle when a button is clicked,
+    // so the vote mutation still fires).
+    const upvoteButton = screen.getByRole('button', { name: /upvote post-punk/i })
+    await user.click(upvoteButton)
+    // We don't assert on mutate args here — useVoteOnTag is a mocked noop;
+    // the guarantee is that clicking the vote button does not throw, does
+    // not navigate, and doesn't blow up on the stopPropagation handler.
+    expect(upvoteButton).toBeInTheDocument()
   })
 })

--- a/frontend/features/tags/components/EntityTagList.tsx
+++ b/frontend/features/tags/components/EntityTagList.tsx
@@ -20,6 +20,12 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from '@/components/ui/hover-card'
+import { formatRelativeTime } from '@/lib/formatRelativeTime'
+import {
   useEntityTags,
   useAddTagToEntity,
   useRemoveTagFromEntity,
@@ -171,65 +177,178 @@ function TagWithVotes({
   const userVote = tag.user_vote ?? 0
   const score = tag.upvotes - tag.downvotes
 
+  // Controlled open state for the attribution hover card. Radix HoverCard
+  // opens on hover and focus out of the box; this state lets us *also* toggle
+  // on click/tap so touch users (where :hover doesn't fire) still have a path
+  // to the attribution info (PSY-441 mobile fallback).
+  const [open, setOpen] = useState(false)
+
+  const handleTriggerClick = (e: React.MouseEvent) => {
+    // Don't toggle the card when the click originated on the inner tag Link
+    // (which navigates) or the vote buttons (which mutate). Those elements
+    // stop propagation via their native semantics / explicit handlers below;
+    // this guard covers any future children we add.
+    const target = e.target as HTMLElement
+    if (target.closest('a, button')) return
+    setOpen(v => !v)
+  }
+
+  const handleTriggerKeyDown = (e: React.KeyboardEvent) => {
+    // Enter/Space on the pill wrapper toggles the card — matches the
+    // mouse-click affordance and keeps keyboard users on par with pointer
+    // users. Radix already opens on focus, so this is an explicit toggle.
+    if (e.key === 'Enter' || e.key === ' ') {
+      // Only handle keystrokes that land on the wrapper itself; inner
+      // focusable elements (the Link, vote buttons) handle their own keys.
+      if (e.target !== e.currentTarget) return
+      e.preventDefault()
+      setOpen(v => !v)
+    }
+  }
+
   return (
-    <div
-      className={cn(
-        'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs',
-        // Official tags get a distinct primary-accent background that
-        // overrides the per-category color, making curated tags visibly
-        // different at a glance (ISSUE-004 from tags-audit-2).
-        tag.is_official
-          ? 'border-primary/40 bg-primary/10 text-foreground'
-          : getCategoryColor(tag.category)
+    <HoverCard open={open} onOpenChange={setOpen} openDelay={120} closeDelay={80}>
+      <HoverCardTrigger asChild>
+        <div
+          role="group"
+          tabIndex={0}
+          aria-label={`${tag.name} tag details`}
+          onClick={handleTriggerClick}
+          onKeyDown={handleTriggerKeyDown}
+          className={cn(
+            'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs cursor-pointer focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 focus:ring-offset-background',
+            // Official tags get a distinct primary-accent background that
+            // overrides the per-category color, making curated tags visibly
+            // different at a glance (ISSUE-004 from tags-audit-2).
+            tag.is_official
+              ? 'border-primary/40 bg-primary/10 text-foreground'
+              : getCategoryColor(tag.category)
+          )}
+        >
+          {tag.is_official && (
+            <TagOfficialIndicator size="sm" tagName={tag.name} />
+          )}
+          <Link
+            href={`/tags/${tag.slug}`}
+            className="font-medium hover:underline"
+            title={tag.is_official ? `${tag.name} (Official)` : tag.name}
+          >
+            {tag.name}
+          </Link>
+
+          {(tag.upvotes > 0 || tag.downvotes > 0) && (
+            <span className="text-[10px] opacity-70 tabular-nums">
+              {score >= 0 ? `+${score}` : score}
+            </span>
+          )}
+
+          {isAuthenticated && (
+            <span className="inline-flex items-center gap-0.5 ml-0.5">
+              <button
+                onClick={e => {
+                  e.stopPropagation()
+                  onVote(tag, true)
+                }}
+                className={cn(
+                  'rounded p-0.5 transition-colors',
+                  userVote === 1
+                    ? 'text-green-500'
+                    : 'text-current opacity-40 hover:opacity-100 hover:text-green-500'
+                )}
+                title="Upvote"
+                aria-label={`Upvote ${tag.name}`}
+              >
+                <ThumbsUp className="h-3 w-3" />
+              </button>
+              <button
+                onClick={e => {
+                  e.stopPropagation()
+                  onVote(tag, false)
+                }}
+                className={cn(
+                  'rounded p-0.5 transition-colors',
+                  userVote === -1
+                    ? 'text-red-500'
+                    : 'text-current opacity-40 hover:opacity-100 hover:text-red-500'
+                )}
+                title="Downvote"
+                aria-label={`Downvote ${tag.name}`}
+              >
+                <ThumbsDown className="h-3 w-3" />
+              </button>
+            </span>
+          )}
+        </div>
+      </HoverCardTrigger>
+      <HoverCardContent
+        align="start"
+        side="top"
+        className="w-[280px] text-sm"
+        data-testid={`tag-attribution-card-${tag.tag_id}`}
+      >
+        <TagAttributionContent tag={tag} />
+      </HoverCardContent>
+    </HoverCard>
+  )
+}
+
+// ──────────────────────────────────────────────
+// Attribution hover-card body
+// ──────────────────────────────────────────────
+
+// PSY-441 — surfaces who added the tag + vote counts + a direct link to the
+// tag detail page. Lives as a separate component so the test suite can assert
+// on the rendered content without driving the Radix hover interaction.
+function TagAttributionContent({ tag }: { tag: EntityTag }) {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-1.5">
+        <Link
+          href={`/tags/${tag.slug}`}
+          className="font-semibold text-foreground hover:underline"
+        >
+          #{tag.name}
+        </Link>
+        {tag.is_official && (
+          <TagOfficialIndicator size="sm" tagName={tag.name} />
+        )}
+      </div>
+
+      {/* Added-by line. Skip entirely when the backend has no username —
+          contributors who tagged anonymously or under a since-deleted account
+          won't leak a dangling "Added by @undefined". */}
+      {tag.added_by_username && (
+        <p className="text-xs text-muted-foreground">
+          Added by{' '}
+          <Link
+            href={`/users/${tag.added_by_username}`}
+            className="text-foreground hover:underline"
+          >
+            @{tag.added_by_username}
+          </Link>
+          {tag.added_at && (
+            <>
+              {' · '}
+              <span>{formatRelativeTime(tag.added_at)}</span>
+            </>
+          )}
+        </p>
       )}
-    >
-      {tag.is_official && (
-        <TagOfficialIndicator size="sm" tagName={tag.name} />
-      )}
+
+      <p className="text-xs text-muted-foreground tabular-nums">
+        <span className="font-medium text-foreground">{tag.upvotes}</span>{' '}
+        {tag.upvotes === 1 ? 'upvote' : 'upvotes'}
+        {' · '}
+        <span className="font-medium text-foreground">{tag.downvotes}</span>{' '}
+        {tag.downvotes === 1 ? 'downvote' : 'downvotes'}
+      </p>
+
       <Link
         href={`/tags/${tag.slug}`}
-        className="font-medium hover:underline"
-        title={tag.is_official ? `${tag.name} (Official)` : tag.name}
+        className="inline-block text-xs text-primary hover:underline"
       >
-        {tag.name}
+        View tag details
       </Link>
-
-      {(tag.upvotes > 0 || tag.downvotes > 0) && (
-        <span className="text-[10px] opacity-70 tabular-nums">
-          {score >= 0 ? `+${score}` : score}
-        </span>
-      )}
-
-      {isAuthenticated && (
-        <span className="inline-flex items-center gap-0.5 ml-0.5">
-          <button
-            onClick={() => onVote(tag, true)}
-            className={cn(
-              'rounded p-0.5 transition-colors',
-              userVote === 1
-                ? 'text-green-500'
-                : 'text-current opacity-40 hover:opacity-100 hover:text-green-500'
-            )}
-            title="Upvote"
-            aria-label={`Upvote ${tag.name}`}
-          >
-            <ThumbsUp className="h-3 w-3" />
-          </button>
-          <button
-            onClick={() => onVote(tag, false)}
-            className={cn(
-              'rounded p-0.5 transition-colors',
-              userVote === -1
-                ? 'text-red-500'
-                : 'text-current opacity-40 hover:opacity-100 hover:text-red-500'
-            )}
-            title="Downvote"
-            aria-label={`Downvote ${tag.name}`}
-          >
-            <ThumbsDown className="h-3 w-3" />
-          </button>
-        </span>
-      )}
     </div>
   )
 }

--- a/frontend/features/tags/types.ts
+++ b/frontend/features/tags/types.ts
@@ -112,6 +112,14 @@ export interface EntityTag {
   wilson_score: number
   user_vote?: number | null
   added_by_username?: string
+  /**
+   * UTC timestamp indicating when the tag was applied to the entity. Optional
+   * because the /entities/{type}/{id}/tags endpoint does not currently return
+   * it (PSY-441 limited work to frontend — no API changes). Typed here so the
+   * pill hover card can surface a relative timestamp once the backend exposes
+   * it without a type refactor.
+   */
+  added_at?: string
 }
 
 export interface TagAlias {


### PR DESCRIPTION
## Summary

Tag pills on entity detail pages now surface who applied the tag, how it was received, and link out to the tag detail page via a Radix HoverCard. Backend already returned `added_by_username` in `/entities/{type}/{id}/tags` (landed in PSY-300); this PR is the frontend wire-up called out in `dogfood-output/tags-audit-2/report.md` ISSUE-005.

- New `components/ui/hover-card.tsx` — shadcn-pattern wrapper on the monolithic `radix-ui` HoverCard primitive, mirroring the existing `popover.tsx`. No new package dependency; `radix-ui@1.4.3` already re-exports `HoverCard`.
- `EntityTagList.TagWithVotes` wraps its pill in `HoverCardTrigger asChild`, projecting a focusable `<div role="group" tabIndex=0>`. Inner `<Link>` and vote `<button>`s keep their original behavior; their click handlers `stopPropagation` so clicking vote arrows or the tag name does not toggle the attribution card.
- Card body shows: `#{name}` link, `Added by @{username}` (linked to `/users/{username}`), optional relative-time caption, `{upvotes} upvote(s) - {downvotes} downvote(s)`, and a `View tag details` shortcut. Card is ~280px wide, portal'd, and unmounted when closed.
- `EntityTag` type gains an optional `added_at?: string` so the relative-time line renders automatically once the backend exposes it (see Data-shape note below).

## Primitive choice

HoverCard-only, not Popover or a composed dual-primitive.

**Why:** Radix HoverCard already implements the hover + focus + Escape contract we need for desktop and keyboard. For touch, where `:hover` never fires, I layered a controlled `open` state on top: clicking the pill wrapper (or pressing Enter/Space when it's focused) toggles `open` via `onOpenChange`. This gives touch users a clean tap-to-open fallback without bringing in a second primitive or wrapping in Popover manually.

Inner `<Link>` / vote `<button>` events are guarded with `e.stopPropagation()` plus a `target.closest('a, button')` check on the wrapper's click handler — the existing navigation and vote flows are untouched.

## Mobile behavior

- **Desktop / pointer:** hover opens the card (Radix default, 120ms openDelay, 80ms closeDelay).
- **Touch:** tap the pill (outside the inner link / vote buttons) to open; tap outside or tap the pill again to close.
- **Keyboard:** focus the pill wrapper (new `tabIndex=0` with visible ring), press Enter or Space to toggle, Escape to dismiss (Radix built-in).

## Data-shape note

`/entities/{type}/{id}/tags` currently returns `added_by_username` (verified in `backend/internal/services/contracts/tag.go` `EntityTagResponse`). It does **not** return a timestamp for when the tag was applied, even though the underlying `entity_tags.created_at` column exists. The acceptance criterion says "no API changes," so I kept the backend untouched and made `added_at` optional on the frontend type — the relative-time caption renders automatically if the backend starts returning it in a follow-up. "Added by" + vote counts + detail link all render today from existing fields.

## PSY-438 verification

Surface 2 (tag detail "Created by") is already live. `frontend/features/tags/components/TagDetail.tsx` lines 176-189 render "Created by @username" in the metadata row alongside the category badge and usage count, using the enriched `TagDetailResponse.created_by` or the legacy `created_by_username` fallback. No new work was needed there; no code changed on that path.

## Test plan

- [ ] `bun run test:run features/tags/components/EntityTagList.test.tsx` passes — 28/28 including 5 new cases covering attribution rendering, keyboard open, missing-username skip, relative-time render when `added_at` is set, and vote/link non-regression
- [ ] Full `bun run test:run` passes — 2627/2627
- [ ] `bun run lint` shows the same 179 findings (33 errors / 146 warnings) as `origin/main`; zero new findings in my changed files (`EntityTagList.tsx`, `EntityTagList.test.tsx`, `hover-card.tsx`, `types.ts`)
- [ ] `bunx tsc --noEmit` reports zero new errors in my changed files (pre-existing errors in unrelated tests persist)
- [ ] Manual smoke: hover a tag pill on an entity page → card appears with username, votes, link; tap on touch (Chrome DevTools device mode) → card appears via click; Tab to focus pill + Enter → card opens
- [ ] Accessibility: pill wrapper is focusable (`tabIndex=0`), announces itself as `{tag.name} tag details`, preserves the inner tag link and vote buttons' accessible names, Escape dismisses

Closes PSY-441

[Claude generated](https://claude.com/claude-code)