### PR TITLE
PSY-434: delete 2 redundant E2E tests (favorite-venue auth, city-filter render)

### DIFF
--- a/frontend/e2e/pages/city-filter.spec.ts
+++ b/frontend/e2e/pages/city-filter.spec.ts
@@ -2,27 +2,11 @@ import { test } from '../fixtures/error-detection'
 import { expect } from '@playwright/test'
 
 test.describe('City filter on shows list', () => {
-  test('city filter combobox and popular cities are visible', async ({ page }) => {
-    await page.goto('/shows')
-
-    // Wait for shows to load first
-    await expect(page.locator('article').first()).toBeVisible({
-      timeout: 10_000,
-    })
-
-    // Combobox trigger should be visible
-    await expect(
-      page.getByTestId('city-filter-combobox')
-    ).toBeVisible({ timeout: 5_000 })
-
-    // Popular cities row should be visible with Phoenix
-    await expect(
-      page.getByTestId('popular-cities')
-    ).toBeVisible()
-    await expect(
-      page.getByRole('button', { name: /Phoenix/i })
-    ).toBeVisible()
-  })
+  // PSY-434 Layer-5 audit: the pure-render "combobox + popular cities
+  // visible" case is already covered by `CityFilters.test.tsx` (`renders
+  // the combobox trigger` at line 28 and `shows popular cities when none
+  // are selected` at line 211). The URL-round-trip assertions below are
+  // genuine E2E (navigation + location + network) and stay.
 
   test('clicking a city in combobox updates URL and filters shows', { tag: '@smoke' }, async ({
     page,

--- a/frontend/e2e/pages/favorite-venue.spec.ts
+++ b/frontend/e2e/pages/favorite-venue.spec.ts
@@ -10,23 +10,10 @@ test.describe('Favorite venue', () => {
   // Tests share DB state (same user favoriting/unfavoriting the same venue),
   // so they must not run in parallel
   test.describe.configure({ mode: 'serial' })
-  test('favorite button is hidden when not authenticated', async ({
-    page,
-  }) => {
-    await page.goto(RESERVED_VENUE_URL)
 
-    // Wait for venue detail to load
-    await expect(
-      page.getByRole('heading', { level: 1, name: RESERVED_VENUE_NAME })
-    ).toBeVisible({ timeout: 10_000 })
-
-    // Favorite button should NOT be visible when unauthenticated
-    await expect(
-      page.getByRole('button', {
-        name: /add to favorites|remove from favorites/i,
-      })
-    ).not.toBeVisible()
-  })
+  // PSY-434 Layer-5 audit: the unauthenticated "button hidden" case is
+  // already covered by `FavoriteVenueButton.test.tsx:47` ("renders nothing
+  // when not authenticated"). The E2E version was pure duplication at ~7 s.
 
   test('can favorite and unfavorite a venue from detail page', { tag: '@smoke' }, async ({
     authenticatedPage,


### PR DESCRIPTION
## Summary

Audit items #3 and #4 from [`docs/learnings/e2e-layer-5-audit.md`](../blob/main/docs/learnings/e2e-layer-5-audit.md) — the zero-risk deletions. Both E2E tests duplicated assertions already covered by component tests.

## Removed

1. **`favorite-venue.spec.ts:13`** "favorite button is hidden when not authenticated" (~7.1 s). Duplicates `features/venues/components/FavoriteVenueButton.test.tsx:47` ("renders nothing when not authenticated"). No new test needed.

2. **`city-filter.spec.ts:5`** "city filter combobox and popular cities are visible" (~7.5 s). Duplicates `components/filters/CityFilters.test.tsx` — "renders the combobox trigger" (line 28) and "shows popular cities when none are selected" (line 211). No new test needed.

The remaining tests in both files — the favorite/unfavorite `@smoke` round-trip and the city-filter URL round-trip + state preservation cases — are genuine E2E (real cookie auth, real navigation, real network) and stay.

## Savings

~14.6 s serial runtime, 2 redundant tests removed from the suite.

## Not in this PR

Audit top-5 items #1 (ai-filler), #2 (artist/venue detail tabs), #5 (show-list-actions admin) all require new component tests first — tracked separately in PSY-471, PSY-472, PSY-473.

## Test plan

- [x] Diff review — the removed tests had no cross-test dependencies (no shared state, no setup ripple).
- [ ] Smoke-on-PR job passes.
- [ ] Post-merge full suite shard distribution unchanged (just two fewer tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)