### PR TITLE
PSY-310: admin low-quality tag queue (Needs Review tab)

### DIFF
--- a/backend/db/migrations/000074_add_tag_reviewed_at.down.sql
+++ b/backend/db/migrations/000074_add_tag_reviewed_at.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_tags_reviewed_at;
+ALTER TABLE tags DROP COLUMN IF EXISTS reviewed_at;

--- a/backend/db/migrations/000074_add_tag_reviewed_at.up.sql
+++ b/backend/db/migrations/000074_add_tag_reviewed_at.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tags ADD COLUMN reviewed_at TIMESTAMPTZ NULL;
+CREATE INDEX idx_tags_reviewed_at ON tags(reviewed_at);

--- a/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
+++ b/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
@@ -3028,6 +3028,8 @@ type mockTagService struct {
 	previewMergeTagsFn func(uint, uint) (*contracts.MergeTagsPreview, error)
 	getTagEntitiesFn func(uint, string, int, int) ([]contracts.TaggedEntityItem, int64, error)
 	getTagDetailFn func(uint) (*contracts.TagDetailResponse, error)
+	getLowQualityTagQueueFn func(int, int) (*contracts.LowQualityTagQueueResponse, error)
+	snoozeLowQualityTagFn func(uint, uint) (error)
 	searchTagsFn func(string, int, string) ([]contracts.TagSearchResult, error)
 	getTrendingTagsFn func(int, string) ([]models.Tag, error)
 	pruneDownvotedTagsFn func() (int64, error)
@@ -3158,6 +3160,18 @@ func (m *mockTagService) GetTagDetail(tagID uint) (*contracts.TagDetailResponse,
 		return m.getTagDetailFn(tagID)
 	}
 	return nil, nil
+}
+func (m *mockTagService) GetLowQualityTagQueue(limit int, offset int) (*contracts.LowQualityTagQueueResponse, error) {
+	if m.getLowQualityTagQueueFn != nil {
+		return m.getLowQualityTagQueueFn(limit, offset)
+	}
+	return nil, nil
+}
+func (m *mockTagService) SnoozeLowQualityTag(tagID uint, actorUserID uint) (error) {
+	if m.snoozeLowQualityTagFn != nil {
+		return m.snoozeLowQualityTagFn(tagID, actorUserID)
+	}
+	return nil
 }
 func (m *mockTagService) SearchTags(query string, limit int, category string) ([]contracts.TagSearchResult, error) {
 	if m.searchTagsFn != nil {

--- a/backend/internal/api/handlers/tag.go
+++ b/backend/internal/api/handlers/tag.go
@@ -883,6 +883,71 @@ func (h *TagHandler) BulkImportAliasesHandler(ctx context.Context, req *BulkImpo
 }
 
 // ============================================================================
+// Low-Quality Tag Queue (admin, PSY-310)
+// ============================================================================
+
+type ListLowQualityTagsRequest struct {
+	Limit  int `query:"limit" required:"false" doc:"Max results (default 20, max 100)" example:"20"`
+	Offset int `query:"offset" required:"false" doc:"Offset for pagination" example:"0"`
+}
+
+type ListLowQualityTagsResponse struct {
+	Body *contracts.LowQualityTagQueueResponse
+}
+
+func (h *TagHandler) ListLowQualityTagsHandler(ctx context.Context, req *ListLowQualityTagsRequest) (*ListLowQualityTagsResponse, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+	if !user.IsAdmin {
+		return nil, huma.Error403Forbidden("Admin access required")
+	}
+
+	queue, err := h.tagService.GetLowQualityTagQueue(req.Limit, req.Offset)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Failed to load low-quality tag queue")
+	}
+
+	return &ListLowQualityTagsResponse{Body: queue}, nil
+}
+
+type SnoozeTagRequest struct {
+	TagID string `path:"tag_id" doc:"Tag ID" example:"1"`
+}
+
+func (h *TagHandler) SnoozeTagHandler(ctx context.Context, req *SnoozeTagRequest) (*struct{}, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+	if !user.IsAdmin {
+		return nil, huma.Error403Forbidden("Admin access required")
+	}
+
+	id, err := strconv.ParseUint(req.TagID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid tag ID")
+	}
+
+	if err := h.tagService.SnoozeLowQualityTag(uint(id), user.ID); err != nil {
+		mapped := mapTagError(err)
+		if mapped != nil {
+			return nil, mapped
+		}
+		return nil, huma.Error500InternalServerError("Failed to snooze tag")
+	}
+
+	if h.auditLog != nil {
+		go func() {
+			h.auditLog.LogAction(user.ID, "snooze_low_quality_tag", "tag", uint(id), nil)
+		}()
+	}
+
+	return nil, nil
+}
+
+// ============================================================================
 // Helpers
 // ============================================================================
 

--- a/backend/internal/api/handlers/tag_integration_test.go
+++ b/backend/internal/api/handlers/tag_integration_test.go
@@ -1,8 +1,10 @@
 package handlers
 
 import (
+	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 
@@ -1611,4 +1613,92 @@ func (s *TagHandlerIntegrationSuite) TestMergePreview_NonAdmin() {
 	req := &MergeTagsPreviewRequest{SourceID: "1", TargetID: 2}
 	_, err := s.handler.MergeTagsPreviewHandler(ctx, req)
 	assertHumaError(s.T(), err, 403)
+}
+
+// ============================================================================
+// Low-Quality Tag Queue (PSY-310)
+// ============================================================================
+
+func (s *TagHandlerIntegrationSuite) TestListLowQualityTags_Admin() {
+	admin := createAdminUser(s.deps.db)
+	// Seed an orphaned tag so the queue has content.
+	orphan := &models.Tag{
+		Name:     "orphan",
+		Slug:     "orphan-lq-admin",
+		Category: "other",
+	}
+	s.Require().NoError(s.deps.db.Create(orphan).Error)
+
+	ctx := ctxWithUser(admin)
+	resp, err := s.handler.ListLowQualityTagsHandler(ctx, &ListLowQualityTagsRequest{Limit: 20, Offset: 0})
+	s.Require().NoError(err)
+	s.Require().NotNil(resp.Body)
+	s.Require().Len(resp.Body.Tags, 1)
+	s.Assert().Equal(orphan.ID, resp.Body.Tags[0].ID)
+	s.Assert().Contains(resp.Body.Tags[0].Reasons, "orphaned")
+}
+
+func (s *TagHandlerIntegrationSuite) TestListLowQualityTags_NonAdmin() {
+	user := createTestUser(s.deps.db)
+	ctx := ctxWithUser(user)
+	_, err := s.handler.ListLowQualityTagsHandler(ctx, &ListLowQualityTagsRequest{})
+	assertHumaError(s.T(), err, 403)
+}
+
+func (s *TagHandlerIntegrationSuite) TestListLowQualityTags_Unauthenticated() {
+	_, err := s.handler.ListLowQualityTagsHandler(context.Background(), &ListLowQualityTagsRequest{})
+	assertHumaError(s.T(), err, 401)
+}
+
+func (s *TagHandlerIntegrationSuite) TestSnoozeTag_Admin_WritesAuditLog() {
+	admin := createAdminUser(s.deps.db)
+	tag := &models.Tag{
+		Name:     "to-snooze",
+		Slug:     "to-snooze-lq",
+		Category: "other",
+	}
+	s.Require().NoError(s.deps.db.Create(tag).Error)
+
+	ctx := ctxWithUser(admin)
+	_, err := s.handler.SnoozeTagHandler(ctx, &SnoozeTagRequest{TagID: fmt.Sprintf("%d", tag.ID)})
+	s.Require().NoError(err)
+
+	// reviewed_at should now be set.
+	var refreshed models.Tag
+	s.Require().NoError(s.deps.db.First(&refreshed, tag.ID).Error)
+	s.Require().NotNil(refreshed.ReviewedAt)
+
+	// Audit log fires via goroutine — poll briefly so the goroutine wins.
+	var log models.AuditLog
+	for i := 0; i < 40; i++ {
+		if err := s.deps.db.Where("action = ? AND entity_id = ?", "snooze_low_quality_tag", tag.ID).First(&log).Error; err == nil {
+			break
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	s.Require().NotZero(log.ID, "audit log was not written in time")
+	s.Equal("tag", log.EntityType)
+	s.Require().NotNil(log.ActorID)
+	s.Equal(admin.ID, *log.ActorID)
+}
+
+func (s *TagHandlerIntegrationSuite) TestSnoozeTag_NotFound() {
+	admin := createAdminUser(s.deps.db)
+	ctx := ctxWithUser(admin)
+	_, err := s.handler.SnoozeTagHandler(ctx, &SnoozeTagRequest{TagID: "99999"})
+	assertHumaError(s.T(), err, 404)
+}
+
+func (s *TagHandlerIntegrationSuite) TestSnoozeTag_NonAdmin() {
+	user := createTestUser(s.deps.db)
+	ctx := ctxWithUser(user)
+	_, err := s.handler.SnoozeTagHandler(ctx, &SnoozeTagRequest{TagID: "1"})
+	assertHumaError(s.T(), err, 403)
+}
+
+func (s *TagHandlerIntegrationSuite) TestSnoozeTag_InvalidID() {
+	admin := createAdminUser(s.deps.db)
+	ctx := ctxWithUser(admin)
+	_, err := s.handler.SnoozeTagHandler(ctx, &SnoozeTagRequest{TagID: "abc"})
+	assertHumaError(s.T(), err, 400)
 }

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -831,6 +831,9 @@ func setupTagRoutes(rc RouteContext) {
 	// Admin: merge tags (PSY-306).
 	huma.Get(rc.Protected, "/admin/tags/{source_id}/merge-preview", tagHandler.MergeTagsPreviewHandler)
 	huma.Post(rc.Protected, "/admin/tags/{source_id}/merge", tagHandler.MergeTagsHandler)
+	// Admin: low-quality tag review queue (PSY-310).
+	huma.Get(rc.Protected, "/admin/tags/low-quality", tagHandler.ListLowQualityTagsHandler)
+	huma.Post(rc.Protected, "/admin/tags/{tag_id}/snooze", tagHandler.SnoozeTagHandler)
 }
 
 // setupArtistRelationshipRoutes configures artist relationship and similar artist endpoints.

--- a/backend/internal/models/tag.go
+++ b/backend/internal/models/tag.go
@@ -44,11 +44,12 @@ type Tag struct {
 	Description *string   `json:"description,omitempty" gorm:"column:description"`
 	ParentID    *uint     `json:"parent_id,omitempty" gorm:"column:parent_id"`
 	Category    string    `json:"category" gorm:"column:category;not null;default:'genre';size:50"`
-	IsOfficial      bool      `json:"is_official" gorm:"column:is_official;not null;default:false"`
-	UsageCount      int       `json:"usage_count" gorm:"column:usage_count;not null;default:0"`
-	CreatedByUserID *uint     `json:"created_by_user_id,omitempty" gorm:"column:created_by_user_id"`
-	CreatedAt       time.Time `json:"created_at"`
-	UpdatedAt       time.Time `json:"updated_at"`
+	IsOfficial      bool       `json:"is_official" gorm:"column:is_official;not null;default:false"`
+	UsageCount      int        `json:"usage_count" gorm:"column:usage_count;not null;default:0"`
+	CreatedByUserID *uint      `json:"created_by_user_id,omitempty" gorm:"column:created_by_user_id"`
+	ReviewedAt      *time.Time `json:"reviewed_at,omitempty" gorm:"column:reviewed_at"`
+	CreatedAt       time.Time  `json:"created_at"`
+	UpdatedAt       time.Time  `json:"updated_at"`
 
 	// Relationships
 	Parent    *Tag        `json:"parent,omitempty" gorm:"foreignKey:ParentID"`

--- a/backend/internal/services/catalog/tag_low_quality.go
+++ b/backend/internal/services/catalog/tag_low_quality.go
@@ -1,0 +1,226 @@
+package catalog
+
+import (
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+
+	apperrors "psychic-homily-backend/internal/errors"
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// Low-quality tag review queue (PSY-310).
+//
+// A tag is "low quality" if it is not official AND at least one of:
+//   - orphaned: usage_count = 0
+//   - aging unused: usage_count < 3 AND created_at < now() - 7 days
+//   - downvoted: aggregate tag_votes has more -1 than +1 across all applications
+//   - short_name: LENGTH(name) < 3
+//   - long_name: LENGTH(name) > 40
+//
+// Snoozed tags (reviewed_at within the last 30 days) are excluded, so admins
+// can clear the queue of known-good-enough tags without deleting them. After
+// 30 days a snoozed tag reappears so community drift gets re-evaluated.
+
+const (
+	lowQualityAgeDays        = 7
+	lowQualityUnusedUsageMin = 3
+	lowQualitySnoozeDays     = 30
+	lowQualityShortNameMax   = 3  // LENGTH(name) < 3 → flagged
+	lowQualityLongNameMin    = 40 // LENGTH(name) > 40 → flagged
+
+	// Reason identifiers returned to the frontend so the UI can render
+	// matching pill labels. Keep in sync with the frontend `LOW_QUALITY_REASONS`.
+	LowQualityReasonOrphaned    = "orphaned"
+	LowQualityReasonAgingUnused = "aging_unused"
+	LowQualityReasonDownvoted   = "downvoted"
+	LowQualityReasonShortName   = "short_name"
+	LowQualityReasonLongName    = "long_name"
+
+	// Audit actions
+	AuditActionSnoozeLowQualityTag = "snooze_low_quality_tag"
+)
+
+// GetLowQualityTagQueue returns non-official tags flagged by at least one of
+// the low-quality criteria, excluding those snoozed within the last 30 days.
+// Orders newest first so recent community activity surfaces quickly.
+func (s *TagService) GetLowQualityTagQueue(limit, offset int) (*contracts.LowQualityTagQueueResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	if limit <= 0 {
+		limit = 20
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	now := time.Now().UTC()
+	agingCutoff := now.Add(-time.Duration(lowQualityAgeDays) * 24 * time.Hour)
+	snoozeCutoff := now.Add(-time.Duration(lowQualitySnoozeDays) * 24 * time.Hour)
+
+	// Build the candidate set. A single composite WHERE keeps pagination honest
+	// (count and page reflect the same filter) and avoids fetching all tags and
+	// filtering in Go.
+	candidateQuery := s.db.Model(&models.Tag{}).
+		Where("is_official = ?", false).
+		Where("(reviewed_at IS NULL OR reviewed_at <= ?)", snoozeCutoff).
+		Where(s.db.
+			Where("usage_count = 0").
+			Or("(usage_count < ? AND created_at < ?)", lowQualityUnusedUsageMin, agingCutoff).
+			Or("LENGTH(name) < ?", lowQualityShortNameMax).
+			Or("LENGTH(name) > ?", lowQualityLongNameMin).
+			Or("id IN (?)", downvotedTagIDsSubquery(s.db)),
+		)
+
+	var total int64
+	if err := candidateQuery.Count(&total).Error; err != nil {
+		return nil, fmt.Errorf("failed to count low-quality tags: %w", err)
+	}
+
+	var tags []models.Tag
+	if err := candidateQuery.Order("created_at DESC").Limit(limit).Offset(offset).Find(&tags).Error; err != nil {
+		return nil, fmt.Errorf("failed to list low-quality tags: %w", err)
+	}
+
+	// Per-tag vote aggregates for the displayed rows — one query for the page.
+	// We still need this for the Reasons computation (downvoted is a threshold
+	// on the aggregate, not just presence in the subquery).
+	votes, err := s.aggregateTagVotes(tags)
+	if err != nil {
+		return nil, err
+	}
+
+	items := make([]contracts.LowQualityTagQueueItem, len(tags))
+	for i, t := range tags {
+		agg := votes[t.ID]
+		items[i] = contracts.LowQualityTagQueueItem{
+			TagListItem: contracts.TagListItem{
+				ID:         t.ID,
+				Name:       t.Name,
+				Slug:       t.Slug,
+				Category:   t.Category,
+				IsOfficial: t.IsOfficial,
+				UsageCount: t.UsageCount,
+				CreatedAt:  t.CreatedAt,
+			},
+			Upvotes:   agg.upvotes,
+			Downvotes: agg.downvotes,
+			Reasons:   lowQualityReasons(t, agingCutoff, agg),
+		}
+	}
+
+	return &contracts.LowQualityTagQueueResponse{
+		Tags:  items,
+		Total: total,
+	}, nil
+}
+
+// SnoozeLowQualityTag marks a tag as reviewed-now so it drops out of the queue
+// for the snooze window. Writes a fire-and-forget audit log entry via the
+// tags_audit indirection pattern — callers (handlers) record the audit log
+// themselves since the service layer has no access to the audit log service.
+func (s *TagService) SnoozeLowQualityTag(tagID uint, actorUserID uint) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	var tag models.Tag
+	if err := s.db.First(&tag, tagID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return apperrors.ErrTagNotFound(tagID)
+		}
+		return fmt.Errorf("failed to get tag: %w", err)
+	}
+
+	now := time.Now().UTC()
+	if err := s.db.Model(&tag).Update("reviewed_at", now).Error; err != nil {
+		return fmt.Errorf("failed to snooze tag: %w", err)
+	}
+
+	return nil
+}
+
+// downvotedTagIDsSubquery builds a subquery returning the IDs of tags whose
+// aggregate vote total across all (entity_type, entity_id) applications has
+// more -1 than +1. Matches the shape PruneDownvotedTags uses on the full
+// tag_votes table but aggregates at the tag level (not per-application) so a
+// broadly downvoted tag surfaces once.
+func downvotedTagIDsSubquery(db *gorm.DB) *gorm.DB {
+	return db.Table("tag_votes").
+		Select("tag_id").
+		Group("tag_id").
+		Having("SUM(CASE WHEN vote = -1 THEN 1 ELSE 0 END) > SUM(CASE WHEN vote = 1 THEN 1 ELSE 0 END)")
+}
+
+type tagVoteAggregate struct {
+	upvotes   int64
+	downvotes int64
+}
+
+// aggregateTagVotes fetches per-tag upvote/downvote counts across all
+// applications of the tag. Empty input → empty map.
+func (s *TagService) aggregateTagVotes(tags []models.Tag) (map[uint]tagVoteAggregate, error) {
+	out := make(map[uint]tagVoteAggregate, len(tags))
+	if len(tags) == 0 {
+		return out, nil
+	}
+
+	ids := make([]uint, len(tags))
+	for i, t := range tags {
+		ids[i] = t.ID
+	}
+
+	type row struct {
+		TagID     uint
+		Upvotes   int64
+		Downvotes int64
+	}
+	var rows []row
+	err := s.db.Table("tag_votes").
+		Select("tag_id, SUM(CASE WHEN vote = 1 THEN 1 ELSE 0 END) AS upvotes, SUM(CASE WHEN vote = -1 THEN 1 ELSE 0 END) AS downvotes").
+		Where("tag_id IN ?", ids).
+		Group("tag_id").
+		Scan(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to aggregate tag votes: %w", err)
+	}
+
+	for _, r := range rows {
+		out[r.TagID] = tagVoteAggregate{upvotes: r.Upvotes, downvotes: r.Downvotes}
+	}
+	return out, nil
+}
+
+// lowQualityReasons returns the human-readable identifiers for every criterion
+// the tag triggers. A tag always has at least one reason (otherwise the SQL
+// filter wouldn't have returned it), but we re-evaluate rather than trust the
+// filter so the UI reflects the actual data the admin is looking at.
+func lowQualityReasons(t models.Tag, agingCutoff time.Time, agg tagVoteAggregate) []string {
+	reasons := make([]string, 0, 4)
+
+	if t.UsageCount == 0 {
+		reasons = append(reasons, LowQualityReasonOrphaned)
+	} else if t.UsageCount < lowQualityUnusedUsageMin && t.CreatedAt.Before(agingCutoff) {
+		reasons = append(reasons, LowQualityReasonAgingUnused)
+	}
+
+	if agg.downvotes > agg.upvotes {
+		reasons = append(reasons, LowQualityReasonDownvoted)
+	}
+
+	nameLen := len(t.Name)
+	if nameLen < lowQualityShortNameMax {
+		reasons = append(reasons, LowQualityReasonShortName)
+	} else if nameLen > lowQualityLongNameMin {
+		reasons = append(reasons, LowQualityReasonLongName)
+	}
+
+	return reasons
+}

--- a/backend/internal/services/catalog/tag_low_quality_test.go
+++ b/backend/internal/services/catalog/tag_low_quality_test.go
@@ -1,0 +1,317 @@
+package catalog
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/testutil"
+)
+
+type TagLowQualityIntegrationSuite struct {
+	suite.Suite
+	testDB     *testutil.TestDatabase
+	db         *gorm.DB
+	tagService *TagService
+}
+
+func (s *TagLowQualityIntegrationSuite) SetupSuite() {
+	s.testDB = testutil.SetupTestPostgres(s.T())
+	s.db = s.testDB.DB
+	s.tagService = NewTagService(s.db)
+}
+
+func (s *TagLowQualityIntegrationSuite) TearDownSuite() {
+	s.testDB.Cleanup()
+}
+
+func (s *TagLowQualityIntegrationSuite) SetupTest() {
+	sqlDB, _ := s.db.DB()
+	_, _ = sqlDB.Exec("DELETE FROM audit_logs")
+	_, _ = sqlDB.Exec("DELETE FROM tag_votes")
+	_, _ = sqlDB.Exec("DELETE FROM entity_tags")
+	_, _ = sqlDB.Exec("DELETE FROM tag_aliases")
+	_, _ = sqlDB.Exec("DELETE FROM tags")
+	_, _ = sqlDB.Exec("DELETE FROM artists")
+	_, _ = sqlDB.Exec("DELETE FROM users")
+}
+
+func TestTagLowQualityIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	suite.Run(t, new(TagLowQualityIntegrationSuite))
+}
+
+// ──────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────
+
+func (s *TagLowQualityIntegrationSuite) createUser(name string) *models.User {
+	email := fmt.Sprintf("%s-%d@test.com", name, time.Now().UnixNano())
+	u := &models.User{Email: &email, FirstName: &name, IsActive: true, EmailVerified: true}
+	s.Require().NoError(s.db.Create(u).Error)
+	return u
+}
+
+func (s *TagLowQualityIntegrationSuite) createArtist(name string) uint {
+	slug := fmt.Sprintf("%s-%d", name, time.Now().UnixNano())
+	a := &models.Artist{Name: name, Slug: &slug}
+	s.Require().NoError(s.db.Create(a).Error)
+	return a.ID
+}
+
+// createTagRaw inserts a tag bypassing the service's validations so we can set
+// arbitrary created_at, name lengths, usage_count, etc. for queue criteria.
+func (s *TagLowQualityIntegrationSuite) createTagRaw(name string, opts tagOpts) *models.Tag {
+	createdAt := time.Now().UTC()
+	if !opts.createdAt.IsZero() {
+		createdAt = opts.createdAt
+	}
+	slug := fmt.Sprintf("%s-%d", name, time.Now().UnixNano())
+	tag := &models.Tag{
+		Name:       name,
+		Slug:       slug,
+		Category:   "other",
+		IsOfficial: opts.official,
+		UsageCount: opts.usageCount,
+		CreatedAt:  createdAt,
+		UpdatedAt:  createdAt,
+		ReviewedAt: opts.reviewedAt,
+	}
+	s.Require().NoError(s.db.Create(tag).Error)
+	return tag
+}
+
+type tagOpts struct {
+	official   bool
+	usageCount int
+	createdAt  time.Time
+	reviewedAt *time.Time
+}
+
+// castVote inserts a tag_vote row. Uses a dedicated artist per call so the
+// (tag, entity, user) PK is never violated across different test scenarios.
+func (s *TagLowQualityIntegrationSuite) castVote(tagID uint, userID uint, value int) {
+	artistID := s.createArtist(fmt.Sprintf("artist-%d-%d", tagID, userID))
+	v := &models.TagVote{
+		TagID:      tagID,
+		EntityType: "artist",
+		EntityID:   artistID,
+		UserID:     userID,
+		Vote:       value,
+	}
+	s.Require().NoError(s.db.Create(v).Error)
+}
+
+// ──────────────────────────────────────────────
+// Criteria — individual
+// ──────────────────────────────────────────────
+
+func (s *TagLowQualityIntegrationSuite) TestCriterion_Orphaned() {
+	tag := s.createTagRaw("orphaned-tag", tagOpts{usageCount: 0})
+
+	resp, err := s.tagService.GetLowQualityTagQueue(20, 0)
+	s.Require().NoError(err)
+	s.Require().Len(resp.Tags, 1)
+	s.Assert().Equal(tag.ID, resp.Tags[0].ID)
+	s.Assert().Contains(resp.Tags[0].Reasons, "orphaned")
+}
+
+func (s *TagLowQualityIntegrationSuite) TestCriterion_AgingUnused() {
+	// Created 10 days ago, usage 1 → aging_unused
+	old := time.Now().UTC().AddDate(0, 0, -10)
+	tag := s.createTagRaw("aging-tag", tagOpts{usageCount: 1, createdAt: old})
+
+	resp, err := s.tagService.GetLowQualityTagQueue(20, 0)
+	s.Require().NoError(err)
+	s.Require().Len(resp.Tags, 1)
+	s.Assert().Equal(tag.ID, resp.Tags[0].ID)
+	s.Assert().Contains(resp.Tags[0].Reasons, "aging_unused")
+}
+
+func (s *TagLowQualityIntegrationSuite) TestCriterion_AgingUnused_RecentTagExcluded() {
+	// Created 1 day ago, usage 1 → NOT aging_unused (too fresh)
+	recent := time.Now().UTC().AddDate(0, 0, -1)
+	s.createTagRaw("fresh-tag", tagOpts{usageCount: 1, createdAt: recent})
+
+	resp, err := s.tagService.GetLowQualityTagQueue(20, 0)
+	s.Require().NoError(err)
+	s.Assert().Empty(resp.Tags)
+}
+
+func (s *TagLowQualityIntegrationSuite) TestCriterion_Downvoted() {
+	tag := s.createTagRaw("hated-tag", tagOpts{usageCount: 5, createdAt: time.Now().UTC()})
+	// Ensure aging_unused doesn't kick in by giving enough usage and recent created_at
+	u1 := s.createUser("voter1")
+	u2 := s.createUser("voter2")
+	u3 := s.createUser("voter3")
+	s.castVote(tag.ID, u1.ID, -1)
+	s.castVote(tag.ID, u2.ID, -1)
+	s.castVote(tag.ID, u3.ID, 1)
+
+	resp, err := s.tagService.GetLowQualityTagQueue(20, 0)
+	s.Require().NoError(err)
+	s.Require().Len(resp.Tags, 1)
+	s.Assert().Equal(tag.ID, resp.Tags[0].ID)
+	s.Assert().Contains(resp.Tags[0].Reasons, "downvoted")
+	s.Assert().EqualValues(1, resp.Tags[0].Upvotes)
+	s.Assert().EqualValues(2, resp.Tags[0].Downvotes)
+}
+
+func (s *TagLowQualityIntegrationSuite) TestCriterion_NetPositiveExcluded() {
+	tag := s.createTagRaw("liked-tag", tagOpts{usageCount: 5, createdAt: time.Now().UTC()})
+	u1 := s.createUser("voter1")
+	u2 := s.createUser("voter2")
+	s.castVote(tag.ID, u1.ID, 1)
+	s.castVote(tag.ID, u2.ID, 1)
+
+	resp, err := s.tagService.GetLowQualityTagQueue(20, 0)
+	s.Require().NoError(err)
+	s.Assert().Empty(resp.Tags, "tag with net-positive votes and healthy usage should not be flagged")
+}
+
+func (s *TagLowQualityIntegrationSuite) TestCriterion_ShortName() {
+	// LENGTH(name) < 3 — "ab" qualifies
+	tag := s.createTagRaw("ab", tagOpts{usageCount: 5, createdAt: time.Now().UTC()})
+
+	resp, err := s.tagService.GetLowQualityTagQueue(20, 0)
+	s.Require().NoError(err)
+	s.Require().Len(resp.Tags, 1)
+	s.Assert().Equal(tag.ID, resp.Tags[0].ID)
+	s.Assert().Contains(resp.Tags[0].Reasons, "short_name")
+}
+
+func (s *TagLowQualityIntegrationSuite) TestCriterion_LongName() {
+	// LENGTH(name) > 40 — 41 chars
+	long := "this-is-an-absurdly-long-tag-name-to-test!!"
+	s.Require().Greater(len(long), 40)
+	tag := s.createTagRaw(long, tagOpts{usageCount: 5, createdAt: time.Now().UTC()})
+
+	resp, err := s.tagService.GetLowQualityTagQueue(20, 0)
+	s.Require().NoError(err)
+	s.Require().Len(resp.Tags, 1)
+	s.Assert().Equal(tag.ID, resp.Tags[0].ID)
+	s.Assert().Contains(resp.Tags[0].Reasons, "long_name")
+}
+
+// ──────────────────────────────────────────────
+// Criteria — combinations and exclusions
+// ──────────────────────────────────────────────
+
+func (s *TagLowQualityIntegrationSuite) TestMultipleReasons() {
+	// Orphaned AND short name — should return both reasons.
+	tag := s.createTagRaw("x", tagOpts{usageCount: 0})
+
+	resp, err := s.tagService.GetLowQualityTagQueue(20, 0)
+	s.Require().NoError(err)
+	s.Require().Len(resp.Tags, 1)
+	s.Assert().Equal(tag.ID, resp.Tags[0].ID)
+	s.Assert().Contains(resp.Tags[0].Reasons, "orphaned")
+	s.Assert().Contains(resp.Tags[0].Reasons, "short_name")
+	s.Assert().Len(resp.Tags[0].Reasons, 2)
+}
+
+func (s *TagLowQualityIntegrationSuite) TestOfficialTagsExcluded() {
+	// Official tags are exempt even if they would otherwise qualify.
+	s.createTagRaw("ab", tagOpts{usageCount: 0, official: true})
+	s.createTagRaw("orphaned-admin-tag", tagOpts{usageCount: 0, official: true})
+
+	resp, err := s.tagService.GetLowQualityTagQueue(20, 0)
+	s.Require().NoError(err)
+	s.Assert().Empty(resp.Tags)
+}
+
+func (s *TagLowQualityIntegrationSuite) TestSnoozedRecently_Excluded() {
+	// Snoozed 10 days ago — still within the 30-day window, excluded.
+	snoozed := time.Now().UTC().AddDate(0, 0, -10)
+	s.createTagRaw("snoozed-tag", tagOpts{usageCount: 0, reviewedAt: &snoozed})
+
+	resp, err := s.tagService.GetLowQualityTagQueue(20, 0)
+	s.Require().NoError(err)
+	s.Assert().Empty(resp.Tags)
+}
+
+func (s *TagLowQualityIntegrationSuite) TestSnoozedExpired_Included() {
+	// Snoozed 40 days ago — past the 30-day window, re-surfaces.
+	snoozed := time.Now().UTC().AddDate(0, 0, -40)
+	tag := s.createTagRaw("old-snooze-tag", tagOpts{usageCount: 0, reviewedAt: &snoozed})
+
+	resp, err := s.tagService.GetLowQualityTagQueue(20, 0)
+	s.Require().NoError(err)
+	s.Require().Len(resp.Tags, 1)
+	s.Assert().Equal(tag.ID, resp.Tags[0].ID)
+}
+
+// ──────────────────────────────────────────────
+// Pagination and ordering
+// ──────────────────────────────────────────────
+
+func (s *TagLowQualityIntegrationSuite) TestPagination() {
+	// Create 5 flagged tags spaced by timestamp so order is predictable.
+	base := time.Now().UTC()
+	for i := 0; i < 5; i++ {
+		s.createTagRaw(fmt.Sprintf("orphan-%d", i), tagOpts{
+			usageCount: 0,
+			createdAt:  base.Add(-time.Duration(i) * time.Hour), // Newer first
+		})
+	}
+
+	resp, err := s.tagService.GetLowQualityTagQueue(2, 0)
+	s.Require().NoError(err)
+	s.Assert().Len(resp.Tags, 2)
+	s.Assert().EqualValues(5, resp.Total)
+
+	// Next page
+	resp2, err := s.tagService.GetLowQualityTagQueue(2, 2)
+	s.Require().NoError(err)
+	s.Assert().Len(resp2.Tags, 2)
+	s.Assert().EqualValues(5, resp2.Total)
+
+	// Ensure page 2 is different from page 1
+	s.Assert().NotEqual(resp.Tags[0].ID, resp2.Tags[0].ID)
+}
+
+func (s *TagLowQualityIntegrationSuite) TestNewestFirstOrder() {
+	base := time.Now().UTC()
+	older := s.createTagRaw("orphan-older", tagOpts{usageCount: 0, createdAt: base.Add(-2 * time.Hour)})
+	newer := s.createTagRaw("orphan-newer", tagOpts{usageCount: 0, createdAt: base.Add(-1 * time.Hour)})
+
+	resp, err := s.tagService.GetLowQualityTagQueue(20, 0)
+	s.Require().NoError(err)
+	s.Require().Len(resp.Tags, 2)
+	s.Assert().Equal(newer.ID, resp.Tags[0].ID, "newer tag should come first")
+	s.Assert().Equal(older.ID, resp.Tags[1].ID)
+}
+
+// ──────────────────────────────────────────────
+// Snooze
+// ──────────────────────────────────────────────
+
+func (s *TagLowQualityIntegrationSuite) TestSnoozeLowQualityTag_SetsReviewedAt() {
+	actor := s.createUser("admin")
+	tag := s.createTagRaw("snooze-me", tagOpts{usageCount: 0})
+
+	err := s.tagService.SnoozeLowQualityTag(tag.ID, actor.ID)
+	s.Require().NoError(err)
+
+	var refreshed models.Tag
+	s.Require().NoError(s.db.First(&refreshed, tag.ID).Error)
+	s.Require().NotNil(refreshed.ReviewedAt)
+	s.Assert().WithinDuration(time.Now().UTC(), *refreshed.ReviewedAt, 10*time.Second)
+
+	// And the queue should now skip it.
+	resp, err := s.tagService.GetLowQualityTagQueue(20, 0)
+	s.Require().NoError(err)
+	s.Assert().Empty(resp.Tags)
+}
+
+func (s *TagLowQualityIntegrationSuite) TestSnoozeLowQualityTag_NotFound() {
+	actor := s.createUser("admin")
+	err := s.tagService.SnoozeLowQualityTag(99999, actor.ID)
+	s.Assert().Error(err)
+}

--- a/backend/internal/services/contracts/tag.go
+++ b/backend/internal/services/contracts/tag.go
@@ -192,6 +192,22 @@ type MergeTagsResult struct {
 	MovedAliases      int64 `json:"moved_aliases"`
 }
 
+// LowQualityTagQueueItem is one row in the admin low-quality-tag review queue.
+// Reasons are human-readable identifiers describing which criteria triggered
+// inclusion ("orphaned", "aging_unused", "downvoted", "short_name", "long_name").
+type LowQualityTagQueueItem struct {
+	TagListItem
+	Upvotes    int64    `json:"upvotes"`
+	Downvotes  int64    `json:"downvotes"`
+	Reasons    []string `json:"reasons"`
+}
+
+// LowQualityTagQueueResponse is the paginated response for the admin queue.
+type LowQualityTagQueueResponse struct {
+	Tags  []LowQualityTagQueueItem `json:"tags"`
+	Total int64                    `json:"total"`
+}
+
 // TagServiceInterface defines the contract for tag operations.
 type TagServiceInterface interface {
 	// CRUD
@@ -228,6 +244,10 @@ type TagServiceInterface interface {
 
 	// Tag detail enrichment
 	GetTagDetail(tagID uint) (*TagDetailResponse, error)
+
+	// Low-quality queue (PSY-310)
+	GetLowQualityTagQueue(limit, offset int) (*LowQualityTagQueueResponse, error)
+	SnoozeLowQualityTag(tagID uint, actorUserID uint) error
 
 	// Utility
 	SearchTags(query string, limit int, category string) ([]TagSearchResult, error)

--- a/frontend/features/tags/admin/LowQualityTagQueue.test.tsx
+++ b/frontend/features/tags/admin/LowQualityTagQueue.test.tsx
@@ -1,0 +1,198 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, fireEvent } from '@testing-library/react'
+import { renderWithProviders } from '@/test/utils'
+import type { LowQualityTagQueueItem } from '../types'
+
+const mockUseLowQualityTagQueue = vi.fn()
+const mockSnooze = vi.fn()
+const mockMarkOfficial = vi.fn()
+const mockDelete = vi.fn()
+
+vi.mock('./useAdminTags', () => ({
+  useLowQualityTagQueue: (...args: unknown[]) =>
+    mockUseLowQualityTagQueue(...args),
+  useSnoozeTag: () => ({
+    mutate: mockSnooze,
+    isPending: false,
+    variables: undefined,
+  }),
+  useMarkTagOfficial: () => ({
+    mutate: mockMarkOfficial,
+    isPending: false,
+    variables: undefined,
+  }),
+  useDeleteTag: () => ({
+    mutate: mockDelete,
+    isPending: false,
+  }),
+  // MergeTagDialog transitively needs these.
+  useMergeTags: () => ({ mutate: vi.fn(), isPending: false }),
+  useMergeTagsPreview: () => ({ data: null, isLoading: false, error: null }),
+  useTagAliases: () => ({ data: { aliases: [] }, isLoading: false }),
+}))
+
+vi.mock('../hooks', () => ({
+  useSearchTags: () => ({ data: { tags: [] }, isLoading: false }),
+}))
+
+import { LowQualityTagQueue } from './LowQualityTagQueue'
+
+function makeItem(
+  overrides: Partial<LowQualityTagQueueItem> = {}
+): LowQualityTagQueueItem {
+  return {
+    id: 1,
+    name: 'rock',
+    slug: 'rock',
+    category: 'genre',
+    is_official: false,
+    usage_count: 0,
+    created_at: '2025-01-01T00:00:00Z',
+    upvotes: 0,
+    downvotes: 0,
+    reasons: ['orphaned'],
+    ...overrides,
+  }
+}
+
+describe('LowQualityTagQueue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the empty state when no tags are flagged', () => {
+    mockUseLowQualityTagQueue.mockReturnValue({
+      data: { tags: [], total: 0 },
+      isLoading: false,
+      error: null,
+    })
+
+    renderWithProviders(<LowQualityTagQueue />)
+
+    expect(screen.getByText(/nothing to review/i)).toBeInTheDocument()
+  })
+
+  it('renders each flagged tag with its reason pills', () => {
+    mockUseLowQualityTagQueue.mockReturnValue({
+      data: {
+        tags: [
+          makeItem({
+            id: 1,
+            name: 'orphan-tag',
+            slug: 'orphan-tag',
+            reasons: ['orphaned', 'short_name'],
+          }),
+          makeItem({
+            id: 2,
+            name: 'downvoted-tag',
+            slug: 'downvoted-tag',
+            usage_count: 3,
+            upvotes: 1,
+            downvotes: 4,
+            reasons: ['downvoted'],
+          }),
+        ],
+        total: 2,
+      },
+      isLoading: false,
+      error: null,
+    })
+
+    renderWithProviders(<LowQualityTagQueue />)
+
+    expect(screen.getByText('orphan-tag')).toBeInTheDocument()
+    expect(screen.getByText('downvoted-tag')).toBeInTheDocument()
+
+    const orphanReasons = screen.getByTestId('reasons-1')
+    expect(orphanReasons).toHaveTextContent('Orphaned')
+    expect(orphanReasons).toHaveTextContent('Short name')
+
+    const downvotedReasons = screen.getByTestId('reasons-2')
+    expect(downvotedReasons).toHaveTextContent('Downvoted')
+  })
+
+  it('fires the snooze mutation when Ignore is clicked', () => {
+    mockUseLowQualityTagQueue.mockReturnValue({
+      data: {
+        tags: [makeItem({ id: 42, name: 'mystery' })],
+        total: 1,
+      },
+      isLoading: false,
+      error: null,
+    })
+
+    renderWithProviders(<LowQualityTagQueue />)
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /ignore mystery for 30 days/i })
+    )
+    expect(mockSnooze).toHaveBeenCalledWith(42)
+  })
+
+  it('fires the mark-official mutation when Official is clicked', () => {
+    mockUseLowQualityTagQueue.mockReturnValue({
+      data: {
+        tags: [makeItem({ id: 7, name: 'goodbadtag' })],
+        total: 1,
+      },
+      isLoading: false,
+      error: null,
+    })
+
+    renderWithProviders(<LowQualityTagQueue />)
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /mark goodbadtag official/i })
+    )
+    expect(mockMarkOfficial).toHaveBeenCalledWith(7)
+  })
+
+  it('shows loading state while fetching', () => {
+    mockUseLowQualityTagQueue.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    })
+
+    const { container } = renderWithProviders(<LowQualityTagQueue />)
+
+    expect(container.querySelector('.animate-spin')).toBeInTheDocument()
+  })
+
+  it('surfaces errors', () => {
+    mockUseLowQualityTagQueue.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('boom'),
+    })
+
+    renderWithProviders(<LowQualityTagQueue />)
+
+    expect(screen.getByText(/boom/)).toBeInTheDocument()
+  })
+
+  it('paginates with Previous/Next', () => {
+    mockUseLowQualityTagQueue.mockReturnValue({
+      data: {
+        tags: [makeItem()],
+        total: 50,
+      },
+      isLoading: false,
+      error: null,
+    })
+
+    renderWithProviders(<LowQualityTagQueue />)
+
+    const prevBtn = screen.getByRole('button', { name: /^previous$/i })
+    const nextBtn = screen.getByRole('button', { name: /^next$/i })
+    expect(prevBtn).toBeDisabled() // offset=0
+    expect(nextBtn).toBeEnabled() // 50 total, 20 per page
+
+    fireEvent.click(nextBtn)
+    // After click, the hook is called again with offset=20. We can verify
+    // via the latest call args.
+    const callArgs = mockUseLowQualityTagQueue.mock.calls.at(-1)?.[0]
+    expect(callArgs).toMatchObject({ limit: 20, offset: 20 })
+  })
+})

--- a/frontend/features/tags/admin/LowQualityTagQueue.tsx
+++ b/frontend/features/tags/admin/LowQualityTagQueue.tsx
@@ -1,0 +1,348 @@
+'use client'
+
+import { useCallback, useState } from 'react'
+import {
+  Loader2,
+  Inbox,
+  Trash2,
+  GitMerge,
+  Sparkles,
+  EyeOff,
+  ThumbsDown,
+  ThumbsUp,
+} from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog'
+import {
+  useDeleteTag,
+  useLowQualityTagQueue,
+  useMarkTagOfficial,
+  useSnoozeTag,
+} from './useAdminTags'
+import { MergeTagDialog } from './MergeTagDialog'
+import {
+  LOW_QUALITY_REASON_LABELS,
+  getCategoryColor,
+  getCategoryLabel,
+  type LowQualityReason,
+} from '../types'
+
+const PAGE_SIZE = 20
+
+type ActiveDialog = 'merge' | 'delete' | null
+
+export function LowQualityTagQueue() {
+  const [offset, setOffset] = useState(0)
+  const { data, isLoading, error } = useLowQualityTagQueue({
+    limit: PAGE_SIZE,
+    offset,
+  })
+
+  const snoozeMutation = useSnoozeTag()
+  const markOfficialMutation = useMarkTagOfficial()
+  const deleteMutation = useDeleteTag()
+
+  const [activeDialog, setActiveDialog] = useState<ActiveDialog>(null)
+  const [selectedTagId, setSelectedTagId] = useState<number | null>(null)
+  const [selectedTagName, setSelectedTagName] = useState('')
+
+  const openMerge = useCallback((id: number, name: string) => {
+    setSelectedTagId(id)
+    setSelectedTagName(name)
+    setActiveDialog('merge')
+  }, [])
+
+  const openDelete = useCallback((id: number, name: string) => {
+    setSelectedTagId(id)
+    setSelectedTagName(name)
+    setActiveDialog('delete')
+  }, [])
+
+  const closeDialog = useCallback(() => {
+    setActiveDialog(null)
+    setSelectedTagId(null)
+    setSelectedTagName('')
+  }, [])
+
+  const handleSnooze = useCallback(
+    (id: number) => {
+      snoozeMutation.mutate(id)
+    },
+    [snoozeMutation]
+  )
+
+  const handleMarkOfficial = useCallback(
+    (id: number) => {
+      markOfficialMutation.mutate(id)
+    },
+    [markOfficialMutation]
+  )
+
+  const handleDelete = useCallback(() => {
+    if (selectedTagId == null) return
+    deleteMutation.mutate(selectedTagId, {
+      onSuccess: () => closeDialog(),
+    })
+  }, [selectedTagId, deleteMutation, closeDialog])
+
+  const tags = data?.tags ?? []
+  const total = data?.total ?? 0
+  const hasPrev = offset > 0
+  const hasNext = offset + PAGE_SIZE < total
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <p className="text-sm text-muted-foreground">
+          Non-official tags flagged by at least one low-quality signal —
+          orphaned, aging unused, downvoted, or unusual name length. Snoozed
+          tags hide for 30 days.
+        </p>
+      </div>
+
+      {isLoading && (
+        <div className="flex items-center justify-center py-12">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      )}
+
+      {error && (
+        <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-center">
+          <p className="text-destructive">
+            {error instanceof Error
+              ? error.message
+              : 'Failed to load review queue.'}
+          </p>
+        </div>
+      )}
+
+      {!isLoading && !error && tags.length === 0 && (
+        <div className="flex flex-col items-center justify-center py-12 text-center">
+          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-muted mb-4">
+            <Inbox className="h-8 w-8 text-muted-foreground" />
+          </div>
+          <h3 className="text-lg font-medium mb-1">Nothing to review</h3>
+          <p className="text-sm text-muted-foreground max-w-sm">
+            No tags match the low-quality criteria. Community tag hygiene is on
+            track.
+          </p>
+        </div>
+      )}
+
+      {!isLoading && !error && tags.length > 0 && (
+        <>
+          <div className="text-sm text-muted-foreground">
+            Showing {offset + 1}-{Math.min(offset + tags.length, total)} of{' '}
+            {total}
+          </div>
+
+          <div className="space-y-2">
+            {tags.map((tag) => {
+              const isBusy =
+                (snoozeMutation.isPending &&
+                  snoozeMutation.variables === tag.id) ||
+                (markOfficialMutation.isPending &&
+                  markOfficialMutation.variables === tag.id)
+
+              return (
+                <div
+                  key={tag.id}
+                  className="flex flex-col gap-3 rounded-lg border p-3 hover:bg-muted/50 transition-colors"
+                  data-testid={`low-quality-tag-${tag.id}`}
+                >
+                  <div className="flex items-start gap-3">
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span className="font-medium text-sm truncate">
+                          {tag.name}
+                        </span>
+                        <Badge
+                          variant="outline"
+                          className={`text-xs flex-shrink-0 ${getCategoryColor(tag.category)}`}
+                        >
+                          {getCategoryLabel(tag.category)}
+                        </Badge>
+                      </div>
+                      <div className="flex items-center gap-3 text-xs text-muted-foreground mt-0.5">
+                        <span>
+                          {tag.usage_count}{' '}
+                          {tag.usage_count === 1 ? 'use' : 'uses'}
+                        </span>
+                        <span className="text-muted-foreground/50">
+                          /{tag.slug}
+                        </span>
+                        {(tag.upvotes > 0 || tag.downvotes > 0) && (
+                          <>
+                            <span className="inline-flex items-center gap-1">
+                              <ThumbsUp className="h-3 w-3" />
+                              {tag.upvotes}
+                            </span>
+                            <span className="inline-flex items-center gap-1">
+                              <ThumbsDown className="h-3 w-3" />
+                              {tag.downvotes}
+                            </span>
+                          </>
+                        )}
+                      </div>
+                    </div>
+
+                    <div className="flex items-center gap-1 flex-shrink-0">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handleMarkOfficial(tag.id)}
+                        disabled={isBusy}
+                        aria-label={`Mark ${tag.name} official`}
+                        title="Promote to official"
+                      >
+                        <Sparkles className="h-3.5 w-3.5 mr-1" />
+                        Official
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => openMerge(tag.id, tag.name)}
+                        aria-label={`Merge ${tag.name}`}
+                        title="Merge into another tag"
+                      >
+                        <GitMerge className="h-3.5 w-3.5 mr-1" />
+                        Merge
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handleSnooze(tag.id)}
+                        disabled={isBusy}
+                        aria-label={`Ignore ${tag.name} for 30 days`}
+                        title="Ignore for 30 days"
+                      >
+                        <EyeOff className="h-3.5 w-3.5 mr-1" />
+                        Ignore
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => openDelete(tag.id, tag.name)}
+                        className="text-muted-foreground hover:text-destructive"
+                        aria-label={`Delete ${tag.name}`}
+                        title="Delete tag"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </Button>
+                    </div>
+                  </div>
+
+                  {tag.reasons.length > 0 && (
+                    <div
+                      className="flex flex-wrap gap-1"
+                      data-testid={`reasons-${tag.id}`}
+                    >
+                      {tag.reasons.map((r: LowQualityReason) => (
+                        <Badge
+                          key={r}
+                          variant="secondary"
+                          className="text-xs"
+                        >
+                          {LOW_QUALITY_REASON_LABELS[r] ?? r}
+                        </Badge>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+
+          <div className="flex items-center justify-between pt-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={!hasPrev}
+              onClick={() => setOffset((o) => Math.max(0, o - PAGE_SIZE))}
+            >
+              Previous
+            </Button>
+            <span className="text-xs text-muted-foreground">
+              Page {Math.floor(offset / PAGE_SIZE) + 1} of{' '}
+              {Math.max(1, Math.ceil(total / PAGE_SIZE))}
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={!hasNext}
+              onClick={() => setOffset((o) => o + PAGE_SIZE)}
+            >
+              Next
+            </Button>
+          </div>
+        </>
+      )}
+
+      {/* Merge dialog — reuses the existing PSY-306 flow */}
+      <MergeTagDialog
+        open={activeDialog === 'merge'}
+        sourceTagId={activeDialog === 'merge' ? selectedTagId : null}
+        sourceTagName={selectedTagName}
+        onClose={closeDialog}
+      />
+
+      {/* Delete confirmation */}
+      <Dialog
+        open={activeDialog === 'delete'}
+        onOpenChange={(open) => !open && closeDialog()}
+      >
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Delete Tag</DialogTitle>
+            <DialogDescription>
+              This action is permanent and cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <p className="text-sm text-muted-foreground">
+              Are you sure you want to delete{' '}
+              <span className="font-semibold text-foreground">
+                &quot;{selectedTagName}&quot;
+              </span>
+              ? This will remove it from all entities and delete all associated
+              aliases and votes.
+            </p>
+            <DialogFooter>
+              <Button
+                variant="outline"
+                onClick={closeDialog}
+                disabled={deleteMutation.isPending}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                onClick={handleDelete}
+                disabled={deleteMutation.isPending}
+              >
+                {deleteMutation.isPending ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Deleting...
+                  </>
+                ) : (
+                  'Delete Tag'
+                )}
+              </Button>
+            </DialogFooter>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}
+
+export default LowQualityTagQueue

--- a/frontend/features/tags/admin/TagManagement.test.tsx
+++ b/frontend/features/tags/admin/TagManagement.test.tsx
@@ -25,6 +25,9 @@ vi.mock('./useAdminTags', () => ({
   useBulkImportAliases: () => ({ mutate: vi.fn(), isPending: false }),
   useMergeTags: () => ({ mutate: vi.fn(), isPending: false }),
   useMergeTagsPreview: () => ({ data: null, isLoading: false, error: null }),
+  useLowQualityTagQueue: () => ({ data: { tags: [], total: 0 }, isLoading: false, error: null }),
+  useSnoozeTag: () => ({ mutate: vi.fn(), isPending: false, variables: undefined }),
+  useMarkTagOfficial: () => ({ mutate: vi.fn(), isPending: false, variables: undefined }),
 }))
 
 import { TagManagement } from './TagManagement'

--- a/frontend/features/tags/admin/TagManagement.tsx
+++ b/frontend/features/tags/admin/TagManagement.tsx
@@ -28,6 +28,7 @@ import {
 } from '@/components/ui/dialog'
 import { useTags, useTag } from '../hooks'
 import { AliasListing } from './AliasListing'
+import { LowQualityTagQueue } from './LowQualityTagQueue'
 import { MergeTagDialog } from './MergeTagDialog'
 import { TagOfficialIndicator } from '../components/TagOfficialIndicator'
 import {
@@ -37,6 +38,7 @@ import {
   useTagAliases,
   useCreateAlias,
   useDeleteAlias,
+  useLowQualityTagQueue,
 } from './useAdminTags'
 import {
   TAG_CATEGORIES,
@@ -46,6 +48,25 @@ import {
 } from '../types'
 
 type DialogMode = 'create' | 'edit' | 'delete' | 'merge' | null
+
+// ============================================================================
+// Needs-Review Tab Badge
+// ============================================================================
+
+function LowQualityBadge() {
+  const { data } = useLowQualityTagQueue({ limit: 1 })
+  const total = data?.total ?? 0
+  if (total === 0) return null
+  return (
+    <Badge
+      variant="secondary"
+      className="h-5 min-w-5 justify-center px-1.5 text-xs"
+      aria-label={`${total} tags need review`}
+    >
+      {total > 99 ? '99+' : total}
+    </Badge>
+  )
+}
 
 // ============================================================================
 // Alias Manager Sub-Component
@@ -601,6 +622,10 @@ export function TagManagement() {
         <TabsList>
           <TabsTrigger value="tags">Tags</TabsTrigger>
           <TabsTrigger value="aliases">Aliases</TabsTrigger>
+          <TabsTrigger value="needs-review" className="gap-2">
+            Needs Review
+            <LowQualityBadge />
+          </TabsTrigger>
         </TabsList>
 
         <TabsContent value="tags" className="space-y-4">
@@ -749,6 +774,10 @@ export function TagManagement() {
 
         <TabsContent value="aliases">
           <AliasListing />
+        </TabsContent>
+
+        <TabsContent value="needs-review">
+          <LowQualityTagQueue />
         </TabsContent>
       </Tabs>
 

--- a/frontend/features/tags/admin/index.ts
+++ b/frontend/features/tags/admin/index.ts
@@ -1,5 +1,6 @@
 export { TagManagement } from './TagManagement'
 export { AliasListing } from './AliasListing'
+export { LowQualityTagQueue } from './LowQualityTagQueue'
 export { MergeTagDialog } from './MergeTagDialog'
 export {
   useCreateTag,
@@ -12,4 +13,7 @@ export {
   useBulkImportAliases,
   useMergeTags,
   useMergeTagsPreview,
+  useLowQualityTagQueue,
+  useSnoozeTag,
+  useMarkTagOfficial,
 } from './useAdminTags'

--- a/frontend/features/tags/admin/useAdminTags.ts
+++ b/frontend/features/tags/admin/useAdminTags.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query'
 import { apiRequest, API_ENDPOINTS } from '@/lib/api'
 import { queryKeys } from '@/lib/queryClient'
 import type {
@@ -11,6 +11,7 @@ import type {
   BulkAliasImportResult,
   MergeTagsPreview,
   MergeTagsResult,
+  LowQualityTagQueueResponse,
 } from '../types'
 
 // ──────────────────────────────────────────────
@@ -238,6 +239,68 @@ export function useMergeTags() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.tags.all })
       queryClient.invalidateQueries({ queryKey: ['tags', 'aliases'] })
+    },
+  })
+}
+
+// ──────────────────────────────────────────────
+// Low-Quality Tag Queue (PSY-310)
+// ──────────────────────────────────────────────
+
+interface UseLowQualityTagQueueParams {
+  limit?: number
+  offset?: number
+}
+
+/**
+ * Fetch the admin low-quality tag review queue. Short staleTime (30s) so
+ * Ignore/Promote/Delete actions reflect quickly without polling.
+ */
+export function useLowQualityTagQueue(params: UseLowQualityTagQueueParams = {}) {
+  const qs = new URLSearchParams()
+  if (params.limit !== undefined) qs.set('limit', String(params.limit))
+  if (params.offset !== undefined) qs.set('offset', String(params.offset))
+  const url = `${API_ENDPOINTS.TAGS.ADMIN_LOW_QUALITY}${qs.toString() ? `?${qs.toString()}` : ''}`
+
+  return useQuery({
+    queryKey: queryKeys.tags.lowQuality(params as Record<string, unknown>),
+    queryFn: () => apiRequest<LowQualityTagQueueResponse>(url),
+    staleTime: 30 * 1000,
+    placeholderData: keepPreviousData,
+  })
+}
+
+/** Snooze a tag (mark reviewed). Invalidates the queue + tag lists. */
+export function useSnoozeTag() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (tagId: number) =>
+      apiRequest<void>(API_ENDPOINTS.TAGS.ADMIN_SNOOZE(tagId), {
+        method: 'POST',
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.tags.lowQuality() })
+      queryClient.invalidateQueries({ queryKey: queryKeys.tags.all })
+    },
+  })
+}
+
+/**
+ * Promote a tag to official by reusing the existing update endpoint
+ * (PUT /tags/{id}) with `is_official: true`. No new backend endpoint needed.
+ */
+export function useMarkTagOfficial() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (tagId: number) =>
+      apiRequest<TagDetailResponse>(API_ENDPOINTS.TAGS.GET(tagId), {
+        method: 'PUT',
+        body: JSON.stringify({ is_official: true }),
+      }),
+    onSuccess: (_data, tagId) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.tags.lowQuality() })
+      queryClient.invalidateQueries({ queryKey: queryKeys.tags.all })
+      queryClient.invalidateQueries({ queryKey: queryKeys.tags.detail(tagId) })
     },
   })
 }

--- a/frontend/features/tags/types.ts
+++ b/frontend/features/tags/types.ts
@@ -204,6 +204,39 @@ export interface MergeTagsResult {
   moved_aliases: number
 }
 
+/**
+ * Reason identifier for why a tag appeared in the low-quality review queue.
+ * Keep in sync with the backend constants in `tag_low_quality.go`.
+ */
+export type LowQualityReason =
+  | 'orphaned'
+  | 'aging_unused'
+  | 'downvoted'
+  | 'short_name'
+  | 'long_name'
+
+/** One row in the admin low-quality tag review queue (PSY-310). */
+export interface LowQualityTagQueueItem extends TagListItem {
+  upvotes: number
+  downvotes: number
+  reasons: LowQualityReason[]
+}
+
+/** Paginated response for GET /admin/tags/low-quality. */
+export interface LowQualityTagQueueResponse {
+  tags: LowQualityTagQueueItem[]
+  total: number
+}
+
+/** Human-readable labels for the reason pills in the queue UI. */
+export const LOW_QUALITY_REASON_LABELS: Record<LowQualityReason, string> = {
+  orphaned: 'Orphaned',
+  aging_unused: 'Aging unused',
+  downvoted: 'Downvoted',
+  short_name: 'Short name',
+  long_name: 'Long name',
+}
+
 export function getCategoryColor(category: string): string {
   const colors: Record<string, string> = {
     genre: 'bg-blue-500/10 text-blue-400 border-blue-500/20',

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -291,6 +291,8 @@ export const API_ENDPOINTS = {
     ADMIN_MERGE: (sourceId: number) => `${API_BASE_URL}/admin/tags/${sourceId}/merge`,
     ADMIN_MERGE_PREVIEW: (sourceId: number, targetId: number) =>
       `${API_BASE_URL}/admin/tags/${sourceId}/merge-preview?target_id=${targetId}`,
+    ADMIN_LOW_QUALITY: `${API_BASE_URL}/admin/tags/low-quality`,
+    ADMIN_SNOOZE: (tagId: number) => `${API_BASE_URL}/admin/tags/${tagId}/snooze`,
   },
 
   // Entity tag endpoints

--- a/frontend/lib/queryClient.ts
+++ b/frontend/lib/queryClient.ts
@@ -278,6 +278,7 @@ export const queryKeys = {
     enrichedDetail: (idOrSlug: string | number) => ['tags', 'detail', 'enriched', String(idOrSlug)] as const,
     aliases: (tagId: number) => ['tags', 'aliases', tagId] as const,
     allAliases: (params?: Record<string, unknown>) => ['tags', 'aliases', 'all', params] as const,
+    lowQuality: (params?: Record<string, unknown>) => ['tags', 'low-quality', params] as const,
     entityTags: (entityType: string, entityId: number) => ['tags', 'entityTags', entityType, entityId] as const,
     tagEntities: (idOrSlug: string | number, params?: Record<string, unknown>) => ['tags', 'tagEntities', String(idOrSlug), params] as const,
   },


### PR DESCRIPTION
## Summary

Adds a **Needs Review** tab to the admin tag management UI listing
non-official tags flagged by at least one low-quality signal. Admins
can mark as official, merge, delete, or ignore for 30 days.

### Criteria (exactly the four from the ticket)

A tag appears in the queue when `is_official = false` **and** at least one of:
- `usage_count = 0` — orphaned
- `usage_count < 3 AND created_at < now() - interval '7 days'` — aging unused
- aggregate tag_votes has more `-1` than `+1` across all applications — downvoted
- `LENGTH(name) < 3 OR LENGTH(name) > 40` — short/long name

…and the tag is not snoozed within the last 30 days (`reviewed_at IS NULL OR reviewed_at <= now() - interval '30 days'`). Ordered newest first.

### How the criteria query was implemented

Confirmed the actual `tag_votes` shape matches the ticket's guess: `vote INT` with values `1` / `-1`. The downvoted filter uses a subquery `GROUP BY tag_id HAVING SUM(vote=-1) > SUM(vote=1)` — same aggregate shape `PruneDownvotedTags` uses, aggregated at the tag level (not per-application) so a broadly downvoted tag surfaces once.

### Integration with existing admin tabs

`frontend/features/tags/admin/TagManagement.tsx` now has three tabs — **Tags**, **Aliases**, **Needs Review** — with a count badge on the new tab. The Aliases tab (PSY-307) and Merge buttons (PSY-306) are untouched; the new tab is additive.

### Reuse

- **Merge** — reuses the PSY-306 `MergeTagDialog` component unchanged.
- **Delete** — uses the existing `useDeleteTag` hook + `DELETE /tags/{id}` endpoint.
- **Mark Official** — reuses `PUT /tags/{id}` (`UpdateTag` already accepts `is_official`). No new backend endpoint for this action.
- **Ignore** — new `POST /admin/tags/{id}/snooze` endpoint backed by the new `reviewed_at` column.

### Backend

- Migration `000074_add_tag_reviewed_at.{up,down}.sql` — adds `tags.reviewed_at TIMESTAMPTZ NULL` + `idx_tags_reviewed_at`.
- `tag_low_quality.go` (new file) — `GetLowQualityTagQueue(limit, offset)` and `SnoozeLowQualityTag(tagID, actorUserID)`. Landed in a separate file to minimize merge surface with the PSY-311 hierarchy-editor branch that also touches `tag_service.go`.
- `tag.go` handler — `GET /admin/tags/low-quality` and `POST /admin/tags/{id}/snooze`, admin-only (handlers check `user.IsAdmin` per project convention). Audit log is fire-and-forget per the project pattern.

### Frontend

- New `LowQualityTagQueue` component in `features/tags/admin/` with per-row Merge/Delete/Mark Official/Ignore.
- New hooks: `useLowQualityTagQueue`, `useSnoozeTag`, `useMarkTagOfficial`.
- Reason pills render from the backend's `reasons` array (`Orphaned`, `Aging unused`, `Downvoted`, `Short name`, `Long name`).
- Pagination: Previous/Next at 20 per page. Tab badge shows total queue size (capped at `99+`).

## Test plan

- [x] Backend service integration tests — each criterion in isolation, combined reasons, official exclusion, snooze within/past 30 days, pagination, newest-first ordering, `SnoozeLowQualityTag` error path (13 tests)
- [x] Backend handler integration tests — admin queue response, 401/403 on non-admin/unauthenticated, snooze writes `reviewed_at` + audit log, 404 on missing tag, 400 on bad ID (6 tests)
- [x] Frontend component tests — empty state, reason pills, snooze/mark-official mutations fire, loading, error, pagination (7 tests)
- [x] `go test ./...` green
- [x] `bun run test:run` green (2,629 tests)
- [ ] Visual verification via dev stack — not performed in this session; UI mirrors the existing Tags/Aliases tab style (shadcn Tabs + Badge + Button primitives, no `components/ui/` primitives modified).

Closes PSY-310

🤖 Generated with [Claude Code](https://claude.com/claude-code)