### PR TITLE
PSY-311: admin parent hierarchy editor for genre tree

### DIFF
--- a/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
+++ b/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
@@ -3026,6 +3026,10 @@ type mockTagService struct {
 	bulkImportAliasesFn func([]contracts.BulkAliasImportItem) (*contracts.BulkAliasImportResult, error)
 	mergeTagsFn func(uint, uint, uint) (*contracts.MergeTagsResult, error)
 	previewMergeTagsFn func(uint, uint) (*contracts.MergeTagsPreview, error)
+	getTagAncestorsFn func(uint) ([]*models.Tag, error)
+	getTagChildrenFn func(uint) ([]*models.Tag, error)
+	getGenreHierarchyFn func() ([]*models.Tag, error)
+	setTagParentFn func(uint, *uint, uint) (error)
 	getTagEntitiesFn func(uint, string, int, int) ([]contracts.TaggedEntityItem, int64, error)
 	getTagDetailFn func(uint) (*contracts.TagDetailResponse, error)
 	getLowQualityTagQueueFn func(int, int) (*contracts.LowQualityTagQueueResponse, error)
@@ -3148,6 +3152,30 @@ func (m *mockTagService) PreviewMergeTags(sourceID uint, targetID uint) (*contra
 		return m.previewMergeTagsFn(sourceID, targetID)
 	}
 	return nil, nil
+}
+func (m *mockTagService) GetTagAncestors(tagID uint) ([]*models.Tag, error) {
+	if m.getTagAncestorsFn != nil {
+		return m.getTagAncestorsFn(tagID)
+	}
+	return nil, nil
+}
+func (m *mockTagService) GetTagChildren(tagID uint) ([]*models.Tag, error) {
+	if m.getTagChildrenFn != nil {
+		return m.getTagChildrenFn(tagID)
+	}
+	return nil, nil
+}
+func (m *mockTagService) GetGenreHierarchy() ([]*models.Tag, error) {
+	if m.getGenreHierarchyFn != nil {
+		return m.getGenreHierarchyFn()
+	}
+	return nil, nil
+}
+func (m *mockTagService) SetTagParent(tagID uint, parentID *uint, actorUserID uint) (error) {
+	if m.setTagParentFn != nil {
+		return m.setTagParentFn(tagID, parentID, actorUserID)
+	}
+	return nil
 }
 func (m *mockTagService) GetTagEntities(tagID uint, entityType string, limit int, offset int) ([]contracts.TaggedEntityItem, int64, error) {
 	if m.getTagEntitiesFn != nil {

--- a/backend/internal/api/handlers/tag.go
+++ b/backend/internal/api/handlers/tag.go
@@ -948,6 +948,101 @@ func (h *TagHandler) SnoozeTagHandler(ctx context.Context, req *SnoozeTagRequest
 }
 
 // ============================================================================
+// Genre hierarchy (admin, PSY-311)
+// ============================================================================
+
+// GenreHierarchyTag is the minimal shape returned by the hierarchy endpoint.
+// The frontend builds the tree client-side from parent_id, so we don't need
+// the heavier TagResponse shape with relationships and creator attribution.
+type GenreHierarchyTag struct {
+	ID         uint   `json:"id"`
+	Name       string `json:"name"`
+	Slug       string `json:"slug"`
+	ParentID   *uint  `json:"parent_id,omitempty"`
+	UsageCount int    `json:"usage_count"`
+	IsOfficial bool   `json:"is_official"`
+}
+
+type GetGenreHierarchyResponse struct {
+	Body struct {
+		Tags []GenreHierarchyTag `json:"tags"`
+	}
+}
+
+// GetGenreHierarchyHandler returns all genre tags as a flat list with
+// parent_id populated. The frontend assembles the tree — this keeps the
+// backend query trivial (one indexed scan) and avoids a recursive CTE.
+func (h *TagHandler) GetGenreHierarchyHandler(ctx context.Context, _ *struct{}) (*GetGenreHierarchyResponse, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+	if !user.IsAdmin {
+		return nil, huma.Error403Forbidden("Admin access required")
+	}
+
+	tags, err := h.tagService.GetGenreHierarchy()
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Failed to load genre hierarchy")
+	}
+
+	items := make([]GenreHierarchyTag, len(tags))
+	for i, t := range tags {
+		items[i] = GenreHierarchyTag{
+			ID:         t.ID,
+			Name:       t.Name,
+			Slug:       t.Slug,
+			ParentID:   t.ParentID,
+			UsageCount: t.UsageCount,
+			IsOfficial: t.IsOfficial,
+		}
+	}
+
+	resp := &GetGenreHierarchyResponse{}
+	resp.Body.Tags = items
+	return resp, nil
+}
+
+// SetTagParentRequest has ParentID as a pointer so the request can
+// explicitly send `null` to clear the parent. Huma treats pointer body
+// fields as required by default; we mark it optional so callers can omit
+// it and default to "clear parent" — but in practice the frontend always
+// sends the field explicitly.
+type SetTagParentRequest struct {
+	TagID string `path:"tag_id" doc:"Tag ID" example:"1"`
+	Body  struct {
+		ParentID *uint `json:"parent_id" required:"false" doc:"New parent tag ID, or null to clear parent"`
+	}
+}
+
+// SetTagParentHandler sets or clears the parent of a genre tag. Cycle
+// detection, category enforcement, and audit logging live in the service.
+// The handler's job is path-id parsing + error mapping.
+func (h *TagHandler) SetTagParentHandler(ctx context.Context, req *SetTagParentRequest) (*struct{}, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+	if !user.IsAdmin {
+		return nil, huma.Error403Forbidden("Admin access required")
+	}
+
+	id, err := strconv.ParseUint(req.TagID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid tag ID")
+	}
+
+	if err := h.tagService.SetTagParent(uint(id), req.Body.ParentID, user.ID); err != nil {
+		if mapped := mapTagError(err); mapped != nil {
+			return nil, mapped
+		}
+		return nil, huma.Error500InternalServerError("Failed to set tag parent")
+	}
+
+	return nil, nil
+}
+
+// ============================================================================
 // Helpers
 // ============================================================================
 
@@ -1022,6 +1117,10 @@ func mapTagError(err error) error {
 			return huma.Error400BadRequest(tagErr.Message)
 		case apperrors.CodeTagMergeAliasConflict:
 			return huma.Error409Conflict(tagErr.Message)
+		case apperrors.CodeTagHierarchyCycle:
+			return huma.Error400BadRequest(tagErr.Message)
+		case apperrors.CodeTagHierarchyNotGenre:
+			return huma.Error400BadRequest(tagErr.Message)
 		}
 	}
 	return nil

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -834,6 +834,9 @@ func setupTagRoutes(rc RouteContext) {
 	// Admin: low-quality tag review queue (PSY-310).
 	huma.Get(rc.Protected, "/admin/tags/low-quality", tagHandler.ListLowQualityTagsHandler)
 	huma.Post(rc.Protected, "/admin/tags/{tag_id}/snooze", tagHandler.SnoozeTagHandler)
+	// Admin: genre-hierarchy editor (PSY-311).
+	huma.Get(rc.Protected, "/admin/tags/hierarchy", tagHandler.GetGenreHierarchyHandler)
+	huma.Patch(rc.Protected, "/admin/tags/{tag_id}/parent", tagHandler.SetTagParentHandler)
 }
 
 // setupArtistRelationshipRoutes configures artist relationship and similar artist endpoints.

--- a/backend/internal/errors/tag.go
+++ b/backend/internal/errors/tag.go
@@ -15,6 +15,8 @@ const (
 	CodeTagNameInvalid           = "TAG_NAME_INVALID"
 	CodeTagMergeInvalid          = "TAG_MERGE_INVALID"
 	CodeTagMergeAliasConflict    = "TAG_MERGE_ALIAS_CONFLICT"
+	CodeTagHierarchyCycle        = "TAG_HIERARCHY_CYCLE"
+	CodeTagHierarchyNotGenre     = "TAG_HIERARCHY_NOT_GENRE"
 )
 
 // TagError represents a tag-related error with additional context.
@@ -116,5 +118,25 @@ func ErrTagMergeAliasConflict(alias string, existingTagID uint) *TagError {
 	return &TagError{
 		Code:    CodeTagMergeAliasConflict,
 		Message: fmt.Sprintf("Cannot merge: alias '%s' already points to tag %d", alias, existingTagID),
+	}
+}
+
+// ErrTagHierarchyCycle is returned when setting a tag's parent would
+// create a cycle (direct self-parent, or proposed parent is a descendant
+// of the tag). Maps to HTTP 400.
+func ErrTagHierarchyCycle(detail string) *TagError {
+	return &TagError{
+		Code:    CodeTagHierarchyCycle,
+		Message: fmt.Sprintf("Cannot set parent: %s", detail),
+	}
+}
+
+// ErrTagHierarchyNotGenre is returned when the hierarchy editor is applied
+// to a non-genre tag (either as the tag being mutated or the proposed parent).
+// Maps to HTTP 400.
+func ErrTagHierarchyNotGenre(tagName, category string) *TagError {
+	return &TagError{
+		Code:    CodeTagHierarchyNotGenre,
+		Message: fmt.Sprintf("Tag hierarchy is genre-only; '%s' is category '%s'", tagName, category),
 	}
 }

--- a/backend/internal/services/catalog/tag_hierarchy.go
+++ b/backend/internal/services/catalog/tag_hierarchy.go
@@ -1,0 +1,287 @@
+package catalog
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"gorm.io/gorm"
+
+	apperrors "psychic-homily-backend/internal/errors"
+	"psychic-homily-backend/internal/models"
+)
+
+// AuditActionSetTagParent is the action name recorded when an admin sets a
+// tag's parent (or clears it). Matches the fire-and-forget direct-GORM
+// convention used by cleanup_service.go (PSY-308) and tag_merge.go (PSY-306).
+const AuditActionSetTagParent = "set_tag_parent"
+
+// maxHierarchyWalkDepth caps ancestor traversal so a malformed/legacy row
+// (already-looped parent chain) can't spin forever. The cycle-detection
+// logic rejects new cycles before they land, but we belt-and-suspenders
+// the walk itself for operational safety.
+const maxHierarchyWalkDepth = 64
+
+// GetTagAncestors walks the parent chain for a tag, from its direct parent
+// up to the root. Returns an empty slice (never nil) when the tag has no
+// parent. The tag itself is NOT included in the result. Ordering is
+// closest-ancestor-first (direct parent at index 0, root last).
+//
+// Bounded by maxHierarchyWalkDepth to protect against pre-existing looped
+// data. Cycle-detection on writes is the real guard; this is a safety net.
+func (s *TagService) GetTagAncestors(tagID uint) ([]*models.Tag, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	ancestors := make([]*models.Tag, 0, 4)
+	seen := map[uint]struct{}{tagID: {}}
+
+	var tag models.Tag
+	if err := s.db.First(&tag, tagID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, apperrors.ErrTagNotFound(tagID)
+		}
+		return nil, fmt.Errorf("failed to load tag: %w", err)
+	}
+
+	currentParentID := tag.ParentID
+	for depth := 0; depth < maxHierarchyWalkDepth; depth++ {
+		if currentParentID == nil {
+			break
+		}
+		if _, loop := seen[*currentParentID]; loop {
+			// Looped data on disk — stop walking and return what we have.
+			break
+		}
+
+		var parent models.Tag
+		if err := s.db.First(&parent, *currentParentID).Error; err != nil {
+			if err == gorm.ErrRecordNotFound {
+				// Orphaned parent_id pointing at a deleted row — stop walking.
+				break
+			}
+			return nil, fmt.Errorf("failed to load ancestor: %w", err)
+		}
+
+		seen[parent.ID] = struct{}{}
+		p := parent // copy so we can take &
+		ancestors = append(ancestors, &p)
+		currentParentID = parent.ParentID
+	}
+
+	return ancestors, nil
+}
+
+// GetTagChildren returns the direct children of a tag (one level down).
+// Ordered by usage_count DESC then name ASC for stable rendering. Returns
+// an empty slice (not nil) when the tag has no children.
+func (s *TagService) GetTagChildren(tagID uint) ([]*models.Tag, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var children []models.Tag
+	err := s.db.Where("parent_id = ?", tagID).
+		Order("usage_count DESC, name ASC").
+		Find(&children).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to load children: %w", err)
+	}
+
+	out := make([]*models.Tag, len(children))
+	for i := range children {
+		t := children[i]
+		out[i] = &t
+	}
+	return out, nil
+}
+
+// GetGenreHierarchy returns all genre tags as a flat list with parent_id
+// populated; the frontend builds the tree client-side. Flat shape keeps
+// the query trivial (one indexed scan) and avoids a recursive CTE. Ordered
+// so the UI can render consistently without client-side sorting.
+func (s *TagService) GetGenreHierarchy() ([]*models.Tag, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	var tags []models.Tag
+	err := s.db.Where("category = ?", models.TagCategoryGenre).
+		Order("name ASC").
+		Find(&tags).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to load genre hierarchy: %w", err)
+	}
+
+	out := make([]*models.Tag, len(tags))
+	for i := range tags {
+		t := tags[i]
+		out[i] = &t
+	}
+	return out, nil
+}
+
+// SetTagParent sets or clears the parent of a tag. Passing parentID=nil
+// clears the parent (makes the tag a root). Rejects:
+//   - tag not found
+//   - tag is not in the 'genre' category (hierarchy is genre-only)
+//   - parentID equals tagID (direct self-parent)
+//   - proposed parent is not found
+//   - proposed parent is not in the 'genre' category
+//   - proposed parent is a descendant of the tag (would create a cycle)
+//
+// Writes a fire-and-forget audit log entry on success, using the direct-GORM
+// pattern from cleanup_service.go (PSY-308). Errors from the audit write are
+// logged but never fail the parent operation.
+func (s *TagService) SetTagParent(tagID uint, parentID *uint, actorUserID uint) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	var tag models.Tag
+	if err := s.db.First(&tag, tagID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return apperrors.ErrTagNotFound(tagID)
+		}
+		return fmt.Errorf("failed to load tag: %w", err)
+	}
+
+	if tag.Category != models.TagCategoryGenre {
+		return apperrors.ErrTagHierarchyNotGenre(tag.Name, tag.Category)
+	}
+
+	if err := s.validateTagParent(&tag, parentID); err != nil {
+		return err
+	}
+
+	// Load parent name for the audit log BEFORE the update, so a race with
+	// a concurrent rename still records the name we resolved against.
+	var parentName string
+	if parentID != nil {
+		var p models.Tag
+		if err := s.db.First(&p, *parentID).Error; err == nil {
+			parentName = p.Name
+		}
+	}
+
+	// Use Select + Updates so GORM writes NULL when parentID is nil.
+	// A plain Updates map would skip the nil entry and leave parent_id unchanged.
+	if err := s.db.Model(&models.Tag{}).
+		Where("id = ?", tagID).
+		Select("parent_id").
+		Updates(map[string]interface{}{"parent_id": parentID}).Error; err != nil {
+		return fmt.Errorf("failed to set tag parent: %w", err)
+	}
+
+	go s.writeSetParentAuditLog(actorUserID, tag.ID, tag.Name, parentID, parentName)
+	return nil
+}
+
+// validateTagParent is the shared cycle-detection + category-guard helper.
+// It is called by SetTagParent and by UpdateTag when the caller supplies a
+// parent_id, so both entry points enforce the same rules.
+//
+// Pass tag = the tag being mutated. parentID = the proposed new parent
+// (nil means "clearing" and always passes). validateTagParent does NOT
+// verify tag.Category == genre — that's the caller's responsibility.
+// Callers routing through UpdateTag want to preserve the historical behavior
+// of not rejecting hierarchy writes on non-genre tags that already have a
+// parent_id — but they SHOULD reject setting a new one. See UpdateTag.
+func (s *TagService) validateTagParent(tag *models.Tag, parentID *uint) error {
+	if parentID == nil {
+		return nil
+	}
+	if *parentID == tag.ID {
+		return apperrors.ErrTagHierarchyCycle("cannot set a tag as its own parent")
+	}
+
+	var parent models.Tag
+	if err := s.db.First(&parent, *parentID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return apperrors.ErrTagNotFound(*parentID)
+		}
+		return fmt.Errorf("failed to load proposed parent: %w", err)
+	}
+	if parent.Category != models.TagCategoryGenre {
+		return apperrors.ErrTagHierarchyNotGenre(parent.Name, parent.Category)
+	}
+
+	// Walk the proposed parent's ancestor chain: if we ever see tag.ID,
+	// setting this parent would create a cycle. Walking ancestors (not
+	// descendants) is O(depth) regardless of subtree size.
+	seen := map[uint]struct{}{parent.ID: {}}
+	cursor := parent.ParentID
+	for depth := 0; depth < maxHierarchyWalkDepth; depth++ {
+		if cursor == nil {
+			return nil
+		}
+		if *cursor == tag.ID {
+			return apperrors.ErrTagHierarchyCycle(
+				fmt.Sprintf("'%s' is an ancestor of '%s'", tag.Name, parent.Name),
+			)
+		}
+		if _, loop := seen[*cursor]; loop {
+			// Pre-existing loop in the data; bail so we don't hang.
+			return nil
+		}
+		seen[*cursor] = struct{}{}
+
+		var anc models.Tag
+		if err := s.db.First(&anc, *cursor).Error; err != nil {
+			if err == gorm.ErrRecordNotFound {
+				return nil
+			}
+			return fmt.Errorf("failed to walk ancestors: %w", err)
+		}
+		cursor = anc.ParentID
+	}
+	return nil
+}
+
+// writeSetParentAuditLog records a parent-set (or parent-clear) in the audit
+// log via direct GORM, matching the pattern in cleanup_service.go (PSY-308).
+// Errors are logged but never bubble up — fire-and-forget.
+func (s *TagService) writeSetParentAuditLog(actorID, tagID uint, tagName string, parentID *uint, parentName string) {
+	if s.db == nil {
+		return
+	}
+
+	metadata := map[string]interface{}{
+		"tag_id":   tagID,
+		"tag_name": tagName,
+	}
+	if parentID != nil {
+		metadata["parent_id"] = *parentID
+		metadata["parent_name"] = parentName
+	} else {
+		metadata["parent_id"] = nil
+		metadata["parent_name"] = nil
+	}
+
+	metadataJSON, err := json.Marshal(metadata)
+	if err != nil {
+		slog.Default().Error("failed to marshal set_tag_parent audit metadata", "error", err)
+		return
+	}
+
+	raw := json.RawMessage(metadataJSON)
+	var actor *uint
+	if actorID > 0 {
+		actor = &actorID
+	}
+
+	entry := models.AuditLog{
+		ActorID:    actor,
+		Action:     AuditActionSetTagParent,
+		EntityType: "tag",
+		EntityID:   tagID,
+		Metadata:   &raw,
+		CreatedAt:  time.Now().UTC(),
+	}
+
+	if err := s.db.Create(&entry).Error; err != nil {
+		slog.Default().Error("failed to write set_tag_parent audit log", "error", err)
+	}
+}

--- a/backend/internal/services/catalog/tag_hierarchy_test.go
+++ b/backend/internal/services/catalog/tag_hierarchy_test.go
@@ -1,0 +1,434 @@
+package catalog
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"gorm.io/gorm"
+
+	apperrors "psychic-homily-backend/internal/errors"
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/testutil"
+)
+
+type TagHierarchyIntegrationSuite struct {
+	suite.Suite
+	testDB     *testutil.TestDatabase
+	db         *gorm.DB
+	tagService *TagService
+}
+
+func (s *TagHierarchyIntegrationSuite) SetupSuite() {
+	s.testDB = testutil.SetupTestPostgres(s.T())
+	s.db = s.testDB.DB
+	s.tagService = NewTagService(s.db)
+}
+
+func (s *TagHierarchyIntegrationSuite) TearDownSuite() {
+	s.testDB.Cleanup()
+}
+
+func (s *TagHierarchyIntegrationSuite) SetupTest() {
+	sqlDB, _ := s.db.DB()
+	_, _ = sqlDB.Exec("DELETE FROM audit_logs")
+	_, _ = sqlDB.Exec("DELETE FROM tag_votes")
+	_, _ = sqlDB.Exec("DELETE FROM entity_tags")
+	_, _ = sqlDB.Exec("DELETE FROM tag_aliases")
+	_, _ = sqlDB.Exec("DELETE FROM tags")
+	_, _ = sqlDB.Exec("DELETE FROM users")
+}
+
+func TestTagHierarchyIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	suite.Run(t, new(TagHierarchyIntegrationSuite))
+}
+
+// ──────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────
+
+func (s *TagHierarchyIntegrationSuite) createUser(name string) *models.User {
+	email := fmt.Sprintf("%s-%d@test.com", name, time.Now().UnixNano())
+	u := &models.User{Email: &email, FirstName: &name, IsActive: true, EmailVerified: true}
+	s.Require().NoError(s.db.Create(u).Error)
+	return u
+}
+
+// createGenre creates a genre tag (no parent).
+func (s *TagHierarchyIntegrationSuite) createGenre(name string) *models.Tag {
+	tag, err := s.tagService.CreateTag(name, nil, nil, models.TagCategoryGenre, false, nil)
+	s.Require().NoError(err)
+	return tag
+}
+
+// createTagWithCategory creates a tag in a specific category (for rejection tests).
+func (s *TagHierarchyIntegrationSuite) createTagWithCategory(name, category string) *models.Tag {
+	tag, err := s.tagService.CreateTag(name, nil, nil, category, false, nil)
+	s.Require().NoError(err)
+	return tag
+}
+
+// ──────────────────────────────────────────────
+// Happy path: set and clear
+// ──────────────────────────────────────────────
+
+func (s *TagHierarchyIntegrationSuite) TestSetTagParent_Simple() {
+	admin := s.createUser("admin")
+	parent := s.createGenre("post-punk")
+	child := s.createGenre("shoegaze")
+
+	err := s.tagService.SetTagParent(child.ID, &parent.ID, admin.ID)
+	s.Require().NoError(err)
+
+	var reloaded models.Tag
+	s.Require().NoError(s.db.First(&reloaded, child.ID).Error)
+	s.Require().NotNil(reloaded.ParentID)
+	s.Equal(parent.ID, *reloaded.ParentID)
+}
+
+func (s *TagHierarchyIntegrationSuite) TestSetTagParent_Clear() {
+	admin := s.createUser("admin")
+	parent := s.createGenre("post-punk")
+	child := s.createGenre("shoegaze")
+
+	// Set first, then clear.
+	s.Require().NoError(s.tagService.SetTagParent(child.ID, &parent.ID, admin.ID))
+	s.Require().NoError(s.tagService.SetTagParent(child.ID, nil, admin.ID))
+
+	var reloaded models.Tag
+	s.Require().NoError(s.db.First(&reloaded, child.ID).Error)
+	s.Nil(reloaded.ParentID, "parent_id should be NULL after clearing")
+}
+
+// ──────────────────────────────────────────────
+// Cycle detection
+// ──────────────────────────────────────────────
+
+// Direct self-parent: tag cannot be its own parent.
+func (s *TagHierarchyIntegrationSuite) TestSetTagParent_SelfParent_Rejected() {
+	admin := s.createUser("admin")
+	tag := s.createGenre("shoegaze")
+
+	err := s.tagService.SetTagParent(tag.ID, &tag.ID, admin.ID)
+	s.Require().Error(err)
+	var tagErr *apperrors.TagError
+	s.Require().ErrorAs(err, &tagErr)
+	s.Equal(apperrors.CodeTagHierarchyCycle, tagErr.Code)
+}
+
+// Depth-2 cycle: A is the parent of B, then try setting A's parent = B.
+func (s *TagHierarchyIntegrationSuite) TestSetTagParent_Cycle_Depth2_Rejected() {
+	admin := s.createUser("admin")
+	a := s.createGenre("a")
+	b := s.createGenre("b")
+
+	// A → B (B's parent is A)
+	s.Require().NoError(s.tagService.SetTagParent(b.ID, &a.ID, admin.ID))
+
+	// Try: A's parent = B (would create cycle A → B → A)
+	err := s.tagService.SetTagParent(a.ID, &b.ID, admin.ID)
+	s.Require().Error(err)
+	var tagErr *apperrors.TagError
+	s.Require().ErrorAs(err, &tagErr)
+	s.Equal(apperrors.CodeTagHierarchyCycle, tagErr.Code)
+}
+
+// Depth-3 cycle: A → B → C, then try setting A's parent = C.
+func (s *TagHierarchyIntegrationSuite) TestSetTagParent_Cycle_Depth3_Rejected() {
+	admin := s.createUser("admin")
+	a := s.createGenre("a")
+	b := s.createGenre("b")
+	c := s.createGenre("c")
+
+	s.Require().NoError(s.tagService.SetTagParent(b.ID, &a.ID, admin.ID))
+	s.Require().NoError(s.tagService.SetTagParent(c.ID, &b.ID, admin.ID))
+
+	// A's parent = C would make: C → B → A → C
+	err := s.tagService.SetTagParent(a.ID, &c.ID, admin.ID)
+	s.Require().Error(err)
+	var tagErr *apperrors.TagError
+	s.Require().ErrorAs(err, &tagErr)
+	s.Equal(apperrors.CodeTagHierarchyCycle, tagErr.Code)
+}
+
+// Depth-4 cycle: A → B → C → D, then try setting A's parent = D.
+func (s *TagHierarchyIntegrationSuite) TestSetTagParent_Cycle_Depth4_Rejected() {
+	admin := s.createUser("admin")
+	a := s.createGenre("a")
+	b := s.createGenre("b")
+	c := s.createGenre("c")
+	d := s.createGenre("d")
+
+	s.Require().NoError(s.tagService.SetTagParent(b.ID, &a.ID, admin.ID))
+	s.Require().NoError(s.tagService.SetTagParent(c.ID, &b.ID, admin.ID))
+	s.Require().NoError(s.tagService.SetTagParent(d.ID, &c.ID, admin.ID))
+
+	err := s.tagService.SetTagParent(a.ID, &d.ID, admin.ID)
+	s.Require().Error(err)
+	var tagErr *apperrors.TagError
+	s.Require().ErrorAs(err, &tagErr)
+	s.Equal(apperrors.CodeTagHierarchyCycle, tagErr.Code)
+}
+
+// Sibling-ish: A → B and A → C both OK. Setting C's parent = B (uncle) is fine,
+// and NOT a cycle — verifies we don't over-reject.
+func (s *TagHierarchyIntegrationSuite) TestSetTagParent_SiblingMove_Allowed() {
+	admin := s.createUser("admin")
+	a := s.createGenre("a")
+	b := s.createGenre("b")
+	c := s.createGenre("c")
+
+	s.Require().NoError(s.tagService.SetTagParent(b.ID, &a.ID, admin.ID))
+	s.Require().NoError(s.tagService.SetTagParent(c.ID, &a.ID, admin.ID))
+
+	// C moves under B: A → B → C. No cycle.
+	err := s.tagService.SetTagParent(c.ID, &b.ID, admin.ID)
+	s.Require().NoError(err)
+}
+
+// ──────────────────────────────────────────────
+// Category enforcement
+// ──────────────────────────────────────────────
+
+// Tag is not a genre → reject.
+func (s *TagHierarchyIntegrationSuite) TestSetTagParent_NonGenreSource_Rejected() {
+	admin := s.createUser("admin")
+	parent := s.createGenre("post-punk")
+	locale := s.createTagWithCategory("arizona", models.TagCategoryLocale)
+
+	err := s.tagService.SetTagParent(locale.ID, &parent.ID, admin.ID)
+	s.Require().Error(err)
+	var tagErr *apperrors.TagError
+	s.Require().ErrorAs(err, &tagErr)
+	s.Equal(apperrors.CodeTagHierarchyNotGenre, tagErr.Code)
+}
+
+// Proposed parent is not a genre → reject.
+func (s *TagHierarchyIntegrationSuite) TestSetTagParent_NonGenreParent_Rejected() {
+	admin := s.createUser("admin")
+	child := s.createGenre("shoegaze")
+	locale := s.createTagWithCategory("arizona", models.TagCategoryLocale)
+
+	err := s.tagService.SetTagParent(child.ID, &locale.ID, admin.ID)
+	s.Require().Error(err)
+	var tagErr *apperrors.TagError
+	s.Require().ErrorAs(err, &tagErr)
+	s.Equal(apperrors.CodeTagHierarchyNotGenre, tagErr.Code)
+}
+
+// ──────────────────────────────────────────────
+// Not found
+// ──────────────────────────────────────────────
+
+func (s *TagHierarchyIntegrationSuite) TestSetTagParent_TagNotFound() {
+	admin := s.createUser("admin")
+	parent := s.createGenre("post-punk")
+
+	err := s.tagService.SetTagParent(99999, &parent.ID, admin.ID)
+	s.Require().Error(err)
+	var tagErr *apperrors.TagError
+	s.Require().ErrorAs(err, &tagErr)
+	s.Equal(apperrors.CodeTagNotFound, tagErr.Code)
+}
+
+func (s *TagHierarchyIntegrationSuite) TestSetTagParent_ParentNotFound() {
+	admin := s.createUser("admin")
+	child := s.createGenre("shoegaze")
+
+	err := s.tagService.SetTagParent(child.ID, uintPtr(99999), admin.ID)
+	s.Require().Error(err)
+	var tagErr *apperrors.TagError
+	s.Require().ErrorAs(err, &tagErr)
+	s.Equal(apperrors.CodeTagNotFound, tagErr.Code)
+}
+
+// ──────────────────────────────────────────────
+// GetGenreHierarchy / GetTagAncestors / GetTagChildren
+// ──────────────────────────────────────────────
+
+func (s *TagHierarchyIntegrationSuite) TestGetGenreHierarchy_OnlyGenres() {
+	admin := s.createUser("admin")
+	g1 := s.createGenre("rock")
+	g2 := s.createGenre("post-rock")
+	// Non-genre tags must not appear.
+	_ = s.createTagWithCategory("arizona", models.TagCategoryLocale)
+	_ = s.createTagWithCategory("misc", models.TagCategoryOther)
+
+	// Wire up a parent link.
+	s.Require().NoError(s.tagService.SetTagParent(g2.ID, &g1.ID, admin.ID))
+
+	tags, err := s.tagService.GetGenreHierarchy()
+	s.Require().NoError(err)
+	s.Len(tags, 2, "hierarchy should include only genre tags")
+
+	byName := map[string]*models.Tag{}
+	for _, t := range tags {
+		byName[t.Name] = t
+	}
+	s.Require().Contains(byName, "rock")
+	s.Require().Contains(byName, "post-rock")
+	s.Nil(byName["rock"].ParentID)
+	s.Require().NotNil(byName["post-rock"].ParentID)
+	s.Equal(g1.ID, *byName["post-rock"].ParentID)
+}
+
+func (s *TagHierarchyIntegrationSuite) TestGetTagAncestors_WalksChain() {
+	admin := s.createUser("admin")
+	a := s.createGenre("a")
+	b := s.createGenre("b")
+	c := s.createGenre("c")
+	s.Require().NoError(s.tagService.SetTagParent(b.ID, &a.ID, admin.ID))
+	s.Require().NoError(s.tagService.SetTagParent(c.ID, &b.ID, admin.ID))
+
+	ancestors, err := s.tagService.GetTagAncestors(c.ID)
+	s.Require().NoError(err)
+	s.Require().Len(ancestors, 2)
+	// Closest-first ordering.
+	s.Equal(b.ID, ancestors[0].ID)
+	s.Equal(a.ID, ancestors[1].ID)
+}
+
+func (s *TagHierarchyIntegrationSuite) TestGetTagAncestors_Root_Empty() {
+	root := s.createGenre("rock")
+	ancestors, err := s.tagService.GetTagAncestors(root.ID)
+	s.Require().NoError(err)
+	s.Empty(ancestors)
+}
+
+func (s *TagHierarchyIntegrationSuite) TestGetTagChildren() {
+	admin := s.createUser("admin")
+	parent := s.createGenre("rock")
+	c1 := s.createGenre("post-rock")
+	c2 := s.createGenre("math-rock")
+	_ = s.createGenre("orphan") // no parent — shouldn't appear
+
+	s.Require().NoError(s.tagService.SetTagParent(c1.ID, &parent.ID, admin.ID))
+	s.Require().NoError(s.tagService.SetTagParent(c2.ID, &parent.ID, admin.ID))
+
+	children, err := s.tagService.GetTagChildren(parent.ID)
+	s.Require().NoError(err)
+	s.Require().Len(children, 2)
+	names := map[string]bool{}
+	for _, c := range children {
+		names[c.Name] = true
+	}
+	s.True(names["post-rock"])
+	s.True(names["math-rock"])
+}
+
+// ──────────────────────────────────────────────
+// UpdateTag parent-path: also protected
+// ──────────────────────────────────────────────
+
+// UpdateTag is the legacy CRUD entry point. Setting parent_id via UpdateTag
+// must go through the same cycle check as SetTagParent.
+func (s *TagHierarchyIntegrationSuite) TestUpdateTag_SetsParent_WithCycleGuard() {
+	admin := s.createUser("admin")
+	a := s.createGenre("a")
+	b := s.createGenre("b")
+	// A → B via UpdateTag.
+	_, err := s.tagService.UpdateTag(b.ID, nil, nil, &a.ID, nil, nil)
+	s.Require().NoError(err)
+
+	// Now B → A via UpdateTag would be a cycle.
+	_, err = s.tagService.UpdateTag(a.ID, nil, nil, &b.ID, nil, nil)
+	s.Require().Error(err)
+	var tagErr *apperrors.TagError
+	s.Require().ErrorAs(err, &tagErr)
+	s.Equal(apperrors.CodeTagHierarchyCycle, tagErr.Code)
+	_ = admin
+}
+
+// UpdateTag on a non-genre tag that tries to set parent_id should be rejected
+// too — the hierarchy is genre-only, end-to-end.
+func (s *TagHierarchyIntegrationSuite) TestUpdateTag_NonGenreWithParentID_Rejected() {
+	admin := s.createUser("admin")
+	genre := s.createGenre("rock")
+	locale := s.createTagWithCategory("arizona", models.TagCategoryLocale)
+
+	_, err := s.tagService.UpdateTag(locale.ID, nil, nil, &genre.ID, nil, nil)
+	s.Require().Error(err)
+	var tagErr *apperrors.TagError
+	s.Require().ErrorAs(err, &tagErr)
+	s.Equal(apperrors.CodeTagHierarchyNotGenre, tagErr.Code)
+	_ = admin
+}
+
+// ──────────────────────────────────────────────
+// Audit log
+// ──────────────────────────────────────────────
+
+func (s *TagHierarchyIntegrationSuite) TestSetTagParent_WritesAuditLog() {
+	admin := s.createUser("admin")
+	parent := s.createGenre("post-punk")
+	child := s.createGenre("shoegaze")
+
+	err := s.tagService.SetTagParent(child.ID, &parent.ID, admin.ID)
+	s.Require().NoError(err)
+
+	// Fire-and-forget audit log — poll briefly so the goroutine wins.
+	var log models.AuditLog
+	for i := 0; i < 40; i++ {
+		err := s.db.Where("action = ? AND entity_id = ?", AuditActionSetTagParent, child.ID).First(&log).Error
+		if err == nil {
+			break
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	s.Require().NotZero(log.ID, "audit log was not written in time")
+	s.Equal("tag", log.EntityType)
+	s.Equal(child.ID, log.EntityID)
+	s.Require().NotNil(log.ActorID)
+	s.Equal(admin.ID, *log.ActorID)
+
+	s.Require().NotNil(log.Metadata)
+	var meta map[string]interface{}
+	s.Require().NoError(json.Unmarshal(*log.Metadata, &meta))
+	s.Equal(float64(child.ID), meta["tag_id"])
+	s.Equal("shoegaze", meta["tag_name"])
+	s.Equal(float64(parent.ID), meta["parent_id"])
+	s.Equal("post-punk", meta["parent_name"])
+}
+
+func (s *TagHierarchyIntegrationSuite) TestSetTagParent_ClearParent_AuditReflectsNull() {
+	admin := s.createUser("admin")
+	parent := s.createGenre("post-punk")
+	child := s.createGenre("shoegaze")
+
+	s.Require().NoError(s.tagService.SetTagParent(child.ID, &parent.ID, admin.ID))
+	// Poll until the first audit log arrives so we don't race the clear below.
+	for i := 0; i < 40; i++ {
+		var count int64
+		s.db.Model(&models.AuditLog{}).
+			Where("action = ? AND entity_id = ?", AuditActionSetTagParent, child.ID).
+			Count(&count)
+		if count > 0 {
+			break
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+
+	s.Require().NoError(s.tagService.SetTagParent(child.ID, nil, admin.ID))
+
+	// Wait for the second audit entry (the clear).
+	var logs []models.AuditLog
+	for i := 0; i < 40; i++ {
+		s.db.Where("action = ? AND entity_id = ?", AuditActionSetTagParent, child.ID).
+			Order("id ASC").Find(&logs)
+		if len(logs) >= 2 {
+			break
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	s.Require().GreaterOrEqual(len(logs), 2)
+
+	var meta map[string]interface{}
+	s.Require().NoError(json.Unmarshal(*logs[len(logs)-1].Metadata, &meta))
+	s.Nil(meta["parent_id"], "cleared parent should serialize as JSON null")
+	s.Nil(meta["parent_name"])
+}

--- a/backend/internal/services/catalog/tag_service.go
+++ b/backend/internal/services/catalog/tag_service.go
@@ -190,6 +190,15 @@ func (s *TagService) UpdateTag(tagID uint, name *string, description *string, pa
 		updates["description"] = *description
 	}
 	if parentID != nil {
+		// Hierarchy edits go through the same cycle + category guard that
+		// SetTagParent uses (PSY-311). Keep the check here so any caller
+		// that sets parent_id via generic update can't bypass validation.
+		if tag.Category != models.TagCategoryGenre {
+			return nil, apperrors.ErrTagHierarchyNotGenre(tag.Name, tag.Category)
+		}
+		if err := s.validateTagParent(&tag, parentID); err != nil {
+			return nil, err
+		}
 		updates["parent_id"] = *parentID
 	}
 	if category != nil {

--- a/backend/internal/services/contracts/tag.go
+++ b/backend/internal/services/contracts/tag.go
@@ -239,6 +239,12 @@ type TagServiceInterface interface {
 	MergeTags(sourceID, targetID uint, actorUserID uint) (*MergeTagsResult, error)
 	PreviewMergeTags(sourceID, targetID uint) (*MergeTagsPreview, error)
 
+	// Hierarchy (genre-only)
+	GetTagAncestors(tagID uint) ([]*models.Tag, error)
+	GetTagChildren(tagID uint) ([]*models.Tag, error)
+	GetGenreHierarchy() ([]*models.Tag, error)
+	SetTagParent(tagID uint, parentID *uint, actorUserID uint) error
+
 	// Tag entities
 	GetTagEntities(tagID uint, entityType string, limit, offset int) ([]TaggedEntityItem, int64, error)
 

--- a/frontend/features/tags/admin/TagHierarchyEditor.test.tsx
+++ b/frontend/features/tags/admin/TagHierarchyEditor.test.tsx
@@ -1,0 +1,349 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
+import { renderWithProviders } from '@/test/utils'
+import { buildHierarchyTree } from './TagHierarchyEditor'
+import type { GenreHierarchyTag } from '../types'
+
+// ──────────────────────────────────────────────
+// Hoisted hook stubs so individual tests can drive them.
+// ──────────────────────────────────────────────
+
+const mockGenreHierarchy = vi.fn()
+const mockSetTagParentMutate = vi.fn()
+const mockUseSetTagParent = vi.fn(() => ({
+  mutate: mockSetTagParentMutate,
+  isPending: false,
+}))
+const mockUseSearchTags = vi.fn(() => ({
+  data: { tags: [] },
+  isLoading: false,
+}))
+
+vi.mock('./useAdminTags', () => ({
+  useGenreHierarchy: () => mockGenreHierarchy(),
+  useSetTagParent: () => mockUseSetTagParent(),
+}))
+
+vi.mock('../hooks', () => ({
+  useSearchTags: () => mockUseSearchTags(),
+}))
+
+// Import after mocks so the component sees the stubs.
+import { TagHierarchyEditor } from './TagHierarchyEditor'
+
+function tag(overrides: Partial<GenreHierarchyTag>): GenreHierarchyTag {
+  return {
+    id: 1,
+    name: 'rock',
+    slug: 'rock',
+    parent_id: null,
+    usage_count: 0,
+    is_official: false,
+    ...overrides,
+  }
+}
+
+// ──────────────────────────────────────────────
+// Pure tree assembly
+// ──────────────────────────────────────────────
+
+describe('buildHierarchyTree', () => {
+  it('returns a flat list of roots when no parent_id is set', () => {
+    const tree = buildHierarchyTree([
+      tag({ id: 1, name: 'rock' }),
+      tag({ id: 2, name: 'post-punk' }),
+    ])
+    expect(tree).toHaveLength(2)
+    // Alphabetical ordering.
+    expect(tree[0].name).toBe('post-punk')
+    expect(tree[1].name).toBe('rock')
+    expect(tree[0].depth).toBe(0)
+    expect(tree[0].children).toEqual([])
+  })
+
+  it('nests children under their parent with incremented depth', () => {
+    const tree = buildHierarchyTree([
+      tag({ id: 1, name: 'post-punk' }),
+      tag({ id: 2, name: 'shoegaze', parent_id: 1 }),
+      tag({ id: 3, name: 'nu-gaze', parent_id: 2 }),
+    ])
+    expect(tree).toHaveLength(1)
+    expect(tree[0].name).toBe('post-punk')
+    expect(tree[0].depth).toBe(0)
+    expect(tree[0].children).toHaveLength(1)
+    expect(tree[0].children[0].name).toBe('shoegaze')
+    expect(tree[0].children[0].depth).toBe(1)
+    expect(tree[0].children[0].children[0].name).toBe('nu-gaze')
+    expect(tree[0].children[0].children[0].depth).toBe(2)
+  })
+
+  it('promotes orphans to roots when parent_id points at a missing tag', () => {
+    const tree = buildHierarchyTree([
+      tag({ id: 1, name: 'rock' }),
+      // parent_id=99 is not in the list.
+      tag({ id: 2, name: 'orphan', parent_id: 99 }),
+    ])
+    expect(tree).toHaveLength(2)
+    expect(tree.map(t => t.name).sort()).toEqual(['orphan', 'rock'])
+  })
+})
+
+// ──────────────────────────────────────────────
+// Component rendering
+// ──────────────────────────────────────────────
+
+describe('TagHierarchyEditor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseSetTagParent.mockReturnValue({
+      mutate: mockSetTagParentMutate,
+      isPending: false,
+    })
+    mockUseSearchTags.mockReturnValue({ data: { tags: [] }, isLoading: false })
+  })
+
+  it('renders a tree of genre tags with indentation per depth', () => {
+    mockGenreHierarchy.mockReturnValue({
+      data: {
+        tags: [
+          tag({ id: 1, name: 'post-punk' }),
+          tag({ id: 2, name: 'shoegaze', parent_id: 1 }),
+          tag({ id: 3, name: 'rock' }),
+        ],
+      },
+      isLoading: false,
+      error: null,
+    })
+
+    renderWithProviders(<TagHierarchyEditor />)
+
+    // The container description mentions "post-punk" in an example, so scope
+    // the assertions to the tree itself via data-testid.
+    const tree = screen.getByTestId('hierarchy-tree')
+    const rows = screen.getAllByTestId('hierarchy-row')
+    expect(rows).toHaveLength(3)
+
+    const rowById = (id: number) =>
+      rows.find(r => r.getAttribute('data-tag-id') === String(id))!
+
+    expect(rowById(1)).toHaveTextContent('post-punk')
+    expect(rowById(2)).toHaveTextContent('shoegaze')
+    expect(rowById(3)).toHaveTextContent('rock')
+    // Child has indentation; root does not.
+    expect(rowById(2)).toHaveStyle({ paddingLeft: '28px' })
+    expect(rowById(1)).toHaveStyle({ paddingLeft: '8px' })
+    expect(tree).toBeInTheDocument()
+  })
+
+  it('opens the parent picker when the edit icon is clicked', async () => {
+    mockGenreHierarchy.mockReturnValue({
+      data: {
+        tags: [
+          tag({ id: 1, name: 'post-punk' }),
+          tag({ id: 2, name: 'shoegaze', parent_id: 1 }),
+        ],
+      },
+      isLoading: false,
+      error: null,
+    })
+
+    renderWithProviders(<TagHierarchyEditor />)
+
+    const editButtons = screen.getAllByRole('button', {
+      name: /edit parent of/i,
+    })
+    fireEvent.click(editButtons[0])
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Set parent for/i)
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('fires the set-parent mutation when a candidate is selected and confirmed', async () => {
+    mockGenreHierarchy.mockReturnValue({
+      data: {
+        tags: [
+          tag({ id: 1, name: 'post-punk' }),
+          tag({ id: 2, name: 'shoegaze' }),
+          tag({ id: 3, name: 'indie' }),
+        ],
+      },
+      isLoading: false,
+      error: null,
+    })
+
+    // Search returns 'post-punk' as a candidate.
+    mockUseSearchTags.mockReturnValue({
+      data: {
+        tags: [
+          {
+            id: 1,
+            name: 'post-punk',
+            slug: 'post-punk',
+            category: 'genre',
+            is_official: false,
+            usage_count: 5,
+            created_at: '2025-01-01T00:00:00Z',
+          },
+        ],
+      },
+      isLoading: false,
+    })
+
+    renderWithProviders(<TagHierarchyEditor />)
+
+    // Open the picker for 'shoegaze'.
+    const editButton = screen.getByRole('button', {
+      name: /edit parent of shoegaze/i,
+    })
+    fireEvent.click(editButton)
+
+    // Type enough to flip debounced query on.
+    const searchBox = await screen.findByPlaceholderText(/Search genre tags/i)
+    fireEvent.change(searchBox, { target: { value: 'post' } })
+
+    // Candidates list has an aria-label; scope findByText to it so we don't
+    // match the "post-punk" that appears in the tree under the dialog.
+    const candidateList = await screen.findByRole('list', {
+      name: /candidate parent tags/i,
+    })
+    const candidate = await screen.findByRole('button', {
+      name: /post-punk/i,
+    })
+    expect(candidateList).toContainElement(candidate)
+    fireEvent.click(candidate)
+
+    const saveBtn = screen.getByRole('button', { name: /^Save$/i })
+    fireEvent.click(saveBtn)
+
+    await waitFor(() => {
+      expect(mockSetTagParentMutate).toHaveBeenCalledWith(
+        { tagId: 2, parentId: 1 },
+        expect.any(Object)
+      )
+    })
+  })
+
+  it('surfaces a backend error message (e.g. cycle detection) in the dialog', async () => {
+    // Two unrelated genre tags, so the pre-filter doesn't hide either
+    // candidate. The error comes from the mutation itself (simulating
+    // backend cycle detection even though this particular setup wouldn't
+    // actually create a cycle — the point is that the UI surfaces whatever
+    // error the backend returns).
+    mockGenreHierarchy.mockReturnValue({
+      data: {
+        tags: [tag({ id: 1, name: 'alpha' }), tag({ id: 2, name: 'beta' })],
+      },
+      isLoading: false,
+      error: null,
+    })
+
+    mockUseSearchTags.mockReturnValue({
+      data: {
+        tags: [
+          {
+            id: 2,
+            name: 'beta',
+            slug: 'beta',
+            category: 'genre',
+            is_official: false,
+            usage_count: 1,
+            created_at: '2025-01-01T00:00:00Z',
+          },
+        ],
+      },
+      isLoading: false,
+    })
+
+    // Simulate the backend returning a cycle-detection error.
+    mockSetTagParentMutate.mockImplementation((_vars, opts) => {
+      opts?.onError?.(
+        new Error("Cannot set parent: 'alpha' is an ancestor of 'beta'")
+      )
+    })
+
+    renderWithProviders(<TagHierarchyEditor />)
+
+    const editButton = screen.getByRole('button', {
+      name: /edit parent of alpha/i,
+    })
+    fireEvent.click(editButton)
+
+    const searchBox = await screen.findByPlaceholderText(/Search genre tags/i)
+    fireEvent.change(searchBox, { target: { value: 'beta' } })
+
+    const candidate = await screen.findByRole('button', {
+      name: /beta/i,
+    })
+    fireEvent.click(candidate)
+
+    const saveBtn = screen.getByRole('button', { name: /^Save$/i })
+    fireEvent.click(saveBtn)
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        /is an ancestor of/i
+      )
+    })
+  })
+
+  it('clears the parent when the Clear parent checkbox is used', async () => {
+    mockGenreHierarchy.mockReturnValue({
+      data: {
+        tags: [
+          tag({ id: 1, name: 'post-punk' }),
+          tag({ id: 2, name: 'shoegaze', parent_id: 1 }),
+        ],
+      },
+      isLoading: false,
+      error: null,
+    })
+
+    renderWithProviders(<TagHierarchyEditor />)
+
+    const editButton = screen.getByRole('button', {
+      name: /edit parent of shoegaze/i,
+    })
+    fireEvent.click(editButton)
+
+    const clearCheckbox = await screen.findByLabelText(
+      /Clear parent \(make this tag a root\)/i
+    )
+    fireEvent.click(clearCheckbox)
+
+    const saveBtn = screen.getByRole('button', { name: /^Save$/i })
+    fireEvent.click(saveBtn)
+
+    await waitFor(() => {
+      expect(mockSetTagParentMutate).toHaveBeenCalledWith(
+        { tagId: 2, parentId: null },
+        expect.any(Object)
+      )
+    })
+  })
+
+  it('shows an empty state when there are no genre tags', () => {
+    mockGenreHierarchy.mockReturnValue({
+      data: { tags: [] },
+      isLoading: false,
+      error: null,
+    })
+
+    renderWithProviders(<TagHierarchyEditor />)
+    expect(screen.getByText(/No Genre Tags/i)).toBeInTheDocument()
+  })
+
+  it('surfaces a load error', () => {
+    mockGenreHierarchy.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('boom'),
+    })
+
+    renderWithProviders(<TagHierarchyEditor />)
+    expect(screen.getByRole('alert')).toHaveTextContent(/boom/)
+  })
+})

--- a/frontend/features/tags/admin/TagHierarchyEditor.tsx
+++ b/frontend/features/tags/admin/TagHierarchyEditor.tsx
@@ -1,0 +1,562 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  ChevronDown,
+  ChevronRight,
+  Hash,
+  Loader2,
+  Pencil,
+  Search,
+  Network,
+  X,
+} from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Badge } from '@/components/ui/badge'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog'
+import { cn } from '@/lib/utils'
+import { useSearchTags } from '../hooks'
+import { useGenreHierarchy, useSetTagParent } from './useAdminTags'
+import type { GenreHierarchyNode, GenreHierarchyTag, TagListItem } from '../types'
+
+// ──────────────────────────────────────────────
+// Tree assembly
+// ──────────────────────────────────────────────
+
+/**
+ * Build a forest of GenreHierarchyNodes from the backend flat list.
+ * Orphaned nodes (parent_id points to a tag not in the list — shouldn't
+ * happen but guard anyway) are promoted to roots.
+ */
+export function buildHierarchyTree(tags: GenreHierarchyTag[]): GenreHierarchyNode[] {
+  const byId = new Map<number, GenreHierarchyNode>()
+  for (const t of tags) {
+    byId.set(t.id, { ...t, depth: 0, children: [] })
+  }
+  const roots: GenreHierarchyNode[] = []
+  for (const node of byId.values()) {
+    if (node.parent_id != null && byId.has(node.parent_id)) {
+      const parent = byId.get(node.parent_id)!
+      parent.children.push(node)
+    } else {
+      roots.push(node)
+    }
+  }
+  // Stamp depth by BFS so children of deeply-nested roots still indent right.
+  const assignDepth = (node: GenreHierarchyNode, depth: number) => {
+    node.depth = depth
+    node.children.sort((a, b) =>
+      a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
+    )
+    for (const c of node.children) assignDepth(c, depth + 1)
+  }
+  roots.sort((a, b) =>
+    a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
+  )
+  for (const r of roots) assignDepth(r, 0)
+  return roots
+}
+
+/**
+ * Collect the IDs of a node and every descendant — used to exclude a tag's
+ * subtree from the parent picker (you can't parent a tag to one of its own
+ * descendants). Backend rejects this too; the pre-filter is UX polish.
+ */
+function collectSubtreeIds(node: GenreHierarchyNode, acc: Set<number>) {
+  acc.add(node.id)
+  for (const c of node.children) collectSubtreeIds(c, acc)
+}
+
+function findNodeById(
+  nodes: GenreHierarchyNode[],
+  id: number
+): GenreHierarchyNode | null {
+  for (const n of nodes) {
+    if (n.id === id) return n
+    const found = findNodeById(n.children, id)
+    if (found) return found
+  }
+  return null
+}
+
+// ──────────────────────────────────────────────
+// Parent picker dialog
+// ──────────────────────────────────────────────
+
+interface ParentPickerDialogProps {
+  open: boolean
+  tagId: number | null
+  tagName: string
+  currentParentId: number | null
+  /** IDs to exclude from candidates — the tag itself and its descendants. */
+  excludedIds: Set<number>
+  onClose: () => void
+}
+
+function ParentPickerDialog({
+  open,
+  tagId,
+  tagName,
+  currentParentId,
+  excludedIds,
+  onClose,
+}: ParentPickerDialogProps) {
+  const [search, setSearch] = useState('')
+  const [debounced, setDebounced] = useState('')
+  const [selected, setSelected] = useState<TagListItem | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [wantsClear, setWantsClear] = useState(false)
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(search), 200)
+    return () => clearTimeout(t)
+  }, [search])
+
+  useEffect(() => {
+    if (!open) return
+    setSearch('')
+    setDebounced('')
+    setSelected(null)
+    setError(null)
+    setWantsClear(false)
+  }, [open, tagId])
+
+  // Genre-only search — hierarchy is genre-only end-to-end.
+  const { data: searchData, isLoading: searching } = useSearchTags(
+    debounced,
+    15,
+    'genre'
+  )
+
+  const candidates = useMemo(() => {
+    const results = searchData?.tags ?? []
+    return results.filter(t => !excludedIds.has(t.id))
+  }, [searchData, excludedIds])
+
+  const setParent = useSetTagParent()
+
+  const handleConfirm = useCallback(() => {
+    if (!tagId) return
+    setError(null)
+    const parentId = wantsClear ? null : selected?.id ?? null
+    if (!wantsClear && parentId === currentParentId) {
+      // No-op; just close to avoid a pointless network round-trip.
+      onClose()
+      return
+    }
+    setParent.mutate(
+      { tagId, parentId },
+      {
+        onSuccess: () => onClose(),
+        onError: err => {
+          setError(err instanceof Error ? err.message : 'Failed to set parent')
+        },
+      }
+    )
+  }, [tagId, wantsClear, selected, currentParentId, setParent, onClose])
+
+  const canConfirm = wantsClear
+    ? currentParentId !== null
+    : selected !== null && selected.id !== currentParentId
+
+  return (
+    <Dialog open={open} onOpenChange={o => !o && onClose()}>
+      <DialogContent className="max-w-md max-h-[85vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Set parent for &quot;{tagName}&quot;</DialogTitle>
+          <DialogDescription>
+            Search for a genre tag to use as the new parent, or clear the
+            parent to make this tag a root.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {error && (
+            <div
+              className="rounded-lg border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive"
+              role="alert"
+            >
+              {error}
+            </div>
+          )}
+
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              placeholder="Search genre tags..."
+              value={search}
+              onChange={e => {
+                setSearch(e.target.value)
+                setWantsClear(false)
+              }}
+              className="pl-9"
+              autoFocus
+              aria-label="Search for a parent tag"
+            />
+          </div>
+
+          {searching && debounced.length >= 2 && (
+            <div className="flex items-center justify-center py-3">
+              <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+            </div>
+          )}
+
+          {!searching && debounced.length >= 2 && candidates.length === 0 && (
+            <p className="text-sm text-muted-foreground">
+              No genre tags match that search (excluding this tag and its
+              descendants).
+            </p>
+          )}
+
+          {candidates.length > 0 && (
+            <ul
+              className="max-h-60 overflow-y-auto rounded-md border divide-y"
+              aria-label="Candidate parent tags"
+            >
+              {candidates.map(c => (
+                <li key={c.id}>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setSelected(c)
+                      setWantsClear(false)
+                    }}
+                    className={cn(
+                      'flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-muted/50 transition-colors',
+                      selected?.id === c.id && 'bg-muted'
+                    )}
+                  >
+                    <Hash className="h-3.5 w-3.5 text-muted-foreground" />
+                    <span className="flex-1 truncate">{c.name}</span>
+                    <span className="text-xs text-muted-foreground">
+                      {c.usage_count} uses
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {selected && !wantsClear && (
+            <p className="text-sm">
+              Selected parent:{' '}
+              <span className="font-medium">{selected.name}</span>
+            </p>
+          )}
+
+          <div className="border-t pt-3">
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={wantsClear}
+                onChange={e => {
+                  setWantsClear(e.target.checked)
+                  if (e.target.checked) setSelected(null)
+                }}
+                className="h-4 w-4 rounded border-muted-foreground"
+              />
+              <span>
+                Clear parent (make this tag a root)
+              </span>
+            </label>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onClose}
+            disabled={setParent.isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={handleConfirm}
+            disabled={!canConfirm || setParent.isPending}
+          >
+            {setParent.isPending ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Saving...
+              </>
+            ) : (
+              'Save'
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+// ──────────────────────────────────────────────
+// Tree node row
+// ──────────────────────────────────────────────
+
+interface NodeRowProps {
+  node: GenreHierarchyNode
+  expandedIds: Set<number>
+  onToggle: (id: number) => void
+  onEdit: (node: GenreHierarchyNode) => void
+}
+
+function NodeRow({ node, expandedIds, onToggle, onEdit }: NodeRowProps) {
+  const expanded = expandedIds.has(node.id)
+  const hasChildren = node.children.length > 0
+
+  return (
+    <>
+      <li
+        className="flex items-center gap-2 rounded-md px-2 py-1.5 hover:bg-muted/50"
+        // Indentation via inline style keeps this flexible for arbitrary depths
+        // without generating a Tailwind class per level.
+        style={{ paddingLeft: `${node.depth * 20 + 8}px` }}
+        data-testid="hierarchy-row"
+        data-tag-id={node.id}
+      >
+        <button
+          type="button"
+          onClick={() => hasChildren && onToggle(node.id)}
+          disabled={!hasChildren}
+          aria-label={
+            hasChildren
+              ? expanded
+                ? `Collapse children of ${node.name}`
+                : `Expand children of ${node.name}`
+              : undefined
+          }
+          className={cn(
+            'flex h-5 w-5 shrink-0 items-center justify-center rounded',
+            hasChildren
+              ? 'hover:bg-muted text-muted-foreground'
+              : 'text-transparent cursor-default'
+          )}
+        >
+          {hasChildren ? (
+            expanded ? (
+              <ChevronDown className="h-3.5 w-3.5" />
+            ) : (
+              <ChevronRight className="h-3.5 w-3.5" />
+            )
+          ) : (
+            // Reserve the slot for alignment.
+            <span className="h-3.5 w-3.5" />
+          )}
+        </button>
+
+        <Hash className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        <span className="flex-1 truncate text-sm font-medium">{node.name}</span>
+        {node.is_official && (
+          <Badge variant="outline" className="text-[10px]">
+            official
+          </Badge>
+        )}
+        <span className="text-xs text-muted-foreground tabular-nums">
+          {node.usage_count}
+        </span>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 w-7 p-0"
+          onClick={() => onEdit(node)}
+          aria-label={`Edit parent of ${node.name}`}
+        >
+          <Pencil className="h-3.5 w-3.5" />
+        </Button>
+      </li>
+
+      {expanded &&
+        node.children.map(child => (
+          <NodeRow
+            key={child.id}
+            node={child}
+            expandedIds={expandedIds}
+            onToggle={onToggle}
+            onEdit={onEdit}
+          />
+        ))}
+    </>
+  )
+}
+
+// ──────────────────────────────────────────────
+// Main editor
+// ──────────────────────────────────────────────
+
+export function TagHierarchyEditor() {
+  const { data, isLoading, error } = useGenreHierarchy()
+  const [search, setSearch] = useState('')
+  const [expandedIds, setExpandedIds] = useState<Set<number>>(new Set())
+  const [editingTag, setEditingTag] = useState<GenreHierarchyNode | null>(null)
+
+  const allTags = useMemo(() => data?.tags ?? [], [data])
+  const roots = useMemo(() => buildHierarchyTree(allTags), [allTags])
+
+  // Filtered view: when a search is active, flatten to matching tags so
+  // admins can jump to a tag buried deep in the tree. Matches are shown
+  // without their tree context — tradeoff for simplicity.
+  const filteredRoots = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    if (!q) return roots
+    const matches: GenreHierarchyNode[] = []
+    const visit = (node: GenreHierarchyNode) => {
+      if (node.name.toLowerCase().includes(q)) {
+        // Flatten matches to depth 0 so the list stays readable during search.
+        matches.push({ ...node, depth: 0, children: [] })
+      }
+      for (const c of node.children) visit(c)
+    }
+    for (const r of roots) visit(r)
+    return matches
+  }, [search, roots])
+
+  const handleToggle = useCallback((id: number) => {
+    setExpandedIds(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }, [])
+
+  // Auto-expand roots on first load so admins see the structure immediately.
+  useEffect(() => {
+    if (roots.length > 0 && expandedIds.size === 0) {
+      setExpandedIds(new Set(roots.map(r => r.id)))
+    }
+    // Intentionally depends only on roots.length; don't re-seed on every
+    // re-render that preserves the same tree.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [roots.length])
+
+  const excludedIds = useMemo(() => {
+    if (!editingTag) return new Set<number>()
+    const fullNode = findNodeById(roots, editingTag.id)
+    const acc = new Set<number>()
+    if (fullNode) collectSubtreeIds(fullNode, acc)
+    else acc.add(editingTag.id)
+    return acc
+  }, [editingTag, roots])
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-xl font-semibold flex items-center gap-2">
+          <Network className="h-5 w-5" />
+          Genre Hierarchy
+        </h2>
+        <p className="text-sm text-muted-foreground mt-1">
+          Set parent/child relationships for genre tags (e.g.{' '}
+          <span className="font-mono">shoegaze</span> under{' '}
+          <span className="font-mono">post-punk</span>). Non-genre categories
+          are flat and do not participate in the hierarchy.
+        </p>
+      </div>
+
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          placeholder="Filter genre tags..."
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          className="pl-9 pr-8"
+          aria-label="Filter genre tags"
+        />
+        {search && (
+          <button
+            type="button"
+            onClick={() => setSearch('')}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+            aria-label="Clear filter"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+
+      {isLoading && (
+        <div className="flex items-center justify-center py-12">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      )}
+
+      {error && (
+        <div
+          className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-center"
+          role="alert"
+        >
+          <p className="text-destructive">
+            {error instanceof Error
+              ? error.message
+              : 'Failed to load genre hierarchy.'}
+          </p>
+        </div>
+      )}
+
+      {!isLoading && !error && allTags.length === 0 && (
+        <div className="flex flex-col items-center justify-center py-12 text-center">
+          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-muted mb-4">
+            <Hash className="h-8 w-8 text-muted-foreground" />
+          </div>
+          <h3 className="text-lg font-medium mb-1">No Genre Tags</h3>
+          <p className="text-sm text-muted-foreground max-w-sm">
+            Create genre tags in the Tags tab to start building a hierarchy.
+          </p>
+        </div>
+      )}
+
+      {!isLoading && !error && allTags.length > 0 && (
+        <>
+          <div className="text-sm text-muted-foreground">
+            {allTags.length} genre tag{allTags.length !== 1 ? 's' : ''}
+            {search &&
+              ` — ${filteredRoots.length} match${filteredRoots.length !== 1 ? 'es' : ''}`}
+          </div>
+
+          {filteredRoots.length === 0 ? (
+            <p className="text-sm text-muted-foreground py-4">
+              No tags match &quot;{search}&quot;.
+            </p>
+          ) : (
+            <ul
+              className="space-y-0.5 rounded-lg border p-1"
+              data-testid="hierarchy-tree"
+            >
+              {filteredRoots.map(node => (
+                <NodeRow
+                  key={node.id}
+                  node={node}
+                  expandedIds={expandedIds}
+                  onToggle={handleToggle}
+                  onEdit={setEditingTag}
+                />
+              ))}
+            </ul>
+          )}
+        </>
+      )}
+
+      <ParentPickerDialog
+        open={editingTag !== null}
+        tagId={editingTag?.id ?? null}
+        tagName={editingTag?.name ?? ''}
+        currentParentId={editingTag?.parent_id ?? null}
+        excludedIds={excludedIds}
+        onClose={() => setEditingTag(null)}
+      />
+    </div>
+  )
+}
+
+export default TagHierarchyEditor

--- a/frontend/features/tags/admin/TagManagement.test.tsx
+++ b/frontend/features/tags/admin/TagManagement.test.tsx
@@ -28,6 +28,8 @@ vi.mock('./useAdminTags', () => ({
   useLowQualityTagQueue: () => ({ data: { tags: [], total: 0 }, isLoading: false, error: null }),
   useSnoozeTag: () => ({ mutate: vi.fn(), isPending: false, variables: undefined }),
   useMarkTagOfficial: () => ({ mutate: vi.fn(), isPending: false, variables: undefined }),
+  useGenreHierarchy: () => ({ data: { tags: [] }, isLoading: false, error: null }),
+  useSetTagParent: () => ({ mutate: vi.fn(), isPending: false }),
 }))
 
 import { TagManagement } from './TagManagement'

--- a/frontend/features/tags/admin/TagManagement.tsx
+++ b/frontend/features/tags/admin/TagManagement.tsx
@@ -30,6 +30,7 @@ import { useTags, useTag } from '../hooks'
 import { AliasListing } from './AliasListing'
 import { LowQualityTagQueue } from './LowQualityTagQueue'
 import { MergeTagDialog } from './MergeTagDialog'
+import { TagHierarchyEditor } from './TagHierarchyEditor'
 import { TagOfficialIndicator } from '../components/TagOfficialIndicator'
 import {
   useCreateTag,
@@ -626,6 +627,7 @@ export function TagManagement() {
             Needs Review
             <LowQualityBadge />
           </TabsTrigger>
+          <TabsTrigger value="hierarchy">Hierarchy</TabsTrigger>
         </TabsList>
 
         <TabsContent value="tags" className="space-y-4">
@@ -778,6 +780,10 @@ export function TagManagement() {
 
         <TabsContent value="needs-review">
           <LowQualityTagQueue />
+        </TabsContent>
+
+        <TabsContent value="hierarchy">
+          <TagHierarchyEditor />
         </TabsContent>
       </Tabs>
 

--- a/frontend/features/tags/admin/index.ts
+++ b/frontend/features/tags/admin/index.ts
@@ -2,6 +2,7 @@ export { TagManagement } from './TagManagement'
 export { AliasListing } from './AliasListing'
 export { LowQualityTagQueue } from './LowQualityTagQueue'
 export { MergeTagDialog } from './MergeTagDialog'
+export { TagHierarchyEditor } from './TagHierarchyEditor'
 export {
   useCreateTag,
   useUpdateTag,
@@ -16,4 +17,6 @@ export {
   useLowQualityTagQueue,
   useSnoozeTag,
   useMarkTagOfficial,
+  useGenreHierarchy,
+  useSetTagParent,
 } from './useAdminTags'

--- a/frontend/features/tags/admin/useAdminTags.ts
+++ b/frontend/features/tags/admin/useAdminTags.ts
@@ -12,6 +12,7 @@ import type {
   MergeTagsPreview,
   MergeTagsResult,
   LowQualityTagQueueResponse,
+  GenreHierarchyResponse,
 } from '../types'
 
 // ──────────────────────────────────────────────
@@ -301,6 +302,58 @@ export function useMarkTagOfficial() {
       queryClient.invalidateQueries({ queryKey: queryKeys.tags.lowQuality() })
       queryClient.invalidateQueries({ queryKey: queryKeys.tags.all })
       queryClient.invalidateQueries({ queryKey: queryKeys.tags.detail(tagId) })
+    },
+  })
+}
+
+// ──────────────────────────────────────────────
+// Genre hierarchy (PSY-311)
+// ──────────────────────────────────────────────
+
+/**
+ * Fetch all genre tags as a flat list with parent_id (admin only).
+ * The frontend builds the tree client-side. 30-second staleTime keeps
+ * the editor snappy after mutations without thrashing the backend.
+ */
+export function useGenreHierarchy(options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: queryKeys.tags.genreHierarchy,
+    queryFn: () =>
+      apiRequest<GenreHierarchyResponse>(API_ENDPOINTS.TAGS.ADMIN_HIERARCHY),
+    enabled: options?.enabled ?? true,
+    staleTime: 30 * 1000,
+  })
+}
+
+interface SetTagParentInput {
+  tagId: number
+  /** Pass null (not undefined) to clear the parent. */
+  parentId: number | null
+}
+
+/**
+ * Set or clear the parent of a genre tag (admin only). Cycle detection and
+ * category enforcement live on the backend; this mutation just surfaces the
+ * error message. Invalidates the genre hierarchy + the affected tag's detail
+ * so the detail page parent/children section stays fresh.
+ */
+export function useSetTagParent() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ tagId, parentId }: SetTagParentInput) =>
+      apiRequest<void>(API_ENDPOINTS.TAGS.ADMIN_SET_PARENT(tagId), {
+        method: 'PATCH',
+        body: JSON.stringify({ parent_id: parentId }),
+      }),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.tags.genreHierarchy })
+      queryClient.invalidateQueries({ queryKey: queryKeys.tags.all })
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.tags.detail(variables.tagId),
+      })
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.tags.enrichedDetail(variables.tagId),
+      })
     },
   })
 }

--- a/frontend/features/tags/types.ts
+++ b/frontend/features/tags/types.ts
@@ -245,6 +245,32 @@ export const LOW_QUALITY_REASON_LABELS: Record<LowQualityReason, string> = {
   long_name: 'Long name',
 }
 
+/**
+ * Genre-hierarchy row — returned by GET /admin/tags/hierarchy (PSY-311).
+ * Flat list; the frontend builds the tree client-side from parent_id.
+ */
+export interface GenreHierarchyTag {
+  id: number
+  name: string
+  slug: string
+  parent_id?: number | null
+  usage_count: number
+  is_official: boolean
+}
+
+export interface GenreHierarchyResponse {
+  tags: GenreHierarchyTag[]
+}
+
+/**
+ * Node in the assembled client-side tree. Convenience shape — not a wire type.
+ * `depth` is 0 for roots and increments per level; used for indentation.
+ */
+export interface GenreHierarchyNode extends GenreHierarchyTag {
+  depth: number
+  children: GenreHierarchyNode[]
+}
+
 export function getCategoryColor(category: string): string {
   const colors: Record<string, string> = {
     genre: 'bg-blue-500/10 text-blue-400 border-blue-500/20',

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -293,6 +293,9 @@ export const API_ENDPOINTS = {
       `${API_BASE_URL}/admin/tags/${sourceId}/merge-preview?target_id=${targetId}`,
     ADMIN_LOW_QUALITY: `${API_BASE_URL}/admin/tags/low-quality`,
     ADMIN_SNOOZE: (tagId: number) => `${API_BASE_URL}/admin/tags/${tagId}/snooze`,
+    // Admin genre-hierarchy editor (PSY-311).
+    ADMIN_HIERARCHY: `${API_BASE_URL}/admin/tags/hierarchy`,
+    ADMIN_SET_PARENT: (tagId: number) => `${API_BASE_URL}/admin/tags/${tagId}/parent`,
   },
 
   // Entity tag endpoints

--- a/frontend/lib/queryClient.ts
+++ b/frontend/lib/queryClient.ts
@@ -279,6 +279,7 @@ export const queryKeys = {
     aliases: (tagId: number) => ['tags', 'aliases', tagId] as const,
     allAliases: (params?: Record<string, unknown>) => ['tags', 'aliases', 'all', params] as const,
     lowQuality: (params?: Record<string, unknown>) => ['tags', 'low-quality', params] as const,
+    genreHierarchy: ['tags', 'hierarchy', 'genre'] as const,
     entityTags: (entityType: string, entityId: number) => ['tags', 'entityTags', entityType, entityId] as const,
     tagEntities: (idOrSlug: string | number, params?: Record<string, unknown>) => ['tags', 'tagEntities', String(idOrSlug), params] as const,
   },


### PR DESCRIPTION
## Summary
- Admin-only genre-hierarchy editor behind a new Hierarchy tab in `/admin/tags`. Flat tree rendered client-side, click-to-open parent picker with autocomplete and clear-parent support.
- Backend cycle detection (walks proposed parent's ancestor chain), category enforcement (genre-only end-to-end), fire-and-forget audit log.
- Cycle/category guards apply both to the new `SetTagParent` path and to `UpdateTag` when `parent_id` is supplied — one validation helper, one API surface.

## Scope (from ticket, pre-authorized)
- Genre-only. Non-genre tags hide the picker / can't have parents.
- Dropdown + autocomplete; **drag-and-drop explicitly deferred** to a follow-up.
- Cycle detection lives in the backend. Frontend pre-filters descendants from the picker as UX polish.

## Cycle detection approach
Walks the proposed parent's ancestor chain — if we encounter the tag itself, reject with `TAG_HIERARCHY_CYCLE` (HTTP 400). O(depth) regardless of subtree size. Also rejects direct self-parent. Depths 1 through 4 covered in the integration suite. Walk is capped at 64 levels as a belt-and-suspenders guard against pre-existing looped data.

## Tag detail parent/children (PSY-438 note)
Already shipped via PSY-438 — verified in `frontend/features/tags/components/TagDetail.tsx` lines 237-258 (`tag-hierarchy` section). No new tag-detail work in this PR.

## Backend
- `services/catalog/tag_hierarchy.go` — `GetTagAncestors`, `GetTagChildren`, `GetGenreHierarchy` (flat list; frontend builds the tree), `SetTagParent`, shared `validateTagParent` helper.
- `services/catalog/tag_service.go` — `UpdateTag` now routes `parent_id` through the same helper, so generic CRUD can't bypass the cycle check.
- `errors/tag.go` — `CodeTagHierarchyCycle` (400), `CodeTagHierarchyNotGenre` (400).
- `api/handlers/tag.go` — `GetGenreHierarchyHandler`, `SetTagParentHandler`.
- Routes: `GET /admin/tags/hierarchy`, `PATCH /admin/tags/{tag_id}/parent`.
- Audit log via direct GORM (matches `cleanup_service.go` / `tag_merge.go`).

## Frontend
- `features/tags/admin/TagHierarchyEditor.tsx` — new component. Indent per depth via inline style so any tree depth works without per-level Tailwind classes.
- `features/tags/admin/useAdminTags.ts` — `useGenreHierarchy`, `useSetTagParent` hooks. Invalidates hierarchy, tag detail, and enriched tag detail on success.
- `TagManagement.tsx` — added `Hierarchy` tab.
- Dialog surfaces backend errors (cycle etc.) in an `role="alert"` region.

## Test plan
- [x] `go test ./...` — 100% green
- [x] `bun run test:run` — 2632/2632 pass
- [x] Backend integration: simple set, clear, direct self-parent, cycle depths 2/3/4, sibling-move allowed, non-genre source rejected, non-genre parent rejected, tag/parent not found, `GetGenreHierarchy` filters to genre only, `GetTagAncestors` closest-first, `GetTagChildren`, `UpdateTag` cycle guard, `UpdateTag` non-genre rejection, audit log happy-path and null-parent.
- [x] Frontend: `buildHierarchyTree` unit tests (roots, nesting, orphan promotion), component tests for render, open picker, fire mutation, surface backend error, clear parent, empty state, load error.
- [ ] Manual smoke: dev stack not booted in this worktree (parallel worktrees use port 8080). Noted for reviewer.

Closes PSY-311

🤖 Generated with [Claude Code](https://claude.com/claude-code)