### PR TITLE
PSY-470: afterEach user_bookmarks reset in follow-and-attendance

### DIFF
--- a/frontend/e2e/pages/follow-and-attendance.spec.ts
+++ b/frontend/e2e/pages/follow-and-attendance.spec.ts
@@ -1,4 +1,9 @@
 import { test, expect } from '../fixtures'
+import {
+  resetTestFixtures,
+  lookupWorkerUserId,
+} from '../fixtures/test-fixtures-reset'
+import { USER_COUNT, userAuthFileForWorker } from '../global-setup'
 
 // PSY-457: backfill E2E coverage for follow + going/interested flows.
 // PSY-430: pin to reserved artist + show seeded by setup-db.sh so parallel
@@ -15,6 +20,26 @@ test.describe('Follow and attendance', () => {
   // Tests share DB state with the same per-worker user, so they must not
   // run in parallel within this file.
   test.describe.configure({ mode: 'serial' })
+
+  // PSY-470: the in-test cleanup at the happy-path tail only runs when the
+  // test passes. When a mid-test failure skips it (see PSY-465), the shared
+  // reserved artist/show rows leak follower/attendance count into the next
+  // repeat and cause cascading `followers_count` mismatches across workers.
+  // workerCleanup (PSY-432) only fires on worker teardown, not between
+  // tests. Scope the reset to just `user_bookmarks` — narrower than the
+  // teardown reset so it stays cheap when run per test.
+  let workerUserId: number | null = null
+
+  test.beforeAll(async ({}, testInfo) => {
+    const seededIndex = testInfo.workerIndex % USER_COUNT
+    workerUserId = await lookupWorkerUserId(userAuthFileForWorker(seededIndex))
+  })
+
+  test.afterEach(async () => {
+    if (workerUserId !== null) {
+      await resetTestFixtures(workerUserId, ['user_bookmarks'])
+    }
+  })
 
   test('follow an artist round-trip surfaces in Library', { tag: '@smoke' }, async ({
     authenticatedPage,


### PR DESCRIPTION
## Summary

The `follow an artist round-trip` and `mark show as going round-trip` tests in `e2e/pages/follow-and-attendance.spec.ts` rely on an in-test cleanup tail to unfollow/unattend after the happy path. When the test fails mid-body (see PSY-465), the cleanup is skipped and the shared reserved rows (`e2e-follow-test` / `e2e-attendance-test` from PSY-430) carry state into the next repeat on the same worker. `workerCleanup` (PSY-432, #396) wipes `user_bookmarks` but only on worker teardown, not between tests.

This adds a describe-level `afterEach` that calls `resetTestFixtures` scoped to `user_bookmarks` only — narrower than the teardown's 5-scope default, so it's cheap to run per test. `workerUserId` is cached in `beforeAll` via `lookupWorkerUserId` so we do one `GET /auth/profile` per worker, not per test. The existing in-test cleanup stays; `afterEach` is defense in depth, not a replacement.

## Not in this PR

Does **not** address PSY-465 (ArtistDetail error boundary), which is the underlying reason mid-test failures occur. That's the other half of the fix.

## Test plan

- [x] `bunx tsc --noEmit` reports no new errors introduced by this file (imports/types resolve: `USER_COUNT`, `userAuthFileForWorker`, `lookupWorkerUserId`, `resetTestFixtures`).
- [x] Backend logs confirm the `afterEach` fires as expected: per-test `POST /admin/test-fixtures/reset` with `tables=[user_bookmarks]` (3 in the `--workers=3` run), followed by the worker-teardown 5-scope reset.
- [ ] Local repro counts (flag):

  | | before (main) | after (this branch) |
  |---|---|---|
  | `--repeat-each=3 --workers=3 --reporter=list` | 3 failed | 3 failed (same failure) |
  | `--workers=1 --reporter=list` | 1 failed | 1 failed (same failure) |

  Both branches fail on the same `page.goto: net::ERR_ABORTED` during `authenticatedPage.goto('/library?tab=artists')` after the Follow button POST succeeds and the "Following 1" assertion passes. That shape does not match the `followers_count` mismatch that PSY-465 documented — it looks like PSY-465 manifesting differently (error boundary aborting navigation), or a pre-existing dev-server flake on my local setup. Either way it is unrelated to the `afterEach` gap this PR closes — the reset helper fires correctly 3×, and the fix only protects the *next* iteration of a test on the same worker. Once PSY-465 or the underlying `net::ERR_ABORTED` is fixed, the serial test suite should pass and this `afterEach` will keep it clean across failures.
- [ ] Smoke-on-PR job passes.

## Related

- Closes PSY-470
- PSY-465 — ArtistDetail error boundary (not addressed here; upstream root cause)
- #396 — PSY-432 shipped `resetTestFixtures` + `workerCleanup`; this PR reuses that helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)