### PR TITLE
PSY-460: mobile collapsible "Show all tags" (Sheet) + fold ISSUE-003

### DIFF
--- a/frontend/features/tags/components/EntityTagList.test.tsx
+++ b/frontend/features/tags/components/EntityTagList.test.tsx
@@ -1,8 +1,20 @@
 import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { screen, waitFor } from '@testing-library/react'
+import { screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { renderWithProviders } from '@/test/utils'
+
+// PSY-460 introduces a mobile "Show all tags" Sheet alongside the existing
+// desktop top-5 cap. Both rows render in the DOM (swapped via Tailwind's
+// `sm:hidden` / `hidden sm:flex` utilities — jsdom does not apply those
+// styles). Existing assertions about "the visible pill row" predate that
+// split and now match elements in both rows. The helper below scopes queries
+// to the desktop row so the original behavior keeps being exercised; mobile-
+// specific assertions go through the `entity-tag-list-mobile-row` /
+// `entity-tag-list-mobile-sheet` testids instead.
+function desktopRow() {
+  return screen.getByTestId('entity-tag-list-desktop-row')
+}
 
 // Mock next/link
 vi.mock('next/link', () => ({
@@ -152,17 +164,19 @@ describe('EntityTagList add-tag dialog accessibility', () => {
     renderWithProviders(
       <EntityTagList entityType="artist" entityId={1} isAuthenticated={false} />
     )
+    const row = desktopRow()
     // The official tag "rock" should have a title tooltip indicating official status
-    const rockLink = screen.getByRole('link', { name: 'rock' })
+    const rockLink = within(row).getByRole('link', { name: 'rock' })
     expect(rockLink).toHaveAttribute('title', 'rock (Official)')
 
     // The community tag "indie" should have a plain title
-    const indieLink = screen.getByRole('link', { name: 'indie' })
+    const indieLink = within(row).getByRole('link', { name: 'indie' })
     expect(indieLink).toHaveAttribute('title', 'indie')
 
-    // The visible BadgeCheck icon marker is present exactly once (only on
-    // the official tag) so the distinction is not tooltip-only.
-    const officialMarkers = screen.getAllByRole('img', { name: 'Official tag' })
+    // The visible BadgeCheck icon marker is present exactly once within the
+    // desktop row (only on the official tag) so the distinction is not
+    // tooltip-only.
+    const officialMarkers = within(row).getAllByRole('img', { name: 'Official tag' })
     expect(officialMarkers).toHaveLength(1)
 
     // And the official pill wrapper carries the primary-accent background
@@ -236,8 +250,8 @@ describe('EntityTagList top-5 cap and Wilson score sorting', () => {
       <EntityTagList entityType="artist" entityId={1} isAuthenticated={false} />
     )
 
-    // 7 tags total, only 5 should be visible
-    const tagLinks = screen.getAllByRole('link')
+    // 7 tags total, only 5 should be visible in the desktop row.
+    const tagLinks = within(desktopRow()).getAllByRole('link')
     expect(tagLinks).toHaveLength(5)
   })
 
@@ -246,7 +260,7 @@ describe('EntityTagList top-5 cap and Wilson score sorting', () => {
       <EntityTagList entityType="artist" entityId={1} isAuthenticated={false} />
     )
 
-    const tagLinks = screen.getAllByRole('link')
+    const tagLinks = within(desktopRow()).getAllByRole('link')
     // Expected order by wilson_score descending: punk(0.62), post-punk(0.60), rock(0.56), shoegaze(0.34), indie(0.21)
     expect(tagLinks[0]).toHaveTextContent('punk')
     expect(tagLinks[1]).toHaveTextContent('post-punk')
@@ -260,7 +274,7 @@ describe('EntityTagList top-5 cap and Wilson score sorting', () => {
       <EntityTagList entityType="artist" entityId={1} isAuthenticated={false} />
     )
 
-    expect(screen.getByText('Show 2 more')).toBeInTheDocument()
+    expect(within(desktopRow()).getByText('Show 2 more')).toBeInTheDocument()
   })
 
   it('expands to show all tags when "Show N more" is clicked', async () => {
@@ -269,10 +283,10 @@ describe('EntityTagList top-5 cap and Wilson score sorting', () => {
       <EntityTagList entityType="artist" entityId={1} isAuthenticated={false} />
     )
 
-    await user.click(screen.getByText('Show 2 more'))
+    await user.click(within(desktopRow()).getByText('Show 2 more'))
 
-    // All 7 tags should now be visible
-    const tagLinks = screen.getAllByRole('link')
+    // All 7 tags should now be visible in the desktop row.
+    const tagLinks = within(desktopRow()).getAllByRole('link')
     expect(tagLinks).toHaveLength(7)
   })
 
@@ -282,13 +296,14 @@ describe('EntityTagList top-5 cap and Wilson score sorting', () => {
       <EntityTagList entityType="artist" entityId={1} isAuthenticated={false} />
     )
 
+    const row = desktopRow()
     // Expand
-    await user.click(screen.getByText('Show 2 more'))
-    expect(screen.getAllByRole('link')).toHaveLength(7)
+    await user.click(within(row).getByText('Show 2 more'))
+    expect(within(row).getAllByRole('link')).toHaveLength(7)
 
     // Collapse
-    await user.click(screen.getByText('Show less'))
-    expect(screen.getAllByRole('link')).toHaveLength(5)
+    await user.click(within(row).getByText('Show less'))
+    expect(within(row).getAllByRole('link')).toHaveLength(5)
   })
 
   it('does not show expand button when 5 or fewer tags exist', () => {
@@ -297,8 +312,10 @@ describe('EntityTagList top-5 cap and Wilson score sorting', () => {
       <EntityTagList entityType="artist" entityId={1} isAuthenticated={false} />
     )
 
-    expect(screen.queryByText(/Show \d+ more/)).not.toBeInTheDocument()
-    expect(screen.queryByText('Show less')).not.toBeInTheDocument()
+    // Only the desktop cap chip is tested here — the mobile "Show all"
+    // chip has its own suite below.
+    expect(within(desktopRow()).queryByText(/Show \d+ more/)).not.toBeInTheDocument()
+    expect(within(desktopRow()).queryByText('Show less')).not.toBeInTheDocument()
   })
 })
 
@@ -749,15 +766,18 @@ describe('EntityTagList tag pill attribution hover card', () => {
       <EntityTagList entityType="artist" entityId={1} isAuthenticated={false} />
     )
 
-    // The pill wrapper carries the aria-label we wired on the HoverCardTrigger.
-    const trigger = screen.getByRole('group', { name: /post-punk tag details/i })
+    // Scope to the desktop row: the mobile row renders the same pills, but
+    // only one trigger needs to be exercised to validate the HoverCard.
+    const row = desktopRow()
+    const trigger = within(row).getByRole('group', { name: /post-punk tag details/i })
     await user.click(trigger)
 
     const card = await screen.findByTestId('tag-attribution-card-10')
     expect(card).toBeInTheDocument()
 
-    // Username link points to the user profile slug.
-    const userLink = screen.getByRole('link', { name: /@testuser2/ })
+    // Username link points to the user profile slug. The card is portalled
+    // outside the row so we query at screen scope.
+    const userLink = within(card).getByRole('link', { name: /@testuser2/ })
     expect(userLink).toHaveAttribute('href', '/users/testuser2')
 
     // Vote counts render with the correct singular/plural agreement.
@@ -768,7 +788,7 @@ describe('EntityTagList tag pill attribution hover card', () => {
     expect(card).toHaveTextContent(/1\s+downvote(?!s)/)
 
     // The "View tag details" action links to the canonical tag detail page.
-    const detailLink = screen.getByRole('link', { name: /view tag details/i })
+    const detailLink = within(card).getByRole('link', { name: /view tag details/i })
     expect(detailLink).toHaveAttribute('href', '/tags/post-punk')
   })
 
@@ -778,7 +798,7 @@ describe('EntityTagList tag pill attribution hover card', () => {
       <EntityTagList entityType="artist" entityId={1} isAuthenticated={false} />
     )
 
-    const trigger = screen.getByRole('group', { name: /post-punk tag details/i })
+    const trigger = within(desktopRow()).getByRole('group', { name: /post-punk tag details/i })
     trigger.focus()
     expect(trigger).toHaveFocus()
 
@@ -796,7 +816,7 @@ describe('EntityTagList tag pill attribution hover card', () => {
     )
 
     // Open the hover card for the "noise" tag (no added_by_username).
-    const trigger = screen.getByRole('group', { name: /noise tag details/i })
+    const trigger = within(desktopRow()).getByRole('group', { name: /noise tag details/i })
     await user.click(trigger)
 
     const card = await screen.findByTestId('tag-attribution-card-11')
@@ -810,7 +830,7 @@ describe('EntityTagList tag pill attribution hover card', () => {
     // blank card.
     expect(card).toHaveTextContent(/0\s+upvotes/)
     expect(card).toHaveTextContent(/0\s+downvotes/)
-    const detailLink = screen.getByRole('link', { name: /view tag details/i })
+    const detailLink = within(card).getByRole('link', { name: /view tag details/i })
     expect(detailLink).toHaveAttribute('href', '/tags/noise')
   })
 
@@ -839,7 +859,9 @@ describe('EntityTagList tag pill attribution hover card', () => {
       <EntityTagList entityType="artist" entityId={1} isAuthenticated={false} />
     )
 
-    await user.click(screen.getByRole('group', { name: /shoegaze tag details/i }))
+    await user.click(
+      within(desktopRow()).getByRole('group', { name: /shoegaze tag details/i })
+    )
 
     const card = await screen.findByTestId('tag-attribution-card-20')
     // formatRelativeTime output for a timestamp ~5 minutes ago.
@@ -852,18 +874,210 @@ describe('EntityTagList tag pill attribution hover card', () => {
       <EntityTagList entityType="artist" entityId={1} isAuthenticated />
     )
 
+    const row = desktopRow()
     // The inline tag-name link still points to the canonical detail page.
-    const tagLink = screen.getByRole('link', { name: 'post-punk' })
+    const tagLink = within(row).getByRole('link', { name: 'post-punk' })
     expect(tagLink).toHaveAttribute('href', '/tags/post-punk')
 
     // Vote buttons are still present and independently clickable (the hover
     // card wrapper guards against its own toggle when a button is clicked,
     // so the vote mutation still fires).
-    const upvoteButton = screen.getByRole('button', { name: /upvote post-punk/i })
+    const upvoteButton = within(row).getByRole('button', { name: /upvote post-punk/i })
     await user.click(upvoteButton)
     // We don't assert on mutate args here — useVoteOnTag is a mocked noop;
     // the guarantee is that clicking the vote button does not throw, does
     // not navigate, and doesn't blow up on the stopPropagation handler.
     expect(upvoteButton).toBeInTheDocument()
+  })
+})
+
+// PSY-460: narrow viewports collapse the tag row to MOBILE_VISIBLE_COUNT
+// pills + a "Show all tags" chip that opens a bottom-sliding Sheet. The
+// sheet re-renders the full tag list and exposes the add-tag flow in its
+// header. Desktop behavior (top-5 cap + inline "Show N more") is covered
+// above and remains unchanged.
+describe('EntityTagList mobile collapsible Sheet', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    currentMockTags = mockManyTags // 7 tags, above the mobile cap of 3
+    currentMockSearchTags = defaultMockSearchTags
+    mockAuthUser = { user_tier: 'contributor' }
+    mockAddMutationError = null
+  })
+
+  it('renders only the first 3 pills in the mobile row when more than 3 tags exist', () => {
+    renderWithProviders(
+      <EntityTagList entityType="artist" entityId={1} isAuthenticated={false} />
+    )
+
+    const mobileRow = screen.getByTestId('entity-tag-list-mobile-row')
+    const tagLinks = within(mobileRow).getAllByRole('link')
+    expect(tagLinks).toHaveLength(3)
+    // Wilson-score order is preserved: punk(0.62), post-punk(0.60), rock(0.56).
+    expect(tagLinks[0]).toHaveTextContent('punk')
+    expect(tagLinks[1]).toHaveTextContent('post-punk')
+    expect(tagLinks[2]).toHaveTextContent('rock')
+  })
+
+  it('shows a "Show all tags" chip in the mobile row with the hidden count', () => {
+    renderWithProviders(
+      <EntityTagList entityType="artist" entityId={1} isAuthenticated={false} />
+    )
+
+    const trigger = screen.getByTestId('entity-tag-list-mobile-show-all')
+    // 7 total - 3 visible = 4 in the drawer.
+    expect(trigger).toHaveTextContent(/4 more/)
+  })
+
+  it('omits the "Show all" chip when 3 or fewer tags exist', () => {
+    currentMockTags = mockEntityTags // 2 tags
+    renderWithProviders(
+      <EntityTagList entityType="artist" entityId={1} isAuthenticated={false} />
+    )
+
+    expect(
+      screen.queryByTestId('entity-tag-list-mobile-show-all')
+    ).not.toBeInTheDocument()
+  })
+
+  it('opens the Sheet with every tag and the "Add" action in its header', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(
+      <EntityTagList entityType="artist" entityId={1} isAuthenticated />
+    )
+
+    await user.click(screen.getByTestId('entity-tag-list-mobile-show-all'))
+
+    const sheet = await screen.findByTestId('entity-tag-list-mobile-sheet')
+    expect(sheet).toBeInTheDocument()
+    // Title surfaces the total count up-front so users know the drawer
+    // contains more than the mobile row exposed.
+    expect(sheet).toHaveTextContent(/All tags \(7\)/)
+
+    // All 7 tag pills are reachable inside the sheet.
+    const tagLinks = within(sheet).getAllByRole('link')
+    expect(tagLinks).toHaveLength(7)
+
+    // The Add-tag action is present in the sheet header — required so mobile
+    // users can still add tags without closing the drawer first.
+    const sheetAdd = within(sheet).getByTestId('entity-tag-list-sheet-add')
+    expect(sheetAdd).toBeInTheDocument()
+  })
+
+  it('renders the vote buttons inside the Sheet when authenticated', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(
+      <EntityTagList entityType="artist" entityId={1} isAuthenticated />
+    )
+
+    await user.click(screen.getByTestId('entity-tag-list-mobile-show-all'))
+
+    const sheet = await screen.findByTestId('entity-tag-list-mobile-sheet')
+    // Each of the 7 pills has upvote + downvote buttons, for a total of 14.
+    const upvotes = within(sheet).getAllByRole('button', { name: /upvote /i })
+    const downvotes = within(sheet).getAllByRole('button', { name: /downvote /i })
+    expect(upvotes).toHaveLength(7)
+    expect(downvotes).toHaveLength(7)
+  })
+
+  it('opens the Add-tag dialog when the sheet-header Add action is clicked', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(
+      <EntityTagList entityType="artist" entityId={1} isAuthenticated />
+    )
+
+    await user.click(screen.getByTestId('entity-tag-list-mobile-show-all'))
+    const sheet = await screen.findByTestId('entity-tag-list-mobile-sheet')
+    await user.click(within(sheet).getByTestId('entity-tag-list-sheet-add'))
+
+    // The Add Tag dialog opens (closing the Sheet first so Radix portals
+    // do not stack). We match on the dialog title because other tests
+    // already cover the full dialog a11y surface.
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Add Tag')).toBeInTheDocument()
+  })
+
+  it('preserves the official indicator inside the Sheet', async () => {
+    const user = userEvent.setup()
+    // Mix one official tag into the ordered list so the indicator assertion
+    // is meaningful (mockManyTags has all is_official=false by default).
+    currentMockTags = {
+      tags: [
+        ...mockManyTags.tags,
+        {
+          tag_id: 100,
+          name: 'official-tag',
+          slug: 'official-tag',
+          category: 'genre',
+          is_official: true,
+          upvotes: 10,
+          downvotes: 0,
+          wilson_score: 0.91,
+          user_vote: 0,
+        },
+      ],
+    }
+
+    renderWithProviders(
+      <EntityTagList entityType="artist" entityId={1} isAuthenticated={false} />
+    )
+
+    await user.click(screen.getByTestId('entity-tag-list-mobile-show-all'))
+    const sheet = await screen.findByTestId('entity-tag-list-mobile-sheet')
+
+    const officialMarkers = within(sheet).getAllByRole('img', { name: 'Official tag' })
+    expect(officialMarkers).toHaveLength(1)
+    expect(within(sheet).getByRole('link', { name: 'official-tag' })).toHaveAttribute(
+      'title',
+      'official-tag (Official)'
+    )
+  })
+
+  it('opens the attribution hover card inside the Sheet (Radix portal compatibility)', async () => {
+    // Keep one tag with full attribution data so the hover card body has
+    // something to render.
+    currentMockTags = {
+      tags: [
+        {
+          tag_id: 30,
+          name: 'post-punk',
+          slug: 'post-punk',
+          category: 'genre',
+          is_official: false,
+          upvotes: 3,
+          downvotes: 1,
+          wilson_score: 0.34,
+          user_vote: 0,
+          added_by_username: 'testuser',
+        },
+        // Pad with 3 more tags so the "Show all" chip still renders.
+        { tag_id: 31, name: 'a', slug: 'a', category: 'genre', is_official: false, upvotes: 0, downvotes: 0, wilson_score: 0.1, user_vote: 0 },
+        { tag_id: 32, name: 'b', slug: 'b', category: 'genre', is_official: false, upvotes: 0, downvotes: 0, wilson_score: 0.1, user_vote: 0 },
+        { tag_id: 33, name: 'c', slug: 'c', category: 'genre', is_official: false, upvotes: 0, downvotes: 0, wilson_score: 0.1, user_vote: 0 },
+      ],
+    }
+
+    const user = userEvent.setup()
+    renderWithProviders(
+      <EntityTagList entityType="artist" entityId={1} isAuthenticated={false} />
+    )
+
+    await user.click(screen.getByTestId('entity-tag-list-mobile-show-all'))
+    const sheet = await screen.findByTestId('entity-tag-list-mobile-sheet')
+
+    // Click the pill inside the sheet — Radix HoverCardContent portals to
+    // document.body, not into the sheet container, so we query the card at
+    // screen scope. If Radix portals fought with the Sheet's own portal we'd
+    // either not find the card or get an overlap conflict; either shows up
+    // here as a failure.
+    await user.click(
+      within(sheet).getByRole('group', { name: /post-punk tag details/i })
+    )
+
+    const card = await screen.findByTestId('tag-attribution-card-30')
+    expect(card).toBeInTheDocument()
+    expect(card).toHaveTextContent('@testuser')
   })
 })

--- a/frontend/features/tags/components/EntityTagList.tsx
+++ b/frontend/features/tags/components/EntityTagList.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useMemo } from 'react'
 import Link from 'next/link'
-import { Plus, ThumbsUp, ThumbsDown, X, Search, Loader2, ChevronDown, ChevronUp } from 'lucide-react'
+import { Plus, ThumbsUp, ThumbsDown, X, Search, Loader2, ChevronDown, ChevronUp, MoreHorizontal } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -11,8 +11,13 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from '@/components/ui/dialog'
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet'
 import {
   Tooltip,
   TooltipContent,
@@ -45,13 +50,20 @@ interface EntityTagListProps {
   isAuthenticated?: boolean
 }
 
+// Desktop collapses after 5 pills (preserves pre-PSY-460 behavior). Mobile
+// collapses much earlier and defers the rest to a Sheet — 3 pills is the
+// sweet spot at 320-414px where a typical pill (~60-120px wide including
+// vote buttons) plus the "+ Add" and "Show all" chips still fit on one or
+// two rows before the Sheet takes over.
 const DEFAULT_VISIBLE_COUNT = 5
+const MOBILE_VISIBLE_COUNT = 3
 
 export function EntityTagList({ entityType, entityId, isAuthenticated }: EntityTagListProps) {
   const { data, isLoading } = useEntityTags(entityType, entityId)
   const voteMutation = useVoteOnTag()
   const removeVoteMutation = useRemoveTagVote()
   const [addDialogOpen, setAddDialogOpen] = useState(false)
+  const [sheetOpen, setSheetOpen] = useState(false)
   const [expanded, setExpanded] = useState(false)
 
   const tags = data?.tags ?? []
@@ -62,9 +74,13 @@ export function EntityTagList({ entityType, entityId, isAuthenticated }: EntityT
     [tags]
   )
 
-  const hasMore = sortedTags.length > DEFAULT_VISIBLE_COUNT
-  const visibleTags = expanded ? sortedTags : sortedTags.slice(0, DEFAULT_VISIBLE_COUNT)
-  const hiddenCount = sortedTags.length - DEFAULT_VISIBLE_COUNT
+  const hasMoreDesktop = sortedTags.length > DEFAULT_VISIBLE_COUNT
+  const desktopVisibleTags = expanded ? sortedTags : sortedTags.slice(0, DEFAULT_VISIBLE_COUNT)
+  const hiddenDesktopCount = sortedTags.length - DEFAULT_VISIBLE_COUNT
+
+  const hasMoreMobile = sortedTags.length > MOBILE_VISIBLE_COUNT
+  const mobileVisibleTags = sortedTags.slice(0, MOBILE_VISIBLE_COUNT)
+  const hiddenMobileCount = sortedTags.length - MOBILE_VISIBLE_COUNT
 
   if (isLoading) {
     return (
@@ -91,72 +107,161 @@ export function EntityTagList({ entityType, entityId, isAuthenticated }: EntityT
     }
   }
 
+  // The Add dialog is rendered once and reused by both the desktop "Add"
+  // chip next to the row heading and the sheet-header "Add" action. Lifting
+  // it out of the trigger tree keeps a single Dialog instance (one piece of
+  // state, one Radix portal) and avoids the "dialog closes when the sheet
+  // closes" problem that happens if the trigger unmounts mid-flow.
+  const addTagDialog = isAuthenticated ? (
+    <Dialog open={addDialogOpen} onOpenChange={setAddDialogOpen}>
+      <DialogContent className="sm:max-w-md" aria-describedby={undefined}>
+        <DialogHeader>
+          <DialogTitle>Add Tag</DialogTitle>
+        </DialogHeader>
+        <AddTagForm
+          entityType={entityType}
+          entityId={entityId}
+          existingTagIds={tags.map(t => t.tag_id)}
+          onSuccess={() => setAddDialogOpen(false)}
+        />
+      </DialogContent>
+    </Dialog>
+  ) : null
+
+  const addTagButton = isAuthenticated ? (
+    <button
+      onClick={() => setAddDialogOpen(true)}
+      className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+      aria-label="Add tag"
+    >
+      <Plus className="h-3 w-3" />
+      Add
+    </button>
+  ) : null
+
   return (
     <div className="py-4">
       <div className="flex items-center gap-2 mb-3">
         <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
           Tags
         </h3>
-        {isAuthenticated && (
-          <Dialog open={addDialogOpen} onOpenChange={setAddDialogOpen}>
-            <DialogTrigger asChild>
-              <button
-                className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
-                aria-label="Add tag"
-              >
-                <Plus className="h-3 w-3" />
-                Add
-              </button>
-            </DialogTrigger>
-            <DialogContent className="sm:max-w-md" aria-describedby={undefined}>
-              <DialogHeader>
-                <DialogTitle>Add Tag</DialogTitle>
-              </DialogHeader>
-              <AddTagForm
-                entityType={entityType}
-                entityId={entityId}
-                existingTagIds={tags.map(t => t.tag_id)}
-                onSuccess={() => setAddDialogOpen(false)}
-              />
-            </DialogContent>
-          </Dialog>
-        )}
+        {addTagButton}
       </div>
+
+      {addTagDialog}
 
       {tags.length === 0 ? (
         <p className="text-sm text-muted-foreground">
           No tags yet. Be the first to add one!
         </p>
       ) : (
-        <div className="flex flex-wrap gap-2 items-center">
-          {visibleTags.map(tag => (
-            <TagWithVotes
-              key={tag.tag_id}
-              tag={tag}
-              isAuthenticated={isAuthenticated}
-              onVote={handleVote}
-            />
-          ))}
-          {hasMore && (
-            <button
-              onClick={() => setExpanded(!expanded)}
-              className="inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
-            >
-              {expanded ? (
-                <>
-                  <ChevronUp className="h-3 w-3" />
-                  Show less
-                </>
-              ) : (
-                <>
-                  <ChevronDown className="h-3 w-3" />
-                  Show {hiddenCount} more
-                </>
-              )}
-            </button>
-          )}
-        </div>
+        <>
+          {/* Mobile: first N pills + "Show all" chip that opens a Sheet.
+              Hidden at >=sm where the desktop top-5 cap takes over. */}
+          <div
+            className="flex flex-wrap gap-2 items-center sm:hidden"
+            data-testid="entity-tag-list-mobile-row"
+          >
+            {mobileVisibleTags.map(tag => (
+              <TagWithVotes
+                key={tag.tag_id}
+                tag={tag}
+                isAuthenticated={isAuthenticated}
+                onVote={handleVote}
+              />
+            ))}
+            {hasMoreMobile && (
+              <button
+                onClick={() => setSheetOpen(true)}
+                data-testid="entity-tag-list-mobile-show-all"
+                className="inline-flex items-center gap-1 rounded-full border border-dashed border-border px-2.5 py-1 text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+                aria-label={`Show all ${sortedTags.length} tags`}
+              >
+                <MoreHorizontal className="h-3 w-3" />
+                Show all tags ({hiddenMobileCount} more)
+              </button>
+            )}
+          </div>
+
+          {/* Desktop: unchanged from pre-PSY-460 — top 5 with inline
+              expand/collapse. Hidden on narrow viewports where the Sheet
+              flow takes over. */}
+          <div
+            className="hidden sm:flex flex-wrap gap-2 items-center"
+            data-testid="entity-tag-list-desktop-row"
+          >
+            {desktopVisibleTags.map(tag => (
+              <TagWithVotes
+                key={tag.tag_id}
+                tag={tag}
+                isAuthenticated={isAuthenticated}
+                onVote={handleVote}
+              />
+            ))}
+            {hasMoreDesktop && (
+              <button
+                onClick={() => setExpanded(!expanded)}
+                className="inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+              >
+                {expanded ? (
+                  <>
+                    <ChevronUp className="h-3 w-3" />
+                    Show less
+                  </>
+                ) : (
+                  <>
+                    <ChevronDown className="h-3 w-3" />
+                    Show {hiddenDesktopCount} more
+                  </>
+                )}
+              </button>
+            )}
+          </div>
+        </>
       )}
+
+      <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
+        <SheetContent
+          side="bottom"
+          className="max-h-[85vh] overflow-y-auto"
+          data-testid="entity-tag-list-mobile-sheet"
+        >
+          <SheetHeader>
+            <SheetTitle className="flex items-center gap-3">
+              <span>All tags ({sortedTags.length})</span>
+              {isAuthenticated && (
+                <button
+                  onClick={() => {
+                    // Close the sheet first so the Add dialog doesn't
+                    // stack a second Radix Portal on top of another
+                    // Portal — keeps focus-trap + overlay behavior clean.
+                    setSheetOpen(false)
+                    setAddDialogOpen(true)
+                  }}
+                  data-testid="entity-tag-list-sheet-add"
+                  className="inline-flex items-center gap-1 rounded-full border border-border px-2 py-0.5 text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+                  aria-label="Add tag"
+                >
+                  <Plus className="h-3 w-3" />
+                  Add
+                </button>
+              )}
+            </SheetTitle>
+          </SheetHeader>
+          <div className="px-4 pb-6 pt-2">
+            <div className="flex flex-wrap gap-2 items-center">
+              {sortedTags.map(tag => (
+                <TagWithVotes
+                  key={tag.tag_id}
+                  tag={tag}
+                  isAuthenticated={isAuthenticated}
+                  onVote={handleVote}
+                />
+              ))}
+            </div>
+          </div>
+        </SheetContent>
+      </Sheet>
     </div>
   )
 }

--- a/frontend/features/tags/components/TagDetail.test.tsx
+++ b/frontend/features/tags/components/TagDetail.test.tsx
@@ -769,6 +769,34 @@ describe('TagDetail', () => {
     )
   })
 
+  // PSY-460 / dogfood tags-audit-4 ISSUE-003: at 375px the h1 + Official
+  // badge + NotifyMeButton cluster overflowed the viewport by ~31px,
+  // clipping "Notify me". Fix mirrors the PSY-467 pattern: the cluster
+  // uses flex-wrap + min-w-0 so the NotifyMeButton can break to a new
+  // row under the title on narrow viewports. jsdom can't verify actual
+  // layout, so we assert the structural classes are present — enough to
+  // catch a regression that strips the wrap.
+  it('header cluster allows the NotifyMeButton to wrap on narrow viewports (ISSUE-003)', () => {
+    mockUseTagDetail.mockReturnValue({
+      data: makeTagDetail({
+        name: 'Shoegaze',
+        is_official: true,
+      }),
+      isLoading: false,
+      error: null,
+    })
+
+    renderWithProviders(<TagDetail slug="shoegaze" />)
+
+    const heading = screen.getByRole('heading', { level: 1, name: 'Shoegaze' })
+    const cluster = heading.parentElement as HTMLElement
+    expect(cluster.className).toContain('flex-wrap')
+    expect(cluster.className).toContain('min-w-0')
+    // The heading itself must be allowed to shrink so long tag names break
+    // instead of forcing the whole cluster off-screen.
+    expect(heading.className).toContain('min-w-0')
+  })
+
   it('renders breadcrumb with tag name', () => {
     mockUseTagDetail.mockReturnValue({
       data: makeTagDetail({ name: 'Jazz' }),

--- a/frontend/features/tags/components/TagDetail.tsx
+++ b/frontend/features/tags/components/TagDetail.tsx
@@ -153,8 +153,13 @@ export function TagDetail({ slug }: TagDetailProps) {
             <Hash className="h-6 w-6" />
           </div>
           <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-3 mb-1">
-              <h1 className="text-3xl font-bold tracking-tight">{tag.name}</h1>
+            {/* ISSUE-003 (dogfood tags-audit-4): at 375px the h1 + Official
+                badge + NotifyMeButton cluster was clipped ~31px off-screen.
+                flex-wrap + min-w-0 lets the NotifyMeButton break to a new
+                row below the title on narrow viewports; desktop (>=sm)
+                keeps the single-row layout. Same pattern as PSY-467. */}
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-2 min-w-0 mb-1">
+              <h1 className="text-3xl font-bold tracking-tight min-w-0 break-words">{tag.name}</h1>
               {tag.is_official && (
                 <TagOfficialIndicator size="md" tagName={tag.name} />
               )}


### PR DESCRIPTION
## Summary

- **Mobile-first tag row**: at `<640px`, `EntityTagList` now caps the inline row at 3 pills and appends a "Show all tags (N more)" chip. Tapping it opens a bottom-sliding Radix `Sheet` with the complete tag list, HoverCard attribution (PSY-441), official indicator (PSY-453), vote buttons, and an "+ Add" action in its header. Desktop (`>=640px`) keeps the existing top-5 cap + inline "Show N more" expand — **unchanged**.
- **Folds in ISSUE-003** from `dogfood-output/tags-audit-4`: tag detail header (`/tags/*`) overflowed ~31px at 375px, clipping "Notify me". Applied the PSY-467 pattern (`flex-wrap` + `min-w-0` on the title cluster, `min-w-0` on the h1). Desktop (`>=1024px`) unchanged.

## Decisions (user-approved)

- **Radix `Sheet`** over an inline expand. Project already uses Radix; `components/ui/sheet.tsx` was already installed (same file used by `TagFacetSheet`). Radix `HoverCard` portals to `document.body` and works cleanly inside the Sheet — verified in the test `opens the attribution hover card inside the Sheet (Radix portal compatibility)`.
- **Fold in ISSUE-003 same PR**. Trivial extension since the fix is the same `sm:`-breakpoint wrap pattern PSY-467 already shipped.
- **N = 3 pills** on mobile. At 320-414px a typical pill (~60-120px wide including vote buttons) plus the `+ Add` chip and `Show all tags` chip still fits on one or two rows. More than 3 starts wrapping to a third row, which defeats the point.

## Implementation notes

- Both mobile (`sm:hidden`) and desktop (`hidden sm:flex`) rows render in the DOM. CSS utilities hide one; jsdom doesn't apply them, so existing tests had to scope within the desktop row. Added `data-testid="entity-tag-list-{mobile,desktop}-row"` and a `desktopRow()` helper in the test file.
- The add-tag `Dialog` is lifted out of its trigger into a single instance controlled by `addDialogOpen`. Both the desktop row's "Add" chip and the sheet-header "Add" action trigger it. Opening from inside the sheet closes the sheet first so Radix doesn't stack two overlay portals.
- Mobile row chip uses a `MoreHorizontal` icon + dashed border so it reads as "overflow" rather than as another pill.

## Test plan

- [x] `bun run test:run` — all 2653 tests pass
- [x] `bun run lint` — 180 problems at baseline (34 errors, 146 warnings); my changes introduced zero new problems and removed one stale import
- [x] New mobile-Sheet suite (9 tests) covers: 3-pill cap, "Show all" chip with hidden count, sheet total-count title, all tags reachable inside sheet, sheet-header Add opens Dialog, vote buttons render inside sheet, official indicator preserved in sheet, HoverCard portals inside sheet
- [x] New TagDetail header structural test asserts `flex-wrap` + `min-w-0` are present
- [x] Existing EntityTagList desktop tests (top-5 cap, Wilson sort, Show more / Show less, HoverCard, official indicator) still pass with `within(desktopRow())` scoping
- [ ] Visual verification at 320 / 375 / 414 / 640 / 1024 / 1440px — NOT performed: did not start the local dev stack in this worktree. The structural tests cover the wrap + sheet surfaces; real-device smoke test recommended before merge.

Closes PSY-460

🤖 Generated with [Claude Code](https://claude.com/claude-code)