### PR TITLE
PSY-473: delete admin-edit E2E (covered by ShowCard.test.tsx)

### DIFF
--- a/frontend/e2e/pages/show-list-actions.spec.ts
+++ b/frontend/e2e/pages/show-list-actions.spec.ts
@@ -77,22 +77,9 @@ test.describe('Show list actions', () => {
     ).toBeVisible({ timeout: 5_000 })
   })
 
-  test('show admin edit controls only for admins', async ({
-    authenticatedPage,
-    adminPage,
-  }) => {
-    await authenticatedPage.goto('/shows')
-    await expect(authenticatedPage.locator('article').first()).toBeVisible({
-      timeout: 10_000,
-    })
-    await expect(
-      authenticatedPage.locator('[title="Edit show"]').first()
-    ).toHaveCount(0)
-
-    await adminPage.goto('/shows')
-    await expect(adminPage.locator('article').first()).toBeVisible({
-      timeout: 10_000,
-    })
-    await expect(adminPage.locator('[title="Edit show"]').first()).toBeVisible()
-  })
+  // PSY-473 / Layer-5 audit item #5: the role-based conditional render
+  // for the admin edit control is already covered by
+  // `features/shows/components/ShowCard.test.tsx:226-234` (both `isAdmin`
+  // branches asserted via `screen.queryByTitle('Edit show')`). The E2E
+  // version spun up two full Playwright contexts for the same assertion.
 })


### PR DESCRIPTION
## Summary

Layer-5 audit item #5. Pure-redundancy deletion — the assertion lives in Vitest already.

The E2E test spun up **two** Playwright contexts (`authenticatedPage` + `adminPage`), navigated both to `/shows`, and asserted `[title="Edit show"]` is visible for the admin but absent for the non-admin. ~9 s round-trip for a single role-based conditional render and the highest-cost fixture setup in the suite.

`frontend/features/shows/components/ShowCard.test.tsx:226-234` covers exactly this:

- `does not show admin edit button for non-admin` — `render(<ShowCard ... isAdmin={false} />)` + `queryByTitle('Edit show')).not.toBeInTheDocument()`
- `shows admin edit button for admin` — `isAdmin={true}` + `getByTitle('Edit show')).toBeInTheDocument()`

Plus `toggles inline edit form when admin clicks edit` (lines 236-248) exercises the interaction itself.

Vitest run on main confirms 34/34 ShowCard tests pass today — coverage is live.

## Savings

~9 s serial runtime, two `authenticated*Page` context boots eliminated.

## Scope

- **Removed**: the single `show admin edit controls only for admins` test (lines 80-97 of `show-list-actions.spec.ts`).
- **Kept**: the other two tests in the same describe block (hidden save button for unauthenticated + toggle-save state for authenticated) — both genuinely real-backend / real-cookie E2Es.

## Test plan

- [x] Vitest: `bunx vitest run features/shows/components/ShowCard.test.tsx` → 34/34 pass
- [x] Diff review: no cross-test dependencies; the removed test was independent
- [ ] CI smoke passes
- [ ] Post-merge full suite reflects the removed test

Closes PSY-473.

🤖 Generated with [Claude Code](https://claude.com/claude-code)