### PR TITLE
PSY-474: fix register.spec.ts strict-mode flake (Next.js RouteAnnouncer)

### DIFF
--- a/frontend/e2e/auth/login.spec.ts
+++ b/frontend/e2e/auth/login.spec.ts
@@ -41,8 +41,12 @@ test.describe('Login', () => {
     await page.locator('#password').fill('wrong-password-here')
     await page.getByRole('button', { name: 'Sign in', exact: true }).click()
 
-    // Error alert appears
-    await expect(page.getByRole('alert')).toBeVisible({ timeout: 10_000 })
+    // PSY-474: filter by non-empty content to skip Next.js's RouteAnnouncer
+    // (a permanent empty `role="alert"` live region at the page root that
+    // would otherwise trip strict-mode alongside the form error alert).
+    await expect(
+      page.getByRole('alert').filter({ hasText: /.+/ })
+    ).toBeVisible({ timeout: 10_000 })
   })
 
   test('shows validation error for empty password', async ({ page }) => {

--- a/frontend/e2e/auth/register.spec.ts
+++ b/frontend/e2e/auth/register.spec.ts
@@ -72,11 +72,14 @@ test.describe('Registration', () => {
     // Submit — server will reject the breached password
     await page.getByRole('button', { name: 'Create account' }).click()
 
-    // Error alert should appear with breach message
-    await expect(page.getByRole('alert')).toBeVisible({ timeout: 10_000 })
+    // PSY-474: can't use `page.getByRole('alert')` unscoped — Next.js's
+    // RouteAnnouncer renders a permanent empty `role="alert"` live region
+    // at the page root for route narration, so any form-level alert makes
+    // the selector match 2 elements and trip strict-mode. The text check
+    // below is content-specific and sufficient on its own.
     await expect(
       page.getByText(/password has been exposed in a data breach/i)
-    ).toBeVisible()
+    ).toBeVisible({ timeout: 10_000 })
 
     // Still on /auth
     expect(page.url()).toContain('/auth')


### PR DESCRIPTION
## Summary

`register.spec.ts:62` "shows error for breached password" has been failing ~60% of post-merge main runs (3 of the last 5 reds — PSY-466, PSY-307, PSY-470 merges). Always the same shape:

```
Error: strict mode violation: getByRole('alert') resolved to 2 elements
    at .../e2e/auth/register.spec.ts:76:43
```

## Root cause

Next.js App Router renders a permanent empty `<p role="alert" aria-live="assertive">` at the page root — the `RouteAnnouncer` that narrates route changes for screen readers. Playwright's `page.getByRole('alert')` finds it. When the form-level error alert (`app/auth/page.tsx:276`) renders alongside, strict-mode matches 2 elements and the check fails.

Evidence — snapshot from [run 24652732690 shard 3](https://github.com/mtrifilo/psychic-homily-web/actions/runs/24652732690):

```yaml
# inside the form panel
- alert [ref=e169]: "Rate limit exceeded. Please try again in 60 seconds."
# at page root, between Next.js dev tools and cookie dialog
- alert [ref=e259]   # RouteAnnouncer, always present
```

The passing 40% of runs depend on fragile hydration timing where the RouteAnnouncer briefly hides from the accessibility tree. Not something to rely on.

## Changes

- **`register.spec.ts:76`** — delete the unscoped `getByRole('alert')` pre-check. The next assertion already checks the specific text (`/password has been exposed in a data breach/i`), so the pre-check was redundant.
- **`login.spec.ts:45`** — this was the *sole* assertion for the test, so it can't just be deleted. Scope with `.filter({ hasText: /.+/ })` to skip empty alert elements.

Both sites carry a `PSY-474` inline comment explaining the RouteAnnouncer issue for future devs.

## Test plan

- [x] `bunx tsc --noEmit` clean on touched specs.
- [ ] Smoke-on-PR passes (this PR touches `login.spec.ts` which has an `@smoke` test, so the PR CI exercises the fix).
- [ ] Post-merge full suite shard 3 goes green on `register.spec.ts:62` for 3 consecutive runs.

## Out of scope

- `magic-link.spec.ts:20` "@smoke" flake — different symptom (`waitForURL` timeout, not strict-mode violation). Tracked as a separate followup if it continues to surface.
- The underlying backend rate-limit that made one failure's form show "Rate limit exceeded" instead of the expected breach message — the selector fix makes the test robust regardless.

Closes PSY-474.

🤖 Generated with [Claude Code](https://claude.com/claude-code)