### PR TITLE
PSY-476: stop ReportShowButton flashing 'Reported' during loading

### DIFF
--- a/frontend/features/shows/components/ReportShowButton.test.tsx
+++ b/frontend/features/shows/components/ReportShowButton.test.tsx
@@ -129,4 +129,26 @@ describe('ReportShowButton', () => {
 
     expect(screen.getByRole('button', { name: /Report Issue/ })).toBeDisabled()
   })
+
+  // PSY-476: during the first render of a React Query hook, `data` is
+  // actually `undefined` (not `{report: null}` as the earlier test
+  // implied). The previous `hasReported = myReport?.report !== null`
+  // guard evaluated `undefined !== null` → true and flashed the
+  // "Reported" disabled button before real data arrived.
+  it('does not flash "Reported" when query is loading with undefined data', () => {
+    mockAuthContext.mockReturnValue({
+      user: { id: '1', is_admin: false },
+      isAuthenticated: true,
+      isLoading: false,
+      logout: vi.fn(),
+    })
+    mockMyShowReport.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    })
+    render(<ReportShowButton showId={1} showTitle="Test Show" />)
+
+    expect(screen.queryByRole('button', { name: /^Reported$/ })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Report Issue/ })).toBeDisabled()
+  })
 })

--- a/frontend/features/shows/components/ReportShowButton.tsx
+++ b/frontend/features/shows/components/ReportShowButton.tsx
@@ -30,7 +30,12 @@ export function ReportShowButton({
   const [isReportDialogOpen, setIsReportDialogOpen] = useState(false)
   const [isLoginPromptOpen, setIsLoginPromptOpen] = useState(false)
 
-  const hasReported = myReport?.report !== null
+  // PSY-476: `myReport?.report !== null` is true when the query is still
+  // loading (`myReport` undefined → `undefined !== null` → true), which
+  // flashed the disabled "Reported" state before real data arrived. Gate
+  // on `!isLoading` and use loose `!= null` so both `undefined` and `null`
+  // mean "no existing report".
+  const hasReported = !isLoading && myReport?.report != null
 
   // If user has already reported, show a disabled "Reported" button
   if (isAuthenticated && hasReported) {


### PR DESCRIPTION
## Summary

`ReportShowButton` briefly rendered the disabled "Reported" badge on every authenticated mount before the `useMyShowReport` query resolved. Unguarded undefined/null comparison:

```ts
// line 33 on main
const hasReported = myReport?.report !== null
```

During loading `myReport` is `undefined`, so `myReport?.report` is `undefined` and `undefined !== null` evaluates to `true`. The early-return on line 36 (`if (isAuthenticated && hasReported)`) fired. Once the query resolved, the correct state rendered — but the flash happened on every mount.

## Fix

```ts
const hasReported = !isLoading && myReport?.report != null
```

- `!isLoading` suppresses the early-return while the query is in flight.
- `!= null` (loose) treats `undefined` and `null` both as "no report", so whichever shape lands after loading reads correctly.

Added a regression test (`does not flash "Reported" when query is loading with undefined data`) that mocks `data: undefined, isLoading: true` — the actual initial shape from TanStack Query, rather than the pre-existing test's `{report: null}` proxy that hid the bug.

## Provenance

Discovered during the [PSY-465 ArtistDetail static-analysis audit](https://linear.app/psychic-homily/issue/PSY-465). Independent of the cold-load error-boundary flake — this is a separate real UX bug flagged by the same investigation.

## Test plan

- [x] `bunx vitest run features/shows/components/ReportShowButton.test.tsx` → 8/8 pass (7 existing + 1 new regression)
- [ ] Smoke CI passes on this PR
- [ ] Manually verify no "Reported" flash on a show page for a user who hasn't reported

Closes PSY-476.

🤖 Generated with [Claude Code](https://claude.com/claude-code)