### PR TITLE
PSY-477: gate useNotificationFilters on auth

### DIFF
--- a/frontend/features/notifications/hooks/index.test.tsx
+++ b/frontend/features/notifications/hooks/index.test.tsx
@@ -17,6 +17,15 @@ vi.mock('@/lib/queryClient', () => ({
   },
 }))
 
+// PSY-477: useNotificationFilters now gates on isAuthenticated so
+// anonymous visitors of public entity pages don't fire 401 requests.
+// Default the mock to authenticated for all existing behavioral tests;
+// the anonymous case has its own dedicated test below.
+const mockUseAuthContext = vi.fn(() => ({ isAuthenticated: true }))
+vi.mock('@/lib/context/AuthContext', () => ({
+  useAuthContext: () => mockUseAuthContext(),
+}))
+
 import {
   useNotificationFilters,
   useNotificationFilterCheck,
@@ -59,6 +68,20 @@ describe('useNotificationFilters', () => {
     })
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
+  })
+
+  // PSY-477: the hook is called transitively by NotifyMeButton on public
+  // entity pages (artist / venue / label / festival). Without the auth
+  // gate, every anonymous visit fires a 401'd GET /me/notification-filters.
+  it('does not fire the query when user is unauthenticated', () => {
+    mockUseAuthContext.mockReturnValueOnce({ isAuthenticated: false })
+    mockApiRequest.mockRejectedValue(new Error('should not be called'))
+
+    renderHook(() => useNotificationFilters(), {
+      wrapper: createWrapper(),
+    })
+
+    expect(mockApiRequest).not.toHaveBeenCalled()
   })
 })
 

--- a/frontend/features/notifications/hooks/index.ts
+++ b/frontend/features/notifications/hooks/index.ts
@@ -8,6 +8,7 @@
 
 import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query'
 import { apiRequest, API_BASE_URL } from '@/lib/api'
+import { useAuthContext } from '@/lib/context/AuthContext'
 import { queryKeys } from '@/lib/queryClient'
 import type {
   NotificationFilter,
@@ -34,12 +35,19 @@ const FILTER_ENDPOINTS = {
 
 /** Fetch all notification filters for the current user */
 export function useNotificationFilters() {
+  // PSY-477: gate on auth so anonymous visitors of public entity pages
+  // (artist / venue / label / festival, via NotifyMeButton →
+  // useNotificationFilterCheck → this hook) don't fire a 401'd request.
+  // FilterList on the notification settings page is behind auth anyway,
+  // so this is strictly a no-op there.
+  const { isAuthenticated } = useAuthContext()
   return useQuery({
     queryKey: queryKeys.notificationFilters.all,
     queryFn: () =>
       apiRequest<{ filters: NotificationFilter[] }>(FILTER_ENDPOINTS.LIST),
     staleTime: 5 * 60 * 1000,
     placeholderData: keepPreviousData,
+    enabled: isAuthenticated,
   })
 }
 


### PR DESCRIPTION
## Summary

`useNotificationFilters` is called transitively by `NotifyMeButton` on every public entity detail page (artist / venue / label / festival) via `useNotificationFilterCheck`. Without an `enabled` gate, every anonymous visit fires a `GET /me/notification-filters` that returns 401, producing `huma_jwt_token_missing` backend warnings on every cold-load of those routes.

## Fix

```ts
export function useNotificationFilters() {
  const { isAuthenticated } = useAuthContext()
  return useQuery({
    // ...
    enabled: isAuthenticated,
  })
}
```

Matches the pattern used in `features/auth/hooks/useFavoriteVenues.ts:59` and `features/venues/components/FavoriteVenuesTab.tsx:163,217,263`.

## Downstream impact

- **`NotifyMeButton`** — already handles `data: undefined` via optional chaining. No change.
- **`useNotificationFilterCheck`** — already handles `data: undefined` via optional chaining. No change.
- **`FilterList`** (notification settings page) — only rendered on authenticated routes, so the gate is a no-op there.

## Provenance

Discovered during the [PSY-465 ArtistDetail static-analysis audit](https://linear.app/psychic-homily/issue/PSY-465). Independent of the cold-load error-boundary flake — this is a separate production bug flagged by the same investigation.

## Test plan

- [x] `bunx vitest run features/notifications/` → 31/31 pass (29 existing + 2 touched for new mock + new anonymous regression case)
- [ ] Smoke CI passes
- [ ] Verify in browser: anonymous visit of `/artists/[slug]` produces zero `/me/notification-filters` requests (network tab)

Closes PSY-477.

🤖 Generated with [Claude Code](https://claude.com/claude-code)