### PR TITLE
PSY-465: force trace:'on' to capture failing ArtistDetail cold-load attempt

### DIFF
--- a/frontend/e2e/pages/follow-and-attendance.spec.ts
+++ b/frontend/e2e/pages/follow-and-attendance.spec.ts
@@ -21,6 +21,16 @@ test.describe('Follow and attendance', () => {
   // run in parallel within this file.
   test.describe.configure({ mode: 'serial' })
 
+  // PSY-465 (temporary — revert after trace capture): override the global
+  // `trace: 'on-first-retry'` config so the FAILING attempt's trace is
+  // captured, not just the clean retry. The flake surfaces only on the
+  // first attempt (cold-load of /artists/[slug] → a child of ArtistDetail
+  // throws → route-level error boundary catches → the test times out).
+  // The retry renders cleanly, so `on-first-retry` captures nothing
+  // useful. Remove this line once the throwing component is identified
+  // and the defensive fix lands.
+  test.use({ trace: 'on' })
+
   // PSY-470: the in-test cleanup at the happy-path tail only runs when the
   // test passes. When a mid-test failure skips it (see PSY-465), the shared
   // reserved artist/show rows leak follower/attendance count into the next

--- a/frontend/e2e/pages/follow-and-attendance.spec.ts
+++ b/frontend/e2e/pages/follow-and-attendance.spec.ts
@@ -16,20 +16,21 @@ const RESERVED_SHOW_SLUG = 'e2e-attendance-test'
 const RESERVED_SHOW_TITLE = 'E2E [attendance-test]'
 const RESERVED_SHOW_URL = `/shows/${RESERVED_SHOW_SLUG}`
 
+// PSY-465 (temporary — revert after trace capture): override the global
+// `trace: 'on-first-retry'` config at file-level so the FAILING attempt's
+// trace is captured, not just the clean retry. The flake surfaces only on
+// the first attempt (cold-load of /artists/[slug] → a child of
+// ArtistDetail throws → route-level error boundary catches → the test
+// times out). The retry renders cleanly, so `on-first-retry` captures
+// nothing useful. Must be top-level per Playwright; scoped-inside-describe
+// throws "Cannot use({ trace }) in a describe group". Remove this line
+// once the throwing component is identified and the defensive fix lands.
+test.use({ trace: 'on' })
+
 test.describe('Follow and attendance', () => {
   // Tests share DB state with the same per-worker user, so they must not
   // run in parallel within this file.
   test.describe.configure({ mode: 'serial' })
-
-  // PSY-465 (temporary — revert after trace capture): override the global
-  // `trace: 'on-first-retry'` config so the FAILING attempt's trace is
-  // captured, not just the clean retry. The flake surfaces only on the
-  // first attempt (cold-load of /artists/[slug] → a child of ArtistDetail
-  // throws → route-level error boundary catches → the test times out).
-  // The retry renders cleanly, so `on-first-retry` captures nothing
-  // useful. Remove this line once the throwing component is identified
-  // and the defensive fix lands.
-  test.use({ trace: 'on' })
 
   // PSY-470: the in-test cleanup at the happy-path tail only runs when the
   // test passes. When a mid-test failure skips it (see PSY-465), the shared


### PR DESCRIPTION
## Summary

**Pivoted from PR-CI capture to post-merge capture** after 4 smoke-on-PR runs with `trace: 'on'` showed zero flake reproduction. The flake reproduces on post-merge full-suite runs ~40% of the time (always on shard 3); smoke-on-PR's smaller suite composition doesn't trigger the race.

Merging this temporary override means the next 2–3 post-merge full-suite runs will each capture a failing trace for `follow-and-attendance.spec.ts:19` if the flake fires. Once captured:

1. Download the `blob-report-3` artifact from the failing run
2. Analyze the trace to identify the throwing component
3. Ship the defensive fix in a follow-up PR that also reverts this `test.use({ trace: 'on' })` line

## Change

One file: `frontend/e2e/pages/follow-and-attendance.spec.ts` — top-level `test.use({ trace: 'on' })` override.

Scoped to this spec only. Other specs keep the global `trace: 'on-first-retry'` config. Negligible CI cost (one extra trace file per run of these tests).

## Why not reproduce on smoke

Observed during the 4 PR-CI smoke attempts: smoke runs ~15-20 tests, full suite runs ~70 across 4 shards. Every documented hit of this flake is shard 3 on the full suite. Shard composition / suite ordering matters — smoke never puts this test in the right context to trigger the race.

## Test plan

- [x] PR CI passes (none of our 4 attempts exhibited the flake — expected for smoke)
- [ ] Merge → next post-merge full-suite run captures trace on shard 3 if flake fires
- [ ] Follow-up PR: defensive fix + revert this override

🤖 Generated with [Claude Code](https://claude.com/claude-code)