### PR TITLE
PSY-458: fix React Compiler memo dep in TagDetail

### DIFF
--- a/frontend/features/tags/components/TagDetail.tsx
+++ b/frontend/features/tags/components/TagDetail.tsx
@@ -375,17 +375,18 @@ function TagPill({ tag }: { tag: TagSummary }) {
 function TaggedEntitiesSection({ slug }: { slug: string }) {
   const { data, isLoading } = useTagEntities(slug, { limit: 200 })
 
+  const entities = data?.entities
   const grouped = useMemo(() => {
-    if (!data?.entities) return {}
+    if (!entities) return {}
     const groups: Record<string, TaggedEntityItem[]> = {}
-    for (const entity of data.entities) {
+    for (const entity of entities) {
       if (!groups[entity.entity_type]) {
         groups[entity.entity_type] = []
       }
       groups[entity.entity_type].push(entity)
     }
     return groups
-  }, [data?.entities])
+  }, [entities])
 
   const sortedTypes = useMemo(() => {
     return ENTITY_TYPE_ORDER.filter((t) => grouped[t]?.length)


### PR DESCRIPTION
## Summary

- The `grouped` useMemo in `TaggedEntitiesSection` declared `[data?.entities]` as its dep, but React Compiler inferred `data.entities`. The mismatch made the compiler skip optimizing the whole component with `react-hooks/preserve-manual-memoization`.
- Fixed by pulling `data?.entities` into a local const `entities` and depending on that, so the source and inferred deps line up.

## Scope

Scoped to the single `useMemo` at the previous line 378. I swept the rest of the file for sibling useMemos with the same shape:

- `breakdownEntries` (line 59) depends on `[tag]` and accesses `tag.usage_breakdown` / properties — dep is the whole object, no mismatch.
- `visibleContributors` (line 70) depends on `[tag]` and accesses `tag.top_contributors` — same, no mismatch.
- `sortedTypes` (line 390) depends on `[grouped]` and reads `grouped[t]` — no mismatch.

ESLint confirms: only the one error, and it's gone after this change. Nothing else in `TagDetail.tsx` touched.

## Test plan

- [x] `bunx eslint features/tags/components/TagDetail.tsx` — zero errors
- [x] `bunx vitest run features/tags` — 181 passed
- [x] `bunx tsc --noEmit -p tsconfig.json` — no new errors on the touched file (pre-existing errors are all in unrelated test files)

Closes PSY-458

Generated with [Claude Code](https://claude.com/claude-code)