### PR TITLE
PSY-485: Add tabbed Tagged Entities + SEO title on tag detail page

### DIFF
--- a/backend/internal/services/catalog/tag_service.go
+++ b/backend/internal/services/catalog/tag_service.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 
 	"gorm.io/gorm"
 
@@ -1071,6 +1072,12 @@ var entityTableMap = map[string]struct {
 }
 
 // GetTagEntities returns entities tagged with a given tag, optionally filtered by entity type.
+//
+// PSY-485: in addition to (entity_type, entity_id, name, slug), this populates
+// per-type fields (city/state, verified, upcoming_show_count, edition_year,
+// release_type, etc.) so the tag detail page can render proper entity cards
+// instead of bare links. Each entity type has its own enrichment query;
+// failures fall back to bare info so we never lose the link.
 func (s *TagService) GetTagEntities(tagID uint, entityType string, limit, offset int) ([]contracts.TaggedEntityItem, int64, error) {
 	if s.db == nil {
 		return nil, 0, fmt.Errorf("database not initialized")
@@ -1109,54 +1116,393 @@ func (s *TagService) GetTagEntities(tagID uint, entityType string, limit, offset
 		byType[et.EntityType] = append(byType[et.EntityType], et.EntityID)
 	}
 
-	// Resolve names and slugs per entity type
-	type entityInfo struct {
+	// Per-type enrichment: builds an index keyed by entityID with all the
+	// optional card fields populated. Each branch swallows query errors and
+	// falls back to bare info so the response is robust if a downstream
+	// table is missing or a JOIN fails.
+	enrichedByType := make(map[string]map[uint]contracts.TaggedEntityItem)
+	for eType, ids := range byType {
+		switch eType {
+		case "artist":
+			enrichedByType[eType] = s.enrichArtists(ids)
+		case "venue":
+			enrichedByType[eType] = s.enrichVenues(ids)
+		case "festival":
+			enrichedByType[eType] = s.enrichFestivals(ids)
+		case "label":
+			enrichedByType[eType] = s.enrichLabels(ids)
+		case "release":
+			enrichedByType[eType] = s.enrichReleases(ids)
+		case "show":
+			enrichedByType[eType] = s.enrichShows(ids)
+		default:
+			enrichedByType[eType] = s.enrichBare(eType, ids)
+		}
+	}
+
+	// Build response in the same order as entityTags (preserves created_at DESC).
+	items := make([]contracts.TaggedEntityItem, 0, len(entityTags))
+	for _, et := range entityTags {
+		item := contracts.TaggedEntityItem{
+			EntityType: et.EntityType,
+			EntityID:   et.EntityID,
+		}
+		if m, ok := enrichedByType[et.EntityType]; ok {
+			if enriched, ok := m[et.EntityID]; ok {
+				// Carry enriched fields, but preserve canonical EntityType / EntityID
+				// from the entity_tags row.
+				enriched.EntityType = et.EntityType
+				enriched.EntityID = et.EntityID
+				item = enriched
+			}
+		}
+		items = append(items, item)
+	}
+
+	return items, total, nil
+}
+
+// enrichBare is a fallback for entity types we don't have a richer query for.
+// It only resolves the name and slug, leaving all other optional fields zero.
+func (s *TagService) enrichBare(entityType string, ids []uint) map[uint]contracts.TaggedEntityItem {
+	out := make(map[uint]contracts.TaggedEntityItem, len(ids))
+	meta, ok := entityTableMap[entityType]
+	if !ok {
+		return out
+	}
+	type row struct {
 		ID   uint
 		Name string
 		Slug string
 	}
-	infoMap := make(map[string]map[uint]entityInfo) // entityType -> entityID -> info
-
-	for eType, ids := range byType {
-		meta, ok := entityTableMap[eType]
-		if !ok {
-			continue
-		}
-
-		var results []entityInfo
-		err := s.db.Raw(
-			fmt.Sprintf("SELECT id, %s AS name, COALESCE(slug, '') AS slug FROM %s WHERE id IN ?", meta.nameCol, meta.table),
-			ids,
-		).Scan(&results).Error
-		if err != nil {
-			continue // skip if table doesn't exist or query fails
-		}
-
-		m := make(map[uint]entityInfo, len(results))
-		for _, r := range results {
-			m[r.ID] = r
-		}
-		infoMap[eType] = m
+	var rows []row
+	if err := s.db.Raw(
+		fmt.Sprintf("SELECT id, %s AS name, COALESCE(slug, '') AS slug FROM %s WHERE id IN ?", meta.nameCol, meta.table),
+		ids,
+	).Scan(&rows).Error; err != nil {
+		return out
 	}
-
-	// Build response
-	items := make([]contracts.TaggedEntityItem, 0, len(entityTags))
-	for _, et := range entityTags {
-		info := entityInfo{}
-		if m, ok := infoMap[et.EntityType]; ok {
-			if i, ok := m[et.EntityID]; ok {
-				info = i
-			}
-		}
-		items = append(items, contracts.TaggedEntityItem{
-			EntityType: et.EntityType,
-			EntityID:   et.EntityID,
-			Name:       info.Name,
-			Slug:       info.Slug,
-		})
+	for _, r := range rows {
+		out[r.ID] = contracts.TaggedEntityItem{Name: r.Name, Slug: r.Slug}
 	}
+	return out
+}
 
-	return items, total, nil
+// enrichArtists adds city/state and an upcoming-show count to each artist row.
+// Upcoming = shows with event_date >= NOW(). Joined via show_artists.
+func (s *TagService) enrichArtists(ids []uint) map[uint]contracts.TaggedEntityItem {
+	out := make(map[uint]contracts.TaggedEntityItem, len(ids))
+	type row struct {
+		ID                uint
+		Name              string
+		Slug              string
+		City              string
+		State             string
+		UpcomingShowCount int
+	}
+	var rows []row
+	err := s.db.Raw(`
+		SELECT a.id,
+		       a.name,
+		       COALESCE(a.slug, '') AS slug,
+		       COALESCE(a.city, '') AS city,
+		       COALESCE(a.state, '') AS state,
+		       COALESCE(c.cnt, 0)::int AS upcoming_show_count
+		FROM artists a
+		LEFT JOIN (
+		    SELECT sa.artist_id, COUNT(DISTINCT s.id) AS cnt
+		    FROM show_artists sa
+		    JOIN shows s ON s.id = sa.show_id
+		    WHERE s.event_date >= NOW()
+		    GROUP BY sa.artist_id
+		) c ON c.artist_id = a.id
+		WHERE a.id IN ?
+	`, ids).Scan(&rows).Error
+	if err != nil {
+		// Fallback: at least name + slug so the link still works.
+		return s.enrichBare("artist", ids)
+	}
+	for _, r := range rows {
+		count := r.UpcomingShowCount
+		out[r.ID] = contracts.TaggedEntityItem{
+			Name:              r.Name,
+			Slug:              r.Slug,
+			City:              r.City,
+			State:             r.State,
+			UpcomingShowCount: &count,
+		}
+	}
+	return out
+}
+
+// enrichVenues adds city/state, the verified flag, and an upcoming-show count.
+func (s *TagService) enrichVenues(ids []uint) map[uint]contracts.TaggedEntityItem {
+	out := make(map[uint]contracts.TaggedEntityItem, len(ids))
+	type row struct {
+		ID                uint
+		Name              string
+		Slug              string
+		City              string
+		State             string
+		Verified          bool
+		UpcomingShowCount int
+	}
+	var rows []row
+	err := s.db.Raw(`
+		SELECT v.id,
+		       v.name,
+		       COALESCE(v.slug, '') AS slug,
+		       COALESCE(v.city, '') AS city,
+		       COALESCE(v.state, '') AS state,
+		       v.verified,
+		       COALESCE(c.cnt, 0)::int AS upcoming_show_count
+		FROM venues v
+		LEFT JOIN (
+		    SELECT sv.venue_id, COUNT(DISTINCT s.id) AS cnt
+		    FROM show_venues sv
+		    JOIN shows s ON s.id = sv.show_id
+		    WHERE s.event_date >= NOW()
+		    GROUP BY sv.venue_id
+		) c ON c.venue_id = v.id
+		WHERE v.id IN ?
+	`, ids).Scan(&rows).Error
+	if err != nil {
+		return s.enrichBare("venue", ids)
+	}
+	for _, r := range rows {
+		verified := r.Verified
+		count := r.UpcomingShowCount
+		out[r.ID] = contracts.TaggedEntityItem{
+			Name:              r.Name,
+			Slug:              r.Slug,
+			City:              r.City,
+			State:             r.State,
+			Verified:          &verified,
+			UpcomingShowCount: &count,
+		}
+	}
+	return out
+}
+
+// enrichFestivals adds edition year, location, status, dates, and counts.
+func (s *TagService) enrichFestivals(ids []uint) map[uint]contracts.TaggedEntityItem {
+	out := make(map[uint]contracts.TaggedEntityItem, len(ids))
+	type row struct {
+		ID          uint
+		Name        string
+		Slug        string
+		EditionYear int
+		City        string
+		State       string
+		Status      string
+		StartDate   time.Time
+		EndDate     time.Time
+		ArtistCount int
+		VenueCount  int
+	}
+	var rows []row
+	err := s.db.Raw(`
+		SELECT f.id,
+		       f.name,
+		       COALESCE(f.slug, '') AS slug,
+		       f.edition_year,
+		       COALESCE(f.city, '') AS city,
+		       COALESCE(f.state, '') AS state,
+		       f.status,
+		       f.start_date,
+		       f.end_date,
+		       COALESCE(ac.cnt, 0)::int AS artist_count,
+		       COALESCE(vc.cnt, 0)::int AS venue_count
+		FROM festivals f
+		LEFT JOIN (
+		    SELECT festival_id, COUNT(*) AS cnt FROM festival_artists GROUP BY festival_id
+		) ac ON ac.festival_id = f.id
+		LEFT JOIN (
+		    SELECT festival_id, COUNT(*) AS cnt FROM festival_venues GROUP BY festival_id
+		) vc ON vc.festival_id = f.id
+		WHERE f.id IN ?
+	`, ids).Scan(&rows).Error
+	if err != nil {
+		return s.enrichBare("festival", ids)
+	}
+	for _, r := range rows {
+		year := r.EditionYear
+		ac := r.ArtistCount
+		vc := r.VenueCount
+		out[r.ID] = contracts.TaggedEntityItem{
+			Name:        r.Name,
+			Slug:        r.Slug,
+			EditionYear: &year,
+			City:        r.City,
+			State:       r.State,
+			Status:      r.Status,
+			StartDate:   r.StartDate.Format("2006-01-02"),
+			EndDate:     r.EndDate.Format("2006-01-02"),
+			ArtistCount: &ac,
+			VenueCount:  &vc,
+		}
+	}
+	return out
+}
+
+// enrichLabels adds location, status, and roster/catalog counts.
+func (s *TagService) enrichLabels(ids []uint) map[uint]contracts.TaggedEntityItem {
+	out := make(map[uint]contracts.TaggedEntityItem, len(ids))
+	type row struct {
+		ID           uint
+		Name         string
+		Slug         string
+		City         string
+		State        string
+		Status       string
+		ArtistCount  int
+		ReleaseCount int
+	}
+	var rows []row
+	err := s.db.Raw(`
+		SELECT l.id,
+		       l.name,
+		       COALESCE(l.slug, '') AS slug,
+		       COALESCE(l.city, '') AS city,
+		       COALESCE(l.state, '') AS state,
+		       l.status,
+		       COALESCE(ac.cnt, 0)::int AS artist_count,
+		       COALESCE(rc.cnt, 0)::int AS release_count
+		FROM labels l
+		LEFT JOIN (
+		    SELECT label_id, COUNT(*) AS cnt FROM artist_labels GROUP BY label_id
+		) ac ON ac.label_id = l.id
+		LEFT JOIN (
+		    SELECT label_id, COUNT(*) AS cnt FROM release_labels GROUP BY label_id
+		) rc ON rc.label_id = l.id
+		WHERE l.id IN ?
+	`, ids).Scan(&rows).Error
+	if err != nil {
+		return s.enrichBare("label", ids)
+	}
+	for _, r := range rows {
+		ac := r.ArtistCount
+		rc := r.ReleaseCount
+		out[r.ID] = contracts.TaggedEntityItem{
+			Name:         r.Name,
+			Slug:         r.Slug,
+			City:         r.City,
+			State:        r.State,
+			Status:       r.Status,
+			ArtistCount:  &ac,
+			ReleaseCount: &rc,
+		}
+	}
+	return out
+}
+
+// enrichReleases adds release type, year, and cover art URL.
+func (s *TagService) enrichReleases(ids []uint) map[uint]contracts.TaggedEntityItem {
+	out := make(map[uint]contracts.TaggedEntityItem, len(ids))
+	type row struct {
+		ID          uint
+		Title       string
+		Slug        string
+		ReleaseType string
+		ReleaseYear *int
+		CoverArtURL *string
+	}
+	var rows []row
+	err := s.db.Raw(`
+		SELECT id,
+		       title,
+		       COALESCE(slug, '') AS slug,
+		       release_type,
+		       release_year,
+		       cover_art_url
+		FROM releases
+		WHERE id IN ?
+	`, ids).Scan(&rows).Error
+	if err != nil {
+		return s.enrichBare("release", ids)
+	}
+	for _, r := range rows {
+		item := contracts.TaggedEntityItem{
+			Name:        r.Title,
+			Slug:        r.Slug,
+			ReleaseType: r.ReleaseType,
+		}
+		if r.ReleaseYear != nil {
+			y := *r.ReleaseYear
+			item.ReleaseYear = &y
+		}
+		if r.CoverArtURL != nil {
+			item.CoverArtURL = *r.CoverArtURL
+		}
+		out[r.ID] = item
+	}
+	return out
+}
+
+// enrichShows adds event_date, the primary venue, and the headliner artist
+// (position = 0 OR set_type = 'headliner'). Falls back to lowest position
+// when no explicit headliner is recorded.
+func (s *TagService) enrichShows(ids []uint) map[uint]contracts.TaggedEntityItem {
+	out := make(map[uint]contracts.TaggedEntityItem, len(ids))
+	type row struct {
+		ID            uint
+		Title         string
+		Slug          string
+		EventDate     time.Time
+		City          string
+		State         string
+		VenueName     string
+		VenueSlug     string
+		HeadlinerName string
+		HeadlinerSlug string
+	}
+	var rows []row
+	err := s.db.Raw(`
+		SELECT s.id,
+		       COALESCE(s.title, '') AS title,
+		       COALESCE(s.slug, '') AS slug,
+		       s.event_date,
+		       COALESCE(s.city, '') AS city,
+		       COALESCE(s.state, '') AS state,
+		       COALESCE(v.name, '') AS venue_name,
+		       COALESCE(v.slug, '') AS venue_slug,
+		       COALESCE(a.name, '') AS headliner_name,
+		       COALESCE(a.slug, '') AS headliner_slug
+		FROM shows s
+		LEFT JOIN LATERAL (
+		    SELECT vv.id, vv.name, vv.slug
+		    FROM show_venues sv
+		    JOIN venues vv ON vv.id = sv.venue_id
+		    WHERE sv.show_id = s.id
+		    LIMIT 1
+		) v ON true
+		LEFT JOIN LATERAL (
+		    SELECT aa.id, aa.name, aa.slug
+		    FROM show_artists sa
+		    JOIN artists aa ON aa.id = sa.artist_id
+		    WHERE sa.show_id = s.id
+		    ORDER BY (sa.set_type = 'headliner') DESC, sa.position ASC
+		    LIMIT 1
+		) a ON true
+		WHERE s.id IN ?
+	`, ids).Scan(&rows).Error
+	if err != nil {
+		return s.enrichBare("show", ids)
+	}
+	for _, r := range rows {
+		out[r.ID] = contracts.TaggedEntityItem{
+			Name:          r.Title,
+			Slug:          r.Slug,
+			EventDate:     r.EventDate.Format(time.RFC3339),
+			City:          r.City,
+			State:         r.State,
+			VenueName:     r.VenueName,
+			VenueSlug:     r.VenueSlug,
+			HeadlinerName: r.HeadlinerName,
+			HeadlinerSlug: r.HeadlinerSlug,
+		}
+	}
+	return out
 }
 
 // ──────────────────────────────────────────────

--- a/backend/internal/services/contracts/tag.go
+++ b/backend/internal/services/contracts/tag.go
@@ -130,11 +130,46 @@ type EntityTagResponse struct {
 }
 
 // TaggedEntityItem represents a single entity tagged with a given tag.
+//
+// PSY-485: extended with optional per-entity-type fields so the tag detail
+// page can render proper entity cards (image/city/upcoming count for
+// artists, verified badge + city for venues, date range/edition for
+// festivals, etc.) instead of bare links. Fields are populated only when
+// applicable to the entity type and otherwise omitted from the response.
 type TaggedEntityItem struct {
 	EntityType string `json:"entity_type"`
 	EntityID   uint   `json:"entity_id"`
 	Name       string `json:"name"`
 	Slug       string `json:"slug"`
+	// Common location (artist, venue, label, festival).
+	City  string `json:"city,omitempty"`
+	State string `json:"state,omitempty"`
+	// Venue-specific.
+	Verified *bool `json:"verified,omitempty"`
+	// Artist/venue-specific.
+	UpcomingShowCount *int `json:"upcoming_show_count,omitempty"`
+	// Festival-specific.
+	EditionYear *int   `json:"edition_year,omitempty"`
+	StartDate   string `json:"start_date,omitempty"`
+	EndDate     string `json:"end_date,omitempty"`
+	// Status applies to festivals (announced/confirmed/cancelled/completed)
+	// and labels (active/inactive/defunct).
+	Status string `json:"status,omitempty"`
+	// Counts populated for festivals (artists in lineup) and labels
+	// (artists on roster, releases in catalog).
+	ArtistCount  *int `json:"artist_count,omitempty"`
+	ReleaseCount *int `json:"release_count,omitempty"`
+	VenueCount   *int `json:"venue_count,omitempty"`
+	// Release-specific.
+	ReleaseType string `json:"release_type,omitempty"`
+	ReleaseYear *int   `json:"release_year,omitempty"`
+	CoverArtURL string `json:"cover_art_url,omitempty"`
+	// Show-specific.
+	EventDate     string `json:"event_date,omitempty"`
+	VenueName     string `json:"venue_name,omitempty"`
+	VenueSlug     string `json:"venue_slug,omitempty"`
+	HeadlinerName string `json:"headliner_name,omitempty"`
+	HeadlinerSlug string `json:"headliner_slug,omitempty"`
 }
 
 // TagAliasResponse represents a tag alias returned to clients.

--- a/frontend/app/tags/[slug]/page.tsx
+++ b/frontend/app/tags/[slug]/page.tsx
@@ -1,9 +1,95 @@
-'use client'
-
 import { Suspense } from 'react'
-import { useParams } from 'next/navigation'
+import type { Metadata } from 'next'
+import * as Sentry from '@sentry/nextjs'
 import { Loader2 } from 'lucide-react'
 import { TagDetail } from '@/features/tags/components'
+
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL ||
+  (process.env.NODE_ENV === 'development'
+    ? 'http://localhost:8080'
+    : 'https://api.psychichomily.com')
+
+interface TagPageProps {
+  params: Promise<{ slug: string }>
+}
+
+interface TagSummaryForMetadata {
+  name: string
+  slug?: string
+  category?: string
+  usage_count?: number
+}
+
+/**
+ * Fetch tag metadata for the document head. We deliberately use the lightweight
+ * GET /tags/{slug} endpoint (not /tags/{slug}/detail) because we only need
+ * name + usage_count for the title/description; the enriched detail call has
+ * extra cost for content the client component will fetch anyway. (PSY-485)
+ */
+async function getTagForMetadata(
+  slug: string
+): Promise<TagSummaryForMetadata | null> {
+  try {
+    const res = await fetch(`${API_BASE_URL}/tags/${slug}`, {
+      next: { revalidate: 3600 },
+    })
+    if (res.ok) {
+      return res.json()
+    }
+    if (res.status >= 500) {
+      Sentry.captureMessage(`Tag page metadata fetch error: ${res.status}`, {
+        level: 'error',
+        tags: { service: 'tag-page' },
+        extra: { slug, status: res.status },
+      })
+    }
+  } catch (error) {
+    Sentry.captureException(error, {
+      level: 'error',
+      tags: { service: 'tag-page' },
+      extra: { slug },
+    })
+  }
+  return null
+}
+
+export async function generateMetadata({
+  params,
+}: TagPageProps): Promise<Metadata> {
+  const { slug } = await params
+  const tag = await getTagForMetadata(slug)
+
+  if (tag) {
+    const usageCount = tag.usage_count ?? 0
+    // Description ties the tag to the things people actually browse for —
+    // shows/artists/releases — so the SERP snippet is concrete rather than
+    // generic boilerplate.
+    const description =
+      usageCount > 0
+        ? `Browse ${usageCount} ${usageCount === 1 ? 'entity' : 'entities'} (artists, shows, releases, and more) tagged ${tag.name} on Psychic Homily.`
+        : `Discover artists, shows, and releases tagged ${tag.name} on Psychic Homily.`
+
+    return {
+      title: `${tag.name} | Tags`,
+      description,
+      alternates: {
+        canonical: `https://psychichomily.com/tags/${slug}`,
+      },
+      openGraph: {
+        title: `${tag.name} | Tags | Psychic Homily`,
+        description,
+        type: 'website',
+        url: `/tags/${slug}`,
+      },
+    }
+  }
+
+  return {
+    title: 'Tag',
+    description: 'Browse entities by tag on Psychic Homily',
+  }
+}
 
 function TagLoadingFallback() {
   return (
@@ -13,12 +99,11 @@ function TagLoadingFallback() {
   )
 }
 
-export default function TagDetailPage() {
-  const params = useParams()
-
+export default async function TagDetailPage({ params }: TagPageProps) {
+  const { slug } = await params
   return (
     <Suspense fallback={<TagLoadingFallback />}>
-      <TagDetail slug={params.slug as string} />
+      <TagDetail slug={slug} />
     </Suspense>
   )
 }

--- a/frontend/features/tags/components/TagDetail.test.tsx
+++ b/frontend/features/tags/components/TagDetail.test.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { TagEnrichedDetailResponse } from '../types'
 
@@ -900,9 +901,9 @@ describe('TagDetail', () => {
     ).not.toBeInTheDocument()
   })
 
-  // ── Tagged Entities (preserved grouped list) ──
+  // ── Tagged Entities (PSY-485 — tabs + entity cards) ──
 
-  it('renders tagged entities grouped by type', () => {
+  it('renders one tab per entity type with non-zero items, hiding empty tabs', () => {
     mockUseTagDetail.mockReturnValue({
       data: makeTagDetail({ usage_count: 3 }),
       isLoading: false,
@@ -911,9 +912,34 @@ describe('TagDetail', () => {
     mockUseTagEntities.mockReturnValue({
       data: {
         entities: [
-          { entity_type: 'artist', entity_id: 1, name: 'Radiohead', slug: 'radiohead' },
-          { entity_type: 'artist', entity_id: 2, name: 'Portishead', slug: 'portishead' },
-          { entity_type: 'venue', entity_id: 10, name: 'The Rebel Lounge', slug: 'the-rebel-lounge' },
+          {
+            entity_type: 'artist',
+            entity_id: 1,
+            name: 'Radiohead',
+            slug: 'radiohead',
+            city: 'Oxford',
+            state: 'UK',
+            upcoming_show_count: 0,
+          },
+          {
+            entity_type: 'artist',
+            entity_id: 2,
+            name: 'Portishead',
+            slug: 'portishead',
+            city: 'Bristol',
+            state: 'UK',
+            upcoming_show_count: 1,
+          },
+          {
+            entity_type: 'venue',
+            entity_id: 10,
+            name: 'The Rebel Lounge',
+            slug: 'the-rebel-lounge',
+            city: 'Phoenix',
+            state: 'AZ',
+            verified: true,
+            upcoming_show_count: 5,
+          },
         ],
         total: 3,
       },
@@ -923,8 +949,16 @@ describe('TagDetail', () => {
     renderWithProviders(<TagDetail slug="rock" />)
 
     expect(screen.getByText('Tagged Entities')).toBeInTheDocument()
-    expect(screen.getAllByText('Artists').length).toBeGreaterThanOrEqual(1)
-    expect(screen.getAllByText('Venues').length).toBeGreaterThanOrEqual(1)
+    // Tabs render only for entity types with items.
+    expect(screen.getByTestId('tagged-entities-tab-artist')).toBeInTheDocument()
+    expect(screen.getByTestId('tagged-entities-tab-venue')).toBeInTheDocument()
+    expect(
+      screen.queryByTestId('tagged-entities-tab-festival')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByTestId('tagged-entities-tab-label')
+    ).not.toBeInTheDocument()
+    // First tab (artist) is active by default — its panel content shows.
     expect(screen.getByRole('link', { name: 'Radiohead' })).toHaveAttribute(
       'href',
       '/artists/radiohead'
@@ -933,10 +967,178 @@ describe('TagDetail', () => {
       'href',
       '/artists/portishead'
     )
-    expect(screen.getByRole('link', { name: 'The Rebel Lounge' })).toHaveAttribute(
+  })
+
+  it('switches the visible card grid when a different tab is activated', async () => {
+    mockUseTagDetail.mockReturnValue({
+      data: makeTagDetail({ usage_count: 3 }),
+      isLoading: false,
+      error: null,
+    })
+    mockUseTagEntities.mockReturnValue({
+      data: {
+        entities: [
+          {
+            entity_type: 'artist',
+            entity_id: 1,
+            name: 'Radiohead',
+            slug: 'radiohead',
+            city: 'Oxford',
+            state: 'UK',
+            upcoming_show_count: 0,
+          },
+          {
+            entity_type: 'venue',
+            entity_id: 10,
+            name: 'The Rebel Lounge',
+            slug: 'the-rebel-lounge',
+            city: 'Phoenix',
+            state: 'AZ',
+            verified: true,
+            upcoming_show_count: 5,
+          },
+        ],
+        total: 2,
+      },
+      isLoading: false,
+    })
+
+    const user = userEvent.setup()
+    renderWithProviders(<TagDetail slug="rock" />)
+
+    // Artist tab is active first; venue link must not be visible yet because
+    // Radix Tabs unmounts inactive panel content.
+    expect(
+      screen.queryByRole('link', { name: /The Rebel Lounge/ })
+    ).not.toBeInTheDocument()
+
+    // Switch to Venues tab.
+    await user.click(screen.getByTestId('tagged-entities-tab-venue'))
+
+    // Now the venue card renders inside the active panel.
+    const venueLink = await screen.findByRole('link', {
+      name: /The Rebel Lounge/,
+    })
+    expect(venueLink).toHaveAttribute('href', '/venues/the-rebel-lounge')
+    // And the original artist link is gone — proves the panel switched, not
+    // just that we duplicated it.
+    expect(
+      screen.queryByRole('link', { name: 'Radiohead' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders cards (not bare list items) for tagged entities', () => {
+    mockUseTagDetail.mockReturnValue({
+      data: makeTagDetail({ usage_count: 1 }),
+      isLoading: false,
+      error: null,
+    })
+    mockUseTagEntities.mockReturnValue({
+      data: {
+        entities: [
+          {
+            entity_type: 'artist',
+            entity_id: 1,
+            name: 'Faetooth',
+            slug: 'faetooth',
+            city: 'Phoenix',
+            state: 'AZ',
+            upcoming_show_count: 3,
+          },
+        ],
+        total: 1,
+      },
+      isLoading: false,
+    })
+
+    renderWithProviders(<TagDetail slug="shoegaze" />)
+
+    // ArtistCard renders an <article> wrapper — that's the
+    // "card not bullet" assertion the dogfood ticket called out.
+    const article = document.querySelector('article')
+    expect(article).toBeInTheDocument()
+    // Card surfaces the location and the upcoming-show count we asked the
+    // backend to populate.
+    expect(screen.getByText('Phoenix, AZ')).toBeInTheDocument()
+    expect(screen.getByText('3 upcoming')).toBeInTheDocument()
+  })
+
+  it('hides Festivals tab on a tag with no festival usage (PSY-485 acceptance)', () => {
+    mockUseTagDetail.mockReturnValue({
+      data: makeTagDetail({ usage_count: 1 }),
+      isLoading: false,
+      error: null,
+    })
+    mockUseTagEntities.mockReturnValue({
+      data: {
+        entities: [
+          {
+            entity_type: 'artist',
+            entity_id: 1,
+            name: 'Solo Artist',
+            slug: 'solo-artist',
+          },
+        ],
+        total: 1,
+      },
+      isLoading: false,
+    })
+
+    renderWithProviders(<TagDetail slug="rock" />)
+
+    expect(screen.getByTestId('tagged-entities-tab-artist')).toBeInTheDocument()
+    expect(
+      screen.queryByTestId('tagged-entities-tab-festival')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByTestId('tagged-entities-tab-show')
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows a Festivals tab on a festival-only tag (PSY-485 multi-venue scenario)', () => {
+    mockUseTagDetail.mockReturnValue({
+      data: makeTagDetail({ usage_count: 1, name: 'multi-venue' }),
+      isLoading: false,
+      error: null,
+    })
+    mockUseTagEntities.mockReturnValue({
+      data: {
+        entities: [
+          {
+            entity_type: 'festival',
+            entity_id: 7,
+            name: 'M3F',
+            slug: 'm3f-2026',
+            edition_year: 2026,
+            city: 'Phoenix',
+            state: 'AZ',
+            status: 'confirmed',
+            start_date: '2026-03-06',
+            end_date: '2026-03-08',
+            artist_count: 42,
+            venue_count: 3,
+          },
+        ],
+        total: 1,
+      },
+      isLoading: false,
+    })
+
+    renderWithProviders(<TagDetail slug="multi-venue" />)
+
+    expect(
+      screen.getByTestId('tagged-entities-tab-festival')
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByTestId('tagged-entities-tab-artist')
+    ).not.toBeInTheDocument()
+    // Festival card surfaces the year + status + lineup count.
+    expect(screen.getByRole('link', { name: 'M3F' })).toHaveAttribute(
       'href',
-      '/venues/the-rebel-lounge'
+      '/festivals/m3f-2026'
     )
+    expect(screen.getByText('Confirmed')).toBeInTheDocument()
+    expect(screen.getByText('42 artists')).toBeInTheDocument()
   })
 
   it('does not render tagged entities section when usage_count is 0', () => {

--- a/frontend/features/tags/components/TagDetail.tsx
+++ b/frontend/features/tags/components/TagDetail.tsx
@@ -1,17 +1,19 @@
 'use client'
 
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import Link from 'next/link'
 import { ArrowLeft, Hash, Loader2, Music, MapPin, Calendar, Disc3, Tag, Tent, Clock } from 'lucide-react'
 import { NotifyMeButton } from '@/features/notifications'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Breadcrumb } from '@/components/shared'
 import { formatRelativeTime } from '@/lib/formatRelativeTime'
 import { useTagDetail, useTagEntities } from '../hooks'
-import { getCategoryColor, getCategoryLabel, getEntityUrl, getEntityTypePluralLabel } from '../types'
+import { getCategoryColor, getCategoryLabel, getEntityTypePluralLabel } from '../types'
 import type { TaggedEntityItem, TagSummary } from '../types'
 import { TagOfficialIndicator } from './TagOfficialIndicator'
+import { TaggedEntityCard } from './TaggedEntityCards'
 
 interface TagDetailProps {
   slug: string
@@ -381,7 +383,7 @@ function TagPill({ tag }: { tag: TagSummary }) {
 }
 
 // ──────────────────────────────────────────────
-// Tagged entities section (preserved from original implementation)
+// Tagged entities section (PSY-485 — tabs + entity cards)
 // ──────────────────────────────────────────────
 
 function TaggedEntitiesSection({ slug }: { slug: string }) {
@@ -400,9 +402,21 @@ function TaggedEntitiesSection({ slug }: { slug: string }) {
     return groups
   }, [entities])
 
+  // Hide entity types with zero items so a genre-only tag doesn't render an
+  // empty Festivals tab (PSY-485 acceptance criterion).
   const sortedTypes = useMemo(() => {
     return ENTITY_TYPE_ORDER.filter((t) => grouped[t]?.length)
   }, [grouped])
+
+  // Default the active tab to the first non-empty entity type. We can't
+  // recompute this in render because Radix Tabs is a controlled component —
+  // need a real piece of state. The state is initialised lazily so it picks
+  // up the first available type once entities load.
+  const [activeTab, setActiveTab] = useState<string | undefined>(undefined)
+  const effectiveTab =
+    activeTab && sortedTypes.includes(activeTab as (typeof sortedTypes)[number])
+      ? activeTab
+      : sortedTypes[0]
 
   if (isLoading) {
     return (
@@ -419,60 +433,60 @@ function TaggedEntitiesSection({ slug }: { slug: string }) {
   }
 
   return (
-    <section className="border-t border-border/50 pt-6">
+    <section className="border-t border-border/50 pt-6" data-testid="tagged-entities">
       <h2 className="text-lg font-semibold mb-4">Tagged Entities</h2>
 
-      {/* Per-type counts — complements the header breakdown summary */}
-      {sortedTypes.length > 1 && (
-        <div className="flex flex-wrap gap-3 mb-6">
-          {sortedTypes.map((entityType) => {
-            const count = grouped[entityType].length
-            const Icon = ENTITY_TYPE_ICONS[entityType] || Hash
-            return (
-              <div
-                key={entityType}
-                className="inline-flex items-center gap-2 rounded-md border border-border/50 bg-muted/30 px-3 py-1.5 text-sm"
-              >
-                <Icon className="h-3.5 w-3.5 text-muted-foreground" />
-                <span className="font-medium">{count}</span>
-                <span className="text-muted-foreground">
-                  {count === 1
-                    ? entityType.charAt(0).toUpperCase() + entityType.slice(1)
-                    : getEntityTypePluralLabel(entityType)}
-                </span>
-              </div>
-            )
-          })}
+      <Tabs
+        value={effectiveTab}
+        onValueChange={setActiveTab}
+        className="w-full"
+      >
+        {/* Tabs are scrollable on narrow viewports — six entity types of
+            "Artists/Shows/Venues/..." would push past 375px otherwise. */}
+        <div className="overflow-x-auto -mx-4 px-4 sm:mx-0 sm:px-0">
+          <TabsList className="h-auto flex flex-wrap gap-1 bg-muted/40 p-1">
+            {sortedTypes.map((entityType) => {
+              const count = grouped[entityType].length
+              const Icon = ENTITY_TYPE_ICONS[entityType] || Hash
+              return (
+                <TabsTrigger
+                  key={entityType}
+                  value={entityType}
+                  data-testid={`tagged-entities-tab-${entityType}`}
+                  className="gap-1.5"
+                >
+                  <Icon className="h-3.5 w-3.5" />
+                  <span>{getEntityTypePluralLabel(entityType)}</span>
+                  <span className="text-xs text-muted-foreground tabular-nums">
+                    {count}
+                  </span>
+                </TabsTrigger>
+              )
+            })}
+          </TabsList>
         </div>
-      )}
 
-      <div className="space-y-6">
         {sortedTypes.map((entityType) => {
           const entities = grouped[entityType]
-          const Icon = ENTITY_TYPE_ICONS[entityType] || Hash
           return (
-            <div key={entityType}>
-              <h3 className="flex items-center gap-2 text-sm font-medium text-muted-foreground mb-2">
-                <Icon className="h-4 w-4" />
-                {getEntityTypePluralLabel(entityType)}
-                <span className="text-xs">({entities.length})</span>
-              </h3>
-              <ul className="grid gap-1">
+            <TabsContent
+              key={entityType}
+              value={entityType}
+              data-testid={`tagged-entities-panel-${entityType}`}
+              className="mt-4"
+            >
+              <div className="grid gap-3">
                 {entities.map((entity) => (
-                  <li key={`${entity.entity_type}-${entity.entity_id}`}>
-                    <Link
-                      href={getEntityUrl(entity.entity_type, entity.slug)}
-                      className="inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm hover:bg-muted/50 transition-colors"
-                    >
-                      {entity.name}
-                    </Link>
-                  </li>
+                  <TaggedEntityCard
+                    key={`${entity.entity_type}-${entity.entity_id}`}
+                    item={entity}
+                  />
                 ))}
-              </ul>
-            </div>
+              </div>
+            </TabsContent>
           )
         })}
-      </div>
+      </Tabs>
     </section>
   )
 }

--- a/frontend/features/tags/components/TaggedEntityCards.tsx
+++ b/frontend/features/tags/components/TaggedEntityCards.tsx
@@ -1,0 +1,281 @@
+'use client'
+
+/**
+ * Tagged-entity card row renderers (PSY-485).
+ *
+ * Adapts the lightweight `TaggedEntityItem` returned by GET /tags/{slug}/entities
+ * into the entity-specific shapes consumed by the existing feature-module cards
+ * (ArtistCard, FestivalCard, LabelCard, ReleaseCard) wherever those work with
+ * minimal data, and renders venue/show rows inline because the heavyweight
+ * VenueCard/ShowCard pull in feature-specific dependencies (favorite buttons,
+ * attendance, music embeds) that don't make sense in this context.
+ *
+ * Each renderer accepts the raw `TaggedEntityItem` so the parent (TagDetail) can
+ * stay agnostic about which fields the backend populated for which type.
+ */
+
+import Link from 'next/link'
+import { BadgeCheck, Calendar, MapPin, Music, Disc3, Tag } from 'lucide-react'
+import { ArtistCard } from '@/features/artists'
+import { FestivalCard } from '@/features/festivals'
+import { LabelCard } from '@/features/labels'
+import { ReleaseCard } from '@/features/releases'
+import { formatShowDateBadge } from '@/lib/utils/showDateBadge'
+import type { TaggedEntityItem } from '../types'
+import { getEntityUrl } from '../types'
+
+// ──────────────────────────────────────────────
+// Per-type adapters
+// ──────────────────────────────────────────────
+
+function TaggedArtistCard({ item }: { item: TaggedEntityItem }) {
+  // Adapt to ArtistListItem. ArtistCard only reads name, slug, city, state,
+  // and upcoming_show_count, so we can pass a minimal shape with the rest
+  // stubbed out.
+  const artist = {
+    id: item.entity_id,
+    slug: item.slug,
+    name: item.name,
+    city: item.city ?? null,
+    state: item.state ?? null,
+    bandcamp_embed_url: null,
+    description: null,
+    social: {
+      instagram: null,
+      facebook: null,
+      twitter: null,
+      youtube: null,
+      spotify: null,
+      soundcloud: null,
+      bandcamp: null,
+      website: null,
+    },
+    created_at: '',
+    updated_at: '',
+    upcoming_show_count: item.upcoming_show_count ?? 0,
+  }
+  return <ArtistCard artist={artist} density="comfortable" />
+}
+
+function TaggedFestivalCard({ item }: { item: TaggedEntityItem }) {
+  // Adapt to FestivalListItem. The card reads name, slug, city, state,
+  // edition_year, start_date, end_date, status, artist_count, venue_count.
+  const festival = {
+    id: item.entity_id,
+    name: item.name,
+    slug: item.slug,
+    series_slug: '', // unused by FestivalCard
+    edition_year: item.edition_year ?? 0,
+    city: item.city || null,
+    state: item.state || null,
+    start_date: item.start_date ?? '',
+    end_date: item.end_date ?? '',
+    status: item.status ?? 'announced',
+    artist_count: item.artist_count ?? 0,
+    venue_count: item.venue_count ?? 0,
+  }
+  return <FestivalCard festival={festival} density="comfortable" />
+}
+
+function TaggedLabelCard({ item }: { item: TaggedEntityItem }) {
+  const label = {
+    id: item.entity_id,
+    name: item.name,
+    slug: item.slug,
+    city: item.city || null,
+    state: item.state || null,
+    status: item.status ?? 'active',
+    artist_count: item.artist_count ?? 0,
+    release_count: item.release_count ?? 0,
+  }
+  return <LabelCard label={label} density="comfortable" />
+}
+
+function TaggedReleaseCard({ item }: { item: TaggedEntityItem }) {
+  // ReleaseCard expects ReleaseListItem with an `artists` array. The tag
+  // detail endpoint doesn't return per-release artist credits (would require
+  // an extra JOIN per row), so we render an empty artists array — the card
+  // gracefully handles that case (no artist line when the array is empty).
+  const release = {
+    id: item.entity_id,
+    title: item.name,
+    slug: item.slug,
+    release_type: item.release_type ?? 'lp',
+    release_year: item.release_year ?? null,
+    cover_art_url: item.cover_art_url ?? null,
+    artist_count: 0,
+    artists: [],
+    label_name: null,
+    label_slug: null,
+  }
+  return <ReleaseCard release={release} density="comfortable" />
+}
+
+/**
+ * Inline venue card. We don't reuse VenueCard because it pulls in
+ * useVenueShows, FavoriteVenueButton, edit/delete dialogs, and other
+ * authenticated affordances that aren't appropriate in this read-only,
+ * cross-entity browsing context. The visual treatment matches the artist
+ * card so the tabs feel cohesive.
+ */
+function TaggedVenueRow({ item }: { item: TaggedEntityItem }) {
+  const hasLocation = item.city || item.state
+  const location = hasLocation
+    ? [item.city, item.state].filter(Boolean).join(', ')
+    : null
+  const upcoming = item.upcoming_show_count ?? 0
+  return (
+    <article className="rounded-lg border border-border/50 bg-card p-4 transition-shadow hover:shadow-sm">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <Link
+            href={getEntityUrl('venue', item.slug)}
+            className="block group"
+          >
+            <h3 className="font-bold text-base text-foreground group-hover:text-primary transition-colors truncate inline-flex items-center gap-1.5">
+              {item.name}
+              {item.verified && (
+                <BadgeCheck className="h-4 w-4 text-primary shrink-0" aria-label="Verified venue" />
+              )}
+            </h3>
+          </Link>
+          {location && (
+            <div className="mt-1 flex items-center gap-1.5 text-sm text-muted-foreground">
+              <MapPin className="h-3.5 w-3.5 shrink-0" />
+              <span>{location}</span>
+            </div>
+          )}
+        </div>
+        <span
+          className={`text-xs font-medium px-2 py-1 rounded-full shrink-0 ${
+            upcoming > 0
+              ? 'bg-primary/10 text-primary'
+              : 'bg-muted text-muted-foreground'
+          }`}
+        >
+          {upcoming} {upcoming === 1 ? 'show' : 'shows'}
+        </span>
+      </div>
+    </article>
+  )
+}
+
+/**
+ * Inline show row. ShowCard wants a full ShowResponse with bill positions,
+ * attendance counters, edit/delete affordances, and music embed plumbing —
+ * none of which the tag-entities endpoint exposes. We render the headliner +
+ * venue + date with the same visual rhythm.
+ */
+function TaggedShowRow({ item }: { item: TaggedEntityItem }) {
+  const dateBadge = item.event_date
+    ? formatShowDateBadge(item.event_date, item.state ?? null)
+    : null
+  const headliner = item.headliner_name
+  const venue = item.venue_name
+  const location =
+    item.city && item.state
+      ? `${item.city}, ${item.state}`
+      : item.city || item.state || null
+
+  return (
+    <article className="rounded-lg border border-border/50 bg-card p-3 sm:p-4 transition-shadow hover:shadow-sm">
+      <div className="flex gap-3 sm:gap-4">
+        {dateBadge && (
+          <Link
+            href={getEntityUrl('show', item.slug)}
+            className="shrink-0 flex flex-col items-center justify-center rounded-md bg-muted/50 hover:bg-muted transition-colors w-14 sm:w-16 py-2"
+          >
+            <span className="text-[10px] sm:text-xs font-bold tracking-widest uppercase text-muted-foreground leading-none">
+              {dateBadge.dayOfWeek}
+            </span>
+            <span className="text-xs sm:text-sm font-semibold text-primary leading-tight mt-0.5">
+              {dateBadge.monthDay}
+            </span>
+          </Link>
+        )}
+        <div className="flex-1 min-w-0">
+          <Link href={getEntityUrl('show', item.slug)} className="block group">
+            <h3 className="font-bold text-base sm:text-lg text-foreground group-hover:text-primary transition-colors truncate">
+              {headliner || item.name || 'Show'}
+            </h3>
+          </Link>
+          {venue && (
+            <div className="text-sm text-muted-foreground mt-0.5">
+              {item.venue_slug ? (
+                <Link
+                  href={`/venues/${item.venue_slug}`}
+                  className="text-primary/80 hover:text-primary font-medium transition-colors"
+                >
+                  {venue}
+                </Link>
+              ) : (
+                <span className="text-primary/80 font-medium">{venue}</span>
+              )}
+              {location && (
+                <span className="text-muted-foreground/80">
+                  {' '}&middot; {location}
+                </span>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </article>
+  )
+}
+
+// ──────────────────────────────────────────────
+// Public renderer
+// ──────────────────────────────────────────────
+
+interface TaggedEntityCardProps {
+  item: TaggedEntityItem
+}
+
+/**
+ * Render a single tagged-entity card based on its type. Any unknown entity
+ * type falls back to a minimal link row so we never silently drop data when
+ * the backend learns about a new tag-eligible entity type.
+ */
+export function TaggedEntityCard({ item }: TaggedEntityCardProps) {
+  switch (item.entity_type) {
+    case 'artist':
+      return <TaggedArtistCard item={item} />
+    case 'venue':
+      return <TaggedVenueRow item={item} />
+    case 'festival':
+      return <TaggedFestivalCard item={item} />
+    case 'label':
+      return <TaggedLabelCard item={item} />
+    case 'release':
+      return <TaggedReleaseCard item={item} />
+    case 'show':
+      return <TaggedShowRow item={item} />
+    default:
+      return (
+        <article className="rounded-lg border border-border/50 bg-card p-4">
+          <Link
+            href={getEntityUrl(item.entity_type, item.slug)}
+            className="font-medium text-foreground hover:text-primary transition-colors"
+          >
+            {item.name}
+          </Link>
+        </article>
+      )
+  }
+}
+
+// Icon helper used by the tab labels — exported alongside so the parent
+// component can stay free of per-type icon mapping repetition.
+export const ENTITY_TYPE_TAB_ICON: Record<
+  string,
+  React.ComponentType<{ className?: string }>
+> = {
+  artist: Music,
+  venue: MapPin,
+  festival: Calendar,
+  label: Tag,
+  release: Disc3,
+  show: Calendar,
+}
+

--- a/frontend/features/tags/types.ts
+++ b/frontend/features/tags/types.ts
@@ -150,6 +150,37 @@ export interface TaggedEntityItem {
   entity_id: number
   name: string
   slug: string
+  // PSY-485: optional per-entity-type fields populated by the backend so the
+  // tag detail page can render proper entity cards instead of bare links.
+  // All fields are omitted on entity types where they don't apply.
+  city?: string
+  state?: string
+  // Venue-specific.
+  verified?: boolean
+  // Artist/venue-specific.
+  upcoming_show_count?: number
+  // Festival-specific.
+  edition_year?: number
+  start_date?: string
+  end_date?: string
+  // Status applies to festivals (announced/confirmed/cancelled/completed)
+  // and labels (active/inactive/defunct).
+  status?: string
+  // Counts populated for festivals (artists in lineup) and labels
+  // (artists on roster, releases in catalog).
+  artist_count?: number
+  release_count?: number
+  venue_count?: number
+  // Release-specific.
+  release_type?: string
+  release_year?: number
+  cover_art_url?: string
+  // Show-specific.
+  event_date?: string
+  venue_name?: string
+  venue_slug?: string
+  headliner_name?: string
+  headliner_slug?: string
 }
 
 export interface TagEntitiesResponse {


### PR DESCRIPTION
## Summary

- Replace the artists-only bullet list on `/tags/{slug}` with a tabbed UI that surfaces Artists, Shows, Venues, Festivals, Labels, and Releases. Tabs with zero items are hidden, so genre tags don't render an empty Festivals tab and a festival-only tag like `multi-venue` finally shows a Festivals tab instead of looking broken.
- Each tab renders proper entity cards (ArtistCard / FestivalCard / LabelCard / ReleaseCard, with inline venue + show rows) instead of bare links — backed by per-entity-type enrichment fields added to `TaggedEntityItem` (city/state, verified, upcoming_show_count, edition_year, status, dates, counts, release_type/year/cover, event_date + headliner + venue).
- Add `generateMetadata` to `app/tags/[slug]/page.tsx` so the title becomes `"{tagName} | Tags | Psychic Homily"` with a usage-count-aware description, canonical, and OG tags. Required converting the page to a server component (the `TagDetail` body remains a client component).

## Test plan

- [x] `cd backend && go test ./internal/services/catalog/ -count=1` — passes
- [x] `cd backend && go test ./internal/api/handlers/ -run TestTag -count=1` — passes
- [x] `cd frontend && bun run test:run features/tags/components/TagDetail.test.tsx` — 43 tests pass, including new tab-switch test, "renders cards (not bullets)" assertion, "hides Festivals tab on artist-only tag", and "shows Festivals tab on festival-only tag (multi-venue scenario)"
- [x] `cd frontend && bun run test:run features/tags/` — 185 tests pass
- [x] `cd frontend && bun run build` — succeeds; `/tags/[slug]` is now `ƒ (Dynamic)` server-rendered for `generateMetadata`
- [ ] Manual: visit `/tags/rock` and confirm tabs appear, Artists tab is active by default, switching to Venues swaps the panel content; document title reads `rock | Tags | Psychic Homily`
- [ ] Manual: visit a tag with zero usage to confirm no Tagged Entities section renders (preserved behaviour)
- [ ] Manual: visit a festival-only tag (e.g. `multi-venue` once seeded) to confirm only the Festivals tab appears

Closes PSY-485

🤖 Generated with [Claude Code](https://claude.com/claude-code)