### PR TITLE
PSY-465: revert trace:'on' override — flake fixed by PSY-470

### DIFF
--- a/frontend/e2e/pages/follow-and-attendance.spec.ts
+++ b/frontend/e2e/pages/follow-and-attendance.spec.ts
@@ -16,17 +16,6 @@ const RESERVED_SHOW_SLUG = 'e2e-attendance-test'
 const RESERVED_SHOW_TITLE = 'E2E [attendance-test]'
 const RESERVED_SHOW_URL = `/shows/${RESERVED_SHOW_SLUG}`
 
-// PSY-465 (temporary — revert after trace capture): override the global
-// `trace: 'on-first-retry'` config at file-level so the FAILING attempt's
-// trace is captured, not just the clean retry. The flake surfaces only on
-// the first attempt (cold-load of /artists/[slug] → a child of
-// ArtistDetail throws → route-level error boundary catches → the test
-// times out). The retry renders cleanly, so `on-first-retry` captures
-// nothing useful. Must be top-level per Playwright; scoped-inside-describe
-// throws "Cannot use({ trace }) in a describe group". Remove this line
-// once the throwing component is identified and the defensive fix lands.
-test.use({ trace: 'on' })
-
 test.describe('Follow and attendance', () => {
   // Tests share DB state with the same per-worker user, so they must not
   // run in parallel within this file.


### PR DESCRIPTION
## Summary

Reverting the temporary `test.use({ trace: 'on' })` override introduced in #414. The flake hasn't reproduced since PSY-470 shipped — strong evidence PSY-470 was the actual fix.

## Evidence

Scanned the last 13+ post-merge main runs since PSY-470 (#406) merged, across all 4 shards each. **Zero `follow-and-attendance` retries detected.** Every shard failure in that window was a different flake:

- `register.spec.ts:62` strict-mode violation — fixed by PSY-474 (#411)
- Docker DB migration timeout — unrelated infra flake, no test ever ran

Historical PSY-465 flake rate was ~40% per the original investigation. Even with variance, ~50 attempts (13 runs × ~4 shards) with zero hits is strong statistical evidence.

## Why PSY-470 was the real fix

The original investigator's hypothesis ([Linear comment on PSY-465](https://linear.app/psychic-homily/issue/PSY-465)) was that a child of `ArtistDetail` throws mid-render on cold-load. The follow-up static-analysis audit ([same ticket](https://linear.app/psychic-homily/issue/PSY-465)) didn't find any un-guarded dereference in the component tree — every query-data access was either null-guarded or protected by a backend contract.

The real cause was the **cross-worker race on shared `e2e-follow-test` artist/show rows** noted as a side finding during the PSY-465 investigation and filed as PSY-470. `followers_count` leaked between workers because in-test cleanup only ran on happy path; a mid-test failure left the dirty row behind.

PSY-470 added an `afterEach` `user_bookmarks` reset to `follow-and-attendance.spec.ts` that cleans up regardless of pass/fail. That closed the race. The "ArtistDetail child throws" signature observed in the original PR #381 failure was likely the error boundary surfacing a chain of assertion failures downstream of the dirty row — a symptom, not the root cause.

## Change

One file: `frontend/e2e/pages/follow-and-attendance.spec.ts` — removed the top-level `test.use({ trace: 'on' })` + its comment. Spec returns to using the global `trace: 'on-first-retry'` config.

## Closes

- **PSY-465** — resolved transitively by PSY-470

🤖 Generated with [Claude Code](https://claude.com/claude-code)