### PR TITLE
PSY-461: migrate ShowDetail to EntityDetailLayout

### DIFF
--- a/frontend/components/shared/EntityDetailLayout.test.tsx
+++ b/frontend/components/shared/EntityDetailLayout.test.tsx
@@ -125,4 +125,42 @@ describe('EntityDetailLayout', () => {
     const tabs = screen.getAllByRole('tab')
     expect(tabs).toHaveLength(4)
   })
+
+  describe('flat (no-tabs) shape', () => {
+    const flatProps = {
+      fallback: { href: '/shows', label: 'Shows' },
+      entityName: 'Test Show',
+      header: <div data-testid="test-header">Test Show</div>,
+      children: <div data-testid="flat-content">Flat content</div>,
+    }
+
+    it('renders without a tablist when tabs are omitted', () => {
+      render(<EntityDetailLayout {...flatProps} />)
+      expect(screen.queryByRole('tablist')).not.toBeInTheDocument()
+      expect(screen.queryByRole('tab')).not.toBeInTheDocument()
+    })
+
+    it('renders without a tablist when tabs is an empty array', () => {
+      render(<EntityDetailLayout {...flatProps} tabs={[]} />)
+      expect(screen.queryByRole('tablist')).not.toBeInTheDocument()
+    })
+
+    it('still renders header, breadcrumb, and children in flat mode', () => {
+      render(<EntityDetailLayout {...flatProps} />)
+      expect(screen.getByTestId('test-header')).toBeInTheDocument()
+      expect(screen.getByRole('navigation', { name: /Breadcrumb/ })).toBeInTheDocument()
+      expect(screen.getByTestId('flat-content')).toBeInTheDocument()
+    })
+
+    it('still renders sidebar in flat mode when provided', () => {
+      render(
+        <EntityDetailLayout
+          {...flatProps}
+          sidebar={<div data-testid="sidebar-content">Sidebar info</div>}
+        />
+      )
+      expect(screen.getByTestId('sidebar-content')).toBeInTheDocument()
+      expect(screen.getByRole('complementary')).toBeInTheDocument()
+    })
+  })
 })

--- a/frontend/components/shared/EntityDetailLayout.tsx
+++ b/frontend/components/shared/EntityDetailLayout.tsx
@@ -24,26 +24,39 @@ interface EntityDetailLayoutProps {
   backLink?: EntityDetailBackLink
   /** Header content (typically an EntityHeader) */
   header: React.ReactNode
-  /** Tab definitions */
-  tabs: EntityDetailTab[]
-  /** Currently active tab value */
-  activeTab: string
-  /** Callback when tab changes */
-  onTabChange: (value: string) => void
+  /**
+   * Tab definitions. Omit or pass an empty array to render a flat,
+   * single-surface layout (no `<Tabs>` wrapper, no `<TabsList>`).
+   */
+  tabs?: EntityDetailTab[]
+  /** Currently active tab value. Required when `tabs` is non-empty. */
+  activeTab?: string
+  /** Callback when tab changes. Required when `tabs` is non-empty. */
+  onTabChange?: (value: string) => void
   /** Optional sidebar content */
   sidebar?: React.ReactNode
   /**
-   * Tab content area. Should include TabsContent components from @/components/ui/tabs
-   * for each tab value. The layout wraps everything in a Tabs provider.
+   * Main content area. When `tabs` is non-empty, should include TabsContent
+   * components from @/components/ui/tabs for each tab value — the layout
+   * wraps everything in a Tabs provider. When `tabs` is empty/undefined,
+   * children render directly in the main column.
    */
   children: React.ReactNode
   className?: string
 }
 
 /**
- * Reusable entity detail page layout with breadcrumb navigation, header, tabs, and optional sidebar.
+ * Reusable entity detail page layout with breadcrumb navigation, header,
+ * optional tabs, and optional sidebar.
  *
- * Usage:
+ * Two shapes:
+ * - Tabbed (default): pass `tabs`, `activeTab`, `onTabChange`. Children are
+ *   TabsContent panels wrapped in a Tabs provider.
+ * - Flat (single-surface): omit `tabs` (or pass `[]`). No tabs bar is
+ *   rendered and children are laid out directly in the main column. Useful
+ *   for pages like ShowDetail/VenueDetail that have a single content surface.
+ *
+ * Usage (tabbed):
  * ```tsx
  * <EntityDetailLayout
  *   fallback={{ href: '/releases', label: 'Releases' }}
@@ -56,6 +69,18 @@ interface EntityDetailLayoutProps {
  * >
  *   <TabsContent value="overview">...</TabsContent>
  *   <TabsContent value="links">...</TabsContent>
+ * </EntityDetailLayout>
+ * ```
+ *
+ * Usage (flat):
+ * ```tsx
+ * <EntityDetailLayout
+ *   fallback={{ href: '/shows', label: 'Shows' }}
+ *   entityName="Show Title"
+ *   header={<ShowHeader show={show} />}
+ * >
+ *   <ShowSection />
+ *   <AnotherSection />
  * </EntityDetailLayout>
  * ```
  */
@@ -74,6 +99,24 @@ export function EntityDetailLayout({
   // Support deprecated backLink prop as fallback
   const resolvedFallback = fallback ?? (backLink ? { href: backLink.href, label: backLink.label.replace(/^Back to /, '') } : { href: '/', label: 'Home' })
   const resolvedEntityName = entityName ?? ''
+  const hasTabs = !!tabs && tabs.length > 0
+
+  const contentBody = (
+    <div
+      className={cn(
+        'flex flex-col gap-8',
+        sidebar && 'lg:flex-row'
+      )}
+    >
+      {/* Main Content (tab panels when tabbed, otherwise flat children) */}
+      <div className="flex-1 min-w-0">{children}</div>
+
+      {/* Sidebar */}
+      {sidebar && (
+        <aside className="w-full lg:w-80 shrink-0">{sidebar}</aside>
+      )}
+    </div>
+  )
 
   return (
     <div className={cn('container max-w-6xl mx-auto px-4 py-6', className)}>
@@ -83,31 +126,21 @@ export function EntityDetailLayout({
       {/* Header */}
       <header className="mb-6">{header}</header>
 
-      {/* Tabs + Content + Sidebar */}
-      <Tabs value={activeTab} onValueChange={onTabChange}>
-        <TabsList className="mb-6">
-          {tabs.map(tab => (
-            <TabsTrigger key={tab.value} value={tab.value}>
-              {tab.label}
-            </TabsTrigger>
-          ))}
-        </TabsList>
+      {hasTabs ? (
+        <Tabs value={activeTab} onValueChange={onTabChange}>
+          <TabsList className="mb-6">
+            {tabs!.map(tab => (
+              <TabsTrigger key={tab.value} value={tab.value}>
+                {tab.label}
+              </TabsTrigger>
+            ))}
+          </TabsList>
 
-        <div
-          className={cn(
-            'flex flex-col gap-8',
-            sidebar && 'lg:flex-row'
-          )}
-        >
-          {/* Main Content (tab panels) */}
-          <div className="flex-1 min-w-0">{children}</div>
-
-          {/* Sidebar */}
-          {sidebar && (
-            <aside className="w-full lg:w-80 shrink-0">{sidebar}</aside>
-          )}
-        </div>
-      </Tabs>
+          {contentBody}
+        </Tabs>
+      ) : (
+        contentBody
+      )}
     </div>
   )
 }

--- a/frontend/features/shows/components/ShowActions.tsx
+++ b/frontend/features/shows/components/ShowActions.tsx
@@ -1,0 +1,146 @@
+'use client'
+
+import { Loader2, Pencil, X, Trash2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { SaveButton, AddToCollectionButton } from '@/components/shared'
+import type { ShowResponse } from '../types'
+import { AttendanceButton } from './AttendanceButton'
+import { ReportShowButton } from './ReportShowButton'
+
+interface ShowActionsProps {
+  show: ShowResponse
+  /** Display name for the show, used by collection/report flows. */
+  showTitle: string
+  /** Whether the current viewer is an admin. */
+  isAdmin: boolean
+  /** Whether the current viewer can delete the show (admin OR owner). */
+  canDelete: boolean
+  /** Whether the current viewer can manage status flags (admin OR owner). */
+  canManageStatus: boolean
+  /** Whether the inline edit form is currently open. */
+  isEditing: boolean
+  /** Toggle the inline edit form. */
+  onToggleEdit: () => void
+  /** Open the delete confirmation dialog. */
+  onOpenDelete: () => void
+  /** Toggle the sold-out status. */
+  onToggleSoldOut: () => void
+  /** Toggle the cancelled status. */
+  onToggleCancelled: () => void
+  /** Pending state of the sold-out mutation. */
+  isSoldOutPending: boolean
+  /** Pending state of the cancelled mutation. */
+  isCancelledPending: boolean
+}
+
+/**
+ * ShowDetail-specific action cluster. Owns the attendance button, the
+ * top row of save/collect/report/edit/delete, and the admin-only status
+ * toggle row (Mark Sold Out / Mark Cancelled).
+ *
+ * This is not `EntityHeader.actions` because shows have two extra rows
+ * (attendance on its own line; admin status toggles as a sub-row) that
+ * would not fit into `EntityHeader`'s single flex-row slot without either
+ * cramming or wrapping awkwardly.
+ */
+export function ShowActions({
+  show,
+  showTitle,
+  isAdmin,
+  canDelete,
+  canManageStatus,
+  isEditing,
+  onToggleEdit,
+  onOpenDelete,
+  onToggleSoldOut,
+  onToggleCancelled,
+  isSoldOutPending,
+  isCancelledPending,
+}: ShowActionsProps) {
+  return (
+    <>
+      {/* Attendance (Going/Interested) */}
+      <AttendanceButton showId={show.id} compact={false} />
+
+      <div className="flex flex-wrap items-center gap-2">
+        <SaveButton showId={show.id} variant="outline" size="sm" />
+        <AddToCollectionButton
+          entityType="show"
+          entityId={show.id}
+          entityName={showTitle}
+        />
+        <ReportShowButton showId={show.id} showTitle={showTitle} />
+
+        {isAdmin && (
+          <Button
+            variant={isEditing ? 'secondary' : 'outline'}
+            size="sm"
+            onClick={onToggleEdit}
+          >
+            {isEditing ? (
+              <>
+                <X className="h-4 w-4 mr-2" />
+                Cancel
+              </>
+            ) : (
+              <>
+                <Pencil className="h-4 w-4 mr-2" />
+                Edit
+              </>
+            )}
+          </Button>
+        )}
+
+        {canDelete && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onOpenDelete}
+            className="text-destructive hover:text-destructive hover:bg-destructive/10"
+          >
+            <Trash2 className="h-4 w-4 mr-2" />
+            Delete
+          </Button>
+        )}
+      </div>
+
+      {/* Status Flag Buttons (Admin or Submitter) */}
+      {canManageStatus && (
+        <div className="flex items-center gap-2">
+          <Button
+            variant={show.is_sold_out ? 'secondary' : 'outline'}
+            size="sm"
+            onClick={onToggleSoldOut}
+            disabled={isSoldOutPending}
+            className={
+              show.is_sold_out
+                ? 'bg-orange-100 text-orange-800 hover:bg-orange-200 dark:bg-orange-900/30 dark:text-orange-400 dark:hover:bg-orange-900/50'
+                : ''
+            }
+          >
+            {isSoldOutPending ? (
+              <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+            ) : null}
+            {show.is_sold_out ? 'Unmark Sold Out' : 'Mark Sold Out'}
+          </Button>
+          <Button
+            variant={show.is_cancelled ? 'secondary' : 'outline'}
+            size="sm"
+            onClick={onToggleCancelled}
+            disabled={isCancelledPending}
+            className={
+              show.is_cancelled
+                ? 'bg-destructive/10 text-destructive hover:bg-destructive/20'
+                : ''
+            }
+          >
+            {isCancelledPending ? (
+              <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+            ) : null}
+            {show.is_cancelled ? 'Unmark Cancelled' : 'Mark Cancelled'}
+          </Button>
+        </div>
+      )}
+    </>
+  )
+}

--- a/frontend/features/shows/components/ShowDetail.test.tsx
+++ b/frontend/features/shows/components/ShowDetail.test.tsx
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { ShowDetail } from './ShowDetail'
 import type { ShowResponse, ArtistResponse } from '../types'
 
 // Mock AuthContext
@@ -47,15 +46,34 @@ vi.mock('next/navigation', () => ({
   usePathname: () => '/shows/test-show',
 }))
 
-// Mock child components
+// Mock child components. We mock EntityDetailLayout to expose slots so tests
+// can reason about the header / content split without pulling in the real
+// Tabs machinery. ShowDetail renders in flat-layout mode (no `tabs` prop).
 vi.mock('@/components/shared', () => ({
   SaveButton: () => <button data-testid="save-button">Save</button>,
   SocialLinks: () => <div data-testid="social-links" />,
   MusicEmbed: () => <div data-testid="music-embed" />,
-  Breadcrumb: ({ fallback, currentPage }: { fallback: { href: string; label: string }; currentPage: string }) => (
-    <nav aria-label="Breadcrumb"><a href={fallback.href}>{fallback.label}</a><span>{currentPage}</span></nav>
-  ),
   AddToCollectionButton: () => <button data-testid="add-to-collection">Collect</button>,
+  EntityDetailLayout: ({
+    header,
+    children,
+    fallback,
+    entityName,
+  }: {
+    header: React.ReactNode
+    children: React.ReactNode
+    fallback: { href: string; label: string }
+    entityName: string
+  }) => (
+    <div data-testid="entity-layout">
+      <nav aria-label="Breadcrumb">
+        <a href={fallback.href}>{fallback.label}</a>
+        <span>{entityName}</span>
+      </nav>
+      <div data-testid="header-slot">{header}</div>
+      <div data-testid="content-slot">{children}</div>
+    </div>
+  ),
 }))
 
 vi.mock('@/components/forms', () => ({
@@ -98,6 +116,8 @@ vi.mock('@/features/comments', () => ({
   ),
 }))
 
+import { ShowDetail } from './ShowDetail'
+
 function makeArtist(overrides: Partial<ArtistResponse> = {}): ArtistResponse {
   return {
     id: 1,
@@ -129,7 +149,7 @@ function makeShow(overrides: Partial<ShowResponse> = {}): ShowResponse {
     ],
     artists: [
       makeArtist({ id: 1, name: 'Headliner', slug: 'headliner' }),
-      makeArtist({ id: 2, name: 'Opener', slug: 'opener' }),
+      makeArtist({ id: 2, name: 'Opener', slug: 'opener', set_type: 'opener' }),
     ],
     created_at: '2024-01-01T00:00:00Z',
     updated_at: '2024-01-01T00:00:00Z',
@@ -284,6 +304,19 @@ describe('ShowDetail', () => {
     it('renders report button', () => {
       render(<ShowDetail showId="1" />)
       expect(screen.getByTestId('report-button')).toBeInTheDocument()
+    })
+
+    it('renders EntityTagList in the header slot', () => {
+      render(<ShowDetail showId="1" />)
+      const header = screen.getByTestId('header-slot')
+      expect(header).toContainElement(screen.getByTestId('entity-tag-list'))
+    })
+
+    it('renders EntityCollections, FieldNotes, and CommentThread as content siblings', () => {
+      render(<ShowDetail showId="1" />)
+      expect(screen.getByTestId('entity-collections')).toBeInTheDocument()
+      expect(screen.getByTestId('field-notes-section')).toBeInTheDocument()
+      expect(screen.getByTestId('comment-thread')).toBeInTheDocument()
     })
   })
 

--- a/frontend/features/shows/components/ShowDetail.tsx
+++ b/frontend/features/shows/components/ShowDetail.tsx
@@ -2,24 +2,22 @@
 
 import { useState } from 'react'
 import Link from 'next/link'
-import { ArrowLeft, ExternalLink, Loader2, MapPin, Pencil, X, Trash2 } from 'lucide-react'
+import { ArrowLeft, Loader2, MapPin } from 'lucide-react'
 import { useShow } from '../hooks/useShows'
 import type { ApiError } from '@/lib/api'
 import { useSetShowSoldOut, useSetShowCancelled } from '@/lib/hooks/admin/useAdminShows'
 import { useAuthContext } from '@/lib/context/AuthContext'
 import type { ArtistResponse } from '../types'
-import { formatShowDate, formatShowTime, formatPrice } from '@/lib/utils/formatters'
 import { Button } from '@/components/ui/button'
-import { SocialLinks, MusicEmbed, SaveButton, Breadcrumb, AddToCollectionButton } from '@/components/shared'
+import { SocialLinks, MusicEmbed, EntityDetailLayout } from '@/components/shared'
 import { EntityCollections } from '@/features/collections'
 import { EntityTagList } from '@/features/tags'
 import { CommentThread, FieldNotesSection } from '@/features/comments'
 import { ShowForm } from '@/components/forms'
 import { Alert, AlertDescription } from '@/components/ui/alert'
-import { Badge } from '@/components/ui/badge'
-import { AttendanceButton } from './AttendanceButton'
 import { DeleteShowDialog } from './DeleteShowDialog'
-import { ReportShowButton } from './ReportShowButton'
+import { ShowHeader } from './ShowHeader'
+import { ShowActions } from './ShowActions'
 
 interface ShowDetailProps {
   showId: string | number
@@ -36,7 +34,7 @@ function artistHasMusic(artist: ArtistResponse): boolean {
 export function ShowDetail({ showId }: ShowDetailProps) {
   const { data: show, isLoading, error } = useShow(showId)
   const { isAuthenticated, user } = useAuthContext()
-  const isAdmin = isAuthenticated && user?.is_admin
+  const isAdmin = !!(isAuthenticated && user?.is_admin)
 
   const [isEditing, setIsEditing] = useState(false)
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
@@ -46,7 +44,7 @@ export function ShowDetail({ showId }: ShowDetailProps) {
   const setCancelledMutation = useSetShowCancelled()
 
   // Check if user is the show owner (submitter)
-  const isOwner = user?.id && show?.submitted_by && String(show.submitted_by) === user.id
+  const isOwner = !!(user?.id && show?.submitted_by && String(show.submitted_by) === user.id)
 
   // Check if user can delete: admin or show owner
   const canDelete = isAdmin || isOwner
@@ -126,324 +124,130 @@ export function ShowDetail({ showId }: ShowDetailProps) {
     )
   }
 
-  const venue = show.venues[0]
   const artists = show.artists
   const artistsWithMusic = artists.filter(artistHasMusic)
+  const showTitle = show.title || artists.map(a => a.name).join(', ')
 
   return (
-    <div className="container max-w-6xl mx-auto px-4 py-6">
-      {/* Breadcrumb Navigation */}
-      <Breadcrumb
-        fallback={{ href: '/shows', label: 'Shows' }}
-        currentPage={show.title || artists.map(a => a.name).join(', ')}
-      />
-
-      {/* Cancelled Alert Banner */}
+    <>
+      {/* Cancelled Alert Banner — rendered above the layout so it stays
+          above the fold even when the header gets tall. */}
       {show.is_cancelled && (
-        <Alert variant="destructive" className="mb-6">
-          <AlertDescription className="font-semibold">
-            This show has been cancelled.
-          </AlertDescription>
-        </Alert>
+        <div className="container max-w-6xl mx-auto px-4 pt-6">
+          <Alert variant="destructive">
+            <AlertDescription className="font-semibold">
+              This show has been cancelled.
+            </AlertDescription>
+          </Alert>
+        </div>
       )}
 
-      {/* Header */}
-      <header className="mb-8">
-        <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
-          <div className="flex-1 min-w-0">
-            {/* Date and Status Badges */}
-            <div className="flex items-center gap-2 mb-2">
-              <span className="text-lg font-bold text-primary">
-                {formatShowDate(show.event_date, show.state)}
-              </span>
-              {show.is_sold_out && (
-                <Badge variant="secondary" className="text-xs font-semibold bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-400">
-                  SOLD OUT
-                </Badge>
-              )}
-            </div>
-
-            {/* Artists — grouped by billing */}
-            {(() => {
-              const headliners = artists.filter(a => a.set_type === 'headliner' || a.is_headliner === true)
-              const support = artists.filter(a => a.set_type !== 'headliner' && a.is_headliner !== true)
-              const effectiveHeadliners = headliners.length > 0 ? headliners : artists.length > 0 ? [artists[0]] : []
-              const effectiveSupport = headliners.length > 0 ? support : artists.slice(1)
-
-              return (
-                <>
-                  <h1 className="text-2xl md:text-3xl font-bold leading-8 md:leading-9">
-                    {effectiveHeadliners.map((artist, index) => (
-                      <span key={artist.id}>
-                        {index > 0 && (
-                          <span className="text-muted-foreground/60 font-normal">
-                            {' '}&bull;{' '}
-                          </span>
-                        )}
-                        {artist.slug ? (
-                          <Link
-                            href={`/artists/${artist.slug}`}
-                            className="hover:text-primary transition-colors"
-                          >
-                            {artist.name}
-                          </Link>
-                        ) : (
-                          <span>{artist.name}</span>
-                        )}
-                      </span>
-                    ))}
-                  </h1>
-                  {effectiveSupport.length > 0 && (
-                    <div className="text-lg text-muted-foreground mt-1">
-                      <span className="italic">w/</span>{' '}
-                      {effectiveSupport.map((artist, index) => (
-                        <span key={artist.id}>
-                          {index > 0 && (
-                            <span className="text-muted-foreground/50">, </span>
-                          )}
-                          {artist.slug ? (
-                            <Link
-                              href={`/artists/${artist.slug}`}
-                              className="hover:text-primary/80 transition-colors"
-                            >
-                              {artist.name}
-                            </Link>
-                          ) : (
-                            <span>{artist.name}</span>
-                          )}
-                          {artist.set_type === 'special_guest' && (
-                            <span className="text-sm text-muted-foreground/70 italic"> (special guest)</span>
-                          )}
-                        </span>
-                      ))}
-                    </div>
-                  )}
-                </>
-              )
-            })()}
-
-            {/* Venue and Location */}
-            {venue && (
-              <div className="mt-2">
-                {venue.slug ? (
-                  <Link
-                    href={`/venues/${venue.slug}`}
-                    className="text-lg text-primary/80 hover:text-primary font-medium transition-colors"
-                  >
-                    {venue.name}
-                  </Link>
-                ) : (
-                  <span className="text-lg text-primary/80 font-medium">
-                    {venue.name}
-                  </span>
-                )}
-                <div className="flex items-center gap-1 text-muted-foreground mt-1">
-                  <MapPin className="h-4 w-4" />
-                  <span>
-                    {venue.city}, {venue.state}
-                  </span>
-                </div>
-                {venue.slug && (
-                  <Link
-                    href={`/venues/${venue.slug}`}
-                    className="inline-block text-sm text-muted-foreground hover:text-primary transition-colors mt-1"
-                  >
-                    See more shows at {venue.name} &rarr;
-                  </Link>
-                )}
-              </div>
-            )}
-
-            {/* Show Details */}
-            <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-muted-foreground mt-3">
-              <span>{formatShowTime(show.event_date, show.state)}</span>
-              {show.price != null && <span>{formatPrice(show.price)}</span>}
-              {show.age_requirement && <span>{show.age_requirement}</span>}
-            </div>
-
-            {/* Ticket URL */}
-            {show.ticket_url && (
-              <div className="mt-3">
-                <a
-                  href={show.ticket_url.startsWith('http') ? show.ticket_url : `https://${show.ticket_url}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
-                >
-                  Buy Tickets
-                  <ExternalLink className="h-3.5 w-3.5" />
-                </a>
-              </div>
-            )}
-
-            {/* Description */}
-            {show.description && (
-              <p className="mt-4 text-muted-foreground">{show.description}</p>
-            )}
-
-            {/* Tags */}
+      <EntityDetailLayout
+        fallback={{ href: '/shows', label: 'Shows' }}
+        entityName={showTitle}
+        header={
+          <>
+            <ShowHeader
+              show={show}
+              actions={
+                <ShowActions
+                  show={show}
+                  showTitle={showTitle}
+                  isAdmin={isAdmin}
+                  canDelete={canDelete}
+                  canManageStatus={canManageStatus}
+                  isEditing={isEditing}
+                  onToggleEdit={() => setIsEditing(!isEditing)}
+                  onOpenDelete={() => setIsDeleteDialogOpen(true)}
+                  onToggleSoldOut={handleToggleSoldOut}
+                  onToggleCancelled={handleToggleCancelled}
+                  isSoldOutPending={setSoldOutMutation.isPending}
+                  isCancelledPending={setCancelledMutation.isPending}
+                />
+              }
+            />
             <EntityTagList
               entityType="show"
               entityId={show.id}
               isAuthenticated={isAuthenticated}
             />
+          </>
+        }
+      >
+        {/* Edit Form */}
+        {isEditing && (
+          <div className="mb-8 p-4 rounded-lg border border-border bg-muted/30">
+            <ShowForm
+              mode="edit"
+              initialData={show}
+              onSuccess={handleEditSuccess}
+              onCancel={handleEditCancel}
+            />
           </div>
+        )}
 
-          {/* Action Buttons */}
-          <div className="flex flex-col items-start sm:items-end gap-2 sm:shrink-0">
-            {/* Attendance (Going/Interested) */}
-            <AttendanceButton showId={show.id} compact={false} />
-
-            <div className="flex flex-wrap items-center gap-2">
-              <SaveButton showId={show.id} variant="outline" size="sm" />
-              <AddToCollectionButton
-                entityType="show"
-                entityId={show.id}
-                entityName={show.title || artists.map(a => a.name).join(', ')}
-              />
-              <ReportShowButton
-                showId={show.id}
-                showTitle={show.title || artists.map(a => a.name).join(', ')}
-              />
-
-              {isAdmin && (
-                <Button
-                  variant={isEditing ? 'secondary' : 'outline'}
-                  size="sm"
-                  onClick={() => setIsEditing(!isEditing)}
-                >
-                  {isEditing ? (
-                    <>
-                      <X className="h-4 w-4 mr-2" />
-                      Cancel
-                    </>
-                  ) : (
-                    <>
-                      <Pencil className="h-4 w-4 mr-2" />
-                      Edit
-                    </>
-                  )}
-                </Button>
-              )}
-
-              {canDelete && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => setIsDeleteDialogOpen(true)}
-                  className="text-destructive hover:text-destructive hover:bg-destructive/10"
-                >
-                  <Trash2 className="h-4 w-4 mr-2" />
-                  Delete
-                </Button>
-              )}
-            </div>
-
-            {/* Status Flag Buttons (Admin or Submitter) */}
-            {canManageStatus && (
-              <div className="flex items-center gap-2">
-                <Button
-                  variant={show.is_sold_out ? 'secondary' : 'outline'}
-                  size="sm"
-                  onClick={handleToggleSoldOut}
-                  disabled={setSoldOutMutation.isPending}
-                  className={show.is_sold_out ? 'bg-orange-100 text-orange-800 hover:bg-orange-200 dark:bg-orange-900/30 dark:text-orange-400 dark:hover:bg-orange-900/50' : ''}
-                >
-                  {setSoldOutMutation.isPending ? (
-                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                  ) : null}
-                  {show.is_sold_out ? 'Unmark Sold Out' : 'Mark Sold Out'}
-                </Button>
-                <Button
-                  variant={show.is_cancelled ? 'secondary' : 'outline'}
-                  size="sm"
-                  onClick={handleToggleCancelled}
-                  disabled={setCancelledMutation.isPending}
-                  className={show.is_cancelled ? 'bg-destructive/10 text-destructive hover:bg-destructive/20' : ''}
-                >
-                  {setCancelledMutation.isPending ? (
-                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                  ) : null}
-                  {show.is_cancelled ? 'Unmark Cancelled' : 'Mark Cancelled'}
-                </Button>
-              </div>
-            )}
-          </div>
-        </div>
-      </header>
-
-      {/* Edit Form */}
-      {isEditing && (
-        <div className="mb-8 p-4 rounded-lg border border-border bg-muted/30">
-          <ShowForm
-            mode="edit"
-            initialData={show}
-            onSuccess={handleEditSuccess}
-            onCancel={handleEditCancel}
-          />
-        </div>
-      )}
-
-      {/* Artist Music Section */}
-      {artistsWithMusic.length > 0 && (
-        <section className="mb-8">
-          <h2 className="text-lg font-semibold mb-4">Listen to the Artists</h2>
-          <div className="space-y-6">
-            {artistsWithMusic.map(artist => (
-              <div key={artist.id} className="space-y-2">
-                <div className="flex items-start justify-between gap-2">
-                  <div>
-                    {artist.slug ? (
-                      <Link
-                        href={`/artists/${artist.slug}`}
-                        className="font-medium hover:text-primary transition-colors"
-                      >
-                        {artist.name}
-                      </Link>
-                    ) : (
-                      <span className="font-medium">{artist.name}</span>
-                    )}
-                    {(artist.city || artist.state) && (
-                      <div className="flex items-center gap-1 text-xs text-muted-foreground mt-0.5">
-                        <MapPin className="h-3 w-3" />
-                        <span>
-                          {[artist.city, artist.state].filter(Boolean).join(', ')}
-                        </span>
-                      </div>
-                    )}
+        {/* Artist Music Section */}
+        {artistsWithMusic.length > 0 && (
+          <section className="mb-8">
+            <h2 className="text-lg font-semibold mb-4">Listen to the Artists</h2>
+            <div className="space-y-6">
+              {artistsWithMusic.map(artist => (
+                <div key={artist.id} className="space-y-2">
+                  <div className="flex items-start justify-between gap-2">
+                    <div>
+                      {artist.slug ? (
+                        <Link
+                          href={`/artists/${artist.slug}`}
+                          className="font-medium hover:text-primary transition-colors"
+                        >
+                          {artist.name}
+                        </Link>
+                      ) : (
+                        <span className="font-medium">{artist.name}</span>
+                      )}
+                      {(artist.city || artist.state) && (
+                        <div className="flex items-center gap-1 text-xs text-muted-foreground mt-0.5">
+                          <MapPin className="h-3 w-3" />
+                          <span>
+                            {[artist.city, artist.state].filter(Boolean).join(', ')}
+                          </span>
+                        </div>
+                      )}
+                    </div>
+                    <SocialLinks social={artist.socials} className="shrink-0" />
                   </div>
-                  <SocialLinks social={artist.socials} className="shrink-0" />
+                  <MusicEmbed
+                    bandcampAlbumUrl={artist.bandcamp_embed_url}
+                    bandcampProfileUrl={artist.socials?.bandcamp}
+                    spotifyUrl={artist.socials?.spotify}
+                    artistName={artist.name}
+                  />
                 </div>
-                <MusicEmbed
-                  bandcampAlbumUrl={artist.bandcamp_embed_url}
-                  bandcampProfileUrl={artist.socials?.bandcamp}
-                  spotifyUrl={artist.socials?.spotify}
-                  artistName={artist.name}
-                />
-              </div>
-            ))}
-          </div>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {/* In Collections */}
+        <section className="mb-8">
+          <EntityCollections entityType="show" entityId={show.id} />
         </section>
-      )}
 
-      {/* In Collections */}
-      <section className="mb-8">
-        <EntityCollections entityType="show" entityId={show.id} />
-      </section>
+        {/* Field Notes */}
+        <section className="mb-8">
+          <FieldNotesSection
+            showId={show.id}
+            showDate={show.event_date}
+            artists={artists.map(a => ({ id: a.id, name: a.name }))}
+          />
+        </section>
+      </EntityDetailLayout>
 
-      {/* Field Notes */}
-      <section className="mb-8">
-        <FieldNotesSection
-          showId={show.id}
-          showDate={show.event_date}
-          artists={artists.map(a => ({ id: a.id, name: a.name }))}
-        />
-      </section>
-
-      {/* Discussion */}
-      <section className="mb-8">
+      {/* Discussion — rendered as a sibling below the layout to match the
+          wrapper shape used by the 4 layout-based detail pages. */}
+      <div className="mt-0 px-4 md:px-0">
         <CommentThread entityType="show" entityId={show.id} />
-      </section>
+      </div>
 
       {/* Delete Confirmation Dialog */}
       <DeleteShowDialog
@@ -451,6 +255,6 @@ export function ShowDetail({ showId }: ShowDetailProps) {
         open={isDeleteDialogOpen}
         onOpenChange={setIsDeleteDialogOpen}
       />
-    </div>
+    </>
   )
 }

--- a/frontend/features/shows/components/ShowHeader.tsx
+++ b/frontend/features/shows/components/ShowHeader.tsx
@@ -1,0 +1,186 @@
+'use client'
+
+import Link from 'next/link'
+import { ExternalLink, MapPin } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { formatShowDate, formatShowTime, formatPrice } from '@/lib/utils/formatters'
+import type { ShowResponse } from '../types'
+
+interface ShowHeaderProps {
+  show: ShowResponse
+  /**
+   * Action cluster rendered on the right side of the header (desktop) or
+   * below the artist/venue block (mobile). Typically a `<ShowActions />`.
+   */
+  actions?: React.ReactNode
+}
+
+/**
+ * ShowDetail-specific header block. Owns the bill-position artist rendering
+ * (headliners as h1, support as "w/ ..." row), venue prominence block
+ * (name link + MapPin + "see more shows at {venue}" link), date + sold-out
+ * badge row, show meta row (time / price / age), ticket URL CTA, and
+ * description paragraph.
+ *
+ * This intentionally diverges from the generic `EntityHeader` — the bill
+ * position semantics (`set_type`) and the co-primary venue entity don't
+ * fit into `EntityHeader`'s single-string `title` / subtitle-badge shape.
+ * See `docs/learnings/entity-detail-layout-migration.md` for rationale.
+ */
+export function ShowHeader({ show, actions }: ShowHeaderProps) {
+  const venue = show.venues[0]
+  const artists = show.artists
+
+  const headliners = artists.filter(
+    a => a.set_type === 'headliner' || a.is_headliner === true
+  )
+  const support = artists.filter(
+    a => a.set_type !== 'headliner' && a.is_headliner !== true
+  )
+  const effectiveHeadliners =
+    headliners.length > 0 ? headliners : artists.length > 0 ? [artists[0]] : []
+  const effectiveSupport = headliners.length > 0 ? support : artists.slice(1)
+
+  return (
+    <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+      <div className="flex-1 min-w-0">
+        {/* Date and Status Badges */}
+        <div className="flex items-center gap-2 mb-2">
+          <span className="text-lg font-bold text-primary">
+            {formatShowDate(show.event_date, show.state)}
+          </span>
+          {show.is_sold_out && (
+            <Badge
+              variant="secondary"
+              className="text-xs font-semibold bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-400"
+            >
+              SOLD OUT
+            </Badge>
+          )}
+        </div>
+
+        {/* Artists — grouped by billing */}
+        <h1 className="text-2xl md:text-3xl font-bold leading-8 md:leading-9">
+          {effectiveHeadliners.map((artist, index) => (
+            <span key={artist.id}>
+              {index > 0 && (
+                <span className="text-muted-foreground/60 font-normal">
+                  {' '}
+                  &bull;{' '}
+                </span>
+              )}
+              {artist.slug ? (
+                <Link
+                  href={`/artists/${artist.slug}`}
+                  className="hover:text-primary transition-colors"
+                >
+                  {artist.name}
+                </Link>
+              ) : (
+                <span>{artist.name}</span>
+              )}
+            </span>
+          ))}
+        </h1>
+        {effectiveSupport.length > 0 && (
+          <div className="text-lg text-muted-foreground mt-1">
+            <span className="italic">w/</span>{' '}
+            {effectiveSupport.map((artist, index) => (
+              <span key={artist.id}>
+                {index > 0 && (
+                  <span className="text-muted-foreground/50">, </span>
+                )}
+                {artist.slug ? (
+                  <Link
+                    href={`/artists/${artist.slug}`}
+                    className="hover:text-primary/80 transition-colors"
+                  >
+                    {artist.name}
+                  </Link>
+                ) : (
+                  <span>{artist.name}</span>
+                )}
+                {artist.set_type === 'special_guest' && (
+                  <span className="text-sm text-muted-foreground/70 italic">
+                    {' '}
+                    (special guest)
+                  </span>
+                )}
+              </span>
+            ))}
+          </div>
+        )}
+
+        {/* Venue and Location */}
+        {venue && (
+          <div className="mt-2">
+            {venue.slug ? (
+              <Link
+                href={`/venues/${venue.slug}`}
+                className="text-lg text-primary/80 hover:text-primary font-medium transition-colors"
+              >
+                {venue.name}
+              </Link>
+            ) : (
+              <span className="text-lg text-primary/80 font-medium">
+                {venue.name}
+              </span>
+            )}
+            <div className="flex items-center gap-1 text-muted-foreground mt-1">
+              <MapPin className="h-4 w-4" />
+              <span>
+                {venue.city}, {venue.state}
+              </span>
+            </div>
+            {venue.slug && (
+              <Link
+                href={`/venues/${venue.slug}`}
+                className="inline-block text-sm text-muted-foreground hover:text-primary transition-colors mt-1"
+              >
+                See more shows at {venue.name} &rarr;
+              </Link>
+            )}
+          </div>
+        )}
+
+        {/* Show Details */}
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-muted-foreground mt-3">
+          <span>{formatShowTime(show.event_date, show.state)}</span>
+          {show.price != null && <span>{formatPrice(show.price)}</span>}
+          {show.age_requirement && <span>{show.age_requirement}</span>}
+        </div>
+
+        {/* Ticket URL */}
+        {show.ticket_url && (
+          <div className="mt-3">
+            <a
+              href={
+                show.ticket_url.startsWith('http')
+                  ? show.ticket_url
+                  : `https://${show.ticket_url}`
+              }
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
+            >
+              Buy Tickets
+              <ExternalLink className="h-3.5 w-3.5" />
+            </a>
+          </div>
+        )}
+
+        {/* Description */}
+        {show.description && (
+          <p className="mt-4 text-muted-foreground">{show.description}</p>
+        )}
+      </div>
+
+      {/* Action cluster (attendance + save + admin status toggles) */}
+      {actions && (
+        <div className="flex flex-col items-start sm:items-end gap-2 sm:shrink-0">
+          {actions}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/features/shows/components/index.ts
+++ b/frontend/features/shows/components/index.ts
@@ -1,6 +1,8 @@
 export { AttendanceButton } from './AttendanceButton'
 export type { AttendanceButtonProps } from './AttendanceButton'
 export { ShowDetail } from './ShowDetail'
+export { ShowHeader } from './ShowHeader'
+export { ShowActions } from './ShowActions'
 export { ShowCard } from './ShowCard'
 export type { ShowCardDensity, ShowCardProps } from './ShowCard'
 export { ShowList } from './ShowList'


### PR DESCRIPTION
## Summary

Executes the migration plan from the PSY-461 design note (PR [#424](https://github.com/mtrifilo/psychic-homily-web/pull/424)).

- **`EntityDetailLayout.tabs` is now optional.** Omitting or passing `[]` renders a flat main column with no `<TabsList>` wrapper — avoids the "lonely Overview tab" bad UX. The 4 existing tabbed pages are unaffected.
- **Extracted `ShowHeader`** (`frontend/features/shows/components/ShowHeader.tsx`) — bill-position artist rendering (headliners as h1, support as "w/ ..."), venue prominence block (link + MapPin + "see more shows at {venue}" link), date/sold-out badge row, show meta row (time / price / age), ticket URL CTA, and description paragraph.
- **Extracted `ShowActions`** (`frontend/features/shows/components/ShowActions.tsx`) — attendance button (top row), save/collect/report/edit/delete cluster (middle row), admin/owner-only status toggle row (Mark Sold Out / Mark Cancelled).
- **`ShowDetail` rewritten** on top of `EntityDetailLayout` with `tabs` omitted; show-specific sections (edit form, Artist Music Section, In Collections, Field Notes) render as children in the flat main column; `CommentThread` wrapped in `div.mt-0 px-4 md:px-0` as a sibling below the layout (matches the 4 existing detail pages). Cancelled alert banner still rendered above the layout.

## Divergences from the design note

None substantive. The design note says "siblings below the layout: edit form, Artist Music Section, EntityCollections, FieldNotesSection, CommentThread". I put the first four **inside** the layout's flat main column (they still appear "below" the header visually, and they inherit the `max-w-6xl` container) and only `CommentThread` as a true JSX sibling — mirroring the `ReleaseDetail` / `ArtistDetail` / `LabelDetail` / `FestivalDetail` convention where only `RevisionHistory` + `CommentThread` are outside the layout. This preserves the container constraint on the main content while matching the full-width comment-thread wrapper shape used elsewhere. Flagging for reviewer sanity check.

## Intentional non-additions (per the design note)

Shows still do **not** render `RevisionHistory`, `AttributionLine`, or `ContributionPrompt`. Show edits go through an admin/owner-driven pathway (inline edit form + status toggles), not community suggest-edit. Preserving that.

## Scope

ShowDetail only. VenueDetail migration is [PSY-490](https://linear.app/psychic-homily/issue/PSY-490) (separate follow-up, same design note).

## Test plan

- [x] `bunx vitest run features/shows` — 314/314 pass (36 ShowDetail tests)
- [x] `bunx vitest run components/shared` — 195/195 pass (17 `EntityDetailLayout` tests, including 4 new ones covering the flat / no-tabs branch)
- [x] `bunx tsc --noEmit -p tsconfig.json` — exit 0
- [x] ESLint clean on touched files
- [ ] Dogfood pass on desktop + mobile confirms no regressions (reviewer — I couldn't run the dev server locally, it's in use by another agent)

Closes PSY-461

Generated with [Claude Code](https://claude.com/claude-code)