### PR TITLE
PSY-488: VenueDetail layout-alignment cleanup

### DIFF
--- a/frontend/features/venues/components/VenueDetail.test.tsx
+++ b/frontend/features/venues/components/VenueDetail.test.tsx
@@ -88,6 +88,13 @@ vi.mock('@/components/shared', () => ({
     <div data-testid="entity-description">{description || (canEdit ? 'Add description' : '')}</div>
   ),
   AddToCollectionButton: () => <button data-testid="add-to-collection">Collect</button>,
+  EntityHeader: ({ title, subtitle, actions }: { title: string; subtitle?: React.ReactNode; actions?: React.ReactNode }) => (
+    <div>
+      <h1>{title}</h1>
+      {subtitle && <div>{subtitle}</div>}
+      {actions && <div>{actions}</div>}
+    </div>
+  ),
 }))
 
 vi.mock('@/features/notifications', () => ({

--- a/frontend/features/venues/components/VenueDetail.tsx
+++ b/frontend/features/venues/components/VenueDetail.tsx
@@ -10,7 +10,7 @@ import type { ApiError } from '@/lib/api'
 import { useAuthContext } from '@/lib/context/AuthContext'
 import { useQueryClient } from '@tanstack/react-query'
 import { queryKeys } from '@/lib/queryClient'
-import { SocialLinks, RevisionHistory, FollowButton, Breadcrumb, TagPill, EntityDescription, AddToCollectionButton } from '@/components/shared'
+import { SocialLinks, RevisionHistory, FollowButton, Breadcrumb, TagPill, EntityDescription, AddToCollectionButton, EntityHeader } from '@/components/shared'
 import { EntityCollections } from '@/features/collections'
 import { CommentThread } from '@/features/comments'
 import { EntityTagList } from '@/features/tags'
@@ -164,7 +164,8 @@ export function VenueDetail({ venueId }: VenueDetailProps) {
   }
 
   return (
-    <div className="container max-w-5xl mx-auto px-4 py-6">
+    // max-w-6xl matches the other 4 EntityDetailLayout-based detail pages (ArtistDetail, ReleaseDetail, LabelDetail, FestivalDetail). Previously max-w-5xl was drift from when the 2-col grid was added; the 400px sidebar + gap still fits comfortably at 6xl on desktop.
+    <div className="container max-w-6xl mx-auto px-4 py-6">
       {/* Breadcrumb Navigation */}
       <Breadcrumb
         fallback={{ href: '/venues', label: 'Venues' }}
@@ -177,72 +178,75 @@ export function VenueDetail({ venueId }: VenueDetailProps) {
         <div className="order-2 lg:order-1">
           {/* Header */}
           <header className="mb-8">
-            <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
-              <div className="flex-1 min-w-0">
-                <div className="flex items-center gap-2 flex-wrap">
-                  <h1 className="text-2xl md:text-3xl font-bold leading-8 md:leading-9">{venue.name}</h1>
+            <EntityHeader
+              title={venue.name}
+              subtitle={
+                <>
                   {venue.verified && (
                     <BadgeCheck
-                      className="h-6 w-6 text-primary shrink-0"
+                      className="h-5 w-5 text-primary shrink-0"
                       aria-label="Verified venue"
                     />
                   )}
+                  <span>{venue.city}, {venue.state}</span>
+                </>
+              }
+              actions={
+                <>
                   <FavoriteVenueButton venueId={venue.id} size="md" />
                   <FollowButton entityType="venues" entityId={venue.id} />
                   <AddToCollectionButton entityType="venue" entityId={venue.id} entityName={venue.name} />
                   <NotifyMeButton entityType="venue" entityId={venue.id} entityName={venue.name} />
-                </div>
-                <p className="text-muted-foreground mt-1">
-                  {venue.city}, {venue.state}
-                </p>
-                {venue.social?.website && (
-                  <a
-                    href={normalizeUrl(venue.social.website)}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1 text-sm text-primary hover:underline mt-1"
-                  >
-                    {getDisplayDomain(venue.social.website)}
-                    <ExternalLink className="h-3 w-3" />
-                  </a>
-                )}
-                <div className="mt-1">
-                  <AttributionLine entityType="venue" entityId={venue.id} />
-                </div>
-              </div>
-
-              {isAuthenticated && (
-                <div className="flex flex-wrap items-center gap-2 sm:shrink-0">
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => setIsEditingVenue(true)}
-                  >
-                    <Pencil className="h-4 w-4 mr-2" />
-                    Edit
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => setIsReportOpen(true)}
-                    className="text-muted-foreground hover:text-foreground"
-                    title="Report an issue"
-                  >
-                    <Flag className="h-4 w-4" />
-                  </Button>
-                  {user?.is_admin && (
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => setIsDeleteVenueOpen(true)}
-                      className="text-destructive hover:text-destructive hover:bg-destructive/10"
-                    >
-                      <Trash2 className="h-4 w-4 mr-2" />
-                      Delete
-                    </Button>
+                  {isAuthenticated && (
+                    <>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setIsEditingVenue(true)}
+                      >
+                        <Pencil className="h-4 w-4 mr-2" />
+                        Edit
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setIsReportOpen(true)}
+                        className="text-muted-foreground hover:text-foreground"
+                        title="Report an issue"
+                      >
+                        <Flag className="h-4 w-4" />
+                      </Button>
+                      {user?.is_admin && (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => setIsDeleteVenueOpen(true)}
+                          className="text-destructive hover:text-destructive hover:bg-destructive/10"
+                        >
+                          <Trash2 className="h-4 w-4 mr-2" />
+                          Delete
+                        </Button>
+                      )}
+                    </>
                   )}
-                </div>
-              )}
+                </>
+              }
+            />
+
+            {venue.social?.website && (
+              <a
+                href={normalizeUrl(venue.social.website)}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 text-sm text-primary hover:underline mt-2"
+              >
+                {getDisplayDomain(venue.social.website)}
+                <ExternalLink className="h-3 w-3" />
+              </a>
+            )}
+
+            <div className="mt-1">
+              <AttributionLine entityType="venue" entityId={venue.id} />
             </div>
 
             {/* Social Links */}
@@ -327,14 +331,18 @@ export function VenueDetail({ venueId }: VenueDetailProps) {
       </div>
 
       {/* Revision History */}
-      <RevisionHistory
-        entityType="venue"
-        entityId={venue.id}
-        isAdmin={!!user?.is_admin}
-      />
+      <div className="mt-0">
+        <RevisionHistory
+          entityType="venue"
+          entityId={venue.id}
+          isAdmin={!!user?.is_admin}
+        />
+      </div>
 
       {/* Discussion */}
-      <CommentThread entityType="venue" entityId={venue.id} />
+      <div className="mt-0 px-4 md:px-0">
+        <CommentThread entityType="venue" entityId={venue.id} />
+      </div>
 
       {/* Edit Drawer (all authenticated users) */}
       {venue && isAuthenticated && (


### PR DESCRIPTION
## Summary

Surgical layout-alignment cleanup of `frontend/features/venues/components/VenueDetail.tsx`. **Non-structural** — the 2-col grid stays per PSY-461 research — load-bearing for the map-beside-header layout and for `VenueShowsList`'s internal upcoming/past `<Tabs>`.

Follow-up to PSY-461; supersedes the canceled PSY-490 (full `EntityDetailLayout` migration was ruled out as load-bearing conflict).

Design note: [`docs/learnings/entity-detail-layout-migration.md`](../blob/main/docs/learnings/entity-detail-layout-migration.md) (section: "VenueDetail divergences").

Closes [PSY-488](https://linear.app/psychic-homily/issue/PSY-488).

## Three wins

### 1. Swap the hand-rolled header for `EntityHeader`

**Before** (excerpt): custom `flex flex-col sm:flex-row …` wrapper with inline h1, `BadgeCheck` hugging the h1, action buttons in a separate flex row, and a duplicated authenticated-user conditional for Edit / Report / Delete.

**After**: single `<EntityHeader>` with `title=`, `subtitle=` (hosts `BadgeCheck` + "Phoenix, AZ"), and `actions=` (Favorite / Follow / AddToCollection / NotifyMe + auth-gated Edit / Report / Delete). Same pattern FestivalDetail uses (`FestivalDetail.tsx:298-325`).

### 2. Wrap RevisionHistory + CommentThread with the canonical mt-0 px-4 md:px-0

**Before**:
```tsx
<RevisionHistory entityType="venue" entityId={venue.id} isAdmin={!!user?.is_admin} />
<CommentThread entityType="venue" entityId={venue.id} />
```

**After**:
```tsx
<div className="mt-0">
  <RevisionHistory entityType="venue" entityId={venue.id} isAdmin={!!user?.is_admin} />
</div>
<div className="mt-0 px-4 md:px-0">
  <CommentThread entityType="venue" entityId={venue.id} />
</div>
```

Matches ArtistDetail / ReleaseDetail / LabelDetail / FestivalDetail. Canonical drift from PSY-449.

### 3. Container max-w-5xl → max-w-6xl for parity

**Before**: `<div className="container max-w-5xl mx-auto px-4 py-6">`
**After**: `<div className="container max-w-6xl mx-auto px-4 py-6">` with a one-line inline comment explaining why (parity with the four `EntityDetailLayout` pages; prior `5xl` was drift from when the 2-col grid was added; 400px fixed sidebar + gap still fits comfortably at 6xl).

## What did NOT change

- 2-col grid (`grid grid-cols-1 lg:grid-cols-[1fr_400px]`) — load-bearing for map-beside-header + `VenueShowsList`'s internal tabs (per PSY-461 research)
- `order-2 lg:order-1` / `order-1 lg:order-2` mobile inversion (map first on mobile)
- `VenueShowsList` and its internal upcoming / past Radix tabs
- Right-column sidebar (`VenueLocationCard` + `VenueGenreProfile` + `EntityCollections`)
- All sibling dialogs (`EntityEditDrawer`, `DeleteVenueDialog`, `ReportEntityDialog`)

Not in scope:
- Full `EntityDetailLayout` migration (PSY-490, canceled)
- `AttributionLine` / `ContributionPrompt` placement churn (PSY-489 territory)
- ShowDetail / ArtistDetail / ReleaseDetail / LabelDetail / FestivalDetail (all untouched)

## Test plan

- [x] `bunx vitest run features/venues` — all 105 tests pass across 7 files, including the PSY-472 real-Radix aria-selected assertions for the upcoming / past tab switch in `VenueDetail.test.tsx`
- [x] `bunx tsc --noEmit -p tsconfig.json` — clean, no new errors on touched files
- [x] ESLint on the two touched files — only pre-existing warnings (`VenueEditForm`, `canEdit`, `_id`, `_opts`), no new findings
- [x] Header block scan: no leftover inline `<h1>`, no `BadgeCheck` outside `subtitle`, no manually-rendered action buttons outside `actions`. All routed through `EntityHeader`.
- [ ] Manual desktop check: map + 2-col grid at 6xl on desktop (deferred, low-risk per ticket: "inner DOM of the left column should look identical")

🤖 Generated with [Claude Code](https://claude.com/claude-code)