### PR TITLE
PSY-494: comment why ShowDetail omits community-edit surfaces

### DIFF
--- a/frontend/features/shows/components/ShowDetail.tsx
+++ b/frontend/features/shows/components/ShowDetail.tsx
@@ -249,6 +249,13 @@ export function ShowDetail({ showId }: ShowDetailProps) {
         <CommentThread entityType="show" entityId={show.id} />
       </div>
 
+      {/* PSY-461 / PSY-489: ShowDetail intentionally omits AttributionLine,
+          ContributionPrompt, and RevisionHistory — shows flow through an
+          admin/owner-only edit pathway, not the community suggest-edit
+          pipeline used by the other 5 detail pages. See
+          docs/learnings/entity-detail-layout-migration.md for the design
+          rationale. Do not "align for parity" with the other detail pages. */}
+
       {/* Delete Confirmation Dialog */}
       <DeleteShowDialog
         show={show}


### PR DESCRIPTION
## Summary
- Adds a 6-line comment in `frontend/features/shows/components/ShowDetail.tsx` documenting that `AttributionLine`, `ContributionPrompt`, and `RevisionHistory` are deliberately absent.
- Placed as a sibling to the existing `CommentThread` wrapper — the spot where the other 5 detail pages render those components — so future reviewers spot the explicit opt-out before attempting to "align for parity".
- References PSY-461 (design note) and PSY-489 (audit), and points readers to `docs/learnings/entity-detail-layout-migration.md` for rationale.

No behavior change. Comment-only.

Closes PSY-494

## Test plan
- [x] Diff is a single-file, comment-only change
- [x] Referenced doc (`docs/learnings/entity-detail-layout-migration.md`) exists
- [x] Comment placed inside the JSX fragment at a valid position (between `CommentThread` wrapper and `DeleteShowDialog`)

Generated with [Claude Code](https://claude.com/claude-code)