### PR TITLE
PSY-491: add RevisionHistory to FestivalDetail

### DIFF
--- a/frontend/features/festivals/components/FestivalDetail.tsx
+++ b/frontend/features/festivals/components/FestivalDetail.tsx
@@ -19,7 +19,7 @@ import {
   useFestivalVenues,
   useFestivals,
 } from '../hooks/useFestivals'
-import { EntityDetailLayout, EntityHeader, SocialLinks, FollowButton, AddToCollectionButton } from '@/components/shared'
+import { EntityDetailLayout, EntityHeader, SocialLinks, FollowButton, AddToCollectionButton, RevisionHistory } from '@/components/shared'
 import { EntityCollections } from '@/features/collections'
 import { TabsContent } from '@/components/ui/tabs'
 import { Badge } from '@/components/ui/badge'
@@ -488,6 +488,15 @@ export function FestivalDetail({ idOrSlug }: FestivalDetailProps) {
         </div>
       </TabsContent>
     </EntityDetailLayout>
+
+    {/* Revision History */}
+    <div className="mt-0">
+      <RevisionHistory
+        entityType="festival"
+        entityId={festival.id}
+        isAdmin={!!user?.is_admin}
+      />
+    </div>
 
     {/* Discussion */}
     <div className="mt-0 px-4 md:px-0">


### PR DESCRIPTION
## Summary

Festival edits already write revision rows on the backend, but `FestivalDetail` was the only entity detail page (artist, venue, release all have it) not rendering the history section. Pure frontend drift — 10-line addition.

## Approach

Read `ArtistDetail.tsx`, `VenueDetail.tsx`, and `ReleaseDetail.tsx` to find the canonical placement. `ArtistDetail` is the closest analog (uses `EntityDetailLayout` like `FestivalDetail`, passes `isAdmin` to enable admin rollback). Matched that pattern exactly:

```tsx
{/* Revision History */}
<div className="mt-0">
  <RevisionHistory
    entityType="festival"
    entityId={festival.id}
    isAdmin={!!user?.is_admin}
  />
</div>
```

Placed between `</EntityDetailLayout>` and the existing `CommentThread` block, next to the discussion section.

## Scope

Just the `RevisionHistory` addition. `AttributionLine` and `ContributionPrompt` are already present on `FestivalDetail` — no other drift to fix here.

## Test plan

- [x] `bunx vitest run features/festivals` — 17 pass
- [x] `bunx tsc --noEmit -p tsconfig.json` — no new errors on touched file
- [x] `bunx eslint features/festivals/components/FestivalDetail.tsx` — only pre-existing errors (React Compiler memo dep + `<img>` warning), unchanged from main
- [ ] Smoke CI passes

Closes PSY-491.

Generated with [Claude Code](https://claude.com/claude-code)