### PR TITLE
PSY-475: env-flagged skip of auth + passkey rate limiters in test

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -124,6 +124,7 @@ The database connection is configured for Docker networking (`db:5432`) when run
 ## Test-only env flags
 
 - **`ENABLE_TEST_FIXTURES=1`** (PSY-432): registers the admin-only `POST /admin/test-fixtures/reset` endpoint used by Playwright worker teardown to wipe a test user's mutable rows. The server **refuses to boot** with this flag set unless `ENVIRONMENT` is `test`, `ci`, or `development` (default-deny — any other value including unset, `production`, `staging`, `preview` causes startup to fail). The endpoint itself also requires an admin JWT, the `X-Test-Fixtures: 1` header, and a target user whose email ends in `@test.local`. Local dev normally leaves this flag unset; E2E global-setup enables it when spawning its private backend.
+- **`DISABLE_AUTH_RATE_LIMITS=1`** (PSY-475): replaces the IP-scoped auth (10/min) + passkey (20/min) rate limiters with no-op middleware. Same default-deny `ENVIRONMENT` gate — startup panics if the flag is on in `production`/`staging`/`preview`/unset. Exists because all parallel Playwright workers share `127.0.0.1`, exhausting the per-IP budget and intermittently flaking `register.spec.ts` + `magic-link.spec.ts`. Production + staging keep the limiters; only test-env skips them.
 
 ## Deployment commands to run
 

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -54,6 +54,13 @@ func main() {
 		log.Fatalf("PSY-432 test-fixtures misconfiguration: %v", err)
 	}
 
+	// PSY-475: same default-deny check for the auth-rate-limit disable
+	// flag. Refuses to boot if DISABLE_AUTH_RATE_LIMITS=1 is combined
+	// with a non-allowed ENVIRONMENT (production, stage, preview, unset).
+	if err := routes.ValidateAuthRateLimitEnvironment(os.Getenv); err != nil {
+		log.Fatalf("PSY-475 auth-rate-limit misconfiguration: %v", err)
+	}
+
 	// Initialize structured logger
 	// Use JSON format in production, text format with debug in development
 	isProduction := environment == config.EnvProduction

--- a/backend/internal/api/routes/auth_rate_limit.go
+++ b/backend/internal/api/routes/auth_rate_limit.go
@@ -1,0 +1,65 @@
+package routes
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// PSY-475: env-flagged skip of the IP-scoped auth/passkey rate limiters
+// during E2E runs. All E2E workers on a CI shard share one IP
+// (127.0.0.1), so auth flows intermittently hit HTTP 429 and break
+// `register.spec.ts` / `magic-link.spec.ts`. Pattern mirrors PSY-432's
+// ENABLE_TEST_FIXTURES gate: env flag honored only when ENVIRONMENT is
+// allowlisted; default-deny at startup refuses to boot in prod/staging/
+// preview/unset with the flag on.
+//
+// Not combined with PSY-432's TestFixturesAllowedEnvironments enum on
+// purpose — separating the two flags lets them be audited / flipped
+// independently. Factor out into a shared `testenv` helper when a third
+// flag lands with the same shape.
+const DisableAuthRateLimitsEnvVar = "DISABLE_AUTH_RATE_LIMITS"
+
+// authRateLimitAllowedEnvironments mirrors the PSY-432 allowed list:
+// test, ci, development. Production / stage / preview / unset all
+// refuse when the flag is on.
+var authRateLimitAllowedEnvironments = map[string]bool{
+	"test":        true,
+	"ci":          true,
+	"development": true,
+}
+
+// IsAuthRateLimitDisabled reports whether the auth + passkey rate
+// limiters should be replaced with no-ops. ValidateAuthRateLimitEnvironment
+// is the safety gate — callers should invoke it at startup before relying
+// on this value for route setup.
+func IsAuthRateLimitDisabled(getenv func(string) string) bool {
+	return getenv(DisableAuthRateLimitsEnvVar) == "1"
+}
+
+// ValidateAuthRateLimitEnvironment returns an error if the disable flag is
+// on in a non-allowlisted ENVIRONMENT. Call from cmd/server/main.go
+// before route setup; a returned error should cause the server to refuse
+// to boot.
+func ValidateAuthRateLimitEnvironment(getenv func(string) string) error {
+	if !IsAuthRateLimitDisabled(getenv) {
+		return nil
+	}
+	env := getenv("ENVIRONMENT")
+	if !authRateLimitAllowedEnvironments[env] {
+		allowed := make([]string, 0, len(authRateLimitAllowedEnvironments))
+		for k := range authRateLimitAllowedEnvironments {
+			allowed = append(allowed, k)
+		}
+		return fmt.Errorf(
+			"%s=1 requires ENVIRONMENT to be one of %v (got %q). Refusing to boot.",
+			DisableAuthRateLimitsEnvVar, allowed, env,
+		)
+	}
+	return nil
+}
+
+// noopRateLimiter returns a pass-through middleware. Used in place of
+// httprate.Limit when IsAuthRateLimitDisabled reports true.
+func noopRateLimiter() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler { return next }
+}

--- a/backend/internal/api/routes/auth_rate_limit_test.go
+++ b/backend/internal/api/routes/auth_rate_limit_test.go
@@ -1,0 +1,99 @@
+package routes
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func envFromMap(m map[string]string) func(string) string {
+	return func(k string) string { return m[k] }
+}
+
+func TestIsAuthRateLimitDisabled(t *testing.T) {
+	cases := []struct {
+		name string
+		env  map[string]string
+		want bool
+	}{
+		{"unset", map[string]string{}, false},
+		{"empty", map[string]string{"DISABLE_AUTH_RATE_LIMITS": ""}, false},
+		{"zero", map[string]string{"DISABLE_AUTH_RATE_LIMITS": "0"}, false},
+		{"true-string", map[string]string{"DISABLE_AUTH_RATE_LIMITS": "true"}, false},
+		{"exactly-1", map[string]string{"DISABLE_AUTH_RATE_LIMITS": "1"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsAuthRateLimitDisabled(envFromMap(tc.env)); got != tc.want {
+				t.Errorf("want %v got %v", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestValidateAuthRateLimitEnvironment(t *testing.T) {
+	cases := []struct {
+		name        string
+		env         map[string]string
+		wantError   bool
+		errContains string
+	}{
+		// Flag off = always safe
+		{"flag-off / env-unset", map[string]string{}, false, ""},
+		{"flag-off / env-production", map[string]string{"ENVIRONMENT": "production"}, false, ""},
+		{"flag-0 / env-production", map[string]string{"DISABLE_AUTH_RATE_LIMITS": "0", "ENVIRONMENT": "production"}, false, ""},
+
+		// Flag on + allowed env = safe
+		{"flag-on / env-test", map[string]string{"DISABLE_AUTH_RATE_LIMITS": "1", "ENVIRONMENT": "test"}, false, ""},
+		{"flag-on / env-ci", map[string]string{"DISABLE_AUTH_RATE_LIMITS": "1", "ENVIRONMENT": "ci"}, false, ""},
+		{"flag-on / env-development", map[string]string{"DISABLE_AUTH_RATE_LIMITS": "1", "ENVIRONMENT": "development"}, false, ""},
+
+		// Flag on + not-allowed env = refuse
+		{"flag-on / env-production", map[string]string{"DISABLE_AUTH_RATE_LIMITS": "1", "ENVIRONMENT": "production"}, true, "production"},
+		{"flag-on / env-stage", map[string]string{"DISABLE_AUTH_RATE_LIMITS": "1", "ENVIRONMENT": "stage"}, true, "stage"},
+		{"flag-on / env-preview", map[string]string{"DISABLE_AUTH_RATE_LIMITS": "1", "ENVIRONMENT": "preview"}, true, "preview"},
+		{"flag-on / env-unset", map[string]string{"DISABLE_AUTH_RATE_LIMITS": "1"}, true, ""},
+		{"flag-on / env-casing", map[string]string{"DISABLE_AUTH_RATE_LIMITS": "1", "ENVIRONMENT": "Test"}, true, "Test"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateAuthRateLimitEnvironment(envFromMap(tc.env))
+			if tc.wantError {
+				if err == nil {
+					t.Fatal("want error got nil")
+				}
+				if tc.errContains != "" && !strings.Contains(err.Error(), tc.errContains) {
+					t.Errorf("error %q missing %q", err.Error(), tc.errContains)
+				}
+			} else if err != nil {
+				t.Errorf("want no error got %v", err)
+			}
+		})
+	}
+}
+
+// TestNoopRateLimiter_PassesThrough asserts the no-op middleware doesn't
+// block or modify requests — it just forwards to next.
+func TestNoopRateLimiter_PassesThrough(t *testing.T) {
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+	wrapped := noopRateLimiter()(next)
+
+	// Fire 100 sequential requests; none should be blocked.
+	for i := 0; i < 100; i++ {
+		called = false
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		wrapped.ServeHTTP(w, req)
+		if !called {
+			t.Fatalf("request %d: next handler not invoked", i)
+		}
+		if w.Code != http.StatusOK {
+			t.Fatalf("request %d: want 200 got %d", i, w.Code)
+		}
+	}
+}

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -158,12 +158,23 @@ func setupAuthRoutes(rc RouteContext) {
 	// - Credential stuffing
 	// - Email bombing via magic links
 	// - Spam account creation
-	authRateLimiter := httprate.Limit(
-		10,              // requests
-		1*time.Minute,   // per duration
-		httprate.WithKeyFuncs(httprate.KeyByIP),
-		httprate.WithLimitHandler(rateLimitHandler),
-	)
+	//
+	// PSY-475: replaced with a no-op when DISABLE_AUTH_RATE_LIMITS=1 in a
+	// whitelisted ENVIRONMENT. All E2E workers share 127.0.0.1, so the
+	// 10/min budget got exhausted and broke register/magic-link tests on
+	// shard 3. Default-deny env check in cmd/server/main.go refuses to
+	// boot with the flag set anywhere other than test/ci/development.
+	var authRateLimiter func(http.Handler) http.Handler
+	if IsAuthRateLimitDisabled(os.Getenv) {
+		authRateLimiter = noopRateLimiter()
+	} else {
+		authRateLimiter = httprate.Limit(
+			10,              // requests
+			1*time.Minute,   // per duration
+			httprate.WithKeyFuncs(httprate.KeyByIP),
+			httprate.WithLimitHandler(rateLimitHandler),
+		)
+	}
 
 	// Rate-limited OAuth routes
 	rc.Router.Group(func(r chi.Router) {
@@ -223,13 +234,19 @@ func setupPasskeyRoutes(rc RouteContext) {
 	passkeyHandler := handlers.NewPasskeyHandler(rc.SC.WebAuthn, rc.SC.JWT, rc.SC.User, rc.Cfg)
 
 	// Create rate limiter for passkey endpoints: 20 requests per minute per IP
-	// Slightly more lenient than auth due to multi-step WebAuthn flow
-	passkeyRateLimiter := httprate.Limit(
-		20,              // requests
-		1*time.Minute,   // per duration
-		httprate.WithKeyFuncs(httprate.KeyByIP),
-		httprate.WithLimitHandler(rateLimitHandler),
-	)
+	// Slightly more lenient than auth due to multi-step WebAuthn flow.
+	// PSY-475: same env-flagged no-op gate as the auth limiter.
+	var passkeyRateLimiter func(http.Handler) http.Handler
+	if IsAuthRateLimitDisabled(os.Getenv) {
+		passkeyRateLimiter = noopRateLimiter()
+	} else {
+		passkeyRateLimiter = httprate.Limit(
+			20,              // requests
+			1*time.Minute,   // per duration
+			httprate.WithKeyFuncs(httprate.KeyByIP),
+			httprate.WithLimitHandler(rateLimitHandler),
+		)
+	}
 
 	// Rate-limited public passkey endpoints
 	rc.Router.Group(func(r chi.Router) {

--- a/frontend/e2e/global-setup.ts
+++ b/frontend/e2e/global-setup.ts
@@ -148,6 +148,14 @@ function startBackend(): ChildProcess {
       // one of {test, ci, development}.
       ENABLE_TEST_FIXTURES: '1',
       ENVIRONMENT: 'test',
+      // PSY-475: replace the IP-scoped auth (10/min) + passkey (20/min)
+      // rate limiters with no-op middleware for E2E. All parallel workers
+      // on a CI shard share 127.0.0.1, so the limits got tripped on shard
+      // 3 and caused intermittent failures in register.spec.ts and
+      // magic-link.spec.ts. Same default-deny ENVIRONMENT guard as
+      // ENABLE_TEST_FIXTURES — the server refuses to boot if the flag is
+      // set in anything other than test/ci/development.
+      DISABLE_AUTH_RATE_LIMITS: '1',
     },
     stdio: ['ignore', 'pipe', 'pipe'],
     detached: true,


### PR DESCRIPTION
## Summary

The route-level auth limiter (10 req/min/IP) and passkey limiter (20 req/min/IP) were tripping on shard 3 of post-merge full-suite runs. All parallel Playwright workers share `127.0.0.1`, so the per-IP budget got exhausted and intermittently broke:

- **`register.spec.ts:62`** — HTTP 429 on `/auth/register` → page showed "Rate limit exceeded" instead of the expected breach message → `getByText(/password has been exposed/i)` timed out (unmasked by PSY-474's selector fix).
- **`magic-link.spec.ts:20`** (`@smoke`) — HTTP 429 on `/auth/magic-link/verify` → happy-path never reached "Welcome back!" → `waitForURL` timeout.

## Fix

Follows PSY-432's pattern exactly — env-flagged test-only relaxation with a default-deny environment gate.

- **`DISABLE_AUTH_RATE_LIMITS=1`** replaces both limiters with a no-op pass-through middleware.
- **`ValidateAuthRateLimitEnvironment`** (in `cmd/server/main.go`) panics at startup if the flag is set in anything other than `{test, ci, development}`. Production, stage, preview, and unset all refuse to boot.
- **`frontend/e2e/global-setup.ts`** sets the flag alongside `ENABLE_TEST_FIXTURES=1` and `ENVIRONMENT=test`.
- `backend/README.md`'s test-only-env-flags section documents the new flag.

## Why env flag not email-based

Ticket floated "relax for `@test.local` emails" as an alternative. Rejected because parsing the request body inside limiter middleware adds complexity and is easier to misuse (a malicious `x@test.local` would bypass). Env-flagged approach is safer, simpler, and matches the PSY-432 shape precisely.

## Not combined with PSY-432's allowed-env list

`TestFixturesAllowedEnvironments` in `test_fixtures.go` has the same `{test, ci, development}` contents. Kept the PSY-475 list separate for now — two independent flags with two independent audit paths. If a third flag with the same shape lands, we can factor a shared `testenv` helper then.

## Tests

- 5-case unit test on `IsAuthRateLimitDisabled` (unset / empty / 0 / "true" string / exactly-"1")
- 11-case unit test on `ValidateAuthRateLimitEnvironment` covering flag-off-safe paths, flag-on + allowed envs, flag-on + rejected envs (production/stage/preview/unset/casing)
- Pass-through assertion for `noopRateLimiter`: 100 sequential requests all forward to next (none blocked, none modified)
- Full backend suite passes (`go test ./...`)

## Out of scope

- `magic-link.spec.ts:20` and `register.spec.ts:62` are expected to go green on the next post-merge run after this lands. Not re-enabling rate limits for their individual tests — the limiters aren't what we're testing on those specs.
- The comment-system's 60s per-entity cooldown + hourly tier limits — different layer (service-level, not route-level), not affected.

Closes PSY-475.

🤖 Generated with [Claude Code](https://claude.com/claude-code)