### PR TITLE
PSY-411: file GitHub issue on post-merge main CI failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,3 +284,112 @@ jobs:
           name: playwright-report
           path: frontend/playwright-report/
           retention-days: 7
+
+  # PSY-411: post-merge CI failures on `main` used to silently go
+  # unnoticed — the 000071 duplicate-migration collision lived on main
+  # for 7 hours before anyone saw it. Branch protection gates PR-branch
+  # CI, but the full E2E suite (sharded) only runs post-merge per
+  # PSY-446's smoke/full split, so a merge-commit failure doesn't block
+  # anything and doesn't page anyone.
+  #
+  # This job files a GitHub issue on any main-branch CI failure.
+  # Dedupes against the commit SHA so rerun storms don't spam. No
+  # external config — uses the built-in GITHUB_TOKEN.
+  notify-main-failure:
+    name: Notify on main CI failure
+    # `always()` so this runs even when upstream `needs:` failed — the
+    # whole point. Scoped to main-branch push events (not PRs).
+    if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && (needs.migration-lint.result == 'failure' || needs.migration-reversibility.result == 'failure' || needs.backend-tests.result == 'failure' || needs.frontend-unit-tests.result == 'failure' || needs.e2e-tests.result == 'failure' || needs.e2e-report.result == 'failure') }}
+    needs:
+      - migration-lint
+      - migration-reversibility
+      - backend-tests
+      - frontend-unit-tests
+      - e2e-tests
+      - e2e-report
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: File or dedupe tracking issue
+        uses: actions/github-script@v7
+        env:
+          RES_MIGRATION_LINT: ${{ needs.migration-lint.result }}
+          RES_MIGRATION_REVERSIBILITY: ${{ needs.migration-reversibility.result }}
+          RES_BACKEND_TESTS: ${{ needs.backend-tests.result }}
+          RES_FRONTEND_UNIT: ${{ needs.frontend-unit-tests.result }}
+          RES_E2E_TESTS: ${{ needs.e2e-tests.result }}
+          RES_E2E_REPORT: ${{ needs.e2e-report.result }}
+        with:
+          script: |
+            const shortSha = context.sha.substring(0, 7)
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            const commitUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/commit/${context.sha}`
+
+            // Dedupe: skip if an open `main-ci-failure` issue already
+            // references this SHA. Catches retries of the same failing run.
+            const { data: existing } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'main-ci-failure',
+              state: 'open',
+              per_page: 50,
+            })
+            if (existing.some(i => i.title.includes(shortSha))) {
+              core.info(`Open issue already references ${shortSha}; skipping.`)
+              return
+            }
+
+            const results = {
+              'Migration Lint': process.env.RES_MIGRATION_LINT,
+              'Migration Reversibility': process.env.RES_MIGRATION_REVERSIBILITY,
+              'Backend Tests': process.env.RES_BACKEND_TESTS,
+              'Frontend Unit Tests': process.env.RES_FRONTEND_UNIT,
+              'E2E Tests (sharded)': process.env.RES_E2E_TESTS,
+              'E2E Merged Report': process.env.RES_E2E_REPORT,
+            }
+            const failed = Object.entries(results)
+              .filter(([_, r]) => r === 'failure')
+              .map(([name]) => name)
+
+            // Fetch commit metadata for author + subject. Nice-to-have —
+            // file the issue even if this call fails.
+            let authorLine = ''
+            let commitSubject = shortSha
+            try {
+              const { data: commit } = await github.rest.repos.getCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: context.sha,
+              })
+              commitSubject = commit.commit.message.split('\n')[0]
+              const login = commit.author && commit.author.login
+              authorLine = login
+                ? `Triggered by: @${login}`
+                : `Commit author: ${commit.commit.author.name}`
+            } catch (err) {
+              core.warning(`Failed to fetch commit metadata: ${err.message}`)
+            }
+
+            const title = `Main CI failed: ${commitSubject.slice(0, 80)} (${shortSha})`
+            const body = [
+              `Post-merge CI on \`main\` failed.`,
+              '',
+              `**Failing jobs:** ${failed.join(', ') || '(none reported as "failure"; check the run directly)'}`,
+              `**Run:** ${runUrl}`,
+              `**Commit:** ${commitUrl}`,
+              authorLine,
+              '',
+              '---',
+              '',
+              'Filed automatically by the `notify-main-failure` job (PSY-411). Close once the root cause is understood (revert, hotfix, or flake). A new issue will file automatically on the next failing run against a different commit.',
+            ].filter(Boolean).join('\n')
+
+            const { data: created } = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels: ['main-ci-failure'],
+            })
+            core.info(`Filed issue #${created.number}: ${created.html_url}`)


### PR DESCRIPTION
## Summary

Post-merge CI on `main` used to silently fail. The 000071 duplicate-migration collision lived on main for 7 hours before anyone saw it — branch protection gates PR-branch CI, but the full E2E suite (sharded) only runs post-merge per PSY-446's smoke/full split, so a merge-commit failure didn't block anything and didn't page anyone.

This PR adds a `notify-main-failure` job that files a GitHub issue on any main-branch CI failure.

## Behavior

Runs only when **all** of these are true:
- `github.event_name == 'push'` (not on PRs)
- `github.ref == 'refs/heads/main'`
- At least one of: migration-lint / migration-reversibility / backend-tests / frontend-unit-tests / e2e-tests / e2e-report has `result == 'failure'`

When it fires, files an issue with:
- Commit subject + short SHA in the title
- List of failing jobs (looked up from `needs.<job>.result`)
- Links to the failing run + the commit
- `@`-mention of the commit author (best-effort via `repos.getCommit` — job still files the issue if the lookup errors)

### Dedupe

Issues are deduped by short SHA in the title. Rapid re-runs of the same failing commit won't spam new issues. A *new* SHA → *new* issue. That's the semantics we want — each merge commit gets one tracking issue.

## Why GitHub issues (not Slack/Discord/email)

- Zero external config: uses the built-in `GITHUB_TOKEN`, no webhooks, no secrets.
- First-class in the existing workflow — the team uses issues + PRs already.
- Scoped permissions: `issues: write` only, nothing else.
- Label-based triage: `main-ci-failure` auto-created on first use; filters show the open queue.

Swapping to a chat-webhook layer later is a small incremental change on top — doesn't need to ship in this PR.

## Not in scope

- **Option (b) from the ticket** (require branches up-to-date before merge) — that's a GitHub branch-protection UI change, not a code change. Recommended settings:
  - "Require branches to be up to date before merging" = **on**
  - "Require status checks to pass before merging" = **on**, with: Migration Lint, Migration Reversibility, Backend Tests, Frontend Unit Tests, E2E Smoke (PR)
  - Expected side effect: serial merges when main moves. Fine for a small team.
- **Auto-revert on failure** — too aggressive for the current flake-rate signal-to-noise ratio. Revisit after a few weeks of issue-based signal.
- **Notifying on flaky passes** (first attempt failed, retry passed) — Playwright's retry behavior makes `result` 'success' in that case. Worth reconsidering if we accumulate flaky-pass drift.

## Validation

Acceptance criterion: "Validate by intentionally breaking main and confirming the signal fires."

Can't validate in this PR without introducing real breakage to main. Two realistic validation paths after merge:

1. **Opportunistic**: the next real post-merge failure files an issue. Historical rate across the past ~20 merges suggests we'll see one within 2–5 merges.
2. **Intentional**: file a throwaway PR that deliberately breaks one job (e.g., add `exit 1` to migration-lint), merge it with admin override, confirm the issue is filed, then revert. Only worth doing if (1) doesn't fire within a few days.

## Test plan

- [x] YAML parses cleanly (verified locally with `yaml.safe_load`)
- [x] `needs:` list matches the jobs that actually run on main push
- [x] `if:` predicate correctly excludes PR events and green-all-the-way-through cases
- [ ] First opportunistic post-merge failure files an expected issue (validated post-merge)

Closes PSY-411.

🤖 Generated with [Claude Code](https://claude.com/claude-code)