### PR TITLE
PSY-495: Drop activity gate on /artists when tag filter engaged (Bandcamp model)

### DIFF
--- a/backend/internal/api/handlers/artist.go
+++ b/backend/internal/api/handlers/artist.go
@@ -119,6 +119,12 @@ func (h *ArtistHandler) ListArtistsHandler(ctx context.Context, req *ListArtists
 	}
 	if tf := parseTagFilter(req.Tags, req.TagMatch); tf.HasTags() {
 		filters["tag_filter"] = tf
+		// PSY-495 (Bandcamp model): when a tag filter is engaged, drop the
+		// default "has upcoming shows" activity gate so tag pages are
+		// evergreen discovery surfaces. A fan filtering by "punk" wants
+		// every punk-tagged artist — active or not — so the facet-chip
+		// count matches the list result count.
+		filters["skip_active_filter"] = true
 	}
 
 	artists, err := h.artistService.GetArtistsWithShowCounts(filters)

--- a/backend/internal/api/handlers/artist_integration_test.go
+++ b/backend/internal/api/handlers/artist_integration_test.go
@@ -157,6 +157,106 @@ func (s *ArtistHandlerIntegrationSuite) TestListArtists_CityFilter() {
 	s.Equal("Phoenix Band", resp.Body.Artists[0].Name)
 }
 
+// --- ListArtists with Tag Filter (PSY-495) ---
+
+// tagArtist is a low-level helper that tags an existing artist with the given
+// tag slug, creating the tag row and entity_tags row if needed. It does NOT
+// bump tags.usage_count — PSY-495 tests only exercise the tag-filter query
+// path, not the count-rollup trigger.
+func (s *ArtistHandlerIntegrationSuite) tagArtist(artistID uint, tagSlug string) {
+	// upsert tag
+	var tag models.Tag
+	if err := s.deps.db.Where("slug = ?", tagSlug).First(&tag).Error; err != nil {
+		tag = models.Tag{
+			Name:     tagSlug,
+			Slug:     tagSlug,
+			Category: models.TagCategoryGenre,
+		}
+		s.Require().NoError(s.deps.db.Create(&tag).Error)
+	}
+
+	// need an AddedByUserID: grab or create a throwaway user
+	adder := createTestUser(s.deps.db)
+
+	entityTag := models.EntityTag{
+		TagID:         tag.ID,
+		EntityType:    models.TagEntityArtist,
+		EntityID:      artistID,
+		AddedByUserID: adder.ID,
+	}
+	s.Require().NoError(s.deps.db.Create(&entityTag).Error)
+}
+
+// TestListArtists_TagFilter_DropsActivityGate is the PSY-495 contract.
+// Without a tag filter, /artists gates on "has upcoming shows". With a tag
+// filter engaged, we follow the Bandcamp model — every artist tagged `X`
+// surfaces, active or not. Facet-chip count parity is what the fix is for.
+func (s *ArtistHandlerIntegrationSuite) TestListArtists_TagFilter_DropsActivityGate() {
+	// Three artists tagged `punk`: one with an upcoming show, two without
+	activeID := s.createArtistWithUpcomingShow("Punk Active Band")
+	inactiveID1 := s.createArtistViaService("Punk Dormant One")
+	inactiveID2 := s.createArtistViaService("Punk Dormant Two")
+
+	s.tagArtist(activeID, "punk")
+	s.tagArtist(inactiveID1, "punk")
+	s.tagArtist(inactiveID2, "punk")
+
+	// One artist tagged `rock` to make sure the filter actually narrows
+	s.createArtistWithUpcomingShow("Rock Noise")
+
+	// With no tag filter: default activity gate applies → only the active
+	// punk band and the rock band show up (2 total)
+	unfiltered, err := s.handler.ListArtistsHandler(s.deps.ctx, &ListArtistsRequest{})
+	s.Require().NoError(err)
+	s.Equal(2, unfiltered.Body.Count, "unfiltered list should exclude dormant artists")
+
+	// With tags=punk: activity gate drops → all 3 punk-tagged artists
+	// surface regardless of upcoming-show status (facet count parity)
+	req := &ListArtistsRequest{Tags: "punk"}
+	resp, err := s.handler.ListArtistsHandler(s.deps.ctx, req)
+	s.Require().NoError(err)
+	s.Equal(3, resp.Body.Count, "tag-filtered list must return all 3 punk artists")
+
+	// Sort order: upcoming_show_count DESC, then name ASC. The active band
+	// sits first; the two dormant ones follow in alphabetical order.
+	s.Equal("Punk Active Band", resp.Body.Artists[0].Name)
+	s.Equal(1, resp.Body.Artists[0].UpcomingShowCount)
+	s.Equal("Punk Dormant One", resp.Body.Artists[1].Name)
+	s.Equal(0, resp.Body.Artists[1].UpcomingShowCount)
+	s.Equal("Punk Dormant Two", resp.Body.Artists[2].Name)
+	s.Equal(0, resp.Body.Artists[2].UpcomingShowCount)
+}
+
+// TestListArtists_TagFilter_SurfacesLastShowDate verifies that evergreen mode
+// populates `last_show_date` for dormant artists so cards can render a
+// "no upcoming shows · last show <Mon Year>" affordance.
+func (s *ArtistHandlerIntegrationSuite) TestListArtists_TagFilter_SurfacesLastShowDate() {
+	dormantID := s.createArtistViaService("Old Shoegaze Band")
+	// Give the dormant artist a past approved show 400 days ago
+	user := createTestUser(s.deps.db)
+	venue := createVerifiedVenue(s.deps.db, "Past Venue", "Phoenix", "AZ")
+	pastShow := &models.Show{
+		Title:       "Past Gig",
+		EventDate:   time.Now().UTC().AddDate(0, 0, -400),
+		City:        stringPtr("Phoenix"),
+		State:       stringPtr("AZ"),
+		Status:      models.ShowStatusApproved,
+		SubmittedBy: &user.ID,
+	}
+	s.deps.db.Create(pastShow)
+	s.deps.db.Exec("INSERT INTO show_venues (show_id, venue_id) VALUES (?, ?)", pastShow.ID, venue.ID)
+	s.deps.db.Exec("INSERT INTO show_artists (show_id, artist_id, position, set_type) VALUES (?, ?, 0, 'headliner')", pastShow.ID, dormantID)
+
+	s.tagArtist(dormantID, "shoegaze")
+
+	resp, err := s.handler.ListArtistsHandler(s.deps.ctx, &ListArtistsRequest{Tags: "shoegaze"})
+	s.Require().NoError(err)
+	s.Equal(1, resp.Body.Count)
+	s.Equal("Old Shoegaze Band", resp.Body.Artists[0].Name)
+	s.Equal(0, resp.Body.Artists[0].UpcomingShowCount)
+	s.Require().NotNil(resp.Body.Artists[0].LastShowDate, "last_show_date should populate for dormant artists in evergreen mode")
+}
+
 // --- GetArtistHandler ---
 
 func (s *ArtistHandlerIntegrationSuite) TestGetArtist_ByID() {

--- a/backend/internal/services/catalog/artist.go
+++ b/backend/internal/services/catalog/artist.go
@@ -324,31 +324,64 @@ func (s *ArtistService) SearchArtists(query string) ([]*contracts.ArtistDetailRe
 // ArtistWithCount is used internally for querying artists with their show counts
 type ArtistWithCount struct {
 	models.Artist
-	UpcomingShowCount int64 `gorm:"column:upcoming_show_count"`
+	UpcomingShowCount int64      `gorm:"column:upcoming_show_count"`
+	LastShowDate      *time.Time `gorm:"column:last_show_date"`
 }
 
 // contracts.ArtistWithShowCountResponse represents an artist with its upcoming show count
 
-// GetArtistsWithShowCounts retrieves artists that have upcoming approved shows,
-// with their show counts. Results are sorted by show count (descending), then name (ascending).
+// GetArtistsWithShowCounts retrieves artists with their upcoming show counts.
+//
+// By default the result is gated on "has at least one upcoming approved show"
+// (the /artists landing/browse flow). When `skip_active_filter` is set to true
+// in the filters map (PSY-495: tag-filter engaged → Bandcamp-style evergreen
+// discovery), the activity gate is dropped and every matching artist is
+// returned, including those with zero upcoming shows. In that mode we also
+// surface `last_show_date` (most recent past approved show) so cards can
+// render a "no upcoming shows · last show <Mon Year>" affordance instead of
+// looking broken.
+//
+// Sort order: upcoming_show_count DESC, name ASC. Active artists surface
+// first, then alphabetical. Preserved across both gated and evergreen modes.
 func (s *ArtistService) GetArtistsWithShowCounts(filters map[string]interface{}) ([]*contracts.ArtistWithShowCountResponse, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
 
+	skipActiveFilter, _ := filters["skip_active_filter"].(bool)
+
 	now := time.Now().UTC()
 
 	// Subquery: count upcoming approved shows per artist
-	subquery := s.db.Table("show_artists").
+	upcomingSubquery := s.db.Table("show_artists").
 		Select("show_artists.artist_id, COUNT(*) as show_count").
 		Joins("JOIN shows ON show_artists.show_id = shows.id").
 		Where("shows.event_date >= ? AND shows.status = ?", now, models.ShowStatusApproved).
 		Group("show_artists.artist_id")
 
-	// Main query: join artists with show counts, only include artists with upcoming shows
-	query := s.db.Table("artists").
-		Select("artists.*, COALESCE(sc.show_count, 0) as upcoming_show_count").
-		Joins("JOIN (?) as sc ON artists.id = sc.artist_id", subquery)
+	var query *gorm.DB
+	if skipActiveFilter {
+		// Evergreen mode: include artists without upcoming shows.
+		// LEFT JOIN on upcoming counts (zero when none), and compute
+		// last past-show date so cards can show "last show <Mon Year>".
+		pastSubquery := s.db.Table("show_artists").
+			Select("show_artists.artist_id, MAX(shows.event_date) as last_show_date").
+			Joins("JOIN shows ON show_artists.show_id = shows.id").
+			Where("shows.event_date < ? AND shows.status = ?", now, models.ShowStatusApproved).
+			Group("show_artists.artist_id")
+
+		query = s.db.Table("artists").
+			Select("artists.*, COALESCE(sc.show_count, 0) as upcoming_show_count, ps.last_show_date as last_show_date").
+			Joins("LEFT JOIN (?) as sc ON artists.id = sc.artist_id", upcomingSubquery).
+			Joins("LEFT JOIN (?) as ps ON artists.id = ps.artist_id", pastSubquery)
+	} else {
+		// Gated mode (default for unfiltered /artists): INNER JOIN so only
+		// artists with upcoming shows are returned. last_show_date is NULL
+		// in this path — the card renders an upcoming count anyway.
+		query = s.db.Table("artists").
+			Select("artists.*, COALESCE(sc.show_count, 0) as upcoming_show_count, NULL as last_show_date").
+			Joins("JOIN (?) as sc ON artists.id = sc.artist_id", upcomingSubquery)
+	}
 
 	// Apply filters
 	if cities, ok := filters["cities"].([]map[string]string); ok && len(cities) > 0 {
@@ -383,10 +416,15 @@ func (s *ArtistService) GetArtistsWithShowCounts(filters map[string]interface{})
 	// Build responses
 	responses := make([]*contracts.ArtistWithShowCountResponse, len(artistsWithCount))
 	for i, ac := range artistsWithCount {
-		responses[i] = &contracts.ArtistWithShowCountResponse{
+		resp := &contracts.ArtistWithShowCountResponse{
 			ArtistDetailResponse: *s.buildArtistResponse(&ac.Artist),
 			UpcomingShowCount:    int(ac.UpcomingShowCount),
 		}
+		if ac.LastShowDate != nil {
+			ts := ac.LastShowDate.UTC()
+			resp.LastShowDate = &ts
+		}
+		responses[i] = resp
 	}
 
 	return responses, nil

--- a/backend/internal/services/contracts/catalog.go
+++ b/backend/internal/services/contracts/catalog.go
@@ -478,9 +478,15 @@ type SocialResponse struct {
 }
 
 // ArtistWithShowCountResponse includes upcoming show count for an artist.
+//
+// LastShowDate is the most recent past approved show date for the artist.
+// Only populated when the service runs in evergreen mode (e.g. tag-filtered
+// /artists per PSY-495); stays nil on the default activity-gated path since
+// the caller already knows there is at least one upcoming show.
 type ArtistWithShowCountResponse struct {
 	ArtistDetailResponse
-	UpcomingShowCount int `json:"upcoming_show_count"`
+	UpcomingShowCount int        `json:"upcoming_show_count"`
+	LastShowDate      *time.Time `json:"last_show_date,omitempty"`
 }
 
 // ArtistCityResponse represents a city with artist count for filtering

--- a/frontend/features/artists/components/ArtistCard.test.tsx
+++ b/frontend/features/artists/components/ArtistCard.test.tsx
@@ -51,10 +51,40 @@ describe('ArtistCard', () => {
     expect(screen.getByText('5 upcoming')).toBeInTheDocument()
   })
 
-  it('renders zero upcoming shows', () => {
-    renderWithProviders(<ArtistCard artist={makeArtist({ upcoming_show_count: 0 })} />)
+  it('renders "No upcoming shows" hint when count is zero and no last-show date (PSY-495)', () => {
+    renderWithProviders(
+      <ArtistCard artist={makeArtist({ upcoming_show_count: 0 })} />
+    )
 
-    expect(screen.getByText('0 upcoming')).toBeInTheDocument()
+    expect(screen.getByText('No upcoming shows')).toBeInTheDocument()
+  })
+
+  it('renders "No upcoming shows · last show Mon YYYY" when last_show_date is known (PSY-495)', () => {
+    renderWithProviders(
+      <ArtistCard
+        artist={makeArtist({
+          upcoming_show_count: 0,
+          last_show_date: '2024-03-15T00:00:00Z',
+        })}
+      />
+    )
+
+    expect(
+      screen.getByText('No upcoming shows · last show Mar 2024')
+    ).toBeInTheDocument()
+  })
+
+  it('falls back to plain "No upcoming shows" when last_show_date is unparseable', () => {
+    renderWithProviders(
+      <ArtistCard
+        artist={makeArtist({
+          upcoming_show_count: 0,
+          last_show_date: 'not-a-date',
+        })}
+      />
+    )
+
+    expect(screen.getByText('No upcoming shows')).toBeInTheDocument()
   })
 
   it('renders location with city and state', () => {

--- a/frontend/features/artists/components/ArtistCard.tsx
+++ b/frontend/features/artists/components/ArtistCard.tsx
@@ -12,6 +12,34 @@ interface ArtistCardProps {
   density?: ArtistCardDensity
 }
 
+// Format an ISO timestamp as "Mon YYYY" for the "last show" hint
+// (e.g. "Mar 2024"). Returns null on unparseable input so the card can
+// gracefully fall back to just "No upcoming shows".
+function formatLastShowMonth(iso: string | null | undefined): string | null {
+  if (!iso) return null
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return null
+  return d.toLocaleString('en-US', { month: 'short', year: 'numeric' })
+}
+
+// Build the "upcoming shows" affordance string. When the artist has upcoming
+// shows, we show the count (current behavior). When the artist has none
+// (PSY-495 Bandcamp model — dormant artists surfaced via tag filter), we
+// show "No upcoming shows" and, if known, the last past-show month so the
+// visitor sees the artist is real, just inactive, not broken.
+function upcomingLabel(artist: ArtistListItem, short: boolean): string {
+  if (artist.upcoming_show_count > 0) {
+    return short
+      ? `${artist.upcoming_show_count} upcoming`
+      : `${artist.upcoming_show_count} upcoming shows`
+  }
+  const lastShow = formatLastShowMonth(artist.last_show_date)
+  if (lastShow) {
+    return `No upcoming shows · last show ${lastShow}`
+  }
+  return 'No upcoming shows'
+}
+
 export function ArtistCard({ artist, density = 'comfortable' }: ArtistCardProps) {
   const hasLocation = artist.city || artist.state
   const location = hasLocation ? getArtistLocation(artist) : null
@@ -29,7 +57,7 @@ export function ArtistCard({ artist, density = 'comfortable' }: ArtistCardProps)
           <span className="text-xs text-muted-foreground shrink-0">{location}</span>
         )}
         <span className="text-xs text-muted-foreground shrink-0 tabular-nums">
-          {artist.upcoming_show_count} upcoming
+          {upcomingLabel(artist, true)}
         </span>
       </article>
     )
@@ -52,7 +80,7 @@ export function ArtistCard({ artist, density = 'comfortable' }: ArtistCardProps)
           )}
           <span className="flex items-center gap-1.5">
             <Music className="h-3.5 w-3.5 shrink-0" />
-            {artist.upcoming_show_count} upcoming shows
+            {upcomingLabel(artist, false)}
           </span>
         </div>
       </article>
@@ -71,7 +99,7 @@ export function ArtistCard({ artist, density = 'comfortable' }: ArtistCardProps)
       <div className="mt-2 space-y-1">
         <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
           <Music className="h-3.5 w-3.5 shrink-0" />
-          <span>{artist.upcoming_show_count} upcoming</span>
+          <span>{upcomingLabel(artist, true)}</span>
         </div>
 
         {hasLocation && (

--- a/frontend/features/artists/types.ts
+++ b/frontend/features/artists/types.ts
@@ -56,6 +56,14 @@ export interface ArtistCitiesResponse {
 
 export interface ArtistListItem extends Artist {
   upcoming_show_count: number
+  /**
+   * Most recent past approved show date (ISO string). Only populated when the
+   * backend is running in evergreen mode — i.e. when the list was requested
+   * with a tag filter (PSY-495 Bandcamp model). Undefined on the default
+   * activity-gated /artists landing because those artists always have at
+   * least one upcoming show.
+   */
+  last_show_date?: string | null
 }
 
 export interface ArtistsListResponse {


### PR DESCRIPTION
## Summary

- `/artists?tags=X` now drops the default "has upcoming shows" gate and returns every artist tagged `X`, matching the facet-chip count (Bandcamp / RYM / Discogs model). `/artists` with no tag filter keeps current behavior (active artists only).
- Evergreen mode also populates `last_show_date` on the response so the artist card can render a "No upcoming shows · last show Mar 2024" affordance instead of looking broken.
- Sort order in both modes: `upcoming_show_count DESC, name ASC` — active artists first, then alphabetical. Documented inline in `GetArtistsWithShowCounts`.

## Files touched

| Area | Change |
|------|--------|
| `backend/internal/services/catalog/artist.go` | Conditional INNER vs LEFT JOIN on the upcoming-show subquery in `GetArtistsWithShowCounts`; adds `last_show_date` computation (MAX past approved event_date) in evergreen mode. |
| `backend/internal/api/handlers/artist.go` | Sets `filters["skip_active_filter"] = true` when `tags` is present on `ListArtistsHandler`. |
| `backend/internal/services/contracts/catalog.go` | Adds `LastShowDate *time.Time` to `ArtistWithShowCountResponse`, omitempty (null when gated). |
| `backend/internal/api/handlers/artist_integration_test.go` | Two new suite tests (details below). |
| `frontend/features/artists/types.ts` | Adds optional `last_show_date?: string \| null` on `ArtistListItem`. |
| `frontend/features/artists/components/ArtistCard.tsx` | `upcomingLabel` helper: shows "N upcoming" when active, "No upcoming shows" when dormant, and "No upcoming shows · last show Mon YYYY" when `last_show_date` is known. Applies to all three densities (compact / comfortable / expanded). |
| `frontend/features/artists/components/ArtistCard.test.tsx` | Updates the zero-count expectation (was "0 upcoming") and adds coverage for the last-show affordance + unparseable-date fallback. |

### Other browse endpoints (audited, no change needed)

- `/labels` — `ListLabels` in `label.go` already filters only on optional `status`/`city`/`state`; **no activity gate**, no change needed. Evergreen by construction.
- `/releases` — `ListReleases` in `release.go` filters only on optional search/type/year/label/tags; **no activity gate**, no change needed. Evergreen by construction.
- `/festivals` — `ListFestivals` in `festival.go` filters only on optional city/state/year/status/series_slug/tags and orders by `start_date DESC, name ASC`; **no activity gate**, no change needed.

So the PSY-495 fix is scoped entirely to the artist path. Nothing in `/festivals` matches this pattern — no follow-up coordination with PSY-499 (shows/festivals tag-filter work) is needed from this ticket. Kept hands off `show_service.go` and `festival_service.go` per the brief.

## Sort-order rationale

Stuck with `upcoming_show_count DESC, name ASC` (the existing sort) in both modes. In gated mode every row has count > 0 so it degrades to "most active first, then alphabetical". In evergreen mode the active rows still surface first (good — fans filtering by "punk" still see active punk artists first), followed by dormant rows in alphabetical order (stable, easy to scan). This matches the Bandcamp feel where the top of a tag page is clearly the "still happening" stuff.

## Test plan

### Backend (added)

- `TestArtistHandlerIntegration/TestListArtists_TagFilter_DropsActivityGate` — seeds 3 artists tagged `punk` (1 with upcoming show, 2 without) and 1 rock band with an upcoming show. Asserts:
  - unfiltered `/artists` returns only the 2 artists with upcoming shows (gated default)
  - `/artists?tags=punk` returns all 3 punk artists (evergreen mode)
  - sort order is `upcoming_show_count DESC, name ASC`
- `TestArtistHandlerIntegration/TestListArtists_TagFilter_SurfacesLastShowDate` — dormant artist with a past show 400 days ago, tagged `shoegaze`. Asserts `/artists?tags=shoegaze` returns it with populated `last_show_date`.

Also ran:
- `go test ./internal/api/handlers/ -run TestArtistHandlerIntegration` — full artist handler suite green (no regressions).
- `go test ./internal/services/catalog/ -run TestTagFilterIntegration` — existing tag-filter integration suite green (confirms gated default preserved when no `skip_active_filter`).
- `go test ./internal/... -short` — full short suite green.
- `bun run test:run -- features/artists/` — 143 artist feature tests green.
- `bun run typecheck` — clean.

### Manual (for reviewers to verify facet-chip parity)

```bash
# Seed prod-like data with tagged inactive artists, then:

# Gated default (current behavior — only active)
curl 'http://localhost:8080/artists' | jq '.count'
# → Same number as today (no behavior change)

# Evergreen mode (PSY-495 fix)
curl 'http://localhost:8080/artists?tags=punk' | jq '.count'
# → Should equal the tag facet chip count on /artists (16 per the repro)

# Chip parity check — compare the two:
curl -s 'http://localhost:8080/tags/facets?entity_type=artist' | jq '.facets[] | select(.slug=="punk") | .count'
curl -s 'http://localhost:8080/artists?tags=punk' | jq '.count'
# → Same number
```

Closes PSY-495