### PR TITLE
PSY-499: Transitive show↔artist tag filter on /shows and /festivals

### DIFF
--- a/backend/internal/services/catalog/festival.go
+++ b/backend/internal/services/catalog/festival.go
@@ -134,7 +134,16 @@ func (s *FestivalService) ListFestivals(filters map[string]interface{}) ([]*cont
 		query = query.Where("series_slug = ?", seriesSlug)
 	}
 	if tf, ok := filters["tag_filter"].(TagFilter); ok {
-		query = ApplyTagFilter(query, s.db, models.TagEntityFestival, "festivals.id", tf)
+		// PSY-499: Festivals are not directly tagged with genre/locale tags —
+		// they inherit meaning from the lineup artists. Filter festivals whose
+		// lineup includes artists matching the tag filter. This is scoped to
+		// tag-filter query building only; the default activity-gate filter
+		// (PSY-495) is untouched.
+		query = ApplyTransitiveArtistTagFilter(
+			query, s.db,
+			"festival_artists", "festival_id", "artist_id",
+			"festivals.id", tf,
+		)
 	}
 
 	// Order by start_date DESC, name ASC

--- a/backend/internal/services/catalog/show.go
+++ b/backend/internal/services/catalog/show.go
@@ -309,7 +309,14 @@ func (s *ShowService) GetShows(filters map[string]interface{}) ([]*contracts.Sho
 		query = query.Where("event_date <= ?", toDate.UTC())
 	}
 	if tf, ok := filters["tag_filter"].(TagFilter); ok {
-		query = ApplyTagFilter(query, s.db, models.TagEntityShow, "shows.id", tf)
+		// PSY-499: Shows are not directly tagged with genre/locale tags — they
+		// inherit meaning from the billed artists. Filter shows whose lineup
+		// includes artists matching the tag filter.
+		query = ApplyTransitiveArtistTagFilter(
+			query, s.db,
+			"show_artists", "show_id", "artist_id",
+			"shows.id", tf,
+		)
 	}
 
 	// Default ordering by event date
@@ -711,10 +718,18 @@ func (s *ShowService) GetUpcomingShows(timezone string, cursor string, limit int
 			}
 		}
 		if len(filters.TagSlugs) > 0 {
-			query = ApplyTagFilter(query, s.db, models.TagEntityShow, "shows.id", TagFilter{
-				TagSlugs: filters.TagSlugs,
-				MatchAny: filters.TagMatchAny,
-			})
+			// PSY-499: Transitive artist-based tag filtering — shows match when
+			// any billed artist has the tag. Direct `entity_type='show'` tags
+			// are ignored because shows are not directly tagged with genres.
+			query = ApplyTransitiveArtistTagFilter(
+				query, s.db,
+				"show_artists", "show_id", "artist_id",
+				"shows.id",
+				TagFilter{
+					TagSlugs: filters.TagSlugs,
+					MatchAny: filters.TagMatchAny,
+				},
+			)
 		}
 	}
 

--- a/backend/internal/services/catalog/tag_filter.go
+++ b/backend/internal/services/catalog/tag_filter.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 
 	"gorm.io/gorm"
+
+	"psychic-homily-backend/internal/models"
 )
 
 // TagFilter captures the tag-filter inputs for browse-list queries
@@ -72,4 +74,92 @@ func ApplyTagFilter(query *gorm.DB, db *gorm.DB, entityType, idColumn string, fi
 		sub = sub.Having("COUNT(DISTINCT entity_tags.tag_id) = ?", len(filter.TagSlugs))
 	}
 	return query.Where(idColumn+" IN (?)", sub)
+}
+
+// ApplyTransitiveArtistTagFilter narrows a GORM query so that rows from a
+// container entity (show or festival) are constrained to those whose lineup
+// includes artists matching the tag filter (PSY-499).
+//
+// Shows and festivals are not directly tagged with genre/locale tags — they
+// inherit meaning from the artists on their bill. This function encodes that
+// semantic: "a show matches `shoegaze` when any billed artist has the
+// `shoegaze` tag". It resolves tag slugs via `tags`, joins through the
+// lineup junction table (e.g. `show_artists`) and `entity_tags` scoped to
+// `entity_type='artist'`, and constrains the outer query to the resulting
+// distinct container IDs.
+//
+// For multi-tag AND semantics the filter requires the collective lineup to
+// cover all N tags (any combination across artists) — this is more useful
+// for discovery than requiring a single artist to carry every tag. For OR
+// semantics, any lineup artist having any of the tags is sufficient.
+//
+// `junctionTable` is the lineup junction (e.g. "show_artists",
+// "festival_artists"), `containerIDColumn` is its container FK column (e.g.
+// "show_id", "festival_id"), `artistIDColumn` is its artist FK column
+// (always "artist_id" for both junctions), and `idColumn` is the outer
+// query's qualified ID (e.g. "shows.id", "festivals.id").
+//
+// Returns the (possibly unchanged) query.
+func ApplyTransitiveArtistTagFilter(
+	query *gorm.DB,
+	db *gorm.DB,
+	junctionTable, containerIDColumn, artistIDColumn, idColumn string,
+	filter TagFilter,
+) *gorm.DB {
+	if !filter.HasTags() {
+		return query
+	}
+	sub := db.Table(junctionTable).
+		Select(junctionTable+"."+containerIDColumn).
+		Joins("JOIN entity_tags ON entity_tags.entity_type = ? AND entity_tags.entity_id = "+junctionTable+"."+artistIDColumn, models.TagEntityArtist).
+		Joins("JOIN tags ON tags.id = entity_tags.tag_id").
+		Where("LOWER(tags.slug) IN ?", filter.TagSlugs).
+		Group(junctionTable + "." + containerIDColumn)
+	if !filter.MatchAny {
+		sub = sub.Having("COUNT(DISTINCT tags.id) = ?", len(filter.TagSlugs))
+	}
+	return query.Where(idColumn+" IN (?)", sub)
+}
+
+// CountTransitiveArtistTagUsage returns a map of tag_id → count of distinct
+// container entities (shows or festivals) whose lineup includes an artist
+// tagged with that tag (PSY-499).
+//
+// Used by the `/tags?entity_type=show` and `/tags?entity_type=festival`
+// facet to surface transitive counts — "shoegaze: 3 shows" when 3 distinct
+// shows have at least one billed artist tagged `shoegaze`, even though no
+// show is directly tagged `shoegaze`.
+//
+// `tagIDs` are the tag IDs to compute counts for (empty → empty map).
+// `junctionTable` is the lineup junction (e.g. "show_artists").
+// `containerIDColumn` is its container FK (e.g. "show_id"). `artistIDColumn`
+// is the artist FK (always "artist_id"). Tags with zero matches are absent
+// from the returned map (callers should treat missing keys as zero).
+func CountTransitiveArtistTagUsage(
+	db *gorm.DB,
+	junctionTable, containerIDColumn, artistIDColumn string,
+	tagIDs []uint,
+) (map[uint]int64, error) {
+	out := make(map[uint]int64)
+	if len(tagIDs) == 0 {
+		return out, nil
+	}
+	type row struct {
+		TagID uint
+		Count int64
+	}
+	var rows []row
+	err := db.Table(junctionTable).
+		Select("entity_tags.tag_id AS tag_id, COUNT(DISTINCT "+junctionTable+"."+containerIDColumn+") AS count").
+		Joins("JOIN entity_tags ON entity_tags.entity_type = ? AND entity_tags.entity_id = "+junctionTable+"."+artistIDColumn, models.TagEntityArtist).
+		Where("entity_tags.tag_id IN ?", tagIDs).
+		Group("entity_tags.tag_id").
+		Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	for _, r := range rows {
+		out[r.TagID] = r.Count
+	}
+	return out, nil
 }

--- a/backend/internal/services/catalog/tag_filter_integration_test.go
+++ b/backend/internal/services/catalog/tag_filter_integration_test.go
@@ -221,6 +221,12 @@ func (s *TagFilterIntegrationTestSuite) TestArtists_UnknownTagReturnsEmpty() {
 
 // ──────────────────────────────────────────────
 // Show tests (GetShows / GetUpcomingShows)
+//
+// PSY-499: Shows are filtered transitively via billed artist tags — direct
+// `entity_type='show'` tags are no longer honored by the filter because
+// nobody manually tags shows with genres. Each test seeds an artist (tagged
+// on the `artist` entity type) and a show that includes that artist on the
+// bill via `show_artists`, then asserts the filter finds the show.
 // ──────────────────────────────────────────────
 
 func (s *TagFilterIntegrationTestSuite) seedShow(title string, eventDate time.Time) uint {
@@ -234,12 +240,37 @@ func (s *TagFilterIntegrationTestSuite) seedShow(title string, eventDate time.Ti
 	return show.ID
 }
 
-func (s *TagFilterIntegrationTestSuite) TestShows_GetShows_AND() {
+// seedArtist creates an artist with a unique slug. Used to build a show
+// lineup whose tags drive the transitive filter.
+func (s *TagFilterIntegrationTestSuite) seedArtist(name string) uint {
+	slug := fmt.Sprintf("%s-%d", name, time.Now().UnixNano())
+	a := &models.Artist{Name: name, Slug: &slug}
+	s.Require().NoError(s.db.Create(a).Error)
+	return a.ID
+}
+
+// addArtistToShow attaches an artist to a show's lineup with the given bill
+// position (0 = headliner).
+func (s *TagFilterIntegrationTestSuite) addArtistToShow(showID, artistID uint, position int) {
+	s.Require().NoError(s.db.Create(&models.ShowArtist{
+		ShowID: showID, ArtistID: artistID, Position: position,
+	}).Error)
+}
+
+func (s *TagFilterIntegrationTestSuite) TestShows_GetShows_AND_Transitive() {
+	// Show A: lineup collectively covers both tags (post-punk + phoenix)
+	// Show B: lineup only covers post-punk
 	sA := s.seedShow("A", time.Now().Add(24*time.Hour).UTC())
 	sB := s.seedShow("B", time.Now().Add(24*time.Hour).UTC())
-	s.tag("show", sA, "post-punk")
-	s.tag("show", sA, "phoenix")
-	s.tag("show", sB, "post-punk")
+	aPP := s.seedArtist("ArtistPP")
+	aPhx := s.seedArtist("ArtistPhx")
+	aPPOnly := s.seedArtist("ArtistPPOnly")
+	s.addArtistToShow(sA, aPP, 0)
+	s.addArtistToShow(sA, aPhx, 1)
+	s.addArtistToShow(sB, aPPOnly, 0)
+	s.tag("artist", aPP, "post-punk")
+	s.tag("artist", aPhx, "phoenix")
+	s.tag("artist", aPPOnly, "post-punk")
 
 	resp, err := s.showService.GetShows(map[string]interface{}{
 		"tag_filter": TagFilter{TagSlugs: []string{"post-punk", "phoenix"}},
@@ -249,12 +280,20 @@ func (s *TagFilterIntegrationTestSuite) TestShows_GetShows_AND() {
 	s.Equal("A", resp[0].Title)
 }
 
-func (s *TagFilterIntegrationTestSuite) TestShows_GetUpcomingShows_AND() {
+func (s *TagFilterIntegrationTestSuite) TestShows_GetUpcomingShows_AND_Transitive() {
+	// Show Upcoming-A: lineup covers both post-punk + shoegaze
+	// Show Upcoming-B: lineup only covers post-punk
 	sA := s.seedShow("Upcoming-A", time.Now().Add(2*24*time.Hour).UTC())
 	sB := s.seedShow("Upcoming-B", time.Now().Add(2*24*time.Hour).UTC())
-	s.tag("show", sA, "post-punk")
-	s.tag("show", sA, "shoegaze")
-	s.tag("show", sB, "post-punk")
+	aPP := s.seedArtist("UPP")
+	aSG := s.seedArtist("USG")
+	aPPOnly := s.seedArtist("UPPOnly")
+	s.addArtistToShow(sA, aPP, 0)
+	s.addArtistToShow(sA, aSG, 1)
+	s.addArtistToShow(sB, aPPOnly, 0)
+	s.tag("artist", aPP, "post-punk")
+	s.tag("artist", aSG, "shoegaze")
+	s.tag("artist", aPPOnly, "post-punk")
 
 	resp, _, err := s.showService.GetUpcomingShows("UTC", "", 50, false, &contracts.UpcomingShowsFilter{
 		TagSlugs: []string{"post-punk", "shoegaze"},
@@ -264,13 +303,19 @@ func (s *TagFilterIntegrationTestSuite) TestShows_GetUpcomingShows_AND() {
 	s.Equal("Upcoming-A", resp[0].Title)
 }
 
-func (s *TagFilterIntegrationTestSuite) TestShows_GetUpcomingShows_OR() {
+func (s *TagFilterIntegrationTestSuite) TestShows_GetUpcomingShows_OR_Transitive() {
+	// Shows A + B both have one matching artist each; C has none.
 	sA := s.seedShow("OR-A", time.Now().Add(2*24*time.Hour).UTC())
 	sB := s.seedShow("OR-B", time.Now().Add(2*24*time.Hour).UTC())
 	sC := s.seedShow("OR-C", time.Now().Add(2*24*time.Hour).UTC())
-	s.tag("show", sA, "post-punk")
-	s.tag("show", sB, "shoegaze")
-	_ = sC
+	aPP := s.seedArtist("ORPP")
+	aSG := s.seedArtist("ORSG")
+	aNone := s.seedArtist("ORNone")
+	s.addArtistToShow(sA, aPP, 0)
+	s.addArtistToShow(sB, aSG, 0)
+	s.addArtistToShow(sC, aNone, 0)
+	s.tag("artist", aPP, "post-punk")
+	s.tag("artist", aSG, "shoegaze")
 
 	resp, _, err := s.showService.GetUpcomingShows("UTC", "", 50, false, &contracts.UpcomingShowsFilter{
 		TagSlugs:    []string{"post-punk", "shoegaze"},
@@ -278,6 +323,83 @@ func (s *TagFilterIntegrationTestSuite) TestShows_GetUpcomingShows_OR() {
 	})
 	s.Require().NoError(err)
 	s.Require().Len(resp, 2)
+}
+
+// TestShows_SingleTag_Transitive is the canonical PSY-499 scenario: a single
+// genre tag on an artist surfaces every show that artist is billed on, even
+// when the show itself has no direct `entity_type='show'` tag. This mirrors
+// the dogfood repro: `/shows?tags=shoegaze` should return the 3 Faetooth
+// shows when Faetooth (an artist) is tagged `shoegaze`.
+func (s *TagFilterIntegrationTestSuite) TestShows_SingleTag_Transitive() {
+	sA := s.seedShow("Shoegaze-A", time.Now().Add(2*24*time.Hour).UTC())
+	sB := s.seedShow("Shoegaze-B", time.Now().Add(3*24*time.Hour).UTC())
+	sC := s.seedShow("Shoegaze-C", time.Now().Add(4*24*time.Hour).UTC())
+	sX := s.seedShow("Other-X", time.Now().Add(2*24*time.Hour).UTC())
+	faetooth := s.seedArtist("Faetooth")
+	other := s.seedArtist("Other")
+	s.addArtistToShow(sA, faetooth, 0)
+	s.addArtistToShow(sB, faetooth, 0)
+	s.addArtistToShow(sC, faetooth, 0)
+	s.addArtistToShow(sX, other, 0)
+	s.tag("artist", faetooth, "shoegaze")
+	// Intentionally do NOT tag show X directly with anything; filter should
+	// still exclude it because the transitive filter ignores show-level tags.
+
+	resp, _, err := s.showService.GetUpcomingShows("UTC", "", 50, false, &contracts.UpcomingShowsFilter{
+		TagSlugs: []string{"shoegaze"},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(resp, 3)
+	titles := map[string]bool{}
+	for _, r := range resp {
+		titles[r.Title] = true
+	}
+	s.True(titles["Shoegaze-A"])
+	s.True(titles["Shoegaze-B"])
+	s.True(titles["Shoegaze-C"])
+}
+
+// TestShows_DirectTagNotSufficient verifies the semantics flip: directly
+// tagging a show with `entity_type='show'` is intentionally a no-op for the
+// filter (PSY-499). Direct show-level tags coexist harmlessly but don't
+// drive discovery — only lineup artist tags do.
+func (s *TagFilterIntegrationTestSuite) TestShows_DirectTagNotSufficient() {
+	sA := s.seedShow("Direct-Only", time.Now().Add(2*24*time.Hour).UTC())
+	// Tag the show directly but give it no tagged artists on the lineup.
+	aUntagged := s.seedArtist("Untagged")
+	s.addArtistToShow(sA, aUntagged, 0)
+	s.tag("show", sA, "shoegaze")
+
+	resp, _, err := s.showService.GetUpcomingShows("UTC", "", 50, false, &contracts.UpcomingShowsFilter{
+		TagSlugs: []string{"shoegaze"},
+	})
+	s.Require().NoError(err)
+	s.Len(resp, 0)
+}
+
+// TestShows_DistinctShowIDs verifies the DISTINCT dedup when a show has
+// multiple matching lineup artists. Without DISTINCT the subquery would
+// return duplicates, but the outer `IN (?)` clause ignores them — this test
+// still asserts a single response row to catch any future refactor that
+// accidentally joins duplicates back in via e.g. a LEFT JOIN.
+func (s *TagFilterIntegrationTestSuite) TestShows_DistinctShowIDs() {
+	sA := s.seedShow("Multi-Shoegaze", time.Now().Add(2*24*time.Hour).UTC())
+	a1 := s.seedArtist("SG1")
+	a2 := s.seedArtist("SG2")
+	a3 := s.seedArtist("SG3")
+	s.addArtistToShow(sA, a1, 0)
+	s.addArtistToShow(sA, a2, 1)
+	s.addArtistToShow(sA, a3, 2)
+	s.tag("artist", a1, "shoegaze")
+	s.tag("artist", a2, "shoegaze")
+	s.tag("artist", a3, "shoegaze")
+
+	resp, _, err := s.showService.GetUpcomingShows("UTC", "", 50, false, &contracts.UpcomingShowsFilter{
+		TagSlugs: []string{"shoegaze"},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(resp, 1)
+	s.Equal("Multi-Shoegaze", resp[0].Title)
 }
 
 // ──────────────────────────────────────────────
@@ -427,12 +549,27 @@ func (s *TagFilterIntegrationTestSuite) seedFestival(name string) uint {
 	return f.ID
 }
 
-func (s *TagFilterIntegrationTestSuite) TestFestivals_AND() {
+// addArtistToFestival attaches an artist to a festival's lineup.
+func (s *TagFilterIntegrationTestSuite) addArtistToFestival(festivalID, artistID uint) {
+	s.Require().NoError(s.db.Create(&models.FestivalArtist{
+		FestivalID: festivalID, ArtistID: artistID,
+	}).Error)
+}
+
+// PSY-499: Festivals filter transitively through `festival_artists`, mirroring
+// the show↔artist pattern.
+func (s *TagFilterIntegrationTestSuite) TestFestivals_AND_Transitive() {
 	f1 := s.seedFestival("Fest1")
 	f2 := s.seedFestival("Fest2")
-	s.tag("festival", f1, "electronic")
-	s.tag("festival", f1, "phoenix")
-	s.tag("festival", f2, "electronic")
+	aElec := s.seedArtist("FElec")
+	aPhx := s.seedArtist("FPhx")
+	aElecOnly := s.seedArtist("FElecOnly")
+	s.addArtistToFestival(f1, aElec)
+	s.addArtistToFestival(f1, aPhx)
+	s.addArtistToFestival(f2, aElecOnly)
+	s.tag("artist", aElec, "electronic")
+	s.tag("artist", aPhx, "phoenix")
+	s.tag("artist", aElecOnly, "electronic")
 
 	out, err := s.festivalService.ListFestivals(map[string]interface{}{
 		"tag_filter": TagFilter{TagSlugs: []string{"electronic", "phoenix"}},
@@ -442,17 +579,160 @@ func (s *TagFilterIntegrationTestSuite) TestFestivals_AND() {
 	s.Equal("Fest1", out[0].Name)
 }
 
-func (s *TagFilterIntegrationTestSuite) TestFestivals_OR() {
+func (s *TagFilterIntegrationTestSuite) TestFestivals_OR_Transitive() {
 	f1 := s.seedFestival("Fest1")
 	f2 := s.seedFestival("Fest2")
 	f3 := s.seedFestival("Fest3")
-	s.tag("festival", f1, "electronic")
-	s.tag("festival", f2, "shoegaze")
-	_ = f3
+	aElec := s.seedArtist("OElec")
+	aSG := s.seedArtist("OSG")
+	aNone := s.seedArtist("ONone")
+	s.addArtistToFestival(f1, aElec)
+	s.addArtistToFestival(f2, aSG)
+	s.addArtistToFestival(f3, aNone)
+	s.tag("artist", aElec, "electronic")
+	s.tag("artist", aSG, "shoegaze")
 
 	out, err := s.festivalService.ListFestivals(map[string]interface{}{
 		"tag_filter": TagFilter{TagSlugs: []string{"electronic", "shoegaze"}, MatchAny: true},
 	})
 	s.Require().NoError(err)
 	s.Len(out, 2)
+}
+
+// TestFestivals_SingleTag_Transitive is the canonical PSY-499 scenario for
+// festivals: an artist tagged `shoegaze` surfaces every festival that artist
+// is on the lineup of, even when no festival is directly tagged.
+func (s *TagFilterIntegrationTestSuite) TestFestivals_SingleTag_Transitive() {
+	f1 := s.seedFestival("SG-Fest1")
+	f2 := s.seedFestival("SG-Fest2")
+	f3 := s.seedFestival("Other-Fest")
+	headliner := s.seedArtist("SGHeadliner")
+	other := s.seedArtist("Unrelated")
+	s.addArtistToFestival(f1, headliner)
+	s.addArtistToFestival(f2, headliner)
+	s.addArtistToFestival(f3, other)
+	s.tag("artist", headliner, "shoegaze")
+
+	out, err := s.festivalService.ListFestivals(map[string]interface{}{
+		"tag_filter": TagFilter{TagSlugs: []string{"shoegaze"}},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(out, 2)
+}
+
+// ──────────────────────────────────────────────
+// Tag facet count (PSY-499): `/tags?entity_type=show|festival` counts must
+// reflect transitive usage — "3 shows have a shoegaze-tagged artist" — not
+// the direct-tag count which is always zero at our data volumes.
+// ──────────────────────────────────────────────
+
+// TestListTags_ShowEntityType_Transitive verifies that when the tags
+// endpoint is scoped to `entity_type=show`, each tag's usage_count reflects
+// the number of distinct shows whose lineup includes an artist with that
+// tag. Shows with a direct `entity_type='show'` tag row do not contribute.
+func (s *TagFilterIntegrationTestSuite) TestListTags_ShowEntityType_Transitive() {
+	// 2 shoegaze shows (same artist, 2 shows), 1 post-punk show,
+	// 1 "other" show that only has a direct show-level tag (must NOT count).
+	sA := s.seedShow("SG-A", time.Now().Add(24*time.Hour).UTC())
+	sB := s.seedShow("SG-B", time.Now().Add(48*time.Hour).UTC())
+	sC := s.seedShow("PP-C", time.Now().Add(72*time.Hour).UTC())
+	sD := s.seedShow("Direct-Only", time.Now().Add(96*time.Hour).UTC())
+
+	sgArtist := s.seedArtist("SGArtist")
+	ppArtist := s.seedArtist("PPArtist")
+	untagged := s.seedArtist("Untagged")
+	s.addArtistToShow(sA, sgArtist, 0)
+	s.addArtistToShow(sB, sgArtist, 0)
+	s.addArtistToShow(sC, ppArtist, 0)
+	s.addArtistToShow(sD, untagged, 0)
+
+	s.tag("artist", sgArtist, "shoegaze")
+	s.tag("artist", ppArtist, "post-punk")
+	// Direct show-level tag: legacy/possible admin action. Must be ignored.
+	s.tag("show", sD, "shoegaze")
+
+	tags, _, err := s.tagService.ListTags("", "", nil, "name", 50, 0, models.TagEntityShow)
+	s.Require().NoError(err)
+	counts := map[string]int{}
+	for _, t := range tags {
+		counts[t.Slug] = t.UsageCount
+	}
+	s.Equal(2, counts["shoegaze"], "shoegaze shows count (transitive via lineup)")
+	s.Equal(1, counts["post-punk"], "post-punk shows count (transitive via lineup)")
+	s.Equal(0, counts["phoenix"], "unused tag should be 0")
+	s.Equal(0, counts["electronic"], "unused tag should be 0")
+}
+
+// TestListTags_ShowEntityType_MultipleArtistsSameShow verifies that a show
+// with multiple artists sharing the same tag still counts once for that
+// tag — DISTINCT dedup is preserved in the facet count.
+func (s *TagFilterIntegrationTestSuite) TestListTags_ShowEntityType_MultipleArtistsSameShow() {
+	sA := s.seedShow("Multi", time.Now().Add(24*time.Hour).UTC())
+	a1 := s.seedArtist("a1")
+	a2 := s.seedArtist("a2")
+	a3 := s.seedArtist("a3")
+	s.addArtistToShow(sA, a1, 0)
+	s.addArtistToShow(sA, a2, 1)
+	s.addArtistToShow(sA, a3, 2)
+	s.tag("artist", a1, "shoegaze")
+	s.tag("artist", a2, "shoegaze")
+	s.tag("artist", a3, "shoegaze")
+
+	tags, _, err := s.tagService.ListTags("", "", nil, "name", 50, 0, models.TagEntityShow)
+	s.Require().NoError(err)
+	var shoegazeCount int
+	for _, t := range tags {
+		if t.Slug == "shoegaze" {
+			shoegazeCount = t.UsageCount
+		}
+	}
+	s.Equal(1, shoegazeCount, "show with 3 shoegaze artists should count once")
+}
+
+// TestListTags_FestivalEntityType_Transitive mirrors the show test for
+// festivals: `/tags?entity_type=festival` facet counts reflect lineup-based
+// transitive usage.
+func (s *TagFilterIntegrationTestSuite) TestListTags_FestivalEntityType_Transitive() {
+	f1 := s.seedFestival("FacetFest1")
+	f2 := s.seedFestival("FacetFest2")
+	f3 := s.seedFestival("DirectOnlyFest")
+	elecArtist := s.seedArtist("ElecArtist")
+	sgArtist := s.seedArtist("FSGArtist")
+	untagged := s.seedArtist("FUntagged")
+	s.addArtistToFestival(f1, elecArtist)
+	s.addArtistToFestival(f2, elecArtist)
+	s.addArtistToFestival(f3, untagged)
+	s.tag("artist", elecArtist, "electronic")
+	s.tag("artist", sgArtist, "shoegaze") // unattached — inflates nothing
+	// Direct festival tag, should NOT count.
+	s.tag("festival", f3, "electronic")
+
+	tags, _, err := s.tagService.ListTags("", "", nil, "name", 50, 0, models.TagEntityFestival)
+	s.Require().NoError(err)
+	counts := map[string]int{}
+	for _, t := range tags {
+		counts[t.Slug] = t.UsageCount
+	}
+	s.Equal(2, counts["electronic"], "electronic festivals (transitive via lineup)")
+	s.Equal(0, counts["shoegaze"], "shoegaze artist not on any festival lineup")
+}
+
+// TestListTags_ArtistEntityType_DirectCount verifies that non-show/festival
+// entity types still use the direct `entity_tags` count — only show/festival
+// are transitive.
+func (s *TagFilterIntegrationTestSuite) TestListTags_ArtistEntityType_DirectCount() {
+	a1 := s.seedArtist("A1")
+	a2 := s.seedArtist("A2")
+	s.tag("artist", a1, "post-punk")
+	s.tag("artist", a2, "post-punk")
+
+	tags, _, err := s.tagService.ListTags("", "", nil, "name", 50, 0, models.TagEntityArtist)
+	s.Require().NoError(err)
+	var ppCount int
+	for _, t := range tags {
+		if t.Slug == "post-punk" {
+			ppCount = t.UsageCount
+		}
+	}
+	s.Equal(2, ppCount, "artist count is direct, not transitive")
 }

--- a/backend/internal/services/catalog/tag_service.go
+++ b/backend/internal/services/catalog/tag_service.go
@@ -172,29 +172,13 @@ func (s *TagService) ListTags(category string, search string, parentID *uint, so
 	}
 
 	if entityType != "" && len(tags) > 0 {
-		// Single GROUP BY to fetch per-entity-type counts for the returned page.
-		// Cheap: one indexed scan over (entity_type, tag_id) for at most `limit`
-		// tag IDs. Tags absent from entity_tags for this type get 0.
 		ids := make([]uint, len(tags))
 		for i, t := range tags {
 			ids[i] = t.ID
 		}
-		type countRow struct {
-			TagID uint
-			Count int64
-		}
-		var rows []countRow
-		err := s.db.Table("entity_tags").
-			Select("tag_id, COUNT(*) AS count").
-			Where("entity_type = ? AND tag_id IN ?", entityType, ids).
-			Group("tag_id").
-			Scan(&rows).Error
+		countByID, err := s.computeEntityTypeTagCounts(entityType, ids)
 		if err != nil {
 			return nil, 0, fmt.Errorf("failed to compute per-entity-type tag counts: %w", err)
-		}
-		countByID := make(map[uint]int64, len(rows))
-		for _, r := range rows {
-			countByID[r.TagID] = r.Count
 		}
 		for i := range tags {
 			tags[i].UsageCount = int(countByID[tags[i].ID])
@@ -208,6 +192,46 @@ func (s *TagService) ListTags(category string, search string, parentID *uint, so
 	}
 
 	return tags, total, nil
+}
+
+// computeEntityTypeTagCounts returns a map of tag_id → usage count scoped to
+// the given entity type, for the provided tag IDs.
+//
+// For most entity types this is the direct count of `entity_tags` rows where
+// `entity_type = ? AND tag_id IN (?)`. For `show` and `festival` the count
+// is computed *transitively* through the lineup (PSY-499): a show matches a
+// tag when any billed artist has it, even though no show is directly tagged
+// with genre/locale tags. This keeps the facet count honest ("shoegaze: 3
+// shows" instead of the misleading "0" when 3 shows have shoegaze-tagged
+// artists on the bill).
+//
+// Tags absent from the relevant tables get 0 (missing from the returned map).
+func (s *TagService) computeEntityTypeTagCounts(entityType string, tagIDs []uint) (map[uint]int64, error) {
+	switch entityType {
+	case models.TagEntityShow:
+		return CountTransitiveArtistTagUsage(s.db, "show_artists", "show_id", "artist_id", tagIDs)
+	case models.TagEntityFestival:
+		return CountTransitiveArtistTagUsage(s.db, "festival_artists", "festival_id", "artist_id", tagIDs)
+	}
+	// Default: direct count against entity_tags for the given entity type.
+	type countRow struct {
+		TagID uint
+		Count int64
+	}
+	var rows []countRow
+	err := s.db.Table("entity_tags").
+		Select("tag_id, COUNT(*) AS count").
+		Where("entity_type = ? AND tag_id IN ?", entityType, tagIDs).
+		Group("tag_id").
+		Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[uint]int64, len(rows))
+	for _, r := range rows {
+		out[r.TagID] = r.Count
+	}
+	return out, nil
 }
 
 // sortTagsByUsageDesc sorts in place by UsageCount DESC, name ASC. Used after

--- a/frontend/features/tags/components/TagFacetPanel.test.tsx
+++ b/frontend/features/tags/components/TagFacetPanel.test.tsx
@@ -255,4 +255,79 @@ describe('TagFacetPanel', () => {
     expect(shoegaze).toBeInTheDocument()
     expect(shoegaze).toHaveAttribute('aria-pressed', 'true')
   })
+
+  // PSY-499: transitive filter info tooltip. Only rendered for show/festival
+  // because those are the container entity types whose genre meaning comes
+  // from their lineup artists — direct-tag pages (artist, venue, label,
+  // release) don't need the explainer.
+  it('renders the transitive-filter info tooltip trigger for show entityType', () => {
+    renderWithProviders(
+      <TagFacetPanel
+        selectedSlugs={[]}
+        onToggle={() => {}}
+        onClear={() => {}}
+        entityType="show"
+      />
+    )
+    const info = screen.getByTestId('tag-facet-transitive-info')
+    expect(info).toBeInTheDocument()
+    expect(info).toHaveAttribute('aria-label', 'How tag filtering works')
+  })
+
+  it('renders the transitive-filter info tooltip trigger for festival entityType', () => {
+    renderWithProviders(
+      <TagFacetPanel
+        selectedSlugs={[]}
+        onToggle={() => {}}
+        onClear={() => {}}
+        entityType="festival"
+      />
+    )
+    expect(screen.getByTestId('tag-facet-transitive-info')).toBeInTheDocument()
+  })
+
+  it('omits the transitive tooltip on direct-tag entity types', () => {
+    renderWithProviders(
+      <TagFacetPanel
+        selectedSlugs={[]}
+        onToggle={() => {}}
+        onClear={() => {}}
+        entityType="artist"
+      />
+    )
+    expect(
+      screen.queryByTestId('tag-facet-transitive-info')
+    ).not.toBeInTheDocument()
+  })
+
+  it('omits the transitive tooltip when no entityType is provided', () => {
+    renderWithProviders(
+      <TagFacetPanel
+        selectedSlugs={[]}
+        onToggle={() => {}}
+        onClear={() => {}}
+      />
+    )
+    expect(
+      screen.queryByTestId('tag-facet-transitive-info')
+    ).not.toBeInTheDocument()
+  })
+
+  it('omits the transitive tooltip when the heading is hidden (sheet mode)', () => {
+    renderWithProviders(
+      <TagFacetPanel
+        selectedSlugs={[]}
+        onToggle={() => {}}
+        onClear={() => {}}
+        entityType="show"
+        hideHeading
+      />
+    )
+    // Sheet mode lifts the heading to a SheetTitle; the tooltip lives with
+    // the heading so it goes away too. (The sheet's own title handles mobile
+    // discovery if a mobile tooltip is added later.)
+    expect(
+      screen.queryByTestId('tag-facet-transitive-info')
+    ).not.toBeInTheDocument()
+  })
 })

--- a/frontend/features/tags/components/TagFacetPanel.tsx
+++ b/frontend/features/tags/components/TagFacetPanel.tsx
@@ -1,11 +1,17 @@
 'use client'
 
 import { useMemo, useState } from 'react'
-import { X, Tag as TagIcon } from 'lucide-react'
+import { X, Tag as TagIcon, Info } from 'lucide-react'
 
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import { useTags } from '../hooks'
 import {
   TAG_CATEGORIES,
@@ -13,6 +19,16 @@ import {
   getCategoryLabel,
 } from '../types'
 import type { TagCategory, TagEntityType, TagListItem } from '../types'
+
+// Copy for the info tooltip next to the facet heading, keyed by entity type.
+// `show` and `festival` surface transitive semantics (PSY-499): filtering by
+// genre matches the container entity whose lineup includes a tagged artist.
+// Other entity types use direct-tag semantics so they don't get a tooltip.
+const TRANSITIVE_TOOLTIP_COPY: Partial<Record<TagEntityType, string>> = {
+  show: 'Filtering by genre matches shows whose artists have that tag.',
+  festival:
+    'Filtering by genre matches festivals whose lineup artists have that tag.',
+}
 
 const DEFAULT_TAGS_PER_CATEGORY = 20
 
@@ -86,6 +102,11 @@ export function TagFacetPanel({
           <h2 className="flex items-center gap-1.5 text-sm font-semibold text-foreground">
             <TagIcon className="h-3.5 w-3.5" aria-hidden />
             {heading}
+            {entityType && TRANSITIVE_TOOLTIP_COPY[entityType] && (
+              <TransitiveTagTooltip
+                text={TRANSITIVE_TOOLTIP_COPY[entityType] ?? ''}
+              />
+            )}
           </h2>
           {selectedSlugs.length > 0 && (
             <Button
@@ -240,6 +261,34 @@ function TagChip({ tag, selected, onToggle }: TagChipProps) {
         {tag.usage_count}
       </span>
     </button>
+  )
+}
+
+/**
+ * Small info icon next to the facet heading that reveals the transitive
+ * semantics of the filter (PSY-499). Only rendered for `show` / `festival`
+ * entity types — direct-tag pages (artist, venue, label, release) don't
+ * need the explainer. Keyboard- and hover-accessible via Radix Tooltip.
+ */
+function TransitiveTagTooltip({ text }: { text: string }) {
+  return (
+    <TooltipProvider delayDuration={120}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            aria-label="How tag filtering works"
+            className="inline-flex items-center rounded-full p-0.5 text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            data-testid="tag-facet-transitive-info"
+          >
+            <Info className="h-3.5 w-3.5" aria-hidden />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="max-w-xs text-xs">
+          {text}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   )
 }
 


### PR DESCRIPTION
## Summary

- `/shows?tags=X` and `/festivals?tags=X` now return containers whose **lineup artists** have the tag, not the (always-empty) set of directly tagged shows/festivals. Canonical dogfood repro fixed: `/shows?tags=shoegaze` returns Faetooth's 3 upcoming shows instead of 0.
- `/tags?entity_type=show|festival` facet counts flip transitive too — they count **distinct containers with any tagged lineup artist**, so chips show honest non-zero counts.
- Adds a small info tooltip next to the `/shows` and `/festivals` facet heading explaining the semantic (`"Filtering by genre matches shows whose artists have that tag."`).
- `/artists`, `/venues`, `/labels`, `/releases` still use direct-tag semantics — unchanged.

## Why

Shows and festivals inherit meaning from their lineup; nobody manually tags individual shows with genre tags (and per the data model they never will). The previous direct-tag filter turned every chip on `/shows` into a 0-result dead end. Prior art: Bandcamp, Last.fm, RYM all aggregate transitively from the smallest tagged unit.

Closes PSY-499.

## Implementation

- `backend/internal/services/catalog/tag_filter.go`: new `ApplyTransitiveArtistTagFilter` and `CountTransitiveArtistTagUsage` helpers. Both resolve slugs via `tags`, join through a lineup junction (`show_artists` / `festival_artists`) and `entity_tags WHERE entity_type='artist'`, and dedup via `GROUP BY` on the container ID.
- AND semantics: the lineup must **collectively** cover all N tags (any combination across artists) — `HAVING COUNT(DISTINCT tags.id) = N`. More useful for discovery than requiring a single artist to carry every tag.
- `backend/internal/services/catalog/show.go`: both `GetShows` and `GetUpcomingShows` now call `ApplyTransitiveArtistTagFilter`.
- `backend/internal/services/catalog/festival.go`: `ListFestivals` does the same. Scoped strictly to tag-filter query building — the festival default activity-gate filter (PSY-495) is untouched.
- `backend/internal/services/catalog/tag_service.go`: `ListTags` entity-type-scoped facet count goes through a new `computeEntityTypeTagCounts` helper that routes `show` / `festival` to the transitive count and everything else to the direct count.
- `frontend/features/tags/components/TagFacetPanel.tsx`: new `TransitiveTagTooltip` — Radix tooltip, keyboard- and hover-accessible, rendered only on `show` / `festival` facets.

## EXPLAIN

Seeded 1000 shows × 2 artists/show = 2000 `show_artists` rows, 200 artists all tagged `rock` (the heaviest realistic tag). Ran EXPLAIN ANALYZE on the post-PSY-499 SQL.

### `/shows?tags=rock`
```
Sort  (cost=175.48..177.98 rows=1000) (actual time=0.649..0.671 rows=1000 loops=1)
  Sort Key: shows.event_date
  ->  Hash Join  (cost=98.52..125.65 rows=1000) (actual time=0.493..0.607)
        Hash Cond: (shows.id = show_artists.show_id)
        ->  Seq Scan on shows (Filter: status='approved')
        ->  Hash
              ->  HashAggregate (Group Key: show_artists.show_id)
                    ->  Hash Join (show_artists.artist_id = entity_tags.entity_id)
                          ->  Seq Scan on show_artists
                          ->  Hash
                                ->  Nested Loop (tags → entity_tags)
                                      ->  Seq Scan on tags (Filter: lower(slug)='rock')
                                      ->  Seq Scan on entity_tags (Filter: entity_type='artist')
Planning Time: 0.340 ms
Execution Time: 0.811 ms
```

### `/tags?entity_type=show` facet count for `rock`
```
GroupAggregate  (cost=0.43..164.36 rows=1) (actual time=0.509..0.509)
  ->  Nested Loop (rows=2000)
        ->  Index Scan using idx_show_artists_show_id on show_artists
        ->  Memoize  (Hits: 1800  Misses: 200)
              ->  Index Scan using idx_entity_tags_entity on entity_tags
                    Index Cond: (entity_type='artist' AND entity_id = show_artists.artist_id)
Planning Time: 0.072 ms
Execution Time: 0.515 ms
```

### Index summary

Planner-visible indexes relevant to the transitive filter (all already exist — no migration needed):

- `idx_entity_tags_entity(entity_type, entity_id)` — composite index used by the facet-count query's `Index Cond`.
- `entity_tags_tag_id_entity_type_entity_id_key(tag_id, entity_type, entity_id)` — unique key, useful for the filter subquery when the tag set is small.
- `idx_show_artists_show_id(show_id)` — used by the facet count's outer scan.
- `idx_show_artists_artist_id(artist_id)` — used when the subquery filters on specific artist IDs.
- `idx_festival_artists_artist_id(artist_id)` — festival-side analogue.
- `idx_tags_slug` / `tags_slug_key` — slug lookup for the tag resolution.

At this data volume the planner chose hash joins (fine — the table scans are cheap and indexed lookup would add overhead for a full-table GROUP BY). On production-scale data the `(entity_type, entity_id)` composite index will become the hot path, as seen in the facet-count plan already.

## Test plan

- [x] Backend: new integration tests in `TagFilterIntegrationTestSuite`:
  - `TestShows_GetShows_AND_Transitive` — two-tag AND via lineup (collective coverage)
  - `TestShows_GetUpcomingShows_AND_Transitive` / `TestShows_GetUpcomingShows_OR_Transitive`
  - `TestShows_SingleTag_Transitive` — the canonical dogfood repro (artist tagged `shoegaze` → 3 matching shows)
  - `TestShows_DirectTagNotSufficient` — directly tagging a show with `entity_type='show'` is a no-op (regression guard for the semantic flip)
  - `TestShows_DistinctShowIDs` — DISTINCT dedup when multiple lineup artists match
  - `TestFestivals_AND_Transitive` / `TestFestivals_OR_Transitive` / `TestFestivals_SingleTag_Transitive`
  - `TestListTags_ShowEntityType_Transitive` — facet count routes through the lineup
  - `TestListTags_ShowEntityType_MultipleArtistsSameShow` — DISTINCT in the facet count
  - `TestListTags_FestivalEntityType_Transitive`
  - `TestListTags_ArtistEntityType_DirectCount` — verifies non-show/festival entity types still use the direct count
- [x] Frontend: 5 new tests in `TagFacetPanel.test.tsx` — renders tooltip trigger for show/festival, omits for artist/none/sheet mode.
- [x] All existing backend tests still pass (`go test ./internal/services/catalog/` = 31s green, handler tests = 30s green).
- [x] All existing frontend tests still pass (549 tests, 7s).
- [ ] Manual curl verification after deploy: `/shows?tags=shoegaze` returns the Faetooth shows; `/tags?entity_type=show&category=genre` shows non-zero counts.

## Scope boundaries (per ticket)

- Did not touch `/artists`, `/venues`, `/labels`, `/releases` filtering (PSY-495 in parallel).
- Did not touch the festival default activity-gate filter (also PSY-495). Edits to `festival.go` are confined to one `if tf, ok := filters["tag_filter"]` block.
- `/venues` transitive support (two hops via shows-at-venue) intentionally deferred per ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)