### PR TITLE
PSY-497: Return 404 status for missing tag detail pages

### DIFF
--- a/frontend/app/tags/[slug]/not-found.tsx
+++ b/frontend/app/tags/[slug]/not-found.tsx
@@ -1,0 +1,35 @@
+import Link from 'next/link'
+import type { Metadata } from 'next'
+import { ArrowLeft } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+// Owned metadata so the tab title reads "Tag not found" instead of inheriting
+// a stale parent title. Matches the `generateMetadata` fallback in
+// `app/tags/[slug]/page.tsx` (PSY-497).
+export const metadata: Metadata = {
+  title: 'Tag not found',
+  description: 'The tag you are looking for does not exist.',
+}
+
+// Rendered by Next.js when `app/tags/[slug]/page.tsx` calls `notFound()` —
+// returns the hard HTTP 404 status. Copy + visual match the original
+// client-rendered not-found branch in `TagDetail` (pre-PSY-497) so the UI
+// is unchanged; the fix is purely at the response-status layer.
+export default function TagNotFound() {
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center">
+      <div className="text-center">
+        <h1 className="text-2xl font-bold mb-2">Tag Not Found</h1>
+        <p className="text-muted-foreground mb-4">
+          The tag you&apos;re looking for doesn&apos;t exist.
+        </p>
+        <Button asChild variant="outline">
+          <Link href="/tags">
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            Back to Tags
+          </Link>
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/app/tags/[slug]/page.tsx
+++ b/frontend/app/tags/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from 'react'
 import type { Metadata } from 'next'
+import { notFound } from 'next/navigation'
 import * as Sentry from '@sentry/nextjs'
 import { Loader2 } from 'lucide-react'
 import { TagDetail } from '@/features/tags/components'
@@ -26,6 +27,10 @@ interface TagSummaryForMetadata {
  * GET /tags/{slug} endpoint (not /tags/{slug}/detail) because we only need
  * name + usage_count for the title/description; the enriched detail call has
  * extra cost for content the client component will fetch anyway. (PSY-485)
+ *
+ * Returns null for 404s (expected for invalid slugs) — the page component
+ * uses that signal to call `notFound()` and return a hard HTTP 404 instead
+ * of a soft-404 (PSY-497).
  */
 async function getTagForMetadata(
   slug: string
@@ -85,9 +90,13 @@ export async function generateMetadata({
     }
   }
 
+  // Missing tag: the page component will call `notFound()` and Next.js will
+  // render `app/tags/[slug]/not-found.tsx`, which owns its own metadata.
+  // Returning a generic "Tag" title here would show briefly before the
+  // not-found page mounts, so use the explicit not-found title instead.
   return {
-    title: 'Tag',
-    description: 'Browse entities by tag on Psychic Homily',
+    title: 'Tag not found',
+    description: 'The tag you are looking for does not exist.',
   }
 }
 
@@ -101,6 +110,22 @@ function TagLoadingFallback() {
 
 export default async function TagDetailPage({ params }: TagPageProps) {
   const { slug } = await params
+
+  // Server-side existence check: if the backend doesn't know this slug, call
+  // `notFound()` so Next.js returns HTTP 404 and renders the route's
+  // `not-found.tsx`. Without this, the client component would render a
+  // friendly "Tag Not Found" page but the response status stays 200 — a
+  // soft-404 that poisons SEO, monitoring, and crawlers (PSY-497).
+  //
+  // We rely on `getTagForMetadata` (already called during metadata
+  // generation) — but Next.js doesn't memoize across `generateMetadata` and
+  // the page component, so this second fetch is unavoidable. It hits
+  // `revalidate: 3600` cache in practice.
+  const tag = await getTagForMetadata(slug)
+  if (!tag) {
+    notFound()
+  }
+
   return (
     <Suspense fallback={<TagLoadingFallback />}>
       <TagDetail slug={slug} />


### PR DESCRIPTION
## Summary

- `/tags/[slug]` for an unknown slug returned **HTTP 200** with a friendly "Tag Not Found" body — a soft-404 that poisons SEO (Google penalizes soft-404s), breaks monitoring (uptime + Sentry can't distinguish missing vs. successful), misleads crawlers (dead links treated as live), and lets the CDN cache the not-found page under the dead URL.
- The server component now fetches the tag up front via the existing lightweight `GET /tags/{slug}` endpoint and calls `notFound()` from `next/navigation` when the backend doesn't know the slug. Next.js then returns a **hard HTTP 404** and renders the new `app/tags/[slug]/not-found.tsx`.
- The rendered UI is unchanged — same "Tag Not Found / Back to Tags" copy and visual as the original client-rendered branch. `generateMetadata` now returns a `Tag not found` title instead of the generic `Tag` for missing tags.

## Before / After

```
# BEFORE (main) — same repro URL on the shared :3000 dev server
$ curl -sI http://localhost:3000/tags/this-tag-does-not-exist-psy-497 | head -1
HTTP/1.1 200 OK

# AFTER (this branch) — port 3456, same URL
$ curl -sI http://localhost:3456/tags/this-tag-does-not-exist-psy-497 | head -1
HTTP/1.1 404 Not Found
```

Body + title verification on the fixed build:

```
$ curl -s http://localhost:3456/tags/this-tag-does-not-exist-psy-497 \
    | grep -oE '(Tag Not Found|Back to Tags|<title[^>]*>[^<]*</title>)'
<title>Tag not found | Psychic Homily</title>
Back to Tags
Tag Not Found
Back to Tags
```

Sanity check — existing tag and browse page still return 200:

```
$ curl -sI http://localhost:3456/tags/punk | head -1
HTTP/1.1 200 OK

$ curl -sI http://localhost:3456/tags | head -1
HTTP/1.1 200 OK
```

## Files touched

- `frontend/app/tags/[slug]/page.tsx` — server component now calls `notFound()` when the backend returns 404; `generateMetadata` returns a `Tag not found` title on the missing-tag branch instead of the generic `Tag`.
- `frontend/app/tags/[slug]/not-found.tsx` — new route-level not-found component. Same friendly "Tag Not Found / Back to Tags" UI as the pre-fix client-rendered branch, plus owned `metadata` so the tab title reads `Tag not found | Psychic Homily`.

## Audit of sibling detail routes

Checked every server-component detail route for the same soft-404 bug (server component returning a plain component on missing data instead of calling `notFound()`):

| Route | Calls `notFound()`? | Evidence |
|---|---|---|
| `/artists/[slug]` | yes | `frontend/app/artists/[slug]/page.tsx:105-107` |
| `/venues/[slug]` | yes | `frontend/app/venues/[slug]/page.tsx:107-109` |
| `/festivals/[slug]` | yes | `frontend/app/festivals/[slug]/page.tsx:109-111` |
| `/labels/[slug]` | yes | `frontend/app/labels/[slug]/page.tsx:107-109` |
| `/releases/[slug]` | yes | `frontend/app/releases/[slug]/page.tsx:105-107` |
| `/shows/[slug]` | yes | `frontend/app/shows/[slug]/page.tsx:149-151` |
| `/tags/[slug]` | **no (this PR fixes it)** | prior `page.tsx:102-109` just rendered `<TagDetail slug={slug} />` unconditionally |

All six sibling routes are already correct — **no follow-up tickets needed**. Tag was the only route with the bug, which tracks with the ticket's theory that PSY-485 converted the tag page from a client component (`useParams`) to an async server component and preserved the friendly not-found branch inside the child client component rather than lifting it to `notFound()`.

## Testing

- `bun run test:run -- features/tags/components/TagDetail.test.tsx` — 46/46 pass (no change to the client component's not-found branches; it still handles runtime 404 errors if the client fetch races ahead of the server fetch).
- `bun run tsc --noEmit` — clean.
- Manual curl verification above.

Closes PSY-497

🤖 Generated with [Claude Code](https://claude.com/claude-code)