### PR TITLE
PSY-496: Scope city filter to originating entity browse page

### DIFF
--- a/frontend/features/artists/components/ArtistList.test.tsx
+++ b/frontend/features/artists/components/ArtistList.test.tsx
@@ -28,19 +28,6 @@ vi.mock('@/lib/hooks/common/useDensity', () => ({
   useDensity: (key: string) => mockUseDensity(key),
 }))
 
-// Mock auth hooks
-const mockUseProfile = vi.fn()
-const mockUseIsAuthenticated = vi.fn()
-vi.mock('@/features/auth', () => ({
-  useProfile: () => mockUseProfile(),
-  useIsAuthenticated: () => mockUseIsAuthenticated(),
-}))
-
-// Mock SaveDefaultsButton
-vi.mock('@/components/filters/SaveDefaultsButton', () => ({
-  SaveDefaultsButton: () => <div data-testid="save-defaults-button">SaveDefaultsButton</div>,
-}))
-
 // Mock child components that are complex
 vi.mock('./ArtistSearch', () => ({
   ArtistSearch: () => <div data-testid="artist-search">ArtistSearch</div>,
@@ -50,12 +37,10 @@ vi.mock('@/components/filters', () => ({
   CityFilters: ({
     onFilterChange,
     selectedCities,
-    children,
   }: {
     onFilterChange: (cities: { city: string; state: string }[]) => void
     selectedCities: { city: string; state: string }[]
     cities: unknown[]
-    children?: React.ReactNode
   }) => (
     <div data-testid="city-filters">
       <span data-testid="selected-count">{selectedCities.length}</span>
@@ -65,7 +50,6 @@ vi.mock('@/components/filters', () => ({
       >
         Clear
       </button>
-      {children}
     </div>
   ),
 }))
@@ -116,8 +100,6 @@ describe('ArtistList', () => {
     vi.clearAllMocks()
     mockGet.mockReturnValue(null)
     mockUseDensity.mockReturnValue({ density: 'comfortable', setDensity: vi.fn() })
-    mockUseProfile.mockReturnValue({ data: null })
-    mockUseIsAuthenticated.mockReturnValue({ isAuthenticated: false })
     mockUseArtistCities.mockReturnValue({
       data: { cities: [] },
       isLoading: false,
@@ -341,5 +323,45 @@ describe('ArtistList', () => {
         tagMatch: 'any',
       })
     )
+  })
+
+  // PSY-496: city filter must be page-scoped. Arriving at /artists from
+  // another entity page (e.g. /shows) without a `cities` URL param should
+  // render the unfiltered list. The shared city filter had been auto-applying
+  // the user's profile favorite_cities on mount, which made users land on
+  // /artists?cities=Phoenix%2CAZ after clicking the sidebar link — most
+  // artists have city: null, so the list rendered "0 artists".
+  describe('PSY-496: city filter is page-scoped (no cross-page persistence)', () => {
+    it('does not call router.replace to append cities param on mount (no URL param)', () => {
+      // Simulate cross-page navigation: arriving at /artists with no cities
+      // URL param. Even if the user previously selected Phoenix on /shows,
+      // /artists should render unfiltered and NOT mutate the URL.
+      mockGet.mockReturnValue(null)
+
+      renderWithProviders(<ArtistList />)
+
+      expect(mockReplace).not.toHaveBeenCalled()
+      expect(mockUseArtists).toHaveBeenCalledWith(
+        expect.objectContaining({ cities: undefined })
+      )
+    })
+
+    it('respects an explicit cities URL param (still supports direct/bookmark nav)', () => {
+      // Manual/bookmark nav: /artists?cities=Phoenix,AZ must still filter.
+      mockGet.mockImplementation((key: string) =>
+        key === 'cities' ? 'Phoenix,AZ' : null
+      )
+
+      renderWithProviders(<ArtistList />)
+
+      // URL must not be mutated by the component.
+      expect(mockReplace).not.toHaveBeenCalled()
+      // Filter drives the list as expected.
+      expect(mockUseArtists).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cities: [{ city: 'Phoenix', state: 'AZ' }],
+        })
+      )
+    })
   })
 })

--- a/frontend/features/artists/components/ArtistList.tsx
+++ b/frontend/features/artists/components/ArtistList.tsx
@@ -1,13 +1,11 @@
 'use client'
 
-import { useCallback, useMemo, useTransition, useRef, useEffect } from 'react'
+import { useCallback, useMemo, useTransition } from 'react'
 import { useSearchParams, useRouter } from 'next/navigation'
 import { useArtists, useArtistCities } from '../hooks/useArtists'
-import { useProfile, useIsAuthenticated } from '@/features/auth'
 import { ArtistCard } from './ArtistCard'
 import { ArtistSearch } from './ArtistSearch'
 import { CityFilters, type CityWithCount, type CityState } from '@/components/filters'
-import { SaveDefaultsButton } from '@/components/filters/SaveDefaultsButton'
 import { LoadingSpinner, DensityToggle } from '@/components/shared'
 import { useDensity } from '@/lib/hooks/common/useDensity'
 import { Button } from '@/components/ui/button'
@@ -35,21 +33,17 @@ function buildCitiesParam(cities: CityState[]): string {
   return cities.map(c => `${c.city},${c.state}`).join('|')
 }
 
-/** Compare two city arrays for equality (order-insensitive) */
-function citiesEqual(a: CityState[], b: CityState[]): boolean {
-  if (a.length !== b.length) return false
-  const setA = new Set(a.map(c => `${c.city}|${c.state}`))
-  return b.every(c => setA.has(`${c.city}|${c.state}`))
-}
-
 export function ArtistList() {
   const router = useRouter()
   const searchParams = useSearchParams()
-  const { isAuthenticated } = useIsAuthenticated()
   const [isPending, startTransition] = useTransition()
-  const { data: profileData } = useProfile()
-  const hasAppliedDefaults = useRef(false)
   const { density, setDensity } = useDensity('artists')
+
+  // PSY-496: city filter is page-scoped — we don't auto-apply the user's
+  // profile-level favorite_cities here. Favorites are shows-centric (the
+  // canonical homepage) and inheriting them on /artists produced the
+  // "0 artists" confusion where most artists have city: null. Users can
+  // still filter by city on /artists manually — the URL drives state.
 
   // Parse multi-city from URL
   const citiesParam = searchParams.get('cities')
@@ -62,29 +56,6 @@ export function ArtistList() {
   const tagMatchParam = searchParams.get('tag_match')
   const selectedTags = useMemo(() => parseTagsParam(tagsParam), [tagsParam])
   const tagMatch: 'all' | 'any' = tagMatchParam === 'any' ? 'any' : 'all'
-
-  // Read favorites from profile
-  const favoriteCities: CityState[] = useMemo(() => {
-    const prefs = profileData?.user?.preferences
-    if (!prefs?.favorite_cities) return []
-    return prefs.favorite_cities
-  }, [profileData?.user?.preferences])
-
-  // Apply favorites as default URL params on initial load (no URL params + not yet applied)
-  useEffect(() => {
-    if (
-      !hasAppliedDefaults.current &&
-      favoriteCities.length > 0 &&
-      !citiesParam
-    ) {
-      hasAppliedDefaults.current = true
-      const params = new URLSearchParams()
-      params.set('cities', buildCitiesParam(favoriteCities))
-      startTransition(() => {
-        router.replace(`/artists?${params.toString()}`, { scroll: false })
-      })
-    }
-  }, [favoriteCities, citiesParam, router])
 
   const { data: citiesData, isLoading: citiesLoading, isFetching: citiesFetching } = useArtistCities()
   const { data, isLoading, isFetching, error, refetch } = useArtists({
@@ -155,9 +126,6 @@ export function ArtistList() {
     )
   }
 
-  // Determine if "Save as default" / "Clear defaults" should show
-  const selectionDiffersFromFavorites = !citiesEqual(selectedCities, favoriteCities)
-
   // Map ArtistCity to CityWithCount
   const cities: CityWithCount[] = citiesData?.cities?.map(c => ({
     city: c.city,
@@ -178,14 +146,7 @@ export function ArtistList() {
             cities={cities}
             selectedCities={selectedCities}
             onFilterChange={handleFilterChange}
-          >
-            {isAuthenticated && selectionDiffersFromFavorites && (
-              <SaveDefaultsButton
-                selectedCities={selectedCities}
-                favoriteCities={favoriteCities}
-              />
-            )}
-          </CityFilters>
+          />
         )}
       </div>
 

--- a/frontend/features/venues/components/VenueList.tsx
+++ b/frontend/features/venues/components/VenueList.tsx
@@ -1,14 +1,12 @@
 'use client'
 
-import { useState, useCallback, useMemo, useTransition, useRef, useEffect } from 'react'
+import { useState, useCallback, useMemo, useTransition } from 'react'
 import { useSearchParams, useRouter } from 'next/navigation'
 import { useVenues, useVenueCities } from '../hooks/useVenues'
-import { useProfile, useIsAuthenticated } from '@/features/auth'
 import type { VenueWithShowCount } from '../types'
 import { VenueCard } from './VenueCard'
 import { VenueSearch } from './VenueSearch'
 import { CityFilters, type CityWithCount, type CityState } from '@/components/filters'
-import { SaveDefaultsButton } from '@/components/filters/SaveDefaultsButton'
 import { LoadingSpinner } from '@/components/shared'
 import { Button } from '@/components/ui/button'
 import {
@@ -37,22 +35,17 @@ function buildCitiesParam(cities: CityState[]): string {
   return cities.map(c => `${c.city},${c.state}`).join('|')
 }
 
-/** Compare two city arrays for equality (order-insensitive) */
-function citiesEqual(a: CityState[], b: CityState[]): boolean {
-  if (a.length !== b.length) return false
-  const setA = new Set(a.map(c => `${c.city}|${c.state}`))
-  return b.every(c => setA.has(`${c.city}|${c.state}`))
-}
-
 export function VenueList() {
   const router = useRouter()
   const searchParams = useSearchParams()
-  const { isAuthenticated } = useIsAuthenticated()
   const [isPending, startTransition] = useTransition()
-  const { data: profileData } = useProfile()
-  const hasAppliedDefaults = useRef(false)
   const [offset, setOffset] = useState(0)
   const [accumulatedVenues, setAccumulatedVenues] = useState<VenueWithShowCount[]>([])
+
+  // PSY-496: city filter is page-scoped — we don't auto-apply the user's
+  // profile-level favorite_cities here. Favorites are shows-centric (the
+  // canonical homepage). Users can still filter by city on /venues manually —
+  // the URL drives state.
 
   // Parse multi-city from URL
   const citiesParam = searchParams.get('cities')
@@ -65,29 +58,6 @@ export function VenueList() {
   const tagMatchParam = searchParams.get('tag_match')
   const selectedTags = useMemo(() => parseTagsParam(tagsParam), [tagsParam])
   const tagMatch: 'all' | 'any' = tagMatchParam === 'any' ? 'any' : 'all'
-
-  // Read favorites from profile
-  const favoriteCities: CityState[] = useMemo(() => {
-    const prefs = profileData?.user?.preferences
-    if (!prefs?.favorite_cities) return []
-    return prefs.favorite_cities
-  }, [profileData?.user?.preferences])
-
-  // Apply favorites as default URL params on initial load (no URL params + not yet applied)
-  useEffect(() => {
-    if (
-      !hasAppliedDefaults.current &&
-      favoriteCities.length > 0 &&
-      !citiesParam
-    ) {
-      hasAppliedDefaults.current = true
-      const params = new URLSearchParams()
-      params.set('cities', buildCitiesParam(favoriteCities))
-      startTransition(() => {
-        router.replace(`/venues?${params.toString()}`, { scroll: false })
-      })
-    }
-  }, [favoriteCities, citiesParam, router])
 
   const { data: citiesData, isLoading: citiesLoading, isFetching: citiesFetching } = useVenueCities()
   const { data, isLoading, isFetching, error, refetch } = useVenues({
@@ -168,9 +138,6 @@ export function VenueList() {
     )
   }
 
-  // Determine if "Save as default" / "Clear defaults" should show
-  const selectionDiffersFromFavorites = !citiesEqual(selectedCities, favoriteCities)
-
   // Map VenueCity to CityWithCount
   const cities: CityWithCount[] = citiesData?.cities?.map(c => ({
     city: c.city,
@@ -187,14 +154,7 @@ export function VenueList() {
             cities={cities}
             selectedCities={selectedCities}
             onFilterChange={handleFilterChange}
-          >
-            {isAuthenticated && selectionDiffersFromFavorites && (
-              <SaveDefaultsButton
-                selectedCities={selectedCities}
-                favoriteCities={favoriteCities}
-              />
-            )}
-          </CityFilters>
+          />
         )}
       </div>
 


### PR DESCRIPTION
## Summary

- Remove the auto-apply-favorites `useEffect` (and the attached `SaveDefaultsButton`) from `/artists` and `/venues` so profile-level `favorite_cities` no longer leak across entity types. Favorites remain shows-centric; users who select `Phoenix, AZ` for shows no longer land on `/artists?cities=Phoenix%2CAZ` after clicking the sidebar link.
- URL-driven city filtering is untouched on all three pages — paginating, toggling density, or linking directly to `/artists?cities=Phoenix,AZ` still filters as expected.
- Component test coverage: `/artists` with no `cities` URL param must NOT mutate the URL via `router.replace`, and an explicit `cities` param is still honored.

## Architecture found

Filter persistence was not driven by a shared hook. Each browse page (`ShowList`, `VenueList`, `ArtistList`) independently read `cities` from `useSearchParams()` and wrote via a local `writeParams()`. The cross-page "persistence" the ticket describes was the **profile `favorite_cities` auto-apply `useEffect`**: each of those three components, on mount, called `router.replace('<path>?cities=...')` when the URL was empty and the user had saved favorites. The user's sidebar click to `/artists` produced a clean `/artists` URL, but `ArtistList` then immediately re-wrote it to `/artists?cities=Phoenix%2CAZ`. Most artists have `city: null`, so the filter matched nothing and rendered "0 artists / No artists match the current filters".

Labels, festivals, and releases never had the bug — none auto-apply favorites, and festivals uses a different `city` (singular) query param that doesn't share the `cities` key.

Removing the `useEffect` from `ArtistList` and `VenueList` is the minimal fix that matches ticket option 1 (page-scope the filter). `ShowList` keeps the auto-apply because `/shows` is the canonical homepage where the favorites default was designed to take effect.

## Files touched

- `frontend/features/artists/components/ArtistList.tsx` — remove auto-apply `useEffect`, `SaveDefaultsButton`, `useProfile` / `useIsAuthenticated` imports, `favoriteCities` memo, `citiesEqual` helper.
- `frontend/features/venues/components/VenueList.tsx` — same surgery.
- `frontend/features/artists/components/ArtistList.test.tsx` — drop obsolete `useProfile` / `useIsAuthenticated` mocks; add `PSY-496: city filter is page-scoped` describe block with two tests covering the new contract.

## Test plan

**Automated**
- [x] `bun run test:run features/artists features/venues features/shows` — 47 files / 564 tests pass (including 2 new PSY-496 tests).
- [x] `bunx tsc --noEmit` — no TypeScript errors.
- [x] `bun run lint` — no new lint errors introduced (pre-existing warnings unchanged).

**Manual repro (the exact ticket scenario)**
1. Sign in as a user who has `Phoenix, AZ` saved in profile → `favorite_cities`.
2. Visit `/shows` → URL auto-populates to `/shows?cities=Phoenix%2CAZ` (preserved behavior).
3. Click the sidebar `Artists` link.
4. Destination URL is `/artists` — **no `cities` param** (the fix).
5. Artists list renders populated (not "0 artists").

**Within-entity persistence still works**
- On `/shows?cities=Phoenix%2CAZ`, hit Load More / toggle density → `cities=Phoenix,AZ` stays in the URL (local `writeParams` preserves it).
- Direct nav to `/artists?cities=Phoenix,AZ` (bookmark / typed URL) still filters to Phoenix artists — the URL drives state, the component doesn't strip it.

## Scope guard

Did not touch:
- Tag filter logic (PSY-499 merged).
- Artist activity gate (PSY-495 merged).
- Tag detail rendering (PSY-497 in parallel).
- Tag pill mobile UX (PSY-498 in parallel).
- Festivals / releases / labels — none had the `cities`-param cross-page leak.

## Ambiguity surfaced

One follow-up candidate, not fixed here: `ShowList.tsx` imports `useSetFavoriteCities` from `@/features/auth` but never uses it (pre-existing dead import). Not in PSY-496 scope.

Closes PSY-496

🤖 Generated with [Claude Code](https://claude.com/claude-code)