### PR TITLE
PSY-498: Two-tap preview + navigate for tag pills on touch devices

### DIFF
--- a/frontend/features/tags/components/EntityTagList.test.tsx
+++ b/frontend/features/tags/components/EntityTagList.test.tsx
@@ -1252,3 +1252,260 @@ describe('EntityTagList zero-tag empty state (PSY-481)', () => {
     ).not.toBeInTheDocument()
   })
 })
+
+// PSY-498: tag pills on coarse-pointer (touch) devices used to single-tap
+// navigate straight to /tags/<slug>, skipping the attribution hover card
+// entirely — so mobile users never saw per-application attribution that
+// PSY-479 surfaced. The two-tap pattern (Twitter/X-style) keeps desktop
+// hover+click untouched while adding: tap 1 → open card, tap 2 → navigate.
+describe('EntityTagList tag pill two-tap on touch devices (PSY-498)', () => {
+  // Helper: flip `window.matchMedia('(pointer: coarse)')` so the hook's
+  // first-render + subsequent reads report a touch device. Other queries
+  // (e.g. `prefers-reduced-motion`) keep matching `false`, matching the
+  // default setup.ts behavior.
+  function setCoarsePointer(isCoarse: boolean) {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: query === '(pointer: coarse)' ? isCoarse : false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    })
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    currentMockTags = {
+      tags: [
+        {
+          tag_id: 77,
+          name: 'shoegaze',
+          slug: 'shoegaze',
+          category: 'genre',
+          is_official: false,
+          upvotes: 2,
+          downvotes: 0,
+          wilson_score: 0.3,
+          user_vote: 0,
+          added_by_username: 'testuser',
+          added_at: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+        },
+      ],
+    }
+    currentMockSearchTags = defaultMockSearchTags
+    mockAuthUser = { user_tier: 'contributor' }
+    mockAddMutationError = null
+    // Reset to the default (non-touch) matchMedia behavior unless a test
+    // opts into coarse pointer. The global `afterEach` in test/setup.ts
+    // already restores matchMedia when the test file exits; this keeps
+    // each individual case hermetic.
+    setCoarsePointer(false)
+  })
+
+  it('opens the card on the first tap and navigates only on the second tap', async () => {
+    setCoarsePointer(true)
+    const user = userEvent.setup()
+    renderWithProviders(
+      <EntityTagList entityType="artist" entityId={1} isAuthenticated />
+    )
+
+    const row = desktopRow()
+    const tagLink = within(row).getByRole('link', { name: 'shoegaze' })
+
+    // The wrapper's click handler runs during the bubbling phase BEFORE the
+    // event reaches document.body, so a document-level listener observes the
+    // final `defaultPrevented` state post-wrapper-handling. An anchor-local
+    // listener would see the state BEFORE the wrapper runs (target-phase →
+    // bubble up to wrapper → bubble up to document), which is why we attach
+    // here instead of on the link itself.
+    const observations: boolean[] = []
+    const docListener = (e: Event) => {
+      if (e.target instanceof HTMLElement && e.target.closest('a[href^="/tags/"]')) {
+        observations.push(e.defaultPrevented)
+      }
+    }
+    document.addEventListener('click', docListener)
+
+    try {
+      // Card is not open yet.
+      expect(
+        screen.queryByTestId('tag-attribution-card-77')
+      ).not.toBeInTheDocument()
+
+      // Tap 1: opens the card, link navigation is suppressed.
+      await user.click(tagLink)
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('tag-attribution-card-77')
+        ).toBeInTheDocument()
+      })
+      expect(observations[0]).toBe(true)
+
+      // Tap 2: card is already open + flagged tap-opened; let the link run.
+      await user.click(tagLink)
+      expect(observations[1]).toBe(false)
+      expect(observations).toHaveLength(2)
+    } finally {
+      document.removeEventListener('click', docListener)
+    }
+  })
+
+  it('keeps desktop click-through untouched (pointer: fine → single click navigates)', async () => {
+    setCoarsePointer(false)
+    const user = userEvent.setup()
+    renderWithProviders(
+      <EntityTagList entityType="artist" entityId={1} isAuthenticated />
+    )
+
+    const tagLink = within(desktopRow()).getByRole('link', { name: 'shoegaze' })
+
+    let defaultPrevented: boolean | null = null
+    const docListener = (e: Event) => {
+      if (e.target instanceof HTMLElement && e.target.closest('a[href^="/tags/"]')) {
+        defaultPrevented = e.defaultPrevented
+      }
+    }
+    document.addEventListener('click', docListener)
+
+    try {
+      await user.click(tagLink)
+      // On a fine-pointer device a single click must navigate — the wrapper
+      // MUST NOT call preventDefault. If this ever flips back to true, the
+      // desktop path has regressed.
+      expect(defaultPrevented).toBe(false)
+    } finally {
+      document.removeEventListener('click', docListener)
+    }
+  })
+
+  it('moves the vote buttons from next-to-pill into the attribution card on touch devices', async () => {
+    setCoarsePointer(true)
+    const user = userEvent.setup()
+    renderWithProviders(
+      <EntityTagList entityType="artist" entityId={1} isAuthenticated />
+    )
+
+    // The inline (next-to-pill) vote buttons are hidden on touch — the card
+    // is the single vote affordance. The pill wrapper only exposes the tag
+    // name link.
+    const row = desktopRow()
+    expect(
+      within(row).queryByRole('button', { name: /upvote shoegaze/i })
+    ).not.toBeInTheDocument()
+    expect(
+      within(row).queryByRole('button', { name: /downvote shoegaze/i })
+    ).not.toBeInTheDocument()
+
+    // Open the card via the first tap and confirm the vote actions + View
+    // link land inside it.
+    await user.click(within(row).getByRole('group', { name: /shoegaze tag details/i }))
+
+    const card = await screen.findByTestId('tag-attribution-card-77')
+    const voteActions = within(card).getByTestId('tag-pill-card-vote-actions-77')
+    expect(voteActions).toBeInTheDocument()
+    expect(
+      within(voteActions).getByRole('button', { name: /upvote shoegaze/i })
+    ).toBeInTheDocument()
+    expect(
+      within(voteActions).getByRole('button', { name: /downvote shoegaze/i })
+    ).toBeInTheDocument()
+
+    // Attribution + "View tag details" link remain alongside the vote
+    // actions so mobile users get the full surface in one card.
+    expect(within(card).getByTestId('tag-pill-attribution')).toHaveTextContent(
+      /Added by/i
+    )
+    expect(
+      within(card).getByRole('link', { name: /view tag details/i })
+    ).toHaveAttribute('href', '/tags/shoegaze')
+  })
+
+  it('keeps vote buttons inline (next to the pill) and out of the card on desktop', async () => {
+    setCoarsePointer(false)
+    const user = userEvent.setup()
+    renderWithProviders(
+      <EntityTagList entityType="artist" entityId={1} isAuthenticated />
+    )
+
+    const row = desktopRow()
+    // Inline vote buttons render for an authenticated fine-pointer user.
+    expect(
+      within(row).getByRole('button', { name: /upvote shoegaze/i })
+    ).toBeInTheDocument()
+
+    // The card still opens (via the wrapper click on empty pill space),
+    // but it must NOT duplicate the vote actions — that renders the bigger,
+    // touch-optimized pair only on coarse pointers.
+    await user.click(within(row).getByRole('group', { name: /shoegaze tag details/i }))
+    const card = await screen.findByTestId('tag-attribution-card-77')
+    expect(
+      within(card).queryByTestId('tag-pill-card-vote-actions-77')
+    ).not.toBeInTheDocument()
+  })
+
+  it('resets the two-tap flag when the card closes (dismiss → fresh two-tap cycle)', async () => {
+    setCoarsePointer(true)
+    const user = userEvent.setup()
+    renderWithProviders(
+      <EntityTagList entityType="artist" entityId={1} isAuthenticated />
+    )
+
+    const row = desktopRow()
+    const tagLink = within(row).getByRole('link', { name: 'shoegaze' })
+
+    const defaultPreventedObservations: boolean[] = []
+    const docListener = (e: Event) => {
+      if (e.target instanceof HTMLElement && e.target.closest('a[href^="/tags/"]')) {
+        defaultPreventedObservations.push(e.defaultPrevented)
+      }
+    }
+    document.addEventListener('click', docListener)
+
+    try {
+      // Tap 1: open the card.
+      await user.click(tagLink)
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('tag-attribution-card-77')
+        ).toBeInTheDocument()
+      })
+
+      // Dismiss the card by clicking outside. Radix's HoverCard listens for
+      // pointer-down outside the trigger + content and fires
+      // onOpenChange(false) — our handleOpenChange clears the tap-opened
+      // ref in that branch. We use a click on document.body because Escape
+      // on jsdom + Radix HoverCard is inconsistent across environments;
+      // outside-click is the more reliable dismiss trigger.
+      await user.click(document.body)
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId('tag-attribution-card-77')
+        ).not.toBeInTheDocument()
+      })
+
+      // Tap 3 (counts as a fresh "tap 1"): should re-open the card — NOT
+      // navigate. If the flag wasn't reset, the stale `open=false` +
+      // `tapOpenedRef=true` combo could let navigation through on the next
+      // tap of the new cycle.
+      await user.click(tagLink)
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('tag-attribution-card-77')
+        ).toBeInTheDocument()
+      })
+
+      // Only the two link taps were observed (the outside-click landed on
+      // document.body, not an anchor). Both suppressed because each was a
+      // fresh first-tap of its cycle.
+      expect(defaultPreventedObservations).toEqual([true, true])
+    } finally {
+      document.removeEventListener('click', docListener)
+    }
+  })
+})

--- a/frontend/features/tags/components/EntityTagList.tsx
+++ b/frontend/features/tags/components/EntityTagList.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, useRef, useSyncExternalStore } from 'react'
 import Link from 'next/link'
 import { Plus, ThumbsUp, ThumbsDown, X, Search, Loader2, ChevronDown, ChevronUp, MoreHorizontal } from 'lucide-react'
 import { cn } from '@/lib/utils'
@@ -285,6 +285,56 @@ export function EntityTagList({ entityType, entityId, isAuthenticated }: EntityT
 }
 
 // ──────────────────────────────────────────────
+// Touch / coarse-pointer detection
+// ──────────────────────────────────────────────
+
+// PSY-498: mobile browsers don't fire :hover, so a simple <a> pill tap
+// navigates away before the user ever sees the attribution hover card.
+// We switch to a Twitter/X-style two-tap pattern on coarse pointers:
+//   tap 1 → open the card (preventDefault the link)
+//   tap 2 → navigate (let the link run)
+//
+// This hook lives here (rather than in lib/) because it has exactly one
+// caller. SSR-safe: the server snapshot is always `false` so the server HTML
+// matches; after hydration the hook reads the live MediaQueryList via
+// `useSyncExternalStore`, which also wires up the change listener and cleans
+// it up on unmount without the "setState inside an effect" double-render.
+function subscribeCoarsePointer(onChange: () => void): () => void {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return () => {}
+  }
+  const mq = window.matchMedia('(pointer: coarse)')
+  // Older Safari versions only ship addListener/removeListener; prefer the
+  // modern API when available so we don't trigger deprecation warnings in
+  // evergreen browsers.
+  if (typeof mq.addEventListener === 'function') {
+    mq.addEventListener('change', onChange)
+    return () => mq.removeEventListener('change', onChange)
+  }
+  mq.addListener(onChange)
+  return () => mq.removeListener(onChange)
+}
+
+function getCoarsePointerSnapshot(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return false
+  }
+  return window.matchMedia('(pointer: coarse)').matches
+}
+
+function getCoarsePointerServerSnapshot(): boolean {
+  return false
+}
+
+function useIsCoarsePointer(): boolean {
+  return useSyncExternalStore(
+    subscribeCoarsePointer,
+    getCoarsePointerSnapshot,
+    getCoarsePointerServerSnapshot
+  )
+}
+
+// ──────────────────────────────────────────────
 // Tag pill with voting
 // ──────────────────────────────────────────────
 
@@ -299,6 +349,7 @@ function TagWithVotes({
 }) {
   const userVote = tag.user_vote ?? 0
   const score = tag.upvotes - tag.downvotes
+  const isCoarsePointer = useIsCoarsePointer()
 
   // Controlled open state for the attribution hover card. Radix HoverCard
   // opens on hover and focus out of the box; this state lets us *also* toggle
@@ -306,12 +357,85 @@ function TagWithVotes({
   // to the attribution info (PSY-441 mobile fallback).
   const [open, setOpen] = useState(false)
 
+  // Ref to the pill wrapper — used by the HoverCardContent's
+  // `onPointerDownOutside` to distinguish "user tapped somewhere truly
+  // outside" (should dismiss) from "user tapped the pill itself" (that's
+  // the second tap of the two-tap sequence, should not dismiss).
+  const triggerRef = useRef<HTMLDivElement | null>(null)
+
+  // PSY-498: tracks whether we're mid-way through a touch two-tap sequence
+  // on this pill. Lives in a ref (not state) so it doesn't participate in
+  // React's render cycle — touch tap 1 sets it, tap 2 reads-and-clears it
+  // synchronously in the same click handler. Explicit dismissals (Escape,
+  // click outside the pill + card, focus-outside) clear it via
+  // `handleCardDismiss` below.
+  const tapOpenedRef = useRef(false)
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen)
+  }
+
+  // Explicit dismissal (Escape key, click outside the trigger+content, or
+  // focus moved outside) — the two-tap cycle is abandoned and the next tap
+  // on the pill must re-open the card, not navigate.
+  const handleCardDismiss = () => {
+    tapOpenedRef.current = false
+  }
+
+  // PSY-498: the Radix DismissableLayer that backs HoverCardContent treats
+  // the trigger as "outside" the content, so tapping the trigger while the
+  // card is open would normally dismiss it (closing the card before our own
+  // click handler runs, breaking the two-tap flow). Intercept the outside-
+  // pointerdown: if it originated on OUR trigger, cancel the dismiss by
+  // preventDefault-ing the Radix event. Genuine outside taps keep dismissing
+  // the card — and also clear the two-tap ref via handleCardDismiss.
+  const handlePointerDownOutside = (event: {
+    detail: { originalEvent: PointerEvent }
+    preventDefault: () => void
+  }) => {
+    const tapTarget = event.detail.originalEvent.target as Node | null
+    if (tapTarget && triggerRef.current?.contains(tapTarget)) {
+      event.preventDefault()
+      return
+    }
+    handleCardDismiss()
+  }
+
   const handleTriggerClick = (e: React.MouseEvent) => {
-    // Don't toggle the card when the click originated on the inner tag Link
-    // (which navigates) or the vote buttons (which mutate). Those elements
-    // stop propagation via their native semantics / explicit handlers below;
-    // this guard covers any future children we add.
     const target = e.target as HTMLElement
+    const anchor = target.closest('a')
+
+    // PSY-498: touch-device two-tap. First tap on a pill — including a tap
+    // that landed on the inner link — opens the card and suppresses
+    // navigation. Second tap on the link (flagged as tap-opened in this
+    // cycle) is allowed through and navigates as normal.
+    if (isCoarsePointer && anchor && anchor.getAttribute('href')?.startsWith('/tags/')) {
+      if (tapOpenedRef.current) {
+        // Commit tap: let the link navigate. Do NOT preventDefault. Reset
+        // the flag so a future tap starts a fresh cycle.
+        tapOpenedRef.current = false
+        return
+      }
+      e.preventDefault()
+      tapOpenedRef.current = true
+      setOpen(true)
+      return
+    }
+
+    // Touch taps that land on the pill padding (outside the link) also
+    // count as "tap 1" of the two-tap cycle: they open the card AND arm
+    // the commit flag, so a subsequent link tap navigates without a third
+    // interaction. Without this, tapping pill padding first and then the
+    // link would require a third tap to commit.
+    if (isCoarsePointer && !target.closest('a, button')) {
+      tapOpenedRef.current = true
+      setOpen(true)
+      return
+    }
+
+    // Desktop + any click that originated on an inner button (votes) or on
+    // a non-pill anchor keeps the pre-PSY-498 behavior: don't toggle the
+    // card, let the child handle the click.
     if (target.closest('a, button')) return
     setOpen(v => !v)
   }
@@ -329,10 +453,16 @@ function TagWithVotes({
     }
   }
 
+  // Whether the inline (next-to-pill) vote buttons render. On touch devices
+  // we move them into the hover card so the pill itself stays a clean tap
+  // target and the card becomes the single action surface for the pill.
+  const showInlineVotes = isAuthenticated && !isCoarsePointer
+
   return (
-    <HoverCard open={open} onOpenChange={setOpen} openDelay={120} closeDelay={80}>
+    <HoverCard open={open} onOpenChange={handleOpenChange} openDelay={120} closeDelay={80}>
       <HoverCardTrigger asChild>
         <div
+          ref={triggerRef}
           role="group"
           tabIndex={0}
           aria-label={`${tag.name} tag details`}
@@ -365,7 +495,7 @@ function TagWithVotes({
             </span>
           )}
 
-          {isAuthenticated && (
+          {showInlineVotes && (
             <span className="inline-flex items-center gap-0.5 ml-0.5">
               <button
                 onClick={e => {
@@ -408,8 +538,26 @@ function TagWithVotes({
         side="top"
         className="w-[280px] text-sm"
         data-testid={`tag-attribution-card-${tag.tag_id}`}
+        // PSY-498: reset the two-tap cycle when the user explicitly
+        // dismisses — Escape or focus moved outside. Pointer-down-outside
+        // has an extra branch to keep the second tap on our own trigger
+        // from getting eaten by Radix's dismissable layer (see
+        // handlePointerDownOutside).
+        onEscapeKeyDown={handleCardDismiss}
+        onPointerDownOutside={handlePointerDownOutside}
+        onFocusOutside={handleCardDismiss}
       >
-        <TagAttributionContent tag={tag} />
+        <TagAttributionContent
+          tag={tag}
+          // PSY-498: on coarse-pointer devices we surface vote buttons inside
+          // the card (they don't render next-to-pill). Passing the handler +
+          // the user's current vote lets the card render a full-sized, tap-
+          // friendly Upvote/Downvote pair without the pill itself competing
+          // for the tap target.
+          showVoteActions={Boolean(isAuthenticated && isCoarsePointer)}
+          userVote={userVote}
+          onVote={onVote}
+        />
       </HoverCardContent>
     </HoverCard>
   )
@@ -422,7 +570,20 @@ function TagWithVotes({
 // PSY-441 — surfaces who added the tag + vote counts + a direct link to the
 // tag detail page. Lives as a separate component so the test suite can assert
 // on the rendered content without driving the Radix hover interaction.
-function TagAttributionContent({ tag }: { tag: EntityTag }) {
+//
+// PSY-498 — on coarse-pointer devices the pill's inline vote buttons migrate
+// into the card (see `showVoteActions`) so the pill stays a clean tap target.
+function TagAttributionContent({
+  tag,
+  showVoteActions = false,
+  userVote = 0,
+  onVote,
+}: {
+  tag: EntityTag
+  showVoteActions?: boolean
+  userVote?: number
+  onVote?: (tag: EntityTag, isUpvote: boolean) => void
+}) {
   return (
     <div className="space-y-2">
       <div className="flex items-center gap-1.5">
@@ -475,6 +636,47 @@ function TagAttributionContent({ tag }: { tag: EntityTag }) {
         <span className="font-medium text-foreground">{tag.downvotes}</span>{' '}
         {tag.downvotes === 1 ? 'downvote' : 'downvotes'}
       </p>
+
+      {showVoteActions && onVote && (
+        // PSY-498: touch-only vote controls. On coarse-pointer devices the
+        // inline next-to-pill vote buttons disappear, so the card is the only
+        // vote affordance. Buttons are full-width tap targets (44px tall via
+        // padding) to comply with WCAG touch-target guidance, and labelled
+        // with the tag name so screen readers can disambiguate between pills.
+        <div
+          className="flex items-stretch gap-2 pt-1"
+          data-testid={`tag-pill-card-vote-actions-${tag.tag_id}`}
+        >
+          <button
+            onClick={() => onVote(tag, true)}
+            className={cn(
+              'flex-1 inline-flex items-center justify-center gap-1.5 rounded-md border px-3 py-2 text-xs font-medium transition-colors',
+              userVote === 1
+                ? 'border-green-500/40 bg-green-500/10 text-green-600'
+                : 'border-input text-muted-foreground hover:text-green-600 hover:border-green-500/40'
+            )}
+            aria-label={`Upvote ${tag.name}`}
+            aria-pressed={userVote === 1}
+          >
+            <ThumbsUp className="h-3.5 w-3.5" />
+            Upvote
+          </button>
+          <button
+            onClick={() => onVote(tag, false)}
+            className={cn(
+              'flex-1 inline-flex items-center justify-center gap-1.5 rounded-md border px-3 py-2 text-xs font-medium transition-colors',
+              userVote === -1
+                ? 'border-red-500/40 bg-red-500/10 text-red-600'
+                : 'border-input text-muted-foreground hover:text-red-600 hover:border-red-500/40'
+            )}
+            aria-label={`Downvote ${tag.name}`}
+            aria-pressed={userVote === -1}
+          >
+            <ThumbsDown className="h-3.5 w-3.5" />
+            Downvote
+          </button>
+        </div>
+      )}
 
       <Link
         href={`/tags/${tag.slug}`}


### PR DESCRIPTION
## Summary

Mobile (`pointer: coarse`) users used to single-tap tag pills straight into `/tags/<slug>`, so the attribution hover card that PSY-441 + PSY-479 wire up — per-application "Added by @X · Nm ago", vote totals, the View link — was **invisible on mobile**. The destination tag detail page does not render per-association attribution, so the headline data had no mobile surface.

This PR adopts the Twitter/X profile-card two-tap pattern:
- **Tap 1** on a pill (touch devices only): opens the hover card, suppresses link navigation via `preventDefault`.
- **Tap 2** on the same pill: lets the link navigate as normal.
- **Desktop hover + click** are untouched.

Vote buttons on touch devices move from next-to-pill into the card so the pill stays a clean tap target.

## Before vs. after

| Interaction | Before | After |
|---|---|---|
| Desktop hover (fine pointer) | Card opens on hover | Card opens on hover *(unchanged)* |
| Desktop click on pill link (fine pointer) | Navigates to `/tags/<slug>` | Navigates to `/tags/<slug>` *(unchanged)* |
| Touch tap 1 on pill (coarse pointer) | Navigates immediately — **attribution skipped** | Opens hover card — attribution + votes visible |
| Touch tap 2 on pill (coarse pointer) | (n/a — already navigated) | Navigates to `/tags/<slug>` |
| Touch dismiss (Escape, outside tap, focus-outside) | — | Resets two-tap cycle |
| Touch vote buttons | Next to pill, tiny | Inside card, full-width Upvote/Downvote pair |

## Mobile hover card contents

All present in the card after tap 1 on a touch device:
- `#<tagname>` canonical link + official indicator (when applicable)
- `Added by @<user> · <relative time>` attribution line (or `Source: system seed` for null-username rows)
- `<upvotes> upvote(s) · <downvotes> downvote(s)` count row
- **Upvote / Downvote** full-width tap-target buttons (only on touch — desktop keeps the inline next-to-pill pair)
- `View tag details` link

## Implementation notes

- `useIsCoarsePointer` — SSR-safe hook using `useSyncExternalStore` over `matchMedia('(pointer: coarse)')`. Local to `EntityTagList.tsx` (single caller).
- `tapOpenedRef` — `useRef<boolean>`, not state. Touch tap 1 sets it; touch tap 2 reads-and-clears it synchronously inside the same click handler. Explicit dismissals clear it.
- Radix's `DismissableLayer` treats the trigger as "outside content" and would fire `onDismiss` on tap 2's pointerdown, closing the card before our click handler sees `open=true`. `handlePointerDownOutside` intercepts the layer event and calls `event.preventDefault()` when the pointerdown landed on our own trigger, keeping the two-tap cycle intact. Genuine outside taps still dismiss and reset the ref.
- On desktop (fine pointer), none of the coarse-pointer branches run — the PSY-441 click-toggle on empty pill space and the link's navigate-on-click behavior are byte-for-byte preserved.

## Test plan

### Added (`frontend/features/tags/components/EntityTagList.test.tsx`, new `describe` block: `EntityTagList tag pill two-tap on touch devices (PSY-498)`)

- [x] `opens the card on the first tap and navigates only on the second tap` — overrides `matchMedia('(pointer: coarse)')` to return true, asserts first-tap `defaultPrevented=true` + card visible, asserts second-tap `defaultPrevented=false`.
- [x] `keeps desktop click-through untouched (pointer: fine → single click navigates)` — regression guard: `defaultPrevented=false` on single click when matchMedia returns false.
- [x] `moves the vote buttons from next-to-pill into the attribution card on touch devices` — inline buttons absent, card's `tag-pill-card-vote-actions-<id>` testid present with both Upvote and Downvote; attribution + View link still render.
- [x] `keeps vote buttons inline (next to the pill) and out of the card on desktop` — desktop fine-pointer still renders inline votes and does NOT duplicate them inside the card.
- [x] `resets the two-tap flag when the card closes (dismiss → fresh two-tap cycle)` — tap 1 → outside-click dismiss → tap 3 re-opens the card (does not navigate), confirming the ref resets on genuine dismissal.

All 46 tests in `EntityTagList.test.tsx` pass; all 218 tests across `features/tags/` pass; full frontend suite (2706 tests) passes. `tsc --noEmit` clean; no new lint errors.

### Manual device/devtools repro

- [ ] Chrome DevTools → Device Toolbar → iPhone 12 Pro (375px). Tap a tag pill on `/artists/faetooth`. First tap: attribution card appears. Second tap on the same pill: navigates to `/tags/<slug>`.
- [ ] Same device → tap pill, then tap somewhere else on the page. Card dismisses. Tap the pill again: first tap re-opens the card (does not navigate).
- [ ] Desktop Chrome at 1280px. Hover a pill: card appears. Click a pill: navigates to `/tags/<slug>` in a single click (no two-tap on desktop).

Closes PSY-498

🤖 Generated with [Claude Code](https://claude.com/claude-code)