### PR TITLE
PSY-502: Ignore local Claude Code and Playwright artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,15 @@ scripts/test-runner/test-runner
 # Claude Code worktrees
 .claude/worktrees/
 
+# Claude Code runtime state
+.claude/scheduled_tasks.lock
+
+# Local-only skill (not ready to share)
+.claude/skills/psy-ticket/
+
+# Playwright blob-reporter output (CI-only reporter; local artifacts)
+frontend/blob-report/
+
 # Dogfood QA output
 dogfood-output*/
 


### PR DESCRIPTION
## Summary

- Adds targeted `.gitignore` entries for three local-only paths that currently show as untracked on a fresh clone:
  - `.claude/scheduled_tasks.lock` — Claude Code runtime lock
  - `.claude/skills/psy-ticket/` — local-only skill
  - `frontend/blob-report/` — Playwright CI blob reporter output
- Keeps the existing `.claude/worktrees/` rule narrow — no blanket ignore under `.claude/`.

## Test plan

- [x] `git check-ignore -v <path>` matches each new entry explicitly
- [x] `git status` on a fresh working tree no longer lists the three paths
- [x] No other `.claude/*` files are newly suppressed

Closes PSY-502