### PR TITLE
PSY-504: enable community edits for labels (backend)

### DIFF
--- a/backend/internal/api/handlers/data_gaps.go
+++ b/backend/internal/api/handlers/data_gaps.go
@@ -26,6 +26,7 @@ type DataGapsHandler struct {
 	venueService    contracts.VenueServiceInterface
 	festivalService contracts.FestivalServiceInterface
 	releaseService  contracts.ReleaseServiceInterface
+	labelService    contracts.LabelServiceInterface
 }
 
 // NewDataGapsHandler creates a new data gaps handler.
@@ -34,18 +35,20 @@ func NewDataGapsHandler(
 	venueService contracts.VenueServiceInterface,
 	festivalService contracts.FestivalServiceInterface,
 	releaseService contracts.ReleaseServiceInterface,
+	labelService contracts.LabelServiceInterface,
 ) *DataGapsHandler {
 	return &DataGapsHandler{
 		artistService:   artistService,
 		venueService:    venueService,
 		festivalService: festivalService,
 		releaseService:  releaseService,
+		labelService:    labelService,
 	}
 }
 
 // GetDataGapsRequest is the Huma request for GET /entities/{entity_type}/{id_or_slug}/data-gaps
 type GetDataGapsRequest struct {
-	EntityType string `path:"entity_type" doc:"Entity type: artist, venue, festival, or release" example:"artist"`
+	EntityType string `path:"entity_type" doc:"Entity type: artist, venue, festival, release, or label" example:"artist"`
 	IDOrSlug   string `path:"id_or_slug" doc:"Entity ID or slug" example:"the-national"`
 }
 
@@ -76,8 +79,10 @@ func (h *DataGapsHandler) GetDataGapsHandler(ctx context.Context, req *GetDataGa
 		gaps, err = h.getFestivalGaps(req.IDOrSlug)
 	case "release":
 		gaps, err = h.getReleaseGaps(req.IDOrSlug)
+	case "label":
+		gaps, err = h.getLabelGaps(req.IDOrSlug)
 	default:
-		return nil, huma.Error400BadRequest("Invalid entity type: must be artist, venue, festival, or release")
+		return nil, huma.Error400BadRequest("Invalid entity type: must be artist, venue, festival, release, or label")
 	}
 
 	if err != nil {
@@ -86,6 +91,7 @@ func (h *DataGapsHandler) GetDataGapsHandler(ctx context.Context, req *GetDataGa
 		var venueErr *apperrors.VenueError
 		var festivalErr *apperrors.FestivalError
 		var releaseErr *apperrors.ReleaseError
+		var labelErr *apperrors.LabelError
 		if errors.As(err, &artistErr) && artistErr.Code == apperrors.CodeArtistNotFound {
 			return nil, huma.Error404NotFound("Artist not found")
 		}
@@ -97,6 +103,9 @@ func (h *DataGapsHandler) GetDataGapsHandler(ctx context.Context, req *GetDataGa
 		}
 		if errors.As(err, &releaseErr) && releaseErr.Code == apperrors.CodeReleaseNotFound {
 			return nil, huma.Error404NotFound("Release not found")
+		}
+		if errors.As(err, &labelErr) && labelErr.Code == apperrors.CodeLabelNotFound {
+			return nil, huma.Error404NotFound("Label not found")
 		}
 		logger.FromContext(ctx).Error("data_gaps_fetch_failed",
 			"entity_type", req.EntityType,
@@ -243,6 +252,41 @@ func (h *DataGapsHandler) getReleaseGaps(idOrSlug string) ([]DataGap, error) {
 	}
 	if isEmptyPtr(release.Description) {
 		gaps = append(gaps, DataGap{Field: "description", Label: "Description", Priority: 4})
+	}
+
+	return gaps, nil
+}
+
+// getLabelGaps fetches a label and returns missing fields as data gaps.
+func (h *DataGapsHandler) getLabelGaps(idOrSlug string) ([]DataGap, error) {
+	var label *contracts.LabelDetailResponse
+	var err error
+
+	if id, parseErr := strconv.ParseUint(idOrSlug, 10, 32); parseErr == nil {
+		label, err = h.labelService.GetLabel(uint(id))
+	} else {
+		label, err = h.labelService.GetLabelBySlug(idOrSlug)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var gaps []DataGap
+
+	if isEmptyPtr(label.Social.Website) {
+		gaps = append(gaps, DataGap{Field: "website", Label: "Website", Priority: 1})
+	}
+	if isEmptyPtr(label.Social.Bandcamp) {
+		gaps = append(gaps, DataGap{Field: "bandcamp", Label: "Bandcamp URL", Priority: 2})
+	}
+	if isEmptyPtr(label.Social.Instagram) {
+		gaps = append(gaps, DataGap{Field: "instagram", Label: "Instagram", Priority: 3})
+	}
+	if isEmptyPtr(label.Description) {
+		gaps = append(gaps, DataGap{Field: "description", Label: "Description", Priority: 4})
+	}
+	if label.FoundedYear == nil {
+		gaps = append(gaps, DataGap{Field: "founded_year", Label: "Founded Year", Priority: 5})
 	}
 
 	return gaps, nil

--- a/backend/internal/api/handlers/data_gaps_test.go
+++ b/backend/internal/api/handlers/data_gaps_test.go
@@ -17,7 +17,7 @@ import (
 // ============================================================================
 
 func testDataGapsHandler() *DataGapsHandler {
-	return NewDataGapsHandler(&mockArtistService{}, &mockVenueService{}, &mockFestivalService{}, &mockReleaseService{})
+	return NewDataGapsHandler(&mockArtistService{}, &mockVenueService{}, &mockFestivalService{}, &mockReleaseService{}, &mockLabelService{})
 }
 
 func dataGapsCtxWithUser() context.Context {
@@ -45,6 +45,7 @@ func TestDataGapsHandler_Artist_WithMissingFields(t *testing.T) {
 		&mockVenueService{},
 		&mockFestivalService{},
 		&mockReleaseService{},
+		&mockLabelService{},
 	)
 
 	resp, err := h.GetDataGapsHandler(dataGapsCtxWithUser(), &GetDataGapsRequest{
@@ -99,6 +100,7 @@ func TestDataGapsHandler_Artist_Complete(t *testing.T) {
 		&mockVenueService{},
 		&mockFestivalService{},
 		&mockReleaseService{},
+		&mockLabelService{},
 	)
 
 	resp, err := h.GetDataGapsHandler(dataGapsCtxWithUser(), &GetDataGapsRequest{
@@ -135,6 +137,7 @@ func TestDataGapsHandler_Venue_WithMissingFields(t *testing.T) {
 		},
 		&mockFestivalService{},
 		&mockReleaseService{},
+		&mockLabelService{},
 	)
 
 	resp, err := h.GetDataGapsHandler(dataGapsCtxWithUser(), &GetDataGapsRequest{
@@ -174,6 +177,7 @@ func TestDataGapsHandler_Festival_WithMissingFields(t *testing.T) {
 			},
 		},
 		&mockReleaseService{},
+		&mockLabelService{},
 	)
 
 	resp, err := h.GetDataGapsHandler(dataGapsCtxWithUser(), &GetDataGapsRequest{
@@ -218,6 +222,7 @@ func TestDataGapsHandler_NotFound(t *testing.T) {
 			},
 		},
 		&mockReleaseService{},
+		&mockLabelService{},
 	)
 
 	tests := []struct {
@@ -271,6 +276,7 @@ func TestDataGapsHandler_ServiceError(t *testing.T) {
 		&mockVenueService{},
 		&mockFestivalService{},
 		&mockReleaseService{},
+		&mockLabelService{},
 	)
 
 	_, err := h.GetDataGapsHandler(dataGapsCtxWithUser(), &GetDataGapsRequest{
@@ -298,6 +304,7 @@ func TestDataGapsHandler_NumericID(t *testing.T) {
 		&mockVenueService{},
 		&mockFestivalService{},
 		&mockReleaseService{},
+		&mockLabelService{},
 	)
 
 	resp, err := h.GetDataGapsHandler(dataGapsCtxWithUser(), &GetDataGapsRequest{
@@ -331,6 +338,7 @@ func TestDataGapsHandler_EmptyStringNotAGap(t *testing.T) {
 		&mockVenueService{},
 		&mockFestivalService{},
 		&mockReleaseService{},
+		&mockLabelService{},
 	)
 
 	resp, err := h.GetDataGapsHandler(dataGapsCtxWithUser(), &GetDataGapsRequest{

--- a/backend/internal/api/handlers/label.go
+++ b/backend/internal/api/handlers/label.go
@@ -10,18 +10,21 @@ import (
 
 	apperrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/logger"
+	"psychic-homily-backend/internal/models"
 	"psychic-homily-backend/internal/services/contracts"
 )
 
 type LabelHandler struct {
 	labelService    contracts.LabelServiceInterface
 	auditLogService contracts.AuditLogServiceInterface
+	revisionService contracts.RevisionServiceInterface
 }
 
-func NewLabelHandler(labelService contracts.LabelServiceInterface, auditLogService contracts.AuditLogServiceInterface) *LabelHandler {
+func NewLabelHandler(labelService contracts.LabelServiceInterface, auditLogService contracts.AuditLogServiceInterface, revisionService contracts.RevisionServiceInterface) *LabelHandler {
 	return &LabelHandler{
 		labelService:    labelService,
 		auditLogService: auditLogService,
+		revisionService: revisionService,
 	}
 }
 
@@ -255,6 +258,7 @@ type UpdateLabelRequest struct {
 		SoundCloud  *string `json:"soundcloud,omitempty" required:"false" doc:"SoundCloud URL"`
 		Bandcamp    *string `json:"bandcamp,omitempty" required:"false" doc:"Bandcamp URL"`
 		Website     *string `json:"website,omitempty" required:"false" doc:"Website URL"`
+		Summary     *string `json:"summary,omitempty" required:"false" doc:"Revision summary describing the change"`
 	}
 }
 
@@ -276,6 +280,12 @@ func (h *LabelHandler) UpdateLabelHandler(ctx context.Context, req *UpdateLabelR
 	labelID, err := h.resolveLabelID(req.LabelID)
 	if err != nil {
 		return nil, err
+	}
+
+	// Capture old values for revision diff (fire-and-forget safe)
+	var oldLabel *contracts.LabelDetailResponse
+	if h.revisionService != nil {
+		oldLabel, _ = h.labelService.GetLabel(labelID)
 	}
 
 	serviceReq := &contracts.UpdateLabelRequest{
@@ -319,6 +329,25 @@ func (h *LabelHandler) UpdateLabelHandler(ctx context.Context, req *UpdateLabelR
 		}()
 	}
 
+	// Record revision (fire and forget)
+	if h.revisionService != nil && oldLabel != nil {
+		go func() {
+			changes := computeLabelChanges(oldLabel, label)
+			if len(changes) > 0 {
+				summary := ""
+				if req.Body.Summary != nil {
+					summary = *req.Body.Summary
+				}
+				if err := h.revisionService.RecordRevision("label", labelID, user.ID, changes, summary); err != nil {
+					logger.Default().Error("record_label_revision_failed",
+						"label_id", labelID,
+						"error", err.Error(),
+					)
+				}
+			}
+		}()
+	}
+
 	logger.FromContext(ctx).Info("label_updated",
 		"label_id", labelID,
 		"admin_id", user.ID,
@@ -326,6 +355,59 @@ func (h *LabelHandler) UpdateLabelHandler(ctx context.Context, req *UpdateLabelR
 	)
 
 	return &UpdateLabelResponse{Body: label}, nil
+}
+
+// computeLabelChanges compares old and new label detail responses and returns field-level diffs.
+func computeLabelChanges(old, new *contracts.LabelDetailResponse) []models.FieldChange {
+	var changes []models.FieldChange
+
+	if old.Name != new.Name {
+		changes = append(changes, models.FieldChange{Field: "name", OldValue: old.Name, NewValue: new.Name})
+	}
+	if ptrToStr(old.City) != ptrToStr(new.City) {
+		changes = append(changes, models.FieldChange{Field: "city", OldValue: ptrToStr(old.City), NewValue: ptrToStr(new.City)})
+	}
+	if ptrToStr(old.State) != ptrToStr(new.State) {
+		changes = append(changes, models.FieldChange{Field: "state", OldValue: ptrToStr(old.State), NewValue: ptrToStr(new.State)})
+	}
+	if ptrToStr(old.Country) != ptrToStr(new.Country) {
+		changes = append(changes, models.FieldChange{Field: "country", OldValue: ptrToStr(old.Country), NewValue: ptrToStr(new.Country)})
+	}
+	if !intPtrEq(old.FoundedYear, new.FoundedYear) {
+		changes = append(changes, models.FieldChange{Field: "founded_year", OldValue: intPtrVal(old.FoundedYear), NewValue: intPtrVal(new.FoundedYear)})
+	}
+	if old.Status != new.Status {
+		changes = append(changes, models.FieldChange{Field: "status", OldValue: old.Status, NewValue: new.Status})
+	}
+	if ptrToStr(old.Description) != ptrToStr(new.Description) {
+		changes = append(changes, models.FieldChange{Field: "description", OldValue: ptrToStr(old.Description), NewValue: ptrToStr(new.Description)})
+	}
+	if ptrToStr(old.Social.Instagram) != ptrToStr(new.Social.Instagram) {
+		changes = append(changes, models.FieldChange{Field: "instagram", OldValue: ptrToStr(old.Social.Instagram), NewValue: ptrToStr(new.Social.Instagram)})
+	}
+	if ptrToStr(old.Social.Facebook) != ptrToStr(new.Social.Facebook) {
+		changes = append(changes, models.FieldChange{Field: "facebook", OldValue: ptrToStr(old.Social.Facebook), NewValue: ptrToStr(new.Social.Facebook)})
+	}
+	if ptrToStr(old.Social.Twitter) != ptrToStr(new.Social.Twitter) {
+		changes = append(changes, models.FieldChange{Field: "twitter", OldValue: ptrToStr(old.Social.Twitter), NewValue: ptrToStr(new.Social.Twitter)})
+	}
+	if ptrToStr(old.Social.YouTube) != ptrToStr(new.Social.YouTube) {
+		changes = append(changes, models.FieldChange{Field: "youtube", OldValue: ptrToStr(old.Social.YouTube), NewValue: ptrToStr(new.Social.YouTube)})
+	}
+	if ptrToStr(old.Social.Spotify) != ptrToStr(new.Social.Spotify) {
+		changes = append(changes, models.FieldChange{Field: "spotify", OldValue: ptrToStr(old.Social.Spotify), NewValue: ptrToStr(new.Social.Spotify)})
+	}
+	if ptrToStr(old.Social.SoundCloud) != ptrToStr(new.Social.SoundCloud) {
+		changes = append(changes, models.FieldChange{Field: "soundcloud", OldValue: ptrToStr(old.Social.SoundCloud), NewValue: ptrToStr(new.Social.SoundCloud)})
+	}
+	if ptrToStr(old.Social.Bandcamp) != ptrToStr(new.Social.Bandcamp) {
+		changes = append(changes, models.FieldChange{Field: "bandcamp", OldValue: ptrToStr(old.Social.Bandcamp), NewValue: ptrToStr(new.Social.Bandcamp)})
+	}
+	if ptrToStr(old.Social.Website) != ptrToStr(new.Social.Website) {
+		changes = append(changes, models.FieldChange{Field: "website", OldValue: ptrToStr(old.Social.Website), NewValue: ptrToStr(new.Social.Website)})
+	}
+
+	return changes
 }
 
 // ============================================================================

--- a/backend/internal/api/handlers/label_integration_test.go
+++ b/backend/internal/api/handlers/label_integration_test.go
@@ -18,7 +18,7 @@ type LabelHandlerIntegrationSuite struct {
 
 func (s *LabelHandlerIntegrationSuite) SetupSuite() {
 	s.deps = setupHandlerIntegrationDeps(s.T())
-	s.handler = NewLabelHandler(s.deps.labelService, s.deps.auditLogService)
+	s.handler = NewLabelHandler(s.deps.labelService, s.deps.auditLogService, nil)
 }
 
 func (s *LabelHandlerIntegrationSuite) TearDownTest() {

--- a/backend/internal/api/handlers/pending_edit.go
+++ b/backend/internal/api/handlers/pending_edit.go
@@ -57,6 +57,13 @@ var allowedEditFields = map[string]map[string]bool{
 		"title": true, "release_year": true, "release_date": true,
 		"release_type": true, "cover_art_url": true, "description": true,
 	},
+	"label": {
+		"name": true, "founded_year": true,
+		"city": true, "state": true, "country": true, "description": true,
+		"instagram": true, "facebook": true, "twitter": true,
+		"youtube": true, "spotify": true, "soundcloud": true,
+		"bandcamp": true, "website": true,
+	},
 }
 
 // canEditDirectly returns true if the user can bypass the pending queue.
@@ -109,6 +116,11 @@ func (h *PendingEditHandler) SuggestFestivalEditHandler(ctx context.Context, req
 // SuggestReleaseEditHandler handles PUT /releases/{entity_id}/suggest-edit
 func (h *PendingEditHandler) SuggestReleaseEditHandler(ctx context.Context, req *SuggestEntityEditRequest) (*SuggestEntityEditResponse, error) {
 	return h.suggestEdit(ctx, "release", req)
+}
+
+// SuggestLabelEditHandler handles PUT /labels/{entity_id}/suggest-edit
+func (h *PendingEditHandler) SuggestLabelEditHandler(ctx context.Context, req *SuggestEntityEditRequest) (*SuggestEntityEditResponse, error) {
+	return h.suggestEdit(ctx, "label", req)
 }
 
 // suggestEdit is the shared implementation for all suggest-edit endpoints.
@@ -299,7 +311,7 @@ func (h *PendingEditHandler) CancelMyPendingEditHandler(ctx context.Context, req
 // AdminListPendingEditsRequest is the Huma request for GET /admin/pending-edits
 type AdminListPendingEditsRequest struct {
 	Status     string `query:"status" required:"false" doc:"Filter by status (pending, approved, rejected)"`
-	EntityType string `query:"entity_type" required:"false" doc:"Filter by entity type (artist, venue, festival, release)"`
+	EntityType string `query:"entity_type" required:"false" doc:"Filter by entity type (artist, venue, festival, release, label)"`
 	Limit      int    `query:"limit" required:"false" doc:"Max results (default 20, max 100)"`
 	Offset     int    `query:"offset" required:"false" doc:"Offset for pagination"`
 }
@@ -501,7 +513,7 @@ func (h *PendingEditHandler) AdminRejectPendingEditHandler(ctx context.Context, 
 
 // AdminGetEntityPendingEditsRequest is the Huma request for GET /admin/pending-edits/entity/{entity_type}/{entity_id}
 type AdminGetEntityPendingEditsRequest struct {
-	EntityType string `path:"entity_type" doc:"Entity type (artist, venue, festival, release)"`
+	EntityType string `path:"entity_type" doc:"Entity type (artist, venue, festival, release, label)"`
 	EntityID   string `path:"entity_id" doc:"Entity ID"`
 }
 

--- a/backend/internal/api/handlers/search_test.go
+++ b/backend/internal/api/handlers/search_test.go
@@ -84,7 +84,7 @@ func TestSearchLabels_Success(t *testing.T) {
 			}, nil
 		},
 	}
-	h := NewLabelHandler(mock, nil)
+	h := NewLabelHandler(mock, nil, nil)
 
 	resp, err := h.SearchLabelsHandler(context.Background(), &SearchLabelsRequest{Query: "sub pop"})
 	if err != nil {
@@ -104,7 +104,7 @@ func TestSearchLabels_EmptyQuery(t *testing.T) {
 			return []*contracts.LabelListResponse{}, nil
 		},
 	}
-	h := NewLabelHandler(mock, nil)
+	h := NewLabelHandler(mock, nil, nil)
 
 	resp, err := h.SearchLabelsHandler(context.Background(), &SearchLabelsRequest{Query: ""})
 	if err != nil {
@@ -121,7 +121,7 @@ func TestSearchLabels_ServiceError(t *testing.T) {
 			return nil, fmt.Errorf("db error")
 		},
 	}
-	h := NewLabelHandler(mock, nil)
+	h := NewLabelHandler(mock, nil, nil)
 
 	_, err := h.SearchLabelsHandler(context.Background(), &SearchLabelsRequest{Query: "test"})
 	if err == nil {

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -374,7 +374,7 @@ func setupReleaseRoutes(rc RouteContext) {
 }
 
 func setupLabelRoutes(rc RouteContext) {
-	labelHandler := handlers.NewLabelHandler(rc.SC.Label, rc.SC.AuditLog)
+	labelHandler := handlers.NewLabelHandler(rc.SC.Label, rc.SC.AuditLog, rc.SC.Revision)
 
 	// Public label endpoints
 	// Note: Static routes must come before parameterized routes
@@ -1021,6 +1021,7 @@ func setupPendingEditRoutes(rc RouteContext) {
 	huma.Put(rc.Protected, "/venues/{entity_id}/suggest-edit", pendingEditHandler.SuggestVenueEditHandler)
 	huma.Put(rc.Protected, "/festivals/{entity_id}/suggest-edit", pendingEditHandler.SuggestFestivalEditHandler)
 	huma.Put(rc.Protected, "/releases/{entity_id}/suggest-edit", pendingEditHandler.SuggestReleaseEditHandler)
+	huma.Put(rc.Protected, "/labels/{entity_id}/suggest-edit", pendingEditHandler.SuggestLabelEditHandler)
 
 	// Protected: user's own pending edits
 	huma.Get(rc.Protected, "/my/pending-edits", pendingEditHandler.GetMyPendingEditsHandler)
@@ -1088,7 +1089,7 @@ func setupLeaderboardRoutes(rc RouteContext) {
 
 // setupDataGapsRoutes configures entity data-gap detection endpoints (protected).
 func setupDataGapsRoutes(rc RouteContext) {
-	dataGapsHandler := handlers.NewDataGapsHandler(rc.SC.Artist, rc.SC.Venue, rc.SC.Festival, rc.SC.Release)
+	dataGapsHandler := handlers.NewDataGapsHandler(rc.SC.Artist, rc.SC.Venue, rc.SC.Festival, rc.SC.Release, rc.SC.Label)
 	huma.Get(rc.Protected, "/entities/{entity_type}/{id_or_slug}/data-gaps", dataGapsHandler.GetDataGapsHandler)
 }
 

--- a/backend/internal/models/pending_entity_edit.go
+++ b/backend/internal/models/pending_entity_edit.go
@@ -20,6 +20,7 @@ const (
 	PendingEditEntityVenue    = "venue"
 	PendingEditEntityFestival = "festival"
 	PendingEditEntityRelease  = "release"
+	PendingEditEntityLabel    = "label"
 )
 
 // PendingEntityEdit represents a proposed edit to an entity awaiting review.
@@ -52,6 +53,7 @@ func ValidPendingEditEntityTypes() []string {
 		PendingEditEntityVenue,
 		PendingEditEntityFestival,
 		PendingEditEntityRelease,
+		PendingEditEntityLabel,
 	}
 }
 

--- a/backend/internal/services/admin/pending_edit.go
+++ b/backend/internal/services/admin/pending_edit.go
@@ -496,6 +496,17 @@ func (s *PendingEditService) resolveEntityInfo(entityType string, entityID uint)
 				url = fmt.Sprintf("%s/releases/%s", s.frontendURL, *release.Slug)
 			}
 		}
+	case "label":
+		var label struct {
+			Name string
+			Slug *string
+		}
+		if err := s.db.Table("labels").Select("name, slug").Where("id = ?", entityID).Scan(&label).Error; err == nil {
+			name = label.Name
+			if label.Slug != nil && *label.Slug != "" {
+				url = fmt.Sprintf("%s/labels/%s", s.frontendURL, *label.Slug)
+			}
+		}
 	}
 
 	return name, url

--- a/backend/internal/services/admin/pending_edit_test.go
+++ b/backend/internal/services/admin/pending_edit_test.go
@@ -24,9 +24,10 @@ func TestIsValidPendingEditEntityType(t *testing.T) {
 	assert.True(t, models.IsValidPendingEditEntityType("venue"))
 	assert.True(t, models.IsValidPendingEditEntityType("festival"))
 	assert.True(t, models.IsValidPendingEditEntityType("release"))
+	assert.True(t, models.IsValidPendingEditEntityType("label"))
 	assert.False(t, models.IsValidPendingEditEntityType("show"))
 	assert.False(t, models.IsValidPendingEditEntityType(""))
-	assert.False(t, models.IsValidPendingEditEntityType("label"))
+	assert.False(t, models.IsValidPendingEditEntityType("comment"))
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Mechanical extension of the shared infrastructure established in PSY-492 (#439) to cover the `label` entity type. Unblocks [PSY-493](https://linear.app/psychic-homily/issue/PSY-493) (LabelDetail frontend wiring).

The contract-drift test added in PSY-492 auto-guarded every required wiring point — forgetting any of `allowedEditFields`, `SuggestLabelEditHandler`, `resolveEntityInfo` case, `data-gaps` case, or `RecordRevision` wiring would have surfaced as a test failure.

## What ships

- `PendingEditEntityLabel = "label"` added to model allowlist; test updated
- `resolveEntityInfo` case in `services/admin/pending_edit.go` (label lookup + `/labels/{slug}` URL)
- `data-gaps` case + `getLabelGaps` in `handlers/data_gaps.go` (`labelService` added to constructor)
- `label` entry in `allowedEditFields` (14 editable fields: name, founded_year, city, state, country, description, + 8 social)
- `SuggestLabelEditHandler` + `PUT /labels/{entity_id}/suggest-edit`
- `computeLabelChanges` diff utility; `revisionService` wired into `LabelHandler`; `Summary` added to `UpdateLabelRequest.Body`
- Revision recording in `UpdateLabelHandler` via fire-and-forget goroutine (matches `artist.go` / `release.go` pattern)

## Design choice: `status` excluded from editable fields

`LabelStatus` (`active`, `inactive`, `defunct`) is controlled-enum admin-only territory. Flipping a label to `defunct` via the community suggest-edit queue would be an unusual moderation load. Kept admin-only; `UpdateLabelRequest` still accepts it via the direct admin PUT.

## Test plan

- [x] `go test ./...` backend — all packages green (admin 44s, catalog 46s integration suites included)
- [x] `go vet ./...` clean
- [x] Contract-drift tests pass with label included (`TestAllowedEditFieldsCoversAllTypes`, `TestSuggestEditHandlerExistsForAllTypes`, `TestDataGapsHandlerAcceptsAllEntityTypes/label`)
- [ ] Manual smoke post-deploy: submit label edit as non-trusted user, approve as admin, verify revision history populates on LabelDetail once PSY-493 ships the UI.

## Dependency tree

```
PSY-492 (merged) ──► PSY-504 (this) ──► PSY-493 (LabelDetail frontend)
         │
         └──────────► PSY-505 (ReleaseDetail drawer frontend)
```

Closes PSY-504