### PR TITLE
PSY-492: Enable community edits for releases + contract-drift test

### DIFF
--- a/backend/internal/api/handlers/data_gaps.go
+++ b/backend/internal/api/handlers/data_gaps.go
@@ -25,6 +25,7 @@ type DataGapsHandler struct {
 	artistService   contracts.ArtistServiceInterface
 	venueService    contracts.VenueServiceInterface
 	festivalService contracts.FestivalServiceInterface
+	releaseService  contracts.ReleaseServiceInterface
 }
 
 // NewDataGapsHandler creates a new data gaps handler.
@@ -32,17 +33,19 @@ func NewDataGapsHandler(
 	artistService contracts.ArtistServiceInterface,
 	venueService contracts.VenueServiceInterface,
 	festivalService contracts.FestivalServiceInterface,
+	releaseService contracts.ReleaseServiceInterface,
 ) *DataGapsHandler {
 	return &DataGapsHandler{
 		artistService:   artistService,
 		venueService:    venueService,
 		festivalService: festivalService,
+		releaseService:  releaseService,
 	}
 }
 
 // GetDataGapsRequest is the Huma request for GET /entities/{entity_type}/{id_or_slug}/data-gaps
 type GetDataGapsRequest struct {
-	EntityType string `path:"entity_type" doc:"Entity type: artist, venue, or festival" example:"artist"`
+	EntityType string `path:"entity_type" doc:"Entity type: artist, venue, festival, or release" example:"artist"`
 	IDOrSlug   string `path:"id_or_slug" doc:"Entity ID or slug" example:"the-national"`
 }
 
@@ -71,8 +74,10 @@ func (h *DataGapsHandler) GetDataGapsHandler(ctx context.Context, req *GetDataGa
 		gaps, err = h.getVenueGaps(req.IDOrSlug)
 	case "festival":
 		gaps, err = h.getFestivalGaps(req.IDOrSlug)
+	case "release":
+		gaps, err = h.getReleaseGaps(req.IDOrSlug)
 	default:
-		return nil, huma.Error400BadRequest("Invalid entity type: must be artist, venue, or festival")
+		return nil, huma.Error400BadRequest("Invalid entity type: must be artist, venue, festival, or release")
 	}
 
 	if err != nil {
@@ -80,6 +85,7 @@ func (h *DataGapsHandler) GetDataGapsHandler(ctx context.Context, req *GetDataGa
 		var artistErr *apperrors.ArtistError
 		var venueErr *apperrors.VenueError
 		var festivalErr *apperrors.FestivalError
+		var releaseErr *apperrors.ReleaseError
 		if errors.As(err, &artistErr) && artistErr.Code == apperrors.CodeArtistNotFound {
 			return nil, huma.Error404NotFound("Artist not found")
 		}
@@ -88,6 +94,9 @@ func (h *DataGapsHandler) GetDataGapsHandler(ctx context.Context, req *GetDataGa
 		}
 		if errors.As(err, &festivalErr) && festivalErr.Code == apperrors.CodeFestivalNotFound {
 			return nil, huma.Error404NotFound("Festival not found")
+		}
+		if errors.As(err, &releaseErr) && releaseErr.Code == apperrors.CodeReleaseNotFound {
+			return nil, huma.Error404NotFound("Release not found")
 		}
 		logger.FromContext(ctx).Error("data_gaps_fetch_failed",
 			"entity_type", req.EntityType,
@@ -200,6 +209,35 @@ func (h *DataGapsHandler) getFestivalGaps(idOrSlug string) ([]DataGap, error) {
 		gaps = append(gaps, DataGap{Field: "flyer_url", Label: "Flyer", Priority: 2})
 	}
 	if isEmptyPtr(festival.Description) {
+		gaps = append(gaps, DataGap{Field: "description", Label: "Description", Priority: 3})
+	}
+
+	return gaps, nil
+}
+
+// getReleaseGaps fetches a release and returns missing fields as data gaps.
+func (h *DataGapsHandler) getReleaseGaps(idOrSlug string) ([]DataGap, error) {
+	var release *contracts.ReleaseDetailResponse
+	var err error
+
+	if id, parseErr := strconv.ParseUint(idOrSlug, 10, 32); parseErr == nil {
+		release, err = h.releaseService.GetRelease(uint(id))
+	} else {
+		release, err = h.releaseService.GetReleaseBySlug(idOrSlug)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var gaps []DataGap
+
+	if isEmptyPtr(release.CoverArtURL) {
+		gaps = append(gaps, DataGap{Field: "cover_art_url", Label: "Cover Art URL", Priority: 1})
+	}
+	if release.ReleaseYear == nil && isEmptyPtr(release.ReleaseDate) {
+		gaps = append(gaps, DataGap{Field: "release_year", Label: "Release Year", Priority: 2})
+	}
+	if isEmptyPtr(release.Description) {
 		gaps = append(gaps, DataGap{Field: "description", Label: "Description", Priority: 3})
 	}
 

--- a/backend/internal/api/handlers/data_gaps_test.go
+++ b/backend/internal/api/handlers/data_gaps_test.go
@@ -17,7 +17,7 @@ import (
 // ============================================================================
 
 func testDataGapsHandler() *DataGapsHandler {
-	return NewDataGapsHandler(&mockArtistService{}, &mockVenueService{}, &mockFestivalService{})
+	return NewDataGapsHandler(&mockArtistService{}, &mockVenueService{}, &mockFestivalService{}, &mockReleaseService{})
 }
 
 func dataGapsCtxWithUser() context.Context {
@@ -44,6 +44,7 @@ func TestDataGapsHandler_Artist_WithMissingFields(t *testing.T) {
 		},
 		&mockVenueService{},
 		&mockFestivalService{},
+		&mockReleaseService{},
 	)
 
 	resp, err := h.GetDataGapsHandler(dataGapsCtxWithUser(), &GetDataGapsRequest{
@@ -97,6 +98,7 @@ func TestDataGapsHandler_Artist_Complete(t *testing.T) {
 		},
 		&mockVenueService{},
 		&mockFestivalService{},
+		&mockReleaseService{},
 	)
 
 	resp, err := h.GetDataGapsHandler(dataGapsCtxWithUser(), &GetDataGapsRequest{
@@ -132,6 +134,7 @@ func TestDataGapsHandler_Venue_WithMissingFields(t *testing.T) {
 			},
 		},
 		&mockFestivalService{},
+		&mockReleaseService{},
 	)
 
 	resp, err := h.GetDataGapsHandler(dataGapsCtxWithUser(), &GetDataGapsRequest{
@@ -170,6 +173,7 @@ func TestDataGapsHandler_Festival_WithMissingFields(t *testing.T) {
 				}, nil
 			},
 		},
+		&mockReleaseService{},
 	)
 
 	resp, err := h.GetDataGapsHandler(dataGapsCtxWithUser(), &GetDataGapsRequest{
@@ -213,6 +217,7 @@ func TestDataGapsHandler_NotFound(t *testing.T) {
 				return nil, apperrors.ErrFestivalNotFound(0)
 			},
 		},
+		&mockReleaseService{},
 	)
 
 	tests := []struct {
@@ -265,6 +270,7 @@ func TestDataGapsHandler_ServiceError(t *testing.T) {
 		},
 		&mockVenueService{},
 		&mockFestivalService{},
+		&mockReleaseService{},
 	)
 
 	_, err := h.GetDataGapsHandler(dataGapsCtxWithUser(), &GetDataGapsRequest{
@@ -291,6 +297,7 @@ func TestDataGapsHandler_NumericID(t *testing.T) {
 		},
 		&mockVenueService{},
 		&mockFestivalService{},
+		&mockReleaseService{},
 	)
 
 	resp, err := h.GetDataGapsHandler(dataGapsCtxWithUser(), &GetDataGapsRequest{
@@ -323,6 +330,7 @@ func TestDataGapsHandler_EmptyStringNotAGap(t *testing.T) {
 		},
 		&mockVenueService{},
 		&mockFestivalService{},
+		&mockReleaseService{},
 	)
 
 	resp, err := h.GetDataGapsHandler(dataGapsCtxWithUser(), &GetDataGapsRequest{

--- a/backend/internal/api/handlers/pending_edit.go
+++ b/backend/internal/api/handlers/pending_edit.go
@@ -53,6 +53,10 @@ var allowedEditFields = map[string]map[string]bool{
 		"city": true, "state": true, "country": true,
 		"website": true, "ticket_url": true, "flyer_url": true,
 	},
+	"release": {
+		"title": true, "release_type": true, "release_year": true,
+		"release_date": true, "cover_art_url": true, "description": true,
+	},
 }
 
 // canEditDirectly returns true if the user can bypass the pending queue.
@@ -100,6 +104,11 @@ func (h *PendingEditHandler) SuggestVenueEditHandler(ctx context.Context, req *S
 // SuggestFestivalEditHandler handles PUT /festivals/{entity_id}/suggest-edit
 func (h *PendingEditHandler) SuggestFestivalEditHandler(ctx context.Context, req *SuggestEntityEditRequest) (*SuggestEntityEditResponse, error) {
 	return h.suggestEdit(ctx, "festival", req)
+}
+
+// SuggestReleaseEditHandler handles PUT /releases/{entity_id}/suggest-edit
+func (h *PendingEditHandler) SuggestReleaseEditHandler(ctx context.Context, req *SuggestEntityEditRequest) (*SuggestEntityEditResponse, error) {
+	return h.suggestEdit(ctx, "release", req)
 }
 
 // suggestEdit is the shared implementation for all suggest-edit endpoints.

--- a/backend/internal/api/handlers/pending_edit_contract_test.go
+++ b/backend/internal/api/handlers/pending_edit_contract_test.go
@@ -1,0 +1,107 @@
+package handlers
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// TestPendingEditContractDrift asserts every entity type in
+// models.ValidPendingEditEntityTypes() has the handler-side wiring required
+// for community edits. PSY-492 added 'release'; PSY-504 will add 'label'.
+// Adding a new type to the allowlist without the rest of this wiring will
+// fail this test, which is the intended pressure.
+//
+// Coverage:
+//   - allowedEditFields has a non-empty entry for the type
+//   - *PendingEditHandler exposes Suggest{Type}EditHandler
+//   - DataGapsHandler.GetDataGapsHandler does not return 400 for the type
+//
+// Not covered here (needs DB integration): resolveEntityInfo name/URL lookup
+// and RecordRevision wiring from admin update. Those live in service-level
+// integration suites.
+func TestPendingEditContractDrift(t *testing.T) {
+	for _, entityType := range models.ValidPendingEditEntityTypes() {
+		entityType := entityType
+		t.Run(entityType, func(t *testing.T) {
+			assertAllowedEditFields(t, entityType)
+			assertSuggestHandlerMethod(t, entityType)
+			assertDataGapsCase(t, entityType)
+		})
+	}
+}
+
+func assertAllowedEditFields(t *testing.T, entityType string) {
+	t.Helper()
+	fields, ok := allowedEditFields[entityType]
+	if !ok {
+		t.Fatalf("allowedEditFields missing entry for %q", entityType)
+	}
+	if len(fields) == 0 {
+		t.Fatalf("allowedEditFields[%q] is empty", entityType)
+	}
+}
+
+func assertSuggestHandlerMethod(t *testing.T, entityType string) {
+	t.Helper()
+	methodName := "Suggest" + capitalize(entityType) + "EditHandler"
+	if _, ok := reflect.TypeOf(&PendingEditHandler{}).MethodByName(methodName); !ok {
+		t.Fatalf("*PendingEditHandler missing method %s — register it alongside SuggestArtistEditHandler", methodName)
+	}
+}
+
+// assertDataGapsCase verifies GetDataGapsHandler routes this entity type to a
+// handler branch instead of rejecting it as "Invalid entity type".
+func assertDataGapsCase(t *testing.T, entityType string) {
+	t.Helper()
+	h := NewDataGapsHandler(
+		&mockArtistService{
+			getArtistBySlugFn: func(string) (*contracts.ArtistDetailResponse, error) {
+				return &contracts.ArtistDetailResponse{ID: 1, Name: "n", Slug: "s"}, nil
+			},
+		},
+		&mockVenueService{
+			getVenueBySlugFn: func(string) (*contracts.VenueDetailResponse, error) {
+				return &contracts.VenueDetailResponse{ID: 1, Name: "n", Slug: "s"}, nil
+			},
+		},
+		&mockFestivalService{
+			getFestivalBySlugFn: func(string) (*contracts.FestivalDetailResponse, error) {
+				return &contracts.FestivalDetailResponse{ID: 1, Name: "n", Slug: "s"}, nil
+			},
+		},
+		&mockReleaseService{
+			getReleaseBySlugFn: func(string) (*contracts.ReleaseDetailResponse, error) {
+				return &contracts.ReleaseDetailResponse{ID: 1, Title: "t", Slug: "s"}, nil
+			},
+		},
+	)
+
+	_, err := h.GetDataGapsHandler(dataGapsCtxWithUser(), &GetDataGapsRequest{
+		EntityType: entityType,
+		IDOrSlug:   "probe",
+	})
+
+	if err == nil {
+		return
+	}
+	var huErr *huma.ErrorModel
+	if errors.As(err, &huErr) && huErr.Status == 400 {
+		t.Fatalf("GetDataGapsHandler returned 400 for entity_type=%q — add a case in the switch", entityType)
+	}
+}
+
+// capitalize converts "artist" -> "Artist". Entity type strings are all
+// lowercase ASCII, so a single-byte uppercase is sufficient.
+func capitalize(s string) string {
+	if s == "" {
+		return ""
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}

--- a/backend/internal/api/handlers/release.go
+++ b/backend/internal/api/handlers/release.go
@@ -10,6 +10,7 @@ import (
 
 	apperrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/logger"
+	"psychic-homily-backend/internal/models"
 	"psychic-homily-backend/internal/services/contracts"
 )
 
@@ -17,13 +18,15 @@ type ReleaseHandler struct {
 	releaseService  contracts.ReleaseServiceInterface
 	artistService   contracts.ArtistServiceInterface
 	auditLogService contracts.AuditLogServiceInterface
+	revisionService contracts.RevisionServiceInterface
 }
 
-func NewReleaseHandler(releaseService contracts.ReleaseServiceInterface, artistService contracts.ArtistServiceInterface, auditLogService contracts.AuditLogServiceInterface) *ReleaseHandler {
+func NewReleaseHandler(releaseService contracts.ReleaseServiceInterface, artistService contracts.ArtistServiceInterface, auditLogService contracts.AuditLogServiceInterface, revisionService contracts.RevisionServiceInterface) *ReleaseHandler {
 	return &ReleaseHandler{
 		releaseService:  releaseService,
 		artistService:   artistService,
 		auditLogService: auditLogService,
+		revisionService: revisionService,
 	}
 }
 
@@ -276,6 +279,7 @@ type UpdateReleaseRequest struct {
 		ReleaseDate *string `json:"release_date,omitempty" required:"false" doc:"Release date (YYYY-MM-DD)"`
 		CoverArtURL *string `json:"cover_art_url,omitempty" required:"false" doc:"Cover art URL"`
 		Description *string `json:"description,omitempty" required:"false" doc:"Description"`
+		Summary     *string `json:"summary,omitempty" required:"false" doc:"Reason for the edit (recorded in revision history)"`
 	}
 }
 
@@ -297,6 +301,12 @@ func (h *ReleaseHandler) UpdateReleaseHandler(ctx context.Context, req *UpdateRe
 	releaseID, err := h.resolveReleaseID(req.ReleaseID)
 	if err != nil {
 		return nil, err
+	}
+
+	// Snapshot the pre-update release so we can diff for the revision log
+	var oldRelease *contracts.ReleaseDetailResponse
+	if h.revisionService != nil {
+		oldRelease, _ = h.releaseService.GetRelease(releaseID)
 	}
 
 	serviceReq := &contracts.UpdateReleaseRequest{
@@ -331,6 +341,25 @@ func (h *ReleaseHandler) UpdateReleaseHandler(ctx context.Context, req *UpdateRe
 		}()
 	}
 
+	// Record revision (fire and forget)
+	if h.revisionService != nil && oldRelease != nil {
+		go func() {
+			changes := computeReleaseChanges(oldRelease, release)
+			if len(changes) > 0 {
+				summary := ""
+				if req.Body.Summary != nil {
+					summary = *req.Body.Summary
+				}
+				if err := h.revisionService.RecordRevision("release", releaseID, user.ID, changes, summary); err != nil {
+					logger.Default().Error("record_release_revision_failed",
+						"release_id", releaseID,
+						"error", err.Error(),
+					)
+				}
+			}
+		}()
+	}
+
 	logger.FromContext(ctx).Info("release_updated",
 		"release_id", releaseID,
 		"admin_id", user.ID,
@@ -338,6 +367,40 @@ func (h *ReleaseHandler) UpdateReleaseHandler(ctx context.Context, req *UpdateRe
 	)
 
 	return &UpdateReleaseResponse{Body: release}, nil
+}
+
+// computeReleaseChanges compares old and new release detail responses and returns field-level diffs.
+func computeReleaseChanges(old, new *contracts.ReleaseDetailResponse) []models.FieldChange {
+	var changes []models.FieldChange
+
+	if old.Title != new.Title {
+		changes = append(changes, models.FieldChange{Field: "title", OldValue: old.Title, NewValue: new.Title})
+	}
+	if old.ReleaseType != new.ReleaseType {
+		changes = append(changes, models.FieldChange{Field: "release_type", OldValue: old.ReleaseType, NewValue: new.ReleaseType})
+	}
+	if intPtrToStr(old.ReleaseYear) != intPtrToStr(new.ReleaseYear) {
+		changes = append(changes, models.FieldChange{Field: "release_year", OldValue: old.ReleaseYear, NewValue: new.ReleaseYear})
+	}
+	if ptrToStr(old.ReleaseDate) != ptrToStr(new.ReleaseDate) {
+		changes = append(changes, models.FieldChange{Field: "release_date", OldValue: ptrToStr(old.ReleaseDate), NewValue: ptrToStr(new.ReleaseDate)})
+	}
+	if ptrToStr(old.CoverArtURL) != ptrToStr(new.CoverArtURL) {
+		changes = append(changes, models.FieldChange{Field: "cover_art_url", OldValue: ptrToStr(old.CoverArtURL), NewValue: ptrToStr(new.CoverArtURL)})
+	}
+	if ptrToStr(old.Description) != ptrToStr(new.Description) {
+		changes = append(changes, models.FieldChange{Field: "description", OldValue: ptrToStr(old.Description), NewValue: ptrToStr(new.Description)})
+	}
+
+	return changes
+}
+
+// intPtrToStr returns "" for nil, else the int formatted as a decimal string. Used only for equality comparison.
+func intPtrToStr(i *int) string {
+	if i == nil {
+		return ""
+	}
+	return strconv.Itoa(*i)
 }
 
 // ============================================================================

--- a/backend/internal/api/handlers/release_integration_test.go
+++ b/backend/internal/api/handlers/release_integration_test.go
@@ -17,7 +17,7 @@ type ReleaseHandlerIntegrationSuite struct {
 
 func (s *ReleaseHandlerIntegrationSuite) SetupSuite() {
 	s.deps = setupHandlerIntegrationDeps(s.T())
-	s.handler = NewReleaseHandler(s.deps.releaseService, s.deps.artistService, s.deps.auditLogService)
+	s.handler = NewReleaseHandler(s.deps.releaseService, s.deps.artistService, s.deps.auditLogService, nil)
 }
 
 func (s *ReleaseHandlerIntegrationSuite) TearDownTest() {

--- a/backend/internal/api/handlers/search_test.go
+++ b/backend/internal/api/handlers/search_test.go
@@ -24,7 +24,7 @@ func TestSearchReleases_Success(t *testing.T) {
 			}, nil
 		},
 	}
-	h := NewReleaseHandler(mock, nil, nil)
+	h := NewReleaseHandler(mock, nil, nil, nil)
 
 	resp, err := h.SearchReleasesHandler(context.Background(), &SearchReleasesRequest{Query: "nevermind"})
 	if err != nil {
@@ -44,7 +44,7 @@ func TestSearchReleases_EmptyQuery(t *testing.T) {
 			return []*contracts.ReleaseListResponse{}, nil
 		},
 	}
-	h := NewReleaseHandler(mock, nil, nil)
+	h := NewReleaseHandler(mock, nil, nil, nil)
 
 	resp, err := h.SearchReleasesHandler(context.Background(), &SearchReleasesRequest{Query: ""})
 	if err != nil {
@@ -61,7 +61,7 @@ func TestSearchReleases_ServiceError(t *testing.T) {
 			return nil, fmt.Errorf("db error")
 		},
 	}
-	h := NewReleaseHandler(mock, nil, nil)
+	h := NewReleaseHandler(mock, nil, nil, nil)
 
 	_, err := h.SearchReleasesHandler(context.Background(), &SearchReleasesRequest{Query: "test"})
 	if err == nil {

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -356,7 +356,7 @@ func setupArtistRoutes(rc RouteContext) {
 }
 
 func setupReleaseRoutes(rc RouteContext) {
-	releaseHandler := handlers.NewReleaseHandler(rc.SC.Release, rc.SC.Artist, rc.SC.AuditLog)
+	releaseHandler := handlers.NewReleaseHandler(rc.SC.Release, rc.SC.Artist, rc.SC.AuditLog, rc.SC.Revision)
 
 	// Public release endpoints
 	// Note: Static routes must come before parameterized routes
@@ -1020,6 +1020,7 @@ func setupPendingEditRoutes(rc RouteContext) {
 	huma.Put(rc.Protected, "/artists/{entity_id}/suggest-edit", pendingEditHandler.SuggestArtistEditHandler)
 	huma.Put(rc.Protected, "/venues/{entity_id}/suggest-edit", pendingEditHandler.SuggestVenueEditHandler)
 	huma.Put(rc.Protected, "/festivals/{entity_id}/suggest-edit", pendingEditHandler.SuggestFestivalEditHandler)
+	huma.Put(rc.Protected, "/releases/{entity_id}/suggest-edit", pendingEditHandler.SuggestReleaseEditHandler)
 
 	// Protected: user's own pending edits
 	huma.Get(rc.Protected, "/my/pending-edits", pendingEditHandler.GetMyPendingEditsHandler)
@@ -1087,7 +1088,7 @@ func setupLeaderboardRoutes(rc RouteContext) {
 
 // setupDataGapsRoutes configures entity data-gap detection endpoints (protected).
 func setupDataGapsRoutes(rc RouteContext) {
-	dataGapsHandler := handlers.NewDataGapsHandler(rc.SC.Artist, rc.SC.Venue, rc.SC.Festival)
+	dataGapsHandler := handlers.NewDataGapsHandler(rc.SC.Artist, rc.SC.Venue, rc.SC.Festival, rc.SC.Release)
 	huma.Get(rc.Protected, "/entities/{entity_type}/{id_or_slug}/data-gaps", dataGapsHandler.GetDataGapsHandler)
 }
 

--- a/backend/internal/models/pending_entity_edit.go
+++ b/backend/internal/models/pending_entity_edit.go
@@ -19,6 +19,7 @@ const (
 	PendingEditEntityArtist   = "artist"
 	PendingEditEntityVenue    = "venue"
 	PendingEditEntityFestival = "festival"
+	PendingEditEntityRelease  = "release"
 )
 
 // PendingEntityEdit represents a proposed edit to an entity awaiting review.
@@ -46,7 +47,12 @@ func (PendingEntityEdit) TableName() string { return "pending_entity_edits" }
 
 // ValidEntityTypes returns the set of entity types that support pending edits.
 func ValidPendingEditEntityTypes() []string {
-	return []string{PendingEditEntityArtist, PendingEditEntityVenue, PendingEditEntityFestival}
+	return []string{
+		PendingEditEntityArtist,
+		PendingEditEntityVenue,
+		PendingEditEntityFestival,
+		PendingEditEntityRelease,
+	}
 }
 
 // IsValidPendingEditEntityType checks if the given entity type supports pending edits.

--- a/backend/internal/services/admin/pending_edit.go
+++ b/backend/internal/services/admin/pending_edit.go
@@ -485,6 +485,17 @@ func (s *PendingEditService) resolveEntityInfo(entityType string, entityID uint)
 				url = fmt.Sprintf("%s/festivals/%s", s.frontendURL, festival.Slug)
 			}
 		}
+	case "release":
+		var release struct {
+			Title string
+			Slug  *string
+		}
+		if err := s.db.Table("releases").Select("title, slug").Where("id = ?", entityID).Scan(&release).Error; err == nil {
+			name = release.Title
+			if release.Slug != nil && *release.Slug != "" {
+				url = fmt.Sprintf("%s/releases/%s", s.frontendURL, *release.Slug)
+			}
+		}
 	}
 
 	return name, url

--- a/backend/internal/services/admin/pending_edit_test.go
+++ b/backend/internal/services/admin/pending_edit_test.go
@@ -23,9 +23,10 @@ func TestIsValidPendingEditEntityType(t *testing.T) {
 	assert.True(t, models.IsValidPendingEditEntityType("artist"))
 	assert.True(t, models.IsValidPendingEditEntityType("venue"))
 	assert.True(t, models.IsValidPendingEditEntityType("festival"))
+	assert.True(t, models.IsValidPendingEditEntityType("release"))
 	assert.False(t, models.IsValidPendingEditEntityType("show"))
 	assert.False(t, models.IsValidPendingEditEntityType(""))
-	assert.False(t, models.IsValidPendingEditEntityType("release"))
+	assert.False(t, models.IsValidPendingEditEntityType("label"))
 }
 
 // =============================================================================

--- a/frontend/features/contributions/types.ts
+++ b/frontend/features/contributions/types.ts
@@ -30,7 +30,7 @@ export interface DataQualityItem {
 
 export type PendingEditStatus = 'pending' | 'approved' | 'rejected'
 
-export type EditableEntityType = 'artist' | 'venue' | 'festival'
+export type EditableEntityType = 'artist' | 'venue' | 'festival' | 'release'
 
 export interface FieldChange {
   field: string
@@ -165,5 +165,13 @@ export const EDITABLE_FIELDS: Record<EditableEntityType, EditableField[]> = {
     { key: 'website', label: 'Website', type: 'url', placeholder: 'https://...', group: 'info' },
     { key: 'ticket_url', label: 'Ticket URL', type: 'url', placeholder: 'https://...', group: 'info' },
     { key: 'flyer_url', label: 'Flyer URL', type: 'url', placeholder: 'https://...', group: 'info' },
+  ],
+  release: [
+    { key: 'title', label: 'Title', type: 'text', group: 'info' },
+    { key: 'release_type', label: 'Release Type', type: 'text', placeholder: 'lp, ep, single, compilation, live, remix, demo', group: 'info' },
+    { key: 'release_year', label: 'Release Year', type: 'text', placeholder: 'YYYY', group: 'info' },
+    { key: 'release_date', label: 'Release Date', type: 'text', placeholder: 'YYYY-MM-DD', group: 'info' },
+    { key: 'cover_art_url', label: 'Cover Art URL', type: 'url', placeholder: 'https://...', group: 'details' },
+    { key: 'description', label: 'Description', type: 'textarea', group: 'details' },
   ],
 }


### PR DESCRIPTION
## Summary

- Extends the unified pending-entity-edit infrastructure to cover **release** (previously artist/venue/festival only). Users can now submit edits via `PUT /releases/{id}/suggest-edit`; admin moderation flows through the shared queue at `GET /admin/pending-edits`.
- Admin direct-edits on `UpdateReleaseHandler` now snapshot → diff → fire-and-forget `RevisionService.RecordRevision`, mirroring the artist handler pattern. `ReleaseDetail`'s existing `AttributionLine` + `RevisionHistory` will light up with real data after merge.
- Adds a contract-drift unit test that walks `models.ValidPendingEditEntityTypes()` and asserts, for every type: non-empty `allowedEditFields` entry, a `Suggest{Type}EditHandler` method, and a non-400 `data-gaps` switch branch. Intended as the pressure test for PSY-504 — it will fail CI if `label` is added to the allowlist without the supporting wiring.

## What changed

**Backend**
- `models.ValidPendingEditEntityTypes()` + new `PendingEditEntityRelease` const
- `allowedEditFields["release"]` — title, release_type, release_year, release_date, cover_art_url, description
- `PendingEditHandler.SuggestReleaseEditHandler` (thin wrapper on the shared impl)
- Route: `PUT /releases/{entity_id}/suggest-edit`
- `PendingEditService.resolveEntityInfo` release case — looks up title + slug, builds `/releases/{slug}` URL
- `DataGapsHandler` gains `releaseService`; `GetDataGapsHandler` switch + `getReleaseGaps` (cover_art_url, release_year/date, description)
- `ReleaseHandler` gains `revisionService`; `UpdateReleaseHandler` snapshots pre-update release, diffs via new `computeReleaseChanges`, fire-and-forget `RecordRevision` (skips if no change). Audit log behavior unchanged.
- `UpdateReleaseRequest.Body.Summary` — optional `*string` recorded on the revision row. Huma `required:"false"` preserved to keep existing admin callers working.
- New `pending_edit_contract_test.go` — table-driven, 4 entity types currently pass.
- `NewReleaseHandler` / `NewDataGapsHandler` signatures grow; all callers updated (routes.go, search_test.go, release_integration_test.go, data_gaps_test.go x9).

**Frontend**
- `EditableEntityType` gains `'release'`.
- `EDITABLE_FIELDS.release` entry — the 6 scalar fields matching backend allowlist.
- **Label deferred to PSY-504**: the backend `Social` struct's field-flatten naming (`social.instagram` vs `instagram`) is that ticket's scope. Adding a speculative label entry now would lock it in prematurely.

## Scope NOT in this PR

- Label backend — [PSY-504](https://linear.app/psychic-homily/issue/PSY-504) (depends on the shared infra landed here; the contract-drift test is the mechanical forcing function).
- ReleaseDetail `EntityEditDrawer` + `ContributionPrompt` JSX wiring — [PSY-505](https://linear.app/psychic-homily/issue/PSY-505).
- LabelDetail frontend — [PSY-493](https://linear.app/psychic-homily/issue/PSY-493).
- Legacy `pending_venue_edits` cleanup — [PSY-503](https://linear.app/psychic-homily/issue/PSY-503).

## Verification

- `go build ./...` clean
- `go test -short ./...` green (includes `services/catalog`, `services/admin`, handler integration suite)
- `TestPendingEditContractDrift` passes for all 4 entity types (artist/venue/festival/release)
- `bunx tsc --noEmit` clean
- `bunx vitest run features/contributions features/releases` — 33/33 pass
- ESLint clean on touched files (pre-existing warnings in `releases/admin/ReleaseManagement.tsx` and `releases/components/ReleaseCard.tsx` are unrelated)

## OpenAPI diff

New route registered: `PUT /releases/{entity_id}/suggest-edit`. `UpdateReleaseRequest` gains an optional `summary` field. No existing routes or required fields changed.

## Test plan

- [ ] Submit a release edit as a `new_user` — lands in admin moderation queue, visible under `My contributions`
- [ ] Submit a release edit as a `trusted_contributor` — auto-applies, revision row written
- [ ] Admin PUT /releases/{id} with a field change — revision row written via the handler's fire-and-forget path
- [ ] Approve a pending release edit from admin moderation — changes applied, revision row written (via service path, unchanged)
- [ ] `GET /entities/release/{id_or_slug}/data-gaps` returns the right subset when cover art / description / release_year are missing
- [ ] Cancel own pending release edit works through the shared `/my/pending-edits/{edit_id}` endpoint

Closes PSY-492

🤖 Generated with [Claude Code](https://claude.com/claude-code)