### PR TITLE
PSY-505: wire EntityEditDrawer + ContributionPrompt onto ReleaseDetail

### DIFF
--- a/frontend/features/releases/components/ReleaseDetail.tsx
+++ b/frontend/features/releases/components/ReleaseDetail.tsx
@@ -2,9 +2,11 @@
 
 import { useState } from 'react'
 import Link from 'next/link'
+import { useQueryClient } from '@tanstack/react-query'
 import {
   Loader2,
   Disc3,
+  Edit2,
   ExternalLink,
   Music,
   Calendar,
@@ -20,7 +22,7 @@ import {
   RevisionHistory,
   AddToCollectionButton,
 } from '@/components/shared'
-import { AttributionLine } from '@/features/contributions'
+import { AttributionLine, ContributionPrompt, EntityEditDrawer } from '@/features/contributions'
 import { EntityTagList } from '@/features/tags'
 import { AsHeardOn } from '@/features/radio'
 import { EntityCollections } from '@/features/collections'
@@ -28,6 +30,7 @@ import { CommentThread } from '@/features/comments'
 import { TabsContent } from '@/components/ui/tabs'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { queryKeys } from '@/lib/queryClient'
 import { getReleaseTypeLabel } from '../types'
 
 /** Known platform display info */
@@ -63,8 +66,16 @@ interface ReleaseDetailProps {
 
 export function ReleaseDetail({ idOrSlug }: ReleaseDetailProps) {
   const { data: release, isLoading, error } = useRelease({ idOrSlug })
-  const { isAuthenticated } = useIsAuthenticated()
+  const { user, isAuthenticated } = useIsAuthenticated()
+  const queryClient = useQueryClient()
+  const canEditDirectly = isAuthenticated && (
+    user?.is_admin ||
+    user?.user_tier === 'trusted_contributor' ||
+    user?.user_tier === 'local_ambassador'
+  )
   const [activeTab, setActiveTab] = useState('overview')
+  const [isEditing, setIsEditing] = useState(false)
+  const [editFocusField, setEditFocusField] = useState<string | undefined>()
 
   if (isLoading) {
     return (
@@ -242,7 +253,20 @@ export function ReleaseDetail({ idOrSlug }: ReleaseDetailProps) {
                 </>
               }
               actions={
-                <AddToCollectionButton entityType="release" entityId={release.id} entityName={release.title} />
+                <div className="flex items-center gap-2">
+                  {isAuthenticated && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setIsEditing(true)}
+                      className="text-muted-foreground hover:text-foreground"
+                      title={canEditDirectly ? 'Edit' : 'Suggest Edit'}
+                    >
+                      <Edit2 className="h-4 w-4" />
+                    </Button>
+                  )}
+                  <AddToCollectionButton entityType="release" entityId={release.id} entityName={release.title} />
+                </div>
               }
             />
             <AttributionLine entityType="release" entityId={release.id} />
@@ -250,6 +274,16 @@ export function ReleaseDetail({ idOrSlug }: ReleaseDetailProps) {
               entityType="release"
               entityId={release.id}
               isAuthenticated={isAuthenticated}
+            />
+            <ContributionPrompt
+              entityType="release"
+              entityId={release.id}
+              entitySlug={release.slug}
+              isAuthenticated={!!isAuthenticated}
+              onEditClick={(focusField) => {
+                setEditFocusField(focusField)
+                setIsEditing(true)
+              }}
             />
           </>
         }
@@ -360,6 +394,28 @@ export function ReleaseDetail({ idOrSlug }: ReleaseDetailProps) {
       <div className="mt-0 px-4 md:px-0">
         <CommentThread entityType="release" entityId={release.id} />
       </div>
+
+      {/* Edit Drawer (all authenticated users) */}
+      {isAuthenticated && (
+        <EntityEditDrawer
+          open={isEditing}
+          onOpenChange={(open) => {
+            setIsEditing(open)
+            if (!open) setEditFocusField(undefined)
+          }}
+          entityType="release"
+          entityId={release.id}
+          entityName={release.title}
+          entity={release as unknown as Record<string, unknown>}
+          canEditDirectly={!!canEditDirectly}
+          focusField={editFocusField}
+          onSuccess={() => {
+            queryClient.invalidateQueries({
+              queryKey: queryKeys.releases.detail(idOrSlug),
+            })
+          }}
+        />
+      )}
     </>
   )
 }


### PR DESCRIPTION
## Summary

Single-file frontend change to light up the release community-edit surface. Mirrors the FestivalDetail pattern.

`ReleaseDetail.tsx` already rendered `AttributionLine` + `RevisionHistory` (populated now that PSY-492's backend shipped in #439), but was missing the actual edit surface: no Edit button, no `ContributionPrompt`, no `EntityEditDrawer`.

## Changes

- **Header actions:** Edit button (title toggles between "Edit" and "Suggest Edit" based on trust tier) alongside the existing `AddToCollectionButton`.
- **Header content:** `ContributionPrompt` after the tag list — surfaces data-gap-based edit nudges, hooks into `setEditFocusField` so a user clicking "Add cover art" opens the drawer focused on that field.
- **Component tree bottom:** `EntityEditDrawer`, mounted for all authenticated users. `canEditDirectly` resolves from `is_admin || user_tier in {trusted_contributor, local_ambassador}` — matches the backend's `canEditDirectly` switch in `backend/internal/api/handlers/pending_edit.go:62-72`.
- Invalidates `queryKeys.releases.detail(idOrSlug)` on success so the detail view re-fetches.

## Deliberately skipped: ReportEntityDialog

`ReportableEntityType` in `features/contributions/types.ts:78` is `'artist' | 'venue' | 'festival' | 'show' | 'comment'` — release isn't reportable yet. Adding that would extend the contract beyond this ticket's scope.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun run test:run` — 2715/2715 passing
- [x] Release feature tests green (13/13)
- [ ] Manual smoke post-deploy: non-trusted user submits release edit, appears in `/admin/pending-edits` queue; admin approves; revision history on ReleaseDetail populates.

Closes PSY-505