### PR TITLE
PSY-510: seed Three Chord Monte (WFMU) + The NTS Breakfast Show

### DIFF
--- a/backend/cmd/seed/main.go
+++ b/backend/cmd/seed/main.go
@@ -996,6 +996,16 @@ func seedRadioStationsAndShows(database *gorm.DB) (int, int) {
 			ArchiveURL:      "https://wfmu.org/playlists/SV",
 			ExternalID:      "SV",
 		},
+		{
+			StationSlug:     "wfmu",
+			Name:            "Three Chord Monte",
+			Slug:            "three-chord-monte-wfmu",
+			HostName:        "Joe Belock",
+			Description:     "Garage, punk, and power pop from longtime WFMU DJ Joe Belock.",
+			ScheduleDisplay: "Mondays 12 PM-3 PM ET",
+			ArchiveURL:      "https://wfmu.org/playlists/TM",
+			ExternalID:      "TM",
+		},
 
 		// NTS shows
 		{
@@ -1017,6 +1027,19 @@ func seedRadioStationsAndShows(database *gorm.DB) (int, int) {
 			ScheduleDisplay: "Weekdays 10 AM-1 PM GMT",
 			ArchiveURL:      "https://www.nts.live/shows/the-do-you-breakfast-show",
 			ExternalID:      "the-do-you-breakfast-show",
+		},
+		{
+			StationSlug:     "nts-radio",
+			Name:            "The NTS Breakfast Show",
+			Slug:            "breakfast-show-nts",
+			// HostName intentionally empty: rotating residents (Louise Chen,
+			// Flo, Zakia, Coco María, and others). Empty string → NULL via
+			// the `if s.HostName != ""` guard below.
+			HostName:        "",
+			Description:     "Daily morning show on NTS, rotating through residents including Louise Chen, Flo, Zakia, Coco María, and others.",
+			ScheduleDisplay: "Weekdays, mornings GMT",
+			ArchiveURL:      "https://www.nts.live/shows/breakfast",
+			ExternalID:      "breakfast",
 		},
 		{
 			StationSlug:     "nts-radio",

--- a/backend/db/migrations/000077_seed_three_chord_monte_and_nts_breakfast_show.down.sql
+++ b/backend/db/migrations/000077_seed_three_chord_monte_and_nts_breakfast_show.down.sql
@@ -1,0 +1,11 @@
+-- Revert PSY-510: remove the two shows.
+-- NOTE: child radio_episodes for these shows are cascaded away on DELETE. If
+-- those episodes matter in your environment, export them before rolling back.
+
+DELETE FROM radio_shows
+WHERE slug = 'three-chord-monte-wfmu'
+  AND station_id = (SELECT id FROM radio_stations WHERE slug = 'wfmu');
+
+DELETE FROM radio_shows
+WHERE slug = 'breakfast-show-nts'
+  AND station_id = (SELECT id FROM radio_stations WHERE slug = 'nts-radio');

--- a/backend/db/migrations/000077_seed_three_chord_monte_and_nts_breakfast_show.up.sql
+++ b/backend/db/migrations/000077_seed_three_chord_monte_and_nts_breakfast_show.up.sql
@@ -1,0 +1,66 @@
+-- PSY-510: seed "Three Chord Monte" (WFMU) and "The NTS Breakfast Show" (NTS).
+-- Both surfaced during PSY-406 dogfooding as partially-imported Discover rows
+-- (slug 'three-chord-monte' on WFMU, 'breakfast-show' on NTS) with real
+-- metadata missing. Research on 2026-04-22 confirmed both are current active
+-- shows; see PSY-510 for evidence.
+--
+-- Idempotent shape: UPDATE path converts existing zombie rows in place
+-- (preserving child radio_episodes), INSERT path covers fresh environments
+-- where Discover hasn't run yet. In prod the UPDATEs are no-ops and the
+-- INSERTs do the work; in dev with zombies the UPDATEs rename + enrich and
+-- the INSERTs ON CONFLICT DO NOTHING.
+
+-- WFMU: Three Chord Monte (Joe Belock, code TM) ---------------------------
+UPDATE radio_shows
+SET slug             = 'three-chord-monte-wfmu',
+    name             = 'Three Chord Monte',
+    host_name        = 'Joe Belock',
+    description      = 'Garage, punk, and power pop from longtime WFMU DJ Joe Belock.',
+    schedule_display = 'Mondays 12 PM-3 PM ET',
+    archive_url      = 'https://wfmu.org/playlists/TM',
+    external_id      = 'TM',
+    updated_at       = NOW()
+WHERE slug = 'three-chord-monte'
+  AND station_id = (SELECT id FROM radio_stations WHERE slug = 'wfmu');
+
+INSERT INTO radio_shows (station_id, name, slug, host_name, description, schedule_display, archive_url, external_id, is_active)
+VALUES
+    ((SELECT id FROM radio_stations WHERE slug = 'wfmu'),
+     'Three Chord Monte',
+     'three-chord-monte-wfmu',
+     'Joe Belock',
+     'Garage, punk, and power pop from longtime WFMU DJ Joe Belock.',
+     'Mondays 12 PM-3 PM ET',
+     'https://wfmu.org/playlists/TM',
+     'TM',
+     TRUE)
+ON CONFLICT (slug) DO NOTHING;
+
+-- NTS: The NTS Breakfast Show (rotating residents, slug "breakfast") ------
+-- host_name stays NULL intentionally — the show rotates through Louise Chen,
+-- Flo, Zakia, Coco María, and others. Filling it with any single DJ would
+-- misrepresent the show.
+UPDATE radio_shows
+SET slug             = 'breakfast-show-nts',
+    name             = 'The NTS Breakfast Show',
+    host_name        = NULL,
+    description      = 'Daily morning show on NTS, rotating through residents including Louise Chen, Flo, Zakia, Coco María, and others.',
+    schedule_display = 'Weekdays, mornings GMT',
+    archive_url      = 'https://www.nts.live/shows/breakfast',
+    external_id      = 'breakfast',
+    updated_at       = NOW()
+WHERE slug = 'breakfast-show'
+  AND station_id = (SELECT id FROM radio_stations WHERE slug = 'nts-radio');
+
+INSERT INTO radio_shows (station_id, name, slug, host_name, description, schedule_display, archive_url, external_id, is_active)
+VALUES
+    ((SELECT id FROM radio_stations WHERE slug = 'nts-radio'),
+     'The NTS Breakfast Show',
+     'breakfast-show-nts',
+     NULL,
+     'Daily morning show on NTS, rotating through residents including Louise Chen, Flo, Zakia, Coco María, and others.',
+     'Weekdays, mornings GMT',
+     'https://www.nts.live/shows/breakfast',
+     'breakfast',
+     TRUE)
+ON CONFLICT (slug) DO NOTHING;


### PR DESCRIPTION
## Summary
- Follow-up to PSY-402 + PSY-408. Two real-but-unseeded radio shows surfaced during PSY-406 dogfooding — Discover runs had left partially-imported rows (slug `three-chord-monte` on WFMU, `breakfast-show` on NTS).
- Research on 2026-04-22 confirmed both are current active shows; adding them to seed + migration so prod + dev + fresh envs converge.

## Three Chord Monte (WFMU)
- Host: Joe Belock
- DJ code `TM`, archive `https://wfmu.org/playlists/TM`
- Schedule: Mondays 12 PM-3 PM ET (per WFMU schedule page)

## The NTS Breakfast Show (NTS)
- **Host: NULL (intentional)** — rotating residents (Louise Chen, Flo, Zakia, Coco María, and others). Filling host_name with any single DJ would misrepresent the show.
- External ID `breakfast`, archive `https://www.nts.live/shows/breakfast`
- Schedule: Weekdays, mornings GMT

## Migration shape
Idempotent:
- **In dev** (zombie rows exist with old slugs): `UPDATE` converts in place, preserving attached `radio_episodes`. The `INSERT` hits `ON CONFLICT DO NOTHING`.
- **In prod / fresh env** (no prior rows): `UPDATE` is a no-op, `INSERT` creates fresh rows.

Both paths tested locally:
```
-- UPDATE path (zombies present)
UPDATE 1 / INSERT 0 0 (conflict)

-- INSERT path (after down clears)
UPDATE 0 / INSERT 0 1
```

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./internal/services/catalog/` pass (37s)
- [x] Up migration verified both paths (UPDATE-in-place and INSERT-fresh)
- [x] Down migration verified — DELETEs both rows (cascades any attached episodes; noted in down SQL)
- [x] `cmd/seed/main.go` entries match migration values

## Not in scope
- E2E seed (`frontend/e2e/setup-db.sh`) — no E2E test depends on either show; E2E seed stays minimal.
- Host name gap on NTS Breakfast Show — intentional given rotating residents.

Closes PSY-510

🤖 Generated with [Claude Code](https://claude.com/claude-code)