### PR TITLE
PSY-511: graph a11y baseline + mobile gating

### DIFF
--- a/frontend/features/artists/components/ArtistGraph.tsx
+++ b/frontend/features/artists/components/ArtistGraph.tsx
@@ -4,6 +4,7 @@ import { useCallback, useMemo, useRef, useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import dynamic from 'next/dynamic'
 import { Loader2 } from 'lucide-react'
+import { useReducedMotion } from '../hooks/useReducedMotion'
 import type { ArtistGraph as ArtistGraphData, ArtistGraphNode, ArtistGraphLink } from '../types'
 
 function GraphSkeleton() {
@@ -73,8 +74,10 @@ interface ArtistGraphProps {
 export function ArtistGraphVisualization({ data, activeTypes, containerWidth }: ArtistGraphProps) {
   const router = useRouter()
   const graphRef = useRef<any>(null) // eslint-disable-line @typescript-eslint/no-explicit-any
+  const containerRef = useRef<HTMLDivElement>(null)
   const [hoveredNode, setHoveredNode] = useState<GraphNode | null>(null)
   const [tooltipPos, setTooltipPos] = useState({ x: 0, y: 0 })
+  const reducedMotion = useReducedMotion()
 
   const graphHeight = containerWidth < 768 ? 350 : 500
 
@@ -154,6 +157,32 @@ export function ArtistGraphVisualization({ data, activeTypes, containerWidth }: 
       }
     }
   }, [graphData])
+
+  // Accessibility: the rendered <canvas> is a visual enhancement; the
+  // <RelatedArtists> list view is the keyboard/screen-reader counterpart
+  // with proper <Link> semantics. We expose the canvas as an image with a
+  // descriptive label so assistive tech announces it sensibly and points
+  // users to the accessible list below.
+  useEffect(() => {
+    if (!containerRef.current) return
+    const canvas = containerRef.current.querySelector('canvas')
+    if (!canvas) return
+    canvas.setAttribute('role', 'img')
+    canvas.setAttribute(
+      'aria-label',
+      `Artist relationship graph for ${data.center.name}. Use the Related Artists list below to navigate.`
+    )
+  }, [data.center.name])
+
+  // Reduced-motion: pause the continuous force simulation after the
+  // initial layout settles so motion-sensitive users get a static
+  // snapshot. Tap, pinch zoom, and pan are unaffected — only the
+  // background tick animation stops.
+  useEffect(() => {
+    if (reducedMotion && graphRef.current) {
+      graphRef.current.pauseAnimation()
+    }
+  }, [reducedMotion])
 
   const handleNodeClick = useCallback(
     (node: GraphNode) => {
@@ -258,7 +287,10 @@ export function ArtistGraphVisualization({ data, activeTypes, containerWidth }: 
   )
 
   return (
-    <div className="relative rounded-lg border border-border/50 overflow-hidden bg-background">
+    <div
+      ref={containerRef}
+      className="relative rounded-lg border border-border/50 overflow-hidden bg-background"
+    >
       <ForceGraph2D
         ref={graphRef}
         graphData={graphData}

--- a/frontend/features/artists/components/RelatedArtists.test.tsx
+++ b/frontend/features/artists/components/RelatedArtists.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { screen } from '@testing-library/react'
 import { renderWithProviders } from '@/test/utils'
 import type { ArtistGraph } from '../types'
@@ -108,8 +108,62 @@ vi.mock('./ArtistGraph', () => ({
 
 import { RelatedArtists } from './RelatedArtists'
 
+// PSY-511: RelatedArtists now defers the View Map button + graph until
+// ResizeObserver reports a real container width (>= 640px). The shared
+// ResizeObserver mock in test/setup.ts never fires its callback, so we
+// override it locally with one that synchronously reports a configurable
+// width. Each test sets the width via setMockContainerWidth() before
+// rendering; the default (1024) is wide enough that the View Map button
+// renders, matching desktop behaviour.
+let mockContainerWidth = 1024
+
+function setMockContainerWidth(width: number) {
+  mockContainerWidth = width
+}
+
+class ImmediateResizeObserver {
+  private callback: ResizeObserverCallback
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback
+  }
+  observe(target: Element): void {
+    // Fire synchronously so the component's useEffect picks up the
+    // measured width on first commit, rather than waiting on a real
+    // browser layout pass.
+    this.callback(
+      [
+        {
+          target,
+          contentRect: { width: mockContainerWidth } as DOMRectReadOnly,
+        } as ResizeObserverEntry,
+      ],
+      this as unknown as ResizeObserver
+    )
+  }
+  unobserve(): void {}
+  disconnect(): void {}
+}
 
 describe('RelatedArtists', () => {
+  // The shared ResizeObserver mock in test/setup.ts is defined with
+  // `writable: true` (and no `configurable`), so re-assignment works
+  // even though Object.defineProperty does not. We swap it back to the
+  // original after the suite so neighbouring tests aren't affected.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const originalResizeObserver = (window as any).ResizeObserver
+
+  beforeEach(() => {
+    setMockContainerWidth(1024)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(window as any).ResizeObserver = ImmediateResizeObserver
+  })
+
+  afterEach(() => {
+    setMockContainerWidth(1024)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(window as any).ResizeObserver = originalResizeObserver
+  })
+
   it('renders the section header', () => {
     renderWithProviders(
       <RelatedArtists artistId={1} artistSlug="gatecreeper" />
@@ -165,7 +219,11 @@ describe('RelatedArtists', () => {
 
   it('shows empty state with suggest button when no relationships exist', async () => {
     const hooks = await import('../hooks/useArtistGraph')
-    vi.mocked(hooks.useArtistGraph).mockReturnValueOnce({
+    // mockReturnValue (not Once): the synchronous ResizeObserver causes
+    // a re-render after the initial commit, so the hook is called more
+    // than once per test — Once would let the second render fall back
+    // to the populated default mock and break the assertion.
+    vi.mocked(hooks.useArtistGraph).mockReturnValue({
       data: {
         center: { id: 1, name: 'Lonely', slug: 'lonely', upcoming_show_count: 0 },
         nodes: [],
@@ -183,11 +241,18 @@ describe('RelatedArtists', () => {
     expect(screen.getByText('No similar artists yet. Be the first to suggest one!')).toBeInTheDocument()
     // Should show the suggest button for authenticated users
     expect(screen.getByText('Suggest similar artist')).toBeInTheDocument()
+
+    // Restore the default for subsequent tests in this suite.
+    vi.mocked(hooks.useArtistGraph).mockReturnValue({
+      data: mockGraphData,
+      isLoading: false,
+      error: null,
+    } as any) // eslint-disable-line @typescript-eslint/no-explicit-any
   })
 
   it('hides section while loading', async () => {
     const hooks = await import('../hooks/useArtistGraph')
-    vi.mocked(hooks.useArtistGraph).mockReturnValueOnce({
+    vi.mocked(hooks.useArtistGraph).mockReturnValue({
       data: undefined,
       isLoading: true,
       error: null,
@@ -197,5 +262,35 @@ describe('RelatedArtists', () => {
       <RelatedArtists artistId={1} artistSlug="loading-artist" />
     )
     expect(container.children.length).toBe(0)
+
+    // Restore the default for subsequent tests in this suite.
+    vi.mocked(hooks.useArtistGraph).mockReturnValue({
+      data: mockGraphData,
+      isLoading: false,
+      error: null,
+    } as any) // eslint-disable-line @typescript-eslint/no-explicit-any
+  })
+
+  // PSY-511: below 640px (Tailwind `sm`) the graph is unusable on a
+  // phone. Hide the View Map button entirely — the list view is the
+  // only surface, no "best viewed on desktop" nag.
+  it('hides the View Map button on narrow viewports (< 640px)', () => {
+    setMockContainerWidth(375)
+    renderWithProviders(
+      <RelatedArtists artistId={1} artistSlug="gatecreeper" />
+    )
+    // List view (artists by name) still renders.
+    expect(screen.getByText('Frozen Soul')).toBeInTheDocument()
+    // View Map button is gated off.
+    expect(screen.queryByText('View Map')).not.toBeInTheDocument()
+    expect(screen.queryByText('Hide Map')).not.toBeInTheDocument()
+  })
+
+  it('shows the View Map button at exactly the 640px breakpoint', () => {
+    setMockContainerWidth(640)
+    renderWithProviders(
+      <RelatedArtists artistId={1} artistSlug="gatecreeper" />
+    )
+    expect(screen.getByText('View Map')).toBeInTheDocument()
   })
 })

--- a/frontend/features/artists/components/RelatedArtists.tsx
+++ b/frontend/features/artists/components/RelatedArtists.tsx
@@ -41,7 +41,10 @@ export function RelatedArtists({ artistId, artistSlug }: RelatedArtistsProps) {
   const [activeTypes, setActiveTypes] = useState<Set<string>>(new Set(ALL_TYPES))
   const [showSuggest, setShowSuggest] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
-  const [containerWidth, setContainerWidth] = useState(800)
+  // Defer the graph render until ResizeObserver reports a real width.
+  // Initialising to a hard-coded value caused the canvas to render at
+  // the wrong size on first paint; null + a measured update is the fix.
+  const [containerWidth, setContainerWidth] = useState<number | null>(null)
 
   // Measure container width for graph
   useEffect(() => {
@@ -128,13 +131,20 @@ export function RelatedArtists({ artistId, artistSlug }: RelatedArtistsProps) {
     })
 
   const hasEnoughForGraph = data.nodes.length >= 3
+  // Mobile gating: below the Tailwind `sm` breakpoint (640px) the graph
+  // is unusable on a phone, so we hide the View Map button entirely and
+  // let the list view be the only surface — no "best viewed on desktop"
+  // nag. `containerWidth === null` (pre-measurement) also gates off so
+  // we never flash the button before we know the viewport width.
+  const graphAvailable =
+    hasEnoughForGraph && containerWidth !== null && containerWidth >= 640
 
   return (
     <div ref={containerRef} className="mt-8 px-4 md:px-0">
       <div className="flex items-center justify-between mb-4">
         <h2 className="text-lg font-semibold">Related Artists</h2>
         <div className="flex items-center gap-2">
-          {hasEnoughForGraph && (
+          {graphAvailable && (
             <Button
               variant={showGraph ? 'default' : 'outline'}
               size="sm"
@@ -148,7 +158,7 @@ export function RelatedArtists({ artistId, artistSlug }: RelatedArtistsProps) {
       </div>
 
       {/* Graph View */}
-      {showGraph && hasEnoughForGraph && (
+      {showGraph && graphAvailable && (
         <div className="mb-6">
           {/* Type Filter Toggles */}
           <div className="flex flex-wrap gap-1.5 mb-3">
@@ -176,7 +186,8 @@ export function RelatedArtists({ artistId, artistSlug }: RelatedArtistsProps) {
           <ArtistGraphVisualization
             data={data}
             activeTypes={activeTypes}
-            containerWidth={containerWidth}
+            // Safe non-null: graphAvailable requires containerWidth !== null
+            containerWidth={containerWidth!}
           />
         </div>
       )}

--- a/frontend/features/artists/hooks/index.ts
+++ b/frontend/features/artists/hooks/index.ts
@@ -17,3 +17,5 @@ export {
   useArtistRelationshipVote,
   useCreateArtistRelationship,
 } from './useArtistGraph'
+
+export { useReducedMotion } from './useReducedMotion'

--- a/frontend/features/artists/hooks/useReducedMotion.test.tsx
+++ b/frontend/features/artists/hooks/useReducedMotion.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useReducedMotion } from './useReducedMotion'
+
+// Helper that swaps out window.matchMedia with a controllable mock so
+// we can assert both the initial snapshot and live updates when the
+// user toggles their OS-level setting mid-session.
+function setupMatchMediaMock(initialReduced: boolean) {
+  const listeners: Array<(ev: MediaQueryListEvent) => void> = []
+  let matches = initialReduced
+
+  const mqList = {
+    get matches() {
+      return matches
+    },
+    media: '(prefers-reduced-motion: reduce)',
+    onchange: null,
+    addEventListener: vi.fn((_event: string, handler: (ev: MediaQueryListEvent) => void) => {
+      listeners.push(handler)
+    }),
+    removeEventListener: vi.fn((_event: string, handler: (ev: MediaQueryListEvent) => void) => {
+      const idx = listeners.indexOf(handler)
+      if (idx >= 0) listeners.splice(idx, 1)
+    }),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }
+
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockReturnValue(mqList),
+  })
+
+  return {
+    fireChange(next: boolean) {
+      matches = next
+      for (const handler of listeners) {
+        handler({ matches: next } as MediaQueryListEvent)
+      }
+    },
+  }
+}
+
+describe('useReducedMotion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    // Reset to the default (non-reduced) matchMedia behaviour from
+    // test/setup.ts so other suites in the same file aren't polluted.
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    })
+  })
+
+  it('returns false when prefers-reduced-motion does not match', () => {
+    setupMatchMediaMock(false)
+    const { result } = renderHook(() => useReducedMotion())
+    expect(result.current).toBe(false)
+  })
+
+  it('returns true when prefers-reduced-motion matches', () => {
+    setupMatchMediaMock(true)
+    const { result } = renderHook(() => useReducedMotion())
+    expect(result.current).toBe(true)
+  })
+
+  it('updates when the OS-level setting toggles mid-session', () => {
+    const { fireChange } = setupMatchMediaMock(false)
+    const { result } = renderHook(() => useReducedMotion())
+    expect(result.current).toBe(false)
+
+    act(() => fireChange(true))
+    expect(result.current).toBe(true)
+
+    act(() => fireChange(false))
+    expect(result.current).toBe(false)
+  })
+})

--- a/frontend/features/artists/hooks/useReducedMotion.ts
+++ b/frontend/features/artists/hooks/useReducedMotion.ts
@@ -1,0 +1,51 @@
+'use client'
+
+import { useSyncExternalStore } from 'react'
+
+// SSR-safe: the server snapshot is always `false` so the server HTML
+// matches; after hydration the hook reads the live MediaQueryList via
+// `useSyncExternalStore`, which also wires up the change listener and
+// cleans it up on unmount without the "setState inside an effect"
+// double-render that ESLint flags.
+//
+// Used by ArtistGraph to pause the continuous force simulation for
+// `prefers-reduced-motion: reduce` users — tap, zoom, and pan still
+// work; only the background motion stops.
+function subscribeReducedMotion(onChange: () => void): () => void {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return () => {}
+  }
+  const mq = window.matchMedia('(prefers-reduced-motion: reduce)')
+  // Older Safari versions only ship addListener/removeListener; prefer
+  // the modern API when available so we don't trigger deprecation
+  // warnings in evergreen browsers.
+  if (typeof mq.addEventListener === 'function') {
+    mq.addEventListener('change', onChange)
+    return () => mq.removeEventListener('change', onChange)
+  }
+  mq.addListener(onChange)
+  return () => mq.removeListener(onChange)
+}
+
+function getReducedMotionSnapshot(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return false
+  }
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+}
+
+function getReducedMotionServerSnapshot(): boolean {
+  return false
+}
+
+/**
+ * Reads the user's `prefers-reduced-motion` setting and re-renders when
+ * it changes mid-session.
+ */
+export function useReducedMotion(): boolean {
+  return useSyncExternalStore(
+    subscribeReducedMotion,
+    getReducedMotionSnapshot,
+    getReducedMotionServerSnapshot
+  )
+}

--- a/frontend/features/artists/index.ts
+++ b/frontend/features/artists/index.ts
@@ -57,6 +57,8 @@ export {
   useCreateArtistRelationship,
 } from './hooks'
 
+export { useReducedMotion } from './hooks'
+
 // Components
 export {
   ArtistCard,


### PR DESCRIPTION
## Summary

- Adds `useReducedMotion` hook (`useSyncExternalStore`-based to match the codebase's existing `useIsCoarsePointer` pattern) and pauses the artist relationship graph's force simulation for `prefers-reduced-motion: reduce` users. Tap, pinch-zoom, and pan still work — only the continuous tick stops.
- Adds `role="img"` + descriptive `aria-label` to the graph canvas; the existing `RelatedArtists` list view stays the keyboard/screen-reader counterpart with proper `<Link>` semantics. No in-canvas keyboard navigation (Google Maps / Figma pattern).
- Hides the View Map button + graph render below 640px so the list view is the mobile primary. Also fixes the canvas sizing bug (`useState(800)` → `useState<number | null>(null)`) that defers render until the ResizeObserver reports a real width — the fix previously slated for PSY-361.

Follows the PSY-369 spike (`docs/strategy/graph-mobile-a11y.md`).

## Test plan

- [ ] On \`/artists/<artist-with-relationships>\` at ≥640px: graph renders, View Map button visible
- [ ] Resize to <640px: View Map button disappears, list view is the only surface
- [ ] DevTools → Rendering → emulate \`prefers-reduced-motion: reduce\`, reload: no canvas tick after initial settle
- [ ] Tap / pinch-zoom / pan still work in reduced-motion mode
- [ ] Screen reader announces "Artist relationship graph for {name}. Use the Related Artists list below to navigate."

Closes PSY-511.

🤖 Generated with [Claude Code](https://claude.com/claude-code)