### PR TITLE
PSY-362: typed-edge visual grammar polish

### DIFF
--- a/frontend/features/artists/components/ArtistGraph.test.ts
+++ b/frontend/features/artists/components/ArtistGraph.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect } from 'vitest'
+import { buildLinkLabel } from './ArtistGraph'
+
+// PSY-362: tooltip strings are the user-facing surface of the underlying signal.
+// These tests pin the format per edge type so future detail-shape changes don't
+// silently drop information from the tooltip.
+describe('buildLinkLabel (PSY-362 edge tooltip text)', () => {
+  describe('similar', () => {
+    it('formats score as percent with vote totals when votes exist', () => {
+      expect(
+        buildLinkLabel({
+          type: 'similar',
+          score: 0.85,
+          votes_up: 8,
+          votes_down: 2,
+          detail: undefined,
+        })
+      ).toBe('Similar: 85% (8 up / 2 down)')
+    })
+
+    it('omits vote totals when there are no votes (auto-derived only)', () => {
+      expect(
+        buildLinkLabel({
+          type: 'similar',
+          score: 0.5,
+          votes_up: 0,
+          votes_down: 0,
+          detail: undefined,
+        })
+      ).toBe('Similar: 50%')
+    })
+
+    it('rounds non-integer score percentages', () => {
+      expect(
+        buildLinkLabel({
+          type: 'similar',
+          score: 0.6789,
+          votes_up: 0,
+          votes_down: 0,
+          detail: undefined,
+        })
+      ).toBe('Similar: 68%')
+    })
+  })
+
+  describe('shared_bills', () => {
+    it('reports count + last-shared date when both are in detail', () => {
+      expect(
+        buildLinkLabel({
+          type: 'shared_bills',
+          score: 0.4,
+          votes_up: 0,
+          votes_down: 0,
+          detail: { shared_count: 7, last_shared: '2026-03-01' },
+        })
+      ).toBe('7 shared shows (last: 2026-03-01)')
+    })
+
+    it('singularizes when count is 1', () => {
+      expect(
+        buildLinkLabel({
+          type: 'shared_bills',
+          score: 0.1,
+          votes_up: 0,
+          votes_down: 0,
+          detail: { shared_count: 1, last_shared: '2026-03-01' },
+        })
+      ).toBe('1 shared show (last: 2026-03-01)')
+    })
+
+    it('omits date when missing from detail', () => {
+      expect(
+        buildLinkLabel({
+          type: 'shared_bills',
+          score: 0.4,
+          votes_up: 0,
+          votes_down: 0,
+          detail: { shared_count: 4 },
+        })
+      ).toBe('4 shared shows')
+    })
+
+    it('falls back when detail is missing entirely', () => {
+      expect(
+        buildLinkLabel({
+          type: 'shared_bills',
+          score: 0,
+          votes_up: 0,
+          votes_down: 0,
+          detail: undefined,
+        })
+      ).toBe('Shared bills')
+    })
+  })
+
+  describe('shared_label', () => {
+    it('shows "Both on {label}" for a single shared label', () => {
+      expect(
+        buildLinkLabel({
+          type: 'shared_label',
+          score: 0.2,
+          votes_up: 0,
+          votes_down: 0,
+          detail: { shared_count: 1, label_names: 'Closed Casket Activities' },
+        })
+      ).toBe('Both on Closed Casket Activities')
+    })
+
+    it('lists labels when multiple are shared', () => {
+      expect(
+        buildLinkLabel({
+          type: 'shared_label',
+          score: 0.4,
+          votes_up: 0,
+          votes_down: 0,
+          detail: {
+            shared_count: 2,
+            label_names: 'Closed Casket Activities, Profound Lore',
+          },
+        })
+      ).toBe('2 shared labels: Closed Casket Activities, Profound Lore')
+    })
+
+    it('falls back to count-only when label names absent', () => {
+      expect(
+        buildLinkLabel({
+          type: 'shared_label',
+          score: 0.4,
+          votes_up: 0,
+          votes_down: 0,
+          detail: { shared_count: 3 },
+        })
+      ).toBe('3 shared labels')
+    })
+
+    it('uses generic fallback when detail is empty', () => {
+      expect(
+        buildLinkLabel({
+          type: 'shared_label',
+          score: 0,
+          votes_up: 0,
+          votes_down: 0,
+          detail: undefined,
+        })
+      ).toBe('Shared label')
+    })
+  })
+
+  describe('radio_cooccurrence', () => {
+    it('reports count and station breakdown when stations > 1', () => {
+      expect(
+        buildLinkLabel({
+          type: 'radio_cooccurrence',
+          score: 0.6,
+          votes_up: 0,
+          votes_down: 0,
+          detail: { co_occurrence_count: 14, station_count: 3, show_count: 9 },
+        })
+      ).toBe('Played together on 14 radio shows across 3 stations')
+    })
+
+    it('omits station breakdown when only 1 station', () => {
+      expect(
+        buildLinkLabel({
+          type: 'radio_cooccurrence',
+          score: 0.3,
+          votes_up: 0,
+          votes_down: 0,
+          detail: { co_occurrence_count: 5, station_count: 1 },
+        })
+      ).toBe('Played together on 5 radio shows')
+    })
+
+    it('singularizes when count is 1', () => {
+      expect(
+        buildLinkLabel({
+          type: 'radio_cooccurrence',
+          score: 0.1,
+          votes_up: 0,
+          votes_down: 0,
+          detail: { co_occurrence_count: 1, station_count: 1 },
+        })
+      ).toBe('Played together on 1 radio show')
+    })
+
+    it('falls back when detail is missing', () => {
+      expect(
+        buildLinkLabel({
+          type: 'radio_cooccurrence',
+          score: 0,
+          votes_up: 0,
+          votes_down: 0,
+          detail: undefined,
+        })
+      ).toBe('Radio co-occurrence')
+    })
+  })
+
+  describe('side_project / member_of (binary facts)', () => {
+    it('side_project tooltip is descriptive without magnitude', () => {
+      expect(
+        buildLinkLabel({
+          type: 'side_project',
+          score: 0,
+          votes_up: 0,
+          votes_down: 0,
+          detail: undefined,
+        })
+      ).toBe('Side project')
+    })
+
+    it('member_of tooltip is descriptive without magnitude', () => {
+      expect(
+        buildLinkLabel({
+          type: 'member_of',
+          score: 0,
+          votes_up: 0,
+          votes_down: 0,
+          detail: undefined,
+        })
+      ).toBe('Member of')
+    })
+  })
+
+  describe('unknown edge types', () => {
+    it('falls back to the type string when not recognised', () => {
+      expect(
+        buildLinkLabel({
+          type: 'totally_made_up',
+          score: 0,
+          votes_up: 0,
+          votes_down: 0,
+          detail: undefined,
+        })
+      ).toBe('totally_made_up')
+    })
+  })
+})

--- a/frontend/features/artists/components/ArtistGraph.tsx
+++ b/frontend/features/artists/components/ArtistGraph.tsx
@@ -22,7 +22,18 @@ const ForceGraph2D = dynamic(() => import('react-force-graph-2d'), {
   loading: () => <GraphSkeleton />,
 })
 
-// Edge type colors
+// PSY-362: Canonical visual style map for typed edges. Keep this co-located here so
+// future graph surfaces (scene-scale, venue, festival) can reuse the same grammar.
+//
+// Colorblind audit (2026-04-24): All 6 colors verified against Protanopia, Deuteranopia,
+// and Tritanopia transformation matrices using a 30-unit RGB Euclidean threshold. All 15
+// pairs pass the threshold under all 3 vision types. Closest pair under any simulator is
+// shared_bills vs radio_cooccurrence at d=35.3 (protanopia), which is also dash-differentiated
+// (solid vs dashed-8-3) for redundancy. Full audit: docs/learnings/graph-colorblind-audit.md.
+//
+// WCAG 2.2 §1.4.1 ("Use of Color"): we never rely on color alone — every edge type has a
+// dash pattern (solid / dashed / dotted) and many also have weight scaling, so information
+// is conveyed through at least two channels.
 const EDGE_COLORS: Record<string, string> = {
   similar: '#a1a1aa',              // zinc-400 (neutral)
   shared_bills: '#60a5fa',         // blue-400
@@ -62,6 +73,87 @@ interface GraphLink {
   votes_down: number
   detail?: Record<string, unknown>
   isCrossConnection: boolean
+}
+
+// Helper: pull a number out of the loosely-typed `detail` JSONB blob.
+// Returns undefined when the field is missing or not coercible to a number.
+function detailNumber(detail: Record<string, unknown> | undefined, key: string): number | undefined {
+  if (!detail) return undefined
+  const v = detail[key]
+  if (typeof v === 'number') return v
+  if (typeof v === 'string') {
+    const n = Number(v)
+    return Number.isFinite(n) ? n : undefined
+  }
+  return undefined
+}
+
+function detailString(detail: Record<string, unknown> | undefined, key: string): string | undefined {
+  if (!detail) return undefined
+  const v = detail[key]
+  return typeof v === 'string' && v.length > 0 ? v : undefined
+}
+
+// Build the hover tooltip string for an edge. The text is edge-type aware and surfaces
+// the underlying raw signal (count, score, label name) sourced from the link's `detail`
+// JSONB or `score` field. If the data shape doesn't carry the field we'd ideally show,
+// we fall back to a description that uses what's available — never fabricate a number.
+//
+// Exported for unit testing the format of each edge type's tooltip string.
+export function buildLinkLabel(link: Pick<GraphLink, 'type' | 'score' | 'votes_up' | 'votes_down' | 'detail'>): string {
+  const detail = link.detail
+  switch (link.type) {
+    case 'similar': {
+      const pct = Math.round(link.score * 100)
+      const total = link.votes_up + link.votes_down
+      if (total > 0) {
+        return `Similar: ${pct}% (${link.votes_up} up / ${link.votes_down} down)`
+      }
+      return `Similar: ${pct}%`
+    }
+    case 'shared_bills': {
+      const count = detailNumber(detail, 'shared_count')
+      const lastShared = detailString(detail, 'last_shared')
+      if (count !== undefined) {
+        const noun = count === 1 ? 'show' : 'shows'
+        return lastShared
+          ? `${count} shared ${noun} (last: ${lastShared})`
+          : `${count} shared ${noun}`
+      }
+      return 'Shared bills'
+    }
+    case 'shared_label': {
+      const count = detailNumber(detail, 'shared_count')
+      const labelNames = detailString(detail, 'label_names')
+      if (labelNames) {
+        return count !== undefined && count > 1
+          ? `${count} shared labels: ${labelNames}`
+          : `Both on ${labelNames}`
+      }
+      if (count !== undefined) {
+        const noun = count === 1 ? 'label' : 'labels'
+        return `${count} shared ${noun}`
+      }
+      return 'Shared label'
+    }
+    case 'radio_cooccurrence': {
+      const coCount = detailNumber(detail, 'co_occurrence_count')
+      const stationCount = detailNumber(detail, 'station_count')
+      if (coCount !== undefined) {
+        const stationPart =
+          stationCount !== undefined && stationCount > 1 ? ` across ${stationCount} stations` : ''
+        const noun = coCount === 1 ? 'show' : 'shows'
+        return `Played together on ${coCount} radio ${noun}${stationPart}`
+      }
+      return 'Radio co-occurrence'
+    }
+    case 'side_project':
+      return 'Side project'
+    case 'member_of':
+      return 'Member of'
+    default:
+      return EDGE_LABELS[link.type] ?? link.type
+  }
 }
 
 interface ArtistGraphProps {
@@ -231,18 +323,32 @@ export function ArtistGraphVisualization({ data, activeTypes, containerWidth }: 
     []
   )
 
+  // PSY-362: Stroke weight encoding per edge type.
+  //
+  //   similar              — magnitude (Wilson similarity score). Scaled.
+  //   shared_bills         — magnitude (recency-weighted shared-show count). Scaled.
+  //   radio_cooccurrence   — magnitude (cross-station-weighted co-occurrence). Scaled.
+  //   shared_label         — magnitude (count of shared labels, normalized to [0,1] in
+  //                          the deriver, capped at 5+ shared labels = 1.0). Scaled.
+  //   side_project         — BINARY fact ("X is a side project of Y"). Intentionally uniform —
+  //                          a side project either exists or does not, there is no magnitude.
+  //   member_of            — BINARY fact ("X is a member of Y"). Intentionally uniform — same
+  //                          rationale as side_project.
   const linkWidth = useCallback(
     (link: GraphLink) => {
-      if (link.type === 'similar') {
-        return Math.max(1, link.score * 3)
+      switch (link.type) {
+        case 'similar':
+        case 'shared_bills':
+        case 'shared_label':
+        case 'radio_cooccurrence':
+          return Math.max(1, link.score * 3)
+        case 'side_project':
+        case 'member_of':
+          // Binary relationship — uniform stroke is intentional.
+          return 1
+        default:
+          return 1
       }
-      if (link.type === 'shared_bills') {
-        return Math.max(1, link.score * 3)
-      }
-      if (link.type === 'radio_cooccurrence') {
-        return Math.max(1, link.score * 3)
-      }
-      return 1
     },
     []
   )
@@ -256,6 +362,12 @@ export function ArtistGraphVisualization({ data, activeTypes, containerWidth }: 
     },
     []
   )
+
+  // PSY-362: hover tooltip on edges. react-force-graph-2d renders this as a native HTML
+  // tooltip when the cursor is over a link. The text surfaces the underlying raw signal
+  // (similarity score, shared count, label name, radio co-occurrence count) so users can
+  // see *why* the graph is drawing this edge.
+  const linkLabel = useCallback((link: GraphLink) => buildLinkLabel(link), [])
 
   return (
     <div className="relative rounded-lg border border-border/50 overflow-hidden bg-background">
@@ -282,6 +394,7 @@ export function ArtistGraphVisualization({ data, activeTypes, containerWidth }: 
         linkColor={linkColor}
         linkWidth={linkWidth}
         linkLineDash={linkLineDash}
+        linkLabel={linkLabel}
         linkDirectionalParticles={0}
         cooldownTicks={100}
         d3AlphaDecay={0.04}
@@ -328,6 +441,18 @@ export function ArtistGraphVisualization({ data, activeTypes, containerWidth }: 
             <span className="text-muted-foreground">{EDGE_LABELS[type] || type}</span>
           </div>
         ))}
+        {/* PSY-362: weight-scale affordance — communicates that line thickness encodes
+            signal magnitude (similarity score, shared-show count, etc.) so users know
+            the visual grammar before hovering individual edges. */}
+        <div className="pt-1 mt-1 border-t border-border/40 flex items-center gap-1.5">
+          <div className="flex flex-col items-center gap-0.5" aria-hidden="true">
+            <div className="w-4 h-px rounded-full bg-muted-foreground/60" />
+            <div className="w-4 h-[3px] rounded-full bg-muted-foreground" />
+          </div>
+          <span className="text-[10px] text-muted-foreground/80 leading-tight">
+            Thicker = stronger signal
+          </span>
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

- Audits the 6 typed-edge colors against Protanopia / Deuteranopia / Tritanopia transformation matrices (30-unit RGB Euclidean threshold). **All 15 pairs cleared all 3 CVD types** — no palette swap. Closest pair: \`shared_bills\` vs \`radio_cooccurrence\` at d=35.3 protanopia, already dash-redundant (solid vs \`[8,3]\`). Audit summary inline above \`EDGE_COLORS\`; full numbers in \`docs/learnings/graph-colorblind-audit.md\` (gitignored, matches the \`docs/\` workflow-artifact convention).
- Extends \`linkWidth\` weight scaling to \`shared_label\` (was uniform-1 — the deriver computes \`min(count/5, 1.0)\`, so a magnitude exists). Documents \`side_project\` and \`member_of\` as intentionally uniform — they're binary facts ("X is a side project of Y"), not magnitudes.
- Adds \`linkLabel\` hover tooltip surfacing the underlying raw signal per edge type ("Similar: 85% (8 up / 2 down)", "7 shared shows (last: 2026-03-01)", "Both on Closed Casket Activities", "Played together on 14 radio shows across 3 stations"). Falls back gracefully when \`detail\` JSONB is sparse — never fabricates a number.
- Adds "Thicker = stronger signal" affordance to the legend so the weight grammar is discoverable before hovering.
- 18 new unit tests for \`buildLinkLabel\` covering every edge type + fallback paths.

## Test plan

- [ ] Open \`/artists/<artist-with-relationships>\` and hover each edge type — tooltip surfaces the right raw signal
- [ ] Legend shows "Thicker = stronger signal" affordance below the type entries
- [ ] \`shared_label\` edges scale by stroke weight when multiple labels are shared
- [ ] \`side_project\` / \`member_of\` edges remain uniform-weight (intentional)
- [ ] No regression in existing graph rendering / interactions

Closes PSY-362.

🤖 Generated with [Claude Code](https://claude.com/claude-code)