### PR TITLE
PSY-516: default scene graph to visible on /scenes/{slug}

### DIFF
--- a/frontend/features/scenes/components/SceneGraph.test.tsx
+++ b/frontend/features/scenes/components/SceneGraph.test.tsx
@@ -137,22 +137,17 @@ describe('SceneGraph', () => {
     expect(screen.getByText(/1 unconnected/)).toBeInTheDocument()
   })
 
-  it('shows the View map button at desktop width', () => {
-    renderWithProviders(<SceneGraph slug="phoenix-az" city="Phoenix" state="AZ" />)
-    expect(screen.getByText('View map')).toBeInTheDocument()
-  })
-
-  it('hides the View map button below the 640px breakpoint', () => {
+  it('hides the canvas below the 640px breakpoint', () => {
     setMockContainerWidth(500)
     renderWithProviders(<SceneGraph slug="phoenix-az" city="Phoenix" state="AZ" />)
-    expect(screen.queryByText('View map')).not.toBeInTheDocument()
+    // PSY-516: header copy is gated by `nodeCount === 0`, not by mobile gating,
+    // so it may still render. The canvas + cluster legend must be absent.
+    expect(screen.queryByTestId('scene-graph-canvas')).not.toBeInTheDocument()
+    expect(screen.queryByText(/Valley Bar \(6\)/)).not.toBeInTheDocument()
   })
 
-  it('reveals canvas + cluster legend after clicking View map', async () => {
-    const user = userEvent.setup()
+  it('renders canvas + cluster legend at desktop width', () => {
     renderWithProviders(<SceneGraph slug="phoenix-az" city="Phoenix" state="AZ" />)
-    expect(screen.queryByTestId('scene-graph-canvas')).not.toBeInTheDocument()
-    await user.click(screen.getByText('View map'))
     expect(screen.getByTestId('scene-graph-canvas')).toBeInTheDocument()
     expect(screen.getByText(/Valley Bar \(6\)/)).toBeInTheDocument()
     expect(screen.getByText(/Crescent Ballroom \(6\)/)).toBeInTheDocument()
@@ -161,7 +156,6 @@ describe('SceneGraph', () => {
   it('toggles cluster visibility when a legend pill is clicked', async () => {
     const user = userEvent.setup()
     renderWithProviders(<SceneGraph slug="phoenix-az" city="Phoenix" state="AZ" />)
-    await user.click(screen.getByText('View map'))
 
     const canvasBefore = screen.getByTestId('scene-graph-canvas')
     expect(canvasBefore).toHaveAttribute('data-hidden-clusters', '')

--- a/frontend/features/scenes/components/SceneGraph.tsx
+++ b/frontend/features/scenes/components/SceneGraph.tsx
@@ -1,30 +1,32 @@
 'use client'
 
 /**
- * SceneGraph (PSY-367)
+ * SceneGraph (PSY-367, PSY-516)
  *
- * Section wrapper for the scene-scale graph: header, "View Map" toggle, cluster
- * legend, and the canvas. Mirrors the BillComposition / RelatedArtists section
- * pattern — graph hidden behind a toggle, mobile-gated below the Tailwind `sm`
- * breakpoint per PSY-369→PSY-511.
+ * Section wrapper for the scene-scale graph: header, cluster legend, and the
+ * canvas. Mobile-gated below the Tailwind `sm` breakpoint per
+ * PSY-369→PSY-511.
  *
- * Decision: inline toggle on the existing `/scenes/{slug}` page rather than a
+ * PSY-516: graph is visible by default at ≥640px (previously hidden behind a
+ * "View map" / "Hide map" toggle). Dogfood feedback flagged the toggle as
+ * friction on a feature whose value is the immediate visual scan. Mobile
+ * gating and the empty-state (`<3` connected artists) gate are unchanged.
+ *
+ * Decision: inline on the existing `/scenes/{slug}` page rather than a
  * separate `/scenes/{slug}/graph` route. Reasons:
- *   - Mirrors the artist-page precedent (per-artist + bill-composition both
- *     toggle inline). One mental model across the app.
  *   - Discoverable: users browsing scenes naturally encounter it; no need to
  *     learn a separate URL.
  *   - Keeps the scene page authoritative for "what the scene is" — the graph
  *     is one of many lenses, alongside venues, artists, pulse, genres.
  *
- * Trade-off accepted: the canvas competes with other page sections, but
- * collapsing by default + the standalone fixed-height container keep that
- * cost bounded.
+ * Trade-off accepted: the canvas mounts on every Phoenix-scale scene visit
+ * and pushes other sections down, but `react-force-graph-2d` is dynamic-
+ * imported with `ssr: false`, the canvas pauses after `cooldownTicks=200`,
+ * and mobile already gates it off.
  */
 
 import { useState, useCallback, useMemo } from 'react'
-import { Network, Eye, EyeOff } from 'lucide-react'
-import { Button } from '@/components/ui/button'
+import { Eye, EyeOff } from 'lucide-react'
 import { useSceneGraph } from '../hooks/useScenes'
 import { SceneGraphVisualization } from './SceneGraphVisualization'
 
@@ -59,7 +61,6 @@ interface SceneGraphProps {
 
 export function SceneGraph({ slug, city, state }: SceneGraphProps) {
   const { data, isLoading } = useSceneGraph({ slug, enabled: Boolean(slug) })
-  const [showGraph, setShowGraph] = useState(false)
   const [hiddenClusters, setHiddenClusters] = useState<Set<string>>(new Set())
   const [containerWidth, setContainerWidth] = useState<number | null>(null)
 
@@ -99,10 +100,9 @@ export function SceneGraph({ slug, city, state }: SceneGraphProps) {
   const graphAvailable =
     hasEnoughForGraph && containerWidth !== null && containerWidth >= GRAPH_BREAKPOINT_PX
 
-  // Section is rendered (with the header) so users get scale info even when the
-  // graph is unavailable; the toggle button is only shown when graphAvailable.
-  // Empty state: scene has < 3 connected artists — render nothing rather than
-  // a confusing skeleton.
+  // Section is rendered (with the header) so users get scale info even when
+  // the graph is unavailable (e.g. mobile). Empty state: scene has < 3
+  // connected artists — render nothing rather than a confusing skeleton.
   if (!data || nodeCount === 0) return null
 
   const toggleCluster = (clusterID: string) => {
@@ -138,19 +138,9 @@ export function SceneGraph({ slug, city, state }: SceneGraphProps) {
             )}
           </p>
         </div>
-        {graphAvailable && (
-          <Button
-            variant={showGraph ? 'default' : 'outline'}
-            size="sm"
-            onClick={() => setShowGraph(prev => !prev)}
-          >
-            <Network className="h-4 w-4 mr-1.5" />
-            {showGraph ? 'Hide map' : 'View map'}
-          </Button>
-        )}
       </div>
 
-      {showGraph && graphAvailable && (
+      {graphAvailable && (
         <div className="space-y-3">
           {/* Cluster legend — click a row to toggle that cluster's visibility.
               "Other" stays clickable so users can hide the long tail at will. */}


### PR DESCRIPTION
## Summary

- Drop the `View map` / `Hide map` toggle on `SceneGraph` so the graph + cluster legend render by default at >=640px. Dogfood feedback (2026-04-28) flagged the toggle as friction on a feature whose value is the immediate visual scan.
- Mobile gating (<640px) and the empty-state (<3 connected artists) gate are unchanged.
- The freed-up button slot in the section header becomes available for PSY-517 (fullscreen mode).

## Stacking

- This stacks on PSY-367 (PR #472) — `frontend/features/scenes/components/SceneGraph.tsx` only exists on that branch.
- When PSY-367 merges, this PR will need a rebase to `main`. That's expected.

## Test plan

- [x] `bun run test:run features/scenes` passes (14 tests across `SceneGraph.test.tsx` + `useScenes.test.tsx`)
- [x] `bun x tsc --noEmit` clean
- [ ] Manual check on a Phoenix-scale scene at desktop width: graph + legend visible without a click
- [ ] Manual check at <640px viewport: canvas + legend hidden, header copy may still show (current behavior)
- [ ] Manual check on a scene with <3 connected artists: section renders nothing

Closes PSY-516