### PR TITLE
PSY-517: fullscreen mode for scene graph (CSS viewport overlay)

### DIFF
--- a/frontend/features/scenes/components/SceneGraph.test.tsx
+++ b/frontend/features/scenes/components/SceneGraph.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { screen } from '@testing-library/react'
+import { screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { renderWithProviders } from '@/test/utils'
 import type { SceneGraphResponse } from '../types'
@@ -68,15 +68,20 @@ vi.mock('../hooks/useScenes', () => ({
 }))
 
 // Canvas can't render in jsdom. Stub the visualization so we can assert toggling.
+// Forward `height` as a data attribute so the overlay sizing test can verify
+// the prop reaches the visualization.
 vi.mock('./SceneGraphVisualization', () => ({
   SceneGraphVisualization: ({
     hiddenClusterIDs,
+    height,
   }: {
     hiddenClusterIDs: Set<string>
+    height?: number
   }) => (
     <div
       data-testid="scene-graph-canvas"
       data-hidden-clusters={Array.from(hiddenClusterIDs).sort().join(',')}
+      data-height={height ?? ''}
     >
       Scene Graph Canvas
     </div>
@@ -198,5 +203,122 @@ describe('SceneGraph', () => {
       <SceneGraph slug="phoenix-az" city="Phoenix" state="AZ" />,
     )
     expect(container.firstChild).toBeNull()
+  })
+
+  describe('fullscreen overlay (PSY-517)', () => {
+    it('renders the Expand button when graph is available at desktop width', () => {
+      renderWithProviders(<SceneGraph slug="phoenix-az" city="Phoenix" state="AZ" />)
+      expect(
+        screen.getByRole('button', { name: /expand scene graph to fullscreen/i }),
+      ).toBeInTheDocument()
+    })
+
+    it('does NOT render the Expand button below the 640px breakpoint (mobile gate inherited)', () => {
+      setMockContainerWidth(500)
+      renderWithProviders(<SceneGraph slug="phoenix-az" city="Phoenix" state="AZ" />)
+      // Mobile gate: graphAvailable === false → Expand button isn't rendered.
+      expect(
+        screen.queryByRole('button', { name: /expand scene graph to fullscreen/i }),
+      ).not.toBeInTheDocument()
+    })
+
+    it('opens the overlay when Expand is clicked', async () => {
+      const user = userEvent.setup()
+      renderWithProviders(<SceneGraph slug="phoenix-az" city="Phoenix" state="AZ" />)
+
+      expect(screen.queryByTestId('scene-graph-overlay')).not.toBeInTheDocument()
+
+      await user.click(
+        screen.getByRole('button', { name: /expand scene graph to fullscreen/i }),
+      )
+
+      const overlay = screen.getByTestId('scene-graph-overlay')
+      expect(overlay).toBeInTheDocument()
+      expect(overlay).toHaveAttribute('role', 'dialog')
+      expect(overlay).toHaveAttribute('aria-modal', 'true')
+      // The Exit button replaces Expand in the header.
+      expect(
+        screen.getByRole('button', { name: /exit fullscreen scene graph/i }),
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: /expand scene graph to fullscreen/i }),
+      ).not.toBeInTheDocument()
+    })
+
+    it('closes the overlay when the Exit button is clicked', async () => {
+      const user = userEvent.setup()
+      renderWithProviders(<SceneGraph slug="phoenix-az" city="Phoenix" state="AZ" />)
+
+      await user.click(
+        screen.getByRole('button', { name: /expand scene graph to fullscreen/i }),
+      )
+      expect(screen.getByTestId('scene-graph-overlay')).toBeInTheDocument()
+
+      await user.click(
+        screen.getByRole('button', { name: /exit fullscreen scene graph/i }),
+      )
+      expect(screen.queryByTestId('scene-graph-overlay')).not.toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: /expand scene graph to fullscreen/i }),
+      ).toBeInTheDocument()
+    })
+
+    it('closes the overlay when Esc is pressed', async () => {
+      const user = userEvent.setup()
+      renderWithProviders(<SceneGraph slug="phoenix-az" city="Phoenix" state="AZ" />)
+
+      await user.click(
+        screen.getByRole('button', { name: /expand scene graph to fullscreen/i }),
+      )
+      expect(screen.getByTestId('scene-graph-overlay')).toBeInTheDocument()
+
+      await user.keyboard('{Escape}')
+
+      expect(screen.queryByTestId('scene-graph-overlay')).not.toBeInTheDocument()
+    })
+
+    it('locks body scroll while open and restores the previous value on close', async () => {
+      const user = userEvent.setup()
+      // Seed an inline overflow value so we can verify the previous-value
+      // restore (not a blind reset to '').
+      document.body.style.overflow = 'auto'
+
+      renderWithProviders(<SceneGraph slug="phoenix-az" city="Phoenix" state="AZ" />)
+      expect(document.body.style.overflow).toBe('auto')
+
+      await user.click(
+        screen.getByRole('button', { name: /expand scene graph to fullscreen/i }),
+      )
+      expect(document.body.style.overflow).toBe('hidden')
+
+      await user.keyboard('{Escape}')
+      expect(document.body.style.overflow).toBe('auto')
+
+      // Cleanup so the next test isn't affected.
+      document.body.style.overflow = ''
+    })
+
+    it('keeps cluster pills interactive inside the overlay', async () => {
+      const user = userEvent.setup()
+      renderWithProviders(<SceneGraph slug="phoenix-az" city="Phoenix" state="AZ" />)
+
+      await user.click(
+        screen.getByRole('button', { name: /expand scene graph to fullscreen/i }),
+      )
+      const overlay = screen.getByTestId('scene-graph-overlay')
+
+      // Pill inside the overlay is rendered + clickable + reflects state on the
+      // overlay's canvas (which receives the same hiddenClusterIDs set).
+      const valleyPill = within(overlay).getByText(/Valley Bar/).closest('button')!
+      expect(valleyPill).toHaveAttribute('aria-pressed', 'true')
+
+      await user.click(valleyPill)
+
+      const valleyPillAfter = within(overlay).getByText(/Valley Bar/).closest('button')!
+      expect(valleyPillAfter).toHaveAttribute('aria-pressed', 'false')
+
+      const overlayCanvas = within(overlay).getByTestId('scene-graph-canvas')
+      expect(overlayCanvas).toHaveAttribute('data-hidden-clusters', 'v_1')
+    })
   })
 })

--- a/frontend/features/scenes/components/SceneGraph.tsx
+++ b/frontend/features/scenes/components/SceneGraph.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 /**
- * SceneGraph (PSY-367, PSY-516)
+ * SceneGraph (PSY-367, PSY-516, PSY-517)
  *
  * Section wrapper for the scene-scale graph: header, cluster legend, and the
  * canvas. Mobile-gated below the Tailwind `sm` breakpoint per
@@ -11,6 +11,12 @@
  * "View map" / "Hide map" toggle). Dogfood feedback flagged the toggle as
  * friction on a feature whose value is the immediate visual scan. Mobile
  * gating and the empty-state (`<3` connected artists) gate are unchanged.
+ *
+ * PSY-517: the slot vacated by PSY-516's removed toggle now hosts an
+ * Expand / Exit button that opens a CSS viewport overlay (not the Browser
+ * Fullscreen API) containing the same graph + cluster legend. Esc closes;
+ * body scroll is locked while open. The overlay inherits the inline
+ * `graphAvailable` gate, so mobile users never see the Expand button.
  *
  * Decision: inline on the existing `/scenes/{slug}` page rather than a
  * separate `/scenes/{slug}/graph` route. Reasons:
@@ -25,13 +31,19 @@
  * and mobile already gates it off.
  */
 
-import { useState, useCallback, useMemo } from 'react'
-import { Eye, EyeOff } from 'lucide-react'
+import { useState, useCallback, useMemo, useEffect } from 'react'
+import { Eye, EyeOff, Maximize2, X } from 'lucide-react'
 import { useSceneGraph } from '../hooks/useScenes'
 import { SceneGraphVisualization } from './SceneGraphVisualization'
 
 const GRAPH_BREAKPOINT_PX = 640
 const MIN_GRAPH_NODES = 3
+
+// Overlay vertical reserve: header bar (~60px) + cluster pill row (~60px) +
+// padding/margins. Subtracted from window.innerHeight to give the canvas the
+// remaining vertical real estate. Tuned to keep the canvas full-bleed without
+// clipping the legend or the title bar.
+const OVERLAY_VERTICAL_RESERVE_PX = 140
 
 // Same Okabe-Ito mapping as SceneGraphVisualization, repeated here to avoid an
 // internal dependency on the canvas component for legend rendering. Keep in
@@ -63,6 +75,9 @@ export function SceneGraph({ slug, city, state }: SceneGraphProps) {
   const { data, isLoading } = useSceneGraph({ slug, enabled: Boolean(slug) })
   const [hiddenClusters, setHiddenClusters] = useState<Set<string>>(new Set())
   const [containerWidth, setContainerWidth] = useState<number | null>(null)
+  const [isFullscreen, setIsFullscreen] = useState(false)
+  const [overlayHeight, setOverlayHeight] = useState<number | null>(null)
+  const [overlayWidth, setOverlayWidth] = useState<number | null>(null)
 
   // Callback ref instead of useRef + useEffect. Using useEffect with `[]` deps
   // would only fire on the *initial* mount — and the initial mount often
@@ -83,6 +98,40 @@ export function SceneGraph({ slug, city, state }: SceneGraphProps) {
     observer.observe(node)
     return () => observer.disconnect()
   }, [])
+
+  // Overlay-mode side effects: body scroll lock, Esc-to-close, and a live
+  // viewport-size listener that keeps the canvas full-bleed when the user
+  // resizes the window. All gated on `isFullscreen` so the listener +
+  // overflow style only exist while the overlay is open. We snapshot the
+  // previous body overflow value and restore it on close — blindly setting
+  // it to '' would clobber any inline value a parent layout had set.
+  useEffect(() => {
+    if (!isFullscreen) return
+
+    const previousOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+
+    const updateDimensions = () => {
+      setOverlayWidth(window.innerWidth)
+      setOverlayHeight(Math.max(200, window.innerHeight - OVERLAY_VERTICAL_RESERVE_PX))
+    }
+    updateDimensions()
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setIsFullscreen(false)
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    window.addEventListener('resize', updateDimensions)
+
+    return () => {
+      document.body.style.overflow = previousOverflow
+      document.removeEventListener('keydown', handleKeyDown)
+      window.removeEventListener('resize', updateDimensions)
+    }
+  }, [isFullscreen])
 
   const isolateCount = useMemo(() => {
     if (!data) return 0
@@ -117,85 +166,161 @@ export function SceneGraph({ slug, city, state }: SceneGraphProps) {
     })
   }
 
+  // Cluster legend pills — same markup inline and in the overlay so the
+  // toggle behavior, ARIA, and color mapping stay in one place.
+  const clusterLegend = data.clusters.length > 0 && (
+    <div className="flex flex-wrap gap-1.5">
+      {data.clusters.map(cluster => {
+        const hidden = hiddenClusters.has(cluster.id)
+        return (
+          <button
+            key={cluster.id}
+            onClick={() => toggleCluster(cluster.id)}
+            aria-pressed={!hidden}
+            className={`inline-flex items-center gap-1.5 text-xs px-2 py-0.5 rounded-full border transition-opacity ${
+              hidden ? 'opacity-40' : 'opacity-100'
+            }`}
+            style={{
+              borderColor: clusterColor(cluster.color_index),
+              color: clusterColor(cluster.color_index),
+            }}
+            title={hidden ? `Show ${cluster.label}` : `Hide ${cluster.label}`}
+          >
+            <span
+              className="inline-block w-2 h-2 rounded-full"
+              style={{ backgroundColor: clusterColor(cluster.color_index) }}
+            />
+            <span className="text-foreground/85">
+              {cluster.label} ({cluster.size})
+            </span>
+            {hidden ? (
+              <EyeOff className="h-3 w-3" aria-hidden="true" />
+            ) : (
+              <Eye className="h-3 w-3" aria-hidden="true" />
+            )}
+          </button>
+        )
+      })}
+    </div>
+  )
+
+  // The Expand button lives inside the header's gap-2 row; it's only rendered
+  // when graphAvailable, which inherits the mobile gate (containerWidth must
+  // be ≥ 640px). That single source of truth means mobile users never see the
+  // Expand button — there's no separate mobile branch to maintain.
+  const expandButton = graphAvailable && !isFullscreen && (
+    <button
+      type="button"
+      onClick={() => setIsFullscreen(true)}
+      className="inline-flex items-center gap-1.5 text-sm px-3 py-1.5 rounded-md border border-border/60 hover:bg-muted/50 transition-colors"
+      aria-label="Expand scene graph to fullscreen"
+    >
+      <Maximize2 className="h-4 w-4" aria-hidden="true" />
+      <span>Expand</span>
+    </button>
+  )
+
+  const sceneHeader = (
+    <div>
+      <h2 className="text-lg font-semibold">Scene graph</h2>
+      <p className="text-sm text-muted-foreground">
+        {nodeCount} {nodeCount === 1 ? 'artist' : 'artists'}
+        {edgeCount > 0 && (
+          <>
+            {' · '}
+            {edgeCount} {edgeCount === 1 ? 'connection' : 'connections'}
+          </>
+        )}
+        {isolateCount > 0 && (
+          <>
+            {' · '}
+            {isolateCount} unconnected
+          </>
+        )}
+      </p>
+    </div>
+  )
+
   return (
-    <div ref={containerRefCallback} className="mt-2">
-      <div className="flex flex-wrap items-center justify-between gap-2 mb-2">
-        <div>
-          <h2 className="text-lg font-semibold">Scene graph</h2>
-          <p className="text-sm text-muted-foreground">
-            {nodeCount} {nodeCount === 1 ? 'artist' : 'artists'}
-            {edgeCount > 0 && (
-              <>
-                {' · '}
-                {edgeCount} {edgeCount === 1 ? 'connection' : 'connections'}
-              </>
-            )}
-            {isolateCount > 0 && (
-              <>
-                {' · '}
-                {isolateCount} unconnected
-              </>
-            )}
-          </p>
+    <>
+      <div
+        ref={containerRefCallback}
+        className="mt-2"
+        // While the overlay is open, hide the inline copy from assistive tech
+        // and inert it for keyboard focus — the overlay's own header is the
+        // single source of truth for scene-graph navigation in that mode.
+        // `inert` is a React 19 boolean prop; aria-hidden is the sibling
+        // affordance for screen readers.
+        aria-hidden={isFullscreen || undefined}
+        inert={isFullscreen || undefined}
+      >
+        <div className="flex flex-wrap items-center justify-between gap-2 mb-2">
+          {sceneHeader}
+          {expandButton}
         </div>
+
+        {graphAvailable && !isFullscreen && (
+          <div className="space-y-3">
+            {/* Cluster legend — click a row to toggle that cluster's visibility.
+                "Other" stays clickable so users can hide the long tail at will. */}
+            {clusterLegend}
+
+            <SceneGraphVisualization
+              data={data}
+              // Safe non-null: graphAvailable requires containerWidth !== null
+              containerWidth={containerWidth!}
+              hiddenClusterIDs={hiddenClusters}
+            />
+
+            <p className="text-xs text-muted-foreground">
+              Showing artists who&apos;ve played approved shows in {city}, {state}. Clusters
+              group artists by their most-frequent venue here. Click a cluster pill above to
+              hide it; click any artist to open their page.
+            </p>
+          </div>
+        )}
       </div>
 
-      {graphAvailable && (
-        <div className="space-y-3">
-          {/* Cluster legend — click a row to toggle that cluster's visibility.
-              "Other" stays clickable so users can hide the long tail at will. */}
-          {data.clusters.length > 0 && (
-            <div className="flex flex-wrap gap-1.5">
-              {data.clusters.map(cluster => {
-                const hidden = hiddenClusters.has(cluster.id)
-                return (
-                  <button
-                    key={cluster.id}
-                    onClick={() => toggleCluster(cluster.id)}
-                    aria-pressed={!hidden}
-                    className={`inline-flex items-center gap-1.5 text-xs px-2 py-0.5 rounded-full border transition-opacity ${
-                      hidden ? 'opacity-40' : 'opacity-100'
-                    }`}
-                    style={{
-                      borderColor: clusterColor(cluster.color_index),
-                      color: clusterColor(cluster.color_index),
-                    }}
-                    title={
-                      hidden ? `Show ${cluster.label}` : `Hide ${cluster.label}`
-                    }
-                  >
-                    <span
-                      className="inline-block w-2 h-2 rounded-full"
-                      style={{ backgroundColor: clusterColor(cluster.color_index) }}
-                    />
-                    <span className="text-foreground/85">
-                      {cluster.label} ({cluster.size})
-                    </span>
-                    {hidden ? (
-                      <EyeOff className="h-3 w-3" aria-hidden="true" />
-                    ) : (
-                      <Eye className="h-3 w-3" aria-hidden="true" />
-                    )}
-                  </button>
-                )
-              })}
-            </div>
-          )}
+      {isFullscreen && graphAvailable && (
+        <div
+          // Full-opacity backdrop so nothing peeks through; the overlay is its
+          // own surface, not a translucent modal. z-50 mirrors other overlays
+          // in the codebase. role=dialog + aria-modal communicates focus
+          // expectations to assistive tech without trapping focus (the
+          // overlay is keyboard-dismissable via Esc).
+          role="dialog"
+          aria-modal="true"
+          aria-label={`Scene graph for ${city}, ${state}, fullscreen`}
+          className="fixed inset-0 z-50 bg-background flex flex-col"
+          data-testid="scene-graph-overlay"
+        >
+          <div className="flex flex-wrap items-center justify-between gap-2 px-4 py-3 border-b border-border/50">
+            {sceneHeader}
+            <button
+              type="button"
+              onClick={() => setIsFullscreen(false)}
+              className="inline-flex items-center gap-1.5 text-sm px-3 py-1.5 rounded-md border border-border/60 hover:bg-muted/50 transition-colors"
+              aria-label="Exit fullscreen scene graph"
+            >
+              <X className="h-4 w-4" aria-hidden="true" />
+              <span>Exit</span>
+            </button>
+          </div>
 
-          <SceneGraphVisualization
-            data={data}
-            // Safe non-null: graphAvailable requires containerWidth !== null
-            containerWidth={containerWidth!}
-            hiddenClusterIDs={hiddenClusters}
-          />
+          <div className="px-4 py-2 border-b border-border/30">{clusterLegend}</div>
 
-          <p className="text-xs text-muted-foreground">
-            Showing artists who&apos;ve played approved shows in {city}, {state}. Clusters
-            group artists by their most-frequent venue here. Click a cluster pill above to
-            hide it; click any artist to open their page.
-          </p>
+          <div className="flex-1 min-h-0 px-4 py-2">
+            {overlayHeight !== null && overlayWidth !== null && (
+              <SceneGraphVisualization
+                data={data}
+                containerWidth={overlayWidth}
+                hiddenClusterIDs={hiddenClusters}
+                height={overlayHeight}
+              />
+            )}
+          </div>
         </div>
       )}
-    </div>
+    </>
   )
 }

--- a/frontend/features/scenes/components/SceneGraphVisualization.tsx
+++ b/frontend/features/scenes/components/SceneGraphVisualization.tsx
@@ -148,12 +148,20 @@ interface SceneGraphVisualizationProps {
    * visible (toggling it would hide the long tail without a way back).
    */
   hiddenClusterIDs: Set<string>
+  /**
+   * Optional explicit canvas height. When omitted, defaults to the inline
+   * sizing (400px on narrow viewports, 560px otherwise). PSY-517 passes an
+   * overlay-aware height in fullscreen mode so the canvas fills the viewport
+   * minus the header/legend reserve.
+   */
+  height?: number
 }
 
 export function SceneGraphVisualization({
   data,
   containerWidth,
   hiddenClusterIDs,
+  height,
 }: SceneGraphVisualizationProps) {
   const router = useRouter()
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -163,7 +171,7 @@ export function SceneGraphVisualization({
   const [hoveredNode, setHoveredNode] = useState<RenderNode | null>(null)
   const [tooltipPos, setTooltipPos] = useState({ x: 0, y: 0 })
 
-  const graphHeight = containerWidth < 768 ? 400 : 560
+  const graphHeight = height ?? (containerWidth < 768 ? 400 : 560)
 
   // Cluster lookup + ordered cluster IDs (for centroid placement). Order is
   // backend-provided (size desc) so colors stay stable across renders.


### PR DESCRIPTION
## Summary

- Repurposes the slot vacated by PSY-516 as an Expand/Exit toggle that opens a CSS viewport overlay (`position: fixed; inset: 0; z-50; bg-background`) containing the graph + cluster legend. **Not** the Browser Fullscreen API.
- `Esc` closes; body scroll is locked while open and the previous `overflow` value is snapshotted + restored on close (not blindly reset to `''`).
- Overlay inherits the inline `graphAvailable` gate (≥ 640px), so mobile users never see the Expand button — single source of truth, no separate mobile branch.
- `SceneGraphVisualization` now accepts an optional `height` prop; overlay passes `window.innerHeight - 140` and updates live on `resize`. Inline rendering keeps its 400/560 default.

## Open-question defaults shipped (per ticket)

- **Icon/label**: `Maximize2` + "Expand" → `X` + "Exit"
- **Cluster pill placement in overlay**: top bar (under the header)
- **Mobile in overlay**: inherits inline gate; `Expand` button only renders when `graphAvailable === true`
- **Backdrop**: `bg-background` (full opacity)

Bonus a11y nicety: when the overlay is open the inline copy gets `aria-hidden` + `inert` so the duplicate `<h2>` doesn't confuse screen readers / keyboard nav.

## Test plan

- [x] `bun run test:run features/scenes` — 21/21 passing (14 existing + 7 new)
- [x] `bun x tsc --noEmit` — clean
- [x] Full suite: 2809/2809 passing, 0 regressions
- [ ] Manual: open `/scenes/phoenix-az` ≥ 640px, click Expand, verify overlay fills viewport, Esc + Exit both close, body scroll restored, cluster pills toggle nodes inside the overlay
- [ ] Manual: < 640px width, verify Expand button never appears

Closes PSY-517

🤖 Generated with [Claude Code](https://claude.com/claude-code)