### PR TITLE
PSY-518: bump scene graph overlay z-index above cookie banner

### DIFF
--- a/frontend/features/scenes/components/SceneGraph.tsx
+++ b/frontend/features/scenes/components/SceneGraph.tsx
@@ -284,14 +284,15 @@ export function SceneGraph({ slug, city, state }: SceneGraphProps) {
       {isFullscreen && graphAvailable && (
         <div
           // Full-opacity backdrop so nothing peeks through; the overlay is its
-          // own surface, not a translucent modal. z-50 mirrors other overlays
-          // in the codebase. role=dialog + aria-modal communicates focus
-          // expectations to assistive tech without trapping focus (the
-          // overlay is keyboard-dismissable via Esc).
+          // own surface, not a translucent modal. z-[60] sits above the cookie
+          // consent banner (z-50) so first-time visitors don't see the banner
+          // painted over the bottom of the canvas (PSY-518). role=dialog +
+          // aria-modal communicates focus expectations to assistive tech
+          // without trapping focus (the overlay is keyboard-dismissable via Esc).
           role="dialog"
           aria-modal="true"
           aria-label={`Scene graph for ${city}, ${state}, fullscreen`}
-          className="fixed inset-0 z-50 bg-background flex flex-col"
+          className="fixed inset-0 z-[60] bg-background flex flex-col"
           data-testid="scene-graph-overlay"
         >
           <div className="flex flex-wrap items-center justify-between gap-2 px-4 py-3 border-b border-border/50">


### PR DESCRIPTION
## Summary

- Scene graph fullscreen overlay and cookie consent banner are both `position: fixed; z-index: 50`. The cookie banner appears later in DOM order and wins the stacking tie, painting over the bottom ~77px of the overlay canvas for first-time visitors.
- One-line className change: `z-50` -> `z-[60]` on the overlay container in `frontend/features/scenes/components/SceneGraph.tsx`. Inline comment updated to explain the bump and reference PSY-518.

## Z-index audit

Per the ticket's acceptance criteria, grepped for fixed-position UI at z-40/50/60+ and verified the new stacking is correct.

```bash
grep -rn "z-\[6\|z-50\|z-40" frontend --include="*.tsx" | grep -i fixed
```

| File | z-index | Stacking vs new `z-[60]` overlay | Notes |
| --- | --- | --- | --- |
| `components/layout/CookieConsentBanner.tsx` | `z-50` | Below | The bug being fixed. Banner now correctly under the overlay. Still functions normally on every other surface. |
| `components/ui/dialog.tsx` (overlay + content) | `z-50` | Below | Radix Dialog. Used for auth modal / standard dialogs. They render below the scene graph overlay, which is correct: the scene overlay owns the viewport once expanded; user dismisses the overlay (Esc) to interact with anything else. |
| `components/ui/sheet.tsx` (overlay + content) | `z-50` | Below | Radix Sheet (e.g. command palette / side drawers). Same reasoning as Dialog -- overlay should win. Esc dismisses. |
| `features/scenes/components/SceneGraphVisualization.tsx` (tooltip) | `z-50` | Below | Inline scene graph hover tooltip. It's only rendered while the inline graph is in the viewport (not while the fullscreen overlay is mounted), so no real conflict. |
| `features/artists/components/ArtistGraph.tsx` (tooltip) | `z-50` | Below | Same -- inline tooltip on a different page. No interaction with the scene overlay. |

No fixed-position UI in the codebase currently uses `z-[60]` or higher, so the new value is the topmost layer.

## Follow-ups (not in scope)

- If a future toast/snackbar needs to appear over the scene overlay (e.g. "Couldn't load nodes"), it would need to be `> z-[60]`. None exists today; flagging for future awareness.
- Auth modal at `z-50` will be hidden under the overlay if a user gets redirected to log in while the overlay is open. The overlay is keyboard-dismissable (Esc) and the close button stays at the top, so this isn't a trap, but noting it as a potential future tweak if any sign-in CTA inside the overlay is added.

## Test plan

- [x] `bun run test:run features/scenes` -- 21/21 passing
- [x] `bun x tsc --noEmit` -- clean
- [ ] Manual: open `/scenes/phoenix-az` in incognito, click Expand, confirm cookie banner is no longer painted over the canvas bottom.
- [ ] Manual: dismiss the overlay, confirm cookie banner is still visible and dismissable on the inline scene page.

Closes PSY-518

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>