### PR TITLE
PSY-519: apply callback-ref fix to BillComposition + RelatedArtists

### DIFF
--- a/frontend/features/artists/components/BillComposition.tsx
+++ b/frontend/features/artists/components/BillComposition.tsx
@@ -12,7 +12,7 @@
  * the legend/filter grammar matches the project's typed-edge palette (PSY-362).
  */
 
-import { useState, useRef, useEffect } from 'react'
+import { useState, useCallback } from 'react'
 import Link from 'next/link'
 import { Network } from 'lucide-react'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
@@ -33,18 +33,23 @@ export function BillComposition({ artistId }: BillCompositionProps) {
   const { data, isLoading } = useArtistBillComposition({ artistId, months, enabled: artistId > 0 })
   const [showGraph, setShowGraph] = useState(false)
   const [containerWidth, setContainerWidth] = useState<number | null>(null)
-  const containerRef = useRef<HTMLDivElement>(null)
 
-  // Same ResizeObserver pattern as RelatedArtists — null until measured so
-  // the canvas never flashes at the wrong size on first paint.
-  useEffect(() => {
-    if (!containerRef.current) return
+  // Callback ref instead of useRef + useEffect (PSY-519). Same fix that
+  // landed on SceneGraph.tsx (PSY-516/PSY-517): on first render this
+  // component returns `null` while TanStack Query is loading, so a ref-
+  // based useEffect with `[]` deps fires once with a null ref, bails, and
+  // never re-runs after the JSX mounts. A callback ref fires whenever the
+  // underlying DOM node mounts/unmounts, so we always measure the right
+  // node. Cleanup return is honored automatically (React 19).
+  const containerRefCallback = useCallback((node: HTMLDivElement | null) => {
+    if (!node) return
+    setContainerWidth(node.getBoundingClientRect().width)
     const observer = new ResizeObserver(entries => {
       for (const entry of entries) {
         setContainerWidth(entry.contentRect.width)
       }
     })
-    observer.observe(containerRef.current)
+    observer.observe(node)
     return () => observer.disconnect()
   }, [])
 
@@ -57,7 +62,7 @@ export function BillComposition({ artistId }: BillCompositionProps) {
     containerWidth >= GRAPH_BREAKPOINT_PX
 
   return (
-    <div ref={containerRef} className="mt-8 px-4 md:px-0">
+    <div ref={containerRefCallback} className="mt-8 px-4 md:px-0">
       <div className="flex flex-wrap items-center justify-between gap-2 mb-4">
         <h2 className="text-lg font-semibold">Bill composition</h2>
         <div className="flex items-center gap-2">

--- a/frontend/features/artists/components/RelatedArtists.tsx
+++ b/frontend/features/artists/components/RelatedArtists.tsx
@@ -59,11 +59,29 @@ export function RelatedArtists({ artistId, artistSlug }: RelatedArtistsProps) {
   const [showGraph, setShowGraph] = useState(false)
   const [activeTypes, setActiveTypes] = useState<Set<string>>(new Set(ALL_TYPES))
   const [showSuggest, setShowSuggest] = useState(false)
-  const containerRef = useRef<HTMLDivElement>(null)
   // Defer the graph render until ResizeObserver reports a real width.
   // Initialising to a hard-coded value caused the canvas to render at
   // the wrong size on first paint; null + a measured update is the fix.
   const [containerWidth, setContainerWidth] = useState<number | null>(null)
+
+  // Callback ref instead of useRef + useEffect (PSY-519). Same fix that
+  // landed on SceneGraph.tsx (PSY-516/PSY-517): on first render this
+  // component returns `null` while TanStack Query is loading, so a ref-
+  // based useEffect with `[]` deps fires once with a null ref, bails, and
+  // never re-runs after the JSX mounts. A callback ref fires whenever the
+  // underlying DOM node mounts/unmounts, so we always measure the right
+  // node. Cleanup return is honored automatically (React 19).
+  const containerRefCallback = useCallback((node: HTMLDivElement | null) => {
+    if (!node) return
+    setContainerWidth(node.getBoundingClientRect().width)
+    const observer = new ResizeObserver(entries => {
+      for (const entry of entries) {
+        setContainerWidth(entry.contentRect.width)
+      }
+    })
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [])
 
   // PSY-361: re-center state. The trail is the breadcrumb of *prior*
   // centers (not including the current). Capped at MAX_TRAIL_SLOTS=3
@@ -75,18 +93,6 @@ export function RelatedArtists({ artistId, artistSlug }: RelatedArtistsProps) {
   const [slugToIdCache, setSlugToIdCache] = useState<Record<string, number>>({})
   const [announcement, setAnnouncement] = useState('')
 
-  // Measure container width for graph
-  useEffect(() => {
-    if (!containerRef.current) return
-    const observer = new ResizeObserver(entries => {
-      for (const entry of entries) {
-        setContainerWidth(entry.contentRect.width)
-      }
-    })
-    observer.observe(containerRef.current)
-    return () => observer.disconnect()
-  }, [])
-
   if (isLoading) return null
 
   const hasRelationships = originalGraph && (originalGraph.nodes.length > 0 || originalGraph.links.length > 0)
@@ -94,7 +100,7 @@ export function RelatedArtists({ artistId, artistSlug }: RelatedArtistsProps) {
   // Empty state: show header + message + suggest button for authenticated users
   if (!hasRelationships) {
     return (
-      <div ref={containerRef} className="mt-8 px-4 md:px-0">
+      <div ref={containerRefCallback} className="mt-8 px-4 md:px-0">
         <h2 className="text-lg font-semibold mb-4">Related Artists</h2>
         <p className="text-sm text-muted-foreground">
           No similar artists yet. Be the first to suggest one!
@@ -169,7 +175,7 @@ export function RelatedArtists({ artistId, artistSlug }: RelatedArtistsProps) {
     hasEnoughForGraph && containerWidth !== null && containerWidth >= 640
 
   return (
-    <div ref={containerRef} className="mt-8 px-4 md:px-0">
+    <div ref={containerRefCallback} className="mt-8 px-4 md:px-0">
       <div className="flex items-center justify-between mb-4">
         <h2 className="text-lg font-semibold">Related Artists</h2>
         <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary

- `BillComposition` (PSY-364) and `RelatedArtists` (PSY-108) used the same `useRef` + `useEffect(() => ..., [])` + `ResizeObserver` pattern to measure container width. On first render both components return `null` while TanStack Query is loading, the effect fires once against a null ref and bails, and `useEffect` never re-runs because deps `[]` haven't changed — `containerWidth` stays `null` forever and the View Map button never renders.
- Apply the same callback-ref refactor that landed on `SceneGraph.tsx` in PSY-516 / PSY-517 (the canonical fix). Net change is ~6 lines per file.
- This clears the known-issue notes in `docs/features/bill-composition.md` and `docs/features/similar-artists.md`.

## Test plan

- [x] `bun run test:run features/artists` — 17 files / 203 tests pass (BillComposition + RelatedArtists existing tests pass unchanged; the `ImmediateResizeObserver` test shim works with both old and new patterns).
- [x] `bun x tsc --noEmit` — clean.
- [ ] Live: open `/artists/just-mustard` (≥3 shows + has related artists) at desktop width; confirm the View Map button now renders on both Bill composition and Related Artists sections.
- [ ] Live: at mobile width (<640px), confirm the button stays hidden — gate still works as designed.

## Notes

- `BillComposition.tsx`: removed `useRef` + `useEffect` imports (no other consumers in the file); added `useCallback`.
- `RelatedArtists.tsx`: kept `useRef` (still used by `SuggestSimilarArtist`'s `inputRef`) and `useEffect` (still used for slug→id cache, trail sync, recenter announcement). Only the container-measurement effect was replaced.

Closes PSY-519

🤖 Generated with [Claude Code](https://claude.com/claude-code)