### PR TITLE
PSY-372: include shows in collection Add Items search

### DIFF
--- a/frontend/components/layout/CommandPalette.test.tsx
+++ b/frontend/components/layout/CommandPalette.test.tsx
@@ -41,6 +41,9 @@ vi.mock('@/lib/context/AuthContext', () => ({
 type MockedEntitySearchData = {
   artists: unknown[]
   venues: unknown[]
+  // PSY-372: shows are returned by useEntitySearch but the palette doesn't
+  // surface them; included here so the mock matches the real shape.
+  shows: unknown[]
   releases: unknown[]
   labels: unknown[]
   festivals: unknown[]
@@ -49,6 +52,7 @@ type MockedEntitySearchData = {
 const emptyEntityData: MockedEntitySearchData = {
   artists: [],
   venues: [],
+  shows: [],
   releases: [],
   labels: [],
   festivals: [],
@@ -268,6 +272,7 @@ describe('CommandPalette — tag row official indicator (PSY-453)', () => {
       data: {
         artists: [],
         venues: [],
+        shows: [],
         releases: [],
         labels: [],
         festivals: [],

--- a/frontend/components/layout/CommandPalette.tsx
+++ b/frontend/components/layout/CommandPalette.tsx
@@ -295,6 +295,12 @@ const allRoutes = [...routes, ...adminRoutes]
 const entityTypeIcons: Record<EntitySearchResult['entityType'], LucideIcon> = {
   artist: Mic2,
   venue: MapPin,
+  // PSY-372: shows are surfaced in the entity search hook for the collection
+  // Add Items panel, but the Cmd+K palette intentionally keeps its existing
+  // behavior of not surfacing shows beyond the static `/shows` route entry.
+  // The icon/label entries exist solely to satisfy the exhaustive `Record`
+  // type — `show` is excluded from the visible-types iteration below.
+  show: Calendar,
   release: Disc3,
   label: Tag,
   festival: Tent,
@@ -305,6 +311,7 @@ const entityTypeIcons: Record<EntitySearchResult['entityType'], LucideIcon> = {
 const entityTypeLabels: Record<EntitySearchResult['entityType'], string> = {
   artist: 'Artists',
   venue: 'Venues',
+  show: 'Shows',
   release: 'Releases',
   label: 'Labels',
   festival: 'Festivals',
@@ -325,8 +332,12 @@ export function CommandPalette() {
   const [recentSearches, setRecentSearches] = useState<string[]>([])
   const [search, setSearch] = useState('')
 
-  // Entity search — only active when palette is open and query is 2+ chars
-  const { data: entityResults, isSearching, totalResults } = useEntitySearch({
+  // Entity search — only active when palette is open and query is 2+ chars.
+  // PSY-372: `totalResults` from the hook now includes shows (which the
+  // collection Add Items panel surfaces). The palette intentionally does not
+  // render shows, so we derive a palette-local `hasEntityResults` from the
+  // visible groups below instead of using the hook's total directly.
+  const { data: entityResults, isSearching } = useEntitySearch({
     query: search,
     enabled: open,
   })
@@ -386,10 +397,12 @@ export function CommandPalette() {
   }, [clearRecentSearches])
 
   const showRecent = !search && recentSearches.length > 0
-  const hasEntityResults = totalResults > 0
   const showEntityResults = search.trim().length >= 2
 
-  // Collect entity result groups that have results, in display order
+  // Collect entity result groups that have results, in display order.
+  // PSY-372: `show` is intentionally excluded — the palette does not surface
+  // shows beyond the static `/shows` route entry. Show results from the
+  // shared hook are simply ignored here.
   const entityGroups = useMemo(() => {
     if (!entityResults) return []
     const types = ['artist', 'venue', 'release', 'label', 'festival', 'tag'] as const
@@ -403,6 +416,10 @@ export function CommandPalette() {
     }
     return groups
   }, [entityResults])
+
+  // Derived from the visible groups so excluded entity types (shows) don't
+  // flip the empty-state copy when they're the only thing that matched.
+  const hasEntityResults = entityGroups.length > 0
 
   return (
     <CommandDialog open={open} onOpenChange={setOpen}>

--- a/frontend/features/collections/components/CollectionDetail.test.tsx
+++ b/frontend/features/collections/components/CollectionDetail.test.tsx
@@ -64,6 +64,9 @@ const mockDeleteMutation = vi.fn(() => ({
 }))
 const mockReorderMutate = vi.fn()
 const mockUpdateMutate = vi.fn()
+// PSY-372: spy for "Add" clicks in the Add Items panel so tests can assert
+// the right entityType/entityId is sent when adding a show.
+const mockAddItemMutate = vi.fn()
 // PSY-351: clone mutation mock — `mutate` invokes the success callback
 // directly so we can assert the post-clone navigation deterministically
 // without spinning up a real React Query client.
@@ -86,7 +89,7 @@ vi.mock('../hooks', () => ({
     error: null,
   }),
   useAddCollectionItem: () => ({
-    mutate: vi.fn(),
+    mutate: mockAddItemMutate,
     isPending: false,
     isError: false,
     error: null,
@@ -133,12 +136,36 @@ vi.mock('@/features/comments', () => ({
 }))
 
 // Mock useEntitySearch
+// Default mock — empty results across all entity types. Individual tests
+// override `mockUseEntitySearchResult` below to seed shows/artists/etc.
+type MockedEntitySearchResult = {
+  data: {
+    artists: unknown[]
+    venues: unknown[]
+    shows: unknown[]
+    releases: unknown[]
+    labels: unknown[]
+    festivals: unknown[]
+    tags: unknown[]
+  }
+  isSearching: boolean
+  totalResults: number
+}
+let mockUseEntitySearchResult: MockedEntitySearchResult = {
+  data: {
+    artists: [],
+    venues: [],
+    shows: [],
+    releases: [],
+    labels: [],
+    festivals: [],
+    tags: [],
+  },
+  isSearching: false,
+  totalResults: 0,
+}
 vi.mock('@/lib/hooks/common/useEntitySearch', () => ({
-  useEntitySearch: () => ({
-    data: { artists: [], venues: [], releases: [], labels: [], festivals: [] },
-    isSearching: false,
-    totalResults: 0,
-  }),
+  useEntitySearch: () => mockUseEntitySearchResult,
 }))
 
 function makeCollection(
@@ -203,6 +230,21 @@ describe('CollectionDetail', () => {
       isLoading: false,
       error: null,
     })
+    // Reset entity search to "no results" between tests so cases that don't
+    // rely on Add Items aren't accidentally polluted by an earlier override.
+    mockUseEntitySearchResult = {
+      data: {
+        artists: [],
+        venues: [],
+        shows: [],
+        releases: [],
+        labels: [],
+        festivals: [],
+        tags: [],
+      },
+      isSearching: false,
+      totalResults: 0,
+    }
   })
 
   it('renders collection title in heading', () => {
@@ -1331,6 +1373,150 @@ describe('CollectionDetail', () => {
       render(<CollectionDetail slug="test-collection" />)
 
       expect(screen.queryByTestId('contributor-badge')).not.toBeInTheDocument()
+    })
+  })
+
+  // ──────────────────────────────────────────────
+  // PSY-372: shows in the Add Items search
+  // ──────────────────────────────────────────────
+
+  describe('PSY-372 shows in Add Items search', () => {
+    /**
+     * Helper: open the Add Items panel and seed the entity-search mock with
+     * results in the requested entity type so the dropdown renders rows the
+     * user can interact with. Calls userEvent.click on "Add Items" but does
+     * not type into the search box — typing is unnecessary because the hook
+     * is mocked and returns the seeded data regardless.
+     */
+    async function openAddItemsWith({
+      shows = [],
+      artists = [],
+    }: {
+      shows?: Array<{
+        id: number
+        slug: string
+        name: string
+        subtitle: string | null
+        entityType: 'show'
+        href: string
+      }>
+      artists?: Array<{
+        id: number
+        slug: string
+        name: string
+        subtitle: string | null
+        entityType: 'artist'
+        href: string
+      }>
+    }) {
+      mockUseEntitySearchResult = {
+        data: {
+          artists,
+          venues: [],
+          shows,
+          releases: [],
+          labels: [],
+          festivals: [],
+          tags: [],
+        },
+        isSearching: false,
+        totalResults: shows.length + artists.length,
+      }
+      const user = userEvent.setup()
+      render(<CollectionDetail slug="test-collection" />)
+      await user.click(screen.getByRole('button', { name: /Add Items/i }))
+      // The Add Items panel only renders the dropdown when the query field
+      // has 2+ chars. Type something to satisfy the gate; the hook is mocked
+      // so the typed value is irrelevant.
+      const input = screen.getByPlaceholderText(/Search artists, shows/)
+      await user.type(input, 'tt')
+      return user
+    }
+
+    it('placeholder copy includes "shows"', async () => {
+      const user = userEvent.setup()
+      render(<CollectionDetail slug="test-collection" />)
+      await user.click(screen.getByRole('button', { name: /Add Items/i }))
+
+      const input = screen.getByPlaceholderText(
+        'Search artists, shows, venues, releases, labels, festivals...'
+      )
+      expect(input).toBeInTheDocument()
+    })
+
+    it('renders show results in the dropdown with the configured label and a "Show" badge', async () => {
+      // Synthesize a show entry mirroring how `useEntitySearch` would emit
+      // it — name pre-formatted as "{Headliner} @ {Venue} · {Date}".
+      const formattedLabel = 'Faetooth @ Valley Bar · Apr 15, 2026'
+      await openAddItemsWith({
+        shows: [
+          {
+            id: 99,
+            slug: 'faetooth-valley-bar-2026-04-15',
+            name: formattedLabel,
+            subtitle: null,
+            entityType: 'show',
+            href: '/shows/faetooth-valley-bar-2026-04-15',
+          },
+        ],
+      })
+
+      // Label rendered verbatim in the dropdown row.
+      expect(screen.getByText(formattedLabel)).toBeInTheDocument()
+      // "Show" badge appears next to the label.
+      expect(screen.getByText('Show')).toBeInTheDocument()
+    })
+
+    it('clicking Add on a show calls the add mutation with entityType "show"', async () => {
+      const user = await openAddItemsWith({
+        shows: [
+          {
+            id: 99,
+            slug: 'faetooth-valley-bar-2026-04-15',
+            name: 'Faetooth @ Valley Bar · Apr 15, 2026',
+            subtitle: null,
+            entityType: 'show',
+            href: '/shows/faetooth-valley-bar-2026-04-15',
+          },
+        ],
+      })
+
+      // The Add Items panel triggers a button labeled "Add Items" (which
+      // opened the dropdown), and each result row also has an "Add" button.
+      // We want the row's button — filter to ones whose accessible name is
+      // exactly "Add" (the row button has just "Add", not "Add Items").
+      const buttons = screen.getAllByRole('button', { name: 'Add' })
+      // There should be exactly one "Add" button (the show row).
+      expect(buttons).toHaveLength(1)
+      await user.click(buttons[0])
+
+      expect(mockAddItemMutate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          slug: 'test-collection',
+          entityType: 'show',
+          entityId: 99,
+        }),
+        expect.any(Object)
+      )
+    })
+
+    it('does not regress: artist results still render with their existing label and badge', async () => {
+      await openAddItemsWith({
+        artists: [
+          {
+            id: 1,
+            slug: 'the-growlers',
+            name: 'The Growlers',
+            subtitle: 'Dana Point, CA',
+            entityType: 'artist',
+            href: '/artists/the-growlers',
+          },
+        ],
+      })
+
+      expect(screen.getByText('The Growlers')).toBeInTheDocument()
+      expect(screen.getByText('Dana Point, CA')).toBeInTheDocument()
+      expect(screen.getByText('Artist')).toBeInTheDocument()
     })
   })
 })

--- a/frontend/features/collections/components/CollectionDetail.tsx
+++ b/frontend/features/collections/components/CollectionDetail.tsx
@@ -1105,10 +1105,13 @@ function AddItemsSection({
     enabled: isOpen,
   })
 
-  // Flatten results into a single list for display
+  // Flatten results into a single list for display.
+  // PSY-372: shows surface alongside the other entity types now that the
+  // /shows/search endpoint exists (PSY-520).
   const allResults: EntitySearchResult[] = searchResults
     ? [
         ...searchResults.artists,
+        ...searchResults.shows,
         ...searchResults.venues,
         ...searchResults.releases,
         ...searchResults.labels,
@@ -1172,7 +1175,7 @@ function AddItemsSection({
           <div className="relative">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
             <Input
-              placeholder="Search artists, venues, releases, labels, festivals..."
+              placeholder="Search artists, shows, venues, releases, labels, festivals..."
               value={searchQuery}
               onChange={e => setSearchQuery(e.target.value)}
               className="pl-9"

--- a/frontend/features/shows/api.ts
+++ b/frontend/features/shows/api.ts
@@ -16,6 +16,8 @@ export const showEndpoints = {
   SUBMIT: `${API_BASE_URL}/shows`,
   UPCOMING: `${API_BASE_URL}/shows/upcoming`,
   CITIES: `${API_BASE_URL}/shows/cities`,
+  // PSY-372 / PSY-520: autocomplete endpoint, used by useEntitySearch.
+  SEARCH: `${API_BASE_URL}/shows/search`,
   GET: (showId: string | number) => `${API_BASE_URL}/shows/${showId}`,
   UPDATE: (showId: string | number) => `${API_BASE_URL}/shows/${showId}`,
   DELETE: (showId: string | number) => `${API_BASE_URL}/shows/${showId}`,
@@ -51,4 +53,5 @@ export const showQueryKeys = {
   cities: (timezone?: string) => ['shows', 'cities', timezone] as const,
   detail: (id: string) => ['shows', 'detail', id] as const,
   userShows: (userId: string) => ['shows', 'user', userId] as const,
+  search: (query: string) => ['shows', 'search', query.toLowerCase()] as const,
 } as const

--- a/frontend/lib/hooks/common/useEntitySearch.test.tsx
+++ b/frontend/lib/hooks/common/useEntitySearch.test.tsx
@@ -24,7 +24,7 @@ describe('useEntitySearch', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     // Default: all endpoints return empty
-    mockApiRequest.mockResolvedValue({ artists: [], venues: [], releases: [], labels: [], festivals: [], tags: [], count: 0 })
+    mockApiRequest.mockResolvedValue({ artists: [], venues: [], shows: [], releases: [], labels: [], festivals: [], tags: [], count: 0 })
   })
 
   it('should not fetch when query is less than 2 characters', () => {
@@ -56,7 +56,7 @@ describe('useEntitySearch', () => {
     expect(mockApiRequest).not.toHaveBeenCalled()
   })
 
-  it('should fetch all 6 entity types when query is 2+ characters', async () => {
+  it('should fetch all 7 entity types when query is 2+ characters', async () => {
     mockApiRequest.mockImplementation((url: string) => {
       if (url.includes('/artists/search')) {
         return Promise.resolve({
@@ -66,6 +66,9 @@ describe('useEntitySearch', () => {
       }
       if (url.includes('/venues/search')) {
         return Promise.resolve({ venues: [], count: 0 })
+      }
+      if (url.includes('/shows/search')) {
+        return Promise.resolve({ shows: [], count: 0 })
       }
       if (url.includes('/releases/search')) {
         return Promise.resolve({ releases: [], count: 0 })
@@ -91,10 +94,11 @@ describe('useEntitySearch', () => {
       expect(result.current.totalResults).toBe(1)
     })
 
-    // All 6 endpoints should be called
-    expect(mockApiRequest).toHaveBeenCalledTimes(6)
+    // All 7 endpoints should be called (PSY-372: shows added)
+    expect(mockApiRequest).toHaveBeenCalledTimes(7)
     expect(mockApiRequest).toHaveBeenCalledWith(expect.stringContaining('/artists/search?q=growlers'))
     expect(mockApiRequest).toHaveBeenCalledWith(expect.stringContaining('/venues/search?q=growlers'))
+    expect(mockApiRequest).toHaveBeenCalledWith(expect.stringContaining('/shows/search?q=growlers'))
     expect(mockApiRequest).toHaveBeenCalledWith(expect.stringContaining('/releases/search?q=growlers'))
     expect(mockApiRequest).toHaveBeenCalledWith(expect.stringContaining('/labels/search?q=growlers'))
     expect(mockApiRequest).toHaveBeenCalledWith(expect.stringContaining('/festivals/search?q=growlers'))
@@ -272,6 +276,94 @@ describe('useEntitySearch', () => {
       entityType: 'label',
       href: '/labels/sub-pop',
     })
+  })
+
+  // PSY-372: shows surface alongside the other entity types now that the
+  // /shows/search endpoint exists (PSY-520). Label format = "{Headliner} @
+  // {Venue} · {Date}" goes into `name`; subtitle is null.
+  it('should map show results correctly', async () => {
+    mockApiRequest.mockImplementation((url: string) => {
+      if (url.includes('/shows/search')) {
+        return Promise.resolve({
+          shows: [
+            {
+              id: 42,
+              slug: 'faetooth-valley-bar-2026-04-15',
+              title: 'Faetooth at Valley Bar',
+              headliner_name: 'Faetooth',
+              venue_name: 'Valley Bar',
+              event_date: '2026-04-15T03:00:00Z',
+            },
+          ],
+          count: 1,
+        })
+      }
+      return Promise.resolve({ artists: [], venues: [], releases: [], labels: [], festivals: [], tags: [], count: 0 })
+    })
+
+    const { result } = renderHook(
+      () => useEntitySearch({ query: 'faetooth' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => {
+      expect(result.current.data?.shows.length).toBe(1)
+    })
+
+    const show = result.current.data!.shows[0]
+    expect(show.id).toBe(42)
+    expect(show.slug).toBe('faetooth-valley-bar-2026-04-15')
+    expect(show.entityType).toBe('show')
+    expect(show.href).toBe('/shows/faetooth-valley-bar-2026-04-15')
+    expect(show.subtitle).toBeNull()
+    // Label format: "{Headliner} @ {Venue} · {Date}". The exact rendered
+    // date depends on the test environment's locale/TZ; assert structure
+    // (headliner, separator, venue, separator, year) instead of full equality
+    // so the test stays stable across CI timezones.
+    expect(show.name).toContain('Faetooth')
+    expect(show.name).toContain('@ Valley Bar')
+    expect(show.name).toContain('·')
+    expect(show.name).toContain('2026')
+  })
+
+  it('should fall back gracefully when show fields are sparse', async () => {
+    // Defensive: a row with no headliner / venue should still render
+    // something meaningful in the dropdown (the title or date) rather than
+    // an empty string or orphan separator.
+    mockApiRequest.mockImplementation((url: string) => {
+      if (url.includes('/shows/search')) {
+        return Promise.resolve({
+          shows: [
+            {
+              id: 7,
+              slug: 'fallback-show',
+              title: 'Fallback Title',
+              headliner_name: '',
+              venue_name: '',
+              event_date: '2026-04-15T03:00:00Z',
+            },
+          ],
+          count: 1,
+        })
+      }
+      return Promise.resolve({ artists: [], venues: [], releases: [], labels: [], festivals: [], tags: [], count: 0 })
+    })
+
+    const { result } = renderHook(
+      () => useEntitySearch({ query: 'fallback' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => {
+      expect(result.current.data?.shows.length).toBe(1)
+    })
+
+    const show = result.current.data!.shows[0]
+    // Without headliner+venue, label is just the date.
+    expect(show.name).toContain('2026')
+    // No orphan "@ " or trailing " · ".
+    expect(show.name).not.toMatch(/^@/)
+    expect(show.name).not.toMatch(/·\s*$/)
   })
 
   it('should map festival results correctly', async () => {

--- a/frontend/lib/hooks/common/useEntitySearch.ts
+++ b/frontend/lib/hooks/common/useEntitySearch.ts
@@ -8,6 +8,7 @@ import { venueEndpoints } from '@/features/venues/api'
 import { releaseEndpoints } from '@/features/releases/api'
 import { labelEndpoints } from '@/features/labels/api'
 import { festivalEndpoints } from '@/features/festivals/api'
+import { showEndpoints } from '@/features/shows/api'
 
 // ============================================================================
 // Types
@@ -19,7 +20,7 @@ export interface EntitySearchResult {
   name: string
   /** Subtitle info (e.g., city/state, release type, year) */
   subtitle: string | null
-  entityType: 'artist' | 'venue' | 'release' | 'label' | 'festival' | 'tag'
+  entityType: 'artist' | 'venue' | 'show' | 'release' | 'label' | 'festival' | 'tag'
   href: string
   /**
    * Only populated for tag results — surfaces the curated-tag mark in the
@@ -31,6 +32,7 @@ export interface EntitySearchResult {
 export interface EntitySearchResults {
   artists: EntitySearchResult[]
   venues: EntitySearchResult[]
+  shows: EntitySearchResult[]
   releases: EntitySearchResult[]
   labels: EntitySearchResult[]
   festivals: EntitySearchResult[]
@@ -52,6 +54,18 @@ interface VenueSearchItem {
   name: string
   city?: string
   state?: string
+}
+
+// PSY-372 / PSY-520: GET /shows/search row shape. Field names mirror
+// backend `contracts.ShowSearchResult` exactly (snake_case on the wire).
+// `event_date` is an ISO 8601 string per Go's time.Time JSON marshalling.
+interface ShowSearchItem {
+  id: number
+  slug: string
+  title: string
+  headliner_name: string
+  venue_name: string
+  event_date: string
 }
 
 interface ReleaseSearchItem {
@@ -120,6 +134,45 @@ function mapVenue(v: VenueSearchItem): EntitySearchResult {
   }
 }
 
+// PSY-372: shows are most recognizable by headliner+venue+date. Most shows
+// have auto-generated titles, so we synthesize the full identifier label
+// here and put it in `name`. Format mirrors the ticket spec exactly:
+// "{Headliner} @ {Venue} · {Date}" (e.g. "Faetooth @ Valley Bar · Apr 15, 2026").
+//
+// Date formatting: the search row only carries the ISO event_date — there's
+// no venue timezone in the payload to localize against, and search labels
+// are identification, not show-up-time. Using the user's locale here is
+// fine; venue-timezone formatting is reserved for show-detail UIs.
+function mapShow(s: ShowSearchItem): EntitySearchResult {
+  const date = new Date(s.event_date)
+  const dateLabel = Number.isNaN(date.getTime())
+    ? ''
+    : date.toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+      })
+
+  // Each segment is conditionally appended so a missing field (sparse data)
+  // doesn't leak orphan separators into the label.
+  const parts: string[] = []
+  if (s.headliner_name) parts.push(s.headliner_name)
+  if (s.venue_name) parts.push(`@ ${s.venue_name}`)
+  // Join headliner + venue with a space so we get "Faetooth @ Valley Bar".
+  const left = parts.join(' ')
+  const label =
+    left && dateLabel ? `${left} · ${dateLabel}` : left || dateLabel || s.title
+
+  return {
+    id: s.id,
+    slug: s.slug,
+    name: label,
+    subtitle: null,
+    entityType: 'show',
+    href: `/shows/${s.slug}`,
+  }
+}
+
 function mapRelease(r: ReleaseSearchItem): EntitySearchResult {
   const parts: string[] = []
   if (r.release_type) parts.push(r.release_type)
@@ -183,13 +236,16 @@ async function fetchEntitySearch(query: string): Promise<EntitySearchResults> {
   const encoded = encodeURIComponent(query)
 
   // Fire all requests in parallel; if individual ones fail, return empty arrays
-  const [artists, venues, releases, labels, festivals, tags] = await Promise.all([
+  const [artists, venues, shows, releases, labels, festivals, tags] = await Promise.all([
     apiRequest<{ artists: ArtistSearchItem[]; count: number }>(
       `${artistEndpoints.SEARCH}?q=${encoded}`
     ).catch(() => ({ artists: [], count: 0 })),
     apiRequest<{ venues: VenueSearchItem[]; count: number }>(
       `${venueEndpoints.SEARCH}?q=${encoded}`
     ).catch(() => ({ venues: [], count: 0 })),
+    apiRequest<{ shows: ShowSearchItem[]; count: number }>(
+      `${showEndpoints.SEARCH}?q=${encoded}`
+    ).catch(() => ({ shows: [], count: 0 })),
     apiRequest<{ releases: ReleaseSearchItem[]; count: number }>(
       `${releaseEndpoints.SEARCH}?q=${encoded}`
     ).catch(() => ({ releases: [], count: 0 })),
@@ -207,6 +263,7 @@ async function fetchEntitySearch(query: string): Promise<EntitySearchResults> {
   return {
     artists: (artists.artists || []).slice(0, MAX_RESULTS_PER_TYPE).map(mapArtist),
     venues: (venues.venues || []).slice(0, MAX_RESULTS_PER_TYPE).map(mapVenue),
+    shows: (shows.shows || []).slice(0, MAX_RESULTS_PER_TYPE).map(mapShow),
     releases: (releases.releases || []).slice(0, MAX_RESULTS_PER_TYPE).map(mapRelease),
     labels: (labels.labels || []).slice(0, MAX_RESULTS_PER_TYPE).map(mapLabel),
     festivals: (festivals.festivals || []).slice(0, MAX_RESULTS_PER_TYPE).map(mapFestival),
@@ -221,6 +278,7 @@ async function fetchEntitySearch(query: string): Promise<EntitySearchResults> {
 const EMPTY_RESULTS: EntitySearchResults = {
   artists: [],
   venues: [],
+  shows: [],
   releases: [],
   labels: [],
   festivals: [],
@@ -228,8 +286,9 @@ const EMPTY_RESULTS: EntitySearchResults = {
 }
 
 /**
- * Hook for searching entities across all types (artists, venues, releases, labels, festivals, tags).
- * Used in the Cmd+K command palette to provide entity results alongside page navigation.
+ * Hook for searching entities across all types (artists, venues, shows,
+ * releases, labels, festivals, tags). Used by the collection-detail
+ * "Add Items" search panel and the Cmd+K command palette.
  *
  * Returns results grouped by entity type, limited to 5 per type.
  * Debounces input by default (300ms) and requires at least 2 characters.
@@ -256,6 +315,7 @@ export function useEntitySearch(options: {
   const totalResults =
     (result.data?.artists.length ?? 0) +
     (result.data?.venues.length ?? 0) +
+    (result.data?.shows.length ?? 0) +
     (result.data?.releases.length ?? 0) +
     (result.data?.labels.length ?? 0) +
     (result.data?.festivals.length ?? 0) +


### PR DESCRIPTION
## Summary

- Wire shows into the shared `useEntitySearch` hook now that the GET `/shows/search` backend endpoint (PSY-520) is shipped, then surface them in the collection-detail Add Items panel.
- Update placeholder copy to "Search artists, shows, venues, releases, labels, festivals..." and render show rows with the ticket-spec label format `"{Headliner} @ {Venue} · {Date}"` (e.g. `"Faetooth @ Valley Bar · Apr 15, 2026"`) — single-line `name`, no subtitle, with the existing "Show" badge from `getEntityTypeLabel`.
- Keep CommandPalette behavior unchanged: it still does not surface shows beyond the static `/shows` route entry. The visible-types iteration excludes `show`, and `hasEntityResults` is now derived from those visible groups so empty-state copy doesn't flip when only shows match.

## What this fixes

The `/collections` browse page already exposes a Shows filter chip backed by `entity_type='show'`. Before this change, that chip always returned "No collections yet" in production because the Add Items search omitted shows entirely — there was no UI path to add a show to a collection. Now you can.

## Test plan

- [x] `cd frontend && bun run test:run features/collections lib/hooks/common features/shows` → 557 / 557 pass.
- [x] `cd frontend && bun run test:run components/layout features/collections lib/hooks` (broader sweep) → 453 / 453 pass.
- [x] `cd frontend && bun x tsc --noEmit` → clean.
- [ ] Manual: open a collection detail page as the creator, click Add Items, search for a known headliner / venue / show title, confirm the show row renders with the configured label and a "Show" badge.
- [ ] Manual: add a show to a collection, then load `/collections?entity_type=show` and confirm the collection appears (closes the original PSY-319 dogfood gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)