### PR TITLE
PSY-514: hide 'Show replies' button when reply_count === 0

### DIFF
--- a/backend/internal/services/contracts/comment.go
+++ b/backend/internal/services/contracts/comment.go
@@ -82,6 +82,11 @@ type CommentResponse struct {
 	Score           float64          `json:"score"`
 	IsEdited        bool             `json:"is_edited"`
 	EditCount       int              `json:"edit_count"`
+	// ReplyCount is the number of direct replies (depth = depth+1, parent_id = this).
+	// Currently populated only by ListCommentsForEntity for top-level comments so
+	// the UI can suppress an "expand replies" affordance on zero-reply threads
+	// (PSY-514). Other paths leave this at the zero value.
+	ReplyCount      int              `json:"reply_count"`
 	UserVote        *int             `json:"user_vote,omitempty"` // 1, -1, or nil if no vote
 	CreatedAt       time.Time        `json:"created_at"`
 	UpdatedAt       time.Time        `json:"updated_at"`

--- a/backend/internal/services/engagement/comment_service.go
+++ b/backend/internal/services/engagement/comment_service.go
@@ -523,10 +523,38 @@ func (s *CommentService) ListCommentsForEntity(entityType string, entityID uint,
 		return nil, fmt.Errorf("failed to fetch comments: %w", err)
 	}
 
+	// PSY-514: count visible replies per top-level comment so the frontend can
+	// suppress the "Show replies" button on zero-reply comments. We only count
+	// visible direct children — hidden/removed replies don't render anything
+	// expandable. One round-trip via GROUP BY keeps this off the per-row N+1.
+	replyCounts := make(map[uint]int, len(comments))
+	if len(comments) > 0 {
+		parentIDs := make([]uint, 0, len(comments))
+		for i := range comments {
+			parentIDs = append(parentIDs, comments[i].ID)
+		}
+		type replyCountRow struct {
+			ParentID uint
+			Count    int
+		}
+		var rows []replyCountRow
+		if err := s.db.Model(&models.Comment{}).
+			Select("parent_id, COUNT(*) AS count").
+			Where("parent_id IN ? AND visibility = ?", parentIDs, models.CommentVisibilityVisible).
+			Group("parent_id").
+			Scan(&rows).Error; err != nil {
+			return nil, fmt.Errorf("failed to count replies: %w", err)
+		}
+		for _, r := range rows {
+			replyCounts[r.ParentID] = r.Count
+		}
+	}
+
 	// Map to response
 	responses := make([]*contracts.CommentResponse, len(comments))
 	for i := range comments {
 		responses[i] = commentToResponse(&comments[i])
+		responses[i].ReplyCount = replyCounts[comments[i].ID]
 	}
 
 	return &contracts.CommentListResponse{

--- a/backend/internal/services/engagement/comment_service_test.go
+++ b/backend/internal/services/engagement/comment_service_test.go
@@ -873,6 +873,45 @@ func (suite *CommentServiceIntegrationTestSuite) TestListComments_InvalidEntityT
 	suite.Contains(err.Error(), "unsupported entity type")
 }
 
+// PSY-514: top-level comments must carry an accurate count of their visible
+// direct replies so the frontend can suppress the "Show replies" button on
+// zero-reply threads. We count visible replies only — hidden/removed replies
+// don't render anything expandable, so they shouldn't bump the count.
+func (suite *CommentServiceIntegrationTestSuite) TestListComments_ReplyCount() {
+	user := suite.createTestUser()
+	artistID := suite.createTestArtist("Reply Count Artist")
+
+	// Three top-level comments: one with two replies, one with a hidden
+	// reply (should count as zero), one with no replies at all.
+	rootWithReplies := suite.insertComment(user.ID, "artist", artistID, "Has replies", nil, nil, 0)
+	suite.insertComment(user.ID, "artist", artistID, "Reply A", &rootWithReplies.ID, &rootWithReplies.ID, 1)
+	suite.insertComment(user.ID, "artist", artistID, "Reply B", &rootWithReplies.ID, &rootWithReplies.ID, 1)
+
+	rootHiddenReply := suite.insertComment(user.ID, "artist", artistID, "Hidden reply only", nil, nil, 0)
+	hiddenReply := suite.insertComment(user.ID, "artist", artistID, "Soft-deleted reply", &rootHiddenReply.ID, &rootHiddenReply.ID, 1)
+	suite.Require().NoError(
+		suite.db.Model(&models.Comment{}).
+			Where("id = ?", hiddenReply.ID).
+			Update("visibility", models.CommentVisibilityHiddenByUser).Error,
+	)
+
+	rootNoReplies := suite.insertComment(user.ID, "artist", artistID, "No replies", nil, nil, 0)
+
+	result, err := suite.commentService.ListCommentsForEntity("artist", artistID, contracts.CommentListFilters{
+		Sort: "new",
+	})
+	suite.Require().NoError(err)
+	suite.Require().Len(result.Comments, 3)
+
+	byID := make(map[uint]*contracts.CommentResponse, len(result.Comments))
+	for _, c := range result.Comments {
+		byID[c.ID] = c
+	}
+	suite.Equal(2, byID[rootWithReplies.ID].ReplyCount, "should count both visible replies")
+	suite.Equal(0, byID[rootHiddenReply.ID].ReplyCount, "hidden replies should not count")
+	suite.Equal(0, byID[rootNoReplies.ID].ReplyCount, "no replies means zero count")
+}
+
 // =============================================================================
 // Group 5: GetThread
 // =============================================================================

--- a/frontend/features/comments/components/CommentCard.test.tsx
+++ b/frontend/features/comments/components/CommentCard.test.tsx
@@ -129,3 +129,88 @@ describe('CommentCard — admin edit history trigger (PSY-297)', () => {
     ).not.toBeInTheDocument()
   })
 })
+
+// PSY-514: top-level comments with zero replies must NOT render a "Show
+// replies" affordance. Previously the button rendered unconditionally on
+// every top-level comment; clicking it removed the button without showing
+// anything else (no replies to load) — read as a no-op, and was actively
+// misleading on `author_only` comments where replies are impossible.
+describe('CommentCard — Show replies button gating (PSY-514)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuthContext.mockReturnValue({
+      isAuthenticated: false,
+      user: null,
+    })
+  })
+
+  const defaultProps = {
+    entityType: 'artist',
+    entityId: 10,
+  }
+
+  it('does NOT render "Show replies" when reply_count is 0', () => {
+    render(
+      <CommentCard
+        {...defaultProps}
+        comment={makeComment({ reply_count: 0 })}
+      />
+    )
+
+    expect(
+      screen.queryByTestId('show-replies-button')
+    ).not.toBeInTheDocument()
+  })
+
+  it('does NOT render "Show replies" when reply_count is missing (undefined)', () => {
+    // Older comment payloads (or paths that don't populate reply_count) are
+    // treated as zero-reply for rendering purposes.
+    render(<CommentCard {...defaultProps} comment={makeComment()} />)
+
+    expect(
+      screen.queryByTestId('show-replies-button')
+    ).not.toBeInTheDocument()
+  })
+
+  it('does NOT render "Show replies" on author_only comments with zero replies', () => {
+    render(
+      <CommentCard
+        {...defaultProps}
+        comment={makeComment({
+          reply_permission: 'author_only',
+          reply_count: 0,
+        })}
+      />
+    )
+
+    expect(
+      screen.queryByTestId('show-replies-button')
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders "Show replies" when reply_count > 0', () => {
+    render(
+      <CommentCard
+        {...defaultProps}
+        comment={makeComment({ reply_count: 3 })}
+      />
+    )
+
+    expect(screen.getByTestId('show-replies-button')).toBeInTheDocument()
+  })
+
+  it('does NOT render "Show replies" on a reply (depth > 0) even with reply_count > 0', () => {
+    // Defense in depth: the button is only the expand-replies affordance
+    // on top-level comments. Nested replies use the inline rendering path.
+    render(
+      <CommentCard
+        {...defaultProps}
+        comment={makeComment({ depth: 1, reply_count: 5 })}
+      />
+    )
+
+    expect(
+      screen.queryByTestId('show-replies-button')
+    ).not.toBeInTheDocument()
+  })
+})

--- a/frontend/features/comments/components/CommentCard.tsx
+++ b/frontend/features/comments/components/CommentCard.tsx
@@ -364,18 +364,28 @@ export function CommentCard({
         </div>
       )}
 
-      {/* Load replies button for top-level comments with no inline replies */}
-      {!hasInlineReplies && !loadedThread && comment.depth === 0 && (
-        <Button
-          variant="ghost"
-          size="sm"
-          className="h-6 px-1 text-xs text-muted-foreground mt-1"
-          onClick={() => setLoadedThread(true)}
-        >
-          <MessageSquare className="h-3.5 w-3.5 mr-1" />
-          Show replies
-        </Button>
-      )}
+      {/* Load replies button for top-level comments with no inline replies.
+          PSY-514: also gate on reply_count > 0 so we don't render a "Show
+          replies" affordance on threads that have none — clicking did
+          nothing, and on `author_only` comments it was actively misleading.
+          Comments fetched by routes that don't populate reply_count (e.g.
+          single-comment endpoints) leave the field undefined; treat the
+          missing-field case the same as 0 since there's no signal to act on. */}
+      {!hasInlineReplies &&
+        !loadedThread &&
+        comment.depth === 0 &&
+        (comment.reply_count ?? 0) > 0 && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 px-1 text-xs text-muted-foreground mt-1"
+            onClick={() => setLoadedThread(true)}
+            data-testid="show-replies-button"
+          >
+            <MessageSquare className="h-3.5 w-3.5 mr-1" />
+            Show replies
+          </Button>
+        )}
 
       {/* Report dialog */}
       {isAuthenticated && !isOwner && (

--- a/frontend/features/comments/components/FieldNoteCard.test.tsx
+++ b/frontend/features/comments/components/FieldNoteCard.test.tsx
@@ -264,4 +264,39 @@ describe('FieldNoteCard', () => {
 
     expect(screen.getByText('Edited')).toBeInTheDocument()
   })
+
+  // PSY-514: same zero-reply gating that applies to CommentCard.
+  describe('Show replies button gating (PSY-514)', () => {
+    it('does NOT render "Show replies" when reply_count is 0', () => {
+      render(
+        <FieldNoteCard
+          comment={makeFieldNote({ reply_count: 0 })}
+          showId={10}
+        />
+      )
+
+      expect(
+        screen.queryByTestId('show-replies-button')
+      ).not.toBeInTheDocument()
+    })
+
+    it('does NOT render "Show replies" when reply_count is missing', () => {
+      render(<FieldNoteCard comment={makeFieldNote()} showId={10} />)
+
+      expect(
+        screen.queryByTestId('show-replies-button')
+      ).not.toBeInTheDocument()
+    })
+
+    it('renders "Show replies" when reply_count > 0', () => {
+      render(
+        <FieldNoteCard
+          comment={makeFieldNote({ reply_count: 2 })}
+          showId={10}
+        />
+      )
+
+      expect(screen.getByTestId('show-replies-button')).toBeInTheDocument()
+    })
+  })
 })

--- a/frontend/features/comments/components/FieldNoteCard.tsx
+++ b/frontend/features/comments/components/FieldNoteCard.tsx
@@ -304,18 +304,24 @@ export function FieldNoteCard({
         </div>
       )}
 
-      {/* Load replies button */}
-      {!hasInlineReplies && !loadedThread && comment.depth === 0 && (
-        <Button
-          variant="ghost"
-          size="sm"
-          className="h-6 px-1 text-xs text-muted-foreground mt-1"
-          onClick={() => setLoadedThread(true)}
-        >
-          <MessageSquare className="h-3.5 w-3.5 mr-1" />
-          Show replies
-        </Button>
-      )}
+      {/* Load replies button. PSY-514: same gating as CommentCard — suppress
+          when reply_count is 0 (or missing), otherwise the click reads as a
+          no-op since there are no replies to fetch. */}
+      {!hasInlineReplies &&
+        !loadedThread &&
+        comment.depth === 0 &&
+        (comment.reply_count ?? 0) > 0 && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 px-1 text-xs text-muted-foreground mt-1"
+            onClick={() => setLoadedThread(true)}
+            data-testid="show-replies-button"
+          >
+            <MessageSquare className="h-3.5 w-3.5 mr-1" />
+            Show replies
+          </Button>
+        )}
 
       {/* Report dialog */}
       {isAuthenticated && !isOwner && (

--- a/frontend/features/comments/types.ts
+++ b/frontend/features/comments/types.ts
@@ -38,6 +38,11 @@ export interface Comment {
   reply_permission: string
   edit_count: number
   is_edited: boolean
+  // PSY-514: count of direct visible replies. Populated by the list endpoint
+  // for top-level comments so we can suppress the "Show replies" affordance
+  // on zero-reply threads. Other endpoints leave this at 0; treat it as a
+  // hint, not an authoritative source for nested rendering.
+  reply_count?: number
   created_at: string
   updated_at: string
   user_vote?: number | null


### PR DESCRIPTION
## Summary

- Fixes the "Show replies" button rendering on zero-reply top-level comments. Clicking did nothing visible (the button just vanished), and on `author_only` ("Replies disabled") comments it was actively misleading — there was no path for replies to ever exist.
- Backend: add `reply_count` to `CommentResponse`, populated only by `ListCommentsForEntity` via a single GROUP BY over visible direct children. Other endpoints leave the field at zero; they don't drive the expand-replies affordance.
- Frontend: gate the "Show replies" button on `(reply_count ?? 0) > 0` in both `CommentCard.tsx` and `FieldNoteCard.tsx` (same bug appeared in both).

## Implementation notes

- The `ListCommentsForEntity` endpoint only returns top-level rows (`parent_id IS NULL`). With no replies in the same response, the previous gating (`!hasInlineReplies && !loadedThread && comment.depth === 0`) effectively rendered the button on every top-level comment. Adding an authoritative count to the response is the cheapest way to know whether replies exist before fetching the thread.
- The new GROUP BY counts visible replies only — `hidden_by_user` / `hidden_by_mod` rows can't render anything expandable, so they shouldn't bump the count.
- Treating missing `reply_count` (undefined) the same as 0 is a safe default for paths that don't populate it (single-comment fetches, mutation responses on freshly-created comments — which by definition have no replies yet).

## Test plan

- [x] Backend: `go test ./internal/services/engagement/ -run TestCommentServiceIntegrationTestSuite/TestListComments_ReplyCount -v` (passes; new test verifies counts ignore hidden replies and zero-reply roots return 0)
- [x] Backend: full `engagement` package test suite passes (`go test ./internal/services/engagement/...`)
- [x] Frontend: `bun run test:run features/comments` — 75/75 pass (includes 8 new PSY-514 cases across CommentCard + FieldNoteCard)
- [x] Frontend: `bun x tsc --noEmit` clean
- [ ] Manual: visit `/artists/health`, confirm `author_only` comment no longer shows "Show replies"; on a comment with replies, the button still renders and toggles correctly

## Out of scope

- Per the ticket coordination note, the metadata/header section of `CommentCard.tsx` and `FieldNoteCard.tsx` (where the parallel PSY-513 agent is adding a "Pending review" badge) was not touched. Changes are confined to the reply-button area.

Closes PSY-514

🤖 Generated with [Claude Code](https://claude.com/claude-code)