### PR TITLE
PSY-513: pending-review comment feedback (toast + optimistic render)

### DIFF
--- a/frontend/features/comments/components/CommentCard.test.tsx
+++ b/frontend/features/comments/components/CommentCard.test.tsx
@@ -129,3 +129,80 @@ describe('CommentCard — admin edit history trigger (PSY-297)', () => {
     ).not.toBeInTheDocument()
   })
 })
+
+// PSY-513: pending-review badge — author-only visibility.
+describe('CommentCard — pending review badge (PSY-513)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const defaultProps = {
+    entityType: 'artist',
+    entityId: 10,
+  }
+
+  it('renders the pending-review badge for the comment author', () => {
+    mockAuthContext.mockReturnValue({
+      isAuthenticated: true,
+      user: { id: '99', email: 'me@me.com' },
+    })
+
+    render(
+      <CommentCard
+        {...defaultProps}
+        comment={makeComment({ visibility: 'pending_review', user_id: 99 })}
+      />
+    )
+
+    expect(screen.getByTestId('pending-review-badge')).toBeInTheDocument()
+    expect(screen.getByText('Pending review')).toBeInTheDocument()
+  })
+
+  it('does NOT render the pending-review badge for non-authors', () => {
+    mockAuthContext.mockReturnValue({
+      isAuthenticated: true,
+      user: { id: '7', email: 'other@user.com' },
+    })
+
+    render(
+      <CommentCard
+        {...defaultProps}
+        comment={makeComment({ visibility: 'pending_review', user_id: 99 })}
+      />
+    )
+
+    expect(screen.queryByTestId('pending-review-badge')).not.toBeInTheDocument()
+  })
+
+  it('does NOT render the pending-review badge for anonymous viewers', () => {
+    mockAuthContext.mockReturnValue({
+      isAuthenticated: false,
+      user: null,
+    })
+
+    render(
+      <CommentCard
+        {...defaultProps}
+        comment={makeComment({ visibility: 'pending_review', user_id: 99 })}
+      />
+    )
+
+    expect(screen.queryByTestId('pending-review-badge')).not.toBeInTheDocument()
+  })
+
+  it('does NOT render the pending-review badge on a normal visible comment', () => {
+    mockAuthContext.mockReturnValue({
+      isAuthenticated: true,
+      user: { id: '99', email: 'me@me.com' },
+    })
+
+    render(
+      <CommentCard
+        {...defaultProps}
+        comment={makeComment({ visibility: 'visible', user_id: 99 })}
+      />
+    )
+
+    expect(screen.queryByTestId('pending-review-badge')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/features/comments/components/CommentCard.tsx
+++ b/frontend/features/comments/components/CommentCard.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { ChevronUp, ChevronDown, MessageSquare, Pencil, Trash2, ChevronRight, Flag, History, Lock } from 'lucide-react'
+import { ChevronUp, ChevronDown, MessageSquare, Pencil, Trash2, ChevronRight, Flag, History, Lock, Clock } from 'lucide-react'
 import { formatRelativeTime } from '@/lib/formatRelativeTime'
 import { useAuthContext } from '@/lib/context/AuthContext'
 import { Button } from '@/components/ui/button'
@@ -138,6 +138,20 @@ export function CommentCard({
         {comment.is_edited && (
           <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
             Edited
+          </Badge>
+        )}
+        {/* PSY-513: pending-review badge for the author of a queued comment.
+            Gated on isOwner so other viewers don't see queued comments even if
+            one slips into the cache. The badge mirrors the existing reply-
+            permission badge pattern (outline + small icon). */}
+        {comment.visibility === 'pending_review' && isOwner && (
+          <Badge
+            variant="outline"
+            className="text-[10px] px-1.5 py-0 gap-1 border-amber-700/50 text-amber-500"
+            data-testid="pending-review-badge"
+          >
+            <Clock className="h-2.5 w-2.5" />
+            Pending review
           </Badge>
         )}
         {/* PSY-296 start: reply-permission badge (only for non-default values). */}

--- a/frontend/features/comments/components/CommentThread.test.tsx
+++ b/frontend/features/comments/components/CommentThread.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { CommentThread } from './CommentThread'
+import type { Comment } from '../types'
 
 // --- Mocks ---
 
@@ -191,5 +192,162 @@ describe('CommentThread', () => {
     expect(screen.getByText('Best')).toBeInTheDocument()
     expect(screen.getByText('New')).toBeInTheDocument()
     expect(screen.getByText('Top')).toBeInTheDocument()
+  })
+
+  // PSY-513: pending-review feedback.
+  describe('pending-review feedback (PSY-513)', () => {
+    function makePending(overrides: Partial<Comment> = {}): Comment {
+      return {
+        id: 9001,
+        entity_type: 'artist',
+        entity_id: 42,
+        user_id: 7,
+        author_name: 'NewUser',
+        body: 'Will it appear?',
+        body_html: '<p>Will it appear?</p>',
+        parent_id: null,
+        root_id: null,
+        depth: 0,
+        ups: 0,
+        downs: 0,
+        score: 0,
+        visibility: 'pending_review',
+        reply_permission: 'anyone',
+        edit_count: 0,
+        is_edited: false,
+        created_at: '2026-04-29T18:00:00Z',
+        updated_at: '2026-04-29T18:00:00Z',
+        ...overrides,
+      }
+    }
+
+    it('renders banner + optimistic comment with badge when POST returns pending_review', () => {
+      const pending = makePending()
+      // Make the mocked mutate invoke onSuccess synchronously with a
+      // pending_review response — emulates a new_user-tier submit.
+      const mutateImpl = vi.fn(
+        (_args: unknown, opts?: { onSuccess?: (data: Comment) => void }) => {
+          opts?.onSuccess?.(pending)
+        }
+      )
+      mockUseCreateComment.mockReturnValue({
+        mutate: mutateImpl,
+        isPending: false,
+      })
+      mockUseAuthContext.mockReturnValue({
+        isAuthenticated: true,
+        user: { id: '7', email: 'newuser@example.com' },
+      })
+      mockUseComments.mockReturnValue({
+        data: { comments: [], total: 0, has_more: false },
+        isLoading: false,
+      })
+
+      render(<CommentThread {...defaultProps} />)
+
+      // Empty state visible before submit.
+      expect(screen.getByTestId('empty-state')).toBeInTheDocument()
+      expect(screen.queryByTestId('pending-review-banner')).not.toBeInTheDocument()
+
+      // Submit the form.
+      fireEvent.change(screen.getByTestId('comment-textarea'), {
+        target: { value: 'Will it appear?' },
+      })
+      fireEvent.click(screen.getByTestId('comment-submit'))
+
+      // Banner appears.
+      expect(screen.getByTestId('pending-review-banner')).toBeInTheDocument()
+      expect(
+        screen.getByText(/awaiting moderation/i)
+      ).toBeInTheDocument()
+
+      // Empty-state is suppressed once a pending comment exists.
+      expect(screen.queryByTestId('empty-state')).not.toBeInTheDocument()
+
+      // Optimistic comment with the Pending review badge is rendered.
+      expect(screen.getByTestId('pending-review-badge')).toBeInTheDocument()
+      expect(screen.getByText('Will it appear?')).toBeInTheDocument()
+    })
+
+    it('does NOT render banner when POST returns visible (trusted-tier auto-publish)', () => {
+      const visible: Comment = {
+        ...makePending({ visibility: 'visible' }),
+      }
+      const mutateImpl = vi.fn(
+        (_args: unknown, opts?: { onSuccess?: (data: Comment) => void }) => {
+          opts?.onSuccess?.(visible)
+        }
+      )
+      mockUseCreateComment.mockReturnValue({
+        mutate: mutateImpl,
+        isPending: false,
+      })
+      mockUseAuthContext.mockReturnValue({
+        isAuthenticated: true,
+        user: { id: '7', email: 'trusted@example.com' },
+      })
+      mockUseComments.mockReturnValue({
+        data: { comments: [], total: 0, has_more: false },
+        isLoading: false,
+      })
+
+      render(<CommentThread {...defaultProps} />)
+
+      fireEvent.change(screen.getByTestId('comment-textarea'), {
+        target: { value: 'Auto-published' },
+      })
+      fireEvent.click(screen.getByTestId('comment-submit'))
+
+      expect(screen.queryByTestId('pending-review-banner')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('pending-review-badge')).not.toBeInTheDocument()
+    })
+
+    it('drops the optimistic entry once the canonical row appears in the list (post-approval refetch)', () => {
+      const pending = makePending()
+      const mutateImpl = vi.fn(
+        (_args: unknown, opts?: { onSuccess?: (data: Comment) => void }) => {
+          opts?.onSuccess?.(pending)
+        }
+      )
+      mockUseCreateComment.mockReturnValue({
+        mutate: mutateImpl,
+        isPending: false,
+      })
+      mockUseAuthContext.mockReturnValue({
+        isAuthenticated: true,
+        user: { id: '7', email: 'newuser@example.com' },
+      })
+
+      // Initially the canonical list is empty (server still has it pending).
+      mockUseComments.mockReturnValue({
+        data: { comments: [], total: 0, has_more: false },
+        isLoading: false,
+      })
+
+      const { rerender } = render(<CommentThread {...defaultProps} />)
+
+      fireEvent.change(screen.getByTestId('comment-textarea'), {
+        target: { value: 'Will it appear?' },
+      })
+      fireEvent.click(screen.getByTestId('comment-submit'))
+
+      expect(screen.getByTestId('pending-review-banner')).toBeInTheDocument()
+
+      // Simulate a refetch after admin approval — same id, now visible.
+      mockUseComments.mockReturnValue({
+        data: {
+          comments: [{ ...pending, visibility: 'visible' }],
+          total: 1,
+          has_more: false,
+        },
+        isLoading: false,
+      })
+
+      rerender(<CommentThread {...defaultProps} />)
+
+      // Optimistic entry de-duped; banner gone.
+      expect(screen.queryByTestId('pending-review-banner')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('pending-review-badge')).not.toBeInTheDocument()
+    })
   })
 })

--- a/frontend/features/comments/components/CommentThread.tsx
+++ b/frontend/features/comments/components/CommentThread.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { MessageSquare } from 'lucide-react'
+import { MessageSquare, Clock } from 'lucide-react'
 import { useAuthContext } from '@/lib/context/AuthContext'
 import { Button } from '@/components/ui/button'
 import { useComments, useCreateComment } from '../hooks'
@@ -25,12 +25,23 @@ const sortLabels: Record<SortOption, string> = {
 export function CommentThread({ entityType, entityId }: CommentThreadProps) {
   const { isAuthenticated } = useAuthContext()
   const [sort, setSort] = useState<SortOption>('best')
+  // PSY-513: track the author's just-submitted pending-review comment so we
+  // can render it optimistically. The public comments list will not include
+  // pending_review rows (server-side filter), so this local state is the
+  // source of truth until a moderator approves it (after which a refetch
+  // surfaces the canonical row and the optimistic entry is de-duped by id).
+  const [pendingComment, setPendingComment] = useState<Comment | null>(null)
 
   const { data, isLoading } = useComments(entityType, entityId, sort)
   const createMutation = useCreateComment()
 
   const comments = data?.comments ?? []
   const total = data?.total ?? 0
+
+  // Drop the optimistic entry once the canonical row appears in the list.
+  const hasCanonicalPending =
+    pendingComment !== null && comments.some((c) => c.id === pendingComment.id)
+  const effectivePending = hasCanonicalPending ? null : pendingComment
 
   // Separate top-level comments and replies
   const topLevel = comments.filter((c) => c.depth === 0)
@@ -43,7 +54,18 @@ export function CommentThread({ entityType, entityId }: CommentThreadProps) {
   }, {})
 
   const handleCreate = (body: string, replyPermission?: ReplyPermission) => {
-    createMutation.mutate({ entityType, entityId, body, replyPermission })
+    createMutation.mutate(
+      { entityType, entityId, body, replyPermission },
+      {
+        onSuccess: (created) => {
+          // Only top-level (parent_id == null) submissions land here; replies
+          // go through useReplyToComment in CommentCard.
+          if (created.visibility === 'pending_review') {
+            setPendingComment(created)
+          }
+        },
+      }
+    )
   }
 
   return (
@@ -97,6 +119,22 @@ export function CommentThread({ entityType, entityId }: CommentThreadProps) {
         </p>
       )}
 
+      {/* PSY-513: pending-review confirmation banner. Inline banner pattern
+          mirrors EntityEditDrawer's "Edit submitted for review" success state
+          since the codebase has no toast primitive. Only the author sees this. */}
+      {effectivePending && (
+        <div
+          className="mb-4 rounded-md border border-amber-700/50 bg-amber-950/40 p-3 flex items-start gap-2"
+          role="status"
+          data-testid="pending-review-banner"
+        >
+          <Clock className="h-4 w-4 mt-0.5 text-amber-500 shrink-0" />
+          <p className="text-sm text-amber-200">
+            Comment submitted — awaiting moderation. You&apos;ll see it here once an admin approves it.
+          </p>
+        </div>
+      )}
+
       {/* Comments list */}
       {isLoading ? (
         <div className="space-y-4">
@@ -108,12 +146,24 @@ export function CommentThread({ entityType, entityId }: CommentThreadProps) {
             </div>
           ))}
         </div>
-      ) : topLevel.length === 0 ? (
+      ) : topLevel.length === 0 && !effectivePending ? (
         <p className="text-sm text-muted-foreground py-8 text-center" data-testid="empty-state">
           No comments yet. Be the first to share your thoughts.
         </p>
       ) : (
         <div className="space-y-4 divide-y divide-border/50">
+          {/* Optimistic pending comment, rendered first so the author can see
+              what they posted. Visible only to the author (gated above by
+              setPendingComment, which only fires for the submitter). */}
+          {effectivePending && (
+            <div className="pt-4 first:pt-0">
+              <CommentCard
+                comment={effectivePending}
+                entityType={entityType}
+                entityId={entityId}
+              />
+            </div>
+          )}
           {topLevel.map((comment) => (
             <div key={comment.id} className="pt-4 first:pt-0">
               <CommentCard

--- a/frontend/features/comments/components/FieldNoteCard.tsx
+++ b/frontend/features/comments/components/FieldNoteCard.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { ChevronUp, ChevronDown, MessageSquare, Star, CheckCircle, Eye, EyeOff, Flag } from 'lucide-react'
+import { ChevronUp, ChevronDown, MessageSquare, Star, CheckCircle, Eye, EyeOff, Flag, Clock } from 'lucide-react'
 import { formatRelativeTime } from '@/lib/formatRelativeTime'
 import { useAuthContext } from '@/lib/context/AuthContext'
 import { Button } from '@/components/ui/button'
@@ -125,6 +125,18 @@ export function FieldNoteCard({
         {comment.is_edited && (
           <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
             Edited
+          </Badge>
+        )}
+        {/* PSY-513: pending-review badge for the author of a queued field
+            note. Mirrors the CommentCard pattern. */}
+        {comment.visibility === 'pending_review' && isOwner && (
+          <Badge
+            variant="outline"
+            className="text-[10px] px-1.5 py-0 gap-1 border-amber-700/50 text-amber-500"
+            data-testid="pending-review-badge"
+          >
+            <Clock className="h-2.5 w-2.5" />
+            Pending review
           </Badge>
         )}
       </div>

--- a/frontend/features/comments/components/FieldNotesSection.test.tsx
+++ b/frontend/features/comments/components/FieldNotesSection.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { FieldNotesSection } from './FieldNotesSection'
+import type { Comment } from '../types'
 
 // --- Mocks ---
 
@@ -272,6 +273,110 @@ describe('FieldNotesSection', () => {
       )
 
       expect(screen.queryByTestId('field-note-auth-gate')).not.toBeInTheDocument()
+    })
+  })
+
+  // PSY-513: pending-review feedback for field notes (mirrors CommentThread).
+  describe('pending-review feedback (PSY-513)', () => {
+    function makePendingNote(overrides: Partial<Comment> = {}): Comment {
+      return {
+        id: 7777,
+        entity_type: 'show',
+        entity_id: 1,
+        user_id: 8,
+        author_name: 'Newcomer',
+        body: 'My take on the show',
+        body_html: '<p>My take on the show</p>',
+        parent_id: null,
+        root_id: null,
+        depth: 0,
+        ups: 0,
+        downs: 0,
+        score: 0,
+        visibility: 'pending_review',
+        reply_permission: 'anyone',
+        edit_count: 0,
+        is_edited: false,
+        created_at: '2026-04-29T18:00:00Z',
+        updated_at: '2026-04-29T18:00:00Z',
+        structured_data: {
+          setlist_spoiler: false,
+          is_verified_attendee: false,
+        },
+        ...overrides,
+      }
+    }
+
+    it('renders banner + optimistic note when POST returns pending_review', () => {
+      const pending = makePendingNote()
+      const mutateImpl = vi.fn(
+        (_args: unknown, opts?: { onSuccess?: (data: Comment) => void }) => {
+          opts?.onSuccess?.(pending)
+        }
+      )
+      mockUseCreateFieldNote.mockReturnValue({
+        mutate: mutateImpl,
+        isPending: false,
+      })
+      mockUseAuthContext.mockReturnValue({
+        isAuthenticated: true,
+        user: { id: '8', email: 'newcomer@example.com' },
+      })
+      mockUseFieldNotes.mockReturnValue({
+        data: { comments: [], total: 0, has_more: false },
+        isLoading: false,
+      })
+
+      render(
+        <FieldNotesSection showId={1} showDate={pastDate} artists={mockArtists} />
+      )
+
+      // Empty state visible before submit.
+      expect(screen.getByTestId('field-notes-empty')).toBeInTheDocument()
+
+      // Submit the form.
+      fireEvent.change(screen.getByTestId('field-note-textarea'), {
+        target: { value: 'My take on the show' },
+      })
+      fireEvent.click(screen.getByTestId('field-note-submit'))
+
+      // Banner appears, empty-state suppressed, badge rendered.
+      expect(screen.getByTestId('pending-review-banner')).toBeInTheDocument()
+      expect(screen.queryByTestId('field-notes-empty')).not.toBeInTheDocument()
+      expect(screen.getByTestId('pending-review-badge')).toBeInTheDocument()
+    })
+
+    it('does NOT render banner when POST returns visible (trusted-tier auto-publish)', () => {
+      const visible = makePendingNote({ visibility: 'visible' })
+      const mutateImpl = vi.fn(
+        (_args: unknown, opts?: { onSuccess?: (data: Comment) => void }) => {
+          opts?.onSuccess?.(visible)
+        }
+      )
+      mockUseCreateFieldNote.mockReturnValue({
+        mutate: mutateImpl,
+        isPending: false,
+      })
+      mockUseAuthContext.mockReturnValue({
+        isAuthenticated: true,
+        user: { id: '8', email: 'trusted@example.com' },
+      })
+      mockUseFieldNotes.mockReturnValue({
+        data: { comments: [], total: 0, has_more: false },
+        isLoading: false,
+      })
+
+      render(
+        <FieldNotesSection showId={1} showDate={pastDate} artists={mockArtists} />
+      )
+
+      fireEvent.change(screen.getByTestId('field-note-textarea'), {
+        target: { value: 'Auto-published note' },
+      })
+      fireEvent.click(screen.getByTestId('field-note-submit'))
+
+      expect(screen.queryByTestId('pending-review-banner')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('pending-review-badge')).not.toBeInTheDocument()
     })
   })
 })

--- a/frontend/features/comments/components/FieldNotesSection.tsx
+++ b/frontend/features/comments/components/FieldNotesSection.tsx
@@ -1,11 +1,12 @@
 'use client'
 
-import { ClipboardList } from 'lucide-react'
+import { useState } from 'react'
+import { ClipboardList, Clock } from 'lucide-react'
 import { useAuthContext } from '@/lib/context/AuthContext'
 import { useFieldNotes, useCreateFieldNote } from '../hooks'
 import { FieldNoteForm } from './FieldNoteForm'
 import { FieldNoteCard } from './FieldNoteCard'
-import type { CreateFieldNoteInput } from '../types'
+import type { Comment, CreateFieldNoteInput } from '../types'
 
 interface ShowArtist {
   id: number
@@ -36,13 +37,30 @@ export function FieldNotesSection({ showId, showDate, artists = [] }: FieldNotes
   const { isAuthenticated } = useAuthContext()
   const { data, isLoading } = useFieldNotes(showId)
   const createMutation = useCreateFieldNote()
+  // PSY-513: track the author's pending-review field note so we can render
+  // it optimistically alongside the public list (which filters out
+  // pending_review). De-duped once the canonical row appears post-approval.
+  const [pendingNote, setPendingNote] = useState<Comment | null>(null)
 
   const fieldNotes = data?.comments ?? []
   const total = data?.total ?? 0
   const isFuture = isShowInFuture(showDate)
 
+  const hasCanonicalPending =
+    pendingNote !== null && fieldNotes.some((c) => c.id === pendingNote.id)
+  const effectivePending = hasCanonicalPending ? null : pendingNote
+
   const handleCreate = (input: CreateFieldNoteInput) => {
-    createMutation.mutate({ showId, input })
+    createMutation.mutate(
+      { showId, input },
+      {
+        onSuccess: (created) => {
+          if (created.visibility === 'pending_review') {
+            setPendingNote(created)
+          }
+        },
+      }
+    )
   }
 
   return (
@@ -88,6 +106,21 @@ export function FieldNotesSection({ showId, showDate, artists = [] }: FieldNotes
             </p>
           )}
 
+          {/* PSY-513: pending-review confirmation banner. Inline pattern
+              mirrors EntityEditDrawer's success state. Only the author sees it. */}
+          {effectivePending && (
+            <div
+              className="mb-4 rounded-md border border-amber-700/50 bg-amber-950/40 p-3 flex items-start gap-2"
+              role="status"
+              data-testid="pending-review-banner"
+            >
+              <Clock className="h-4 w-4 mt-0.5 text-amber-500 shrink-0" />
+              <p className="text-sm text-amber-200">
+                Field note submitted — awaiting moderation. You&apos;ll see it here once an admin approves it.
+              </p>
+            </div>
+          )}
+
           {/* Field notes list */}
           {isLoading ? (
             <div className="space-y-4">
@@ -99,7 +132,7 @@ export function FieldNotesSection({ showId, showDate, artists = [] }: FieldNotes
                 </div>
               ))}
             </div>
-          ) : fieldNotes.length === 0 ? (
+          ) : fieldNotes.length === 0 && !effectivePending ? (
             <p
               className="text-sm text-muted-foreground py-8 text-center"
               data-testid="field-notes-empty"
@@ -108,6 +141,13 @@ export function FieldNotesSection({ showId, showDate, artists = [] }: FieldNotes
             </p>
           ) : (
             <div className="space-y-4">
+              {effectivePending && (
+                <FieldNoteCard
+                  comment={effectivePending}
+                  showId={showId}
+                  artists={artists}
+                />
+              )}
               {fieldNotes.map((note) => (
                 <FieldNoteCard
                   key={note.id}


### PR DESCRIPTION
## Summary

- After a successful comment/field-note POST whose response has `visibility = pending_review`, the author now sees an inline banner ("Comment submitted — awaiting moderation. You'll see it here once an admin approves it.") and an optimistically-rendered card with a "Pending review" badge.
- Both `CommentThread` and `FieldNotesSection` track the just-submitted pending entry in local state. Since the backend filters `pending_review` rows out of public list responses, the optimistic entry is the source of truth until a moderator approves it; the next refetch surfaces the canonical row (de-duped by id).
- Empty-state copy is suppressed when the author has a pending entry. The "Pending review" badge is gated on `viewer == author` so other viewers don't see queued comments even if one slips into the cache.
- No regression on auto-published (trusted-tier) comments: banner + badge only render when `visibility === 'pending_review'`.

## Implementation note

The ticket suggested using "the existing toast primitive in this codebase" but a search showed **no toast library is installed and no toast hook exists** (the `toast.*` calls in `lib/hooks/admin/useAdminArtists.ts` are JSDoc examples, not real usage). I used the existing inline-banner pattern that `EntityEditDrawer.tsx` already uses for its "Edit submitted for review" success state — same UX intent (visible success acknowledgement), zero new dependency, consistent with the rest of the codebase. If you'd prefer to add a toast library (e.g. `sonner`) for this and future use, happy to do that as a follow-up.

## Files changed

- `frontend/features/comments/components/CommentThread.tsx` — track `pendingComment` state, render banner + optimistic card, suppress empty-state, de-dup once canonical row arrives.
- `frontend/features/comments/components/CommentCard.tsx` — "Pending review" badge in header, gated on `isOwner` + `visibility === 'pending_review'`. Confined to the metadata section to avoid merge conflicts with the parallel PSY-514 agent (which edits the footer/reply-button region).
- `frontend/features/comments/components/FieldNotesSection.tsx` + `FieldNoteCard.tsx` — same wiring, mirrored exactly.
- Test files extended for: badge author-only visibility, banner appears on `pending_review` response, banner does NOT appear on `visible` response, optimistic entry de-duped on refetch, empty-state hidden when pending exists.

## Test plan

- [x] `cd frontend && bun run test:run features/comments` — 76 passed (was 67; added 9 new tests across 3 test files)
- [x] `cd frontend && bun x tsc --noEmit` — clean
- [x] Full frontend test suite (`bun run test:run`) — 2893 / 2893 pass
- [x] Lint clean for all touched files
- [ ] Manual verification: sign in as `new_user`-tier account, post a comment on `/artists/<slug>` Discussion section, confirm banner + badge appear, confirm admin Moderation queue still receives the comment.

Closes PSY-513

🤖 Generated with [Claude Code](https://claude.com/claude-code)