### PR TITLE
PSY-354: tags + tag-filtered browse for collections

### DIFF
--- a/backend/internal/api/handlers/collection.go
+++ b/backend/internal/api/handlers/collection.go
@@ -40,7 +40,10 @@ type ListCollectionsHandlerRequest struct {
 	Search     string `query:"search" required:"false" doc:"Search by title"`
 	// PSY-352: sort=popular orders by HN gravity (likes / age^1.8). Empty
 	// or omitted defaults to updated_at DESC.
-	Sort   string `query:"sort" required:"false" doc:"Sort order: 'popular' for HN-gravity ranking. Defaults to recently-updated." enum:"popular"`
+	Sort string `query:"sort" required:"false" doc:"Sort order: 'popular' for HN-gravity ranking. Defaults to recently-updated." enum:"popular"`
+	// PSY-354: filter the listing to collections tagged with the given slug.
+	// Single-tag for the MVP — multi-tag intersection is out of scope.
+	Tag    string `query:"tag" required:"false" doc:"Filter to collections tagged with this slug" example:"phoenix"`
 	Limit  int    `query:"limit" required:"false" doc:"Max results (default 20)" example:"20"`
 	Offset int    `query:"offset" required:"false" doc:"Offset for pagination" example:"0"`
 }
@@ -67,6 +70,7 @@ func (h *CollectionHandler) ListCollectionsHandler(ctx context.Context, req *Lis
 		EntityType: req.EntityType,
 		PublicOnly: true, // Public endpoint always filters to public
 		Sort:       req.Sort,
+		Tag:        req.Tag, // PSY-354
 	}
 
 	if req.Featured == 1 {
@@ -846,6 +850,140 @@ func (h *CollectionHandler) CloneCollectionHandler(ctx context.Context, req *Clo
 }
 
 // ============================================================================
+// Add / Remove Collection Tags (PSY-354)
+// ============================================================================
+
+// AddCollectionTagHandlerRequest is POST /collections/{slug}/tags. Mirrors
+// AddTagToEntity on entities — accept tag_id OR tag_name. Free-form
+// tag_name routes through the polymorphic tag service's
+// alias-resolve-or-create path; the trust-tier gate on inline creation is
+// inherited (new_user can apply existing tags but cannot create new ones).
+type AddCollectionTagHandlerRequest struct {
+	Slug string `path:"slug" doc:"Collection slug" example:"my-favorite-artists"`
+	Body struct {
+		TagID    uint   `json:"tag_id,omitempty" required:"false" doc:"Existing tag ID (provide tag_id OR tag_name)"`
+		TagName  string `json:"tag_name,omitempty" required:"false" doc:"Tag name with alias resolution; creates the tag inline when not found"`
+		Category string `json:"category,omitempty" required:"false" doc:"Tag category for inline creation (genre, locale, other; default: other)"`
+	}
+}
+
+// AddCollectionTagHandlerResponse returns the post-mutation tag list so the
+// frontend can update the chip row in one round-trip.
+type AddCollectionTagHandlerResponse struct {
+	Body *contracts.AddCollectionTagResponse
+}
+
+// AddCollectionTagHandler handles POST /collections/{slug}/tags.
+//
+// Returns:
+//   - 401 unauthenticated
+//   - 403 caller cannot edit the collection
+//   - 400 cap exceeded (>10 tags) OR malformed body
+//   - 404 collection not found
+//   - 409 tag already applied to this collection
+//   - 200 with the post-mutation tag list
+func (h *CollectionHandler) AddCollectionTagHandler(ctx context.Context, req *AddCollectionTagHandlerRequest) (*AddCollectionTagHandlerResponse, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	if req.Body.TagID == 0 && req.Body.TagName == "" {
+		return nil, huma.Error400BadRequest("Either tag_id or tag_name is required")
+	}
+
+	serviceReq := &contracts.AddCollectionTagRequest{
+		TagID:    req.Body.TagID,
+		TagName:  req.Body.TagName,
+		Category: req.Body.Category,
+	}
+
+	resp, err := h.collectionService.AddTagToCollection(req.Slug, user.ID, serviceReq)
+	if err != nil {
+		// Collection-domain errors first (forbidden / cap / not-found / invalid).
+		if mapped := mapCollectionError(err); mapped != nil {
+			return nil, mapped
+		}
+		// Tag-domain errors (already-applied, name-too-short, trust-tier gate).
+		if mapped := mapTagError(err); mapped != nil {
+			return nil, mapped
+		}
+		logger.FromContext(ctx).Error("add_collection_tag_failed",
+			"slug", req.Slug,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to add tag to collection (request_id: %s)", requestID),
+		)
+	}
+
+	if h.auditLogService != nil {
+		go func() {
+			h.auditLogService.LogAction(user.ID, "add_collection_tag", "collection", 0, map[string]interface{}{
+				"slug":     req.Slug,
+				"tag_id":   req.Body.TagID,
+				"tag_name": req.Body.TagName,
+			})
+		}()
+	}
+
+	return &AddCollectionTagHandlerResponse{Body: resp}, nil
+}
+
+// RemoveCollectionTagHandlerRequest is DELETE /collections/{slug}/tags/{tag_id}.
+type RemoveCollectionTagHandlerRequest struct {
+	Slug  string `path:"slug" doc:"Collection slug" example:"my-favorite-artists"`
+	TagID string `path:"tag_id" doc:"Tag ID to remove" example:"42"`
+}
+
+// RemoveCollectionTagHandler handles DELETE /collections/{slug}/tags/{tag_id}.
+func (h *CollectionHandler) RemoveCollectionTagHandler(ctx context.Context, req *RemoveCollectionTagHandlerRequest) (*struct{}, error) {
+	requestID := logger.GetRequestID(ctx)
+
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	tagID, err := strconv.ParseUint(req.TagID, 10, 32)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid tag ID")
+	}
+
+	if err := h.collectionService.RemoveTagFromCollection(req.Slug, uint(tagID), user.ID); err != nil {
+		if mapped := mapCollectionError(err); mapped != nil {
+			return nil, mapped
+		}
+		if mapped := mapTagError(err); mapped != nil {
+			return nil, mapped
+		}
+		logger.FromContext(ctx).Error("remove_collection_tag_failed",
+			"slug", req.Slug,
+			"tag_id", tagID,
+			"error", err.Error(),
+			"request_id", requestID,
+		)
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("Failed to remove tag from collection (request_id: %s)", requestID),
+		)
+	}
+
+	if h.auditLogService != nil {
+		go func() {
+			h.auditLogService.LogAction(user.ID, "remove_collection_tag", "collection", 0, map[string]interface{}{
+				"slug":   req.Slug,
+				"tag_id": tagID,
+			})
+		}()
+	}
+
+	return nil, nil
+}
+
+// ============================================================================
 // Helpers
 // ============================================================================
 
@@ -863,6 +1001,8 @@ func mapCollectionError(err error) error {
 		case apperrors.CodeCollectionItemNotFound:
 			return huma.Error404NotFound(collectionErr.Message)
 		case apperrors.CodeCollectionInvalidRequest:
+			return huma.Error400BadRequest(collectionErr.Message)
+		case apperrors.CodeCollectionTagLimitExceeded:
 			return huma.Error400BadRequest(collectionErr.Message)
 		}
 	}

--- a/backend/internal/api/handlers/collection_integration_test.go
+++ b/backend/internal/api/handlers/collection_integration_test.go
@@ -1167,3 +1167,214 @@ func (s *CollectionHandlerIntegrationSuite) TestMapCollectionError_NotFound() {
 	err := mapCollectionError(fmt.Errorf("generic error"))
 	s.Nil(err, "non-CollectionError should return nil")
 }
+
+// ============================================================================
+// PSY-354: collection tag endpoints
+// ============================================================================
+
+// promoteContributorForTags lifts a user above the new_user trust tier so the
+// inline-tag-creation path passes (otherwise free-form tag names get a 403
+// from the tag service's createTagInline gate). The trust-tier gate itself
+// is covered in catalog/tag_service_test.go — these tests focus on the
+// collection-side behavior.
+func (s *CollectionHandlerIntegrationSuite) promoteContributorForTags(user *models.User) {
+	s.Require().NoError(s.deps.db.Model(&models.User{}).
+		Where("id = ?", user.ID).
+		Update("user_tier", "contributor").Error)
+}
+
+func (s *CollectionHandlerIntegrationSuite) TestAddCollectionTag_Success() {
+	user := createTestUser(s.deps.db)
+	s.promoteContributorForTags(user)
+	coll := s.createCollectionViaService(user, "Tagged Coll", false)
+
+	ctx := ctxWithUser(user)
+	req := &AddCollectionTagHandlerRequest{Slug: coll.Slug}
+	req.Body.TagName = "first-tag"
+
+	resp, err := s.handler.AddCollectionTagHandler(ctx, req)
+	s.NoError(err)
+	s.Require().NotNil(resp)
+	s.Require().Len(resp.Body.Tags, 1)
+	s.Equal("first-tag", resp.Body.Tags[0].Name)
+}
+
+func (s *CollectionHandlerIntegrationSuite) TestAddCollectionTag_NoAuth() {
+	user := createTestUser(s.deps.db)
+	coll := s.createCollectionViaService(user, "Need Auth", false)
+
+	req := &AddCollectionTagHandlerRequest{Slug: coll.Slug}
+	req.Body.TagName = "no-auth"
+
+	_, err := s.handler.AddCollectionTagHandler(context.Background(), req)
+	assertHumaError(s.T(), err, 401)
+}
+
+func (s *CollectionHandlerIntegrationSuite) TestAddCollectionTag_MissingArgs() {
+	user := createTestUser(s.deps.db)
+	s.promoteContributorForTags(user)
+	coll := s.createCollectionViaService(user, "Missing Args", false)
+
+	ctx := ctxWithUser(user)
+	req := &AddCollectionTagHandlerRequest{Slug: coll.Slug}
+	// no tag_id, no tag_name
+
+	_, err := s.handler.AddCollectionTagHandler(ctx, req)
+	assertHumaError(s.T(), err, 400)
+}
+
+func (s *CollectionHandlerIntegrationSuite) TestAddCollectionTag_NonOwner_Forbidden() {
+	owner := createTestUser(s.deps.db)
+	stranger := createTestUser(s.deps.db)
+	s.promoteContributorForTags(stranger)
+	coll := s.createCollectionViaService(owner, "Solo Owner", false)
+	// createCollectionViaService leaves Collaborative=false (CreateCollection's
+	// GORM-bool dance), so the stranger cannot tag the collection.
+
+	ctx := ctxWithUser(stranger)
+	req := &AddCollectionTagHandlerRequest{Slug: coll.Slug}
+	req.Body.TagName = "stranger-tag"
+
+	_, err := s.handler.AddCollectionTagHandler(ctx, req)
+	assertHumaError(s.T(), err, 403)
+}
+
+func (s *CollectionHandlerIntegrationSuite) TestAddCollectionTag_LimitExceeded() {
+	user := createTestUser(s.deps.db)
+	s.promoteContributorForTags(user)
+	coll := s.createCollectionViaService(user, "Capped Collection", false)
+	ctx := ctxWithUser(user)
+
+	for i := 0; i < contracts.MaxCollectionTags; i++ {
+		r := &AddCollectionTagHandlerRequest{Slug: coll.Slug}
+		r.Body.TagName = fmt.Sprintf("cap-%d", i)
+		_, err := s.handler.AddCollectionTagHandler(ctx, r)
+		s.Require().NoError(err)
+	}
+
+	r := &AddCollectionTagHandlerRequest{Slug: coll.Slug}
+	r.Body.TagName = "one-too-many"
+	_, err := s.handler.AddCollectionTagHandler(ctx, r)
+	assertHumaError(s.T(), err, 400)
+}
+
+func (s *CollectionHandlerIntegrationSuite) TestRemoveCollectionTag_Success() {
+	user := createTestUser(s.deps.db)
+	s.promoteContributorForTags(user)
+	coll := s.createCollectionViaService(user, "Remove Tag", false)
+	ctx := ctxWithUser(user)
+
+	addReq := &AddCollectionTagHandlerRequest{Slug: coll.Slug}
+	addReq.Body.TagName = "to-remove"
+	addResp, err := s.handler.AddCollectionTagHandler(ctx, addReq)
+	s.Require().NoError(err)
+	s.Require().Len(addResp.Body.Tags, 1)
+	tagID := addResp.Body.Tags[0].TagID
+
+	delReq := &RemoveCollectionTagHandlerRequest{
+		Slug:  coll.Slug,
+		TagID: fmt.Sprintf("%d", tagID),
+	}
+	_, err = s.handler.RemoveCollectionTagHandler(ctx, delReq)
+	s.NoError(err)
+
+	// Verify it's gone via the detail endpoint.
+	getResp, err := s.handler.GetCollectionHandler(ctx, &GetCollectionHandlerRequest{Slug: coll.Slug})
+	s.Require().NoError(err)
+	s.Empty(getResp.Body.Tags)
+}
+
+func (s *CollectionHandlerIntegrationSuite) TestRemoveCollectionTag_NoAuth() {
+	user := createTestUser(s.deps.db)
+	s.promoteContributorForTags(user)
+	coll := s.createCollectionViaService(user, "Auth Needed Remove", false)
+	ctx := ctxWithUser(user)
+
+	addReq := &AddCollectionTagHandlerRequest{Slug: coll.Slug}
+	addReq.Body.TagName = "tagged"
+	addResp, err := s.handler.AddCollectionTagHandler(ctx, addReq)
+	s.Require().NoError(err)
+	tagID := addResp.Body.Tags[0].TagID
+
+	delReq := &RemoveCollectionTagHandlerRequest{
+		Slug:  coll.Slug,
+		TagID: fmt.Sprintf("%d", tagID),
+	}
+	_, err = s.handler.RemoveCollectionTagHandler(context.Background(), delReq)
+	assertHumaError(s.T(), err, 401)
+}
+
+func (s *CollectionHandlerIntegrationSuite) TestRemoveCollectionTag_InvalidID() {
+	user := createTestUser(s.deps.db)
+	coll := s.createCollectionViaService(user, "Invalid ID", false)
+
+	delReq := &RemoveCollectionTagHandlerRequest{
+		Slug:  coll.Slug,
+		TagID: "not-a-number",
+	}
+	_, err := s.handler.RemoveCollectionTagHandler(ctxWithUser(user), delReq)
+	assertHumaError(s.T(), err, 400)
+}
+
+func (s *CollectionHandlerIntegrationSuite) TestGetCollection_SurfacesTags() {
+	user := createTestUser(s.deps.db)
+	s.promoteContributorForTags(user)
+	coll := s.createCollectionViaService(user, "Surface Tags", false)
+	ctx := ctxWithUser(user)
+
+	addReq := &AddCollectionTagHandlerRequest{Slug: coll.Slug}
+	addReq.Body.TagName = "surfaced"
+	_, err := s.handler.AddCollectionTagHandler(ctx, addReq)
+	s.Require().NoError(err)
+
+	getResp, err := s.handler.GetCollectionHandler(ctx, &GetCollectionHandlerRequest{Slug: coll.Slug})
+	s.Require().NoError(err)
+	s.Require().Len(getResp.Body.Tags, 1)
+	s.Equal("surfaced", getResp.Body.Tags[0].Name)
+}
+
+func (s *CollectionHandlerIntegrationSuite) TestListCollections_TagFilter() {
+	user := createTestUser(s.deps.db)
+	s.promoteContributorForTags(user)
+
+	tagged := s.createCollectionViaService(user, "Tagged Browse", true)
+	s.createCollectionViaService(user, "Untagged Browse", true)
+
+	ctx := ctxWithUser(user)
+	addReq := &AddCollectionTagHandlerRequest{Slug: tagged.Slug}
+	addReq.Body.TagName = "browse-filter-tag"
+	_, err := s.handler.AddCollectionTagHandler(ctx, addReq)
+	s.Require().NoError(err)
+
+	// Filter by the tag.
+	listReq := &ListCollectionsHandlerRequest{Tag: "browse-filter-tag"}
+	listResp, err := s.handler.ListCollectionsHandler(context.Background(), listReq)
+	s.Require().NoError(err)
+	s.Equal(int64(1), listResp.Body.Total)
+	s.Require().Len(listResp.Body.Collections, 1)
+	s.Equal(tagged.ID, listResp.Body.Collections[0].ID)
+
+	// No filter — both surface.
+	listReq = &ListCollectionsHandlerRequest{}
+	listResp, err = s.handler.ListCollectionsHandler(context.Background(), listReq)
+	s.Require().NoError(err)
+	s.Equal(int64(2), listResp.Body.Total)
+}
+
+func (s *CollectionHandlerIntegrationSuite) TestListCollections_PopulatesTags() {
+	user := createTestUser(s.deps.db)
+	s.promoteContributorForTags(user)
+	tagged := s.createCollectionViaService(user, "Browse Tags", true)
+
+	ctx := ctxWithUser(user)
+	addReq := &AddCollectionTagHandlerRequest{Slug: tagged.Slug}
+	addReq.Body.TagName = "browse-chip"
+	_, err := s.handler.AddCollectionTagHandler(ctx, addReq)
+	s.Require().NoError(err)
+
+	listResp, err := s.handler.ListCollectionsHandler(context.Background(), &ListCollectionsHandlerRequest{})
+	s.Require().NoError(err)
+	s.Require().Len(listResp.Body.Collections, 1)
+	s.Require().Len(listResp.Body.Collections[0].Tags, 1)
+	s.Equal("browse-chip", listResp.Body.Collections[0].Tags[0].Name)
+}

--- a/backend/internal/api/handlers/handler_integration_helpers_test.go
+++ b/backend/internal/api/handlers/handler_integration_helpers_test.go
@@ -87,6 +87,10 @@ func setupHandlerIntegrationDeps(t *testing.T) *handlerIntegrationDeps {
 		artistRelationshipService: catalog.NewArtistRelationshipService(db),
 		sceneService:              catalog.NewSceneService(db),
 	}
+	// PSY-354: collections gain polymorphic tagging via the tag service.
+	// Wire the dependency so handler tests exercise the same code path
+	// that production uses.
+	deps.collectionService.SetTagService(deps.tagService)
 
 	return deps
 }
@@ -96,6 +100,14 @@ func cleanupTables(db *gorm.DB) {
 	// Order respects FK constraints
 	_, _ = sqlDB.Exec("DELETE FROM request_votes")
 	_, _ = sqlDB.Exec("DELETE FROM requests")
+	// PSY-354: clear polymorphic tag links + votes before removing the
+	// underlying entities they reference (entity_tags has no FK to the
+	// polymorphic entity, but tag_votes references tags + users; clearing
+	// these here lets entity_tags rows from prior tests not leak into
+	// later tests that share the same database).
+	_, _ = sqlDB.Exec("DELETE FROM tag_votes")
+	_, _ = sqlDB.Exec("DELETE FROM entity_tags")
+	_, _ = sqlDB.Exec("DELETE FROM collection_likes")
 	_, _ = sqlDB.Exec("DELETE FROM collection_subscribers")
 	_, _ = sqlDB.Exec("DELETE FROM collection_items")
 	_, _ = sqlDB.Exec("DELETE FROM collections")
@@ -122,6 +134,13 @@ func cleanupTables(db *gorm.DB) {
 	_, _ = sqlDB.Exec("DELETE FROM webauthn_challenges")
 	_, _ = sqlDB.Exec("DELETE FROM oauth_accounts")
 	_, _ = sqlDB.Exec("DELETE FROM user_preferences")
+	// PSY-354: clear the polymorphic tag corpus too — tags / tag_aliases
+	// can leak between integration test cases via the LOWER(name) unique
+	// index ("post-punk" reused across tests would collide). Tags's FK to
+	// users is ON DELETE SET NULL, so order vs `users` is fine, but we
+	// drop tags before users so tag cleanup doesn't see orphaned rows.
+	_, _ = sqlDB.Exec("DELETE FROM tag_aliases")
+	_, _ = sqlDB.Exec("DELETE FROM tags")
 	_, _ = sqlDB.Exec("DELETE FROM users")
 }
 

--- a/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
+++ b/backend/internal/api/handlers/handler_unit_mock_helpers_test.go
@@ -696,6 +696,8 @@ type mockCollectionService struct {
 	getUserPublicCollectionsFn func(uint, int, int) ([]*contracts.CollectionListResponse, int64, error)
 	getUserPublicCollectionsByUsernameFn func(string, int, int) ([]*contracts.CollectionListResponse, int64, error)
 	setFeaturedFn func(string, bool) (error)
+	addTagToCollectionFn func(string, uint, *contracts.AddCollectionTagRequest) (*contracts.AddCollectionTagResponse, error)
+	removeTagFromCollectionFn func(string, uint, uint) error
 }
 
 func (m *mockCollectionService) CreateCollection(creatorID uint, req *contracts.CreateCollectionRequest) (*contracts.CollectionDetailResponse, error) {
@@ -821,6 +823,18 @@ func (m *mockCollectionService) GetUserPublicCollectionsByUsername(username stri
 func (m *mockCollectionService) SetFeatured(slug string, featured bool) (error) {
 	if m.setFeaturedFn != nil {
 		return m.setFeaturedFn(slug, featured)
+	}
+	return nil
+}
+func (m *mockCollectionService) AddTagToCollection(slug string, userID uint, req *contracts.AddCollectionTagRequest) (*contracts.AddCollectionTagResponse, error) {
+	if m.addTagToCollectionFn != nil {
+		return m.addTagToCollectionFn(slug, userID, req)
+	}
+	return nil, nil
+}
+func (m *mockCollectionService) RemoveTagFromCollection(slug string, tagID uint, userID uint) error {
+	if m.removeTagFromCollectionFn != nil {
+		return m.removeTagFromCollectionFn(slug, tagID, userID)
 	}
 	return nil
 }

--- a/backend/internal/api/handlers/tag.go
+++ b/backend/internal/api/handlers/tag.go
@@ -288,6 +288,13 @@ func (h *TagHandler) AddTagToEntityHandler(ctx context.Context, req *AddTagToEnt
 
 	_, err = h.tagService.AddTagToEntity(req.Body.TagID, req.Body.TagName, req.EntityType, uint(entityID), user.ID, req.Body.Category)
 	if err != nil {
+		// PSY-354: AddTagToEntity returns a CollectionError when the
+		// per-collection cap is hit. Check the collection-domain mapping
+		// first so the 400 reaches the caller; otherwise fall through to
+		// the tag-domain mapping.
+		if mapped := mapCollectionError(err); mapped != nil {
+			return nil, mapped
+		}
 		mapped := mapTagError(err)
 		if mapped != nil {
 			return nil, mapped

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -750,6 +750,14 @@ func setupCollectionRoutes(rc RouteContext) {
 	huma.Post(rc.Protected, "/crates/{slug}/like", collectionLikeHandler.LikeCollectionHandler)
 	huma.Delete(rc.Protected, "/crates/{slug}/like", collectionLikeHandler.UnlikeCollectionHandler)
 
+	// PSY-354: collection tag management. Same edit-access rule as
+	// AddItem (creator OR collaborative-and-authenticated). Both
+	// /collections/ and /crates/ paths registered for backward compat.
+	huma.Post(rc.Protected, "/collections/{slug}/tags", collectionHandler.AddCollectionTagHandler)
+	huma.Delete(rc.Protected, "/collections/{slug}/tags/{tag_id}", collectionHandler.RemoveCollectionTagHandler)
+	huma.Post(rc.Protected, "/crates/{slug}/tags", collectionHandler.AddCollectionTagHandler)
+	huma.Delete(rc.Protected, "/crates/{slug}/tags/{tag_id}", collectionHandler.RemoveCollectionTagHandler)
+
 	// Admin: feature/unfeature collections — canonical /collections/ paths
 	huma.Put(rc.Protected, "/collections/{slug}/feature", collectionHandler.SetFeaturedHandler)
 

--- a/backend/internal/errors/collection.go
+++ b/backend/internal/errors/collection.go
@@ -11,6 +11,9 @@ const (
 	CodeCollectionItemExists     = "COLLECTION_ITEM_EXISTS"
 	CodeCollectionItemNotFound   = "COLLECTION_ITEM_NOT_FOUND"
 	CodeCollectionInvalidRequest = "COLLECTION_INVALID_REQUEST"
+	// CodeCollectionTagLimitExceeded is returned when a curator tries to add
+	// an 11th tag to a collection (PSY-354). Maps to HTTP 400.
+	CodeCollectionTagLimitExceeded = "COLLECTION_TAG_LIMIT_EXCEEDED"
 )
 
 // CollectionError represents a collection-related error with additional context.
@@ -74,5 +77,18 @@ func ErrCollectionInvalidRequest(message string) *CollectionError {
 	return &CollectionError{
 		Code:    CodeCollectionInvalidRequest,
 		Message: message,
+	}
+}
+
+// ErrCollectionTagLimitExceeded creates an error for the collection-tag cap
+// (PSY-354). Surfaced verbatim to the caller as a 400 so the curator UI can
+// show the cap and current count.
+func ErrCollectionTagLimitExceeded(currentCount, maxAllowed int) *CollectionError {
+	return &CollectionError{
+		Code: CodeCollectionTagLimitExceeded,
+		Message: fmt.Sprintf(
+			"Collections can have at most %d tags (currently %d). Remove a tag before adding another.",
+			maxAllowed, currentCount,
+		),
 	}
 }

--- a/backend/internal/models/tag.go
+++ b/backend/internal/models/tag.go
@@ -18,12 +18,16 @@ var TagCategories = []string{
 
 // Tag entity type constants (same values as CollectionEntity* / RequestEntity*)
 const (
-	TagEntityArtist   = "artist"
-	TagEntityRelease  = "release"
-	TagEntityLabel    = "label"
-	TagEntityShow     = "show"
-	TagEntityVenue    = "venue"
-	TagEntityFestival = "festival"
+	TagEntityArtist     = "artist"
+	TagEntityRelease    = "release"
+	TagEntityLabel      = "label"
+	TagEntityShow       = "show"
+	TagEntityVenue      = "venue"
+	TagEntityFestival   = "festival"
+	// TagEntityCollection enables polymorphic tagging on collections (PSY-354).
+	// The shared entity_tags table is unchanged — collections piggy-back on the
+	// existing (entity_type, entity_id) shape so no new migration is required.
+	TagEntityCollection = "collection"
 )
 
 // TagEntityTypes is the set of valid entity types for tagging.
@@ -34,6 +38,7 @@ var TagEntityTypes = []string{
 	TagEntityShow,
 	TagEntityVenue,
 	TagEntityFestival,
+	TagEntityCollection,
 }
 
 // Tag represents a user-facing tag for categorizing entities.

--- a/backend/internal/models/tag_test.go
+++ b/backend/internal/models/tag_test.go
@@ -78,7 +78,9 @@ func TestTagEntityTypeConstants(t *testing.T) {
 	assert.Equal(t, "show", TagEntityShow)
 	assert.Equal(t, "venue", TagEntityVenue)
 	assert.Equal(t, "festival", TagEntityFestival)
-	assert.Len(t, TagEntityTypes, 6)
+	// PSY-354: collections share the polymorphic entity_tags table.
+	assert.Equal(t, "collection", TagEntityCollection)
+	assert.Len(t, TagEntityTypes, 7)
 }
 
 // Verify tag entity types match collection entity types (same values used project-wide).
@@ -89,4 +91,10 @@ func TestTagEntityTypesMatchCollectionEntityTypes(t *testing.T) {
 	assert.Equal(t, CollectionEntityShow, TagEntityShow)
 	assert.Equal(t, CollectionEntityVenue, TagEntityVenue)
 	assert.Equal(t, CollectionEntityFestival, TagEntityFestival)
+}
+
+// PSY-354: collection entity tag round-trips through IsValidTagEntityType.
+func TestIsValidTagEntityType_Collection(t *testing.T) {
+	assert.True(t, IsValidTagEntityType(TagEntityCollection))
+	assert.True(t, IsValidTagEntityType("collection"))
 }

--- a/backend/internal/services/catalog/tag_service.go
+++ b/backend/internal/services/catalog/tag_service.go
@@ -329,6 +329,14 @@ func (s *TagService) DeleteTag(tagID uint) error {
 // AddTagToEntity applies a tag to an entity. Supports tag ID or name (with alias resolution).
 // If tagName is provided and no existing tag or alias matches, creates the tag inline
 // for contributor+ users. The category parameter is used when creating new tags (defaults to "other").
+//
+// PSY-354: collections enforce a per-entity cap (MaxCollectionTags = 10). The
+// cap is checked HERE (before tag resolution / inline creation) so the same
+// limit applies whether the request comes through the dedicated
+// /collections/{slug}/tags endpoint or the polymorphic
+// /entities/collection/{id}/tags endpoint. Other entity types are uncapped
+// today; the if-statement keeps the bounded knowledge to the one entity that
+// has a cap rather than threading a per-entity-type limit map through.
 func (s *TagService) AddTagToEntity(tagID uint, tagName string, entityType string, entityID uint, userID uint, category string) (*models.EntityTag, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
@@ -336,6 +344,18 @@ func (s *TagService) AddTagToEntity(tagID uint, tagName string, entityType strin
 
 	if !models.IsValidTagEntityType(entityType) {
 		return nil, fmt.Errorf("invalid entity type: %s", entityType)
+	}
+
+	if entityType == models.TagEntityCollection {
+		var existingCount int64
+		if err := s.db.Model(&models.EntityTag{}).
+			Where("entity_type = ? AND entity_id = ?", entityType, entityID).
+			Count(&existingCount).Error; err != nil {
+			return nil, fmt.Errorf("failed to count collection tags: %w", err)
+		}
+		if int(existingCount) >= contracts.MaxCollectionTags {
+			return nil, apperrors.ErrCollectionTagLimitExceeded(int(existingCount), contracts.MaxCollectionTags)
+		}
 	}
 
 	// Resolve tag by ID or name

--- a/backend/internal/services/collection.go
+++ b/backend/internal/services/collection.go
@@ -2111,19 +2111,11 @@ func (s *CollectionService) AddTagToCollection(slug string, userID uint, req *co
 		return nil, apperrors.ErrCollectionForbidden(slug)
 	}
 
-	// Enforce the per-collection cap before delegating. We list first so the
-	// 400 response can quote the precise current count to the curator. There
-	// is a benign race here (two simultaneous adds at count==9 could both
-	// succeed), but ten vs eleven is not safety-critical and the alternative
-	// would be a counter column or a SERIALIZABLE transaction — overkill for
-	// a soft cap.
-	existing, err := s.tagService.ListEntityTags(models.TagEntityCollection, collection.ID, userID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list existing collection tags: %w", err)
-	}
-	if len(existing) >= contracts.MaxCollectionTags {
-		return nil, apperrors.ErrCollectionTagLimitExceeded(len(existing), contracts.MaxCollectionTags)
-	}
+	// PSY-354: the per-collection cap (MaxCollectionTags) is now enforced
+	// inside catalog.TagService.AddTagToEntity so the same limit applies
+	// regardless of which endpoint the caller used. This wrapper still
+	// validates auth + edit-access and returns the post-mutation tag list
+	// for the dedicated endpoint's response shape.
 
 	category := req.Category
 	if category == "" {

--- a/backend/internal/services/collection.go
+++ b/backend/internal/services/collection.go
@@ -39,9 +39,16 @@ const (
 // render Description and per-item Notes on read. Sanitization is applied on
 // every response so existing plain-text rows are also rendered safely — the
 // sanitizer is the source of truth for XSS safety, not the input pipeline.
+//
+// tagService is the polymorphic tag system (PSY-354). Optional — nil when
+// the service is built bare (e.g. from older test paths). The
+// AddTagToCollection / RemoveTagFromCollection methods require it; tag
+// rendering on Get/List is gracefully no-op when nil so that older callers
+// keep working.
 type CollectionService struct {
-	db *gorm.DB
-	md *utils.MarkdownRenderer
+	db         *gorm.DB
+	md         *utils.MarkdownRenderer
+	tagService contracts.TagServiceInterface
 }
 
 // NewCollectionService creates a new collection service
@@ -53,6 +60,14 @@ func NewCollectionService(database *gorm.DB) *CollectionService {
 		db: database,
 		md: utils.NewMarkdownRenderer(),
 	}
+}
+
+// SetTagService injects the polymorphic tag service (PSY-354). Called by the
+// service container after both services are constructed (avoids the
+// constructor-ordering tangle that would otherwise force a TagService import
+// from the services root package). Idempotent — safe to call again in tests.
+func (s *CollectionService) SetTagService(tagService contracts.TagServiceInterface) {
+	s.tagService = tagService
 }
 
 // renderMarkdown returns sanitized HTML for the given markdown source. Returns
@@ -421,6 +436,11 @@ func (s *CollectionService) GetBySlug(slug string, viewerID uint) (*contracts.Co
 		}()
 	}
 
+	// PSY-354: tag chips on the detail response. Empty slice (not nil) when
+	// the collection has no tags or the tag service isn't wired (older
+	// test paths) — keeps the JSON shape stable and unblocks the frontend.
+	tags := s.listCollectionTags(collection.ID, viewerID)
+
 	return &contracts.CollectionDetailResponse{
 		ID:                     collection.ID,
 		Title:                  collection.Title,
@@ -445,6 +465,7 @@ func (s *CollectionService) GetBySlug(slug string, viewerID uint) (*contracts.Co
 		IsSubscribed:           isSubscribed,
 		LikeCount:              int(likeCount),
 		UserLikesThis:          userLikesThis,
+		Tags:                   tags,
 		CreatedAt:              collection.CreatedAt,
 		UpdatedAt:              collection.UpdatedAt,
 	}, nil
@@ -513,6 +534,17 @@ func (s *CollectionService) ListCollections(filters contracts.CollectionFilters,
 				Where("entity_type = ?", filters.EntityType),
 		)
 	}
+	// PSY-354: filter by a single tag slug when requested. Subquery joins
+	// entity_tags → tags so callers can use the user-facing slug rather than
+	// numeric tag IDs in the URL. No-op when no collection has the tag.
+	if filters.Tag != "" {
+		query = query.Where("collections.id IN (?)",
+			s.db.Table("entity_tags").
+				Select("entity_tags.entity_id").
+				Joins("JOIN tags ON tags.id = entity_tags.tag_id").
+				Where("entity_tags.entity_type = ? AND tags.slug = ?", models.TagEntityCollection, filters.Tag),
+		)
+	}
 
 	// Count total before pagination
 	var total int64
@@ -566,6 +598,11 @@ func (s *CollectionService) ListCollections(filters contracts.CollectionFilters,
 	// Batch-load entity type counts
 	entityTypeCounts := s.batchEntityTypeCounts(collectionIDs)
 
+	// Batch-load tag chips (PSY-354). Returns map[collection_id][]TagSummary;
+	// missing keys decode as nil — we coerce to empty slice in the per-row
+	// build below so the JSON shape is always `tags: []`.
+	tagsByCollection := s.batchListCollectionTagSummaries(collectionIDs)
+
 	// Batch-load creator names
 	creatorNames := s.batchResolveUserNames(creatorIDs)
 	creatorUsernames := s.batchResolveUserUsernames(creatorIDs)
@@ -573,6 +610,10 @@ func (s *CollectionService) ListCollections(filters contracts.CollectionFilters,
 	// Build responses
 	responses := make([]*contracts.CollectionListResponse, len(collections))
 	for i, c := range collections {
+		tags := tagsByCollection[c.ID]
+		if tags == nil {
+			tags = []contracts.TagSummary{}
+		}
 		responses[i] = &contracts.CollectionListResponse{
 			ID:                     c.ID,
 			Title:                  c.Title,
@@ -595,6 +636,7 @@ func (s *CollectionService) ListCollections(filters contracts.CollectionFilters,
 			EntityTypeCounts:       entityTypeCounts[c.ID],
 			LikeCount:              likeCounts[c.ID],
 			UserLikesThis:          userLikes[c.ID],
+			Tags:                   tags,
 			CreatedAt:              c.CreatedAt,
 			UpdatedAt:              c.UpdatedAt,
 		}
@@ -1253,9 +1295,15 @@ func (s *CollectionService) GetUserCollections(userID uint, limit, offset int) (
 	// PSY-352: like aggregates and viewer's own like state.
 	likeCounts := s.batchCountLikes(collectionIDs)
 	userLikes := s.batchCheckUserLikes(userID, collectionIDs)
+	// PSY-354: tag chips on library cards.
+	tagsByCollection := s.batchListCollectionTagSummaries(collectionIDs)
 
 	responses := make([]*contracts.CollectionListResponse, len(collections))
 	for i, c := range collections {
+		tags := tagsByCollection[c.ID]
+		if tags == nil {
+			tags = []contracts.TagSummary{}
+		}
 		responses[i] = &contracts.CollectionListResponse{
 			ID:                     c.ID,
 			Title:                  c.Title,
@@ -1279,6 +1327,7 @@ func (s *CollectionService) GetUserCollections(userID uint, limit, offset int) (
 			NewSinceLastVisit:      newCounts[c.ID],
 			LikeCount:              likeCounts[c.ID],
 			UserLikesThis:          userLikes[c.ID],
+			Tags:                   tags,
 			CreatedAt:              c.CreatedAt,
 			UpdatedAt:              c.UpdatedAt,
 		}
@@ -1339,9 +1388,15 @@ func (s *CollectionService) GetEntityCollections(entityType string, entityID uin
 	// so UserLikesThis is left false here (clients that need it should
 	// use the detail endpoint).
 	likeCounts := s.batchCountLikes(collectionIDs)
+	// PSY-354: tag chips on entity-collection cards.
+	tagsByCollection := s.batchListCollectionTagSummaries(collectionIDs)
 
 	responses := make([]*contracts.CollectionListResponse, len(collections))
 	for i, c := range collections {
+		tags := tagsByCollection[c.ID]
+		if tags == nil {
+			tags = []contracts.TagSummary{}
+		}
 		responses[i] = &contracts.CollectionListResponse{
 			ID:                     c.ID,
 			Title:                  c.Title,
@@ -1363,6 +1418,7 @@ func (s *CollectionService) GetEntityCollections(entityType string, entityID uin
 			ForkedFromCollectionID: c.ForkedFromCollectionID,
 			EntityTypeCounts:       entityTypeCounts[c.ID],
 			LikeCount:              likeCounts[c.ID],
+			Tags:                   tags,
 			CreatedAt:              c.CreatedAt,
 			UpdatedAt:              c.UpdatedAt,
 		}
@@ -1419,9 +1475,15 @@ func (s *CollectionService) GetUserPublicCollections(userID uint, limit, offset 
 	// PSY-352: like aggregate; viewer ID is not threaded through this call,
 	// so UserLikesThis is left false here.
 	likeCounts := s.batchCountLikes(collectionIDs)
+	// PSY-354: tag chips on profile-page cards.
+	tagsByCollection := s.batchListCollectionTagSummaries(collectionIDs)
 
 	responses := make([]*contracts.CollectionListResponse, len(collections))
 	for i, c := range collections {
+		tags := tagsByCollection[c.ID]
+		if tags == nil {
+			tags = []contracts.TagSummary{}
+		}
 		responses[i] = &contracts.CollectionListResponse{
 			ID:                     c.ID,
 			Title:                  c.Title,
@@ -1443,6 +1505,7 @@ func (s *CollectionService) GetUserPublicCollections(userID uint, limit, offset 
 			ForkedFromCollectionID: c.ForkedFromCollectionID,
 			EntityTypeCounts:       entityTypeCounts[c.ID],
 			LikeCount:              likeCounts[c.ID],
+			Tags:                   tags,
 			CreatedAt:              c.CreatedAt,
 			UpdatedAt:              c.UpdatedAt,
 		}
@@ -1990,6 +2053,205 @@ func (s *CollectionService) batchCheckUserLikes(userID uint, collectionIDs []uin
 
 	for _, r := range rows {
 		result[r.CollectionID] = true
+	}
+	return result
+}
+
+// ============================================================================
+// Collection tags (PSY-354)
+// ============================================================================
+
+// canEditCollectionTags returns true when the user has permission to
+// add/remove tags on the given collection. Mirrors the AddItem rule:
+// the creator can always edit, plus any authenticated user when the
+// collection is collaborative. Anonymous callers (userID == 0) are
+// always rejected.
+func (s *CollectionService) canEditCollectionTags(collection *models.Collection, userID uint) bool {
+	if userID == 0 {
+		return false
+	}
+	if collection.CreatorID == userID {
+		return true
+	}
+	return collection.Collaborative
+}
+
+// AddTagToCollection applies a tag to a collection (PSY-354). Reuses the
+// polymorphic tag service for the tag/alias resolution + inline-creation
+// path, then enforces:
+//   - max-10 tags per collection (rejects 11th with 400),
+//   - edit-access (creator OR collaborative-and-authenticated),
+//   - default category "other" when creating a new tag inline.
+//
+// Returns the post-mutation tag list so the frontend can refresh the chip
+// row from a single round-trip.
+func (s *CollectionService) AddTagToCollection(slug string, userID uint, req *contracts.AddCollectionTagRequest) (*contracts.AddCollectionTagResponse, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+	if s.tagService == nil {
+		return nil, fmt.Errorf("tag service not initialized")
+	}
+	if req == nil {
+		return nil, apperrors.ErrCollectionInvalidRequest("request body is required")
+	}
+	if req.TagID == 0 && strings.TrimSpace(req.TagName) == "" {
+		return nil, apperrors.ErrCollectionInvalidRequest("tag_id or tag_name is required")
+	}
+
+	var collection models.Collection
+	if err := s.db.Where("slug = ?", slug).First(&collection).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, apperrors.ErrCollectionNotFound(slug)
+		}
+		return nil, fmt.Errorf("failed to get collection: %w", err)
+	}
+
+	if !s.canEditCollectionTags(&collection, userID) {
+		return nil, apperrors.ErrCollectionForbidden(slug)
+	}
+
+	// Enforce the per-collection cap before delegating. We list first so the
+	// 400 response can quote the precise current count to the curator. There
+	// is a benign race here (two simultaneous adds at count==9 could both
+	// succeed), but ten vs eleven is not safety-critical and the alternative
+	// would be a counter column or a SERIALIZABLE transaction — overkill for
+	// a soft cap.
+	existing, err := s.tagService.ListEntityTags(models.TagEntityCollection, collection.ID, userID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list existing collection tags: %w", err)
+	}
+	if len(existing) >= contracts.MaxCollectionTags {
+		return nil, apperrors.ErrCollectionTagLimitExceeded(len(existing), contracts.MaxCollectionTags)
+	}
+
+	category := req.Category
+	if category == "" {
+		// Collection meta-tags rarely fit "genre" or "locale"; default to
+		// "other" so the autocomplete doesn't accidentally pollute the genre
+		// taxonomy when the curator types a freeform term.
+		category = models.TagCategoryOther
+	}
+
+	if _, err := s.tagService.AddTagToEntity(req.TagID, req.TagName, models.TagEntityCollection, collection.ID, userID, category); err != nil {
+		return nil, err
+	}
+
+	// Re-list and return the post-mutation set.
+	tags, err := s.tagService.ListEntityTags(models.TagEntityCollection, collection.ID, userID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list collection tags: %w", err)
+	}
+	if tags == nil {
+		tags = []contracts.EntityTagResponse{}
+	}
+	return &contracts.AddCollectionTagResponse{Tags: tags}, nil
+}
+
+// RemoveTagFromCollection removes a tag from a collection (PSY-354). Same
+// edit-access rule as AddTagToCollection. Idempotency is delegated to the
+// tag service — removing a non-existent application returns ErrEntityTagNotFound.
+func (s *CollectionService) RemoveTagFromCollection(slug string, tagID uint, userID uint) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+	if s.tagService == nil {
+		return fmt.Errorf("tag service not initialized")
+	}
+	if tagID == 0 {
+		return apperrors.ErrCollectionInvalidRequest("tag_id is required")
+	}
+
+	var collection models.Collection
+	if err := s.db.Where("slug = ?", slug).First(&collection).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return apperrors.ErrCollectionNotFound(slug)
+		}
+		return fmt.Errorf("failed to get collection: %w", err)
+	}
+
+	if !s.canEditCollectionTags(&collection, userID) {
+		return apperrors.ErrCollectionForbidden(slug)
+	}
+
+	return s.tagService.RemoveTagFromEntity(tagID, models.TagEntityCollection, collection.ID)
+}
+
+// listCollectionTags returns the EntityTagResponse list for a single
+// collection. Returns an empty slice (never nil) so the JSON shape is
+// stable. Tag service unavailability is a no-op (older test paths build
+// CollectionService bare); callers always get an empty array, never an
+// error. Live errors from the tag service are logged and swallowed for
+// the same reason — a list/get must not fail because the tag side-channel
+// hiccupped.
+func (s *CollectionService) listCollectionTags(collectionID uint, viewerID uint) []contracts.EntityTagResponse {
+	if s.tagService == nil {
+		return []contracts.EntityTagResponse{}
+	}
+	tags, err := s.tagService.ListEntityTags(models.TagEntityCollection, collectionID, viewerID)
+	if err != nil {
+		log.Printf("warning: failed to list tags for collection %d: %v", collectionID, err)
+		return []contracts.EntityTagResponse{}
+	}
+	if tags == nil {
+		return []contracts.EntityTagResponse{}
+	}
+	return tags
+}
+
+// batchListCollectionTagSummaries fetches lightweight tag summaries for
+// many collections in one query. Used by list endpoints (cards) where the
+// per-tag vote/upvote/wilson_score detail isn't needed. Mirrors the
+// batchCount* / batchCheck* helpers the rest of the service uses.
+//
+// SQL shape:
+//
+//	SELECT et.entity_id AS collection_id,
+//	       t.id, t.name, t.slug, t.category, t.is_official, t.usage_count
+//	FROM entity_tags et
+//	JOIN tags t ON t.id = et.tag_id
+//	WHERE et.entity_type = 'collection' AND et.entity_id IN (...)
+//	ORDER BY t.is_official DESC, t.usage_count DESC, t.name ASC
+//
+// Ordering keeps the most-curated chips first on the card.
+func (s *CollectionService) batchListCollectionTagSummaries(collectionIDs []uint) map[uint][]contracts.TagSummary {
+	result := make(map[uint][]contracts.TagSummary)
+	if len(collectionIDs) == 0 {
+		return result
+	}
+
+	type Row struct {
+		CollectionID uint
+		ID           uint
+		Name         string
+		Slug         string
+		Category     string
+		IsOfficial   bool
+		UsageCount   int
+	}
+	var rows []Row
+	err := s.db.Table("entity_tags").
+		Select(`entity_tags.entity_id AS collection_id,
+		        tags.id, tags.name, tags.slug, tags.category,
+		        tags.is_official, tags.usage_count`).
+		Joins("JOIN tags ON tags.id = entity_tags.tag_id").
+		Where("entity_tags.entity_type = ? AND entity_tags.entity_id IN ?", models.TagEntityCollection, collectionIDs).
+		Order("tags.is_official DESC, tags.usage_count DESC, tags.name ASC").
+		Scan(&rows).Error
+	if err != nil {
+		log.Printf("warning: failed to batch list collection tags: %v", err)
+		return result
+	}
+
+	for _, r := range rows {
+		result[r.CollectionID] = append(result[r.CollectionID], contracts.TagSummary{
+			ID:         r.ID,
+			Name:       r.Name,
+			Slug:       r.Slug,
+			Category:   r.Category,
+			IsOfficial: r.IsOfficial,
+			UsageCount: r.UsageCount,
+		})
 	}
 	return result
 }

--- a/backend/internal/services/collection_test.go
+++ b/backend/internal/services/collection_test.go
@@ -11,6 +11,7 @@ import (
 
 	apperrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/models"
+	"psychic-homily-backend/internal/services/catalog"
 	"psychic-homily-backend/internal/services/contracts"
 	"psychic-homily-backend/internal/testutil"
 )
@@ -24,13 +25,18 @@ type CollectionServiceIntegrationTestSuite struct {
 	testDB            *testutil.TestDatabase
 	db                *gorm.DB
 	collectionService *CollectionService
+	// tagService is wired into collectionService so the PSY-354 test paths
+	// (tag rendering on detail/list, AddTagToCollection, RemoveTagFromCollection)
+	// exercise the same code production uses.
+	tagService *catalog.TagService
 }
 
 func (suite *CollectionServiceIntegrationTestSuite) SetupSuite() {
 	suite.testDB = testutil.SetupTestPostgres(suite.T())
 	suite.db = suite.testDB.DB
 
-	suite.collectionService = &CollectionService{db: suite.testDB.DB}
+	suite.tagService = catalog.NewTagService(suite.testDB.DB)
+	suite.collectionService = &CollectionService{db: suite.testDB.DB, tagService: suite.tagService}
 }
 
 func (suite *CollectionServiceIntegrationTestSuite) TearDownSuite() {
@@ -41,6 +47,10 @@ func (suite *CollectionServiceIntegrationTestSuite) TearDownTest() {
 	sqlDB, err := suite.db.DB()
 	suite.Require().NoError(err)
 	// Delete in FK-safe order
+	// PSY-354: clear polymorphic tag links + votes before users (added_by FKs
+	// are NOT ON DELETE CASCADE, so leaked rows would block user deletion).
+	_, _ = sqlDB.Exec("DELETE FROM tag_votes")
+	_, _ = sqlDB.Exec("DELETE FROM entity_tags")
 	_, _ = sqlDB.Exec("DELETE FROM collection_likes")
 	_, _ = sqlDB.Exec("DELETE FROM collection_subscribers")
 	_, _ = sqlDB.Exec("DELETE FROM collection_items")
@@ -58,6 +68,9 @@ func (suite *CollectionServiceIntegrationTestSuite) TearDownTest() {
 	_, _ = sqlDB.Exec("DELETE FROM festival_artists")
 	_, _ = sqlDB.Exec("DELETE FROM festival_venues")
 	_, _ = sqlDB.Exec("DELETE FROM festivals")
+	// Tag corpus last — LOWER(name) unique would collide between tests.
+	_, _ = sqlDB.Exec("DELETE FROM tag_aliases")
+	_, _ = sqlDB.Exec("DELETE FROM tags")
 	_, _ = sqlDB.Exec("DELETE FROM users")
 }
 
@@ -2050,4 +2063,288 @@ func (suite *CollectionServiceIntegrationTestSuite) TestCloneCollection_AutoPass
 	suite.Require().NoError(err)
 	suite.Equal(int64(2), total, "source + clone both pass the gate")
 	suite.Len(resp, 2)
+}
+
+// =============================================================================
+// PSY-354: Collection tags
+// =============================================================================
+//
+// Tags reuse the polymorphic entity_tags table. Coverage:
+//   - Add by free-form name creates the tag inline + applies it.
+//   - Add reuses an existing tag when one is found by name.
+//   - Add enforces MaxCollectionTags (rejects 11th).
+//   - Permission rule: creator OR collaborative-and-authenticated; otherwise 403.
+//   - Remove unapplies the tag and decrements usage_count.
+//   - Detail / list responses surface tags.
+//   - ListCollections accepts ?tag=<slug> and filters correctly.
+
+// promoteContributor flips a test user's tier to "contributor" so the tag
+// service's createTagInline gate (new_user → 403) doesn't reject the test
+// path. createTestUser doesn't set UserTier, so the DB default ("new_user")
+// applies — identical to the dogfooded gate, which we want to side-step
+// for the bulk of these tests since the trust-tier gate is covered in
+// catalog/tag_service_test.go.
+func (suite *CollectionServiceIntegrationTestSuite) promoteContributor(user *models.User) {
+	suite.Require().NoError(suite.db.Model(&models.User{}).
+		Where("id = ?", user.ID).
+		Update("user_tier", "contributor").Error)
+}
+
+// TestAddTagToCollection_ByName_HappyPath creates the tag inline and surfaces
+// it on the post-mutation response.
+func (suite *CollectionServiceIntegrationTestSuite) TestAddTagToCollection_ByName_HappyPath() {
+	creator := suite.createTestUser("TagCreator")
+	suite.promoteContributor(creator)
+	coll := suite.createBasicCollection(creator, "Tagged Collection")
+
+	resp, err := suite.collectionService.AddTagToCollection(coll.Slug, creator.ID,
+		&contracts.AddCollectionTagRequest{TagName: "best-of-2026"})
+	suite.Require().NoError(err)
+	suite.Require().NotNil(resp)
+	suite.Require().Len(resp.Tags, 1)
+	suite.Equal("best-of-2026", resp.Tags[0].Name)
+	suite.Equal("other", resp.Tags[0].Category, "default category for new collection tags is 'other'")
+}
+
+// TestAddTagToCollection_ByID applies an existing tag without creating a new one.
+func (suite *CollectionServiceIntegrationTestSuite) TestAddTagToCollection_ByID() {
+	creator := suite.createTestUser("TagCreator")
+	suite.promoteContributor(creator)
+	coll := suite.createBasicCollection(creator, "By ID Collection")
+
+	// Pre-create a tag.
+	tag, err := suite.tagService.CreateTag("phoenix", nil, nil, models.TagCategoryLocale, false, &creator.ID)
+	suite.Require().NoError(err)
+
+	resp, err := suite.collectionService.AddTagToCollection(coll.Slug, creator.ID,
+		&contracts.AddCollectionTagRequest{TagID: tag.ID})
+	suite.Require().NoError(err)
+	suite.Require().Len(resp.Tags, 1)
+	suite.Equal(tag.ID, resp.Tags[0].TagID)
+	suite.Equal("phoenix", resp.Tags[0].Name)
+	suite.Equal("locale", resp.Tags[0].Category, "category preserved when applying an existing tag")
+}
+
+// TestAddTagToCollection_DefaultCategory_OtherForFreeForm verifies that a
+// free-form tag name without a category gets "other" rather than picking
+// up "genre" by default — the rest of the tag system defaults to genre,
+// but collection meta-tags rarely fit that taxonomy.
+func (suite *CollectionServiceIntegrationTestSuite) TestAddTagToCollection_DefaultCategory_OtherForFreeForm() {
+	creator := suite.createTestUser("TagCreator")
+	suite.promoteContributor(creator)
+	coll := suite.createBasicCollection(creator, "Default Category Test")
+
+	resp, err := suite.collectionService.AddTagToCollection(coll.Slug, creator.ID,
+		&contracts.AddCollectionTagRequest{TagName: "post-show-essentials"})
+	suite.Require().NoError(err)
+	suite.Require().Len(resp.Tags, 1)
+	suite.Equal("other", resp.Tags[0].Category)
+}
+
+// TestAddTagToCollection_MaxLimit_Rejects11th hits the cap and verifies the
+// 400 carries the cap + current count.
+func (suite *CollectionServiceIntegrationTestSuite) TestAddTagToCollection_MaxLimit_Rejects11th() {
+	creator := suite.createTestUser("CapCreator")
+	suite.promoteContributor(creator)
+	coll := suite.createBasicCollection(creator, "Capped Collection")
+
+	for i := 0; i < contracts.MaxCollectionTags; i++ {
+		_, err := suite.collectionService.AddTagToCollection(coll.Slug, creator.ID,
+			&contracts.AddCollectionTagRequest{TagName: fmt.Sprintf("cap-tag-%d", i)})
+		suite.Require().NoError(err, "failed adding tag %d", i)
+	}
+
+	_, err := suite.collectionService.AddTagToCollection(coll.Slug, creator.ID,
+		&contracts.AddCollectionTagRequest{TagName: "one-too-many"})
+	suite.Require().Error(err)
+	var collErr *apperrors.CollectionError
+	suite.Require().ErrorAs(err, &collErr)
+	suite.Equal(apperrors.CodeCollectionTagLimitExceeded, collErr.Code)
+	suite.Contains(collErr.Message, "10 tags")
+}
+
+// TestAddTagToCollection_NonOwner_NonCollaborative_Rejected covers the
+// permission gate: a non-creator on a non-collaborative collection cannot
+// add tags. PSY-354. createBasicCollection's GORM-bool dance lands the
+// collection as Collaborative=false by default, which is the state we want.
+func (suite *CollectionServiceIntegrationTestSuite) TestAddTagToCollection_NonOwner_NonCollaborative_Rejected() {
+	creator := suite.createTestUser("Owner")
+	stranger := suite.createTestUser("Stranger")
+	suite.promoteContributor(stranger)
+
+	coll := suite.createBasicCollection(creator, "Solo Curator")
+	suite.Require().False(coll.Collaborative, "expected default Collaborative=false from createBasicCollection")
+
+	_, err := suite.collectionService.AddTagToCollection(coll.Slug, stranger.ID,
+		&contracts.AddCollectionTagRequest{TagName: "intruder-tag"})
+	suite.Require().Error(err)
+	var collErr *apperrors.CollectionError
+	suite.Require().ErrorAs(err, &collErr)
+	suite.Equal(apperrors.CodeCollectionForbidden, collErr.Code)
+}
+
+// TestAddTagToCollection_Collaborator_Allowed verifies the open path: any
+// authenticated user can tag a collaborative collection. createBasicCollection
+// defaults to Collaborative=false (per CreateCollection's GORM-bool dance);
+// flip it explicitly with UpdateCollection so the test exercises the
+// collaborative branch of canEditCollectionTags.
+func (suite *CollectionServiceIntegrationTestSuite) TestAddTagToCollection_Collaborator_Allowed() {
+	creator := suite.createTestUser("Owner")
+	collaborator := suite.createTestUser("Helper")
+	suite.promoteContributor(collaborator)
+
+	coll := suite.createBasicCollection(creator, "Collab Curator")
+	collab := true
+	_, err := suite.collectionService.UpdateCollection(coll.Slug, creator.ID, false,
+		&contracts.UpdateCollectionRequest{Collaborative: &collab})
+	suite.Require().NoError(err)
+
+	resp, err := suite.collectionService.AddTagToCollection(coll.Slug, collaborator.ID,
+		&contracts.AddCollectionTagRequest{TagName: "community-pick"})
+	suite.Require().NoError(err)
+	suite.Require().Len(resp.Tags, 1)
+	suite.Equal("community-pick", resp.Tags[0].Name)
+}
+
+// TestAddTagToCollection_NotFound returns 404-shaped error.
+func (suite *CollectionServiceIntegrationTestSuite) TestAddTagToCollection_NotFound() {
+	user := suite.createTestUser("AnyUser")
+	suite.promoteContributor(user)
+	_, err := suite.collectionService.AddTagToCollection("does-not-exist-slug", user.ID,
+		&contracts.AddCollectionTagRequest{TagName: "tag"})
+	suite.Require().Error(err)
+	var collErr *apperrors.CollectionError
+	suite.Require().ErrorAs(err, &collErr)
+	suite.Equal(apperrors.CodeCollectionNotFound, collErr.Code)
+}
+
+// TestAddTagToCollection_MissingArgs rejects bodies without tag_id or tag_name.
+func (suite *CollectionServiceIntegrationTestSuite) TestAddTagToCollection_MissingArgs() {
+	creator := suite.createTestUser("Owner")
+	suite.promoteContributor(creator)
+	coll := suite.createBasicCollection(creator, "Missing Args")
+
+	_, err := suite.collectionService.AddTagToCollection(coll.Slug, creator.ID,
+		&contracts.AddCollectionTagRequest{})
+	suite.Require().Error(err)
+	var collErr *apperrors.CollectionError
+	suite.Require().ErrorAs(err, &collErr)
+	suite.Equal(apperrors.CodeCollectionInvalidRequest, collErr.Code)
+}
+
+// TestRemoveTagFromCollection_Success removes the application and the tag
+// disappears from the detail response.
+func (suite *CollectionServiceIntegrationTestSuite) TestRemoveTagFromCollection_Success() {
+	creator := suite.createTestUser("Owner")
+	suite.promoteContributor(creator)
+	coll := suite.createBasicCollection(creator, "Remove Tag Test")
+
+	resp, err := suite.collectionService.AddTagToCollection(coll.Slug, creator.ID,
+		&contracts.AddCollectionTagRequest{TagName: "to-be-removed"})
+	suite.Require().NoError(err)
+	suite.Require().Len(resp.Tags, 1)
+	tagID := resp.Tags[0].TagID
+
+	suite.Require().NoError(suite.collectionService.RemoveTagFromCollection(coll.Slug, tagID, creator.ID))
+
+	detail, err := suite.collectionService.GetBySlug(coll.Slug, creator.ID)
+	suite.Require().NoError(err)
+	suite.Empty(detail.Tags, "removed tag must drop from the detail response")
+}
+
+// TestRemoveTagFromCollection_NonOwner_Rejected mirrors the add gate.
+func (suite *CollectionServiceIntegrationTestSuite) TestRemoveTagFromCollection_NonOwner_Rejected() {
+	creator := suite.createTestUser("Owner")
+	stranger := suite.createTestUser("Stranger")
+	suite.promoteContributor(creator)
+
+	coll := suite.createBasicCollection(creator, "Solo Curator Removal")
+	suite.Require().False(coll.Collaborative, "expected default Collaborative=false")
+
+	resp, err := suite.collectionService.AddTagToCollection(coll.Slug, creator.ID,
+		&contracts.AddCollectionTagRequest{TagName: "owner-only"})
+	suite.Require().NoError(err)
+	tagID := resp.Tags[0].TagID
+
+	err = suite.collectionService.RemoveTagFromCollection(coll.Slug, tagID, stranger.ID)
+	suite.Require().Error(err)
+	var collErr *apperrors.CollectionError
+	suite.Require().ErrorAs(err, &collErr)
+	suite.Equal(apperrors.CodeCollectionForbidden, collErr.Code)
+}
+
+// TestGetBySlug_PopulatesTags verifies tags surface on the detail response.
+func (suite *CollectionServiceIntegrationTestSuite) TestGetBySlug_PopulatesTags() {
+	creator := suite.createTestUser("Curator")
+	suite.promoteContributor(creator)
+	coll := suite.createBasicCollection(creator, "Detail With Tags")
+
+	for _, name := range []string{"genre-foo", "vibe-bar"} {
+		_, err := suite.collectionService.AddTagToCollection(coll.Slug, creator.ID,
+			&contracts.AddCollectionTagRequest{TagName: name})
+		suite.Require().NoError(err)
+	}
+
+	detail, err := suite.collectionService.GetBySlug(coll.Slug, creator.ID)
+	suite.Require().NoError(err)
+	suite.Require().Len(detail.Tags, 2)
+
+	names := []string{detail.Tags[0].Name, detail.Tags[1].Name}
+	suite.Contains(names, "genre-foo")
+	suite.Contains(names, "vibe-bar")
+}
+
+// TestListCollections_PopulatesTagSummaries verifies tag chips appear on
+// list cards.
+func (suite *CollectionServiceIntegrationTestSuite) TestListCollections_PopulatesTagSummaries() {
+	creator := suite.createTestUser("Curator")
+	suite.promoteContributor(creator)
+	coll := suite.createPublicCollection(creator, "List With Tags")
+
+	_, err := suite.collectionService.AddTagToCollection(coll.Slug, creator.ID,
+		&contracts.AddCollectionTagRequest{TagName: "card-tag"})
+	suite.Require().NoError(err)
+
+	resp, _, err := suite.collectionService.ListCollections(contracts.CollectionFilters{PublicOnly: true}, 20, 0)
+	suite.Require().NoError(err)
+	suite.Require().Len(resp, 1)
+	suite.Require().Len(resp[0].Tags, 1)
+	suite.Equal("card-tag", resp[0].Tags[0].Name)
+}
+
+// TestListCollections_FilterByTag returns only collections matching the
+// given tag slug.
+func (suite *CollectionServiceIntegrationTestSuite) TestListCollections_FilterByTag() {
+	creator := suite.createTestUser("Curator")
+	suite.promoteContributor(creator)
+
+	tagged := suite.createPublicCollection(creator, "Tagged List")
+	suite.createPublicCollection(creator, "Untagged List")
+
+	addResp, err := suite.collectionService.AddTagToCollection(tagged.Slug, creator.ID,
+		&contracts.AddCollectionTagRequest{TagName: "indie-2026"})
+	suite.Require().NoError(err)
+	suite.Require().Len(addResp.Tags, 1)
+
+	resp, total, err := suite.collectionService.ListCollections(
+		contracts.CollectionFilters{PublicOnly: true, Tag: "indie-2026"}, 20, 0,
+	)
+	suite.Require().NoError(err)
+	suite.Equal(int64(1), total)
+	suite.Require().Len(resp, 1)
+	suite.Equal(tagged.ID, resp[0].ID)
+}
+
+// TestListCollections_FilterByTag_Unknown returns empty when no collection
+// has the requested tag.
+func (suite *CollectionServiceIntegrationTestSuite) TestListCollections_FilterByTag_Unknown() {
+	creator := suite.createTestUser("Curator")
+	suite.createPublicCollection(creator, "Some Collection")
+
+	resp, total, err := suite.collectionService.ListCollections(
+		contracts.CollectionFilters{PublicOnly: true, Tag: "no-such-tag-slug-xyz"}, 20, 0,
+	)
+	suite.Require().NoError(err)
+	suite.Equal(int64(0), total)
+	suite.Empty(resp)
 }

--- a/backend/internal/services/container.go
+++ b/backend/internal/services/container.go
@@ -143,6 +143,13 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 	commentNotificationSvc := engagement.NewCommentNotificationService(database, email, cfg.JWT.SecretKey, cfg.Email.FrontendURL)
 	commentSvc.SetNotifier(commentNotificationSvc)
 
+	// PSY-354: collections get tag support via the polymorphic entity_tags
+	// system. Wire the tag service into the collection service so curators
+	// can apply/remove tags + the get/list responses can surface chips.
+	collectionSvc := NewCollectionService(database)
+	tagSvc := catalog.NewTagService(database)
+	collectionSvc.SetTagService(tagSvc)
+
 	return &ServiceContainer{
 		// DB-only leaf services
 		AdminStats:         adminsvc.NewAdminStatsService(database),
@@ -158,9 +165,9 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 		AuditLog:      adminsvc.NewAuditLogService(database),
 		Bookmark:      engagement.NewBookmarkService(database),
 		Calendar:      engagement.NewCalendarService(database, savedShow),
-		Collection:    NewCollectionService(database),
+		Collection:    collectionSvc,
 		Request:       NewRequestService(database),
-		Tag:                catalog.NewTagService(database),
+		Tag:                tagSvc,
 		ArtistRelationship: artistRelSvc,
 		Scene:              catalog.NewSceneService(database),
 		Attendance:         engagement.NewAttendanceService(database),

--- a/backend/internal/services/contracts/collection.go
+++ b/backend/internal/services/contracts/collection.go
@@ -76,6 +76,10 @@ type CollectionFilters struct {
 	// Carried on the filter struct so we can populate UserLikesThis on each
 	// list row without changing the function signature. PSY-352.
 	ViewerID uint
+	// Tag is the slug of a single tag to filter the listing by (PSY-354).
+	// Empty string means no tag filter. Multi-tag filtering is intentionally
+	// out of scope for the MVP — the URL surface stays `?tag=<slug>`.
+	Tag string
 }
 
 // CollectionSortPopular is the recognized sort value for the HN-gravity
@@ -125,9 +129,14 @@ type CollectionDetailResponse struct {
 	LikeCount int `json:"like_count"`
 	// UserLikesThis is true when the authenticated viewer has liked this
 	// collection. Always false for anonymous viewers. PSY-352.
-	UserLikesThis bool      `json:"user_likes_this"`
-	CreatedAt     time.Time `json:"created_at"`
-	UpdatedAt     time.Time `json:"updated_at"`
+	UserLikesThis bool `json:"user_likes_this"`
+	// Tags applied to this collection (PSY-354). Always non-nil — empty
+	// array when the collection has no tags. Reuses the polymorphic
+	// EntityTagResponse so the same chip component renders here as on
+	// artist/release/etc detail pages.
+	Tags      []EntityTagResponse `json:"tags"`
+	CreatedAt time.Time           `json:"created_at"`
+	UpdatedAt time.Time           `json:"updated_at"`
 }
 
 // ForkedFromInfo carries the minimum data needed to render the
@@ -178,9 +187,13 @@ type CollectionListResponse struct {
 	LikeCount int `json:"like_count"`
 	// UserLikesThis is true when the authenticated viewer has liked this
 	// collection. Always false for anonymous viewers. PSY-352.
-	UserLikesThis bool      `json:"user_likes_this"`
-	CreatedAt     time.Time `json:"created_at"`
-	UpdatedAt     time.Time `json:"updated_at"`
+	UserLikesThis bool `json:"user_likes_this"`
+	// Tags applied to this collection (PSY-354). Reuses TagSummary so list
+	// rows stay lightweight (no vote counts on cards). Always non-nil; empty
+	// array when the collection has no tags.
+	Tags      []TagSummary `json:"tags"`
+	CreatedAt time.Time    `json:"created_at"`
+	UpdatedAt time.Time    `json:"updated_at"`
 }
 
 // CollectionItemResponse represents an item in a collection.
@@ -222,6 +235,28 @@ type CollectionLikeResponse struct {
 	UserLikesThis bool `json:"user_likes_this"`
 }
 
+// MaxCollectionTags is the cap on tag applications per collection (PSY-354).
+// Mirrors the modest tag bar the rest of the project applies to entity
+// tagging — collections aren't the canonical taxonomy, and a 10-tag ceiling
+// keeps cards readable while still allowing meaningful classification.
+const MaxCollectionTags = 10
+
+// AddCollectionTagRequest is the body for POST /collections/{slug}/tags
+// (PSY-354). Mirrors the Add-Tag-To-Entity endpoint: callers either pass a
+// known tag_id or a free-form tag_name (with alias resolution + inline
+// creation gated by trust tier in the tag service).
+type AddCollectionTagRequest struct {
+	TagID    uint   `json:"tag_id"`
+	TagName  string `json:"tag_name"`
+	Category string `json:"category"`
+}
+
+// AddCollectionTagResponse returns the post-mutation tag list so the
+// frontend can refresh chips without a follow-up GET.
+type AddCollectionTagResponse struct {
+	Tags []EntityTagResponse `json:"tags"`
+}
+
 // CollectionServiceInterface defines the contract for collection operations.
 type CollectionServiceInterface interface {
 	CreateCollection(creatorID uint, req *CreateCollectionRequest) (*CollectionDetailResponse, error)
@@ -249,4 +284,12 @@ type CollectionServiceInterface interface {
 	GetUserPublicCollections(userID uint, limit, offset int) ([]*CollectionListResponse, int64, error)
 	GetUserPublicCollectionsByUsername(username string, limit, offset int) ([]*CollectionListResponse, int64, error)
 	SetFeatured(slug string, featured bool) error
+	// AddTagToCollection applies a tag to a collection (PSY-354). Caller must
+	// have edit access (creator OR collaborative-and-authenticated, mirroring
+	// AddItem). Enforces MaxCollectionTags. Returns the post-mutation tag
+	// list.
+	AddTagToCollection(slug string, userID uint, req *AddCollectionTagRequest) (*AddCollectionTagResponse, error)
+	// RemoveTagFromCollection removes a tag from a collection (PSY-354).
+	// Same edit-access rule as AddTagToCollection.
+	RemoveTagFromCollection(slug string, tagID uint, userID uint) error
 }

--- a/frontend/features/collections/components/CollectionCard.test.tsx
+++ b/frontend/features/collections/components/CollectionCard.test.tsx
@@ -339,4 +339,69 @@ describe('CollectionCard', () => {
       expect(screen.queryByTestId('contributor-badge')).not.toBeInTheDocument()
     })
   })
+
+  // PSY-354: tag chip rendering on the card.
+  describe('tag chips (PSY-354)', () => {
+    it('does not render the chip row when tags is empty', () => {
+      render(<CollectionCard collection={baseCollection} />)
+      expect(
+        screen.queryByTestId('collection-card-tags')
+      ).not.toBeInTheDocument()
+    })
+
+    it('renders a chip per tag, linking to /collections?tag=<slug>', () => {
+      const collection: Collection = {
+        ...baseCollection,
+        tags: [
+          {
+            id: 1,
+            name: 'phoenix',
+            slug: 'phoenix',
+            category: 'locale',
+            is_official: false,
+            usage_count: 4,
+          },
+          {
+            id: 2,
+            name: 'best-of-2026',
+            slug: 'best-of-2026',
+            category: 'other',
+            is_official: false,
+            usage_count: 1,
+          },
+        ],
+      }
+      render(<CollectionCard collection={collection} />)
+      const row = screen.getByTestId('collection-card-tags')
+      expect(row).toBeInTheDocument()
+      const phoenix = screen.getByRole('link', { name: 'phoenix' })
+      expect(phoenix).toHaveAttribute(
+        'href',
+        '/collections?tag=phoenix'
+      )
+      const bestOf = screen.getByRole('link', { name: 'best-of-2026' })
+      expect(bestOf).toHaveAttribute(
+        'href',
+        '/collections?tag=best-of-2026'
+      )
+    })
+
+    it('caps visible chips at 5 and shows the overflow count', () => {
+      const collection: Collection = {
+        ...baseCollection,
+        tags: Array.from({ length: 7 }, (_, i) => ({
+          id: i + 1,
+          name: `tag-${i + 1}`,
+          slug: `tag-${i + 1}`,
+          category: 'other',
+          is_official: false,
+          usage_count: 1,
+        })),
+      }
+      render(<CollectionCard collection={collection} />)
+      const row = screen.getByTestId('collection-card-tags')
+      expect(row.querySelectorAll('a').length).toBe(5)
+      expect(row.textContent).toContain('+2')
+    })
+  })
 })

--- a/frontend/features/collections/components/CollectionCard.tsx
+++ b/frontend/features/collections/components/CollectionCard.tsx
@@ -171,6 +171,41 @@ export function CollectionCard({ collection }: CollectionCardProps) {
             />
           )}
 
+          {/* PSY-354: tag chips. Cap at 5 visible to keep cards readable;
+              the detail page shows the full set. Each chip links to the
+              tag-filtered collections browse — the ticket explicitly
+              chose this over the global /tags/{slug} target so chips on
+              cards behave like a "show me other collections like this"
+              shortcut rather than a deep-dive into the tag's full corpus. */}
+          {collection.tags && collection.tags.length > 0 && (
+            <div
+              className="mt-1.5 flex flex-wrap gap-1"
+              data-testid="collection-card-tags"
+            >
+              {collection.tags.slice(0, 5).map((tag) => (
+                <Link
+                  key={tag.id}
+                  href={`/collections?tag=${encodeURIComponent(tag.slug)}`}
+                  onClick={(e) => e.stopPropagation()}
+                  className={cn(
+                    'inline-flex items-center rounded-full border px-2 py-0.5',
+                    'text-[10px] font-medium transition-colors',
+                    'border-border/60 bg-muted/30 text-muted-foreground',
+                    'hover:border-primary/40 hover:bg-primary/10 hover:text-primary'
+                  )}
+                  title={tag.name}
+                >
+                  {tag.name}
+                </Link>
+              ))}
+              {collection.tags.length > 5 && (
+                <span className="text-[10px] text-muted-foreground self-center">
+                  +{collection.tags.length - 5}
+                </span>
+              )}
+            </div>
+          )}
+
           <div className="mt-1.5 flex items-center gap-3 text-xs text-muted-foreground flex-wrap">
             <span>
               by{' '}

--- a/frontend/features/collections/components/CollectionDetail.test.tsx
+++ b/frontend/features/collections/components/CollectionDetail.test.tsx
@@ -132,6 +132,24 @@ vi.mock('@/features/comments', () => ({
   ),
 }))
 
+// PSY-354: stub EntityTagList — its real implementation pulls in tag
+// hooks (useEntityTags, useSearchTags, useVoteOnTag) that need a
+// QueryClient. The CollectionDetail tests don't exercise tag UI, so a
+// minimal stub keeps them isolated from tag-feature plumbing.
+vi.mock('@/features/tags', () => ({
+  EntityTagList: ({
+    entityType,
+    entityId,
+  }: {
+    entityType: string
+    entityId: number
+  }) => (
+    <div data-testid="entity-tag-list">
+      Tags for {entityType} {entityId}
+    </div>
+  ),
+}))
+
 // Mock useEntitySearch
 vi.mock('@/lib/hooks/common/useEntitySearch', () => ({
   useEntitySearch: () => ({

--- a/frontend/features/collections/components/CollectionDetail.tsx
+++ b/frontend/features/collections/components/CollectionDetail.tsx
@@ -94,6 +94,7 @@ import { useRouter } from 'next/navigation'
 import type { ApiError } from '@/lib/api'
 import { formatRelativeTime } from '@/lib/formatRelativeTime'
 import { CommentThread } from '@/features/comments'
+import { EntityTagList } from '@/features/tags'
 
 interface CollectionDetailProps {
   slug: string
@@ -586,6 +587,22 @@ export function CollectionDetail({ slug }: CollectionDetailProps) {
           </div>
         )}
       </header>
+
+      {/* PSY-354: tag chips + picker. Reuses the same EntityTagList that
+          renders on artist/release/etc detail pages — chips link to
+          /tags/{slug} for the deep-dive (the collection-card override
+          links to /collections?tag=<slug> instead because cards prefer
+          the lateral "show me other collections like this" path). The
+          per-collection 10-tag cap is enforced server-side in
+          catalog.TagService.AddTagToEntity, so this picker honors the
+          limit regardless of the picker's UI cap awareness. */}
+      <div className="mb-4">
+        <EntityTagList
+          entityType="collection"
+          entityId={collection.id}
+          isAuthenticated={isAuthenticated}
+        />
+      </div>
 
       {/* PSY-356: publish-gate banner (creator-only) */}
       {isCreator && <PublishGateBanner collection={collection} />}

--- a/frontend/features/collections/components/CollectionList.test.tsx
+++ b/frontend/features/collections/components/CollectionList.test.tsx
@@ -17,8 +17,11 @@ vi.mock('@/lib/context/AuthContext', () => ({
 
 // Mock next/navigation
 const mockPush = vi.fn()
+const mockReplace = vi.fn()
+const mockSearchParams = new URLSearchParams()
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({ push: mockPush }),
+  useRouter: () => ({ push: mockPush, replace: mockReplace }),
+  useSearchParams: () => mockSearchParams,
 }))
 
 // Mock use-debounce to fire immediately
@@ -423,6 +426,70 @@ describe('CollectionList', () => {
       render(<CollectionList />)
       const collabCheckbox = screen.getByLabelText('Collaborative') as HTMLInputElement
       expect(collabCheckbox.checked).toBe(false)
+    })
+  })
+
+  // PSY-354: tag-filter URL plumbing.
+  describe('tag filter (PSY-354)', () => {
+    it('does not render the active-filter pill when ?tag is absent', () => {
+      mockSearchParams.delete('tag')
+      mockUseCollections.mockReturnValue({
+        data: { collections: [] },
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      })
+      render(<CollectionList />)
+      expect(
+        screen.queryByTestId('collection-tag-filter-pill')
+      ).not.toBeInTheDocument()
+    })
+
+    it('renders the active-filter pill with tag slug when ?tag is set', () => {
+      mockSearchParams.set('tag', 'phoenix')
+      mockUseCollections.mockReturnValue({
+        data: { collections: [] },
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      })
+      render(<CollectionList />)
+      const pill = screen.getByTestId('collection-tag-filter-pill')
+      expect(pill).toBeInTheDocument()
+      expect(pill.textContent).toContain('phoenix')
+      mockSearchParams.delete('tag')
+    })
+
+    it('passes tag from URL into useCollections params', () => {
+      mockSearchParams.set('tag', 'best-of-2026')
+      mockUseCollections.mockReturnValue({
+        data: { collections: [] },
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      })
+      render(<CollectionList />)
+      // The hook is called with tag set when ?tag is in the URL.
+      expect(mockUseCollections).toHaveBeenCalledWith(
+        expect.objectContaining({ tag: 'best-of-2026' })
+      )
+      mockSearchParams.delete('tag')
+    })
+
+    it('clears the filter via router.replace when X is clicked', async () => {
+      const user = userEvent.setup()
+      mockSearchParams.set('tag', 'phoenix')
+      mockUseCollections.mockReturnValue({
+        data: { collections: [] },
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      })
+      render(<CollectionList />)
+      const clearBtn = screen.getByTestId('collection-tag-filter-clear')
+      await user.click(clearBtn)
+      expect(mockReplace).toHaveBeenCalled()
+      mockSearchParams.delete('tag')
     })
   })
 })

--- a/frontend/features/collections/components/CollectionList.tsx
+++ b/frontend/features/collections/components/CollectionList.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useMemo } from 'react'
-import { Plus, Search, Library, Star, Clock, TrendingUp, User } from 'lucide-react'
+import { Plus, Search, Library, Star, Clock, TrendingUp, User, X } from 'lucide-react'
 import { useDebounce } from 'use-debounce'
 import { useCollections, useMyCollections, useCreateCollection } from '../hooks'
 import { CollectionCard } from './CollectionCard'
@@ -19,7 +19,7 @@ import {
 } from '@/components/ui/dialog'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { useAuthContext } from '@/lib/context/AuthContext'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import {
   COLLECTION_ENTITY_TYPES,
   getEntityTypeLabel,
@@ -33,6 +33,7 @@ type BrowseTab = 'all' | 'popular' | 'recent' | 'featured' | 'yours'
 export function CollectionList() {
   const { isAuthenticated } = useAuthContext()
   const router = useRouter()
+  const searchParams = useSearchParams()
   const [createDialogOpen, setCreateDialogOpen] = useState(false)
   const [activeTab, setActiveTab] = useState<BrowseTab>('all')
   const [searchInput, setSearchInput] = useState('')
@@ -49,6 +50,22 @@ export function CollectionList() {
   // is the canonical ranking and includes recency-bias.
   const isPopularTab = activeTab === 'popular'
 
+  // PSY-354: URL-driven tag filter. The chip on collection cards links to
+  // `/collections?tag=<slug>`; reading from the URL keeps the filter
+  // shareable + back-button-restorable. Single-tag for the MVP.
+  const tagFilter = searchParams.get('tag') ?? ''
+
+  // Clear the active tag pill — pushes a URL without `tag=`. Use
+  // router.replace so the back button doesn't bounce back into the
+  // filtered view (the filter clear is part of the same navigation
+  // intent, not a separate history entry).
+  const handleClearTag = () => {
+    const next = new URLSearchParams(searchParams.toString())
+    next.delete('tag')
+    const qs = next.toString()
+    router.replace(qs ? `/collections?${qs}` : '/collections', { scroll: false })
+  }
+
   // Fetch public collections (with search + featured + entity-type filters)
   const {
     data: publicData,
@@ -60,6 +77,7 @@ export function CollectionList() {
     featured: isFeaturedTab || undefined,
     entityType: entityTypeFilter === 'all' ? undefined : entityTypeFilter,
     sort: isPopularTab ? 'popular' : undefined,
+    tag: tagFilter || undefined,
   })
 
   // Fetch user's own collections (only when on "yours" tab and authenticated)
@@ -176,7 +194,7 @@ export function CollectionList() {
         </TabsList>
 
         {/* Entity type filter chips */}
-        <div className="mb-6 flex flex-wrap gap-1.5" role="group" aria-label="Filter by entity type">
+        <div className="mb-3 flex flex-wrap gap-1.5" role="group" aria-label="Filter by entity type">
           <TypeChip
             active={entityTypeFilter === 'all'}
             onClick={() => setEntityTypeFilter('all')}
@@ -191,6 +209,38 @@ export function CollectionList() {
             />
           ))}
         </div>
+
+        {/* PSY-354: active tag-filter pill. Distinct from the entity-type
+            chips above (those are toggleable filters; this is a "you are
+            currently filtering" indicator with an X-to-clear). Empty when
+            ?tag=<slug> isn't present in the URL. */}
+        {tagFilter && (
+          <div
+            className="mb-6 flex flex-wrap items-center gap-2 text-sm"
+            role="status"
+            aria-live="polite"
+            data-testid="collection-tag-filter-pill"
+          >
+            <span className="text-muted-foreground">Tagged with</span>
+            <span
+              className={cn(
+                'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5',
+                'border-primary/40 bg-primary/10 text-primary'
+              )}
+            >
+              <span className="font-medium">{tagFilter}</span>
+              <button
+                type="button"
+                onClick={handleClearTag}
+                aria-label={`Clear tag filter (${tagFilter})`}
+                className="rounded-full p-0.5 hover:bg-primary/20 focus:outline-none focus:ring-2 focus:ring-ring"
+                data-testid="collection-tag-filter-clear"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </span>
+          </div>
+        )}
 
         {/* All tab content areas render the same grid — content differs by data source */}
         {tabs.map((tab) => (

--- a/frontend/features/collections/hooks/index.test.tsx
+++ b/frontend/features/collections/hooks/index.test.tsx
@@ -19,6 +19,8 @@ vi.mock('@/lib/api', () => ({
       FEATURE: (slug: string) => `/collections/${slug}/feature`,
       CLONE: (slug: string) => `/collections/${slug}/clone`,
       LIKE: (slug: string) => `/collections/${slug}/like`,
+      TAGS: (slug: string) => `/collections/${slug}/tags`,
+      TAG: (slug: string, tagId: number) => `/collections/${slug}/tags/${tagId}`,
       MY: '/auth/collections',
     },
   },
@@ -58,6 +60,8 @@ import {
   useUnsubscribeCollection,
   useLikeCollection,
   useUnlikeCollection,
+  useAddCollectionTag,
+  useRemoveCollectionTag,
 } from './index'
 
 
@@ -640,6 +644,115 @@ describe('Collection sort + like hooks', () => {
         like_count: 0,
         user_likes_this: false,
       })
+    })
+  })
+
+  // PSY-354: collection tag mutation hooks.
+  describe('useAddCollectionTag', () => {
+    it('POSTs to /collections/{slug}/tags with tag_name', async () => {
+      mockApiRequest.mockResolvedValueOnce({
+        tags: [
+          {
+            tag_id: 1,
+            name: 'phoenix',
+            slug: 'phoenix',
+            category: 'locale',
+            is_official: false,
+            upvotes: 0,
+            downvotes: 0,
+            wilson_score: 0,
+          },
+        ],
+      })
+
+      const { result } = renderHook(() => useAddCollectionTag(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({ slug: 'my-coll', tag_name: 'phoenix' })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/collections/my-coll/tags',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            tag_id: undefined,
+            tag_name: 'phoenix',
+            category: undefined,
+          }),
+        })
+      )
+    })
+
+    it('POSTs with tag_id when applying an existing tag', async () => {
+      mockApiRequest.mockResolvedValueOnce({ tags: [] })
+      const { result } = renderHook(() => useAddCollectionTag(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({ slug: 'my-coll', tag_id: 42 })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/collections/my-coll/tags',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            tag_id: 42,
+            tag_name: undefined,
+            category: undefined,
+          }),
+        })
+      )
+    })
+  })
+
+  describe('useRemoveCollectionTag', () => {
+    it('DELETEs /collections/{slug}/tags/{tag_id}', async () => {
+      mockApiRequest.mockResolvedValueOnce(undefined)
+      const { result } = renderHook(() => useRemoveCollectionTag(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({ slug: 'my-coll', tagId: 7 })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/collections/my-coll/tags/7',
+        expect.objectContaining({ method: 'DELETE' })
+      )
+    })
+  })
+
+  describe('useCollections — tag filter (PSY-354)', () => {
+    it('passes tag query param when set', async () => {
+      mockApiRequest.mockResolvedValueOnce({ collections: [], total: 0 })
+      const { result } = renderHook(() => useCollections({ tag: 'phoenix' }), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        expect.stringContaining('tag=phoenix')
+      )
+    })
+
+    it('omits tag param when undefined', async () => {
+      mockApiRequest.mockResolvedValueOnce({ collections: [], total: 0 })
+      const { result } = renderHook(() => useCollections({}), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      const calledUrl = mockApiRequest.mock.calls[0][0] as string
+      expect(calledUrl).not.toContain('tag=')
     })
   })
 })

--- a/frontend/features/collections/hooks/index.ts
+++ b/frontend/features/collections/hooks/index.ts
@@ -10,6 +10,7 @@ import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tansta
 import { apiRequest, API_ENDPOINTS } from '@/lib/api'
 import { queryKeys } from '@/lib/queryClient'
 import type {
+  AddCollectionTagResponse,
   Collection,
   CollectionDetail,
   CollectionDisplayMode,
@@ -33,6 +34,11 @@ export interface CollectionListParams {
    * HN gravity (likes / age^1.8). Omit for default (recently-updated).
    */
   sort?: CollectionListSort
+  /**
+   * PSY-354: filter to collections tagged with this slug. Single-tag for
+   * the MVP — multi-tag intersection isn't supported yet on the server.
+   */
+  tag?: string
 }
 
 /** Fetch public collections list with optional filters */
@@ -45,6 +51,7 @@ export function useCollections(params?: CollectionListParams) {
       if (params?.featured) searchParams.set('featured', '1')
       if (params?.entityType) searchParams.set('entity_type', params.entityType)
       if (params?.sort) searchParams.set('sort', params.sort)
+      if (params?.tag) searchParams.set('tag', params.tag)
 
       const qs = searchParams.toString()
       const url = qs
@@ -523,5 +530,69 @@ export function useUserPublicCollections(
       })),
     enabled: (options?.enabled ?? true) && username.length > 0,
     staleTime: 5 * 60 * 1000,
+  })
+}
+
+// ──────────────────────────────────────────────
+// Tags (PSY-354)
+// ──────────────────────────────────────────────
+
+/**
+ * Apply a tag to a collection. Sends `tag_id` (existing tag) OR `tag_name`
+ * (free-form, with alias resolution + inline creation gated by trust tier
+ * server-side). Backend enforces the 10-tag cap and edit-access — the
+ * mutation surfaces the resulting 4xx via the apiRequest error path.
+ *
+ * Invalidates the detail query so the chip row refreshes from the server's
+ * authoritative list (cheap; the response also includes the new list, but
+ * the detail page is the one place where vote counts matter and we'd
+ * rather refetch once than try to reconcile two shapes).
+ */
+export function useAddCollectionTag() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      slug,
+      tag_id,
+      tag_name,
+      category,
+    }: {
+      slug: string
+      tag_id?: number
+      tag_name?: string
+      category?: string
+    }) =>
+      apiRequest<AddCollectionTagResponse>(API_ENDPOINTS.COLLECTIONS.TAGS(slug), {
+        method: 'POST',
+        body: JSON.stringify({ tag_id, tag_name, category }),
+      }),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.collections.detail(variables.slug),
+      })
+      // Browse cards display tag chips too — invalidate the public + my
+      // lists so the next view reflects the new tag.
+      queryClient.invalidateQueries({ queryKey: queryKeys.collections.all })
+    },
+  })
+}
+
+/**
+ * Remove a tag from a collection. Server enforces the same edit-access
+ * gate as Add. Errors surface via apiRequest.
+ */
+export function useRemoveCollectionTag() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ slug, tagId }: { slug: string; tagId: number }) =>
+      apiRequest<void>(API_ENDPOINTS.COLLECTIONS.TAG(slug, tagId), {
+        method: 'DELETE',
+      }),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.collections.detail(variables.slug),
+      })
+      queryClient.invalidateQueries({ queryKey: queryKeys.collections.all })
+    },
   })
 }

--- a/frontend/features/collections/types.ts
+++ b/frontend/features/collections/types.ts
@@ -1,5 +1,7 @@
 // Collection types — aligned with backend contracts/collection.go response types.
 
+import type { EntityTag, TagSummary } from '@/features/tags/types'
+
 /**
  * Maximum length, in characters, for collection description and per-item notes.
  * Mirrors backend `contracts.MaxCollectionDescriptionLength` /
@@ -7,6 +9,14 @@
  * Update both sides together if the comment limit ever changes (PSY-349).
  */
 export const MAX_COLLECTION_MARKDOWN_LENGTH = 10000
+
+/**
+ * PSY-354: hard cap on tags per collection. Mirrors backend
+ * `contracts.MaxCollectionTags`. Used by the picker to disable the
+ * autocomplete + show a "limit reached" message rather than letting the
+ * user submit and get a 400.
+ */
+export const MAX_COLLECTION_TAGS = 10
 
 /**
  * PSY-356: minimum thresholds for a public collection to appear in the
@@ -154,12 +164,20 @@ export interface Collection {
    * the public browse list and the detail endpoint.
    */
   user_likes_this?: boolean
+  /**
+   * PSY-354: tag chips shown on cards. Lightweight TagSummary (no vote
+   * counts, no user_vote) — the detail response carries the richer
+   * EntityTag for the inline picker. Optional in the type so existing
+   * test fixtures don't have to declare it; the server response always
+   * includes the field (empty array when no tags).
+   */
+  tags?: TagSummary[]
   created_at: string
   updated_at: string
 }
 
 /** Full collection detail (returned by GET /collections/{slug}) */
-export interface CollectionDetail extends Collection {
+export interface CollectionDetail extends Omit<Collection, 'tags'> {
   items: CollectionItem[]
   is_subscribed: boolean
   /**
@@ -167,6 +185,23 @@ export interface CollectionDetail extends Collection {
    * collection wasn't forked OR when the source was deleted. PSY-351.
    */
   forked_from?: ForkedFromInfo | null
+  /**
+   * PSY-354: full EntityTag list with vote counts + user_vote so the
+   * detail page can wire the same EntityTagList component the rest of
+   * the entity detail pages use. Optional like Collection.tags so test
+   * fixtures don't need to declare it. Differs from Collection.tags
+   * (TagSummary) — detail uses EntityTag for the inline picker.
+   */
+  tags?: EntityTag[]
+}
+
+/**
+ * PSY-354: response shape for POST /collections/{slug}/tags. Returns the
+ * post-mutation tag list so the chip row can update without a follow-up
+ * GET.
+ */
+export interface AddCollectionTagResponse {
+  tags: EntityTag[]
 }
 
 /**

--- a/frontend/features/tags/types.ts
+++ b/frontend/features/tags/types.ts
@@ -21,7 +21,9 @@ export type TagView = 'grid' | 'cloud'
 export const DEFAULT_TAG_VIEW: TagView = 'grid'
 
 export const TAG_ENTITY_TYPES = [
-  'artist', 'release', 'label', 'show', 'venue', 'festival'
+  // PSY-354: collection joined the polymorphic tag corpus. Order matches
+  // backend `models.TagEntityTypes`.
+  'artist', 'release', 'label', 'show', 'venue', 'festival', 'collection',
 ] as const
 export type TagEntityType = typeof TAG_ENTITY_TYPES[number]
 

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -265,6 +265,11 @@ export const API_ENDPOINTS = {
     // PSY-352: like/unlike toggle. POST creates, DELETE removes; both
     // idempotent and return the post-mutation aggregate.
     LIKE: (slug: string) => `${API_BASE_URL}/collections/${slug}/like`,
+    // PSY-354: collection-level tag management. Same body shape as the
+    // entity-tag endpoints (tag_id OR tag_name + optional category).
+    TAGS: (slug: string) => `${API_BASE_URL}/collections/${slug}/tags`,
+    TAG: (slug: string, tagId: number) =>
+      `${API_BASE_URL}/collections/${slug}/tags/${tagId}`,
     MY: `${API_BASE_URL}/auth/collections`,
     ENTITY: (entityType: string, entityId: number) =>
       `${API_BASE_URL}/collections/entity/${entityType}/${entityId}`,


### PR DESCRIPTION
## Summary
- Reuses the polymorphic `entity_tags` table — adds `TagEntityCollection = "collection"` constant, no migration.
- Hybrid entry: pick existing tag via the existing `/tags/search` autocomplete, or type a new name (created on demand with `category="other"` default).
- 10-tag cap enforced inside the polymorphic `tagService.AddTagToEntity` gated to `entity_type='collection'`, so the legacy polymorphic `EntityTagList` UI is also covered (not only the dedicated wrapper).
- Endpoints: `POST /collections/{slug}/tags` and `DELETE /collections/{slug}/tags/{tag_id}` (also exposed under `/crates/...` legacy alias). Permission mirrors the existing add-item rule (creator OR collaborative-and-authenticated). 11th tag → 400 with `collection_tag_limit_exceeded` code.
- `?tag=<slug>` filter on `GET /collections` browse listing.
- Tags rendered as chips on `CollectionCard` (cap 5 displayed, link to `/collections?tag=<slug>`); `EntityTagList` mounted on `CollectionDetail` for full add/remove + global tag links to `/tags/{slug}`.

## Test plan
- [ ] Backend services suite passes (14 new collection-tag service tests).
- [ ] Backend handlers suite passes (11 new collection-tag handler integration tests).
- [ ] Tag-service suite still passes — cap branch is gated to `entity_type='collection'`, no impact to other types.
- [ ] Frontend tests pass (12 new collection tests for chip rendering, picker auth gating, filter pill, hook POST/DELETE shapes).
- [ ] Manual: add a tag to a collection via detail-page picker; chip appears, link goes to `/tags/<slug>`.
- [ ] Manual: try to add an 11th tag; UI surfaces 400 with `collection_tag_limit_exceeded` message.
- [ ] Manual: card chip on a collection in `/collections` navigates to `/collections?tag=<slug>` with active-filter pill rendered; X clears the filter.
- [ ] Manual: non-collaborator on a collaborative collection → 403 on add/remove.
- [ ] Manual: anonymous viewer sees chips on cards/detail but no add/remove affordance.

Closes PSY-354