### PR TITLE
PSY-423: admin middleware group + route-level enforcement

### DIFF
--- a/backend/internal/api/handlers/admin/admin_data.go
+++ b/backend/internal/api/handlers/admin/admin_data.go
@@ -7,6 +7,7 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 
 	"psychic-homily-backend/internal/api/handlers/shared"
+	"psychic-homily-backend/internal/api/middleware"
 	"psychic-homily-backend/internal/logger"
 	"psychic-homily-backend/internal/services/contracts"
 )
@@ -44,14 +45,10 @@ type ExportShowsResponse struct {
 	Body contracts.ExportShowsResult `json:"body"`
 }
 
-// ExportShowsHandler handles GET /admin/export/shows
+// ExportShowsHandler handles GET /admin/export/shows.
+// PSY-423: admin gating handled by HumaAdminMiddleware on rc.Admin.
 func (h *AdminDataHandler) ExportShowsHandler(ctx context.Context, req *ExportShowsRequest) (*ExportShowsResponse, error) {
 	requestID := logger.GetRequestID(ctx)
-
-	_, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
 
 	offset := req.Offset
 	if offset < 0 {
@@ -113,14 +110,10 @@ type ExportArtistsResponse struct {
 	Body contracts.ExportArtistsResult `json:"body"`
 }
 
-// ExportArtistsHandler handles GET /admin/export/artists
+// ExportArtistsHandler handles GET /admin/export/artists.
+// PSY-423: admin gating handled by HumaAdminMiddleware on rc.Admin.
 func (h *AdminDataHandler) ExportArtistsHandler(ctx context.Context, req *ExportArtistsRequest) (*ExportArtistsResponse, error) {
 	requestID := logger.GetRequestID(ctx)
-
-	_, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
 
 	offset := req.Offset
 	if offset < 0 {
@@ -173,14 +166,10 @@ type ExportVenuesResponse struct {
 	Body contracts.ExportVenuesResult `json:"body"`
 }
 
-// ExportVenuesHandler handles GET /admin/export/venues
+// ExportVenuesHandler handles GET /admin/export/venues.
+// PSY-423: admin gating handled by HumaAdminMiddleware on rc.Admin.
 func (h *AdminDataHandler) ExportVenuesHandler(ctx context.Context, req *ExportVenuesRequest) (*ExportVenuesResponse, error) {
 	requestID := logger.GetRequestID(ctx)
-
-	_, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
 
 	offset := req.Offset
 	if offset < 0 {
@@ -239,14 +228,12 @@ type DataImportResponse struct {
 	Body contracts.DataImportResult `json:"body"`
 }
 
-// DataImportHandler handles POST /admin/data/import
+// DataImportHandler handles POST /admin/data/import.
+// PSY-423: admin gating handled by HumaAdminMiddleware on rc.Admin.
 func (h *AdminDataHandler) DataImportHandler(ctx context.Context, req *DataImportRequest) (*DataImportResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	// Validate limits
 	totalItems := len(req.Body.Shows) + len(req.Body.Artists) + len(req.Body.Venues)

--- a/backend/internal/api/handlers/admin/admin_shows.go
+++ b/backend/internal/api/handlers/admin/admin_shows.go
@@ -9,6 +9,7 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 
 	"psychic-homily-backend/internal/api/handlers/shared"
+	"psychic-homily-backend/internal/api/middleware"
 	"psychic-homily-backend/internal/logger"
 	catalogm "psychic-homily-backend/internal/models/catalog"
 	"psychic-homily-backend/internal/services/contracts"
@@ -139,11 +140,6 @@ type BatchRejectShowsResponse struct {
 func (h *AdminShowHandler) GetPendingShowsHandler(ctx context.Context, req *GetPendingShowsRequest) (*GetPendingShowsResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	_, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	// Validate limit
 	limit := req.Limit
 	if limit < 1 {
@@ -218,11 +214,6 @@ func (h *AdminShowHandler) GetPendingShowsHandler(ctx context.Context, req *GetP
 func (h *AdminShowHandler) GetRejectedShowsHandler(ctx context.Context, req *GetRejectedShowsRequest) (*GetRejectedShowsResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	_, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	// Validate limit
 	limit := req.Limit
 	if limit < 1 {
@@ -275,10 +266,7 @@ func (h *AdminShowHandler) GetRejectedShowsHandler(ctx context.Context, req *Get
 func (h *AdminShowHandler) ApproveShowHandler(ctx context.Context, req *ApproveShowRequest) (*ApproveShowResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	// Parse show ID
 	showID, err := strconv.ParseUint(req.ShowID, 10, 32)
@@ -346,10 +334,7 @@ func (h *AdminShowHandler) ApproveShowHandler(ctx context.Context, req *ApproveS
 func (h *AdminShowHandler) RejectShowHandler(ctx context.Context, req *RejectShowRequest) (*RejectShowResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	// Parse show ID
 	showID, err := strconv.ParseUint(req.ShowID, 10, 32)
@@ -399,10 +384,7 @@ func (h *AdminShowHandler) RejectShowHandler(ctx context.Context, req *RejectSho
 
 // BatchApproveShowsHandler handles POST /admin/shows/batch-approve
 func (h *AdminShowHandler) BatchApproveShowsHandler(ctx context.Context, req *BatchApproveShowsRequest) (*BatchApproveShowsResponse, error) {
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	result, err := h.showAdminService.BatchApproveShows(req.Body.ShowIDs)
 	if err != nil {
@@ -460,10 +442,7 @@ func (h *AdminShowHandler) BatchApproveShowsHandler(ctx context.Context, req *Ba
 
 // BatchRejectShowsHandler handles POST /admin/shows/batch-reject
 func (h *AdminShowHandler) BatchRejectShowsHandler(ctx context.Context, req *BatchRejectShowsRequest) (*BatchRejectShowsResponse, error) {
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	// Validate reason
 	if req.Body.Reason == "" {
@@ -522,10 +501,7 @@ type ImportShowPreviewResponse struct {
 func (h *AdminShowHandler) ImportShowPreviewHandler(ctx context.Context, req *ImportShowPreviewRequest) (*ImportShowPreviewResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	// Decode base64 content
 	content, err := base64.StdEncoding.DecodeString(req.Body.Content)
@@ -581,10 +557,7 @@ type ImportShowConfirmResponse struct {
 func (h *AdminShowHandler) ImportShowConfirmHandler(ctx context.Context, req *ImportShowConfirmRequest) (*ImportShowConfirmResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	// Decode base64 content
 	content, err := base64.StdEncoding.DecodeString(req.Body.Content)
@@ -659,11 +632,6 @@ type GetAdminShowsResponse struct {
 // Returns paginated show list with full details for admin export purposes
 func (h *AdminShowHandler) GetAdminShowsHandler(ctx context.Context, req *GetAdminShowsRequest) (*GetAdminShowsResponse, error) {
 	requestID := logger.GetRequestID(ctx)
-
-	_, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
 
 	// Validate limit
 	limit := req.Limit
@@ -743,10 +711,7 @@ type BulkExportShowsResponse struct {
 func (h *AdminShowHandler) BulkExportShowsHandler(ctx context.Context, req *BulkExportShowsRequest) (*BulkExportShowsResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	if len(req.Body.ShowIDs) == 0 {
 		return nil, huma.Error400BadRequest("At least one show ID is required")
@@ -824,10 +789,7 @@ type BulkImportPreviewResponse struct {
 func (h *AdminShowHandler) BulkImportPreviewHandler(ctx context.Context, req *BulkImportPreviewRequest) (*BulkImportPreviewResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	if len(req.Body.Shows) == 0 {
 		return nil, huma.Error400BadRequest("At least one show is required")
@@ -941,10 +903,7 @@ type BulkImportConfirmResponse struct {
 func (h *AdminShowHandler) BulkImportConfirmHandler(ctx context.Context, req *BulkImportConfirmRequest) (*BulkImportConfirmResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	if len(req.Body.Shows) == 0 {
 		return nil, huma.Error400BadRequest("At least one show is required")

--- a/backend/internal/api/handlers/admin/admin_stats.go
+++ b/backend/internal/api/handlers/admin/admin_stats.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 
-	"psychic-homily-backend/internal/api/handlers/shared"
+	"psychic-homily-backend/internal/api/middleware"
 	"psychic-homily-backend/internal/logger"
 	"psychic-homily-backend/internal/services/contracts"
 )
@@ -37,10 +37,7 @@ type GetAdminStatsResponse struct {
 func (h *AdminStatsHandler) GetAdminStatsHandler(ctx context.Context, req *GetAdminStatsRequest) (*GetAdminStatsResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	logger.FromContext(ctx).Debug("admin_stats_attempt",
 		"admin_id", user.ID,
@@ -76,10 +73,7 @@ type GetActivityFeedResponse struct {
 func (h *AdminStatsHandler) GetActivityFeedHandler(ctx context.Context, req *GetActivityFeedRequest) (*GetActivityFeedResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	logger.FromContext(ctx).Debug("admin_activity_feed_attempt",
 		"admin_id", user.ID,

--- a/backend/internal/api/handlers/admin/admin_test.go
+++ b/backend/internal/api/handlers/admin/admin_test.go
@@ -51,137 +51,23 @@ func adminCtx() context.Context {
 }
 
 // ============================================================================
-// Admin Guard: all handlers require admin access
-// Tests both nil-user and non-admin user scenarios for every admin handler.
+// Admin Guard moved to middleware (PSY-423)
+//
+// Previously: each admin handler called shared.RequireAdmin(ctx) and a sweep
+// test (TestAdminHandler_RequiresAdmin) here verified that nil-user / non-admin
+// callers got 403. The gate now lives in middleware.HumaAdminMiddleware on the
+// rc.Admin Huma group; handlers no longer enforce admin internally.
+//
+// The middleware-level gate is covered by:
+//   - middleware.TestHumaAdminMiddleware* (unit tests of the middleware)
+//   - routes.TestAdminGroup_NonAdmin_Returns403 (integration: a non-admin
+//     request to a route registered on rc.Admin returns 403 without entering
+//     the handler)
+//
+// Calling these handlers directly with nil/non-admin context is no longer a
+// supported usage — the tests above guarantee real callers cannot reach the
+// handler without the gate firing.
 // ============================================================================
-
-func TestAdminHandler_RequiresAdmin(t *testing.T) {
-	showH := testAdminShowHandler()
-	venueH := testAdminVenueHandler()
-	tokenH := testAdminTokenHandler()
-	dataH := testAdminDataHandler()
-	userH := testAdminUserHandler()
-	statsH := testAdminStatsHandler()
-	discoveryH := testAdminDiscoveryHandler()
-
-	tests := []struct {
-		name string
-		fn   func(ctx context.Context) error
-	}{
-		{"GetPendingShows", func(ctx context.Context) error {
-			_, err := showH.GetPendingShowsHandler(ctx, &GetPendingShowsRequest{})
-			return err
-		}},
-		{"GetRejectedShows", func(ctx context.Context) error {
-			_, err := showH.GetRejectedShowsHandler(ctx, &GetRejectedShowsRequest{})
-			return err
-		}},
-		{"ApproveShow", func(ctx context.Context) error {
-			_, err := showH.ApproveShowHandler(ctx, &ApproveShowRequest{})
-			return err
-		}},
-		{"RejectShow", func(ctx context.Context) error {
-			_, err := showH.RejectShowHandler(ctx, &RejectShowRequest{})
-			return err
-		}},
-		{"VerifyVenue", func(ctx context.Context) error {
-			_, err := venueH.VerifyVenueHandler(ctx, &VerifyVenueRequest{})
-			return err
-		}},
-		{"GetUnverifiedVenues", func(ctx context.Context) error {
-			_, err := venueH.GetUnverifiedVenuesHandler(ctx, &GetUnverifiedVenuesRequest{})
-			return err
-		}},
-		{"ImportShowPreview", func(ctx context.Context) error {
-			_, err := showH.ImportShowPreviewHandler(ctx, &ImportShowPreviewRequest{})
-			return err
-		}},
-		{"ImportShowConfirm", func(ctx context.Context) error {
-			_, err := showH.ImportShowConfirmHandler(ctx, &ImportShowConfirmRequest{})
-			return err
-		}},
-		{"GetAdminShows", func(ctx context.Context) error {
-			_, err := showH.GetAdminShowsHandler(ctx, &GetAdminShowsRequest{})
-			return err
-		}},
-		{"BulkExportShows", func(ctx context.Context) error {
-			_, err := showH.BulkExportShowsHandler(ctx, &BulkExportShowsRequest{})
-			return err
-		}},
-		{"BulkImportPreview", func(ctx context.Context) error {
-			_, err := showH.BulkImportPreviewHandler(ctx, &BulkImportPreviewRequest{})
-			return err
-		}},
-		{"BulkImportConfirm", func(ctx context.Context) error {
-			_, err := showH.BulkImportConfirmHandler(ctx, &BulkImportConfirmRequest{})
-			return err
-		}},
-		{"DiscoveryImport", func(ctx context.Context) error {
-			_, err := discoveryH.DiscoveryImportHandler(ctx, &pipeline.DiscoveryImportRequest{})
-			return err
-		}},
-		{"DiscoveryCheck", func(ctx context.Context) error {
-			_, err := discoveryH.DiscoveryCheckHandler(ctx, &pipeline.DiscoveryCheckRequest{})
-			return err
-		}},
-		{"CreateAPIToken", func(ctx context.Context) error {
-			_, err := tokenH.CreateAPITokenHandler(ctx, &CreateAPITokenRequest{})
-			return err
-		}},
-		{"ListAPITokens", func(ctx context.Context) error {
-			_, err := tokenH.ListAPITokensHandler(ctx, &ListAPITokensRequest{})
-			return err
-		}},
-		{"RevokeAPIToken", func(ctx context.Context) error {
-			_, err := tokenH.RevokeAPITokenHandler(ctx, &RevokeAPITokenRequest{})
-			return err
-		}},
-		{"ExportShows", func(ctx context.Context) error {
-			_, err := dataH.ExportShowsHandler(ctx, &ExportShowsRequest{})
-			return err
-		}},
-		{"ExportArtists", func(ctx context.Context) error {
-			_, err := dataH.ExportArtistsHandler(ctx, &ExportArtistsRequest{})
-			return err
-		}},
-		{"ExportVenues", func(ctx context.Context) error {
-			_, err := dataH.ExportVenuesHandler(ctx, &ExportVenuesRequest{})
-			return err
-		}},
-		{"DataImport", func(ctx context.Context) error {
-			_, err := dataH.DataImportHandler(ctx, &DataImportRequest{})
-			return err
-		}},
-		{"GetAdminUsers", func(ctx context.Context) error {
-			_, err := userH.GetAdminUsersHandler(ctx, &GetAdminUsersRequest{})
-			return err
-		}},
-		{"GetAdminStats", func(ctx context.Context) error {
-			_, err := statsH.GetAdminStatsHandler(ctx, &GetAdminStatsRequest{})
-			return err
-		}},
-		{"BatchApproveShows", func(ctx context.Context) error {
-			_, err := showH.BatchApproveShowsHandler(ctx, &BatchApproveShowsRequest{})
-			return err
-		}},
-		{"BatchRejectShows", func(ctx context.Context) error {
-			_, err := showH.BatchRejectShowsHandler(ctx, &BatchRejectShowsRequest{})
-			return err
-		}},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name+"_NoUser", func(t *testing.T) {
-			err := tc.fn(context.Background())
-			testhelpers.AssertHumaError(t, err, 403)
-		})
-		t.Run(tc.name+"_NonAdmin", func(t *testing.T) {
-			ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: false})
-			err := tc.fn(ctx)
-			testhelpers.AssertHumaError(t, err, 403)
-		})
-	}
-}
 
 // ============================================================================
 // Specific validation tests (require admin context to pass the guard)
@@ -1248,21 +1134,6 @@ func TestBatchApproveShowsHandler_Success(t *testing.T) {
 	}
 }
 
-func TestBatchApproveShowsHandler_AdminRequired(t *testing.T) {
-	h := testAdminShowHandler()
-	req := &BatchApproveShowsRequest{}
-	req.Body.ShowIDs = []uint{1}
-
-	// No user context
-	_, err := h.BatchApproveShowsHandler(context.Background(), req)
-	testhelpers.AssertHumaError(t, err, 403)
-
-	// Non-admin user
-	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: false})
-	_, err = h.BatchApproveShowsHandler(ctx, req)
-	testhelpers.AssertHumaError(t, err, 403)
-}
-
 func TestBatchRejectShowsHandler_Success(t *testing.T) {
 	h := adminShowHandler(func(ah *AdminShowHandler) {
 		ah.showAdminService = &testhelpers.MockShowAdminService{
@@ -1301,22 +1172,6 @@ func TestBatchRejectShowsHandler_Success(t *testing.T) {
 	if len(resp.Body.Errors) != 0 {
 		t.Errorf("expected 0 errors, got %d", len(resp.Body.Errors))
 	}
-}
-
-func TestBatchRejectShowsHandler_AdminRequired(t *testing.T) {
-	h := testAdminShowHandler()
-	req := &BatchRejectShowsRequest{}
-	req.Body.ShowIDs = []uint{1}
-	req.Body.Reason = "bad data"
-
-	// No user context
-	_, err := h.BatchRejectShowsHandler(context.Background(), req)
-	testhelpers.AssertHumaError(t, err, 403)
-
-	// Non-admin user
-	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: false})
-	_, err = h.BatchRejectShowsHandler(ctx, req)
-	testhelpers.AssertHumaError(t, err, 403)
 }
 
 func TestBatchRejectShowsHandler_RequiresReason(t *testing.T) {

--- a/backend/internal/api/handlers/admin/admin_tokens.go
+++ b/backend/internal/api/handlers/admin/admin_tokens.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 
-	"psychic-homily-backend/internal/api/handlers/shared"
+	"psychic-homily-backend/internal/api/middleware"
 	"psychic-homily-backend/internal/logger"
 	"psychic-homily-backend/internal/services/contracts"
 )
@@ -43,10 +43,7 @@ type CreateAPITokenResponse struct {
 func (h *AdminTokenHandler) CreateAPITokenHandler(ctx context.Context, req *CreateAPITokenRequest) (*CreateAPITokenResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	// Validate expiration days
 	expirationDays := req.Body.ExpirationDays
@@ -104,10 +101,7 @@ type ListAPITokensResponse struct {
 func (h *AdminTokenHandler) ListAPITokensHandler(ctx context.Context, req *ListAPITokensRequest) (*ListAPITokensResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	logger.FromContext(ctx).Debug("admin_list_tokens_attempt",
 		"admin_id", user.ID,
@@ -154,10 +148,7 @@ type RevokeAPITokenResponse struct {
 func (h *AdminTokenHandler) RevokeAPITokenHandler(ctx context.Context, req *RevokeAPITokenRequest) (*RevokeAPITokenResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	// Parse token ID
 	tokenID, err := strconv.ParseUint(req.TokenID, 10, 32)

--- a/backend/internal/api/handlers/admin/admin_users.go
+++ b/backend/internal/api/handlers/admin/admin_users.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 
-	"psychic-homily-backend/internal/api/handlers/shared"
 	"psychic-homily-backend/internal/logger"
 	"psychic-homily-backend/internal/services/contracts"
 )
@@ -43,11 +42,6 @@ type GetAdminUsersResponse struct {
 // GetAdminUsersHandler handles GET /admin/users
 func (h *AdminUserHandler) GetAdminUsersHandler(ctx context.Context, req *GetAdminUsersRequest) (*GetAdminUsersResponse, error) {
 	requestID := logger.GetRequestID(ctx)
-
-	_, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
 
 	// Validate limit
 	limit := req.Limit

--- a/backend/internal/api/handlers/admin/admin_venues.go
+++ b/backend/internal/api/handlers/admin/admin_venues.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 
-	"psychic-homily-backend/internal/api/handlers/shared"
+	"psychic-homily-backend/internal/api/middleware"
 	"psychic-homily-backend/internal/logger"
 	"psychic-homily-backend/internal/services/contracts"
 )
@@ -57,10 +57,7 @@ type GetUnverifiedVenuesResponse struct {
 func (h *AdminVenueHandler) VerifyVenueHandler(ctx context.Context, req *VerifyVenueRequest) (*VerifyVenueResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	// Parse venue ID
 	venueID, err := strconv.ParseUint(req.VenueID, 10, 32)
@@ -102,11 +99,6 @@ func (h *AdminVenueHandler) VerifyVenueHandler(ctx context.Context, req *VerifyV
 // Returns venues that have not been verified by an admin, for admin review.
 func (h *AdminVenueHandler) GetUnverifiedVenuesHandler(ctx context.Context, req *GetUnverifiedVenuesRequest) (*GetUnverifiedVenuesResponse, error) {
 	requestID := logger.GetRequestID(ctx)
-
-	_, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
 
 	// Validate limit
 	limit := req.Limit

--- a/backend/internal/api/handlers/admin/analytics.go
+++ b/backend/internal/api/handlers/admin/analytics.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 
-	"psychic-homily-backend/internal/api/handlers/shared"
 	"psychic-homily-backend/internal/logger"
 	"psychic-homily-backend/internal/services/contracts"
 )
@@ -51,10 +50,6 @@ type GetGrowthMetricsResponse struct {
 
 // GetGrowthMetricsHandler handles GET /admin/analytics/growth
 func (h *AnalyticsHandler) GetGrowthMetricsHandler(ctx context.Context, req *GetGrowthMetricsRequest) (*GetGrowthMetricsResponse, error) {
-	_, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
 
 	months := req.Months
 	if months <= 0 {
@@ -107,10 +102,6 @@ type GetEngagementMetricsResponse struct {
 
 // GetEngagementMetricsHandler handles GET /admin/analytics/engagement
 func (h *AnalyticsHandler) GetEngagementMetricsHandler(ctx context.Context, req *GetEngagementMetricsRequest) (*GetEngagementMetricsResponse, error) {
-	_, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
 
 	months := req.Months
 	if months <= 0 {
@@ -168,10 +159,6 @@ type GetCommunityHealthResponse struct {
 
 // GetCommunityHealthHandler handles GET /admin/analytics/community
 func (h *AnalyticsHandler) GetCommunityHealthHandler(ctx context.Context, _ *GetCommunityHealthRequest) (*GetCommunityHealthResponse, error) {
-	_, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
 
 	data, err := h.analyticsService.GetCommunityHealth()
 	if err != nil {
@@ -226,10 +213,6 @@ type GetDataQualityTrendsResponse struct {
 
 // GetDataQualityTrendsHandler handles GET /admin/analytics/data-quality
 func (h *AnalyticsHandler) GetDataQualityTrendsHandler(ctx context.Context, req *GetDataQualityTrendsRequest) (*GetDataQualityTrendsResponse, error) {
-	_, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
 
 	months := req.Months
 	if months <= 0 {

--- a/backend/internal/api/handlers/admin/analytics_test.go
+++ b/backend/internal/api/handlers/admin/analytics_test.go
@@ -30,69 +30,17 @@ func analyticsNonAdminCtx() context.Context {
 // Tests: Admin Guard - Growth
 // ============================================================================
 
-func TestAnalyticsHandler_Growth_RequiresAdmin(t *testing.T) {
-	h := testAnalyticsHandler()
-
-	t.Run("NoUser", func(t *testing.T) {
-		_, err := h.GetGrowthMetricsHandler(context.Background(), &GetGrowthMetricsRequest{})
-		testhelpers.AssertHumaError(t, err, 403)
-	})
-	t.Run("NonAdmin", func(t *testing.T) {
-		_, err := h.GetGrowthMetricsHandler(analyticsNonAdminCtx(), &GetGrowthMetricsRequest{})
-		testhelpers.AssertHumaError(t, err, 403)
-	})
-}
-
 // ============================================================================
 // Tests: Admin Guard - Engagement
 // ============================================================================
-
-func TestAnalyticsHandler_Engagement_RequiresAdmin(t *testing.T) {
-	h := testAnalyticsHandler()
-
-	t.Run("NoUser", func(t *testing.T) {
-		_, err := h.GetEngagementMetricsHandler(context.Background(), &GetEngagementMetricsRequest{})
-		testhelpers.AssertHumaError(t, err, 403)
-	})
-	t.Run("NonAdmin", func(t *testing.T) {
-		_, err := h.GetEngagementMetricsHandler(analyticsNonAdminCtx(), &GetEngagementMetricsRequest{})
-		testhelpers.AssertHumaError(t, err, 403)
-	})
-}
 
 // ============================================================================
 // Tests: Admin Guard - Community
 // ============================================================================
 
-func TestAnalyticsHandler_Community_RequiresAdmin(t *testing.T) {
-	h := testAnalyticsHandler()
-
-	t.Run("NoUser", func(t *testing.T) {
-		_, err := h.GetCommunityHealthHandler(context.Background(), &GetCommunityHealthRequest{})
-		testhelpers.AssertHumaError(t, err, 403)
-	})
-	t.Run("NonAdmin", func(t *testing.T) {
-		_, err := h.GetCommunityHealthHandler(analyticsNonAdminCtx(), &GetCommunityHealthRequest{})
-		testhelpers.AssertHumaError(t, err, 403)
-	})
-}
-
 // ============================================================================
 // Tests: Admin Guard - Data Quality Trends
 // ============================================================================
-
-func TestAnalyticsHandler_DataQuality_RequiresAdmin(t *testing.T) {
-	h := testAnalyticsHandler()
-
-	t.Run("NoUser", func(t *testing.T) {
-		_, err := h.GetDataQualityTrendsHandler(context.Background(), &GetDataQualityTrendsRequest{})
-		testhelpers.AssertHumaError(t, err, 403)
-	})
-	t.Run("NonAdmin", func(t *testing.T) {
-		_, err := h.GetDataQualityTrendsHandler(analyticsNonAdminCtx(), &GetDataQualityTrendsRequest{})
-		testhelpers.AssertHumaError(t, err, 403)
-	})
-}
 
 // ============================================================================
 // Tests: GetGrowthMetricsHandler

--- a/backend/internal/api/handlers/admin/audit_log.go
+++ b/backend/internal/api/handlers/admin/audit_log.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 
-	"psychic-homily-backend/internal/api/handlers/shared"
 	"psychic-homily-backend/internal/logger"
 	"psychic-homily-backend/internal/services/contracts"
 )
@@ -42,11 +41,6 @@ type GetAuditLogsResponse struct {
 // GetAuditLogsHandler handles GET /admin/audit-logs
 func (h *AuditLogHandler) GetAuditLogsHandler(ctx context.Context, req *GetAuditLogsRequest) (*GetAuditLogsResponse, error) {
 	requestID := logger.GetRequestID(ctx)
-
-	_, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
 
 	// Validate limit
 	limit := req.Limit

--- a/backend/internal/api/handlers/admin/audit_log_test.go
+++ b/backend/internal/api/handlers/admin/audit_log_test.go
@@ -1,7 +1,6 @@
 package admin
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -15,23 +14,6 @@ func testAuditLogHandler() *AuditLogHandler {
 }
 
 // --- GetAuditLogsHandler ---
-
-func TestGetAuditLogsHandler_NoAuth(t *testing.T) {
-	h := testAuditLogHandler()
-	req := &GetAuditLogsRequest{}
-
-	_, err := h.GetAuditLogsHandler(context.Background(), req)
-	testhelpers.AssertHumaError(t, err, 403)
-}
-
-func TestGetAuditLogsHandler_NonAdmin(t *testing.T) {
-	h := testAuditLogHandler()
-	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: false})
-	req := &GetAuditLogsRequest{}
-
-	_, err := h.GetAuditLogsHandler(ctx, req)
-	testhelpers.AssertHumaError(t, err, 403)
-}
 
 func TestGetAuditLogsHandler_Success(t *testing.T) {
 	logs := []*contracts.AuditLogResponse{{ID: 1, Action: "approve_show"}}

--- a/backend/internal/api/handlers/admin/auto_promotion.go
+++ b/backend/internal/api/handlers/admin/auto_promotion.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 
-	"psychic-homily-backend/internal/api/handlers/shared"
+	"psychic-homily-backend/internal/api/middleware"
 	"psychic-homily-backend/internal/logger"
 	"psychic-homily-backend/internal/services/contracts"
 )
@@ -37,10 +37,7 @@ type EvaluateAllUsersResponse struct {
 func (h *AutoPromotionHandler) EvaluateAllUsersHandler(ctx context.Context, req *EvaluateAllUsersRequest) (*EvaluateAllUsersResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	logger.FromContext(ctx).Info("auto_promotion_evaluate_attempt",
 		"admin_id", user.ID,
@@ -82,10 +79,7 @@ type EvaluateUserResponse struct {
 func (h *AutoPromotionHandler) EvaluateUserHandler(ctx context.Context, req *EvaluateUserRequest) (*EvaluateUserResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	logger.FromContext(ctx).Info("auto_promotion_evaluate_user_attempt",
 		"admin_id", user.ID,

--- a/backend/internal/api/handlers/admin/data_quality.go
+++ b/backend/internal/api/handlers/admin/data_quality.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 
-	"psychic-homily-backend/internal/api/handlers/shared"
 	"psychic-homily-backend/internal/logger"
 	"psychic-homily-backend/internal/services/contracts"
 )
@@ -48,10 +47,6 @@ type DataQualityCategoryResponse struct {
 
 // GetDataQualitySummaryHandler handles GET /admin/data-quality
 func (h *DataQualityHandler) GetDataQualitySummaryHandler(ctx context.Context, _ *GetDataQualitySummaryRequest) (*GetDataQualitySummaryResponse, error) {
-	_, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
 
 	summary, err := h.dataQualityService.GetSummary()
 	if err != nil {
@@ -106,10 +101,6 @@ type GetDataQualityCategoryResponse struct {
 
 // GetDataQualityCategoryHandler handles GET /admin/data-quality/{category}
 func (h *DataQualityHandler) GetDataQualityCategoryHandler(ctx context.Context, req *GetDataQualityCategoryRequest) (*GetDataQualityCategoryResponse, error) {
-	_, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
 
 	limit := req.Limit
 	if limit <= 0 {

--- a/backend/internal/api/handlers/admin/data_quality_test.go
+++ b/backend/internal/api/handlers/admin/data_quality_test.go
@@ -30,32 +30,6 @@ func dataQualityNonAdminCtx() context.Context {
 // Tests: Admin Guard
 // ============================================================================
 
-func TestDataQualityHandler_Summary_RequiresAdmin(t *testing.T) {
-	h := testDataQualityHandler()
-
-	t.Run("NoUser", func(t *testing.T) {
-		_, err := h.GetDataQualitySummaryHandler(context.Background(), &GetDataQualitySummaryRequest{})
-		testhelpers.AssertHumaError(t, err, 403)
-	})
-	t.Run("NonAdmin", func(t *testing.T) {
-		_, err := h.GetDataQualitySummaryHandler(dataQualityNonAdminCtx(), &GetDataQualitySummaryRequest{})
-		testhelpers.AssertHumaError(t, err, 403)
-	})
-}
-
-func TestDataQualityHandler_Category_RequiresAdmin(t *testing.T) {
-	h := testDataQualityHandler()
-
-	t.Run("NoUser", func(t *testing.T) {
-		_, err := h.GetDataQualityCategoryHandler(context.Background(), &GetDataQualityCategoryRequest{Category: "artists_missing_links"})
-		testhelpers.AssertHumaError(t, err, 403)
-	})
-	t.Run("NonAdmin", func(t *testing.T) {
-		_, err := h.GetDataQualityCategoryHandler(dataQualityNonAdminCtx(), &GetDataQualityCategoryRequest{Category: "artists_missing_links"})
-		testhelpers.AssertHumaError(t, err, 403)
-	})
-}
-
 // ============================================================================
 // Tests: GetDataQualitySummaryHandler
 // ============================================================================

--- a/backend/internal/api/handlers/admin/pending_edit.go
+++ b/backend/internal/api/handlers/admin/pending_edit.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 
-	"psychic-homily-backend/internal/api/handlers/shared"
 	"psychic-homily-backend/internal/api/middleware"
 	"psychic-homily-backend/internal/logger"
 	adminm "psychic-homily-backend/internal/models/admin"
@@ -328,9 +327,6 @@ type AdminListPendingEditsResponse struct {
 
 // AdminListPendingEditsHandler handles GET /admin/pending-edits
 func (h *PendingEditHandler) AdminListPendingEditsHandler(ctx context.Context, req *AdminListPendingEditsRequest) (*AdminListPendingEditsResponse, error) {
-	if _, err := shared.RequireAdmin(ctx); err != nil {
-		return nil, err
-	}
 
 	edits, total, err := h.pendingEditService.ListPendingEdits(&contracts.PendingEditFilters{
 		Status:     req.Status,
@@ -363,9 +359,6 @@ type AdminGetPendingEditResponse struct {
 
 // AdminGetPendingEditHandler handles GET /admin/pending-edits/{edit_id}
 func (h *PendingEditHandler) AdminGetPendingEditHandler(ctx context.Context, req *AdminGetPendingEditRequest) (*AdminGetPendingEditResponse, error) {
-	if _, err := shared.RequireAdmin(ctx); err != nil {
-		return nil, err
-	}
 
 	editID, err := strconv.ParseUint(req.EditID, 10, 64)
 	if err != nil {
@@ -398,10 +391,7 @@ type AdminApprovePendingEditResponse struct {
 
 // AdminApprovePendingEditHandler handles POST /admin/pending-edits/{edit_id}/approve
 func (h *PendingEditHandler) AdminApprovePendingEditHandler(ctx context.Context, req *AdminApprovePendingEditRequest) (*AdminApprovePendingEditResponse, error) {
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	editID, err := strconv.ParseUint(req.EditID, 10, 64)
 	if err != nil {
@@ -462,10 +452,7 @@ type AdminRejectPendingEditResponse struct {
 
 // AdminRejectPendingEditHandler handles POST /admin/pending-edits/{edit_id}/reject
 func (h *PendingEditHandler) AdminRejectPendingEditHandler(ctx context.Context, req *AdminRejectPendingEditRequest) (*AdminRejectPendingEditResponse, error) {
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	editID, err := strconv.ParseUint(req.EditID, 10, 64)
 	if err != nil {
@@ -528,9 +515,6 @@ type AdminGetEntityPendingEditsResponse struct {
 
 // AdminGetEntityPendingEditsHandler handles GET /admin/pending-edits/entity/{entity_type}/{entity_id}
 func (h *PendingEditHandler) AdminGetEntityPendingEditsHandler(ctx context.Context, req *AdminGetEntityPendingEditsRequest) (*AdminGetEntityPendingEditsResponse, error) {
-	if _, err := shared.RequireAdmin(ctx); err != nil {
-		return nil, err
-	}
 
 	if !adminm.IsValidPendingEditEntityType(req.EntityType) {
 		return nil, huma.Error400BadRequest(fmt.Sprintf("Invalid entity type: %s", req.EntityType))

--- a/backend/internal/api/handlers/admin/pending_edit_test.go
+++ b/backend/internal/api/handlers/admin/pending_edit_test.go
@@ -431,19 +431,6 @@ func TestCancelMyPendingEdit_WrongUser(t *testing.T) {
 // Tests: Admin — List Pending Edits
 // ============================================================================
 
-func TestAdminListPendingEdits_RequiresAdmin(t *testing.T) {
-	h := testPendingEditHandler()
-
-	t.Run("NoUser", func(t *testing.T) {
-		_, err := h.AdminListPendingEditsHandler(context.Background(), &AdminListPendingEditsRequest{})
-		testhelpers.AssertHumaError(t, err, 403)
-	})
-	t.Run("NonAdmin", func(t *testing.T) {
-		_, err := h.AdminListPendingEditsHandler(pendingEditNewUserCtx(), &AdminListPendingEditsRequest{})
-		testhelpers.AssertHumaError(t, err, 403)
-	})
-}
-
 func TestAdminListPendingEdits_Success(t *testing.T) {
 	edits := []contracts.PendingEditResponse{*makePendingEditResponse(1)}
 	h := NewPendingEditHandler(
@@ -472,12 +459,6 @@ func TestAdminListPendingEdits_Success(t *testing.T) {
 // ============================================================================
 // Tests: Admin — Get Pending Edit
 // ============================================================================
-
-func TestAdminGetPendingEdit_RequiresAdmin(t *testing.T) {
-	h := testPendingEditHandler()
-	_, err := h.AdminGetPendingEditHandler(pendingEditNewUserCtx(), &AdminGetPendingEditRequest{EditID: "1"})
-	testhelpers.AssertHumaError(t, err, 403)
-}
 
 func TestAdminGetPendingEdit_NotFound(t *testing.T) {
 	h := NewPendingEditHandler(
@@ -519,12 +500,6 @@ func TestAdminGetPendingEdit_Success(t *testing.T) {
 // ============================================================================
 // Tests: Admin — Approve
 // ============================================================================
-
-func TestAdminApprove_RequiresAdmin(t *testing.T) {
-	h := testPendingEditHandler()
-	_, err := h.AdminApprovePendingEditHandler(pendingEditNewUserCtx(), &AdminApprovePendingEditRequest{EditID: "1"})
-	testhelpers.AssertHumaError(t, err, 403)
-}
 
 func TestAdminApprove_Success(t *testing.T) {
 	approved := makePendingEditResponse(1)
@@ -584,14 +559,6 @@ func TestAdminApprove_AlreadyReviewed(t *testing.T) {
 // ============================================================================
 // Tests: Admin — Reject
 // ============================================================================
-
-func TestAdminReject_RequiresAdmin(t *testing.T) {
-	h := testPendingEditHandler()
-	req := &AdminRejectPendingEditRequest{EditID: "1"}
-	req.Body.Reason = "bad"
-	_, err := h.AdminRejectPendingEditHandler(pendingEditNewUserCtx(), req)
-	testhelpers.AssertHumaError(t, err, 403)
-}
 
 func TestAdminReject_EmptyReason(t *testing.T) {
 	h := testPendingEditHandler()
@@ -653,14 +620,6 @@ func TestAdminReject_NotFound(t *testing.T) {
 // ============================================================================
 // Tests: Admin — Get Entity Pending Edits
 // ============================================================================
-
-func TestAdminGetEntityPendingEdits_RequiresAdmin(t *testing.T) {
-	h := testPendingEditHandler()
-	_, err := h.AdminGetEntityPendingEditsHandler(pendingEditNewUserCtx(), &AdminGetEntityPendingEditsRequest{
-		EntityType: "artist", EntityID: "1",
-	})
-	testhelpers.AssertHumaError(t, err, 403)
-}
 
 func TestAdminGetEntityPendingEdits_InvalidEntityType(t *testing.T) {
 	h := testPendingEditHandler()

--- a/backend/internal/api/handlers/admin/revision.go
+++ b/backend/internal/api/handlers/admin/revision.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 
-	"psychic-homily-backend/internal/api/handlers/shared"
+	"psychic-homily-backend/internal/api/middleware"
 	"psychic-homily-backend/internal/logger"
 	adminm "psychic-homily-backend/internal/models/admin"
 	"psychic-homily-backend/internal/services/contracts"
@@ -246,10 +246,7 @@ type RollbackRevisionResponse struct {
 
 // RollbackRevisionHandler handles POST /admin/revisions/{revision_id}/rollback
 func (h *RevisionHandler) RollbackRevisionHandler(ctx context.Context, req *RollbackRevisionRequest) (*RollbackRevisionResponse, error) {
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	revisionID, err := strconv.ParseUint(req.RevisionID, 10, 64)
 	if err != nil {

--- a/backend/internal/api/handlers/admin/revision_test.go
+++ b/backend/internal/api/handlers/admin/revision_test.go
@@ -56,19 +56,6 @@ func makeTestRevision(id uint) adminm.Revision {
 // Tests: Admin Guard (Rollback only)
 // ============================================================================
 
-func TestRevisionHandler_Rollback_RequiresAdmin(t *testing.T) {
-	h := testRevisionHandler()
-
-	t.Run("NoUser", func(t *testing.T) {
-		_, err := h.RollbackRevisionHandler(context.Background(), &RollbackRevisionRequest{RevisionID: "1"})
-		testhelpers.AssertHumaError(t, err, 403)
-	})
-	t.Run("NonAdmin", func(t *testing.T) {
-		_, err := h.RollbackRevisionHandler(revisionNonAdminCtx(), &RollbackRevisionRequest{RevisionID: "1"})
-		testhelpers.AssertHumaError(t, err, 403)
-	})
-}
-
 // ============================================================================
 // Tests: GetEntityHistoryHandler
 // ============================================================================

--- a/backend/internal/api/handlers/admin/test_fixtures.go
+++ b/backend/internal/api/handlers/admin/test_fixtures.go
@@ -206,8 +206,11 @@ func (h *TestFixtureHandler) Reset(ctx context.Context, req *ResetTestFixturesRe
 		return nil, huma.Error400BadRequest(fmt.Sprintf("%s header is required", TestFixturesHeader))
 	}
 
-	// Defense 3: admin only. Route lives on the protected group so JWT is
-	// validated upstream; we only need to assert IsAdmin here.
+	// Defense 3: admin only. Route lives on the rc.Admin group (PSY-423) so
+	// HumaAdminMiddleware enforces admin upstream; the inline check stays as
+	// defense-in-depth for this security-sensitive endpoint and so the
+	// suite's integration tests (which call this handler directly, bypassing
+	// the middleware) keep their assertion that non-admin → 403.
 	user := middleware.GetUserFromContext(ctx)
 	if user == nil || !user.IsAdmin {
 		return nil, huma.Error403Forbidden("admin required")

--- a/backend/internal/api/handlers/catalog/artist.go
+++ b/backend/internal/api/handlers/catalog/artist.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 
-	"psychic-homily-backend/internal/api/handlers/shared"
 	"psychic-homily-backend/internal/api/middleware"
 	apperrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/logger"
@@ -350,10 +349,7 @@ type AdminCreateArtistResponse struct {
 func (h *ArtistHandler) AdminCreateArtistHandler(ctx context.Context, req *AdminCreateArtistRequest) (*AdminCreateArtistResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	// Validate name
 	name := strings.TrimSpace(req.Body.Name)
@@ -765,10 +761,7 @@ type AdminUpdateArtistResponse struct {
 func (h *ArtistHandler) AdminUpdateArtistHandler(ctx context.Context, req *AdminUpdateArtistRequest) (*AdminUpdateArtistResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	// Parse artist ID
 	artistID, err := strconv.ParseUint(req.ArtistID, 10, 32)
@@ -1005,10 +998,7 @@ type AddArtistAliasResponse struct {
 func (h *ArtistHandler) AddArtistAliasHandler(ctx context.Context, req *AddArtistAliasRequest) (*AddArtistAliasResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	artistID, err := strconv.ParseUint(req.ArtistID, 10, 32)
 	if err != nil {
@@ -1058,10 +1048,7 @@ type DeleteArtistAliasRequest struct {
 func (h *ArtistHandler) DeleteArtistAliasHandler(ctx context.Context, req *DeleteArtistAliasRequest) (*struct{}, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	aliasID, err := strconv.ParseUint(req.AliasID, 10, 32)
 	if err != nil {
@@ -1115,10 +1102,7 @@ type MergeArtistsResponse struct {
 func (h *ArtistHandler) MergeArtistsHandler(ctx context.Context, req *MergeArtistsRequest) (*MergeArtistsResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	if req.Body.CanonicalArtistID == 0 || req.Body.MergeFromArtistID == 0 {
 		return nil, huma.Error400BadRequest("Both canonical_artist_id and merge_from_artist_id are required")

--- a/backend/internal/api/handlers/catalog/artist_relationship_test.go
+++ b/backend/internal/api/handlers/catalog/artist_relationship_test.go
@@ -227,23 +227,6 @@ func TestRemoveVote_MissingType(t *testing.T) {
 
 // --- DeleteRelationshipHandler ---
 
-func TestDeleteRelationship_NoAuth(t *testing.T) {
-	h := testArtistRelationshipHandler()
-	req := &DeleteRelationshipRequest{SourceID: "1", TargetID: "2", Type: "similar"}
-
-	_, err := h.DeleteRelationshipHandler(context.Background(), req)
-	testhelpers.AssertHumaError(t, err, 401)
-}
-
-func TestDeleteRelationship_NonAdmin(t *testing.T) {
-	h := testArtistRelationshipHandler()
-	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: false})
-	req := &DeleteRelationshipRequest{SourceID: "1", TargetID: "2", Type: "similar"}
-
-	_, err := h.DeleteRelationshipHandler(ctx, req)
-	testhelpers.AssertHumaError(t, err, 403)
-}
-
 // --- splitAndTrim ---
 
 func TestSplitAndTrim(t *testing.T) {

--- a/backend/internal/api/handlers/catalog/artist_test.go
+++ b/backend/internal/api/handlers/catalog/artist_test.go
@@ -36,23 +36,6 @@ func TestDeleteArtist_InvalidID(t *testing.T) {
 
 // --- AdminUpdateArtistHandler ---
 
-func TestAdminUpdateArtist_NoUser(t *testing.T) {
-	h := testArtistHandler()
-	req := &AdminUpdateArtistRequest{ArtistID: "1"}
-
-	_, err := h.AdminUpdateArtistHandler(context.Background(), req)
-	testhelpers.AssertHumaError(t, err, 403)
-}
-
-func TestAdminUpdateArtist_NonAdmin(t *testing.T) {
-	h := testArtistHandler()
-	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: false})
-	req := &AdminUpdateArtistRequest{ArtistID: "1"}
-
-	_, err := h.AdminUpdateArtistHandler(ctx, req)
-	testhelpers.AssertHumaError(t, err, 403)
-}
-
 func TestAdminUpdateArtist_InvalidID(t *testing.T) {
 	h := testArtistHandler()
 	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
@@ -885,25 +868,6 @@ func TestGetArtistAliases_NotFound(t *testing.T) {
 // Mock-based tests: AddArtistAliasHandler
 // ============================================================================
 
-func TestAddArtistAlias_NoUser(t *testing.T) {
-	h := testArtistHandler()
-	req := &AddArtistAliasRequest{ArtistID: "1"}
-	req.Body.Alias = "test"
-
-	_, err := h.AddArtistAliasHandler(context.Background(), req)
-	testhelpers.AssertHumaError(t, err, 403)
-}
-
-func TestAddArtistAlias_NonAdmin(t *testing.T) {
-	h := testArtistHandler()
-	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: false})
-	req := &AddArtistAliasRequest{ArtistID: "1"}
-	req.Body.Alias = "test"
-
-	_, err := h.AddArtistAliasHandler(ctx, req)
-	testhelpers.AssertHumaError(t, err, 403)
-}
-
 func TestAddArtistAlias_InvalidID(t *testing.T) {
 	h := testArtistHandler()
 	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
@@ -966,19 +930,6 @@ func TestAddArtistAlias_Conflict(t *testing.T) {
 // Mock-based tests: DeleteArtistAliasHandler
 // ============================================================================
 
-func TestDeleteArtistAlias_NoUser(t *testing.T) {
-	h := testArtistHandler()
-	_, err := h.DeleteArtistAliasHandler(context.Background(), &DeleteArtistAliasRequest{ArtistID: "1", AliasID: "1"})
-	testhelpers.AssertHumaError(t, err, 403)
-}
-
-func TestDeleteArtistAlias_NonAdmin(t *testing.T) {
-	h := testArtistHandler()
-	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: false})
-	_, err := h.DeleteArtistAliasHandler(ctx, &DeleteArtistAliasRequest{ArtistID: "1", AliasID: "1"})
-	testhelpers.AssertHumaError(t, err, 403)
-}
-
 func TestDeleteArtistAlias_InvalidAliasID(t *testing.T) {
 	h := testArtistHandler()
 	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
@@ -1020,27 +971,6 @@ func TestDeleteArtistAlias_NotFound(t *testing.T) {
 // ============================================================================
 // Mock-based tests: MergeArtistsHandler
 // ============================================================================
-
-func TestMergeArtists_NoUser(t *testing.T) {
-	h := testArtistHandler()
-	req := &MergeArtistsRequest{}
-	req.Body.CanonicalArtistID = 1
-	req.Body.MergeFromArtistID = 2
-
-	_, err := h.MergeArtistsHandler(context.Background(), req)
-	testhelpers.AssertHumaError(t, err, 403)
-}
-
-func TestMergeArtists_NonAdmin(t *testing.T) {
-	h := testArtistHandler()
-	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: false})
-	req := &MergeArtistsRequest{}
-	req.Body.CanonicalArtistID = 1
-	req.Body.MergeFromArtistID = 2
-
-	_, err := h.MergeArtistsHandler(ctx, req)
-	testhelpers.AssertHumaError(t, err, 403)
-}
 
 func TestMergeArtists_MissingIDs(t *testing.T) {
 	h := testArtistHandler()
@@ -1124,25 +1054,6 @@ func TestMergeArtists_NotFound(t *testing.T) {
 // ============================================================================
 // Mock-based tests: AdminCreateArtistHandler
 // ============================================================================
-
-func TestAdminCreateArtist_NoUser(t *testing.T) {
-	h := testArtistHandler()
-	req := &AdminCreateArtistRequest{}
-	req.Body.Name = "Test Artist"
-
-	_, err := h.AdminCreateArtistHandler(context.Background(), req)
-	testhelpers.AssertHumaError(t, err, 403)
-}
-
-func TestAdminCreateArtist_NonAdmin(t *testing.T) {
-	h := testArtistHandler()
-	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: false})
-	req := &AdminCreateArtistRequest{}
-	req.Body.Name = "Test Artist"
-
-	_, err := h.AdminCreateArtistHandler(ctx, req)
-	testhelpers.AssertHumaError(t, err, 403)
-}
 
 func TestAdminCreateArtist_EmptyName(t *testing.T) {
 	h := testArtistHandler()

--- a/backend/internal/api/handlers/catalog/festival.go
+++ b/backend/internal/api/handlers/catalog/festival.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 
-	"psychic-homily-backend/internal/api/handlers/shared"
+	"psychic-homily-backend/internal/api/middleware"
 	apperrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/logger"
 	adminm "psychic-homily-backend/internal/models/admin"
@@ -191,10 +191,7 @@ type CreateFestivalResponse struct {
 func (h *FestivalHandler) CreateFestivalHandler(ctx context.Context, req *CreateFestivalRequest) (*CreateFestivalResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	if req.Body.Name == "" {
 		return nil, huma.Error400BadRequest("Name is required")
@@ -291,10 +288,7 @@ type UpdateFestivalResponse struct {
 func (h *FestivalHandler) UpdateFestivalHandler(ctx context.Context, req *UpdateFestivalRequest) (*UpdateFestivalResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	festivalID, err := h.resolveFestivalID(req.FestivalID)
 	if err != nil {
@@ -388,10 +382,7 @@ type DeleteFestivalRequest struct {
 func (h *FestivalHandler) DeleteFestivalHandler(ctx context.Context, req *DeleteFestivalRequest) (*struct{}, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	festivalID, err := h.resolveFestivalID(req.FestivalID)
 	if err != nil {
@@ -499,10 +490,7 @@ type AddFestivalArtistHandlerResponse struct {
 func (h *FestivalHandler) AddFestivalArtistHandler(ctx context.Context, req *AddFestivalArtistHandlerRequest) (*AddFestivalArtistHandlerResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	festivalID, err := strconv.ParseUint(req.FestivalID, 10, 32)
 	if err != nil {
@@ -575,10 +563,7 @@ type UpdateFestivalArtistHandlerResponse struct {
 func (h *FestivalHandler) UpdateFestivalArtistHandler(ctx context.Context, req *UpdateFestivalArtistHandlerRequest) (*UpdateFestivalArtistHandlerResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	festivalID, err := strconv.ParseUint(req.FestivalID, 10, 32)
 	if err != nil {
@@ -635,10 +620,7 @@ type RemoveFestivalArtistRequest struct {
 func (h *FestivalHandler) RemoveFestivalArtistHandler(ctx context.Context, req *RemoveFestivalArtistRequest) (*struct{}, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	festivalID, err := strconv.ParseUint(req.FestivalID, 10, 32)
 	if err != nil {
@@ -734,10 +716,7 @@ type AddFestivalVenueHandlerResponse struct {
 func (h *FestivalHandler) AddFestivalVenueHandler(ctx context.Context, req *AddFestivalVenueHandlerRequest) (*AddFestivalVenueHandlerResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	festivalID, err := strconv.ParseUint(req.FestivalID, 10, 32)
 	if err != nil {
@@ -792,10 +771,7 @@ type RemoveFestivalVenueRequest struct {
 func (h *FestivalHandler) RemoveFestivalVenueHandler(ctx context.Context, req *RemoveFestivalVenueRequest) (*struct{}, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	festivalID, err := strconv.ParseUint(req.FestivalID, 10, 32)
 	if err != nil {

--- a/backend/internal/api/handlers/catalog/label.go
+++ b/backend/internal/api/handlers/catalog/label.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 
-	"psychic-homily-backend/internal/api/handlers/shared"
+	"psychic-homily-backend/internal/api/middleware"
 	apperrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/logger"
 	adminm "psychic-homily-backend/internal/models/admin"
@@ -182,10 +182,7 @@ type CreateLabelResponse struct {
 func (h *LabelHandler) CreateLabelHandler(ctx context.Context, req *CreateLabelRequest) (*CreateLabelResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	if req.Body.Name == "" {
 		return nil, huma.Error400BadRequest("Name is required")
@@ -272,10 +269,7 @@ type UpdateLabelResponse struct {
 func (h *LabelHandler) UpdateLabelHandler(ctx context.Context, req *UpdateLabelRequest) (*UpdateLabelResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	// Resolve label ID
 	labelID, err := h.resolveLabelID(req.LabelID)
@@ -424,10 +418,7 @@ type DeleteLabelRequest struct {
 func (h *LabelHandler) DeleteLabelHandler(ctx context.Context, req *DeleteLabelRequest) (*struct{}, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	// Resolve label ID
 	labelID, err := h.resolveLabelID(req.LabelID)
@@ -572,10 +563,7 @@ type AddArtistToLabelResponse struct {
 func (h *LabelHandler) AddArtistToLabelHandler(ctx context.Context, req *AddArtistToLabelRequest) (*AddArtistToLabelResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	// Resolve label ID
 	labelID, err := h.resolveLabelID(req.LabelID)
@@ -647,10 +635,7 @@ type AddReleaseToLabelResponse struct {
 func (h *LabelHandler) AddReleaseToLabelHandler(ctx context.Context, req *AddReleaseToLabelRequest) (*AddReleaseToLabelResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	// Resolve label ID
 	labelID, err := h.resolveLabelID(req.LabelID)

--- a/backend/internal/api/handlers/catalog/radio.go
+++ b/backend/internal/api/handlers/catalog/radio.go
@@ -10,6 +10,7 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 
 	"psychic-homily-backend/internal/api/handlers/shared"
+	"psychic-homily-backend/internal/api/middleware"
 	apperrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/logger"
 	"psychic-homily-backend/internal/services/contracts"
@@ -616,10 +617,7 @@ type AdminCreateRadioStationResponse struct {
 func (h *RadioHandler) AdminCreateRadioStationHandler(ctx context.Context, req *AdminCreateRadioStationRequest) (*AdminCreateRadioStationResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	if req.Body.Name == "" {
 		return nil, huma.Error400BadRequest("Name is required")
@@ -714,10 +712,7 @@ type AdminUpdateRadioStationResponse struct {
 func (h *RadioHandler) AdminUpdateRadioStationHandler(ctx context.Context, req *AdminUpdateRadioStationRequest) (*AdminUpdateRadioStationResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	serviceReq := &contracts.UpdateRadioStationRequest{
 		Name:             req.Body.Name,
@@ -785,12 +780,9 @@ type AdminDeleteRadioStationRequest struct {
 func (h *RadioHandler) AdminDeleteRadioStationHandler(ctx context.Context, req *AdminDeleteRadioStationRequest) (*struct{}, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
-	err = h.stationWriter.DeleteStation(req.StationID)
+	err := h.stationWriter.DeleteStation(req.StationID)
 	if err != nil {
 		var radioErr *apperrors.RadioError
 		if errors.As(err, &radioErr) && radioErr.Code == apperrors.CodeRadioStationNotFound {
@@ -852,10 +844,7 @@ type AdminCreateRadioShowResponse struct {
 func (h *RadioHandler) AdminCreateRadioShowHandler(ctx context.Context, req *AdminCreateRadioShowRequest) (*AdminCreateRadioShowResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	if req.Body.Name == "" {
 		return nil, huma.Error400BadRequest("Name is required")
@@ -938,10 +927,7 @@ type AdminUpdateRadioShowResponse struct {
 func (h *RadioHandler) AdminUpdateRadioShowHandler(ctx context.Context, req *AdminUpdateRadioShowRequest) (*AdminUpdateRadioShowResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	serviceReq := &contracts.UpdateRadioShowRequest{
 		Name:            req.Body.Name,
@@ -1000,12 +986,9 @@ type AdminDeleteRadioShowRequest struct {
 func (h *RadioHandler) AdminDeleteRadioShowHandler(ctx context.Context, req *AdminDeleteRadioShowRequest) (*struct{}, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
-	err = h.showWriter.DeleteShow(req.ShowID)
+	err := h.showWriter.DeleteShow(req.ShowID)
 	if err != nil {
 		var radioErr *apperrors.RadioError
 		if errors.As(err, &radioErr) && radioErr.Code == apperrors.CodeRadioShowNotFound {
@@ -1053,10 +1036,6 @@ type AdminDiscoverShowsResponse struct {
 
 // AdminDiscoverShowsHandler handles POST /admin/radio-stations/{id}/discover
 func (h *RadioHandler) AdminDiscoverShowsHandler(ctx context.Context, req *AdminDiscoverShowsRequest) (*AdminDiscoverShowsResponse, error) {
-	_, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
 
 	result, err := h.importer.DiscoverStationShows(req.StationID)
 	if err != nil {
@@ -1078,10 +1057,6 @@ type AdminTriggerFetchRequest struct {
 // AdminTriggerFetchHandler handles POST /admin/radio-stations/{id}/fetch
 // Repurposed to call DiscoverStationShows.
 func (h *RadioHandler) AdminTriggerFetchHandler(ctx context.Context, req *AdminTriggerFetchRequest) (*AdminDiscoverShowsResponse, error) {
-	_, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
 
 	result, err := h.importer.DiscoverStationShows(req.StationID)
 	if err != nil {
@@ -1111,10 +1086,6 @@ type AdminImportShowEpisodesResponse struct {
 
 // AdminImportShowEpisodesHandler handles POST /admin/radio-shows/{id}/import
 func (h *RadioHandler) AdminImportShowEpisodesHandler(ctx context.Context, req *AdminImportShowEpisodesRequest) (*AdminImportShowEpisodesResponse, error) {
-	_, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
 
 	result, err := h.importer.ImportShowEpisodes(req.ShowID, req.Body.Since, req.Body.Until)
 	if err != nil {
@@ -1145,10 +1116,6 @@ type AdminGetUnmatchedPlaysResponse struct {
 
 // AdminGetUnmatchedPlaysHandler handles GET /admin/radio/unmatched
 func (h *RadioHandler) AdminGetUnmatchedPlaysHandler(ctx context.Context, req *AdminGetUnmatchedPlaysRequest) (*AdminGetUnmatchedPlaysResponse, error) {
-	_, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
 
 	limit := req.Limit
 	if limit <= 0 {
@@ -1195,10 +1162,7 @@ type AdminLinkPlayResponse struct {
 func (h *RadioHandler) AdminLinkPlayHandler(ctx context.Context, req *AdminLinkPlayRequest) (*AdminLinkPlayResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	linkReq := &contracts.LinkPlayRequest{
 		ArtistID:  req.Body.ArtistID,
@@ -1254,10 +1218,7 @@ type AdminBulkLinkPlaysResponse struct {
 func (h *RadioHandler) AdminBulkLinkPlaysHandler(ctx context.Context, req *AdminBulkLinkPlaysRequest) (*AdminBulkLinkPlaysResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	if req.Body.ArtistName == "" {
 		return nil, huma.Error400BadRequest("artist_name is required")
@@ -1328,10 +1289,7 @@ type AdminCreateImportJobResponse struct {
 func (h *RadioHandler) AdminCreateImportJobHandler(ctx context.Context, req *AdminCreateImportJobRequest) (*AdminCreateImportJobResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	if req.Body.Since == "" {
 		return nil, huma.Error400BadRequest("since date is required")
@@ -1399,10 +1357,6 @@ type AdminGetImportJobResponse struct {
 
 // AdminGetImportJobHandler handles GET /admin/radio/import-jobs/{id}
 func (h *RadioHandler) AdminGetImportJobHandler(ctx context.Context, req *AdminGetImportJobRequest) (*AdminGetImportJobResponse, error) {
-	_, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
 
 	job, err := h.importJobManager.GetImportJob(req.JobID)
 	if err != nil {
@@ -1432,10 +1386,7 @@ type AdminCancelImportJobResponse struct {
 func (h *RadioHandler) AdminCancelImportJobHandler(ctx context.Context, req *AdminCancelImportJobRequest) (*AdminCancelImportJobResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	if err := h.importJobManager.CancelImportJob(req.JobID); err != nil {
 		logger.FromContext(ctx).Error("cancel_import_job_failed",
@@ -1485,10 +1436,6 @@ type AdminListImportJobsResponse struct {
 
 // AdminListImportJobsHandler handles GET /admin/radio-shows/{id}/import-jobs
 func (h *RadioHandler) AdminListImportJobsHandler(ctx context.Context, req *AdminListImportJobsRequest) (*AdminListImportJobsResponse, error) {
-	_, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
 
 	jobs, err := h.importJobManager.ListImportJobs(req.ShowID)
 	if err != nil {

--- a/backend/internal/api/handlers/catalog/radio_test.go
+++ b/backend/internal/api/handlers/catalog/radio_test.go
@@ -633,17 +633,6 @@ func TestAdminCreateRadioStation_Success(t *testing.T) {
 	}
 }
 
-func TestAdminCreateRadioStation_NotAdmin(t *testing.T) {
-	mock := &testhelpers.MockRadioService{}
-	h := testRadioHandler(mock)
-	req := &AdminCreateRadioStationRequest{}
-	req.Body.Name = "KEXP"
-	req.Body.BroadcastType = "both"
-
-	_, err := h.AdminCreateRadioStationHandler(context.Background(), req)
-	testhelpers.AssertHumaError(t, err, 403)
-}
-
 func TestAdminCreateRadioStation_MissingName(t *testing.T) {
 	mock := &testhelpers.MockRadioService{}
 	h := testRadioHandler(mock)
@@ -707,15 +696,6 @@ func TestAdminUpdateRadioStation_Success(t *testing.T) {
 	}
 }
 
-func TestAdminUpdateRadioStation_NotAdmin(t *testing.T) {
-	mock := &testhelpers.MockRadioService{}
-	h := testRadioHandler(mock)
-	req := &AdminUpdateRadioStationRequest{StationID: 1}
-
-	_, err := h.AdminUpdateRadioStationHandler(context.Background(), req)
-	testhelpers.AssertHumaError(t, err, 403)
-}
-
 func TestAdminUpdateRadioStation_NotFound(t *testing.T) {
 	mock := &testhelpers.MockRadioService{
 		UpdateStationFn: func(stationID uint, req *contracts.UpdateRadioStationRequest) (*contracts.RadioStationDetailResponse, error) {
@@ -746,15 +726,6 @@ func TestAdminDeleteRadioStation_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-}
-
-func TestAdminDeleteRadioStation_NotAdmin(t *testing.T) {
-	mock := &testhelpers.MockRadioService{}
-	h := testRadioHandler(mock)
-	req := &AdminDeleteRadioStationRequest{StationID: 1}
-
-	_, err := h.AdminDeleteRadioStationHandler(context.Background(), req)
-	testhelpers.AssertHumaError(t, err, 403)
 }
 
 func TestAdminDeleteRadioStation_NotFound(t *testing.T) {
@@ -796,16 +767,6 @@ func TestAdminCreateRadioShow_Success(t *testing.T) {
 	if resp.Body.Name != "Morning Show" {
 		t.Errorf("expected Morning Show, got %s", resp.Body.Name)
 	}
-}
-
-func TestAdminCreateRadioShow_NotAdmin(t *testing.T) {
-	mock := &testhelpers.MockRadioService{}
-	h := testRadioHandler(mock)
-	req := &AdminCreateRadioShowRequest{StationID: 1}
-	req.Body.Name = "Morning Show"
-
-	_, err := h.AdminCreateRadioShowHandler(context.Background(), req)
-	testhelpers.AssertHumaError(t, err, 403)
 }
 
 func TestAdminCreateRadioShow_MissingName(t *testing.T) {
@@ -859,15 +820,6 @@ func TestAdminUpdateRadioShow_Success(t *testing.T) {
 	}
 }
 
-func TestAdminUpdateRadioShow_NotAdmin(t *testing.T) {
-	mock := &testhelpers.MockRadioService{}
-	h := testRadioHandler(mock)
-	req := &AdminUpdateRadioShowRequest{ShowID: 1}
-
-	_, err := h.AdminUpdateRadioShowHandler(context.Background(), req)
-	testhelpers.AssertHumaError(t, err, 403)
-}
-
 func TestAdminUpdateRadioShow_NotFound(t *testing.T) {
 	mock := &testhelpers.MockRadioService{
 		UpdateShowFn: func(showID uint, req *contracts.UpdateRadioShowRequest) (*contracts.RadioShowDetailResponse, error) {
@@ -898,15 +850,6 @@ func TestAdminDeleteRadioShow_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-}
-
-func TestAdminDeleteRadioShow_NotAdmin(t *testing.T) {
-	mock := &testhelpers.MockRadioService{}
-	h := testRadioHandler(mock)
-	req := &AdminDeleteRadioShowRequest{ShowID: 1}
-
-	_, err := h.AdminDeleteRadioShowHandler(context.Background(), req)
-	testhelpers.AssertHumaError(t, err, 403)
 }
 
 func TestAdminDeleteRadioShow_NotFound(t *testing.T) {
@@ -944,15 +887,6 @@ func TestAdminTriggerFetch_Success(t *testing.T) {
 	}
 }
 
-func TestAdminTriggerFetch_NotAdmin(t *testing.T) {
-	mock := &testhelpers.MockRadioService{}
-	h := testRadioHandler(mock)
-	req := &AdminTriggerFetchRequest{StationID: 1}
-
-	_, err := h.AdminTriggerFetchHandler(context.Background(), req)
-	testhelpers.AssertHumaError(t, err, 403)
-}
-
 // ============================================================================
 // AdminDiscoverShowsHandler Tests
 // ============================================================================
@@ -976,15 +910,6 @@ func TestAdminDiscoverShows_Success(t *testing.T) {
 	if len(resp.Body.ShowNames) != 2 {
 		t.Fatalf("expected 2 show names, got %d", len(resp.Body.ShowNames))
 	}
-}
-
-func TestAdminDiscoverShows_NotAdmin(t *testing.T) {
-	mock := &testhelpers.MockRadioService{}
-	h := testRadioHandler(mock)
-	req := &AdminDiscoverShowsRequest{StationID: 1}
-
-	_, err := h.AdminDiscoverShowsHandler(context.Background(), req)
-	testhelpers.AssertHumaError(t, err, 403)
 }
 
 func TestAdminDiscoverShows_ServiceError(t *testing.T) {
@@ -1032,17 +957,6 @@ func TestAdminImportShowEpisodes_Success(t *testing.T) {
 	if resp.Body.PlaysMatched != 30 {
 		t.Fatalf("expected 30 plays matched, got %d", resp.Body.PlaysMatched)
 	}
-}
-
-func TestAdminImportShowEpisodes_NotAdmin(t *testing.T) {
-	mock := &testhelpers.MockRadioService{}
-	h := testRadioHandler(mock)
-	req := &AdminImportShowEpisodesRequest{ShowID: 1}
-	req.Body.Since = "2024-01-01"
-	req.Body.Until = "2024-12-31"
-
-	_, err := h.AdminImportShowEpisodesHandler(context.Background(), req)
-	testhelpers.AssertHumaError(t, err, 403)
 }
 
 func TestAdminImportShowEpisodes_ServiceError(t *testing.T) {
@@ -1103,17 +1017,6 @@ func TestAdminCreateImportJob_Success(t *testing.T) {
 	if resp.Body.Status != "pending" {
 		t.Errorf("expected status 'pending', got %s", resp.Body.Status)
 	}
-}
-
-func TestAdminCreateImportJob_NotAdmin(t *testing.T) {
-	mock := &testhelpers.MockRadioService{}
-	h := testRadioHandler(mock)
-	req := &AdminCreateImportJobRequest{ShowID: 1}
-	req.Body.Since = "2025-01-01"
-	req.Body.Until = "2025-12-31"
-
-	_, err := h.AdminCreateImportJobHandler(context.Background(), req)
-	testhelpers.AssertHumaError(t, err, 403)
 }
 
 func TestAdminCreateImportJob_MissingSince(t *testing.T) {
@@ -1197,13 +1100,6 @@ func TestAdminGetImportJob_NotFound(t *testing.T) {
 	testhelpers.AssertHumaError(t, err, 404)
 }
 
-func TestAdminGetImportJob_NotAdmin(t *testing.T) {
-	mock := &testhelpers.MockRadioService{}
-	h := testRadioHandler(mock)
-	_, err := h.AdminGetImportJobHandler(context.Background(), &AdminGetImportJobRequest{JobID: 1})
-	testhelpers.AssertHumaError(t, err, 403)
-}
-
 // ============================================================================
 // AdminCancelImportJobHandler Tests
 // ============================================================================
@@ -1233,13 +1129,6 @@ func TestAdminCancelImportJob_ServiceError(t *testing.T) {
 	h := testRadioHandler(mock)
 	_, err := h.AdminCancelImportJobHandler(radioAdminCtx(), &AdminCancelImportJobRequest{JobID: 1})
 	testhelpers.AssertHumaError(t, err, 500)
-}
-
-func TestAdminCancelImportJob_NotAdmin(t *testing.T) {
-	mock := &testhelpers.MockRadioService{}
-	h := testRadioHandler(mock)
-	_, err := h.AdminCancelImportJobHandler(context.Background(), &AdminCancelImportJobRequest{JobID: 1})
-	testhelpers.AssertHumaError(t, err, 403)
 }
 
 // ============================================================================
@@ -1304,9 +1193,3 @@ func TestAdminListImportJobs_ServiceError(t *testing.T) {
 	testhelpers.AssertHumaError(t, err, 500)
 }
 
-func TestAdminListImportJobs_NotAdmin(t *testing.T) {
-	mock := &testhelpers.MockRadioService{}
-	h := testRadioHandler(mock)
-	_, err := h.AdminListImportJobsHandler(context.Background(), &AdminListImportJobsRequest{ShowID: 1})
-	testhelpers.AssertHumaError(t, err, 403)
-}

--- a/backend/internal/api/handlers/catalog/release.go
+++ b/backend/internal/api/handlers/catalog/release.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 
-	"psychic-homily-backend/internal/api/handlers/shared"
+	"psychic-homily-backend/internal/api/middleware"
 	apperrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/logger"
 	adminm "psychic-homily-backend/internal/models/admin"
@@ -203,10 +203,7 @@ type CreateReleaseResponse struct {
 func (h *ReleaseHandler) CreateReleaseHandler(ctx context.Context, req *CreateReleaseRequest) (*CreateReleaseResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	if req.Body.Title == "" {
 		return nil, huma.Error400BadRequest("Title is required")
@@ -293,10 +290,7 @@ type UpdateReleaseResponse struct {
 func (h *ReleaseHandler) UpdateReleaseHandler(ctx context.Context, req *UpdateReleaseRequest) (*UpdateReleaseResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	// Resolve release ID
 	releaseID, err := h.resolveReleaseID(req.ReleaseID)
@@ -428,10 +422,7 @@ type DeleteReleaseRequest struct {
 func (h *ReleaseHandler) DeleteReleaseHandler(ctx context.Context, req *DeleteReleaseRequest) (*struct{}, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	// Resolve release ID
 	releaseID, err := h.resolveReleaseID(req.ReleaseID)
@@ -545,10 +536,7 @@ type AddExternalLinkResponse struct {
 func (h *ReleaseHandler) AddExternalLinkHandler(ctx context.Context, req *AddExternalLinkRequest) (*AddExternalLinkResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	releaseID, err := strconv.ParseUint(req.ReleaseID, 10, 32)
 	if err != nil {
@@ -595,10 +583,7 @@ type RemoveExternalLinkRequest struct {
 func (h *ReleaseHandler) RemoveExternalLinkHandler(ctx context.Context, req *RemoveExternalLinkRequest) (*struct{}, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	linkID, err := strconv.ParseUint(req.LinkID, 10, 32)
 	if err != nil {

--- a/backend/internal/api/handlers/catalog/venue.go
+++ b/backend/internal/api/handlers/catalog/venue.go
@@ -7,14 +7,14 @@ import (
 	"strconv"
 	"strings"
 
-	"psychic-homily-backend/internal/api/handlers/shared"
 	"psychic-homily-backend/internal/api/middleware"
 	apperrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/logger"
 	"psychic-homily-backend/internal/services/contracts"
 
-	"github.com/danielgtaylor/huma/v2"
 	adminm "psychic-homily-backend/internal/models/admin"
+
+	"github.com/danielgtaylor/huma/v2"
 )
 
 type VenueHandler struct {
@@ -286,10 +286,7 @@ type AdminCreateVenueResponse struct {
 func (h *VenueHandler) AdminCreateVenueHandler(ctx context.Context, req *AdminCreateVenueRequest) (*AdminCreateVenueResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	// Build service request
 	serviceReq := &contracts.CreateVenueRequest{
@@ -382,10 +379,7 @@ type UpdateVenueResponse struct {
 func (h *VenueHandler) UpdateVenueHandler(ctx context.Context, req *UpdateVenueRequest) (*UpdateVenueResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	// Parse venue ID
 	venueID, err := strconv.ParseUint(req.VenueID, 10, 32)

--- a/backend/internal/api/handlers/catalog/venue_test.go
+++ b/backend/internal/api/handlers/catalog/venue_test.go
@@ -16,52 +16,14 @@ func testVenueHandler() *VenueHandler {
 }
 
 // --- AdminCreateVenueHandler ---
-
-func TestAdminCreateVenueHandler_NoAuth(t *testing.T) {
-	h := testVenueHandler()
-	req := &AdminCreateVenueRequest{}
-	req.Body.Name = "Test Venue"
-	req.Body.City = "Phoenix"
-	req.Body.State = "AZ"
-
-	_, err := h.AdminCreateVenueHandler(context.Background(), req)
-	testhelpers.AssertHumaError(t, err, 403)
-}
-
-func TestAdminCreateVenueHandler_NonAdmin(t *testing.T) {
-	h := testVenueHandler()
-	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: false})
-	req := &AdminCreateVenueRequest{}
-	req.Body.Name = "Test Venue"
-	req.Body.City = "Phoenix"
-	req.Body.State = "AZ"
-
-	_, err := h.AdminCreateVenueHandler(ctx, req)
-	testhelpers.AssertHumaError(t, err, 403)
-}
+// PSY-423: handler-level admin gate moved to HumaAdminMiddleware on rc.Admin.
+// _NoAuth/_NonAdmin tests deleted; see middleware/admin_test.go for the gate.
 
 // --- UpdateVenueHandler (admin-only post-PSY-503) ---
-
-func TestUpdateVenueHandler_NoAuth(t *testing.T) {
-	h := testVenueHandler()
-	req := &UpdateVenueRequest{VenueID: "1"}
-
-	// Admin-only handler: unauthenticated requests get 403 (requireAdmin
-	// collapses "no user" and "non-admin" into the same response).
-	_, err := h.UpdateVenueHandler(context.Background(), req)
-	testhelpers.AssertHumaError(t, err, 403)
-}
-
-func TestUpdateVenueHandler_NonAdmin(t *testing.T) {
-	h := testVenueHandler()
-	// Even a venue submitter can't direct-update via this endpoint; they
-	// must use PUT /venues/{id}/suggest-edit through SuggestVenueEditHandler.
-	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: false})
-	req := &UpdateVenueRequest{VenueID: "1"}
-
-	_, err := h.UpdateVenueHandler(ctx, req)
-	testhelpers.AssertHumaError(t, err, 403)
-}
+// PSY-423: handler-level admin gate moved to HumaAdminMiddleware on rc.Admin.
+// _NoAuth/_NonAdmin tests deleted; middleware-level gate is covered by
+// middleware.TestHumaAdminMiddleware* and the route integration test in
+// internal/api/routes.
 
 func TestUpdateVenueHandler_InvalidID(t *testing.T) {
 	h := testVenueHandler()

--- a/backend/internal/api/handlers/community/artist_report.go
+++ b/backend/internal/api/handlers/community/artist_report.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 
-	"psychic-homily-backend/internal/api/handlers/shared"
 	"psychic-homily-backend/internal/api/middleware"
 	"psychic-homily-backend/internal/logger"
 	"psychic-homily-backend/internal/services/contracts"
@@ -192,11 +191,6 @@ type GetPendingArtistReportsResponse struct {
 func (h *ArtistReportHandler) GetPendingArtistReportsHandler(ctx context.Context, req *GetPendingArtistReportsRequest) (*GetPendingArtistReportsResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	_, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	// Validate limit
 	limit := req.Limit
 	if limit < 1 {
@@ -256,10 +250,7 @@ type DismissArtistReportResponse struct {
 func (h *ArtistReportHandler) DismissArtistReportHandler(ctx context.Context, req *DismissArtistReportRequest) (*DismissArtistReportResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	// Parse report ID
 	reportID, err := strconv.ParseUint(req.ReportID, 10, 32)
@@ -318,10 +309,7 @@ type ResolveArtistReportResponse struct {
 func (h *ArtistReportHandler) ResolveArtistReportHandler(ctx context.Context, req *ResolveArtistReportRequest) (*ResolveArtistReportResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	// Parse report ID
 	reportID, err := strconv.ParseUint(req.ReportID, 10, 32)

--- a/backend/internal/api/handlers/community/artist_report_test.go
+++ b/backend/internal/api/handlers/community/artist_report_test.go
@@ -157,23 +157,6 @@ func TestGetMyArtistReportHandler_ServiceError(t *testing.T) {
 
 // --- GetPendingArtistReportsHandler ---
 
-func TestGetPendingArtistReportsHandler_NoAuth(t *testing.T) {
-	h := testArtistReportHandler()
-	req := &GetPendingArtistReportsRequest{}
-
-	_, err := h.GetPendingArtistReportsHandler(context.Background(), req)
-	testhelpers.AssertHumaError(t, err, 403)
-}
-
-func TestGetPendingArtistReportsHandler_NonAdmin(t *testing.T) {
-	h := testArtistReportHandler()
-	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: false})
-	req := &GetPendingArtistReportsRequest{}
-
-	_, err := h.GetPendingArtistReportsHandler(ctx, req)
-	testhelpers.AssertHumaError(t, err, 403)
-}
-
 func TestGetPendingArtistReportsHandler_Success(t *testing.T) {
 	reports := []*contracts.ArtistReportResponse{{ID: 1}, {ID: 2}}
 	mock := &testhelpers.MockArtistReportService{
@@ -210,23 +193,6 @@ func TestGetPendingArtistReportsHandler_ServiceError(t *testing.T) {
 }
 
 // --- DismissArtistReportHandler ---
-
-func TestDismissArtistReportHandler_NoAuth(t *testing.T) {
-	h := testArtistReportHandler()
-	req := &DismissArtistReportRequest{ReportID: "1"}
-
-	_, err := h.DismissArtistReportHandler(context.Background(), req)
-	testhelpers.AssertHumaError(t, err, 403)
-}
-
-func TestDismissArtistReportHandler_NonAdmin(t *testing.T) {
-	h := testArtistReportHandler()
-	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: false})
-	req := &DismissArtistReportRequest{ReportID: "1"}
-
-	_, err := h.DismissArtistReportHandler(ctx, req)
-	testhelpers.AssertHumaError(t, err, 403)
-}
 
 func TestDismissArtistReportHandler_InvalidID(t *testing.T) {
 	h := testArtistReportHandler()
@@ -288,23 +254,6 @@ func TestDismissArtistReportHandler_ServiceError(t *testing.T) {
 }
 
 // --- ResolveArtistReportHandler ---
-
-func TestResolveArtistReportHandler_NoAuth(t *testing.T) {
-	h := testArtistReportHandler()
-	req := &ResolveArtistReportRequest{ReportID: "1"}
-
-	_, err := h.ResolveArtistReportHandler(context.Background(), req)
-	testhelpers.AssertHumaError(t, err, 403)
-}
-
-func TestResolveArtistReportHandler_NonAdmin(t *testing.T) {
-	h := testArtistReportHandler()
-	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: false})
-	req := &ResolveArtistReportRequest{ReportID: "1"}
-
-	_, err := h.ResolveArtistReportHandler(ctx, req)
-	testhelpers.AssertHumaError(t, err, 403)
-}
 
 func TestResolveArtistReportHandler_InvalidID(t *testing.T) {
 	h := testArtistReportHandler()

--- a/backend/internal/api/handlers/community/collection.go
+++ b/backend/internal/api/handlers/community/collection.go
@@ -41,7 +41,7 @@ type ListCollectionsHandlerRequest struct {
 	// tag names/aliases (case-insensitive ILIKE substring). Empty / whitespace
 	// queries short-circuit before hitting the DB. Title-tier matches rank
 	// above body-tier matches when the default sort is in effect.
-	Search     string `query:"search" required:"false" doc:"Search across collection title, description, item notes, and tag names/aliases (case-insensitive substring)"`
+	Search string `query:"search" required:"false" doc:"Search across collection title, description, item notes, and tag names/aliases (case-insensitive substring)"`
 	// PSY-352: sort=popular orders by HN gravity (likes / age^1.8). Empty
 	// or omitted defaults to updated_at DESC.
 	Sort string `query:"sort" required:"false" doc:"Sort order: 'popular' for HN-gravity ranking. Defaults to recently-updated." enum:"popular"`
@@ -633,16 +633,14 @@ type SetFeaturedHandlerRequest struct {
 	}
 }
 
-// SetFeaturedHandler handles PUT /collections/{slug}/feature
+// SetFeaturedHandler handles PUT /collections/{slug}/feature.
+// PSY-423: admin gating handled by HumaAdminMiddleware on rc.Admin.
 func (h *CollectionHandler) SetFeaturedHandler(ctx context.Context, req *SetFeaturedHandlerRequest) (*struct{}, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
-	err = h.collectionService.SetFeatured(req.Slug, req.Body.Featured)
+	err := h.collectionService.SetFeatured(req.Slug, req.Body.Featured)
 	if err != nil {
 		mappedErr := shared.MapCollectionError(err)
 		if mappedErr != nil {

--- a/backend/internal/api/handlers/community/collection_integration_test.go
+++ b/backend/internal/api/handlers/community/collection_integration_test.go
@@ -1070,25 +1070,9 @@ func (s *CollectionHandlerIntegrationSuite) TestSetFeatured_Unfeature() {
 	s.False(getResp.Body.IsFeatured)
 }
 
-func (s *CollectionHandlerIntegrationSuite) TestSetFeatured_NonAdminForbidden() {
-	user := testhelpers.CreateTestUser(s.deps.DB)
-	coll := s.createCollectionViaService(user, "Not Your Feature", true)
-
-	ctx := testhelpers.CtxWithUser(user)
-	req := &SetFeaturedHandlerRequest{Slug: coll.Slug}
-	req.Body.Featured = true
-
-	_, err := s.handler.SetFeaturedHandler(ctx, req)
-	testhelpers.AssertHumaError(s.T(), err, 403)
-}
-
-func (s *CollectionHandlerIntegrationSuite) TestSetFeatured_NoAuth() {
-	req := &SetFeaturedHandlerRequest{Slug: "some-slug"}
-	req.Body.Featured = true
-
-	_, err := s.handler.SetFeaturedHandler(context.Background(), req)
-	testhelpers.AssertHumaError(s.T(), err, 403)
-}
+// PSY-423: SetFeaturedHandler admin gate moved to HumaAdminMiddleware on
+// rc.Admin. NonAdminForbidden/NoAuth tests deleted; the gate is covered by
+// middleware unit tests + the route integration test.
 
 func (s *CollectionHandlerIntegrationSuite) TestSetFeatured_NotFound() {
 	admin := testhelpers.CreateAdminUser(s.deps.DB)

--- a/backend/internal/api/handlers/community/entity_report.go
+++ b/backend/internal/api/handlers/community/entity_report.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 
-	"psychic-homily-backend/internal/api/handlers/shared"
 	"psychic-homily-backend/internal/api/middleware"
 	"psychic-homily-backend/internal/logger"
 	communitym "psychic-homily-backend/internal/models/community"
@@ -151,9 +150,6 @@ type AdminListEntityReportsResponse struct {
 
 // AdminListEntityReportsHandler handles GET /admin/entity-reports
 func (h *EntityReportHandler) AdminListEntityReportsHandler(ctx context.Context, req *AdminListEntityReportsRequest) (*AdminListEntityReportsResponse, error) {
-	if _, err := shared.RequireAdmin(ctx); err != nil {
-		return nil, err
-	}
 
 	reports, total, err := h.entityReportService.ListEntityReports(&contracts.EntityReportFilters{
 		Status:     req.Status,
@@ -188,9 +184,6 @@ type AdminGetEntityReportResponse struct {
 
 // AdminGetEntityReportHandler handles GET /admin/entity-reports/{report_id}
 func (h *EntityReportHandler) AdminGetEntityReportHandler(ctx context.Context, req *AdminGetEntityReportRequest) (*AdminGetEntityReportResponse, error) {
-	if _, err := shared.RequireAdmin(ctx); err != nil {
-		return nil, err
-	}
 
 	reportID, err := strconv.ParseUint(req.ReportID, 10, 64)
 	if err != nil {
@@ -228,10 +221,7 @@ type AdminResolveEntityReportResponse struct {
 
 // AdminResolveEntityReportHandler handles POST /admin/entity-reports/{report_id}/resolve
 func (h *EntityReportHandler) AdminResolveEntityReportHandler(ctx context.Context, req *AdminResolveEntityReportRequest) (*AdminResolveEntityReportResponse, error) {
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	reportID, err := strconv.ParseUint(req.ReportID, 10, 64)
 	if err != nil {
@@ -294,10 +284,7 @@ type AdminDismissEntityReportResponse struct {
 
 // AdminDismissEntityReportHandler handles POST /admin/entity-reports/{report_id}/dismiss
 func (h *EntityReportHandler) AdminDismissEntityReportHandler(ctx context.Context, req *AdminDismissEntityReportRequest) (*AdminDismissEntityReportResponse, error) {
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	reportID, err := strconv.ParseUint(req.ReportID, 10, 64)
 	if err != nil {

--- a/backend/internal/api/handlers/community/entity_report_test.go
+++ b/backend/internal/api/handlers/community/entity_report_test.go
@@ -238,19 +238,6 @@ func TestReportEntity_ServiceError(t *testing.T) {
 // Tests: Admin — List Entity Reports
 // ============================================================================
 
-func TestAdminListEntityReports_RequiresAdmin(t *testing.T) {
-	h := testEntityReportHandler()
-
-	t.Run("NoUser", func(t *testing.T) {
-		_, err := h.AdminListEntityReportsHandler(context.Background(), &AdminListEntityReportsRequest{})
-		testhelpers.AssertHumaError(t, err, 403)
-	})
-	t.Run("NonAdmin", func(t *testing.T) {
-		_, err := h.AdminListEntityReportsHandler(entityReportUserCtx(), &AdminListEntityReportsRequest{})
-		testhelpers.AssertHumaError(t, err, 403)
-	})
-}
-
 func TestAdminListEntityReports_Success(t *testing.T) {
 	reports := []contracts.EntityReportResponse{*makeEntityReportResponse(1, "artist", "inaccurate")}
 	h := NewEntityReportHandler(
@@ -308,12 +295,6 @@ func TestAdminListEntityReports_WithEntityTypeFilter(t *testing.T) {
 // Tests: Admin — Get Single Entity Report
 // ============================================================================
 
-func TestAdminGetEntityReport_RequiresAdmin(t *testing.T) {
-	h := testEntityReportHandler()
-	_, err := h.AdminGetEntityReportHandler(entityReportUserCtx(), &AdminGetEntityReportRequest{ReportID: "1"})
-	testhelpers.AssertHumaError(t, err, 403)
-}
-
 func TestAdminGetEntityReport_InvalidID(t *testing.T) {
 	h := testEntityReportHandler()
 	_, err := h.AdminGetEntityReportHandler(entityReportAdminCtx(), &AdminGetEntityReportRequest{ReportID: "abc"})
@@ -360,13 +341,6 @@ func TestAdminGetEntityReport_Success(t *testing.T) {
 // ============================================================================
 // Tests: Admin — Resolve Entity Report
 // ============================================================================
-
-func TestAdminResolveEntityReport_RequiresAdmin(t *testing.T) {
-	h := testEntityReportHandler()
-	req := &AdminResolveEntityReportRequest{ReportID: "1"}
-	_, err := h.AdminResolveEntityReportHandler(entityReportUserCtx(), req)
-	testhelpers.AssertHumaError(t, err, 403)
-}
 
 func TestAdminResolveEntityReport_InvalidID(t *testing.T) {
 	h := testEntityReportHandler()
@@ -440,13 +414,6 @@ func TestAdminResolveEntityReport_AlreadyReviewed(t *testing.T) {
 // ============================================================================
 // Tests: Admin — Dismiss Entity Report
 // ============================================================================
-
-func TestAdminDismissEntityReport_RequiresAdmin(t *testing.T) {
-	h := testEntityReportHandler()
-	req := &AdminDismissEntityReportRequest{ReportID: "1"}
-	_, err := h.AdminDismissEntityReportHandler(entityReportUserCtx(), req)
-	testhelpers.AssertHumaError(t, err, 403)
-}
 
 func TestAdminDismissEntityReport_InvalidID(t *testing.T) {
 	h := testEntityReportHandler()

--- a/backend/internal/api/handlers/community/show_report.go
+++ b/backend/internal/api/handlers/community/show_report.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 
-	"psychic-homily-backend/internal/api/handlers/shared"
 	"psychic-homily-backend/internal/api/middleware"
 	"psychic-homily-backend/internal/logger"
 	"psychic-homily-backend/internal/services/contracts"
@@ -192,11 +191,6 @@ type GetPendingReportsResponse struct {
 func (h *ShowReportHandler) GetPendingReportsHandler(ctx context.Context, req *GetPendingReportsRequest) (*GetPendingReportsResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	_, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	// Validate limit
 	limit := req.Limit
 	if limit < 1 {
@@ -256,10 +250,7 @@ type DismissReportResponse struct {
 func (h *ShowReportHandler) DismissReportHandler(ctx context.Context, req *DismissReportRequest) (*DismissReportResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	// Parse report ID
 	reportID, err := strconv.ParseUint(req.ReportID, 10, 32)
@@ -319,10 +310,7 @@ type ResolveReportResponse struct {
 func (h *ShowReportHandler) ResolveReportHandler(ctx context.Context, req *ResolveReportRequest) (*ResolveReportResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	// Parse report ID
 	reportID, err := strconv.ParseUint(req.ReportID, 10, 32)

--- a/backend/internal/api/handlers/community/show_report_test.go
+++ b/backend/internal/api/handlers/community/show_report_test.go
@@ -157,23 +157,6 @@ func TestGetMyReportHandler_ServiceError(t *testing.T) {
 
 // --- GetPendingReportsHandler ---
 
-func TestGetPendingReportsHandler_NoAuth(t *testing.T) {
-	h := testShowReportHandler()
-	req := &GetPendingReportsRequest{}
-
-	_, err := h.GetPendingReportsHandler(context.Background(), req)
-	testhelpers.AssertHumaError(t, err, 403)
-}
-
-func TestGetPendingReportsHandler_NonAdmin(t *testing.T) {
-	h := testShowReportHandler()
-	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: false})
-	req := &GetPendingReportsRequest{}
-
-	_, err := h.GetPendingReportsHandler(ctx, req)
-	testhelpers.AssertHumaError(t, err, 403)
-}
-
 func TestGetPendingReportsHandler_Success(t *testing.T) {
 	reports := []*contracts.ShowReportResponse{{ID: 1}, {ID: 2}}
 	mock := &testhelpers.MockShowReportService{
@@ -210,23 +193,6 @@ func TestGetPendingReportsHandler_ServiceError(t *testing.T) {
 }
 
 // --- DismissReportHandler ---
-
-func TestDismissReportHandler_NoAuth(t *testing.T) {
-	h := testShowReportHandler()
-	req := &DismissReportRequest{ReportID: "1"}
-
-	_, err := h.DismissReportHandler(context.Background(), req)
-	testhelpers.AssertHumaError(t, err, 403)
-}
-
-func TestDismissReportHandler_NonAdmin(t *testing.T) {
-	h := testShowReportHandler()
-	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: false})
-	req := &DismissReportRequest{ReportID: "1"}
-
-	_, err := h.DismissReportHandler(ctx, req)
-	testhelpers.AssertHumaError(t, err, 403)
-}
 
 func TestDismissReportHandler_InvalidID(t *testing.T) {
 	h := testShowReportHandler()
@@ -288,23 +254,6 @@ func TestDismissReportHandler_ServiceError(t *testing.T) {
 }
 
 // --- ResolveReportHandler ---
-
-func TestResolveReportHandler_NoAuth(t *testing.T) {
-	h := testShowReportHandler()
-	req := &ResolveReportRequest{ReportID: "1"}
-
-	_, err := h.ResolveReportHandler(context.Background(), req)
-	testhelpers.AssertHumaError(t, err, 403)
-}
-
-func TestResolveReportHandler_NonAdmin(t *testing.T) {
-	h := testShowReportHandler()
-	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: false})
-	req := &ResolveReportRequest{ReportID: "1"}
-
-	_, err := h.ResolveReportHandler(ctx, req)
-	testhelpers.AssertHumaError(t, err, 403)
-}
 
 func TestResolveReportHandler_InvalidID(t *testing.T) {
 	h := testShowReportHandler()

--- a/backend/internal/api/handlers/engagement/comment_admin.go
+++ b/backend/internal/api/handlers/engagement/comment_admin.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 
-	"psychic-homily-backend/internal/api/handlers/shared"
+	"psychic-homily-backend/internal/api/middleware"
 	"psychic-homily-backend/internal/logger"
 	"psychic-homily-backend/internal/services/contracts"
 )
@@ -55,10 +55,7 @@ type AdminHideCommentRequest struct {
 
 // AdminHideCommentHandler handles POST /admin/comments/{comment_id}/hide
 func (h *CommentAdminHandler) AdminHideCommentHandler(ctx context.Context, req *AdminHideCommentRequest) (*struct{}, error) {
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	commentID, err := strconv.ParseUint(req.CommentID, 10, 32)
 	if err != nil {
@@ -103,10 +100,7 @@ type AdminRestoreCommentRequest struct {
 
 // AdminRestoreCommentHandler handles POST /admin/comments/{comment_id}/restore
 func (h *CommentAdminHandler) AdminRestoreCommentHandler(ctx context.Context, req *AdminRestoreCommentRequest) (*struct{}, error) {
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	commentID, err := strconv.ParseUint(req.CommentID, 10, 32)
 	if err != nil {
@@ -156,9 +150,6 @@ type AdminListPendingCommentsResponse struct {
 
 // AdminListPendingCommentsHandler handles GET /admin/comments/pending
 func (h *CommentAdminHandler) AdminListPendingCommentsHandler(ctx context.Context, req *AdminListPendingCommentsRequest) (*AdminListPendingCommentsResponse, error) {
-	if _, err := shared.RequireAdmin(ctx); err != nil {
-		return nil, err
-	}
 
 	limit := req.Limit
 	if limit <= 0 {
@@ -198,10 +189,7 @@ type AdminApproveCommentRequest struct {
 
 // AdminApproveCommentHandler handles POST /admin/comments/{comment_id}/approve
 func (h *CommentAdminHandler) AdminApproveCommentHandler(ctx context.Context, req *AdminApproveCommentRequest) (*struct{}, error) {
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	commentID, err := strconv.ParseUint(req.CommentID, 10, 32)
 	if err != nil {
@@ -245,10 +233,7 @@ type AdminRejectCommentRequest struct {
 
 // AdminRejectCommentHandler handles POST /admin/comments/{comment_id}/reject
 func (h *CommentAdminHandler) AdminRejectCommentHandler(ctx context.Context, req *AdminRejectCommentRequest) (*struct{}, error) {
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	commentID, err := strconv.ParseUint(req.CommentID, 10, 32)
 	if err != nil {
@@ -302,10 +287,7 @@ type AdminGetCommentEditHistoryResponse struct {
 // AdminGetCommentEditHistoryHandler handles GET /admin/comments/{comment_id}/edits.
 // Returns the chronological edit history (oldest first) plus the current body.
 func (h *CommentAdminHandler) AdminGetCommentEditHistoryHandler(ctx context.Context, req *AdminGetCommentEditHistoryRequest) (*AdminGetCommentEditHistoryResponse, error) {
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	commentID, err := strconv.ParseUint(req.CommentID, 10, 32)
 	if err != nil {

--- a/backend/internal/api/handlers/engagement/comment_admin_test.go
+++ b/backend/internal/api/handlers/engagement/comment_admin_test.go
@@ -31,23 +31,6 @@ func commentAdminUserCtx() context.Context {
 // Tests: Hide Comment — Auth & Validation
 // ============================================================================
 
-func TestAdminHideComment_RequiresAdmin(t *testing.T) {
-	h := testCommentAdminHandler()
-
-	t.Run("NoUser", func(t *testing.T) {
-		req := &AdminHideCommentRequest{CommentID: "1"}
-		req.Body.Reason = "spam"
-		_, err := h.AdminHideCommentHandler(context.Background(), req)
-		testhelpers.AssertHumaError(t, err, 403)
-	})
-	t.Run("NonAdmin", func(t *testing.T) {
-		req := &AdminHideCommentRequest{CommentID: "1"}
-		req.Body.Reason = "spam"
-		_, err := h.AdminHideCommentHandler(commentAdminUserCtx(), req)
-		testhelpers.AssertHumaError(t, err, 403)
-	})
-}
-
 func TestAdminHideComment_InvalidID(t *testing.T) {
 	h := testCommentAdminHandler()
 	req := &AdminHideCommentRequest{CommentID: "abc"}
@@ -103,19 +86,6 @@ func TestAdminHideComment_Success(t *testing.T) {
 // Tests: Restore Comment — Auth & Validation
 // ============================================================================
 
-func TestAdminRestoreComment_RequiresAdmin(t *testing.T) {
-	h := testCommentAdminHandler()
-
-	t.Run("NoUser", func(t *testing.T) {
-		_, err := h.AdminRestoreCommentHandler(context.Background(), &AdminRestoreCommentRequest{CommentID: "1"})
-		testhelpers.AssertHumaError(t, err, 403)
-	})
-	t.Run("NonAdmin", func(t *testing.T) {
-		_, err := h.AdminRestoreCommentHandler(commentAdminUserCtx(), &AdminRestoreCommentRequest{CommentID: "1"})
-		testhelpers.AssertHumaError(t, err, 403)
-	})
-}
-
 func TestAdminRestoreComment_InvalidID(t *testing.T) {
 	h := testCommentAdminHandler()
 	_, err := h.AdminRestoreCommentHandler(commentAdminAdminCtx(), &AdminRestoreCommentRequest{CommentID: "abc"})
@@ -169,19 +139,6 @@ func TestAdminRestoreComment_Success(t *testing.T) {
 // ============================================================================
 // Tests: List Pending Comments — Auth & Pagination
 // ============================================================================
-
-func TestAdminListPendingComments_RequiresAdmin(t *testing.T) {
-	h := testCommentAdminHandler()
-
-	t.Run("NoUser", func(t *testing.T) {
-		_, err := h.AdminListPendingCommentsHandler(context.Background(), &AdminListPendingCommentsRequest{})
-		testhelpers.AssertHumaError(t, err, 403)
-	})
-	t.Run("NonAdmin", func(t *testing.T) {
-		_, err := h.AdminListPendingCommentsHandler(commentAdminUserCtx(), &AdminListPendingCommentsRequest{})
-		testhelpers.AssertHumaError(t, err, 403)
-	})
-}
 
 func TestAdminListPendingComments_Success(t *testing.T) {
 	pendingComments := []*contracts.CommentResponse{
@@ -237,19 +194,6 @@ func TestAdminListPendingComments_ServiceError(t *testing.T) {
 // Tests: Approve Comment — Auth & Validation
 // ============================================================================
 
-func TestAdminApproveComment_RequiresAdmin(t *testing.T) {
-	h := testCommentAdminHandler()
-
-	t.Run("NoUser", func(t *testing.T) {
-		_, err := h.AdminApproveCommentHandler(context.Background(), &AdminApproveCommentRequest{CommentID: "1"})
-		testhelpers.AssertHumaError(t, err, 403)
-	})
-	t.Run("NonAdmin", func(t *testing.T) {
-		_, err := h.AdminApproveCommentHandler(commentAdminUserCtx(), &AdminApproveCommentRequest{CommentID: "1"})
-		testhelpers.AssertHumaError(t, err, 403)
-	})
-}
-
 func TestAdminApproveComment_InvalidID(t *testing.T) {
 	h := testCommentAdminHandler()
 	_, err := h.AdminApproveCommentHandler(commentAdminAdminCtx(), &AdminApproveCommentRequest{CommentID: "abc"})
@@ -303,23 +247,6 @@ func TestAdminApproveComment_Success(t *testing.T) {
 // ============================================================================
 // Tests: Reject Comment — Auth & Validation
 // ============================================================================
-
-func TestAdminRejectComment_RequiresAdmin(t *testing.T) {
-	h := testCommentAdminHandler()
-
-	t.Run("NoUser", func(t *testing.T) {
-		req := &AdminRejectCommentRequest{CommentID: "1"}
-		req.Body.Reason = "spam"
-		_, err := h.AdminRejectCommentHandler(context.Background(), req)
-		testhelpers.AssertHumaError(t, err, 403)
-	})
-	t.Run("NonAdmin", func(t *testing.T) {
-		req := &AdminRejectCommentRequest{CommentID: "1"}
-		req.Body.Reason = "spam"
-		_, err := h.AdminRejectCommentHandler(commentAdminUserCtx(), req)
-		testhelpers.AssertHumaError(t, err, 403)
-	})
-}
 
 func TestAdminRejectComment_InvalidID(t *testing.T) {
 	h := testCommentAdminHandler()
@@ -420,19 +347,6 @@ func TestCreateComment_HourlyLimitError(t *testing.T) {
 // ============================================================================
 // Tests: Admin Get Comment Edit History — Auth & Response (PSY-297)
 // ============================================================================
-
-func TestAdminGetCommentEditHistory_RequiresAdmin(t *testing.T) {
-	h := testCommentAdminHandler()
-
-	t.Run("NoUser", func(t *testing.T) {
-		_, err := h.AdminGetCommentEditHistoryHandler(context.Background(), &AdminGetCommentEditHistoryRequest{CommentID: "1"})
-		testhelpers.AssertHumaError(t, err, 403)
-	})
-	t.Run("NonAdmin", func(t *testing.T) {
-		_, err := h.AdminGetCommentEditHistoryHandler(commentAdminUserCtx(), &AdminGetCommentEditHistoryRequest{CommentID: "1"})
-		testhelpers.AssertHumaError(t, err, 403)
-	})
-}
 
 func TestAdminGetCommentEditHistory_InvalidID(t *testing.T) {
 	h := testCommentAdminHandler()

--- a/backend/internal/api/handlers/pipeline/admin_discovery.go
+++ b/backend/internal/api/handlers/pipeline/admin_discovery.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 
-	"psychic-homily-backend/internal/api/handlers/shared"
+	"psychic-homily-backend/internal/api/middleware"
 	"psychic-homily-backend/internal/logger"
 	catalogm "psychic-homily-backend/internal/models/catalog"
 	"psychic-homily-backend/internal/services/contracts"
@@ -63,10 +63,7 @@ type DiscoveryImportResponse struct {
 func (h *AdminDiscoveryHandler) DiscoveryImportHandler(ctx context.Context, req *DiscoveryImportRequest) (*DiscoveryImportResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	if len(req.Body.Events) == 0 {
 		return nil, huma.Error400BadRequest("At least one event is required")
@@ -159,10 +156,7 @@ type DiscoveryCheckResponse struct {
 func (h *AdminDiscoveryHandler) DiscoveryCheckHandler(ctx context.Context, req *DiscoveryCheckRequest) (*DiscoveryCheckResponse, error) {
 	requestID := logger.GetRequestID(ctx)
 
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	if len(req.Body.Events) == 0 {
 		return nil, huma.Error400BadRequest("At least one event is required")

--- a/backend/internal/api/handlers/pipeline/pipeline.go
+++ b/backend/internal/api/handlers/pipeline/pipeline.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 
-	"psychic-homily-backend/internal/api/handlers/shared"
+	"psychic-homily-backend/internal/api/middleware"
 	"psychic-homily-backend/internal/logger"
 	adminm "psychic-homily-backend/internal/models/admin"
 	"psychic-homily-backend/internal/services/contracts"
@@ -48,10 +48,7 @@ type ExtractVenueResponse struct {
 
 // ExtractVenueHandler handles POST /admin/pipeline/extract/{venue_id}
 func (h *PipelineHandler) ExtractVenueHandler(ctx context.Context, req *ExtractVenueRequest) (*ExtractVenueResponse, error) {
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	venueID, err := strconv.ParseUint(req.VenueID, 10, 64)
 	if err != nil {
@@ -111,10 +108,6 @@ type ListPipelineVenuesResponse struct {
 
 // ListPipelineVenuesHandler handles GET /admin/pipeline/venues
 func (h *PipelineHandler) ListPipelineVenuesHandler(ctx context.Context, req *ListPipelineVenuesRequest) (*ListPipelineVenuesResponse, error) {
-	_, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
 
 	configs, err := h.venueConfigService.ListConfigured()
 	if err != nil {
@@ -177,10 +170,6 @@ type VenueRejectionStatsResponse struct {
 
 // VenueRejectionStatsHandler handles GET /admin/pipeline/venues/{venue_id}/stats
 func (h *PipelineHandler) VenueRejectionStatsHandler(ctx context.Context, req *VenueRejectionStatsRequest) (*VenueRejectionStatsResponse, error) {
-	_, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
 
 	venueID, err := strconv.ParseUint(req.VenueID, 10, 64)
 	if err != nil {
@@ -219,10 +208,7 @@ type UpdateExtractionNotesResponse struct {
 
 // UpdateExtractionNotesHandler handles PATCH /admin/pipeline/venues/{venue_id}/notes
 func (h *PipelineHandler) UpdateExtractionNotesHandler(ctx context.Context, req *UpdateExtractionNotesRequest) (*UpdateExtractionNotesResponse, error) {
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	venueID, err := strconv.ParseUint(req.VenueID, 10, 64)
 	if err != nil {
@@ -271,10 +257,7 @@ type UpdateVenueConfigResponse struct {
 
 // UpdateVenueConfigHandler handles PUT /admin/pipeline/venues/{venue_id}/config
 func (h *PipelineHandler) UpdateVenueConfigHandler(ctx context.Context, req *UpdateVenueConfigRequest) (*UpdateVenueConfigResponse, error) {
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	venueID, err := strconv.ParseUint(req.VenueID, 10, 64)
 	if err != nil {
@@ -345,10 +328,6 @@ type GetVenueRunsResponse struct {
 
 // GetVenueRunsHandler handles GET /admin/pipeline/venues/{venue_id}/runs
 func (h *PipelineHandler) GetVenueRunsHandler(ctx context.Context, req *GetVenueRunsRequest) (*GetVenueRunsResponse, error) {
-	_, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
 
 	venueID, err := strconv.ParseUint(req.VenueID, 10, 64)
 	if err != nil {
@@ -393,10 +372,6 @@ type GetImportHistoryResponse struct {
 
 // GetImportHistoryHandler handles GET /admin/pipeline/imports
 func (h *PipelineHandler) GetImportHistoryHandler(ctx context.Context, req *GetImportHistoryRequest) (*GetImportHistoryResponse, error) {
-	_, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
 
 	imports, total, err := h.venueConfigService.GetAllRecentRuns(req.Limit, req.Offset)
 	if err != nil {
@@ -428,10 +403,7 @@ type ResetRenderMethodResponse struct {
 
 // ResetRenderMethodHandler handles POST /admin/pipeline/venues/{venue_id}/reset-render-method
 func (h *PipelineHandler) ResetRenderMethodHandler(ctx context.Context, req *ResetRenderMethodRequest) (*ResetRenderMethodResponse, error) {
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	venueID, err := strconv.ParseUint(req.VenueID, 10, 64)
 	if err != nil {
@@ -468,10 +440,6 @@ type EnrichmentStatusResponse struct {
 
 // EnrichmentStatusHandler handles GET /admin/pipeline/enrichment/status
 func (h *PipelineHandler) EnrichmentStatusHandler(ctx context.Context, req *EnrichmentStatusRequest) (*EnrichmentStatusResponse, error) {
-	_, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
 
 	stats, err := h.enrichmentService.GetQueueStats()
 	if err != nil {
@@ -499,10 +467,7 @@ type TriggerEnrichmentResponse struct {
 
 // TriggerEnrichmentHandler handles POST /admin/pipeline/enrichment/trigger/{show_id}
 func (h *PipelineHandler) TriggerEnrichmentHandler(ctx context.Context, req *TriggerEnrichmentRequest) (*TriggerEnrichmentResponse, error) {
-	user, err := shared.RequireAdmin(ctx)
-	if err != nil {
-		return nil, err
-	}
+	user := middleware.GetUserFromContext(ctx)
 
 	showID, err := strconv.ParseUint(req.ShowID, 10, 64)
 	if err != nil {

--- a/backend/internal/api/handlers/pipeline/pipeline_test.go
+++ b/backend/internal/api/handlers/pipeline/pipeline_test.go
@@ -32,59 +32,6 @@ func pipelineNonAdminCtx() context.Context {
 // Tests: Admin Guard
 // ============================================================================
 
-func TestPipelineHandler_RequiresAdmin(t *testing.T) {
-	h := testPipelineHandler()
-
-	tests := []struct {
-		name string
-		fn   func(ctx context.Context) error
-	}{
-		{"ExtractVenue", func(ctx context.Context) error {
-			_, err := h.ExtractVenueHandler(ctx, &ExtractVenueRequest{VenueID: "1"})
-			return err
-		}},
-		{"ListPipelineVenues", func(ctx context.Context) error {
-			_, err := h.ListPipelineVenuesHandler(ctx, &ListPipelineVenuesRequest{})
-			return err
-		}},
-		{"VenueRejectionStats", func(ctx context.Context) error {
-			_, err := h.VenueRejectionStatsHandler(ctx, &VenueRejectionStatsRequest{VenueID: "1"})
-			return err
-		}},
-		{"UpdateExtractionNotes", func(ctx context.Context) error {
-			_, err := h.UpdateExtractionNotesHandler(ctx, &UpdateExtractionNotesRequest{VenueID: "1"})
-			return err
-		}},
-		{"UpdateVenueConfig", func(ctx context.Context) error {
-			_, err := h.UpdateVenueConfigHandler(ctx, &UpdateVenueConfigRequest{VenueID: "1"})
-			return err
-		}},
-		{"GetVenueRuns", func(ctx context.Context) error {
-			_, err := h.GetVenueRunsHandler(ctx, &GetVenueRunsRequest{VenueID: "1"})
-			return err
-		}},
-		{"ResetRenderMethod", func(ctx context.Context) error {
-			_, err := h.ResetRenderMethodHandler(ctx, &ResetRenderMethodRequest{VenueID: "1"})
-			return err
-		}},
-		{"GetImportHistory", func(ctx context.Context) error {
-			_, err := h.GetImportHistoryHandler(ctx, &GetImportHistoryRequest{})
-			return err
-		}},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name+"_NoUser", func(t *testing.T) {
-			err := tc.fn(context.Background())
-			testhelpers.AssertHumaError(t, err, 403)
-		})
-		t.Run(tc.name+"_NonAdmin", func(t *testing.T) {
-			err := tc.fn(pipelineNonAdminCtx())
-			testhelpers.AssertHumaError(t, err, 403)
-		})
-	}
-}
-
 // ============================================================================
 // Tests: ExtractVenueHandler
 // ============================================================================
@@ -776,15 +723,6 @@ func TestPipelineHandler_EnrichmentStatus_Success(t *testing.T) {
 	}
 }
 
-func TestPipelineHandler_EnrichmentStatus_RequiresAdmin(t *testing.T) {
-	h := testPipelineHandler()
-	_, err := h.EnrichmentStatusHandler(context.Background(), &EnrichmentStatusRequest{})
-	testhelpers.AssertHumaError(t, err, 403)
-
-	_, err = h.EnrichmentStatusHandler(pipelineNonAdminCtx(), &EnrichmentStatusRequest{})
-	testhelpers.AssertHumaError(t, err, 403)
-}
-
 func TestPipelineHandler_EnrichmentStatus_ServiceError(t *testing.T) {
 	h := NewPipelineHandler(
 		&testhelpers.MockPipelineService{},
@@ -832,15 +770,6 @@ func TestPipelineHandler_TriggerEnrichment_Success(t *testing.T) {
 	if receivedType != "all" {
 		t.Errorf("expected type=all, got %s", receivedType)
 	}
-}
-
-func TestPipelineHandler_TriggerEnrichment_RequiresAdmin(t *testing.T) {
-	h := testPipelineHandler()
-	_, err := h.TriggerEnrichmentHandler(context.Background(), &TriggerEnrichmentRequest{ShowID: "1"})
-	testhelpers.AssertHumaError(t, err, 403)
-
-	_, err = h.TriggerEnrichmentHandler(pipelineNonAdminCtx(), &TriggerEnrichmentRequest{ShowID: "1"})
-	testhelpers.AssertHumaError(t, err, 403)
 }
 
 func TestPipelineHandler_TriggerEnrichment_InvalidShowID(t *testing.T) {

--- a/backend/internal/api/handlers/shared/helpers.go
+++ b/backend/internal/api/handlers/shared/helpers.go
@@ -18,6 +18,15 @@ import (
 
 // RequireAdmin verifies the request is from an admin user.
 // Returns the user on success, or a 403 Forbidden error.
+//
+// PSY-423: prefer registering admin-only endpoints on the rc.Admin Huma group
+// (which wires HumaAdminMiddleware) instead of calling this helper inline.
+// The middleware enforces the admin gate at the route level, makes the
+// admin scope visible in route declarations, and removes the policy from N
+// handlers down to one. This helper is retained for the rare conditional
+// callsite where neither rc.Protected nor rc.Admin fits — for example, an
+// endpoint that admits anonymous internal-service requests via an alternative
+// auth mechanism but otherwise requires admin (currently zero such callers).
 func RequireAdmin(ctx context.Context) (*authm.User, error) {
 	user := middleware.GetUserFromContext(ctx)
 	if user == nil || !user.IsAdmin {

--- a/backend/internal/api/middleware/admin.go
+++ b/backend/internal/api/middleware/admin.go
@@ -1,0 +1,83 @@
+package middleware
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	autherrors "psychic-homily-backend/internal/errors"
+	"psychic-homily-backend/internal/logger"
+)
+
+// AdminErrorResponse represents the error response for admin authorization failures.
+// Mirrors JWTErrorResponse so frontend code paths handling 401/403 are uniform.
+type AdminErrorResponse struct {
+	Success   bool   `json:"success"`
+	Message   string `json:"message"`
+	ErrorCode string `json:"error_code"`
+	RequestID string `json:"request_id,omitempty"`
+}
+
+// HumaAdminMiddleware enforces that the authenticated user has IsAdmin=true.
+// MUST be installed AFTER HumaJWTMiddleware (which populates the user in context);
+// otherwise no user will be present and every request will be rejected.
+//
+// Returns 403 Forbidden if the user is missing or not an admin. The response
+// shape matches JWT error responses so frontend handling is uniform.
+//
+// Pair with a Huma group whose middleware chain is JWT then Admin:
+//
+//	adminGroup := huma.NewGroup(api, "")
+//	adminGroup.UseMiddleware(middleware.HumaJWTMiddleware(...))
+//	adminGroup.UseMiddleware(middleware.HumaAdminMiddleware())
+//
+// Endpoints registered on adminGroup are gated at the route level — handlers
+// no longer need to call shared.RequireAdmin(ctx) (PSY-423).
+func HumaAdminMiddleware() func(ctx huma.Context, next func(huma.Context)) {
+	return func(ctx huma.Context, next func(huma.Context)) {
+		var requestID string
+		if id, ok := ctx.Context().Value(logger.RequestIDContextKey).(string); ok {
+			requestID = id
+		}
+
+		user := GetUserFromContext(ctx.Context())
+		if user == nil {
+			// JWT middleware should have rejected the request already; a nil
+			// user here means the admin group was wired without JWT upstream.
+			logger.FromContext(ctx.Context()).Warn("admin_middleware_no_user",
+				"path", ctx.URL().Path,
+				"request_id", requestID,
+			)
+			writeHumaAdminError(ctx, requestID, autherrors.CodeUnauthorized, "Authentication required")
+			return
+		}
+
+		if !user.IsAdmin {
+			logger.FromContext(ctx.Context()).Warn("admin_access_denied",
+				"user_id", user.ID,
+				"path", ctx.URL().Path,
+				"request_id", requestID,
+			)
+			writeHumaAdminError(ctx, requestID, autherrors.CodeUnauthorized, "Admin access required")
+			return
+		}
+
+		next(ctx)
+	}
+}
+
+// writeHumaAdminError writes a JSON 403 response for admin authorization failures.
+func writeHumaAdminError(ctx huma.Context, requestID, errorCode, message string) {
+	ctx.SetStatus(http.StatusForbidden)
+	ctx.SetHeader("Content-Type", "application/json")
+
+	resp := AdminErrorResponse{
+		Success:   false,
+		Message:   message,
+		ErrorCode: errorCode,
+		RequestID: requestID,
+	}
+	data, _ := json.Marshal(resp)
+	ctx.BodyWriter().Write(data)
+}

--- a/backend/internal/api/middleware/admin_test.go
+++ b/backend/internal/api/middleware/admin_test.go
@@ -1,0 +1,136 @@
+package middleware
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	authm "psychic-homily-backend/internal/models/auth"
+)
+
+// HumaAdminMiddleware tests
+//
+// PSY-423: this middleware enforces IsAdmin=true after JWTMiddleware has
+// populated the user. We test it independently of JWT — the contract is "if
+// the user in context isn't an admin, reject with 403".
+
+func TestHumaAdminMiddleware_NoUser_Returns403(t *testing.T) {
+	mw := HumaAdminMiddleware()
+	req := httptest.NewRequest(http.MethodGet, "/admin/test", nil)
+	ctx, rr := newHumaContext(t, req)
+
+	called := false
+	mw(ctx, func(huma.Context) { called = true })
+
+	if called {
+		t.Error("next() should not have been called for unauthenticated request")
+	}
+	if rr.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusForbidden)
+	}
+
+	var body AdminErrorResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to parse body: %v", err)
+	}
+	if body.Success {
+		t.Error("Success should be false")
+	}
+	if body.ErrorCode == "" {
+		t.Error("ErrorCode should be set")
+	}
+}
+
+func TestHumaAdminMiddleware_NonAdmin_Returns403(t *testing.T) {
+	mw := HumaAdminMiddleware()
+	req := httptest.NewRequest(http.MethodGet, "/admin/test", nil)
+	base, rr := newHumaContext(t, req)
+	user := &authm.User{IsAdmin: false}
+	user.ID = 42
+	ctx := huma.WithValue(base, UserContextKey, user)
+
+	called := false
+	mw(ctx, func(huma.Context) { called = true })
+
+	if called {
+		t.Error("next() should not have been called for non-admin user")
+	}
+	if rr.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusForbidden)
+	}
+
+	var body AdminErrorResponse
+	json.Unmarshal(rr.Body.Bytes(), &body)
+	if !contains(body.Message, "Admin") && !contains(body.Message, "admin") {
+		t.Errorf("Message should mention admin, got %q", body.Message)
+	}
+}
+
+func TestHumaAdminMiddleware_AdminUser_PassesThrough(t *testing.T) {
+	mw := HumaAdminMiddleware()
+	req := httptest.NewRequest(http.MethodGet, "/admin/test", nil)
+	base, rr := newHumaContext(t, req)
+	user := &authm.User{IsAdmin: true}
+	user.ID = 1
+	ctx := huma.WithValue(base, UserContextKey, user)
+
+	var capturedUser *authm.User
+	called := false
+	mw(ctx, func(next huma.Context) {
+		called = true
+		if u, ok := next.Context().Value(UserContextKey).(*authm.User); ok {
+			capturedUser = u
+		}
+	})
+
+	if !called {
+		t.Fatal("next() should have been called for admin user")
+	}
+	if rr.Code != 0 && rr.Code != http.StatusOK {
+		// SetStatus is not called by the middleware on the success path; the
+		// recorder default is 200 once Write is called. Either is acceptable.
+		t.Errorf("status = %d, expected 0 (unset) or 200", rr.Code)
+	}
+	if capturedUser == nil {
+		t.Fatal("user should be propagated to next handler")
+	}
+	if !capturedUser.IsAdmin {
+		t.Error("admin flag should be preserved")
+	}
+	if capturedUser.ID != 1 {
+		t.Errorf("user ID = %d, want 1", capturedUser.ID)
+	}
+}
+
+// TestHumaAdminMiddleware_RequestIDPropagated checks that the error response
+// echoes the request ID so the frontend / Sentry can correlate.
+func TestHumaAdminMiddleware_RequestIDPropagated(t *testing.T) {
+	mw := HumaAdminMiddleware()
+	req := httptest.NewRequest(http.MethodGet, "/admin/test", nil)
+	ctx, rr := newHumaContextWithRequestID(t, req, "req-admin-7")
+
+	mw(ctx, func(huma.Context) { t.Error("next() should not run") })
+
+	var body AdminErrorResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("parse body: %v", err)
+	}
+	if body.RequestID != "req-admin-7" {
+		t.Errorf("RequestID = %q, want req-admin-7", body.RequestID)
+	}
+}
+
+func contains(haystack, needle string) bool {
+	if len(needle) == 0 {
+		return true
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/api/routes/admin.go
+++ b/backend/internal/api/routes/admin.go
@@ -8,8 +8,9 @@ import (
 	pipelineh "psychic-homily-backend/internal/api/handlers/pipeline"
 )
 
-// setupAdminRoutes configures admin-only endpoints
-// Note: Admin check is performed inside handlers, JWT auth is required via protected group
+// setupAdminRoutes configures admin-only endpoints.
+// PSY-423: registered on rc.Admin so the admin gate is enforced by
+// HumaAdminMiddleware at the route level — handlers do not call RequireAdmin.
 func setupAdminRoutes(rc RouteContext) {
 	// Domain-specific admin handlers
 	statsHandler := adminh.NewAdminStatsHandler(rc.SC.AdminStats)
@@ -27,74 +28,78 @@ func setupAdminRoutes(rc RouteContext) {
 	auditLogHandler := adminh.NewAuditLogHandler(rc.SC.AuditLog)
 
 	// Admin dashboard stats endpoint
-	huma.Get(rc.Protected, "/admin/stats", statsHandler.GetAdminStatsHandler)
-	huma.Get(rc.Protected, "/admin/activity", statsHandler.GetActivityFeedHandler)
+	huma.Get(rc.Admin, "/admin/stats", statsHandler.GetAdminStatsHandler)
+	huma.Get(rc.Admin, "/admin/activity", statsHandler.GetActivityFeedHandler)
 
 	// Admin show listing endpoint (for CLI export)
-	huma.Get(rc.Protected, "/admin/shows", showHandler.GetAdminShowsHandler)
+	huma.Get(rc.Admin, "/admin/shows", showHandler.GetAdminShowsHandler)
 
 	// Admin show management endpoints
-	huma.Get(rc.Protected, "/admin/shows/pending", showHandler.GetPendingShowsHandler)
-	huma.Get(rc.Protected, "/admin/shows/rejected", showHandler.GetRejectedShowsHandler)
-	huma.Post(rc.Protected, "/admin/shows/{show_id}/approve", showHandler.ApproveShowHandler)
-	huma.Post(rc.Protected, "/admin/shows/{show_id}/reject", showHandler.RejectShowHandler)
-	huma.Post(rc.Protected, "/admin/shows/batch-approve", showHandler.BatchApproveShowsHandler)
-	huma.Post(rc.Protected, "/admin/shows/batch-reject", showHandler.BatchRejectShowsHandler)
+	huma.Get(rc.Admin, "/admin/shows/pending", showHandler.GetPendingShowsHandler)
+	huma.Get(rc.Admin, "/admin/shows/rejected", showHandler.GetRejectedShowsHandler)
+	huma.Post(rc.Admin, "/admin/shows/{show_id}/approve", showHandler.ApproveShowHandler)
+	huma.Post(rc.Admin, "/admin/shows/{show_id}/reject", showHandler.RejectShowHandler)
+	huma.Post(rc.Admin, "/admin/shows/batch-approve", showHandler.BatchApproveShowsHandler)
+	huma.Post(rc.Admin, "/admin/shows/batch-reject", showHandler.BatchRejectShowsHandler)
 
 	// Admin show import endpoints (single)
-	huma.Post(rc.Protected, "/admin/shows/import/preview", showHandler.ImportShowPreviewHandler)
-	huma.Post(rc.Protected, "/admin/shows/import/confirm", showHandler.ImportShowConfirmHandler)
+	huma.Post(rc.Admin, "/admin/shows/import/preview", showHandler.ImportShowPreviewHandler)
+	huma.Post(rc.Admin, "/admin/shows/import/confirm", showHandler.ImportShowConfirmHandler)
 
 	// Admin show export/import endpoints (bulk - for CLI)
-	huma.Post(rc.Protected, "/admin/shows/export/bulk", showHandler.BulkExportShowsHandler)
-	huma.Post(rc.Protected, "/admin/shows/import/bulk/preview", showHandler.BulkImportPreviewHandler)
-	huma.Post(rc.Protected, "/admin/shows/import/bulk/confirm", showHandler.BulkImportConfirmHandler)
+	huma.Post(rc.Admin, "/admin/shows/export/bulk", showHandler.BulkExportShowsHandler)
+	huma.Post(rc.Admin, "/admin/shows/import/bulk/preview", showHandler.BulkImportPreviewHandler)
+	huma.Post(rc.Admin, "/admin/shows/import/bulk/confirm", showHandler.BulkImportConfirmHandler)
 
 	// Admin venue management endpoints
-	huma.Get(rc.Protected, "/admin/venues/unverified", venueHandler.GetUnverifiedVenuesHandler)
-	huma.Post(rc.Protected, "/admin/venues/{venue_id}/verify", venueHandler.VerifyVenueHandler)
+	huma.Get(rc.Admin, "/admin/venues/unverified", venueHandler.GetUnverifiedVenuesHandler)
+	huma.Post(rc.Admin, "/admin/venues/{venue_id}/verify", venueHandler.VerifyVenueHandler)
 
-	// Admin artist management endpoints
+	// Admin artist management endpoints — STAY on rc.Protected because they
+	// support an X-Internal-Secret bypass for the automated discovery service
+	// (no user context). Handler enforces admin OR internal-secret. Do not
+	// migrate to rc.Admin without first refactoring the internal-service auth
+	// path.
 	huma.Patch(rc.Protected, "/admin/artists/{artist_id}/bandcamp", artistHandler.UpdateArtistBandcampHandler)
 	huma.Patch(rc.Protected, "/admin/artists/{artist_id}/spotify", artistHandler.UpdateArtistSpotifyHandler)
 
 	// Admin discovery endpoints (for local discovery app)
-	huma.Post(rc.Protected, "/admin/discovery/import", discoveryHandler.DiscoveryImportHandler)
-	huma.Post(rc.Protected, "/admin/discovery/check", discoveryHandler.DiscoveryCheckHandler)
+	huma.Post(rc.Admin, "/admin/discovery/import", discoveryHandler.DiscoveryImportHandler)
+	huma.Post(rc.Admin, "/admin/discovery/check", discoveryHandler.DiscoveryCheckHandler)
 
 	// Admin API token management endpoints
-	huma.Post(rc.Protected, "/admin/tokens", tokenHandler.CreateAPITokenHandler)
-	huma.Get(rc.Protected, "/admin/tokens", tokenHandler.ListAPITokensHandler)
-	huma.Delete(rc.Protected, "/admin/tokens/{token_id}", tokenHandler.RevokeAPITokenHandler)
+	huma.Post(rc.Admin, "/admin/tokens", tokenHandler.CreateAPITokenHandler)
+	huma.Get(rc.Admin, "/admin/tokens", tokenHandler.ListAPITokensHandler)
+	huma.Delete(rc.Admin, "/admin/tokens/{token_id}", tokenHandler.RevokeAPITokenHandler)
 
 	// Admin data export endpoints (for syncing local data to Stage/Production)
-	huma.Get(rc.Protected, "/admin/export/shows", dataHandler.ExportShowsHandler)
-	huma.Get(rc.Protected, "/admin/export/artists", dataHandler.ExportArtistsHandler)
-	huma.Get(rc.Protected, "/admin/export/venues", dataHandler.ExportVenuesHandler)
+	huma.Get(rc.Admin, "/admin/export/shows", dataHandler.ExportShowsHandler)
+	huma.Get(rc.Admin, "/admin/export/artists", dataHandler.ExportArtistsHandler)
+	huma.Get(rc.Admin, "/admin/export/venues", dataHandler.ExportVenuesHandler)
 
 	// Admin data import endpoint (for syncing local data to Stage/Production)
-	huma.Post(rc.Protected, "/admin/data/import", dataHandler.DataImportHandler)
+	huma.Post(rc.Admin, "/admin/data/import", dataHandler.DataImportHandler)
 
 	// Admin audit log endpoint
-	huma.Get(rc.Protected, "/admin/audit-logs", auditLogHandler.GetAuditLogsHandler)
+	huma.Get(rc.Admin, "/admin/audit-logs", auditLogHandler.GetAuditLogsHandler)
 
 	// Admin user list endpoint
-	huma.Get(rc.Protected, "/admin/users", userHandler.GetAdminUsersHandler)
+	huma.Get(rc.Admin, "/admin/users", userHandler.GetAdminUsersHandler)
 
 	// Admin data quality endpoints
 	dataQualityHandler := adminh.NewDataQualityHandler(rc.SC.DataQuality)
-	huma.Get(rc.Protected, "/admin/data-quality", dataQualityHandler.GetDataQualitySummaryHandler)
-	huma.Get(rc.Protected, "/admin/data-quality/{category}", dataQualityHandler.GetDataQualityCategoryHandler)
+	huma.Get(rc.Admin, "/admin/data-quality", dataQualityHandler.GetDataQualitySummaryHandler)
+	huma.Get(rc.Admin, "/admin/data-quality/{category}", dataQualityHandler.GetDataQualityCategoryHandler)
 
 	// Admin auto-promotion endpoints (manual trigger for tier evaluation)
 	autoPromotionHandler := adminh.NewAutoPromotionHandler(rc.SC.AutoPromotion)
-	huma.Post(rc.Protected, "/admin/auto-promotion/evaluate", autoPromotionHandler.EvaluateAllUsersHandler)
-	huma.Get(rc.Protected, "/admin/auto-promotion/evaluate/{user_id}", autoPromotionHandler.EvaluateUserHandler)
+	huma.Post(rc.Admin, "/admin/auto-promotion/evaluate", autoPromotionHandler.EvaluateAllUsersHandler)
+	huma.Get(rc.Admin, "/admin/auto-promotion/evaluate/{user_id}", autoPromotionHandler.EvaluateUserHandler)
 
 	// Admin analytics endpoints
 	analyticsHandler := adminh.NewAnalyticsHandler(rc.SC.Analytics)
-	huma.Get(rc.Protected, "/admin/analytics/growth", analyticsHandler.GetGrowthMetricsHandler)
-	huma.Get(rc.Protected, "/admin/analytics/engagement", analyticsHandler.GetEngagementMetricsHandler)
-	huma.Get(rc.Protected, "/admin/analytics/community", analyticsHandler.GetCommunityHealthHandler)
-	huma.Get(rc.Protected, "/admin/analytics/data-quality", analyticsHandler.GetDataQualityTrendsHandler)
+	huma.Get(rc.Admin, "/admin/analytics/growth", analyticsHandler.GetGrowthMetricsHandler)
+	huma.Get(rc.Admin, "/admin/analytics/engagement", analyticsHandler.GetEngagementMetricsHandler)
+	huma.Get(rc.Admin, "/admin/analytics/community", analyticsHandler.GetCommunityHealthHandler)
+	huma.Get(rc.Admin, "/admin/analytics/data-quality", analyticsHandler.GetDataQualityTrendsHandler)
 }

--- a/backend/internal/api/routes/admin_group_test.go
+++ b/backend/internal/api/routes/admin_group_test.go
@@ -1,0 +1,113 @@
+package routes
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/humatest"
+
+	"psychic-homily-backend/internal/api/middleware"
+	authm "psychic-homily-backend/internal/models/auth"
+)
+
+// PSY-423: integration test for the rc.Admin route group.
+//
+// Wires HumaAdminMiddleware on a Huma group exactly like routes.go does in
+// production, registers a sentinel /admin/test-only route, and asserts:
+//   - non-admin user → 403, handler NOT entered
+//   - missing user (unauth) → 403, handler NOT entered
+//   - admin user → 200, handler entered
+//
+// This guards the move from inline shared.RequireAdmin(ctx) to route-level
+// enforcement: if a future PR forgets to install HumaAdminMiddleware on the
+// admin group, the test fails. We bypass real JWT here — the contract under
+// test is the admin group, not JWT itself (covered in middleware/jwt_test.go).
+
+type adminGroupTestRequest struct{}
+type adminGroupTestResponse struct {
+	Body struct {
+		Message string `json:"message"`
+	}
+}
+
+// buildAdminGroupTestAPI returns a humatest.TestAPI wired with:
+//
+//	userInjector → HumaAdminMiddleware → sentinel handler
+//
+// The userInjector translates the X-Test-User header ("admin", "user", or
+// missing) into a context user, mimicking what JWT middleware would do.
+func buildAdminGroupTestAPI(t *testing.T, handlerCalled *bool) humatest.TestAPI {
+	t.Helper()
+
+	_, api := humatest.New(t, huma.DefaultConfig("test-admin-group", "1.0.0"))
+
+	userInjector := func(ctx huma.Context, next func(huma.Context)) {
+		switch ctx.Header("X-Test-User") {
+		case "admin":
+			u := &authm.User{IsAdmin: true}
+			u.ID = 1
+			next(huma.WithValue(ctx, middleware.UserContextKey, u))
+		case "user":
+			u := &authm.User{IsAdmin: false}
+			u.ID = 2
+			next(huma.WithValue(ctx, middleware.UserContextKey, u))
+		default:
+			// no header → no user, exactly like an unauthenticated request
+			next(ctx)
+		}
+	}
+
+	adminGroup := huma.NewGroup(api, "")
+	adminGroup.UseMiddleware(userInjector)
+	adminGroup.UseMiddleware(middleware.HumaAdminMiddleware())
+
+	huma.Register(adminGroup, huma.Operation{
+		OperationID: "test-admin-only",
+		Method:      http.MethodGet,
+		Path:        "/admin/test-only",
+	}, func(_ context.Context, _ *adminGroupTestRequest) (*adminGroupTestResponse, error) {
+		*handlerCalled = true
+		out := &adminGroupTestResponse{}
+		out.Body.Message = "ok"
+		return out, nil
+	})
+
+	return api
+}
+
+func TestAdminGroup_NonAdmin_Returns403(t *testing.T) {
+	tests := []struct {
+		name           string
+		userHeader     string
+		wantStatus     int
+		wantHandlerHit bool
+	}{
+		{name: "no_user", userHeader: "", wantStatus: http.StatusForbidden, wantHandlerHit: false},
+		{name: "non_admin", userHeader: "user", wantStatus: http.StatusForbidden, wantHandlerHit: false},
+		{name: "admin", userHeader: "admin", wantStatus: http.StatusOK, wantHandlerHit: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			handlerCalled := false
+			api := buildAdminGroupTestAPI(t, &handlerCalled)
+
+			args := []any{}
+			if tc.userHeader != "" {
+				args = append(args, "X-Test-User: "+tc.userHeader)
+			}
+			resp := api.Get("/admin/test-only", args...)
+
+			if resp.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d (body: %s)",
+					resp.Code, tc.wantStatus, resp.Body.String())
+			}
+			if handlerCalled != tc.wantHandlerHit {
+				t.Fatalf("handlerCalled = %v, want %v — admin gate did not behave as expected",
+					handlerCalled, tc.wantHandlerHit)
+			}
+		})
+	}
+}

--- a/backend/internal/api/routes/artist_relationships.go
+++ b/backend/internal/api/routes/artist_relationships.go
@@ -23,9 +23,9 @@ func setupArtistRelationshipRoutes(rc RouteContext) {
 	huma.Post(rc.Protected, "/artists/relationships/{source_id}/{target_id}/vote", relHandler.VoteHandler)
 	huma.Delete(rc.Protected, "/artists/relationships/{source_id}/{target_id}/vote", relHandler.RemoveVoteHandler)
 
-	// Admin: delete relationships
-	huma.Delete(rc.Protected, "/artists/relationships/{source_id}/{target_id}", relHandler.DeleteRelationshipHandler)
+	// Admin: delete relationships (PSY-423: route-gated by HumaAdminMiddleware)
+	huma.Delete(rc.Admin, "/artists/relationships/{source_id}/{target_id}", relHandler.DeleteRelationshipHandler)
 
-	// Admin: trigger relationship derivation
-	huma.Post(rc.Protected, "/admin/artist-relationships/derive", relHandler.DeriveRelationshipsHandler)
+	// Admin: trigger relationship derivation (PSY-423: route-gated by HumaAdminMiddleware)
+	huma.Post(rc.Admin, "/admin/artist-relationships/derive", relHandler.DeriveRelationshipsHandler)
 }

--- a/backend/internal/api/routes/artists.go
+++ b/backend/internal/api/routes/artists.go
@@ -19,11 +19,13 @@ func setupArtistRoutes(rc RouteContext) {
 	huma.Get(rc.API, "/artists/{artist_id}/labels", artistHandler.GetArtistLabelsHandler)
 	huma.Get(rc.API, "/artists/{artist_id}/aliases", artistHandler.GetArtistAliasesHandler)
 
-	// Protected artist endpoints
+	// Protected artist endpoints (any authenticated user)
 	huma.Delete(rc.Protected, "/artists/{artist_id}", artistHandler.DeleteArtistHandler)
-	huma.Post(rc.Protected, "/admin/artists", artistHandler.AdminCreateArtistHandler)
-	huma.Patch(rc.Protected, "/admin/artists/{artist_id}", artistHandler.AdminUpdateArtistHandler)
-	huma.Post(rc.Protected, "/admin/artists/{artist_id}/aliases", artistHandler.AddArtistAliasHandler)
-	huma.Delete(rc.Protected, "/admin/artists/{artist_id}/aliases/{alias_id}", artistHandler.DeleteArtistAliasHandler)
-	huma.Post(rc.Protected, "/admin/artists/merge", artistHandler.MergeArtistsHandler)
+
+	// Admin-only artist endpoints (PSY-423: route-gated by HumaAdminMiddleware)
+	huma.Post(rc.Admin, "/admin/artists", artistHandler.AdminCreateArtistHandler)
+	huma.Patch(rc.Admin, "/admin/artists/{artist_id}", artistHandler.AdminUpdateArtistHandler)
+	huma.Post(rc.Admin, "/admin/artists/{artist_id}/aliases", artistHandler.AddArtistAliasHandler)
+	huma.Delete(rc.Admin, "/admin/artists/{artist_id}/aliases/{alias_id}", artistHandler.DeleteArtistAliasHandler)
+	huma.Post(rc.Admin, "/admin/artists/merge", artistHandler.MergeArtistsHandler)
 }

--- a/backend/internal/api/routes/collections.go
+++ b/backend/internal/api/routes/collections.go
@@ -78,11 +78,10 @@ func setupCollectionRoutes(rc RouteContext) {
 	huma.Post(rc.Protected, "/crates/{slug}/tags", collectionHandler.AddCollectionTagHandler)
 	huma.Delete(rc.Protected, "/crates/{slug}/tags/{tag_id}", collectionHandler.RemoveCollectionTagHandler)
 
-	// Admin: feature/unfeature collections — canonical /collections/ paths
-	huma.Put(rc.Protected, "/collections/{slug}/feature", collectionHandler.SetFeaturedHandler)
-
-	// Admin: feature/unfeature collections — legacy /crates/ paths (backward compat)
-	huma.Put(rc.Protected, "/crates/{slug}/feature", collectionHandler.SetFeaturedHandler)
+	// Admin-only: feature/unfeature collections (PSY-423: route-gated by HumaAdminMiddleware).
+	huma.Put(rc.Admin, "/collections/{slug}/feature", collectionHandler.SetFeaturedHandler)
+	// Legacy /crates/ path (backward compat).
+	huma.Put(rc.Admin, "/crates/{slug}/feature", collectionHandler.SetFeaturedHandler)
 
 	// Entity collections — public, find collections containing a given entity
 	huma.Get(optionalAuthGroup, "/collections/entity/{entity_type}/{entity_id}", collectionHandler.GetEntityCollectionsHandler)

--- a/backend/internal/api/routes/comments.go
+++ b/backend/internal/api/routes/comments.go
@@ -30,16 +30,16 @@ func setupCommentRoutes(rc RouteContext) {
 	// PSY-296: owner-only reply-permission toggle.
 	huma.Put(rc.Protected, "/comments/{comment_id}/reply-permission", commentHandler.UpdateReplyPermissionHandler)
 
-	// Admin: comment moderation
+	// Admin: comment moderation (PSY-423: route-gated by HumaAdminMiddleware)
 	// NOTE: literal paths MUST be registered before parameterized paths to avoid
 	// {comment_id} consuming "pending" as a value and returning 404.
-	huma.Get(rc.Protected, "/admin/comments/pending", commentAdminHandler.AdminListPendingCommentsHandler)
-	huma.Post(rc.Protected, "/admin/comments/{comment_id}/hide", commentAdminHandler.AdminHideCommentHandler)
-	huma.Post(rc.Protected, "/admin/comments/{comment_id}/restore", commentAdminHandler.AdminRestoreCommentHandler)
-	huma.Post(rc.Protected, "/admin/comments/{comment_id}/approve", commentAdminHandler.AdminApproveCommentHandler)
-	huma.Post(rc.Protected, "/admin/comments/{comment_id}/reject", commentAdminHandler.AdminRejectCommentHandler)
+	huma.Get(rc.Admin, "/admin/comments/pending", commentAdminHandler.AdminListPendingCommentsHandler)
+	huma.Post(rc.Admin, "/admin/comments/{comment_id}/hide", commentAdminHandler.AdminHideCommentHandler)
+	huma.Post(rc.Admin, "/admin/comments/{comment_id}/restore", commentAdminHandler.AdminRestoreCommentHandler)
+	huma.Post(rc.Admin, "/admin/comments/{comment_id}/approve", commentAdminHandler.AdminApproveCommentHandler)
+	huma.Post(rc.Admin, "/admin/comments/{comment_id}/reject", commentAdminHandler.AdminRejectCommentHandler)
 	// Admin: edit history viewer (PSY-297)
-	huma.Get(rc.Protected, "/admin/comments/{comment_id}/edits", commentAdminHandler.AdminGetCommentEditHistoryHandler)
+	huma.Get(rc.Admin, "/admin/comments/{comment_id}/edits", commentAdminHandler.AdminGetCommentEditHistoryHandler)
 }
 
 // setupCommentVoteRoutes configures comment voting endpoints.

--- a/backend/internal/api/routes/festivals.go
+++ b/backend/internal/api/routes/festivals.go
@@ -26,13 +26,13 @@ func setupFestivalRoutes(rc RouteContext) {
 	huma.Get(rc.API, "/artists/{artist_id}/festival-trajectory", intelHandler.GetArtistFestivalTrajectoryHandler)
 	huma.Get(rc.API, "/festivals/series/{series_slug}/compare", intelHandler.GetSeriesComparisonHandler)
 
-	// Protected festival endpoints (admin-only checks inside handlers)
-	huma.Post(rc.Protected, "/festivals", festivalHandler.CreateFestivalHandler)
-	huma.Put(rc.Protected, "/festivals/{festival_id}", festivalHandler.UpdateFestivalHandler)
-	huma.Delete(rc.Protected, "/festivals/{festival_id}", festivalHandler.DeleteFestivalHandler)
-	huma.Post(rc.Protected, "/festivals/{festival_id}/artists", festivalHandler.AddFestivalArtistHandler)
-	huma.Put(rc.Protected, "/festivals/{festival_id}/artists/{artist_id}", festivalHandler.UpdateFestivalArtistHandler)
-	huma.Delete(rc.Protected, "/festivals/{festival_id}/artists/{artist_id}", festivalHandler.RemoveFestivalArtistHandler)
-	huma.Post(rc.Protected, "/festivals/{festival_id}/venues", festivalHandler.AddFestivalVenueHandler)
-	huma.Delete(rc.Protected, "/festivals/{festival_id}/venues/{venue_id}", festivalHandler.RemoveFestivalVenueHandler)
+	// Admin-only festival endpoints (PSY-423: route-gated by HumaAdminMiddleware).
+	huma.Post(rc.Admin, "/festivals", festivalHandler.CreateFestivalHandler)
+	huma.Put(rc.Admin, "/festivals/{festival_id}", festivalHandler.UpdateFestivalHandler)
+	huma.Delete(rc.Admin, "/festivals/{festival_id}", festivalHandler.DeleteFestivalHandler)
+	huma.Post(rc.Admin, "/festivals/{festival_id}/artists", festivalHandler.AddFestivalArtistHandler)
+	huma.Put(rc.Admin, "/festivals/{festival_id}/artists/{artist_id}", festivalHandler.UpdateFestivalArtistHandler)
+	huma.Delete(rc.Admin, "/festivals/{festival_id}/artists/{artist_id}", festivalHandler.RemoveFestivalArtistHandler)
+	huma.Post(rc.Admin, "/festivals/{festival_id}/venues", festivalHandler.AddFestivalVenueHandler)
+	huma.Delete(rc.Admin, "/festivals/{festival_id}/venues/{venue_id}", festivalHandler.RemoveFestivalVenueHandler)
 }

--- a/backend/internal/api/routes/labels.go
+++ b/backend/internal/api/routes/labels.go
@@ -17,10 +17,12 @@ func setupLabelRoutes(rc RouteContext) {
 	huma.Get(rc.API, "/labels/{label_id}/artists", labelHandler.GetLabelRosterHandler)
 	huma.Get(rc.API, "/labels/{label_id}/releases", labelHandler.GetLabelCatalogHandler)
 
-	// Protected label endpoints (admin-only checks inside handlers)
-	huma.Post(rc.Protected, "/labels", labelHandler.CreateLabelHandler)
-	huma.Put(rc.Protected, "/labels/{label_id}", labelHandler.UpdateLabelHandler)
-	huma.Delete(rc.Protected, "/labels/{label_id}", labelHandler.DeleteLabelHandler)
-	huma.Post(rc.Protected, "/admin/labels/{label_id}/artists", labelHandler.AddArtistToLabelHandler)
-	huma.Post(rc.Protected, "/admin/labels/{label_id}/releases", labelHandler.AddReleaseToLabelHandler)
+	// Admin-only label endpoints (PSY-423: route-gated by HumaAdminMiddleware).
+	// Non-admins must use the pending-edit flow (suggest-edit) which routes
+	// through community/pending_entity_edits.
+	huma.Post(rc.Admin, "/labels", labelHandler.CreateLabelHandler)
+	huma.Put(rc.Admin, "/labels/{label_id}", labelHandler.UpdateLabelHandler)
+	huma.Delete(rc.Admin, "/labels/{label_id}", labelHandler.DeleteLabelHandler)
+	huma.Post(rc.Admin, "/admin/labels/{label_id}/artists", labelHandler.AddArtistToLabelHandler)
+	huma.Post(rc.Admin, "/admin/labels/{label_id}/releases", labelHandler.AddReleaseToLabelHandler)
 }

--- a/backend/internal/api/routes/pending_edits.go
+++ b/backend/internal/api/routes/pending_edits.go
@@ -23,10 +23,10 @@ func setupPendingEditRoutes(rc RouteContext) {
 	huma.Get(rc.Protected, "/my/pending-edits", pendingEditHandler.GetMyPendingEditsHandler)
 	huma.Delete(rc.Protected, "/my/pending-edits/{edit_id}", pendingEditHandler.CancelMyPendingEditHandler)
 
-	// Admin: review queue
-	huma.Get(rc.Protected, "/admin/pending-edits", pendingEditHandler.AdminListPendingEditsHandler)
-	huma.Get(rc.Protected, "/admin/pending-edits/{edit_id}", pendingEditHandler.AdminGetPendingEditHandler)
-	huma.Post(rc.Protected, "/admin/pending-edits/{edit_id}/approve", pendingEditHandler.AdminApprovePendingEditHandler)
-	huma.Post(rc.Protected, "/admin/pending-edits/{edit_id}/reject", pendingEditHandler.AdminRejectPendingEditHandler)
-	huma.Get(rc.Protected, "/admin/pending-edits/entity/{entity_type}/{entity_id}", pendingEditHandler.AdminGetEntityPendingEditsHandler)
+	// Admin-only: review queue (PSY-423: route-gated by HumaAdminMiddleware)
+	huma.Get(rc.Admin, "/admin/pending-edits", pendingEditHandler.AdminListPendingEditsHandler)
+	huma.Get(rc.Admin, "/admin/pending-edits/{edit_id}", pendingEditHandler.AdminGetPendingEditHandler)
+	huma.Post(rc.Admin, "/admin/pending-edits/{edit_id}/approve", pendingEditHandler.AdminApprovePendingEditHandler)
+	huma.Post(rc.Admin, "/admin/pending-edits/{edit_id}/reject", pendingEditHandler.AdminRejectPendingEditHandler)
+	huma.Get(rc.Admin, "/admin/pending-edits/entity/{entity_type}/{entity_id}", pendingEditHandler.AdminGetEntityPendingEditsHandler)
 }

--- a/backend/internal/api/routes/pipeline.go
+++ b/backend/internal/api/routes/pipeline.go
@@ -7,18 +7,19 @@ import (
 )
 
 // setupPipelineRoutes configures AI extraction pipeline admin endpoints.
-// Admin check is performed inside handlers, JWT auth is required via protected group.
+// PSY-423: registered on rc.Admin so the admin gate is enforced by
+// HumaAdminMiddleware at the route level — handlers do not call RequireAdmin.
 func setupPipelineRoutes(rc RouteContext) {
 	pipelineHandler := pipelineh.NewPipelineHandler(rc.SC.Pipeline, rc.SC.VenueSourceConfig, rc.SC.Enrichment)
 
-	huma.Post(rc.Protected, "/admin/pipeline/extract/{venue_id}", pipelineHandler.ExtractVenueHandler)
-	huma.Get(rc.Protected, "/admin/pipeline/imports", pipelineHandler.GetImportHistoryHandler)
-	huma.Get(rc.Protected, "/admin/pipeline/venues", pipelineHandler.ListPipelineVenuesHandler)
-	huma.Get(rc.Protected, "/admin/pipeline/venues/{venue_id}/stats", pipelineHandler.VenueRejectionStatsHandler)
-	huma.Patch(rc.Protected, "/admin/pipeline/venues/{venue_id}/notes", pipelineHandler.UpdateExtractionNotesHandler)
-	huma.Put(rc.Protected, "/admin/pipeline/venues/{venue_id}/config", pipelineHandler.UpdateVenueConfigHandler)
-	huma.Get(rc.Protected, "/admin/pipeline/venues/{venue_id}/runs", pipelineHandler.GetVenueRunsHandler)
-	huma.Post(rc.Protected, "/admin/pipeline/venues/{venue_id}/reset-render-method", pipelineHandler.ResetRenderMethodHandler)
-	huma.Get(rc.Protected, "/admin/pipeline/enrichment/status", pipelineHandler.EnrichmentStatusHandler)
-	huma.Post(rc.Protected, "/admin/pipeline/enrichment/trigger/{show_id}", pipelineHandler.TriggerEnrichmentHandler)
+	huma.Post(rc.Admin, "/admin/pipeline/extract/{venue_id}", pipelineHandler.ExtractVenueHandler)
+	huma.Get(rc.Admin, "/admin/pipeline/imports", pipelineHandler.GetImportHistoryHandler)
+	huma.Get(rc.Admin, "/admin/pipeline/venues", pipelineHandler.ListPipelineVenuesHandler)
+	huma.Get(rc.Admin, "/admin/pipeline/venues/{venue_id}/stats", pipelineHandler.VenueRejectionStatsHandler)
+	huma.Patch(rc.Admin, "/admin/pipeline/venues/{venue_id}/notes", pipelineHandler.UpdateExtractionNotesHandler)
+	huma.Put(rc.Admin, "/admin/pipeline/venues/{venue_id}/config", pipelineHandler.UpdateVenueConfigHandler)
+	huma.Get(rc.Admin, "/admin/pipeline/venues/{venue_id}/runs", pipelineHandler.GetVenueRunsHandler)
+	huma.Post(rc.Admin, "/admin/pipeline/venues/{venue_id}/reset-render-method", pipelineHandler.ResetRenderMethodHandler)
+	huma.Get(rc.Admin, "/admin/pipeline/enrichment/status", pipelineHandler.EnrichmentStatusHandler)
+	huma.Post(rc.Admin, "/admin/pipeline/enrichment/trigger/{show_id}", pipelineHandler.TriggerEnrichmentHandler)
 }

--- a/backend/internal/api/routes/radio.go
+++ b/backend/internal/api/routes/radio.go
@@ -30,27 +30,27 @@ func setupRadioRoutes(rc RouteContext) {
 	huma.Get(rc.API, "/radio/new-releases", radioHandler.GetRadioNewReleaseRadarHandler)
 	huma.Get(rc.API, "/radio/stats", radioHandler.GetRadioStatsHandler)
 
-	// Admin radio station endpoints (admin-only checks inside handlers)
-	huma.Post(rc.Protected, "/admin/radio-stations", radioHandler.AdminCreateRadioStationHandler)
-	huma.Put(rc.Protected, "/admin/radio-stations/{id}", radioHandler.AdminUpdateRadioStationHandler)
-	huma.Delete(rc.Protected, "/admin/radio-stations/{id}", radioHandler.AdminDeleteRadioStationHandler)
-	huma.Post(rc.Protected, "/admin/radio-stations/{id}/shows", radioHandler.AdminCreateRadioShowHandler)
-	huma.Post(rc.Protected, "/admin/radio-stations/{id}/fetch", radioHandler.AdminTriggerFetchHandler)
-	huma.Post(rc.Protected, "/admin/radio-stations/{id}/discover", radioHandler.AdminDiscoverShowsHandler)
+	// Admin-only radio station endpoints (PSY-423: route-gated by HumaAdminMiddleware).
+	huma.Post(rc.Admin, "/admin/radio-stations", radioHandler.AdminCreateRadioStationHandler)
+	huma.Put(rc.Admin, "/admin/radio-stations/{id}", radioHandler.AdminUpdateRadioStationHandler)
+	huma.Delete(rc.Admin, "/admin/radio-stations/{id}", radioHandler.AdminDeleteRadioStationHandler)
+	huma.Post(rc.Admin, "/admin/radio-stations/{id}/shows", radioHandler.AdminCreateRadioShowHandler)
+	huma.Post(rc.Admin, "/admin/radio-stations/{id}/fetch", radioHandler.AdminTriggerFetchHandler)
+	huma.Post(rc.Admin, "/admin/radio-stations/{id}/discover", radioHandler.AdminDiscoverShowsHandler)
 
-	// Admin radio show endpoints (admin-only checks inside handlers)
-	huma.Put(rc.Protected, "/admin/radio-shows/{id}", radioHandler.AdminUpdateRadioShowHandler)
-	huma.Delete(rc.Protected, "/admin/radio-shows/{id}", radioHandler.AdminDeleteRadioShowHandler)
-	huma.Post(rc.Protected, "/admin/radio-shows/{id}/import", radioHandler.AdminImportShowEpisodesHandler)
+	// Admin-only radio show endpoints (PSY-423).
+	huma.Put(rc.Admin, "/admin/radio-shows/{id}", radioHandler.AdminUpdateRadioShowHandler)
+	huma.Delete(rc.Admin, "/admin/radio-shows/{id}", radioHandler.AdminDeleteRadioShowHandler)
+	huma.Post(rc.Admin, "/admin/radio-shows/{id}/import", radioHandler.AdminImportShowEpisodesHandler)
 
-	// Admin import job endpoints
-	huma.Post(rc.Protected, "/admin/radio-shows/{id}/import-job", radioHandler.AdminCreateImportJobHandler)
-	huma.Get(rc.Protected, "/admin/radio/import-jobs/{id}", radioHandler.AdminGetImportJobHandler)
-	huma.Post(rc.Protected, "/admin/radio/import-jobs/{id}/cancel", radioHandler.AdminCancelImportJobHandler)
-	huma.Get(rc.Protected, "/admin/radio-shows/{id}/import-jobs", radioHandler.AdminListImportJobsHandler)
+	// Admin-only import job endpoints (PSY-423).
+	huma.Post(rc.Admin, "/admin/radio-shows/{id}/import-job", radioHandler.AdminCreateImportJobHandler)
+	huma.Get(rc.Admin, "/admin/radio/import-jobs/{id}", radioHandler.AdminGetImportJobHandler)
+	huma.Post(rc.Admin, "/admin/radio/import-jobs/{id}/cancel", radioHandler.AdminCancelImportJobHandler)
+	huma.Get(rc.Admin, "/admin/radio-shows/{id}/import-jobs", radioHandler.AdminListImportJobsHandler)
 
-	// Admin unmatched play management endpoints
-	huma.Get(rc.Protected, "/admin/radio/unmatched", radioHandler.AdminGetUnmatchedPlaysHandler)
-	huma.Post(rc.Protected, "/admin/radio/plays/{id}/link", radioHandler.AdminLinkPlayHandler)
-	huma.Post(rc.Protected, "/admin/radio/plays/bulk-link", radioHandler.AdminBulkLinkPlaysHandler)
+	// Admin-only unmatched play management endpoints (PSY-423).
+	huma.Get(rc.Admin, "/admin/radio/unmatched", radioHandler.AdminGetUnmatchedPlaysHandler)
+	huma.Post(rc.Admin, "/admin/radio/plays/{id}/link", radioHandler.AdminLinkPlayHandler)
+	huma.Post(rc.Admin, "/admin/radio/plays/bulk-link", radioHandler.AdminBulkLinkPlaysHandler)
 }

--- a/backend/internal/api/routes/releases.go
+++ b/backend/internal/api/routes/releases.go
@@ -16,10 +16,10 @@ func setupReleaseRoutes(rc RouteContext) {
 	huma.Get(rc.API, "/releases/{release_id}", releaseHandler.GetReleaseHandler)
 	huma.Get(rc.API, "/artists/{artist_id}/releases", releaseHandler.GetArtistReleasesHandler)
 
-	// Protected release endpoints (admin-only checks inside handlers)
-	huma.Post(rc.Protected, "/releases", releaseHandler.CreateReleaseHandler)
-	huma.Put(rc.Protected, "/releases/{release_id}", releaseHandler.UpdateReleaseHandler)
-	huma.Delete(rc.Protected, "/releases/{release_id}", releaseHandler.DeleteReleaseHandler)
-	huma.Post(rc.Protected, "/releases/{release_id}/links", releaseHandler.AddExternalLinkHandler)
-	huma.Delete(rc.Protected, "/releases/{release_id}/links/{link_id}", releaseHandler.RemoveExternalLinkHandler)
+	// Admin-only release endpoints (PSY-423: route-gated by HumaAdminMiddleware).
+	huma.Post(rc.Admin, "/releases", releaseHandler.CreateReleaseHandler)
+	huma.Put(rc.Admin, "/releases/{release_id}", releaseHandler.UpdateReleaseHandler)
+	huma.Delete(rc.Admin, "/releases/{release_id}", releaseHandler.DeleteReleaseHandler)
+	huma.Post(rc.Admin, "/releases/{release_id}/links", releaseHandler.AddExternalLinkHandler)
+	huma.Delete(rc.Admin, "/releases/{release_id}/links/{link_id}", releaseHandler.RemoveExternalLinkHandler)
 }

--- a/backend/internal/api/routes/reports.go
+++ b/backend/internal/api/routes/reports.go
@@ -35,10 +35,10 @@ func setupShowReportRoutes(rc RouteContext) {
 	// Protected report endpoints (no additional rate limiting)
 	huma.Get(rc.Protected, "/shows/{show_id}/my-report", showReportHandler.GetMyReportHandler)
 
-	// Admin endpoints for managing reports
-	huma.Get(rc.Protected, "/admin/reports", showReportHandler.GetPendingReportsHandler)
-	huma.Post(rc.Protected, "/admin/reports/{report_id}/dismiss", showReportHandler.DismissReportHandler)
-	huma.Post(rc.Protected, "/admin/reports/{report_id}/resolve", showReportHandler.ResolveReportHandler)
+	// Admin-only show report management (PSY-423: route-gated by HumaAdminMiddleware).
+	huma.Get(rc.Admin, "/admin/reports", showReportHandler.GetPendingReportsHandler)
+	huma.Post(rc.Admin, "/admin/reports/{report_id}/dismiss", showReportHandler.DismissReportHandler)
+	huma.Post(rc.Admin, "/admin/reports/{report_id}/resolve", showReportHandler.ResolveReportHandler)
 }
 
 // setupArtistReportRoutes configures artist report endpoints
@@ -62,10 +62,10 @@ func setupArtistReportRoutes(rc RouteContext) {
 	// Protected report endpoints (no additional rate limiting)
 	huma.Get(rc.Protected, "/artists/{artist_id}/my-report", artistReportHandler.GetMyArtistReportHandler)
 
-	// Admin endpoints for managing artist reports
-	huma.Get(rc.Protected, "/admin/artist-reports", artistReportHandler.GetPendingArtistReportsHandler)
-	huma.Post(rc.Protected, "/admin/artist-reports/{report_id}/dismiss", artistReportHandler.DismissArtistReportHandler)
-	huma.Post(rc.Protected, "/admin/artist-reports/{report_id}/resolve", artistReportHandler.ResolveArtistReportHandler)
+	// Admin-only artist report management (PSY-423: route-gated by HumaAdminMiddleware).
+	huma.Get(rc.Admin, "/admin/artist-reports", artistReportHandler.GetPendingArtistReportsHandler)
+	huma.Post(rc.Admin, "/admin/artist-reports/{report_id}/dismiss", artistReportHandler.DismissArtistReportHandler)
+	huma.Post(rc.Admin, "/admin/artist-reports/{report_id}/resolve", artistReportHandler.ResolveArtistReportHandler)
 }
 
 // setupEntityReportRoutes configures entity report endpoints.
@@ -95,9 +95,9 @@ func setupEntityReportRoutes(rc RouteContext) {
 		huma.Post(reportAPI, "/comments/{entity_id}/report", entityReportHandler.ReportCommentHandler)
 	})
 
-	// Admin: entity report management
-	huma.Get(rc.Protected, "/admin/entity-reports", entityReportHandler.AdminListEntityReportsHandler)
-	huma.Get(rc.Protected, "/admin/entity-reports/{report_id}", entityReportHandler.AdminGetEntityReportHandler)
-	huma.Post(rc.Protected, "/admin/entity-reports/{report_id}/resolve", entityReportHandler.AdminResolveEntityReportHandler)
-	huma.Post(rc.Protected, "/admin/entity-reports/{report_id}/dismiss", entityReportHandler.AdminDismissEntityReportHandler)
+	// Admin-only entity report management (PSY-423: route-gated by HumaAdminMiddleware).
+	huma.Get(rc.Admin, "/admin/entity-reports", entityReportHandler.AdminListEntityReportsHandler)
+	huma.Get(rc.Admin, "/admin/entity-reports/{report_id}", entityReportHandler.AdminGetEntityReportHandler)
+	huma.Post(rc.Admin, "/admin/entity-reports/{report_id}/resolve", entityReportHandler.AdminResolveEntityReportHandler)
+	huma.Post(rc.Admin, "/admin/entity-reports/{report_id}/dismiss", entityReportHandler.AdminDismissEntityReportHandler)
 }

--- a/backend/internal/api/routes/revisions.go
+++ b/backend/internal/api/routes/revisions.go
@@ -16,6 +16,6 @@ func setupRevisionRoutes(rc RouteContext) {
 	huma.Get(rc.API, "/revisions/{revision_id}", revisionHandler.GetRevisionHandler)
 	huma.Get(rc.API, "/users/{user_id}/revisions", revisionHandler.GetUserRevisionsHandler)
 
-	// Admin rollback endpoint
-	huma.Post(rc.Protected, "/admin/revisions/{revision_id}/rollback", revisionHandler.RollbackRevisionHandler)
+	// Admin-only rollback endpoint (PSY-423: route-gated by HumaAdminMiddleware)
+	huma.Post(rc.Admin, "/admin/revisions/{revision_id}/rollback", revisionHandler.RollbackRevisionHandler)
 }

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -37,11 +37,21 @@ func SetupRoutes(router *chi.Mux, sc *services.ServiceContainer, cfg *config.Con
 	// Enrich Sentry scope with authenticated user context (runs after JWT middleware)
 	protectedGroup.UseMiddleware(middleware.HumaSentryContextMiddleware)
 
+	// PSY-423: admin group. JWT first (populates user), then Admin middleware
+	// (requires IsAdmin=true). Endpoints registered on this group are gated at
+	// the route level — handlers do not need to call shared.RequireAdmin(ctx).
+	// Conditional-admin endpoints (owner-or-admin) stay on protectedGroup.
+	adminGroup := huma.NewGroup(api, "")
+	adminGroup.UseMiddleware(middleware.HumaJWTMiddleware(sc.JWT, cfg.Session))
+	adminGroup.UseMiddleware(middleware.HumaAdminMiddleware())
+	adminGroup.UseMiddleware(middleware.HumaSentryContextMiddleware)
+
 	// Build the shared RouteContext once, pass to all setup functions
 	rc := RouteContext{
 		Router:    router,
 		API:       api,
 		Protected: protectedGroup,
+		Admin:     adminGroup,
 		SC:        sc,
 		Cfg:       cfg,
 	}

--- a/backend/internal/api/routes/shared.go
+++ b/backend/internal/api/routes/shared.go
@@ -16,10 +16,23 @@ import (
 
 // RouteContext holds the shared dependencies passed to every route setup function.
 // Each function uses only what it needs from the struct.
+//
+// Group hierarchy (PSY-423):
+//   - API:       no auth — public endpoints
+//   - Protected: API + JWT middleware — auth-required, any signed-in user
+//   - Admin:     API + JWT + Admin middleware — auth-required AND IsAdmin=true
+//
+// Register endpoints on the narrowest group that fits. Admin-only endpoints
+// belong on Admin so the admin gate is visible at registration time and
+// handlers don't carry a redundant shared.RequireAdmin(ctx) call. Endpoints
+// where the user can act on their own resource OR an admin can act on any
+// (e.g. "delete own show vs delete any show") stay on Protected with
+// handler-side conditional logic.
 type RouteContext struct {
 	Router    *chi.Mux                   // The chi mux (for Chi-level middleware groups and raw HTTP routes)
 	API       huma.API                   // The public Huma API wrapper
 	Protected *huma.Group                // Protected (auth-required) Huma API group
+	Admin     *huma.Group                // Admin-only Huma API group (JWT + IsAdmin enforced by middleware)
 	SC        *services.ServiceContainer // All instantiated services
 	Cfg       *config.Config             // Application configuration
 }

--- a/backend/internal/api/routes/tags.go
+++ b/backend/internal/api/routes/tags.go
@@ -66,24 +66,24 @@ func setupTagRoutes(rc RouteContext) {
 		huma.Delete(tagVoteAPI, "/tags/{tag_id}/entities/{entity_type}/{entity_id}/votes", tagHandler.RemoveTagVoteHandler)
 	})
 
-	// Admin: tag CRUD and alias management
-	huma.Post(rc.Protected, "/tags", tagHandler.CreateTagHandler)
-	huma.Put(rc.Protected, "/tags/{tag_id}", tagHandler.UpdateTagHandler)
-	huma.Delete(rc.Protected, "/tags/{tag_id}", tagHandler.DeleteTagHandler)
-	huma.Post(rc.Protected, "/tags/{tag_id}/aliases", tagHandler.CreateAliasHandler)
-	huma.Delete(rc.Protected, "/tags/{tag_id}/aliases/{alias_id}", tagHandler.DeleteAliasHandler)
-	// Admin: global alias listing + bulk CSV/JSON import (PSY-307).
-	huma.Get(rc.Protected, "/admin/tags/aliases", tagHandler.ListAllAliasesHandler)
-	huma.Post(rc.Protected, "/admin/tags/aliases/bulk", tagHandler.BulkImportAliasesHandler)
-	// Admin: merge tags (PSY-306).
-	huma.Get(rc.Protected, "/admin/tags/{source_id}/merge-preview", tagHandler.MergeTagsPreviewHandler)
-	huma.Post(rc.Protected, "/admin/tags/{source_id}/merge", tagHandler.MergeTagsHandler)
-	// Admin: low-quality tag review queue (PSY-310).
-	huma.Get(rc.Protected, "/admin/tags/low-quality", tagHandler.ListLowQualityTagsHandler)
-	huma.Post(rc.Protected, "/admin/tags/{tag_id}/snooze", tagHandler.SnoozeTagHandler)
-	// Admin: bulk action on low-quality queue (PSY-487).
-	huma.Post(rc.Protected, "/admin/tags/low-quality/bulk-action", tagHandler.BulkLowQualityTagsHandler)
-	// Admin: genre-hierarchy editor (PSY-311).
-	huma.Get(rc.Protected, "/admin/tags/hierarchy", tagHandler.GetGenreHierarchyHandler)
-	huma.Patch(rc.Protected, "/admin/tags/{tag_id}/parent", tagHandler.SetTagParentHandler)
+	// Admin-only: tag CRUD and alias management (PSY-423: route-gated by HumaAdminMiddleware).
+	huma.Post(rc.Admin, "/tags", tagHandler.CreateTagHandler)
+	huma.Put(rc.Admin, "/tags/{tag_id}", tagHandler.UpdateTagHandler)
+	huma.Delete(rc.Admin, "/tags/{tag_id}", tagHandler.DeleteTagHandler)
+	huma.Post(rc.Admin, "/tags/{tag_id}/aliases", tagHandler.CreateAliasHandler)
+	huma.Delete(rc.Admin, "/tags/{tag_id}/aliases/{alias_id}", tagHandler.DeleteAliasHandler)
+	// Admin-only: global alias listing + bulk CSV/JSON import (PSY-307).
+	huma.Get(rc.Admin, "/admin/tags/aliases", tagHandler.ListAllAliasesHandler)
+	huma.Post(rc.Admin, "/admin/tags/aliases/bulk", tagHandler.BulkImportAliasesHandler)
+	// Admin-only: merge tags (PSY-306).
+	huma.Get(rc.Admin, "/admin/tags/{source_id}/merge-preview", tagHandler.MergeTagsPreviewHandler)
+	huma.Post(rc.Admin, "/admin/tags/{source_id}/merge", tagHandler.MergeTagsHandler)
+	// Admin-only: low-quality tag review queue (PSY-310).
+	huma.Get(rc.Admin, "/admin/tags/low-quality", tagHandler.ListLowQualityTagsHandler)
+	huma.Post(rc.Admin, "/admin/tags/{tag_id}/snooze", tagHandler.SnoozeTagHandler)
+	// Admin-only: bulk action on low-quality queue (PSY-487).
+	huma.Post(rc.Admin, "/admin/tags/low-quality/bulk-action", tagHandler.BulkLowQualityTagsHandler)
+	// Admin-only: genre-hierarchy editor (PSY-311).
+	huma.Get(rc.Admin, "/admin/tags/hierarchy", tagHandler.GetGenreHierarchyHandler)
+	huma.Patch(rc.Admin, "/admin/tags/{tag_id}/parent", tagHandler.SetTagParentHandler)
 }

--- a/backend/internal/api/routes/test_fixtures.go
+++ b/backend/internal/api/routes/test_fixtures.go
@@ -14,6 +14,9 @@ import (
 // route is not registered at all — requests return 404, not 403.
 // cmd/server/main.go additionally refuses to boot if the flag is set in a
 // non-allowed ENVIRONMENT (adminh.ValidateTestFixturesEnvironment).
+//
+// PSY-423: registered on rc.Admin so the admin gate is enforced by
+// HumaAdminMiddleware at the route level.
 func setupTestFixtureRoutes(rc RouteContext) {
 	if !adminh.IsTestFixturesEnabled(os.Getenv) {
 		return
@@ -23,5 +26,5 @@ func setupTestFixtureRoutes(rc RouteContext) {
 		return
 	}
 	h := adminh.NewTestFixtureHandler(database)
-	huma.Post(rc.Protected, "/admin/test-fixtures/reset", h.Reset)
+	huma.Post(rc.Admin, "/admin/test-fixtures/reset", h.Reset)
 }

--- a/backend/internal/api/routes/venues.go
+++ b/backend/internal/api/routes/venues.go
@@ -19,8 +19,13 @@ func setupVenueRoutes(rc RouteContext) {
 	huma.Get(rc.API, "/venues/{venue_id}/genres", venueHandler.GetVenueGenresHandler)
 	huma.Get(rc.API, "/venues/{venue_id}/bill-network", venueHandler.GetVenueBillNetworkHandler)
 
-	// Protected venue endpoints - require authentication
-	huma.Post(rc.Protected, "/admin/venues", venueHandler.AdminCreateVenueHandler)
-	huma.Put(rc.Protected, "/venues/{venue_id}", venueHandler.UpdateVenueHandler)
+	// Admin-only venue endpoints (PSY-423: route-gated by HumaAdminMiddleware).
+	// Non-admins must use the suggest-edit / pending-edit flow.
+	huma.Post(rc.Admin, "/admin/venues", venueHandler.AdminCreateVenueHandler)
+	huma.Put(rc.Admin, "/venues/{venue_id}", venueHandler.UpdateVenueHandler)
+
+	// Conditional-admin: any authenticated user can delete venues they
+	// submitted; admin can delete any. Stays on Protected with handler-side
+	// ownership-or-admin check.
 	huma.Delete(rc.Protected, "/venues/{venue_id}", venueHandler.DeleteVenueHandler)
 }


### PR DESCRIPTION
## Summary

- Add `HumaAdminMiddleware` that runs after JWT and rejects with 403 unless `user.IsAdmin`
- Add `RouteContext.Admin` (a JWT+Admin-gated `huma.Group`) and wire it in `routes.go`
- Move all admin-only endpoints from `rc.Protected` to `rc.Admin`; drop the inline `shared.RequireAdmin(ctx)` calls in those handlers
- Conditional-admin endpoints (owner-or-admin, internal-service bypass) stay on `rc.Protected` with handler-side logic and an inline comment

## Audit

| | before | after |
|---|---|---|
| `shared.RequireAdmin(ctx)` callsites in non-test handler code | **109** | **0** |
| Files with `shared.RequireAdmin(ctx)` callsites | **25** | **0** |
| Endpoints registered on `rc.Admin` | n/a | **127** |
| Route files registering admin endpoints | n/a | **16** |

`shared.RequireAdmin` (the helper itself) is retained in `handlers/shared/helpers.go` for the rare conditional callsite where neither `rc.Protected` nor `rc.Admin` fits — currently zero callers; documented as a fallback.

### Conditional-admin endpoints (intentionally left on `rc.Protected`)

These endpoints permit admin OR another principal, so a route-level gate would over-restrict:

- `catalog/artist.go` `UpdateArtistBandcampHandler` / `UpdateArtistSpotifyHandler` — `X-Internal-Secret` bypass for the AI music-discovery service (no user context). Inline check: admin OR matching internal secret.
- `catalog/show.go` `UpdateShowHandler` / `DeleteShowHandler` / `UnpublishShowHandler` / `MakePrivateShowHandler` / `PublishShowHandler` / `SetShowSoldOutHandler` / `SetShowCancelledHandler` — admin OR show submitter.
- `catalog/venue.go` `DeleteVenueHandler` — admin OR venue submitter.
- `auth/auth.go` `GenerateCLITokenHandler` — admin-only but uses a soft-fail 200-with-`success=false` body for legacy reasons (frontend handles both equally; not a security regression). Left on `Protected` to preserve the existing API contract.
- `admin/test_fixtures.go` `Reset` — moved to `rc.Admin`, but the inline check stays as defense-in-depth: this endpoint deletes test data, and the suite's integration tests call the handler directly (bypassing middleware), so the inline check keeps those assertions meaningful.

### Tests

- **Handler-level admin sweep tests removed** — `TestAdminHandler_RequiresAdmin`, `TestPipelineHandler_RequiresAdmin`, `TestAdminHideComment_RequiresAdmin`, and ~50 sibling `_NoUser` / `_NonAdmin` / `_NotAdmin` tests across handler packages. The handlers no longer enforce the gate; testing it at the handler level would prove nothing about real-world callers.
- **Middleware unit tests added** in `backend/internal/api/middleware/admin_test.go` — covers nil user, non-admin user, admin user, and request-ID propagation in error responses.
- **Route integration test added** in `backend/internal/api/routes/admin_group_test.go` — wires `HumaAdminMiddleware` exactly like production, registers a sentinel admin route, and verifies that non-admin / unauth requests get 403 *without entering the handler* and admin requests reach it. Guards regression: a future PR that re-introduces inline `RequireAdmin` and forgets to register `HumaAdminMiddleware` on the group fails this test.

## Test plan

- [x] `cd backend && go build ./...` (passes)
- [x] `cd backend && go test -short -count=1 ./...` (all packages pass)
- [x] `grep -rn "shared.RequireAdmin(ctx)" backend/internal/api/handlers/ --include="*.go" | grep -v "_test.go"` → 0 results
- [x] `grep -rn "huma.[A-Za-z]*\(rc.Admin," backend/internal/api/routes/ --include="*.go"` → 127 results across 16 files
- [ ] Reviewer spot-checks: pick 3 of the 127 `rc.Admin` registrations; confirm each was previously calling `shared.RequireAdmin(ctx)` and is genuinely admin-only (not conditional)
- [ ] Reviewer spot-checks: pick 1 of each conditional-admin endpoint listed above; confirm the inline check is still present and correct

Closes PSY-423

🤖 Generated with [Claude Code](https://claude.com/claude-code)