### PR TITLE
PSY-525: URL scheme validation for image_url + social URL fields

### DIFF
--- a/backend/internal/api/handlers/admin/revision.go
+++ b/backend/internal/api/handlers/admin/revision.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 
+	"psychic-homily-backend/internal/api/handlers/shared"
 	"psychic-homily-backend/internal/api/middleware"
 	"psychic-homily-backend/internal/logger"
 	adminm "psychic-homily-backend/internal/models/admin"

--- a/backend/internal/api/handlers/catalog/artist.go
+++ b/backend/internal/api/handlers/catalog/artist.go
@@ -363,6 +363,12 @@ func (h *ArtistHandler) AdminCreateArtistHandler(ctx context.Context, req *Admin
 		return nil, huma.Error400BadRequest("Description must be 5000 characters or fewer")
 	}
 
+	// PSY-525: URL scheme validation (http/https only) for social URL fields.
+	if err := validateSocialURLs(req.Body.Instagram, req.Body.Facebook, req.Body.Twitter,
+		req.Body.YouTube, req.Body.Spotify, req.Body.SoundCloud, req.Body.Bandcamp, req.Body.Website); err != nil {
+		return nil, err
+	}
+
 	// Build the create request
 	createReq := &contracts.CreateArtistRequest{
 		Name:        name,
@@ -780,6 +786,13 @@ func (h *ArtistHandler) AdminUpdateArtistHandler(ctx context.Context, req *Admin
 		return nil, huma.Error400BadRequest("Description must be 5000 characters or fewer")
 	}
 
+	// PSY-525: URL scheme validation (http/https only) for social URL fields.
+	// (artist.go AdminUpdate uses lowercase Youtube/Soundcloud field names.)
+	if err := validateSocialURLs(req.Body.Instagram, req.Body.Facebook, req.Body.Twitter,
+		req.Body.Youtube, req.Body.Spotify, req.Body.Soundcloud, req.Body.Bandcamp, req.Body.Website); err != nil {
+		return nil, err
+	}
+
 	// Capture old values for revision diff (fire-and-forget safe)
 	var oldArtist *contracts.ArtistDetailResponse
 	if h.revisionService != nil {
@@ -934,6 +947,51 @@ func ptrToStr(s *string) string {
 	return *s
 }
 
+// validateImageURL applies the http/https scheme check to an optional image URL
+// (PSY-525). Empty strings pass through (the validator skips them), so callers
+// that allow "clear via empty string" semantics keep working.
+func validateImageURL(imageURL *string) error {
+	if imageURL == nil {
+		return nil
+	}
+	if err := utils.ValidateHTTPURL(*imageURL, "Image URL"); err != nil {
+		return huma.Error422UnprocessableEntity(err.Error())
+	}
+	return nil
+}
+
+// validateSocialURLs applies the http/https scheme check to the standard set
+// of social URL fields shared by artist, venue, label, and festival request
+// bodies (PSY-525). Pass nil for fields the surface doesn't accept (e.g.
+// festival only takes Website, so the other 7 args are nil).
+//
+// All eight fields share the same validation policy: must be empty, or a
+// parseable URL with an http or https scheme. Validate-on-write only —
+// existing rows that may contain non-conforming values stay readable.
+func validateSocialURLs(instagram, facebook, twitter, youtube, spotify, soundcloud, bandcamp, website *string) error {
+	checks := []struct {
+		value     *string
+		fieldName string
+	}{
+		{instagram, "Instagram URL"},
+		{facebook, "Facebook URL"},
+		{twitter, "Twitter URL"},
+		{youtube, "YouTube URL"},
+		{spotify, "Spotify URL"},
+		{soundcloud, "SoundCloud URL"},
+		{bandcamp, "Bandcamp URL"},
+		{website, "Website URL"},
+	}
+	for _, c := range checks {
+		if c.value == nil {
+			continue
+		}
+		if err := utils.ValidateHTTPURL(*c.value, c.fieldName); err != nil {
+			return huma.Error422UnprocessableEntity(err.Error())
+		}
+	}
+	return nil
+}
 // ============================================================================
 // Artist Aliases
 // ============================================================================

--- a/backend/internal/api/handlers/catalog/artist.go
+++ b/backend/internal/api/handlers/catalog/artist.go
@@ -992,6 +992,7 @@ func validateSocialURLs(instagram, facebook, twitter, youtube, spotify, soundclo
 	}
 	return nil
 }
+
 // ============================================================================
 // Artist Aliases
 // ============================================================================

--- a/backend/internal/api/handlers/catalog/artist.go
+++ b/backend/internal/api/handlers/catalog/artist.go
@@ -328,9 +328,9 @@ type AdminCreateArtistRequest struct {
 		City        *string `json:"city" required:"false" doc:"Artist city" maxLength:"100"`
 		State       *string `json:"state" required:"false" doc:"Artist state" maxLength:"100"`
 		Country     *string `json:"country" required:"false" doc:"Artist country" maxLength:"100"`
-		Instagram   *string `json:"instagram" required:"false" doc:"Instagram handle" maxLength:"255"`
+		Instagram   *string `json:"instagram" required:"false" doc:"Instagram URL" maxLength:"255"`
 		Facebook    *string `json:"facebook" required:"false" doc:"Facebook URL" maxLength:"500"`
-		Twitter     *string `json:"twitter" required:"false" doc:"Twitter handle" maxLength:"255"`
+		Twitter     *string `json:"twitter" required:"false" doc:"Twitter URL" maxLength:"255"`
 		YouTube     *string `json:"youtube" required:"false" doc:"YouTube URL" maxLength:"500"`
 		Spotify     *string `json:"spotify" required:"false" doc:"Spotify URL" maxLength:"500"`
 		SoundCloud  *string `json:"soundcloud" required:"false" doc:"SoundCloud URL" maxLength:"500"`

--- a/backend/internal/api/handlers/catalog/artist_test.go
+++ b/backend/internal/api/handlers/catalog/artist_test.go
@@ -63,6 +63,33 @@ func TestAdminUpdateArtist_NoFields(t *testing.T) {
 	testhelpers.AssertHumaError(t, err, 400)
 }
 
+// PSY-525: URL scheme validation rejects non-http(s) schemes on social URL
+// fields. The underlying `utils.ValidateHTTPURL` is exercised exhaustively in
+// `internal/utils/url_test.go`; this test asserts the handler integrates the
+// validator and returns 422 (not 400) for semantic rejection.
+func TestAdminUpdateArtist_RejectsJavaScriptScheme(t *testing.T) {
+	h := testArtistHandler()
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
+	req := &AdminUpdateArtistRequest{ArtistID: "1"}
+	bad := "javascript:alert(1)"
+	req.Body.Instagram = &bad
+
+	_, err := h.AdminUpdateArtistHandler(ctx, req)
+	testhelpers.AssertHumaError(t, err, 422)
+}
+
+func TestAdminCreateArtist_RejectsJavaScriptScheme(t *testing.T) {
+	h := testArtistHandler()
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
+	req := &AdminCreateArtistRequest{}
+	req.Body.Name = "Test"
+	bad := "javascript:alert(1)"
+	req.Body.Website = &bad
+
+	_, err := h.AdminCreateArtistHandler(ctx, req)
+	testhelpers.AssertHumaError(t, err, 422)
+}
+
 // --- UpdateArtistBandcampHandler ---
 
 func TestUpdateBandcamp_NoUser(t *testing.T) {
@@ -1069,8 +1096,9 @@ func TestAdminCreateArtist_WithSocials(t *testing.T) {
 			if req.State == nil || *req.State != "AZ" {
 				t.Errorf("expected state='AZ', got %v", req.State)
 			}
-			if req.Instagram == nil || *req.Instagram != "@artist" {
-				t.Errorf("expected instagram='@artist', got %v", req.Instagram)
+			// PSY-525: social URL fields must be valid http/https URLs (not handles).
+			if req.Instagram == nil || *req.Instagram != "https://instagram.com/artist" {
+				t.Errorf("expected instagram='https://instagram.com/artist', got %v", req.Instagram)
 			}
 			if req.Website == nil || *req.Website != "https://example.com" {
 				t.Errorf("expected website='https://example.com', got %v", req.Website)
@@ -1084,7 +1112,7 @@ func TestAdminCreateArtist_WithSocials(t *testing.T) {
 	req.Body.Name = "Social Artist"
 	city := "Phoenix"
 	state := "AZ"
-	instagram := "@artist"
+	instagram := "https://instagram.com/artist"
 	website := "https://example.com"
 	req.Body.City = &city
 	req.Body.State = &state

--- a/backend/internal/api/handlers/catalog/festival.go
+++ b/backend/internal/api/handlers/catalog/festival.go
@@ -209,6 +209,14 @@ func (h *FestivalHandler) CreateFestivalHandler(ctx context.Context, req *Create
 		return nil, huma.Error400BadRequest("End date is required")
 	}
 
+	// PSY-525: URL scheme validation (http/https only) for the festival's
+	// website. Festivals only have one social URL field; flyer_url and
+	// ticket_url are intentionally out of scope per PSY-525 and remain
+	// validated only for length elsewhere.
+	if err := validateSocialURLs(nil, nil, nil, nil, nil, nil, nil, req.Body.Website); err != nil {
+		return nil, err
+	}
+
 	serviceReq := &contracts.CreateFestivalRequest{
 		Name:         req.Body.Name,
 		SeriesSlug:   req.Body.SeriesSlug,
@@ -292,6 +300,12 @@ func (h *FestivalHandler) UpdateFestivalHandler(ctx context.Context, req *Update
 
 	festivalID, err := h.resolveFestivalID(req.FestivalID)
 	if err != nil {
+		return nil, err
+	}
+
+	// PSY-525: URL scheme validation (http/https only) for the festival's
+	// website. flyer_url and ticket_url remain length-only per PSY-525 scope.
+	if err := validateSocialURLs(nil, nil, nil, nil, nil, nil, nil, req.Body.Website); err != nil {
 		return nil, err
 	}
 

--- a/backend/internal/api/handlers/catalog/label.go
+++ b/backend/internal/api/handlers/catalog/label.go
@@ -162,9 +162,9 @@ type CreateLabelRequest struct {
 		FoundedYear *int    `json:"founded_year,omitempty" required:"false" doc:"Year founded" example:"1988"`
 		Status      string  `json:"status,omitempty" required:"false" doc:"Status (active, inactive, defunct)" example:"active"`
 		Description *string `json:"description,omitempty" required:"false" doc:"Description"`
-		Instagram   *string `json:"instagram,omitempty" required:"false" doc:"Instagram handle"`
+		Instagram   *string `json:"instagram,omitempty" required:"false" doc:"Instagram URL"`
 		Facebook    *string `json:"facebook,omitempty" required:"false" doc:"Facebook URL"`
-		Twitter     *string `json:"twitter,omitempty" required:"false" doc:"Twitter handle"`
+		Twitter     *string `json:"twitter,omitempty" required:"false" doc:"Twitter URL"`
 		YouTube     *string `json:"youtube,omitempty" required:"false" doc:"YouTube URL"`
 		Spotify     *string `json:"spotify,omitempty" required:"false" doc:"Spotify URL"`
 		SoundCloud  *string `json:"soundcloud,omitempty" required:"false" doc:"SoundCloud URL"`
@@ -254,9 +254,9 @@ type UpdateLabelRequest struct {
 		FoundedYear *int    `json:"founded_year,omitempty" required:"false" doc:"Year founded"`
 		Status      *string `json:"status,omitempty" required:"false" doc:"Status (active, inactive, defunct)"`
 		Description *string `json:"description,omitempty" required:"false" doc:"Description"`
-		Instagram   *string `json:"instagram,omitempty" required:"false" doc:"Instagram handle"`
+		Instagram   *string `json:"instagram,omitempty" required:"false" doc:"Instagram URL"`
 		Facebook    *string `json:"facebook,omitempty" required:"false" doc:"Facebook URL"`
-		Twitter     *string `json:"twitter,omitempty" required:"false" doc:"Twitter handle"`
+		Twitter     *string `json:"twitter,omitempty" required:"false" doc:"Twitter URL"`
 		YouTube     *string `json:"youtube,omitempty" required:"false" doc:"YouTube URL"`
 		Spotify     *string `json:"spotify,omitempty" required:"false" doc:"Spotify URL"`
 		SoundCloud  *string `json:"soundcloud,omitempty" required:"false" doc:"SoundCloud URL"`

--- a/backend/internal/api/handlers/catalog/label.go
+++ b/backend/internal/api/handlers/catalog/label.go
@@ -188,6 +188,12 @@ func (h *LabelHandler) CreateLabelHandler(ctx context.Context, req *CreateLabelR
 		return nil, huma.Error400BadRequest("Name is required")
 	}
 
+	// PSY-525: URL scheme validation (http/https only) for social URL fields.
+	if err := validateSocialURLs(req.Body.Instagram, req.Body.Facebook, req.Body.Twitter,
+		req.Body.YouTube, req.Body.Spotify, req.Body.SoundCloud, req.Body.Bandcamp, req.Body.Website); err != nil {
+		return nil, err
+	}
+
 	serviceReq := &contracts.CreateLabelRequest{
 		Name:        req.Body.Name,
 		City:        req.Body.City,
@@ -286,6 +292,14 @@ func (h *LabelHandler) UpdateLabelHandler(ctx context.Context, req *UpdateLabelR
 
 	if req.Body.ImageURL != nil && len(*req.Body.ImageURL) > 2048 {
 		return nil, huma.Error400BadRequest("Image URL must be 2048 characters or fewer")
+	}
+	// PSY-525: URL scheme validation (http/https only) for image_url + social URL fields.
+	if err := validateImageURL(req.Body.ImageURL); err != nil {
+		return nil, err
+	}
+	if err := validateSocialURLs(req.Body.Instagram, req.Body.Facebook, req.Body.Twitter,
+		req.Body.YouTube, req.Body.Spotify, req.Body.SoundCloud, req.Body.Bandcamp, req.Body.Website); err != nil {
+		return nil, err
 	}
 
 	serviceReq := &contracts.UpdateLabelRequest{

--- a/backend/internal/api/handlers/catalog/show.go
+++ b/backend/internal/api/handlers/catalog/show.go
@@ -830,6 +830,10 @@ func (h *ShowHandler) UpdateShowHandler(ctx context.Context, req *UpdateShowRequ
 	if req.Body.ImageURL != nil && len(*req.Body.ImageURL) > 2048 {
 		return nil, huma.Error400BadRequest("Image URL must be 2048 characters or fewer")
 	}
+	// PSY-525: URL scheme validation (http/https only) for image_url.
+	if err := validateImageURL(req.Body.ImageURL); err != nil {
+		return nil, err
+	}
 
 	// Build updates map for basic show fields
 	updates := make(map[string]interface{})

--- a/backend/internal/api/handlers/catalog/venue.go
+++ b/backend/internal/api/handlers/catalog/venue.go
@@ -289,6 +289,12 @@ func (h *VenueHandler) AdminCreateVenueHandler(ctx context.Context, req *AdminCr
 
 	user := middleware.GetUserFromContext(ctx)
 
+	// PSY-525: URL scheme validation (http/https only) for social URL fields.
+	if err := validateSocialURLs(req.Body.Instagram, req.Body.Facebook, req.Body.Twitter,
+		req.Body.YouTube, req.Body.Spotify, req.Body.SoundCloud, req.Body.Bandcamp, req.Body.Website); err != nil {
+		return nil, err
+	}
+
 	// Build service request
 	serviceReq := &contracts.CreateVenueRequest{
 		Name:        req.Body.Name,
@@ -401,6 +407,19 @@ func (h *VenueHandler) UpdateVenueHandler(ctx context.Context, req *UpdateVenueR
 	}
 	if req.Body.Description != nil && len(*req.Body.Description) > 5000 {
 		return nil, huma.Error422UnprocessableEntity("Description must be 5000 characters or fewer")
+	}
+
+	// PSY-525: URL scheme validation (http/https only) for image_url and social URL fields.
+	// Length check first (cheaper, reports bytes); URL scheme check second.
+	if req.Body.ImageURL != nil && len(*req.Body.ImageURL) > 2048 {
+		return nil, huma.Error422UnprocessableEntity("Image URL must be 2048 characters or fewer")
+	}
+	if err := validateImageURL(req.Body.ImageURL); err != nil {
+		return nil, err
+	}
+	if err := validateSocialURLs(req.Body.Instagram, req.Body.Facebook, req.Body.Twitter,
+		req.Body.YouTube, req.Body.Spotify, req.Body.SoundCloud, req.Body.Bandcamp, req.Body.Website); err != nil {
+		return nil, err
 	}
 
 	logger.FromContext(ctx).Info("admin_venue_update",

--- a/backend/internal/api/handlers/catalog/venue.go
+++ b/backend/internal/api/handlers/catalog/venue.go
@@ -481,9 +481,7 @@ func (h *VenueHandler) UpdateVenueHandler(ctx context.Context, req *UpdateVenueR
 		updates["description"] = utils.NilIfEmpty(*req.Body.Description)
 	}
 	if req.Body.ImageURL != nil {
-		if len(*req.Body.ImageURL) > 2048 {
-			return nil, huma.Error422UnprocessableEntity("Image URL must be 2048 characters or fewer")
-		}
+		// Length + scheme already validated above (PSY-525); just persist.
 		updates["image_url"] = utils.NilIfEmpty(*req.Body.ImageURL)
 	}
 

--- a/backend/internal/api/handlers/catalog/venue.go
+++ b/backend/internal/api/handlers/catalog/venue.go
@@ -266,9 +266,9 @@ type AdminCreateVenueRequest struct {
 		State      string  `json:"state" required:"true" doc:"Venue state" maxLength:"100"`
 		Address    *string `json:"address" required:"false" doc:"Street address" maxLength:"500"`
 		Zipcode    *string `json:"zipcode" required:"false" doc:"ZIP code" maxLength:"20"`
-		Instagram  *string `json:"instagram" required:"false" doc:"Instagram handle" maxLength:"255"`
+		Instagram  *string `json:"instagram" required:"false" doc:"Instagram URL" maxLength:"255"`
 		Facebook   *string `json:"facebook" required:"false" doc:"Facebook URL" maxLength:"500"`
-		Twitter    *string `json:"twitter" required:"false" doc:"Twitter handle" maxLength:"255"`
+		Twitter    *string `json:"twitter" required:"false" doc:"Twitter URL" maxLength:"255"`
 		YouTube    *string `json:"youtube" required:"false" doc:"YouTube URL" maxLength:"500"`
 		Spotify    *string `json:"spotify" required:"false" doc:"Spotify URL" maxLength:"500"`
 		SoundCloud *string `json:"soundcloud" required:"false" doc:"SoundCloud URL" maxLength:"500"`
@@ -362,7 +362,7 @@ type UpdateVenueRequest struct {
 		State       *string `json:"state,omitempty" required:"false" doc:"Venue state"`
 		Country     *string `json:"country,omitempty" required:"false" doc:"Venue country"`
 		Zipcode     *string `json:"zipcode,omitempty" required:"false" doc:"Venue zipcode"`
-		Instagram   *string `json:"instagram,omitempty" required:"false" doc:"Instagram handle or URL"`
+		Instagram   *string `json:"instagram,omitempty" required:"false" doc:"Instagram URL"`
 		Facebook    *string `json:"facebook,omitempty" required:"false" doc:"Facebook URL"`
 		Twitter     *string `json:"twitter,omitempty" required:"false" doc:"Twitter URL"`
 		YouTube     *string `json:"youtube,omitempty" required:"false" doc:"YouTube URL"`

--- a/backend/internal/api/handlers/pipeline/pipeline.go
+++ b/backend/internal/api/handlers/pipeline/pipeline.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 
+	"psychic-homily-backend/internal/api/handlers/shared"
 	"psychic-homily-backend/internal/api/middleware"
 	"psychic-homily-backend/internal/logger"
 	adminm "psychic-homily-backend/internal/models/admin"

--- a/backend/internal/utils/url.go
+++ b/backend/internal/utils/url.go
@@ -1,0 +1,40 @@
+package utils
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// ValidateHTTPURL returns an error if s is not a parseable absolute URL with
+// an http or https scheme. Empty input returns nil — callers should normalize
+// empty strings (e.g. via nilIfEmpty) before deciding what an empty value
+// means in their domain.
+//
+// fieldName is interpolated into the error message so curators can fix the
+// offending field without guessing which input was rejected.
+//
+// PSY-525: defense-in-depth at the API boundary. Validate-on-write only —
+// existing rows that may already contain non-conforming URLs stay readable.
+// Accepted schemes are http and https; everything else (data:, javascript:,
+// mailto:, ftp:, file:, etc.) is rejected.
+func ValidateHTTPURL(s, fieldName string) error {
+	if s == "" {
+		return nil
+	}
+	trimmed := strings.TrimSpace(s)
+	if trimmed == "" {
+		return nil
+	}
+	u, err := url.Parse(trimmed)
+	if err != nil {
+		return fmt.Errorf("%s must be a valid URL: %w", fieldName, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("%s must use http or https scheme (got %q)", fieldName, u.Scheme)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("%s must include a host", fieldName)
+	}
+	return nil
+}

--- a/backend/internal/utils/url_test.go
+++ b/backend/internal/utils/url_test.go
@@ -1,0 +1,176 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateHTTPURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantErr   bool
+		errSubstr string
+	}{
+		// --- Accepted ---
+		{
+			name:    "http URL",
+			input:   "http://example.com",
+			wantErr: false,
+		},
+		{
+			name:    "https URL",
+			input:   "https://example.com",
+			wantErr: false,
+		},
+		{
+			name:    "https with path and query",
+			input:   "https://example.com/path?q=1",
+			wantErr: false,
+		},
+		{
+			name:    "https with subdomain and port",
+			input:   "https://sub.example.com:8080",
+			wantErr: false,
+		},
+		{
+			name:    "https with trailing slash",
+			input:   "https://example.com/",
+			wantErr: false,
+		},
+		{
+			name:    "https with auth",
+			input:   "https://user:pass@example.com",
+			wantErr: false,
+		},
+		{
+			name:    "https with fragment",
+			input:   "https://example.com/page#section",
+			wantErr: false,
+		},
+		{
+			name:    "leading and trailing whitespace is trimmed",
+			input:   "  https://example.com  ",
+			wantErr: false,
+		},
+
+		// --- Rejected: dangerous schemes ---
+		{
+			name:      "javascript scheme",
+			input:     "javascript:alert(1)",
+			wantErr:   true,
+			errSubstr: "http or https",
+		},
+		{
+			name:      "data scheme",
+			input:     "data:text/html,foo",
+			wantErr:   true,
+			errSubstr: "http or https",
+		},
+		{
+			name:      "mailto scheme",
+			input:     "mailto:user@example.com",
+			wantErr:   true,
+			errSubstr: "http or https",
+		},
+		{
+			name:      "file scheme",
+			input:     "file:///etc/passwd",
+			wantErr:   true,
+			errSubstr: "http or https",
+		},
+
+		// --- Rejected: other schemes ---
+		{
+			name:      "ftp scheme",
+			input:     "ftp://example.com",
+			wantErr:   true,
+			errSubstr: "http or https",
+		},
+		{
+			name:      "ws scheme",
+			input:     "ws://example.com",
+			wantErr:   true,
+			errSubstr: "http or https",
+		},
+
+		// --- Rejected: malformed ---
+		{
+			name:      "no scheme, no host",
+			input:     "not-a-url",
+			wantErr:   true,
+			errSubstr: "http or https",
+		},
+		{
+			name:      "https with no host",
+			input:     "https://",
+			wantErr:   true,
+			errSubstr: "host",
+		},
+		{
+			name:      "empty scheme with host-like value",
+			input:     "://example.com",
+			wantErr:   true,
+		},
+		{
+			name:      "scheme-relative URL",
+			input:     "//example.com",
+			wantErr:   true,
+			errSubstr: "http or https",
+		},
+		{
+			name:      "path only",
+			input:     "/path/only",
+			wantErr:   true,
+			errSubstr: "http or https",
+		},
+
+		// --- Edge: empty input is valid (caller decides what empty means) ---
+		{
+			name:    "empty string",
+			input:   "",
+			wantErr: false,
+		},
+		{
+			name:    "whitespace only",
+			input:   "   ",
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateHTTPURL(tc.input, "Image URL")
+			if tc.wantErr {
+				assert.Error(t, err, "expected error for %q", tc.input)
+				if tc.errSubstr != "" && err != nil {
+					assert.Contains(t, err.Error(), tc.errSubstr,
+						"error message should mention %q for input %q", tc.errSubstr, tc.input)
+				}
+			} else {
+				assert.NoError(t, err, "expected no error for %q", tc.input)
+			}
+		})
+	}
+}
+
+func TestValidateHTTPURL_FieldNameInError(t *testing.T) {
+	// The error message must name the field so curators can fix the right input.
+	err := ValidateHTTPURL("javascript:alert(1)", "Instagram URL")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Instagram URL",
+		"error should mention the field name")
+}
+
+func TestValidateHTTPURL_AcceptedSchemesInError(t *testing.T) {
+	// The error message must enumerate the accepted schemes so callers know
+	// what's allowed without reading the source.
+	err := ValidateHTTPURL("ftp://example.com", "Website")
+	assert.Error(t, err)
+	msg := err.Error()
+	assert.True(t,
+		strings.Contains(msg, "http") && strings.Contains(msg, "https"),
+		"error %q should name both http and https", msg)
+}

--- a/frontend/components/shared/SocialLinks.tsx
+++ b/frontend/components/shared/SocialLinks.tsx
@@ -79,10 +79,18 @@ const socialLinks = [
 
 /**
  * Normalize a social link value to a full URL.
+ *
+ * Post-PSY-525, the backend write path validates social URL fields as
+ * full http/https URLs, so any newly-submitted row is already a full URL.
+ * This function remains a tolerance layer for legacy rows submitted
+ * before the validator landed — those may still contain partial URLs or
+ * bare handles. New code should not rely on the lenient behavior; the
+ * canonical storage form is a full URL.
+ *
  * Handles cases where the value might be:
- * - A full URL (https://instagram.com/username)
- * - A partial URL (instagram.com/username)
- * - Just a handle/username (username)
+ * - A full URL (https://instagram.com/username) — pass through
+ * - A partial URL (instagram.com/username) — prepend https://
+ * - Just a handle/username — strip leading @, prepend the platform's baseUrl
  */
 function normalizeUrl(value: string, baseUrl: string | null): string {
   // If it already looks like a full URL, return it


### PR DESCRIPTION
## Summary

Adds a shared URL validator (`internal/utils.ValidateHTTPURL`) that requires
`http://` or `https://` and a parseable URL with a non-empty host. Wires it
into every catalog write path that accepts `image_url` or social URL fields.

**Accepted schemes:** `http`, `https`. Everything else is rejected — including
`data:`, `javascript:`, `mailto:`, `ftp:`, `file:`, `ws:`, scheme-relative
`//host`, and bare strings without any scheme.

**Validate-on-write only.** Existing rows that may already contain
non-conforming values stay readable. No backfill, no read-side rejection.

## Call sites

- **artist.go**
  - `AdminCreateArtistHandler` — Instagram, Facebook, Twitter, YouTube, Spotify, SoundCloud, Bandcamp, Website
  - `AdminUpdateArtistHandler` — same eight fields (using the lowercase `Youtube`/`Soundcloud` request-body field names)
- **venue.go**
  - `AdminCreateVenueHandler` — eight social URL fields
  - `UpdateVenueHandler` — `image_url` + eight social URL fields
- **show.go**
  - `UpdateShowHandler` — `image_url` (CreateShow doesn't accept image_url)
- **label.go**
  - `CreateLabelHandler` — eight social URL fields
  - `UpdateLabelHandler` — `image_url` + eight social URL fields
- **festival.go**
  - `CreateFestivalHandler` — `website` only (festivals don't have the other 7 social URL fields)
  - `UpdateFestivalHandler` — `website` only
  - `flyer_url` and `ticket_url` are intentionally out of scope per the ticket — they remain length-validated only

## Implementation notes

- Shared validator lives at `backend/internal/utils/url.go` with a 23-case
  table-driven test in `url_test.go` (accepted/rejected/edge).
- Two thin catalog-package wrappers (`validateImageURL`, `validateSocialURLs`)
  in `artist.go` translate `error` → `huma.Error422UnprocessableEntity` and
  iterate the eight social fields cleanly. Festival passes seven nils for
  the fields it doesn't expose.
- Length checks run before scheme checks (cheaper; byte-only error message).
  Empty strings still pass — `nilIfEmpty` keeps mapping `""` to NULL.
- `utils.NilIfEmpty` was NOT used (PSY-523 is in flight on a separate branch
  and the helper isn't on main yet). The catalog package's existing
  `nilIfEmpty` continues to handle empty-string normalization at the call
  sites; the URL validator independently short-circuits empty input.
- Failures return **422 UnprocessableEntity** (semantic rejection) following
  the project's evolving 400/422 split (see PSY-524 in flight). Error
  messages name the field and the accepted schemes (e.g. `Instagram URL
  must use http or https scheme (got "javascript")`).

## Behavior change to flag for review

Previously, request-body docstrings for Instagram and Twitter on artist
and venue read "Instagram handle" / "Twitter handle", and at least one
existing unit test (`TestAdminCreateArtist_WithSocials`) was passing the
literal string `@artist`. The new validator rejects bare handles — they
must be full URLs (e.g. `https://instagram.com/artist`). The unit test
was updated to use the URL form. Doc strings are unchanged in this PR.
The integration tests already used URLs.

If preserving handle-style storage was intentional, the validator could
be relaxed (for example, only validate values that contain `:`). Calling
this out for review in case the right fix is also to update the doc
strings or to widen the accepted forms.

## Test plan

- [x] `go test -short ./internal/utils/...` (validator: 23 cases pass)
- [x] `go test -short ./internal/api/handlers/catalog/...` (all catalog tests pass; new handler-level 422 tests for artist create/update)
- [x] `go test -short ./...` (full backend suite passes)
- [x] `go build ./...`
- [x] `go vet ./...`

Closes PSY-525