### PR TITLE
PSY-527: wire grid drag-drop + keyboard reorder for collection items

### DIFF
--- a/frontend/features/collections/components/CollectionDetail.test.tsx
+++ b/frontend/features/collections/components/CollectionDetail.test.tsx
@@ -1765,4 +1765,195 @@ describe('CollectionDetail', () => {
       expect(expandedContainer.className).toContain('sm:grid-cols-2')
     })
   })
+
+  // PSY-348 drag tests force list mode via beforeEach; these exercise
+  // the grid-mode path that was non-functional pre-PSY-527.
+  describe('PSY-527: grid + ranked reorder', () => {
+    const sampleItems = [
+      {
+        id: 31,
+        entity_type: 'release',
+        entity_id: 301,
+        entity_name: 'First Release',
+        entity_slug: 'first-release',
+        image_url: null,
+        position: 0,
+        added_by_user_id: 1,
+        added_by_name: 'testuser',
+        notes: null,
+        created_at: '2025-01-01T00:00:00Z',
+      },
+      {
+        id: 32,
+        entity_type: 'release',
+        entity_id: 302,
+        entity_name: 'Second Release',
+        entity_slug: 'second-release',
+        image_url: null,
+        position: 1,
+        added_by_user_id: 1,
+        added_by_name: 'testuser',
+        notes: null,
+        created_at: '2025-01-01T00:00:00Z',
+      },
+      {
+        id: 33,
+        entity_type: 'release',
+        entity_id: 303,
+        entity_name: 'Third Release',
+        entity_slug: 'third-release',
+        image_url: null,
+        position: 2,
+        added_by_user_id: 1,
+        added_by_name: 'testuser',
+        notes: null,
+        created_at: '2025-01-01T00:00:00Z',
+      },
+    ]
+
+    beforeEach(() => {
+      window.localStorage.removeItem('ph-collection-items-view-mode')
+    })
+
+    it('renders one drag handle per grid card in ranked + creator mode', () => {
+      mockCollection.mockReturnValue({
+        data: makeCollection({ display_mode: 'ranked', items: sampleItems }),
+        isLoading: false,
+        error: null,
+      })
+      render(<CollectionDetail slug="test-collection" />)
+
+      expect(screen.getByTestId('collection-items')).toHaveAttribute(
+        'data-view-mode',
+        'grid'
+      )
+      // Regression guard: fails if useSortable is removed from CollectionItemCard.
+      expect(
+        screen.getAllByTestId('collection-item-card-reorder')
+      ).toHaveLength(3)
+      expect(
+        screen.getAllByRole('button', { name: /^Drag to reorder/ })
+      ).toHaveLength(3)
+    })
+
+    it('does NOT render the reorder cluster in grid + unranked mode', () => {
+      mockCollection.mockReturnValue({
+        data: makeCollection({ display_mode: 'unranked', items: sampleItems }),
+        isLoading: false,
+        error: null,
+      })
+      render(<CollectionDetail slug="test-collection" />)
+
+      expect(screen.getByTestId('collection-items')).toHaveAttribute(
+        'data-view-mode',
+        'grid'
+      )
+      expect(
+        screen.queryAllByTestId('collection-item-card-reorder')
+      ).toHaveLength(0)
+    })
+
+    it('does NOT render drag handles in grid + ranked for non-creator', () => {
+      mockAuthContext.mockReturnValue({
+        user: { id: '999' },
+        isAuthenticated: true,
+        isLoading: false,
+        logout: vi.fn(),
+      })
+      mockCollection.mockReturnValue({
+        data: makeCollection({
+          display_mode: 'ranked',
+          items: sampleItems,
+          creator_id: 1,
+        }),
+        isLoading: false,
+        error: null,
+      })
+      render(<CollectionDetail slug="test-collection" />)
+
+      // Position badges still visible (everyone sees the ranking).
+      expect(
+        screen.getAllByTestId('collection-item-card-position')
+      ).toHaveLength(3)
+      expect(
+        screen.queryAllByTestId('collection-item-card-reorder')
+      ).toHaveLength(0)
+      expect(
+        screen.queryAllByRole('button', { name: /^Drag to reorder/ })
+      ).toHaveLength(0)
+    })
+
+    it('keyboard fallback: Move down on first grid card sends correct reorder payload', async () => {
+      mockCollection.mockReturnValue({
+        data: makeCollection({ display_mode: 'ranked', items: sampleItems }),
+        isLoading: false,
+        error: null,
+      })
+      const user = userEvent.setup()
+      render(<CollectionDetail slug="test-collection" />)
+
+      const moveDownButtons = screen.getAllByRole('button', {
+        name: 'Move down',
+      })
+      expect(moveDownButtons).toHaveLength(3)
+      await user.click(moveDownButtons[0])
+
+      expect(mockReorderMutate).toHaveBeenCalledWith({
+        slug: 'test-collection',
+        items: [
+          { item_id: 32, position: 0 },
+          { item_id: 31, position: 1 },
+          { item_id: 33, position: 2 },
+        ],
+      })
+    })
+
+    it('keyboard fallback: Move up on last grid card sends correct reorder payload', async () => {
+      mockCollection.mockReturnValue({
+        data: makeCollection({ display_mode: 'ranked', items: sampleItems }),
+        isLoading: false,
+        error: null,
+      })
+      const user = userEvent.setup()
+      render(<CollectionDetail slug="test-collection" />)
+
+      const moveUpButtons = screen.getAllByRole('button', { name: 'Move up' })
+      await user.click(moveUpButtons[moveUpButtons.length - 1])
+
+      expect(mockReorderMutate).toHaveBeenCalledWith({
+        slug: 'test-collection',
+        items: [
+          { item_id: 31, position: 0 },
+          { item_id: 33, position: 1 },
+          { item_id: 32, position: 2 },
+        ],
+      })
+    })
+
+    it('keyboard fallback: Move up disabled on first grid card', () => {
+      mockCollection.mockReturnValue({
+        data: makeCollection({ display_mode: 'ranked', items: sampleItems }),
+        isLoading: false,
+        error: null,
+      })
+      render(<CollectionDetail slug="test-collection" />)
+
+      const moveUpButtons = screen.getAllByRole('button', { name: 'Move up' })
+      expect(moveUpButtons[0]).toBeDisabled()
+    })
+
+    it('keyboard fallback: Move down disabled on last grid card', () => {
+      mockCollection.mockReturnValue({
+        data: makeCollection({ display_mode: 'ranked', items: sampleItems }),
+        isLoading: false,
+        error: null,
+      })
+      render(<CollectionDetail slug="test-collection" />)
+
+      const moveDownButtons = screen.getAllByRole('button', {
+        name: 'Move down',
+      })
+      expect(moveDownButtons[moveDownButtons.length - 1]).toBeDisabled()
+    })
+  })
 })

--- a/frontend/features/collections/components/CollectionDetail.tsx
+++ b/frontend/features/collections/components/CollectionDetail.tsx
@@ -918,15 +918,21 @@ function CollectionItemsList({
       <CollectionItemCard
         key={item.id}
         item={item}
-        // Position badge only meaningful for ranked collections.
         position={isRanked ? index + 1 : undefined}
         density={density}
-        // PSY-526: gate the per-card Remove control on the same
-        // `isCreator` value the list-view row uses. Pass `slug` so the
-        // card can drive `useRemoveCollectionItem` directly without
-        // re-deriving it from the URL.
         isCreator={isCreator}
         slug={slug}
+        reorder={
+          canReorder
+            ? {
+                index,
+                totalItems: items.length,
+                onMoveUp: handleMoveUp,
+                onMoveDown: handleMoveDown,
+                isPending: reorderMutation.isPending,
+              }
+            : undefined
+        }
       />
     ))
 

--- a/frontend/features/collections/components/CollectionItemCard.test.tsx
+++ b/frontend/features/collections/components/CollectionItemCard.test.tsx
@@ -507,4 +507,20 @@ describe('CollectionItemCard', () => {
       ).toBeDisabled()
     })
   })
+
+  // Regression guard: the canReorder=true path requires a SortableContext
+  // and is covered by integration tests in CollectionDetail.test.tsx.
+  describe('PSY-527: reorder cluster gating', () => {
+    it('does not render the reorder cluster when reorder prop is omitted', () => {
+      render(
+        <CollectionItemCard item={makeItem()} density="comfortable" />
+      )
+      expect(
+        screen.queryByTestId('collection-item-card-reorder')
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByTestId('collection-item-card-drag-handle')
+      ).not.toBeInTheDocument()
+    })
+  })
 })

--- a/frontend/features/collections/components/CollectionItemCard.tsx
+++ b/frontend/features/collections/components/CollectionItemCard.tsx
@@ -34,8 +34,13 @@ import {
   X,
   MoreVertical,
   Loader2,
+  GripVertical,
+  ChevronUp,
+  ChevronDown,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
+import { useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
 import { cn } from '@/lib/utils'
 import { getEntityUrl, getEntityTypeLabel, type CollectionItem } from '../types'
 import { MarkdownContent } from './MarkdownEditor'
@@ -61,23 +66,25 @@ export type CollectionItemCardDensity = 'compact' | 'comfortable' | 'expanded'
 
 interface CollectionItemCardProps {
   item: CollectionItem
-  /**
-   * Display position number (1-indexed). Only rendered when set; this is
-   * how the parent decides whether to show the ranked position badge.
-   */
+  /** 1-indexed display position. Renders the ranked position badge when set. */
   position?: number
   density: CollectionItemCardDensity
-  /**
-   * PSY-526: when true, render a Remove control overlaid on the image
-   * area. Mirrors the gating CollectionItemRow uses; the parent
-   * (CollectionDetail) computes `isCreator` once and threads it down.
-   */
   isCreator?: boolean
-  /**
-   * Required when `isCreator` is true — the parent collection's slug, used
-   * by the remove mutation. Optional otherwise.
-   */
+  /** Required when isCreator — used by the Remove mutation. */
   slug?: string
+  /**
+   * Drag + keyboard reorder wiring. When set, the card registers with the
+   * parent SortableContext and renders the reorder cluster. When omitted,
+   * useSortable still runs (in disabled mode) to keep React hook order
+   * stable across reorder-eligibility transitions.
+   */
+  reorder?: {
+    index: number
+    totalItems: number
+    onMoveUp: (index: number) => void
+    onMoveDown: (index: number) => void
+    isPending?: boolean
+  }
 }
 
 /**
@@ -104,14 +111,35 @@ export function CollectionItemCard({
   density,
   isCreator = false,
   slug,
+  reorder,
 }: CollectionItemCardProps) {
   const Icon = ENTITY_ICONS[item.entity_type] ?? Library
   const entityUrl = getEntityUrl(item.entity_type, item.entity_slug)
   const typeLabel = getEntityTypeLabel(item.entity_type)
   const hasImage = Boolean(item.image_url)
+  const canReorder = Boolean(reorder)
+
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: item.id, disabled: !canReorder })
+
+  const sortableStyle: React.CSSProperties = canReorder
+    ? {
+        transform: CSS.Transform.toString(transform),
+        transition,
+        opacity: isDragging ? 0.6 : undefined,
+      }
+    : {}
 
   return (
     <article
+      ref={canReorder ? setNodeRef : undefined}
+      style={sortableStyle}
       className="relative flex flex-col gap-2"
       data-testid="collection-item-card"
       data-entity-type={item.entity_type}
@@ -219,6 +247,50 @@ export function CollectionItemCard({
           itemId={item.id}
           entityName={item.entity_name}
         />
+      )}
+
+      {/* Sibling of <Link> (PSY-526 pattern) to avoid <button> in <a>. In
+          flow rather than overlaid because the image-area bottom can't be
+          reached from outside the Link without JS measurement. */}
+      {reorder && (
+        <div
+          className="self-start flex items-center gap-0.5 rounded-md border border-border/50 bg-background/80 p-0.5"
+          data-testid="collection-item-card-reorder"
+        >
+          <button
+            type="button"
+            {...attributes}
+            {...listeners}
+            className="touch-none cursor-grab active:cursor-grabbing h-6 w-6 flex items-center justify-center rounded text-muted-foreground hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            aria-label={`Drag to reorder ${item.entity_name}. Use space to lift, arrow keys to move.`}
+            title="Drag to reorder"
+            data-testid="collection-item-card-drag-handle"
+          >
+            <GripVertical className="h-3.5 w-3.5" />
+          </button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 w-6 p-0 text-muted-foreground hover:text-foreground"
+            onClick={() => reorder.onMoveUp(reorder.index)}
+            disabled={reorder.index === 0 || reorder.isPending}
+            title="Move up"
+            aria-label="Move up"
+          >
+            <ChevronUp className="h-3.5 w-3.5" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 w-6 p-0 text-muted-foreground hover:text-foreground"
+            onClick={() => reorder.onMoveDown(reorder.index)}
+            disabled={reorder.index === reorder.totalItems - 1 || reorder.isPending}
+            title="Move down"
+            aria-label="Move down"
+          >
+            <ChevronDown className="h-3.5 w-3.5" />
+          </Button>
+        </div>
       )}
 
       {/* Caption — server-rendered markdown notes. Always visible (never


### PR DESCRIPTION
## Summary

Closes PSY-527.

PSY-360 shipped a grid view for collection items but never wired `useSortable` into `CollectionItemCard`, so drag-to-reorder and the Move-up/Move-down keyboard fallback were both non-functional in grid + ranked + creator mode. The existing PSY-348 drag tests forced list mode in `beforeEach` (`CollectionDetail.test.tsx:735`), so the regression went uncovered until the post-merge review of PRs #488–492.

## Changes

- **`CollectionItemCard.tsx`** — `useSortable` wiring (always called with `disabled` when omitted, mirroring `CollectionItemRow`'s hook-order contract) + reorder cluster (drag handle + Move-up/Move-down). Cluster is a sibling of `<Link>` to mirror PSY-526's pattern: avoids `<button>` in `<a>` and preserves the Playwright single-Link strict-mode contract. In flow rather than overlaid because the image-area bottom can't be reached from outside the Link without JS measurement.
- **`CollectionItemCard` API** — bundled the 6 reorder props into a single `reorder?: { index, totalItems, onMoveUp, onMoveDown, isPending? }` object so the type system enforces all-or-nothing rather than 6 independently-optional props.
- **`CollectionDetail.tsx`** — `renderGridCards` threads the `reorder` prop when `canReorder` (matches list-view row gating: creator AND ranked).
- Reused `<Button variant="ghost">` for the Move buttons (matches `CollectionItemRow`); raw `<button>` only on the drag handle since `{...listeners}` needs direct DOM.

## Tests

7 new tests, all green:

- `CollectionDetail.test.tsx > PSY-527: grid + ranked reorder` — 6 tests: drag handles render in grid+ranked+creator (regression guard); cluster absent in unranked; cluster + drag handles absent for non-creator; Move-down/Move-up payloads correct; Move buttons disabled at edges.
- `CollectionItemCard.test.tsx > PSY-527: reorder cluster gating` — unit-level guard that the cluster stays absent when the `reorder` prop is omitted.

These tests would have failed before this PR — they are the regression guard the ticket asked for.

## Test plan

- [x] `bun x tsc --noEmit` clean
- [x] `bun run test:run features/collections/components/CollectionItemCard.test.tsx features/collections/components/CollectionDetail.test.tsx` — 109/109 pass
- [x] `bun run test:run` — 2968/2969 pass; the 1 failure is `EntityTagList.test.tsx > opens the attribution hover card inside the Sheet (Radix portal compatibility)` which re-passes in isolation (pre-existing flake, unrelated to this PR)
- [ ] Manual: ranked-mode collection in grid view — pointer drag reorders cards; keyboard Move-up/Move-down updates positions
- [ ] Manual: list-view drag continues to work (no regression)
- [ ] Manual: card click still navigates via outer `<Link>` without being swallowed by drag listeners

🤖 Generated with [Claude Code](https://claude.com/claude-code)