### PR TITLE
PSY-556: keep density toggle visible (disabled) in collection list view

### DIFF
--- a/frontend/components/shared/DensityToggle.test.tsx
+++ b/frontend/components/shared/DensityToggle.test.tsx
@@ -75,4 +75,62 @@ describe('DensityToggle', () => {
       expect(radio).toHaveAttribute('type', 'button')
     }
   })
+
+  // PSY-556: when the surrounding view doesn't apply density (e.g. a list
+  // layout), the toggle stays mounted but disabled so the toolbar doesn't
+  // shift between modes. Persisted selection is preserved by the parent.
+  describe('when disabled', () => {
+    it('keeps all radios in the DOM (no conditional unmount)', () => {
+      render(
+        <DensityToggle
+          density="comfortable"
+          onDensityChange={mockOnDensityChange}
+          disabled
+          disabledTooltip="Density only applies to grid view"
+        />
+      )
+      expect(screen.getAllByRole('radio')).toHaveLength(3)
+    })
+
+    it('marks the radiogroup aria-disabled and disables each button', () => {
+      render(
+        <DensityToggle
+          density="comfortable"
+          onDensityChange={mockOnDensityChange}
+          disabled
+        />
+      )
+      expect(screen.getByRole('radiogroup')).toHaveAttribute('aria-disabled', 'true')
+      for (const radio of screen.getAllByRole('radio')) {
+        expect(radio).toBeDisabled()
+      }
+    })
+
+    it('does not call onDensityChange when a disabled radio is clicked', async () => {
+      const user = userEvent.setup()
+      render(
+        <DensityToggle
+          density="comfortable"
+          onDensityChange={mockOnDensityChange}
+          disabled
+        />
+      )
+      await user.click(screen.getByRole('radio', { name: 'Compact' }))
+      expect(mockOnDensityChange).not.toHaveBeenCalled()
+    })
+
+    it('preserves the current selection (aria-checked still reflects density)', () => {
+      render(
+        <DensityToggle
+          density="expanded"
+          onDensityChange={mockOnDensityChange}
+          disabled
+        />
+      )
+      expect(screen.getByRole('radio', { name: 'Expanded' })).toHaveAttribute(
+        'aria-checked',
+        'true'
+      )
+    })
+  })
 })

--- a/frontend/components/shared/DensityToggle.tsx
+++ b/frontend/components/shared/DensityToggle.tsx
@@ -2,6 +2,12 @@
 
 import { cn } from '@/lib/utils'
 import { type Density } from '@/lib/hooks/common/useDensity'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 
 const DENSITY_OPTIONS: { value: Density; label: string }[] = [
   { value: 'compact', label: 'Compact' },
@@ -16,6 +22,19 @@ export interface DensityToggleProps {
   onDensityChange: (value: Density) => void
   /** Additional CSS classes */
   className?: string
+  /**
+   * Visually present the radios but disable interaction. The persisted
+   * selection is preserved so re-enabling restores the previous choice
+   * (PSY-556). Use this when the surrounding view doesn't apply density
+   * (e.g. a list layout) but the parent still wants the control visible
+   * to avoid layout shift on view-mode switch.
+   */
+  disabled?: boolean
+  /**
+   * Tooltip text shown on hover/focus when {@link disabled} is true.
+   * Ignored when not disabled.
+   */
+  disabledTooltip?: string
 }
 
 /**
@@ -26,13 +45,23 @@ export interface DensityToggleProps {
  *   const { density, setDensity } = useDensity('shows')
  *   <DensityToggle density={density} onDensityChange={setDensity} />
  */
-export function DensityToggle({ density, onDensityChange, className }: DensityToggleProps) {
-
-  return (
+export function DensityToggle({
+  density,
+  onDensityChange,
+  className,
+  disabled = false,
+  disabledTooltip,
+}: DensityToggleProps) {
+  const group = (
     <div
-      className={cn('inline-flex items-center rounded-lg border border-border/50 bg-muted/30 p-0.5', className)}
+      className={cn(
+        'inline-flex items-center rounded-lg border border-border/50 bg-muted/30 p-0.5',
+        disabled && 'opacity-50',
+        className
+      )}
       role="radiogroup"
       aria-label="Display density"
+      aria-disabled={disabled || undefined}
     >
       {DENSITY_OPTIONS.map(option => (
         <button
@@ -40,13 +69,15 @@ export function DensityToggle({ density, onDensityChange, className }: DensityTo
           type="button"
           role="radio"
           aria-checked={density === option.value}
+          disabled={disabled}
           onClick={() => onDensityChange(option.value)}
           data-testid={`density-${option.value}`}
           className={cn(
             'px-2.5 py-1 text-xs font-medium rounded-md transition-colors duration-100',
             density === option.value
               ? 'bg-background text-foreground shadow-sm'
-              : 'text-muted-foreground hover:text-foreground'
+              : 'text-muted-foreground hover:text-foreground',
+            disabled && 'cursor-not-allowed hover:text-muted-foreground'
           )}
         >
           {option.label}
@@ -54,4 +85,24 @@ export function DensityToggle({ density, onDensityChange, className }: DensityTo
       ))}
     </div>
   )
+
+  // When disabled with a tooltip, wrap the group in a span trigger so
+  // hover/focus still register (Radix Tooltip won't fire pointer events
+  // on disabled buttons themselves).
+  if (disabled && disabledTooltip) {
+    return (
+      <TooltipProvider delayDuration={300}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span tabIndex={0} className="inline-flex">
+              {group}
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>{disabledTooltip}</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    )
+  }
+
+  return group
 }

--- a/frontend/components/shared/DensityToggle.tsx
+++ b/frontend/components/shared/DensityToggle.tsx
@@ -49,7 +49,7 @@ export function DensityToggle({
   density,
   onDensityChange,
   className,
-  disabled = false,
+  disabled,
   disabledTooltip,
 }: DensityToggleProps) {
   const group = (
@@ -73,11 +73,10 @@ export function DensityToggle({
           onClick={() => onDensityChange(option.value)}
           data-testid={`density-${option.value}`}
           className={cn(
-            'px-2.5 py-1 text-xs font-medium rounded-md transition-colors duration-100',
+            'px-2.5 py-1 text-xs font-medium rounded-md transition-colors duration-100 disabled:cursor-not-allowed disabled:hover:text-current',
             density === option.value
               ? 'bg-background text-foreground shadow-sm'
-              : 'text-muted-foreground hover:text-foreground',
-            disabled && 'cursor-not-allowed hover:text-muted-foreground'
+              : 'text-muted-foreground hover:text-foreground'
           )}
         >
           {option.label}
@@ -86,9 +85,8 @@ export function DensityToggle({
     </div>
   )
 
-  // When disabled with a tooltip, wrap the group in a span trigger so
-  // hover/focus still register (Radix Tooltip won't fire pointer events
-  // on disabled buttons themselves).
+  // Wrap in a span trigger when disabled — Radix Tooltip won't fire
+  // pointer events on disabled buttons themselves.
   if (disabled && disabledTooltip) {
     return (
       <TooltipProvider delayDuration={300}>

--- a/frontend/features/collections/components/CollectionDetail.test.tsx
+++ b/frontend/features/collections/components/CollectionDetail.test.tsx
@@ -54,14 +54,21 @@ vi.mock('@/components/shared', () => ({
   // PSY-360: stub the density toggle so the items-list view-mode toggle
   // can render without pulling in the real (no behavior we exercise from
   // here — density coverage lives in the DensityToggle's own test file).
+  // PSY-556: surface the `disabled` prop on the stub so the parent test
+  // can assert that list view disables the toggle (visible but inert).
   DensityToggle: ({
     density,
     onDensityChange,
+    disabled,
   }: {
     density: 'compact' | 'comfortable' | 'expanded'
     onDensityChange: (value: 'compact' | 'comfortable' | 'expanded') => void
+    disabled?: boolean
   }) => (
-    <div data-testid="density-toggle-stub">
+    <div
+      data-testid="density-toggle-stub"
+      data-disabled={disabled ? 'true' : 'false'}
+    >
       <button onClick={() => onDensityChange('compact')}>compact</button>
       <button onClick={() => onDensityChange('comfortable')}>comfortable</button>
       <button onClick={() => onDensityChange('expanded')}>expanded</button>
@@ -1686,7 +1693,7 @@ describe('CollectionDetail', () => {
       expect(screen.queryAllByTestId('collection-item-card')).toHaveLength(0)
     })
 
-    it('density toggle is visible only in grid view', async () => {
+    it('density toggle stays mounted in list view but is disabled (PSY-556)', async () => {
       mockCollection.mockReturnValue({
         data: makeCollection({ items: sampleItems }),
         isLoading: false,
@@ -1695,14 +1702,24 @@ describe('CollectionDetail', () => {
       const user = userEvent.setup()
       render(<CollectionDetail slug="test-collection" />)
 
-      // Visible in grid.
-      expect(screen.getByTestId('density-toggle-stub')).toBeInTheDocument()
+      // Visible AND enabled in grid view.
+      const toggle = screen.getByTestId('density-toggle-stub')
+      expect(toggle).toBeInTheDocument()
+      expect(toggle).toHaveAttribute('data-disabled', 'false')
 
-      // Switch to list — density toggle disappears (no effect on list).
+      // Switch to list — toggle stays mounted (no layout shift) but is
+      // disabled. Persisted selection is preserved by useDensity.
       await user.click(screen.getByTestId('view-mode-list'))
-      expect(
-        screen.queryByTestId('density-toggle-stub')
-      ).not.toBeInTheDocument()
+      const toggleAfter = screen.getByTestId('density-toggle-stub')
+      expect(toggleAfter).toBeInTheDocument()
+      expect(toggleAfter).toHaveAttribute('data-disabled', 'true')
+
+      // Switch back to grid — re-enabled.
+      await user.click(screen.getByTestId('view-mode-grid'))
+      expect(screen.getByTestId('density-toggle-stub')).toHaveAttribute(
+        'data-disabled',
+        'false'
+      )
     })
 
     it('grid view in ranked mode shows position badges on each card', () => {

--- a/frontend/features/collections/components/CollectionDetail.tsx
+++ b/frontend/features/collections/components/CollectionDetail.tsx
@@ -933,18 +933,20 @@ function CollectionItemsList({
   const renderItems = isGridView ? renderGridCards : renderListRows
 
   // Header row: section title on the left, view + density toggles on the
-  // right. Density toggle only appears in grid view (it has no effect on
-  // the list layout).
+  // right. Density toggle stays mounted in list view so the toolbar
+  // doesn't shift between modes (PSY-556); it's disabled there with a
+  // tooltip explaining the constraint. The persisted selection is
+  // preserved so toggling back to grid restores the user's choice.
   const header = (
     <div className="mb-4 flex items-center justify-between gap-3 flex-wrap">
       <h2 className="text-lg font-semibold">Items</h2>
       <div className="flex items-center gap-2">
-        {isGridView && (
-          <DensityToggle
-            density={density}
-            onDensityChange={setDensity}
-          />
-        )}
+        <DensityToggle
+          density={density}
+          onDensityChange={setDensity}
+          disabled={!isGridView}
+          disabledTooltip="Density only applies to grid view"
+        />
         <div
           className="inline-flex items-center rounded-lg border border-border/50 bg-muted/30 p-0.5"
           role="radiogroup"


### PR DESCRIPTION
## Summary
- Keep density radios visible in list view, disabled with tooltip per ticket Option A
- Persisted selection unchanged; selection preserved on re-enable

## Test plan
- [ ] frontend typecheck passes
- [ ] manual: switch to List view → density radios visible but disabled, tooltip on hover
- [ ] manual: switch back to Grid → radios re-enable with previous selection
- [ ] manual: no layout shift between modes

Closes PSY-556