### PR TITLE
PSY-551: forward auth cookie in collection SSR fetch

### DIFF
--- a/frontend/app/collections/[slug]/page.tsx
+++ b/frontend/app/collections/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from 'react'
 import { Metadata } from 'next'
+import { cookies } from 'next/headers'
 import { notFound } from 'next/navigation'
 import * as Sentry from '@sentry/nextjs'
 import { Loader2 } from 'lucide-react'
@@ -22,11 +23,28 @@ interface CollectionData {
   creator_name?: string
 }
 
+// PSY-551: forward the viewer's auth cookie so SSR sees the same view as the
+// browser. Private collections 404 to anonymous viewers (correct), but the
+// page route runs server-side and previously bypassed the /api proxy that
+// normally attaches the cookie — so private-but-owned collections rendered
+// 404 for their own creator. Mirrors the cookie-forward pattern in
+// app/api/[...path]/route.ts.
 async function getCollection(slug: string): Promise<CollectionData | null> {
+  const cookieStore = await cookies()
+  const authToken = cookieStore.get('auth_token')
+
+  // When auth is present the backend response is viewer-specific (private
+  // collections gate on creator_id), so we must NOT cache it across users.
+  // Anonymous requests stay on ISR for public-collection performance.
+  const fetchInit: RequestInit & { next?: { revalidate: number } } = authToken
+    ? {
+        headers: { Cookie: `auth_token=${authToken.value}` },
+        cache: 'no-store',
+      }
+    : { next: { revalidate: 3600 } }
+
   try {
-    const res = await fetch(`${API_BASE_URL}/collections/${slug}`, {
-      next: { revalidate: 3600 },
-    })
+    const res = await fetch(`${API_BASE_URL}/collections/${slug}`, fetchInit)
     if (res.ok) {
       return res.json()
     }

--- a/frontend/app/collections/[slug]/page.tsx
+++ b/frontend/app/collections/[slug]/page.tsx
@@ -36,7 +36,7 @@ async function getCollection(slug: string): Promise<CollectionData | null> {
   // When auth is present the backend response is viewer-specific (private
   // collections gate on creator_id), so we must NOT cache it across users.
   // Anonymous requests stay on ISR for public-collection performance.
-  const fetchInit: RequestInit & { next?: { revalidate: number } } = authToken
+  const fetchInit: RequestInit = authToken
     ? {
         headers: { Cookie: `auth_token=${authToken.value}` },
         cache: 'no-store',

--- a/frontend/e2e/pages/private-collection-owner.spec.ts
+++ b/frontend/e2e/pages/private-collection-owner.spec.ts
@@ -22,14 +22,15 @@ test.describe('Private collection detail (owner access)', () => {
         .first()
         .click()
 
-      // 2. Fill the title and uncheck Public to make it private.
+      // 2. Fill the title and uncheck Public to make it private. The Create
+      // form defaults Public=on, so we assert that pre-condition before the
+      // toggle to fail loudly if the form ever flips its default.
       await authenticatedPage
         .getByLabel('Title', { exact: true })
         .fill(PRIVATE_TITLE)
       const publicCheckbox = authenticatedPage.getByRole('checkbox', {
         name: 'Public',
       })
-      // The form defaults Public=on (CollectionList.tsx line 432). Toggle off.
       await expect(publicCheckbox).toBeChecked()
       await publicCheckbox.uncheck()
 

--- a/frontend/e2e/pages/private-collection-owner.spec.ts
+++ b/frontend/e2e/pages/private-collection-owner.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from '../fixtures'
+
+// PSY-551: regression test for "private collection detail page 404s for its
+// own owner". The page route ran an SSR fetch against the backend without
+// forwarding the viewer's auth cookie, so the backend returned 404 (correct
+// for anon viewers of private collections) and the page called notFound()
+// even when rendered for the creator. Fixed by forwarding `auth_token` from
+// `next/headers` into the SSR fetch (see app/collections/[slug]/page.tsx).
+//
+// PSY-432: worker teardown auto-resets the `collections` table for the
+// worker user, so the collection created here doesn't pollute later runs.
+const PRIVATE_TITLE = `PSY-551 Private ${Date.now()}`
+
+test.describe('Private collection detail (owner access)', () => {
+  test(
+    'create-private redirects to detail page and renders (not 404)',
+    async ({ authenticatedPage }) => {
+      // 1. Open the collections browse page and start the create flow.
+      await authenticatedPage.goto('/collections')
+      await authenticatedPage
+        .getByRole('button', { name: 'Create Collection' })
+        .first()
+        .click()
+
+      // 2. Fill the title and uncheck Public to make it private.
+      await authenticatedPage
+        .getByLabel('Title', { exact: true })
+        .fill(PRIVATE_TITLE)
+      const publicCheckbox = authenticatedPage.getByRole('checkbox', {
+        name: 'Public',
+      })
+      // The form defaults Public=on (CollectionList.tsx line 432). Toggle off.
+      await expect(publicCheckbox).toBeChecked()
+      await publicCheckbox.uncheck()
+
+      // 3. Submit, wait for the create POST, then for the auto-redirect to
+      // /collections/<slug>. The redirect is what previously rendered 404.
+      const [createResponse] = await Promise.all([
+        authenticatedPage.waitForResponse(
+          (resp) =>
+            /\/collections\/?$/.test(new URL(resp.url()).pathname) &&
+            resp.request().method() === 'POST',
+          { timeout: 10_000 }
+        ),
+        authenticatedPage
+          .getByRole('button', { name: 'Create', exact: true })
+          .click(),
+      ])
+      expect(createResponse.status()).toBeLessThan(400)
+      const created = (await createResponse.json()) as { slug?: string }
+      expect(created.slug).toBeTruthy()
+      const slug = created.slug as string
+
+      await authenticatedPage.waitForURL(`/collections/${slug}`)
+
+      // 4. Detail page renders the private collection's title (not 404).
+      // not-found.tsx renders "Page not found" — assert it's NOT visible to
+      // catch regressions where the page falls through to notFound().
+      await expect(
+        authenticatedPage.getByRole('heading', { name: PRIVATE_TITLE })
+      ).toBeVisible({ timeout: 10_000 })
+      await expect(
+        authenticatedPage.getByText('Page not found', { exact: false })
+      ).toHaveCount(0)
+
+      // 5. Hard reload — the SSR fetch (which is what regressed) runs again
+      // here, so this is the strongest signal that auth forwarding works.
+      await authenticatedPage.reload()
+      await expect(
+        authenticatedPage.getByRole('heading', { name: PRIVATE_TITLE })
+      ).toBeVisible({ timeout: 10_000 })
+
+      // 6. Navigating from the "Yours" tab also runs the SSR detail fetch.
+      await authenticatedPage.goto('/collections')
+      await authenticatedPage
+        .getByRole('tab', { name: 'Yours' })
+        .click()
+      await authenticatedPage
+        .getByRole('link', { name: PRIVATE_TITLE })
+        .first()
+        .click()
+      await authenticatedPage.waitForURL(`/collections/${slug}`)
+      await expect(
+        authenticatedPage.getByRole('heading', { name: PRIVATE_TITLE })
+      ).toBeVisible({ timeout: 10_000 })
+    }
+  )
+})


### PR DESCRIPTION
## Summary
- Private collection detail page returned 404 for its own creator because the SSR fetch in `app/collections/[slug]/page.tsx` did not forward the viewer's `auth_token` cookie to the backend (the browser-side fetch goes through `/api/[...path]/route.ts` which forwards the cookie; the SSR fetch bypasses that proxy).
- Forward `auth_token` from `cookies()` (`next/headers`) into the SSR fetch and switch to `cache: 'no-store'` when auth is present so user-specific responses aren't cached across viewers; anonymous requests stay on ISR for public-collection performance.

## Test plan
- [ ] frontend typecheck passes
- [ ] manual: create private collection → lands on detail page (200, not 404)
- [ ] manual: click private collection from Yours tab → renders
- [ ] manual: anon user visiting same slug → still 404
- [ ] manual: public collection → renders for everyone

Closes PSY-551