### PR TITLE
PSY-552: resolve comment author name and link byline to profile

### DIFF
--- a/backend/internal/services/contracts/comment.go
+++ b/backend/internal/services/contracts/comment.go
@@ -62,13 +62,21 @@ type CommentListFilters struct {
 
 // CommentResponse represents a comment with author info for API responses.
 type CommentResponse struct {
-	ID              uint             `json:"id"`
-	EntityType      string           `json:"entity_type"`
-	EntityID        uint             `json:"entity_id"`
-	Kind            string           `json:"kind"`
-	UserID          uint             `json:"user_id"`
-	AuthorName      string           `json:"author_name"`
-	AuthorUsername  string           `json:"author_username,omitempty"`
+	ID         uint   `json:"id"`
+	EntityType string `json:"entity_type"`
+	EntityID   uint   `json:"entity_id"`
+	Kind       string `json:"kind"`
+	UserID     uint   `json:"user_id"`
+	// AuthorName is the resolved display name for the comment's author —
+	// never empty. Resolution chain mirrors PSY-353: username → first/last
+	// → email-prefix → "Anonymous".
+	AuthorName string `json:"author_name"`
+	// AuthorUsername is the author's username when set — used by the
+	// frontend to link the byline to /users/:username. Pointer so the JSON
+	// encodes null (not "") for accounts that never set a username, the
+	// same shape PSY-353 standardized for collection contributor
+	// attribution. PSY-552.
+	AuthorUsername  *string          `json:"author_username"`
 	ParentID        *uint            `json:"parent_id,omitempty"`
 	RootID          *uint            `json:"root_id,omitempty"`
 	Depth           int              `json:"depth"`

--- a/backend/internal/services/engagement/comment_service.go
+++ b/backend/internal/services/engagement/comment_service.go
@@ -151,6 +151,8 @@ func commentToResponse(c *engagementm.Comment) *contracts.CommentResponse {
 		EntityID:        c.EntityID,
 		Kind:            string(c.Kind),
 		UserID:          c.UserID,
+		AuthorName:      resolveCommentAuthorName(&c.User),
+		AuthorUsername:  resolveCommentAuthorUsername(&c.User),
 		ParentID:        c.ParentID,
 		RootID:          c.RootID,
 		Depth:           c.Depth,
@@ -167,18 +169,50 @@ func commentToResponse(c *engagementm.Comment) *contracts.CommentResponse {
 		CreatedAt:       c.CreatedAt,
 		UpdatedAt:       c.UpdatedAt,
 	}
+	return resp
+}
 
-	// Populate author info from preloaded User
-	if c.User.ID != 0 {
-		if c.User.Username != nil {
-			resp.AuthorUsername = *c.User.Username
+// resolveCommentAuthorName returns the display name for a comment's author —
+// never empty. Mirrors CollectionService.resolveUserName (PSY-353): prefer
+// username, fall back to first/last, then to the local-part of the email,
+// finally "Anonymous". Operates on the preloaded User so callers don't pay
+// an extra query per comment. PSY-552.
+func resolveCommentAuthorName(u *authm.User) string {
+	if u == nil || u.ID == 0 {
+		return "Anonymous"
+	}
+	if u.Username != nil && *u.Username != "" {
+		return *u.Username
+	}
+	if u.FirstName != nil && *u.FirstName != "" {
+		name := *u.FirstName
+		if u.LastName != nil && *u.LastName != "" {
+			name += " " + *u.LastName
 		}
-		if c.User.FirstName != nil {
-			resp.AuthorName = *c.User.FirstName
+		return name
+	}
+	if u.Email != nil && *u.Email != "" {
+		if idx := strings.Index(*u.Email, "@"); idx > 0 {
+			return (*u.Email)[:idx]
 		}
 	}
+	return "Anonymous"
+}
 
-	return resp
+// resolveCommentAuthorUsername returns the author's username for /users/:username
+// links, or nil when the user has no username set. Distinct from
+// resolveCommentAuthorName, which falls back to first/last/email and so cannot
+// be safely used in a URL slug. Mirrors CollectionService.resolveUserUsername
+// (PSY-353). PSY-552.
+func resolveCommentAuthorUsername(u *authm.User) *string {
+	if u == nil || u.ID == 0 {
+		return nil
+	}
+	if u.Username == nil || *u.Username == "" {
+		return nil
+	}
+	username := *u.Username
+	return &username
 }
 
 // userTierHourlyLimit returns the hourly comment limit for a given user tier.

--- a/backend/internal/services/engagement/comment_service_test.go
+++ b/backend/internal/services/engagement/comment_service_test.go
@@ -295,6 +295,109 @@ func TestUserTierHourlyLimit(t *testing.T) {
 	assert.Equal(t, 5, userTierHourlyLimit("unknown_tier"))
 }
 
+// PSY-552: AuthorName resolver chain — username → first/last → email-prefix
+// → "Anonymous". Mirrors the PSY-353 collection contributor pattern. These
+// are pure-function tests (no DB) so the chain is locked down even when the
+// integration suite can't run.
+func TestResolveCommentAuthorName(t *testing.T) {
+	t.Run("NilUser_Anonymous", func(t *testing.T) {
+		assert.Equal(t, "Anonymous", resolveCommentAuthorName(nil))
+	})
+
+	t.Run("ZeroIDUser_Anonymous", func(t *testing.T) {
+		assert.Equal(t, "Anonymous", resolveCommentAuthorName(&authm.User{}))
+	})
+
+	t.Run("UsernameWins", func(t *testing.T) {
+		username := "ph_user"
+		first := "Ignored"
+		email := "ignored@example.com"
+		u := &authm.User{Username: &username, FirstName: &first, Email: &email}
+		u.ID = 7
+		assert.Equal(t, "ph_user", resolveCommentAuthorName(u))
+	})
+
+	t.Run("FirstAndLast_NoUsername", func(t *testing.T) {
+		first := "Jane"
+		last := "Doe"
+		u := &authm.User{FirstName: &first, LastName: &last}
+		u.ID = 8
+		assert.Equal(t, "Jane Doe", resolveCommentAuthorName(u))
+	})
+
+	t.Run("FirstOnly_NoUsername", func(t *testing.T) {
+		first := "Jane"
+		u := &authm.User{FirstName: &first}
+		u.ID = 9
+		assert.Equal(t, "Jane", resolveCommentAuthorName(u))
+	})
+
+	t.Run("EmailPrefixFallback", func(t *testing.T) {
+		email := "dogfood@psychichomily.com"
+		u := &authm.User{Email: &email}
+		u.ID = 10
+		assert.Equal(t, "dogfood", resolveCommentAuthorName(u))
+	})
+
+	t.Run("EmailWithNoAtSign_Anonymous", func(t *testing.T) {
+		// Should never happen in practice (email column has @ on insert),
+		// but the helper falls through to "Anonymous" rather than echo a
+		// malformed string.
+		email := "noatsign"
+		u := &authm.User{Email: &email}
+		u.ID = 11
+		assert.Equal(t, "Anonymous", resolveCommentAuthorName(u))
+	})
+
+	t.Run("EmptyUsernamePointer_FallsThrough", func(t *testing.T) {
+		// PSY-552 regression check: a non-nil Username pointer pointing at
+		// an empty string must NOT short-circuit the chain (the original bug
+		// was treating *Username==""\ as a valid display name).
+		empty := ""
+		first := "Backup"
+		u := &authm.User{Username: &empty, FirstName: &first}
+		u.ID = 12
+		assert.Equal(t, "Backup", resolveCommentAuthorName(u))
+	})
+}
+
+// PSY-552: AuthorUsername must be non-nil only when the user has a real
+// username. Mirrors PSY-353's resolveUserUsername: nil signals to the
+// frontend "render byline as plain text — no /users/:slug link".
+func TestResolveCommentAuthorUsername(t *testing.T) {
+	t.Run("NilUser_Nil", func(t *testing.T) {
+		assert.Nil(t, resolveCommentAuthorUsername(nil))
+	})
+
+	t.Run("ZeroIDUser_Nil", func(t *testing.T) {
+		assert.Nil(t, resolveCommentAuthorUsername(&authm.User{}))
+	})
+
+	t.Run("NoUsername_Nil", func(t *testing.T) {
+		first := "Jane"
+		u := &authm.User{FirstName: &first}
+		u.ID = 1
+		assert.Nil(t, resolveCommentAuthorUsername(u))
+	})
+
+	t.Run("EmptyUsername_Nil", func(t *testing.T) {
+		empty := ""
+		u := &authm.User{Username: &empty}
+		u.ID = 2
+		assert.Nil(t, resolveCommentAuthorUsername(u))
+	})
+
+	t.Run("UsernameSet_Pointer", func(t *testing.T) {
+		username := "ph_user"
+		u := &authm.User{Username: &username}
+		u.ID = 3
+		got := resolveCommentAuthorUsername(u)
+		if assert.NotNil(t, got) {
+			assert.Equal(t, "ph_user", *got)
+		}
+	})
+}
+
 func TestWilsonScore(t *testing.T) {
 	t.Run("NoVotes", func(t *testing.T) {
 		score := wilsonScore(0, 0)
@@ -510,7 +613,13 @@ func (suite *CommentServiceIntegrationTestSuite) TestCreateComment_TopLevel_Arti
 	suite.Equal(0, comment.Ups)
 	suite.Equal(0, comment.Downs)
 	suite.False(comment.IsEdited)
-	suite.Equal("Test", comment.AuthorName)
+	// PSY-552: AuthorName uses the shared resolveUserName chain — username
+	// wins over first/last when set. createTestUser sets both, so the
+	// username is what surfaces here.
+	suite.Require().NotNil(user.Username)
+	suite.Equal(*user.Username, comment.AuthorName)
+	suite.Require().NotNil(comment.AuthorUsername)
+	suite.Equal(*user.Username, *comment.AuthorUsername)
 }
 
 func (suite *CommentServiceIntegrationTestSuite) TestCreateComment_TopLevel_Venue() {
@@ -539,6 +648,67 @@ func (suite *CommentServiceIntegrationTestSuite) TestCreateComment_TopLevel_Show
 	suite.Require().NoError(err)
 	suite.Equal("show", comment.EntityType)
 	suite.Equal(showID, comment.EntityID)
+}
+
+// PSY-552: AuthorName must never be empty. Users without username/first/last
+// name should fall back to the local-part of their email (matching the
+// PSY-353 resolveUserName chain used everywhere else). AuthorUsername must
+// be nil-pointer for those users so the frontend renders the byline as
+// plain text rather than a broken /users/ link.
+func (suite *CommentServiceIntegrationTestSuite) TestCreateComment_AuthorName_EmailPrefixFallback() {
+	// User has only an email — no username, no first/last.
+	email := fmt.Sprintf("dogfood+%d@psychichomily.com", time.Now().UnixNano())
+	user := &authm.User{
+		Email:         &email,
+		IsActive:      true,
+		EmailVerified: true,
+		UserTier:      "contributor",
+	}
+	suite.Require().NoError(suite.db.Create(user).Error)
+
+	artistID := suite.createTestArtist("Email Prefix Artist")
+	comment, err := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "Hello",
+	})
+	suite.Require().NoError(err)
+
+	// Local-part of the email (everything before '@') is the fallback.
+	prefix := email[:strings.Index(email, "@")]
+	suite.Equal(prefix, comment.AuthorName, "author_name must fall back to email prefix")
+	suite.NotEmpty(comment.AuthorName, "author_name must never be empty")
+	suite.Nil(comment.AuthorUsername, "author_username must be nil for users without a username")
+}
+
+// PSY-552: When the user has a username, AuthorName surfaces the username
+// AND AuthorUsername is populated so the frontend can link the byline to
+// /users/:username. Both kinds (comment and field_note) share the same
+// commentToResponse path, so this test exercises a field note for coverage
+// across the two code paths.
+func (suite *CommentServiceIntegrationTestSuite) TestCreateFieldNote_AuthorNameAndUsernamePopulated() {
+	user := suite.createTestUser() // sets username + first/last
+	suite.Require().NotNil(user.Username)
+
+	// Field notes require a past show.
+	slug := fmt.Sprintf("past-show-%d", time.Now().UnixNano())
+	show := &catalogm.Show{
+		Title:     "Past Show",
+		Slug:      &slug,
+		EventDate: time.Now().Add(-24 * time.Hour),
+		Status:    catalogm.ShowStatusApproved,
+	}
+	suite.Require().NoError(suite.db.Create(show).Error)
+
+	note, err := suite.commentService.CreateFieldNote(user.ID, &contracts.CreateFieldNoteRequest{
+		ShowID: show.ID,
+		Body:   "Excellent set",
+	})
+	suite.Require().NoError(err)
+	suite.Equal("field_note", note.Kind)
+	suite.Equal(*user.Username, note.AuthorName)
+	suite.Require().NotNil(note.AuthorUsername)
+	suite.Equal(*user.Username, *note.AuthorUsername)
 }
 
 func (suite *CommentServiceIntegrationTestSuite) TestCreateComment_EntityNotFound() {

--- a/backend/internal/services/engagement/comment_service_test.go
+++ b/backend/internal/services/engagement/comment_service_test.go
@@ -351,8 +351,9 @@ func TestResolveCommentAuthorName(t *testing.T) {
 
 	t.Run("EmptyUsernamePointer_FallsThrough", func(t *testing.T) {
 		// PSY-552 regression check: a non-nil Username pointer pointing at
-		// an empty string must NOT short-circuit the chain (the original bug
-		// was treating *Username==""\ as a valid display name).
+		// an empty string must NOT short-circuit the chain (the original
+		// bug surfaced because *Username == "" was treated as a valid
+		// display name, leaking an empty author_name on the wire).
 		empty := ""
 		first := "Backup"
 		u := &authm.User{Username: &empty, FirstName: &first}

--- a/frontend/features/comments/components/CommentCard.test.tsx
+++ b/frontend/features/comments/components/CommentCard.test.tsx
@@ -291,3 +291,61 @@ describe('CommentCard — Show replies button gating (PSY-514)', () => {
     ).not.toBeInTheDocument()
   })
 })
+
+// PSY-552: linkable author byline. When author_username is set the byline
+// renders as a Link to /users/:username; otherwise it falls back to plain
+// text (matches the PSY-353 collection contributor pattern).
+describe('CommentCard — author byline linkability (PSY-552)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuthContext.mockReturnValue({
+      isAuthenticated: false,
+      user: null,
+    })
+  })
+
+  const defaultProps = {
+    entityType: 'artist',
+    entityId: 10,
+  }
+
+  it('links the byline to /users/:username when author_username is set', () => {
+    render(
+      <CommentCard
+        {...defaultProps}
+        comment={makeComment({
+          author_name: 'Jane Doe',
+          author_username: 'janedoe',
+        })}
+      />
+    )
+
+    const link = screen.getByTestId('comment-author-link')
+    expect(link).toHaveAttribute('href', '/users/janedoe')
+    expect(link).toHaveTextContent('Jane Doe')
+    expect(screen.queryByTestId('comment-author-name')).not.toBeInTheDocument()
+  })
+
+  it('renders the byline as plain text when author_username is null', () => {
+    render(
+      <CommentCard
+        {...defaultProps}
+        comment={makeComment({
+          author_name: 'jane',
+          author_username: null,
+        })}
+      />
+    )
+
+    expect(screen.getByTestId('comment-author-name')).toHaveTextContent('jane')
+    expect(screen.queryByTestId('comment-author-link')).not.toBeInTheDocument()
+  })
+
+  it('renders the byline as plain text when author_username is missing', () => {
+    // Older payloads or paths that haven't propagated the field yet.
+    render(<CommentCard {...defaultProps} comment={makeComment()} />)
+
+    expect(screen.getByTestId('comment-author-name')).toBeInTheDocument()
+    expect(screen.queryByTestId('comment-author-link')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/features/comments/components/CommentCard.tsx
+++ b/frontend/features/comments/components/CommentCard.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import Link from 'next/link'
 import { ChevronUp, ChevronDown, MessageSquare, Pencil, Trash2, ChevronRight, Flag, History, Lock, Clock } from 'lucide-react'
 import { formatRelativeTime } from '@/lib/formatRelativeTime'
 import { useAuthContext } from '@/lib/context/AuthContext'
@@ -129,9 +130,26 @@ export function CommentCard({
 
   return (
     <div className={depthMargin} data-testid="comment-card">
-      {/* Header: author + timestamp */}
+      {/* Header: author + timestamp. PSY-552: link byline to the author's
+          profile when author_username is set; otherwise plain text (matches
+          PSY-353 collection attribution). */}
       <div className="flex items-center gap-2 text-sm">
-        <span className="font-medium text-foreground">{comment.author_name}</span>
+        {comment.author_username ? (
+          <Link
+            href={`/users/${comment.author_username}`}
+            className="font-medium text-foreground hover:underline"
+            data-testid="comment-author-link"
+          >
+            {comment.author_name}
+          </Link>
+        ) : (
+          <span
+            className="font-medium text-foreground"
+            data-testid="comment-author-name"
+          >
+            {comment.author_name}
+          </span>
+        )}
         <span className="text-muted-foreground">
           {formatRelativeTime(comment.created_at)}
         </span>

--- a/frontend/features/comments/components/FieldNoteCard.test.tsx
+++ b/frontend/features/comments/components/FieldNoteCard.test.tsx
@@ -265,6 +265,47 @@ describe('FieldNoteCard', () => {
     expect(screen.getByText('Edited')).toBeInTheDocument()
   })
 
+  // PSY-552: linkable author byline — same shape as CommentCard.
+  describe('author byline linkability (PSY-552)', () => {
+    it('links the byline to /users/:username when author_username is set', () => {
+      render(
+        <FieldNoteCard
+          comment={makeFieldNote({
+            author_name: 'Jane Doe',
+            author_username: 'janedoe',
+          })}
+          showId={10}
+        />
+      )
+
+      const link = screen.getByTestId('field-note-author-link')
+      expect(link).toHaveAttribute('href', '/users/janedoe')
+      expect(link).toHaveTextContent('Jane Doe')
+      expect(
+        screen.queryByTestId('field-note-author-name')
+      ).not.toBeInTheDocument()
+    })
+
+    it('renders plain text byline when author_username is null', () => {
+      render(
+        <FieldNoteCard
+          comment={makeFieldNote({
+            author_name: 'jane',
+            author_username: null,
+          })}
+          showId={10}
+        />
+      )
+
+      expect(screen.getByTestId('field-note-author-name')).toHaveTextContent(
+        'jane'
+      )
+      expect(
+        screen.queryByTestId('field-note-author-link')
+      ).not.toBeInTheDocument()
+    })
+  })
+
   // PSY-514: same zero-reply gating that applies to CommentCard.
   describe('Show replies button gating (PSY-514)', () => {
     it('does NOT render "Show replies" when reply_count is 0', () => {

--- a/frontend/features/comments/components/FieldNoteCard.tsx
+++ b/frontend/features/comments/components/FieldNoteCard.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import Link from 'next/link'
 import { ChevronUp, ChevronDown, MessageSquare, Star, CheckCircle, Eye, EyeOff, Flag, Clock } from 'lucide-react'
 import { formatRelativeTime } from '@/lib/formatRelativeTime'
 import { useAuthContext } from '@/lib/context/AuthContext'
@@ -106,9 +107,26 @@ export function FieldNoteCard({
 
   return (
     <div data-testid="field-note-card" className="rounded-lg border border-border/50 bg-card p-4">
-      {/* Header: author + verified badge + timestamp */}
+      {/* Header: author + verified badge + timestamp. PSY-552: link byline
+          to the author's profile when author_username is set; otherwise
+          plain text. */}
       <div className="flex items-center gap-2 text-sm">
-        <span className="font-medium text-foreground">{comment.author_name}</span>
+        {comment.author_username ? (
+          <Link
+            href={`/users/${comment.author_username}`}
+            className="font-medium text-foreground hover:underline"
+            data-testid="field-note-author-link"
+          >
+            {comment.author_name}
+          </Link>
+        ) : (
+          <span
+            className="font-medium text-foreground"
+            data-testid="field-note-author-name"
+          >
+            {comment.author_name}
+          </span>
+        )}
         {isVerified && (
           <Badge
             variant="secondary"

--- a/frontend/features/comments/types.ts
+++ b/frontend/features/comments/types.ts
@@ -26,6 +26,12 @@ export interface Comment {
   entity_id: number
   user_id: number
   author_name: string
+  /**
+   * Author's username when set, used to link the byline to /users/:username.
+   * Null when the user has not set a username — render the name as plain
+   * text in that case (PSY-552, mirrors PSY-353 collection attribution).
+   */
+  author_username?: string | null
   body: string
   body_html: string
   parent_id: number | null


### PR DESCRIPTION
## Summary
- Backend: `commentToResponse` now runs the shared PSY-353 resolver chain (username → first/last → email-prefix → "Anonymous") via two new helpers, so `author_name` is never empty across both comment kinds (`comment` and `field_note`). `AuthorUsername` is now `*string` with `json:"author_username"` (no `omitempty`) so the frontend can distinguish "no username set" (null) from "field absent."
- Frontend: `CommentCard` and `FieldNoteCard` render the byline as a `<Link>` to `/users/:username` when `author_username` is set; otherwise plain text. Same shape as the PSY-353 collection contributor attribution.
- Tests: pure-function unit tests lock down the resolver chain (no DB), integration tests cover email-prefix fallback and the field-note path, vitest specs cover linked / unlinked / missing-field render branches.

## Test plan
- [ ] backend tests pass (`go test ./...` for the comments package)
- [ ] frontend typecheck passes
- [ ] manual: comment as user without first/last name → name renders as email prefix
- [ ] manual: comment as user with username → name links to /users/{username}

Closes PSY-552

🤖 Generated with [Claude Code](https://claude.com/claude-code)