### PR TITLE
PSY-553: surface tagged collections on tag detail page

### DIFF
--- a/backend/internal/services/catalog/tag_service.go
+++ b/backend/internal/services/catalog/tag_service.go
@@ -1180,6 +1180,13 @@ func (s *TagService) GetTagEntities(tagID uint, entityType string, limit, offset
 			enrichedByType[eType] = s.enrichReleases(ids)
 		case "show":
 			enrichedByType[eType] = s.enrichShows(ids)
+		case "collection":
+			// PSY-553: collections (PSY-354) need their own enrichment branch.
+			// `enrichBare` would fail anyway because collections aren't in
+			// `entityTableMap`, but more importantly: tag detail is a public
+			// page and tagged-but-private collections must not leak via this
+			// endpoint, so this branch applies an `is_public = true` filter.
+			enrichedByType[eType] = s.enrichCollections(ids)
 		default:
 			enrichedByType[eType] = s.enrichBare(eType, ids)
 		}
@@ -1199,6 +1206,12 @@ func (s *TagService) GetTagEntities(tagID uint, entityType string, limit, offset
 				enriched.EntityType = et.EntityType
 				enriched.EntityID = et.EntityID
 				item = enriched
+			} else if et.EntityType == "collection" {
+				// PSY-553: enrichCollections deliberately drops private (and
+				// deleted) collections so the public tag detail page can't
+				// leak them. A missed lookup here means "intentionally
+				// hidden" — skip rather than emitting a bare empty-name row.
+				continue
 			}
 		}
 		items = append(items, item)
@@ -1545,6 +1558,49 @@ func (s *TagService) enrichShows(ids []uint) map[uint]contracts.TaggedEntityItem
 			VenueSlug:     r.VenueSlug,
 			HeadlinerName: r.HeadlinerName,
 			HeadlinerSlug: r.HeadlinerSlug,
+		}
+	}
+	return out
+}
+
+// enrichCollections resolves tagged collections to (title → name, slug).
+//
+// PSY-553: tag detail is a public, unauthenticated endpoint, so private
+// collections must NOT leak through this surface even when tagged. The
+// `is_public = true` filter is applied directly in the SQL; collections
+// excluded here are dropped from the response in the build loop above
+// (by the matching `if et.EntityType == "collection" { continue }`
+// branch on a missed lookup). Public collections that have since been
+// deleted are also naturally excluded.
+//
+// Unlike artist/venue/etc., we do not fall back to `enrichBare` on query
+// error: `entityTableMap` does not contain "collection", and a fallthrough
+// would expose an empty-name placeholder for every tagged collection. On
+// query error we return an empty map, which means "drop everything" — the
+// log will show the underlying issue while the user sees a missing tab
+// rather than a leak of every tagged collection's id.
+func (s *TagService) enrichCollections(ids []uint) map[uint]contracts.TaggedEntityItem {
+	out := make(map[uint]contracts.TaggedEntityItem, len(ids))
+	type row struct {
+		ID    uint
+		Title string
+		Slug  string
+	}
+	var rows []row
+	if err := s.db.Raw(`
+		SELECT id,
+		       title,
+		       COALESCE(slug, '') AS slug
+		FROM collections
+		WHERE id IN ?
+		  AND is_public = true
+	`, ids).Scan(&rows).Error; err != nil {
+		return out
+	}
+	for _, r := range rows {
+		out[r.ID] = contracts.TaggedEntityItem{
+			Name: r.Title,
+			Slug: r.Slug,
 		}
 	}
 	return out

--- a/backend/internal/services/catalog/tag_service.go
+++ b/backend/internal/services/catalog/tag_service.go
@@ -1181,11 +1181,6 @@ func (s *TagService) GetTagEntities(tagID uint, entityType string, limit, offset
 		case "show":
 			enrichedByType[eType] = s.enrichShows(ids)
 		case "collection":
-			// PSY-553: collections (PSY-354) need their own enrichment branch.
-			// `enrichBare` would fail anyway because collections aren't in
-			// `entityTableMap`, but more importantly: tag detail is a public
-			// page and tagged-but-private collections must not leak via this
-			// endpoint, so this branch applies an `is_public = true` filter.
 			enrichedByType[eType] = s.enrichCollections(ids)
 		default:
 			enrichedByType[eType] = s.enrichBare(eType, ids)
@@ -1207,10 +1202,9 @@ func (s *TagService) GetTagEntities(tagID uint, entityType string, limit, offset
 				enriched.EntityID = et.EntityID
 				item = enriched
 			} else if et.EntityType == "collection" {
-				// PSY-553: enrichCollections deliberately drops private (and
-				// deleted) collections so the public tag detail page can't
-				// leak them. A missed lookup here means "intentionally
-				// hidden" — skip rather than emitting a bare empty-name row.
+				// PSY-553: enrichCollections drops private + deleted
+				// collections so the public tag detail page can't leak
+				// them; skip rather than emit an empty-name placeholder.
 				continue
 			}
 		}
@@ -1565,20 +1559,14 @@ func (s *TagService) enrichShows(ids []uint) map[uint]contracts.TaggedEntityItem
 
 // enrichCollections resolves tagged collections to (title → name, slug).
 //
-// PSY-553: tag detail is a public, unauthenticated endpoint, so private
-// collections must NOT leak through this surface even when tagged. The
-// `is_public = true` filter is applied directly in the SQL; collections
-// excluded here are dropped from the response in the build loop above
-// (by the matching `if et.EntityType == "collection" { continue }`
-// branch on a missed lookup). Public collections that have since been
-// deleted are also naturally excluded.
-//
-// Unlike artist/venue/etc., we do not fall back to `enrichBare` on query
-// error: `entityTableMap` does not contain "collection", and a fallthrough
-// would expose an empty-name placeholder for every tagged collection. On
-// query error we return an empty map, which means "drop everything" — the
-// log will show the underlying issue while the user sees a missing tab
-// rather than a leak of every tagged collection's id.
+// PSY-553: tag detail is public, so private collections must NOT leak
+// through this surface even when tagged — the `is_public = true` filter is
+// load-bearing. Excluded collections (private OR deleted) are dropped from
+// the response in the build loop above via the matching collection-type
+// continue branch. On query error we return an empty map (drop all) rather
+// than fall back to `enrichBare` because `entityTableMap` has no collection
+// entry and a fallthrough would surface every tagged collection's id with
+// an empty name.
 func (s *TagService) enrichCollections(ids []uint) map[uint]contracts.TaggedEntityItem {
 	out := make(map[uint]contracts.TaggedEntityItem, len(ids))
 	type row struct {

--- a/backend/internal/services/catalog/tag_service_test.go
+++ b/backend/internal/services/catalog/tag_service_test.go
@@ -12,6 +12,7 @@ import (
 	apperrors "psychic-homily-backend/internal/errors"
 	authm "psychic-homily-backend/internal/models/auth"
 	catalogm "psychic-homily-backend/internal/models/catalog"
+	communitym "psychic-homily-backend/internal/models/community"
 	"psychic-homily-backend/internal/services/contracts"
 	"psychic-homily-backend/internal/testutil"
 )
@@ -84,6 +85,10 @@ func (suite *TagServiceIntegrationTestSuite) SetupTest() {
 	_, _ = sqlDB.Exec("DELETE FROM shows")
 	_, _ = sqlDB.Exec("DELETE FROM artists")
 	_, _ = sqlDB.Exec("DELETE FROM venues")
+	// PSY-553: collections need cleanup so the GetTagEntities collection
+	// branch test (which exercises the is_public visibility filter) starts
+	// from a known empty state. Cascading FKs handle child tables.
+	_, _ = sqlDB.Exec("DELETE FROM collections")
 	_, _ = sqlDB.Exec("DELETE FROM users")
 }
 
@@ -1153,6 +1158,76 @@ func (suite *TagServiceIntegrationTestSuite) createVenue(name string) uint {
 	err := suite.db.Create(venue).Error
 	suite.Require().NoError(err)
 	return venue.ID
+}
+
+// createCollection creates a minimal collection for tag-collection tests.
+// `isPublic` controls the visibility flag the GetTagEntities collection
+// branch checks (PSY-553).
+//
+// GORM zero-value gotcha: `IsPublic: false` on Create is the bool zero value
+// and GORM skips the column, so the DB default (`true`) would win. We always
+// Create with `IsPublic: true` and Update to false when the caller asked for
+// private — same pattern as the IsActive fix called out in MEMORY.md.
+func (suite *TagServiceIntegrationTestSuite) createCollection(creatorID uint, title string, isPublic bool) *communitym.Collection {
+	slug := fmt.Sprintf("%s-%d", title, time.Now().UnixNano())
+	c := &communitym.Collection{
+		Title:     title,
+		Slug:      slug,
+		CreatorID: creatorID,
+		IsPublic:  true,
+	}
+	err := suite.db.Create(c).Error
+	suite.Require().NoError(err)
+	if !isPublic {
+		err = suite.db.Model(c).Update("is_public", false).Error
+		suite.Require().NoError(err)
+		c.IsPublic = false
+	}
+	return c
+}
+
+// PSY-553: tagged collections must surface with non-empty name/slug on the
+// public tag-detail endpoint, and private collections must NOT leak through
+// it even when tagged. Both clauses live in the same test so a regression to
+// either side fails together.
+func (suite *TagServiceIntegrationTestSuite) TestGetTagEntities_Collections_PublicAndPrivate() {
+	user := suite.createTestUserWithTier("tagger", "contributor")
+	tag := suite.createTag("psychedelic", "genre")
+
+	publicColl := suite.createCollection(user.ID, "Public Picks", true)
+	privateColl := suite.createCollection(user.ID, "Private Picks", false)
+
+	_, err := suite.tagService.AddTagToEntity(tag.ID, "", catalogm.TagEntityCollection, publicColl.ID, user.ID, "")
+	suite.Require().NoError(err)
+	_, err = suite.tagService.AddTagToEntity(tag.ID, "", catalogm.TagEntityCollection, privateColl.ID, user.ID, "")
+	suite.Require().NoError(err)
+
+	items, _, err := suite.tagService.GetTagEntities(tag.ID, "", 50, 0)
+	suite.Require().NoError(err)
+
+	// Filter to just the collection rows so this test stays focused on the
+	// collection branch — co-existing tagged entity types in this suite would
+	// otherwise need their own asserts.
+	var collItems []contracts.TaggedEntityItem
+	for _, it := range items {
+		if it.EntityType == catalogm.TagEntityCollection {
+			collItems = append(collItems, it)
+		}
+	}
+
+	suite.Require().Len(collItems, 1, "private collection must be excluded from the public tag-entities response")
+	suite.Assert().Equal(publicColl.ID, collItems[0].EntityID)
+	suite.Assert().Equal("Public Picks", collItems[0].Name, "title should map to the response `name` field")
+	suite.Assert().NotEmpty(collItems[0].Slug, "slug must be populated so the frontend can build /collections/{slug}")
+	suite.Assert().Equal(publicColl.Slug, collItems[0].Slug)
+
+	// Same assertion via the entity_type filter — exercises the
+	// `entity_type=collection` query-param path the frontend uses.
+	filtered, _, err := suite.tagService.GetTagEntities(tag.ID, catalogm.TagEntityCollection, 50, 0)
+	suite.Require().NoError(err)
+	suite.Require().Len(filtered, 1)
+	suite.Assert().Equal(publicColl.ID, filtered[0].EntityID)
+	suite.Assert().Equal("Public Picks", filtered[0].Name)
 }
 
 func (suite *TagServiceIntegrationTestSuite) TestGetTagDetail_NotFound() {

--- a/frontend/features/tags/components/TagDetail.tsx
+++ b/frontend/features/tags/components/TagDetail.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from 'react'
 import Link from 'next/link'
-import { ArrowLeft, Hash, Loader2, Music, MapPin, Calendar, Disc3, Tag, Tent, Clock } from 'lucide-react'
+import { ArrowLeft, Hash, Loader2, Library, Music, MapPin, Calendar, Disc3, Tag, Tent, Clock } from 'lucide-react'
 import { NotifyMeButton } from '@/features/notifications'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
@@ -19,8 +19,23 @@ interface TagDetailProps {
   slug: string
 }
 
-/** Entity type display order — genre tags use parent/children nav; others are flat. */
-const ENTITY_TYPE_ORDER = ['artist', 'venue', 'show', 'release', 'label', 'festival'] as const
+/**
+ * Entity type display order — genre tags use parent/children nav; others are flat.
+ *
+ * PSY-553: collections (PSY-354) appear after the existing entity-type tabs
+ * because they're a meta-type — a collection-of-entities, not a primary
+ * entity. Tabs whose count is zero are filtered out below, so the Collections
+ * tab is hidden until at least one tagged collection is public.
+ */
+const ENTITY_TYPE_ORDER = [
+  'artist',
+  'venue',
+  'show',
+  'release',
+  'label',
+  'festival',
+  'collection',
+] as const
 
 const ENTITY_TYPE_ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
   artist: Music,
@@ -29,6 +44,7 @@ const ENTITY_TYPE_ICONS: Record<string, React.ComponentType<{ className?: string
   release: Disc3,
   label: Tag,
   festival: Tent,
+  collection: Library,
 }
 
 /** Singular display label for entity types used in the breakdown row. */
@@ -46,6 +62,8 @@ function getEntityTypeSingularLabel(entityType: string): string {
       return 'label'
     case 'festival':
       return 'festival'
+    case 'collection':
+      return 'collection'
     default:
       return entityType
   }

--- a/frontend/features/tags/components/TaggedEntityCards.tsx
+++ b/frontend/features/tags/components/TaggedEntityCards.tsx
@@ -15,7 +15,7 @@
  */
 
 import Link from 'next/link'
-import { BadgeCheck, Calendar, MapPin, Music, Disc3, Tag } from 'lucide-react'
+import { BadgeCheck, Calendar, Library, MapPin, Music, Disc3, Tag } from 'lucide-react'
 import { ArtistCard } from '@/features/artists'
 import { FestivalCard } from '@/features/festivals'
 import { LabelCard } from '@/features/labels'
@@ -224,6 +224,36 @@ function TaggedShowRow({ item }: { item: TaggedEntityItem }) {
   )
 }
 
+/**
+ * PSY-553: tagged collection row. The backend (`enrichCollections`) only
+ * populates name + slug for collections (no city/state/counts), and the
+ * full CollectionCard requires a heavyweight shape with item counts,
+ * contributor counts, like state, etc. that the tag-entities endpoint
+ * doesn't return. Following the TaggedShowRow / TaggedVenueRow precedent,
+ * we render a minimal inline row that links to /collections/{slug}.
+ */
+function TaggedCollectionRow({ item }: { item: TaggedEntityItem }) {
+  return (
+    <article className="rounded-lg border border-border/50 bg-card p-4 transition-shadow hover:shadow-sm">
+      <div className="flex items-start gap-3">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-muted/50">
+          <Library className="h-5 w-5 text-muted-foreground/70" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <Link
+            href={getEntityUrl('collection', item.slug)}
+            className="block group"
+          >
+            <h3 className="font-bold text-base text-foreground group-hover:text-primary transition-colors truncate">
+              {item.name}
+            </h3>
+          </Link>
+        </div>
+      </div>
+    </article>
+  )
+}
+
 // ──────────────────────────────────────────────
 // Public renderer
 // ──────────────────────────────────────────────
@@ -251,6 +281,8 @@ export function TaggedEntityCard({ item }: TaggedEntityCardProps) {
       return <TaggedReleaseCard item={item} />
     case 'show':
       return <TaggedShowRow item={item} />
+    case 'collection':
+      return <TaggedCollectionRow item={item} />
     default:
       return (
         <article className="rounded-lg border border-border/50 bg-card p-4">
@@ -277,5 +309,6 @@ export const ENTITY_TYPE_TAB_ICON: Record<
   label: Tag,
   release: Disc3,
   show: Calendar,
+  collection: Library,
 }
 

--- a/frontend/features/tags/types.ts
+++ b/frontend/features/tags/types.ts
@@ -376,6 +376,10 @@ export function getEntityUrl(entityType: string, entitySlug: string): string {
       return `/labels/${entitySlug}`
     case 'festival':
       return `/festivals/${entitySlug}`
+    case 'collection':
+      // PSY-553: tagged collections (PSY-354) link to the same detail page
+      // entity-card chips link to from the collection browse list.
+      return `/collections/${entitySlug}`
     default:
       return '#'
   }
@@ -396,6 +400,9 @@ export function getEntityTypePluralLabel(entityType: string): string {
       return 'Labels'
     case 'festival':
       return 'Festivals'
+    case 'collection':
+      // PSY-553: powering the "Collections N" tab on the tag detail page.
+      return 'Collections'
     default:
       return entityType
   }


### PR DESCRIPTION
## Summary
- Backend `GetTagEntities` had no `case "collection"` branch, so collection rows came back with empty name/slug. Add `enrichCollections` mapping `collections.title → name` with an `is_public = true` filter so private collections never leak through the public tag-detail endpoint; collections that fail the visibility lookup are dropped from the response rather than emitting bare empty-name placeholders.
- Frontend extends `ENTITY_TYPE_ORDER` with `collection` (after the existing entity types — meta-type), adds the icon + plural/singular labels + URL helper, and a minimal `TaggedCollectionRow` linking to `/collections/{slug}`. Tabs whose count is zero are already filtered out by the existing `sortedTypes` logic, so the Collections tab is hidden until a public collection is tagged.

## Test plan
- [ ] backend tests pass for tags package
- [ ] frontend typecheck passes
- [ ] manual: tag a public collection, visit /tags/{slug}, see Collections N tab + the collection
- [ ] manual: tag a private collection, visit /tags/{slug}, do NOT see it

Closes PSY-553