### PR TITLE
PSY-554: typed Lucide fallback for collection cover (null + onError)

### DIFF
--- a/frontend/features/collections/components/CollectionCard.test.tsx
+++ b/frontend/features/collections/components/CollectionCard.test.tsx
@@ -200,6 +200,29 @@ describe('CollectionCard', () => {
     expect(img).toHaveAttribute('src', 'https://example.com/cover.jpg')
   })
 
+  // PSY-554: when the cover URL 404s, the tile must not stay blank — the
+  // existing entity-type mosaic / Library fallback used for null URLs
+  // should also render after onError fires.
+  it('falls back to the entity-type mosaic when the cover image fails to load', () => {
+    const collection = {
+      ...baseCollection,
+      cover_image_url: 'https://example.com/missing.jpg',
+      entity_type_counts: { artist: 3, release: 1 },
+    }
+    render(<CollectionCard collection={collection} />)
+
+    const img = screen.getByRole('img', { name: 'Arizona Indie Essentials cover' })
+    fireEvent.error(img)
+    expect(
+      screen.queryByRole('img', { name: 'Arizona Indie Essentials cover' })
+    ).not.toBeInTheDocument()
+    // Mosaic icons replace the broken image; we don't assert on the
+    // specific Lucide markup since that's an implementation detail of
+    // CollectionCoverImage's fallback prop. Sanity-check is that the
+    // image is gone but the surrounding card is still intact.
+    expect(screen.getByText('Arizona Indie Essentials')).toBeInTheDocument()
+  })
+
   // PSY-350: "N new since last visit" badge
   it('renders the N-new badge when new_since_last_visit > 0', () => {
     const collection = { ...baseCollection, new_since_last_visit: 3 }

--- a/frontend/features/collections/components/CollectionCard.tsx
+++ b/frontend/features/collections/components/CollectionCard.tsx
@@ -20,6 +20,7 @@ import { Badge } from '@/components/ui/badge'
 import { formatRelativeTime } from '@/lib/formatRelativeTime'
 import { getEntityTypeLabel, type Collection } from '../types'
 import { MarkdownContent } from './MarkdownEditor'
+import { CollectionCoverImage } from './CollectionCoverImage'
 import { useLikeCollection, useUnlikeCollection } from '../hooks'
 import { useAuthContext } from '@/lib/context/AuthContext'
 
@@ -68,44 +69,45 @@ export function CollectionCard({ collection }: CollectionCardProps) {
   return (
     <article className="rounded-lg border border-border/50 bg-card p-4 transition-shadow hover:shadow-sm">
       <div className="flex gap-3">
-        {/* Icon / cover image / entity-type mosaic */}
-        <div className="h-16 w-16 shrink-0 rounded-md bg-muted/50 flex items-center justify-center overflow-hidden">
-          {collection.cover_image_url ? (
-            <img
-              src={collection.cover_image_url}
-              alt={`${collection.title} cover`}
-              className="h-full w-full object-cover"
-            />
-          ) : mosaicTypes.length > 0 ? (
-            <div
-              className={cn(
-                'grid gap-0.5 p-1.5',
-                mosaicTypes.length === 1
-                  ? 'grid-cols-1'
-                  : 'grid-cols-2'
-              )}
-            >
-              {mosaicTypes.map((type) => {
-                const Icon = ENTITY_ICONS[type] ?? Library
-                return (
-                  <div
-                    key={type}
-                    className="flex items-center justify-center"
-                  >
-                    <Icon
-                      className={cn(
-                        'text-muted-foreground/50',
-                        mosaicTypes.length === 1 ? 'h-7 w-7' : 'h-5 w-5'
-                      )}
-                    />
-                  </div>
-                )
-              })}
-            </div>
-          ) : (
-            <Library className="h-8 w-8 text-muted-foreground/40" />
-          )}
-        </div>
+        {/* Cover image with onError-driven fallback to entity-type mosaic
+            (or a single Library icon when no entity types are present).
+            PSY-554: a 404 on cover_image_url no longer leaves the tile
+            blank — it falls through to the same mosaic the null-URL case
+            already used. */}
+        <CollectionCoverImage
+          url={collection.cover_image_url}
+          alt={`${collection.title} cover`}
+          className="h-16 w-16 shrink-0 rounded-md bg-muted/50"
+          fallback={
+            mosaicTypes.length > 0 ? (
+              <div
+                className={cn(
+                  'grid gap-0.5 p-1.5',
+                  mosaicTypes.length === 1 ? 'grid-cols-1' : 'grid-cols-2'
+                )}
+              >
+                {mosaicTypes.map((type) => {
+                  const Icon = ENTITY_ICONS[type] ?? Library
+                  return (
+                    <div
+                      key={type}
+                      className="flex items-center justify-center"
+                    >
+                      <Icon
+                        className={cn(
+                          'text-muted-foreground/50',
+                          mosaicTypes.length === 1 ? 'h-7 w-7' : 'h-5 w-5'
+                        )}
+                      />
+                    </div>
+                  )
+                })}
+              </div>
+            ) : (
+              <Library className="h-8 w-8 text-muted-foreground/40" />
+            )
+          }
+        />
 
         {/* Text content */}
         <div className="flex-1 min-w-0">

--- a/frontend/features/collections/components/CollectionCoverImage.test.tsx
+++ b/frontend/features/collections/components/CollectionCoverImage.test.tsx
@@ -1,0 +1,117 @@
+import React from 'react'
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { CollectionCoverImage } from './CollectionCoverImage'
+
+const FALLBACK_TEXT = 'fallback content'
+
+function Fallback() {
+  return <span data-testid="fallback">{FALLBACK_TEXT}</span>
+}
+
+describe('CollectionCoverImage', () => {
+  it('renders the image when a URL is provided', () => {
+    render(
+      <CollectionCoverImage
+        url="https://example.com/cover.jpg"
+        alt="cover"
+        fallback={<Fallback />}
+      />
+    )
+
+    const img = screen.getByAltText('cover') as HTMLImageElement
+    expect(img).toBeInTheDocument()
+    expect(img.src).toBe('https://example.com/cover.jpg')
+    expect(screen.queryByTestId('fallback')).not.toBeInTheDocument()
+  })
+
+  it('renders the fallback when the URL is null', () => {
+    render(
+      <CollectionCoverImage url={null} alt="cover" fallback={<Fallback />} />
+    )
+
+    expect(screen.getByTestId('fallback')).toBeInTheDocument()
+    expect(screen.queryByAltText('cover')).not.toBeInTheDocument()
+  })
+
+  it('renders the fallback when the URL is an empty string', () => {
+    render(
+      <CollectionCoverImage url="" alt="cover" fallback={<Fallback />} />
+    )
+
+    expect(screen.getByTestId('fallback')).toBeInTheDocument()
+  })
+
+  it('renders the fallback when the URL is whitespace-only', () => {
+    render(
+      <CollectionCoverImage url="   " alt="cover" fallback={<Fallback />} />
+    )
+
+    expect(screen.getByTestId('fallback')).toBeInTheDocument()
+  })
+
+  it('falls back to the fallback when the image errors (404)', () => {
+    render(
+      <CollectionCoverImage
+        url="https://example.com/missing.jpg"
+        alt="cover"
+        fallback={<Fallback />}
+      />
+    )
+
+    const img = screen.getByAltText('cover')
+    expect(screen.queryByTestId('fallback')).not.toBeInTheDocument()
+    fireEvent.error(img)
+    expect(screen.getByTestId('fallback')).toBeInTheDocument()
+    expect(screen.queryByAltText('cover')).not.toBeInTheDocument()
+  })
+
+  it('forwards className to the outer container in both image and fallback states', () => {
+    const { rerender } = render(
+      <CollectionCoverImage
+        url="https://example.com/cover.jpg"
+        alt="cover"
+        className="h-24 w-24 rounded-lg"
+        fallback={<Fallback />}
+      />
+    )
+    const imageContainer = screen.getByAltText('cover').parentElement
+    expect(imageContainer).toHaveClass('h-24', 'w-24', 'rounded-lg')
+
+    rerender(
+      <CollectionCoverImage
+        url={null}
+        alt="cover"
+        className="h-24 w-24 rounded-lg"
+        fallback={<Fallback />}
+      />
+    )
+    // Same outer container, fallback now inside.
+    const fallbackContainer = screen.getByTestId('fallback').parentElement?.parentElement
+    expect(fallbackContainer).toHaveClass('h-24', 'w-24', 'rounded-lg')
+  })
+
+  it('clears the errored state when the URL changes to a new image', () => {
+    const { rerender } = render(
+      <CollectionCoverImage
+        url="https://example.com/missing.jpg"
+        alt="cover"
+        fallback={<Fallback />}
+      />
+    )
+    fireEvent.error(screen.getByAltText('cover'))
+    expect(screen.getByTestId('fallback')).toBeInTheDocument()
+
+    rerender(
+      <CollectionCoverImage
+        url="https://example.com/working.jpg"
+        alt="cover"
+        fallback={<Fallback />}
+      />
+    )
+    // New URL, errored flag reset, image rendered again.
+    const img = screen.getByAltText('cover') as HTMLImageElement
+    expect(img.src).toBe('https://example.com/working.jpg')
+    expect(screen.queryByTestId('fallback')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/features/collections/components/CollectionCoverImage.test.tsx
+++ b/frontend/features/collections/components/CollectionCoverImage.test.tsx
@@ -3,10 +3,8 @@ import { describe, it, expect } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { CollectionCoverImage } from './CollectionCoverImage'
 
-const FALLBACK_TEXT = 'fallback content'
-
 function Fallback() {
-  return <span data-testid="fallback">{FALLBACK_TEXT}</span>
+  return <span data-testid="fallback">fallback content</span>
 }
 
 describe('CollectionCoverImage', () => {

--- a/frontend/features/collections/components/CollectionCoverImage.tsx
+++ b/frontend/features/collections/components/CollectionCoverImage.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+/**
+ * CollectionCoverImage (PSY-554)
+ *
+ * Shared cover-image renderer for the collection detail header and the
+ * browse list card. Internalizes two small but easy-to-forget concerns:
+ *
+ *   1. Null/empty `url` — render the supplied `fallback` instead of a
+ *      broken or empty `<img>`.
+ *   2. `<img>` `onError` — when the URL resolves to a 404 (or any load
+ *      failure), swap to the same `fallback`. Without this, a stale or
+ *      moved image leaves the cover slot blank with only alt text.
+ *
+ * The component is intentionally layout-agnostic: callers supply the tile
+ * shape (size, rounding, border, background) via `className` and the
+ * fallback content as children-via-prop. Each cover surface keeps its
+ * own visual language (h-16 mosaic on the browse card, h-24 typed
+ * Library icon on the detail page) without this component picking sides.
+ *
+ * PSY-360's CollectionItemCard.tsx is the per-item-card analog; this
+ * component covers the parallel "collection itself" cover sites.
+ */
+
+import { useState, type ReactNode } from 'react'
+import { cn } from '@/lib/utils'
+
+interface CollectionCoverImageProps {
+  /** Cover URL from `Collection.cover_image_url`. May be null/empty/undefined. */
+  url: string | null | undefined
+  /** Alt text for the rendered `<img>`. Ignored when the fallback renders. */
+  alt: string
+  /**
+   * Tile shape — size, rounding, border, background. The same classes
+   * apply to both the image container and the fallback container so the
+   * surrounding layout doesn't shift between states.
+   */
+  className?: string
+  /**
+   * What to render when `url` is null/empty OR the image fails to load.
+   * Each cover site supplies its own (typed Lucide icon on detail,
+   * entity-type mosaic on the browse card).
+   */
+  fallback: ReactNode
+}
+
+export function CollectionCoverImage({
+  url,
+  alt,
+  className,
+  fallback,
+}: CollectionCoverImageProps) {
+  const trimmed = url?.trim() ?? ''
+
+  // Track the URL alongside the error flag so the error state resets
+  // automatically when the URL changes (e.g. after an edit). Storing
+  // both in one piece of state — rather than syncing via useEffect —
+  // follows the React-recommended "reset state on prop change" pattern
+  // (https://react.dev/learn/you-might-not-need-an-effect#resetting-all-state-when-a-prop-changes).
+  const [errorState, setErrorState] = useState<{
+    url: string
+    errored: boolean
+  }>({ url: trimmed, errored: false })
+
+  // If the URL changed since we last recorded an error, reset during
+  // render — avoids a "load fallback briefly then flicker to image"
+  // round-trip from a useEffect-based reset.
+  const errored = errorState.url === trimmed && errorState.errored
+  const showImage = trimmed.length > 0 && !errored
+
+  return (
+    <div className={cn('overflow-hidden', className)}>
+      {showImage ? (
+        /* eslint-disable-next-line @next/next/no-img-element */
+        <img
+          src={trimmed}
+          alt={alt}
+          className="h-full w-full object-cover"
+          onError={() => setErrorState({ url: trimmed, errored: true })}
+        />
+      ) : (
+        // Centered fallback container so an icon (or any short content)
+        // sits in the middle of the tile. Mosaic-style fallbacks supply
+        // their own grid wrapper inside the children.
+        <div className="flex h-full w-full items-center justify-center">
+          {fallback}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/features/collections/components/CollectionCoverImage.tsx
+++ b/frontend/features/collections/components/CollectionCoverImage.tsx
@@ -52,20 +52,15 @@ export function CollectionCoverImage({
 }: CollectionCoverImageProps) {
   const trimmed = url?.trim() ?? ''
 
-  // Track the URL alongside the error flag so the error state resets
-  // automatically when the URL changes (e.g. after an edit). Storing
-  // both in one piece of state — rather than syncing via useEffect —
-  // follows the React-recommended "reset state on prop change" pattern
-  // (https://react.dev/learn/you-might-not-need-an-effect#resetting-all-state-when-a-prop-changes).
+  // Pin the errored flag to the URL it was recorded for so a later URL
+  // change (e.g. after an edit) auto-resets without a useEffect. See
+  // https://react.dev/learn/you-might-not-need-an-effect#resetting-all-state-when-a-prop-changes.
   const [errorState, setErrorState] = useState<{
     url: string
     errored: boolean
   }>({ url: trimmed, errored: false })
 
-  // If the URL changed since we last recorded an error, reset during
-  // render — avoids a "load fallback briefly then flicker to image"
-  // round-trip from a useEffect-based reset.
-  const errored = errorState.url === trimmed && errorState.errored
+  const errored = errorState.errored && errorState.url === trimmed
   const showImage = trimmed.length > 0 && !errored
 
   return (

--- a/frontend/features/collections/components/CollectionDetail.tsx
+++ b/frontend/features/collections/components/CollectionDetail.tsx
@@ -87,6 +87,7 @@ import type { CollectionDisplayMode, CollectionItem, CollectionDetail as Collect
 import { MarkdownEditor, MarkdownContent } from './MarkdownEditor'
 import { CollectionGraph } from './CollectionGraph'
 import { CollectionItemCard } from './CollectionItemCard'
+import { CollectionCoverImage } from './CollectionCoverImage'
 import { useDensity, type Density } from '@/lib/hooks/common/useDensity'
 import { DensityToggle } from '@/components/shared'
 import { useEntitySearch } from '@/lib/hooks/common/useEntitySearch'
@@ -331,15 +332,20 @@ export function CollectionDetail({ slug }: CollectionDetailProps) {
           <div>
             <div className="flex items-start justify-between gap-4">
               <div className="flex items-start gap-4 min-w-0">
-                {collection.cover_image_url && (
-                  <div className="h-24 w-24 shrink-0 rounded-lg overflow-hidden border border-border/50 bg-muted/50">
-                    <img
-                      src={collection.cover_image_url}
-                      alt={`${collection.title} cover`}
-                      className="h-full w-full object-cover"
+                {/* PSY-554: cover always renders (typed Library icon when
+                    URL is null/empty or `<img>` 404s). Same h-24 footprint
+                    in either state so the header layout doesn't shift. */}
+                <CollectionCoverImage
+                  url={collection.cover_image_url}
+                  alt={`${collection.title} cover`}
+                  className="h-24 w-24 shrink-0 rounded-lg border border-border/50 bg-muted/50"
+                  fallback={
+                    <Library
+                      className="h-10 w-10 text-muted-foreground/50"
+                      aria-hidden="true"
                     />
-                  </div>
-                )}
+                  }
+                />
                 <div className="min-w-0">
                 <div className="flex items-center gap-3 mb-1 flex-wrap">
                   <h1 className="text-3xl font-bold tracking-tight">


### PR DESCRIPTION
## Summary
- Apply PSY-360 typed-Lucide fallback to collection cover (null URL or `<img>` `onError`).
- Cover detail page + browse card both fall back via a small shared `CollectionCoverImage` component (size + rounding kept identical between image and fallback states so layout doesn't shift).
- Detail page header now uses a typed `Library` icon as the fallback (it previously hid the cover entirely when null). Browse card keeps its existing entity-type mosaic / single-`Library` fallback — the fix there is wiring `onError` so a 404 falls through to that same fallback instead of leaving the tile blank.
- Out of scope (per ticket): the cover-image picker / upload preview on the InlineEditForm.

## Test plan
- [x] frontend typecheck passes
- [x] vitest run for collection components — 110/110 pass (102 pre-existing + 7 new in `CollectionCoverImage.test.tsx` + 1 new in `CollectionCard.test.tsx`)
- [ ] manual: collection with null `cover_image_url` renders Lucide icon, not blank
- [ ] manual: collection with broken URL (404) renders Lucide icon after `onError`
- [ ] manual: working URL still renders the image
- [ ] manual: layout doesn't shift between image and fallback

Closes PSY-554

🤖 Generated with [Claude Code](https://claude.com/claude-code)