### PR TITLE
PSY-555: collection graph renders all entity types (Option B)

### DIFF
--- a/backend/internal/services/collection.go
+++ b/backend/internal/services/collection.go
@@ -2483,13 +2483,39 @@ func (s *CollectionService) batchUpcomingShowCountForArtists(artistIDs []uint) m
 	return out
 }
 
-// GetCollectionGraph returns the artist-relationship subgraph for the
-// collection's artist items. PSY-366.
+// Derived edge types for the multi-type collection graph (PSY-555).
+// These are NOT stored in artist_relationships — they're derived at query
+// time from existing junction tables (show_artists, artist_releases, etc.).
+const (
+	CollectionEdgePlayedAt    = "played_at"   // artist ↔ venue (via shows the artist played at the venue)
+	CollectionEdgeDiscography = "discography" // artist ↔ release (artist made the release)
+	CollectionEdgeSignedTo    = "signed_to"   // artist ↔ label (artist signed to the label)
+	CollectionEdgeLineup      = "lineup"      // artist ↔ festival (artist played the festival)
+	CollectionEdgeShowLineup  = "show_lineup" // show ↔ artist (the show's billed acts)
+	CollectionEdgeShowVenue   = "show_venue"  // show ↔ venue (the show's location)
+)
+
+// GetCollectionGraph returns the multi-type knowledge subgraph for the
+// collection's items. PSY-366 (artist-only origin), PSY-555 (Option B —
+// every collection item becomes a node).
 //
 // Visibility gate mirrors GetBySlug: private collections return
 // ErrCollectionForbidden unless viewer is the creator. Collections that exist
-// but contain no artist items return a 200 response with empty nodes/links —
-// the collection is valid, just non-graph-able.
+// but contain no items return a 200 response with empty nodes/links — the
+// collection is valid, just non-graph-able.
+//
+// Edge derivation rules:
+//   - artist ↔ artist  : stored artist_relationships rows (subject to type
+//     filter via the original PSY-366 allowlist)
+//   - artist ↔ venue   : artist played the venue (via show_artists ⋈ show_venues)
+//   - artist ↔ release : artist made the release (via artist_releases)
+//   - artist ↔ label   : artist signed to the label (via artist_labels)
+//   - artist ↔ festival: artist played the festival (via festival_artists)
+//   - show   ↔ artist  : show's lineup (via show_artists)
+//   - show   ↔ venue   : show's location (via show_venues)
+//
+// Both endpoints must be in the collection — we never invent phantom nodes.
+// Edges between non-artist nodes (venue↔festival etc.) are out of scope.
 func (s *CollectionService) GetCollectionGraph(slug string, viewerID uint, types []string) (*contracts.CollectionGraphResponse, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
@@ -2508,101 +2534,587 @@ func (s *CollectionService) GetCollectionGraph(slug string, viewerID uint, types
 	}
 
 	resolvedTypes := resolveCollectionEdgeTypes(types)
-	noEdgesByFilter := len(types) > 0 && len(resolvedTypes) == 0
+	// Type filter only applies to the stored artist_relationships allowlist.
+	// noStoredEdges short-circuits artist↔artist edges when the caller passed
+	// an explicit but all-rejected filter (mirrors PSY-366 behaviour).
+	// Derived edge types (played_at etc.) are not part of the user-facing
+	// type filter today — they're an "always-on" side of the graph.
+	noStoredEdges := len(types) > 0 && len(resolvedTypes) == 0
 
 	resp := &contracts.CollectionGraphResponse{
 		Collection: contracts.CollectionGraphInfo{
-			Slug: collection.Slug,
-			Name: collection.Title,
+			Slug:         collection.Slug,
+			Name:         collection.Title,
+			EntityCounts: map[string]int{},
 		},
 		Nodes: []contracts.CollectionGraphNode{},
 		Links: []contracts.CollectionGraphLink{},
 	}
 
+	// Load all collection items, regardless of entity type.
 	var items []communitym.CollectionItem
 	if err := s.db.
-		Where("collection_id = ? AND entity_type = ?", collection.ID, communitym.CollectionEntityArtist).
+		Where("collection_id = ?", collection.ID).
 		Order("position ASC, created_at ASC").
 		Find(&items).Error; err != nil {
-		return nil, fmt.Errorf("failed to load artist items: %w", err)
+		return nil, fmt.Errorf("failed to load collection items: %w", err)
 	}
 	if len(items) == 0 {
 		return resp, nil
 	}
 
-	artistIDs := make([]uint, 0, len(items))
-	for _, it := range items {
-		artistIDs = append(artistIDs, it.EntityID)
-	}
+	// Bucket entity IDs by type so each detail-load query stays narrow.
+	idsByType := bucketCollectionItemIDs(items)
 
-	type artistRow struct {
-		ID    uint
-		Name  string
-		Slug  string
-		City  *string
-		State *string
+	// Build nodes for each entity type. Returned in the order: artist,
+	// venue, show, release, label, festival — stable per type, sorted by
+	// name within type.
+	nodes, nodeIDByEntity, err := s.buildCollectionGraphNodes(items, idsByType)
+	if err != nil {
+		return nil, err
 	}
-	var artistRows []artistRow
-	if err := s.db.Table("artists").
-		Select("id, name, slug, city, state").
-		Where("id IN ?", artistIDs).
-		Order("name ASC").
-		Scan(&artistRows).Error; err != nil {
-		return nil, fmt.Errorf("failed to load artist details: %w", err)
-	}
-	if len(artistRows) == 0 {
+	if len(nodes) == 0 {
+		// Items existed but every detail row was missing (deleted entity).
 		return resp, nil
 	}
 
-	upcomingByArtist := s.batchUpcomingShowCountForArtists(artistIDs)
+	// Build edges. nodeIDByEntity maps (entityType, entityID) → node ID
+	// (currently the collection_item row id) so links can reference nodes
+	// uniquely even when entity DB IDs collide across types.
+	links, err := s.buildCollectionGraphLinks(idsByType, nodeIDByEntity, resolvedTypes, noStoredEdges)
+	if err != nil {
+		return nil, err
+	}
 
-	var rels []collectionRelationshipRow
-	if !noEdgesByFilter {
-		fetched, err := s.queryCollectionRelationships(artistIDs, resolvedTypes)
+	// Mark isolates (no in-set edges, post type-filter).
+	connected := make(map[uint]bool, len(nodes))
+	for _, l := range links {
+		connected[l.SourceID] = true
+		connected[l.TargetID] = true
+	}
+	for i := range nodes {
+		nodes[i].IsIsolate = !connected[nodes[i].ID]
+		resp.Collection.EntityCounts[nodes[i].EntityType]++
+	}
+
+	resp.Nodes = nodes
+	resp.Links = links
+	resp.Collection.ArtistCount = resp.Collection.EntityCounts[communitym.CollectionEntityArtist]
+	resp.Collection.EdgeCount = len(resp.Links)
+	return resp, nil
+}
+
+// bucketCollectionItemIDs groups item entity IDs by type. Returns a map
+// keyed by communitym.CollectionEntity* constants. Empty buckets are
+// omitted (callers should range over the map directly).
+func bucketCollectionItemIDs(items []communitym.CollectionItem) map[string][]uint {
+	out := make(map[string][]uint, 6)
+	for _, it := range items {
+		out[it.EntityType] = append(out[it.EntityType], it.EntityID)
+	}
+	return out
+}
+
+// entityNodeKey is the lookup key for nodeIDByEntity. Two different entity
+// types can share a numeric DB ID; the type qualifier disambiguates.
+type entityNodeKey struct {
+	EntityType string
+	EntityID   uint
+}
+
+// buildCollectionGraphNodes loads detail rows for every entity type in the
+// collection and emits one node per item. Returns nodes ordered by type
+// (artist, venue, show, release, label, festival) then by name within
+// type, plus a (entity_type, entity_id) → node ID map used for edge
+// construction.
+//
+// Node ID == collection_item.id. This is naturally unique within the
+// response (composite primary key (collection_id, entity_type, entity_id)
+// ensures one item row per (entity_type, entity_id) in a collection) and
+// avoids the cross-type DB-ID collision the artist-only design didn't have
+// to worry about.
+func (s *CollectionService) buildCollectionGraphNodes(
+	items []communitym.CollectionItem,
+	idsByType map[string][]uint,
+) ([]contracts.CollectionGraphNode, map[entityNodeKey]uint, error) {
+	// Index items by (entity_type, entity_id) so we can recover the
+	// collection_item.id in node-emission order.
+	itemByKey := make(map[entityNodeKey]communitym.CollectionItem, len(items))
+	for _, it := range items {
+		itemByKey[entityNodeKey{EntityType: it.EntityType, EntityID: it.EntityID}] = it
+	}
+
+	nodes := make([]contracts.CollectionGraphNode, 0, len(items))
+	nodeIDByEntity := make(map[entityNodeKey]uint, len(items))
+
+	// Iterate in a stable type order so the response ordering is deterministic.
+	typeOrder := []string{
+		communitym.CollectionEntityArtist,
+		communitym.CollectionEntityVenue,
+		communitym.CollectionEntityShow,
+		communitym.CollectionEntityRelease,
+		communitym.CollectionEntityLabel,
+		communitym.CollectionEntityFestival,
+	}
+
+	upcomingByArtist := s.batchUpcomingShowCountForArtists(idsByType[communitym.CollectionEntityArtist])
+
+	for _, et := range typeOrder {
+		ids := idsByType[et]
+		if len(ids) == 0 {
+			continue
+		}
+		details, err := s.loadEntityDetailsForGraph(et, ids)
+		if err != nil {
+			return nil, nil, err
+		}
+		for _, d := range details {
+			key := entityNodeKey{EntityType: et, EntityID: d.ID}
+			item, ok := itemByKey[key]
+			if !ok {
+				// Detail row exists but the collection_item it came from
+				// was deleted between queries. Skip.
+				continue
+			}
+			node := contracts.CollectionGraphNode{
+				ID:         item.ID,
+				EntityType: et,
+				Name:       d.Name,
+				Slug:       d.Slug,
+				City:       d.City,
+				State:      d.State,
+			}
+			if et == communitym.CollectionEntityArtist {
+				node.UpcomingShowCount = upcomingByArtist[d.ID]
+			}
+			nodes = append(nodes, node)
+			nodeIDByEntity[key] = item.ID
+		}
+	}
+
+	return nodes, nodeIDByEntity, nil
+}
+
+// graphEntityDetail is the per-type detail-row DTO used by node building.
+// City/State are blank for entity types that don't have them (releases,
+// labels can have city/state but we don't surface them on the node tooltip;
+// shows store city/state directly on the row).
+type graphEntityDetail struct {
+	ID    uint
+	Name  string
+	Slug  string
+	City  string
+	State string
+}
+
+// loadEntityDetailsForGraph fetches the rows needed to render nodes for one
+// entity type. Each branch below is a tight 5-column SELECT on the entity
+// table — no joins. Slug is COALESCE'd to "" on the SQL side because most
+// entity tables have nullable slug.
+func (s *CollectionService) loadEntityDetailsForGraph(entityType string, ids []uint) ([]graphEntityDetail, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	type row struct {
+		ID    uint
+		Name  string
+		Slug  *string
+		City  *string
+		State *string
+	}
+	var raws []row
+
+	switch entityType {
+	case communitym.CollectionEntityArtist:
+		if err := s.db.Table("artists").
+			Select("id, name, slug, city, state").
+			Where("id IN ?", ids).
+			Order("name ASC").Scan(&raws).Error; err != nil {
+			return nil, fmt.Errorf("failed to load artist details: %w", err)
+		}
+	case communitym.CollectionEntityVenue:
+		if err := s.db.Table("venues").
+			Select("id, name, slug, city, state").
+			Where("id IN ?", ids).
+			Order("name ASC").Scan(&raws).Error; err != nil {
+			return nil, fmt.Errorf("failed to load venue details: %w", err)
+		}
+	case communitym.CollectionEntityShow:
+		if err := s.db.Table("shows").
+			Select("id, title AS name, slug, city, state").
+			Where("id IN ?", ids).
+			Order("title ASC").Scan(&raws).Error; err != nil {
+			return nil, fmt.Errorf("failed to load show details: %w", err)
+		}
+	case communitym.CollectionEntityRelease:
+		// Releases don't have city/state — `Select` gives the row blank
+		// values so the shape stays uniform.
+		if err := s.db.Table("releases").
+			Select("id, title AS name, slug, NULL AS city, NULL AS state").
+			Where("id IN ?", ids).
+			Order("title ASC").Scan(&raws).Error; err != nil {
+			return nil, fmt.Errorf("failed to load release details: %w", err)
+		}
+	case communitym.CollectionEntityLabel:
+		if err := s.db.Table("labels").
+			Select("id, name, slug, city, state").
+			Where("id IN ?", ids).
+			Order("name ASC").Scan(&raws).Error; err != nil {
+			return nil, fmt.Errorf("failed to load label details: %w", err)
+		}
+	case communitym.CollectionEntityFestival:
+		if err := s.db.Table("festivals").
+			Select("id, name, slug, city, state").
+			Where("id IN ?", ids).
+			Order("name ASC").Scan(&raws).Error; err != nil {
+			return nil, fmt.Errorf("failed to load festival details: %w", err)
+		}
+	default:
+		// Unknown entity type — silently skip. No new types should appear
+		// without updating CollectionEntity* and this switch.
+		return nil, nil
+	}
+
+	out := make([]graphEntityDetail, 0, len(raws))
+	for _, r := range raws {
+		d := graphEntityDetail{ID: r.ID, Name: r.Name}
+		if r.Slug != nil {
+			d.Slug = *r.Slug
+		}
+		if r.City != nil {
+			d.City = *r.City
+		}
+		if r.State != nil {
+			d.State = *r.State
+		}
+		out = append(out, d)
+	}
+	return out, nil
+}
+
+// buildCollectionGraphLinks emits all in-set edges. Returns links with
+// source_id/target_id pointing at NODE IDs (collection_item.id), not
+// underlying entity IDs.
+func (s *CollectionService) buildCollectionGraphLinks(
+	idsByType map[string][]uint,
+	nodeIDByEntity map[entityNodeKey]uint,
+	resolvedArtistTypes []string,
+	noStoredEdges bool,
+) ([]contracts.CollectionGraphLink, error) {
+	links := make([]contracts.CollectionGraphLink, 0)
+
+	// 1. Stored artist↔artist edges (PSY-366 origin path).
+	artistIDs := idsByType[communitym.CollectionEntityArtist]
+	if !noStoredEdges && len(artistIDs) >= 2 {
+		rels, err := s.queryCollectionRelationships(artistIDs, resolvedArtistTypes)
 		if err != nil {
 			return nil, fmt.Errorf("failed to query collection relationships: %w", err)
 		}
-		rels = fetched
+		for _, r := range rels {
+			srcKey := entityNodeKey{EntityType: communitym.CollectionEntityArtist, EntityID: r.SourceArtistID}
+			tgtKey := entityNodeKey{EntityType: communitym.CollectionEntityArtist, EntityID: r.TargetArtistID}
+			srcNodeID, srcOK := nodeIDByEntity[srcKey]
+			tgtNodeID, tgtOK := nodeIDByEntity[tgtKey]
+			if !srcOK || !tgtOK {
+				continue
+			}
+			var detail any
+			if len(r.Detail) > 0 {
+				_ = json.Unmarshal(r.Detail, &detail)
+			}
+			links = append(links, contracts.CollectionGraphLink{
+				SourceID: srcNodeID,
+				TargetID: tgtNodeID,
+				Type:     r.RelationshipType,
+				Score:    float64(r.Score),
+				Detail:   detail,
+			})
+		}
 	}
 
-	connected := make(map[uint]bool, len(artistRows))
-	for _, l := range rels {
-		var detail any
-		if len(l.Detail) > 0 {
-			_ = json.Unmarshal(l.Detail, &detail)
+	// 2. Derived multi-type edges.
+	derivedAppenders := []func() error{
+		// artist ↔ venue (via shows the artist played at the venue)
+		func() error {
+			venueIDs := idsByType[communitym.CollectionEntityVenue]
+			if len(artistIDs) == 0 || len(venueIDs) == 0 {
+				return nil
+			}
+			pairs, err := s.queryArtistVenuePairs(artistIDs, venueIDs)
+			if err != nil {
+				return err
+			}
+			for _, p := range pairs {
+				srcID, tgtID, ok := lookupNodeIDs(nodeIDByEntity,
+					communitym.CollectionEntityArtist, p.ArtistID,
+					communitym.CollectionEntityVenue, p.VenueID)
+				if !ok {
+					continue
+				}
+				links = append(links, contracts.CollectionGraphLink{
+					SourceID: srcID,
+					TargetID: tgtID,
+					Type:     CollectionEdgePlayedAt,
+				})
+			}
+			return nil
+		},
+		// artist ↔ release (artist made the release)
+		func() error {
+			releaseIDs := idsByType[communitym.CollectionEntityRelease]
+			if len(artistIDs) == 0 || len(releaseIDs) == 0 {
+				return nil
+			}
+			pairs, err := s.queryArtistReleasePairs(artistIDs, releaseIDs)
+			if err != nil {
+				return err
+			}
+			for _, p := range pairs {
+				srcID, tgtID, ok := lookupNodeIDs(nodeIDByEntity,
+					communitym.CollectionEntityArtist, p.ArtistID,
+					communitym.CollectionEntityRelease, p.ReleaseID)
+				if !ok {
+					continue
+				}
+				links = append(links, contracts.CollectionGraphLink{
+					SourceID: srcID,
+					TargetID: tgtID,
+					Type:     CollectionEdgeDiscography,
+				})
+			}
+			return nil
+		},
+		// artist ↔ label (signing — direct artist_labels join)
+		func() error {
+			labelIDs := idsByType[communitym.CollectionEntityLabel]
+			if len(artistIDs) == 0 || len(labelIDs) == 0 {
+				return nil
+			}
+			pairs, err := s.queryArtistLabelPairs(artistIDs, labelIDs)
+			if err != nil {
+				return err
+			}
+			for _, p := range pairs {
+				srcID, tgtID, ok := lookupNodeIDs(nodeIDByEntity,
+					communitym.CollectionEntityArtist, p.ArtistID,
+					communitym.CollectionEntityLabel, p.LabelID)
+				if !ok {
+					continue
+				}
+				links = append(links, contracts.CollectionGraphLink{
+					SourceID: srcID,
+					TargetID: tgtID,
+					Type:     CollectionEdgeSignedTo,
+				})
+			}
+			return nil
+		},
+		// artist ↔ festival (lineup)
+		func() error {
+			festivalIDs := idsByType[communitym.CollectionEntityFestival]
+			if len(artistIDs) == 0 || len(festivalIDs) == 0 {
+				return nil
+			}
+			pairs, err := s.queryArtistFestivalPairs(artistIDs, festivalIDs)
+			if err != nil {
+				return err
+			}
+			for _, p := range pairs {
+				srcID, tgtID, ok := lookupNodeIDs(nodeIDByEntity,
+					communitym.CollectionEntityArtist, p.ArtistID,
+					communitym.CollectionEntityFestival, p.FestivalID)
+				if !ok {
+					continue
+				}
+				links = append(links, contracts.CollectionGraphLink{
+					SourceID: srcID,
+					TargetID: tgtID,
+					Type:     CollectionEdgeLineup,
+				})
+			}
+			return nil
+		},
+		// show ↔ artist (the show's lineup)
+		func() error {
+			showIDs := idsByType[communitym.CollectionEntityShow]
+			if len(showIDs) == 0 || len(artistIDs) == 0 {
+				return nil
+			}
+			pairs, err := s.queryShowArtistPairs(showIDs, artistIDs)
+			if err != nil {
+				return err
+			}
+			for _, p := range pairs {
+				srcID, tgtID, ok := lookupNodeIDs(nodeIDByEntity,
+					communitym.CollectionEntityShow, p.ShowID,
+					communitym.CollectionEntityArtist, p.ArtistID)
+				if !ok {
+					continue
+				}
+				links = append(links, contracts.CollectionGraphLink{
+					SourceID: srcID,
+					TargetID: tgtID,
+					Type:     CollectionEdgeShowLineup,
+				})
+			}
+			return nil
+		},
+		// show ↔ venue (the show's location)
+		func() error {
+			showIDs := idsByType[communitym.CollectionEntityShow]
+			venueIDs := idsByType[communitym.CollectionEntityVenue]
+			if len(showIDs) == 0 || len(venueIDs) == 0 {
+				return nil
+			}
+			pairs, err := s.queryShowVenuePairs(showIDs, venueIDs)
+			if err != nil {
+				return err
+			}
+			for _, p := range pairs {
+				srcID, tgtID, ok := lookupNodeIDs(nodeIDByEntity,
+					communitym.CollectionEntityShow, p.ShowID,
+					communitym.CollectionEntityVenue, p.VenueID)
+				if !ok {
+					continue
+				}
+				links = append(links, contracts.CollectionGraphLink{
+					SourceID: srcID,
+					TargetID: tgtID,
+					Type:     CollectionEdgeShowVenue,
+				})
+			}
+			return nil
+		},
+	}
+	for _, fn := range derivedAppenders {
+		if err := fn(); err != nil {
+			return nil, err
 		}
-		resp.Links = append(resp.Links, contracts.CollectionGraphLink{
-			SourceID: l.SourceArtistID,
-			TargetID: l.TargetArtistID,
-			Type:     l.RelationshipType,
-			Score:    float64(l.Score),
-			Detail:   detail,
-		})
-		connected[l.SourceArtistID] = true
-		connected[l.TargetArtistID] = true
 	}
 
-	for _, r := range artistRows {
-		city := ""
-		if r.City != nil {
-			city = *r.City
-		}
-		state := ""
-		if r.State != nil {
-			state = *r.State
-		}
-		resp.Nodes = append(resp.Nodes, contracts.CollectionGraphNode{
-			ID:                r.ID,
-			Name:              r.Name,
-			Slug:              r.Slug,
-			City:              city,
-			State:             state,
-			UpcomingShowCount: upcomingByArtist[r.ID],
-			IsIsolate:         !connected[r.ID],
-		})
-	}
+	return links, nil
+}
 
-	resp.Collection.ArtistCount = len(resp.Nodes)
-	resp.Collection.EdgeCount = len(resp.Links)
-	return resp, nil
+// lookupNodeIDs is a tiny helper that resolves a (type, id) pair to its
+// node IDs in one call. Returns ok=false when either side is missing —
+// only happens when a row was deleted between queries.
+func lookupNodeIDs(
+	nodeIDByEntity map[entityNodeKey]uint,
+	srcType string, srcID uint,
+	tgtType string, tgtID uint,
+) (uint, uint, bool) {
+	srcNodeID, srcOK := nodeIDByEntity[entityNodeKey{EntityType: srcType, EntityID: srcID}]
+	tgtNodeID, tgtOK := nodeIDByEntity[entityNodeKey{EntityType: tgtType, EntityID: tgtID}]
+	if !srcOK || !tgtOK {
+		return 0, 0, false
+	}
+	return srcNodeID, tgtNodeID, true
+}
+
+// ──────────────────────────────────────────────
+// Multi-type relationship lookups (PSY-555)
+// ──────────────────────────────────────────────
+//
+// Each query selects the canonical pair table joined as needed and returns
+// distinct (artist, X) rows. Existing services like CollectionService
+// don't have a uniform "get pairs in set" API, so we keep these private
+// to graph construction — the queries are narrow and the surface area is
+// small.
+
+type artistVenuePair struct {
+	ArtistID uint
+	VenueID  uint
+}
+
+func (s *CollectionService) queryArtistVenuePairs(artistIDs, venueIDs []uint) ([]artistVenuePair, error) {
+	var rows []artistVenuePair
+	if err := s.db.Table("show_artists").
+		Select("DISTINCT show_artists.artist_id, show_venues.venue_id").
+		Joins("JOIN show_venues ON show_venues.show_id = show_artists.show_id").
+		Where("show_artists.artist_id IN ? AND show_venues.venue_id IN ?", artistIDs, venueIDs).
+		Scan(&rows).Error; err != nil {
+		return nil, fmt.Errorf("failed to query artist-venue pairs: %w", err)
+	}
+	return rows, nil
+}
+
+type artistReleasePair struct {
+	ArtistID  uint
+	ReleaseID uint
+}
+
+func (s *CollectionService) queryArtistReleasePairs(artistIDs, releaseIDs []uint) ([]artistReleasePair, error) {
+	var rows []artistReleasePair
+	if err := s.db.Table("artist_releases").
+		Select("DISTINCT artist_id, release_id").
+		Where("artist_id IN ? AND release_id IN ?", artistIDs, releaseIDs).
+		Scan(&rows).Error; err != nil {
+		return nil, fmt.Errorf("failed to query artist-release pairs: %w", err)
+	}
+	return rows, nil
+}
+
+type artistLabelPair struct {
+	ArtistID uint
+	LabelID  uint
+}
+
+func (s *CollectionService) queryArtistLabelPairs(artistIDs, labelIDs []uint) ([]artistLabelPair, error) {
+	var rows []artistLabelPair
+	if err := s.db.Table("artist_labels").
+		Select("DISTINCT artist_id, label_id").
+		Where("artist_id IN ? AND label_id IN ?", artistIDs, labelIDs).
+		Scan(&rows).Error; err != nil {
+		return nil, fmt.Errorf("failed to query artist-label pairs: %w", err)
+	}
+	return rows, nil
+}
+
+type artistFestivalPair struct {
+	ArtistID   uint
+	FestivalID uint
+}
+
+func (s *CollectionService) queryArtistFestivalPairs(artistIDs, festivalIDs []uint) ([]artistFestivalPair, error) {
+	var rows []artistFestivalPair
+	if err := s.db.Table("festival_artists").
+		Select("DISTINCT artist_id, festival_id").
+		Where("artist_id IN ? AND festival_id IN ?", artistIDs, festivalIDs).
+		Scan(&rows).Error; err != nil {
+		return nil, fmt.Errorf("failed to query artist-festival pairs: %w", err)
+	}
+	return rows, nil
+}
+
+type showArtistPair struct {
+	ShowID   uint
+	ArtistID uint
+}
+
+func (s *CollectionService) queryShowArtistPairs(showIDs, artistIDs []uint) ([]showArtistPair, error) {
+	var rows []showArtistPair
+	if err := s.db.Table("show_artists").
+		Select("DISTINCT show_id, artist_id").
+		Where("show_id IN ? AND artist_id IN ?", showIDs, artistIDs).
+		Scan(&rows).Error; err != nil {
+		return nil, fmt.Errorf("failed to query show-artist pairs: %w", err)
+	}
+	return rows, nil
+}
+
+type showVenuePair struct {
+	ShowID  uint
+	VenueID uint
+}
+
+func (s *CollectionService) queryShowVenuePairs(showIDs, venueIDs []uint) ([]showVenuePair, error) {
+	var rows []showVenuePair
+	if err := s.db.Table("show_venues").
+		Select("DISTINCT show_id, venue_id").
+		Where("show_id IN ? AND venue_id IN ?", showIDs, venueIDs).
+		Scan(&rows).Error; err != nil {
+		return nil, fmt.Errorf("failed to query show-venue pairs: %w", err)
+	}
+	return rows, nil
 }

--- a/backend/internal/services/collection.go
+++ b/backend/internal/services/collection.go
@@ -2709,8 +2709,9 @@ type graphEntityDetail struct {
 
 // loadEntityDetailsForGraph fetches the rows needed to render nodes for one
 // entity type. Each branch below is a tight 5-column SELECT on the entity
-// table — no joins. Slug is COALESCE'd to "" on the SQL side because most
-// entity tables have nullable slug.
+// table — no joins. The intermediate `row` shape uses *string for slug,
+// city, state because most entity tables have nullable columns; the loop
+// at the bottom collapses nil → "".
 func (s *CollectionService) loadEntityDetailsForGraph(entityType string, ids []uint) ([]graphEntityDetail, error) {
 	if len(ids) == 0 {
 		return nil, nil
@@ -2812,11 +2813,10 @@ func (s *CollectionService) buildCollectionGraphLinks(
 			return nil, fmt.Errorf("failed to query collection relationships: %w", err)
 		}
 		for _, r := range rels {
-			srcKey := entityNodeKey{EntityType: communitym.CollectionEntityArtist, EntityID: r.SourceArtistID}
-			tgtKey := entityNodeKey{EntityType: communitym.CollectionEntityArtist, EntityID: r.TargetArtistID}
-			srcNodeID, srcOK := nodeIDByEntity[srcKey]
-			tgtNodeID, tgtOK := nodeIDByEntity[tgtKey]
-			if !srcOK || !tgtOK {
+			srcNodeID, tgtNodeID, ok := lookupNodeIDs(nodeIDByEntity,
+				communitym.CollectionEntityArtist, r.SourceArtistID,
+				communitym.CollectionEntityArtist, r.TargetArtistID)
+			if !ok {
 				continue
 			}
 			var detail any
@@ -2833,167 +2833,90 @@ func (s *CollectionService) buildCollectionGraphLinks(
 		}
 	}
 
-	// 2. Derived multi-type edges.
-	derivedAppenders := []func() error{
-		// artist ↔ venue (via shows the artist played at the venue)
-		func() error {
-			venueIDs := idsByType[communitym.CollectionEntityVenue]
-			if len(artistIDs) == 0 || len(venueIDs) == 0 {
-				return nil
-			}
-			pairs, err := s.queryArtistVenuePairs(artistIDs, venueIDs)
-			if err != nil {
-				return err
-			}
-			for _, p := range pairs {
-				srcID, tgtID, ok := lookupNodeIDs(nodeIDByEntity,
-					communitym.CollectionEntityArtist, p.ArtistID,
-					communitym.CollectionEntityVenue, p.VenueID)
-				if !ok {
-					continue
-				}
-				links = append(links, contracts.CollectionGraphLink{
-					SourceID: srcID,
-					TargetID: tgtID,
-					Type:     CollectionEdgePlayedAt,
-				})
-			}
-			return nil
+	// 2. Derived multi-type edges. Each spec declares the source/target
+	// entity types it joins, the edge type emitted, and the pair-query
+	// func. The unified loop below skips empty sides, runs the query, and
+	// appends one link per resolved pair.
+	derivedSpecs := []derivedEdgeSpec{
+		{
+			srcType: communitym.CollectionEntityArtist,
+			tgtType: communitym.CollectionEntityVenue,
+			edge:    CollectionEdgePlayedAt,
+			query:   s.queryArtistVenuePairs,
 		},
-		// artist ↔ release (artist made the release)
-		func() error {
-			releaseIDs := idsByType[communitym.CollectionEntityRelease]
-			if len(artistIDs) == 0 || len(releaseIDs) == 0 {
-				return nil
-			}
-			pairs, err := s.queryArtistReleasePairs(artistIDs, releaseIDs)
-			if err != nil {
-				return err
-			}
-			for _, p := range pairs {
-				srcID, tgtID, ok := lookupNodeIDs(nodeIDByEntity,
-					communitym.CollectionEntityArtist, p.ArtistID,
-					communitym.CollectionEntityRelease, p.ReleaseID)
-				if !ok {
-					continue
-				}
-				links = append(links, contracts.CollectionGraphLink{
-					SourceID: srcID,
-					TargetID: tgtID,
-					Type:     CollectionEdgeDiscography,
-				})
-			}
-			return nil
+		{
+			srcType: communitym.CollectionEntityArtist,
+			tgtType: communitym.CollectionEntityRelease,
+			edge:    CollectionEdgeDiscography,
+			query:   s.queryArtistReleasePairs,
 		},
-		// artist ↔ label (signing — direct artist_labels join)
-		func() error {
-			labelIDs := idsByType[communitym.CollectionEntityLabel]
-			if len(artistIDs) == 0 || len(labelIDs) == 0 {
-				return nil
-			}
-			pairs, err := s.queryArtistLabelPairs(artistIDs, labelIDs)
-			if err != nil {
-				return err
-			}
-			for _, p := range pairs {
-				srcID, tgtID, ok := lookupNodeIDs(nodeIDByEntity,
-					communitym.CollectionEntityArtist, p.ArtistID,
-					communitym.CollectionEntityLabel, p.LabelID)
-				if !ok {
-					continue
-				}
-				links = append(links, contracts.CollectionGraphLink{
-					SourceID: srcID,
-					TargetID: tgtID,
-					Type:     CollectionEdgeSignedTo,
-				})
-			}
-			return nil
+		{
+			srcType: communitym.CollectionEntityArtist,
+			tgtType: communitym.CollectionEntityLabel,
+			edge:    CollectionEdgeSignedTo,
+			query:   s.queryArtistLabelPairs,
 		},
-		// artist ↔ festival (lineup)
-		func() error {
-			festivalIDs := idsByType[communitym.CollectionEntityFestival]
-			if len(artistIDs) == 0 || len(festivalIDs) == 0 {
-				return nil
-			}
-			pairs, err := s.queryArtistFestivalPairs(artistIDs, festivalIDs)
-			if err != nil {
-				return err
-			}
-			for _, p := range pairs {
-				srcID, tgtID, ok := lookupNodeIDs(nodeIDByEntity,
-					communitym.CollectionEntityArtist, p.ArtistID,
-					communitym.CollectionEntityFestival, p.FestivalID)
-				if !ok {
-					continue
-				}
-				links = append(links, contracts.CollectionGraphLink{
-					SourceID: srcID,
-					TargetID: tgtID,
-					Type:     CollectionEdgeLineup,
-				})
-			}
-			return nil
+		{
+			srcType: communitym.CollectionEntityArtist,
+			tgtType: communitym.CollectionEntityFestival,
+			edge:    CollectionEdgeLineup,
+			query:   s.queryArtistFestivalPairs,
 		},
-		// show ↔ artist (the show's lineup)
-		func() error {
-			showIDs := idsByType[communitym.CollectionEntityShow]
-			if len(showIDs) == 0 || len(artistIDs) == 0 {
-				return nil
-			}
-			pairs, err := s.queryShowArtistPairs(showIDs, artistIDs)
-			if err != nil {
-				return err
-			}
-			for _, p := range pairs {
-				srcID, tgtID, ok := lookupNodeIDs(nodeIDByEntity,
-					communitym.CollectionEntityShow, p.ShowID,
-					communitym.CollectionEntityArtist, p.ArtistID)
-				if !ok {
-					continue
-				}
-				links = append(links, contracts.CollectionGraphLink{
-					SourceID: srcID,
-					TargetID: tgtID,
-					Type:     CollectionEdgeShowLineup,
-				})
-			}
-			return nil
+		{
+			srcType: communitym.CollectionEntityShow,
+			tgtType: communitym.CollectionEntityArtist,
+			edge:    CollectionEdgeShowLineup,
+			query:   s.queryShowArtistPairs,
 		},
-		// show ↔ venue (the show's location)
-		func() error {
-			showIDs := idsByType[communitym.CollectionEntityShow]
-			venueIDs := idsByType[communitym.CollectionEntityVenue]
-			if len(showIDs) == 0 || len(venueIDs) == 0 {
-				return nil
-			}
-			pairs, err := s.queryShowVenuePairs(showIDs, venueIDs)
-			if err != nil {
-				return err
-			}
-			for _, p := range pairs {
-				srcID, tgtID, ok := lookupNodeIDs(nodeIDByEntity,
-					communitym.CollectionEntityShow, p.ShowID,
-					communitym.CollectionEntityVenue, p.VenueID)
-				if !ok {
-					continue
-				}
-				links = append(links, contracts.CollectionGraphLink{
-					SourceID: srcID,
-					TargetID: tgtID,
-					Type:     CollectionEdgeShowVenue,
-				})
-			}
-			return nil
+		{
+			srcType: communitym.CollectionEntityShow,
+			tgtType: communitym.CollectionEntityVenue,
+			edge:    CollectionEdgeShowVenue,
+			query:   s.queryShowVenuePairs,
 		},
 	}
-	for _, fn := range derivedAppenders {
-		if err := fn(); err != nil {
+	for _, spec := range derivedSpecs {
+		srcIDs := idsByType[spec.srcType]
+		tgtIDs := idsByType[spec.tgtType]
+		if len(srcIDs) == 0 || len(tgtIDs) == 0 {
+			continue
+		}
+		pairs, err := spec.query(srcIDs, tgtIDs)
+		if err != nil {
 			return nil, err
+		}
+		for _, p := range pairs {
+			srcNodeID, tgtNodeID, ok := lookupNodeIDs(nodeIDByEntity,
+				spec.srcType, p.SrcID, spec.tgtType, p.TgtID)
+			if !ok {
+				continue
+			}
+			links = append(links, contracts.CollectionGraphLink{
+				SourceID: srcNodeID,
+				TargetID: tgtNodeID,
+				Type:     spec.edge,
+			})
 		}
 	}
 
 	return links, nil
+}
+
+// derivedEdgePair is the uniform return shape for every multi-type pair
+// query. SrcID and TgtID align with derivedEdgeSpec.srcType / tgtType.
+type derivedEdgePair struct {
+	SrcID uint
+	TgtID uint
+}
+
+// derivedEdgeSpec is one row in the derived-edge dispatch table. The
+// query func returns pairs already filtered to (srcIDs ∩ tgtIDs); the
+// loop appends one edge per pair after resolving node IDs.
+type derivedEdgeSpec struct {
+	srcType string
+	tgtType string
+	edge    string
+	query   func(srcIDs, tgtIDs []uint) ([]derivedEdgePair, error)
 }
 
 // lookupNodeIDs is a tiny helper that resolves a (type, id) pair to its
@@ -3016,21 +2939,19 @@ func lookupNodeIDs(
 // Multi-type relationship lookups (PSY-555)
 // ──────────────────────────────────────────────
 //
-// Each query selects the canonical pair table joined as needed and returns
-// distinct (artist, X) rows. Existing services like CollectionService
-// don't have a uniform "get pairs in set" API, so we keep these private
-// to graph construction — the queries are narrow and the surface area is
-// small.
+// Each query returns distinct (src, tgt) ID pairs that exist in the
+// underlying junction table AND have both sides in the caller-supplied
+// ID set. Returned shape is uniform (derivedEdgePair) so the dispatch
+// table in buildCollectionGraphLinks can iterate generically.
+//
+// Most queries hit a single junction table directly; queryArtistVenuePairs
+// is the only one that needs a join (artists are linked to venues via the
+// shows they played).
 
-type artistVenuePair struct {
-	ArtistID uint
-	VenueID  uint
-}
-
-func (s *CollectionService) queryArtistVenuePairs(artistIDs, venueIDs []uint) ([]artistVenuePair, error) {
-	var rows []artistVenuePair
+func (s *CollectionService) queryArtistVenuePairs(artistIDs, venueIDs []uint) ([]derivedEdgePair, error) {
+	var rows []derivedEdgePair
 	if err := s.db.Table("show_artists").
-		Select("DISTINCT show_artists.artist_id, show_venues.venue_id").
+		Select("DISTINCT show_artists.artist_id AS src_id, show_venues.venue_id AS tgt_id").
 		Joins("JOIN show_venues ON show_venues.show_id = show_artists.show_id").
 		Where("show_artists.artist_id IN ? AND show_venues.venue_id IN ?", artistIDs, venueIDs).
 		Scan(&rows).Error; err != nil {
@@ -3039,82 +2960,43 @@ func (s *CollectionService) queryArtistVenuePairs(artistIDs, venueIDs []uint) ([
 	return rows, nil
 }
 
-type artistReleasePair struct {
-	ArtistID  uint
-	ReleaseID uint
+func (s *CollectionService) queryArtistReleasePairs(artistIDs, releaseIDs []uint) ([]derivedEdgePair, error) {
+	return s.queryEdgePairs("artist_releases", "artist_id", "release_id",
+		artistIDs, releaseIDs, "artist-release")
 }
 
-func (s *CollectionService) queryArtistReleasePairs(artistIDs, releaseIDs []uint) ([]artistReleasePair, error) {
-	var rows []artistReleasePair
-	if err := s.db.Table("artist_releases").
-		Select("DISTINCT artist_id, release_id").
-		Where("artist_id IN ? AND release_id IN ?", artistIDs, releaseIDs).
+func (s *CollectionService) queryArtistLabelPairs(artistIDs, labelIDs []uint) ([]derivedEdgePair, error) {
+	return s.queryEdgePairs("artist_labels", "artist_id", "label_id",
+		artistIDs, labelIDs, "artist-label")
+}
+
+func (s *CollectionService) queryArtistFestivalPairs(artistIDs, festivalIDs []uint) ([]derivedEdgePair, error) {
+	return s.queryEdgePairs("festival_artists", "artist_id", "festival_id",
+		artistIDs, festivalIDs, "artist-festival")
+}
+
+func (s *CollectionService) queryShowArtistPairs(showIDs, artistIDs []uint) ([]derivedEdgePair, error) {
+	return s.queryEdgePairs("show_artists", "show_id", "artist_id",
+		showIDs, artistIDs, "show-artist")
+}
+
+func (s *CollectionService) queryShowVenuePairs(showIDs, venueIDs []uint) ([]derivedEdgePair, error) {
+	return s.queryEdgePairs("show_venues", "show_id", "venue_id",
+		showIDs, venueIDs, "show-venue")
+}
+
+// queryEdgePairs is the single-junction-table variant: SELECT DISTINCT
+// (srcCol, tgtCol) FROM table WHERE srcCol IN srcIDs AND tgtCol IN tgtIDs.
+// label is used to namespace error messages.
+func (s *CollectionService) queryEdgePairs(table, srcCol, tgtCol string, srcIDs, tgtIDs []uint, label string) ([]derivedEdgePair, error) {
+	var rows []derivedEdgePair
+	selectExpr := fmt.Sprintf("DISTINCT %s AS src_id, %s AS tgt_id", srcCol, tgtCol)
+	whereExpr := fmt.Sprintf("%s IN ? AND %s IN ?", srcCol, tgtCol)
+	if err := s.db.Table(table).
+		Select(selectExpr).
+		Where(whereExpr, srcIDs, tgtIDs).
 		Scan(&rows).Error; err != nil {
-		return nil, fmt.Errorf("failed to query artist-release pairs: %w", err)
-	}
-	return rows, nil
-}
-
-type artistLabelPair struct {
-	ArtistID uint
-	LabelID  uint
-}
-
-func (s *CollectionService) queryArtistLabelPairs(artistIDs, labelIDs []uint) ([]artistLabelPair, error) {
-	var rows []artistLabelPair
-	if err := s.db.Table("artist_labels").
-		Select("DISTINCT artist_id, label_id").
-		Where("artist_id IN ? AND label_id IN ?", artistIDs, labelIDs).
-		Scan(&rows).Error; err != nil {
-		return nil, fmt.Errorf("failed to query artist-label pairs: %w", err)
-	}
-	return rows, nil
-}
-
-type artistFestivalPair struct {
-	ArtistID   uint
-	FestivalID uint
-}
-
-func (s *CollectionService) queryArtistFestivalPairs(artistIDs, festivalIDs []uint) ([]artistFestivalPair, error) {
-	var rows []artistFestivalPair
-	if err := s.db.Table("festival_artists").
-		Select("DISTINCT artist_id, festival_id").
-		Where("artist_id IN ? AND festival_id IN ?", artistIDs, festivalIDs).
-		Scan(&rows).Error; err != nil {
-		return nil, fmt.Errorf("failed to query artist-festival pairs: %w", err)
-	}
-	return rows, nil
-}
-
-type showArtistPair struct {
-	ShowID   uint
-	ArtistID uint
-}
-
-func (s *CollectionService) queryShowArtistPairs(showIDs, artistIDs []uint) ([]showArtistPair, error) {
-	var rows []showArtistPair
-	if err := s.db.Table("show_artists").
-		Select("DISTINCT show_id, artist_id").
-		Where("show_id IN ? AND artist_id IN ?", showIDs, artistIDs).
-		Scan(&rows).Error; err != nil {
-		return nil, fmt.Errorf("failed to query show-artist pairs: %w", err)
-	}
-	return rows, nil
-}
-
-type showVenuePair struct {
-	ShowID  uint
-	VenueID uint
-}
-
-func (s *CollectionService) queryShowVenuePairs(showIDs, venueIDs []uint) ([]showVenuePair, error) {
-	var rows []showVenuePair
-	if err := s.db.Table("show_venues").
-		Select("DISTINCT show_id, venue_id").
-		Where("show_id IN ? AND venue_id IN ?", showIDs, venueIDs).
-		Scan(&rows).Error; err != nil {
-		return nil, fmt.Errorf("failed to query show-venue pairs: %w", err)
+		return nil, fmt.Errorf("failed to query %s pairs: %w", label, err)
 	}
 	return rows, nil
 }

--- a/backend/internal/services/collection_graph_test.go
+++ b/backend/internal/services/collection_graph_test.go
@@ -2,6 +2,8 @@ package services
 
 import (
 	"encoding/json"
+	"fmt"
+	"time"
 
 	apperrors "psychic-homily-backend/internal/errors"
 	catalogm "psychic-homily-backend/internal/models/catalog"
@@ -148,7 +150,10 @@ func (suite *CollectionServiceIntegrationTestSuite) TestGetCollectionGraph_NotFo
 	suite.Equal(apperrors.CodeCollectionNotFound, collErr.Code)
 }
 
-func (suite *CollectionServiceIntegrationTestSuite) TestGetCollectionGraph_MixedEntityTypesFiltersToArtistsOnly() {
+func (suite *CollectionServiceIntegrationTestSuite) TestGetCollectionGraph_MixedEntityTypesEachBecomesNode() {
+	// PSY-555 (Option B): every collection item becomes a node, regardless
+	// of entity type. ArtistCount is preserved for backward compat (= count
+	// of artist nodes specifically); total node count = items count.
 	creator := suite.createTestUser("MixedCreator")
 	priv := suite.createBasicCollection(creator, "Mixed Types")
 	a1 := suite.createTestArtist("MixedArt1")
@@ -157,27 +162,31 @@ func (suite *CollectionServiceIntegrationTestSuite) TestGetCollectionGraph_Mixed
 
 	suite.addArtistItemToCollection(priv.ID, a1.ID, creator.ID)
 	suite.addArtistItemToCollection(priv.ID, a2.ID, creator.ID)
-	// Add a venue item — should NOT appear in graph.
 	suite.addNonArtistItemToCollection(priv.ID, venue.ID, creator.ID, communitym.CollectionEntityVenue)
 
 	graph, err := suite.collectionService.GetCollectionGraph(priv.Slug, creator.ID, nil)
 	suite.Require().NoError(err)
-	suite.Len(graph.Nodes, 2, "only the two artist items should appear; the venue item is filtered out")
-	suite.Equal(2, graph.Collection.ArtistCount)
+	suite.Len(graph.Nodes, 3, "every item — including the venue — should appear as a node")
+	suite.Equal(2, graph.Collection.ArtistCount, "ArtistCount counts artist nodes only")
+	suite.Equal(2, graph.Collection.EntityCounts[communitym.CollectionEntityArtist])
+	suite.Equal(1, graph.Collection.EntityCounts[communitym.CollectionEntityVenue])
 }
 
-func (suite *CollectionServiceIntegrationTestSuite) TestGetCollectionGraph_EmptyArtistSetReturnsEmptyGraph() {
+func (suite *CollectionServiceIntegrationTestSuite) TestGetCollectionGraph_VenueOnlyCollectionStillRendersNode() {
+	// PSY-555: a single-venue collection used to return zero nodes (the
+	// artist-only filter dropped everything). Now the venue is a node
+	// itself; with no artists in the set, there are no edges.
 	creator := suite.createTestUser("EmptyArtistCreator")
 	priv := suite.createBasicCollection(creator, "No Artists")
 	venue := suite.createTestVenueForCollection("Lonely Venue")
-	// Only a venue item — no artist items at all.
 	suite.addNonArtistItemToCollection(priv.ID, venue.ID, creator.ID, communitym.CollectionEntityVenue)
 
 	graph, err := suite.collectionService.GetCollectionGraph(priv.Slug, creator.ID, nil)
 	suite.Require().NoError(err)
 	suite.NotNil(graph)
-	suite.Empty(graph.Nodes)
-	suite.Empty(graph.Links)
+	suite.Len(graph.Nodes, 1, "the venue is its own node")
+	suite.Equal(communitym.CollectionEntityVenue, graph.Nodes[0].EntityType)
+	suite.Empty(graph.Links, "no artists in set → no edges")
 	suite.Equal(0, graph.Collection.ArtistCount)
 	suite.Equal(0, graph.Collection.EdgeCount)
 }
@@ -254,6 +263,206 @@ func (suite *CollectionServiceIntegrationTestSuite) TestGetCollectionGraph_Relat
 	detailMap, ok := graph.Links[0].Detail.(map[string]any)
 	suite.Require().True(ok, "detail should round-trip as map[string]any")
 	suite.Equal("Trunk Space", detailMap["venue"])
+}
+
+// =============================================================================
+// PSY-555: multi-type collection graph (Option B)
+// =============================================================================
+
+// TestGetCollectionGraph_MultiType_VenueReleaseArtist exercises the ticket's
+// canonical case: a collection with venue + release + 1 artist who played
+// the venue and made the release. Expected: 3 nodes, 2 edges
+// (artist↔venue via played_at, artist↔release via discography).
+func (suite *CollectionServiceIntegrationTestSuite) TestGetCollectionGraph_MultiType_VenueReleaseArtist() {
+	creator := suite.createTestUser("MultiTypeCreator")
+	priv := suite.createBasicCollection(creator, "Multi Type Triangle")
+
+	artist := suite.createTestArtist("MultiArtist")
+	venue := suite.createTestVenueForCollection("MultiVenue")
+
+	// Release made by the artist.
+	releaseSlug := fmt.Sprintf("multi-release-%d", time.Now().UnixNano())
+	release := &catalogm.Release{
+		Title:       "Multi Release",
+		Slug:        &releaseSlug,
+		ReleaseType: catalogm.ReleaseTypeLP,
+	}
+	suite.Require().NoError(suite.db.Create(release).Error)
+	ar := &catalogm.ArtistRelease{
+		ArtistID:  artist.ID,
+		ReleaseID: release.ID,
+		Role:      catalogm.ArtistReleaseRoleMain,
+	}
+	suite.Require().NoError(suite.db.Create(ar).Error)
+
+	// Show staged at the venue with the artist on the bill — this is what
+	// makes the artist↔venue "played_at" edge resolvable.
+	show := &catalogm.Show{
+		Title:     "Multi Show",
+		EventDate: time.Now().Add(-24 * time.Hour),
+		Status:    catalogm.ShowStatusApproved,
+	}
+	suite.Require().NoError(suite.db.Create(show).Error)
+	suite.Require().NoError(suite.db.Create(&catalogm.ShowArtist{
+		ShowID: show.ID, ArtistID: artist.ID,
+	}).Error)
+	suite.Require().NoError(suite.db.Create(&catalogm.ShowVenue{
+		ShowID: show.ID, VenueID: venue.ID,
+	}).Error)
+
+	// Add the three entities to the collection. The show is intentionally
+	// NOT in the collection so its node doesn't appear (and so the
+	// show_lineup/show_venue derived edges don't fire). The "played_at"
+	// edge is artist↔venue regardless of which show source-of-truth'd it.
+	suite.addArtistItemToCollection(priv.ID, artist.ID, creator.ID)
+	suite.addNonArtistItemToCollection(priv.ID, venue.ID, creator.ID, communitym.CollectionEntityVenue)
+	suite.addNonArtistItemToCollection(priv.ID, release.ID, creator.ID, communitym.CollectionEntityRelease)
+
+	graph, err := suite.collectionService.GetCollectionGraph(priv.Slug, creator.ID, nil)
+	suite.Require().NoError(err)
+	suite.Require().Len(graph.Nodes, 3, "artist + venue + release each become a node")
+	suite.Require().Len(graph.Links, 2, "exactly two edges: artist↔venue (played_at) and artist↔release (discography)")
+
+	// Assert each node has the correct entity_type.
+	gotTypes := make(map[string]int, 3)
+	for _, n := range graph.Nodes {
+		gotTypes[n.EntityType]++
+	}
+	suite.Equal(1, gotTypes[communitym.CollectionEntityArtist])
+	suite.Equal(1, gotTypes[communitym.CollectionEntityVenue])
+	suite.Equal(1, gotTypes[communitym.CollectionEntityRelease])
+
+	// Assert the link types are exactly the two derived ones.
+	gotLinkTypes := make(map[string]int, 2)
+	for _, l := range graph.Links {
+		gotLinkTypes[l.Type]++
+	}
+	suite.Equal(1, gotLinkTypes[CollectionEdgePlayedAt], "expected one played_at edge")
+	suite.Equal(1, gotLinkTypes[CollectionEdgeDiscography], "expected one discography edge")
+
+	// EntityCounts breakdown should match.
+	suite.Equal(1, graph.Collection.EntityCounts[communitym.CollectionEntityArtist])
+	suite.Equal(1, graph.Collection.EntityCounts[communitym.CollectionEntityVenue])
+	suite.Equal(1, graph.Collection.EntityCounts[communitym.CollectionEntityRelease])
+	suite.Equal(2, graph.Collection.EdgeCount)
+
+	// No isolates — every node has at least one edge in this set.
+	for _, n := range graph.Nodes {
+		suite.False(n.IsIsolate, "node %s (%s) should not be isolated", n.Name, n.EntityType)
+	}
+}
+
+// TestGetCollectionGraph_MultiType_PhantomEdgeNotEmitted documents the
+// "edge to a node only if BOTH endpoints are in the collection" rule:
+// putting a release alone (no artist) in a collection must NOT emit
+// discography edges into a phantom artist node.
+func (suite *CollectionServiceIntegrationTestSuite) TestGetCollectionGraph_MultiType_PhantomEdgeNotEmitted() {
+	creator := suite.createTestUser("PhantomCreator")
+	priv := suite.createBasicCollection(creator, "Phantom Edge Test")
+
+	artist := suite.createTestArtist("PhantomArtist") // NOT in the collection
+	releaseSlug := fmt.Sprintf("phantom-release-%d", time.Now().UnixNano())
+	release := &catalogm.Release{
+		Title:       "Phantom Release",
+		Slug:        &releaseSlug,
+		ReleaseType: catalogm.ReleaseTypeLP,
+	}
+	suite.Require().NoError(suite.db.Create(release).Error)
+	suite.Require().NoError(suite.db.Create(&catalogm.ArtistRelease{
+		ArtistID: artist.ID, ReleaseID: release.ID, Role: catalogm.ArtistReleaseRoleMain,
+	}).Error)
+
+	suite.addNonArtistItemToCollection(priv.ID, release.ID, creator.ID, communitym.CollectionEntityRelease)
+
+	graph, err := suite.collectionService.GetCollectionGraph(priv.Slug, creator.ID, nil)
+	suite.Require().NoError(err)
+	suite.Len(graph.Nodes, 1, "only the release is in the collection")
+	suite.Empty(graph.Links, "no edges — the artist endpoint isn't in the collection")
+}
+
+// TestGetCollectionGraph_MultiType_ShowEdges documents the show-as-node
+// behaviour: a show in the collection edges to in-collection artists (its
+// lineup) and venues (its location). PSY-555.
+func (suite *CollectionServiceIntegrationTestSuite) TestGetCollectionGraph_MultiType_ShowEdges() {
+	creator := suite.createTestUser("ShowEdgeCreator")
+	priv := suite.createBasicCollection(creator, "Show Edge Test")
+
+	artist := suite.createTestArtist("ShowEdgeArtist")
+	venue := suite.createTestVenueForCollection("ShowEdgeVenue")
+	show := &catalogm.Show{
+		Title:     "ShowEdgeShow",
+		EventDate: time.Now().Add(-24 * time.Hour),
+		Status:    catalogm.ShowStatusApproved,
+	}
+	suite.Require().NoError(suite.db.Create(show).Error)
+	suite.Require().NoError(suite.db.Create(&catalogm.ShowArtist{
+		ShowID: show.ID, ArtistID: artist.ID,
+	}).Error)
+	suite.Require().NoError(suite.db.Create(&catalogm.ShowVenue{
+		ShowID: show.ID, VenueID: venue.ID,
+	}).Error)
+
+	suite.addArtistItemToCollection(priv.ID, artist.ID, creator.ID)
+	suite.addNonArtistItemToCollection(priv.ID, venue.ID, creator.ID, communitym.CollectionEntityVenue)
+	suite.addNonArtistItemToCollection(priv.ID, show.ID, creator.ID, communitym.CollectionEntityShow)
+
+	graph, err := suite.collectionService.GetCollectionGraph(priv.Slug, creator.ID, nil)
+	suite.Require().NoError(err)
+	suite.Len(graph.Nodes, 3)
+
+	// Expected edges: show↔artist (show_lineup), show↔venue (show_venue),
+	// artist↔venue (played_at — artist played the venue via this same show).
+	gotLinkTypes := make(map[string]int)
+	for _, l := range graph.Links {
+		gotLinkTypes[l.Type]++
+	}
+	suite.Equal(1, gotLinkTypes[CollectionEdgeShowLineup])
+	suite.Equal(1, gotLinkTypes[CollectionEdgeShowVenue])
+	suite.Equal(1, gotLinkTypes[CollectionEdgePlayedAt])
+	suite.Equal(3, graph.Collection.EdgeCount)
+}
+
+// TestGetCollectionGraph_MultiType_NodeIDsAreItemIDs verifies the node-ID
+// invariant the frontend depends on: source_id/target_id reference node
+// IDs (collection_item.id), not raw entity DB IDs. This matters because
+// e.g. artist 5 and venue 5 collide on entity ID alone.
+func (suite *CollectionServiceIntegrationTestSuite) TestGetCollectionGraph_MultiType_NodeIDsAreItemIDs() {
+	creator := suite.createTestUser("NodeIDCreator")
+	priv := suite.createBasicCollection(creator, "Node ID Test")
+	artist := suite.createTestArtist("NodeIDArtist")
+	venue := suite.createTestVenueForCollection("NodeIDVenue")
+	show := &catalogm.Show{
+		Title:     "NodeIDShow",
+		EventDate: time.Now().Add(-24 * time.Hour),
+		Status:    catalogm.ShowStatusApproved,
+	}
+	suite.Require().NoError(suite.db.Create(show).Error)
+	suite.Require().NoError(suite.db.Create(&catalogm.ShowArtist{
+		ShowID: show.ID, ArtistID: artist.ID,
+	}).Error)
+	suite.Require().NoError(suite.db.Create(&catalogm.ShowVenue{
+		ShowID: show.ID, VenueID: venue.ID,
+	}).Error)
+
+	suite.addArtistItemToCollection(priv.ID, artist.ID, creator.ID)
+	suite.addNonArtistItemToCollection(priv.ID, venue.ID, creator.ID, communitym.CollectionEntityVenue)
+
+	graph, err := suite.collectionService.GetCollectionGraph(priv.Slug, creator.ID, nil)
+	suite.Require().NoError(err)
+	suite.Require().Len(graph.Nodes, 2)
+	suite.Require().Len(graph.Links, 1)
+
+	// Every link's source and target must resolve to a node in the response.
+	nodeIDs := make(map[uint]string, len(graph.Nodes))
+	for _, n := range graph.Nodes {
+		nodeIDs[n.ID] = n.EntityType
+	}
+	for _, l := range graph.Links {
+		_, srcOK := nodeIDs[l.SourceID]
+		_, tgtOK := nodeIDs[l.TargetID]
+		suite.True(srcOK, "link source_id %d must reference a node in the response", l.SourceID)
+		suite.True(tgtOK, "link target_id %d must reference a node in the response", l.TargetID)
+	}
 }
 
 // Verify the contract type signature aligns with the interface — this is a

--- a/backend/internal/services/contracts/collection.go
+++ b/backend/internal/services/contracts/collection.go
@@ -273,19 +273,35 @@ type AddCollectionTagResponse struct {
 }
 
 // ──────────────────────────────────────────────
-// Collection graph (PSY-366) — derived per-collection artist relationship graph
+// Collection graph (PSY-366, PSY-555) — multi-type per-collection knowledge graph
 // ──────────────────────────────────────────────
 //
-// The collection analog of the scene graph (PSY-367). Edges are stored
-// `artist_relationships` rows where both endpoints are in the collection's
-// artist items. Mirrors the {Info, Nodes, Links} shape so a shared frontend
-// ForceGraphView can render the payload — no clusters in v1 (collections
-// have no natural cluster signal). See docs/research/knowledge-graph-viz-prior-art.md
-// §5.4 for the entry-point-invisibility motivation.
+// PSY-555 broadened the graph from artist-only to a full multi-type graph
+// (Option B in the ticket): every collection item — artist, venue, show,
+// release, label, festival — becomes a node. Edges are derived from the
+// existing relational model so no new storage is needed:
+//
+//   - artist ↔ artist  : stored `artist_relationships` rows (PSY-366 origin)
+//   - artist ↔ venue   : artist played the venue, via show_artists ⋈ show_venues
+//   - artist ↔ release : artist made the release, via artist_releases
+//   - artist ↔ label   : artist signed to the label, via artist_labels
+//   - artist ↔ festival: artist played the festival, via festival_artists
+//   - show   ↔ artist  : show's lineup, via show_artists
+//   - show   ↔ venue   : show's location, via show_venues
+//
+// Edges are emitted ONLY when both endpoints are present in the collection.
+// We never invent phantom nodes for relationships that pull in entities the
+// curator did not choose — that would explode the graph. Edges between
+// non-artist nodes (venue↔festival etc.) are intentionally out of scope.
+//
+// Mirrors the {Info, Nodes, Links} shape so a shared frontend ForceGraphView
+// can render the payload — no clusters in v1 (collections have no natural
+// cluster signal). See docs/research/knowledge-graph-viz-prior-art.md §5.4
+// for the entry-point-invisibility motivation.
 
 // CollectionGraphResponse is the payload for GET /collections/{slug}/graph.
-// Returned for any collection with at least one artist item; collections
-// containing only non-artist entity types return empty nodes/links (200, not 404).
+// Returned for any collection; collections with no items return empty
+// nodes/links (200, not 404).
 type CollectionGraphResponse struct {
 	Collection CollectionGraphInfo   `json:"collection"`
 	Nodes      []CollectionGraphNode `json:"nodes"`
@@ -293,28 +309,64 @@ type CollectionGraphResponse struct {
 }
 
 // CollectionGraphInfo holds collection metadata for the graph response.
+//
+// EntityCounts is the per-type breakdown of nodes returned in the response
+// (artist / venue / show / release / label / festival). The frontend uses
+// this to render the subtitle copy ("1 artist · 1 venue · 1 release"). Always
+// non-nil; empty map when the collection has no items.
+//
+// ArtistCount is preserved for backward compatibility with PSY-366-era
+// callers and equals EntityCounts["artist"].
 type CollectionGraphInfo struct {
-	Slug        string `json:"slug"`
-	Name        string `json:"name"`
-	ArtistCount int    `json:"artist_count"` // distinct artists in the collection (includes isolates)
-	EdgeCount   int    `json:"edge_count"`   // total edges in the response (post type-filter)
+	Slug         string         `json:"slug"`
+	Name         string         `json:"name"`
+	ArtistCount  int            `json:"artist_count"` // distinct artists in the collection (includes isolates)
+	EdgeCount    int            `json:"edge_count"`   // total edges in the response (post type-filter)
+	EntityCounts map[string]int `json:"entity_counts"`
 }
 
-// CollectionGraphNode represents an artist item in the collection graph.
-// Mirrors SceneGraphNode minus ClusterID (no clustering in v1).
+// CollectionGraphNode represents a single collection item in the graph.
+//
+// EntityType is one of the six community.CollectionEntity* constants:
+// "artist", "venue", "show", "release", "label", "festival". Frontend uses
+// it to pick the node icon and color.
+//
+// City and State are populated when the underlying record has them (artist,
+// venue) and empty otherwise (releases / labels / shows / festivals don't
+// always have a stable place — keep the field in the union shape and let
+// the renderer omit it).
+//
+// UpcomingShowCount is meaningful only for artists; non-artist nodes return
+// 0. Kept on the shared shape so the frontend ForceGraphView (PSY-365)
+// renders the same node type regardless of entity.
 type CollectionGraphNode struct {
 	ID                uint   `json:"id"`
+	EntityType        string `json:"entity_type"`
 	Name              string `json:"name"`
 	Slug              string `json:"slug"`
 	City              string `json:"city,omitempty"`
 	State             string `json:"state,omitempty"`
 	UpcomingShowCount int    `json:"upcoming_show_count"`
-	IsIsolate         bool   `json:"is_isolate"` // true when artist has no in-set edges (post type-filter)
+	IsIsolate         bool   `json:"is_isolate"` // true when node has no in-set edges (post type-filter)
 }
 
-// CollectionGraphLink represents a stored relationship between two artist
-// items. Mirrors SceneGraphLink minus IsCrossCluster (no clustering in v1).
-// Voting and user-vote data are intentionally omitted — collection graph is
+// CollectionGraphLink represents an edge in the collection graph.
+//
+// Type uses the existing artist-relationship grammar where it applies
+// (shared_bills, shared_label, member_of, side_project, similar,
+// radio_cooccurrence) and adds derived types for the multi-type cases:
+//   - "played_at"     : artist played the venue (artist ↔ venue)
+//   - "discography"   : artist made the release (artist ↔ release)
+//   - "signed_to"     : artist signed to the label (artist ↔ label)
+//   - "lineup"        : artist played the festival (artist ↔ festival)
+//   - "show_lineup"   : show ↔ artist (the show's billed acts)
+//   - "show_venue"    : show ↔ venue (the show's location)
+//
+// SourceID/TargetID are NODE IDs unique within the response — for two
+// different entity types with the same DB ID (e.g. artist 5 and venue 5),
+// the IDs are namespaced by buildNodeID below to keep them distinct.
+//
+// Voting/user-vote data are intentionally omitted — collection graph is
 // read-only, like scene graph.
 type CollectionGraphLink struct {
 	SourceID uint    `json:"source_id"`

--- a/frontend/features/collections/components/CollectionDetail.tsx
+++ b/frontend/features/collections/components/CollectionDetail.tsx
@@ -203,8 +203,8 @@ export function CollectionDetail({ slug }: CollectionDetailProps) {
   // collection non-empty".
   const hasItems = items.length > 0
 
-  // Gate auto-open on artist items so `#graph` on a non-artist collection no-ops.
-  const autoOpenFromHash = hash === GRAPH_HASH && artistItemCount > 0
+  // Gate auto-open so `#graph` on an empty collection no-ops; multi-type graph (PSY-555) can render any item.
+  const autoOpenFromHash = hash === GRAPH_HASH && hasItems
   const showGraph = showGraphOverride ?? autoOpenFromHash
 
   if (isLoading) {

--- a/frontend/features/collections/components/CollectionDetail.tsx
+++ b/frontend/features/collections/components/CollectionDetail.tsx
@@ -197,9 +197,12 @@ export function CollectionDetail({ slug }: CollectionDetailProps) {
   }, [])
 
   const items = collection?.items ?? []
-  // PSY-366: only surface the graph toggle when the collection has at least
-  // one artist item — non-artist-only collections have nothing to graph.
-  const artistItemCount = items.filter(it => it.entity_type === 'artist').length
+  // PSY-555 (was PSY-366): surface the graph toggle whenever the collection
+  // has any items. Pre-PSY-555 the toggle was gated on artist items only
+  // because non-artist items couldn't be rendered; with the multi-type
+  // graph every entity type becomes a node, so the gate moves to "is the
+  // collection non-empty".
+  const hasItems = items.length > 0
 
   if (isLoading) {
     return (
@@ -532,10 +535,10 @@ export function CollectionDetail({ slug }: CollectionDetailProps) {
                   {showCopied ? 'Copied!' : 'Share'}
                 </Button>
 
-                {/* PSY-366: Explore graph toggle. Visible only when the
-                    collection has artist items — non-artist-only collections
-                    have nothing to graph. */}
-                {artistItemCount > 0 && (
+                {/* PSY-555 (was PSY-366): Explore graph toggle. Visible
+                    whenever the collection has at least one item — every
+                    entity type renders as a node in the multi-type graph. */}
+                {hasItems && (
                   <Button
                     variant={showGraph ? 'default' : 'outline'}
                     size="sm"
@@ -639,10 +642,10 @@ export function CollectionDetail({ slug }: CollectionDetailProps) {
       {/* PSY-356: publish-gate banner (creator-only) */}
       {isCreator && <PublishGateBanner collection={collection} />}
 
-      {/* PSY-366: collection graph (toggleable). Renders only when the
-          user clicks "Explore graph" in the actions row. The wrapper has
-          `id="graph"` so Cmd+K deep-links resolve. */}
-      {showGraph && artistItemCount > 0 && (
+      {/* PSY-555 (was PSY-366): collection graph (toggleable). Renders
+          only when the user clicks "Explore graph" in the actions row.
+          The wrapper has `id="graph"` so Cmd+K deep-links resolve. */}
+      {showGraph && hasItems && (
         <CollectionGraph slug={slug} collectionTitle={collection.title} />
       )}
 

--- a/frontend/features/collections/components/CollectionGraph.tsx
+++ b/frontend/features/collections/components/CollectionGraph.tsx
@@ -1,28 +1,26 @@
 'use client'
 
 /**
- * CollectionGraph (PSY-366)
+ * CollectionGraph (PSY-366, PSY-555)
  *
- * Section wrapper for the collection-scoped artist-relationship graph: header,
- * canvas, fullscreen overlay. Mirrors the SceneGraph (PSY-367, PSY-516,
- * PSY-517) layout pattern — same callback-ref width measurement, same
- * mobile gate, same body-scroll-lock + Esc-close fullscreen overlay.
+ * Section wrapper for the collection's knowledge subgraph: header, canvas,
+ * fullscreen overlay. PSY-555 broadened the graph from artist-only to a
+ * full multi-type graph (Option B) — every collection item is now a node.
+ *
+ * Mirrors the SceneGraph (PSY-367, PSY-516, PSY-517) layout pattern — same
+ * callback-ref width measurement, same mobile gate, same body-scroll-lock +
+ * Esc-close fullscreen overlay.
  *
  * Differs from SceneGraph in three ways:
- *   1. No clusters — collections have no natural cluster signal (curator-
- *      chosen items don't share a venue or scene). `clusters={[]}` is
- *      passed to ForceGraphView; nodes default to the "other" bucket.
+ *   1. Clusters are entity TYPES (artist / venue / show / release / label /
+ *      festival), not scene buckets — entity type is the most useful
+ *      grouping signal for a curator-chosen mixed-type set.
  *   2. No `MIN_GRAPH_NODES=3` empty-state gate — the parent
- *      (CollectionDetail) only renders this when artistItemCount > 0, so
- *      the user has explicit intent. A single artist shows as one dot;
- *      that's honest, not a crash.
- *   3. Toggle-driven, not default-visible — collections may have many
- *      non-artist items, and an always-on graph would compete with the
- *      items list for attention. The parent owns the toggle state.
+ *      (CollectionDetail) only renders this when the collection has items.
+ *   3. Toggle-driven, not default-visible. The parent owns the toggle.
  *
  * Mobile gating retained: below 640px the canvas is unusable (PSY-369),
- * so the graph slot collapses to a teaser message + "Open on a larger
- * screen" affordance.
+ * so the graph slot collapses to a teaser message.
  */
 
 import { useState, useCallback, useEffect, useMemo } from 'react'
@@ -30,10 +28,36 @@ import { useRouter } from 'next/navigation'
 import { Maximize2, X } from 'lucide-react'
 import { useCollectionGraph } from '../hooks'
 import { ForceGraphView } from '@/components/graph/ForceGraphView'
-import type { GraphNode } from '@/components/graph/ForceGraphView'
+import type { GraphCluster, GraphNode } from '@/components/graph/ForceGraphView'
+import {
+  COLLECTION_ENTITY_TYPES,
+  getEntityTypeLabel,
+  getEntityUrl,
+  type CollectionGraphNode,
+} from '../types'
 
 const GRAPH_BREAKPOINT_PX = 640
 const OVERLAY_VERTICAL_RESERVE_PX = 140
+
+/**
+ * PSY-555: stable color-index per entity type, indexing into the
+ * Okabe-Ito 8-color palette already used by ForceGraphView. The same
+ * type → index mapping is used everywhere in the component so the color
+ * the user sees on the canvas matches the legend hint and the icon row.
+ *
+ * The order is the same as COLLECTION_ENTITY_TYPES so the node-builder
+ * iteration and the cluster-legend ordering stay aligned.
+ *
+ * Indexes 0–5 (skipping 6/yellow which has poor contrast on dark mode).
+ */
+const ENTITY_COLOR_INDEX: Record<string, number> = {
+  artist: 0,
+  venue: 1,
+  show: 2,
+  release: 3,
+  label: 4,
+  festival: 5,
+}
 
 interface CollectionGraphProps {
   slug: string
@@ -95,20 +119,82 @@ export function CollectionGraph({ slug, collectionTitle }: CollectionGraphProps)
     return data.nodes.reduce((n, node) => (node.is_isolate ? n + 1 : n), 0)
   }, [data])
 
-  const handleNodeClick = useCallback(
+  // PSY-555: enrich nodes with cluster_id (the entity type), and produce
+  // matching cluster definitions so ForceGraphView paints each type in
+  // its own color. We only declare clusters that actually appear in the
+  // payload, so single-type collections still look clean.
+  const { renderNodes, clusters } = useMemo(() => {
+    if (!data) {
+      return { renderNodes: [] as GraphNode[], clusters: [] as GraphCluster[] }
+    }
+    const counts: Record<string, number> = {}
+    const enriched: GraphNode[] = data.nodes.map(n => {
+      const entityType = n.entity_type ?? 'artist'
+      counts[entityType] = (counts[entityType] ?? 0) + 1
+      return {
+        id: n.id,
+        name: n.name,
+        slug: n.slug,
+        city: n.city,
+        state: n.state,
+        upcoming_show_count: n.upcoming_show_count,
+        is_isolate: n.is_isolate,
+        cluster_id: entityType,
+      }
+    })
+    const clusterDefs: GraphCluster[] = COLLECTION_ENTITY_TYPES
+      .filter(t => (counts[t] ?? 0) > 0)
+      .map(t => ({
+        id: t,
+        label: getEntityTypeLabel(t),
+        size: counts[t],
+        color_index: ENTITY_COLOR_INDEX[t] ?? -1,
+      }))
+    return { renderNodes: enriched, clusters: clusterDefs }
+  }, [data])
+
+  // PSY-555: route to the right entity detail page based on the node's
+  // entity_type. Falls back to /artists/ for legacy nodes that don't
+  // carry the field (shouldn't happen in production, but the fallback
+  // matches the PSY-366 baseline behaviour).
+  const navigateToNode = useCallback(
     (node: GraphNode) => {
-      router.push(`/artists/${node.slug}`)
+      const original = data?.nodes.find(
+        (n: CollectionGraphNode) => n.id === node.id,
+      )
+      const entityType = original?.entity_type ?? 'artist'
+      router.push(getEntityUrl(entityType, node.slug))
     },
-    [router],
+    [data, router],
   )
 
   const handleNodeClickOverlay = useCallback(
     (node: GraphNode) => {
       setIsFullscreen(false)
-      router.push(`/artists/${node.slug}`)
+      navigateToNode(node)
     },
-    [router],
+    [navigateToNode],
   )
+
+  // PSY-555: subtitle reflects the multi-type breakdown. Uses
+  // entity_counts when present, falling back to artist_count for
+  // PSY-366-era response shapes.
+  const subtitleParts = useMemo(() => {
+    if (!data) return [] as string[]
+    const counts =
+      data.collection.entity_counts ??
+      // legacy fallback — old responses only carry artist_count
+      ({ artist: data.collection.artist_count } as Record<string, number>)
+    return COLLECTION_ENTITY_TYPES.flatMap(t => {
+      const count = counts[t] ?? 0
+      if (count <= 0) return []
+      // singular vs. plural copy — `getEntityTypeLabel` is "Artist"
+      // (singular); for the count display we lowercase + pluralize.
+      const labelLower = getEntityTypeLabel(t).toLowerCase()
+      const pluralized = count === 1 ? labelLower : `${labelLower}s`
+      return [`${count} ${pluralized}`]
+    })
+  }, [data])
 
   // Always render the wrapper so the callback ref fires even before data
   // arrives — otherwise we'd never measure the container.
@@ -121,7 +207,7 @@ export function CollectionGraph({ slug, collectionTitle }: CollectionGraphProps)
     <div>
       <h2 className="text-lg font-semibold">Collection graph</h2>
       <p className="text-sm text-muted-foreground">
-        {nodeCount} {nodeCount === 1 ? 'artist' : 'artists'}
+        {subtitleParts.length > 0 ? subtitleParts.join(' · ') : 'No items'}
         {edgeCount > 0 && (
           <>
             {' · '}
@@ -150,7 +236,7 @@ export function CollectionGraph({ slug, collectionTitle }: CollectionGraphProps)
     </button>
   )
 
-  const ariaLabel = `Relationship graph for collection ${collectionTitle}: ${nodeCount} artists, ${edgeCount} connections.`
+  const ariaLabel = `Knowledge graph for collection ${collectionTitle}: ${nodeCount} items, ${edgeCount} connections.`
 
   return (
     <>
@@ -173,7 +259,8 @@ export function CollectionGraph({ slug, collectionTitle }: CollectionGraphProps)
 
         {!isLoading && data && nodeCount === 0 && (
           <p className="text-sm text-muted-foreground">
-            No artist items yet — add an artist to this collection to see its graph.
+            No items yet — add an artist, venue, release, label, festival, or
+            show to this collection to see its graph.
           </p>
         )}
 
@@ -186,17 +273,18 @@ export function CollectionGraph({ slug, collectionTitle }: CollectionGraphProps)
         {!isLoading && data && nodeCount > 0 && graphAvailable && !isFullscreen && (
           <div className="space-y-3">
             <ForceGraphView
-              nodes={data.nodes}
+              nodes={renderNodes}
               links={data.links}
-              clusters={[]}
+              clusters={clusters}
               containerWidth={containerWidth!}
               ariaLabel={ariaLabel}
-              onNodeClick={handleNodeClick}
+              onNodeClick={navigateToNode}
             />
             <p className="text-xs text-muted-foreground">
-              Showing artists in this collection and their stored relationships
-              (shared bills, shared label, member of, side project, similar, radio
-              co-occurrence). Click any artist to open their page.
+              Showing every item in this collection and the relationships
+              between them — artists, venues they’ve played, releases
+              they’ve made, labels they’re on, festivals they’ve
+              played, and shows. Click any node to open its page.
             </p>
           </div>
         )}
@@ -228,9 +316,9 @@ export function CollectionGraph({ slug, collectionTitle }: CollectionGraphProps)
           <div className="flex-1 min-h-0 px-4 py-2">
             {overlayHeight !== null && overlayWidth !== null && (
               <ForceGraphView
-                nodes={data.nodes}
+                nodes={renderNodes}
                 links={data.links}
-                clusters={[]}
+                clusters={clusters}
                 containerWidth={overlayWidth}
                 height={overlayHeight}
                 ariaLabel={ariaLabel}

--- a/frontend/features/collections/components/CollectionGraph.tsx
+++ b/frontend/features/collections/components/CollectionGraph.tsx
@@ -33,7 +33,6 @@ import {
   COLLECTION_ENTITY_TYPES,
   getEntityTypeLabel,
   getEntityUrl,
-  type CollectionGraphNode,
 } from '../types'
 
 const GRAPH_BREAKPOINT_PX = 640
@@ -154,18 +153,16 @@ export function CollectionGraph({ slug, collectionTitle }: CollectionGraphProps)
   }, [data])
 
   // PSY-555: route to the right entity detail page based on the node's
-  // entity_type. Falls back to /artists/ for legacy nodes that don't
-  // carry the field (shouldn't happen in production, but the fallback
-  // matches the PSY-366 baseline behaviour).
+  // entity_type. The render-node's `cluster_id` carries the entity type
+  // (set above when enriching). Falls back to /artists/ for legacy nodes
+  // that don't carry it — shouldn't happen in production, matches the
+  // PSY-366 baseline.
   const navigateToNode = useCallback(
     (node: GraphNode) => {
-      const original = data?.nodes.find(
-        (n: CollectionGraphNode) => n.id === node.id,
-      )
-      const entityType = original?.entity_type ?? 'artist'
+      const entityType = node.cluster_id ?? 'artist'
       router.push(getEntityUrl(entityType, node.slug))
     },
-    [data, router],
+    [router],
   )
 
   const handleNodeClickOverlay = useCallback(

--- a/frontend/features/collections/types.ts
+++ b/frontend/features/collections/types.ts
@@ -282,30 +282,65 @@ export function getEntityTypeLabel(entityType: string): string {
 }
 
 // =============================================================================
-// PSY-366: Collection graph types — mirror the backend contracts exactly.
+// Collection graph types — mirror the backend contracts exactly.
+//
+// PSY-366: artist-only graph (origin).
+// PSY-555: extended to multi-type — every collection item becomes a node.
 // =============================================================================
 
 export interface CollectionGraphInfo {
   slug: string
   name: string
+  /**
+   * Distinct artist nodes in the response. PSY-366 backwards-compat field;
+   * equivalent to `entity_counts.artist`. The frontend prefers
+   * `entity_counts` for the multi-type subtitle.
+   */
   artist_count: number
   edge_count: number
+  /**
+   * PSY-555: per-type breakdown of nodes ("artist", "venue", "show",
+   * "release", "label", "festival" → count). Always non-nil from the
+   * server; the type allows undefined for older fixtures.
+   */
+  entity_counts?: Record<string, number>
 }
 
 export interface CollectionGraphNode {
+  /**
+   * Stable node ID, unique within the response. PSY-555: this is the
+   * underlying `collection_item.id` rather than the entity's own DB ID,
+   * so artist 5 and venue 5 in the same collection don't collide.
+   * Treat as opaque on the frontend — link source/target reference it,
+   * but routing uses `entity_type` + `slug`.
+   */
   id: number
+  /**
+   * PSY-555: one of "artist", "venue", "show", "release", "label",
+   * "festival". Frontend uses this to pick the node icon/color and the
+   * route prefix on click. Optional in the type so older fixtures still
+   * compile; the server response always populates it.
+   */
+  entity_type?: string
   name: string
   slug: string
   city?: string
   state?: string
+  /** Meaningful only for artist nodes; 0 for non-artist nodes. */
   upcoming_show_count: number
-  /** True when the artist has zero in-set edges (post type-filter). */
+  /** True when the node has zero in-set edges (post type-filter). */
   is_isolate: boolean
 }
 
 export interface CollectionGraphLink {
   source_id: number
   target_id: number
+  /**
+   * Edge type. Stored artist-relationship grammar plus PSY-555 derived
+   * types: "played_at" (artist↔venue), "discography" (artist↔release),
+   * "signed_to" (artist↔label), "lineup" (artist↔festival),
+   * "show_lineup" (show↔artist), "show_venue" (show↔venue).
+   */
   type: string
   score: number
   detail?: Record<string, unknown>


### PR DESCRIPTION
## Summary
- Switch collection graph from artist-only to full multi-type per ticket Option B
- Render venue / release / label / festival / show nodes alongside artists, edged via existing artist↔X relationships (plus show↔artist and show↔venue when shows are in the collection)
- Subtitle reflects the multi-type count

## Implementation notes
- Edges only emit when both endpoints are in the collection — no phantom nodes
- Node IDs use `collection_item.id` (unique within a response) so cross-type DB-ID collisions (artist 5 vs venue 5) don't conflate nodes
- Frontend uses entity types as ForceGraphView clusters so each type gets a distinct color via the existing cluster-color machinery (no changes to the shared canvas component)
- Click-routing dispatches by `entity_type` via `getEntityUrl`
- "Explore graph" toggle now shows whenever the collection has any items (was: artist items only)
- Show entity edges to in-collection artists (lineup) and venues (location) — see `show_lineup` / `show_venue` link types

## Test plan
- [x] backend tests pass (graph endpoint) — 13 graph service tests + handler tests
- [x] frontend typecheck passes
- [x] frontend collection tests (216) pass
- [ ] manual: open /collections/dogfood-test-collection-psy-319 → graph shows all 5 entity types
- [ ] manual: artist-only collection still renders correctly
- [ ] manual: empty collection still shows empty state

Closes PSY-555