### PR TITLE
PSY-560: render edit attribution as resolved username

### DIFF
--- a/backend/internal/api/handlers/admin/revision.go
+++ b/backend/internal/api/handlers/admin/revision.go
@@ -47,13 +47,9 @@ var validEntityTypes = map[string]bool{
 // --- Response Types ---
 
 // RevisionResponseItem represents a single revision in API responses.
-//
-// PSY-560: UserName uses the full resolveUserName chain (username → first/last
-// → email-prefix → "Anonymous") so it is never empty. UserUsername is a
-// separate, URL-safe slug — nil when the user has no username set, so the
-// frontend can decide whether to render a /users/:username link or plain text.
-// Mirrors the CommentResponse author_name + author_username split (PSY-552 /
-// PSY-353).
+// UserName is never empty (resolveRevisionUserName chain).
+// UserUsername is nil when no username is set — distinct from UserName so
+// the frontend can decide between a /users/:username link and plain text.
 type RevisionResponseItem struct {
 	ID           uint                 `json:"id"`
 	EntityType   string               `json:"entity_type"`
@@ -66,12 +62,11 @@ type RevisionResponseItem struct {
 	CreatedAt    string               `json:"created_at"`
 }
 
-// resolveRevisionUserName returns the display name for a revision's author —
-// never empty. Mirrors CollectionService.resolveUserName (PSY-353) and
-// resolveCommentAuthorName (PSY-552): prefer username, fall back to
-// first/last, then to the local-part of the email, finally "Anonymous".
-// Operates on the preloaded User so callers don't pay an extra query per
-// revision. PSY-560.
+// resolveRevisionUserName returns the display name for a revision's author,
+// never empty. Resolution chain: username → first/last → email-prefix →
+// "Anonymous". Mirrors resolveCommentAuthorName (PSY-552) and
+// CollectionService.resolveUserName (PSY-353); operates on the preloaded
+// User so there's no extra query per revision.
 func resolveRevisionUserName(u *authm.User) string {
 	if u == nil || u.ID == 0 {
 		return "Anonymous"
@@ -94,10 +89,10 @@ func resolveRevisionUserName(u *authm.User) string {
 	return "Anonymous"
 }
 
-// resolveRevisionUserUsername returns the author's username for
-// /users/:username links, or nil when the user has no username set. Distinct
-// from resolveRevisionUserName, which falls back to first/last/email and so
-// cannot be safely used in a URL slug. PSY-560.
+// resolveRevisionUserUsername returns the URL-safe username slug, or nil
+// when the user has no username set. Distinct from resolveRevisionUserName,
+// whose fallback to first/last/email can't be used in a /users/:username
+// link. Mirrors resolveCommentAuthorUsername (PSY-552).
 func resolveRevisionUserUsername(u *authm.User) *string {
 	if u == nil || u.ID == 0 {
 		return nil

--- a/backend/internal/api/handlers/admin/revision.go
+++ b/backend/internal/api/handlers/admin/revision.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/danielgtaylor/huma/v2"
 
@@ -12,6 +13,7 @@ import (
 	"psychic-homily-backend/internal/api/middleware"
 	"psychic-homily-backend/internal/logger"
 	adminm "psychic-homily-backend/internal/models/admin"
+	authm "psychic-homily-backend/internal/models/auth"
 	"psychic-homily-backend/internal/services/contracts"
 )
 
@@ -45,36 +47,81 @@ var validEntityTypes = map[string]bool{
 // --- Response Types ---
 
 // RevisionResponseItem represents a single revision in API responses.
+//
+// PSY-560: UserName uses the full resolveUserName chain (username → first/last
+// → email-prefix → "Anonymous") so it is never empty. UserUsername is a
+// separate, URL-safe slug — nil when the user has no username set, so the
+// frontend can decide whether to render a /users/:username link or plain text.
+// Mirrors the CommentResponse author_name + author_username split (PSY-552 /
+// PSY-353).
 type RevisionResponseItem struct {
-	ID         uint                 `json:"id"`
-	EntityType string               `json:"entity_type"`
-	EntityID   uint                 `json:"entity_id"`
-	UserID     uint                 `json:"user_id"`
-	UserName   string               `json:"user_name,omitempty"`
-	Changes    []adminm.FieldChange `json:"changes"`
-	Summary    string               `json:"summary,omitempty"`
-	CreatedAt  string               `json:"created_at"`
+	ID           uint                 `json:"id"`
+	EntityType   string               `json:"entity_type"`
+	EntityID     uint                 `json:"entity_id"`
+	UserID       uint                 `json:"user_id"`
+	UserName     string               `json:"user_name,omitempty"`
+	UserUsername *string              `json:"user_username"`
+	Changes      []adminm.FieldChange `json:"changes"`
+	Summary      string               `json:"summary,omitempty"`
+	CreatedAt    string               `json:"created_at"`
+}
+
+// resolveRevisionUserName returns the display name for a revision's author —
+// never empty. Mirrors CollectionService.resolveUserName (PSY-353) and
+// resolveCommentAuthorName (PSY-552): prefer username, fall back to
+// first/last, then to the local-part of the email, finally "Anonymous".
+// Operates on the preloaded User so callers don't pay an extra query per
+// revision. PSY-560.
+func resolveRevisionUserName(u *authm.User) string {
+	if u == nil || u.ID == 0 {
+		return "Anonymous"
+	}
+	if u.Username != nil && *u.Username != "" {
+		return *u.Username
+	}
+	if u.FirstName != nil && *u.FirstName != "" {
+		name := *u.FirstName
+		if u.LastName != nil && *u.LastName != "" {
+			name += " " + *u.LastName
+		}
+		return name
+	}
+	if u.Email != nil && *u.Email != "" {
+		if idx := strings.Index(*u.Email, "@"); idx > 0 {
+			return (*u.Email)[:idx]
+		}
+	}
+	return "Anonymous"
+}
+
+// resolveRevisionUserUsername returns the author's username for
+// /users/:username links, or nil when the user has no username set. Distinct
+// from resolveRevisionUserName, which falls back to first/last/email and so
+// cannot be safely used in a URL slug. PSY-560.
+func resolveRevisionUserUsername(u *authm.User) *string {
+	if u == nil || u.ID == 0 {
+		return nil
+	}
+	if u.Username == nil || *u.Username == "" {
+		return nil
+	}
+	username := *u.Username
+	return &username
 }
 
 // mapRevisionToResponse converts a adminm.Revision to a RevisionResponseItem.
 func mapRevisionToResponse(r adminm.Revision) RevisionResponseItem {
 	item := RevisionResponseItem{
-		ID:         r.ID,
-		EntityType: r.EntityType,
-		EntityID:   r.EntityID,
-		UserID:     r.UserID,
-		CreatedAt:  r.CreatedAt.Format("2006-01-02T15:04:05Z"),
+		ID:           r.ID,
+		EntityType:   r.EntityType,
+		EntityID:     r.EntityID,
+		UserID:       r.UserID,
+		UserName:     resolveRevisionUserName(&r.User),
+		UserUsername: resolveRevisionUserUsername(&r.User),
+		CreatedAt:    r.CreatedAt.Format("2006-01-02T15:04:05Z"),
 	}
 
 	item.Summary = shared.Deref(r.Summary)
-
-	// Populate user name from preloaded User relation. Username wins;
-	// FirstName is the fallback when Username is unset.
-	if r.User.Username != nil {
-		item.UserName = *r.User.Username
-	} else if r.User.FirstName != nil {
-		item.UserName = *r.User.FirstName
-	}
 
 	// Unmarshal field changes from JSONB
 	if r.FieldChanges != nil {

--- a/backend/internal/api/handlers/admin/revision_test.go
+++ b/backend/internal/api/handlers/admin/revision_test.go
@@ -436,4 +436,115 @@ func TestMapRevisionToResponse_FallbackToFirstName(t *testing.T) {
 	if item.UserName != "John" {
 		t.Errorf("expected user_name=John, got %s", item.UserName)
 	}
+	if item.UserUsername != nil {
+		t.Errorf("expected user_username=nil when username unset, got %v", *item.UserUsername)
+	}
+}
+
+// PSY-560: full resolveUserName chain (username → first/last → email-prefix
+// → "Anonymous") + linkable user_username for /users/:username profile
+// links. Mirrors PSY-552's resolveCommentAuthorName.
+
+func TestMapRevisionToResponse_PrefersUsername(t *testing.T) {
+	username := "asdf"
+	firstName := "John"
+	r := adminm.Revision{
+		ID:        1,
+		UserID:    5,
+		CreatedAt: time.Date(2026, 3, 10, 12, 0, 0, 0, time.UTC),
+		User: authm.User{
+			ID:        5,
+			Username:  &username,
+			FirstName: &firstName,
+		},
+	}
+
+	item := mapRevisionToResponse(r)
+	if item.UserName != "asdf" {
+		t.Errorf("expected user_name=asdf (username wins), got %s", item.UserName)
+	}
+	if item.UserUsername == nil || *item.UserUsername != "asdf" {
+		t.Errorf("expected user_username=&\"asdf\", got %v", item.UserUsername)
+	}
+}
+
+func TestMapRevisionToResponse_FallbackToFirstAndLastName(t *testing.T) {
+	first := "Jane"
+	last := "Doe"
+	r := adminm.Revision{
+		ID:        1,
+		UserID:    5,
+		CreatedAt: time.Date(2026, 3, 10, 12, 0, 0, 0, time.UTC),
+		User: authm.User{
+			ID:        5,
+			FirstName: &first,
+			LastName:  &last,
+		},
+	}
+
+	item := mapRevisionToResponse(r)
+	if item.UserName != "Jane Doe" {
+		t.Errorf("expected user_name=\"Jane Doe\", got %s", item.UserName)
+	}
+}
+
+func TestMapRevisionToResponse_FallbackToEmailPrefix(t *testing.T) {
+	email := "asdf@admin.com"
+	r := adminm.Revision{
+		ID:        1,
+		UserID:    5,
+		CreatedAt: time.Date(2026, 3, 10, 12, 0, 0, 0, time.UTC),
+		User: authm.User{
+			ID:    5,
+			Email: &email,
+		},
+	}
+
+	item := mapRevisionToResponse(r)
+	if item.UserName != "asdf" {
+		t.Errorf("expected user_name=asdf (email local-part), got %s", item.UserName)
+	}
+	if item.UserUsername != nil {
+		t.Errorf("expected user_username=nil (no username set), got %v", *item.UserUsername)
+	}
+}
+
+func TestMapRevisionToResponse_FallbackToAnonymous(t *testing.T) {
+	r := adminm.Revision{
+		ID:        1,
+		UserID:    5,
+		CreatedAt: time.Date(2026, 3, 10, 12, 0, 0, 0, time.UTC),
+		User:      authm.User{ID: 5},
+	}
+
+	item := mapRevisionToResponse(r)
+	if item.UserName != "Anonymous" {
+		t.Errorf("expected user_name=Anonymous when no identity fields set, got %s", item.UserName)
+	}
+}
+
+// Empty-string username should not be linkable — the User would have ""
+// stored, which is a valid GORM zero-value but a bad URL slug. PSY-560
+// guards against this explicitly to mirror resolveCommentAuthorUsername.
+func TestMapRevisionToResponse_EmptyUsernameTreatedAsUnset(t *testing.T) {
+	emptyUsername := ""
+	firstName := "Jane"
+	r := adminm.Revision{
+		ID:        1,
+		UserID:    5,
+		CreatedAt: time.Date(2026, 3, 10, 12, 0, 0, 0, time.UTC),
+		User: authm.User{
+			ID:        5,
+			Username:  &emptyUsername,
+			FirstName: &firstName,
+		},
+	}
+
+	item := mapRevisionToResponse(r)
+	if item.UserName != "Jane" {
+		t.Errorf("expected display name to fall through past empty username, got %s", item.UserName)
+	}
+	if item.UserUsername != nil {
+		t.Errorf("expected user_username=nil when username is empty string, got %v", *item.UserUsername)
+	}
 }

--- a/frontend/components/shared/RevisionHistory.test.tsx
+++ b/frontend/components/shared/RevisionHistory.test.tsx
@@ -13,6 +13,7 @@ const mockRevisions: RevisionItem[] = [
     entity_id: 42,
     user_id: 10,
     user_name: 'alice',
+    user_username: 'alice',
     changes: [
       { field: 'name', old_value: 'Old Name', new_value: 'New Name' },
       { field: 'city', old_value: null, new_value: 'Phoenix' },
@@ -20,12 +21,15 @@ const mockRevisions: RevisionItem[] = [
     summary: 'Updated artist info',
     created_at: new Date(Date.now() - 5 * 60 * 1000).toISOString(), // 5 mins ago
   },
+  // Editor with no username slug — backend resolved their display name
+  // through the email-prefix branch, but the row is not linkable. PSY-560.
   {
     id: 2,
     entity_type: 'artist',
     entity_id: 42,
     user_id: 20,
-    user_name: undefined,
+    user_name: 'asdf',
+    user_username: null,
     changes: [
       { field: 'state', old_value: 'CA', new_value: 'AZ' },
     ],
@@ -170,7 +174,11 @@ describe('RevisionHistory', () => {
     expect(link).toHaveAttribute('href', '/users/alice')
   })
 
-  it('shows fallback "User #ID" when user_name is not set', async () => {
+  // PSY-560: when user_username is null the byline must be plain text (no
+  // /users/:username link, since it would 404). The display name itself is
+  // resolved server-side through the resolveUserName chain — first/last,
+  // email-prefix, "Anonymous" — so we no longer fall back to "User #N".
+  it('renders display name as plain text when user_username is null', async () => {
     const user = userEvent.setup()
     mockUseEntityRevisions.mockReturnValue({
       data: { revisions: mockRevisions, total: 2 },
@@ -180,7 +188,38 @@ describe('RevisionHistory', () => {
     render(<RevisionHistory entityType="artist" entityId={42} />)
 
     await user.click(screen.getByText('History'))
-    expect(screen.getByText('User #20')).toBeInTheDocument()
+    expect(screen.getByText('asdf')).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'asdf' })).not.toBeInTheDocument()
+    expect(screen.queryByText(/User #/)).not.toBeInTheDocument()
+  })
+
+  // Fallback for a defensive payload — if the backend ever omits user_name
+  // entirely, we render "Anonymous" rather than the bare "User #N" debug
+  // string. PSY-560.
+  it('renders "Anonymous" when user_name is missing entirely', async () => {
+    const user = userEvent.setup()
+    mockUseEntityRevisions.mockReturnValue({
+      data: {
+        revisions: [
+          {
+            id: 99,
+            entity_type: 'artist',
+            entity_id: 42,
+            user_id: 99,
+            // user_name and user_username intentionally omitted
+            changes: [{ field: 'x', old_value: 'a', new_value: 'b' }],
+            created_at: new Date().toISOString(),
+          },
+        ],
+        total: 1,
+      },
+      isLoading: false,
+      error: null,
+    })
+    render(<RevisionHistory entityType="artist" entityId={42} />)
+
+    await user.click(screen.getByText('History'))
+    expect(screen.getByText('Anonymous')).toBeInTheDocument()
   })
 
   it('shows relative time for recent revisions', async () => {

--- a/frontend/components/shared/RevisionHistory.tsx
+++ b/frontend/components/shared/RevisionHistory.tsx
@@ -82,17 +82,23 @@ function RevisionEntry({
         </div>
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 flex-wrap">
-            {revision.user_name ? (
+            {/* PSY-560: link to /users/:username only when the user has a
+                username slug. Otherwise render the resolved display name
+                (first/last, email-prefix, "Anonymous") as plain text. The
+                resolveUserName chain on the backend means user_name is
+                effectively never empty for known users; the explicit
+                fallback here is defense-in-depth for legacy payloads. */}
+            {revision.user_username ? (
               <Link
-                href={`/users/${revision.user_name}`}
+                href={`/users/${revision.user_username}`}
                 onClick={e => e.stopPropagation()}
                 className="text-sm font-medium hover:underline"
               >
-                {revision.user_name}
+                {revision.user_name || 'Anonymous'}
               </Link>
             ) : (
-              <span className="text-sm font-medium text-muted-foreground">
-                User #{revision.user_id}
+              <span className="text-sm font-medium text-foreground">
+                {revision.user_name || 'Anonymous'}
               </span>
             )}
             <span className="text-xs text-muted-foreground">

--- a/frontend/components/shared/RevisionHistory.tsx
+++ b/frontend/components/shared/RevisionHistory.tsx
@@ -66,6 +66,9 @@ function RevisionEntry({
   isRollingBack: boolean
 }) {
   const [expanded, setExpanded] = useState(false)
+  // user_name is resolved server-side via the full chain (PSY-560); the
+  // 'Anonymous' fallback covers legacy/empty payloads.
+  const displayName = revision.user_name || 'Anonymous'
 
   return (
     <div className="border-b border-border/50 last:border-b-0">
@@ -82,23 +85,18 @@ function RevisionEntry({
         </div>
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 flex-wrap">
-            {/* PSY-560: link to /users/:username only when the user has a
-                username slug. Otherwise render the resolved display name
-                (first/last, email-prefix, "Anonymous") as plain text. The
-                resolveUserName chain on the backend means user_name is
-                effectively never empty for known users; the explicit
-                fallback here is defense-in-depth for legacy payloads. */}
+            {/* user_username is the linkable slug; nil means unlinkable. PSY-560. */}
             {revision.user_username ? (
               <Link
                 href={`/users/${revision.user_username}`}
                 onClick={e => e.stopPropagation()}
                 className="text-sm font-medium hover:underline"
               >
-                {revision.user_name || 'Anonymous'}
+                {displayName}
               </Link>
             ) : (
               <span className="text-sm font-medium text-foreground">
-                {revision.user_name || 'Anonymous'}
+                {displayName}
               </span>
             )}
             <span className="text-xs text-muted-foreground">

--- a/frontend/features/contributions/components/AttributionLine.test.tsx
+++ b/frontend/features/contributions/components/AttributionLine.test.tsx
@@ -33,6 +33,7 @@ describe('AttributionLine', () => {
     mockUseEntityAttribution.mockReturnValue({
       data: {
         userName: 'alice',
+        userUsername: 'alice',
         createdAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
       },
     })
@@ -45,6 +46,7 @@ describe('AttributionLine', () => {
     mockUseEntityAttribution.mockReturnValue({
       data: {
         userName: 'alice',
+        userUsername: 'alice',
         createdAt: new Date().toISOString(),
       },
     })
@@ -53,10 +55,44 @@ describe('AttributionLine', () => {
     expect(link).toHaveAttribute('href', '/users/alice')
   })
 
+  // PSY-560: when the editor has no username slug, the byline must render
+  // the resolved display name (first/last, email-prefix, "Anonymous") as
+  // plain text — never as a link, since /users/:username would 404. Mirrors
+  // CommentCard byline behavior (PSY-552).
+  it('renders display name as plain text when userUsername is null', () => {
+    mockUseEntityAttribution.mockReturnValue({
+      data: {
+        userName: 'asdf',
+        userUsername: null,
+        createdAt: new Date().toISOString(),
+      },
+    })
+    render(<AttributionLine entityType="artist" entityId={42} />)
+    expect(screen.getByText('asdf')).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'asdf' })).not.toBeInTheDocument()
+  })
+
+  // Display name and slug can differ — e.g. a user with username "jdoe"
+  // and first name "Jane Doe" would surface "Jane Doe" as the visible
+  // text but link to /users/jdoe. PSY-560.
+  it('uses userUsername for the link href but userName for visible text', () => {
+    mockUseEntityAttribution.mockReturnValue({
+      data: {
+        userName: 'Jane Doe',
+        userUsername: 'jdoe',
+        createdAt: new Date().toISOString(),
+      },
+    })
+    render(<AttributionLine entityType="artist" entityId={42} />)
+    const link = screen.getByText('Jane Doe').closest('a')
+    expect(link).toHaveAttribute('href', '/users/jdoe')
+  })
+
   it('shows relative time for recent edits', () => {
     mockUseEntityAttribution.mockReturnValue({
       data: {
         userName: 'bob',
+        userUsername: 'bob',
         createdAt: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
       },
     })
@@ -68,6 +104,7 @@ describe('AttributionLine', () => {
     mockUseEntityAttribution.mockReturnValue({
       data: {
         userName: 'carol',
+        userUsername: 'carol',
         createdAt: new Date(Date.now() - 10 * 1000).toISOString(),
       },
     })
@@ -79,6 +116,7 @@ describe('AttributionLine', () => {
     mockUseEntityAttribution.mockReturnValue({
       data: {
         userName: 'dave',
+        userUsername: 'dave',
         createdAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
       },
     })
@@ -90,6 +128,7 @@ describe('AttributionLine', () => {
     mockUseEntityAttribution.mockReturnValue({
       data: {
         userName: 'eve',
+        userUsername: 'eve',
         createdAt: '2025-01-15T12:00:00Z',
       },
     })
@@ -108,6 +147,7 @@ describe('AttributionLine', () => {
     mockUseEntityAttribution.mockReturnValue({
       data: {
         userName: 'testuser',
+        userUsername: 'testuser',
         createdAt: new Date().toISOString(),
       },
     })

--- a/frontend/features/contributions/components/AttributionLine.tsx
+++ b/frontend/features/contributions/components/AttributionLine.tsx
@@ -21,10 +21,7 @@ export function AttributionLine({ entityType, entityId }: AttributionLineProps) 
     return null
   }
 
-  // PSY-560: link to /users/:username only when the user has a username
-  // slug — falling back to the resolved display name (first/last,
-  // email-prefix, "Anonymous") as plain text otherwise. Mirrors the
-  // CommentCard byline pattern (PSY-552 / PSY-353).
+  // userUsername is the linkable slug; nil means unlinkable. PSY-560.
   return (
     <p className="text-xs text-muted-foreground">
       Last edited by{' '}

--- a/frontend/features/contributions/components/AttributionLine.tsx
+++ b/frontend/features/contributions/components/AttributionLine.tsx
@@ -21,15 +21,23 @@ export function AttributionLine({ entityType, entityId }: AttributionLineProps) 
     return null
   }
 
+  // PSY-560: link to /users/:username only when the user has a username
+  // slug — falling back to the resolved display name (first/last,
+  // email-prefix, "Anonymous") as plain text otherwise. Mirrors the
+  // CommentCard byline pattern (PSY-552 / PSY-353).
   return (
     <p className="text-xs text-muted-foreground">
       Last edited by{' '}
-      <Link
-        href={`/users/${attribution.userName}`}
-        className="hover:underline"
-      >
-        {attribution.userName}
-      </Link>
+      {attribution.userUsername ? (
+        <Link
+          href={`/users/${attribution.userUsername}`}
+          className="hover:underline"
+        >
+          {attribution.userName}
+        </Link>
+      ) : (
+        <span>{attribution.userName}</span>
+      )}
       {' '}&middot;{' '}
       {formatRelativeTime(attribution.createdAt)}
     </p>

--- a/frontend/features/contributions/hooks/useEntityAttribution.ts
+++ b/frontend/features/contributions/hooks/useEntityAttribution.ts
@@ -6,6 +6,7 @@ interface RevisionItem {
   id: number
   user_id: number
   user_name?: string
+  user_username?: string | null
   created_at: string
 }
 
@@ -15,13 +16,23 @@ interface EntityHistoryResponse {
 }
 
 export interface EntityAttribution {
+  /**
+   * Resolved display name — never empty. Backend uses the resolveUserName
+   * chain (username → first/last → email-prefix → "Anonymous"). PSY-560.
+   */
   userName: string
+  /**
+   * Linkable username slug. Null when the user has no username set; the
+   * AttributionLine renders plain text in that case rather than a broken
+   * /users/:username link. Mirrors PSY-552 / PSY-353. PSY-560.
+   */
+  userUsername: string | null
   createdAt: string
 }
 
 /**
  * Fetches the most recent revision for an entity to show "Last edited by" attribution.
- * Returns the most recent editor's username and timestamp.
+ * Returns the most recent editor's display name and (when set) linkable username.
  * Returns null data if no revisions exist.
  */
 export function useEntityAttribution(
@@ -39,7 +50,11 @@ export function useEntityAttribution(
       }
       const revision = data.revisions[0]
       return {
-        userName: revision.user_name || `User #${revision.user_id}`,
+        // Backend already resolves through the full chain; "Anonymous" is
+        // the final fallback. The `|| 'Anonymous'` here is belt-and-braces
+        // for old payloads or a hypothetical empty string from the wire.
+        userName: revision.user_name || 'Anonymous',
+        userUsername: revision.user_username ?? null,
         createdAt: revision.created_at,
       }
     },

--- a/frontend/features/contributions/hooks/useEntityAttribution.ts
+++ b/frontend/features/contributions/hooks/useEntityAttribution.ts
@@ -16,16 +16,9 @@ interface EntityHistoryResponse {
 }
 
 export interface EntityAttribution {
-  /**
-   * Resolved display name — never empty. Backend uses the resolveUserName
-   * chain (username → first/last → email-prefix → "Anonymous"). PSY-560.
-   */
+  /** Resolved display name; never empty (backend resolveUserName chain). */
   userName: string
-  /**
-   * Linkable username slug. Null when the user has no username set; the
-   * AttributionLine renders plain text in that case rather than a broken
-   * /users/:username link. Mirrors PSY-552 / PSY-353. PSY-560.
-   */
+  /** URL-safe username slug; null when the user has no username set. */
   userUsername: string | null
   createdAt: string
 }
@@ -50,9 +43,7 @@ export function useEntityAttribution(
       }
       const revision = data.revisions[0]
       return {
-        // Backend already resolves through the full chain; "Anonymous" is
-        // the final fallback. The `|| 'Anonymous'` here is belt-and-braces
-        // for old payloads or a hypothetical empty string from the wire.
+        // 'Anonymous' fallback is defensive — backend should always populate.
         userName: revision.user_name || 'Anonymous',
         userUsername: revision.user_username ?? null,
         createdAt: revision.created_at,

--- a/frontend/lib/hooks/common/useRevisions.ts
+++ b/frontend/lib/hooks/common/useRevisions.ts
@@ -15,17 +15,9 @@ export interface RevisionItem {
   entity_type: string
   entity_id: number
   user_id: number
-  /**
-   * Resolved display name — never empty when the User row exists. Backend
-   * uses the resolveUserName chain (username → first/last → email-prefix →
-   * "Anonymous"). PSY-560.
-   */
+  /** Resolved display name; never empty (backend resolveUserName chain). */
   user_name?: string
-  /**
-   * Linkable username slug. Null when the user has no username set; in that
-   * case the frontend should render `user_name` as plain text rather than a
-   * /users/:username link. Mirrors comment author_username (PSY-552). PSY-560.
-   */
+  /** URL-safe username slug; null when the user has no username set. */
   user_username?: string | null
   changes: FieldChange[]
   summary?: string

--- a/frontend/lib/hooks/common/useRevisions.ts
+++ b/frontend/lib/hooks/common/useRevisions.ts
@@ -15,7 +15,18 @@ export interface RevisionItem {
   entity_type: string
   entity_id: number
   user_id: number
+  /**
+   * Resolved display name — never empty when the User row exists. Backend
+   * uses the resolveUserName chain (username → first/last → email-prefix →
+   * "Anonymous"). PSY-560.
+   */
   user_name?: string
+  /**
+   * Linkable username slug. Null when the user has no username set; in that
+   * case the frontend should render `user_name` as plain text rather than a
+   * /users/:username link. Mirrors comment author_username (PSY-552). PSY-560.
+   */
+  user_username?: string | null
   changes: FieldChange[]
   summary?: string
   created_at: string


### PR DESCRIPTION
## Summary
- Routes "Last edited by …" + History accordion through resolveUserName / resolveUserUsername (the same chain the comment surface uses).
- Linkable to /users/{username} when set; plain text fallback.
- Applied across all 5 entity-detail pages with attribution (artists, venues, releases, labels, festivals — shows intentionally omit per PSY-461/489).
- History endpoint now returns `user_username` (`*string`, nil when no username) alongside `user_name` (display, never empty) so the frontend can decide between link vs plain text without extra round-trips. OpenAPI is additive only.

## Test plan
- [ ] Edit artist as admin (asdf@admin.com): "Last edited by asdf" appears on detail page.
- [ ] Expand History accordion: rows render `asdf` (or username link if set), not `User #5`.
- [ ] Edit a venue/release/label/festival: same fix applies.
- [ ] User without username: plain text rendering, no broken link.

Closes PSY-560

🤖 Generated with [Claude Code](https://claude.com/claude-code)