### PR TITLE
PSY-558: persist country field on artists end-to-end

### DIFF
--- a/backend/internal/api/handlers/catalog/artist.go
+++ b/backend/internal/api/handlers/catalog/artist.go
@@ -909,6 +909,9 @@ func computeArtistChanges(old, new *contracts.ArtistDetailResponse) []adminm.Fie
 	if ptrToStr(old.State) != ptrToStr(new.State) {
 		changes = append(changes, adminm.FieldChange{Field: "state", OldValue: ptrToStr(old.State), NewValue: ptrToStr(new.State)})
 	}
+	if ptrToStr(old.Country) != ptrToStr(new.Country) {
+		changes = append(changes, adminm.FieldChange{Field: "country", OldValue: ptrToStr(old.Country), NewValue: ptrToStr(new.Country)})
+	}
 	if ptrToStr(old.Social.Instagram) != ptrToStr(new.Social.Instagram) {
 		changes = append(changes, adminm.FieldChange{Field: "instagram", OldValue: ptrToStr(old.Social.Instagram), NewValue: ptrToStr(new.Social.Instagram)})
 	}

--- a/backend/internal/services/catalog/artist.go
+++ b/backend/internal/services/catalog/artist.go
@@ -58,6 +58,7 @@ func (s *ArtistService) CreateArtist(req *contracts.CreateArtistRequest) (*contr
 		Slug:        &slug,
 		State:       req.State,
 		City:        req.City,
+		Country:     req.Country,
 		Description: req.Description,
 		Social: catalogm.Social{
 			Instagram:  req.Instagram,
@@ -487,6 +488,7 @@ func (s *ArtistService) buildArtistResponse(artist *catalogm.Artist) *contracts.
 		Name:             artist.Name,
 		State:            artist.State,
 		City:             artist.City,
+		Country:          artist.Country,
 		BandcampEmbedURL: artist.BandcampEmbedURL,
 		Description:      artist.Description,
 		ImageURL:         artist.ImageURL,

--- a/backend/internal/services/contracts/catalog.go
+++ b/backend/internal/services/contracts/catalog.go
@@ -423,6 +423,7 @@ type ArtistDetailResponse struct {
 	Name             string         `json:"name"`
 	State            *string        `json:"state"`
 	City             *string        `json:"city"`
+	Country          *string        `json:"country,omitempty"` // PSY-558: optional country (Australia, UK, etc.)
 	BandcampEmbedURL *string        `json:"bandcamp_embed_url"`
 	Description      *string        `json:"description,omitempty"`
 	ImageURL         *string        `json:"image_url"` // Optional artist photo (PSY-521)

--- a/frontend/features/artists/components/ArtistDetail.tsx
+++ b/frontend/features/artists/components/ArtistDetail.tsx
@@ -19,7 +19,6 @@ import {
 import { useQueryClient } from '@tanstack/react-query'
 import { useArtist } from '../hooks/useArtists'
 import { getArtistLocation } from '../types'
-import type { Artist } from '../types'
 import { useArtistReleases } from '@/features/releases/hooks/useReleases'
 import { useArtistAliases } from '@/lib/hooks/admin/useAdminArtists'
 import { useArtistLabels, useLabelRoster } from '@/features/labels/hooks/useLabels'
@@ -339,7 +338,7 @@ function ArtistSidebar({
           </h3>
           <div className="flex items-center gap-1.5 text-sm">
             <MapPin className="h-4 w-4 text-muted-foreground" />
-            <span>{getArtistLocation(artist as Artist)}</span>
+            <span>{getArtistLocation(artist)}</span>
           </div>
         </div>
       )}

--- a/frontend/features/artists/components/ArtistDetail.tsx
+++ b/frontend/features/artists/components/ArtistDetail.tsx
@@ -18,6 +18,8 @@ import {
 } from 'lucide-react'
 import { useQueryClient } from '@tanstack/react-query'
 import { useArtist } from '../hooks/useArtists'
+import { getArtistLocation } from '../types'
+import type { Artist } from '../types'
 import { useArtistReleases } from '@/features/releases/hooks/useReleases'
 import { useArtistAliases } from '@/lib/hooks/admin/useAdminArtists'
 import { useArtistLabels, useLabelRoster } from '@/features/labels/hooks/useLabels'
@@ -307,6 +309,7 @@ function ArtistSidebar({
     slug: string
     city: string | null
     state: string | null
+    country?: string | null
     bandcamp_embed_url: string | null
     social: {
       instagram: string | null
@@ -322,7 +325,7 @@ function ArtistSidebar({
   labels: ArtistLabel[]
   labelsLoading: boolean
 }) {
-  const hasLocation = artist.city || artist.state
+  const hasLocation = artist.city || artist.state || artist.country
   const { data: aliasesData } = useArtistAliases(artist.id)
   const aliases = aliasesData?.aliases ?? []
 
@@ -336,7 +339,7 @@ function ArtistSidebar({
           </h3>
           <div className="flex items-center gap-1.5 text-sm">
             <MapPin className="h-4 w-4 text-muted-foreground" />
-            <span>{[artist.city, artist.state].filter(Boolean).join(', ')}</span>
+            <span>{getArtistLocation(artist as Artist)}</span>
           </div>
         </div>
       )}
@@ -919,10 +922,10 @@ export function ArtistDetail({ artistId }: ArtistDetailProps) {
     { value: 'labels', label: 'Labels' },
   ]
 
-  const headerSubtitle = (artist.city || artist.state) ? (
+  const headerSubtitle = (artist.city || artist.state || artist.country) ? (
     <>
       <MapPin className="h-4 w-4" />
-      <span>{[artist.city, artist.state].filter(Boolean).join(', ')}</span>
+      <span>{getArtistLocation(artist)}</span>
     </>
   ) : undefined
 

--- a/frontend/features/artists/types.ts
+++ b/frontend/features/artists/types.ts
@@ -22,6 +22,11 @@ export interface Artist {
   name: string
   state: string | null
   city: string | null
+  /**
+   * Optional country (PSY-558). Surfaced in the location pill conditionally —
+   * see `getArtistLocation` for the display rule (US + state set hides "USA").
+   */
+  country?: string | null
   bandcamp_embed_url: string | null
   description?: string | null
   /** Optional artist photo URL (PSY-521). */
@@ -83,10 +88,26 @@ export interface ArtistSearchResponse {
 }
 
 /**
- * Get a formatted location string for an artist
+ * Get a formatted location string for an artist (PSY-558 display rule).
+ *
+ * Country is included unless state is set AND country is "USA"/"US" — local
+ * audiences read "Phoenix, AZ" as US-implicit, so adding "USA" is noise.
+ * International artists ("Melbourne, Australia", "London, England, UK",
+ * "Tokyo, Japan") always render the country since the state cue alone is
+ * not enough to locate them.
+ *
+ * Comparison is case-insensitive and trimmed; either spelling ("USA"/"US")
+ * triggers the suppression.
  */
 export const getArtistLocation = (artist: Artist): string => {
-  const parts = [artist.city, artist.state].filter(Boolean)
+  const parts = [artist.city, artist.state].filter(Boolean) as string[]
+  const country = artist.country?.trim() ?? ''
+  const stateSet = !!artist.state
+  const countryIsUS =
+    country.toUpperCase() === 'USA' || country.toUpperCase() === 'US'
+  if (country && !(stateSet && countryIsUS)) {
+    parts.push(country)
+  }
   return parts.length > 0 ? parts.join(', ') : 'Location Unknown'
 }
 

--- a/frontend/features/artists/types.ts
+++ b/frontend/features/artists/types.ts
@@ -97,9 +97,13 @@ export interface ArtistSearchResponse {
  * not enough to locate them.
  *
  * Comparison is case-insensitive and trimmed; either spelling ("USA"/"US")
- * triggers the suppression.
+ * triggers the suppression. Parameter is structurally typed (city/state/country
+ * only) so callers with a narrower row shape — e.g. the ArtistSidebar prop —
+ * can pass directly without a cast.
  */
-export const getArtistLocation = (artist: Artist): string => {
+export const getArtistLocation = (
+  artist: { city?: string | null; state?: string | null; country?: string | null },
+): string => {
   const parts = [artist.city, artist.state].filter(Boolean) as string[]
   const country = artist.country?.trim() ?? ''
   const stateSet = !!artist.state

--- a/frontend/lib/types/typeHelpers.test.ts
+++ b/frontend/lib/types/typeHelpers.test.ts
@@ -131,6 +131,77 @@ describe('Type Helper Functions', () => {
       // Empty string is falsy, so it gets filtered out
       expect(getArtistLocation(artist)).toBe('AZ')
     })
+
+    // PSY-558: country display rule. State + US-coded country suppresses the
+    // country segment because "Phoenix, AZ" is US-implicit to local readers.
+    // Everything else includes the country.
+    const baseArtist = (
+      overrides: Partial<Artist>,
+    ): Artist => ({
+      id: 100,
+      slug: 's',
+      name: 'n',
+      city: null,
+      state: null,
+      country: null,
+      bandcamp_embed_url: null,
+      social: {
+        instagram: null,
+        facebook: null,
+        twitter: null,
+        youtube: null,
+        spotify: null,
+        soundcloud: null,
+        bandcamp: null,
+        website: null,
+      },
+      created_at: '2025-01-01T00:00:00Z',
+      updated_at: '2025-01-01T00:00:00Z',
+      ...overrides,
+    })
+
+    it('suppresses country when state is set and country is "USA"', () => {
+      expect(
+        getArtistLocation(baseArtist({ city: 'Phoenix', state: 'AZ', country: 'USA' })),
+      ).toBe('Phoenix, AZ')
+    })
+
+    it('suppresses country when state is set and country is "US"', () => {
+      expect(
+        getArtistLocation(baseArtist({ city: 'Phoenix', state: 'AZ', country: 'US' })),
+      ).toBe('Phoenix, AZ')
+    })
+
+    it('treats US suppression as case-insensitive', () => {
+      expect(
+        getArtistLocation(baseArtist({ city: 'Phoenix', state: 'AZ', country: 'usa' })),
+      ).toBe('Phoenix, AZ')
+    })
+
+    it('includes non-US country with city only', () => {
+      expect(
+        getArtistLocation(baseArtist({ city: 'Melbourne', country: 'Australia' })),
+      ).toBe('Melbourne, Australia')
+    })
+
+    it('includes non-US country with city + state', () => {
+      expect(
+        getArtistLocation(baseArtist({ city: 'London', state: 'England', country: 'UK' })),
+      ).toBe('London, England, UK')
+    })
+
+    it('includes country when state is null even if country is US', () => {
+      // No state => "USA" carries the locator load and should render.
+      expect(
+        getArtistLocation(baseArtist({ city: 'Phoenix', country: 'USA' })),
+      ).toBe('Phoenix, USA')
+    })
+
+    it('handles Tokyo, Japan (no state, non-US country)', () => {
+      expect(
+        getArtistLocation(baseArtist({ city: 'Tokyo', country: 'Japan' })),
+      ).toBe('Tokyo, Japan')
+    })
   })
 
   describe('getVenueLocation', () => {


### PR DESCRIPTION
## Summary
- Adds optional `country` to `ArtistDetailResponse` and threads it through CreateArtist + buildArtistResponse so GET endpoints surface the value the column has been storing since migration 000059.
- Adds `country` to `computeArtistChanges` so admin updates record the diff in revisions; pending-edit flow needed no changes (the JSONB-driven `allowedEditFields["artist"]` already lists `country`).
- Frontend `getArtistLocation` now applies the conditional display rule: hide country when state is set AND country is "USA"/"US"; otherwise include. Sidebar location card and header subtitle in `ArtistDetail` call the helper instead of joining `[city, state]` inline.
- Memory note added documenting the display rule + canonical helper.

## Test plan
- [ ] Edit artist as admin: set Country=Australia, save, verify pill renders "Melbourne, Australia" and curl response includes country.
- [ ] Edit artist as non-admin: submit for review, verify pending_edit captures country in field_changes.
- [ ] Edit US artist: state=AZ, country=USA — pill renders "Phoenix, AZ" without country.
- [ ] Re-open drawer after save: Country field is pre-populated.

Closes PSY-558