### PR TITLE
PSY-559: dedup show records by artist+venue+date+time

### DIFF
--- a/backend/cmd/dedup-shows/main.go
+++ b/backend/cmd/dedup-shows/main.go
@@ -1,0 +1,211 @@
+// Command dedup-shows merges show records that share
+// (artist_id, venue_id, event_date+time) and re-points all FKs to a
+// single canonical row. Time-of-day is part of the dedup key so
+// matinee+evening sets at the same venue on the same day are NOT
+// collapsed (PSY-559).
+//
+// Usage:
+//
+//	go run ./cmd/dedup-shows                # dry-run (default)
+//	go run ./cmd/dedup-shows --confirm      # apply changes
+//	go run ./cmd/dedup-shows --verbose      # per-cluster output
+//	go run ./cmd/dedup-shows --no-slug-fix  # skip slug recanonicalisation
+//
+// The dry-run path prints a per-cluster plan plus an aggregate count.
+// The confirm path runs the same plan inside a single transaction
+// per cluster (each cluster is independent — a partial run leaves
+// partial progress, never half-merged shows).
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/joho/godotenv"
+	"gorm.io/gorm"
+
+	"psychic-homily-backend/db"
+	"psychic-homily-backend/internal/config"
+	catalogm "psychic-homily-backend/internal/models/catalog"
+	"psychic-homily-backend/internal/services/catalog"
+)
+
+var (
+	confirm   bool
+	verbose   bool
+	noSlugFix bool
+	envFile   string
+)
+
+func main() {
+	flag.BoolVar(&confirm, "confirm", false, "Apply changes (default: dry-run only)")
+	flag.BoolVar(&verbose, "verbose", false, "Print per-cluster details")
+	flag.BoolVar(&noSlugFix, "no-slug-fix", false, "Skip slug recanonicalisation pass on winners")
+	flag.StringVar(&envFile, "env", "", "Path to .env file (defaults to .env.development / .env)")
+	flag.Parse()
+
+	loadEnv()
+
+	cfg, err := config.Load()
+	if err != nil {
+		log.Fatalf("load config: %v", err)
+	}
+	if err := db.Connect(cfg); err != nil {
+		log.Fatalf("connect db: %v", err)
+	}
+	database := db.GetDB()
+
+	mode := "DRY RUN"
+	if confirm {
+		mode = "LIVE"
+	}
+	fmt.Printf("=== Show Dedup (%s) — PSY-559 ===\n\n", mode)
+
+	clusters, err := catalog.FindShowDedupClusters(database)
+	if err != nil {
+		log.Fatalf("find clusters: %v", err)
+	}
+
+	fmt.Printf("Found %d duplicate cluster(s).\n\n", len(clusters))
+	if len(clusters) == 0 {
+		fmt.Println("No duplicates to merge. Done.")
+		return
+	}
+
+	summary := &catalog.ShowDedupSummary{ClustersFound: len(clusters)}
+
+	for _, cluster := range clusters {
+		printCluster(database, cluster)
+
+		if !confirm {
+			continue
+		}
+
+		// Each cluster runs in its own transaction. A failed merge on
+		// one cluster doesn't roll back the others — keeps the cmd
+		// safe to re-run on partially-completed state.
+		err := database.Transaction(func(tx *gorm.DB) error {
+			for _, loserID := range cluster.LoserIDs {
+				if err := catalog.MergeDuplicateShow(tx, cluster.WinnerID, loserID, summary); err != nil {
+					return fmt.Errorf("merge loser %d into winner %d: %w", loserID, cluster.WinnerID, err)
+				}
+			}
+			if !noSlugFix {
+				rewritten, err := catalog.RecanonicaliseShowSlug(tx, cluster.WinnerID)
+				if err != nil {
+					return fmt.Errorf("slug recanonicalise winner %d: %w", cluster.WinnerID, err)
+				}
+				if rewritten {
+					summary.SlugsRewritten++
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			fmt.Printf("  [ERROR] %v\n", err)
+			continue
+		}
+		fmt.Printf("  [MERGED] winner=%d, losers=%v\n", cluster.WinnerID, cluster.LoserIDs)
+	}
+
+	// Slug recanonicalise on shows that were already in canonical
+	// form is a separate pass for non-cluster shows? Out of scope —
+	// the work plan only requires winners be backfilled to canonical
+	// form, and the cluster loop handles that above.
+
+	printSummary(summary)
+}
+
+func loadEnv() {
+	if envFile != "" {
+		if err := godotenv.Load(envFile); err != nil {
+			log.Fatalf("load env file %s: %v", envFile, err)
+		}
+		log.Printf("loaded env from %s", envFile)
+		return
+	}
+	for _, ef := range []string{".env.development", ".env"} {
+		if err := godotenv.Load(ef); err == nil {
+			log.Printf("loaded env from %s", ef)
+			return
+		}
+	}
+	log.Println("no .env loaded; using process environment")
+}
+
+func printCluster(database *gorm.DB, cluster catalog.ShowDedupCluster) {
+	fmt.Printf("Cluster: artist=%d, venue=%d, event_date=%s\n",
+		cluster.Key.ArtistID, cluster.Key.VenueID, cluster.Key.EventDate.UTC().Format("2006-01-02T15:04:05Z"))
+	fmt.Printf("  Winner: show %d (created %s)\n", cluster.WinnerID, cluster.CreatedAt[0].UTC().Format("2006-01-02"))
+	for i, loserID := range cluster.LoserIDs {
+		// CreatedAt index for loser i is i+1 (winner is index 0).
+		fmt.Printf("  Loser:  show %d (created %s)\n", loserID, cluster.CreatedAt[i+1].UTC().Format("2006-01-02"))
+	}
+
+	if !verbose {
+		return
+	}
+
+	// Pull a one-line description of each show for reviewer context.
+	for _, id := range cluster.ShowIDs {
+		var s catalogm.Show
+		if err := database.First(&s, id).Error; err != nil {
+			fmt.Printf("    show %d: <load failed: %v>\n", id, err)
+			continue
+		}
+		slug := "<no slug>"
+		if s.Slug != nil {
+			slug = *s.Slug
+		}
+		fmt.Printf("    show %d: title=%q slug=%s status=%s event_date=%s\n",
+			s.ID, s.Title, slug, s.Status, s.EventDate.UTC().Format("2006-01-02T15:04:05Z"))
+	}
+}
+
+func printSummary(s *catalog.ShowDedupSummary) {
+	fmt.Println()
+	fmt.Println("=== Summary ===")
+	fmt.Printf("Clusters found:           %d\n", s.ClustersFound)
+	fmt.Printf("Losers merged:            %d\n", s.LosersMerged)
+	fmt.Println()
+	fmt.Println("FK repointing:")
+	fmt.Printf("  show_venues:            moved=%d skipped=%d\n", s.ShowVenuesMoved, s.ShowVenuesSkipped)
+	fmt.Printf("  show_artists:           moved=%d skipped=%d\n", s.ShowArtistsMoved, s.ShowArtistsSkipped)
+	fmt.Printf("  show_reports:           moved=%d\n", s.ShowReportsMoved)
+	fmt.Printf("  enrichment_queue:       moved=%d\n", s.EnrichmentMoved)
+	fmt.Printf("  duplicate_of_show_id:   repointed=%d\n", s.DuplicateOfRepoint)
+	fmt.Println("Polymorphic refs:")
+	fmt.Printf("  comments:               moved=%d\n", s.CommentsRepointed)
+	fmt.Printf("  comment_subscriptions:  moved=%d skipped=%d\n", s.SubsRepointed, s.SubsSkipped)
+	fmt.Printf("  entity_tags:            moved=%d skipped=%d\n", s.EntityTagsMoved, s.EntityTagsSkipped)
+	fmt.Printf("  entity_reports:         moved=%d\n", s.EntityReportsMoved)
+	fmt.Printf("  pending_entity_edits:   moved=%d\n", s.PendingEditsMoved)
+	fmt.Printf("  revisions:              moved=%d\n", s.RevisionsMoved)
+	fmt.Printf("  requests:               moved=%d\n", s.RequestsMoved)
+	fmt.Printf("  audit_logs:             moved=%d\n", s.AuditLogsMoved)
+	fmt.Printf("  collection_items:       moved=%d skipped=%d\n", s.CollectionsMoved, s.CollectionsSkipped)
+	fmt.Printf("  user_bookmarks:         moved=%d skipped=%d\n", s.BookmarksMoved, s.BookmarksSkipped)
+	fmt.Println()
+	fmt.Printf("Slugs recanonicalised:    %d\n", s.SlugsRewritten)
+	fmt.Println()
+	if !confirm {
+		fmt.Println("DRY RUN — no DB writes. Re-run with --confirm to apply.")
+	} else {
+		fmt.Println("LIVE — changes committed.")
+	}
+
+	if s.ClustersFound > 0 && !confirm {
+		fmt.Println()
+		fmt.Println("NOTE: dry-run prints the cluster plan, NOT per-FK movement counts;")
+		fmt.Println("those numbers are populated only on --confirm because conflict-aware")
+		fmt.Println("counts depend on actual UPDATE/DELETE row counts in a transaction.")
+	}
+
+	// Exit non-zero if we found duplicates and didn't confirm — useful
+	// for CI/cron wrappers that want to alert on regression.
+	if s.ClustersFound > 0 && !confirm {
+		os.Exit(2)
+	}
+}

--- a/backend/cmd/dedup-shows/main.go
+++ b/backend/cmd/dedup-shows/main.go
@@ -110,11 +110,6 @@ func main() {
 		fmt.Printf("  [MERGED] winner=%d, losers=%v\n", cluster.WinnerID, cluster.LoserIDs)
 	}
 
-	// Slug recanonicalise on shows that were already in canonical
-	// form is a separate pass for non-cluster shows? Out of scope —
-	// the work plan only requires winners be backfilled to canonical
-	// form, and the cluster loop handles that above.
-
 	printSummary(summary)
 }
 

--- a/backend/internal/services/catalog/show_dedup.go
+++ b/backend/internal/services/catalog/show_dedup.go
@@ -1,0 +1,579 @@
+package catalog
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"gorm.io/gorm"
+
+	catalogm "psychic-homily-backend/internal/models/catalog"
+	"psychic-homily-backend/internal/utils"
+)
+
+// ShowDedupKey identifies a cluster of duplicate shows by the
+// (artist, venue, event_date) tuple. Time-of-day is part of the key so
+// matinee + evening sets at the same venue on the same day are NOT
+// collapsed (PSY-559).
+type ShowDedupKey struct {
+	ArtistID  uint
+	VenueID   uint
+	EventDate time.Time
+}
+
+// ShowDedupCluster represents a group of shows that share the same
+// (artist, venue, event_date). The first ID is the winner (earliest
+// created_at). Remaining IDs will be merged into it.
+type ShowDedupCluster struct {
+	Key       ShowDedupKey
+	WinnerID  uint
+	LoserIDs  []uint
+	ShowIDs   []uint // all IDs in cluster, sorted by created_at ASC
+	CreatedAt []time.Time
+}
+
+// ShowDedupSummary summarises the work performed (or planned) by a
+// dedup pass. Used by both --dry-run and --confirm flows so reviewers
+// can audit the merge before live writes.
+type ShowDedupSummary struct {
+	ClustersFound      int
+	LosersMerged       int
+	ShowVenuesMoved    int64
+	ShowVenuesSkipped  int64
+	ShowArtistsMoved   int64
+	ShowArtistsSkipped int64
+	ShowReportsMoved   int64
+	EnrichmentMoved    int64
+	BookmarksMoved     int64
+	BookmarksSkipped   int64
+	CommentsRepointed  int64
+	SubsRepointed      int64
+	SubsSkipped        int64
+	EntityTagsMoved    int64
+	EntityTagsSkipped  int64
+	EntityReportsMoved int64
+	PendingEditsMoved  int64
+	RevisionsMoved     int64
+	RequestsMoved      int64
+	AuditLogsMoved     int64
+	CollectionsMoved   int64
+	CollectionsSkipped int64
+	DuplicateOfRepoint int64
+	SlugsRewritten     int
+}
+
+// FindShowDedupClusters finds groups of shows that share the same
+// (artist_id, venue_id, event_date). Returns one cluster per group of
+// 2+ shows. The dedup key includes the FULL event_date timestamp so
+// matinee/evening shows at the same venue on the same day are
+// preserved.
+//
+// Implementation note: we join shows with show_artists and show_venues
+// and group by (artist_id, venue_id, event_date). A show with multiple
+// headliners or multiple venues will appear in multiple clusters, but
+// each cluster is processed independently and idempotently.
+func FindShowDedupClusters(db *gorm.DB) ([]ShowDedupCluster, error) {
+	type row struct {
+		ArtistID  uint      `gorm:"column:artist_id"`
+		VenueID   uint      `gorm:"column:venue_id"`
+		EventDate time.Time `gorm:"column:event_date"`
+		ShowID    uint      `gorm:"column:show_id"`
+		CreatedAt time.Time `gorm:"column:created_at"`
+	}
+
+	// Pull all (artist, venue, event_date) tuples that have 2+ shows.
+	// Filter approved+private only — pending/rejected duplicates are
+	// admin-review concerns, not user-facing duplication.
+	var rows []row
+	err := db.Raw(`
+		SELECT
+			sa.artist_id  AS artist_id,
+			sv.venue_id   AS venue_id,
+			s.event_date  AS event_date,
+			s.id          AS show_id,
+			s.created_at  AS created_at
+		FROM shows s
+		JOIN show_artists sa ON sa.show_id = s.id
+		JOIN show_venues  sv ON sv.show_id = s.id
+		WHERE s.status IN ('approved','private')
+		ORDER BY sa.artist_id, sv.venue_id, s.event_date, s.created_at ASC, s.id ASC
+	`).Scan(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan show clusters: %w", err)
+	}
+
+	// Group rows by (artist_id, venue_id, event_date). Use a stable
+	// string key so map iteration order doesn't leak into output —
+	// we sort the final slice deterministically below.
+	type groupKey struct {
+		ArtistID  uint
+		VenueID   uint
+		EventDate string
+	}
+	groups := map[groupKey][]row{}
+	for _, r := range rows {
+		k := groupKey{r.ArtistID, r.VenueID, r.EventDate.UTC().Format(time.RFC3339Nano)}
+		groups[k] = append(groups[k], r)
+	}
+
+	clusters := make([]ShowDedupCluster, 0)
+	for _, members := range groups {
+		// Deduplicate within group by show_id — a single show can
+		// appear multiple times if it has multiple artists or venues
+		// matching the same key. Take the first (earliest created_at).
+		seen := map[uint]bool{}
+		uniq := make([]row, 0, len(members))
+		for _, m := range members {
+			if seen[m.ShowID] {
+				continue
+			}
+			seen[m.ShowID] = true
+			uniq = append(uniq, m)
+		}
+		if len(uniq) < 2 {
+			continue
+		}
+
+		// Sort by created_at ASC, then ID ASC as a tiebreaker.
+		sort.Slice(uniq, func(i, j int) bool {
+			if !uniq[i].CreatedAt.Equal(uniq[j].CreatedAt) {
+				return uniq[i].CreatedAt.Before(uniq[j].CreatedAt)
+			}
+			return uniq[i].ShowID < uniq[j].ShowID
+		})
+
+		ids := make([]uint, len(uniq))
+		createds := make([]time.Time, len(uniq))
+		for i, m := range uniq {
+			ids[i] = m.ShowID
+			createds[i] = m.CreatedAt
+		}
+
+		clusters = append(clusters, ShowDedupCluster{
+			Key: ShowDedupKey{
+				ArtistID:  uniq[0].ArtistID,
+				VenueID:   uniq[0].VenueID,
+				EventDate: uniq[0].EventDate,
+			},
+			WinnerID:  ids[0],
+			LoserIDs:  ids[1:],
+			ShowIDs:   ids,
+			CreatedAt: createds,
+		})
+	}
+
+	// Stable order across runs: sort clusters by (artist_id, venue_id, event_date).
+	sort.Slice(clusters, func(i, j int) bool {
+		a, b := clusters[i].Key, clusters[j].Key
+		if a.ArtistID != b.ArtistID {
+			return a.ArtistID < b.ArtistID
+		}
+		if a.VenueID != b.VenueID {
+			return a.VenueID < b.VenueID
+		}
+		return a.EventDate.Before(b.EventDate)
+	})
+
+	return clusters, nil
+}
+
+// MergeDuplicateShow merges loser into winner inside an existing
+// transaction. All FKs (direct + polymorphic) are repointed with
+// conflict-aware semantics. The loser is then deleted, which cascades
+// to show_venues / show_artists / show_reports / enrichment_queue
+// rows that still belong to it.
+//
+// Conflict policy: when a UNIQUE / PK conflict would occur on the
+// winner, the loser's row is dropped (the winner's pre-existing row
+// wins). This matches the tag_merge.go pattern.
+func MergeDuplicateShow(tx *gorm.DB, winnerID, loserID uint, summary *ShowDedupSummary) error {
+	if winnerID == 0 || loserID == 0 {
+		return fmt.Errorf("winnerID and loserID must be non-zero")
+	}
+	if winnerID == loserID {
+		return fmt.Errorf("winnerID == loserID")
+	}
+
+	// 1. show_venues — copy missing rows from loser to winner, drop conflicts.
+	moved, skipped, err := movePolymorphicJunction(tx, "show_venues", "show_id", "venue_id", winnerID, loserID)
+	if err != nil {
+		return fmt.Errorf("show_venues: %w", err)
+	}
+	summary.ShowVenuesMoved += moved
+	summary.ShowVenuesSkipped += skipped
+
+	// 2. show_artists — same pattern. Preserve position/set_type from
+	// loser only when winner doesn't already have the artist (handled
+	// by the conflict-skip below).
+	moved, skipped, err = movePolymorphicJunction(tx, "show_artists", "show_id", "artist_id", winnerID, loserID)
+	if err != nil {
+		return fmt.Errorf("show_artists: %w", err)
+	}
+	summary.ShowArtistsMoved += moved
+	summary.ShowArtistsSkipped += skipped
+
+	// 3. show_reports — repoint to winner (no unique constraint).
+	res := tx.Exec(`UPDATE show_reports SET show_id = ? WHERE show_id = ?`, winnerID, loserID)
+	if res.Error != nil {
+		return fmt.Errorf("show_reports: %w", res.Error)
+	}
+	summary.ShowReportsMoved += res.RowsAffected
+
+	// 4. enrichment_queue — repoint to winner.
+	res = tx.Exec(`UPDATE enrichment_queue SET show_id = ? WHERE show_id = ?`, winnerID, loserID)
+	if res.Error != nil {
+		return fmt.Errorf("enrichment_queue: %w", res.Error)
+	}
+	summary.EnrichmentMoved += res.RowsAffected
+
+	// 5. shows.duplicate_of_show_id — repoint loser→winner so any
+	// existing duplicate-of pointer survives the merge.
+	res = tx.Exec(`UPDATE shows SET duplicate_of_show_id = ? WHERE duplicate_of_show_id = ?`, winnerID, loserID)
+	if res.Error != nil {
+		return fmt.Errorf("duplicate_of_show_id: %w", res.Error)
+	}
+	summary.DuplicateOfRepoint += res.RowsAffected
+
+	// 6. comments — repoint entity_id (no unique constraint on
+	// (entity_type, entity_id) for comments — same comment thread
+	// just gets renamed under the winner).
+	res = tx.Exec(`
+		UPDATE comments
+		SET entity_id = ?
+		WHERE entity_type = 'show' AND entity_id = ?
+	`, winnerID, loserID)
+	if res.Error != nil {
+		return fmt.Errorf("comments: %w", res.Error)
+	}
+	summary.CommentsRepointed += res.RowsAffected
+
+	// 7. comment_subscriptions — PK is (user_id, entity_type,
+	// entity_id). Drop conflicts then repoint.
+	moved, skipped, err = movePolymorphicEntity(tx, "comment_subscriptions",
+		`(SELECT 1 FROM comment_subscriptions cs2
+		   WHERE cs2.user_id = comment_subscriptions.user_id
+			 AND cs2.entity_type = 'show'
+			 AND cs2.entity_id = ?)`, winnerID, loserID)
+	if err != nil {
+		return fmt.Errorf("comment_subscriptions: %w", err)
+	}
+	summary.SubsRepointed += moved
+	summary.SubsSkipped += skipped
+
+	// 8. entity_tags — UNIQUE (tag_id, entity_type, entity_id) per
+	// migration 000051. Drop conflicts, then move.
+	moved, skipped, err = movePolymorphicEntityWithTagConflict(tx, "entity_tags", winnerID, loserID)
+	if err != nil {
+		return fmt.Errorf("entity_tags: %w", err)
+	}
+	summary.EntityTagsMoved += moved
+	summary.EntityTagsSkipped += skipped
+
+	// 9. entity_reports — repoint (no relevant unique).
+	res = tx.Exec(`
+		UPDATE entity_reports
+		SET entity_id = ?
+		WHERE entity_type = 'show' AND entity_id = ?
+	`, winnerID, loserID)
+	if res.Error != nil {
+		return fmt.Errorf("entity_reports: %w", res.Error)
+	}
+	summary.EntityReportsMoved += res.RowsAffected
+
+	// 10. pending_entity_edits — repoint.
+	res = tx.Exec(`
+		UPDATE pending_entity_edits
+		SET entity_id = ?
+		WHERE entity_type = 'show' AND entity_id = ?
+	`, winnerID, loserID)
+	if res.Error != nil {
+		return fmt.Errorf("pending_entity_edits: %w", res.Error)
+	}
+	summary.PendingEditsMoved += res.RowsAffected
+
+	// 11. revisions — repoint.
+	res = tx.Exec(`
+		UPDATE revisions
+		SET entity_id = ?
+		WHERE entity_type = 'show' AND entity_id = ?
+	`, winnerID, loserID)
+	if res.Error != nil {
+		return fmt.Errorf("revisions: %w", res.Error)
+	}
+	summary.RevisionsMoved += res.RowsAffected
+
+	// 12. requests — points via requested_entity_id, not entity_id.
+	res = tx.Exec(`
+		UPDATE requests
+		SET requested_entity_id = ?
+		WHERE entity_type = 'show' AND requested_entity_id = ?
+	`, winnerID, loserID)
+	if res.Error != nil {
+		return fmt.Errorf("requests: %w", res.Error)
+	}
+	summary.RequestsMoved += res.RowsAffected
+
+	// 13. audit_logs — repoint.
+	res = tx.Exec(`
+		UPDATE audit_logs
+		SET entity_id = ?
+		WHERE entity_type = 'show' AND entity_id = ?
+	`, winnerID, loserID)
+	if res.Error != nil {
+		return fmt.Errorf("audit_logs: %w", res.Error)
+	}
+	summary.AuditLogsMoved += res.RowsAffected
+
+	// 14. collection_items — UNIQUE (collection_id, entity_type,
+	// entity_id) handled inline; conflicts dropped.
+	moved, skipped, err = moveCollectionItems(tx, winnerID, loserID)
+	if err != nil {
+		return fmt.Errorf("collection_items: %w", err)
+	}
+	summary.CollectionsMoved += moved
+	summary.CollectionsSkipped += skipped
+
+	// 15. user_bookmarks — UNIQUE (user_id, entity_type, entity_id, action).
+	moved, skipped, err = moveBookmarks(tx, winnerID, loserID)
+	if err != nil {
+		return fmt.Errorf("user_bookmarks: %w", err)
+	}
+	summary.BookmarksMoved += moved
+	summary.BookmarksSkipped += skipped
+
+	// 16. Delete the loser show. CASCADE handles anything left in
+	// show_venues / show_artists / show_reports / enrichment_queue
+	// (i.e. nothing — all repointed above).
+	if err := tx.Delete(&catalogm.Show{}, loserID).Error; err != nil {
+		return fmt.Errorf("delete loser show %d: %w", loserID, err)
+	}
+
+	summary.LosersMerged++
+	return nil
+}
+
+// movePolymorphicJunction drops conflicting rows on (show_id, otherCol)
+// where the winner already has an entry, then re-points the rest to
+// the winner. Used for show_venues and show_artists.
+func movePolymorphicJunction(tx *gorm.DB, table, primaryCol, otherCol string, winnerID, loserID uint) (moved, skipped int64, err error) {
+	// Drop loser rows whose otherCol value already exists on the winner.
+	delSQL := fmt.Sprintf(`
+		DELETE FROM %s
+		WHERE %s = ?
+		  AND EXISTS (
+			SELECT 1 FROM %s w
+			WHERE w.%s = ?
+			  AND w.%s = %s.%s
+		  )
+	`, table, primaryCol, table, primaryCol, otherCol, table, otherCol)
+	del := tx.Exec(delSQL, loserID, winnerID)
+	if del.Error != nil {
+		return 0, 0, del.Error
+	}
+	skipped = del.RowsAffected
+
+	updSQL := fmt.Sprintf(`UPDATE %s SET %s = ? WHERE %s = ?`, table, primaryCol, primaryCol)
+	upd := tx.Exec(updSQL, winnerID, loserID)
+	if upd.Error != nil {
+		return 0, 0, upd.Error
+	}
+	moved = upd.RowsAffected
+	return moved, skipped, nil
+}
+
+// movePolymorphicEntity is a generic conflict-aware move for tables
+// keyed on (some_user_or_other_col, entity_type='show', entity_id).
+// `existsClause` must use a placeholder `?` that gets bound to
+// winnerID — see the comment_subscriptions call site for the shape.
+func movePolymorphicEntity(tx *gorm.DB, table, existsClause string, winnerID, loserID uint) (moved, skipped int64, err error) {
+	delSQL := fmt.Sprintf(`
+		DELETE FROM %s
+		WHERE entity_type = 'show'
+		  AND entity_id = ?
+		  AND EXISTS %s
+	`, table, existsClause)
+	del := tx.Exec(delSQL, loserID, winnerID)
+	if del.Error != nil {
+		return 0, 0, del.Error
+	}
+	skipped = del.RowsAffected
+
+	updSQL := fmt.Sprintf(`
+		UPDATE %s
+		SET entity_id = ?
+		WHERE entity_type = 'show' AND entity_id = ?
+	`, table)
+	upd := tx.Exec(updSQL, winnerID, loserID)
+	if upd.Error != nil {
+		return 0, 0, upd.Error
+	}
+	moved = upd.RowsAffected
+	return moved, skipped, nil
+}
+
+// movePolymorphicEntityWithTagConflict handles entity_tags, where the
+// uniqueness key is (tag_id, entity_type, entity_id) — distinct from
+// the simpler (user_id, entity_type, entity_id) shape.
+func movePolymorphicEntityWithTagConflict(tx *gorm.DB, table string, winnerID, loserID uint) (moved, skipped int64, err error) {
+	del := tx.Exec(`
+		DELETE FROM entity_tags
+		WHERE entity_type = 'show'
+		  AND entity_id = ?
+		  AND EXISTS (
+			SELECT 1 FROM entity_tags et2
+			WHERE et2.tag_id = entity_tags.tag_id
+			  AND et2.entity_type = 'show'
+			  AND et2.entity_id = ?
+		  )
+	`, loserID, winnerID)
+	if del.Error != nil {
+		return 0, 0, del.Error
+	}
+	skipped = del.RowsAffected
+
+	upd := tx.Exec(`
+		UPDATE entity_tags
+		SET entity_id = ?
+		WHERE entity_type = 'show' AND entity_id = ?
+	`, winnerID, loserID)
+	if upd.Error != nil {
+		return 0, 0, upd.Error
+	}
+	moved = upd.RowsAffected
+	return moved, skipped, nil
+}
+
+// moveCollectionItems handles collection_items uniqueness on
+// (collection_id, entity_type, entity_id).
+func moveCollectionItems(tx *gorm.DB, winnerID, loserID uint) (moved, skipped int64, err error) {
+	del := tx.Exec(`
+		DELETE FROM collection_items
+		WHERE entity_type = 'show'
+		  AND entity_id = ?
+		  AND EXISTS (
+			SELECT 1 FROM collection_items ci2
+			WHERE ci2.collection_id = collection_items.collection_id
+			  AND ci2.entity_type = 'show'
+			  AND ci2.entity_id = ?
+		  )
+	`, loserID, winnerID)
+	if del.Error != nil {
+		return 0, 0, del.Error
+	}
+	skipped = del.RowsAffected
+
+	upd := tx.Exec(`
+		UPDATE collection_items
+		SET entity_id = ?
+		WHERE entity_type = 'show' AND entity_id = ?
+	`, winnerID, loserID)
+	if upd.Error != nil {
+		return 0, 0, upd.Error
+	}
+	moved = upd.RowsAffected
+	return moved, skipped, nil
+}
+
+// moveBookmarks handles user_bookmarks uniqueness on
+// (user_id, entity_type, entity_id, action).
+func moveBookmarks(tx *gorm.DB, winnerID, loserID uint) (moved, skipped int64, err error) {
+	del := tx.Exec(`
+		DELETE FROM user_bookmarks
+		WHERE entity_type = 'show'
+		  AND entity_id = ?
+		  AND EXISTS (
+			SELECT 1 FROM user_bookmarks b2
+			WHERE b2.user_id = user_bookmarks.user_id
+			  AND b2.action  = user_bookmarks.action
+			  AND b2.entity_type = 'show'
+			  AND b2.entity_id = ?
+		  )
+	`, loserID, winnerID)
+	if del.Error != nil {
+		return 0, 0, del.Error
+	}
+	skipped = del.RowsAffected
+
+	upd := tx.Exec(`
+		UPDATE user_bookmarks
+		SET entity_id = ?
+		WHERE entity_type = 'show' AND entity_id = ?
+	`, winnerID, loserID)
+	if upd.Error != nil {
+		return 0, 0, upd.Error
+	}
+	moved = upd.RowsAffected
+	return moved, skipped, nil
+}
+
+// RecanonicaliseShowSlug recomputes the show's slug using the canonical
+// venue-timezone-aware GenerateShowSlug helper. Idempotent: if the
+// computed slug already matches the stored slug, no DB write happens.
+//
+// Used by the dedup cmd to fix slugs left in the legacy
+// migration-000019 form ("…YYYY-MM-DD" derived from raw UTC date) on
+// shows that survive a merge. Returns true if the slug was rewritten.
+func RecanonicaliseShowSlug(tx *gorm.DB, showID uint) (bool, error) {
+	var show catalogm.Show
+	if err := tx.First(&show, showID).Error; err != nil {
+		return false, fmt.Errorf("load show: %w", err)
+	}
+
+	// Resolve headliner — set_type='headliner' wins, else position=0.
+	var artists []catalogm.Artist
+	if err := tx.Table("artists").
+		Joins("JOIN show_artists ON show_artists.artist_id = artists.id").
+		Where("show_artists.show_id = ?", showID).
+		Order("CASE WHEN show_artists.set_type='headliner' THEN 0 ELSE 1 END, show_artists.position ASC, artists.id ASC").
+		Find(&artists).Error; err != nil {
+		return false, fmt.Errorf("load show artists: %w", err)
+	}
+
+	// Resolve venue — first by show_venues join.
+	var venues []catalogm.Venue
+	if err := tx.Table("venues").
+		Joins("JOIN show_venues ON show_venues.venue_id = venues.id").
+		Where("show_venues.show_id = ?", showID).
+		Order("venues.id ASC").
+		Find(&venues).Error; err != nil {
+		return false, fmt.Errorf("load show venues: %w", err)
+	}
+
+	headlinerName := "unknown"
+	if len(artists) > 0 {
+		headlinerName = artists[0].Name
+	}
+	venueName := "unknown"
+	if len(venues) > 0 {
+		venueName = venues[0].Name
+	}
+
+	state := ""
+	if show.State != nil {
+		state = *show.State
+	}
+
+	canonical := utils.GenerateShowSlug(show.EventDate, headlinerName, venueName, state)
+	current := ""
+	if show.Slug != nil {
+		current = *show.Slug
+	}
+	if canonical == current {
+		return false, nil
+	}
+
+	// Ensure uniqueness — if the canonical slug already exists on
+	// another show, append a numeric suffix.
+	unique := utils.GenerateUniqueSlug(canonical, func(candidate string) bool {
+		var count int64
+		tx.Model(&catalogm.Show{}).
+			Where("slug = ? AND id <> ?", candidate, showID).
+			Count(&count)
+		return count > 0
+	})
+
+	if err := tx.Model(&catalogm.Show{}).Where("id = ?", showID).Update("slug", unique).Error; err != nil {
+		return false, fmt.Errorf("update slug: %w", err)
+	}
+	return true, nil
+}

--- a/backend/internal/services/catalog/show_dedup.go
+++ b/backend/internal/services/catalog/show_dedup.go
@@ -3,6 +3,7 @@ package catalog
 import (
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"gorm.io/gorm"
@@ -179,9 +180,7 @@ func FindShowDedupClusters(db *gorm.DB) ([]ShowDedupCluster, error) {
 
 // MergeDuplicateShow merges loser into winner inside an existing
 // transaction. All FKs (direct + polymorphic) are repointed with
-// conflict-aware semantics. The loser is then deleted, which cascades
-// to show_venues / show_artists / show_reports / enrichment_queue
-// rows that still belong to it.
+// conflict-aware semantics. The loser is then deleted.
 //
 // Conflict policy: when a UNIQUE / PK conflict would occur on the
 // winner, the loser's row is dropped (the winner's pre-existing row
@@ -194,7 +193,7 @@ func MergeDuplicateShow(tx *gorm.DB, winnerID, loserID uint, summary *ShowDedupS
 		return fmt.Errorf("winnerID == loserID")
 	}
 
-	// 1. show_venues — copy missing rows from loser to winner, drop conflicts.
+	// Junction tables with composite PK (show_id, otherCol).
 	moved, skipped, err := movePolymorphicJunction(tx, "show_venues", "show_id", "venue_id", winnerID, loserID)
 	if err != nil {
 		return fmt.Errorf("show_venues: %w", err)
@@ -202,9 +201,6 @@ func MergeDuplicateShow(tx *gorm.DB, winnerID, loserID uint, summary *ShowDedupS
 	summary.ShowVenuesMoved += moved
 	summary.ShowVenuesSkipped += skipped
 
-	// 2. show_artists — same pattern. Preserve position/set_type from
-	// loser only when winner doesn't already have the artist (handled
-	// by the conflict-skip below).
 	moved, skipped, err = movePolymorphicJunction(tx, "show_artists", "show_id", "artist_id", winnerID, loserID)
 	if err != nil {
 		return fmt.Errorf("show_artists: %w", err)
@@ -212,136 +208,68 @@ func MergeDuplicateShow(tx *gorm.DB, winnerID, loserID uint, summary *ShowDedupS
 	summary.ShowArtistsMoved += moved
 	summary.ShowArtistsSkipped += skipped
 
-	// 3. show_reports — repoint to winner (no unique constraint).
-	res := tx.Exec(`UPDATE show_reports SET show_id = ? WHERE show_id = ?`, winnerID, loserID)
-	if res.Error != nil {
-		return fmt.Errorf("show_reports: %w", res.Error)
+	// Plain FK repoints — no unique constraint to worry about.
+	for _, op := range []struct {
+		name string
+		sql  string
+		dst  *int64
+	}{
+		{"show_reports", `UPDATE show_reports SET show_id = ? WHERE show_id = ?`, &summary.ShowReportsMoved},
+		{"enrichment_queue", `UPDATE enrichment_queue SET show_id = ? WHERE show_id = ?`, &summary.EnrichmentMoved},
+		{"duplicate_of_show_id", `UPDATE shows SET duplicate_of_show_id = ? WHERE duplicate_of_show_id = ?`, &summary.DuplicateOfRepoint},
+	} {
+		res := tx.Exec(op.sql, winnerID, loserID)
+		if res.Error != nil {
+			return fmt.Errorf("%s: %w", op.name, res.Error)
+		}
+		*op.dst += res.RowsAffected
 	}
-	summary.ShowReportsMoved += res.RowsAffected
 
-	// 4. enrichment_queue — repoint to winner.
-	res = tx.Exec(`UPDATE enrichment_queue SET show_id = ? WHERE show_id = ?`, winnerID, loserID)
-	if res.Error != nil {
-		return fmt.Errorf("enrichment_queue: %w", res.Error)
+	// Polymorphic FK repoints (entity_type='show'). Tables with no
+	// uniqueness constraint on (entity_type, entity_id) just need a
+	// straight UPDATE.
+	for _, op := range []struct {
+		name string
+		sql  string
+		dst  *int64
+	}{
+		{"comments", `UPDATE comments SET entity_id = ? WHERE entity_type = 'show' AND entity_id = ?`, &summary.CommentsRepointed},
+		{"entity_reports", `UPDATE entity_reports SET entity_id = ? WHERE entity_type = 'show' AND entity_id = ?`, &summary.EntityReportsMoved},
+		{"pending_entity_edits", `UPDATE pending_entity_edits SET entity_id = ? WHERE entity_type = 'show' AND entity_id = ?`, &summary.PendingEditsMoved},
+		{"revisions", `UPDATE revisions SET entity_id = ? WHERE entity_type = 'show' AND entity_id = ?`, &summary.RevisionsMoved},
+		{"audit_logs", `UPDATE audit_logs SET entity_id = ? WHERE entity_type = 'show' AND entity_id = ?`, &summary.AuditLogsMoved},
+		// requests uses requested_entity_id, not entity_id.
+		{"requests", `UPDATE requests SET requested_entity_id = ? WHERE entity_type = 'show' AND requested_entity_id = ?`, &summary.RequestsMoved},
+	} {
+		res := tx.Exec(op.sql, winnerID, loserID)
+		if res.Error != nil {
+			return fmt.Errorf("%s: %w", op.name, res.Error)
+		}
+		*op.dst += res.RowsAffected
 	}
-	summary.EnrichmentMoved += res.RowsAffected
 
-	// 5. shows.duplicate_of_show_id — repoint loser→winner so any
-	// existing duplicate-of pointer survives the merge.
-	res = tx.Exec(`UPDATE shows SET duplicate_of_show_id = ? WHERE duplicate_of_show_id = ?`, winnerID, loserID)
-	if res.Error != nil {
-		return fmt.Errorf("duplicate_of_show_id: %w", res.Error)
+	// Polymorphic FK repoints WITH a uniqueness constraint —
+	// conflict-correlation columns vary per table.
+	for _, op := range []struct {
+		name        string
+		correlation []string
+		moved       *int64
+		skipped     *int64
+	}{
+		{"comment_subscriptions", []string{"user_id"}, &summary.SubsRepointed, &summary.SubsSkipped},
+		{"entity_tags", []string{"tag_id"}, &summary.EntityTagsMoved, &summary.EntityTagsSkipped},
+		{"collection_items", []string{"collection_id"}, &summary.CollectionsMoved, &summary.CollectionsSkipped},
+		{"user_bookmarks", []string{"user_id", "action"}, &summary.BookmarksMoved, &summary.BookmarksSkipped},
+	} {
+		moved, skipped, err = movePolymorphicEntity(tx, op.name, op.correlation, winnerID, loserID)
+		if err != nil {
+			return fmt.Errorf("%s: %w", op.name, err)
+		}
+		*op.moved += moved
+		*op.skipped += skipped
 	}
-	summary.DuplicateOfRepoint += res.RowsAffected
 
-	// 6. comments — repoint entity_id (no unique constraint on
-	// (entity_type, entity_id) for comments — same comment thread
-	// just gets renamed under the winner).
-	res = tx.Exec(`
-		UPDATE comments
-		SET entity_id = ?
-		WHERE entity_type = 'show' AND entity_id = ?
-	`, winnerID, loserID)
-	if res.Error != nil {
-		return fmt.Errorf("comments: %w", res.Error)
-	}
-	summary.CommentsRepointed += res.RowsAffected
-
-	// 7. comment_subscriptions — PK is (user_id, entity_type,
-	// entity_id). Drop conflicts then repoint.
-	moved, skipped, err = movePolymorphicEntity(tx, "comment_subscriptions",
-		`(SELECT 1 FROM comment_subscriptions cs2
-		   WHERE cs2.user_id = comment_subscriptions.user_id
-			 AND cs2.entity_type = 'show'
-			 AND cs2.entity_id = ?)`, winnerID, loserID)
-	if err != nil {
-		return fmt.Errorf("comment_subscriptions: %w", err)
-	}
-	summary.SubsRepointed += moved
-	summary.SubsSkipped += skipped
-
-	// 8. entity_tags — UNIQUE (tag_id, entity_type, entity_id) per
-	// migration 000051. Drop conflicts, then move.
-	moved, skipped, err = movePolymorphicEntityWithTagConflict(tx, "entity_tags", winnerID, loserID)
-	if err != nil {
-		return fmt.Errorf("entity_tags: %w", err)
-	}
-	summary.EntityTagsMoved += moved
-	summary.EntityTagsSkipped += skipped
-
-	// 9. entity_reports — repoint (no relevant unique).
-	res = tx.Exec(`
-		UPDATE entity_reports
-		SET entity_id = ?
-		WHERE entity_type = 'show' AND entity_id = ?
-	`, winnerID, loserID)
-	if res.Error != nil {
-		return fmt.Errorf("entity_reports: %w", res.Error)
-	}
-	summary.EntityReportsMoved += res.RowsAffected
-
-	// 10. pending_entity_edits — repoint.
-	res = tx.Exec(`
-		UPDATE pending_entity_edits
-		SET entity_id = ?
-		WHERE entity_type = 'show' AND entity_id = ?
-	`, winnerID, loserID)
-	if res.Error != nil {
-		return fmt.Errorf("pending_entity_edits: %w", res.Error)
-	}
-	summary.PendingEditsMoved += res.RowsAffected
-
-	// 11. revisions — repoint.
-	res = tx.Exec(`
-		UPDATE revisions
-		SET entity_id = ?
-		WHERE entity_type = 'show' AND entity_id = ?
-	`, winnerID, loserID)
-	if res.Error != nil {
-		return fmt.Errorf("revisions: %w", res.Error)
-	}
-	summary.RevisionsMoved += res.RowsAffected
-
-	// 12. requests — points via requested_entity_id, not entity_id.
-	res = tx.Exec(`
-		UPDATE requests
-		SET requested_entity_id = ?
-		WHERE entity_type = 'show' AND requested_entity_id = ?
-	`, winnerID, loserID)
-	if res.Error != nil {
-		return fmt.Errorf("requests: %w", res.Error)
-	}
-	summary.RequestsMoved += res.RowsAffected
-
-	// 13. audit_logs — repoint.
-	res = tx.Exec(`
-		UPDATE audit_logs
-		SET entity_id = ?
-		WHERE entity_type = 'show' AND entity_id = ?
-	`, winnerID, loserID)
-	if res.Error != nil {
-		return fmt.Errorf("audit_logs: %w", res.Error)
-	}
-	summary.AuditLogsMoved += res.RowsAffected
-
-	// 14. collection_items — UNIQUE (collection_id, entity_type,
-	// entity_id) handled inline; conflicts dropped.
-	moved, skipped, err = moveCollectionItems(tx, winnerID, loserID)
-	if err != nil {
-		return fmt.Errorf("collection_items: %w", err)
-	}
-	summary.CollectionsMoved += moved
-	summary.CollectionsSkipped += skipped
-
-	// 15. user_bookmarks — UNIQUE (user_id, entity_type, entity_id, action).
-	moved, skipped, err = moveBookmarks(tx, winnerID, loserID)
-	if err != nil {
-		return fmt.Errorf("user_bookmarks: %w", err)
-	}
-	summary.BookmarksMoved += moved
-	summary.BookmarksSkipped += skipped
-
-	// 16. Delete the loser show. CASCADE handles anything left in
+	// Delete the loser show. CASCADE handles anything left in
 	// show_venues / show_artists / show_reports / enrichment_queue
 	// (i.e. nothing — all repointed above).
 	if err := tx.Delete(&catalogm.Show{}, loserID).Error; err != nil {
@@ -381,17 +309,32 @@ func movePolymorphicJunction(tx *gorm.DB, table, primaryCol, otherCol string, wi
 	return moved, skipped, nil
 }
 
-// movePolymorphicEntity is a generic conflict-aware move for tables
-// keyed on (some_user_or_other_col, entity_type='show', entity_id).
-// `existsClause` must use a placeholder `?` that gets bound to
-// winnerID — see the comment_subscriptions call site for the shape.
-func movePolymorphicEntity(tx *gorm.DB, table, existsClause string, winnerID, loserID uint) (moved, skipped int64, err error) {
+// movePolymorphicEntity is a conflict-aware FK repoint for tables
+// keyed on `(<correlation columns>, entity_type='show', entity_id)`.
+// Loser rows whose `<correlation>` already collides with a winner
+// row are deleted (winner wins); remaining rows are repointed to the
+// winner. Used for comment_subscriptions, entity_tags,
+// collection_items and user_bookmarks — `correlation` differs per
+// table (e.g. `["user_id", "action"]` for user_bookmarks).
+func movePolymorphicEntity(tx *gorm.DB, table string, correlation []string, winnerID, loserID uint) (moved, skipped int64, err error) {
+	if len(correlation) == 0 {
+		return 0, 0, fmt.Errorf("correlation must not be empty")
+	}
+	conds := make([]string, len(correlation))
+	for i, col := range correlation {
+		conds[i] = fmt.Sprintf("t2.%s = %s.%s", col, table, col)
+	}
 	delSQL := fmt.Sprintf(`
 		DELETE FROM %s
 		WHERE entity_type = 'show'
 		  AND entity_id = ?
-		  AND EXISTS %s
-	`, table, existsClause)
+		  AND EXISTS (
+			SELECT 1 FROM %s t2
+			WHERE t2.entity_type = 'show'
+			  AND t2.entity_id = ?
+			  AND %s
+		  )
+	`, table, table, strings.Join(conds, " AND "))
 	del := tx.Exec(delSQL, loserID, winnerID)
 	if del.Error != nil {
 		return 0, 0, del.Error
@@ -404,101 +347,6 @@ func movePolymorphicEntity(tx *gorm.DB, table, existsClause string, winnerID, lo
 		WHERE entity_type = 'show' AND entity_id = ?
 	`, table)
 	upd := tx.Exec(updSQL, winnerID, loserID)
-	if upd.Error != nil {
-		return 0, 0, upd.Error
-	}
-	moved = upd.RowsAffected
-	return moved, skipped, nil
-}
-
-// movePolymorphicEntityWithTagConflict handles entity_tags, where the
-// uniqueness key is (tag_id, entity_type, entity_id) — distinct from
-// the simpler (user_id, entity_type, entity_id) shape.
-func movePolymorphicEntityWithTagConflict(tx *gorm.DB, table string, winnerID, loserID uint) (moved, skipped int64, err error) {
-	del := tx.Exec(`
-		DELETE FROM entity_tags
-		WHERE entity_type = 'show'
-		  AND entity_id = ?
-		  AND EXISTS (
-			SELECT 1 FROM entity_tags et2
-			WHERE et2.tag_id = entity_tags.tag_id
-			  AND et2.entity_type = 'show'
-			  AND et2.entity_id = ?
-		  )
-	`, loserID, winnerID)
-	if del.Error != nil {
-		return 0, 0, del.Error
-	}
-	skipped = del.RowsAffected
-
-	upd := tx.Exec(`
-		UPDATE entity_tags
-		SET entity_id = ?
-		WHERE entity_type = 'show' AND entity_id = ?
-	`, winnerID, loserID)
-	if upd.Error != nil {
-		return 0, 0, upd.Error
-	}
-	moved = upd.RowsAffected
-	return moved, skipped, nil
-}
-
-// moveCollectionItems handles collection_items uniqueness on
-// (collection_id, entity_type, entity_id).
-func moveCollectionItems(tx *gorm.DB, winnerID, loserID uint) (moved, skipped int64, err error) {
-	del := tx.Exec(`
-		DELETE FROM collection_items
-		WHERE entity_type = 'show'
-		  AND entity_id = ?
-		  AND EXISTS (
-			SELECT 1 FROM collection_items ci2
-			WHERE ci2.collection_id = collection_items.collection_id
-			  AND ci2.entity_type = 'show'
-			  AND ci2.entity_id = ?
-		  )
-	`, loserID, winnerID)
-	if del.Error != nil {
-		return 0, 0, del.Error
-	}
-	skipped = del.RowsAffected
-
-	upd := tx.Exec(`
-		UPDATE collection_items
-		SET entity_id = ?
-		WHERE entity_type = 'show' AND entity_id = ?
-	`, winnerID, loserID)
-	if upd.Error != nil {
-		return 0, 0, upd.Error
-	}
-	moved = upd.RowsAffected
-	return moved, skipped, nil
-}
-
-// moveBookmarks handles user_bookmarks uniqueness on
-// (user_id, entity_type, entity_id, action).
-func moveBookmarks(tx *gorm.DB, winnerID, loserID uint) (moved, skipped int64, err error) {
-	del := tx.Exec(`
-		DELETE FROM user_bookmarks
-		WHERE entity_type = 'show'
-		  AND entity_id = ?
-		  AND EXISTS (
-			SELECT 1 FROM user_bookmarks b2
-			WHERE b2.user_id = user_bookmarks.user_id
-			  AND b2.action  = user_bookmarks.action
-			  AND b2.entity_type = 'show'
-			  AND b2.entity_id = ?
-		  )
-	`, loserID, winnerID)
-	if del.Error != nil {
-		return 0, 0, del.Error
-	}
-	skipped = del.RowsAffected
-
-	upd := tx.Exec(`
-		UPDATE user_bookmarks
-		SET entity_id = ?
-		WHERE entity_type = 'show' AND entity_id = ?
-	`, winnerID, loserID)
 	if upd.Error != nil {
 		return 0, 0, upd.Error
 	}

--- a/backend/internal/services/catalog/show_dedup_test.go
+++ b/backend/internal/services/catalog/show_dedup_test.go
@@ -1,0 +1,314 @@
+package catalog
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"gorm.io/gorm"
+
+	authm "psychic-homily-backend/internal/models/auth"
+	catalogm "psychic-homily-backend/internal/models/catalog"
+	"psychic-homily-backend/internal/testutil"
+)
+
+// =============================================================================
+// PSY-559: Show dedup integration tests
+// =============================================================================
+
+type ShowDedupTestSuite struct {
+	suite.Suite
+	testDB *testutil.TestDatabase
+	db     *gorm.DB
+}
+
+func (s *ShowDedupTestSuite) SetupSuite() {
+	s.testDB = testutil.SetupTestPostgres(s.T())
+	s.db = s.testDB.DB
+}
+
+func (s *ShowDedupTestSuite) TearDownSuite() {
+	if s.testDB != nil {
+		s.testDB.Cleanup()
+	}
+}
+
+func (s *ShowDedupTestSuite) TearDownTest() {
+	sqlDB, err := s.db.DB()
+	s.Require().NoError(err)
+	for _, t := range []string{
+		"comment_subscriptions", "comment_votes", "comment_edits", "comments",
+		"entity_tags", "entity_reports", "pending_entity_edits",
+		"revisions", "requests", "audit_logs", "collection_items",
+		"user_bookmarks", "show_reports", "enrichment_queue",
+		"show_artists", "show_venues", "shows", "artists", "venues", "users",
+	} {
+		_, _ = sqlDB.Exec(fmt.Sprintf("DELETE FROM %s", t))
+	}
+}
+
+func TestShowDedupTestSuite(t *testing.T) {
+	suite.Run(t, new(ShowDedupTestSuite))
+}
+
+// --- helpers ---
+
+func (s *ShowDedupTestSuite) seedUser(email string) *authm.User {
+	u := &authm.User{
+		Email:         stringPtr(email),
+		FirstName:     stringPtr("Test"),
+		LastName:      stringPtr("User"),
+		IsActive:      true,
+		EmailVerified: true,
+	}
+	s.Require().NoError(s.db.Create(u).Error)
+	return u
+}
+
+func (s *ShowDedupTestSuite) seedArtist(name string) *catalogm.Artist {
+	slug := name
+	a := &catalogm.Artist{Name: name, Slug: &slug}
+	s.Require().NoError(s.db.Create(a).Error)
+	return a
+}
+
+func (s *ShowDedupTestSuite) seedVenue(name, city, state string) *catalogm.Venue {
+	slug := name
+	v := &catalogm.Venue{Name: name, Slug: &slug, City: city, State: state, Verified: true}
+	s.Require().NoError(s.db.Create(v).Error)
+	return v
+}
+
+// seedShow inserts a show with the given event_date, links artist as
+// headliner and venue. Uses raw SQL so we control created_at exactly.
+func (s *ShowDedupTestSuite) seedShow(title string, eventDate, createdAt time.Time, artistID, venueID uint, state string) uint {
+	var id uint
+	row := s.db.Raw(`
+		INSERT INTO shows (title, event_date, state, status, source, created_at, updated_at, slug)
+		VALUES (?, ?, ?, 'approved', 'user', ?, ?, ?)
+		RETURNING id
+	`, title, eventDate, state, createdAt, createdAt, fmt.Sprintf("%s-%d", title, eventDate.Unix())).Row()
+	s.Require().NoError(row.Scan(&id))
+
+	s.Require().NoError(s.db.Exec(
+		`INSERT INTO show_artists (show_id, artist_id, position, set_type) VALUES (?, ?, 0, 'headliner')`,
+		id, artistID).Error)
+	s.Require().NoError(s.db.Exec(
+		`INSERT INTO show_venues (show_id, venue_id) VALUES (?, ?)`,
+		id, venueID).Error)
+	return id
+}
+
+// --- tests ---
+
+// TestFindClusters_BasicPair confirms two shows with the same
+// (artist, venue, event_date) are detected as a duplicate cluster.
+func (s *ShowDedupTestSuite) TestFindClusters_BasicPair() {
+	a := s.seedArtist("Peter Hook")
+	v := s.seedVenue("The Van Buren", "Phoenix", "AZ")
+	eventDate := time.Date(2026, 9, 16, 2, 30, 0, 0, time.UTC) // 7:30pm Phoenix on Sept 15
+	earlier := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	later := time.Date(2026, 2, 1, 12, 0, 0, 0, time.UTC)
+
+	id1 := s.seedShow("Peter Hook 1", eventDate, earlier, a.ID, v.ID, "AZ")
+	id2 := s.seedShow("Peter Hook 2", eventDate, later, a.ID, v.ID, "AZ")
+
+	clusters, err := FindShowDedupClusters(s.db)
+	s.Require().NoError(err)
+	s.Require().Len(clusters, 1)
+
+	c := clusters[0]
+	s.Equal(a.ID, c.Key.ArtistID)
+	s.Equal(v.ID, c.Key.VenueID)
+	s.True(eventDate.Equal(c.Key.EventDate))
+	s.Equal(id1, c.WinnerID)
+	s.Equal([]uint{id2}, c.LoserIDs)
+}
+
+// TestFindClusters_MatineeAndEvening — the matinee+evening exception
+// case from the ticket. Same artist + same venue on the same DATE
+// but DIFFERENT event_date timestamps must NOT be collapsed.
+func (s *ShowDedupTestSuite) TestFindClusters_MatineeAndEvening() {
+	a := s.seedArtist("Just Mustard")
+	v := s.seedVenue("Valley Bar", "Phoenix", "AZ")
+	matinee := time.Date(2026, 5, 17, 20, 0, 0, 0, time.UTC) // 1pm AZ
+	evening := time.Date(2026, 5, 18, 3, 0, 0, 0, time.UTC)  // 8pm AZ
+	created := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	_ = s.seedShow("Matinee", matinee, created, a.ID, v.ID, "AZ")
+	_ = s.seedShow("Evening", evening, created, a.ID, v.ID, "AZ")
+
+	clusters, err := FindShowDedupClusters(s.db)
+	s.Require().NoError(err)
+	s.Empty(clusters, "matinee+evening at same venue must not be collapsed")
+}
+
+// TestFindClusters_DifferentVenues confirms shows with the same artist
+// + event_date but different venues are NOT clustered.
+func (s *ShowDedupTestSuite) TestFindClusters_DifferentVenues() {
+	a := s.seedArtist("Amyl And The Sniffers")
+	v1 := s.seedVenue("Van Buren", "Phoenix", "AZ")
+	v2 := s.seedVenue("Crescent Ballroom", "Phoenix", "AZ")
+	eventDate := time.Date(2026, 4, 11, 2, 30, 0, 0, time.UTC)
+	created := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	_ = s.seedShow("Show A", eventDate, created, a.ID, v1.ID, "AZ")
+	_ = s.seedShow("Show B", eventDate, created, a.ID, v2.ID, "AZ")
+
+	clusters, err := FindShowDedupClusters(s.db)
+	s.Require().NoError(err)
+	s.Empty(clusters)
+}
+
+// TestMergeDuplicateShow_BasicMerge runs the full merge and confirms
+// the loser is gone, the winner is preserved.
+func (s *ShowDedupTestSuite) TestMergeDuplicateShow_BasicMerge() {
+	a := s.seedArtist("Headliner")
+	v := s.seedVenue("Hall", "Phoenix", "AZ")
+	eventDate := time.Date(2026, 6, 1, 3, 0, 0, 0, time.UTC)
+	t1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+
+	winner := s.seedShow("First", eventDate, t1, a.ID, v.ID, "AZ")
+	loser := s.seedShow("Second", eventDate, t2, a.ID, v.ID, "AZ")
+
+	summary := &ShowDedupSummary{}
+	err := s.db.Transaction(func(tx *gorm.DB) error {
+		return MergeDuplicateShow(tx, winner, loser, summary)
+	})
+	s.Require().NoError(err)
+
+	// Winner survives.
+	var winnerCount int64
+	s.db.Model(&catalogm.Show{}).Where("id = ?", winner).Count(&winnerCount)
+	s.Equal(int64(1), winnerCount)
+
+	// Loser deleted.
+	var loserCount int64
+	s.db.Model(&catalogm.Show{}).Where("id = ?", loser).Count(&loserCount)
+	s.Equal(int64(0), loserCount)
+
+	// show_artists / show_venues junctions still cover the winner.
+	var saCount, svCount int64
+	s.db.Table("show_artists").Where("show_id = ?", winner).Count(&saCount)
+	s.db.Table("show_venues").Where("show_id = ?", winner).Count(&svCount)
+	s.Equal(int64(1), saCount)
+	s.Equal(int64(1), svCount)
+
+	s.Equal(1, summary.LosersMerged)
+}
+
+// TestMergeDuplicateShow_RepointsBookmarks confirms a bookmark on the
+// loser is repointed to the winner, with conflicts dropped.
+func (s *ShowDedupTestSuite) TestMergeDuplicateShow_RepointsBookmarks() {
+	a := s.seedArtist("X")
+	v := s.seedVenue("Y", "Phoenix", "AZ")
+	eventDate := time.Date(2026, 6, 1, 3, 0, 0, 0, time.UTC)
+	winner := s.seedShow("W", eventDate, time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), a.ID, v.ID, "AZ")
+	loser := s.seedShow("L", eventDate, time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC), a.ID, v.ID, "AZ")
+
+	u1 := s.seedUser("a@test.com")
+	u2 := s.seedUser("b@test.com")
+
+	// u1 has a 'save' on the winner already — loser's save by u1
+	// must be dropped on conflict.
+	insertBookmark := `INSERT INTO user_bookmarks (user_id, entity_type, entity_id, action) VALUES (?, 'show', ?, 'save')`
+	s.Require().NoError(s.db.Exec(insertBookmark, u1.ID, winner).Error)
+	s.Require().NoError(s.db.Exec(insertBookmark, u1.ID, loser).Error)
+	s.Require().NoError(s.db.Exec(insertBookmark, u2.ID, loser).Error) // no conflict
+
+	summary := &ShowDedupSummary{}
+	err := s.db.Transaction(func(tx *gorm.DB) error {
+		return MergeDuplicateShow(tx, winner, loser, summary)
+	})
+	s.Require().NoError(err)
+
+	// u1 still has exactly one save on winner; u2 also has one.
+	var u1Count, u2Count int64
+	s.db.Table("user_bookmarks").
+		Where("user_id = ? AND entity_type = 'show' AND entity_id = ? AND action = 'save'", u1.ID, winner).
+		Count(&u1Count)
+	s.db.Table("user_bookmarks").
+		Where("user_id = ? AND entity_type = 'show' AND entity_id = ? AND action = 'save'", u2.ID, winner).
+		Count(&u2Count)
+	s.Equal(int64(1), u1Count)
+	s.Equal(int64(1), u2Count)
+
+	// Nothing left pointing at the loser.
+	var loserCount int64
+	s.db.Table("user_bookmarks").
+		Where("entity_type = 'show' AND entity_id = ?", loser).
+		Count(&loserCount)
+	s.Equal(int64(0), loserCount)
+
+	s.Equal(int64(1), summary.BookmarksMoved)
+	s.Equal(int64(1), summary.BookmarksSkipped)
+}
+
+// TestMergeDuplicateShow_RepointsCollectionItems confirms collection
+// items are repointed and the unique-per-collection constraint is
+// honoured.
+func (s *ShowDedupTestSuite) TestMergeDuplicateShow_RepointsCollectionItems() {
+	a := s.seedArtist("X")
+	v := s.seedVenue("Y", "Phoenix", "AZ")
+	eventDate := time.Date(2026, 6, 1, 3, 0, 0, 0, time.UTC)
+	winner := s.seedShow("W", eventDate, time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), a.ID, v.ID, "AZ")
+	loser := s.seedShow("L", eventDate, time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC), a.ID, v.ID, "AZ")
+
+	u := s.seedUser("c@test.com")
+
+	// Create a collection. Use only the columns required by NOT NULL.
+	var collectionID uint
+	row := s.db.Raw(`
+		INSERT INTO collections (title, slug, creator_id)
+		VALUES ('Test', ?, ?)
+		RETURNING id
+	`, fmt.Sprintf("test-%d", time.Now().UnixNano()), u.ID).Row()
+	s.Require().NoError(row.Scan(&collectionID))
+
+	// One item on winner already, one item on loser → conflict drop.
+	insertItem := `INSERT INTO collection_items (collection_id, entity_type, entity_id, position, added_by_user_id) VALUES (?, 'show', ?, 0, ?)`
+	s.Require().NoError(s.db.Exec(insertItem, collectionID, winner, u.ID).Error)
+	s.Require().NoError(s.db.Exec(insertItem, collectionID, loser, u.ID).Error)
+
+	summary := &ShowDedupSummary{}
+	err := s.db.Transaction(func(tx *gorm.DB) error {
+		return MergeDuplicateShow(tx, winner, loser, summary)
+	})
+	s.Require().NoError(err)
+
+	var n int64
+	s.db.Table("collection_items").
+		Where("collection_id = ? AND entity_type = 'show' AND entity_id = ?", collectionID, winner).
+		Count(&n)
+	s.Equal(int64(1), n, "exactly one item should remain on winner per collection")
+	s.Equal(int64(1), summary.CollectionsSkipped)
+}
+
+// TestRecanonicaliseShowSlug rewrites a legacy (UTC-derived) slug to
+// the venue-timezone-aware canonical form.
+func (s *ShowDedupTestSuite) TestRecanonicaliseShowSlug() {
+	a := s.seedArtist("Peter Hook")
+	v := s.seedVenue("The Van Buren", "Phoenix", "AZ")
+
+	// 7:30pm Phoenix on Sept 15 = 02:30 UTC on Sept 16. Legacy
+	// migration-000019 slug used UTC date → "…2026-09-16".
+	eventDate := time.Date(2026, 9, 16, 2, 30, 0, 0, time.UTC)
+	id := s.seedShow("Peter Hook", eventDate, time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), a.ID, v.ID, "AZ")
+
+	// Force a legacy-style slug.
+	legacy := "peter-hook-and-the-light-at-the-van-buren-2026-09-16"
+	s.Require().NoError(s.db.Model(&catalogm.Show{}).Where("id = ?", id).Update("slug", legacy).Error)
+
+	rewritten, err := RecanonicaliseShowSlug(s.db, id)
+	s.Require().NoError(err)
+	s.True(rewritten)
+
+	var got catalogm.Show
+	s.Require().NoError(s.db.First(&got, id).Error)
+	s.Require().NotNil(got.Slug)
+	// Canonical form puts the venue-local date FIRST.
+	s.Contains(*got.Slug, "2026-09-15")
+	s.Contains(*got.Slug, "at-the-van-buren")
+}

--- a/frontend/features/artists/components/ArtistShowsList.test.tsx
+++ b/frontend/features/artists/components/ArtistShowsList.test.tsx
@@ -45,6 +45,10 @@ vi.mock('@/features/shows', () => ({
       useCompactLayout: true,
     },
   },
+  // PSY-559: render-time dedup helper. Identity passthrough in tests
+  // keeps fixtures deterministic — dedup behaviour is exercised in
+  // features/shows/utils.test.ts.
+  dedupArtistShows: <T,>(shows: T[]) => shows,
 }))
 
 import { ArtistShowsList } from './ArtistShowsList'

--- a/frontend/features/artists/components/ArtistShowsList.tsx
+++ b/frontend/features/artists/components/ArtistShowsList.tsx
@@ -5,7 +5,11 @@ import { Loader2, Calendar, History } from 'lucide-react'
 import { useArtistShows } from '../hooks/useArtists'
 import type { ArtistTimeFilter } from '../types'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
-import { CompactShowRow, SHOW_LIST_FEATURE_POLICY } from '@/features/shows'
+import {
+  CompactShowRow,
+  SHOW_LIST_FEATURE_POLICY,
+  dedupArtistShows,
+} from '@/features/shows'
 
 interface ArtistShowsListProps {
   artistId: number
@@ -55,11 +59,15 @@ function ShowsTabContent({
     )
   }
 
+  // PSY-559: Render-time dedup so duplicate shows sharing
+  // (artist_id, venue_id, event_date+time) collapse to one row even
+  // before the backend dedup cmd runs against this DB.
+  const visibleShows = dedupArtistShows(data.shows)
   const isPastShow = timeFilter === 'past'
 
   return (
     <div>
-      {data.shows.map(show => {
+      {visibleShows.map(show => {
         const otherArtists = show.artists.filter(a => a.id !== artistId)
         return (
           <CompactShowRow
@@ -74,9 +82,9 @@ function ShowsTabContent({
           />
         )
       })}
-      {data.total > data.shows.length && (
+      {data.total > visibleShows.length && (
         <div className="text-center text-sm text-muted-foreground pt-4">
-          Showing {data.shows.length} of {data.total} shows
+          Showing {visibleShows.length} of {data.total} shows
         </div>
       )}
     </div>

--- a/frontend/features/shows/index.ts
+++ b/frontend/features/shows/index.ts
@@ -112,6 +112,9 @@ export {
   useMyShows,
 } from './hooks'
 
+// Utilities
+export { dedupArtistShows, dedupVenueShows } from './utils'
+
 // Components
 export {
   AttendanceButton,

--- a/frontend/features/shows/utils.test.ts
+++ b/frontend/features/shows/utils.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest'
+import { dedupArtistShows, dedupVenueShows } from './utils'
+
+// =============================================================================
+// PSY-559: dedup helpers
+// =============================================================================
+
+describe('dedupArtistShows', () => {
+  it('collapses two shows sharing (venue.id, event_date) to lowest id', () => {
+    const eventDate = '2026-09-16T02:30:00Z'
+    const shows = [
+      {
+        id: 64,
+        event_date: eventDate,
+        venue: { id: 1 },
+        artists: [{ id: 10, is_headliner: true }],
+      },
+      {
+        id: 786,
+        event_date: eventDate,
+        venue: { id: 1 },
+        artists: [{ id: 10, is_headliner: true }],
+      },
+    ]
+    const result = dedupArtistShows(shows)
+    expect(result.map(s => s.id)).toEqual([64])
+  })
+
+  it('preserves matinee + evening at the same venue on the same day', () => {
+    const matinee = '2026-05-17T20:00:00Z' // 1pm AZ
+    const evening = '2026-05-18T03:00:00Z' // 8pm AZ
+    const shows = [
+      {
+        id: 100,
+        event_date: matinee,
+        venue: { id: 7 },
+        artists: [{ id: 22, is_headliner: true }],
+      },
+      {
+        id: 101,
+        event_date: evening,
+        venue: { id: 7 },
+        artists: [{ id: 22, is_headliner: true }],
+      },
+    ]
+    const result = dedupArtistShows(shows)
+    expect(result.map(s => s.id)).toEqual([100, 101])
+  })
+
+  it('does not collapse same artist on the same date at different venues', () => {
+    const eventDate = '2026-04-11T02:30:00Z'
+    const shows = [
+      {
+        id: 1,
+        event_date: eventDate,
+        venue: { id: 1 },
+        artists: [{ id: 99, is_headliner: true }],
+      },
+      {
+        id: 2,
+        event_date: eventDate,
+        venue: { id: 2 },
+        artists: [{ id: 99, is_headliner: true }],
+      },
+    ]
+    expect(dedupArtistShows(shows)).toHaveLength(2)
+  })
+
+  it('preserves API ordering when no duplicates', () => {
+    const shows = [
+      {
+        id: 5,
+        event_date: '2026-01-01T00:00:00Z',
+        venue: { id: 1 },
+        artists: [{ id: 1, is_headliner: true }],
+      },
+      {
+        id: 3,
+        event_date: '2026-02-01T00:00:00Z',
+        venue: { id: 1 },
+        artists: [{ id: 1, is_headliner: true }],
+      },
+    ]
+    expect(dedupArtistShows(shows).map(s => s.id)).toEqual([5, 3])
+  })
+
+  it('treats missing venue as venue id 0 (still dedupes by event_date)', () => {
+    const eventDate = '2026-06-01T00:00:00Z'
+    const shows = [
+      { id: 1, event_date: eventDate, artists: [{ id: 1, is_headliner: true }] },
+      { id: 2, event_date: eventDate, artists: [{ id: 1, is_headliner: true }] },
+    ]
+    expect(dedupArtistShows(shows).map(s => s.id)).toEqual([1])
+  })
+})
+
+describe('dedupVenueShows', () => {
+  it('collapses two shows sharing (headliner_artist_id, event_date) to lowest id', () => {
+    const eventDate = '2026-09-16T02:30:00Z'
+    const shows = [
+      {
+        id: 64,
+        event_date: eventDate,
+        artists: [
+          { id: 10, is_headliner: true, position: 0, set_type: 'headliner' },
+        ],
+      },
+      {
+        id: 786,
+        event_date: eventDate,
+        artists: [
+          { id: 10, is_headliner: true, position: 0, set_type: 'headliner' },
+        ],
+      },
+    ]
+    expect(dedupVenueShows(shows).map(s => s.id)).toEqual([64])
+  })
+
+  it('preserves matinee + evening when artist is the same', () => {
+    const matinee = '2026-05-17T20:00:00Z'
+    const evening = '2026-05-18T03:00:00Z'
+    const artists = [
+      { id: 22, is_headliner: true, position: 0, set_type: 'headliner' },
+    ]
+    const shows = [
+      { id: 100, event_date: matinee, artists },
+      { id: 101, event_date: evening, artists },
+    ]
+    expect(dedupVenueShows(shows)).toHaveLength(2)
+  })
+
+  it('does not collapse different headliners on the same date', () => {
+    const eventDate = '2026-06-01T00:00:00Z'
+    const shows = [
+      {
+        id: 1,
+        event_date: eventDate,
+        artists: [
+          { id: 1, is_headliner: true, position: 0, set_type: 'headliner' },
+        ],
+      },
+      {
+        id: 2,
+        event_date: eventDate,
+        artists: [
+          { id: 2, is_headliner: true, position: 0, set_type: 'headliner' },
+        ],
+      },
+    ]
+    expect(dedupVenueShows(shows)).toHaveLength(2)
+  })
+
+  it('falls back to position 0 when set_type is unset', () => {
+    const eventDate = '2026-06-01T00:00:00Z'
+    const shows = [
+      {
+        id: 1,
+        event_date: eventDate,
+        artists: [{ id: 5, position: 0, set_type: 'performer' }],
+      },
+      {
+        id: 2,
+        event_date: eventDate,
+        artists: [{ id: 5, position: 0, set_type: 'performer' }],
+      },
+    ]
+    expect(dedupVenueShows(shows).map(s => s.id)).toEqual([1])
+  })
+})

--- a/frontend/features/shows/utils.ts
+++ b/frontend/features/shows/utils.ts
@@ -1,0 +1,102 @@
+/**
+ * dedupShowsByArtistVenueDateTime collapses literal-duplicate show
+ * rows that share the same `(artist_id, venue_id, event_date+time)`
+ * tuple. PSY-559.
+ *
+ * The dedup key MUST include time (full ISO event_date), not just the
+ * date — matinee + evening sets at the same venue on the same day are
+ * NOT duplicates and must remain visible.
+ *
+ * Lowest-ID wins. Used as a render-time stopgap on artist + venue
+ * detail pages so the visual fix lands even if the backend dedup cmd
+ * (cmd/dedup-shows) hasn't been run on the target environment yet.
+ *
+ * Generic over T to work with both ArtistShowResponse (has top-level
+ * `venue.id`) and VenueShowResponse (no venue field — venue is
+ * implicit since the list is already scoped to one venue, so we key
+ * on the headliner artist instead).
+ */
+
+interface ShowLike {
+  id: number
+  event_date: string
+}
+
+interface ArtistInList {
+  id: number
+  is_headliner?: boolean | null
+  set_type?: string
+  position?: number
+}
+
+interface ShowWithVenueAndArtists extends ShowLike {
+  venue?: { id: number } | null
+  artists: ArtistInList[]
+}
+
+interface ShowWithArtists extends ShowLike {
+  artists: ArtistInList[]
+}
+
+/**
+ * Pick a stable headliner artist id for a show. Prefer
+ * `set_type === 'headliner'`, then `is_headliner`, then position 0,
+ * then the first artist. Returns null if the show has no artists.
+ */
+function headlinerArtistId(show: ShowWithArtists): number | null {
+  if (!show.artists || show.artists.length === 0) {
+    return null
+  }
+  const byHeadlinerSetType = show.artists.find(a => a.set_type === 'headliner')
+  if (byHeadlinerSetType) return byHeadlinerSetType.id
+  const byHeadlinerFlag = show.artists.find(a => a.is_headliner === true)
+  if (byHeadlinerFlag) return byHeadlinerFlag.id
+  const byPosition = show.artists.find(a => a.position === 0)
+  if (byPosition) return byPosition.id
+  return show.artists[0].id
+}
+
+/**
+ * Dedup shows on an ARTIST detail page. Each show carries its own
+ * `venue.id`, so the key is `(venue.id, event_date)`. Lowest show.id
+ * wins on collision.
+ */
+export function dedupArtistShows<T extends ShowWithVenueAndArtists>(shows: T[]): T[] {
+  const seen = new Map<string, T>()
+  for (const show of shows) {
+    const venueId = show.venue?.id ?? 0
+    const key = `${venueId}|${show.event_date}`
+    const existing = seen.get(key)
+    if (!existing || show.id < existing.id) {
+      seen.set(key, show)
+    }
+  }
+  // Preserve input order: walk the original list and only keep entries
+  // whose id matches the winner for their key. (Map iteration order is
+  // insertion order, but a later collision can replace an earlier
+  // winner — that would shuffle the ordering relative to the API
+  // response. Filter from the original instead.)
+  const winners = new Set<number>()
+  for (const v of seen.values()) winners.add(v.id)
+  return shows.filter(s => winners.has(s.id))
+}
+
+/**
+ * Dedup shows on a VENUE detail page. The list is already scoped to
+ * ONE venue, so the key is `(headliner_artist_id, event_date)`.
+ * Shows without artists keep their own bucket (key uses 0).
+ */
+export function dedupVenueShows<T extends ShowWithArtists>(shows: T[]): T[] {
+  const seen = new Map<string, T>()
+  for (const show of shows) {
+    const artistId = headlinerArtistId(show) ?? 0
+    const key = `${artistId}|${show.event_date}`
+    const existing = seen.get(key)
+    if (!existing || show.id < existing.id) {
+      seen.set(key, show)
+    }
+  }
+  const winners = new Set<number>()
+  for (const v of seen.values()) winners.add(v.id)
+  return shows.filter(s => winners.has(s.id))
+}

--- a/frontend/features/shows/utils.ts
+++ b/frontend/features/shows/utils.ts
@@ -1,20 +1,14 @@
 /**
- * dedupShowsByArtistVenueDateTime collapses literal-duplicate show
- * rows that share the same `(artist_id, venue_id, event_date+time)`
- * tuple. PSY-559.
+ * Render-time dedup helpers for show lists shown on artist + venue
+ * detail pages (PSY-559).
  *
- * The dedup key MUST include time (full ISO event_date), not just the
- * date — matinee + evening sets at the same venue on the same day are
- * NOT duplicates and must remain visible.
+ * The dedup key MUST include time (full ISO event_date), not just
+ * the date — matinee + evening sets at the same venue on the same
+ * day are NOT duplicates and must remain visible.
  *
- * Lowest-ID wins. Used as a render-time stopgap on artist + venue
- * detail pages so the visual fix lands even if the backend dedup cmd
- * (cmd/dedup-shows) hasn't been run on the target environment yet.
- *
- * Generic over T to work with both ArtistShowResponse (has top-level
- * `venue.id`) and VenueShowResponse (no venue field — venue is
- * implicit since the list is already scoped to one venue, so we key
- * on the headliner artist instead).
+ * Lowest-ID wins. Used as a stopgap so the visual fix lands even if
+ * the backend dedup cmd (`cmd/dedup-shows`) hasn't been run on the
+ * target environment yet.
  */
 
 interface ShowLike {
@@ -38,47 +32,51 @@ interface ShowWithArtists extends ShowLike {
   artists: ArtistInList[]
 }
 
-/**
- * Pick a stable headliner artist id for a show. Prefer
- * `set_type === 'headliner'`, then `is_headliner`, then position 0,
- * then the first artist. Returns null if the show has no artists.
- */
+// Pick a stable headliner artist id for a show. Prefer set_type, then
+// is_headliner, then position 0, then the first artist. Returns null
+// when the show has no artists.
 function headlinerArtistId(show: ShowWithArtists): number | null {
   if (!show.artists || show.artists.length === 0) {
     return null
   }
-  const byHeadlinerSetType = show.artists.find(a => a.set_type === 'headliner')
-  if (byHeadlinerSetType) return byHeadlinerSetType.id
-  const byHeadlinerFlag = show.artists.find(a => a.is_headliner === true)
-  if (byHeadlinerFlag) return byHeadlinerFlag.id
-  const byPosition = show.artists.find(a => a.position === 0)
-  if (byPosition) return byPosition.id
-  return show.artists[0].id
+  return (
+    show.artists.find(a => a.set_type === 'headliner')?.id ??
+    show.artists.find(a => a.is_headliner === true)?.id ??
+    show.artists.find(a => a.position === 0)?.id ??
+    show.artists[0].id
+  )
+}
+
+// Filter input to one row per dedup key, preserving input order.
+// Among collisions on the same key, the show with the lowest id wins.
+//
+// Map iteration order alone is not enough: a later row can replace an
+// earlier winner inside the Map and that mutation would shuffle the
+// rendered order relative to the API response. We collect winner ids
+// into a Set and re-filter the original array instead.
+function pickWinners<T extends ShowLike>(
+  shows: T[],
+  keyFor: (show: T) => string,
+): T[] {
+  const winnersByKey = new Map<string, T>()
+  for (const show of shows) {
+    const key = keyFor(show)
+    const existing = winnersByKey.get(key)
+    if (!existing || show.id < existing.id) {
+      winnersByKey.set(key, show)
+    }
+  }
+  const winnerIds = new Set<number>()
+  for (const v of winnersByKey.values()) winnerIds.add(v.id)
+  return shows.filter(s => winnerIds.has(s.id))
 }
 
 /**
  * Dedup shows on an ARTIST detail page. Each show carries its own
- * `venue.id`, so the key is `(venue.id, event_date)`. Lowest show.id
- * wins on collision.
+ * `venue.id`, so the key is `(venue.id, event_date)`.
  */
 export function dedupArtistShows<T extends ShowWithVenueAndArtists>(shows: T[]): T[] {
-  const seen = new Map<string, T>()
-  for (const show of shows) {
-    const venueId = show.venue?.id ?? 0
-    const key = `${venueId}|${show.event_date}`
-    const existing = seen.get(key)
-    if (!existing || show.id < existing.id) {
-      seen.set(key, show)
-    }
-  }
-  // Preserve input order: walk the original list and only keep entries
-  // whose id matches the winner for their key. (Map iteration order is
-  // insertion order, but a later collision can replace an earlier
-  // winner — that would shuffle the ordering relative to the API
-  // response. Filter from the original instead.)
-  const winners = new Set<number>()
-  for (const v of seen.values()) winners.add(v.id)
-  return shows.filter(s => winners.has(s.id))
+  return pickWinners(shows, show => `${show.venue?.id ?? 0}|${show.event_date}`)
 }
 
 /**
@@ -87,16 +85,5 @@ export function dedupArtistShows<T extends ShowWithVenueAndArtists>(shows: T[]):
  * Shows without artists keep their own bucket (key uses 0).
  */
 export function dedupVenueShows<T extends ShowWithArtists>(shows: T[]): T[] {
-  const seen = new Map<string, T>()
-  for (const show of shows) {
-    const artistId = headlinerArtistId(show) ?? 0
-    const key = `${artistId}|${show.event_date}`
-    const existing = seen.get(key)
-    if (!existing || show.id < existing.id) {
-      seen.set(key, show)
-    }
-  }
-  const winners = new Set<number>()
-  for (const v of seen.values()) winners.add(v.id)
-  return shows.filter(s => winners.has(s.id))
+  return pickWinners(shows, show => `${headlinerArtistId(show) ?? 0}|${show.event_date}`)
 }

--- a/frontend/features/venues/components/VenueShowsList.tsx
+++ b/frontend/features/venues/components/VenueShowsList.tsx
@@ -7,7 +7,11 @@ import { useAuthContext } from '@/lib/context/AuthContext'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
 import { Button } from '@/components/ui/button'
 import { ShowForm } from '@/components/forms/ShowForm'
-import { CompactShowRow, SHOW_LIST_FEATURE_POLICY } from '@/features/shows'
+import {
+  CompactShowRow,
+  SHOW_LIST_FEATURE_POLICY,
+  dedupVenueShows,
+} from '@/features/shows'
 
 interface VenueShowsListProps {
   venueId: number
@@ -66,11 +70,15 @@ function ShowsTabContent({
     )
   }
 
+  // PSY-559: Render-time dedup so duplicate shows sharing
+  // (artist_id, venue_id, event_date+time) collapse to one row even
+  // before the backend dedup cmd runs against this DB.
+  const visibleShows = dedupVenueShows(data.shows)
   const isPastShow = timeFilter === 'past'
 
   return (
     <div>
-      {data.shows.map(show => (
+      {visibleShows.map(show => (
         <CompactShowRow
           key={show.id}
           show={show}


### PR DESCRIPTION
## Summary

- **Layer 1 (durable backend dedup)**: new `cmd/dedup-shows` (`--dry-run` default, `--confirm` to apply) finds shows sharing `(artist_id, venue_id, event_date)` and merges by retaining earliest-`created_at`. Repoints all FKs (direct: `show_venues`, `show_artists`, `show_reports`, `enrichment_queue`, `shows.duplicate_of_show_id`; polymorphic `entity_type='show'`: `comments`, `comment_subscriptions`, `entity_tags`, `entity_reports`, `pending_entity_edits`, `revisions`, `requests.requested_entity_id`, `audit_logs`, `collection_items`, `user_bookmarks`) with conflict-aware semantics matching `tag_merge.go`. Per-cluster transactions so a partial run is safe to re-run.
- **Layer 3 (frontend render-time stopgap)**: `ArtistShowsList` + `VenueShowsList` dedup at render time via new `dedupArtistShows` / `dedupVenueShows` helpers (`features/shows/utils.ts`). Lowest-id wins. Visual fix lands even before the backend cmd has been run.
- **Dedup key includes time** (`event_date` is TIMESTAMPTZ; full timestamp matters), so matinee + evening sets at the same venue on the same day are NOT collapsed. Verified against `/artists/just-mustard` May 17 (1pm + 8pm at Valley Bar are distinct event_date timestamps).
- **Slug fix**: legacy migration-000019 backfill used `TO_CHAR(event_date, 'YYYY-MM-DD')` directly so shows with late-evening UTC timestamps got next-day slugs (show 64's `…2026-09-16` for an event_date of 2026-09-15 19:30 Phoenix → 02:30 UTC the 16th). New `RecanonicaliseShowSlug` re-derives via the existing timezone-aware `utils.GenerateShowSlug` and runs against each cluster winner during the `--confirm` pass.
- **CLAUDE.md updated**: dedup key + matinee/evening exception + slug bug origin captured in MEMORY.md (see "Show dedup key (PSY-559)" entry).

## Dry-run output (130 clusters in local dev DB, both ticket-cited pairs detected)

```
=== Show Dedup (DRY RUN) — PSY-559 ===

Found 130 duplicate cluster(s).

Cluster: artist=79, venue=12, event_date=2026-09-16T02:30:00Z
  Winner: show 64 (created 2025-11-29)
  Loser:  show 786 (created 2026-04-24)

Cluster: artist=113, venue=12, event_date=2025-04-11T03:00:00Z
  Winner: show 23 (created 2025-11-29)
  Loser:  show 745 (created 2026-04-24)
...
=== Summary ===
Clusters found:           130
Losers merged:            0
DRY RUN — no DB writes. Re-run with --confirm to apply.
```

`/artists/just-mustard` May 17 shows (id 460 matinee + id 63 evening, both at Valley Bar) do NOT appear in any cluster — confirming the matinee/evening exception holds.

## Out of scope

Adding a uniqueness index `(artist_id, venue_id, event_date)` is OUT OF SCOPE for this PR. Will be filed as a follow-up after this dedup completes cleanly on staging/prod.

## Test plan

- [ ] Run `go run ./backend/cmd/dedup-shows --env backend/.env.development` against a staging-quality DB and capture the dry-run output.
- [ ] Verify the Peter Hook (64 + 786) and Amyl (23 + 745) pairs from the ticket are in the cluster list.
- [ ] Re-run with `--confirm` on staging; verify the per-FK movement counts are non-zero in the final summary.
- [ ] Verify `/artists/peter-hook-and-the-light` and `/artists/amyl-and-the-sniffers` no longer render duplicate rows.
- [ ] Verify `/artists` "X upcoming" counts drop to expected values (Peter Hook should read "1 upcoming", not "2").
- [ ] Verify `/artists/just-mustard` May 17 still shows BOTH 1pm and 8pm Valley Bar shows.
- [ ] Verify show 64's slug post-merge is `2026-09-15-…` (canonical) rather than legacy `…2026-09-16`.
- [ ] Frontend dedup: deploy frontend and confirm artist + venue detail pages dedup even on a DB where the cmd has not yet been run.

Closes PSY-559