### PR TITLE
PSY-588: filter field notes out of comments list endpoint

### DIFF
--- a/backend/internal/services/contracts/comment.go
+++ b/backend/internal/services/contracts/comment.go
@@ -51,9 +51,13 @@ type FieldNoteStructuredData struct {
 type CommentListFilters struct {
 	Sort       string // best, new, top, controversial
 	Visibility string // visible, hidden_by_user, hidden_by_mod, pending_review, or empty for visible only
-	Kind       string // comment, field_note, or empty for all
-	Limit      int
-	Offset     int
+	// Kind: "comment", "field_note", or empty for the default ("comment").
+	// Field notes have a dedicated `/shows/{id}/field-notes` endpoint and must
+	// never leak into the discussion list (PSY-588). Callers that legitimately
+	// need both must request each kind separately.
+	Kind   string
+	Limit  int
+	Offset int
 }
 
 // ──────────────────────────────────────────────

--- a/backend/internal/services/engagement/comment_service.go
+++ b/backend/internal/services/engagement/comment_service.go
@@ -530,9 +530,13 @@ func (s *CommentService) ListCommentsForEntity(entityType string, entityID uint,
 		query = query.Where("visibility = ?", engagementm.CommentVisibilityVisible)
 	}
 
-	// Filter by kind
+	// Filter by kind (default: regular comments only — field notes have a
+	// dedicated /shows/{id}/field-notes endpoint and must not leak into
+	// the discussion list, PSY-588).
 	if filters.Kind != "" {
 		query = query.Where("kind = ?", filters.Kind)
+	} else {
+		query = query.Where("kind = ?", engagementm.CommentKindComment)
 	}
 
 	// Count total matching comments

--- a/backend/internal/services/engagement/comment_service.go
+++ b/backend/internal/services/engagement/comment_service.go
@@ -533,11 +533,11 @@ func (s *CommentService) ListCommentsForEntity(entityType string, entityID uint,
 	// Filter by kind (default: regular comments only — field notes have a
 	// dedicated /shows/{id}/field-notes endpoint and must not leak into
 	// the discussion list, PSY-588).
-	if filters.Kind != "" {
-		query = query.Where("kind = ?", filters.Kind)
-	} else {
-		query = query.Where("kind = ?", engagementm.CommentKindComment)
+	kind := engagementm.CommentKind(filters.Kind)
+	if kind == "" {
+		kind = engagementm.CommentKindComment
 	}
+	query = query.Where("kind = ?", kind)
 
 	// Count total matching comments
 	var total int64

--- a/backend/internal/services/engagement/comment_service_test.go
+++ b/backend/internal/services/engagement/comment_service_test.go
@@ -1022,6 +1022,38 @@ func (suite *CommentServiceIntegrationTestSuite) TestListComments_FilterByKind()
 	suite.Equal("field_note", result.Comments[0].Kind)
 }
 
+// PSY-588: when no kind filter is supplied, ListCommentsForEntity must return
+// ONLY rows with kind='comment'. Field notes have a dedicated endpoint and
+// previously leaked into the discussion list, causing the same row to render
+// twice on the show detail page (once correctly under "Field Notes", once
+// incorrectly under "Discussion" with edit/delete affordances exposed).
+func (suite *CommentServiceIntegrationTestSuite) TestListComments_DefaultKindExcludesFieldNotes() {
+	user := suite.createTestUser()
+	showID := suite.createTestShow("Default Kind Show")
+
+	// One regular comment + one field note on the same show.
+	suite.insertComment(user.ID, "show", showID, "Regular comment", nil, nil, 0)
+	fnComment := &engagementm.Comment{
+		EntityType:      engagementm.CommentEntityShow,
+		EntityID:        showID,
+		Kind:            engagementm.CommentKindFieldNote,
+		UserID:          user.ID,
+		Body:            "Field note body",
+		BodyHTML:        "<p>Field note body</p>",
+		Visibility:      engagementm.CommentVisibilityVisible,
+		ReplyPermission: engagementm.ReplyPermissionAnyone,
+	}
+	suite.Require().NoError(suite.db.Create(fnComment).Error)
+
+	// No kind filter → must return only the comment, never the field note.
+	result, err := suite.commentService.ListCommentsForEntity("show", showID, contracts.CommentListFilters{})
+	suite.Require().NoError(err)
+	suite.Equal(int64(1), result.Total)
+	suite.Require().Len(result.Comments, 1)
+	suite.Equal(string(engagementm.CommentKindComment), result.Comments[0].Kind)
+	suite.Equal("Regular comment", result.Comments[0].Body)
+}
+
 func (suite *CommentServiceIntegrationTestSuite) TestListComments_HiddenNotVisible() {
 	user := suite.createTestUser()
 	artistID := suite.createTestArtist("Hidden Artist")


### PR DESCRIPTION
## Summary
- `ListCommentsForEntity` defaulted to no kind filter when callers didn't specify one, so `GET /entities/show/{id}/comments` returned both `comment` and `field_note` rows. The frontend already had a dedicated `/shows/{id}/field-notes` endpoint, so a single field note rendered twice on the show detail page — once correctly under "Field Notes", once incorrectly under "Discussion" with edit/delete affordances exposed (a footgun: a confused user could delete their field note from the wrong section).
- Default the kind filter to `engagementm.CommentKindComment` when the caller doesn't specify, so the route name (`/comments`) actually returns comments. Field notes continue to flow through `ListFieldNotesForShow`, which already filtered correctly. Updated the contract docstring on `CommentListFilters.Kind` to reflect that empty no longer means "all".
- Added a backend integration test (`TestListComments_DefaultKindExcludesFieldNotes`) that posts one comment + one field note on the same show, calls the list endpoint with no kind filter, and asserts only the comment comes back. The existing `TestListFieldNotesForShow_OnlyFieldNotes` already covers the symmetric case.

## Test plan
- [ ] `cd backend && go test ./internal/services/engagement/...` — all comment + field-note suites pass (verified locally)
- [ ] On `/shows/62` (or any past show), sign in as admin, post a field note, and confirm "Field Notes (1)" appears with the structured-data card AND "Discussion (0)" — the duplicate Discussion entry should no longer appear.
- [ ] Post a regular comment on the same show afterward; confirm "Field Notes (1)" stays at 1 and "Discussion (1)" now shows the comment (not the field note body).
- [ ] Sanity-check the dedicated field-notes endpoint still returns the field note (it filters by kind explicitly and is unchanged).

Closes PSY-588