### PR TITLE
PSY-578: collection-report taxonomy + admin gate

### DIFF
--- a/backend/internal/api/handlers/community/entity_report_test.go
+++ b/backend/internal/api/handlers/community/entity_report_test.go
@@ -179,8 +179,9 @@ func TestReportShow_Success(t *testing.T) {
 	}
 }
 
-// PSY-357: collections accept the same shape as the other entity types and
-// reuse the comment vocabulary (spam/harassment/off_topic/inaccurate/other).
+// PSY-357: collections accept the same shape as the other entity types.
+// PSY-578: collection-specific taxonomy is spam/inappropriate/misleading/other
+// (diverges from the comment vocabulary — see entity_report.go for rationale).
 func TestReportCollection_Success(t *testing.T) {
 	expected := makeEntityReportResponse(5, "collection", "spam")
 	h := NewEntityReportHandler(

--- a/backend/internal/models/community/entity_report.go
+++ b/backend/internal/models/community/entity_report.go
@@ -61,15 +61,21 @@ var validReportTypes = map[string]map[string]bool{
 		"inaccurate": true,
 		"other":      true,
 	},
-	// PSY-357: collections reuse the comment vocabulary verbatim.
-	// Both are user-generated content surfaces where the abuse vectors
-	// (spam/harassment/off-topic/inaccurate/other) are the same shape.
+	// PSY-578: collection-specific taxonomy. Diverges from the comment set
+	// because curated lists have different abuse vectors:
+	//   - Harassment: rare on a list of items vs. on a personal message;
+	//     when present, "Inappropriate" covers it.
+	//   - Off Topic: doesn't fit a curated list (the curator chose the
+	//     items; "off topic" is a category complaint, not a moderation
+	//     issue).
+	// Replaces both with:
+	//   - Inappropriate: NSFW cover image, hateful theme, etc.
+	//   - Misleading: false claims in description / item notes.
 	EntityReportEntityCollection: {
-		"spam":       true,
-		"harassment": true,
-		"off_topic":  true,
-		"inaccurate": true,
-		"other":      true,
+		"spam":          true,
+		"inappropriate": true,
+		"misleading":    true,
+		"other":         true,
 	},
 }
 

--- a/backend/internal/services/admin/entity_report_test.go
+++ b/backend/internal/services/admin/entity_report_test.go
@@ -55,12 +55,15 @@ func TestEntityReportModel_Validation(t *testing.T) {
 	assert.True(t, communitym.IsValidReportType("show", "wrong_date"))
 	assert.False(t, communitym.IsValidReportType("show", "removal_request"))
 
-	// PSY-357: collection reuses the comment vocabulary verbatim.
+	// PSY-578: collection-specific taxonomy.
 	assert.True(t, communitym.IsValidReportType("collection", "spam"))
-	assert.True(t, communitym.IsValidReportType("collection", "harassment"))
-	assert.True(t, communitym.IsValidReportType("collection", "off_topic"))
-	assert.True(t, communitym.IsValidReportType("collection", "inaccurate"))
+	assert.True(t, communitym.IsValidReportType("collection", "inappropriate"))
+	assert.True(t, communitym.IsValidReportType("collection", "misleading"))
 	assert.True(t, communitym.IsValidReportType("collection", "other"))
+	// Legacy comment-vocabulary types no longer accepted for collections.
+	assert.False(t, communitym.IsValidReportType("collection", "harassment"))
+	assert.False(t, communitym.IsValidReportType("collection", "off_topic"))
+	assert.False(t, communitym.IsValidReportType("collection", "inaccurate"))
 	assert.False(t, communitym.IsValidReportType("collection", "cancelled"))
 	assert.False(t, communitym.IsValidReportType("collection", "wrong_image"))
 
@@ -81,8 +84,9 @@ func TestValidReportTypesForEntity(t *testing.T) {
 	showTypes := communitym.ValidReportTypesForEntity("show")
 	assert.Len(t, showTypes, 5)
 
+	// PSY-578: collection has 4 types (spam/inappropriate/misleading/other).
 	collectionTypes := communitym.ValidReportTypesForEntity("collection")
-	assert.Len(t, collectionTypes, 5)
+	assert.Len(t, collectionTypes, 4)
 
 	unknownTypes := communitym.ValidReportTypesForEntity("release")
 	assert.Nil(t, unknownTypes)

--- a/frontend/features/collections/components/CollectionDetail.test.tsx
+++ b/frontend/features/collections/components/CollectionDetail.test.tsx
@@ -5,7 +5,14 @@ import { CollectionDetail } from './CollectionDetail'
 import type { CollectionDetail as CollectionDetailType } from '../types'
 
 // Mock AuthContext
-const mockAuthContext = vi.fn(() => ({
+type MockAuthUser = { id: string; is_admin?: boolean } | null
+type MockAuthValue = {
+  user: MockAuthUser
+  isAuthenticated: boolean
+  isLoading: boolean
+  logout: () => void
+}
+const mockAuthContext = vi.fn<() => MockAuthValue>(() => ({
   user: { id: '1' },
   isAuthenticated: true,
   isLoading: false,
@@ -733,6 +740,89 @@ describe('CollectionDetail', () => {
       await user.click(screen.getByTestId('collection-like-button'))
       expect(mockUnlikeMutate).toHaveBeenCalledWith({ slug: 'test-collection' })
       expect(mockLikeMutate).not.toHaveBeenCalled()
+    })
+  })
+
+  // ──────────────────────────────────────────────
+  // PSY-578: report button visibility on collection header
+  // ──────────────────────────────────────────────
+
+  describe('PSY-578 report button visibility', () => {
+    it('renders Report for an authenticated non-creator non-admin', () => {
+      mockAuthContext.mockReturnValue({
+        user: { id: '999', is_admin: false },
+        isAuthenticated: true,
+        isLoading: false,
+        logout: vi.fn(),
+      })
+      mockCollection.mockReturnValue({
+        data: makeCollection({ creator_id: 1 }),
+        isLoading: false,
+        error: null,
+      })
+      render(<CollectionDetail slug="test-collection" />)
+
+      expect(
+        screen.getByTestId('collection-report-button')
+      ).toBeInTheDocument()
+    })
+
+    it('hides Report for the collection creator', () => {
+      // Creator uses Edit / Delete instead of Report.
+      mockAuthContext.mockReturnValue({
+        user: { id: '1', is_admin: false },
+        isAuthenticated: true,
+        isLoading: false,
+        logout: vi.fn(),
+      })
+      mockCollection.mockReturnValue({
+        data: makeCollection({ creator_id: 1 }),
+        isLoading: false,
+        error: null,
+      })
+      render(<CollectionDetail slug="test-collection" />)
+
+      expect(
+        screen.queryByTestId('collection-report-button')
+      ).not.toBeInTheDocument()
+    })
+
+    it('hides Report for admins (they use the moderation queue)', () => {
+      mockAuthContext.mockReturnValue({
+        user: { id: '999', is_admin: true },
+        isAuthenticated: true,
+        isLoading: false,
+        logout: vi.fn(),
+      })
+      mockCollection.mockReturnValue({
+        data: makeCollection({ creator_id: 1 }),
+        isLoading: false,
+        error: null,
+      })
+      render(<CollectionDetail slug="test-collection" />)
+
+      expect(
+        screen.queryByTestId('collection-report-button')
+      ).not.toBeInTheDocument()
+    })
+
+    it('hides Report for unauthenticated viewers', () => {
+      mockAuthContext.mockReturnValue({
+        user: null,
+        isAuthenticated: false,
+        isLoading: false,
+        logout: vi.fn(),
+      })
+      mockCollection.mockReturnValue({
+        data: makeCollection({ creator_id: 1 }),
+        isLoading: false,
+        error: null,
+      })
+      render(<CollectionDetail slug="test-collection" />)
+
+      expect(
+        screen.queryByTestId('collection-report-button')
+      ).not.toBeInTheDocument()
     })
   })
 

--- a/frontend/features/collections/components/CollectionDetail.tsx
+++ b/frontend/features/collections/components/CollectionDetail.tsx
@@ -263,11 +263,18 @@ export function CollectionDetail({ slug }: CollectionDetailProps) {
 
   const currentUserId = user?.id ? Number(user.id) : undefined
   const isCreator = currentUserId === collection.creator_id
+  const isAdmin = user?.is_admin === true
   const canSubscribe = isAuthenticated && !isCreator
   // PSY-351: per ticket, the clone button is hidden on the user's own
   // collections (you wouldn't fork yourself). Anyone else who is
   // authenticated may clone any public collection.
   const canClone = isAuthenticated && !isCreator && collection.is_public
+  // PSY-578: Report button is for community members. Admins use the
+  // moderation queue instead, so the trigger is suppressed for them
+  // (acceptance criterion: "Admin sees their existing Edit/Delete
+  // buttons (no Report button — they use the moderation queue)").
+  // Owners can't report themselves either.
+  const canReport = isAuthenticated && !isCreator && !isAdmin
 
   // PSY-351 attribution state.
   // - forkedFromInfo set + collection.forked_from_collection_id set →
@@ -609,14 +616,12 @@ export function CollectionDetail({ slug }: CollectionDetailProps) {
                   </Button>
                 )}
 
-                {/* PSY-357: report a collection. Mirrors the Report button
-                    on artist/venue/festival/show detail pages. Only shown
-                    to authenticated non-owners — owners shouldn't report
-                    themselves, and unauthenticated viewers see no trigger
-                    (consistent with the comment-report pattern; the
-                    dialog opens directly so we don't need the
-                    LoginPromptDialog dance here). */}
-                {isAuthenticated && !isCreator && (
+                {/* PSY-357 / PSY-578: report a collection. Mirrors the
+                    Report button on artist/venue/festival/show detail
+                    pages. Visible to authenticated non-creators who are
+                    not admins (admins moderate via the queue, see
+                    canReport). */}
+                {canReport && (
                   <Button
                     variant="outline"
                     size="sm"
@@ -699,16 +704,20 @@ export function CollectionDetail({ slug }: CollectionDetailProps) {
       {/* Discussion */}
       <CommentThread entityType="collection" entityId={collection.id} />
 
-      {/* PSY-357: report dialog. Only mounted when the caller is allowed
-          to report (authenticated non-owner) so we don't ship the dialog
-          tree to viewers who can't open it. */}
-      {isAuthenticated && !isCreator && (
+      {/* PSY-357 / PSY-578: report dialog. Only mounted when the caller
+          is allowed to report (matches `canReport` above) so we don't
+          ship the dialog tree to viewers who can't open it. The
+          `entityTypeLabel` makes the dialog copy explicit ("Report Issue
+          with collection 'X'") rather than the bare entity-name fallback
+          used by other entity reports. */}
+      {canReport && (
         <ReportEntityDialog
           open={isReportOpen}
           onOpenChange={setIsReportOpen}
           entityType="collection"
           entityId={collection.id}
           entityName={collection.title}
+          entityTypeLabel="collection"
         />
       )}
 

--- a/frontend/features/collections/components/CollectionDetail.tsx
+++ b/frontend/features/collections/components/CollectionDetail.tsx
@@ -269,11 +269,8 @@ export function CollectionDetail({ slug }: CollectionDetailProps) {
   // collections (you wouldn't fork yourself). Anyone else who is
   // authenticated may clone any public collection.
   const canClone = isAuthenticated && !isCreator && collection.is_public
-  // PSY-578: Report button is for community members. Admins use the
-  // moderation queue instead, so the trigger is suppressed for them
-  // (acceptance criterion: "Admin sees their existing Edit/Delete
-  // buttons (no Report button — they use the moderation queue)").
-  // Owners can't report themselves either.
+  // PSY-578: admins moderate via the queue, so they don't need (or get)
+  // the Report trigger here. Creators are excluded for the obvious reason.
   const canReport = isAuthenticated && !isCreator && !isAdmin
 
   // PSY-351 attribution state.
@@ -616,11 +613,8 @@ export function CollectionDetail({ slug }: CollectionDetailProps) {
                   </Button>
                 )}
 
-                {/* PSY-357 / PSY-578: report a collection. Mirrors the
-                    Report button on artist/venue/festival/show detail
-                    pages. Visible to authenticated non-creators who are
-                    not admins (admins moderate via the queue, see
-                    canReport). */}
+                {/* PSY-578: report a collection. Mirrors the Report
+                    button on artist/venue/festival/show detail pages. */}
                 {canReport && (
                   <Button
                     variant="outline"
@@ -704,12 +698,10 @@ export function CollectionDetail({ slug }: CollectionDetailProps) {
       {/* Discussion */}
       <CommentThread entityType="collection" entityId={collection.id} />
 
-      {/* PSY-357 / PSY-578: report dialog. Only mounted when the caller
-          is allowed to report (matches `canReport` above) so we don't
-          ship the dialog tree to viewers who can't open it. The
-          `entityTypeLabel` makes the dialog copy explicit ("Report Issue
-          with collection 'X'") rather than the bare entity-name fallback
-          used by other entity reports. */}
+      {/* Mounted only when `canReport` so we don't ship the dialog tree
+          to viewers who can't open it. `entityTypeLabel="collection"`
+          makes the modal copy explicit ("Report Issue with collection
+          'X'") rather than the bare entity-name fallback. */}
       {canReport && (
         <ReportEntityDialog
           open={isReportOpen}

--- a/frontend/features/contributions/components/ReportEntityDialog.tsx
+++ b/frontend/features/contributions/components/ReportEntityDialog.tsx
@@ -22,7 +22,20 @@ interface ReportEntityDialogProps {
   onOpenChange: (open: boolean) => void
   entityType: ReportableEntityType
   entityId: number
+  /**
+   * Display name for the entity being reported. The dialog quotes this
+   * verbatim ("Report Issue with 'X'"), so callers should pass the
+   * thing the viewer would recognise — collection title, artist name,
+   * "Comment by Foo", etc. — not a raw ID.
+   */
   entityName: string
+  /**
+   * Optional human-readable type label inserted before the entity name
+   * (e.g. `entityTypeLabel="collection"` yields "Report Issue with
+   * collection 'X'"). Omit when the entity name is already
+   * self-describing (e.g. "Comment by Foo"). PSY-578.
+   */
+  entityTypeLabel?: string
 }
 
 export function ReportEntityDialog({
@@ -31,6 +44,7 @@ export function ReportEntityDialog({
   entityType,
   entityId,
   entityName,
+  entityTypeLabel,
 }: ReportEntityDialogProps) {
   const [selectedType, setSelectedType] = useState<string | null>(null)
   const [details, setDetails] = useState('')
@@ -83,8 +97,17 @@ export function ReportEntityDialog({
             Report Issue
           </DialogTitle>
           <DialogDescription>
-            Report an issue with &quot;{entityName}&quot;. Our team will review
-            your report.
+            {entityTypeLabel ? (
+              <>
+                Report an issue with {entityTypeLabel} &quot;{entityName}&quot;.
+                Our team will review your report.
+              </>
+            ) : (
+              <>
+                Report an issue with &quot;{entityName}&quot;. Our team will
+                review your report.
+              </>
+            )}
           </DialogDescription>
         </DialogHeader>
 

--- a/frontend/features/contributions/components/ReportEntityDialog.tsx
+++ b/frontend/features/contributions/components/ReportEntityDialog.tsx
@@ -97,17 +97,8 @@ export function ReportEntityDialog({
             Report Issue
           </DialogTitle>
           <DialogDescription>
-            {entityTypeLabel ? (
-              <>
-                Report an issue with {entityTypeLabel} &quot;{entityName}&quot;.
-                Our team will review your report.
-              </>
-            ) : (
-              <>
-                Report an issue with &quot;{entityName}&quot;. Our team will
-                review your report.
-              </>
-            )}
+            Report an issue with {entityTypeLabel ? `${entityTypeLabel} ` : ''}
+            &quot;{entityName}&quot;. Our team will review your report.
           </DialogDescription>
         </DialogHeader>
 

--- a/frontend/features/contributions/types.ts
+++ b/frontend/features/contributions/types.ts
@@ -130,13 +130,15 @@ export const REPORT_TYPES: Record<ReportableEntityType, ReportTypeOption[]> = {
     { value: 'inaccurate', label: 'Inaccurate', description: 'This comment contains incorrect information' },
     { value: 'other', label: 'Other', description: 'Another issue not listed above' },
   ],
-  // PSY-357: collection reuses the comment vocabulary verbatim — both are
-  // user-generated content surfaces with the same abuse vectors.
+  // PSY-578: collection-specific taxonomy (diverges from comment vocab —
+  // "Harassment" rarely fits a curated list, "Off Topic" is a category
+  // complaint not a moderation issue, and "Inaccurate" doesn't capture the
+  // common cases). Aligned with the backend allow list in
+  // backend/internal/models/community/entity_report.go.
   collection: [
     { value: 'spam', label: 'Spam', description: 'This collection is spam or advertising' },
-    { value: 'harassment', label: 'Harassment', description: 'This collection is abusive or harassing' },
-    { value: 'off_topic', label: 'Off Topic', description: 'This collection is irrelevant or misplaced' },
-    { value: 'inaccurate', label: 'Inaccurate', description: 'This collection contains incorrect information' },
+    { value: 'inappropriate', label: 'Inappropriate', description: 'NSFW cover, hateful theme, or abusive content' },
+    { value: 'misleading', label: 'Misleading', description: 'False claims in the description or item notes' },
     { value: 'other', label: 'Other', description: 'Another issue not listed above' },
   ],
 }


### PR DESCRIPTION
## Summary
- Replace the comment-vocab collection report types (spam/harassment/off_topic/inaccurate/other) with the ticket-decided taxonomy: **spam / inappropriate / misleading / other**. Backend allow list + frontend `REPORT_TYPES.collection` updated together.
- Add an admin gate to the Report button on the collection detail page. New `canReport` predicate (`isAuthenticated && !isCreator && !isAdmin`) replaces the previous `isAuthenticated && !isCreator` so admins moderate via the queue, not the in-page report flow (per acceptance criterion).
- Surface an optional `entityTypeLabel` prop on `ReportEntityDialog` so the collection caller renders "Report Issue with collection 'X'" without the comment-report site (`Comment by Foo`) regressing.

## Test plan
- [ ] Sign in as a regular non-admin user, open a collection you don't own — Report button visible next to Fork.
- [ ] Click Report — modal title says "Report Issue with collection 'X'", reasons are Spam / Inappropriate / Misleading / Other.
- [ ] Submit with each reason — request 200s; row appears in `entity_reports` with `entity_type = 'collection'` and the chosen `report_type`.
- [ ] Sign in as the collection's creator — Report button is hidden, Edit / Delete still shown.
- [ ] Sign in as an admin viewing someone else's collection — Report button is hidden.
- [ ] Sign out — Report button is hidden.
- [ ] Visit `/admin/moderation` as admin — the new collection report appears in the queue.
- [ ] Open a comment-report modal on any commented entity — title still says "Report Issue with 'Comment by Foo'" (regression check on the new optional prop).

Closes PSY-578