### PR TITLE
PSY-589: surface comment 429 rate-limit inline

### DIFF
--- a/backend/internal/api/handlers/engagement/comment.go
+++ b/backend/internal/api/handlers/engagement/comment.go
@@ -3,6 +3,7 @@ package engagement
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strconv"
 	"strings"
 
@@ -13,6 +14,23 @@ import (
 	authm "psychic-homily-backend/internal/models/auth"
 	"psychic-homily-backend/internal/services/contracts"
 )
+
+// rateLimited429 wraps a 429 service-layer error with a `Retry-After` header
+// per RFC 7231 §7.1.3 so clients can populate countdown copy without parsing
+// the body. The per-entity cooldown is 60s; the global hourly cap is bounded
+// by 3600s (clients should treat the hourly variant as a soft upper bound).
+// Both branches share the same handler wrapping so reply/top-level/field-note
+// surfaces stay consistent.
+func rateLimited429(err error) error {
+	retryAfter := "60"
+	if strings.Contains(err.Error(), "hourly comment limit") {
+		retryAfter = "3600"
+	}
+	return huma.ErrorWithHeaders(
+		huma.Error429TooManyRequests(err.Error()),
+		http.Header{"Retry-After": []string{retryAfter}},
+	)
+}
 
 // ============================================================================
 // Focused interfaces for dependency injection
@@ -284,7 +302,7 @@ func (h *CommentHandler) CreateCommentHandler(ctx context.Context, req *CreateCo
 			return nil, huma.Error400BadRequest(err.Error())
 		}
 		if strings.Contains(err.Error(), "please wait") || strings.Contains(err.Error(), "hourly comment limit") {
-			return nil, huma.Error429TooManyRequests(err.Error())
+			return nil, rateLimited429(err)
 		}
 		requestID := logger.GetRequestID(ctx)
 		return nil, huma.Error500InternalServerError(
@@ -380,7 +398,7 @@ func (h *CommentHandler) CreateReplyHandler(ctx context.Context, req *CreateRepl
 			return nil, huma.Error404NotFound(err.Error())
 		}
 		if strings.Contains(err.Error(), "please wait") || strings.Contains(err.Error(), "hourly comment limit") {
-			return nil, huma.Error429TooManyRequests(err.Error())
+			return nil, rateLimited429(err)
 		}
 		requestID := logger.GetRequestID(ctx)
 		return nil, huma.Error500InternalServerError(

--- a/backend/internal/api/handlers/engagement/comment_admin_test.go
+++ b/backend/internal/api/handlers/engagement/comment_admin_test.go
@@ -2,14 +2,32 @@ package engagement
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
+
+	"github.com/danielgtaylor/huma/v2"
 
 	"psychic-homily-backend/internal/api/handlers/shared/testhelpers"
 	authm "psychic-homily-backend/internal/models/auth"
 	"psychic-homily-backend/internal/services/contracts"
 )
+
+// assertRetryAfter asserts that a 429-class error carries the expected
+// `Retry-After` header. RFC 7231 §7.1.3 requires it on a 429 so clients
+// can populate countdown copy without parsing the body.
+func assertRetryAfter(t *testing.T, err error, expected string) {
+	t.Helper()
+	var he huma.HeadersError
+	if !errors.As(err, &he) {
+		t.Fatalf("expected error with headers, got %T: %v", err, err)
+	}
+	got := he.GetHeaders().Get("Retry-After")
+	if got != expected {
+		t.Errorf("Retry-After = %q, want %q", got, expected)
+	}
+}
 
 // ============================================================================
 // Test helpers
@@ -329,6 +347,7 @@ func TestCreateComment_RateLimitError(t *testing.T) {
 	req.Body.Body = "Hello"
 	_, err := h.CreateCommentHandler(commentUserCtx(), req)
 	testhelpers.AssertHumaError(t, err, 429)
+	assertRetryAfter(t, err, "60")
 }
 
 func TestCreateComment_HourlyLimitError(t *testing.T) {
@@ -342,6 +361,26 @@ func TestCreateComment_HourlyLimitError(t *testing.T) {
 	req.Body.Body = "Hello"
 	_, err := h.CreateCommentHandler(commentUserCtx(), req)
 	testhelpers.AssertHumaError(t, err, 429)
+	assertRetryAfter(t, err, "3600")
+}
+
+// PSY-589: reply path should also surface Retry-After so the inline 429
+// banner on the reply form can populate countdown copy.
+func TestCreateReply_RateLimitError_HasRetryAfter(t *testing.T) {
+	mock := &testhelpers.MockCommentService{
+		GetCommentFn: func(id uint) (*contracts.CommentResponse, error) {
+			return makeCommentResponse(id, "show", 1, 99), nil
+		},
+		CreateCommentFn: func(userID uint, req *contracts.CreateCommentRequest) (*contracts.CommentResponse, error) {
+			return nil, fmt.Errorf("please wait 60 seconds between comments on the same entity")
+		},
+	}
+	h := NewCommentHandler(mock, mock, nil, nil)
+	req := &CreateReplyRequest{CommentID: "5"}
+	req.Body.Body = "Hello"
+	_, err := h.CreateReplyHandler(commentUserCtx(), req)
+	testhelpers.AssertHumaError(t, err, 429)
+	assertRetryAfter(t, err, "60")
 }
 
 // ============================================================================

--- a/backend/internal/api/handlers/engagement/field_note.go
+++ b/backend/internal/api/handlers/engagement/field_note.go
@@ -111,7 +111,7 @@ func (h *FieldNoteHandler) CreateFieldNoteHandler(ctx context.Context, req *Crea
 			return nil, huma.Error400BadRequest(err.Error())
 		}
 		if strings.Contains(err.Error(), "please wait") || strings.Contains(err.Error(), "hourly comment limit") {
-			return nil, huma.Error429TooManyRequests(err.Error())
+			return nil, rateLimited429(err)
 		}
 		requestID := logger.GetRequestID(ctx)
 		return nil, huma.Error500InternalServerError(

--- a/frontend/features/comments/components/CommentCard.test.tsx
+++ b/frontend/features/comments/components/CommentCard.test.tsx
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { CommentCard } from './CommentCard'
 import type { Comment } from '../types'
 
@@ -16,16 +16,23 @@ vi.mock('@/lib/context/AuthContext', () => ({
 }))
 
 const defaultMutationReturn = { mutate: vi.fn(), isPending: false }
+const mockUseReplyToComment = vi.fn()
 
-vi.mock('../hooks', () => ({
-  useReplyToComment: () => defaultMutationReturn,
-  useUpdateComment: () => defaultMutationReturn,
-  useUpdateReplyPermission: () => defaultMutationReturn,
-  useDeleteComment: () => defaultMutationReturn,
-  useVoteComment: () => defaultMutationReturn,
-  useUnvoteComment: () => defaultMutationReturn,
-  useCommentThread: () => ({ data: undefined }),
-}))
+vi.mock('../hooks', async () => {
+  // Bring through formatCommentSubmissionError (PSY-589) so the form
+  // renders the same banner copy in tests as it does in the real card.
+  const actual = await vi.importActual<typeof import('../hooks')>('../hooks')
+  return {
+    useReplyToComment: () => mockUseReplyToComment(),
+    useUpdateComment: () => defaultMutationReturn,
+    useUpdateReplyPermission: () => defaultMutationReturn,
+    useDeleteComment: () => defaultMutationReturn,
+    useVoteComment: () => defaultMutationReturn,
+    useUnvoteComment: () => defaultMutationReturn,
+    useCommentThread: () => ({ data: undefined }),
+    formatCommentSubmissionError: actual.formatCommentSubmissionError,
+  }
+})
 
 vi.mock('@/features/contributions', () => ({
   ReportEntityDialog: () => null,
@@ -64,6 +71,7 @@ function makeComment(overrides: Partial<Comment> = {}): Comment {
 describe('CommentCard — admin edit history trigger (PSY-297)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockUseReplyToComment.mockReturnValue(defaultMutationReturn)
   })
 
   const defaultProps = {
@@ -134,6 +142,7 @@ describe('CommentCard — admin edit history trigger (PSY-297)', () => {
 describe('CommentCard — pending review badge (PSY-513)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockUseReplyToComment.mockReturnValue(defaultMutationReturn)
   })
 
   const defaultProps = {
@@ -347,5 +356,48 @@ describe('CommentCard — author byline linkability (PSY-552)', () => {
 
     expect(screen.getByTestId('comment-author-name')).toBeInTheDocument()
     expect(screen.queryByTestId('comment-author-link')).not.toBeInTheDocument()
+  })
+})
+
+// PSY-589: reply form must surface 429 inline, not silently clear.
+describe('CommentCard — reply rate-limit banner (PSY-589)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseReplyToComment.mockReturnValue(defaultMutationReturn)
+  })
+
+  const defaultProps = {
+    entityType: 'artist',
+    entityId: 10,
+  }
+
+  it('renders inline 429 banner with countdown copy when reply mutation rate-limits', () => {
+    const err = Object.assign(
+      new Error('please wait 60 seconds between comments on the same entity'),
+      { status: 429, retryAfter: 60 }
+    )
+    mockUseReplyToComment.mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+      error: err,
+    })
+    mockAuthContext.mockReturnValue({
+      isAuthenticated: true,
+      user: { id: '7', email: 'rate@example.com' },
+    })
+
+    render(
+      <CommentCard
+        {...defaultProps}
+        comment={makeComment({ user_id: 99, edit_count: 0, is_edited: false })}
+      />
+    )
+
+    // Open the reply form.
+    fireEvent.click(screen.getByText('Reply'))
+
+    const banner = screen.getByTestId('comment-form-error')
+    expect(banner).toBeInTheDocument()
+    expect(banner).toHaveTextContent('Please wait 60s before commenting again.')
   })
 })

--- a/frontend/features/comments/components/CommentCard.tsx
+++ b/frontend/features/comments/components/CommentCard.tsx
@@ -19,6 +19,7 @@ import {
   useVoteComment,
   useUnvoteComment,
   useCommentThread,
+  formatCommentSubmissionError,
 } from '../hooks'
 import {
   REPLY_PERMISSION_BADGE_LABELS,
@@ -54,6 +55,11 @@ export function CommentCard({
   // PSY-297: admin edit history viewer. Gated by is_admin and only fetched
   // when the dialog is opened (hook is `enabled` on open).
   const [isEditHistoryOpen, setIsEditHistoryOpen] = useState(false)
+  // PSY-589: bumped on a successful reply submission so the reply form
+  // clears its textarea. The form is also closed on success below; the
+  // reset is belt-and-suspenders for the case where future code path
+  // keeps the form mounted across submits.
+  const [replyGeneration, setReplyGeneration] = useState(0)
 
   const replyMutation = useReplyToComment()
   const updateMutation = useUpdateComment()
@@ -88,7 +94,15 @@ export function CommentCard({
         entityId,
         replyPermission,
       },
-      { onSuccess: () => setIsReplying(false) }
+      {
+        onSuccess: () => {
+          setIsReplying(false)
+          // PSY-589: clear the reply form on success. On 4xx the form
+          // stays open with the draft intact and the inline banner
+          // shown so the user can fix and retry.
+          setReplyGeneration((g) => g + 1)
+        },
+      }
     )
   }
 
@@ -364,6 +378,8 @@ export function CommentCard({
             submitLabel="Reply"
             onCancel={() => setIsReplying(false)}
             isPending={replyMutation.isPending}
+            errorMessage={formatCommentSubmissionError(replyMutation.error)}
+            resetSignal={replyGeneration}
           />
         </div>
       )}

--- a/frontend/features/comments/components/CommentCard.tsx
+++ b/frontend/features/comments/components/CommentCard.tsx
@@ -55,11 +55,6 @@ export function CommentCard({
   // PSY-297: admin edit history viewer. Gated by is_admin and only fetched
   // when the dialog is opened (hook is `enabled` on open).
   const [isEditHistoryOpen, setIsEditHistoryOpen] = useState(false)
-  // PSY-589: bumped on a successful reply submission so the reply form
-  // clears its textarea. The form is also closed on success below; the
-  // reset is belt-and-suspenders for the case where future code path
-  // keeps the form mounted across submits.
-  const [replyGeneration, setReplyGeneration] = useState(0)
 
   const replyMutation = useReplyToComment()
   const updateMutation = useUpdateComment()
@@ -94,15 +89,10 @@ export function CommentCard({
         entityId,
         replyPermission,
       },
-      {
-        onSuccess: () => {
-          setIsReplying(false)
-          // PSY-589: clear the reply form on success. On 4xx the form
-          // stays open with the draft intact and the inline banner
-          // shown so the user can fix and retry.
-          setReplyGeneration((g) => g + 1)
-        },
-      }
+      // On success, the form unmounts (clearing its draft); on error
+      // (e.g. 429 — PSY-589), it stays open with the inline banner so the
+      // user can retry without retyping.
+      { onSuccess: () => setIsReplying(false) }
     )
   }
 
@@ -379,7 +369,6 @@ export function CommentCard({
             onCancel={() => setIsReplying(false)}
             isPending={replyMutation.isPending}
             errorMessage={formatCommentSubmissionError(replyMutation.error)}
-            resetSignal={replyGeneration}
           />
         </div>
       )}

--- a/frontend/features/comments/components/CommentForm.test.tsx
+++ b/frontend/features/comments/components/CommentForm.test.tsx
@@ -26,7 +26,7 @@ describe('CommentForm', () => {
     expect(screen.getByTestId('comment-submit')).not.toBeDisabled()
   })
 
-  it('calls onSubmit with trimmed body and clears textarea', () => {
+  it('calls onSubmit with trimmed body but does NOT clear textarea (PSY-589 — clear is parent-driven via resetSignal)', () => {
     const handleSubmit = vi.fn()
     render(<CommentForm onSubmit={handleSubmit} />)
 
@@ -36,6 +36,28 @@ describe('CommentForm', () => {
     fireEvent.click(screen.getByTestId('comment-submit'))
 
     expect(handleSubmit).toHaveBeenCalledWith('Great show!', undefined)
+    // PSY-589: form keeps the draft. Parent clears via resetSignal on
+    // mutation success so 4xx errors don't discard typed text.
+    expect(screen.getByTestId('comment-textarea')).toHaveValue('  Great show!  ')
+  })
+
+  it('clears textarea when parent bumps resetSignal (PSY-589)', () => {
+    const handleSubmit = vi.fn()
+    const { rerender } = render(
+      <CommentForm onSubmit={handleSubmit} resetSignal={0} />
+    )
+
+    fireEvent.change(screen.getByTestId('comment-textarea'), {
+      target: { value: 'Great show!' },
+    })
+    fireEvent.click(screen.getByTestId('comment-submit'))
+
+    expect(handleSubmit).toHaveBeenCalledWith('Great show!', undefined)
+    // Pre-bump: draft preserved.
+    expect(screen.getByTestId('comment-textarea')).toHaveValue('Great show!')
+
+    // Parent signals success.
+    rerender(<CommentForm onSubmit={handleSubmit} resetSignal={1} />)
     expect(screen.getByTestId('comment-textarea')).toHaveValue('')
   })
 
@@ -52,6 +74,46 @@ describe('CommentForm', () => {
     expect(handleSubmit).toHaveBeenCalledWith('Original text', undefined)
     // In edit mode, should NOT clear the textarea
     expect(screen.getByTestId('comment-textarea')).toHaveValue('Original text')
+  })
+
+  it('renders an inline error banner when errorMessage is set (PSY-589)', () => {
+    render(
+      <CommentForm
+        onSubmit={vi.fn()}
+        errorMessage="Please wait 60s before commenting again."
+      />
+    )
+    const banner = screen.getByTestId('comment-form-error')
+    expect(banner).toBeInTheDocument()
+    expect(banner).toHaveAttribute('role', 'alert')
+    expect(banner).toHaveTextContent(
+      'Please wait 60s before commenting again.'
+    )
+  })
+
+  it('does not clear the textarea when an error is present so the draft is preserved (PSY-589)', () => {
+    const handleSubmit = vi.fn()
+    const { rerender } = render(
+      <CommentForm onSubmit={handleSubmit} resetSignal={0} />
+    )
+
+    fireEvent.change(screen.getByTestId('comment-textarea'), {
+      target: { value: 'first try' },
+    })
+    fireEvent.click(screen.getByTestId('comment-submit'))
+
+    // Mutation comes back 429 — parent renders an errorMessage but does NOT
+    // bump resetSignal. The draft must survive.
+    rerender(
+      <CommentForm
+        onSubmit={handleSubmit}
+        resetSignal={0}
+        errorMessage="Please wait 60s before commenting again."
+      />
+    )
+
+    expect(screen.getByTestId('comment-form-error')).toBeInTheDocument()
+    expect(screen.getByTestId('comment-textarea')).toHaveValue('first try')
   })
 
   it('renders cancel button when onCancel is provided', () => {

--- a/frontend/features/comments/components/CommentForm.tsx
+++ b/frontend/features/comments/components/CommentForm.tsx
@@ -52,16 +52,14 @@ export function CommentForm({
     initialReplyPermission
   )
 
-  // PSY-589: parent bumps `resetSignal` from a mutation `onSuccess` callback.
-  // We only clear when the bumped value differs from the seed (undefined),
-  // so an edit-mode form (which never receives a resetSignal) keeps its body
-  // for the entire edit lifetime.
+  // PSY-589: parent bumps `resetSignal` from mutation onSuccess. Edit-mode
+  // callers don't pass it, so the body is preserved for the edit lifetime.
   useEffect(() => {
     if (resetSignal === undefined) return
     setBody('')
     setReplyPermission(initialReplyPermission)
-    // initialReplyPermission is captured at signal time; we don't want a
-    // change to it (or to the body via setBody) to re-fire a clear.
+    // Only fire on resetSignal changes; initialReplyPermission is read
+    // lazily on success and shouldn't re-trigger.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [resetSignal])
 

--- a/frontend/features/comments/components/CommentForm.tsx
+++ b/frontend/features/comments/components/CommentForm.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Textarea } from '@/components/ui/textarea'
 import { Button } from '@/components/ui/button'
 import { Loader2 } from 'lucide-react'
@@ -18,6 +18,21 @@ interface CommentFormProps {
   allowReplyPermission?: boolean
   /** Initial reply-permission value (defaults to user pref or 'anyone'). */
   initialReplyPermission?: ReplyPermission
+  /**
+   * PSY-589: optional inline error banner. When set, renders a
+   * destructive-styled message above the textarea. The form does NOT
+   * auto-clear while an error is present so the user can retry without
+   * retyping their draft.
+   */
+  errorMessage?: string | null
+  /**
+   * PSY-589: bumping this number signals "submission succeeded — clear
+   * the textarea." Replaces the old optimistic clear-on-submit behavior
+   * which discarded drafts when the request later 4xx'd. Edit-mode
+   * callers (which pass `initialBody`) leave this undefined and tear
+   * the form down via `onCancel` instead.
+   */
+  resetSignal?: number
 }
 
 export function CommentForm({
@@ -29,26 +44,47 @@ export function CommentForm({
   isPending = false,
   allowReplyPermission = false,
   initialReplyPermission = 'anyone',
+  errorMessage,
+  resetSignal,
 }: CommentFormProps) {
   const [body, setBody] = useState(initialBody)
   const [replyPermission, setReplyPermission] = useState<ReplyPermission>(
     initialReplyPermission
   )
 
+  // PSY-589: parent bumps `resetSignal` from a mutation `onSuccess` callback.
+  // We only clear when the bumped value differs from the seed (undefined),
+  // so an edit-mode form (which never receives a resetSignal) keeps its body
+  // for the entire edit lifetime.
+  useEffect(() => {
+    if (resetSignal === undefined) return
+    setBody('')
+    setReplyPermission(initialReplyPermission)
+    // initialReplyPermission is captured at signal time; we don't want a
+    // change to it (or to the body via setBody) to re-fire a clear.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [resetSignal])
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
     const trimmed = body.trim()
     if (!trimmed) return
     onSubmit(trimmed, allowReplyPermission ? replyPermission : undefined)
-    if (!initialBody) {
-      setBody('')
-    }
   }
 
   const isDisabled = !body.trim() || isPending
 
   return (
     <form onSubmit={handleSubmit} className="space-y-3">
+      {errorMessage && (
+        <div
+          className="rounded-md border border-red-800 bg-red-950/50 p-3"
+          role="alert"
+          data-testid="comment-form-error"
+        >
+          <p className="text-sm text-red-400">{errorMessage}</p>
+        </div>
+      )}
       <Textarea
         value={body}
         onChange={(e) => setBody(e.target.value)}

--- a/frontend/features/comments/components/CommentThread.test.tsx
+++ b/frontend/features/comments/components/CommentThread.test.tsx
@@ -11,17 +11,23 @@ const mockUseAuthContext = vi.fn()
 
 const defaultMutationReturn = { mutate: vi.fn(), isPending: false }
 
-vi.mock('../hooks', () => ({
-  useComments: (...args: unknown[]) => mockUseComments(...args),
-  useCreateComment: () => mockUseCreateComment(),
-  useReplyToComment: () => defaultMutationReturn,
-  useUpdateComment: () => defaultMutationReturn,
-  useUpdateReplyPermission: () => defaultMutationReturn,
-  useDeleteComment: () => defaultMutationReturn,
-  useVoteComment: () => defaultMutationReturn,
-  useUnvoteComment: () => defaultMutationReturn,
-  useCommentThread: () => ({ data: undefined }),
-}))
+vi.mock('../hooks', async () => {
+  // PSY-589: bring through the real formatCommentSubmissionError so the
+  // CommentThread test can assert on the exact banner copy under 429.
+  const actual = await vi.importActual<typeof import('../hooks')>('../hooks')
+  return {
+    useComments: (...args: unknown[]) => mockUseComments(...args),
+    useCreateComment: () => mockUseCreateComment(),
+    useReplyToComment: () => defaultMutationReturn,
+    useUpdateComment: () => defaultMutationReturn,
+    useUpdateReplyPermission: () => defaultMutationReturn,
+    useDeleteComment: () => defaultMutationReturn,
+    useVoteComment: () => defaultMutationReturn,
+    useUnvoteComment: () => defaultMutationReturn,
+    useCommentThread: () => ({ data: undefined }),
+    formatCommentSubmissionError: actual.formatCommentSubmissionError,
+  }
+})
 
 vi.mock('@/lib/context/AuthContext', () => ({
   useAuthContext: () => mockUseAuthContext(),
@@ -300,6 +306,34 @@ describe('CommentThread', () => {
 
       expect(screen.queryByTestId('pending-review-banner')).not.toBeInTheDocument()
       expect(screen.queryByTestId('pending-review-badge')).not.toBeInTheDocument()
+    })
+
+    // PSY-589: when the create mutation 429s, the form must surface an
+    // inline banner instead of silently clearing.
+    it('renders inline 429 banner with countdown copy when create mutation rate-limits', () => {
+      const err = Object.assign(
+        new Error('please wait 60 seconds between comments on the same entity'),
+        { status: 429, retryAfter: 60 }
+      )
+      mockUseCreateComment.mockReturnValue({
+        mutate: vi.fn(),
+        isPending: false,
+        error: err,
+      })
+      mockUseAuthContext.mockReturnValue({
+        isAuthenticated: true,
+        user: { id: '7', email: 'rate@example.com' },
+      })
+      mockUseComments.mockReturnValue({
+        data: { comments: [], total: 0, has_more: false },
+        isLoading: false,
+      })
+
+      render(<CommentThread {...defaultProps} />)
+
+      const banner = screen.getByTestId('comment-form-error')
+      expect(banner).toBeInTheDocument()
+      expect(banner).toHaveTextContent('Please wait 60s before commenting again.')
     })
 
     it('drops the optimistic entry once the canonical row appears in the list (post-approval refetch)', () => {

--- a/frontend/features/comments/components/CommentThread.tsx
+++ b/frontend/features/comments/components/CommentThread.tsx
@@ -4,7 +4,11 @@ import { useState } from 'react'
 import { MessageSquare, Clock } from 'lucide-react'
 import { useAuthContext } from '@/lib/context/AuthContext'
 import { Button } from '@/components/ui/button'
-import { useComments, useCreateComment } from '../hooks'
+import {
+  useComments,
+  useCreateComment,
+  formatCommentSubmissionError,
+} from '../hooks'
 import { CommentForm } from './CommentForm'
 import { CommentCard } from './CommentCard'
 import type { Comment, ReplyPermission } from '../types'
@@ -31,6 +35,10 @@ export function CommentThread({ entityType, entityId }: CommentThreadProps) {
   // source of truth until a moderator approves it (after which a refetch
   // surfaces the canonical row and the optimistic entry is de-duped by id).
   const [pendingComment, setPendingComment] = useState<Comment | null>(null)
+  // PSY-589: bumped on every successful submit so the form can clear its
+  // textarea via `resetSignal`. The form keeps the draft on error so the
+  // user can retry without retyping.
+  const [submitGeneration, setSubmitGeneration] = useState(0)
 
   const { data, isLoading } = useComments(entityType, entityId, sort)
   const createMutation = useCreateComment()
@@ -63,6 +71,9 @@ export function CommentThread({ entityType, entityId }: CommentThreadProps) {
           if (created.visibility === 'pending_review') {
             setPendingComment(created)
           }
+          // PSY-589: clear the form ONLY on success. On 4xx the form
+          // retains the draft so the user can retry.
+          setSubmitGeneration((g) => g + 1)
         },
       }
     )
@@ -108,6 +119,8 @@ export function CommentThread({ entityType, entityId }: CommentThreadProps) {
             placeholder="Share your thoughts..."
             isPending={createMutation.isPending}
             allowReplyPermission
+            errorMessage={formatCommentSubmissionError(createMutation.error)}
+            resetSignal={submitGeneration}
           />
         </div>
       ) : (

--- a/frontend/features/comments/hooks/index.test.ts
+++ b/frontend/features/comments/hooks/index.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import type { ApiError } from '@/lib/api'
+import { formatCommentSubmissionError } from './index'
+
+// PSY-589: the hook's 429 path must surface an inline error message
+// (instead of silently swallowing the failure and clearing the form).
+// formatCommentSubmissionError is the seam — the hook itself is a thin
+// react-query mutation, but it exposes the api.ts error verbatim, and
+// CommentThread/CommentCard pass that error through this formatter to
+// drive the banner copy + countdown.
+describe('formatCommentSubmissionError (PSY-589)', () => {
+  it('returns null when there is no error (no banner)', () => {
+    expect(formatCommentSubmissionError(null)).toBeNull()
+    expect(formatCommentSubmissionError(undefined)).toBeNull()
+  })
+
+  it('uses Retry-After seconds for 429 countdown copy', () => {
+    const err: ApiError = Object.assign(new Error('please wait 60 seconds...'), {
+      status: 429,
+      retryAfter: 60,
+    })
+    expect(formatCommentSubmissionError(err)).toBe(
+      'Please wait 60s before commenting again.'
+    )
+  })
+
+  it('falls back to capitalized server message when Retry-After is missing', () => {
+    const err: ApiError = Object.assign(
+      new Error('please wait 60 seconds between comments on the same entity'),
+      { status: 429 }
+    )
+    expect(formatCommentSubmissionError(err)).toBe(
+      'Please wait 60 seconds between comments on the same entity'
+    )
+  })
+
+  it('falls back to a static message for 429 with neither header nor body', () => {
+    const err: ApiError = Object.assign(new Error(''), { status: 429 })
+    expect(formatCommentSubmissionError(err)).toBe(
+      'Please wait a minute before commenting again.'
+    )
+  })
+
+  it('capitalizes generic non-429 server messages (project copy convention)', () => {
+    const err: ApiError = Object.assign(new Error('something went wrong'), {
+      status: 500,
+    })
+    expect(formatCommentSubmissionError(err)).toBe('Something went wrong')
+  })
+
+  it('handles plain Error instances without ApiError fields', () => {
+    expect(formatCommentSubmissionError(new Error('boom'))).toBe('Boom')
+  })
+})

--- a/frontend/features/comments/hooks/index.ts
+++ b/frontend/features/comments/hooks/index.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { apiRequest } from '@/lib/api'
+import { apiRequest, type ApiError } from '@/lib/api'
 import { queryKeys } from '@/lib/queryClient'
 import {
   commentEndpoints,
@@ -17,6 +17,48 @@ import type {
   CreateFieldNoteInput,
   ReplyPermission,
 } from '../types'
+
+// ============================================================================
+// Error formatting (PSY-589)
+// ============================================================================
+
+/**
+ * Capitalize the first character of a non-empty string. Backend service
+ * messages use lowercase ("please wait 60 seconds...") to keep substring
+ * routing in handlers simple; the project copy convention is to capitalize
+ * the first word in user-facing text, so we normalize at the display
+ * boundary.
+ */
+function capitalizeFirst(s: string): string {
+  if (!s) return s
+  return s.charAt(0).toUpperCase() + s.slice(1)
+}
+
+/**
+ * Format a submission error into a user-facing inline-banner string. 429
+ * gets countdown copy populated from the `Retry-After` header (or the
+ * service message body as a fallback). Any other status falls back to the
+ * raw message. Returns null if there is no error.
+ *
+ * Exported for unit testing — the hook test asserts that 429 with a
+ * Retry-After header produces "Please wait Ns before commenting again."
+ */
+export function formatCommentSubmissionError(error: unknown): string | null {
+  if (!error) return null
+  const apiErr = error as ApiError
+  if (apiErr.status === 429) {
+    if (apiErr.retryAfter && Number.isFinite(apiErr.retryAfter)) {
+      return `Please wait ${apiErr.retryAfter}s before commenting again.`
+    }
+    if (apiErr.message) {
+      return capitalizeFirst(apiErr.message)
+    }
+    return 'Please wait a minute before commenting again.'
+  }
+  if (apiErr.message) return capitalizeFirst(apiErr.message)
+  if (error instanceof Error) return capitalizeFirst(error.message)
+  return 'Something went wrong. Please try again.'
+}
 
 // ============================================================================
 // Queries

--- a/frontend/features/comments/hooks/index.ts
+++ b/frontend/features/comments/hooks/index.ts
@@ -50,13 +50,10 @@ export function formatCommentSubmissionError(error: unknown): string | null {
     if (apiErr.retryAfter && Number.isFinite(apiErr.retryAfter)) {
       return `Please wait ${apiErr.retryAfter}s before commenting again.`
     }
-    if (apiErr.message) {
-      return capitalizeFirst(apiErr.message)
-    }
+    if (apiErr.message) return capitalizeFirst(apiErr.message)
     return 'Please wait a minute before commenting again.'
   }
   if (apiErr.message) return capitalizeFirst(apiErr.message)
-  if (error instanceof Error) return capitalizeFirst(error.message)
   return 'Something went wrong. Please try again.'
 }
 

--- a/frontend/lib/api.test.ts
+++ b/frontend/lib/api.test.ts
@@ -337,6 +337,83 @@ describe('API Module', () => {
       }
     })
 
+    // PSY-589: Retry-After surfacing for inline rate-limit countdown copy.
+    it('exposes Retry-After seconds on the thrown error for 429 responses', async () => {
+      const headers = new Headers()
+      headers.set('Retry-After', '60')
+
+      const mockResponse = {
+        ok: false,
+        status: 429,
+        statusText: 'Too Many Requests',
+        json: () =>
+          Promise.resolve({
+            detail: 'please wait 60 seconds between comments on the same entity',
+          }),
+        headers,
+      }
+      vi.mocked(fetch).mockResolvedValue(mockResponse as Response)
+
+      const { apiRequest } = await import('./api')
+
+      try {
+        await apiRequest('/test')
+        expect.fail('Should have thrown')
+      } catch (error) {
+        expect((error as { status: number }).status).toBe(429)
+        expect((error as { retryAfter: number }).retryAfter).toBe(60)
+      }
+    })
+
+    it('omits retryAfter when Retry-After is absent on 429', async () => {
+      const mockResponse = {
+        ok: false,
+        status: 429,
+        statusText: 'Too Many Requests',
+        json: () => Promise.resolve({ detail: 'rate limited' }),
+        headers: new Headers(),
+      }
+      vi.mocked(fetch).mockResolvedValue(mockResponse as Response)
+
+      const { apiRequest } = await import('./api')
+
+      try {
+        await apiRequest('/test')
+        expect.fail('Should have thrown')
+      } catch (error) {
+        expect((error as { status: number }).status).toBe(429)
+        expect(
+          (error as { retryAfter?: number }).retryAfter
+        ).toBeUndefined()
+      }
+    })
+
+    it('does not parse Retry-After on non-429 responses', async () => {
+      const headers = new Headers()
+      headers.set('Retry-After', '120') // some servers send this on 503
+
+      const mockResponse = {
+        ok: false,
+        status: 503,
+        statusText: 'Service Unavailable',
+        json: () => Promise.resolve({ message: 'down' }),
+        headers,
+      }
+      vi.mocked(fetch).mockResolvedValue(mockResponse as Response)
+
+      const { apiRequest } = await import('./api')
+
+      try {
+        await apiRequest('/test')
+        expect.fail('Should have thrown')
+      } catch (error) {
+        expect((error as { status: number }).status).toBe(503)
+        expect(
+          (error as { retryAfter?: number }).retryAfter
+        ).toBeUndefined()
+      }
+    })
+
     it('handles JSON parse errors in error response', async () => {
       const mockResponse = {
         ok: false,

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -398,6 +398,13 @@ export interface ApiError extends Error {
   requestId?: string
   errorCode?: string
   details?: unknown
+  /**
+   * Seconds until the client may retry. Populated from the `Retry-After`
+   * response header per RFC 7231 §7.1.3 (currently only an integer-second
+   * Retry-After is parsed; HTTP-date variants are ignored). Used by the
+   * comment compose form (PSY-589) to populate countdown copy on 429.
+   */
+  retryAfter?: number
 }
 
 /**
@@ -516,6 +523,21 @@ export const apiRequest = async <T = unknown>(
     apiError.requestId = requestId || errorBody.request_id
     apiError.errorCode = errorBody.error_code
     apiError.details = errorBody.details || errorBody.errors || errorBody
+
+    // PSY-589: surface Retry-After on 429 so callers can render a
+    // countdown ("Please wait Ns before commenting again"). RFC 7231
+    // §7.1.3 also allows an HTTP-date form; we only parse the integer
+    // delta-seconds variant since every backend rate-limit path emits
+    // that form.
+    if (response.status === 429) {
+      const retryAfterRaw = response.headers.get('Retry-After')
+      if (retryAfterRaw) {
+        const seconds = parseInt(retryAfterRaw, 10)
+        if (Number.isFinite(seconds) && seconds > 0) {
+          apiError.retryAfter = seconds
+        }
+      }
+    }
 
     throw apiError
   }


### PR DESCRIPTION
## Summary
- Backend wraps comment 429s with `Retry-After` per RFC 7231 §7.1.3 (60s per-entity, 3600s hourly cap) via a shared `rateLimited429` helper across comment + reply + field-note handlers.
- Frontend `apiRequest` parses integer `Retry-After` onto a new `ApiError.retryAfter` field on 429.
- `CommentForm` now renders an inline destructive banner from a parent-supplied `errorMessage`, and clears its textarea only when the parent bumps a `resetSignal` — drafts survive 4xx errors so users can retry without retyping.
- `CommentThread` (top-level) and `CommentCard` (reply) wire `mutation.error` through a shared `formatCommentSubmissionError` formatter that produces "Please wait Ns before commenting again." for 429 and capitalizes other server messages.

## Test plan
- [ ] Sign in as new_user, post a comment on a show, immediately try to post another comment on the same show → inline 429 banner appears with countdown copy and the draft is preserved
- [ ] Same flow but with reply: post top-level comment, click Reply on it, post immediately → inline 429 banner appears on the reply form, draft preserved
- [ ] Wait 60s and retry → banner clears, comment posts, textarea clears
- [ ] Verify `Retry-After: 60` header on the 429 response (e.g. via DevTools Network pane on the failed POST)
- [ ] `cd backend && go test ./internal/api/handlers/engagement/... ./internal/services/engagement/...` — passes
- [ ] `cd frontend && npx vitest run features/comments lib/api.test.ts` — 130 tests pass

Closes PSY-589