### PR TITLE
PSY-611: restore main CI - fix backend tier-cap test + E2E selectors

### DIFF
--- a/backend/internal/api/handlers/community/collection_integration_test.go
+++ b/backend/internal/api/handlers/community/collection_integration_test.go
@@ -1157,7 +1157,8 @@ func (s *CollectionHandlerIntegrationSuite) TestGetUserCollections_WithLimit() {
 // user's collections containing artist X and one that doesn't, then asserts
 // only the two matching IDs come back.
 func (s *CollectionHandlerIntegrationSuite) TestGetUserCollectionsContaining_OnlyMatchingCollections() {
-	user := testhelpers.CreateTestUser(s.deps.DB)
+	// Admin so PSY-358 cap doesn't gate the third create.
+	user := testhelpers.CreateAdminUser(s.deps.DB)
 	collA := s.createCollectionViaService(user, "Has Artist A", false)
 	collB := s.createCollectionViaService(user, "Has Artist B", false)
 	collC := s.createCollectionViaService(user, "No Artist", false)

--- a/frontend/e2e/pages/add-to-collection.spec.ts
+++ b/frontend/e2e/pages/add-to-collection.spec.ts
@@ -40,16 +40,21 @@ test.describe('Add to Collection', () => {
       await collectButton.click()
 
       // 3. Pick the pre-seeded "E2E Worker Collection" from the picker.
-      // The picker renders each collection as a button whose text is the
-      // collection title.
-      const collectionRow = authenticatedPage.getByRole('button', {
+      // PSY-359 rebuilt the picker into a multi-select: each collection is a
+      // checkbox (accessible name = collection title) and submission happens
+      // through a single bottom "Add to N collection(s)" button.
+      const collectionCheckbox = authenticatedPage.getByRole('checkbox', {
         name: RESERVED_COLLECTION_TITLE,
       })
-      await expect(collectionRow).toBeVisible({ timeout: 5_000 })
+      await expect(collectionCheckbox).toBeVisible({ timeout: 5_000 })
+      await collectionCheckbox.click()
+
+      const submitButton = authenticatedPage.getByRole('button', {
+        name: /Add to 1 collection/,
+      })
 
       // PSY-430: waitForResponse wraps the mutation so we don't race on the
-      // optimistic UI state — the popover shows success before the network
-      // request completes.
+      // optimistic UI state — the popover updates before the request completes.
       const [addResponse] = await Promise.all([
         authenticatedPage.waitForResponse(
           (resp) =>
@@ -58,7 +63,7 @@ test.describe('Add to Collection', () => {
             resp.request().method() === 'POST',
           { timeout: 10_000 }
         ),
-        collectionRow.click(),
+        submitButton.click(),
       ])
       expect(addResponse.status()).toBeLessThan(400)
 
@@ -69,10 +74,9 @@ test.describe('Add to Collection', () => {
       expect(slugMatch).not.toBeNull()
       const collectionSlug = slugMatch![1]
 
-      // 4. Confirm success feedback rendered in the popover.
-      await expect(
-        authenticatedPage.getByText(`Added to "${RESERVED_COLLECTION_TITLE}"`)
-      ).toBeVisible({ timeout: 5_000 })
+      // 4. Confirm the popover reflects success: the checkbox stays checked
+      // (PSY-359 keeps the row in `savedIds` after a successful add).
+      await expect(collectionCheckbox).toBeChecked()
 
       // 5. Navigate to the collection detail page.
       await authenticatedPage.goto(`/collections/${collectionSlug}`)


### PR DESCRIPTION
## Summary

Two pre-existing main CI failures, both fallout from PSY-358/PSY-359 work that shipped without updating dependent tests. Caught while triaging PRs #547, #548, #549 from the May 2026 Entity & Collections Dogfood batch — both failures reproduced on un-modified `main`.

- **Backend** (`TestGetUserCollectionsContaining_OnlyMatchingCollections`): created 3 collections via `CreateTestUser` (new_user tier, 2-coll cap from PSY-358). Switched to `CreateAdminUser`, mirroring the verbatim comment + helper choice already used by the sibling `TestGetUserCollections_WithLimit` at line 1138 of the same file.
- **E2E** (`add-to-collection.spec.ts:19:7`): PSY-359 rebuilt `AddToCollectionButton` from button-per-collection into a multi-select checkbox + submit pattern. Updated selectors to pick the collection via checkbox, click the bottom submit button, and assert post-submit state via `toBeChecked()` (PSY-359 keeps the row in `savedIds`). Dropped the obsolete `'Added to "..."'` text assertion — the post-add navigation + collection-detail item-list verification (steps 5–6) remains the load-bearing success check.

Test-only change. No product behavior shift.

## Test plan

- [x] `cd backend && go test -run TestGetUserCollectionsContaining_OnlyMatchingCollections ./internal/api/handlers/community/...` → **ok**
- [x] `cd frontend && bun run test:e2e -- e2e/pages/add-to-collection.spec.ts --project=chromium` → **1 passed (18.6s)**
- [ ] CI green on this PR (Backend Tests + E2E Smoke + frontend unit tests)

## Notes

- `/simplify` ran clean; no second commit needed.
- After this lands, the in-flight dogfood-batch PRs (#547, #548, #549) should rebase to pick up the green base.

Closes PSY-611