### PR TITLE
PSY-610: surface inline errors on tag-admin mutations

### DIFF
--- a/frontend/features/tags/admin/LowQualityTagQueue.test.tsx
+++ b/frontend/features/tags/admin/LowQualityTagQueue.test.tsx
@@ -132,8 +132,6 @@ describe('LowQualityTagQueue', () => {
     fireEvent.click(
       screen.getByRole('button', { name: /ignore mystery for 30 days/i })
     )
-    // The handler now wires an onError callback for inline error surfacing
-    // (PSY-610), so the second arg is the react-query options object.
     expect(mockSnooze).toHaveBeenCalledWith(42, expect.any(Object))
   })
 

--- a/frontend/features/tags/admin/LowQualityTagQueue.test.tsx
+++ b/frontend/features/tags/admin/LowQualityTagQueue.test.tsx
@@ -132,7 +132,9 @@ describe('LowQualityTagQueue', () => {
     fireEvent.click(
       screen.getByRole('button', { name: /ignore mystery for 30 days/i })
     )
-    expect(mockSnooze).toHaveBeenCalledWith(42)
+    // The handler now wires an onError callback for inline error surfacing
+    // (PSY-610), so the second arg is the react-query options object.
+    expect(mockSnooze).toHaveBeenCalledWith(42, expect.any(Object))
   })
 
   it('fires the mark-official mutation when Official is clicked', () => {
@@ -150,7 +152,7 @@ describe('LowQualityTagQueue', () => {
     fireEvent.click(
       screen.getByRole('button', { name: /mark goodbadtag official/i })
     )
-    expect(mockMarkOfficial).toHaveBeenCalledWith(7)
+    expect(mockMarkOfficial).toHaveBeenCalledWith(7, expect.any(Object))
   })
 
   it('shows loading state while fetching', () => {

--- a/frontend/features/tags/admin/LowQualityTagQueue.tsx
+++ b/frontend/features/tags/admin/LowQualityTagQueue.tsx
@@ -78,6 +78,11 @@ export function LowQualityTagQueue() {
   // successful bulk action.
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set())
   const [bulkError, setBulkError] = useState<string | null>(null)
+  // Row-level error for the inline per-tag actions (Snooze / Mark Official /
+  // Delete). Lives on the queue page (not inside the row) so it can't be
+  // missed when the row drops out of view on success, and so a single banner
+  // covers all three single-row mutations.
+  const [rowError, setRowError] = useState<string | null>(null)
   const [bulkDeleteConfirmText, setBulkDeleteConfirmText] = useState('')
 
   // Multi-select signal-type filter chips (PSY-487).
@@ -106,22 +111,39 @@ export function LowQualityTagQueue() {
 
   const handleSnooze = useCallback(
     (id: number) => {
-      snoozeMutation.mutate(id)
+      setRowError(null)
+      snoozeMutation.mutate(id, {
+        onError: (err) => {
+          setRowError(err instanceof Error ? err.message : 'Failed to ignore tag')
+        },
+      })
     },
     [snoozeMutation]
   )
 
   const handleMarkOfficial = useCallback(
     (id: number) => {
-      markOfficialMutation.mutate(id)
+      setRowError(null)
+      markOfficialMutation.mutate(id, {
+        onError: (err) => {
+          setRowError(
+            err instanceof Error ? err.message : 'Failed to mark tag official'
+          )
+        },
+      })
     },
     [markOfficialMutation]
   )
 
   const handleDelete = useCallback(() => {
     if (selectedTagId == null) return
+    setRowError(null)
     deleteMutation.mutate(selectedTagId, {
       onSuccess: () => closeDialog(),
+      onError: (err) => {
+        setRowError(err instanceof Error ? err.message : 'Failed to delete tag')
+        closeDialog()
+      },
     })
   }, [selectedTagId, deleteMutation, closeDialog])
 
@@ -367,6 +389,15 @@ export function LowQualityTagQueue() {
               ? error.message
               : 'Failed to load review queue.'}
           </p>
+        </div>
+      )}
+
+      {rowError && (
+        <div
+          role="alert"
+          className="rounded-lg border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive"
+        >
+          {rowError}
         </div>
       )}
 

--- a/frontend/features/tags/admin/TagManagement.tsx
+++ b/frontend/features/tags/admin/TagManagement.tsx
@@ -78,18 +78,37 @@ function AliasManager({ tagId }: { tagId: number }) {
   const createAlias = useCreateAlias()
   const deleteAlias = useDeleteAlias()
   const [newAlias, setNewAlias] = useState('')
+  const [aliasError, setAliasError] = useState<string | null>(null)
 
   const handleAdd = useCallback(() => {
     if (!newAlias.trim()) return
+    setAliasError(null)
     createAlias.mutate(
       { tagId, alias: newAlias.trim() },
-      { onSuccess: () => setNewAlias('') }
+      {
+        onSuccess: () => setNewAlias(''),
+        onError: (err) => {
+          setAliasError(
+            err instanceof Error ? err.message : 'Failed to add alias'
+          )
+        },
+      }
     )
   }, [tagId, newAlias, createAlias])
 
   const handleRemove = useCallback(
     (aliasId: number) => {
-      deleteAlias.mutate({ tagId, aliasId })
+      setAliasError(null)
+      deleteAlias.mutate(
+        { tagId, aliasId },
+        {
+          onError: (err) => {
+            setAliasError(
+              err instanceof Error ? err.message : 'Failed to remove alias'
+            )
+          },
+        }
+      )
     },
     [tagId, deleteAlias]
   )
@@ -97,6 +116,14 @@ function AliasManager({ tagId }: { tagId: number }) {
   return (
     <div className="space-y-3">
       <Label>Aliases</Label>
+      {aliasError && (
+        <div
+          role="alert"
+          className="rounded-lg border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive"
+        >
+          {aliasError}
+        </div>
+      )}
       <div className="flex items-end gap-2">
         <div className="flex-1">
           <Input


### PR DESCRIPTION
## Summary
- Wire `onError` + visible `role="alert"` banner on the previously silent tag-admin mutations: `useCreateAlias` / `useDeleteAlias` (AliasManager in TagManagement) and `useSnoozeTag` / `useMarkTagOfficial` / `useDeleteTag` (LowQualityTagQueue). Pattern matches `LabelManagement.tsx`.
- Audit doc claimed the surface was 100% silent (10/10); current code review showed 5 silent call sites — the other six (CreateTagForm, EditTagForm, DeleteConfirmation, BulkImportDialog, MergeTagDialog, ParentPickerDialog) already had `setError` + `onError` wired and were left untouched.

## Test plan
- [x] cd frontend && bun run typecheck — passed
- [x] cd frontend && bun run test:run features/tags — 223/223 passed

Closes PSY-610