### PR TITLE
PSY-608: Surface mutation errors on every comment + field-note action

### DIFF
--- a/frontend/features/comments/components/CommentCard.test.tsx
+++ b/frontend/features/comments/components/CommentCard.test.tsx
@@ -17,19 +17,27 @@ vi.mock('@/lib/context/AuthContext', () => ({
 
 const defaultMutationReturn = { mutate: vi.fn(), isPending: false }
 const mockUseReplyToComment = vi.fn()
+// PSY-608: per-mutation overrides so we can assert the new error banners.
+const mockUseUpdateComment = vi.fn()
+const mockUseUpdateReplyPermission = vi.fn()
+const mockUseDeleteComment = vi.fn()
+const mockUseVoteComment = vi.fn()
+const mockUseUnvoteComment = vi.fn()
 
 vi.mock('../hooks', async () => {
-  // Bring through formatCommentSubmissionError (PSY-589) so the form
-  // renders the same banner copy in tests as it does in the real card.
+  // Bring through formatCommentSubmissionError (PSY-589) and
+  // useAutoDismissError (PSY-608) so the card renders the canonical
+  // inline-banner copy and the auto-dismiss vote banner state in tests.
   const actual = await vi.importActual<typeof import('../hooks')>('../hooks')
   return {
     useReplyToComment: () => mockUseReplyToComment(),
-    useUpdateComment: () => defaultMutationReturn,
-    useUpdateReplyPermission: () => defaultMutationReturn,
-    useDeleteComment: () => defaultMutationReturn,
-    useVoteComment: () => defaultMutationReturn,
-    useUnvoteComment: () => defaultMutationReturn,
+    useUpdateComment: () => mockUseUpdateComment(),
+    useUpdateReplyPermission: () => mockUseUpdateReplyPermission(),
+    useDeleteComment: () => mockUseDeleteComment(),
+    useVoteComment: () => mockUseVoteComment(),
+    useUnvoteComment: () => mockUseUnvoteComment(),
     useCommentThread: () => ({ data: undefined }),
+    useAutoDismissError: actual.useAutoDismissError,
     formatCommentSubmissionError: actual.formatCommentSubmissionError,
   }
 })
@@ -42,6 +50,18 @@ vi.mock('@/features/contributions', () => ({
 vi.mock('./CommentEditHistory', () => ({
   CommentEditHistory: () => <div data-testid="stub-edit-history-dialog" />,
 }))
+
+// PSY-608: convenience reset for every per-mutation mock. Default to the
+// neutral { mutate, isPending: false } shape so the card renders normally;
+// individual tests override one mutation at a time to assert error UI.
+function resetAllMutationMocks() {
+  mockUseReplyToComment.mockReturnValue(defaultMutationReturn)
+  mockUseUpdateComment.mockReturnValue(defaultMutationReturn)
+  mockUseUpdateReplyPermission.mockReturnValue(defaultMutationReturn)
+  mockUseDeleteComment.mockReturnValue(defaultMutationReturn)
+  mockUseVoteComment.mockReturnValue(defaultMutationReturn)
+  mockUseUnvoteComment.mockReturnValue(defaultMutationReturn)
+}
 
 function makeComment(overrides: Partial<Comment> = {}): Comment {
   return {
@@ -71,7 +91,7 @@ function makeComment(overrides: Partial<Comment> = {}): Comment {
 describe('CommentCard — admin edit history trigger (PSY-297)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockUseReplyToComment.mockReturnValue(defaultMutationReturn)
+    resetAllMutationMocks()
   })
 
   const defaultProps = {
@@ -142,7 +162,7 @@ describe('CommentCard — admin edit history trigger (PSY-297)', () => {
 describe('CommentCard — pending review badge (PSY-513)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockUseReplyToComment.mockReturnValue(defaultMutationReturn)
+    resetAllMutationMocks()
   })
 
   const defaultProps = {
@@ -224,6 +244,7 @@ describe('CommentCard — pending review badge (PSY-513)', () => {
 describe('CommentCard — Show replies button gating (PSY-514)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    resetAllMutationMocks()
     mockAuthContext.mockReturnValue({
       isAuthenticated: false,
       user: null,
@@ -307,6 +328,7 @@ describe('CommentCard — Show replies button gating (PSY-514)', () => {
 describe('CommentCard — author byline linkability (PSY-552)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    resetAllMutationMocks()
     mockAuthContext.mockReturnValue({
       isAuthenticated: false,
       user: null,
@@ -363,7 +385,7 @@ describe('CommentCard — author byline linkability (PSY-552)', () => {
 describe('CommentCard — reply rate-limit banner (PSY-589)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockUseReplyToComment.mockReturnValue(defaultMutationReturn)
+    resetAllMutationMocks()
   })
 
   const defaultProps = {
@@ -399,5 +421,144 @@ describe('CommentCard — reply rate-limit banner (PSY-589)', () => {
     const banner = screen.getByTestId('comment-form-error')
     expect(banner).toBeInTheDocument()
     expect(banner).toHaveTextContent('Please wait 60s before commenting again.')
+  })
+})
+
+// PSY-608: every comment mutation must surface 4xx feedback. Optimistic
+// rollback (vote/unvote) uses an auto-dismiss banner; the rest stay sticky
+// until the next retry / success.
+describe('CommentCard — mutation error surfacing (PSY-608)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetAllMutationMocks()
+  })
+
+  const ownerProps = {
+    entityType: 'artist' as const,
+    entityId: 10,
+  }
+
+  function ownerAuth() {
+    mockAuthContext.mockReturnValue({
+      isAuthenticated: true,
+      user: { id: '99', email: 'me@me.com' },
+    })
+  }
+
+  it('renders the edit-form error banner when useUpdateComment fails', () => {
+    ownerAuth()
+    mockUseUpdateComment.mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+      error: Object.assign(new Error('comment is too long'), { status: 400 }),
+    })
+
+    render(<CommentCard {...ownerProps} comment={makeComment()} />)
+
+    // Open edit mode.
+    fireEvent.click(screen.getByText('Edit'))
+
+    const banner = screen.getByTestId('comment-form-error')
+    expect(banner).toBeInTheDocument()
+    expect(banner).toHaveTextContent('Comment is too long')
+  })
+
+  it('renders the delete-error banner when useDeleteComment fails', () => {
+    ownerAuth()
+    mockUseDeleteComment.mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+      isError: true,
+      error: Object.assign(new Error('cannot delete pinned comment'), {
+        status: 403,
+      }),
+    })
+
+    render(<CommentCard {...ownerProps} comment={makeComment()} />)
+
+    const banner = screen.getByTestId('delete-error-banner')
+    expect(banner).toBeInTheDocument()
+    expect(banner).toHaveAttribute('role', 'alert')
+    expect(banner).toHaveTextContent('Cannot delete pinned comment')
+  })
+
+  it('renders the reply-permission error banner when useUpdateReplyPermission fails', () => {
+    ownerAuth()
+    mockUseUpdateReplyPermission.mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+      isError: true,
+      error: Object.assign(new Error('invalid permission'), { status: 400 }),
+    })
+
+    render(<CommentCard {...ownerProps} comment={makeComment()} />)
+
+    const banner = screen.getByTestId('reply-permission-error-banner')
+    expect(banner).toBeInTheDocument()
+    expect(banner).toHaveAttribute('role', 'alert')
+    expect(banner).toHaveTextContent('Invalid permission')
+  })
+
+  it('renders the auto-dismiss vote-error banner when useVoteComment rejects via onError', () => {
+    ownerAuth()
+    // Mock vote mutation that fires onError synchronously when mutate() is
+    // called — emulates the rollback path. The auto-dismiss banner reads
+    // from useAutoDismissError state, so a synchronous onError populates it
+    // before the next render.
+    const voteError = Object.assign(new Error('rate limited'), {
+      status: 429,
+      retryAfter: 60,
+    })
+    const mutateImpl = vi.fn(
+      (_args: unknown, opts?: { onError?: (err: unknown) => void }) => {
+        opts?.onError?.(voteError)
+      }
+    )
+    mockUseVoteComment.mockReturnValue({
+      mutate: mutateImpl,
+      isPending: false,
+    })
+
+    render(<CommentCard {...ownerProps} comment={makeComment()} />)
+
+    expect(screen.queryByTestId('vote-error-banner')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByLabelText('Upvote'))
+
+    const banner = screen.getByTestId('vote-error-banner')
+    expect(banner).toBeInTheDocument()
+    expect(banner).toHaveAttribute('role', 'alert')
+    // Reuses formatCommentSubmissionError → 429 countdown copy.
+    expect(banner).toHaveTextContent(
+      'Please wait 60s before commenting again.'
+    )
+  })
+
+  it('renders the auto-dismiss vote-error banner when useUnvoteComment rejects via onError', () => {
+    ownerAuth()
+    const voteError = Object.assign(new Error('vote failed'), { status: 500 })
+    const mutateImpl = vi.fn(
+      (_args: unknown, opts?: { onError?: (err: unknown) => void }) => {
+        opts?.onError?.(voteError)
+      }
+    )
+    mockUseUnvoteComment.mockReturnValue({
+      mutate: mutateImpl,
+      isPending: false,
+    })
+
+    // Comment already upvoted — clicking upvote toggles off (unvote path).
+    render(
+      <CommentCard
+        {...ownerProps}
+        comment={makeComment({ user_vote: 1 })}
+      />
+    )
+
+    fireEvent.click(screen.getByLabelText('Upvote'))
+
+    const banner = screen.getByTestId('vote-error-banner')
+    expect(banner).toBeInTheDocument()
+    expect(banner).toHaveTextContent('Vote failed')
   })
 })

--- a/frontend/features/comments/components/CommentCard.tsx
+++ b/frontend/features/comments/components/CommentCard.tsx
@@ -9,6 +9,7 @@ import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { CommentForm } from './CommentForm'
 import { CommentEditHistory } from './CommentEditHistory'
+import { MutationErrorBanner } from './MutationErrorBanner'
 import { ReplyPermissionSelect } from './ReplyPermissionSelect'
 import { ReportEntityDialog } from '@/features/contributions'
 import {
@@ -351,46 +352,34 @@ export function CommentCard({
       )}
 
       {/* PSY-608: sticky banners for non-optimistic owner mutations
-          (delete, change reply-permission). Stay visible until the next
-          retry / success so the user has a chance to read the message. */}
+          (delete, change reply-permission); auto-dismiss for the
+          optimistic vote/unvote rollback path. */}
       {!isEditing && deleteMutation.isError && (
-        <div
-          className="mt-2 rounded-md border border-red-800 bg-red-950/50 px-3 py-2"
-          role="alert"
-          data-testid="delete-error-banner"
-        >
-          <p className="text-sm text-red-400">
-            {formatCommentSubmissionError(deleteMutation.error) ??
-              'Failed to delete comment. Please try again.'}
-          </p>
-        </div>
+        <MutationErrorBanner
+          testId="delete-error-banner"
+          message={
+            formatCommentSubmissionError(deleteMutation.error) ??
+            'Failed to delete comment. Please try again.'
+          }
+        />
       )}
       {!isEditing && updateReplyPermissionMutation.isError && (
-        <div
-          className="mt-2 rounded-md border border-red-800 bg-red-950/50 px-3 py-2"
-          role="alert"
-          data-testid="reply-permission-error-banner"
-        >
-          <p className="text-sm text-red-400">
-            {formatCommentSubmissionError(updateReplyPermissionMutation.error) ??
-              'Failed to update reply permission. Please try again.'}
-          </p>
-        </div>
+        <MutationErrorBanner
+          testId="reply-permission-error-banner"
+          message={
+            formatCommentSubmissionError(updateReplyPermissionMutation.error) ??
+            'Failed to update reply permission. Please try again.'
+          }
+        />
       )}
-      {/* PSY-608: auto-dismiss banner for vote/unvote failures. The
-          optimistic-rollback restores the cached state silently; without
-          this, the user sees the icon flip back with no explanation. */}
       {!isEditing && voteError.error !== null && (
-        <div
-          className="mt-2 rounded-md border border-red-800 bg-red-950/50 px-3 py-2"
-          role="alert"
-          data-testid="vote-error-banner"
-        >
-          <p className="text-sm text-red-400">
-            {formatCommentSubmissionError(voteError.error) ??
-              'Vote failed. Please try again.'}
-          </p>
-        </div>
+        <MutationErrorBanner
+          testId="vote-error-banner"
+          message={
+            formatCommentSubmissionError(voteError.error) ??
+            'Vote failed. Please try again.'
+          }
+        />
       )}
 
       {/* PSY-297: Admin-only edit history trigger.

--- a/frontend/features/comments/components/CommentCard.tsx
+++ b/frontend/features/comments/components/CommentCard.tsx
@@ -19,6 +19,7 @@ import {
   useVoteComment,
   useUnvoteComment,
   useCommentThread,
+  useAutoDismissError,
   formatCommentSubmissionError,
 } from '../hooks'
 import {
@@ -62,6 +63,10 @@ export function CommentCard({
   const deleteMutation = useDeleteComment()
   const voteMutation = useVoteComment()
   const unvoteMutation = useUnvoteComment()
+  // PSY-608: optimistic vote/unvote rollback hides the failure visually.
+  // Show a brief auto-dismissing banner so the user knows the action was
+  // reverted, mirroring SaveButton / FavoriteVenueButton (~3s).
+  const voteError = useAutoDismissError()
 
   // Load thread on demand if no inline replies were provided
   const hasInlineReplies = replies.length > 0
@@ -74,9 +79,15 @@ export function CommentCard({
     if (!isAuthenticated) return
     if (comment.user_vote === direction) {
       // Toggle off
-      unvoteMutation.mutate({ commentId: comment.id, entityType, entityId })
+      unvoteMutation.mutate(
+        { commentId: comment.id, entityType, entityId },
+        { onError: (err) => voteError.show(err) }
+      )
     } else {
-      voteMutation.mutate({ commentId: comment.id, direction, entityType, entityId })
+      voteMutation.mutate(
+        { commentId: comment.id, direction, entityType, entityId },
+        { onError: (err) => voteError.show(err) }
+      )
     }
   }
 
@@ -202,6 +213,7 @@ export function CommentCard({
             submitLabel="Save"
             onCancel={() => setIsEditing(false)}
             isPending={updateMutation.isPending}
+            errorMessage={formatCommentSubmissionError(updateMutation.error)}
           />
         </div>
       ) : (
@@ -335,6 +347,49 @@ export function CommentCard({
             </label>
           )}
           {/* PSY-296 end */}
+        </div>
+      )}
+
+      {/* PSY-608: sticky banners for non-optimistic owner mutations
+          (delete, change reply-permission). Stay visible until the next
+          retry / success so the user has a chance to read the message. */}
+      {!isEditing && deleteMutation.isError && (
+        <div
+          className="mt-2 rounded-md border border-red-800 bg-red-950/50 px-3 py-2"
+          role="alert"
+          data-testid="delete-error-banner"
+        >
+          <p className="text-sm text-red-400">
+            {formatCommentSubmissionError(deleteMutation.error) ??
+              'Failed to delete comment. Please try again.'}
+          </p>
+        </div>
+      )}
+      {!isEditing && updateReplyPermissionMutation.isError && (
+        <div
+          className="mt-2 rounded-md border border-red-800 bg-red-950/50 px-3 py-2"
+          role="alert"
+          data-testid="reply-permission-error-banner"
+        >
+          <p className="text-sm text-red-400">
+            {formatCommentSubmissionError(updateReplyPermissionMutation.error) ??
+              'Failed to update reply permission. Please try again.'}
+          </p>
+        </div>
+      )}
+      {/* PSY-608: auto-dismiss banner for vote/unvote failures. The
+          optimistic-rollback restores the cached state silently; without
+          this, the user sees the icon flip back with no explanation. */}
+      {!isEditing && voteError.error !== null && (
+        <div
+          className="mt-2 rounded-md border border-red-800 bg-red-950/50 px-3 py-2"
+          role="alert"
+          data-testid="vote-error-banner"
+        >
+          <p className="text-sm text-red-400">
+            {formatCommentSubmissionError(voteError.error) ??
+              'Vote failed. Please try again.'}
+          </p>
         </div>
       )}
 

--- a/frontend/features/comments/components/CommentThread.test.tsx
+++ b/frontend/features/comments/components/CommentThread.test.tsx
@@ -14,6 +14,9 @@ const defaultMutationReturn = { mutate: vi.fn(), isPending: false }
 vi.mock('../hooks', async () => {
   // PSY-589: bring through the real formatCommentSubmissionError so the
   // CommentThread test can assert on the exact banner copy under 429.
+  // PSY-608: also bring through useAutoDismissError so the CommentCard
+  // children rendered inside CommentThread can call the auto-dismiss
+  // banner state hook without panicking on undefined.
   const actual = await vi.importActual<typeof import('../hooks')>('../hooks')
   return {
     useComments: (...args: unknown[]) => mockUseComments(...args),
@@ -25,6 +28,7 @@ vi.mock('../hooks', async () => {
     useVoteComment: () => defaultMutationReturn,
     useUnvoteComment: () => defaultMutationReturn,
     useCommentThread: () => ({ data: undefined }),
+    useAutoDismissError: actual.useAutoDismissError,
     formatCommentSubmissionError: actual.formatCommentSubmissionError,
   }
 })

--- a/frontend/features/comments/components/FieldNoteCard.test.tsx
+++ b/frontend/features/comments/components/FieldNoteCard.test.tsx
@@ -12,13 +12,31 @@ vi.mock('@/lib/context/AuthContext', () => ({
 }))
 
 const defaultMutationReturn = { mutate: vi.fn(), isPending: false }
+// PSY-608: per-mutation overrides so we can assert reply + vote error UI.
+const mockUseReplyToComment = vi.fn()
+const mockUseVoteComment = vi.fn()
+const mockUseUnvoteComment = vi.fn()
 
-vi.mock('../hooks', () => ({
-  useReplyToComment: () => defaultMutationReturn,
-  useVoteComment: () => defaultMutationReturn,
-  useUnvoteComment: () => defaultMutationReturn,
-  useCommentThread: () => ({ data: undefined }),
-}))
+vi.mock('../hooks', async () => {
+  // PSY-608: bring through the real formatCommentSubmissionError +
+  // useAutoDismissError so the FieldNoteCard renders the canonical inline
+  // error banner copy in tests.
+  const actual = await vi.importActual<typeof import('../hooks')>('../hooks')
+  return {
+    useReplyToComment: () => mockUseReplyToComment(),
+    useVoteComment: () => mockUseVoteComment(),
+    useUnvoteComment: () => mockUseUnvoteComment(),
+    useCommentThread: () => ({ data: undefined }),
+    useAutoDismissError: actual.useAutoDismissError,
+    formatCommentSubmissionError: actual.formatCommentSubmissionError,
+  }
+})
+
+function resetFieldNoteCardMocks() {
+  mockUseReplyToComment.mockReturnValue(defaultMutationReturn)
+  mockUseVoteComment.mockReturnValue(defaultMutationReturn)
+  mockUseUnvoteComment.mockReturnValue(defaultMutationReturn)
+}
 
 vi.mock('@/features/contributions', () => ({
   ReportEntityDialog: () => null,
@@ -59,6 +77,7 @@ function makeFieldNote(overrides: Partial<Comment> = {}): Comment {
 describe('FieldNoteCard', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    resetFieldNoteCardMocks()
     mockAuthContext.mockReturnValue({
       user: null,
       isAuthenticated: false,
@@ -338,6 +357,97 @@ describe('FieldNoteCard', () => {
       )
 
       expect(screen.getByTestId('show-replies-button')).toBeInTheDocument()
+    })
+  })
+
+  // PSY-608: vote/unvote optimistic-rollback shows an auto-dismiss banner;
+  // reply form shows a sticky banner via the shared CommentForm slot.
+  describe('mutation error surfacing (PSY-608)', () => {
+    function authedUser() {
+      mockAuthContext.mockReturnValue({
+        isAuthenticated: true,
+        user: { id: '7', email: 'rate@example.com' },
+      })
+    }
+
+    it('renders inline 429 banner with countdown copy when reply mutation rate-limits', () => {
+      authedUser()
+      const err = Object.assign(
+        new Error('please wait 60 seconds between comments on the same entity'),
+        { status: 429, retryAfter: 60 }
+      )
+      mockUseReplyToComment.mockReturnValue({
+        mutate: vi.fn(),
+        isPending: false,
+        error: err,
+      })
+
+      render(<FieldNoteCard comment={makeFieldNote()} showId={10} />)
+
+      // Open the reply form.
+      fireEvent.click(screen.getByText('Reply'))
+
+      const banner = screen.getByTestId('comment-form-error')
+      expect(banner).toBeInTheDocument()
+      expect(banner).toHaveTextContent('Please wait 60s before commenting again.')
+    })
+
+    it('renders the auto-dismiss vote-error banner when useVoteComment rejects', () => {
+      authedUser()
+      const voteError = Object.assign(new Error('vote failed'), { status: 500 })
+      const mutateImpl = vi.fn(
+        (_args: unknown, opts?: { onError?: (err: unknown) => void }) => {
+          opts?.onError?.(voteError)
+        }
+      )
+      mockUseVoteComment.mockReturnValue({
+        mutate: mutateImpl,
+        isPending: false,
+      })
+
+      render(<FieldNoteCard comment={makeFieldNote()} showId={10} />)
+
+      expect(screen.queryByTestId('vote-error-banner')).not.toBeInTheDocument()
+
+      fireEvent.click(screen.getByLabelText('Upvote'))
+
+      const banner = screen.getByTestId('vote-error-banner')
+      expect(banner).toBeInTheDocument()
+      expect(banner).toHaveAttribute('role', 'alert')
+      expect(banner).toHaveTextContent('Vote failed')
+    })
+
+    it('renders the auto-dismiss vote-error banner when useUnvoteComment rejects', () => {
+      authedUser()
+      const voteError = Object.assign(new Error('rate limited'), {
+        status: 429,
+        retryAfter: 60,
+      })
+      const mutateImpl = vi.fn(
+        (_args: unknown, opts?: { onError?: (err: unknown) => void }) => {
+          opts?.onError?.(voteError)
+        }
+      )
+      mockUseUnvoteComment.mockReturnValue({
+        mutate: mutateImpl,
+        isPending: false,
+      })
+
+      // Already upvoted — clicking upvote toggles off (unvote path).
+      render(
+        <FieldNoteCard
+          comment={makeFieldNote({ user_vote: 1 })}
+          showId={10}
+        />
+      )
+
+      fireEvent.click(screen.getByLabelText('Upvote'))
+
+      const banner = screen.getByTestId('vote-error-banner')
+      expect(banner).toBeInTheDocument()
+      expect(banner).toHaveTextContent(
+        'Please wait 60s before commenting again.'
+      )
     })
   })
 })

--- a/frontend/features/comments/components/FieldNoteCard.tsx
+++ b/frontend/features/comments/components/FieldNoteCard.tsx
@@ -8,6 +8,7 @@ import { useAuthContext } from '@/lib/context/AuthContext'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { CommentForm } from './CommentForm'
+import { MutationErrorBanner } from './MutationErrorBanner'
 import { ReportEntityDialog } from '@/features/contributions'
 import {
   useReplyToComment,
@@ -252,16 +253,14 @@ export function FieldNoteCard({
           optimistic-rollback restores the cached state silently; without
           this, the user sees the icon flip back with no explanation. */}
       {voteError.error !== null && (
-        <div
-          className="mt-3 rounded-md border border-red-800 bg-red-950/50 px-3 py-2"
-          role="alert"
-          data-testid="vote-error-banner"
-        >
-          <p className="text-sm text-red-400">
-            {formatCommentSubmissionError(voteError.error) ??
-              'Vote failed. Please try again.'}
-          </p>
-        </div>
+        <MutationErrorBanner
+          testId="vote-error-banner"
+          marginTop="mt-3"
+          message={
+            formatCommentSubmissionError(voteError.error) ??
+            'Vote failed. Please try again.'
+          }
+        />
       )}
 
       {/* Actions row: votes + reply + report */}

--- a/frontend/features/comments/components/FieldNoteCard.tsx
+++ b/frontend/features/comments/components/FieldNoteCard.tsx
@@ -14,6 +14,8 @@ import {
   useVoteComment,
   useUnvoteComment,
   useCommentThread,
+  useAutoDismissError,
+  formatCommentSubmissionError,
 } from '../hooks'
 import type { Comment } from '../types'
 
@@ -65,6 +67,10 @@ export function FieldNoteCard({
   const replyMutation = useReplyToComment()
   const voteMutation = useVoteComment()
   const unvoteMutation = useUnvoteComment()
+  // PSY-608: optimistic vote/unvote rollback hides the failure visually.
+  // Show a brief auto-dismissing banner so the user knows the action was
+  // reverted, mirroring SaveButton / FavoriteVenueButton (~3s).
+  const voteError = useAutoDismissError()
 
   const hasInlineReplies = replies.length > 0
   const { data: threadData } = useCommentThread(comment.id, loadedThread && !hasInlineReplies)
@@ -82,9 +88,15 @@ export function FieldNoteCard({
   const handleVote = (direction: 1 | -1) => {
     if (!isAuthenticated) return
     if (comment.user_vote === direction) {
-      unvoteMutation.mutate({ commentId: comment.id, entityType: 'show', entityId: showId })
+      unvoteMutation.mutate(
+        { commentId: comment.id, entityType: 'show', entityId: showId },
+        { onError: (err) => voteError.show(err) }
+      )
     } else {
-      voteMutation.mutate({ commentId: comment.id, direction, entityType: 'show', entityId: showId })
+      voteMutation.mutate(
+        { commentId: comment.id, direction, entityType: 'show', entityId: showId },
+        { onError: (err) => voteError.show(err) }
+      )
     }
   }
 
@@ -236,6 +248,22 @@ export function FieldNoteCard({
         </div>
       )}
 
+      {/* PSY-608: auto-dismiss banner for vote/unvote failures. The
+          optimistic-rollback restores the cached state silently; without
+          this, the user sees the icon flip back with no explanation. */}
+      {voteError.error !== null && (
+        <div
+          className="mt-3 rounded-md border border-red-800 bg-red-950/50 px-3 py-2"
+          role="alert"
+          data-testid="vote-error-banner"
+        >
+          <p className="text-sm text-red-400">
+            {formatCommentSubmissionError(voteError.error) ??
+              'Vote failed. Please try again.'}
+          </p>
+        </div>
+      )}
+
       {/* Actions row: votes + reply + report */}
       <div className="flex items-center gap-1 mt-3">
         {/* Vote buttons */}
@@ -293,7 +321,8 @@ export function FieldNoteCard({
         )}
       </div>
 
-      {/* Inline reply form */}
+      {/* Inline reply form. PSY-608: surface 4xx (e.g. 429) inline so reply
+          mutations don't fail silently — same pattern as CommentCard. */}
       {isReplying && (
         <div className="mt-3 ml-4">
           <CommentForm
@@ -302,6 +331,7 @@ export function FieldNoteCard({
             submitLabel="Reply"
             onCancel={() => setIsReplying(false)}
             isPending={replyMutation.isPending}
+            errorMessage={formatCommentSubmissionError(replyMutation.error)}
           />
         </div>
       )}

--- a/frontend/features/comments/components/FieldNoteForm.test.tsx
+++ b/frontend/features/comments/components/FieldNoteForm.test.tsx
@@ -42,7 +42,7 @@ describe('FieldNoteForm', () => {
     expect(screen.getByTestId('field-note-submit')).not.toBeDisabled()
   })
 
-  it('calls onSubmit with body and resets form', () => {
+  it('calls onSubmit with trimmed body but does NOT clear form (PSY-608 — clear is parent-driven via resetSignal)', () => {
     const handleSubmit = vi.fn()
     render(<FieldNoteForm onSubmit={handleSubmit} />)
 
@@ -54,7 +54,73 @@ describe('FieldNoteForm', () => {
     expect(handleSubmit).toHaveBeenCalledWith(
       expect.objectContaining({ body: 'Amazing performance' })
     )
+    // PSY-608: form keeps the draft so 4xx errors don't discard typed text.
+    // Parent clears via resetSignal on mutation success.
+    expect(screen.getByTestId('field-note-textarea')).toHaveValue(
+      '  Amazing performance  '
+    )
+  })
+
+  it('clears form when parent bumps resetSignal (PSY-608)', () => {
+    const handleSubmit = vi.fn()
+    const { rerender } = render(
+      <FieldNoteForm onSubmit={handleSubmit} resetSignal={0} />
+    )
+
+    fireEvent.change(screen.getByTestId('field-note-textarea'), {
+      target: { value: 'My note' },
+    })
+    fireEvent.click(screen.getByTestId('field-note-submit'))
+
+    expect(handleSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ body: 'My note' })
+    )
+    // Pre-bump: draft preserved.
+    expect(screen.getByTestId('field-note-textarea')).toHaveValue('My note')
+
+    // Parent signals success.
+    rerender(<FieldNoteForm onSubmit={handleSubmit} resetSignal={1} />)
     expect(screen.getByTestId('field-note-textarea')).toHaveValue('')
+  })
+
+  it('renders an inline error banner when errorMessage is set (PSY-608)', () => {
+    render(
+      <FieldNoteForm
+        onSubmit={vi.fn()}
+        errorMessage="Please wait 60s before commenting again."
+      />
+    )
+    const banner = screen.getByTestId('field-note-form-error')
+    expect(banner).toBeInTheDocument()
+    expect(banner).toHaveAttribute('role', 'alert')
+    expect(banner).toHaveTextContent(
+      'Please wait 60s before commenting again.'
+    )
+  })
+
+  it('preserves draft when an errorMessage is present and no resetSignal bump (PSY-608)', () => {
+    const handleSubmit = vi.fn()
+    const { rerender } = render(
+      <FieldNoteForm onSubmit={handleSubmit} resetSignal={0} />
+    )
+
+    fireEvent.change(screen.getByTestId('field-note-textarea'), {
+      target: { value: 'first try' },
+    })
+    fireEvent.click(screen.getByTestId('field-note-submit'))
+
+    // Mutation comes back 4xx — parent renders errorMessage but does NOT
+    // bump resetSignal. The draft must survive.
+    rerender(
+      <FieldNoteForm
+        onSubmit={handleSubmit}
+        resetSignal={0}
+        errorMessage="Please wait 60s before commenting again."
+      />
+    )
+
+    expect(screen.getByTestId('field-note-form-error')).toBeInTheDocument()
+    expect(screen.getByTestId('field-note-textarea')).toHaveValue('first try')
   })
 
   it('includes sound quality when set', async () => {

--- a/frontend/features/comments/components/FieldNoteForm.tsx
+++ b/frontend/features/comments/components/FieldNoteForm.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Loader2, Star } from 'lucide-react'
 import { Textarea } from '@/components/ui/textarea'
 import { Input } from '@/components/ui/input'
@@ -20,6 +20,19 @@ interface FieldNoteFormProps {
   isPending?: boolean
   disabled?: boolean
   disabledMessage?: string
+  /**
+   * PSY-608: optional inline error banner. When set, renders a
+   * destructive-styled message above the textarea. Mirrors CommentForm's
+   * errorMessage; reuse the same `formatCommentSubmissionError` helper for
+   * 429 countdown copy.
+   */
+  errorMessage?: string | null
+  /**
+   * PSY-608: bumping this number signals "submission succeeded — clear
+   * the form." Mirrors CommentForm.resetSignal. Without this, the previous
+   * eager-clear-on-submit behaviour discarded the draft on 4xx errors.
+   */
+  resetSignal?: number
 }
 
 function StarRating({
@@ -68,6 +81,8 @@ export function FieldNoteForm({
   isPending = false,
   disabled = false,
   disabledMessage,
+  errorMessage,
+  resetSignal,
 }: FieldNoteFormProps) {
   const [body, setBody] = useState('')
   const [soundQuality, setSoundQuality] = useState(0)
@@ -76,6 +91,19 @@ export function FieldNoteForm({
   const [setlistSpoiler, setSetlistSpoiler] = useState(false)
   const [showArtistId, setShowArtistId] = useState<number | undefined>(undefined)
   const [songPosition, setSongPosition] = useState('')
+
+  // PSY-608: parent bumps resetSignal from mutation onSuccess. Mirrors the
+  // CommentForm pattern so a 4xx response keeps the user's draft intact.
+  useEffect(() => {
+    if (resetSignal === undefined) return
+    setBody('')
+    setSoundQuality(0)
+    setCrowdEnergy(0)
+    setNotableMoments('')
+    setSetlistSpoiler(false)
+    setShowArtistId(undefined)
+    setSongPosition('')
+  }, [resetSignal])
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
@@ -94,14 +122,9 @@ export function FieldNoteForm({
     }
 
     onSubmit(input)
-    // Reset form
-    setBody('')
-    setSoundQuality(0)
-    setCrowdEnergy(0)
-    setNotableMoments('')
-    setSetlistSpoiler(false)
-    setShowArtistId(undefined)
-    setSongPosition('')
+    // PSY-608: reset is parent-driven via resetSignal (mirrors CommentForm).
+    // Eagerly clearing here previously discarded the draft when the request
+    // came back 4xx; now the parent bumps resetSignal only on success.
   }
 
   if (disabled && disabledMessage) {
@@ -119,6 +142,17 @@ export function FieldNoteForm({
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4" data-testid="field-note-form">
+      {/* PSY-608: inline error banner — same shape as CommentForm. Parent
+          wires this from the createFieldNote mutation error. */}
+      {errorMessage && (
+        <div
+          className="rounded-md border border-red-800 bg-red-950/50 p-3"
+          role="alert"
+          data-testid="field-note-form-error"
+        >
+          <p className="text-sm text-red-400">{errorMessage}</p>
+        </div>
+      )}
       {/* Body */}
       <Textarea
         value={body}

--- a/frontend/features/comments/components/FieldNotesSection.test.tsx
+++ b/frontend/features/comments/components/FieldNotesSection.test.tsx
@@ -11,14 +11,21 @@ const mockUseAuthContext = vi.fn()
 
 const defaultMutationReturn = { mutate: vi.fn(), isPending: false }
 
-vi.mock('../hooks', () => ({
-  useFieldNotes: (...args: unknown[]) => mockUseFieldNotes(...args),
-  useCreateFieldNote: () => mockUseCreateFieldNote(),
-  useReplyToComment: () => defaultMutationReturn,
-  useVoteComment: () => defaultMutationReturn,
-  useUnvoteComment: () => defaultMutationReturn,
-  useCommentThread: () => ({ data: undefined }),
-}))
+vi.mock('../hooks', async () => {
+  // PSY-608: bring through the real formatCommentSubmissionError so the
+  // FieldNotesSection test can assert on the exact 4xx banner copy.
+  const actual = await vi.importActual<typeof import('../hooks')>('../hooks')
+  return {
+    useFieldNotes: (...args: unknown[]) => mockUseFieldNotes(...args),
+    useCreateFieldNote: () => mockUseCreateFieldNote(),
+    useReplyToComment: () => defaultMutationReturn,
+    useVoteComment: () => defaultMutationReturn,
+    useUnvoteComment: () => defaultMutationReturn,
+    useCommentThread: () => ({ data: undefined }),
+    useAutoDismissError: actual.useAutoDismissError,
+    formatCommentSubmissionError: actual.formatCommentSubmissionError,
+  }
+})
 
 vi.mock('@/lib/context/AuthContext', () => ({
   useAuthContext: () => mockUseAuthContext(),
@@ -377,6 +384,45 @@ describe('FieldNotesSection', () => {
 
       expect(screen.queryByTestId('pending-review-banner')).not.toBeInTheDocument()
       expect(screen.queryByTestId('pending-review-badge')).not.toBeInTheDocument()
+    })
+  })
+
+  // PSY-608: createFieldNote 4xx must surface inline (was silent — same
+  // failure mode as PSY-589 on createComment).
+  describe('mutation error surfacing (PSY-608)', () => {
+    it('renders inline 429 banner with countdown copy when create mutation rate-limits', () => {
+      const err = Object.assign(
+        new Error('please wait 60 seconds between comments on the same entity'),
+        { status: 429, retryAfter: 60 }
+      )
+      mockUseCreateFieldNote.mockReturnValue({
+        mutate: vi.fn(),
+        isPending: false,
+        error: err,
+      })
+      mockUseAuthContext.mockReturnValue({
+        isAuthenticated: true,
+        user: { id: '8', email: 'rate@example.com' },
+      })
+      mockUseFieldNotes.mockReturnValue({
+        data: { comments: [], total: 0, has_more: false },
+        isLoading: false,
+      })
+
+      render(
+        <FieldNotesSection
+          showId={1}
+          showDate={pastDate}
+          artists={mockArtists}
+        />
+      )
+
+      const banner = screen.getByTestId('field-note-form-error')
+      expect(banner).toBeInTheDocument()
+      expect(banner).toHaveAttribute('role', 'alert')
+      expect(banner).toHaveTextContent(
+        'Please wait 60s before commenting again.'
+      )
     })
   })
 })

--- a/frontend/features/comments/components/FieldNotesSection.tsx
+++ b/frontend/features/comments/components/FieldNotesSection.tsx
@@ -3,7 +3,11 @@
 import { useState } from 'react'
 import { ClipboardList, Clock } from 'lucide-react'
 import { useAuthContext } from '@/lib/context/AuthContext'
-import { useFieldNotes, useCreateFieldNote } from '../hooks'
+import {
+  useFieldNotes,
+  useCreateFieldNote,
+  formatCommentSubmissionError,
+} from '../hooks'
 import { FieldNoteForm } from './FieldNoteForm'
 import { FieldNoteCard } from './FieldNoteCard'
 import type { Comment, CreateFieldNoteInput } from '../types'
@@ -41,6 +45,10 @@ export function FieldNotesSection({ showId, showDate, artists = [] }: FieldNotes
   // it optimistically alongside the public list (which filters out
   // pending_review). De-duped once the canonical row appears post-approval.
   const [pendingNote, setPendingNote] = useState<Comment | null>(null)
+  // PSY-608: bumped on every successful submit so FieldNoteForm clears its
+  // local state. The form keeps the draft on error so the user can retry
+  // without retyping (mirrors CommentForm's resetSignal pattern).
+  const [submitGeneration, setSubmitGeneration] = useState(0)
 
   const fieldNotes = data?.comments ?? []
   const total = data?.total ?? 0
@@ -58,6 +66,9 @@ export function FieldNotesSection({ showId, showDate, artists = [] }: FieldNotes
           if (created.visibility === 'pending_review') {
             setPendingNote(created)
           }
+          // PSY-608: clear the form ONLY on success. On 4xx the form
+          // retains the draft so the user can retry.
+          setSubmitGeneration((g) => g + 1)
         },
       }
     )
@@ -95,6 +106,10 @@ export function FieldNotesSection({ showId, showDate, artists = [] }: FieldNotes
                 onSubmit={handleCreate}
                 artists={artists}
                 isPending={createMutation.isPending}
+                errorMessage={formatCommentSubmissionError(
+                  createMutation.error
+                )}
+                resetSignal={submitGeneration}
               />
             </div>
           ) : (

--- a/frontend/features/comments/components/MutationErrorBanner.tsx
+++ b/frontend/features/comments/components/MutationErrorBanner.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+/**
+ * Inline error banner for comment / field-note mutations (PSY-608).
+ *
+ * Shared visual shape for sticky-until-retry banners (delete, reply
+ * permission) and auto-dismiss banners (vote / unvote). Keep the
+ * destructive styling consistent across all surfaces inside the comments
+ * feature module — the `errorMessage` slots inside `CommentForm` /
+ * `FieldNoteForm` use a slightly larger pad (`p-3`) since they sit above a
+ * form field; this banner uses `px-3 py-2` because it's anchored next to
+ * an action row.
+ *
+ * Internal to the comments feature — not re-exported from the public
+ * `components/index.ts`.
+ */
+interface MutationErrorBannerProps {
+  message: string
+  testId: string
+  /** Margin-top override; defaults to `mt-2`. FieldNoteCard uses `mt-3`. */
+  marginTop?: 'mt-2' | 'mt-3'
+}
+
+export function MutationErrorBanner({
+  message,
+  testId,
+  marginTop = 'mt-2',
+}: MutationErrorBannerProps) {
+  return (
+    <div
+      className={`${marginTop} rounded-md border border-red-800 bg-red-950/50 px-3 py-2`}
+      role="alert"
+      data-testid={testId}
+    >
+      <p className="text-sm text-red-400">{message}</p>
+    </div>
+  )
+}

--- a/frontend/features/comments/hooks/index.test.ts
+++ b/frontend/features/comments/hooks/index.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
 import type { ApiError } from '@/lib/api'
-import { formatCommentSubmissionError } from './index'
+import { formatCommentSubmissionError, useAutoDismissError } from './index'
 
 // PSY-589: the hook's 429 path must surface an inline error message
 // (instead of silently swallowing the failure and clearing the form).
@@ -50,5 +51,92 @@ describe('formatCommentSubmissionError (PSY-589)', () => {
 
   it('handles plain Error instances without ApiError fields', () => {
     expect(formatCommentSubmissionError(new Error('boom'))).toBe('Boom')
+  })
+})
+
+// PSY-608: auto-dismiss banner state for optimistic-rollback mutations.
+// The hook keeps the rollback's silent cache restore but surfaces a brief
+// "action was reverted" message so the user knows what happened.
+describe('useAutoDismissError (PSY-608)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('starts with no error', () => {
+    const { result } = renderHook(() => useAutoDismissError())
+    expect(result.current.error).toBeNull()
+  })
+
+  it('exposes the error after show() is called', () => {
+    const { result } = renderHook(() => useAutoDismissError(3000))
+    const err = new Error('boom')
+
+    act(() => {
+      result.current.show(err)
+    })
+
+    expect(result.current.error).toBe(err)
+  })
+
+  it('clears the error after the timeout elapses', () => {
+    const { result } = renderHook(() => useAutoDismissError(3000))
+
+    act(() => {
+      result.current.show(new Error('boom'))
+    })
+    expect(result.current.error).not.toBeNull()
+
+    act(() => {
+      vi.advanceTimersByTime(3000)
+    })
+
+    expect(result.current.error).toBeNull()
+  })
+
+  it('resets the timer when show() is called again before timeout', () => {
+    const { result } = renderHook(() => useAutoDismissError(3000))
+
+    act(() => {
+      result.current.show(new Error('first'))
+    })
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+    // Re-trigger before timeout — second error visible, timer reset.
+    const second = new Error('second')
+    act(() => {
+      result.current.show(second)
+    })
+    expect(result.current.error).toBe(second)
+
+    // Original timeout would have fired by now, but the reset delays it.
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+    expect(result.current.error).toBe(second)
+
+    // Full second-timeout window completes.
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+    expect(result.current.error).toBeNull()
+  })
+
+  it('clears the pending timeout on unmount (no setState on unmounted component)', () => {
+    const { result, unmount } = renderHook(() => useAutoDismissError(3000))
+
+    act(() => {
+      result.current.show(new Error('boom'))
+    })
+    unmount()
+
+    // Advancing past the dismiss window must not throw or warn.
+    act(() => {
+      vi.advanceTimersByTime(5000)
+    })
   })
 })

--- a/frontend/features/comments/hooks/index.ts
+++ b/frontend/features/comments/hooks/index.ts
@@ -1,5 +1,6 @@
 'use client'
 
+import { useEffect, useRef, useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { apiRequest, type ApiError } from '@/lib/api'
 import { queryKeys } from '@/lib/queryClient'
@@ -55,6 +56,42 @@ export function formatCommentSubmissionError(error: unknown): string | null {
   }
   if (apiErr.message) return capitalizeFirst(apiErr.message)
   return 'Something went wrong. Please try again.'
+}
+
+/**
+ * PSY-608: auto-dismiss banner state for optimistic-rollback mutations
+ * (vote / unvote). Mirrors the SaveButton / FavoriteVenueButton pattern:
+ * keep the rollback's silent cache restore, but surface a brief "action
+ * was reverted" message so the user knows what just happened.
+ *
+ * - `error`: latest mutation error (or null when displayed window has
+ *   elapsed). Use this in JSX to gate banner rendering.
+ * - `show(error)`: call from `onError` with the failure to display it.
+ *   Subsequent calls reset the timer.
+ *
+ * Cleans up the pending timeout on unmount and on each new `show()` call
+ * so we never call setState on an unmounted component.
+ */
+export function useAutoDismissError(timeoutMs = 3000): {
+  error: unknown
+  show: (error: unknown) => void
+} {
+  const [error, setError] = useState<unknown>(null)
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current)
+    }
+  }, [])
+
+  const show = (next: unknown) => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current)
+    setError(next)
+    timeoutRef.current = setTimeout(() => setError(null), timeoutMs)
+  }
+
+  return { error, show }
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Wire inline error banners on every silent comment / field-note mutation (8 hooks per the PSY-596 audit). Reuses `formatCommentSubmissionError` for 429 countdown copy on create / reply / update paths.
- Add `useAutoDismissError` (~3s) for the optimistic vote / unvote rollback path so the user sees the action was reverted, mirroring `SaveButton` / `FavoriteVenueButton`.
- Mirror `CommentForm`'s parent-driven `resetSignal` on `FieldNoteForm` so 4xx no longer discards the user's draft.
- Extract the duplicated banner JSX into a small internal `MutationErrorBanner` component.

## Test plan
- [x] cd frontend && bun run typecheck — passed
- [x] cd frontend && bun run test:run features/comments — passed (117 tests, +17 new)
- [x] cd frontend && bun run test:run — passed (3053 tests, full sweep)

Closes PSY-608