### PR TITLE
PSY-612: consolidate backend user-resolver chain

### DIFF
--- a/backend/internal/api/handlers/community/request.go
+++ b/backend/internal/api/handlers/community/request.go
@@ -11,9 +11,9 @@ import (
 	"psychic-homily-backend/internal/api/middleware"
 	apperrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/logger"
-	authm "psychic-homily-backend/internal/models/auth"
 	communitym "psychic-homily-backend/internal/models/community"
 	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/services/shared"
 )
 
 // RequestHandler handles request-related API requests
@@ -460,30 +460,15 @@ func buildRequestResponse(request *communitym.Request, userVote *int) *contracts
 
 	// Resolve requester name
 	if request.Requester.ID > 0 {
-		resp.RequesterName = resolveUserDisplayName(&request.Requester)
+		resp.RequesterName = shared.ResolveUserName(&request.Requester)
 	}
 
 	// Resolve fulfiller name
 	if request.Fulfiller != nil && request.Fulfiller.ID > 0 {
-		resp.FulfillerName = resolveUserDisplayName(request.Fulfiller)
+		resp.FulfillerName = shared.ResolveUserName(request.Fulfiller)
 	}
 
 	return resp
-}
-
-// resolveUserDisplayName returns a display name for a user.
-func resolveUserDisplayName(user *authm.User) string {
-	if user.Username != nil && *user.Username != "" {
-		return *user.Username
-	}
-	if user.FirstName != nil && *user.FirstName != "" {
-		name := *user.FirstName
-		if user.LastName != nil && *user.LastName != "" {
-			name += " " + *user.LastName
-		}
-		return name
-	}
-	return "Unknown"
 }
 
 // mapRequestError converts a RequestError to an appropriate Huma HTTP error

--- a/backend/internal/api/handlers/community/request_test.go
+++ b/backend/internal/api/handlers/community/request_test.go
@@ -672,28 +672,10 @@ func TestBuildRequestResponse_NoVote(t *testing.T) {
 	}
 }
 
-func TestResolveUserDisplayName(t *testing.T) {
-	username := "cooluser"
-	firstName := "Jane"
-	lastName := "Doe"
-
-	tests := []struct {
-		name     string
-		user     *authm.User
-		expected string
-	}{
-		{"username", &authm.User{Username: &username}, "cooluser"},
-		{"first+last", &authm.User{FirstName: &firstName, LastName: &lastName}, "Jane Doe"},
-		{"first only", &authm.User{FirstName: &firstName}, "Jane"},
-		{"empty", &authm.User{}, "Unknown"},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			result := resolveUserDisplayName(tc.user)
-			if result != tc.expected {
-				t.Errorf("expected %q, got %q", tc.expected, result)
-			}
-		})
-	}
-}
+// PSY-612: Request requester/fulfiller name resolution now delegates to
+// services/shared.ResolveUserName. The full chain — including the email
+// local-part fallback that this surface previously omitted (it stopped at
+// "Unknown" instead of falling through to the email prefix) — is locked
+// down in services/shared/user_resolver_test.go. Integration coverage that
+// buildRequestResponse delegates correctly is retained via
+// TestBuildRequestResponse_WithVote.

--- a/backend/internal/api/handlers/community/request_test.go
+++ b/backend/internal/api/handlers/community/request_test.go
@@ -671,11 +671,3 @@ func TestBuildRequestResponse_NoVote(t *testing.T) {
 		t.Errorf("expected user_vote=nil, got %v", resp.UserVote)
 	}
 }
-
-// PSY-612: Request requester/fulfiller name resolution now delegates to
-// services/shared.ResolveUserName. The full chain — including the email
-// local-part fallback that this surface previously omitted (it stopped at
-// "Unknown" instead of falling through to the email prefix) — is locked
-// down in services/shared/user_resolver_test.go. Integration coverage that
-// buildRequestResponse delegates correctly is retained via
-// TestBuildRequestResponse_WithVote.

--- a/backend/internal/services/admin/audit_log.go
+++ b/backend/internal/services/admin/audit_log.go
@@ -11,6 +11,7 @@ import (
 	"psychic-homily-backend/internal/logger"
 	adminm "psychic-homily-backend/internal/models/admin"
 	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/services/shared"
 )
 
 // AuditLogService handles audit log business logic
@@ -124,8 +125,14 @@ func (s *AuditLogService) buildResponse(log *adminm.AuditLog) *contracts.AuditLo
 		CreatedAt:  log.CreatedAt,
 	}
 
-	if log.Actor != nil && log.Actor.Email != nil {
-		resp.ActorEmail = *log.Actor.Email
+	if log.Actor != nil {
+		if log.Actor.Email != nil {
+			resp.ActorEmail = *log.Actor.Email
+		}
+		// PSY-612: ship resolved name + username so the admin audit log can
+		// render the same display string as every other moderation surface.
+		resp.ActorName = shared.ResolveUserName(log.Actor)
+		resp.ActorUsername = shared.ResolveUserUsername(log.Actor)
 	}
 
 	if log.Metadata != nil {

--- a/backend/internal/services/admin/audit_log.go
+++ b/backend/internal/services/admin/audit_log.go
@@ -129,8 +129,6 @@ func (s *AuditLogService) buildResponse(log *adminm.AuditLog) *contracts.AuditLo
 		if log.Actor.Email != nil {
 			resp.ActorEmail = *log.Actor.Email
 		}
-		// PSY-612: ship resolved name + username so the admin audit log can
-		// render the same display string as every other moderation surface.
 		resp.ActorName = shared.ResolveUserName(log.Actor)
 		resp.ActorUsername = shared.ResolveUserUsername(log.Actor)
 	}

--- a/backend/internal/services/admin/entity_report.go
+++ b/backend/internal/services/admin/entity_report.go
@@ -9,6 +9,7 @@ import (
 	"psychic-homily-backend/db"
 	communitym "psychic-homily-backend/internal/models/community"
 	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/services/shared"
 )
 
 // EntityReportService handles business logic for generalized entity reports.
@@ -271,12 +272,12 @@ func (s *EntityReportService) toResponse(report *communitym.EntityReport) *contr
 
 	// Resolve reporter name
 	if report.Reporter.ID != 0 {
-		resp.ReporterName = displayName(&report.Reporter)
+		resp.ReporterName = shared.ResolveUserName(&report.Reporter)
 	}
 
 	// Resolve reviewer name
 	if report.Reviewer != nil && report.Reviewer.ID != 0 {
-		resp.ReviewerName = displayName(report.Reviewer)
+		resp.ReviewerName = shared.ResolveUserName(report.Reviewer)
 	}
 
 	return resp

--- a/backend/internal/services/admin/pending_edit.go
+++ b/backend/internal/services/admin/pending_edit.go
@@ -12,6 +12,7 @@ import (
 	adminm "psychic-homily-backend/internal/models/admin"
 	authm "psychic-homily-backend/internal/models/auth"
 	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/services/shared"
 )
 
 // PendingEditService handles business logic for generic pending entity edits.
@@ -359,12 +360,12 @@ func (s *PendingEditService) toResponse(edit *adminm.PendingEntityEdit) *contrac
 
 	// Resolve submitter name
 	if edit.Submitter.ID != 0 {
-		resp.SubmitterName = displayName(&edit.Submitter)
+		resp.SubmitterName = shared.ResolveUserName(&edit.Submitter)
 	}
 
 	// Resolve reviewer name
 	if edit.Reviewer != nil && edit.Reviewer.ID != 0 {
-		resp.ReviewerName = displayName(edit.Reviewer)
+		resp.ReviewerName = shared.ResolveUserName(edit.Reviewer)
 	}
 
 	return resp
@@ -377,24 +378,6 @@ func (s *PendingEditService) toResponses(edits []adminm.PendingEntityEdit) []con
 		responses[i] = *s.toResponse(&edits[i])
 	}
 	return responses
-}
-
-// displayName returns a display name from a user, preferring username > first+last > email.
-func displayName(u *authm.User) string {
-	if u.Username != nil && *u.Username != "" {
-		return *u.Username
-	}
-	if u.FirstName != nil && *u.FirstName != "" {
-		name := *u.FirstName
-		if u.LastName != nil && *u.LastName != "" {
-			name += " " + *u.LastName
-		}
-		return name
-	}
-	if u.Email != nil {
-		return *u.Email
-	}
-	return ""
 }
 
 // sendApprovalEmail looks up the submitter and entity, then sends an approval notification.
@@ -415,7 +398,7 @@ func (s *PendingEditService) sendApprovalEmail(edit *adminm.PendingEntityEdit) {
 	}
 
 	entityName, entityURL := s.resolveEntityInfo(edit.EntityType, edit.EntityID)
-	username := displayName(&user)
+	username := shared.ResolveUserName(&user)
 
 	if err := s.emailService.SendEditApprovedEmail(*user.Email, username, edit.EntityType, entityName, entityURL); err != nil {
 		log.Printf("sendApprovalEmail: failed to send email to %s: %v", *user.Email, err)
@@ -440,7 +423,7 @@ func (s *PendingEditService) sendRejectionEmail(edit *adminm.PendingEntityEdit, 
 	}
 
 	entityName, _ := s.resolveEntityInfo(edit.EntityType, edit.EntityID)
-	username := displayName(&user)
+	username := shared.ResolveUserName(&user)
 
 	if err := s.emailService.SendEditRejectedEmail(*user.Email, username, edit.EntityType, entityName, reason); err != nil {
 		log.Printf("sendRejectionEmail: failed to send email to %s: %v", *user.Email, err)

--- a/backend/internal/services/admin/pending_edit_test.go
+++ b/backend/internal/services/admin/pending_edit_test.go
@@ -874,41 +874,11 @@ func (s *PendingEditServiceIntegrationTestSuite) TestCancelPendingEdit_AllowsNew
 	s.NotNil(resp)
 }
 
-// =============================================================================
-// displayName helper tests
-// =============================================================================
-
-func TestDisplayName(t *testing.T) {
-	username := "testuser"
-	first := "John"
-	last := "Doe"
-	email := "john@test.com"
-
-	t.Run("PreferUsername", func(t *testing.T) {
-		u := &authm.User{Username: &username, FirstName: &first, Email: &email}
-		assert.Equal(t, "testuser", displayName(u))
-	})
-
-	t.Run("FallbackToFirstLast", func(t *testing.T) {
-		u := &authm.User{FirstName: &first, LastName: &last, Email: &email}
-		assert.Equal(t, "John Doe", displayName(u))
-	})
-
-	t.Run("FallbackToFirstOnly", func(t *testing.T) {
-		u := &authm.User{FirstName: &first, Email: &email}
-		assert.Equal(t, "John", displayName(u))
-	})
-
-	t.Run("FallbackToEmail", func(t *testing.T) {
-		u := &authm.User{Email: &email}
-		assert.Equal(t, "john@test.com", displayName(u))
-	})
-
-	t.Run("EmptyUser", func(t *testing.T) {
-		u := &authm.User{}
-		assert.Equal(t, "", displayName(u))
-	})
-}
+// PSY-612: the per-service displayName helper has been replaced with
+// services/shared.ResolveUserName. The full chain — including the email
+// local-part fallback that this surface previously omitted (it leaked the
+// raw email and returned "" for empty users) — is locked down in
+// services/shared/user_resolver_test.go.
 
 // =============================================================================
 // Email notification tests

--- a/backend/internal/services/admin/pending_edit_test.go
+++ b/backend/internal/services/admin/pending_edit_test.go
@@ -874,12 +874,6 @@ func (s *PendingEditServiceIntegrationTestSuite) TestCancelPendingEdit_AllowsNew
 	s.NotNil(resp)
 }
 
-// PSY-612: the per-service displayName helper has been replaced with
-// services/shared.ResolveUserName. The full chain — including the email
-// local-part fallback that this surface previously omitted (it leaked the
-// raw email and returned "" for empty users) — is locked down in
-// services/shared/user_resolver_test.go.
-
 // =============================================================================
 // Email notification tests
 // =============================================================================

--- a/backend/internal/services/community/collection.go
+++ b/backend/internal/services/community/collection.go
@@ -1850,11 +1850,9 @@ func (s *CollectionService) SetFeatured(slug string, featured bool) error {
 // Helper methods
 // ============================================================================
 
-// resolveUserUsername loads a user by ID and returns the *string username.
-// Thin wrapper around shared.ResolveUserUsername — see that helper for the
-// behaviour contract. PSY-612 consolidated the resolution chain into a
-// single shared helper; this method exists for callsite ergonomics
-// (callers in this file have a userID, not a preloaded *User).
+// resolveUserUsername loads a user by ID and delegates to
+// shared.ResolveUserUsername. Returns nil when the lookup fails so the
+// caller can render the byline unlinked.
 func (s *CollectionService) resolveUserUsername(userID uint) *string {
 	var user authm.User
 	if err := s.db.Select("id, username").First(&user, userID).Error; err != nil {
@@ -1864,9 +1862,8 @@ func (s *CollectionService) resolveUserUsername(userID uint) *string {
 }
 
 // batchResolveUserUsernames resolves usernames for multiple user IDs in a
-// single query. Delegates to shared.BatchResolveUserUsernames. Returns an
-// empty map on DB error (parity with the prior implementation, which
-// silently ignored Find errors).
+// single query. Returns an empty (non-nil) map on DB error so callers can
+// index without a nil-check guard.
 func (s *CollectionService) batchResolveUserUsernames(userIDs []uint) map[uint]*string {
 	result, err := shared.BatchResolveUserUsernames(s.db, userIDs)
 	if err != nil {
@@ -1875,9 +1872,8 @@ func (s *CollectionService) batchResolveUserUsernames(userIDs []uint) map[uint]*
 	return result
 }
 
-// resolveUserName loads a user by ID and returns the never-empty display
-// name. Thin wrapper around shared.ResolveUserName — see that helper for
-// the resolution chain.
+// resolveUserName loads a user by ID and delegates to shared.ResolveUserName.
+// Falls back to "Anonymous" when the lookup fails.
 func (s *CollectionService) resolveUserName(userID uint) string {
 	var user authm.User
 	if err := s.db.Select("id, username, first_name, last_name, email").First(&user, userID).Error; err != nil {
@@ -1887,9 +1883,8 @@ func (s *CollectionService) resolveUserName(userID uint) string {
 }
 
 // batchResolveUserNames resolves display names for multiple user IDs in a
-// single query. Delegates to shared.BatchResolveUserNames. Returns an empty
-// map on DB error (parity with the prior implementation, which silently
-// ignored Find errors).
+// single query. Returns an empty (non-nil) map on DB error so callers can
+// index without a nil-check guard.
 func (s *CollectionService) batchResolveUserNames(userIDs []uint) map[uint]string {
 	result, err := shared.BatchResolveUserNames(s.db, userIDs)
 	if err != nil {

--- a/backend/internal/services/community/collection.go
+++ b/backend/internal/services/community/collection.go
@@ -16,6 +16,7 @@ import (
 	catalogm "psychic-homily-backend/internal/models/catalog"
 	communitym "psychic-homily-backend/internal/models/community"
 	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/services/shared"
 	"psychic-homily-backend/internal/utils"
 )
 
@@ -1849,97 +1850,51 @@ func (s *CollectionService) SetFeatured(slug string, featured bool) error {
 // Helper methods
 // ============================================================================
 
-// resolveUserUsername returns the user's username (for /users/:username
-// links) or nil when the user has no username set. Distinct from
-// resolveUserName, which falls back to first/last/email so it can never be
-// safely used in a URL slug. PSY-353.
+// resolveUserUsername loads a user by ID and returns the *string username.
+// Thin wrapper around shared.ResolveUserUsername — see that helper for the
+// behaviour contract. PSY-612 consolidated the resolution chain into a
+// single shared helper; this method exists for callsite ergonomics
+// (callers in this file have a userID, not a preloaded *User).
 func (s *CollectionService) resolveUserUsername(userID uint) *string {
 	var user authm.User
 	if err := s.db.Select("id, username").First(&user, userID).Error; err != nil {
 		return nil
 	}
-	if user.Username == nil || *user.Username == "" {
-		return nil
-	}
-	username := *user.Username
-	return &username
+	return shared.ResolveUserUsername(&user)
 }
 
-// batchResolveUserUsernames resolves usernames for multiple user IDs.
-// Map values are nil-pointer when the user has no username — callers should
-// treat that as "render unlinked". PSY-353.
+// batchResolveUserUsernames resolves usernames for multiple user IDs in a
+// single query. Delegates to shared.BatchResolveUserUsernames. Returns an
+// empty map on DB error (parity with the prior implementation, which
+// silently ignored Find errors).
 func (s *CollectionService) batchResolveUserUsernames(userIDs []uint) map[uint]*string {
-	result := make(map[uint]*string)
-	if len(userIDs) == 0 {
-		return result
-	}
-	var users []authm.User
-	s.db.Select("id, username").Where("id IN ?", userIDs).Find(&users)
-	for _, user := range users {
-		if user.Username != nil && *user.Username != "" {
-			username := *user.Username
-			result[user.ID] = &username
-		} else {
-			result[user.ID] = nil
-		}
+	result, err := shared.BatchResolveUserUsernames(s.db, userIDs)
+	if err != nil {
+		return make(map[uint]*string)
 	}
 	return result
 }
 
-// resolveUserName returns the display name for a user ID
+// resolveUserName loads a user by ID and returns the never-empty display
+// name. Thin wrapper around shared.ResolveUserName — see that helper for
+// the resolution chain.
 func (s *CollectionService) resolveUserName(userID uint) string {
 	var user authm.User
 	if err := s.db.Select("id, username, first_name, last_name, email").First(&user, userID).Error; err != nil {
 		return "Anonymous"
 	}
-	if user.Username != nil && *user.Username != "" {
-		return *user.Username
-	}
-	if user.FirstName != nil && *user.FirstName != "" {
-		name := *user.FirstName
-		if user.LastName != nil && *user.LastName != "" {
-			name += " " + *user.LastName
-		}
-		return name
-	}
-	if user.Email != nil && *user.Email != "" {
-		if idx := strings.Index(*user.Email, "@"); idx > 0 {
-			return (*user.Email)[:idx]
-		}
-	}
-	return "Anonymous"
+	return shared.ResolveUserName(&user)
 }
 
-// batchResolveUserNames resolves user names for multiple user IDs
+// batchResolveUserNames resolves display names for multiple user IDs in a
+// single query. Delegates to shared.BatchResolveUserNames. Returns an empty
+// map on DB error (parity with the prior implementation, which silently
+// ignored Find errors).
 func (s *CollectionService) batchResolveUserNames(userIDs []uint) map[uint]string {
-	result := make(map[uint]string)
-	if len(userIDs) == 0 {
-		return result
+	result, err := shared.BatchResolveUserNames(s.db, userIDs)
+	if err != nil {
+		return make(map[uint]string)
 	}
-
-	var users []authm.User
-	s.db.Select("id, username, first_name, last_name, email").Where("id IN ?", userIDs).Find(&users)
-
-	for _, user := range users {
-		if user.Username != nil && *user.Username != "" {
-			result[user.ID] = *user.Username
-		} else if user.FirstName != nil && *user.FirstName != "" {
-			name := *user.FirstName
-			if user.LastName != nil && *user.LastName != "" {
-				name += " " + *user.LastName
-			}
-			result[user.ID] = name
-		} else if user.Email != nil && *user.Email != "" {
-			if idx := strings.Index(*user.Email, "@"); idx > 0 {
-				result[user.ID] = (*user.Email)[:idx]
-			} else {
-				result[user.ID] = "Anonymous"
-			}
-		} else {
-			result[user.ID] = "Anonymous"
-		}
-	}
-
 	return result
 }
 

--- a/backend/internal/services/contracts/admin.go
+++ b/backend/internal/services/contracts/admin.go
@@ -19,16 +19,24 @@ type AuditLogFilters struct {
 	ActorID    *uint
 }
 
-// AuditLogResponse represents an audit log entry in API responses
+// AuditLogResponse represents an audit log entry in API responses.
+//
+// PSY-612: ActorName + ActorUsername were added so the admin audit log can
+// render a resolved display name (matching the rest of the moderation UI)
+// and an optional /users/:slug link, rather than leaking the raw email.
+// ActorEmail is retained for backward compatibility — the UI can phase off
+// it once the frontend ships the <UserAttribution /> primitive (PSY-613).
 type AuditLogResponse struct {
-	ID         uint                   `json:"id"`
-	ActorID    *uint                  `json:"actor_id"`
-	ActorEmail string                 `json:"actor_email,omitempty"`
-	Action     string                 `json:"action"`
-	EntityType string                 `json:"entity_type"`
-	EntityID   uint                   `json:"entity_id"`
-	Metadata   map[string]interface{} `json:"metadata,omitempty"`
-	CreatedAt  time.Time              `json:"created_at"`
+	ID            uint                   `json:"id"`
+	ActorID       *uint                  `json:"actor_id"`
+	ActorEmail    string                 `json:"actor_email,omitempty"`
+	ActorName     string                 `json:"actor_name,omitempty"`
+	ActorUsername *string                `json:"actor_username,omitempty"`
+	Action        string                 `json:"action"`
+	EntityType    string                 `json:"entity_type"`
+	EntityID      uint                   `json:"entity_id"`
+	Metadata      map[string]interface{} `json:"metadata,omitempty"`
+	CreatedAt     time.Time              `json:"created_at"`
 }
 
 // ──────────────────────────────────────────────

--- a/backend/internal/services/contracts/admin.go
+++ b/backend/internal/services/contracts/admin.go
@@ -21,11 +21,10 @@ type AuditLogFilters struct {
 
 // AuditLogResponse represents an audit log entry in API responses.
 //
-// PSY-612: ActorName + ActorUsername were added so the admin audit log can
-// render a resolved display name (matching the rest of the moderation UI)
-// and an optional /users/:slug link, rather than leaking the raw email.
-// ActorEmail is retained for backward compatibility — the UI can phase off
-// it once the frontend ships the <UserAttribution /> primitive (PSY-613).
+// ActorEmail is retained alongside ActorName/ActorUsername for backward
+// compatibility with existing frontend consumers; new consumers should
+// prefer the resolved name (and the optional /users/:slug link via
+// ActorUsername) and treat ActorEmail as deprecated.
 type AuditLogResponse struct {
 	ID            uint                   `json:"id"`
 	ActorID       *uint                  `json:"actor_id"`

--- a/backend/internal/services/engagement/comment_notification.go
+++ b/backend/internal/services/engagement/comment_notification.go
@@ -16,9 +16,9 @@ import (
 	"github.com/getsentry/sentry-go"
 	"gorm.io/gorm"
 
-	authm "psychic-homily-backend/internal/models/auth"
 	engagementm "psychic-homily-backend/internal/models/engagement"
 	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/services/shared"
 )
 
 // CommentNotificationService sends emails to subscribers and @-mentioned users on
@@ -232,21 +232,6 @@ func (s *CommentNotificationService) buildCommentURL(entityType engagementm.Comm
 	return fmt.Sprintf("%s#comment-%d", s.buildEntityURL(entityType, entityID), commentID)
 }
 
-// displayName returns a friendly name for a user: username first, else
-// first name, else "A contributor".
-func displayName(u *authm.User) string {
-	if u == nil {
-		return "A contributor"
-	}
-	if u.Username != nil && *u.Username != "" {
-		return *u.Username
-	}
-	if u.FirstName != nil && *u.FirstName != "" {
-		return *u.FirstName
-	}
-	return "A contributor"
-}
-
 // ─────────────────────────────────────────────────────────────
 // NotifySubscribers
 // ─────────────────────────────────────────────────────────────
@@ -315,7 +300,7 @@ func (s *CommentNotificationService) NotifySubscribers(commentID uint) error {
 	entityName := s.buildEntityName(comment.EntityType, comment.EntityID)
 	entityURL := s.buildEntityURL(comment.EntityType, comment.EntityID)
 	excerpt := buildExcerpt(comment.Body)
-	commenterName := displayName(&comment.User)
+	commenterName := shared.ResolveUserName(&comment.User)
 	now := time.Now().UTC()
 
 	for _, r := range rows {
@@ -429,7 +414,7 @@ func (s *CommentNotificationService) NotifyMentioned(commentID uint) error {
 	entityName := s.buildEntityName(comment.EntityType, comment.EntityID)
 	commentURL := s.buildCommentURL(comment.EntityType, comment.EntityID, comment.ID)
 	excerpt := buildExcerpt(comment.Body)
-	mentionerName := displayName(&comment.User)
+	mentionerName := shared.ResolveUserName(&comment.User)
 
 	for _, r := range rows {
 		if r.UserID == comment.UserID {

--- a/backend/internal/services/engagement/comment_service.go
+++ b/backend/internal/services/engagement/comment_service.go
@@ -20,6 +20,7 @@ import (
 	catalogm "psychic-homily-backend/internal/models/catalog"
 	engagementm "psychic-homily-backend/internal/models/engagement"
 	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/services/shared"
 )
 
 // FollowChecker is the minimal FollowService surface that CommentService
@@ -151,8 +152,8 @@ func commentToResponse(c *engagementm.Comment) *contracts.CommentResponse {
 		EntityID:        c.EntityID,
 		Kind:            string(c.Kind),
 		UserID:          c.UserID,
-		AuthorName:      resolveCommentAuthorName(&c.User),
-		AuthorUsername:  resolveCommentAuthorUsername(&c.User),
+		AuthorName:      shared.ResolveUserName(&c.User),
+		AuthorUsername:  shared.ResolveUserUsername(&c.User),
 		ParentID:        c.ParentID,
 		RootID:          c.RootID,
 		Depth:           c.Depth,
@@ -170,49 +171,6 @@ func commentToResponse(c *engagementm.Comment) *contracts.CommentResponse {
 		UpdatedAt:       c.UpdatedAt,
 	}
 	return resp
-}
-
-// resolveCommentAuthorName returns the display name for a comment's author —
-// never empty. Mirrors CollectionService.resolveUserName (PSY-353): prefer
-// username, fall back to first/last, then to the local-part of the email,
-// finally "Anonymous". Operates on the preloaded User so callers don't pay
-// an extra query per comment. PSY-552.
-func resolveCommentAuthorName(u *authm.User) string {
-	if u == nil || u.ID == 0 {
-		return "Anonymous"
-	}
-	if u.Username != nil && *u.Username != "" {
-		return *u.Username
-	}
-	if u.FirstName != nil && *u.FirstName != "" {
-		name := *u.FirstName
-		if u.LastName != nil && *u.LastName != "" {
-			name += " " + *u.LastName
-		}
-		return name
-	}
-	if u.Email != nil && *u.Email != "" {
-		if idx := strings.Index(*u.Email, "@"); idx > 0 {
-			return (*u.Email)[:idx]
-		}
-	}
-	return "Anonymous"
-}
-
-// resolveCommentAuthorUsername returns the author's username for /users/:username
-// links, or nil when the user has no username set. Distinct from
-// resolveCommentAuthorName, which falls back to first/last/email and so cannot
-// be safely used in a URL slug. Mirrors CollectionService.resolveUserUsername
-// (PSY-353). PSY-552.
-func resolveCommentAuthorUsername(u *authm.User) *string {
-	if u == nil || u.ID == 0 {
-		return nil
-	}
-	if u.Username == nil || *u.Username == "" {
-		return nil
-	}
-	username := *u.Username
-	return &username
 }
 
 // userTierHourlyLimit returns the hourly comment limit for a given user tier.
@@ -799,11 +757,13 @@ func (s *CommentService) GetCommentEditHistory(requesterID uint, commentID uint)
 			EditorUserID: e.EditorUserID,
 		}
 		if e.Editor != nil && e.Editor.ID != 0 {
-			if e.Editor.Username != nil {
-				entry.EditorUsername = *e.Editor.Username
-			}
-			if e.Editor.FirstName != nil {
-				entry.EditorName = *e.Editor.FirstName
+			// PSY-591/PSY-612: full canonical resolution chain — the prior
+			// implementation only set EditorName from FirstName and skipped
+			// the username + email-prefix fallbacks, so editors without a
+			// first name rendered as a blank cell in the admin UI.
+			entry.EditorName = shared.ResolveUserName(e.Editor)
+			if username := shared.ResolveUserUsername(e.Editor); username != nil {
+				entry.EditorUsername = *username
 			}
 		}
 		entries[i] = entry

--- a/backend/internal/services/engagement/comment_service.go
+++ b/backend/internal/services/engagement/comment_service.go
@@ -757,10 +757,6 @@ func (s *CommentService) GetCommentEditHistory(requesterID uint, commentID uint)
 			EditorUserID: e.EditorUserID,
 		}
 		if e.Editor != nil && e.Editor.ID != 0 {
-			// PSY-591/PSY-612: full canonical resolution chain — the prior
-			// implementation only set EditorName from FirstName and skipped
-			// the username + email-prefix fallbacks, so editors without a
-			// first name rendered as a blank cell in the admin UI.
 			entry.EditorName = shared.ResolveUserName(e.Editor)
 			if username := shared.ResolveUserUsername(e.Editor); username != nil {
 				entry.EditorUsername = *username

--- a/backend/internal/services/engagement/comment_service_test.go
+++ b/backend/internal/services/engagement/comment_service_test.go
@@ -295,13 +295,6 @@ func TestUserTierHourlyLimit(t *testing.T) {
 	assert.Equal(t, 5, userTierHourlyLimit("unknown_tier"))
 }
 
-// PSY-552: AuthorName / AuthorUsername resolution is now centralised in
-// services/shared.ResolveUserName / ResolveUserUsername (PSY-612). The full
-// chain — including the PSY-552 regression for non-nil-but-empty username
-// pointers — is locked down in services/shared/user_resolver_test.go.
-// Integration coverage that the comment surface delegates correctly is
-// retained via the CommentServiceIntegrationTestSuite.
-
 func TestWilsonScore(t *testing.T) {
 	t.Run("NoVotes", func(t *testing.T) {
 		score := wilsonScore(0, 0)

--- a/backend/internal/services/engagement/comment_service_test.go
+++ b/backend/internal/services/engagement/comment_service_test.go
@@ -295,109 +295,12 @@ func TestUserTierHourlyLimit(t *testing.T) {
 	assert.Equal(t, 5, userTierHourlyLimit("unknown_tier"))
 }
 
-// PSY-552: AuthorName resolver chain — username → first/last → email-prefix
-// → "Anonymous". Mirrors the PSY-353 collection contributor pattern. These
-// are pure-function tests (no DB) so the chain is locked down even when the
-// integration suite can't run.
-func TestResolveCommentAuthorName(t *testing.T) {
-	t.Run("NilUser_Anonymous", func(t *testing.T) {
-		assert.Equal(t, "Anonymous", resolveCommentAuthorName(nil))
-	})
-
-	t.Run("ZeroIDUser_Anonymous", func(t *testing.T) {
-		assert.Equal(t, "Anonymous", resolveCommentAuthorName(&authm.User{}))
-	})
-
-	t.Run("UsernameWins", func(t *testing.T) {
-		username := "ph_user"
-		first := "Ignored"
-		email := "ignored@example.com"
-		u := &authm.User{Username: &username, FirstName: &first, Email: &email}
-		u.ID = 7
-		assert.Equal(t, "ph_user", resolveCommentAuthorName(u))
-	})
-
-	t.Run("FirstAndLast_NoUsername", func(t *testing.T) {
-		first := "Jane"
-		last := "Doe"
-		u := &authm.User{FirstName: &first, LastName: &last}
-		u.ID = 8
-		assert.Equal(t, "Jane Doe", resolveCommentAuthorName(u))
-	})
-
-	t.Run("FirstOnly_NoUsername", func(t *testing.T) {
-		first := "Jane"
-		u := &authm.User{FirstName: &first}
-		u.ID = 9
-		assert.Equal(t, "Jane", resolveCommentAuthorName(u))
-	})
-
-	t.Run("EmailPrefixFallback", func(t *testing.T) {
-		email := "dogfood@psychichomily.com"
-		u := &authm.User{Email: &email}
-		u.ID = 10
-		assert.Equal(t, "dogfood", resolveCommentAuthorName(u))
-	})
-
-	t.Run("EmailWithNoAtSign_Anonymous", func(t *testing.T) {
-		// Should never happen in practice (email column has @ on insert),
-		// but the helper falls through to "Anonymous" rather than echo a
-		// malformed string.
-		email := "noatsign"
-		u := &authm.User{Email: &email}
-		u.ID = 11
-		assert.Equal(t, "Anonymous", resolveCommentAuthorName(u))
-	})
-
-	t.Run("EmptyUsernamePointer_FallsThrough", func(t *testing.T) {
-		// PSY-552 regression check: a non-nil Username pointer pointing at
-		// an empty string must NOT short-circuit the chain (the original
-		// bug surfaced because *Username == "" was treated as a valid
-		// display name, leaking an empty author_name on the wire).
-		empty := ""
-		first := "Backup"
-		u := &authm.User{Username: &empty, FirstName: &first}
-		u.ID = 12
-		assert.Equal(t, "Backup", resolveCommentAuthorName(u))
-	})
-}
-
-// PSY-552: AuthorUsername must be non-nil only when the user has a real
-// username. Mirrors PSY-353's resolveUserUsername: nil signals to the
-// frontend "render byline as plain text — no /users/:slug link".
-func TestResolveCommentAuthorUsername(t *testing.T) {
-	t.Run("NilUser_Nil", func(t *testing.T) {
-		assert.Nil(t, resolveCommentAuthorUsername(nil))
-	})
-
-	t.Run("ZeroIDUser_Nil", func(t *testing.T) {
-		assert.Nil(t, resolveCommentAuthorUsername(&authm.User{}))
-	})
-
-	t.Run("NoUsername_Nil", func(t *testing.T) {
-		first := "Jane"
-		u := &authm.User{FirstName: &first}
-		u.ID = 1
-		assert.Nil(t, resolveCommentAuthorUsername(u))
-	})
-
-	t.Run("EmptyUsername_Nil", func(t *testing.T) {
-		empty := ""
-		u := &authm.User{Username: &empty}
-		u.ID = 2
-		assert.Nil(t, resolveCommentAuthorUsername(u))
-	})
-
-	t.Run("UsernameSet_Pointer", func(t *testing.T) {
-		username := "ph_user"
-		u := &authm.User{Username: &username}
-		u.ID = 3
-		got := resolveCommentAuthorUsername(u)
-		if assert.NotNil(t, got) {
-			assert.Equal(t, "ph_user", *got)
-		}
-	})
-}
+// PSY-552: AuthorName / AuthorUsername resolution is now centralised in
+// services/shared.ResolveUserName / ResolveUserUsername (PSY-612). The full
+// chain — including the PSY-552 regression for non-nil-but-empty username
+// pointers — is locked down in services/shared/user_resolver_test.go.
+// Integration coverage that the comment surface delegates correctly is
+// retained via the CommentServiceIntegrationTestSuite.
 
 func TestWilsonScore(t *testing.T) {
 	t.Run("NoVotes", func(t *testing.T) {

--- a/backend/internal/services/shared/user_resolver.go
+++ b/backend/internal/services/shared/user_resolver.go
@@ -1,0 +1,127 @@
+// Package shared exposes cross-cutting service helpers that don't belong to a
+// single domain (collection, comment, request, etc.). It is the canonical home
+// for resolution chains, name formatters, and other zero-dependency utilities
+// that need to render identically regardless of which surface looks them up.
+//
+// User attribution (PSY-612 / PSY-598):
+//
+//	Resolve* helpers return the same display name for a given user no matter
+//	which handler asks. Prior to consolidation, five backend sites had their
+//	own slightly-different chains: some stopped at "Unknown", some leaked the
+//	raw email address, and some omitted the email-prefix step entirely. See
+//	docs/research/user-attribution-audit.md for the full classification.
+package shared
+
+import (
+	"strings"
+
+	"gorm.io/gorm"
+
+	authm "psychic-homily-backend/internal/models/auth"
+)
+
+// ResolveUserName returns the display name for a user. Never empty.
+//
+// Resolution chain, in order:
+//  1. user.Username                            (preferred, also the URL slug)
+//  2. user.FirstName [+ " " + user.LastName]   (human full name)
+//  3. local-part of user.Email (before "@")    (last-resort handle)
+//  4. "Anonymous"                              (terminal fallback)
+//
+// nil-safe: returns "Anonymous" when the user is nil or has ID 0.
+//
+// Use this whenever a backend response needs a label for a user. Pair with
+// ResolveUserUsername when you also want a profile-link slug — the username
+// form returns *string so consumers can omit the link when no username is set.
+func ResolveUserName(user *authm.User) string {
+	if user == nil || user.ID == 0 {
+		return "Anonymous"
+	}
+	if user.Username != nil && *user.Username != "" {
+		return *user.Username
+	}
+	if user.FirstName != nil && *user.FirstName != "" {
+		name := *user.FirstName
+		if user.LastName != nil && *user.LastName != "" {
+			name += " " + *user.LastName
+		}
+		return name
+	}
+	if user.Email != nil && *user.Email != "" {
+		if idx := strings.Index(*user.Email, "@"); idx > 0 {
+			return (*user.Email)[:idx]
+		}
+	}
+	return "Anonymous"
+}
+
+// ResolveUserUsername returns the user's username for /users/:username links,
+// or nil when the user has no username set. Distinct from ResolveUserName,
+// which falls back to first/last/email and so cannot be safely used in a URL
+// slug.
+//
+// nil-safe: returns nil when the user is nil or has ID 0.
+//
+// Callers should treat nil as "render unlinked" — emit plain text with no
+// anchor — and a non-nil pointer as "render <Link href={'/users/' + *u}>".
+func ResolveUserUsername(user *authm.User) *string {
+	if user == nil || user.ID == 0 {
+		return nil
+	}
+	if user.Username == nil || *user.Username == "" {
+		return nil
+	}
+	username := *user.Username
+	return &username
+}
+
+// BatchResolveUserNames resolves display names for multiple user IDs in a
+// single query. Returns a map keyed by user ID; missing users are absent
+// from the map (callers can default to "Anonymous" via ResolveUserName(nil)
+// or by checking the map directly).
+//
+// Returns an empty map (not nil) when userIDs is empty so callers can index
+// without nil-check guards.
+func BatchResolveUserNames(db *gorm.DB, userIDs []uint) (map[uint]string, error) {
+	result := make(map[uint]string)
+	if len(userIDs) == 0 {
+		return result, nil
+	}
+
+	var users []authm.User
+	if err := db.Select("id, username, first_name, last_name, email").
+		Where("id IN ?", userIDs).
+		Find(&users).Error; err != nil {
+		return nil, err
+	}
+
+	for i := range users {
+		result[users[i].ID] = ResolveUserName(&users[i])
+	}
+	return result, nil
+}
+
+// BatchResolveUserUsernames resolves usernames for multiple user IDs in a
+// single query. Map values are nil-pointer when the user has no username —
+// callers should treat that as "render unlinked".
+//
+// Returns an empty map (not nil) when userIDs is empty so callers can index
+// without nil-check guards.
+func BatchResolveUserUsernames(db *gorm.DB, userIDs []uint) (map[uint]*string, error) {
+	result := make(map[uint]*string)
+	if len(userIDs) == 0 {
+		return result, nil
+	}
+
+	var users []authm.User
+	if err := db.Select("id, username").
+		Where("id IN ?", userIDs).
+		Find(&users).Error; err != nil {
+		return nil, err
+	}
+
+	for i := range users {
+		result[users[i].ID] = ResolveUserUsername(&users[i])
+	}
+	return result, nil
+}

--- a/backend/internal/services/shared/user_resolver_test.go
+++ b/backend/internal/services/shared/user_resolver_test.go
@@ -1,0 +1,111 @@
+package shared
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	authm "psychic-homily-backend/internal/models/auth"
+)
+
+// =============================================================================
+// ResolveUserName — full-chain coverage
+// =============================================================================
+
+func TestResolveUserName_Nil(t *testing.T) {
+	assert.Equal(t, "Anonymous", ResolveUserName(nil))
+}
+
+func TestResolveUserName_ZeroID(t *testing.T) {
+	// A zero-ID user (e.g. an unloaded preload) should be treated as nil.
+	assert.Equal(t, "Anonymous", ResolveUserName(&authm.User{}))
+}
+
+func TestResolveUserName_PrefersUsername(t *testing.T) {
+	username := "ph_user"
+	first := "Jane"
+	last := "Doe"
+	email := "jane@test.com"
+	u := &authm.User{ID: 1, Username: &username, FirstName: &first, LastName: &last, Email: &email}
+	assert.Equal(t, "ph_user", ResolveUserName(u))
+}
+
+func TestResolveUserName_FirstAndLast(t *testing.T) {
+	first := "Jane"
+	last := "Doe"
+	email := "jane@test.com"
+	u := &authm.User{ID: 1, FirstName: &first, LastName: &last, Email: &email}
+	assert.Equal(t, "Jane Doe", ResolveUserName(u))
+}
+
+func TestResolveUserName_FirstOnly(t *testing.T) {
+	first := "Jane"
+	email := "jane@test.com"
+	u := &authm.User{ID: 1, FirstName: &first, Email: &email}
+	assert.Equal(t, "Jane", ResolveUserName(u))
+}
+
+func TestResolveUserName_FallbackToEmailPrefix(t *testing.T) {
+	email := "dogfood@test.com"
+	u := &authm.User{ID: 1, Email: &email}
+	assert.Equal(t, "dogfood", ResolveUserName(u))
+}
+
+func TestResolveUserName_AnonymousWhenAllEmpty(t *testing.T) {
+	emptyUsername := ""
+	emptyFirst := ""
+	u := &authm.User{ID: 1, Username: &emptyUsername, FirstName: &emptyFirst}
+	assert.Equal(t, "Anonymous", ResolveUserName(u))
+}
+
+func TestResolveUserName_EmailWithoutAtSign(t *testing.T) {
+	// Edge case: malformed email field that has no "@". Must fall through to
+	// "Anonymous" rather than returning the raw value.
+	bad := "no-at-sign"
+	u := &authm.User{ID: 1, Email: &bad}
+	assert.Equal(t, "Anonymous", ResolveUserName(u))
+}
+
+func TestResolveUserName_BlankUsernameFallsThrough(t *testing.T) {
+	// A non-nil but empty username must fall through to first/last.
+	blank := ""
+	first := "Backup"
+	u := &authm.User{ID: 1, Username: &blank, FirstName: &first}
+	assert.Equal(t, "Backup", ResolveUserName(u))
+}
+
+// =============================================================================
+// ResolveUserUsername — *string semantics
+// =============================================================================
+
+func TestResolveUserUsername_NilReturnsNil(t *testing.T) {
+	assert.Nil(t, ResolveUserUsername(nil))
+}
+
+func TestResolveUserUsername_ZeroIDReturnsNil(t *testing.T) {
+	assert.Nil(t, ResolveUserUsername(&authm.User{}))
+}
+
+func TestResolveUserUsername_NoUsernameReturnsNil(t *testing.T) {
+	first := "Jane"
+	u := &authm.User{ID: 1, FirstName: &first}
+	assert.Nil(t, ResolveUserUsername(u))
+}
+
+func TestResolveUserUsername_BlankUsernameReturnsNil(t *testing.T) {
+	blank := ""
+	u := &authm.User{ID: 1, Username: &blank}
+	assert.Nil(t, ResolveUserUsername(u))
+}
+
+func TestResolveUserUsername_ReturnsCopy(t *testing.T) {
+	username := "ph_user"
+	u := &authm.User{ID: 1, Username: &username}
+	got := ResolveUserUsername(u)
+	if assert.NotNil(t, got) {
+		assert.Equal(t, "ph_user", *got)
+		// Mutating the source must not affect the returned value.
+		username = "mutated"
+		assert.Equal(t, "ph_user", *got)
+	}
+}


### PR DESCRIPTION
## Summary
- Introduce `services/shared.{ResolveUserName, ResolveUserUsername, BatchResolveUserNames, BatchResolveUserUsernames}` as the single source of truth for user-attribution display strings; replace 6 fragmented per-package implementations (3 of them buggy: pending_edit + entity_report leaked raw email and returned `""`, comment_notification stopped at `"A contributor"`, request stopped at `"Unknown"`).
- Knock-on fix: `GetCommentEditHistory` now sets `EditorName` via the full canonical chain (was only setting `FirstName`), closing the PSY-591 blank-cell bug; `AuditLogResponse` gains `actor_name` + `actor_username` so the admin audit log can render a resolved name and an optional `/users/:slug` link rather than leaking raw email (`actor_email` retained for compatibility — frontend follow-up is PSY-613).

## Test plan
- [x] `cd backend && go build ./...` — passed (caught a 6th forgotten call site in `entity_report.go` that grep didn't surface initially)
- [x] `cd backend && go test ./internal/services/shared/...` — passed
- [x] `cd backend && go test ./internal/services/...` — all packages pass (admin, auth, catalog, community, engagement, notification, pipeline, shared, user)
- [x] `cd backend && go test ./internal/api/handlers/community/... ./internal/api/handlers/admin/... ./internal/api/handlers/engagement/...` — passed (touched `request.go` + audit-log DTO; engagement covers `commentToResponse` + `GetCommentEditHistory` integration)

Closes PSY-612