### PR TITLE
PSY-615: add panic recovery to all 8 background-service ticker loops

### DIFF
--- a/backend/internal/services/admin/auto_promotion.go
+++ b/backend/internal/services/admin/auto_promotion.go
@@ -110,7 +110,6 @@ func (s *AutoPromotionService) Stop() {
 }
 
 // run is the main loop for the auto-promotion scheduler.
-// Panic recovery via shared.RunTickerLoop (PSY-615).
 func (s *AutoPromotionService) run(ctx context.Context) {
 	defer s.wg.Done()
 	shared.RunTickerLoop(ctx, "auto_promotion", s.interval, s.stopCh, true, func(_ context.Context) {

--- a/backend/internal/services/admin/auto_promotion.go
+++ b/backend/internal/services/admin/auto_promotion.go
@@ -17,6 +17,7 @@ import (
 	authm "psychic-homily-backend/internal/models/auth"
 	"psychic-homily-backend/internal/services/contracts"
 	"psychic-homily-backend/internal/services/notification"
+	"psychic-homily-backend/internal/services/shared"
 )
 
 // User tier constants.
@@ -109,27 +110,12 @@ func (s *AutoPromotionService) Stop() {
 }
 
 // run is the main loop for the auto-promotion scheduler.
+// Panic recovery via shared.RunTickerLoop (PSY-615).
 func (s *AutoPromotionService) run(ctx context.Context) {
 	defer s.wg.Done()
-
-	// Run immediately on startup
-	s.runEvaluationCycle()
-
-	ticker := time.NewTicker(s.interval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			s.logger.Info("auto-promotion scheduler context cancelled")
-			return
-		case <-s.stopCh:
-			s.logger.Info("auto-promotion scheduler received stop signal")
-			return
-		case <-ticker.C:
-			s.runEvaluationCycle()
-		}
-	}
+	shared.RunTickerLoop(ctx, "auto_promotion", s.interval, s.stopCh, true, func(_ context.Context) {
+		s.runEvaluationCycle()
+	})
 }
 
 // runEvaluationCycle performs a single evaluation of all users.

--- a/backend/internal/services/admin/cleanup.go
+++ b/backend/internal/services/admin/cleanup.go
@@ -100,10 +100,8 @@ func NewCleanupService(database *gorm.DB, userSvc cleanupUserService) *CleanupSe
 
 // Start begins the background cleanup job.
 //
-// PSY-615: account cleanup and tag prune run on two independent goroutines
-// (one per ticker) so a panic in one cycle can't take down the other. Each
-// loop is wrapped in shared.RunTickerLoop for panic recovery + isolated
-// per-tick recover.
+// Account cleanup and tag prune run on two independent goroutines (one
+// per ticker) so a panic in one cycle can't take down the other.
 func (s *CleanupService) Start(ctx context.Context) {
 	s.wg.Add(1)
 	go s.runCleanupLoop(ctx)
@@ -118,8 +116,7 @@ func (s *CleanupService) Start(ctx context.Context) {
 }
 
 // Stop gracefully stops the cleanup service.
-// Both ticker loops watch the same stopCh + ctx, so a single close + wait
-// drains both goroutines.
+// Both ticker loops watch the same stopCh, so one close drains both.
 func (s *CleanupService) Stop() {
 	close(s.stopCh)
 	s.wg.Wait()

--- a/backend/internal/services/admin/cleanup.go
+++ b/backend/internal/services/admin/cleanup.go
@@ -16,6 +16,7 @@ import (
 	adminm "psychic-homily-backend/internal/models/admin"
 	authm "psychic-homily-backend/internal/models/auth"
 	"psychic-homily-backend/internal/services/notification"
+	"psychic-homily-backend/internal/services/shared"
 )
 
 // Default cleanup interval (24 hours)
@@ -97,10 +98,17 @@ func NewCleanupService(database *gorm.DB, userSvc cleanupUserService) *CleanupSe
 	}
 }
 
-// Start begins the background cleanup job
+// Start begins the background cleanup job.
+//
+// PSY-615: account cleanup and tag prune run on two independent goroutines
+// (one per ticker) so a panic in one cycle can't take down the other. Each
+// loop is wrapped in shared.RunTickerLoop for panic recovery + isolated
+// per-tick recover.
 func (s *CleanupService) Start(ctx context.Context) {
 	s.wg.Add(1)
-	go s.run(ctx)
+	go s.runCleanupLoop(ctx)
+	s.wg.Add(1)
+	go s.runTagPruneLoop(ctx)
 	s.logger.Info("account cleanup service started",
 		"interval_hours", s.interval.Hours(),
 		"tag_prune_enabled", s.tagPruneEnabled,
@@ -109,42 +117,29 @@ func (s *CleanupService) Start(ctx context.Context) {
 	)
 }
 
-// Stop gracefully stops the cleanup service
+// Stop gracefully stops the cleanup service.
+// Both ticker loops watch the same stopCh + ctx, so a single close + wait
+// drains both goroutines.
 func (s *CleanupService) Stop() {
 	close(s.stopCh)
 	s.wg.Wait()
 	s.logger.Info("account cleanup service stopped")
 }
 
-// run is the main loop for the cleanup service.
-// Runs account cleanup and tag prune on independent tickers in a single goroutine.
-func (s *CleanupService) run(ctx context.Context) {
+// runCleanupLoop runs the account cleanup cycle on its own ticker.
+func (s *CleanupService) runCleanupLoop(ctx context.Context) {
 	defer s.wg.Done()
+	shared.RunTickerLoop(ctx, "cleanup_accounts", s.interval, s.stopCh, true, func(_ context.Context) {
+		s.runCleanupCycle()
+	})
+}
 
-	// Run immediately on startup
-	s.runCleanupCycle()
-	s.runTagPruneCycle(ctx)
-
-	ticker := time.NewTicker(s.interval)
-	defer ticker.Stop()
-
-	tagPruneTicker := time.NewTicker(s.tagPruneInterval)
-	defer tagPruneTicker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			s.logger.Info("cleanup service context cancelled")
-			return
-		case <-s.stopCh:
-			s.logger.Info("cleanup service received stop signal")
-			return
-		case <-ticker.C:
-			s.runCleanupCycle()
-		case <-tagPruneTicker.C:
-			s.runTagPruneCycle(ctx)
-		}
-	}
+// runTagPruneLoop runs the entity-tags prune cycle on its own ticker.
+func (s *CleanupService) runTagPruneLoop(ctx context.Context) {
+	defer s.wg.Done()
+	shared.RunTickerLoop(ctx, "cleanup_tag_prune", s.tagPruneInterval, s.stopCh, true, func(c context.Context) {
+		s.runTagPruneCycle(c)
+	})
 }
 
 // runCleanupCycle performs a single cleanup cycle

--- a/backend/internal/services/catalog/radio_fetch_service.go
+++ b/backend/internal/services/catalog/radio_fetch_service.go
@@ -115,8 +115,7 @@ func (s *RadioFetchService) Stop() {
 	s.logger.Info("radio fetch service stopped")
 }
 
-// runFetchLoop runs the periodic station fetch cycle.
-// Panic recovery via shared.RunTickerLoop (PSY-615). Runs once on startup.
+// runFetchLoop runs the periodic station fetch cycle. Runs once on startup.
 func (s *RadioFetchService) runFetchLoop(ctx context.Context) {
 	defer s.wg.Done()
 	shared.RunTickerLoop(ctx, "radio_fetch", s.fetchInterval, s.stopCh, true, func(_ context.Context) {
@@ -125,8 +124,7 @@ func (s *RadioFetchService) runFetchLoop(ctx context.Context) {
 }
 
 // runAffinityLoop runs the periodic affinity computation.
-// Panic recovery via shared.RunTickerLoop (PSY-615). Does NOT run on startup —
-// the first fetch cycle is allowed to complete first.
+// No startup cycle — the first fetch cycle is allowed to complete first.
 func (s *RadioFetchService) runAffinityLoop(ctx context.Context) {
 	defer s.wg.Done()
 	shared.RunTickerLoop(ctx, "radio_affinity", s.affinityInterval, s.stopCh, false, func(_ context.Context) {
@@ -135,8 +133,7 @@ func (s *RadioFetchService) runAffinityLoop(ctx context.Context) {
 }
 
 // runReMatchLoop runs the periodic re-matching of unmatched plays.
-// Panic recovery via shared.RunTickerLoop (PSY-615). Does NOT run on startup —
-// the first fetch cycle is allowed to complete first.
+// No startup cycle — the first fetch cycle is allowed to complete first.
 func (s *RadioFetchService) runReMatchLoop(ctx context.Context) {
 	defer s.wg.Done()
 	shared.RunTickerLoop(ctx, "radio_rematch", s.rematchInterval, s.stopCh, false, func(_ context.Context) {

--- a/backend/internal/services/catalog/radio_fetch_service.go
+++ b/backend/internal/services/catalog/radio_fetch_service.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/services/shared"
 )
 
 // Default radio fetch interval (6 hours)
@@ -115,65 +116,32 @@ func (s *RadioFetchService) Stop() {
 }
 
 // runFetchLoop runs the periodic station fetch cycle.
+// Panic recovery via shared.RunTickerLoop (PSY-615). Runs once on startup.
 func (s *RadioFetchService) runFetchLoop(ctx context.Context) {
 	defer s.wg.Done()
-
-	// Run immediately on startup
-	s.runFetchCycle()
-
-	ticker := time.NewTicker(s.fetchInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-s.stopCh:
-			return
-		case <-ticker.C:
-			s.runFetchCycle()
-		}
-	}
+	shared.RunTickerLoop(ctx, "radio_fetch", s.fetchInterval, s.stopCh, true, func(_ context.Context) {
+		s.runFetchCycle()
+	})
 }
 
 // runAffinityLoop runs the periodic affinity computation.
+// Panic recovery via shared.RunTickerLoop (PSY-615). Does NOT run on startup —
+// the first fetch cycle is allowed to complete first.
 func (s *RadioFetchService) runAffinityLoop(ctx context.Context) {
 	defer s.wg.Done()
-
-	// Don't run immediately — let the first fetch cycle complete
-	ticker := time.NewTicker(s.affinityInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-s.stopCh:
-			return
-		case <-ticker.C:
-			s.runAffinityCycle()
-		}
-	}
+	shared.RunTickerLoop(ctx, "radio_affinity", s.affinityInterval, s.stopCh, false, func(_ context.Context) {
+		s.runAffinityCycle()
+	})
 }
 
 // runReMatchLoop runs the periodic re-matching of unmatched plays.
+// Panic recovery via shared.RunTickerLoop (PSY-615). Does NOT run on startup —
+// the first fetch cycle is allowed to complete first.
 func (s *RadioFetchService) runReMatchLoop(ctx context.Context) {
 	defer s.wg.Done()
-
-	// Don't run immediately — let the first fetch cycle complete
-	ticker := time.NewTicker(s.rematchInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-s.stopCh:
-			return
-		case <-ticker.C:
-			s.runReMatchCycle()
-		}
-	}
+	shared.RunTickerLoop(ctx, "radio_rematch", s.rematchInterval, s.stopCh, false, func(_ context.Context) {
+		s.runReMatchCycle()
+	})
 }
 
 // runFetchCycle fetches new episodes from all active stations sequentially.

--- a/backend/internal/services/catalog/relationship_derivation_service.go
+++ b/backend/internal/services/catalog/relationship_derivation_service.go
@@ -65,8 +65,7 @@ func (s *RelationshipDerivationService) Stop() {
 }
 
 // runLoop runs the periodic derivation cycle.
-// Panic recovery via shared.RunTickerLoop (PSY-615). Does NOT run on startup —
-// the admin endpoint is used for immediate triggering.
+// No startup cycle — the admin endpoint is used for immediate triggering.
 func (s *RelationshipDerivationService) runLoop(ctx context.Context) {
 	defer s.wg.Done()
 	shared.RunTickerLoop(ctx, "relationship_derivation", s.interval, s.stopCh, false, func(_ context.Context) {

--- a/backend/internal/services/catalog/relationship_derivation_service.go
+++ b/backend/internal/services/catalog/relationship_derivation_service.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"sync"
 	"time"
+
+	"psychic-homily-backend/internal/services/shared"
 )
 
 // DefaultDerivationInterval is the default interval for relationship derivation (24 hours).
@@ -63,24 +65,13 @@ func (s *RelationshipDerivationService) Stop() {
 }
 
 // runLoop runs the periodic derivation cycle.
+// Panic recovery via shared.RunTickerLoop (PSY-615). Does NOT run on startup —
+// the admin endpoint is used for immediate triggering.
 func (s *RelationshipDerivationService) runLoop(ctx context.Context) {
 	defer s.wg.Done()
-
-	// Don't run immediately on startup — let the server initialize first.
-	// The admin endpoint can be used for immediate triggering.
-	ticker := time.NewTicker(s.interval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-s.stopCh:
-			return
-		case <-ticker.C:
-			s.RunDerivationCycle()
-		}
-	}
+	shared.RunTickerLoop(ctx, "relationship_derivation", s.interval, s.stopCh, false, func(_ context.Context) {
+		s.RunDerivationCycle()
+	})
 }
 
 // RunDerivationCycle runs both shared_bills and shared_label derivation.

--- a/backend/internal/services/engagement/collection_digest.go
+++ b/backend/internal/services/engagement/collection_digest.go
@@ -112,11 +112,10 @@ func (s *CollectionDigestService) Stop() {
 	s.logger.Info("collection digest service stopped")
 }
 
-// run is the main loop for the digest service.
-// Panic recovery via shared.RunTickerLoop (PSY-615). Runs once on startup —
-// admins exercising the service don't have to wait a full interval to see
-// output. The job is idempotent — running twice in a row sends nothing the
-// second time because cursors moved.
+// run is the main loop for the digest service. Runs once on startup so
+// admins exercising the service don't wait a full interval to see output.
+// The job is idempotent — running twice in a row sends nothing the second
+// time because cursors moved.
 func (s *CollectionDigestService) run(ctx context.Context) {
 	defer s.wg.Done()
 	shared.RunTickerLoop(ctx, "collection_digest", s.interval, s.stopCh, true, func(_ context.Context) {

--- a/backend/internal/services/engagement/collection_digest.go
+++ b/backend/internal/services/engagement/collection_digest.go
@@ -19,6 +19,7 @@ import (
 	"psychic-homily-backend/internal/config"
 	communitym "psychic-homily-backend/internal/models/community"
 	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/services/shared"
 )
 
 // DefaultCollectionDigestInterval is how often the digest job runs.
@@ -112,29 +113,15 @@ func (s *CollectionDigestService) Stop() {
 }
 
 // run is the main loop for the digest service.
+// Panic recovery via shared.RunTickerLoop (PSY-615). Runs once on startup —
+// admins exercising the service don't have to wait a full interval to see
+// output. The job is idempotent — running twice in a row sends nothing the
+// second time because cursors moved.
 func (s *CollectionDigestService) run(ctx context.Context) {
 	defer s.wg.Done()
-
-	// Run immediately on startup so admins exercising the service don't have
-	// to wait a full interval to see output. The job is idempotent — running
-	// twice in a row sends nothing the second time because cursors moved.
-	s.runDigestCycle()
-
-	ticker := time.NewTicker(s.interval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			s.logger.Info("collection digest service context cancelled")
-			return
-		case <-s.stopCh:
-			s.logger.Info("collection digest service received stop signal")
-			return
-		case <-ticker.C:
-			s.runDigestCycle()
-		}
-	}
+	shared.RunTickerLoop(ctx, "collection_digest", s.interval, s.stopCh, true, func(_ context.Context) {
+		s.runDigestCycle()
+	})
 }
 
 // digestCandidate is the result of the per-(user,collection) candidate query —

--- a/backend/internal/services/engagement/reminder.go
+++ b/backend/internal/services/engagement/reminder.go
@@ -17,6 +17,7 @@ import (
 	"psychic-homily-backend/db"
 	"psychic-homily-backend/internal/config"
 	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/services/shared"
 )
 
 // Default reminder check interval (30 minutes)
@@ -85,28 +86,15 @@ func (s *ReminderService) Stop() {
 	s.logger.Info("show reminder service stopped")
 }
 
-// run is the main loop for the reminder service
+// run is the main loop for the reminder service.
+// Panic recovery is provided by shared.RunTickerLoop (PSY-615): a panic
+// in a single tick is logged and the loop continues; a panic in the
+// ticker setup is logged and the loop returns.
 func (s *ReminderService) run(ctx context.Context) {
 	defer s.wg.Done()
-
-	// Run immediately on startup
-	s.runReminderCycle()
-
-	ticker := time.NewTicker(s.interval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			s.logger.Info("reminder service context cancelled")
-			return
-		case <-s.stopCh:
-			s.logger.Info("reminder service received stop signal")
-			return
-		case <-ticker.C:
-			s.runReminderCycle()
-		}
-	}
+	shared.RunTickerLoop(ctx, "reminder", s.interval, s.stopCh, true, func(_ context.Context) {
+		s.runReminderCycle()
+	})
 }
 
 // runReminderCycle finds shows happening in ~24h and sends reminders

--- a/backend/internal/services/engagement/reminder.go
+++ b/backend/internal/services/engagement/reminder.go
@@ -87,9 +87,6 @@ func (s *ReminderService) Stop() {
 }
 
 // run is the main loop for the reminder service.
-// Panic recovery is provided by shared.RunTickerLoop (PSY-615): a panic
-// in a single tick is logged and the loop continues; a panic in the
-// ticker setup is logged and the loop returns.
 func (s *ReminderService) run(ctx context.Context) {
 	defer s.wg.Done()
 	shared.RunTickerLoop(ctx, "reminder", s.interval, s.stopCh, true, func(_ context.Context) {

--- a/backend/internal/services/pipeline/enrichment_worker.go
+++ b/backend/internal/services/pipeline/enrichment_worker.go
@@ -5,6 +5,8 @@ import (
 	"log/slog"
 	"sync"
 	"time"
+
+	"psychic-homily-backend/internal/services/shared"
 )
 
 const (
@@ -54,24 +56,13 @@ func (w *EnrichmentWorker) Stop() {
 }
 
 // run is the main loop for the enrichment worker.
+// Panic recovery via shared.RunTickerLoop (PSY-615). The enrichment worker
+// does NOT run a startup cycle — it waits one interval before processing.
 func (w *EnrichmentWorker) run(ctx context.Context) {
 	defer w.wg.Done()
-
-	ticker := time.NewTicker(w.interval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			w.logger.Info("enrichment worker context cancelled")
-			return
-		case <-w.stopCh:
-			w.logger.Info("enrichment worker received stop signal")
-			return
-		case <-ticker.C:
-			w.processTick(ctx)
-		}
-	}
+	shared.RunTickerLoop(ctx, "enrichment_worker", w.interval, w.stopCh, false, func(c context.Context) {
+		w.processTick(c)
+	})
 }
 
 // processTick processes a batch of enrichment items.

--- a/backend/internal/services/pipeline/enrichment_worker.go
+++ b/backend/internal/services/pipeline/enrichment_worker.go
@@ -56,8 +56,7 @@ func (w *EnrichmentWorker) Stop() {
 }
 
 // run is the main loop for the enrichment worker.
-// Panic recovery via shared.RunTickerLoop (PSY-615). The enrichment worker
-// does NOT run a startup cycle — it waits one interval before processing.
+// No startup cycle — waits one interval before the first tick.
 func (w *EnrichmentWorker) run(ctx context.Context) {
 	defer w.wg.Done()
 	shared.RunTickerLoop(ctx, "enrichment_worker", w.interval, w.stopCh, false, func(c context.Context) {

--- a/backend/internal/services/pipeline/scheduler.go
+++ b/backend/internal/services/pipeline/scheduler.go
@@ -116,7 +116,6 @@ func (s *SchedulerService) Stop() {
 }
 
 // run is the main loop for the scheduler.
-// Panic recovery via shared.RunTickerLoop (PSY-615).
 func (s *SchedulerService) run(ctx context.Context) {
 	defer s.wg.Done()
 	shared.RunTickerLoop(ctx, "scheduler", s.interval, s.stopCh, true, func(_ context.Context) {

--- a/backend/internal/services/pipeline/scheduler.go
+++ b/backend/internal/services/pipeline/scheduler.go
@@ -14,6 +14,7 @@ import (
 	"psychic-homily-backend/db"
 	adminm "psychic-homily-backend/internal/models/admin"
 	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/services/shared"
 )
 
 // Default extraction interval (24 hours)
@@ -115,27 +116,12 @@ func (s *SchedulerService) Stop() {
 }
 
 // run is the main loop for the scheduler.
+// Panic recovery via shared.RunTickerLoop (PSY-615).
 func (s *SchedulerService) run(ctx context.Context) {
 	defer s.wg.Done()
-
-	// Run immediately on startup
-	s.runExtractionCycle()
-
-	ticker := time.NewTicker(s.interval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			s.logger.Info("extraction scheduler context cancelled")
-			return
-		case <-s.stopCh:
-			s.logger.Info("extraction scheduler received stop signal")
-			return
-		case <-ticker.C:
-			s.runExtractionCycle()
-		}
-	}
+	shared.RunTickerLoop(ctx, "scheduler", s.interval, s.stopCh, true, func(_ context.Context) {
+		s.runExtractionCycle()
+	})
 }
 
 // runExtractionCycle performs a single extraction cycle across all configured venues.

--- a/backend/internal/services/shared/ticker_loop.go
+++ b/backend/internal/services/shared/ticker_loop.go
@@ -1,0 +1,90 @@
+// Package shared provides cross-cutting helpers for background services
+// (panic-safe ticker loops, etc.). Per-service business logic stays in
+// the per-domain service packages — this package is intentionally tiny.
+package shared
+
+import (
+	"context"
+	"log/slog"
+	"runtime/debug"
+	"time"
+)
+
+// RunTickerLoop runs `work` on every tick of `interval`, returning when
+// `ctx` is canceled or `stopCh` is closed.
+//
+// Two layers of `recover()` are intentional:
+//
+//  1. The outer recover (top of the function) catches a panic in the
+//     ticker setup itself — `time.NewTicker(interval)` panics if
+//     `interval <= 0`, for example. Without it, that panic would bubble
+//     out into the supervising goroutine and crash the process.
+//  2. The inner per-tick recover (inside `runOneCycle`) lets a single
+//     bad tick fail without taking down the loop. The next tick still
+//     fires.
+//
+// Both layers log via `slog.Default()` with field keys matching the
+// project's slog convention (`service`, `panic`, `stack`).
+//
+// `runImmediately` is a convenience for services that want to fire
+// `work` once at startup before entering the ticker loop. Most existing
+// services do this so an admin exercising the service doesn't have to
+// wait a full interval to see output. The startup cycle is wrapped in
+// the same per-cycle recover, so a panic there also doesn't kill the
+// loop.
+//
+// `stopCh` is optional (nil-safe). The existing services pair `ctx` with
+// a `close(stopCh)`-based stop channel for explicit shutdown signals;
+// the helper preserves that semantics.
+func RunTickerLoop(
+	ctx context.Context,
+	name string,
+	interval time.Duration,
+	stopCh <-chan struct{},
+	runImmediately bool,
+	work func(context.Context),
+) {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Default().Error("background service panic — service stopping",
+				"service", name,
+				"panic", r,
+				"stack", string(debug.Stack()),
+			)
+		}
+	}()
+
+	if runImmediately {
+		runOneCycle(ctx, name, work)
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-stopCh:
+			return
+		case <-ticker.C:
+			runOneCycle(ctx, name, work)
+		}
+	}
+}
+
+// runOneCycle isolates the per-tick recover so a panic in one tick
+// doesn't stop the loop. Exposed only inside this package — callers
+// drive cycles through RunTickerLoop.
+func runOneCycle(ctx context.Context, name string, work func(context.Context)) {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Default().Error("background service tick panic — continuing",
+				"service", name,
+				"panic", r,
+				"stack", string(debug.Stack()),
+			)
+		}
+	}()
+	work(ctx)
+}

--- a/backend/internal/services/shared/ticker_loop_test.go
+++ b/backend/internal/services/shared/ticker_loop_test.go
@@ -1,0 +1,240 @@
+package shared
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// withCapturedSlog swaps the slog default logger for a JSON handler that
+// writes to a buffer for the duration of the test, restoring the original
+// logger on cleanup. Use to assert that panic recoveries actually log.
+func withCapturedSlog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	original := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(original) })
+	return buf
+}
+
+// TestRunTickerLoop_PanicInWorkContinuesLoop is the canonical demonstration:
+// a tick that panics is recovered, logged, and the loop fires the next tick.
+// This is the load-bearing assertion of PSY-615.
+func TestRunTickerLoop_PanicInWorkContinuesLoop(t *testing.T) {
+	logs := withCapturedSlog(t)
+
+	var calls atomic.Int32
+	work := func(_ context.Context) {
+		n := calls.Add(1)
+		if n == 1 {
+			panic("boom on tick 1")
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		RunTickerLoop(ctx, "test-service", 10*time.Millisecond, nil, false, work)
+		close(done)
+	}()
+
+	<-done
+
+	got := calls.Load()
+	require.Greater(t, int(got), 1, "loop should have ticked at least twice; got %d", got)
+
+	logged := logs.String()
+	assert.Contains(t, logged, "background service tick panic — continuing", "panic should be logged")
+	assert.Contains(t, logged, `"service":"test-service"`, "service name should be in log")
+	assert.Contains(t, logged, "boom on tick 1", "panic value should be in log")
+	assert.Contains(t, logged, `"stack"`, "stack trace should be in log")
+}
+
+// TestRunTickerLoop_NormalWorkRunsRepeatedly sanity-checks the helper
+// on the happy path: a non-panicking work function runs once per tick.
+func TestRunTickerLoop_NormalWorkRunsRepeatedly(t *testing.T) {
+	var calls atomic.Int32
+	work := func(_ context.Context) {
+		calls.Add(1)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		RunTickerLoop(ctx, "happy-service", 10*time.Millisecond, nil, false, work)
+		close(done)
+	}()
+
+	<-done
+
+	got := calls.Load()
+	assert.GreaterOrEqual(t, int(got), 3, "expected several ticks in 100ms with 10ms interval; got %d", got)
+}
+
+// TestRunTickerLoop_RunImmediately fires the work function once before
+// entering the ticker loop. Used by services that want a startup cycle.
+func TestRunTickerLoop_RunImmediately(t *testing.T) {
+	var calls atomic.Int32
+	work := func(_ context.Context) {
+		calls.Add(1)
+	}
+
+	// Long interval — only the immediate startup call should land before
+	// ctx times out.
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		RunTickerLoop(ctx, "startup-service", 1*time.Hour, nil, true, work)
+		close(done)
+	}()
+
+	<-done
+	assert.Equal(t, int32(1), calls.Load(), "exactly one cycle should have run (the startup cycle)")
+}
+
+// TestRunTickerLoop_StartupPanicDoesNotKillLoop covers the case where
+// the startup cycle panics — the loop must still fire a regular tick after.
+func TestRunTickerLoop_StartupPanicDoesNotKillLoop(t *testing.T) {
+	logs := withCapturedSlog(t)
+
+	var calls atomic.Int32
+	work := func(_ context.Context) {
+		n := calls.Add(1)
+		if n == 1 {
+			panic("boom on startup")
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		RunTickerLoop(ctx, "startup-panic-service", 10*time.Millisecond, nil, true, work)
+		close(done)
+	}()
+
+	<-done
+
+	got := calls.Load()
+	require.Greater(t, int(got), 1, "loop should keep running after startup panic; got %d calls", got)
+	assert.Contains(t, logs.String(), "boom on startup")
+}
+
+// TestRunTickerLoop_StopChannel covers the explicit `close(stopCh)`
+// shutdown path. Each existing service uses both `<-ctx.Done()` and
+// `<-stopCh`; the helper must honor stopCh too.
+func TestRunTickerLoop_StopChannel(t *testing.T) {
+	var calls atomic.Int32
+	work := func(_ context.Context) {
+		calls.Add(1)
+	}
+
+	stopCh := make(chan struct{})
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		RunTickerLoop(ctx, "stop-ch-service", 10*time.Millisecond, stopCh, false, work)
+	}()
+
+	// Let it tick a few times, then close stopCh.
+	time.Sleep(50 * time.Millisecond)
+	close(stopCh)
+
+	// wg.Wait should return once the loop sees the closed channel.
+	waitDone := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(waitDone)
+	}()
+
+	select {
+	case <-waitDone:
+		// expected
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("RunTickerLoop did not return after stopCh was closed")
+	}
+}
+
+// TestRunTickerLoop_ContextCancellationStopsLoop covers the `<-ctx.Done()`
+// path independently from stopCh.
+func TestRunTickerLoop_ContextCancellationStopsLoop(t *testing.T) {
+	var calls atomic.Int32
+	work := func(_ context.Context) {
+		calls.Add(1)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		RunTickerLoop(ctx, "ctx-cancel-service", 10*time.Millisecond, nil, false, work)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	waitDone := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(waitDone)
+	}()
+
+	select {
+	case <-waitDone:
+		// expected
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("RunTickerLoop did not return after context cancel")
+	}
+}
+
+// TestRunTickerLoop_OuterRecoverCatchesSetupPanic covers the outer
+// recover. `time.NewTicker(0)` panics with a duration <= 0; without the
+// outer recover that panic would bubble out and kill the supervising
+// goroutine. The loop returns early but the process keeps running.
+func TestRunTickerLoop_OuterRecoverCatchesSetupPanic(t *testing.T) {
+	logs := withCapturedSlog(t)
+
+	work := func(_ context.Context) {}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	// Recover here too — if the helper's recover failed, the goroutine
+	// would crash and we want the test to fail with a clear message
+	// rather than a process-level panic.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("outer recover failed; panic escaped: %v", r)
+		}
+	}()
+
+	RunTickerLoop(ctx, "setup-panic-service", 0, nil, false, work)
+
+	logged := logs.String()
+	require.True(t,
+		strings.Contains(logged, "background service panic — service stopping"),
+		"outer recover should have logged the setup panic; got: %s", logged,
+	)
+	assert.Contains(t, logged, `"service":"setup-panic-service"`)
+}


### PR DESCRIPTION
## Summary
- Add `services/shared.RunTickerLoop` with two-level `recover()`: outer catches ticker-setup panics, inner per-tick recover lets one bad tick fail without stopping the loop. Logs via `slog.Default()` with stack trace.
- Migrate all 8 ticker-based background services (cleanup, reminder, scheduler, enrichment, auto-promotion, radio-fetch [3 loops], relationship-derivation, collection-digest) to use the helper. Per-service cycle bodies and `Start`/`Stop`/`stopCh`/`wg` machinery unchanged.
- Split `CleanupService` from one goroutine running two tickers into two independent goroutines so a panic in account-cleanup can't take down tag-prune (and vice versa). Both share `stopCh`; shutdown semantics unchanged.

Sentry capture in the recover paths is deferred to a follow-up — keeping this PR focused on the cross-cutting log-and-survive behavior the audit called out.

Closes the cross-cutting "0 of 8 services have panic recovery" finding from `docs/research/background-services-health-audit.md`.

## Test plan
- [x] `cd backend && go test -count=1 ./internal/services/shared/... ./internal/services/admin/... ./internal/services/engagement/... ./internal/services/pipeline/... ./internal/services/catalog/...` — passed (all 5 packages green; new `shared` helper has 7 unit tests covering panic-during-tick, panic-during-startup, panic-during-setup, happy-path ticking, ctx cancel, stopCh close, and run-immediately)
- [x] `cd backend && go test -count=1 ./...` — passed (full backend test suite green)
- [x] `cd backend && go build ./...` — passed
- [x] `cd backend && go vet ./internal/services/...` — passed
- Frontend skipped: backend-only diff, no frontend touched.

Closes PSY-615

## Memory note
The in-repo CLAUDE.md doesn't exist; the proposed user-level MEMORY.md update under "Key Non-Obvious Patterns" → "Background services" entry:

> **Background services**: CleanupService (now 2 goroutines: account cleanup + tag prune), ReminderService, SchedulerService, EnrichmentWorker, AutoPromotionService, RadioFetchService (3 goroutines: fetch/affinity/rematch), CollectionDigestService, RelationshipDerivationService — **8 services** (10 ticker goroutines), all started/stopped in `cmd/server/main.go`. **All ticker loops are wrapped in `services/shared.RunTickerLoop` (PSY-615)** for panic recovery: outer recover catches ticker-setup panics, inner per-tick recover lets a single bad cycle fail without killing the loop. Stack traces are logged via `slog.Default()`. The previous "0 of 8 services have panic recovery" gap is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)