### PR TITLE
PSY-616: fix oauth_account list lying-Z timestamp

### DIFF
--- a/backend/internal/api/handlers/auth/oauth_account.go
+++ b/backend/internal/api/handlers/auth/oauth_account.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"time"
 
 	"github.com/danielgtaylor/huma/v2"
 
@@ -72,11 +73,17 @@ func (h *OAuthAccountHandler) GetOAuthAccountsHandler(ctx context.Context, req *
 	responseAccounts := make([]OAuthAccountResponse, len(accounts))
 	for i, acc := range accounts {
 		responseAccounts[i] = OAuthAccountResponse{
-			Provider:    acc.Provider,
-			Email:       acc.ProviderEmail,
-			Name:        acc.ProviderName,
-			AvatarURL:   acc.ProviderAvatarURL,
-			ConnectedAt: acc.CreatedAt.Format("2006-01-02T15:04:05Z"),
+			Provider:  acc.Provider,
+			Email:     acc.ProviderEmail,
+			Name:      acc.ProviderName,
+			AvatarURL: acc.ProviderAvatarURL,
+			// PSY-616 (sibling of PSY-604): must convert to UTC before
+			// formatting — the literal "Z" in the layout asserts the value
+			// is UTC but Format does not convert. A local time.Time would
+			// otherwise be stamped with "Z" while still carrying the local
+			// clock reading, drifting any downstream timestamp render by
+			// the local UTC offset (e.g. 7h on Phoenix MST).
+			ConnectedAt: acc.CreatedAt.UTC().Format(time.RFC3339),
 		}
 	}
 

--- a/backend/internal/api/handlers/auth/oauth_account_test.go
+++ b/backend/internal/api/handlers/auth/oauth_account_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"testing"
+	"time"
 
 	"psychic-homily-backend/internal/api/handlers/shared/testhelpers"
 	authm "psychic-homily-backend/internal/models/auth"
@@ -20,6 +21,53 @@ func TestGetOAuthAccountsHandler_NoAuth(t *testing.T) {
 
 	_, err := h.GetOAuthAccountsHandler(context.Background(), req)
 	testhelpers.AssertHumaError(t, err, 401)
+}
+
+// TestGetOAuthAccountsHandler_ConnectedAtIsUTC is the PSY-616 regression
+// guard (sibling of PSY-604's TestRevisionHandler_GetEntityHistory_CreatedAtIsUTC).
+// Before the fix, an OAuth account whose CreatedAt was a local time.Time
+// (e.g. served from a DB driver that returns timestamptz in the session
+// TZ) was formatted via t.Format("2006-01-02T15:04:05Z") — Format does
+// NOT convert to UTC, so the literal "Z" in the layout asserted UTC while
+// the value still carried the local clock reading. The fix is to call
+// .UTC() before .Format(time.RFC3339) on the field. This test asserts the
+// response field reflects the UTC equivalent of the input time, not the
+// local clock.
+func TestGetOAuthAccountsHandler_ConnectedAtIsUTC(t *testing.T) {
+	// 13:00 Phoenix MST (UTC-7) == 20:00 UTC
+	phoenix, err := time.LoadLocation("America/Phoenix")
+	if err != nil {
+		t.Fatalf("failed to load Phoenix location: %v", err)
+	}
+	localTime := time.Date(2026, 5, 4, 13, 0, 0, 0, phoenix)
+
+	mockUserService := &testhelpers.MockUserService{
+		GetOAuthAccountsFn: func(userID uint) ([]authm.OAuthAccount, error) {
+			return []authm.OAuthAccount{{
+				ID:        1,
+				UserID:    userID,
+				Provider:  "google",
+				CreatedAt: localTime,
+			}}, nil
+		},
+	}
+
+	h := NewOAuthAccountHandler(mockUserService)
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1})
+
+	resp, err := h.GetOAuthAccountsHandler(ctx, &GetOAuthAccountsRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Body.Accounts) != 1 {
+		t.Fatalf("expected 1 account, got %d", len(resp.Body.Accounts))
+	}
+
+	got := resp.Body.Accounts[0].ConnectedAt
+	want := "2026-05-04T20:00:00Z"
+	if got != want {
+		t.Errorf("ConnectedAt timezone drift: got %q, want %q (input was 13:00 Phoenix == 20:00 UTC)", got, want)
+	}
 }
 
 // --- UnlinkOAuthAccountHandler ---


### PR DESCRIPTION
## Summary
- Sibling of PSY-604. `GetOAuthAccountsHandler` formatted `acc.CreatedAt` with the layout `"2006-01-02T15:04:05Z"` — the literal `Z` asserts UTC but `time.Time.Format` does not convert. A Phoenix-local `13:00` was sent over the wire as `2026-05-04T13:00:00Z` (claiming UTC, actually 7h stale).
- Fix mirrors PSY-604: call `.UTC().Format(time.RFC3339)` before serializing. Adds a regression test that mirrors `TestRevisionHandler_GetEntityHistory_CreatedAtIsUTC` — Phoenix-local input must surface as the UTC-converted hour in the response.
- Repo-wide grep for `Format("2006-01-02T15:04:05Z")` no longer returns any production lying-Z usage. Remaining hits are benign (`dedup-shows/main.go` already prefixes `.UTC()`; two test/comment refs).

## Test plan
- [x] `cd backend && go test ./internal/api/handlers/auth/...` — passed (8.2s, includes new regression test)
- [x] `cd backend && go build ./...` — passed
- [x] Frontend test suites skipped — no frontend files touched in this PR.

Closes PSY-616