### PR TITLE
PSY-601: dedupe Recent Activity rows + resolve _edit entity names

### DIFF
--- a/backend/internal/api/handlers/admin/pending_edit.go
+++ b/backend/internal/api/handlers/admin/pending_edit.go
@@ -214,13 +214,12 @@ func (h *PendingEditHandler) suggestEdit(ctx context.Context, entityType string,
 		}
 	}
 
-	// Fire-and-forget audit log for pending edit
-	if h.auditLogService != nil {
-		go h.auditLogService.LogAction(user.ID, "suggest_edit_"+entityType, entityType, uint(entityID), map[string]interface{}{
-			"edit_id": resp.ID,
-			"summary": summary,
-		})
-	}
+	// PSY-601: do NOT write a "suggest_edit_*" audit_log row here. The
+	// pending_entity_edits row created above is already the user-facing
+	// activity event (it surfaces as "submit_<type>_edit" via the UNION in
+	// ContributorProfileService.GetContributionHistory). Writing both made
+	// every Suggest Edit appear twice in the contributor's Recent Activity
+	// feed. The "suggest_edit_*" audit action has no other readers.
 
 	out := &SuggestEntityEditResponse{}
 	out.Body.PendingEdit = resp

--- a/backend/internal/api/handlers/admin/pending_edit.go
+++ b/backend/internal/api/handlers/admin/pending_edit.go
@@ -214,12 +214,11 @@ func (h *PendingEditHandler) suggestEdit(ctx context.Context, entityType string,
 		}
 	}
 
-	// PSY-601: do NOT write a "suggest_edit_*" audit_log row here. The
-	// pending_entity_edits row created above is already the user-facing
-	// activity event (it surfaces as "submit_<type>_edit" via the UNION in
-	// ContributorProfileService.GetContributionHistory). Writing both made
-	// every Suggest Edit appear twice in the contributor's Recent Activity
-	// feed. The "suggest_edit_*" audit action has no other readers.
+	// No audit_log emit on the pending path: the pending_entity_edits row
+	// above is the user-facing event, surfaced as "submit_<type>_edit" by
+	// the UNION in ContributorProfileService.GetContributionHistory. A
+	// parallel "suggest_edit_*" audit row would double-render in Recent
+	// Activity (no other reader consumes that audit action).
 
 	out := &SuggestEntityEditResponse{}
 	out.Body.PendingEdit = resp

--- a/backend/internal/services/user/contributor_profile.go
+++ b/backend/internal/services/user/contributor_profile.go
@@ -875,6 +875,11 @@ func (s *ContributorProfileService) enrichEntityNames(entries []*contracts.Contr
 			for _, r := range results {
 				names[r.ID] = r.Title
 			}
+		// venue/release/label/festival/artist + their "_edit" synthetic
+		// discriminators (emitted by the pending_entity_edits UNION in
+		// GetContributionHistory) all resolve names from the same underlying
+		// table. Without these aliases, the activity-feed entity-name slot
+		// renders the raw discriminator string ("artist_edit", etc.).
 		case "venue", "venue_edit":
 			var results []struct {
 				ID   uint
@@ -884,7 +889,7 @@ func (s *ContributorProfileService) enrichEntityNames(entries []*contracts.Contr
 			for _, r := range results {
 				names[r.ID] = r.Name
 			}
-		case "artist":
+		case "artist", "artist_edit":
 			var results []struct {
 				ID   uint
 				Name string
@@ -893,7 +898,7 @@ func (s *ContributorProfileService) enrichEntityNames(entries []*contracts.Contr
 			for _, r := range results {
 				names[r.ID] = r.Name
 			}
-		case "release":
+		case "release", "release_edit":
 			var results []struct {
 				ID    uint
 				Title string
@@ -902,7 +907,7 @@ func (s *ContributorProfileService) enrichEntityNames(entries []*contracts.Contr
 			for _, r := range results {
 				names[r.ID] = r.Title
 			}
-		case "label":
+		case "label", "label_edit":
 			var results []struct {
 				ID   uint
 				Name string
@@ -911,7 +916,7 @@ func (s *ContributorProfileService) enrichEntityNames(entries []*contracts.Contr
 			for _, r := range results {
 				names[r.ID] = r.Name
 			}
-		case "festival":
+		case "festival", "festival_edit":
 			var results []struct {
 				ID   uint
 				Name string

--- a/backend/internal/services/user/contributor_profile.go
+++ b/backend/internal/services/user/contributor_profile.go
@@ -865,6 +865,9 @@ func (s *ContributorProfileService) enrichEntityNames(entries []*contracts.Contr
 			continue
 		}
 		names := make(map[uint]string)
+		// "<type>_edit" cases handle the synthetic discriminator emitted by
+		// the pending_entity_edits UNION in GetContributionHistory; they
+		// resolve from the same underlying table as their base type.
 		switch entityType {
 		case "show":
 			var results []struct {
@@ -875,11 +878,6 @@ func (s *ContributorProfileService) enrichEntityNames(entries []*contracts.Contr
 			for _, r := range results {
 				names[r.ID] = r.Title
 			}
-		// venue/release/label/festival/artist + their "_edit" synthetic
-		// discriminators (emitted by the pending_entity_edits UNION in
-		// GetContributionHistory) all resolve names from the same underlying
-		// table. Without these aliases, the activity-feed entity-name slot
-		// renders the raw discriminator string ("artist_edit", etc.).
 		case "venue", "venue_edit":
 			var results []struct {
 				ID   uint

--- a/backend/internal/services/user/contributor_profile_test.go
+++ b/backend/internal/services/user/contributor_profile_test.go
@@ -886,6 +886,124 @@ func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetContributionH
 	suite.Equal(show1.ID, entries[1].EntityID)
 }
 
+// TestGetContributionHistory_PendingEditEnriched_AllEntityTypes is the
+// PSY-601 regression test: pending_entity_edits rows surface in the feed
+// with synthetic entity_type "<type>_edit" (e.g. "artist_edit"). All five
+// supported entity types must resolve back to a human-readable entity name
+// rather than leaking the raw discriminator string into the UI.
+func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetContributionHistory_PendingEditEnriched_AllEntityTypes() {
+	cases := []struct {
+		name           string
+		entityType     string // value stored on PendingEntityEdit (no _edit suffix)
+		expectedName   string
+		setup          func(submittedBy uint) uint // returns entity ID created
+		wantAction     string
+		wantEntityType string // the synthetic "<type>_edit" we expect on the response
+	}{
+		{
+			name:         "artist",
+			entityType:   adminm.PendingEditEntityArtist,
+			expectedName: "Amyl and The Sniffers",
+			setup: func(_ uint) uint {
+				a := &catalogm.Artist{Name: "Amyl and The Sniffers"}
+				suite.Require().NoError(suite.db.Create(a).Error)
+				return a.ID
+			},
+			wantAction:     "submit_artist_edit",
+			wantEntityType: "artist_edit",
+		},
+		{
+			name:         "venue",
+			entityType:   adminm.PendingEditEntityVenue,
+			expectedName: "Valley Bar",
+			setup: func(_ uint) uint {
+				// Create the venue WITHOUT a submitted_by — otherwise the
+				// venueQuery UNION would emit a "submit_venue" row alongside
+				// the "submit_venue_edit" row, and the test wouldn't be
+				// isolating the enrichment-of-_edit-types behaviour.
+				v := &catalogm.Venue{Name: "Valley Bar", City: "Phoenix", State: "AZ"}
+				suite.Require().NoError(suite.db.Create(v).Error)
+				return v.ID
+			},
+			wantAction:     "submit_venue_edit",
+			wantEntityType: "venue_edit",
+		},
+		{
+			name:         "release",
+			entityType:   adminm.PendingEditEntityRelease,
+			expectedName: "Comfort to Me",
+			setup: func(_ uint) uint {
+				r := &catalogm.Release{Title: "Comfort to Me"}
+				suite.Require().NoError(suite.db.Create(r).Error)
+				return r.ID
+			},
+			wantAction:     "submit_release_edit",
+			wantEntityType: "release_edit",
+		},
+		{
+			name:         "label",
+			entityType:   adminm.PendingEditEntityLabel,
+			expectedName: "Rough Trade",
+			setup: func(_ uint) uint {
+				l := &catalogm.Label{Name: "Rough Trade"}
+				suite.Require().NoError(suite.db.Create(l).Error)
+				return l.ID
+			},
+			wantAction:     "submit_label_edit",
+			wantEntityType: "label_edit",
+		},
+		{
+			name:         "festival",
+			entityType:   adminm.PendingEditEntityFestival,
+			expectedName: "Zona Music Festival",
+			setup: func(_ uint) uint {
+				slug := fmt.Sprintf("zona-2026-%d", time.Now().UnixNano())
+				f := &catalogm.Festival{
+					Name:        "Zona Music Festival",
+					Slug:        slug,
+					SeriesSlug:  "zona",
+					EditionYear: 2026,
+					StartDate:   "2026-12-01",
+					EndDate:     "2026-12-02",
+				}
+				suite.Require().NoError(suite.db.Create(f).Error)
+				return f.ID
+			},
+			wantAction:     "submit_festival_edit",
+			wantEntityType: "festival_edit",
+		},
+	}
+
+	for _, tc := range cases {
+		suite.Run(tc.name, func() {
+			user := suite.createTestUser(fmt.Sprintf("editenrich-%s-%d", tc.name, time.Now().UnixNano()))
+			entityID := tc.setup(user.ID)
+
+			changes := json.RawMessage(`[{"field":"name","old_value":"X","new_value":"Y"}]`)
+			suite.Require().NoError(suite.db.Create(&adminm.PendingEntityEdit{
+				EntityType:   tc.entityType,
+				EntityID:     entityID,
+				SubmittedBy:  user.ID,
+				FieldChanges: &changes,
+				Summary:      "Fix name",
+				Status:       adminm.PendingEditStatusPending,
+			}).Error)
+
+			entries, _, err := suite.profileService.GetContributionHistory(user.ID, 20, 0, "")
+
+			suite.Require().NoError(err)
+			suite.Require().Len(entries, 1, "expected exactly one feed row for one suggest-edit")
+			suite.Equal(tc.wantAction, entries[0].Action)
+			suite.Equal(tc.wantEntityType, entries[0].EntityType)
+			suite.Equal(entityID, entries[0].EntityID)
+			suite.Equal(tc.expectedName, entries[0].EntityName,
+				"entity_name must resolve to the underlying entity, not the raw '%s' discriminator",
+				tc.wantEntityType,
+			)
+		})
+	}
+}
+
 // =============================================================================
 // Group 5: Privacy Settings
 // =============================================================================

--- a/backend/internal/services/user/contributor_profile_test.go
+++ b/backend/internal/services/user/contributor_profile_test.go
@@ -886,11 +886,12 @@ func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetContributionH
 	suite.Equal(show1.ID, entries[1].EntityID)
 }
 
-// TestGetContributionHistory_PendingEditEnriched_AllEntityTypes is the
-// PSY-601 regression test: pending_entity_edits rows surface in the feed
-// with synthetic entity_type "<type>_edit" (e.g. "artist_edit"). All five
-// supported entity types must resolve back to a human-readable entity name
-// rather than leaking the raw discriminator string into the UI.
+// TestGetContributionHistory_PendingEditEnriched_AllEntityTypes verifies
+// that pending_entity_edits rows — which surface in the feed with the
+// synthetic entity_type "<type>_edit" — resolve to a human-readable entity
+// name for every supported type. Without enrichment, the activity-feed
+// entity-name slot leaks the raw discriminator string ("artist_edit", etc.)
+// directly into the UI.
 func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetContributionHistory_PendingEditEnriched_AllEntityTypes() {
 	cases := []struct {
 		name           string
@@ -916,11 +917,10 @@ func (suite *ContributorProfileServiceIntegrationTestSuite) TestGetContributionH
 			name:         "venue",
 			entityType:   adminm.PendingEditEntityVenue,
 			expectedName: "Valley Bar",
+			// Bypass createVenue: setting submitted_by here would inject an
+			// extra "submit_venue" row from the venueQuery UNION and stop
+			// us from isolating the _edit enrichment path.
 			setup: func(_ uint) uint {
-				// Create the venue WITHOUT a submitted_by — otherwise the
-				// venueQuery UNION would emit a "submit_venue" row alongside
-				// the "submit_venue_edit" row, and the test wouldn't be
-				// isolating the enrichment-of-_edit-types behaviour.
 				v := &catalogm.Venue{Name: "Valley Bar", City: "Phoenix", State: "AZ"}
 				suite.Require().NoError(suite.db.Create(v).Error)
 				return v.ID

--- a/frontend/components/contributor/ContributionTimeline.test.tsx
+++ b/frontend/components/contributor/ContributionTimeline.test.tsx
@@ -106,6 +106,39 @@ describe('ContributionTimeline', () => {
     }
   })
 
+  // PSY-601: pending_entity_edits surface as "<type>_edit" and must link
+  // back to the underlying entity (not 404, not no-link). The action label
+  // must also be the friendly form, not the auto-formatted "Submit X Edit".
+  it('links pending-edit synthetic types to their underlying entity', () => {
+    const cases = [
+      { entityType: 'venue_edit', expectedHref: '/venues/42', friendlyAction: 'Suggested venue edit' },
+      { entityType: 'artist_edit', expectedHref: '/artists/42', friendlyAction: 'Suggested artist edit' },
+      { entityType: 'release_edit', expectedHref: '/releases/42', friendlyAction: 'Suggested release edit' },
+      { entityType: 'label_edit', expectedHref: '/labels/42', friendlyAction: 'Suggested label edit' },
+      { entityType: 'festival_edit', expectedHref: '/festivals/42', friendlyAction: 'Suggested festival edit' },
+    ] as const
+    for (const { entityType, expectedHref, friendlyAction } of cases) {
+      const action = `submit_${entityType}` // e.g. submit_artist_edit
+      const { unmount } = render(
+        <ContributionTimeline
+          contributions={[
+            makeEntry({
+              id: Math.random(),
+              action,
+              entity_type: entityType,
+              entity_id: 42,
+              entity_name: 'Resolved Entity Name',
+            }),
+          ]}
+        />
+      )
+      const link = screen.getByText('Resolved Entity Name')
+      expect(link.closest('a')).toHaveAttribute('href', expectedHref)
+      expect(screen.getByText(friendlyAction)).toBeInTheDocument()
+      unmount()
+    }
+  })
+
   it('renders entity name without link for unknown entity types', () => {
     render(
       <ContributionTimeline

--- a/frontend/components/contributor/ContributionTimeline.test.tsx
+++ b/frontend/components/contributor/ContributionTimeline.test.tsx
@@ -106,9 +106,9 @@ describe('ContributionTimeline', () => {
     }
   })
 
-  // PSY-601: pending_entity_edits surface as "<type>_edit" and must link
-  // back to the underlying entity (not 404, not no-link). The action label
-  // must also be the friendly form, not the auto-formatted "Submit X Edit".
+  // pending_entity_edits surface as "<type>_edit" and must link back to
+  // the underlying entity (not 404, not no-link). Action label must also
+  // be the friendly form, not the auto-formatted "Submit X Edit".
   it('links pending-edit synthetic types to their underlying entity', () => {
     const cases = [
       { entityType: 'venue_edit', expectedHref: '/venues/42', friendlyAction: 'Suggested venue edit' },

--- a/frontend/components/contributor/ContributionTimeline.tsx
+++ b/frontend/components/contributor/ContributionTimeline.tsx
@@ -14,6 +14,9 @@ import type { LucideIcon } from 'lucide-react'
 import type { ContributionEntry } from '@/features/auth'
 import { formatRelativeTime } from '@/lib/formatRelativeTime'
 
+// "<type>_edit" entries are the synthetic discriminators emitted by the
+// pending_entity_edits UNION in GetContributionHistory; they reuse the
+// underlying entity's icon, fallback label, and link target.
 const entityTypeIcons: Record<string, LucideIcon> = {
   show: Calendar,
   venue: MapPin,
@@ -21,8 +24,6 @@ const entityTypeIcons: Record<string, LucideIcon> = {
   label: Tag,
   festival: Tent,
   artist: Mic2,
-  // PSY-601: synthetic "_edit" discriminators reuse the underlying
-  // entity icon so a "Suggested artist edit" row still gets the artist mic.
   venue_edit: MapPin,
   artist_edit: Mic2,
   release_edit: Disc3,
@@ -47,9 +48,6 @@ function getEntityLink(entry: ContributionEntry): string | null {
       return `/requests/${entry.entity_id}`
     case 'collection':
       return `/collections/${entry.entity_id}`
-    // PSY-601: pending_entity_edits surface with entity_type "<type>_edit"
-    // (synthetic discriminator from the activity-feed UNION). Strip the
-    // suffix so the row links back to the underlying entity.
     case 'venue_edit':
     case 'artist_edit':
     case 'release_edit':
@@ -76,9 +74,6 @@ const entityTypeLabels: Record<string, string> = {
   festival: 'a festival',
   request: 'a request',
   collection: 'a collection',
-  // PSY-601: synthetic "_edit" discriminators fall back to the underlying
-  // entity copy. Used when entity_name is missing (e.g. entity hard-deleted
-  // after the edit was submitted).
   venue_edit: 'a venue',
   artist_edit: 'an artist',
   release_edit: 'a release',
@@ -98,9 +93,6 @@ function getFallbackEntityLabel(entry: ContributionEntry): string {
 const actionLabels: Record<string, string> = {
   submit_show: 'Submitted show',
   submit_venue: 'Submitted venue',
-  // PSY-601: actions emitted by the pending_entity_edits UNION. Without
-  // these, the auto-formatted fallback ("Submit Artist Edit") leaked
-  // through and looked like internal jargon.
   submit_artist_edit: 'Suggested artist edit',
   submit_venue_edit: 'Suggested venue edit',
   submit_release_edit: 'Suggested release edit',

--- a/frontend/components/contributor/ContributionTimeline.tsx
+++ b/frontend/components/contributor/ContributionTimeline.tsx
@@ -21,6 +21,13 @@ const entityTypeIcons: Record<string, LucideIcon> = {
   label: Tag,
   festival: Tent,
   artist: Mic2,
+  // PSY-601: synthetic "_edit" discriminators reuse the underlying
+  // entity icon so a "Suggested artist edit" row still gets the artist mic.
+  venue_edit: MapPin,
+  artist_edit: Mic2,
+  release_edit: Disc3,
+  label_edit: Tag,
+  festival_edit: Tent,
 }
 
 function getEntityIcon(entityType: string): LucideIcon {
@@ -40,8 +47,17 @@ function getEntityLink(entry: ContributionEntry): string | null {
       return `/requests/${entry.entity_id}`
     case 'collection':
       return `/collections/${entry.entity_id}`
+    // PSY-601: pending_entity_edits surface with entity_type "<type>_edit"
+    // (synthetic discriminator from the activity-feed UNION). Strip the
+    // suffix so the row links back to the underlying entity.
     case 'venue_edit':
-      return `/venues/${entry.entity_id}`
+    case 'artist_edit':
+    case 'release_edit':
+    case 'label_edit':
+    case 'festival_edit': {
+      const baseType = entry.entity_type.slice(0, -'_edit'.length)
+      return `/${baseType}s/${entry.entity_id}`
+    }
     default:
       return null
   }
@@ -60,7 +76,14 @@ const entityTypeLabels: Record<string, string> = {
   festival: 'a festival',
   request: 'a request',
   collection: 'a collection',
+  // PSY-601: synthetic "_edit" discriminators fall back to the underlying
+  // entity copy. Used when entity_name is missing (e.g. entity hard-deleted
+  // after the edit was submitted).
   venue_edit: 'a venue',
+  artist_edit: 'an artist',
+  release_edit: 'a release',
+  label_edit: 'a label',
+  festival_edit: 'a festival',
 }
 
 function getFallbackEntityLabel(entry: ContributionEntry): string {
@@ -75,7 +98,14 @@ function getFallbackEntityLabel(entry: ContributionEntry): string {
 const actionLabels: Record<string, string> = {
   submit_show: 'Submitted show',
   submit_venue: 'Submitted venue',
+  // PSY-601: actions emitted by the pending_entity_edits UNION. Without
+  // these, the auto-formatted fallback ("Submit Artist Edit") leaked
+  // through and looked like internal jargon.
+  submit_artist_edit: 'Suggested artist edit',
   submit_venue_edit: 'Suggested venue edit',
+  submit_release_edit: 'Suggested release edit',
+  submit_label_edit: 'Suggested label edit',
+  submit_festival_edit: 'Suggested festival edit',
   create: 'Created',
   update: 'Updated',
   delete: 'Deleted',


### PR DESCRIPTION
## Summary
- A single Suggest Edit was rendering as **two rows** in the contributor Recent Activity feed; the second row leaked the raw `artist_edit` discriminator into the entity-name slot. Two distinct bugs in one finding.
- **Dual-write fix**: removed the redundant `suggest_edit_*` audit_log emit at the suggest-edit write site. The pending_entity_edits row is the user-facing event (it surfaces as `submit_<type>_edit` via the UNION in `GetContributionHistory`); the audit_log row had no other readers. Cleaner than render-side filtering.
- **Enrichment fix**: `enrichEntityNames` only handled `venue_edit` of the `*_edit` synthetic-discriminator family. Added the four missing types (`artist_edit`, `release_edit`, `label_edit`, `festival_edit`) so the entity-name slot resolves to the underlying entity instead of leaking the discriminator string.
- Frontend `ContributionTimeline` got matching coverage so the deduped row renders cleanly: friendly action label (`Suggested artist edit` instead of auto-formatted `Submit Artist Edit`), correct entity link (e.g. `/artists/:id` from `artist_edit`), and entity-typed icon.
- Out of scope: trusted-user direct-edit-via-suggest path also dual-renders (`edit_<type>` audit_log + pending_entity_edits row), but `edit_<type>` is read by `stats.ArtistsEdited` and the admin dashboard, so removing it would break stats. Worth a follow-up but the testuser2 (untrusted) repro is fixed.

## Test plan
- [x] `cd backend && go test ./internal/services/user/... ./internal/services/admin/... ./internal/api/handlers/... -count=1` — passed
- [x] `cd frontend && bun run typecheck` — passed
- [x] `cd frontend && bun run test:run components/contributor/` — passed (152 tests across 11 files)
- [x] `cd backend && go build ./...` — passed
- [x] New integration test `TestGetContributionHistory_PendingEditEnriched_AllEntityTypes` exercises all 5 entity types end-to-end through `GetContributionHistory`, asserting one row per suggest-edit and the resolved entity name (not the raw discriminator)
- [x] New frontend test `links pending-edit synthetic types to their underlying entity` covers all 5 `_edit` types for href + friendly action label

Closes PSY-601