### PR TITLE
PSY-603: surface admin Approve/Reject success banner inline

### DIFF
--- a/frontend/app/admin/moderation/_components/ModerationQueue.test.tsx
+++ b/frontend/app/admin/moderation/_components/ModerationQueue.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, within } from '@testing-library/react'
+import { act, fireEvent, render, screen, within } from '@testing-library/react'
 import { ModerationQueue } from './ModerationQueue'
 
 // --- Mock data ---
@@ -325,5 +325,119 @@ describe('ModerationQueue', () => {
     expect(screen.getByTestId('pending-comment-edit-badge')).toHaveTextContent(
       '1 edit'
     )
+  })
+
+  // ─── PSY-603: page-level success banner on Approve / Reject ───────────────
+  //
+  // The banner state lives on ModerationQueue (not the card) because the card
+  // unmounts on success when the pending-edits query invalidates. These tests
+  // drive the success path by overriding the approve/reject mutation mocks to
+  // immediately invoke the per-call onSuccess option.
+
+  describe('Approve / Reject success banner (PSY-603)', () => {
+    function captureMutationOnSuccess() {
+      // Approve takes (editId, options); reject takes (variables, options).
+      // Both pass options as the SECOND argument, so the same shape works.
+      const approveMutate = vi.fn(
+        (_args: unknown, opts?: { onSuccess?: () => void }) => {
+          opts?.onSuccess?.()
+        }
+      )
+      const rejectMutate = vi.fn(
+        (_args: unknown, opts?: { onSuccess?: () => void }) => {
+          opts?.onSuccess?.()
+        }
+      )
+      mockUseApprovePendingEdit.mockReturnValue({
+        ...defaultMutationReturn,
+        mutate: approveMutate,
+      })
+      mockUseRejectPendingEdit.mockReturnValue({
+        ...defaultMutationReturn,
+        mutate: rejectMutate,
+      })
+      return { approveMutate, rejectMutate }
+    }
+
+    it('does NOT render the banner before any action is taken', () => {
+      setDefaultMocks({ edits: [mockPendingEdit] })
+
+      render(<ModerationQueue />)
+
+      expect(
+        screen.queryByTestId('moderation-success-banner')
+      ).not.toBeInTheDocument()
+    })
+
+    it('renders the success banner with entity name after Approve succeeds', () => {
+      captureMutationOnSuccess()
+      setDefaultMocks({ edits: [mockPendingEdit] })
+
+      render(<ModerationQueue />)
+      fireEvent.click(screen.getByText('Approve'))
+
+      const banner = screen.getByTestId('moderation-success-banner')
+      expect(banner).toHaveTextContent('Approved')
+      expect(banner).toHaveTextContent('Test Artist')
+    })
+
+    it('renders the success banner with submitter-notified copy after Reject succeeds', () => {
+      captureMutationOnSuccess()
+      setDefaultMocks({ edits: [mockPendingEdit] })
+
+      render(<ModerationQueue />)
+      // Open the rejection-reason input, fill it, confirm.
+      fireEvent.click(screen.getByText('Reject'))
+      const textarea = screen.getByPlaceholderText(/Rejection reason/i)
+      fireEvent.change(textarea, { target: { value: 'Inaccurate change' } })
+      fireEvent.click(screen.getByText('Confirm Reject'))
+
+      const banner = screen.getByTestId('moderation-success-banner')
+      expect(banner).toHaveTextContent('Rejected')
+      expect(banner).toHaveTextContent(/submitter notified/i)
+    })
+
+    it('auto-dismisses the banner after the timeout elapses', () => {
+      vi.useFakeTimers()
+      try {
+        captureMutationOnSuccess()
+        setDefaultMocks({ edits: [mockPendingEdit] })
+
+        render(<ModerationQueue />)
+        fireEvent.click(screen.getByText('Approve'))
+        expect(
+          screen.getByTestId('moderation-success-banner')
+        ).toBeInTheDocument()
+
+        // Advance just past the 5s timeout.
+        act(() => {
+          vi.advanceTimersByTime(5001)
+        })
+
+        expect(
+          screen.queryByTestId('moderation-success-banner')
+        ).not.toBeInTheDocument()
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('clears the banner immediately when the admin switches filter tabs', () => {
+      captureMutationOnSuccess()
+      setDefaultMocks({ edits: [mockPendingEdit] })
+
+      render(<ModerationQueue />)
+      fireEvent.click(screen.getByText('Approve'))
+      expect(
+        screen.getByTestId('moderation-success-banner')
+      ).toBeInTheDocument()
+
+      // Click the "Reports" filter tab.
+      fireEvent.click(screen.getByText('Reports'))
+
+      expect(
+        screen.queryByTestId('moderation-success-banner')
+      ).not.toBeInTheDocument()
+    })
   })
 })

--- a/frontend/app/admin/moderation/_components/ModerationQueue.tsx
+++ b/frontend/app/admin/moderation/_components/ModerationQueue.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useMemo, useCallback } from 'react'
+import { useState, useMemo, useCallback, useEffect } from 'react'
 import {
   Loader2,
   Inbox,
@@ -106,9 +106,26 @@ type ModerationItem =
   | { type: 'report'; data: EntityReportResponse }
   | { type: 'comment'; data: PendingComment }
 
+// ─── PSY-603: success banner state ───────────────────────────────────────────
+
+type ModerationActionVerb = 'approved' | 'rejected'
+
+interface ModerationAction {
+  verb: ModerationActionVerb
+  entityLabel: string
+}
+
+const SUCCESS_BANNER_TIMEOUT_MS = 5000
+
 // ─── Pending Edit Card ───────────────────────────────────────────────────────
 
-function PendingEditCard({ edit }: { edit: PendingEditResponse }) {
+function PendingEditCard({
+  edit,
+  onActionSuccess,
+}: {
+  edit: PendingEditResponse
+  onActionSuccess: (action: ModerationAction) => void
+}) {
   const [expanded, setExpanded] = useState(false)
   const [rejecting, setRejecting] = useState(false)
   const [rejectionReason, setRejectionReason] = useState('')
@@ -118,17 +135,31 @@ function PendingEditCard({ edit }: { edit: PendingEditResponse }) {
 
   const isActioning = approveMutation.isPending || rejectMutation.isPending
 
+  const entityLabel = edit.entity_name || `${entityTypeLabel(edit.entity_type)} #${edit.entity_id}`
+
   const handleApprove = useCallback(() => {
-    approveMutation.mutate(edit.id)
-  }, [approveMutation, edit.id])
+    approveMutation.mutate(edit.id, {
+      // PSY-603: bubble success up to ModerationQueue so the page-level
+      // banner can render. The card itself is about to unmount because the
+      // pending-edits query gets invalidated, so a card-local banner would
+      // disappear with the row.
+      onSuccess: () => onActionSuccess({ verb: 'approved', entityLabel }),
+    })
+  }, [approveMutation, edit.id, onActionSuccess, entityLabel])
 
   const handleReject = useCallback(() => {
     if (!rejectionReason.trim()) return
     rejectMutation.mutate(
       { editId: edit.id, reason: rejectionReason.trim() },
-      { onSuccess: () => { setRejecting(false); setRejectionReason('') } }
+      {
+        onSuccess: () => {
+          setRejecting(false)
+          setRejectionReason('')
+          onActionSuccess({ verb: 'rejected', entityLabel })
+        },
+      }
     )
-  }, [rejectMutation, edit.id, rejectionReason])
+  }, [rejectMutation, edit.id, rejectionReason, onActionSuccess, entityLabel])
 
   return (
     <Card className="overflow-hidden">
@@ -149,7 +180,7 @@ function PendingEditCard({ edit }: { edit: PendingEditResponse }) {
               target="_blank"
               rel="noopener noreferrer"
             >
-              {edit.entity_name || `${entityTypeLabel(edit.entity_type)} #${edit.entity_id}`}
+              {entityLabel}
               <ExternalLink className="h-3 w-3 inline ml-1 opacity-50" />
             </a>
           </div>
@@ -944,6 +975,28 @@ export function ModerationQueue() {
   const [itemTypeFilter, setItemTypeFilter] = useState<ItemTypeFilter>('all')
   const [entityTypeFilter, setEntityTypeFilter] = useState<EntityTypeFilter>('')
 
+  // PSY-603: page-level success banner. Cards bubble up via onActionSuccess
+  // because they unmount on success (the row is removed from the queue).
+  // Auto-dismisses after SUCCESS_BANNER_TIMEOUT_MS, and clears immediately
+  // when the admin changes either filter (treating filter change as a "tab
+  // change" — a fresh review surface should not carry a stale confirmation).
+  const [lastAction, setLastAction] = useState<ModerationAction | null>(null)
+
+  const handleActionSuccess = useCallback((action: ModerationAction) => {
+    setLastAction(action)
+  }, [])
+
+  useEffect(() => {
+    if (!lastAction) return
+    const timer = setTimeout(() => setLastAction(null), SUCCESS_BANNER_TIMEOUT_MS)
+    return () => clearTimeout(timer)
+  }, [lastAction])
+
+  // Clear the banner when the admin switches filter tabs.
+  useEffect(() => {
+    setLastAction(null)
+  }, [itemTypeFilter, entityTypeFilter])
+
   // Fetch pending edits
   const {
     data: editsData,
@@ -1037,6 +1090,11 @@ export function ModerationQueue() {
 
   return (
     <div className="space-y-4">
+      {/* PSY-603: page-level success banner for Approve / Reject. Reuses the
+          PSY-562 pattern (green border + Check icon) from EntityEditDrawer.
+          Auto-dismisses after 5s or clears on filter change (see effects above). */}
+      {lastAction && <ModerationSuccessBanner action={lastAction} />}
+
       {/* Filter bar */}
       <div className="flex flex-wrap items-center gap-3">
         {/* Item type filter */}
@@ -1111,7 +1169,13 @@ export function ModerationQueue() {
         <div className="grid gap-3">
           {items.map(item => {
             if (item.type === 'edit') {
-              return <PendingEditCard key={`edit-${item.data.id}`} edit={item.data as PendingEditResponse} />
+              return (
+                <PendingEditCard
+                  key={`edit-${item.data.id}`}
+                  edit={item.data as PendingEditResponse}
+                  onActionSuccess={handleActionSuccess}
+                />
+              )
             }
             if (item.type === 'comment') {
               return <PendingCommentCard key={`comment-${item.data.id}`} comment={item.data as PendingComment} />
@@ -1130,6 +1194,38 @@ export function ModerationQueue() {
           })}
         </div>
       )}
+    </div>
+  )
+}
+
+// ─── Moderation Success Banner (PSY-603) ─────────────────────────────────────
+
+/**
+ * Inline success banner shown above the moderation queue after a successful
+ * Approve or Reject. Mirrors the PSY-562 EntityEditDrawer success-state
+ * pattern (green border + Check icon) so the admin surface is consistent
+ * with the contributor-side direct-edit flow.
+ *
+ * The optimistic row removal stays as-is; this banner is purely additive
+ * positive feedback. The parent owns auto-dismiss + filter-change reset.
+ */
+function ModerationSuccessBanner({ action }: { action: ModerationAction }) {
+  const message =
+    action.verb === 'approved'
+      ? `Approved — change applied to ${action.entityLabel}`
+      : `Rejected — submitter notified of reason`
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      data-testid="moderation-success-banner"
+      className="rounded-md border border-green-800 bg-green-950/50 p-4"
+    >
+      <div className="flex items-center gap-2 text-green-400">
+        <Check className="h-4 w-4" />
+        <span className="font-medium">{message}</span>
+      </div>
     </div>
   )
 }

--- a/frontend/app/admin/moderation/_components/ModerationQueue.tsx
+++ b/frontend/app/admin/moderation/_components/ModerationQueue.tsx
@@ -992,7 +992,6 @@ export function ModerationQueue() {
     return () => clearTimeout(timer)
   }, [lastAction])
 
-  // Clear the banner when the admin switches filter tabs.
   useEffect(() => {
     setLastAction(null)
   }, [itemTypeFilter, entityTypeFilter])
@@ -1090,9 +1089,6 @@ export function ModerationQueue() {
 
   return (
     <div className="space-y-4">
-      {/* PSY-603: page-level success banner for Approve / Reject. Reuses the
-          PSY-562 pattern (green border + Check icon) from EntityEditDrawer.
-          Auto-dismisses after 5s or clears on filter change (see effects above). */}
       {lastAction && <ModerationSuccessBanner action={lastAction} />}
 
       {/* Filter bar */}


### PR DESCRIPTION
## Summary
- Cards in the admin moderation queue now bubble Approve / Reject success up to a page-level banner above the queue list, reusing the PSY-562 EntityEditDrawer success pattern (green border + Check icon).
- Banner copy is verb-aware: "Approved — change applied to <entity>" or "Rejected — submitter notified of reason". Auto-dismiss after 5s; clears immediately on filter-tab change.
- Error rendering left untouched (already class A per the May 5 PSY-596 audit, ModerationQueue.tsx:264).

## Test plan
- [x] cd frontend && bun run typecheck — passed
- [x] cd frontend && bun run test:run app/admin/moderation — passed (19/19, including 5 new banner cases: not-rendered-before-action, Approve copy + entity name, Reject copy, auto-dismiss after timeout, clear on filter change)
- [x] cd frontend && bun run test:run app/admin lib/hooks/admin components/admin — passed (261/261, no regressions in surrounding admin surfaces)

## Manual repro
Logged in as admin (asdf@admin.com), navigated to /admin/moderation. Approved a pending edit on artist "Eraser" (id 793) — green banner rendered above the queue list reading "Approved — change applied to Eraser", count decremented from 4 to 3, and the row disappeared. Banner auto-dismissed after ~5s. Repeated for Reject on a different pending edit (artist "Droll", filled rejection reason, confirmed) — banner read "Rejected — submitter notified of reason". Screenshots: `dogfood-output/PSY-603/screenshots/approve-success.png`, `reject-success.png`.

## Simplify
Dropped two narrative comments that duplicated nearby context (the filter-reset effect's body / deps already self-document; the JSX block comment was already covered by the banner component's JSDoc). No behaviour change; all 19 tests still pass.

## Notes for reviewer
- A natural follow-up would be to generalize `frontend/features/contributions/components/EntitySaveSuccessBanner.tsx` to take an optional `message` prop and reuse it here. Skipped on purpose: it would touch 5 detail-page call sites and risk merge friction with parallel worktrees. Filing as an observation rather than expanding scope.
- Other moderation-card families (PendingCommentCard, EntityReportCard, CollectionReportCard, CommentReportCard) have Resolve / Dismiss / Hide verbs rather than Approve / Reject; the ticket scope and dogfood evidence are specifically about the Approve/Reject pending-edit row, so those cards keep their current row-removal-only feedback. Easy to extend the same pattern to them later if the same gap is reported.

Closes PSY-603