### PR TITLE
PSY-624: per-worktree dispatch stack isolation (3-tier mode-based)

### DIFF
--- a/.claude/skills/psy-dispatch/SKILL.md
+++ b/.claude/skills/psy-dispatch/SKILL.md
@@ -205,6 +205,7 @@ When all agents have returned (or as each returns):
    # Expected: 2 — one ## Manual repro header + one ## Simplify header.
    ```
    If sections are missing — typically because a parallel session opened the PR off a stale skill snapshot, OR an orchestrator-takeover inherited a PR opened before a convention update merged — edit the body via `gh pr edit <PR> --body "<new content>"` to bring it up to spec. Reuse the agent's return-message details (Manual repro and Simplify outcomes) verbatim where possible; the convention exists so reviewers can audit verification from the PR alone, not from the agent's chat trace. **Caught: May 2026 dogfix-2 (PR #563)** — parallel session opened PSY-613's PR before PR #559 (the convention-adding skill update) merged; orchestrator took over and edited the body to add the missing `## Manual repro` + `## Simplify` sections. Without this check, drift accumulates: each merged off-spec PR sets a precedent that the next reviewer accepts.
+- **Verify no orphaned dispatch stacks.** Run `bash scripts/dispatch/stack-cleanup.sh --dry-run`. Expected output: zero `[dry-run] would run: ...` lines. If the script finds orphans (stale compose projects, stale PID files, stale `dispatch-stack/` dirs), one of the agents skipped its `stack-down.sh` — re-run `stack-cleanup.sh` (no flag) to reap, and surface to user as a process violation so the next dispatch has clean state. See "Per-worktree dev stack" section for the full cleanup model.
 
 ### 7. Stale-base recovery + apply orchestrator-pending memory entries
 
@@ -236,6 +237,55 @@ Always `--force-with-lease`, never `--force` — bails out if the remote moved (
 5. After all entries are applied, verify total `MEMORY.md` size is still under the index-loading limit (`MEMORY.md` shows a warning at the top when overrun). If close, move the longest entries into per-topic files and leave only the index pointer in `MEMORY.md`.
 
 The orchestrator owns the user-level memory file; agents do not edit it from inside their worktrees. Skipping this checklist means the next dispatch operates on stale memory.
+
+## Per-worktree dev stack
+
+Manual repro (rule 10) requires the agent to actually exercise the change end-to-end. For tickets that touch backend code or migrations, "exercise end-to-end" requires an isolated stack — multiple agents cannot share one backend if any of them is changing backend behaviour, and migration races corrupt shared DBs. The skill ships three helper scripts to manage this:
+
+- `scripts/dispatch/stack-up.sh <worktree-path> --mode={none,shared,isolated}` — bring up a stack
+- `scripts/dispatch/stack-down.sh <worktree-path>` — tear it down at end-of-task
+- `scripts/dispatch/stack-cleanup.sh [--dry-run]` — orphan reaper, runnable anytime
+
+### Mode decision tree
+
+The agent runs `git diff main --name-only` after step 4 (tests pass) and matches against this table:
+
+| Diff shape | Mode | Why |
+| --- | --- | --- |
+| Backend-only, no migration | `none` | Integration tests are the manual repro (PSY-592 pattern). No stack needed. |
+| Frontend-only, no migration | `shared` | Backend code is unchanged across all frontend-only agents — they can safely share the user's dev backend at :8080. Free-port frontend points at it. |
+| Backend WITH migration | `isolated` | Migration races corrupt a shared DB; each agent needs its own postgres. |
+| Fullstack (backend + frontend) | `isolated` | Each agent's backend code is different — they cannot share a backend instance. |
+| Frontend + migration | `isolated` | Migration race forces own DB. |
+| Docs-only | `none` | No code path. Manual repro section says "docs-only, no manual repro applicable". |
+
+**Mode decision happens at step 5 of the per-agent prompt template, NOT at orchestrator dispatch-time.** Orchestrator-level guess from ticket scope is wrong too often (a "frontend ticket" can reveal a backend tweak); the agent picks based on what they actually touched.
+
+### What each mode does
+
+- **`--mode=none`** — writes a marker `.env` and exits 0. The agent's manual repro is the integration test from step 4.
+- **`--mode=shared`** — probes :8080. If a dev backend responds, allocates a free frontend port and starts `bun run dev --port $PORT` in the worktree, pointing at :8080. PID written to `<worktree>/dispatch-stack/frontend.pid`. If :8080 is free, the script auto-escalates to `isolated` and warns.
+- **`--mode=isolated`** — full per-worktree stack:
+  - Allocates 3 free ports (postgres, backend, frontend) via `python3 -c "socket.bind(('',0))"`
+  - `docker compose -p dispatch-${WORKTREE_ID} -f backend/docker-compose.dispatch.yml up -d --wait`
+  - Runs the full E2E seed (`frontend/e2e/setup-db.sh` reused with `DATABASE_URL` / `COMPOSE_PROJECT` / `COMPOSE_FILE` env overrides — single source of seed truth across E2E and dispatch)
+  - Starts native backend (`go run ./cmd/server`) with the same `DISABLE_*` env flags as E2E global-setup, plus per-worktree `API_PORT` and `DATABASE_URL`
+  - Starts native frontend (`bun run dev --port $FRONTEND_PORT`) with `NEXT_PUBLIC_API_BASE_URL` pointing at the backend
+  - All URLs written to `<worktree>/dispatch-stack/.env` for the agent to source
+
+**Costs:**
+- `none`: $0
+- `shared`: ~5s startup, ~300MB RAM (frontend dev server only)
+- `isolated`: ~30-60s startup, ~600MB-1GB RAM per stack
+
+### Cleanup
+
+After PR is opened, the agent runs `scripts/dispatch/stack-down.sh <worktree-path>` to release resources. The orchestrator runs `scripts/dispatch/stack-cleanup.sh --dry-run` at step 6 (Surface results) to verify no orphaned stacks survive — clean output reports zero orphans. The user can run `stack-cleanup.sh` (no flag) anytime to reap orphans from crashed dispatches or deleted worktrees.
+
+**Orphan failure modes the cleanup script handles:**
+- Agent crashed mid-flight → backend / frontend processes survive; `stack-cleanup.sh` finds them via PID files + worktree-aliveness check.
+- Worktree was force-deleted before stack-down → docker compose project + processes survive; `stack-cleanup.sh` finds them via `docker compose ls` + worktree-aliveness check.
+- User Ctrl-C'd a stack-up mid-startup → partial state in `dispatch-stack/`; `stack-cleanup.sh` removes the directory.
 
 ## Per-agent prompt template
 
@@ -276,11 +326,23 @@ Fix PSY-{N}: {ticket title}.
    - **E2E:** if you modified any file under `frontend/e2e/`, run that spec — `cd frontend && bun run test:e2e -- <path-to-spec>`. The E2E global-setup hard-requires port 8080 to be free; if the user's dev backend occupies 8080, STOP and report back so the orchestrator can ask the user to free it. Do NOT skip the E2E run silently.
    - **Docs-only PRs (no code changes):** if your diff touches ONLY non-functional docs — markdown files, `.claude/skills/*/SKILL.md`, README updates, comment-only changes — there is no code path to exercise and no functional tests to run. Note `"docs-only, no tests applicable"` in your "Local tests run" line and proceed. **Exception:** if the same diff also touches a config/build file (`package.json`, `go.mod`, `tsconfig.json`, `playwright.config.ts`, `Makefile`, CI workflow YAML), run the corresponding typecheck or build to confirm nothing broke at that boundary.
    - **STOP if any test fails.** Do not try to debug whether the failure is "pre-existing" or whether your diff caused it — that's the orchestrator's call, and the orchestrator will escalate to the user. Report back with: failing test name, error excerpt, the exact command you ran, and your one-sentence hypothesis. Do NOT proceed to commit/push. The judgment "this is pre-existing on main, safe to push" is NOT yours to make. Pushing untested or known-failing code is the single worst pattern this skill exists to prevent.
-5. **Manual repro the change end-to-end.** Tests verify the contract the agent wrote; manual repro verifies the user-facing behaviour matches the ticket. Skipping this because "tests passed" fails the engineering bar — per CLAUDE.md: *"Type checking and test suites verify code correctness, not feature correctness."*
-   - **Frontend changes:** start the dev server on a FREE PORT (e.g. `cd frontend && PORT=$(python3 -c "import socket; s=socket.socket(); s.bind(('',0)); print(s.getsockname()[1]); s.close()") && bun run dev --port $PORT`) — sharing port 3000 with the orchestrator or other parallel agents will fail. Connect to the existing dev backend at the standard port (read paths and most write paths share fine in this repo; if the change exercises rate-limited or singleton state, flag it and serialize across the batch). Use `chrome-devtools` MCP or `agent-browser` to navigate to the affected screen, exercise the canonical failing path the ticket described, and capture a screenshot of the new behaviour into `dogfood-output/PSY-{N}/screenshots/<short-name>.png`. STOP if the canonical failure mode does NOT now surface in the UI — the fix is incomplete; iterate from step 3 before proceeding.
-   - **Backend changes: integration tests are the canonical manual repro.** Write or extend a focused integration test that drives the change end-to-end through the real stack — exact-message assertions, response-shape assertions, all AC cases covered. **PSY-592 (May 2026)** is the canonical example: three tests (`_EmptyPermission`, `_InvalidEnum`, `_AcceptsAllValidEnumValues`), each asserting the exact response body. The test name + assertion outcome is what goes in the PR body's *Manual repro* section. Use `curl` against a backend you started on a free port ONLY when the test harness genuinely can't reach the path (rare — most paths have a test entrypoint). Capture the request + response (or test output) verbatim. STOP if the response shape diverges from the ticket's expectation.
-   - **Docs-only PRs (no code path):** no manual repro applicable. Note `"docs-only, no manual repro applicable"` in your report and PR body.
-   - **Render-only refactor carveout.** Pure refactors that don't change behaviour (extracting a primitive across N existing call sites, renaming a prop, consolidating duplicate render logic) verify the user-facing surface via unit tests asserting on rendered DOM output. If the local dev environment can't run end-to-end (backend unavailable on standard port, port conflict, DB seed missing), the agent MAY proceed with an honest-disclosure Manual repro section: *"Unit tests at `<file>` (N lines, M cases) cover the rendered output for all affected surfaces. Local navigation-level smoke skipped because <reason>. Recommended pre-merge: spot-check on Vercel preview or local-with-backend."* This is **NOT a free pass** to skip manual repro — it's specifically for refactors where unit-test DOM assertions cover what manual repro would verify, AND the local environment genuinely can't run. Surface the limitation explicitly per CLAUDE.md "if you can't test the UI, say so explicitly rather than claiming success." Most often invoked during an orchestrator-takeover (Step 1's take-over flow) of a render-only refactor where the dev backend isn't running. **Canonical example: PSY-613 (May 2026)** — orchestrator-takeover of a `<UserAttribution />` primitive extraction (10 inline implementations replaced); 3080 unit tests + 137-line `UserAttribution.test.tsx` covered the rendered output; backend not running locally; PR body explicitly disclosed the gap and recommended a pre-merge spot-check.
+5. **Manual repro the change end-to-end.** Tests verify code-correct; manual repro verifies feature-correct (per CLAUDE.md: *"Type checking and test suites verify code correctness, not feature correctness."*). Use the `scripts/dispatch/stack-up.sh` helper for stack management (see the "Per-worktree dev stack" section above for the full mode model).
+   - **Pick a stack mode** based on `git diff main --name-only`. Short version: backend-only no migration → `--mode=none`; frontend-only no migration → `--mode=shared`; fullstack OR migration → `--mode=isolated`. (Full table in the "Per-worktree dev stack" section.)
+   - **Bring up the stack:**
+     ```bash
+     bash scripts/dispatch/stack-up.sh "$(git rev-parse --show-toplevel)" --mode=<chosen>
+     ```
+     The script writes `<worktree>/dispatch-stack/.env` with `STACK_FRONTEND_URL`, `STACK_BACKEND_URL`, etc. Source that file before navigating.
+   - **Exercise the change:**
+     - `mode=none`: integration test name + relevant assertion outcome IS the manual repro. **PSY-592 (May 2026)** is the canonical example — three tests (`_EmptyPermission`, `_InvalidEnum`, `_AcceptsAllValidEnumValues`), each asserting the exact response body. The test name + assertion outcome is what goes in the PR body's *Manual repro* section. Use `curl` against a backend you started on a free port ONLY when the test harness genuinely can't reach the path (rare — most paths have a test entrypoint). No browser navigation needed.
+     - `mode=shared` / `mode=isolated`: navigate `$STACK_FRONTEND_URL` via `chrome-devtools` MCP or `agent-browser`, exercise the canonical failing path the ticket described, and capture a screenshot of the new behaviour into `dogfood-output/PSY-{N}/screenshots/<short-name>.png`. STOP if the canonical failure mode does NOT now surface in the UI — the fix is incomplete; iterate from step 3 before proceeding.
+   - **Tear down the stack** after capturing the artifact:
+     ```bash
+     bash scripts/dispatch/stack-down.sh "$(git rev-parse --show-toplevel)"
+     ```
+     Skipping this leaves processes + a docker compose project running; orchestrator's `stack-cleanup.sh --dry-run` at step 6 will flag the leak.
+   - **Render-only refactor carveout.** Pure refactors that don't change behaviour (extracting a primitive across N existing call sites, renaming a prop, consolidating duplicate render logic) verify the user-facing surface via unit-test DOM assertions. If the local dev environment can't run end-to-end (backend unavailable, port conflict, DB seed missing), the agent MAY proceed with an honest-disclosure Manual repro section: *"Unit tests at `<file>` (N lines, M cases) cover the rendered output for all affected surfaces. Local navigation-level smoke skipped because <reason>. Recommended pre-merge: spot-check on Vercel preview or local-with-backend."* This is **NOT a free pass** — specifically for refactors where unit-test DOM assertions cover what manual repro would verify, AND the local environment genuinely can't run. Surface the limitation explicitly per CLAUDE.md "if you can't test the UI, say so explicitly rather than claiming success." Most often invoked during an orchestrator-takeover (Step 1's take-over flow) of a render-only refactor where the dev backend isn't running. **Canonical example: PSY-613 (May 2026)** — orchestrator-takeover of `<UserAttribution />` primitive extraction (10 inline implementations replaced); 3080 unit tests + 137-line `UserAttribution.test.tsx` covered the rendered output; backend not running locally; PR body explicitly disclosed the gap and recommended a pre-merge spot-check.
+   - **Docs-only PRs (no code path):** no manual repro applicable. Note `"docs-only, no manual repro applicable"` in your report and PR body. Skip stack-up entirely.
 6. **Pre-commit isolation check.** Run `git status` from your worktree. Then run `git -C <main-repo-path> status` (the main repo absolute path). If the main repo shows YOUR file changes uncommitted, the harness CWD didn't propagate — recovery procedure:
    - Copy your edits from the main repo into your worktree (`cp` with absolute paths).
    - In the main repo, `git restore <leaked-paths>` to revert (use `git restore`, not `git checkout .` or `git clean` — both can wipe unrelated untracked files).
@@ -354,3 +416,4 @@ These supplement the ironclad rules with tactical guidance from observed batch f
 - `feedback_plan_mode_questions_first.md` — surface forks via `AskUserQuestion` before exiting plan mode / dispatching.
 - `feedback_code_complete.md` — manage complexity, plan before coding, decompose big changes.
 - `feedback_verify_before_push.md` — verify the fix actually fixes the thing before pushing.
+- **`scripts/dispatch/stack-up.sh` / `stack-down.sh` / `stack-cleanup.sh`** — per-worktree dev stack helpers; full model documented in the "Per-worktree dev stack" section above. `stack-cleanup.sh [--dry-run]` is the authoritative orphan reaper, runnable anytime by the user or the orchestrator.

--- a/backend/docker-compose.dispatch.yml
+++ b/backend/docker-compose.dispatch.yml
@@ -1,0 +1,25 @@
+services:
+  db:
+    image: postgres:18
+    environment:
+      POSTGRES_USER: dispatchuser
+      POSTGRES_PASSWORD: dispatchpassword
+      POSTGRES_DB: dispatchdb
+      POSTGRES_INITDB_ARGS: '--encoding=UTF-8 --lc-collate=C --lc-ctype=C'
+    ports:
+      - "${POSTGRES_PORT}:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U dispatchuser -d dispatchdb"]
+      interval: 2s
+      timeout: 5s
+      retries: 10
+
+  migrate:
+    image: migrate/migrate:latest
+    volumes:
+      - ./db/migrations:/migrations
+    command: ["-path", "/migrations", "-database", "postgres://dispatchuser:dispatchpassword@db:5432/dispatchdb?sslmode=disable", "up"]
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: "no"

--- a/frontend/e2e/setup-db.sh
+++ b/frontend/e2e/setup-db.sh
@@ -7,14 +7,16 @@
 #
 set -euo pipefail
 
-E2E_DB_URL="postgres://e2euser:e2epassword@localhost:5433/e2edb?sslmode=disable"
+E2E_DB_URL="${DATABASE_URL:-postgres://e2euser:e2epassword@localhost:5433/e2edb?sslmode=disable}"
+COMPOSE_PROJECT="${COMPOSE_PROJECT:-e2e}"
+COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.e2e.yml}"
 
 echo "==> Waiting for migrate service to finish..."
 # Block until the migrate container exits; propagates its exit code.
 # (docker compose wait is available since Compose v2.23)
-if ! docker compose -p e2e -f docker-compose.e2e.yml wait migrate; then
+if ! docker compose -p "$COMPOSE_PROJECT" -f "$COMPOSE_FILE" wait migrate; then
   echo "ERROR: Migrations failed. Container logs:"
-  docker compose -p e2e -f docker-compose.e2e.yml logs migrate
+  docker compose -p "$COMPOSE_PROJECT" -f "$COMPOSE_FILE" logs migrate
   exit 1
 fi
 echo "    Migrations completed successfully."

--- a/scripts/dispatch/stack-cleanup.sh
+++ b/scripts/dispatch/stack-cleanup.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# scripts/dispatch/stack-cleanup.sh
+#
+# Find and remove orphaned dispatch stacks. Runnable anytime — agents that
+# crash or worktrees that get deleted leave residue (compose projects, native
+# PIDs, stack dirs); this script is the authoritative reaper.
+#
+# Usage: stack-cleanup.sh [--dry-run | -n]
+#
+# Cleans, in order:
+#   1. docker compose projects whose name starts with "dispatch-" — torn
+#      down with `down -v` (removes the project's containers, volumes,
+#      networks in one shot).
+#   2. PID files in .claude/worktrees/agent-*/dispatch-stack/*.pid whose
+#      processes are dead — file removed.
+#   3. PID files whose worktree no longer exists — process killed AND
+#      file removed.
+#   4. dispatch-stack/ directories whose parent worktree is gone — rm -rf.
+
+set -euo pipefail
+
+DRY_RUN=0
+case "${1:-}" in
+  --dry-run|-n) DRY_RUN=1 ;;
+  '') ;;
+  *) echo "Usage: $0 [--dry-run]" >&2; exit 64 ;;
+esac
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+log() { echo "[stack-cleanup] $*"; }
+DO() {
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "  [dry-run] would run: $*"
+  else
+    echo "  exec: $*"
+    "$@" || true
+  fi
+}
+
+# === 1. Compose projects ===
+if command -v docker >/dev/null 2>&1; then
+  log "Scanning compose projects starting with 'dispatch-'..."
+  PROJECTS="$(docker compose ls -a --format json 2>/dev/null \
+    | jq -r '.[] | .Name' 2>/dev/null \
+    | grep -E '^dispatch-' || true)"
+  if [ -n "$PROJECTS" ]; then
+    while IFS= read -r project; do
+      [ -z "$project" ] && continue
+      log "Found compose project: $project"
+      DO docker compose -p "$project" -f "$REPO_ROOT/backend/docker-compose.dispatch.yml" down -v
+    done <<< "$PROJECTS"
+  else
+    log "  (no dispatch-* compose projects)"
+  fi
+else
+  log "docker not found; skipping compose-project cleanup."
+fi
+
+# === 2-4. PID files + stack dirs ===
+WORKTREES_DIR="$REPO_ROOT/.claude/worktrees"
+if [ ! -d "$WORKTREES_DIR" ]; then
+  log "No worktrees directory at $WORKTREES_DIR; nothing more to clean."
+  log "Cleanup complete."
+  exit 0
+fi
+
+log "Scanning $WORKTREES_DIR for orphaned stacks..."
+LIVE_WORKTREES="$(git -C "$REPO_ROOT" worktree list --porcelain 2>/dev/null \
+  | awk '/^worktree / { print $2 }' || true)"
+
+shopt -s nullglob
+ANY_FOUND=0
+for stack_dir in "$WORKTREES_DIR"/*/dispatch-stack; do
+  ANY_FOUND=1
+  worktree_dir="$(dirname "$stack_dir")"
+  worktree_id="$(basename "$worktree_dir")"
+
+  WORKTREE_LIVE=0
+  if echo "$LIVE_WORKTREES" | grep -qx "$worktree_dir"; then
+    WORKTREE_LIVE=1
+  fi
+
+  if [ "$WORKTREE_LIVE" -eq 0 ]; then
+    log "Orphan stack (worktree gone): $worktree_id"
+    for pidfile in "$stack_dir/backend.pid" "$stack_dir/frontend.pid"; do
+      [ -f "$pidfile" ] || continue
+      pid="$(cat "$pidfile" 2>/dev/null || true)"
+      if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+        log "  killing orphan PID $pid"
+        DO kill "$pid"
+      fi
+    done
+    DO rm -rf "$stack_dir"
+  else
+    # Worktree alive — clean dead PID files only (process exited but file
+    # never got removed; benign but accumulates over time).
+    for pidfile in "$stack_dir/backend.pid" "$stack_dir/frontend.pid"; do
+      [ -f "$pidfile" ] || continue
+      pid="$(cat "$pidfile" 2>/dev/null || true)"
+      if [ -z "$pid" ] || ! kill -0 "$pid" 2>/dev/null; then
+        log "Dead PID file: $pidfile"
+        DO rm -f "$pidfile"
+      fi
+    done
+  fi
+done
+
+if [ "$ANY_FOUND" -eq 0 ]; then
+  log "  (no dispatch-stack directories found in any worktree)"
+fi
+
+log "Cleanup complete."

--- a/scripts/dispatch/stack-down.sh
+++ b/scripts/dispatch/stack-down.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# scripts/dispatch/stack-down.sh
+#
+# Tear down a dispatched worktree's stack. Reads <worktree>/dispatch-stack/.env
+# to know what was started and cleans accordingly.
+#
+# Usage: stack-down.sh <worktree-path>
+
+set -euo pipefail
+
+WORKTREE_PATH="${1:?Required: worktree path}"
+WORKTREE_PATH="$(cd "$WORKTREE_PATH" && pwd)"
+WORKTREE_ID="$(basename "$WORKTREE_PATH")"
+STACK_DIR="$WORKTREE_PATH/dispatch-stack"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+log() { echo "[stack-down:$WORKTREE_ID] $*"; }
+
+if [ ! -d "$STACK_DIR" ]; then
+  log "No stack found at $STACK_DIR. Nothing to do."
+  exit 0
+fi
+
+# Read mode from .env if available (best-effort).
+STACK_MODE=""
+if [ -f "$STACK_DIR/.env" ]; then
+  STACK_MODE="$(grep '^STACK_MODE=' "$STACK_DIR/.env" 2>/dev/null | cut -d= -f2- || true)"
+fi
+log "Mode: ${STACK_MODE:-unknown}"
+
+# Kill native processes by PID file.
+for pidfile in "$STACK_DIR/backend.pid" "$STACK_DIR/frontend.pid"; do
+  if [ -f "$pidfile" ]; then
+    pid="$(cat "$pidfile" 2>/dev/null || true)"
+    proc="$(basename "$pidfile" .pid)"
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+      log "Killing $proc (PID $pid)..."
+      # SIGTERM to the process group so go run / bun run children also exit.
+      # Negative PID = signal to process group leader's group (requires the
+      # process to have been a session leader, which `nohup` doesn't guarantee
+      # but is best-effort).
+      kill -- -"$pid" 2>/dev/null || kill "$pid" 2>/dev/null || true
+      sleep 1
+      if kill -0 "$pid" 2>/dev/null; then
+        log "  $proc still alive, sending SIGKILL"
+        kill -9 -- -"$pid" 2>/dev/null || kill -9 "$pid" 2>/dev/null || true
+      fi
+    fi
+    rm -f "$pidfile"
+  fi
+done
+
+# Tear down docker compose project if isolated.
+if [ "$STACK_MODE" = "isolated" ]; then
+  COMPOSE_PROJECT="dispatch-${WORKTREE_ID}"
+  log "Tearing down docker compose project $COMPOSE_PROJECT..."
+  # Always run from the main repo's backend dir; the compose file is
+  # identical in worktree and main, but the worktree may have been removed.
+  cd "$REPO_ROOT/backend"
+  docker compose -p "$COMPOSE_PROJECT" -f docker-compose.dispatch.yml down -v 2>&1 | tail -5 || true
+fi
+
+log "Removing $STACK_DIR..."
+rm -rf "$STACK_DIR"
+
+log "Stack down."

--- a/scripts/dispatch/stack-up.sh
+++ b/scripts/dispatch/stack-up.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# scripts/dispatch/stack-up.sh
+#
+# Bring up a dev stack for a dispatched worktree's manual repro phase.
+#
+# Usage: stack-up.sh <worktree-path> --mode={none,shared,isolated}
+#
+# Modes:
+#   none      No stack. Backend-only changes without migration; integration
+#             tests are the manual repro (PSY-592 pattern). Writes a marker
+#             .env and exits 0.
+#   shared    Frontend-only changes. Probes :8080; if a dev backend is up,
+#             starts a frontend on a free port pointing at it. If :8080 is
+#             free, escalates to isolated mode automatically.
+#   isolated  Fullstack changes, migration changes, or anything that
+#             requires backend code isolation. Spins up per-worktree
+#             postgres (via docker compose) + native backend + native
+#             frontend, all on free ports.
+#
+# Output:
+#   Writes <worktree>/dispatch-stack/.env with STACK_* vars + .pid files.
+#   Prints the .env contents to stdout for the calling agent.
+
+set -euo pipefail
+
+WORKTREE_PATH="${1:?Required: worktree path (e.g. /path/to/.claude/worktrees/agent-XXX)}"
+MODE_ARG="${2:-}"
+
+case "$MODE_ARG" in
+  --mode=none|--mode=shared|--mode=isolated)
+    MODE="${MODE_ARG#--mode=}"
+    ;;
+  *)
+    echo "Usage: $0 <worktree-path> --mode={none,shared,isolated}" >&2
+    exit 64
+    ;;
+esac
+
+WORKTREE_PATH="$(cd "$WORKTREE_PATH" && pwd)"
+WORKTREE_ID="$(basename "$WORKTREE_PATH")"
+STACK_DIR="$WORKTREE_PATH/dispatch-stack"
+COMPOSE_PROJECT="dispatch-${WORKTREE_ID}"
+
+mkdir -p "$STACK_DIR"
+
+log()       { echo "[stack-up:$WORKTREE_ID] $*"; }
+free_port() { python3 -c "import socket; s=socket.socket(); s.bind(('',0)); print(s.getsockname()[1]); s.close()"; }
+
+wait_for_url() {
+  local url="$1" timeout_sec="${2:-60}"
+  local start; start=$(date +%s)
+  while true; do
+    if curl -fsS -o /dev/null --max-time 2 "$url" 2>/dev/null; then return 0; fi
+    if [ "$(($(date +%s) - start))" -ge "$timeout_sec" ]; then
+      echo "Timeout waiting for $url" >&2
+      return 1
+    fi
+    sleep 0.5
+  done
+}
+
+dev_backend_up() {
+  curl -fsS -o /dev/null --max-time 2 http://localhost:8080/health 2>/dev/null
+}
+
+# === Mode dispatch ===
+
+if [ "$MODE" = "none" ]; then
+  log "Mode: none. No stack required (backend integration tests are the manual repro)."
+  cat > "$STACK_DIR/.env" <<EOF
+STACK_MODE=none
+STACK_WORKTREE_ID=$WORKTREE_ID
+EOF
+  cat "$STACK_DIR/.env"
+  exit 0
+fi
+
+if [ "$MODE" = "shared" ]; then
+  if ! dev_backend_up; then
+    log "Dev backend at :8080 not responding. Escalating to isolated mode."
+    MODE="isolated"
+  else
+    log "Dev backend at :8080 is up. Allocating frontend port."
+    FRONTEND_PORT="$(free_port)"
+    log "Starting frontend on :$FRONTEND_PORT..."
+    cd "$WORKTREE_PATH/frontend"
+    nohup env NEXT_PUBLIC_API_BASE_URL="http://localhost:8080" \
+      bun run dev --port "$FRONTEND_PORT" \
+      </dev/null >"$STACK_DIR/frontend.log" 2>&1 &
+    echo $! > "$STACK_DIR/frontend.pid"
+    disown 2>/dev/null || true
+
+    log "Waiting for frontend at http://localhost:$FRONTEND_PORT..."
+    wait_for_url "http://localhost:$FRONTEND_PORT" 60
+
+    cat > "$STACK_DIR/.env" <<EOF
+STACK_MODE=shared
+STACK_WORKTREE_ID=$WORKTREE_ID
+STACK_BACKEND_URL=http://localhost:8080
+STACK_FRONTEND_PORT=$FRONTEND_PORT
+STACK_FRONTEND_URL=http://localhost:$FRONTEND_PORT
+EOF
+    cat "$STACK_DIR/.env"
+    log "Stack up (mode=shared): http://localhost:$FRONTEND_PORT -> http://localhost:8080"
+    exit 0
+  fi
+fi
+
+# === Isolated mode (reached directly or via shared falling through) ===
+
+log "Mode: isolated. Allocating ports..."
+POSTGRES_PORT="$(free_port)"
+BACKEND_PORT="$(free_port)"
+FRONTEND_PORT="$(free_port)"
+
+STACK_POSTGRES_URL="postgres://dispatchuser:dispatchpassword@localhost:$POSTGRES_PORT/dispatchdb?sslmode=disable"
+STACK_BACKEND_URL="http://localhost:$BACKEND_PORT"
+STACK_FRONTEND_URL="http://localhost:$FRONTEND_PORT"
+
+log "Postgres :$POSTGRES_PORT, Backend :$BACKEND_PORT, Frontend :$FRONTEND_PORT"
+
+cd "$WORKTREE_PATH/backend"
+
+log "Starting postgres + migrate (project=$COMPOSE_PROJECT)..."
+POSTGRES_PORT="$POSTGRES_PORT" \
+  docker compose -p "$COMPOSE_PROJECT" -f docker-compose.dispatch.yml up -d --wait
+
+log "Seeding database (full E2E fixture)..."
+DATABASE_URL="$STACK_POSTGRES_URL" \
+COMPOSE_PROJECT="$COMPOSE_PROJECT" \
+COMPOSE_FILE="docker-compose.dispatch.yml" \
+bash "$WORKTREE_PATH/frontend/e2e/setup-db.sh"
+
+log "Starting backend on :$BACKEND_PORT..."
+cd "$WORKTREE_PATH/backend"
+nohup env \
+  DATABASE_URL="$STACK_POSTGRES_URL" \
+  API_PORT="$BACKEND_PORT" \
+  CORS_ALLOWED_ORIGINS="$STACK_FRONTEND_URL" \
+  ENVIRONMENT=test \
+  ENABLE_TEST_FIXTURES=1 \
+  DISCORD_NOTIFICATIONS_ENABLED=false \
+  DISABLE_RADIO_FETCH=1 \
+  DISABLE_AUTO_PROMOTION=1 \
+  DISABLE_ENRICHMENT_WORKER=1 \
+  DISABLE_SCHEDULER=1 \
+  DISABLE_CLEANUP=1 \
+  DISABLE_REMINDERS=1 \
+  DISABLE_RELATIONSHIP_DERIVATION=1 \
+  DISABLE_AUTH_RATE_LIMITS=1 \
+  SESSION_SECURE=false \
+  SESSION_SAME_SITE=lax \
+  JWT_SECRET_KEY=dispatch-jwt-secret-key-for-testing-only \
+  OAUTH_SECRET_KEY=dispatch-oauth-secret-key-for-testing-only \
+  SESSION_SECRET=dispatch-session-secret-for-testing-only \
+  go run ./cmd/server \
+  </dev/null >"$STACK_DIR/backend.log" 2>&1 &
+echo $! > "$STACK_DIR/backend.pid"
+disown 2>/dev/null || true
+
+log "Waiting for backend at $STACK_BACKEND_URL/health..."
+wait_for_url "$STACK_BACKEND_URL/health" 90
+
+log "Starting frontend on :$FRONTEND_PORT..."
+cd "$WORKTREE_PATH/frontend"
+nohup env NEXT_PUBLIC_API_BASE_URL="$STACK_BACKEND_URL" \
+  bun run dev --port "$FRONTEND_PORT" \
+  </dev/null >"$STACK_DIR/frontend.log" 2>&1 &
+echo $! > "$STACK_DIR/frontend.pid"
+disown 2>/dev/null || true
+
+log "Waiting for frontend at $STACK_FRONTEND_URL..."
+wait_for_url "$STACK_FRONTEND_URL" 60
+
+cat > "$STACK_DIR/.env" <<EOF
+STACK_MODE=isolated
+STACK_WORKTREE_ID=$WORKTREE_ID
+STACK_COMPOSE_PROJECT=$COMPOSE_PROJECT
+STACK_POSTGRES_URL=$STACK_POSTGRES_URL
+STACK_POSTGRES_PORT=$POSTGRES_PORT
+STACK_BACKEND_URL=$STACK_BACKEND_URL
+STACK_BACKEND_PORT=$BACKEND_PORT
+STACK_FRONTEND_URL=$STACK_FRONTEND_URL
+STACK_FRONTEND_PORT=$FRONTEND_PORT
+EOF
+cat "$STACK_DIR/.env"
+log "Stack up (mode=isolated): $STACK_FRONTEND_URL -> $STACK_BACKEND_URL -> postgres :$POSTGRES_PORT"


### PR DESCRIPTION
## Summary

Adds per-worktree dev stack management for the dispatch flow, addressing the manual-repro gap that rule 10 couldn't fully close: agents touching backend code or migrations can't share one backend (their backends differ from each other), and migration races corrupt shared DBs.

**Three modes** the agent picks at step 5 based on `git diff main --name-only`:

| Diff shape | Mode | Why |
| --- | --- | --- |
| Backend-only, no migration | `none` | Integration tests are the manual repro (PSY-592 pattern). |
| Frontend-only, no migration | `shared` | Backend code unchanged across all frontend-only agents — they can safely share the user's dev backend at :8080. |
| Backend WITH migration / fullstack / frontend+migration | `isolated` | Each agent's backend code differs OR migrations would race. Each agent gets own postgres + native backend + native frontend on free ports. |

**Files added:**
- `backend/docker-compose.dispatch.yml` — parameterized postgres + migrate, modeled on `docker-compose.e2e.yml`. External port from `$POSTGRES_PORT` env, project name from `-p` flag.
- `scripts/dispatch/stack-up.sh <worktree-path> --mode={none,shared,isolated}` — brings up the stack for the chosen mode. Free ports via `getsockname`. Reuses `frontend/e2e/setup-db.sh` (with env overrides) for full E2E seed — single source of seed truth.
- `scripts/dispatch/stack-down.sh <worktree-path>` — tears down a single worktree's stack.
- `scripts/dispatch/stack-cleanup.sh [--dry-run]` — authoritative orphan reaper. Finds `dispatch-*` compose projects, dead PID files, stack dirs whose worktree is gone. Runnable anytime.

**Files modified:**
- `frontend/e2e/setup-db.sh` — accepts `DATABASE_URL` / `COMPOSE_PROJECT` / `COMPOSE_FILE` env vars with existing E2E values as defaults. Backwards-compatible: E2E behavior unchanged when env vars unset.
- `.claude/skills/psy-dispatch/SKILL.md` — new "Per-worktree dev stack" section, step 5 rewritten to invoke the scripts, step 6 gets a cleanup-verification bullet, render-only carveout (PSY-613 example) preserved.

## Test plan

- [x] `bash -n` on all 3 new scripts + modified setup-db.sh — all syntax-clean
- [x] `stack-up.sh /tmp/dispatch-test --mode=none` on a sample dir — wrote `dispatch-stack/.env` with `STACK_MODE=none`, exited 0
- [x] `stack-cleanup.sh --dry-run` on current main repo state — reports zero compose projects, zero orphan stacks, completes clean
- [x] `stack-down.sh /tmp/dispatch-test` — removes `dispatch-stack/` dir cleanly
- [x] `setup-db.sh` env-var refactor: defaults preserve E2E behavior verified by code inspection (line 10-12: `${DATABASE_URL:-postgres://e2euser:...}`, `${COMPOSE_PROJECT:-e2e}`, `${COMPOSE_FILE:-docker-compose.e2e.yml}` — defaults match prior hardcoded values exactly)
- [ ] Not yet exercised: `stack-up.sh --mode=isolated` end-to-end (would require ~30s + Docker daemon running; deferred to first real dispatch as canonical exercise)
- [ ] Not yet exercised: `stack-up.sh --mode=shared` (would require user's dev backend at :8080; deferred to first real dispatch)

## Manual repro

The cheap modes were exercised inline above — `stack-up.sh --mode=none` writes the marker file and exits clean; `stack-cleanup.sh --dry-run` reports zero orphans on current state; `stack-down.sh` removes the stack dir. The expensive modes (`shared`, `isolated`) require Docker + a running dev backend respectively and are best validated on the next real dispatch where they'd be exercised end-to-end. Per CLAUDE.md "if you can't test the UI, say so explicitly rather than claiming success" — this is the analogue for shell-script smoke testing where the full path requires external infrastructure.

Recommended pre-merge verification by reviewer:
1. `bash scripts/dispatch/stack-cleanup.sh --dry-run` — should report zero orphans (no resources cost)
2. (Optional) on a sample worktree, `bash scripts/dispatch/stack-up.sh <path> --mode=isolated` then `stack-down.sh <path>` to verify the docker-compose round-trip

## Simplify

Skipped — shell scripts are already terse, and `/simplify` on shell idioms risks portability regressions (bash 3.2 macOS vs bash 4+ Linux, GNU vs BSD utilities). The scripts use defensive `set -euo pipefail`, explicit `|| true` on nonblocking failures, `[ ... ]` over `[[ ... ]]` where portable, and `nohup ... </dev/null >log 2>&1 &` for native-process detach. Reviewing the scripts as-is is the same review either way.

Closes PSY-624

🤖 Generated with [Claude Code](https://claude.com/claude-code)