### PR TITLE
PSY-571: lock in dedup pass for Chet Faker slug pair

### DIFF
--- a/backend/internal/services/catalog/show_dedup_test.go
+++ b/backend/internal/services/catalog/show_dedup_test.go
@@ -312,3 +312,73 @@ func (s *ShowDedupTestSuite) TestRecanonicaliseShowSlug() {
 	s.Contains(*got.Slug, "2026-09-15")
 	s.Contains(*got.Slug, "at-the-van-buren")
 }
+
+// TestDedupChetFakerPair_LegacyAndCanonicalSlugs_PSY571 locks in the
+// end-to-end behaviour for the Chet Faker shape from PSY-571: two
+// shows share the same (artist, venue, event_date) but carry
+// different slug forms — the older record has the legacy migration-
+// 000019 UTC-derived slug ("…YYYY-MM-DD"), the newer record has the
+// canonical venue-local-date-first slug ("YYYY-MM-DD-…").
+//
+// The full dedup pass must:
+//  1. detect the pair as a single cluster (existing key catches it);
+//  2. merge the loser into the winner (older record wins by created_at);
+//  3. recanonicalise the surviving record's slug to the canonical form.
+//
+// After the pass exactly one show remains, with the canonical slug.
+func (s *ShowDedupTestSuite) TestDedupChetFakerPair_LegacyAndCanonicalSlugs_PSY571() {
+	a := s.seedArtist("Chet Faker")
+	v := s.seedVenue("The Van Buren", "Phoenix", "AZ")
+
+	// 8pm Phoenix on May 3 = 03:00 UTC on May 4. Same event_date for
+	// both records — only the slugs differ.
+	eventDate := time.Date(2026, 5, 4, 3, 0, 0, 0, time.UTC)
+	earlier := time.Date(2025, 11, 29, 0, 0, 0, 0, time.UTC)
+	later := time.Date(2026, 4, 24, 0, 0, 0, 0, time.UTC)
+
+	// seedShow generates a slug from title — give the two records
+	// distinct titles so initial inserts don't collide on the unique
+	// index, then overwrite each slug below.
+	winnerID := s.seedShow("Chet Faker (legacy)", eventDate, earlier, a.ID, v.ID, "AZ")
+	loserID := s.seedShow("Chet Faker (canonical)", eventDate, later, a.ID, v.ID, "AZ")
+
+	// Force the legacy + canonical slug pairing seen in production.
+	legacySlug := "chet-faker-at-the-van-buren-2026-05-04"
+	canonicalSlug := "2026-05-03-chet-faker-at-the-van-buren"
+	s.Require().NoError(s.db.Model(&catalogm.Show{}).Where("id = ?", winnerID).Update("slug", legacySlug).Error)
+	s.Require().NoError(s.db.Model(&catalogm.Show{}).Where("id = ?", loserID).Update("slug", canonicalSlug).Error)
+
+	clusters, err := FindShowDedupClusters(s.db)
+	s.Require().NoError(err)
+	s.Require().Len(clusters, 1)
+	s.Equal(winnerID, clusters[0].WinnerID, "older record should win")
+	s.Equal([]uint{loserID}, clusters[0].LoserIDs)
+
+	// Mirror the dedup-shows cmd's per-cluster transaction: merge
+	// losers, then recanonicalise the winner's slug.
+	summary := &ShowDedupSummary{}
+	err = s.db.Transaction(func(tx *gorm.DB) error {
+		if err := MergeDuplicateShow(tx, winnerID, loserID, summary); err != nil {
+			return err
+		}
+		_, err := RecanonicaliseShowSlug(tx, winnerID)
+		return err
+	})
+	s.Require().NoError(err)
+
+	// Loser is gone, exactly one Chet Faker show remains.
+	var remaining int64
+	s.db.Model(&catalogm.Show{}).
+		Joins("JOIN show_artists sa ON sa.show_id = shows.id").
+		Joins("JOIN show_venues  sv ON sv.show_id = shows.id").
+		Where("sa.artist_id = ? AND sv.venue_id = ? AND shows.event_date = ?", a.ID, v.ID, eventDate).
+		Count(&remaining)
+	s.Equal(int64(1), remaining, "exactly one Chet Faker show should remain post-merge")
+
+	// Surviving slug is the canonical venue-local form.
+	var got catalogm.Show
+	s.Require().NoError(s.db.First(&got, winnerID).Error)
+	s.Require().NotNil(got.Slug)
+	s.Equal(canonicalSlug, *got.Slug,
+		"winner's slug should be recanonicalised to the venue-local-date-first form")
+}


### PR DESCRIPTION
## Summary
- Adds an integration test that replicates the PSY-571 shape: two shows sharing `(artist, venue, event_date)` but carrying different slug forms (legacy migration-000019 UTC-derived vs canonical venue-local-date-first). The test exercises the full dedup-shows cmd flow — cluster detection, merge, slug recanonicalisation — and asserts the surviving record carries the canonical slug.
- No production code change required: investigation confirmed both Chet Faker records share an identical `event_date` timestamp, so the existing `(artist_id, venue_id, event_date)` dedup key catches them as-is. `GenerateShowSlug` already does the venue-timezone conversion correctly; the off-by-one slugs in the DB are legacy data from migration 000019's `TO_CHAR(event_date)` backfill.
- Unique constraint on `(artist_id, venue_id, event_date)` deferred to a sibling ticket per PSY-559's MEMORY note ("after the cmd lands cleanly") — adding it now would require running the dedup cmd as a migration prerequisite on every environment.

## Test plan
- [x] cd backend && go build ./... — passed
- [x] cd backend && go test ./internal/services/catalog/... — passed (49.7s, all 8 ShowDedup tests + full catalog package green)
- [x] cd backend && go test ./internal/utils/... — passed (slug + timezone tests still green)

## Manual repro
Ran `go run ./cmd/dedup-shows --env=.env.development` (dry-run) against the local dev DB. Output included:

```
Cluster: artist=65, venue=12, event_date=2026-05-04T03:00:00Z
  Winner: show 62 (created 2025-11-29)
  Loser:  show 784 (created 2026-04-24)
```

Show 62 carries the legacy slug `chet-faker-at-the-van-buren-2026-05-04`; show 784 carries the canonical slug `2026-05-03-chet-faker-at-the-van-buren`. The Chet Faker pair from the show-details dogfood is in the merge set without modification, alongside 129 other legacy/canonical clusters.

The new integration test `TestDedupChetFakerPair_LegacyAndCanonicalSlugs_PSY571` exercises the same flow end-to-end and asserts the surviving record carries the canonical slug `2026-05-03-chet-faker-at-the-van-buren` post-merge.

## Simplify
Trimmed two narrate-what inline comments; kept the doc comment + non-obvious WHY explainers (event_date sharing, distinct seedShow titles).

Closes PSY-571