### PR TITLE
PSY-583: include owner's private collections in entity backlinks

### DIFF
--- a/backend/internal/api/handlers/community/collection.go
+++ b/backend/internal/api/handlers/community/collection.go
@@ -801,7 +801,15 @@ func (h *CollectionHandler) GetEntityCollectionsHandler(ctx context.Context, req
 		limit = 10
 	}
 
-	collections, err := h.collectionService.GetEntityCollections(req.EntityType, uint(entityID), limit)
+	// PSY-583: surface the viewer's own private collections so a creator
+	// sees their own private collections in the entity backlinks block.
+	// Anonymous viewers and non-owners continue to see only public ones.
+	var viewerID uint
+	if user := middleware.GetUserFromContext(ctx); user != nil {
+		viewerID = user.ID
+	}
+
+	collections, err := h.collectionService.GetEntityCollections(req.EntityType, uint(entityID), viewerID, limit)
 	if err != nil {
 		return nil, huma.Error500InternalServerError("Failed to fetch entity collections", err)
 	}

--- a/backend/internal/api/handlers/shared/testhelpers/mocks_gen.go
+++ b/backend/internal/api/handlers/shared/testhelpers/mocks_gen.go
@@ -17,13 +17,13 @@ import (
 	"github.com/markbates/goth"
 	"gorm.io/gorm"
 
+	"psychic-homily-backend/internal/services/contracts"
 	adminm "psychic-homily-backend/internal/models/admin"
 	authm "psychic-homily-backend/internal/models/auth"
 	catalogm "psychic-homily-backend/internal/models/catalog"
 	communitym "psychic-homily-backend/internal/models/community"
 	engagementm "psychic-homily-backend/internal/models/engagement"
 	notificationm "psychic-homily-backend/internal/models/notification"
-	"psychic-homily-backend/internal/services/contracts"
 )
 
 // Suppress unused import warnings.
@@ -49,11 +49,11 @@ var (
 // ============================================================================
 
 type MockAPITokenService struct {
-	CreateTokenFn          func(uint, *string, int) (*contracts.APITokenCreateResponse, error)
-	ValidateTokenFn        func(string) (*authm.User, *adminm.APIToken, error)
-	ListTokensFn           func(uint) ([]contracts.APITokenResponse, error)
-	RevokeTokenFn          func(uint, uint) error
-	GetTokenFn             func(uint, uint) (*contracts.APITokenResponse, error)
+	CreateTokenFn func(uint, *string, int) (*contracts.APITokenCreateResponse, error)
+	ValidateTokenFn func(string) (*authm.User, *adminm.APIToken, error)
+	ListTokensFn func(uint) ([]contracts.APITokenResponse, error)
+	RevokeTokenFn func(uint, uint) (error)
+	GetTokenFn func(uint, uint) (*contracts.APITokenResponse, error)
 	CleanupExpiredTokensFn func() (int64, error)
 }
 
@@ -75,7 +75,7 @@ func (m *MockAPITokenService) ListTokens(userID uint) ([]contracts.APITokenRespo
 	}
 	return nil, nil
 }
-func (m *MockAPITokenService) RevokeToken(userID uint, tokenID uint) error {
+func (m *MockAPITokenService) RevokeToken(userID uint, tokenID uint) (error) {
 	if m.RevokeTokenFn != nil {
 		return m.RevokeTokenFn(userID, tokenID)
 	}
@@ -121,9 +121,9 @@ func (m *MockAdminStatsService) GetRecentActivity() (*contracts.ActivityFeedResp
 // ============================================================================
 
 type MockAnalyticsService struct {
-	GetGrowthMetricsFn     func(int) (*contracts.GrowthMetricsResponse, error)
+	GetGrowthMetricsFn func(int) (*contracts.GrowthMetricsResponse, error)
 	GetEngagementMetricsFn func(int) (*contracts.EngagementMetricsResponse, error)
-	GetCommunityHealthFn   func() (*contracts.CommunityHealthResponse, error)
+	GetCommunityHealthFn func() (*contracts.CommunityHealthResponse, error)
 	GetDataQualityTrendsFn func(int) (*contracts.DataQualityTrendsResponse, error)
 }
 
@@ -180,17 +180,17 @@ func (m *MockAnalyticsService) GetDataQualityTrends(months int) (*contracts.Data
 // ============================================================================
 
 type MockArtistRelationshipService struct {
-	CreateRelationshipFn       func(uint, uint, string, bool) (*catalogm.ArtistRelationship, error)
-	GetRelationshipFn          func(uint, uint, string) (*catalogm.ArtistRelationship, error)
-	GetRelatedArtistsFn        func(uint, string, int) ([]contracts.RelatedArtistResponse, error)
-	DeleteRelationshipFn       func(uint, uint, string) error
-	GetArtistGraphFn           func(uint, []string, uint) (*contracts.ArtistGraph, error)
+	CreateRelationshipFn func(uint, uint, string, bool) (*catalogm.ArtistRelationship, error)
+	GetRelationshipFn func(uint, uint, string) (*catalogm.ArtistRelationship, error)
+	GetRelatedArtistsFn func(uint, string, int) ([]contracts.RelatedArtistResponse, error)
+	DeleteRelationshipFn func(uint, uint, string) (error)
+	GetArtistGraphFn func(uint, []string, uint) (*contracts.ArtistGraph, error)
 	GetArtistBillCompositionFn func(uint, int) (*contracts.ArtistBillComposition, error)
-	VoteFn                     func(uint, uint, string, uint, bool) error
-	RemoveVoteFn               func(uint, uint, string, uint) error
-	GetUserVoteFn              func(uint, uint, string, uint) (*catalogm.ArtistRelationshipVote, error)
-	DeriveSharedBillsFn        func(int) (int64, error)
-	DeriveSharedLabelsFn       func(int) (int64, error)
+	VoteFn func(uint, uint, string, uint, bool) (error)
+	RemoveVoteFn func(uint, uint, string, uint) (error)
+	GetUserVoteFn func(uint, uint, string, uint) (*catalogm.ArtistRelationshipVote, error)
+	DeriveSharedBillsFn func(int) (int64, error)
+	DeriveSharedLabelsFn func(int) (int64, error)
 }
 
 func (m *MockArtistRelationshipService) CreateRelationship(sourceID uint, targetID uint, relType string, autoDerived bool) (*catalogm.ArtistRelationship, error) {
@@ -211,7 +211,7 @@ func (m *MockArtistRelationshipService) GetRelatedArtists(artistID uint, relType
 	}
 	return nil, nil
 }
-func (m *MockArtistRelationshipService) DeleteRelationship(artistA uint, artistB uint, relType string) error {
+func (m *MockArtistRelationshipService) DeleteRelationship(artistA uint, artistB uint, relType string) (error) {
 	if m.DeleteRelationshipFn != nil {
 		return m.DeleteRelationshipFn(artistA, artistB, relType)
 	}
@@ -229,13 +229,13 @@ func (m *MockArtistRelationshipService) GetArtistBillComposition(artistID uint, 
 	}
 	return nil, nil
 }
-func (m *MockArtistRelationshipService) Vote(artistA uint, artistB uint, relType string, userID uint, isUpvote bool) error {
+func (m *MockArtistRelationshipService) Vote(artistA uint, artistB uint, relType string, userID uint, isUpvote bool) (error) {
 	if m.VoteFn != nil {
 		return m.VoteFn(artistA, artistB, relType, userID, isUpvote)
 	}
 	return nil
 }
-func (m *MockArtistRelationshipService) RemoveVote(artistA uint, artistB uint, relType string, userID uint) error {
+func (m *MockArtistRelationshipService) RemoveVote(artistA uint, artistB uint, relType string, userID uint) (error) {
 	if m.RemoveVoteFn != nil {
 		return m.RemoveVoteFn(artistA, artistB, relType, userID)
 	}
@@ -265,12 +265,12 @@ func (m *MockArtistRelationshipService) DeriveSharedLabels(minLabels int) (int64
 // ============================================================================
 
 type MockArtistReportService struct {
-	CreateReportFn           func(uint, uint, string, *string) (*contracts.ArtistReportResponse, error)
+	CreateReportFn func(uint, uint, string, *string) (*contracts.ArtistReportResponse, error)
 	GetUserReportForArtistFn func(uint, uint) (*contracts.ArtistReportResponse, error)
-	GetPendingReportsFn      func(int, int) ([]*contracts.ArtistReportResponse, int64, error)
-	DismissReportFn          func(uint, uint, *string) (*contracts.ArtistReportResponse, error)
-	ResolveReportFn          func(uint, uint, *string) (*contracts.ArtistReportResponse, error)
-	GetReportByIDFn          func(uint) (*communitym.ArtistReport, error)
+	GetPendingReportsFn func(int, int) ([]*contracts.ArtistReportResponse, int64, error)
+	DismissReportFn func(uint, uint, *string) (*contracts.ArtistReportResponse, error)
+	ResolveReportFn func(uint, uint, *string) (*contracts.ArtistReportResponse, error)
+	GetReportByIDFn func(uint) (*communitym.ArtistReport, error)
 }
 
 func (m *MockArtistReportService) CreateReport(userID uint, artistID uint, reportType string, details *string) (*contracts.ArtistReportResponse, error) {
@@ -315,22 +315,22 @@ func (m *MockArtistReportService) GetReportByID(reportID uint) (*communitym.Arti
 // ============================================================================
 
 type MockArtistService struct {
-	CreateArtistFn             func(*contracts.CreateArtistRequest) (*contracts.ArtistDetailResponse, error)
-	GetArtistFn                func(uint) (*contracts.ArtistDetailResponse, error)
-	GetArtistByNameFn          func(string) (*contracts.ArtistDetailResponse, error)
-	GetArtistBySlugFn          func(string) (*contracts.ArtistDetailResponse, error)
-	GetArtistsFn               func(map[string]interface{}) ([]*contracts.ArtistDetailResponse, error)
+	CreateArtistFn func(*contracts.CreateArtistRequest) (*contracts.ArtistDetailResponse, error)
+	GetArtistFn func(uint) (*contracts.ArtistDetailResponse, error)
+	GetArtistByNameFn func(string) (*contracts.ArtistDetailResponse, error)
+	GetArtistBySlugFn func(string) (*contracts.ArtistDetailResponse, error)
+	GetArtistsFn func(map[string]interface{}) ([]*contracts.ArtistDetailResponse, error)
 	GetArtistsWithShowCountsFn func(map[string]interface{}) ([]*contracts.ArtistWithShowCountResponse, error)
-	UpdateArtistFn             func(uint, map[string]interface{}) (*contracts.ArtistDetailResponse, error)
-	DeleteArtistFn             func(uint) error
-	SearchArtistsFn            func(string) ([]*contracts.ArtistDetailResponse, error)
-	GetShowsForArtistFn        func(uint, string, int, string) ([]*contracts.ArtistShowResponse, int64, error)
-	GetArtistCitiesFn          func() ([]*contracts.ArtistCityResponse, error)
-	GetLabelsForArtistFn       func(uint) ([]*contracts.ArtistLabelResponse, error)
-	AddArtistAliasFn           func(uint, string) (*contracts.ArtistAliasResponse, error)
-	RemoveArtistAliasFn        func(uint) error
-	GetArtistAliasesFn         func(uint) ([]*contracts.ArtistAliasResponse, error)
-	MergeArtistsFn             func(uint, uint) (*contracts.MergeArtistResult, error)
+	UpdateArtistFn func(uint, map[string]interface{}) (*contracts.ArtistDetailResponse, error)
+	DeleteArtistFn func(uint) (error)
+	SearchArtistsFn func(string) ([]*contracts.ArtistDetailResponse, error)
+	GetShowsForArtistFn func(uint, string, int, string) ([]*contracts.ArtistShowResponse, int64, error)
+	GetArtistCitiesFn func() ([]*contracts.ArtistCityResponse, error)
+	GetLabelsForArtistFn func(uint) ([]*contracts.ArtistLabelResponse, error)
+	AddArtistAliasFn func(uint, string) (*contracts.ArtistAliasResponse, error)
+	RemoveArtistAliasFn func(uint) (error)
+	GetArtistAliasesFn func(uint) ([]*contracts.ArtistAliasResponse, error)
+	MergeArtistsFn func(uint, uint) (*contracts.MergeArtistResult, error)
 }
 
 func (m *MockArtistService) CreateArtist(req *contracts.CreateArtistRequest) (*contracts.ArtistDetailResponse, error) {
@@ -375,7 +375,7 @@ func (m *MockArtistService) UpdateArtist(artistID uint, updates map[string]inter
 	}
 	return nil, nil
 }
-func (m *MockArtistService) DeleteArtist(artistID uint) error {
+func (m *MockArtistService) DeleteArtist(artistID uint) (error) {
 	if m.DeleteArtistFn != nil {
 		return m.DeleteArtistFn(artistID)
 	}
@@ -411,7 +411,7 @@ func (m *MockArtistService) AddArtistAlias(artistID uint, alias string) (*contra
 	}
 	return nil, nil
 }
-func (m *MockArtistService) RemoveArtistAlias(aliasID uint) error {
+func (m *MockArtistService) RemoveArtistAlias(aliasID uint) (error) {
 	if m.RemoveArtistAliasFn != nil {
 		return m.RemoveArtistAliasFn(aliasID)
 	}
@@ -435,22 +435,22 @@ func (m *MockArtistService) MergeArtists(canonicalID uint, mergeFromID uint) (*c
 // ============================================================================
 
 type MockAttendanceService struct {
-	SetAttendanceFn            func(uint, uint, string) error
-	RemoveAttendanceFn         func(uint, uint) error
-	GetUserAttendanceFn        func(uint, uint) (string, error)
-	GetAttendanceCountsFn      func(uint) (*contracts.AttendanceCountsResponse, error)
+	SetAttendanceFn func(uint, uint, string) (error)
+	RemoveAttendanceFn func(uint, uint) (error)
+	GetUserAttendanceFn func(uint, uint) (string, error)
+	GetAttendanceCountsFn func(uint) (*contracts.AttendanceCountsResponse, error)
 	GetBatchAttendanceCountsFn func([]uint) (map[uint]*contracts.AttendanceCountsResponse, error)
-	GetBatchUserAttendanceFn   func(uint, []uint) (map[uint]string, error)
-	GetUserAttendingShowsFn    func(uint, string, int, int) ([]*contracts.AttendingShowResponse, int64, error)
+	GetBatchUserAttendanceFn func(uint, []uint) (map[uint]string, error)
+	GetUserAttendingShowsFn func(uint, string, int, int) ([]*contracts.AttendingShowResponse, int64, error)
 }
 
-func (m *MockAttendanceService) SetAttendance(userID uint, showID uint, status string) error {
+func (m *MockAttendanceService) SetAttendance(userID uint, showID uint, status string) (error) {
 	if m.SetAttendanceFn != nil {
 		return m.SetAttendanceFn(userID, showID, status)
 	}
 	return nil
 }
-func (m *MockAttendanceService) RemoveAttendance(userID uint, showID uint) error {
+func (m *MockAttendanceService) RemoveAttendance(userID uint, showID uint) (error) {
 	if m.RemoveAttendanceFn != nil {
 		return m.RemoveAttendanceFn(userID, showID)
 	}
@@ -496,7 +496,7 @@ func (m *MockAttendanceService) GetUserAttendingShows(userID uint, status string
 // ============================================================================
 
 type MockAuditLogService struct {
-	LogActionFn    func(uint, string, string, uint, map[string]interface{})
+	LogActionFn func(uint, string, string, uint, map[string]interface{})
 	GetAuditLogsFn func(int, int, contracts.AuditLogFilters) ([]*contracts.AuditLogResponse, int64, error)
 }
 
@@ -517,16 +517,16 @@ func (m *MockAuditLogService) GetAuditLogs(limit int, offset int, filters contra
 // ============================================================================
 
 type MockAuthService struct {
-	OAuthLoginFn               func(http.ResponseWriter, *http.Request, string) error
-	OAuthCallbackFn            func(http.ResponseWriter, *http.Request, string) (*authm.User, string, error)
+	OAuthLoginFn func(http.ResponseWriter, *http.Request, string) (error)
+	OAuthCallbackFn func(http.ResponseWriter, *http.Request, string) (*authm.User, string, error)
 	OAuthCallbackWithConsentFn func(http.ResponseWriter, *http.Request, string, *contracts.OAuthSignupConsent) (*authm.User, string, error)
-	GetUserProfileFn           func(uint) (*authm.User, error)
-	RefreshUserTokenFn         func(*authm.User) (string, error)
-	LogoutFn                   func(http.ResponseWriter, *http.Request) error
-	SetOAuthCompleterFn        func(contracts.OAuthCompleter)
+	GetUserProfileFn func(uint) (*authm.User, error)
+	RefreshUserTokenFn func(*authm.User) (string, error)
+	LogoutFn func(http.ResponseWriter, *http.Request) (error)
+	SetOAuthCompleterFn func(contracts.OAuthCompleter)
 }
 
-func (m *MockAuthService) OAuthLogin(w http.ResponseWriter, r *http.Request, provider string) error {
+func (m *MockAuthService) OAuthLogin(w http.ResponseWriter, r *http.Request, provider string) (error) {
 	if m.OAuthLoginFn != nil {
 		return m.OAuthLoginFn(w, r, provider)
 	}
@@ -556,7 +556,7 @@ func (m *MockAuthService) RefreshUserToken(user *authm.User) (string, error) {
 	}
 	return "", nil
 }
-func (m *MockAuthService) Logout(w http.ResponseWriter, r *http.Request) error {
+func (m *MockAuthService) Logout(w http.ResponseWriter, r *http.Request) (error) {
 	if m.LogoutFn != nil {
 		return m.LogoutFn(w, r)
 	}
@@ -574,7 +574,7 @@ func (m *MockAuthService) SetOAuthCompleter(completer contracts.OAuthCompleter) 
 
 type MockAutoPromotionService struct {
 	EvaluateAllUsersFn func() (*contracts.AutoPromotionResult, error)
-	EvaluateUserFn     func(uint) (*contracts.UserEvaluationResult, error)
+	EvaluateUserFn func(uint) (*contracts.UserEvaluationResult, error)
 }
 
 func (m *MockAutoPromotionService) EvaluateAllUsers() (*contracts.AutoPromotionResult, error) {
@@ -595,11 +595,11 @@ func (m *MockAutoPromotionService) EvaluateUser(userID uint) (*contracts.UserEva
 // ============================================================================
 
 type MockCalendarService struct {
-	CreateTokenFn           func(uint, string) (*contracts.CalendarTokenCreateResponse, error)
-	GetTokenStatusFn        func(uint) (*contracts.CalendarTokenStatusResponse, error)
-	DeleteTokenFn           func(uint) error
+	CreateTokenFn func(uint, string) (*contracts.CalendarTokenCreateResponse, error)
+	GetTokenStatusFn func(uint) (*contracts.CalendarTokenStatusResponse, error)
+	DeleteTokenFn func(uint) (error)
 	ValidateCalendarTokenFn func(string) (*authm.User, error)
-	GenerateICSFeedFn       func(uint, string) ([]byte, error)
+	GenerateICSFeedFn func(uint, string) ([]byte, error)
 }
 
 func (m *MockCalendarService) CreateToken(userID uint, apiBaseURL string) (*contracts.CalendarTokenCreateResponse, error) {
@@ -614,7 +614,7 @@ func (m *MockCalendarService) GetTokenStatus(userID uint) (*contracts.CalendarTo
 	}
 	return nil, nil
 }
-func (m *MockCalendarService) DeleteToken(userID uint) error {
+func (m *MockCalendarService) DeleteToken(userID uint) (error) {
 	if m.DeleteTokenFn != nil {
 		return m.DeleteTokenFn(userID)
 	}
@@ -638,10 +638,10 @@ func (m *MockCalendarService) GenerateICSFeed(userID uint, frontendURL string) (
 // ============================================================================
 
 type MockChartsService struct {
-	GetTrendingShowsFn  func(int) ([]contracts.TrendingShow, error)
+	GetTrendingShowsFn func(int) ([]contracts.TrendingShow, error)
 	GetPopularArtistsFn func(int) ([]contracts.PopularArtist, error)
-	GetActiveVenuesFn   func(int) ([]contracts.ActiveVenue, error)
-	GetHotReleasesFn    func(int) ([]contracts.HotRelease, error)
+	GetActiveVenuesFn func(int) ([]contracts.ActiveVenue, error)
+	GetHotReleasesFn func(int) ([]contracts.HotRelease, error)
 	GetChartsOverviewFn func() (*contracts.ChartsOverview, error)
 }
 
@@ -686,31 +686,31 @@ func (m *MockChartsService) GetChartsOverview() (*contracts.ChartsOverview, erro
 // ============================================================================
 
 type MockCollectionService struct {
-	CreateCollectionFn                   func(uint, *contracts.CreateCollectionRequest) (*contracts.CollectionDetailResponse, error)
-	CloneCollectionFn                    func(string, uint) (*contracts.CollectionDetailResponse, error)
-	GetBySlugFn                          func(string, uint) (*contracts.CollectionDetailResponse, error)
-	ListCollectionsFn                    func(contracts.CollectionFilters, int, int) ([]*contracts.CollectionListResponse, int64, error)
-	UpdateCollectionFn                   func(string, uint, bool, *contracts.UpdateCollectionRequest) (*contracts.CollectionDetailResponse, error)
-	DeleteCollectionFn                   func(string, uint, bool) error
-	AddItemFn                            func(string, uint, *contracts.AddCollectionItemRequest) (*contracts.CollectionItemResponse, error)
-	UpdateItemFn                         func(string, uint, uint, bool, *contracts.UpdateCollectionItemRequest) (*contracts.CollectionItemResponse, error)
-	RemoveItemFn                         func(string, uint, uint, bool) error
-	ReorderItemsFn                       func(string, uint, *contracts.ReorderCollectionItemsRequest) error
-	SubscribeFn                          func(string, uint) error
-	UnsubscribeFn                        func(string, uint) error
-	MarkVisitedFn                        func(string, uint) error
-	LikeFn                               func(string, uint) (*contracts.CollectionLikeResponse, error)
-	UnlikeFn                             func(string, uint) (*contracts.CollectionLikeResponse, error)
-	GetStatsFn                           func(string) (*contracts.CollectionStatsResponse, error)
-	GetUserCollectionsFn                 func(uint, int, int) ([]*contracts.CollectionListResponse, int64, error)
+	CreateCollectionFn func(uint, *contracts.CreateCollectionRequest) (*contracts.CollectionDetailResponse, error)
+	CloneCollectionFn func(string, uint) (*contracts.CollectionDetailResponse, error)
+	GetBySlugFn func(string, uint) (*contracts.CollectionDetailResponse, error)
+	ListCollectionsFn func(contracts.CollectionFilters, int, int) ([]*contracts.CollectionListResponse, int64, error)
+	UpdateCollectionFn func(string, uint, bool, *contracts.UpdateCollectionRequest) (*contracts.CollectionDetailResponse, error)
+	DeleteCollectionFn func(string, uint, bool) (error)
+	AddItemFn func(string, uint, *contracts.AddCollectionItemRequest) (*contracts.CollectionItemResponse, error)
+	UpdateItemFn func(string, uint, uint, bool, *contracts.UpdateCollectionItemRequest) (*contracts.CollectionItemResponse, error)
+	RemoveItemFn func(string, uint, uint, bool) (error)
+	ReorderItemsFn func(string, uint, *contracts.ReorderCollectionItemsRequest) (error)
+	SubscribeFn func(string, uint) (error)
+	UnsubscribeFn func(string, uint) (error)
+	MarkVisitedFn func(string, uint) (error)
+	LikeFn func(string, uint) (*contracts.CollectionLikeResponse, error)
+	UnlikeFn func(string, uint) (*contracts.CollectionLikeResponse, error)
+	GetStatsFn func(string) (*contracts.CollectionStatsResponse, error)
+	GetUserCollectionsFn func(uint, int, int) ([]*contracts.CollectionListResponse, int64, error)
 	GetUserCollectionsContainingEntityFn func(uint, string, uint) ([]uint, error)
-	GetEntityCollectionsFn               func(string, uint, int) ([]*contracts.CollectionListResponse, error)
-	GetUserPublicCollectionsFn           func(uint, int, int) ([]*contracts.CollectionListResponse, int64, error)
+	GetEntityCollectionsFn func(string, uint, uint, int) ([]*contracts.CollectionListResponse, error)
+	GetUserPublicCollectionsFn func(uint, int, int) ([]*contracts.CollectionListResponse, int64, error)
 	GetUserPublicCollectionsByUsernameFn func(string, int, int) ([]*contracts.CollectionListResponse, int64, error)
-	SetFeaturedFn                        func(string, bool) error
-	AddTagToCollectionFn                 func(string, uint, *contracts.AddCollectionTagRequest) (*contracts.AddCollectionTagResponse, error)
-	RemoveTagFromCollectionFn            func(string, uint, uint) error
-	GetCollectionGraphFn                 func(string, uint, []string) (*contracts.CollectionGraphResponse, error)
+	SetFeaturedFn func(string, bool) (error)
+	AddTagToCollectionFn func(string, uint, *contracts.AddCollectionTagRequest) (*contracts.AddCollectionTagResponse, error)
+	RemoveTagFromCollectionFn func(string, uint, uint) (error)
+	GetCollectionGraphFn func(string, uint, []string) (*contracts.CollectionGraphResponse, error)
 }
 
 func (m *MockCollectionService) CreateCollection(creatorID uint, req *contracts.CreateCollectionRequest) (*contracts.CollectionDetailResponse, error) {
@@ -743,7 +743,7 @@ func (m *MockCollectionService) UpdateCollection(slug string, userID uint, isAdm
 	}
 	return nil, nil
 }
-func (m *MockCollectionService) DeleteCollection(slug string, userID uint, isAdmin bool) error {
+func (m *MockCollectionService) DeleteCollection(slug string, userID uint, isAdmin bool) (error) {
 	if m.DeleteCollectionFn != nil {
 		return m.DeleteCollectionFn(slug, userID, isAdmin)
 	}
@@ -761,31 +761,31 @@ func (m *MockCollectionService) UpdateItem(slug string, itemID uint, userID uint
 	}
 	return nil, nil
 }
-func (m *MockCollectionService) RemoveItem(slug string, itemID uint, userID uint, isAdmin bool) error {
+func (m *MockCollectionService) RemoveItem(slug string, itemID uint, userID uint, isAdmin bool) (error) {
 	if m.RemoveItemFn != nil {
 		return m.RemoveItemFn(slug, itemID, userID, isAdmin)
 	}
 	return nil
 }
-func (m *MockCollectionService) ReorderItems(slug string, userID uint, req *contracts.ReorderCollectionItemsRequest) error {
+func (m *MockCollectionService) ReorderItems(slug string, userID uint, req *contracts.ReorderCollectionItemsRequest) (error) {
 	if m.ReorderItemsFn != nil {
 		return m.ReorderItemsFn(slug, userID, req)
 	}
 	return nil
 }
-func (m *MockCollectionService) Subscribe(slug string, userID uint) error {
+func (m *MockCollectionService) Subscribe(slug string, userID uint) (error) {
 	if m.SubscribeFn != nil {
 		return m.SubscribeFn(slug, userID)
 	}
 	return nil
 }
-func (m *MockCollectionService) Unsubscribe(slug string, userID uint) error {
+func (m *MockCollectionService) Unsubscribe(slug string, userID uint) (error) {
 	if m.UnsubscribeFn != nil {
 		return m.UnsubscribeFn(slug, userID)
 	}
 	return nil
 }
-func (m *MockCollectionService) MarkVisited(slug string, userID uint) error {
+func (m *MockCollectionService) MarkVisited(slug string, userID uint) (error) {
 	if m.MarkVisitedFn != nil {
 		return m.MarkVisitedFn(slug, userID)
 	}
@@ -819,11 +819,11 @@ func (m *MockCollectionService) GetUserCollectionsContainingEntity(userID uint, 
 	if m.GetUserCollectionsContainingEntityFn != nil {
 		return m.GetUserCollectionsContainingEntityFn(userID, entityType, entityID)
 	}
-	return []uint{}, nil
+	return nil, nil
 }
-func (m *MockCollectionService) GetEntityCollections(entityType string, entityID uint, limit int) ([]*contracts.CollectionListResponse, error) {
+func (m *MockCollectionService) GetEntityCollections(entityType string, entityID uint, viewerID uint, limit int) ([]*contracts.CollectionListResponse, error) {
 	if m.GetEntityCollectionsFn != nil {
-		return m.GetEntityCollectionsFn(entityType, entityID, limit)
+		return m.GetEntityCollectionsFn(entityType, entityID, viewerID, limit)
 	}
 	return nil, nil
 }
@@ -839,7 +839,7 @@ func (m *MockCollectionService) GetUserPublicCollectionsByUsername(username stri
 	}
 	return nil, 0, nil
 }
-func (m *MockCollectionService) SetFeatured(slug string, featured bool) error {
+func (m *MockCollectionService) SetFeatured(slug string, featured bool) (error) {
 	if m.SetFeaturedFn != nil {
 		return m.SetFeaturedFn(slug, featured)
 	}
@@ -851,7 +851,7 @@ func (m *MockCollectionService) AddTagToCollection(slug string, userID uint, req
 	}
 	return nil, nil
 }
-func (m *MockCollectionService) RemoveTagFromCollection(slug string, tagID uint, userID uint) error {
+func (m *MockCollectionService) RemoveTagFromCollection(slug string, tagID uint, userID uint) (error) {
 	if m.RemoveTagFromCollectionFn != nil {
 		return m.RemoveTagFromCollectionFn(slug, tagID, userID)
 	}
@@ -869,21 +869,21 @@ func (m *MockCollectionService) GetCollectionGraph(slug string, viewerID uint, t
 // ============================================================================
 
 type MockCommentAdminService struct {
-	HideCommentFn           func(uint, uint, string) error
-	RestoreCommentFn        func(uint, uint) error
-	ListPendingCommentsFn   func(int, int) ([]*contracts.CommentResponse, int64, error)
-	ApproveCommentFn        func(uint, uint) error
-	RejectCommentFn         func(uint, uint, string) error
+	HideCommentFn func(uint, uint, string) (error)
+	RestoreCommentFn func(uint, uint) (error)
+	ListPendingCommentsFn func(int, int) ([]*contracts.CommentResponse, int64, error)
+	ApproveCommentFn func(uint, uint) (error)
+	RejectCommentFn func(uint, uint, string) (error)
 	GetCommentEditHistoryFn func(uint, uint) (*contracts.CommentEditHistoryResponse, error)
 }
 
-func (m *MockCommentAdminService) HideComment(adminUserID uint, commentID uint, reason string) error {
+func (m *MockCommentAdminService) HideComment(adminUserID uint, commentID uint, reason string) (error) {
 	if m.HideCommentFn != nil {
 		return m.HideCommentFn(adminUserID, commentID, reason)
 	}
 	return nil
 }
-func (m *MockCommentAdminService) RestoreComment(adminUserID uint, commentID uint) error {
+func (m *MockCommentAdminService) RestoreComment(adminUserID uint, commentID uint) (error) {
 	if m.RestoreCommentFn != nil {
 		return m.RestoreCommentFn(adminUserID, commentID)
 	}
@@ -895,13 +895,13 @@ func (m *MockCommentAdminService) ListPendingComments(limit int, offset int) ([]
 	}
 	return nil, 0, nil
 }
-func (m *MockCommentAdminService) ApproveComment(adminUserID uint, commentID uint) error {
+func (m *MockCommentAdminService) ApproveComment(adminUserID uint, commentID uint) (error) {
 	if m.ApproveCommentFn != nil {
 		return m.ApproveCommentFn(adminUserID, commentID)
 	}
 	return nil
 }
-func (m *MockCommentAdminService) RejectComment(adminUserID uint, commentID uint, reason string) error {
+func (m *MockCommentAdminService) RejectComment(adminUserID uint, commentID uint, reason string) (error) {
 	if m.RejectCommentFn != nil {
 		return m.RejectCommentFn(adminUserID, commentID, reason)
 	}
@@ -919,13 +919,13 @@ func (m *MockCommentAdminService) GetCommentEditHistory(requesterID uint, commen
 // ============================================================================
 
 type MockCommentService struct {
-	CreateCommentFn         func(uint, *contracts.CreateCommentRequest) (*contracts.CommentResponse, error)
-	GetCommentFn            func(uint) (*contracts.CommentResponse, error)
+	CreateCommentFn func(uint, *contracts.CreateCommentRequest) (*contracts.CommentResponse, error)
+	GetCommentFn func(uint) (*contracts.CommentResponse, error)
 	ListCommentsForEntityFn func(string, uint, contracts.CommentListFilters) (*contracts.CommentListResponse, error)
-	GetThreadFn             func(uint) ([]*contracts.CommentResponse, error)
-	UpdateCommentFn         func(uint, uint, *contracts.UpdateCommentRequest) (*contracts.CommentResponse, error)
+	GetThreadFn func(uint) ([]*contracts.CommentResponse, error)
+	UpdateCommentFn func(uint, uint, *contracts.UpdateCommentRequest) (*contracts.CommentResponse, error)
 	UpdateReplyPermissionFn func(uint, uint, string) (*contracts.CommentResponse, error)
-	DeleteCommentFn         func(uint, uint, bool) error
+	DeleteCommentFn func(uint, uint, bool) (error)
 }
 
 func (m *MockCommentService) CreateComment(userID uint, req *contracts.CreateCommentRequest) (*contracts.CommentResponse, error) {
@@ -964,7 +964,7 @@ func (m *MockCommentService) UpdateReplyPermission(userID uint, commentID uint, 
 	}
 	return nil, nil
 }
-func (m *MockCommentService) DeleteComment(userID uint, commentID uint, isAdmin bool) error {
+func (m *MockCommentService) DeleteComment(userID uint, commentID uint, isAdmin bool) (error) {
 	if m.DeleteCommentFn != nil {
 		return m.DeleteCommentFn(userID, commentID, isAdmin)
 	}
@@ -976,22 +976,22 @@ func (m *MockCommentService) DeleteComment(userID uint, commentID uint, isAdmin 
 // ============================================================================
 
 type MockCommentSubscriptionService struct {
-	SubscribeFn               func(uint, string, uint) error
-	UnsubscribeFn             func(uint, string, uint) error
-	IsSubscribedFn            func(uint, string, uint) (bool, error)
-	MarkReadFn                func(uint, string, uint) error
-	GetUnreadCountFn          func(uint, string, uint) (int, error)
+	SubscribeFn func(uint, string, uint) (error)
+	UnsubscribeFn func(uint, string, uint) (error)
+	IsSubscribedFn func(uint, string, uint) (bool, error)
+	MarkReadFn func(uint, string, uint) (error)
+	GetUnreadCountFn func(uint, string, uint) (int, error)
 	GetSubscriptionsForUserFn func(uint, int, int) ([]contracts.SubscriptionResponse, int64, error)
 	GetSubscribersForEntityFn func(string, uint) ([]uint, error)
 }
 
-func (m *MockCommentSubscriptionService) Subscribe(userID uint, entityType string, entityID uint) error {
+func (m *MockCommentSubscriptionService) Subscribe(userID uint, entityType string, entityID uint) (error) {
 	if m.SubscribeFn != nil {
 		return m.SubscribeFn(userID, entityType, entityID)
 	}
 	return nil
 }
-func (m *MockCommentSubscriptionService) Unsubscribe(userID uint, entityType string, entityID uint) error {
+func (m *MockCommentSubscriptionService) Unsubscribe(userID uint, entityType string, entityID uint) (error) {
 	if m.UnsubscribeFn != nil {
 		return m.UnsubscribeFn(userID, entityType, entityID)
 	}
@@ -1003,7 +1003,7 @@ func (m *MockCommentSubscriptionService) IsSubscribed(userID uint, entityType st
 	}
 	return false, nil
 }
-func (m *MockCommentSubscriptionService) MarkRead(userID uint, entityType string, entityID uint) error {
+func (m *MockCommentSubscriptionService) MarkRead(userID uint, entityType string, entityID uint) (error) {
 	if m.MarkReadFn != nil {
 		return m.MarkReadFn(userID, entityType, entityID)
 	}
@@ -1033,20 +1033,20 @@ func (m *MockCommentSubscriptionService) GetSubscribersForEntity(entityType stri
 // ============================================================================
 
 type MockCommentVoteService struct {
-	VoteFn                    func(uint, uint, int) error
-	UnvoteFn                  func(uint, uint) error
-	GetUserVoteFn             func(uint, uint) (*int, error)
+	VoteFn func(uint, uint, int) (error)
+	UnvoteFn func(uint, uint) (error)
+	GetUserVoteFn func(uint, uint) (*int, error)
 	GetUserVotesForCommentsFn func(uint, []uint) (map[uint]int, error)
-	GetCommentVoteCountsFn    func(uint) (int, int, float64, error)
+	GetCommentVoteCountsFn func(uint) (int, int, float64, error)
 }
 
-func (m *MockCommentVoteService) Vote(userID uint, commentID uint, direction int) error {
+func (m *MockCommentVoteService) Vote(userID uint, commentID uint, direction int) (error) {
 	if m.VoteFn != nil {
 		return m.VoteFn(userID, commentID, direction)
 	}
 	return nil
 }
-func (m *MockCommentVoteService) Unvote(userID uint, commentID uint) error {
+func (m *MockCommentVoteService) Unvote(userID uint, commentID uint) (error) {
 	if m.UnvoteFn != nil {
 		return m.UnvoteFn(userID, commentID)
 	}
@@ -1076,18 +1076,18 @@ func (m *MockCommentVoteService) GetCommentVoteCounts(commentID uint) (int, int,
 // ============================================================================
 
 type MockContributorProfileService struct {
-	GetPublicProfileFn       func(string, *uint) (*contracts.PublicProfileResponse, error)
-	GetOwnProfileFn          func(uint) (*contracts.PublicProfileResponse, error)
-	GetContributionStatsFn   func(uint) (*contracts.ContributionStats, error)
+	GetPublicProfileFn func(string, *uint) (*contracts.PublicProfileResponse, error)
+	GetOwnProfileFn func(uint) (*contracts.PublicProfileResponse, error)
+	GetContributionStatsFn func(uint) (*contracts.ContributionStats, error)
 	GetContributionHistoryFn func(uint, int, int, string) ([]*contracts.ContributionEntry, int64, error)
-	UpdatePrivacySettingsFn  func(uint, contracts.PrivacySettings) (*contracts.PrivacySettings, error)
-	GetUserSectionsFn        func(uint) ([]*contracts.ProfileSectionResponse, error)
-	GetOwnSectionsFn         func(uint) ([]*contracts.ProfileSectionResponse, error)
-	CreateSectionFn          func(uint, string, string, int) (*contracts.ProfileSectionResponse, error)
-	UpdateSectionFn          func(uint, uint, map[string]interface{}) (*contracts.ProfileSectionResponse, error)
-	DeleteSectionFn          func(uint, uint) error
-	GetActivityHeatmapFn     func(uint) (*contracts.ActivityHeatmapResponse, error)
-	GetPercentileRankingsFn  func(uint) (*contracts.PercentileRankings, error)
+	UpdatePrivacySettingsFn func(uint, contracts.PrivacySettings) (*contracts.PrivacySettings, error)
+	GetUserSectionsFn func(uint) ([]*contracts.ProfileSectionResponse, error)
+	GetOwnSectionsFn func(uint) ([]*contracts.ProfileSectionResponse, error)
+	CreateSectionFn func(uint, string, string, int) (*contracts.ProfileSectionResponse, error)
+	UpdateSectionFn func(uint, uint, map[string]interface{}) (*contracts.ProfileSectionResponse, error)
+	DeleteSectionFn func(uint, uint) (error)
+	GetActivityHeatmapFn func(uint) (*contracts.ActivityHeatmapResponse, error)
+	GetPercentileRankingsFn func(uint) (*contracts.PercentileRankings, error)
 }
 
 func (m *MockContributorProfileService) GetPublicProfile(username string, viewerID *uint) (*contracts.PublicProfileResponse, error) {
@@ -1144,7 +1144,7 @@ func (m *MockContributorProfileService) UpdateSection(userID uint, sectionID uin
 	}
 	return nil, nil
 }
-func (m *MockContributorProfileService) DeleteSection(userID uint, sectionID uint) error {
+func (m *MockContributorProfileService) DeleteSection(userID uint, sectionID uint) (error) {
 	if m.DeleteSectionFn != nil {
 		return m.DeleteSectionFn(userID, sectionID)
 	}
@@ -1168,7 +1168,7 @@ func (m *MockContributorProfileService) GetPercentileRankings(userID uint) (*con
 // ============================================================================
 
 type MockDataQualityService struct {
-	GetSummaryFn       func() (*contracts.DataQualitySummary, error)
+	GetSummaryFn func() (*contracts.DataQualitySummary, error)
 	GetCategoryItemsFn func(string, int, int) ([]*contracts.DataQualityItem, int64, error)
 }
 
@@ -1190,10 +1190,10 @@ func (m *MockDataQualityService) GetCategoryItems(category string, limit int, of
 // ============================================================================
 
 type MockDataSyncService struct {
-	ExportShowsFn   func(contracts.ExportShowsParams) (*contracts.ExportShowsResult, error)
+	ExportShowsFn func(contracts.ExportShowsParams) (*contracts.ExportShowsResult, error)
 	ExportArtistsFn func(contracts.ExportArtistsParams) (*contracts.ExportArtistsResult, error)
-	ExportVenuesFn  func(contracts.ExportVenuesParams) (*contracts.ExportVenuesResult, error)
-	ImportDataFn    func(contracts.DataImportRequest) (*contracts.DataImportResult, error)
+	ExportVenuesFn func(contracts.ExportVenuesParams) (*contracts.ExportVenuesResult, error)
+	ImportDataFn func(contracts.DataImportRequest) (*contracts.DataImportResult, error)
 }
 
 func (m *MockDataSyncService) ExportShows(params contracts.ExportShowsParams) (*contracts.ExportShowsResult, error) {
@@ -1226,18 +1226,18 @@ func (m *MockDataSyncService) ImportData(req contracts.DataImportRequest) (*cont
 // ============================================================================
 
 type MockDiscordService struct {
-	IsConfiguredFn           func() bool
-	NotifyNewUserFn          func(*authm.User)
-	NotifyNewShowFn          func(*contracts.ShowResponse, string)
+	IsConfiguredFn func() (bool)
+	NotifyNewUserFn func(*authm.User)
+	NotifyNewShowFn func(*contracts.ShowResponse, string)
 	NotifyShowStatusChangeFn func(string, uint, string, string, string)
-	NotifyShowApprovedFn     func(*contracts.ShowResponse)
-	NotifyShowRejectedFn     func(*contracts.ShowResponse, string)
-	NotifyShowReportFn       func(*communitym.ShowReport, string)
-	NotifyArtistReportFn     func(*communitym.ArtistReport, string)
-	NotifyNewVenueFn         func(uint, string, string, string, *string, string)
+	NotifyShowApprovedFn func(*contracts.ShowResponse)
+	NotifyShowRejectedFn func(*contracts.ShowResponse, string)
+	NotifyShowReportFn func(*communitym.ShowReport, string)
+	NotifyArtistReportFn func(*communitym.ArtistReport, string)
+	NotifyNewVenueFn func(uint, string, string, string, *string, string)
 }
 
-func (m *MockDiscordService) IsConfigured() bool {
+func (m *MockDiscordService) IsConfigured() (bool) {
 	if m.IsConfiguredFn != nil {
 		return m.IsConfiguredFn()
 	}
@@ -1289,10 +1289,10 @@ func (m *MockDiscordService) NotifyNewVenue(venueID uint, venueName string, city
 // ============================================================================
 
 type MockDiscoveryService struct {
-	ImportFromJSONFn       func(string, bool) (*contracts.ImportResult, error)
+	ImportFromJSONFn func(string, bool) (*contracts.ImportResult, error)
 	ImportFromJSONWithDBFn func(string, bool, *gorm.DB) (*contracts.ImportResult, error)
-	CheckEventsFn          func([]contracts.CheckEventInput) (*contracts.CheckEventsResult, error)
-	ImportEventsFn         func([]contracts.DiscoveredEvent, bool, bool, catalogm.ShowStatus) (*contracts.ImportResult, error)
+	CheckEventsFn func([]contracts.CheckEventInput) (*contracts.CheckEventsResult, error)
+	ImportEventsFn func([]contracts.DiscoveredEvent, bool, bool, catalogm.ShowStatus) (*contracts.ImportResult, error)
 }
 
 func (m *MockDiscoveryService) ImportFromJSON(filepath string, dryRun bool) (*contracts.ImportResult, error) {
@@ -1325,101 +1325,101 @@ func (m *MockDiscoveryService) ImportEvents(events []contracts.DiscoveredEvent, 
 // ============================================================================
 
 type MockEmailService struct {
-	IsConfiguredFn                 func() bool
-	SendVerificationEmailFn        func(string, string) error
-	SendMagicLinkEmailFn           func(string, string) error
-	SendAccountRecoveryEmailFn     func(string, string, int) error
-	SendShowReminderEmailFn        func(string, string, string, string, time.Time, []string) error
-	SendFilterNotificationEmailFn  func(string, string, string, string) error
-	SendTierPromotionEmailFn       func(string, string, string, string, string, []string) error
-	SendTierDemotionEmailFn        func(string, string, string, string, string) error
-	SendTierDemotionWarningEmailFn func(string, string, string, float64, float64) error
-	SendEditApprovedEmailFn        func(string, string, string, string, string) error
-	SendEditRejectedEmailFn        func(string, string, string, string, string) error
-	SendCommentNotificationFn      func(string, string, string, string, string, string, string) error
-	SendMentionNotificationFn      func(string, string, string, string, string, string, string) error
-	SendCollectionDigestEmailFn    func(string, []contracts.CollectionDigestGroup, string) error
+	IsConfiguredFn func() (bool)
+	SendVerificationEmailFn func(string, string) (error)
+	SendMagicLinkEmailFn func(string, string) (error)
+	SendAccountRecoveryEmailFn func(string, string, int) (error)
+	SendShowReminderEmailFn func(string, string, string, string, time.Time, []string) (error)
+	SendFilterNotificationEmailFn func(string, string, string, string) (error)
+	SendTierPromotionEmailFn func(string, string, string, string, string, []string) (error)
+	SendTierDemotionEmailFn func(string, string, string, string, string) (error)
+	SendTierDemotionWarningEmailFn func(string, string, string, float64, float64) (error)
+	SendEditApprovedEmailFn func(string, string, string, string, string) (error)
+	SendEditRejectedEmailFn func(string, string, string, string, string) (error)
+	SendCommentNotificationFn func(string, string, string, string, string, string, string) (error)
+	SendMentionNotificationFn func(string, string, string, string, string, string, string) (error)
+	SendCollectionDigestEmailFn func(string, []contracts.CollectionDigestGroup, string) (error)
 }
 
-func (m *MockEmailService) IsConfigured() bool {
+func (m *MockEmailService) IsConfigured() (bool) {
 	if m.IsConfiguredFn != nil {
 		return m.IsConfiguredFn()
 	}
 	return false
 }
-func (m *MockEmailService) SendVerificationEmail(toEmail string, token string) error {
+func (m *MockEmailService) SendVerificationEmail(toEmail string, token string) (error) {
 	if m.SendVerificationEmailFn != nil {
 		return m.SendVerificationEmailFn(toEmail, token)
 	}
 	return nil
 }
-func (m *MockEmailService) SendMagicLinkEmail(toEmail string, token string) error {
+func (m *MockEmailService) SendMagicLinkEmail(toEmail string, token string) (error) {
 	if m.SendMagicLinkEmailFn != nil {
 		return m.SendMagicLinkEmailFn(toEmail, token)
 	}
 	return nil
 }
-func (m *MockEmailService) SendAccountRecoveryEmail(toEmail string, token string, daysRemaining int) error {
+func (m *MockEmailService) SendAccountRecoveryEmail(toEmail string, token string, daysRemaining int) (error) {
 	if m.SendAccountRecoveryEmailFn != nil {
 		return m.SendAccountRecoveryEmailFn(toEmail, token, daysRemaining)
 	}
 	return nil
 }
-func (m *MockEmailService) SendShowReminderEmail(toEmail string, showTitle string, showURL string, unsubscribeURL string, eventDate time.Time, venues []string) error {
+func (m *MockEmailService) SendShowReminderEmail(toEmail string, showTitle string, showURL string, unsubscribeURL string, eventDate time.Time, venues []string) (error) {
 	if m.SendShowReminderEmailFn != nil {
 		return m.SendShowReminderEmailFn(toEmail, showTitle, showURL, unsubscribeURL, eventDate, venues)
 	}
 	return nil
 }
-func (m *MockEmailService) SendFilterNotificationEmail(toEmail string, subject string, htmlBody string, unsubscribeURL string) error {
+func (m *MockEmailService) SendFilterNotificationEmail(toEmail string, subject string, htmlBody string, unsubscribeURL string) (error) {
 	if m.SendFilterNotificationEmailFn != nil {
 		return m.SendFilterNotificationEmailFn(toEmail, subject, htmlBody, unsubscribeURL)
 	}
 	return nil
 }
-func (m *MockEmailService) SendTierPromotionEmail(toEmail string, username string, oldTier string, newTier string, reason string, newPermissions []string) error {
+func (m *MockEmailService) SendTierPromotionEmail(toEmail string, username string, oldTier string, newTier string, reason string, newPermissions []string) (error) {
 	if m.SendTierPromotionEmailFn != nil {
 		return m.SendTierPromotionEmailFn(toEmail, username, oldTier, newTier, reason, newPermissions)
 	}
 	return nil
 }
-func (m *MockEmailService) SendTierDemotionEmail(toEmail string, username string, oldTier string, newTier string, reason string) error {
+func (m *MockEmailService) SendTierDemotionEmail(toEmail string, username string, oldTier string, newTier string, reason string) (error) {
 	if m.SendTierDemotionEmailFn != nil {
 		return m.SendTierDemotionEmailFn(toEmail, username, oldTier, newTier, reason)
 	}
 	return nil
 }
-func (m *MockEmailService) SendTierDemotionWarningEmail(toEmail string, username string, currentTier string, currentRate float64, threshold float64) error {
+func (m *MockEmailService) SendTierDemotionWarningEmail(toEmail string, username string, currentTier string, currentRate float64, threshold float64) (error) {
 	if m.SendTierDemotionWarningEmailFn != nil {
 		return m.SendTierDemotionWarningEmailFn(toEmail, username, currentTier, currentRate, threshold)
 	}
 	return nil
 }
-func (m *MockEmailService) SendEditApprovedEmail(toEmail string, username string, entityType string, entityName string, entityURL string) error {
+func (m *MockEmailService) SendEditApprovedEmail(toEmail string, username string, entityType string, entityName string, entityURL string) (error) {
 	if m.SendEditApprovedEmailFn != nil {
 		return m.SendEditApprovedEmailFn(toEmail, username, entityType, entityName, entityURL)
 	}
 	return nil
 }
-func (m *MockEmailService) SendEditRejectedEmail(toEmail string, username string, entityType string, entityName string, rejectionReason string) error {
+func (m *MockEmailService) SendEditRejectedEmail(toEmail string, username string, entityType string, entityName string, rejectionReason string) (error) {
 	if m.SendEditRejectedEmailFn != nil {
 		return m.SendEditRejectedEmailFn(toEmail, username, entityType, entityName, rejectionReason)
 	}
 	return nil
 }
-func (m *MockEmailService) SendCommentNotification(toEmail string, commenterName string, entityType string, entityName string, commentExcerpt string, entityURL string, unsubscribeURL string) error {
+func (m *MockEmailService) SendCommentNotification(toEmail string, commenterName string, entityType string, entityName string, commentExcerpt string, entityURL string, unsubscribeURL string) (error) {
 	if m.SendCommentNotificationFn != nil {
 		return m.SendCommentNotificationFn(toEmail, commenterName, entityType, entityName, commentExcerpt, entityURL, unsubscribeURL)
 	}
 	return nil
 }
-func (m *MockEmailService) SendMentionNotification(toEmail string, mentionerName string, entityType string, entityName string, commentExcerpt string, commentURL string, unsubscribeURL string) error {
+func (m *MockEmailService) SendMentionNotification(toEmail string, mentionerName string, entityType string, entityName string, commentExcerpt string, commentURL string, unsubscribeURL string) (error) {
 	if m.SendMentionNotificationFn != nil {
 		return m.SendMentionNotificationFn(toEmail, mentionerName, entityType, entityName, commentExcerpt, commentURL, unsubscribeURL)
 	}
 	return nil
 }
-func (m *MockEmailService) SendCollectionDigestEmail(toEmail string, groups []contracts.CollectionDigestGroup, unsubscribeURL string) error {
+func (m *MockEmailService) SendCollectionDigestEmail(toEmail string, groups []contracts.CollectionDigestGroup, unsubscribeURL string) (error) {
 	if m.SendCollectionDigestEmailFn != nil {
 		return m.SendCollectionDigestEmailFn(toEmail, groups, unsubscribeURL)
 	}
@@ -1431,13 +1431,13 @@ func (m *MockEmailService) SendCollectionDigestEmail(toEmail string, groups []co
 // ============================================================================
 
 type MockEnrichmentService struct {
-	QueueShowForEnrichmentFn func(uint, string) error
-	ProcessQueueFn           func(context.Context, int) (int, error)
-	EnrichShowFn             func(context.Context, uint) (*contracts.EnrichmentResult, error)
-	GetQueueStatsFn          func() (*contracts.EnrichmentQueueStats, error)
+	QueueShowForEnrichmentFn func(uint, string) (error)
+	ProcessQueueFn func(context.Context, int) (int, error)
+	EnrichShowFn func(context.Context, uint) (*contracts.EnrichmentResult, error)
+	GetQueueStatsFn func() (*contracts.EnrichmentQueueStats, error)
 }
 
-func (m *MockEnrichmentService) QueueShowForEnrichment(showID uint, enrichmentType string) error {
+func (m *MockEnrichmentService) QueueShowForEnrichment(showID uint, enrichmentType string) (error) {
 	if m.QueueShowForEnrichmentFn != nil {
 		return m.QueueShowForEnrichmentFn(showID, enrichmentType)
 	}
@@ -1467,10 +1467,10 @@ func (m *MockEnrichmentService) GetQueueStats() (*contracts.EnrichmentQueueStats
 // ============================================================================
 
 type MockEntityReportService struct {
-	CreateEntityReportFn  func(*contracts.CreateEntityReportRequest) (*contracts.EntityReportResponse, error)
-	GetEntityReportFn     func(uint) (*contracts.EntityReportResponse, error)
-	GetEntityReportsFn    func(string, uint) ([]contracts.EntityReportResponse, error)
-	ListEntityReportsFn   func(*contracts.EntityReportFilters) ([]contracts.EntityReportResponse, int64, error)
+	CreateEntityReportFn func(*contracts.CreateEntityReportRequest) (*contracts.EntityReportResponse, error)
+	GetEntityReportFn func(uint) (*contracts.EntityReportResponse, error)
+	GetEntityReportsFn func(string, uint) ([]contracts.EntityReportResponse, error)
+	ListEntityReportsFn func(*contracts.EntityReportFilters) ([]contracts.EntityReportResponse, int64, error)
 	ResolveEntityReportFn func(uint, uint, string) (*contracts.EntityReportResponse, error)
 	DismissEntityReportFn func(uint, uint, string) (*contracts.EntityReportResponse, error)
 }
@@ -1517,7 +1517,7 @@ func (m *MockEntityReportService) DismissEntityReport(reportID uint, reviewerID 
 // ============================================================================
 
 type MockExtractionService struct {
-	ExtractShowFn         func(*contracts.ExtractShowRequest) (*contracts.ExtractShowResponse, error)
+	ExtractShowFn func(*contracts.ExtractShowRequest) (*contracts.ExtractShowResponse, error)
 	ExtractCalendarPageFn func(string, string, string, ...string) (*contracts.CalendarExtractionResponse, error)
 }
 
@@ -1539,21 +1539,21 @@ func (m *MockExtractionService) ExtractCalendarPage(venueName string, content st
 // ============================================================================
 
 type MockFavoriteVenueService struct {
-	FavoriteVenueFn                 func(uint, uint) error
-	UnfavoriteVenueFn               func(uint, uint) error
-	GetUserFavoriteVenuesFn         func(uint, int, int) ([]*contracts.FavoriteVenueResponse, int64, error)
-	IsVenueFavoritedFn              func(uint, uint) (bool, error)
+	FavoriteVenueFn func(uint, uint) (error)
+	UnfavoriteVenueFn func(uint, uint) (error)
+	GetUserFavoriteVenuesFn func(uint, int, int) ([]*contracts.FavoriteVenueResponse, int64, error)
+	IsVenueFavoritedFn func(uint, uint) (bool, error)
 	GetUpcomingShowsFromFavoritesFn func(uint, string, int, int) ([]*contracts.FavoriteVenueShowResponse, int64, error)
-	GetFavoriteVenueIDsFn           func(uint, []uint) (map[uint]bool, error)
+	GetFavoriteVenueIDsFn func(uint, []uint) (map[uint]bool, error)
 }
 
-func (m *MockFavoriteVenueService) FavoriteVenue(userID uint, venueID uint) error {
+func (m *MockFavoriteVenueService) FavoriteVenue(userID uint, venueID uint) (error) {
 	if m.FavoriteVenueFn != nil {
 		return m.FavoriteVenueFn(userID, venueID)
 	}
 	return nil
 }
-func (m *MockFavoriteVenueService) UnfavoriteVenue(userID uint, venueID uint) error {
+func (m *MockFavoriteVenueService) UnfavoriteVenue(userID uint, venueID uint) (error) {
 	if m.UnfavoriteVenueFn != nil {
 		return m.UnfavoriteVenueFn(userID, venueID)
 	}
@@ -1589,11 +1589,11 @@ func (m *MockFavoriteVenueService) GetFavoriteVenueIDs(userID uint, venueIDs []u
 // ============================================================================
 
 type MockFestivalIntelligenceService struct {
-	GetSimilarFestivalsFn         func(uint, int) ([]contracts.SimilarFestival, error)
-	GetFestivalOverlapFn          func(uint, uint) (*contracts.FestivalOverlap, error)
-	GetFestivalBreakoutsFn        func(uint) (*contracts.FestivalBreakouts, error)
+	GetSimilarFestivalsFn func(uint, int) ([]contracts.SimilarFestival, error)
+	GetFestivalOverlapFn func(uint, uint) (*contracts.FestivalOverlap, error)
+	GetFestivalBreakoutsFn func(uint) (*contracts.FestivalBreakouts, error)
 	GetArtistFestivalTrajectoryFn func(uint) (*contracts.ArtistTrajectory, error)
-	GetSeriesComparisonFn         func(string, []int) (*contracts.SeriesComparison, error)
+	GetSeriesComparisonFn func(string, []int) (*contracts.SeriesComparison, error)
 }
 
 func (m *MockFestivalIntelligenceService) GetSimilarFestivals(festivalID uint, limit int) ([]contracts.SimilarFestival, error) {
@@ -1632,20 +1632,20 @@ func (m *MockFestivalIntelligenceService) GetSeriesComparison(seriesSlug string,
 // ============================================================================
 
 type MockFestivalService struct {
-	CreateFestivalFn        func(*contracts.CreateFestivalRequest) (*contracts.FestivalDetailResponse, error)
-	GetFestivalFn           func(uint) (*contracts.FestivalDetailResponse, error)
-	GetFestivalBySlugFn     func(string) (*contracts.FestivalDetailResponse, error)
-	ListFestivalsFn         func(map[string]interface{}) ([]*contracts.FestivalListResponse, error)
-	SearchFestivalsFn       func(string) ([]*contracts.FestivalListResponse, error)
-	UpdateFestivalFn        func(uint, *contracts.UpdateFestivalRequest) (*contracts.FestivalDetailResponse, error)
-	DeleteFestivalFn        func(uint) error
-	GetFestivalArtistsFn    func(uint, *string) ([]*contracts.FestivalArtistResponse, error)
-	AddFestivalArtistFn     func(uint, *contracts.AddFestivalArtistRequest) (*contracts.FestivalArtistResponse, error)
-	UpdateFestivalArtistFn  func(uint, uint, *contracts.UpdateFestivalArtistRequest) (*contracts.FestivalArtistResponse, error)
-	RemoveFestivalArtistFn  func(uint, uint) error
-	GetFestivalVenuesFn     func(uint) ([]*contracts.FestivalVenueResponse, error)
-	AddFestivalVenueFn      func(uint, *contracts.AddFestivalVenueRequest) (*contracts.FestivalVenueResponse, error)
-	RemoveFestivalVenueFn   func(uint, uint) error
+	CreateFestivalFn func(*contracts.CreateFestivalRequest) (*contracts.FestivalDetailResponse, error)
+	GetFestivalFn func(uint) (*contracts.FestivalDetailResponse, error)
+	GetFestivalBySlugFn func(string) (*contracts.FestivalDetailResponse, error)
+	ListFestivalsFn func(map[string]interface{}) ([]*contracts.FestivalListResponse, error)
+	SearchFestivalsFn func(string) ([]*contracts.FestivalListResponse, error)
+	UpdateFestivalFn func(uint, *contracts.UpdateFestivalRequest) (*contracts.FestivalDetailResponse, error)
+	DeleteFestivalFn func(uint) (error)
+	GetFestivalArtistsFn func(uint, *string) ([]*contracts.FestivalArtistResponse, error)
+	AddFestivalArtistFn func(uint, *contracts.AddFestivalArtistRequest) (*contracts.FestivalArtistResponse, error)
+	UpdateFestivalArtistFn func(uint, uint, *contracts.UpdateFestivalArtistRequest) (*contracts.FestivalArtistResponse, error)
+	RemoveFestivalArtistFn func(uint, uint) (error)
+	GetFestivalVenuesFn func(uint) ([]*contracts.FestivalVenueResponse, error)
+	AddFestivalVenueFn func(uint, *contracts.AddFestivalVenueRequest) (*contracts.FestivalVenueResponse, error)
+	RemoveFestivalVenueFn func(uint, uint) (error)
 	GetFestivalsForArtistFn func(uint) ([]*contracts.ArtistFestivalListResponse, error)
 }
 
@@ -1685,7 +1685,7 @@ func (m *MockFestivalService) UpdateFestival(festivalID uint, req *contracts.Upd
 	}
 	return nil, nil
 }
-func (m *MockFestivalService) DeleteFestival(festivalID uint) error {
+func (m *MockFestivalService) DeleteFestival(festivalID uint) (error) {
 	if m.DeleteFestivalFn != nil {
 		return m.DeleteFestivalFn(festivalID)
 	}
@@ -1709,7 +1709,7 @@ func (m *MockFestivalService) UpdateFestivalArtist(festivalID uint, artistID uin
 	}
 	return nil, nil
 }
-func (m *MockFestivalService) RemoveFestivalArtist(festivalID uint, artistID uint) error {
+func (m *MockFestivalService) RemoveFestivalArtist(festivalID uint, artistID uint) (error) {
 	if m.RemoveFestivalArtistFn != nil {
 		return m.RemoveFestivalArtistFn(festivalID, artistID)
 	}
@@ -1727,7 +1727,7 @@ func (m *MockFestivalService) AddFestivalVenue(festivalID uint, req *contracts.A
 	}
 	return nil, nil
 }
-func (m *MockFestivalService) RemoveFestivalVenue(festivalID uint, venueID uint) error {
+func (m *MockFestivalService) RemoveFestivalVenue(festivalID uint, venueID uint) (error) {
 	if m.RemoveFestivalVenueFn != nil {
 		return m.RemoveFestivalVenueFn(festivalID, venueID)
 	}
@@ -1745,7 +1745,7 @@ func (m *MockFestivalService) GetFestivalsForArtist(artistID uint) ([]*contracts
 // ============================================================================
 
 type MockFieldNoteService struct {
-	CreateFieldNoteFn       func(uint, *contracts.CreateFieldNoteRequest) (*contracts.CommentResponse, error)
+	CreateFieldNoteFn func(uint, *contracts.CreateFieldNoteRequest) (*contracts.CommentResponse, error)
 	ListFieldNotesForShowFn func(uint, int, int) (*contracts.CommentListResponse, error)
 }
 
@@ -1767,23 +1767,23 @@ func (m *MockFieldNoteService) ListFieldNotesForShow(showID uint, limit int, off
 // ============================================================================
 
 type MockFollowService struct {
-	FollowFn                 func(uint, string, uint) error
-	UnfollowFn               func(uint, string, uint) error
-	IsFollowingFn            func(uint, string, uint) (bool, error)
-	GetFollowerCountFn       func(string, uint) (int64, error)
+	FollowFn func(uint, string, uint) (error)
+	UnfollowFn func(uint, string, uint) (error)
+	IsFollowingFn func(uint, string, uint) (bool, error)
+	GetFollowerCountFn func(string, uint) (int64, error)
 	GetBatchFollowerCountsFn func(string, []uint) (map[uint]int64, error)
-	GetBatchUserFollowingFn  func(uint, string, []uint) (map[uint]bool, error)
-	GetUserFollowingFn       func(uint, string, int, int) ([]*contracts.FollowingEntityResponse, int64, error)
-	GetFollowersFn           func(string, uint, int, int) ([]*contracts.FollowerResponse, int64, error)
+	GetBatchUserFollowingFn func(uint, string, []uint) (map[uint]bool, error)
+	GetUserFollowingFn func(uint, string, int, int) ([]*contracts.FollowingEntityResponse, int64, error)
+	GetFollowersFn func(string, uint, int, int) ([]*contracts.FollowerResponse, int64, error)
 }
 
-func (m *MockFollowService) Follow(userID uint, entityType string, entityID uint) error {
+func (m *MockFollowService) Follow(userID uint, entityType string, entityID uint) (error) {
 	if m.FollowFn != nil {
 		return m.FollowFn(userID, entityType, entityID)
 	}
 	return nil
 }
-func (m *MockFollowService) Unfollow(userID uint, entityType string, entityID uint) error {
+func (m *MockFollowService) Unfollow(userID uint, entityType string, entityID uint) (error) {
 	if m.UnfollowFn != nil {
 		return m.UnfollowFn(userID, entityType, entityID)
 	}
@@ -1835,15 +1835,15 @@ func (m *MockFollowService) GetFollowers(entityType string, entityID uint, limit
 // ============================================================================
 
 type MockJWTService struct {
-	CreateTokenFn                  func(*authm.User) (string, error)
-	ValidateTokenFn                func(string) (*authm.User, error)
-	RefreshTokenFn                 func(string) (string, error)
-	ValidateTokenLenientFn         func(string, time.Duration) (*authm.User, error)
-	CreateVerificationTokenFn      func(uint, string) (string, error)
-	ValidateVerificationTokenFn    func(string) (*contracts.VerificationTokenClaims, error)
-	CreateMagicLinkTokenFn         func(uint, string) (string, error)
-	ValidateMagicLinkTokenFn       func(string) (*contracts.MagicLinkTokenClaims, error)
-	CreateAccountRecoveryTokenFn   func(uint, string) (string, error)
+	CreateTokenFn func(*authm.User) (string, error)
+	ValidateTokenFn func(string) (*authm.User, error)
+	RefreshTokenFn func(string) (string, error)
+	ValidateTokenLenientFn func(string, time.Duration) (*authm.User, error)
+	CreateVerificationTokenFn func(uint, string) (string, error)
+	ValidateVerificationTokenFn func(string) (*contracts.VerificationTokenClaims, error)
+	CreateMagicLinkTokenFn func(uint, string) (string, error)
+	ValidateMagicLinkTokenFn func(string) (*contracts.MagicLinkTokenClaims, error)
+	CreateAccountRecoveryTokenFn func(uint, string) (string, error)
 	ValidateAccountRecoveryTokenFn func(string) (*contracts.AccountRecoveryTokenClaims, error)
 }
 
@@ -1913,17 +1913,17 @@ func (m *MockJWTService) ValidateAccountRecoveryToken(tokenString string) (*cont
 // ============================================================================
 
 type MockLabelService struct {
-	CreateLabelFn       func(*contracts.CreateLabelRequest) (*contracts.LabelDetailResponse, error)
-	GetLabelFn          func(uint) (*contracts.LabelDetailResponse, error)
-	GetLabelBySlugFn    func(string) (*contracts.LabelDetailResponse, error)
-	ListLabelsFn        func(map[string]interface{}) ([]*contracts.LabelListResponse, error)
-	SearchLabelsFn      func(string) ([]*contracts.LabelListResponse, error)
-	UpdateLabelFn       func(uint, *contracts.UpdateLabelRequest) (*contracts.LabelDetailResponse, error)
-	DeleteLabelFn       func(uint) error
-	GetLabelRosterFn    func(uint) ([]*contracts.LabelArtistResponse, error)
-	GetLabelCatalogFn   func(uint) ([]*contracts.LabelReleaseResponse, error)
-	AddArtistToLabelFn  func(uint, uint) error
-	AddReleaseToLabelFn func(uint, uint, *string) error
+	CreateLabelFn func(*contracts.CreateLabelRequest) (*contracts.LabelDetailResponse, error)
+	GetLabelFn func(uint) (*contracts.LabelDetailResponse, error)
+	GetLabelBySlugFn func(string) (*contracts.LabelDetailResponse, error)
+	ListLabelsFn func(map[string]interface{}) ([]*contracts.LabelListResponse, error)
+	SearchLabelsFn func(string) ([]*contracts.LabelListResponse, error)
+	UpdateLabelFn func(uint, *contracts.UpdateLabelRequest) (*contracts.LabelDetailResponse, error)
+	DeleteLabelFn func(uint) (error)
+	GetLabelRosterFn func(uint) ([]*contracts.LabelArtistResponse, error)
+	GetLabelCatalogFn func(uint) ([]*contracts.LabelReleaseResponse, error)
+	AddArtistToLabelFn func(uint, uint) (error)
+	AddReleaseToLabelFn func(uint, uint, *string) (error)
 }
 
 func (m *MockLabelService) CreateLabel(req *contracts.CreateLabelRequest) (*contracts.LabelDetailResponse, error) {
@@ -1962,7 +1962,7 @@ func (m *MockLabelService) UpdateLabel(labelID uint, req *contracts.UpdateLabelR
 	}
 	return nil, nil
 }
-func (m *MockLabelService) DeleteLabel(labelID uint) error {
+func (m *MockLabelService) DeleteLabel(labelID uint) (error) {
 	if m.DeleteLabelFn != nil {
 		return m.DeleteLabelFn(labelID)
 	}
@@ -1980,13 +1980,13 @@ func (m *MockLabelService) GetLabelCatalog(labelID uint) ([]*contracts.LabelRele
 	}
 	return nil, nil
 }
-func (m *MockLabelService) AddArtistToLabel(labelID uint, artistID uint) error {
+func (m *MockLabelService) AddArtistToLabel(labelID uint, artistID uint) (error) {
 	if m.AddArtistToLabelFn != nil {
 		return m.AddArtistToLabelFn(labelID, artistID)
 	}
 	return nil
 }
-func (m *MockLabelService) AddReleaseToLabel(labelID uint, releaseID uint, catalogNumber *string) error {
+func (m *MockLabelService) AddReleaseToLabel(labelID uint, releaseID uint, catalogNumber *string) (error) {
 	if m.AddReleaseToLabelFn != nil {
 		return m.AddReleaseToLabelFn(labelID, releaseID, catalogNumber)
 	}
@@ -1999,7 +1999,7 @@ func (m *MockLabelService) AddReleaseToLabel(labelID uint, releaseID uint, catal
 
 type MockLeaderboardService struct {
 	GetLeaderboardFn func(string, string, int) ([]contracts.LeaderboardEntry, error)
-	GetUserRankFn    func(uint, string, string) (*int, error)
+	GetUserRankFn func(uint, string, string) (*int, error)
 }
 
 func (m *MockLeaderboardService) GetLeaderboard(dimension string, period string, limit int) ([]contracts.LeaderboardEntry, error) {
@@ -2020,11 +2020,11 @@ func (m *MockLeaderboardService) GetUserRank(userID uint, dimension string, peri
 // ============================================================================
 
 type MockMusicDiscoveryService struct {
-	IsConfiguredFn           func() bool
+	IsConfiguredFn func() (bool)
 	DiscoverMusicForArtistFn func(uint, string)
 }
 
-func (m *MockMusicDiscoveryService) IsConfigured() bool {
+func (m *MockMusicDiscoveryService) IsConfigured() (bool) {
 	if m.IsConfiguredFn != nil {
 		return m.IsConfiguredFn()
 	}
@@ -2041,17 +2041,17 @@ func (m *MockMusicDiscoveryService) DiscoverMusicForArtist(artistID uint, artist
 // ============================================================================
 
 type MockNotificationFilterService struct {
-	CreateFilterFn         func(uint, contracts.CreateFilterInput) (*notificationm.NotificationFilter, error)
-	UpdateFilterFn         func(uint, uint, contracts.UpdateFilterInput) (*notificationm.NotificationFilter, error)
-	DeleteFilterFn         func(uint, uint) error
-	GetUserFiltersFn       func(uint) ([]notificationm.NotificationFilter, error)
-	GetFilterFn            func(uint, uint) (*notificationm.NotificationFilter, error)
-	QuickCreateFilterFn    func(uint, string, uint) (*notificationm.NotificationFilter, error)
-	MatchAndNotifyFn       func(*catalogm.Show) error
-	MatchAndNotifyBatchFn  func([]catalogm.Show) error
+	CreateFilterFn func(uint, contracts.CreateFilterInput) (*notificationm.NotificationFilter, error)
+	UpdateFilterFn func(uint, uint, contracts.UpdateFilterInput) (*notificationm.NotificationFilter, error)
+	DeleteFilterFn func(uint, uint) (error)
+	GetUserFiltersFn func(uint) ([]notificationm.NotificationFilter, error)
+	GetFilterFn func(uint, uint) (*notificationm.NotificationFilter, error)
+	QuickCreateFilterFn func(uint, string, uint) (*notificationm.NotificationFilter, error)
+	MatchAndNotifyFn func(*catalogm.Show) (error)
+	MatchAndNotifyBatchFn func([]catalogm.Show) (error)
 	GetUserNotificationsFn func(uint, int, int) ([]contracts.NotificationLogEntry, error)
-	GetUnreadCountFn       func(uint) (int64, error)
-	PauseFilterFn          func(uint) error
+	GetUnreadCountFn func(uint) (int64, error)
+	PauseFilterFn func(uint) (error)
 }
 
 func (m *MockNotificationFilterService) CreateFilter(userID uint, input contracts.CreateFilterInput) (*notificationm.NotificationFilter, error) {
@@ -2066,7 +2066,7 @@ func (m *MockNotificationFilterService) UpdateFilter(userID uint, filterID uint,
 	}
 	return nil, nil
 }
-func (m *MockNotificationFilterService) DeleteFilter(userID uint, filterID uint) error {
+func (m *MockNotificationFilterService) DeleteFilter(userID uint, filterID uint) (error) {
 	if m.DeleteFilterFn != nil {
 		return m.DeleteFilterFn(userID, filterID)
 	}
@@ -2090,13 +2090,13 @@ func (m *MockNotificationFilterService) QuickCreateFilter(userID uint, entityTyp
 	}
 	return nil, nil
 }
-func (m *MockNotificationFilterService) MatchAndNotify(show *catalogm.Show) error {
+func (m *MockNotificationFilterService) MatchAndNotify(show *catalogm.Show) (error) {
 	if m.MatchAndNotifyFn != nil {
 		return m.MatchAndNotifyFn(show)
 	}
 	return nil
 }
-func (m *MockNotificationFilterService) MatchAndNotifyBatch(shows []catalogm.Show) error {
+func (m *MockNotificationFilterService) MatchAndNotifyBatch(shows []catalogm.Show) (error) {
 	if m.MatchAndNotifyBatchFn != nil {
 		return m.MatchAndNotifyBatchFn(shows)
 	}
@@ -2114,7 +2114,7 @@ func (m *MockNotificationFilterService) GetUnreadCount(userID uint) (int64, erro
 	}
 	return 0, nil
 }
-func (m *MockNotificationFilterService) PauseFilter(filterID uint) error {
+func (m *MockNotificationFilterService) PauseFilter(filterID uint) (error) {
 	if m.PauseFilterFn != nil {
 		return m.PauseFilterFn(filterID)
 	}
@@ -2127,8 +2127,8 @@ func (m *MockNotificationFilterService) PauseFilter(filterID uint) error {
 
 type MockPasswordValidator struct {
 	ValidatePasswordFn func(string) (*contracts.PasswordValidationResult, error)
-	IsBreachedFn       func(string) (bool, error)
-	IsCommonPasswordFn func(string) bool
+	IsBreachedFn func(string) (bool, error)
+	IsCommonPasswordFn func(string) (bool)
 }
 
 func (m *MockPasswordValidator) ValidatePassword(password string) (*contracts.PasswordValidationResult, error) {
@@ -2143,7 +2143,7 @@ func (m *MockPasswordValidator) IsBreached(password string) (bool, error) {
 	}
 	return false, nil
 }
-func (m *MockPasswordValidator) IsCommonPassword(password string) bool {
+func (m *MockPasswordValidator) IsCommonPassword(password string) (bool) {
 	if m.IsCommonPasswordFn != nil {
 		return m.IsCommonPasswordFn(password)
 	}
@@ -2155,14 +2155,14 @@ func (m *MockPasswordValidator) IsCommonPassword(password string) bool {
 // ============================================================================
 
 type MockPendingEditService struct {
-	CreatePendingEditFn        func(*contracts.CreatePendingEditRequest) (*contracts.PendingEditResponse, error)
-	GetPendingEditFn           func(uint) (*contracts.PendingEditResponse, error)
+	CreatePendingEditFn func(*contracts.CreatePendingEditRequest) (*contracts.PendingEditResponse, error)
+	GetPendingEditFn func(uint) (*contracts.PendingEditResponse, error)
 	GetPendingEditsForEntityFn func(string, uint) ([]contracts.PendingEditResponse, error)
-	GetUserPendingEditsFn      func(uint, int, int) ([]contracts.PendingEditResponse, int64, error)
-	ListPendingEditsFn         func(*contracts.PendingEditFilters) ([]contracts.PendingEditResponse, int64, error)
-	ApprovePendingEditFn       func(uint, uint) (*contracts.PendingEditResponse, error)
-	RejectPendingEditFn        func(uint, uint, string) (*contracts.PendingEditResponse, error)
-	CancelPendingEditFn        func(uint, uint) error
+	GetUserPendingEditsFn func(uint, int, int) ([]contracts.PendingEditResponse, int64, error)
+	ListPendingEditsFn func(*contracts.PendingEditFilters) ([]contracts.PendingEditResponse, int64, error)
+	ApprovePendingEditFn func(uint, uint) (*contracts.PendingEditResponse, error)
+	RejectPendingEditFn func(uint, uint, string) (*contracts.PendingEditResponse, error)
+	CancelPendingEditFn func(uint, uint) (error)
 }
 
 func (m *MockPendingEditService) CreatePendingEdit(req *contracts.CreatePendingEditRequest) (*contracts.PendingEditResponse, error) {
@@ -2207,7 +2207,7 @@ func (m *MockPendingEditService) RejectPendingEdit(editID uint, reviewerID uint,
 	}
 	return nil, nil
 }
-func (m *MockPendingEditService) CancelPendingEdit(editID uint, userID uint) error {
+func (m *MockPendingEditService) CancelPendingEdit(editID uint, userID uint) (error) {
 	if m.CancelPendingEditFn != nil {
 		return m.CancelPendingEditFn(editID, userID)
 	}
@@ -2242,44 +2242,44 @@ func (m *MockPipelineService) ExtractVenue(venueID uint, dryRun bool) (*contract
 // ============================================================================
 
 type MockRadioService struct {
-	CreateStationFn               func(*contracts.CreateRadioStationRequest) (*contracts.RadioStationDetailResponse, error)
-	GetStationFn                  func(uint) (*contracts.RadioStationDetailResponse, error)
-	GetStationBySlugFn            func(string) (*contracts.RadioStationDetailResponse, error)
-	ListStationsFn                func(map[string]interface{}) ([]*contracts.RadioStationListResponse, error)
-	UpdateStationFn               func(uint, *contracts.UpdateRadioStationRequest) (*contracts.RadioStationDetailResponse, error)
-	DeleteStationFn               func(uint) error
-	CreateShowFn                  func(uint, *contracts.CreateRadioShowRequest) (*contracts.RadioShowDetailResponse, error)
-	GetShowFn                     func(uint) (*contracts.RadioShowDetailResponse, error)
-	GetShowBySlugFn               func(string) (*contracts.RadioShowDetailResponse, error)
-	ListShowsFn                   func(uint) ([]*contracts.RadioShowListResponse, error)
-	UpdateShowFn                  func(uint, *contracts.UpdateRadioShowRequest) (*contracts.RadioShowDetailResponse, error)
-	DeleteShowFn                  func(uint) error
-	GetEpisodesFn                 func(uint, int, int) ([]*contracts.RadioEpisodeResponse, int64, error)
-	GetEpisodeByShowAndDateFn     func(uint, string) (*contracts.RadioEpisodeDetailResponse, error)
-	GetEpisodeDetailFn            func(uint) (*contracts.RadioEpisodeDetailResponse, error)
-	GetTopArtistsForShowFn        func(uint, int, int) ([]*contracts.RadioTopArtistResponse, error)
-	GetTopLabelsForShowFn         func(uint, int, int) ([]*contracts.RadioTopLabelResponse, error)
-	GetAsHeardOnForArtistFn       func(uint) ([]*contracts.RadioAsHeardOnResponse, error)
-	GetAsHeardOnForReleaseFn      func(uint) ([]*contracts.RadioAsHeardOnResponse, error)
-	GetNewReleaseRadarFn          func(uint, int) ([]*contracts.RadioNewReleaseRadarEntry, error)
-	GetRadioStatsFn               func() (*contracts.RadioStatsResponse, error)
-	ImportStationFn               func(uint, int) (*contracts.RadioImportResult, error)
-	FetchNewEpisodesFn            func(uint) (*contracts.RadioImportResult, error)
-	ImportEpisodePlaylistFn       func(uint, string) (*contracts.EpisodeImportResult, error)
-	DiscoverStationShowsFn        func(uint) (*contracts.RadioDiscoverResult, error)
-	ImportShowEpisodesFn          func(uint, string, string) (*contracts.RadioImportResult, error)
-	MatchPlaysFn                  func(uint) (*contracts.MatchResult, error)
-	GetUnmatchedPlaysFn           func(uint, int, int) ([]*contracts.UnmatchedPlayGroup, int64, error)
-	LinkPlayFn                    func(uint, *contracts.LinkPlayRequest) error
-	BulkLinkPlaysFn               func(*contracts.BulkLinkRequest) (*contracts.BulkLinkResult, error)
-	ComputeAffinityFn             func() error
+	CreateStationFn func(*contracts.CreateRadioStationRequest) (*contracts.RadioStationDetailResponse, error)
+	GetStationFn func(uint) (*contracts.RadioStationDetailResponse, error)
+	GetStationBySlugFn func(string) (*contracts.RadioStationDetailResponse, error)
+	ListStationsFn func(map[string]interface{}) ([]*contracts.RadioStationListResponse, error)
+	UpdateStationFn func(uint, *contracts.UpdateRadioStationRequest) (*contracts.RadioStationDetailResponse, error)
+	DeleteStationFn func(uint) (error)
+	CreateShowFn func(uint, *contracts.CreateRadioShowRequest) (*contracts.RadioShowDetailResponse, error)
+	GetShowFn func(uint) (*contracts.RadioShowDetailResponse, error)
+	GetShowBySlugFn func(string) (*contracts.RadioShowDetailResponse, error)
+	ListShowsFn func(uint) ([]*contracts.RadioShowListResponse, error)
+	UpdateShowFn func(uint, *contracts.UpdateRadioShowRequest) (*contracts.RadioShowDetailResponse, error)
+	DeleteShowFn func(uint) (error)
+	GetEpisodesFn func(uint, int, int) ([]*contracts.RadioEpisodeResponse, int64, error)
+	GetEpisodeByShowAndDateFn func(uint, string) (*contracts.RadioEpisodeDetailResponse, error)
+	GetEpisodeDetailFn func(uint) (*contracts.RadioEpisodeDetailResponse, error)
+	GetTopArtistsForShowFn func(uint, int, int) ([]*contracts.RadioTopArtistResponse, error)
+	GetTopLabelsForShowFn func(uint, int, int) ([]*contracts.RadioTopLabelResponse, error)
+	GetAsHeardOnForArtistFn func(uint) ([]*contracts.RadioAsHeardOnResponse, error)
+	GetAsHeardOnForReleaseFn func(uint) ([]*contracts.RadioAsHeardOnResponse, error)
+	GetNewReleaseRadarFn func(uint, int) ([]*contracts.RadioNewReleaseRadarEntry, error)
+	GetRadioStatsFn func() (*contracts.RadioStatsResponse, error)
+	ImportStationFn func(uint, int) (*contracts.RadioImportResult, error)
+	FetchNewEpisodesFn func(uint) (*contracts.RadioImportResult, error)
+	ImportEpisodePlaylistFn func(uint, string) (*contracts.EpisodeImportResult, error)
+	DiscoverStationShowsFn func(uint) (*contracts.RadioDiscoverResult, error)
+	ImportShowEpisodesFn func(uint, string, string) (*contracts.RadioImportResult, error)
+	MatchPlaysFn func(uint) (*contracts.MatchResult, error)
+	GetUnmatchedPlaysFn func(uint, int, int) ([]*contracts.UnmatchedPlayGroup, int64, error)
+	LinkPlayFn func(uint, *contracts.LinkPlayRequest) (error)
+	BulkLinkPlaysFn func(*contracts.BulkLinkRequest) (*contracts.BulkLinkResult, error)
+	ComputeAffinityFn func() (error)
 	SyncAffinityToRelationshipsFn func() (*contracts.SyncAffinityResult, error)
-	ReMatchUnmatchedFn            func() (*contracts.MatchResult, error)
-	CreateImportJobFn             func(uint, string, string) (*contracts.RadioImportJobResponse, error)
-	StartImportJobFn              func(uint) error
-	CancelImportJobFn             func(uint) error
-	GetImportJobFn                func(uint) (*contracts.RadioImportJobResponse, error)
-	ListImportJobsFn              func(uint) ([]*contracts.RadioImportJobResponse, error)
+	ReMatchUnmatchedFn func() (*contracts.MatchResult, error)
+	CreateImportJobFn func(uint, string, string) (*contracts.RadioImportJobResponse, error)
+	StartImportJobFn func(uint) (error)
+	CancelImportJobFn func(uint) (error)
+	GetImportJobFn func(uint) (*contracts.RadioImportJobResponse, error)
+	ListImportJobsFn func(uint) ([]*contracts.RadioImportJobResponse, error)
 }
 
 func (m *MockRadioService) CreateStation(req *contracts.CreateRadioStationRequest) (*contracts.RadioStationDetailResponse, error) {
@@ -2312,7 +2312,7 @@ func (m *MockRadioService) UpdateStation(stationID uint, req *contracts.UpdateRa
 	}
 	return nil, nil
 }
-func (m *MockRadioService) DeleteStation(stationID uint) error {
+func (m *MockRadioService) DeleteStation(stationID uint) (error) {
 	if m.DeleteStationFn != nil {
 		return m.DeleteStationFn(stationID)
 	}
@@ -2348,7 +2348,7 @@ func (m *MockRadioService) UpdateShow(showID uint, req *contracts.UpdateRadioSho
 	}
 	return nil, nil
 }
-func (m *MockRadioService) DeleteShow(showID uint) error {
+func (m *MockRadioService) DeleteShow(showID uint) (error) {
 	if m.DeleteShowFn != nil {
 		return m.DeleteShowFn(showID)
 	}
@@ -2450,7 +2450,7 @@ func (m *MockRadioService) GetUnmatchedPlays(stationID uint, limit int, offset i
 	}
 	return nil, 0, nil
 }
-func (m *MockRadioService) LinkPlay(playID uint, req *contracts.LinkPlayRequest) error {
+func (m *MockRadioService) LinkPlay(playID uint, req *contracts.LinkPlayRequest) (error) {
 	if m.LinkPlayFn != nil {
 		return m.LinkPlayFn(playID, req)
 	}
@@ -2462,7 +2462,7 @@ func (m *MockRadioService) BulkLinkPlays(req *contracts.BulkLinkRequest) (*contr
 	}
 	return nil, nil
 }
-func (m *MockRadioService) ComputeAffinity() error {
+func (m *MockRadioService) ComputeAffinity() (error) {
 	if m.ComputeAffinityFn != nil {
 		return m.ComputeAffinityFn()
 	}
@@ -2486,13 +2486,13 @@ func (m *MockRadioService) CreateImportJob(showID uint, since string, until stri
 	}
 	return nil, nil
 }
-func (m *MockRadioService) StartImportJob(jobID uint) error {
+func (m *MockRadioService) StartImportJob(jobID uint) (error) {
 	if m.StartImportJobFn != nil {
 		return m.StartImportJobFn(jobID)
 	}
 	return nil
 }
-func (m *MockRadioService) CancelImportJob(jobID uint) error {
+func (m *MockRadioService) CancelImportJob(jobID uint) (error) {
 	if m.CancelImportJobFn != nil {
 		return m.CancelImportJobFn(jobID)
 	}
@@ -2516,17 +2516,17 @@ func (m *MockRadioService) ListImportJobs(showID uint) ([]*contracts.RadioImport
 // ============================================================================
 
 type MockReleaseService struct {
-	CreateReleaseFn                 func(*contracts.CreateReleaseRequest) (*contracts.ReleaseDetailResponse, error)
-	GetReleaseFn                    func(uint) (*contracts.ReleaseDetailResponse, error)
-	GetReleaseBySlugFn              func(string) (*contracts.ReleaseDetailResponse, error)
-	ListReleasesFn                  func(contracts.ReleaseListFilters) ([]*contracts.ReleaseListResponse, int64, error)
-	SearchReleasesFn                func(string) ([]*contracts.ReleaseListResponse, error)
-	UpdateReleaseFn                 func(uint, *contracts.UpdateReleaseRequest) (*contracts.ReleaseDetailResponse, error)
-	DeleteReleaseFn                 func(uint) error
-	GetReleasesForArtistFn          func(uint) ([]*contracts.ReleaseListResponse, error)
+	CreateReleaseFn func(*contracts.CreateReleaseRequest) (*contracts.ReleaseDetailResponse, error)
+	GetReleaseFn func(uint) (*contracts.ReleaseDetailResponse, error)
+	GetReleaseBySlugFn func(string) (*contracts.ReleaseDetailResponse, error)
+	ListReleasesFn func(contracts.ReleaseListFilters) ([]*contracts.ReleaseListResponse, int64, error)
+	SearchReleasesFn func(string) ([]*contracts.ReleaseListResponse, error)
+	UpdateReleaseFn func(uint, *contracts.UpdateReleaseRequest) (*contracts.ReleaseDetailResponse, error)
+	DeleteReleaseFn func(uint) (error)
+	GetReleasesForArtistFn func(uint) ([]*contracts.ReleaseListResponse, error)
 	GetReleasesForArtistWithRolesFn func(uint) ([]*contracts.ArtistReleaseListResponse, error)
-	AddExternalLinkFn               func(uint, string, string) (*contracts.ReleaseExternalLinkResponse, error)
-	RemoveExternalLinkFn            func(uint) error
+	AddExternalLinkFn func(uint, string, string) (*contracts.ReleaseExternalLinkResponse, error)
+	RemoveExternalLinkFn func(uint) (error)
 }
 
 func (m *MockReleaseService) CreateRelease(req *contracts.CreateReleaseRequest) (*contracts.ReleaseDetailResponse, error) {
@@ -2565,7 +2565,7 @@ func (m *MockReleaseService) UpdateRelease(releaseID uint, req *contracts.Update
 	}
 	return nil, nil
 }
-func (m *MockReleaseService) DeleteRelease(releaseID uint) error {
+func (m *MockReleaseService) DeleteRelease(releaseID uint) (error) {
 	if m.DeleteReleaseFn != nil {
 		return m.DeleteReleaseFn(releaseID)
 	}
@@ -2589,7 +2589,7 @@ func (m *MockReleaseService) AddExternalLink(releaseID uint, platform string, ur
 	}
 	return nil, nil
 }
-func (m *MockReleaseService) RemoveExternalLink(linkID uint) error {
+func (m *MockReleaseService) RemoveExternalLink(linkID uint) (error) {
 	if m.RemoveExternalLinkFn != nil {
 		return m.RemoveExternalLinkFn(linkID)
 	}
@@ -2601,16 +2601,16 @@ func (m *MockReleaseService) RemoveExternalLink(linkID uint) error {
 // ============================================================================
 
 type MockRequestService struct {
-	CreateRequestFn  func(uint, string, string, string, *uint) (*communitym.Request, error)
-	GetRequestFn     func(uint) (*communitym.Request, error)
-	ListRequestsFn   func(string, string, string, int, int) ([]communitym.Request, int64, error)
-	UpdateRequestFn  func(uint, uint, *string, *string) (*communitym.Request, error)
-	DeleteRequestFn  func(uint, uint, bool) error
-	VoteFn           func(uint, uint, bool) error
-	RemoveVoteFn     func(uint, uint) error
-	FulfillRequestFn func(uint, uint, *uint) error
-	CloseRequestFn   func(uint, uint, bool) error
-	GetUserVoteFn    func(uint, uint) (*communitym.RequestVote, error)
+	CreateRequestFn func(uint, string, string, string, *uint) (*communitym.Request, error)
+	GetRequestFn func(uint) (*communitym.Request, error)
+	ListRequestsFn func(string, string, string, int, int) ([]communitym.Request, int64, error)
+	UpdateRequestFn func(uint, uint, *string, *string) (*communitym.Request, error)
+	DeleteRequestFn func(uint, uint, bool) (error)
+	VoteFn func(uint, uint, bool) (error)
+	RemoveVoteFn func(uint, uint) (error)
+	FulfillRequestFn func(uint, uint, *uint) (error)
+	CloseRequestFn func(uint, uint, bool) (error)
+	GetUserVoteFn func(uint, uint) (*communitym.RequestVote, error)
 }
 
 func (m *MockRequestService) CreateRequest(userID uint, title string, description string, entityType string, requestedEntityID *uint) (*communitym.Request, error) {
@@ -2654,31 +2654,31 @@ func (m *MockRequestService) UpdateRequest(requestID uint, userID uint, title *s
 	t := "Updated"
 	return &communitym.Request{ID: requestID, Title: t, EntityType: "artist", Status: communitym.RequestStatusPending, RequesterID: userID}, nil
 }
-func (m *MockRequestService) DeleteRequest(requestID uint, userID uint, isAdmin bool) error {
+func (m *MockRequestService) DeleteRequest(requestID uint, userID uint, isAdmin bool) (error) {
 	if m.DeleteRequestFn != nil {
 		return m.DeleteRequestFn(requestID, userID, isAdmin)
 	}
 	return nil
 }
-func (m *MockRequestService) Vote(requestID uint, userID uint, isUpvote bool) error {
+func (m *MockRequestService) Vote(requestID uint, userID uint, isUpvote bool) (error) {
 	if m.VoteFn != nil {
 		return m.VoteFn(requestID, userID, isUpvote)
 	}
 	return nil
 }
-func (m *MockRequestService) RemoveVote(requestID uint, userID uint) error {
+func (m *MockRequestService) RemoveVote(requestID uint, userID uint) (error) {
 	if m.RemoveVoteFn != nil {
 		return m.RemoveVoteFn(requestID, userID)
 	}
 	return nil
 }
-func (m *MockRequestService) FulfillRequest(requestID uint, fulfillerID uint, fulfilledEntityID *uint) error {
+func (m *MockRequestService) FulfillRequest(requestID uint, fulfillerID uint, fulfilledEntityID *uint) (error) {
 	if m.FulfillRequestFn != nil {
 		return m.FulfillRequestFn(requestID, fulfillerID, fulfilledEntityID)
 	}
 	return nil
 }
-func (m *MockRequestService) CloseRequest(requestID uint, userID uint, isAdmin bool) error {
+func (m *MockRequestService) CloseRequest(requestID uint, userID uint, isAdmin bool) (error) {
 	if m.CloseRequestFn != nil {
 		return m.CloseRequestFn(requestID, userID, isAdmin)
 	}
@@ -2696,14 +2696,14 @@ func (m *MockRequestService) GetUserVote(requestID uint, userID uint) (*communit
 // ============================================================================
 
 type MockRevisionService struct {
-	RecordRevisionFn   func(string, uint, uint, []adminm.FieldChange, string) error
+	RecordRevisionFn func(string, uint, uint, []adminm.FieldChange, string) (error)
 	GetEntityHistoryFn func(string, uint, int, int) ([]adminm.Revision, int64, error)
-	GetRevisionFn      func(uint) (*adminm.Revision, error)
+	GetRevisionFn func(uint) (*adminm.Revision, error)
 	GetUserRevisionsFn func(uint, int, int) ([]adminm.Revision, int64, error)
-	RollbackFn         func(uint, uint) error
+	RollbackFn func(uint, uint) (error)
 }
 
-func (m *MockRevisionService) RecordRevision(entityType string, entityID uint, userID uint, changes []adminm.FieldChange, summary string) error {
+func (m *MockRevisionService) RecordRevision(entityType string, entityID uint, userID uint, changes []adminm.FieldChange, summary string) (error) {
 	if m.RecordRevisionFn != nil {
 		return m.RecordRevisionFn(entityType, entityID, userID, changes, summary)
 	}
@@ -2727,7 +2727,7 @@ func (m *MockRevisionService) GetUserRevisions(userID uint, limit int, offset in
 	}
 	return nil, 0, nil
 }
-func (m *MockRevisionService) Rollback(revisionID uint, adminUserID uint) error {
+func (m *MockRevisionService) Rollback(revisionID uint, adminUserID uint) (error) {
 	if m.RollbackFn != nil {
 		return m.RollbackFn(revisionID, adminUserID)
 	}
@@ -2739,20 +2739,20 @@ func (m *MockRevisionService) Rollback(revisionID uint, adminUserID uint) error 
 // ============================================================================
 
 type MockSavedShowService struct {
-	SaveShowFn          func(uint, uint) error
-	UnsaveShowFn        func(uint, uint) error
+	SaveShowFn func(uint, uint) (error)
+	UnsaveShowFn func(uint, uint) (error)
 	GetUserSavedShowsFn func(uint, int, int) ([]*contracts.SavedShowResponse, int64, error)
-	IsShowSavedFn       func(uint, uint) (bool, error)
-	GetSavedShowIDsFn   func(uint, []uint) (map[uint]bool, error)
+	IsShowSavedFn func(uint, uint) (bool, error)
+	GetSavedShowIDsFn func(uint, []uint) (map[uint]bool, error)
 }
 
-func (m *MockSavedShowService) SaveShow(userID uint, showID uint) error {
+func (m *MockSavedShowService) SaveShow(userID uint, showID uint) (error) {
 	if m.SaveShowFn != nil {
 		return m.SaveShowFn(userID, showID)
 	}
 	return nil
 }
-func (m *MockSavedShowService) UnsaveShow(userID uint, showID uint) error {
+func (m *MockSavedShowService) UnsaveShow(userID uint, showID uint) (error) {
 	if m.UnsaveShowFn != nil {
 		return m.UnsaveShowFn(userID, showID)
 	}
@@ -2782,13 +2782,13 @@ func (m *MockSavedShowService) GetSavedShowIDs(userID uint, showIDs []uint) (map
 // ============================================================================
 
 type MockSceneService struct {
-	ListScenesFn                func() ([]*contracts.SceneListResponse, error)
-	GetSceneDetailFn            func(string, string) (*contracts.SceneDetailResponse, error)
-	GetActiveArtistsFn          func(string, string, int, int, int) ([]*contracts.SceneArtistResponse, int64, error)
-	ParseSceneSlugFn            func(string) (string, string, error)
+	ListScenesFn func() ([]*contracts.SceneListResponse, error)
+	GetSceneDetailFn func(string, string) (*contracts.SceneDetailResponse, error)
+	GetActiveArtistsFn func(string, string, int, int, int) ([]*contracts.SceneArtistResponse, int64, error)
+	ParseSceneSlugFn func(string) (string, string, error)
 	GetSceneGenreDistributionFn func(string, string) ([]contracts.GenreCount, error)
-	GetGenreDiversityIndexFn    func(string, string) (float64, error)
-	GetSceneGraphFn             func(string, string, []string) (*contracts.SceneGraphResponse, error)
+	GetGenreDiversityIndexFn func(string, string) (float64, error)
+	GetSceneGraphFn func(string, string, []string) (*contracts.SceneGraphResponse, error)
 }
 
 func (m *MockSceneService) ListScenes() ([]*contracts.SceneListResponse, error) {
@@ -2839,13 +2839,13 @@ func (m *MockSceneService) GetSceneGraph(city string, state string, types []stri
 // ============================================================================
 
 type MockShowAdminService struct {
-	GetPendingShowsFn   func(int, int, *contracts.PendingShowsFilter) ([]*contracts.ShowResponse, int64, error)
-	GetRejectedShowsFn  func(int, int, string) ([]*contracts.ShowResponse, int64, error)
-	ApproveShowFn       func(uint, bool) (*contracts.ShowResponse, error)
-	RejectShowFn        func(uint, string) (*contracts.ShowResponse, error)
+	GetPendingShowsFn func(int, int, *contracts.PendingShowsFilter) ([]*contracts.ShowResponse, int64, error)
+	GetRejectedShowsFn func(int, int, string) ([]*contracts.ShowResponse, int64, error)
+	ApproveShowFn func(uint, bool) (*contracts.ShowResponse, error)
+	RejectShowFn func(uint, string) (*contracts.ShowResponse, error)
 	BatchApproveShowsFn func([]uint) (*contracts.BatchShowResult, error)
-	BatchRejectShowsFn  func([]uint, string, string) (*contracts.BatchShowResult, error)
-	GetAdminShowsFn     func(int, int, contracts.AdminShowFilters) ([]*contracts.ShowResponse, int64, error)
+	BatchRejectShowsFn func([]uint, string, string) (*contracts.BatchShowResult, error)
+	GetAdminShowsFn func(int, int, contracts.AdminShowFilters) ([]*contracts.ShowResponse, int64, error)
 }
 
 func (m *MockShowAdminService) GetPendingShows(limit int, offset int, filters *contracts.PendingShowsFilter) ([]*contracts.ShowResponse, int64, error) {
@@ -2897,9 +2897,9 @@ func (m *MockShowAdminService) GetAdminShows(limit int, offset int, filters cont
 
 type MockShowImportService struct {
 	ExportShowToMarkdownFn func(uint) ([]byte, string, error)
-	ParseShowMarkdownFn    func([]byte) (*contracts.ParsedShowImport, error)
-	PreviewShowImportFn    func([]byte) (*contracts.ImportPreviewResponse, error)
-	ConfirmShowImportFn    func([]byte, bool) (*contracts.ShowResponse, error)
+	ParseShowMarkdownFn func([]byte) (*contracts.ParsedShowImport, error)
+	PreviewShowImportFn func([]byte) (*contracts.ImportPreviewResponse, error)
+	ConfirmShowImportFn func([]byte, bool) (*contracts.ShowResponse, error)
 }
 
 func (m *MockShowImportService) ExportShowToMarkdown(showID uint) ([]byte, string, error) {
@@ -2932,13 +2932,13 @@ func (m *MockShowImportService) ConfirmShowImport(content []byte, isAdmin bool) 
 // ============================================================================
 
 type MockShowReportService struct {
-	CreateReportFn          func(uint, uint, string, *string) (*contracts.ShowReportResponse, error)
-	GetUserReportForShowFn  func(uint, uint) (*contracts.ShowReportResponse, error)
-	GetPendingReportsFn     func(int, int) ([]*contracts.ShowReportResponse, int64, error)
-	DismissReportFn         func(uint, uint, *string) (*contracts.ShowReportResponse, error)
-	ResolveReportFn         func(uint, uint, *string) (*contracts.ShowReportResponse, error)
+	CreateReportFn func(uint, uint, string, *string) (*contracts.ShowReportResponse, error)
+	GetUserReportForShowFn func(uint, uint) (*contracts.ShowReportResponse, error)
+	GetPendingReportsFn func(int, int) ([]*contracts.ShowReportResponse, int64, error)
+	DismissReportFn func(uint, uint, *string) (*contracts.ShowReportResponse, error)
+	ResolveReportFn func(uint, uint, *string) (*contracts.ShowReportResponse, error)
 	ResolveReportWithFlagFn func(uint, uint, *string, bool) (*contracts.ShowReportResponse, error)
-	GetReportByIDFn         func(uint) (*communitym.ShowReport, error)
+	GetReportByIDFn func(uint) (*communitym.ShowReport, error)
 }
 
 func (m *MockShowReportService) CreateReport(userID uint, showID uint, reportType string, details *string) (*contracts.ShowReportResponse, error) {
@@ -2989,17 +2989,17 @@ func (m *MockShowReportService) GetReportByID(reportID uint) (*communitym.ShowRe
 // ============================================================================
 
 type MockShowService struct {
-	CreateShowFn              func(*contracts.CreateShowRequest) (*contracts.ShowResponse, error)
-	GetShowFn                 func(uint) (*contracts.ShowResponse, error)
-	GetShowBySlugFn           func(string) (*contracts.ShowResponse, error)
-	GetShowsFn                func(map[string]interface{}) ([]*contracts.ShowResponse, error)
-	GetUserSubmissionsFn      func(uint, int, int) ([]contracts.ShowResponse, int, error)
-	UpdateShowFn              func(uint, map[string]interface{}) (*contracts.ShowResponse, error)
+	CreateShowFn func(*contracts.CreateShowRequest) (*contracts.ShowResponse, error)
+	GetShowFn func(uint) (*contracts.ShowResponse, error)
+	GetShowBySlugFn func(string) (*contracts.ShowResponse, error)
+	GetShowsFn func(map[string]interface{}) ([]*contracts.ShowResponse, error)
+	GetUserSubmissionsFn func(uint, int, int) ([]contracts.ShowResponse, int, error)
+	UpdateShowFn func(uint, map[string]interface{}) (*contracts.ShowResponse, error)
 	UpdateShowWithRelationsFn func(uint, map[string]interface{}, []contracts.CreateShowVenue, []contracts.CreateShowArtist, bool) (*contracts.ShowResponse, []contracts.OrphanedArtist, error)
-	GetUpcomingShowsFn        func(string, string, int, bool, *contracts.UpcomingShowsFilter) ([]*contracts.ShowResponse, *string, error)
-	GetShowCitiesFn           func(string) ([]contracts.ShowCityResponse, error)
-	DeleteShowFn              func(uint) error
-	SearchShowsFn             func(string) ([]*contracts.ShowSearchResult, error)
+	GetUpcomingShowsFn func(string, string, int, bool, *contracts.UpcomingShowsFilter) ([]*contracts.ShowResponse, *string, error)
+	GetShowCitiesFn func(string) ([]contracts.ShowCityResponse, error)
+	DeleteShowFn func(uint) (error)
+	SearchShowsFn func(string) ([]*contracts.ShowSearchResult, error)
 }
 
 func (m *MockShowService) CreateShow(req *contracts.CreateShowRequest) (*contracts.ShowResponse, error) {
@@ -3056,7 +3056,7 @@ func (m *MockShowService) GetShowCities(timezone string) ([]contracts.ShowCityRe
 	}
 	return nil, nil
 }
-func (m *MockShowService) DeleteShow(showID uint) error {
+func (m *MockShowService) DeleteShow(showID uint) (error) {
 	if m.DeleteShowFn != nil {
 		return m.DeleteShowFn(showID)
 	}
@@ -3074,10 +3074,10 @@ func (m *MockShowService) SearchShows(query string) ([]*contracts.ShowSearchResu
 // ============================================================================
 
 type MockShowStateService struct {
-	UnpublishShowFn    func(uint, uint, bool) (*contracts.ShowResponse, error)
-	MakePrivateShowFn  func(uint, uint, bool) (*contracts.ShowResponse, error)
-	PublishShowFn      func(uint, uint, bool) (*contracts.ShowResponse, error)
-	SetShowSoldOutFn   func(uint, bool) (*contracts.ShowResponse, error)
+	UnpublishShowFn func(uint, uint, bool) (*contracts.ShowResponse, error)
+	MakePrivateShowFn func(uint, uint, bool) (*contracts.ShowResponse, error)
+	PublishShowFn func(uint, uint, bool) (*contracts.ShowResponse, error)
+	SetShowSoldOutFn func(uint, bool) (*contracts.ShowResponse, error)
 	SetShowCancelledFn func(uint, bool) (*contracts.ShowResponse, error)
 }
 
@@ -3117,37 +3117,37 @@ func (m *MockShowStateService) SetShowCancelled(showID uint, isCancelled bool) (
 // ============================================================================
 
 type MockTagService struct {
-	CreateTagFn                func(string, *string, *uint, string, bool, *uint) (*catalogm.Tag, error)
-	GetTagFn                   func(uint) (*catalogm.Tag, error)
-	GetTagBySlugFn             func(string) (*catalogm.Tag, error)
-	ListTagsFn                 func(string, string, *uint, string, int, int, string) ([]catalogm.Tag, int64, error)
-	UpdateTagFn                func(uint, *string, *string, *uint, *string, *bool) (*catalogm.Tag, error)
-	DeleteTagFn                func(uint) error
-	AddTagToEntityFn           func(uint, string, string, uint, uint, string) (*catalogm.EntityTag, error)
-	RemoveTagFromEntityFn      func(uint, string, uint) error
-	ListEntityTagsFn           func(string, uint, uint) ([]contracts.EntityTagResponse, error)
-	VoteOnTagFn                func(uint, string, uint, uint, bool) error
-	RemoveTagVoteFn            func(uint, string, uint, uint) error
-	CreateAliasFn              func(uint, string) (*catalogm.TagAlias, error)
-	DeleteAliasFn              func(uint) error
-	ListAliasesFn              func(uint) ([]catalogm.TagAlias, error)
-	ResolveAliasFn             func(string) (*catalogm.Tag, error)
-	ListAllAliasesFn           func(string, int, int) ([]contracts.TagAliasListing, int64, error)
-	BulkImportAliasesFn        func([]contracts.BulkAliasImportItem) (*contracts.BulkAliasImportResult, error)
-	MergeTagsFn                func(uint, uint, uint) (*contracts.MergeTagsResult, error)
-	PreviewMergeTagsFn         func(uint, uint) (*contracts.MergeTagsPreview, error)
-	GetTagAncestorsFn          func(uint) ([]*catalogm.Tag, error)
-	GetTagChildrenFn           func(uint) ([]*catalogm.Tag, error)
-	GetGenreHierarchyFn        func() ([]*catalogm.Tag, error)
-	SetTagParentFn             func(uint, *uint, uint) error
-	GetTagEntitiesFn           func(uint, string, int, int) ([]contracts.TaggedEntityItem, int64, error)
-	GetTagDetailFn             func(uint) (*contracts.TagDetailResponse, error)
-	GetLowQualityTagQueueFn    func(int, int) (*contracts.LowQualityTagQueueResponse, error)
-	SnoozeLowQualityTagFn      func(uint, uint) error
+	CreateTagFn func(string, *string, *uint, string, bool, *uint) (*catalogm.Tag, error)
+	GetTagFn func(uint) (*catalogm.Tag, error)
+	GetTagBySlugFn func(string) (*catalogm.Tag, error)
+	ListTagsFn func(string, string, *uint, string, int, int, string) ([]catalogm.Tag, int64, error)
+	UpdateTagFn func(uint, *string, *string, *uint, *string, *bool) (*catalogm.Tag, error)
+	DeleteTagFn func(uint) (error)
+	AddTagToEntityFn func(uint, string, string, uint, uint, string) (*catalogm.EntityTag, error)
+	RemoveTagFromEntityFn func(uint, string, uint) (error)
+	ListEntityTagsFn func(string, uint, uint) ([]contracts.EntityTagResponse, error)
+	VoteOnTagFn func(uint, string, uint, uint, bool) (error)
+	RemoveTagVoteFn func(uint, string, uint, uint) (error)
+	CreateAliasFn func(uint, string) (*catalogm.TagAlias, error)
+	DeleteAliasFn func(uint) (error)
+	ListAliasesFn func(uint) ([]catalogm.TagAlias, error)
+	ResolveAliasFn func(string) (*catalogm.Tag, error)
+	ListAllAliasesFn func(string, int, int) ([]contracts.TagAliasListing, int64, error)
+	BulkImportAliasesFn func([]contracts.BulkAliasImportItem) (*contracts.BulkAliasImportResult, error)
+	MergeTagsFn func(uint, uint, uint) (*contracts.MergeTagsResult, error)
+	PreviewMergeTagsFn func(uint, uint) (*contracts.MergeTagsPreview, error)
+	GetTagAncestorsFn func(uint) ([]*catalogm.Tag, error)
+	GetTagChildrenFn func(uint) ([]*catalogm.Tag, error)
+	GetGenreHierarchyFn func() ([]*catalogm.Tag, error)
+	SetTagParentFn func(uint, *uint, uint) (error)
+	GetTagEntitiesFn func(uint, string, int, int) ([]contracts.TaggedEntityItem, int64, error)
+	GetTagDetailFn func(uint) (*contracts.TagDetailResponse, error)
+	GetLowQualityTagQueueFn func(int, int) (*contracts.LowQualityTagQueueResponse, error)
+	SnoozeLowQualityTagFn func(uint, uint) (error)
 	BulkActionLowQualityTagsFn func(string, []uint) (*contracts.BulkLowQualityTagActionResult, error)
-	SearchTagsFn               func(string, int, string) ([]contracts.TagSearchResult, error)
-	GetTrendingTagsFn          func(int, string) ([]catalogm.Tag, error)
-	PruneDownvotedTagsFn       func() (int64, error)
+	SearchTagsFn func(string, int, string) ([]contracts.TagSearchResult, error)
+	GetTrendingTagsFn func(int, string) ([]catalogm.Tag, error)
+	PruneDownvotedTagsFn func() (int64, error)
 }
 
 func (m *MockTagService) CreateTag(name string, description *string, parentID *uint, category string, isOfficial bool, userID *uint) (*catalogm.Tag, error) {
@@ -3180,7 +3180,7 @@ func (m *MockTagService) UpdateTag(tagID uint, name *string, description *string
 	}
 	return nil, nil
 }
-func (m *MockTagService) DeleteTag(tagID uint) error {
+func (m *MockTagService) DeleteTag(tagID uint) (error) {
 	if m.DeleteTagFn != nil {
 		return m.DeleteTagFn(tagID)
 	}
@@ -3192,7 +3192,7 @@ func (m *MockTagService) AddTagToEntity(tagID uint, tagName string, entityType s
 	}
 	return nil, nil
 }
-func (m *MockTagService) RemoveTagFromEntity(tagID uint, entityType string, entityID uint) error {
+func (m *MockTagService) RemoveTagFromEntity(tagID uint, entityType string, entityID uint) (error) {
 	if m.RemoveTagFromEntityFn != nil {
 		return m.RemoveTagFromEntityFn(tagID, entityType, entityID)
 	}
@@ -3204,13 +3204,13 @@ func (m *MockTagService) ListEntityTags(entityType string, entityID uint, userID
 	}
 	return nil, nil
 }
-func (m *MockTagService) VoteOnTag(tagID uint, entityType string, entityID uint, userID uint, isUpvote bool) error {
+func (m *MockTagService) VoteOnTag(tagID uint, entityType string, entityID uint, userID uint, isUpvote bool) (error) {
 	if m.VoteOnTagFn != nil {
 		return m.VoteOnTagFn(tagID, entityType, entityID, userID, isUpvote)
 	}
 	return nil
 }
-func (m *MockTagService) RemoveTagVote(tagID uint, entityType string, entityID uint, userID uint) error {
+func (m *MockTagService) RemoveTagVote(tagID uint, entityType string, entityID uint, userID uint) (error) {
 	if m.RemoveTagVoteFn != nil {
 		return m.RemoveTagVoteFn(tagID, entityType, entityID, userID)
 	}
@@ -3222,7 +3222,7 @@ func (m *MockTagService) CreateAlias(tagID uint, alias string) (*catalogm.TagAli
 	}
 	return nil, nil
 }
-func (m *MockTagService) DeleteAlias(aliasID uint) error {
+func (m *MockTagService) DeleteAlias(aliasID uint) (error) {
 	if m.DeleteAliasFn != nil {
 		return m.DeleteAliasFn(aliasID)
 	}
@@ -3282,7 +3282,7 @@ func (m *MockTagService) GetGenreHierarchy() ([]*catalogm.Tag, error) {
 	}
 	return nil, nil
 }
-func (m *MockTagService) SetTagParent(tagID uint, parentID *uint, actorUserID uint) error {
+func (m *MockTagService) SetTagParent(tagID uint, parentID *uint, actorUserID uint) (error) {
 	if m.SetTagParentFn != nil {
 		return m.SetTagParentFn(tagID, parentID, actorUserID)
 	}
@@ -3306,7 +3306,7 @@ func (m *MockTagService) GetLowQualityTagQueue(limit int, offset int) (*contract
 	}
 	return nil, nil
 }
-func (m *MockTagService) SnoozeLowQualityTag(tagID uint, actorUserID uint) error {
+func (m *MockTagService) SnoozeLowQualityTag(tagID uint, actorUserID uint) (error) {
 	if m.SnoozeLowQualityTagFn != nil {
 		return m.SnoozeLowQualityTagFn(tagID, actorUserID)
 	}
@@ -3342,45 +3342,45 @@ func (m *MockTagService) PruneDownvotedTags() (int64, error) {
 // ============================================================================
 
 type MockUserService struct {
-	ListUsersFn                       func(int, int, contracts.AdminUserFilters) ([]*contracts.AdminUserResponse, int64, error)
-	FindOrCreateUserFn                func(goth.User, string) (*authm.User, error)
-	FindOrCreateUserWithConsentFn     func(goth.User, string, *contracts.OAuthSignupConsent) (*authm.User, error)
-	AuthenticateUserWithPasswordFn    func(string, string) (*authm.User, error)
-	CreateUserWithPasswordFn          func(string, string, string, string) (*authm.User, error)
+	ListUsersFn func(int, int, contracts.AdminUserFilters) ([]*contracts.AdminUserResponse, int64, error)
+	FindOrCreateUserFn func(goth.User, string) (*authm.User, error)
+	FindOrCreateUserWithConsentFn func(goth.User, string, *contracts.OAuthSignupConsent) (*authm.User, error)
+	AuthenticateUserWithPasswordFn func(string, string) (*authm.User, error)
+	CreateUserWithPasswordFn func(string, string, string, string) (*authm.User, error)
 	CreateUserWithPasswordWithLegalFn func(string, string, string, string, contracts.LegalAcceptance) (*authm.User, error)
-	GetUserByIDFn                     func(uint) (*authm.User, error)
-	GetUserByEmailFn                  func(string) (*authm.User, error)
-	GetUserByUsernameFn               func(string) (*authm.User, error)
-	UpdateUserFn                      func(uint, map[string]any) (*authm.User, error)
-	HashPasswordFn                    func(string) (string, error)
-	VerifyPasswordFn                  func(string, string) error
-	IsAccountLockedFn                 func(*authm.User) bool
-	GetLockTimeRemainingFn            func(*authm.User) time.Duration
-	IncrementFailedAttemptsFn         func(uint) error
-	ResetFailedAttemptsFn             func(uint) error
-	UpdatePasswordFn                  func(uint, string, string) error
-	SetEmailVerifiedFn                func(uint, bool) error
-	GetDeletionSummaryFn              func(uint) (*contracts.DeletionSummary, error)
-	SoftDeleteAccountFn               func(uint, *string) error
-	CreateUserWithoutPasswordFn       func(string) (*authm.User, error)
-	ExportUserDataFn                  func(uint) (*contracts.UserDataExport, error)
-	ExportUserDataJSONFn              func(uint) ([]byte, error)
-	GetOAuthAccountsFn                func(uint) ([]authm.OAuthAccount, error)
-	GetUserByEmailIncludingDeletedFn  func(string) (*authm.User, error)
-	IsAccountRecoverableFn            func(*authm.User) bool
-	GetDaysUntilPermanentDeletionFn   func(*authm.User) int
-	RestoreAccountFn                  func(uint) error
-	GetExpiredDeletedAccountsFn       func() ([]authm.User, error)
-	PermanentlyDeleteUserFn           func(uint) error
-	CanUnlinkOAuthAccountFn           func(uint, string) (bool, string, error)
-	UnlinkOAuthAccountFn              func(uint, string) error
-	GetFavoriteCitiesFn               func(uint) ([]authm.FavoriteCity, error)
-	SetFavoriteCitiesFn               func(uint, []authm.FavoriteCity) error
-	SetShowRemindersFn                func(uint, bool) error
-	SetDefaultReplyPermissionFn       func(uint, string) error
-	SetNotifyOnCommentSubscriptionFn  func(uint, bool) error
-	SetNotifyOnMentionFn              func(uint, bool) error
-	SetNotifyOnCollectionDigestFn     func(uint, bool) error
+	GetUserByIDFn func(uint) (*authm.User, error)
+	GetUserByEmailFn func(string) (*authm.User, error)
+	GetUserByUsernameFn func(string) (*authm.User, error)
+	UpdateUserFn func(uint, map[string]any) (*authm.User, error)
+	HashPasswordFn func(string) (string, error)
+	VerifyPasswordFn func(string, string) (error)
+	IsAccountLockedFn func(*authm.User) (bool)
+	GetLockTimeRemainingFn func(*authm.User) (time.Duration)
+	IncrementFailedAttemptsFn func(uint) (error)
+	ResetFailedAttemptsFn func(uint) (error)
+	UpdatePasswordFn func(uint, string, string) (error)
+	SetEmailVerifiedFn func(uint, bool) (error)
+	GetDeletionSummaryFn func(uint) (*contracts.DeletionSummary, error)
+	SoftDeleteAccountFn func(uint, *string) (error)
+	CreateUserWithoutPasswordFn func(string) (*authm.User, error)
+	ExportUserDataFn func(uint) (*contracts.UserDataExport, error)
+	ExportUserDataJSONFn func(uint) ([]byte, error)
+	GetOAuthAccountsFn func(uint) ([]authm.OAuthAccount, error)
+	GetUserByEmailIncludingDeletedFn func(string) (*authm.User, error)
+	IsAccountRecoverableFn func(*authm.User) (bool)
+	GetDaysUntilPermanentDeletionFn func(*authm.User) (int)
+	RestoreAccountFn func(uint) (error)
+	GetExpiredDeletedAccountsFn func() ([]authm.User, error)
+	PermanentlyDeleteUserFn func(uint) (error)
+	CanUnlinkOAuthAccountFn func(uint, string) (bool, string, error)
+	UnlinkOAuthAccountFn func(uint, string) (error)
+	GetFavoriteCitiesFn func(uint) ([]authm.FavoriteCity, error)
+	SetFavoriteCitiesFn func(uint, []authm.FavoriteCity) (error)
+	SetShowRemindersFn func(uint, bool) (error)
+	SetDefaultReplyPermissionFn func(uint, string) (error)
+	SetNotifyOnCommentSubscriptionFn func(uint, bool) (error)
+	SetNotifyOnMentionFn func(uint, bool) (error)
+	SetNotifyOnCollectionDigestFn func(uint, bool) (error)
 }
 
 func (m *MockUserService) ListUsers(limit int, offset int, filters contracts.AdminUserFilters) ([]*contracts.AdminUserResponse, int64, error) {
@@ -3449,43 +3449,43 @@ func (m *MockUserService) HashPassword(password string) (string, error) {
 	}
 	return "", nil
 }
-func (m *MockUserService) VerifyPassword(hashedPassword string, password string) error {
+func (m *MockUserService) VerifyPassword(hashedPassword string, password string) (error) {
 	if m.VerifyPasswordFn != nil {
 		return m.VerifyPasswordFn(hashedPassword, password)
 	}
 	return nil
 }
-func (m *MockUserService) IsAccountLocked(user *authm.User) bool {
+func (m *MockUserService) IsAccountLocked(user *authm.User) (bool) {
 	if m.IsAccountLockedFn != nil {
 		return m.IsAccountLockedFn(user)
 	}
 	return false
 }
-func (m *MockUserService) GetLockTimeRemaining(user *authm.User) time.Duration {
+func (m *MockUserService) GetLockTimeRemaining(user *authm.User) (time.Duration) {
 	if m.GetLockTimeRemainingFn != nil {
 		return m.GetLockTimeRemainingFn(user)
 	}
 	return 0
 }
-func (m *MockUserService) IncrementFailedAttempts(userID uint) error {
+func (m *MockUserService) IncrementFailedAttempts(userID uint) (error) {
 	if m.IncrementFailedAttemptsFn != nil {
 		return m.IncrementFailedAttemptsFn(userID)
 	}
 	return nil
 }
-func (m *MockUserService) ResetFailedAttempts(userID uint) error {
+func (m *MockUserService) ResetFailedAttempts(userID uint) (error) {
 	if m.ResetFailedAttemptsFn != nil {
 		return m.ResetFailedAttemptsFn(userID)
 	}
 	return nil
 }
-func (m *MockUserService) UpdatePassword(userID uint, currentPassword string, newPassword string) error {
+func (m *MockUserService) UpdatePassword(userID uint, currentPassword string, newPassword string) (error) {
 	if m.UpdatePasswordFn != nil {
 		return m.UpdatePasswordFn(userID, currentPassword, newPassword)
 	}
 	return nil
 }
-func (m *MockUserService) SetEmailVerified(userID uint, verified bool) error {
+func (m *MockUserService) SetEmailVerified(userID uint, verified bool) (error) {
 	if m.SetEmailVerifiedFn != nil {
 		return m.SetEmailVerifiedFn(userID, verified)
 	}
@@ -3497,7 +3497,7 @@ func (m *MockUserService) GetDeletionSummary(userID uint) (*contracts.DeletionSu
 	}
 	return nil, nil
 }
-func (m *MockUserService) SoftDeleteAccount(userID uint, reason *string) error {
+func (m *MockUserService) SoftDeleteAccount(userID uint, reason *string) (error) {
 	if m.SoftDeleteAccountFn != nil {
 		return m.SoftDeleteAccountFn(userID, reason)
 	}
@@ -3533,19 +3533,19 @@ func (m *MockUserService) GetUserByEmailIncludingDeleted(email string) (*authm.U
 	}
 	return nil, nil
 }
-func (m *MockUserService) IsAccountRecoverable(user *authm.User) bool {
+func (m *MockUserService) IsAccountRecoverable(user *authm.User) (bool) {
 	if m.IsAccountRecoverableFn != nil {
 		return m.IsAccountRecoverableFn(user)
 	}
 	return false
 }
-func (m *MockUserService) GetDaysUntilPermanentDeletion(user *authm.User) int {
+func (m *MockUserService) GetDaysUntilPermanentDeletion(user *authm.User) (int) {
 	if m.GetDaysUntilPermanentDeletionFn != nil {
 		return m.GetDaysUntilPermanentDeletionFn(user)
 	}
 	return 0
 }
-func (m *MockUserService) RestoreAccount(userID uint) error {
+func (m *MockUserService) RestoreAccount(userID uint) (error) {
 	if m.RestoreAccountFn != nil {
 		return m.RestoreAccountFn(userID)
 	}
@@ -3557,7 +3557,7 @@ func (m *MockUserService) GetExpiredDeletedAccounts() ([]authm.User, error) {
 	}
 	return nil, nil
 }
-func (m *MockUserService) PermanentlyDeleteUser(userID uint) error {
+func (m *MockUserService) PermanentlyDeleteUser(userID uint) (error) {
 	if m.PermanentlyDeleteUserFn != nil {
 		return m.PermanentlyDeleteUserFn(userID)
 	}
@@ -3569,7 +3569,7 @@ func (m *MockUserService) CanUnlinkOAuthAccount(userID uint, provider string) (b
 	}
 	return false, "", nil
 }
-func (m *MockUserService) UnlinkOAuthAccount(userID uint, provider string) error {
+func (m *MockUserService) UnlinkOAuthAccount(userID uint, provider string) (error) {
 	if m.UnlinkOAuthAccountFn != nil {
 		return m.UnlinkOAuthAccountFn(userID, provider)
 	}
@@ -3581,37 +3581,37 @@ func (m *MockUserService) GetFavoriteCities(userID uint) ([]authm.FavoriteCity, 
 	}
 	return []authm.FavoriteCity{}, nil
 }
-func (m *MockUserService) SetFavoriteCities(userID uint, cities []authm.FavoriteCity) error {
+func (m *MockUserService) SetFavoriteCities(userID uint, cities []authm.FavoriteCity) (error) {
 	if m.SetFavoriteCitiesFn != nil {
 		return m.SetFavoriteCitiesFn(userID, cities)
 	}
 	return nil
 }
-func (m *MockUserService) SetShowReminders(userID uint, enabled bool) error {
+func (m *MockUserService) SetShowReminders(userID uint, enabled bool) (error) {
 	if m.SetShowRemindersFn != nil {
 		return m.SetShowRemindersFn(userID, enabled)
 	}
 	return nil
 }
-func (m *MockUserService) SetDefaultReplyPermission(userID uint, permission string) error {
+func (m *MockUserService) SetDefaultReplyPermission(userID uint, permission string) (error) {
 	if m.SetDefaultReplyPermissionFn != nil {
 		return m.SetDefaultReplyPermissionFn(userID, permission)
 	}
 	return nil
 }
-func (m *MockUserService) SetNotifyOnCommentSubscription(userID uint, enabled bool) error {
+func (m *MockUserService) SetNotifyOnCommentSubscription(userID uint, enabled bool) (error) {
 	if m.SetNotifyOnCommentSubscriptionFn != nil {
 		return m.SetNotifyOnCommentSubscriptionFn(userID, enabled)
 	}
 	return nil
 }
-func (m *MockUserService) SetNotifyOnMention(userID uint, enabled bool) error {
+func (m *MockUserService) SetNotifyOnMention(userID uint, enabled bool) (error) {
 	if m.SetNotifyOnMentionFn != nil {
 		return m.SetNotifyOnMentionFn(userID, enabled)
 	}
 	return nil
 }
-func (m *MockUserService) SetNotifyOnCollectionDigest(userID uint, enabled bool) error {
+func (m *MockUserService) SetNotifyOnCollectionDigest(userID uint, enabled bool) (error) {
 	if m.SetNotifyOnCollectionDigestFn != nil {
 		return m.SetNotifyOnCollectionDigestFn(userID, enabled)
 	}
@@ -3623,23 +3623,23 @@ func (m *MockUserService) SetNotifyOnCollectionDigest(userID uint, enabled bool)
 // ============================================================================
 
 type MockVenueService struct {
-	CreateVenueFn              func(*contracts.CreateVenueRequest, bool) (*contracts.VenueDetailResponse, error)
-	GetVenueFn                 func(uint) (*contracts.VenueDetailResponse, error)
-	GetVenueBySlugFn           func(string) (*contracts.VenueDetailResponse, error)
-	GetVenuesFn                func(map[string]interface{}) ([]*contracts.VenueDetailResponse, error)
-	UpdateVenueFn              func(uint, map[string]interface{}) (*contracts.VenueDetailResponse, error)
-	DeleteVenueFn              func(uint) error
-	SearchVenuesFn             func(string) ([]*contracts.VenueDetailResponse, error)
-	FindOrCreateVenueFn        func(string, string, string, *string, *string, *gorm.DB, bool) (*catalogm.Venue, bool, error)
-	VerifyVenueFn              func(uint) (*contracts.VenueDetailResponse, error)
-	GetVenuesWithShowCountsFn  func(contracts.VenueListFilters, int, int) ([]*contracts.VenueWithShowCountResponse, int64, error)
+	CreateVenueFn func(*contracts.CreateVenueRequest, bool) (*contracts.VenueDetailResponse, error)
+	GetVenueFn func(uint) (*contracts.VenueDetailResponse, error)
+	GetVenueBySlugFn func(string) (*contracts.VenueDetailResponse, error)
+	GetVenuesFn func(map[string]interface{}) ([]*contracts.VenueDetailResponse, error)
+	UpdateVenueFn func(uint, map[string]interface{}) (*contracts.VenueDetailResponse, error)
+	DeleteVenueFn func(uint) (error)
+	SearchVenuesFn func(string) ([]*contracts.VenueDetailResponse, error)
+	FindOrCreateVenueFn func(string, string, string, *string, *string, *gorm.DB, bool) (*catalogm.Venue, bool, error)
+	VerifyVenueFn func(uint) (*contracts.VenueDetailResponse, error)
+	GetVenuesWithShowCountsFn func(contracts.VenueListFilters, int, int) ([]*contracts.VenueWithShowCountResponse, int64, error)
 	GetUpcomingShowsForVenueFn func(uint, string, int) ([]*contracts.VenueShowResponse, int64, error)
-	GetShowsForVenueFn         func(uint, string, int, string) ([]*contracts.VenueShowResponse, int64, error)
-	GetVenueCitiesFn           func() ([]*contracts.VenueCityResponse, error)
-	GetVenueModelFn            func(uint) (*catalogm.Venue, error)
-	GetUnverifiedVenuesFn      func(int, int) ([]*contracts.UnverifiedVenueResponse, int64, error)
-	GetVenueGenreProfileFn     func(uint) ([]contracts.GenreCount, error)
-	GetVenueBillNetworkFn      func(uint, string, *int) (*contracts.VenueBillNetworkResponse, error)
+	GetShowsForVenueFn func(uint, string, int, string) ([]*contracts.VenueShowResponse, int64, error)
+	GetVenueCitiesFn func() ([]*contracts.VenueCityResponse, error)
+	GetVenueModelFn func(uint) (*catalogm.Venue, error)
+	GetUnverifiedVenuesFn func(int, int) ([]*contracts.UnverifiedVenueResponse, int64, error)
+	GetVenueGenreProfileFn func(uint) ([]contracts.GenreCount, error)
+	GetVenueBillNetworkFn func(uint, string, *int) (*contracts.VenueBillNetworkResponse, error)
 }
 
 func (m *MockVenueService) CreateVenue(req *contracts.CreateVenueRequest, isAdmin bool) (*contracts.VenueDetailResponse, error) {
@@ -3672,7 +3672,7 @@ func (m *MockVenueService) UpdateVenue(venueID uint, updates map[string]interfac
 	}
 	return nil, nil
 }
-func (m *MockVenueService) DeleteVenue(venueID uint) error {
+func (m *MockVenueService) DeleteVenue(venueID uint) (error) {
 	if m.DeleteVenueFn != nil {
 		return m.DeleteVenueFn(venueID)
 	}
@@ -3750,17 +3750,17 @@ func (m *MockVenueService) GetVenueBillNetwork(venueID uint, window string, year
 // ============================================================================
 
 type MockVenueSourceConfigService struct {
-	GetByVenueIDFn          func(uint) (*adminm.VenueSourceConfig, error)
-	CreateOrUpdateFn        func(*adminm.VenueSourceConfig) (*adminm.VenueSourceConfig, error)
-	UpdateAfterRunFn        func(uint, *string, *string, int) error
-	IncrementFailuresFn     func(uint) error
-	RecordRunFn             func(*adminm.VenueExtractionRun) error
-	GetRecentRunsFn         func(uint, int) ([]adminm.VenueExtractionRun, error)
-	GetAllRecentRunsFn      func(int, int) ([]contracts.ImportHistoryEntry, int64, error)
-	ListConfiguredFn        func() ([]adminm.VenueSourceConfig, error)
-	GetRejectionStatsFn     func(uint) (*contracts.VenueRejectionStats, error)
-	UpdateExtractionNotesFn func(uint, *string) error
-	ResetRenderMethodFn     func(uint) error
+	GetByVenueIDFn func(uint) (*adminm.VenueSourceConfig, error)
+	CreateOrUpdateFn func(*adminm.VenueSourceConfig) (*adminm.VenueSourceConfig, error)
+	UpdateAfterRunFn func(uint, *string, *string, int) (error)
+	IncrementFailuresFn func(uint) (error)
+	RecordRunFn func(*adminm.VenueExtractionRun) (error)
+	GetRecentRunsFn func(uint, int) ([]adminm.VenueExtractionRun, error)
+	GetAllRecentRunsFn func(int, int) ([]contracts.ImportHistoryEntry, int64, error)
+	ListConfiguredFn func() ([]adminm.VenueSourceConfig, error)
+	GetRejectionStatsFn func(uint) (*contracts.VenueRejectionStats, error)
+	UpdateExtractionNotesFn func(uint, *string) (error)
+	ResetRenderMethodFn func(uint) (error)
 }
 
 func (m *MockVenueSourceConfigService) GetByVenueID(venueID uint) (*adminm.VenueSourceConfig, error) {
@@ -3775,19 +3775,19 @@ func (m *MockVenueSourceConfigService) CreateOrUpdate(config *adminm.VenueSource
 	}
 	return config, nil
 }
-func (m *MockVenueSourceConfigService) UpdateAfterRun(venueID uint, contentHash *string, etag *string, eventsExtracted int) error {
+func (m *MockVenueSourceConfigService) UpdateAfterRun(venueID uint, contentHash *string, etag *string, eventsExtracted int) (error) {
 	if m.UpdateAfterRunFn != nil {
 		return m.UpdateAfterRunFn(venueID, contentHash, etag, eventsExtracted)
 	}
 	return nil
 }
-func (m *MockVenueSourceConfigService) IncrementFailures(venueID uint) error {
+func (m *MockVenueSourceConfigService) IncrementFailures(venueID uint) (error) {
 	if m.IncrementFailuresFn != nil {
 		return m.IncrementFailuresFn(venueID)
 	}
 	return nil
 }
-func (m *MockVenueSourceConfigService) RecordRun(run *adminm.VenueExtractionRun) error {
+func (m *MockVenueSourceConfigService) RecordRun(run *adminm.VenueExtractionRun) (error) {
 	if m.RecordRunFn != nil {
 		return m.RecordRunFn(run)
 	}
@@ -3817,13 +3817,13 @@ func (m *MockVenueSourceConfigService) GetRejectionStats(venueID uint) (*contrac
 	}
 	return &contracts.VenueRejectionStats{RejectionBreakdown: make(map[string]int64)}, nil
 }
-func (m *MockVenueSourceConfigService) UpdateExtractionNotes(venueID uint, notes *string) error {
+func (m *MockVenueSourceConfigService) UpdateExtractionNotes(venueID uint, notes *string) (error) {
 	if m.UpdateExtractionNotesFn != nil {
 		return m.UpdateExtractionNotesFn(venueID, notes)
 	}
 	return nil
 }
-func (m *MockVenueSourceConfigService) ResetRenderMethod(venueID uint) error {
+func (m *MockVenueSourceConfigService) ResetRenderMethod(venueID uint) (error) {
 	if m.ResetRenderMethodFn != nil {
 		return m.ResetRenderMethodFn(venueID)
 	}
@@ -3835,23 +3835,23 @@ func (m *MockVenueSourceConfigService) ResetRenderMethod(venueID uint) error {
 // ============================================================================
 
 type MockWebAuthnService struct {
-	BeginRegistrationFn                 func(*authm.User) (*protocol.CredentialCreation, *webauthn.SessionData, error)
-	FinishRegistrationFn                func(*authm.User, *webauthn.SessionData, *protocol.ParsedCredentialCreationData, string) (*authm.WebAuthnCredential, error)
-	BeginLoginFn                        func(*authm.User) (*protocol.CredentialAssertion, *webauthn.SessionData, error)
-	BeginDiscoverableLoginFn            func() (*protocol.CredentialAssertion, *webauthn.SessionData, error)
-	FinishLoginFn                       func(*authm.User, *webauthn.SessionData, *protocol.ParsedCredentialAssertionData) (*authm.WebAuthnCredential, error)
-	FinishDiscoverableLoginFn           func(*webauthn.SessionData, *protocol.ParsedCredentialAssertionData) (*authm.User, *authm.WebAuthnCredential, error)
-	GetUserCredentialsFn                func(uint) ([]authm.WebAuthnCredential, error)
-	DeleteCredentialFn                  func(uint, uint) error
-	UpdateCredentialNameFn              func(uint, uint, string) error
-	StoreChallengeFn                    func(uint, *webauthn.SessionData, string) (string, error)
-	GetChallengeFn                      func(string, string) (*webauthn.SessionData, uint, error)
-	DeleteChallengeFn                   func(string) error
-	CleanupExpiredChallengesFn          func() error
-	BeginRegistrationForEmailFn         func(string) (*protocol.CredentialCreation, *webauthn.SessionData, error)
-	StoreChallengeWithEmailFn           func(string, *webauthn.SessionData, string) (string, error)
-	GetChallengeWithEmailFn             func(string, string) (*webauthn.SessionData, string, error)
-	FinishSignupRegistrationFn          func(string, *webauthn.SessionData, *protocol.ParsedCredentialCreationData, string) (*authm.User, error)
+	BeginRegistrationFn func(*authm.User) (*protocol.CredentialCreation, *webauthn.SessionData, error)
+	FinishRegistrationFn func(*authm.User, *webauthn.SessionData, *protocol.ParsedCredentialCreationData, string) (*authm.WebAuthnCredential, error)
+	BeginLoginFn func(*authm.User) (*protocol.CredentialAssertion, *webauthn.SessionData, error)
+	BeginDiscoverableLoginFn func() (*protocol.CredentialAssertion, *webauthn.SessionData, error)
+	FinishLoginFn func(*authm.User, *webauthn.SessionData, *protocol.ParsedCredentialAssertionData) (*authm.WebAuthnCredential, error)
+	FinishDiscoverableLoginFn func(*webauthn.SessionData, *protocol.ParsedCredentialAssertionData) (*authm.User, *authm.WebAuthnCredential, error)
+	GetUserCredentialsFn func(uint) ([]authm.WebAuthnCredential, error)
+	DeleteCredentialFn func(uint, uint) (error)
+	UpdateCredentialNameFn func(uint, uint, string) (error)
+	StoreChallengeFn func(uint, *webauthn.SessionData, string) (string, error)
+	GetChallengeFn func(string, string) (*webauthn.SessionData, uint, error)
+	DeleteChallengeFn func(string) (error)
+	CleanupExpiredChallengesFn func() (error)
+	BeginRegistrationForEmailFn func(string) (*protocol.CredentialCreation, *webauthn.SessionData, error)
+	StoreChallengeWithEmailFn func(string, *webauthn.SessionData, string) (string, error)
+	GetChallengeWithEmailFn func(string, string) (*webauthn.SessionData, string, error)
+	FinishSignupRegistrationFn func(string, *webauthn.SessionData, *protocol.ParsedCredentialCreationData, string) (*authm.User, error)
 	FinishSignupRegistrationWithLegalFn func(string, *webauthn.SessionData, *protocol.ParsedCredentialCreationData, string, contracts.LegalAcceptance) (*authm.User, error)
 }
 
@@ -3897,13 +3897,13 @@ func (m *MockWebAuthnService) GetUserCredentials(userID uint) ([]authm.WebAuthnC
 	}
 	return nil, nil
 }
-func (m *MockWebAuthnService) DeleteCredential(userID uint, credentialID uint) error {
+func (m *MockWebAuthnService) DeleteCredential(userID uint, credentialID uint) (error) {
 	if m.DeleteCredentialFn != nil {
 		return m.DeleteCredentialFn(userID, credentialID)
 	}
 	return nil
 }
-func (m *MockWebAuthnService) UpdateCredentialName(userID uint, credentialID uint, displayName string) error {
+func (m *MockWebAuthnService) UpdateCredentialName(userID uint, credentialID uint, displayName string) (error) {
 	if m.UpdateCredentialNameFn != nil {
 		return m.UpdateCredentialNameFn(userID, credentialID, displayName)
 	}
@@ -3921,13 +3921,13 @@ func (m *MockWebAuthnService) GetChallenge(challengeID string, operation string)
 	}
 	return nil, 0, nil
 }
-func (m *MockWebAuthnService) DeleteChallenge(challengeID string) error {
+func (m *MockWebAuthnService) DeleteChallenge(challengeID string) (error) {
 	if m.DeleteChallengeFn != nil {
 		return m.DeleteChallengeFn(challengeID)
 	}
 	return nil
 }
-func (m *MockWebAuthnService) CleanupExpiredChallenges() error {
+func (m *MockWebAuthnService) CleanupExpiredChallenges() (error) {
 	if m.CleanupExpiredChallengesFn != nil {
 		return m.CleanupExpiredChallengesFn()
 	}

--- a/backend/internal/services/community/collection.go
+++ b/backend/internal/services/community/collection.go
@@ -1690,9 +1690,10 @@ func (s *CollectionService) GetEntityCollections(entityType string, entityID uin
 	entityTypeCounts := s.batchEntityTypeCounts(collectionIDs)
 	creatorNames := s.batchResolveUserNames(creatorIDs)
 	creatorUsernames := s.batchResolveUserUsernames(creatorIDs)
-	// PSY-352: like aggregate; viewer ID isn't threaded through this call,
-	// so UserLikesThis is left false here (clients that need it should
-	// use the detail endpoint).
+	// PSY-352: like aggregate. UserLikesThis is intentionally left false
+	// on this surface — the entity-backlinks card doesn't render a like
+	// state, so we skip the per-viewer batchCheckUserLikes round-trip.
+	// Clients that need it should use the detail endpoint.
 	likeCounts := s.batchCountLikes(collectionIDs)
 	// PSY-354: tag chips on entity-collection cards.
 	tagsByCollection := s.batchListCollectionTagSummaries(collectionIDs)

--- a/backend/internal/services/community/collection.go
+++ b/backend/internal/services/community/collection.go
@@ -1629,8 +1629,13 @@ func (s *CollectionService) GetUserCollectionsContainingEntity(userID uint, enti
 	return ids, nil
 }
 
-// GetEntityCollections returns public collections that contain the given entity
-func (s *CollectionService) GetEntityCollections(entityType string, entityID uint, limit int) ([]*contracts.CollectionListResponse, error) {
+// GetEntityCollections returns collections that contain the given entity.
+// Privacy filter: public collections are visible to everyone; private
+// collections are surfaced only when the viewer is the creator (the owner
+// already has full visibility into their own private content). Pass
+// viewerID == 0 for anonymous callers — only public collections will
+// match. PSY-583.
+func (s *CollectionService) GetEntityCollections(entityType string, entityID uint, viewerID uint, limit int) ([]*contracts.CollectionListResponse, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
@@ -1639,12 +1644,20 @@ func (s *CollectionService) GetEntityCollections(entityType string, entityID uin
 		limit = 10
 	}
 
-	// Find collection IDs that contain this entity (public collections only)
+	// Find collection IDs that contain this entity. Public collections are
+	// visible to everyone; the viewer's own private collections are also
+	// included when viewerID > 0.
+	visibility := s.db.Where("collections.is_public = ?", true)
+	if viewerID > 0 {
+		visibility = visibility.Or("collections.creator_id = ?", viewerID)
+	}
+
 	var collectionIDs []uint
 	err := s.db.Model(&communitym.CollectionItem{}).
 		Select("DISTINCT collection_items.collection_id").
 		Joins("JOIN collections ON collections.id = collection_items.collection_id").
-		Where("collection_items.entity_type = ? AND collection_items.entity_id = ? AND collections.is_public = ?", entityType, entityID, true).
+		Where("collection_items.entity_type = ? AND collection_items.entity_id = ?", entityType, entityID).
+		Where(visibility).
 		Limit(limit).
 		Pluck("collection_items.collection_id", &collectionIDs).Error
 	if err != nil {

--- a/backend/internal/services/community/collection_test.go
+++ b/backend/internal/services/community/collection_test.go
@@ -3167,3 +3167,141 @@ func (suite *CollectionServiceIntegrationTestSuite) TestGetBySlug_ImageURL_NilWh
 	suite.Nil(detail.Items[0].ImageURL,
 		"whitespace-only image URLs should normalize to nil so the frontend renders the typed-icon fallback")
 }
+
+// =============================================================================
+// Group 16 (PSY-583): GetEntityCollections privacy filter
+// =============================================================================
+//
+// The "In Collections" backlinks block is built from GetEntityCollections.
+// Public collections are visible to everyone. Private collections are
+// visible only to their creator — anonymous viewers and authenticated
+// non-owners must NOT see them in the entity backlinks.
+//
+// The fixture seeds one public + one private collection by the same
+// owner, both containing the same artist, and asserts what each viewer
+// class sees.
+
+// TestGetEntityCollections_AnonymousViewerSeesOnlyPublic verifies that
+// an unauthenticated caller (viewerID == 0) sees public collections but
+// NOT the owner's private collection containing the same entity.
+func (suite *CollectionServiceIntegrationTestSuite) TestGetEntityCollections_AnonymousViewerSeesOnlyPublic() {
+	owner := suite.createTestUser("BacklinkOwner")
+	artist := suite.createTestArtist(fmt.Sprintf("Backlink Anon %d", time.Now().UnixNano()))
+
+	pub := suite.createPublicCollection(owner, "Backlink Public")
+	_, err := suite.collectionService.AddItem(pub.Slug, owner.ID, &contracts.AddCollectionItemRequest{
+		EntityType: communitym.CollectionEntityArtist,
+		EntityID:   artist.ID,
+	})
+	suite.Require().NoError(err)
+
+	priv := suite.createBasicCollection(owner, "Backlink Private")
+	_, err = suite.collectionService.AddItem(priv.Slug, owner.ID, &contracts.AddCollectionItemRequest{
+		EntityType: communitym.CollectionEntityArtist,
+		EntityID:   artist.ID,
+	})
+	suite.Require().NoError(err)
+
+	resp, err := suite.collectionService.GetEntityCollections(
+		communitym.CollectionEntityArtist, artist.ID, 0, 10,
+	)
+	suite.Require().NoError(err)
+	suite.Require().Len(resp, 1, "anonymous viewer must see exactly the public collection")
+	suite.Equal(pub.ID, resp[0].ID)
+}
+
+// TestGetEntityCollections_NonOwnerSeesOnlyPublic verifies that an
+// authenticated viewer who is NOT the creator sees public collections
+// but not the creator's private collection.
+func (suite *CollectionServiceIntegrationTestSuite) TestGetEntityCollections_NonOwnerSeesOnlyPublic() {
+	owner := suite.createTestUser("BacklinkOwnerNonOwnerCase")
+	other := suite.createTestUser("BacklinkOtherViewer")
+	artist := suite.createTestArtist(fmt.Sprintf("Backlink NonOwner %d", time.Now().UnixNano()))
+
+	pub := suite.createPublicCollection(owner, "Backlink Public NonOwner Case")
+	_, err := suite.collectionService.AddItem(pub.Slug, owner.ID, &contracts.AddCollectionItemRequest{
+		EntityType: communitym.CollectionEntityArtist,
+		EntityID:   artist.ID,
+	})
+	suite.Require().NoError(err)
+
+	priv := suite.createBasicCollection(owner, "Backlink Private NonOwner Case")
+	_, err = suite.collectionService.AddItem(priv.Slug, owner.ID, &contracts.AddCollectionItemRequest{
+		EntityType: communitym.CollectionEntityArtist,
+		EntityID:   artist.ID,
+	})
+	suite.Require().NoError(err)
+
+	resp, err := suite.collectionService.GetEntityCollections(
+		communitym.CollectionEntityArtist, artist.ID, other.ID, 10,
+	)
+	suite.Require().NoError(err)
+	suite.Require().Len(resp, 1, "non-owner authenticated viewer must see only the public collection")
+	suite.Equal(pub.ID, resp[0].ID)
+}
+
+// TestGetEntityCollections_OwnerSeesPublicAndOwnPrivate verifies that
+// the creator sees their own private collections in the entity backlinks
+// — the bug PSY-583 fixes. Public collections continue to appear too.
+func (suite *CollectionServiceIntegrationTestSuite) TestGetEntityCollections_OwnerSeesPublicAndOwnPrivate() {
+	owner := suite.createTestUser("BacklinkOwnerCase")
+	artist := suite.createTestArtist(fmt.Sprintf("Backlink Owner %d", time.Now().UnixNano()))
+
+	pub := suite.createPublicCollection(owner, "Backlink Public Owner Case")
+	_, err := suite.collectionService.AddItem(pub.Slug, owner.ID, &contracts.AddCollectionItemRequest{
+		EntityType: communitym.CollectionEntityArtist,
+		EntityID:   artist.ID,
+	})
+	suite.Require().NoError(err)
+
+	priv := suite.createBasicCollection(owner, "Backlink Private Owner Case")
+	_, err = suite.collectionService.AddItem(priv.Slug, owner.ID, &contracts.AddCollectionItemRequest{
+		EntityType: communitym.CollectionEntityArtist,
+		EntityID:   artist.ID,
+	})
+	suite.Require().NoError(err)
+
+	resp, err := suite.collectionService.GetEntityCollections(
+		communitym.CollectionEntityArtist, artist.ID, owner.ID, 10,
+	)
+	suite.Require().NoError(err)
+	suite.Require().Len(resp, 2, "owner must see both their public and private collections containing the entity")
+
+	ids := map[uint]bool{resp[0].ID: true, resp[1].ID: true}
+	suite.True(ids[pub.ID], "owner result set must include the public collection")
+	suite.True(ids[priv.ID], "owner result set must include their own private collection (PSY-583)")
+}
+
+// TestGetEntityCollections_OtherUsersPrivateInvisible_ToOwner ensures
+// the privacy filter is scoped to the viewer's OWN private collections —
+// a viewer who happens to also own private collections does not gain
+// visibility into a different user's private collections.
+func (suite *CollectionServiceIntegrationTestSuite) TestGetEntityCollections_OtherUsersPrivateInvisible_ToOwner() {
+	ownerA := suite.createTestUser("BacklinkOwnerA")
+	ownerB := suite.createTestUser("BacklinkOwnerB")
+	artist := suite.createTestArtist(fmt.Sprintf("Backlink Cross %d", time.Now().UnixNano()))
+
+	// Owner A has a private collection containing the artist.
+	privA := suite.createBasicCollection(ownerA, "A Private")
+	_, err := suite.collectionService.AddItem(privA.Slug, ownerA.ID, &contracts.AddCollectionItemRequest{
+		EntityType: communitym.CollectionEntityArtist,
+		EntityID:   artist.ID,
+	})
+	suite.Require().NoError(err)
+
+	// Owner B has a private collection ALSO containing the artist.
+	privB := suite.createBasicCollection(ownerB, "B Private")
+	_, err = suite.collectionService.AddItem(privB.Slug, ownerB.ID, &contracts.AddCollectionItemRequest{
+		EntityType: communitym.CollectionEntityArtist,
+		EntityID:   artist.ID,
+	})
+	suite.Require().NoError(err)
+
+	// Owner A queries — should see only their own private, not B's.
+	resp, err := suite.collectionService.GetEntityCollections(
+		communitym.CollectionEntityArtist, artist.ID, ownerA.ID, 10,
+	)
+	suite.Require().NoError(err)
+	suite.Require().Len(resp, 1, "owner A must see only their own private collection, not owner B's")
+	suite.Equal(privA.ID, resp[0].ID)
+}

--- a/backend/internal/services/contracts/collection.go
+++ b/backend/internal/services/contracts/collection.go
@@ -404,7 +404,11 @@ type CollectionServiceInterface interface {
 	// the supplied entity. Backs the multi-select Add-to-Collection
 	// popover (PSY-359). Returns empty slice for userID == 0.
 	GetUserCollectionsContainingEntity(userID uint, entityType string, entityID uint) ([]uint, error)
-	GetEntityCollections(entityType string, entityID uint, limit int) ([]*CollectionListResponse, error)
+	// GetEntityCollections returns collections that contain the given
+	// entity. Public collections are returned to all viewers; the viewer's
+	// own private collections are included when viewerID > 0. Pass
+	// viewerID == 0 for anonymous callers. PSY-583.
+	GetEntityCollections(entityType string, entityID uint, viewerID uint, limit int) ([]*CollectionListResponse, error)
 	GetUserPublicCollections(userID uint, limit, offset int) ([]*CollectionListResponse, int64, error)
 	GetUserPublicCollectionsByUsername(username string, limit, offset int) ([]*CollectionListResponse, int64, error)
 	SetFeatured(slug string, featured bool) error


### PR DESCRIPTION
## Summary
- Extend `GetEntityCollections` privacy filter from `is_public = true` to `is_public = true OR creator_id = <viewer>` so a creator sees their own private collections in the entity backlinks block. Anonymous viewers and authenticated non-owners continue to see public collections only.
- Thread `viewerID` through the handler from optional auth (0 when anonymous), the `CollectionServiceInterface` signature, and regenerated mocks.
- No frontend change — per the ticket's open-question default, no "Private" badge is added.

## Test plan
- [x] `cd backend && go build ./...` — passed
- [x] `cd backend && go test ./internal/api/handlers/community/... ./internal/services/community/... -timeout 15m` — passed (handlers 20.9s, services 12.8s; includes the four new viewer-case tests)

## Manual repro
Backend integration tests in `backend/internal/services/community/collection_test.go` (Group 16) cover all three viewer cases against a Postgres testcontainer:

- `TestGetEntityCollections_AnonymousViewerSeesOnlyPublic` — viewerID=0 sees the public collection only.
- `TestGetEntityCollections_NonOwnerSeesOnlyPublic` — authenticated non-creator sees the public collection only.
- `TestGetEntityCollections_OwnerSeesPublicAndOwnPrivate` — the canonical PSY-583 verification: creator sees BOTH their public and their private collection containing the entity.
- `TestGetEntityCollections_OtherUsersPrivateInvisible_ToOwner` — cross-owner check: owner A's query does NOT leak owner B's private collection.

All four pass against the suite's Postgres 18 testcontainer.

## Simplify
One stale comment about the Like aggregator was rewritten — viewer ID is now threaded through, so the rationale shifts from "we can't" to "we don't need to on this surface". Comment-only, no logic change.

Closes PSY-583