### PR TITLE
PSY-621: unify reply-permission validation across handlers

### DIFF
--- a/backend/internal/api/handlers/auth/user_preferences.go
+++ b/backend/internal/api/handlers/auth/user_preferences.go
@@ -202,17 +202,26 @@ type SetDefaultReplyPermissionResponse struct {
 }
 
 // SetDefaultReplyPermissionHandler handles PATCH /auth/preferences/default-reply-permission.
+//
+// Validation contract is unified with PUT /comments/{id}/reply-permission
+// (PSY-621): missing/empty -> 400 "reply_permission is required";
+// unrecognized -> 400 with `shared.InvalidReplyPermissionMessage`. The
+// service-layer enum check stays as defence-in-depth and surfaces as 400
+// for the same reason.
 func (h *UserPreferencesHandler) SetDefaultReplyPermissionHandler(ctx context.Context, req *SetDefaultReplyPermissionRequest) (*SetDefaultReplyPermissionResponse, error) {
 	user := middleware.GetUserFromContext(ctx)
 	if user == nil {
 		return nil, huma.Error401Unauthorized("Authentication required")
 	}
 
-	perm := req.Body.Permission
+	// Two-step validation distinguishes "field absent / blank" from
+	// "field present with bad value" so the 400 detail isn't misleading.
+	perm := strings.TrimSpace(req.Body.Permission)
+	if perm == "" {
+		return nil, huma.Error400BadRequest("reply_permission is required")
+	}
 	if !engagementm.IsValidReplyPermission(perm) {
-		return nil, huma.Error422UnprocessableEntity(
-			fmt.Sprintf("invalid reply_permission: %q (want anyone, followers, or author_only)", perm),
-		)
+		return nil, huma.Error400BadRequest(shared.InvalidReplyPermissionMessage)
 	}
 
 	if err := h.userService.SetDefaultReplyPermission(user.ID, perm); err != nil {
@@ -221,7 +230,7 @@ func (h *UserPreferencesHandler) SetDefaultReplyPermissionHandler(ctx context.Co
 			"user_id", user.ID,
 		)
 		if strings.Contains(err.Error(), "invalid reply_permission") {
-			return nil, huma.Error422UnprocessableEntity(err.Error())
+			return nil, huma.Error400BadRequest(shared.InvalidReplyPermissionMessage)
 		}
 		return nil, huma.Error422UnprocessableEntity(
 			fmt.Sprintf("Failed to update default reply permission: %s", err.Error()),

--- a/backend/internal/api/handlers/auth/user_preferences_test.go
+++ b/backend/internal/api/handlers/auth/user_preferences_test.go
@@ -355,3 +355,87 @@ func TestUnsubscribeMentionHandler_Success(t *testing.T) {
 		t.Fatal("expected SetNotifyOnMention to be called")
 	}
 }
+
+// ──────────────────────────────────────────────
+// PSY-621: SetDefaultReplyPermissionHandler validation contract
+// ──────────────────────────────────────────────
+//
+// Mirrors the three-case shape used by PUT /comments/{id}/reply-permission
+// (PSY-592 in comment_test.go: _EmptyPermission / _InvalidEnum /
+// _AcceptsAllValidEnumValues). PSY-621 unifies the validation contract:
+// missing/empty -> 400 "reply_permission is required"; unrecognized ->
+// 400 with the canonical `shared.InvalidReplyPermissionMessage`. Previously
+// invalid-enum returned 422 with a different message.
+
+func TestSetDefaultReplyPermission_EmptyPermission(t *testing.T) {
+	mock := &testhelpers.MockUserService{
+		SetDefaultReplyPermissionFn: func(userID uint, permission string) error {
+			t.Fatalf("service must not be invoked for empty permission; got call with permission=%q", permission)
+			return nil
+		},
+	}
+	h := NewUserPreferencesHandler(mock, "secret")
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1})
+	req := &SetDefaultReplyPermissionRequest{}
+	req.Body.Permission = "   "
+	_, err := h.SetDefaultReplyPermissionHandler(ctx, req)
+	testhelpers.AssertHumaErrorWithDetail(t, err, 400, "reply_permission is required")
+}
+
+// TestSetDefaultReplyPermission_InvalidEnum: an unrecognized value must
+// be rejected with the explicit-list message, NOT
+// "reply_permission is required" (which implies the field was absent).
+// The service mock fails the test if invoked — the handler-level enum
+// check must short-circuit before the service is called.
+func TestSetDefaultReplyPermission_InvalidEnum(t *testing.T) {
+	mock := &testhelpers.MockUserService{
+		SetDefaultReplyPermissionFn: func(userID uint, permission string) error {
+			t.Fatalf("service must not be invoked for invalid enum value; got call with permission=%q", permission)
+			return nil
+		},
+	}
+	h := NewUserPreferencesHandler(mock, "secret")
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1})
+	req := &SetDefaultReplyPermissionRequest{}
+	req.Body.Permission = "garbage"
+	_, err := h.SetDefaultReplyPermissionHandler(ctx, req)
+	testhelpers.AssertHumaErrorWithDetail(t, err, 400, "permission must be one of: anyone, followers, author_only")
+}
+
+// TestSetDefaultReplyPermission_AcceptsAllValidEnumValues: all three
+// recognized enum values must clear the handler-level enum check and
+// reach the service layer. Complements the _InvalidEnum and
+// _EmptyPermission negative cases above.
+func TestSetDefaultReplyPermission_AcceptsAllValidEnumValues(t *testing.T) {
+	for _, perm := range []string{"anyone", "followers", "author_only"} {
+		t.Run(perm, func(t *testing.T) {
+			var called bool
+			mock := &testhelpers.MockUserService{
+				SetDefaultReplyPermissionFn: func(userID uint, permission string) error {
+					called = true
+					if permission != perm {
+						t.Errorf("expected permission=%q, got %q", perm, permission)
+					}
+					return nil
+				},
+			}
+			h := NewUserPreferencesHandler(mock, "secret")
+			ctx := testhelpers.CtxWithUser(&authm.User{ID: 1})
+			req := &SetDefaultReplyPermissionRequest{}
+			req.Body.Permission = perm
+			resp, err := h.SetDefaultReplyPermissionHandler(ctx, req)
+			if err != nil {
+				t.Fatalf("unexpected error for permission=%q: %v", perm, err)
+			}
+			if !called {
+				t.Fatalf("expected service called for permission=%q", perm)
+			}
+			if !resp.Body.Success {
+				t.Fatalf("expected success=true for permission=%q", perm)
+			}
+			if resp.Body.DefaultReplyPermission != perm {
+				t.Errorf("expected default_reply_permission=%q, got %q", perm, resp.Body.DefaultReplyPermission)
+			}
+		})
+	}
+}

--- a/backend/internal/api/handlers/engagement/comment.go
+++ b/backend/internal/api/handlers/engagement/comment.go
@@ -9,19 +9,13 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 
+	"psychic-homily-backend/internal/api/handlers/shared"
 	"psychic-homily-backend/internal/api/middleware"
 	"psychic-homily-backend/internal/logger"
 	authm "psychic-homily-backend/internal/models/auth"
 	engagementm "psychic-homily-backend/internal/models/engagement"
 	"psychic-homily-backend/internal/services/contracts"
 )
-
-// invalidReplyPermissionMessage is the canonical 400 response detail
-// when `permission` is present but unrecognized. Distinct from
-// "permission is required" (sent when the field is empty) so clients
-// can tell which failure they hit. Keep in lockstep with
-// `engagementm.IsValidReplyPermission`.
-const invalidReplyPermissionMessage = "permission must be one of: anyone, followers, author_only"
 
 // rateLimited429 wraps a 429 service-layer error with a `Retry-After` header
 // per RFC 7231 §7.1.3 so clients can populate countdown copy without parsing
@@ -528,13 +522,13 @@ func (h *CommentHandler) UpdateReplyPermissionHandler(ctx context.Context, req *
 		return nil, huma.Error400BadRequest("permission is required")
 	}
 	if !engagementm.IsValidReplyPermission(perm) {
-		return nil, huma.Error400BadRequest(invalidReplyPermissionMessage)
+		return nil, huma.Error400BadRequest(shared.InvalidReplyPermissionMessage)
 	}
 
 	comment, err := h.writer.UpdateReplyPermission(user.ID, uint(commentID), perm)
 	if err != nil {
 		if strings.Contains(err.Error(), "invalid reply_permission") {
-			return nil, huma.Error400BadRequest(invalidReplyPermissionMessage)
+			return nil, huma.Error400BadRequest(shared.InvalidReplyPermissionMessage)
 		}
 		if strings.Contains(err.Error(), "not found") {
 			return nil, huma.Error404NotFound("Comment not found")

--- a/backend/internal/api/handlers/shared/reply_permission.go
+++ b/backend/internal/api/handlers/shared/reply_permission.go
@@ -1,0 +1,17 @@
+package shared
+
+// InvalidReplyPermissionMessage is the canonical 400 response detail
+// when a reply-permission field is present but unrecognized. Distinct
+// from the "<field> is required" detail (sent when the field is empty
+// or missing) so clients can tell which failure they hit.
+//
+// Used by:
+//   - PUT /comments/{id}/reply-permission (per-comment override; PSY-296,
+//     sharper validation in PSY-592)
+//   - PATCH /auth/preferences/default-reply-permission (per-user default;
+//     PSY-296, unified to match the per-comment handler in PSY-621)
+//
+// Keep in lockstep with `engagementm.IsValidReplyPermission`. If new
+// enum values are added, update both this constant and the validator
+// together.
+const InvalidReplyPermissionMessage = "permission must be one of: anyone, followers, author_only"


### PR DESCRIPTION
## Summary
- Promotes the reply-permission canonical 400 message to `shared.InvalidReplyPermissionMessage` (new `backend/internal/api/handlers/shared/reply_permission.go`); both `engagement/comment.go` and `auth/user_preferences.go` reference it.
- `SetDefaultReplyPermissionHandler` (PATCH `/auth/preferences/default-reply-permission`) now returns 400 — not 422 — for invalid-enum, plus 400 `reply_permission is required` for missing/empty input. Generic non-enum service errors keep their existing 422 path.
- Aligns the per-user-default endpoint with the per-comment override endpoint (PSY-592 in PUT `/comments/{id}/reply-permission`) so the same `ReplyPermissionSelect` UI surface gets the same error contract on both paths.

Frontend mutation (`useSetDefaultReplyPermission`) does not special-case status codes — it shows a generic retry banner — so the 422 -> 400 shift is safe.

## Test plan
- [x] `cd backend && go build ./...` — passed
- [x] `cd backend && go test ./internal/api/handlers/...` — passed (all packages, including engagement / auth / shared)

## Manual repro
Backend ticket — integration tests are the manual repro. New tests in `backend/internal/api/handlers/auth/user_preferences_test.go`:
- `TestSetDefaultReplyPermission_EmptyPermission`: expected 400 with detail `"reply_permission is required"` — passed
- `TestSetDefaultReplyPermission_InvalidEnum`: expected 400 with detail `"permission must be one of: anyone, followers, author_only"` — passed
- `TestSetDefaultReplyPermission_AcceptsAllValidEnumValues`: expected 200 (success) for `{anyone, followers, author_only}` (subtests) — passed

Existing `TestUpdateReplyPermission_*` cases in `comment_test.go` re-run clean against the now-shared constant (no test changes needed; they assert on the literal string).

Stack mode: `--mode=none` (backend-only, no migration). `stack-up.sh` / `stack-down.sh` invoked successfully.

## Simplify
Reviewed for reuse / quality / efficiency. No changes needed — the diff reuses `engagementm.IsValidReplyPermission`, mirrors comment.go's two-step validation pattern exactly, and contains no stringly-typed leakage. Comments document non-obvious WHY (status disambiguation, lock-step constant requirement).

Closes PSY-621

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>