### PR TITLE
PSY-582: render full entity-type breakdown on collection cards

### DIFF
--- a/frontend/features/collections/components/CollectionCard.test.tsx
+++ b/frontend/features/collections/components/CollectionCard.test.tsx
@@ -259,6 +259,62 @@ describe('CollectionCard', () => {
     expect(screen.queryByText(/new$/)).not.toBeInTheDocument()
   })
 
+  // PSY-582: render the FULL entity-type breakdown so badge counts always
+  // sum to item_count. Previous behaviour silently sliced to the top 2
+  // entity types, producing math discrepancies on the card (e.g. "3 artists
+  // 1 festival" + "7 items" with no indication of the 3 missing types).
+  describe('entity-type breakdown (PSY-582)', () => {
+    it('renders a badge for every entity type, no truncation', () => {
+      const collection: Collection = {
+        ...baseCollection,
+        item_count: 7,
+        entity_type_counts: {
+          venue: 1,
+          artist: 3,
+          release: 1,
+          label: 1,
+          festival: 1,
+        },
+      }
+      render(<CollectionCard collection={collection} />)
+
+      expect(screen.getByText('3 artists')).toBeInTheDocument()
+      expect(screen.getByText('1 venue')).toBeInTheDocument()
+      expect(screen.getByText('1 release')).toBeInTheDocument()
+      expect(screen.getByText('1 label')).toBeInTheDocument()
+      expect(screen.getByText('1 festival')).toBeInTheDocument()
+    })
+
+    it('counts on the breakdown badges sum to item_count', () => {
+      const collection: Collection = {
+        ...baseCollection,
+        item_count: 7,
+        entity_type_counts: {
+          venue: 1,
+          artist: 3,
+          release: 1,
+          label: 1,
+          festival: 1,
+        },
+      }
+      const { container } = render(<CollectionCard collection={collection} />)
+
+      // Pull the leading integer off every breakdown badge and sum them.
+      // We match against the known label suffixes so other badges (Featured,
+      // Collaborative, "5 items", etc.) don't get caught.
+      const badges = Array.from(container.querySelectorAll('span,div'))
+        .map((el) => el.textContent ?? '')
+        .filter((t) =>
+          /^\d+\s+(artist|venue|show|release|label|festival)s?$/.test(t.trim())
+        )
+      const sum = badges.reduce((acc, t) => {
+        const match = t.trim().match(/^(\d+)/)
+        return acc + (match ? Number(match[1]) : 0)
+      }, 0)
+      expect(sum).toBe(7)
+    })
+  })
+
   // ──────────────────────────────────────────────
   // PSY-352: like toggle
   // ──────────────────────────────────────────────

--- a/frontend/features/collections/components/CollectionCard.test.tsx
+++ b/frontend/features/collections/components/CollectionCard.test.tsx
@@ -264,19 +264,20 @@ describe('CollectionCard', () => {
   // entity types, producing math discrepancies on the card (e.g. "3 artists
   // 1 festival" + "7 items" with no indication of the 3 missing types).
   describe('entity-type breakdown (PSY-582)', () => {
+    const fiveTypeCollection: Collection = {
+      ...baseCollection,
+      item_count: 7,
+      entity_type_counts: {
+        venue: 1,
+        artist: 3,
+        release: 1,
+        label: 1,
+        festival: 1,
+      },
+    }
+
     it('renders a badge for every entity type, no truncation', () => {
-      const collection: Collection = {
-        ...baseCollection,
-        item_count: 7,
-        entity_type_counts: {
-          venue: 1,
-          artist: 3,
-          release: 1,
-          label: 1,
-          festival: 1,
-        },
-      }
-      render(<CollectionCard collection={collection} />)
+      render(<CollectionCard collection={fiveTypeCollection} />)
 
       expect(screen.getByText('3 artists')).toBeInTheDocument()
       expect(screen.getByText('1 venue')).toBeInTheDocument()
@@ -286,31 +287,19 @@ describe('CollectionCard', () => {
     })
 
     it('counts on the breakdown badges sum to item_count', () => {
-      const collection: Collection = {
-        ...baseCollection,
-        item_count: 7,
-        entity_type_counts: {
-          venue: 1,
-          artist: 3,
-          release: 1,
-          label: 1,
-          festival: 1,
-        },
-      }
-      const { container } = render(<CollectionCard collection={collection} />)
+      const { container } = render(
+        <CollectionCard collection={fiveTypeCollection} />
+      )
 
       // Pull the leading integer off every breakdown badge and sum them.
       // We match against the known label suffixes so other badges (Featured,
       // Collaborative, "5 items", etc.) don't get caught.
-      const badges = Array.from(container.querySelectorAll('span,div'))
-        .map((el) => el.textContent ?? '')
+      const sum = Array.from(container.querySelectorAll('span,div'))
+        .map((el) => (el.textContent ?? '').trim())
         .filter((t) =>
-          /^\d+\s+(artist|venue|show|release|label|festival)s?$/.test(t.trim())
+          /^\d+\s+(artist|venue|show|release|label|festival)s?$/.test(t)
         )
-      const sum = badges.reduce((acc, t) => {
-        const match = t.trim().match(/^(\d+)/)
-        return acc + (match ? Number(match[1]) : 0)
-      }, 0)
+        .reduce((acc, t) => acc + Number(t.match(/^(\d+)/)![1]), 0)
       expect(sum).toBe(7)
     })
   })

--- a/frontend/features/collections/components/CollectionCard.tsx
+++ b/frontend/features/collections/components/CollectionCard.tsx
@@ -100,15 +100,19 @@ export function CollectionCard({ collection }: CollectionCardProps) {
 
   const isLikePending = likeMutation.isPending || unlikeMutation.isPending
 
-  const topEntityTypes = Object.entries(collection.entity_type_counts ?? {})
+  // PSY-582: render the FULL entity-type breakdown so badge counts always
+  // sum to item_count. Slicing to top-N silently dropped types (the original
+  // truncation showed only 2) and produced cards where "3 artists 1 festival"
+  // didn't add up to the displayed "7 items". Most collections have ≤5
+  // entity types so the badges still wrap cleanly at narrow widths; matches
+  // the detail-page rendering. Keep the count-desc sort so the largest
+  // bucket leads.
+  const entityTypeBreakdown = Object.entries(collection.entity_type_counts ?? {})
     .sort((a, b) => b[1] - a[1])
-    .slice(0, 2)
 
-  // Get up to 4 entity type icons for the mosaic placeholder
-  const mosaicTypes = Object.entries(collection.entity_type_counts ?? {})
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, 4)
-    .map(([type]) => type)
+  // Get up to 4 entity type icons for the mosaic placeholder. The mosaic
+  // fallback is space-bounded (4 icons in a 2x2 grid), so this slice stays.
+  const mosaicTypes = entityTypeBreakdown.slice(0, 4).map(([type]) => type)
 
   return (
     <article className="rounded-lg border border-border/50 bg-card p-4 transition-shadow hover:shadow-sm">
@@ -192,7 +196,7 @@ export function CollectionCard({ collection }: CollectionCardProps) {
                 Collaborative
               </Badge>
             )}
-            {topEntityTypes.map(([type, count]) => (
+            {entityTypeBreakdown.map(([type, count]) => (
               <Badge
                 key={type}
                 variant="outline"

--- a/frontend/features/collections/components/CollectionCard.tsx
+++ b/frontend/features/collections/components/CollectionCard.tsx
@@ -100,18 +100,16 @@ export function CollectionCard({ collection }: CollectionCardProps) {
 
   const isLikePending = likeMutation.isPending || unlikeMutation.isPending
 
-  // PSY-582: render the FULL entity-type breakdown so badge counts always
-  // sum to item_count. Slicing to top-N silently dropped types (the original
-  // truncation showed only 2) and produced cards where "3 artists 1 festival"
-  // didn't add up to the displayed "7 items". Most collections have ≤5
-  // entity types so the badges still wrap cleanly at narrow widths; matches
-  // the detail-page rendering. Keep the count-desc sort so the largest
-  // bucket leads.
-  const entityTypeBreakdown = Object.entries(collection.entity_type_counts ?? {})
-    .sort((a, b) => b[1] - a[1])
+  // PSY-582: render the FULL breakdown so badge counts always sum to
+  // item_count — the previous top-2 slice silently dropped types and
+  // produced cards where "3 artists 1 festival" didn't add up to "7 items".
+  // Sorted count-desc so the largest bucket leads.
+  const entityTypeBreakdown = Object.entries(
+    collection.entity_type_counts ?? {}
+  ).sort((a, b) => b[1] - a[1])
 
-  // Get up to 4 entity type icons for the mosaic placeholder. The mosaic
-  // fallback is space-bounded (4 icons in a 2x2 grid), so this slice stays.
+  // Mosaic placeholder is space-bounded by the 2x2 fallback tile, so its
+  // top-4 slice stays.
   const mosaicTypes = entityTypeBreakdown.slice(0, 4).map(([type]) => type)
 
   return (


### PR DESCRIPTION
## Summary

- Stop slicing the entity-type breakdown to the top 2 on browse cards. Render every entity type so the displayed counts always sum to \`item_count\`.
- The truncation was silent (no \"+N more\" indicator) and produced cards like \"3 artists 1 festival\" sitting next to \"7 items\" — the math didn't add up and there was no cue that the breakdown was partial.
- Most collections have ≤5 entity types so the badges still wrap cleanly down to 320px width. Mosaic-fallback (top-4 icons in a 2x2 placeholder tile) keeps its space-bounded slice — that wasn't the bug.

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun run test:run features/collections\` — 254/254 pass (added 2 cases under \"entity-type breakdown (PSY-582)\": one asserts every type renders, one asserts the badge counts sum to \`item_count\`)

## Manual repro

Stack mode: \`shared\` (frontend-only). Auto-escalated to \`isolated\` once during bring-up because the dispatch script's API_PORT env didn't take effect on the backend (filed mentally as an existing stack-up footgun, not in scope here); ran the manual repro against the resulting backend on :8080 + frontend on :51968.

Seeded a public test collection with 5 distinct entity types (3 artists + 1 venue + 1 release + 1 label + 1 festival = 7 items) and verified on \`/collections\`:

- Desktop (1280px): card shows \"3 artists\", \"1 festival\", \"1 label\", \"1 release\", \"1 venue\" wrapping across two lines, with \"7 items\" below — math checks. \`dogfood-output/PSY-582/screenshots/full-breakdown-desktop.png\`
- Mobile (390px iPhone 12): same breakdown, wraps cleanly. \`full-breakdown-mobile.png\`
- Narrow mobile (320px): same breakdown, wraps cleanly. \`full-breakdown-mobile-320.png\`
- Popular tab: same component (\`CollectionList\` shares \`CollectionCard\` across All / Popular / Recent / Featured / Yours), full breakdown renders.

## Simplify

\`/simplify\` second-pass tightened the new code:

- Trimmed the \`entityTypeBreakdown\` comment to the load-bearing WHY (the parent commit + ticket already explain the full failure mode).
- Hoisted the 5-type / 7-item test fixture into a \`describe\`-scoped const; flattened the badge-sum reducer. No behaviour change; tests re-ran green.

Closes PSY-582