### PR TITLE
PSY-590: add Edit + Delete affordances to field notes

### DIFF
--- a/frontend/features/comments/components/FieldNoteCard.test.tsx
+++ b/frontend/features/comments/components/FieldNoteCard.test.tsx
@@ -13,7 +13,10 @@ vi.mock('@/lib/context/AuthContext', () => ({
 
 const defaultMutationReturn = { mutate: vi.fn(), isPending: false }
 // PSY-608: per-mutation overrides so we can assert reply + vote error UI.
+// PSY-590: edit + delete mutations join the mock surface.
 const mockUseReplyToComment = vi.fn()
+const mockUseUpdateComment = vi.fn()
+const mockUseDeleteComment = vi.fn()
 const mockUseVoteComment = vi.fn()
 const mockUseUnvoteComment = vi.fn()
 
@@ -24,6 +27,8 @@ vi.mock('../hooks', async () => {
   const actual = await vi.importActual<typeof import('../hooks')>('../hooks')
   return {
     useReplyToComment: () => mockUseReplyToComment(),
+    useUpdateComment: () => mockUseUpdateComment(),
+    useDeleteComment: () => mockUseDeleteComment(),
     useVoteComment: () => mockUseVoteComment(),
     useUnvoteComment: () => mockUseUnvoteComment(),
     useCommentThread: () => ({ data: undefined }),
@@ -34,12 +39,19 @@ vi.mock('../hooks', async () => {
 
 function resetFieldNoteCardMocks() {
   mockUseReplyToComment.mockReturnValue(defaultMutationReturn)
+  mockUseUpdateComment.mockReturnValue(defaultMutationReturn)
+  mockUseDeleteComment.mockReturnValue(defaultMutationReturn)
   mockUseVoteComment.mockReturnValue(defaultMutationReturn)
   mockUseUnvoteComment.mockReturnValue(defaultMutationReturn)
 }
 
 vi.mock('@/features/contributions', () => ({
   ReportEntityDialog: () => null,
+}))
+
+// PSY-590: stub the edit history dialog — only its render condition matters here.
+vi.mock('./CommentEditHistory', () => ({
+  CommentEditHistory: () => <div data-testid="stub-edit-history-dialog" />,
 }))
 
 function makeFieldNote(overrides: Partial<Comment> = {}): Comment {
@@ -448,6 +460,229 @@ describe('FieldNoteCard', () => {
       expect(banner).toHaveTextContent(
         'Please wait 60s before commenting again.'
       )
+    })
+  })
+
+  // PSY-590: Edit + Delete affordances on the author's own field note. Mirrors
+  // the CommentCard surface (Pencil + Trash2 + inline Yes/No confirm + admin-
+  // only edit history trigger). The makeFieldNote helper fixes user_id=2, so
+  // we sign in as that user to exercise the owner branch.
+  describe('Edit + Delete affordances (PSY-590)', () => {
+    function ownerAuth() {
+      mockAuthContext.mockReturnValue({
+        isAuthenticated: true,
+        user: { id: '2', email: 'owner@example.com', is_admin: false },
+      })
+    }
+    function adminAuth() {
+      mockAuthContext.mockReturnValue({
+        isAuthenticated: true,
+        user: { id: '99', email: 'admin@example.com', is_admin: true },
+      })
+    }
+    function otherUserAuth() {
+      mockAuthContext.mockReturnValue({
+        isAuthenticated: true,
+        user: { id: '99', email: 'other@example.com', is_admin: false },
+      })
+    }
+
+    it('renders Edit + Delete for the author', () => {
+      ownerAuth()
+      render(<FieldNoteCard comment={makeFieldNote()} showId={10} />)
+      expect(screen.getByTestId('edit-field-note-button')).toBeInTheDocument()
+      expect(screen.getByTestId('delete-field-note-button')).toBeInTheDocument()
+    })
+
+    it('does NOT render Edit + Delete for non-author non-admin viewers', () => {
+      otherUserAuth()
+      render(<FieldNoteCard comment={makeFieldNote()} showId={10} />)
+      expect(
+        screen.queryByTestId('edit-field-note-button')
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByTestId('delete-field-note-button')
+      ).not.toBeInTheDocument()
+      // Non-owner sees Report instead.
+      expect(
+        screen.getByTestId('report-field-note-button')
+      ).toBeInTheDocument()
+    })
+
+    it('does NOT render Edit + Delete for anonymous viewers', () => {
+      // beforeEach sets isAuthenticated=false by default.
+      render(<FieldNoteCard comment={makeFieldNote()} showId={10} />)
+      expect(
+        screen.queryByTestId('edit-field-note-button')
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByTestId('delete-field-note-button')
+      ).not.toBeInTheDocument()
+    })
+
+    it('opens an inline edit form populated with the existing body when Edit is clicked', () => {
+      ownerAuth()
+      render(
+        <FieldNoteCard
+          comment={makeFieldNote({ body: 'My original take' })}
+          showId={10}
+        />
+      )
+
+      fireEvent.click(screen.getByTestId('edit-field-note-button'))
+
+      const textarea = screen.getByTestId(
+        'comment-textarea'
+      ) as HTMLTextAreaElement
+      expect(textarea.value).toBe('My original take')
+      // The read-only body view is replaced while editing.
+      expect(screen.queryByTestId('field-note-body')).not.toBeInTheDocument()
+    })
+
+    it('calls useUpdateComment with the edited body on Save', () => {
+      ownerAuth()
+      const mutate = vi.fn()
+      mockUseUpdateComment.mockReturnValue({
+        mutate,
+        isPending: false,
+      })
+      render(
+        <FieldNoteCard
+          comment={makeFieldNote({ body: 'before' })}
+          showId={10}
+        />
+      )
+
+      fireEvent.click(screen.getByTestId('edit-field-note-button'))
+      const textarea = screen.getByTestId('comment-textarea')
+      fireEvent.change(textarea, { target: { value: 'after' } })
+      fireEvent.click(screen.getByText('Save'))
+
+      expect(mutate).toHaveBeenCalledTimes(1)
+      const [args] = mutate.mock.calls[0]
+      expect(args).toMatchObject({
+        commentId: 1,
+        body: 'after',
+        entityType: 'show',
+        entityId: 10,
+      })
+    })
+
+    it('renders inline edit-form error banner on update failure', () => {
+      ownerAuth()
+      mockUseUpdateComment.mockReturnValue({
+        mutate: vi.fn(),
+        isPending: false,
+        error: Object.assign(new Error('comment is too long'), { status: 400 }),
+      })
+      render(<FieldNoteCard comment={makeFieldNote()} showId={10} />)
+      fireEvent.click(screen.getByTestId('edit-field-note-button'))
+
+      const banner = screen.getByTestId('comment-form-error')
+      expect(banner).toBeInTheDocument()
+      expect(banner).toHaveTextContent('Comment is too long')
+    })
+
+    it('shows inline Yes/No confirmation when Delete is clicked', () => {
+      ownerAuth()
+      render(<FieldNoteCard comment={makeFieldNote()} showId={10} />)
+
+      fireEvent.click(screen.getByTestId('delete-field-note-button'))
+
+      expect(
+        screen.getByTestId('delete-field-note-confirm')
+      ).toBeInTheDocument()
+      expect(screen.getByTestId('delete-field-note-yes')).toBeInTheDocument()
+      expect(screen.getByTestId('delete-field-note-no')).toBeInTheDocument()
+      // Delete button itself is replaced by the confirm row.
+      expect(
+        screen.queryByTestId('delete-field-note-button')
+      ).not.toBeInTheDocument()
+    })
+
+    it('calls useDeleteComment when Yes is clicked, dismisses on No', () => {
+      ownerAuth()
+      const mutate = vi.fn()
+      mockUseDeleteComment.mockReturnValue({ mutate, isPending: false })
+      render(<FieldNoteCard comment={makeFieldNote()} showId={10} />)
+
+      // Open confirm, then cancel.
+      fireEvent.click(screen.getByTestId('delete-field-note-button'))
+      fireEvent.click(screen.getByTestId('delete-field-note-no'))
+      expect(
+        screen.queryByTestId('delete-field-note-confirm')
+      ).not.toBeInTheDocument()
+      expect(mutate).not.toHaveBeenCalled()
+
+      // Open again, confirm.
+      fireEvent.click(screen.getByTestId('delete-field-note-button'))
+      fireEvent.click(screen.getByTestId('delete-field-note-yes'))
+
+      expect(mutate).toHaveBeenCalledTimes(1)
+      const [args] = mutate.mock.calls[0]
+      expect(args).toMatchObject({
+        commentId: 1,
+        entityType: 'show',
+        entityId: 10,
+      })
+    })
+
+    it('renders the delete-error banner when useDeleteComment fails', () => {
+      ownerAuth()
+      mockUseDeleteComment.mockReturnValue({
+        mutate: vi.fn(),
+        isPending: false,
+        isError: true,
+        error: Object.assign(new Error('cannot delete pinned note'), {
+          status: 403,
+        }),
+      })
+      render(<FieldNoteCard comment={makeFieldNote()} showId={10} />)
+
+      const banner = screen.getByTestId('delete-error-banner')
+      expect(banner).toBeInTheDocument()
+      expect(banner).toHaveAttribute('role', 'alert')
+      expect(banner).toHaveTextContent('Cannot delete pinned note')
+    })
+
+    it('renders the admin edit-history button for admins when the field note has edits', () => {
+      adminAuth()
+      render(
+        <FieldNoteCard
+          comment={makeFieldNote({ edit_count: 2, is_edited: true })}
+          showId={10}
+        />
+      )
+
+      const btn = screen.getByTestId('admin-edit-history-button')
+      expect(btn).toBeInTheDocument()
+      expect(btn).toHaveTextContent('Edit history (2)')
+    })
+
+    it('hides the admin edit-history button for admins when the field note has never been edited', () => {
+      adminAuth()
+      render(
+        <FieldNoteCard
+          comment={makeFieldNote({ edit_count: 0, is_edited: false })}
+          showId={10}
+        />
+      )
+      expect(
+        screen.queryByTestId('admin-edit-history-button')
+      ).not.toBeInTheDocument()
+    })
+
+    it('does NOT render the admin edit-history button for non-admin viewers', () => {
+      ownerAuth()
+      render(
+        <FieldNoteCard
+          comment={makeFieldNote({ edit_count: 2, is_edited: true })}
+          showId={10}
+        />
+      )
+      expect(
+        screen.queryByTestId('admin-edit-history-button')
+      ).not.toBeInTheDocument()
     })
   })
 })

--- a/frontend/features/comments/components/FieldNoteCard.tsx
+++ b/frontend/features/comments/components/FieldNoteCard.tsx
@@ -1,17 +1,20 @@
 'use client'
 
 import { useState } from 'react'
-import { ChevronUp, ChevronDown, MessageSquare, Star, CheckCircle, Eye, EyeOff, Flag, Clock } from 'lucide-react'
+import { ChevronUp, ChevronDown, MessageSquare, Star, CheckCircle, Eye, EyeOff, Flag, Clock, Pencil, Trash2, History } from 'lucide-react'
 import { formatRelativeTime } from '@/lib/formatRelativeTime'
 import { useAuthContext } from '@/lib/context/AuthContext'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { UserAttribution } from '@/components/shared'
 import { CommentForm } from './CommentForm'
+import { CommentEditHistory } from './CommentEditHistory'
 import { MutationErrorBanner } from './MutationErrorBanner'
 import { ReportEntityDialog } from '@/features/contributions'
 import {
   useReplyToComment,
+  useUpdateComment,
+  useDeleteComment,
   useVoteComment,
   useUnvoteComment,
   useCommentThread,
@@ -58,14 +61,22 @@ export function FieldNoteCard({
   const { user, isAuthenticated } = useAuthContext()
   const currentUserId = user?.id ? Number(user.id) : null
   const isOwner = currentUserId === comment.user_id
+  const isAdmin = Boolean(user?.is_admin)
 
   const [isReplying, setIsReplying] = useState(false)
+  const [isEditing, setIsEditing] = useState(false)
+  const [isDeleteConfirm, setIsDeleteConfirm] = useState(false)
   const [showSpoiler, setShowSpoiler] = useState(false)
   const [showReplies, setShowReplies] = useState(true)
   const [loadedThread, setLoadedThread] = useState(false)
   const [isReportOpen, setIsReportOpen] = useState(false)
+  // PSY-590: admin edit history viewer — gated by is_admin and only fetched
+  // when the dialog is opened (mirrors CommentCard / PSY-297 pattern).
+  const [isEditHistoryOpen, setIsEditHistoryOpen] = useState(false)
 
   const replyMutation = useReplyToComment()
+  const updateMutation = useUpdateComment()
+  const deleteMutation = useDeleteComment()
   const voteMutation = useVoteComment()
   const unvoteMutation = useUnvoteComment()
   // PSY-608: optimistic vote/unvote rollback hides the failure visually.
@@ -105,6 +116,27 @@ export function FieldNoteCard({
     replyMutation.mutate(
       { commentId: comment.id, body, entityType: 'show', entityId: showId },
       { onSuccess: () => setIsReplying(false) }
+    )
+  }
+
+  // PSY-590: edit + delete mirror the CommentCard wiring. The backend
+  // PUT/DELETE /comments/{id} endpoints operate on the row regardless of
+  // kind, so field-note edits go through the same useUpdateComment hook
+  // and inherit the comment_edits history (admin-visible via PSY-297).
+  // Structured fields (sound/crowd/notable/etc.) are intentionally NOT
+  // editable here — only the body, matching the existing comment-edit
+  // surface and the "mirror comment behavior" decision on this ticket.
+  const handleEdit = (body: string) => {
+    updateMutation.mutate(
+      { commentId: comment.id, body, entityType: 'show', entityId: showId },
+      { onSuccess: () => setIsEditing(false) }
+    )
+  }
+
+  const handleDelete = () => {
+    deleteMutation.mutate(
+      { commentId: comment.id, entityType: 'show', entityId: showId },
+      { onSuccess: () => setIsDeleteConfirm(false) }
     )
   }
 
@@ -192,8 +224,22 @@ export function FieldNoteCard({
         </div>
       )}
 
-      {/* Body — with spoiler handling */}
-      {isSpoiler && !showSpoiler ? (
+      {/* Body — with spoiler handling. PSY-590: edit mode replaces the
+          rendered body with a CommentForm; only the body field is editable
+          (mirrors comment-edit). Structured fields (sound/crowd/notable/etc.)
+          remain saved as-is on the row. */}
+      {isEditing ? (
+        <div className="mt-2">
+          <CommentForm
+            onSubmit={handleEdit}
+            initialBody={comment.body}
+            submitLabel="Save"
+            onCancel={() => setIsEditing(false)}
+            isPending={updateMutation.isPending}
+            errorMessage={formatCommentSubmissionError(updateMutation.error)}
+          />
+        </div>
+      ) : isSpoiler && !showSpoiler ? (
         <div className="mt-2" data-testid="spoiler-gate">
           <button
             onClick={() => setShowSpoiler(true)}
@@ -239,7 +285,7 @@ export function FieldNoteCard({
       {/* PSY-608: auto-dismiss banner for vote/unvote failures. The
           optimistic-rollback restores the cached state silently; without
           this, the user sees the icon flip back with no explanation. */}
-      {voteError.error !== null && (
+      {!isEditing && voteError.error !== null && (
         <MutationErrorBanner
           testId="vote-error-banner"
           marginTop="mt-3"
@@ -250,62 +296,150 @@ export function FieldNoteCard({
         />
       )}
 
-      {/* Actions row: votes + reply + report */}
-      <div className="flex items-center gap-1 mt-3">
-        {/* Vote buttons */}
-        <Button
-          variant="ghost"
-          size="sm"
-          className={`h-7 w-7 p-0 ${comment.user_vote === 1 ? 'text-primary' : 'text-muted-foreground'}`}
-          onClick={() => handleVote(1)}
-          disabled={!isAuthenticated}
-          aria-label="Upvote"
-          data-testid="upvote-button"
-        >
-          <ChevronUp className="h-4 w-4" />
-        </Button>
-        <span className="text-xs font-medium min-w-[1.5rem] text-center" data-testid="vote-score">
-          {comment.ups - comment.downs}
-        </span>
-        <Button
-          variant="ghost"
-          size="sm"
-          className={`h-7 w-7 p-0 ${comment.user_vote === -1 ? 'text-destructive' : 'text-muted-foreground'}`}
-          onClick={() => handleVote(-1)}
-          disabled={!isAuthenticated}
-          aria-label="Downvote"
-          data-testid="downvote-button"
-        >
-          <ChevronDown className="h-4 w-4" />
-        </Button>
+      {/* PSY-590: sticky banner for delete failures — mirrors CommentCard
+          (the inline edit-form banner is owned by CommentForm via
+          errorMessage above). */}
+      {!isEditing && deleteMutation.isError && (
+        <MutationErrorBanner
+          testId="delete-error-banner"
+          message={
+            formatCommentSubmissionError(deleteMutation.error) ??
+            'Failed to delete field note. Please try again.'
+          }
+        />
+      )}
 
-        {/* Reply button */}
-        {isAuthenticated && comment.depth < 2 && comment.reply_permission !== 'author_only' && (
+      {/* Actions row: votes + reply + edit + delete + report */}
+      {!isEditing && (
+        <div className="flex items-center gap-1 mt-3">
+          {/* Vote buttons */}
           <Button
             variant="ghost"
             size="sm"
-            className="h-7 px-2 text-xs text-muted-foreground"
-            onClick={() => setIsReplying(!isReplying)}
+            className={`h-7 w-7 p-0 ${comment.user_vote === 1 ? 'text-primary' : 'text-muted-foreground'}`}
+            onClick={() => handleVote(1)}
+            disabled={!isAuthenticated}
+            aria-label="Upvote"
+            data-testid="upvote-button"
           >
-            <MessageSquare className="h-3.5 w-3.5 mr-1" />
-            Reply
+            <ChevronUp className="h-4 w-4" />
           </Button>
-        )}
-
-        {/* Report button (non-owner, authenticated) */}
-        {isAuthenticated && !isOwner && (
+          <span className="text-xs font-medium min-w-[1.5rem] text-center" data-testid="vote-score">
+            {comment.ups - comment.downs}
+          </span>
           <Button
             variant="ghost"
             size="sm"
-            className="h-7 px-2 text-xs text-muted-foreground"
-            onClick={() => setIsReportOpen(true)}
-            data-testid="report-field-note-button"
+            className={`h-7 w-7 p-0 ${comment.user_vote === -1 ? 'text-destructive' : 'text-muted-foreground'}`}
+            onClick={() => handleVote(-1)}
+            disabled={!isAuthenticated}
+            aria-label="Downvote"
+            data-testid="downvote-button"
           >
-            <Flag className="h-3.5 w-3.5 mr-1" />
-            Report
+            <ChevronDown className="h-4 w-4" />
           </Button>
-        )}
-      </div>
+
+          {/* Reply button */}
+          {isAuthenticated && comment.depth < 2 && comment.reply_permission !== 'author_only' && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 px-2 text-xs text-muted-foreground"
+              onClick={() => setIsReplying(!isReplying)}
+            >
+              <MessageSquare className="h-3.5 w-3.5 mr-1" />
+              Reply
+            </Button>
+          )}
+
+          {/* PSY-590: Edit button (own field notes). Mirrors CommentCard. */}
+          {isOwner && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 px-2 text-xs text-muted-foreground"
+              onClick={() => setIsEditing(true)}
+              data-testid="edit-field-note-button"
+            >
+              <Pencil className="h-3.5 w-3.5 mr-1" />
+              Edit
+            </Button>
+          )}
+
+          {/* PSY-590: Delete button (own field notes) with inline Yes/No
+              confirmation, mirroring CommentCard. */}
+          {isOwner && !isDeleteConfirm && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 px-2 text-xs text-muted-foreground"
+              onClick={() => setIsDeleteConfirm(true)}
+              data-testid="delete-field-note-button"
+            >
+              <Trash2 className="h-3.5 w-3.5 mr-1" />
+              Delete
+            </Button>
+          )}
+
+          {isDeleteConfirm && (
+            <div className="flex items-center gap-1 ml-1" data-testid="delete-field-note-confirm">
+              <span className="text-xs text-destructive">Delete?</span>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 px-2 text-xs text-destructive"
+                onClick={handleDelete}
+                disabled={deleteMutation.isPending}
+                data-testid="delete-field-note-yes"
+              >
+                Yes
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 px-2 text-xs text-muted-foreground"
+                onClick={() => setIsDeleteConfirm(false)}
+                data-testid="delete-field-note-no"
+              >
+                No
+              </Button>
+            </div>
+          )}
+
+          {/* Report button (non-owner, authenticated) */}
+          {isAuthenticated && !isOwner && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 px-2 text-xs text-muted-foreground"
+              onClick={() => setIsReportOpen(true)}
+              data-testid="report-field-note-button"
+            >
+              <Flag className="h-3.5 w-3.5 mr-1" />
+              Report
+            </Button>
+          )}
+        </div>
+      )}
+
+      {/* PSY-590: admin-only edit history trigger. Mirrors CommentCard
+          (PSY-297) — gated on is_admin and rendered only when at least one
+          edit has been recorded. */}
+      {!isEditing && isAdmin && comment.edit_count > 0 && (
+        <div className="mt-1 pt-1 border-t border-border/40 flex items-center">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 px-2 text-[11px] text-muted-foreground hover:text-foreground"
+            onClick={() => setIsEditHistoryOpen(true)}
+            data-testid="admin-edit-history-button"
+            aria-label="View edit history"
+          >
+            <History className="h-3 w-3 mr-1" />
+            Edit history ({comment.edit_count})
+          </Button>
+        </div>
+      )}
 
       {/* Inline reply form. PSY-608: surface 4xx (e.g. 429) inline so reply
           mutations don't fail silently — same pattern as CommentCard. */}
@@ -377,6 +511,16 @@ export function FieldNoteCard({
           entityType="comment"
           entityId={comment.id}
           entityName={`Field note by ${comment.author_name}`}
+        />
+      )}
+
+      {/* PSY-590: admin edit history dialog. Mounted on-demand so we don't
+          fetch history for every field note on the page (mirrors PSY-297). */}
+      {isAdmin && isEditHistoryOpen && (
+        <CommentEditHistory
+          open={isEditHistoryOpen}
+          onOpenChange={setIsEditHistoryOpen}
+          commentId={comment.id}
         />
       )}
     </div>

--- a/frontend/features/comments/components/FieldNotesSection.test.tsx
+++ b/frontend/features/comments/components/FieldNotesSection.test.tsx
@@ -14,11 +14,15 @@ const defaultMutationReturn = { mutate: vi.fn(), isPending: false }
 vi.mock('../hooks', async () => {
   // PSY-608: bring through the real formatCommentSubmissionError so the
   // FieldNotesSection test can assert on the exact 4xx banner copy.
+  // PSY-590: FieldNoteCard now consumes useUpdateComment + useDeleteComment;
+  // stub them with the same neutral mutation return so the cards render.
   const actual = await vi.importActual<typeof import('../hooks')>('../hooks')
   return {
     useFieldNotes: (...args: unknown[]) => mockUseFieldNotes(...args),
     useCreateFieldNote: () => mockUseCreateFieldNote(),
     useReplyToComment: () => defaultMutationReturn,
+    useUpdateComment: () => defaultMutationReturn,
+    useDeleteComment: () => defaultMutationReturn,
     useVoteComment: () => defaultMutationReturn,
     useUnvoteComment: () => defaultMutationReturn,
     useCommentThread: () => ({ data: undefined }),
@@ -33,6 +37,12 @@ vi.mock('@/lib/context/AuthContext', () => ({
 
 vi.mock('@/features/contributions', () => ({
   ReportEntityDialog: () => null,
+}))
+
+// PSY-590: stub the admin edit-history dialog so the section renders even when
+// authenticated as admin (cards may try to lazy-mount the dialog).
+vi.mock('./CommentEditHistory', () => ({
+  CommentEditHistory: () => null,
 }))
 
 const pastDate = '2025-01-15T20:00:00Z'

--- a/frontend/features/comments/hooks/index.ts
+++ b/frontend/features/comments/hooks/index.ts
@@ -269,6 +269,14 @@ export function useUpdateComment() {
       queryClient.invalidateQueries({
         queryKey: commentQueryKeys.entity(variables.entityType, variables.entityId),
       })
+      // PSY-590: field notes share the comments table but live in a separate
+      // query cache (`fieldNoteQueryKeys.show`). Field-note edits flow through
+      // this hook too, so refresh that cache when the target is a show.
+      if (variables.entityType === 'show') {
+        queryClient.invalidateQueries({
+          queryKey: fieldNoteQueryKeys.show(variables.entityId),
+        })
+      }
     },
   })
 }
@@ -291,6 +299,12 @@ export function useDeleteComment() {
       queryClient.invalidateQueries({
         queryKey: commentQueryKeys.entity(variables.entityType, variables.entityId),
       })
+      // PSY-590: see useUpdateComment — keep the field-note cache in sync.
+      if (variables.entityType === 'show') {
+        queryClient.invalidateQueries({
+          queryKey: fieldNoteQueryKeys.show(variables.entityId),
+        })
+      }
     },
   })
 }


### PR DESCRIPTION
## Summary
- FieldNoteCard now mirrors CommentCard's owner surface: Edit + Delete buttons (Pencil/Trash2) with inline Yes/No delete confirmation, "Edited" badge on bumped `is_edited`, and the admin-only "Edit history" trigger gated on `is_admin && edit_count > 0` (reuses `CommentEditHistory` from PSY-297).
- Body-only edit by design (mirrors comment-edit and the `UpdateComment` service contract). Structured fields (sound/crowd/notable/etc.) stay saved as-is on the row — see in-file comment for the decision rationale.
- `useUpdateComment` / `useDeleteComment` now also invalidate `fieldNoteQueryKeys.show(entityId)` when `entityType === 'show'`, so the section refreshes after an owner mutation (the comment cache key alone doesn't cover field notes).
- Sticky `delete-error-banner` mirrors CommentCard's PSY-608 pattern; inline edit-form errors flow through `CommentForm.errorMessage`.

## Test plan
- [x] cd frontend && bun run typecheck — passed
- [x] cd frontend && bun run test:run features/comments — passed (129 tests, 12 new in `Edit + Delete affordances (PSY-590)`)

## Manual repro
Logged in as admin (`e2e-admin@test.local`), seeded a past show + a `field_note` row authored by that user, navigated to the show page, exercised Edit + Delete on the field note. Edit changed the body, "Edited" badge rendered, admin "Edit history (1)" trigger appeared. Delete opened the inline confirm; clicking Yes removed the card and the DB row went `visibility=hidden_by_user` with `edit_count=1` and a `comment_edits` row written. Screenshots: `dogfood-output/PSY-590/screenshots/edit-affordance-visible.png`, `edit-history-after-save.png`, `delete-confirmation.png`.

## Simplify
No changes — the implementation is a tight mirror of the existing CommentCard pattern; reused hooks, banner component, edit-history dialog, and naming conventions were the right call. Reviewer agents flagged nothing actionable.

Closes PSY-590