### PR TITLE
PSY-617: capture ticker-loop panics in Sentry

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -25,6 +25,7 @@ import (
 	"psychic-homily-backend/internal/config"
 	"psychic-homily-backend/internal/logger"
 	"psychic-homily-backend/internal/services"
+	servicesshared "psychic-homily-backend/internal/services/shared"
 )
 
 func main() {
@@ -84,6 +85,20 @@ func main() {
 	} else {
 		log.Printf("SENTRY_DSN not set, error tracking disabled")
 	}
+
+	// PSY-617: escalate background-service panics to Sentry. The handler
+	// runs after the slog.Error inside RunTickerLoop's recover paths, so a
+	// panicking ticker now logs AND pages, instead of only logging. Safe
+	// when SENTRY_DSN is unset — sentry.CaptureException no-ops without a
+	// configured hub.
+	servicesshared.SetPanicHandler(func(service string, panicValue any, stack []byte) {
+		sentry.WithScope(func(scope *sentry.Scope) {
+			scope.SetTag("service", service)
+			scope.SetTag("source", "background_ticker")
+			scope.SetExtra("stack", string(stack))
+			sentry.CaptureException(fmt.Errorf("background service panic in %s: %v", service, panicValue))
+		})
+	})
 
 	// Connect to database
 	if err := db.Connect(cfg); err != nil {

--- a/backend/internal/services/shared/ticker_loop.go
+++ b/backend/internal/services/shared/ticker_loop.go
@@ -7,8 +7,61 @@ import (
 	"context"
 	"log/slog"
 	"runtime/debug"
+	"sync"
 	"time"
 )
+
+// PanicHandler is invoked when a panic is recovered inside RunTickerLoop.
+// `service` is the loop name, `panicValue` is the recovered value (whatever
+// the work passed to `panic`), and `stack` is the stack trace as a string.
+//
+// Wiring point for observability: cmd/server/main.go installs a Sentry-
+// capturing handler at startup. Tests install their own handler. When no
+// handler is set, panics are logged via slog and otherwise swallowed —
+// matching pre-PSY-617 behaviour.
+//
+// The handler runs on the goroutine that recovered the panic; it should
+// return promptly (Sentry's CaptureException is non-blocking, so the
+// canonical handler is fine).
+type PanicHandler func(service string, panicValue any, stack []byte)
+
+var (
+	panicHandlerMu sync.RWMutex
+	panicHandler   PanicHandler
+)
+
+// SetPanicHandler installs a process-wide handler for ticker-loop panics.
+// Pass nil to clear (used by tests via t.Cleanup).
+//
+// Intended to be called once at startup from cmd/server/main.go after
+// Sentry is initialised. Safe to call concurrently with RunTickerLoop.
+func SetPanicHandler(h PanicHandler) {
+	panicHandlerMu.Lock()
+	panicHandler = h
+	panicHandlerMu.Unlock()
+}
+
+// invokePanicHandler runs the registered handler under the read lock so it
+// can't race with SetPanicHandler. Recovers any panic the handler itself
+// raises so a buggy handler can't take down the loop it was meant to
+// observe.
+func invokePanicHandler(service string, panicValue any, stack []byte) {
+	panicHandlerMu.RLock()
+	h := panicHandler
+	panicHandlerMu.RUnlock()
+	if h == nil {
+		return
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Default().Error("ticker-loop panic handler itself panicked",
+				"service", service,
+				"panic", r,
+			)
+		}
+	}()
+	h(service, panicValue, stack)
+}
 
 // RunTickerLoop runs `work` on every tick of `interval`, returning when
 // `ctx` is canceled or `stopCh` is closed.
@@ -46,11 +99,13 @@ func RunTickerLoop(
 ) {
 	defer func() {
 		if r := recover(); r != nil {
+			stack := debug.Stack()
 			slog.Default().Error("background service panic — service stopping",
 				"service", name,
 				"panic", r,
-				"stack", string(debug.Stack()),
+				"stack", string(stack),
 			)
+			invokePanicHandler(name, r, stack)
 		}
 	}()
 
@@ -79,11 +134,13 @@ func RunTickerLoop(
 func runOneCycle(ctx context.Context, name string, work func(context.Context)) {
 	defer func() {
 		if r := recover(); r != nil {
+			stack := debug.Stack()
 			slog.Default().Error("background service tick panic — continuing",
 				"service", name,
 				"panic", r,
-				"stack", string(debug.Stack()),
+				"stack", string(stack),
 			)
+			invokePanicHandler(name, r, stack)
 		}
 	}()
 	work(ctx)

--- a/backend/internal/services/shared/ticker_loop_test.go
+++ b/backend/internal/services/shared/ticker_loop_test.go
@@ -208,6 +208,165 @@ func TestRunTickerLoop_ContextCancellationStopsLoop(t *testing.T) {
 	}
 }
 
+// capturedPanic records the args invokePanicHandler passes through so
+// PSY-617's Sentry-wiring tests can assert against them without depending
+// on the live Sentry SDK or a transport mock.
+type capturedPanic struct {
+	service    string
+	panicValue any
+	stack      []byte
+}
+
+// installRecordingPanicHandler installs a thread-safe recorder for the
+// duration of the test, restoring the previous (nil) handler on cleanup.
+// Returns a function that snapshots the captured calls.
+func installRecordingPanicHandler(t *testing.T) func() []capturedPanic {
+	t.Helper()
+	var (
+		mu       sync.Mutex
+		captured []capturedPanic
+	)
+	SetPanicHandler(func(service string, panicValue any, stack []byte) {
+		mu.Lock()
+		defer mu.Unlock()
+		captured = append(captured, capturedPanic{service: service, panicValue: panicValue, stack: stack})
+	})
+	t.Cleanup(func() { SetPanicHandler(nil) })
+	return func() []capturedPanic {
+		mu.Lock()
+		defer mu.Unlock()
+		out := make([]capturedPanic, len(captured))
+		copy(out, captured)
+		return out
+	}
+}
+
+// TestRunTickerLoop_PanicHandlerInvokedOnTickPanic is the load-bearing
+// PSY-617 assertion: a panic inside per-tick work invokes the registered
+// PanicHandler with the service name, panic value, and stack trace —
+// in addition to the slog.Error already exercised by the PSY-615 test.
+// The handler is the wiring point cmd/server/main.go uses to escalate
+// to Sentry.
+func TestRunTickerLoop_PanicHandlerInvokedOnTickPanic(t *testing.T) {
+	_ = withCapturedSlog(t) // suppress noisy stack trace from slog.Error
+	snapshot := installRecordingPanicHandler(t)
+
+	var calls atomic.Int32
+	work := func(_ context.Context) {
+		if calls.Add(1) == 1 {
+			panic("boom-tick")
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		RunTickerLoop(ctx, "panic-handler-test-service", 10*time.Millisecond, nil, false, work)
+		close(done)
+	}()
+	<-done
+
+	got := snapshot()
+	require.Len(t, got, 1, "panic handler should be invoked exactly once for the single tick panic")
+	assert.Equal(t, "panic-handler-test-service", got[0].service)
+	assert.Equal(t, "boom-tick", got[0].panicValue)
+	assert.NotEmpty(t, got[0].stack, "stack trace should be populated")
+	assert.Contains(t, string(got[0].stack), "ticker_loop.go", "stack should reference the recover site")
+}
+
+// TestRunTickerLoop_PanicHandlerInvokedOnSetupPanic exercises the outer
+// recover path: time.NewTicker(0) panics during loop setup. The handler
+// must be invoked exactly once, with the configured service name, before
+// the loop returns.
+func TestRunTickerLoop_PanicHandlerInvokedOnSetupPanic(t *testing.T) {
+	_ = withCapturedSlog(t)
+	snapshot := installRecordingPanicHandler(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("outer recover failed; panic escaped: %v", r)
+		}
+	}()
+
+	RunTickerLoop(ctx, "setup-panic-handler-service", 0, nil, false, func(_ context.Context) {})
+
+	got := snapshot()
+	require.Len(t, got, 1, "panic handler should be invoked exactly once for the setup panic")
+	assert.Equal(t, "setup-panic-handler-service", got[0].service)
+	assert.NotNil(t, got[0].panicValue, "panic value should be propagated")
+	assert.NotEmpty(t, got[0].stack)
+}
+
+// TestRunTickerLoop_NilPanicHandlerIsNoop guards the contract that an
+// unset handler (the package default) doesn't panic and doesn't change
+// the existing slog-only behaviour. Defensive clear in case a sibling
+// test in the package leaked a handler past its t.Cleanup.
+func TestRunTickerLoop_NilPanicHandlerIsNoop(t *testing.T) {
+	logs := withCapturedSlog(t)
+	SetPanicHandler(nil)
+	t.Cleanup(func() { SetPanicHandler(nil) })
+
+	var calls atomic.Int32
+	work := func(_ context.Context) {
+		if calls.Add(1) == 1 {
+			panic("boom-no-handler")
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		RunTickerLoop(ctx, "no-handler-service", 10*time.Millisecond, nil, false, work)
+		close(done)
+	}()
+	<-done
+
+	assert.Greater(t, int(calls.Load()), 1, "loop should still continue past the panic")
+	assert.Contains(t, logs.String(), "boom-no-handler", "slog path still fires when handler is nil")
+}
+
+// TestRunTickerLoop_PanicHandlerOwnPanicDoesNotKillLoop guards against a
+// buggy handler taking down the loop it was meant to observe. If the
+// handler panics, the recover inside invokePanicHandler must swallow it
+// and the loop must continue ticking.
+func TestRunTickerLoop_PanicHandlerOwnPanicDoesNotKillLoop(t *testing.T) {
+	_ = withCapturedSlog(t)
+
+	var handlerCalls atomic.Int32
+	SetPanicHandler(func(_ string, _ any, _ []byte) {
+		handlerCalls.Add(1)
+		panic("handler is buggy")
+	})
+	t.Cleanup(func() { SetPanicHandler(nil) })
+
+	var calls atomic.Int32
+	work := func(_ context.Context) {
+		if calls.Add(1) == 1 {
+			panic("trigger-handler")
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		RunTickerLoop(ctx, "buggy-handler-service", 10*time.Millisecond, nil, false, work)
+		close(done)
+	}()
+	<-done
+
+	require.Greater(t, int(handlerCalls.Load()), 0, "handler should have been called at least once")
+	assert.Greater(t, int(calls.Load()), 1, "loop should keep ticking after handler panic")
+}
+
 // TestRunTickerLoop_OuterRecoverCatchesSetupPanic covers the outer
 // recover. `time.NewTicker(0)` panics with a duration <= 0; without the
 // outer recover that panic would bubble out and kill the supervising


### PR DESCRIPTION
## Summary
- Add process-wide `PanicHandler` callback hook in `services/shared` and wire a Sentry-capturing closure in `cmd/server/main.go` after the existing Sentry init.
- Both recover paths in `RunTickerLoop` now invoke the handler alongside `slog.Error` — a panic in any of the 10 ticker goroutines now pages via Sentry instead of only logging.
- Handler is a no-op when unset (preserves test/dev behaviour and the SENTRY_DSN-unset case).
- Avoided importing `sentry-go` into the low-level `services/shared` package per the ticket's dependency-light preference.

## Test plan
- [x] `cd backend && go build ./...` — passed
- [x] `cd backend && go test ./internal/services/shared/...` — passed (11 ticker_loop tests + user_resolver tests; includes 4 new PSY-617 tests)
- [x] `cd backend && go test -race ./internal/services/shared/...` — passed (race-clean; mutex protects the package-level handler)
- [x] `cd backend && go vet ./internal/services/shared/... ./cmd/server/...` — passed

## Manual repro
- `TestRunTickerLoop_PanicHandlerInvokedOnTickPanic` — asserts a panic-injected work function invokes the registered PanicHandler with service `"panic-handler-test-service"`, panic value `"boom-tick"`, and a stack trace containing `ticker_loop.go`. Passed: handler invoked exactly once with all three fields populated.
- `TestRunTickerLoop_PanicHandlerInvokedOnSetupPanic` — same assertion for the outer recover path (`time.NewTicker(0)` setup panic). Passed.
- Live Sentry smoke test (DSN-configured environment) is out of scope for this PR — the unit-test mock-handler assertion is the test contract per the AC.

## Simplify
- Trimmed dead `prevCleared` variable from the nil-handler test; logic was the same either way.

Closes PSY-617