### PR TITLE
PSY-584: bypass new_user tier gate for admins in tag-create popover

### DIFF
--- a/frontend/features/tags/components/EntityTagList.test.tsx
+++ b/frontend/features/tags/components/EntityTagList.test.tsx
@@ -124,7 +124,7 @@ vi.mock('../types', () => ({
 // Default auth context: a contributor (can create tags). Individual tests
 // override `mockAuthUser` to exercise the new_user disabled-Create path
 // added in PSY-443.
-type MockAuthUser = { user_tier?: string } | null
+type MockAuthUser = { user_tier?: string; is_admin?: boolean } | null
 let mockAuthUser: MockAuthUser = { user_tier: 'contributor' }
 vi.mock('@/lib/context/AuthContext', () => ({
   useAuthContext: () => ({
@@ -692,6 +692,28 @@ describe('EntityTagList add-tag dialog create-tag tier gating', () => {
 
   it('renders an enabled Create button for trusted_contributor tier', async () => {
     mockAuthUser = { user_tier: 'trusted_contributor' }
+    await openDialogAndSearch('brand-new-tag')
+
+    await waitFor(() => {
+      expect(screen.getByText('No matching tags found.')).toBeInTheDocument()
+    })
+
+    const createButton = screen.getByRole('button', {
+      name: /Create "brand-new-tag"/,
+    })
+    expect(createButton).not.toBeDisabled()
+    expect(
+      screen.queryByTestId('tag-create-tier-gate')
+    ).not.toBeInTheDocument()
+  })
+
+  // PSY-584: admins bypass the tier check even when their user_tier is
+  // 'new_user' (matches the backend short-circuit in createTagInline).
+  // Without this short-circuit, an admin who hasn't earned Contributor tier
+  // through normal contributions would see the "New tags require Contributor
+  // tier" gate and never reach the Create button.
+  it('renders an enabled Create button for admin even with new_user tier', async () => {
+    mockAuthUser = { user_tier: 'new_user', is_admin: true }
     await openDialogAndSearch('brand-new-tag')
 
     await waitFor(() => {

--- a/frontend/features/tags/components/EntityTagList.tsx
+++ b/frontend/features/tags/components/EntityTagList.tsx
@@ -710,7 +710,7 @@ function AddTagForm({
   // same gate client-side so users see a tooltip instead of a dead-end 403.
   // Admins bypass the tier check (PSY-584) — matches the backend short-circuit
   // in createTagInline (`user.UserTier == "new_user" && !user.IsAdmin`).
-  const canCreateTags = Boolean(user?.is_admin) || user?.user_tier !== 'new_user'
+  const canCreateTags = user?.is_admin || user?.user_tier !== 'new_user'
   const [searchQuery, setSearchQuery] = useState('')
   const [debouncedQuery, setDebouncedQuery] = useState('')
   const [filterCategory, setFilterCategory] = useState<string>('')

--- a/frontend/features/tags/components/EntityTagList.tsx
+++ b/frontend/features/tags/components/EntityTagList.tsx
@@ -708,7 +708,9 @@ function AddTagForm({
   // Only `new_user` tier is blocked from creating new tags server-side
   // (CodeTagCreationForbidden in backend/internal/errors/tag.go). Mirror the
   // same gate client-side so users see a tooltip instead of a dead-end 403.
-  const canCreateTags = user?.user_tier !== 'new_user'
+  // Admins bypass the tier check (PSY-584) — matches the backend short-circuit
+  // in createTagInline (`user.UserTier == "new_user" && !user.IsAdmin`).
+  const canCreateTags = Boolean(user?.is_admin) || user?.user_tier !== 'new_user'
   const [searchQuery, setSearchQuery] = useState('')
   const [debouncedQuery, setDebouncedQuery] = useState('')
   const [filterCategory, setFilterCategory] = useState<string>('')


### PR DESCRIPTION
## Summary
- Frontend `canCreateTags` in `EntityTagList`'s Add-tag popover now mirrors the backend short-circuit: admins bypass the `new_user` tier check, matching the gate in `TagService.createTagInline` (`user.UserTier == "new_user" && !user.IsAdmin`). Without this, an admin whose tier hadn't yet auto-promoted to Contributor saw "New tags require Contributor tier" and never reached the Create button.

## Investigation note
The backend was already correct. The gate at `backend/internal/services/catalog/tag_service.go:454` had the `&& !user.IsAdmin` short-circuit, and three integration tests already covered all three personas (admin / contributor / new_user). The user-visible bug was purely the frontend mirror gate failing to honour `is_admin`. Fix lives client-side; backend tests are unchanged but re-run for the AC.

## Test plan
- [x] `cd backend && go build ./...` — passed
- [x] `cd backend && go test ./internal/services/catalog/... -run TestTagServiceIntegration/TestAddTagToEntity_InlineCreate` — 10/10 passed (covers the 3 AC personas: admin / contributor / new_user)
- [x] `cd frontend && bun run test -- --run features/tags/components/EntityTagList.test.tsx` — 47/47 passed (1 new test: "renders an enabled Create button for admin even with new_user tier")

## Manual repro
Backend (already passing on `main`, re-run as the canonical repro for the AC):
- `TestAddTagToEntity_InlineCreate_AdminSuccess` — admin with `user_tier='new_user'` creates `admin-created-tag` successfully (no tier error). PASS.
- `TestAddTagToEntity_InlineCreate_ContributorSuccess` — contributor creates `shoegaze-revival` successfully. PASS.
- `TestAddTagToEntity_InlineCreate_NewUserForbidden` — `new_user` (non-admin) gets `CodeTagCreationForbidden`. PASS.

Frontend (new test asserts the parallel UI behaviour):
- `renders an enabled Create button for admin even with new_user tier` — `is_admin: true, user_tier: 'new_user'` → Create button rendered, gate prose absent. PASS.
- Existing `hides the Create button for new_user tier...` — still PASS for non-admin new_user.
- Existing `renders an enabled Create button for contributor tier...` — still PASS.

End-to-end: admin signs in, opens Add tag on a collection, types `doom` (or any non-existing tag), now sees the Create button + Category dropdown instead of the "New tags require Contributor tier" gate prose.

## Simplify
Dropped explicit `Boolean(user?.is_admin)` wrapper in favour of plain `user?.is_admin || ...` to match the repo convention used in LabelDetail / ReleaseDetail / FestivalDetail. No behaviour change.

Closes PSY-584