### PR TITLE
PSY-579: make grid-card Remove control visible on hover

### DIFF
--- a/frontend/features/collections/components/CollectionItemCard.test.tsx
+++ b/frontend/features/collections/components/CollectionItemCard.test.tsx
@@ -479,14 +479,11 @@ describe('CollectionItemCard', () => {
     })
 
     it('places `group` on the <article> so group-hover: resolves on the sibling Remove control (PSY-579)', () => {
-      // PSY-579 regression guard: PSY-526 originally put the `group`
-      // class on the <Link> wrapper, but the Remove control is a sibling
-      // of (not a descendant of) the Link. With `group` only on the
-      // Link, `group-hover:opacity-100` on the Remove button never
-      // resolved a matching `.group:hover` ancestor and the button
-      // stayed at opacity-0 forever — present in the DOM but invisible.
-      // Anchor the marker on the <article> so any descendant with a
-      // `group-hover:` class fires correctly when the card is hovered.
+      // The Remove control is a SIBLING of the wrapping <Link>, not a
+      // descendant. If `group` lives only on the Link (as PSY-526
+      // originally placed it), the button's `group-hover:opacity-100`
+      // has no matching `.group:hover` ancestor and stays at
+      // opacity-0 — present in the DOM but invisible.
       render(
         <CollectionItemCard
           item={makeItem()}
@@ -497,10 +494,7 @@ describe('CollectionItemCard', () => {
       )
       const card = screen.getByTestId('collection-item-card')
       const removeBtn = screen.getByTestId('collection-item-card-remove')
-      // The article carries `group`.
       expect(card.classList.contains('group')).toBe(true)
-      // And the Remove control's `group-hover:` resolves at least one
-      // `.group` ancestor — proving the visibility toggle is wired.
       expect(removeBtn.closest('.group')).toBe(card)
     })
 

--- a/frontend/features/collections/components/CollectionItemCard.test.tsx
+++ b/frontend/features/collections/components/CollectionItemCard.test.tsx
@@ -478,6 +478,32 @@ describe('CollectionItemCard', () => {
       ).toBe(true)
     })
 
+    it('places `group` on the <article> so group-hover: resolves on the sibling Remove control (PSY-579)', () => {
+      // PSY-579 regression guard: PSY-526 originally put the `group`
+      // class on the <Link> wrapper, but the Remove control is a sibling
+      // of (not a descendant of) the Link. With `group` only on the
+      // Link, `group-hover:opacity-100` on the Remove button never
+      // resolved a matching `.group:hover` ancestor and the button
+      // stayed at opacity-0 forever — present in the DOM but invisible.
+      // Anchor the marker on the <article> so any descendant with a
+      // `group-hover:` class fires correctly when the card is hovered.
+      render(
+        <CollectionItemCard
+          item={makeItem()}
+          density="comfortable"
+          isCreator={true}
+          slug="my-coll"
+        />
+      )
+      const card = screen.getByTestId('collection-item-card')
+      const removeBtn = screen.getByTestId('collection-item-card-remove')
+      // The article carries `group`.
+      expect(card.classList.contains('group')).toBe(true)
+      // And the Remove control's `group-hover:` resolves at least one
+      // `.group` ancestor — proving the visibility toggle is wired.
+      expect(removeBtn.closest('.group')).toBe(card)
+    })
+
     it('keeps the title="Remove from collection" smoke-test selector intact', () => {
       // PSY-526: the existing E2E smoke test in add-to-collection.spec.ts
       // queries by title to find the Remove trigger. Preserve that

--- a/frontend/features/collections/components/CollectionItemCard.tsx
+++ b/frontend/features/collections/components/CollectionItemCard.tsx
@@ -141,11 +141,10 @@ export function CollectionItemCard({
     <article
       ref={canReorder ? setNodeRef : undefined}
       style={sortableStyle}
-      // PSY-579: `group` lives on the <article> (not just the inner <Link>)
-      // so the hover-revealed Remove control — which is a sibling of the
-      // Link, not a descendant — can resolve `group-hover:opacity-100`
-      // correctly. Keeping `group` on the Link as well would be redundant
-      // (any descendant `group-hover:` walks up to the article and fires).
+      // PSY-579: `group` must live on the <article> (a shared ancestor)
+      // because the hover-revealed Remove control is a sibling of the
+      // <Link>, not a descendant — so its `group-hover:opacity-100`
+      // would never resolve a `.group:hover` ancestor otherwise.
       className="group relative flex flex-col gap-2"
       data-testid="collection-item-card"
       data-entity-type={item.entity_type}

--- a/frontend/features/collections/components/CollectionItemCard.tsx
+++ b/frontend/features/collections/components/CollectionItemCard.tsx
@@ -141,7 +141,12 @@ export function CollectionItemCard({
     <article
       ref={canReorder ? setNodeRef : undefined}
       style={sortableStyle}
-      className="relative flex flex-col gap-2"
+      // PSY-579: `group` lives on the <article> (not just the inner <Link>)
+      // so the hover-revealed Remove control — which is a sibling of the
+      // Link, not a descendant — can resolve `group-hover:opacity-100`
+      // correctly. Keeping `group` on the Link as well would be redundant
+      // (any descendant `group-hover:` walks up to the article and fires).
+      className="group relative flex flex-col gap-2"
       data-testid="collection-item-card"
       data-entity-type={item.entity_type}
     >
@@ -151,7 +156,7 @@ export function CollectionItemCard({
           outside so inline links in markdown notes remain independent. */}
       <Link
         href={entityUrl}
-        className="group flex flex-col gap-2 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        className="flex flex-col gap-2 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         aria-label={`${item.entity_name} (${typeLabel})`}
       >
         <div


### PR DESCRIPTION
## Summary
- Move Tailwind's `group` marker from the inner `<Link>` to the wrapping `<article>` so the hover-revealed Remove control (which is a sibling of the Link, not a descendant) can resolve `group-hover:opacity-100` and actually appear at opacity 1 on hover/focus-visible.
- Add a regression test asserting the Remove control's nearest `.group` ancestor IS the article. Behavior, handler wiring, and event-stop semantics are otherwise untouched.

## Test plan
- [x] cd frontend && bun run typecheck — passed
- [x] cd frontend && bun run test:run features/collections — 255 passed (added 1 regression test)

## Manual repro
Screenshots: `dogfood-output/PSY-579/screenshots/{grid-card-hover.png, grid-card-focus.png, after-remove.png}`.
- `grid-card-hover.png` — hovering the first card reveals the Remove X in the top-right of the cover; the other (un-hovered) cards do not show the X.
- `grid-card-focus.png` — programmatic-but-`:focus-visible`-matching focus on the Remove button shows it at opacity 1, with the destructive red color and focus ring.
- `after-remove.png` — clicking X opens the inline confirm; clicking Remove deletes the item (3 items → 2 items, Valley Fever gone). URL stays on the collection page (no card navigation triggered). Verified across Compact / Comfortable / Expanded densities (programmatic ancestor check + manual hover spot-check).

## Simplify
Trimmed the explanatory comments down to the non-obvious WHY (sibling-not-descendant Link relationship); dropped a "keeping `group` on the Link would be redundant" meta-narration line and the assertion-narration comments inside the regression test.

Closes PSY-579