### PR TITLE
PSY-581: default Add Items search open on empty collections

### DIFF
--- a/frontend/features/collections/components/CollectionDetail.test.tsx
+++ b/frontend/features/collections/components/CollectionDetail.test.tsx
@@ -1616,11 +1616,13 @@ describe('CollectionDetail', () => {
 
   describe('PSY-372 shows in Add Items search', () => {
     /**
-     * Helper: open the Add Items panel and seed the entity-search mock with
-     * results in the requested entity type so the dropdown renders rows the
-     * user can interact with. Calls userEvent.click on "Add Items" but does
-     * not type into the search box — typing is unnecessary because the hook
-     * is mocked and returns the seeded data regardless.
+     * Helper: seed the entity-search mock with results in the requested
+     * entity type so the dropdown renders rows the user can interact with,
+     * then type a 2+ char query to satisfy the dropdown's render gate. The
+     * hook is mocked so the typed value is irrelevant — only the length
+     * matters. PSY-581: the default fixture renders an empty collection
+     * (`items: []`) so the Add Items panel is now open on first paint and
+     * no toggle click is needed.
      */
     async function openAddItemsWith({
       shows = [],
@@ -1658,19 +1660,17 @@ describe('CollectionDetail', () => {
       }
       const user = userEvent.setup()
       render(<CollectionDetail slug="test-collection" />)
-      await user.click(screen.getByRole('button', { name: /Add Items/i }))
       // The Add Items panel only renders the dropdown when the query field
-      // has 2+ chars. Type something to satisfy the gate; the hook is mocked
-      // so the typed value is irrelevant.
+      // has 2+ chars. Type something to satisfy the gate.
       const input = screen.getByPlaceholderText(/Search artists, shows/)
       await user.type(input, 'tt')
       return user
     }
 
     it('placeholder copy includes "shows"', async () => {
-      const user = userEvent.setup()
+      // PSY-581: empty fixture defaults the panel open, so the input is
+      // immediately present without a toggle click.
       render(<CollectionDetail slug="test-collection" />)
-      await user.click(screen.getByRole('button', { name: /Add Items/i }))
 
       const input = screen.getByPlaceholderText(
         'Search artists, shows, venues, releases, labels, festivals...'
@@ -1752,6 +1752,62 @@ describe('CollectionDetail', () => {
       expect(screen.getByText('Dana Point, CA')).toBeInTheDocument()
       expect(screen.getByText('Artist')).toBeInTheDocument()
     })
+  })
+
+  // ──────────────────────────────────────────────
+  // PSY-581: Add Items default-open on empty collections
+  // ──────────────────────────────────────────────
+
+  describe('PSY-581 Add Items default-open on empty collections', () => {
+    /** Sample item used to drop the collection out of the empty state. */
+    const sampleItem = {
+      id: 100,
+      entity_type: 'artist',
+      entity_id: 1,
+      entity_name: 'Sample Artist',
+      entity_slug: 'sample-artist',
+      image_url: null,
+      position: 0,
+      added_by_user_id: 1,
+      added_by_name: 'testuser',
+      notes: null,
+      created_at: '2025-01-01T00:00:00Z',
+    }
+
+    it('renders the search input by default when the collection is empty', () => {
+      // Default fixture has `items: []` and the current user is the creator
+      // so the empty-state path applies.
+      render(<CollectionDetail slug="test-collection" />)
+
+      // Search input is immediately visible — no toggle click needed.
+      expect(
+        screen.getByPlaceholderText(
+          'Search artists, shows, venues, releases, labels, festivals...'
+        )
+      ).toBeInTheDocument()
+    })
+
+    it('keeps the panel collapsed by default when the collection has items', () => {
+      mockCollection.mockReturnValue({
+        data: makeCollection({ items: [sampleItem] }),
+        isLoading: false,
+        error: null,
+      })
+
+      render(<CollectionDetail slug="test-collection" />)
+
+      // Toggle button is rendered…
+      expect(
+        screen.getByRole('button', { name: /Add Items/i })
+      ).toBeInTheDocument()
+      // …and the search input is NOT yet rendered.
+      expect(
+        screen.queryByPlaceholderText(
+          'Search artists, shows, venues, releases, labels, festivals...'
+        )
+      ).not.toBeInTheDocument()
+    })
+
   })
 
   // ──────────────────────────────────────────────

--- a/frontend/features/collections/components/CollectionDetail.test.tsx
+++ b/frontend/features/collections/components/CollectionDetail.test.tsx
@@ -1796,18 +1796,15 @@ describe('CollectionDetail', () => {
 
       render(<CollectionDetail slug="test-collection" />)
 
-      // Toggle button is rendered…
       expect(
         screen.getByRole('button', { name: /Add Items/i })
       ).toBeInTheDocument()
-      // …and the search input is NOT yet rendered.
       expect(
         screen.queryByPlaceholderText(
           'Search artists, shows, venues, releases, labels, festivals...'
         )
       ).not.toBeInTheDocument()
     })
-
   })
 
   // ──────────────────────────────────────────────

--- a/frontend/features/collections/components/CollectionDetail.tsx
+++ b/frontend/features/collections/components/CollectionDetail.tsx
@@ -863,9 +863,18 @@ export function CollectionDetail({ slug }: CollectionDetailProps) {
         <CollectionGraph slug={slug} collectionTitle={collection.title} />
       )}
 
-      {/* Add Items (creator only) */}
+      {/* Add Items (creator only).
+          PSY-581: default the search panel open on empty collections so the
+          empty-state copy ("Add your first item using the search above")
+          is honest — the search IS visible. Non-empty collections keep the
+          collapsed default so the items list stays the focal point and the
+          page doesn't feel busier than it needs to. */}
       {isCreator && (
-        <AddItemsSection slug={slug} existingItems={items} />
+        <AddItemsSection
+          slug={slug}
+          existingItems={items}
+          defaultOpen={items.length === 0}
+        />
       )}
 
       {/* Items list */}
@@ -1591,11 +1600,20 @@ function CollectionItemRow({
 function AddItemsSection({
   slug,
   existingItems,
+  defaultOpen = false,
 }: {
   slug: string
   existingItems: CollectionItem[]
+  /**
+   * PSY-581: when true, the search panel renders open on first paint.
+   * The parent passes `items.length === 0` so empty collections show the
+   * search input immediately (matches the empty-state "use search above"
+   * copy); non-empty collections stay collapsed so the items list keeps
+   * the focal position. The collapse toggle is preserved either way.
+   */
+  defaultOpen?: boolean
 }) {
-  const [isOpen, setIsOpen] = useState(false)
+  const [isOpen, setIsOpen] = useState(defaultOpen)
   const [searchQuery, setSearchQuery] = useState('')
   const [addedMessage, setAddedMessage] = useState<string | null>(null)
   const addMutation = useAddCollectionItem()

--- a/frontend/features/collections/components/CollectionDetail.tsx
+++ b/frontend/features/collections/components/CollectionDetail.tsx
@@ -863,12 +863,9 @@ export function CollectionDetail({ slug }: CollectionDetailProps) {
         <CollectionGraph slug={slug} collectionTitle={collection.title} />
       )}
 
-      {/* Add Items (creator only).
-          PSY-581: default the search panel open on empty collections so the
-          empty-state copy ("Add your first item using the search above")
-          is honest — the search IS visible. Non-empty collections keep the
-          collapsed default so the items list stays the focal point and the
-          page doesn't feel busier than it needs to. */}
+      {/* Add Items (creator only). PSY-581: empty collections render the
+          search open so the "Add your first item using the search above"
+          copy is honest. */}
       {isCreator && (
         <AddItemsSection
           slug={slug}
@@ -1606,10 +1603,9 @@ function AddItemsSection({
   existingItems: CollectionItem[]
   /**
    * PSY-581: when true, the search panel renders open on first paint.
-   * The parent passes `items.length === 0` so empty collections show the
-   * search input immediately (matches the empty-state "use search above"
-   * copy); non-empty collections stay collapsed so the items list keeps
-   * the focal position. The collapse toggle is preserved either way.
+   * Parent passes `items.length === 0` so the empty-state "use search
+   * above" copy stays honest. Sets only the initial state — the X
+   * toggle still collapses/reopens the panel.
    */
   defaultOpen?: boolean
 }) {


### PR DESCRIPTION
## Summary
- Empty-state copy ("Add your first item using the search above") was misleading: the AddItemsSection rendered collapsed by default, so first-time creators scanning upward for a search field found only an "Add Items" button.
- Lift `items.length === 0` into a `defaultOpen` prop on `AddItemsSection`. Empty collections now render the search input immediately on first paint; non-empty collections keep the collapsed default so the items list stays the focal point. The X close button still toggles the panel either way.

## Test plan
- [x] `cd frontend && bun run typecheck` — passed
- [x] `cd frontend && bun run test:run features/collections` — passed (256 tests; +2 new for PSY-581 default-open/collapsed)

## Manual repro
Screenshots: `dogfood-output/PSY-581/screenshots/{empty-collection-default-open.png, non-empty-collection-collapsed.png}`. Verified end-to-end against the dispatch stack: empty collection shows the search input immediately at the top of the page; non-empty preserves the collapsed "Add Items" button default.

## Simplify
Trimmed editorialising prose from the parent JSX comment and the `defaultOpen` prop's JSDoc; dropped WHAT-narrating comments inside the non-empty-collapsed test. Tests still 256/256.

Closes PSY-581