### PR TITLE
PSY-580: apply browse-search query on Yours tab

### DIFF
--- a/backend/internal/api/handlers/community/collection.go
+++ b/backend/internal/api/handlers/community/collection.go
@@ -674,8 +674,12 @@ func (h *CollectionHandler) SetFeaturedHandler(ctx context.Context, req *SetFeat
 
 // GetUserCollectionsHandlerRequest represents the request for getting the authenticated user's collections
 type GetUserCollectionsHandlerRequest struct {
-	Limit  int `query:"limit" required:"false" doc:"Max results (default 20)" example:"20"`
-	Offset int `query:"offset" required:"false" doc:"Offset for pagination" example:"0"`
+	// PSY-580: search across title, description, item notes, and tag
+	// names/aliases — same field expansion as the public browse listing
+	// (PSY-355). Empty / whitespace disables the predicate.
+	Search string `query:"search" required:"false" doc:"Search across collection title, description, item notes, and tag names/aliases (case-insensitive substring)"`
+	Limit  int    `query:"limit" required:"false" doc:"Max results (default 20)" example:"20"`
+	Offset int    `query:"offset" required:"false" doc:"Offset for pagination" example:"0"`
 }
 
 // GetUserCollectionsHandlerResponse represents the response for the user collections endpoint
@@ -698,7 +702,12 @@ func (h *CollectionHandler) GetUserCollectionsHandler(ctx context.Context, req *
 		limit = 20
 	}
 
-	collections, total, err := h.collectionService.GetUserCollections(user.ID, limit, req.Offset)
+	// PSY-580: trim whitespace at the boundary so an all-spaces query never
+	// reaches the SQL layer. Mirrors the public ListCollectionsHandler
+	// short-circuit (PSY-520 + PSY-355 convention).
+	search := strings.TrimSpace(req.Search)
+
+	collections, total, err := h.collectionService.GetUserCollections(user.ID, search, limit, req.Offset)
 	if err != nil {
 		return nil, huma.Error500InternalServerError("Failed to fetch collections", err)
 	}

--- a/backend/internal/api/handlers/shared/testhelpers/mocks_gen.go
+++ b/backend/internal/api/handlers/shared/testhelpers/mocks_gen.go
@@ -702,7 +702,7 @@ type MockCollectionService struct {
 	LikeFn func(string, uint) (*contracts.CollectionLikeResponse, error)
 	UnlikeFn func(string, uint) (*contracts.CollectionLikeResponse, error)
 	GetStatsFn func(string) (*contracts.CollectionStatsResponse, error)
-	GetUserCollectionsFn func(uint, int, int) ([]*contracts.CollectionListResponse, int64, error)
+	GetUserCollectionsFn func(uint, string, int, int) ([]*contracts.CollectionListResponse, int64, error)
 	GetUserCollectionsContainingEntityFn func(uint, string, uint) ([]uint, error)
 	GetEntityCollectionsFn func(string, uint, uint, int) ([]*contracts.CollectionListResponse, error)
 	GetUserPublicCollectionsFn func(uint, int, int) ([]*contracts.CollectionListResponse, int64, error)
@@ -809,9 +809,9 @@ func (m *MockCollectionService) GetStats(slug string) (*contracts.CollectionStat
 	}
 	return nil, nil
 }
-func (m *MockCollectionService) GetUserCollections(userID uint, limit int, offset int) ([]*contracts.CollectionListResponse, int64, error) {
+func (m *MockCollectionService) GetUserCollections(userID uint, search string, limit int, offset int) ([]*contracts.CollectionListResponse, int64, error) {
 	if m.GetUserCollectionsFn != nil {
-		return m.GetUserCollectionsFn(userID, limit, offset)
+		return m.GetUserCollectionsFn(userID, search, limit, offset)
 	}
 	return nil, 0, nil
 }

--- a/backend/internal/services/community/collection.go
+++ b/backend/internal/services/community/collection.go
@@ -704,27 +704,7 @@ func (s *CollectionService) ListCollections(filters contracts.CollectionFilters,
 	// `collection_items.notes`, `tags.name`, and `tag_aliases.alias`.
 	searchTerm := strings.TrimSpace(filters.Search)
 	if searchTerm != "" {
-		pattern := "%" + searchTerm + "%"
-		query = query.Where(`
-			collections.title ILIKE ?
-			OR collections.description ILIKE ?
-			OR EXISTS (
-				SELECT 1 FROM collection_items ci
-				WHERE ci.collection_id = collections.id
-				  AND ci.notes ILIKE ?
-			)
-			OR EXISTS (
-				SELECT 1 FROM entity_tags et
-				JOIN tags t ON t.id = et.tag_id
-				LEFT JOIN tag_aliases ta ON ta.tag_id = t.id
-				WHERE et.entity_type = ?
-				  AND et.entity_id = collections.id
-				  AND (t.name ILIKE ? OR ta.alias ILIKE ?)
-			)
-		`,
-			pattern, pattern, pattern,
-			catalogm.TagEntityCollection, pattern, pattern,
-		)
+		query = applyCollectionSearchWhere(query, searchTerm)
 	}
 	if filters.EntityType != "" {
 		query = query.Where("id IN (?)",
@@ -879,6 +859,47 @@ func applyCollectionSort(query *gorm.DB, sort string) *gorm.DB {
 		) DESC`).Order("collections.updated_at DESC")
 	}
 	return query.Order("updated_at DESC")
+}
+
+// applyCollectionSearchWhere appends the PSY-355 expanded-search OR clause
+// to the query, matching across:
+//
+//	1. collections.title           (exact field on the row)
+//	2. collections.description     (raw markdown source on the row)
+//	3. any item's notes            (correlated EXISTS over collection_items)
+//	4. any applied tag name/alias  (correlated EXISTS over entity_tags +
+//	                               tags + tag_aliases for the polymorphic
+//	                               collection entity)
+//
+// Caller is responsible for trimming whitespace and short-circuiting the
+// empty case BEFORE invoking this helper — passing an empty searchTerm
+// here would widen the result set with `%%`. Both ListCollections (public
+// browse) and GetUserCollections (Yours tab — PSY-580) share this clause
+// so the per-tab endpoint separation doesn't drift into two SQL
+// implementations. Pair this with applySearchRelevanceOrder for the
+// matching tier rank ORDER BY.
+func applyCollectionSearchWhere(query *gorm.DB, searchTerm string) *gorm.DB {
+	pattern := "%" + searchTerm + "%"
+	return query.Where(`
+		collections.title ILIKE ?
+		OR collections.description ILIKE ?
+		OR EXISTS (
+			SELECT 1 FROM collection_items ci
+			WHERE ci.collection_id = collections.id
+			  AND ci.notes ILIKE ?
+		)
+		OR EXISTS (
+			SELECT 1 FROM entity_tags et
+			JOIN tags t ON t.id = et.tag_id
+			LEFT JOIN tag_aliases ta ON ta.tag_id = t.id
+			WHERE et.entity_type = ?
+			  AND et.entity_id = collections.id
+			  AND (t.name ILIKE ? OR ta.alias ILIKE ?)
+		)
+	`,
+		pattern, pattern, pattern,
+		catalogm.TagEntityCollection, pattern, pattern,
+	)
 }
 
 // applySearchRelevanceOrder is the search-rank ORDER BY clause used when
@@ -1490,7 +1511,7 @@ func (s *CollectionService) GetStats(slug string) (*contracts.CollectionStatsRes
 }
 
 // GetUserCollections retrieves collections created by or subscribed to by a user
-func (s *CollectionService) GetUserCollections(userID uint, limit, offset int) ([]*contracts.CollectionListResponse, int64, error) {
+func (s *CollectionService) GetUserCollections(userID uint, search string, limit, offset int) ([]*contracts.CollectionListResponse, int64, error) {
 	if s.db == nil {
 		return nil, 0, fmt.Errorf("database not initialized")
 	}
@@ -1507,14 +1528,34 @@ func (s *CollectionService) GetUserCollections(userID uint, limit, offset int) (
 	query := s.db.Model(&communitym.Collection{}).
 		Where("creator_id = ? OR id IN (?)", userID, subQuery)
 
+	// PSY-580: Yours tab now honours the search box. Reuse the public-browse
+	// field expansion (title / description / item notes / tag name+aliases —
+	// PSY-355) so the search behaviour is identical regardless of which tab
+	// the user is on. Whitespace-only queries short-circuit at the handler
+	// boundary; the trim here is defensive for direct service callers.
+	searchTerm := strings.TrimSpace(search)
+	if searchTerm != "" {
+		query = applyCollectionSearchWhere(query, searchTerm)
+	}
+
 	// Count total
 	var total int64
 	if err := query.Count(&total).Error; err != nil {
 		return nil, 0, fmt.Errorf("failed to count user collections: %w", err)
 	}
 
+	// PSY-580: when search is active, lead with the same tier rank used by
+	// the public browse path (title > description > notes > tag, then
+	// updated_at DESC). No-search path keeps the long-standing
+	// updated_at DESC ordering that the library tab expects.
 	var collections []communitym.Collection
-	if err := query.Order("updated_at DESC").Limit(limit).Offset(offset).Find(&collections).Error; err != nil {
+	if searchTerm != "" {
+		pattern := "%" + searchTerm + "%"
+		query = applySearchRelevanceOrder(query, pattern).Limit(limit).Offset(offset)
+	} else {
+		query = query.Order("updated_at DESC").Limit(limit).Offset(offset)
+	}
+	if err := query.Find(&collections).Error; err != nil {
 		return nil, 0, fmt.Errorf("failed to get user collections: %w", err)
 	}
 

--- a/backend/internal/services/community/collection_test.go
+++ b/backend/internal/services/community/collection_test.go
@@ -1661,7 +1661,7 @@ func (suite *CollectionServiceIntegrationTestSuite) TestGetUserCollections_Creat
 	suite.createBasicCollection(user, "My Collection 1")
 	suite.createBasicCollection(user, "My Collection 2")
 
-	resp, total, err := suite.collectionService.GetUserCollections(user.ID, 20, 0)
+	resp, total, err := suite.collectionService.GetUserCollections(user.ID, "", 20, 0)
 
 	suite.Require().NoError(err)
 	suite.Equal(int64(2), total)
@@ -1679,7 +1679,7 @@ func (suite *CollectionServiceIntegrationTestSuite) TestGetUserCollections_Inclu
 	// Subscriber's own collection
 	suite.createBasicCollection(subscriber, "Own Collection")
 
-	resp, total, err := suite.collectionService.GetUserCollections(subscriber.ID, 20, 0)
+	resp, total, err := suite.collectionService.GetUserCollections(subscriber.ID, "", 20, 0)
 
 	suite.Require().NoError(err)
 	suite.Equal(int64(2), total) // 1 created + 1 subscribed
@@ -1689,11 +1689,193 @@ func (suite *CollectionServiceIntegrationTestSuite) TestGetUserCollections_Inclu
 func (suite *CollectionServiceIntegrationTestSuite) TestGetUserCollections_Empty() {
 	user := suite.createTestUser("EmptyUserColl")
 
-	resp, total, err := suite.collectionService.GetUserCollections(user.ID, 20, 0)
+	resp, total, err := suite.collectionService.GetUserCollections(user.ID, "", 20, 0)
 
 	suite.Require().NoError(err)
 	suite.Equal(int64(0), total)
 	suite.Empty(resp)
+}
+
+// =============================================================================
+// PSY-580: Yours-tab search applies the same field-expansion as the public
+// browse listing (PSY-355). Mirrors the public-browse search test cases so
+// the two paths stay in sync via the shared applyCollectionSearchWhere +
+// applySearchRelevanceOrder helpers.
+// =============================================================================
+
+// TestGetUserCollections_Search_TitleMatch confirms a title-only match wins
+// when the search box is non-empty on the Yours tab — the bug repro from the
+// ticket (typing nonsense yields all of the user's collections) is gone.
+func (suite *CollectionServiceIntegrationTestSuite) TestGetUserCollections_Search_TitleMatch() {
+	user := suite.createTestUser("YoursTitleSearcher")
+	suite.createBasicCollection(user, "Phoenix Punk Bands")
+	suite.createBasicCollection(user, "Chicago Jazz Venues")
+
+	resp, total, err := suite.collectionService.GetUserCollections(user.ID, "punk", 20, 0)
+
+	suite.Require().NoError(err)
+	suite.Equal(int64(1), total)
+	suite.Require().Len(resp, 1)
+	suite.Equal("Phoenix Punk Bands", resp[0].Title)
+}
+
+// TestGetUserCollections_Search_NotesMatch covers the per-item notes branch
+// (PSY-355 tier 3) — the second high-impact match type the ticket called out.
+func (suite *CollectionServiceIntegrationTestSuite) TestGetUserCollections_Search_NotesMatch() {
+	user := suite.createTestUser("YoursNotesSearcher")
+	target := suite.createBasicCollection(user, "Generic Title")
+	suite.createBasicCollection(user, "Other Generic Title")
+
+	suite.addItemWithNotes(target.Slug, user.ID,
+		"saw them open for slowdive at the warehouse — wall of sound")
+
+	resp, total, err := suite.collectionService.GetUserCollections(
+		user.ID, "slowdive", 20, 0,
+	)
+
+	suite.Require().NoError(err)
+	suite.Equal(int64(1), total)
+	suite.Require().Len(resp, 1)
+	suite.Equal(target.ID, resp[0].ID)
+}
+
+// TestGetUserCollections_Search_TagAliasMatch verifies tag-name and
+// tag-alias resolution works on the Yours-tab path. The test seeds an alias
+// row and queries by the alias text — the polymorphic entity_tags subquery
+// must surface the collection tagged with the canonical name.
+func (suite *CollectionServiceIntegrationTestSuite) TestGetUserCollections_Search_TagAliasMatch() {
+	user := suite.createTestUser("YoursAliasSearcher")
+	suite.promoteContributor(user)
+
+	target := suite.createBasicCollection(user, "Untitled Yours Mix")
+	suite.createBasicCollection(user, "Other Untitled")
+
+	tag, err := suite.tagService.CreateTag("psychedelic-rock", nil, nil, catalogm.TagCategoryGenre, false, &user.ID)
+	suite.Require().NoError(err)
+	suite.Require().NoError(suite.db.Create(&catalogm.TagAlias{
+		TagID: tag.ID,
+		Alias: "psych-rock",
+	}).Error)
+
+	_, err = suite.collectionService.AddTagToCollection(target.Slug, user.ID,
+		&contracts.AddCollectionTagRequest{TagID: tag.ID})
+	suite.Require().NoError(err)
+
+	resp, total, err := suite.collectionService.GetUserCollections(
+		user.ID, "psych-rock", 20, 0,
+	)
+
+	suite.Require().NoError(err)
+	suite.Equal(int64(1), total)
+	suite.Require().Len(resp, 1)
+	suite.Equal(target.ID, resp[0].ID)
+}
+
+// TestGetUserCollections_Search_NoMatch covers the original ticket repro:
+// typing nonsense returns an empty list (not the full library).
+func (suite *CollectionServiceIntegrationTestSuite) TestGetUserCollections_Search_NoMatch() {
+	user := suite.createTestUser("YoursNoMatchSearcher")
+	suite.createBasicCollection(user, "Alpha")
+	suite.createBasicCollection(user, "Beta")
+	suite.createBasicCollection(user, "Gamma")
+
+	resp, total, err := suite.collectionService.GetUserCollections(
+		user.ID, "qzxqzxqzxnonsense", 20, 0,
+	)
+
+	suite.Require().NoError(err)
+	suite.Equal(int64(0), total, "nonsense search must return zero matches")
+	suite.Empty(resp, "rendered list must be empty for a no-match search")
+}
+
+// TestGetUserCollections_Search_Empty_ShortCircuits confirms that clearing
+// the search box re-shows all of the user's collections — the ticket's
+// "Clearing the search re-shows all of the user's collections" AC.
+func (suite *CollectionServiceIntegrationTestSuite) TestGetUserCollections_Search_Empty_ShortCircuits() {
+	user := suite.createTestUser("YoursEmptySearch")
+	suite.createBasicCollection(user, "Alpha")
+	suite.createBasicCollection(user, "Beta")
+	suite.createBasicCollection(user, "Gamma")
+
+	resp, total, err := suite.collectionService.GetUserCollections(user.ID, "", 20, 0)
+
+	suite.Require().NoError(err)
+	suite.Equal(int64(3), total)
+	suite.Len(resp, 3)
+}
+
+// TestGetUserCollections_Search_Whitespace_ShortCircuits guards the
+// service-direct path (the handler trims at the boundary too) — a
+// whitespace-only query must not fragment the SQL OR clause.
+func (suite *CollectionServiceIntegrationTestSuite) TestGetUserCollections_Search_Whitespace_ShortCircuits() {
+	user := suite.createTestUser("YoursWhitespace")
+	suite.createBasicCollection(user, "Alpha")
+	suite.createBasicCollection(user, "Beta")
+
+	resp, total, err := suite.collectionService.GetUserCollections(user.ID, "   \t  ", 20, 0)
+
+	suite.Require().NoError(err)
+	suite.Equal(int64(2), total)
+	suite.Len(resp, 2)
+}
+
+// TestGetUserCollections_Search_OwnPrivateNotLeaked guards the privacy
+// invariant: search must only widen the match within the user's own +
+// subscribed-to set, never leak some other user's private collections.
+func (suite *CollectionServiceIntegrationTestSuite) TestGetUserCollections_Search_OwnPrivateNotLeaked() {
+	owner := suite.createTestUser("YoursPrivacyOwner")
+	stranger := suite.createTestUser("YoursPrivacyStranger")
+
+	// Owner's own private collection — should appear when owner searches.
+	ownTarget := suite.createBasicCollection(owner, "Owner Private Punk")
+
+	// Stranger's private collection with a matching title — must NOT appear
+	// in the owner's Yours list, even though the search would otherwise hit
+	// it. is_public=false on creation; no subscription link.
+	suite.createBasicCollection(stranger, "Stranger Private Punk")
+
+	resp, total, err := suite.collectionService.GetUserCollections(
+		owner.ID, "punk", 20, 0,
+	)
+
+	suite.Require().NoError(err)
+	suite.Equal(int64(1), total, "owner's search must not surface stranger's private collection")
+	suite.Require().Len(resp, 1)
+	suite.Equal(ownTarget.ID, resp[0].ID)
+}
+
+// TestGetUserCollections_Search_RelevanceTierOrder mirrors the public-browse
+// tier-rank test on the Yours-tab path. Confirms the shared
+// applySearchRelevanceOrder helper kicks in on the user-library query too,
+// so a title hit beats a description hit beats a notes hit beats a tag hit.
+func (suite *CollectionServiceIntegrationTestSuite) TestGetUserCollections_Search_RelevanceTierOrder() {
+	user := suite.createTestUser("YoursRelevance")
+	suite.promoteContributor(user)
+
+	tagOnly := suite.createBasicCollection(user, "Tag Only Yours")
+	_, err := suite.collectionService.AddTagToCollection(tagOnly.Slug, user.ID,
+		&contracts.AddCollectionTagRequest{TagName: "rocketship"})
+	suite.Require().NoError(err)
+
+	notesOnly := suite.createBasicCollection(user, "Notes Only Yours")
+	suite.addItemWithNotes(notesOnly.Slug, user.ID, "rocketship-only-yours")
+
+	descOnly := suite.createBasicCollection(user, "Description Only Yours")
+	suite.updateCollectionDescription(descOnly.Slug, user.ID, "a deep dive into rocketship sounds")
+
+	titleOnly := suite.createBasicCollection(user, "Rocketship Yours Best Of")
+
+	resp, total, err := suite.collectionService.GetUserCollections(
+		user.ID, "rocketship", 20, 0,
+	)
+
+	suite.Require().NoError(err)
+	suite.Equal(int64(4), total)
+	suite.Require().Len(resp, 4)
+	suite.Equal(titleOnly.ID, resp[0].ID, "tier 1: title match leads")
+	suite.Equal(descOnly.ID, resp[1].ID, "tier 2: description match second")
+	suite.Equal(notesOnly.ID, resp[2].ID, "tier 3: notes match third")
+	suite.Equal(tagOnly.ID, resp[3].ID, "tier 4: tag match last")
 }
 
 // =============================================================================
@@ -1904,7 +2086,7 @@ func (suite *CollectionServiceIntegrationTestSuite) TestGetUserCollections_NewSi
 		Update("created_at", visitedAt.Add(45*time.Minute)).Error)
 
 	// Fetch via the user-collections endpoint.
-	resp, _, err := suite.collectionService.GetUserCollections(subscriber.ID, 20, 0)
+	resp, _, err := suite.collectionService.GetUserCollections(subscriber.ID, "", 20, 0)
 	suite.Require().NoError(err)
 	suite.Require().Len(resp, 1)
 	suite.Equal(1, resp[0].NewSinceLastVisit, "expected exactly one new item since visit (excluding self-add)")
@@ -1933,7 +2115,7 @@ func (suite *CollectionServiceIntegrationTestSuite) TestGetUserCollections_NewSi
 	})
 	suite.Require().NoError(err)
 
-	resp, _, err := suite.collectionService.GetUserCollections(subscriber.ID, 20, 0)
+	resp, _, err := suite.collectionService.GetUserCollections(subscriber.ID, "", 20, 0)
 	suite.Require().NoError(err)
 	suite.Require().Len(resp, 1)
 	suite.Equal(1, resp[0].NewSinceLastVisit)
@@ -2251,7 +2433,7 @@ func (suite *CollectionServiceIntegrationTestSuite) TestUserLibrary_NotFilteredB
 	user := suite.createTestUser("LibraryOwner")
 	suite.createBareCollection(user, "Below Gate Library")
 
-	resp, total, err := suite.collectionService.GetUserCollections(user.ID, 20, 0)
+	resp, total, err := suite.collectionService.GetUserCollections(user.ID, "", 20, 0)
 	suite.Require().NoError(err)
 	suite.Equal(int64(1), total, "user's own library must include under-gate collections")
 	suite.Require().Len(resp, 1)

--- a/backend/internal/services/contracts/collection.go
+++ b/backend/internal/services/contracts/collection.go
@@ -398,7 +398,13 @@ type CollectionServiceInterface interface {
 	// when the like doesn't exist is a no-op. PSY-352.
 	Unlike(slug string, userID uint) (*CollectionLikeResponse, error)
 	GetStats(slug string) (*CollectionStatsResponse, error)
-	GetUserCollections(userID uint, limit, offset int) ([]*CollectionListResponse, int64, error)
+	// GetUserCollections returns the user's own + subscribed-to collections.
+	// `search` is optional (PSY-580); empty/whitespace disables the predicate
+	// and returns the full library. When set, it expands across title,
+	// description, item notes, and tag names/aliases — same fields as the
+	// public browse listing (PSY-355). Tier-ranked relevance ORDER BY is
+	// applied when search is non-empty; otherwise default updated_at DESC.
+	GetUserCollections(userID uint, search string, limit, offset int) ([]*CollectionListResponse, int64, error)
 	// GetUserCollectionsContainingEntity returns the IDs of the user's
 	// editable collections (creator + subscribed) that already contain
 	// the supplied entity. Backs the multi-select Add-to-Collection

--- a/frontend/features/collections/components/CollectionList.test.tsx
+++ b/frontend/features/collections/components/CollectionList.test.tsx
@@ -36,7 +36,9 @@ const mockCreateMutate = vi.fn()
 
 vi.mock('../hooks', () => ({
   useCollections: (params: unknown) => mockUseCollections(params),
-  useMyCollections: () => mockUseMyCollections(),
+  // PSY-580: Yours-tab hook now takes an optional `{ search }` arg. Forward
+  // it to the spy so tests can assert the search box is wired through.
+  useMyCollections: (params: unknown) => mockUseMyCollections(params),
   useCreateCollection: () => ({
     mutate: mockCreateMutate,
     isPending: false,
@@ -331,6 +333,79 @@ describe('CollectionList', () => {
       const searchInput = screen.getByPlaceholderText('Search collections...')
       await user.type(searchInput, 'nonexistent')
       expect(screen.getByText('No collections found')).toBeInTheDocument()
+    })
+
+    // PSY-580 regression: previously the Yours tab silently ignored the
+    // search box because useMyCollections() didn't accept any params, so
+    // every keystroke widened the cache hit but the rendered list never
+    // narrowed. Verify the typed term flows into the hook now. Note:
+    // useMyCollections is also called from the inline CreateCollectionForm
+    // (with no args) so we filter to the call coming from the list view —
+    // the one whose first arg is the params object.
+    it('forwards search term to useMyCollections on the Yours tab', async () => {
+      const user = userEvent.setup()
+      mockAuthContext.mockReturnValue({
+        user: { id: '1' },
+        isAuthenticated: true,
+        isLoading: false,
+        logout: vi.fn(),
+      })
+      mockUseCollections.mockReturnValue({
+        data: { collections: [] },
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      })
+      mockUseMyCollections.mockReturnValue({
+        data: { collections: [] },
+        isLoading: false,
+        error: null,
+      })
+
+      render(<CollectionList />)
+      const searchInput = screen.getByPlaceholderText('Search collections...')
+      await user.type(searchInput, 'shoegaze')
+
+      // CreateCollectionForm also invokes useMyCollections() with no args —
+      // filter to the list view's call (the one that carries the search arg).
+      const searchCalls = mockUseMyCollections.mock.calls.filter(
+        (args: unknown[]) => args[0] !== undefined
+      )
+      expect(searchCalls.length).toBeGreaterThan(0)
+      const lastSearchCall = searchCalls[searchCalls.length - 1]
+      expect(lastSearchCall[0]).toEqual({ search: 'shoegaze' })
+    })
+
+    // No search → list view passes `{ search: undefined }`. Confirms the
+    // empty case doesn't pass an empty string through (which would still
+    // differ from undefined and could fragment the query cache).
+    it('passes search: undefined when the box is empty', () => {
+      mockAuthContext.mockReturnValue({
+        user: { id: '1' },
+        isAuthenticated: true,
+        isLoading: false,
+        logout: vi.fn(),
+      })
+      mockUseCollections.mockReturnValue({
+        data: { collections: [] },
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      })
+      mockUseMyCollections.mockReturnValue({
+        data: { collections: [] },
+        isLoading: false,
+        error: null,
+      })
+
+      render(<CollectionList />)
+      // List-view call is the one with a params object (the form's call has
+      // no args); confirm the params shape is `{ search: undefined }`.
+      const listViewCall = mockUseMyCollections.mock.calls.find(
+        (args: unknown[]) => args[0] !== undefined
+      )
+      expect(listViewCall).toBeDefined()
+      expect(listViewCall![0]).toEqual({ search: undefined })
     })
   })
 

--- a/frontend/features/collections/components/CollectionList.tsx
+++ b/frontend/features/collections/components/CollectionList.tsx
@@ -87,12 +87,16 @@ export function CollectionList() {
     tag: tagFilter || undefined,
   })
 
-  // Fetch user's own collections (only when on "yours" tab and authenticated)
+  // Fetch user's own collections (only when on "yours" tab and authenticated).
+  // PSY-580: pass the same search term the public-browse hook receives so the
+  // Yours tab filters via the backend's expanded search (title / description /
+  // item notes / tag names+aliases — PSY-355). Empty / whitespace short-
+  // circuits inside the hook.
   const {
     data: myData,
     isLoading: myLoading,
     error: myError,
-  } = useMyCollections()
+  } = useMyCollections({ search: searchTerm || undefined })
 
   // Determine which data to use based on active tab
   const isYoursTab = activeTab === 'yours'

--- a/frontend/features/collections/hooks/index.test.tsx
+++ b/frontend/features/collections/hooks/index.test.tsx
@@ -36,6 +36,13 @@ vi.mock('@/lib/queryClient', () => ({
       detail: (slug: string) => ['collections', 'detail', slug],
       stats: (slug: string) => ['collections', 'stats', slug],
       my: ['collections', 'my'],
+      // PSY-580: parameterized "Yours tab" key — bare invocation collapses to
+      // the same key as `my` so legacy callers and mutation invalidations
+      // continue to share the cache slot. Distinct searches get distinct keys.
+      myList: (params?: { search?: string }) =>
+        params && Object.values(params).some((v) => v != null && v !== '')
+          ? ['collections', 'my', params]
+          : ['collections', 'my'],
       // PSY-359: pre-check answer for "does the user already have this entity
       // in any of their collections" — drives the multi-select popover.
       containing: (entityType: string, entityId: number) =>
@@ -175,6 +182,55 @@ describe('Collection query hooks', () => {
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true))
       expect(mockApiRequest).toHaveBeenCalledWith('/auth/collections')
+    })
+
+    // PSY-580: passes the search term through as a `?search=` query param so
+    // the backend applies the same field-expansion (title/description/notes/
+    // tag-name+aliases) as the public browse listing.
+    it('forwards search term as ?search= query param', async () => {
+      mockApiRequest.mockResolvedValueOnce({ collections: [], total: 0 })
+
+      const { result } = renderHook(
+        () => useMyCollections({ search: 'shoegaze' }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/auth/collections?search=shoegaze'
+      )
+    })
+
+    // Empty / whitespace-only searches must not append a useless query param —
+    // the bare endpoint URL is the cached cache key, and adding `?search=` to
+    // it would silently fragment the cache.
+    it('omits the search param when the value is whitespace', async () => {
+      mockApiRequest.mockResolvedValueOnce({ collections: [], total: 0 })
+
+      const { result } = renderHook(
+        () => useMyCollections({ search: '   \t  ' }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      expect(mockApiRequest).toHaveBeenCalledWith('/auth/collections')
+    })
+
+    // URL-encodes search terms with reserved characters so a query like
+    // "post-punk & jazz" round-trips through the URL bar without
+    // accidentally splitting on the ampersand.
+    it('URL-encodes search terms with reserved characters', async () => {
+      mockApiRequest.mockResolvedValueOnce({ collections: [], total: 0 })
+
+      const { result } = renderHook(
+        () => useMyCollections({ search: 'post-punk & jazz' }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/auth/collections?search=post-punk%20%26%20jazz'
+      )
     })
   })
 

--- a/frontend/features/collections/hooks/index.ts
+++ b/frontend/features/collections/hooks/index.ts
@@ -122,18 +122,33 @@ export function useCollectionStats(slug: string, options?: { enabled?: boolean }
   })
 }
 
-/** Fetch the authenticated user's own collections */
-export function useMyCollections() {
+/**
+ * Fetch the authenticated user's own collections.
+ *
+ * PSY-580: optional `search` param. When set, the backend expands the match
+ * across title, description, item notes, and tag names/aliases (same field
+ * coverage as the public browse listing — PSY-355). Empty / whitespace
+ * disables the predicate and returns the full library. The query key is
+ * scoped per-search so distinct searches don't share a cache entry, but
+ * the bare prefix matches mutation invalidations on `queryKeys.collections.my`.
+ */
+export function useMyCollections(params?: { search?: string }) {
+  const search = params?.search?.trim() || undefined
   return useQuery({
-    queryKey: queryKeys.collections.my,
-    queryFn: () =>
-      apiRequest<{ collections: Collection[]; total: number }>(
-        API_ENDPOINTS.COLLECTIONS.MY
-      ).then((data) => ({
-        collections: data.collections ?? [],
-        total: data.total,
-      })),
+    queryKey: queryKeys.collections.myList({ search }),
+    queryFn: () => {
+      const url = search
+        ? `${API_ENDPOINTS.COLLECTIONS.MY}?search=${encodeURIComponent(search)}`
+        : API_ENDPOINTS.COLLECTIONS.MY
+      return apiRequest<{ collections: Collection[]; total: number }>(url).then(
+        (data) => ({
+          collections: data.collections ?? [],
+          total: data.total,
+        })
+      )
+    },
     staleTime: 5 * 60 * 1000,
+    placeholderData: keepPreviousData,
   })
 }
 

--- a/frontend/lib/queryClient.ts
+++ b/frontend/lib/queryClient.ts
@@ -255,7 +255,20 @@ export const queryKeys = {
     stats: (slug: string) => ['collections', 'stats', slug] as const,
     // PSY-366: artist-relationship subgraph for the collection's artist items.
     graph: (slug: string, types?: string[]) => ['collections', 'graph', slug, types ?? null] as const,
+    // Bare prefix used by mutation invalidations — TanStack matches every
+    // descendant query (myList(...) variants below) under this prefix.
     my: ['collections', 'my'] as const,
+    /**
+     * PSY-580: parameterized "Yours tab" key. Pass `{ search }` to scope a
+     * query to a specific search term so loading + cached results don't
+     * bleed across distinct searches. Bare invocation (no params) lands at
+     * the same key as `my`, so existing callers that didn't search continue
+     * to share that cache entry.
+     */
+    myList: (params?: { search?: string }) =>
+      params && Object.values(params).some((v) => v != null && v !== '')
+        ? (['collections', 'my', params] as const)
+        : (['collections', 'my'] as const),
     // PSY-359: which of the user's own collections already contain a given
     // entity. Drives the pre-check state on the multi-select Add-to-Collection
     // popover. Cached per (entityType, entityId) so each entity page has its


### PR DESCRIPTION
## Summary
- Yours tab silently ignored the search box because `useMyCollections()` took no params and `GetUserCollections` (backend) only accepted userID/limit/offset. Typing a no-match string still rendered every owned + subscribed collection.
- Wire the same field-expansion the public browse listing uses (PSY-355: title, description, item notes, tag names+aliases) into the Yours-tab path. Extracted `applyCollectionSearchWhere` so both `ListCollections` and `GetUserCollections` share the WHERE clause; reused `applySearchRelevanceOrder` for the tier rank when search is active.
- Frontend `useMyCollections` takes optional `{ search }` keyed per-search via new `queryKeys.collections.myList`. Bare `my` prefix is preserved for mutation invalidations; `myList()` collapses to the bare key when search is empty so legacy callers (`AddToCollectionButton`, `CreateCollectionForm`) keep sharing the cache slot.

## Test plan
- [x] cd backend && go build ./... — passed
- [x] cd backend && go test ./internal/api/handlers/community/... ./internal/services/community/... — passed (8 new search tests in `collection_test.go`)
- [x] cd frontend && bun run typecheck — passed
- [x] cd frontend && bun run test:run features/collections — passed (3 new hook tests + 2 new CollectionList tests, 259 total)

## Manual repro
Stack up isolated; signed in as `e2e-admin@test.local`; created 3 collections: "Phoenix Punk Bands", "Chicago Jazz Venues", "Shoegaze Essentials". Yours tab + search "punk" → only "Phoenix Punk Bands" rendered. Search "qzxqzxqzxnonsense" → empty state ("No collections found"). Cleared search → all 3 collections returned. Screenshot: `dogfood-output/PSY-580/screenshots/02-yours-tab-search-punk.png`.

## Simplify
Code reviewed across reuse / quality / efficiency dimensions; no changes needed. Implementation reuses `applySearchRelevanceOrder`, factors `applyCollectionSearchWhere` to avoid SQL duplication across the public + Yours paths, and mirrors existing patterns (`strings.TrimSpace` boundary trim, `placeholderData: keepPreviousData` cache option).

Closes PSY-580

🤖 Generated with [Claude Code](https://claude.com/claude-code)