### PR TITLE
PSY-626: fix dispatch-stack helpers blocking real isolated/shared use

### DIFF
--- a/frontend/app/api/[...path]/route.ts
+++ b/frontend/app/api/[...path]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
 import * as Sentry from '@sentry/nextjs'
 
-const BACKEND_URL = 'http://localhost:8080'
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8080'
 
 /**
  * Proxy all API requests to the backend.

--- a/frontend/e2e/setup-db.sh
+++ b/frontend/e2e/setup-db.sh
@@ -13,9 +13,48 @@ COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.e2e.yml}"
 
 echo "==> Waiting for migrate service to finish..."
 # Block until the migrate container exits; propagates its exit code.
-# (docker compose wait is available since Compose v2.23)
-if ! docker compose -p "$COMPOSE_PROJECT" -f "$COMPOSE_FILE" wait migrate; then
-  echo "ERROR: Migrations failed. Container logs:"
+#
+# `docker compose wait` is unreliable here: it returns "no containers for
+# project" with exit 1 once the container has already exited, which happens
+# when the parent already used `up -d --wait` (PSY-624 dispatch path) and
+# the migrate one-shot finished before we polled. Inspect ps state directly.
+#
+# Output format is one JSON object per service (NDJSON) — `--format json
+# <service>` filters to a single line. Tested against Docker Compose v5.0.1.
+wait_migrate_done() {
+  local timeout_sec="${1:-60}" start row state exit_code
+  start=$(date +%s)
+  while true; do
+    row=$(docker compose -p "$COMPOSE_PROJECT" -f "$COMPOSE_FILE" \
+      ps -a --format json migrate 2>/dev/null) || row=""
+    if [ -n "$row" ]; then
+      state=$(echo "$row" | jq -r '.State')
+      exit_code=$(echo "$row" | jq -r '.ExitCode')
+      case "$state" in
+        exited)
+          if [ "$exit_code" = "0" ]; then
+            return 0
+          fi
+          echo "ERROR: migrate exited with code $exit_code"
+          return 1
+          ;;
+        running|created|restarting)
+          ;;
+        *)
+          echo "WARN: migrate in unexpected state '$state'"
+          ;;
+      esac
+    fi
+    if [ "$(($(date +%s) - start))" -ge "$timeout_sec" ]; then
+      echo "ERROR: timeout waiting for migrate to finish"
+      return 1
+    fi
+    sleep 0.5
+  done
+}
+
+if ! wait_migrate_done 60; then
+  echo "Container logs:"
   docker compose -p "$COMPOSE_PROJECT" -f "$COMPOSE_FILE" logs migrate
   exit 1
 fi

--- a/scripts/dispatch/stack-up.sh
+++ b/scripts/dispatch/stack-up.sh
@@ -60,7 +60,12 @@ wait_for_url() {
 }
 
 dev_backend_up() {
-  curl -fsS -o /dev/null --max-time 2 http://localhost:8080/health 2>/dev/null
+  # The /health handler always returns 200 — even when the database is down
+  # the body reports status:"unhealthy". Parse the body so we don't pick a
+  # broken backend and silently skip the isolated-mode setup.
+  local body
+  body=$(curl -fsS --max-time 2 http://localhost:8080/health 2>/dev/null) || return 1
+  echo "$body" | jq -e '.status == "healthy"' >/dev/null 2>&1
 }
 
 # === Mode dispatch ===
@@ -85,6 +90,7 @@ if [ "$MODE" = "shared" ]; then
     log "Starting frontend on :$FRONTEND_PORT..."
     cd "$WORKTREE_PATH/frontend"
     nohup env NEXT_PUBLIC_API_BASE_URL="http://localhost:8080" \
+      BACKEND_URL="http://localhost:8080" \
       bun run dev --port "$FRONTEND_PORT" \
       </dev/null >"$STACK_DIR/frontend.log" 2>&1 &
     echo $! > "$STACK_DIR/frontend.pid"
@@ -99,6 +105,7 @@ STACK_WORKTREE_ID=$WORKTREE_ID
 STACK_BACKEND_URL=http://localhost:8080
 STACK_FRONTEND_PORT=$FRONTEND_PORT
 STACK_FRONTEND_URL=http://localhost:$FRONTEND_PORT
+BACKEND_URL=http://localhost:8080
 EOF
     cat "$STACK_DIR/.env"
     log "Stack up (mode=shared): http://localhost:$FRONTEND_PORT -> http://localhost:8080"
@@ -122,8 +129,13 @@ log "Postgres :$POSTGRES_PORT, Backend :$BACKEND_PORT, Frontend :$FRONTEND_PORT"
 cd "$WORKTREE_PATH/backend"
 
 log "Starting postgres + migrate (project=$COMPOSE_PROJECT)..."
+# Don't pass --wait: the migrate one-shot exits with 0, which `compose up
+# --wait` treats as failure. setup-db.sh waits for migrate to finish via
+# `compose ps -a --format json migrate`, and the db's healthcheck is
+# observed transitively (migrate `depends_on: db: condition: service_healthy`,
+# so migrate completing implies db is healthy). Mirrors frontend/e2e/global-setup.ts.
 POSTGRES_PORT="$POSTGRES_PORT" \
-  docker compose -p "$COMPOSE_PROJECT" -f docker-compose.dispatch.yml up -d --wait
+  docker compose -p "$COMPOSE_PROJECT" -f docker-compose.dispatch.yml up -d
 
 log "Seeding database (full E2E fixture)..."
 DATABASE_URL="$STACK_POSTGRES_URL" \
@@ -135,7 +147,7 @@ log "Starting backend on :$BACKEND_PORT..."
 cd "$WORKTREE_PATH/backend"
 nohup env \
   DATABASE_URL="$STACK_POSTGRES_URL" \
-  API_PORT="$BACKEND_PORT" \
+  API_ADDR="localhost:$BACKEND_PORT" \
   CORS_ALLOWED_ORIGINS="$STACK_FRONTEND_URL" \
   ENVIRONMENT=test \
   ENABLE_TEST_FIXTURES=1 \
@@ -163,7 +175,12 @@ wait_for_url "$STACK_BACKEND_URL/health" 90
 
 log "Starting frontend on :$FRONTEND_PORT..."
 cd "$WORKTREE_PATH/frontend"
+# BACKEND_URL is read by the catch-all proxy at app/api/[...path]/route.ts
+# and the per-route admin/AI proxies under app/api/admin/* and app/api/ai/*.
+# Without it, the Next.js proxy hardcodes http://localhost:8080 and can't
+# reach an isolated-mode backend on a non-default port.
 nohup env NEXT_PUBLIC_API_BASE_URL="$STACK_BACKEND_URL" \
+  BACKEND_URL="$STACK_BACKEND_URL" \
   bun run dev --port "$FRONTEND_PORT" \
   </dev/null >"$STACK_DIR/frontend.log" 2>&1 &
 echo $! > "$STACK_DIR/frontend.pid"
@@ -182,6 +199,7 @@ STACK_BACKEND_URL=$STACK_BACKEND_URL
 STACK_BACKEND_PORT=$BACKEND_PORT
 STACK_FRONTEND_URL=$STACK_FRONTEND_URL
 STACK_FRONTEND_PORT=$FRONTEND_PORT
+BACKEND_URL=$STACK_BACKEND_URL
 EOF
 cat "$STACK_DIR/.env"
 log "Stack up (mode=isolated): $STACK_FRONTEND_URL -> $STACK_BACKEND_URL -> postgres :$POSTGRES_PORT"


### PR DESCRIPTION
## Summary

PSY-624 shipped the dispatch-stack helpers but they didn't work end-to-end in either `--mode=isolated` (backend silently ignored the per-worktree port and bound to :8080) or `--mode=shared` (probe accepted a backend reporting `status:"unhealthy"` in its body). PSY-580/579/620 each had to spin postgres+backend+frontend manually. Five bugs found and fixed (the spec called out four; a fifth surfaced during end-to-end verification):

- **Bug 1**: `API_PORT` vs `API_ADDR` mismatch — backend reads `API_ADDR` (`backend/internal/config/config.go:25`); the wrong env var was a no-op.
- **Bug 2**: `docker compose wait migrate` returns exit 1 ("no containers for project") once the one-shot has exited. Replaced with a `ps -a --format json migrate` + jq exit-code poll that handles both still-running (regular E2E) and already-exited (dispatch).
- **Bug 3**: `dev_backend_up()` accepted any HTTP 200 from `:8080/health`, even though the body reports `status:"unhealthy"` when the database is down. Now parses the body via `jq -e '.status == "healthy"'`.
- **Bug 4**: Frontend proxy hardcoded `http://localhost:8080`. Now reads `process.env.BACKEND_URL || 'http://localhost:8080'`, matching the convention used by every per-route admin/AI proxy under `frontend/app/api/admin/*` and `frontend/app/api/ai/*`. `stack-up.sh` exports `BACKEND_URL` into the frontend's `nohup env` and writes it to `dispatch-stack/.env`.
- **Bug 5** (surfaced during verification): `compose up -d --wait` exits 1 when a `restart: no` one-shot exits 0; same reason `frontend/e2e/global-setup.ts:90-91` already documents avoiding `--wait`. Dropped here too — `setup-db.sh`'s new ps-based poll is the gate that confirms migrate succeeded.

## Test plan

- [x] `cd backend && go build ./...` — passed
- [x] `cd frontend && bun run typecheck` — passed
- [x] `cd frontend && bun run test:run` — 218 files / 3113 tests passed

## Manual repro

Ran `stack-up.sh --mode=isolated` from a fresh worktree against `origin/main` (no manual workaround, no pre-existing :8080 backend). Stack came up cleanly:

```
[stack-up:agent-a9f05129cac9525d0] Mode: isolated. Allocating ports...
[stack-up:agent-a9f05129cac9525d0] Postgres :55248, Backend :55249, Frontend :55250
[stack-up:agent-a9f05129cac9525d0] Starting postgres + migrate (project=dispatch-agent-a9f05129cac9525d0)...
... (migrate exits 0) ...
[stack-up:agent-a9f05129cac9525d0] Seeding database (full E2E fixture)...
... (full E2E fixture seeds) ...
[stack-up:agent-a9f05129cac9525d0] Starting backend on :55249...
[stack-up:agent-a9f05129cac9525d0] Waiting for backend at http://localhost:55249/health...
[stack-up:agent-a9f05129cac9525d0] Starting frontend on :55250...
[stack-up:agent-a9f05129cac9525d0] Waiting for frontend at http://localhost:55250...
STACK_MODE=isolated
STACK_BACKEND_URL=http://localhost:55249
STACK_BACKEND_PORT=55249
STACK_FRONTEND_URL=http://localhost:55250
STACK_FRONTEND_PORT=55250
BACKEND_URL=http://localhost:55249
[stack-up:agent-a9f05129cac9525d0] Stack up (mode=isolated): http://localhost:55250 -> http://localhost:55249 -> postgres :55248
```

End-to-end probes (note: backend is on :55249, NOT :8080 — bug 1 fix verified):

```
$ curl -fsS http://localhost:55249/health | jq .
{
  "status": "healthy",
  "components": {
    "database": { "status": "healthy", "latency": "877.041µs" }
  },
  ...
}

$ curl -fsS http://localhost:55250/api/health | jq .
{ "status": "healthy", ... }   # frontend proxy → backend on :55249 (bug 4 fix)

$ curl -fsS "http://localhost:55250/api/shows?limit=2" | jq 'length'
65   # full E2E fixture reachable through proxy
```

`stack-down.sh` cleaned native processes, the compose project, and the `dispatch-stack/` dir without leaving orphans.

Bugs 3 + 5 verified by behaviour test rather than live repro:
- Bug 3: `echo '{"status":"unhealthy"}' | jq -e '.status == "healthy"'` returns failure; healthy body returns success; empty/malformed body returns failure
- Bug 5: confirmed `compose -p dispatch-test ... up -d --wait` exits 1 on the migrate one-shot even though every container reports clean exit 0

## Simplify

`/simplify` reviewed all three files: comments are load-bearing WHY (not WHAT), the new helpers don't duplicate existing utilities, and the conventions match (`BACKEND_URL` env var, `API_ADDR` constant). No simplifications applied.

Closes PSY-626