### PR TITLE
PSY-572: enforce per-entity field allowlist in ApprovePendingEdit

### DIFF
--- a/backend/internal/api/handlers/admin/pending_edit.go
+++ b/backend/internal/api/handlers/admin/pending_edit.go
@@ -390,9 +390,13 @@ func (h *PendingEditHandler) AdminApprovePendingEditHandler(ctx context.Context,
 		// PSY-572: pending_edit carried fields not on the per-entity allowlist.
 		// The service has already auto-marked the row 'rejected' and logged
 		// the rejected fields with the edit ID + admin user ID; surface a 400
-		// so the admin UI can show the reason.
+		// so the admin UI can show which fields blocked the approval.
 		if errors.Is(err, adminm.ErrPendingEditDisallowedFields) {
-			return nil, huma.Error400BadRequest(err.Error())
+			rejected := strings.TrimPrefix(err.Error(), adminm.ErrPendingEditDisallowedFields.Error()+": ")
+			return nil, huma.Error400BadRequest(fmt.Sprintf(
+				"This edit was auto-rejected: it includes field(s) the contributor UI does not allow (%s). The pending edit has been marked rejected.",
+				rejected,
+			))
 		}
 		if strings.Contains(err.Error(), "not found") {
 			return nil, huma.Error404NotFound("Pending edit not found")

--- a/backend/internal/api/handlers/admin/pending_edit.go
+++ b/backend/internal/api/handlers/admin/pending_edit.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -33,40 +34,21 @@ func NewPendingEditHandler(
 	}
 }
 
-// Allowed fields per entity type for user-submitted edits.
-// Admin-only fields (status, verified, auto_approve, etc.) are excluded.
-var allowedEditFields = map[string]map[string]bool{
-	"artist": {
-		"name": true, "city": true, "state": true, "country": true,
-		"description": true, "bandcamp_embed_url": true, "image_url": true,
-		"instagram": true, "facebook": true, "twitter": true,
-		"youtube": true, "spotify": true, "soundcloud": true,
-		"bandcamp": true, "website": true,
-	},
-	"venue": {
-		"name": true, "address": true, "city": true, "state": true,
-		"country": true, "zipcode": true, "description": true, "image_url": true,
-		"instagram": true, "facebook": true, "twitter": true,
-		"youtube": true, "spotify": true, "soundcloud": true,
-		"bandcamp": true, "website": true,
-	},
-	"festival": {
-		"name": true, "description": true, "location_name": true,
-		"city": true, "state": true, "country": true,
-		"website": true, "ticket_url": true, "flyer_url": true,
-	},
-	"release": {
-		"title": true, "release_year": true, "release_date": true,
-		"release_type": true, "cover_art_url": true, "description": true,
-	},
-	"label": {
-		"name": true, "founded_year": true,
-		"city": true, "state": true, "country": true, "description": true,
-		"image_url": true,
-		"instagram": true, "facebook": true, "twitter": true,
-		"youtube": true, "spotify": true, "soundcloud": true,
-		"bandcamp": true, "website": true,
-	},
+// allowedEditFields delegates to the per-entity allowlists co-located with
+// each catalog model (PSY-572). The same maps are consulted by the
+// ApprovePendingEdit gate in services/admin/pending_edit.go, so a malformed
+// pending_entity_edits row that bypassed this handler's suggest-edit
+// validator still cannot land non-allowlisted columns.
+//
+// MUST stay in sync with the frontend EDITABLE_FIELDS map in
+// frontend/features/contributions/types.ts. Per-entity sources of truth
+// live in internal/models/catalog/{entity}_allowlist.go.
+//
+// Admin-only fields (status, verified, auto_approve, etc.) are intentionally
+// excluded — those go through the typed admin Edit handlers.
+func allowedEditFields(entityType string) map[string]bool {
+	allowed, _ := adminm.AllowedEditFields(entityType)
+	return allowed
 }
 
 // canEditDirectly returns true if the user can bypass the pending queue.
@@ -152,7 +134,7 @@ func (h *PendingEditHandler) suggestEdit(ctx context.Context, entityType string,
 	// strings in the pending queue. Without this gate, the field-name
 	// allowlist controls *which* fields can be edited but not *what values*
 	// they take — and ApprovePendingEdit applies values blindly.
-	allowed := allowedEditFields[entityType]
+	allowed := allowedEditFields(entityType)
 	for _, change := range req.Body.Changes {
 		if !allowed[change.Field] {
 			return nil, huma.Error422UnprocessableEntity(fmt.Sprintf("Field '%s' is not editable on %s entities", change.Field, entityType))
@@ -405,6 +387,13 @@ func (h *PendingEditHandler) AdminApprovePendingEditHandler(ctx context.Context,
 
 	approved, err := h.pendingEditService.ApprovePendingEdit(uint(editID), user.ID)
 	if err != nil {
+		// PSY-572: pending_edit carried fields not on the per-entity allowlist.
+		// The service has already auto-marked the row 'rejected' and logged
+		// the rejected fields with the edit ID + admin user ID; surface a 400
+		// so the admin UI can show the reason.
+		if errors.Is(err, adminm.ErrPendingEditDisallowedFields) {
+			return nil, huma.Error400BadRequest(err.Error())
+		}
 		if strings.Contains(err.Error(), "not found") {
 			return nil, huma.Error404NotFound("Pending edit not found")
 		}

--- a/backend/internal/api/handlers/admin/pending_edit_contract_test.go
+++ b/backend/internal/api/handlers/admin/pending_edit_contract_test.go
@@ -19,9 +19,9 @@ import (
 // PSY-492 contract drift guard.
 func TestAllowedEditFieldsCoversAllTypes(t *testing.T) {
 	for _, entityType := range adminm.ValidPendingEditEntityTypes() {
-		fields, ok := allowedEditFields[entityType]
-		assert.Truef(t, ok, "allowedEditFields missing entry for %q", entityType)
-		assert.NotEmptyf(t, fields, "allowedEditFields[%q] is empty", entityType)
+		fields, ok := adminm.AllowedEditFields(entityType)
+		assert.Truef(t, ok, "AllowedEditFields missing entry for %q", entityType)
+		assert.NotEmptyf(t, fields, "AllowedEditFields(%q) is empty", entityType)
 	}
 }
 

--- a/backend/internal/api/handlers/admin/pending_edit_test.go
+++ b/backend/internal/api/handlers/admin/pending_edit_test.go
@@ -687,47 +687,51 @@ func TestCanEditDirectly(t *testing.T) {
 
 func TestAllowedEditFields(t *testing.T) {
 	// Artist allowed (image_url added in PSY-521)
+	artist := allowedEditFields("artist")
 	for _, f := range []string{"name", "city", "state", "instagram", "bandcamp", "description", "image_url"} {
-		if !allowedEditFields["artist"][f] {
+		if !artist[f] {
 			t.Errorf("expected %s to be allowed for artist", f)
 		}
 	}
 	// Artist disallowed
 	for _, f := range []string{"slug", "is_active", "data_source", "created_at"} {
-		if allowedEditFields["artist"][f] {
+		if artist[f] {
 			t.Errorf("expected %s to be disallowed for artist", f)
 		}
 	}
 
 	// Venue allowed (image_url added in PSY-521)
+	venue := allowedEditFields("venue")
 	for _, f := range []string{"name", "address", "city", "zipcode", "website", "image_url"} {
-		if !allowedEditFields["venue"][f] {
+		if !venue[f] {
 			t.Errorf("expected %s to be allowed for venue", f)
 		}
 	}
 	// Venue disallowed
 	for _, f := range []string{"verified", "submitted_by", "auto_approve"} {
-		if allowedEditFields["venue"][f] {
+		if venue[f] {
 			t.Errorf("expected %s to be disallowed for venue", f)
 		}
 	}
 
 	// Festival allowed
+	festival := allowedEditFields("festival")
 	for _, f := range []string{"name", "description", "website", "ticket_url", "flyer_url"} {
-		if !allowedEditFields["festival"][f] {
+		if !festival[f] {
 			t.Errorf("expected %s to be allowed for festival", f)
 		}
 	}
 	// Festival disallowed
 	for _, f := range []string{"status", "slug", "series_slug", "edition_year"} {
-		if allowedEditFields["festival"][f] {
+		if festival[f] {
 			t.Errorf("expected %s to be disallowed for festival", f)
 		}
 	}
 
 	// Label allowed (image_url added in PSY-521)
+	label := allowedEditFields("label")
 	for _, f := range []string{"name", "city", "state", "founded_year", "description", "image_url"} {
-		if !allowedEditFields["label"][f] {
+		if !label[f] {
 			t.Errorf("expected %s to be allowed for label", f)
 		}
 	}

--- a/backend/internal/models/admin/pending_edit_allowlist.go
+++ b/backend/internal/models/admin/pending_edit_allowlist.go
@@ -1,0 +1,79 @@
+package admin
+
+import (
+	"errors"
+
+	catalogm "psychic-homily-backend/internal/models/catalog"
+)
+
+// ErrPendingEditDisallowedFields is the sentinel returned by
+// ApprovePendingEdit when field_changes carries one or more columns not on
+// the per-entity allowlist (PSY-572). The pending_edit row is auto-marked
+// 'rejected' with a rejection_reason naming the offending fields, and the
+// entity is left untouched. Handler callers can errors.Is for this sentinel
+// to map to a 400 with the rejected list.
+var ErrPendingEditDisallowedFields = errors.New("pending edit carries disallowed fields")
+
+// AllowedEditFields returns the per-entity allowlist of column names that
+// the pending-edit pipeline is permitted to mutate, plus a boolean for
+// whether the entityType is recognized at all.
+//
+// The per-entity maps live alongside the entity models in
+// internal/models/catalog/{entity}_allowlist.go so each entity owns its
+// own contributor-editable surface area (PSY-424 per-entity convention).
+// This aggregator is the single read point used by both the suggest-edit
+// validator (handlers/admin/pending_edit.go) and the approve gate in
+// services/admin/pending_edit.go::ApprovePendingEdit.
+func AllowedEditFields(entityType string) (map[string]bool, bool) {
+	switch entityType {
+	case PendingEditEntityArtist:
+		return catalogm.ArtistAllowedEditFields, true
+	case PendingEditEntityVenue:
+		return catalogm.VenueAllowedEditFields, true
+	case PendingEditEntityFestival:
+		return catalogm.FestivalAllowedEditFields, true
+	case PendingEditEntityRelease:
+		return catalogm.ReleaseAllowedEditFields, true
+	case PendingEditEntityLabel:
+		return catalogm.LabelAllowedEditFields, true
+	default:
+		return nil, false
+	}
+}
+
+// FilterAllowedFields partitions the proposed FieldChanges into those
+// permitted by the per-entity allowlist and those rejected. Used by
+// ApprovePendingEdit as a defence-in-depth gate: even if a malformed or
+// maliciously-crafted pending_entity_edits row carries columns the
+// suggest-edit validator never sees (e.g. a row inserted via a different
+// path, or one whose handler validator was bypassed), Updates() will not
+// be called with a non-allowlisted column.
+//
+// rejected contains the field NAMES only (not full FieldChange structs)
+// because the caller logs them and surfaces them in an error message —
+// the original values are sensitive to log if the attacker controlled
+// them.
+//
+// Unrecognized entityType returns (nil, all changes) so the caller can
+// distinguish "unknown entity type" from "all fields rejected for a
+// known entity": rejected == len(changes) AND filtered is nil.
+func FilterAllowedFields(entityType string, changes []FieldChange) (filtered []FieldChange, rejected []string) {
+	allowed, ok := AllowedEditFields(entityType)
+	if !ok {
+		// Unknown entity type — nothing is allowlisted, all fields rejected.
+		rejected = make([]string, 0, len(changes))
+		for _, c := range changes {
+			rejected = append(rejected, c.Field)
+		}
+		return nil, rejected
+	}
+	filtered = make([]FieldChange, 0, len(changes))
+	for _, c := range changes {
+		if allowed[c.Field] {
+			filtered = append(filtered, c)
+		} else {
+			rejected = append(rejected, c.Field)
+		}
+	}
+	return filtered, rejected
+}

--- a/backend/internal/models/admin/pending_edit_allowlist_test.go
+++ b/backend/internal/models/admin/pending_edit_allowlist_test.go
@@ -1,0 +1,141 @@
+package admin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestAllowedEditFields_KnownTypes verifies every entity type returned by
+// ValidPendingEditEntityTypes() has an entry. Pairs with the
+// ValidPendingEditEntityTypes contract test in handlers/admin to make
+// sure adding a new entity type triggers a build/test failure rather
+// than a silent "no fields editable" surface.
+func TestAllowedEditFields_KnownTypes(t *testing.T) {
+	for _, entityType := range ValidPendingEditEntityTypes() {
+		fields, ok := AllowedEditFields(entityType)
+		assert.Truef(t, ok, "AllowedEditFields missing entry for %q", entityType)
+		assert.NotEmptyf(t, fields, "AllowedEditFields(%q) is empty", entityType)
+	}
+}
+
+func TestAllowedEditFields_UnknownTypeReturnsFalse(t *testing.T) {
+	fields, ok := AllowedEditFields("show")
+	assert.False(t, ok)
+	assert.Nil(t, fields)
+
+	fields, ok = AllowedEditFields("")
+	assert.False(t, ok)
+	assert.Nil(t, fields)
+
+	fields, ok = AllowedEditFields("user")
+	assert.False(t, ok)
+	assert.Nil(t, fields)
+}
+
+// TestAllowedEditFields_DangerousColumnsExcluded asserts that obviously
+// privileged or identity-shaping columns are NOT on any entity's
+// allowlist. This guards against a contributor (or a malformed pending
+// edit row from any source) flipping is_admin, password_hash, trust_tier,
+// or rewriting slug / submitted_by / data_source via the pending-edit
+// pipeline. The 'shows' table reuses the same column families, so the
+// guard applies even though show is not yet a pending_edit entity.
+func TestAllowedEditFields_DangerousColumnsExcluded(t *testing.T) {
+	// Columns that should never be reachable via pending_edits regardless
+	// of entity type. Mix of:
+	//   - auth/identity columns from users table (not on entity tables,
+	//     but if the JSONB lied about entity_type, GORM would still try
+	//     to set them on whatever table — so the allowlist must reject
+	//     them per-entity)
+	//   - internal provenance columns (data_source, source_confidence)
+	//   - identity columns (id, slug, submitted_by, created_at)
+	//   - status / verified columns gated to admins only
+	dangerous := []string{
+		"id",
+		"slug",
+		"submitted_by",
+		"created_at",
+		"updated_at",
+		"data_source",
+		"source_confidence",
+		"last_verified_at",
+		"is_admin",
+		"is_active",
+		"password_hash",
+		"trust_tier",
+		"user_tier",
+		"verified",
+		"auto_approve",
+		"status", // (admin-only on festival; not editable elsewhere)
+	}
+	for _, entityType := range ValidPendingEditEntityTypes() {
+		fields, ok := AllowedEditFields(entityType)
+		if !ok {
+			t.Fatalf("expected allowlist for %q to exist", entityType)
+		}
+		for _, col := range dangerous {
+			assert.Falsef(t, fields[col],
+				"%q must NOT be allowlisted for %s — privileged or identity column",
+				col, entityType,
+			)
+		}
+	}
+}
+
+func TestFilterAllowedFields_AllAllowed(t *testing.T) {
+	changes := []FieldChange{
+		{Field: "name", NewValue: "New Name"},
+		{Field: "city", NewValue: "Phoenix"},
+	}
+	filtered, rejected := FilterAllowedFields(PendingEditEntityArtist, changes)
+	assert.Empty(t, rejected)
+	assert.Len(t, filtered, 2)
+	assert.Equal(t, "name", filtered[0].Field)
+	assert.Equal(t, "city", filtered[1].Field)
+}
+
+func TestFilterAllowedFields_SomeRejected(t *testing.T) {
+	changes := []FieldChange{
+		{Field: "name", NewValue: "New Name"},
+		{Field: "is_admin", NewValue: true},
+		{Field: "city", NewValue: "Phoenix"},
+		{Field: "password_hash", NewValue: "pwned"},
+	}
+	filtered, rejected := FilterAllowedFields(PendingEditEntityArtist, changes)
+	assert.ElementsMatch(t, []string{"is_admin", "password_hash"}, rejected)
+	assert.Len(t, filtered, 2)
+	// In-allowlist fields preserved in original order with their values intact.
+	assert.Equal(t, "name", filtered[0].Field)
+	assert.Equal(t, "New Name", filtered[0].NewValue)
+	assert.Equal(t, "city", filtered[1].Field)
+}
+
+func TestFilterAllowedFields_AllRejectedKnownEntity(t *testing.T) {
+	changes := []FieldChange{
+		{Field: "is_admin", NewValue: true},
+		{Field: "password_hash", NewValue: "pwned"},
+	}
+	filtered, rejected := FilterAllowedFields(PendingEditEntityArtist, changes)
+	assert.ElementsMatch(t, []string{"is_admin", "password_hash"}, rejected)
+	assert.Empty(t, filtered)
+}
+
+func TestFilterAllowedFields_UnknownEntityRejectsAll(t *testing.T) {
+	changes := []FieldChange{
+		{Field: "name", NewValue: "x"},
+		{Field: "city", NewValue: "y"},
+	}
+	filtered, rejected := FilterAllowedFields("show", changes)
+	assert.Nil(t, filtered)
+	assert.ElementsMatch(t, []string{"name", "city"}, rejected)
+}
+
+func TestFilterAllowedFields_EmptyChanges(t *testing.T) {
+	filtered, rejected := FilterAllowedFields(PendingEditEntityArtist, nil)
+	assert.Empty(t, rejected)
+	assert.Empty(t, filtered)
+
+	filtered, rejected = FilterAllowedFields(PendingEditEntityArtist, []FieldChange{})
+	assert.Empty(t, rejected)
+	assert.Empty(t, filtered)
+}

--- a/backend/internal/models/catalog/artist_allowlist.go
+++ b/backend/internal/models/catalog/artist_allowlist.go
@@ -1,0 +1,35 @@
+package catalog
+
+// ArtistAllowedEditFields enumerates the columns a contributor (or trusted
+// user on the auto-apply path) is allowed to change via the pending-edit
+// pipeline. Anything not listed here is rejected by ApprovePendingEdit
+// before Updates() is called, so columns like id, slug, submitted_by,
+// data_source, is_admin, password_hash, etc. cannot be smuggled through
+// the field_changes JSONB blob.
+//
+// MUST stay in sync with the frontend EDITABLE_FIELDS map in
+// frontend/features/contributions/types.ts and with the backend suggest-edit
+// validator. Adding a column here without also exposing it on the frontend
+// is harmless (just unused); adding it on the frontend without listing it
+// here will cause submissions to be rejected at approve time.
+//
+// Admin-only fields (status, verified, auto_approve, etc.) are intentionally
+// excluded — those go through the typed admin Edit handlers (UpdateArtistHandler,
+// etc.) which have per-field request struct schemas.
+var ArtistAllowedEditFields = map[string]bool{
+	"name":               true,
+	"city":               true,
+	"state":              true,
+	"country":            true,
+	"description":        true,
+	"bandcamp_embed_url": true,
+	"image_url":          true,
+	"instagram":          true,
+	"facebook":           true,
+	"twitter":            true,
+	"youtube":            true,
+	"spotify":            true,
+	"soundcloud":         true,
+	"bandcamp":           true,
+	"website":            true,
+}

--- a/backend/internal/models/catalog/festival_allowlist.go
+++ b/backend/internal/models/catalog/festival_allowlist.go
@@ -1,0 +1,19 @@
+package catalog
+
+// FestivalAllowedEditFields enumerates the columns a contributor (or trusted
+// user on the auto-apply path) is allowed to change via the pending-edit
+// pipeline. See ArtistAllowedEditFields for the full rationale.
+//
+// MUST stay in sync with frontend EDITABLE_FIELDS.festival in
+// frontend/features/contributions/types.ts.
+var FestivalAllowedEditFields = map[string]bool{
+	"name":          true,
+	"description":   true,
+	"location_name": true,
+	"city":          true,
+	"state":         true,
+	"country":       true,
+	"website":       true,
+	"ticket_url":    true,
+	"flyer_url":     true,
+}

--- a/backend/internal/models/catalog/label_allowlist.go
+++ b/backend/internal/models/catalog/label_allowlist.go
@@ -1,0 +1,25 @@
+package catalog
+
+// LabelAllowedEditFields enumerates the columns a contributor (or trusted
+// user on the auto-apply path) is allowed to change via the pending-edit
+// pipeline. See ArtistAllowedEditFields for the full rationale.
+//
+// MUST stay in sync with frontend EDITABLE_FIELDS.label in
+// frontend/features/contributions/types.ts.
+var LabelAllowedEditFields = map[string]bool{
+	"name":         true,
+	"founded_year": true,
+	"city":         true,
+	"state":        true,
+	"country":      true,
+	"description":  true,
+	"image_url":    true,
+	"instagram":    true,
+	"facebook":     true,
+	"twitter":      true,
+	"youtube":      true,
+	"spotify":      true,
+	"soundcloud":   true,
+	"bandcamp":     true,
+	"website":      true,
+}

--- a/backend/internal/models/catalog/release_allowlist.go
+++ b/backend/internal/models/catalog/release_allowlist.go
@@ -1,0 +1,16 @@
+package catalog
+
+// ReleaseAllowedEditFields enumerates the columns a contributor (or trusted
+// user on the auto-apply path) is allowed to change via the pending-edit
+// pipeline. See ArtistAllowedEditFields for the full rationale.
+//
+// MUST stay in sync with frontend EDITABLE_FIELDS.release in
+// frontend/features/contributions/types.ts.
+var ReleaseAllowedEditFields = map[string]bool{
+	"title":         true,
+	"release_year":  true,
+	"release_date":  true,
+	"release_type":  true,
+	"cover_art_url": true,
+	"description":   true,
+}

--- a/backend/internal/models/catalog/venue_allowlist.go
+++ b/backend/internal/models/catalog/venue_allowlist.go
@@ -1,0 +1,26 @@
+package catalog
+
+// VenueAllowedEditFields enumerates the columns a contributor (or trusted
+// user on the auto-apply path) is allowed to change via the pending-edit
+// pipeline. See ArtistAllowedEditFields for the full rationale.
+//
+// MUST stay in sync with frontend EDITABLE_FIELDS.venue in
+// frontend/features/contributions/types.ts.
+var VenueAllowedEditFields = map[string]bool{
+	"name":        true,
+	"address":     true,
+	"city":        true,
+	"state":       true,
+	"country":     true,
+	"zipcode":     true,
+	"description": true,
+	"image_url":   true,
+	"instagram":   true,
+	"facebook":    true,
+	"twitter":     true,
+	"youtube":     true,
+	"spotify":     true,
+	"soundcloud":  true,
+	"bandcamp":    true,
+	"website":     true,
+}

--- a/backend/internal/services/admin/pending_edit.go
+++ b/backend/internal/services/admin/pending_edit.go
@@ -235,12 +235,11 @@ func (s *PendingEditService) ApprovePendingEdit(editID uint, reviewerID uint) (*
 	// before mutating the entity.
 	_, rejectedFields := adminm.FilterAllowedFields(edit.EntityType, changes)
 	if len(rejectedFields) > 0 {
+		joined := strings.Join(rejectedFields, ", ")
 		reason := fmt.Sprintf(
 			"Rejected automatically: pending edit carries %d field(s) not allowed for %s entities (%s). "+
 				"This usually indicates a corrupted submission — the contributor's UI does not expose these fields.",
-			len(rejectedFields),
-			edit.EntityType,
-			strings.Join(rejectedFields, ", "),
+			len(rejectedFields), edit.EntityType, joined,
 		)
 		slog.Default().Error("pending_edit_disallowed_fields",
 			"edit_id", edit.ID,
@@ -260,7 +259,7 @@ func (s *PendingEditService) ApprovePendingEdit(editID uint, reviewerID uint) (*
 		}).Error; err != nil {
 			return nil, fmt.Errorf("failed to auto-reject pending edit with disallowed fields: %w", err)
 		}
-		return nil, fmt.Errorf("%w: %s", adminm.ErrPendingEditDisallowedFields, strings.Join(rejectedFields, ", "))
+		return nil, fmt.Errorf("%w: %s", adminm.ErrPendingEditDisallowedFields, joined)
 	}
 
 	// Build update map from new values

--- a/backend/internal/services/admin/pending_edit.go
+++ b/backend/internal/services/admin/pending_edit.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"log/slog"
+	"strings"
 	"time"
 
 	"gorm.io/gorm"
@@ -221,6 +223,44 @@ func (s *PendingEditService) ApprovePendingEdit(editID uint, reviewerID uint) (*
 	var changes []adminm.FieldChange
 	if err := json.Unmarshal(*edit.FieldChanges, &changes); err != nil {
 		return nil, fmt.Errorf("failed to parse field changes: %w", err)
+	}
+
+	// PSY-572: per-entity allowlist gate. Defence in depth — even though the
+	// suggest-edit handler validates field names at submission time, an
+	// attacker (or a buggy/legacy code path) that manages to land a
+	// pending_entity_edits row carrying a non-allowlisted column (e.g.
+	// is_admin, password_hash, trust_tier) must not have it applied via
+	// the untyped Updates() call below. If any rejected fields are present,
+	// auto-mark the pending_edit 'rejected' with a clear reason and bail
+	// before mutating the entity.
+	_, rejectedFields := adminm.FilterAllowedFields(edit.EntityType, changes)
+	if len(rejectedFields) > 0 {
+		reason := fmt.Sprintf(
+			"Rejected automatically: pending edit carries %d field(s) not allowed for %s entities (%s). "+
+				"This usually indicates a corrupted submission — the contributor's UI does not expose these fields.",
+			len(rejectedFields),
+			edit.EntityType,
+			strings.Join(rejectedFields, ", "),
+		)
+		slog.Default().Error("pending_edit_disallowed_fields",
+			"edit_id", edit.ID,
+			"entity_type", edit.EntityType,
+			"entity_id", edit.EntityID,
+			"submitted_by", edit.SubmittedBy,
+			"reviewer_id", reviewerID,
+			"rejected_fields", rejectedFields,
+		)
+		now := time.Now()
+		if err := s.db.Model(&edit).Updates(map[string]interface{}{
+			"status":           adminm.PendingEditStatusRejected,
+			"reviewed_by":      reviewerID,
+			"reviewed_at":      now,
+			"rejection_reason": reason,
+			"updated_at":       now,
+		}).Error; err != nil {
+			return nil, fmt.Errorf("failed to auto-reject pending edit with disallowed fields: %w", err)
+		}
+		return nil, fmt.Errorf("%w: %s", adminm.ErrPendingEditDisallowedFields, strings.Join(rejectedFields, ", "))
 	}
 
 	// Build update map from new values

--- a/backend/internal/services/admin/pending_edit_test.go
+++ b/backend/internal/services/admin/pending_edit_test.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -756,6 +757,134 @@ func (s *PendingEditServiceIntegrationTestSuite) TestApprovePendingEdit_AllowsNe
 	})
 	s.NoError(err)
 	s.NotNil(resp)
+}
+
+// =============================================================================
+// PSY-572: per-entity field allowlist gate inside ApprovePendingEdit
+// =============================================================================
+//
+// These tests assert the defence-in-depth gate that filters non-allowlisted
+// columns out of pending_edits.field_changes BEFORE the untyped Updates()
+// call. Even if the suggest-edit handler validator was bypassed (legacy
+// rows, direct DB writes, future code paths), ApprovePendingEdit must
+// not apply privileged columns like is_admin, password_hash, etc.
+
+// TestApprovePendingEdit_RejectsDisallowedField simulates a malformed pending
+// edit row carrying both an in-allowlist column ("name") and an out-of-
+// allowlist column ("is_admin"). The whole approval must fail (no partial
+// apply), the entity must be unchanged, and the pending_edit must move to
+// 'rejected' with a rejection_reason naming the offending field.
+func (s *PendingEditServiceIntegrationTestSuite) TestApprovePendingEdit_RejectsDisallowedField() {
+	user := s.createTestUser()
+	reviewer := s.createTestUser()
+	artist := s.createTestArtist("Genuine")
+
+	// CreatePendingEdit doesn't validate field names server-side (the
+	// handler-level validator is what blocks contributors), so we can
+	// land a malformed row directly through the service.
+	created, err := s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "artist",
+		EntityID:   artist.ID,
+		UserID:     user.ID,
+		Changes: []adminm.FieldChange{
+			{Field: "name", OldValue: "Genuine", NewValue: "Compromised"},
+			{Field: "is_admin", OldValue: false, NewValue: true},
+		},
+		Summary: "malicious edit smuggling is_admin",
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(created)
+
+	// Approve must fail with the disallowed-fields sentinel.
+	_, err = s.svc.ApprovePendingEdit(created.ID, reviewer.ID)
+	s.Require().Error(err)
+	s.True(errors.Is(err, adminm.ErrPendingEditDisallowedFields),
+		"expected ErrPendingEditDisallowedFields, got %v", err)
+	s.Contains(err.Error(), "is_admin")
+
+	// Entity must NOT have been mutated — neither the in-allowlist field
+	// (name) nor the out-of-allowlist field (which doesn't exist on artists
+	// anyway, but we want the test to prove "no Updates() ran").
+	var artistAfter catalogm.Artist
+	s.Require().NoError(s.db.First(&artistAfter, artist.ID).Error)
+	s.Equal("Genuine", artistAfter.Name, "name should not have changed despite being on allowlist — the whole approval was rejected")
+
+	// Pending edit must be marked 'rejected' with a reason that names the
+	// offending field, so the admin UI surfaces a clear explanation.
+	resp, err := s.svc.GetPendingEdit(created.ID)
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+	s.Equal(adminm.PendingEditStatusRejected, resp.Status)
+	s.Require().NotNil(resp.ReviewedBy)
+	s.Equal(reviewer.ID, *resp.ReviewedBy)
+	s.NotNil(resp.ReviewedAt)
+	s.Require().NotNil(resp.RejectionReason)
+	s.Contains(*resp.RejectionReason, "is_admin")
+	s.Contains(*resp.RejectionReason, "artist")
+}
+
+// TestApprovePendingEdit_AppliesAllAllowedFields covers the happy path
+// alongside the rejection path: a pending_edit with only allowlisted
+// fields still applies cleanly after PSY-572 (no regression).
+func (s *PendingEditServiceIntegrationTestSuite) TestApprovePendingEdit_AppliesAllAllowedFields() {
+	user := s.createTestUser()
+	reviewer := s.createTestUser()
+	artist := s.createTestArtist("Old")
+
+	created, err := s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "artist",
+		EntityID:   artist.ID,
+		UserID:     user.ID,
+		Changes: []adminm.FieldChange{
+			{Field: "name", OldValue: "Old", NewValue: "New"},
+			{Field: "city", OldValue: nil, NewValue: "Phoenix"},
+			{Field: "instagram", OldValue: nil, NewValue: "https://instagram.com/x"},
+		},
+		Summary: "fill in info",
+	})
+	s.Require().NoError(err)
+
+	resp, err := s.svc.ApprovePendingEdit(created.ID, reviewer.ID)
+	s.Require().NoError(err)
+	s.Equal(adminm.PendingEditStatusApproved, resp.Status)
+
+	var artistAfter catalogm.Artist
+	s.Require().NoError(s.db.First(&artistAfter, artist.ID).Error)
+	s.Equal("New", artistAfter.Name)
+	s.Require().NotNil(artistAfter.City)
+	s.Equal("Phoenix", *artistAfter.City)
+}
+
+// TestApprovePendingEdit_RejectsMultipleDisallowedFields: every offending
+// field must show up in the rejection reason, not just the first one.
+func (s *PendingEditServiceIntegrationTestSuite) TestApprovePendingEdit_RejectsMultipleDisallowedFields() {
+	user := s.createTestUser()
+	reviewer := s.createTestUser()
+	venue := s.createTestVenue("Genuine Venue")
+
+	created, _ := s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "venue",
+		EntityID:   venue.ID,
+		UserID:     user.ID,
+		Changes: []adminm.FieldChange{
+			{Field: "name", NewValue: "Pwned"},
+			{Field: "is_admin", NewValue: true},
+			{Field: "password_hash", NewValue: "x"},
+			{Field: "trust_tier", NewValue: "admin"},
+		},
+		Summary: "many bad fields",
+	})
+
+	_, err := s.svc.ApprovePendingEdit(created.ID, reviewer.ID)
+	s.Require().Error(err)
+	s.True(errors.Is(err, adminm.ErrPendingEditDisallowedFields))
+	for _, bad := range []string{"is_admin", "password_hash", "trust_tier"} {
+		s.Contains(err.Error(), bad)
+	}
+
+	var venueAfter catalogm.Venue
+	s.Require().NoError(s.db.First(&venueAfter, venue.ID).Error)
+	s.Equal("Genuine Venue", venueAfter.Name)
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- Per-entity field allowlists co-located with each catalog model (`internal/models/catalog/{artist,venue,festival,release,label}_allowlist.go`), aggregated by `models/admin.AllowedEditFields(entityType)` and `FilterAllowedFields(entityType, changes)`.
- `ApprovePendingEdit` now filters incoming `field_changes` against the per-entity allowlist before any `Updates(...)` call. If anything is rejected: auto-mark the pending_edit `'rejected'`, write a clear `rejection_reason`, structured-log (slog) the edit ID + admin user ID + rejected field names, and bail with `adminm.ErrPendingEditDisallowedFields`. Handler maps the sentinel to a 400 with curator-readable copy.
- Suggest-edit handler now reads the same allowlists (replacing the inline duplicate map). Single source of truth, two read points.
- Existing happy-path approval (in-allowlist fields) is unchanged.
- Direct-admin Edit handlers (`UpdateArtistHandler` etc.) were already safe: typed Huma request structs schema-validate each column at the API boundary, so no `Updates(map)` on user-controlled keys is reachable through them — gate not needed.

## Test plan
- [x] `cd backend && go build ./...` — passed
- [x] `go test ./internal/services/admin/... ./internal/api/handlers/admin/... ./internal/models/admin/... ./internal/models/catalog/...` — passed (includes 7 new allowlist tests in `models/admin` covering all 5 pending-edit entity types + 3 new integration tests in `services/admin` exercising the gate end-to-end against Postgres)

## Manual repro
Integration test name: `TestPendingEditServiceIntegrationSuite/TestApprovePendingEdit_RejectsDisallowedField` (plus `_RejectsMultipleDisallowedFields` for multi-field coverage and `_AppliesAllAllowedFields` for the no-regression path).

Setup: a pending_entity_edits row landed with `entity_type="artist"`, `field_changes=[{name:"Genuine"->"Compromised"}, {is_admin:false->true}]`.

Asserted outcomes:
- `ApprovePendingEdit` returned `errors.Is(err, adminm.ErrPendingEditDisallowedFields)` and the error message contained `is_admin`.
- The artist's `name` was unchanged ("Genuine") — the in-allowlist field did NOT apply because the whole approval failed atomically.
- The pending_edit row moved to `status='rejected'` with `reviewed_by=<reviewer.ID>` and `rejection_reason` containing both `is_admin` and `artist`.
- slog emitted: `pending_edit_disallowed_fields edit_id=2 entity_type=artist entity_id=2 submitted_by=3 reviewer_id=4 rejected_fields=[is_admin]`

The multi-field test additionally asserted that `is_admin`, `password_hash`, AND `trust_tier` all show up in the surfaced error (not just the first).

## Simplify
1 cleanup applied: curator-friendly 400 message in `AdminApprovePendingEditHandler` (no longer leaks the internal sentinel phrase), and `strings.Join(rejectedFields, ", ")` is now computed once and reused across the rejection_reason column and the wrapped error. No reuse opportunities or efficiency issues found in the rest of the diff.

## Notes for reviewer
- **Decision 1 (per-entity allowlist files)**: maps live alongside each entity model in `internal/models/catalog/<entity>_allowlist.go`, aggregated through a single switch in `internal/models/admin/pending_edit_allowlist.go`. Adding a 6th pending-edit entity type means adding one allowlist file + one case to the switch — fails the existing `TestAllowedEditFieldsCoversAllTypes` contract test if you forget the latter.
- **Decision 2 (reuse `'rejected'` status)**: no migration, no admin-UI churn. Auto-rejected rows look identical to curator-rejected rows except for the system-generated `rejection_reason` text — admins can grep the queue for the "Rejected automatically:" prefix if they want to triage.
- **No notification email is sent on auto-rejection** (unlike `RejectPendingEdit`). This is intentional: the contributor's UI never lets them submit these fields, so a corrupted-row auto-rejection is a system event, not feedback for the submitter. If we ever see false positives, we can revisit.
- **Direct-admin Edit drawer was NOT gated**. Per the implementation note above, those handlers are already safe (typed request structs).

Closes PSY-572