### PR TITLE
PSY-569: show success banner after admin save on show edit

### DIFF
--- a/frontend/features/shows/components/ShowDetail.test.tsx
+++ b/frontend/features/shows/components/ShowDetail.test.tsx
@@ -77,11 +77,27 @@ vi.mock('@/components/shared', () => ({
 }))
 
 vi.mock('@/components/forms', () => ({
-  ShowForm: ({ onCancel }: { onCancel: () => void }) => (
+  ShowForm: ({ onSuccess, onCancel }: { onSuccess: () => void; onCancel: () => void }) => (
     <div data-testid="show-form">
+      <button onClick={onSuccess}>Save Form</button>
       <button onClick={onCancel}>Cancel Form</button>
     </div>
   ),
+}))
+
+// Mock contributions feature so we can drive the success banner from tests
+// without exercising the real auto-dismiss timer. PSY-569 wires the show edit
+// form's onSuccess into `useEntitySaveSuccessBanner.handleSaveSuccess`; we
+// surface a settable visibility flag here to verify the banner renders.
+const mockSaveBannerHandleSaveSuccess = vi.fn()
+let mockSaveBannerVisible = false
+vi.mock('@/features/contributions', () => ({
+  EntitySaveSuccessBanner: ({ visible }: { visible: boolean }) =>
+    visible ? <div data-testid="save-success-banner">Changes saved</div> : null,
+  useEntitySaveSuccessBanner: () => ({
+    isVisible: mockSaveBannerVisible,
+    handleSaveSuccess: mockSaveBannerHandleSaveSuccess,
+  }),
 }))
 
 vi.mock('./DeleteShowDialog', () => ({
@@ -162,6 +178,7 @@ function makeShow(overrides: Partial<ShowResponse> = {}): ShowResponse {
 describe('ShowDetail', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockSaveBannerVisible = false
     mockAuthContext.mockReturnValue({
       user: null,
       isAuthenticated: false,
@@ -384,6 +401,33 @@ describe('ShowDetail', () => {
       )
       await user.click(cancelButtons[0])
       expect(screen.queryByTestId('show-form')).not.toBeInTheDocument()
+    })
+
+    // PSY-569: after a successful save the banner hook is told to flash, the
+    // edit form collapses, and the success banner is left visible on the
+    // page. Mirrors the artist/venue/release/label/festival detail pages.
+    it('flashes the save banner and collapses the form after a successful save', async () => {
+      const user = userEvent.setup()
+      render(<ShowDetail showId="1" />)
+
+      await user.click(screen.getByRole('button', { name: /Edit/ }))
+      expect(screen.getByTestId('show-form')).toBeInTheDocument()
+
+      await user.click(screen.getByRole('button', { name: 'Save Form' }))
+
+      expect(mockSaveBannerHandleSaveSuccess).toHaveBeenCalledWith({ applied: true })
+      expect(screen.queryByTestId('show-form')).not.toBeInTheDocument()
+    })
+
+    it('renders the save success banner when the hook reports it visible', () => {
+      mockSaveBannerVisible = true
+      render(<ShowDetail showId="1" />)
+      expect(screen.getByTestId('save-success-banner')).toBeInTheDocument()
+    })
+
+    it('does not render the save success banner when hidden', () => {
+      render(<ShowDetail showId="1" />)
+      expect(screen.queryByTestId('save-success-banner')).not.toBeInTheDocument()
     })
 
     it('opens delete dialog on click', async () => {

--- a/frontend/features/shows/components/ShowDetail.tsx
+++ b/frontend/features/shows/components/ShowDetail.tsx
@@ -13,6 +13,7 @@ import { SocialLinks, MusicEmbed, EntityDetailLayout } from '@/components/shared
 import { EntityCollections } from '@/features/collections'
 import { EntityTagList } from '@/features/tags'
 import { CommentThread, FieldNotesSection } from '@/features/comments'
+import { EntitySaveSuccessBanner, useEntitySaveSuccessBanner } from '@/features/contributions'
 import { ShowForm } from '@/components/forms'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { DeleteShowDialog } from './DeleteShowDialog'
@@ -38,6 +39,7 @@ export function ShowDetail({ showId }: ShowDetailProps) {
 
   const [isEditing, setIsEditing] = useState(false)
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
+  const saveBanner = useEntitySaveSuccessBanner()
 
   // Admin mutations for status flags
   const setSoldOutMutation = useSetShowSoldOut()
@@ -54,6 +56,11 @@ export function ShowDetail({ showId }: ShowDetailProps) {
 
   const handleEditSuccess = () => {
     setIsEditing(false)
+    // Show edits flow through an admin/owner-only direct-save path (see the
+    // PSY-461 / PSY-489 note below) — no pending-review branch — so this is
+    // always an "applied" save. Mirrors the artist/venue/release/label/festival
+    // detail pages' use of `EntitySaveSuccessBanner` post-PSY-562/PSY-622.
+    saveBanner.handleSaveSuccess({ applied: true })
   }
 
   const handleEditCancel = () => {
@@ -174,6 +181,13 @@ export function ShowDetail({ showId }: ShowDetailProps) {
           </>
         }
       >
+        {/* Page-level success banner (PSY-569). Renders briefly after a
+            direct admin/owner save via the inline {@link ShowForm}, mirroring
+            the artist / venue / release / label / festival detail pages
+            (PSY-562 / PSY-622). Show edits always flow through the
+            direct-save path, so the banner key is unconditional. */}
+        <EntitySaveSuccessBanner visible={saveBanner.isVisible} />
+
         {/* Edit Form */}
         {isEditing && (
           <div className="mb-8 p-4 rounded-lg border border-border bg-muted/30">

--- a/frontend/features/shows/components/ShowDetail.tsx
+++ b/frontend/features/shows/components/ShowDetail.tsx
@@ -56,10 +56,8 @@ export function ShowDetail({ showId }: ShowDetailProps) {
 
   const handleEditSuccess = () => {
     setIsEditing(false)
-    // Show edits flow through an admin/owner-only direct-save path (see the
-    // PSY-461 / PSY-489 note below) — no pending-review branch — so this is
-    // always an "applied" save. Mirrors the artist/venue/release/label/festival
-    // detail pages' use of `EntitySaveSuccessBanner` post-PSY-562/PSY-622.
+    // Show edits have no pending-review branch (admin/owner-only direct
+    // save), so the result is always `applied: true`.
     saveBanner.handleSaveSuccess({ applied: true })
   }
 
@@ -181,11 +179,12 @@ export function ShowDetail({ showId }: ShowDetailProps) {
           </>
         }
       >
-        {/* Page-level success banner (PSY-569). Renders briefly after a
-            direct admin/owner save via the inline {@link ShowForm}, mirroring
-            the artist / venue / release / label / festival detail pages
-            (PSY-562 / PSY-622). Show edits always flow through the
-            direct-save path, so the banner key is unconditional. */}
+        {/* Page-level "Changes saved" banner (PSY-569). Mirrors the artist /
+            venue / release / label / festival detail pages (PSY-562 / PSY-622)
+            but is fed by the inline {@link ShowForm} instead of the shared
+            {@link EntityEditDrawer}, since show edits run through an
+            admin/owner-only direct-save path (see PSY-461 / PSY-489 note
+            below). */}
         <EntitySaveSuccessBanner visible={saveBanner.isVisible} />
 
         {/* Edit Form */}


### PR DESCRIPTION
## Summary
- After saving an admin/owner edit on a show, the inline `ShowForm` collapsed back to the show detail with no visible confirmation. PSY-562 fixed this for the other 5 detail pages and PSY-622 generalised it into `EntitySaveSuccessBanner`; show was missed because it edits via a one-off inline form, not `EntityEditDrawer`.
- Wires `useEntitySaveSuccessBanner` + `EntitySaveSuccessBanner` into `ShowDetail`. Shows have an admin/owner-only direct-save path (no pending-review branch — see PSY-461 / PSY-489 note in the file), so the call site unconditionally passes `{ applied: true }`.

## Test plan
- [x] cd frontend && bun run typecheck — passed
- [x] cd frontend && bun run test:run features/shows — passed (326 tests in 29 files; ShowDetail 39 / 39, including 3 new banner-wiring cases)

## Manual repro
Screenshot: dogfood-output/PSY-569/screenshots/show-edit-saved-with-banner.png. Logged in as admin on the dispatch stack, opened a show, clicked Edit, changed the description, clicked Save Changes; after the form's in-flight "Show Updated!" state collapses (~1.5 s) the green "Changes saved" banner renders inline above Field Notes and auto-dismisses after 5 s. Banner is the same primitive (`EntitySaveSuccessBanner`) used by artist / venue / release / label / festival detail pages.

## Simplify
Tightened two newly-added comments — trimmed redundant cross-references and clarified the JSX comment's slightly ambiguous "banner key is unconditional" phrasing. No behaviour change, no test diff.

Closes PSY-569