### PR TITLE
PSY-594: capitalize 'Please' in comment 429 rate-limit message

### DIFF
--- a/backend/internal/api/handlers/engagement/comment.go
+++ b/backend/internal/api/handlers/engagement/comment.go
@@ -303,7 +303,7 @@ func (h *CommentHandler) CreateCommentHandler(ctx context.Context, req *CreateCo
 		if strings.Contains(err.Error(), "body is required") || strings.Contains(err.Error(), "exceeds maximum length") {
 			return nil, huma.Error400BadRequest(err.Error())
 		}
-		if strings.Contains(err.Error(), "please wait") || strings.Contains(err.Error(), "hourly comment limit") {
+		if strings.Contains(err.Error(), "Please wait") || strings.Contains(err.Error(), "hourly comment limit") {
 			return nil, rateLimited429(err)
 		}
 		requestID := logger.GetRequestID(ctx)
@@ -399,7 +399,7 @@ func (h *CommentHandler) CreateReplyHandler(ctx context.Context, req *CreateRepl
 		if strings.Contains(err.Error(), "parent comment not found") {
 			return nil, huma.Error404NotFound(err.Error())
 		}
-		if strings.Contains(err.Error(), "please wait") || strings.Contains(err.Error(), "hourly comment limit") {
+		if strings.Contains(err.Error(), "Please wait") || strings.Contains(err.Error(), "hourly comment limit") {
 			return nil, rateLimited429(err)
 		}
 		requestID := logger.GetRequestID(ctx)

--- a/backend/internal/api/handlers/engagement/comment_admin_test.go
+++ b/backend/internal/api/handlers/engagement/comment_admin_test.go
@@ -339,7 +339,7 @@ func TestAdminRejectComment_Success(t *testing.T) {
 func TestCreateComment_RateLimitError(t *testing.T) {
 	mock := &testhelpers.MockCommentService{
 		CreateCommentFn: func(userID uint, req *contracts.CreateCommentRequest) (*contracts.CommentResponse, error) {
-			return nil, fmt.Errorf("please wait 60 seconds between comments on the same entity")
+			return nil, fmt.Errorf("Please wait 60 seconds between comments on the same entity")
 		},
 	}
 	h := NewCommentHandler(mock, mock, nil, nil)
@@ -372,7 +372,7 @@ func TestCreateReply_RateLimitError_HasRetryAfter(t *testing.T) {
 			return makeCommentResponse(id, "show", 1, 99), nil
 		},
 		CreateCommentFn: func(userID uint, req *contracts.CreateCommentRequest) (*contracts.CommentResponse, error) {
-			return nil, fmt.Errorf("please wait 60 seconds between comments on the same entity")
+			return nil, fmt.Errorf("Please wait 60 seconds between comments on the same entity")
 		},
 	}
 	h := NewCommentHandler(mock, mock, nil, nil)

--- a/backend/internal/api/handlers/engagement/field_note.go
+++ b/backend/internal/api/handlers/engagement/field_note.go
@@ -112,7 +112,7 @@ func (h *FieldNoteHandler) CreateFieldNoteHandler(ctx context.Context, req *Crea
 		if strings.Contains(err.Error(), "artist is not on this show") {
 			return nil, huma.Error400BadRequest(err.Error())
 		}
-		if strings.Contains(err.Error(), "please wait") || strings.Contains(err.Error(), "hourly comment limit") {
+		if strings.Contains(err.Error(), "Please wait") || strings.Contains(err.Error(), "hourly comment limit") {
 			return nil, rateLimited429(err)
 		}
 		requestID := logger.GetRequestID(ctx)

--- a/backend/internal/api/handlers/engagement/field_note_test.go
+++ b/backend/internal/api/handlers/engagement/field_note_test.go
@@ -155,7 +155,7 @@ func TestCreateFieldNote_ArtistNotOnShow(t *testing.T) {
 func TestCreateFieldNote_RateLimited(t *testing.T) {
 	mock := &testhelpers.MockFieldNoteService{
 		CreateFieldNoteFn: func(userID uint, req *contracts.CreateFieldNoteRequest) (*contracts.CommentResponse, error) {
-			return nil, fmt.Errorf("please wait 60 seconds between comments on the same entity")
+			return nil, fmt.Errorf("Please wait 60 seconds between comments on the same entity")
 		},
 	}
 	h := NewFieldNoteHandler(mock, mock, nil)

--- a/backend/internal/services/engagement/comment_service.go
+++ b/backend/internal/services/engagement/comment_service.go
@@ -288,7 +288,7 @@ func (s *CommentService) CreateComment(userID uint, req *contracts.CreateComment
 		return nil, fmt.Errorf("failed to check rate limit: %w", err)
 	}
 	if recentEntityCount > 0 {
-		return nil, errors.New("please wait 60 seconds between comments on the same entity")
+		return nil, errors.New("Please wait 60 seconds between comments on the same entity")
 	}
 
 	// Rate limiting: global hourly limit based on trust tier
@@ -881,7 +881,7 @@ func (s *CommentService) CreateFieldNote(userID uint, req *contracts.CreateField
 		return nil, fmt.Errorf("failed to check rate limit: %w", err)
 	}
 	if recentEntityCount > 0 {
-		return nil, errors.New("please wait 60 seconds between comments on the same entity")
+		return nil, errors.New("Please wait 60 seconds between comments on the same entity")
 	}
 
 	// Rate limiting: global hourly limit based on trust tier

--- a/backend/internal/services/engagement/comment_service_test.go
+++ b/backend/internal/services/engagement/comment_service_test.go
@@ -1416,7 +1416,7 @@ func (suite *CommentServiceIntegrationTestSuite) TestRateLimit_PerEntityCooldown
 		Body:       "Too fast",
 	})
 	suite.Error(err)
-	suite.Contains(err.Error(), "please wait 60 seconds")
+	suite.Contains(err.Error(), "Please wait 60 seconds")
 }
 
 func (suite *CommentServiceIntegrationTestSuite) TestRateLimit_DifferentEntityAllowed() {

--- a/frontend/features/comments/hooks/index.ts
+++ b/frontend/features/comments/hooks/index.ts
@@ -24,11 +24,15 @@ import type {
 // ============================================================================
 
 /**
- * Capitalize the first character of a non-empty string. Backend service
- * messages use lowercase ("please wait 60 seconds...") to keep substring
- * routing in handlers simple; the project copy convention is to capitalize
- * the first word in user-facing text, so we normalize at the display
- * boundary.
+ * Capitalize the first character of a non-empty string. Most backend
+ * service-layer error messages still follow Go's lowercase-leading
+ * convention (e.g. "comment body is required"); the project copy
+ * convention is to capitalize the first word in user-facing text, so we
+ * normalize at the display boundary. PSY-594 capitalized the 429
+ * rate-limit message ("Please wait 60 seconds...") at the source so
+ * mailbox-provider/header tooling sees the user-facing form even
+ * without this hook; capitalizeFirst is idempotent on already-capital
+ * input.
  */
 function capitalizeFirst(s: string): string {
   if (!s) return s


### PR DESCRIPTION
## Summary
- Capitalize 'Please' in comment 429 rate-limit message (was lowercase 'please') at the service-layer source so mailbox-provider / `Retry-After`-aware tooling sees the user-facing form verbatim
- Update the substring-match error routing in `comment.go` / `field_note.go` (`"please wait"` → `"Please wait"`) and the three handler-test mocks + the integration-test substring assertion
- Update the frontend `capitalizeFirst` docstring in `formatCommentSubmissionError` (PSY-589) to reflect the new backend state — the helper is still needed for other Go-convention lowercase-leading errors, and is idempotent on already-capitalized input

## Test plan
- [x] `go build ./...` — passed
- [x] `go test ./internal/api/handlers/engagement/... ./internal/services/engagement/...` — passed (handlers 7.353s, services 30.316s)
- [x] `bun run typecheck` — passed
- [x] `bun run test:run features/comments` — passed (138/138 across 8 suites)

## Manual repro
`go test ./internal/services/engagement/... -run 'TestCommentServiceIntegrationTestSuite/TestRateLimit_PerEntityCooldown' -v` — PASS. The integration test creates two comments on the same entity within 60s and asserts `Please wait 60 seconds` is a substring of the returned error. Test passing IS the manual repro of the new capitalized message reaching the wire (the service-layer error is what `huma.Error429TooManyRequests(err.Error())` puts into the response body via `rateLimited429`).

## Simplify
No changes. Reviewed for reuse (existing duplication pattern preserved; substring routing already used partial matches), quality (no new state/params/conditionals; docstring update explains WHY per project convention), and efficiency (byte-equivalent change, no hot-path cost). Code already clean.

## Scope-adjacent (no widening per ticket)
`comment_service.go` has many other lowercase-leading error returns (`"comment body is required"`, `"only the comment author can edit this comment"`, `"replies to this comment are disabled"`, etc.). These are intentional Go-convention wrapped-error strings and are normalized at the display boundary by `capitalizeFirst` in `formatCommentSubmissionError`. Not in scope here. Worth a separate audit ticket if we want to standardize on capitalized-at-source for ALL user-visible service errors — happy to file if desired.

Closes PSY-594