### PR TITLE
PSY-585: add Cover image URL to Create Collection modal

### DIFF
--- a/frontend/features/collections/components/CollectionList.test.tsx
+++ b/frontend/features/collections/components/CollectionList.test.tsx
@@ -520,6 +520,127 @@ describe('CollectionList', () => {
     })
   })
 
+  // PSY-585: Cover image URL field on the Create modal — parity with Edit.
+  // The field renders, an empty value submits cleanly (no cover key in the
+  // payload), and a valid URL submits with the cover_image_url key set.
+  describe('cover image URL field on create (PSY-585)', () => {
+    beforeEach(() => {
+      mockAuthContext.mockReturnValue({
+        user: { id: '1' },
+        isAuthenticated: true,
+        isLoading: false,
+        logout: vi.fn(),
+      })
+      mockUseCollections.mockReturnValue({
+        data: { collections: [] },
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      })
+    })
+
+    it('renders the Cover image URL field with the create-only helper text', () => {
+      render(<CollectionList />)
+
+      // Field is present and has the URL input semantics. The accessible
+      // label includes the trailing "(optional)" hint span, so we match
+      // by data-testid to keep the assertion stable against copy tweaks.
+      const input = screen.getByTestId(
+        'create-cover-image-url-input'
+      ) as HTMLInputElement
+      expect(input).toBeInTheDocument()
+      expect(input.type).toBe('url')
+
+      // Helper copy: matches Edit form sans the "remove the current cover"
+      // half (no current cover to remove on create).
+      expect(
+        screen.getByText('Paste a direct image URL (e.g. Bandcamp art).')
+      ).toBeInTheDocument()
+    })
+
+    it('submits with cover_image_url when a valid URL is entered', async () => {
+      const user = userEvent.setup()
+      render(<CollectionList />)
+
+      const titleInput = screen.getByLabelText('Title') as HTMLInputElement
+      await user.type(titleInput, 'My Picks')
+
+      const coverInput = screen.getByTestId(
+        'create-cover-image-url-input'
+      ) as HTMLInputElement
+      await user.type(coverInput, 'https://example.com/cover.jpg')
+
+      // The form's submit button is the only button labeled "Create" (the
+      // header button reads "Create Collection"). Click it to fire submit.
+      const submitButton = screen.getByRole('button', { name: 'Create' })
+      await user.click(submitButton)
+
+      expect(mockCreateMutate).toHaveBeenCalled()
+      const callArgs = mockCreateMutate.mock.calls[0]
+      const payload = callArgs[0] as Record<string, unknown>
+      expect(payload).toMatchObject({
+        title: 'My Picks',
+        is_public: true,
+        collaborative: false,
+        cover_image_url: 'https://example.com/cover.jpg',
+      })
+    })
+
+    it('omits cover_image_url from the payload when the field is empty', async () => {
+      const user = userEvent.setup()
+      render(<CollectionList />)
+
+      const titleInput = screen.getByLabelText('Title') as HTMLInputElement
+      await user.type(titleInput, 'No Cover')
+
+      // Don't touch the cover field — it stays empty.
+      const submitButton = screen.getByRole('button', { name: 'Create' })
+      await user.click(submitButton)
+
+      expect(mockCreateMutate).toHaveBeenCalled()
+      const payload = mockCreateMutate.mock.calls[0][0] as Record<
+        string,
+        unknown
+      >
+      // JSON.stringify in the hook drops `undefined` keys, so we mirror
+      // that: empty cover URL means the key carries `undefined` here and
+      // never appears in the wire body.
+      expect(payload.cover_image_url).toBeUndefined()
+      expect(payload).toMatchObject({
+        title: 'No Cover',
+        is_public: true,
+        collaborative: false,
+      })
+    })
+
+    it('blocks submit and shows an inline error for an invalid URL', async () => {
+      const user = userEvent.setup()
+      render(<CollectionList />)
+
+      const titleInput = screen.getByLabelText('Title') as HTMLInputElement
+      await user.type(titleInput, 'Bad URL Test')
+
+      const coverInput = screen.getByTestId(
+        'create-cover-image-url-input'
+      ) as HTMLInputElement
+      // `not-a-url` fails the WHATWG URL parser → validateCoverImageUrl
+      // returns the "Enter a valid URL..." message.
+      await user.type(coverInput, 'not-a-url')
+      // Blur to flip `coverImageUrlTouched` so the error renders.
+      coverInput.blur()
+
+      // The Create submit button must be disabled while the URL is invalid.
+      const submitButton = screen.getByRole('button', {
+        name: 'Create',
+      }) as HTMLButtonElement
+      expect(submitButton.disabled).toBe(true)
+
+      // Clicking it should be a no-op (mutate must not fire).
+      await user.click(submitButton)
+      expect(mockCreateMutate).not.toHaveBeenCalled()
+    })
+  })
+
   // PSY-354: tag-filter URL plumbing.
   describe('tag filter (PSY-354)', () => {
     it('does not render the active-filter pill when ?tag is absent', () => {

--- a/frontend/features/collections/components/CollectionList.tsx
+++ b/frontend/features/collections/components/CollectionList.tsx
@@ -7,7 +7,11 @@ import { useDebounce } from 'use-debounce'
 import { useCollections, useMyCollections, useCreateCollection } from '../hooks'
 import { CollectionCard } from './CollectionCard'
 import { MarkdownEditor } from './MarkdownEditor'
-import { MAX_COLLECTION_MARKDOWN_LENGTH } from '../types'
+import {
+  MAX_COLLECTION_MARKDOWN_LENGTH,
+  MAX_COVER_IMAGE_URL_LENGTH,
+  validateCoverImageUrl,
+} from '../types'
 import { LoadingSpinner } from '@/components/shared'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -497,10 +501,26 @@ function CreateCollectionForm({ onSuccess }: { onSuccess: (slug?: string) => voi
   const [description, setDescription] = useState('')
   const [isPublic, setIsPublic] = useState(true)
   const [collaborative, setCollaborative] = useState(false)
+  // PSY-585: cover image URL on create — mirrors the Edit form's field
+  // shape (validation, preview, clear button) so users can set the cover
+  // in one step instead of create-then-immediately-edit. Empty string is
+  // the "no cover" affordance and is the default; we omit the field from
+  // the request payload entirely when it's empty so the backend stores
+  // null rather than an empty string.
+  const [coverImageUrl, setCoverImageUrl] = useState('')
+  const [coverImageUrlTouched, setCoverImageUrlTouched] = useState(false)
+
+  const trimmedCoverUrl = coverImageUrl.trim()
+  const coverImageUrlError = validateCoverImageUrl(coverImageUrl)
+  const showCoverImageUrlError =
+    coverImageUrlTouched && coverImageUrlError !== null
+  const showCoverImagePreview =
+    trimmedCoverUrl.length > 0 && coverImageUrlError === null
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
     if (!title.trim()) return
+    if (coverImageUrlError) return
 
     createMutation.mutate(
       {
@@ -508,11 +528,17 @@ function CreateCollectionForm({ onSuccess }: { onSuccess: (slug?: string) => voi
         description: description.trim() || undefined,
         is_public: isPublic,
         collaborative,
+        // Empty string means "no cover" — omit the field rather than
+        // sending an empty string so the backend column stays null.
+        cover_image_url:
+          trimmedCoverUrl.length === 0 ? undefined : trimmedCoverUrl,
       },
       {
         onSuccess: (data) => {
           setTitle('')
           setDescription('')
+          setCoverImageUrl('')
+          setCoverImageUrlTouched(false)
           onSuccess(data?.slug)
         },
       }
@@ -590,6 +616,85 @@ function CreateCollectionForm({ onSuccess }: { onSuccess: (slug?: string) => voi
         />
       </div>
 
+      {/* PSY-585: Cover image URL (parity with Edit form). Optional; empty
+          submits cleanly with no cover. Validation, inline preview, and
+          clear-button mirror the Edit form's shape — only the helper text
+          differs (no "remove the current cover" half on create). */}
+      <div>
+        <label
+          htmlFor="create-cover-image-url"
+          className="text-sm font-medium mb-1.5 block"
+        >
+          Cover image URL{' '}
+          <span className="text-xs font-normal text-muted-foreground">
+            (optional)
+          </span>
+        </label>
+        <div className="flex gap-2">
+          <Input
+            id="create-cover-image-url"
+            type="url"
+            inputMode="url"
+            value={coverImageUrl}
+            onChange={e => {
+              setCoverImageUrl(e.target.value)
+              setCoverImageUrlTouched(true)
+            }}
+            onBlur={() => setCoverImageUrlTouched(true)}
+            placeholder="https://example.com/cover.jpg"
+            maxLength={MAX_COVER_IMAGE_URL_LENGTH}
+            aria-invalid={showCoverImageUrlError ? true : undefined}
+            aria-describedby={
+              showCoverImageUrlError
+                ? 'create-cover-image-url-error'
+                : 'create-cover-image-url-help'
+            }
+            data-testid="create-cover-image-url-input"
+          />
+          {trimmedCoverUrl.length > 0 && (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                setCoverImageUrl('')
+                setCoverImageUrlTouched(true)
+              }}
+              data-testid="create-cover-image-url-clear"
+            >
+              <X className="h-4 w-4 mr-1" />
+              Clear
+            </Button>
+          )}
+        </div>
+        {showCoverImageUrlError ? (
+          <p
+            id="create-cover-image-url-error"
+            className="text-xs text-destructive mt-1.5"
+            role="alert"
+          >
+            {coverImageUrlError}
+          </p>
+        ) : (
+          <p
+            id="create-cover-image-url-help"
+            className="text-xs text-muted-foreground mt-1.5"
+          >
+            Paste a direct image URL (e.g. Bandcamp art).
+          </p>
+        )}
+        {showCoverImagePreview && (
+          <div className="mt-2 h-24 w-24 rounded-lg overflow-hidden border border-border/50 bg-muted/50">
+            <img
+              src={trimmedCoverUrl}
+              alt="Cover image preview"
+              className="h-full w-full object-cover"
+              data-testid="create-cover-image-url-preview"
+            />
+          </div>
+        )}
+      </div>
+
       <div className="flex items-center gap-6">
         <label className="flex items-center gap-2 text-sm cursor-pointer">
           <input
@@ -623,7 +728,12 @@ function CreateCollectionForm({ onSuccess }: { onSuccess: (slug?: string) => voi
       <div className="flex justify-end gap-2">
         <Button
           type="submit"
-          disabled={!title.trim() || createMutation.isPending || atOrOverCap}
+          disabled={
+            !title.trim() ||
+            coverImageUrlError !== null ||
+            createMutation.isPending ||
+            atOrOverCap
+          }
         >
           {createMutation.isPending ? 'Creating...' : 'Create'}
         </Button>

--- a/frontend/features/collections/hooks/index.test.tsx
+++ b/frontend/features/collections/hooks/index.test.tsx
@@ -317,6 +317,40 @@ describe('Collection mutation hooks', () => {
         })
       )
     })
+
+    // PSY-585: POST must round-trip cover_image_url so the Create modal can
+    // set the cover in one step (parity with the Edit form's PUT path).
+    it('forwards cover_image_url in the POST body', async () => {
+      mockApiRequest.mockResolvedValueOnce({ id: 1, title: 'New', slug: 'new' })
+
+      const { result } = renderHook(() => useCreateCollection(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        result.current.mutate({
+          title: 'New',
+          is_public: true,
+          collaborative: false,
+          cover_image_url: 'https://example.com/cover.jpg',
+        })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/collections',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            title: 'New',
+            is_public: true,
+            collaborative: false,
+            cover_image_url: 'https://example.com/cover.jpg',
+          }),
+        })
+      )
+    })
   })
 
   describe('useUpdateCollection', () => {

--- a/frontend/features/collections/hooks/index.ts
+++ b/frontend/features/collections/hooks/index.ts
@@ -209,6 +209,13 @@ export function useCreateCollection() {
       is_public: boolean
       collaborative: boolean
       display_mode?: CollectionDisplayMode
+      /**
+       * Cover image URL. PSY-585. Optional on create — omit / empty / null
+       * means no cover. Backend `CreateCollectionHandler` already accepts
+       * `cover_image_url` (PSY-371 added it for Update; the request struct
+       * carries it on POST too), so this is a UI-only wire-up.
+       */
+      cover_image_url?: string | null
     }) =>
       apiRequest<CollectionDetail>(API_ENDPOINTS.COLLECTIONS.LIST, {
         method: 'POST',


### PR DESCRIPTION
## Summary
- Adds a Cover image URL field to the Create Collection modal, mirroring the Edit form's field shape (input + clear button + URL validation + image preview).
- Backend POST `/collections` already accepts `cover_image_url` — no backend changes needed.
- Empty submits cleanly (key omitted from payload, backend stores null); valid URL submits with the field set; invalid URL shows inline error and disables Submit.

## Test plan
- [x] `bun run typecheck` — passed
- [x] `bun run test:run features/collections` — passed (278/278 across 9 files; 4 new test cases for the cover URL field — render, valid-submit, empty-submit, invalid-blocks-submit)

## Manual repro
**Render-only refactor carveout disclosure**: this PR was completed via orchestrator-takeover after the dispatched agent stalled at the chrome-devtools MCP boundary (PSY-627 watchdog pattern). Original-agent's manual repro never completed; orchestrator did NOT re-run the browser-MCP verification.

Mitigations:
- 4 unit tests assert the rendered field + form-submit payload shape comprehensively (renders with type=url + correct helper text, submits with `cover_image_url` set, omits the key when empty, blocks Submit on invalid URL via the existing `disabled` derivation).
- The implementation mirrors the Edit form's already-shipped field shape (`CollectionDetail.tsx:1889-1965`); the validation helper and max-length constant are imported from `../types` (shared with Edit).
- Recommended pre-merge spot-check on Vercel preview: open Create Collection modal, paste an image URL, submit, confirm cover renders on the new collection.

## Simplify
`/simplify` flagged the new Create field is ~95% identical to the Edit form's existing cover-URL field at `CollectionDetail.tsx:1889-1965` — both reviews recommend extracting a shared `<CoverImageUrlField>` primitive. **Deferred to a follow-up ticket** to keep this PR scoped to "add field to Create modal" rather than widening to a refactor of the Edit form. Extraction ticket coming separately.

## Note on takeover
Original dispatch agent stalled at chrome-devtools MCP during manual repro. Orchestrator took over: rebased onto current main (was 5 commits behind wave-2 merges), reset to origin's known-good commit, ran tests, opened PR.

Closes PSY-585