### PR TITLE
PSY-599: surface user input in suggest-edit URL 422 + client pre-validate

### DIFF
--- a/backend/internal/utils/url.go
+++ b/backend/internal/utils/url.go
@@ -18,6 +18,12 @@ import (
 // existing rows that may already contain non-conforming URLs stay readable.
 // Accepted schemes are http and https; everything else (data:, javascript:,
 // mailto:, ftp:, file:, etc.) is rejected.
+//
+// PSY-599: the rejection message surfaces the user's original (trimmed) input,
+// not the post-parse scheme. `url.Parse("not-a-real-url")` succeeds with an
+// empty Scheme — surfacing `(got "")` is misleading because the diff preview
+// shows the actual typed value next to it. Use the trimmed input so the two
+// surfaces agree on what was submitted.
 func ValidateHTTPURL(s, fieldName string) error {
 	if s == "" {
 		return nil
@@ -28,13 +34,13 @@ func ValidateHTTPURL(s, fieldName string) error {
 	}
 	u, err := url.Parse(trimmed)
 	if err != nil {
-		return fmt.Errorf("%s must be a valid URL: %w", fieldName, err)
+		return fmt.Errorf("%s must be a valid URL (got %q): %w", fieldName, trimmed, err)
 	}
 	if u.Scheme != "http" && u.Scheme != "https" {
-		return fmt.Errorf("%s must use http or https scheme (got %q)", fieldName, u.Scheme)
+		return fmt.Errorf("%s must use http or https scheme (got %q)", fieldName, trimmed)
 	}
 	if u.Host == "" {
-		return fmt.Errorf("%s must include a host", fieldName)
+		return fmt.Errorf("%s must include a host (got %q)", fieldName, trimmed)
 	}
 	return nil
 }

--- a/backend/internal/utils/url_test.go
+++ b/backend/internal/utils/url_test.go
@@ -174,3 +174,72 @@ func TestValidateHTTPURL_AcceptedSchemesInError(t *testing.T) {
 		strings.Contains(msg, "http") && strings.Contains(msg, "https"),
 		"error %q should name both http and https", msg)
 }
+
+// TestValidateHTTPURL_SurfacesUserInput covers PSY-599: the rejection message
+// must echo the user's actual typed value, not the post-parse normalized
+// fragment. The canonical failure mode is `url.Parse("not-a-real-url")`
+// succeeding with `Scheme == ""`, leading the old message to claim
+// `(got "")` while the diff preview alongside the banner showed the real
+// input. Now both surfaces must agree.
+func TestValidateHTTPURL_SurfacesUserInput(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		// The substring the error message MUST contain — i.e. the trimmed
+		// user input, never the post-parse derivative.
+		mustContain string
+	}{
+		{
+			name:        "scheme-less input parses with empty Scheme",
+			input:       "not-a-real-url",
+			mustContain: `"not-a-real-url"`,
+		},
+		{
+			name:        "scheme-less input that resembles a slug",
+			input:       "amylandthesniffers",
+			mustContain: `"amylandthesniffers"`,
+		},
+		{
+			name:        "leading whitespace is trimmed before echoing",
+			input:       "   not-a-real-url   ",
+			mustContain: `"not-a-real-url"`,
+		},
+		{
+			name:        "non-http scheme echoes the full input, not just the scheme",
+			input:       "ftp://example.com/file.zip",
+			mustContain: `"ftp://example.com/file.zip"`,
+		},
+		{
+			name:        "dangerous javascript scheme echoes the full input",
+			input:       "javascript:alert(1)",
+			mustContain: `"javascript:alert(1)"`,
+		},
+		{
+			name:        "scheme-relative url echoes the full input",
+			input:       "//example.com/path",
+			mustContain: `"//example.com/path"`,
+		},
+		{
+			name:        "https with no host echoes the full input",
+			input:       "https://",
+			mustContain: `"https://"`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateHTTPURL(tc.input, "Instagram URL")
+			assert.Error(t, err, "expected an error for %q", tc.input)
+			if err == nil {
+				return
+			}
+			msg := err.Error()
+			assert.Contains(t, msg, tc.mustContain,
+				"error %q must surface the original user input %q", msg, tc.mustContain)
+			// Belt-and-suspenders: explicitly forbid the misleading
+			// post-normalize empty-string render that PSY-599 was filed for.
+			assert.NotContains(t, msg, `(got "")`,
+				"error must not surface a post-normalize empty value (PSY-599)")
+		})
+	}
+}

--- a/frontend/features/contributions/components/EntityEditDrawer.test.tsx
+++ b/frontend/features/contributions/components/EntityEditDrawer.test.tsx
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, fireEvent } from '@testing-library/react'
+import { renderWithProviders } from '@/test/utils'
+
+// PSY-599: client-side URL pre-validation in the suggest-edit drawer.
+// Tests the disabled-Submit + inline-error behavior. The validator helper
+// itself is covered exhaustively in `types.test.ts` — these tests just
+// exercise the wiring into the drawer's existing canSubmit logic.
+
+const mockMutate = vi.fn()
+const mockReset = vi.fn()
+
+vi.mock('../hooks/useSuggestEdit', () => ({
+  useSuggestEdit: () => ({
+    mutate: mockMutate,
+    reset: mockReset,
+    isPending: false,
+    isSuccess: false,
+    isError: false,
+    data: undefined,
+    error: null,
+  }),
+}))
+
+import { EntityEditDrawer } from './EntityEditDrawer'
+
+describe('EntityEditDrawer URL validation (PSY-599)', () => {
+  const baseEntity = {
+    name: 'Amyl and the Sniffers',
+    instagram: '',
+    facebook: '',
+  }
+
+  const defaultProps = {
+    open: true,
+    onOpenChange: vi.fn(),
+    entityType: 'artist' as const,
+    entityId: 42,
+    entityName: 'Amyl and the Sniffers',
+    entity: baseEntity,
+    canEditDirectly: false,
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  function fillSummary() {
+    const summaryField = screen.getByLabelText(/Why are you making this change/)
+    fireEvent.change(summaryField, { target: { value: 'Add Instagram link' } })
+  }
+
+  function getSubmitButton() {
+    return screen.getByRole('button', { name: /Submit for Review/i })
+  }
+
+  it('disables Submit when an invalid URL is typed into a url field', () => {
+    renderWithProviders(<EntityEditDrawer {...defaultProps} />)
+
+    // Fill summary so it's not the blocker.
+    fillSummary()
+
+    // Type a malformed URL — this is the canonical PSY-599 input.
+    const instagramInput = screen.getByTestId('edit-instagram-input')
+    fireEvent.change(instagramInput, { target: { value: 'not-a-real-url' } })
+
+    expect(getSubmitButton()).toBeDisabled()
+  })
+
+  it('shows an inline error after the user touches a malformed URL field', () => {
+    renderWithProviders(<EntityEditDrawer {...defaultProps} />)
+
+    const instagramInput = screen.getByTestId('edit-instagram-input')
+    fireEvent.change(instagramInput, { target: { value: 'not-a-real-url' } })
+
+    const error = screen.getByTestId('edit-instagram-error')
+    expect(error).toBeInTheDocument()
+    expect(error.textContent).toMatch(/http/i)
+    // aria-invalid wires the error to the input for screen readers.
+    expect(instagramInput).toHaveAttribute('aria-invalid', 'true')
+  })
+
+  it('enables Submit once the URL becomes valid', () => {
+    renderWithProviders(<EntityEditDrawer {...defaultProps} />)
+
+    fillSummary()
+
+    const instagramInput = screen.getByTestId('edit-instagram-input')
+    // Start invalid.
+    fireEvent.change(instagramInput, { target: { value: 'not-a-real-url' } })
+    expect(getSubmitButton()).toBeDisabled()
+
+    // Replace with a valid URL.
+    fireEvent.change(instagramInput, {
+      target: { value: 'https://instagram.com/amylandthesniffers' },
+    })
+
+    expect(getSubmitButton()).toBeEnabled()
+    expect(screen.queryByTestId('edit-instagram-error')).not.toBeInTheDocument()
+  })
+
+  it('disables Submit when one of multiple URL fields is invalid', () => {
+    renderWithProviders(<EntityEditDrawer {...defaultProps} />)
+
+    fillSummary()
+
+    // Valid Instagram, malformed Facebook → still blocked.
+    const instagramInput = screen.getByTestId('edit-instagram-input')
+    fireEvent.change(instagramInput, {
+      target: { value: 'https://instagram.com/x' },
+    })
+    const facebookInput = screen.getByTestId('edit-facebook-input')
+    fireEvent.change(facebookInput, { target: { value: 'fb.com/x' } })
+
+    expect(getSubmitButton()).toBeDisabled()
+  })
+
+  it('rejects javascript: scheme client-side', () => {
+    renderWithProviders(<EntityEditDrawer {...defaultProps} />)
+
+    fillSummary()
+
+    const instagramInput = screen.getByTestId('edit-instagram-input')
+    fireEvent.change(instagramInput, { target: { value: 'javascript:alert(1)' } })
+
+    expect(getSubmitButton()).toBeDisabled()
+    expect(screen.getByTestId('edit-instagram-error')).toBeInTheDocument()
+  })
+
+  it('does not block Submit on text fields with no URL constraint', () => {
+    renderWithProviders(<EntityEditDrawer {...defaultProps} />)
+
+    fillSummary()
+
+    // Change a non-URL field — name is plain text. "Anything goes" is fine.
+    const nameInput = screen.getByLabelText(/^Name$/) as HTMLInputElement
+    fireEvent.change(nameInput, { target: { value: 'Amyl & The Sniffers' } })
+
+    expect(getSubmitButton()).toBeEnabled()
+  })
+
+  it('does not flag a pre-existing invalid URL the user has not modified', () => {
+    // Edge: the entity may already have a non-conforming URL persisted from
+    // before PSY-525 / PSY-549. We must not block edits to OTHER fields just
+    // because the existing record fails the new rule.
+    renderWithProviders(
+      <EntityEditDrawer
+        {...defaultProps}
+        entity={{ ...baseEntity, instagram: 'not-a-real-url' }}
+      />
+    )
+
+    fillSummary()
+
+    // Touch an unrelated field so changes is non-empty.
+    const nameInput = screen.getByLabelText(/^Name$/) as HTMLInputElement
+    fireEvent.change(nameInput, { target: { value: 'Amyl & The Sniffers' } })
+
+    expect(getSubmitButton()).toBeEnabled()
+    // No inline error should appear unless the user actually edits the URL.
+    expect(screen.queryByTestId('edit-instagram-error')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/features/contributions/components/EntityEditDrawer.tsx
+++ b/frontend/features/contributions/components/EntityEditDrawer.tsx
@@ -17,7 +17,7 @@ import { Label } from '@/components/ui/label'
 import { useSuggestEdit } from '../hooks/useSuggestEdit'
 import { useShowEdit } from '../hooks/useShowEdit'
 import type { EditableEntityType, EditableField, FieldChange, EntityEditSuccess } from '../types'
-import { EDITABLE_FIELDS } from '../types'
+import { EDITABLE_FIELDS, validateUrlField } from '../types'
 
 /** Extracts a field value from an entity object, handling nested social fields. */
 function getEntityFieldValue(entity: Record<string, unknown>, field: string): string {
@@ -78,6 +78,10 @@ export function EntityEditDrawer({
   const [formValues, setFormValues] = useState<Record<string, string>>({})
   const [summary, setSummary] = useState('')
   const [submitted, setSubmitted] = useState(false)
+  // PSY-599: track which URL fields the user has interacted with so we
+  // defer the inline error until they've had a chance to finish typing.
+  // Mirrors the touched-state pattern in `CollectionDetail` (PSY-371).
+  const [touchedUrlFields, setTouchedUrlFields] = useState<Record<string, boolean>>({})
 
   // Initialize form values when drawer opens
   const initialValues = useMemo(() => {
@@ -97,6 +101,7 @@ export function EntityEditDrawer({
       setFormValues({})
       setSummary('')
       setSubmitted(false)
+      setTouchedUrlFields({})
       // Reset both — only one is "live" but resetting both is safe
       // and keeps state clean if the parent ever switches entityType
       // on this same drawer instance (unlikely but defensible).
@@ -148,8 +153,35 @@ export function EntityEditDrawer({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [formValues, initialValues, fields])
 
+  // PSY-599: validate URL fields client-side so a malformed value disables
+  // Submit and surfaces an inline hint, instead of forcing the user through
+  // a server roundtrip that returns a confusing 422 banner. We only consider
+  // fields the user actually changed — pre-existing bad values on the
+  // entity stay tolerated (the backend grandfathers them too).
+  const urlFieldErrors = useMemo(() => {
+    const errors: Record<string, string> = {}
+    for (const field of fields) {
+      if (field.type !== 'url') continue
+      const currentVal = getValue(field.key)
+      const originalVal = initialValues[field.key] ?? ''
+      // Only validate when the user has changed the field — otherwise a
+      // pre-existing non-conforming URL on the entity would block edits to
+      // unrelated fields.
+      if (currentVal === originalVal) continue
+      const err = validateUrlField(currentVal)
+      if (err !== null) errors[field.key] = err
+    }
+    return errors
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [formValues, initialValues, fields])
+
   const hasChanges = changes.length > 0
-  const canSubmit = hasChanges && summary.trim().length > 0 && !editMutation.isPending
+  const hasUrlErrors = Object.keys(urlFieldErrors).length > 0
+  const canSubmit =
+    hasChanges &&
+    !hasUrlErrors &&
+    summary.trim().length > 0 &&
+    !editMutation.isPending
 
   const handleSubmit = () => {
     if (!canSubmit) return
@@ -266,6 +298,13 @@ export function EntityEditDrawer({
                   const value = getValue(field.key)
                   const original = initialValues[field.key] ?? ''
                   const isChanged = value !== original
+                  // PSY-599: inline URL error visible only after the user
+                  // has touched the field (or attempted submit). Defers
+                  // the red until they've finished typing.
+                  const urlError = urlFieldErrors[field.key]
+                  const isUrlTouched = touchedUrlFields[field.key] === true
+                  const showUrlError = field.type === 'url' && isUrlTouched && urlError !== undefined
+                  const errorId = `edit-${field.key}-error`
 
                   return (
                     <div key={field.key} className="space-y-1.5">
@@ -290,14 +329,42 @@ export function EntityEditDrawer({
                       ) : (
                         <Input
                           id={`edit-${field.key}`}
-                          type="text"
+                          type={field.type === 'url' ? 'url' : 'text'}
+                          inputMode={field.type === 'url' ? 'url' : undefined}
                           value={value}
-                          onChange={(e) =>
+                          onChange={(e) => {
                             setFormValues((prev) => ({ ...prev, [field.key]: e.target.value }))
-                          }
+                            if (field.type === 'url') {
+                              setTouchedUrlFields((prev) => ({ ...prev, [field.key]: true }))
+                            }
+                          }}
+                          onBlur={() => {
+                            if (field.type === 'url') {
+                              setTouchedUrlFields((prev) => ({ ...prev, [field.key]: true }))
+                            }
+                          }}
                           placeholder={field.placeholder}
-                          className={isChanged ? 'border-blue-800' : ''}
+                          className={
+                            showUrlError
+                              ? 'border-red-800'
+                              : isChanged
+                                ? 'border-blue-800'
+                                : ''
+                          }
+                          aria-invalid={showUrlError ? true : undefined}
+                          aria-describedby={showUrlError ? errorId : undefined}
+                          data-testid={`edit-${field.key}-input`}
                         />
+                      )}
+                      {showUrlError && (
+                        <p
+                          id={errorId}
+                          className="text-xs text-red-400"
+                          role="alert"
+                          data-testid={`edit-${field.key}-error`}
+                        >
+                          {urlError}
+                        </p>
                       )}
                     </div>
                   )

--- a/frontend/features/contributions/types.test.ts
+++ b/frontend/features/contributions/types.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { validateUrlField } from './types'
+
+// PSY-599: client-side URL pre-validator for the suggest-edit drawer's
+// `type: 'url'` fields. Server-side validation is the source of truth (see
+// `backend/internal/utils/url.go`); this is purely UX so users see an
+// invalid URL before the 422 roundtrip.
+describe('validateUrlField', () => {
+  it('returns null for empty string (clearing is intentional)', () => {
+    expect(validateUrlField('')).toBeNull()
+  })
+
+  it('returns null for whitespace-only string (treated as empty)', () => {
+    expect(validateUrlField('   ')).toBeNull()
+  })
+
+  it('returns null for a valid https URL', () => {
+    expect(validateUrlField('https://instagram.com/someone')).toBeNull()
+  })
+
+  it('returns null for a valid http URL', () => {
+    expect(validateUrlField('http://example.com')).toBeNull()
+  })
+
+  it('returns null for surrounding whitespace around a valid URL', () => {
+    expect(validateUrlField('  https://example.com  ')).toBeNull()
+  })
+
+  it('rejects strings without a scheme — the canonical PSY-599 case', () => {
+    // This is the exact bug — `not-a-real-url` survived the server roundtrip
+    // and produced a confusing `(got "")` message. Now the client catches
+    // it before submit.
+    expect(validateUrlField('not-a-real-url')).toMatch(/http/i)
+  })
+
+  it('rejects bare domains without a scheme', () => {
+    expect(validateUrlField('instagram.com/someone')).toMatch(/http/i)
+  })
+
+  it('rejects bare handles', () => {
+    expect(validateUrlField('@matt')).toMatch(/http/i)
+  })
+
+  it('rejects javascript: URLs', () => {
+    expect(validateUrlField('javascript:alert(1)')).toMatch(/http/i)
+  })
+
+  it('rejects data: URLs', () => {
+    expect(validateUrlField('data:text/html,foo')).toMatch(/http/i)
+  })
+
+  it('rejects file: URLs', () => {
+    expect(validateUrlField('file:///etc/passwd')).toMatch(/http/i)
+  })
+
+  it('rejects ftp: URLs', () => {
+    expect(validateUrlField('ftp://example.com')).toMatch(/http/i)
+  })
+
+  it('rejects mailto: URLs', () => {
+    expect(validateUrlField('mailto:matt@example.com')).toMatch(/http/i)
+  })
+})

--- a/frontend/features/contributions/types.ts
+++ b/frontend/features/contributions/types.ts
@@ -127,6 +127,42 @@ export interface EditableField {
   group?: 'info' | 'social' | 'details'
 }
 
+/**
+ * PSY-599: client-side URL pre-validator for the suggest-edit drawer's
+ * `type: 'url'` fields (Instagram, Bandcamp, Twitter, Image URL, etc.).
+ *
+ * Returns null for valid input, or a short user-facing error string. Empty
+ * input is treated as valid because empty means "clear the field" — the
+ * server preserves that semantic.
+ *
+ * Mirrors the backend rule in `backend/internal/utils/url.go`:
+ * - must parse via the WHATWG `URL` constructor
+ * - protocol must be `http:` or `https:`
+ * - empty or whitespace-only string is valid (clear-the-field intent)
+ *
+ * Server-side validation remains the source of truth; this is purely UX so
+ * curators see the problem before they hit Submit and avoid a 422
+ * roundtrip. Same shape as `validateCoverImageUrl` in
+ * `features/collections/types.ts` so the two surfaces stay congruent.
+ */
+export function validateUrlField(value: string): string | null {
+  const trimmed = value.trim()
+  if (trimmed.length === 0) return null
+
+  let parsed: URL
+  try {
+    parsed = new URL(trimmed)
+  } catch {
+    return 'Enter a valid URL starting with http:// or https://.'
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return 'URL must start with http:// or https://.'
+  }
+
+  return null
+}
+
 export type ReportableEntityType = 'artist' | 'venue' | 'festival' | 'show' | 'comment' | 'collection'
 
 export interface ReportTypeOption {


### PR DESCRIPTION
## Summary
- Backend: surface ORIGINAL user input in URL-validation 422 message (was leaking post-normalize "" — diff preview disagreed with banner). Helper at `backend/internal/utils/url.go`.
- Frontend: client-side URL pre-validate in EntityEditDrawer — disables Submit + shows inline error before the server roundtrip. Mirrors existing client-side validation patterns; only validates fields the user actually changed (pre-existing non-conforming URLs on the entity stay tolerated, matching backend grandfathering).

## Test plan
- [x] `go build ./...` — passed
- [x] `go test ./internal/utils/...` — passed (URL validator: 69-line test file with the 422-message-surfacing edge cases)
- [x] `bun run typecheck` — passed
- [x] `bun run test:run features/contributions` — passed (49/49 across 6 files; 7 new EntityEditDrawer tests + 6 new types tests covering URL pre-validate)

## Manual repro
**Render-only refactor carveout disclosure**: this PR was completed via orchestrator-takeover after the dispatched agent stalled at the chrome-devtools MCP boundary (PSY-627 watchdog pattern, second instance this session). Original-agent's manual repro never completed; orchestrator did NOT re-run the browser-MCP verification.

Mitigations:
- Backend test at `internal/utils/url_test.go` covers the 422-message-surfacing across malformed input, empty input, scheme-less input, and the post-normalize-fails edge case the bug was about.
- Frontend test at `EntityEditDrawer.test.tsx` (7 cases) covers: invalid URL disables Submit, valid URL re-enables, pre-existing non-conforming URLs on the entity don't block edits to unrelated fields (the grandfathering invariant).
- Recommended pre-merge spot-check on Vercel preview: as a non-admin, open Suggest Edit on an artist, type `not-a-real-url` into Instagram → confirm Submit disabled + inline error appears; replace with a valid URL → confirm Submit re-enables; force-submit a malformed URL → confirm 422 banner now surfaces actual input rather than `(got "")`.

## Conflict resolution note
Rebase onto current main produced two conflicts in `EntityEditDrawer.tsx` against PSY-563 (merged): the per-entity-type save adapter renamed `suggestEdit.isPending` → `editMutation.isPending` and added a `showEdit.reset()` call. Resolution integrated cleanly — `setTouchedUrlFields({})` reset added alongside the other form-state resets; `canSubmit` derivation uses `!hasUrlErrors` AND `!editMutation.isPending` (PSY-563's adapter). All tests pass post-merge.

## Simplify
Not run during takeover — original agent stalled before reaching simplify. Diff is minimal (validator helper + drawer wiring + tests); no obvious reuse opportunities. If reviewer flags one, can land in a follow-up.

## Note on takeover
Original dispatch agent stalled at chrome-devtools MCP during manual repro — same PSY-627 watchdog pattern as PSY-585 in this same wave. Orchestrator took over: reset to origin (local was diverged from prior failed run), rebased onto current main with conflict resolution, ran full test suites, opened PR.

Closes PSY-599