### PR TITLE
PSY-631: fix E2E submit-show tests after PSY-600 route move

### DIFF
--- a/frontend/e2e/auth/verify-email.spec.ts
+++ b/frontend/e2e/auth/verify-email.spec.ts
@@ -26,13 +26,15 @@ test.describe('Email Verification', () => {
     // Navigate to the verify-email page with the token
     await page.goto(`/verify-email?token=${token}`)
 
-    // Assert success state
+    // Assert success state. Scope CTA assertions to <main> so the sidebar's
+    // "Submit a Show" nav link (PSY-600) doesn't trip strict-mode resolution.
     await expect(page.getByText('Email Verified!')).toBeVisible({
       timeout: 15_000,
     })
-    await expect(page.getByRole('link', { name: 'Submit a Show' })).toBeVisible()
+    const main = page.getByRole('main')
+    await expect(main.getByRole('link', { name: 'Submit a Show' })).toBeVisible()
     await expect(
-      page.getByRole('link', { name: 'Go to My Library' })
+      main.getByRole('link', { name: 'Go to My Library' })
     ).toBeVisible()
   })
 

--- a/frontend/e2e/auth/verify-email.spec.ts
+++ b/frontend/e2e/auth/verify-email.spec.ts
@@ -31,10 +31,11 @@ test.describe('Email Verification', () => {
     await expect(page.getByText('Email Verified!')).toBeVisible({
       timeout: 15_000,
     })
-    const main = page.getByRole('main')
-    await expect(main.getByRole('link', { name: 'Submit a Show' })).toBeVisible()
     await expect(
-      main.getByRole('link', { name: 'Go to My Library' })
+      page.getByRole('main').getByRole('link', { name: 'Submit a Show' })
+    ).toBeVisible()
+    await expect(
+      page.getByRole('main').getByRole('link', { name: 'Go to My Library' })
     ).toBeVisible()
   })
 

--- a/frontend/e2e/pages/submit-show.spec.ts
+++ b/frontend/e2e/pages/submit-show.spec.ts
@@ -15,7 +15,7 @@ test.describe('Submit a show', () => {
   test('displays submission form for verified user', async ({
     authenticatedPage,
   }) => {
-    await authenticatedPage.goto('/submissions')
+    await authenticatedPage.goto('/shows/submit')
 
     // Page heading
     await expect(
@@ -49,7 +49,7 @@ test.describe('Submit a show', () => {
     authenticatedPage,
     cleanBetweenRetries: _cleanup,
   }) => {
-    await authenticatedPage.goto('/submissions')
+    await authenticatedPage.goto('/shows/submit')
 
     await expect(
       authenticatedPage.getByRole('heading', { name: 'Submit a Show' })

--- a/frontend/e2e/pages/submit-show.spec.ts
+++ b/frontend/e2e/pages/submit-show.spec.ts
@@ -123,7 +123,7 @@ unauthTest.describe('Submit show — unauthenticated', () => {
   unauthTest(
     'redirects unauthenticated user to login',
     async ({ page }) => {
-      await page.goto('/submissions')
+      await page.goto('/shows/submit')
 
       // Should redirect to auth page
       await page.waitForURL(/\/auth/, { timeout: 10_000 })


### PR DESCRIPTION
## Summary
- Update 3 broken E2E tests after PSY-600 (PR #590) moved `/submissions` → `/shows/submit` and added a "Submit a Show" sidebar nav link.
- `submit-show.spec.ts`: 3 sites navigate to `/shows/submit` (2 authenticated + 1 unauth redirect test).
- `verify-email.spec.ts`: scope success-state CTA assertions to `<main>` so the sidebar's "Submit a Show" link doesn't trip Playwright's strict-mode resolution.

## Test plan
- [x] `bun run typecheck` — passed
- [x] `bun run test:e2e -- e2e/pages/submit-show.spec.ts e2e/auth/verify-email.spec.ts` — 6 passed (22.4s, post-simplify)

## Manual repro
Test name + assertion outcome IS the manual repro for an E2E selector fix. Local run reproduced all 3 originally-failing cases from origin/main (`verifies email with valid token`, `displays submission form for verified user`, `submits a show with existing venue`) and confirmed they now pass alongside the 3 previously-passing cases in the same specs — total 6/6 green. Pre-fix CI evidence: https://github.com/mtrifilo/psychic-homily-web/actions/runs/25642537899

## Simplify
edited 2 files, +5 -4 net lines — inlined a 2-use `page.getByRole('main')` extraction in verify-email.spec.ts and migrated the unauth submit-show redirect test (`/submissions` → `/shows/submit`) so it tests its documented intent rather than passing by PSY-600 coincidence.

Closes PSY-631