### PR TITLE
PSY-607: lock in no-email-leak invariant for moderation report bylines

### DIFF
--- a/backend/internal/services/admin/entity_report_test.go
+++ b/backend/internal/services/admin/entity_report_test.go
@@ -312,7 +312,6 @@ func (s *EntityReportServiceIntegrationTestSuite) TestCreateEntityReport_EmailOn
 	s.NoError(err)
 	s.Require().NotNil(resp)
 	s.Equal(emailLocalPart, resp.ReporterName, "must render email prefix, not full email")
-	s.NotEqual(emailFull, resp.ReporterName, "full email must never leak into the byline")
 	s.NotContains(resp.ReporterName, "@", "byline must never contain '@' for email-only users")
 	s.Nil(resp.ReporterUsername, "username should be nil when not set on the user")
 }
@@ -624,20 +623,16 @@ func (s *EntityReportServiceIntegrationTestSuite) TestListEntityReports_MixedRep
 	s.NoError(err)
 	s.Require().Len(reports, 2)
 
+	// The username-set reporter renders their username; the email-only
+	// reporter renders their email PREFIX. Neither byline contains "@" —
+	// that's the no-email-leak invariant. Keyed by report_type so the
+	// assertion is robust to listing order changes.
+	resolvedNames := make(map[string]string, len(reports))
 	for _, r := range reports {
-		s.NotEmpty(r.ReporterName, "every reporter must render through the resolver chain")
 		s.NotContains(
 			r.ReporterName, "@",
 			"reporter byline must never contain '@' — that's an email leak (PSY-607)",
 		)
-		s.NotEqual(emailFull, r.ReporterName, "full email must never appear in byline")
-	}
-
-	// Sanity-check the per-reporter resolution is what we expect: the
-	// username-set reporter renders their username; the email-only reporter
-	// renders their email PREFIX.
-	resolvedNames := make(map[string]string, len(reports))
-	for _, r := range reports {
 		resolvedNames[r.ReportType] = r.ReporterName
 	}
 	s.Equal(*withUsername.Username, resolvedNames["closed_permanently"])

--- a/backend/internal/services/admin/entity_report_test.go
+++ b/backend/internal/services/admin/entity_report_test.go
@@ -279,6 +279,44 @@ func (s *EntityReportServiceIntegrationTestSuite) TestCreateEntityReport_NoUsern
 	s.Nil(resp.ReporterUsername, "username should be nil when not set on the user")
 }
 
+// TestCreateEntityReport_EmailOnlyReporter_NoEmailLeak locks in the PSY-607
+// invariant: when a reporter has only an email (no username, no first/last
+// name), the byline must render the email PREFIX (local-part before "@")
+// — never the full email address.
+//
+// Pre-PSY-612 regression: the entity_report service had its own `displayName`
+// helper whose terminal branch returned `*u.Email` verbatim, which leaked
+// `asdf@admin.com` into the admin moderation queue (dogfood ISSUE-009 —
+// `dogfood-output/pending-edits/screenshots/reject-step-4-result.png`).
+// PSY-612 swapped to `shared.ResolveUserName`, which falls through to the
+// email-prefix step instead. This test asserts that contract at the service
+// boundary so a future regression can't reintroduce the full-email leak.
+func (s *EntityReportServiceIntegrationTestSuite) TestCreateEntityReport_EmailOnlyReporter_NoEmailLeak() {
+	emailLocalPart := fmt.Sprintf("er-emailonly-%d", time.Now().UnixNano())
+	emailFull := emailLocalPart + "@admin.com"
+	user := &authm.User{
+		Email:         &emailFull,
+		IsActive:      true,
+		EmailVerified: true,
+	}
+	s.Require().NoError(s.db.Create(user).Error)
+	artist := s.createTestArtist("Test Artist")
+
+	resp, err := s.svc.CreateEntityReport(&contracts.CreateEntityReportRequest{
+		EntityType: "artist",
+		EntityID:   artist.ID,
+		UserID:     user.ID,
+		ReportType: "inaccurate",
+	})
+
+	s.NoError(err)
+	s.Require().NotNil(resp)
+	s.Equal(emailLocalPart, resp.ReporterName, "must render email prefix, not full email")
+	s.NotEqual(emailFull, resp.ReporterName, "full email must never leak into the byline")
+	s.NotContains(resp.ReporterName, "@", "byline must never contain '@' for email-only users")
+	s.Nil(resp.ReporterUsername, "username should be nil when not set on the user")
+}
+
 func (s *EntityReportServiceIntegrationTestSuite) TestCreateEntityReport_VenueSuccess() {
 	user := s.createTestUser()
 	venue := s.createTestVenue("Test Venue")
@@ -551,6 +589,59 @@ func (s *EntityReportServiceIntegrationTestSuite) TestListEntityReports_Paginati
 	s.NoError(err)
 	s.Equal(int64(3), total)
 	s.Len(reports, 1)
+}
+
+// TestListEntityReports_MixedReporterAccounts_NoEmailLeak locks in the
+// PSY-607 invariant for the LIST path — the admin moderation queue's hot
+// path. Reports from a username-set reporter and an email-only reporter
+// must render with consistent attribution formatting: username for the
+// first, email-PREFIX (never the full email) for the second.
+//
+// Repro evidence: dogfood ISSUE-009 showed two adjacent Van Buren report
+// rows with mismatched byline format (one `by testuser2`, one
+// `by asdf@admin.com`) — the email-leak side of that mismatch is what this
+// test pins.
+func (s *EntityReportServiceIntegrationTestSuite) TestListEntityReports_MixedReporterAccounts_NoEmailLeak() {
+	withUsername := s.createTestUser()
+
+	emailLocalPart := fmt.Sprintf("er-mixed-emailonly-%d", time.Now().UnixNano())
+	emailFull := emailLocalPart + "@admin.com"
+	emailOnly := &authm.User{
+		Email:         &emailFull,
+		IsActive:      true,
+		EmailVerified: true,
+	}
+	s.Require().NoError(s.db.Create(emailOnly).Error)
+
+	venue := s.createTestVenue("Mixed Reporters Venue")
+	s.createReport("venue", venue.ID, withUsername.ID, "closed_permanently")
+	s.createReport("venue", venue.ID, emailOnly.ID, "inaccurate")
+
+	reports, _, err := s.svc.ListEntityReports(&contracts.EntityReportFilters{
+		Status:     "pending",
+		EntityType: "venue",
+	})
+	s.NoError(err)
+	s.Require().Len(reports, 2)
+
+	for _, r := range reports {
+		s.NotEmpty(r.ReporterName, "every reporter must render through the resolver chain")
+		s.NotContains(
+			r.ReporterName, "@",
+			"reporter byline must never contain '@' — that's an email leak (PSY-607)",
+		)
+		s.NotEqual(emailFull, r.ReporterName, "full email must never appear in byline")
+	}
+
+	// Sanity-check the per-reporter resolution is what we expect: the
+	// username-set reporter renders their username; the email-only reporter
+	// renders their email PREFIX.
+	resolvedNames := make(map[string]string, len(reports))
+	for _, r := range reports {
+		resolvedNames[r.ReportType] = r.ReporterName
+	}
+	s.Equal(*withUsername.Username, resolvedNames["closed_permanently"])
+	s.Equal(emailLocalPart, resolvedNames["inaccurate"])
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- Adds two integration tests that lock in the PSY-607 invariant for the admin moderation queue's report-row byline: the resolved username (or email PREFIX for email-only reporters) — never the full email address.
- No production code change. The dogfood evidence (`dogfood-output/pending-edits/screenshots/reject-step-4-result.png`, May 4) predates PSY-612 (May 5) and PSY-619 (May 6), both of which already wired the canonical resolver chain (`shared.ResolveUserName` / `ResolveUserUsername`) through `EntityReportResponse`. The remaining gap was test coverage — the existing `TestCreateEntityReport_NoUsername` only asserts `ReporterName` is non-empty, which would not catch a regression that reintroduced a full-email fallback.

## Test plan

- [x] `cd backend && go build ./...` — clean
- [x] `cd backend && go test ./internal/services/shared/ ./internal/services/admin/` — pass (shared 1.65s, admin 169.97s, both green)
- [x] `cd backend && go test ./internal/api/handlers/community/... -run "EntityReport"` — pass
- [x] `cd frontend && bun run typecheck` — clean
- [x] `cd frontend && bun run test:run app/admin/moderation` — pass (19/19)
- [x] `cd frontend && bun run test:run components/shared/UserAttribution` — pass (14/14)

## Manual repro

Backend-only with no migration → integration tests ARE the manual repro (per `pattern_dispatch_stacks.md` `mode=none`). Two new tests reproduce the exact ISSUE-009 scenario at the service boundary:

- `TestCreateEntityReport_EmailOnlyReporter_NoEmailLeak` — creates an email-only reporter (`er-emailonly-{nano}@admin.com`), reports an artist, asserts `ReporterName == "er-emailonly-{nano}"` and `!strings.Contains(ReporterName, "@")`. Passes — confirms the create path renders the email PREFIX, not the full email.
- `TestListEntityReports_MixedReporterAccounts_NoEmailLeak` — creates two reporters (one with username, one email-only), submits a report from each on the same venue, calls `ListEntityReports` (the admin moderation queue's hot path), asserts both bylines render through the resolver chain with no `@` leak. Passes — confirms adjacent rows render with consistent attribution formatting.

Both fail loudly if a future refactor reintroduces the pre-PSY-612 `return *u.Email` terminal branch — that's the invariant PSY-607 was opened to codify.

## Simplify

Ran `/simplify`. Dropped two redundant `NotEqual(emailFull, ...)` assertions because `NotContains("@", ...)` already covers them. Folded a per-test "sanity-check" comment into the loop intent. Net -10 lines, no behaviour change.

## Notes for reviewer

- The dogfood screenshot in `dogfood-output/pending-edits/report.md#issue-009` shows `by asdf@admin.com` in the moderation queue. That predates PSY-612 (which replaced the entity_report service's local `displayName` helper that had `return *u.Email` as its terminal fallback) and PSY-619 (which added `*_username` fields on `EntityReportResponse`). The current code already routes every report-row reporter through `shared.ResolveUserName` + `shared.ResolveUserUsername` — verified end-to-end in this branch.
- Per CLAUDE.md memory ("Audit recurring bug patterns at 2 instances, not 3"), I also swept other reporter-byline surfaces. `services/admin/audit_log.go` correctly uses the resolver (it ALSO retains `ActorEmail` for back-compat, but `ActorName` / `ActorUsername` are canonical). `services/admin/show_report.go` and `services/admin/artist_report.go` (legacy `/admin/reports` page) don't render a "by" line at all in their cards, so they're not affected by PSY-607. No additional sites need fixing.

## Proposed memory entries (no in-repo CLAUDE.md exists)

Add to `pattern_*.md` or the user-attribution audit memory file:

> **PSY-607 (May 11): no-email-leak invariant for admin moderation report bylines.** Pre-PSY-612, the entity_report service had its own `displayName` helper that returned `*u.Email` verbatim as its terminal fallback (leaking `asdf@admin.com` into the admin moderation queue — dogfood ISSUE-009 screenshot May 4). PSY-612 swapped to `shared.ResolveUserName` (email PREFIX), PSY-619 wired the resolver through `EntityReportResponse`. PSY-607 added two regression tests (`TestCreateEntityReport_EmailOnlyReporter_NoEmailLeak`, `TestListEntityReports_MixedReporterAccounts_NoEmailLeak`) that lock in the contract at the service boundary. **When adding a new user-attribution surface, repeat this pattern: a regression test that asserts `!strings.Contains(name, "@")` for an email-only reporter.** PSY-598 audit list now has 3 confirmed instances of the user-attribution leak pattern (PSY-560 suggest-edit byline, PSY-591 comment edit history, PSY-607 admin moderation report rows).

Closes PSY-607

🤖 Generated with [Claude Code](https://claude.com/claude-code)