### PR TITLE
PSY-593: block self-voting on own comments

### DIFF
--- a/backend/internal/api/handlers/engagement/comment_vote.go
+++ b/backend/internal/api/handlers/engagement/comment_vote.go
@@ -63,9 +63,6 @@ func (h *CommentVoteHandler) VoteCommentHandler(ctx context.Context, req *VoteCo
 		if err.Error() == "comment not found" {
 			return nil, huma.Error404NotFound("Comment not found")
 		}
-		// PSY-593: self-votes are rejected with 403. The frontend hides the
-		// vote buttons on own comments, so this path is defensive insurance
-		// against a stale UI or a direct API call.
 		if err.Error() == "cannot vote on your own comment" {
 			return nil, huma.Error403Forbidden("Cannot vote on your own comment")
 		}

--- a/backend/internal/api/handlers/engagement/comment_vote.go
+++ b/backend/internal/api/handlers/engagement/comment_vote.go
@@ -63,6 +63,12 @@ func (h *CommentVoteHandler) VoteCommentHandler(ctx context.Context, req *VoteCo
 		if err.Error() == "comment not found" {
 			return nil, huma.Error404NotFound("Comment not found")
 		}
+		// PSY-593: self-votes are rejected with 403. The frontend hides the
+		// vote buttons on own comments, so this path is defensive insurance
+		// against a stale UI or a direct API call.
+		if err.Error() == "cannot vote on your own comment" {
+			return nil, huma.Error403Forbidden("Cannot vote on your own comment")
+		}
 		return nil, huma.Error500InternalServerError(fmt.Sprintf("Failed to vote: %v", err))
 	}
 

--- a/backend/internal/api/handlers/engagement/comment_vote_test.go
+++ b/backend/internal/api/handlers/engagement/comment_vote_test.go
@@ -125,6 +125,38 @@ func TestVoteComment_ServiceError(t *testing.T) {
 	testhelpers.AssertHumaError(t, err, 500)
 }
 
+// PSY-593: self-vote rejection surfaces as 403 from the handler. Covers both
+// up and down so the guard cannot regress on one direction.
+func TestVoteComment_SelfVoteUpForbidden(t *testing.T) {
+	h := NewCommentVoteHandler(&testhelpers.MockCommentVoteService{
+		VoteFn: func(userID uint, commentID uint, direction int) error {
+			return fmt.Errorf("cannot vote on your own comment")
+		},
+	})
+
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1})
+	req := &VoteCommentRequest{CommentID: "42"}
+	req.Body.Direction = 1
+
+	_, err := h.VoteCommentHandler(ctx, req)
+	testhelpers.AssertHumaError(t, err, 403)
+}
+
+func TestVoteComment_SelfVoteDownForbidden(t *testing.T) {
+	h := NewCommentVoteHandler(&testhelpers.MockCommentVoteService{
+		VoteFn: func(userID uint, commentID uint, direction int) error {
+			return fmt.Errorf("cannot vote on your own comment")
+		},
+	})
+
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1})
+	req := &VoteCommentRequest{CommentID: "42"}
+	req.Body.Direction = -1
+
+	_, err := h.VoteCommentHandler(ctx, req)
+	testhelpers.AssertHumaError(t, err, 403)
+}
+
 // ============================================================================
 // UnvoteCommentHandler Tests
 // ============================================================================

--- a/backend/internal/services/engagement/comment_vote_service.go
+++ b/backend/internal/services/engagement/comment_vote_service.go
@@ -46,10 +46,9 @@ func (s *CommentVoteService) Vote(userID uint, commentID uint, direction int) er
 		return fmt.Errorf("failed to get comment: %w", err)
 	}
 
-	// PSY-593: reject self-votes (both up and down) — matches HN/Lobsters
-	// convention. The frontend hides the vote buttons on own comments, so
-	// this is defensive insurance against a stale UI or a direct API call.
-	// Existing self-votes in the DB are left as-is — no migration cleanup.
+	// PSY-593: authors cannot vote on their own comments (HN/Lobsters
+	// convention). The frontend hides the buttons; this guard is defensive
+	// insurance against a stale UI or a direct API call.
 	if comment.UserID == userID {
 		return fmt.Errorf("cannot vote on your own comment")
 	}

--- a/backend/internal/services/engagement/comment_vote_service.go
+++ b/backend/internal/services/engagement/comment_vote_service.go
@@ -46,6 +46,14 @@ func (s *CommentVoteService) Vote(userID uint, commentID uint, direction int) er
 		return fmt.Errorf("failed to get comment: %w", err)
 	}
 
+	// PSY-593: reject self-votes (both up and down) — matches HN/Lobsters
+	// convention. The frontend hides the vote buttons on own comments, so
+	// this is defensive insurance against a stale UI or a direct API call.
+	// Existing self-votes in the DB are left as-is — no migration cleanup.
+	if comment.UserID == userID {
+		return fmt.Errorf("cannot vote on your own comment")
+	}
+
 	return s.db.Transaction(func(tx *gorm.DB) error {
 		// Upsert the vote
 		var existingVote engagementm.CommentVote

--- a/backend/internal/services/engagement/comment_vote_service_test.go
+++ b/backend/internal/services/engagement/comment_vote_service_test.go
@@ -81,15 +81,19 @@ func (suite *CommentVoteServiceIntegrationTestSuite) createTestComment(userID ui
 // VOTE TESTS
 // =============================================================================
 
+// PSY-593: vote tests now use distinct author / voter users since
+// self-votes are blocked. Helpers below create a comment owned by `author`
+// and a separate `voter` user who casts votes against it.
 func (suite *CommentVoteServiceIntegrationTestSuite) TestVoteUp() {
-	user := suite.createTestUser()
-	comment := suite.createTestComment(user.ID)
+	author := suite.createTestUser()
+	voter := suite.createTestUser()
+	comment := suite.createTestComment(author.ID)
 
-	err := suite.service.Vote(user.ID, comment.ID, 1)
+	err := suite.service.Vote(voter.ID, comment.ID, 1)
 	suite.NoError(err)
 
 	// Verify vote was created
-	vote, err := suite.service.GetUserVote(user.ID, comment.ID)
+	vote, err := suite.service.GetUserVote(voter.ID, comment.ID)
 	suite.NoError(err)
 	suite.NotNil(vote)
 	suite.Equal(1, *vote)
@@ -103,13 +107,14 @@ func (suite *CommentVoteServiceIntegrationTestSuite) TestVoteUp() {
 }
 
 func (suite *CommentVoteServiceIntegrationTestSuite) TestVoteDown() {
-	user := suite.createTestUser()
-	comment := suite.createTestComment(user.ID)
+	author := suite.createTestUser()
+	voter := suite.createTestUser()
+	comment := suite.createTestComment(author.ID)
 
-	err := suite.service.Vote(user.ID, comment.ID, -1)
+	err := suite.service.Vote(voter.ID, comment.ID, -1)
 	suite.NoError(err)
 
-	vote, err := suite.service.GetUserVote(user.ID, comment.ID)
+	vote, err := suite.service.GetUserVote(voter.ID, comment.ID)
 	suite.NoError(err)
 	suite.NotNil(vote)
 	suite.Equal(-1, *vote)
@@ -123,11 +128,12 @@ func (suite *CommentVoteServiceIntegrationTestSuite) TestVoteDown() {
 }
 
 func (suite *CommentVoteServiceIntegrationTestSuite) TestChangeVoteDirection() {
-	user := suite.createTestUser()
-	comment := suite.createTestComment(user.ID)
+	author := suite.createTestUser()
+	voter := suite.createTestUser()
+	comment := suite.createTestComment(author.ID)
 
 	// Vote up first
-	err := suite.service.Vote(user.ID, comment.ID, 1)
+	err := suite.service.Vote(voter.ID, comment.ID, 1)
 	suite.NoError(err)
 
 	var afterUp engagementm.Comment
@@ -136,10 +142,10 @@ func (suite *CommentVoteServiceIntegrationTestSuite) TestChangeVoteDirection() {
 	suite.Equal(0, afterUp.Downs)
 
 	// Change to down
-	err = suite.service.Vote(user.ID, comment.ID, -1)
+	err = suite.service.Vote(voter.ID, comment.ID, -1)
 	suite.NoError(err)
 
-	vote, err := suite.service.GetUserVote(user.ID, comment.ID)
+	vote, err := suite.service.GetUserVote(voter.ID, comment.ID)
 	suite.NoError(err)
 	suite.NotNil(vote)
 	suite.Equal(-1, *vote)
@@ -151,13 +157,14 @@ func (suite *CommentVoteServiceIntegrationTestSuite) TestChangeVoteDirection() {
 }
 
 func (suite *CommentVoteServiceIntegrationTestSuite) TestVoteSameDirectionIdempotent() {
-	user := suite.createTestUser()
-	comment := suite.createTestComment(user.ID)
+	author := suite.createTestUser()
+	voter := suite.createTestUser()
+	comment := suite.createTestComment(author.ID)
 
 	// Vote up twice
-	err := suite.service.Vote(user.ID, comment.ID, 1)
+	err := suite.service.Vote(voter.ID, comment.ID, 1)
 	suite.NoError(err)
-	err = suite.service.Vote(user.ID, comment.ID, 1)
+	err = suite.service.Vote(voter.ID, comment.ID, 1)
 	suite.NoError(err)
 
 	var updated engagementm.Comment
@@ -167,10 +174,11 @@ func (suite *CommentVoteServiceIntegrationTestSuite) TestVoteSameDirectionIdempo
 }
 
 func (suite *CommentVoteServiceIntegrationTestSuite) TestVoteInvalidDirection() {
-	user := suite.createTestUser()
-	comment := suite.createTestComment(user.ID)
+	author := suite.createTestUser()
+	voter := suite.createTestUser()
+	comment := suite.createTestComment(author.ID)
 
-	err := suite.service.Vote(user.ID, comment.ID, 2)
+	err := suite.service.Vote(voter.ID, comment.ID, 2)
 	suite.Error(err)
 	suite.Contains(err.Error(), "invalid vote direction")
 }
@@ -183,16 +191,70 @@ func (suite *CommentVoteServiceIntegrationTestSuite) TestVoteNonexistentComment(
 	suite.Contains(err.Error(), "comment not found")
 }
 
+// PSY-593: authors cannot vote on their own comments. Block both up and down.
+func (suite *CommentVoteServiceIntegrationTestSuite) TestVoteOnOwnCommentUpBlocked() {
+	author := suite.createTestUser()
+	comment := suite.createTestComment(author.ID)
+
+	err := suite.service.Vote(author.ID, comment.ID, 1)
+	suite.Error(err)
+	suite.Contains(err.Error(), "cannot vote on your own comment")
+
+	// Aggregates must not move.
+	var updated engagementm.Comment
+	suite.db.First(&updated, comment.ID)
+	suite.Equal(0, updated.Ups)
+	suite.Equal(0, updated.Downs)
+
+	// No vote row was persisted.
+	vote, err := suite.service.GetUserVote(author.ID, comment.ID)
+	suite.NoError(err)
+	suite.Nil(vote)
+}
+
+func (suite *CommentVoteServiceIntegrationTestSuite) TestVoteOnOwnCommentDownBlocked() {
+	author := suite.createTestUser()
+	comment := suite.createTestComment(author.ID)
+
+	err := suite.service.Vote(author.ID, comment.ID, -1)
+	suite.Error(err)
+	suite.Contains(err.Error(), "cannot vote on your own comment")
+
+	var updated engagementm.Comment
+	suite.db.First(&updated, comment.ID)
+	suite.Equal(0, updated.Ups)
+	suite.Equal(0, updated.Downs)
+
+	vote, err := suite.service.GetUserVote(author.ID, comment.ID)
+	suite.NoError(err)
+	suite.Nil(vote)
+}
+
+// PSY-593: a different user can still vote — the guard is scoped to the author.
+func (suite *CommentVoteServiceIntegrationTestSuite) TestVoteOnOthersCommentAllowed() {
+	author := suite.createTestUser()
+	voter := suite.createTestUser()
+	comment := suite.createTestComment(author.ID)
+
+	err := suite.service.Vote(voter.ID, comment.ID, 1)
+	suite.NoError(err)
+
+	var updated engagementm.Comment
+	suite.db.First(&updated, comment.ID)
+	suite.Equal(1, updated.Ups)
+}
+
 // =============================================================================
 // UNVOTE TESTS
 // =============================================================================
 
 func (suite *CommentVoteServiceIntegrationTestSuite) TestUnvote() {
-	user := suite.createTestUser()
-	comment := suite.createTestComment(user.ID)
+	author := suite.createTestUser()
+	voter := suite.createTestUser()
+	comment := suite.createTestComment(author.ID)
 
 	// Vote first
-	err := suite.service.Vote(user.ID, comment.ID, 1)
+	err := suite.service.Vote(voter.ID, comment.ID, 1)
 	suite.NoError(err)
 
 	// Verify aggregates
@@ -201,11 +263,11 @@ func (suite *CommentVoteServiceIntegrationTestSuite) TestUnvote() {
 	suite.Equal(1, afterVote.Ups)
 
 	// Unvote
-	err = suite.service.Unvote(user.ID, comment.ID)
+	err = suite.service.Unvote(voter.ID, comment.ID)
 	suite.NoError(err)
 
 	// Vote should be nil
-	vote, err := suite.service.GetUserVote(user.ID, comment.ID)
+	vote, err := suite.service.GetUserVote(voter.ID, comment.ID)
 	suite.NoError(err)
 	suite.Nil(vote)
 
@@ -252,16 +314,17 @@ func (suite *CommentVoteServiceIntegrationTestSuite) TestGetUserVoteNoVote() {
 // =============================================================================
 
 func (suite *CommentVoteServiceIntegrationTestSuite) TestGetUserVotesForComments() {
-	user := suite.createTestUser()
-	c1 := suite.createTestComment(user.ID)
-	c2 := suite.createTestComment(user.ID)
-	c3 := suite.createTestComment(user.ID)
+	author := suite.createTestUser()
+	voter := suite.createTestUser()
+	c1 := suite.createTestComment(author.ID)
+	c2 := suite.createTestComment(author.ID)
+	c3 := suite.createTestComment(author.ID)
 
 	// Vote on c1 (up) and c2 (down), skip c3
-	suite.NoError(suite.service.Vote(user.ID, c1.ID, 1))
-	suite.NoError(suite.service.Vote(user.ID, c2.ID, -1))
+	suite.NoError(suite.service.Vote(voter.ID, c1.ID, 1))
+	suite.NoError(suite.service.Vote(voter.ID, c2.ID, -1))
 
-	votes, err := suite.service.GetUserVotesForComments(user.ID, []uint{c1.ID, c2.ID, c3.ID})
+	votes, err := suite.service.GetUserVotesForComments(voter.ID, []uint{c1.ID, c2.ID, c3.ID})
 	suite.NoError(err)
 	suite.Equal(1, votes[c1.ID])
 	suite.Equal(-1, votes[c2.ID])
@@ -283,13 +346,16 @@ func (suite *CommentVoteServiceIntegrationTestSuite) TestGetUserVotesForComments
 // =============================================================================
 
 func (suite *CommentVoteServiceIntegrationTestSuite) TestGetCommentVoteCounts() {
-	user1 := suite.createTestUser()
-	user2 := suite.createTestUser()
-	comment := suite.createTestComment(user1.ID)
+	// PSY-593: self-vote blocked, so the comment author is now a distinct
+	// user from the two voters.
+	author := suite.createTestUser()
+	voter1 := suite.createTestUser()
+	voter2 := suite.createTestUser()
+	comment := suite.createTestComment(author.ID)
 
 	// Two upvotes
-	suite.NoError(suite.service.Vote(user1.ID, comment.ID, 1))
-	suite.NoError(suite.service.Vote(user2.ID, comment.ID, 1))
+	suite.NoError(suite.service.Vote(voter1.ID, comment.ID, 1))
+	suite.NoError(suite.service.Vote(voter2.ID, comment.ID, 1))
 
 	ups, downs, score, err := suite.service.GetCommentVoteCounts(comment.ID)
 	suite.NoError(err)

--- a/backend/internal/services/engagement/comment_vote_service_test.go
+++ b/backend/internal/services/engagement/comment_vote_service_test.go
@@ -81,9 +81,8 @@ func (suite *CommentVoteServiceIntegrationTestSuite) createTestComment(userID ui
 // VOTE TESTS
 // =============================================================================
 
-// PSY-593: vote tests now use distinct author / voter users since
-// self-votes are blocked. Helpers below create a comment owned by `author`
-// and a separate `voter` user who casts votes against it.
+// PSY-593: self-votes are blocked, so vote tests need a distinct
+// `author` (who owns the comment) and `voter` (who casts the vote).
 func (suite *CommentVoteServiceIntegrationTestSuite) TestVoteUp() {
 	author := suite.createTestUser()
 	voter := suite.createTestUser()
@@ -230,7 +229,6 @@ func (suite *CommentVoteServiceIntegrationTestSuite) TestVoteOnOwnCommentDownBlo
 	suite.Nil(vote)
 }
 
-// PSY-593: a different user can still vote — the guard is scoped to the author.
 func (suite *CommentVoteServiceIntegrationTestSuite) TestVoteOnOthersCommentAllowed() {
 	author := suite.createTestUser()
 	voter := suite.createTestUser()
@@ -346,8 +344,6 @@ func (suite *CommentVoteServiceIntegrationTestSuite) TestGetUserVotesForComments
 // =============================================================================
 
 func (suite *CommentVoteServiceIntegrationTestSuite) TestGetCommentVoteCounts() {
-	// PSY-593: self-vote blocked, so the comment author is now a distinct
-	// user from the two voters.
 	author := suite.createTestUser()
 	voter1 := suite.createTestUser()
 	voter2 := suite.createTestUser()

--- a/frontend/features/comments/components/CommentCard.test.tsx
+++ b/frontend/features/comments/components/CommentCard.test.tsx
@@ -623,10 +623,10 @@ describe('CommentCard — self-vote button hiding (PSY-593)', () => {
     expect(screen.getByTestId('vote-score')).toHaveTextContent('2')
   })
 
-  it('hides vote buttons on own comment for anonymous viewer of own posts (defensive)', () => {
-    // Anonymous viewers can't be the author (no user.id), so the buttons
-    // should render (disabled by isAuthenticated). This guards against
-    // accidentally hiding the affordance for everyone.
+  it('renders vote buttons for anonymous viewers (no author match possible)', () => {
+    // Guards against accidentally hiding the affordance when user.id is
+    // absent — anonymous viewers can't be the author by definition, and
+    // the buttons are still disabled by isAuthenticated.
     mockAuthContext.mockReturnValue({
       isAuthenticated: false,
       user: null,

--- a/frontend/features/comments/components/CommentCard.test.tsx
+++ b/frontend/features/comments/components/CommentCard.test.tsx
@@ -500,7 +500,13 @@ describe('CommentCard — mutation error surfacing (PSY-608)', () => {
   })
 
   it('renders the auto-dismiss vote-error banner when useVoteComment rejects via onError', () => {
-    ownerAuth()
+    // PSY-593: vote buttons are hidden on own comments, so the vote-error
+    // banner is now reachable only on others' comments. Sign in as a
+    // non-author so the buttons render.
+    mockAuthContext.mockReturnValue({
+      isAuthenticated: true,
+      user: { id: '7', email: 'other@user.com' },
+    })
     // Mock vote mutation that fires onError synchronously when mutate() is
     // called — emulates the rollback path. The auto-dismiss banner reads
     // from useAutoDismissError state, so a synchronous onError populates it
@@ -535,7 +541,11 @@ describe('CommentCard — mutation error surfacing (PSY-608)', () => {
   })
 
   it('renders the auto-dismiss vote-error banner when useUnvoteComment rejects via onError', () => {
-    ownerAuth()
+    // PSY-593: see sibling test above — non-author viewer required.
+    mockAuthContext.mockReturnValue({
+      isAuthenticated: true,
+      user: { id: '7', email: 'other@user.com' },
+    })
     const voteError = Object.assign(new Error('vote failed'), { status: 500 })
     const mutateImpl = vi.fn(
       (_args: unknown, opts?: { onError?: (err: unknown) => void }) => {
@@ -560,5 +570,76 @@ describe('CommentCard — mutation error surfacing (PSY-608)', () => {
     const banner = screen.getByTestId('vote-error-banner')
     expect(banner).toBeInTheDocument()
     expect(banner).toHaveTextContent('Vote failed')
+  })
+})
+
+// PSY-593: authors cannot vote on their own comments. The frontend hides the
+// up/down buttons; the score remains visible as a plain span.
+describe('CommentCard — self-vote button hiding (PSY-593)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetAllMutationMocks()
+  })
+
+  const defaultProps = {
+    entityType: 'artist',
+    entityId: 10,
+  }
+
+  it('hides Upvote and Downvote buttons on own comments', () => {
+    mockAuthContext.mockReturnValue({
+      isAuthenticated: true,
+      user: { id: '99', email: 'me@me.com' },
+    })
+
+    render(
+      <CommentCard
+        {...defaultProps}
+        comment={makeComment({ user_id: 99, ups: 3, downs: 1 })}
+      />
+    )
+
+    expect(screen.queryByTestId('upvote-button')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('downvote-button')).not.toBeInTheDocument()
+    // Score stays visible — authors can still see their score.
+    expect(screen.getByTestId('vote-score')).toHaveTextContent('2')
+  })
+
+  it('renders Upvote and Downvote buttons on another user\'s comment', () => {
+    mockAuthContext.mockReturnValue({
+      isAuthenticated: true,
+      user: { id: '7', email: 'other@user.com' },
+    })
+
+    render(
+      <CommentCard
+        {...defaultProps}
+        comment={makeComment({ user_id: 99, ups: 3, downs: 1 })}
+      />
+    )
+
+    expect(screen.getByTestId('upvote-button')).toBeInTheDocument()
+    expect(screen.getByTestId('downvote-button')).toBeInTheDocument()
+    expect(screen.getByTestId('vote-score')).toHaveTextContent('2')
+  })
+
+  it('hides vote buttons on own comment for anonymous viewer of own posts (defensive)', () => {
+    // Anonymous viewers can't be the author (no user.id), so the buttons
+    // should render (disabled by isAuthenticated). This guards against
+    // accidentally hiding the affordance for everyone.
+    mockAuthContext.mockReturnValue({
+      isAuthenticated: false,
+      user: null,
+    })
+
+    render(
+      <CommentCard
+        {...defaultProps}
+        comment={makeComment({ user_id: 99 })}
+      />
+    )
+
+    expect(screen.getByTestId('upvote-button')).toBeInTheDocument()
+    expect(screen.getByTestId('downvote-button')).toBeInTheDocument()
   })
 })

--- a/frontend/features/comments/components/CommentCard.tsx
+++ b/frontend/features/comments/components/CommentCard.tsx
@@ -214,45 +214,40 @@ export function CommentCard({
       {/* Actions row: votes + reply + edit + delete */}
       {!isEditing && (
         <div className="flex items-center gap-1 mt-2">
-          {/* Vote buttons. PSY-593: authors cannot vote on their own comments
-              (matches HN/Lobsters). Hide the up/down buttons on own comments
-              and render the score as a plain span so the count stays visible
-              to the author. */}
-          {!isOwner ? (
-            <>
-              <Button
-                variant="ghost"
-                size="sm"
-                className={`h-7 w-7 p-0 ${comment.user_vote === 1 ? 'text-primary' : 'text-muted-foreground'}`}
-                onClick={() => handleVote(1)}
-                disabled={!isAuthenticated}
-                aria-label="Upvote"
-                data-testid="upvote-button"
-              >
-                <ChevronUp className="h-4 w-4" />
-              </Button>
-              <span className="text-xs font-medium min-w-[1.5rem] text-center" data-testid="vote-score">
-                {comment.ups - comment.downs}
-              </span>
-              <Button
-                variant="ghost"
-                size="sm"
-                className={`h-7 w-7 p-0 ${comment.user_vote === -1 ? 'text-destructive' : 'text-muted-foreground'}`}
-                onClick={() => handleVote(-1)}
-                disabled={!isAuthenticated}
-                aria-label="Downvote"
-                data-testid="downvote-button"
-              >
-                <ChevronDown className="h-4 w-4" />
-              </Button>
-            </>
-          ) : (
-            <span
-              className="text-xs font-medium min-w-[1.5rem] text-center text-muted-foreground"
-              data-testid="vote-score"
+          {/* PSY-593: authors don't see vote buttons on their own comments
+              (matches HN/Lobsters — authors must not self-promote). Score
+              still renders so the author can see it. */}
+          {!isOwner && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className={`h-7 w-7 p-0 ${comment.user_vote === 1 ? 'text-primary' : 'text-muted-foreground'}`}
+              onClick={() => handleVote(1)}
+              disabled={!isAuthenticated}
+              aria-label="Upvote"
+              data-testid="upvote-button"
             >
-              {comment.ups - comment.downs}
-            </span>
+              <ChevronUp className="h-4 w-4" />
+            </Button>
+          )}
+          <span
+            className={`text-xs font-medium min-w-[1.5rem] text-center ${isOwner ? 'text-muted-foreground' : ''}`}
+            data-testid="vote-score"
+          >
+            {comment.ups - comment.downs}
+          </span>
+          {!isOwner && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className={`h-7 w-7 p-0 ${comment.user_vote === -1 ? 'text-destructive' : 'text-muted-foreground'}`}
+              onClick={() => handleVote(-1)}
+              disabled={!isAuthenticated}
+              aria-label="Downvote"
+              data-testid="downvote-button"
+            >
+              <ChevronDown className="h-4 w-4" />
+            </Button>
           )}
 
           {/* Reply button (hidden at depth >= 2). PSY-296: for

--- a/frontend/features/comments/components/CommentCard.tsx
+++ b/frontend/features/comments/components/CommentCard.tsx
@@ -214,32 +214,46 @@ export function CommentCard({
       {/* Actions row: votes + reply + edit + delete */}
       {!isEditing && (
         <div className="flex items-center gap-1 mt-2">
-          {/* Vote buttons */}
-          <Button
-            variant="ghost"
-            size="sm"
-            className={`h-7 w-7 p-0 ${comment.user_vote === 1 ? 'text-primary' : 'text-muted-foreground'}`}
-            onClick={() => handleVote(1)}
-            disabled={!isAuthenticated}
-            aria-label="Upvote"
-            data-testid="upvote-button"
-          >
-            <ChevronUp className="h-4 w-4" />
-          </Button>
-          <span className="text-xs font-medium min-w-[1.5rem] text-center" data-testid="vote-score">
-            {comment.ups - comment.downs}
-          </span>
-          <Button
-            variant="ghost"
-            size="sm"
-            className={`h-7 w-7 p-0 ${comment.user_vote === -1 ? 'text-destructive' : 'text-muted-foreground'}`}
-            onClick={() => handleVote(-1)}
-            disabled={!isAuthenticated}
-            aria-label="Downvote"
-            data-testid="downvote-button"
-          >
-            <ChevronDown className="h-4 w-4" />
-          </Button>
+          {/* Vote buttons. PSY-593: authors cannot vote on their own comments
+              (matches HN/Lobsters). Hide the up/down buttons on own comments
+              and render the score as a plain span so the count stays visible
+              to the author. */}
+          {!isOwner ? (
+            <>
+              <Button
+                variant="ghost"
+                size="sm"
+                className={`h-7 w-7 p-0 ${comment.user_vote === 1 ? 'text-primary' : 'text-muted-foreground'}`}
+                onClick={() => handleVote(1)}
+                disabled={!isAuthenticated}
+                aria-label="Upvote"
+                data-testid="upvote-button"
+              >
+                <ChevronUp className="h-4 w-4" />
+              </Button>
+              <span className="text-xs font-medium min-w-[1.5rem] text-center" data-testid="vote-score">
+                {comment.ups - comment.downs}
+              </span>
+              <Button
+                variant="ghost"
+                size="sm"
+                className={`h-7 w-7 p-0 ${comment.user_vote === -1 ? 'text-destructive' : 'text-muted-foreground'}`}
+                onClick={() => handleVote(-1)}
+                disabled={!isAuthenticated}
+                aria-label="Downvote"
+                data-testid="downvote-button"
+              >
+                <ChevronDown className="h-4 w-4" />
+              </Button>
+            </>
+          ) : (
+            <span
+              className="text-xs font-medium min-w-[1.5rem] text-center text-muted-foreground"
+              data-testid="vote-score"
+            >
+              {comment.ups - comment.downs}
+            </span>
+          )}
 
           {/* Reply button (hidden at depth >= 2). PSY-296: for
               author_only we hide the button for non-authors; for followers

--- a/frontend/features/comments/components/FieldNoteCard.test.tsx
+++ b/frontend/features/comments/components/FieldNoteCard.test.tsx
@@ -463,6 +463,46 @@ describe('FieldNoteCard', () => {
     })
   })
 
+  // PSY-593: authors cannot vote on their own field notes. The frontend
+  // hides the up/down buttons; the score remains visible as a plain span.
+  describe('self-vote button hiding (PSY-593)', () => {
+    it('hides Upvote and Downvote buttons on own field note', () => {
+      mockAuthContext.mockReturnValue({
+        isAuthenticated: true,
+        user: { id: '2', email: 'owner@example.com' },
+      })
+
+      render(
+        <FieldNoteCard
+          comment={makeFieldNote({ user_id: 2, ups: 5, downs: 1 })}
+          showId={10}
+        />
+      )
+
+      expect(screen.queryByTestId('upvote-button')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('downvote-button')).not.toBeInTheDocument()
+      // Score still visible — authors can see their own score.
+      expect(screen.getByTestId('vote-score')).toHaveTextContent('4')
+    })
+
+    it('renders Upvote and Downvote buttons on another user\'s field note', () => {
+      mockAuthContext.mockReturnValue({
+        isAuthenticated: true,
+        user: { id: '99', email: 'other@user.com' },
+      })
+
+      render(
+        <FieldNoteCard
+          comment={makeFieldNote({ user_id: 2 })}
+          showId={10}
+        />
+      )
+
+      expect(screen.getByTestId('upvote-button')).toBeInTheDocument()
+      expect(screen.getByTestId('downvote-button')).toBeInTheDocument()
+    })
+  })
+
   // PSY-590: Edit + Delete affordances on the author's own field note. Mirrors
   // the CommentCard surface (Pencil + Trash2 + inline Yes/No confirm + admin-
   // only edit history trigger). The makeFieldNote helper fixes user_id=2, so

--- a/frontend/features/comments/components/FieldNoteCard.tsx
+++ b/frontend/features/comments/components/FieldNoteCard.tsx
@@ -312,32 +312,45 @@ export function FieldNoteCard({
       {/* Actions row: votes + reply + edit + delete + report */}
       {!isEditing && (
         <div className="flex items-center gap-1 mt-3">
-          {/* Vote buttons */}
-          <Button
-            variant="ghost"
-            size="sm"
-            className={`h-7 w-7 p-0 ${comment.user_vote === 1 ? 'text-primary' : 'text-muted-foreground'}`}
-            onClick={() => handleVote(1)}
-            disabled={!isAuthenticated}
-            aria-label="Upvote"
-            data-testid="upvote-button"
-          >
-            <ChevronUp className="h-4 w-4" />
-          </Button>
-          <span className="text-xs font-medium min-w-[1.5rem] text-center" data-testid="vote-score">
-            {comment.ups - comment.downs}
-          </span>
-          <Button
-            variant="ghost"
-            size="sm"
-            className={`h-7 w-7 p-0 ${comment.user_vote === -1 ? 'text-destructive' : 'text-muted-foreground'}`}
-            onClick={() => handleVote(-1)}
-            disabled={!isAuthenticated}
-            aria-label="Downvote"
-            data-testid="downvote-button"
-          >
-            <ChevronDown className="h-4 w-4" />
-          </Button>
+          {/* Vote buttons. PSY-593: authors cannot vote on their own field
+              notes (matches HN/Lobsters / CommentCard). Hide the up/down
+              buttons on own comments and render the score as a plain span. */}
+          {!isOwner ? (
+            <>
+              <Button
+                variant="ghost"
+                size="sm"
+                className={`h-7 w-7 p-0 ${comment.user_vote === 1 ? 'text-primary' : 'text-muted-foreground'}`}
+                onClick={() => handleVote(1)}
+                disabled={!isAuthenticated}
+                aria-label="Upvote"
+                data-testid="upvote-button"
+              >
+                <ChevronUp className="h-4 w-4" />
+              </Button>
+              <span className="text-xs font-medium min-w-[1.5rem] text-center" data-testid="vote-score">
+                {comment.ups - comment.downs}
+              </span>
+              <Button
+                variant="ghost"
+                size="sm"
+                className={`h-7 w-7 p-0 ${comment.user_vote === -1 ? 'text-destructive' : 'text-muted-foreground'}`}
+                onClick={() => handleVote(-1)}
+                disabled={!isAuthenticated}
+                aria-label="Downvote"
+                data-testid="downvote-button"
+              >
+                <ChevronDown className="h-4 w-4" />
+              </Button>
+            </>
+          ) : (
+            <span
+              className="text-xs font-medium min-w-[1.5rem] text-center text-muted-foreground"
+              data-testid="vote-score"
+            >
+              {comment.ups - comment.downs}
+            </span>
+          )}
 
           {/* Reply button */}
           {isAuthenticated && comment.depth < 2 && comment.reply_permission !== 'author_only' && (

--- a/frontend/features/comments/components/FieldNoteCard.tsx
+++ b/frontend/features/comments/components/FieldNoteCard.tsx
@@ -312,44 +312,40 @@ export function FieldNoteCard({
       {/* Actions row: votes + reply + edit + delete + report */}
       {!isEditing && (
         <div className="flex items-center gap-1 mt-3">
-          {/* Vote buttons. PSY-593: authors cannot vote on their own field
-              notes (matches HN/Lobsters / CommentCard). Hide the up/down
-              buttons on own comments and render the score as a plain span. */}
-          {!isOwner ? (
-            <>
-              <Button
-                variant="ghost"
-                size="sm"
-                className={`h-7 w-7 p-0 ${comment.user_vote === 1 ? 'text-primary' : 'text-muted-foreground'}`}
-                onClick={() => handleVote(1)}
-                disabled={!isAuthenticated}
-                aria-label="Upvote"
-                data-testid="upvote-button"
-              >
-                <ChevronUp className="h-4 w-4" />
-              </Button>
-              <span className="text-xs font-medium min-w-[1.5rem] text-center" data-testid="vote-score">
-                {comment.ups - comment.downs}
-              </span>
-              <Button
-                variant="ghost"
-                size="sm"
-                className={`h-7 w-7 p-0 ${comment.user_vote === -1 ? 'text-destructive' : 'text-muted-foreground'}`}
-                onClick={() => handleVote(-1)}
-                disabled={!isAuthenticated}
-                aria-label="Downvote"
-                data-testid="downvote-button"
-              >
-                <ChevronDown className="h-4 w-4" />
-              </Button>
-            </>
-          ) : (
-            <span
-              className="text-xs font-medium min-w-[1.5rem] text-center text-muted-foreground"
-              data-testid="vote-score"
+          {/* PSY-593: authors don't see vote buttons on their own field
+              notes (matches HN/Lobsters — authors must not self-promote).
+              Score still renders so the author can see it. */}
+          {!isOwner && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className={`h-7 w-7 p-0 ${comment.user_vote === 1 ? 'text-primary' : 'text-muted-foreground'}`}
+              onClick={() => handleVote(1)}
+              disabled={!isAuthenticated}
+              aria-label="Upvote"
+              data-testid="upvote-button"
             >
-              {comment.ups - comment.downs}
-            </span>
+              <ChevronUp className="h-4 w-4" />
+            </Button>
+          )}
+          <span
+            className={`text-xs font-medium min-w-[1.5rem] text-center ${isOwner ? 'text-muted-foreground' : ''}`}
+            data-testid="vote-score"
+          >
+            {comment.ups - comment.downs}
+          </span>
+          {!isOwner && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className={`h-7 w-7 p-0 ${comment.user_vote === -1 ? 'text-destructive' : 'text-muted-foreground'}`}
+              onClick={() => handleVote(-1)}
+              disabled={!isAuthenticated}
+              aria-label="Downvote"
+              data-testid="downvote-button"
+            >
+              <ChevronDown className="h-4 w-4" />
+            </Button>
           )}
 
           {/* Reply button */}


### PR DESCRIPTION
## Summary

Authors could previously upvote AND downvote their own comments. Both succeeded silently and updated the displayed count. PSY-593 blocks self-voting (matches HN / Lobsters / Reddit-old) — authors must not be able to manipulate their own visibility.

- **Backend** rejects `POST /comments/{id}/vote` with **403 Forbidden** when `user_id == comment.user_id` (`backend/internal/services/engagement/comment_vote_service.go` + `backend/internal/api/handlers/engagement/comment_vote.go`).
- **Frontend** hides the Upvote / Downvote chevrons on own comments in both `CommentCard` and `FieldNoteCard`; the score still renders so the author can see it.
- Existing self-votes in the DB are left as-is — no migration.

The 403 path is defensive — the frontend never surfaces a button that would 403, but a stale UI or direct API call is handled cleanly.

## Test plan

- [x] Backend handler unit tests cover both self-up and self-down → 403 (`TestVoteComment_SelfVoteUpForbidden`, `TestVoteComment_SelfVoteDownForbidden`).
- [x] Backend service integration tests cover self-up blocked, self-down blocked, and a non-author still allowed (`TestVoteOnOwnCommentUpBlocked`, `TestVoteOnOwnCommentDownBlocked`, `TestVoteOnOthersCommentAllowed`).
- [x] All existing service vote tests refactored to use distinct `author` / `voter` users since self-voting is no longer a valid setup.
- [x] Frontend unit tests cover the hide-on-own-comment + render-on-others'-comment cases for `CommentCard` and `FieldNoteCard` (3 + 2 new tests).
- [x] `cd backend && go build ./...` clean.
- [x] `cd backend && go test ./internal/services/engagement/... ./internal/api/handlers/engagement/...` — 100% pass.
- [x] `cd frontend && bun run typecheck` clean.
- [x] `cd frontend && bun run test:run features/comments` — 143 / 143 pass.

## Manual repro

Per-worktree isolated dispatch stack on `http://localhost:49778`, two test users on the same show (PSY-593 worktree).

1. Logged in as `e2e-user@test.local`, posted a comment on `shows/2026-05-16-e2e-test-show-4`.
2. Verified the comment's action row renders **no Upvote / Downvote chevrons** — only the score span (`0`), Reply, Edit, Delete.
3. Issued `POST /api/comments/3/vote` (direction: 1 and -1) as the author from the browser console → both returned **403** with `"Cannot vote on your own comment"`.
4. Logged out, logged in as `e2e-user-1@test.local`, navigated back to the same show.
5. Verified the same comment now renders chevron-up, score, chevron-down, Reply, Report (no Edit/Delete since not owner).
6. Clicked Upvote → score went `0 → 1` cleanly.

Screenshots (gitignored, local-only): `dogfood-output/PSY-593/screenshots/01-own-comment-no-vote-buttons.png`, `02-other-user-comment-vote-buttons-visible.png`.

## Simplify

`/simplify` pass landed as a separate commit (`PSY-593: simplify — flatten vote-button conditional + trim narration`):
- Collapse score-span duplication: render the score once with a conditional owner-muted class, instead of branching the whole block with two identical spans (CommentCard + FieldNoteCard).
- Trim change-narration comments to the load-bearing "why" (HN/Lobsters convention + defensive-insurance rationale).
- Fix one test title that contradicted its own assertion.
- All tests re-ran clean after the simplify.

Closes PSY-593

🤖 Generated with [Claude Code](https://claude.com/claude-code)