### PR TITLE
PSY-567: 30-min author edit/delete window on field notes

### DIFF
--- a/backend/internal/api/handlers/engagement/comment.go
+++ b/backend/internal/api/handlers/engagement/comment.go
@@ -426,10 +426,16 @@ func (h *CommentHandler) CreateReplyHandler(ctx context.Context, req *CreateRepl
 // ============================================================================
 
 // UpdateCommentRequest represents the request for updating a comment.
+//
+// `StructuredData` is field-note-only (PSY-567): when supplied AND the target
+// is a field note, ratings + verified-attendee + spoiler flag are atomically
+// replaced as a unit alongside the body. Regular comments ignore it. Omit
+// the field for a body-only edit.
 type UpdateCommentRequest struct {
 	CommentID string `path:"comment_id" doc:"Comment ID" example:"1"`
 	Body      struct {
-		Body string `json:"body" doc:"Updated comment body (Markdown)" example:"Updated: Great show last night!"`
+		Body           string                             `json:"body" doc:"Updated comment body (Markdown)" example:"Updated: Great show last night!"`
+		StructuredData *contracts.FieldNoteStructuredData `json:"structured_data,omitempty" required:"false" doc:"Field-note-only: replaces ratings / verified-attendee / spoiler as a unit"`
 	}
 }
 
@@ -455,7 +461,8 @@ func (h *CommentHandler) UpdateCommentHandler(ctx context.Context, req *UpdateCo
 	}
 
 	serviceReq := &contracts.UpdateCommentRequest{
-		Body: req.Body.Body,
+		Body:           req.Body.Body,
+		StructuredData: req.Body.StructuredData,
 	}
 
 	comment, err := h.writer.UpdateComment(user.ID, uint(commentID), serviceReq)
@@ -466,7 +473,16 @@ func (h *CommentHandler) UpdateCommentHandler(ctx context.Context, req *UpdateCo
 		if strings.Contains(err.Error(), "only the comment author") {
 			return nil, huma.Error403Forbidden("You can only edit your own comments")
 		}
+		// PSY-567: field-note 30-min edit window. 403 lets the frontend
+		// reflect "no longer editable" without needing a separate state
+		// flag — the same status it already handles for not-author edits.
+		if strings.Contains(err.Error(), "field note edit window has expired") {
+			return nil, huma.Error403Forbidden(err.Error())
+		}
 		if strings.Contains(err.Error(), "body is required") || strings.Contains(err.Error(), "exceeds maximum length") {
+			return nil, huma.Error400BadRequest(err.Error())
+		}
+		if strings.Contains(err.Error(), "sound_quality must be") || strings.Contains(err.Error(), "crowd_energy must be") {
 			return nil, huma.Error400BadRequest(err.Error())
 		}
 		requestID := logger.GetRequestID(ctx)
@@ -581,6 +597,12 @@ func (h *CommentHandler) DeleteCommentHandler(ctx context.Context, req *DeleteCo
 		}
 		if strings.Contains(err.Error(), "only the comment author or an admin") {
 			return nil, huma.Error403Forbidden("You can only delete your own comments")
+		}
+		// PSY-567: 30-min field-note self-delete window. After expiry the
+		// row is immutable to the author; admin moderation (and the
+		// Report flow) are the out-of-window retraction paths.
+		if strings.Contains(err.Error(), "field note edit window has expired") {
+			return nil, huma.Error403Forbidden(err.Error())
 		}
 		requestID := logger.GetRequestID(ctx)
 		return nil, huma.Error500InternalServerError(

--- a/backend/internal/services/contracts/comment.go
+++ b/backend/internal/services/contracts/comment.go
@@ -20,8 +20,17 @@ type CreateCommentRequest struct {
 }
 
 // UpdateCommentRequest contains the fields that can be updated on a comment.
+//
+// `StructuredData` is optional and only meaningful when the target comment is
+// a field note (PSY-567). When supplied AND the target is a field note, it
+// REPLACES the existing structured_data row atomically with the body update —
+// ratings, verified-attendee, spoiler are edited as a single unit, never
+// merged with stored values. On a regular comment the field is ignored.
+// On a field-note edit it is optional: nil leaves the existing structured_data
+// untouched (body-only edit still works).
 type UpdateCommentRequest struct {
-	Body string `json:"body"`
+	Body           string                   `json:"body"`
+	StructuredData *FieldNoteStructuredData `json:"structured_data,omitempty"`
 }
 
 // CreateFieldNoteRequest contains the fields needed to create a field note on a show.

--- a/backend/internal/services/engagement/comment_service.go
+++ b/backend/internal/services/engagement/comment_service.go
@@ -860,17 +860,14 @@ func (s *CommentService) DeleteComment(userID uint, commentID uint, isAdmin bool
 		return errors.New("only the comment author or an admin can delete this comment")
 	}
 
-	// PSY-567: field-note window applies to AUTHOR self-deletes. An admin
-	// moderating someone else's note bypasses the window (that's the
-	// out-of-window retraction path the AC mentions). The
-	// "isAdmin && comment.UserID == userID" check matches the existing
-	// pattern below where an admin deleting their own row is treated as a
-	// user action.
-	isAuthorAction := comment.UserID == userID
-	if comment.Kind == engagementm.CommentKindFieldNote && isAuthorAction {
-		if !withinFieldNoteEditWindow(comment.CreatedAt) {
-			return errors.New("field note edit window has expired")
-		}
+	// PSY-567: field-note window applies to author self-deletes (incl.
+	// admins acting on their own note — the window is per-author, not
+	// per-role). Admin moderation of someone else's note bypasses it,
+	// which is the out-of-window retraction path the AC mentions.
+	if comment.Kind == engagementm.CommentKindFieldNote &&
+		comment.UserID == userID &&
+		!withinFieldNoteEditWindow(comment.CreatedAt) {
+		return errors.New("field note edit window has expired")
 	}
 
 	visibility := engagementm.CommentVisibilityHiddenByUser

--- a/backend/internal/services/engagement/comment_service.go
+++ b/backend/internal/services/engagement/comment_service.go
@@ -117,6 +117,22 @@ func wilsonScore(ups, downs int) float64 {
 	return (phat + z*z/(2*n) - z*math.Sqrt((phat*(1-phat)+z*z/(4*n))/n)) / (1 + z*z/n)
 }
 
+// FieldNoteEditWindow is the time-bounded window during which a field note's
+// author can Edit or Delete their own note (PSY-567). After the window
+// elapses, the row becomes immutable to the author — only admin moderation
+// and the user-facing Report flow remain. The constant lives here (rather
+// than `models/engagement`) because it's a service-layer policy, not a
+// schema invariant; if a future ticket wants to make this per-user or
+// configurable, this is the right seam.
+const FieldNoteEditWindow = 30 * time.Minute
+
+// withinFieldNoteEditWindow reports whether the given creation timestamp is
+// still within the field-note author-edit grace window. Centralized so the
+// edit + delete paths can't drift apart.
+func withinFieldNoteEditWindow(createdAt time.Time) bool {
+	return time.Since(createdAt) < FieldNoteEditWindow
+}
+
 // validateCommentEntityType checks if the entity type is supported.
 func validateCommentEntityType(entityType string) (engagementm.CommentEntityType, error) {
 	ct := engagementm.CommentEntityType(entityType)
@@ -602,6 +618,12 @@ func (s *CommentService) GetThread(rootID uint) ([]*contracts.CommentResponse, e
 // UpdateComment updates a comment's body. Only the author can update their own comment.
 // Writes the prior body to comment_edits (with the editor's user ID) and bumps the
 // edit counter — all in a single transaction so the edit log and body update are atomic.
+//
+// Field notes (PSY-567) carry an additional time-bounded gate: the author can
+// edit only within FieldNoteEditWindow of created_at, and may supply a
+// `structured_data` payload to atomically replace ratings / verified-attendee
+// / spoiler flag alongside the body change. Out-of-window edits return an
+// "edit window expired" error mapped to 403 at the handler.
 func (s *CommentService) UpdateComment(userID uint, commentID uint, req *contracts.UpdateCommentRequest) (*contracts.CommentResponse, error) {
 	if s.db == nil {
 		return nil, errors.New("database not initialized")
@@ -629,6 +651,37 @@ func (s *CommentService) UpdateComment(userID uint, commentID uint, req *contrac
 		return nil, errors.New("only the comment author can edit this comment")
 	}
 
+	// PSY-567: field notes have a 30-minute author-edit window. Regular
+	// comments retain their unbounded author-edit behaviour (unchanged).
+	// The window protects historical-record integrity once the note has
+	// had a chance to be read / referenced; admin moderation remains the
+	// out-of-window retraction path.
+	isFieldNote := comment.Kind == engagementm.CommentKindFieldNote
+	if isFieldNote && !withinFieldNoteEditWindow(comment.CreatedAt) {
+		return nil, errors.New("field note edit window has expired")
+	}
+
+	// Validate + serialise structured-data update (field notes only). On
+	// regular comments any supplied structured_data is silently ignored —
+	// the field is field-note-specific and giving a 400 here would
+	// complicate callers that share the UpdateComment hook for both kinds.
+	var newStructuredData *json.RawMessage
+	if isFieldNote && req.StructuredData != nil {
+		sd := req.StructuredData
+		if sd.SoundQuality != nil && (*sd.SoundQuality < 1 || *sd.SoundQuality > 5) {
+			return nil, errors.New("sound_quality must be between 1 and 5")
+		}
+		if sd.CrowdEnergy != nil && (*sd.CrowdEnergy < 1 || *sd.CrowdEnergy > 5) {
+			return nil, errors.New("crowd_energy must be between 1 and 5")
+		}
+		sdJSON, err := json.Marshal(sd)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal structured data: %w", err)
+		}
+		raw := json.RawMessage(sdJSON)
+		newStructuredData = &raw
+	}
+
 	bodyHTML := s.renderMarkdown(body)
 	now := time.Now()
 
@@ -647,13 +700,19 @@ func (s *CommentService) UpdateComment(userID uint, commentID uint, req *contrac
 			return fmt.Errorf("failed to save edit history: %w", err)
 		}
 
-		// Update the comment body and bump edit_count/updated_at.
-		if err := tx.Model(&comment).Updates(map[string]interface{}{
+		// Update the comment body and bump edit_count/updated_at. Structured
+		// data ride-alongs (field notes, PSY-567) replace the JSONB column
+		// in-place as a unit — never merged, matching the "as a unit" AC.
+		updates := map[string]interface{}{
 			"body":       body,
 			"body_html":  bodyHTML,
 			"edit_count": gorm.Expr("edit_count + 1"),
 			"updated_at": now,
-		}).Error; err != nil {
+		}
+		if newStructuredData != nil {
+			updates["structured_data"] = newStructuredData
+		}
+		if err := tx.Model(&comment).Updates(updates).Error; err != nil {
 			return fmt.Errorf("failed to update comment: %w", err)
 		}
 		return nil
@@ -774,6 +833,15 @@ func (s *CommentService) GetCommentEditHistory(requesterID uint, commentID uint)
 
 // DeleteComment performs a soft delete by setting visibility.
 // Authors set hidden_by_user; admins set hidden_by_mod.
+//
+// For field notes (PSY-567), the author-delete path additionally enforces the
+// FieldNoteEditWindow grace period — out-of-window author deletes return an
+// "edit window expired" error mapped to 403 at the handler. Admin
+// moderation (`isAdmin=true`) bypasses the window so moderation queues
+// remain functional regardless of note age. An admin deleting their OWN
+// field note is treated as a user action and is also bounded by the window
+// (admins authoring field notes don't get a special-case bypass — the
+// window guarantee is per-author, not per-role).
 func (s *CommentService) DeleteComment(userID uint, commentID uint, isAdmin bool) error {
 	if s.db == nil {
 		return errors.New("database not initialized")
@@ -790,6 +858,19 @@ func (s *CommentService) DeleteComment(userID uint, commentID uint, isAdmin bool
 	// Non-admin users can only delete their own comments
 	if !isAdmin && comment.UserID != userID {
 		return errors.New("only the comment author or an admin can delete this comment")
+	}
+
+	// PSY-567: field-note window applies to AUTHOR self-deletes. An admin
+	// moderating someone else's note bypasses the window (that's the
+	// out-of-window retraction path the AC mentions). The
+	// "isAdmin && comment.UserID == userID" check matches the existing
+	// pattern below where an admin deleting their own row is treated as a
+	// user action.
+	isAuthorAction := comment.UserID == userID
+	if comment.Kind == engagementm.CommentKindFieldNote && isAuthorAction {
+		if !withinFieldNoteEditWindow(comment.CreatedAt) {
+			return errors.New("field note edit window has expired")
+		}
 	}
 
 	visibility := engagementm.CommentVisibilityHiddenByUser

--- a/backend/internal/services/engagement/field_note_test.go
+++ b/backend/internal/services/engagement/field_note_test.go
@@ -832,3 +832,209 @@ func (suite *FieldNoteIntegrationTestSuite) TestCreateFieldNote_AutoSubscribes()
 	suite.Require().NoError(err)
 	suite.Equal(user.ID, sub.UserID)
 }
+
+// =============================================================================
+// Group 7: Author Edit/Delete Window (PSY-567)
+// =============================================================================
+// Field notes are immutable to the author after FieldNoteEditWindow (30 min).
+// Admins can still moderate (hide/restore via the admin handlers). The same
+// rule applies to author self-delete. Regular comments are unchanged.
+
+// agedFieldNote inserts a field note and back-dates its created_at to make
+// the row appear `age` old without sleeping in tests.
+func (suite *FieldNoteIntegrationTestSuite) agedFieldNote(userID, showID uint, body string, age time.Duration) *engagementm.Comment {
+	note := suite.insertFieldNote(userID, showID, body, nil)
+	backdated := time.Now().Add(-age)
+	suite.Require().NoError(
+		suite.db.Model(note).Update("created_at", backdated).Error,
+	)
+	note.CreatedAt = backdated
+	return note
+}
+
+func (suite *FieldNoteIntegrationTestSuite) TestUpdateFieldNote_WithinWindow_Succeeds() {
+	user := suite.createTestUser()
+	showID := suite.createPastShow("Edit Window OK", 2)
+	note := suite.agedFieldNote(user.ID, showID, "original body", 5*time.Minute)
+
+	updated, err := suite.commentService.UpdateComment(user.ID, note.ID, &contracts.UpdateCommentRequest{
+		Body: "edited body within window",
+	})
+	suite.Require().NoError(err)
+	suite.Equal("edited body within window", updated.Body)
+	suite.True(updated.IsEdited)
+	suite.Equal(1, updated.EditCount)
+}
+
+func (suite *FieldNoteIntegrationTestSuite) TestUpdateFieldNote_OutOfWindow_403() {
+	user := suite.createTestUser()
+	showID := suite.createPastShow("Edit Window Expired", 2)
+	note := suite.agedFieldNote(user.ID, showID, "old body", FieldNoteEditWindow+time.Minute)
+
+	_, err := suite.commentService.UpdateComment(user.ID, note.ID, &contracts.UpdateCommentRequest{
+		Body: "attempted edit after window",
+	})
+	suite.Require().Error(err)
+	suite.Contains(err.Error(), "field note edit window has expired")
+
+	// Body must be unchanged
+	var reloaded engagementm.Comment
+	suite.Require().NoError(suite.db.First(&reloaded, note.ID).Error)
+	suite.Equal("old body", reloaded.Body)
+	suite.Equal(0, reloaded.EditCount)
+}
+
+func (suite *FieldNoteIntegrationTestSuite) TestUpdateFieldNote_StructuredDataReplaced() {
+	// PSY-567 AC: edit must allow updating structured fields (ratings,
+	// verified-attendee, spoiler) as a unit, not body-only.
+	user := suite.createTestUser()
+	showID := suite.createPastShow("SD Edit", 2)
+	sq := 3
+	ce := 3
+	note := suite.insertFieldNote(user.ID, showID, "first take", &contracts.FieldNoteStructuredData{
+		SoundQuality:       &sq,
+		CrowdEnergy:        &ce,
+		SetlistSpoiler:     false,
+		IsVerifiedAttendee: false,
+	})
+
+	newSQ := 5
+	newCE := 4
+	updated, err := suite.commentService.UpdateComment(user.ID, note.ID, &contracts.UpdateCommentRequest{
+		Body: "revised take",
+		StructuredData: &contracts.FieldNoteStructuredData{
+			SoundQuality:       &newSQ,
+			CrowdEnergy:        &newCE,
+			SetlistSpoiler:     true,
+			IsVerifiedAttendee: true,
+		},
+	})
+	suite.Require().NoError(err)
+	suite.Equal("revised take", updated.Body)
+	suite.Require().NotNil(updated.StructuredData)
+
+	var sd contracts.FieldNoteStructuredData
+	suite.Require().NoError(json.Unmarshal(*updated.StructuredData, &sd))
+	suite.Equal(&newSQ, sd.SoundQuality)
+	suite.Equal(&newCE, sd.CrowdEnergy)
+	suite.True(sd.SetlistSpoiler)
+	suite.True(sd.IsVerifiedAttendee)
+}
+
+func (suite *FieldNoteIntegrationTestSuite) TestUpdateFieldNote_StructuredDataInvalidRange() {
+	user := suite.createTestUser()
+	showID := suite.createPastShow("SD Invalid Edit", 2)
+	note := suite.insertFieldNote(user.ID, showID, "valid body", nil)
+
+	bad := 7
+	_, err := suite.commentService.UpdateComment(user.ID, note.ID, &contracts.UpdateCommentRequest{
+		Body: "still valid body",
+		StructuredData: &contracts.FieldNoteStructuredData{
+			SoundQuality: &bad,
+		},
+	})
+	suite.Require().Error(err)
+	suite.Contains(err.Error(), "sound_quality must be between 1 and 5")
+
+	// Row should be untouched (validation runs before the transaction).
+	var reloaded engagementm.Comment
+	suite.Require().NoError(suite.db.First(&reloaded, note.ID).Error)
+	suite.Equal("valid body", reloaded.Body)
+	suite.Equal(0, reloaded.EditCount)
+}
+
+func (suite *FieldNoteIntegrationTestSuite) TestUpdateRegularComment_NoWindowApplied() {
+	// PSY-567 must NOT regress regular comments — they retain unbounded
+	// author-edit. Backdate one well past the field-note window and assert
+	// the edit still succeeds.
+	user := suite.createTestUser()
+	artistID := suite.createTestArtistFor("Regular Edit", &authm.User{})
+	original, err := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
+		EntityType: "artist",
+		EntityID:   artistID,
+		Body:       "original regular comment",
+	})
+	suite.Require().NoError(err)
+	suite.Require().NoError(
+		suite.db.Model(&engagementm.Comment{}).Where("id = ?", original.ID).
+			Update("created_at", time.Now().Add(-2*FieldNoteEditWindow)).Error,
+	)
+
+	updated, err := suite.commentService.UpdateComment(user.ID, original.ID, &contracts.UpdateCommentRequest{
+		Body: "edited 1h+ later",
+	})
+	suite.Require().NoError(err)
+	suite.Equal("edited 1h+ later", updated.Body)
+}
+
+func (suite *FieldNoteIntegrationTestSuite) TestDeleteFieldNote_WithinWindow_Succeeds() {
+	user := suite.createTestUser()
+	showID := suite.createPastShow("Delete Window OK", 2)
+	note := suite.agedFieldNote(user.ID, showID, "delete me", 5*time.Minute)
+
+	err := suite.commentService.DeleteComment(user.ID, note.ID, false)
+	suite.Require().NoError(err)
+
+	var reloaded engagementm.Comment
+	suite.Require().NoError(suite.db.First(&reloaded, note.ID).Error)
+	suite.Equal(engagementm.CommentVisibilityHiddenByUser, reloaded.Visibility)
+}
+
+func (suite *FieldNoteIntegrationTestSuite) TestDeleteFieldNote_OutOfWindow_403() {
+	user := suite.createTestUser()
+	showID := suite.createPastShow("Delete Window Expired", 2)
+	note := suite.agedFieldNote(user.ID, showID, "stale note", FieldNoteEditWindow+time.Minute)
+
+	err := suite.commentService.DeleteComment(user.ID, note.ID, false)
+	suite.Require().Error(err)
+	suite.Contains(err.Error(), "field note edit window has expired")
+
+	// Visibility unchanged
+	var reloaded engagementm.Comment
+	suite.Require().NoError(suite.db.First(&reloaded, note.ID).Error)
+	suite.Equal(engagementm.CommentVisibilityVisible, reloaded.Visibility)
+}
+
+func (suite *FieldNoteIntegrationTestSuite) TestDeleteFieldNote_AdminOutOfWindow_Succeeds() {
+	// Admin moderation bypasses the author window — that's how out-of-
+	// window retraction works (per AC).
+	user := suite.createTestUser()
+	admin := suite.createTestAdminFor()
+	showID := suite.createPastShow("Admin Override", 2)
+	note := suite.agedFieldNote(user.ID, showID, "old note", FieldNoteEditWindow+time.Minute)
+
+	err := suite.commentService.DeleteComment(admin.ID, note.ID, true)
+	suite.Require().NoError(err)
+
+	var reloaded engagementm.Comment
+	suite.Require().NoError(suite.db.First(&reloaded, note.ID).Error)
+	suite.Equal(engagementm.CommentVisibilityHiddenByMod, reloaded.Visibility)
+}
+
+// Local test helpers — keep these out of the existing groups so they're
+// adjacent to the PSY-567 suite that consumes them.
+
+func (suite *FieldNoteIntegrationTestSuite) createTestAdminFor() *authm.User {
+	user := &authm.User{
+		Email:         stringPtr(fmt.Sprintf("fn-admin-%d@test.com", time.Now().UnixNano())),
+		Username:      stringPtr(fmt.Sprintf("fnadmin%d", time.Now().UnixNano())),
+		FirstName:     stringPtr("Admin"),
+		LastName:      stringPtr("User"),
+		IsActive:      true,
+		EmailVerified: true,
+		UserTier:      "admin",
+		IsAdmin:       true,
+	}
+	err := suite.db.Create(user).Error
+	suite.Require().NoError(err)
+	return user
+}
+
+// createTestArtistFor is a thin alias kept here only because the existing
+// createTestArtist helper takes a name; the regression test for regular
+// comments needs an artist row independent of the field-note suite's
+// helpers in the same package. The signature accepts an unused user arg so
+// future expansions can record ownership without another helper.
+func (suite *FieldNoteIntegrationTestSuite) createTestArtistFor(name string, _ *authm.User) uint {
+	return suite.createTestArtist(name)
+}

--- a/backend/internal/services/engagement/field_note_test.go
+++ b/backend/internal/services/engagement/field_note_test.go
@@ -948,7 +948,7 @@ func (suite *FieldNoteIntegrationTestSuite) TestUpdateRegularComment_NoWindowApp
 	// author-edit. Backdate one well past the field-note window and assert
 	// the edit still succeeds.
 	user := suite.createTestUser()
-	artistID := suite.createTestArtistFor("Regular Edit", &authm.User{})
+	artistID := suite.createTestArtist("Regular Edit")
 	original, err := suite.commentService.CreateComment(user.ID, &contracts.CreateCommentRequest{
 		EntityType: "artist",
 		EntityID:   artistID,
@@ -999,7 +999,7 @@ func (suite *FieldNoteIntegrationTestSuite) TestDeleteFieldNote_AdminOutOfWindow
 	// Admin moderation bypasses the author window — that's how out-of-
 	// window retraction works (per AC).
 	user := suite.createTestUser()
-	admin := suite.createTestAdminFor()
+	admin := suite.createTestAdmin()
 	showID := suite.createPastShow("Admin Override", 2)
 	note := suite.agedFieldNote(user.ID, showID, "old note", FieldNoteEditWindow+time.Minute)
 
@@ -1011,10 +1011,10 @@ func (suite *FieldNoteIntegrationTestSuite) TestDeleteFieldNote_AdminOutOfWindow
 	suite.Equal(engagementm.CommentVisibilityHiddenByMod, reloaded.Visibility)
 }
 
-// Local test helpers — keep these out of the existing groups so they're
-// adjacent to the PSY-567 suite that consumes them.
-
-func (suite *FieldNoteIntegrationTestSuite) createTestAdminFor() *authm.User {
+// createTestAdmin mirrors the CommentServiceIntegrationTestSuite helper of
+// the same name — separate suite types in the same package can't share
+// methods, so PSY-567's admin-bypass test needs its own.
+func (suite *FieldNoteIntegrationTestSuite) createTestAdmin() *authm.User {
 	user := &authm.User{
 		Email:         stringPtr(fmt.Sprintf("fn-admin-%d@test.com", time.Now().UnixNano())),
 		Username:      stringPtr(fmt.Sprintf("fnadmin%d", time.Now().UnixNano())),
@@ -1028,13 +1028,4 @@ func (suite *FieldNoteIntegrationTestSuite) createTestAdminFor() *authm.User {
 	err := suite.db.Create(user).Error
 	suite.Require().NoError(err)
 	return user
-}
-
-// createTestArtistFor is a thin alias kept here only because the existing
-// createTestArtist helper takes a name; the regression test for regular
-// comments needs an artist row independent of the field-note suite's
-// helpers in the same package. The signature accepts an unused user arg so
-// future expansions can record ownership without another helper.
-func (suite *FieldNoteIntegrationTestSuite) createTestArtistFor(name string, _ *authm.User) uint {
-	return suite.createTestArtist(name)
 }

--- a/frontend/features/comments/components/FieldNoteCard.test.tsx
+++ b/frontend/features/comments/components/FieldNoteCard.test.tsx
@@ -54,11 +54,17 @@ vi.mock('./CommentEditHistory', () => ({
   CommentEditHistory: () => <div data-testid="stub-edit-history-dialog" />,
 }))
 
+// PSY-567: default created_at is "now" so the field-note's author still has
+// access to the Edit/Delete buttons in the existing PSY-590 test cases. Tests
+// that exercise the OUT-OF-window behaviour override `created_at` with a
+// timestamp older than 30 minutes.
 function makeFieldNote(overrides: Partial<Comment> = {}): Comment {
+  const nowIso = new Date().toISOString()
   return {
     id: 1,
     entity_type: 'show',
     entity_id: 10,
+    kind: 'field_note',
     user_id: 2,
     author_name: 'TestUser',
     body: 'Amazing show!',
@@ -73,8 +79,8 @@ function makeFieldNote(overrides: Partial<Comment> = {}): Comment {
     reply_permission: 'anyone',
     edit_count: 0,
     is_edited: false,
-    created_at: '2026-04-01T00:00:00Z',
-    updated_at: '2026-04-01T00:00:00Z',
+    created_at: nowIso,
+    updated_at: nowIso,
     structured_data: {
       sound_quality: 4,
       crowd_energy: 5,
@@ -521,6 +527,8 @@ describe('FieldNoteCard', () => {
     })
 
     it('opens an inline edit form populated with the existing body when Edit is clicked', () => {
+      // PSY-567: root field-note edit now opens the FieldNoteForm (with
+      // structured-data fields) instead of the body-only CommentForm.
       ownerAuth()
       render(
         <FieldNoteCard
@@ -532,14 +540,24 @@ describe('FieldNoteCard', () => {
       fireEvent.click(screen.getByTestId('edit-field-note-button'))
 
       const textarea = screen.getByTestId(
-        'comment-textarea'
+        'field-note-textarea'
       ) as HTMLTextAreaElement
       expect(textarea.value).toBe('My original take')
       // The read-only body view is replaced while editing.
       expect(screen.queryByTestId('field-note-body')).not.toBeInTheDocument()
+      // PSY-567: structured-data inputs are present so ratings / verified-
+      // attendee / spoiler can be edited as a unit.
+      expect(screen.getByTestId('sound-quality-rating')).toBeInTheDocument()
+      expect(screen.getByTestId('crowd-energy-rating')).toBeInTheDocument()
+      expect(
+        screen.getByTestId('verified-attendee-checkbox')
+      ).toBeInTheDocument()
+      expect(
+        screen.getByTestId('setlist-spoiler-checkbox')
+      ).toBeInTheDocument()
     })
 
-    it('calls useUpdateComment with the edited body on Save', () => {
+    it('calls useUpdateComment with the edited body + structured data on Save', () => {
       ownerAuth()
       const mutate = vi.fn()
       mockUseUpdateComment.mockReturnValue({
@@ -554,17 +572,26 @@ describe('FieldNoteCard', () => {
       )
 
       fireEvent.click(screen.getByTestId('edit-field-note-button'))
-      const textarea = screen.getByTestId('comment-textarea')
+      const textarea = screen.getByTestId('field-note-textarea')
       fireEvent.change(textarea, { target: { value: 'after' } })
       fireEvent.click(screen.getByText('Save'))
 
       expect(mutate).toHaveBeenCalledTimes(1)
       const [args] = mutate.mock.calls[0]
+      // PSY-567: edit submits body + structured_data as a unit. The
+      // fixture's existing ratings carry through unchanged.
       expect(args).toMatchObject({
         commentId: 1,
         body: 'after',
         entityType: 'show',
         entityId: 10,
+        structuredData: {
+          sound_quality: 4,
+          crowd_energy: 5,
+          notable_moments: 'Played 3 new songs',
+          setlist_spoiler: false,
+          is_verified_attendee: true,
+        },
       })
     })
 
@@ -578,7 +605,8 @@ describe('FieldNoteCard', () => {
       render(<FieldNoteCard comment={makeFieldNote()} showId={10} />)
       fireEvent.click(screen.getByTestId('edit-field-note-button'))
 
-      const banner = screen.getByTestId('comment-form-error')
+      // PSY-567: the field-note edit form has its own error banner testid.
+      const banner = screen.getByTestId('field-note-form-error')
       expect(banner).toBeInTheDocument()
       expect(banner).toHaveTextContent('Comment is too long')
     })
@@ -683,6 +711,97 @@ describe('FieldNoteCard', () => {
       expect(
         screen.queryByTestId('admin-edit-history-button')
       ).not.toBeInTheDocument()
+    })
+  })
+
+  // PSY-567: Reddit-style 30-minute author-edit window. Buttons are
+  // rendered for the author within the window and HIDDEN after. After
+  // expiry, the only retraction path is the Report button (handled by
+  // the existing non-owner branch when the user is not the author).
+  describe('30-minute author-edit window (PSY-567)', () => {
+    function ownerAuth() {
+      mockAuthContext.mockReturnValue({
+        isAuthenticated: true,
+        user: { id: '2', email: 'owner@example.com', is_admin: false },
+      })
+    }
+
+    it('renders Edit + Delete for the author within the 30-min window', () => {
+      ownerAuth()
+      const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString()
+      render(
+        <FieldNoteCard
+          comment={makeFieldNote({ created_at: fiveMinutesAgo })}
+          showId={10}
+        />
+      )
+      expect(screen.getByTestId('edit-field-note-button')).toBeInTheDocument()
+      expect(
+        screen.getByTestId('delete-field-note-button')
+      ).toBeInTheDocument()
+    })
+
+    it('HIDES Edit + Delete for the author once the 30-min window has elapsed', () => {
+      ownerAuth()
+      const thirtyOneMinutesAgo = new Date(
+        Date.now() - 31 * 60 * 1000
+      ).toISOString()
+      render(
+        <FieldNoteCard
+          comment={makeFieldNote({ created_at: thirtyOneMinutesAgo })}
+          showId={10}
+        />
+      )
+      expect(
+        screen.queryByTestId('edit-field-note-button')
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByTestId('delete-field-note-button')
+      ).not.toBeInTheDocument()
+    })
+
+    it('keeps Edit + Delete visible at exactly 29:59 (boundary, in window)', () => {
+      // Boundary check just before expiry. 29 minutes + 59 seconds is still
+      // < 30 minutes so the buttons must render.
+      ownerAuth()
+      const justInsideWindow = new Date(
+        Date.now() - (29 * 60 * 1000 + 59 * 1000)
+      ).toISOString()
+      render(
+        <FieldNoteCard
+          comment={makeFieldNote({ created_at: justInsideWindow })}
+          showId={10}
+        />
+      )
+      expect(screen.getByTestId('edit-field-note-button')).toBeInTheDocument()
+      expect(
+        screen.getByTestId('delete-field-note-button')
+      ).toBeInTheDocument()
+    })
+
+    it('does NOT show Edit/Delete for a regular comment kind on the same row, even within 30min', () => {
+      // Defence in depth: a comment that somehow ends up rendered by
+      // FieldNoteCard with kind="comment" (e.g. nested reply rendering)
+      // does NOT pick up the 30-min window — the field-note rule must
+      // not change the existing comment-edit semantics.
+      ownerAuth()
+      const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString()
+      render(
+        <FieldNoteCard
+          comment={makeFieldNote({
+            kind: 'comment',
+            depth: 1,
+            created_at: fiveMinutesAgo,
+          })}
+          showId={10}
+        />
+      )
+      // Replies edit through the normal Edit/Delete path — they still
+      // render (the window logic short-circuits for non-field-note kinds).
+      expect(screen.getByTestId('edit-field-note-button')).toBeInTheDocument()
+      expect(
+        screen.getByTestId('delete-field-note-button')
+      ).toBeInTheDocument()
     })
   })
 })

--- a/frontend/features/comments/components/FieldNoteCard.tsx
+++ b/frontend/features/comments/components/FieldNoteCard.tsx
@@ -9,6 +9,7 @@ import { Badge } from '@/components/ui/badge'
 import { UserAttribution } from '@/components/shared'
 import { CommentForm } from './CommentForm'
 import { CommentEditHistory } from './CommentEditHistory'
+import { FieldNoteForm } from './FieldNoteForm'
 import { MutationErrorBanner } from './MutationErrorBanner'
 import { ReportEntityDialog } from '@/features/contributions'
 import {
@@ -21,7 +22,12 @@ import {
   useAutoDismissError,
   formatCommentSubmissionError,
 } from '../hooks'
-import type { Comment } from '../types'
+import {
+  isWithinFieldNoteEditWindow,
+  type Comment,
+  type CreateFieldNoteInput,
+  type FieldNoteStructuredData,
+} from '../types'
 
 interface ShowArtist {
   id: number
@@ -62,6 +68,16 @@ export function FieldNoteCard({
   const currentUserId = user?.id ? Number(user.id) : null
   const isOwner = currentUserId === comment.user_id
   const isAdmin = Boolean(user?.is_admin)
+  // PSY-567: 30-min author-edit window. Computed on each render — no
+  // ticking interval; buttons disappear naturally as the note ages out
+  // during the user's session (and the backend rejects out-of-window
+  // edits with 403 as a safety net for any stale render). Replies that
+  // are regular comments (depth > 0) are intentionally NOT bounded by
+  // this — the field-note window applies only to the `kind: field_note`
+  // root row.
+  const isFieldNote = comment.kind === 'field_note'
+  const isEditable =
+    isOwner && (!isFieldNote || isWithinFieldNoteEditWindow(comment.created_at))
 
   const [isReplying, setIsReplying] = useState(false)
   const [isEditing, setIsEditing] = useState(false)
@@ -123,10 +139,36 @@ export function FieldNoteCard({
   // PUT/DELETE /comments/{id} endpoints operate on the row regardless of
   // kind, so field-note edits go through the same useUpdateComment hook
   // and inherit the comment_edits history (admin-visible via PSY-297).
-  // Structured fields (sound/crowd/notable/etc.) are intentionally NOT
-  // editable here — only the body, matching the existing comment-edit
-  // surface and the "mirror comment behavior" decision on this ticket.
-  const handleEdit = (body: string) => {
+  // PSY-567: structured fields (ratings, verified-attendee, spoiler,
+  // notable moments, artist set, song position) are now editable as a
+  // unit — the FieldNoteForm carries the same fields as creation and
+  // the backend replaces structured_data atomically with the body.
+  const handleEdit = (input: CreateFieldNoteInput) => {
+    const structuredData: FieldNoteStructuredData = {
+      show_artist_id: input.show_artist_id ?? null,
+      song_position: input.song_position ?? null,
+      sound_quality: input.sound_quality ?? null,
+      crowd_energy: input.crowd_energy ?? null,
+      notable_moments: input.notable_moments ?? null,
+      setlist_spoiler: input.setlist_spoiler ?? false,
+      is_verified_attendee: input.verified_attendee ?? false,
+    }
+    updateMutation.mutate(
+      {
+        commentId: comment.id,
+        body: input.body,
+        entityType: 'show',
+        entityId: showId,
+        structuredData,
+      },
+      { onSuccess: () => setIsEditing(false) }
+    )
+  }
+
+  // PSY-590: comment replies under a field note are regular comments and
+  // edit body-only via CommentForm (mirrors CommentCard). This handler is
+  // used only on the reply rows below.
+  const handleEditReplyBody = (body: string) => {
     updateMutation.mutate(
       { commentId: comment.id, body, entityType: 'show', entityId: showId },
       { onSuccess: () => setIsEditing(false) }
@@ -225,13 +267,37 @@ export function FieldNoteCard({
       )}
 
       {/* Body — with spoiler handling. PSY-590: edit mode replaces the
-          rendered body with a CommentForm; only the body field is editable
-          (mirrors comment-edit). Structured fields (sound/crowd/notable/etc.)
-          remain saved as-is on the row. */}
-      {isEditing ? (
+          rendered body with an edit form.
+          PSY-567: the ROOT field-note edits via FieldNoteForm so structured
+          fields (sound / crowd / notable / artist / position / spoiler /
+          verified-attendee) are editable as a unit. Replies under a field
+          note are regular comments (kind="comment", no structured data) and
+          continue to edit body-only via CommentForm. */}
+      {isEditing && isFieldNote ? (
+        <div className="mt-2">
+          <FieldNoteForm
+            onSubmit={handleEdit}
+            artists={artists}
+            isPending={updateMutation.isPending}
+            errorMessage={formatCommentSubmissionError(updateMutation.error)}
+            onCancel={() => setIsEditing(false)}
+            submitLabel="Save"
+            initialValues={{
+              body: comment.body,
+              sound_quality: sd?.sound_quality ?? null,
+              crowd_energy: sd?.crowd_energy ?? null,
+              notable_moments: sd?.notable_moments ?? null,
+              setlist_spoiler: sd?.setlist_spoiler ?? false,
+              show_artist_id: sd?.show_artist_id ?? null,
+              song_position: sd?.song_position ?? null,
+              verified_attendee: sd?.is_verified_attendee ?? false,
+            }}
+          />
+        </div>
+      ) : isEditing ? (
         <div className="mt-2">
           <CommentForm
-            onSubmit={handleEdit}
+            onSubmit={handleEditReplyBody}
             initialBody={comment.body}
             submitLabel="Save"
             onCancel={() => setIsEditing(false)}
@@ -352,8 +418,11 @@ export function FieldNoteCard({
             </Button>
           )}
 
-          {/* PSY-590: Edit button (own field notes). Mirrors CommentCard. */}
-          {isOwner && (
+          {/* PSY-590: Edit button (own field notes). Mirrors CommentCard.
+              PSY-567: gated on the 30-min author-edit window for field
+              notes; after the window, Report is the only retraction path.
+              The empty action row IS the affordance — no tooltip, per AC. */}
+          {isEditable && (
             <Button
               variant="ghost"
               size="sm"
@@ -367,8 +436,9 @@ export function FieldNoteCard({
           )}
 
           {/* PSY-590: Delete button (own field notes) with inline Yes/No
-              confirmation, mirroring CommentCard. */}
-          {isOwner && !isDeleteConfirm && (
+              confirmation, mirroring CommentCard.
+              PSY-567: same 30-min author window as Edit. */}
+          {isEditable && !isDeleteConfirm && (
             <Button
               variant="ghost"
               size="sm"

--- a/frontend/features/comments/components/FieldNoteForm.tsx
+++ b/frontend/features/comments/components/FieldNoteForm.tsx
@@ -42,6 +42,34 @@ interface FieldNoteFormProps {
    * notes.
    */
   defaultVerifiedAttendee?: boolean
+  /**
+   * PSY-567: optional initial values for edit mode. When supplied, all
+   * fields pre-populate from the existing note. resetSignal still works
+   * but resets back to these initial values (not blank). Mode visibility
+   * stays identical to create — the same structured-data fields are
+   * shown, satisfying the "edit as a unit, not body-only" AC.
+   */
+  initialValues?: {
+    body: string
+    sound_quality?: number | null
+    crowd_energy?: number | null
+    notable_moments?: string | null
+    setlist_spoiler?: boolean
+    show_artist_id?: number | null
+    song_position?: number | null
+    verified_attendee?: boolean
+  }
+  /**
+   * PSY-567: submit-button label override. Defaults to "Post Field Note"
+   * for the create path; edit mode uses "Save".
+   */
+  submitLabel?: string
+  /**
+   * PSY-567: optional Cancel callback. When supplied, a secondary
+   * "Cancel" button renders alongside Submit so the user can abort an
+   * in-progress edit without losing the rendered note.
+   */
+  onCancel?: () => void
 }
 
 function StarRating({
@@ -93,21 +121,41 @@ export function FieldNoteForm({
   errorMessage,
   resetSignal,
   defaultVerifiedAttendee = false,
+  initialValues,
+  submitLabel,
+  onCancel,
 }: FieldNoteFormProps) {
-  const [body, setBody] = useState('')
-  const [soundQuality, setSoundQuality] = useState(0)
-  const [crowdEnergy, setCrowdEnergy] = useState(0)
-  const [notableMoments, setNotableMoments] = useState('')
-  const [setlistSpoiler, setSetlistSpoiler] = useState(false)
-  const [showArtistId, setShowArtistId] = useState<number | undefined>(undefined)
-  const [songPosition, setSongPosition] = useState('')
+  // PSY-567: in edit mode (initialValues supplied) hydrate from the
+  // existing note. Otherwise default to empty/zero (create path, unchanged).
+  const [body, setBody] = useState(initialValues?.body ?? '')
+  const [soundQuality, setSoundQuality] = useState(initialValues?.sound_quality ?? 0)
+  const [crowdEnergy, setCrowdEnergy] = useState(initialValues?.crowd_energy ?? 0)
+  const [notableMoments, setNotableMoments] = useState(initialValues?.notable_moments ?? '')
+  const [setlistSpoiler, setSetlistSpoiler] = useState(
+    initialValues?.setlist_spoiler ?? false
+  )
+  const [showArtistId, setShowArtistId] = useState<number | undefined>(
+    initialValues?.show_artist_id ?? undefined
+  )
+  const [songPosition, setSongPosition] = useState(
+    initialValues?.song_position != null ? String(initialValues.song_position) : ''
+  )
   // PSY-568: self-claim "I attended this show". Initial state mirrors the
   // user's current Going RSVP; falls back to false. Re-syncs when the
   // default changes (e.g. attendance loads after the form mounts).
-  const [verifiedAttendee, setVerifiedAttendee] = useState(defaultVerifiedAttendee)
+  // PSY-567: in edit mode, the stored value takes precedence over the
+  // Going-RSVP default — the user's prior self-claim is what they're
+  // editing.
+  const [verifiedAttendee, setVerifiedAttendee] = useState(
+    initialValues?.verified_attendee ?? defaultVerifiedAttendee
+  )
   useEffect(() => {
+    // PSY-567: only re-sync from Going status on the CREATE path. Editing
+    // an existing note must not silently overwrite the prior self-claim
+    // when attendance data loads after the form mounts.
+    if (initialValues) return
     setVerifiedAttendee(defaultVerifiedAttendee)
-  }, [defaultVerifiedAttendee])
+  }, [defaultVerifiedAttendee, initialValues])
 
   // PSY-608: parent bumps resetSignal from mutation onSuccess. Mirrors the
   // CommentForm pattern so a 4xx response keeps the user's draft intact.
@@ -116,8 +164,25 @@ export function FieldNoteForm({
   // dep array — its own useEffect above handles re-sync when Going status
   // changes, and including it here would wipe the user's draft on every
   // attendance refetch.
+  // PSY-567: in edit mode, reset returns to initialValues (not blank) so
+  // a save-then-reopen cycle shows the freshly-saved state.
   useEffect(() => {
     if (resetSignal === undefined) return
+    if (initialValues) {
+      setBody(initialValues.body)
+      setSoundQuality(initialValues.sound_quality ?? 0)
+      setCrowdEnergy(initialValues.crowd_energy ?? 0)
+      setNotableMoments(initialValues.notable_moments ?? '')
+      setSetlistSpoiler(initialValues.setlist_spoiler ?? false)
+      setShowArtistId(initialValues.show_artist_id ?? undefined)
+      setSongPosition(
+        initialValues.song_position != null
+          ? String(initialValues.song_position)
+          : ''
+      )
+      setVerifiedAttendee(initialValues.verified_attendee ?? false)
+      return
+    }
     setBody('')
     setSoundQuality(0)
     setCrowdEnergy(0)
@@ -308,8 +373,20 @@ export function FieldNoteForm({
           data-testid="field-note-submit"
         >
           {isPending && <Loader2 className="h-4 w-4 mr-1.5 animate-spin" />}
-          Post Field Note
+          {submitLabel ?? 'Post Field Note'}
         </Button>
+        {onCancel && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={onCancel}
+            disabled={isPending}
+            data-testid="field-note-cancel"
+          >
+            Cancel
+          </Button>
+        )}
       </div>
     </form>
   )

--- a/frontend/features/comments/hooks/index.ts
+++ b/frontend/features/comments/hooks/index.ts
@@ -16,6 +16,7 @@ import type {
   CommentListResponse,
   CommentThreadResponse,
   CreateFieldNoteInput,
+  FieldNoteStructuredData,
   ReplyPermission,
 } from '../types'
 
@@ -259,15 +260,25 @@ export function useUpdateComment() {
     mutationFn: ({
       commentId,
       body,
+      structuredData,
     }: {
       commentId: number
       body: string
       entityType: string
       entityId: number
+      // PSY-567: field-note edits send the full structured-data block so
+      // ratings / verified-attendee / spoiler are replaced atomically with
+      // the body. Backend ignores this for non-field-note comments, so the
+      // same hook stays usable from CommentCard. Undefined => body-only edit.
+      structuredData?: FieldNoteStructuredData | null
     }) =>
       apiRequest<Comment>(commentEndpoints.UPDATE(commentId), {
         method: 'PUT',
-        body: JSON.stringify({ body }),
+        body: JSON.stringify(
+          structuredData !== undefined && structuredData !== null
+            ? { body, structured_data: structuredData }
+            : { body }
+        ),
       }),
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({

--- a/frontend/features/comments/hooks/index.ts
+++ b/frontend/features/comments/hooks/index.ts
@@ -275,7 +275,7 @@ export function useUpdateComment() {
       apiRequest<Comment>(commentEndpoints.UPDATE(commentId), {
         method: 'PUT',
         body: JSON.stringify(
-          structuredData !== undefined && structuredData !== null
+          structuredData != null
             ? { body, structured_data: structuredData }
             : { body }
         ),

--- a/frontend/features/comments/types.ts
+++ b/frontend/features/comments/types.ts
@@ -24,6 +24,13 @@ export interface Comment {
   id: number
   entity_type: string
   entity_id: number
+  // PSY-567: "comment" | "field_note". Reusing the unified Comment shape
+  // for both kinds means field-note-only UI (e.g. the 30-min author-edit
+  // window) needs to discriminate on this field at render time. Backend
+  // emits it on every `CommentResponse`. Optional in the TS type because
+  // pre-existing test fixtures + cache-write paths predate this field;
+  // treat absence as "comment" at use sites.
+  kind?: string
   user_id: number
   author_name: string
   /**
@@ -93,4 +100,23 @@ export interface CreateFieldNoteInput {
   // badge on existing notes. Frontend pre-fills the checkbox from the
   // user's current Going RSVP but the value sent here is authoritative.
   verified_attendee?: boolean
+}
+
+// PSY-567: time-bounded edit / delete window for a field note's author.
+// Matches the backend `FieldNoteEditWindow` constant. Author Edit + Delete
+// affordances are gated on `now - created_at < this`; after expiry, the
+// only retraction path is Report (moderator action).
+//
+// Implemented as a derived boolean evaluated on each render. We deliberately
+// do NOT install a ticking interval — the buttons disappear naturally as the
+// note ages out during the user's session, which is acceptable UX (the user
+// either gets a stale visible button that fails with a 403 on click, or the
+// component re-renders for an unrelated reason and the buttons disappear).
+// The backend window check is authoritative; the frontend gate is a UX hint.
+export const FIELD_NOTE_EDIT_WINDOW_MS = 30 * 60 * 1000
+
+export function isWithinFieldNoteEditWindow(createdAt: string): boolean {
+  const created = new Date(createdAt).getTime()
+  if (!Number.isFinite(created)) return false
+  return Date.now() - created < FIELD_NOTE_EDIT_WINDOW_MS
 }


### PR DESCRIPTION
## Summary
- Field-note authors can Edit + Delete their own notes within 30 min of `created_at`; immutable to the author after the window. Path C from the ticket.
- Backend: `FieldNoteEditWindow = 30 * time.Minute` constant. `UpdateComment` / `DeleteComment` check window for author-initiated edits/deletes on `kind=field_note`; admin moderation bypasses. Returns HTTP 403 with "field note edit window has expired" out-of-window. Regular comments retain unbounded edit semantics (no regression).
- `UpdateCommentRequest` extended with optional `StructuredData` — when the target is a field note, JSONB is replaced atomically alongside body. Regular comments ignore the field.
- Frontend: `isWithinFieldNoteEditWindow(created_at)` derived helper (no ticking interval; evaluated per render). `FieldNoteCard` gates Edit + Delete; rendered action row stays empty post-expiry (no tooltip, per AC). `FieldNoteForm` accepts `initialValues` / `submitLabel` / `onCancel` so edit mode reuses the same structured-data inputs.

## Test plan
- [x] `cd backend && go build ./...` — clean
- [x] `cd backend && go test ./internal/services/engagement/...` — pass (incl. 7 new field-note edit-window tests)
- [x] `cd backend && go test ./internal/api/handlers/engagement/...` — pass
- [x] `cd frontend && bun run typecheck` — clean
- [x] `cd frontend && bun run test:run features/comments` — 142/142 pass

## Manual repro
Dispatch stack in isolated mode. Posted a field note as the test user on a past show. Backdated `created_at` to in-window (5 min ago) and out-of-window (35 min ago) via `dogfood-output/PSY-567/screenshots/repro.mjs`.

- In-window (`dogfood-output/PSY-567/screenshots/in-window-state.png`): action row shows `^ 0 v  Reply  Edit  Delete`. Edit opens the form with all structured-data fields pre-populated; submit updates the row in place. Delete soft-removes.
- Out-of-window (`dogfood-output/PSY-567/screenshots/out-of-window-state.png`): same author, same surface — action row shows `^ 0 v  Reply` only. No Edit, no Delete, no tooltip (intentional per AC). Direct `PUT /api/comments/{id}` returned `{ status: 403, detail: "field note edit window has expired" }`.

## Simplify
Ran `/simplify` — 4 small fixes landed as a separate commit (`PSY-567: simplify per /simplify review`):
1. Drop `createTestArtistFor` wrapper (call `createTestArtist` directly).
2. Rename `createTestAdminFor` → `createTestAdmin` (sibling-suite naming).
3. Inline `isAuthorAction` boolean in `DeleteComment` (one use; surrounding comment block documents the rule).
4. Collapse `structuredData !== undefined && structuredData !== null` → `structuredData != null`.

Net: 3 files, -27 / +15 lines. All tests re-ran green.

## Notes for reviewer
Orchestrator-takeover: agent completed all work (implementation + tests + manual repro + simplify) but stalled at the push / `gh pr create` step. Orchestrator pushed the branch and opened the PR with the agent's evidence verbatim. The two commits + screenshots in `dogfood-output/PSY-567/` are the full record.

Closes PSY-567