### PR TITLE
PSY-633: write dispatch-stack .env before frontend health check

### DIFF
--- a/scripts/dispatch/stack-up.sh
+++ b/scripts/dispatch/stack-up.sh
@@ -109,9 +109,10 @@ if [ "$MODE" = "shared" ]; then
     echo $! > "$STACK_DIR/frontend.pid"
     disown 2>/dev/null || true
 
-    log "Waiting for frontend at http://localhost:$FRONTEND_PORT..."
-    wait_for_url "http://localhost:$FRONTEND_PORT" 60
-
+    # PSY-633: write .env BEFORE the frontend health check. If the wait times
+    # out (set -e exits the script), stack-down.sh still has the identifiers
+    # it needs to clean up. Shared mode doesn't run docker compose, but the
+    # PID files plus a present .env keep cleanup paths consistent.
     cat > "$STACK_DIR/.env" <<EOF
 STACK_MODE=shared
 STACK_WORKTREE_ID=$WORKTREE_ID
@@ -120,6 +121,10 @@ STACK_FRONTEND_PORT=$FRONTEND_PORT
 STACK_FRONTEND_URL=http://localhost:$FRONTEND_PORT
 BACKEND_URL=http://localhost:8080
 EOF
+
+    log "Waiting for frontend at http://localhost:$FRONTEND_PORT..."
+    wait_for_url "http://localhost:$FRONTEND_PORT" 60
+
     cat "$STACK_DIR/.env"
     log "Stack up (mode=shared): http://localhost:$FRONTEND_PORT -> http://localhost:8080"
     exit 0
@@ -186,6 +191,27 @@ disown 2>/dev/null || true
 log "Waiting for backend at $STACK_BACKEND_URL/health..."
 wait_for_url "$STACK_BACKEND_URL/health" 90
 
+# PSY-633: write .env BEFORE the frontend health check. If the wait times out
+# (set -e exits the script), stack-down.sh still reads STACK_MODE=isolated +
+# STACK_COMPOSE_PROJECT and runs `docker compose down -v` to reap postgres.
+# All values below are known at this point: ports were allocated upfront and
+# the backend just passed its health check. Frontend URL + port reflect the
+# port we already bound (or will attempt to bind) — they're stable even if
+# the dev server never reaches `wait_for_url`.
+cat > "$STACK_DIR/.env" <<EOF
+STACK_MODE=isolated
+STACK_WORKTREE_ID=$WORKTREE_ID
+STACK_COMPOSE_PROJECT=$COMPOSE_PROJECT
+STACK_POSTGRES_URL=$STACK_POSTGRES_URL
+STACK_POSTGRES_PORT=$POSTGRES_PORT
+STACK_BACKEND_URL=$STACK_BACKEND_URL
+STACK_BACKEND_PORT=$BACKEND_PORT
+STACK_FRONTEND_URL=$STACK_FRONTEND_URL
+STACK_FRONTEND_PORT=$FRONTEND_PORT
+BACKEND_URL=$STACK_BACKEND_URL
+NEXT_PUBLIC_API_URL=$STACK_FRONTEND_URL/api
+EOF
+
 log "Starting frontend on :$FRONTEND_PORT..."
 cd "$WORKTREE_PATH/frontend"
 # See the file header for the routing convention. NEXT_PUBLIC_API_URL points
@@ -203,18 +229,5 @@ disown 2>/dev/null || true
 log "Waiting for frontend at $STACK_FRONTEND_URL..."
 wait_for_url "$STACK_FRONTEND_URL" 60
 
-cat > "$STACK_DIR/.env" <<EOF
-STACK_MODE=isolated
-STACK_WORKTREE_ID=$WORKTREE_ID
-STACK_COMPOSE_PROJECT=$COMPOSE_PROJECT
-STACK_POSTGRES_URL=$STACK_POSTGRES_URL
-STACK_POSTGRES_PORT=$POSTGRES_PORT
-STACK_BACKEND_URL=$STACK_BACKEND_URL
-STACK_BACKEND_PORT=$BACKEND_PORT
-STACK_FRONTEND_URL=$STACK_FRONTEND_URL
-STACK_FRONTEND_PORT=$FRONTEND_PORT
-BACKEND_URL=$STACK_BACKEND_URL
-NEXT_PUBLIC_API_URL=$STACK_FRONTEND_URL/api
-EOF
 cat "$STACK_DIR/.env"
 log "Stack up (mode=isolated): $STACK_FRONTEND_URL -> $STACK_BACKEND_URL -> postgres :$POSTGRES_PORT"

--- a/scripts/dispatch/stack-up.sh
+++ b/scripts/dispatch/stack-up.sh
@@ -194,10 +194,9 @@ wait_for_url "$STACK_BACKEND_URL/health" 90
 # PSY-633: write .env BEFORE the frontend health check. If the wait times out
 # (set -e exits the script), stack-down.sh still reads STACK_MODE=isolated +
 # STACK_COMPOSE_PROJECT and runs `docker compose down -v` to reap postgres.
-# All values below are known at this point: ports were allocated upfront and
-# the backend just passed its health check. Frontend URL + port reflect the
-# port we already bound (or will attempt to bind) — they're stable even if
-# the dev server never reaches `wait_for_url`.
+# All values are stable at this point: ports were allocated upfront and the
+# backend just passed its health check — the frontend port is identifier
+# only, the dev server doesn't need to come up for stack-down to use it.
 cat > "$STACK_DIR/.env" <<EOF
 STACK_MODE=isolated
 STACK_WORKTREE_ID=$WORKTREE_ID


### PR DESCRIPTION
## Summary

- `scripts/dispatch/stack-up.sh` wrote `<worktree>/dispatch-stack/.env` only on the happy path — AFTER `wait_for_url` for the frontend returned. Under `set -e`, a frontend timeout (slow `bun run dev`, broken dev script, port race) exited the script before `.env` landed, and `stack-down.sh` (which gates docker compose teardown on `STACK_MODE=isolated` read from the missing `.env`) silently skipped the postgres reap.
- Fix: move the `.env` write to **before** the frontend health check in both shared and isolated modes. In isolated mode that's right after the backend passes `/health` — all values are stable: ports were allocated upfront, and the frontend port is an identifier the teardown can use even if the dev server never comes up.
- Caught by PSY-628's spike agent on May 11 (had to manually run `docker compose down` after stack-down silently no-op'd). Next in the dispatch-stack latent-bug series (PSY-625, PSY-626, PSY-629).

## Test plan

- [x] `bash -n scripts/dispatch/{stack-up,stack-down,stack-cleanup}.sh` — all clean
- [x] `cd backend && go build ./...` — clean (insurance; shell-script change)
- [x] `cd frontend && bun run typecheck` — clean (insurance)
- [x] **Happy path regression**: `stack-up.sh --mode=isolated` brought up postgres :53940 + backend :53941 + frontend :53942; `.env` present with all `STACK_*` vars; `curl -sI http://localhost:53942` returned 200; `curl /health` returned `"status":"healthy"`; `stack-down.sh` cleanly removed container + network + `dispatch-stack/`.
- [x] **Broken-frontend regression**: temporarily set `frontend/package.json` `dev` to `"exit 1"`; `stack-up.sh --mode=isolated` proceeded through postgres + migrate + backend, then timed out at frontend wait. `.env` IS present after the timeout (this is the fix). `stack-down.sh` then successfully ran `docker compose -p dispatch-agent-* down -v`, removed `dispatch-agent-*-db-1` + network, and cleared `dispatch-stack/`. Test-only `package.json` change reverted before commit.

## Manual repro

Full transcripts at `dogfood-output/PSY-633/repro.txt` + the four `.log` files (`stack-up-happy.log`, `stack-down-happy.log`, `stack-up-broken-frontend.log`, `stack-down-broken-frontend.log`).

Broken-frontend regression key moment:

```
[stack-up:agent-a4ad4aea93852fd33] Waiting for backend at http://localhost:54081/health...
[stack-up:agent-a4ad4aea93852fd33] Starting frontend on :54082...
[stack-up:agent-a4ad4aea93852fd33] Waiting for frontend at http://localhost:54082...
Timeout waiting for http://localhost:54082
```

After the timeout, `.env` was on disk with `STACK_MODE=isolated` + `STACK_COMPOSE_PROJECT=dispatch-agent-a4ad4aea93852fd33`, and `stack-down.sh` then reaped the orphan postgres + network cleanly.

## Simplify

`/simplify` ran; one cosmetic comment tightening only (drop a parenthetical hedge that confused the load-bearing claim about which values are stable at write time). Separate commit on the branch.

## Scope-adjacent observations (not fixed here)

Noticed during repro, filing separately per scope discipline:

- `stack-cleanup.sh` from inside a worktree silently no-ops: `REPO_ROOT` is computed as `SCRIPT_DIR/../..`, which from `<worktree>/scripts/dispatch` resolves to the **worktree** root, not the main repo. The script then scans `<worktree>/.claude/worktrees/` (which doesn't exist) and skips all PID/orphan-stack work. Likely the same root cause behind PSY-595's reported intermittent stack-cleanup false-positives. From the main repo invocation it works correctly. Separate ticket.
- Pre-existing `go run` orphan in stack-down: killing the `go run` parent PID leaves the `server` binary child running. Unrelated to `.env` ordering; needs a process-group fix at spawn (`setsid`) or teardown. Separate ticket.

Closes PSY-633