### PR TITLE
PSY-634: fix stack-cleanup.sh REPO_ROOT when invoked from worktree

### DIFF
--- a/scripts/dispatch/stack-cleanup.sh
+++ b/scripts/dispatch/stack-cleanup.sh
@@ -27,7 +27,17 @@ case "${1:-}" in
 esac
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+# Resolve to the MAIN repo root, even when this script lives inside a linked
+# worktree (e.g. .claude/worktrees/agent-XXX/scripts/dispatch). `git rev-parse
+# --git-common-dir` returns the main repo's `.git` from any linked worktree;
+# its parent is the main repo root. Falls back to SCRIPT_DIR/../.. if git is
+# unavailable or the script lives outside any repo.
+GIT_COMMON_DIR="$(git -C "$SCRIPT_DIR" rev-parse --git-common-dir 2>/dev/null || true)"
+if [ -n "$GIT_COMMON_DIR" ] && [ -d "$GIT_COMMON_DIR" ]; then
+  REPO_ROOT="$(cd "$GIT_COMMON_DIR/.." && pwd)"
+else
+  REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+fi
 
 log() { echo "[stack-cleanup] $*"; }
 DO() {


### PR DESCRIPTION
## Summary

- `scripts/dispatch/stack-cleanup.sh` computed `REPO_ROOT` as `SCRIPT_DIR/../..`. When the script lived inside a linked worktree (`.claude/worktrees/agent-XXX/scripts/dispatch/...`), that resolved to the worktree root, not the main repo. The script then scanned `<worktree>/.claude/worktrees/` (nonexistent) and silently no-op'd, leaving real orphan stacks in the main repo unreaped.
- Fix: derive `REPO_ROOT` from `git rev-parse --git-common-dir`, which returns the main repo's `.git` from any linked worktree. Parent of that is the main repo root. Fall back to the original `SCRIPT_DIR/../..` expression if git is unavailable.
- Only `stack-cleanup.sh` is affected — `stack-up.sh` / `stack-down.sh` take a worktree path argument explicitly and don't scan the whole worktrees dir.

## Test plan

- [x] `bash -n scripts/dispatch/stack-cleanup.sh` (syntax)
- [x] `cd backend && go build ./...` (cheap safety net)
- [x] `cd frontend && bun run typecheck` (cheap safety net)
- [x] Manual repro from worktree (see below)

## Manual repro

Invoked the script from inside an agent worktree (`.claude/worktrees/agent-a13debb37494149e7`) — both before and after the fix.

**Before fix** (buggy — scans the worktree, not the main repo):

```
[stack-cleanup] No worktrees directory at /Users/mtrifilo/dev/psychic-homily-web/.claude/worktrees/agent-a13debb37494149e7/.claude/worktrees; nothing more to clean.
```

**After fix** (correctly scans the main repo's `.claude/worktrees/`):

```
[stack-cleanup] Scanning compose projects starting with 'dispatch-'...
[stack-cleanup]   (no dispatch-* compose projects)
[stack-cleanup] Scanning /Users/mtrifilo/dev/psychic-homily-web/.claude/worktrees for orphaned stacks...
[stack-cleanup] Cleanup complete.
```

No `[dry-run] would run:` lines emitted because every existing `dispatch-stack/` dir is backed by a live worktree with no dead PID files — confirmed safe (no risk to the parallel session's worktrees during verification).

## Simplify

Ran `/simplify` review (reuse / quality / efficiency) on the 10-line change. No issues found — comment explains the WHY of the `git-common-dir` idiom, no duplication, no hot-path impact. `stack-down.sh` has the same `SCRIPT_DIR/../..` expression but is out of scope for this ticket (it takes a worktree path arg and doesn't scan the worktrees dir).

Closes PSY-634

🤖 Generated with [Claude Code](https://claude.com/claude-code)