### PR TITLE
PSY-635: reap port-bound survivors in stack-down

### DIFF
--- a/scripts/dispatch/stack-down.sh
+++ b/scripts/dispatch/stack-down.sh
@@ -23,24 +23,33 @@ if [ ! -d "$STACK_DIR" ]; then
   exit 0
 fi
 
-# Read mode from .env if available (best-effort).
+# Read mode + ports from .env if available (best-effort).
 STACK_MODE=""
+STACK_BACKEND_PORT=""
+STACK_FRONTEND_PORT=""
 if [ -f "$STACK_DIR/.env" ]; then
   STACK_MODE="$(grep '^STACK_MODE=' "$STACK_DIR/.env" 2>/dev/null | cut -d= -f2- || true)"
+  STACK_BACKEND_PORT="$(grep '^STACK_BACKEND_PORT=' "$STACK_DIR/.env" 2>/dev/null | cut -d= -f2- || true)"
+  STACK_FRONTEND_PORT="$(grep '^STACK_FRONTEND_PORT=' "$STACK_DIR/.env" 2>/dev/null | cut -d= -f2- || true)"
 fi
 log "Mode: ${STACK_MODE:-unknown}"
 
 # Kill native processes by PID file.
+#
+# PSY-635: the backend.pid points at `go run ./cmd/server`, which spawns a
+# compiled `server` child. Killing the parent leaves the child reparented to
+# init and still listening on the backend port. `nohup` does NOT make the
+# parent a session leader, so the historical `kill -- -PID` (negative PID to
+# signal the whole process group) misses the child. We do the PID kill first
+# (terminates the go-run wrapper so it can't respawn), then below sweep the
+# stack's allocated ports for any survivor — defensive against this exact
+# parent/child split, plus any equivalent shape from bun's frontend tree.
 for pidfile in "$STACK_DIR/backend.pid" "$STACK_DIR/frontend.pid"; do
   if [ -f "$pidfile" ]; then
     pid="$(cat "$pidfile" 2>/dev/null || true)"
     proc="$(basename "$pidfile" .pid)"
     if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
       log "Killing $proc (PID $pid)..."
-      # SIGTERM to the process group so go run / bun run children also exit.
-      # Negative PID = signal to process group leader's group (requires the
-      # process to have been a session leader, which `nohup` doesn't guarantee
-      # but is best-effort).
       kill -- -"$pid" 2>/dev/null || kill "$pid" 2>/dev/null || true
       sleep 1
       if kill -0 "$pid" 2>/dev/null; then
@@ -51,6 +60,28 @@ for pidfile in "$STACK_DIR/backend.pid" "$STACK_DIR/frontend.pid"; do
     rm -f "$pidfile"
   fi
 done
+
+# PSY-635: reap port-bound survivors (e.g. the `server` child of `go run`).
+# Ports were allocated free per-worktree, so anything still listening on
+# STACK_BACKEND_PORT / STACK_FRONTEND_PORT after the PID kill is ours.
+reap_port() {
+  local label="$1" port="$2"
+  [ -z "$port" ] && return 0
+  command -v lsof >/dev/null 2>&1 || { log "lsof not found; skipping port sweep for $label."; return 0; }
+  local survivors
+  survivors="$(lsof -ti tcp:"$port" 2>/dev/null || true)"
+  [ -z "$survivors" ] && return 0
+  log "Reaping $label survivors on :$port (PIDs: $(echo "$survivors" | tr '\n' ' '))..."
+  echo "$survivors" | xargs kill 2>/dev/null || true
+  sleep 1
+  survivors="$(lsof -ti tcp:"$port" 2>/dev/null || true)"
+  [ -z "$survivors" ] && return 0
+  log "  still alive on :$port, sending SIGKILL (PIDs: $(echo "$survivors" | tr '\n' ' '))"
+  echo "$survivors" | xargs kill -9 2>/dev/null || true
+}
+
+reap_port backend "$STACK_BACKEND_PORT"
+reap_port frontend "$STACK_FRONTEND_PORT"
 
 # Tear down docker compose project if isolated.
 if [ "$STACK_MODE" = "isolated" ]; then


### PR DESCRIPTION
## Summary

- `scripts/dispatch/stack-down.sh` killed only the recorded `go run ./cmd/server` wrapper PID; the compiled `server` child was reparented to init and kept holding the backend port. Result: every dispatch tear-down leaked an orphan `server`.
- `nohup` does not make the parent a session leader, so the historical `kill -- -PID` (negative PID = signal the process group) never actually reached the child.
- Fix: after the PID kill, sweep `STACK_BACKEND_PORT` / `STACK_FRONTEND_PORT` (read from `dispatch-stack/.env`) with `lsof -ti tcp:$port` and SIGTERM-then-SIGKILL any survivors. Free per-worktree ports are unambiguously ours.

## Test plan

- [x] `bash -n scripts/dispatch/stack-up.sh && bash -n scripts/dispatch/stack-down.sh`
- [x] `cd backend && go build ./...`
- [x] `cd frontend && bun run typecheck`

## Manual repro

Isolated-mode stack-up in this worktree (backend `:62600`, frontend `:62601`).

**Pre stack-down — the orphan-shape bug visible in real PIDs:**
```
--- backend.pid file (the recorded PID) ---
91224
--- ps -p 91224 ---
91224     1 go run ./cmd/server                            <-- this is what stack-down kills
--- lsof -ti tcp:62600 (who is actually listening) ---
91268
--- ps -p 91268 ---
91268 91224 .../go-build.../b001/exe/server                <-- PPID = 91224; killing parent strands this child
```

**Stack-down output (note the new port-sweep line):**
```
[stack-down:...] Killing backend (PID 91224)...
[stack-down:...] Killing frontend (PID 91271)...
[stack-down:...] Reaping backend survivors on :62600 (PIDs: 91268 )...
[stack-down:...] Tearing down docker compose project ...
[stack-down:...] Stack down.
```

**Post stack-down — zero orphans:**
```
--- lsof -ti tcp:62600 ---
(no listeners — clean)
--- lsof -ti tcp:62601 ---
(no listeners — clean)
--- ps -p 91268 ---
(91268 reaped)
--- ps -p 91224 ---
(91224 reaped)
--- docker compose ls ---
(no compose project — clean)
```

Full evidence at `dogfood-output/PSY-635/repro.txt` (worktree-local, not committed).

## Simplify

Ran `/simplify`. Reviewed for reuse (no existing helper in `scripts/`; `.env` grep idiom already established), quality (early-return guard clauses in `reap_port`, comments document non-obvious WHY of the parent/child split + free-port safety argument), efficiency (stack-down is not a hot path; two `lsof` calls per port are necessary signal for SIGTERM-vs-SIGKILL diagnostics). No fixes needed.

Closes PSY-635