### PR TITLE
PSY-638: add BracketLink + SectionHeader primitives

### DIFF
--- a/frontend/components/shared/BracketLink.test.tsx
+++ b/frontend/components/shared/BracketLink.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { BracketLink } from './BracketLink'
+
+describe('BracketLink', () => {
+  it('renders the label wrapped in literal brackets', () => {
+    render(<BracketLink label="Follow" />)
+    expect(screen.getByText('Follow')).toBeInTheDocument()
+    expect(screen.getByText('[')).toBeInTheDocument()
+    expect(screen.getByText(']')).toBeInTheDocument()
+  })
+
+  it('renders as a button when no href is provided', () => {
+    render(<BracketLink label="Follow" />)
+    const button = screen.getByRole('button', { name: 'Follow' })
+    expect(button).toBeInTheDocument()
+    expect(button).toHaveAttribute('type', 'button')
+  })
+
+  it('renders as a link when href is provided', () => {
+    render(<BracketLink label="View history" href="/artists/x/history" />)
+    const link = screen.getByRole('link', { name: 'View history' })
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', '/artists/x/history')
+  })
+
+  it('calls onClick when button is clicked', async () => {
+    const user = userEvent.setup()
+    const onClick = vi.fn()
+    render(<BracketLink label="Follow" onClick={onClick} />)
+    await user.click(screen.getByRole('button'))
+    expect(onClick).toHaveBeenCalledOnce()
+  })
+
+  it('marks itself aria-pressed when active', () => {
+    render(<BracketLink label="Following" active />)
+    expect(screen.getByRole('button')).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('does not set aria-pressed when inactive', () => {
+    render(<BracketLink label="Follow" />)
+    expect(screen.getByRole('button')).not.toHaveAttribute('aria-pressed')
+  })
+
+  it('applies danger styling for danger variant', () => {
+    render(<BracketLink label="X" variant="danger" onClick={vi.fn()} />)
+    const button = screen.getByRole('button')
+    expect(button.className).toContain('text-destructive')
+  })
+
+  it('is disabled when disabled prop is set', () => {
+    const onClick = vi.fn()
+    render(<BracketLink label="Follow" onClick={onClick} disabled />)
+    expect(screen.getByRole('button')).toBeDisabled()
+  })
+
+  it('does not fire onClick when disabled', async () => {
+    const user = userEvent.setup()
+    const onClick = vi.fn()
+    render(<BracketLink label="Follow" onClick={onClick} disabled />)
+    await user.click(screen.getByRole('button'))
+    expect(onClick).not.toHaveBeenCalled()
+  })
+
+  it('falls back to button when href is provided AND disabled', () => {
+    render(<BracketLink label="Follow" href="/somewhere" disabled />)
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+    expect(screen.getByRole('button')).toBeInTheDocument()
+  })
+
+  it('uses ariaLabel override when provided', () => {
+    render(<BracketLink label="X" ariaLabel="Remove tag" onClick={vi.fn()} />)
+    expect(screen.getByRole('button', { name: 'Remove tag' })).toBeInTheDocument()
+  })
+
+  it('passes title to underlying element', () => {
+    render(<BracketLink label="X" title="Remove" onClick={vi.fn()} />)
+    expect(screen.getByRole('button')).toHaveAttribute('title', 'Remove')
+  })
+
+  it('applies custom className', () => {
+    render(<BracketLink label="Follow" className="ml-4" />)
+    expect(screen.getByRole('button').className).toContain('ml-4')
+  })
+
+  it('marks brackets as aria-hidden so screen readers read only the label', () => {
+    render(<BracketLink label="Follow" />)
+    const openBracket = screen.getByText('[')
+    const closeBracket = screen.getByText(']')
+    expect(openBracket).toHaveAttribute('aria-hidden', 'true')
+    expect(closeBracket).toHaveAttribute('aria-hidden', 'true')
+  })
+})

--- a/frontend/components/shared/BracketLink.tsx
+++ b/frontend/components/shared/BracketLink.tsx
@@ -1,0 +1,103 @@
+'use client'
+
+import Link from 'next/link'
+import { cn } from '@/lib/utils'
+
+export interface BracketLinkProps {
+  /** Visible label, rendered inside literal [brackets]. e.g. label="Follow" -> "[Follow]" */
+  label: string
+  /** Navigation target. When provided, renders as <Link>; otherwise as <button type="button">. */
+  href?: string
+  /** Click handler (used when href is omitted). */
+  onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void
+  /** Active / toggled-on state. Emphasizes the link (e.g. [Following] after a successful follow). */
+  active?: boolean
+  /** Visual variant. `danger` is red for destructive actions like [Remove] / [Delete] / [X]. */
+  variant?: 'default' | 'danger'
+  /**
+   * Disabled state — un-clickable, dimmed.
+   *
+   * Note: when `href` is also set, a disabled BracketLink renders as a
+   * `<button disabled>` rather than an `<a>`. Anchors have no native disabled
+   * state, so the alternatives (`aria-disabled` + `tabIndex={-1}` + preventing
+   * default click) leak click-to-navigate to consumers that bypass keyboard /
+   * AT (right-click → open in new tab still navigates). The button swap is
+   * the simplest correct behavior.
+   */
+  disabled?: boolean
+  /** Tooltip (also exposed as title attribute). */
+  title?: string
+  /** ARIA label override (defaults to the visible label). */
+  ariaLabel?: string
+  /** Additional CSS classes. */
+  className?: string
+}
+
+/**
+ * Gazelle-style bracketed text link. Replaces icon-buttons in dense entity-page chrome:
+ * the brackets ARE the affordance, not a hover state. Renders as <Link> when `href` is
+ * provided, otherwise as <button type="button">.
+ *
+ * Usage:
+ *   <BracketLink label="Follow" onClick={handleFollow} />
+ *   <BracketLink label="Following" active onClick={handleUnfollow} />
+ *   <BracketLink label="View history" href={`/artists/${slug}/history`} />
+ *   <BracketLink label="X" variant="danger" onClick={handleRemove} title="Remove" />
+ */
+export function BracketLink({
+  label,
+  href,
+  onClick,
+  active = false,
+  variant = 'default',
+  disabled = false,
+  title,
+  ariaLabel,
+  className,
+}: BracketLinkProps) {
+  const classes = cn(
+    'inline-flex items-baseline whitespace-nowrap text-sm tabular-nums',
+    'transition-colors',
+    variant === 'default' && !active && 'text-muted-foreground hover:text-foreground',
+    variant === 'default' && active && 'text-foreground font-medium',
+    variant === 'danger' && 'text-destructive hover:text-destructive/80',
+    disabled && 'opacity-50 cursor-not-allowed pointer-events-none',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 rounded-sm',
+    className
+  )
+
+  const content = (
+    <>
+      <span aria-hidden="true">[</span>
+      <span>{label}</span>
+      <span aria-hidden="true">]</span>
+    </>
+  )
+
+  if (href && !disabled) {
+    return (
+      <Link
+        href={href}
+        className={classes}
+        title={title}
+        aria-label={ariaLabel ?? label}
+      >
+        {content}
+      </Link>
+    )
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={classes}
+      title={title}
+      aria-label={ariaLabel ?? label}
+      aria-pressed={active || undefined}
+    >
+      {content}
+    </button>
+  )
+}

--- a/frontend/components/shared/SectionHeader.test.tsx
+++ b/frontend/components/shared/SectionHeader.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { SectionHeader } from './SectionHeader'
+import { BracketLink } from './BracketLink'
+
+describe('SectionHeader', () => {
+  it('renders the title', () => {
+    render(<SectionHeader title="Statistics" />)
+    expect(screen.getByText('Statistics')).toBeInTheDocument()
+  })
+
+  it('renders as an h3 by default', () => {
+    render(<SectionHeader title="Tags" />)
+    expect(screen.getByRole('heading', { level: 3, name: 'Tags' })).toBeInTheDocument()
+  })
+
+  it('honors the `as` prop for heading level', () => {
+    render(<SectionHeader title="Tags" as="h2" />)
+    expect(screen.getByRole('heading', { level: 2, name: 'Tags' })).toBeInTheDocument()
+  })
+
+  it('renders an action when provided', () => {
+    render(
+      <SectionHeader
+        title="Past shows"
+        action={<BracketLink label="Toggle" onClick={vi.fn()} />}
+      />
+    )
+    expect(screen.getByRole('button', { name: 'Toggle' })).toBeInTheDocument()
+  })
+
+  it('does not render an action slot when action is omitted', () => {
+    render(<SectionHeader title="Statistics" />)
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
+  it('action click fires parent handler (parent owns state)', async () => {
+    const user = userEvent.setup()
+    const onToggle = vi.fn()
+    render(
+      <SectionHeader
+        title="Past shows"
+        action={<BracketLink label="Toggle" onClick={onToggle} />}
+      />
+    )
+    await user.click(screen.getByRole('button', { name: 'Toggle' }))
+    expect(onToggle).toHaveBeenCalledOnce()
+  })
+
+  it('toggles the underline divider based on underline prop', () => {
+    const { container, rerender } = render(<SectionHeader title="Tags" />)
+    const wrapper = container.firstChild as HTMLElement
+    expect(wrapper.className).toContain('border-b')
+
+    rerender(<SectionHeader title="Tags" underline={false} />)
+    expect(wrapper.className).not.toContain('border-b')
+  })
+
+  it('forwards custom className onto the wrapping element', () => {
+    const { container } = render(<SectionHeader title="Tags" className="mt-8" />)
+    const wrapper = container.firstChild as HTMLElement
+    expect(wrapper.className).toContain('mt-8')
+  })
+})

--- a/frontend/components/shared/SectionHeader.tsx
+++ b/frontend/components/shared/SectionHeader.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import { cn } from '@/lib/utils'
+
+export interface SectionHeaderProps {
+  /** Section title (rendered in uppercase tracking-wider style). */
+  title: string
+  /** Optional inline action node, rendered to the right of the title. Typically a <BracketLink>. */
+  action?: React.ReactNode
+  /** Heading level for the rendered element. Defaults to 'h3'. */
+  as?: 'h2' | 'h3' | 'h4'
+  /** Visual size: 'sm' for sidebar (11–12px), 'md' for main column (13–14px). Defaults to 'sm'. */
+  size?: 'sm' | 'md'
+  /** Render a thin underline divider beneath the header. Defaults to true. */
+  underline?: boolean
+  /** Additional CSS classes on the wrapping div. */
+  className?: string
+}
+
+/**
+ * Tight section header for density-first surfaces. One-line bar with a title and an
+ * optional inline action (commonly a <BracketLink> like [Toggle] or [Add tag]).
+ *
+ * State (collapsed / expanded) is owned by the parent — this primitive is presentational
+ * only. The parent decides whether to render the section body based on its own state.
+ *
+ * Usage:
+ *   <SectionHeader title="Statistics" />
+ *
+ *   <SectionHeader
+ *     title="Past shows"
+ *     action={<BracketLink label={collapsed ? 'Show' : 'Hide'} onClick={() => setCollapsed(c => !c)} />}
+ *   />
+ *
+ *   <SectionHeader title="Tags" action={<BracketLink label="Add tag" onClick={openTagForm} />} />
+ */
+export function SectionHeader({
+  title,
+  action,
+  as: Tag = 'h3',
+  size = 'sm',
+  underline = true,
+  className,
+}: SectionHeaderProps) {
+  return (
+    <div
+      className={cn(
+        'flex items-baseline justify-between gap-2',
+        underline && 'border-b border-border/50 pb-1 mb-2',
+        className
+      )}
+    >
+      <Tag
+        className={cn(
+          'font-semibold text-muted-foreground uppercase tracking-wider',
+          size === 'sm' && 'text-xs',
+          size === 'md' && 'text-sm'
+        )}
+      >
+        {title}
+      </Tag>
+      {action && <div className="shrink-0 text-xs">{action}</div>}
+    </div>
+  )
+}

--- a/frontend/components/shared/index.ts
+++ b/frontend/components/shared/index.ts
@@ -28,3 +28,7 @@ export type {
 } from './EntityCardTitle'
 export { StatusBanner } from './StatusBanner'
 export type { StatusBannerProps, StatusBannerVariant } from './StatusBanner'
+export { BracketLink } from './BracketLink'
+export type { BracketLinkProps } from './BracketLink'
+export { SectionHeader } from './SectionHeader'
+export type { SectionHeaderProps } from './SectionHeader'


### PR DESCRIPTION
## Summary
- Add `BracketLink` — bracketed text link primitive ([Follow], [Toggle], [X]) for density-first entity-page chrome; replaces icon-button density. Renders `<Link>` with `href`, `<button>` without. Brackets are `aria-hidden`; toggleable buttons get `aria-pressed`.
- Add `SectionHeader` — tight section-title bar with optional inline action slot (typically a `BracketLink`). Presentational; collapse state is parent-owned.
- Primitives ship unused; adoption sweep happens in PSY-641 (ArtistDetail refactor) and downstream entity pages.

First ticket in the new "Artist Page Density Redesign — May 2026" project. Spec: `docs/features/artist-page-redesign.md`. Research: `docs/research/artist-page-prior-art.md`.

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun run test:run components/shared/BracketLink components/shared/SectionHeader` — 22 tests pass
- [x] `/simplify` review run; quality findings applied (added JSDoc on `disabled+href` element-swap; trimmed brittle styling-class assertions to behavioral tests)
- [ ] No visual regression — primitives are not yet wired into any page

Closes PSY-638

🤖 Generated with [Claude Code](https://claude.com/claude-code)