### PR TITLE
PSY-640: add DenseTable primitive

### DIFF
--- a/frontend/components/shared/DenseTable.test.tsx
+++ b/frontend/components/shared/DenseTable.test.tsx
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { DenseTable, DenseTableGroupHeader } from './DenseTable'
+
+describe('DenseTable', () => {
+  it('renders a table with the given rows', () => {
+    render(
+      <DenseTable>
+        <thead>
+          <tr>
+            <th>Title</th>
+            <th>Year</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Heart Under</td>
+            <td>2022</td>
+          </tr>
+        </tbody>
+      </DenseTable>
+    )
+    expect(screen.getByRole('table')).toBeInTheDocument()
+    expect(screen.getByText('Heart Under')).toBeInTheDocument()
+    expect(screen.getByText('2022')).toBeInTheDocument()
+  })
+
+  it('renders thead column headers as <th> cells', () => {
+    render(
+      <DenseTable>
+        <thead>
+          <tr>
+            <th>Title</th>
+            <th>Year</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>x</td>
+            <td>x</td>
+          </tr>
+        </tbody>
+      </DenseTable>
+    )
+    expect(screen.getByRole('columnheader', { name: 'Title' })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: 'Year' })).toBeInTheDocument()
+  })
+
+  it('forwards custom className', () => {
+    const { container } = render(
+      <DenseTable className="mt-4">
+        <tbody>
+          <tr>
+            <td>x</td>
+          </tr>
+        </tbody>
+      </DenseTable>
+    )
+    const table = container.querySelector('table')
+    expect(table?.className).toContain('mt-4')
+  })
+
+  it('forwards arbitrary table HTML attributes (e.g. aria-label)', () => {
+    render(
+      <DenseTable aria-label="Discography">
+        <tbody>
+          <tr>
+            <td>x</td>
+          </tr>
+        </tbody>
+      </DenseTable>
+    )
+    expect(screen.getByRole('table', { name: 'Discography' })).toBeInTheDocument()
+  })
+})
+
+describe('DenseTableGroupHeader', () => {
+  it('renders the title inside the table body', () => {
+    render(
+      <DenseTable>
+        <tbody>
+          <DenseTableGroupHeader title="Albums & EPs" colSpan={3} />
+          <tr>
+            <td colSpan={3}>row</td>
+          </tr>
+        </tbody>
+      </DenseTable>
+    )
+    expect(screen.getByText('Albums & EPs')).toBeInTheDocument()
+  })
+
+  it('renders as a <th scope="rowgroup"> for accessibility', () => {
+    render(
+      <DenseTable>
+        <tbody>
+          <DenseTableGroupHeader title="Singles" colSpan={3} />
+          <tr>
+            <td colSpan={3}>row</td>
+          </tr>
+        </tbody>
+      </DenseTable>
+    )
+    const th = screen.getByText('Singles').closest('th')
+    expect(th).toHaveAttribute('scope', 'rowgroup')
+  })
+
+  it('spans the given number of columns', () => {
+    render(
+      <DenseTable>
+        <tbody>
+          <DenseTableGroupHeader title="Singles" colSpan={4} />
+          <tr>
+            <td colSpan={4}>row</td>
+          </tr>
+        </tbody>
+      </DenseTable>
+    )
+    const th = screen.getByText('Singles').closest('th')
+    expect(th).toHaveAttribute('colspan', '4')
+  })
+
+  it('forwards custom className onto the wrapping tr', () => {
+    render(
+      <DenseTable>
+        <tbody>
+          <DenseTableGroupHeader
+            title="Production"
+            colSpan={2}
+            className="custom-row-cls"
+          />
+          <tr>
+            <td colSpan={2}>row</td>
+          </tr>
+        </tbody>
+      </DenseTable>
+    )
+    const tr = screen.getByText('Production').closest('tr')
+    expect(tr?.className).toContain('custom-row-cls')
+  })
+})

--- a/frontend/components/shared/DenseTable.tsx
+++ b/frontend/components/shared/DenseTable.tsx
@@ -1,0 +1,109 @@
+'use client'
+
+import type { TableHTMLAttributes, ReactNode } from 'react'
+import { cn } from '@/lib/utils'
+
+export type DenseTableVariant = 'standard' | 'alternating' | 'bare'
+
+const VARIANT_CLASSES: Record<DenseTableVariant, string> = {
+  standard:
+    '[&_thead_th]:border-b [&_thead_th]:border-border [&_tbody_tr]:border-b [&_tbody_tr]:border-border/40 [&_tbody_tr:last-child]:border-b-0',
+  alternating:
+    '[&_thead_th]:border-b [&_thead_th]:border-border [&_tbody_tr:nth-child(odd)]:bg-muted/20 [&_tbody_tr]:border-b [&_tbody_tr]:border-border/30 [&_tbody_tr:last-child]:border-b-0',
+  bare: '[&_tbody_tr]:border-b [&_tbody_tr]:border-border/20 [&_tbody_tr:last-child]:border-b-0',
+}
+
+export interface DenseTableProps extends TableHTMLAttributes<HTMLTableElement> {
+  /**
+   * Visual variant:
+   * - `standard` (default) — header chrome + per-row bottom border.
+   * - `alternating` — header chrome + Gazelle-style striped rows
+   *   (`bg-muted/20` on odd rows).
+   * - `bare` — minimal chrome; row dividers only, no header background.
+   *   Use when the surrounding `<SectionHeader>` already establishes context.
+   */
+  variant?: DenseTableVariant
+  /** Table children: `<thead>` / `<tbody>` / `<tr>` / `<td>` / `<th>`. */
+  children?: ReactNode
+}
+
+/**
+ * Density-first table primitive for entity-page lists (shows, discography,
+ * similar artists, etc.). Tight typography (13–14px body, ~1.25 line-height),
+ * `tabular-nums` baked in for numeric alignment, minimal padding (`py-1.5
+ * px-2`). Built on native `<table>` — no shadcn Table wrapper in this project.
+ *
+ * Pair with `<SectionHeader>` for the section title and `<DenseTableGroupHeader>`
+ * for grouped tables (e.g. Discography by release type).
+ *
+ * Usage:
+ *   <DenseTable variant="alternating">
+ *     <thead>
+ *       <tr>
+ *         <th>Title</th>
+ *         <th className="text-right">Year</th>
+ *       </tr>
+ *     </thead>
+ *     <tbody>
+ *       <DenseTableGroupHeader title="Albums & EPs" colSpan={2} />
+ *       <tr>
+ *         <td>Heart Under</td>
+ *         <td className="text-right">2022</td>
+ *       </tr>
+ *     </tbody>
+ *   </DenseTable>
+ */
+export function DenseTable({
+  variant = 'standard',
+  className,
+  children,
+  ...rest
+}: DenseTableProps) {
+  return (
+    <table
+      className={cn(
+        'w-full text-sm leading-tight tabular-nums',
+        '[&_td]:py-1.5 [&_td]:px-2 [&_td]:align-baseline',
+        '[&_th]:py-1.5 [&_th]:px-2 [&_th]:align-baseline [&_th]:text-left',
+        '[&_thead_th]:text-xs [&_thead_th]:font-semibold [&_thead_th]:uppercase [&_thead_th]:tracking-wider [&_thead_th]:text-muted-foreground',
+        VARIANT_CLASSES[variant],
+        className
+      )}
+      {...rest}
+    >
+      {children}
+    </table>
+  )
+}
+
+export interface DenseTableGroupHeaderProps {
+  /** Group title (rendered uppercase tracking-wider). */
+  title: string
+  /** Number of columns the header should span. Must match the table's column count. */
+  colSpan: number
+  /** Additional CSS classes on the wrapping `<tr>`. */
+  className?: string
+}
+
+/**
+ * Group-header row for use inside a `<DenseTable>`'s `<tbody>`. Renders a
+ * single full-width `<th scope="rowgroup">` to group rows by category
+ * (Albums & EPs / Singles / etc.) without breaking `<table>` semantics.
+ */
+export function DenseTableGroupHeader({
+  title,
+  colSpan,
+  className,
+}: DenseTableGroupHeaderProps) {
+  return (
+    <tr className={cn('bg-muted/40', className)}>
+      <th
+        scope="rowgroup"
+        colSpan={colSpan}
+        className="text-xs font-semibold uppercase tracking-wider text-muted-foreground"
+      >
+        {title}
+      </th>
+    </tr>
+  )
+}

--- a/frontend/components/shared/index.ts
+++ b/frontend/components/shared/index.ts
@@ -32,3 +32,9 @@ export { BracketLink } from './BracketLink'
 export type { BracketLinkProps } from './BracketLink'
 export { SectionHeader } from './SectionHeader'
 export type { SectionHeaderProps } from './SectionHeader'
+export { DenseTable, DenseTableGroupHeader } from './DenseTable'
+export type {
+  DenseTableProps,
+  DenseTableVariant,
+  DenseTableGroupHeaderProps,
+} from './DenseTable'


### PR DESCRIPTION
## Summary
- Add `DenseTable` — density-first table primitive built on native `<table>` (no shadcn Table in this project). Variants: `standard`, `alternating` (Gazelle-style striped), `bare`. Tight typography (13–14px, ~1.25 leading), `tabular-nums`, minimal padding. Variant classes hoisted to a module-level map for readability.
- Add `DenseTableGroupHeader` — full-width `<th scope="rowgroup">` for grouped tables (Albums & EPs / Singles / etc.). Proper a11y semantics.
- Primitives ship unused; adoption in PSY-641. Three future-sweep candidates noted in commit body.

Spec: `docs/features/artist-page-redesign.md`. Second primitive in the Artist Page Density Redesign project; first (`BracketLink` + `SectionHeader`) merged as #630.

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun run test:run components/shared/DenseTable` — 8 tests pass
- [x] `/simplify` review run; 4 quality findings applied (variant class extraction to const map; `<th scope="rowgroup">` for group header to drop the `!py-1` override; type-only React imports; brittle Tailwind-class assertions dropped from tests)
- [ ] No visual regression — primitive is not yet wired into any page

Closes PSY-640

🤖 Generated with [Claude Code](https://claude.com/claude-code)