### PR TITLE
PSY-639: StatsList primitive + fold stats into artist response

### DIFF
--- a/backend/internal/services/catalog/artist.go
+++ b/backend/internal/services/catalog/artist.go
@@ -2,6 +2,7 @@ package catalog
 
 import (
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -94,7 +95,9 @@ func (s *ArtistService) GetArtist(artistID uint) (*contracts.ArtistDetailRespons
 		return nil, fmt.Errorf("failed to get artist: %w", err)
 	}
 
-	return s.buildArtistResponse(&artist), nil
+	resp := s.buildArtistResponse(&artist)
+	resp.Stats = s.buildArtistStats(artist.ID)
+	return resp, nil
 }
 
 // GetArtistByName retrieves an artist by name (case-insensitive)
@@ -130,7 +133,9 @@ func (s *ArtistService) GetArtistBySlug(slug string) (*contracts.ArtistDetailRes
 		return nil, fmt.Errorf("failed to get artist: %w", err)
 	}
 
-	return s.buildArtistResponse(&artist), nil
+	resp := s.buildArtistResponse(&artist)
+	resp.Stats = s.buildArtistStats(artist.ID)
+	return resp, nil
 }
 
 // GetArtists retrieves artists with optional filtering
@@ -474,6 +479,48 @@ func (s *ArtistService) GetArtistCities() ([]*contracts.ArtistCityResponse, erro
 	}
 
 	return responses, nil
+}
+
+// buildArtistStats populates the at-a-glance stats block on the artist
+// detail page (PSY-639) in a single round-trip — five scalar subqueries,
+// each hitting an indexed artist_id FK. Stats are sidebar polish: on query
+// failure we log and return zeroed counts rather than failing the whole
+// artist response.
+//
+// Subquery notes:
+//   - releases: DISTINCT release_id — the (artist_id, release_id, role) PK
+//     lets one artist have multiple rows per release (composer + performer).
+//   - shows_tracked: plain COUNT — (show_id, artist_id) PK is one row per
+//     show; includes past + future.
+//   - similar_artists: artist_relationships has a CHECK source_artist_id <
+//     target_artist_id, so this artist is the source in some rows and the
+//     target in others; DISTINCT on the *other* side collapses multiple
+//     relationship_type rows between the same pair.
+//   - festival_appearances: plain COUNT — festival_artists has a UNIQUE
+//     (festival_id, artist_id) constraint, so COUNT(*) == COUNT(DISTINCT).
+func (s *ArtistService) buildArtistStats(artistID uint) *contracts.ArtistStatsResponse {
+	stats := &contracts.ArtistStatsResponse{}
+	if s.db == nil {
+		return stats
+	}
+
+	err := s.db.Raw(`
+		SELECT
+			(SELECT COUNT(DISTINCT release_id) FROM artist_releases WHERE artist_id = @id) AS releases,
+			(SELECT COUNT(*) FROM artist_labels WHERE artist_id = @id) AS labels,
+			(SELECT COUNT(*) FROM show_artists WHERE artist_id = @id) AS shows_tracked,
+			(SELECT COUNT(DISTINCT CASE
+				WHEN source_artist_id = @id THEN target_artist_id
+				ELSE source_artist_id
+			END) FROM artist_relationships
+			WHERE source_artist_id = @id OR target_artist_id = @id) AS similar_artists,
+			(SELECT COUNT(*) FROM festival_artists WHERE artist_id = @id) AS festival_appearances
+	`, map[string]interface{}{"id": artistID}).Scan(stats).Error
+	if err != nil {
+		log.Printf("WARN buildArtistStats: failed to count stats for artist_id=%d: %v", artistID, err)
+	}
+
+	return stats
 }
 
 // buildArtistResponse converts an Artist model to contracts.ArtistDetailResponse

--- a/backend/internal/services/catalog/artist_test.go
+++ b/backend/internal/services/catalog/artist_test.go
@@ -1355,3 +1355,112 @@ func (suite *ArtistServiceIntegrationTestSuite) TestMergeArtists_NotificationFil
 	suite.Contains(artistIDs, fmt.Sprintf("%d", canonical.ID))
 	suite.NotContains(artistIDs, fmt.Sprintf("%d", mergeFrom.ID))
 }
+
+// =============================================================================
+// PSY-639: GetArtist with stats
+// =============================================================================
+
+func (suite *ArtistServiceIntegrationTestSuite) TestGetArtist_Stats_SparseArtist() {
+	artist, err := suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "Sparse Stats Artist"})
+	suite.Require().NoError(err)
+
+	resp, err := suite.artistService.GetArtist(artist.ID)
+
+	suite.Require().NoError(err)
+	suite.Require().NotNil(resp.Stats, "Stats must be populated on GetArtist responses")
+	suite.Equal(0, resp.Stats.Releases)
+	suite.Equal(0, resp.Stats.Labels)
+	suite.Equal(0, resp.Stats.ShowsTracked)
+	suite.Equal(0, resp.Stats.SimilarArtists)
+	suite.Equal(0, resp.Stats.FestivalAppearances)
+}
+
+func (suite *ArtistServiceIntegrationTestSuite) TestGetArtist_Stats_Populated() {
+	artist, err := suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "Populated Stats Artist"})
+	suite.Require().NoError(err)
+	user := suite.createTestUser()
+	venue := suite.createTestVenue("Stats Venue", "Phoenix", "AZ")
+
+	// 1 release, 2 roles on it (main + producer) — DISTINCT release_id => 1.
+	release := &catalogm.Release{Title: "Stats LP", ReleaseType: catalogm.ReleaseTypeLP}
+	suite.Require().NoError(suite.db.Create(release).Error)
+	suite.Require().NoError(suite.db.Create(&catalogm.ArtistRelease{ArtistID: artist.ID, ReleaseID: release.ID, Role: catalogm.ArtistReleaseRoleMain}).Error)
+	suite.Require().NoError(suite.db.Create(&catalogm.ArtistRelease{ArtistID: artist.ID, ReleaseID: release.ID, Role: catalogm.ArtistReleaseRoleProducer}).Error)
+
+	// 2 labels
+	labelA := &catalogm.Label{Name: "Label Alpha"}
+	labelB := &catalogm.Label{Name: "Label Beta"}
+	suite.Require().NoError(suite.db.Create(labelA).Error)
+	suite.Require().NoError(suite.db.Create(labelB).Error)
+	suite.Require().NoError(suite.db.Create(&catalogm.ArtistLabel{ArtistID: artist.ID, LabelID: labelA.ID}).Error)
+	suite.Require().NoError(suite.db.Create(&catalogm.ArtistLabel{ArtistID: artist.ID, LabelID: labelB.ID}).Error)
+
+	// 2 shows (past + future, both counted)
+	suite.createApprovedShowWithArtist(artist.ID, venue.ID, user.ID, time.Now().AddDate(0, -1, 0))
+	suite.createApprovedShowWithArtist(artist.ID, venue.ID, user.ID, time.Now().AddDate(0, 1, 0))
+
+	// Similar artists: this artist is both source (vs higher ID) and target
+	// (vs lower ID) due to the source<target CHECK constraint. 3 distinct
+	// related artists, one of them via TWO relationship_types (verify DISTINCT).
+	other1, _ := suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "Similar Alpha"})
+	other2, _ := suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "Similar Beta"})
+	other3, _ := suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "Similar Gamma"})
+	sourceID := func(a, b uint) uint {
+		if a < b {
+			return a
+		}
+		return b
+	}
+	targetID := func(a, b uint) uint {
+		if a < b {
+			return b
+		}
+		return a
+	}
+	for _, other := range []uint{other1.ID, other2.ID, other3.ID} {
+		suite.Require().NoError(suite.db.Create(&catalogm.ArtistRelationship{
+			SourceArtistID:   sourceID(artist.ID, other),
+			TargetArtistID:   targetID(artist.ID, other),
+			RelationshipType: "similar",
+		}).Error)
+	}
+	// Duplicate other1 with a second relationship_type — should NOT double-count.
+	suite.Require().NoError(suite.db.Create(&catalogm.ArtistRelationship{
+		SourceArtistID:   sourceID(artist.ID, other1.ID),
+		TargetArtistID:   targetID(artist.ID, other1.ID),
+		RelationshipType: "influence",
+	}).Error)
+
+	// 2 festivals (festival_artists has a UNIQUE (festival_id, artist_id)
+	// constraint — an artist can't appear twice on the same festival).
+	festivalA := &catalogm.Festival{Name: "Stats Fest A", Slug: "stats-fest-a-2026", SeriesSlug: "stats-fest-a", EditionYear: 2026, StartDate: "2026-06-01", EndDate: "2026-06-02"}
+	festivalB := &catalogm.Festival{Name: "Stats Fest B", Slug: "stats-fest-b-2026", SeriesSlug: "stats-fest-b", EditionYear: 2026, StartDate: "2026-07-01", EndDate: "2026-07-02"}
+	suite.Require().NoError(suite.db.Create(festivalA).Error)
+	suite.Require().NoError(suite.db.Create(festivalB).Error)
+	suite.Require().NoError(suite.db.Create(&catalogm.FestivalArtist{FestivalID: festivalA.ID, ArtistID: artist.ID}).Error)
+	suite.Require().NoError(suite.db.Create(&catalogm.FestivalArtist{FestivalID: festivalB.ID, ArtistID: artist.ID}).Error)
+
+	resp, err := suite.artistService.GetArtist(artist.ID)
+
+	suite.Require().NoError(err)
+	suite.Require().NotNil(resp.Stats)
+	suite.Equal(1, resp.Stats.Releases, "DISTINCT release_id should collapse multi-role rows")
+	suite.Equal(2, resp.Stats.Labels)
+	suite.Equal(2, resp.Stats.ShowsTracked, "ShowsTracked counts past + future")
+	suite.Equal(3, resp.Stats.SimilarArtists, "DISTINCT related-artist count should collapse multi-relationship-type duplicates")
+	suite.Equal(2, resp.Stats.FestivalAppearances)
+}
+
+func (suite *ArtistServiceIntegrationTestSuite) TestGetArtistBySlug_PopulatesStats() {
+	artist, err := suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "Slug Stats Artist"})
+	suite.Require().NoError(err)
+	user := suite.createTestUser()
+	venue := suite.createTestVenue("Slug Stats Venue", "Phoenix", "AZ")
+	suite.createApprovedShowWithArtist(artist.ID, venue.ID, user.ID, time.Now().AddDate(0, 1, 0))
+
+	resp, err := suite.artistService.GetArtistBySlug(artist.Slug)
+
+	suite.Require().NoError(err)
+	suite.Require().NotNil(resp.Stats, "Stats must be populated on GetArtistBySlug responses too")
+	suite.Equal(1, resp.Stats.ShowsTracked)
+}

--- a/backend/internal/services/contracts/catalog.go
+++ b/backend/internal/services/contracts/catalog.go
@@ -418,18 +418,33 @@ type CreateArtistRequest struct {
 
 // ArtistDetailResponse represents the artist data returned to clients
 type ArtistDetailResponse struct {
-	ID               uint           `json:"id"`
-	Slug             string         `json:"slug"`
-	Name             string         `json:"name"`
-	State            *string        `json:"state"`
-	City             *string        `json:"city"`
-	Country          *string        `json:"country,omitempty"` // PSY-558: optional country (Australia, UK, etc.)
-	BandcampEmbedURL *string        `json:"bandcamp_embed_url"`
-	Description      *string        `json:"description,omitempty"`
-	ImageURL         *string        `json:"image_url"` // Optional artist photo (PSY-521)
-	Social           SocialResponse `json:"social"`
-	CreatedAt        time.Time      `json:"created_at"`
-	UpdatedAt        time.Time      `json:"updated_at"`
+	ID               uint                 `json:"id"`
+	Slug             string               `json:"slug"`
+	Name             string               `json:"name"`
+	State            *string              `json:"state"`
+	City             *string              `json:"city"`
+	Country          *string              `json:"country,omitempty"` // PSY-558: optional country (Australia, UK, etc.)
+	BandcampEmbedURL *string              `json:"bandcamp_embed_url"`
+	Description      *string              `json:"description,omitempty"`
+	ImageURL         *string              `json:"image_url"` // Optional artist photo (PSY-521)
+	Social           SocialResponse       `json:"social"`
+	CreatedAt        time.Time            `json:"created_at"`
+	UpdatedAt        time.Time            `json:"updated_at"`
+	// Stats is populated only by detail-page lookups (GetArtist /
+	// GetArtistBySlug — PSY-639). List, search, and mutation responses leave
+	// it nil so the omitempty tag drops it from the wire.
+	Stats *ArtistStatsResponse `json:"stats,omitempty"`
+}
+
+// ArtistStatsResponse carries the at-a-glance counts surfaced on the artist
+// detail page sidebar (PSY-639). Folded into ArtistDetailResponse on the
+// detail-page lookups; nil on list / search / mutation responses.
+type ArtistStatsResponse struct {
+	Releases            int `json:"releases"`
+	Labels              int `json:"labels"`
+	ShowsTracked        int `json:"shows_tracked"` // past + future
+	SimilarArtists      int `json:"similar_artists"`
+	FestivalAppearances int `json:"festival_appearances"`
 }
 
 // SocialResponse represents social media links

--- a/frontend/components/shared/StatsList.test.tsx
+++ b/frontend/components/shared/StatsList.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { StatsList } from './StatsList'
+
+describe('StatsList', () => {
+  const items = [
+    { label: 'Releases', value: 4 },
+    { label: 'Labels', value: 2 },
+    { label: 'Shows tracked', value: 13 },
+  ]
+
+  it('renders nothing when items is empty', () => {
+    const { container } = render(<StatsList items={[]} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders each label and value in the sidebar variant', () => {
+    render(<StatsList items={items} />)
+    expect(screen.getByText('Releases')).toBeInTheDocument()
+    expect(screen.getByText('4')).toBeInTheDocument()
+    expect(screen.getByText('Labels')).toBeInTheDocument()
+    expect(screen.getByText('2')).toBeInTheDocument()
+    expect(screen.getByText('Shows tracked')).toBeInTheDocument()
+    expect(screen.getByText('13')).toBeInTheDocument()
+  })
+
+  it('renders as a <dl> in sidebar variant', () => {
+    const { container } = render(<StatsList items={items} />)
+    expect(container.querySelector('dl')).toBeInTheDocument()
+    expect(container.querySelectorAll('dt')).toHaveLength(3)
+    expect(container.querySelectorAll('dd')).toHaveLength(3)
+  })
+
+  it('formats numeric values with thousands separators', () => {
+    render(<StatsList items={[{ label: 'Releases', value: 1234 }]} />)
+    expect(screen.getByText('1,234')).toBeInTheDocument()
+  })
+
+  it('renders string values as-is (no number formatting)', () => {
+    render(<StatsList items={[{ label: 'Status', value: 'Active' }]} />)
+    expect(screen.getByText('Active')).toBeInTheDocument()
+  })
+
+  it('renders ReactNode values as-is (e.g. links)', () => {
+    render(
+      <StatsList
+        items={[
+          {
+            label: 'Last show',
+            value: <a href="/shows/x">May 17 at Valley Bar</a>,
+          },
+        ]}
+      />
+    )
+    expect(
+      screen.getByRole('link', { name: 'May 17 at Valley Bar' })
+    ).toBeInTheDocument()
+  })
+
+  it('renders inline variant as a single paragraph with middots', () => {
+    const { container } = render(<StatsList items={items} variant="inline" />)
+    expect(container.querySelector('p')).toBeInTheDocument()
+    expect(container.querySelector('dl')).not.toBeInTheDocument()
+    // 3 items => 2 middot separators
+    const middots = container.querySelectorAll('span[aria-hidden="true"]')
+    expect(middots).toHaveLength(2)
+  })
+
+  it('inline variant lowercases labels for natural prose reading', () => {
+    render(<StatsList items={items} variant="inline" />)
+    expect(screen.getByText('releases')).toBeInTheDocument()
+    expect(screen.getByText('shows tracked')).toBeInTheDocument()
+  })
+
+  it('forwards custom className', () => {
+    const { container } = render(
+      <StatsList items={items} className="mt-4" />
+    )
+    expect((container.firstChild as HTMLElement).className).toContain('mt-4')
+  })
+})

--- a/frontend/components/shared/StatsList.tsx
+++ b/frontend/components/shared/StatsList.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import { cn } from '@/lib/utils'
+
+export interface StatsListItem {
+  /** Stat label, shown verbatim (e.g. "Releases"). */
+  label: string
+  /**
+   * Stat value. Numbers are formatted with thousands separators; strings and
+   * nodes render as-is so callers can pass formatted values, links, or icons.
+   */
+  value: number | string | ReactNode
+}
+
+export type StatsListVariant = 'sidebar' | 'inline'
+
+export interface StatsListProps {
+  /** Stat rows in display order. Empty arrays render nothing. */
+  items: StatsListItem[]
+  /**
+   * Layout variant:
+   * - `sidebar` (default) — vertical `<dl>` stacked rows ("Releases  4").
+   *   Tight typography for the artist-page sidebar.
+   * - `inline` — single horizontal middot-separated strip ("4 releases · 2 labels · …").
+   *   For stat headers above main-column content. NOTE: the inline variant
+   *   lowercases labels for natural prose reading — pass plain-noun labels
+   *   ("Releases", "Shows tracked"), not proper nouns or already-styled text.
+   */
+  variant?: StatsListVariant
+  /** Additional CSS classes on the wrapping element. */
+  className?: string
+}
+
+const numberFormatter = new Intl.NumberFormat('en-US')
+
+function formatValue(value: StatsListItem['value']): ReactNode {
+  if (typeof value === 'number') {
+    return numberFormatter.format(value)
+  }
+  return value
+}
+
+/**
+ * Density-first stat block for entity pages (PSY-639). Pairs with
+ * `<SectionHeader title="Statistics" />` in the artist sidebar.
+ *
+ * Sidebar variant: vertical `<dl>` with one row per stat — label on the
+ * left, value right-aligned with `tabular-nums`.
+ *
+ * Inline variant: a single row of middot-separated `<value> <label>` pairs
+ * for placement above main-column content ("4 releases · 2 labels · 13 shows").
+ */
+export function StatsList({
+  items,
+  variant = 'sidebar',
+  className,
+}: StatsListProps) {
+  if (items.length === 0) return null
+
+  if (variant === 'inline') {
+    return (
+      <p
+        className={cn(
+          'text-sm text-muted-foreground tabular-nums',
+          className
+        )}
+      >
+        {items.map((item, idx) => (
+          <span key={item.label}>
+            {idx > 0 && (
+              <span aria-hidden="true" className="mx-1.5">
+                ·
+              </span>
+            )}
+            <span className="text-foreground font-medium">{formatValue(item.value)}</span>{' '}
+            <span>{item.label.toLowerCase()}</span>
+          </span>
+        ))}
+      </p>
+    )
+  }
+
+  return (
+    <dl className={cn('text-sm space-y-0.5', className)}>
+      {items.map(item => (
+        <div
+          key={item.label}
+          className="flex items-baseline justify-between gap-2"
+        >
+          <dt className="text-muted-foreground">{item.label}</dt>
+          <dd className="font-medium tabular-nums">{formatValue(item.value)}</dd>
+        </div>
+      ))}
+    </dl>
+  )
+}

--- a/frontend/components/shared/index.ts
+++ b/frontend/components/shared/index.ts
@@ -38,3 +38,9 @@ export type {
   DenseTableVariant,
   DenseTableGroupHeaderProps,
 } from './DenseTable'
+export { StatsList } from './StatsList'
+export type {
+  StatsListProps,
+  StatsListItem,
+  StatsListVariant,
+} from './StatsList'

--- a/frontend/features/artists/types.ts
+++ b/frontend/features/artists/types.ts
@@ -16,6 +16,22 @@ export interface ArtistSocial {
   website: string | null
 }
 
+/**
+ * Five at-a-glance counts surfaced in the artist detail page sidebar (PSY-639).
+ * Populated only on single-artist detail responses (GetArtist /
+ * GetArtistBySlug); undefined on list / search / mutation responses.
+ *
+ * `shows_tracked` counts past + future shows. `active_since` was considered
+ * and dropped — most artists lack the signals to derive it accurately.
+ */
+export interface ArtistStats {
+  releases: number
+  labels: number
+  shows_tracked: number
+  similar_artists: number
+  festival_appearances: number
+}
+
 export interface Artist {
   id: number
   slug: string
@@ -34,6 +50,8 @@ export interface Artist {
   social: ArtistSocial
   created_at: string
   updated_at: string
+  /** Populated by detail-page lookups (PSY-639). Undefined on list rows. */
+  stats?: ArtistStats
 }
 
 export interface ArtistEditRequest {


### PR DESCRIPTION
## Summary
- **Backend**: `GET /artists/:id` + by-slug now return a `stats` object — 5 counts: releases, labels, shows_tracked (past+future), similar_artists, festival_appearances. Folded into the existing `ArtistDetailResponse` (single round-trip, no new endpoint). `Stats` is a pointer + `omitempty` so list/search/mutation responses stay byte-identical.
- `buildArtistStats` runs all 5 counts as scalar subqueries in **one** query, each hitting an indexed `artist_id` FK. Query failure logs a WARN and returns zeroed counts — sidebar polish degrades gracefully rather than failing the page.
- "Active since" was dropped from the spec — most artists lack the signals to derive it accurately.
- **Frontend**: `StatsList` primitive — `sidebar` (vertical `<dl>`) + `inline` (middot prose strip) variants. Numeric values get thousands separators. `ArtistStats` type + `stats?` on `Artist`.
- Ships unwired; `ArtistDetail` consumes it in PSY-641.

Third item in the Artist Page Density Redesign project (#630, #631 merged).

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./internal/services/catalog/ ./internal/api/handlers/catalog/` — all pass; 3 new integration tests (sparse artist → all zeros; populated artist → verifies DISTINCT release_id collapses multi-role rows, DISTINCT similar-artist collapses multi-relationship-type rows, 2-festival count; slug path populates stats)
- [x] `bun run typecheck` clean
- [x] `bun run test:run components/shared/StatsList features/artists` — 217 pass (9 new StatsList tests)
- [x] `/simplify` run; applied the one real finding — combined 5 sequential COUNTs into a single-round-trip query (was a 6x round-trip regression on the detail path), which also collapsed 5 silent error-swallows into one logged WARN. Plus a JSDoc note on the inline-variant label lowercasing.
- [ ] No visual regression — primitive + endpoint field not yet wired into any page

Closes PSY-639

🤖 Generated with [Claude Code](https://claude.com/claude-code)