### PR TITLE
PSY-641: restructure ArtistDetail to two-column density-first shell

### DIFF
--- a/frontend/components/shared/AddToCollectionButton.test.tsx
+++ b/frontend/components/shared/AddToCollectionButton.test.tsx
@@ -376,3 +376,43 @@ describe('AddToCollectionButton', () => {
     errorSpy.mockRestore()
   })
 })
+
+describe('AddToCollectionButton — bracket variant (PSY-641)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuthContext.mockReturnValue({
+      user: { id: '1' },
+      isAuthenticated: true,
+      isLoading: false,
+      logout: vi.fn(),
+    })
+  })
+
+  it('renders [Add to collection] as a bracket link in bracket variant', () => {
+    render(
+      <AddToCollectionButton
+        entityType="artist"
+        entityId={1}
+        entityName="Test Artist"
+        variant="bracket"
+      />
+    )
+    const trigger = screen.getByRole('button', { name: /add to collection/i })
+    expect(trigger).toBeInTheDocument()
+    expect(trigger).toHaveTextContent('[Add to collection]')
+  })
+
+  it('bracket trigger opens the collections popover when clicked', async () => {
+    const user = userEvent.setup()
+    render(
+      <AddToCollectionButton
+        entityType="artist"
+        entityId={1}
+        entityName="Test Artist"
+        variant="bracket"
+      />
+    )
+    await user.click(screen.getByRole('button', { name: /add to collection/i }))
+    expect(await screen.findByText('My Favorites')).toBeInTheDocument()
+  })
+})

--- a/frontend/components/shared/AddToCollectionButton.tsx
+++ b/frontend/components/shared/AddToCollectionButton.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from 'react'
 import Link from 'next/link'
 import { Library, Check, Plus, Loader2, AlertCircle } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { BracketLink } from './BracketLink'
 import { Checkbox } from '@/components/ui/checkbox'
 import {
   Popover,
@@ -22,7 +23,12 @@ interface AddToCollectionButtonProps {
   entityType: CollectionEntityType
   entityId: number
   entityName: string
-  variant?: 'default' | 'ghost' | 'outline'
+  /**
+   * Trigger style. `default`/`ghost`/`outline` render a shadcn Button.
+   * `bracket` renders a `<BracketLink>` for dense entity-page header
+   * linkboxes (PSY-641) — `[Add to collection]`.
+   */
+  variant?: 'default' | 'ghost' | 'outline' | 'bracket'
   size?: 'sm' | 'default' | 'icon'
 }
 
@@ -176,16 +182,24 @@ export function AddToCollectionButton({
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
-        <Button
-          variant={variant}
-          size={size}
-          className={size === 'icon' ? 'h-8 w-8 p-0' : ''}
-          title={`Add "${entityName}" to a collection`}
-          aria-label="Add to Collection"
-        >
-          <Library className="h-4 w-4" />
-          {size !== 'icon' && <span className="ml-1.5">Collect</span>}
-        </Button>
+        {variant === 'bracket' ? (
+          <BracketLink
+            label="Add to collection"
+            title={`Add "${entityName}" to a collection`}
+            aria-label="Add to Collection"
+          />
+        ) : (
+          <Button
+            variant={variant}
+            size={size}
+            className={size === 'icon' ? 'h-8 w-8 p-0' : ''}
+            title={`Add "${entityName}" to a collection`}
+            aria-label="Add to Collection"
+          >
+            <Library className="h-4 w-4" />
+            {size !== 'icon' && <span className="ml-1.5">Collect</span>}
+          </Button>
+        )}
       </PopoverTrigger>
       <PopoverContent className="w-72 p-0" align="end">
         <div className="p-3 border-b border-border">

--- a/frontend/components/shared/BracketLink.tsx
+++ b/frontend/components/shared/BracketLink.tsx
@@ -1,9 +1,14 @@
 'use client'
 
+import { forwardRef } from 'react'
 import Link from 'next/link'
 import { cn } from '@/lib/utils'
 
-export interface BracketLinkProps {
+export interface BracketLinkProps
+  extends Omit<
+    React.ButtonHTMLAttributes<HTMLButtonElement>,
+    'onClick' | 'type'
+  > {
   /** Visible label, rendered inside literal [brackets]. e.g. label="Follow" -> "[Follow]" */
   label: string
   /** Navigation target. When provided, renders as <Link>; otherwise as <button type="button">. */
@@ -14,23 +19,8 @@ export interface BracketLinkProps {
   active?: boolean
   /** Visual variant. `danger` is red for destructive actions like [Remove] / [Delete] / [X]. */
   variant?: 'default' | 'danger'
-  /**
-   * Disabled state — un-clickable, dimmed.
-   *
-   * Note: when `href` is also set, a disabled BracketLink renders as a
-   * `<button disabled>` rather than an `<a>`. Anchors have no native disabled
-   * state, so the alternatives (`aria-disabled` + `tabIndex={-1}` + preventing
-   * default click) leak click-to-navigate to consumers that bypass keyboard /
-   * AT (right-click → open in new tab still navigates). The button swap is
-   * the simplest correct behavior.
-   */
-  disabled?: boolean
-  /** Tooltip (also exposed as title attribute). */
-  title?: string
   /** ARIA label override (defaults to the visible label). */
   ariaLabel?: string
-  /** Additional CSS classes. */
-  className?: string
 }
 
 /**
@@ -38,66 +28,84 @@ export interface BracketLinkProps {
  * the brackets ARE the affordance, not a hover state. Renders as <Link> when `href` is
  * provided, otherwise as <button type="button">.
  *
+ * The button branch forwards a ref and spreads remaining props, so it composes as a
+ * Radix `asChild` trigger (e.g. inside `<PopoverTrigger asChild>`). The <Link> branch
+ * is plain navigation only — it does not receive the ref or spread props.
+ *
+ * Note: when `href` AND `disabled` are both set, renders as a `<button disabled>` rather
+ * than an `<a>` — anchors have no native disabled state, and the alternatives leak
+ * click-to-navigate to keyboard/AT-bypassing consumers.
+ *
  * Usage:
  *   <BracketLink label="Follow" onClick={handleFollow} />
  *   <BracketLink label="Following" active onClick={handleUnfollow} />
  *   <BracketLink label="View history" href={`/artists/${slug}/history`} />
  *   <BracketLink label="X" variant="danger" onClick={handleRemove} title="Remove" />
  */
-export function BracketLink({
-  label,
-  href,
-  onClick,
-  active = false,
-  variant = 'default',
-  disabled = false,
-  title,
-  ariaLabel,
-  className,
-}: BracketLinkProps) {
-  const classes = cn(
-    'inline-flex items-baseline whitespace-nowrap text-sm tabular-nums',
-    'transition-colors',
-    variant === 'default' && !active && 'text-muted-foreground hover:text-foreground',
-    variant === 'default' && active && 'text-foreground font-medium',
-    variant === 'danger' && 'text-destructive hover:text-destructive/80',
-    disabled && 'opacity-50 cursor-not-allowed pointer-events-none',
-    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 rounded-sm',
-    className
-  )
+export const BracketLink = forwardRef<HTMLButtonElement, BracketLinkProps>(
+  function BracketLink(
+    {
+      label,
+      href,
+      onClick,
+      active = false,
+      variant = 'default',
+      disabled = false,
+      title,
+      ariaLabel,
+      className,
+      ...rest
+    },
+    ref
+  ) {
+    const classes = cn(
+      'inline-flex items-baseline whitespace-nowrap text-sm tabular-nums',
+      'transition-colors',
+      variant === 'default' &&
+        !active &&
+        'text-muted-foreground hover:text-foreground',
+      variant === 'default' && active && 'text-foreground font-medium',
+      variant === 'danger' && 'text-destructive hover:text-destructive/80',
+      disabled && 'opacity-50 cursor-not-allowed pointer-events-none',
+      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 rounded-sm',
+      className
+    )
 
-  const content = (
-    <>
-      <span aria-hidden="true">[</span>
-      <span>{label}</span>
-      <span aria-hidden="true">]</span>
-    </>
-  )
+    const content = (
+      <>
+        <span aria-hidden="true">[</span>
+        <span>{label}</span>
+        <span aria-hidden="true">]</span>
+      </>
+    )
 
-  if (href && !disabled) {
+    if (href && !disabled) {
+      return (
+        <Link
+          href={href}
+          className={classes}
+          title={title}
+          aria-label={ariaLabel ?? label}
+        >
+          {content}
+        </Link>
+      )
+    }
+
     return (
-      <Link
-        href={href}
+      <button
+        ref={ref}
+        type="button"
+        onClick={onClick}
+        disabled={disabled}
         className={classes}
         title={title}
         aria-label={ariaLabel ?? label}
+        aria-pressed={active || undefined}
+        {...rest}
       >
         {content}
-      </Link>
+      </button>
     )
   }
-
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={disabled}
-      className={classes}
-      title={title}
-      aria-label={ariaLabel ?? label}
-      aria-pressed={active || undefined}
-    >
-      {content}
-    </button>
-  )
-}
+)

--- a/frontend/components/shared/FollowButton.test.tsx
+++ b/frontend/components/shared/FollowButton.test.tsx
@@ -164,3 +164,51 @@ describe('FollowButton', () => {
     expect(screen.getByText('5')).toBeInTheDocument()
   })
 })
+
+describe('FollowButton — bracket variant (PSY-641)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsAuthenticated = true
+    mockFollowStatusData = { follower_count: 10, is_following: false }
+    mockStatusLoading = false
+  })
+
+  it('renders [Follow] as a bracket link when not following', () => {
+    render(
+      <FollowButton entityType="artists" entityId={1} variant="bracket" />,
+      { wrapper: createWrapper() }
+    )
+    const btn = screen.getByRole('button', { name: 'Follow' })
+    expect(btn).toBeInTheDocument()
+    expect(btn).not.toHaveAttribute('aria-pressed')
+  })
+
+  it('renders [Following] with aria-pressed when following', () => {
+    mockFollowStatusData = { follower_count: 10, is_following: true }
+    render(
+      <FollowButton entityType="artists" entityId={1} variant="bracket" />,
+      { wrapper: createWrapper() }
+    )
+    const btn = screen.getByRole('button', { name: 'Following' })
+    expect(btn).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('calls follow mutation when the bracket link is clicked', () => {
+    render(
+      <FollowButton entityType="artists" entityId={1} variant="bracket" />,
+      { wrapper: createWrapper() }
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Follow' }))
+    expect(mockFollowMutate).toHaveBeenCalledWith({ entityType: 'artists', entityId: 1 })
+  })
+
+  it('renders a disabled [Follow] while follow status is loading', () => {
+    mockStatusLoading = true
+    mockFollowStatusData = undefined
+    render(
+      <FollowButton entityType="artists" entityId={1} variant="bracket" />,
+      { wrapper: createWrapper() }
+    )
+    expect(screen.getByRole('button', { name: 'Follow' })).toBeDisabled()
+  })
+})

--- a/frontend/components/shared/FollowButton.tsx
+++ b/frontend/components/shared/FollowButton.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { useRouter, usePathname } from 'next/navigation'
 import { UserPlus, UserCheck, UserMinus, Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { BracketLink } from './BracketLink'
 import { useAuthContext } from '@/lib/context/AuthContext'
 import {
   useFollowStatus,
@@ -20,6 +21,12 @@ interface FollowButtonProps {
   compact?: boolean
   /** Pre-fetched data from batch endpoint, avoids extra request */
   followData?: { follower_count: number; is_following: boolean }
+  /**
+   * Rendering style. `button` (default) is the shadcn Button used everywhere
+   * today. `bracket` renders a `<BracketLink>` for dense entity-page header
+   * linkboxes (PSY-641) — `[Follow]` toggling to `[Following]`.
+   */
+  variant?: 'button' | 'bracket'
 }
 
 export function FollowButton({
@@ -27,6 +34,7 @@ export function FollowButton({
   entityId,
   compact = false,
   followData,
+  variant = 'button',
 }: FollowButtonProps) {
   const router = useRouter()
   const pathname = usePathname()
@@ -64,6 +72,22 @@ export function FollowButton({
     } else {
       follow.mutate({ entityType, entityId })
     }
+  }
+
+  // Bracket variant — dense header linkbox. Toggles [Follow] ↔ [Following];
+  // ignores `compact` (brackets are already maximally compact).
+  if (variant === 'bracket') {
+    if (!followData && statusLoading) {
+      return <BracketLink label="Follow" disabled />
+    }
+    return (
+      <BracketLink
+        label={isFollowing ? 'Following' : 'Follow'}
+        active={isFollowing}
+        onClick={handleClick}
+        disabled={isMutating}
+      />
+    )
   }
 
   // Don't show loading spinner for pre-fetched data

--- a/frontend/features/artists/components/ArtistDetail.test.tsx
+++ b/frontend/features/artists/components/ArtistDetail.test.tsx
@@ -20,11 +20,6 @@ vi.mock('next/link', () => ({
   ),
 }))
 
-// NOTE: `@/components/ui/tabs` is intentionally NOT mocked. The new tab-switch test at
-// the bottom of this file (see "ArtistShowsList tabs (real Radix)") relies on real Radix
-// behavior (aria-selected). The `EntityDetailLayout` mock below wraps children in a real
-// <Tabs> root so the <TabsContent> panels rendered by ArtistDetail still have a provider.
-
 // Mock hooks
 const mockUseArtist = vi.fn()
 vi.mock('../hooks/useArtists', () => ({
@@ -87,17 +82,6 @@ vi.mock('@/features/contributions', () => ({
   ContributionPrompt: () => null,
 }))
 
-vi.mock('@/components/forms/ArtistEditForm', () => ({
-  ArtistEditForm: ({
-    open,
-  }: {
-    open: boolean
-    artist: unknown
-    onOpenChange: (v: boolean) => void
-    onSuccess: () => void
-  }) => (open ? <div data-testid="edit-form">Edit Form</div> : null),
-}))
-
 // Mock comments feature
 vi.mock('@/features/comments', () => ({
   CommentThread: ({ entityType, entityId }: { entityType: string; entityId: number }) => (
@@ -113,92 +97,102 @@ vi.mock('next/navigation', () => ({
 
 // Mock NotifyMeButton to avoid deep notification hooks dependency
 vi.mock('@/features/notifications', () => ({
-  NotifyMeButton: ({ entityName }: { entityType: string; entityId: number; entityName: string }) => (
+  NotifyMeButton: ({ entityName }: { entityType: string; entityId: number; entityName: string; variant?: string }) => (
     <button data-testid="notify-me-button">Notify {entityName}</button>
   ),
 }))
 
-// PSY-364: ArtistDetail now mounts <BillComposition>, which fires its own fetch.
-// Stub it out so this suite doesn't need to set up bill-composition fixtures.
+// PSY-364: ArtistDetail mounts <BillComposition>, which fires its own fetch.
+// Stub it out so this suite doesn't need bill-composition fixtures.
 vi.mock('./BillComposition', () => ({
   BillComposition: () => null,
 }))
 
-vi.mock('@/components/shared', async () => {
-  // Import the real Tabs so that the TabsContent children passed to
-  // EntityDetailLayout have a provider in scope.
-  const { Tabs } = await vi.importActual<typeof import('@/components/ui/tabs')>(
-    '@/components/ui/tabs'
-  )
-  return {
-    SocialLinks: () => <div data-testid="social-links">Social Links</div>,
-    MusicEmbed: () => <div data-testid="music-embed">Music Embed</div>,
-    EntityDetailLayout: ({
-      children,
-      sidebar,
-      header,
-      tabs,
-      activeTab,
-      onTabChange,
-      fallback,
-      entityName,
-    }: {
-      children: React.ReactNode
-      sidebar: React.ReactNode
-      header: React.ReactNode
-      tabs: { value: string; label: string }[]
-      activeTab: string
-      onTabChange: (tab: string) => void
-      fallback: { href: string; label: string }
-      entityName: string
-    }) => (
-      <div data-testid="entity-layout">
-        <a href={fallback.href}>{fallback.label}</a>
-        <span data-testid="entity-name">{entityName}</span>
-        <div data-testid="header-slot">{header}</div>
-        <Tabs value={activeTab} onValueChange={onTabChange}>
-          <div data-testid="tabs">
-            {tabs.map(tab => (
-              <button
-                key={tab.value}
-                data-testid={`tab-${tab.value}`}
-                onClick={() => onTabChange(tab.value)}
-                data-active={tab.value === activeTab}
-              >
-                {tab.label}
-              </button>
-            ))}
-          </div>
-          <div data-testid="sidebar-slot">{sidebar}</div>
-          <div data-testid="content-slot">{children}</div>
-        </Tabs>
-      </div>
+// PSY-641: ArtistDetail is now a flat two-column layout — no page-level tabs.
+// The mock renders header / sidebar / children slots directly. The new
+// density primitives (BracketLink, SectionHeader, StatsList) get lightweight
+// mocks so their props are inspectable.
+vi.mock('@/components/shared', () => ({
+  SocialLinks: () => <div data-testid="social-links">Social Links</div>,
+  MusicEmbed: () => <div data-testid="music-embed">Music Embed</div>,
+  EntityDetailLayout: ({
+    children,
+    sidebar,
+    header,
+    fallback,
+    entityName,
+  }: {
+    children: React.ReactNode
+    sidebar: React.ReactNode
+    header: React.ReactNode
+    fallback: { href: string; label: string }
+    entityName: string
+  }) => (
+    <div data-testid="entity-layout">
+      <a href={fallback.href}>{fallback.label}</a>
+      <span data-testid="entity-name">{entityName}</span>
+      <div data-testid="header-slot">{header}</div>
+      <div data-testid="sidebar-slot">{sidebar}</div>
+      <div data-testid="content-slot">{children}</div>
+    </div>
+  ),
+  EntityHeader: ({
+    title,
+    subtitle,
+    actions,
+  }: {
+    title: string
+    subtitle?: React.ReactNode
+    actions?: React.ReactNode
+  }) => (
+    <div data-testid="entity-header">
+      <h1>{title}</h1>
+      {subtitle && <div data-testid="subtitle">{subtitle}</div>}
+      {actions && <div data-testid="header-actions">{actions}</div>}
+    </div>
+  ),
+  RevisionHistory: () => <div data-testid="revision-history">Revision History</div>,
+  FollowButton: ({ entityType, entityId }: { entityType: string; entityId: number; variant?: string }) => (
+    <button data-testid="follow-button">Follow {entityType} {entityId}</button>
+  ),
+  EntityDescription: ({ description, canEdit }: { description: string | null | undefined; canEdit: boolean }) => (
+    <div data-testid="entity-description">{description || (canEdit ? 'Add description' : '')}</div>
+  ),
+  AddToCollectionButton: () => (
+    <button data-testid="add-to-collection">[Add to collection]</button>
+  ),
+  BracketLink: ({
+    label,
+    href,
+    onClick,
+    title,
+  }: {
+    label: string
+    href?: string
+    onClick?: () => void
+    title?: string
+  }) =>
+    href ? (
+      <a href={href} title={title} data-testid={`bracket-${label}`}>
+        [{label}]
+      </a>
+    ) : (
+      <button onClick={onClick} title={title} data-testid={`bracket-${label}`}>
+        [{label}]
+      </button>
     ),
-    EntityHeader: ({
-      title,
-      subtitle,
-      actions,
-    }: {
-      title: string
-      subtitle?: React.ReactNode
-      actions?: React.ReactNode
-    }) => (
-      <div data-testid="entity-header">
-        <h1>{title}</h1>
-        {subtitle && <div data-testid="subtitle">{subtitle}</div>}
-        {actions && <div data-testid="header-actions">{actions}</div>}
-      </div>
-    ),
-    RevisionHistory: () => <div data-testid="revision-history">Revision History</div>,
-    FollowButton: ({ entityType, entityId }: { entityType: string; entityId: number }) => (
-      <button data-testid="follow-button">Follow {entityType} {entityId}</button>
-    ),
-    EntityDescription: ({ description, canEdit }: { description: string | null | undefined; canEdit: boolean }) => (
-      <div data-testid="entity-description">{description || (canEdit ? 'Add description' : '')}</div>
-    ),
-    AddToCollectionButton: () => <button data-testid="add-to-collection">Collect</button>,
-  }
-})
+  SectionHeader: ({ title }: { title: string }) => <h3>{title}</h3>,
+  StatsList: ({ items }: { items: { label: string; value: React.ReactNode }[] }) => (
+    <dl data-testid="stats-list">
+      {items.map(i => (
+        <div key={i.label}>
+          <dt>{i.label}</dt>
+          <dd>{i.value}</dd>
+        </div>
+      ))}
+    </dl>
+  ),
+}))
 
 import { ArtistDetail } from './ArtistDetail'
 
@@ -331,14 +325,28 @@ describe('ArtistDetail', () => {
       expect(screen.getByTestId('entity-name')).toHaveTextContent('Test Artist')
     })
 
-    it('renders tabs for overview, discography, and labels', () => {
+    it('renders a flat single-scroll main column with no page-level tabs', () => {
       renderWithProviders(<ArtistDetail artistId="test-artist" />)
-      expect(screen.getByTestId('tab-overview')).toBeInTheDocument()
-      expect(screen.getByTestId('tab-discography')).toBeInTheDocument()
-      expect(screen.getByTestId('tab-labels')).toBeInTheDocument()
+      // The Discography / Labels page-level tabs were removed in PSY-641.
+      expect(screen.queryByTestId('tab-discography')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('tab-labels')).not.toBeInTheDocument()
+      // Main-column content renders directly.
+      expect(screen.getByTestId('artist-shows-list')).toBeInTheDocument()
+      expect(screen.getByTestId('comment-thread')).toBeInTheDocument()
+      expect(screen.getByTestId('revision-history')).toBeInTheDocument()
     })
 
-    it('shows report button in header actions for authenticated users', () => {
+    it('renders the header action linkbox as bracket links', () => {
+      renderWithProviders(<ArtistDetail artistId="test-artist" />)
+      const headerActions = screen.getByTestId('header-actions')
+      // Stateful trio + the always-on [Graph] link.
+      expect(headerActions).toHaveTextContent('Follow')
+      expect(headerActions).toHaveTextContent('Notify')
+      expect(headerActions).toHaveTextContent('Add to collection')
+      expect(screen.getByTestId('bracket-Graph')).toHaveAttribute('href', '#graph')
+    })
+
+    it('shows the report bracket link for authenticated users', () => {
       mockUseIsAuthenticated.mockReturnValue({
         user: { is_admin: false },
         isAuthenticated: true,
@@ -348,9 +356,29 @@ describe('ArtistDetail', () => {
       expect(screen.getByTitle('Report an issue')).toBeInTheDocument()
     })
 
-    it('does not show report button for unauthenticated users', () => {
+    it('does not show the report bracket link for unauthenticated users', () => {
       renderWithProviders(<ArtistDetail artistId="test-artist" />)
       expect(screen.queryByTitle('Report an issue')).not.toBeInTheDocument()
+    })
+
+    it('shows a Suggest edit link for authenticated non-trusted users', () => {
+      mockUseIsAuthenticated.mockReturnValue({
+        user: { is_admin: false },
+        isAuthenticated: true,
+        isLoading: false,
+      })
+      renderWithProviders(<ArtistDetail artistId="test-artist" />)
+      expect(screen.getByTestId('bracket-Suggest edit')).toBeInTheDocument()
+    })
+
+    it('shows an Edit link for trusted-tier users', () => {
+      mockUseIsAuthenticated.mockReturnValue({
+        user: { is_admin: false, user_tier: 'trusted_contributor' },
+        isAuthenticated: true,
+        isLoading: false,
+      })
+      renderWithProviders(<ArtistDetail artistId="test-artist" />)
+      expect(screen.getByTestId('bracket-Edit')).toBeInTheDocument()
     })
 
     it('renders artist shows list', () => {
@@ -359,35 +387,88 @@ describe('ArtistDetail', () => {
       expect(screen.getByText('Shows for 42')).toBeInTheDocument()
     })
 
-    it('renders social links in sidebar', () => {
-      renderWithProviders(<ArtistDetail artistId="test-artist" />)
-      expect(screen.getByTestId('social-links')).toBeInTheDocument()
-    })
-
-    it('renders music embed in sidebar', () => {
-      renderWithProviders(<ArtistDetail artistId="test-artist" />)
-      expect(screen.getByTestId('music-embed')).toBeInTheDocument()
-    })
-
-    it('shows location in sidebar when available', () => {
-      renderWithProviders(<ArtistDetail artistId="test-artist" />)
-      // Location appears in both header subtitle and sidebar;
-      // verify sidebar has "Location" heading
-      const sidebarSlot = screen.getByTestId('sidebar-slot')
-      expect(sidebarSlot).toHaveTextContent('Location')
-      expect(sidebarSlot).toHaveTextContent('Phoenix, AZ')
-    })
-
-    it('hides location in sidebar when not available', () => {
+    it('renders the statistics block in the sidebar when stats are present', () => {
       mockUseArtist.mockReturnValue({
-        data: makeArtist({ city: null, state: null }),
+        data: makeArtist({
+          stats: {
+            releases: 4,
+            labels: 2,
+            shows_tracked: 13,
+            similar_artists: 8,
+            festival_appearances: 3,
+          },
+        }),
         isLoading: false,
         error: null,
       })
 
       renderWithProviders(<ArtistDetail artistId="test-artist" />)
       const sidebarSlot = screen.getByTestId('sidebar-slot')
-      expect(sidebarSlot).not.toHaveTextContent('Location')
+      expect(sidebarSlot).toHaveTextContent('Statistics')
+      expect(sidebarSlot).toHaveTextContent('Releases')
+      expect(sidebarSlot).toHaveTextContent('13')
+    })
+
+    it('omits the statistics block when stats are absent', () => {
+      // Default makeArtist() has no `stats` field.
+      renderWithProviders(<ArtistDetail artistId="test-artist" />)
+      expect(screen.queryByTestId('stats-list')).not.toBeInTheDocument()
+    })
+
+    it('renders social links in the sidebar when the artist has any', () => {
+      mockUseArtist.mockReturnValue({
+        data: makeArtist({
+          social: {
+            instagram: 'https://instagram.com/test',
+            facebook: null,
+            twitter: null,
+            youtube: null,
+            spotify: null,
+            soundcloud: null,
+            bandcamp: null,
+            website: null,
+          },
+        }),
+        isLoading: false,
+        error: null,
+      })
+
+      renderWithProviders(<ArtistDetail artistId="test-artist" />)
+      expect(screen.getByTestId('social-links')).toBeInTheDocument()
+    })
+
+    it('hides the links section when the artist has no social links', () => {
+      // Default makeArtist() has all-null social fields.
+      renderWithProviders(<ArtistDetail artistId="test-artist" />)
+      expect(screen.queryByTestId('social-links')).not.toBeInTheDocument()
+    })
+
+    it('renders the music embed in the sidebar when a music link exists', () => {
+      mockUseArtist.mockReturnValue({
+        data: makeArtist({
+          social: {
+            instagram: null,
+            facebook: null,
+            twitter: null,
+            youtube: null,
+            spotify: 'https://open.spotify.com/artist/123',
+            soundcloud: null,
+            bandcamp: null,
+            website: null,
+          },
+        }),
+        isLoading: false,
+        error: null,
+      })
+
+      renderWithProviders(<ArtistDetail artistId="test-artist" />)
+      expect(screen.getByTestId('music-embed')).toBeInTheDocument()
+    })
+
+    it('hides the music embed when the artist has no music link', () => {
+      // Default makeArtist() has no bandcamp_embed_url and all-null social.
+      renderWithProviders(<ArtistDetail artistId="test-artist" />)
+      expect(screen.queryByTestId('music-embed')).not.toBeInTheDocument()
     })
 
     it('shows label links in sidebar when labels exist', () => {
@@ -413,8 +494,6 @@ describe('ArtistDetail', () => {
 
       renderWithProviders(<ArtistDetail artistId="test-artist" />)
       const sidebarSlot = screen.getByTestId('sidebar-slot')
-      // Sidebar should NOT contain the "Labels" heading when there are no labels
-      // Note: The tab labeled "Labels" exists in a different part of the DOM
       const sidebarHeadings = sidebarSlot.querySelectorAll('h3')
       const labelsHeading = Array.from(sidebarHeadings).find(
         h => h.textContent === 'Labels'
@@ -432,7 +511,7 @@ describe('ArtistDetail', () => {
       })
     })
 
-    it('does not show edit button for non-admin users', () => {
+    it('does not show edit drawer for non-admin users by default', () => {
       mockUseIsAuthenticated.mockReturnValue({
         user: { is_admin: false },
         isAuthenticated: true,
@@ -440,8 +519,7 @@ describe('ArtistDetail', () => {
       })
 
       renderWithProviders(<ArtistDetail artistId="test-artist" />)
-      // The Edit2 icon button should not be present; check that edit form isn't rendered
-      expect(screen.queryByTestId('edit-form')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('edit-drawer')).not.toBeInTheDocument()
     })
 
     it('does not show admin music controls for non-admin users', () => {
@@ -598,9 +676,9 @@ describe('ArtistDetail', () => {
 
 // Replaces e2e: pages/artist-detail.spec.ts "shows tabs switch between upcoming and past"
 // (moved to a component test per PSY-472, audit doc docs/research/e2e-layer-5-audit.md item #2).
-// Renders the real ArtistShowsList (which owns the Upcoming/Past tabs) against real Radix Tabs
-// — the blanket ./ArtistShowsList mock above is bypassed via vi.importActual so the rest of the
-// ArtistDetail suite stays on the fast mocked path.
+// ArtistShowsList still owns its own Upcoming/Past tabs (unchanged by PSY-641 — the
+// page-level tabs were what got removed). Renders the real ArtistShowsList against real
+// Radix Tabs; the blanket ./ArtistShowsList mock above is bypassed via vi.importActual.
 describe('ArtistShowsList tabs (real Radix)', () => {
   it('switches aria-selected between upcoming and past tabs on click', async () => {
     const user = userEvent.setup()

--- a/frontend/features/artists/components/ArtistDetail.tsx
+++ b/frontend/features/artists/components/ArtistDetail.tsx
@@ -11,14 +11,12 @@ import {
   X,
   Check,
   AlertCircle,
-  Edit2,
   Disc3,
-  Tag,
-  Flag,
 } from 'lucide-react'
 import { useQueryClient } from '@tanstack/react-query'
 import { useArtist } from '../hooks/useArtists'
-import { getArtistLocation } from '../types'
+import { getArtistLocation, hasAnySocialLink } from '../types'
+import type { Artist } from '../types'
 import { useArtistReleases } from '@/features/releases/hooks/useReleases'
 import { useArtistAliases } from '@/lib/hooks/admin/useAdminArtists'
 import { useArtistLabels, useLabelRoster } from '@/features/labels/hooks/useLabels'
@@ -33,10 +31,21 @@ import {
   useArtistUpdate,
   type MusicPlatform,
 } from '@/lib/hooks/admin/useAdminArtists'
-import { SocialLinks, MusicEmbed, EntityDetailLayout, EntityHeader, RevisionHistory, FollowButton, EntityDescription, AddToCollectionButton } from '@/components/shared'
+import {
+  SocialLinks,
+  MusicEmbed,
+  EntityDetailLayout,
+  EntityHeader,
+  RevisionHistory,
+  FollowButton,
+  EntityDescription,
+  AddToCollectionButton,
+  BracketLink,
+  SectionHeader,
+  StatsList,
+} from '@/components/shared'
 import { ArtistTrajectoryChart } from '@/features/festivals/components/ArtistTrajectoryChart'
 import { EntityTagList } from '@/features/tags'
-import { ArtistEditForm } from '@/components/forms/ArtistEditForm'
 import { EntityEditDrawer, EntitySaveSuccessBanner, useEntitySaveSuccessBanner, AttributionLine, ReportEntityDialog, ContributionPrompt } from '@/features/contributions'
 import { AsHeardOn } from '@/features/radio'
 import { EntityCollections } from '@/features/collections'
@@ -48,7 +57,6 @@ import { BillComposition } from './BillComposition'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Alert, AlertDescription } from '@/components/ui/alert'
-import { TabsContent } from '@/components/ui/tabs'
 import { Badge } from '@/components/ui/badge'
 import { getReleaseTypeLabel } from '@/features/releases/types'
 import type { ArtistReleaseListItem } from '@/features/releases/types'
@@ -170,62 +178,6 @@ function DiscographyTab({ artistIdOrSlug }: { artistIdOrSlug: string | number })
   )
 }
 
-// --- Labels Tab ---
-
-function LabelsTab({ artistIdOrSlug }: { artistIdOrSlug: string | number }) {
-  const { data, isLoading, error } = useArtistLabels({ artistIdOrSlug })
-
-  if (isLoading) {
-    return (
-      <div className="flex justify-center py-8">
-        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-      </div>
-    )
-  }
-
-  if (error) {
-    return (
-      <div className="py-8 text-center text-sm text-destructive">
-        Failed to load labels
-      </div>
-    )
-  }
-
-  if (!data?.labels || data.labels.length === 0) {
-    return (
-      <div className="py-8 text-center text-sm text-muted-foreground">
-        No label affiliations yet
-      </div>
-    )
-  }
-
-  return (
-    <div className="space-y-3">
-      {data.labels.map(label => (
-        <Link
-          key={label.id}
-          href={`/labels/${label.slug}`}
-          className="flex items-center gap-3 p-3 rounded-md border border-border/50 hover:bg-muted/50 transition-colors group"
-        >
-          <div className="w-10 h-10 bg-muted rounded flex-shrink-0 flex items-center justify-center">
-            <Tag className="h-5 w-5 text-muted-foreground" />
-          </div>
-          <div className="flex-1 min-w-0">
-            <p className="text-sm font-medium group-hover:text-foreground">
-              {label.name}
-            </p>
-            {(label.city || label.state) && (
-              <p className="text-xs text-muted-foreground">
-                {[label.city, label.state].filter(Boolean).join(', ')}
-              </p>
-            )}
-          </div>
-        </Link>
-      ))}
-    </div>
-  )
-}
-
 // --- Also on this label sidebar section ---
 
 function AlsoOnThisLabel({
@@ -301,54 +253,70 @@ function ArtistSidebar({
   artist,
   labels,
   labelsLoading,
+  isAuthenticated,
 }: {
-  artist: {
-    id: number
-    name: string
-    slug: string
-    city: string | null
-    state: string | null
-    country?: string | null
-    bandcamp_embed_url: string | null
-    social: {
-      instagram: string | null
-      facebook: string | null
-      twitter: string | null
-      youtube: string | null
-      spotify: string | null
-      soundcloud: string | null
-      bandcamp: string | null
-      website: string | null
-    }
-  }
+  artist: Artist
   labels: ArtistLabel[]
   labelsLoading: boolean
+  isAuthenticated: boolean
 }) {
-  const hasLocation = artist.city || artist.state || artist.country
   const { data: aliasesData } = useArtistAliases(artist.id)
   const aliases = aliasesData?.aliases ?? []
 
+  const statsItems = artist.stats
+    ? [
+        { label: 'Releases', value: artist.stats.releases },
+        { label: 'Labels', value: artist.stats.labels },
+        { label: 'Shows tracked', value: artist.stats.shows_tracked },
+        { label: 'Similar artists', value: artist.stats.similar_artists },
+        {
+          label: 'Festival appearances',
+          value: artist.stats.festival_appearances,
+        },
+      ]
+    : []
+
+  const hasSocialLinks = !!artist.social && hasAnySocialLink(artist.social)
+  const hasMusicLink = Boolean(
+    artist.social?.spotify ||
+      artist.bandcamp_embed_url ||
+      artist.social?.bandcamp
+  )
+
   return (
     <div className="space-y-6">
-      {/* Location */}
-      {hasLocation && (
-        <div>
-          <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
-            Location
-          </h3>
-          <div className="flex items-center gap-1.5 text-sm">
-            <MapPin className="h-4 w-4 text-muted-foreground" />
-            <span>{getArtistLocation(artist)}</span>
-          </div>
-        </div>
+      {/* Photo */}
+      {artist.image_url && (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={artist.image_url}
+          alt={artist.name}
+          className="w-full rounded-md border border-border/50"
+        />
       )}
+
+      {/* Statistics */}
+      {statsItems.length > 0 && (
+        <section>
+          <SectionHeader title="Statistics" />
+          <StatsList items={statsItems} />
+        </section>
+      )}
+
+      {/* Tags — EntityTagList renders its own header + empty state. Not
+          wrapped in SectionHeader (it owns its header); its "No tags yet"
+          empty state is left for PSY-643 (empty-state audit), since fixing
+          it means touching a component shared by 4 other entity pages. */}
+      <EntityTagList
+        entityType="artist"
+        entityId={artist.id}
+        isAuthenticated={isAuthenticated}
+      />
 
       {/* Aliases */}
       {aliases.length > 0 && (
-        <div>
-          <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
-            Also known as
-          </h3>
+        <section>
+          <SectionHeader title="Also known as" />
           <div className="space-y-1">
             {aliases.map(alias => (
               <p key={alias.id} className="text-sm text-muted-foreground">
@@ -356,25 +324,13 @@ function ArtistSidebar({
               </p>
             ))}
           </div>
-        </div>
+        </section>
       )}
 
-      {/* Social Links */}
-      {artist.social && (
-        <div>
-          <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
-            Links
-          </h3>
-          <SocialLinks social={artist.social} />
-        </div>
-      )}
-
-      {/* Label Affiliations */}
+      {/* Labels (inline list) */}
       {!labelsLoading && labels.length > 0 && (
-        <div>
-          <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
-            Labels
-          </h3>
+        <section>
+          <SectionHeader title="Labels" />
           <div className="space-y-1">
             {labels.map(label => (
               <Link
@@ -386,29 +342,40 @@ function ArtistSidebar({
               </Link>
             ))}
           </div>
-        </div>
+        </section>
       )}
 
-      {/* Festival Trajectory */}
-      <ArtistTrajectoryChart artistIdOrSlug={artist.id} />
+      {/* Links */}
+      {hasSocialLinks && (
+        <section>
+          <SectionHeader title="Links" />
+          <SocialLinks social={artist.social} />
+        </section>
+      )}
 
-      {/* Music Embed */}
-      <MusicEmbed
-        bandcampAlbumUrl={artist.bandcamp_embed_url}
-        bandcampProfileUrl={artist.social?.bandcamp}
-        spotifyUrl={artist.social?.spotify}
-        artistName={artist.name}
-      />
+      {/* Top tracks — compact embed, rendered only when a music link exists */}
+      {hasMusicLink && (
+        <section>
+          <SectionHeader title="Top tracks" />
+          <MusicEmbed
+            bandcampAlbumUrl={artist.bandcamp_embed_url}
+            bandcampProfileUrl={artist.social?.bandcamp}
+            spotifyUrl={artist.social?.spotify}
+            artistName={artist.name}
+            compact
+          />
+        </section>
+      )}
 
       {/* Also on this label */}
       {!labelsLoading && labels.length > 0 && (
         <AlsoOnThisLabel labels={labels} currentArtistId={artist.id} />
       )}
 
-      {/* As Heard On (radio) */}
+      {/* As heard on (radio) — self-hides when empty */}
       <AsHeardOn entityType="artist" entitySlug={artist.slug} />
 
-      {/* In Collections */}
+      {/* In collections — self-hides when empty */}
       <EntityCollections entityType="artist" entityId={artist.id} />
     </div>
   )
@@ -846,7 +813,6 @@ export function ArtistDetail({ artistId }: ArtistDetailProps) {
   const canEditDirectly = isAdmin || user?.user_tier === 'trusted_contributor' || user?.user_tier === 'local_ambassador'
   const updateArtist = useArtistUpdate()
 
-  const [activeTab, setActiveTab] = useState('overview')
   const [isEditing, setIsEditing] = useState(false)
   const [editFocusField, setEditFocusField] = useState<string | undefined>()
   const [isReportOpen, setIsReportOpen] = useState(false)
@@ -915,13 +881,6 @@ export function ArtistDetail({ artistId }: ArtistDetailProps) {
 
   const labels = labelsData?.labels ?? []
 
-  // Build tabs - only show tabs that have content or always show
-  const tabs = [
-    { value: 'overview', label: 'Overview' },
-    { value: 'discography', label: 'Discography' },
-    { value: 'labels', label: 'Labels' },
-  ]
-
   const headerSubtitle = (artist.city || artist.state || artist.country) ? (
     <>
       <MapPin className="h-4 w-4" />
@@ -929,32 +888,37 @@ export function ArtistDetail({ artistId }: ArtistDetailProps) {
     </>
   ) : undefined
 
+  // Gazelle-style bracketed action linkbox — no icon buttons. The stateful
+  // trio (Follow / Notify / Add to collection) render their own bracket
+  // variant; they each handle the unauthenticated → /auth redirect internally.
   const headerActions = (
-    <div className="flex items-center gap-2">
-      <NotifyMeButton entityType="artist" entityId={artist.id} entityName={artist.name} />
-      <FollowButton entityType="artists" entityId={artist.id} />
-      <AddToCollectionButton entityType="artist" entityId={artist.id} entityName={artist.name} />
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+      <FollowButton entityType="artists" entityId={artist.id} variant="bracket" />
+      <NotifyMeButton
+        entityType="artist"
+        entityId={artist.id}
+        entityName={artist.name}
+        variant="bracket"
+      />
+      <AddToCollectionButton
+        entityType="artist"
+        entityId={artist.id}
+        entityName={artist.name}
+        variant="bracket"
+      />
       {isAuthenticated && (
-        <Button
-          variant="ghost"
-          size="sm"
+        <BracketLink
+          label={canEditDirectly ? 'Edit' : 'Suggest edit'}
           onClick={() => setIsEditing(true)}
-          className="text-muted-foreground hover:text-foreground"
-          title={canEditDirectly ? 'Edit' : 'Suggest Edit'}
-        >
-          <Edit2 className="h-4 w-4" />
-        </Button>
+        />
       )}
+      <BracketLink label="Graph" href="#graph" />
       {isAuthenticated && (
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => setIsReportOpen(true)}
-          className="text-muted-foreground hover:text-foreground"
+        <BracketLink
+          label="Report"
           title="Report an issue"
-        >
-          <Flag className="h-4 w-4" />
-        </Button>
+          onClick={() => setIsReportOpen(true)}
+        />
       )}
     </div>
   )
@@ -973,11 +937,6 @@ export function ArtistDetail({ artistId }: ArtistDetailProps) {
             />
             <EntitySaveSuccessBanner visible={saveBanner.isVisible} />
             <AttributionLine entityType="artist" entityId={artist.id} />
-            <EntityTagList
-              entityType="artist"
-              entityId={artist.id}
-              isAuthenticated={isAuthenticated}
-            />
             <ContributionPrompt
               entityType="artist"
               entityId={artist.id}
@@ -990,20 +949,28 @@ export function ArtistDetail({ artistId }: ArtistDetailProps) {
             />
           </>
         }
-        tabs={tabs}
-        activeTab={activeTab}
-        onTabChange={setActiveTab}
         sidebar={
           <ArtistSidebar
             artist={artist}
             labels={labels}
             labelsLoading={labelsLoading}
+            isAuthenticated={!!isAuthenticated}
           />
         }
       >
-        {/* Overview Tab */}
-        <TabsContent value="overview">
-          {/* Description */}
+        {/* Single-scroll main column — no tabs. Order follows the spec:
+            shows → discography → bills → festival trajectory → bio →
+            admin music controls → revision history → discussion.
+            (docs/features/artist-page-redesign.md) */}
+        <div className="space-y-8">
+          <ArtistShowsList artistId={artist.id} />
+
+          <DiscographyTab artistIdOrSlug={artistId} />
+
+          <BillComposition artistId={artist.id} />
+
+          <ArtistTrajectoryChart artistIdOrSlug={artist.id} />
+
           <EntityDescription
             description={artist.description}
             canEdit={!!isAdmin}
@@ -1025,45 +992,24 @@ export function ArtistDetail({ artistId }: ArtistDetailProps) {
             }}
           />
 
-          {/* Admin music embed controls */}
           {isAdmin && (
             <AdminMusicControls artist={artist} artistId={artistId} />
           )}
 
-          {/* Shows List */}
-          <ArtistShowsList artistId={artist.id} />
-        </TabsContent>
+          <RevisionHistory
+            entityType="artist"
+            entityId={artist.id}
+            isAdmin={!!isAdmin}
+          />
 
-        {/* Discography Tab */}
-        <TabsContent value="discography">
-          <DiscographyTab artistIdOrSlug={artistId} />
-        </TabsContent>
-
-        {/* Labels Tab */}
-        <TabsContent value="labels">
-          <LabelsTab artistIdOrSlug={artistId} />
-        </TabsContent>
+          <CommentThread entityType="artist" entityId={artist.id} />
+        </div>
       </EntityDetailLayout>
 
-      {/* Bill Composition (PSY-364) */}
-      <BillComposition artistId={artist.id} />
-
-      {/* Related Artists */}
+      {/* Related Artists — stays full-width below the layout for slice A;
+          moves into the sidebar as a dense list + graph-thumbnail modal in
+          PSY-645. The [Graph] header link targets this section's #graph hash. */}
       <RelatedArtists artistId={artist.id} artistSlug={artist.slug} />
-
-      {/* Revision History */}
-      <div className="mt-0">
-        <RevisionHistory
-          entityType="artist"
-          entityId={artist.id}
-          isAdmin={!!isAdmin}
-        />
-      </div>
-
-      {/* Discussion */}
-      <div className="mt-0 px-4 md:px-0">
-        <CommentThread entityType="artist" entityId={artist.id} />
-      </div>
 
       {/* Edit Drawer (all authenticated users) */}
       {isAuthenticated && (

--- a/frontend/features/artists/types.ts
+++ b/frontend/features/artists/types.ts
@@ -17,6 +17,18 @@ export interface ArtistSocial {
 }
 
 /**
+ * True when the artist has at least one non-empty social / streaming link.
+ * Used to hide the sidebar "Links" section entirely when there's nothing to
+ * show (PSY-641). `LabelDetail` carries a near-identical predicate — worth
+ * converging on a shared helper when the cross-entity header rollout lands.
+ */
+export function hasAnySocialLink(social: ArtistSocial): boolean {
+  return Object.values(social).some(
+    value => typeof value === 'string' && value.trim().length > 0
+  )
+}
+
+/**
  * Five at-a-glance counts surfaced in the artist detail page sidebar (PSY-639).
  * Populated only on single-artist detail responses (GetArtist /
  * GetArtistBySlug); undefined on list / search / mutation responses.

--- a/frontend/features/notifications/components/NotifyMeButton.test.tsx
+++ b/frontend/features/notifications/components/NotifyMeButton.test.tsx
@@ -214,3 +214,86 @@ describe('NotifyMeButton', () => {
     expect(screen.queryByRole('alert')).not.toBeInTheDocument()
   })
 })
+
+describe('NotifyMeButton — bracket variant (PSY-641)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuthContext.mockReturnValue({
+      isAuthenticated: true,
+      user: { id: '1' },
+    })
+    mockFilterCheck.mockReturnValue({
+      data: undefined,
+      hasFilter: false,
+      isLoading: false,
+      isSuccess: true,
+    })
+    mockQuickCreate.mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+      isError: false,
+      error: null,
+    })
+    mockDeleteFilter.mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+      isError: false,
+      error: null,
+    })
+  })
+
+  it('renders [Notify me] as a bracket link when no filter exists', () => {
+    render(
+      <NotifyMeButton
+        entityType="artist"
+        entityId={1}
+        entityName="Test Artist"
+        variant="bracket"
+      />
+    )
+    const btn = screen.getByRole('button', { name: 'Notify me' })
+    expect(btn).toBeInTheDocument()
+    expect(btn).not.toHaveAttribute('aria-pressed')
+  })
+
+  it('renders [Notifications on] with aria-pressed when a filter exists', () => {
+    mockFilterCheck.mockReturnValue({
+      data: { id: 7 },
+      hasFilter: true,
+      isLoading: false,
+      isSuccess: true,
+    })
+    render(
+      <NotifyMeButton
+        entityType="artist"
+        entityId={1}
+        entityName="Test Artist"
+        variant="bracket"
+      />
+    )
+    expect(
+      screen.getByRole('button', { name: 'Notifications on' })
+    ).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('creates a filter when the bracket link is clicked', async () => {
+    const mutate = vi.fn()
+    mockQuickCreate.mockReturnValue({
+      mutate,
+      isPending: false,
+      isError: false,
+      error: null,
+    })
+    const user = userEvent.setup()
+    render(
+      <NotifyMeButton
+        entityType="artist"
+        entityId={1}
+        entityName="Test Artist"
+        variant="bracket"
+      />
+    )
+    await user.click(screen.getByRole('button', { name: 'Notify me' }))
+    expect(mutate).toHaveBeenCalledWith({ entityType: 'artist', entityId: 1 })
+  })
+})

--- a/frontend/features/notifications/components/NotifyMeButton.tsx
+++ b/frontend/features/notifications/components/NotifyMeButton.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { useRouter, usePathname } from 'next/navigation'
 import { AlertCircle, Bell, BellRing, Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { BracketLink } from '@/components/shared/BracketLink'
 import { useAuthContext } from '@/lib/context/AuthContext'
 import {
   useNotificationFilterCheck,
@@ -19,6 +20,12 @@ interface NotifyMeButtonProps {
   entityName: string
   /** Compact mode for tighter layouts */
   compact?: boolean
+  /**
+   * Rendering style. `button` (default) is the shadcn Button. `bracket`
+   * renders a `<BracketLink>` for dense entity-page header linkboxes
+   * (PSY-641) — `[Notify me]` toggling to `[Notifications on]`.
+   */
+  variant?: 'button' | 'bracket'
 }
 
 const entityLabels: Record<NotifyEntityType, string> = {
@@ -33,6 +40,7 @@ export function NotifyMeButton({
   entityId,
   entityName,
   compact = false,
+  variant = 'button',
 }: NotifyMeButtonProps) {
   const router = useRouter()
   const pathname = usePathname()
@@ -63,6 +71,22 @@ export function NotifyMeButton({
     } else {
       quickCreate.mutate({ entityType, entityId })
     }
+  }
+
+  // Bracket variant — dense header linkbox. handleClick already handles the
+  // unauthenticated → /auth redirect, so a single BracketLink covers all states.
+  if (variant === 'bracket') {
+    if (isAuthenticated && checkLoading) {
+      return <BracketLink label="Notify me" disabled />
+    }
+    return (
+      <BracketLink
+        label={hasFilter ? 'Notifications on' : 'Notify me'}
+        active={hasFilter}
+        onClick={handleClick}
+        disabled={isMutating}
+      />
+    )
   }
 
   // Don't render for unauthenticated users in loading state


### PR DESCRIPTION
## Summary

Slice A of a 3-way split of the artist-page redesign (the original PSY-641 was ~10 concerns / ~2k lines; split per the project's decomposition norm). Spec: `docs/features/artist-page-redesign.md`.

- **Tabs removed.** `EntityDetailLayout` flat mode — single-scroll main column. Order per spec: shows → discography → bills → festival trajectory → bio → admin music controls → revision history → discussion.
- **Header linkbox.** Icon-button actions replaced with a Gazelle-style `BracketLink` linkbox: `[Follow] [Notify me] [Add to collection] [Suggest edit]/[Edit] [Graph] [Report]`.
- **New dense `ArtistSidebar`:** photo, `StatsList` (5 counts from PSY-639), `EntityTagList`, aliases, labels (inline list — replaces the old Labels tab), links, compact Spotify slot, also-on-this-label, as-heard-on, in-collections. Sections hide when empty.
- **`variant="bracket"` added to `FollowButton` / `NotifyMeButton` / `AddToCollectionButton`** — additive, default `button`, so the 4 other entity pages are untouched. `BracketLink` refactored to `forwardRef` + prop-spread so it composes as a Radix `PopoverTrigger asChild` child.
- New `hasAnySocialLink` helper in `artists/types.ts` for the sidebar's hide-when-empty Links section.

## Scoping decisions (flagging for review)

- **`RelatedArtists` stays full-width below the layout** for this slice — it moves into the sidebar as a dense list + graph-thumbnail modal in **PSY-645**.
- **`EntityTagList` renders with its own header + "No tags yet" empty state** — left for **PSY-643** (the empty-state audit); fixing it means touching a component shared by 4 other entity pages.
- **3 header links deferred** — `[Add tag]` (needs header↔sidebar coordination state), `[Subscribe]` (no confirmed comment-subscription hook), `[View history]` (redundant — RevisionHistory is a visible main-column section). The 6 that work cleanly ship now.
- **`FestivalTrajectory` moved sidebar → main column**, uncollapsed. **PSY-644** wraps it (+ BillComposition + RevisionHistory) in collapsible `[Toggle]` sections.
- **Known consequence**: removing tabs means `useArtistReleases` (DiscographyTab) now fires on initial load instead of on tab-click — one extra request, accepted (discography is primary content per spec; PSY-644 can gate it if Discography becomes collapsible).
- Cross-entity header convergence (venue/release/label/festival) is in the spec's deferred section.

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun run test:run features/artists components/shared features/notifications` — 602 pass (incl. 33 rewritten ArtistDetail tests + new bracket-variant tests for the 3 buttons)
- [x] `/simplify` run — applied 2 findings (extracted `hasAnySocialLink` helper; fixed a test mock that asserted stale "Collect" text instead of the real `[Add to collection]`)
- [x] Manual repro vs running dev servers: `amyl-and-the-sniffers` (rich-ish) + `just-mustard` (the canonical "looks horrible" page) — two-column layout, tab-free, header linkbox, hide-when-empty all verified. Backend is pre-PSY-639 (no `stats` field) so the StatsList section showed its hidden path; the populated path is covered by component tests.

Closes PSY-641

🤖 Generated with [Claude Code](https://claude.com/claude-code)