### PR TITLE
PSY-644: artist main-column density — DenseTable shows + 10-bucket discography + collapsibles

### DIFF
--- a/frontend/features/artists/components/ArtistDetail.test.tsx
+++ b/frontend/features/artists/components/ArtistDetail.test.tsx
@@ -674,35 +674,8 @@ describe('ArtistDetail', () => {
   })
 })
 
-// Replaces e2e: pages/artist-detail.spec.ts "shows tabs switch between upcoming and past"
-// (moved to a component test per PSY-472, audit doc docs/research/e2e-layer-5-audit.md item #2).
-// ArtistShowsList still owns its own Upcoming/Past tabs (unchanged by PSY-641 — the
-// page-level tabs were what got removed). Renders the real ArtistShowsList against real
-// Radix Tabs; the blanket ./ArtistShowsList mock above is bypassed via vi.importActual.
-describe('ArtistShowsList tabs (real Radix)', () => {
-  it('switches aria-selected between upcoming and past tabs on click', async () => {
-    const user = userEvent.setup()
-    const { ArtistShowsList: RealArtistShowsList } = await vi.importActual<
-      typeof import('./ArtistShowsList')
-    >('./ArtistShowsList')
-
-    renderWithProviders(<RealArtistShowsList artistId={42} />)
-
-    const upcomingTab = screen.getByRole('tab', { name: /upcoming/i })
-    const pastTab = screen.getByRole('tab', { name: /past shows/i })
-
-    // Upcoming tab is selected by default
-    expect(upcomingTab).toHaveAttribute('aria-selected', 'true')
-    expect(pastTab).toHaveAttribute('aria-selected', 'false')
-
-    // Click Past Shows → it becomes selected
-    await user.click(pastTab)
-    expect(pastTab).toHaveAttribute('aria-selected', 'true')
-    expect(upcomingTab).toHaveAttribute('aria-selected', 'false')
-
-    // Click back to Upcoming
-    await user.click(upcomingTab)
-    expect(upcomingTab).toHaveAttribute('aria-selected', 'true')
-    expect(pastTab).toHaveAttribute('aria-selected', 'false')
-  })
-})
+// PSY-644 removed ArtistShowsList's internal Upcoming/Past Radix tabs; the
+// pre-PSY-644 "switches aria-selected between upcoming and past tabs" test
+// has been retired. The new two-section structure (upcoming always visible,
+// past collapsed via `[Show]`/`[Hide]`) is covered in
+// features/artists/components/ArtistShowsList.test.tsx.

--- a/frontend/features/artists/components/ArtistDetail.tsx
+++ b/frontend/features/artists/components/ArtistDetail.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { useState } from 'react'
+import { Fragment, useState } from 'react'
 import {
   ArrowLeft,
   Loader2,
@@ -11,7 +11,6 @@ import {
   X,
   Check,
   AlertCircle,
-  Disc3,
 } from 'lucide-react'
 import { useQueryClient } from '@tanstack/react-query'
 import { useArtist } from '../hooks/useArtists'
@@ -43,6 +42,8 @@ import {
   BracketLink,
   SectionHeader,
   StatsList,
+  DenseTable,
+  DenseTableGroupHeader,
 } from '@/components/shared'
 import { ArtistTrajectoryChart } from '@/features/festivals/components/ArtistTrajectoryChart'
 import { EntityTagList } from '@/features/tags'
@@ -57,7 +58,6 @@ import { BillComposition } from './BillComposition'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Alert, AlertDescription } from '@/components/ui/alert'
-import { Badge } from '@/components/ui/badge'
 import { getReleaseTypeLabel } from '@/features/releases/types'
 import type { ArtistReleaseListItem } from '@/features/releases/types'
 import type { ArtistLabel } from '@/features/labels/types'
@@ -66,56 +66,30 @@ interface ArtistDetailProps {
   artistId: string | number
 }
 
-// --- Discography Tab ---
+// --- Discography ---
 
-interface DiscographySectionProps {
-  title: string
-  releases: ArtistReleaseListItem[]
-}
-
-function DiscographySection({ title, releases }: DiscographySectionProps) {
-  if (releases.length === 0) return null
-
-  return (
-    <div className="mb-6">
-      <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-3">
-        {title}
-      </h3>
-      <div className="space-y-2">
-        {releases.map(release => (
-          <Link
-            key={release.id}
-            href={`/releases/${release.slug}`}
-            className="flex items-center gap-3 p-2 rounded-md hover:bg-muted/50 transition-colors group"
-          >
-            <div className="w-10 h-10 bg-muted rounded flex-shrink-0 flex items-center justify-center">
-              {release.cover_art_url ? (
-                <img
-                  src={release.cover_art_url}
-                  alt={release.title}
-                  className="w-10 h-10 rounded object-cover"
-                />
-              ) : (
-                <Disc3 className="h-5 w-5 text-muted-foreground" />
-              )}
-            </div>
-            <div className="flex-1 min-w-0">
-              <p className="text-sm font-medium group-hover:text-foreground truncate">
-                {release.title}
-              </p>
-              <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
-                  {getReleaseTypeLabel(release.release_type)}
-                </Badge>
-                {release.release_year && <span>{release.release_year}</span>}
-              </div>
-            </div>
-          </Link>
-        ))}
-      </div>
-    </div>
-  )
-}
+// Gazelle-style ~10 buckets, mapped to PH's release_type + ArtistRelease.role
+// enums. "Soundtracks" from the spec's option list is dropped (no PH
+// release_type) and an "Other Releases" catch-all handles main-role rows
+// that aren't lp/ep/single/compilation (e.g. live, demo). Empty buckets
+// don't render; the whole section hides when 0 releases.
+const MAIN_NAMED_TYPES = new Set(['lp', 'ep', 'single', 'compilation'])
+const DISCOGRAPHY_BUCKETS: ReadonlyArray<{
+  key: string
+  label: string
+  match: (r: ArtistReleaseListItem) => boolean
+}> = [
+  { key: 'albums', label: 'Albums', match: r => r.role === 'main' && r.release_type === 'lp' },
+  { key: 'eps', label: 'EPs', match: r => r.role === 'main' && r.release_type === 'ep' },
+  { key: 'singles', label: 'Singles', match: r => r.role === 'main' && r.release_type === 'single' },
+  { key: 'compilations', label: 'Compilations', match: r => r.role === 'main' && r.release_type === 'compilation' },
+  { key: 'other_main', label: 'Other Releases', match: r => r.role === 'main' && !MAIN_NAMED_TYPES.has(r.release_type) },
+  { key: 'guest', label: 'Guest Appearances', match: r => r.role === 'featured' },
+  { key: 'remixes', label: 'Remixes', match: r => r.role === 'remixer' },
+  { key: 'dj', label: 'DJ Mixes', match: r => r.role === 'dj' },
+  { key: 'production', label: 'Production', match: r => r.role === 'producer' },
+  { key: 'composition', label: 'Composition', match: r => r.role === 'composer' },
+]
 
 function DiscographyTab({ artistIdOrSlug }: { artistIdOrSlug: string | number }) {
   const { data, isLoading, error } = useArtistReleases({ artistIdOrSlug })
@@ -136,45 +110,72 @@ function DiscographyTab({ artistIdOrSlug }: { artistIdOrSlug: string | number })
     )
   }
 
-  if (!data?.releases || data.releases.length === 0) {
-    return (
-      <div className="py-8 text-center text-sm text-muted-foreground">
-        No releases yet
-      </div>
-    )
-  }
+  // Hide the whole section when empty — primary content sections in the
+  // redesign hide entirely rather than render an apologetic empty state
+  // (the only exception is upcoming shows, where the empty state has an
+  // action affordance).
+  if (!data?.releases || data.releases.length === 0) return null
 
-  // Group releases by role category
-  const albumsAndEPs = data.releases.filter(
-    r => r.role === 'main' && (r.release_type === 'lp' || r.release_type === 'ep')
-  )
-  const singles = data.releases.filter(
-    r => r.role === 'main' && r.release_type === 'single'
-  )
-  const otherMain = data.releases.filter(
-    r =>
-      r.role === 'main' &&
-      r.release_type !== 'lp' &&
-      r.release_type !== 'ep' &&
-      r.release_type !== 'single'
-  )
-  const appearsOn = data.releases.filter(r => r.role === 'featured')
-  const production = data.releases.filter(
-    r =>
-      r.role === 'producer' ||
-      r.role === 'remixer' ||
-      r.role === 'composer' ||
-      r.role === 'dj'
-  )
+  const groups = DISCOGRAPHY_BUCKETS.map(b => ({
+    ...b,
+    releases: data.releases.filter(b.match),
+  })).filter(g => g.releases.length > 0)
+
+  if (groups.length === 0) return null
 
   return (
-    <div>
-      <DiscographySection title="Albums & EPs" releases={albumsAndEPs} />
-      <DiscographySection title="Singles" releases={singles} />
-      <DiscographySection title="Other Releases" releases={otherMain} />
-      <DiscographySection title="Appears On" releases={appearsOn} />
-      <DiscographySection title="Production" releases={production} />
-    </div>
+    <section>
+      <SectionHeader title="Discography" as="h2" size="md" />
+      <DenseTable variant="alternating" aria-label="Discography">
+        <thead>
+          <tr>
+            <th>Title</th>
+            <th className="text-right">Year</th>
+            <th>Type</th>
+            <th>Label</th>
+          </tr>
+        </thead>
+        <tbody>
+          {groups.map(g => (
+            <Fragment key={g.key}>
+              <DenseTableGroupHeader title={g.label} colSpan={4} />
+              {g.releases.map(r => (
+                <tr key={`${r.id}-${r.role}`}>
+                  <td>
+                    <Link
+                      href={`/releases/${r.slug}`}
+                      className="hover:text-primary underline-offset-2 hover:underline"
+                    >
+                      {r.title}
+                    </Link>
+                  </td>
+                  <td className="text-right text-muted-foreground">
+                    {r.release_year ?? '—'}
+                  </td>
+                  <td className="text-muted-foreground">
+                    {getReleaseTypeLabel(r.release_type)}
+                  </td>
+                  <td className="text-muted-foreground">
+                    {r.label_name && r.label_slug ? (
+                      <Link
+                        href={`/labels/${r.label_slug}`}
+                        className="hover:text-foreground hover:underline"
+                      >
+                        {r.label_name}
+                      </Link>
+                    ) : r.label_name ? (
+                      r.label_name
+                    ) : (
+                      '—'
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </Fragment>
+          ))}
+        </tbody>
+      </DenseTable>
+    </section>
   )
 }
 
@@ -958,18 +959,14 @@ export function ArtistDetail({ artistId }: ArtistDetailProps) {
           />
         }
       >
-        {/* Single-scroll main column — no tabs. Order follows the spec:
-            shows → discography → bills → festival trajectory → bio →
-            admin music controls → revision history → discussion.
-            (docs/features/artist-page-redesign.md) */}
         <div className="space-y-8">
-          <ArtistShowsList artistId={artist.id} />
+          <ArtistShowsList artistId={artist.id} artistName={artist.name} />
 
           <DiscographyTab artistIdOrSlug={artistId} />
 
-          <BillComposition artistId={artist.id} />
+          <BillComposition artistId={artist.id} defaultCollapsed />
 
-          <ArtistTrajectoryChart artistIdOrSlug={artist.id} />
+          <ArtistTrajectoryChart artistIdOrSlug={artist.id} defaultCollapsed />
 
           <EntityDescription
             description={artist.description}

--- a/frontend/features/artists/components/ArtistShowsList.test.tsx
+++ b/frontend/features/artists/components/ArtistShowsList.test.tsx
@@ -2,53 +2,75 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { renderWithProviders } from '@/test/utils'
-import type { ArtistShow } from '../types'
+import type { ArtistShow, ArtistTimeFilter } from '../types'
 
-// Mock the artist shows hook
-const mockUseArtistShows = vi.fn()
+// Routes useArtistShows fetches by `timeFilter` so the test fixtures for
+// upcoming vs past can be set independently.
+const upcomingResult = {
+  data: undefined as { shows: ArtistShow[]; total: number } | undefined,
+  isLoading: false,
+  error: null as Error | null,
+}
+const pastResult = {
+  data: undefined as { shows: ArtistShow[]; total: number } | undefined,
+  isLoading: false,
+  error: null as Error | null,
+}
+
 vi.mock('../hooks/useArtists', () => ({
-  useArtistShows: (opts: unknown) => mockUseArtistShows(opts),
+  useArtistShows: ({ timeFilter }: { timeFilter: ArtistTimeFilter }) =>
+    timeFilter === 'past' ? pastResult : upcomingResult,
 }))
 
-// Mock CompactShowRow to avoid pulling in its dependencies
+// Identity passthrough — dedup behavior is exercised in features/shows/utils.test.ts.
 vi.mock('@/features/shows', () => ({
-  CompactShowRow: ({
-    show,
-  }: {
-    show: { id: number; title: string }
-  }) => (
-    <div data-testid={`show-row-${show.id}`}>{show.title}</div>
-  ),
-  SHOW_LIST_FEATURE_POLICY: {
-    discovery: {
-      showDetailsLink: true,
-      showSaveButton: true,
-      showExpandMusic: true,
-      showAdminActions: true,
-      showOwnerActions: true,
-      useCompactLayout: false,
-    },
-    ownership: {
-      showDetailsLink: true,
-      showSaveButton: true,
-      showExpandMusic: false,
-      showAdminActions: true,
-      showOwnerActions: true,
-      useCompactLayout: false,
-    },
-    context: {
-      showDetailsLink: true,
-      showSaveButton: false,
-      showExpandMusic: false,
-      showAdminActions: false,
-      showOwnerActions: false,
-      useCompactLayout: true,
-    },
-  },
-  // PSY-559: render-time dedup helper. Identity passthrough in tests
-  // keeps fixtures deterministic — dedup behaviour is exercised in
-  // features/shows/utils.test.ts.
   dedupArtistShows: <T,>(shows: T[]) => shows,
+}))
+
+// Lightweight shared primitive mocks — render plain elements with the props
+// the tests care about. Real implementations are unit-tested in their own
+// files; we just need inspectable wrappers here.
+vi.mock('@/components/shared', () => ({
+  BracketLink: ({
+    label,
+    onClick,
+  }: {
+    label: string
+    onClick?: () => void
+  }) => (
+    <button data-testid={`bracket-${label}`} onClick={onClick}>
+      [{label}]
+    </button>
+  ),
+  SectionHeader: ({
+    title,
+    action,
+  }: {
+    title: string
+    action?: React.ReactNode
+  }) => (
+    <div data-testid={`section-header-${title}`}>
+      <h2>{title}</h2>
+      {action}
+    </div>
+  ),
+  DenseTable: ({
+    children,
+    'aria-label': ariaLabel,
+  }: {
+    children: React.ReactNode
+    'aria-label'?: string
+  }) => (
+    <table data-testid={`densetable-${ariaLabel ?? 'unlabeled'}`} aria-label={ariaLabel}>
+      {children}
+    </table>
+  ),
+}))
+
+vi.mock('@/features/notifications', () => ({
+  NotifyMeButton: ({ entityName }: { entityName: string }) => (
+    <button data-testid="notify-me-button">Notify me about {entityName}</button>
+  ),
 }))
 
 import { ArtistShowsList } from './ArtistShowsList'
@@ -76,155 +98,111 @@ function makeShow(overrides: Partial<ArtistShow> = {}): ArtistShow {
   }
 }
 
-describe('ArtistShowsList', () => {
+function setUpcoming(data: { shows: ArtistShow[]; total?: number } | null, opts?: { isLoading?: boolean; error?: Error | null }) {
+  upcomingResult.data = data ? { shows: data.shows, total: data.total ?? data.shows.length } : undefined
+  upcomingResult.isLoading = opts?.isLoading ?? false
+  upcomingResult.error = opts?.error ?? null
+}
+
+function setPast(data: { shows: ArtistShow[]; total?: number } | null, opts?: { isLoading?: boolean; error?: Error | null }) {
+  pastResult.data = data ? { shows: data.shows, total: data.total ?? data.shows.length } : undefined
+  pastResult.isLoading = opts?.isLoading ?? false
+  pastResult.error = opts?.error ?? null
+}
+
+describe('ArtistShowsList — upcoming section', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
-    mockUseArtistShows.mockReturnValue({
-      data: undefined,
-      isLoading: false,
-      error: null,
-    })
+    setUpcoming(null)
+    setPast(null)
   })
 
-  it('renders upcoming and past tabs', () => {
-    renderWithProviders(<ArtistShowsList artistId={42} />)
-    expect(screen.getByText('Upcoming')).toBeInTheDocument()
-    expect(screen.getByText('Past Shows')).toBeInTheDocument()
+  it('renders the Upcoming shows section header always', () => {
+    renderWithProviders(<ArtistShowsList artistId={42} artistName="Test Artist" />)
+    expect(screen.getByTestId('section-header-Upcoming shows')).toBeInTheDocument()
   })
 
-  it('defaults to the upcoming tab', () => {
-    renderWithProviders(<ArtistShowsList artistId={42} />)
-    // Upcoming tab should be active - the hook should be called with upcoming enabled
-    expect(mockUseArtistShows).toHaveBeenCalledWith(
-      expect.objectContaining({
-        timeFilter: 'upcoming',
-        enabled: true,
-      })
-    )
+  it('shows a loader while upcoming shows are loading', () => {
+    setUpcoming(null, { isLoading: true })
+    renderWithProviders(<ArtistShowsList artistId={42} artistName="Test Artist" />)
+    expect(document.querySelector('.animate-spin')).toBeInTheDocument()
   })
 
-  it('shows loading spinner when loading', () => {
-    mockUseArtistShows.mockReturnValue({
-      data: undefined,
-      isLoading: true,
-      error: null,
-    })
-
-    renderWithProviders(<ArtistShowsList artistId={42} />)
-    // The loading spinner should be present (a Loader2 with animate-spin)
-    const spinner = document.querySelector('.animate-spin')
-    expect(spinner).toBeInTheDocument()
+  it('shows an error message when the upcoming fetch fails', () => {
+    setUpcoming(null, { error: new Error('boom') })
+    renderWithProviders(<ArtistShowsList artistId={42} artistName="Test Artist" />)
+    expect(screen.getByText(/Failed to load shows/i)).toBeInTheDocument()
   })
 
-  it('shows error message on error', () => {
-    mockUseArtistShows.mockReturnValue({
-      data: undefined,
-      isLoading: false,
-      error: new Error('Failed'),
-    })
-
-    renderWithProviders(<ArtistShowsList artistId={42} />)
-    expect(screen.getByText('Failed to load shows')).toBeInTheDocument()
+  it('renders an inline [Notify me] affordance when there are no upcoming shows', () => {
+    setUpcoming({ shows: [] })
+    renderWithProviders(<ArtistShowsList artistId={42} artistName="Just Mustard" />)
+    expect(screen.getByText(/No upcoming shows yet/i)).toBeInTheDocument()
+    expect(screen.getByTestId('notify-me-button')).toHaveTextContent('Just Mustard')
   })
 
-  it('shows empty state for no upcoming shows', () => {
-    mockUseArtistShows.mockReturnValue({
-      data: { shows: [], total: 0, artist_id: 42 },
-      isLoading: false,
-      error: null,
-    })
-
-    renderWithProviders(<ArtistShowsList artistId={42} />)
-    expect(screen.getByText('No upcoming shows')).toBeInTheDocument()
+  it('renders upcoming shows as a DenseTable when data is present', () => {
+    setUpcoming({ shows: [makeShow()] })
+    renderWithProviders(<ArtistShowsList artistId={42} artistName="Test Artist" />)
+    expect(screen.getByTestId('densetable-Upcoming shows')).toBeInTheDocument()
+    expect(screen.getByText('Test Venue')).toBeInTheDocument()
   })
 
-  it('renders shows when data available', () => {
-    const shows = [
-      makeShow({ id: 1, title: 'Show One' }),
-      makeShow({ id: 2, title: 'Show Two' }),
-    ]
-    mockUseArtistShows.mockReturnValue({
-      data: { shows, total: 2, artist_id: 42 },
-      isLoading: false,
-      error: null,
-    })
-
-    renderWithProviders(<ArtistShowsList artistId={42} />)
-    expect(screen.getByTestId('show-row-1')).toBeInTheDocument()
-    expect(screen.getByTestId('show-row-2')).toBeInTheDocument()
+  it('shows the "Showing N of M" hint when results are truncated', () => {
+    setUpcoming({ shows: [makeShow()], total: 30 })
+    renderWithProviders(<ArtistShowsList artistId={42} artistName="Test Artist" />)
+    expect(screen.getByText(/Showing 1 of 30 shows/)).toBeInTheDocument()
   })
 
-  it('switches to past tab on click', async () => {
+  it('filters the current artist out of the Bill column', () => {
+    setUpcoming({ shows: [makeShow()] })
+    renderWithProviders(<ArtistShowsList artistId={42} artistName="Main Artist" />)
+    // Bill cell should mention The Opener but NOT Main Artist (artistId=42).
+    expect(screen.getByText('The Opener')).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Main Artist' })).not.toBeInTheDocument()
+  })
+})
+
+describe('ArtistShowsList — past section', () => {
+  beforeEach(() => {
+    setUpcoming(null)
+    setPast(null)
+  })
+
+  it('omits the Past shows section entirely when there are 0 past shows', () => {
+    setPast({ shows: [] })
+    renderWithProviders(<ArtistShowsList artistId={42} artistName="Test Artist" />)
+    expect(screen.queryByTestId('section-header-Past shows')).not.toBeInTheDocument()
+  })
+
+  it('renders the Past shows section header with a [Show] toggle when past shows exist', () => {
+    setPast({ shows: [makeShow({ id: 5, title: 'Past Show' })] })
+    renderWithProviders(<ArtistShowsList artistId={42} artistName="Test Artist" />)
+    expect(screen.getByTestId('section-header-Past shows')).toBeInTheDocument()
+    expect(screen.getByTestId('bracket-Show')).toBeInTheDocument()
+  })
+
+  it('past shows body is collapsed by default', () => {
+    setPast({ shows: [makeShow({ id: 5, title: 'Past Show' })] })
+    renderWithProviders(<ArtistShowsList artistId={42} artistName="Test Artist" />)
+    expect(screen.queryByTestId('densetable-Past shows')).not.toBeInTheDocument()
+  })
+
+  it('expands the past shows body when [Show] is clicked', async () => {
     const user = userEvent.setup()
-    // Return empty for both upcoming and past
-    mockUseArtistShows.mockReturnValue({
-      data: { shows: [], total: 0, artist_id: 42 },
-      isLoading: false,
-      error: null,
-    })
-
-    renderWithProviders(<ArtistShowsList artistId={42} />)
-
-    await user.click(screen.getByText('Past Shows'))
-
-    // After click, past tab hook should be called with enabled=true and upcoming with enabled=false
-    const calls = mockUseArtistShows.mock.calls
-    const lastCalls = calls.slice(-2)
-    const pastCall = lastCalls.find(
-      (c: unknown[]) => (c[0] as { timeFilter: string }).timeFilter === 'past'
-    )
-    expect(pastCall).toBeTruthy()
-    expect((pastCall![0] as { enabled: boolean }).enabled).toBe(true)
+    setPast({ shows: [makeShow({ id: 5, title: 'Past Show' })] })
+    renderWithProviders(<ArtistShowsList artistId={42} artistName="Test Artist" />)
+    await user.click(screen.getByTestId('bracket-Show'))
+    expect(screen.getByTestId('densetable-Past shows')).toBeInTheDocument()
+    // Toggle label flips to [Hide].
+    expect(screen.getByTestId('bracket-Hide')).toBeInTheDocument()
   })
 
-  it('shows count indicator when there are more shows than displayed', () => {
-    const shows = [makeShow({ id: 1, title: 'Show One' })]
-    mockUseArtistShows.mockReturnValue({
-      data: { shows, total: 25, artist_id: 42 },
-      isLoading: false,
-      error: null,
-    })
-
-    renderWithProviders(<ArtistShowsList artistId={42} />)
-    expect(screen.getByText('Showing 1 of 25 shows')).toBeInTheDocument()
-  })
-
-  it('does not show count indicator when all shows displayed', () => {
-    const shows = [makeShow({ id: 1, title: 'Show One' })]
-    mockUseArtistShows.mockReturnValue({
-      data: { shows, total: 1, artist_id: 42 },
-      isLoading: false,
-      error: null,
-    })
-
-    renderWithProviders(<ArtistShowsList artistId={42} />)
-    expect(screen.queryByText(/Showing/)).not.toBeInTheDocument()
-  })
-
-  it('shows "No past shows" empty state on past tab', async () => {
+  it('collapses again when [Hide] is clicked', async () => {
     const user = userEvent.setup()
-    mockUseArtistShows.mockReturnValue({
-      data: { shows: [], total: 0, artist_id: 42 },
-      isLoading: false,
-      error: null,
-    })
-
-    renderWithProviders(<ArtistShowsList artistId={42} />)
-    await user.click(screen.getByText('Past Shows'))
-
-    expect(screen.getByText('No past shows')).toBeInTheDocument()
-  })
-
-  it('applies custom className', () => {
-    mockUseArtistShows.mockReturnValue({
-      data: { shows: [], total: 0, artist_id: 42 },
-      isLoading: false,
-      error: null,
-    })
-
-    const { container } = renderWithProviders(
-      <ArtistShowsList artistId={42} className="custom-class" />
-    )
-    expect(container.firstChild).toHaveClass('custom-class')
+    setPast({ shows: [makeShow({ id: 5, title: 'Past Show' })] })
+    renderWithProviders(<ArtistShowsList artistId={42} artistName="Test Artist" />)
+    await user.click(screen.getByTestId('bracket-Show'))
+    await user.click(screen.getByTestId('bracket-Hide'))
+    expect(screen.queryByTestId('densetable-Past shows')).not.toBeInTheDocument()
   })
 })

--- a/frontend/features/artists/components/ArtistShowsList.tsx
+++ b/frontend/features/artists/components/ArtistShowsList.tsx
@@ -1,132 +1,225 @@
 'use client'
 
 import { useState } from 'react'
-import { Loader2, Calendar, History } from 'lucide-react'
-import { useArtistShows } from '../hooks/useArtists'
-import type { ArtistTimeFilter } from '../types'
-import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
+import Link from 'next/link'
+import { Loader2 } from 'lucide-react'
 import {
-  CompactShowRow,
-  SHOW_LIST_FEATURE_POLICY,
-  dedupArtistShows,
-} from '@/features/shows'
+  BracketLink,
+  SectionHeader,
+  DenseTable,
+} from '@/components/shared'
+import { NotifyMeButton } from '@/features/notifications'
+import { dedupArtistShows } from '@/features/shows'
+import { formatShowDate, formatShowTime } from '@/lib/utils/formatters'
+import { useArtistShows } from '../hooks/useArtists'
+import type { ArtistShow } from '../types'
 
 interface ArtistShowsListProps {
   artistId: number
+  artistName: string
   className?: string
 }
 
-interface ShowsTabContentProps {
-  artistId: number
-  timeFilter: ArtistTimeFilter
-  enabled: boolean
-}
+const TIMEZONE = Intl.DateTimeFormat().resolvedOptions().timeZone
 
-function ShowsTabContent({
-  artistId,
-  timeFilter,
-  enabled,
-}: ShowsTabContentProps) {
-  const { data, isLoading, error } = useArtistShows({
-    artistId,
-    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-    timeFilter,
-    enabled,
-    limit: 50,
-  })
-
-  if (isLoading) {
-    return (
-      <div className="flex justify-center py-8">
-        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-      </div>
-    )
-  }
-
-  if (error) {
-    return (
-      <div className="py-8 text-center text-sm text-destructive">
-        Failed to load shows
-      </div>
-    )
-  }
-
-  if (!data?.shows || data.shows.length === 0) {
-    return (
-      <div className="py-8 text-center text-sm text-muted-foreground">
-        {timeFilter === 'past' ? 'No past shows' : 'No upcoming shows'}
-      </div>
-    )
-  }
-
-  // PSY-559: Render-time dedup so duplicate shows sharing
-  // (artist_id, venue_id, event_date+time) collapse to one row even
-  // before the backend dedup cmd runs against this DB.
-  const visibleShows = dedupArtistShows(data.shows)
-  const isPastShow = timeFilter === 'past'
-
+function ShowsLoader() {
   return (
-    <div>
-      {visibleShows.map(show => {
-        const otherArtists = show.artists.filter(a => a.id !== artistId)
-        return (
-          <CompactShowRow
-            key={show.id}
-            show={show}
-            state={show.venue?.state}
-            isPastShow={isPastShow}
-            primaryLine="venue"
-            venue={show.venue}
-            secondaryArtists={otherArtists}
-            showDetailsLink={SHOW_LIST_FEATURE_POLICY.context.showDetailsLink}
-          />
-        )
-      })}
-      {data.total > visibleShows.length && (
-        <div className="text-center text-sm text-muted-foreground pt-4">
-          Showing {visibleShows.length} of {data.total} shows
-        </div>
-      )}
+    <div className="flex justify-center py-6">
+      <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
     </div>
   )
 }
 
-export function ArtistShowsList({ artistId, className }: ArtistShowsListProps) {
-  const [activeTab, setActiveTab] = useState<ArtistTimeFilter>('upcoming')
+function ShowRow({ show, artistId }: { show: ArtistShow; artistId: number }) {
+  const state = show.venue?.state ?? null
+  const otherArtists = show.artists.filter(a => a.id !== artistId)
+  const detailsHref = `/shows/${show.slug || show.id}`
+  return (
+    <tr>
+      <td className="whitespace-nowrap">
+        <Link
+          href={detailsHref}
+          className="hover:text-primary hover:underline underline-offset-2"
+        >
+          {formatShowDate(show.event_date, state)}
+        </Link>
+      </td>
+      <td>
+        {show.venue ? (
+          <span>
+            <Link
+              href={`/venues/${show.venue.slug}`}
+              className="font-medium hover:text-primary hover:underline"
+            >
+              {show.venue.name}
+            </Link>
+            <span className="text-muted-foreground">
+              {' · '}
+              {[show.venue.city, show.venue.state].filter(Boolean).join(', ')}
+            </span>
+          </span>
+        ) : (
+          <span className="text-muted-foreground">Venue TBA</span>
+        )}
+      </td>
+      <td className="text-muted-foreground">
+        {otherArtists.length > 0 ? (
+          <span>
+            <span className="italic">w/</span>{' '}
+            {otherArtists.map((a, i) => (
+              <span key={a.id}>
+                {i > 0 && ', '}
+                <Link
+                  href={`/artists/${a.slug}`}
+                  className="hover:text-foreground hover:underline"
+                >
+                  {a.name}
+                </Link>
+              </span>
+            ))}
+          </span>
+        ) : (
+          '—'
+        )}
+      </td>
+      <td className="text-right whitespace-nowrap text-muted-foreground">
+        {formatShowTime(show.event_date, state)}
+      </td>
+    </tr>
+  )
+}
+
+function ShowsTable({
+  shows,
+  total,
+  artistId,
+  isPast,
+}: {
+  shows: ArtistShow[]
+  total: number
+  artistId: number
+  isPast: boolean
+}) {
+  return (
+    <>
+      <DenseTable
+        variant="alternating"
+        aria-label={isPast ? 'Past shows' : 'Upcoming shows'}
+      >
+        <thead>
+          <tr>
+            <th>Date</th>
+            <th>Venue · Location</th>
+            <th>Bill</th>
+            <th className="text-right">Time</th>
+          </tr>
+        </thead>
+        <tbody>
+          {shows.map(show => (
+            <ShowRow key={show.id} show={show} artistId={artistId} />
+          ))}
+        </tbody>
+      </DenseTable>
+      {total > shows.length && (
+        <p className="text-xs text-muted-foreground mt-2">
+          Showing {shows.length} of {total} shows
+        </p>
+      )}
+    </>
+  )
+}
+
+/**
+ * Artist shows — two density-first sections (PSY-644).
+ *
+ * - **Upcoming shows**: always rendered. Empty state shows an inline
+ *   `[Notify me]` affordance because shows are PH's primary signal —
+ *   landing on an artist with zero upcoming shows should let the user
+ *   subscribe immediately, not get a bare "no shows yet" message.
+ * - **Past shows**: separate section, collapsed by default with a
+ *   `[Show]`/`[Hide]` toggle. The whole section hides when the artist has
+ *   zero past shows. Fetch fires eagerly on page load so the empty-section
+ *   hide can happen without an expand round-trip.
+ *
+ * Replaces the pre-PSY-644 internal Upcoming/Past Radix tabs.
+ */
+export function ArtistShowsList({
+  artistId,
+  artistName,
+  className,
+}: ArtistShowsListProps) {
+  const [pastOpen, setPastOpen] = useState(false)
+  const upcoming = useArtistShows({
+    artistId,
+    timezone: TIMEZONE,
+    timeFilter: 'upcoming',
+    enabled: true,
+    limit: 50,
+  })
+  const past = useArtistShows({
+    artistId,
+    timezone: TIMEZONE,
+    timeFilter: 'past',
+    enabled: true,
+    limit: 50,
+  })
+
+  const upcomingShows = upcoming.data?.shows
+    ? dedupArtistShows(upcoming.data.shows)
+    : []
+  const pastShows = past.data?.shows ? dedupArtistShows(past.data.shows) : []
 
   return (
     <div className={className}>
-      <Tabs
-        value={activeTab}
-        onValueChange={value => setActiveTab(value as ArtistTimeFilter)}
-      >
-        <TabsList>
-          <TabsTrigger value="upcoming" className="gap-2">
-            <Calendar className="h-4 w-4" />
-            Upcoming
-          </TabsTrigger>
-          <TabsTrigger value="past" className="gap-2">
-            <History className="h-4 w-4" />
-            Past Shows
-          </TabsTrigger>
-        </TabsList>
-
-        <TabsContent value="upcoming" className="mt-4">
-          <ShowsTabContent
+      <section>
+        <SectionHeader title="Upcoming shows" as="h2" size="md" />
+        {upcoming.isLoading ? (
+          <ShowsLoader />
+        ) : upcoming.error ? (
+          <p className="py-3 text-sm text-destructive">Failed to load shows</p>
+        ) : upcomingShows.length === 0 ? (
+          <div className="flex items-baseline gap-3 py-2 text-sm text-muted-foreground">
+            <span>No upcoming shows yet.</span>
+            <NotifyMeButton
+              entityType="artist"
+              entityId={artistId}
+              entityName={artistName}
+              variant="bracket"
+            />
+          </div>
+        ) : (
+          <ShowsTable
+            shows={upcomingShows}
+            total={upcoming.data?.total ?? upcomingShows.length}
             artistId={artistId}
-            timeFilter="upcoming"
-            enabled={activeTab === 'upcoming'}
+            isPast={false}
           />
-        </TabsContent>
+        )}
+      </section>
 
-        <TabsContent value="past" className="mt-4">
-          <ShowsTabContent
-            artistId={artistId}
-            timeFilter="past"
-            enabled={activeTab === 'past'}
+      {pastShows.length > 0 && (
+        <section className="mt-8">
+          <SectionHeader
+            title="Past shows"
+            as="h2"
+            size="md"
+            action={
+              <BracketLink
+                label={pastOpen ? 'Hide' : 'Show'}
+                onClick={() => setPastOpen(!pastOpen)}
+              />
+            }
           />
-        </TabsContent>
-      </Tabs>
+          {pastOpen && (
+            <ShowsTable
+              shows={pastShows}
+              total={past.data?.total ?? pastShows.length}
+              artistId={artistId}
+              isPast={true}
+            />
+          )}
+        </section>
+      )}
     </div>
   )
 }

--- a/frontend/features/artists/components/BillComposition.test.tsx
+++ b/frontend/features/artists/components/BillComposition.test.tsx
@@ -204,3 +204,45 @@ describe('BillComposition', () => {
     expect(screen.getByText("Hasn't opened for anyone yet.")).toBeInTheDocument()
   })
 })
+
+describe('BillComposition — defaultCollapsed (PSY-644)', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const originalResizeObserver = (window as any).ResizeObserver
+
+  beforeEach(() => {
+    setMockContainerWidth(1024)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(window as any).ResizeObserver = ImmediateResizeObserver
+  })
+
+  afterEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(window as any).ResizeObserver = originalResizeObserver
+  })
+
+  it('renders only the header with a [Show] toggle when defaultCollapsed', () => {
+    renderWithProviders(<BillComposition artistId={1} defaultCollapsed />)
+    expect(screen.getByRole('heading', { name: 'Bill composition' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Show' })).toBeInTheDocument()
+    // Stats line + opens-with rows hidden while collapsed.
+    expect(screen.queryByText(/as headliner/)).not.toBeInTheDocument()
+    expect(screen.queryByText('Frozen Soul')).not.toBeInTheDocument()
+  })
+
+  it('reveals the body when the [Show] toggle is clicked', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<BillComposition artistId={1} defaultCollapsed />)
+    await user.click(screen.getByRole('button', { name: 'Show' }))
+    expect(screen.getByText(/as headliner/)).toBeInTheDocument()
+    expect(screen.getByText('Frozen Soul')).toBeInTheDocument()
+    // Toggle label flips to [Hide].
+    expect(screen.getByRole('button', { name: 'Hide' })).toBeInTheDocument()
+  })
+
+  it('without defaultCollapsed, renders body eagerly (pre-PSY-644 behavior)', () => {
+    renderWithProviders(<BillComposition artistId={1} />)
+    expect(screen.getByText(/as headliner/)).toBeInTheDocument()
+    expect(screen.getByText('Frozen Soul')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Show' })).not.toBeInTheDocument()
+  })
+})

--- a/frontend/features/artists/components/BillComposition.tsx
+++ b/frontend/features/artists/components/BillComposition.tsx
@@ -17,18 +17,28 @@ import Link from 'next/link'
 import { Network } from 'lucide-react'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Button } from '@/components/ui/button'
+import { BracketLink } from '@/components/shared/BracketLink'
 import { useArtistBillComposition } from '../hooks/useArtistBillComposition'
 import { ArtistGraphVisualization } from './ArtistGraph'
 import type { BillCoArtist } from '../types'
 
 interface BillCompositionProps {
   artistId: number
+  /**
+   * Start collapsed (PSY-644 dense main column). Renders only the
+   * `<h2>Bill composition</h2>` header with a `[Show]`/`[Hide]` toggle until
+   * expanded. The data fetch stays eager so the existing
+   * "hide-when-below-threshold" behavior still applies — collapsed-but-empty
+   * artists still disappear entirely.
+   */
+  defaultCollapsed?: boolean
 }
 
 const GRAPH_BREAKPOINT_PX = 640
 const MIN_GRAPH_NODES = 3
 
-export function BillComposition({ artistId }: BillCompositionProps) {
+export function BillComposition({ artistId, defaultCollapsed = false }: BillCompositionProps) {
+  const [open, setOpen] = useState(!defaultCollapsed)
   const [months, setMonths] = useState<0 | 12>(0)
   const { data, isLoading } = useArtistBillComposition({ artistId, months, enabled: artistId > 0 })
   const [showGraph, setShowGraph] = useState(false)
@@ -64,68 +74,82 @@ export function BillComposition({ artistId }: BillCompositionProps) {
   return (
     <div ref={containerRefCallback} className="mt-8 px-4 md:px-0">
       <div className="flex flex-wrap items-center justify-between gap-2 mb-4">
-        <h2 className="text-lg font-semibold">Bill composition</h2>
-        <div className="flex items-center gap-2">
-          <Tabs
-            value={months === 0 ? 'all' : '12m'}
-            onValueChange={value => setMonths(value === 'all' ? 0 : 12)}
-          >
-            <TabsList>
-              <TabsTrigger value="all">All time</TabsTrigger>
-              <TabsTrigger value="12m">Last 12 months</TabsTrigger>
-            </TabsList>
-          </Tabs>
-          {graphAvailable && (
-            <Button
-              variant={showGraph ? 'default' : 'outline'}
-              size="sm"
-              onClick={() => setShowGraph(!showGraph)}
-            >
-              <Network className="h-4 w-4 mr-1.5" />
-              {showGraph ? 'Hide graph' : 'Explore graph'}
-            </Button>
+        <div className="flex items-baseline gap-3">
+          <h2 className="text-lg font-semibold">Bill composition</h2>
+          {defaultCollapsed && (
+            <BracketLink
+              label={open ? 'Hide' : 'Show'}
+              onClick={() => setOpen(!open)}
+            />
           )}
         </div>
+        {open && (
+          <div className="flex items-center gap-2">
+            <Tabs
+              value={months === 0 ? 'all' : '12m'}
+              onValueChange={value => setMonths(value === 'all' ? 0 : 12)}
+            >
+              <TabsList>
+                <TabsTrigger value="all">All time</TabsTrigger>
+                <TabsTrigger value="12m">Last 12 months</TabsTrigger>
+              </TabsList>
+            </Tabs>
+            {graphAvailable && (
+              <Button
+                variant={showGraph ? 'default' : 'outline'}
+                size="sm"
+                onClick={() => setShowGraph(!showGraph)}
+              >
+                <Network className="h-4 w-4 mr-1.5" />
+                {showGraph ? 'Hide graph' : 'Explore graph'}
+              </Button>
+            )}
+          </div>
+        )}
       </div>
 
-      <p className="text-sm text-muted-foreground mb-4">
-        {data.stats.total_shows} {data.stats.total_shows === 1 ? 'show' : 'shows'}
-        {' · '}
-        {data.stats.headliner_count} as headliner
-        {' · '}
-        {data.stats.opener_count} as opener
-      </p>
+      {open && (
+        <>
+          <p className="text-sm text-muted-foreground mb-4">
+            {data.stats.total_shows} {data.stats.total_shows === 1 ? 'show' : 'shows'}
+            {' · '}
+            {data.stats.headliner_count} as headliner
+            {' · '}
+            {data.stats.opener_count} as opener
+          </p>
 
-      {showGraph && graphAvailable && (
-        <div className="mb-6">
-          <ArtistGraphVisualization
-            data={data.graph}
-            activeTypes={new Set(['shared_bills'])}
-            containerWidth={containerWidth!}
-          />
-        </div>
+          {showGraph && graphAvailable && (
+            <div className="mb-6">
+              <ArtistGraphVisualization
+                data={data.graph}
+                activeTypes={new Set(['shared_bills'])}
+                containerWidth={containerWidth!}
+              />
+            </div>
+          )}
+
+          <div className="grid md:grid-cols-2 gap-6">
+            <BillCoArtistTable
+              title="Opens with"
+              rows={data.opens_with}
+              emptyText={
+                months === 12
+                  ? 'No opening acts in the last 12 months.'
+                  : "Hasn't shared a bill with an opening act yet."
+              }
+            />
+            <BillCoArtistTable
+              title="Closes with"
+              rows={data.closes_with}
+              emptyText={
+                months === 12
+                  ? "Hasn't opened for anyone in the last 12 months."
+                  : "Hasn't opened for anyone yet."
+              }
+            />
+          </div>
+        </>
       )}
-
-      <div className="grid md:grid-cols-2 gap-6">
-        <BillCoArtistTable
-          title="Opens with"
-          rows={data.opens_with}
-          emptyText={
-            months === 12
-              ? 'No opening acts in the last 12 months.'
-              : "Hasn't shared a bill with an opening act yet."
-          }
-        />
-        <BillCoArtistTable
-          title="Closes with"
-          rows={data.closes_with}
-          emptyText={
-            months === 12
-              ? "Hasn't opened for anyone in the last 12 months."
-              : "Hasn't opened for anyone yet."
-          }
-        />
-      </div>
     </div>
   )
 }

--- a/frontend/features/festivals/components/ArtistTrajectoryChart.test.tsx
+++ b/frontend/features/festivals/components/ArtistTrajectoryChart.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders } from '@/test/utils'
+import type { ArtistTrajectory } from '../types'
+
+const mockUseTrajectory = vi.fn()
+vi.mock('../hooks/useFestivals', () => ({
+  useArtistFestivalTrajectory: (opts: unknown) => mockUseTrajectory(opts),
+}))
+
+import { ArtistTrajectoryChart } from './ArtistTrajectoryChart'
+
+function makeTrajectory(overrides: Partial<ArtistTrajectory> = {}): ArtistTrajectory {
+  return {
+    artist: { id: 1, name: 'Test Artist', slug: 'test-artist' },
+    appearances: [
+      { festival_slug: 'sxsw-2024', festival_name: 'SXSW 2024', year: 2024, tier: 'mid_card' },
+      { festival_slug: 'pitchfork-2023', festival_name: 'Pitchfork 2023', year: 2023, tier: 'opener' },
+    ],
+    best_tier: 'mid_card',
+    total_appearances: 2,
+    breakout_score: 0.5,
+    ...overrides,
+  }
+}
+
+describe('ArtistTrajectoryChart', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns null when the artist has no festival appearances', () => {
+    mockUseTrajectory.mockReturnValue({ data: null, isLoading: false })
+    const { container } = renderWithProviders(
+      <ArtistTrajectoryChart artistIdOrSlug={1} />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders the chart with header + appearances when data is present', () => {
+    mockUseTrajectory.mockReturnValue({
+      data: makeTrajectory(),
+      isLoading: false,
+    })
+    renderWithProviders(<ArtistTrajectoryChart artistIdOrSlug={1} />)
+    expect(screen.getByText('Festival History')).toBeInTheDocument()
+    expect(screen.getByText('SXSW 2024')).toBeInTheDocument()
+    expect(screen.getByText('Pitchfork 2023')).toBeInTheDocument()
+  })
+
+  it('renders the header with a [Show] toggle when defaultCollapsed and body is hidden', () => {
+    mockUseTrajectory.mockReturnValue({
+      data: makeTrajectory(),
+      isLoading: false,
+    })
+    renderWithProviders(
+      <ArtistTrajectoryChart artistIdOrSlug={1} defaultCollapsed />
+    )
+    expect(screen.getByText('Festival History')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Show' })).toBeInTheDocument()
+    expect(screen.queryByText('SXSW 2024')).not.toBeInTheDocument()
+  })
+
+  it('reveals the body when [Show] is clicked in collapsed mode', async () => {
+    const user = userEvent.setup()
+    mockUseTrajectory.mockReturnValue({
+      data: makeTrajectory(),
+      isLoading: false,
+    })
+    renderWithProviders(
+      <ArtistTrajectoryChart artistIdOrSlug={1} defaultCollapsed />
+    )
+    await user.click(screen.getByRole('button', { name: 'Show' }))
+    expect(screen.getByText('SXSW 2024')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Hide' })).toBeInTheDocument()
+  })
+
+  it('still hides the entire component when collapsed and there are no appearances', () => {
+    mockUseTrajectory.mockReturnValue({ data: null, isLoading: false })
+    const { container } = renderWithProviders(
+      <ArtistTrajectoryChart artistIdOrSlug={1} defaultCollapsed />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/frontend/features/festivals/components/ArtistTrajectoryChart.tsx
+++ b/frontend/features/festivals/components/ArtistTrajectoryChart.tsx
@@ -1,43 +1,36 @@
 'use client'
 
+import { useState } from 'react'
 import Link from 'next/link'
 import { Loader2, TrendingUp, Minus } from 'lucide-react'
+import { BracketLink } from '@/components/shared/BracketLink'
 import { useArtistFestivalTrajectory } from '../hooks/useFestivals'
 import { getBillingTierLabel, getTierBarWidth } from '../types'
+import type { ArtistTrajectory } from '../types'
 
 interface ArtistTrajectoryChartProps {
   artistIdOrSlug: string | number
   enabled?: boolean
+  /**
+   * Start collapsed (PSY-644 dense main column). Renders the header with a
+   * `[Show]`/`[Hide]` toggle; the body renders only when expanded. The data
+   * fetch stays eager (matches the pre-PSY-644 behavior and the established
+   * sidebar/main-column pattern); when there's no festival history the
+   * component returns null so the section disappears entirely.
+   */
+  defaultCollapsed?: boolean
 }
 
-export function ArtistTrajectoryChart({ artistIdOrSlug, enabled = true }: ArtistTrajectoryChartProps) {
-  const { data, isLoading } = useArtistFestivalTrajectory({
-    artistIdOrSlug,
-    enabled,
-  })
-
-  if (isLoading) {
-    return (
-      <div className="flex justify-center py-4">
-        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
-      </div>
-    )
-  }
-
-  if (!data || data.total_appearances === 0) {
-    return null
-  }
-
+function ChartBody({ data }: { data: ArtistTrajectory }) {
   const isRising = data.breakout_score > 0
-
   return (
-    <div>
-      <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-3">
-        Festival History
-      </h3>
+    <>
       <div className="space-y-2">
-        {data.appearances.map((entry) => (
-          <div key={`${entry.festival_slug}-${entry.year}`} className="flex items-center gap-3">
+        {data.appearances.map(entry => (
+          <div
+            key={`${entry.festival_slug}-${entry.year}`}
+            className="flex items-center gap-3"
+          >
             <span className="text-xs text-muted-foreground w-10 text-right tabular-nums">
               {entry.year}
             </span>
@@ -77,6 +70,56 @@ export function ArtistTrajectoryChart({ artistIdOrSlug, enabled = true }: Artist
           )}
         </div>
       )}
+    </>
+  )
+}
+
+export function ArtistTrajectoryChart({
+  artistIdOrSlug,
+  enabled = true,
+  defaultCollapsed = false,
+}: ArtistTrajectoryChartProps) {
+  const [open, setOpen] = useState(!defaultCollapsed)
+  const { data, isLoading } = useArtistFestivalTrajectory({
+    artistIdOrSlug,
+    enabled,
+  })
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-4">
+        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  if (!data || data.total_appearances === 0) {
+    return null
+  }
+
+  if (defaultCollapsed) {
+    return (
+      <div>
+        <div className="flex items-baseline justify-between gap-2 mb-2">
+          <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+            Festival History
+          </h2>
+          <BracketLink
+            label={open ? 'Hide' : 'Show'}
+            onClick={() => setOpen(!open)}
+          />
+        </div>
+        {open && <ChartBody data={data} />}
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-3">
+        Festival History
+      </h2>
+      <ChartBody data={data} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Slice B of 3 in the artist-page redesign (slice A merged as #633; slice C — PSY-645 — moves RelatedArtists into the sidebar). Spec: `docs/features/artist-page-redesign.md`.

- **Discography → 10-bucket grouped `DenseTable`.** A `DISCOGRAPHY_BUCKETS` registry maps PH's `release_type` + `ArtistRelease.role` enums to: Albums / EPs / Singles / Compilations / Other Releases (catch-all for main-role live/demo) / Guest Appearances / Remixes / DJ Mixes / Production / Composition. Empty buckets and the empty whole section hide entirely (replaces the pre-PSY-644 "No releases yet" message).
- **Shows → two density-first sections.** Drops `ArtistShowsList`'s internal Upcoming/Past Radix tabs. Upcoming always visible; Past collapsed by default via `[Show]`/`[Hide]`, hides entirely when 0. Inline `<ShowRow>` renders a `DenseTable` row (Date · Venue · Bill · Time). Empty upcoming renders an inline `[Notify me]` affordance — shows are PH's primary signal, so don't hide.
- **`BillComposition` + `ArtistTrajectoryChart`** each gain an additive `defaultCollapsed?: boolean` prop. The artist-page main column passes it; other callers (none today) see unchanged behaviour. Fetch stays eager so the existing hide-when-empty / below-threshold logic still applies.
- **`RevisionHistory` is already a collapsed-by-default accordion** — left as-is, no double-wrap.

## Notable scoping decisions

- **`release_type == 'remix'` for a main-role artist currently falls into "Other Releases"** (the Remixes bucket is gated on `role === 'remixer'`). Gazelle historically treats both as Remixes. Flagged for product decision — should `match: r => r.role === 'remixer' || (r.role === 'main' && r.release_type === 'remix')`? Trivial to change once decided.
- **Two `useArtistShows` fetches per page load** (upcoming + past). Past is eager so the "hide section when 0 past shows" check happens without an expand round-trip. Reviewer confirmed cheap (~4 indexed queries; `show_artists.artist_id` is the hot lookup).
- **Per-row `Intl.DateTimeFormat` constructions** noted as a project-wide micro-cost worth caching in `lib/utils/timeUtils.ts` — out of slice B scope, follow-up if profiler warrants.
- **`useCollapsible` hook extraction deferred.** `BillComposition` + `ArtistTrajectoryChart` share the same 3-line `useState(!defaultCollapsed)` pattern; a reviewer flagged `CollectionDetail.tsx` as a third candidate. Worth a tiny follow-up ticket but out of slice B's mandate.

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun run test:run features/artists features/festivals/components/ArtistTrajectoryChart components/shared` — 524 pass (new: 12 ArtistShowsList, 5 ArtistTrajectoryChart, 3 BillComposition `defaultCollapsed`)
- [x] `/simplify` run — 5 findings applied (use `formatShowDate` instead of assembling `formatShowDateBadge` parts; extract `<ShowRow>` sub-component; promote ArtistTrajectoryChart `<h3>` → `<h2>` for main-column hierarchy consistency; drop redundant `|| 'AZ'` callsite fallback — helpers default internally; delete change-narrative comment)
- [x] Manual repro vs running dev servers: `just-mustard` artist page now shows ~11 shows in a DenseTable (vs 4–5 in the old card layout); Past Shows correctly collapsed; Bill composition / Festival History correctly hidden (below_threshold / no festival data); discography section correctly hidden for artists with no releases.

Closes PSY-644

🤖 Generated with [Claude Code](https://claude.com/claude-code)