### PR TITLE
PSY-659: fix E2E artist-detail tabs → headings after PSY-644 refactor

### DIFF
--- a/frontend/e2e/pages/artist-detail.spec.ts
+++ b/frontend/e2e/pages/artist-detail.spec.ts
@@ -34,10 +34,14 @@ test.describe('Artist detail', () => {
     const breadcrumbNav = page.locator('nav[aria-label="Breadcrumb"]')
     await expect(breadcrumbNav.getByRole('link', { name: 'Artists' })).toBeVisible()
 
-    // Upcoming and Past Shows tabs (nested inside the Overview tab content)
-    await expect(page.getByRole('tab', { name: /upcoming/i })).toBeVisible()
+    // Upcoming and Past shows sections — PSY-644 replaced the Radix `<Tabs>`
+    // in ArtistShowsList with `<SectionHeader as="h2">` rendering ("Past shows"
+    // heading is always present as the collapsible's trigger).
     await expect(
-      page.getByRole('tab', { name: /past shows/i })
+      page.getByRole('heading', { name: /upcoming shows/i })
+    ).toBeVisible()
+    await expect(
+      page.getByRole('heading', { name: /past shows/i })
     ).toBeVisible()
   })
 


### PR DESCRIPTION
## Summary
- PSY-644 (PR #635) replaced the Radix `<Tabs>` UI in `ArtistShowsList` with `<SectionHeader as="h2">` (inline comment at `frontend/features/artists/components/ArtistShowsList.tsx:144` says it explicitly).
- `e2e/pages/artist-detail.spec.ts:37-41` still asserted on `getByRole('tab', ...)` — selectors that no longer exist. Failure inherited by PSY-641, PSY-644, PSY-645 merges (main red for 3 consecutive runs on `e2e/pages/artist-detail.spec.ts:5 › Artist detail › displays artist information with shows tabs`).
- Swap to `getByRole('heading', { name: /upcoming shows/i })` + the matching `/past shows/i` heading. "Past shows" heading is always rendered (as the collapsible's trigger), so the assertion holds without exercising the collapse state.

## Test plan
- [x] `cd frontend && bun run typecheck` — clean
- [ ] Local E2E run skipped — port 8080 occupied by a residual dev backend from a parallel session; CI will verify end-to-end

## Manual repro
E2E selector swap; the assertion outcome IS the manual repro. CI on this PR will report 6 passed (or whatever the artist-detail spec's pass count is) against the new ArtistShowsList structure. Pre-fix CI evidence: https://github.com/mtrifilo/psychic-homily-web/actions (most recent main run before this PR — failing on shard 3).

## Scope check
`venue-detail.spec.ts:37-41` has the identical assertion pattern but is intentionally LEFT UNCHANGED — `VenueShowsList.tsx` still uses Radix `<Tabs>` (`frontend/features/venues/components/VenueShowsList.tsx:7` imports + lines 116-122 `<TabsTrigger>`), so the venue spec continues to pass. Only the artist surface was refactored in PSY-644.

## Simplify
Ran `/simplify` — three reviewers (reuse / quality / efficiency). Reuse + quality reported clean. Efficiency reviewer was a false positive (conflated artist-detail and venue-detail specs). No changes.

Closes PSY-659