### PR TITLE
PSY-654: EntityTagList hide-when-empty + [Add tag] in header linkbox

### DIFF
--- a/frontend/features/artists/components/ArtistDetail.test.tsx
+++ b/frontend/features/artists/components/ArtistDetail.test.tsx
@@ -385,6 +385,21 @@ describe('ArtistDetail', () => {
       expect(screen.getByTestId('bracket-Edit')).toBeInTheDocument()
     })
 
+    it('shows the [Add tag] bracket link for authenticated users (PSY-654)', () => {
+      mockUseIsAuthenticated.mockReturnValue({
+        user: { is_admin: false },
+        isAuthenticated: true,
+        isLoading: false,
+      })
+      renderWithProviders(<ArtistDetail artistId="test-artist" />)
+      expect(screen.getByTestId('bracket-Add tag')).toBeInTheDocument()
+    })
+
+    it('does not show the [Add tag] bracket link for unauthenticated users', () => {
+      renderWithProviders(<ArtistDetail artistId="test-artist" />)
+      expect(screen.queryByTestId('bracket-Add tag')).not.toBeInTheDocument()
+    })
+
     it('renders artist shows list', () => {
       renderWithProviders(<ArtistDetail artistId="test-artist" />)
       expect(screen.getByTestId('artist-shows-list')).toBeInTheDocument()

--- a/frontend/features/artists/components/ArtistDetail.tsx
+++ b/frontend/features/artists/components/ArtistDetail.tsx
@@ -46,7 +46,7 @@ import {
   DenseTableGroupHeader,
 } from '@/components/shared'
 import { ArtistTrajectoryChart } from '@/features/festivals/components/ArtistTrajectoryChart'
-import { EntityTagList } from '@/features/tags'
+import { EntityTagList, AddTagDialog } from '@/features/tags'
 import { EntityEditDrawer, EntitySaveSuccessBanner, useEntitySaveSuccessBanner, AttributionLine, ReportEntityDialog, ContributionPrompt } from '@/features/contributions'
 import { AsHeardOn } from '@/features/radio'
 import { EntityCollections } from '@/features/collections'
@@ -316,10 +316,9 @@ function ArtistSidebar({
         onOpenGraph={onOpenGraph}
       />
 
-      {/* Tags — EntityTagList renders its own header + empty state. Not
-          wrapped in SectionHeader (it owns its header); its "No tags yet"
-          empty state is left for PSY-643 (empty-state audit), since fixing
-          it means touching a component shared by 4 other entity pages. */}
+      {/* Tags — EntityTagList renders its own header. PSY-654 hides the
+          whole component when no tags exist; the [Add tag] linkbox entry
+          below owns the affordance for tagless artists. */}
       <EntityTagList
         entityType="artist"
         entityId={artist.id}
@@ -829,6 +828,7 @@ export function ArtistDetail({ artistId }: ArtistDetailProps) {
   const [isEditing, setIsEditing] = useState(false)
   const [editFocusField, setEditFocusField] = useState<string | undefined>()
   const [isReportOpen, setIsReportOpen] = useState(false)
+  const [addTagDialogOpen, setAddTagDialogOpen] = useState(false)
   // Graph Dialog open state — reactive to the `#graph` URL hash (PSY-361
   // shareable graph URLs still work) AND user toggles (header [Graph] link,
   // sidebar [Explore graph], close button). User intent sticks once set.
@@ -941,6 +941,12 @@ export function ArtistDetail({ artistId }: ArtistDetailProps) {
         <BracketLink
           label={canEditDirectly ? 'Edit' : 'Suggest edit'}
           onClick={() => setIsEditing(true)}
+        />
+      )}
+      {isAuthenticated && (
+        <BracketLink
+          label="Add tag"
+          onClick={() => setAddTagDialogOpen(true)}
         />
       )}
       <BracketLink label="Graph" onClick={openGraphDialog} />
@@ -1076,6 +1082,15 @@ export function ArtistDetail({ artistId }: ArtistDetailProps) {
           entityType="artist"
           entityId={artist.id}
           entityName={artist.name}
+        />
+      )}
+
+      {isAuthenticated && (
+        <AddTagDialog
+          entityType="artist"
+          entityId={artist.id}
+          open={addTagDialogOpen}
+          onOpenChange={setAddTagDialogOpen}
         />
       )}
     </>

--- a/frontend/features/tags/components/EntityTagList.test.tsx
+++ b/frontend/features/tags/components/EntityTagList.test.tsx
@@ -139,7 +139,7 @@ vi.mock('@/lib/context/AuthContext', () => ({
   }),
 }))
 
-import { EntityTagList } from './EntityTagList'
+import { EntityTagList, AddTagDialog } from './EntityTagList'
 
 describe('EntityTagList add-tag dialog accessibility', () => {
   beforeEach(() => {
@@ -1180,12 +1180,12 @@ describe('EntityTagList mobile collapsible Sheet', () => {
   })
 })
 
-// PSY-481: zero-tag entities used to render nothing (early-return), which
-// hid the entire TAGS section + add CTA on every untagged entity. The
-// wrapper now always renders so logged-out users see a muted empty-state
-// line and logged-in users get a "+ Add the first tag" CTA — the cheapest
-// possible widening of the contributor funnel on sparse entities.
-describe('EntityTagList zero-tag empty state (PSY-481)', () => {
+// PSY-654: hide-when-empty supersedes the PSY-481 muted empty-state.
+// The audit found the always-on TAGS heading + empty CTA was the highest-
+// volume empty-state surface — visible on every untagged entity across 5
+// pages. Policy is now: render nothing when tags.length === 0; the
+// per-page bracket linkbox owns the [Add tag] affordance.
+describe('EntityTagList zero-tag hide-when-empty (PSY-654)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     currentMockTags = { tags: [] }
@@ -1194,83 +1194,47 @@ describe('EntityTagList zero-tag empty state (PSY-481)', () => {
     mockAddMutationError = null
   })
 
-  it('renders the TAGS heading + muted empty state for logged-out users (no CTA)', () => {
-    renderWithProviders(
+  it('renders nothing for logged-out users on a zero-tag entity', () => {
+    const { container } = renderWithProviders(
       <EntityTagList entityType="venue" entityId={1} isAuthenticated={false} />
     )
 
-    // The heading is now always rendered — confirms the wrapper no longer
-    // disappears on (zero tags + logged-out).
+    expect(container).toBeEmptyDOMElement()
     expect(
-      screen.getByRole('heading', { level: 3, name: /tags/i })
-    ).toBeInTheDocument()
-
-    // Muted empty-state line is visible.
-    const empty = screen.getByTestId('entity-tag-list-empty')
-    expect(empty).toHaveTextContent('No tags yet.')
-
-    // No add affordance for anonymous visitors — neither the heading-row
-    // chip nor the empty-state CTA.
-    expect(
-      screen.queryByRole('button', { name: 'Add tag' })
+      screen.queryByRole('heading', { level: 3, name: /tags/i })
     ).not.toBeInTheDocument()
+    expect(
+      screen.queryByTestId('entity-tag-list-empty')
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders nothing for logged-in users on a zero-tag entity', () => {
+    const { container } = renderWithProviders(
+      <EntityTagList entityType="venue" entityId={1} isAuthenticated />
+    )
+
+    // The per-page bracket linkbox owns the [Add tag] affordance —
+    // EntityTagList no longer renders its own empty-state CTA.
+    expect(container).toBeEmptyDOMElement()
     expect(
       screen.queryByTestId('entity-tag-list-empty-add-cta')
     ).not.toBeInTheDocument()
-  })
-
-  it('renders the "+ Add the first tag" CTA for logged-in users on a zero-tag entity', () => {
-    renderWithProviders(
-      <EntityTagList entityType="venue" entityId={1} isAuthenticated />
-    )
-
-    // Heading + muted line still render.
     expect(
-      screen.getByRole('heading', { level: 3, name: /tags/i })
-    ).toBeInTheDocument()
-    expect(screen.getByTestId('entity-tag-list-empty')).toHaveTextContent(
-      'No tags yet.'
-    )
-
-    // The CTA is visible with both the testid and an accessible aria-label
-    // so the funnel-widening signal can be analytics-tracked separately
-    // from the always-on heading-row "Add" chip.
-    const cta = screen.getByTestId('entity-tag-list-empty-add-cta')
-    expect(cta).toBeInTheDocument()
-    expect(cta).toHaveAttribute('aria-label', 'Add the first tag')
-    expect(cta).toHaveTextContent(/Add the first tag/i)
+      screen.queryByRole('button', { name: /add the first tag/i })
+    ).not.toBeInTheDocument()
   })
 
-  it('opens the add-tag dialog when the "+ Add the first tag" CTA is clicked', async () => {
-    const user = userEvent.setup()
-    renderWithProviders(
-      <EntityTagList entityType="venue" entityId={1} isAuthenticated />
-    )
-
-    await user.click(screen.getByTestId('entity-tag-list-empty-add-cta'))
-
-    // The same Add Tag dialog instance opens — proves the empty-state CTA
-    // shares the existing portal/state and doesn't fork the dialog tree.
-    await waitFor(() => {
-      expect(screen.getByRole('dialog')).toBeInTheDocument()
-    })
-    expect(screen.getByText('Add Tag')).toBeInTheDocument()
-  })
-
-  it('does not render the empty-state pill row when at least one tag exists', () => {
+  it('renders the section when at least one tag exists', () => {
     currentMockTags = mockEntityTags // 2 tags
     renderWithProviders(
       <EntityTagList entityType="artist" entityId={1} isAuthenticated />
     )
 
-    // Empty-state container is suppressed once any tag is applied — keeps
-    // the rich-tag layout untouched on entities like festival viva-phx-2026
-    // and artist faetooth.
+    expect(
+      screen.getByRole('heading', { level: 3, name: /tags/i })
+    ).toBeInTheDocument()
     expect(
       screen.queryByTestId('entity-tag-list-empty')
-    ).not.toBeInTheDocument()
-    expect(
-      screen.queryByTestId('entity-tag-list-empty-add-cta')
     ).not.toBeInTheDocument()
   })
 })
@@ -1529,5 +1493,91 @@ describe('EntityTagList tag pill two-tap on touch devices (PSY-498)', () => {
     } finally {
       document.removeEventListener('click', docListener)
     }
+  })
+})
+
+// PSY-654: AddTagDialog is the standalone Dialog wrapper consumed by per-page
+// bracket linkboxes (ArtistDetail [Add tag], and later PSY-655–658). It mirrors
+// the dialog EntityTagList opens via its internal "+ Add" chip, but is
+// controllable from outside so a tagless entity can still expose the
+// affordance after EntityTagList itself hides.
+describe('AddTagDialog standalone (PSY-654)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    currentMockTags = { tags: [] }
+    currentMockSearchTags = defaultMockSearchTags
+    mockAuthUser = { user_tier: 'contributor' }
+    mockAddMutationError = null
+  })
+
+  it('renders nothing when open is false', () => {
+    renderWithProviders(
+      <AddTagDialog
+        entityType="artist"
+        entityId={1}
+        open={false}
+        onOpenChange={vi.fn()}
+      />
+    )
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(screen.queryByText('Add Tag')).not.toBeInTheDocument()
+  })
+
+  it('renders the Add Tag dialog when open', () => {
+    renderWithProviders(
+      <AddTagDialog
+        entityType="artist"
+        entityId={1}
+        open={true}
+        onOpenChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByText('Add Tag')).toBeInTheDocument()
+  })
+
+  it('calls onOpenChange(false) after a successful add', async () => {
+    const onOpenChange = vi.fn()
+    const user = userEvent.setup()
+    // The default mock returns 'punk' for any search; override to empty so
+    // the form surfaces the Create button instead of an existing match.
+    currentMockSearchTags = { tags: [] }
+    // Make the mutation invoke the onSuccess callback so AddTagDialog can
+    // close itself the same way EntityTagList's internal dialog does.
+    mockAddMutate.mockImplementation(
+      (
+        _vars: unknown,
+        opts?: { onSuccess?: () => void }
+      ) => {
+        opts?.onSuccess?.()
+      }
+    )
+
+    renderWithProviders(
+      <AddTagDialog
+        entityType="artist"
+        entityId={1}
+        open={true}
+        onOpenChange={onOpenChange}
+      />
+    )
+
+    // Type a tag name + click Create using the form the dialog renders.
+    const input = screen.getByPlaceholderText('Search tags or type a new one...')
+    await user.type(input, 'doom')
+
+    await waitFor(() => {
+      expect(screen.getByText('No matching tags found.')).toBeInTheDocument()
+    })
+
+    await user.click(
+      screen.getByRole('button', { name: /Create "doom"/ })
+    )
+
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false)
+    })
   })
 })

--- a/frontend/features/tags/components/EntityTagList.tsx
+++ b/frontend/features/tags/components/EntityTagList.tsx
@@ -44,6 +44,45 @@ interface EntityTagListProps {
   isAuthenticated?: boolean
 }
 
+/**
+ * Controlled add-tag Dialog. Pages can mount this at page level so a header
+ * `[Add tag]` BracketLink (or any other affordance) can trigger the add flow
+ * even when `EntityTagList` is hidden (PSY-654 hides the list on tagless
+ * entities). Fetches existing tag IDs via `useEntityTags` — same query key as
+ * the list, so it cache-hits when both are mounted.
+ */
+export interface AddTagDialogProps {
+  entityType: string
+  entityId: number
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function AddTagDialog({
+  entityType,
+  entityId,
+  open,
+  onOpenChange,
+}: AddTagDialogProps) {
+  const { data } = useEntityTags(entityType, entityId)
+  const existingTagIds = (data?.tags ?? []).map(t => t.tag_id)
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md" aria-describedby={undefined}>
+        <DialogHeader>
+          <DialogTitle>Add Tag</DialogTitle>
+        </DialogHeader>
+        <AddTagForm
+          entityType={entityType}
+          entityId={entityId}
+          existingTagIds={existingTagIds}
+          onSuccess={() => onOpenChange(false)}
+        />
+      </DialogContent>
+    </Dialog>
+  )
+}
+
 // Desktop collapses after 5 pills (preserves pre-PSY-460 behavior). Mobile
 // collapses much earlier and defers the rest to a Sheet — 3 pills is the
 // sweet spot at 320-414px where a typical pill (~60-120px wide including
@@ -84,16 +123,10 @@ export function EntityTagList({ entityType, entityId, isAuthenticated }: EntityT
     )
   }
 
-  // PSY-481: previously this returned null for the (zero tags + logged-out)
-  // case, which hid the entire TAGS section on every untagged entity. The
-  // wrapper now always renders so:
-  //   • logged-out users see a muted "No tags yet." one-liner — they get a
-  //     visible signal that tagging is supported on this entity, and the
-  //     detail-page layout no longer collapses on sparse entities.
-  //   • logged-in users see the same empty-state line plus a
-  //     "+ Add the first tag" CTA that opens the existing add-tag dialog
-  //     (the existing-tag application path works for every tier; only
-  //     creating brand-new tag terms is gated — PSY-483).
+  // Hide the section on tagless entities; the per-page header linkbox owns
+  // the [Add tag] affordance via the exported `<AddTagDialog>`.
+  if (tags.length === 0) return null
+
   const handleVote = (tag: EntityTag, isUpvote: boolean) => {
     if (!isAuthenticated) return
     const currentVote = tag.user_vote ?? 0
@@ -150,93 +183,66 @@ export function EntityTagList({ entityType, entityId, isAuthenticated }: EntityT
 
       {addTagDialog}
 
-      {tags.length === 0 ? (
-        // PSY-481 — render an empty-state row that reads as a muted one-liner
-        // for logged-out users and adds a visible "+ Add the first tag" CTA
-        // for logged-in users. The CTA reuses the same Dialog instance as the
-        // chip next to the heading, so there's only ever one Radix portal.
-        <div
-          className="flex flex-wrap items-center gap-2"
-          data-testid="entity-tag-list-empty"
-        >
-          <p className="text-sm text-muted-foreground">No tags yet.</p>
-          {isAuthenticated && (
-            <button
-              onClick={() => setAddDialogOpen(true)}
-              data-testid="entity-tag-list-empty-add-cta"
-              className="inline-flex items-center gap-1 rounded-full border border-dashed border-border px-2.5 py-1 text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
-              aria-label="Add the first tag"
-            >
-              <Plus className="h-3 w-3" />
-              Add the first tag
-            </button>
-          )}
-        </div>
-      ) : (
-        <>
-          {/* Mobile: first N pills + "Show all" chip that opens a Sheet.
-              Hidden at >=sm where the desktop top-5 cap takes over. */}
-          <div
-            className="flex flex-wrap gap-2 items-center sm:hidden"
-            data-testid="entity-tag-list-mobile-row"
+      {/* Mobile: first N pills + "Show all" chip that opens a Sheet.
+          Hidden at >=sm where the desktop top-5 cap takes over. */}
+      <div
+        className="flex flex-wrap gap-2 items-center sm:hidden"
+        data-testid="entity-tag-list-mobile-row"
+      >
+        {mobileVisibleTags.map(tag => (
+          <TagWithVotes
+            key={tag.tag_id}
+            tag={tag}
+            isAuthenticated={isAuthenticated}
+            onVote={handleVote}
+          />
+        ))}
+        {hasMoreMobile && (
+          <button
+            onClick={() => setSheetOpen(true)}
+            data-testid="entity-tag-list-mobile-show-all"
+            className="inline-flex items-center gap-1 rounded-full border border-dashed border-border px-2.5 py-1 text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+            aria-label={`Show all ${sortedTags.length} tags`}
           >
-            {mobileVisibleTags.map(tag => (
-              <TagWithVotes
-                key={tag.tag_id}
-                tag={tag}
-                isAuthenticated={isAuthenticated}
-                onVote={handleVote}
-              />
-            ))}
-            {hasMoreMobile && (
-              <button
-                onClick={() => setSheetOpen(true)}
-                data-testid="entity-tag-list-mobile-show-all"
-                className="inline-flex items-center gap-1 rounded-full border border-dashed border-border px-2.5 py-1 text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
-                aria-label={`Show all ${sortedTags.length} tags`}
-              >
-                <MoreHorizontal className="h-3 w-3" />
-                Show all tags ({hiddenMobileCount} more)
-              </button>
-            )}
-          </div>
+            <MoreHorizontal className="h-3 w-3" />
+            Show all tags ({hiddenMobileCount} more)
+          </button>
+        )}
+      </div>
 
-          {/* Desktop: unchanged from pre-PSY-460 — top 5 with inline
-              expand/collapse. Hidden on narrow viewports where the Sheet
-              flow takes over. */}
-          <div
-            className="hidden sm:flex flex-wrap gap-2 items-center"
-            data-testid="entity-tag-list-desktop-row"
+      {/* Desktop: top 5 with inline expand/collapse. Hidden on narrow
+          viewports where the Sheet flow takes over. */}
+      <div
+        className="hidden sm:flex flex-wrap gap-2 items-center"
+        data-testid="entity-tag-list-desktop-row"
+      >
+        {desktopVisibleTags.map(tag => (
+          <TagWithVotes
+            key={tag.tag_id}
+            tag={tag}
+            isAuthenticated={isAuthenticated}
+            onVote={handleVote}
+          />
+        ))}
+        {hasMoreDesktop && (
+          <button
+            onClick={() => setExpanded(!expanded)}
+            className="inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
           >
-            {desktopVisibleTags.map(tag => (
-              <TagWithVotes
-                key={tag.tag_id}
-                tag={tag}
-                isAuthenticated={isAuthenticated}
-                onVote={handleVote}
-              />
-            ))}
-            {hasMoreDesktop && (
-              <button
-                onClick={() => setExpanded(!expanded)}
-                className="inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
-              >
-                {expanded ? (
-                  <>
-                    <ChevronUp className="h-3 w-3" />
-                    Show less
-                  </>
-                ) : (
-                  <>
-                    <ChevronDown className="h-3 w-3" />
-                    Show {hiddenDesktopCount} more
-                  </>
-                )}
-              </button>
+            {expanded ? (
+              <>
+                <ChevronUp className="h-3 w-3" />
+                Show less
+              </>
+            ) : (
+              <>
+                <ChevronDown className="h-3 w-3" />
+                Show {hiddenDesktopCount} more
+              </>
             )}
-          </div>
-        </>
-      )}
+          </button>
+        )}
+      </div>
 
       <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
         <SheetContent

--- a/frontend/features/tags/components/index.ts
+++ b/frontend/features/tags/components/index.ts
@@ -1,4 +1,5 @@
-export { EntityTagList } from './EntityTagList'
+export { EntityTagList, AddTagDialog } from './EntityTagList'
+export type { AddTagDialogProps } from './EntityTagList'
 export { TagBrowse } from './TagBrowse'
 export { TagDetail } from './TagDetail'
 export { TagOfficialIndicator } from './TagOfficialIndicator'

--- a/frontend/features/tags/index.ts
+++ b/frontend/features/tags/index.ts
@@ -47,6 +47,7 @@ export {
 
 export {
   EntityTagList,
+  AddTagDialog,
   TagBrowse,
   TagDetail,
   TagOfficialIndicator,
@@ -57,6 +58,7 @@ export {
 } from './components'
 
 export type {
+  AddTagDialogProps,
   TagFacetPanelProps,
   TagFacetSheetProps,
 } from './components'


### PR DESCRIPTION
Closes PSY-654.

## Summary

- `EntityTagList` returns `null` when no tags exist (was: muted "No tags yet." + inline "Add the first tag" CTA on every tagless entity, across 5 entity pages).
- New exported `<AddTagDialog>` standalone wrapper so per-page bracket linkboxes can mount the [Add tag] affordance after the tag section itself disappears.
- `ArtistDetail` is the first consumer: mounts `<AddTagDialog>` at page level and adds `[Add tag]` BracketLink (auth-gated) to its header linkbox.
- Kills the **highest-volume** empty-state surface flagged by the PSY-643 audit — 4 HIGH-severity sites resolved at the shared-component layer.

## Scope narrowed from original ticket

The 4 non-artist entity detail pages (Venue / Release / Label / Festival) don't yet have BracketLink header linkboxes — that's part of each page's density refactor (PSY-655/656/657/658). So the full "5 pages get `[Add tag]` in header linkbox" can't happen here alone.

This PR ships the shared-component change + ArtistDetail wiring; per-page tickets will pick up `[Add tag]` as a sub-acceptance criterion. **Interim regression**: the 4 non-artist pages temporarily lose the in-section "Add the first tag" affordance for tagless entities. Authenticated users can still add tags from any tagged entity via EntityTagList's existing "+ Add" chip.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run test:run features/tags features/artists` — 441/441 pass
- [x] `/simplify` — 3 quality fixes applied (dead Fragment removed, comments trimmed); reuse + efficiency clean
- [x] PSY-481 empty-state describe block replaced with PSY-654 hide-when-empty assertions
- [x] New `AddTagDialog standalone` describe covers open/closed render + onOpenChange-on-success
- [x] ArtistDetail assertions for `[Add tag]` BracketLink (visible authed, hidden unauthed)
- [ ] Manual repro: tagless artist page (no Tags section, but `[Add tag]` BracketLink in header opens dialog and adds tag), tagged artist page (Tags section + linkbox `[Add tag]` both work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)