### PR TITLE
PSY-649: restyle 7 ShadCN primitives — sharp corners, no shadows

### DIFF
--- a/.claude/skills/psy-solo/SKILL.md
+++ b/.claude/skills/psy-solo/SKILL.md
@@ -103,6 +103,21 @@ Invoke `Skill` with `skill: "simplify"`. The simplify skill spawns 3 parallel re
 
 If `/simplify` produced code changes, re-run the relevant test commands from phase 4.
 
+### Phase 5.5: /psy-self-review (after screenshots, before push)
+
+After `/simplify` is clean AND screenshots are captured (phase 6 if applicable), invoke `Skill` with `skill: "psy-self-review"`. It spawns 3 parallel reviewer sub-agents that check the draft PR body against session evidence:
+- Agent 1: every `[x]` test-plan item has a matching command / screenshot / test run in the session log
+- Agent 2: every behavior change in the diff is claimed-or-disclaimed in the PR body
+- Agent 3: convention + asymmetry traps (unauth fallback symmetry, truthy-empty gate shapes, dialog open/close URL-hash symmetry)
+
+**BLOCKING findings** (claims with no evidence) STOP the push — fix by re-doing the verification OR downgrading the `[x]` to `[ ]` with a "deferred manual repro" note. **WARNING / NIT findings** are agent's judgment call.
+
+Pass the draft PR body + session bash log path + git diff to the skill. The skill is honest about scope (can't verify what a screenshot SHOWS, only that it exists; spot-Read the PNG yourself for load-bearing claims).
+
+Required for any PR with a `## Test plan` containing `[x]` items. Skip only for backend-only / docs-only / config-only PRs where `/simplify` already covers the audit surface.
+
+Born out of the May 16–17 retro: PSY-658 shipped with an unverified `[x]` claim that caught a real bug post-merge (PSY-663). This phase exists to prevent that recurring. See `.claude/skills/psy-self-review/SKILL.md`.
+
 ### Phase 6: Screenshots (UI tickets only)
 
 Skip this phase entirely for backend-only / docs-only / config-only tickets — note `"no UI surface, screenshots skipped"` in the test plan.
@@ -273,6 +288,7 @@ Do NOT delete the draft release after the PR is open — the asset URLs depend o
 ## Related skills and memories
 
 - **`psy-dispatch`** — parallel-worktree batch execution. Use when 2+ tickets need to ship; `psy-solo` is for single tickets where worktree overhead would be friction.
+- **`/psy-self-review`** — invoked at phase 5.5 between `/simplify` and `git push`. Sub-agent audits the draft PR body against session evidence; BLOCKING finding (unverified `[x]` claim) stops the push.
 - **`/psy-audit` (planned, post-PSY-656)** — multi-page post-shipped UI audit pattern (sweep N merged tickets via screenshots + DOM-eval, file follow-ups, post project-update). Different scope from `psy-solo` (retrospective sweep vs forward per-ticket). Will be drafted after PSY-656 validates the audit cadence is genuinely reusable. May 16 audit was the first instance: caught PSY-663 + PSY-664 in ~30 minutes.
 - **`psy-ticket`** — ticket creation; pair with phase 7 to file the follow-ups this skill identifies.
 - **`linear-cli`** — generic Linear surface; drop down to it if `linear issue` lacks a flag.

--- a/frontend/components/ui/alert.tsx
+++ b/frontend/components/ui/alert.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const alertVariants = cva(
-  "relative w-full rounded-lg border px-4 py-3 text-sm grid has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] grid-cols-[0_1fr] has-[>svg]:gap-x-3 gap-y-0.5 items-start [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current",
+  "relative w-full rounded-md border px-4 py-3 text-sm grid has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] grid-cols-[0_1fr] has-[>svg]:gap-x-3 gap-y-0.5 items-start [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current",
   {
     variants: {
       variant: {

--- a/frontend/components/ui/badge.tsx
+++ b/frontend/components/ui/badge.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 
 const badgeVariants = cva(
-  'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  'inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
   {
     variants: {
       variant: {

--- a/frontend/components/ui/button.tsx
+++ b/frontend/components/ui/button.tsx
@@ -13,7 +13,7 @@ const buttonVariants = cva(
         destructive:
           "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+          "border bg-background hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost:

--- a/frontend/components/ui/card.tsx
+++ b/frontend/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        "bg-card text-card-foreground flex flex-col gap-4 rounded-lg border py-4",
         className
       )}
       {...props}
@@ -20,7 +20,7 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card-header"
       className={cn(
-        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-2 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-2 px-4 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-4",
         className
       )}
       {...props}
@@ -32,7 +32,7 @@ function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-title"
-      className={cn("leading-none font-semibold", className)}
+      className={cn("leading-none font-display font-semibold", className)}
       {...props}
     />
   )
@@ -65,7 +65,7 @@ function CardContent({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-content"
-      className={cn("px-6", className)}
+      className={cn("px-4", className)}
       {...props}
     />
   )
@@ -75,7 +75,7 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-footer"
-      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
+      className={cn("flex items-center px-4 [.border-t]:pt-4", className)}
       {...props}
     />
   )

--- a/frontend/components/ui/input.tsx
+++ b/frontend/components/ui/input.tsx
@@ -8,7 +8,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
         "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
         className

--- a/frontend/components/ui/password-strength-meter.tsx
+++ b/frontend/components/ui/password-strength-meter.tsx
@@ -107,9 +107,9 @@ export function PasswordStrengthMeter({
           <span className="text-muted-foreground">Password strength</span>
           <span className={cn('font-medium', color)}>{label}</span>
         </div>
-        <div className="h-1.5 w-full rounded-full bg-muted overflow-hidden">
+        <div className="h-1.5 w-full rounded-sm bg-muted overflow-hidden">
           <div
-            className={cn('h-full rounded-full transition-all duration-300', bgColor)}
+            className={cn('h-full rounded-sm transition-all duration-300', bgColor)}
             style={{ width: `${strength}%` }}
           />
         </div>

--- a/frontend/components/ui/switch.tsx
+++ b/frontend/components/ui/switch.tsx
@@ -17,7 +17,7 @@ function Switch({
       data-slot="switch"
       data-size={size}
       className={cn(
-        "peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 group/switch inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-[1.15rem] data-[size=default]:w-8 data-[size=sm]:h-3.5 data-[size=sm]:w-6",
+        "peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 group/switch inline-flex shrink-0 items-center rounded-md border border-transparent transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-[1.15rem] data-[size=default]:w-8 data-[size=sm]:h-3.5 data-[size=sm]:w-6",
         className
       )}
       {...props}
@@ -25,7 +25,7 @@ function Switch({
       <SwitchPrimitive.Thumb
         data-slot="switch-thumb"
         className={cn(
-          "bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block rounded-full ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0"
+          "bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block rounded-md ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0"
         )}
       />
     </SwitchPrimitive.Root>


### PR DESCRIPTION
Closes PSY-649.

## Summary
- Restyle 7 ShadCN UI primitives to the PSY-646 editorial direction (sharp corners, borders over shadows, no `rounded-full`, Satoshi-no-600 caveat).
- Pure className swaps — CVA variant APIs, props, exports, `data-slot` attributes all preserved. No consumer changes needed.
- 4 in-scope primitives already aligned per audit: `checkbox` / `label` / `skeleton` / `textarea`.

### Bonus — `psy-solo` skill update bundled
Second commit on this branch (`chore: document Phase 5.5 /psy-self-review in psy-solo skill`) adds a 16-line Phase 5.5 section to `.claude/skills/psy-solo/SKILL.md` documenting the new `/psy-self-review` step between `/simplify` and screenshots. Bundled here rather than as a one-file PR. Unrelated to the design-system restyle — workflow infrastructure update validated end-to-end by this PR itself (0 blocking findings, 4 non-blocking caught + addressed pre-push).

## Changes

| File | Change |
|---|---|
| `alert.tsx` | `rounded-lg` → `rounded-md` |
| `badge.tsx` | `rounded-full` → `rounded-md`; `font-semibold` → `font-medium` (Satoshi has no 600) |
| `button.tsx` | drop `shadow-xs` on outline; keep `border` |
| `card.tsx` | `rounded-xl` → `rounded-lg`; drop `shadow-sm`; `py-6` → `py-4`; `gap-6` → `gap-4` on outer; `px-6` → `px-4` on Header/Content/Footer; CardTitle gains `font-display` |
| `input.tsx` | drop `shadow-xs`; keep border |
| `password-strength-meter.tsx` | `rounded-full` → `rounded-sm` on outer + inner fill bars |
| `switch.tsx` | `rounded-full` → `rounded-md` on root + thumb; drop `shadow-xs` |

## Design decisions (user-approved via AskUserQuestion)
- **CardTitle font**: `font-display font-semibold` (Clash Display 600 — treats CardTitle as a true heading; resolves correctly via `--font-display` in globals.css:31).
- **Card padding tightening**: outer `py-4` + sub-components `px-4` + gap `gap-4`.
- **Switch thumb**: `rounded-md` to match root, consistent with the sharp-corners principle.

## Heads up from /simplify
Clean across all 3 reviewer passes (reuse / quality / efficiency). Leftover `shadow-*` / `rounded-full` references in `tabs.tsx`, `dialog.tsx`, `DensityToggle.tsx`, `TagPill.tsx`, `LoadingSpinner.tsx`, `SubmissionSuccessDialog.tsx` are all in the audit doc under PSY-650/651/652 scope — not regressions.

## Test plan
- [x] `bun run typecheck` — clean (`tsc --noEmit` no output)
- [x] No `.test.tsx` files import these primitives directly — no unit-test maintenance
- [x] `/simplify` — clean across all 3 reviewer passes, no changes required
- [x] `/psy-self-review` — 0 blocking findings; coverage gaps documented below
- [x] Manual repro on local dev stack against light mode (newsprint): homepage, /auth, /scenes, /artists/amyl-and-the-sniffers, /releases/all-the-young-droids-junkshop-synth-pop-1978-1985
- [x] Card + CardTitle render verified via DOM eval on /scenes: 10 `[data-slot="card"]` nodes report `borderRadius: 6px` (= `rounded-lg`), `paddingTop: 16px` (= `py-4`), `boxShadow: none`; 10 `[data-slot="card-title"]` nodes report `fontFamily: clashDisplay`, `fontWeight: 600`
- [x] Badge render verified via DOM eval on release detail: `borderRadius: 4px` (= `rounded-md`), `fontWeight: 500` (= `font-medium`)

## Coverage gaps (visual / runtime not exercised locally)
- **Dark mode** — tokens differ light vs dark; only light mode screenshotted. Dark mode tokens were updated in PSY-648 + verified at the token level; component-level dark rendering not visually exercised.
- **`PasswordStrengthMeter`** — render path requires a password-signup flow; site auth is passkey + magic-link + OAuth (no password signup). Component is used at settings/change-password + admin/notifications which need auth. Class change verified via diff but not screenshotted.
- **`Alert` primitive** — no surface in the homepage / /auth / /scenes / entity-detail / release-detail sweep surfaced an Alert. Class change verified via diff only.
- **`Switch` primitive** — used on settings/notification surfaces which need auth. Class change verified via diff only.
- **Non-default Button + Badge variants** — `Button outline` covered (Continue with Google, Sign in with passkey at /auth; Reject All / Customize on cookie banner); `Button default/primary` covered (Accept All); `Button destructive`/`secondary`/`ghost`/`link` not screenshotted. `Badge default` covered ("Compilation" tag at release detail); `Badge secondary`/`destructive`/`outline` not screenshotted.

## Screenshots

Newsprint light mode rendered against local dev backend.

**`/scenes` — strongest evidence of the restyle.** 10 Card primitives in a 3-col grid, each with `rounded-lg` (6px corners), hairline border, no shadow, `py-4` padding. CardTitles ("Phoenix, AZ", "Tucson, AZ", "Mesa, AZ", …) render in **Clash Display 600** — visibly heavier and more editorial than the surrounding Satoshi body text.

![scenes](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-609c5ee7cf04ae6acdb1/psy-649-scenes.png)

**Homepage** — newsprint `--background` `#f4f1ea`, burnt-orange `--primary` `#d2541b` "Accept All" button, outline Buttons (Reject All / Customize) with hairline borders and no shadow, search Input with `rounded-md` + no shadow.

![homepage](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-609c5ee7cf04ae6acdb1/psy-649-homepage.png)

**/auth** — outline Button variants (Continue with Google, Sign in with passkey) with hairline borders and no shadow; Email/Password Inputs (`rounded-md`, no shadow). Tabs visible at top are PSY-650 scope, included incidentally.

![auth](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-609c5ee7cf04ae6acdb1/psy-649-auth.png)

**Artist detail** — entity page with sidebar groupings using the new tightened Card layout. TagPill chips at bottom right still show `rounded-full` — that's PSY-651 scope per the audit (lines 79-80).

![artist](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-609c5ee7cf04ae6acdb1/psy-649-artist.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
