### PR TITLE
PSY-656: LabelDetail density — remove 3-tab system + BracketLink linkbox

### DIFF
--- a/frontend/features/labels/components/LabelDetail.tsx
+++ b/frontend/features/labels/components/LabelDetail.tsx
@@ -1,27 +1,30 @@
 'use client'
 
-import { useState } from 'react'
+import { Fragment, useState } from 'react'
 import Link from 'next/link'
 import { useQueryClient } from '@tanstack/react-query'
-import {
-  Loader2,
-  Tag,
-  MapPin,
-  Calendar,
-  Users,
-  Disc3,
-  Music,
-  Edit2,
-} from 'lucide-react'
+import { Loader2, Tag, MapPin } from 'lucide-react'
 import { useLabel, useLabelRoster, useLabelCatalog } from '../hooks/useLabels'
-import { EntityDetailLayout, EntityHeader, SocialLinks, FollowButton, AddToCollectionButton, RevisionHistory } from '@/components/shared'
+import {
+  EntityDetailLayout,
+  EntityHeader,
+  SocialLinks,
+  FollowButton,
+  AddToCollectionButton,
+  RevisionHistory,
+  BracketLink,
+  SectionHeader,
+  StatsList,
+  DenseTable,
+  DenseTableGroupHeader,
+  type StatsListItem,
+} from '@/components/shared'
 import { EntityCollections } from '@/features/collections'
 import { CommentThread } from '@/features/comments'
-import { EntityTagList } from '@/features/tags'
+import { EntityTagList, AddTagDialog } from '@/features/tags'
 import { NotifyMeButton } from '@/features/notifications'
 import { useIsAuthenticated } from '@/features/auth'
 import { AttributionLine, ContributionPrompt, EntityEditDrawer, EntitySaveSuccessBanner, useEntitySaveSuccessBanner } from '@/features/contributions'
-import { TabsContent } from '@/components/ui/tabs'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { queryKeys } from '@/lib/queryClient'
@@ -29,8 +32,24 @@ import {
   getLabelStatusLabel,
   getLabelStatusVariant,
   formatLabelLocation,
+  type LabelRelease,
 } from '../types'
-import { getReleaseTypeLabel } from '@/features/releases/types'
+import { RELEASE_TYPES, type ReleaseType } from '@/features/releases/types'
+
+const CATALOG_BUCKETS: Array<{
+  key: ReleaseType | 'other'
+  label: string
+  match: (r: LabelRelease) => boolean
+}> = [
+  { key: 'lp', label: 'Albums', match: r => r.release_type === 'lp' },
+  { key: 'ep', label: 'EPs', match: r => r.release_type === 'ep' },
+  { key: 'single', label: 'Singles', match: r => r.release_type === 'single' },
+  { key: 'compilation', label: 'Compilations', match: r => r.release_type === 'compilation' },
+  { key: 'live', label: 'Live', match: r => r.release_type === 'live' },
+  { key: 'remix', label: 'Remixes', match: r => r.release_type === 'remix' },
+  { key: 'demo', label: 'Demos', match: r => r.release_type === 'demo' },
+  { key: 'other', label: 'Other', match: r => !(RELEASE_TYPES as readonly string[]).includes(r.release_type) },
+]
 
 interface LabelDetailProps {
   idOrSlug: string | number
@@ -53,9 +72,9 @@ export function LabelDetail({ idOrSlug }: LabelDetailProps) {
     labelIdOrSlug: idOrSlug,
     enabled: !!label,
   })
-  const [activeTab, setActiveTab] = useState('overview')
   const [isEditing, setIsEditing] = useState(false)
   const [editFocusField, setEditFocusField] = useState<string | undefined>()
+  const [addTagDialogOpen, setAddTagDialogOpen] = useState(false)
   const saveBanner = useEntitySaveSuccessBanner()
 
   if (isLoading) {
@@ -116,79 +135,58 @@ export function LabelDetail({ idOrSlug }: LabelDetailProps) {
   // suppress the "Links" heading when SocialLinks would render nothing —
   // otherwise the detail page shows an orphan section header underlined by
   // empty space.
+  const hasDescription = !!label.description && label.description.trim().length > 0
   const hasSocialLinks = !!(
     label.social &&
     Object.values(label.social).some(value => typeof value === 'string' && value.trim() !== '')
   )
 
-  const tabs = [
-    { value: 'overview', label: 'Overview' },
-    { value: 'roster', label: `Roster (${label.artist_count})` },
-    { value: 'catalog', label: `Catalog (${label.release_count})` },
+  const statsItems: StatsListItem[] = [
+    { label: 'Roster', value: label.artist_count },
+    { label: 'Catalog', value: label.release_count },
   ]
+  if (label.founded_year) {
+    // String() bypasses StatsList's Intl.NumberFormat thousands separator —
+    // 1980 should render as "1980", not "1,980".
+    statsItems.push({ label: 'Founded', value: String(label.founded_year) })
+  }
+  statsItems.push({
+    label: 'Status',
+    value: (
+      <Badge variant={getLabelStatusVariant(label.status)} className="text-[10px] px-1.5 py-0">
+        {getLabelStatusLabel(label.status)}
+      </Badge>
+    ),
+  })
+
+  const catalogGroups = CATALOG_BUCKETS.map(b => ({
+    ...b,
+    releases: catalog.filter(b.match),
+  })).filter(g => g.releases.length > 0)
 
   const sidebar = (
     <div className="space-y-6">
-      {/* Label Icon */}
-      <div className="rounded-lg border border-border/50 bg-card overflow-hidden">
-        <div className="w-full aspect-square bg-muted/30 flex items-center justify-center">
-          <Tag className="h-16 w-16 text-muted-foreground/30" />
+      {label.image_url ? (
+        <div className="rounded-lg border border-border/50 bg-card overflow-hidden">
+          <img
+            src={label.image_url}
+            alt={`${label.name} logo`}
+            className="w-full aspect-square object-cover"
+          />
         </div>
-      </div>
-
-      {/* Quick Info */}
-      <div className="rounded-lg border border-border/50 bg-card p-4 space-y-3">
-        <h3 className="text-sm font-semibold text-foreground">Details</h3>
-
-        <div className="space-y-2 text-sm">
-          <div className="flex items-center gap-2 text-muted-foreground">
-            <Tag className="h-4 w-4 shrink-0" />
-            <span>
-              Status:{' '}
-              <Badge
-                variant={getLabelStatusVariant(label.status)}
-                className="text-[10px] px-1.5 py-0 ml-1"
-              >
-                {getLabelStatusLabel(label.status)}
-              </Badge>
-            </span>
-          </div>
-
-          {location && (
-            <div className="flex items-center gap-2 text-muted-foreground">
-              <MapPin className="h-4 w-4 shrink-0" />
-              <span>{location}</span>
-            </div>
-          )}
-
-          {label.founded_year && (
-            <div className="flex items-center gap-2 text-muted-foreground">
-              <Calendar className="h-4 w-4 shrink-0" />
-              <span>Founded: {label.founded_year}</span>
-            </div>
-          )}
-
-          <div className="flex items-center gap-2 text-muted-foreground">
-            <Users className="h-4 w-4 shrink-0" />
-            <span>
-              {label.artist_count === 1
-                ? '1 artist'
-                : `${label.artist_count} artists`}
-            </span>
-          </div>
-
-          <div className="flex items-center gap-2 text-muted-foreground">
-            <Disc3 className="h-4 w-4 shrink-0" />
-            <span>
-              {label.release_count === 1
-                ? '1 release'
-                : `${label.release_count} releases`}
-            </span>
+      ) : (
+        <div className="rounded-lg border border-border/50 bg-card overflow-hidden">
+          <div className="w-full aspect-square bg-muted/30 flex items-center justify-center">
+            <Tag className="h-16 w-16 text-muted-foreground/30" />
           </div>
         </div>
-      </div>
+      )}
 
-      {/* In Collections */}
+      <section>
+        <SectionHeader title="Statistics" />
+        <StatsList items={statsItems} />
+      </section>
+
       <EntityCollections entityType="label" entityId={label.id} />
     </div>
   )
@@ -217,21 +215,45 @@ export function LabelDetail({ idOrSlug }: LabelDetailProps) {
               </>
             }
             actions={
-              <div className="flex items-center gap-2">
+              <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+                <FollowButton
+                  entityType="labels"
+                  entityId={label.id}
+                  variant="bracket"
+                />
+                <NotifyMeButton
+                  entityType="label"
+                  entityId={label.id}
+                  entityName={label.name}
+                  variant="bracket"
+                />
+                <AddToCollectionButton
+                  entityType="label"
+                  entityId={label.id}
+                  entityName={label.name}
+                  variant="bracket"
+                />
                 {isAuthenticated && (
-                  <Button
-                    variant="ghost"
-                    size="sm"
+                  <BracketLink
+                    label={canEditDirectly ? 'Edit' : 'Suggest edit'}
                     onClick={() => setIsEditing(true)}
-                    className="text-muted-foreground hover:text-foreground"
-                    title={canEditDirectly ? 'Edit' : 'Suggest Edit'}
-                  >
-                    <Edit2 className="h-4 w-4" />
-                  </Button>
+                  />
                 )}
-                <NotifyMeButton entityType="label" entityId={label.id} entityName={label.name} />
-                <FollowButton entityType="labels" entityId={label.id} />
-                <AddToCollectionButton entityType="label" entityId={label.id} entityName={label.name} />
+                {isAuthenticated && !hasDescription && (
+                  <BracketLink
+                    label="Suggest description"
+                    onClick={() => {
+                      setEditFocusField('description')
+                      setIsEditing(true)
+                    }}
+                  />
+                )}
+                {isAuthenticated && (
+                  <BracketLink
+                    label="Add tag"
+                    onClick={() => setAddTagDialogOpen(true)}
+                  />
+                )}
               </div>
             }
           />
@@ -254,137 +276,91 @@ export function LabelDetail({ idOrSlug }: LabelDetailProps) {
           />
         </>
       }
-      tabs={tabs}
-      activeTab={activeTab}
-      onTabChange={setActiveTab}
       sidebar={sidebar}
     >
-      {/* Overview Tab */}
-      <TabsContent value="overview">
-        <div className="space-y-8">
-          {/* Description */}
-          {label.description && (
-            <div>
-              <h2 className="text-lg font-semibold mb-3">About</h2>
-              <p className="text-muted-foreground leading-relaxed whitespace-pre-line">
-                {label.description}
-              </p>
-            </div>
-          )}
-
-          {/* Social Links — only render the heading when there's actually
-              something for SocialLinks to show (PSY-481). */}
-          {hasSocialLinks && (
-            <div>
-              <h2 className="text-lg font-semibold mb-3">Links</h2>
-              <SocialLinks social={label.social} />
-            </div>
-          )}
-
-          {/* Quick preview of roster + catalog when no description */}
-          {!label.description && !hasSocialLinks && (
-            <div className="text-sm text-muted-foreground">
-              No additional information available for this label.
-            </div>
-          )}
-        </div>
-      </TabsContent>
-
-      {/* Roster Tab */}
-      <TabsContent value="roster">
-        <div>
-          <h2 className="text-lg font-semibold mb-4">Artist Roster</h2>
-          {rosterLoading ? (
-            <div className="flex justify-center py-8">
-              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-            </div>
-          ) : roster.length === 0 ? (
-            <p className="text-sm text-muted-foreground">
-              No artists are currently associated with this label.
+      <div className="space-y-8">
+        {hasDescription && (
+          <section>
+            <SectionHeader title="About" as="h2" size="md" />
+            <p className="text-muted-foreground leading-relaxed whitespace-pre-line">
+              {label.description}
             </p>
-          ) : (
-            <div className="space-y-2">
+          </section>
+        )}
+
+        {hasSocialLinks && (
+          <section>
+            <SectionHeader title="Links" as="h2" size="md" />
+            <SocialLinks social={label.social} />
+          </section>
+        )}
+
+        {rosterLoading ? (
+          <div className="flex justify-center py-8">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        ) : roster.length > 0 ? (
+          <section>
+            <SectionHeader title="Roster" as="h2" size="md" />
+            <ul className="space-y-1 text-sm">
               {roster.map(artist => (
-                <div
-                  key={artist.id}
-                  className="flex items-center rounded-lg border border-border/50 bg-card p-3"
-                >
-                  <Users className="h-4 w-4 text-muted-foreground mr-3 shrink-0" />
+                <li key={artist.id}>
                   <Link
                     href={`/artists/${artist.slug}`}
-                    className="font-medium text-foreground hover:text-primary transition-colors"
+                    className="text-foreground hover:text-primary hover:underline underline-offset-2 transition-colors"
                   >
                     {artist.name}
                   </Link>
-                </div>
+                </li>
               ))}
-            </div>
-          )}
-        </div>
-      </TabsContent>
+            </ul>
+          </section>
+        ) : null}
 
-      {/* Catalog Tab */}
-      <TabsContent value="catalog">
-        <div>
-          <h2 className="text-lg font-semibold mb-4">Release Catalog</h2>
-          {catalogLoading ? (
-            <div className="flex justify-center py-8">
-              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-            </div>
-          ) : catalog.length === 0 ? (
-            <p className="text-sm text-muted-foreground">
-              No releases are currently in this label&apos;s catalog.
-            </p>
-          ) : (
-            <div className="space-y-2">
-              {catalog.map(release => (
-                <div
-                  key={release.id}
-                  className="flex items-center gap-3 rounded-lg border border-border/50 bg-card p-3"
-                >
-                  {/* Cover art or placeholder */}
-                  <div className="h-10 w-10 shrink-0 rounded-md bg-muted/50 flex items-center justify-center overflow-hidden">
-                    {release.cover_art_url ? (
-                      <img
-                        src={release.cover_art_url}
-                        alt={`${release.title} cover art`}
-                        className="h-full w-full object-cover"
-                      />
-                    ) : (
-                      <Music className="h-5 w-5 text-muted-foreground/40" />
-                    )}
-                  </div>
-
-                  <div className="flex-1 min-w-0">
-                    <Link
-                      href={`/releases/${release.slug}`}
-                      className="font-medium text-foreground hover:text-primary transition-colors truncate block"
-                    >
-                      {release.title}
-                    </Link>
-                    <div className="flex items-center gap-2 text-xs text-muted-foreground mt-0.5">
-                      <Badge
-                        variant="secondary"
-                        className="text-[10px] px-1.5 py-0"
-                      >
-                        {getReleaseTypeLabel(release.release_type)}
-                      </Badge>
-                      {release.release_year && (
-                        <span>{release.release_year}</span>
-                      )}
-                      {release.catalog_number && (
-                        <span className="text-muted-foreground/60">
-                          {release.catalog_number}
-                        </span>
-                      )}
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
-      </TabsContent>
+        {catalogLoading ? (
+          <div className="flex justify-center py-8">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        ) : catalogGroups.length > 0 ? (
+          <section>
+            <SectionHeader title="Catalog" as="h2" size="md" />
+            <DenseTable variant="alternating" aria-label="Catalog">
+              <thead>
+                <tr>
+                  <th>Title</th>
+                  <th className="text-right">Year</th>
+                  <th>Catalog #</th>
+                </tr>
+              </thead>
+              <tbody>
+                {catalogGroups.map(g => (
+                  <Fragment key={g.key}>
+                    <DenseTableGroupHeader title={g.label} colSpan={3} />
+                    {g.releases.map(r => (
+                      <tr key={r.id}>
+                        <td>
+                          <Link
+                            href={`/releases/${r.slug}`}
+                            className="hover:text-primary underline-offset-2 hover:underline"
+                          >
+                            {r.title}
+                          </Link>
+                        </td>
+                        <td className="text-right text-muted-foreground">
+                          {r.release_year ?? '—'}
+                        </td>
+                        <td className="text-muted-foreground">
+                          {r.catalog_number ?? '—'}
+                        </td>
+                      </tr>
+                    ))}
+                  </Fragment>
+                ))}
+              </tbody>
+            </DenseTable>
+          </section>
+        ) : null}
+      </div>
     </EntityDetailLayout>
 
     {/* Revision History */}
@@ -417,6 +393,15 @@ export function LabelDetail({ idOrSlug }: LabelDetailProps) {
           })
           saveBanner.handleSaveSuccess(result)
         }}
+      />
+    )}
+
+    {isAuthenticated && (
+      <AddTagDialog
+        entityType="label"
+        entityId={label.id}
+        open={addTagDialogOpen}
+        onOpenChange={setAddTagDialogOpen}
       />
     )}
   </>


### PR DESCRIPTION
Closes PSY-656.

## Summary

- Removes the 3-tab system (Overview / Roster / Catalog). `EntityDetailLayout` now uses flat mode.
- Header rewrite: Edit icon-button + button-variant Follow / Notify / AddToCollection → `BracketLink` linkbox: `[Follow]` `[Notify me]` `[Add to collection]` `[Edit | Suggest edit]` `[Suggest description]` (auth + when description empty) `[Add tag]`.
- Sidebar slimmed: drops the "Details" card. Replaced with `<SectionHeader title="Statistics" />` + `<StatsList items={[Roster, Catalog, Founded, Status]} />`. Adds `label.image_url` logo when present (Tag placeholder otherwise).
- Main column flat sections: About (description) → Links (social) → Roster (simple `<ul>`) → Catalog (`DenseTable` with `DenseTableGroupHeader` buckets by `release_type` — Albums / EPs / Singles / Compilations / Live / Remixes / Demos / Other). Each section self-hides when empty.
- Removes "No additional information available for this label." fallback.
- Mounts `<AddTagDialog>` page-level (auth-only).
- Reuses `RELEASE_TYPES` + `ReleaseType` from `frontend/features/releases/types.ts` to type `CATALOG_BUCKETS` and derive the "other" predicate (no more drift risk on the hardcoded type list).
- Reuses `StatsListItem` from `@/components/shared` instead of re-typing inline.
- One file changed, net -19 lines.

**Caught during manual repro**: `StatsList` was rendering the `Founded` year as `1,980` (`Intl.NumberFormat` thousands separator). Fix: pass `String(label.founded_year)` to bypass the formatter for year values. Comment in code explains the why.

## Deferred (per pre-implementation Q&A)

- **`[Report]`** — label is not in `REPORT_TYPES` (frontend `ReportableEntityType` union or backend `ValidEntityReportEntityTypes`). Same shape as the PSY-657 (festival) / PSY-658 (release) decisions. Filed **PSY-666** to add label end-to-end (mirrors PSY-661 release reports).

## Findings from `/simplify`

Pre-existing peer-wide gaps surfaced; **not addressed in this PR** (would each be its own cross-page refactor):
- `hasDescription` boolean is inlined identically across 4 detail pages (Label / Release / Festival / inside `EntityDescription` shared component). Worth extracting a `hasNonEmptyDescription(s)` helper to `@/components/shared/`.
- Logo-placeholder block (aspect-square + muted bg + lucide icon) is duplicated across Release / Festival / Label sidebars with only the fallback icon swapped. Worth a shared `<EntityImage src? fallbackIcon entityName />` primitive.

## Test plan

- [x] `bun run typecheck` — clean (run twice: once after main refactor, once after StatsList year fix)
- [x] `bun run test:run features/labels` — 12/12 passing (`useLabels.test.tsx`); no `LabelDetail.test.tsx` exists yet
- [x] `/simplify` — applied 2 fixes (CATALOG_BUCKETS typing tightened to `ReleaseType | 'other'` + `StatsListItem[]` reused); skipped 3 pre-existing peer-wide gaps noted above
- [x] Manual repro against local dev stack with `/labels/4ad`: header BracketLinks `[Follow] [Notify me]` render for unauth ✓; TAGS section renders (indie rock chip) ✓; ROSTER renders (Alvvays + Pixies) ✓; CATALOG DenseTable renders with ALBUMS bucket header + 4 LP rows ✓; sidebar StatsList renders `Roster: 2 · Catalog: 4 · Founded: 1980 · Status: Active` ✓; About + Links sections correctly hidden (4ad has no description / no social) ✓; year `Founded: 1980` no longer renders as `1,980` after StatsList-bypass fix ✓
- [x] `/psy-self-review` — see below

## Screenshots

Viewport (header + TAGS + Roster + Catalog top of fold):

![PSY-656 LabelDetail viewport](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-6e325d13bbbac1add0a2/psy-656-label-viewport.png)

Full page (flat layout; sidebar Statistics + EntityCollections; History + Discussion below):

![PSY-656 LabelDetail full page](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-6e325d13bbbac1add0a2/psy-656-label-full.png)

## Coverage gaps

Honest disclosure of what the screenshots / manual repro do NOT cover (the dev DB is sparse for labels):

- **Rich-data paths not exercised**: NO label in the local dev DB has `description`, `image_url`, or any `social.*` field populated. Verified the hide-when-empty paths render correctly (About / Links / `[Suggest description]` BracketLink); did NOT visually verify the rich-data paths. **PSY-665 (rich dev seed)** will unblock this for future audits.
- **Multi-bucket Catalog not exercised**: every label in dev has uniform `release_type` (`4ad` is all `lp`, others same). The Catalog DenseTable renders a single `ALBUMS` bucket header here. Bucket grouping logic verified via code path + types; visual multi-bucket render verified only via unit-test-level reasoning. PSY-665 should seed at least one label with mixed types so this is observable.
- **Authenticated header brackets not visually verified**: `[Edit | Suggest edit]`, `[Suggest description]` (when desc empty), and `[Add tag]` only render for authenticated viewers. Skipped the auth login flow per `psy-solo` convention; the brackets exist in the diff at lines 232-252.
- **`[Add to collection]` invisible for unauth viewers**: known bug from PSY-663 (`AddToCollectionButton.tsx:99` returns `null` for unauth on ALL variants including `bracket`). Label has `[Follow]` and `[Notify me]` as public brackets so the linkbox is not empty — unlike ReleaseDetail (PSY-658) which has neither. Fix lands in PSY-663 follow-up.
- **`[Add tag]` → `AddTagDialog` open / submit / close cycle not exercised** (gated on auth). The dialog mount + `addTagDialogOpen` state wiring is in place but the end-to-end interaction wasn't verified locally. Same shape as PSY-657/658 — the dialog primitive is shared.
- **`canEditDirectly` Edit / Suggest edit label variant** — `BracketLink label={canEditDirectly ? 'Edit' : 'Suggest edit'}` introduces a trust-tier conditional; only unauth was exercised, so neither the trusted-user `Edit` label nor the standard-user `Suggest edit` label was visually verified. Identical pattern to PSY-657/658 — low risk, but called out for completeness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
