### PR TITLE
PSY-667: psy-solo + psy-self-review iter-1 + /simplify pre-push hook

### DIFF
--- a/.claude/hooks/check-simplify-before-pr.sh
+++ b/.claude/hooks/check-simplify-before-pr.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# PreToolUse hook on Bash — blocks `gh pr create` if the PR body lacks a
+# checked test-plan item for /simplify.
+#
+# Encodes the psy-solo phase 5 + psy-dispatch ironclad rule 3 convention:
+# /simplify must run before push. Belt-and-suspenders on top of
+# /psy-self-review's body-claim audit — catches the case where the agent
+# skips /simplify AND doesn't claim it (which /psy-self-review can't detect
+# because there's no [x] claim to audit).
+#
+# Bypass for explicit one-offs: set CLAUDE_SKIP_SIMPLIFY_CHECK=1 in the call.
+
+set -euo pipefail
+
+# Read tool input JSON from stdin
+input="$(cat)"
+command=$(echo "$input" | jq -r '.tool_input.command // empty')
+
+# Only fire for `gh pr create` (skip `gh pr edit`, `gh pr view`, etc.)
+if ! [[ "$command" =~ ^[[:space:]]*gh[[:space:]]+pr[[:space:]]+create ]]; then
+    exit 0
+fi
+
+# Explicit bypass
+if [[ "${CLAUDE_SKIP_SIMPLIFY_CHECK:-}" == "1" ]]; then
+    echo "[check-simplify-before-pr] CLAUDE_SKIP_SIMPLIFY_CHECK=1 — bypassing" >&2
+    exit 0
+fi
+
+# Locate the PR body
+body=""
+if [[ "$command" =~ --body-file[[:space:]]+([^[:space:]]+) ]]; then
+    body_file="${BASH_REMATCH[1]}"
+    if [[ -r "$body_file" ]]; then
+        body="$(cat "$body_file")"
+    fi
+elif [[ "$command" =~ --body[[:space:]]+\"(.*)\" ]]; then
+    body="${BASH_REMATCH[1]}"
+fi
+
+# If we can't read the body, fall back to permissive — avoid false-positive
+# blocks on edge syntax (heredoc inside subshell, --body-file with shell
+# expansion, etc.). /psy-self-review's Agent 1 audit is the second line.
+if [[ -z "$body" ]]; then
+    exit 0
+fi
+
+# Accept any of:
+#   - [x] /simplify
+#   - [x] `/simplify`
+#   - [x] /simplify — <outcome>
+#   - [x] `/simplify` — <outcome>
+# Case-insensitive on the X. Indented bullet allowed.
+if echo "$body" | grep -qiE '^[[:space:]]*-[[:space:]]*\[x\][[:space:]]*`?/simplify`?'; then
+    exit 0
+fi
+
+# Missing — block the push
+cat >&2 <<'EOF'
+
+ERROR — pre-push convention violation
+
+PR body must contain a checked test-plan item for /simplify:
+    - [x] /simplify — <outcome>
+or
+    - [x] `/simplify` — <outcome>
+
+The /psy-solo phase 5 + /psy-dispatch ironclad rule 3 both require /simplify
+to run before push. If you ran /simplify, add the [x] claim to your PR body
+and re-run gh pr create.
+
+If you genuinely skipped /simplify (tiny typo fix, docs-only, etc.), explicitly
+downgrade to [ ] with a "skipped — <reason>" note. Reviewers need the signal.
+
+To bypass this hook for a specific call:
+    CLAUDE_SKIP_SIMPLIFY_CHECK=1 gh pr create ...
+
+EOF
+exit 1

--- a/.claude/hooks/check-simplify-before-pr.sh
+++ b/.claude/hooks/check-simplify-before-pr.sh
@@ -12,6 +12,10 @@
 
 set -euo pipefail
 
+# Fail-open if jq is missing — better to skip the check than to block ALL
+# Bash tool calls because a dependency is unavailable on this machine.
+command -v jq >/dev/null || exit 0
+
 # Read tool input JSON from stdin
 input="$(cat)"
 command=$(echo "$input" | jq -r '.tool_input.command // empty')
@@ -27,9 +31,12 @@ if [[ "${CLAUDE_SKIP_SIMPLIFY_CHECK:-}" == "1" ]]; then
     exit 0
 fi
 
-# Locate the PR body
+# Locate the PR body. Handles both `--body-file <path>` and `--body-file=<path>`.
+# Paths with spaces / shell quoting aren't supported here; if the regex misses,
+# the empty-body fallback at the next block falls back to permissive (rely on
+# /psy-self-review's Agent 1 audit instead of risking a false-positive block).
 body=""
-if [[ "$command" =~ --body-file[[:space:]]+([^[:space:]]+) ]]; then
+if [[ "$command" =~ --body-file[=[:space:]]+([^[:space:]]+) ]]; then
     body_file="${BASH_REMATCH[1]}"
     if [[ -r "$body_file" ]]; then
         body="$(cat "$body_file")"
@@ -50,8 +57,9 @@ fi
 #   - [x] `/simplify`
 #   - [x] /simplify — <outcome>
 #   - [x] `/simplify` — <outcome>
-# Case-insensitive on the X. Indented bullet allowed.
-if echo "$body" | grep -qiE '^[[:space:]]*-[[:space:]]*\[x\][[:space:]]*`?/simplify`?'; then
+# Lowercase `[x]` only — `[X]` is a typo signal worth catching as a miss,
+# not silently accepting. Indented bullet allowed.
+if echo "$body" | grep -qE '^[[:space:]]*-[[:space:]]*\[x\][[:space:]]*`?/simplify`?'; then
     exit 0
 fi
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/check-simplify-before-pr.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/psy-self-review/SKILL.md
+++ b/.claude/skills/psy-self-review/SKILL.md
@@ -73,14 +73,16 @@ This catches the PSY-664 shape: the diff introduced a close-path branch (`onOpen
 
 Sanity-check the PR body for project-convention drift + scan the diff for known asymmetry traps:
 
-- PR title format: `PSY-{N}: <under 70 chars>` — flag if over 70 or missing prefix.
+- PR title format: `PSY-{N}: <under 70 chars>` — **NOTE**: PR title is passed to `gh pr create --title` SEPARATELY from the body. If the title isn't supplied alongside the body in this skill's input, mark as **N/A — title not in scope**; recommend the calling agent verify length manually before `gh pr create`. Future improvement: caller passes `title` as a separate input.
 - PR body contains `Closes PSY-{N}` — flag if missing.
+- PR body does NOT contain unresolved `PSY-XXX` / `PSY-???` / `PSY-{N}` placeholder strings — these slip through when follow-up filing (phase 7) happens AFTER the PR body is drafted. Flag any placeholder.
 - `## Coverage gaps` section present (or explicitly stated as "no gaps") — flag if missing entirely; reviewers need to know what wasn't exercised.
-- `## Heads up from /simplify` present if simplify surfaced concerns; absent if `/simplify` was clean.
+- `## Heads up from /simplify` (or `## Findings from /simplify`) present if simplify surfaced concerns; absent if `/simplify` was clean.
 - `## Deferred (per pre-implementation Q&A)` section present if any spike questions resulted in "skip + file follow-up" decisions during phase 2; absent if none.
 - For frontend diffs touching shared components: if `if (!isAuthenticated) return null` is added/modified, check peer components (FollowButton.tsx, NotifyMeButton.tsx, AddToCollectionButton.tsx, EntityTagList.tsx, etc.) for the convention. Asymmetric unauth fallbacks is the PSY-663 footgun.
 - For frontend diffs gating on optional API data: check the gate uses shape-aware predicates (`Object.values(x).some(...)`, `.length > 0`) not truthy-only (`!!x` where `x` could be `{}` or `[]`). PSY-657 root cause.
 - For frontend diffs adding dialog open/close paths: check the URL-hash-cleanup symmetry (PSY-664 root cause) — if open SETS a hash, close should CLEAR it.
+- **For frontend diffs passing year-shape numeric values to `<StatsList />`** (`founded_year`, `edition_year`, `release_year`, `established_year`, etc.): check the value is wrapped in `String()` to bypass `Intl.NumberFormat` thousands separator. **Caught: PSY-656 manual repro** — 4AD's `founded_year: 1980` rendered as `1,980` in the sidebar. Fix: `value: String(label.founded_year)` with an inline comment explaining the why.
 
 For each finding: flag with a specific file:line reference + the convention/asymmetry it violates.
 
@@ -213,16 +215,18 @@ Git diff (truncated to relevant hunks):
 Your job — check for:
 
 **PR convention**:
-- Title format `PSY-{N}: <under 70 chars>`
+- Title format `PSY-{N}: <under 70 chars>` — **NOTE**: PR title is passed to `gh pr create --title` separately. If the title isn't supplied here, mark as `N/A — title not in scope` and recommend the calling agent verify length manually before `gh pr create`.
 - Body contains `Closes PSY-{N}`
+- Body does NOT contain unresolved `PSY-XXX` / `PSY-???` placeholder strings (slips through when follow-up filing happens after PR-body drafting)
 - `## Coverage gaps` section present (or explicitly stated as "no gaps")
-- `## Heads up from /simplify` if /simplify surfaced concerns; absent if clean
+- `## Heads up from /simplify` (or `## Findings from /simplify`) if /simplify surfaced concerns; absent if clean
 - `## Deferred` section if phase 2 produced "skip + file follow-up" decisions
 
 **Frontend asymmetry traps**:
 - If `if (!isAuthenticated) return null` is added/modified in a shared component: check that peer components (FollowButton, NotifyMeButton, AddToCollectionButton, EntityTagList) have consistent unauth-fallback patterns. Asymmetric fallbacks were PSY-663's root cause (AddToCollectionButton returned null while Follow/Notify rendered).
 - If gating render on optional API data: gate must use shape-aware predicates (`Object.values(x).some(...)`, `.length > 0`), NOT truthy-only (`!!x` where x could be `{}` or `[]`). PSY-657 root cause was `!!festival.social` being true when `social: {}`.
 - If adding dialog open/close paths with URL-hash management: OPEN setting a hash means CLOSE must CLEAR the hash. PSY-664 root cause was an asymmetric close.
+- If passing a year-shape numeric value to `<StatsList />` (founded_year, edition_year, release_year, established_year, etc.): check the value is wrapped in `String()` to bypass `Intl.NumberFormat` thousands separator. PSY-656 root cause: `1980` rendered as `1,980` in the 4AD sidebar.
 
 For each finding: cite file:line + the specific convention/asymmetry violated.
 

--- a/.claude/skills/psy-solo/SKILL.md
+++ b/.claude/skills/psy-solo/SKILL.md
@@ -103,21 +103,6 @@ Invoke `Skill` with `skill: "simplify"`. The simplify skill spawns 3 parallel re
 
 If `/simplify` produced code changes, re-run the relevant test commands from phase 4.
 
-### Phase 5.5: /psy-self-review (after screenshots, before push)
-
-After `/simplify` is clean AND screenshots are captured (phase 6 if applicable), invoke `Skill` with `skill: "psy-self-review"`. It spawns 3 parallel reviewer sub-agents that check the draft PR body against session evidence:
-- Agent 1: every `[x]` test-plan item has a matching command / screenshot / test run in the session log
-- Agent 2: every behavior change in the diff is claimed-or-disclaimed in the PR body
-- Agent 3: convention + asymmetry traps (unauth fallback symmetry, truthy-empty gate shapes, dialog open/close URL-hash symmetry)
-
-**BLOCKING findings** (claims with no evidence) STOP the push — fix by re-doing the verification OR downgrading the `[x]` to `[ ]` with a "deferred manual repro" note. **WARNING / NIT findings** are agent's judgment call.
-
-Pass the draft PR body + session bash log path + git diff to the skill. The skill is honest about scope (can't verify what a screenshot SHOWS, only that it exists; spot-Read the PNG yourself for load-bearing claims).
-
-Required for any PR with a `## Test plan` containing `[x]` items. Skip only for backend-only / docs-only / config-only PRs where `/simplify` already covers the audit surface.
-
-Born out of the May 16–17 retro: PSY-658 shipped with an unverified `[x]` claim that caught a real bug post-merge (PSY-663). This phase exists to prevent that recurring. See `.claude/skills/psy-self-review/SKILL.md`.
-
 ### Phase 6: Screenshots (UI tickets only)
 
 Skip this phase entirely for backend-only / docs-only / config-only tickets — note `"no UI surface, screenshots skipped"` in the test plan.
@@ -155,6 +140,8 @@ agent-browser screenshot --full /tmp/psy-{N}-<short>-full.png   # full page (all
 ```
 
 **Prefer separate sequential foreground `agent-browser` calls over chained `open && sleep && screenshot && eval` in a single background bash.** The chained background pattern repeatedly returned ambiguous status (background-task completion with empty output, or the eval racing against navigation and erroring `Execution context was destroyed`). Separate foreground calls are slower per step but every step has visible result/error feedback, so you can react to a failure instead of guessing. Caught: May 16 audit — at least 4 chained-background calls hung or returned empty before I switched to foreground-sequential.
+
+**`agent-browser navigate reload` doesn't work** — the CLI interprets `reload` as a URL and tries to navigate to `https://reload/`. To reload after a code change (re-hydration of changed component, etc.), re-issue `agent-browser open <same-url>`. Caught: PSY-656 manual repro after the year-bug fix.
 
 Read the PNG back with the `Read` tool to verify visually before uploading — every once in a while, render is missing a section because hydration hadn't completed, or the dev server hit a runtime error you didn't see in the log. Heavy artist pages can need 12–15s for full hydration (multiple parallel data fetches — shows, discography, similar, labels, festival appearances). If the first screenshot looks blank or partial, wait another 5–8s and re-capture before assuming a render bug.
 
@@ -217,7 +204,30 @@ linear issue create \
 
 Description files should explain: the problem, the proposed change (backend / frontend / both), open questions, acceptance criteria, and a `## Source` line citing the parent ticket. See PSY-660 / PSY-661 / PSY-662 from the May 2026 Entity Pages Density Rollout for canonical examples.
 
+**Capture the filed PSY IDs** — you'll substitute them into the PR body's `## Deferred` section in phase 7.5. Filing in phase 7 BEFORE phase 7.5 / 7.6 means the PR body references real IDs (not `PSY-XXX` placeholders that `/psy-self-review` would then flag — caught: PSY-656 self-review warned about an unsubstituted placeholder because filing happened too late).
+
+### Phase 7.5: Draft PR body to /tmp/
+
+Write the planned PR body to `/tmp/psy-{N}-pr-body.md`. Use the [phase 8 template](#phase-8-commit--push--open-pr) below — substitute the real PSY IDs from phase 7 for any `PSY-{M}` placeholders. This is a real artifact (not a mental draft) because `/psy-self-review` (next phase) needs to read it.
+
+### Phase 7.6: /psy-self-review
+
+Invoke `Skill` with `skill: "psy-self-review"`, passing the `/tmp/psy-{N}-pr-body.md` path as arg. It spawns 3 parallel reviewer sub-agents that check the drafted PR body against session evidence:
+- Agent 1: every `[x]` test-plan item has a matching command / screenshot / test run in the session log
+- Agent 2: every behavior change in the diff is claimed-or-disclaimed in the PR body
+- Agent 3: convention + asymmetry traps (unauth fallback symmetry, truthy-empty gate shapes, dialog open/close URL-hash symmetry, year-shape numerics passed to `StatsList` without `String()` wrap, unresolved `PSY-XXX` placeholders)
+
+**BLOCKING findings** (claims with no evidence) STOP the push — fix by re-doing the verification OR downgrading the `[x]` to `[ ]` with a "deferred manual repro" note. **WARNING / NIT findings** are agent's judgment call (warnings usually require a PR-body patch; nits usually require a small disclosure line).
+
+The skill is honest about scope (can't verify what a screenshot SHOWS, only that it exists; cannot audit PR title since it's passed via `--title` separately from the body; spot-Read PNGs yourself for load-bearing claims).
+
+Required for any PR with a `## Test plan` containing `[x]` items. Skip only for backend-only / docs-only / config-only PRs where `/simplify` already covers the audit surface.
+
+Born out of the May 16–17 retro: PSY-658 shipped with an unverified `[x]` claim that caught a real bug post-merge (PSY-663). This phase exists to prevent that recurring. See `.claude/skills/psy-self-review/SKILL.md`.
+
 ### Phase 8: Commit + push + open PR
+
+The PR body is the file you wrote in phase 7.5 and refined in phase 7.6 — use `--body-file`, not an inline heredoc.
 
 ```bash
 git -C <repo> add <specific files>                # NOT `git add .` — never accidentally add untracked
@@ -225,7 +235,12 @@ git -C <repo> commit -m "PSY-{N}: <imperative summary>
 
 Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
 git -C <repo> push -u origin PSY-{N}/<branch>
-gh pr create --title "PSY-{N}: <under-70-char summary>" --body "$(cat <<'EOF'
+gh pr create --title "PSY-{N}: <under-70-char summary>" --body-file /tmp/psy-{N}-pr-body.md
+```
+
+#### PR body template (use as starting point for the phase 7.5 draft)
+
+```markdown
 Closes PSY-{N}.
 
 ## Summary
@@ -242,20 +257,30 @@ Closes PSY-{N}.
 - [x] `bun run typecheck` — clean
 - [x] `bun run test:run features/<scope>` — N/N passing
 - [x] `/simplify` — <outcome>
-- [x] Manual repro against local dev stack with <entity>: <one-sentence description>
+- [x] `/psy-self-review` — <outcome: clean / N findings addressed>
+- [x] Manual repro against local dev stack with <entity>: <one-sentence description of what was visually verified>
 
 ## Screenshots
 <embed the asset URLs from phase 6f, with one-sentence captions describing what each shows>
 
 ![<alt>](<asset-url>)
 
-<If the dev DB couldn't exercise all render paths (e.g. no entity has a description, no entity is tagged, no entity has external_links), state that explicitly: "verified hide-when-empty paths on <slug>; rich-data paths (description / links / etc.) not exercised locally because no <entity> in dev DB has those fields populated." Honest-disclosure beats silent gap — the reviewer needs to know what the screenshot does and doesn't cover.>
+## Coverage gaps
+
+Honest disclosure of what the screenshots / manual repro do NOT cover:
+
+- **Rich-data paths not exercised** (dev DB is sparse — PSY-665 will unblock): <list which optional fields weren't populated on the entity tested>
+- **`[Add tag]` → `AddTagDialog` open / submit / close cycle not exercised** (gated on auth; dialog primitive shared across all entity pages).
+- **`canEditDirectly ? 'Edit' : 'Suggest edit'` label variant not visually verified** (trust-tier conditional; only unauth was exercised, so neither label was rendered).
+- **Authenticated header brackets not visually verified**: `[Edit | Suggest edit]`, `[Suggest description]` (when desc empty), `[Add tag]`, `[Report]` only render for authenticated viewers. Skipped the auth login flow per psy-solo convention; the brackets exist in the diff at <file:line>.
+- <add any UI-ticket-specific gaps here, e.g. multi-bucket grouping not observable because dev data has only one bucket type>
 
 EOF
-)"
 ```
 
-PR title under 70 chars. Body MUST include `Closes PSY-{N}`. If `/simplify` was clean, drop the `## Heads up` section. For non-UI tickets, replace `## Screenshots` with a Manual repro line in the Test plan ("no UI surface" or curl-against-backend response).
+The 3 bracket-related lines under `## Coverage gaps` are standard for any UI ticket using the header-linkbox + AddTagDialog pattern. Include them by default; remove only if the specific PR doesn't touch them.
+
+PR title under 70 chars (verify manually — `/psy-self-review` cannot audit titles passed via `--title`). Body MUST include `Closes PSY-{N}`. If `/simplify` was clean, drop the `## Heads up` section. For non-UI tickets, drop `## Screenshots` and add a Manual repro line in the Test plan ("no UI surface" or curl-against-backend response).
 
 ### Phase 9: Cleanup
 

--- a/.claude/skills/psy-solo/SKILL.md
+++ b/.claude/skills/psy-solo/SKILL.md
@@ -313,7 +313,7 @@ Do NOT delete the draft release after the PR is open — the asset URLs depend o
 ## Related skills and memories
 
 - **`psy-dispatch`** — parallel-worktree batch execution. Use when 2+ tickets need to ship; `psy-solo` is for single tickets where worktree overhead would be friction.
-- **`/psy-self-review`** — invoked at phase 5.5 between `/simplify` and `git push`. Sub-agent audits the draft PR body against session evidence; BLOCKING finding (unverified `[x]` claim) stops the push.
+- **`/psy-self-review`** — invoked at phase 7.6 between follow-up filing (phases 7 / 7.5) and `git push` (phase 8). Sub-agent audits the draft PR body against session evidence; BLOCKING finding (unverified `[x]` claim) stops the push.
 - **`/psy-audit` (planned, post-PSY-656)** — multi-page post-shipped UI audit pattern (sweep N merged tickets via screenshots + DOM-eval, file follow-ups, post project-update). Different scope from `psy-solo` (retrospective sweep vs forward per-ticket). Will be drafted after PSY-656 validates the audit cadence is genuinely reusable. May 16 audit was the first instance: caught PSY-663 + PSY-664 in ~30 minutes.
 - **`psy-ticket`** — ticket creation; pair with phase 7 to file the follow-ups this skill identifies.
 - **`linear-cli`** — generic Linear surface; drop down to it if `linear issue` lacks a flag.

--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,9 @@ postgres-data/
 !pnpm-lock.yaml
 !go.sum
 !vercel.json
+# Shared Claude Code project settings (hooks, etc.); settings.local.json
+# stays ignored for user-specific allow-list customizations.
+!.claude/settings.json
 
 # Backup files
 *.backup


### PR DESCRIPTION
Closes PSY-667.

## Summary

Iter-1 refinements to `/psy-solo` + `/psy-self-review` from PSY-656 battle-testing, plus the first programmatic enforcement of the "`/simplify` before push" convention. First concrete deliverable for the "Agent self-verify & dogfood tooling — May 2026" project.

**5 skill refinements (caught during PSY-656)**:
1. **Year-trap check** in `/psy-self-review` Agent 3 — `<StatsList />` numeric values that look like years (`founded_year`, `edition_year`, `release_year`) need `String()` wrap to bypass `Intl.NumberFormat`. Caught when 4AD's founded year rendered as `1,980` instead of `1980`.
2. **Phase ordering fix** in `/psy-solo` — old Phase 5.5 was misnumbered AND ran before follow-up tickets were filed, causing `PSY-XXX` placeholders to slip through self-review. Now: Phase 7 (file follow-ups) → 7.5 (draft PR body with real IDs) → 7.6 (`/psy-self-review`) → 8 (push + PR).
3. **Standard auth-only `## Coverage gaps` defaults** in `/psy-solo` PR template — pre-includes the `AddTagDialog` cycle + `canEditDirectly` Edit-variant + auth-only-bracket lines that apply to every UI ticket using the header-linkbox pattern. Prevents `/psy-self-review` Agent 2 from re-flagging the same nits each ticket.
4. **`agent-browser navigate reload` gotcha** documented in `/psy-solo` Phase 6c — the CLI interprets `reload` as a URL; workaround is `agent-browser open <same-url>`.
5. **PR-title-not-in-scope** clarification in `/psy-self-review` Agent 3 — title is passed to `gh pr create --title` separately, so the skill marks the check `N/A` and recommends manual verification.

**Pre-push enforcement** (new mechanism):
- `.claude/hooks/check-simplify-before-pr.sh` (90 lines bash) — `PreToolUse` hook on `Bash` that blocks `gh pr create` if the PR body lacks `[x] /simplify`. Belt-and-suspenders on top of `/psy-self-review`: catches the case where an agent skips `/simplify` AND doesn't claim it (which the self-review audit can't detect — no `[x]` line means no claim to verify).
- `.claude/settings.json` (NEW, project-tracked) — registers the hook.
- `.gitignore` exception (`!.claude/settings.json`) — opens up shared hook config; `settings.local.json` stays user-local.
- Bypass for explicit one-offs: `CLAUDE_SKIP_SIMPLIFY_CHECK=1 gh pr create ...`.

## Heads up from `/simplify`

3 findings from quality reviewer, all addressed in a separate `PSY-667: simplify pass` commit:
1. **`jq` dependency unchecked** → hook now fails open (`command -v jq >/dev/null || exit 0`) instead of blocking ALL Bash calls if jq is missing.
2. **`--body-file=<path>` equals-sign form** not matched → regex updated to `--body-file[=[:space:]]+(...)` to accept both space-separated and equals-sign forms.
3. **`grep -i` accepted `[X]` uppercase** → dropped `-i` so uppercase typos block rather than silently pass.

Verified via 2 new manual test cases (equals-sign passes; `[X]` blocks).

## Test plan

- [x] Hook script tested with 6 scenarios: positive (`[x] /simplify` present) ✓; negative (absent, returns 1 + helpful error) ✓; unrelated `gh pr` calls (silent allow) ✓; env-var bypass ✓; equals-sign `--body-file=` form (post-simplify) ✓; uppercase `[X]` typo (post-simplify, now blocks) ✓.
- [x] `git check-ignore -v .claude/settings.json .claude/settings.local.json` — confirms `settings.json` now trackable via the new exception (line 72); `settings.local.json` still ignored (line 63 `*.json` catches it).
- [x] `git status --short` after `git add` — 5 files staged, no unintended additions.
- [x] `/simplify` — applied 3 findings as a separate commit (jq fail-open + equals-sign regex + drop case-insensitive grep)
- [x] `/psy-self-review` — 0 blocking; 1 warning (stale `phase 5.5` reference at `psy-solo/SKILL.md:316`, fixed in commit `PSY-667: self-review pass`); 2 nits added to Coverage gaps below; PR draft approved.
- [x] Manual repro: 6 hook test scenarios above. Bash script behavior verified end-to-end.

## Manual repro

No UI surface. This is agent-tooling infra:
- Skills are markdown docs the agent reads.
- Hook script fires in Claude Code session lifecycle, not via browser navigation.
- Settings.json is config, not user-facing.

Verification is the 6 hook test cases under Test plan above. Confirmed via:
```bash
echo '{"tool_input":{"command":"gh pr create --body-file=/tmp/test.md"}}' \
  | .claude/hooks/check-simplify-before-pr.sh; echo "exit=$?"
```

## Coverage gaps

Honest disclosure of what was NOT verified locally:

- **Hook fire under live Claude Code session not yet observed** — the hook will fire on this PR's `gh pr create` itself, which is the live test. If the PR opens successfully, the hook + settings registration both work. If it blocks, I'll debug and re-push. Future PRs will fire it routinely.
- **Hook activation requires Claude Code session restart** — Claude Code reads `.claude/settings.json` at session start (with user approval prompt on first encounter of a new hook). The hook won't be active for any in-flight session that started before this PR merged; only post-merge sessions will pick it up. Worth noting in PR-merge follow-up.
- **No collaborators tested** — the hook applies to every Claude Code user on this repo. If another contributor uses Claude Code without `jq` installed, the new fail-open path keeps things working. If they're on a substantially different shell / bash version (we use bash 3.2 per macOS default), regex behavior may differ. Tested only on this machine.
- **No UI screenshots** — agent-tooling diff; nothing to render.
- **Hook empty-body fall-back not exercised** — when `--body-file` regex misses (shell expansion, unreadable path, etc.), the hook falls back to permissive (lines 53-55 of the script). Verified by code inspection only; no test case exercises it because constructing an unreadable-path input is contrived. Rationale: false-positive blocks are worse than missed catches; `/psy-self-review` Agent 1 is the second line of defense.
- **`--body "..."` inline form not exercised** — the script regex-matches `--body[[:space:]]+"(.*)"` for inline-quoted bodies, but the 6 hook test cases all use `--body-file`. The `--body` branch is verified by code inspection only; the gh CLI accepts both forms but the agent-driven workflow now exclusively uses `--body-file` per the updated phase 8 convention, so the inline path is effectively legacy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
