### PR TITLE
PSY-650: drop overlay shadows, font-display titles, tabs underline

### DIFF
--- a/frontend/components/ui/command.tsx
+++ b/frontend/components/ui/command.tsx
@@ -26,7 +26,7 @@ Command.displayName = CommandPrimitive.displayName
 function CommandDialog({ children, ...props }: DialogProps) {
   return (
     <Dialog {...props}>
-      <DialogContent className="overflow-hidden p-0 shadow-lg sm:max-w-[520px] [&>button:last-child]:hidden">
+      <DialogContent className="overflow-hidden p-0 sm:max-w-[520px] [&>button:last-child]:hidden">
         <DialogTitle className="sr-only">Command palette</DialogTitle>
         <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground">
           {children}

--- a/frontend/components/ui/dialog.tsx
+++ b/frontend/components/ui/dialog.tsx
@@ -38,7 +38,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-sm duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
         className
       )}
       {...props}
@@ -88,7 +88,7 @@ const DialogTitle = React.forwardRef<
   <DialogPrimitive.Title
     ref={ref}
     className={cn(
-      'text-lg font-semibold leading-none tracking-tight',
+      'text-lg font-display font-semibold leading-none tracking-tight',
       className
     )}
     {...props}

--- a/frontend/components/ui/dropdown-menu.tsx
+++ b/frontend/components/ui/dropdown-menu.tsx
@@ -42,7 +42,7 @@ function DropdownMenuContent({
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1",
           className
         )}
         {...props}
@@ -230,7 +230,7 @@ function DropdownMenuSubContent({
     <DropdownMenuPrimitive.SubContent
       data-slot="dropdown-menu-sub-content"
       className={cn(
-        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
+        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1",
         className
       )}
       {...props}

--- a/frontend/components/ui/hover-card.tsx
+++ b/frontend/components/ui/hover-card.tsx
@@ -19,7 +19,7 @@ const HoverCardContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-50 w-64 rounded-md border bg-popover p-4 text-popover-foreground outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className
       )}
       {...props}

--- a/frontend/components/ui/popover.tsx
+++ b/frontend/components/ui/popover.tsx
@@ -21,7 +21,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 w-72 rounded-md border bg-popover p-0 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-50 w-72 rounded-md border bg-popover p-0 text-popover-foreground outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className
       )}
       {...props}

--- a/frontend/components/ui/sheet.tsx
+++ b/frontend/components/ui/sheet.tsx
@@ -58,7 +58,7 @@ function SheetContent({
       <SheetPrimitive.Content
         data-slot="sheet-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-sm transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
           side === "right" &&
             "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
           side === "left" &&
@@ -108,7 +108,7 @@ function SheetTitle({
   return (
     <SheetPrimitive.Title
       data-slot="sheet-title"
-      className={cn("text-foreground font-semibold", className)}
+      className={cn("text-foreground font-display font-semibold", className)}
       {...props}
     />
   )

--- a/frontend/components/ui/tabs.tsx
+++ b/frontend/components/ui/tabs.tsx
@@ -26,7 +26,7 @@ function TabsList({
     <TabsPrimitive.List
       data-slot="tabs-list"
       className={cn(
-        "bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]",
+        "bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-md p-[3px]",
         className
       )}
       {...props}
@@ -42,7 +42,7 @@ function TabsTrigger({
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "data-[state=active]:bg-background data-[state=active]:border-b-primary dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}

--- a/frontend/components/ui/tooltip.tsx
+++ b/frontend/components/ui/tooltip.tsx
@@ -20,7 +20,7 @@ const TooltipContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        'z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        'z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         className
       )}
       {...props}


### PR DESCRIPTION
Closes PSY-650.

## Summary
- Restyle 7 overlay/control primitives to consume the PSY-647/648 editorial token foundation.
- Pure className swaps — Radix wiring, props, exports, `data-slot` attributes all preserved.
- 1 in-scope primitive already aligned per audit: `command.tsx` (but its consumer-side `shadow-lg` override was cleaned up — see Changes).

## Changes

| File | Change |
|---|---|
| `dialog.tsx` | DialogContent: drop `shadow-lg`, re-add minimal `shadow-sm` (Dialog reserved for shadow per audit); DialogTitle: `font-semibold` → `font-display font-semibold` |
| `sheet.tsx` | SheetContent: drop `shadow-lg`, re-add `shadow-sm` (same reasoning); SheetTitle: `font-semibold` → `font-display font-semibold` |
| `popover.tsx` | drop `shadow-md` (border only) |
| `hover-card.tsx` | drop `shadow-md` (border only) |
| `dropdown-menu.tsx` | drop `shadow-md` on Content + `shadow-lg` on SubContent (border only) |
| `tooltip.tsx` | drop `shadow-md` (border only) |
| `tabs.tsx` | TabsList: `rounded-lg` → `rounded-md`; TabsTrigger: drop `shadow-sm` on active state, add `border-b-primary` indicator |
| `command.tsx` | drop consumer-side `shadow-lg` override on `<DialogContent>` (was leaking after Dialog's shadow dropped) — caught by `/simplify` |

## Design decisions (user-approved via AskUserQuestion)
- **Overlay shadows**: drop on popover/dropdown/tooltip/hover-card (hairline border only). Dialog + Sheet **revisited after screenshot** — initial decision was full shadowless, but the rendered CommandDialog looked under-elevated, so re-added the most minimal Tailwind shadow (`shadow-sm`, 3px blur at 10% opacity — much subtler than the original `shadow-lg`). Honors the audit's "reserve shadow for true overlays" reservation.
- **Tabs active indicator**: drop `shadow-sm`, add `border-b-primary` 1px burnt-orange underline. Keeps `bg-background` swap as a second cue. Active "Sign in" tab DOM-verified: `borderBottomColor: rgb(210, 84, 27)` = `--primary`.
- **DialogTitle + SheetTitle font**: `font-display font-semibold` (Clash Display 600, matches PSY-649 CardTitle precedent — heading-like semantics).

## Heads up from /simplify
1 actionable finding (fixed inline): `command.tsx:29` had `shadow-lg` as a consumer-side override on `<DialogContent>` that was leaking the pre-PSY-650 elevation after Dialog dropped its base shadow. Audit said `command.tsx` needed "no changes" but didn't reconcile the cascade. Dropped the override; CommandDialog now inherits the new `shadow-sm` from DialogContent's base.

Non-actionable flags from `/simplify` worth recording for a future ticket:
- Emergent heading-primitive pattern across CardTitle / DialogTitle / SheetTitle (all now `font-display font-semibold`); AlertTitle is the outlier (`font-medium tracking-tight`). Worth a follow-up to either align AlertTitle or introduce a shared `<OverlayTitle>` primitive — out of PSY-650 scope.

## Test plan
- [x] `bun run typecheck` — clean
- [x] No `.test.tsx` files import these primitives directly — no unit-test maintenance
- [x] `/simplify` — 1 finding fixed (command.tsx shadow-lg override drop)
- [x] `/psy-self-review` — 0 blocking findings; 2 additional coverage gaps + 1 title NIT surfaced and addressed
- [x] Tabs DOM-verified on `/auth`: active "Sign in" trigger reports `borderBottomColor: rgb(210, 84, 27)` (= `--primary`), `borderBottomWidth: 1px`, `backgroundColor: rgb(244, 241, 234)` (= `--background`). Inactive "Create account": transparent border + transparent bg.
- [x] CommandDialog visually verified on `/auth` after Cmd+K: dialog renders with new `shadow-sm` + 1px hairline border on the dim Cmd+K backdrop.

## Coverage gaps (visual not exercised locally)
- **Dark mode** — tokens differ light vs dark; only light mode screenshotted.
- **Sheet primitive** — usually triggered by mobile nav (desktop viewport doesn't show); class change verified via diff only.
- **Popover / HoverCard / DropdownMenu / Tooltip** — interactive triggers (hover/click). Class change verified via diff (zero `shadow-*` remaining in any) but rendered visuals not screenshotted.
- **`DialogTitle font-display` visible rendering** — the only Dialog screenshotted (CommandDialog) marks its `DialogTitle` as `sr-only`, so the font swap is not visually present in any captured screenshot. Diff-verified only.
- **`shadow-sm` against a non-dim backdrop** — the CommandDialog screenshot exercises `shadow-sm` against the Cmd+K dim overlay, which boosts perceived elevation. A "normal" Dialog opened over a regular page (no overlay dim) was not exercised; the chosen elevation may read differently in that context.

## Screenshots

**Tabs at `/auth`** — active "Sign in" tab has the new 1px `border-b-primary` burnt-orange indicator + `bg-background` swap. Subtle in static PNG but DOM-confirmed above. Inactive "Create account" tab has neither.

![tabs](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-60d0eca41133bf30a567/psy-650-tabs.png)

**CommandDialog (Cmd+K)** — Dialog primitive with `shadow-sm` for elevation against the dim backdrop, `sm:rounded-lg` corners. Inherits the new shadow from `DialogContent`'s base now that the consumer-side `shadow-lg` override was cleaned up. `DialogTitle` is `sr-only` here so the `font-display` swap is not visible in this surface.

![command-dialog](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-60d0eca41133bf30a567/psy-650-command-dialog-v2.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
