### PR TITLE
PSY-651: align TagPill, MusicEmbed, EntityDescription styles

### DIFF
--- a/frontend/components/shared/EntityDescription.tsx
+++ b/frontend/components/shared/EntityDescription.tsx
@@ -158,7 +158,7 @@ export function EntityDescription({
     return (
       <button
         onClick={handleStartEdit}
-        className="w-full rounded-lg border border-dashed border-muted-foreground/25 bg-muted/30 p-4 text-left transition-colors hover:bg-muted/50"
+        className="w-full rounded-md border border-dashed border-muted-foreground/25 bg-muted/30 p-4 text-left transition-colors hover:bg-muted/50"
       >
         <p className="text-sm text-muted-foreground">
           No description yet.{' '}

--- a/frontend/components/shared/MusicEmbed.tsx
+++ b/frontend/components/shared/MusicEmbed.tsx
@@ -105,12 +105,12 @@ export function MusicEmbed({
     return (
       <section className={compact ? 'mb-2' : 'mb-8'}>
         {!compact && (
-          <h2 className="text-lg font-semibold mb-4 flex items-center gap-2">
+          <h2 className="text-lg font-display font-semibold mb-4 flex items-center gap-2">
             <Music className="h-5 w-5" />
             Music
           </h2>
         )}
-        <div className={`flex items-center justify-center ${compact ? 'py-4' : 'py-8'} bg-muted/30 rounded-lg`}>
+        <div className={`flex items-center justify-center ${compact ? 'py-4' : 'py-8'} bg-muted/30 rounded-md`}>
           <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
         </div>
       </section>
@@ -120,7 +120,7 @@ export function MusicEmbed({
   return (
     <section className={compact ? 'mb-2' : 'mb-8'}>
       {!compact && (
-        <h2 className="text-lg font-semibold mb-4 flex items-center gap-2">
+        <h2 className="text-lg font-display font-semibold mb-4 flex items-center gap-2">
           <Music className="h-5 w-5" />
           Music
         </h2>

--- a/frontend/components/shared/TagPill.tsx
+++ b/frontend/components/shared/TagPill.tsx
@@ -32,7 +32,7 @@ export function TagPill({
   onClick,
 }: TagPillProps) {
   const pillClasses = cn(
-    'inline-flex items-center gap-1 rounded-full px-2.5 py-0.5',
+    'inline-flex items-center gap-1 rounded-md px-2.5 py-0.5',
     'text-xs font-medium',
     'bg-muted text-muted-foreground',
     'border border-border/50',
@@ -46,7 +46,7 @@ export function TagPill({
     <>
       <span>{label}</span>
       {voteCount !== undefined && (
-        <span className="text-primary/70 font-semibold">
+        <span className="text-primary/70 font-mono">
           {voteCount >= 0 ? `+${voteCount}` : voteCount}
         </span>
       )}


### PR DESCRIPTION
Closes PSY-651.

## Summary
- Align 3 shared entity-display primitives to the PSY-646 editorial direction. Pure className swaps; APIs/exports/test surfaces all preserved.
- 11 of 14 shared primitives already aligned per audit: `BracketLink` / `Breadcrumb` / `DenseTable` / `EntityCardTitle` / `EntityDetailLayout` / `EntityHeader` / `RelationshipBadge` / `SectionHeader` / `SocialLinks` / `StatsList` / `UserAttribution`. Lightest restyle ticket in the queue.

## Changes

| File | Change |
|---|---|
| `TagPill.tsx` | `rounded-full` → `rounded-md` (square chip per direction); vote-count `<span>` `font-semibold` → `font-mono` (Space Mono is the design-system numerics face per the PSY-647 spec) |
| `EntityDescription.tsx` | empty-state CTA button `rounded-lg` → `rounded-md` |
| `MusicEmbed.tsx` | both `<h2>` section headings `font-semibold` → `font-display font-semibold` (Clash Display 600 — matches PSY-649 CardTitle / PSY-650 DialogTitle precedent); loading-state placeholder `rounded-lg` → `rounded-md` |

## Design decisions (no AskUserQuestion forks — all per audit + cross-cutting font rule)
- **TagPill vote count**: `/simplify` flagged that the audit's blanket "font-semibold → font-medium on Satoshi" would lose the weight differentiator (parent label is already `font-medium`). Resolved by routing the numeric vote count through the design-system-correct face (`font-mono` = Space Mono per the spike spec for "data / metadata / numerics"). Visual differentiation preserved via face-change + retained `text-primary/70` color.
- **MusicEmbed headings**: PSY-649/650 established `font-display font-semibold` for component titles. Applied symmetrically to both render branches (loading + populated). `/simplify` caught a `replace_all` miss on the second occurrence (different indentation) — fixed in the same iteration.
- **SectionHeader + DenseTable left untouched**: their `font-semibold uppercase tracking-wider` is a deliberate small-caps eyebrow pattern from PSY-638/639. Audit explicitly said "no changes". `/simplify` Agent 3 confirmed the load-bearing role and the skip was correct.

## Heads up from /simplify
2 actionable findings (both fixed inline):
1. **MusicEmbed.tsx:123 asymmetric peer**: my `replace_all` for the `<h2>` font swap only hit line 108 (10-space indent); line 123 (8-space indent inside a different JSX branch) was missed. Fixed with a targeted second edit covering both branches.
2. **TagPill vote-count font choice**: changed `font-medium` to `font-mono` (Space Mono) for the design-system-correct numeric annotation treatment.

Non-actionable flag for future:
- **Inline section `<h2>` headings**: MusicEmbed's `<h2 className="text-lg font-display font-semibold mb-4 flex items-center gap-2">` pattern may recur in other features (would benefit from a shared `OverlaySectionTitle` primitive once a 3rd consumer arrives). Not extracted now — rule of three not met.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run test:run components/shared/{TagPill,EntityDescription,MusicEmbed}.test.tsx` — **46/46 passing** across 3 test files
- [x] `/simplify` — 2 actionable findings fixed (font swap symmetry + vote-count face choice)
- [x] `/psy-self-review` — see report
- [x] Code-level verification: `grep "font-semibold\|font-display\|font-mono" frontend/components/shared/{MusicEmbed,TagPill}.tsx` confirms both MusicEmbed `<h2>` branches paired with `font-display`; TagPill vote count uses `font-mono`; no bare-Satoshi `font-semibold` survivors in the 3 touched files.

## Coverage gaps (visual not exercised locally)
The dev DB state and conditional render gates kept the 3 changed primitives off any rendered page accessible without auth or specific data shapes. Code change verified via grep, type, and unit tests; runtime visuals not screenshotted this round.

- **TagPill**: the SHARED `TagPill` is used by `SceneDetail` (only when `data.genres` non-empty) and `VenueDetail` (only when the venue has tags). Phoenix/Tucson scenes in the dev DB have no `genres`; sampled venues had no tags. `/tags/<slug>` uses a LOCAL `TagPill` defined inside `TagDetail.tsx:383` — NOT the shared one — so its visual is unchanged by this PR.
- **TagPill vote count weight resolution**: the vote-count `<span>` uses `font-mono` only (no explicit weight class) so it inherits parent's `font-medium` (Satoshi 500). Space Mono ships only 400 + 700 weights, so the inherited 500 will fall back to either 400 (most likely) or 700 depending on browser font-stack strategy. The face change (Satoshi → Space Mono) + retained `text-primary/70` color provide the primary differentiation; the weight resolution is a secondary visual that's font-stack-dependent and not exercised this round. If a future visual-audit shows the weight contrast is insufficient, explicit `font-bold` would restore it (Space Mono 700 exists).
- **MusicEmbed `<h2>`**: only renders when consumer passes `compact={false}`. Production usage: `ArtistDetail` uses `compact` (no heading rendered → its peer SectionHeader "Top tracks" eyebrow appears instead); `ShowDetail` + `ShowCard` use default (heading SHOULD render but artists in dev DB rarely have bandcamp embed URLs — only 1 of 20 sampled does, and the show detail page for that artist's lineup didn't surface MusicEmbed in viewport scope).
- **EntityDescription empty-state button**: only rendered when `canEdit` is true (auth required to see the dashed-border "Add description" affordance). Auth flow not exercised this round.
- **Dark mode**: not exercised; component classes are token-agnostic for the swapped values.

Considered acceptable scope: `/simplify` Agent 3 confirmed no missed PSY-651-scope files; PSY-652-scope files (LoadingSpinner, DensityToggle, SubmissionSuccessDialog, etc.) intentionally deferred to their own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
