### PR TITLE
PSY-652: align 6 action+status primitives, drop slate-500 literal

### DIFF
--- a/frontend/components/shared/AddToCollectionButton.tsx
+++ b/frontend/components/shared/AddToCollectionButton.tsx
@@ -203,7 +203,7 @@ export function AddToCollectionButton({
       </PopoverTrigger>
       <PopoverContent className="w-72 p-0" align="end">
         <div className="p-3 border-b border-border">
-          <h4 className="text-sm font-semibold">Add to Collection</h4>
+          <h4 className="text-sm font-display font-semibold">Add to Collection</h4>
           <p className="text-xs text-muted-foreground mt-0.5 truncate">
             {entityName}
           </p>

--- a/frontend/components/shared/DensityToggle.tsx
+++ b/frontend/components/shared/DensityToggle.tsx
@@ -55,7 +55,7 @@ export function DensityToggle({
   const group = (
     <div
       className={cn(
-        'inline-flex items-center rounded-lg border border-border/50 bg-muted/30 p-0.5',
+        'inline-flex items-center rounded-md border border-border/50 bg-muted/30 p-0.5',
         disabled && 'opacity-50',
         className
       )}
@@ -75,7 +75,7 @@ export function DensityToggle({
           className={cn(
             'px-2.5 py-1 text-xs font-medium rounded-md transition-colors duration-100 disabled:cursor-not-allowed disabled:hover:text-current',
             density === option.value
-              ? 'bg-background text-foreground shadow-sm'
+              ? 'bg-background text-foreground border border-border'
               : 'text-muted-foreground hover:text-foreground'
           )}
         >

--- a/frontend/components/shared/InlineErrorBanner.test.tsx
+++ b/frontend/components/shared/InlineErrorBanner.test.tsx
@@ -33,7 +33,7 @@ describe('InlineErrorBanner', () => {
 
     const banner = screen.getByRole('alert')
     expect(banner).toHaveClass(
-      'rounded-lg',
+      'rounded-md',
       'border',
       'border-destructive/50',
       'bg-destructive/10',
@@ -122,7 +122,7 @@ describe('InlineErrorBanner', () => {
 
       const banner = screen.getByRole('alert')
       expect(banner).toHaveClass(
-        'rounded-lg',
+        'rounded-md',
         'border',
         'border-destructive/50',
         'bg-destructive/10'

--- a/frontend/components/shared/InlineErrorBanner.tsx
+++ b/frontend/components/shared/InlineErrorBanner.tsx
@@ -64,7 +64,7 @@ export function InlineErrorBanner({
       role="alert"
       data-testid={testId}
       className={cn(
-        'rounded-lg border border-destructive/50 bg-destructive/10',
+        'rounded-md border border-destructive/50 bg-destructive/10',
         VARIANT_CLASSES[variant],
         className
       )}

--- a/frontend/components/shared/RevisionHistory.tsx
+++ b/frontend/components/shared/RevisionHistory.tsx
@@ -169,10 +169,10 @@ export function RevisionHistory({ entityType, entityId, isAdmin = false }: Revis
   const hasMore = offset + limit < total
 
   return (
-    <div className="mt-8 border border-border/50 rounded-lg">
+    <div className="mt-8 border border-border/50 rounded-md">
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="w-full flex items-center gap-2 px-4 py-3 text-left hover:bg-muted/30 transition-colors rounded-lg"
+        className="w-full flex items-center gap-2 px-4 py-3 text-left hover:bg-muted/30 transition-colors rounded-md"
       >
         <History className="h-4 w-4 text-muted-foreground shrink-0" />
         <span className="text-sm font-medium">History</span>

--- a/frontend/components/shared/SaveButton.tsx
+++ b/frontend/components/shared/SaveButton.tsx
@@ -74,7 +74,7 @@ export function SaveButton({
 
       {/* Error tooltip */}
       {showError && error && (
-        <div className="absolute top-full left-1/2 -translate-x-1/2 mt-2 px-3 py-1.5 bg-destructive text-destructive-foreground text-xs rounded-md whitespace-nowrap z-50 shadow-lg">
+        <div className="absolute top-full left-1/2 -translate-x-1/2 mt-2 px-3 py-1.5 bg-destructive text-destructive-foreground text-xs rounded-md whitespace-nowrap z-50 shadow-sm">
           Failed to {isSaved ? 'remove' : 'save'} show
         </div>
       )}

--- a/frontend/components/shared/SubmissionSuccessDialog.tsx
+++ b/frontend/components/shared/SubmissionSuccessDialog.tsx
@@ -28,8 +28,8 @@ export function SubmissionSuccessDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader className="text-center sm:text-center">
-          <div className="mx-auto mb-2 flex h-12 w-12 items-center justify-center rounded-full bg-slate-500/10">
-            <EyeOff className="h-6 w-6 text-slate-500" />
+          <div className="mx-auto mb-2 flex h-12 w-12 items-center justify-center rounded-full bg-muted-foreground/10">
+            <EyeOff className="h-6 w-6 text-muted-foreground" />
           </div>
           <DialogTitle className="text-xl">Private Show Added</DialogTitle>
           <DialogDescription className="text-center">

--- a/frontend/features/venues/components/FavoriteVenueButton.tsx
+++ b/frontend/features/venues/components/FavoriteVenueButton.tsx
@@ -85,7 +85,7 @@ export function FavoriteVenueButton({
 
       {/* Error tooltip */}
       {showError && error && (
-        <div className="absolute top-full left-1/2 -translate-x-1/2 mt-2 px-3 py-1.5 bg-destructive text-destructive-foreground text-xs rounded-md whitespace-nowrap z-50 shadow-lg">
+        <div className="absolute top-full left-1/2 -translate-x-1/2 mt-2 px-3 py-1.5 bg-destructive text-destructive-foreground text-xs rounded-md whitespace-nowrap z-50 shadow-sm">
           Failed to {isFavorited ? 'remove' : 'add'} favorite
         </div>
       )}


### PR DESCRIPTION
Closes PSY-652.

## Summary
- Align 6 shared action/status primitives to the PSY-646 editorial direction. APIs/exports preserved; mutation-feedback banner conventions (red destructive) preserved.
- Drop the codebase's only color-literal violation (`slate-500` on `SubmissionSuccessDialog`).
- 1 in-scope file SKIPPED on design judgment: `LoadingSpinner.tsx` — see Design decisions.
- 2 in-scope files already aligned per audit: `FollowButton.tsx`, `StatusBanner.tsx`.

## Changes

| File | Change |
|---|---|
| `AddToCollectionButton.tsx` | popover h4 `font-semibold` → `font-display font-semibold` (heading semantics, matches PSY-649/650/651 precedent) |
| `DensityToggle.tsx` | container `rounded-lg` → `rounded-md`; active button drop `shadow-sm`, add `border border-border` hairline (`/simplify` Agent 2: bg-background swap alone was insufficient against bg-muted/30 container on newsprint palette) |
| `InlineErrorBanner.tsx` | `rounded-lg` → `rounded-md`. **Banner color tokens (red destructive) preserved** per ticket requirement |
| `InlineErrorBanner.test.tsx` | 2 className assertions updated `rounded-lg` → `rounded-md` |
| `RevisionHistory.tsx` | both rounded-lg (outer + button) → `rounded-md` |
| `SaveButton.tsx` | error tooltip drop `shadow-lg`, add `shadow-sm` (PSY-650 Dialog precedent for true overlays) |
| `SubmissionSuccessDialog.tsx` | icon-badge `bg-slate-500/10` + `text-slate-500` → `bg-muted-foreground/10` + `text-muted-foreground` (semantic token for "private/hidden" affordance — the codebase's only color literal violation, gone) |
| `features/venues/FavoriteVenueButton.tsx` | tooltip `shadow-lg` → `shadow-sm` (`/simplify` Agent 1 caught: clone of SaveButton's tooltip with the same shadow drift — fixed in-scope to keep peers aligned) |

## Design decisions

- **LoadingSpinner.tsx SKIPPED**: audit said `rounded-full → rounded-md`, but the CSS spinner mechanism (`animate-spin rounded-full border-b-2 border-foreground`) **geometrically depends on the circle** — a "spinning square with a single bottom border" renders as a flickering line, not a loading indicator. The audit's "no rounded-full" heuristic targets pill / chip shapes, not the literal geometry of a CSS spinner. Same reasoning preserves Avatar circles in `ui/`.
- **SubmissionSuccessDialog icon shape**: audit said `rounded-full → rounded-lg`, but `/simplify` Agent 2 made a strong case that centered icon badges read better as circles (universal pattern; matches Avatar/spinner exemption above). Kept `rounded-full` on the icon wrapper, applied only the color-literal cleanup. Two-out-of-three audit instruction followed.
- **DensityToggle active state**: audit said "drop shadow, use border for active state". Initial implementation dropped shadow without border, relying on bg-background swap alone. `/simplify` Agent 2 flagged that against the newsprint palette's tight luminance range (bg-background `#f4f1ea` vs container bg-muted/30) the swap is too subtle. Restored the hairline `border border-border` per the audit's original recommendation.

## Heads up from /simplify

3 actionable findings, all fixed inline:
1. **DensityToggle active state** — added border (above).
2. **SubmissionSuccessDialog icon shape** — reverted to rounded-full (above).
3. **FavoriteVenueButton tooltip drift** — Agent 1 spotted that `FavoriteVenueButton.tsx:88` is a byte-identical clone of `SaveButton.tsx:77`'s error tooltip but still had `shadow-lg`. Fixed in-scope to prevent peer drift.

Non-actionable observations for future:
- **Emergent `font-display font-semibold` heading pattern** across 4+ shared surfaces (CardTitle, DialogTitle, SheetTitle, MusicEmbed h2, AddToCollectionButton h4). Worth a future `<DisplayHeading>` primitive — not extracted now (rule of three+ met but inconsistent positioning across consumers makes a clean API non-obvious).
- **Emergent `<IconBadge>` pattern**: `SubmissionSuccessDialog.tsx:31`, `TagDetail.tsx:181`, `VenueDeniedDialog.tsx:33` all render an `h-12 w-12 items-center justify-center rounded-* bg-*/10` centered icon wrapper with divergent radius (lg vs full) and tone. Worth a future `<IconBadge tone="muted|destructive" shape="circle|square" />` primitive.
- **Emergent error-tooltip pattern**: `SaveButton.tsx:77` and `FavoriteVenueButton.tsx:88` are now byte-identical — a 3rd consumer would justify extracting `<InlineErrorTooltip>` OR migrating both to `<Tooltip>` from `components/ui/tooltip.tsx`.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run test:run components/shared features/venues/components/FavoriteVenueButton` — **310/310 passing** across 24 test files (includes the updated `InlineErrorBanner.test.tsx` className assertion)
- [x] `/simplify` — 3 actionable findings fixed (DensityToggle border, SubmissionSuccessDialog icon shape, FavoriteVenueButton clone)
- [x] `/psy-self-review` — see report
- [x] **DensityToggle DOM-verified on `/artists`** (active "Comfortable" tab): `containerBorderRadius: 4px` (= `rounded-md`); active button `borderColor: rgb(202, 190, 159)` (= `--border` `#cabe9f`), `borderWidth: 1px`, `backgroundColor: rgb(244, 241, 234)` (= `--background`), `boxShadow: none`; inactive buttons report `borderWidth: 0px`, no bg, no shadow — correct asymmetric active-state cue.
- [x] **DensityToggle visually captured** at `/artists`: see Screenshots.

## Coverage gaps (visual not exercised locally)

- **Dark mode** — only light mode screenshotted; component classes are token-agnostic for the swapped values.
- **DensityToggle indicator-tracks-active-button across states** — DOM measurement + screenshot only cover "Comfortable" as the active button. The asymmetric active-state cue (border + bg swap follows whichever button is clicked) is verified for Comfortable; Compact + Expanded active states not visually captured this round.
- **`AddToCollectionButton` popover `<h4>`** — requires auth + popover open. Class change verified via diff; not screenshotted.
- **`InlineErrorBanner`** — only renders on error states (form submission failures, network issues). Diff + tests verified; not screenshotted.
- **`SaveButton` + `FavoriteVenueButton` error tooltips** — same: only render on action failure. Diff verified; not screenshotted.
- **`RevisionHistory`** — collapsed by default; needs interaction to expand and shows edit-history rows (which also need auth). Diff verified; not screenshotted.
- **`SubmissionSuccessDialog`** — renders only after successful private show submission (auth + form completion + private flag). Diff verified; not screenshotted.

## Screenshots

**DensityToggle at `/artists`** — clean editorial appearance. Container has new `rounded-md` corners. Active "Comfortable" button shows the new hairline `border-border` indicator + `bg-background` swap; inactive "Compact" and "Expanded" buttons have no border. No shadows anywhere.

![density-toggle](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-e71903638be04d5e559a/psy-652-density-toggle.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
