### PR TITLE
PSY-653: align 4 shell primitives, square TopBar logo

### DIFF
--- a/frontend/components/layout/CommandPalette.tsx
+++ b/frontend/components/layout/CommandPalette.tsx
@@ -546,7 +546,7 @@ export function CommandPalette() {
                   key={`recent-${label}`}
                   value={`recent-${label}`}
                   onSelect={() => handleRecentSelect(label)}
-                  className="cursor-pointer gap-3 rounded-lg px-2 py-2.5"
+                  className="cursor-pointer gap-3 rounded-md px-2 py-2.5"
                   keywords={[label]}
                 >
                   <Clock className="h-4 w-4 text-muted-foreground" />
@@ -575,7 +575,7 @@ export function CommandPalette() {
                   key={`entity-${type}-${result.id}`}
                   value={`entity-${type}-${result.id}-${result.name}`}
                   onSelect={() => handleEntitySelect(result)}
-                  className="cursor-pointer gap-3 rounded-lg px-2 py-2.5"
+                  className="cursor-pointer gap-3 rounded-md px-2 py-2.5"
                   keywords={[result.name]}
                 >
                   <Icon className="h-4 w-4 text-muted-foreground" />
@@ -618,7 +618,7 @@ export function CommandPalette() {
                     value={route.label}
                     onSelect={() => handleSelect(route.href, route.label)}
                     keywords={route.keywords}
-                    className="cursor-pointer gap-3 rounded-lg px-2 py-2.5"
+                    className="cursor-pointer gap-3 rounded-md px-2 py-2.5"
                   >
                     <Icon className="h-4 w-4 text-muted-foreground" />
                     <span>{route.label}</span>
@@ -642,7 +642,7 @@ export function CommandPalette() {
                 value={route.label}
                 onSelect={() => handleSelect(route.href, route.label)}
                 keywords={route.keywords}
-                className="cursor-pointer gap-3 rounded-lg px-2 py-2.5"
+                className="cursor-pointer gap-3 rounded-md px-2 py-2.5"
               >
                 <Icon className="h-4 w-4 text-muted-foreground" />
                 <span>{route.label}</span>
@@ -666,7 +666,7 @@ export function CommandPalette() {
                     value={route.label}
                     onSelect={() => handleSelect(route.href, route.label)}
                     keywords={route.keywords}
-                    className="cursor-pointer gap-3 rounded-lg px-2 py-2.5"
+                    className="cursor-pointer gap-3 rounded-md px-2 py-2.5"
                   >
                     <Icon className="h-4 w-4 text-muted-foreground" />
                     <span>{route.label}</span>

--- a/frontend/components/layout/CookieConsentBanner.tsx
+++ b/frontend/components/layout/CookieConsentBanner.tsx
@@ -33,7 +33,7 @@ export function CookieConsentBanner() {
   return (
     <>
       <div
-        className="fixed bottom-0 left-0 right-0 z-50 border-t bg-background p-4 shadow-lg motion-safe:animate-in motion-safe:slide-in-from-bottom motion-safe:duration-300"
+        className="fixed bottom-0 left-0 right-0 z-50 border-t bg-background p-3 motion-safe:animate-in motion-safe:slide-in-from-bottom motion-safe:duration-300"
         role="dialog"
         aria-label="Cookie consent"
         aria-describedby="cookie-consent-description"

--- a/frontend/components/layout/Footer.tsx
+++ b/frontend/components/layout/Footer.tsx
@@ -9,7 +9,7 @@ export default function Footer() {
 
   return (
     <footer className="w-full border-t border-border/30 mt-auto">
-      <div className="max-w-7xl mx-auto px-4 py-6">
+      <div className="max-w-7xl mx-auto px-4 py-4">
         <div className="flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-muted-foreground">
           <p>&copy; {currentYear} Psychic Homily</p>
           <nav className="flex items-center gap-4">

--- a/frontend/components/layout/TopBar.tsx
+++ b/frontend/components/layout/TopBar.tsx
@@ -207,14 +207,14 @@ export function TopBar({ mobileOpen, onMobileOpenChange, onSearchClick }: TopBar
           </Sheet>
 
           <Link href="/" className="flex items-center gap-2 transition-opacity hover:opacity-80">
-            <div className="relative h-[36px] w-[36px] overflow-hidden rounded-full">
+            <div className="relative h-[36px] w-[36px] overflow-hidden rounded-md">
               <Image
                 src="/PsychicHomilyLogov2.svg"
                 alt="Psychic Homily Logo"
                 width={36}
                 height={36}
                 priority
-                className="rounded-full"
+                className="rounded-md"
                 style={{ filter: 'url(#glitch)' }}
               />
             </div>


### PR DESCRIPTION
Closes PSY-653.

Last ticket in the Design System Overhaul: Editorial & Dense sprint. Aligns the four `components/layout/` files the audit flagged; the other four shell files (CookiePreferencesDialog, mode-toggle, Sidebar, SidebarLayout) were already in spec.

## Summary
- **CommandPalette.tsx** — 5 `CommandItem` className strings: `rounded-lg` → `rounded-md` (lines 549, 578, 621, 645, 669).
- **CookieConsentBanner.tsx** — fixed banner div: drop `shadow-lg`, `p-4` → `p-3` (line 36). `border-t` was already present; it now carries all the elevation.
- **Footer.tsx** — content wrapper: `py-6` → `py-4` (line 12) for tighter editorial vertical rhythm.
- **TopBar.tsx** — logo wrapper + inner `<Image>` (lines 210, 217): `rounded-full` → `rounded-md`. User avatar circles at lines 261/264 retained as `rounded-full` (allowed icon ornament per sprint convention).

## Notes
- The inner `<Image>`'s `rounded-md` (line 217) is technically redundant given the wrapper's `overflow-hidden rounded-md` does the clipping. Kept matching for defense-in-depth (mirrors the pre-PR pattern where both carried `rounded-full`) and because the image also carries an SVG `filter: url(#glitch)` whose interaction with overflow clipping is not worth re-litigating in a class-swap PR. `/simplify` flagged this as a NIT; decision is to keep.
- The 5x CommandItem className duplication in `CommandPalette.tsx` is pre-existing, not introduced here. Out of scope per the sprint's "pure swaps, no extraction" pattern (matches PSY-649/650/651/652).

## Test plan
- [x] `bun run typecheck` — clean.
- [x] `bun run test:run components/layout` — 112/112 passing across 8 test files (CommandPalette, CookieConsentBanner, CookiePreferencesDialog, Footer, mode-toggle, Sidebar, SidebarLayout, TopBar). No class-string assertions in tests, so no test updates needed.
- [x] `/simplify` — clean across reuse/quality/efficiency. 2 NITs; one intentionally retained (see Notes), other was pre-existing out-of-scope.
- [x] `/psy-self-review` — see Phase 7.6 in workflow.
- [x] Manual repro against local dev stack on homepage in both light and dark themes:
  - TopBar logo renders as a rounded square (`rounded-md`) instead of a circle.
  - Cookie consent banner has no drop shadow, tighter vertical padding, and reads cleanly against the bottom border.
  - Footer is tighter (single-line copyright + nav links on one row at sm+ widths).
  - Command palette items have the sharper `rounded-md` corners; DOM-eval confirms all 19 rendered items carry the new class.

## Screenshots

**Light theme — homepage with cookie banner visible:** new squared logo top-left, banner has no shadow + tighter padding at bottom.

![Light theme homepage](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-e359f0737aade476fcd9/psy-653-home-light-top.png)

**Light theme — full page:** captures footer (tighter `py-4`) at the bottom alongside the rest of the shell.

![Light theme full page](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-e359f0737aade476fcd9/psy-653-home-light-full.png)

**Dark theme — homepage:** same shell changes carry through to dark; logo squared, banner clean, sidebar unchanged.

![Dark theme homepage](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-e359f0737aade476fcd9/psy-653-home-dark-top.png)

**Command palette open (dark):** items have the new `rounded-md` corners. Highlighted "Shows" row shows the slightly squarer selected-state bg vs the prior `rounded-lg`.

![Command palette dark](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-e359f0737aade476fcd9/psy-653-palette-dark.png)

## Coverage gaps

Honest disclosure of what the screenshots / manual repro do NOT cover:

- **Mobile (<sm) viewport not explicitly captured** — at mobile width the "Psychic Homily" wordmark in the TopBar is hidden, leaving just the 36×36 logo (the squared corners are most visible at this size). The cookie banner's button row also stacks vertically (`flex-col gap-4 sm:flex-row`) and the `p-4`→`p-3` padding change applies there too. Visual-only risk; classes are width-agnostic. Mobile-sheet hamburger menu (`TopBar.tsx:62–207`) untouched by this diff.
- **Authenticated user avatar circle not visually verified** — the `rounded-full` retention at TopBar.tsx:261/264 was confirmed via diff inspection only. Auth flow was skipped per psy-solo convention.
- **Light-theme command palette not screenshotted** — the radius change is theme-independent (Tailwind class), and the dark palette + DOM-eval prove the class is applied. Adding a light-mode palette screenshot would not surface new information.
- **Cookie-banner Reject/Customize/Accept flows not exercised** — banner appearance is the only thing this PR changes; the existing tests in `CookieConsentBanner.test.tsx` cover the interaction surface.
