### PR TITLE
PSY-642: open artist bio inline editing to trusted tiers

### DIFF
--- a/.claude/skills/psy-solo/SKILL.md
+++ b/.claude/skills/psy-solo/SKILL.md
@@ -165,7 +165,13 @@ const d = Array.from(document.querySelectorAll('[role=\"dialog\"]')).find(el => 
 
 Caught: May 16 post-shipped-UI audit — `offsetParent` false-negative made the Graph Dialog look like it never auto-opened from `#graph` URL; subsequent screenshot confirmed it DID open (the bug was on close, not on open).
 
-**6e. Auth-state screenshots are usually skippable.** Unauthenticated screenshots show the structural changes (flat layout, hide-when-empty, sidebar shape, public BracketLinks like `[Follow]`). Auth-only brackets (`[Edit | Suggest edit]`, `[Suggest description]`, `[Add tag]`, `[Report]`) are visible in the diff and can be described in the PR body. Skip the auth login flow unless the reviewer needs to see the rendered auth-only state.
+**6e. Auth-state screenshots — capture when the diff changes auth-gated behavior.** Skip the auth login flow only when the diff is structural / public-surface-only and the auth-only brackets are unchanged. For diffs that *change* what auth users see (permission expansion, new auth-gated affordances, gate flips like `canEdit={!!isAdmin}` → `canEdit={!!canEditDirectly}`), the rendered authenticated state IS the user-facing change — screenshot it.
+
+**Local dev test accounts** (harmless dev creds, owner-provided 2026-05-17):
+- Admin: `asdf@admin.com` / `adminadmin`
+- Non-admin: `asdfTwo@admin.com` / `TangoTango1` (default `contributor` tier; promote via admin UI or DB to test `trusted_contributor` / `local_ambassador` paths)
+
+Login URL: `http://localhost:3000/auth/login`. Use `agent-browser fill` for the form and `agent-browser click` for the submit; the JWT lands in cookies + AuthContext picks it up after a navigation. To promote a tier for trusted-tier screenshots: log in as admin first, hit the user management surface (or run a direct SQL update against the local dev DB — see `backend/db/migrations/` for the user-tier column).
 
 **6f. Upload via `gh release create --draft` for image hosting.** GitHub markdown can't embed local files or base64 PNGs, and `gh` has no direct image-upload API for PRs. The reliable path: create a DRAFT release with the PNGs as assets and embed the asset download URLs.
 

--- a/frontend/features/artists/components/ArtistDetail.test.tsx
+++ b/frontend/features/artists/components/ArtistDetail.test.tsx
@@ -80,6 +80,7 @@ vi.mock('@/features/contributions', () => ({
   ReportEntityDialog: ({ open, entityName }: { open: boolean; entityName: string }) =>
     open ? <div data-testid="report-dialog">Report {entityName}</div> : null,
   ContributionPrompt: () => null,
+  useSuggestEdit: () => ({ mutate: vi.fn(), isPending: false }),
 }))
 
 // Mock comments feature

--- a/frontend/features/artists/components/ArtistDetail.tsx
+++ b/frontend/features/artists/components/ArtistDetail.tsx
@@ -47,7 +47,7 @@ import {
 } from '@/components/shared'
 import { ArtistTrajectoryChart } from '@/features/festivals/components/ArtistTrajectoryChart'
 import { EntityTagList, AddTagDialog } from '@/features/tags'
-import { EntityEditDrawer, EntitySaveSuccessBanner, useEntitySaveSuccessBanner, AttributionLine, ReportEntityDialog, ContributionPrompt } from '@/features/contributions'
+import { EntityEditDrawer, EntitySaveSuccessBanner, useEntitySaveSuccessBanner, AttributionLine, ReportEntityDialog, ContributionPrompt, useSuggestEdit } from '@/features/contributions'
 import { AsHeardOn } from '@/features/radio'
 import { EntityCollections } from '@/features/collections'
 import { CommentThread } from '@/features/comments'
@@ -824,6 +824,7 @@ export function ArtistDetail({ artistId }: ArtistDetailProps) {
   const isAdmin = isAuthenticated && user?.is_admin
   const canEditDirectly = isAdmin || user?.user_tier === 'trusted_contributor' || user?.user_tier === 'local_ambassador'
   const updateArtist = useArtistUpdate()
+  const suggestArtistEdit = useSuggestEdit()
 
   const [isEditing, setIsEditing] = useState(false)
   const [editFocusField, setEditFocusField] = useState<string | undefined>()
@@ -1007,19 +1008,44 @@ export function ArtistDetail({ artistId }: ArtistDetailProps) {
 
           <EntityDescription
             description={artist.description}
-            canEdit={!!isAdmin}
+            canEdit={!!canEditDirectly}
             onSave={async (description) => {
               await new Promise<void>((resolve, reject) => {
-                updateArtist.mutate(
-                  { artistId: artist.id, data: { description } },
+                if (isAdmin) {
+                  updateArtist.mutate(
+                    { artistId: artist.id, data: { description } },
+                    {
+                      onSuccess: () => {
+                        queryClient.invalidateQueries({
+                          queryKey: queryKeys.artists.detail(artistId),
+                        })
+                        resolve()
+                      },
+                      onError: reject,
+                    }
+                  )
+                  return
+                }
+                // PSY-642: trusted_contributor + local_ambassador route through
+                // suggest-edit, which auto-applies for them via canEditDirectly
+                // (backend pending_edit.go). useSuggestEdit's own onSuccess
+                // invalidates ['artists'], which prefix-matches the detail key.
+                suggestArtistEdit.mutate(
                   {
-                    onSuccess: () => {
-                      queryClient.invalidateQueries({
-                        queryKey: queryKeys.artists.detail(artistId),
-                      })
-                      resolve()
-                    },
-                    onError: (err) => reject(err),
+                    entityType: 'artist',
+                    entityId: artist.id,
+                    changes: [
+                      {
+                        field: 'description',
+                        old_value: artist.description ?? '',
+                        new_value: description,
+                      },
+                    ],
+                    summary: 'Updated description via inline editor',
+                  },
+                  {
+                    onSuccess: () => resolve(),
+                    onError: reject,
                   }
                 )
               })


### PR DESCRIPTION
Closes PSY-642.

## Summary
- Flip `EntityDescription`'s `canEdit` prop on `ArtistDetail.tsx` from `!!isAdmin` to `!!canEditDirectly` so `trusted_contributor` + `local_ambassador` see the inline bio editor (previously admin-only).
- Branch the `onSave` callback: admins keep routing through `useArtistUpdate` (PATCH `/admin/artists/:id`); trusted tiers route through `useSuggestEdit` (PUT `/artists/:id/suggest-edit`), which auto-applies for them via the existing backend `canEditDirectly` helper. Summary is synthesized (`"Updated description via inline editor"`) because the inline editor doesn't collect one — the `revisions` row captures the diff + editor identity, which is the load-bearing audit signal.

Backend untouched. The suggest-edit pipeline, `description` in `ArtistAllowedEditFields`, the `canEditDirectly` helper at `backend/internal/api/handlers/admin/pending_edit.go`, and trust-tier coverage in `pending_edit_test.go` (`TestCanEditDirectly` + trusted-contributor auto-apply assertions) were all already in place.

Also bundles a small `psy-solo` SKILL update: replaces the "auth-state screenshots are usually skippable" guidance with the rule that auth-gated permission flips MUST be screenshotted, and records the owner-provided local-dev test accounts so future agents can run the same trusted-tier repro without re-asking.

## Deferred (per pre-implementation Q&A)
- **Venue surface (`VenueDetail.tsx:286`)** — identical admin-only gate + `useVenueUpdate` shape; intentionally out of scope per the ticket boundary. Filed **PSY-668**.
- **Pending-edit invalidation when a direct-apply lands** — system-wide concern (a regular user's open `pending_entity_edits` row on the same `(entity, field)` is not auto-marked superseded when a trusted user direct-edits). Pre-exists this PR; not unique to bio editing. Not filed — surface as a separate audit if/when it bites in practice.

## Heads up from `/simplify`
Reviewer flagged that `useSuggestEdit`'s built-in `onSuccess` already invalidates `['artists']` (prefix-matches the detail key), so the suggest branch doesn't need its own `queryClient.invalidateQueries(queryKeys.artists.detail(...))`. Dropped that call; the admin branch keeps its explicit invalidate to preserve pre-existing behavior. Also dropped a `(err) => reject(err)` identity wrap on both branches.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run test:run features/artists` — 215/215 passing
- [x] `cd backend && go build ./...` — clean (backend untouched; sanity check)
- [x] `cd backend && go test ./internal/api/handlers/admin/... ./internal/services/catalog/...` — green (pending_edit + artist service paths covering the trust-tier branches we rely on)
- [x] `/simplify` — addressed two findings (drop redundant invalidate in suggest branch; drop `(err) => reject(err)` identity wraps)
- [x] `/psy-self-review` — clean
- [x] Manual repro: promoted `asdfTwo@admin.com` to `trusted_contributor` via `UPDATE users SET user_tier='trusted_contributor' WHERE email='asdfTwo@admin.com'`; logged in via `/auth`; navigated to `/artists/amyl-and-the-sniffers`; saw + clicked the new pencil affordance; edited the bio with a sentinel string; saved. Verified the persisted bio in `artists.description`, an `approved` row in `pending_entity_edits` (status=approved, reviewed_by=self via canEditDirectly auto-apply), and a matching `revisions` row with `summary='Updated description via inline editor'`, `user_id=7`, and `field_changes` carrying the old→new diff. Then reset the bio back to its original value.

## Screenshots
Trusted_contributor on `/artists/amyl-and-the-sniffers`:

![Trusted user sees the new pencil affordance on the bio (was admin-only before this PR)](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-1b33b48c45aa2d87f3a5/psy-642-trusted-bio-render.png)

![Clicking the affordance opens the same inline textarea editor that admins have used](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-1b33b48c45aa2d87f3a5/psy-642-trusted-bio-editing.png)

![After Save, the bio updates with the new value (sentinel `[PSY-642 trusted edit test]` proves the round-trip; reset post-screenshot)](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-1b33b48c45aa2d87f3a5/psy-642-trusted-bio-saved.png)

## Coverage gaps
- **Admin path not re-screenshotted.** The `updateArtist.mutate(...)` call inside the admin branch is byte-identical to the pre-PR call, but the branching structure around it IS new (the call is now gated behind an `if (isAdmin) { ... return }` early-return). Risk is low — the call signature, endpoint, payload, and invalidation are unchanged — but no admin-session screenshot was taken to confirm the gated path still fires.
- **`local_ambassador` tier not separately exercised.** `canEditDirectly` recognizes both `trusted_contributor` and `local_ambassador`; the backend `canEditDirectly` helper at `backend/internal/api/handlers/admin/pending_edit.go` returns true for both. Only `trusted_contributor` was screenshotted because both share the exact same code path on both sides; the unit test `TestCanEditDirectly` already covers both tiers.
- **Regular-user-blocked path not separately exercised.** Regular `contributor` / `new_user` accounts see `canEditDirectly=false`, so the pencil affordance is not rendered — they have no path to call `onSave`. Verified by the existing `EntityDescription` primitive's `canEdit`-gated render branch; no new test added because the existing primitive is unchanged.
- **Error path on the suggest branch not exercised.** `suggestArtistEdit.mutate(..., { onError: reject })` rejects the outer Promise, which propagates to `EntityDescription`'s `catch` block and renders the error string. Manual repro only exercised the happy path; backend error cases (429 rate-limit per PSY-589, 409 duplicate-pending, 403 / 422 validation) are not visually verified to render correctly. Backend behavior is tested separately in `pending_edit_test.go`.
- **Empty-prior-description path (`artist.description ?? ''` fallback for `old_value`) not exercised.** Amyl and The Sniffers had a non-null description in the repro. The `?? ''` fallback only fires when prior description is null; semantically equivalent to null on the backend (per `pending_edit` handling), but the "first-ever-edit-from-empty" path was not visually round-tripped.
- **Pending-edit conflict with regular-user's open suggested edit** — see Deferred section above; pre-existing system-wide concern, not introduced by this PR.
