### PR TITLE
PSY-669: surface network + sibling stations on radio station response

### DIFF
--- a/backend/cmd/seed/main.go
+++ b/backend/cmd/seed/main.go
@@ -848,6 +848,7 @@ func seedRadioStationsAndShows(database *gorm.DB) (int, int) {
 			BroadcastType:  s.BroadcastType,
 			PlaylistSource: &s.PlaylistSource,
 			IsActive:       true,
+			IsFlagship:     s.IsFlagship,
 		}
 		if s.State != "" {
 			station.State = &s.State

--- a/backend/db/migrations/20260517155740_radio_stations_add_is_flagship.down.sql
+++ b/backend/db/migrations/20260517155740_radio_stations_add_is_flagship.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE radio_stations DROP COLUMN IF EXISTS is_flagship;

--- a/backend/db/migrations/20260517155740_radio_stations_add_is_flagship.up.sql
+++ b/backend/db/migrations/20260517155740_radio_stations_add_is_flagship.up.sql
@@ -1,0 +1,11 @@
+-- PSY-669: add is_flagship to radio_stations so the network nesting UI
+-- can derive which station of a network is the primary/default view
+-- (e.g. WFMU 91.1 is the flagship of the WFMU network; the 3 stream-only
+-- sub-channels are non-flagship siblings). Backfills WFMU only — every
+-- other existing station has no network_id today, so flagship is moot.
+ALTER TABLE radio_stations
+  ADD COLUMN is_flagship BOOLEAN NOT NULL DEFAULT FALSE;
+
+UPDATE radio_stations
+   SET is_flagship = TRUE
+ WHERE slug = 'wfmu';

--- a/backend/internal/models/catalog/radio.go
+++ b/backend/internal/models/catalog/radio.go
@@ -70,6 +70,7 @@ type RadioStation struct {
 	LastPlaylistFetchAt *time.Time       `gorm:"column:last_playlist_fetch_at"`
 	IsActive            bool             `gorm:"column:is_active;not null;default:true"`
 	NetworkID           *uint            `gorm:"column:network_id"`
+	IsFlagship          bool             `gorm:"column:is_flagship;not null;default:false"`
 	CreatedAt           time.Time        `gorm:"not null"`
 	UpdatedAt           time.Time        `gorm:"not null"`
 

--- a/backend/internal/seeddata/radio.go
+++ b/backend/internal/seeddata/radio.go
@@ -44,6 +44,7 @@ type RadioStation struct {
 	FrequencyMHz   float64 // 0 -> NULL (for internet-only stations)
 	PlaylistSource string  // provider tag used by the fetcher pipeline
 	NetworkSlug    string  // empty -> NULL (station has no parent network)
+	IsFlagship     bool    // true -> primary station of NetworkSlug; only one flagship per network
 }
 
 // RadioShow is the canonical description of a flagship show on a radio
@@ -103,6 +104,7 @@ var RadioStations = []RadioStation{
 		FrequencyMHz:   91.1,
 		PlaylistSource: "wfmu_scrape",
 		NetworkSlug:    "wfmu",
+		IsFlagship:     true,
 	},
 	{
 		// PSY-508: WFMU stream-only 24/7 sub-channel curated by Doug

--- a/backend/internal/seeddata/radio_sql.go
+++ b/backend/internal/seeddata/radio_sql.go
@@ -38,7 +38,7 @@ func RenderRadioSeedSQL(w io.Writer) error {
 	b.WriteString("ON CONFLICT (slug) DO NOTHING;\n\n")
 
 	b.WriteString("-- Radio stations (generated from backend/internal/seeddata/radio.go)\n")
-	b.WriteString("INSERT INTO radio_stations (name, slug, description, city, state, country, timezone, stream_url, website, donation_url, broadcast_type, frequency_mhz, playlist_source, network_id, is_active, created_at, updated_at) VALUES\n")
+	b.WriteString("INSERT INTO radio_stations (name, slug, description, city, state, country, timezone, stream_url, website, donation_url, broadcast_type, frequency_mhz, playlist_source, network_id, is_flagship, is_active, created_at, updated_at) VALUES\n")
 	for i, s := range RadioStations {
 		b.WriteString("  (")
 		b.WriteString(sqlString(s.Name))
@@ -68,6 +68,8 @@ func RenderRadioSeedSQL(w io.Writer) error {
 		b.WriteString(sqlString(s.PlaylistSource))
 		b.WriteString(", ")
 		b.WriteString(sqlNetworkIDFromSlug(s.NetworkSlug))
+		b.WriteString(", ")
+		b.WriteString(strconv.FormatBool(s.IsFlagship))
 		b.WriteString(", true, NOW(), NOW())")
 		if i < len(RadioStations)-1 {
 			b.WriteString(",")

--- a/backend/internal/services/catalog/radio.go
+++ b/backend/internal/services/catalog/radio.go
@@ -160,27 +160,57 @@ func (s *RadioService) ListStations(filters map[string]interface{}) ([]*contract
 		}
 	}
 
+	// Batch-load siblings per network so list responses can render the
+	// network tab bar without N+1 (one extra query total, regardless of
+	// how many networked stations are in the response).
+	networkIDSet := make(map[uint]struct{})
+	for _, st := range stations {
+		if st.NetworkID != nil {
+			networkIDSet[*st.NetworkID] = struct{}{}
+		}
+	}
+	networkIDs := make([]uint, 0, len(networkIDSet))
+	for id := range networkIDSet {
+		networkIDs = append(networkIDs, id)
+	}
+	stationsByNetwork := s.batchFetchSiblings(networkIDs)
+
 	responses := make([]*contracts.RadioStationListResponse, len(stations))
 	for i, st := range stations {
 		var networkSlug *string
+		var network *contracts.RadioNetworkInfo
 		if st.Network != nil {
 			slug := st.Network.Slug
 			networkSlug = &slug
+			network = &contracts.RadioNetworkInfo{
+				Slug:       st.Network.Slug,
+				Name:       st.Network.Name,
+				IsFlagship: st.IsFlagship,
+			}
 		}
+
+		var networkScoped []contracts.RadioSiblingStationResponse
+		if st.NetworkID != nil {
+			networkScoped = stationsByNetwork[*st.NetworkID]
+		}
+		siblings := excludeSibling(networkScoped, st.ID)
+
 		responses[i] = &contracts.RadioStationListResponse{
-			ID:            st.ID,
-			Name:          st.Name,
-			Slug:          st.Slug,
-			City:          st.City,
-			State:         st.State,
-			Country:       st.Country,
-			BroadcastType: st.BroadcastType,
-			FrequencyMHz:  st.FrequencyMHz,
-			LogoURL:       st.LogoURL,
-			IsActive:      st.IsActive,
-			NetworkID:     st.NetworkID,
-			NetworkSlug:   networkSlug,
-			ShowCount:     showCounts[st.ID],
+			ID:              st.ID,
+			Name:            st.Name,
+			Slug:            st.Slug,
+			City:            st.City,
+			State:           st.State,
+			Country:         st.Country,
+			BroadcastType:   st.BroadcastType,
+			FrequencyMHz:    st.FrequencyMHz,
+			LogoURL:         st.LogoURL,
+			IsActive:        st.IsActive,
+			NetworkID:       st.NetworkID,
+			NetworkSlug:     networkSlug,
+			Network:         network,
+			SiblingStations: siblings,
+			ShowCount:       showCounts[st.ID],
 		}
 	}
 
@@ -922,12 +952,21 @@ func (s *RadioService) buildStationDetailResponse(station *catalogm.RadioStation
 	s.db.Model(&catalogm.RadioShow{}).Where("station_id = ?", station.ID).Count(&showCount)
 
 	// network_slug is convenience for clients that already know how to
-	// resolve a slug; full network objects are not embedded here.
+	// resolve a slug; the nested Network object below carries the same
+	// info plus name + is_flagship.
 	var networkSlug *string
+	var network *contracts.RadioNetworkInfo
 	if station.Network != nil {
 		slug := station.Network.Slug
 		networkSlug = &slug
+		network = &contracts.RadioNetworkInfo{
+			Slug:       station.Network.Slug,
+			Name:       station.Network.Name,
+			IsFlagship: station.IsFlagship,
+		}
 	}
+
+	siblings := s.fetchSiblings(station.NetworkID, station.ID)
 
 	return &contracts.RadioStationDetailResponse{
 		ID:                  station.ID,
@@ -953,10 +992,68 @@ func (s *RadioService) buildStationDetailResponse(station *catalogm.RadioStation
 		IsActive:            station.IsActive,
 		NetworkID:           station.NetworkID,
 		NetworkSlug:         networkSlug,
+		Network:             network,
+		SiblingStations:     siblings,
 		ShowCount:           int(showCount),
 		CreatedAt:           station.CreatedAt,
 		UpdatedAt:           station.UpdatedAt,
 	}, nil
+}
+
+// fetchSiblings is the single-station-response convenience wrapper around
+// batchFetchSiblings. Used by buildStationDetailResponse so single-station
+// fetch paths and the list path share one query shape.
+func (s *RadioService) fetchSiblings(networkID *uint, excludeStationID uint) []contracts.RadioSiblingStationResponse {
+	if networkID == nil {
+		return []contracts.RadioSiblingStationResponse{}
+	}
+	byNetwork := s.batchFetchSiblings([]uint{*networkID})
+	return excludeSibling(byNetwork[*networkID], excludeStationID)
+}
+
+// batchFetchSiblings returns network_id → all stations in that network
+// (caller-side filters self via excludeSibling). One query for any number
+// of network ids; no N+1. Select() narrows the row read so we skip the
+// JSONB blobs (stream_urls/social/playlist_config) the sibling response
+// doesn't render — ~25-column hydration shrinks to 6 scalar columns.
+func (s *RadioService) batchFetchSiblings(networkIDs []uint) map[uint][]contracts.RadioSiblingStationResponse {
+	out := make(map[uint][]contracts.RadioSiblingStationResponse, len(networkIDs))
+	if len(networkIDs) == 0 {
+		return out
+	}
+	var stations []catalogm.RadioStation
+	s.db.
+		Select("id, slug, name, broadcast_type, is_flagship, network_id").
+		Where("network_id IN ?", networkIDs).
+		Order("is_flagship DESC, name ASC").
+		Find(&stations)
+	for _, st := range stations {
+		if st.NetworkID == nil {
+			continue
+		}
+		out[*st.NetworkID] = append(out[*st.NetworkID], contracts.RadioSiblingStationResponse{
+			ID:            st.ID,
+			Slug:          st.Slug,
+			Name:          st.Name,
+			BroadcastType: st.BroadcastType,
+			IsFlagship:    st.IsFlagship,
+		})
+	}
+	return out
+}
+
+// excludeSibling drops the entry with the given id and returns the remaining
+// stations as a non-nil slice — empty `[]`, never `nil`, so the JSON shape
+// stays stable for frontend iterators.
+func excludeSibling(siblings []contracts.RadioSiblingStationResponse, excludeID uint) []contracts.RadioSiblingStationResponse {
+	out := make([]contracts.RadioSiblingStationResponse, 0, len(siblings))
+	for _, sib := range siblings {
+		if sib.ID == excludeID {
+			continue
+		}
+		out = append(out, sib)
+	}
+	return out
 }
 
 func (s *RadioService) buildShowDetailResponse(show *catalogm.RadioShow) (*contracts.RadioShowDetailResponse, error) {

--- a/backend/internal/services/catalog/radio_test.go
+++ b/backend/internal/services/catalog/radio_test.go
@@ -952,3 +952,170 @@ func (suite *RadioServiceIntegrationTestSuite) TestRadioNetwork_GetStationBySlug
 	suite.Require().NotNil(resp.NetworkSlug)
 	suite.Equal("wfmu", *resp.NetworkSlug)
 }
+
+// =============================================================================
+// PSY-669: NETWORK INFO + SIBLING_STATIONS PROJECTION TESTS
+// =============================================================================
+
+// seedWFMUNetwork seeds the canonical WFMU network + 4 stations (flagship +
+// 3 stream-only sub-channels) used by the PSY-669 network projection tests.
+// Returns the seeded stations by slug for easy lookup.
+func (suite *RadioServiceIntegrationTestSuite) seedWFMUNetwork() (network catalogm.RadioNetwork, stationsBySlug map[string]catalogm.RadioStation) {
+	suite.Require().NoError(suite.db.Exec(`INSERT INTO radio_networks (slug, name) VALUES ('wfmu', 'WFMU')`).Error)
+	suite.Require().NoError(suite.db.Where("slug = ?", "wfmu").First(&network).Error)
+
+	rows := []catalogm.RadioStation{
+		{Name: "WFMU", Slug: "wfmu", BroadcastType: catalogm.BroadcastTypeBoth, IsActive: true, NetworkID: &network.ID, IsFlagship: true},
+		{Name: "Give the Drummer Radio", Slug: "wfmu-drummer", BroadcastType: catalogm.BroadcastTypeInternet, IsActive: true, NetworkID: &network.ID, IsFlagship: false},
+		{Name: "Rock'n'Soul Radio", Slug: "wfmu-rocknsoulradio", BroadcastType: catalogm.BroadcastTypeInternet, IsActive: true, NetworkID: &network.ID, IsFlagship: false},
+		{Name: "Sheena's Jungle Room", Slug: "wfmu-sheena", BroadcastType: catalogm.BroadcastTypeInternet, IsActive: true, NetworkID: &network.ID, IsFlagship: false},
+	}
+	stationsBySlug = make(map[string]catalogm.RadioStation, len(rows))
+	for i := range rows {
+		suite.Require().NoError(suite.db.Create(&rows[i]).Error)
+		stationsBySlug[rows[i].Slug] = rows[i]
+	}
+	return network, stationsBySlug
+}
+
+// TestRadioNetwork_GetStation_FlagshipResponse verifies the flagship station's
+// detail response carries Network.IsFlagship=true and SiblingStations contains
+// the 3 non-flagship sub-streams (self excluded), sorted alphabetically since
+// they share the same is_flagship=false level.
+func (suite *RadioServiceIntegrationTestSuite) TestRadioNetwork_GetStation_FlagshipResponse() {
+	_, stations := suite.seedWFMUNetwork()
+	flagship := stations["wfmu"]
+
+	resp, err := suite.radioService.GetStation(flagship.ID)
+	suite.Require().NoError(err)
+
+	suite.Require().NotNil(resp.Network)
+	suite.Equal("wfmu", resp.Network.Slug)
+	suite.Equal("WFMU", resp.Network.Name)
+	suite.True(resp.Network.IsFlagship, "flagship station should report is_flagship=true on its network info")
+
+	suite.Require().Len(resp.SiblingStations, 3, "flagship should see 3 sibling sub-streams")
+	suite.Equal("Give the Drummer Radio", resp.SiblingStations[0].Name)
+	suite.Equal("Rock'n'Soul Radio", resp.SiblingStations[1].Name)
+	suite.Equal("Sheena's Jungle Room", resp.SiblingStations[2].Name)
+	for _, sib := range resp.SiblingStations {
+		suite.False(sib.IsFlagship, "siblings of the flagship should all be non-flagship: got %s flagged", sib.Slug)
+		suite.NotEqual(flagship.ID, sib.ID, "self must be excluded from siblings")
+	}
+}
+
+// TestRadioNetwork_GetStation_SiblingResponse verifies that fetching a
+// non-flagship sub-stream returns Network.IsFlagship=false and SiblingStations
+// includes the flagship FIRST (flagship-first ordering matters for the tab bar
+// UI which leads with the main station).
+func (suite *RadioServiceIntegrationTestSuite) TestRadioNetwork_GetStation_SiblingResponse() {
+	_, stations := suite.seedWFMUNetwork()
+	drummer := stations["wfmu-drummer"]
+
+	resp, err := suite.radioService.GetStation(drummer.ID)
+	suite.Require().NoError(err)
+
+	suite.Require().NotNil(resp.Network)
+	suite.Equal("wfmu", resp.Network.Slug)
+	suite.False(resp.Network.IsFlagship, "drummer is not the flagship")
+
+	suite.Require().Len(resp.SiblingStations, 3, "drummer should see 3 siblings: flagship + 2 other sub-streams")
+	suite.Equal("WFMU", resp.SiblingStations[0].Name, "flagship must come first in sibling ordering")
+	suite.True(resp.SiblingStations[0].IsFlagship)
+	suite.Equal("Rock'n'Soul Radio", resp.SiblingStations[1].Name)
+	suite.False(resp.SiblingStations[1].IsFlagship)
+	suite.Equal("Sheena's Jungle Room", resp.SiblingStations[2].Name)
+	suite.False(resp.SiblingStations[2].IsFlagship)
+
+	for _, sib := range resp.SiblingStations {
+		suite.NotEqual(drummer.ID, sib.ID, "self must be excluded from siblings")
+	}
+}
+
+// TestRadioNetwork_GetStation_NetworkLessResponse verifies a station that
+// belongs to no network returns Network=nil and SiblingStations as an empty
+// (non-nil) slice. Frontend depends on the JSON shape being a stable `[]`,
+// not `null`, so iterators don't trip.
+func (suite *RadioServiceIntegrationTestSuite) TestRadioNetwork_GetStation_NetworkLessResponse() {
+	station := &catalogm.RadioStation{
+		Name:          "KEXP",
+		Slug:          "kexp",
+		BroadcastType: catalogm.BroadcastTypeBoth,
+		IsActive:      true,
+	}
+	suite.Require().NoError(suite.db.Create(station).Error)
+
+	resp, err := suite.radioService.GetStation(station.ID)
+	suite.Require().NoError(err)
+
+	suite.Nil(resp.Network)
+	suite.NotNil(resp.SiblingStations, "JSON shape must be `[]`, not `null`")
+	suite.Empty(resp.SiblingStations)
+}
+
+// TestRadioNetwork_GetStationBySlug_PopulatesNetworkAndSiblings is the
+// slug-keyed counterpart to TestRadioNetwork_GetStation_SiblingResponse and
+// guards against regressions where one of the two single-station fetch paths
+// drifts away from the other.
+func (suite *RadioServiceIntegrationTestSuite) TestRadioNetwork_GetStationBySlug_PopulatesNetworkAndSiblings() {
+	suite.seedWFMUNetwork()
+
+	resp, err := suite.radioService.GetStationBySlug("wfmu-sheena")
+	suite.Require().NoError(err)
+
+	suite.Require().NotNil(resp.Network)
+	suite.Equal("wfmu", resp.Network.Slug)
+	suite.False(resp.Network.IsFlagship)
+	suite.Require().Len(resp.SiblingStations, 3)
+	suite.Equal("WFMU", resp.SiblingStations[0].Name, "flagship must come first")
+	suite.True(resp.SiblingStations[0].IsFlagship)
+}
+
+// TestRadioNetwork_ListStations_PopulatesNetworkAndSiblings verifies the
+// batch path used by GET /radio-stations. Asserts every station in the
+// response gets correctly-populated Network info + siblings, AND that
+// network-less stations in the same response are unaffected.
+func (suite *RadioServiceIntegrationTestSuite) TestRadioNetwork_ListStations_PopulatesNetworkAndSiblings() {
+	suite.seedWFMUNetwork()
+	// Add a network-less station to the same response to exercise the
+	// mixed-case branch (some rows have a network, some don't).
+	kexp := &catalogm.RadioStation{
+		Name: "KEXP", Slug: "kexp", BroadcastType: catalogm.BroadcastTypeBoth, IsActive: true,
+	}
+	suite.Require().NoError(suite.db.Create(kexp).Error)
+
+	resp, err := suite.radioService.ListStations(map[string]interface{}{"is_active": true})
+	suite.Require().NoError(err)
+	suite.Require().Len(resp, 5, "expected 4 WFMU stations + 1 network-less KEXP")
+
+	bySlug := map[string]*contracts.RadioStationListResponse{}
+	for _, r := range resp {
+		bySlug[r.Slug] = r
+	}
+
+	// Flagship sees 3 non-flagship siblings.
+	wfmu := bySlug["wfmu"]
+	suite.Require().NotNil(wfmu)
+	suite.Require().NotNil(wfmu.Network)
+	suite.True(wfmu.Network.IsFlagship)
+	suite.Require().Len(wfmu.SiblingStations, 3)
+	for _, sib := range wfmu.SiblingStations {
+		suite.False(sib.IsFlagship)
+	}
+
+	// A sub-stream sees flagship + 2 other sub-streams.
+	drummer := bySlug["wfmu-drummer"]
+	suite.Require().NotNil(drummer)
+	suite.Require().NotNil(drummer.Network)
+	suite.False(drummer.Network.IsFlagship)
+	suite.Require().Len(drummer.SiblingStations, 3)
+	suite.Equal("WFMU", drummer.SiblingStations[0].Name, "flagship-first ordering")
+	suite.True(drummer.SiblingStations[0].IsFlagship)
+
+	// Network-less station has nil Network and empty SiblingStations.
+	k := bySlug["kexp"]
+	suite.Require().NotNil(k)
+	suite.Nil(k.Network)
+	suite.NotNil(k.SiblingStations)
+	suite.Empty(k.SiblingStations)
+}

--- a/backend/internal/services/contracts/radio.go
+++ b/backend/internal/services/contracts/radio.go
@@ -53,51 +53,79 @@ type UpdateRadioStationRequest struct {
 	IsActive         *bool            `json:"is_active"`
 }
 
+// RadioNetworkInfo is the per-station view of its parent network, embedded
+// in RadioStationDetailResponse and RadioStationListResponse. `is_flagship`
+// is the bool on the *station* (radio_stations.is_flagship) — true means
+// THIS station is the network's primary/default broadcast. Frontend uses
+// it to render WFMU 91.1 as the default tab and the 3 stream-only siblings
+// as secondary tabs.
+type RadioNetworkInfo struct {
+	Slug       string `json:"slug"`
+	Name       string `json:"name"`
+	IsFlagship bool   `json:"is_flagship"`
+}
+
+// RadioSiblingStationResponse is a sibling station within the same network,
+// embedded in RadioStationDetailResponse.SiblingStations. Includes every
+// station in the network OTHER than the one this response represents, so a
+// tab bar can render the full set with the active tab highlighted.
+type RadioSiblingStationResponse struct {
+	ID            uint   `json:"id"`
+	Slug          string `json:"slug"`
+	Name          string `json:"name"`
+	BroadcastType string `json:"broadcast_type"`
+	IsFlagship    bool   `json:"is_flagship"`
+}
+
 // RadioStationDetailResponse represents the full radio station data returned to clients
 type RadioStationDetailResponse struct {
-	ID                  uint             `json:"id"`
-	Name                string           `json:"name"`
-	Slug                string           `json:"slug"`
-	Description         *string          `json:"description"`
-	City                *string          `json:"city"`
-	State               *string          `json:"state"`
-	Country             *string          `json:"country"`
-	Timezone            *string          `json:"timezone"`
-	StreamURL           *string          `json:"stream_url"`
-	StreamURLs          *json.RawMessage `json:"stream_urls"`
-	Website             *string          `json:"website"`
-	DonationURL         *string          `json:"donation_url"`
-	DonationEmbedURL    *string          `json:"donation_embed_url"`
-	LogoURL             *string          `json:"logo_url"`
-	Social              *json.RawMessage `json:"social"`
-	BroadcastType       string           `json:"broadcast_type"`
-	FrequencyMHz        *float64         `json:"frequency_mhz"`
-	PlaylistSource      *string          `json:"playlist_source"`
-	PlaylistConfig      *json.RawMessage `json:"playlist_config"`
-	LastPlaylistFetchAt *time.Time       `json:"last_playlist_fetch_at"`
-	IsActive            bool             `json:"is_active"`
-	NetworkID           *uint            `json:"network_id"`
-	NetworkSlug         *string          `json:"network_slug"`
-	ShowCount           int              `json:"show_count"`
-	CreatedAt           time.Time        `json:"created_at"`
-	UpdatedAt           time.Time        `json:"updated_at"`
+	ID                  uint                          `json:"id"`
+	Name                string                        `json:"name"`
+	Slug                string                        `json:"slug"`
+	Description         *string                       `json:"description"`
+	City                *string                       `json:"city"`
+	State               *string                       `json:"state"`
+	Country             *string                       `json:"country"`
+	Timezone            *string                       `json:"timezone"`
+	StreamURL           *string                       `json:"stream_url"`
+	StreamURLs          *json.RawMessage              `json:"stream_urls"`
+	Website             *string                       `json:"website"`
+	DonationURL         *string                       `json:"donation_url"`
+	DonationEmbedURL    *string                       `json:"donation_embed_url"`
+	LogoURL             *string                       `json:"logo_url"`
+	Social              *json.RawMessage              `json:"social"`
+	BroadcastType       string                        `json:"broadcast_type"`
+	FrequencyMHz        *float64                      `json:"frequency_mhz"`
+	PlaylistSource      *string                       `json:"playlist_source"`
+	PlaylistConfig      *json.RawMessage              `json:"playlist_config"`
+	LastPlaylistFetchAt *time.Time                    `json:"last_playlist_fetch_at"`
+	IsActive            bool                          `json:"is_active"`
+	NetworkID           *uint                         `json:"network_id"`
+	NetworkSlug         *string                       `json:"network_slug"`
+	Network             *RadioNetworkInfo             `json:"network"`
+	SiblingStations     []RadioSiblingStationResponse `json:"sibling_stations"`
+	ShowCount           int                           `json:"show_count"`
+	CreatedAt           time.Time                     `json:"created_at"`
+	UpdatedAt           time.Time                     `json:"updated_at"`
 }
 
 // RadioStationListResponse represents a radio station in list views
 type RadioStationListResponse struct {
-	ID            uint     `json:"id"`
-	Name          string   `json:"name"`
-	Slug          string   `json:"slug"`
-	City          *string  `json:"city"`
-	State         *string  `json:"state"`
-	Country       *string  `json:"country"`
-	BroadcastType string   `json:"broadcast_type"`
-	FrequencyMHz  *float64 `json:"frequency_mhz"`
-	LogoURL       *string  `json:"logo_url"`
-	IsActive      bool     `json:"is_active"`
-	NetworkID     *uint    `json:"network_id"`
-	NetworkSlug   *string  `json:"network_slug"`
-	ShowCount     int      `json:"show_count"`
+	ID              uint                          `json:"id"`
+	Name            string                        `json:"name"`
+	Slug            string                        `json:"slug"`
+	City            *string                       `json:"city"`
+	State           *string                       `json:"state"`
+	Country         *string                       `json:"country"`
+	BroadcastType   string                        `json:"broadcast_type"`
+	FrequencyMHz    *float64                      `json:"frequency_mhz"`
+	LogoURL         *string                       `json:"logo_url"`
+	IsActive        bool                          `json:"is_active"`
+	NetworkID       *uint                         `json:"network_id"`
+	NetworkSlug     *string                       `json:"network_slug"`
+	Network         *RadioNetworkInfo             `json:"network"`
+	SiblingStations []RadioSiblingStationResponse `json:"sibling_stations"`
+	ShowCount       int                           `json:"show_count"`
 }
 
 // ──────────────────────────────────────────────


### PR DESCRIPTION
Closes PSY-669.

## Summary

- Adds `is_flagship BOOLEAN NOT NULL DEFAULT FALSE` column to `radio_stations` via a new timestamp migration; backfills WFMU as flagship (`slug='wfmu'`). Seed data + Go model + SQL renderer all carry the new field.
- Extends `RadioStationDetailResponse` and `RadioStationListResponse` with two new nullable fields: nested `network: {slug, name, is_flagship}` and `sibling_stations: [{id, slug, name, broadcast_type, is_flagship}]`. Siblings are flagship-first sorted; the current station is excluded.
- `ListStations` batches the sibling fetch (single `WHERE network_id IN (...)` query for the whole response) so adding the new field doesn't introduce N+1. `Select()` projection narrows the sibling row read to the 6 scalar columns the response needs, skipping the 3 JSONB blobs (`stream_urls`, `social`, `playlist_config`).
- 5 new integration tests cover flagship / sibling / network-less responses + the slug-keyed path + the list-batch path.
- No frontend consumer yet — that's PSY-673 (hide non-flagship from `/radio` index) and PSY-674 (network tab switcher on station detail).

## Implementation note — flat `network_slug` vs nested `network.slug`

The response now carries `network_slug` (pre-existing) AND `network.slug` (new). Both ship the same byte. Kept the flat field for back-compat since pre-PSY-669 frontend code may already read `network_slug`. Once PSY-673 / PSY-674 migrate the frontend to the nested `network` object, `network_slug` becomes a candidate for a deprecate-and-remove follow-up.

## Test plan

- [x] `go build ./...` — clean (after refactor too)
- [x] `go test ./internal/services/catalog/... -run TestRadioServiceIntegrationTestSuite` — 47 existing + 5 new = 52/52 passing (2.0s)
- [x] `go test ./internal/seeddata/...` — passing (renderer shape + row-count tests unaffected by the new `is_flagship` column emission)
- [x] `/simplify` — 3 reviewers (reuse / quality / efficiency); fixes applied:
  - Collapsed 3 sibling-exclusion strategies (SQL `id !=`, in-loop `continue`, "callers must filter") into one in-memory helper `excludeSibling`
  - `batchFetchSiblings` now returns `map[uint][]contracts.RadioSiblingStationResponse` directly (was returning the GORM model — leaky)
  - Added `Select("id, slug, name, broadcast_type, is_flagship, network_id")` projection so we skip the 3 JSONB blobs
  - Test helper `seedWFMUNetwork` now uses `catalogm.BroadcastTypeBoth` / `BroadcastTypeInternet` constants instead of raw strings
- [x] Migration shape verified: testcontainers spins fresh Postgres for every integration test run, applies all migrations including `20260517155740_radio_stations_add_is_flagship.up.sql`, and the 52-test suite passes — confirms the migration applies cleanly + the `is_flagship` column is populated as the model + service expects.
- [x] no UI surface, screenshots skipped

## Coverage gaps

- **Migration round-trip (up→down→up) not verified locally** — the CI guard added in PSY-413 covers reversibility, so the down migration (`DROP COLUMN IF EXISTS is_flagship`) will be exercised there. No local repro of the down direction in this branch.
- **OpenAPI spec diff not inspected** — Huma derives the spec from struct tags; adding two new nullable JSON fields (`network`, `sibling_stations`) is additive and shouldn't break consumers, but I didn't generate / diff the spec file in this PR. The `NetworkSlug` flat field is untouched, so any contract test pinned on it stays green.
- **N+1 avoidance not asserted via query count** — `batchFetchSiblings` is verified for correctness (a 5-station list resolves siblings on both the WFMU-network rows and the network-less KEXP row), but the test doesn't pin the query count via `sqlmock` or similar. The single-query shape is confirmed by reading the helper at `radio.go:194-218`.
- **End-to-end frontend repro not possible from this PR alone** — the nested `network` + `sibling_stations` fields aren't consumed yet. PSY-673 and PSY-674 will exercise them visually on staging.
- **Auto-discover and auto-backfill gaps (PSY-671 / PSY-672) are still unfixed** — out of scope for this PR; the runbook (PSY-675) documents the manual workarounds.
