### PR TITLE
PSY-673: hide non-flagship network stations from /radio index

### DIFF
--- a/frontend/app/radio/_components/RadioHub.tsx
+++ b/frontend/app/radio/_components/RadioHub.tsx
@@ -7,6 +7,7 @@ import {
   useRadioStats,
   useNewReleaseRadar,
   RadioStationCard,
+  isStationVisibleOnIndex,
 } from '@/features/radio'
 import type { RadioNewReleaseRadarEntry } from '@/features/radio'
 
@@ -14,6 +15,11 @@ export default function RadioHub() {
   const { data: stationsData, isLoading, error } = useRadioStations()
   const { data: stats } = useRadioStats()
   const { data: radarData, isLoading: radarLoading } = useNewReleaseRadar({ limit: 10 })
+
+  // PSY-673: hide non-flagship siblings of any network. Sub-streams remain
+  // reachable via their direct /radio/{slug} URL and via the flagship's tab
+  // bar (PSY-674).
+  const visibleStations = stationsData?.stations.filter(isStationVisibleOnIndex) ?? []
 
   return (
     <div className="flex min-h-screen items-start justify-center">
@@ -53,23 +59,21 @@ export default function RadioHub() {
         )}
 
         {!isLoading && !error && stationsData && (
-          <>
-            {stationsData.stations && stationsData.stations.length > 0 ? (
-              <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-                {stationsData.stations.map(station => (
-                  <RadioStationCard key={station.id} station={station} />
-                ))}
-              </div>
-            ) : (
-              <div className="py-12 text-center">
-                <Radio className="h-12 w-12 text-muted-foreground/30 mx-auto mb-3" />
-                <p className="text-muted-foreground">No radio stations yet</p>
-                <p className="text-sm text-muted-foreground/60 mt-1">
-                  Radio stations will appear here once they are added.
-                </p>
-              </div>
-            )}
-          </>
+          visibleStations.length > 0 ? (
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+              {visibleStations.map(station => (
+                <RadioStationCard key={station.id} station={station} />
+              ))}
+            </div>
+          ) : (
+            <div className="py-12 text-center">
+              <Radio className="h-12 w-12 text-muted-foreground/30 mx-auto mb-3" />
+              <p className="text-muted-foreground">No radio stations yet</p>
+              <p className="text-sm text-muted-foreground/60 mt-1">
+                Radio stations will appear here once they are added.
+              </p>
+            </div>
+          )
         )}
       </main>
     </div>

--- a/frontend/features/radio/components/RadioStationCard.tsx
+++ b/frontend/features/radio/components/RadioStationCard.tsx
@@ -14,6 +14,12 @@ export function RadioStationCard({ station }: RadioStationCardProps) {
   const stationUrl = `/radio/${station.slug}`
   const location = [station.city, station.state].filter(Boolean).join(', ')
   const broadcastLabel = getBroadcastTypeLabel(station.broadcast_type)
+  // PSY-673: only flagship cards advertise sibling channels. Non-flagship
+  // cards never reach this component on /radio (filtered by
+  // isStationVisibleOnIndex); the is_flagship guard keeps the count from
+  // appearing if the card is reused on a surface that doesn't filter.
+  const siblingCount = station.sibling_stations.length
+  const showChannels = station.network?.is_flagship && siblingCount > 0
 
   return (
     <article className="rounded-lg border border-border/50 bg-card p-5 transition-shadow hover:shadow-sm">
@@ -60,6 +66,12 @@ export function RadioStationCard({ station }: RadioStationCardProps) {
               </span>
             )}
           </div>
+
+          {showChannels && (
+            <div className="mt-1.5 text-xs text-muted-foreground/80">
+              + {siblingCount} {siblingCount === 1 ? 'channel' : 'channels'}
+            </div>
+          )}
         </div>
       </div>
 

--- a/frontend/features/radio/index.ts
+++ b/frontend/features/radio/index.ts
@@ -8,6 +8,8 @@ export type {
   RadioStationListItem,
   RadioStationDetail,
   RadioStationsListResponse,
+  RadioNetworkInfo,
+  RadioSiblingStation,
   RadioShowListItem,
   RadioShowDetail,
   RadioShowsListResponse,
@@ -33,6 +35,7 @@ export {
   getBroadcastTypeLabel,
   getRotationStatusLabel,
   getRotationStatusColor,
+  isStationVisibleOnIndex,
 } from './types'
 
 // Hooks

--- a/frontend/features/radio/types.test.ts
+++ b/frontend/features/radio/types.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { isStationVisibleOnIndex } from './types'
+import type { RadioNetworkInfo } from './types'
+
+// PSY-673: filter used by /radio (RadioHub) to hide non-flagship siblings of
+// any network. Sub-streams remain reachable by direct URL and via the
+// flagship's tab bar (PSY-674); the index just stops listing them as
+// standalone broadcasters.
+describe('isStationVisibleOnIndex', () => {
+  it('shows network-less stations (KEXP, NTS today)', () => {
+    expect(isStationVisibleOnIndex({ network: null })).toBe(true)
+  })
+
+  it('shows the flagship of a network (WFMU 91.1)', () => {
+    const network: RadioNetworkInfo = {
+      slug: 'wfmu',
+      name: 'WFMU',
+      is_flagship: true,
+    }
+    expect(isStationVisibleOnIndex({ network })).toBe(true)
+  })
+
+  it('hides non-flagship siblings (Drummer / Rock\'n\'Soul / Sheena\'s)', () => {
+    const network: RadioNetworkInfo = {
+      slug: 'wfmu',
+      name: 'WFMU',
+      is_flagship: false,
+    }
+    expect(isStationVisibleOnIndex({ network })).toBe(false)
+  })
+
+  // Guards against a regression where the function returns truthy for any
+  // non-null network instead of specifically checking is_flagship.
+  it('does not depend on network slug or name, only is_flagship', () => {
+    const flagshipOfDifferentNetwork: RadioNetworkInfo = {
+      slug: 'somafm',
+      name: 'SomaFM',
+      is_flagship: true,
+    }
+    expect(isStationVisibleOnIndex({ network: flagshipOfDifferentNetwork })).toBe(true)
+
+    const siblingOfDifferentNetwork: RadioNetworkInfo = {
+      slug: 'somafm',
+      name: 'SomaFM',
+      is_flagship: false,
+    }
+    expect(isStationVisibleOnIndex({ network: siblingOfDifferentNetwork })).toBe(false)
+  })
+})

--- a/frontend/features/radio/types.ts
+++ b/frontend/features/radio/types.ts
@@ -9,6 +9,27 @@
 // Radio Station
 // ============================================================================
 
+// PSY-669 / PSY-673: per-station network metadata. `is_flagship` is the
+// bool on the station itself (radio_stations.is_flagship): true means
+// THIS station is the network's primary/default broadcast. Frontend uses
+// it to (a) hide non-flagship siblings from the /radio index, and (b)
+// render the network tab bar (PSY-674) with the flagship as default.
+export interface RadioNetworkInfo {
+  slug: string
+  name: string
+  is_flagship: boolean
+}
+
+// PSY-669: other stations in the same network. Excludes self.
+// Flagship-first sort; alphabetical within is_flagship buckets.
+export interface RadioSiblingStation {
+  id: number
+  slug: string
+  name: string
+  broadcast_type: string
+  is_flagship: boolean
+}
+
 export interface RadioStationListItem {
   id: number
   name: string
@@ -20,7 +41,20 @@ export interface RadioStationListItem {
   frequency_mhz: number | null
   logo_url: string | null
   is_active: boolean
+  network: RadioNetworkInfo | null
+  sibling_stations: RadioSiblingStation[]
   show_count: number
+}
+
+// PSY-673: returns true when a station should appear on the /radio index.
+// Network-less stations always render. Stations in a network render only
+// when they're the flagship; non-flagship siblings reach their pages via
+// the flagship's tab bar (PSY-674) or via their direct /radio/{slug} URL.
+export function isStationVisibleOnIndex(station: {
+  network: RadioNetworkInfo | null
+}): boolean {
+  if (!station.network) return true
+  return station.network.is_flagship
 }
 
 export interface RadioStationDetail {
@@ -45,6 +79,8 @@ export interface RadioStationDetail {
   playlist_config: Record<string, unknown> | null
   last_playlist_fetch_at: string | null
   is_active: boolean
+  network: RadioNetworkInfo | null
+  sibling_stations: RadioSiblingStation[]
   show_count: number
   created_at: string
   updated_at: string


### PR DESCRIPTION
Closes PSY-673.

## Summary

- `/radio` now renders only **flagship + network-less stations** (3 cards: KEXP, NTS, WFMU) instead of the previous 6 flat cards. Filter is render-time only — the API keeps returning all 6 stations; the index just hides non-flagship siblings.
- Adds **"+ N channels"** affordance below the show count on flagship cards (per the chosen UX option). Only shows when the station is the network flagship AND has ≥1 sibling — so single-station-network flagships don't get a meaningless "+ 0 channels" string.
- Hidden sub-streams (`/radio/wfmu-drummer`, `/radio/wfmu-rocknsoulradio`, `/radio/wfmu-sheena`) remain reachable via their direct URL — only the index render changes.
- Pure type-only extension on `RadioStationListItem` + `RadioStationDetail` (adds `network: RadioNetworkInfo | null` + `sibling_stations: RadioSiblingStation[]`); the helper `isStationVisibleOnIndex` is a standalone pure function so it tests cleanly.
- Unblocks PSY-674 (network tab switcher on station detail pages).

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run test:run features/radio` — 4/4 passing (`types.test.ts` covers null network, flagship true, flagship false, name-independence regression)
- [x] `/simplify` — 3 reviewers; 2 cleanups applied: collapsed the IIFE in `RadioHub.tsx` into a hoisted `const visibleStations`, and dropped the defensive `?? []` / `?.length ?? 0` guards that the typed contract already enforces (PSY-669 backend tests assert `sibling_stations` is always `[]` not `null`)
- [x] `/psy-self-review` — 3 reviewers (results addressed inline before push)
- [x] Manual repro against local dev stack — `/radio` index renders 3 cards (KEXP, NTS, WFMU) with the "+ 3 channels" affordance on WFMU; `/radio/wfmu-drummer` direct URL still renders the sub-stream page (screenshots below)

## Screenshots

**`/radio` — 3 cards, WFMU shows "+ 3 channels"**

![/radio index with flagship-only cards](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-46a29399a5b951013fb8/psy-673-radio-index-full.png)

**`/radio/wfmu-drummer` — sub-stream direct URL still renders**

![Sub-stream direct URL renders](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-46a29399a5b951013fb8/psy-673-substream-direct.png)

## Coverage gaps

- **`+ 1 channel` singular branch not exercised.** Current dev data has WFMU with 3 siblings; the singular form (`siblingCount === 1`) ships unverified. Proof reduces to reading the ternary at `RadioStationCard.tsx`. Easy to verify if a single-sibling network gets seeded later.
- **`is_flagship && siblingCount === 0` false branch not exercised.** Guards against rendering "+ 0 channels" if a flagship has no siblings. No such station exists in dev data (KEXP/NTS hit `showChannels=false` via the `is_flagship` undefined path, not the `siblingCount === 0` path). Defensive, not load-bearing today.
- **Top-of-page stat ("6 stations") still counts hidden sub-streams.** The stats endpoint counts all DB rows; this PR doesn't touch it. Possibly worth a follow-up if it confuses users — but it's also technically accurate (there ARE 6 stations; we just nest them). Out of scope here.
- **Tab bar UI not in this PR.** The network tab switcher (PSY-674) is the natural next step — without it, the only way to reach `wfmu-drummer` is the direct URL. Screenshots above confirm direct URLs work.
- **Local dev-data oddity unrelated to this PR**: KEXP / WFMU's `broadcast_type` reads as `"freeform"` on stage (visible as the badge in the screenshot). That value isn't in `BROADCAST_TYPE_LABELS`, so the badge falls back to the raw string. Pre-existing dev-data drift, not introduced by this PR.
- **Visual test for the affordance render not written** — the unit test covers the filter logic; the affordance is a tiny conditional render that the screenshot proves works. Adding a render test would be a one-liner snapshot-style assertion; deferred unless the pattern becomes load-bearing.
