### PR TITLE
PSY-676: expose frequency_mhz on RadioSiblingStation

### DIFF
--- a/backend/internal/services/catalog/radio.go
+++ b/backend/internal/services/catalog/radio.go
@@ -1015,7 +1015,7 @@ func (s *RadioService) fetchSiblings(networkID *uint, excludeStationID uint) []c
 // (caller-side filters self via excludeSibling). One query for any number
 // of network ids; no N+1. Select() narrows the row read so we skip the
 // JSONB blobs (stream_urls/social/playlist_config) the sibling response
-// doesn't render — ~25-column hydration shrinks to 6 scalar columns.
+// doesn't render — ~25-column hydration shrinks to 7 scalar columns.
 func (s *RadioService) batchFetchSiblings(networkIDs []uint) map[uint][]contracts.RadioSiblingStationResponse {
 	out := make(map[uint][]contracts.RadioSiblingStationResponse, len(networkIDs))
 	if len(networkIDs) == 0 {
@@ -1023,7 +1023,7 @@ func (s *RadioService) batchFetchSiblings(networkIDs []uint) map[uint][]contract
 	}
 	var stations []catalogm.RadioStation
 	s.db.
-		Select("id, slug, name, broadcast_type, is_flagship, network_id").
+		Select("id, slug, name, broadcast_type, frequency_mhz, is_flagship, network_id").
 		Where("network_id IN ?", networkIDs).
 		Order("is_flagship DESC, name ASC").
 		Find(&stations)
@@ -1036,6 +1036,7 @@ func (s *RadioService) batchFetchSiblings(networkIDs []uint) map[uint][]contract
 			Slug:          st.Slug,
 			Name:          st.Name,
 			BroadcastType: st.BroadcastType,
+			FrequencyMHz:  st.FrequencyMHz,
 			IsFlagship:    st.IsFlagship,
 		})
 	}

--- a/backend/internal/services/catalog/radio_test.go
+++ b/backend/internal/services/catalog/radio_test.go
@@ -964,8 +964,9 @@ func (suite *RadioServiceIntegrationTestSuite) seedWFMUNetwork() (network catalo
 	suite.Require().NoError(suite.db.Exec(`INSERT INTO radio_networks (slug, name) VALUES ('wfmu', 'WFMU')`).Error)
 	suite.Require().NoError(suite.db.Where("slug = ?", "wfmu").First(&network).Error)
 
+	flagshipFreq := 91.1
 	rows := []catalogm.RadioStation{
-		{Name: "WFMU", Slug: "wfmu", BroadcastType: catalogm.BroadcastTypeBoth, IsActive: true, NetworkID: &network.ID, IsFlagship: true},
+		{Name: "WFMU", Slug: "wfmu", BroadcastType: catalogm.BroadcastTypeBoth, FrequencyMHz: &flagshipFreq, IsActive: true, NetworkID: &network.ID, IsFlagship: true},
 		{Name: "Give the Drummer Radio", Slug: "wfmu-drummer", BroadcastType: catalogm.BroadcastTypeInternet, IsActive: true, NetworkID: &network.ID, IsFlagship: false},
 		{Name: "Rock'n'Soul Radio", Slug: "wfmu-rocknsoulradio", BroadcastType: catalogm.BroadcastTypeInternet, IsActive: true, NetworkID: &network.ID, IsFlagship: false},
 		{Name: "Sheena's Jungle Room", Slug: "wfmu-sheena", BroadcastType: catalogm.BroadcastTypeInternet, IsActive: true, NetworkID: &network.ID, IsFlagship: false},
@@ -1022,8 +1023,14 @@ func (suite *RadioServiceIntegrationTestSuite) TestRadioNetwork_GetStation_Sibli
 	suite.Require().Len(resp.SiblingStations, 3, "drummer should see 3 siblings: flagship + 2 other sub-streams")
 	suite.Equal("WFMU", resp.SiblingStations[0].Name, "flagship must come first in sibling ordering")
 	suite.True(resp.SiblingStations[0].IsFlagship)
+	// PSY-676: flagship-as-sibling carries frequency so NetworkTabBar can render
+	// the flagship tab as "WFMU 91.1" from any sub-stream page, matching the
+	// label that renders from the flagship's own /radio/wfmu page.
+	suite.Require().NotNil(resp.SiblingStations[0].FrequencyMHz, "flagship sibling should carry frequency_mhz")
+	suite.InDelta(91.1, *resp.SiblingStations[0].FrequencyMHz, 0.001)
 	suite.Equal("Rock'n'Soul Radio", resp.SiblingStations[1].Name)
 	suite.False(resp.SiblingStations[1].IsFlagship)
+	suite.Nil(resp.SiblingStations[1].FrequencyMHz, "internet-only sub-stream has no frequency")
 	suite.Equal("Sheena's Jungle Room", resp.SiblingStations[2].Name)
 	suite.False(resp.SiblingStations[2].IsFlagship)
 
@@ -1069,6 +1076,8 @@ func (suite *RadioServiceIntegrationTestSuite) TestRadioNetwork_GetStationBySlug
 	suite.Require().Len(resp.SiblingStations, 3)
 	suite.Equal("WFMU", resp.SiblingStations[0].Name, "flagship must come first")
 	suite.True(resp.SiblingStations[0].IsFlagship)
+	suite.Require().NotNil(resp.SiblingStations[0].FrequencyMHz, "slug-keyed path must also carry flagship frequency_mhz")
+	suite.InDelta(91.1, *resp.SiblingStations[0].FrequencyMHz, 0.001)
 }
 
 // TestRadioNetwork_ListStations_PopulatesNetworkAndSiblings verifies the
@@ -1111,6 +1120,8 @@ func (suite *RadioServiceIntegrationTestSuite) TestRadioNetwork_ListStations_Pop
 	suite.Require().Len(drummer.SiblingStations, 3)
 	suite.Equal("WFMU", drummer.SiblingStations[0].Name, "flagship-first ordering")
 	suite.True(drummer.SiblingStations[0].IsFlagship)
+	suite.Require().NotNil(drummer.SiblingStations[0].FrequencyMHz, "list path must also carry flagship frequency_mhz")
+	suite.InDelta(91.1, *drummer.SiblingStations[0].FrequencyMHz, 0.001)
 
 	// Network-less station has nil Network and empty SiblingStations.
 	k := bySlug["kexp"]

--- a/backend/internal/services/contracts/radio.go
+++ b/backend/internal/services/contracts/radio.go
@@ -70,11 +70,12 @@ type RadioNetworkInfo struct {
 // station in the network OTHER than the one this response represents, so a
 // tab bar can render the full set with the active tab highlighted.
 type RadioSiblingStationResponse struct {
-	ID            uint   `json:"id"`
-	Slug          string `json:"slug"`
-	Name          string `json:"name"`
-	BroadcastType string `json:"broadcast_type"`
-	IsFlagship    bool   `json:"is_flagship"`
+	ID            uint     `json:"id"`
+	Slug          string   `json:"slug"`
+	Name          string   `json:"name"`
+	BroadcastType string   `json:"broadcast_type"`
+	FrequencyMHz  *float64 `json:"frequency_mhz"`
+	IsFlagship    bool     `json:"is_flagship"`
 }
 
 // RadioStationDetailResponse represents the full radio station data returned to clients

--- a/frontend/features/radio/components/NetworkTabBar.tsx
+++ b/frontend/features/radio/components/NetworkTabBar.tsx
@@ -98,8 +98,7 @@ function buildTabs(station: RadioStationDetail): TabEntry[] {
       label: tabLabel({
         name: sib.name,
         isFlagship: sib.is_flagship,
-        // Sibling responses don't carry frequency; flagship-sibling tabs render name-only.
-        frequencyMHz: null,
+        frequencyMHz: sib.frequency_mhz,
       }),
       href: getStationDetailUrl(sib.slug, {
         slug: station.network.slug,

--- a/frontend/features/radio/types.ts
+++ b/frontend/features/radio/types.ts
@@ -27,6 +27,7 @@ export interface RadioSiblingStation {
   slug: string
   name: string
   broadcast_type: string
+  frequency_mhz: number | null
   is_flagship: boolean
 }
 


### PR DESCRIPTION
Closes PSY-676.

## Summary

- Extend `RadioSiblingStationResponse` contract with `frequency_mhz *float64` and populate it from the existing `batchFetchSiblings` projection.
- Mirror the field in the frontend `RadioSiblingStation` interface.
- Replace the hardcoded `frequencyMHz: null` in `NetworkTabBar.buildTabs` with `sib.frequency_mhz`, so the flagship-as-sibling tab now renders `"WFMU 91.1"` (matching the label shown from the flagship's own `/radio/wfmu` page).

Closes the asymmetry disclosed in PSY-674's coverage gaps: previously, viewing a sub-stream (e.g. `/radio/wfmu/channel/drummer`) showed the flagship tab as just `"WFMU"` because the sibling response didn't carry frequency.

## Test plan

- [x] `go build ./...` — clean
- [x] `bun run typecheck` — clean
- [x] `go test ./internal/services/catalog/... -run "Radio|Sibling|Network"` — all passing; `TestRadioNetwork_GetStation_SiblingResponse` extended with `NotNil` + `InDelta(91.1)` on the flagship sibling and `Nil` on a non-flagship sub-stream (regression guard against projection drift); same assertion pair added to `TestRadioNetwork_GetStationBySlug_PopulatesNetworkAndSiblings` (slug-keyed path) and `TestRadioNetwork_ListStations_PopulatesNetworkAndSiblings` (list path) — all three single-station + list response shapes covered
- [x] `bun run test:run features/radio` — 8/8 passing
- [x] `/simplify` — 3 reviewer agents reported clean; addressed one nit (stale `"6 scalar columns"` comment in `batchFetchSiblings` → `"7 scalar columns"` after adding `frequency_mhz`)
- [x] Manual repro against local dev stack: `curl /radio-stations/wfmu-drummer` returns `sibling_stations[0].frequency_mhz: 91.1` for the WFMU flagship; both `/radio/wfmu` (self) and `/radio/wfmu/channel/drummer` (sub-stream) render the flagship tab as `"WFMU 91.1"` (screenshots below)

## Screenshots

`/radio/wfmu/channel/drummer` — sub-stream page. Flagship tab now reads `"WFMU 91.1"` instead of just `"WFMU"`.

![drummer page tab bar](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-a94f84d238a4b9e107df/psy-676-drummer-tab.png)

`/radio/wfmu` — flagship's own page, for comparison. Same `"WFMU 91.1"` label (unchanged by this PR; included to show the symmetry). Also verifies that the three sub-stream siblings (Give the Drummer Radio, Rock'n'Soul Radio, Sheena's Jungle Room) continue to render name-only — `tabLabel` only appends frequency when `isFlagship && frequencyMHz != null`, so internet-only sub-streams stay name-only as before.

![flagship page tab bar](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-a94f84d238a4b9e107df/psy-676-wfmu-tab.png)

## Coverage gaps

- **Singular `"+ N channel"` vs plural label form on `/radio` cards** — unverified; dev data only has WFMU with 3 siblings. Pre-existing gap noted in PSY-674's handoff doc; not in scope for this PR.
- **Mobile horizontal scroll on `NetworkTabBar`** — tab row has `overflow-x-auto`; not exercised at narrow viewport during this PR (no diff to the scroll behavior).
- **Authenticated header brackets** not affected by this PR (diff is contract + label only; no bracket adds/removes/gates).
