### PR TITLE
PSY-671: add periodic radio show discovery loop

### DIFF
--- a/backend/internal/api/handlers/shared/testhelpers/mocks_gen.go
+++ b/backend/internal/api/handlers/shared/testhelpers/mocks_gen.go
@@ -1241,6 +1241,7 @@ type MockDiscordService struct {
 	NotifyShowReportFn func(*communitym.ShowReport, string)
 	NotifyArtistReportFn func(*communitym.ArtistReport, string)
 	NotifyNewVenueFn func(uint, string, string, string, *string, string)
+	NotifyNewRadioShowsFn func(string, []string)
 }
 
 func (m *MockDiscordService) IsConfigured() (bool) {
@@ -1287,6 +1288,11 @@ func (m *MockDiscordService) NotifyArtistReport(report *communitym.ArtistReport,
 func (m *MockDiscordService) NotifyNewVenue(venueID uint, venueName string, city string, state string, address *string, submitterEmail string) {
 	if m.NotifyNewVenueFn != nil {
 		m.NotifyNewVenueFn(venueID, venueName, city, state, address, submitterEmail)
+	}
+}
+func (m *MockDiscordService) NotifyNewRadioShows(stationName string, newShowNames []string) {
+	if m.NotifyNewRadioShowsFn != nil {
+		m.NotifyNewRadioShowsFn(stationName, newShowNames)
 	}
 }
 

--- a/backend/internal/services/catalog/radio_fetch_service.go
+++ b/backend/internal/services/catalog/radio_fetch_service.go
@@ -21,6 +21,11 @@ const DefaultAffinityInterval = 24 * time.Hour
 // Default re-matching interval (7 days)
 const DefaultReMatchInterval = 7 * 24 * time.Hour
 
+// Default show-discovery interval (24 hours). Provider rosters change slowly
+// (WFMU adds shows monthly at most; KEXP/NTS slower), so once a day is plenty
+// and the per-station DJ-index fetch cost is negligible.
+const DefaultDiscoverInterval = 24 * time.Hour
+
 // radioCircuitBreakerThreshold is the number of consecutive failures before
 // a station is temporarily skipped during fetch cycles.
 const radioCircuitBreakerThreshold = 5
@@ -29,6 +34,7 @@ const radioCircuitBreakerThreshold = 5
 //  1. Fetches new episodes from all active stations with playlist sources (every 6h)
 //  2. Computes artist affinity from co-occurrence data (daily)
 //  3. Re-matches unmatched plays against newly added artists (weekly)
+//  4. Discovers newly-added shows on every active station (daily)
 //
 // It follows the same Start/Stop pattern as SchedulerService and other background services.
 type RadioFetchService struct {
@@ -38,6 +44,7 @@ type RadioFetchService struct {
 	fetchInterval    time.Duration
 	affinityInterval time.Duration
 	rematchInterval  time.Duration
+	discoverInterval time.Duration
 
 	stopCh chan struct{}
 	wg     sync.WaitGroup
@@ -45,7 +52,8 @@ type RadioFetchService struct {
 
 	// consecutiveFailures tracks per-station failures within a fetch cycle
 	// Reset on success, incremented on failure. Stations with >= threshold
-	// failures are skipped until the counter resets.
+	// failures are skipped until the counter resets. Shared across the fetch
+	// and discover loops so a wedged provider gets one circuit breaker, not two.
 	mu                  sync.Mutex
 	consecutiveFailures map[uint]int
 }
@@ -55,6 +63,7 @@ type RadioFetchService struct {
 //   - RADIO_FETCH_INTERVAL_HOURS (default 6)
 //   - RADIO_AFFINITY_INTERVAL_HOURS (default 24)
 //   - RADIO_REMATCH_INTERVAL_HOURS (default 168, i.e. 7 days)
+//   - RADIO_DISCOVER_INTERVAL_HOURS (default 24)
 func NewRadioFetchService(
 	radioService *RadioService,
 	discordService contracts.DiscordServiceInterface,
@@ -80,12 +89,20 @@ func NewRadioFetchService(
 		}
 	}
 
+	discoverInterval := DefaultDiscoverInterval
+	if envVal := os.Getenv("RADIO_DISCOVER_INTERVAL_HOURS"); envVal != "" {
+		if hours, err := strconv.Atoi(envVal); err == nil && hours > 0 {
+			discoverInterval = time.Duration(hours) * time.Hour
+		}
+	}
+
 	return &RadioFetchService{
 		radioService:        radioService,
 		discordService:      discordService,
 		fetchInterval:       fetchInterval,
 		affinityInterval:    affinityInterval,
 		rematchInterval:     rematchInterval,
+		discoverInterval:    discoverInterval,
 		stopCh:              make(chan struct{}),
 		logger:              slog.Default(),
 		consecutiveFailures: make(map[uint]int),
@@ -100,11 +117,14 @@ func (s *RadioFetchService) Start(ctx context.Context) {
 	go s.runAffinityLoop(ctx)
 	s.wg.Add(1)
 	go s.runReMatchLoop(ctx)
+	s.wg.Add(1)
+	go s.runDiscoverLoop(ctx)
 
 	s.logger.Info("radio fetch service started",
 		"fetch_interval_hours", s.fetchInterval.Hours(),
 		"affinity_interval_hours", s.affinityInterval.Hours(),
 		"rematch_interval_hours", s.rematchInterval.Hours(),
+		"discover_interval_hours", s.discoverInterval.Hours(),
 	)
 }
 
@@ -138,6 +158,15 @@ func (s *RadioFetchService) runReMatchLoop(ctx context.Context) {
 	defer s.wg.Done()
 	shared.RunTickerLoop(ctx, "radio_rematch", s.rematchInterval, s.stopCh, false, func(_ context.Context) {
 		s.runReMatchCycle()
+	})
+}
+
+// runDiscoverLoop runs the periodic show-discovery cycle. Runs immediately on
+// startup so operators see output without waiting a full interval.
+func (s *RadioFetchService) runDiscoverLoop(ctx context.Context) {
+	defer s.wg.Done()
+	shared.RunTickerLoop(ctx, "radio_discover", s.discoverInterval, s.stopCh, true, func(_ context.Context) {
+		s.runDiscoverCycle()
 	})
 }
 
@@ -289,6 +318,98 @@ func (s *RadioFetchService) runReMatchCycle() {
 	)
 }
 
+// runDiscoverCycle calls DiscoverStationShows for every active station with a
+// playlist source. The cycle is idempotent — existing shows are no-ops; only
+// brand-new rows fire the per-station Discord notification.
+func (s *RadioFetchService) runDiscoverCycle() {
+	cycleStart := time.Now()
+	s.logger.Info("starting radio discover cycle")
+
+	stations, err := s.radioService.GetActiveStationsWithPlaylistSource()
+	if err != nil {
+		s.logger.Error("failed to list active stations for discover", "error", err)
+		return
+	}
+
+	if len(stations) == 0 {
+		s.logger.Info("no active stations with playlist source found for discover")
+		return
+	}
+
+	var (
+		totalProcessed   int
+		totalDiscovered  int
+		totalNew         int
+		totalFailed      int
+		stationsNotified int
+	)
+
+	for _, station := range stations {
+		s.mu.Lock()
+		failures := s.consecutiveFailures[station.ID]
+		s.mu.Unlock()
+
+		if failures >= radioCircuitBreakerThreshold {
+			s.logger.Warn("skipping station for discover (circuit breaker)",
+				"station_id", station.ID,
+				"station_name", station.Name,
+				"consecutive_failures", failures,
+			)
+			continue
+		}
+
+		totalProcessed++
+		s.logger.Info("discovering shows for station",
+			"station_id", station.ID,
+			"station_name", station.Name,
+		)
+
+		result, err := s.radioService.DiscoverStationShows(station.ID)
+		if err != nil {
+			totalFailed++
+			s.logger.Error("station discover failed",
+				"station_id", station.ID,
+				"station_name", station.Name,
+				"error", err,
+			)
+
+			s.mu.Lock()
+			s.consecutiveFailures[station.ID]++
+			s.mu.Unlock()
+			continue
+		}
+
+		s.mu.Lock()
+		s.consecutiveFailures[station.ID] = 0
+		s.mu.Unlock()
+
+		totalDiscovered += result.ShowsDiscovered
+		totalNew += result.ShowsNew
+
+		s.logger.Info("station discover complete",
+			"station_id", station.ID,
+			"station_name", station.Name,
+			"shows_discovered", result.ShowsDiscovered,
+			"shows_new", result.ShowsNew,
+			"error_count", len(result.Errors),
+		)
+
+		if result.ShowsNew > 0 && s.discordService != nil {
+			s.discordService.NotifyNewRadioShows(station.Name, result.NewShowNames)
+			stationsNotified++
+		}
+	}
+
+	s.logger.Info("radio discover cycle complete",
+		"stations_processed", totalProcessed,
+		"shows_discovered", totalDiscovered,
+		"shows_new", totalNew,
+		"failures", totalFailed,
+		"stations_notified", stationsNotified,
+		"duration", time.Since(cycleStart),
+	)
+}
+
 // GetConsecutiveFailures returns the failure count for a station. Exported for testing.
 func (s *RadioFetchService) GetConsecutiveFailures(stationID uint) int {
 	s.mu.Lock()
@@ -316,4 +437,9 @@ func (s *RadioFetchService) RunAffinityCycleNow() {
 // RunReMatchCycleNow triggers an immediate re-match cycle (useful for testing/admin).
 func (s *RadioFetchService) RunReMatchCycleNow() {
 	s.runReMatchCycle()
+}
+
+// RunDiscoverCycleNow triggers an immediate discover cycle (useful for testing/admin).
+func (s *RadioFetchService) RunDiscoverCycleNow() {
+	s.runDiscoverCycle()
 }

--- a/backend/internal/services/catalog/radio_fetch_service_test.go
+++ b/backend/internal/services/catalog/radio_fetch_service_test.go
@@ -120,6 +120,7 @@ func TestRadioFetchService_RunReMatchCycleNilDB(t *testing.T) {
 		fetchInterval:       1 * time.Hour,
 		affinityInterval:    24 * time.Hour,
 		rematchInterval:     168 * time.Hour,
+		discoverInterval:    24 * time.Hour,
 		stopCh:              make(chan struct{}),
 		logger:              testLogger(),
 		consecutiveFailures: make(map[uint]int),
@@ -127,4 +128,40 @@ func TestRadioFetchService_RunReMatchCycleNilDB(t *testing.T) {
 
 	// Should not panic — just log an error
 	svc.RunReMatchCycleNow()
+}
+
+// TestRadioFetchService_RunDiscoverCycleNilDB verifies discover cycle (PSY-671)
+// handles nil DB gracefully — GetActiveStationsWithPlaylistSource errors out
+// and the cycle logs the failure without panicking.
+func TestRadioFetchService_RunDiscoverCycleNilDB(t *testing.T) {
+	svc := &RadioFetchService{
+		radioService:        &RadioService{db: nil},
+		fetchInterval:       1 * time.Hour,
+		affinityInterval:    24 * time.Hour,
+		rematchInterval:     168 * time.Hour,
+		discoverInterval:    24 * time.Hour,
+		stopCh:              make(chan struct{}),
+		logger:              testLogger(),
+		consecutiveFailures: make(map[uint]int),
+	}
+
+	svc.RunDiscoverCycleNow()
+}
+
+// TestRadioFetchService_DiscoverInterval_EnvOverride verifies PSY-671's
+// RADIO_DISCOVER_INTERVAL_HOURS env var is honored. Defaults to 24h.
+func TestRadioFetchService_DiscoverInterval_EnvOverride(t *testing.T) {
+	t.Setenv("RADIO_DISCOVER_INTERVAL_HOURS", "48")
+	svc := NewRadioFetchService(&RadioService{db: nil}, nil)
+	if svc.discoverInterval != 48*time.Hour {
+		t.Fatalf("expected 48h discover interval, got %v", svc.discoverInterval)
+	}
+}
+
+func TestRadioFetchService_DiscoverInterval_Default(t *testing.T) {
+	t.Setenv("RADIO_DISCOVER_INTERVAL_HOURS", "")
+	svc := NewRadioFetchService(&RadioService{db: nil}, nil)
+	if svc.discoverInterval != DefaultDiscoverInterval {
+		t.Fatalf("expected default %v, got %v", DefaultDiscoverInterval, svc.discoverInterval)
+	}
 }

--- a/backend/internal/services/catalog/radio_import.go
+++ b/backend/internal/services/catalog/radio_import.go
@@ -57,7 +57,7 @@ func (s *RadioService) ImportStation(stationID uint, backfillDays int) (*contrac
 
 	showMap := make(map[string]uint) // external_id → our show ID
 	for _, importShow := range importedShows {
-		showID, err := s.upsertRadioShow(stationID, importShow)
+		showID, _, err := s.upsertRadioShow(stationID, importShow)
 		if err != nil {
 			result.Errors = append(result.Errors, fmt.Sprintf("upsert show %s: %v", importShow.Name, err))
 			continue
@@ -252,13 +252,17 @@ func (s *RadioService) DiscoverStationShows(stationID uint) (*contracts.RadioDis
 	}
 
 	for _, importShow := range importedShows {
-		_, err := s.upsertRadioShow(stationID, importShow)
+		_, created, err := s.upsertRadioShow(stationID, importShow)
 		if err != nil {
 			result.Errors = append(result.Errors, fmt.Sprintf("upsert show %s: %v", importShow.Name, err))
 			continue
 		}
 		result.ShowsDiscovered++
 		result.ShowNames = append(result.ShowNames, importShow.Name)
+		if created {
+			result.ShowsNew++
+			result.NewShowNames = append(result.NewShowNames, importShow.Name)
+		}
 	}
 
 	return result, nil
@@ -384,7 +388,12 @@ func (s *RadioService) ImportShowEpisodes(showID uint, since string, until strin
 // When a show already exists, only fields that are currently empty/NULL in
 // the database are populated from the import data. This preserves
 // admin-curated or migration-seeded values.
-func (s *RadioService) upsertRadioShow(stationID uint, importShow RadioShowImport) (uint, error) {
+// upsertRadioShow returns (showID, created, error). created is true ONLY when
+// a brand-new row was inserted; both the match-by-external-id and the
+// match-by-slug fallback paths return false because they update an existing
+// row. Callers use the bool to distinguish "new arrival" from "idempotent
+// re-run" — e.g. to fire a notification only on actually-new shows.
+func (s *RadioService) upsertRadioShow(stationID uint, importShow RadioShowImport) (uint, bool, error) {
 	// Try matching by external_id first (canonical path)
 	var existing catalogm.RadioShow
 	err := s.db.Where("station_id = ? AND external_id = ?", stationID, importShow.ExternalID).First(&existing).Error
@@ -394,11 +403,11 @@ func (s *RadioService) upsertRadioShow(stationID uint, importShow RadioShowImpor
 		if len(updates) > 0 {
 			s.db.Model(&existing).Updates(updates)
 		}
-		return existing.ID, nil
+		return existing.ID, false, nil
 	}
 
 	if err != gorm.ErrRecordNotFound {
-		return 0, fmt.Errorf("checking existing show by external_id: %w", err)
+		return 0, false, fmt.Errorf("checking existing show by external_id: %w", err)
 	}
 
 	// Fallback: match by slug within the same station.
@@ -413,11 +422,11 @@ func (s *RadioService) upsertRadioShow(stationID uint, importShow RadioShowImpor
 		updates := s.buildNullSafeShowUpdates(&existing, importShow)
 		updates["external_id"] = importShow.ExternalID
 		s.db.Model(&existing).Updates(updates)
-		return existing.ID, nil
+		return existing.ID, false, nil
 	}
 
 	if err != gorm.ErrRecordNotFound {
-		return 0, fmt.Errorf("checking existing show by slug: %w", err)
+		return 0, false, fmt.Errorf("checking existing show by slug: %w", err)
 	}
 
 	// Create new show
@@ -439,10 +448,10 @@ func (s *RadioService) upsertRadioShow(stationID uint, importShow RadioShowImpor
 	}
 
 	if err := s.db.Create(show).Error; err != nil {
-		return 0, fmt.Errorf("creating show: %w", err)
+		return 0, false, fmt.Errorf("creating show: %w", err)
 	}
 
-	return show.ID, nil
+	return show.ID, true, nil
 }
 
 // buildNullSafeShowUpdates returns a map of fields to update, only including

--- a/backend/internal/services/catalog/radio_provider_test.go
+++ b/backend/internal/services/catalog/radio_provider_test.go
@@ -1199,7 +1199,7 @@ func (suite *RadioImportIntegrationTestSuite) TestUpsertRadioShow_CreateNew() {
 		HostName:   stringPtr("John Richards"),
 	}
 
-	showID, err := suite.radioService.upsertRadioShow(station.ID, importShow)
+	showID, _, err := suite.radioService.upsertRadioShow(station.ID, importShow)
 	suite.Require().NoError(err)
 	suite.NotZero(showID)
 
@@ -1238,7 +1238,7 @@ func (suite *RadioImportIntegrationTestSuite) TestUpsertRadioShow_PreservesCurat
 		ImageURL:    stringPtr("https://example.com/image.jpg"),
 	}
 
-	showID, err := suite.radioService.upsertRadioShow(station.ID, importShow)
+	showID, _, err := suite.radioService.upsertRadioShow(station.ID, importShow)
 	suite.Require().NoError(err)
 	suite.Equal(show.ID, showID)
 
@@ -1275,7 +1275,7 @@ func (suite *RadioImportIntegrationTestSuite) TestUpsertRadioShow_FillsEmptyFiel
 		ArchiveURL:  stringPtr("https://example.com/archive"),
 	}
 
-	showID, err := suite.radioService.upsertRadioShow(station.ID, importShow)
+	showID, _, err := suite.radioService.upsertRadioShow(station.ID, importShow)
 	suite.Require().NoError(err)
 	suite.Equal(show.ID, showID)
 
@@ -1310,7 +1310,7 @@ func (suite *RadioImportIntegrationTestSuite) TestUpsertRadioShow_SlugFallback()
 		HostName:   stringPtr("John Richards"),
 	}
 
-	showID, err := suite.radioService.upsertRadioShow(station.ID, importShow)
+	showID, _, err := suite.radioService.upsertRadioShow(station.ID, importShow)
 	suite.Require().NoError(err)
 	suite.Equal(show.ID, showID, "should match the existing show by slug, not create a new one")
 
@@ -1347,7 +1347,7 @@ func (suite *RadioImportIntegrationTestSuite) TestUpsertRadioShow_SlugFallbackDo
 		Name:       "Morning Show",
 	}
 
-	showID, err := suite.radioService.upsertRadioShow(station2.ID, importShow)
+	showID, _, err := suite.radioService.upsertRadioShow(station2.ID, importShow)
 	suite.Require().NoError(err)
 	suite.NotEqual(show.ID, showID, "should not match show from a different station")
 }
@@ -1544,7 +1544,7 @@ func (suite *RadioImportIntegrationTestSuite) runImportWithProvider(stationID ui
 
 	showMap := make(map[string]uint)
 	for _, importShow := range importedShows {
-		showID, err := suite.radioService.upsertRadioShow(stationID, importShow)
+		showID, _, err := suite.radioService.upsertRadioShow(stationID, importShow)
 		if err != nil {
 			result.Errors = append(result.Errors, fmt.Sprintf("upsert show: %v", err))
 			continue

--- a/backend/internal/services/contracts/notification.go
+++ b/backend/internal/services/contracts/notification.go
@@ -80,4 +80,5 @@ type DiscordServiceInterface interface {
 	NotifyShowReport(report *communitym.ShowReport, reporterEmail string)
 	NotifyArtistReport(report *communitym.ArtistReport, reporterEmail string)
 	NotifyNewVenue(venueID uint, venueName, city, state string, address *string, submitterEmail string)
+	NotifyNewRadioShows(stationName string, newShowNames []string)
 }

--- a/backend/internal/services/contracts/radio.go
+++ b/backend/internal/services/contracts/radio.go
@@ -337,9 +337,15 @@ type RadioImportResult struct {
 }
 
 // RadioDiscoverResult summarizes the result of discovering shows for a station.
+// ShowsDiscovered + ShowNames count every show the provider returned
+// (idempotent upserts included). ShowsNew + NewShowNames count only the rows
+// that didn't previously exist — callers use this delta to drive notifications
+// on actually-new shows, not on every cycle.
 type RadioDiscoverResult struct {
 	ShowsDiscovered int      `json:"shows_discovered"`
 	ShowNames       []string `json:"show_names"`
+	ShowsNew        int      `json:"shows_new"`
+	NewShowNames    []string `json:"new_show_names"`
 	Errors          []string `json:"errors,omitempty"`
 }
 

--- a/backend/internal/services/notification/discord.go
+++ b/backend/internal/services/notification/discord.go
@@ -348,6 +348,37 @@ func (s *DiscordService) NotifyNewVenue(venueID uint, venueName, city, state str
 	go s.sendWebhook(embed)
 }
 
+// NotifyNewRadioShows sends a notification when the periodic discover loop
+// finds one or more shows that didn't previously exist for a station.
+// Fire-and-forget; silently skipped when Discord isn't configured.
+func (s *DiscordService) NotifyNewRadioShows(stationName string, newShowNames []string) {
+	if !s.IsConfigured() || len(newShowNames) == 0 {
+		return
+	}
+
+	// Cap the rendered list so a one-off provider-grid expansion doesn't blow
+	// past Discord's embed-field limits. Surface a count tail when truncated.
+	const maxShown = 25
+	displayed := newShowNames
+	tail := ""
+	if len(newShowNames) > maxShown {
+		displayed = newShowNames[:maxShown]
+		tail = fmt.Sprintf("\n…and %d more", len(newShowNames)-maxShown)
+	}
+
+	embed := DiscordEmbed{
+		Title:       fmt.Sprintf("New Radio Shows: %s", stationName),
+		Description: fmt.Sprintf("Discovered %d new show(s)", len(newShowNames)),
+		Color:       ColorBlue,
+		Timestamp:   time.Now().UTC().Format(time.RFC3339),
+		Fields: []DiscordEmbedField{
+			{Name: "Shows", Value: strings.Join(displayed, "\n") + tail, Inline: false},
+		},
+	}
+
+	go s.sendWebhook(embed)
+}
+
 // sendWebhook sends an embed to the Discord webhook (fire-and-forget)
 func (s *DiscordService) sendWebhook(embed DiscordEmbed) {
 	payload := DiscordWebhookPayload{

--- a/backend/internal/services/notification/discord_test.go
+++ b/backend/internal/services/notification/discord_test.go
@@ -753,3 +753,58 @@ func TestNotifyArtistReport_UnknownArtist(t *testing.T) {
 	payload := parseWebhookPayload(t, raw)
 	assert.Contains(t, payload.Embeds[0].Title, "Unknown Artist")
 }
+
+// =============================================================================
+// NotifyNewRadioShows (PSY-671)
+// =============================================================================
+
+func TestNotifyNewRadioShows_Success(t *testing.T) {
+	svc, payloads, _ := setupDiscordTest(t)
+
+	svc.NotifyNewRadioShows("WFMU", []string{"Three Chord Monte", "Bodega Pop", "Downtown Soulville"})
+
+	raw := waitForPayload(t, payloads)
+	payload := parseWebhookPayload(t, raw)
+	require.Len(t, payload.Embeds, 1)
+	e := payload.Embeds[0]
+	assert.Equal(t, "New Radio Shows: WFMU", e.Title)
+	assert.Equal(t, "Discovered 3 new show(s)", e.Description)
+	assert.Equal(t, ColorBlue, e.Color)
+	require.Len(t, e.Fields, 1)
+	assert.Equal(t, "Shows", e.Fields[0].Name)
+	assert.Contains(t, e.Fields[0].Value, "Three Chord Monte")
+	assert.Contains(t, e.Fields[0].Value, "Bodega Pop")
+	assert.Contains(t, e.Fields[0].Value, "Downtown Soulville")
+}
+
+func TestNotifyNewRadioShows_EmptyList(t *testing.T) {
+	svc, payloads, _ := setupDiscordTest(t)
+
+	svc.NotifyNewRadioShows("WFMU", []string{})
+
+	assertNoPayload(t, payloads)
+}
+
+func TestNotifyNewRadioShows_NotConfigured(t *testing.T) {
+	svc := &DiscordService{enabled: false}
+
+	svc.NotifyNewRadioShows("WFMU", []string{"Show A"})
+}
+
+func TestNotifyNewRadioShows_CapsAtTwentyFive(t *testing.T) {
+	svc, payloads, _ := setupDiscordTest(t)
+
+	names := make([]string, 30)
+	for i := range names {
+		names[i] = "Show " + string(rune('A'+i%26))
+	}
+
+	svc.NotifyNewRadioShows("WFMU", names)
+
+	raw := waitForPayload(t, payloads)
+	payload := parseWebhookPayload(t, raw)
+	require.Len(t, payload.Embeds, 1)
+	value := payload.Embeds[0].Fields[0].Value
+	assert.Contains(t, value, "…and 5 more")
+	assert.Equal(t, "Discovered 30 new show(s)", payload.Embeds[0].Description)
+}

--- a/backend/internal/services/pipeline/scheduler_test.go
+++ b/backend/internal/services/pipeline/scheduler_test.go
@@ -139,6 +139,7 @@ func (s *stubDiscordService) NotifyArtistReport(report *communitym.ArtistReport,
 }
 func (s *stubDiscordService) NotifyNewVenue(venueID uint, venueName, city, state string, address *string, submitterEmail string) {
 }
+func (s *stubDiscordService) NotifyNewRadioShows(stationName string, newShowNames []string) {}
 
 // ── Tests ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Closes PSY-671.

## Summary

- Add a 4th periodic ticker goroutine (`runDiscoverLoop` / `runDiscoverCycle`) to `RadioFetchService`. Default cadence 24h via `RADIO_DISCOVER_INTERVAL_HOURS`. Runs immediately on startup so operators see output without waiting a full interval (mirrors the existing `runFetchLoop` startup behavior).
- Per-station: skip via the existing circuit breaker (shared with `runFetchCycle` so a wedged provider gets one threshold, not two), call `DiscoverStationShows`, increment failures on error / reset on success.
- Fire `DiscordService.NotifyNewRadioShows(stationName, newShowNames)` only when the cycle finds ≥1 actually-new shows for a station — not on every cycle.
- Plumbing for "actually-new": `upsertRadioShow` now returns `(uint, bool, error)` where `bool=true` ONLY for brand-new inserts (both existing-row paths return false). `DiscoverStationShows` aggregates the bool into the new `RadioDiscoverResult.ShowsNew` + `NewShowNames` fields.
- New Discord embed `NotifyNewRadioShows` (`ColorBlue`, capped at 25 names with "…and N more" tail). Mirrors the existing 9 `Notify*` methods exactly.

Concrete blast: when WFMU adds a new program to its DJ grid, the catalog picks it up within 24h instead of requiring a manual admin `/discover` POST. Frees PSY-672's auto-backfill work to focus on the historical-episodes side.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/services/catalog/... -run "RadioFetchService" -count=1` — 8/8 passing, including 3 new (`RunDiscoverCycleNilDB`, `DiscoverInterval_EnvOverride`, `DiscoverInterval_Default`)
- [x] `go test ./internal/services/catalog/... -count=1` — full catalog suite (~26s, includes the modified `upsertRadioShow` integration tests) passes
- [x] `go test ./internal/services/notification/... -count=1` — passes, including 4 new `NotifyNewRadioShows` tests (`Success`, `EmptyList`, `NotConfigured`, `CapsAtTwentyFive` covering embed shape + 25-cap behavior)
- [x] `go test ./internal/api/handlers/catalog/... -count=1` — handler-layer suite passes (verifies the new `RadioDiscoverResult` fields don't break the admin `/discover` endpoint)
- [x] `/simplify` — 3 reviewer agents reported clean. Addressed Agent 2's recommendation: stripped `PSY-671` ticket references from 4 doc comments to avoid rot (kept the semantic explanation), and removed the duplicated "shared circuit breaker" rationale from the cycle doc (kept it on the field doc where the invariant belongs)
- [x] No UI surface — backend-only behavioral change. Discover endpoint response gains 2 additive fields (`shows_new`, `new_show_names`); existing admin UI ignores them, frontend TS interface can adopt later if useful
- [x] Mocks regenerated via `cd backend && go run ./internal/api/handlers/gen/ > ./internal/api/handlers/shared/testhelpers/mocks_gen.go`

## Heads up from `/simplify`

`/simplify`'s reuse agent flagged the 4th env-var-override block in `NewRadioFetchService` as part of a repo-wide pattern (10+ similar sites: pipeline scheduler, cleanup, auto-promotion, collection digest, etc.). A `shared.HoursFromEnv` helper would compress all of them — pre-existing duplication, **not** new debt from this PR. Deliberately not in scope; the within-this-PR pattern is consistent with the 3 existing peer copies in the same constructor.

## Coverage gaps

- **End-to-end "discover cycle fires Discord notification on a real new show"** not unit-tested: `RadioService` is a concrete struct (not an interface), and the per-provider `DiscoverShows` impls fetch real external data. The closest unit-level coverage is the 4 `NotifyNewRadioShows` tests (proves the embed is correct + fire-and-forget) + the `RunDiscoverCycleNilDB` test (proves the cycle doesn't panic on a degenerate path). Full integration via local dev stack: run `RunDiscoverCycleNow()` against a seeded `psychicdb`, observe `"station discover complete"` slog line + Discord webhook hit. Documented but not exercised in CI.
- **Circuit-breaker integration on discover loop** not asserted in a test. Pattern shared with `runFetchCycle` (`TestRadioFetchService_CircuitBreaker` covers the underlying `SetConsecutiveFailures`/`GetConsecutiveFailures` map mechanics; the same map drives both loops). A discover-specific test would be near-duplicate.
- **Discord webhook payload** when `len(newShowNames) > 25` is asserted via `CapsAtTwentyFive` to truncate AND include the "…and N more" tail; the actual `embed.Fields[0].Value` length isn't checked against Discord's 1024-char field limit. With 25 names averaging ~30 chars + tail, we're well under the limit, but a pathological "30 × 60-char show names" case could exceed it. Practically unreachable with the current providers (WFMU/KEXP/NTS show names are short); worth a `len(...) > 1024` extra-truncation guard if a future provider has longer names.
- **`pattern_background_services.md` auto-memory** not updated (per `feedback_no_commit_md_files.md`). The service goroutine count goes from 10 → 11; will update the user-level memory after merge.
