### PR TITLE
PSY-672: auto-backfill historical playlists on new show discovery

### DIFF
--- a/backend/internal/api/handlers/shared/testhelpers/mocks_gen.go
+++ b/backend/internal/api/handlers/shared/testhelpers/mocks_gen.go
@@ -1242,6 +1242,7 @@ type MockDiscordService struct {
 	NotifyArtistReportFn func(*communitym.ArtistReport, string)
 	NotifyNewVenueFn func(uint, string, string, string, *string, string)
 	NotifyNewRadioShowsFn func(string, []string)
+	NotifyBackfillCompletedFn func(string, []string, int, int)
 }
 
 func (m *MockDiscordService) IsConfigured() (bool) {
@@ -1293,6 +1294,11 @@ func (m *MockDiscordService) NotifyNewVenue(venueID uint, venueName string, city
 func (m *MockDiscordService) NotifyNewRadioShows(stationName string, newShowNames []string) {
 	if m.NotifyNewRadioShowsFn != nil {
 		m.NotifyNewRadioShowsFn(stationName, newShowNames)
+	}
+}
+func (m *MockDiscordService) NotifyBackfillCompleted(stationName string, completedShows []string, totalEpisodes int, totalPlays int) {
+	if m.NotifyBackfillCompletedFn != nil {
+		m.NotifyBackfillCompletedFn(stationName, completedShows, totalEpisodes, totalPlays)
 	}
 }
 

--- a/backend/internal/services/catalog/radio_fetch_service.go
+++ b/backend/internal/services/catalog/radio_fetch_service.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	catalogm "psychic-homily-backend/internal/models/catalog"
 	"psychic-homily-backend/internal/services/contracts"
 	"psychic-homily-backend/internal/services/shared"
 )
@@ -25,6 +26,17 @@ const DefaultReMatchInterval = 7 * 24 * time.Hour
 // (WFMU adds shows monthly at most; KEXP/NTS slower), so once a day is plenty
 // and the per-station DJ-index fetch cost is negligible.
 const DefaultDiscoverInterval = 24 * time.Hour
+
+// Default auto-backfill window (90 days). When the discover loop finds a new
+// show, an import job is created + started for the last N days so the show
+// arrives with some history instead of just the next ~7 days of episodes.
+// Set RADIO_AUTO_BACKFILL_DAYS=0 to disable auto-backfill entirely.
+const DefaultAutoBackfillDays = 90
+
+// autoBackfillPollInterval is how often the per-station backfill goroutine
+// polls a running import job for completion. The job updates its DB row every
+// 10 episodes; 5s is comfortably finer-grained than typical job tick rates.
+const autoBackfillPollInterval = 5 * time.Second
 
 // radioCircuitBreakerThreshold is the number of consecutive failures before
 // a station is temporarily skipped during fetch cycles.
@@ -46,6 +58,10 @@ type RadioFetchService struct {
 	rematchInterval  time.Duration
 	discoverInterval time.Duration
 
+	// autoBackfillDays: how far back to backfill when discovery finds a new show.
+	// 0 disables auto-backfill (admins can still manually trigger via /admin/radio-shows/{id}/import-job).
+	autoBackfillDays int
+
 	stopCh chan struct{}
 	wg     sync.WaitGroup
 	logger *slog.Logger
@@ -64,6 +80,7 @@ type RadioFetchService struct {
 //   - RADIO_AFFINITY_INTERVAL_HOURS (default 24)
 //   - RADIO_REMATCH_INTERVAL_HOURS (default 168, i.e. 7 days)
 //   - RADIO_DISCOVER_INTERVAL_HOURS (default 24)
+//   - RADIO_AUTO_BACKFILL_DAYS (default 90; 0 disables auto-backfill)
 func NewRadioFetchService(
 	radioService *RadioService,
 	discordService contracts.DiscordServiceInterface,
@@ -96,6 +113,15 @@ func NewRadioFetchService(
 		}
 	}
 
+	// 0 explicitly disables auto-backfill. Negative values are silently treated
+	// as 0 (defensive). Default 90 if env unset or invalid.
+	autoBackfillDays := DefaultAutoBackfillDays
+	if envVal := os.Getenv("RADIO_AUTO_BACKFILL_DAYS"); envVal != "" {
+		if days, err := strconv.Atoi(envVal); err == nil && days >= 0 {
+			autoBackfillDays = days
+		}
+	}
+
 	return &RadioFetchService{
 		radioService:        radioService,
 		discordService:      discordService,
@@ -103,6 +129,7 @@ func NewRadioFetchService(
 		affinityInterval:    affinityInterval,
 		rematchInterval:     rematchInterval,
 		discoverInterval:    discoverInterval,
+		autoBackfillDays:    autoBackfillDays,
 		stopCh:              make(chan struct{}),
 		logger:              slog.Default(),
 		consecutiveFailures: make(map[uint]int),
@@ -398,6 +425,16 @@ func (s *RadioFetchService) runDiscoverCycle() {
 			s.discordService.NotifyNewRadioShows(station.Name, result.NewShowNames)
 			stationsNotified++
 		}
+
+		// Kick off the per-station auto-backfill drain in its own goroutine so
+		// the discover cycle returns immediately. Serializes jobs PER STATION
+		// (one at a time) so a 56-show provider burst doesn't fan out into
+		// concurrent provider hits — the existing 1-rps per-instance rate
+		// limiter on each provider handles per-episode pacing.
+		if s.autoBackfillDays > 0 && len(result.NewShowIDs) > 0 {
+			s.wg.Add(1)
+			go s.autoBackfillStation(station.Name, result.NewShowIDs, result.NewShowNames)
+		}
 	}
 
 	s.logger.Info("radio discover cycle complete",
@@ -408,6 +445,133 @@ func (s *RadioFetchService) runDiscoverCycle() {
 		"stations_notified", stationsNotified,
 		"duration", time.Since(cycleStart),
 	)
+}
+
+// autoBackfillStation drains a per-station batch of newly-discovered shows
+// SERIALLY — one import job at a time per station, polling each to completion
+// before starting the next. Single batched Discord notification at the end.
+//
+// Why serial: provider HTTP clients are rate-limited at 1 req/sec PER INSTANCE
+// (existing wfmuRateLimit / kexpRateLimit / ntsRateLimit). Each import job
+// gets its own provider instance via getProvider, so parallel jobs would each
+// have an independent rate limiter and could collectively hit a provider
+// faster than the per-instance cap intends. Per-station serialization keeps
+// effective egress at ~1 req/sec/provider.
+//
+// Process lifetime: the goroutine respects s.stopCh so a service Stop()
+// abandons pending jobs cleanly (no orphan ticker goroutines). Already-started
+// jobs continue in their own runImportJob goroutine until they finish or are
+// cancelled.
+func (s *RadioFetchService) autoBackfillStation(stationName string, showIDs []uint, showNames []string) {
+	defer s.wg.Done()
+
+	until := time.Now()
+	since := until.AddDate(0, 0, -s.autoBackfillDays)
+	sinceStr := since.Format("2006-01-02")
+	untilStr := until.Format("2006-01-02")
+
+	s.logger.Info("auto_backfill_started",
+		"station", stationName,
+		"shows", len(showIDs),
+		"since", sinceStr,
+		"until", untilStr,
+	)
+
+	var (
+		completedShows []string
+		totalEpisodes  int
+		totalPlays     int
+	)
+
+	for i, showID := range showIDs {
+		showName := showNames[i]
+
+		job, err := s.radioService.CreateImportJob(showID, sinceStr, untilStr)
+		if err != nil {
+			s.logger.Warn("auto_backfill_create_job_failed",
+				"show_id", showID,
+				"show", showName,
+				"error", err,
+			)
+			continue
+		}
+
+		if err := s.radioService.StartImportJob(job.ID); err != nil {
+			s.logger.Warn("auto_backfill_start_job_failed",
+				"show_id", showID,
+				"job_id", job.ID,
+				"error", err,
+			)
+			continue
+		}
+
+		finalJob, result := s.waitForJobCompletion(job.ID)
+		switch result {
+		case jobWaitShutdown:
+			s.logger.Info("auto_backfill_abandoned_on_shutdown", "job_id", job.ID)
+			return
+		case jobWaitPollError:
+			continue
+		}
+
+		if finalJob.Status == catalogm.RadioImportJobStatusCompleted {
+			completedShows = append(completedShows, showName)
+			totalEpisodes += finalJob.EpisodesImported
+			totalPlays += finalJob.PlaysMatched
+		} else {
+			s.logger.Warn("auto_backfill_job_did_not_complete",
+				"job_id", job.ID,
+				"status", finalJob.Status,
+			)
+		}
+	}
+
+	s.logger.Info("auto_backfill_finished",
+		"station", stationName,
+		"completed", len(completedShows),
+		"episodes_imported", totalEpisodes,
+		"plays_matched", totalPlays,
+	)
+
+	if s.discordService != nil && len(completedShows) > 0 {
+		s.discordService.NotifyBackfillCompleted(stationName, completedShows, totalEpisodes, totalPlays)
+	}
+}
+
+// jobWaitResult distinguishes the three outcomes of waitForJobCompletion so the
+// caller can route shutdown vs poll-error vs terminal without bool-overloading.
+type jobWaitResult int
+
+const (
+	jobWaitTerminal  jobWaitResult = iota // job reached completed/failed/cancelled — *Job is non-nil
+	jobWaitShutdown                       // service shutting down — caller should return
+	jobWaitPollError                      // GetImportJob failed — caller should continue to next show
+)
+
+// waitForJobCompletion polls a running import job every autoBackfillPollInterval
+// until it reaches a terminal status (catalogm.RadioImportJobStatus{Completed,
+// Failed,Cancelled}), or returns earlier if s.stopCh closes (shutdown) or a
+// GetImportJob call errors (poll error).
+func (s *RadioFetchService) waitForJobCompletion(jobID uint) (*contracts.RadioImportJobResponse, jobWaitResult) {
+	for {
+		select {
+		case <-s.stopCh:
+			return nil, jobWaitShutdown
+		case <-time.After(autoBackfillPollInterval):
+		}
+
+		job, err := s.radioService.GetImportJob(jobID)
+		if err != nil {
+			s.logger.Warn("auto_backfill_poll_job_load_failed", "job_id", jobID, "error", err)
+			return nil, jobWaitPollError
+		}
+		switch job.Status {
+		case catalogm.RadioImportJobStatusCompleted,
+			catalogm.RadioImportJobStatusFailed,
+			catalogm.RadioImportJobStatusCancelled:
+			return job, jobWaitTerminal
+		}
+	}
 }
 
 // GetConsecutiveFailures returns the failure count for a station. Exported for testing.

--- a/backend/internal/services/catalog/radio_fetch_service_test.go
+++ b/backend/internal/services/catalog/radio_fetch_service_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"testing"
 	"time"
+
+	"psychic-homily-backend/internal/services/contracts"
 )
 
 // testLogger returns a minimal slog.Logger suitable for testing.
@@ -163,5 +165,74 @@ func TestRadioFetchService_DiscoverInterval_Default(t *testing.T) {
 	svc := NewRadioFetchService(&RadioService{db: nil}, nil)
 	if svc.discoverInterval != DefaultDiscoverInterval {
 		t.Fatalf("expected default %v, got %v", DefaultDiscoverInterval, svc.discoverInterval)
+	}
+}
+
+// PSY-672: RADIO_AUTO_BACKFILL_DAYS env var. Default 90, 0 disables.
+func TestRadioFetchService_AutoBackfillDays_Default(t *testing.T) {
+	t.Setenv("RADIO_AUTO_BACKFILL_DAYS", "")
+	svc := NewRadioFetchService(&RadioService{db: nil}, nil)
+	if svc.autoBackfillDays != DefaultAutoBackfillDays {
+		t.Fatalf("expected default %d, got %d", DefaultAutoBackfillDays, svc.autoBackfillDays)
+	}
+}
+
+func TestRadioFetchService_AutoBackfillDays_EnvOverride(t *testing.T) {
+	t.Setenv("RADIO_AUTO_BACKFILL_DAYS", "30")
+	svc := NewRadioFetchService(&RadioService{db: nil}, nil)
+	if svc.autoBackfillDays != 30 {
+		t.Fatalf("expected 30, got %d", svc.autoBackfillDays)
+	}
+}
+
+func TestRadioFetchService_AutoBackfillDays_DisableViaZero(t *testing.T) {
+	t.Setenv("RADIO_AUTO_BACKFILL_DAYS", "0")
+	svc := NewRadioFetchService(&RadioService{db: nil}, nil)
+	if svc.autoBackfillDays != 0 {
+		t.Fatalf("expected 0 (disabled), got %d", svc.autoBackfillDays)
+	}
+}
+
+func TestRadioFetchService_AutoBackfillDays_NegativeFallsBackToDefault(t *testing.T) {
+	t.Setenv("RADIO_AUTO_BACKFILL_DAYS", "-5")
+	svc := NewRadioFetchService(&RadioService{db: nil}, nil)
+	if svc.autoBackfillDays != DefaultAutoBackfillDays {
+		t.Fatalf("negative value should fall back to default %d, got %d", DefaultAutoBackfillDays, svc.autoBackfillDays)
+	}
+}
+
+// PSY-672: waitForJobCompletion respects stopCh — a service shutdown mid-poll
+// should return jobWaitShutdown within one poll interval so the drain goroutine
+// can return cleanly without orphan ticks.
+func TestRadioFetchService_WaitForJobCompletion_ShutdownAbort(t *testing.T) {
+	svc := &RadioFetchService{
+		radioService:        &RadioService{db: nil},
+		stopCh:              make(chan struct{}),
+		logger:              testLogger(),
+		consecutiveFailures: make(map[uint]int),
+	}
+
+	// Close stopCh immediately; the wait should return jobWaitShutdown on the
+	// first select iteration without ever hitting GetImportJob.
+	close(svc.stopCh)
+	done := make(chan struct{})
+	var (
+		job    *contracts.RadioImportJobResponse
+		result jobWaitResult
+	)
+	go func() {
+		job, result = svc.waitForJobCompletion(1)
+		close(done)
+	}()
+	select {
+	case <-done:
+		if result != jobWaitShutdown {
+			t.Fatalf("expected jobWaitShutdown on stopCh close, got %v", result)
+		}
+		if job != nil {
+			t.Fatal("expected nil job on stopCh close")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("waitForJobCompletion did not honor stopCh within 2s")
 	}
 }

--- a/backend/internal/services/catalog/radio_import.go
+++ b/backend/internal/services/catalog/radio_import.go
@@ -252,7 +252,7 @@ func (s *RadioService) DiscoverStationShows(stationID uint) (*contracts.RadioDis
 	}
 
 	for _, importShow := range importedShows {
-		_, created, err := s.upsertRadioShow(stationID, importShow)
+		showID, created, err := s.upsertRadioShow(stationID, importShow)
 		if err != nil {
 			result.Errors = append(result.Errors, fmt.Sprintf("upsert show %s: %v", importShow.Name, err))
 			continue
@@ -262,6 +262,7 @@ func (s *RadioService) DiscoverStationShows(stationID uint) (*contracts.RadioDis
 		if created {
 			result.ShowsNew++
 			result.NewShowNames = append(result.NewShowNames, importShow.Name)
+			result.NewShowIDs = append(result.NewShowIDs, showID)
 		}
 	}
 

--- a/backend/internal/services/contracts/notification.go
+++ b/backend/internal/services/contracts/notification.go
@@ -81,4 +81,5 @@ type DiscordServiceInterface interface {
 	NotifyArtistReport(report *communitym.ArtistReport, reporterEmail string)
 	NotifyNewVenue(venueID uint, venueName, city, state string, address *string, submitterEmail string)
 	NotifyNewRadioShows(stationName string, newShowNames []string)
+	NotifyBackfillCompleted(stationName string, completedShows []string, totalEpisodes int, totalPlays int)
 }

--- a/backend/internal/services/contracts/radio.go
+++ b/backend/internal/services/contracts/radio.go
@@ -340,12 +340,15 @@ type RadioImportResult struct {
 // ShowsDiscovered + ShowNames count every show the provider returned
 // (idempotent upserts included). ShowsNew + NewShowNames count only the rows
 // that didn't previously exist — callers use this delta to drive notifications
-// on actually-new shows, not on every cycle.
+// on actually-new shows, not on every cycle. NewShowIDs is parallel to
+// NewShowNames (same length, same order); the discover orchestrator uses the
+// IDs to enqueue auto-backfill import jobs.
 type RadioDiscoverResult struct {
 	ShowsDiscovered int      `json:"shows_discovered"`
 	ShowNames       []string `json:"show_names"`
 	ShowsNew        int      `json:"shows_new"`
 	NewShowNames    []string `json:"new_show_names"`
+	NewShowIDs      []uint   `json:"new_show_ids"`
 	Errors          []string `json:"errors,omitempty"`
 }
 

--- a/backend/internal/services/notification/discord.go
+++ b/backend/internal/services/notification/discord.go
@@ -379,6 +379,38 @@ func (s *DiscordService) NotifyNewRadioShows(stationName string, newShowNames []
 	go s.sendWebhook(embed)
 }
 
+// NotifyBackfillCompleted sends one batched notification when the auto-backfill
+// drain finishes for a station — fires AFTER all per-show backfill jobs from a
+// discover cycle have drained, not per-show. Fire-and-forget; silently skipped
+// when Discord isn't configured or no shows actually completed.
+func (s *DiscordService) NotifyBackfillCompleted(stationName string, completedShows []string, totalEpisodes int, totalPlays int) {
+	if !s.IsConfigured() || len(completedShows) == 0 {
+		return
+	}
+
+	// Cap the rendered list (Discord embed field limit is 1024 chars; show
+	// names average ~30 chars + line breaks).
+	const maxShown = 25
+	displayed := completedShows
+	tail := ""
+	if len(completedShows) > maxShown {
+		displayed = completedShows[:maxShown]
+		tail = fmt.Sprintf("\n…and %d more", len(completedShows)-maxShown)
+	}
+
+	embed := DiscordEmbed{
+		Title:       fmt.Sprintf("Backfill Complete: %s", stationName),
+		Description: fmt.Sprintf("Backfilled %d show(s) — %d episodes, %d plays matched", len(completedShows), totalEpisodes, totalPlays),
+		Color:       ColorGreen,
+		Timestamp:   time.Now().UTC().Format(time.RFC3339),
+		Fields: []DiscordEmbedField{
+			{Name: "Shows", Value: strings.Join(displayed, "\n") + tail, Inline: false},
+		},
+	}
+
+	go s.sendWebhook(embed)
+}
+
 // sendWebhook sends an embed to the Discord webhook (fire-and-forget)
 func (s *DiscordService) sendWebhook(embed DiscordEmbed) {
 	payload := DiscordWebhookPayload{

--- a/backend/internal/services/notification/discord_test.go
+++ b/backend/internal/services/notification/discord_test.go
@@ -808,3 +808,55 @@ func TestNotifyNewRadioShows_CapsAtTwentyFive(t *testing.T) {
 	assert.Contains(t, value, "…and 5 more")
 	assert.Equal(t, "Discovered 30 new show(s)", payload.Embeds[0].Description)
 }
+
+// =============================================================================
+// NotifyBackfillCompleted (PSY-672)
+// =============================================================================
+
+func TestNotifyBackfillCompleted_Success(t *testing.T) {
+	svc, payloads, _ := setupDiscordTest(t)
+
+	svc.NotifyBackfillCompleted("WFMU", []string{"Three Chord Monte", "Bodega Pop"}, 26, 412)
+
+	raw := waitForPayload(t, payloads)
+	payload := parseWebhookPayload(t, raw)
+	require.Len(t, payload.Embeds, 1)
+	e := payload.Embeds[0]
+	assert.Equal(t, "Backfill Complete: WFMU", e.Title)
+	assert.Equal(t, "Backfilled 2 show(s) — 26 episodes, 412 plays matched", e.Description)
+	assert.Equal(t, ColorGreen, e.Color)
+	require.Len(t, e.Fields, 1)
+	assert.Contains(t, e.Fields[0].Value, "Three Chord Monte")
+	assert.Contains(t, e.Fields[0].Value, "Bodega Pop")
+}
+
+func TestNotifyBackfillCompleted_EmptyList(t *testing.T) {
+	svc, payloads, _ := setupDiscordTest(t)
+
+	svc.NotifyBackfillCompleted("WFMU", []string{}, 0, 0)
+
+	assertNoPayload(t, payloads)
+}
+
+func TestNotifyBackfillCompleted_NotConfigured(t *testing.T) {
+	svc := &DiscordService{enabled: false}
+
+	svc.NotifyBackfillCompleted("WFMU", []string{"Show A"}, 5, 50)
+}
+
+func TestNotifyBackfillCompleted_CapsAtTwentyFive(t *testing.T) {
+	svc, payloads, _ := setupDiscordTest(t)
+
+	names := make([]string, 30)
+	for i := range names {
+		names[i] = "Show " + string(rune('A'+i%26))
+	}
+
+	svc.NotifyBackfillCompleted("WFMU", names, 390, 8000)
+
+	raw := waitForPayload(t, payloads)
+	payload := parseWebhookPayload(t, raw)
+	require.Len(t, payload.Embeds, 1)
+	assert.Contains(t, payload.Embeds[0].Fields[0].Value, "…and 5 more")
+	assert.Contains(t, payload.Embeds[0].Description, "30 show(s)")
+}

--- a/backend/internal/services/pipeline/scheduler_test.go
+++ b/backend/internal/services/pipeline/scheduler_test.go
@@ -140,6 +140,8 @@ func (s *stubDiscordService) NotifyArtistReport(report *communitym.ArtistReport,
 func (s *stubDiscordService) NotifyNewVenue(venueID uint, venueName, city, state string, address *string, submitterEmail string) {
 }
 func (s *stubDiscordService) NotifyNewRadioShows(stationName string, newShowNames []string) {}
+func (s *stubDiscordService) NotifyBackfillCompleted(stationName string, completedShows []string, totalEpisodes int, totalPlays int) {
+}
 
 // ── Tests ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Closes PSY-672.

## Summary

Wires PSY-671's periodic discover loop into an auto-backfill flow. When `DiscoverStationShows` finds a brand-new show, the discover cycle spawns a **per-station** goroutine that drains the new shows SERIALLY:

- For each new show: `CreateImportJob(showID, since=now-90d, until=now)` → `StartImportJob` → poll every 5s for terminal status.
- After all shows drain, fires ONE batched Discord `NotifyBackfillCompleted(stationName, completedShows, totalEpisodes, totalPlays)`.
- Default window `RADIO_AUTO_BACKFILL_DAYS=90`; set to `0` to disable.

**Why serial per-station**: each provider has a 1-rps rate limiter (`wfmuRateLimit` / `kexpRateLimit` / `ntsRateLimit`), but it's **per-instance** — `getProvider` returns a fresh instance per import job. Parallel jobs would have independent limiters and could collectively exceed the per-instance cap. Per-station serialization keeps effective egress at ≤1 rps/provider regardless of burst size. Different stations drain in parallel (3 providers → 3 concurrent station goroutines worst-case).

Concrete blast: WFMU's grid has ~60 programs; today the catalog has 4. First post-deploy discover cycle finds ~56 new shows and drains them sequentially over ~13 minutes (≈14 sec/show for a 90-day, 13-episode weekly backfill), generating 1 Discord ping at the end instead of 56.

Contract changes (additive, JSON-stable):
- `RadioDiscoverResult.NewShowIDs []uint` (parallel to existing `NewShowNames`)
- `DiscordServiceInterface.NotifyBackfillCompleted(...)` (mock regen + stub update in `pipeline/scheduler_test.go` per the [[interface-change-full-suite]] lesson from PSY-671)
- `upsertRadioShow` signature unchanged (PSY-671 already added the `created bool` we needed)

## Heads up from `/simplify`

Three findings, all addressed:
- **BUG**: `waitForJobCompletion`'s original `(*Job, bool)` return shape had a nil-panic on `GetImportJob` error (`(nil, true)` would skip the shutdown guard and dereference). Refactored to a `jobWaitResult` enum (`jobWaitTerminal` / `jobWaitShutdown` / `jobWaitPollError`); caller `switch`es and `continue`s on poll error.
- **Stringly-typed**: replaced `"completed"` / `"failed"` / `"cancelled"` literals with `catalogm.RadioImportJobStatus*` constants from `models/catalog/radio.go:210-214`.
- **Defensive bounds-check**: dropped the `if i < len(showNames)` guard. The parallel-array invariant (`NewShowIDs` + `NewShowNames` appended together) is enforced one layer up at `radio_import.go:262-265` and documented in the contract.

Reuse-agent findings deliberately deferred:
- Env-override parse block is now 5x in the same constructor (fetch/affinity/rematch/discover/auto-backfill — pattern hit ~10× repo-wide). Same call as PSY-671: stay consistent with established pattern; file a dedicated `shared.HoursFromEnv` ticket if/when this becomes painful.
- `NotifyBackfillCompleted` shape duplicates `NotifyNewRadioShows` (PSY-671). Existing 9 `Notify*` methods are all hand-written peers; extraction is a separate audit across all 11.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — full suite green (~3m), per [[interface-change-full-suite]] (PSY-671 caught a missed hand-rolled stub in `pipeline/scheduler_test.go` only via CI — running full suite up-front this time)
- [x] `go test ./internal/services/notification/... -count=1 -run NotifyBackfillCompleted` — 4 new tests passing (Success / EmptyList / NotConfigured / CapsAtTwentyFive covering embed shape + 25-cap tail)
- [x] `go test ./internal/services/catalog/... -count=1 -run "AutoBackfillDays|WaitForJobCompletion"` — 5 new tests passing (env-var default / override / disable-via-zero / negative-fallback / stopCh-shutdown-abort using the `jobWaitShutdown` enum value)
- [x] `/simplify` — 3 reviewer agents flagged the nil-panic + stringly-typed status + defensive bound; all three fixed inline. Re-ran `go test ./...` after fixes — clean.
- [x] No UI surface — backend-only behavioral change. New `RadioDiscoverResult.new_show_ids` field is additive on the admin `/discover` response; existing frontend admin UI ignores it.
- [x] Mocks regenerated via `cd backend && go run ./internal/api/handlers/gen/ > ./internal/api/handlers/shared/testhelpers/mocks_gen.go`; `stubDiscordService` in `pipeline/scheduler_test.go` hand-updated to satisfy the new interface method.
- [x] Runbook landed at `docs/runbooks/radio-auto-backfill.md` (346 lines; gitignored per project convention). Cross-linked from `docs/INDEX.md`. Documents the design rationale, configuration, failure modes + recovery (orphan-running-row cleanup SQL), tuning, verification queries, and file references.

## Coverage gaps

- **End-to-end auto-backfill cycle** (discover → create job → start → poll → notify) is not unit-tested as a single flow. `RadioService` is a concrete struct (not an interface), `runImportJob` spawns its own goroutine, and providers fetch real external data — testing the full flow would require either a complex mock harness or a true integration test against a stubbed provider. Unit coverage today: `NotifyBackfillCompleted` (4 tests), `waitForJobCompletion` shutdown-abort path (1 test), env-var parsing (4 tests). Full flow verified via local dev stack manual repro: triggering `RunDiscoverCycleNow()` against a seeded `psychicdb` produces the expected slog sequence + Discord webhook hit. Documented in the runbook's "What the auto-backfill goroutine looks like in slog" section.
- **`waitForJobCompletion` poll-error path** (`jobWaitPollError`) not asserted in a test. The shutdown-abort test exercises one branch of the same `switch`; pollError is a parallel branch with identical mechanics. Worth adding if `runImportJob` ever swallows errors silently — currently it doesn't, so the gap is low-risk.
- **Process-restart leaves orphan `status=running` rows.** Pre-existing risk shared with all admin-triggered jobs (`StartImportJob` spawns bare `go runImportJob`, not tied to `s.wg`). PSY-672 doesn't make it worse; the runbook documents the manual SQL cleanup (`UPDATE radio_import_jobs SET status='failed' WHERE status='running' AND started_at < NOW() - INTERVAL '1 hour'`). A persistent worker pool that recovers orphans on startup would address this — out of scope; file a follow-up ticket if it bites.
- **No auto-retry of failed auto-backfill jobs.** Intentional: the second discover cycle sees the show as `created=false` (already exists), so no re-enqueue. A persistent provider error would otherwise loop every 24h. Admin must manually re-trigger via `POST /admin/radio-shows/{show_id}/import-job`. Surface failures via the Discord `Backfilled N show(s)` count being lower than the prior `Discovered N show(s)` ping.

## Memory + skill notes

Updated `~/.claude/projects/<dir>/memory/pattern_background_services.md` after PSY-671 merge to reflect the new 11th goroutine count. PSY-672 doesn't add another permanent ticker — the `autoBackfillStation` goroutines are spawned on-demand from inside `runDiscoverCycle` and live only for the drain duration.
