### PR TITLE
PSY-670: drop WFMU RSS path to capture fill-in episodes

### DIFF
--- a/backend/internal/services/catalog/radio_provider_wfmu.go
+++ b/backend/internal/services/catalog/radio_provider_wfmu.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/mmcdole/gofeed"
 	"golang.org/x/net/html"
 )
 
@@ -18,14 +17,9 @@ const (
 	wfmuUserAgent      = "PsychicHomily/1.0 (radio-playlist-indexer)"
 	wfmuDefaultTimeout = 30 * time.Second
 	wfmuRateLimit      = 1 * time.Second
-	// wfmuRSSFallbackWindow is the age threshold beyond which FetchNewEpisodes
-	// switches from the 10-item RSS feed to the full HTML archive page. RSS is
-	// sufficient for ongoing incremental fetches; the archive page is required
-	// for historical backfill.
-	wfmuRSSFallbackWindow = 14 * 24 * time.Hour
 )
 
-// WFMUProvider implements RadioPlaylistProvider for WFMU's HTML playlists and RSS feeds.
+// WFMUProvider implements RadioPlaylistProvider for WFMU's HTML playlists.
 type WFMUProvider struct {
 	httpClient  *http.Client
 	baseURL     string
@@ -80,38 +74,15 @@ func (p *WFMUProvider) DiscoverShows() ([]RadioShowImport, error) {
 // FetchNewEpisodes returns episodes for a WFMU show within [since, until].
 // A zero until means no upper bound.
 //
-// WFMU's RSS feed (/playlistfeed/{CODE}.xml) returns only the most recent 10
-// episodes, which works for incremental fetches but makes historical backfill
-// impossible. When `since` falls within the RSS fallback window (~14 days ago),
-// we use the fast RSS path. For older `since` values we scrape the full show
-// archive page (/playlists/{CODE}), which lists every episode ever aired for
-// the show — up to ~26 years of history.
+// Always scrapes the show archive page (/playlists/{CODE}), which lists every
+// episode ever aired for the show — up to ~26 years of history. An earlier
+// implementation used WFMU's RSS feed (/playlistfeed/{CODE}.xml) for recent
+// windows, but the feed filters out fill-in / guest-DJ episodes that the
+// archive page includes. The archive page is ~10x the bytes of the RSS feed
+// but only one HTTP request per show per cycle, well within the per-instance
+// rate budget.
 func (p *WFMUProvider) FetchNewEpisodes(showExternalID string, since time.Time, until time.Time) ([]RadioEpisodeImport, error) {
-	// Use RSS for recent windows: fast, sufficient, cheap.
-	// A zero `since` means "all history" — always use the archive page.
-	if !since.IsZero() && time.Since(since) < wfmuRSSFallbackWindow {
-		return p.fetchEpisodesFromRSS(showExternalID, since, until)
-	}
 	return p.fetchEpisodesFromArchivePage(showExternalID, since, until)
-}
-
-// fetchEpisodesFromRSS fetches recent episodes from the WFMU playlist RSS feed
-// (/playlistfeed/{CODE}.xml). The feed contains the 10 most recent episodes.
-func (p *WFMUProvider) fetchEpisodesFromRSS(showExternalID string, since time.Time, until time.Time) ([]RadioEpisodeImport, error) {
-	<-p.rateLimiter.C
-
-	feedURL := fmt.Sprintf("%s/playlistfeed/%s.xml", p.baseURL, showExternalID)
-	body, err := p.doGet(feedURL)
-	if err != nil {
-		return nil, fmt.Errorf("fetching RSS feed for %s: %w", showExternalID, err)
-	}
-
-	episodes, err := parseWFMURSSFeed(body, showExternalID, since, until)
-	if err != nil {
-		return nil, fmt.Errorf("parsing RSS feed for %s: %w", showExternalID, err)
-	}
-
-	return episodes, nil
 }
 
 // fetchEpisodesFromArchivePage fetches all historical episodes by scraping the
@@ -439,97 +410,12 @@ func getAttr(n *html.Node, key string) string {
 }
 
 // =============================================================================
-// RSS Feed Parser — FetchNewEpisodes
+// Episode ID + Month Map (shared helpers)
 // =============================================================================
 
 // episodeIDRegex extracts the numeric show ID from WFMU playlist URLs.
 // Matches: /playlists/shows/162230 or http://www.wfmu.org/playlists/shows/162230
 var episodeIDRegex = regexp.MustCompile(`/playlists/shows/(\d+)`)
-
-// parseWFMURSSFeed parses a WFMU playlist RSS feed and returns episodes within [since, until].
-// A zero until means no upper bound.
-func parseWFMURSSFeed(body []byte, showExternalID string, since time.Time, until time.Time) ([]RadioEpisodeImport, error) {
-	fp := gofeed.NewParser()
-	feed, err := fp.ParseString(string(body))
-	if err != nil {
-		return nil, fmt.Errorf("parsing RSS: %w", err)
-	}
-
-	var episodes []RadioEpisodeImport
-
-	for _, item := range feed.Items {
-		// Extract episode ID from the link URL
-		epID := extractEpisodeID(item.Link)
-		if epID == "" {
-			// Try GUID as fallback
-			epID = extractEpisodeID(item.GUID)
-		}
-		if epID == "" {
-			continue
-		}
-
-		// Parse publish date
-		var pubTime time.Time
-		if item.PublishedParsed != nil {
-			pubTime = *item.PublishedParsed
-		} else if item.Published != "" {
-			// Try manual parse if gofeed didn't handle it
-			pubTime, _ = time.Parse(time.RFC1123Z, item.Published)
-		}
-
-		// Filter by since time
-		if !pubTime.IsZero() && pubTime.Before(since) {
-			continue
-		}
-
-		// Filter by until time
-		if !pubTime.IsZero() && !until.IsZero() && pubTime.After(until) {
-			continue
-		}
-
-		// Determine air date: prefer extracting from title (reflects local broadcast date),
-		// fall back to pubDate in original timezone. WFMU RSS pubDates are in Eastern time
-		// so a 10pm EDT show becomes the next day in UTC — we want the local broadcast date.
-		airDate := ""
-		if item.Title != "" {
-			airDate = extractDateFromTitle(item.Title)
-		}
-		if airDate == "" && !pubTime.IsZero() {
-			// Use the original timezone from the RSS feed if available
-			if item.Published != "" {
-				if parsed, err := time.Parse("Mon, 02 Jan 2006 15:04:05 -0700", item.Published); err == nil {
-					airDate = parsed.Format("2006-01-02")
-				}
-			}
-			if airDate == "" {
-				airDate = pubTime.Format("2006-01-02")
-			}
-		}
-
-		ep := RadioEpisodeImport{
-			ExternalID:     epID,
-			ShowExternalID: showExternalID,
-			AirDate:        airDate,
-		}
-
-		if item.Title != "" {
-			title := item.Title
-			ep.Title = &title
-		}
-
-		if item.Link != "" {
-			archive := item.Link
-			ep.ArchiveURL = &archive
-		}
-
-		episodes = append(episodes, ep)
-	}
-
-	return episodes, nil
-}
-
-// titleDateRegex matches dates like "March 12, 2026" or "January 15, 2026" in titles.
-var titleDateRegex = regexp.MustCompile(`(?i)(January|February|March|April|May|June|July|August|September|October|November|December)\s+(\d{1,2}),?\s+(\d{4})`)
 
 // monthMap maps month names to month numbers.
 var monthMap = map[string]time.Month{
@@ -537,30 +423,6 @@ var monthMap = map[string]time.Month{
 	"april": time.April, "may": time.May, "june": time.June,
 	"july": time.July, "august": time.August, "september": time.September,
 	"october": time.October, "november": time.November, "december": time.December,
-}
-
-// extractDateFromTitle parses a date from a WFMU RSS title like
-// "WFMU Playlist: Show Name from March 12, 2026".
-func extractDateFromTitle(title string) string {
-	matches := titleDateRegex.FindStringSubmatch(title)
-	if len(matches) < 4 {
-		return ""
-	}
-
-	month, ok := monthMap[strings.ToLower(matches[1])]
-	if !ok {
-		return ""
-	}
-	day, err := strconv.Atoi(matches[2])
-	if err != nil {
-		return ""
-	}
-	year, err := strconv.Atoi(matches[3])
-	if err != nil {
-		return ""
-	}
-
-	return time.Date(year, month, day, 0, 0, 0, 0, time.UTC).Format("2006-01-02")
 }
 
 // extractEpisodeID pulls the numeric episode ID from a WFMU URL.

--- a/backend/internal/services/catalog/radio_provider_wfmu_test.go
+++ b/backend/internal/services/catalog/radio_provider_wfmu_test.go
@@ -48,44 +48,6 @@ const wfmuDJIndexHTML = `<!DOCTYPE html>
 </body>
 </html>`
 
-const wfmuRSSFeed = `<?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0">
-<channel>
-  <title>WFMU's recent playlists from Nervous Boogie with Richard J.</title>
-  <link>http://www.wfmu.org/playlists/NB</link>
-  <description>WFMU's most recent playlists from Nervous Boogie with Richard J.</description>
-  <language>en</language>
-  <item>
-    <title>WFMU Playlist: Nervous Boogie from March 12, 2026</title>
-    <link>http://www.wfmu.org/playlists/shows/162145</link>
-    <description>&lt;a href="http://www.wfmu.org/playlists/shows/162145"&gt;Playlist&lt;/a&gt; from Nervous Boogie on WFMU</description>
-    <guid isPermaLink="true">http://www.wfmu.org/playlists/shows/162145</guid>
-    <pubDate>Thu, 12 Mar 2026 22:00:00 -0400</pubDate>
-  </item>
-  <item>
-    <title>WFMU Playlist: Nervous Boogie from March 5, 2026</title>
-    <link>http://www.wfmu.org/playlists/shows/161980</link>
-    <description>&lt;a href="http://www.wfmu.org/playlists/shows/161980"&gt;Playlist&lt;/a&gt; from Nervous Boogie on WFMU</description>
-    <guid isPermaLink="true">http://www.wfmu.org/playlists/shows/161980</guid>
-    <pubDate>Thu, 05 Mar 2026 22:00:00 -0400</pubDate>
-  </item>
-  <item>
-    <title>WFMU Playlist: Nervous Boogie from February 26, 2026</title>
-    <link>http://www.wfmu.org/playlists/shows/161800</link>
-    <description>&lt;a href="http://www.wfmu.org/playlists/shows/161800"&gt;Playlist&lt;/a&gt;</description>
-    <guid isPermaLink="true">http://www.wfmu.org/playlists/shows/161800</guid>
-    <pubDate>Thu, 26 Feb 2026 22:00:00 -0400</pubDate>
-  </item>
-  <item>
-    <title>WFMU Playlist: Nervous Boogie from January 15, 2026</title>
-    <link>http://www.wfmu.org/playlists/shows/160500</link>
-    <description>&lt;a href="http://www.wfmu.org/playlists/shows/160500"&gt;Playlist&lt;/a&gt;</description>
-    <guid isPermaLink="true">http://www.wfmu.org/playlists/shows/160500</guid>
-    <pubDate>Thu, 15 Jan 2026 22:00:00 -0400</pubDate>
-  </item>
-</channel>
-</rss>`
-
 const wfmuPlaylistPageHTML = `<!DOCTYPE html>
 <html>
 <head><title>Nervous Boogie: Playlist from March 12, 2026</title></head>
@@ -292,16 +254,6 @@ const wfmuMinimalColumnsHTML = `<!DOCTYPE html>
 </body>
 </html>`
 
-const wfmuRSSFeedEmpty = `<?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0">
-<channel>
-  <title>WFMU's recent playlists from Empty Show</title>
-  <link>http://www.wfmu.org/playlists/ES</link>
-  <description>No episodes</description>
-  <language>en</language>
-</channel>
-</rss>`
-
 // =============================================================================
 // DJ Index Parsing Tests
 // =============================================================================
@@ -418,54 +370,6 @@ func TestWFMU_ExtractDJName(t *testing.T) {
 			assert.Equal(t, tc.expected, result)
 		})
 	}
-}
-
-// =============================================================================
-// RSS Feed Parsing Tests
-// =============================================================================
-
-func TestWFMU_ParseRSSFeed_AllEpisodes(t *testing.T) {
-	// Use a "since" time that's before all items
-	since := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
-	episodes, err := parseWFMURSSFeed([]byte(wfmuRSSFeed), "NB", since, time.Time{})
-	require.NoError(t, err)
-	assert.Len(t, episodes, 4, "should parse all 4 episodes")
-
-	// Check first episode
-	ep := episodes[0]
-	assert.Equal(t, "162145", ep.ExternalID)
-	assert.Equal(t, "NB", ep.ShowExternalID)
-	assert.Equal(t, "2026-03-12", ep.AirDate)
-	assert.NotNil(t, ep.Title)
-	assert.Contains(t, *ep.Title, "Nervous Boogie")
-	assert.NotNil(t, ep.ArchiveURL)
-	assert.Contains(t, *ep.ArchiveURL, "/playlists/shows/162145")
-}
-
-func TestWFMU_ParseRSSFeed_SinceFilter(t *testing.T) {
-	// Only get episodes since March 1, 2026
-	since := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
-	episodes, err := parseWFMURSSFeed([]byte(wfmuRSSFeed), "NB", since, time.Time{})
-	require.NoError(t, err)
-	assert.Len(t, episodes, 2, "should only return episodes after March 1")
-
-	// Both should be March episodes
-	for _, ep := range episodes {
-		assert.True(t, strings.HasPrefix(ep.AirDate, "2026-03"),
-			"expected March 2026 episode, got %s", ep.AirDate)
-	}
-}
-
-func TestWFMU_ParseRSSFeed_Empty(t *testing.T) {
-	since := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
-	episodes, err := parseWFMURSSFeed([]byte(wfmuRSSFeedEmpty), "ES", since, time.Time{})
-	require.NoError(t, err)
-	assert.Empty(t, episodes, "should return empty for feed with no items")
-}
-
-func TestWFMU_ParseRSSFeed_MalformedXML(t *testing.T) {
-	_, err := parseWFMURSSFeed([]byte("this is not xml"), "XX", time.Time{}, time.Time{})
-	assert.Error(t, err, "should error on malformed XML")
 }
 
 func TestWFMU_ExtractEpisodeID(t *testing.T) {
@@ -714,18 +618,21 @@ func TestWFMU_DiscoverShows_Integration(t *testing.T) {
 }
 
 func TestWFMU_FetchNewEpisodes_Integration(t *testing.T) {
-	// Track which path was taken — recent `since` should hit the RSS feed,
-	// NOT the archive page.
+	// PSY-670: FetchNewEpisodes always hits the archive page now (the RSS path
+	// was dropped because WFMU's RSS feed filters out fill-in / guest-DJ
+	// episodes that the archive page includes). RSS hits should be zero
+	// regardless of how recent `since` is.
+	archiveBody := loadWFMUTestdata(t, "wfmu_archive_page_bt.html")
 	var rssHits, archiveHits int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/playlistfeed/NB.xml":
+		case "/playlistfeed/BT.xml":
 			rssHits++
-			w.Header().Set("Content-Type", "application/rss+xml")
-			fmt.Fprint(w, wfmuRSSFeed)
-		case "/playlists/NB":
-			archiveHits++
 			http.NotFound(w, r)
+		case "/playlists/BT":
+			archiveHits++
+			w.Header().Set("Content-Type", "text/html")
+			w.Write(archiveBody)
 		default:
 			http.NotFound(w, r)
 		}
@@ -735,19 +642,15 @@ func TestWFMU_FetchNewEpisodes_Integration(t *testing.T) {
 	provider := NewWFMUProviderWithClient(server.Client(), server.URL)
 	defer provider.Close()
 
-	// Recent `since` — should use RSS path.
 	since := time.Now().Add(-7 * 24 * time.Hour)
-	episodes, err := provider.FetchNewEpisodes("NB", since, time.Time{})
+	episodes, err := provider.FetchNewEpisodes("BT", since, time.Time{})
 	require.NoError(t, err)
-	assert.Equal(t, 1, rssHits, "recent since should hit the RSS feed")
-	assert.Equal(t, 0, archiveHits, "recent since should NOT hit the archive page")
+	assert.Equal(t, 0, rssHits, "RSS feed should never be hit post-PSY-670")
+	assert.Equal(t, 1, archiveHits, "archive page is the only path now")
 
-	// Episodes returned depend on how many RSS items are newer than `since`;
-	// the contract we verify is that every returned episode has the expected
-	// shape.
 	for _, ep := range episodes {
 		assert.NotEmpty(t, ep.ExternalID)
-		assert.Equal(t, "NB", ep.ShowExternalID)
+		assert.Equal(t, "BT", ep.ShowExternalID)
 		assert.NotEmpty(t, ep.AirDate)
 	}
 }
@@ -798,7 +701,10 @@ func TestWFMU_HTTPError_DiscoverShows(t *testing.T) {
 	assert.Contains(t, err.Error(), "500")
 }
 
-func TestWFMU_HTTPError_FetchNewEpisodes(t *testing.T) {
+func TestWFMU_HTTPError_FetchNewEpisodes_404(t *testing.T) {
+	// 404 on the archive page (unknown show code) is treated as "no episodes"
+	// rather than an error — matches DiscoverShows semantics so a scheduled
+	// fetch over a stale/typo'd show code doesn't trip the circuit breaker.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 		fmt.Fprint(w, "Not Found")
@@ -808,9 +714,24 @@ func TestWFMU_HTTPError_FetchNewEpisodes(t *testing.T) {
 	provider := NewWFMUProviderWithClient(server.Client(), server.URL)
 	defer provider.Close()
 
-	_, err := provider.FetchNewEpisodes("INVALID", time.Now(), time.Time{})
+	eps, err := provider.FetchNewEpisodes("INVALID", time.Now(), time.Time{})
+	require.NoError(t, err)
+	assert.Empty(t, eps)
+}
+
+func TestWFMU_HTTPError_FetchNewEpisodes_5xx(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, "Internal Server Error")
+	}))
+	defer server.Close()
+
+	provider := NewWFMUProviderWithClient(server.Client(), server.URL)
+	defer provider.Close()
+
+	_, err := provider.FetchNewEpisodes("ANY", time.Now(), time.Time{})
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "404")
+	assert.Contains(t, err.Error(), "500")
 }
 
 func TestWFMU_HTTPError_FetchPlaylist(t *testing.T) {
@@ -839,8 +760,6 @@ func TestWFMU_RateLimiting(t *testing.T) {
 		switch {
 		case strings.HasSuffix(r.URL.Path, "/playlists/"):
 			fmt.Fprint(w, wfmuDJIndexHTML)
-		case strings.HasSuffix(r.URL.Path, ".xml"):
-			fmt.Fprint(w, wfmuRSSFeedEmpty)
 		default:
 			fmt.Fprint(w, wfmuEmptyPlaylistHTML)
 		}
@@ -945,25 +864,6 @@ func TestWFMU_ParseWFMUReleaseYear(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.input, func(t *testing.T) {
 			assert.Equal(t, tc.expected, parseWFMUReleaseYear(tc.input))
-		})
-	}
-}
-
-func TestWFMU_ExtractDateFromTitle(t *testing.T) {
-	tests := []struct {
-		title    string
-		expected string
-	}{
-		{"WFMU Playlist: Nervous Boogie from March 12, 2026", "2026-03-12"},
-		{"WFMU Playlist: Wake from January 5, 2026", "2026-01-05"},
-		{"WFMU Playlist: Show from December 31, 2025", "2025-12-31"},
-		{"Some random title without a date", ""},
-		{"", ""},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.title, func(t *testing.T) {
-			assert.Equal(t, tc.expected, extractDateFromTitle(tc.title))
 		})
 	}
 }
@@ -1157,6 +1057,62 @@ func TestWFMU_ParseArchivePage_MalformedRows(t *testing.T) {
 	assert.Equal(t, "2024-01-24", byID["103"].AirDate)
 }
 
+// Fill-in / guest-DJ rows on the show archive page point their "Listen here"
+// link at the GUEST'S playlist URL (a different show ID than the hosting
+// show). Captured shape from a real WFMU show page:
+//
+//	May 11, 2026:
+//	<b>Ira fills in. <a href="https://wfmu.org/playlists/shows/164051">Listen here</a></b>
+//
+// The archive parser MUST return this row as an episode under the hosting
+// show, with the guest playlist's external_id. FetchPlaylist on that ID then
+// imports the guest's actual track plays for the broadcast that aired in the
+// hosting show's slot.
+func TestWFMU_ParseArchivePage_FillInWithListenHereLink(t *testing.T) {
+	body := []byte(`<!DOCTYPE html><html><body>
+<div class="showlist">
+<ul>
+<li>
+  <span class="KDBFavIcon KDBepisode" id="KDBepisode-163880"></span>
+  May 4, 2026:
+  <b>Millennial Rock</b>
+  | <a href="/playlists/shows/163880">See the playlist</a>
+</li>
+<li>
+  <span class="KDBFavIcon KDBepisode" id="KDBepisode-164141"></span>
+  May 11, 2026:
+  <b>Ira fills in. <a href="https://wfmu.org/playlists/shows/164051">Listen here</a></b>
+</li>
+<li>
+  <span class="KDBFavIcon KDBepisode" id="KDBepisode-164363"></span>
+  May 18, 2026:
+  <b>live music from John Cozz and the Wellers!</b>
+  | <a href="/playlists/shows/164363">See the playlist</a>
+</li>
+</ul>
+</div>
+</body></html>`)
+
+	episodes, err := parseWFMUArchivePage(body, "TM", time.Time{}, time.Time{})
+	require.NoError(t, err)
+	require.Len(t, episodes, 3, "regular + fill-in + regular should all be captured")
+
+	byID := make(map[string]RadioEpisodeImport)
+	for _, ep := range episodes {
+		byID[ep.ExternalID] = ep
+	}
+
+	// The fill-in episode is identified by the GUEST DJ's playlist ID, not TM's.
+	fillIn, ok := byID["164051"]
+	require.True(t, ok, "fill-in episode (guest playlist id 164051) must be captured under TM")
+	assert.Equal(t, "TM", fillIn.ShowExternalID, "fill-in still belongs to the hosting show")
+	assert.Equal(t, "2026-05-11", fillIn.AirDate)
+	require.NotNil(t, fillIn.Title)
+	assert.Contains(t, *fillIn.Title, "Ira fills in", "title should reflect the fill-in nature")
+	require.NotNil(t, fillIn.ArchiveURL)
+	assert.Contains(t, *fillIn.ArchiveURL, "/playlists/shows/164051")
+}
+
 func TestWFMU_ParseArchivePage_Deduplication(t *testing.T) {
 	// Duplicate episode IDs should be deduped.
 	body := []byte(`<!DOCTYPE html><html><body>
@@ -1213,13 +1169,9 @@ func TestWFMU_ExtractArchiveDate(t *testing.T) {
 func TestWFMU_FetchNewEpisodes_ArchiveFallback_Integration(t *testing.T) {
 	archiveBody := loadWFMUTestdata(t, "wfmu_archive_page_bt.html")
 
-	var rssHits, archiveHits int
+	var archiveHits int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/playlistfeed/BT.xml":
-			rssHits++
-			w.Header().Set("Content-Type", "application/rss+xml")
-			fmt.Fprint(w, wfmuRSSFeed)
 		case "/playlists/BT":
 			archiveHits++
 			w.Header().Set("Content-Type", "text/html")
@@ -1233,13 +1185,12 @@ func TestWFMU_FetchNewEpisodes_ArchiveFallback_Integration(t *testing.T) {
 	provider := NewWFMUProviderWithClient(server.Client(), server.URL)
 	defer provider.Close()
 
-	// Old `since` (beyond the 14-day window) triggers the archive page path.
+	// PSY-670: historical AND recent since both hit the archive page now.
 	since := time.Date(2017, 1, 1, 0, 0, 0, 0, time.UTC)
 	episodes, err := provider.FetchNewEpisodes("BT", since, time.Time{})
 	require.NoError(t, err)
 
-	assert.Equal(t, 0, rssHits, "historical since should NOT hit RSS")
-	assert.Equal(t, 1, archiveHits, "historical since should hit archive page")
+	assert.Equal(t, 1, archiveHits, "should hit archive page")
 	assert.Len(t, episodes, 5, "should return all 5 modern episodes from fixture")
 
 	for _, ep := range episodes {


### PR DESCRIPTION
Closes PSY-670.

## Summary

Fixes the missing-fill-in bug, but **NOT** via the ticket's hypothesized path. Investigation found the real cause is different:

**Ticket hypothesis** (what I started with): `parseArchiveEpisodeRow` silently drops rows that lack a `/playlists/shows/{ID}` anchor, so fill-in episodes never become DB rows.

**Actual cause** (what I found by curling `wfmu.org/playlists/TM` + running the existing parser against the real HTML): the archive parser handles fill-in rows correctly. WFMU fill-in rows DO contain a `/playlists/shows/{ID}` href — it points to the GUEST DJ's playlist, e.g. for Three Chord Monte May 11 2026:

```html
<b>Ira fills in. <a href="https://wfmu.org/playlists/shows/164051">Listen here</a></b>
```

The parser correctly returns this row as an episode under TM with `external_id="164051"`. The real bug is in the ROUTING: `FetchNewEpisodes` used WFMU's RSS feed (`/playlistfeed/{CODE}.xml`) when `since` was within 14 days, and the RSS feed **server-side filters out** fill-in / guest-DJ episodes that the archive page includes. Scheduled fetches (since=7d) hit the RSS path → fill-in invisible. Auto-backfill (PSY-672, since=90d > 14d) was already hitting the archive page → unaffected.

**Fix**: drop the RSS fallback entirely. `FetchNewEpisodes` always scrapes the archive page now. Cost: ~10x larger HTTP response per show per cycle (one archive page vs one RSS feed), well within the per-instance 1-rps budget. Benefit: every episode the archive page lists — including fill-ins — gets captured.

Net diff: -290 LOC (dead RSS-path code + RSS test fixtures), +50 LOC (one new test for the fill-in row shape). Companion runbook `docs/runbooks/radio-shows-and-backfill.md` updated to mark Gap 1/2/3 as resolved (PSY-670/671/672 all shipped now).

## Heads up from `/simplify`

`/simplify` flagged 3 doc-comment ticket-ref rot concerns (carried forward from the PSY-671 lesson — strip ticket IDs from inline rationale, keep semantic WHY). Addressed all three. Reuse + efficiency agents reported clean.

## Test plan

- [x] `go build ./...` — clean (no dangling references to removed RSS symbols)
- [x] `go test ./... ` — full suite green (~3m), per [[interface-change-full-suite]] convention from PSY-671 (this PR doesn't change an interface, but the RSS removal touched enough cross-package symbols that the full suite is the safer check)
- [x] `go test ./internal/services/catalog/... -run "WFMU" -count=1` — all WFMU tests passing including the new `TestWFMU_ParseArchivePage_FillInWithListenHereLink` (verifies a fixture mirroring the real wfmu.org/playlists/TM May 11 2026 row shape: parser returns 3 episodes including the fill-in, with the guest playlist ID 164051 attached to the hosting show TM)
- [x] `/simplify` — 3 reviewer agents; addressed 3 doc-comment ticket-ref nits (stripped `PSY-670` parenthetical from FetchNewEpisodes doc + simplified the new test's doc comment to drop the back-reference + removed `PSY-670:` prefix from the 404 test comment). Reuse + efficiency clean. Re-ran WFMU tests after fixes — still passing.
- [x] Manual investigation against real WFMU page: `curl -sS "https://wfmu.org/playlists/TM"` retrieved 17k lines; ran the existing `parseWFMUArchivePage` over the response and confirmed it returns 3 episodes for the May 1–18 2026 window (164363 May 18 live music, 164051 May 11 Ira fill-in, 163880 May 4 Millennial Rock) — proving the parser was never the bottleneck. The RSS path was. (Probe test file deleted after verification; the canonical assertion of fill-in capture is the new `TestWFMU_ParseArchivePage_FillInWithListenHereLink`.)
- [x] No UI surface — backend-only behavioral change. No admin endpoint contract changed. The 404-on-FetchNewEpisodes semantic change (was: error; now: empty slice + nil error) is internal to the scheduled-fetch loop and matches the existing `DiscoverShows` 404 handling — circuit breaker is unaffected because the path returned an error before but the cycle continued anyway.

## Coverage gaps

- **End-to-end "scheduled fetch picks up a new fill-in" not unit-tested as a single flow.** Closest unit coverage: the new `TestWFMU_ParseArchivePage_FillInWithListenHereLink` proves the parser captures the fill-in shape; the modified `TestWFMU_FetchNewEpisodes_Integration` proves `FetchNewEpisodes` hits the archive path (not RSS). Connecting "the next scheduled fetch will find the May 11 fill-in" requires a live import cycle against a real WFMU response, which the integration test infrastructure isn't set up for.
- **Historical fill-ins missed by prior RSS-path cycles** stay missing until an admin runs Workflow B (`POST /admin/radio-shows/{id}/import-job`) with `since` set to before the offending cycle. The runbook (`docs/runbooks/radio-shows-and-backfill.md`) documents the recovery path. No automatic backfill is triggered for the historical gap — out of scope for this PR.
- **RSS feed semantic change not visible to admin UI**: the admin `/discover` response contract is unchanged. The `RadioImportResult` shape is unchanged. Only behavioral difference is that `FetchNewEpisodes` returns slightly more episodes per cycle (the fill-ins it was missing). Existing frontend admin UI ignores the difference.
- **404 from archive page is now `(nil, nil)` instead of `(nil, error)`** for `FetchNewEpisodes`. Matches the existing `DiscoverShows` semantics (admin operator hitting a stale/typo'd show code shouldn't trip the per-station circuit breaker). New `TestWFMU_HTTPError_FetchNewEpisodes_404` asserts this; `TestWFMU_HTTPError_FetchNewEpisodes_5xx` asserts that real errors still propagate.

## Memory notes

`/simplify` doc-comment ticket-ref policy from PSY-671's review applied consistently here too — the [[strip-ticket-refs-from-doc-comments]] pattern is becoming standard. Worth a memory note if a 3rd PR runs into the same finding.
