### PR TITLE
PSY-677: useLocalStorageEnum migration + intent-leak fix

### DIFF
--- a/frontend/features/contributions/components/ContributionPrompt.test.tsx
+++ b/frontend/features/contributions/components/ContributionPrompt.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { act, render, screen, fireEvent } from '@testing-library/react'
 import { ContributionPrompt } from './ContributionPrompt'
 
 // --- Mocks ---
@@ -115,6 +115,22 @@ describe('ContributionPrompt', () => {
     )
   })
 
+  it('hides the prompt in the same render after the dismiss button is clicked', () => {
+    mockUseDataGaps.mockReturnValue({
+      data: {
+        gaps: [{ field: 'bandcamp', label: 'Bandcamp URL', priority: 1 }],
+      },
+      isLoading: false,
+    })
+
+    render(<ContributionPrompt {...defaultProps} />)
+    expect(screen.getByTestId('contribution-prompt')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('dismiss-prompt'))
+
+    expect(screen.queryByTestId('contribution-prompt')).not.toBeInTheDocument()
+  })
+
   it('stays hidden after dismissal', () => {
     // Pre-set the dismissal in localStorage store
     store['dismissed-prompt-artist-42'] = 'true'
@@ -193,6 +209,20 @@ describe('ContributionPrompt', () => {
     expect(screen.getByText('Know the Instagram?')).toBeInTheDocument()
   })
 
+  it('falls back to generic prompt text for fields not in the template map', () => {
+    mockUseDataGaps.mockReturnValue({
+      data: {
+        // 'social_facebook' is not in promptTemplates — hits the fallback path.
+        gaps: [{ field: 'social_facebook', label: 'Facebook', priority: 1 }],
+      },
+      isLoading: false,
+    })
+
+    render(<ContributionPrompt {...defaultProps} />)
+
+    expect(screen.getByText("Help complete this artist's profile")).toBeInTheDocument()
+  })
+
   it('shows correct prompt for festival flyer field', () => {
     mockUseDataGaps.mockReturnValue({
       data: {
@@ -223,5 +253,102 @@ describe('ContributionPrompt', () => {
 
     const { container } = render(<ContributionPrompt {...defaultProps} />)
     expect(container.firstChild).toBeNull()
+  })
+
+  it('hides when a cross-tab storage event reports the prompt was dismissed', () => {
+    mockUseDataGaps.mockReturnValue({
+      data: {
+        gaps: [{ field: 'bandcamp', label: 'Bandcamp URL', priority: 1 }],
+      },
+      isLoading: false,
+    })
+
+    const { container } = render(<ContributionPrompt {...defaultProps} />)
+    expect(screen.getByTestId('contribution-prompt')).toBeInTheDocument()
+
+    // Another tab dismissed this prompt — the 'storage' event fires in
+    // every other tab. useLocalStorageEnum's subscriber re-reads localStorage
+    // and the prompt hides without any in-tab interaction.
+    act(() => {
+      store['dismissed-prompt-artist-42'] = 'true'
+      window.dispatchEvent(
+        new StorageEvent('storage', { key: 'dismissed-prompt-artist-42' })
+      )
+    })
+
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('passes the gating contract through to useDataGaps via the enabled flag', () => {
+    mockUseDataGaps.mockReturnValue({
+      data: { gaps: [] },
+      isLoading: false,
+    })
+
+    // Unauthenticated viewer: enabled should be false so the network call is skipped.
+    const { unmount } = render(
+      <ContributionPrompt {...defaultProps} isAuthenticated={false} />
+    )
+    expect(mockUseDataGaps).toHaveBeenLastCalledWith(
+      'artist',
+      'test-artist',
+      expect.objectContaining({ enabled: false })
+    )
+    unmount()
+
+    // Authenticated viewer with no prior dismissal: enabled should be true.
+    mockUseDataGaps.mockClear()
+    render(<ContributionPrompt {...defaultProps} />)
+    expect(mockUseDataGaps).toHaveBeenLastCalledWith(
+      'artist',
+      'test-artist',
+      expect.objectContaining({ enabled: true })
+    )
+
+    // Pre-dismissed entity: enabled should be false so the gap fetch is skipped.
+    mockUseDataGaps.mockClear()
+    store['dismissed-prompt-venue-99'] = 'true'
+    render(
+      <ContributionPrompt
+        {...defaultProps}
+        entityType="venue"
+        entityId={99}
+        entitySlug="some-venue"
+      />
+    )
+    expect(mockUseDataGaps).toHaveBeenLastCalledWith(
+      'venue',
+      'some-venue',
+      expect.objectContaining({ enabled: false })
+    )
+  })
+
+  it('keeps dismissals isolated per (entityType, entityId)', () => {
+    mockUseDataGaps.mockReturnValue({
+      data: {
+        gaps: [{ field: 'bandcamp', label: 'Bandcamp URL', priority: 1 }],
+      },
+      isLoading: false,
+    })
+
+    // Artist 42 was dismissed in a prior session.
+    store['dismissed-prompt-artist-42'] = 'true'
+
+    // Artist 42 — should stay hidden.
+    const { container: artistContainer } = render(
+      <ContributionPrompt {...defaultProps} />
+    )
+    expect(artistContainer.firstChild).toBeNull()
+
+    // Different entity (venue 10) — should still render.
+    render(
+      <ContributionPrompt
+        {...defaultProps}
+        entityType="venue"
+        entityId={10}
+        entitySlug="some-venue"
+      />
+    )
+    expect(screen.getByTestId('contribution-prompt')).toBeInTheDocument()
   })
 })

--- a/frontend/features/contributions/components/ContributionPrompt.tsx
+++ b/frontend/features/contributions/components/ContributionPrompt.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { useState, useCallback } from 'react'
+import { useCallback } from 'react'
 import { Lightbulb, X, ArrowRight } from 'lucide-react'
+import { useLocalStorageEnum } from '@/lib/hooks/common/useLocalStorageEnum'
 import { useDataGaps } from '../hooks/useDataGaps'
 import type { EditableEntityType } from '../types'
 
@@ -29,13 +30,11 @@ function getDismissalKey(entityType: string, entityId: number): string {
   return `dismissed-prompt-${entityType}-${entityId}`
 }
 
-function checkDismissed(entityType: string, entityId: number): boolean {
-  try {
-    return localStorage.getItem(getDismissalKey(entityType, entityId)) === 'true'
-  } catch {
-    return false
-  }
-}
+// Boolean-as-enum so the dismissal flag can ride the SSR-safe
+// useLocalStorageEnum hook. The 'false' default lets an absent key read as
+// "not dismissed".
+const DISMISSAL_VALUES = ['true', 'false'] as const
+type DismissalFlag = (typeof DISMISSAL_VALUES)[number]
 
 interface ContributionPromptProps {
   entityType: EditableEntityType
@@ -54,22 +53,20 @@ export function ContributionPrompt({
   isAuthenticated,
   onEditClick,
 }: ContributionPromptProps) {
-  const [isDismissed, setIsDismissed] = useState(() =>
-    checkDismissed(entityType, entityId)
+  const [dismissalFlag, setDismissalFlag] = useLocalStorageEnum<DismissalFlag>(
+    getDismissalKey(entityType, entityId),
+    'false',
+    DISMISSAL_VALUES
   )
+  const isDismissed = dismissalFlag === 'true'
 
   const { data, isLoading } = useDataGaps(entityType, entitySlug, {
     enabled: isAuthenticated && !isDismissed,
   })
 
   const handleDismiss = useCallback(() => {
-    setIsDismissed(true)
-    try {
-      localStorage.setItem(getDismissalKey(entityType, entityId), 'true')
-    } catch {
-      // localStorage unavailable
-    }
-  }, [entityType, entityId])
+    setDismissalFlag('true')
+  }, [setDismissalFlag])
 
   // Don't render anything if:
   // - Not authenticated

--- a/frontend/lib/hooks/common/useLocalStorageEnum.test.ts
+++ b/frontend/lib/hooks/common/useLocalStorageEnum.test.ts
@@ -164,4 +164,32 @@ describe('useLocalStorageEnum', () => {
     expect(a.result.current[0]).toBe('blue')
     expect(b.result.current[0]).toBe('green')
   })
+
+  it('drops a stale intent override when the key prop changes mid-instance', () => {
+    // Simulates a component instance whose `key` prop changes (e.g.
+    // ContributionPrompt re-rendered with a different entityId) AFTER a
+    // setter call that failed to persist (localStorage.setItem threw).
+    // Without per-key intent isolation, the stale 'true' intent from the
+    // previous key would bleed through into the new key's read.
+    localStorageMock.setItem.mockImplementation(() => {
+      throw new Error('localStorage full')
+    })
+
+    const { result, rerender } = renderHook(
+      ({ key }) => useLocalStorageEnum<Color>(key, 'red', COLORS),
+      { initialProps: { key: 'key-1' } }
+    )
+
+    act(() => {
+      result.current[1]('blue')
+    })
+    // Intent layer kept the calling component live.
+    expect(result.current[0]).toBe('blue')
+
+    // Key changes to an unrelated entity. The new key has no stored value
+    // and no intent — should fall back to the default.
+    rerender({ key: 'key-2' })
+
+    expect(result.current[0]).toBe('red')
+  })
 })

--- a/frontend/lib/hooks/common/useLocalStorageEnum.ts
+++ b/frontend/lib/hooks/common/useLocalStorageEnum.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useState, useSyncExternalStore } from 'react'
+import { useCallback, useState, useSyncExternalStore } from 'react'
 
 // The 'storage' event only fires in OTHER tabs/windows, never the tab that
 // wrote the value. This custom event keeps multiple readers of the same key
@@ -38,11 +38,11 @@ export function useLocalStorageEnum<T extends string>(
   defaultValue: T,
   allowed: ReadonlyArray<T>
 ): readonly [T, (next: T) => void] {
-  // Per-component intent layer. Set on every setValue, cleared once the
-  // useSyncExternalStore snapshot catches up. This keeps the UI responsive
-  // even if localStorage.setItem throws, without leaking state across
-  // unrelated components or tests.
-  const [intent, setIntent] = useState<T | null>(null)
+  // Per-component intent layer. The intent is tagged with the key it was set
+  // for; reads with a different key naturally ignore it (no useEffect-based
+  // reset needed when the key prop changes). Cleared during render once
+  // storage catches up so cross-tab / cross-component updates can win again.
+  const [intent, setIntent] = useState<{ key: string; value: T } | null>(null)
 
   const getClientSnapshot = useCallback((): T => {
     try {
@@ -64,27 +64,28 @@ export function useLocalStorageEnum<T extends string>(
     getServerSnapshot
   )
 
-  // Drop the intent once storage agrees so cross-tab / cross-component
-  // updates can win again.
-  useEffect(() => {
-    if (intent !== null && storageValue === intent) {
-      setIntent(null)
-    }
-  }, [intent, storageValue])
+  const intentApplies = intent !== null && intent.key === key
+  const value = intentApplies ? intent.value : storageValue
 
-  const value = intent ?? storageValue
+  // Compare-during-render reset (the React-recommended alternative to a
+  // useEffect — see react.dev/learn/you-might-not-need-an-effect): once
+  // storage agrees with the intent for the current key, drop the intent so
+  // subsequent cross-tab / cross-component updates win.
+  if (intentApplies && storageValue === intent.value) {
+    setIntent(null)
+  }
 
   const setValue = useCallback(
     (next: T) => {
-      setIntent(next)
+      setIntent({ key, value: next })
       try {
         window.localStorage.setItem(key, next)
         window.dispatchEvent(new Event(SAME_TAB_EVENT))
       } catch {
-        // localStorage unavailable; the intent layer above keeps this
-        // component's UI live. Other components reading the same key will
-        // not re-render until localStorage recovers — acceptable for the
-        // private-mode / quota-exceeded edge cases.
+        // localStorage unavailable; the keyed intent keeps this component's
+        // UI live. Other components reading the same key will not re-render
+        // until localStorage recovers — acceptable for the private-mode /
+        // quota-exceeded edge cases.
       }
     },
     [key]


### PR DESCRIPTION
Closes PSY-677.

## Summary

- `ContributionPrompt.tsx` now delegates its dismissal flag to the shared SSR-safe `useLocalStorageEnum` hook (shipped in PSY-528) instead of lazy `useState(() => localStorage.getItem(...))`. Boolean state is encoded as a 2-value enum so the existing hook applies — no new abstraction.
- `useLocalStorageEnum` intent layer was leaking across `key` changes for the same component instance: if `setItem` failed for one key, the stale intent would bleed into the next key's reads. Fixed by tagging the intent with `{ key, value }` so a key mismatch self-invalidates — no useEffect needed.
- `useLocalStorageEnum` simultaneously migrated off two useEffects (one for the leak-fix, one for the clear-on-match) to the compare-during-render pattern. Per React docs (`react.dev/learn/you-might-not-need-an-effect`), useEffect to setState on a prop change is an anti-pattern.

## Heads up from `/simplify`

`/simplify` was clean on the ContributionPrompt diff itself (trimmed one editorial comment block). The hook bug + useEffect → compare-during-render refactor came out of a coverage-gap audit after `/simplify` and a user pushback on the first attempt at the fix.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run test:run lib/hooks/common` — 91/91 passing (new intent-leak test covers the bug + fix; 10 prior tests unchanged)
- [x] `bun run test:run features/contributions` — 49/49 passing (5 new ContributionPrompt tests + 11 prior)
- [x] `bun run test:run features/contributions features/collections features/artists features/shows features/releases features/labels features/festivals features/venues` — 1041/1041 passing across all affected features
- [x] Manual repro against local dev stack at `/artists/amyl-and-the-sniffers` (authenticated viewer): (a) fresh state — prompt renders; (b) click dismiss — prompt hides immediately + `localStorage['dismissed-prompt-artist-113'] = 'true'`; (c) reload — prompt stays hidden, zero React hydration warnings in console; (d) re-verified after the hook refactor
- [x] Cross-consumer manual repro at `/artists` (browse page, highest-traffic `useDensity` consumer): clicked Compact density → `localStorage['ph-density-artists'] = 'compact'`; reloaded → density persists. Verifies the hook refactor didn't regress the `useDensity` API for the other call path.

**Coverage notes — additions on top of the pre-existing 11 ContributionPrompt tests:**

- `hides the prompt in the same render after the dismiss button is clicked` — covers the user-visible side of dismiss (prior test only asserted the localStorage side-effect)
- `falls back to generic prompt text for fields not in the template map` — covers the `getPromptText` fallback (`Help complete this ${entityType}'s profile`)
- `passes the gating contract through to useDataGaps via the enabled flag` — asserts the `isAuthenticated && !isDismissed` gating actually reaches `useDataGaps`, not just the rendered side-effect
- `hides when a cross-tab storage event reports the prompt was dismissed` — covers the new cross-tab sync behavior the hook enables
- `keeps dismissals isolated per (entityType, entityId)` — covers per-key isolation under the shared module-level subscribe
- `drops a stale intent override when the key prop changes mid-instance` (in `useLocalStorageEnum.test.ts`) — demonstrates the intent-leak bug + asserts the fix

## Screenshots

Fresh state — prompt renders at the top of the page ("Know this artist's Bandcamp?"):

![Contribution prompt visible](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-df624f861647a02b6136/psy-677-prompt-visible.png)

After dismiss + page reload — prompt stays hidden, no hydration warning in console:

![Contribution prompt dismissed and persisted](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-df624f861647a02b6136/psy-677-prompt-dismissed.png)

## Context note

The original ticket framed this as a hydration-warning fix. Empirical verification on the live dev page (per `feedback_verify_ticket_hypothesis_first.md`) showed that no hydration warning fires today — `useDataGaps` returns `isLoading=true` on both server and client, so both render `null` and the lazy-`useState` divergence is masked. The migration ships anyway as a **consistency cleanup** + proactive hardening (the pattern would surface a real bug the moment anyone adds SSR prefetch for data gaps or replaces the loading-null with a skeleton). The hook refactor (intent leak + useEffect → compare-during-render) is the real load-bearing change in this PR.

## Coverage gaps

- **Authenticated unauth round-trip not visually verified.** The unauth-returns-null branch is unit-tested. Manual repro was done only as authenticated viewer.
- **Cross-tab dismissal not manually verified across two real browser tabs.** Unit-tested via `StorageEvent` dispatch.
- **Private-mode browser (setItem throws) not manually verified.** Unit-tested at the hook layer (`keeps the calling component responsive when localStorage.setItem throws` + the new `drops a stale intent override when the key prop changes mid-instance`).
- **Other `useLocalStorageEnum` callers not all visually re-verified.** `useDensity` smoke-tested on `/artists` (cross-consumer test plan above). `CollectionDetail` view-mode + the other 5 density consumers (`ShowList`, `ReleaseList`, `LabelList`, `FestivalList`, plus the in-grid `CollectionDetail`) covered only by the 1041-test sweep — the refactor preserved the public API exactly, so test pass is high-confidence regression coverage.

EOF
