### PR TITLE
PSY-531: harden collection search inputs + sort-override test gap

### DIFF
--- a/backend/internal/api/handlers/catalog/show.go
+++ b/backend/internal/api/handlers/catalog/show.go
@@ -230,7 +230,7 @@ type GetShowsRequest struct {
 // SearchShowsRequest represents the autocomplete search request for shows.
 // PSY-520.
 type SearchShowsRequest struct {
-	Query string `query:"q" doc:"Search query. Matches show title or any bill artist name (case-insensitive)." example:"valley bar"`
+	Query string `query:"q" maxLength:"200" doc:"Search query. Matches show title or any bill artist name (case-insensitive)." example:"valley bar"`
 }
 
 // SearchShowsResponse represents the autocomplete search response for shows.

--- a/backend/internal/api/handlers/community/collection.go
+++ b/backend/internal/api/handlers/community/collection.go
@@ -41,15 +41,15 @@ type ListCollectionsHandlerRequest struct {
 	// tag names/aliases (case-insensitive ILIKE substring). Empty / whitespace
 	// queries short-circuit before hitting the DB. Title-tier matches rank
 	// above body-tier matches when the default sort is in effect.
-	Search string `query:"search" required:"false" doc:"Search across collection title, description, item notes, and tag names/aliases (case-insensitive substring)"`
+	Search string `query:"search" required:"false" maxLength:"200" doc:"Search across collection title, description, item notes, and tag names/aliases (case-insensitive substring)"`
 	// PSY-352: sort=popular orders by HN gravity (likes / age^1.8). Empty
 	// or omitted defaults to updated_at DESC.
 	Sort string `query:"sort" required:"false" doc:"Sort order: 'popular' for HN-gravity ranking. Defaults to recently-updated." enum:"popular"`
 	// PSY-354: filter the listing to collections tagged with the given slug.
 	// Single-tag for the MVP — multi-tag intersection is out of scope.
 	Tag    string `query:"tag" required:"false" doc:"Filter to collections tagged with this slug" example:"phoenix"`
-	Limit  int    `query:"limit" required:"false" doc:"Max results (default 20)" example:"20"`
-	Offset int    `query:"offset" required:"false" doc:"Offset for pagination" example:"0"`
+	Limit  int    `query:"limit" required:"false" minimum:"1" maximum:"100" doc:"Max results (default 20)" example:"20"`
+	Offset int    `query:"offset" required:"false" minimum:"0" doc:"Offset for pagination" example:"0"`
 }
 
 // ListCollectionsHandlerResponse represents the response for listing collections
@@ -677,9 +677,9 @@ type GetUserCollectionsHandlerRequest struct {
 	// PSY-580: search across title, description, item notes, and tag
 	// names/aliases — same field expansion as the public browse listing
 	// (PSY-355). Empty / whitespace disables the predicate.
-	Search string `query:"search" required:"false" doc:"Search across collection title, description, item notes, and tag names/aliases (case-insensitive substring)"`
-	Limit  int    `query:"limit" required:"false" doc:"Max results (default 20)" example:"20"`
-	Offset int    `query:"offset" required:"false" doc:"Offset for pagination" example:"0"`
+	Search string `query:"search" required:"false" maxLength:"200" doc:"Search across collection title, description, item notes, and tag names/aliases (case-insensitive substring)"`
+	Limit  int    `query:"limit" required:"false" minimum:"1" maximum:"100" doc:"Max results (default 20)" example:"20"`
+	Offset int    `query:"offset" required:"false" minimum:"0" doc:"Offset for pagination" example:"0"`
 }
 
 // GetUserCollectionsHandlerResponse represents the response for the user collections endpoint

--- a/backend/internal/services/catalog/show.go
+++ b/backend/internal/services/catalog/show.go
@@ -20,6 +20,7 @@ import (
 	apperrors "psychic-homily-backend/internal/errors"
 	catalogm "psychic-homily-backend/internal/models/catalog"
 	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/services/shared"
 	"psychic-homily-backend/internal/utils"
 )
 
@@ -917,7 +918,7 @@ func (s *ShowService) SearchShows(query string) ([]*contracts.ShowSearchResult, 
 		return []*contracts.ShowSearchResult{}, nil
 	}
 
-	pattern := "%" + query + "%"
+	pattern := shared.LikePattern(query)
 
 	// Single query: select shows whose title matches OR any artist on the
 	// bill matches, then resolve headliner/venue via correlated subqueries.

--- a/backend/internal/services/community/collection.go
+++ b/backend/internal/services/community/collection.go
@@ -742,9 +742,8 @@ func (s *CollectionService) ListCollections(filters contracts.CollectionFilters,
 	// tiebreaker. An explicit `sort=popular` wins over relevance — that's
 	// the user's deliberate choice and mirrors how most browse UIs treat
 	// "sort + filter" combinations.
-	if searchTerm != "" && filters.Sort == "" {
-		pattern := "%" + searchTerm + "%"
-		query = applySearchRelevanceOrder(query, pattern).Limit(limit).Offset(offset)
+	if searchTerm != "" && filters.Sort == contracts.CollectionSortDefault {
+		query = applySearchRelevanceOrder(query, shared.LikePattern(searchTerm)).Limit(limit).Offset(offset)
 	} else {
 		query = applyCollectionSort(query, filters.Sort).Limit(limit).Offset(offset)
 	}
@@ -879,7 +878,7 @@ func applyCollectionSort(query *gorm.DB, sort string) *gorm.DB {
 // implementations. Pair this with applySearchRelevanceOrder for the
 // matching tier rank ORDER BY.
 func applyCollectionSearchWhere(query *gorm.DB, searchTerm string) *gorm.DB {
-	pattern := "%" + searchTerm + "%"
+	pattern := shared.LikePattern(searchTerm)
 	return query.Where(`
 		collections.title ILIKE ?
 		OR collections.description ILIKE ?
@@ -1550,8 +1549,7 @@ func (s *CollectionService) GetUserCollections(userID uint, search string, limit
 	// updated_at DESC ordering that the library tab expects.
 	var collections []communitym.Collection
 	if searchTerm != "" {
-		pattern := "%" + searchTerm + "%"
-		query = applySearchRelevanceOrder(query, pattern).Limit(limit).Offset(offset)
+		query = applySearchRelevanceOrder(query, shared.LikePattern(searchTerm)).Limit(limit).Offset(offset)
 	} else {
 		query = query.Order("updated_at DESC").Limit(limit).Offset(offset)
 	}

--- a/backend/internal/services/community/collection_test.go
+++ b/backend/internal/services/community/collection_test.go
@@ -681,6 +681,31 @@ func (suite *CollectionServiceIntegrationTestSuite) TestListCollections_FilterBy
 	suite.Equal(tagOnly.ID, resp[3].ID, "tier 4: tag match last")
 }
 
+// TestListCollections_FilterBySearch_EscapesLikeWildcards confirms that
+// `%` in a user-supplied search term is matched as a literal character,
+// not as the SQL ANY-substring wildcard. Without escaping, `foo%bar`
+// would silently match `foothing-bar`; we want it to match only rows
+// whose title (or description / notes / tag) actually contains the
+// literal text `foo%bar`.
+func (suite *CollectionServiceIntegrationTestSuite) TestListCollections_FilterBySearch_EscapesLikeWildcards() {
+	user := suite.createTestUser("WildcardSearcher")
+
+	// Decoy: this title would match `foo%bar` if `%` were treated as the
+	// wildcard. With escaping, it must NOT match.
+	suite.createBasicCollection(user, "foothing-and-bar")
+	// Target: a literal `%` in the title — the only correct match.
+	target := suite.createBasicCollection(user, "Mix Tape: foo%bar Edition")
+
+	resp, total, err := suite.collectionService.ListCollections(
+		contracts.CollectionFilters{Search: "foo%bar"}, 20, 0,
+	)
+
+	suite.Require().NoError(err)
+	suite.Equal(int64(1), total, "wildcard `%` in search term must be literal, not ANY-substring")
+	suite.Require().Len(resp, 1)
+	suite.Equal(target.ID, resp[0].ID)
+}
+
 // TestListCollections_FilterBySearch_EmptyShortCircuits confirms an empty
 // string disables the search predicate. (The handler also short-circuits
 // before reaching the service; this guards the service-direct path used by
@@ -718,21 +743,25 @@ func (suite *CollectionServiceIntegrationTestSuite) TestListCollections_FilterBy
 
 // TestListCollections_FilterBySearch_PopularSortOverridesRelevance verifies
 // that an explicit ?sort=popular wins over relevance ranking when both
-// search and sort are set. The user's deliberate sort choice always wins.
+// search and sort are set. Both collections match "indie" but in different
+// tiers — titleMatch is tier 1, descMatch is tier 2 — so relevance would
+// surface titleMatch first. We then like descMatch so HN gravity flips the
+// order; if a regression silently routed through applySearchRelevanceOrder
+// despite Sort=popular, the title-tier match would still win and the
+// assertion would fail.
 func (suite *CollectionServiceIntegrationTestSuite) TestListCollections_FilterBySearch_PopularSortOverridesRelevance() {
-	user := suite.createTestUser("SortOverride")
+	creator := suite.createTestUser("SortOverrideCreator")
+	liker := suite.createTestUser("SortOverrideLiker")
 
-	// All three collections match the search term but in different tiers.
-	// With relevance ordering: title > description > notes. With popular
-	// sort: order is by likes (none here) then updated_at DESC.
-	titleMatch := suite.createBasicCollection(user, "Indie Anthems")
-	descMatch := suite.createBasicCollection(user, "Eclectic Mix")
-	suite.updateCollectionDescription(descMatch.Slug, user.ID, "indie playlist seed for the year")
+	titleMatch := suite.createPublicCollection(creator, "Indie Anthems")
+	descMatch := suite.createPublicCollection(creator, "Eclectic Mix")
+	suite.updateCollectionDescription(descMatch.Slug, creator.ID, "indie playlist seed for the year")
 
-	// Verify the explicit Sort knob is respected — we don't assert the
-	// exact ordering popular produces (that's covered elsewhere) but we
-	// confirm the call succeeds and surfaces both rows. The relevance
-	// tier-order test above proves the default-sort path.
+	// Bias gravity toward descMatch so the popular ordering inverts the
+	// relevance ordering. titleMatch keeps zero likes.
+	_, err := suite.collectionService.Like(descMatch.Slug, liker.ID)
+	suite.Require().NoError(err)
+
 	resp, total, err := suite.collectionService.ListCollections(
 		contracts.CollectionFilters{
 			Search: "indie",
@@ -743,10 +772,9 @@ func (suite *CollectionServiceIntegrationTestSuite) TestListCollections_FilterBy
 	suite.Require().NoError(err)
 	suite.Equal(int64(2), total)
 	suite.Require().Len(resp, 2)
-	// Both rows present — order is popular-driven, not relevance-driven.
-	ids := []uint{resp[0].ID, resp[1].ID}
-	suite.Contains(ids, titleMatch.ID)
-	suite.Contains(ids, descMatch.ID)
+	suite.Equal(descMatch.ID, resp[0].ID,
+		"popular sort must win: descMatch has likes and should outrank the title-tier match")
+	suite.Equal(titleMatch.ID, resp[1].ID)
 }
 
 // TestListCollections_FilterBySearch_CaseInsensitive confirms ILIKE behavior:

--- a/backend/internal/services/contracts/collection.go
+++ b/backend/internal/services/contracts/collection.go
@@ -86,6 +86,13 @@ type CollectionFilters struct {
 	Tag string
 }
 
+// CollectionSortDefault is the implicit "no sort requested" value (recently-
+// updated ordering, or relevance ranking when ?search is also set). Made
+// explicit so the relevance-vs-popular branch in ListCollections doesn't
+// gate on a bare string literal that quietly degrades if a new sort enum
+// value is added later.
+const CollectionSortDefault = ""
+
 // CollectionSortPopular is the recognized sort value for the HN-gravity
 // "popular" ordering. PSY-352.
 const CollectionSortPopular = "popular"

--- a/backend/internal/services/shared/like.go
+++ b/backend/internal/services/shared/like.go
@@ -1,0 +1,29 @@
+package shared
+
+import "strings"
+
+// likeEscaper escapes the characters that would otherwise have wildcard
+// meaning inside a SQL LIKE / ILIKE pattern. Postgres treats `\` as the
+// default escape character, so escaped wildcards become literal characters
+// without needing an explicit ESCAPE clause.
+//
+//	\  → \\   (escape the escape character first)
+//	%  → \%   (any-substring wildcard becomes literal)
+//	_  → \_   (single-character wildcard becomes literal)
+var likeEscaper = strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
+
+// LikePattern produces a substring-match LIKE / ILIKE pattern for the given
+// user-supplied search term. Escapes wildcard characters so the input is
+// matched literally, then wraps with `%…%`. Use anywhere a user-entered
+// search string is interpolated into an ILIKE.
+//
+//	shared.LikePattern("indie")     // "%indie%"
+//	shared.LikePattern("foo%bar")   // "%foo\%bar%"
+//	shared.LikePattern("a_b")       // "%a\_b%"
+//
+// Callers are still responsible for trimming whitespace and short-circuiting
+// the empty-string case before reaching the DB — an empty term here would
+// produce `%%` and widen the result set.
+func LikePattern(searchTerm string) string {
+	return "%" + likeEscaper.Replace(searchTerm) + "%"
+}

--- a/backend/internal/services/shared/like_test.go
+++ b/backend/internal/services/shared/like_test.go
@@ -1,0 +1,27 @@
+package shared
+
+import "testing"
+
+func TestLikePattern(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain word", "indie", `%indie%`},
+		{"percent literal", "foo%bar", `%foo\%bar%`},
+		{"underscore literal", "a_b", `%a\_b%`},
+		{"backslash literal", `path\to`, `%path\\to%`},
+		{"mixed wildcards + backslash", `100%_done\`, `%100\%\_done\\%`},
+		{"empty input still wraps", "", `%%`},
+		{"unicode untouched", "café", `%café%`},
+		{"backslash gets escaped before % so order is right", `\%`, `%\\\%%`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := LikePattern(c.in); got != c.want {
+				t.Errorf("LikePattern(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes PSY-531.

## Summary

- **LIKE wildcard escape**: new `backend/internal/services/shared/LikePattern(searchTerm string) string` helper escapes `\`, `%`, `_` then wraps with `%…%`. Wired into 3 collection-browse sites + `SearchShows` so a search for `foo%bar` matches the literal substring, not the SQL ANY-wildcard interpretation.
- **Input-length caps**: Huma `maxLength:"200"` on `ListCollectionsHandlerRequest.Search` and `GetUserCollectionsHandlerRequest.Search` (the Yours-tab sibling) and `SearchShowsRequest.Query`. Huma `minimum:"1" maximum:"100"` on both `Limit` fields and `minimum:"0"` on both `Offset` fields. Closes the long-search × large-limit × 4-ILIKE + 2-EXISTS load-amplification path.
- **`PopularSortOverridesRelevance` test is now load-bearing**: the prior version asserted only that both rows were present (a regression silently routing through `applySearchRelevanceOrder` when `Sort=popular` would have passed). Rewritten to seed two collections matching `"indie"` in different relevance tiers (title vs description), like the description-tier collection, and assert popular-driven ordering inverts the relevance ordering.
- **`CollectionSortDefault = ""` constant** added next to `CollectionSortPopular`. The `searchTerm != "" && filters.Sort == ""` branch now gates on the constant instead of a bare literal, so adding a future sort enum value (e.g. `"recent"`) can't quietly bypass relevance ranking via type-system silence.
- **Regression test** for the wildcard-escape: `TestListCollections_FilterBySearch_EscapesLikeWildcards` seeds a decoy row that would match `foo%bar` under wildcard semantics and a target row containing the literal `foo%bar`; asserts only the target is returned.

## Deferred (per /simplify finding)

- **~20 other inline `"%" + s + "%"` sites across catalog services (artists / venues / festivals / labels / releases / tags / show-admin-filters / data-sync / radio-unmatched).** Same bug class, broader surface. PSY-531 scope was four sites called out in the parent ticket; the wider surface was flagged by /simplify reviewers as the natural follow-up per `feedback_audit_recurring_bugs.md`. Filed **PSY-678** with the full grep + sibling-helper proposal (`LikePrefixPattern` for autocomplete starts-with sites).

## Heads up from `/simplify`

`/simplify` was otherwise clean. The Yours-tab handler (`GetUserCollectionsHandlerRequest`) was caught as having the same fields without validation tags — added in this PR rather than deferred since it shares the exact same `applySearchRelevanceOrder` + `shared.LikePattern` code path.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/services/shared/...` — `LikePattern` helper (8 cases incl. empty / unicode / escape-ordering)
- [x] `go test ./internal/services/community/...` — full community suite, includes new `EscapesLikeWildcards` regression + rewritten `PopularSortOverridesRelevance`
- [x] `go test ./internal/services/catalog/...` — full catalog suite covers the `SearchShows` callsite migration
- [x] `go test ./internal/api/handlers/community/...` and `.../catalog/...` — handler suites cover the new Huma validation tags
- [x] `/simplify` — three reviewers; converged on adding validation tags to `GetUserCollectionsHandlerRequest` (addressed) + filing PSY-678 for the wider migration (filed)
- [x] No UI surface — backend-only PR, no screenshots applicable. Manual repro deferred to OpenAPI spec review (see Coverage gaps).

## Coverage gaps

- **OpenAPI client impact not manually reviewed.** The new `maxLength` / `minimum` / `maximum` tags change the generated OpenAPI schema and will tighten what the frontend's generated types accept. Existing callers pass small `limit` values (20-default) and reasonable search terms, so the practical risk is low — but a frontend regenerate + typecheck would be the rigorous confirmation.
- **`pg_trgm` index plan not benchmarked.** `LikePattern` adds `\` characters to user-supplied terms when wildcards are present; Postgres's trigram operator class indexes these correctly, but I didn't EXPLAIN-ANALYZE the new pattern shape against the existing search corpus. Practical risk: zero for the corpus size today; worth a re-check if the corpus grows by 100x.
- **Untouched admin pipeline LIKE sites** (`services/catalog/show.go:1121, 1137` — admin shows page rejection-reason filter). Same code path as `SearchShows` for shape, but the admin auth gate makes the load-amplification risk lower. Folded into PSY-678 audit rather than this PR.

EOF
