### PR TITLE
PSY-678: migrate remaining inline LIKE patterns to shared helpers

### DIFF
--- a/backend/internal/services/admin/data_sync.go
+++ b/backend/internal/services/admin/data_sync.go
@@ -10,6 +10,7 @@ import (
 	"psychic-homily-backend/db"
 	catalogm "psychic-homily-backend/internal/models/catalog"
 	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/services/shared"
 	"psychic-homily-backend/internal/utils"
 )
 
@@ -191,7 +192,7 @@ func (s *DataSyncService) ExportArtists(params contracts.ExportArtistsParams) (*
 	query := s.db.Model(&catalogm.Artist{})
 
 	if params.Search != "" {
-		query = query.Where("LOWER(name) LIKE LOWER(?)", "%"+params.Search+"%")
+		query = query.Where("LOWER(name) LIKE LOWER(?)", shared.LikePattern(params.Search))
 	}
 
 	var total int64
@@ -249,7 +250,7 @@ func (s *DataSyncService) ExportVenues(params contracts.ExportVenuesParams) (*co
 	query := s.db.Model(&catalogm.Venue{})
 
 	if params.Search != "" {
-		query = query.Where("LOWER(name) LIKE LOWER(?)", "%"+params.Search+"%")
+		query = query.Where("LOWER(name) LIKE LOWER(?)", shared.LikePattern(params.Search))
 	}
 	if params.Verified != nil {
 		query = query.Where("verified = ?", *params.Verified)

--- a/backend/internal/services/catalog/artist.go
+++ b/backend/internal/services/catalog/artist.go
@@ -12,6 +12,7 @@ import (
 	apperrors "psychic-homily-backend/internal/errors"
 	catalogm "psychic-homily-backend/internal/models/catalog"
 	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/services/shared"
 	"psychic-homily-backend/internal/utils"
 )
 
@@ -169,7 +170,7 @@ func (s *ArtistService) GetArtists(filters map[string]interface{}) ([]*contracts
 		}
 	}
 	if name, ok := filters["name"].(string); ok && name != "" {
-		query = query.Where("LOWER(name) LIKE LOWER(?)", "%"+name+"%")
+		query = query.Where("LOWER(name) LIKE LOWER(?)", shared.LikePattern(name))
 	}
 	if tf, ok := filters["tag_filter"].(TagFilter); ok {
 		query = ApplyTagFilter(query, s.db, catalogm.TagEntityArtist, "artists.id", tf)
@@ -284,19 +285,23 @@ func (s *ArtistService) SearchArtists(query string) ([]*contracts.ArtistDetailRe
 	// Strategy depends on query length for optimal performance
 	if len(query) <= 2 {
 		// For short queries: use fast case-insensitive prefix search on name + aliases
+		prefixPattern := shared.LikePrefixPattern(query)
 		err = s.db.
 			Where("id IN (?)",
-				s.db.Table("artists").Select("id").Where("LOWER(name) LIKE LOWER(?)", query+"%"),
+				s.db.Table("artists").Select("id").Where("LOWER(name) LIKE LOWER(?)", prefixPattern),
 			).
 			Or("id IN (?)",
-				s.db.Table("artist_aliases").Select("artist_id").Where("LOWER(alias) LIKE LOWER(?)", query+"%"),
+				s.db.Table("artist_aliases").Select("artist_id").Where("LOWER(alias) LIKE LOWER(?)", prefixPattern),
 			).
 			Order("name ASC").
 			Limit(10).
 			Find(&artists).Error
 	} else {
-		// For longer queries: search names and aliases with similarity scoring
-		// Uses UNION to find matching artists by name or alias, then ranks by best similarity
+		// For longer queries: search names and aliases with similarity scoring.
+		// Uses UNION to find matching artists by name or alias, then ranks by best similarity.
+		// `name % ?` / `alias % ?` are the pg_trgm similarity operator and take the
+		// raw term; the ILIKE branches escape via LikePattern.
+		substringPattern := shared.LikePattern(query)
 		err = s.db.Raw(`
 			SELECT a.* FROM artists a
 			WHERE a.id IN (
@@ -309,7 +314,7 @@ func (s *ArtistService) SearchArtists(query string) ([]*contracts.ArtistDetailRe
 				COALESCE((SELECT MAX(similarity(aa.alias, ?)) FROM artist_aliases aa WHERE aa.artist_id = a.id), 0)
 			) DESC, a.name ASC
 			LIMIT 10
-		`, "%"+query+"%", query, "%"+query+"%", query, query, query).
+		`, substringPattern, query, substringPattern, query, query, query).
 			Scan(&artists).Error
 	}
 

--- a/backend/internal/services/catalog/festival.go
+++ b/backend/internal/services/catalog/festival.go
@@ -9,6 +9,7 @@ import (
 	apperrors "psychic-homily-backend/internal/errors"
 	catalogm "psychic-homily-backend/internal/models/catalog"
 	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/services/shared"
 	"psychic-homily-backend/internal/utils"
 )
 
@@ -232,14 +233,14 @@ func (s *FestivalService) SearchFestivals(query string) ([]*contracts.FestivalLi
 	if len(query) <= 2 {
 		// For short queries: prefix match
 		err = s.db.
-			Where("LOWER(name) LIKE LOWER(?)", query+"%").
+			Where("LOWER(name) LIKE LOWER(?)", shared.LikePrefixPattern(query)).
 			Order("name ASC").
 			Limit(20).
 			Find(&festivals).Error
 	} else {
 		// For longer queries: ILIKE substring match, ordered by name
 		err = s.db.
-			Where("name ILIKE ?", "%"+query+"%").
+			Where("name ILIKE ?", shared.LikePattern(query)).
 			Order("name ASC").
 			Limit(20).
 			Find(&festivals).Error

--- a/backend/internal/services/catalog/label.go
+++ b/backend/internal/services/catalog/label.go
@@ -9,6 +9,7 @@ import (
 	apperrors "psychic-homily-backend/internal/errors"
 	catalogm "psychic-homily-backend/internal/models/catalog"
 	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/services/shared"
 	"psychic-homily-backend/internal/utils"
 )
 
@@ -220,14 +221,14 @@ func (s *LabelService) SearchLabels(query string) ([]*contracts.LabelListRespons
 	if len(query) <= 2 {
 		// For short queries: prefix match
 		err = s.db.
-			Where("LOWER(name) LIKE LOWER(?)", query+"%").
+			Where("LOWER(name) LIKE LOWER(?)", shared.LikePrefixPattern(query)).
 			Order("name ASC").
 			Limit(20).
 			Find(&labels).Error
 	} else {
 		// For longer queries: ILIKE substring match, ordered by name
 		err = s.db.
-			Where("name ILIKE ?", "%"+query+"%").
+			Where("name ILIKE ?", shared.LikePattern(query)).
 			Order("name ASC").
 			Limit(20).
 			Find(&labels).Error

--- a/backend/internal/services/catalog/radio_unmatched.go
+++ b/backend/internal/services/catalog/radio_unmatched.go
@@ -10,6 +10,7 @@ import (
 
 	catalogm "psychic-homily-backend/internal/models/catalog"
 	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/services/shared"
 )
 
 // GetUnmatchedPlays returns unmatched plays grouped by artist_name,
@@ -172,7 +173,7 @@ func (s *RadioService) suggestArtistMatches(artistName string, limit int) []cont
 	// 3. LIKE match (prefix)
 	remaining = limit - len(matches)
 	var likeMatches []catalogm.Artist
-	s.db.Where("LOWER(name) LIKE ?", normalizedName+"%").
+	s.db.Where("LOWER(name) LIKE ?", shared.LikePrefixPattern(normalizedName)).
 		Limit(remaining).
 		Find(&likeMatches)
 

--- a/backend/internal/services/catalog/release.go
+++ b/backend/internal/services/catalog/release.go
@@ -9,6 +9,7 @@ import (
 	apperrors "psychic-homily-backend/internal/errors"
 	catalogm "psychic-homily-backend/internal/models/catalog"
 	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/services/shared"
 	"psychic-homily-backend/internal/utils"
 )
 
@@ -165,7 +166,7 @@ func (s *ReleaseService) ListReleases(filters contracts.ReleaseListFilters) ([]*
 		)
 	}
 	if filters.Search != "" {
-		searchPattern := "%" + filters.Search + "%"
+		searchPattern := shared.LikePattern(filters.Search)
 		// Search by release title OR by artist name (via artist_releases + artists join)
 		query = query.Where(
 			"releases.title ILIKE ? OR releases.id IN (?)",
@@ -246,14 +247,14 @@ func (s *ReleaseService) SearchReleases(query string) ([]*contracts.ReleaseListR
 	if len(query) <= 2 {
 		// For short queries: prefix match
 		err = s.db.
-			Where("LOWER(title) LIKE LOWER(?)", query+"%").
+			Where("LOWER(title) LIKE LOWER(?)", shared.LikePrefixPattern(query)).
 			Order("title ASC").
 			Limit(20).
 			Find(&releases).Error
 	} else {
 		// For longer queries: ILIKE substring match, ordered by title
 		err = s.db.
-			Where("title ILIKE ?", "%"+query+"%").
+			Where("title ILIKE ?", shared.LikePattern(query)).
 			Order("title ASC").
 			Limit(20).
 			Find(&releases).Error

--- a/backend/internal/services/catalog/show.go
+++ b/backend/internal/services/catalog/show.go
@@ -1118,7 +1118,7 @@ func (s *ShowService) GetRejectedShows(limit, offset int, search string) ([]*con
 
 	// Add search filter if provided
 	if search != "" {
-		searchPattern := "%" + search + "%"
+		searchPattern := shared.LikePattern(search)
 		baseQuery = baseQuery.Where("title ILIKE ? OR rejection_reason ILIKE ?", searchPattern, searchPattern)
 	}
 
@@ -1134,7 +1134,7 @@ func (s *ShowService) GetRejectedShows(limit, offset int, search string) ([]*con
 		Where("status = ?", catalogm.ShowStatusRejected).
 		Scopes(func(db *gorm.DB) *gorm.DB {
 			if search != "" {
-				searchPattern := "%" + search + "%"
+				searchPattern := shared.LikePattern(search)
 				return db.Where("title ILIKE ? OR rejection_reason ILIKE ?", searchPattern, searchPattern)
 			}
 			return db

--- a/backend/internal/services/catalog/tag_service.go
+++ b/backend/internal/services/catalog/tag_service.go
@@ -15,6 +15,7 @@ import (
 	authm "psychic-homily-backend/internal/models/auth"
 	catalogm "psychic-homily-backend/internal/models/catalog"
 	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/services/shared"
 	"psychic-homily-backend/internal/utils"
 )
 
@@ -142,7 +143,7 @@ func (s *TagService) ListTags(category string, search string, parentID *uint, so
 		query = query.Where("category = ?", category)
 	}
 	if search != "" {
-		query = query.Where("LOWER(name) LIKE LOWER(?)", "%"+search+"%")
+		query = query.Where("LOWER(name) LIKE LOWER(?)", shared.LikePattern(search))
 	}
 	if parentID != nil {
 		query = query.Where("parent_id = ?", *parentID)
@@ -777,7 +778,7 @@ func (s *TagService) ListAllAliases(search string, limit, offset int) ([]contrac
 		Joins("JOIN tags AS t ON t.id = ta.tag_id")
 
 	if search != "" {
-		pattern := "%" + strings.ToLower(search) + "%"
+		pattern := shared.LikePattern(strings.ToLower(search))
 		query = query.Where("LOWER(ta.alias) LIKE ? OR LOWER(t.name) LIKE ?", pattern, pattern)
 	}
 
@@ -958,10 +959,11 @@ func (s *TagService) SearchTags(query string, limit int, category string) ([]con
 
 	// Search tags by name and by alias, dedup by tag ID.
 	// Group the OR conditions to ensure category filter applies to both.
+	pattern := shared.LikePattern(q)
 	db := s.db.Where(
-		s.db.Where("LOWER(name) LIKE ?", "%"+q+"%").
+		s.db.Where("LOWER(name) LIKE ?", pattern).
 			Or("id IN (?)",
-				s.db.Model(&catalogm.TagAlias{}).Select("tag_id").Where("LOWER(alias) LIKE ?", "%"+q+"%"),
+				s.db.Model(&catalogm.TagAlias{}).Select("tag_id").Where("LOWER(alias) LIKE ?", pattern),
 			),
 	)
 
@@ -981,7 +983,6 @@ func (s *TagService) SearchTags(query string, limit int, category string) ([]con
 	// look up which alias on that tag matched so the UI can surface the
 	// provenance. A single batch query avoids N+1.
 	results := make([]contracts.TagSearchResult, len(tags))
-	pattern := "%" + q + "%"
 
 	// Collect the tag IDs whose name did not match the query — those are
 	// the ones that were returned only because of an alias match.

--- a/backend/internal/services/catalog/venue.go
+++ b/backend/internal/services/catalog/venue.go
@@ -11,6 +11,7 @@ import (
 	apperrors "psychic-homily-backend/internal/errors"
 	catalogm "psychic-homily-backend/internal/models/catalog"
 	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/services/shared"
 	"psychic-homily-backend/internal/utils"
 )
 
@@ -136,7 +137,7 @@ func (s *VenueService) GetVenues(filters map[string]interface{}) ([]*contracts.V
 		query = query.Where("city = ?", city)
 	}
 	if name, ok := filters["name"].(string); ok && name != "" {
-		query = query.Where("LOWER(name) LIKE LOWER(?)", "%"+name+"%")
+		query = query.Where("LOWER(name) LIKE LOWER(?)", shared.LikePattern(name))
 	}
 	if tf, ok := filters["tag_filter"].(TagFilter); ok {
 		query = ApplyTagFilter(query, s.db, catalogm.TagEntityVenue, "venues.id", tf)
@@ -263,14 +264,16 @@ func (venueService *VenueService) SearchVenues(query string) ([]*contracts.Venue
 
 	if len(query) <= 2 {
 		err = venueService.db.
-			Where("LOWER(name) LIKE LOWER(?)", query+"%").
+			Where("LOWER(name) LIKE LOWER(?)", shared.LikePrefixPattern(query)).
 			Order("name ASC").
 			Limit(10).
 			Find(&venues).Error
 	} else {
+		// `name % ?` is the pg_trgm similarity operator (NOT a LIKE pattern),
+		// so its argument stays raw. The ILIKE branch escapes via LikePattern.
 		err = venueService.db.
 			Select("venues.*, similarity(name, ?) as sim_score", query).
-			Where("name ILIKE ? OR name % ?", "%"+query+"%", query).
+			Where("name ILIKE ? OR name % ?", shared.LikePattern(query), query).
 			Order("sim_score DESC, name ASC").
 			Limit(10).
 			Find(&venues).Error

--- a/backend/internal/services/shared/like.go
+++ b/backend/internal/services/shared/like.go
@@ -27,3 +27,20 @@ var likeEscaper = strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
 func LikePattern(searchTerm string) string {
 	return "%" + likeEscaper.Replace(searchTerm) + "%"
 }
+
+// LikePrefixPattern produces a starts-with LIKE / ILIKE pattern. Same escape
+// guarantees as LikePattern but only appends a trailing `%`, so the input is
+// matched as a literal prefix. Use for autocomplete-style "name starts
+// with X" lookups where the DB has (or should have) a btree index on
+// `LOWER(column)` that the optimizer can use only when the leading
+// character is a literal.
+//
+//	shared.LikePrefixPattern("foo")     // "foo%"
+//	shared.LikePrefixPattern("foo%")    // "foo\%%"
+//	shared.LikePrefixPattern("a_")      // "a\_%"
+//
+// Same empty-string caveat as LikePattern — an empty term here produces `%`
+// which matches every row.
+func LikePrefixPattern(searchTerm string) string {
+	return likeEscaper.Replace(searchTerm) + "%"
+}

--- a/backend/internal/services/shared/like_test.go
+++ b/backend/internal/services/shared/like_test.go
@@ -25,3 +25,25 @@ func TestLikePattern(t *testing.T) {
 		})
 	}
 }
+
+func TestLikePrefixPattern(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain prefix", "foo", `foo%`},
+		{"percent literal in prefix", "100%", `100\%%`},
+		{"underscore literal in prefix", "a_", `a\_%`},
+		{"backslash literal in prefix", `path\`, `path\\%`},
+		{"empty input collapses to wildcard-only", "", `%`},
+		{"unicode untouched", "café", `café%`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := LikePrefixPattern(c.in); got != c.want {
+				t.Errorf("LikePrefixPattern(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/backend/internal/services/user/user.go
+++ b/backend/internal/services/user/user.go
@@ -15,6 +15,7 @@ import (
 	catalogm "psychic-homily-backend/internal/models/catalog"
 	engagementm "psychic-homily-backend/internal/models/engagement"
 	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/services/shared"
 )
 
 // Account lockout constants
@@ -34,7 +35,7 @@ func (s *UserService) ListUsers(limit, offset int, filters contracts.AdminUserFi
 
 	// Apply search filter
 	if filters.Search != "" {
-		searchPattern := "%" + filters.Search + "%"
+		searchPattern := shared.LikePattern(filters.Search)
 		query = query.Where("(email ILIKE ? OR username ILIKE ?)", searchPattern, searchPattern)
 	}
 


### PR DESCRIPTION
Closes PSY-678.

## Summary

- **23 inline `"%" + s + "%"` LIKE patterns migrated** to the shared SSR-safe helpers (`shared.LikePattern` for substring matches, new `shared.LikePrefixPattern` for autocomplete starts-with). Same bug-class fix PSY-531 applied to the collection-browse + show-autocomplete paths, now uniformly across the catalog (artists / venues / festivals / labels / releases / tags / radio matching / admin show pipeline) + admin data sync + admin user list.
- **New `LikePrefixPattern(s)` helper** at `backend/internal/services/shared/like.go`. Reuses the existing module-level `likeEscaper *strings.Replacer` (no per-call allocator), escapes `\ % _` then appends a trailing `%`. Paired test in `like_test.go` covers the same edge cases as `LikePattern` (plain / wildcards / backslash / unicode / empty).
- **`pg_trgm` similarity-operator arguments stay raw** (artist.go `name % ?` / `alias % ?`; venue.go `name % ?`) — the migration touches only the ILIKE branches that sit alongside the trgm operator. Inline comments at both sites explain why the two sides escape differently.
- **Silent bonus win** (worth flagging): a user searching for `100%` or `a_b` on any of the 23 migrated surfaces now matches the literal substring, not the SQL wildcard interpretation. Same UX as PSY-531's `foo%bar` regression test, just propagated to the rest of the search surface.

## Deferred (per pre-implementation Q&A)

- **Huma validation tag audit on the 9 handlers** feeding these services (`maxLength:"200"` on Search/Query inputs, `minimum`/`maximum` on Limit/Offset). Filed **PSY-679** — the matching input-bounding hardening that PSY-531 applied to the collection-browse + show-autocomplete handlers, deferred here to keep this PR focused on the LIKE bug-class fix.

## Heads up from `/simplify`

`/simplify` was clean overall. Three reviewers (reuse / quality / efficiency) converged on:
- A small `tag_service.go` cleanup — `SearchTags` had two `shared.LikePattern(q)` calls under different variable names. Consolidated to one `pattern` var (folded into this PR).
- No missed migration sites — the only `"%" + ... + "%"` left in the repo is a constant-prefix string in admin test fixtures (`test_fixtures.go:107`), correctly out of scope.
- No hot-loop helper calls; no per-request allocator churn (the Replacer is module-level).

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/services/shared/...` — new `TestLikePrefixPattern` (6 cases) + existing `TestLikePattern` pass
- [x] `go test ./internal/services/catalog/...` — full catalog service suite (all migrated services)
- [x] `go test ./internal/services/admin/... ./internal/services/user/...` — admin data sync + user list service suites
- [x] `go test ./internal/...` — full backend suite (no regressions in handlers, engagement, notification, pipeline, etc.)
- [x] `/simplify` — three parallel reviewers; one finding addressed (tag_service duplicate-pattern cleanup); no other actionable issues
- [x] No UI surface — backend-only PR, screenshots N/A. `/psy-self-review` skipped per its own "do NOT invoke for backend-only PRs" guidance.

## Coverage gaps

- **Per-domain integration regression tests not added.** PSY-531 added an end-to-end "`foo%bar` matches literal" test for the collection-browse path; the equivalent integration test was NOT added per-domain (artist / venue / festival / label / release / tag) in this PR. Rationale: the helper is unit-tested at `like_test.go` to escape correctly, every migrated site uniformly delegates via `shared.LikePattern(...)` or `shared.LikePrefixPattern(...)`, and all existing per-domain service tests pass — so the wiring is sound. Adding 6 more integration tests would balloon the PR. Worth a separate "per-domain LIKE-escape regression coverage" sweep if desired.
- **OpenAPI / frontend-type client impact NOT applicable here** — this PR doesn't change any handler request shape; OpenAPI is unaffected. (PSY-679 will be the one to watch for client impact when it lands the validation tags.)
- **Production query plan not benchmarked.** Escaped patterns add `\` characters when wildcards are present; trigram indexes handle this correctly, but no EXPLAIN ANALYZE was run against the existing corpus. Practical risk: zero for current corpus size; worth re-checking if corpus grows by 100x.

EOF
