### PR TITLE
PSY-679: Huma validation tags on PSY-678 handler request structs

### DIFF
--- a/backend/internal/api/handlers/admin/admin_data.go
+++ b/backend/internal/api/handlers/admin/admin_data.go
@@ -99,9 +99,9 @@ func (h *AdminDataHandler) ExportShowsHandler(ctx context.Context, req *ExportSh
 
 // ExportArtistsRequest represents the HTTP request for exporting artists
 type ExportArtistsRequest struct {
-	Limit  int    `query:"limit" default:"50" doc:"Number of artists to return (max 200)"`
-	Offset int    `query:"offset" default:"0" doc:"Offset for pagination"`
-	Search string `query:"search" doc:"Search by name"`
+	Limit  int    `query:"limit" default:"50" minimum:"1" maximum:"200" doc:"Number of artists to return (max 200)"`
+	Offset int    `query:"offset" default:"0" minimum:"0" doc:"Offset for pagination"`
+	Search string `query:"search" maxLength:"200" doc:"Search by name"`
 }
 
 // ExportArtistsResponse represents the HTTP response for exporting artists
@@ -151,9 +151,9 @@ func (h *AdminDataHandler) ExportArtistsHandler(ctx context.Context, req *Export
 
 // ExportVenuesRequest represents the HTTP request for exporting venues
 type ExportVenuesRequest struct {
-	Limit    int    `query:"limit" default:"50" doc:"Number of venues to return (max 200)"`
-	Offset   int    `query:"offset" default:"0" doc:"Offset for pagination"`
-	Search   string `query:"search" doc:"Search by name"`
+	Limit    int    `query:"limit" default:"50" minimum:"1" maximum:"200" doc:"Number of venues to return (max 200)"`
+	Offset   int    `query:"offset" default:"0" minimum:"0" doc:"Offset for pagination"`
+	Search   string `query:"search" maxLength:"200" doc:"Search by name"`
 	Verified string `query:"verified" doc:"Filter by verified status: true, false, or empty for all"`
 	City     string `query:"city" doc:"Filter by city"`
 	State    string `query:"state" doc:"Filter by state"`

--- a/backend/internal/api/handlers/admin/admin_shows.go
+++ b/backend/internal/api/handlers/admin/admin_shows.go
@@ -65,9 +65,9 @@ type GetPendingShowsResponse struct {
 
 // GetRejectedShowsRequest represents the HTTP request for listing rejected shows
 type GetRejectedShowsRequest struct {
-	Limit  int    `query:"limit" default:"50" doc:"Number of shows to return (max 100)"`
-	Offset int    `query:"offset" default:"0" doc:"Offset for pagination"`
-	Search string `query:"search" doc:"Search by show title or rejection reason"`
+	Limit  int    `query:"limit" default:"50" minimum:"1" maximum:"100" doc:"Number of shows to return (max 100)"`
+	Offset int    `query:"offset" default:"0" minimum:"0" doc:"Offset for pagination"`
+	Search string `query:"search" maxLength:"200" doc:"Search by show title or rejection reason"`
 }
 
 // GetRejectedShowsResponse represents the HTTP response for listing rejected shows

--- a/backend/internal/api/handlers/admin/admin_users.go
+++ b/backend/internal/api/handlers/admin/admin_users.go
@@ -26,9 +26,9 @@ func NewAdminUserHandler(
 
 // GetAdminUsersRequest represents the HTTP request for listing users
 type GetAdminUsersRequest struct {
-	Limit  int    `query:"limit" default:"50" doc:"Number of users to return (max 100)"`
-	Offset int    `query:"offset" default:"0" doc:"Offset for pagination"`
-	Search string `query:"search" doc:"Search by email or username"`
+	Limit  int    `query:"limit" default:"50" minimum:"1" maximum:"100" doc:"Number of users to return (max 100)"`
+	Offset int    `query:"offset" default:"0" minimum:"0" doc:"Offset for pagination"`
+	Search string `query:"search" maxLength:"200" doc:"Search by email or username"`
 }
 
 // GetAdminUsersResponse represents the HTTP response for listing users

--- a/backend/internal/api/handlers/catalog/artist.go
+++ b/backend/internal/api/handlers/catalog/artist.go
@@ -45,7 +45,7 @@ func NewArtistHandler(artistService contracts.ArtistServiceInterface, auditLogSe
 
 // SearchArtistsRequest represents the autocomplete search request
 type SearchArtistsRequest struct {
-	Query string `query:"q" doc:"Search query for artist autocomplete" example:"radio"`
+	Query string `query:"q" maxLength:"200" doc:"Search query for artist autocomplete" example:"radio"`
 }
 
 // SearchArtistsResponse represents the autocomplete search response

--- a/backend/internal/api/handlers/catalog/festival.go
+++ b/backend/internal/api/handlers/catalog/festival.go
@@ -38,7 +38,7 @@ func NewFestivalHandler(festivalService contracts.FestivalServiceInterface, arti
 
 // SearchFestivalsRequest represents the autocomplete search request
 type SearchFestivalsRequest struct {
-	Query string `query:"q" doc:"Search query for festival autocomplete" example:"m3f"`
+	Query string `query:"q" maxLength:"200" doc:"Search query for festival autocomplete" example:"m3f"`
 }
 
 // SearchFestivalsResponse represents the autocomplete search response

--- a/backend/internal/api/handlers/catalog/label.go
+++ b/backend/internal/api/handlers/catalog/label.go
@@ -36,7 +36,7 @@ func NewLabelHandler(labelService contracts.LabelServiceInterface, auditLogServi
 
 // SearchLabelsRequest represents the autocomplete search request
 type SearchLabelsRequest struct {
-	Query string `query:"q" doc:"Search query for label autocomplete" example:"sub pop"`
+	Query string `query:"q" maxLength:"200" doc:"Search query for label autocomplete" example:"sub pop"`
 }
 
 // SearchLabelsResponse represents the autocomplete search response

--- a/backend/internal/api/handlers/catalog/radio.go
+++ b/backend/internal/api/handlers/catalog/radio.go
@@ -1099,8 +1099,8 @@ func (h *RadioHandler) AdminImportShowEpisodesHandler(ctx context.Context, req *
 // AdminGetUnmatchedPlaysRequest represents the request for listing unmatched plays.
 type AdminGetUnmatchedPlaysRequest struct {
 	StationID uint `query:"station_id" required:"false" doc:"Filter by station ID (0 for all)" example:"0"`
-	Limit     int  `query:"limit" required:"false" doc:"Max results (default 50)" example:"50"`
-	Offset    int  `query:"offset" required:"false" doc:"Offset for pagination" example:"0"`
+	Limit     int  `query:"limit" required:"false" default:"50" minimum:"1" maximum:"100" doc:"Max results (default 50)" example:"50"`
+	Offset    int  `query:"offset" required:"false" default:"0" minimum:"0" doc:"Offset for pagination" example:"0"`
 }
 
 // AdminGetUnmatchedPlaysResponse represents the response for listing unmatched plays.

--- a/backend/internal/api/handlers/catalog/release.go
+++ b/backend/internal/api/handlers/catalog/release.go
@@ -37,7 +37,7 @@ func NewReleaseHandler(releaseService contracts.ReleaseServiceInterface, artistS
 
 // SearchReleasesRequest represents the autocomplete search request
 type SearchReleasesRequest struct {
-	Query string `query:"q" doc:"Search query for release autocomplete" example:"nevermind"`
+	Query string `query:"q" maxLength:"200" doc:"Search query for release autocomplete" example:"nevermind"`
 }
 
 // SearchReleasesResponse represents the autocomplete search response
@@ -71,11 +71,11 @@ type ListReleasesRequest struct {
 	ArtistID    uint   `query:"artist_id" required:"false" doc:"Filter by artist ID" example:"1"`
 	ReleaseType string `query:"release_type" required:"false" doc:"Filter by release type" example:"lp"`
 	Year        int    `query:"year" required:"false" doc:"Filter by release year" example:"2024"`
-	Search      string `query:"search" required:"false" doc:"Search by release title or artist name" example:"nevermind"`
+	Search      string `query:"search" required:"false" maxLength:"200" doc:"Search by release title or artist name" example:"nevermind"`
 	Sort        string `query:"sort" required:"false" doc:"Sort order: newest, oldest, title_asc, title_desc, recently_added" example:"newest"`
 	LabelID     uint   `query:"label_id" required:"false" doc:"Filter by label ID" example:"1"`
-	Limit       int    `query:"limit" required:"false" doc:"Page size (default 50, max 200)" example:"50"`
-	Offset      int    `query:"offset" required:"false" doc:"Pagination offset" example:"0"`
+	Limit       int    `query:"limit" required:"false" minimum:"1" maximum:"200" doc:"Page size (default 50, max 200)" example:"50"`
+	Offset      int    `query:"offset" required:"false" minimum:"0" doc:"Pagination offset" example:"0"`
 	Tags        string `query:"tags" required:"false" doc:"Comma-separated tag slugs. Multi-tag filter (PSY-309): AND by default; set tag_match=any for OR." example:"shoegaze,dream-pop"`
 	TagMatch    string `query:"tag_match" required:"false" doc:"Tag matching mode: 'all' (default, AND) or 'any' (OR)" example:"all" enum:"all,any"`
 }

--- a/backend/internal/api/handlers/catalog/tag.go
+++ b/backend/internal/api/handlers/catalog/tag.go
@@ -34,11 +34,11 @@ func NewTagHandler(tagService contracts.TagServiceInterface, auditLog contracts.
 
 type ListTagsRequest struct {
 	Category string `query:"category" required:"false" doc:"Filter by category (genre, locale, other)"`
-	Search   string `query:"search" required:"false" doc:"Search tags by name"`
+	Search   string `query:"search" required:"false" maxLength:"200" doc:"Search tags by name"`
 	ParentID uint   `query:"parent_id" required:"false" doc:"Filter by parent tag ID"`
 	Sort     string `query:"sort" required:"false" doc:"Sort by: usage, name, created (default: usage)"`
-	Limit    int    `query:"limit" required:"false" doc:"Max results (default 50)" example:"50"`
-	Offset   int    `query:"offset" required:"false" doc:"Offset for pagination" example:"0"`
+	Limit    int    `query:"limit" required:"false" minimum:"1" maximum:"100" doc:"Max results (default 50)" example:"50"`
+	Offset   int    `query:"offset" required:"false" minimum:"0" doc:"Offset for pagination" example:"0"`
 	// EntityType scopes the per-tag usage_count in the response to a single
 	// entity type (PSY-484). Used by the browse-page tag facet so the count
 	// next to each chip reflects "tags applied to <this entity type>" rather
@@ -179,8 +179,8 @@ func (h *TagHandler) ListTagEntitiesHandler(ctx context.Context, req *ListTagEnt
 // ============================================================================
 
 type SearchTagsRequest struct {
-	Query    string `query:"q" doc:"Search query" example:"post"`
-	Limit    int    `query:"limit" required:"false" doc:"Max results (default 10)" example:"10"`
+	Query    string `query:"q" maxLength:"200" doc:"Search query" example:"post"`
+	Limit    int    `query:"limit" required:"false" minimum:"1" maximum:"100" doc:"Max results (default 10)" example:"10"`
 	Category string `query:"category" required:"false" doc:"Filter by category (genre, locale, descriptor, era, mood, instrument, technique, origin, status, other)" example:"genre"`
 }
 
@@ -691,9 +691,9 @@ func (h *TagHandler) DeleteAliasHandler(ctx context.Context, req *DeleteAliasReq
 // ============================================================================
 
 type ListAllAliasesRequest struct {
-	Search string `query:"search" required:"false" doc:"Search by alias text or canonical tag name"`
-	Limit  int    `query:"limit" required:"false" doc:"Max results (default 50, max 500)" example:"50"`
-	Offset int    `query:"offset" required:"false" doc:"Offset for pagination" example:"0"`
+	Search string `query:"search" required:"false" maxLength:"200" doc:"Search by alias text or canonical tag name"`
+	Limit  int    `query:"limit" required:"false" minimum:"1" maximum:"500" doc:"Max results (default 50, max 500)" example:"50"`
+	Offset int    `query:"offset" required:"false" minimum:"0" doc:"Offset for pagination" example:"0"`
 }
 
 type ListAllAliasesResponse struct {

--- a/backend/internal/api/handlers/catalog/venue.go
+++ b/backend/internal/api/handlers/catalog/venue.go
@@ -36,7 +36,7 @@ func NewVenueHandler(venueService contracts.VenueServiceInterface, discordServic
 }
 
 type SearchVenuesRequest struct {
-	Query string `query:"q" doc:"Search query for venue autocomplete" example:"empty bottle"`
+	Query string `query:"q" maxLength:"200" doc:"Search query for venue autocomplete" example:"empty bottle"`
 }
 
 type SearchVenuesResponse struct {


### PR DESCRIPTION
Closes PSY-679.

## Summary

- Huma validation tags added to 14 handler request structs that feed the PSY-678-migrated services: `maxLength:"200"` on Search/Query inputs (substring + autocomplete), `minimum:"1" maximum:"<doc-string-bound>"` on Limit, `minimum:"0"` on Offset. Maximum values pick from each handler's existing "(max N)" doc string when present (100 / 200 / 500); otherwise default to 100 to match the peer convention (`venue.go:67`, `scene.go:97`).
- Closes the input-bounding loop opened by PSY-531 (collection-browse + show-autocomplete) and PSY-678 (LIKE-pattern migration across the catalog + admin services). With this PR, every search-input + pagination triad on the PSY-678-migrated surfaces rejects oversized input at the Huma boundary with a clean 422 instead of cascading into the load-amplification path documented in PSY-531.
- Small consistency fix on `AdminGetUnmatchedPlaysRequest` (radio.go:1100): added `default:"50"` / `default:"0"` to match the peer admin handlers in the same diff (`admin_data.go`, `admin_shows.go`).

## Deferred (per /simplify finding)

- **~30 other unprotected Limit/Offset handler sites** repo-wide (engagement, community, notification, pipeline, charts, festival-intelligence, artist-relationship, admin/revision, admin/pending_edit, admin/audit_log, admin/data_quality, admin/admin_venues, etc.). Per `feedback_audit_recurring_bugs.md` the input-bounding pattern is now on its 3rd round, so a dedicated audit ticket is warranted. Filed **PSY-696** — includes an optional `shared.PaginationParams` embed proposal that would stop the drift permanently.
- **Adjacent filter-string fields not bounded** on the touched structs (`Verified` / `City` / `State` on `ExportVenuesRequest`, `Category` / `Sort` on `ListTagsRequest`, etc.). PSY-679 explicitly scopes to Search / Query / Limit / Offset — the filter-string siblings are short-enum / short-slug fields with lower abuse surface; leaving them is intentional.

## Heads up from `/simplify`

`/simplify` was otherwise clean. Three reviewers (reuse / quality / efficiency) converged on:
- Coverage gap fixed (radio.go default tag).
- Broader Limit/Offset audit filed as PSY-696.
- Verified service-side fallbacks (`if limit <= 0 { limit = N }`) still work — Huma skips validation when params are absent (no `default:` triggers), so existing zero-value fallthroughs continue to apply.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/api/handlers/catalog/...` — full catalog handler suite passes
- [x] `go test ./internal/api/handlers/admin/...` — full admin handler suite passes
- [x] `/simplify` — three parallel reviewers; one inline fix (radio.go default tag), one follow-up filed (PSY-696); no other actionable findings
- [x] No UI surface — backend-only PR, screenshots N/A. `/psy-self-review` skipped per its own "do NOT invoke for backend-only PRs" guidance.

## Coverage gaps

- **OpenAPI / frontend client impact NOT manually verified.** This PR tightens the generated OpenAPI schema. The picked `maximum` values match each handler's existing doc string ("(max N)"), so no current real-world caller should newly hit a 422 — but a frontend regenerate + typecheck would be the rigorous confirmation. The risk is bounded: typical callers pass small Limit values (≤ 50) and short search terms (< 30 chars), so a regression would have to come from an unusual client.
- **One real behavior change**: explicit `?limit=0` calls now return 422 (previously fell through to the service-side `if limit <= 0 { limit = N }` fallback). `limit=0` is nonsense input; the new 422 aligns with the existing convention on peer handlers (`venue.go:67`, `scene.go:97`, etc.) that PSY-531 already followed.
- **Adjacent filter-string fields** (intentionally out of scope; see Deferred above).

EOF
