### PR TITLE
PSY-703: expand vitest coverage scope to features/ and app/

### DIFF
--- a/frontend/vitest.config.mts
+++ b/frontend/vitest.config.mts
@@ -18,7 +18,7 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html', 'lcov'],
-      include: ['lib/**/*.ts', 'lib/**/*.tsx', 'components/**/*.tsx'],
+      include: ['{lib,components,features,app}/**/*.{ts,tsx}'],
       exclude: ['**/*.test.{ts,tsx}', '**/types/**'],
     },
   },


### PR DESCRIPTION
Closes PSY-703.

## Summary

- Extend vitest coverage `include` to measure `features/**` and `app/**` (previously excluded — `bun run test:coverage` reported a misleading number that hid the bulk of the application).
- Collapse to brace-expansion glob `{lib,components,features,app}/**/*.{ts,tsx}` — 7 explicit patterns → 1, and picks up `components/**/*.ts` which the prior `components/**/*.tsx` literal silently excluded (8 untested barrel `index.ts` files).
- One-file change, no logic touched.

## Baseline coverage (post-expansion)

`bun run test:coverage` on this branch:

| Metric     | %      |
| ---------- | ------ |
| Statements | 46.16  |
| Branches   | 44.02  |
| Functions  | 41.78  |
| Lines      | 46.55  |

This is the honest measurement of the application now that `features/**` + `app/**` are in scope. The remaining 53 tickets in the **Frontend Test Coverage Hardening — May 2026** project (PSY-680..737) will move these numbers up; future projects can pick a CI threshold against this baseline.

## Heads up from `/simplify`

3 reviewer agents ran in parallel. Two converged on the same fix (brace-expansion glob) which also closed a pre-existing coverage gap on `components/**/*.ts` — applied inline. No deferred findings.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run test:run` — 236 files / 3339 tests passing
- [x] `bun run test:coverage` — runs successfully; brace-expansion glob resolves correctly (verified by grep): `features/` rows include `features/{artists,auth,blog,charts,comments,labels,radio,releases,requests,scenes}`; `app/` rows include `app/{auth,admin,api/[...path],api/oembed,artists,blog,charts}`; 15+ `*/index.ts` barrel rows now reported (was 0 with the prior `.tsx`-only literal — proves the `components/**/*.ts` gap closure)
- [x] `/simplify` — clean after collapsing to brace-expansion glob
- [x] No UI surface, screenshots skipped

## Coverage gaps

- No CI gate is being set in this PR — that's a separate decision per the ticket scope. PSY-703's job is to make accurate measurement possible; threshold enforcement is intentionally deferred.
- The reported 46.16% reflects the codebase as of this branch; it is NOT a target. Treat it as the floor that subsequent tickets in this project should move up from.
