### PR TITLE
PSY-765: restore main CI on artist-detail + venue-detail E2E specs

### DIFF
--- a/frontend/e2e/pages/artist-detail.spec.ts
+++ b/frontend/e2e/pages/artist-detail.spec.ts
@@ -34,14 +34,14 @@ test.describe('Artist detail', () => {
     const breadcrumbNav = page.locator('nav[aria-label="Breadcrumb"]')
     await expect(breadcrumbNav.getByRole('link', { name: 'Artists' })).toBeVisible()
 
-    // Upcoming and Past shows sections — PSY-644 replaced the Radix `<Tabs>`
-    // in ArtistShowsList with `<SectionHeader as="h2">` rendering ("Past shows"
-    // heading is always present as the collapsible's trigger).
+    // ArtistShowsList renders the upcoming-shows heading unconditionally and
+    // the past-shows `<section>` (which wraps the past-shows heading) only
+    // when `pastShows.length > 0`. The E2E seed (setup-db.sh) inserts only
+    // future-dated shows, so the past-shows assertion would never resolve
+    // here; collapsible-trigger behaviour is covered by
+    // ArtistShowsList.test.tsx instead.
     await expect(
       page.getByRole('heading', { name: /upcoming shows/i })
-    ).toBeVisible()
-    await expect(
-      page.getByRole('heading', { name: /past shows/i })
     ).toBeVisible()
   })
 

--- a/frontend/e2e/pages/venue-detail.spec.ts
+++ b/frontend/e2e/pages/venue-detail.spec.ts
@@ -34,10 +34,13 @@ test.describe('Venue detail', () => {
     const breadcrumbNav = page.locator('nav[aria-label="Breadcrumb"]')
     await expect(breadcrumbNav.getByRole('link', { name: 'Venues' })).toBeVisible()
 
-    // Upcoming and Past Shows tabs
-    await expect(page.getByRole('tab', { name: /upcoming/i })).toBeVisible()
+    // VenueShowsList renders the upcoming-shows heading unconditionally and
+    // the past-shows `<section>` only when `pastShows.length > 0`. The E2E
+    // seed (setup-db.sh) inserts only future-dated shows, so the past-shows
+    // assertion would never resolve here; collapsible-trigger behaviour is
+    // covered by VenueShowsList.test.tsx instead.
     await expect(
-      page.getByRole('tab', { name: /past shows/i })
+      page.getByRole('heading', { name: /upcoming shows/i })
     ).toBeVisible()
   })
 


### PR DESCRIPTION
Closes PSY-765.

## Summary

Main CI has been red for 3 days / ~30 merges since the Entity Pages Density Rollout (PSY-644 + PSY-655 wave). Two E2E tests fail consistently on `push`-to-main full runs (shards 3/4 + 4/4); PR CI runs only the `@smoke` subset, so the failure is invisible during review.

- **`artist-detail.spec.ts:5`** asserted on a `past shows` heading that PSY-659 claimed was always rendered. `ArtistShowsList.tsx:200` gates the entire past-shows `<section>` (heading included) on `pastShows.length > 0`, and the E2E seed (`frontend/e2e/setup-db.sh:243-275`) inserts only future-dated shows. The assertion never resolves on any seeded artist. Drop it; keep the upcoming-shows heading assertion which always resolves.
- **`venue-detail.spec.ts:5`** was never updated after PSY-655's matching `VenueShowsList` Tabs → SectionHeader refactor. PSY-659's PR body's scope check claimed `VenueShowsList` was unchanged — incorrect; it shipped in the same wave. Tab selectors don't exist anymore. Same shape of fix: swap to `<heading>` for upcoming; drop past-shows assertion for the same seed reason.

Past-shows collapsible-trigger behaviour stays covered by the component tests (`ArtistShowsList.test.tsx` + `VenueShowsList.test.tsx`) where seed shape is mock-controlled. The E2E suite's value is end-to-end navigation, not collapsible state.

## Test plan

- [x] `cd frontend && bun run typecheck` — clean
- [x] `cd frontend && bun run test:e2e pages/artist-detail.spec.ts pages/venue-detail.spec.ts` — **2 passed (14.3s)**
- [x] Reproduced original failures locally first (`artist-detail` line 45 past-shows heading not found; `venue-detail` line 38 tab not found), then verified the fix resolves both.
- [x] No `/simplify` — pure E2E spec edits (2 files, no production code path), no shared abstraction to review.
- [x] No `/psy-self-review` — test-only PR, no manual repro applicable beyond the E2E run itself.

## Coverage gaps

- **Past-shows assertion intentionally dropped** — adding past-dated shows to `setup-db.sh` would broaden the seed and risk affecting other tests' counts/orderings. Filed as out-of-scope; the component-test layer already exercises the collapsible-trigger branch. If you want stronger E2E coverage, a follow-up could add a small dedicated "E2E [past-show]" seed row + per-spec assertion.
- **`@smoke` subset not extended** — PR CI runs `@smoke` only; the artist/venue-detail specs aren't tagged `@smoke`. So this PR's PR-CI won't actually exercise the failing path; the green signal will come only after merge when the full suite runs on main. This is the existing CI gating shape — broadening `@smoke` is out of scope.

## Process note

Caught during `/psy-dispatch` pre-flight (Step B: "Verify origin/main CI is currently green") while preparing to dispatch PSY-738/739/740/741/742 (the PSY-696 per-domain split). Per the skill's red-main decision tree, the recommended path was to fix main first; this PR is that fix. The dispatch is parked until this merges.
