### PR TITLE
PSY-726: ENTITY_PLURAL map for useSuggestEdit (no silent 404s)

### DIFF
--- a/frontend/features/contributions/hooks/useSuggestEdit.test.tsx
+++ b/frontend/features/contributions/hooks/useSuggestEdit.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { createWrapper } from '@/test/utils'
+import type { EditableEntityType } from '../types'
+
+const mockApiRequest = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+// Import after mocks are wired.
+import { useSuggestEdit } from './useSuggestEdit'
+
+describe('useSuggestEdit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  // PSY-726: replaces `entityType + 's'` with an exhaustive ENTITY_PLURAL
+  // map. Enumerating every EditableEntityType is the manual-repro evidence
+  // for the refactor — if any entity is added to EditableEntityType without
+  // a matching ENTITY_PLURAL entry, this test (and TS) catches it.
+  const cases: Array<{ entityType: EditableEntityType; expectedPlural: string }> = [
+    { entityType: 'artist', expectedPlural: 'artists' },
+    { entityType: 'venue', expectedPlural: 'venues' },
+    { entityType: 'festival', expectedPlural: 'festivals' },
+    { entityType: 'release', expectedPlural: 'releases' },
+    { entityType: 'label', expectedPlural: 'labels' },
+    { entityType: 'show', expectedPlural: 'shows' },
+  ]
+
+  it.each(cases)(
+    'builds the suggest-edit URL for $entityType using the plural map',
+    async ({ entityType, expectedPlural }) => {
+      mockApiRequest.mockResolvedValueOnce({
+        applied: true,
+        message: 'ok',
+      })
+
+      const { result } = renderHook(() => useSuggestEdit(), {
+        wrapper: createWrapper(),
+      })
+
+      result.current.mutate({
+        entityType,
+        entityId: 42,
+        changes: [{ field: 'description', old_value: 'old', new_value: 'new' }],
+        summary: 'tighten copy',
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        `http://localhost:8080/${expectedPlural}/42/suggest-edit`,
+        {
+          method: 'PUT',
+          body: JSON.stringify({
+            changes: [{ field: 'description', old_value: 'old', new_value: 'new' }],
+            summary: 'tighten copy',
+          }),
+        }
+      )
+    }
+  )
+})

--- a/frontend/features/contributions/hooks/useSuggestEdit.test.tsx
+++ b/frontend/features/contributions/hooks/useSuggestEdit.test.tsx
@@ -19,10 +19,10 @@ describe('useSuggestEdit', () => {
     mockApiRequest.mockReset()
   })
 
-  // PSY-726: replaces `entityType + 's'` with an exhaustive ENTITY_PLURAL
-  // map. Enumerating every EditableEntityType is the manual-repro evidence
-  // for the refactor — if any entity is added to EditableEntityType without
-  // a matching ENTITY_PLURAL entry, this test (and TS) catches it.
+  // Enumerating every EditableEntityType is the verification that the
+  // ENTITY_PLURAL map stays in sync with the union — if a new entity is
+  // added without a matching plural, TS catches the map and this test
+  // catches the URL shape.
   const cases: Array<{ entityType: EditableEntityType; expectedPlural: string }> = [
     { entityType: 'artist', expectedPlural: 'artists' },
     { entityType: 'venue', expectedPlural: 'venues' },

--- a/frontend/features/contributions/hooks/useSuggestEdit.ts
+++ b/frontend/features/contributions/hooks/useSuggestEdit.ts
@@ -2,6 +2,23 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { apiRequest, API_BASE_URL } from '@/lib/api'
 import type { EditableEntityType, SuggestEditRequest, SuggestEditResponse } from '../types'
 
+/**
+ * Explicit singular → URL plural map for the suggest-edit endpoint and the
+ * react-query cache key. `Record<EditableEntityType, string>` makes the map
+ * exhaustive: adding a new editable entity (or an entity with an irregular
+ * plural) is a compile error here, not a silent 404 at runtime. Show is
+ * present for type-completeness even though `EntityEditDrawer` routes show
+ * edits to `useShowEdit` instead — see EditableEntityType doc.
+ */
+const ENTITY_PLURAL: Record<EditableEntityType, string> = {
+  artist: 'artists',
+  venue: 'venues',
+  festival: 'festivals',
+  release: 'releases',
+  label: 'labels',
+  show: 'shows',
+}
+
 export const useSuggestEdit = () => {
   const queryClient = useQueryClient()
 
@@ -15,7 +32,7 @@ export const useSuggestEdit = () => {
       entityType: EditableEntityType
       entityId: number
     }): Promise<SuggestEditResponse> => {
-      const pluralType = entityType + 's'
+      const pluralType = ENTITY_PLURAL[entityType]
       return apiRequest<SuggestEditResponse>(
         `${API_BASE_URL}/${pluralType}/${entityId}/suggest-edit`,
         {
@@ -25,7 +42,7 @@ export const useSuggestEdit = () => {
       )
     },
     onSuccess: (_data, { entityType }) => {
-      const pluralType = entityType + 's'
+      const pluralType = ENTITY_PLURAL[entityType]
       queryClient.invalidateQueries({ queryKey: [pluralType] })
       queryClient.invalidateQueries({ queryKey: ['my-pending-edits'] })
     },


### PR DESCRIPTION
## Summary
- Replace `entityType + 's'` with `ENTITY_PLURAL[entityType]` at both call sites in `useSuggestEdit`. The map is typed `Record<EditableEntityType, string>`, so adding a new entity (or one with an irregular plural) is now a compile-time error here rather than a silent backend 404 later.
- Add `useSuggestEdit.test.tsx` enumerating every `EditableEntityType` and asserting the URL the hook posts — locks the refactor as render-shape-preserving and guards the map.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run test:run features/contributions/hooks` — 9/9 passing (3 existing useMyPendingEdits + 6 new useSuggestEdit enumeration cases)
- [x] Enumeration test over `EditableEntityType` (artist, venue, festival, release, label, show) — all pass

## Manual repro
Render-only refactor of internal URL construction — no UI surface change. Per the dispatch playbook render-only carveout, the new enumeration test in `useSuggestEdit.test.tsx` IS the manual repro: it covers every `EditableEntityType` value and asserts the exact URL that `apiRequest` receives, proving the refactor preserves URL shape across the full union.

## Simplify
Three review angles run inline. One finding fixed in a separate commit: stripped the `PSY-726:` ticket reference from the test-block comment (per `feedback_strip_ticket_refs_from_doc_comments.md`) and reworded to explain the WHY (TS + test together pin the map to the union). No reuse/efficiency issues found. The `Record<EditableEntityType, T>` shape matches the existing `EDITABLE_FIELDS` / `REPORT_TYPES` convention in `types.ts`.

Out-of-scope observation (not addressed here): `features/contributions/hooks/useReportEntity.ts:47` carries the same `entityType + 's'` pattern over `ReportableEntityType` (with special-cases for `comment` and `show`). That's a sibling occurrence of the same risk — flagging for a follow-up ticket per `feedback_audit_recurring_bugs.md` (audit at 2 instances).

Closes PSY-726