### PR TITLE
PSY-733: call notFound() instead of inline error div on empty slug

### DIFF
--- a/frontend/app/artists/[slug]/page.tsx
+++ b/frontend/app/artists/[slug]/page.tsx
@@ -88,16 +88,7 @@ export default async function ArtistPage({ params }: ArtistPageProps) {
   const { slug } = await params
 
   if (!slug) {
-    return (
-      <div className="flex min-h-[60vh] items-center justify-center">
-        <div className="text-center">
-          <h1 className="text-2xl font-bold mb-2">Invalid Artist</h1>
-          <p className="text-muted-foreground">
-            The artist could not be found.
-          </p>
-        </div>
-      </div>
-    )
+    notFound()
   }
 
   const artistData = await getArtist(slug)

--- a/frontend/app/collections/[slug]/page.tsx
+++ b/frontend/app/collections/[slug]/page.tsx
@@ -109,16 +109,7 @@ export default async function CollectionPage({ params }: CollectionPageProps) {
   const { slug } = await params
 
   if (!slug) {
-    return (
-      <div className="flex min-h-[60vh] items-center justify-center">
-        <div className="text-center">
-          <h1 className="text-2xl font-bold mb-2">Invalid Collection</h1>
-          <p className="text-muted-foreground">
-            The collection could not be found.
-          </p>
-        </div>
-      </div>
-    )
+    notFound()
   }
 
   const collectionData = await getCollection(slug)

--- a/frontend/app/festivals/[slug]/page.tsx
+++ b/frontend/app/festivals/[slug]/page.tsx
@@ -92,16 +92,7 @@ export default async function FestivalPage({ params }: FestivalPageProps) {
   const { slug } = await params
 
   if (!slug) {
-    return (
-      <div className="flex min-h-[60vh] items-center justify-center">
-        <div className="text-center">
-          <h1 className="text-2xl font-bold mb-2">Invalid Festival</h1>
-          <p className="text-muted-foreground">
-            The festival could not be found.
-          </p>
-        </div>
-      </div>
-    )
+    notFound()
   }
 
   const festivalData = await getFestival(slug)

--- a/frontend/app/labels/[slug]/page.tsx
+++ b/frontend/app/labels/[slug]/page.tsx
@@ -90,16 +90,7 @@ export default async function LabelPage({ params }: LabelPageProps) {
   const { slug } = await params
 
   if (!slug) {
-    return (
-      <div className="flex min-h-[60vh] items-center justify-center">
-        <div className="text-center">
-          <h1 className="text-2xl font-bold mb-2">Invalid Label</h1>
-          <p className="text-muted-foreground">
-            The label could not be found.
-          </p>
-        </div>
-      </div>
-    )
+    notFound()
   }
 
   const labelData = await getLabel(slug)

--- a/frontend/app/releases/[slug]/page.tsx
+++ b/frontend/app/releases/[slug]/page.tsx
@@ -88,16 +88,7 @@ export default async function ReleasePage({ params }: ReleasePageProps) {
   const { slug } = await params
 
   if (!slug) {
-    return (
-      <div className="flex min-h-[60vh] items-center justify-center">
-        <div className="text-center">
-          <h1 className="text-2xl font-bold mb-2">Invalid Release</h1>
-          <p className="text-muted-foreground">
-            The release could not be found.
-          </p>
-        </div>
-      </div>
-    )
+    notFound()
   }
 
   const releaseData = await getRelease(slug)

--- a/frontend/app/scenes/[slug]/page.tsx
+++ b/frontend/app/scenes/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from 'react'
+import { notFound } from 'next/navigation'
 import { Loader2 } from 'lucide-react'
 import { SceneDetailView } from '@/features/scenes'
 
@@ -41,16 +42,7 @@ export default async function ScenePage({ params }: ScenePageProps) {
   const { slug } = await params
 
   if (!slug) {
-    return (
-      <div className="flex min-h-[60vh] items-center justify-center">
-        <div className="text-center">
-          <h1 className="text-2xl font-bold mb-2">Invalid Scene</h1>
-          <p className="text-muted-foreground">
-            The scene could not be found.
-          </p>
-        </div>
-      </div>
-    )
+    notFound()
   }
 
   return (

--- a/frontend/app/shows/[slug]/page.tsx
+++ b/frontend/app/shows/[slug]/page.tsx
@@ -132,16 +132,7 @@ export default async function ShowPage({ params }: ShowPageProps) {
   const { slug } = await params
 
   if (!slug) {
-    return (
-      <div className="flex min-h-[60vh] items-center justify-center">
-        <div className="text-center">
-          <h1 className="text-2xl font-bold mb-2">Invalid Show</h1>
-          <p className="text-muted-foreground">
-            The show could not be found.
-          </p>
-        </div>
-      </div>
-    )
+    notFound()
   }
 
   const showData = await getShow(slug)

--- a/frontend/app/users/[username]/page.tsx
+++ b/frontend/app/users/[username]/page.tsx
@@ -2,6 +2,7 @@
 
 import { use } from 'react'
 import { Suspense } from 'react'
+import { notFound } from 'next/navigation'
 import { Loader2 } from 'lucide-react'
 import { PublicProfile } from '@/components/contributor'
 
@@ -21,16 +22,7 @@ export default function UserProfilePage({ params }: UserProfilePageProps) {
   const { username } = use(params)
 
   if (!username) {
-    return (
-      <div className="flex min-h-[60vh] items-center justify-center">
-        <div className="text-center">
-          <h1 className="text-2xl font-bold mb-2">Invalid User</h1>
-          <p className="text-muted-foreground">
-            The user could not be found.
-          </p>
-        </div>
-      </div>
-    )
+    notFound()
   }
 
   return (

--- a/frontend/app/venues/[slug]/page.tsx
+++ b/frontend/app/venues/[slug]/page.tsx
@@ -90,16 +90,7 @@ export default async function VenuePage({ params }: VenuePageProps) {
   const { slug } = await params
 
   if (!slug) {
-    return (
-      <div className="flex min-h-[60vh] items-center justify-center">
-        <div className="text-center">
-          <h1 className="text-2xl font-bold mb-2">Invalid Venue</h1>
-          <p className="text-muted-foreground">
-            The venue could not be found.
-          </p>
-        </div>
-      </div>
-    )
+    notFound()
   }
 
   const venueData = await getVenue(slug)


### PR DESCRIPTION
## Summary
- Nine dynamic-route pages had a defensive `if (!slug) { return <div>...Invalid X... }` branch that rendered an inline error message with **200 OK**, bypassing Next.js notFound() handling and breaking SEO. Replaced each branch with `notFound()`.
- Branch is unreachable today: Next.js's default `trailingSlash: false` 308-redirects `/<route>/` to `/<route>` before the dynamic segment renders, so the param always has a value. Kept the guard as `notFound()` to preserve defense-in-depth without the SEO regression — same number of lines, correct semantics.
- Pages fixed: artists, collections, festivals, labels, releases, scenes, shows, users, venues. Added `notFound` import to scenes and users (the other seven already imported it for the data-fetch-miss branch).

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run test:run app` — 113/113 passed (no existing tests touch these page bodies; suite green as a regression check)
- [x] sibling-page audit: 9 pages had the `if (!<param>) { return <div>... }` pattern and were fixed (artists, collections, festivals, labels, releases, scenes, shows, users, venues). categories already used `notFound()` correctly on the derived `categoryName` value (left alone). 5 sibling pages have no raw-param guard at all — they only gate on fetched data (blog → `if (!post)`, dj-sets → `if (!mix)`, tags → `if (!tag)`, requests, radio/*) — left alone.

## Manual repro
Dev-mode evidence (stack `--mode=shared` against per-worktree backend on :56888, frontend on :56889):

`curl -s -o /dev/null -w "%{http_code}" http://localhost:56889/shows/` → `308` (redirects to `/shows`). Confirms the `if (!slug)` branch is unreachable via URL — Next.js handles trailing-slash normalization before page render. The branch was always dead-code defense.

`curl -s -o /dev/null -w "%{http_code}" http://localhost:56889/shows/this-definitely-doesnt-exist` → `200` in dev (standard Next.js dev-mode behavior; `notFound()` returns 404 in prod build). Existing `if (!showData) notFound()` branch at line 140 still triggers — verified the served HTML contains `next-error`/`404`/`not-found` markers. No regression.

Backend confirmed returning 404 for invalid slug: `curl -s -o /dev/null -w "%{http_code}" http://localhost:56888/shows/this-definitely-doesnt-exist` → `404`.

## Simplify
Reviewed for code reuse, quality, and efficiency. Diff is uniform 9-file removal of inline error JSX, replaced with the canonical `notFound()` call from `next/navigation`. No duplication, no new utilities needed, no efficiency issues (notFound() short-circuits via thrown error). Extracting a 3-line helper would be over-abstraction across page entrypoints with different param names (slug vs username). No changes from /simplify.

Closes PSY-733