### PR TITLE
PSY-729: clear featured-toggle error on next successful toggle

### DIFF
--- a/frontend/components/admin/CollectionManagement.test.tsx
+++ b/frontend/components/admin/CollectionManagement.test.tsx
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { CollectionManagement } from './CollectionManagement'
+import type { Collection } from '@/features/collections'
+
+// Mock the collections feature module. `useSetFeatured` is the focus of this
+// test — the inner mutate fn is a spy whose behaviour each test case
+// controls (success vs error) by overriding `nextSetFeaturedOutcome`.
+type MutateOptions = {
+  onSuccess?: () => void
+  onError?: (err: unknown) => void
+}
+
+let nextSetFeaturedOutcome:
+  | { kind: 'success' }
+  | { kind: 'error'; error: Error } = { kind: 'success' }
+
+const mockSetFeaturedMutate = vi.fn(
+  (_vars: { slug: string; featured: boolean }, options: MutateOptions = {}) => {
+    if (nextSetFeaturedOutcome.kind === 'success') {
+      options.onSuccess?.()
+    } else {
+      options.onError?.(nextSetFeaturedOutcome.error)
+    }
+  }
+)
+
+const mockDeleteMutate = vi.fn()
+
+vi.mock('@/features/collections', () => ({
+  useCollections: () => mockUseCollections(),
+  useCollection: () => ({ data: undefined, isLoading: false }),
+  useCollectionStats: () => ({ data: undefined, isLoading: false }),
+  useSetFeatured: () => ({
+    mutate: mockSetFeaturedMutate,
+    isPending: false,
+  }),
+  useDeleteCollection: () => ({
+    mutate: mockDeleteMutate,
+    isPending: false,
+    error: null,
+  }),
+}))
+
+const mockUseCollections = vi.fn()
+
+function makeCollection(overrides: Partial<Collection> = {}): Collection {
+  return {
+    id: 1,
+    title: 'Test Collection',
+    slug: 'test-collection',
+    description: 'A test collection',
+    creator_id: 1,
+    creator_name: 'testuser',
+    collaborative: false,
+    is_public: true,
+    is_featured: false,
+    display_mode: 'unranked',
+    item_count: 5,
+    subscriber_count: 3,
+    contributor_count: 1,
+    forks_count: 0,
+    forked_from_collection_id: null,
+    like_count: 0,
+    user_likes_this: false,
+    created_at: '2025-01-01T00:00:00Z',
+    updated_at: '2025-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('CollectionManagement', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    nextSetFeaturedOutcome = { kind: 'success' }
+    mockUseCollections.mockReturnValue({
+      data: {
+        collections: [
+          makeCollection({ id: 1, title: 'Coll A', slug: 'coll-a' }),
+        ],
+        total: 1,
+      },
+      isLoading: false,
+      error: null,
+    })
+  })
+
+  describe('featured toggle error banner (PSY-729)', () => {
+    it('does not show error banner initially', () => {
+      render(<CollectionManagement />)
+      expect(
+        screen.queryByTestId('featured-toggle-error')
+      ).not.toBeInTheDocument()
+    })
+
+    it('shows error banner when featured toggle fails', async () => {
+      const user = userEvent.setup()
+      nextSetFeaturedOutcome = {
+        kind: 'error',
+        error: new Error('Network timeout'),
+      }
+
+      render(<CollectionManagement />)
+      await user.click(screen.getByRole('switch'))
+
+      const banner = await screen.findByTestId('featured-toggle-error')
+      expect(banner).toBeInTheDocument()
+      expect(banner.textContent).toContain('Network timeout')
+    })
+
+    // Regression for PSY-729: a failed toggle sets the inline error banner,
+    // and the next successful toggle must clear it. Previously, only the
+    // onError callback was wired to setFeaturedError, so the banner
+    // persisted across subsequent successful toggles until the user
+    // reloaded or manually dismissed.
+    //
+    // This test specifically validates that an onSuccess callback is
+    // wired into the mutate options and that invoking it clears the
+    // banner. We intentionally bypass the click handler for the success
+    // step — the click handler already clears the banner pre-mutate
+    // (line 292), which would mask a missing onSuccess.
+    it('clears error banner on the next successful featured toggle', async () => {
+      const user = userEvent.setup()
+      // First click fails → banner surfaces via onError.
+      nextSetFeaturedOutcome = {
+        kind: 'error',
+        error: new Error('Network timeout'),
+      }
+      render(<CollectionManagement />)
+      await user.click(screen.getByRole('switch'))
+      expect(
+        await screen.findByTestId('featured-toggle-error')
+      ).toBeInTheDocument()
+
+      // Grab the most recent mutate call's options and invoke its
+      // onSuccess directly. This proves the convention is wired in
+      // the mutation contract itself, not just in the click handler.
+      const lastCall =
+        mockSetFeaturedMutate.mock.calls[
+          mockSetFeaturedMutate.mock.calls.length - 1
+        ]
+      const options = lastCall[1] as MutateOptions
+      expect(options.onSuccess).toBeDefined()
+
+      // Invoke onSuccess (this is what TanStack Query does on a
+      // successful mutation). Wrap in act so the state update flushes.
+      const { act } = await import('@testing-library/react')
+      act(() => {
+        options.onSuccess?.()
+      })
+
+      expect(
+        screen.queryByTestId('featured-toggle-error')
+      ).not.toBeInTheDocument()
+    })
+
+    it('uses fallback copy when the rejection is not an Error instance', async () => {
+      const user = userEvent.setup()
+      // Non-Error rejection (e.g. plain string thrown by the fetch helper).
+      // The onError fallback must still surface a human-readable message.
+      nextSetFeaturedOutcome = {
+        kind: 'error',
+        error: 'not-an-error-instance' as unknown as Error,
+      }
+
+      render(<CollectionManagement />)
+      await user.click(screen.getByRole('switch'))
+
+      const banner = await screen.findByTestId('featured-toggle-error')
+      expect(banner.textContent).toContain(
+        'Failed to update featured status'
+      )
+    })
+
+    it('passes through slug and featured flag to mutate', async () => {
+      const user = userEvent.setup()
+      render(<CollectionManagement />)
+      await user.click(screen.getByRole('switch'))
+
+      expect(mockSetFeaturedMutate).toHaveBeenCalledWith(
+        { slug: 'coll-a', featured: true },
+        expect.any(Object)
+      )
+    })
+  })
+})

--- a/frontend/components/admin/CollectionManagement.test.tsx
+++ b/frontend/components/admin/CollectionManagement.test.tsx
@@ -1,12 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { CollectionManagement } from './CollectionManagement'
 import type { Collection } from '@/features/collections'
 
-// Mock the collections feature module. `useSetFeatured` is the focus of this
-// test — the inner mutate fn is a spy whose behaviour each test case
-// controls (success vs error) by overriding `nextSetFeaturedOutcome`.
 type MutateOptions = {
   onSuccess?: () => void
   onError?: (err: unknown) => void
@@ -14,7 +11,7 @@ type MutateOptions = {
 
 let nextSetFeaturedOutcome:
   | { kind: 'success' }
-  | { kind: 'error'; error: Error } = { kind: 'success' }
+  | { kind: 'error'; error: unknown } = { kind: 'success' }
 
 const mockSetFeaturedMutate = vi.fn(
   (_vars: { slug: string; featured: boolean }, options: MutateOptions = {}) => {
@@ -109,20 +106,11 @@ describe('CollectionManagement', () => {
       expect(banner.textContent).toContain('Network timeout')
     })
 
-    // Regression for PSY-729: a failed toggle sets the inline error banner,
-    // and the next successful toggle must clear it. Previously, only the
-    // onError callback was wired to setFeaturedError, so the banner
-    // persisted across subsequent successful toggles until the user
-    // reloaded or manually dismissed.
-    //
-    // This test specifically validates that an onSuccess callback is
-    // wired into the mutate options and that invoking it clears the
-    // banner. We intentionally bypass the click handler for the success
-    // step — the click handler already clears the banner pre-mutate
-    // (line 292), which would mask a missing onSuccess.
+    // The click handler also clears the banner pre-mutate, which would
+    // mask a missing onSuccess. Bypass it: invoke the captured onSuccess
+    // directly to prove the clear is wired into the mutation contract.
     it('clears error banner on the next successful featured toggle', async () => {
       const user = userEvent.setup()
-      // First click fails → banner surfaces via onError.
       nextSetFeaturedOutcome = {
         kind: 'error',
         error: new Error('Network timeout'),
@@ -133,9 +121,6 @@ describe('CollectionManagement', () => {
         await screen.findByTestId('featured-toggle-error')
       ).toBeInTheDocument()
 
-      // Grab the most recent mutate call's options and invoke its
-      // onSuccess directly. This proves the convention is wired in
-      // the mutation contract itself, not just in the click handler.
       const lastCall =
         mockSetFeaturedMutate.mock.calls[
           mockSetFeaturedMutate.mock.calls.length - 1
@@ -143,9 +128,6 @@ describe('CollectionManagement', () => {
       const options = lastCall[1] as MutateOptions
       expect(options.onSuccess).toBeDefined()
 
-      // Invoke onSuccess (this is what TanStack Query does on a
-      // successful mutation). Wrap in act so the state update flushes.
-      const { act } = await import('@testing-library/react')
       act(() => {
         options.onSuccess?.()
       })
@@ -161,7 +143,7 @@ describe('CollectionManagement', () => {
       // The onError fallback must still surface a human-readable message.
       nextSetFeaturedOutcome = {
         kind: 'error',
-        error: 'not-an-error-instance' as unknown as Error,
+        error: 'not-an-error-instance',
       }
 
       render(<CollectionManagement />)

--- a/frontend/components/admin/CollectionManagement.tsx
+++ b/frontend/components/admin/CollectionManagement.tsx
@@ -296,6 +296,16 @@ export function CollectionManagement() {
                               featured: checked,
                             },
                             {
+                              onSuccess: () => {
+                                // Clears-on-next-success per the
+                                // sticky-on-error mutation-feedback
+                                // convention. Guards against the banner
+                                // surviving a successful toggle elsewhere
+                                // (refetch retry, parallel mutation, etc.)
+                                // — relying on the click handler's
+                                // pre-mutate reset alone is fragile.
+                                setFeaturedError(null)
+                              },
                               onError: (err) => {
                                 setFeaturedError(
                                   err instanceof Error

--- a/frontend/components/admin/CollectionManagement.tsx
+++ b/frontend/components/admin/CollectionManagement.tsx
@@ -299,11 +299,10 @@ export function CollectionManagement() {
                               onSuccess: () => {
                                 // Clears-on-next-success per the
                                 // sticky-on-error mutation-feedback
-                                // convention. Guards against the banner
-                                // surviving a successful toggle elsewhere
-                                // (refetch retry, parallel mutation, etc.)
-                                // — relying on the click handler's
-                                // pre-mutate reset alone is fragile.
+                                // convention. The click handler's
+                                // pre-mutate reset covers the common
+                                // case but misses retries / parallel
+                                // successes that don't go through it.
                                 setFeaturedError(null)
                               },
                               onError: (err) => {


### PR DESCRIPTION
## Summary
- `CollectionManagement.tsx` wired the featured-toggle inline error banner via `mutate`'s `onError` but never via `onSuccess`. The click handler's pre-mutate `setFeaturedError(null)` masked the bug in the common case, but the banner would persist if a refetch retry or parallel mutation succeeded between explicit clicks. Wire `onSuccess` to clear so the convention lives in the mutation contract itself, not the click handler.
- Adds `CollectionManagement.test.tsx` (first test file for this component) covering: initial state, error surface, regression for clear-on-next-success, non-Error rejection fallback, and slug/featured payload pass-through.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run test:run components/admin` — 131/131 passing (12 files, 5 new in `CollectionManagement.test.tsx`)
- [x] clear-on-success regression test — verified to FAIL when `onSuccess` is removed and PASS with the fix (proven during dev, see PR description for the carveout note)

## Manual repro
Render-only carveout: the regression test covers the clear-on-success path by capturing the mutate options passed to the `useSetFeatured` hook and invoking the captured `onSuccess` directly — this intentionally bypasses the click handler's pre-mutate reset (which would mask a missing `onSuccess`). The test was verified to fail when the fix is reverted, confirming it actually catches the bug. No live browser repro performed.

## Simplify
- Lifted `act` from a dynamic `import('@testing-library/react')` inside the test body to the top-level import (matches the existing pattern in `features/auth/hooks/useAuth.test.tsx`).
- Widened the test's error union from `Error` to `unknown` to drop a double-cast in the non-Error fallback case.
- Trimmed narration-style comments that restated the code; kept only the WHY for the regression-test design choice and the source-side WHY for adding `onSuccess` alongside the click handler's clear.

Closes PSY-729