### PR TITLE
PSY-730: PipelineVenues resetRenderMethod inline error banner

### DIFF
--- a/frontend/components/admin/PipelineVenues.test.tsx
+++ b/frontend/components/admin/PipelineVenues.test.tsx
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { PipelineVenueInfo } from '@/lib/hooks/usePipeline'
+
+// `vi.hoisted` lets us share these handles between the hoisted vi.mock factory
+// and the test bodies below. Anything referenced inside `vi.mock` factories
+// MUST live in here, since `vi.mock` calls are hoisted above module-level
+// const declarations.
+const { mockResetMutate, mocks, venueFixture } = vi.hoisted(() => {
+  type MutateOpts = {
+    onSuccess?: () => void
+    onError?: (err: unknown) => void
+  }
+  const mocks = {
+    lastResetMutateOpts: null as MutateOpts | null,
+  }
+  const mockResetMutate = vi.fn(
+    (_vars: { venueId: number }, opts?: MutateOpts) => {
+      mocks.lastResetMutateOpts = opts ?? null
+    }
+  )
+  const venueFixture: PipelineVenueInfo = {
+    venue_id: 42,
+    venue_name: 'The Rebel Lounge',
+    venue_slug: 'the-rebel-lounge',
+    preferred_source: 'ai',
+    render_method: 'static',
+    events_expected: 0,
+    consecutive_failures: 0,
+    strategy_locked: false,
+    auto_approve: false,
+    total_runs: 0,
+  }
+  return { mockResetMutate, mocks, venueFixture }
+})
+
+vi.mock('@/lib/hooks/usePipeline', () => ({
+  usePipelineVenues: () => ({
+    data: { venues: [venueFixture], total: 1 },
+    isLoading: false,
+    error: null,
+  }),
+  useVenueRejectionStats: () => ({ data: null, isLoading: false }),
+  useVenueExtractionRuns: () => ({
+    data: { runs: [], total: 0 },
+    isLoading: false,
+  }),
+  useImportHistory: () => ({
+    data: { imports: [], total: 0 },
+    isLoading: false,
+    error: null,
+  }),
+  useUpdateVenueConfig: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+    error: null,
+  }),
+  useExtractVenue: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+    data: undefined,
+    error: null,
+  }),
+  useResetRenderMethod: () => ({
+    mutate: mockResetMutate,
+    isPending: false,
+  }),
+}))
+
+vi.mock('@/features/venues', () => ({
+  useVenueSearch: () => ({ data: { venues: [] } }),
+}))
+
+import { PipelineVenues } from './PipelineVenues'
+
+describe('PipelineVenues — resetRenderMethod error banner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.lastResetMutateOpts = null
+  })
+
+  async function openVenueDetail(user: ReturnType<typeof userEvent.setup>) {
+    // Expand the venue row to reveal the detail panel with the Reset button.
+    await user.click(screen.getByText('The Rebel Lounge'))
+  }
+
+  it('surfaces an inline error banner when the reset mutation fails, then clears it on the next successful reset', async () => {
+    const user = userEvent.setup()
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+
+    render(<PipelineVenues />)
+    await openVenueDetail(user)
+
+    // First reset — fails.
+    await user.click(screen.getByRole('button', { name: 'Reset' }))
+
+    expect(mockResetMutate).toHaveBeenCalledWith(
+      { venueId: 42 },
+      expect.objectContaining({
+        onError: expect.any(Function),
+        onSuccess: expect.any(Function),
+      })
+    )
+    expect(screen.queryByTestId('reset-render-method-error')).not.toBeInTheDocument()
+
+    // Simulate the mutation rejecting.
+    mocks.lastResetMutateOpts?.onError?.(new Error('Server exploded'))
+    const banner = await screen.findByTestId('reset-render-method-error')
+    expect(banner).toHaveTextContent('Server exploded')
+
+    // Second reset — succeeds. The banner should disappear.
+    await user.click(screen.getByRole('button', { name: 'Reset' }))
+    mocks.lastResetMutateOpts?.onSuccess?.()
+
+    expect(screen.queryByTestId('reset-render-method-error')).not.toBeInTheDocument()
+
+    confirmSpy.mockRestore()
+  })
+
+  it('falls back to a generic message when the error is not an Error instance', async () => {
+    const user = userEvent.setup()
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+
+    render(<PipelineVenues />)
+    await openVenueDetail(user)
+
+    await user.click(screen.getByRole('button', { name: 'Reset' }))
+    mocks.lastResetMutateOpts?.onError?.('string failure mode')
+
+    const banner = await screen.findByTestId('reset-render-method-error')
+    expect(banner).toHaveTextContent('Failed to reset render method')
+
+    confirmSpy.mockRestore()
+  })
+
+  it('does not fire the mutation when the user cancels the confirm dialog', async () => {
+    const user = userEvent.setup()
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+
+    render(<PipelineVenues />)
+    await openVenueDetail(user)
+
+    await user.click(screen.getByRole('button', { name: 'Reset' }))
+
+    expect(mockResetMutate).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('reset-render-method-error')).not.toBeInTheDocument()
+
+    confirmSpy.mockRestore()
+  })
+})

--- a/frontend/components/admin/PipelineVenues.tsx
+++ b/frontend/components/admin/PipelineVenues.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/lib/hooks/usePipeline'
 import { useVenueSearch } from '@/features/venues'
 import { Switch } from '@/components/ui/switch'
+import { InlineErrorBanner } from '@/components/shared'
 
 function ApprovalBadge({ rate }: { rate?: number }) {
   if (rate === undefined || rate === null) {
@@ -322,6 +323,10 @@ function VenueDetailPanel({
   const resetRenderMethod = useResetRenderMethod()
   const extractVenue = useExtractVenue()
   const [isEditingConfig, setIsEditingConfig] = useState(false)
+  // Surface reset-render-method failures so admins aren't left wondering why
+  // the render method didn't change. Sticky until the next successful reset
+  // clears it, per the project mutation-feedback convention.
+  const [resetError, setResetError] = useState<string | null>(null)
 
   const handleExtract = (dryRun: boolean) => {
     extractVenue.mutate({ venueId: venue.venue_id, dryRun })
@@ -329,7 +334,20 @@ function VenueDetailPanel({
 
   const handleResetRenderMethod = () => {
     if (window.confirm('Reset render method to auto-detect? It will be re-detected on the next pipeline run.')) {
-      resetRenderMethod.mutate({ venueId: venue.venue_id })
+      setResetError(null)
+      resetRenderMethod.mutate(
+        { venueId: venue.venue_id },
+        {
+          onSuccess: () => {
+            setResetError(null)
+          },
+          onError: (err) => {
+            setResetError(
+              err instanceof Error ? err.message : 'Failed to reset render method'
+            )
+          },
+        }
+      )
     }
   }
 
@@ -440,6 +458,11 @@ function VenueDetailPanel({
               <span className="text-muted-foreground">Notes:</span>{' '}
               <span className="italic">{venue.extraction_notes}</span>
             </div>
+          )}
+          {resetError && (
+            <InlineErrorBanner testId="reset-render-method-error">
+              {resetError}
+            </InlineErrorBanner>
           )}
         </div>
       )}


### PR DESCRIPTION
## Summary
- Add sticky `InlineErrorBanner` to `VenueDetailPanel` driven by local `resetError` state; the `onError` callback fills it (with a generic fallback for non-`Error` rejections), the `onSuccess` callback and the next attempt clear it
- Restores the project mutation-feedback convention for the one admin mutation that was silently failing — pipeline reset for an individual venue's render method
- Add `PipelineVenues.test.tsx` covering the error-then-success regression, the non-`Error` fallback message, and the confirm-cancel no-op path

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run test:run components/admin` — 129/129 passing (12 files), including 3 new `PipelineVenues` tests
- [x] error-then-success regression test — passed (covers banner appears on `onError`, mock invocation receives both `onSuccess` + `onError` callbacks, banner disappears after `onSuccess` fires)

## Manual repro
Render-only carveout (pattern_dispatch_stacks.md): the regression test exercises both the failure path (custom `Error` message + non-`Error` fallback) and the recovery path (`onSuccess` clears the banner), plus the confirm-cancel branch. No live screenshot — stacking the admin dev environment to trigger a single confirm-dialog mutation failure would be high overhead for behaviour the unit tests already cover end-to-end.

## Simplify
Reviewed for reuse, quality, and efficiency. No changes needed — the `err instanceof Error ? err.message : <fallback>` formatter is the project's inline convention (5+ sites, no shared helper); the `vi.hoisted` mock pattern is the canonical Vitest shape for capturing callback options; pre-clearing on attempt + clearing on `onSuccess` mirrors the established `CollectionManagement.tsx` / `LabelManagement.tsx` flow.

Closes PSY-730

🤖 Generated with [Claude Code](https://claude.com/claude-code)