### PR TITLE
PSY-743: allowlist cli_callback to loopback (token exfiltration fix)

### DIFF
--- a/backend/internal/api/handlers/auth/cli_callback_validator.go
+++ b/backend/internal/api/handlers/auth/cli_callback_validator.go
@@ -1,0 +1,100 @@
+package auth
+
+import (
+	"errors"
+	"net"
+	"net/url"
+	"strings"
+)
+
+// errInvalidCLICallback is returned when a cli_callback value is not on the
+// loopback allowlist. The message is intentionally generic — we do not echo
+// the rejected value back to the caller.
+var errInvalidCLICallback = errors.New("cli_callback must be a loopback (localhost) http URL")
+
+// allowedCLICallbackHosts is the set of hostnames the CLI OAuth callback may
+// target. The CLI runs a transient HTTP listener on the user's own machine, so
+// the only legitimate destinations are loopback addresses.
+//
+// NOTE: the in-repo `cli/` client (token-paste `ph init`) does not currently
+// use the OAuth `cli_callback` flow at all, and no custom URI scheme
+// (e.g. `psychichomily://`) exists anywhere in the codebase. The allowlist is
+// therefore restricted to loopback. If a future CLI build adopts a custom
+// scheme, add it here deliberately rather than widening host matching.
+var allowedCLICallbackHosts = map[string]struct{}{
+	"localhost": {},
+	"127.0.0.1": {},
+	"::1":       {},
+}
+
+// validateCLICallback enforces that a cli_callback redirect target points only
+// at the local machine. It defends against open-redirect token exfiltration:
+// the OAuth flow appends a 24h JWT to this URL, so an attacker-controlled host
+// would receive the victim's credentials.
+//
+// On success it returns the parsed-and-re-serialized URL (canonical form) so
+// callers store a normalized value. On failure it returns errInvalidCLICallback.
+//
+// Rejected by construction: non-http schemes (javascript:, data:, file://,
+// https), non-loopback hosts (evil.com), unicode/punycode-spoofed loopback,
+// loopback as a credential or subdomain (http://127.0.0.1@evil.com,
+// http://localhost.evil.com), and empty/garbage input.
+func validateCLICallback(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", errInvalidCLICallback
+	}
+
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", errInvalidCLICallback
+	}
+
+	// Only plain http is valid for a local loopback listener. This rejects
+	// https, file, data, javascript, and any custom scheme outright.
+	if u.Scheme != "http" {
+		return "", errInvalidCLICallback
+	}
+
+	// Reject embedded credentials (http://127.0.0.1@evil.com parses Host as
+	// evil.com, but be explicit and refuse any userinfo component).
+	if u.User != nil {
+		return "", errInvalidCLICallback
+	}
+
+	// u.Hostname() strips any :port and surrounding [] for IPv6, giving the
+	// bare host. This is what we match against the allowlist — matching the
+	// full Host would let "127.0.0.1.evil.com" or a spoofed port slip through.
+	host := strings.ToLower(u.Hostname())
+	if host == "" {
+		return "", errInvalidCLICallback
+	}
+
+	// Defense against unicode/punycode homograph spoofing of "localhost"
+	// (e.g. "lоcalhost" with a Cyrillic 'о', or its xn-- punycode form):
+	// require the host to be pure ASCII. Loopback names/IPs are all ASCII.
+	if !isASCII(host) {
+		return "", errInvalidCLICallback
+	}
+
+	if _, ok := allowedCLICallbackHosts[host]; !ok {
+		// Also accept any IPv4 loopback address (127.0.0.0/8), matching the
+		// OS convention that the entire block is loopback.
+		if ip := net.ParseIP(host); ip == nil || !ip.IsLoopback() {
+			return "", errInvalidCLICallback
+		}
+	}
+
+	return u.String(), nil
+}
+
+// isASCII reports whether s contains only ASCII bytes. Used to reject
+// unicode-spoofed hostnames before allowlist matching.
+func isASCII(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] > 127 {
+			return false
+		}
+	}
+	return true
+}

--- a/backend/internal/api/handlers/auth/cli_callback_validator_test.go
+++ b/backend/internal/api/handlers/auth/cli_callback_validator_test.go
@@ -1,0 +1,70 @@
+package auth
+
+import "testing"
+
+func TestValidateCLICallback_Allowed(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{"loopback ipv4 with port", "http://127.0.0.1:8888/callback"},
+		{"loopback ipv4 no port", "http://127.0.0.1/callback"},
+		{"loopback ipv4 block", "http://127.0.0.5:53682/cb"},
+		{"loopback ipv6 with port", "http://[::1]:8888/callback"},
+		{"loopback ipv6 no port", "http://[::1]/callback"},
+		{"localhost with port", "http://localhost:8888/cli-cb"},
+		{"localhost uppercase", "http://LOCALHOST:8888/cb"},
+		{"localhost with query", "http://localhost:8888/cb?state=abc"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := validateCLICallback(tc.raw)
+			if err != nil {
+				t.Fatalf("expected %q to be allowed, got error: %v", tc.raw, err)
+			}
+			if got == "" {
+				t.Errorf("expected non-empty canonical URL for %q", tc.raw)
+			}
+		})
+	}
+}
+
+func TestValidateCLICallback_Rejected(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{"empty", ""},
+		{"whitespace only", "   "},
+		{"external host", "https://evil.com/steal"},
+		{"external host http", "http://evil.com/steal"},
+		{"javascript scheme", "javascript:alert(document.cookie)"},
+		{"data scheme", "data:text/html,<script>alert(1)</script>"},
+		{"file scheme", "file:///etc/passwd"},
+		{"https loopback", "https://127.0.0.1:8888/cb"},  // loopback but wrong scheme
+		{"https localhost", "https://localhost:8888/cb"}, // loopback but wrong scheme
+		{"custom scheme loopback", "psychichomily://127.0.0.1/cb"},
+		{"loopback as subdomain", "http://127.0.0.1.evil.com/cb"},
+		{"localhost as subdomain", "http://localhost.evil.com/cb"},
+		{"loopback as credential", "http://127.0.0.1@evil.com/cb"},
+		{"localhost as credential", "http://localhost@evil.com/cb"},
+		{"unicode spoofed localhost", "http://lоcalhost:8888/cb"}, // Cyrillic 'о'
+		{"punycode spoofed localhost", "http://xn--lcalhost-9zd:8888/cb"},
+		{"protocol-relative", "//evil.com/cb"},
+		{"bare host no scheme", "evil.com/cb"},
+		{"public ip", "http://93.184.216.34/cb"},
+		{"private non-loopback ip", "http://192.168.1.1/cb"},
+		{"link-local ip", "http://169.254.169.254/cb"}, // cloud metadata SSRF target
+		{"garbage", "http://%zz"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := validateCLICallback(tc.raw)
+			if err == nil {
+				t.Fatalf("expected %q to be rejected, got allowed value %q", tc.raw, got)
+			}
+		})
+	}
+}

--- a/backend/internal/api/handlers/auth/oauth_handlers.go
+++ b/backend/internal/api/handlers/auth/oauth_handlers.go
@@ -146,6 +146,19 @@ func (h *OAuthHTTPHandler) OAuthLoginHTTPHandler(w http.ResponseWriter, r *http.
 	// Check for CLI callback parameter
 	cliCallback := r.URL.Query().Get("cli_callback")
 	if cliCallback != "" {
+		// Reject any callback that is not a loopback URL. The OAuth callback
+		// appends a 24h JWT to this destination, so an attacker-controlled
+		// host (e.g. ?cli_callback=https://evil.com/steal) would exfiltrate
+		// the victim's token. SameSite=Lax does NOT mitigate — the OAuth
+		// cookie is set on this same top-level navigation.
+		validated, err := validateCLICallback(cliCallback)
+		if err != nil {
+			log.Printf("WARN: rejected open-redirect cli_callback from %s: %v", r.RemoteAddr, err)
+			http.Error(w, "Invalid cli_callback", http.StatusBadRequest)
+			return
+		}
+		cliCallback = validated
+
 		// Generate unique ID and store callback in memory
 		callbackID := generateRandomID()
 		storeCLICallback(callbackID, cliCallback)
@@ -197,9 +210,18 @@ func (h *OAuthHTTPHandler) OAuthCallbackHTTPHandler(w http.ResponseWriter, r *ht
 	if cookie, err := r.Cookie("cli_callback_id"); err == nil {
 		callbackID := cookie.Value
 		if callback, ok := getCLICallback(callbackID); ok {
-			cliCallback = callback
 			deleteCLICallback(callbackID)
-			log.Printf("DEBUG: CLI callback found for ID %s: %s", callbackID, cliCallback)
+			// Defense in depth: re-validate the stored callback before we
+			// build a token-bearing redirect from it. Even though the value
+			// was checked at initiation, never trust a stored redirect target
+			// against the loopback allowlist a second time. A rejected value
+			// falls back to the standard web flow (no token leaked).
+			if validated, verr := validateCLICallback(callback); verr == nil {
+				cliCallback = validated
+				log.Printf("DEBUG: CLI callback found for ID %s: %s", callbackID, cliCallback)
+			} else {
+				log.Printf("WARN: rejected non-loopback cli_callback at callback from %s: %v", r.RemoteAddr, verr)
+			}
 		}
 		// Clear the CLI callback ID cookie
 		http.SetCookie(w, &http.Cookie{

--- a/backend/internal/api/handlers/auth/oauth_handlers_test.go
+++ b/backend/internal/api/handlers/auth/oauth_handlers_test.go
@@ -202,6 +202,32 @@ func TestOAuthLoginHTTPHandler_CLICallbackStored(t *testing.T) {
 	}
 }
 
+func TestOAuthLoginHTTPHandler_CLICallbackRejected_400(t *testing.T) {
+	defer cleanCLICallbackStore()
+
+	handler := NewOAuthHTTPHandler(nil, nil)
+
+	req := httptest.NewRequest("GET", "/auth/login/google?cli_callback=https://evil.com/steal", nil)
+	w := httptest.NewRecorder()
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("provider", "google")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	handler.OAuthLoginHTTPHandler(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for off-allowlist cli_callback, got %d", w.Code)
+	}
+
+	// No cookie should be set and nothing stored for a rejected callback.
+	for _, c := range w.Result().Cookies() {
+		if c.Name == "cli_callback_id" {
+			t.Error("expected no cli_callback_id cookie for rejected callback")
+		}
+	}
+}
+
 func TestOAuthLoginHTTPHandler_ValidProvider_GoogleQueryParam(t *testing.T) {
 	// Verify that the handler adds the provider to query params for Goth
 	// (gothic.BeginAuthHandler will fail without registered providers, but


### PR DESCRIPTION
## Summary

Hardens the CLI OAuth callback against open-redirect token exfiltration — the project's one CRITICAL-severity security finding.

`/auth/login/{provider}?cli_callback=...` read `cli_callback` with no scheme/host allowlist, stored it server-side, then on successful OAuth appended the victim's 24h JWT to it and redirected. **Attack scenario:** luring a victim to `/auth/login/google?cli_callback=https://evil.com/steal` delivered that victim's JWT to `evil.com`. `SameSite=Lax` does not mitigate — the OAuth-initiation cookie is set on the same top-level navigation.

- New `validateCLICallback(raw) (string, error)` in `internal/api/handlers/auth/cli_callback_validator.go`: accepts only loopback http URLs (`localhost`, `127.0.0.0/8`, `[::1]`). Rejects non-http schemes (`https`/`javascript:`/`data:`/`file://`/custom), external hosts, embedded credentials (`http://127.0.0.1@evil.com`), loopback-as-subdomain (`http://127.0.0.1.evil.com`), and unicode/punycode-spoofed loopback.
- Wired at **initiation** (reject off-allowlist with `400`) and **re-validated at the callback** before building the token redirect (defense in depth; a rejected stored value falls back to the standard web flow, no token leaked).
- Rejections log at WARN with the client IP (`r.RemoteAddr`).

**Allowlist scope (please confirm):** the in-repo `cli/` client uses token-paste `ph init` and does **not** exercise the `cli_callback` OAuth flow, and no `psychichomily://`-style custom URI scheme exists anywhere in the repo. Per the ticket's guidance I restricted the allowlist to loopback rather than guess a custom scheme. If a future CLI build adopts a custom scheme, add it to `allowedCLICallbackHosts` deliberately.

## Test plan

- [x] `cd backend && go build ./...` — exit 0
- [x] `cd backend && go test ./internal/api/handlers/auth/...` — `ok` (8.0s; existing OAuth integration suite with its `localhost:8888` callbacks still passes)
- [x] `cd backend && go test ./...` — exit 0, 27 packages `ok`, 0 FAIL
- [x] `cd backend && go vet ./internal/api/handlers/auth/...` — clean

## Manual repro

Backend-only; the unit test IS the repro (`--mode=none`, no browser).

`go test ./internal/api/handlers/auth/... -run TestValidateCLICallback -v` — all subtests PASS:
- Allowed: `http://127.0.0.1:8888/callback`, `http://[::1]:8888/callback`, `http://localhost:8888/cli-cb`, `http://127.0.0.5:.../cb` (127/8).
- Rejected: `https://evil.com/steal`, `http://evil.com/steal`, `javascript:...`, `data:...`, `file:///etc/passwd`, `https://127.0.0.1/...` (wrong scheme), `psychichomily://127.0.0.1/cb` (custom scheme), `http://127.0.0.1.evil.com/cb` + `http://localhost.evil.com/cb` (subdomain), `http://127.0.0.1@evil.com/cb` (credential), `http://lоcalhost/...` (Cyrillic homograph), `xn--lcalhost-9zd` (punycode), `http://169.254.169.254/cb` (link-local SSRF target).

`TestOAuthLoginHTTPHandler_CLICallbackRejected_400` asserts `/auth/login/google?cli_callback=https://evil.com/steal` returns `400` and sets no `cli_callback_id` cookie. Test output shows the WARN line: `WARN: rejected open-redirect cli_callback from 192.0.2.1:1234: cli_callback must be a loopback (localhost) http URL`.

## Simplify

Reviewed the diff across reuse/quality/efficiency lenses — no changes. Confirmed the existing `utils.ValidateHTTPURL` is a deliberately different contract (http+https, any host, curator-facing error that echoes input) and reusing it would weaken the loopback-only security posture; the dedicated validator is correct. No `PSY-` refs in production comments.

Closes PSY-743