### PR TITLE
PSY-745: constant-time INTERNAL_API_SECRET check via config

### DIFF
--- a/backend/internal/api/handlers/catalog/artist.go
+++ b/backend/internal/api/handlers/catalog/artist.go
@@ -2,9 +2,9 @@ package catalog
 
 import (
 	"context"
+	"crypto/subtle"
 	"errors"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 
@@ -12,6 +12,7 @@ import (
 
 	"psychic-homily-backend/internal/api/handlers/shared"
 	"psychic-homily-backend/internal/api/middleware"
+	"psychic-homily-backend/internal/config"
 	apperrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/logger"
 	adminm "psychic-homily-backend/internal/models/admin"
@@ -19,28 +20,39 @@ import (
 	"psychic-homily-backend/internal/utils"
 )
 
-// isInternalServiceRequest checks if the request has a valid internal service secret
-func isInternalServiceRequest(ctx huma.Context) bool {
-	internalSecret := os.Getenv("INTERNAL_API_SECRET")
-	if internalSecret == "" {
-		return false
-	}
-	requestSecret := ctx.Header("X-Internal-Secret")
-	return requestSecret == internalSecret
-}
-
 type ArtistHandler struct {
 	artistService   contracts.ArtistServiceInterface
 	auditLogService contracts.AuditLogServiceInterface
 	revisionService contracts.RevisionServiceInterface
+	// internalSecret is the configured INTERNAL_API_SECRET, loaded once at
+	// startup. The artist Bandcamp/Spotify mutation endpoints accept it as an
+	// admin bypass for the discovery backfill bot.
+	internalSecret string
 }
 
-func NewArtistHandler(artistService contracts.ArtistServiceInterface, auditLogService contracts.AuditLogServiceInterface, revisionService contracts.RevisionServiceInterface) *ArtistHandler {
+func NewArtistHandler(artistService contracts.ArtistServiceInterface, auditLogService contracts.AuditLogServiceInterface, revisionService contracts.RevisionServiceInterface, cfg *config.Config) *ArtistHandler {
+	var internalSecret string
+	if cfg != nil {
+		internalSecret = cfg.MusicDiscovery.InternalAPISecret
+	}
 	return &ArtistHandler{
 		artistService:   artistService,
 		auditLogService: auditLogService,
 		revisionService: revisionService,
+		internalSecret:  internalSecret,
 	}
+}
+
+// matchesInternalSecret reports whether the request-supplied secret matches the
+// configured internal API secret. The comparison is constant-time to avoid a
+// timing oracle: these endpoints are mounted on rc.Protected (not rc.Admin)
+// because a match grants an admin-equivalent bypass. An empty configured secret
+// never matches, so the bypass is disabled when INTERNAL_API_SECRET is unset.
+func (h *ArtistHandler) matchesInternalSecret(provided string) bool {
+	if h.internalSecret == "" {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(provided), []byte(h.internalSecret)) == 1
 }
 
 // SearchArtistsRequest represents the autocomplete search request
@@ -440,8 +452,7 @@ func (h *ArtistHandler) UpdateArtistBandcampHandler(ctx context.Context, req *Up
 
 	// Check for internal service request (automated discovery)
 	isInternalRequest := false
-	internalSecret := os.Getenv("INTERNAL_API_SECRET")
-	if internalSecret != "" && req.InternalSecret == internalSecret {
+	if h.matchesInternalSecret(req.InternalSecret) {
 		isInternalRequest = true
 		logger.FromContext(ctx).Info("internal_service_request",
 			"endpoint", "update_artist_bandcamp",
@@ -577,8 +588,7 @@ func (h *ArtistHandler) UpdateArtistSpotifyHandler(ctx context.Context, req *Upd
 
 	// Check for internal service request (automated discovery)
 	isInternalRequest := false
-	internalSecret := os.Getenv("INTERNAL_API_SECRET")
-	if internalSecret != "" && req.InternalSecret == internalSecret {
+	if h.matchesInternalSecret(req.InternalSecret) {
 		isInternalRequest = true
 		logger.FromContext(ctx).Info("internal_service_request",
 			"endpoint", "update_artist_spotify",

--- a/backend/internal/api/handlers/catalog/artist_integration_test.go
+++ b/backend/internal/api/handlers/catalog/artist_integration_test.go
@@ -20,7 +20,7 @@ type ArtistHandlerIntegrationSuite struct {
 
 func (s *ArtistHandlerIntegrationSuite) SetupSuite() {
 	s.deps = testhelpers.SetupIntegrationDeps(s.T())
-	s.handler = NewArtistHandler(s.deps.ArtistService, s.deps.AuditLogService, nil)
+	s.handler = NewArtistHandler(s.deps.ArtistService, s.deps.AuditLogService, nil, nil)
 }
 
 func (s *ArtistHandlerIntegrationSuite) TearDownTest() {

--- a/backend/internal/api/handlers/catalog/artist_test.go
+++ b/backend/internal/api/handlers/catalog/artist_test.go
@@ -6,13 +6,53 @@ import (
 	"testing"
 
 	"psychic-homily-backend/internal/api/handlers/shared/testhelpers"
+	"psychic-homily-backend/internal/config"
 	apperrors "psychic-homily-backend/internal/errors"
 	authm "psychic-homily-backend/internal/models/auth"
 	"psychic-homily-backend/internal/services/contracts"
 )
 
 func testArtistHandler() *ArtistHandler {
-	return NewArtistHandler(nil, nil, nil)
+	return NewArtistHandler(nil, nil, nil, nil)
+}
+
+// --- matchesInternalSecret (constant-time internal-secret bypass) ---
+
+func TestMatchesInternalSecret(t *testing.T) {
+	const secret = "a-real-internal-api-secret-32+chars"
+
+	configured := NewArtistHandler(nil, nil, nil, &config.Config{
+		MusicDiscovery: config.MusicDiscoveryConfig{InternalAPISecret: secret},
+	})
+
+	t.Run("accepts matching secret", func(t *testing.T) {
+		if !configured.matchesInternalSecret(secret) {
+			t.Error("expected matching secret to be accepted")
+		}
+	})
+
+	t.Run("rejects wrong secret", func(t *testing.T) {
+		if configured.matchesInternalSecret("wrong-secret") {
+			t.Error("expected wrong secret to be rejected")
+		}
+	})
+
+	t.Run("rejects empty provided secret", func(t *testing.T) {
+		if configured.matchesInternalSecret("") {
+			t.Error("expected empty provided secret to be rejected")
+		}
+	})
+
+	t.Run("unset configured secret never matches", func(t *testing.T) {
+		// nil config → empty configured secret → bypass disabled.
+		unconfigured := NewArtistHandler(nil, nil, nil, nil)
+		if unconfigured.matchesInternalSecret("") {
+			t.Error("empty provided secret must not match an unset configured secret")
+		}
+		if unconfigured.matchesInternalSecret(secret) {
+			t.Error("a non-empty secret must not match an unset configured secret")
+		}
+	})
 }
 
 // --- DeleteArtistHandler ---
@@ -239,7 +279,7 @@ func TestSearchArtists_Success(t *testing.T) {
 			return []*contracts.ArtistDetailResponse{{ID: 1, Name: "Radiohead"}}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil, nil)
+	h := NewArtistHandler(mock, nil, nil, nil)
 
 	resp, err := h.SearchArtistsHandler(context.Background(), &SearchArtistsRequest{Query: "radio"})
 	if err != nil {
@@ -259,7 +299,7 @@ func TestSearchArtists_ServiceError(t *testing.T) {
 			return nil, fmt.Errorf("db error")
 		},
 	}
-	h := NewArtistHandler(mock, nil, nil)
+	h := NewArtistHandler(mock, nil, nil, nil)
 
 	_, err := h.SearchArtistsHandler(context.Background(), &SearchArtistsRequest{Query: "test"})
 	if err == nil {
@@ -280,7 +320,7 @@ func TestListArtists_Success(t *testing.T) {
 			}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil, nil)
+	h := NewArtistHandler(mock, nil, nil, nil)
 
 	resp, err := h.ListArtistsHandler(context.Background(), &ListArtistsRequest{})
 	if err != nil {
@@ -308,7 +348,7 @@ func TestListArtists_WithFilters(t *testing.T) {
 			}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil, nil)
+	h := NewArtistHandler(mock, nil, nil, nil)
 
 	resp, err := h.ListArtistsHandler(context.Background(), &ListArtistsRequest{State: "AZ", City: "Phoenix"})
 	if err != nil {
@@ -325,7 +365,7 @@ func TestListArtists_ServiceError(t *testing.T) {
 			return nil, fmt.Errorf("db error")
 		},
 	}
-	h := NewArtistHandler(mock, nil, nil)
+	h := NewArtistHandler(mock, nil, nil, nil)
 
 	_, err := h.ListArtistsHandler(context.Background(), &ListArtistsRequest{})
 	testhelpers.AssertHumaError(t, err, 500)
@@ -344,7 +384,7 @@ func TestGetArtist_ByID(t *testing.T) {
 			return &contracts.ArtistDetailResponse{ID: 42, Name: "Test Artist"}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil, nil)
+	h := NewArtistHandler(mock, nil, nil, nil)
 
 	resp, err := h.GetArtistHandler(context.Background(), &GetArtistRequest{ArtistID: "42"})
 	if err != nil {
@@ -364,7 +404,7 @@ func TestGetArtist_BySlug(t *testing.T) {
 			return &contracts.ArtistDetailResponse{ID: 10, Slug: "the-national"}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil, nil)
+	h := NewArtistHandler(mock, nil, nil, nil)
 
 	resp, err := h.GetArtistHandler(context.Background(), &GetArtistRequest{ArtistID: "the-national"})
 	if err != nil {
@@ -381,7 +421,7 @@ func TestGetArtist_NotFound(t *testing.T) {
 			return nil, apperrors.ErrArtistNotFound(99)
 		},
 	}
-	h := NewArtistHandler(mock, nil, nil)
+	h := NewArtistHandler(mock, nil, nil, nil)
 
 	_, err := h.GetArtistHandler(context.Background(), &GetArtistRequest{ArtistID: "99"})
 	testhelpers.AssertHumaError(t, err, 404)
@@ -393,7 +433,7 @@ func TestGetArtist_ServiceError(t *testing.T) {
 			return nil, fmt.Errorf("db error")
 		},
 	}
-	h := NewArtistHandler(mock, nil, nil)
+	h := NewArtistHandler(mock, nil, nil, nil)
 
 	_, err := h.GetArtistHandler(context.Background(), &GetArtistRequest{ArtistID: "42"})
 	testhelpers.AssertHumaError(t, err, 500)
@@ -412,7 +452,7 @@ func TestGetArtistShows_ByID(t *testing.T) {
 			return []*contracts.ArtistShowResponse{{ID: 100}}, 1, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil, nil)
+	h := NewArtistHandler(mock, nil, nil, nil)
 
 	resp, err := h.GetArtistShowsHandler(context.Background(), &GetArtistShowsRequest{ArtistID: "5", Limit: 20})
 	if err != nil {
@@ -438,7 +478,7 @@ func TestGetArtistShows_BySlug(t *testing.T) {
 			return []*contracts.ArtistShowResponse{{ID: 200}}, 1, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil, nil)
+	h := NewArtistHandler(mock, nil, nil, nil)
 
 	resp, err := h.GetArtistShowsHandler(context.Background(), &GetArtistShowsRequest{ArtistID: "the-national", Limit: 20})
 	if err != nil {
@@ -455,7 +495,7 @@ func TestGetArtistShows_ArtistNotFound(t *testing.T) {
 			return nil, 0, apperrors.ErrArtistNotFound(99)
 		},
 	}
-	h := NewArtistHandler(mock, nil, nil)
+	h := NewArtistHandler(mock, nil, nil, nil)
 
 	_, err := h.GetArtistShowsHandler(context.Background(), &GetArtistShowsRequest{ArtistID: "99", Limit: 20})
 	testhelpers.AssertHumaError(t, err, 404)
@@ -467,7 +507,7 @@ func TestGetArtistShows_ServiceError(t *testing.T) {
 			return nil, 0, fmt.Errorf("db error")
 		},
 	}
-	h := NewArtistHandler(mock, nil, nil)
+	h := NewArtistHandler(mock, nil, nil, nil)
 
 	_, err := h.GetArtistShowsHandler(context.Background(), &GetArtistShowsRequest{ArtistID: "5", Limit: 20})
 	testhelpers.AssertHumaError(t, err, 500)
@@ -486,7 +526,7 @@ func TestDeleteArtist_Success(t *testing.T) {
 			return nil
 		},
 	}
-	h := NewArtistHandler(mock, nil, nil)
+	h := NewArtistHandler(mock, nil, nil, nil)
 	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1})
 
 	_, err := h.DeleteArtistHandler(ctx, &DeleteArtistRequest{ArtistID: "42"})
@@ -501,7 +541,7 @@ func TestDeleteArtist_NotFound(t *testing.T) {
 			return apperrors.ErrArtistNotFound(99)
 		},
 	}
-	h := NewArtistHandler(mock, nil, nil)
+	h := NewArtistHandler(mock, nil, nil, nil)
 	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1})
 
 	_, err := h.DeleteArtistHandler(ctx, &DeleteArtistRequest{ArtistID: "99"})
@@ -514,7 +554,7 @@ func TestDeleteArtist_HasShows(t *testing.T) {
 			return apperrors.ErrArtistHasShows(42, 3)
 		},
 	}
-	h := NewArtistHandler(mock, nil, nil)
+	h := NewArtistHandler(mock, nil, nil, nil)
 	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1})
 
 	_, err := h.DeleteArtistHandler(ctx, &DeleteArtistRequest{ArtistID: "42"})
@@ -527,7 +567,7 @@ func TestDeleteArtist_ServiceError(t *testing.T) {
 			return fmt.Errorf("db error")
 		},
 	}
-	h := NewArtistHandler(mock, nil, nil)
+	h := NewArtistHandler(mock, nil, nil, nil)
 	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1})
 
 	_, err := h.DeleteArtistHandler(ctx, &DeleteArtistRequest{ArtistID: "42"})
@@ -547,7 +587,7 @@ func TestAdminUpdateArtist_Success(t *testing.T) {
 			return &contracts.ArtistDetailResponse{ID: 42, Name: "Updated"}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil, nil)
+	h := NewArtistHandler(mock, nil, nil, nil)
 	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
 	name := "Updated"
 	req := &AdminUpdateArtistRequest{ArtistID: "42"}
@@ -568,7 +608,7 @@ func TestAdminUpdateArtist_NotFound(t *testing.T) {
 			return nil, apperrors.ErrArtistNotFound(99)
 		},
 	}
-	h := NewArtistHandler(mock, nil, nil)
+	h := NewArtistHandler(mock, nil, nil, nil)
 	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
 	name := "Test"
 	req := &AdminUpdateArtistRequest{ArtistID: "99"}
@@ -604,7 +644,7 @@ func TestAdminUpdateArtist_AuditLogCalled(t *testing.T) {
 			}
 		},
 	}
-	h := NewArtistHandler(artistMock, auditMock, nil)
+	h := NewArtistHandler(artistMock, auditMock, nil, nil)
 	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
 	name := "New Name"
 	req := &AdminUpdateArtistRequest{ArtistID: "42"}
@@ -640,7 +680,7 @@ func TestUpdateBandcamp_Success(t *testing.T) {
 			return &contracts.ArtistDetailResponse{ID: 42}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil, nil)
+	h := NewArtistHandler(mock, nil, nil, nil)
 	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
 	url := "https://artist.bandcamp.com/album/cool-album"
 	req := &UpdateArtistBandcampRequest{ArtistID: "42"}
@@ -667,7 +707,7 @@ func TestUpdateBandcamp_ClearURL(t *testing.T) {
 			return &contracts.ArtistDetailResponse{ID: 42}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil, nil)
+	h := NewArtistHandler(mock, nil, nil, nil)
 	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
 	empty := ""
 	req := &UpdateArtistBandcampRequest{ArtistID: "42"}
@@ -695,7 +735,7 @@ func TestUpdateSpotify_Success(t *testing.T) {
 			return &contracts.ArtistDetailResponse{ID: 42}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil, nil)
+	h := NewArtistHandler(mock, nil, nil, nil)
 	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
 	url := "https://open.spotify.com/artist/abc123"
 	req := &UpdateArtistSpotifyRequest{ArtistID: "42"}
@@ -723,7 +763,7 @@ func TestGetArtistCities_Success(t *testing.T) {
 			}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil, nil)
+	h := NewArtistHandler(mock, nil, nil, nil)
 
 	resp, err := h.GetArtistCitiesHandler(context.Background(), &GetArtistCitiesRequest{})
 	if err != nil {
@@ -746,7 +786,7 @@ func TestGetArtistCities_ServiceError(t *testing.T) {
 			return nil, fmt.Errorf("db error")
 		},
 	}
-	h := NewArtistHandler(mock, nil, nil)
+	h := NewArtistHandler(mock, nil, nil, nil)
 
 	_, err := h.GetArtistCitiesHandler(context.Background(), &GetArtistCitiesRequest{})
 	testhelpers.AssertHumaError(t, err, 500)
@@ -758,7 +798,7 @@ func TestGetArtistCities_Empty(t *testing.T) {
 			return []*contracts.ArtistCityResponse{}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil, nil)
+	h := NewArtistHandler(mock, nil, nil, nil)
 
 	resp, err := h.GetArtistCitiesHandler(context.Background(), &GetArtistCitiesRequest{})
 	if err != nil {
@@ -791,7 +831,7 @@ func TestListArtists_WithCitiesFilter(t *testing.T) {
 			}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil, nil)
+	h := NewArtistHandler(mock, nil, nil, nil)
 
 	resp, err := h.ListArtistsHandler(context.Background(), &ListArtistsRequest{Cities: "Phoenix,AZ|Mesa,AZ"})
 	if err != nil {
@@ -815,7 +855,7 @@ func TestListArtists_CitiesOverridesLegacy(t *testing.T) {
 			return []*contracts.ArtistWithShowCountResponse{}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil, nil)
+	h := NewArtistHandler(mock, nil, nil, nil)
 
 	_, err := h.ListArtistsHandler(context.Background(), &ListArtistsRequest{
 		Cities: "Phoenix,AZ",
@@ -849,7 +889,7 @@ func TestGetArtistAliases_Success(t *testing.T) {
 			}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil, nil)
+	h := NewArtistHandler(mock, nil, nil, nil)
 
 	resp, err := h.GetArtistAliasesHandler(context.Background(), &GetArtistAliasesRequest{ArtistID: "42"})
 	if err != nil {
@@ -866,7 +906,7 @@ func TestGetArtistAliases_NotFound(t *testing.T) {
 			return nil, apperrors.ErrArtistNotFound(artistID)
 		},
 	}
-	h := NewArtistHandler(mock, nil, nil)
+	h := NewArtistHandler(mock, nil, nil, nil)
 
 	_, err := h.GetArtistAliasesHandler(context.Background(), &GetArtistAliasesRequest{ArtistID: "99"})
 	testhelpers.AssertHumaError(t, err, 404)
@@ -901,7 +941,7 @@ func TestAddArtistAlias_Success(t *testing.T) {
 			return &contracts.ArtistAliasResponse{ID: 1, ArtistID: 42, Alias: alias}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil, nil)
+	h := NewArtistHandler(mock, nil, nil, nil)
 	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
 	req := &AddArtistAliasRequest{ArtistID: "42"}
 	req.Body.Alias = "New Alias"
@@ -921,7 +961,7 @@ func TestAddArtistAlias_Conflict(t *testing.T) {
 			return nil, fmt.Errorf("alias 'Test' already exists")
 		},
 	}
-	h := NewArtistHandler(mock, nil, nil)
+	h := NewArtistHandler(mock, nil, nil, nil)
 	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
 	req := &AddArtistAliasRequest{ArtistID: "42"}
 	req.Body.Alias = "Test"
@@ -946,7 +986,7 @@ func TestDeleteArtistAlias_Success(t *testing.T) {
 			return nil
 		},
 	}
-	h := NewArtistHandler(mock, nil, nil)
+	h := NewArtistHandler(mock, nil, nil, nil)
 	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
 
 	_, err := h.DeleteArtistAliasHandler(ctx, &DeleteArtistAliasRequest{ArtistID: "1", AliasID: "5"})
@@ -961,7 +1001,7 @@ func TestDeleteArtistAlias_NotFound(t *testing.T) {
 			return fmt.Errorf("alias not found")
 		},
 	}
-	h := NewArtistHandler(mock, nil, nil)
+	h := NewArtistHandler(mock, nil, nil, nil)
 	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
 
 	_, err := h.DeleteArtistAliasHandler(ctx, &DeleteArtistAliasRequest{ArtistID: "1", AliasID: "99"})
@@ -985,7 +1025,7 @@ func TestMergeArtists_SelfMerge(t *testing.T) {
 			return nil, fmt.Errorf("cannot merge an artist with itself")
 		},
 	}
-	h := NewArtistHandler(mock, nil, nil)
+	h := NewArtistHandler(mock, nil, nil, nil)
 	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
 	req := &MergeArtistsRequest{}
 	req.Body.CanonicalArtistID = 5
@@ -1013,7 +1053,7 @@ func TestMergeArtists_Success(t *testing.T) {
 			}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil, nil)
+	h := NewArtistHandler(mock, nil, nil, nil)
 	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
 	req := &MergeArtistsRequest{}
 	req.Body.CanonicalArtistID = 1
@@ -1037,7 +1077,7 @@ func TestMergeArtists_NotFound(t *testing.T) {
 			return nil, apperrors.ErrArtistNotFound(canonicalID)
 		},
 	}
-	h := NewArtistHandler(mock, nil, nil)
+	h := NewArtistHandler(mock, nil, nil, nil)
 	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
 	req := &MergeArtistsRequest{}
 	req.Body.CanonicalArtistID = 99
@@ -1066,7 +1106,7 @@ func TestAdminCreateArtist_Success(t *testing.T) {
 			return &contracts.ArtistDetailResponse{ID: 42, Name: "New Artist", Slug: "new-artist"}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil, nil)
+	h := NewArtistHandler(mock, nil, nil, nil)
 	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
 	req := &AdminCreateArtistRequest{}
 	req.Body.Name = "New Artist"
@@ -1108,7 +1148,7 @@ func TestAdminCreateArtist_WithSocials(t *testing.T) {
 			return &contracts.ArtistDetailResponse{ID: 43, Name: "Social Artist"}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil, nil)
+	h := NewArtistHandler(mock, nil, nil, nil)
 	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
 	req := &AdminCreateArtistRequest{}
 	req.Body.Name = "Social Artist"
@@ -1136,7 +1176,7 @@ func TestAdminCreateArtist_Conflict(t *testing.T) {
 			return nil, fmt.Errorf("artist with name 'Existing' already exists")
 		},
 	}
-	h := NewArtistHandler(mock, nil, nil)
+	h := NewArtistHandler(mock, nil, nil, nil)
 	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
 	req := &AdminCreateArtistRequest{}
 	req.Body.Name = "Existing"
@@ -1151,7 +1191,7 @@ func TestAdminCreateArtist_ServiceError(t *testing.T) {
 			return nil, fmt.Errorf("db error")
 		},
 	}
-	h := NewArtistHandler(mock, nil, nil)
+	h := NewArtistHandler(mock, nil, nil, nil)
 	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
 	req := &AdminCreateArtistRequest{}
 	req.Body.Name = "Test"
@@ -1187,7 +1227,7 @@ func TestAdminCreateArtist_AuditLogCalled(t *testing.T) {
 			}
 		},
 	}
-	h := NewArtistHandler(artistMock, auditMock, nil)
+	h := NewArtistHandler(artistMock, auditMock, nil, nil)
 	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
 	req := &AdminCreateArtistRequest{}
 	req.Body.Name = "Audit Test Artist"
@@ -1211,7 +1251,7 @@ func TestDeleteArtist_ZeroID(t *testing.T) {
 			return apperrors.ErrArtistNotFound(id)
 		},
 	}
-	h := NewArtistHandler(mock, nil, nil)
+	h := NewArtistHandler(mock, nil, nil, nil)
 	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
 	_, err := h.DeleteArtistHandler(ctx, &DeleteArtistRequest{ArtistID: "0"})
 	testhelpers.AssertHumaError(t, err, 404)
@@ -1230,7 +1270,7 @@ func TestAdminUpdateArtist_ZeroID(t *testing.T) {
 			return nil, apperrors.ErrArtistNotFound(id)
 		},
 	}
-	h := NewArtistHandler(mock, nil, nil)
+	h := NewArtistHandler(mock, nil, nil, nil)
 	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
 	req := &AdminUpdateArtistRequest{ArtistID: "0"}
 	name := "Test Name"
@@ -1245,7 +1285,7 @@ func TestAdminUpdateArtist_VeryLargeID(t *testing.T) {
 			return nil, apperrors.ErrArtistNotFound(id)
 		},
 	}
-	h := NewArtistHandler(mock, nil, nil)
+	h := NewArtistHandler(mock, nil, nil, nil)
 	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
 	req := &AdminUpdateArtistRequest{ArtistID: "4294967295"}
 	name := "Test Name"
@@ -1273,7 +1313,7 @@ func TestAdminCreateArtist_NameTrimmed(t *testing.T) {
 			return &contracts.ArtistDetailResponse{ID: 44, Name: "Trimmed Name"}, nil
 		},
 	}
-	h := NewArtistHandler(mock, nil, nil)
+	h := NewArtistHandler(mock, nil, nil, nil)
 	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
 	req := &AdminCreateArtistRequest{}
 	req.Body.Name = "  Trimmed Name  "

--- a/backend/internal/api/routes/admin.go
+++ b/backend/internal/api/routes/admin.go
@@ -26,7 +26,7 @@ func setupAdminRoutes(rc RouteContext) {
 	dataHandler := adminh.NewAdminDataHandler(rc.SC.DataSync)
 	discoveryHandler := pipelineh.NewAdminDiscoveryHandler(rc.SC.Discovery)
 
-	artistHandler := catalogh.NewArtistHandler(rc.SC.Artist, rc.SC.AuditLog, rc.SC.Revision)
+	artistHandler := catalogh.NewArtistHandler(rc.SC.Artist, rc.SC.AuditLog, rc.SC.Revision, rc.Cfg)
 	auditLogHandler := adminh.NewAuditLogHandler(rc.SC.AuditLog)
 
 	// Admin dashboard stats endpoint

--- a/backend/internal/api/routes/artists.go
+++ b/backend/internal/api/routes/artists.go
@@ -7,7 +7,7 @@ import (
 )
 
 func setupArtistRoutes(rc RouteContext) {
-	artistHandler := catalogh.NewArtistHandler(rc.SC.Artist, rc.SC.AuditLog, rc.SC.Revision)
+	artistHandler := catalogh.NewArtistHandler(rc.SC.Artist, rc.SC.AuditLog, rc.SC.Revision, rc.Cfg)
 
 	// Public artist endpoints - registered on main API without middleware
 	// Note: Static routes must come before parameterized routes

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -389,6 +389,11 @@ var placeholderSecrets = []string{
 	"your-super-secret-jwt-key-32-chars-minimum",
 }
 
+// minInternalAPISecretLength is the minimum length required for INTERNAL_API_SECRET
+// in deployed environments. It guards the admin-bypass path on the artist
+// Bandcamp/Spotify mutation endpoints against weak or unset secrets.
+const minInternalAPISecretLength = 32
+
 // Validate checks that security-critical secrets are not placeholder defaults.
 // Skips validation only for explicit "development" environment or local database URLs.
 func (c *Config) Validate() error {
@@ -417,6 +422,16 @@ func (c *Config) Validate() error {
 		if c.OAuth.SecretKey == placeholder {
 			return fmt.Errorf("OAUTH_SECRET_KEY is using a placeholder default; set a unique secret for %s", env)
 		}
+	}
+
+	// The internal API secret bypasses the admin requirement on the artist
+	// Bandcamp/Spotify mutation paths, so a weak or unset value is a privilege
+	// escalation risk. Require a non-trivial secret in deployed environments.
+	if len(c.MusicDiscovery.InternalAPISecret) < minInternalAPISecretLength {
+		return fmt.Errorf(
+			"INTERNAL_API_SECRET must be set and at least %d characters for %s",
+			minInternalAPISecretLength, env,
+		)
 	}
 
 	return nil

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -426,12 +426,16 @@ func (c *Config) Validate() error {
 
 	// The internal API secret bypasses the admin requirement on the artist
 	// Bandcamp/Spotify mutation paths, so a weak or unset value is a privilege
-	// escalation risk. Require a non-trivial secret in deployed environments.
-	if len(c.MusicDiscovery.InternalAPISecret) < minInternalAPISecretLength {
-		return fmt.Errorf(
-			"INTERNAL_API_SECRET must be set and at least %d characters for %s",
-			minInternalAPISecretLength, env,
-		)
+	// escalation risk in a real deployment. Only enforce for production/stage:
+	// test/CI run with the bypass disabled (an empty secret never matches in
+	// the constant-time compare), so they need not supply it.
+	if env == EnvProduction || env == EnvStage {
+		if len(c.MusicDiscovery.InternalAPISecret) < minInternalAPISecretLength {
+			return fmt.Errorf(
+				"INTERNAL_API_SECRET must be set and at least %d characters for %s",
+				minInternalAPISecretLength, env,
+			)
+		}
 	}
 
 	return nil

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -465,6 +465,22 @@ func TestValidate(t *testing.T) {
 			t.Error("expected error for unset internal API secret in stage, got nil")
 		}
 	})
+
+	t.Run("test env does not require internal API secret", func(t *testing.T) {
+		// The E2E/CI backend boots with ENVIRONMENT=test and does not supply
+		// INTERNAL_API_SECRET; the admin-bypass path stays disabled there. The
+		// secret must only be required for production/stage, or the test backend
+		// fails to boot and the E2E smoke suite times out.
+		t.Setenv("ENVIRONMENT", "test")
+		cfg := &Config{
+			JWT:   JWTConfig{SecretKey: "e2e-jwt-secret-key-for-testing-only"},
+			OAuth: OAuthConfig{SecretKey: "e2e-oauth-secret-key-for-testing-only"},
+			// MusicDiscovery.InternalAPISecret deliberately unset
+		}
+		if err := cfg.Validate(); err != nil {
+			t.Errorf("expected nil error in test env without internal API secret, got: %v", err)
+		}
+	})
 }
 
 // --- getFrontendURL tests ---

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -422,11 +422,47 @@ func TestValidate(t *testing.T) {
 	t.Run("production with real secrets passes", func(t *testing.T) {
 		t.Setenv("ENVIRONMENT", "production")
 		cfg := &Config{
-			JWT:   JWTConfig{SecretKey: "a-real-production-jwt-secret-key"},
-			OAuth: OAuthConfig{SecretKey: "a-real-production-oauth-secret"},
+			JWT:            JWTConfig{SecretKey: "a-real-production-jwt-secret-key"},
+			OAuth:          OAuthConfig{SecretKey: "a-real-production-oauth-secret"},
+			MusicDiscovery: MusicDiscoveryConfig{InternalAPISecret: "a-real-internal-api-secret-32+chars"},
 		}
 		if err := cfg.Validate(); err != nil {
 			t.Errorf("expected nil error with real secrets, got: %v", err)
+		}
+	})
+
+	t.Run("production with unset internal API secret errors", func(t *testing.T) {
+		t.Setenv("ENVIRONMENT", "production")
+		cfg := &Config{
+			JWT:   JWTConfig{SecretKey: "a-real-production-jwt-secret-key"},
+			OAuth: OAuthConfig{SecretKey: "a-real-production-oauth-secret"},
+			// MusicDiscovery.InternalAPISecret deliberately unset
+		}
+		if err := cfg.Validate(); err == nil {
+			t.Error("expected error for unset internal API secret, got nil")
+		}
+	})
+
+	t.Run("production with short internal API secret errors", func(t *testing.T) {
+		t.Setenv("ENVIRONMENT", "production")
+		cfg := &Config{
+			JWT:            JWTConfig{SecretKey: "a-real-production-jwt-secret-key"},
+			OAuth:          OAuthConfig{SecretKey: "a-real-production-oauth-secret"},
+			MusicDiscovery: MusicDiscoveryConfig{InternalAPISecret: "too-short"},
+		}
+		if err := cfg.Validate(); err == nil {
+			t.Error("expected error for sub-32-char internal API secret, got nil")
+		}
+	})
+
+	t.Run("stage with unset internal API secret errors", func(t *testing.T) {
+		t.Setenv("ENVIRONMENT", "stage")
+		cfg := &Config{
+			JWT:   JWTConfig{SecretKey: "a-real-stage-jwt-secret-key"},
+			OAuth: OAuthConfig{SecretKey: "a-real-stage-oauth-secret"},
+		}
+		if err := cfg.Validate(); err == nil {
+			t.Error("expected error for unset internal API secret in stage, got nil")
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- `INTERNAL_API_SECRET` now flows through `config.Config` (loaded once at startup as `cfg.MusicDiscovery.InternalAPISecret`) and is stored on `ArtistHandler` instead of being re-read from `os.Getenv` on every request.
- Both inline secret comparisons (Bandcamp + Spotify update handlers) now go through `ArtistHandler.matchesInternalSecret`, which uses `crypto/subtle.ConstantTimeCompare` gated on a non-empty configured secret. This closes a timing oracle: these endpoints sit on `rc.Protected` (not `rc.Admin`) precisely because a match grants an admin-equivalent bypass, so a non-constant-time `==` was a privilege-escalation vector.
- Deleted the unused `isInternalServiceRequest` helper (the third, dead, comparison site).
- `Config.Validate()` now rejects an unset or sub-32-char secret in `production`/`stage`.

Note: the ticket proposed adding a new `config.Config.InternalAPISecret` field, but the secret was already loaded into `cfg.MusicDiscovery.InternalAPISecret`. Reused the existing field rather than adding a duplicate (same env var, single source of truth).

## Test plan
- [x] `cd backend && go build ./...` — clean (constructor signature change ripples to all call sites; build confirms none missed)
- [x] `cd backend && go test ./...` — full suite passes (exit 0)
- [x] `cd backend && go test ./internal/api/handlers/catalog/... ./internal/config/...` — pass (incl. DB-backed integration suite)
- [x] `go vet` on changed packages — clean

## Manual repro
`TestMatchesInternalSecret` (`internal/api/handlers/catalog/artist_test.go`) is the repro: with a configured 35-char secret it asserts the matching secret is accepted (`matchesInternalSecret(secret)` true), a wrong secret is rejected, an empty provided secret is rejected, and an unset configured secret (nil config) never matches any input. `TestValidate` adds three subtests asserting `Config.Validate()` returns an error for an unset secret (production + stage) and a sub-32-char secret. All pass.

## Simplify
Ran `/simplify` (3-lens review). No edits needed — reused the existing config field/`Validate()` rather than duplicating, extracted the `32` threshold to a named constant, comments carry only security WHY, no ticket refs, deleted dead code, and the hot path now reads a struct field instead of a per-request `os.Getenv` syscall.

Closes PSY-745