### PR TITLE
PSY-746: stop Sentry middleware leaking secrets + plaintext email

### DIFF
--- a/backend/internal/api/middleware/sentry.go
+++ b/backend/internal/api/middleware/sentry.go
@@ -21,20 +21,23 @@ func HumaSentryContextMiddleware(ctx huma.Context, next func(huma.Context)) {
 				scope.SetTag("request_id", reqID)
 			}
 
-			// HTTP context
+			// HTTP context. The raw query string is deliberately NOT
+			// tagged: secret-bearing routes (magic-link ?token=, digest
+			// unsubscribe ?sig=) would otherwise land in searchable Sentry
+			// retention. Sentry's default request integration still captures
+			// the full URL, so method+path remain sufficient for triage.
 			scope.SetTag("http.method", ctx.Method())
 			scope.SetTag("http.path", ctx.URL().Path)
-			if q := ctx.URL().RawQuery; q != "" {
-				scope.SetTag("http.query", q)
-			}
 
-			// User context (nil if not authenticated yet)
+			// User context (nil if not authenticated yet). Email is masked
+			// via logger.HashEmail so the observability tier never holds
+			// plaintext addresses; ID + masked email keep events correlatable.
 			if user := GetUserFromContext(ctx.Context()); user != nil {
 				sentryUser := sentry.User{
 					ID: fmt.Sprintf("%d", user.ID),
 				}
 				if user.Email != nil {
-					sentryUser.Email = *user.Email
+					sentryUser.Email = logger.HashEmail(*user.Email)
 				}
 				scope.SetUser(sentryUser)
 				scope.SetTag("user.is_admin", fmt.Sprintf("%t", user.IsAdmin))

--- a/backend/internal/api/middleware/sentry_test.go
+++ b/backend/internal/api/middleware/sentry_test.go
@@ -1,0 +1,140 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/humatest"
+	"github.com/getsentry/sentry-go"
+
+	"psychic-homily-backend/internal/logger"
+	authm "psychic-homily-backend/internal/models/auth"
+)
+
+// captureWithMiddleware runs HumaSentryContextMiddleware against req with a
+// Sentry hub whose client's BeforeSend hook captures the serialized event.
+// Triggering CaptureException through the same hub applies the scope the
+// middleware configured, so the returned event reflects the tags/user it set.
+func captureWithMiddleware(t *testing.T, req *http.Request) *sentry.Event {
+	t.Helper()
+
+	var captured *sentry.Event
+	client, err := sentry.NewClient(sentry.ClientOptions{
+		// No DSN: BeforeSend still runs, but nothing leaves the process.
+		BeforeSend: func(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
+			captured = event
+			return nil // drop — we only need the serialized shape
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to create sentry test client: %v", err)
+	}
+	hub := sentry.NewHub(client, sentry.NewScope())
+	reqWithHub := req.WithContext(sentry.SetHubOnContext(req.Context(), hub))
+	rr := httptest.NewRecorder()
+	ctx := humatest.NewContext(nil, reqWithHub, rr)
+
+	HumaSentryContextMiddleware(ctx, func(huma.Context) {})
+
+	hub.CaptureException(errors.New("boom"))
+	if captured == nil {
+		t.Fatal("expected an event to be captured")
+	}
+	return captured
+}
+
+func userPtr(s string) *string { return &s }
+
+// --- HumaSentryContextMiddleware tests ---
+
+func TestHumaSentryContextMiddleware_DropsRawQueryTag(t *testing.T) {
+	// A magic-link request with a secret token in the query string.
+	req := httptest.NewRequest(http.MethodGet, "/auth/magic-link?token=supersecretjwt", nil)
+	captured := captureWithMiddleware(t, req)
+
+	// The raw query tag must be absent.
+	if v, ok := captured.Tags["http.query"]; ok {
+		t.Errorf("http.query tag should be dropped, got %q", v)
+	}
+
+	// Path tag must still be present and must not carry the secret.
+	if got := captured.Tags["http.path"]; got != "/auth/magic-link" {
+		t.Errorf("http.path = %q, want %q", got, "/auth/magic-link")
+	}
+	if got := captured.Tags["http.method"]; got != http.MethodGet {
+		t.Errorf("http.method = %q, want GET", got)
+	}
+
+	// Defense in depth: no tag value anywhere should contain the secret.
+	for k, v := range captured.Tags {
+		if v == "supersecretjwt" || (len(v) > 0 && contains(v, "supersecretjwt")) {
+			t.Errorf("tag %q leaks the secret token: %q", k, v)
+		}
+	}
+}
+
+func TestHumaSentryContextMiddleware_HashesUserEmail(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/me", nil)
+
+	email := "matt.trifilo@gmail.com"
+	user := &authm.User{ID: 42, Email: userPtr(email), IsAdmin: true}
+	reqWithUser := req.WithContext(
+		context.WithValue(req.Context(), UserContextKey, user),
+	)
+	captured := captureWithMiddleware(t, reqWithUser)
+
+	// Email must be masked, never plaintext.
+	if captured.User.Email == email {
+		t.Errorf("user email is plaintext %q, want masked", captured.User.Email)
+	}
+	want := logger.HashEmail(email)
+	if captured.User.Email != want {
+		t.Errorf("user email = %q, want masked %q", captured.User.Email, want)
+	}
+
+	// ID must still be present so events remain correlatable by user.
+	if captured.User.ID != "42" {
+		t.Errorf("user ID = %q, want %q", captured.User.ID, "42")
+	}
+	if got := captured.Tags["user.is_admin"]; got != "true" {
+		t.Errorf("user.is_admin = %q, want true", got)
+	}
+}
+
+func TestHumaSentryContextMiddleware_NoUserNoEmailTag(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/public", nil)
+	captured := captureWithMiddleware(t, req)
+
+	if !captured.User.IsEmpty() {
+		t.Errorf("user should be empty for unauthenticated request, got %+v", captured.User)
+	}
+	if v, ok := captured.Tags["http.query"]; ok {
+		t.Errorf("http.query tag should be dropped, got %q", v)
+	}
+}
+
+func TestHumaSentryContextMiddleware_CallsNext(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+	rr := httptest.NewRecorder()
+	ctx := humatest.NewContext(nil, req, rr)
+
+	called := false
+	HumaSentryContextMiddleware(ctx, func(huma.Context) { called = true })
+
+	if !called {
+		t.Error("next handler was not called")
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/api/middleware/sentry_test.go
+++ b/backend/internal/api/middleware/sentry_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -47,8 +48,6 @@ func captureWithMiddleware(t *testing.T, req *http.Request) *sentry.Event {
 	return captured
 }
 
-func userPtr(s string) *string { return &s }
-
 // --- HumaSentryContextMiddleware tests ---
 
 func TestHumaSentryContextMiddleware_DropsRawQueryTag(t *testing.T) {
@@ -71,7 +70,7 @@ func TestHumaSentryContextMiddleware_DropsRawQueryTag(t *testing.T) {
 
 	// Defense in depth: no tag value anywhere should contain the secret.
 	for k, v := range captured.Tags {
-		if v == "supersecretjwt" || (len(v) > 0 && contains(v, "supersecretjwt")) {
+		if strings.Contains(v, "supersecretjwt") {
 			t.Errorf("tag %q leaks the secret token: %q", k, v)
 		}
 	}
@@ -81,7 +80,7 @@ func TestHumaSentryContextMiddleware_HashesUserEmail(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/me", nil)
 
 	email := "matt.trifilo@gmail.com"
-	user := &authm.User{ID: 42, Email: userPtr(email), IsAdmin: true}
+	user := &authm.User{ID: 42, Email: strPtr(email), IsAdmin: true}
 	reqWithUser := req.WithContext(
 		context.WithValue(req.Context(), UserContextKey, user),
 	)
@@ -128,13 +127,4 @@ func TestHumaSentryContextMiddleware_CallsNext(t *testing.T) {
 	if !called {
 		t.Error("next handler was not called")
 	}
-}
-
-func contains(s, sub string) bool {
-	for i := 0; i+len(sub) <= len(s); i++ {
-		if s[i:i+len(sub)] == sub {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
## Summary
- Drop the `http.query` Sentry tag entirely. Secret-bearing routes (`/auth/magic-link?token=`, `/unsubscribe/collection-digest?sig=`) were tagging magic-link JWTs and HMAC signatures into searchable Sentry retention. Sentry's default request integration already captures the full URL, so `http.method` + `http.path` remain sufficient for triage and there is no scrub-list to maintain.
- Mask the authenticated user's email via the existing `logger.HashEmail` instead of attaching plaintext. Events stay correlatable by user ID + masked email (`ma***@gmail.com`).
- Audited the sibling Sentry scopes — the `sentryhttp` chi entrypoint (`cmd/server/main.go`) sets no tags itself, and the panic handler + service-layer notification/discovery scopes only set categorical tags (`service`, `email_type`, `status_code`, `stack`). No secret-bearing path/header/body values found, so no further remediation was needed.

## Test plan
- [x] `cd backend && go build ./...`
- [x] `cd backend && go test ./internal/api/middleware/...`
- [x] `cd backend && go test ./...` (full suite, all packages `ok`)
- [x] `go vet ./internal/api/middleware/...`

## Manual repro
New unit tests in `backend/internal/api/middleware/sentry_test.go` exercise the middleware via a real Sentry client with a `BeforeSend` hook, then capture an event through the bound hub and assert on the serialized tags/user:
- `TestHumaSentryContextMiddleware_DropsRawQueryTag` — fires `/auth/magic-link?token=supersecretjwt`; asserts `http.query` is absent, `http.path` == `/auth/magic-link`, and no tag value contains the secret token.
- `TestHumaSentryContextMiddleware_HashesUserEmail` — asserts `event.User.Email` equals `logger.HashEmail(email)` (never plaintext) and `event.User.ID` is preserved.

Verified the tests are real repros (not vacuous): temporarily reintroducing the leak made both fail with `http.query tag should be dropped, got "token=supersecretjwt"` and `user email is plaintext "matt.trifilo@gmail.com"`; reverting made them pass.

## Simplify
`/simplify` (inline 3-lens review, Agent tool disallowed in this flow): reused stdlib `strings.Contains` for the secret-leak guard (dropped a hand-rolled substring scan + redundant exact-match condition) and dropped a duplicate `userPtr` helper in favor of the package's existing `strPtr` (`jwt_test.go`). Committed separately; middleware tests + vet re-run green.

Closes PSY-746