### PR TITLE
PSY-760: delegate user-name resolution to canonical resolver

### DIFF
--- a/backend/internal/services/admin/stats.go
+++ b/backend/internal/services/admin/stats.go
@@ -14,6 +14,7 @@ import (
 	catalogm "psychic-homily-backend/internal/models/catalog"
 	communitym "psychic-homily-backend/internal/models/community"
 	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/services/shared"
 )
 
 // AdminStatsService handles admin dashboard statistics
@@ -161,7 +162,7 @@ func (s *AdminStatsService) GetRecentActivity() (*contracts.ActivityFeedResponse
 			Timestamp:   log.CreatedAt,
 		}
 		if log.Actor != nil {
-			event.ActorName = resolveActorName(log.Actor)
+			event.ActorName = shared.ResolveUserName(log.Actor)
 		}
 		event.EntitySlug = s.resolveEntitySlug(log.EntityType, log.EntityID)
 		events = append(events, event)
@@ -179,7 +180,7 @@ func (s *AdminStatsService) GetRecentActivity() (*contracts.ActivityFeedResponse
 			Timestamp:   log.CreatedAt,
 		}
 		if log.Actor != nil {
-			event.ActorName = resolveActorName(log.Actor)
+			event.ActorName = shared.ResolveUserName(log.Actor)
 		}
 		event.EntitySlug = s.resolveEntitySlug(log.EntityType, log.EntityID)
 		events = append(events, event)
@@ -335,20 +336,6 @@ func normalizeEntityType(entityType string) string {
 		return normalized
 	}
 	return entityType
-}
-
-// resolveActorName returns a display name from a User model.
-func resolveActorName(user *authm.User) string {
-	if user.FirstName != nil && user.LastName != nil && *user.FirstName != "" {
-		return *user.FirstName + " " + *user.LastName
-	}
-	if user.Username != nil && *user.Username != "" {
-		return *user.Username
-	}
-	if user.Email != nil && *user.Email != "" {
-		return *user.Email
-	}
-	return "Unknown"
 }
 
 // resolveEntitySlug looks up the slug for an entity. Returns empty string if not found.

--- a/backend/internal/services/admin/stats_test.go
+++ b/backend/internal/services/admin/stats_test.go
@@ -406,6 +406,53 @@ func (suite *AdminStatsServiceIntegrationTestSuite) TestGetRecentActivity_ActorN
 	suite.Equal("cooluser", feed.Events[0].ActorName)
 }
 
+// PSY-760: actor name now delegates to the canonical shared.ResolveUserName
+// chain, which prefers username over first/last name. Previously this surface
+// showed "FirstName LastName" first — this asserts the intended user-visible
+// reordering.
+func (suite *AdminStatsServiceIntegrationTestSuite) TestGetRecentActivity_ActorNamePrefersUsername() {
+	firstName := "Jane"
+	lastName := "Doe"
+	username := "jdoe_dj"
+	email := "jane@test.com"
+	user := &authm.User{
+		Email:     &email,
+		Username:  &username,
+		FirstName: &firstName,
+		LastName:  &lastName,
+		IsActive:  true,
+	}
+	err := suite.db.Create(user).Error
+	suite.Require().NoError(err)
+
+	suite.createAuditLog(user.ID, "approve_show", "show", 1)
+
+	feed, err := suite.service.GetRecentActivity()
+	suite.Require().NoError(err)
+	suite.Require().Len(feed.Events, 1)
+	suite.Equal("jdoe_dj", feed.Events[0].ActorName)
+}
+
+// PSY-760: a raw email address must never surface as the actor display string.
+// A user with only an email resolves to its local-part, not the full address.
+func (suite *AdminStatsServiceIntegrationTestSuite) TestGetRecentActivity_ActorNameNeverLeaksRawEmail() {
+	email := "secret.person@private.example.com"
+	user := &authm.User{
+		Email:    &email,
+		IsActive: true,
+	}
+	err := suite.db.Create(user).Error
+	suite.Require().NoError(err)
+
+	suite.createAuditLog(user.ID, "approve_show", "show", 1)
+
+	feed, err := suite.service.GetRecentActivity()
+	suite.Require().NoError(err)
+	suite.Require().Len(feed.Events, 1)
+	suite.Equal("secret.person", feed.Events[0].ActorName)
+	suite.NotContains(feed.Events[0].ActorName, "@", "actor name must not leak a raw email")
+}
+
 func (suite *AdminStatsServiceIntegrationTestSuite) TestGetRecentActivity_UnknownActionFallback() {
 	user := suite.createUser("admin@test.com")
 	suite.createAuditLog(user.ID, "some_new_action", "widget", 42)

--- a/backend/internal/services/notification/discord.go
+++ b/backend/internal/services/notification/discord.go
@@ -14,6 +14,7 @@ import (
 	authm "psychic-homily-backend/internal/models/auth"
 	communitym "psychic-homily-backend/internal/models/community"
 	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/services/shared"
 )
 
 // Discord embed colors
@@ -465,25 +466,18 @@ func HashEmail(email string) string {
 	return local[:2] + "***@" + domain
 }
 
-// buildUserName builds a display name from user fields
+// buildUserName builds a display name from user fields.
+//
+// Thin wrapper over the canonical shared.ResolveUserName chain (username →
+// first/last → email-prefix → anonymous). The only Discord-specific twist is
+// the terminal label: where the canonical chain yields its anonymous sentinel,
+// this surface shows "Not provided" to match the embed's other empty-field copy.
 func buildUserName(user *authm.User) string {
-	if user == nil {
-		return "N/A"
-	}
-
-	var parts []string
-	if user.FirstName != nil && *user.FirstName != "" {
-		parts = append(parts, *user.FirstName)
-	}
-	if user.LastName != nil && *user.LastName != "" {
-		parts = append(parts, *user.LastName)
-	}
-
-	if len(parts) == 0 {
+	name := shared.ResolveUserName(user)
+	if name == shared.AnonymousUserName {
 		return "Not provided"
 	}
-
-	return strings.Join(parts, " ")
+	return name
 }
 
 // buildVenueList builds a comma-separated list of venue names

--- a/backend/internal/services/notification/discord_test.go
+++ b/backend/internal/services/notification/discord_test.go
@@ -164,22 +164,37 @@ func TestHashEmail(t *testing.T) {
 	}
 }
 
+// buildUserName is a thin wrapper over the canonical shared.ResolveUserName
+// chain (username → first/last → email-prefix), substituting the Discord-only
+// "Not provided" label for the chain's anonymous sentinel. Fixtures set ID: 1
+// because the canonical resolver short-circuits ID-0 users to anonymous, and
+// in production every user reaching this path comes from the DB with a real ID.
 func TestBuildUserName(t *testing.T) {
 	tests := []struct {
 		name string
 		user *authm.User
 		want string
 	}{
-		{"full name", &authm.User{FirstName: stringPtr("John"), LastName: stringPtr("Doe")}, "John Doe"},
-		{"first only", &authm.User{FirstName: stringPtr("Jane")}, "Jane"},
-		{"last only", &authm.User{LastName: stringPtr("Smith")}, "Smith"},
-		{"neither", &authm.User{}, "Not provided"},
-		{"nil user", nil, "N/A"},
-		{"empty strings", &authm.User{FirstName: stringPtr(""), LastName: stringPtr("")}, "Not provided"},
+		// Canonical chain: username wins over first/last and over email.
+		{"prefers username", &authm.User{ID: 1, Username: stringPtr("dj_cool"), FirstName: stringPtr("John"), LastName: stringPtr("Doe"), Email: stringPtr("john@example.com")}, "dj_cool"},
+		{"full name when no username", &authm.User{ID: 1, FirstName: stringPtr("John"), LastName: stringPtr("Doe")}, "John Doe"},
+		{"first only", &authm.User{ID: 1, FirstName: stringPtr("Jane")}, "Jane"},
+		// Email is only ever shown as its local-part (never the full address).
+		{"email prefix, not full email", &authm.User{ID: 1, Email: stringPtr("solo@example.com")}, "solo"},
+		// Chain bottoms out → Discord-specific terminal label.
+		{"neither", &authm.User{ID: 1}, "Not provided"},
+		{"empty strings", &authm.User{ID: 1, FirstName: stringPtr(""), LastName: stringPtr("")}, "Not provided"},
+		{"nil user", nil, "Not provided"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, buildUserName(tt.user))
+			got := buildUserName(tt.user)
+			assert.Equal(t, tt.want, got)
+			// Regression guard for PSY-760: a raw email address must never
+			// surface as the display string outside the canonical chain.
+			if tt.user != nil && tt.user.Email != nil {
+				assert.NotContains(t, got, "@", "buildUserName must not leak a raw email")
+			}
 		})
 	}
 }
@@ -346,7 +361,10 @@ func TestNotifyNewUser_NilUser(t *testing.T) {
 	assertNoPayload(t, payloads)
 }
 
-func TestNotifyNewUser_NoName(t *testing.T) {
+// PSY-760: a username-less, name-less signup now resolves through the canonical
+// chain's email-prefix step (the local-part only — never the full address). This
+// replaced the old "Not provided" output for users that have an email on file.
+func TestNotifyNewUser_NoName_FallsBackToEmailPrefix(t *testing.T) {
 	svc, payloads, _ := setupDiscordTest(t)
 	email := "anon@example.com"
 	user := &authm.User{ID: 1, Email: &email}
@@ -355,7 +373,22 @@ func TestNotifyNewUser_NoName(t *testing.T) {
 
 	raw := waitForPayload(t, payloads)
 	payload := parseWebhookPayload(t, raw)
-	// Name field should say "Not provided"
+	nameField := payload.Embeds[0].Fields[2]
+	assert.Equal(t, "Name", nameField.Name)
+	assert.Equal(t, "anon", nameField.Value)
+	assert.NotContains(t, nameField.Value, "@", "Discord embed must not leak a raw email")
+}
+
+// "Not provided" is still the terminal label when the canonical chain bottoms
+// out entirely (no username, no name, no usable email).
+func TestNotifyNewUser_NoIdentifiers_NotProvided(t *testing.T) {
+	svc, payloads, _ := setupDiscordTest(t)
+	user := &authm.User{ID: 1}
+
+	svc.NotifyNewUser(user)
+
+	raw := waitForPayload(t, payloads)
+	payload := parseWebhookPayload(t, raw)
 	nameField := payload.Embeds[0].Fields[2]
 	assert.Equal(t, "Name", nameField.Name)
 	assert.Equal(t, "Not provided", nameField.Value)

--- a/backend/internal/services/shared/user_resolver.go
+++ b/backend/internal/services/shared/user_resolver.go
@@ -20,22 +20,30 @@ import (
 	authm "psychic-homily-backend/internal/models/auth"
 )
 
+// AnonymousUserName is the terminal label ResolveUserName returns when a user
+// has no username, name, or email to resolve (and for nil / ID-0 users).
+//
+// Exported so surfaces that layer their own channel-specific empty-state copy
+// (e.g. a Discord embed's "Not provided") can detect "the chain bottomed out"
+// without re-deriving the chain or hardcoding the sentinel string.
+const AnonymousUserName = "Anonymous"
+
 // ResolveUserName returns the display name for a user. Never empty.
 //
 // Resolution chain, in order:
 //  1. user.Username                            (preferred, also the URL slug)
 //  2. user.FirstName [+ " " + user.LastName]   (human full name)
 //  3. local-part of user.Email (before "@")    (last-resort handle)
-//  4. "Anonymous"                              (terminal fallback)
+//  4. AnonymousUserName                        (terminal fallback)
 //
-// nil-safe: returns "Anonymous" when the user is nil or has ID 0.
+// nil-safe: returns AnonymousUserName when the user is nil or has ID 0.
 //
 // Use this whenever a backend response needs a label for a user. Pair with
 // ResolveUserUsername when you also want a profile-link slug — the username
 // form returns *string so consumers can omit the link when no username is set.
 func ResolveUserName(user *authm.User) string {
 	if user == nil || user.ID == 0 {
-		return "Anonymous"
+		return AnonymousUserName
 	}
 	if user.Username != nil && *user.Username != "" {
 		return *user.Username
@@ -52,7 +60,7 @@ func ResolveUserName(user *authm.User) string {
 			return (*user.Email)[:idx]
 		}
 	}
-	return "Anonymous"
+	return AnonymousUserName
 }
 
 // ResolveUserUsername returns the user's username for /users/:username links,


### PR DESCRIPTION
## Summary
- Two service-layer sites re-rolled user display-name resolution with chains that diverged from the canonical `services/shared.ResolveUserName`. Both now delegate to it.
- `admin/stats.go` `resolveActorName` (FirstName+LastName → username → **raw email** → "Unknown") leaked the whole email and ordered fields wrong. Removed the helper; the two `ActorName` assignment sites now call `shared.ResolveUserName` inline (matching the sibling `audit_log.go` surface).
- `notification/discord.go` `buildUserName` invented "Not provided"/"N/A" fallbacks and skipped the email-prefix step. Now a thin wrapper that calls `shared.ResolveUserName` and substitutes its Discord-specific "Not provided" label **only** when the canonical chain returns the anonymous sentinel.
- Exported `shared.AnonymousUserName` (was a bare `"Anonymous"` literal x3) so the wrapper detects the terminal case without re-deriving the chain or hardcoding the string.

### User-visible changes (intended)
- Admin activity feed now shows **username first** (was full name first).
- Discord new-user embed shows the **email local-part** for username/name-less signups (was "Not provided"). A raw email is never shown on either surface — only the local-part, exactly as the canonical chain does everywhere else.

## Test plan
- [x] `go build ./...` — exit 0 (this is how missed call sites would surface; none did — both helpers were truly package-local)
- [x] `go test ./internal/services/notification/...` — pass (Discord wrapper unit tests)
- [x] `go test ./internal/services/shared/...` — pass (resolver + `AnonymousUserName` refactor)
- [x] `go test ./internal/services/admin/...` — pass (admin stats integration suite, Postgres testcontainer)
- [x] `go test ./...` — exit 0, no FAIL lines
- [x] `gofmt -l` clean on all touched files

## Manual repro
Backend-only, no migration — the new/updated unit + integration tests ARE the repro:
- `TestBuildUserName` (notification): asserts username-first, email-local-part (`solo@example.com` → `solo`), "Not provided" terminal, and `NotContains(got, "@")` so a raw email can never be the display string.
- `TestNotifyNewUser_NoName_FallsBackToEmailPrefix`: end-to-end embed for a name-less signup now shows `anon` (local-part of `anon@example.com`), not the full address; `TestNotifyNewUser_NoIdentifiers_NotProvided` confirms the "Not provided" terminal still fires for a truly-empty user.
- `TestGetRecentActivity_ActorNamePrefersUsername` (admin): user with username + first/last resolves to the **username** (the intended reordering).
- `TestGetRecentActivity_ActorNameNeverLeaksRawEmail`: user with only `secret.person@private.example.com` resolves to `secret.person` and `NotContains(actorName, "@")`.
- Pre-existing `TestGetRecentActivity_ActorNameResolution` (→ "Jane Doe") and `_ActorNameFallbackToUsername` (→ "cooluser") stay green.

## Simplify
`/simplify` run after the implementation commit. Code already matched the established convention — dominant pattern is inline `shared.ResolveUserName(...)` at the assignment site (request.go, entity_report.go, audit_log.go, comment_service.go, pending_edit.go); thin local wrappers for surface-specific logic have precedent at `collection.go:1928`. No edits needed, so no separate simplify commit. The grep-gate / lint rule (acceptance-criteria nice-to-have) is deferred — the repo has no golangci-lint config or grep-gate CI today, so adding one is net-new infra disproportionate to this fix.

## Scope-adjacent
Eight other `services/` files deref user name fields, but none is a divergent display-name chain: they pass query-computed `Username`/`DisplayName` straight onto response DTOs, extract a username for a URL slug, or (in `comment_notification.go`) already use `shared.ResolveUserName`. No additional in-scope sites.

Closes PSY-760