### PR TITLE
PSY-754: fix entity_edit_audit_logs timestamp + ID types

### DIFF
--- a/backend/db/migrations/20260520004455_fix_entity_edit_audit_logs_timestamps.down.sql
+++ b/backend/db/migrations/20260520004455_fix_entity_edit_audit_logs_timestamps.down.sql
@@ -1,0 +1,16 @@
+-- Revert PSY-754: restore the as-created column types from
+-- 20260507043954_create_entity_edit_audit_logs.up.sql so the up->down->up
+-- round-trip lands back on the original schema.
+--
+-- TIMESTAMPTZ -> TIMESTAMP records the wall-clock value in UTC (the session
+-- runs in UTC), which is the inverse of the up migration's
+-- `AT TIME ZONE 'UTC'` reinterpretation.
+
+ALTER TABLE entity_edit_audit_logs
+    ALTER COLUMN entity_id TYPE INT;
+
+ALTER TABLE entity_edit_audit_logs
+    ALTER COLUMN actor_id TYPE INT;
+
+ALTER TABLE entity_edit_audit_logs
+    ALTER COLUMN created_at TYPE TIMESTAMP USING created_at AT TIME ZONE 'UTC';

--- a/backend/db/migrations/20260520004455_fix_entity_edit_audit_logs_timestamps.up.sql
+++ b/backend/db/migrations/20260520004455_fix_entity_edit_audit_logs_timestamps.up.sql
@@ -1,0 +1,27 @@
+-- PSY-754: Fix entity_edit_audit_logs schema regression introduced when the
+-- table was split out in PSY-618.
+--
+-- The table was created with `created_at TIMESTAMP` (no time zone) and 32-bit
+-- `actor_id INT` / `entity_id INT`. Migration 000038 had already standardized
+-- audit_logs.created_at to TIMESTAMPTZ; the new sibling table regressed that.
+-- The writer (services/admin/audit_log.go) stores zoned UTC via
+-- time.Now().UTC(), but a bare TIMESTAMP column drops the zone, which
+-- mis-renders on read (the PSY-604/616 timezone bug class).
+--
+-- Converting TIMESTAMP -> TIMESTAMPTZ is a metadata-only change for an empty
+-- or small table; `AT TIME ZONE 'UTC'` reinterprets existing naive values as
+-- the UTC instants they were written as (matching the writer), rather than
+-- letting PostgreSQL assume the server timezone.
+--
+-- Widening the foreign-key columns to BIGINT matches the BIGSERIAL primary key
+-- and the Go model's `uint` fields (64-bit on our platforms), avoiding silent
+-- failure past 2^31.
+
+ALTER TABLE entity_edit_audit_logs
+    ALTER COLUMN created_at TYPE TIMESTAMPTZ USING created_at AT TIME ZONE 'UTC';
+
+ALTER TABLE entity_edit_audit_logs
+    ALTER COLUMN actor_id TYPE BIGINT;
+
+ALTER TABLE entity_edit_audit_logs
+    ALTER COLUMN entity_id TYPE BIGINT;


### PR DESCRIPTION
## Summary
- `entity_edit_audit_logs` (split out in PSY-618) was created with `created_at TIMESTAMP` (no time zone) and 32-bit `actor_id`/`entity_id` `INT` columns, re-introducing the PSY-604/616 timezone bug class that migration 000038 had already fixed for the sibling `audit_logs` table.
- The writer (`internal/services/admin/audit_log.go`) stores zoned UTC via `time.Now().UTC()`, but the bare `TIMESTAMP` column dropped the zone, so reads mis-rendered. The 32-bit IDs would also fail past 2^31 despite the `BIGSERIAL` PK and `uint` Go model fields.
- New TIMESTAMP-versioned migration converts `created_at` to `TIMESTAMPTZ` (`USING created_at AT TIME ZONE 'UTC'`, matching the writer) and widens `actor_id`/`entity_id` to `BIGINT`. Mirrors the canonical 000038 ALTER pattern.
- **No GORM model change needed.** `EntityEditAuditLog` already uses `*uint`/`uint` (64-bit on our platforms → maps cleanly to `BIGINT`) and `time.Time` (→ `TIMESTAMPTZ`). The project drives schema via SQL migrations, not struct tags — zero models in the repo carry an explicit `type:timestamptz` tag, and the sibling `AuditLog` model is identical. Adding a tag would diverge from convention for no behavioral benefit.

## Test plan
- [x] `cd backend && go build ./...` — passes
- [x] `cd backend && go test ./internal/services/admin/...` — `ok` (26.3s)
- [x] `cd backend && go test ./...` — full suite passes, no failures
- [x] Migration up→down→up round-trip via `migrate` v4.19.1 (matches CI/production): down reverts to `timestamp without time zone` + `integer`; re-up lands on `timestamp with time zone` + `bigint`; `schema_migrations` not dirty. This is the exact sequence the CI reversibility guard runs.

## Manual repro
Brought up an isolated per-worktree stack (`stack-up.sh --mode=isolated`), applied all migrations (latest applied = `20260520004455`, dirty=`f`), and verified:

Column types after migration:
```
 created_at  | timestamp with time zone   (was: timestamp without time zone)
 actor_id    | bigint                     (was: integer)
 entity_id   | bigint                     (was: integer)
```

Timezone round-trip (inserted UTC instant `2026-05-19 23:30:00+00`, read back at three session timezones — same epoch, correct offset):
```
SET TIME ZONE 'UTC';             -> 2026-05-19 23:30:00+00
SET TIME ZONE 'America/Phoenix'; -> 2026-05-19 16:30:00-07
SET TIME ZONE 'Asia/Tokyo';      -> 2026-05-20 08:30:00+09
EXTRACT(EPOCH ...)               -> 1779233400  (identical instant)
```
This is the correct PSY-604/616 behavior. With the old bare `TIMESTAMP`, all three would have rendered `2026-05-19 23:30:00` with no offset (the bug). Stack torn down after.

## Simplify
`/simplify` run before PR — migration was already clean (no edits). It mirrors the canonical 000038 ALTER pattern, follows the migration-file ticket-ref convention (19 existing migrations lead with a `PSY-` ref; migrations are immutable historical records, an explicit exception to the strip-ticket-refs rule), and comments are WHY-only. No separate simplify commit.

## Scope-adjacent observations
- Audited every migration created since 000038 (`grep` for bare-`TIMESTAMP` columns excluding `WITH TIME ZONE`/`TIMESTAMPTZ`): the only regression was this table. No follow-up needed for new tables.
- **Pre-existing (out of scope, not fixed here):** the sibling `audit_logs` table (000022) still has `actor_id INT` / `entity_id INT` — migration 000038 only standardized its `created_at`, not its ID widths. Same latent 2^31 risk; its Go model uses `uint` too. Worth a small follow-up to widen `audit_logs` IDs to `BIGINT` for symmetry, but it's outside this ticket's scope.

Closes PSY-754