### PR TITLE
PSY-752: dedup shows on full timestamp, not same-day range

### DIFF
--- a/backend/internal/services/catalog/show.go
+++ b/backend/internal/services/catalog/show.go
@@ -238,7 +238,6 @@ func (s *ShowService) checkDuplicateHeadlinerConflicts(tx *gorm.DB, req *contrac
 		for _, venueName := range venueNames {
 			var existingShows []catalogm.Show
 
-			// Query for shows at the same exact event_date with the same headliner and venue
 			err := tx.Table("shows").
 				Joins("JOIN show_artists ON shows.id = show_artists.show_id").
 				Joins("JOIN artists ON show_artists.artist_id = artists.id").

--- a/backend/internal/services/catalog/show.go
+++ b/backend/internal/services/catalog/show.go
@@ -211,29 +211,34 @@ func (s *ShowService) checkDuplicateHeadlinerConflicts(tx *gorm.DB, req *contrac
 		venueNames = append(venueNames, venue.Name)
 	}
 
-	// Compute date window for same-day matching (matches discovery import logic)
+	// The dedup key is the FULL event_date timestamp (PSY-559): a matinee and
+	// an evening set at the same venue with the same headliner are distinct
+	// shows, not duplicates. Match on exact-timestamp equality, mirroring the
+	// shows_artist_venue_eventdate_uniq unique index.
 	eventDate := req.EventDate.UTC()
-	startOfDay := time.Date(eventDate.Year(), eventDate.Month(), eventDate.Day(), 0, 0, 0, 0, time.UTC)
-	endOfDay := startOfDay.Add(24 * time.Hour)
 
-	// Acquire advisory lock keyed on (headliner, venue, date) to serialize concurrent inserts.
-	// Uses FNV hash to produce a stable int64 lock key. Auto-released on transaction commit/rollback.
+	// Acquire advisory lock keyed on (headliner, venue, exact timestamp) to
+	// serialize concurrent inserts of the SAME show. Keying on the full
+	// timestamp (not the calendar day) lets matinee + evening inserts proceed
+	// in parallel. Uses FNV hash for a stable int64 lock key; auto-released on
+	// transaction commit/rollback.
 	for _, headlinerName := range headlinerNames {
 		for _, venueName := range venueNames {
-			lockKey := fnvHash(strings.ToLower(headlinerName) + "|" + strings.ToLower(venueName) + "|" + startOfDay.Format("2006-01-02"))
+			lockKey := fnvHash(strings.ToLower(headlinerName) + "|" + strings.ToLower(venueName) + "|" + eventDate.Format(time.RFC3339Nano))
 			if err := tx.Exec("SELECT pg_advisory_xact_lock(?)", lockKey).Error; err != nil {
 				return fmt.Errorf("failed to acquire advisory lock: %w", err)
 			}
 		}
 	}
 
-	// Check for conflicts: same headliner + same venue + same day (case-insensitive).
-	// Matches headliner by explicit set_type='headliner' OR position=0 (first billed artist).
+	// Check for conflicts: same headliner + same venue + same exact timestamp
+	// (case-insensitive). Matches headliner by explicit set_type='headliner'
+	// OR position=0 (first billed artist).
 	for _, headlinerName := range headlinerNames {
 		for _, venueName := range venueNames {
 			var existingShows []catalogm.Show
 
-			// Query for shows on the same day with the same headliner and venue
+			// Query for shows at the same exact event_date with the same headliner and venue
 			err := tx.Table("shows").
 				Joins("JOIN show_artists ON shows.id = show_artists.show_id").
 				Joins("JOIN artists ON show_artists.artist_id = artists.id").
@@ -242,7 +247,7 @@ func (s *ShowService) checkDuplicateHeadlinerConflicts(tx *gorm.DB, req *contrac
 				Where("LOWER(artists.name) = LOWER(?) AND LOWER(venues.name) = LOWER(?)",
 					headlinerName, venueName).
 				Where("(show_artists.set_type = ? OR show_artists.position = 0)", "headliner").
-				Where("shows.event_date >= ? AND shows.event_date < ?", startOfDay, endOfDay).
+				Where("shows.event_date = ?", eventDate).
 				Find(&existingShows).Error
 
 			if err != nil {

--- a/backend/internal/services/catalog/show_test.go
+++ b/backend/internal/services/catalog/show_test.go
@@ -891,6 +891,47 @@ func (suite *ShowServiceIntegrationTestSuite) TestCreateShow_DuplicateHeadliner_
 	suite.NotNil(resp)
 }
 
+// TestCreateShow_SameDayDifferentTime_OK is the PSY-752 regression guard:
+// a matinee (15:00) and an evening (21:00) show with the SAME headliner at the
+// SAME venue on the SAME calendar day are distinct shows, not duplicates. The
+// dedup key is the full event_date TIMESTAMPTZ (PSY-559), so the second create
+// must succeed. The prior same-day RANGE check threw away the time component
+// and false-flagged the evening show as a duplicate.
+func (suite *ShowServiceIntegrationTestSuite) TestCreateShow_SameDayDifferentTime_OK() {
+	user := suite.createTestUser()
+
+	matinee := &contracts.CreateShowRequest{
+		Title:             "Matinee Set",
+		EventDate:         time.Date(2026, 6, 1, 15, 0, 0, 0, time.UTC),
+		City:              "Phoenix",
+		State:             "AZ",
+		Venues:            []contracts.CreateShowVenue{{Name: "Two-Set Venue", City: "Phoenix", State: "AZ"}},
+		Artists:           []contracts.CreateShowArtist{{Name: "Two-Set Headliner", IsHeadliner: boolPtr(true)}},
+		SubmittedByUserID: &user.ID,
+		SubmitterIsAdmin:  true,
+	}
+	matineeResp, err := suite.showService.CreateShow(matinee)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(matineeResp)
+
+	// Same headliner, same venue, same DAY but a different time-of-day.
+	evening := &contracts.CreateShowRequest{
+		Title:             "Evening Set",
+		EventDate:         time.Date(2026, 6, 1, 21, 0, 0, 0, time.UTC),
+		City:              "Phoenix",
+		State:             "AZ",
+		Venues:            []contracts.CreateShowVenue{{Name: "Two-Set Venue", City: "Phoenix", State: "AZ"}},
+		Artists:           []contracts.CreateShowArtist{{Name: "Two-Set Headliner", IsHeadliner: boolPtr(true)}},
+		SubmittedByUserID: &user.ID,
+		SubmitterIsAdmin:  true,
+	}
+	eveningResp, err := suite.showService.CreateShow(evening)
+
+	suite.Require().NoError(err, "matinee + evening at same venue/headliner are distinct shows (PSY-559), not duplicates")
+	suite.Require().NotNil(eveningResp)
+	suite.NotEqual(matineeResp.ID, eveningResp.ID, "both shows should persist as distinct rows")
+}
+
 func (suite *ShowServiceIntegrationTestSuite) TestCreateShow_DuplicateHeadliner_DifferentVenue_OK() {
 	user := suite.createTestUser()
 	eventDate := time.Date(2026, 11, 5, 20, 0, 0, 0, time.UTC)

--- a/backend/internal/services/pipeline/discovery.go
+++ b/backend/internal/services/pipeline/discovery.go
@@ -176,11 +176,10 @@ func (s *DiscoveryService) ImportFromJSON(filepath string, dryRun bool) (*contra
 }
 
 // checkHeadlinerDuplicate checks if there's an existing non-rejected show with the same
-// headliner at the same venue on the same date. Returns the matching show or nil.
+// headliner at the same venue at the same exact event_date. Returns the matching show or nil.
+// The dedup key is the FULL event_date timestamp (PSY-559) — matinee and evening sets at
+// the same venue are distinct shows, not duplicates.
 func (s *DiscoveryService) checkHeadlinerDuplicate(headlinerName, venueName string, eventDate time.Time) *catalogm.Show {
-	startOfDay := time.Date(eventDate.Year(), eventDate.Month(), eventDate.Day(), 0, 0, 0, 0, time.UTC)
-	endOfDay := startOfDay.Add(24 * time.Hour)
-
 	var existingShow catalogm.Show
 	err := s.db.
 		Joins("JOIN show_artists ON shows.id = show_artists.show_id").
@@ -190,7 +189,7 @@ func (s *DiscoveryService) checkHeadlinerDuplicate(headlinerName, venueName stri
 		Where("LOWER(artists.name) = LOWER(?)", headlinerName).
 		Where("(show_artists.set_type = ? OR show_artists.position = 0)", "headliner").
 		Where("LOWER(venues.name) = LOWER(?)", venueName).
-		Where("shows.event_date >= ? AND shows.event_date < ?", startOfDay, endOfDay).
+		Where("shows.event_date = ?", eventDate).
 		Where("shows.status NOT IN ?", []catalogm.ShowStatus{catalogm.ShowStatusRejected, catalogm.ShowStatusPrivate}).
 		First(&existingShow).Error
 	if err != nil {
@@ -262,20 +261,19 @@ func (s *DiscoveryService) importEvent(event *contracts.DiscoveredEvent, dryRun 
 		return fmt.Sprintf("ERROR: Failed to parse date for %s: %v", event.Title, err), "error"
 	}
 
-	// Check if there's a rejected show at the same venue on the same date
-	// This prevents re-importing events that were previously rejected
-	startOfDay := time.Date(eventDate.Year(), eventDate.Month(), eventDate.Day(), 0, 0, 0, 0, time.UTC)
-	endOfDay := startOfDay.Add(24 * time.Hour)
-
+	// Check if there's a rejected show at the same venue at the same exact
+	// event_date. This prevents re-importing events that were previously
+	// rejected. Keyed on the FULL event_date timestamp (PSY-559) so a rejected
+	// matinee does not block a legitimate evening import at the same venue.
 	var rejectedShow catalogm.Show
 	err = s.db.Joins("JOIN show_venues ON shows.id = show_venues.show_id").
 		Joins("JOIN venues ON show_venues.venue_id = venues.id").
-		Where("LOWER(venues.name) = LOWER(?) AND shows.event_date >= ? AND shows.event_date < ? AND shows.status = ?",
-			venueConfig.Name, startOfDay, endOfDay, catalogm.ShowStatusRejected).
+		Where("LOWER(venues.name) = LOWER(?) AND shows.event_date = ? AND shows.status = ?",
+			venueConfig.Name, eventDate, catalogm.ShowStatusRejected).
 		First(&rejectedShow).Error
 	if err == nil {
 		return fmt.Sprintf("REJECTED: %s matches previously rejected show #%d at %s on %s",
-			event.Title, rejectedShow.ID, venueConfig.Name, eventDate.Format("2006-01-02")), "rejected"
+			event.Title, rejectedShow.ID, venueConfig.Name, eventDate.Format("2006-01-02 15:04")), "rejected"
 	}
 
 	// Check for duplicate: same headliner + venue + date as an existing show.
@@ -798,6 +796,14 @@ func (s *DiscoveryService) CheckEvents(events []contracts.CheckEventInput) (*con
 		if err != nil {
 			continue
 		}
+		// This is a read-only "does a show already exist at this venue that
+		// day" status lookup for the scraper UI — NOT a dedup-rejection gate.
+		// Unlike the dedup checks above, the CheckEventInput here carries only
+		// a date (YYYY-MM-DD), with no time-of-day, so a full-timestamp
+		// equality match is impossible. The same-day range is the correct
+		// (and only feasible) comparison for a date-only input. Surfacing a
+		// same-day match here never rejects an import; importEvent's
+		// full-timestamp dedup checks remain the authoritative gate.
 		startOfDay := eventDate
 		endOfDay := eventDate.Add(24 * time.Hour)
 

--- a/backend/internal/services/pipeline/discovery_test.go
+++ b/backend/internal/services/pipeline/discovery_test.go
@@ -757,9 +757,14 @@ func (suite *DiscoveryIntegrationTestSuite) TestImportEvents_HeadlinerDuplicate_
 	artist.Slug = &slug
 	suite.Require().NoError(suite.db.Create(artist).Error)
 
+	// Store the existing show at midnight UTC so it matches the exact
+	// event_date a date-only import produces (parseEventDate with no ShowTime
+	// yields 00:00 UTC). The dedup key is the FULL timestamp (PSY-559), so the
+	// fixture must share the import's exact event_date to be a true duplicate —
+	// a different time-of-day would be a distinct (matinee/evening) show.
 	show := &catalogm.Show{
 		Title:     "Existing Show",
-		EventDate: time.Date(2026, 11, 15, 2, 0, 0, 0, time.UTC),
+		EventDate: time.Date(2026, 11, 15, 0, 0, 0, 0, time.UTC),
 		Status:    catalogm.ShowStatusApproved,
 		Source:    catalogm.ShowSourceUser,
 	}
@@ -771,7 +776,8 @@ func (suite *DiscoveryIntegrationTestSuite) TestImportEvents_HeadlinerDuplicate_
 		"INSERT INTO show_artists (show_id, artist_id, position, set_type) VALUES (?, ?, 0, 'performer')",
 		show.ID, artist.ID).Error)
 
-	// Now try to import an event with the same artist at the same venue on the same date
+	// Now try to import an event with the same artist at the same venue at the
+	// same exact event_date (date-only import → 00:00 UTC, matching the fixture)
 	events := []contracts.DiscoveredEvent{
 		suite.makeEvent("evt-pos0-001", "Position Zero Band Live", "valley-bar", "2026-11-15", []string{"Position Zero Band"}),
 	}


### PR DESCRIPTION
## Summary
- The show dedup-rejection checks computed a start-of-day/end-of-day window and matched `event_date` within that range, discarding the time component. This contradicted the PSY-559 dedup key (full `event_date TIMESTAMPTZ`) and the `shows_artist_venue_eventdate_uniq` unique index: a legitimate matinee + evening pair at the same venue/headliner was false-flagged as a duplicate, and a scraper that found both had one silently skipped.
- Replaced the range with exact-timestamp equality (`event_date = ?`) at the three dedup-rejection sites, and re-keyed the FNV advisory lock on the full timestamp so concurrent matinee/evening inserts no longer serialize on the calendar day.

### Sites changed
- `catalog/show.go` `checkDuplicateHeadlinerConflicts` (CreateShow) — query + advisory-lock key.
- `pipeline/discovery.go` `checkHeadlinerDuplicate`.
- `pipeline/discovery.go` rejected-show re-import block.

### Heads-up: site #4 is intentionally NOT converted
The ticket lists a 4th site — the `CheckEvents` venue+date fallback (`discovery.go`). I left it as a same-day range **on purpose** and documented why inline:
- Its input (`CheckEventInput`) carries only a **date** (`YYYY-MM-DD`, no time-of-day), so a full-timestamp equality match is impossible without a contract/wire-format change (out of scope for this ticket).
- It is a **read-only** "does a show exist at this venue that day" status lookup for the scraper UI — it never rejects or skips an import. `importEvent`'s full-timestamp checks remain the authoritative dedup gate.
- Forcing `event_date = midnightUTC` there would *break* the fallback for every show stored with a real start time — a regression, not a fix.

This means the AC "All 4 sites use full-timestamp equality" is met for the 3 genuine dedup-rejection sites; the 4th is a documented exemption. Flagging for reviewer confirmation — happy to file a follow-up to thread time-of-day through `CheckEventInput` if exact matching there is desired.

`cmd/dedup-shows` / `FindShowDedupClusters` already group by the full `event_date` timestamp (audited, no fix needed).

## Test plan
- [x] `cd backend && go build ./...`
- [x] `cd backend && go vet ./internal/services/catalog/ ./internal/services/pipeline/`
- [x] `cd backend && go test ./internal/services/catalog/... ./internal/services/pipeline/...`
- [x] `cd backend && go test ./...` (full suite — all packages `ok`, exit 0)

## Manual repro
The new regression test **is** the repro (backend-only, no migration):
`TestCreateShow_SameDayDifferentTime_OK` — creates a matinee at `2026-06-01 15:00:00 UTC`, then the same artist+venue at `2026-06-01 21:00:00 UTC`. Before: second create rejected ("already performing"). After: second create succeeds and both persist as distinct rows (asserts `matineeResp.ID != eveningResp.ID`). PASS.

Existing same-time dedup still works: `TestCreateShow_DuplicateHeadliner_SameVenueSameDay_Fails` and `TestImportEvents_HeadlinerDuplicate_*` still reject true same-timestamp duplicates. PASS.

`TestImportEvents_HeadlinerDuplicate_Position0Match` encoded the old buggy assumption (fixture stored `02:00 UTC` vs a midnight date-only import, relying on same-day collision). Updated the fixture to store the existing show at the same exact timestamp the import produces, so it still asserts true same-show dedup under the corrected semantics.

## Simplify
Ran the three-lens review (reuse / quality / efficiency). One edit: dropped a redundant inline comment that narrated the WHERE clause (block comment already explains the full-timestamp key). No reuse or efficiency issues; advisory-lock key reuses the canonical `time.RFC3339Nano` format already used by `FindShowDedupClusters`.

Closes PSY-752