### PR TITLE
PSY-691: add tests for charts list components

### DIFF
--- a/frontend/features/charts/components/ActiveVenuesList.test.tsx
+++ b/frontend/features/charts/components/ActiveVenuesList.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, within } from '@/test/utils'
+import { ActiveVenuesList } from './ActiveVenuesList'
+import type { ActiveVenue } from '../types'
+
+function makeVenue(overrides: Partial<ActiveVenue> = {}): ActiveVenue {
+  return {
+    venue_id: 1,
+    name: 'The Rebel Lounge',
+    slug: 'the-rebel-lounge',
+    city: 'Phoenix',
+    state: 'AZ',
+    upcoming_show_count: 18,
+    follow_count: 65,
+    score: 83,
+    ...overrides,
+  }
+}
+
+describe('ActiveVenuesList', () => {
+  it('renders ranked venues in the order provided', () => {
+    const venues = [
+      makeVenue({ venue_id: 1, name: 'First Venue', slug: 'first-venue' }),
+      makeVenue({ venue_id: 2, name: 'Second Venue', slug: 'second-venue' }),
+      makeVenue({ venue_id: 3, name: 'Third Venue', slug: 'third-venue' }),
+    ]
+
+    render(<ActiveVenuesList venues={venues} />)
+
+    const items = screen.getAllByRole('listitem')
+    expect(items).toHaveLength(3)
+
+    expect(within(items[0]).getByText('1')).toBeInTheDocument()
+    expect(within(items[0]).getByText('First Venue')).toBeInTheDocument()
+    expect(within(items[1]).getByText('2')).toBeInTheDocument()
+    expect(within(items[1]).getByText('Second Venue')).toBeInTheDocument()
+    expect(within(items[2]).getByText('3')).toBeInTheDocument()
+    expect(within(items[2]).getByText('Third Venue')).toBeInTheDocument()
+  })
+
+  it('links each venue to its detail page', () => {
+    render(<ActiveVenuesList venues={[makeVenue()]} />)
+
+    const link = screen.getByRole('link', { name: /The Rebel Lounge/ })
+    expect(link).toHaveAttribute('href', '/venues/the-rebel-lounge')
+  })
+
+  it('renders city with state in full mode', () => {
+    render(<ActiveVenuesList venues={[makeVenue({ city: 'Phoenix', state: 'AZ' })]} />)
+
+    expect(screen.getByText('Phoenix, AZ')).toBeInTheDocument()
+  })
+
+  it('omits the state separator when state is empty', () => {
+    render(<ActiveVenuesList venues={[makeVenue({ city: 'Phoenix', state: '' })]} />)
+
+    expect(screen.getByText('Phoenix')).toBeInTheDocument()
+    expect(screen.queryByText(/Phoenix,/)).not.toBeInTheDocument()
+  })
+
+  it('renders upcoming-show and follower counts in full mode', () => {
+    render(<ActiveVenuesList venues={[makeVenue({ upcoming_show_count: 18, follow_count: 65 })]} />)
+
+    expect(screen.getByText('18')).toBeInTheDocument()
+    expect(screen.getByText('65')).toBeInTheDocument()
+  })
+
+  it('hides city and counts in compact mode', () => {
+    render(
+      <ActiveVenuesList
+        venues={[makeVenue({ city: 'Phoenix', state: 'AZ', upcoming_show_count: 18, follow_count: 65 })]}
+        compact
+      />
+    )
+
+    expect(screen.queryByText('Phoenix, AZ')).not.toBeInTheDocument()
+    expect(screen.queryByText('18')).not.toBeInTheDocument()
+    expect(screen.queryByText('65')).not.toBeInTheDocument()
+    // Name still renders when compact.
+    expect(screen.getByText('The Rebel Lounge')).toBeInTheDocument()
+  })
+
+  it('renders the empty state when there are no venues', () => {
+    render(<ActiveVenuesList venues={[]} />)
+
+    expect(screen.getByText('No active venues right now.')).toBeInTheDocument()
+    expect(screen.queryByRole('list')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/features/charts/components/HotReleasesList.test.tsx
+++ b/frontend/features/charts/components/HotReleasesList.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, within } from '@/test/utils'
+import { HotReleasesList } from './HotReleasesList'
+import type { HotRelease } from '../types'
+
+function makeRelease(overrides: Partial<HotRelease> = {}): HotRelease {
+  return {
+    release_id: 1,
+    title: 'Eternal Drift',
+    slug: 'eternal-drift',
+    release_date: '2026-03-01',
+    artist_names: ['Moonlight Parade'],
+    bookmark_count: 34,
+    ...overrides,
+  }
+}
+
+describe('HotReleasesList', () => {
+  it('renders ranked releases in the order provided', () => {
+    const releases = [
+      makeRelease({ release_id: 1, title: 'First Release', slug: 'first-release' }),
+      makeRelease({ release_id: 2, title: 'Second Release', slug: 'second-release' }),
+      makeRelease({ release_id: 3, title: 'Third Release', slug: 'third-release' }),
+    ]
+
+    render(<HotReleasesList releases={releases} />)
+
+    const items = screen.getAllByRole('listitem')
+    expect(items).toHaveLength(3)
+
+    expect(within(items[0]).getByText('1')).toBeInTheDocument()
+    expect(within(items[0]).getByText('First Release')).toBeInTheDocument()
+    expect(within(items[1]).getByText('2')).toBeInTheDocument()
+    expect(within(items[1]).getByText('Second Release')).toBeInTheDocument()
+    expect(within(items[2]).getByText('3')).toBeInTheDocument()
+    expect(within(items[2]).getByText('Third Release')).toBeInTheDocument()
+  })
+
+  it('links each release to its detail page', () => {
+    render(<HotReleasesList releases={[makeRelease()]} />)
+
+    const link = screen.getByRole('link', { name: /Eternal Drift/ })
+    expect(link).toHaveAttribute('href', '/releases/eternal-drift')
+  })
+
+  it('renders bookmark count', () => {
+    render(<HotReleasesList releases={[makeRelease({ bookmark_count: 34 })]} />)
+
+    expect(screen.getByText('34')).toBeInTheDocument()
+  })
+
+  it('renders joined artist names in full mode', () => {
+    render(<HotReleasesList releases={[makeRelease({ artist_names: ['Band A', 'Band B'] })]} />)
+
+    expect(screen.getByText('Band A, Band B')).toBeInTheDocument()
+  })
+
+  it('handles a missing release date without rendering a date', () => {
+    render(<HotReleasesList releases={[makeRelease({ release_date: null, artist_names: ['Solo'] })]} />)
+
+    // Title and artist still render; absence of a date must not throw.
+    expect(screen.getByText('Eternal Drift')).toBeInTheDocument()
+    expect(screen.getByText('Solo')).toBeInTheDocument()
+  })
+
+  it('omits the artist line when there are no artist names', () => {
+    render(<HotReleasesList releases={[makeRelease({ artist_names: [], release_date: null })]} />)
+
+    expect(screen.getByText('Eternal Drift')).toBeInTheDocument()
+    expect(screen.queryByText('Moonlight Parade')).not.toBeInTheDocument()
+  })
+
+  it('hides artist metadata but keeps bookmark count in compact mode', () => {
+    render(<HotReleasesList releases={[makeRelease({ artist_names: ['Band A'], bookmark_count: 34 })]} compact />)
+
+    expect(screen.queryByText('Band A')).not.toBeInTheDocument()
+    // Bookmark count is outside the !compact block, so it stays visible.
+    expect(screen.getByText('34')).toBeInTheDocument()
+    expect(screen.getByText('Eternal Drift')).toBeInTheDocument()
+  })
+
+  it('renders the empty state when there are no releases', () => {
+    render(<HotReleasesList releases={[]} />)
+
+    expect(screen.getByText('No recent releases yet.')).toBeInTheDocument()
+    expect(screen.queryByRole('list')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/features/charts/components/PopularArtistsList.test.tsx
+++ b/frontend/features/charts/components/PopularArtistsList.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, within } from '@/test/utils'
+import { PopularArtistsList } from './PopularArtistsList'
+import type { PopularArtist } from '../types'
+
+function makeArtist(overrides: Partial<PopularArtist> = {}): PopularArtist {
+  return {
+    artist_id: 1,
+    name: 'Moonlight Parade',
+    slug: 'moonlight-parade',
+    image_url: '',
+    follow_count: 120,
+    upcoming_show_count: 5,
+    score: 125,
+    ...overrides,
+  }
+}
+
+describe('PopularArtistsList', () => {
+  it('renders ranked artists in the order provided', () => {
+    const artists = [
+      makeArtist({ artist_id: 1, name: 'First Artist', slug: 'first-artist' }),
+      makeArtist({ artist_id: 2, name: 'Second Artist', slug: 'second-artist' }),
+      makeArtist({ artist_id: 3, name: 'Third Artist', slug: 'third-artist' }),
+    ]
+
+    render(<PopularArtistsList artists={artists} />)
+
+    const items = screen.getAllByRole('listitem')
+    expect(items).toHaveLength(3)
+
+    expect(within(items[0]).getByText('1')).toBeInTheDocument()
+    expect(within(items[0]).getByText('First Artist')).toBeInTheDocument()
+    expect(within(items[1]).getByText('2')).toBeInTheDocument()
+    expect(within(items[1]).getByText('Second Artist')).toBeInTheDocument()
+    expect(within(items[2]).getByText('3')).toBeInTheDocument()
+    expect(within(items[2]).getByText('Third Artist')).toBeInTheDocument()
+  })
+
+  it('links each artist to its detail page', () => {
+    render(<PopularArtistsList artists={[makeArtist()]} />)
+
+    const link = screen.getByRole('link', { name: /Moonlight Parade/ })
+    expect(link).toHaveAttribute('href', '/artists/moonlight-parade')
+  })
+
+  it('renders follower and upcoming-show counts in full mode', () => {
+    render(<PopularArtistsList artists={[makeArtist({ follow_count: 120, upcoming_show_count: 5 })]} />)
+
+    expect(screen.getByText('120')).toBeInTheDocument()
+    expect(screen.getByText('5')).toBeInTheDocument()
+  })
+
+  it('hides counts in compact mode', () => {
+    render(<PopularArtistsList artists={[makeArtist({ follow_count: 120, upcoming_show_count: 5 })]} compact />)
+
+    expect(screen.queryByText('120')).not.toBeInTheDocument()
+    expect(screen.queryByText('5')).not.toBeInTheDocument()
+    // Name still renders when compact.
+    expect(screen.getByText('Moonlight Parade')).toBeInTheDocument()
+  })
+
+  it('renders the empty state when there are no artists', () => {
+    render(<PopularArtistsList artists={[]} />)
+
+    expect(screen.getByText('No popular artists right now.')).toBeInTheDocument()
+    expect(screen.queryByRole('list')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/features/charts/components/TrendingShowsList.test.tsx
+++ b/frontend/features/charts/components/TrendingShowsList.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, within } from '@/test/utils'
+import { TrendingShowsList } from './TrendingShowsList'
+import type { TrendingShow } from '../types'
+
+function makeShow(overrides: Partial<TrendingShow> = {}): TrendingShow {
+  return {
+    show_id: 1,
+    title: 'Night of Echoes',
+    slug: 'night-of-echoes',
+    date: '2026-04-15T20:00:00Z',
+    venue_name: 'Valley Bar',
+    venue_slug: 'valley-bar',
+    city: 'Phoenix',
+    artist_names: ['Moonlight Parade'],
+    going_count: 42,
+    interested_count: 88,
+    total_attendance: 130,
+    ...overrides,
+  }
+}
+
+describe('TrendingShowsList', () => {
+  it('renders ranked shows in the order provided', () => {
+    const shows = [
+      makeShow({ show_id: 1, title: 'First Show', slug: 'first-show' }),
+      makeShow({ show_id: 2, title: 'Second Show', slug: 'second-show' }),
+      makeShow({ show_id: 3, title: 'Third Show', slug: 'third-show' }),
+    ]
+
+    render(<TrendingShowsList shows={shows} />)
+
+    const items = screen.getAllByRole('listitem')
+    expect(items).toHaveLength(3)
+
+    // Rank badges are 1-based and follow array order.
+    expect(within(items[0]).getByText('1')).toBeInTheDocument()
+    expect(within(items[0]).getByText('First Show')).toBeInTheDocument()
+    expect(within(items[1]).getByText('2')).toBeInTheDocument()
+    expect(within(items[1]).getByText('Second Show')).toBeInTheDocument()
+    expect(within(items[2]).getByText('3')).toBeInTheDocument()
+    expect(within(items[2]).getByText('Third Show')).toBeInTheDocument()
+  })
+
+  it('links each show to its detail page', () => {
+    render(<TrendingShowsList shows={[makeShow()]} />)
+
+    const link = screen.getByRole('link', { name: /Night of Echoes/ })
+    expect(link).toHaveAttribute('href', '/shows/night-of-echoes')
+  })
+
+  it('renders attendance counts', () => {
+    render(<TrendingShowsList shows={[makeShow({ going_count: 42, interested_count: 88 })]} />)
+
+    expect(screen.getByText('42')).toBeInTheDocument()
+    expect(screen.getByText('88')).toBeInTheDocument()
+  })
+
+  it('renders venue and city metadata in full mode', () => {
+    render(<TrendingShowsList shows={[makeShow({ venue_name: 'Valley Bar', city: 'Phoenix' })]} />)
+
+    expect(screen.getByText('Valley Bar')).toBeInTheDocument()
+    expect(screen.getByText('Phoenix')).toBeInTheDocument()
+  })
+
+  it('hides venue/city metadata in compact mode', () => {
+    render(<TrendingShowsList shows={[makeShow({ venue_name: 'Valley Bar', city: 'Phoenix' })]} compact />)
+
+    expect(screen.queryByText('Valley Bar')).not.toBeInTheDocument()
+    expect(screen.queryByText('Phoenix')).not.toBeInTheDocument()
+    // Attendance counts stay visible even when compact.
+    expect(screen.getByText('42')).toBeInTheDocument()
+  })
+
+  describe('display title fallback', () => {
+    it('uses the explicit title when present', () => {
+      render(<TrendingShowsList shows={[makeShow({ title: 'Explicit Title' })]} />)
+      expect(screen.getByText('Explicit Title')).toBeInTheDocument()
+    })
+
+    it('falls back to "artists @ venue" when title is empty', () => {
+      render(
+        <TrendingShowsList
+          shows={[makeShow({ title: '', artist_names: ['Band A', 'Band B'], venue_name: 'The Venue' })]}
+        />
+      )
+      expect(screen.getByText('Band A, Band B @ The Venue')).toBeInTheDocument()
+    })
+
+    it('falls back to artists only when venue is missing', () => {
+      render(
+        <TrendingShowsList
+          shows={[makeShow({ title: '', artist_names: ['Solo Act'], venue_name: '' })]}
+        />
+      )
+      expect(screen.getByText('Solo Act')).toBeInTheDocument()
+    })
+
+    it('falls back to "Show @ venue" when only the venue is known', () => {
+      render(
+        <TrendingShowsList
+          shows={[makeShow({ title: '', artist_names: [], venue_name: 'Lonely Venue' })]}
+        />
+      )
+      expect(screen.getByText('Show @ Lonely Venue')).toBeInTheDocument()
+    })
+
+    it('falls back to "Untitled Show" when nothing is known', () => {
+      render(
+        <TrendingShowsList
+          shows={[makeShow({ title: '', artist_names: [], venue_name: '' })]}
+        />
+      )
+      expect(screen.getByText('Untitled Show')).toBeInTheDocument()
+    })
+  })
+
+  it('renders the empty state when there are no shows', () => {
+    render(<TrendingShowsList shows={[]} />)
+
+    expect(screen.getByText('No upcoming shows right now.')).toBeInTheDocument()
+    expect(screen.queryByRole('list')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- Add sibling tests for the four previously-untested charts list components: `ActiveVenuesList`, `HotReleasesList`, `PopularArtistsList`, `TrendingShowsList`.
- Each covers ranked-order rendering (via the 1-based rank badges), detail-page link hrefs, full-vs-compact metadata visibility, conditional fields (nullable release date, empty artist names, optional venue state), the `TrendingShows` display-title fallback chain, and the empty state.
- `useCharts.test.tsx` already exercises all four chart hooks plus overview with and without the `limit` param (no time-window param exists on these hooks), so its coverage breadth was left unchanged.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run test:run features/charts` — 50/50 passing (31 new across the 4 list components)

## Manual repro
Test-only diff; no runtime change. Passing suite IS the verification.

## Simplify
Ran; no issues found. Tests follow the established local-`makeX`-factory convention (39 other test files) and use `render` from `@/test/utils`; comments are WHY-only; no duplication or efficiency concerns. No edits, so no separate commit.

Closes PSY-691