### PR TITLE
PSY-692: test sweep for features/blog embed components

### DIFF
--- a/frontend/features/blog/components/bandcamp-embed.test.tsx
+++ b/frontend/features/blog/components/bandcamp-embed.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import { Bandcamp } from './bandcamp-embed'
+
+/**
+ * Bandcamp builds its embed/link URLs from props (it has no single `url`
+ * prop). The iframe's child <a> is the fallback shown when the embed can't
+ * load, so the tests assert both the iframe src and that fallback anchor.
+ */
+describe('Bandcamp', () => {
+  it('renders an iframe titled "<title> by <artist>"', () => {
+    const { container } = render(
+      <Bandcamp album="123" artist="myband" title="my-album" />
+    )
+    const iframe = container.querySelector('iframe')
+    expect(iframe).toBeInTheDocument()
+    expect(iframe).toHaveAttribute('title', 'my-album by myband')
+  })
+
+  it('embeds the album id in the src when album is provided', () => {
+    const { container } = render(
+      <Bandcamp album="123" artist="myband" title="my-album" />
+    )
+    const src = container.querySelector('iframe')?.getAttribute('src') ?? ''
+    expect(src).toContain('https://bandcamp.com/EmbeddedPlayer/')
+    expect(src).toContain('album=123')
+    expect(src).not.toContain('track=')
+  })
+
+  it('embeds the track id in the src when track is provided', () => {
+    const { container } = render(
+      <Bandcamp track="456" artist="myband" title="my-track" />
+    )
+    const src = container.querySelector('iframe')?.getAttribute('src') ?? ''
+    expect(src).toContain('track=456')
+    expect(src).not.toContain('album=')
+  })
+
+  it('applies default embed params to the src', () => {
+    const { container } = render(
+      <Bandcamp album="123" artist="myband" title="my-album" />
+    )
+    const src = container.querySelector('iframe')?.getAttribute('src') ?? ''
+    expect(src).toContain('size=large')
+    expect(src).toContain('bgcol=ffffff')
+    expect(src).toContain('linkcol=0687f5')
+    expect(src).toContain('tracklist=false')
+    expect(src).toContain('artwork=small')
+    expect(src).toContain('transparent=true')
+  })
+
+  it('overrides defaults with custom embed params', () => {
+    const { container } = render(
+      <Bandcamp
+        album="123"
+        artist="myband"
+        title="my-album"
+        size="small"
+        artwork="big"
+        bgcol="000000"
+        linkcol="ffcc00"
+        tracklist="true"
+      />
+    )
+    const src = container.querySelector('iframe')?.getAttribute('src') ?? ''
+    expect(src).toContain('size=small')
+    expect(src).toContain('artwork=big')
+    expect(src).toContain('bgcol=000000')
+    expect(src).toContain('linkcol=ffcc00')
+    expect(src).toContain('tracklist=true')
+  })
+
+  it('renders an album fallback link when album is provided', () => {
+    const { container } = render(
+      <Bandcamp album="123" artist="myband" title="my-album" />
+    )
+    const link = container.querySelector('iframe a')
+    expect(link).toHaveAttribute(
+      'href',
+      'https://myband.bandcamp.com/album/my-album'
+    )
+    expect(link).toHaveTextContent('my-album by myband')
+  })
+
+  it('renders a track fallback link when only track is provided', () => {
+    const { container } = render(
+      <Bandcamp track="456" artist="myband" title="my-track" />
+    )
+    const link = container.querySelector('iframe a')
+    expect(link).toHaveAttribute(
+      'href',
+      'https://myband.bandcamp.com/track/my-track'
+    )
+  })
+
+  it('applies the height prop to the iframe style', () => {
+    const { container } = render(
+      <Bandcamp album="123" artist="myband" title="my-album" height="350" />
+    )
+    const iframe = container.querySelector('iframe')
+    expect(iframe).toHaveStyle({ height: '350px' })
+  })
+})

--- a/frontend/features/blog/components/mdx-content.test.tsx
+++ b/frontend/features/blog/components/mdx-content.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import type { ComponentType } from 'react'
+
+/**
+ * `MDXRemote` from next-mdx-remote/rsc is an async server component that
+ * compiles MDX in the RSC runtime — it cannot execute under jsdom/vitest.
+ * We mock it to a passthrough so we can assert what MDXContent itself
+ * controls: the prose wrapper, the forwarded `source`, and the custom
+ * `components` map (embeds + styled element overrides). The map's render
+ * functions are then exercised directly since they are plain components.
+ */
+type MDXRemoteProps = {
+  source: string
+  components: Record<string, ComponentType<Record<string, unknown>>>
+}
+
+const mdxRemoteSpy = vi.fn()
+
+vi.mock('next-mdx-remote/rsc', () => ({
+  MDXRemote: (props: MDXRemoteProps) => {
+    mdxRemoteSpy(props)
+    return <div data-testid="mdx-rendered">{props.source}</div>
+  },
+}))
+
+import { MDXContent } from './mdx-content'
+
+function getComponentsMap(): MDXRemoteProps['components'] {
+  render(<MDXContent source="content" />)
+  return mdxRemoteSpy.mock.calls.at(-1)![0].components
+}
+
+describe('MDXContent', () => {
+  it('wraps rendered MDX in a prose container', () => {
+    const { container } = render(<MDXContent source="# Hello" />)
+    const wrapper = container.querySelector('div.prose')
+    expect(wrapper).toBeInTheDocument()
+    expect(wrapper?.className).toContain('max-w-none')
+  })
+
+  it('forwards the source string to MDXRemote', () => {
+    const source = '# Heading\n\nbody'
+    render(<MDXContent source={source} />)
+    expect(screen.getByTestId('mdx-rendered')).toHaveTextContent('# Heading')
+    expect(mdxRemoteSpy.mock.calls.at(-1)![0].source).toBe(source)
+  })
+
+  it('registers the Bandcamp and SoundCloud embeds as MDX components', () => {
+    const components = getComponentsMap()
+    expect(components.Bandcamp).toBeDefined()
+    expect(components.SoundCloud).toBeDefined()
+  })
+
+  it('styles code with a monospace highlight class', () => {
+    const Code = getComponentsMap().code
+    const { container } = render(<Code>const x = 1</Code>)
+    const code = container.querySelector('code')
+    expect(code).toHaveTextContent('const x = 1')
+    expect(code?.className).toContain('font-mono')
+    expect(code?.className).toContain('bg-muted')
+  })
+
+  it('styles pre code blocks with a highlight background', () => {
+    const Pre = getComponentsMap().pre
+    const { container } = render(<Pre>block</Pre>)
+    const pre = container.querySelector('pre')
+    expect(pre?.className).toContain('bg-muted')
+    expect(pre?.className).toContain('overflow-x-auto')
+  })
+
+  it('opens external anchors in a new tab with safe rel', () => {
+    const Anchor = getComponentsMap().a
+    const { container } = render(
+      <Anchor href="https://example.com">external</Anchor>
+    )
+    const anchor = container.querySelector('a')
+    expect(anchor).toHaveAttribute('target', '_blank')
+    expect(anchor).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  it('keeps internal anchors in the same tab', () => {
+    const Anchor = getComponentsMap().a
+    const { container } = render(<Anchor href="/blog">internal</Anchor>)
+    const anchor = container.querySelector('a')
+    expect(anchor).not.toHaveAttribute('target')
+    expect(anchor).not.toHaveAttribute('rel')
+  })
+})

--- a/frontend/features/blog/components/soundcloud-embed.test.tsx
+++ b/frontend/features/blog/components/soundcloud-embed.test.tsx
@@ -24,7 +24,6 @@ describe('SoundCloud', () => {
 
   it('omits the attribution block when neither artist nor title is set', () => {
     const { container } = render(<SoundCloud url={PLAYER_URL} />)
-    // Only the iframe child should exist inside the wrapper div.
     const wrapper = container.querySelector('div.mb-6')
     expect(wrapper?.childElementCount).toBe(1)
     expect(wrapper?.firstElementChild?.tagName).toBe('IFRAME')

--- a/frontend/features/blog/components/soundcloud-embed.test.tsx
+++ b/frontend/features/blog/components/soundcloud-embed.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { SoundCloud } from './soundcloud-embed'
+
+const PLAYER_URL = 'https://w.soundcloud.com/player/?url=track'
+
+describe('SoundCloud', () => {
+  it('renders an iframe with the provided url as src', () => {
+    const { container } = render(<SoundCloud url={PLAYER_URL} />)
+    const iframe = container.querySelector('iframe')
+    expect(iframe).toBeInTheDocument()
+    expect(iframe).toHaveAttribute('src', PLAYER_URL)
+  })
+
+  it('falls back to a default iframe title when none is given', () => {
+    render(<SoundCloud url={PLAYER_URL} />)
+    expect(screen.getByTitle('SoundCloud Player')).toBeInTheDocument()
+  })
+
+  it('uses the provided title as the iframe title', () => {
+    render(<SoundCloud url={PLAYER_URL} title="My Track" />)
+    expect(screen.getByTitle('My Track')).toBeInTheDocument()
+  })
+
+  it('omits the attribution block when neither artist nor title is set', () => {
+    const { container } = render(<SoundCloud url={PLAYER_URL} />)
+    // Only the iframe child should exist inside the wrapper div.
+    const wrapper = container.querySelector('div.mb-6')
+    expect(wrapper?.childElementCount).toBe(1)
+    expect(wrapper?.firstElementChild?.tagName).toBe('IFRAME')
+  })
+
+  it('renders a plain-text artist when artist is set without a url', () => {
+    render(<SoundCloud url={PLAYER_URL} artist="DJ Test" />)
+    expect(screen.getByText('DJ Test')).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'DJ Test' })).toBeNull()
+  })
+
+  it('renders an artist link when artist_url is provided', () => {
+    render(
+      <SoundCloud
+        url={PLAYER_URL}
+        artist="DJ Test"
+        artist_url="https://soundcloud.com/djtest"
+      />
+    )
+    const link = screen.getByRole('link', { name: 'DJ Test' })
+    expect(link).toHaveAttribute('href', 'https://soundcloud.com/djtest')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  it('renders a plain-text title when title is set without a track url', () => {
+    render(<SoundCloud url={PLAYER_URL} title="My Track" />)
+    expect(screen.getByText('My Track')).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'My Track' })).toBeNull()
+  })
+
+  it('renders a track link when track_url is provided', () => {
+    render(
+      <SoundCloud
+        url={PLAYER_URL}
+        title="My Track"
+        track_url="https://soundcloud.com/djtest/my-track"
+      />
+    )
+    const link = screen.getByRole('link', { name: 'My Track' })
+    expect(link).toHaveAttribute(
+      'href',
+      'https://soundcloud.com/djtest/my-track'
+    )
+  })
+
+  it('separates artist and title with a middot when both are present', () => {
+    const { container } = render(
+      <SoundCloud url={PLAYER_URL} artist="DJ Test" title="My Track" />
+    )
+    expect(container.textContent).toContain('·')
+  })
+})


### PR DESCRIPTION
## Summary
- Adds sibling tests for the three previously-untested components in `frontend/features/blog/components/`, bringing every component in the directory to a sibling test.
- `bandcamp-embed`: iframe src construction (album vs track branch, default + custom embed params), the child `<a>` fallback link (album/track URL), and the height style.
- `soundcloud-embed`: iframe src/title (default `SoundCloud Player` vs provided), and the conditional attribution block (plain-text vs linked artist/title, middot separator).
- `mdx-content`: `next-mdx-remote/rsc` is mocked (it's an async RSC component that can't compile MDX under jsdom); tests assert the prose wrapper, the forwarded `source`, and the custom `components` map — including the `code`/`pre` highlight classes and external-vs-internal anchor handling.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run test:run features/blog` — 59/59 passing (24 new: 8 Bandcamp + 9 SoundCloud + 7 MDXContent)

## Manual repro
Test-only diff; no runtime change. The passing suite IS the verification.

## Simplify
Code was convention-aligned (matches `ShowStatusBadge.test.tsx` render/screen pattern; `vi.mock` factory matches the comments-feature tests). Only fix: removed one redundant WHAT-narrating comment.

Closes PSY-692