### PR TITLE
PSY-689: add test coverage for features/requests module

### DIFF
--- a/frontend/features/requests/components/RequestCard.test.tsx
+++ b/frontend/features/requests/components/RequestCard.test.tsx
@@ -1,0 +1,225 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { Request } from '../types'
+
+// ── Mocks ──────────────────────────────────────────
+
+type MockAuthValue = {
+  user: { id: string; is_admin?: boolean } | null
+  isAuthenticated: boolean
+  isLoading: boolean
+  logout: () => void
+}
+const mockAuthContext = vi.fn<() => MockAuthValue>(() => ({
+  user: { id: '1' },
+  isAuthenticated: true,
+  isLoading: false,
+  logout: vi.fn(),
+}))
+vi.mock('@/lib/context/AuthContext', () => ({
+  useAuthContext: () => mockAuthContext(),
+}))
+
+const mockVoteMutate = vi.fn()
+const mockRemoveVoteMutate = vi.fn()
+const mockVoteMutation = vi.fn(() => ({
+  mutate: mockVoteMutate,
+  isPending: false,
+}))
+const mockRemoveVoteMutation = vi.fn(() => ({
+  mutate: mockRemoveVoteMutate,
+  isPending: false,
+}))
+vi.mock('../hooks', () => ({
+  useVoteRequest: () => mockVoteMutation(),
+  useRemoveVoteRequest: () => mockRemoveVoteMutation(),
+}))
+
+vi.mock('next/link', () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string
+    children: React.ReactNode
+    [key: string]: unknown
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}))
+
+import { RequestCard } from './RequestCard'
+
+function makeRequest(overrides: Partial<Request> = {}): Request {
+  return {
+    id: 42,
+    title: 'Add Slowdive discography',
+    description: 'Shoegaze legends, missing a few EPs.',
+    entity_type: 'artist',
+    status: 'pending',
+    requester_id: 1,
+    requester_name: 'jane',
+    requester_username: 'jane',
+    vote_score: 5,
+    upvotes: 7,
+    downvotes: 2,
+    wilson_score: 0.5,
+    user_vote: null,
+    created_at: '2026-05-18T12:00:00Z',
+    updated_at: '2026-05-18T12:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('RequestCard', () => {
+  beforeEach(() => {
+    mockAuthContext.mockReturnValue({
+      user: { id: '1' },
+      isAuthenticated: true,
+      isLoading: false,
+      logout: vi.fn(),
+    })
+    mockVoteMutation.mockReturnValue({ mutate: mockVoteMutate, isPending: false })
+    mockRemoveVoteMutation.mockReturnValue({
+      mutate: mockRemoveVoteMutate,
+      isPending: false,
+    })
+  })
+
+  it('renders as an article element', () => {
+    render(<RequestCard request={makeRequest()} />)
+    expect(screen.getByRole('article')).toBeInTheDocument()
+  })
+
+  it('renders the title linked to the request detail page', () => {
+    render(<RequestCard request={makeRequest()} />)
+    const titleLink = screen
+      .getByText('Add Slowdive discography')
+      .closest('a')
+    expect(titleLink).toHaveAttribute('href', '/requests/42')
+  })
+
+  it('renders the entity-type and status badges', () => {
+    render(<RequestCard request={makeRequest()} />)
+    expect(screen.getByText('Artist')).toBeInTheDocument()
+    expect(screen.getByText('Pending')).toBeInTheDocument()
+  })
+
+  it('renders the in-progress status label for an in_progress request', () => {
+    render(<RequestCard request={makeRequest({ status: 'in_progress' })} />)
+    expect(screen.getByText('In Progress')).toBeInTheDocument()
+  })
+
+  it('renders the vote score', () => {
+    render(<RequestCard request={makeRequest({ vote_score: 5 })} />)
+    expect(screen.getByText('5')).toBeInTheDocument()
+  })
+
+  it('renders the description when present', () => {
+    render(<RequestCard request={makeRequest()} />)
+    expect(
+      screen.getByText('Shoegaze legends, missing a few EPs.')
+    ).toBeInTheDocument()
+  })
+
+  it('omits the description paragraph when absent', () => {
+    render(<RequestCard request={makeRequest({ description: undefined })} />)
+    expect(
+      screen.queryByText('Shoegaze legends, missing a few EPs.')
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders the requester attribution', () => {
+    render(<RequestCard request={makeRequest()} />)
+    // UserAttribution links to the profile when username is set.
+    const byline = screen.getByText('jane').closest('a')
+    expect(byline).toHaveAttribute('href', '/users/jane')
+  })
+
+  it('renders requester as plain text when username is null', () => {
+    render(
+      <RequestCard
+        request={makeRequest({
+          requester_name: 'jane',
+          requester_username: null,
+        })}
+      />
+    )
+    expect(screen.getByText('jane').closest('a')).toBeNull()
+  })
+
+  describe('voting', () => {
+    it('casts an upvote when no prior vote exists', async () => {
+      const user = userEvent.setup()
+      render(<RequestCard request={makeRequest({ user_vote: null })} />)
+
+      await user.click(screen.getByRole('button', { name: 'Upvote' }))
+      expect(mockVoteMutate).toHaveBeenCalledWith({
+        requestId: 42,
+        is_upvote: true,
+      })
+      expect(mockRemoveVoteMutate).not.toHaveBeenCalled()
+    })
+
+    it('removes the vote when re-clicking an existing upvote', async () => {
+      const user = userEvent.setup()
+      render(<RequestCard request={makeRequest({ user_vote: 1 })} />)
+
+      await user.click(screen.getByRole('button', { name: 'Upvote' }))
+      expect(mockRemoveVoteMutate).toHaveBeenCalledWith({ requestId: 42 })
+      expect(mockVoteMutate).not.toHaveBeenCalled()
+    })
+
+    it('casts a downvote when no prior vote exists', async () => {
+      const user = userEvent.setup()
+      render(<RequestCard request={makeRequest({ user_vote: null })} />)
+
+      await user.click(screen.getByRole('button', { name: 'Downvote' }))
+      expect(mockVoteMutate).toHaveBeenCalledWith({
+        requestId: 42,
+        is_upvote: false,
+      })
+    })
+
+    it('removes the vote when re-clicking an existing downvote', async () => {
+      const user = userEvent.setup()
+      render(<RequestCard request={makeRequest({ user_vote: -1 })} />)
+
+      await user.click(screen.getByRole('button', { name: 'Downvote' }))
+      expect(mockRemoveVoteMutate).toHaveBeenCalledWith({ requestId: 42 })
+    })
+
+    it('disables vote buttons and does not mutate when unauthenticated', async () => {
+      const user = userEvent.setup()
+      mockAuthContext.mockReturnValue({
+        user: null,
+        isAuthenticated: false,
+        isLoading: false,
+        logout: vi.fn(),
+      })
+      render(<RequestCard request={makeRequest()} />)
+
+      const upvote = screen.getByRole('button', { name: 'Upvote' })
+      expect(upvote).toBeDisabled()
+
+      await user.click(upvote)
+      expect(mockVoteMutate).not.toHaveBeenCalled()
+      expect(mockRemoveVoteMutate).not.toHaveBeenCalled()
+    })
+
+    it('disables both vote buttons while a vote is pending', () => {
+      mockVoteMutation.mockReturnValue({
+        mutate: mockVoteMutate,
+        isPending: true,
+      })
+      render(<RequestCard request={makeRequest()} />)
+      expect(screen.getByRole('button', { name: 'Upvote' })).toBeDisabled()
+      expect(screen.getByRole('button', { name: 'Downvote' })).toBeDisabled()
+    })
+  })
+})

--- a/frontend/features/requests/components/RequestDetail.test.tsx
+++ b/frontend/features/requests/components/RequestDetail.test.tsx
@@ -1,0 +1,498 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { Request } from '../types'
+
+// ── Mocks ──────────────────────────────────────────
+
+type MockAuthValue = {
+  user: { id: string; is_admin?: boolean } | null
+  isAuthenticated: boolean
+  isLoading: boolean
+  logout: () => void
+}
+const mockAuthContext = vi.fn<() => MockAuthValue>(() => ({
+  user: { id: '1' },
+  isAuthenticated: true,
+  isLoading: false,
+  logout: vi.fn(),
+}))
+vi.mock('@/lib/context/AuthContext', () => ({
+  useAuthContext: () => mockAuthContext(),
+}))
+
+const mockPush = vi.fn()
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}))
+
+vi.mock('next/link', () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string
+    children: React.ReactNode
+    [key: string]: unknown
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}))
+
+vi.mock('@/components/shared', () => ({
+  Breadcrumb: ({ currentPage }: { currentPage: string }) => (
+    <nav aria-label="Breadcrumb">
+      <span data-testid="breadcrumb-current">{currentPage}</span>
+    </nav>
+  ),
+  UserAttribution: ({
+    name,
+    username,
+  }: {
+    name?: string | null
+    username?: string | null
+    className?: string
+  }) =>
+    username ? (
+      <a href={`/users/${username}`}>{name}</a>
+    ) : (
+      <span>{name}</span>
+    ),
+}))
+
+// Hooks — query + mutation stubs. The mutation factories are reset per-test
+// so individual cases can flip isPending without leaking across tests.
+const mockUseRequest = vi.fn()
+
+const mockDeleteMutate = vi.fn()
+const mockVoteMutate = vi.fn()
+const mockRemoveVoteMutate = vi.fn()
+const mockFulfillMutate = vi.fn()
+const mockCloseMutate = vi.fn()
+const mockUpdateMutate = vi.fn()
+
+type MutationStub = {
+  mutate: ReturnType<typeof vi.fn>
+  isPending: boolean
+  isError?: boolean
+  error?: Error | null
+}
+const mockDeleteMutation = vi.fn<() => MutationStub>(() => ({
+  mutate: mockDeleteMutate,
+  isPending: false,
+}))
+const mockVoteMutation = vi.fn<() => MutationStub>(() => ({
+  mutate: mockVoteMutate,
+  isPending: false,
+}))
+const mockRemoveVoteMutation = vi.fn<() => MutationStub>(() => ({
+  mutate: mockRemoveVoteMutate,
+  isPending: false,
+}))
+const mockFulfillMutation = vi.fn<() => MutationStub>(() => ({
+  mutate: mockFulfillMutate,
+  isPending: false,
+}))
+const mockCloseMutation = vi.fn<() => MutationStub>(() => ({
+  mutate: mockCloseMutate,
+  isPending: false,
+}))
+const mockUpdateMutation = vi.fn<() => MutationStub>(() => ({
+  mutate: mockUpdateMutate,
+  isPending: false,
+  error: null,
+}))
+
+vi.mock('../hooks', () => ({
+  useRequest: (id: number) => mockUseRequest(id),
+  useUpdateRequest: () => mockUpdateMutation(),
+  useDeleteRequest: () => mockDeleteMutation(),
+  useVoteRequest: () => mockVoteMutation(),
+  useRemoveVoteRequest: () => mockRemoveVoteMutation(),
+  useFulfillRequest: () => mockFulfillMutation(),
+  useCloseRequest: () => mockCloseMutation(),
+}))
+
+import { RequestDetail } from './RequestDetail'
+
+function makeRequest(overrides: Partial<Request> = {}): Request {
+  return {
+    id: 42,
+    title: 'Add Slowdive discography',
+    description: 'Shoegaze legends.',
+    entity_type: 'artist',
+    status: 'pending',
+    requester_id: 1,
+    requester_name: 'jane',
+    requester_username: 'jane',
+    vote_score: 5,
+    upvotes: 7,
+    downvotes: 2,
+    wilson_score: 0.5,
+    user_vote: null,
+    created_at: '2026-05-18T12:00:00Z',
+    updated_at: '2026-05-18T12:00:00Z',
+    ...overrides,
+  }
+}
+
+// The delete action is an icon-only button with no accessible name, so it
+// can't be reached via getByRole name. It is the only action styled with the
+// destructive class, which is the stable hook the test targets.
+function getDeleteButton(): HTMLElement {
+  const deleteBtn = screen
+    .getAllByRole('button')
+    .find(b => b.className.includes('text-destructive'))
+  if (!deleteBtn) throw new Error('delete button not found')
+  return deleteBtn
+}
+
+function queryResult(
+  overrides: Partial<ReturnType<typeof mockUseRequest>> = {}
+) {
+  return {
+    data: makeRequest(),
+    isLoading: false,
+    error: null,
+    ...overrides,
+  }
+}
+
+describe('RequestDetail', () => {
+  beforeEach(() => {
+    mockAuthContext.mockReturnValue({
+      user: { id: '1' },
+      isAuthenticated: true,
+      isLoading: false,
+      logout: vi.fn(),
+    })
+    mockUseRequest.mockReturnValue(queryResult())
+    mockDeleteMutation.mockReturnValue({
+      mutate: mockDeleteMutate,
+      isPending: false,
+    })
+    mockVoteMutation.mockReturnValue({ mutate: mockVoteMutate, isPending: false })
+    mockRemoveVoteMutation.mockReturnValue({
+      mutate: mockRemoveVoteMutate,
+      isPending: false,
+    })
+    mockFulfillMutation.mockReturnValue({
+      mutate: mockFulfillMutate,
+      isPending: false,
+    })
+    mockCloseMutation.mockReturnValue({
+      mutate: mockCloseMutate,
+      isPending: false,
+    })
+    mockUpdateMutation.mockReturnValue({
+      mutate: mockUpdateMutate,
+      isPending: false,
+      error: null,
+    })
+  })
+
+  describe('loading and error states', () => {
+    it('renders a spinner while loading', () => {
+      mockUseRequest.mockReturnValue(
+        queryResult({ isLoading: true, data: undefined })
+      )
+      const { container } = render(<RequestDetail requestId={42} />)
+      expect(container.querySelector('.animate-spin')).toBeInTheDocument()
+    })
+
+    it('renders a not-found message for a 404 error', () => {
+      mockUseRequest.mockReturnValue(
+        queryResult({ error: new Error('not found'), data: undefined })
+      )
+      render(<RequestDetail requestId={42} />)
+      expect(screen.getByText('Request Not Found')).toBeInTheDocument()
+    })
+
+    it('renders a generic error message for other errors', () => {
+      mockUseRequest.mockReturnValue(
+        queryResult({ error: new Error('server exploded'), data: undefined })
+      )
+      render(<RequestDetail requestId={42} />)
+      expect(screen.getByText('Error Loading Request')).toBeInTheDocument()
+      expect(screen.getByText('server exploded')).toBeInTheDocument()
+    })
+
+    it('renders a not-found message when the request is missing', () => {
+      mockUseRequest.mockReturnValue(queryResult({ data: undefined }))
+      render(<RequestDetail requestId={42} />)
+      expect(screen.getByText('Request Not Found')).toBeInTheDocument()
+    })
+  })
+
+  describe('rendering', () => {
+    it('renders the title, status badge, and entity-type badge', () => {
+      render(<RequestDetail requestId={42} />)
+      expect(
+        screen.getByRole('heading', { name: 'Add Slowdive discography' })
+      ).toBeInTheDocument()
+      expect(screen.getByText('Pending')).toBeInTheDocument()
+      expect(screen.getByText('Artist')).toBeInTheDocument()
+    })
+
+    it('renders the vote score plus the up/down breakdown', () => {
+      render(<RequestDetail requestId={42} />)
+      expect(screen.getByText('5')).toBeInTheDocument()
+      expect(screen.getByText('7 up / 2 down')).toBeInTheDocument()
+    })
+
+    it('renders the requester attribution as a profile link', () => {
+      render(<RequestDetail requestId={42} />)
+      expect(screen.getByText('jane').closest('a')).toHaveAttribute(
+        'href',
+        '/users/jane'
+      )
+    })
+
+    it('renders the description', () => {
+      render(<RequestDetail requestId={42} />)
+      expect(screen.getByText('Shoegaze legends.')).toBeInTheDocument()
+    })
+
+    it('links to the requested entity when one is attached', () => {
+      mockUseRequest.mockReturnValue(
+        queryResult({
+          data: makeRequest({ entity_type: 'artist', requested_entity_id: 99 }),
+        })
+      )
+      render(<RequestDetail requestId={42} />)
+      const link = screen
+        .getByText(/View requested artist/i)
+        .closest('a')
+      expect(link).toHaveAttribute('href', '/artists/99')
+    })
+
+    it('renders fulfillment info for a fulfilled request', () => {
+      mockUseRequest.mockReturnValue(
+        queryResult({
+          data: makeRequest({
+            status: 'fulfilled',
+            fulfiller_name: 'admin-bob',
+            fulfilled_at: '2026-05-19T12:00:00Z',
+          }),
+        })
+      )
+      render(<RequestDetail requestId={42} />)
+      // "Fulfilled" appears twice for a fulfilled request: the status badge
+      // and the fulfillment info box. The fulfiller byline is unique.
+      expect(screen.getAllByText('Fulfilled')).toHaveLength(2)
+      expect(screen.getByText(/by admin-bob/)).toBeInTheDocument()
+    })
+  })
+
+  describe('voting', () => {
+    it('casts an upvote when no prior vote exists', async () => {
+      const user = userEvent.setup()
+      render(<RequestDetail requestId={42} />)
+      await user.click(screen.getByRole('button', { name: 'Upvote' }))
+      expect(mockVoteMutate).toHaveBeenCalledWith({
+        requestId: 42,
+        is_upvote: true,
+      })
+    })
+
+    it('removes the vote when re-clicking an existing upvote', async () => {
+      const user = userEvent.setup()
+      mockUseRequest.mockReturnValue(
+        queryResult({ data: makeRequest({ user_vote: 1 }) })
+      )
+      render(<RequestDetail requestId={42} />)
+      await user.click(screen.getByRole('button', { name: 'Upvote' }))
+      expect(mockRemoveVoteMutate).toHaveBeenCalledWith({ requestId: 42 })
+    })
+
+    it('disables vote buttons when unauthenticated', () => {
+      mockAuthContext.mockReturnValue({
+        user: null,
+        isAuthenticated: false,
+        isLoading: false,
+        logout: vi.fn(),
+      })
+      render(<RequestDetail requestId={42} />)
+      expect(screen.getByRole('button', { name: 'Upvote' })).toBeDisabled()
+      expect(screen.getByRole('button', { name: 'Downvote' })).toBeDisabled()
+    })
+  })
+
+  describe('permission-gated actions', () => {
+    it('shows Edit and Delete for the requester', () => {
+      // requester_id 1 matches the authed user id '1'.
+      render(<RequestDetail requestId={42} />)
+      expect(
+        screen.getByRole('button', { name: /Edit/i })
+      ).toBeInTheDocument()
+      expect(getDeleteButton()).toBeInTheDocument()
+      // Fulfill/Close are admin-only and must stay hidden for a plain requester.
+      expect(
+        screen.queryByRole('button', { name: /Fulfill/i })
+      ).not.toBeInTheDocument()
+    })
+
+    it('hides Edit/Delete for a non-owner non-admin', () => {
+      mockAuthContext.mockReturnValue({
+        user: { id: '99', is_admin: false },
+        isAuthenticated: true,
+        isLoading: false,
+        logout: vi.fn(),
+      })
+      render(<RequestDetail requestId={42} />)
+      expect(
+        screen.queryByRole('button', { name: /Edit/i })
+      ).not.toBeInTheDocument()
+    })
+
+    it('shows admin-only Fulfill and Close on a pending request', () => {
+      mockAuthContext.mockReturnValue({
+        user: { id: '99', is_admin: true },
+        isAuthenticated: true,
+        isLoading: false,
+        logout: vi.fn(),
+      })
+      render(<RequestDetail requestId={42} />)
+      expect(
+        screen.getByRole('button', { name: /Fulfill/i })
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: /Close/i })
+      ).toBeInTheDocument()
+    })
+
+    it('hides Fulfill once the request is already fulfilled', () => {
+      mockAuthContext.mockReturnValue({
+        user: { id: '99', is_admin: true },
+        isAuthenticated: true,
+        isLoading: false,
+        logout: vi.fn(),
+      })
+      mockUseRequest.mockReturnValue(
+        queryResult({ data: makeRequest({ status: 'fulfilled' }) })
+      )
+      render(<RequestDetail requestId={42} />)
+      expect(
+        screen.queryByRole('button', { name: /Fulfill/i })
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  describe('mutating actions', () => {
+    it('deletes and navigates away after confirmation', async () => {
+      const user = userEvent.setup()
+      const confirmSpy = vi
+        .spyOn(window, 'confirm')
+        .mockReturnValue(true)
+      // mutate calls onSuccess synchronously so we can assert the redirect.
+      mockDeleteMutate.mockImplementation(
+        (_vars, opts?: { onSuccess?: () => void }) => opts?.onSuccess?.()
+      )
+
+      render(<RequestDetail requestId={42} />)
+      await user.click(getDeleteButton())
+
+      expect(confirmSpy).toHaveBeenCalled()
+      expect(mockDeleteMutate).toHaveBeenCalledWith(
+        { requestId: 42 },
+        expect.objectContaining({ onSuccess: expect.any(Function) })
+      )
+      expect(mockPush).toHaveBeenCalledWith('/requests')
+      confirmSpy.mockRestore()
+    })
+
+    it('does not delete when confirmation is dismissed', async () => {
+      const user = userEvent.setup()
+      const confirmSpy = vi
+        .spyOn(window, 'confirm')
+        .mockReturnValue(false)
+
+      render(<RequestDetail requestId={42} />)
+      await user.click(getDeleteButton())
+
+      expect(confirmSpy).toHaveBeenCalled()
+      expect(mockDeleteMutate).not.toHaveBeenCalled()
+      confirmSpy.mockRestore()
+    })
+
+    it('fulfills immediately without a confirm prompt', async () => {
+      const user = userEvent.setup()
+      const confirmSpy = vi.spyOn(window, 'confirm')
+      mockAuthContext.mockReturnValue({
+        user: { id: '99', is_admin: true },
+        isAuthenticated: true,
+        isLoading: false,
+        logout: vi.fn(),
+      })
+      render(<RequestDetail requestId={42} />)
+
+      await user.click(screen.getByRole('button', { name: /Fulfill/i }))
+      expect(mockFulfillMutate).toHaveBeenCalledWith({ requestId: 42 })
+      expect(confirmSpy).not.toHaveBeenCalled()
+      confirmSpy.mockRestore()
+    })
+
+    it('closes the request after confirmation', async () => {
+      const user = userEvent.setup()
+      const confirmSpy = vi
+        .spyOn(window, 'confirm')
+        .mockReturnValue(true)
+      mockAuthContext.mockReturnValue({
+        user: { id: '99', is_admin: true },
+        isAuthenticated: true,
+        isLoading: false,
+        logout: vi.fn(),
+      })
+      render(<RequestDetail requestId={42} />)
+
+      await user.click(screen.getByRole('button', { name: /Close/i }))
+      expect(confirmSpy).toHaveBeenCalled()
+      expect(mockCloseMutate).toHaveBeenCalledWith({ requestId: 42 })
+      confirmSpy.mockRestore()
+    })
+  })
+
+  describe('inline edit', () => {
+    it('opens the inline edit form and saves an update', async () => {
+      const user = userEvent.setup()
+      mockUpdateMutate.mockImplementation(
+        (_vars, opts?: { onSuccess?: () => void }) => opts?.onSuccess?.()
+      )
+      render(<RequestDetail requestId={42} />)
+
+      await user.click(screen.getByRole('button', { name: /Edit/i }))
+
+      const titleInput = screen.getByLabelText('Title')
+      await user.clear(titleInput)
+      await user.type(titleInput, 'Updated title')
+      await user.click(screen.getByRole('button', { name: /Save/i }))
+
+      expect(mockUpdateMutate).toHaveBeenCalledWith(
+        {
+          requestId: 42,
+          title: 'Updated title',
+          description: 'Shoegaze legends.',
+        },
+        expect.objectContaining({ onSuccess: expect.any(Function) })
+      )
+    })
+
+    it('returns to the read view when editing is cancelled', async () => {
+      const user = userEvent.setup()
+      render(<RequestDetail requestId={42} />)
+
+      await user.click(screen.getByRole('button', { name: /Edit/i }))
+      expect(screen.getByLabelText('Title')).toBeInTheDocument()
+
+      await user.click(screen.getByRole('button', { name: 'Cancel' }))
+      expect(screen.queryByLabelText('Title')).not.toBeInTheDocument()
+      expect(
+        screen.getByRole('heading', { name: 'Add Slowdive discography' })
+      ).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/features/requests/components/RequestList.test.tsx
+++ b/frontend/features/requests/components/RequestList.test.tsx
@@ -1,0 +1,340 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { Request, RequestListResponse } from '../types'
+
+// ── Mocks ──────────────────────────────────────────
+
+type MockAuthValue = {
+  user: { id: string; is_admin?: boolean } | null
+  isAuthenticated: boolean
+  isLoading: boolean
+  logout: () => void
+}
+const mockAuthContext = vi.fn<() => MockAuthValue>(() => ({
+  user: null,
+  isAuthenticated: false,
+  isLoading: false,
+  logout: vi.fn(),
+}))
+vi.mock('@/lib/context/AuthContext', () => ({
+  useAuthContext: () => mockAuthContext(),
+}))
+
+const mockUseRequests = vi.fn()
+const mockCreateMutate = vi.fn()
+const mockCreateMutation = vi.fn(() => ({
+  mutate: mockCreateMutate,
+  isPending: false,
+  error: null,
+}))
+const mockRefetch = vi.fn()
+vi.mock('../hooks', () => ({
+  useRequests: (params: unknown) => mockUseRequests(params),
+  useCreateRequest: () => mockCreateMutation(),
+}))
+
+// Stub RequestCard so the list test does not pull in the card's own hooks.
+vi.mock('./RequestCard', () => ({
+  RequestCard: ({ request }: { request: Request }) => (
+    <article data-testid={`request-card-${request.id}`}>{request.title}</article>
+  ),
+}))
+
+vi.mock('@/components/shared', () => ({
+  LoadingSpinner: () => <div data-testid="loading-spinner">Loading...</div>,
+}))
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+    ...props
+  }: {
+    children: React.ReactNode
+    onClick?: () => void
+    disabled?: boolean
+    [key: string]: unknown
+  }) => (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      type={props.type as 'button' | 'reset' | 'submit' | undefined}
+    >
+      {children}
+    </button>
+  ),
+}))
+
+vi.mock('@/components/ui/input', () => ({
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => (
+    <input {...props} />
+  ),
+}))
+
+vi.mock('@/components/ui/textarea', () => ({
+  Textarea: (props: React.TextareaHTMLAttributes<HTMLTextAreaElement>) => (
+    <textarea {...props} />
+  ),
+}))
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ children, open }: { children: React.ReactNode; open: boolean }) => (
+    <div data-testid="dialog" data-open={open}>
+      {children}
+    </div>
+  ),
+  DialogContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="dialog-content">{children}</div>
+  ),
+  DialogHeader: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogTitle: ({ children }: { children: React.ReactNode }) => (
+    <h2>{children}</h2>
+  ),
+  DialogTrigger: ({ children }: { children: React.ReactNode; asChild?: boolean }) => (
+    <>{children}</>
+  ),
+}))
+
+import { RequestList } from './RequestList'
+
+function makeRequest(overrides: Partial<Request> = {}): Request {
+  return {
+    id: 1,
+    title: 'Add Slowdive',
+    entity_type: 'artist',
+    status: 'pending',
+    requester_id: 1,
+    requester_name: 'jane',
+    requester_username: 'jane',
+    vote_score: 3,
+    upvotes: 4,
+    downvotes: 1,
+    wilson_score: 0.5,
+    user_vote: null,
+    created_at: '2026-05-18T12:00:00Z',
+    updated_at: '2026-05-18T12:00:00Z',
+    ...overrides,
+  }
+}
+
+function listResult(
+  overrides: Partial<ReturnType<typeof mockUseRequests>> = {}
+) {
+  return {
+    data: { requests: [], total: 0 } as RequestListResponse,
+    isLoading: false,
+    error: null,
+    refetch: mockRefetch,
+    ...overrides,
+  }
+}
+
+describe('RequestList', () => {
+  beforeEach(() => {
+    mockAuthContext.mockReturnValue({
+      user: null,
+      isAuthenticated: false,
+      isLoading: false,
+      logout: vi.fn(),
+    })
+    mockCreateMutation.mockReturnValue({
+      mutate: mockCreateMutate,
+      isPending: false,
+      error: null,
+    })
+    mockUseRequests.mockReturnValue(listResult())
+  })
+
+  it('shows a loading spinner before the first response', () => {
+    mockUseRequests.mockReturnValue(
+      listResult({ isLoading: true, data: undefined })
+    )
+    render(<RequestList />)
+    expect(screen.getByTestId('loading-spinner')).toBeInTheDocument()
+  })
+
+  it('shows an error state with a retry button', async () => {
+    const user = userEvent.setup()
+    mockUseRequests.mockReturnValue(
+      listResult({ error: new Error('boom'), data: undefined })
+    )
+    render(<RequestList />)
+
+    expect(
+      screen.getByText(/Failed to load requests/i)
+    ).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(mockRefetch).toHaveBeenCalled()
+  })
+
+  it('renders a card per request and a results count', () => {
+    mockUseRequests.mockReturnValue(
+      listResult({
+        data: {
+          requests: [
+            makeRequest({ id: 1, title: 'Add Slowdive' }),
+            makeRequest({ id: 2, title: 'Add Ride' }),
+          ],
+          total: 2,
+        },
+      })
+    )
+    render(<RequestList />)
+
+    expect(screen.getByTestId('request-card-1')).toBeInTheDocument()
+    expect(screen.getByTestId('request-card-2')).toBeInTheDocument()
+    expect(screen.getByText('2 requests found')).toBeInTheDocument()
+  })
+
+  it('uses the singular noun for a single result', () => {
+    mockUseRequests.mockReturnValue(
+      listResult({ data: { requests: [makeRequest()], total: 1 } })
+    )
+    render(<RequestList />)
+    expect(screen.getByText('1 request found')).toBeInTheDocument()
+  })
+
+  it('renders an empty state when there are no requests', () => {
+    render(<RequestList />)
+    expect(screen.getByText('No requests found.')).toBeInTheDocument()
+  })
+
+  it('passes the votes sort to useRequests by default', () => {
+    render(<RequestList />)
+    expect(mockUseRequests).toHaveBeenCalledWith(
+      expect.objectContaining({ sort_by: 'votes', limit: 20, offset: 0 })
+    )
+  })
+
+  it('forwards the selected entity-type filter to useRequests', async () => {
+    const user = userEvent.setup()
+    render(<RequestList />)
+
+    await user.selectOptions(
+      screen.getByLabelText('Filter by entity type'),
+      'venue'
+    )
+    expect(mockUseRequests).toHaveBeenLastCalledWith(
+      expect.objectContaining({ entity_type: 'venue' })
+    )
+  })
+
+  it('forwards the selected status filter to useRequests', async () => {
+    const user = userEvent.setup()
+    render(<RequestList />)
+
+    await user.selectOptions(
+      screen.getByLabelText('Filter by status'),
+      'fulfilled'
+    )
+    expect(mockUseRequests).toHaveBeenLastCalledWith(
+      expect.objectContaining({ status: 'fulfilled' })
+    )
+  })
+
+  it('forwards the chosen sort to useRequests', async () => {
+    const user = userEvent.setup()
+    render(<RequestList />)
+
+    await user.selectOptions(screen.getByLabelText('Sort by'), 'newest')
+    expect(mockUseRequests).toHaveBeenLastCalledWith(
+      expect.objectContaining({ sort_by: 'newest' })
+    )
+  })
+
+  describe('authentication-gated UI', () => {
+    it('hides the New Request action when signed out', () => {
+      render(<RequestList />)
+      expect(
+        screen.queryByRole('button', { name: /New Request/i })
+      ).not.toBeInTheDocument()
+    })
+
+    it('shows the New Request action when signed in', () => {
+      mockAuthContext.mockReturnValue({
+        user: { id: '1' },
+        isAuthenticated: true,
+        isLoading: false,
+        logout: vi.fn(),
+      })
+      render(<RequestList />)
+      expect(
+        screen.getByRole('button', { name: /New Request/i })
+      ).toBeInTheDocument()
+    })
+  })
+
+  describe('pagination', () => {
+    it('hides pagination on a single page', () => {
+      mockUseRequests.mockReturnValue(
+        listResult({ data: { requests: [makeRequest()], total: 5 } })
+      )
+      render(<RequestList />)
+      expect(
+        screen.queryByRole('button', { name: 'Next' })
+      ).not.toBeInTheDocument()
+    })
+
+    it('advances the offset when Next is clicked', async () => {
+      const user = userEvent.setup()
+      mockUseRequests.mockReturnValue(
+        listResult({
+          data: { requests: [makeRequest()], total: 40 },
+        })
+      )
+      render(<RequestList />)
+
+      await user.click(screen.getByRole('button', { name: 'Next' }))
+      expect(mockUseRequests).toHaveBeenLastCalledWith(
+        expect.objectContaining({ offset: 20 })
+      )
+    })
+  })
+
+  describe('create form', () => {
+    beforeEach(() => {
+      mockAuthContext.mockReturnValue({
+        user: { id: '1' },
+        isAuthenticated: true,
+        isLoading: false,
+        logout: vi.fn(),
+      })
+    })
+
+    it('submits a new request with trimmed title and entity type', async () => {
+      const user = userEvent.setup()
+      render(<RequestList />)
+
+      const dialog = screen.getByTestId('dialog-content')
+      await user.type(within(dialog).getByLabelText('Title'), '  New Band  ')
+      await user.click(
+        within(dialog).getByRole('button', { name: 'Create Request' })
+      )
+
+      expect(mockCreateMutate).toHaveBeenCalledWith(
+        { title: 'New Band', description: undefined, entity_type: 'artist' },
+        expect.objectContaining({ onSuccess: expect.any(Function) })
+      )
+    })
+
+    it('does not submit when the title is blank', async () => {
+      const user = userEvent.setup()
+      render(<RequestList />)
+
+      const dialog = screen.getByTestId('dialog-content')
+      const submit = within(dialog).getByRole('button', {
+        name: 'Create Request',
+      })
+      // Empty title keeps the submit disabled; clicking is a no-op.
+      expect(submit).toBeDisabled()
+      await user.click(submit)
+      expect(mockCreateMutate).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/frontend/features/requests/types.test.ts
+++ b/frontend/features/requests/types.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  REQUEST_ENTITY_TYPES,
+  REQUEST_STATUSES,
+  REQUEST_SORT_OPTIONS,
+  getEntityTypeLabel,
+  getStatusLabel,
+  getEntityTypeColor,
+  getStatusColor,
+  getEntityUrl,
+  formatTimeAgo,
+  formatDate,
+} from './types'
+
+describe('request type constants', () => {
+  it('exposes the six supported entity types', () => {
+    expect(REQUEST_ENTITY_TYPES).toEqual([
+      'artist',
+      'release',
+      'label',
+      'show',
+      'venue',
+      'festival',
+    ])
+  })
+
+  it('exposes the five lifecycle statuses', () => {
+    expect(REQUEST_STATUSES).toEqual([
+      'pending',
+      'in_progress',
+      'fulfilled',
+      'rejected',
+      'cancelled',
+    ])
+  })
+
+  it('exposes the three sort options', () => {
+    expect(REQUEST_SORT_OPTIONS).toEqual(['votes', 'newest', 'oldest'])
+  })
+})
+
+describe('getEntityTypeLabel', () => {
+  it.each([
+    ['artist', 'Artist'],
+    ['venue', 'Venue'],
+    ['show', 'Show'],
+    ['release', 'Release'],
+    ['label', 'Label'],
+    ['festival', 'Festival'],
+  ])('maps %s to %s', (input, expected) => {
+    expect(getEntityTypeLabel(input)).toBe(expected)
+  })
+
+  it('returns the raw value for an unknown type', () => {
+    expect(getEntityTypeLabel('mixtape')).toBe('mixtape')
+  })
+})
+
+describe('getStatusLabel', () => {
+  it.each([
+    ['pending', 'Pending'],
+    ['in_progress', 'In Progress'],
+    ['fulfilled', 'Fulfilled'],
+    ['rejected', 'Rejected'],
+    ['cancelled', 'Cancelled'],
+  ])('maps %s to %s', (input, expected) => {
+    expect(getStatusLabel(input)).toBe(expected)
+  })
+
+  it('returns the raw value for an unknown status', () => {
+    expect(getStatusLabel('archived')).toBe('archived')
+  })
+})
+
+describe('getEntityTypeColor', () => {
+  it('returns a distinct class for each known entity type', () => {
+    const colors = REQUEST_ENTITY_TYPES.map(getEntityTypeColor)
+    // Every known type maps to a unique, non-muted class.
+    expect(new Set(colors).size).toBe(REQUEST_ENTITY_TYPES.length)
+    colors.forEach(c => expect(c).not.toContain('text-muted-foreground'))
+  })
+
+  it('falls back to muted styling for an unknown type', () => {
+    expect(getEntityTypeColor('unknown')).toBe(
+      'bg-muted text-muted-foreground'
+    )
+  })
+})
+
+describe('getStatusColor', () => {
+  it('returns a yellow class for pending', () => {
+    expect(getStatusColor('pending')).toContain('yellow')
+  })
+
+  it('returns a green class for fulfilled', () => {
+    expect(getStatusColor('fulfilled')).toContain('green')
+  })
+
+  it('returns a red class for rejected', () => {
+    expect(getStatusColor('rejected')).toContain('red')
+  })
+
+  it('falls back to muted styling for cancelled and unknown', () => {
+    expect(getStatusColor('cancelled')).toBe('bg-muted text-muted-foreground')
+    expect(getStatusColor('whatever')).toBe('bg-muted text-muted-foreground')
+  })
+})
+
+describe('getEntityUrl', () => {
+  it.each([
+    ['artist', 7, '/artists/7'],
+    ['venue', 7, '/venues/7'],
+    ['show', 7, '/shows/7'],
+    ['release', 7, '/releases/7'],
+    ['label', 7, '/labels/7'],
+    ['festival', 7, '/festivals/7'],
+  ])('builds %s url', (type, id, expected) => {
+    expect(getEntityUrl(type, id)).toBe(expected)
+  })
+
+  it('returns "#" for an unknown entity type', () => {
+    expect(getEntityUrl('mixtape', 7)).toBe('#')
+  })
+})
+
+describe('formatDate', () => {
+  it('formats an ISO date as "Mon D, YYYY"', () => {
+    // Use midday UTC so the date does not roll backward in negative-offset
+    // test environments.
+    expect(formatDate('2026-01-05T12:00:00Z')).toBe('Jan 5, 2026')
+  })
+})
+
+describe('formatTimeAgo', () => {
+  // formatTimeAgo compares against Date.now(); pin the clock so the relative
+  // strings are deterministic regardless of when the suite runs.
+  const NOW = new Date('2026-05-19T12:00:00Z')
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  function ago(ms: number): string {
+    return formatTimeAgo(new Date(NOW.getTime() - ms).toISOString())
+  }
+
+  const SECOND = 1000
+  const MINUTE = 60 * SECOND
+  const HOUR = 60 * MINUTE
+  const DAY = 24 * HOUR
+  const WEEK = 7 * DAY
+
+  it('returns "just now" under a minute', () => {
+    expect(ago(30 * SECOND)).toBe('just now')
+  })
+
+  it('singularizes one minute', () => {
+    expect(ago(MINUTE)).toBe('1 minute ago')
+  })
+
+  it('pluralizes minutes', () => {
+    expect(ago(5 * MINUTE)).toBe('5 minutes ago')
+  })
+
+  it('singularizes one hour', () => {
+    expect(ago(HOUR)).toBe('1 hour ago')
+  })
+
+  it('pluralizes hours', () => {
+    expect(ago(3 * HOUR)).toBe('3 hours ago')
+  })
+
+  it('singularizes one day', () => {
+    expect(ago(DAY)).toBe('1 day ago')
+  })
+
+  it('pluralizes days', () => {
+    expect(ago(3 * DAY)).toBe('3 days ago')
+  })
+
+  it('singularizes one week', () => {
+    expect(ago(WEEK)).toBe('1 week ago')
+  })
+
+  it('pluralizes weeks', () => {
+    expect(ago(3 * WEEK)).toBe('3 weeks ago')
+  })
+
+  it('singularizes one month', () => {
+    // The month branch is only reachable once the week count reaches 5
+    // (diffWeeks < 5 short-circuits first), so 35 days is the floor for
+    // "1 month ago" rather than 31.
+    expect(ago(35 * DAY)).toBe('1 month ago')
+  })
+
+  it('pluralizes months', () => {
+    expect(ago(90 * DAY)).toBe('3 months ago')
+  })
+
+  it('falls back to an absolute date past a year', () => {
+    // ~13 months ago — beyond the relative window, so it returns formatDate().
+    expect(ago(400 * DAY)).toBe(formatDate(new Date(NOW.getTime() - 400 * DAY).toISOString()))
+  })
+})


### PR DESCRIPTION
## Summary
- Add sibling tests for the three untested request components and the `types` helpers, closing the `features/requests/` coverage gap (was 1 test of ~5 files).
- `RequestCard` (15 tests): render, entity-type + status badges, vote interaction (cast/remove for up + down), unauthenticated + pending disabled states.
- `RequestList` (15 tests): loading/error/empty states, filter + sort wiring to `useRequests`, pagination, auth-gated New Request action, create-form submit + blank-title guard.
- `RequestDetail` (23 tests): loading/404/generic-error/missing states, vote widget, permission-gated edit/fulfill/close/delete actions, delete confirm + cancel flows, inline edit save + cancel.
- `types` (42 tests): entity/status label + color maps, entity URL builder, and `formatTimeAgo` relative-time boundaries (including the non-obvious week→month threshold).
- Existing `hooks/index.test.tsx` already covers all nine exported hooks end-to-end (loading/success/error + optimistic update/rollback); left as-is.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run test:run features/requests` — 110/110 passing

## Manual repro
Test-only diff; no runtime change. Passing suite IS the verification.

## Coverage gaps
- The ticket AC lists a "comments link," but no comments link/section exists in any requests component (`app/requests/[id]/page.tsx` renders only `<RequestDetail>`, which has no comments UI). Nothing to cover; flagged rather than invented.
- `RequestDetail`'s delete button is icon-only with no accessible name, so the tests target it via its `text-destructive` class. Noted as a minor a11y gap in the component (not fixed here, out of scope).

## Simplify
Ran `/simplify` (Agent tool unavailable in this env, so reviewed the three lenses — reuse/quality/efficiency — directly). One quality fix: replaced a brittle positional `buttons[buttons.length - 1]` delete-button selector with a `getDeleteButton()` helper keyed on the stable destructive class, and strengthened the requester-permissions test to assert the delete button's presence. Re-ran typecheck + tests after the edit; both green.

Closes PSY-689