### PR TITLE
PSY-690: test coverage for features/scenes module

### DIFF
--- a/frontend/features/scenes/components/SceneDetail.test.tsx
+++ b/frontend/features/scenes/components/SceneDetail.test.tsx
@@ -1,0 +1,282 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, within } from '@testing-library/react'
+import { renderWithProviders } from '@/test/utils'
+import type {
+  SceneDetail,
+  SceneArtistsResponse,
+  SceneGenreResponse,
+} from '../types'
+
+// PSY-690: SceneDetailView orchestrates the scene page — loading/not-found
+// branches, the header + stat summary, and the content cards (which delegate
+// to useSceneArtists / useSceneGenres and the ScenePulse / SceneGraph
+// children). Mock the data hooks and the two child components so this test
+// covers the view's own composition without dragging in the canvas.
+
+vi.mock('next/link', () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string
+    children: React.ReactNode
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}))
+
+// Child components are covered by their own sibling tests; stub them so the
+// canvas (SceneGraph → SceneGraphVisualization → ForceGraphView) never mounts
+// and ScenePulse logic isn't re-asserted here.
+vi.mock('./ScenePulse', () => ({
+  ScenePulse: () => <div data-testid="scene-pulse" />,
+}))
+vi.mock('./SceneGraph', () => ({
+  SceneGraph: () => <div data-testid="scene-graph" />,
+}))
+
+const mockUseSceneDetail = vi.fn()
+const mockUseSceneArtists = vi.fn()
+const mockUseSceneGenres = vi.fn()
+vi.mock('../hooks', () => ({
+  useSceneDetail: () => mockUseSceneDetail(),
+  useSceneArtists: () => mockUseSceneArtists(),
+  useSceneGenres: () => mockUseSceneGenres(),
+}))
+
+import { SceneDetailView } from './SceneDetail'
+
+function buildScene(overrides: Partial<SceneDetail> = {}): SceneDetail {
+  return {
+    city: 'Phoenix',
+    state: 'AZ',
+    slug: 'phoenix-az',
+    description: null,
+    stats: {
+      venue_count: 12,
+      artist_count: 85,
+      upcoming_show_count: 45,
+      festival_count: 0,
+    },
+    pulse: {
+      shows_this_month: 30,
+      shows_prev_month: 25,
+      shows_trend: 5,
+      new_artists_30d: 8,
+      active_venues_this_month: 10,
+      shows_by_month: [20, 22, 25, 28, 30, 30],
+    },
+    ...overrides,
+  }
+}
+
+const emptyArtists: SceneArtistsResponse = { artists: [], total: 0 }
+const emptyGenres: SceneGenreResponse = {
+  genres: [],
+  diversity_index: 0,
+  diversity_label: '',
+}
+
+describe('SceneDetailView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Sensible defaults for the inner lists; individual tests override.
+    mockUseSceneArtists.mockReturnValue({ data: emptyArtists, isLoading: false })
+    mockUseSceneGenres.mockReturnValue({ data: emptyGenres, isLoading: false })
+  })
+
+  it('renders a loading spinner while the scene detail is loading', () => {
+    mockUseSceneDetail.mockReturnValue({ data: undefined, isLoading: true, error: null })
+    const { container } = renderWithProviders(<SceneDetailView slug="phoenix-az" />)
+    expect(container.querySelector('.animate-spin')).toBeInTheDocument()
+  })
+
+  it('renders the not-found state on error', () => {
+    mockUseSceneDetail.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('nope'),
+    })
+    renderWithProviders(<SceneDetailView slug="missing" />)
+    expect(screen.getByText('Scene not found')).toBeInTheDocument()
+    expect(screen.getByText('Browse all scenes')).toBeInTheDocument()
+  })
+
+  it('renders the not-found state when there is no data and no error', () => {
+    mockUseSceneDetail.mockReturnValue({ data: undefined, isLoading: false, error: null })
+    renderWithProviders(<SceneDetailView slug="missing" />)
+    expect(screen.getByText('Scene not found')).toBeInTheDocument()
+  })
+
+  describe('populated scene', () => {
+    it('renders the city/state heading and the stat summary line', () => {
+      mockUseSceneDetail.mockReturnValue({
+        data: buildScene(),
+        isLoading: false,
+        error: null,
+      })
+      renderWithProviders(<SceneDetailView slug="phoenix-az" />)
+
+      const heading = screen.getByRole('heading', { level: 1, name: 'Phoenix, AZ' })
+      expect(heading).toBeInTheDocument()
+
+      // The stat summary is the single `<p>` directly after the heading; the
+      // venue/artist/show counts also appear in the cards below, so match the
+      // whole joined line rather than substrings.
+      const summary = heading.nextElementSibling as HTMLElement
+      const sep = ' · ' // statParts.join separator
+      expect(summary.textContent).toBe(
+        ['12 venues', '85 artists', '45 upcoming shows'].join(sep)
+      )
+    })
+
+    it('renders the scene description when present', () => {
+      mockUseSceneDetail.mockReturnValue({
+        data: buildScene({ description: 'A desert DIY scene.' }),
+        isLoading: false,
+        error: null,
+      })
+      renderWithProviders(<SceneDetailView slug="phoenix-az" />)
+      expect(screen.getByText('A desert DIY scene.')).toBeInTheDocument()
+    })
+
+    it('mounts the ScenePulse and SceneGraph children', () => {
+      mockUseSceneDetail.mockReturnValue({
+        data: buildScene(),
+        isLoading: false,
+        error: null,
+      })
+      renderWithProviders(<SceneDetailView slug="phoenix-az" />)
+      expect(screen.getByTestId('scene-pulse')).toBeInTheDocument()
+      expect(screen.getByTestId('scene-graph')).toBeInTheDocument()
+    })
+
+    it('hides the festivals card when festival_count is 0', () => {
+      mockUseSceneDetail.mockReturnValue({
+        data: buildScene({
+          stats: {
+            venue_count: 12,
+            artist_count: 85,
+            upcoming_show_count: 45,
+            festival_count: 0,
+          },
+        }),
+        isLoading: false,
+        error: null,
+      })
+      renderWithProviders(<SceneDetailView slug="phoenix-az" />)
+      expect(screen.queryByText('Festivals')).not.toBeInTheDocument()
+    })
+
+    it('shows the festivals card when festival_count > 0', () => {
+      mockUseSceneDetail.mockReturnValue({
+        data: buildScene({
+          stats: {
+            venue_count: 12,
+            artist_count: 85,
+            upcoming_show_count: 45,
+            festival_count: 3,
+          },
+        }),
+        isLoading: false,
+        error: null,
+      })
+      renderWithProviders(<SceneDetailView slug="phoenix-az" />)
+      expect(screen.getByText('Festivals')).toBeInTheDocument()
+      expect(screen.getByText(/3 festivals in Phoenix/)).toBeInTheDocument()
+    })
+  })
+
+  describe('active artists list', () => {
+    beforeEach(() => {
+      mockUseSceneDetail.mockReturnValue({
+        data: buildScene(),
+        isLoading: false,
+        error: null,
+      })
+    })
+
+    it('renders an artist row per result with a pluralized show-count badge', () => {
+      mockUseSceneArtists.mockReturnValue({
+        data: {
+          artists: [
+            { id: 1, slug: 'gatecreeper', name: 'Gatecreeper', city: 'Phoenix', state: 'AZ', show_count: 5 },
+            { id: 2, slug: 'sundressed', name: 'Sundressed', city: 'Phoenix', state: 'AZ', show_count: 1 },
+          ],
+          total: 2,
+        } as SceneArtistsResponse,
+        isLoading: false,
+      })
+      renderWithProviders(<SceneDetailView slug="phoenix-az" />)
+
+      const gatecreeper = screen.getByText('Gatecreeper').closest('a')!
+      expect(gatecreeper).toHaveAttribute('href', '/artists/gatecreeper')
+      expect(within(gatecreeper).getByText('5 shows')).toBeInTheDocument()
+
+      const sundressed = screen.getByText('Sundressed').closest('a')!
+      expect(within(sundressed).getByText('1 show')).toBeInTheDocument()
+    })
+
+    it('renders an empty-state message when no active artists', () => {
+      mockUseSceneArtists.mockReturnValue({ data: emptyArtists, isLoading: false })
+      renderWithProviders(<SceneDetailView slug="phoenix-az" />)
+      expect(
+        screen.getByText('No active artists in the last 90 days.')
+      ).toBeInTheDocument()
+    })
+
+    it('renders the "and N more" overflow line when total exceeds 10', () => {
+      // The overflow copy is `total - 10` (the list caps display at 10).
+      mockUseSceneArtists.mockReturnValue({
+        data: {
+          artists: [
+            { id: 1, slug: 'a-1', name: 'Artist 1', city: 'Phoenix', state: 'AZ', show_count: 9 },
+          ],
+          total: 14,
+        } as SceneArtistsResponse,
+        isLoading: false,
+      })
+      renderWithProviders(<SceneDetailView slug="phoenix-az" />)
+      expect(screen.getByText(/and 4 more artists/)).toBeInTheDocument()
+    })
+  })
+
+  describe('genre distribution', () => {
+    beforeEach(() => {
+      mockUseSceneDetail.mockReturnValue({
+        data: buildScene(),
+        isLoading: false,
+        error: null,
+      })
+    })
+
+    it('renders the genre section with a diversity label and tag pills', () => {
+      mockUseSceneGenres.mockReturnValue({
+        data: {
+          genres: [
+            { tag_id: 1, name: 'punk', slug: 'punk', count: 12 },
+            { tag_id: 2, name: 'metal', slug: 'metal', count: 8 },
+          ],
+          diversity_index: 0.8,
+          diversity_label: 'High diversity',
+        } as SceneGenreResponse,
+        isLoading: false,
+      })
+      renderWithProviders(<SceneDetailView slug="phoenix-az" />)
+
+      expect(screen.getByText('Genre Distribution')).toBeInTheDocument()
+      expect(screen.getByText('High diversity')).toBeInTheDocument()
+      expect(screen.getByText('punk')).toBeInTheDocument()
+      expect(screen.getByText('metal')).toBeInTheDocument()
+    })
+
+    it('renders nothing for the genre section when there are no genres', () => {
+      mockUseSceneGenres.mockReturnValue({ data: emptyGenres, isLoading: false })
+      renderWithProviders(<SceneDetailView slug="phoenix-az" />)
+      expect(screen.queryByText('Genre Distribution')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/features/scenes/components/SceneGraphVisualization.test.tsx
+++ b/frontend/features/scenes/components/SceneGraphVisualization.test.tsx
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import type { SceneGraphResponse } from '../types'
+import type { GraphNode } from '@/components/graph/ForceGraphView'
+
+// PSY-690: SceneGraphVisualization is a thin shape adapter over the shared
+// ForceGraphView. Its own responsibilities are: (1) compose the scene-specific
+// aria-label, (2) hold the next-router dependency and translate a node click
+// into navigation to that artist, and (3) forward props (data, width, height,
+// hiddenClusterIDs) through unchanged.
+//
+// jsdom can't render the d3/canvas pipeline (ForceGraphView dynamic-imports
+// react-force-graph-2d with ssr:false), so we mock ForceGraphView and assert
+// on the props the wrapper hands it — this both smoke-mounts the wrapper
+// without throwing and verifies its adapter logic. The reduced-motion
+// simulation pause lives inside ForceGraphView, not this wrapper, so it's out
+// of scope here.
+
+const mockPush = vi.fn()
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}))
+
+// Capture the props ForceGraphView receives and expose its onNodeClick so we
+// can drive the navigation path.
+interface CapturedProps {
+  nodes: unknown
+  links: unknown
+  clusters: unknown
+  containerWidth: number
+  height?: number
+  hiddenClusterIDs: Set<string>
+  ariaLabel: string
+  onNodeClick: (node: GraphNode) => void
+}
+let lastProps: CapturedProps | null = null
+
+vi.mock('@/components/graph/ForceGraphView', () => ({
+  ForceGraphView: (props: CapturedProps) => {
+    lastProps = props
+    return (
+      <div data-testid="force-graph-view" aria-label={props.ariaLabel} role="img" />
+    )
+  },
+}))
+
+import { SceneGraphVisualization } from './SceneGraphVisualization'
+
+const data: SceneGraphResponse = {
+  scene: {
+    slug: 'phoenix-az',
+    city: 'Phoenix',
+    state: 'AZ',
+    artist_count: 12,
+    edge_count: 4,
+  },
+  clusters: [{ id: 'v_1', label: 'Valley Bar', size: 6, color_index: 0 }],
+  nodes: [
+    {
+      id: 1,
+      name: 'Gatecreeper',
+      slug: 'gatecreeper',
+      upcoming_show_count: 0,
+      cluster_id: 'v_1',
+      is_isolate: false,
+    },
+  ],
+  links: [],
+}
+
+describe('SceneGraphVisualization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    lastProps = null
+  })
+
+  it('smoke-mounts without throwing and renders the graph view element', () => {
+    render(
+      <SceneGraphVisualization
+        data={data}
+        containerWidth={1024}
+        hiddenClusterIDs={new Set()}
+      />
+    )
+    expect(screen.getByTestId('force-graph-view')).toBeInTheDocument()
+  })
+
+  it('composes the scene-specific aria-label from the scene metadata', () => {
+    render(
+      <SceneGraphVisualization
+        data={data}
+        containerWidth={1024}
+        hiddenClusterIDs={new Set()}
+      />
+    )
+    const view = screen.getByTestId('force-graph-view')
+    expect(view).toHaveAttribute(
+      'aria-label',
+      'Scene relationship graph for Phoenix, AZ: 12 artists, 4 connections.'
+    )
+  })
+
+  it('forwards graph payload, width, and hidden clusters to ForceGraphView', () => {
+    const hidden = new Set(['v_1'])
+    render(
+      <SceneGraphVisualization
+        data={data}
+        containerWidth={777}
+        hiddenClusterIDs={hidden}
+        height={500}
+      />
+    )
+    expect(lastProps).not.toBeNull()
+    expect(lastProps!.nodes).toBe(data.nodes)
+    expect(lastProps!.links).toBe(data.links)
+    expect(lastProps!.clusters).toBe(data.clusters)
+    expect(lastProps!.containerWidth).toBe(777)
+    expect(lastProps!.height).toBe(500)
+    expect(lastProps!.hiddenClusterIDs).toBe(hidden)
+  })
+
+  it('omits height when not provided so ForceGraphView applies its default', () => {
+    render(
+      <SceneGraphVisualization
+        data={data}
+        containerWidth={1024}
+        hiddenClusterIDs={new Set()}
+      />
+    )
+    expect(lastProps!.height).toBeUndefined()
+  })
+
+  it('navigates to the artist page when a node is clicked', () => {
+    render(
+      <SceneGraphVisualization
+        data={data}
+        containerWidth={1024}
+        hiddenClusterIDs={new Set()}
+      />
+    )
+    // Drive the click handler the wrapper handed to ForceGraphView.
+    lastProps!.onNodeClick({
+      id: 1,
+      name: 'Gatecreeper',
+      slug: 'gatecreeper',
+      upcoming_show_count: 0,
+    })
+    expect(mockPush).toHaveBeenCalledWith('/artists/gatecreeper')
+  })
+})

--- a/frontend/features/scenes/components/SceneList.test.tsx
+++ b/frontend/features/scenes/components/SceneList.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import { renderWithProviders } from '@/test/utils'
+import type { SceneListResponse } from '../types'
+
+// PSY-690: SceneList is a thin presentational wrapper over useScenes with four
+// branches — loading, error, empty, and the populated card grid. Mock the hook
+// so each branch can be driven directly.
+
+// Mock next/link so the grid renders plain anchors in jsdom.
+vi.mock('next/link', () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string
+    children: React.ReactNode
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}))
+
+const mockUseScenes = vi.fn()
+vi.mock('../hooks', () => ({
+  useScenes: () => mockUseScenes(),
+}))
+
+import { SceneList } from './SceneList'
+
+const sampleData: SceneListResponse = {
+  scenes: [
+    {
+      city: 'Phoenix',
+      state: 'AZ',
+      slug: 'phoenix-az',
+      venue_count: 12,
+      upcoming_show_count: 45,
+      total_show_count: 200,
+    },
+    {
+      city: 'Tucson',
+      state: 'AZ',
+      slug: 'tucson-az',
+      venue_count: 1,
+      upcoming_show_count: 0,
+      total_show_count: 1,
+    },
+  ],
+  count: 2,
+}
+
+describe('SceneList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders a loading spinner while fetching', () => {
+    mockUseScenes.mockReturnValue({ data: undefined, isLoading: true, error: null })
+    const { container } = renderWithProviders(<SceneList />)
+    // LoadingSpinner is an unlabeled spinner div; assert on its animate-spin
+    // class rather than a role it doesn't expose.
+    expect(container.querySelector('.animate-spin')).toBeInTheDocument()
+    // No scene cards while loading.
+    expect(screen.queryByText(/, AZ$/)).not.toBeInTheDocument()
+  })
+
+  it('renders an error message when the request fails', () => {
+    mockUseScenes.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('boom'),
+    })
+    renderWithProviders(<SceneList />)
+    expect(screen.getByText(/Failed to load scenes/i)).toBeInTheDocument()
+  })
+
+  it('renders the empty state when there are no scenes', () => {
+    mockUseScenes.mockReturnValue({
+      data: { scenes: [], count: 0 },
+      isLoading: false,
+      error: null,
+    })
+    renderWithProviders(<SceneList />)
+    expect(screen.getByText('No scenes yet')).toBeInTheDocument()
+    expect(
+      screen.getByText(/Scene pages appear for cities with venue and show activity/i)
+    ).toBeInTheDocument()
+  })
+
+  describe('populated grid', () => {
+    beforeEach(() => {
+      mockUseScenes.mockReturnValue({
+        data: sampleData,
+        isLoading: false,
+        error: null,
+      })
+    })
+
+    it('renders a card per scene linking to its detail page', () => {
+      renderWithProviders(<SceneList />)
+
+      expect(screen.getByText('Phoenix, AZ')).toBeInTheDocument()
+      expect(screen.getByText('Tucson, AZ')).toBeInTheDocument()
+
+      const phoenixLink = screen.getByText('Phoenix, AZ').closest('a')!
+      expect(phoenixLink).toHaveAttribute('href', '/scenes/phoenix-az')
+      const tucsonLink = screen.getByText('Tucson, AZ').closest('a')!
+      expect(tucsonLink).toHaveAttribute('href', '/scenes/tucson-az')
+    })
+
+    it('pluralizes venue and show counts', () => {
+      renderWithProviders(<SceneList />)
+      // Phoenix: plural forms.
+      expect(screen.getByText('12 venues')).toBeInTheDocument()
+      expect(screen.getByText('200 shows')).toBeInTheDocument()
+      // Tucson: singular forms (count === 1).
+      expect(screen.getByText('1 venue')).toBeInTheDocument()
+      expect(screen.getByText('1 show')).toBeInTheDocument()
+    })
+
+    it('shows the upcoming badge only when upcoming_show_count > 0', () => {
+      renderWithProviders(<SceneList />)
+      // Phoenix has 45 upcoming.
+      expect(screen.getByText('45 upcoming')).toBeInTheDocument()
+      // Tucson has 0 upcoming — no upcoming label rendered.
+      expect(screen.queryByText('0 upcoming')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/features/scenes/components/ScenePulse.test.tsx
+++ b/frontend/features/scenes/components/ScenePulse.test.tsx
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ScenePulse } from './ScenePulse'
+import type { ScenePulse as ScenePulseData } from '../types'
+
+// PSY-690: ScenePulse renders three activity metrics (shows this month, new
+// artists, active venues), a trend indicator vs last month, and a 6-month
+// sparkline. The sparkline month labels derive from the real `Date`, so the
+// label assertions pin the system clock to a known date.
+
+function buildPulse(overrides: Partial<ScenePulseData> = {}): ScenePulseData {
+  return {
+    shows_this_month: 30,
+    shows_prev_month: 25,
+    shows_trend: 5,
+    new_artists_30d: 8,
+    active_venues_this_month: 10,
+    shows_by_month: [20, 22, 25, 28, 30, 30],
+    ...overrides,
+  }
+}
+
+describe('ScenePulse', () => {
+  it('renders the three activity counts with their metric labels', () => {
+    const { container } = render(<ScenePulse pulse={buildPulse()} />)
+
+    expect(screen.getByText('Scene Pulse')).toBeInTheDocument()
+
+    expect(screen.getByText('Shows this month')).toBeInTheDocument()
+    expect(screen.getByText('New artists')).toBeInTheDocument()
+    expect(screen.getByText('Active venues')).toBeInTheDocument()
+
+    // The three big metric values render in `.text-2xl` spans; the sparkline
+    // bar labels reuse the same digits, so scope to the metric spans.
+    const metricValues = Array.from(
+      container.querySelectorAll('span.text-2xl')
+    ).map((el) => el.textContent)
+    expect(metricValues).toEqual(['30', '8', '10'])
+  })
+
+  it('renders the time-window labels for each metric', () => {
+    render(<ScenePulse pulse={buildPulse()} />)
+
+    // The new-artists window and the active-venues window.
+    expect(screen.getByText('past 30 days')).toBeInTheDocument()
+    expect(screen.getByText('this month')).toBeInTheDocument()
+    // The shows-this-month metric carries a vs-last-month comparison.
+    expect(screen.getByText(/vs 25 last month/)).toBeInTheDocument()
+  })
+
+  describe('trend indicator', () => {
+    it('shows a positive trend with a leading plus sign', () => {
+      render(<ScenePulse pulse={buildPulse({ shows_trend: 5 })} />)
+      expect(screen.getByText('+5')).toBeInTheDocument()
+    })
+
+    it('shows a negative trend with its sign preserved', () => {
+      render(<ScenePulse pulse={buildPulse({ shows_trend: -3 })} />)
+      // The raw negative number already carries the minus sign.
+      expect(screen.getByText('-3')).toBeInTheDocument()
+    })
+
+    it('shows a flat zero trend without a sign', () => {
+      render(<ScenePulse pulse={buildPulse({ shows_trend: 0 })} />)
+      expect(screen.getByText('0')).toBeInTheDocument()
+    })
+  })
+
+  describe('sparkline', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+      // Pin to mid-month so the day=1 normalization in getMonthLabel can't
+      // overflow regardless of month length. June 2026.
+      vi.setSystemTime(new Date('2026-06-15T12:00:00Z'))
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('renders the section heading and labels the last 6 months oldest-first', () => {
+      // index 0 = oldest (5 months ago = Jan), last = current (Jun).
+      render(<ScenePulse pulse={buildPulse({ shows_by_month: [1, 2, 3, 4, 5, 6] })} />)
+
+      expect(
+        screen.getByText('Shows per month (last 6 months)')
+      ).toBeInTheDocument()
+
+      // 6 months back from June 2026: Jan, Feb, Mar, Apr, May, Jun.
+      for (const month of ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun']) {
+        expect(screen.getByText(month)).toBeInTheDocument()
+      }
+    })
+
+    it('renders each non-zero monthly value and suppresses zero-value labels', () => {
+      const { container } = render(
+        <ScenePulse pulse={buildPulse({ shows_by_month: [0, 7, 0, 9, 0, 11] })} />
+      )
+
+      // Non-zero values appear as bar labels.
+      expect(screen.getByText('7')).toBeInTheDocument()
+      expect(screen.getByText('9')).toBeInTheDocument()
+      expect(screen.getByText('11')).toBeInTheDocument()
+
+      // The sparkline value labels use the [10px] utility; a zero value
+      // renders an empty label, so none of those spans should read "0".
+      const valueLabels = Array.from(
+        container.querySelectorAll('span.text-\\[10px\\]')
+      )
+      const zeroValueLabel = valueLabels.find((el) => el.textContent === '0')
+      expect(zeroValueLabel).toBeUndefined()
+    })
+
+    it('hides the sparkline section when there is no monthly data', () => {
+      render(<ScenePulse pulse={buildPulse({ shows_by_month: [] })} />)
+      expect(
+        screen.queryByText('Shows per month (last 6 months)')
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  it('renders zero counts without crashing (empty scene)', () => {
+    const { container } = render(
+      <ScenePulse
+        pulse={buildPulse({
+          shows_this_month: 0,
+          shows_prev_month: 0,
+          shows_trend: 0,
+          new_artists_30d: 0,
+          active_venues_this_month: 0,
+          shows_by_month: [],
+        })}
+      />
+    )
+
+    // All three big metric values render their zero (sparkline is hidden when
+    // shows_by_month is empty, so these are the only `.text-2xl` spans).
+    const metricValues = Array.from(
+      container.querySelectorAll('span.text-2xl')
+    ).map((el) => el.textContent)
+    expect(metricValues).toEqual(['0', '0', '0'])
+  })
+})

--- a/frontend/features/scenes/types.test.ts
+++ b/frontend/features/scenes/types.test.ts
@@ -21,7 +21,8 @@ import type {
 // so these are compile-time contract guards: each fixture must satisfy its
 // interface for `tsc --noEmit` (run by `bun run typecheck`) to pass, which
 // catches accidental field renames/removals. The runtime expects double as a
-// readable record of the expected shape and exercise the optional fields.
+// readable record of the expected shape and exercise the optional/nullable
+// fields (description, node city/state, link detail).
 
 describe('scene types contract', () => {
   it('SceneListItem / SceneListResponse', () => {

--- a/frontend/features/scenes/types.test.ts
+++ b/frontend/features/scenes/types.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect } from 'vitest'
+import type {
+  SceneListItem,
+  SceneListResponse,
+  SceneStats,
+  ScenePulse,
+  SceneDetail,
+  SceneArtist,
+  SceneArtistsResponse,
+  GenreCount,
+  SceneGenreResponse,
+  SceneGraphInfo,
+  SceneGraphCluster,
+  SceneGraphNode,
+  SceneGraphLink,
+  SceneGraphResponse,
+} from './types'
+
+// PSY-690: types.ts is interface-only (no runtime exports), mirroring the
+// backend scene_service.go response shapes. There's no behavior to exercise,
+// so these are compile-time contract guards: each fixture must satisfy its
+// interface for `tsc --noEmit` (run by `bun run typecheck`) to pass, which
+// catches accidental field renames/removals. The runtime expects double as a
+// readable record of the expected shape and exercise the optional fields.
+
+describe('scene types contract', () => {
+  it('SceneListItem / SceneListResponse', () => {
+    const item: SceneListItem = {
+      city: 'Phoenix',
+      state: 'AZ',
+      slug: 'phoenix-az',
+      venue_count: 12,
+      upcoming_show_count: 45,
+      total_show_count: 200,
+    }
+    const response: SceneListResponse = { scenes: [item], count: 1 }
+
+    expect(response.count).toBe(1)
+    expect(response.scenes[0].slug).toBe('phoenix-az')
+  })
+
+  it('SceneStats / ScenePulse / SceneDetail (nullable description)', () => {
+    const stats: SceneStats = {
+      venue_count: 12,
+      artist_count: 85,
+      upcoming_show_count: 45,
+      festival_count: 2,
+    }
+    const pulse: ScenePulse = {
+      shows_this_month: 30,
+      shows_prev_month: 25,
+      shows_trend: 5,
+      new_artists_30d: 8,
+      active_venues_this_month: 10,
+      shows_by_month: [20, 22, 25, 28, 30, 30],
+    }
+    const detail: SceneDetail = {
+      city: 'Phoenix',
+      state: 'AZ',
+      slug: 'phoenix-az',
+      description: null,
+      stats,
+      pulse,
+    }
+
+    // description is explicitly nullable.
+    expect(detail.description).toBeNull()
+    const described: SceneDetail = { ...detail, description: 'A desert scene.' }
+    expect(described.description).toBe('A desert scene.')
+    expect(detail.pulse.shows_by_month).toHaveLength(6)
+  })
+
+  it('SceneArtist / SceneArtistsResponse', () => {
+    const artist: SceneArtist = {
+      id: 1,
+      slug: 'gatecreeper',
+      name: 'Gatecreeper',
+      city: 'Phoenix',
+      state: 'AZ',
+      show_count: 5,
+    }
+    const response: SceneArtistsResponse = { artists: [artist], total: 1 }
+
+    expect(response.total).toBe(1)
+    expect(response.artists[0].show_count).toBe(5)
+  })
+
+  it('GenreCount / SceneGenreResponse', () => {
+    const genre: GenreCount = { tag_id: 1, name: 'punk', slug: 'punk', count: 12 }
+    const response: SceneGenreResponse = {
+      genres: [genre],
+      diversity_index: 0.8,
+      diversity_label: 'High diversity',
+    }
+
+    expect(response.diversity_index).toBeCloseTo(0.8)
+    expect(response.genres[0].slug).toBe('punk')
+  })
+
+  it('SceneGraphInfo / SceneGraphCluster', () => {
+    const info: SceneGraphInfo = {
+      slug: 'phoenix-az',
+      city: 'Phoenix',
+      state: 'AZ',
+      artist_count: 12,
+      edge_count: 4,
+    }
+    const cluster: SceneGraphCluster = {
+      id: 'v_1',
+      label: 'Valley Bar',
+      size: 6,
+      color_index: 0,
+    }
+    // "other" cluster uses color_index -1 per the field doc.
+    const otherCluster: SceneGraphCluster = {
+      id: 'other',
+      label: 'Other',
+      size: 3,
+      color_index: -1,
+    }
+
+    expect(info.edge_count).toBe(4)
+    expect(cluster.color_index).toBe(0)
+    expect(otherCluster.color_index).toBe(-1)
+  })
+
+  it('SceneGraphNode (optional city/state) / SceneGraphLink (optional detail)', () => {
+    const node: SceneGraphNode = {
+      id: 1,
+      name: 'Gatecreeper',
+      slug: 'gatecreeper',
+      upcoming_show_count: 0,
+      cluster_id: 'v_1',
+      is_isolate: false,
+    }
+    // city/state are optional.
+    const locatedNode: SceneGraphNode = { ...node, city: 'Phoenix', state: 'AZ' }
+
+    const link: SceneGraphLink = {
+      source_id: 1,
+      target_id: 2,
+      type: 'shared_bills',
+      score: 0.5,
+      is_cross_cluster: false,
+    }
+    // detail is optional and carries arbitrary metadata.
+    const detailedLink: SceneGraphLink = {
+      ...link,
+      detail: { shared_show_count: 3 },
+    }
+
+    expect(node.city).toBeUndefined()
+    expect(locatedNode.state).toBe('AZ')
+    expect(link.detail).toBeUndefined()
+    expect(detailedLink.detail).toEqual({ shared_show_count: 3 })
+  })
+
+  it('SceneGraphResponse composes the graph payload', () => {
+    const response: SceneGraphResponse = {
+      scene: {
+        slug: 'phoenix-az',
+        city: 'Phoenix',
+        state: 'AZ',
+        artist_count: 2,
+        edge_count: 1,
+      },
+      clusters: [{ id: 'v_1', label: 'Valley Bar', size: 2, color_index: 0 }],
+      nodes: [
+        {
+          id: 1,
+          name: 'Gatecreeper',
+          slug: 'gatecreeper',
+          upcoming_show_count: 0,
+          cluster_id: 'v_1',
+          is_isolate: false,
+        },
+        {
+          id: 2,
+          name: 'Sundressed',
+          slug: 'sundressed',
+          upcoming_show_count: 1,
+          cluster_id: 'v_1',
+          is_isolate: false,
+        },
+      ],
+      links: [
+        {
+          source_id: 1,
+          target_id: 2,
+          type: 'shared_bills',
+          score: 0.5,
+          is_cross_cluster: false,
+        },
+      ],
+    }
+
+    expect(response.nodes).toHaveLength(2)
+    expect(response.links).toHaveLength(1)
+    expect(response.clusters[0].id).toBe('v_1')
+    expect(response.scene.artist_count).toBe(2)
+  })
+})


### PR DESCRIPTION
## Summary
- Add sibling tests for the five previously-untested files in `frontend/features/scenes/`, taking the module from 2/7 to full coverage of substantive files.
- `ScenePulse.test.tsx` — activity counts (scoped to the `.text-2xl` metric spans to avoid sparkline-digit collisions), positive/negative/flat trend indicator, time-window labels, and the 6-month sparkline (pinned clock for deterministic month labels; zero-value-label suppression; hidden-when-empty).
- `SceneList.test.tsx` — loading / error / empty / populated-grid branches, detail-page links, and venue/show/upcoming pluralization.
- `SceneDetail.test.tsx` — loading + not-found branches, header + joined stat summary, conditional festivals card, and the active-artists + genre-distribution sub-lists (`ScenePulse`/`SceneGraph` children stubbed so the canvas never mounts).
- `SceneGraphVisualization.test.tsx` — smoke-mount + aria-label composition + node-click→`/artists/{slug}` navigation, via a mocked `ForceGraphView` (jsdom can't render the d3/canvas pipeline). The wrapper itself does not use `useReducedMotion` — that branch lives in `ForceGraphView`, out of scope here.
- `types.test.ts` — compile-time contract guards for the interface-only types file (no runtime exports); fixtures must satisfy each interface for `tsc` to pass, plus runtime assertions exercise the optional/nullable fields.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run test:run features/scenes` — 61/61 passing (7 files)

## Manual repro
Test-only diff; no runtime change. The passing suite IS the verification.

## Coverage gaps
- The three barrel `index.ts` files (`features/scenes/index.ts`, `components/index.ts`, `hooks/index.ts`) have no sibling tests. They are pure re-exports with no logic, and the underlying hooks/types/components are tested directly — consistent with the rest of the repo and the ticket's explicit untested-file list.

## Simplify
Ran `/simplify`. One finding: a garbled sentence in the `types.test.ts` header comment; fixed in a separate commit. Test code was otherwise clean and consistent with existing in-module patterns (`SceneGraph.test.tsx`, `useScenes.test.tsx`).

Closes PSY-690