### PR TITLE
PSY-758: typed Update requests for show/venue/artist

### DIFF
--- a/backend/internal/api/handlers/catalog/artist.go
+++ b/backend/internal/api/handlers/catalog/artist.go
@@ -491,10 +491,7 @@ func (h *ArtistHandler) UpdateArtistBandcampHandler(ctx context.Context, req *Up
 
 	// Always write the embed column; an empty string clears it (the service
 	// normalizes empty input to SQL NULL).
-	embedValue := ""
-	if req.Body.BandcampEmbedURL != nil {
-		embedValue = *req.Body.BandcampEmbedURL
-	}
+	embedValue := shared.Deref(req.Body.BandcampEmbedURL)
 	serviceReq := &contracts.UpdateArtistRequest{
 		BandcampEmbedURL: &embedValue,
 	}
@@ -631,10 +628,7 @@ func (h *ArtistHandler) UpdateArtistSpotifyHandler(ctx context.Context, req *Upd
 
 	// Always write the spotify column; an empty string clears it (the service
 	// normalizes empty input to SQL NULL).
-	spotifyValue := ""
-	if req.Body.SpotifyURL != nil {
-		spotifyValue = *req.Body.SpotifyURL
-	}
+	spotifyValue := shared.Deref(req.Body.SpotifyURL)
 	serviceReq := &contracts.UpdateArtistRequest{
 		Spotify: &spotifyValue,
 	}

--- a/backend/internal/api/handlers/catalog/artist.go
+++ b/backend/internal/api/handlers/catalog/artist.go
@@ -16,7 +16,6 @@ import (
 	"psychic-homily-backend/internal/logger"
 	adminm "psychic-homily-backend/internal/models/admin"
 	"psychic-homily-backend/internal/services/contracts"
-	"psychic-homily-backend/internal/utils"
 )
 
 // isInternalServiceRequest checks if the request has a valid internal service secret
@@ -490,29 +489,32 @@ func (h *ArtistHandler) UpdateArtistBandcampHandler(ctx context.Context, req *Up
 		"is_internal", isInternalRequest,
 	)
 
-	// Prepare updates - if URL is empty string, set to nil to clear the field
-	var bandcampURL *string
-	if req.Body.BandcampEmbedURL != nil && *req.Body.BandcampEmbedURL != "" {
-		bandcampURL = req.Body.BandcampEmbedURL
+	// Always write the embed column; an empty string clears it (the service
+	// normalizes empty input to SQL NULL).
+	embedValue := ""
+	if req.Body.BandcampEmbedURL != nil {
+		embedValue = *req.Body.BandcampEmbedURL
+	}
+	serviceReq := &contracts.UpdateArtistRequest{
+		BandcampEmbedURL: &embedValue,
 	}
 
-	updates := map[string]interface{}{
-		"bandcamp_embed_url": bandcampURL,
-	}
-
-	// Also set the social bandcamp profile URL from the embed URL
-	if bandcampURL != nil {
+	// Mirror the embed URL into the social bandcamp profile URL.
+	if embedValue != "" {
 		// Extract profile URL: https://artist.bandcamp.com/album/name → https://artist.bandcamp.com
-		if idx := strings.Index(*bandcampURL, ".bandcamp.com"); idx != -1 {
-			profileURL := (*bandcampURL)[:idx+len(".bandcamp.com")]
-			updates["bandcamp"] = profileURL
+		if idx := strings.Index(embedValue, ".bandcamp.com"); idx != -1 {
+			profileURL := embedValue[:idx+len(".bandcamp.com")]
+			serviceReq.Bandcamp = &profileURL
 		}
+		// If the URL lacks a bandcamp.com host the social link is left
+		// unchanged (Bandcamp stays nil — no write).
 	} else {
-		// Clear the social bandcamp link when clearing the embed URL
-		updates["bandcamp"] = nil
+		// Clear the social bandcamp link when clearing the embed URL.
+		empty := ""
+		serviceReq.Bandcamp = &empty
 	}
 
-	artist, err := h.artistService.UpdateArtist(uint(artistID), updates)
+	artist, err := h.artistService.UpdateArtist(uint(artistID), serviceReq)
 	if err != nil {
 		var artistErr *apperrors.ArtistError
 		if errors.As(err, &artistErr) && artistErr.Code == apperrors.CodeArtistNotFound {
@@ -627,17 +629,17 @@ func (h *ArtistHandler) UpdateArtistSpotifyHandler(ctx context.Context, req *Upd
 		"is_internal", isInternalRequest,
 	)
 
-	// Prepare updates - if URL is empty string, set to nil to clear the field
-	var spotifyURL *string
-	if req.Body.SpotifyURL != nil && *req.Body.SpotifyURL != "" {
-		spotifyURL = req.Body.SpotifyURL
+	// Always write the spotify column; an empty string clears it (the service
+	// normalizes empty input to SQL NULL).
+	spotifyValue := ""
+	if req.Body.SpotifyURL != nil {
+		spotifyValue = *req.Body.SpotifyURL
+	}
+	serviceReq := &contracts.UpdateArtistRequest{
+		Spotify: &spotifyValue,
 	}
 
-	updates := map[string]interface{}{
-		"spotify": spotifyURL,
-	}
-
-	artist, err := h.artistService.UpdateArtist(uint(artistID), updates)
+	artist, err := h.artistService.UpdateArtist(uint(artistID), serviceReq)
 	if err != nil {
 		var artistErr *apperrors.ArtistError
 		if errors.As(err, &artistErr) && artistErr.Code == apperrors.CodeArtistNotFound {
@@ -738,6 +740,26 @@ func (h *ArtistHandler) DeleteArtistHandler(ctx context.Context, req *DeleteArti
 // Admin Update Artist
 // ============================================================================
 
+// hasArtistUpdateFields reports whether the request carries at least one field
+// to update. The admin endpoint rejects an empty PATCH with 422 rather than
+// issuing a no-op write.
+func hasArtistUpdateFields(req *contracts.UpdateArtistRequest) bool {
+	return req.Name != nil ||
+		req.State != nil ||
+		req.City != nil ||
+		req.Country != nil ||
+		req.Description != nil ||
+		req.BandcampEmbedURL != nil ||
+		req.Instagram != nil ||
+		req.Facebook != nil ||
+		req.Twitter != nil ||
+		req.YouTube != nil ||
+		req.Spotify != nil ||
+		req.SoundCloud != nil ||
+		req.Bandcamp != nil ||
+		req.Website != nil
+}
+
 // AdminUpdateArtistRequest represents the request for updating an artist (admin only)
 type AdminUpdateArtistRequest struct {
 	ArtistID string `path:"artist_id" validate:"required" doc:"Artist ID"`
@@ -800,54 +822,35 @@ func (h *ArtistHandler) AdminUpdateArtistHandler(ctx context.Context, req *Admin
 		oldArtist, _ = h.artistService.GetArtist(uint(artistID))
 	}
 
-	// Build updates map with only provided fields
-	updates := map[string]interface{}{}
-
+	// Trim the name at the boundary; the service applies the uniqueness guard
+	// and slug regeneration, and normalizes the remaining nullable fields'
+	// empty values to SQL NULL.
+	var trimmedName *string
 	if req.Body.Name != nil {
-		updates["name"] = strings.TrimSpace(*req.Body.Name)
+		trimmed := strings.TrimSpace(*req.Body.Name)
+		trimmedName = &trimmed
 	}
-	if req.Body.City != nil {
-		updates["city"] = utils.NilIfEmpty(*req.Body.City)
-	}
-	if req.Body.State != nil {
-		updates["state"] = utils.NilIfEmpty(*req.Body.State)
-	}
-	if req.Body.Country != nil {
-		updates["country"] = utils.NilIfEmpty(*req.Body.Country)
-	}
-	if req.Body.Instagram != nil {
-		updates["instagram"] = utils.NilIfEmpty(*req.Body.Instagram)
-	}
-	if req.Body.Facebook != nil {
-		updates["facebook"] = utils.NilIfEmpty(*req.Body.Facebook)
-	}
-	if req.Body.Twitter != nil {
-		updates["twitter"] = utils.NilIfEmpty(*req.Body.Twitter)
-	}
-	if req.Body.Youtube != nil {
-		updates["youtube"] = utils.NilIfEmpty(*req.Body.Youtube)
-	}
-	if req.Body.Spotify != nil {
-		updates["spotify"] = utils.NilIfEmpty(*req.Body.Spotify)
-	}
-	if req.Body.Soundcloud != nil {
-		updates["soundcloud"] = utils.NilIfEmpty(*req.Body.Soundcloud)
-	}
-	if req.Body.Bandcamp != nil {
-		updates["bandcamp"] = utils.NilIfEmpty(*req.Body.Bandcamp)
-	}
-	if req.Body.Website != nil {
-		updates["website"] = utils.NilIfEmpty(*req.Body.Website)
-	}
-	if req.Body.Description != nil {
-		updates["description"] = utils.NilIfEmpty(*req.Body.Description)
+	serviceReq := &contracts.UpdateArtistRequest{
+		Name:        trimmedName,
+		City:        req.Body.City,
+		State:       req.Body.State,
+		Country:     req.Body.Country,
+		Description: req.Body.Description,
+		Instagram:   req.Body.Instagram,
+		Facebook:    req.Body.Facebook,
+		Twitter:     req.Body.Twitter,
+		YouTube:     req.Body.Youtube,
+		Spotify:     req.Body.Spotify,
+		SoundCloud:  req.Body.Soundcloud,
+		Bandcamp:    req.Body.Bandcamp,
+		Website:     req.Body.Website,
 	}
 
-	if len(updates) == 0 {
+	if !hasArtistUpdateFields(serviceReq) {
 		return nil, huma.Error422UnprocessableEntity("No fields to update")
 	}
 
-	artist, err := h.artistService.UpdateArtist(uint(artistID), updates)
+	artist, err := h.artistService.UpdateArtist(uint(artistID), serviceReq)
 	if err != nil {
 		var artistErr *apperrors.ArtistError
 		if errors.As(err, &artistErr) && artistErr.Code == apperrors.CodeArtistNotFound {

--- a/backend/internal/api/handlers/catalog/artist_test.go
+++ b/backend/internal/api/handlers/catalog/artist_test.go
@@ -540,7 +540,7 @@ func TestDeleteArtist_ServiceError(t *testing.T) {
 
 func TestAdminUpdateArtist_Success(t *testing.T) {
 	mock := &testhelpers.MockArtistService{
-		UpdateArtistFn: func(artistID uint, updates map[string]interface{}) (*contracts.ArtistDetailResponse, error) {
+		UpdateArtistFn: func(artistID uint, _ *contracts.UpdateArtistRequest) (*contracts.ArtistDetailResponse, error) {
 			if artistID != 42 {
 				t.Errorf("expected artistID=42, got %d", artistID)
 			}
@@ -564,7 +564,7 @@ func TestAdminUpdateArtist_Success(t *testing.T) {
 
 func TestAdminUpdateArtist_NotFound(t *testing.T) {
 	mock := &testhelpers.MockArtistService{
-		UpdateArtistFn: func(_ uint, _ map[string]interface{}) (*contracts.ArtistDetailResponse, error) {
+		UpdateArtistFn: func(_ uint, _ *contracts.UpdateArtistRequest) (*contracts.ArtistDetailResponse, error) {
 			return nil, apperrors.ErrArtistNotFound(99)
 		},
 	}
@@ -581,7 +581,7 @@ func TestAdminUpdateArtist_NotFound(t *testing.T) {
 func TestAdminUpdateArtist_AuditLogCalled(t *testing.T) {
 	var auditCalled bool
 	artistMock := &testhelpers.MockArtistService{
-		UpdateArtistFn: func(_ uint, _ map[string]interface{}) (*contracts.ArtistDetailResponse, error) {
+		UpdateArtistFn: func(_ uint, _ *contracts.UpdateArtistRequest) (*contracts.ArtistDetailResponse, error) {
 			return &contracts.ArtistDetailResponse{ID: 42}, nil
 		},
 	}
@@ -625,17 +625,21 @@ func TestAdminUpdateArtist_AuditLogCalled(t *testing.T) {
 
 func TestUpdateBandcamp_Success(t *testing.T) {
 	mock := &testhelpers.MockArtistService{
-		UpdateArtistFn: func(artistID uint, updates map[string]interface{}) (*contracts.ArtistDetailResponse, error) {
+		UpdateArtistFn: func(artistID uint, req *contracts.UpdateArtistRequest) (*contracts.ArtistDetailResponse, error) {
 			if artistID != 42 {
 				t.Errorf("expected artistID=42, got %d", artistID)
 			}
-			// Verify bandcamp_embed_url is set
-			if _, ok := updates["bandcamp_embed_url"]; !ok {
-				t.Error("expected bandcamp_embed_url in updates")
+			// Verify bandcamp_embed_url is set to the full URL
+			if req.BandcampEmbedURL == nil {
+				t.Error("expected bandcamp_embed_url to be set")
+			} else if *req.BandcampEmbedURL != "https://artist.bandcamp.com/album/cool-album" {
+				t.Errorf("expected full embed URL, got %q", *req.BandcampEmbedURL)
 			}
 			// Verify social bandcamp profile URL is derived
-			if _, ok := updates["bandcamp"]; !ok {
-				t.Error("expected bandcamp profile URL in updates")
+			if req.Bandcamp == nil {
+				t.Error("expected bandcamp profile URL to be derived")
+			} else if *req.Bandcamp != "https://artist.bandcamp.com" {
+				t.Errorf("expected derived profile URL, got %q", *req.Bandcamp)
 			}
 			return &contracts.ArtistDetailResponse{ID: 42}, nil
 		},
@@ -657,12 +661,19 @@ func TestUpdateBandcamp_Success(t *testing.T) {
 
 func TestUpdateBandcamp_ClearURL(t *testing.T) {
 	mock := &testhelpers.MockArtistService{
-		UpdateArtistFn: func(_ uint, updates map[string]interface{}) (*contracts.ArtistDetailResponse, error) {
-			// When clearing, bandcamp_embed_url should be a nil *string
-			if v, ok := updates["bandcamp_embed_url"]; ok {
-				if sp, isStr := v.(*string); isStr && sp != nil {
-					t.Errorf("expected nil *string for bandcamp_embed_url, got %q", *sp)
-				}
+		UpdateArtistFn: func(_ uint, req *contracts.UpdateArtistRequest) (*contracts.ArtistDetailResponse, error) {
+			// When clearing, the handler signals an empty string for both the
+			// embed and social bandcamp fields; the service normalizes empty
+			// input to SQL NULL.
+			if req.BandcampEmbedURL == nil {
+				t.Error("expected bandcamp_embed_url to be set (empty string clears it)")
+			} else if *req.BandcampEmbedURL != "" {
+				t.Errorf("expected empty bandcamp_embed_url to clear, got %q", *req.BandcampEmbedURL)
+			}
+			if req.Bandcamp == nil {
+				t.Error("expected bandcamp social to be set (empty string clears it)")
+			} else if *req.Bandcamp != "" {
+				t.Errorf("expected empty bandcamp social to clear, got %q", *req.Bandcamp)
 			}
 			return &contracts.ArtistDetailResponse{ID: 42}, nil
 		},
@@ -685,12 +696,14 @@ func TestUpdateBandcamp_ClearURL(t *testing.T) {
 
 func TestUpdateSpotify_Success(t *testing.T) {
 	mock := &testhelpers.MockArtistService{
-		UpdateArtistFn: func(artistID uint, updates map[string]interface{}) (*contracts.ArtistDetailResponse, error) {
+		UpdateArtistFn: func(artistID uint, req *contracts.UpdateArtistRequest) (*contracts.ArtistDetailResponse, error) {
 			if artistID != 42 {
 				t.Errorf("expected artistID=42, got %d", artistID)
 			}
-			if _, ok := updates["spotify"]; !ok {
-				t.Error("expected spotify in updates")
+			if req.Spotify == nil {
+				t.Error("expected spotify to be set")
+			} else if *req.Spotify != "https://open.spotify.com/artist/abc123" {
+				t.Errorf("expected spotify URL, got %q", *req.Spotify)
 			}
 			return &contracts.ArtistDetailResponse{ID: 42}, nil
 		},
@@ -1226,7 +1239,7 @@ func TestDeleteArtist_OverflowID(t *testing.T) {
 
 func TestAdminUpdateArtist_ZeroID(t *testing.T) {
 	mock := &testhelpers.MockArtistService{
-		UpdateArtistFn: func(id uint, updates map[string]interface{}) (*contracts.ArtistDetailResponse, error) {
+		UpdateArtistFn: func(id uint, _ *contracts.UpdateArtistRequest) (*contracts.ArtistDetailResponse, error) {
 			return nil, apperrors.ErrArtistNotFound(id)
 		},
 	}
@@ -1241,7 +1254,7 @@ func TestAdminUpdateArtist_ZeroID(t *testing.T) {
 
 func TestAdminUpdateArtist_VeryLargeID(t *testing.T) {
 	mock := &testhelpers.MockArtistService{
-		UpdateArtistFn: func(id uint, updates map[string]interface{}) (*contracts.ArtistDetailResponse, error) {
+		UpdateArtistFn: func(id uint, _ *contracts.UpdateArtistRequest) (*contracts.ArtistDetailResponse, error) {
 			return nil, apperrors.ErrArtistNotFound(id)
 		},
 	}

--- a/backend/internal/api/handlers/catalog/show.go
+++ b/backend/internal/api/handlers/catalog/show.go
@@ -17,7 +17,6 @@ import (
 	"psychic-homily-backend/internal/logger"
 	adminm "psychic-homily-backend/internal/models/admin"
 	"psychic-homily-backend/internal/services/contracts"
-	"psychic-homily-backend/internal/utils"
 )
 
 // ShowHandler handles show-related HTTP requests
@@ -853,34 +852,19 @@ func (h *ShowHandler) UpdateShowHandler(ctx context.Context, req *UpdateShowRequ
 		return nil, huma.Error422UnprocessableEntity("Summary must be 5000 characters or fewer")
 	}
 
-	// Build updates map for basic show fields
-	updates := make(map[string]interface{})
-	if req.Body.Title != nil {
-		updates["title"] = *req.Body.Title
-	}
-	if req.Body.EventDate != nil {
-		updates["event_date"] = *req.Body.EventDate
-	}
-	if req.Body.City != nil {
-		updates["city"] = *req.Body.City
-	}
-	if req.Body.State != nil {
-		updates["state"] = *req.Body.State
-	}
-	if req.Body.Price != nil {
-		updates["price"] = *req.Body.Price
-	}
-	if req.Body.AgeRequirement != nil {
-		updates["age_requirement"] = *req.Body.AgeRequirement
-	}
-	if req.Body.Description != nil {
-		updates["description"] = *req.Body.Description
-	}
-	if req.Body.TicketURL != nil {
-		updates["ticket_url"] = *req.Body.TicketURL
-	}
-	if req.Body.ImageURL != nil {
-		updates["image_url"] = utils.NilIfEmpty(*req.Body.ImageURL)
+	// Build typed update request for basic show fields. The service writes
+	// only the non-nil fields, converts EventDate to UTC, and normalizes an
+	// empty ImageURL to SQL NULL.
+	serviceUpdates := &contracts.UpdateShowRequest{
+		Title:          req.Body.Title,
+		EventDate:      req.Body.EventDate,
+		City:           req.Body.City,
+		State:          req.Body.State,
+		Price:          req.Body.Price,
+		AgeRequirement: req.Body.AgeRequirement,
+		Description:    req.Body.Description,
+		TicketURL:      req.Body.TicketURL,
+		ImageURL:       req.Body.ImageURL,
 	}
 
 	// Convert venues to service format (nil if not provided)
@@ -914,13 +898,12 @@ func (h *ShowHandler) UpdateShowHandler(ctx context.Context, req *UpdateShowRequ
 
 	logger.FromContext(ctx).Debug("show_update_attempt",
 		"show_id", showID,
-		"update_fields", len(updates),
 		"has_venues", serviceVenues != nil,
 		"has_artists", serviceArtists != nil,
 	)
 
 	// Update show using service with relations support (pass admin status for venue verification)
-	show, orphanedArtists, err := h.showService.UpdateShowWithRelations(uint(showID), updates, serviceVenues, serviceArtists, isAdmin)
+	show, orphanedArtists, err := h.showService.UpdateShowWithRelations(uint(showID), serviceUpdates, serviceVenues, serviceArtists, isAdmin)
 	if err != nil {
 		showErr := apperrors.ErrShowUpdateFailed(uint(showID), err)
 		logger.FromContext(ctx).Error("show_update_failed",

--- a/backend/internal/api/handlers/catalog/show_test.go
+++ b/backend/internal/api/handlers/catalog/show_test.go
@@ -545,7 +545,7 @@ func TestUpdateShowHandler_OwnerSuccess(t *testing.T) {
 		GetShowFn: func(_ uint) (*contracts.ShowResponse, error) {
 			return &contracts.ShowResponse{ID: 1, SubmittedBy: &userID, Status: "pending"}, nil
 		},
-		UpdateShowWithRelationsFn: func(showID uint, _ map[string]interface{}, _ []contracts.CreateShowVenue, _ []contracts.CreateShowArtist, _ bool) (*contracts.ShowResponse, []contracts.OrphanedArtist, error) {
+		UpdateShowWithRelationsFn: func(showID uint, _ *contracts.UpdateShowRequest, _ []contracts.CreateShowVenue, _ []contracts.CreateShowArtist, _ bool) (*contracts.ShowResponse, []contracts.OrphanedArtist, error) {
 			return &contracts.ShowResponse{ID: showID, Title: "Updated"}, nil, nil
 		},
 	}
@@ -570,7 +570,7 @@ func TestUpdateShowHandler_AdminSuccess(t *testing.T) {
 		GetShowFn: func(_ uint) (*contracts.ShowResponse, error) {
 			return &contracts.ShowResponse{ID: 1, SubmittedBy: &otherUser, Status: "approved"}, nil
 		},
-		UpdateShowWithRelationsFn: func(showID uint, _ map[string]interface{}, _ []contracts.CreateShowVenue, _ []contracts.CreateShowArtist, _ bool) (*contracts.ShowResponse, []contracts.OrphanedArtist, error) {
+		UpdateShowWithRelationsFn: func(showID uint, _ *contracts.UpdateShowRequest, _ []contracts.CreateShowVenue, _ []contracts.CreateShowArtist, _ bool) (*contracts.ShowResponse, []contracts.OrphanedArtist, error) {
 			return &contracts.ShowResponse{ID: showID}, nil, nil
 		},
 	}
@@ -619,7 +619,7 @@ func TestUpdateShowHandler_ServiceError(t *testing.T) {
 		GetShowFn: func(_ uint) (*contracts.ShowResponse, error) {
 			return &contracts.ShowResponse{ID: 1, SubmittedBy: &userID}, nil
 		},
-		UpdateShowWithRelationsFn: func(_ uint, _ map[string]interface{}, _ []contracts.CreateShowVenue, _ []contracts.CreateShowArtist, _ bool) (*contracts.ShowResponse, []contracts.OrphanedArtist, error) {
+		UpdateShowWithRelationsFn: func(_ uint, _ *contracts.UpdateShowRequest, _ []contracts.CreateShowVenue, _ []contracts.CreateShowArtist, _ bool) (*contracts.ShowResponse, []contracts.OrphanedArtist, error) {
 			return nil, nil, fmt.Errorf("update failed")
 		},
 	}
@@ -673,7 +673,7 @@ func TestUpdateShowHandler_RecordsRevisionOnChange(t *testing.T) {
 				Status:      "pending",
 			}, nil
 		},
-		UpdateShowWithRelationsFn: func(showID uint, _ map[string]interface{}, _ []contracts.CreateShowVenue, _ []contracts.CreateShowArtist, _ bool) (*contracts.ShowResponse, []contracts.OrphanedArtist, error) {
+		UpdateShowWithRelationsFn: func(showID uint, _ *contracts.UpdateShowRequest, _ []contracts.CreateShowVenue, _ []contracts.CreateShowArtist, _ bool) (*contracts.ShowResponse, []contracts.OrphanedArtist, error) {
 			newDescription := "New description"
 			return &contracts.ShowResponse{
 				ID:          showID,
@@ -768,7 +768,7 @@ func TestUpdateShowHandler_SkipsRevisionWhenNoChanges(t *testing.T) {
 				Status:      "pending",
 			}, nil
 		},
-		UpdateShowWithRelationsFn: func(showID uint, _ map[string]interface{}, _ []contracts.CreateShowVenue, _ []contracts.CreateShowArtist, _ bool) (*contracts.ShowResponse, []contracts.OrphanedArtist, error) {
+		UpdateShowWithRelationsFn: func(showID uint, _ *contracts.UpdateShowRequest, _ []contracts.CreateShowVenue, _ []contracts.CreateShowArtist, _ bool) (*contracts.ShowResponse, []contracts.OrphanedArtist, error) {
 			return &contracts.ShowResponse{
 				ID:    showID,
 				Title: "Same Title",

--- a/backend/internal/api/handlers/catalog/venue.go
+++ b/backend/internal/api/handlers/catalog/venue.go
@@ -12,7 +12,6 @@ import (
 	apperrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/logger"
 	"psychic-homily-backend/internal/services/contracts"
-	"psychic-homily-backend/internal/utils"
 
 	adminm "psychic-homily-backend/internal/models/admin"
 
@@ -435,58 +434,28 @@ func (h *VenueHandler) UpdateVenueHandler(ctx context.Context, req *UpdateVenueR
 		oldVenue, _ = h.venueService.GetVenue(uint(venueID))
 	}
 
-	updates := make(map[string]interface{})
-	if req.Body.Name != nil {
-		updates["name"] = *req.Body.Name
-	}
-	if req.Body.Address != nil {
-		updates["address"] = *req.Body.Address
-	}
-	if req.Body.City != nil {
-		updates["city"] = *req.Body.City
-	}
-	if req.Body.State != nil {
-		updates["state"] = *req.Body.State
-	}
-	if req.Body.Country != nil {
-		updates["country"] = *req.Body.Country
-	}
-	if req.Body.Zipcode != nil {
-		updates["zipcode"] = *req.Body.Zipcode
-	}
-	if req.Body.Instagram != nil {
-		updates["instagram"] = *req.Body.Instagram
-	}
-	if req.Body.Facebook != nil {
-		updates["facebook"] = *req.Body.Facebook
-	}
-	if req.Body.Twitter != nil {
-		updates["twitter"] = *req.Body.Twitter
-	}
-	if req.Body.YouTube != nil {
-		updates["youtube"] = *req.Body.YouTube
-	}
-	if req.Body.Spotify != nil {
-		updates["spotify"] = *req.Body.Spotify
-	}
-	if req.Body.SoundCloud != nil {
-		updates["soundcloud"] = *req.Body.SoundCloud
-	}
-	if req.Body.Bandcamp != nil {
-		updates["bandcamp"] = *req.Body.Bandcamp
-	}
-	if req.Body.Website != nil {
-		updates["website"] = *req.Body.Website
-	}
-	if req.Body.Description != nil {
-		updates["description"] = utils.NilIfEmpty(*req.Body.Description)
-	}
-	if req.Body.ImageURL != nil {
-		// Length + scheme already validated above (PSY-525); just persist.
-		updates["image_url"] = utils.NilIfEmpty(*req.Body.ImageURL)
+	// Image URL length + scheme already validated above (PSY-525); the service
+	// normalizes empty Description/ImageURL to SQL NULL.
+	serviceReq := &contracts.UpdateVenueRequest{
+		Name:        req.Body.Name,
+		Address:     req.Body.Address,
+		City:        req.Body.City,
+		State:       req.Body.State,
+		Country:     req.Body.Country,
+		Zipcode:     req.Body.Zipcode,
+		Description: req.Body.Description,
+		ImageURL:    req.Body.ImageURL,
+		Instagram:   req.Body.Instagram,
+		Facebook:    req.Body.Facebook,
+		Twitter:     req.Body.Twitter,
+		YouTube:     req.Body.YouTube,
+		Spotify:     req.Body.Spotify,
+		SoundCloud:  req.Body.SoundCloud,
+		Bandcamp:    req.Body.Bandcamp,
+		Website:     req.Body.Website,
 	}
 
-	updatedVenue, err := h.venueService.UpdateVenue(uint(venueID), updates)
+	updatedVenue, err := h.venueService.UpdateVenue(uint(venueID), serviceReq)
 	if err != nil {
 		var venueErr *apperrors.VenueError
 		if errors.As(err, &venueErr) && venueErr.Code == apperrors.CodeVenueNotFound {

--- a/backend/internal/api/handlers/catalog/venue.go
+++ b/backend/internal/api/handlers/catalog/venue.go
@@ -434,7 +434,7 @@ func (h *VenueHandler) UpdateVenueHandler(ctx context.Context, req *UpdateVenueR
 		oldVenue, _ = h.venueService.GetVenue(uint(venueID))
 	}
 
-	// Image URL length + scheme already validated above (PSY-525); the service
+	// Image URL length + scheme already validated above; the service
 	// normalizes empty Description/ImageURL to SQL NULL.
 	serviceReq := &contracts.UpdateVenueRequest{
 		Name:        req.Body.Name,

--- a/backend/internal/api/handlers/catalog/venue_test.go
+++ b/backend/internal/api/handlers/catalog/venue_test.go
@@ -82,7 +82,7 @@ func TestGetVenueHandler_OverflowID(t *testing.T) {
 
 func TestUpdateVenueHandler_ZeroID(t *testing.T) {
 	mock := &testhelpers.MockVenueService{
-		UpdateVenueFn: func(venueID uint, _ map[string]interface{}) (*contracts.VenueDetailResponse, error) {
+		UpdateVenueFn: func(venueID uint, _ *contracts.UpdateVenueRequest) (*contracts.VenueDetailResponse, error) {
 			return nil, apperrors.ErrVenueNotFound(venueID)
 		},
 	}

--- a/backend/internal/api/handlers/shared/testhelpers/mocks_gen.go
+++ b/backend/internal/api/handlers/shared/testhelpers/mocks_gen.go
@@ -321,7 +321,7 @@ type MockArtistService struct {
 	GetArtistBySlugFn func(string) (*contracts.ArtistDetailResponse, error)
 	GetArtistsFn func(map[string]interface{}) ([]*contracts.ArtistDetailResponse, error)
 	GetArtistsWithShowCountsFn func(map[string]interface{}) ([]*contracts.ArtistWithShowCountResponse, error)
-	UpdateArtistFn func(uint, map[string]interface{}) (*contracts.ArtistDetailResponse, error)
+	UpdateArtistFn func(uint, *contracts.UpdateArtistRequest) (*contracts.ArtistDetailResponse, error)
 	DeleteArtistFn func(uint) (error)
 	SearchArtistsFn func(string) ([]*contracts.ArtistDetailResponse, error)
 	GetShowsForArtistFn func(uint, string, int, string) ([]*contracts.ArtistShowResponse, int64, error)
@@ -369,9 +369,9 @@ func (m *MockArtistService) GetArtistsWithShowCounts(filters map[string]interfac
 	}
 	return nil, nil
 }
-func (m *MockArtistService) UpdateArtist(artistID uint, updates map[string]interface{}) (*contracts.ArtistDetailResponse, error) {
+func (m *MockArtistService) UpdateArtist(artistID uint, req *contracts.UpdateArtistRequest) (*contracts.ArtistDetailResponse, error) {
 	if m.UpdateArtistFn != nil {
-		return m.UpdateArtistFn(artistID, updates)
+		return m.UpdateArtistFn(artistID, req)
 	}
 	return nil, nil
 }
@@ -3026,8 +3026,8 @@ type MockShowService struct {
 	GetShowBySlugFn func(string) (*contracts.ShowResponse, error)
 	GetShowsFn func(map[string]interface{}) ([]*contracts.ShowResponse, error)
 	GetUserSubmissionsFn func(uint, int, int) ([]contracts.ShowResponse, int, error)
-	UpdateShowFn func(uint, map[string]interface{}) (*contracts.ShowResponse, error)
-	UpdateShowWithRelationsFn func(uint, map[string]interface{}, []contracts.CreateShowVenue, []contracts.CreateShowArtist, bool) (*contracts.ShowResponse, []contracts.OrphanedArtist, error)
+	UpdateShowFn func(uint, *contracts.UpdateShowRequest) (*contracts.ShowResponse, error)
+	UpdateShowWithRelationsFn func(uint, *contracts.UpdateShowRequest, []contracts.CreateShowVenue, []contracts.CreateShowArtist, bool) (*contracts.ShowResponse, []contracts.OrphanedArtist, error)
 	GetUpcomingShowsFn func(string, string, int, bool, *contracts.UpcomingShowsFilter) ([]*contracts.ShowResponse, *string, error)
 	GetShowCitiesFn func(string) ([]contracts.ShowCityResponse, error)
 	DeleteShowFn func(uint) (error)
@@ -3064,15 +3064,15 @@ func (m *MockShowService) GetUserSubmissions(userID uint, limit int, offset int)
 	}
 	return nil, 0, nil
 }
-func (m *MockShowService) UpdateShow(showID uint, updates map[string]interface{}) (*contracts.ShowResponse, error) {
+func (m *MockShowService) UpdateShow(showID uint, req *contracts.UpdateShowRequest) (*contracts.ShowResponse, error) {
 	if m.UpdateShowFn != nil {
-		return m.UpdateShowFn(showID, updates)
+		return m.UpdateShowFn(showID, req)
 	}
 	return nil, nil
 }
-func (m *MockShowService) UpdateShowWithRelations(showID uint, updates map[string]interface{}, venues []contracts.CreateShowVenue, artists []contracts.CreateShowArtist, isAdmin bool) (*contracts.ShowResponse, []contracts.OrphanedArtist, error) {
+func (m *MockShowService) UpdateShowWithRelations(showID uint, req *contracts.UpdateShowRequest, venues []contracts.CreateShowVenue, artists []contracts.CreateShowArtist, isAdmin bool) (*contracts.ShowResponse, []contracts.OrphanedArtist, error) {
 	if m.UpdateShowWithRelationsFn != nil {
-		return m.UpdateShowWithRelationsFn(showID, updates, venues, artists, isAdmin)
+		return m.UpdateShowWithRelationsFn(showID, req, venues, artists, isAdmin)
 	}
 	return nil, nil, nil
 }
@@ -3659,7 +3659,7 @@ type MockVenueService struct {
 	GetVenueFn func(uint) (*contracts.VenueDetailResponse, error)
 	GetVenueBySlugFn func(string) (*contracts.VenueDetailResponse, error)
 	GetVenuesFn func(map[string]interface{}) ([]*contracts.VenueDetailResponse, error)
-	UpdateVenueFn func(uint, map[string]interface{}) (*contracts.VenueDetailResponse, error)
+	UpdateVenueFn func(uint, *contracts.UpdateVenueRequest) (*contracts.VenueDetailResponse, error)
 	DeleteVenueFn func(uint) (error)
 	SearchVenuesFn func(string) ([]*contracts.VenueDetailResponse, error)
 	FindOrCreateVenueFn func(string, string, string, *string, *string, *gorm.DB, bool) (*catalogm.Venue, bool, error)
@@ -3698,9 +3698,9 @@ func (m *MockVenueService) GetVenues(filters map[string]interface{}) ([]*contrac
 	}
 	return nil, nil
 }
-func (m *MockVenueService) UpdateVenue(venueID uint, updates map[string]interface{}) (*contracts.VenueDetailResponse, error) {
+func (m *MockVenueService) UpdateVenue(venueID uint, req *contracts.UpdateVenueRequest) (*contracts.VenueDetailResponse, error) {
 	if m.UpdateVenueFn != nil {
-		return m.UpdateVenueFn(venueID, updates)
+		return m.UpdateVenueFn(venueID, req)
 	}
 	return nil, nil
 }

--- a/backend/internal/services/catalog/artist.go
+++ b/backend/internal/services/catalog/artist.go
@@ -195,13 +195,20 @@ func (s *ArtistService) GetArtists(filters map[string]interface{}) ([]*contracts
 }
 
 // UpdateArtist updates an existing artist
-func (s *ArtistService) UpdateArtist(artistID uint, updates map[string]interface{}) (*contracts.ArtistDetailResponse, error) {
+func (s *ArtistService) UpdateArtist(artistID uint, req *contracts.UpdateArtistRequest) (*contracts.ArtistDetailResponse, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
 
-	// Check if name is being updated and if it conflicts with existing artist
-	if name, ok := updates["name"].(string); ok {
+	// Translate the typed request into a GORM update map. Only non-nil fields
+	// are written so omitted fields stay unchanged. Every column is nullable
+	// except name, so empty input normalizes to SQL NULL via utils.NilIfEmpty.
+	updates := map[string]interface{}{}
+
+	// Name maps to a NOT NULL column and additionally drives the uniqueness
+	// guard and slug regeneration.
+	if req.Name != nil {
+		name := *req.Name
 		var existingArtist catalogm.Artist
 		err := s.db.Where("LOWER(name) = LOWER(?) AND id != ?", name, artistID).First(&existingArtist).Error
 		if err == nil {
@@ -209,6 +216,7 @@ func (s *ArtistService) UpdateArtist(artistID uint, updates map[string]interface
 		} else if err != gorm.ErrRecordNotFound {
 			return nil, fmt.Errorf("failed to check existing artist: %w", err)
 		}
+		updates["name"] = name
 
 		// Regenerate slug when name changes
 		baseSlug := utils.GenerateArtistSlug(name)
@@ -219,10 +227,51 @@ func (s *ArtistService) UpdateArtist(artistID uint, updates map[string]interface
 		})
 		updates["slug"] = slug
 	}
+	if req.State != nil {
+		updates["state"] = utils.NilIfEmpty(*req.State)
+	}
+	if req.City != nil {
+		updates["city"] = utils.NilIfEmpty(*req.City)
+	}
+	if req.Country != nil {
+		updates["country"] = utils.NilIfEmpty(*req.Country)
+	}
+	if req.Description != nil {
+		updates["description"] = utils.NilIfEmpty(*req.Description)
+	}
+	if req.BandcampEmbedURL != nil {
+		updates["bandcamp_embed_url"] = utils.NilIfEmpty(*req.BandcampEmbedURL)
+	}
+	if req.Instagram != nil {
+		updates["instagram"] = utils.NilIfEmpty(*req.Instagram)
+	}
+	if req.Facebook != nil {
+		updates["facebook"] = utils.NilIfEmpty(*req.Facebook)
+	}
+	if req.Twitter != nil {
+		updates["twitter"] = utils.NilIfEmpty(*req.Twitter)
+	}
+	if req.YouTube != nil {
+		updates["youtube"] = utils.NilIfEmpty(*req.YouTube)
+	}
+	if req.Spotify != nil {
+		updates["spotify"] = utils.NilIfEmpty(*req.Spotify)
+	}
+	if req.SoundCloud != nil {
+		updates["soundcloud"] = utils.NilIfEmpty(*req.SoundCloud)
+	}
+	if req.Bandcamp != nil {
+		updates["bandcamp"] = utils.NilIfEmpty(*req.Bandcamp)
+	}
+	if req.Website != nil {
+		updates["website"] = utils.NilIfEmpty(*req.Website)
+	}
 
-	err := s.db.Model(&catalogm.Artist{}).Where("id = ?", artistID).Updates(updates).Error
-	if err != nil {
-		return nil, fmt.Errorf("failed to update artist: %w", err)
+	if len(updates) > 0 {
+		err := s.db.Model(&catalogm.Artist{}).Where("id = ?", artistID).Updates(updates).Error
+		if err != nil {
+			return nil, fmt.Errorf("failed to update artist: %w", err)
+		}
 	}
 
 	return s.GetArtist(artistID)

--- a/backend/internal/services/catalog/artist_test.go
+++ b/backend/internal/services/catalog/artist_test.go
@@ -345,9 +345,9 @@ func (suite *ArtistServiceIntegrationTestSuite) TestUpdateArtist_BasicFields() {
 	created, err := suite.artistService.CreateArtist(&contracts.CreateArtistRequest{Name: "Original Artist"})
 	suite.Require().NoError(err)
 
-	resp, err := suite.artistService.UpdateArtist(created.ID, map[string]interface{}{
-		"city":  "Mesa",
-		"state": "AZ",
+	resp, err := suite.artistService.UpdateArtist(created.ID, &contracts.UpdateArtistRequest{
+		City:  stringPtr("Mesa"),
+		State: stringPtr("AZ"),
 	})
 
 	suite.Require().NoError(err)
@@ -361,8 +361,8 @@ func (suite *ArtistServiceIntegrationTestSuite) TestUpdateArtist_NameChangeRegen
 	suite.Require().NoError(err)
 	oldSlug := created.Slug
 
-	resp, err := suite.artistService.UpdateArtist(created.ID, map[string]interface{}{
-		"name": "New Name Band",
+	resp, err := suite.artistService.UpdateArtist(created.ID, &contracts.UpdateArtistRequest{
+		Name: stringPtr("New Name Band"),
 	})
 
 	suite.Require().NoError(err)
@@ -379,7 +379,7 @@ func (suite *ArtistServiceIntegrationTestSuite) TestUpdateArtist_DuplicateName_F
 	suite.Require().NoError(err)
 
 	// Try to rename "Other Artist" to "Existing Artist"
-	_, err = suite.artistService.UpdateArtist(other.ID, map[string]interface{}{"name": "Existing Artist"})
+	_, err = suite.artistService.UpdateArtist(other.ID, &contracts.UpdateArtistRequest{Name: stringPtr("Existing Artist")})
 
 	suite.Require().Error(err)
 	suite.Contains(err.Error(), "already exists")
@@ -390,9 +390,9 @@ func (suite *ArtistServiceIntegrationTestSuite) TestUpdateArtist_SameNameSameArt
 	suite.Require().NoError(err)
 
 	// Update city while keeping the same name — should not conflict with self
-	resp, err := suite.artistService.UpdateArtist(created.ID, map[string]interface{}{
-		"name": "Keep My Name",
-		"city": "Scottsdale",
+	resp, err := suite.artistService.UpdateArtist(created.ID, &contracts.UpdateArtistRequest{
+		Name: stringPtr("Keep My Name"),
+		City: stringPtr("Scottsdale"),
 	})
 
 	suite.Require().NoError(err)
@@ -403,7 +403,7 @@ func (suite *ArtistServiceIntegrationTestSuite) TestUpdateArtist_SameNameSameArt
 func (suite *ArtistServiceIntegrationTestSuite) TestUpdateArtist_NotFound() {
 	// Updating a non-existent artist — the Updates call succeeds (0 rows affected),
 	// but the subsequent GetArtist reload returns ARTIST_NOT_FOUND
-	resp, err := suite.artistService.UpdateArtist(99999, map[string]interface{}{"city": "Nowhere"})
+	resp, err := suite.artistService.UpdateArtist(99999, &contracts.UpdateArtistRequest{City: stringPtr("Nowhere")})
 
 	suite.Require().Error(err)
 	suite.Nil(resp)

--- a/backend/internal/services/catalog/show.go
+++ b/backend/internal/services/catalog/show.go
@@ -380,15 +380,54 @@ func (s *ShowService) GetUserSubmissions(userID uint, limit, offset int) ([]cont
 }
 
 // UpdateShow updates an existing show (basic fields only)
-func (s *ShowService) UpdateShow(showID uint, updates map[string]interface{}) (*contracts.ShowResponse, error) {
+// showUpdatesToMap translates a typed UpdateShowRequest into a GORM update
+// map. Only non-nil fields are written so omitted fields stay unchanged.
+// EventDate is normalized to UTC before storing (PSY-576 keeps the
+// denormalized show_artists.event_date in sync downstream); ImageURL is
+// nullable and normalizes empty input to SQL NULL. The remaining fields are
+// written verbatim to preserve prior handler behavior. A nil req yields an
+// empty map (used by the relations path when only associations change).
+func showUpdatesToMap(req *contracts.UpdateShowRequest) map[string]interface{} {
+	updates := map[string]interface{}{}
+	if req == nil {
+		return updates
+	}
+	if req.Title != nil {
+		updates["title"] = *req.Title
+	}
+	if req.EventDate != nil {
+		updates["event_date"] = req.EventDate.UTC()
+	}
+	if req.City != nil {
+		updates["city"] = *req.City
+	}
+	if req.State != nil {
+		updates["state"] = *req.State
+	}
+	if req.Price != nil {
+		updates["price"] = *req.Price
+	}
+	if req.AgeRequirement != nil {
+		updates["age_requirement"] = *req.AgeRequirement
+	}
+	if req.Description != nil {
+		updates["description"] = *req.Description
+	}
+	if req.TicketURL != nil {
+		updates["ticket_url"] = *req.TicketURL
+	}
+	if req.ImageURL != nil {
+		updates["image_url"] = utils.NilIfEmpty(*req.ImageURL)
+	}
+	return updates
+}
+
+func (s *ShowService) UpdateShow(showID uint, req *contracts.UpdateShowRequest) (*contracts.ShowResponse, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
 
-	// Handle event_date conversion to UTC if present
-	if eventDate, ok := updates["event_date"].(time.Time); ok {
-		updates["event_date"] = eventDate.UTC()
-	}
+	updates := showUpdatesToMap(req)
 
 	_, eventDateChanged := updates["event_date"]
 	err := s.db.Transaction(func(tx *gorm.DB) error {
@@ -422,7 +461,7 @@ func (s *ShowService) UpdateShow(showID uint, updates map[string]interface{}) (*
 // Returns the updated show response and any artists that became orphaned (0 shows).
 func (s *ShowService) UpdateShowWithRelations(
 	showID uint,
-	updates map[string]interface{},
+	req *contracts.UpdateShowRequest,
 	venues []contracts.CreateShowVenue,
 	artists []contracts.CreateShowArtist,
 	isAdmin bool,
@@ -431,10 +470,7 @@ func (s *ShowService) UpdateShowWithRelations(
 		return nil, nil, fmt.Errorf("database not initialized")
 	}
 
-	// Handle event_date conversion to UTC if present
-	if eventDate, ok := updates["event_date"].(time.Time); ok {
-		updates["event_date"] = eventDate.UTC()
-	}
+	updates := showUpdatesToMap(req)
 
 	var response *contracts.ShowResponse
 	var orphanedArtists []contracts.OrphanedArtist

--- a/backend/internal/services/catalog/show.go
+++ b/backend/internal/services/catalog/show.go
@@ -382,11 +382,11 @@ func (s *ShowService) GetUserSubmissions(userID uint, limit, offset int) ([]cont
 // UpdateShow updates an existing show (basic fields only)
 // showUpdatesToMap translates a typed UpdateShowRequest into a GORM update
 // map. Only non-nil fields are written so omitted fields stay unchanged.
-// EventDate is normalized to UTC before storing (PSY-576 keeps the
-// denormalized show_artists.event_date in sync downstream); ImageURL is
-// nullable and normalizes empty input to SQL NULL. The remaining fields are
-// written verbatim to preserve prior handler behavior. A nil req yields an
-// empty map (used by the relations path when only associations change).
+// EventDate is normalized to UTC before storing so the denormalized
+// show_artists.event_date stays in sync downstream; ImageURL is nullable and
+// normalizes empty input to SQL NULL. The remaining fields are written
+// verbatim to preserve prior handler behavior. A nil req yields an empty map
+// (used by the relations path when only associations change).
 func showUpdatesToMap(req *contracts.UpdateShowRequest) map[string]interface{} {
 	updates := map[string]interface{}{}
 	if req == nil {

--- a/backend/internal/services/catalog/show_test.go
+++ b/backend/internal/services/catalog/show_test.go
@@ -453,9 +453,9 @@ func (suite *ShowServiceIntegrationTestSuite) TestDeleteShow_AssociationsCleaned
 func (suite *ShowServiceIntegrationTestSuite) TestUpdateShow_BasicFields() {
 	created := suite.createTestShow()
 
-	resp, err := suite.showService.UpdateShow(created.ID, map[string]interface{}{
-		"title":       "Updated Title",
-		"description": "New description",
+	resp, err := suite.showService.UpdateShow(created.ID, &contracts.UpdateShowRequest{
+		Title:       stringPtr("Updated Title"),
+		Description: stringPtr("New description"),
 	})
 
 	suite.Require().NoError(err)
@@ -470,8 +470,8 @@ func (suite *ShowServiceIntegrationTestSuite) TestUpdateShow_EventDate_UTC() {
 	eastern, _ := time.LoadLocation("America/New_York")
 	newDate := time.Date(2026, 12, 25, 20, 0, 0, 0, eastern)
 
-	resp, err := suite.showService.UpdateShow(created.ID, map[string]interface{}{
-		"event_date": newDate,
+	resp, err := suite.showService.UpdateShow(created.ID, &contracts.UpdateShowRequest{
+		EventDate: &newDate,
 	})
 
 	suite.Require().NoError(err)
@@ -1070,8 +1070,8 @@ func (suite *ShowServiceIntegrationTestSuite) TestUpdateShow_CascadesEventDateTo
 	resp, err := suite.showService.CreateShow(req)
 	suite.Require().NoError(err)
 
-	_, err = suite.showService.UpdateShow(resp.ID, map[string]interface{}{
-		"event_date": newDate,
+	_, err = suite.showService.UpdateShow(resp.ID, &contracts.UpdateShowRequest{
+		EventDate: &newDate,
 	})
 	suite.Require().NoError(err)
 

--- a/backend/internal/services/catalog/venue.go
+++ b/backend/internal/services/catalog/venue.go
@@ -162,7 +162,7 @@ func (s *VenueService) GetVenues(filters map[string]interface{}) ([]*contracts.V
 }
 
 // UpdateVenue updates an existing venue
-func (s *VenueService) UpdateVenue(venueID uint, updates map[string]interface{}) (*contracts.VenueDetailResponse, error) {
+func (s *VenueService) UpdateVenue(venueID uint, req *contracts.UpdateVenueRequest) (*contracts.VenueDetailResponse, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
@@ -178,22 +178,16 @@ func (s *VenueService) UpdateVenue(venueID uint, updates map[string]interface{})
 		return nil, fmt.Errorf("failed to get venue: %w", err)
 	}
 
-	// Determine what values to check
-	var checkName string
-	var checkCity string
-
-	// If name is being updated, use new name, otherwise use current
-	if name, ok := updates["name"].(string); ok && name != "" {
-		checkName = name
-	} else {
-		checkName = currentVenue.Name
+	// Determine what values to check for the duplicate guard. A provided name
+	// or city replaces the current value; an empty provided value falls back
+	// to the current (mirrors the prior map-key check semantics).
+	checkName := currentVenue.Name
+	if req.Name != nil && *req.Name != "" {
+		checkName = *req.Name
 	}
-
-	// If city is being updated, use new city, otherwise use current
-	if city, ok := updates["city"].(string); ok && city != "" {
-		checkCity = city
-	} else {
-		checkCity = currentVenue.City
+	checkCity := currentVenue.City
+	if req.City != nil && *req.City != "" {
+		checkCity = *req.City
 	}
 
 	// Check for duplicate venue with same name and city (excluding current venue)
@@ -205,10 +199,67 @@ func (s *VenueService) UpdateVenue(venueID uint, updates map[string]interface{})
 		return nil, fmt.Errorf("failed to check existing venue: %w", err)
 	}
 
+	// Translate the typed request into a GORM update map. Only non-nil fields
+	// are written so omitted fields stay unchanged. Name/City/State are NOT
+	// NULL columns written verbatim; Description and ImageURL are nullable and
+	// normalize empty input to SQL NULL. Address/Country/Zipcode and the social
+	// fields are written through as-is to preserve prior behavior.
+	updates := map[string]interface{}{}
+	if req.Name != nil {
+		updates["name"] = *req.Name
+	}
+	if req.Address != nil {
+		updates["address"] = *req.Address
+	}
+	if req.City != nil {
+		updates["city"] = *req.City
+	}
+	if req.State != nil {
+		updates["state"] = *req.State
+	}
+	if req.Country != nil {
+		updates["country"] = *req.Country
+	}
+	if req.Zipcode != nil {
+		updates["zipcode"] = *req.Zipcode
+	}
+	if req.Instagram != nil {
+		updates["instagram"] = *req.Instagram
+	}
+	if req.Facebook != nil {
+		updates["facebook"] = *req.Facebook
+	}
+	if req.Twitter != nil {
+		updates["twitter"] = *req.Twitter
+	}
+	if req.YouTube != nil {
+		updates["youtube"] = *req.YouTube
+	}
+	if req.Spotify != nil {
+		updates["spotify"] = *req.Spotify
+	}
+	if req.SoundCloud != nil {
+		updates["soundcloud"] = *req.SoundCloud
+	}
+	if req.Bandcamp != nil {
+		updates["bandcamp"] = *req.Bandcamp
+	}
+	if req.Website != nil {
+		updates["website"] = *req.Website
+	}
+	if req.Description != nil {
+		updates["description"] = utils.NilIfEmpty(*req.Description)
+	}
+	if req.ImageURL != nil {
+		updates["image_url"] = utils.NilIfEmpty(*req.ImageURL)
+	}
+
 	// Update the venue
-	err = s.db.Model(&catalogm.Venue{}).Where("id = ?", venueID).Updates(updates).Error
-	if err != nil {
-		return nil, fmt.Errorf("failed to update venue: %w", err)
+	if len(updates) > 0 {
+		err = s.db.Model(&catalogm.Venue{}).Where("id = ?", venueID).Updates(updates).Error
+		if err != nil {
+			return nil, fmt.Errorf("failed to update venue: %w", err)
+		}
 	}
 
 	return s.GetVenue(venueID)

--- a/backend/internal/services/catalog/venue_test.go
+++ b/backend/internal/services/catalog/venue_test.go
@@ -311,9 +311,9 @@ func (suite *VenueServiceIntegrationTestSuite) TestUpdateVenue_BasicFields() {
 	}, true)
 	suite.Require().NoError(err)
 
-	resp, err := suite.venueService.UpdateVenue(created.ID, map[string]interface{}{
-		"name":    "Updated Name",
-		"address": "123 Main St",
+	resp, err := suite.venueService.UpdateVenue(created.ID, &contracts.UpdateVenueRequest{
+		Name:    stringPtr("Updated Name"),
+		Address: stringPtr("123 Main St"),
 	})
 
 	suite.Require().NoError(err)
@@ -322,7 +322,7 @@ func (suite *VenueServiceIntegrationTestSuite) TestUpdateVenue_BasicFields() {
 }
 
 func (suite *VenueServiceIntegrationTestSuite) TestUpdateVenue_NotFound() {
-	resp, err := suite.venueService.UpdateVenue(99999, map[string]interface{}{"name": "x"})
+	resp, err := suite.venueService.UpdateVenue(99999, &contracts.UpdateVenueRequest{Name: stringPtr("x")})
 
 	suite.Require().Error(err)
 	suite.Nil(resp)
@@ -345,7 +345,7 @@ func (suite *VenueServiceIntegrationTestSuite) TestUpdateVenue_DuplicateNameCity
 	suite.Require().NoError(err)
 
 	// Try to rename "Other Venue" to "Existing Venue" in same city
-	_, err = suite.venueService.UpdateVenue(other.ID, map[string]interface{}{"name": "Existing Venue"})
+	_, err = suite.venueService.UpdateVenue(other.ID, &contracts.UpdateVenueRequest{Name: stringPtr("Existing Venue")})
 
 	suite.Require().Error(err)
 	suite.Contains(err.Error(), "already exists")
@@ -360,9 +360,9 @@ func (suite *VenueServiceIntegrationTestSuite) TestUpdateVenue_SameNameSameVenue
 	suite.Require().NoError(err)
 
 	// Update address while keeping the same name — should not conflict with self
-	resp, err := suite.venueService.UpdateVenue(created.ID, map[string]interface{}{
-		"name":    "Keep My Name",
-		"address": "456 New St",
+	resp, err := suite.venueService.UpdateVenue(created.ID, &contracts.UpdateVenueRequest{
+		Name:    stringPtr("Keep My Name"),
+		Address: stringPtr("456 New St"),
 	})
 
 	suite.Require().NoError(err)

--- a/backend/internal/services/contracts/catalog.go
+++ b/backend/internal/services/contracts/catalog.go
@@ -52,6 +52,22 @@ type CreateShowRequest struct {
 	IsPrivate         bool  `json:"-"` // Whether show should be private (user's list only)
 }
 
+// UpdateShowRequest represents the basic show fields that can be updated.
+// A nil field means "leave unchanged"; only non-nil fields are written.
+// Artist and venue association replacement is handled separately via the
+// venues/artists params on UpdateShowWithRelations.
+type UpdateShowRequest struct {
+	Title          *string    `json:"title"`
+	EventDate      *time.Time `json:"event_date"`
+	City           *string    `json:"city"`
+	State          *string    `json:"state"`
+	Price          *float64   `json:"price"`
+	AgeRequirement *string    `json:"age_requirement"`
+	Description    *string    `json:"description"`
+	TicketURL      *string    `json:"ticket_url"`
+	ImageURL       *string    `json:"image_url"`
+}
+
 // ShowResponse represents the show data returned to clients
 type ShowResponse struct {
 	ID                uint             `json:"id"`
@@ -323,6 +339,33 @@ type CreateVenueRequest struct {
 	SubmittedBy *uint   `json:"-"` // Set by handler, not from request body
 }
 
+// UpdateVenueRequest represents the data that can be updated on a venue.
+// A nil field means "leave unchanged"; only non-nil fields are written.
+//
+// Name/City/State map to NOT NULL columns and are written as-is (the handler
+// rejects empty values up front). The remaining optional string columns are
+// nullable, so Description and ImageURL normalize an empty string to SQL NULL
+// in the service (utils.NilIfEmpty). Address/Country/Zipcode and the social
+// fields preserve the prior behavior of writing the value through verbatim.
+type UpdateVenueRequest struct {
+	Name        *string `json:"name"`
+	Address     *string `json:"address"`
+	City        *string `json:"city"`
+	State       *string `json:"state"`
+	Country     *string `json:"country"`
+	Zipcode     *string `json:"zipcode"`
+	Description *string `json:"description"`
+	ImageURL    *string `json:"image_url"`
+	Instagram   *string `json:"instagram"`
+	Facebook    *string `json:"facebook"`
+	Twitter     *string `json:"twitter"`
+	YouTube     *string `json:"youtube"`
+	Spotify     *string `json:"spotify"`
+	SoundCloud  *string `json:"soundcloud"`
+	Bandcamp    *string `json:"bandcamp"`
+	Website     *string `json:"website"`
+}
+
 // VenueDetailResponse represents the venue data returned to clients
 type VenueDetailResponse struct {
 	ID          uint           `json:"id"`
@@ -414,6 +457,31 @@ type CreateArtistRequest struct {
 	Bandcamp    *string `json:"bandcamp"`
 	Website     *string `json:"website"`
 	Description *string `json:"description"`
+}
+
+// UpdateArtistRequest represents the data that can be updated on an artist.
+// A nil field means "leave unchanged"; only non-nil fields are written.
+//
+// Every column here is nullable, so the service normalizes an empty string to
+// SQL NULL (utils.NilIfEmpty) for all fields except Name, which maps to a NOT
+// NULL column. Name additionally drives slug regeneration and a uniqueness
+// check in the service. BandcampEmbedURL is the embed-specific column distinct
+// from the Bandcamp social profile URL.
+type UpdateArtistRequest struct {
+	Name             *string `json:"name"`
+	State            *string `json:"state"`
+	City             *string `json:"city"`
+	Country          *string `json:"country"`
+	Description      *string `json:"description"`
+	BandcampEmbedURL *string `json:"bandcamp_embed_url"`
+	Instagram        *string `json:"instagram"`
+	Facebook         *string `json:"facebook"`
+	Twitter          *string `json:"twitter"`
+	YouTube          *string `json:"youtube"`
+	Spotify          *string `json:"spotify"`
+	SoundCloud       *string `json:"soundcloud"`
+	Bandcamp         *string `json:"bandcamp"`
+	Website          *string `json:"website"`
 }
 
 // ArtistDetailResponse represents the artist data returned to clients
@@ -765,8 +833,8 @@ type ShowServiceInterface interface {
 	GetShowBySlug(slug string) (*ShowResponse, error)
 	GetShows(filters map[string]interface{}) ([]*ShowResponse, error)
 	GetUserSubmissions(userID uint, limit, offset int) ([]ShowResponse, int, error)
-	UpdateShow(showID uint, updates map[string]interface{}) (*ShowResponse, error)
-	UpdateShowWithRelations(showID uint, updates map[string]interface{}, venues []CreateShowVenue, artists []CreateShowArtist, isAdmin bool) (*ShowResponse, []OrphanedArtist, error)
+	UpdateShow(showID uint, req *UpdateShowRequest) (*ShowResponse, error)
+	UpdateShowWithRelations(showID uint, req *UpdateShowRequest, venues []CreateShowVenue, artists []CreateShowArtist, isAdmin bool) (*ShowResponse, []OrphanedArtist, error)
 	GetUpcomingShows(timezone string, cursor string, limit int, includeNonApproved bool, filters *UpcomingShowsFilter) ([]*ShowResponse, *string, error)
 	GetShowCities(timezone string) ([]ShowCityResponse, error)
 	DeleteShow(showID uint) error
@@ -826,7 +894,7 @@ type VenueServiceInterface interface {
 	GetVenue(venueID uint) (*VenueDetailResponse, error)
 	GetVenueBySlug(slug string) (*VenueDetailResponse, error)
 	GetVenues(filters map[string]interface{}) ([]*VenueDetailResponse, error)
-	UpdateVenue(venueID uint, updates map[string]interface{}) (*VenueDetailResponse, error)
+	UpdateVenue(venueID uint, req *UpdateVenueRequest) (*VenueDetailResponse, error)
 	DeleteVenue(venueID uint) error
 	SearchVenues(query string) ([]*VenueDetailResponse, error)
 	FindOrCreateVenue(name, city, state string, address, zipcode *string, db *gorm.DB, isAdmin bool) (*catalogm.Venue, bool, error)
@@ -857,7 +925,7 @@ type ArtistServiceInterface interface {
 	GetArtistBySlug(slug string) (*ArtistDetailResponse, error)
 	GetArtists(filters map[string]interface{}) ([]*ArtistDetailResponse, error)
 	GetArtistsWithShowCounts(filters map[string]interface{}) ([]*ArtistWithShowCountResponse, error)
-	UpdateArtist(artistID uint, updates map[string]interface{}) (*ArtistDetailResponse, error)
+	UpdateArtist(artistID uint, req *UpdateArtistRequest) (*ArtistDetailResponse, error)
 	DeleteArtist(artistID uint) error
 	SearchArtists(query string) ([]*ArtistDetailResponse, error)
 	GetShowsForArtist(artistID uint, timezone string, limit int, timeFilter string) ([]*ArtistShowResponse, int64, error)

--- a/backend/internal/services/pipeline/enrichment_test.go
+++ b/backend/internal/services/pipeline/enrichment_test.go
@@ -101,7 +101,7 @@ func (m *mockArtistServiceForEnrichment) GetArtists(filters map[string]interface
 func (m *mockArtistServiceForEnrichment) GetArtistsWithShowCounts(filters map[string]interface{}) ([]*contracts.ArtistWithShowCountResponse, error) {
 	return nil, nil
 }
-func (m *mockArtistServiceForEnrichment) UpdateArtist(artistID uint, updates map[string]interface{}) (*contracts.ArtistDetailResponse, error) {
+func (m *mockArtistServiceForEnrichment) UpdateArtist(artistID uint, req *contracts.UpdateArtistRequest) (*contracts.ArtistDetailResponse, error) {
 	return nil, nil
 }
 func (m *mockArtistServiceForEnrichment) DeleteArtist(artistID uint) error { return nil }

--- a/backend/internal/services/pipeline/orchestrator_test.go
+++ b/backend/internal/services/pipeline/orchestrator_test.go
@@ -169,7 +169,7 @@ func (s *stubVenueService) GetVenueBySlug(slug string) (*contracts.VenueDetailRe
 func (s *stubVenueService) GetVenues(filters map[string]interface{}) ([]*contracts.VenueDetailResponse, error) {
 	panic("not implemented")
 }
-func (s *stubVenueService) UpdateVenue(venueID uint, updates map[string]interface{}) (*contracts.VenueDetailResponse, error) {
+func (s *stubVenueService) UpdateVenue(venueID uint, req *contracts.UpdateVenueRequest) (*contracts.VenueDetailResponse, error) {
 	panic("not implemented")
 }
 func (s *stubVenueService) DeleteVenue(venueID uint) error { panic("not implemented") }


### PR DESCRIPTION
## Summary
- Migrate `UpdateShow`, `UpdateShowWithRelations`, `UpdateVenue`, and `UpdateArtist` from the legacy `Update*(map[string]interface{})` signatures to typed `UpdateShowRequest` / `UpdateVenueRequest` / `UpdateArtistRequest` structs, matching festival/release/label.
- Each service now translates its typed struct into a GORM update map internally (a nil field means "leave unchanged"), preserving the prior `utils.NilIfEmpty` normalization so empty input still lands as SQL NULL on the same nullable columns it did before. `UpdateShowWithRelations` keeps its relation params; the only signature change is `updates map` → `req *UpdateShowRequest`.
- Removed the ~30-line handler-side map-building boilerplate for all three entities. The bandcamp/spotify artist endpoints now signal clear-to-NULL by passing an empty string through the typed request (the service NULLs it) rather than hand-building a nil-valued map. Behavior is unchanged end to end.
- `UpdateShowWithRelations` body decomposition stays out of scope (that's PSY-759); only its signature changed here.

## Test plan
- [x] `cd backend && go build ./...` — clean
- [x] `cd backend && go vet ./...` — clean
- [x] `cd backend && go test ./...` — EXIT 0, 27 packages ok, 0 failures
- [x] Scoped: `go test ./internal/api/handlers/catalog/... ./internal/services/catalog/... ./internal/services/pipeline/... ./internal/api/handlers/pipeline/...` — all ok (full suite re-run because the shared generated mock interface changed)

## Manual repro
Update tests across both layers exercise the field-omission and clear-to-NULL semantics (Docker/testcontainers Postgres):
- `TestUpdateArtist_BasicFields` / `TestUpdateVenue_BasicFields` / `TestUpdateShow_BasicFields` — update a subset of fields; untouched fields stay unchanged.
- `TestUpdateArtist_NameChangeRegeneratesSlug`, `TestUpdateArtist_DuplicateName_Fails`, `TestUpdateArtist_SameNameSameArtist_OK`, `TestUpdateVenue_DuplicateNameCity_Fails`, `TestUpdateVenue_SameNameSameVenue_OK` — name/city dup-guard + slug regen still keyed off the typed fields.
- `TestUpdateShow_EventDate_UTC` + `TestUpdateShow_CascadesEventDateToShowArtists` — `*time.Time` field still UTC-normalized and cascades to `show_artists.event_date`.
- `TestUpdateBandcamp_AdminSuccess` / `TestUpdateBandcamp_ClearURL` / `TestUpdateSpotify_AdminSuccess` / `TestUpdateSpotify_ClearURL` (integration) — set populates the embed + derived social profile; clearing with `""` NULLs the column (`resp.Body.BandcampEmbedURL`/`Social.Spotify` come back nil). The mock-level `TestUpdateBandcamp_Success`/`_ClearURL`/`TestUpdateSpotify_Success` now assert against the typed request fields instead of map keys.
- `TestAdminUpdateArtist_NoFields` — empty PATCH still rejected 422 via the new `hasArtistUpdateFields` guard.

All of the above pass.

## Simplify
Ran `/simplify`. The code already mirrored the festival/label/release template, so only minor fixes: stripped two ticket refs from doc comments (kept the semantic why), and reused `shared.Deref` for the bandcamp/spotify nil-to-empty unwraps. Committed separately as `PSY-758: simplify pass`.

## Notes
- `mocks_gen.go` is generated, but the committed copy on `main` was stale relative to the generator (a full regen swept in ~1100 lines of unrelated `(error)`→`error` / alignment drift). To keep this PR minimal, I applied only the four method-signature changes by hand (12 insertions / 12 deletions) instead of regenerating wholesale. Backend CI runs `go test ./...` with no gofmt/lint gate, so this is safe.

Closes PSY-758