### PR TITLE
PSY-686: test sweep for features/festivals module

### DIFF
--- a/frontend/features/festivals/admin/FestivalManagement.test.tsx
+++ b/frontend/features/festivals/admin/FestivalManagement.test.tsx
@@ -1,0 +1,247 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders } from '@/test/utils'
+import type { FestivalListItem } from '../types'
+
+// Read hooks
+const mockUseFestivals = vi.fn()
+const mockUseFestival = vi.fn()
+const mockUseFestivalLineup = vi.fn()
+const mockUseFestivalVenues = vi.fn()
+vi.mock('../hooks/useFestivals', () => ({
+  useFestivals: (opts: unknown) => mockUseFestivals(opts),
+  useFestival: (opts: unknown) => mockUseFestival(opts),
+  useFestivalLineup: (opts: unknown) => mockUseFestivalLineup(opts),
+  useFestivalVenues: (opts: unknown) => mockUseFestivalVenues(opts),
+}))
+
+// Admin mutation hooks. The factory is hoisted above module scope by vitest,
+// so the no-op return value is inlined rather than referencing an outer const.
+vi.mock('../hooks/useAdminFestivals', () => {
+  const noopMutation = () => ({ mutate: vi.fn(), isPending: false })
+  return {
+    useCreateFestival: noopMutation,
+    useUpdateFestival: noopMutation,
+    useDeleteFestival: noopMutation,
+    useAddFestivalArtist: noopMutation,
+    useUpdateFestivalArtist: noopMutation,
+    useRemoveFestivalArtist: noopMutation,
+    useAddFestivalVenue: noopMutation,
+    useRemoveFestivalVenue: noopMutation,
+  }
+})
+
+// Search hooks pulled in by the lineup/venue management panels
+vi.mock('@/features/artists', () => ({
+  useArtistSearch: () => ({ data: { artists: [] }, isLoading: false }),
+}))
+vi.mock('@/features/venues', () => ({
+  useVenueSearch: () => ({ data: { venues: [] }, isLoading: false }),
+}))
+
+import { FestivalManagement } from './FestivalManagement'
+
+function makeFestival(overrides: Partial<FestivalListItem> = {}): FestivalListItem {
+  return {
+    id: 1,
+    name: 'FORM Arcosanti',
+    slug: 'form-arcosanti-2025',
+    series_slug: 'form-arcosanti',
+    edition_year: 2025,
+    city: 'Mayer',
+    state: 'AZ',
+    start_date: '2025-05-09',
+    end_date: '2025-05-11',
+    status: 'confirmed',
+    artist_count: 12,
+    venue_count: 1,
+    ...overrides,
+  }
+}
+
+describe('FestivalManagement', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseFestival.mockReturnValue({ data: undefined, isLoading: false })
+    mockUseFestivalLineup.mockReturnValue({
+      data: { artists: [], count: 0 },
+      isLoading: false,
+    })
+    mockUseFestivalVenues.mockReturnValue({
+      data: { venues: [], count: 0 },
+      isLoading: false,
+    })
+  })
+
+  it('shows the loading spinner while festivals are fetching', () => {
+    mockUseFestivals.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    })
+    renderWithProviders(<FestivalManagement />)
+    expect(document.querySelector('.animate-spin')).toBeInTheDocument()
+  })
+
+  it('renders an error banner when the query fails', () => {
+    mockUseFestivals.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('load failed'),
+    })
+    renderWithProviders(<FestivalManagement />)
+    expect(screen.getByText('load failed')).toBeInTheDocument()
+  })
+
+  it('renders the empty state when there are no festivals', () => {
+    mockUseFestivals.mockReturnValue({
+      data: { festivals: [], count: 0 },
+      isLoading: false,
+      error: null,
+    })
+    renderWithProviders(<FestivalManagement />)
+    expect(screen.getByText('No Festivals Found')).toBeInTheDocument()
+    expect(
+      screen.getByText(/No festivals yet\. Create your first festival/)
+    ).toBeInTheDocument()
+  })
+
+  it('lists festivals with their status and a count', () => {
+    mockUseFestivals.mockReturnValue({
+      data: {
+        festivals: [
+          makeFestival({ id: 1, name: 'FORM Arcosanti' }),
+          makeFestival({ id: 2, name: 'Desert Daze', status: 'announced' }),
+        ],
+        count: 2,
+      },
+      isLoading: false,
+      error: null,
+    })
+    renderWithProviders(<FestivalManagement />)
+
+    expect(screen.getByText('FORM Arcosanti')).toBeInTheDocument()
+    expect(screen.getByText('Desert Daze')).toBeInTheDocument()
+    expect(screen.getByText('2 festivals')).toBeInTheDocument()
+    // "Confirmed"/"Announced" also appear as <option> text in the status
+    // filter; the row status badges are <div>s, so filter to those.
+    const confirmedBadges = screen
+      .getAllByText('Confirmed')
+      .filter((el) => el.tagName === 'DIV')
+    expect(confirmedBadges).toHaveLength(1)
+    const announcedBadges = screen
+      .getAllByText('Announced')
+      .filter((el) => el.tagName === 'DIV')
+    expect(announcedBadges).toHaveLength(1)
+  })
+
+  it('filters the list client-side by the debounced search input', async () => {
+    const user = userEvent.setup()
+    mockUseFestivals.mockReturnValue({
+      data: {
+        festivals: [
+          makeFestival({ id: 1, name: 'FORM Arcosanti' }),
+          makeFestival({ id: 2, name: 'Desert Daze' }),
+        ],
+        count: 2,
+      },
+      isLoading: false,
+      error: null,
+    })
+    renderWithProviders(<FestivalManagement />)
+
+    await user.type(screen.getByPlaceholderText('Search festivals...'), 'desert')
+
+    await waitFor(() =>
+      expect(screen.queryByText('FORM Arcosanti')).not.toBeInTheDocument()
+    )
+    expect(screen.getByText('Desert Daze')).toBeInTheDocument()
+    expect(screen.getByText(/matching "desert"/)).toBeInTheDocument()
+  })
+
+  it('opens the create dialog from the New Festival button', async () => {
+    const user = userEvent.setup()
+    mockUseFestivals.mockReturnValue({
+      data: { festivals: [], count: 0 },
+      isLoading: false,
+      error: null,
+    })
+    renderWithProviders(<FestivalManagement />)
+
+    await user.click(screen.getByRole('button', { name: /New Festival/ }))
+    expect(
+      screen.getByRole('heading', { name: 'Create Festival' })
+    ).toBeInTheDocument()
+  })
+
+  it('opens the delete confirmation with the festival name', async () => {
+    const user = userEvent.setup()
+    mockUseFestivals.mockReturnValue({
+      data: { festivals: [makeFestival({ name: 'FORM Arcosanti' })], count: 1 },
+      isLoading: false,
+      error: null,
+    })
+    const { container } = renderWithProviders(<FestivalManagement />)
+
+    // Edit/Delete are icon-only buttons with no accessible name; the delete
+    // button is the only one carrying the destructive hover affordance.
+    const deleteButton = container.querySelector<HTMLButtonElement>(
+      'button.hover\\:text-destructive'
+    )
+    expect(deleteButton).not.toBeNull()
+    await user.click(deleteButton!)
+
+    expect(
+      screen.getByRole('heading', { name: 'Delete Festival' })
+    ).toBeInTheDocument()
+    // The confirmation copy echoes the name (quoted) in a bold span. The row
+    // behind the dialog also shows the name, so match the quoted variant.
+    expect(screen.getByText('"FORM Arcosanti"')).toBeInTheDocument()
+  })
+
+  it('navigates into the lineup management panel', async () => {
+    const user = userEvent.setup()
+    mockUseFestivals.mockReturnValue({
+      data: { festivals: [makeFestival({ id: 7, name: 'FORM Arcosanti' })], count: 1 },
+      isLoading: false,
+      error: null,
+    })
+    renderWithProviders(<FestivalManagement />)
+
+    await user.click(screen.getByRole('button', { name: /Lineup/ }))
+
+    expect(
+      screen.getByRole('heading', { name: /FORM Arcosanti - Lineup/ })
+    ).toBeInTheDocument()
+    expect(mockUseFestivalLineup).toHaveBeenCalledWith({
+      festivalId: 7,
+      enabled: true,
+    })
+    // Back button returns to the list
+    await user.click(screen.getByRole('button', { name: /Back/ }))
+    expect(
+      screen.getByRole('heading', { name: 'Festivals' })
+    ).toBeInTheDocument()
+  })
+
+  it('navigates into the venue management panel', async () => {
+    const user = userEvent.setup()
+    mockUseFestivals.mockReturnValue({
+      data: { festivals: [makeFestival({ id: 7, name: 'FORM Arcosanti' })], count: 1 },
+      isLoading: false,
+      error: null,
+    })
+    renderWithProviders(<FestivalManagement />)
+
+    await user.click(screen.getByRole('button', { name: /Venues/ }))
+
+    expect(
+      screen.getByRole('heading', { name: /FORM Arcosanti - Venues/ })
+    ).toBeInTheDocument()
+    expect(mockUseFestivalVenues).toHaveBeenCalledWith({
+      festivalIdOrSlug: 7,
+      enabled: true,
+    })
+  })
+})

--- a/frontend/features/festivals/admin/index.test.ts
+++ b/frontend/features/festivals/admin/index.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest'
+import * as admin from './index'
+
+// admin/index.ts is the barrel for the admin festival management surface.
+describe('festivals admin barrel', () => {
+  it('re-exports the FestivalManagement component', () => {
+    expect(typeof admin.FestivalManagement).toBe('function')
+  })
+})

--- a/frontend/features/festivals/api.test.ts
+++ b/frontend/features/festivals/api.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest'
+import { festivalEndpoints, festivalQueryKeys } from './api'
+
+// The endpoint builders embed API_BASE_URL, which the vitest config pins to
+// http://localhost:8080 via NEXT_PUBLIC_API_URL.
+const BASE = 'http://localhost:8080'
+
+describe('festivalEndpoints', () => {
+  it('exposes static collection endpoints', () => {
+    expect(festivalEndpoints.LIST).toBe(`${BASE}/festivals`)
+    expect(festivalEndpoints.SEARCH).toBe(`${BASE}/festivals/search`)
+    expect(festivalEndpoints.CREATE).toBe(`${BASE}/festivals`)
+  })
+
+  it('builds detail + mutation endpoints from an id or slug', () => {
+    expect(festivalEndpoints.GET('form-arcosanti')).toBe(
+      `${BASE}/festivals/form-arcosanti`
+    )
+    expect(festivalEndpoints.GET(42)).toBe(`${BASE}/festivals/42`)
+    expect(festivalEndpoints.UPDATE(42)).toBe(`${BASE}/festivals/42`)
+    expect(festivalEndpoints.DELETE(42)).toBe(`${BASE}/festivals/42`)
+  })
+
+  it('builds lineup (artist) endpoints', () => {
+    expect(festivalEndpoints.ARTISTS(1)).toBe(`${BASE}/festivals/1/artists`)
+    expect(festivalEndpoints.ADD_ARTIST(1)).toBe(`${BASE}/festivals/1/artists`)
+    expect(festivalEndpoints.UPDATE_ARTIST(1, 7)).toBe(
+      `${BASE}/festivals/1/artists/7`
+    )
+    expect(festivalEndpoints.REMOVE_ARTIST(1, 7)).toBe(
+      `${BASE}/festivals/1/artists/7`
+    )
+  })
+
+  it('builds venue endpoints', () => {
+    expect(festivalEndpoints.VENUES(1)).toBe(`${BASE}/festivals/1/venues`)
+    expect(festivalEndpoints.ADD_VENUE(1)).toBe(`${BASE}/festivals/1/venues`)
+    expect(festivalEndpoints.REMOVE_VENUE(1, 9)).toBe(
+      `${BASE}/festivals/1/venues/9`
+    )
+  })
+
+  it('builds artist-scoped festival endpoints', () => {
+    expect(festivalEndpoints.ARTIST_FESTIVALS('radiohead')).toBe(
+      `${BASE}/artists/radiohead/festivals`
+    )
+    expect(festivalEndpoints.ARTIST_TRAJECTORY('radiohead')).toBe(
+      `${BASE}/artists/radiohead/festival-trajectory`
+    )
+  })
+
+  it('builds festival-intelligence endpoints', () => {
+    expect(festivalEndpoints.SIMILAR(1)).toBe(`${BASE}/festivals/1/similar`)
+    expect(festivalEndpoints.OVERLAP(1, 2)).toBe(
+      `${BASE}/festivals/1/overlap/2`
+    )
+    expect(festivalEndpoints.BREAKOUTS(1)).toBe(
+      `${BASE}/festivals/1/breakouts`
+    )
+    expect(festivalEndpoints.SERIES_COMPARE('coachella')).toBe(
+      `${BASE}/festivals/series/coachella/compare`
+    )
+  })
+})
+
+describe('festivalQueryKeys', () => {
+  it('exposes the root key used for invalidation', () => {
+    expect(festivalQueryKeys.all).toEqual(['festivals'])
+  })
+
+  it('namespaces list keys under the filter object', () => {
+    expect(festivalQueryKeys.list()).toEqual(['festivals', 'list', undefined])
+    expect(festivalQueryKeys.list({ year: 2025 })).toEqual([
+      'festivals',
+      'list',
+      { year: 2025 },
+    ])
+  })
+
+  it('lower-cases the search key for case-insensitive caching', () => {
+    expect(festivalQueryKeys.search('Coachella')).toEqual([
+      'festivals',
+      'search',
+      'coachella',
+    ])
+  })
+
+  it('stringifies ids in detail/artist/venue keys for stable equality', () => {
+    expect(festivalQueryKeys.detail(42)).toEqual(['festivals', 'detail', '42'])
+    expect(festivalQueryKeys.detail('form')).toEqual([
+      'festivals',
+      'detail',
+      'form',
+    ])
+    expect(festivalQueryKeys.venues(3)).toEqual(['festivals', 'venues', '3'])
+    expect(festivalQueryKeys.artistFestivals(5)).toEqual([
+      'festivals',
+      'artist',
+      '5',
+    ])
+  })
+
+  it('includes the optional dayDate segment in the artists key', () => {
+    expect(festivalQueryKeys.artists(1)).toEqual([
+      'festivals',
+      'artists',
+      '1',
+      undefined,
+    ])
+    expect(festivalQueryKeys.artists(1, '2025-05-09')).toEqual([
+      'festivals',
+      'artists',
+      '1',
+      '2025-05-09',
+    ])
+  })
+
+  it('builds intelligence keys', () => {
+    expect(festivalQueryKeys.similar(1)).toEqual(['festivals', 'similar', '1'])
+    expect(festivalQueryKeys.overlap(1, 2)).toEqual([
+      'festivals',
+      'overlap',
+      '1',
+      '2',
+    ])
+    expect(festivalQueryKeys.breakouts(1)).toEqual([
+      'festivals',
+      'breakouts',
+      '1',
+    ])
+    expect(festivalQueryKeys.artistTrajectory(7)).toEqual([
+      'festivals',
+      'trajectory',
+      '7',
+    ])
+  })
+
+  it('joins the years array into the seriesCompare key', () => {
+    expect(festivalQueryKeys.seriesCompare('coachella', [2024, 2025])).toEqual([
+      'festivals',
+      'series',
+      'coachella',
+      '2024,2025',
+    ])
+  })
+})

--- a/frontend/features/festivals/components/FestivalCard.test.tsx
+++ b/frontend/features/festivals/components/FestivalCard.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { FestivalCard } from './FestivalCard'
+import type { FestivalListItem } from '../types'
+
+function makeFestival(overrides: Partial<FestivalListItem> = {}): FestivalListItem {
+  return {
+    id: 1,
+    name: 'FORM Arcosanti',
+    slug: 'form-arcosanti-2025',
+    series_slug: 'form-arcosanti',
+    edition_year: 2025,
+    city: 'Mayer',
+    state: 'AZ',
+    start_date: '2025-05-09',
+    end_date: '2025-05-11',
+    status: 'confirmed',
+    artist_count: 12,
+    venue_count: 1,
+    ...overrides,
+  }
+}
+
+describe('FestivalCard', () => {
+  it('renders as an article with the festival name linking to its page', () => {
+    render(<FestivalCard festival={makeFestival()} />)
+    expect(screen.getByRole('article')).toBeInTheDocument()
+    const link = screen.getByRole('link', { name: 'FORM Arcosanti' })
+    expect(link).toHaveAttribute('href', '/festivals/form-arcosanti-2025')
+  })
+
+  it('renders the status badge label', () => {
+    render(<FestivalCard festival={makeFestival({ status: 'announced' })} />)
+    expect(screen.getByText('Announced')).toBeInTheDocument()
+  })
+
+  it('renders the city/state location', () => {
+    render(<FestivalCard festival={makeFestival()} />)
+    expect(screen.getByText('Mayer, AZ')).toBeInTheDocument()
+  })
+
+  it('renders the formatted date range and edition year', () => {
+    render(<FestivalCard festival={makeFestival()} />)
+    expect(screen.getByText('May 9–11, 2025')).toBeInTheDocument()
+    expect(screen.getByText('2025')).toBeInTheDocument()
+  })
+
+  it('singularizes the artist count', () => {
+    render(<FestivalCard festival={makeFestival({ artist_count: 1 })} />)
+    expect(screen.getByText('1 artist')).toBeInTheDocument()
+  })
+
+  it('pluralizes the artist count', () => {
+    render(<FestivalCard festival={makeFestival({ artist_count: 12 })} />)
+    expect(screen.getByText('12 artists')).toBeInTheDocument()
+  })
+
+  it('omits location when neither city nor state is set', () => {
+    render(
+      <FestivalCard festival={makeFestival({ city: null, state: null })} />
+    )
+    expect(screen.queryByText(/, AZ/)).not.toBeInTheDocument()
+  })
+
+  describe('compact density', () => {
+    it('renders the name as a link and the artist count', () => {
+      render(<FestivalCard festival={makeFestival()} density="compact" />)
+      const link = screen.getByRole('link', { name: 'FORM Arcosanti' })
+      expect(link).toHaveAttribute('href', '/festivals/form-arcosanti-2025')
+      expect(screen.getByText('12 artists')).toBeInTheDocument()
+    })
+  })
+
+  describe('expanded density', () => {
+    it('shows the venue count when present', () => {
+      render(
+        <FestivalCard
+          festival={makeFestival({ venue_count: 3 })}
+          density="expanded"
+        />
+      )
+      expect(screen.getByText('3 venues')).toBeInTheDocument()
+    })
+
+    it('hides the venue count when zero', () => {
+      render(
+        <FestivalCard
+          festival={makeFestival({ venue_count: 0 })}
+          density="expanded"
+        />
+      )
+      expect(screen.queryByText(/venue/)).not.toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/features/festivals/components/FestivalDetail.test.tsx
+++ b/frontend/features/festivals/components/FestivalDetail.test.tsx
@@ -1,0 +1,313 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import { renderWithProviders } from '@/test/utils'
+import type { FestivalDetail as FestivalDetailType } from '../types'
+
+// next/link
+vi.mock('next/link', () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string
+    children: React.ReactNode
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}))
+
+// Data hooks (festival detail + its lineup/venue/series companions)
+const mockUseFestival = vi.fn()
+const mockUseFestivalArtists = vi.fn()
+const mockUseFestivalVenues = vi.fn()
+const mockUseFestivals = vi.fn()
+vi.mock('../hooks/useFestivals', () => ({
+  useFestival: (opts: unknown) => mockUseFestival(opts),
+  useFestivalArtists: (opts: unknown) => mockUseFestivalArtists(opts),
+  useFestivalVenues: (opts: unknown) => mockUseFestivalVenues(opts),
+  useFestivals: (opts: unknown) => mockUseFestivals(opts),
+}))
+
+const mockUseIsAuthenticated = vi.fn()
+vi.mock('@/features/auth', () => ({
+  useIsAuthenticated: () => mockUseIsAuthenticated(),
+}))
+
+// Heavy intelligence children get their own coverage; stub here to stay focused.
+vi.mock('./FestivalLineup', () => ({
+  FestivalLineup: ({ artists }: { artists: unknown[] }) => (
+    <div data-testid="festival-lineup">Lineup ({artists.length})</div>
+  ),
+}))
+vi.mock('./SimilarFestivals', () => ({
+  SimilarFestivals: () => <div data-testid="similar-festivals" />,
+}))
+vi.mock('./RisingArtists', () => ({
+  RisingArtists: () => <div data-testid="rising-artists" />,
+}))
+vi.mock('./SeriesHistory', () => ({
+  SeriesHistory: () => <div data-testid="series-history" />,
+}))
+
+vi.mock('@/features/collections', () => ({
+  EntityCollections: () => <div data-testid="entity-collections" />,
+}))
+
+vi.mock('@/features/contributions', () => ({
+  EntityEditDrawer: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="edit-drawer">Edit Drawer</div> : null,
+  EntitySaveSuccessBanner: ({ visible }: { visible: boolean }) =>
+    visible ? <div data-testid="save-banner">Saved</div> : null,
+  useEntitySaveSuccessBanner: () => ({
+    isVisible: false,
+    handleSaveSuccess: vi.fn(),
+  }),
+  AttributionLine: () => null,
+  ReportEntityDialog: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="report-dialog" /> : null,
+  ContributionPrompt: () => null,
+}))
+
+vi.mock('@/features/comments', () => ({
+  CommentThread: () => <div data-testid="comment-thread" />,
+}))
+
+vi.mock('@/features/tags', () => ({
+  EntityTagList: () => <div data-testid="entity-tag-list" />,
+  AddTagDialog: () => null,
+}))
+
+vi.mock('@/components/shared', () => ({
+  EntityDetailLayout: ({
+    children,
+    sidebar,
+    header,
+    fallback,
+  }: {
+    children: React.ReactNode
+    sidebar: React.ReactNode
+    header: React.ReactNode
+    fallback: { href: string; label: string }
+  }) => (
+    <div data-testid="entity-layout">
+      <a href={fallback.href}>{fallback.label}</a>
+      <div data-testid="header-slot">{header}</div>
+      <div data-testid="sidebar-slot">{sidebar}</div>
+      <div data-testid="content-slot">{children}</div>
+    </div>
+  ),
+  EntityHeader: ({
+    title,
+    subtitle,
+    actions,
+  }: {
+    title: string
+    subtitle?: React.ReactNode
+    actions?: React.ReactNode
+  }) => (
+    <div data-testid="entity-header">
+      <h1>{title}</h1>
+      {subtitle && <div data-testid="subtitle">{subtitle}</div>}
+      {actions && <div data-testid="header-actions">{actions}</div>}
+    </div>
+  ),
+  SocialLinks: () => <div data-testid="social-links" />,
+  FollowButton: () => <button data-testid="follow-button">Follow</button>,
+  AddToCollectionButton: () => (
+    <button data-testid="add-to-collection">Add</button>
+  ),
+  RevisionHistory: () => <div data-testid="revision-history" />,
+  BracketLink: ({ label, onClick }: { label: string; onClick?: () => void }) => (
+    <button onClick={onClick} data-testid={`bracket-${label}`}>
+      [{label}]
+    </button>
+  ),
+  SectionHeader: ({ title }: { title: string }) => <h3>{title}</h3>,
+  StatsList: ({ items }: { items: { label: string; value: React.ReactNode }[] }) => (
+    <dl data-testid="stats-list">
+      {items.map((i) => (
+        <div key={i.label}>
+          <dt>{i.label}</dt>
+          <dd>{i.value}</dd>
+        </div>
+      ))}
+    </dl>
+  ),
+}))
+
+import { FestivalDetail } from './FestivalDetail'
+
+function makeFestival(
+  overrides: Partial<FestivalDetailType> = {}
+): FestivalDetailType {
+  return {
+    id: 1,
+    name: 'FORM Arcosanti',
+    slug: 'form-arcosanti-2025',
+    series_slug: 'form-arcosanti',
+    edition_year: 2025,
+    description: null,
+    location_name: 'Arcosanti',
+    city: 'Mayer',
+    state: 'AZ',
+    country: 'US',
+    start_date: '2025-05-09',
+    end_date: '2025-05-11',
+    website: null,
+    ticket_url: null,
+    flyer_url: null,
+    status: 'confirmed',
+    social: null,
+    artist_count: 12,
+    venue_count: 1,
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('FestivalDetail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseIsAuthenticated.mockReturnValue({
+      user: null,
+      isAuthenticated: false,
+      isLoading: false,
+    })
+    mockUseFestivalArtists.mockReturnValue({ data: { artists: [] }, isLoading: false })
+    mockUseFestivalVenues.mockReturnValue({ data: { venues: [] }, isLoading: false })
+    mockUseFestivals.mockReturnValue({ data: { festivals: [] } })
+  })
+
+  it('shows a loading spinner while the festival is fetching', () => {
+    mockUseFestival.mockReturnValue({ data: undefined, isLoading: true, error: null })
+    renderWithProviders(<FestivalDetail idOrSlug="form-arcosanti" />)
+    expect(document.querySelector('.animate-spin')).toBeInTheDocument()
+  })
+
+  it('renders a 404 message for a not-found error', () => {
+    mockUseFestival.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('festival not found'),
+    })
+    renderWithProviders(<FestivalDetail idOrSlug="missing" />)
+    expect(screen.getByText('Festival Not Found')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Back to Festivals' })).toHaveAttribute(
+      'href',
+      '/festivals'
+    )
+  })
+
+  it('renders a generic error message for non-404 errors', () => {
+    mockUseFestival.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('server exploded'),
+    })
+    renderWithProviders(<FestivalDetail idOrSlug="boom" />)
+    expect(screen.getByText('Error Loading Festival')).toBeInTheDocument()
+    expect(screen.getByText('server exploded')).toBeInTheDocument()
+  })
+
+  it('renders the header, stats, and lineup when the festival loads', () => {
+    mockUseFestival.mockReturnValue({
+      data: makeFestival(),
+      isLoading: false,
+      error: null,
+    })
+    mockUseFestivalArtists.mockReturnValue({
+      data: { artists: [{ id: 1, day_date: null }] },
+      isLoading: false,
+    })
+    renderWithProviders(<FestivalDetail idOrSlug="form-arcosanti" />)
+
+    expect(
+      screen.getByRole('heading', { name: 'FORM Arcosanti' })
+    ).toBeInTheDocument()
+    expect(screen.getByText('Confirmed')).toBeInTheDocument()
+    expect(screen.getByText('May 9–11, 2025')).toBeInTheDocument()
+    expect(screen.getByTestId('festival-lineup')).toHaveTextContent('Lineup (1)')
+  })
+
+  it('renders the website and ticket links when present', () => {
+    mockUseFestival.mockReturnValue({
+      data: makeFestival({
+        website: 'https://form.com',
+        ticket_url: 'https://tickets.com',
+      }),
+      isLoading: false,
+      error: null,
+    })
+    renderWithProviders(<FestivalDetail idOrSlug="form-arcosanti" />)
+
+    expect(
+      screen.getByRole('link', { name: 'Official Website' })
+    ).toHaveAttribute('href', 'https://form.com')
+    expect(screen.getByRole('link', { name: 'Buy Tickets' })).toHaveAttribute(
+      'href',
+      'https://tickets.com'
+    )
+  })
+
+  it('renders the venues section with venue links', () => {
+    mockUseFestival.mockReturnValue({
+      data: makeFestival(),
+      isLoading: false,
+      error: null,
+    })
+    mockUseFestivalVenues.mockReturnValue({
+      data: {
+        venues: [
+          {
+            id: 1,
+            venue_id: 5,
+            venue_name: 'The Venue',
+            venue_slug: 'the-venue',
+            city: 'Phoenix',
+            state: 'AZ',
+            is_primary: true,
+          },
+        ],
+      },
+      isLoading: false,
+    })
+    renderWithProviders(<FestivalDetail idOrSlug="form-arcosanti" />)
+
+    expect(screen.getByRole('heading', { name: 'Venues' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'The Venue' })).toHaveAttribute(
+      'href',
+      '/venues/the-venue'
+    )
+    expect(screen.getByText('Primary')).toBeInTheDocument()
+  })
+
+  it('hides contribution affordances for anonymous visitors', () => {
+    mockUseFestival.mockReturnValue({
+      data: makeFestival(),
+      isLoading: false,
+      error: null,
+    })
+    renderWithProviders(<FestivalDetail idOrSlug="form-arcosanti" />)
+    expect(screen.queryByTestId('bracket-Report')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('bracket-Edit')).not.toBeInTheDocument()
+  })
+
+  it('shows an Edit affordance for trusted contributors', () => {
+    mockUseIsAuthenticated.mockReturnValue({
+      user: { is_admin: false, user_tier: 'trusted_contributor' },
+      isAuthenticated: true,
+      isLoading: false,
+    })
+    mockUseFestival.mockReturnValue({
+      data: makeFestival(),
+      isLoading: false,
+      error: null,
+    })
+    renderWithProviders(<FestivalDetail idOrSlug="form-arcosanti" />)
+    expect(screen.getByTestId('bracket-Edit')).toBeInTheDocument()
+  })
+})

--- a/frontend/features/festivals/components/FestivalLineup.test.tsx
+++ b/frontend/features/festivals/components/FestivalLineup.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { FestivalLineup } from './FestivalLineup'
+import type { FestivalArtist } from '../types'
+
+function makeArtist(overrides: Partial<FestivalArtist> = {}): FestivalArtist {
+  return {
+    id: 1,
+    artist_id: 1,
+    artist_slug: 'artist-one',
+    artist_name: 'Artist One',
+    billing_tier: 'mid_card',
+    position: 1,
+    day_date: null,
+    stage: null,
+    set_time: null,
+    venue_id: null,
+    ...overrides,
+  }
+}
+
+describe('FestivalLineup', () => {
+  it('renders nothing when there are no artists', () => {
+    const { container } = render(<FestivalLineup artists={[]} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders artist names linking to artist pages', () => {
+    render(
+      <FestivalLineup
+        artists={[
+          makeArtist({ id: 1, artist_name: 'Headliner', artist_slug: 'headliner', billing_tier: 'headliner' }),
+        ]}
+      />
+    )
+    const link = screen.getByRole('link', { name: 'Headliner' })
+    expect(link).toHaveAttribute('href', '/artists/headliner')
+  })
+
+  it('renders artists without a slug as plain text (href #)', () => {
+    render(
+      <FestivalLineup
+        artists={[makeArtist({ artist_name: 'No Slug', artist_slug: '' })]}
+      />
+    )
+    const link = screen.getByText('No Slug').closest('a')
+    expect(link).toHaveAttribute('href', '#')
+  })
+
+  it('groups artists under their billing-tier headings in display order', () => {
+    render(
+      <FestivalLineup
+        artists={[
+          makeArtist({ id: 1, artist_name: 'Big', billing_tier: 'headliner' }),
+          makeArtist({ id: 2, artist_name: 'Small', billing_tier: 'undercard' }),
+        ]}
+      />
+    )
+    expect(screen.getByText('Headliner')).toBeInTheDocument()
+    expect(screen.getByText('Undercard')).toBeInTheDocument()
+    expect(screen.getByText('Big')).toBeInTheDocument()
+    expect(screen.getByText('Small')).toBeInTheDocument()
+  })
+
+  it('defaults a missing billing_tier to mid_card', () => {
+    render(
+      <FestivalLineup
+        artists={[makeArtist({ artist_name: 'Untiered', billing_tier: '' })]}
+      />
+    )
+    expect(screen.getByText('Mid Card')).toBeInTheDocument()
+    expect(screen.getByText('Untiered')).toBeInTheDocument()
+  })
+
+  describe('multiDay grouping', () => {
+    it('renders a day header per distinct day_date', () => {
+      render(
+        <FestivalLineup
+          multiDay
+          artists={[
+            makeArtist({ id: 1, artist_name: 'Day1 Act', day_date: '2025-05-09' }),
+            makeArtist({ id: 2, artist_name: 'Day2 Act', day_date: '2025-05-10' }),
+          ]}
+        />
+      )
+      // Friday May 9 / Saturday May 10, 2025 — assert on the weekday+month text.
+      expect(screen.getByText(/May 9/)).toBeInTheDocument()
+      expect(screen.getByText(/May 10/)).toBeInTheDocument()
+      expect(screen.getByText('Day1 Act')).toBeInTheDocument()
+      expect(screen.getByText('Day2 Act')).toBeInTheDocument()
+    })
+
+    it('buckets day-less artists under an Additional Artists heading', () => {
+      render(
+        <FestivalLineup
+          multiDay
+          artists={[
+            makeArtist({ id: 1, artist_name: 'Scheduled', day_date: '2025-05-09' }),
+            makeArtist({ id: 2, artist_name: 'Unscheduled', day_date: null }),
+          ]}
+        />
+      )
+      expect(screen.getByText('Additional Artists')).toBeInTheDocument()
+      expect(screen.getByText('Unscheduled')).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/features/festivals/components/FestivalList.test.tsx
+++ b/frontend/features/festivals/components/FestivalList.test.tsx
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { FestivalsListResponse } from '../types'
+
+// next/navigation
+const mockPush = vi.fn()
+const mockGet = vi.fn<(key: string) => string | null>()
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+  useSearchParams: () => ({ get: mockGet }),
+}))
+
+// Data hook
+const mockUseFestivals = vi.fn()
+vi.mock('../hooks/useFestivals', () => ({
+  useFestivals: (opts: unknown) => mockUseFestivals(opts),
+}))
+
+// Density preference
+vi.mock('@/lib/hooks/common/useDensity', () => ({
+  useDensity: () => ({ density: 'comfortable', setDensity: vi.fn() }),
+}))
+
+// Tag faceting (pulls in tag query infra otherwise)
+vi.mock('@/features/tags', () => ({
+  TagFacetPanel: () => <div data-testid="tag-facet-panel" />,
+  TagFacetSheet: () => <div data-testid="tag-facet-sheet" />,
+  parseTagsParam: (raw: string | null) =>
+    raw ? raw.split(',').filter(Boolean) : [],
+  buildTagsParam: (tags: string[]) => tags.join(','),
+}))
+
+import { FestivalList } from './FestivalList'
+
+function makeFestival(
+  id: number,
+  name: string
+): FestivalsListResponse['festivals'][number] {
+  return {
+    id,
+    name,
+    slug: `${name.toLowerCase().replace(/\s+/g, '-')}-2025`,
+    series_slug: name.toLowerCase().replace(/\s+/g, '-'),
+    edition_year: 2025,
+    city: 'Phoenix',
+    state: 'AZ',
+    start_date: '2025-05-09',
+    end_date: '2025-05-11',
+    status: 'confirmed',
+    artist_count: 5,
+    venue_count: 1,
+  }
+}
+
+describe('FestivalList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGet.mockReturnValue(null)
+  })
+
+  it('shows the loading spinner on the initial load', () => {
+    mockUseFestivals.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isFetching: true,
+      error: null,
+      refetch: vi.fn(),
+    })
+    const { container } = render(<FestivalList />)
+    expect(container.querySelector('.animate-spin')).toBeInTheDocument()
+  })
+
+  it('renders an error state with a retry button that refetches', async () => {
+    const refetch = vi.fn()
+    mockUseFestivals.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isFetching: false,
+      error: new Error('nope'),
+      refetch,
+    })
+    render(<FestivalList />)
+
+    expect(
+      screen.getByText('Failed to load festivals. Please try again later.')
+    ).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(refetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders the empty state when no festivals exist', () => {
+    mockUseFestivals.mockReturnValue({
+      data: { festivals: [], count: 0 },
+      isLoading: false,
+      isFetching: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+    render(<FestivalList />)
+    expect(
+      screen.getByText('No festivals available at this time.')
+    ).toBeInTheDocument()
+  })
+
+  it('renders festival cards and a count for a populated list', () => {
+    mockUseFestivals.mockReturnValue({
+      data: {
+        festivals: [makeFestival(1, 'FORM'), makeFestival(2, 'Desert Daze')],
+        count: 2,
+      },
+      isLoading: false,
+      isFetching: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+    render(<FestivalList />)
+
+    expect(screen.getByTestId('festival-count')).toHaveTextContent(
+      '2 festivals'
+    )
+    expect(screen.getByRole('link', { name: 'FORM' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: 'Desert Daze' })
+    ).toBeInTheDocument()
+  })
+
+  it('pushes a status filter to the URL when a status chip is clicked', async () => {
+    mockUseFestivals.mockReturnValue({
+      data: { festivals: [makeFestival(1, 'FORM')], count: 1 },
+      isLoading: false,
+      isFetching: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+    render(<FestivalList />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Confirmed' }))
+    expect(mockPush).toHaveBeenCalledWith('/festivals?status=confirmed', {
+      scroll: false,
+    })
+  })
+})

--- a/frontend/features/festivals/components/RisingArtists.test.tsx
+++ b/frontend/features/festivals/components/RisingArtists.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import type { FestivalBreakouts } from '../types'
+
+const mockUseBreakouts = vi.fn()
+vi.mock('../hooks/useFestivals', () => ({
+  useFestivalBreakouts: (opts: unknown) => mockUseBreakouts(opts),
+}))
+
+import { RisingArtists } from './RisingArtists'
+
+function makeBreakouts(overrides: Partial<FestivalBreakouts> = {}): FestivalBreakouts {
+  return {
+    breakouts: [
+      {
+        artist: { id: 1, name: 'Rising Star', slug: 'rising-star' },
+        current_tier: 'sub_headliner',
+        trajectory: [
+          { festival_name: 'SXSW', festival_slug: 'sxsw-2023', year: 2023, tier: 'opener' },
+          { festival_name: 'Pitchfork', festival_slug: 'pitchfork-2024', year: 2024, tier: 'mid_card' },
+        ],
+        tier_improvement: 2,
+        breakout_score: 0.8,
+      },
+    ],
+    milestones: [
+      {
+        artist: { id: 2, name: 'Debutant', slug: 'debutant' },
+        milestone: 'first_festival_appearance',
+        tier: 'local',
+        festival: 'FORM',
+      },
+    ],
+    ...overrides,
+  }
+}
+
+describe('RisingArtists', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows a loading spinner while fetching', () => {
+    mockUseBreakouts.mockReturnValue({ data: undefined, isLoading: true })
+    const { container } = render(<RisingArtists festivalIdOrSlug={1} />)
+    expect(container.querySelector('.animate-spin')).toBeInTheDocument()
+  })
+
+  it('renders nothing when there is no data', () => {
+    mockUseBreakouts.mockReturnValue({ data: null, isLoading: false })
+    const { container } = render(<RisingArtists festivalIdOrSlug={1} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing when both breakouts and milestones are empty', () => {
+    mockUseBreakouts.mockReturnValue({
+      data: { breakouts: [], milestones: [] },
+      isLoading: false,
+    })
+    const { container } = render(<RisingArtists festivalIdOrSlug={1} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders breakout artists with their trajectory and tier', () => {
+    mockUseBreakouts.mockReturnValue({ data: makeBreakouts(), isLoading: false })
+    render(<RisingArtists festivalIdOrSlug={1} />)
+
+    expect(screen.getByText('Rising Artists')).toBeInTheDocument()
+    const link = screen.getByRole('link', { name: 'Rising Star' })
+    expect(link).toHaveAttribute('href', '/artists/rising-star')
+    // current tier badge
+    expect(screen.getByText('Sub-Headliner')).toBeInTheDocument()
+    // trajectory festival names appear
+    expect(screen.getByText(/SXSW/)).toBeInTheDocument()
+    expect(screen.getByText(/Pitchfork/)).toBeInTheDocument()
+  })
+
+  it('renders the milestones section with the milestone label', () => {
+    mockUseBreakouts.mockReturnValue({ data: makeBreakouts(), isLoading: false })
+    render(<RisingArtists festivalIdOrSlug={1} />)
+
+    expect(screen.getByText('Milestones')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Debutant' })).toBeInTheDocument()
+    expect(screen.getByText('Festival Debut')).toBeInTheDocument()
+  })
+})

--- a/frontend/features/festivals/components/SeriesHistory.test.tsx
+++ b/frontend/features/festivals/components/SeriesHistory.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import type { SeriesComparison } from '../types'
+
+const mockUseSeries = vi.fn()
+vi.mock('../hooks/useFestivals', () => ({
+  useSeriesComparison: (opts: unknown) => mockUseSeries(opts),
+}))
+
+import { SeriesHistory } from './SeriesHistory'
+
+function makeComparison(
+  overrides: Partial<SeriesComparison> = {}
+): SeriesComparison {
+  return {
+    series_slug: 'form-arcosanti',
+    editions: [
+      { festival_id: 10, name: 'FORM 2023', slug: 'form-2023', year: 2023, artist_count: 30 },
+      { festival_id: 11, name: 'FORM 2024', slug: 'form-2024', year: 2024, artist_count: 40 },
+    ],
+    returning_artists: [
+      {
+        artist: { id: 1, name: 'Returner', slug: 'returner' },
+        years: [2023, 2024],
+        tiers: { '2023': 'undercard', '2024': 'mid_card' },
+      },
+    ],
+    newcomers: [
+      { artist: { id: 2, name: 'Newbie', slug: 'newbie' }, tier: 'local' },
+    ],
+    retention_rate: 0.5,
+    lineup_growth: 0.33,
+    ...overrides,
+  }
+}
+
+describe('SeriesHistory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders nothing when fewer than 2 editions exist', () => {
+    mockUseSeries.mockReturnValue({ data: undefined, isLoading: false })
+    const { container } = render(
+      <SeriesHistory seriesSlug="form-arcosanti" editions={[{ year: 2024 }]} />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('disables the hook until at least two years are present', () => {
+    mockUseSeries.mockReturnValue({ data: undefined, isLoading: false })
+    render(
+      <SeriesHistory
+        seriesSlug="form-arcosanti"
+        editions={[{ year: 2023 }, { year: 2024 }]}
+      />
+    )
+    expect(mockUseSeries).toHaveBeenCalledWith({
+      seriesSlug: 'form-arcosanti',
+      years: [2023, 2024],
+      enabled: true,
+    })
+  })
+
+  it('shows a loading spinner while fetching with enough years', () => {
+    mockUseSeries.mockReturnValue({ data: undefined, isLoading: true })
+    const { container } = render(
+      <SeriesHistory
+        seriesSlug="form-arcosanti"
+        editions={[{ year: 2023 }, { year: 2024 }]}
+      />
+    )
+    expect(container.querySelector('.animate-spin')).toBeInTheDocument()
+  })
+
+  it('renders nothing when the comparison data is absent', () => {
+    mockUseSeries.mockReturnValue({ data: null, isLoading: false })
+    const { container } = render(
+      <SeriesHistory
+        seriesSlug="form-arcosanti"
+        editions={[{ year: 2023 }, { year: 2024 }]}
+      />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders editions, metrics, returning artists, and newcomers', () => {
+    mockUseSeries.mockReturnValue({ data: makeComparison(), isLoading: false })
+    render(
+      <SeriesHistory
+        seriesSlug="form-arcosanti"
+        editions={[{ year: 2023 }, { year: 2024 }]}
+      />
+    )
+
+    // Edition links
+    const editionLink = screen.getByRole('link', { name: /2023/ })
+    expect(editionLink).toHaveAttribute('href', '/festivals/form-2023')
+
+    // Metrics formatting
+    expect(screen.getByText('50%')).toBeInTheDocument()
+    expect(screen.getByText('+33%')).toBeInTheDocument()
+
+    // Returning artists header reflects the count and lists the artist
+    expect(screen.getByText('Returning Artists (1)')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Returner' })).toBeInTheDocument()
+
+    // Newcomers header uses the latest year, and lists the newcomer
+    expect(screen.getByText('2024 Newcomers (1)')).toBeInTheDocument()
+    expect(screen.getByText('Newbie')).toBeInTheDocument()
+  })
+
+  it('prefixes negative lineup growth with no plus sign', () => {
+    mockUseSeries.mockReturnValue({
+      data: makeComparison({ lineup_growth: -0.2 }),
+      isLoading: false,
+    })
+    render(
+      <SeriesHistory
+        seriesSlug="form-arcosanti"
+        editions={[{ year: 2023 }, { year: 2024 }]}
+      />
+    )
+    expect(screen.getByText('-20%')).toBeInTheDocument()
+  })
+})

--- a/frontend/features/festivals/components/SimilarFestivals.test.tsx
+++ b/frontend/features/festivals/components/SimilarFestivals.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import type { SimilarFestivalsResponse } from '../types'
+
+const mockUseSimilar = vi.fn()
+vi.mock('../hooks/useFestivals', () => ({
+  useSimilarFestivals: (opts: unknown) => mockUseSimilar(opts),
+}))
+
+import { SimilarFestivals } from './SimilarFestivals'
+
+function makeSimilar(
+  overrides: Partial<SimilarFestivalsResponse> = {}
+): SimilarFestivalsResponse {
+  return {
+    similar: [
+      {
+        festival: {
+          id: 2,
+          name: 'Desert Daze',
+          slug: 'desert-daze-2025',
+          series_slug: 'desert-daze',
+          edition_year: 2025,
+          city: 'Lake Perris',
+          state: 'CA',
+        },
+        shared_artist_count: 4,
+        jaccard: 0.123,
+        weighted_score: 0.5,
+        top_shared: [
+          {
+            artist_id: 7,
+            name: 'Shared Act',
+            slug: 'shared-act',
+            tier_at_source: 'mid_card',
+            tier_at_target: 'headliner',
+          },
+        ],
+      },
+    ],
+    ...overrides,
+  }
+}
+
+describe('SimilarFestivals', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('requests a limit of 5 from the hook', () => {
+    mockUseSimilar.mockReturnValue({ data: undefined, isLoading: true })
+    render(<SimilarFestivals festivalIdOrSlug={1} />)
+    expect(mockUseSimilar).toHaveBeenCalledWith({
+      festivalIdOrSlug: 1,
+      limit: 5,
+      enabled: true,
+    })
+  })
+
+  it('shows a loading spinner while fetching', () => {
+    mockUseSimilar.mockReturnValue({ data: undefined, isLoading: true })
+    const { container } = render(<SimilarFestivals festivalIdOrSlug={1} />)
+    expect(container.querySelector('.animate-spin')).toBeInTheDocument()
+  })
+
+  it('renders nothing when there are no similar festivals', () => {
+    mockUseSimilar.mockReturnValue({
+      data: { similar: [] },
+      isLoading: false,
+    })
+    const { container } = render(<SimilarFestivals festivalIdOrSlug={1} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders similar festivals with overlap stats and shared artists', () => {
+    mockUseSimilar.mockReturnValue({ data: makeSimilar(), isLoading: false })
+    render(<SimilarFestivals festivalIdOrSlug={1} />)
+
+    expect(screen.getByText('Similar Festivals')).toBeInTheDocument()
+    const festivalLink = screen.getByRole('link', { name: 'Desert Daze' })
+    expect(festivalLink).toHaveAttribute('href', '/festivals/desert-daze-2025')
+    expect(screen.getByText('4 shared')).toBeInTheDocument()
+    expect(screen.getByText('12.3% overlap')).toBeInTheDocument()
+    // shared artist badge links to the artist with the target-tier label
+    expect(screen.getByText('Shared Act')).toBeInTheDocument()
+    expect(screen.getByText('Headliner')).toBeInTheDocument()
+  })
+})

--- a/frontend/features/festivals/components/index.test.ts
+++ b/frontend/features/festivals/components/index.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest'
+import * as components from './index'
+
+// components/index.ts is the barrel that also exposes the FestivalDetail
+// component (kept out of the root module barrel to avoid colliding with the
+// FestivalDetail type). Assert every component re-export resolves.
+describe('festivals components barrel', () => {
+  it('re-exports every festival component', () => {
+    expect(typeof components.FestivalCard).toBe('function')
+    expect(typeof components.FestivalDetail).toBe('function')
+    expect(typeof components.FestivalLineup).toBe('function')
+    expect(typeof components.FestivalList).toBe('function')
+    expect(typeof components.SimilarFestivals).toBe('function')
+    expect(typeof components.RisingArtists).toBe('function')
+    expect(typeof components.ArtistTrajectoryChart).toBe('function')
+    expect(typeof components.SeriesHistory).toBe('function')
+  })
+})

--- a/frontend/features/festivals/hooks/index.test.ts
+++ b/frontend/features/festivals/hooks/index.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import * as hooks from './index'
+
+// The hooks barrel re-exports both the read hooks (useFestivals.ts) and the
+// admin mutation hooks (useAdminFestivals.ts). Assert both groups resolve.
+describe('festivals hooks barrel', () => {
+  it('re-exports the read hooks', () => {
+    expect(typeof hooks.useFestivals).toBe('function')
+    expect(typeof hooks.useFestival).toBe('function')
+    expect(typeof hooks.useFestivalArtists).toBe('function')
+    expect(typeof hooks.useFestivalLineup).toBe('function')
+    expect(typeof hooks.useFestivalVenues).toBe('function')
+    expect(typeof hooks.useArtistFestivals).toBe('function')
+    expect(typeof hooks.useSimilarFestivals).toBe('function')
+    expect(typeof hooks.useFestivalBreakouts).toBe('function')
+    expect(typeof hooks.useArtistFestivalTrajectory).toBe('function')
+    expect(typeof hooks.useSeriesComparison).toBe('function')
+  })
+
+  it('re-exports the admin mutation hooks', () => {
+    expect(typeof hooks.useCreateFestival).toBe('function')
+    expect(typeof hooks.useUpdateFestival).toBe('function')
+    expect(typeof hooks.useDeleteFestival).toBe('function')
+    expect(typeof hooks.useAddFestivalArtist).toBe('function')
+    expect(typeof hooks.useUpdateFestivalArtist).toBe('function')
+    expect(typeof hooks.useRemoveFestivalArtist).toBe('function')
+    expect(typeof hooks.useAddFestivalVenue).toBe('function')
+    expect(typeof hooks.useRemoveFestivalVenue).toBe('function')
+  })
+})

--- a/frontend/features/festivals/hooks/useAdminFestivals.test.tsx
+++ b/frontend/features/festivals/hooks/useAdminFestivals.test.tsx
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient } from '@tanstack/react-query'
+import { createWrapperWithClient } from '@/test/utils'
+
+const mockApiRequest = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+}))
+
+// The endpoint builders embed API_BASE_URL; pin it so the assertions below
+// match the exact URLs the hooks pass to apiRequest.
+const BASE = 'http://localhost:8080'
+
+import {
+  useCreateFestival,
+  useUpdateFestival,
+  useDeleteFestival,
+  useAddFestivalArtist,
+  useUpdateFestivalArtist,
+  useRemoveFestivalArtist,
+  useAddFestivalVenue,
+  useRemoveFestivalVenue,
+} from './useAdminFestivals'
+
+let queryClient: QueryClient
+let invalidateSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockApiRequest.mockReset()
+  queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+  })
+  invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+})
+
+function wrapper() {
+  return createWrapperWithClient(queryClient)
+}
+
+describe('useCreateFestival', () => {
+  it('POSTs to the create endpoint and invalidates the festivals key', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 1, name: 'M3F' })
+
+    const { result } = renderHook(() => useCreateFestival(), {
+      wrapper: wrapper(),
+    })
+
+    result.current.mutate({
+      name: 'M3F',
+      series_slug: 'm3f',
+      edition_year: 2026,
+      start_date: '2026-03-06',
+      end_date: '2026-03-08',
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(`${BASE}/festivals`, {
+      method: 'POST',
+      body: JSON.stringify({
+        name: 'M3F',
+        series_slug: 'm3f',
+        edition_year: 2026,
+        start_date: '2026-03-06',
+        end_date: '2026-03-08',
+      }),
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['festivals'] })
+  })
+
+  it('surfaces the error and does not invalidate when the request fails', async () => {
+    mockApiRequest.mockRejectedValueOnce(new Error('boom'))
+
+    const { result } = renderHook(() => useCreateFestival(), {
+      wrapper: wrapper(),
+    })
+
+    result.current.mutate({
+      name: 'M3F',
+      series_slug: 'm3f',
+      edition_year: 2026,
+      start_date: '2026-03-06',
+      end_date: '2026-03-08',
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error).toEqual(new Error('boom'))
+    expect(invalidateSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('useUpdateFestival', () => {
+  it('PUTs to the festival endpoint and invalidates on success', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 42, name: 'Renamed' })
+
+    const { result } = renderHook(() => useUpdateFestival(), {
+      wrapper: wrapper(),
+    })
+
+    result.current.mutate({ festivalId: 42, data: { name: 'Renamed' } })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(`${BASE}/festivals/42`, {
+      method: 'PUT',
+      body: JSON.stringify({ name: 'Renamed' }),
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['festivals'] })
+  })
+})
+
+describe('useDeleteFestival', () => {
+  it('DELETEs the festival endpoint and invalidates on success', async () => {
+    mockApiRequest.mockResolvedValueOnce(undefined)
+
+    const { result } = renderHook(() => useDeleteFestival(), {
+      wrapper: wrapper(),
+    })
+
+    result.current.mutate(42)
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(`${BASE}/festivals/42`, {
+      method: 'DELETE',
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['festivals'] })
+  })
+})
+
+describe('useAddFestivalArtist', () => {
+  it('POSTs to the lineup endpoint and invalidates on success', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 1, artist_id: 7 })
+
+    const { result } = renderHook(() => useAddFestivalArtist(), {
+      wrapper: wrapper(),
+    })
+
+    result.current.mutate({
+      festivalId: 1,
+      data: { artist_id: 7, billing_tier: 'headliner' },
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(`${BASE}/festivals/1/artists`, {
+      method: 'POST',
+      body: JSON.stringify({ artist_id: 7, billing_tier: 'headliner' }),
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['festivals'] })
+  })
+})
+
+describe('useUpdateFestivalArtist', () => {
+  it('PUTs to the lineup-entry endpoint and invalidates on success', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 1, artist_id: 7 })
+
+    const { result } = renderHook(() => useUpdateFestivalArtist(), {
+      wrapper: wrapper(),
+    })
+
+    result.current.mutate({
+      festivalId: 1,
+      artistId: 7,
+      data: { position: 3 },
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      `${BASE}/festivals/1/artists/7`,
+      { method: 'PUT', body: JSON.stringify({ position: 3 }) }
+    )
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['festivals'] })
+  })
+})
+
+describe('useRemoveFestivalArtist', () => {
+  it('DELETEs the lineup-entry endpoint and invalidates on success', async () => {
+    mockApiRequest.mockResolvedValueOnce(undefined)
+
+    const { result } = renderHook(() => useRemoveFestivalArtist(), {
+      wrapper: wrapper(),
+    })
+
+    result.current.mutate({ festivalId: 1, artistId: 7 })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      `${BASE}/festivals/1/artists/7`,
+      { method: 'DELETE' }
+    )
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['festivals'] })
+  })
+})
+
+describe('useAddFestivalVenue', () => {
+  it('POSTs to the venue endpoint and invalidates on success', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 1, venue_id: 9 })
+
+    const { result } = renderHook(() => useAddFestivalVenue(), {
+      wrapper: wrapper(),
+    })
+
+    result.current.mutate({
+      festivalId: 1,
+      data: { venue_id: 9, is_primary: true },
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(`${BASE}/festivals/1/venues`, {
+      method: 'POST',
+      body: JSON.stringify({ venue_id: 9, is_primary: true }),
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['festivals'] })
+  })
+})
+
+describe('useRemoveFestivalVenue', () => {
+  it('DELETEs the venue endpoint and invalidates on success', async () => {
+    mockApiRequest.mockResolvedValueOnce(undefined)
+
+    const { result } = renderHook(() => useRemoveFestivalVenue(), {
+      wrapper: wrapper(),
+    })
+
+    result.current.mutate({ festivalId: 1, venueId: 9 })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      `${BASE}/festivals/1/venues/9`,
+      { method: 'DELETE' }
+    )
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['festivals'] })
+  })
+})

--- a/frontend/features/festivals/index.test.ts
+++ b/frontend/features/festivals/index.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import * as festivals from './index'
+
+// The module barrel is the only entry point other features import from, so a
+// missing/renamed re-export is a real breakage. Assert the public surface.
+describe('festivals public API barrel', () => {
+  it('re-exports the API config', () => {
+    expect(festivals.festivalEndpoints).toBeDefined()
+    expect(festivals.festivalQueryKeys).toBeDefined()
+  })
+
+  it('re-exports the type helper functions and constants', () => {
+    expect(typeof festivals.getFestivalStatusVariant).toBe('function')
+    expect(typeof festivals.getFestivalStatusLabel).toBe('function')
+    expect(typeof festivals.getBillingTierLabel).toBe('function')
+    expect(typeof festivals.formatFestivalLocation).toBe('function')
+    expect(typeof festivals.formatFestivalDateRange).toBe('function')
+    expect(typeof festivals.formatFestivalDates).toBe('function')
+    expect(typeof festivals.getTierBarWidth).toBe('function')
+    expect(typeof festivals.getMilestoneLabel).toBe('function')
+    expect(Array.isArray(festivals.FESTIVAL_STATUSES)).toBe(true)
+    expect(Array.isArray(festivals.BILLING_TIERS)).toBe(true)
+    expect(festivals.BILLING_TIER_ORDER).toBe(festivals.BILLING_TIERS)
+  })
+
+  it('re-exports the read hooks', () => {
+    expect(typeof festivals.useFestivals).toBe('function')
+    expect(typeof festivals.useFestival).toBe('function')
+    expect(typeof festivals.useFestivalArtists).toBe('function')
+    expect(typeof festivals.useFestivalLineup).toBe('function')
+    expect(typeof festivals.useFestivalVenues).toBe('function')
+    expect(typeof festivals.useArtistFestivals).toBe('function')
+    expect(typeof festivals.useSimilarFestivals).toBe('function')
+    expect(typeof festivals.useFestivalBreakouts).toBe('function')
+    expect(typeof festivals.useArtistFestivalTrajectory).toBe('function')
+    expect(typeof festivals.useSeriesComparison).toBe('function')
+  })
+
+  it('re-exports the public components', () => {
+    expect(typeof festivals.FestivalCard).toBe('function')
+    expect(typeof festivals.FestivalLineup).toBe('function')
+    expect(typeof festivals.FestivalList).toBe('function')
+  })
+})

--- a/frontend/features/festivals/types.test.ts
+++ b/frontend/features/festivals/types.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest'
+import {
+  FESTIVAL_STATUSES,
+  FESTIVAL_STATUS_LABELS,
+  BILLING_TIERS,
+  BILLING_TIER_ORDER,
+  BILLING_TIER_LABELS,
+  getFestivalStatusVariant,
+  getFestivalStatusLabel,
+  getBillingTierLabel,
+  formatFestivalLocation,
+  formatFestivalDateRange,
+  formatFestivalDates,
+  getTierBarWidth,
+  getMilestoneLabel,
+} from './types'
+
+describe('status constants', () => {
+  it('keeps a label for every status in the filter list', () => {
+    for (const status of FESTIVAL_STATUSES) {
+      expect(FESTIVAL_STATUS_LABELS[status]).toBeTruthy()
+    }
+  })
+})
+
+describe('getFestivalStatusVariant', () => {
+  it('maps known statuses to badge variants', () => {
+    expect(getFestivalStatusVariant('confirmed')).toBe('default')
+    expect(getFestivalStatusVariant('announced')).toBe('secondary')
+    expect(getFestivalStatusVariant('cancelled')).toBe('destructive')
+    expect(getFestivalStatusVariant('completed')).toBe('outline')
+  })
+
+  it('falls back to secondary for unknown statuses', () => {
+    expect(getFestivalStatusVariant('something-else')).toBe('secondary')
+  })
+})
+
+describe('getFestivalStatusLabel', () => {
+  it('returns the curated label for known statuses', () => {
+    expect(getFestivalStatusLabel('announced')).toBe('Announced')
+    expect(getFestivalStatusLabel('completed')).toBe('Completed')
+  })
+
+  it('capitalizes the first letter for unknown statuses', () => {
+    expect(getFestivalStatusLabel('postponed')).toBe('Postponed')
+  })
+})
+
+describe('billing tier constants', () => {
+  it('keeps a label for every billing tier', () => {
+    for (const tier of BILLING_TIERS) {
+      expect(BILLING_TIER_LABELS[tier]).toBeTruthy()
+    }
+  })
+
+  it('aliases BILLING_TIER_ORDER to BILLING_TIERS', () => {
+    expect(BILLING_TIER_ORDER).toBe(BILLING_TIERS)
+  })
+})
+
+describe('getBillingTierLabel', () => {
+  it('returns the curated label for known tiers', () => {
+    expect(getBillingTierLabel('headliner')).toBe('Headliner')
+    expect(getBillingTierLabel('sub_headliner')).toBe('Sub-Headliner')
+    expect(getBillingTierLabel('dj')).toBe('DJ')
+  })
+
+  it('title-cases snake_case for unknown tiers', () => {
+    expect(getBillingTierLabel('special_guest')).toBe('Special Guest')
+  })
+})
+
+describe('formatFestivalLocation', () => {
+  it('returns null when nothing is set', () => {
+    expect(
+      formatFestivalLocation({ location_name: null, city: null, state: null })
+    ).toBeNull()
+  })
+
+  it('combines city and state', () => {
+    expect(
+      formatFestivalLocation({ city: 'Phoenix', state: 'AZ' })
+    ).toBe('Phoenix, AZ')
+  })
+
+  it('uses city alone when state is missing', () => {
+    expect(formatFestivalLocation({ city: 'Phoenix', state: null })).toBe(
+      'Phoenix'
+    )
+  })
+
+  it('uses state alone when city is missing', () => {
+    expect(formatFestivalLocation({ city: null, state: 'AZ' })).toBe('AZ')
+  })
+
+  it('prepends a venue/location name with an em-dash separator', () => {
+    expect(
+      formatFestivalLocation({
+        location_name: 'Hance Park',
+        city: 'Phoenix',
+        state: 'AZ',
+      })
+    ).toBe('Hance Park — Phoenix, AZ')
+  })
+})
+
+describe('formatFestivalDateRange', () => {
+  it('renders a single date when start equals end', () => {
+    expect(formatFestivalDateRange('2025-05-09', '2025-05-09')).toBe(
+      'May 9, 2025'
+    )
+  })
+
+  it('collapses the month when start and end share one', () => {
+    expect(formatFestivalDateRange('2025-05-09', '2025-05-11')).toBe(
+      'May 9–11, 2025'
+    )
+  })
+
+  it('spells out both months when they differ', () => {
+    expect(formatFestivalDateRange('2025-05-30', '2025-06-01')).toBe(
+      'May 30 – Jun 1, 2025'
+    )
+  })
+
+  it('is aliased by formatFestivalDates', () => {
+    expect(formatFestivalDates).toBe(formatFestivalDateRange)
+  })
+})
+
+describe('getTierBarWidth', () => {
+  it('returns a descending width per known tier', () => {
+    expect(getTierBarWidth('headliner')).toBe(100)
+    expect(getTierBarWidth('sub_headliner')).toBe(80)
+    expect(getTierBarWidth('mid_card')).toBe(60)
+    expect(getTierBarWidth('undercard')).toBe(40)
+    expect(getTierBarWidth('local')).toBe(25)
+    expect(getTierBarWidth('dj')).toBe(25)
+    expect(getTierBarWidth('host')).toBe(15)
+  })
+
+  it('falls back to 30 for unknown tiers', () => {
+    expect(getTierBarWidth('mystery')).toBe(30)
+  })
+})
+
+describe('getMilestoneLabel', () => {
+  it('returns curated labels for known milestones', () => {
+    expect(getMilestoneLabel('first_festival_appearance')).toBe(
+      'Festival Debut'
+    )
+    expect(getMilestoneLabel('first_headliner')).toBe('First Headliner')
+    expect(getMilestoneLabel('local_graduation')).toBe('Graduated from Local')
+  })
+
+  it('title-cases snake_case for unknown milestones', () => {
+    expect(getMilestoneLabel('first_sub_headliner')).toBe(
+      'First Sub Headliner'
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- Backfill sibling tests for every previously untested file in `frontend/features/festivals/` (Phase 2c shipped festival intelligence with minimal FE coverage).
- Coverage added: `api.ts` (endpoint URLs + query keys), `types.ts` (label/variant helpers, location/date formatters, tier-bar widths, milestone labels), `hooks/useAdminFestivals.ts` (every mutation's endpoint/method/body + cache invalidation, plus error path), all 7 components (`FestivalCard`, `FestivalList`, `FestivalLineup`, `FestivalDetail`, `RisingArtists`, `SeriesHistory`, `SimilarFestivals`) for render/key-text/links/loading/empty states, `admin/FestivalManagement.tsx` (list/loading/error/empty, client-side search filter, create/delete dialogs, lineup/venue panel nav), and the index barrels.
- 128 tests across 17 files in the module (113 new + 15 pre-existing).

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run test:run features/festivals` — 128/128 passing

## Manual repro
Test-only diff; no runtime behavior change. Passing suite IS the verification.

## Simplify
Ran `/simplify` (reuse / quality / efficiency review). No changes needed — comments are WHY-only, no ticket refs in test bodies, type-specific `make*` builders follow the established per-suite convention, mocks reset per test for isolation.

Closes PSY-686