### PR TITLE
PSY-685: test coverage for features/radio module

### DIFF
--- a/frontend/features/radio/api.test.ts
+++ b/frontend/features/radio/api.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest'
+import { radioEndpoints, radioQueryKeys } from './api'
+
+// API_BASE_URL resolves to 'http://localhost:8080' under vitest
+// (NEXT_PUBLIC_API_URL set in vitest.config.mts), so endpoint strings
+// below are asserted against that fully-resolved base.
+const BASE = 'http://localhost:8080'
+
+describe('radioEndpoints', () => {
+  it('STATIONS is the collection URL', () => {
+    expect(radioEndpoints.STATIONS).toBe(`${BASE}/radio-stations`)
+  })
+
+  it('STATION(slug) appends the slug', () => {
+    expect(radioEndpoints.STATION('kexp')).toBe(`${BASE}/radio-stations/kexp`)
+  })
+
+  it('SHOWS is the collection URL', () => {
+    expect(radioEndpoints.SHOWS).toBe(`${BASE}/radio-shows`)
+  })
+
+  it('SHOW(slug) appends the slug', () => {
+    expect(radioEndpoints.SHOW('wfmu-drummer')).toBe(`${BASE}/radio-shows/wfmu-drummer`)
+  })
+
+  it('SHOW_EPISODES(slug) nests under the show', () => {
+    expect(radioEndpoints.SHOW_EPISODES('wfmu-drummer')).toBe(
+      `${BASE}/radio-shows/wfmu-drummer/episodes`
+    )
+  })
+
+  it('SHOW_EPISODE_BY_DATE(slug, date) nests the date segment', () => {
+    expect(radioEndpoints.SHOW_EPISODE_BY_DATE('wfmu-drummer', '2026-05-01')).toBe(
+      `${BASE}/radio-shows/wfmu-drummer/episodes/2026-05-01`
+    )
+  })
+
+  it('SHOW_TOP_ARTISTS(slug) nests under the show', () => {
+    expect(radioEndpoints.SHOW_TOP_ARTISTS('wfmu-drummer')).toBe(
+      `${BASE}/radio-shows/wfmu-drummer/top-artists`
+    )
+  })
+
+  it('SHOW_TOP_LABELS(slug) nests under the show', () => {
+    expect(radioEndpoints.SHOW_TOP_LABELS('wfmu-drummer')).toBe(
+      `${BASE}/radio-shows/wfmu-drummer/top-labels`
+    )
+  })
+
+  it('ARTIST_RADIO_PLAYS(slug) nests under the artist', () => {
+    expect(radioEndpoints.ARTIST_RADIO_PLAYS('gatecreeper')).toBe(
+      `${BASE}/artists/gatecreeper/radio-plays`
+    )
+  })
+
+  it('RELEASE_RADIO_PLAYS(slug) nests under the release', () => {
+    expect(radioEndpoints.RELEASE_RADIO_PLAYS('an-unkindness')).toBe(
+      `${BASE}/releases/an-unkindness/radio-plays`
+    )
+  })
+
+  it('NEW_RELEASES is the aggregation URL', () => {
+    expect(radioEndpoints.NEW_RELEASES).toBe(`${BASE}/radio/new-releases`)
+  })
+
+  it('STATS is the aggregation URL', () => {
+    expect(radioEndpoints.STATS).toBe(`${BASE}/radio/stats`)
+  })
+})
+
+describe('radioQueryKeys', () => {
+  it('stations() is a stable single-segment key', () => {
+    expect(radioQueryKeys.stations()).toEqual(['radio-stations'])
+  })
+
+  it('station(slug) scopes by slug', () => {
+    expect(radioQueryKeys.station('kexp')).toEqual(['radio-stations', 'kexp'])
+  })
+
+  it('shows(stationId) wraps the id in a params object', () => {
+    expect(radioQueryKeys.shows(7)).toEqual(['radio-shows', { stationId: 7 }])
+  })
+
+  it('shows() with no id still carries an undefined stationId for cache stability', () => {
+    expect(radioQueryKeys.shows()).toEqual(['radio-shows', { stationId: undefined }])
+  })
+
+  it('show(slug) scopes by slug', () => {
+    expect(radioQueryKeys.show('drummer')).toEqual(['radio-shows', 'drummer'])
+  })
+
+  it('episodes(slug, params) carries the params object', () => {
+    expect(radioQueryKeys.episodes('drummer', { limit: 20, offset: 0 })).toEqual([
+      'radio-shows',
+      'drummer',
+      'episodes',
+      { limit: 20, offset: 0 },
+    ])
+  })
+
+  it('episode(slug, date) scopes by show + date', () => {
+    expect(radioQueryKeys.episode('drummer', '2026-05-01')).toEqual([
+      'radio-shows',
+      'drummer',
+      'episodes',
+      '2026-05-01',
+    ])
+  })
+
+  it('topArtists(slug, params) carries the params object', () => {
+    expect(radioQueryKeys.topArtists('drummer', { period: 90, limit: 20 })).toEqual([
+      'radio-shows',
+      'drummer',
+      'top-artists',
+      { period: 90, limit: 20 },
+    ])
+  })
+
+  it('topLabels(slug, params) carries the params object', () => {
+    expect(radioQueryKeys.topLabels('drummer', { period: 90, limit: 20 })).toEqual([
+      'radio-shows',
+      'drummer',
+      'top-labels',
+      { period: 90, limit: 20 },
+    ])
+  })
+
+  it('artistPlays(slug) scopes under the artist namespace', () => {
+    expect(radioQueryKeys.artistPlays('gatecreeper')).toEqual([
+      'artists',
+      'gatecreeper',
+      'radio-plays',
+    ])
+  })
+
+  it('releasePlays(slug) scopes under the release namespace', () => {
+    expect(radioQueryKeys.releasePlays('an-unkindness')).toEqual([
+      'releases',
+      'an-unkindness',
+      'radio-plays',
+    ])
+  })
+
+  it('newReleases(params) carries the params object', () => {
+    expect(radioQueryKeys.newReleases({ stationId: 7, limit: 20 })).toEqual([
+      'radio',
+      'new-releases',
+      { stationId: 7, limit: 20 },
+    ])
+  })
+
+  it('stats() is a stable two-segment key', () => {
+    expect(radioQueryKeys.stats()).toEqual(['radio', 'stats'])
+  })
+})

--- a/frontend/features/radio/components/AsHeardOn.test.tsx
+++ b/frontend/features/radio/components/AsHeardOn.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import type { RadioAsHeardOnResponse } from '../types'
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode; [key: string]: unknown }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}))
+
+// AsHeardOn always calls both hooks (gated by `enabled`), then selects one by
+// entityType. Mock both so each branch is independently controllable.
+const mockUseArtistRadioPlays = vi.fn()
+const mockUseReleaseRadioPlays = vi.fn()
+vi.mock('../hooks/useArtistRadioPlays', () => ({
+  useArtistRadioPlays: (...args: unknown[]) => mockUseArtistRadioPlays(...args),
+}))
+vi.mock('../hooks/useReleaseRadioPlays', () => ({
+  useReleaseRadioPlays: (...args: unknown[]) => mockUseReleaseRadioPlays(...args),
+}))
+
+import { AsHeardOn } from './AsHeardOn'
+
+function response(): RadioAsHeardOnResponse {
+  return {
+    stations: [
+      {
+        station_id: 1,
+        station_name: 'KEXP',
+        station_slug: 'kexp',
+        show_id: 10,
+        show_name: 'Morning Show',
+        show_slug: 'morning-show',
+        play_count: 3,
+        last_played: '2026-05-01T00:00:00Z',
+      },
+    ],
+    count: 1,
+  }
+}
+
+const empty = () => ({ data: { stations: [], count: 0 }, isLoading: false })
+const loading = () => ({ data: undefined, isLoading: true })
+
+describe('AsHeardOn', () => {
+  beforeEach(() => {
+    mockUseArtistRadioPlays.mockReset()
+    mockUseReleaseRadioPlays.mockReset()
+    mockUseArtistRadioPlays.mockReturnValue(empty())
+    mockUseReleaseRadioPlays.mockReturnValue(empty())
+  })
+
+  it('renders the As Heard On header and show link for an artist', () => {
+    mockUseArtistRadioPlays.mockReturnValue({ data: response(), isLoading: false })
+    render(<AsHeardOn entityType="artist" entitySlug="gatecreeper" />)
+
+    expect(screen.getByText('As Heard On')).toBeInTheDocument()
+    const link = screen.getByText('Morning Show').closest('a')
+    expect(link).toHaveAttribute('href', '/radio/kexp/morning-show')
+  })
+
+  it('renders the station name and pluralized play count', () => {
+    mockUseArtistRadioPlays.mockReturnValue({ data: response(), isLoading: false })
+    render(<AsHeardOn entityType="artist" entitySlug="gatecreeper" />)
+    expect(screen.getByText(/KEXP - 3 plays/)).toBeInTheDocument()
+  })
+
+  it('singularizes a single play', () => {
+    const data = response()
+    data.stations[0].play_count = 1
+    mockUseArtistRadioPlays.mockReturnValue({ data, isLoading: false })
+    render(<AsHeardOn entityType="artist" entitySlug="gatecreeper" />)
+    expect(screen.getByText(/KEXP - 1 play$/)).toBeInTheDocument()
+  })
+
+  it('selects the release query when entityType is release', () => {
+    mockUseReleaseRadioPlays.mockReturnValue({ data: response(), isLoading: false })
+    render(<AsHeardOn entityType="release" entitySlug="an-unkindness" />)
+    expect(screen.getByText('As Heard On')).toBeInTheDocument()
+    expect(screen.getByText('Morning Show')).toBeInTheDocument()
+  })
+
+  it('renders nothing while the active query is loading', () => {
+    mockUseArtistRadioPlays.mockReturnValue(loading())
+    const { container } = render(
+      <AsHeardOn entityType="artist" entitySlug="gatecreeper" />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing when there are no plays', () => {
+    mockUseArtistRadioPlays.mockReturnValue(empty())
+    const { container } = render(
+      <AsHeardOn entityType="artist" entitySlug="gatecreeper" />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('gates the artist hook on entityType and enabled', () => {
+    mockUseArtistRadioPlays.mockReturnValue(empty())
+    render(<AsHeardOn entityType="artist" entitySlug="gatecreeper" enabled={false} />)
+    // enabled passed through as `enabled && entityType === 'artist'`.
+    expect(mockUseArtistRadioPlays).toHaveBeenCalledWith('gatecreeper', false)
+    expect(mockUseReleaseRadioPlays).toHaveBeenCalledWith('gatecreeper', false)
+  })
+
+  it('enables only the matching hook for the entity type', () => {
+    mockUseReleaseRadioPlays.mockReturnValue(empty())
+    render(<AsHeardOn entityType="release" entitySlug="an-unkindness" />)
+    expect(mockUseArtistRadioPlays).toHaveBeenCalledWith('an-unkindness', false)
+    expect(mockUseReleaseRadioPlays).toHaveBeenCalledWith('an-unkindness', true)
+  })
+})

--- a/frontend/features/radio/components/NetworkTabBar.test.tsx
+++ b/frontend/features/radio/components/NetworkTabBar.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import { NetworkTabBar } from './NetworkTabBar'
+import type { RadioStationDetail, RadioSiblingStation } from '../types'
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode; [key: string]: unknown }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}))
+
+function makeSibling(overrides: Partial<RadioSiblingStation> = {}): RadioSiblingStation {
+  return {
+    id: 2,
+    slug: 'wfmu-drummer',
+    name: 'Drummer',
+    broadcast_type: 'internet',
+    frequency_mhz: null,
+    is_flagship: false,
+    ...overrides,
+  }
+}
+
+function makeStation(overrides: Partial<RadioStationDetail> = {}): RadioStationDetail {
+  return {
+    id: 1,
+    name: 'WFMU',
+    slug: 'wfmu',
+    description: null,
+    city: 'Jersey City',
+    state: 'NJ',
+    country: 'USA',
+    timezone: 'America/New_York',
+    stream_url: null,
+    stream_urls: null,
+    website: null,
+    donation_url: null,
+    donation_embed_url: null,
+    logo_url: null,
+    social: null,
+    broadcast_type: 'both',
+    frequency_mhz: 91.1,
+    playlist_source: null,
+    playlist_config: null,
+    last_playlist_fetch_at: null,
+    is_active: true,
+    network: { slug: 'wfmu', name: 'WFMU', is_flagship: true },
+    sibling_stations: [makeSibling()],
+    show_count: 5,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('NetworkTabBar', () => {
+  it('renders nothing for a network-less station', () => {
+    const { container } = render(
+      <NetworkTabBar currentStation={makeStation({ network: null })} />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing when the network has only the flagship (single tab)', () => {
+    const station = makeStation({ sibling_stations: [] })
+    const { container } = render(<NetworkTabBar currentStation={station} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders a labelled nav for a multi-station network', () => {
+    render(<NetworkTabBar currentStation={makeStation()} />)
+    expect(
+      screen.getByRole('navigation', { name: 'WFMU network channels' })
+    ).toBeInTheDocument()
+  })
+
+  it('renders one tab per station (current + siblings)', () => {
+    const station = makeStation({
+      sibling_stations: [
+        makeSibling({ id: 2, slug: 'wfmu-drummer', name: 'Drummer' }),
+        makeSibling({ id: 3, slug: 'wfmu-sheena', name: 'Sheena' }),
+      ],
+    })
+    render(<NetworkTabBar currentStation={station} />)
+    expect(screen.getAllByRole('link')).toHaveLength(3)
+  })
+
+  it('appends the frequency to the flagship tab label', () => {
+    render(<NetworkTabBar currentStation={makeStation()} />)
+    expect(screen.getByText('WFMU 91.1')).toBeInTheDocument()
+  })
+
+  it('marks the current station tab with aria-current=page', () => {
+    render(<NetworkTabBar currentStation={makeStation()} />)
+    const current = screen.getByText('WFMU 91.1').closest('a')
+    expect(current).toHaveAttribute('aria-current', 'page')
+  })
+
+  it('links siblings to their network channel URLs', () => {
+    render(<NetworkTabBar currentStation={makeStation()} />)
+    const sibling = screen.getByText('Drummer').closest('a')
+    expect(sibling).toHaveAttribute('href', '/radio/wfmu/channel/drummer')
+    expect(sibling).not.toHaveAttribute('aria-current')
+  })
+
+  it('orders the flagship tab first regardless of sibling order', () => {
+    const station = makeStation({
+      sibling_stations: [
+        makeSibling({ id: 2, slug: 'wfmu-aardvark', name: 'Aardvark' }),
+      ],
+    })
+    render(<NetworkTabBar currentStation={station} />)
+    const nav = screen.getByRole('navigation')
+    const links = within(nav).getAllByRole('link')
+    // Flagship "WFMU 91.1" sorts ahead of the alphabetically-earlier "Aardvark".
+    expect(links[0]).toHaveTextContent('WFMU 91.1')
+    expect(links[1]).toHaveTextContent('Aardvark')
+  })
+})

--- a/frontend/features/radio/components/RadioEpisodeRow.test.tsx
+++ b/frontend/features/radio/components/RadioEpisodeRow.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { RadioEpisodeRow } from './RadioEpisodeRow'
+import type { RadioEpisodeListItem } from '../types'
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode; [key: string]: unknown }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}))
+
+function makeEpisode(overrides: Partial<RadioEpisodeListItem> = {}): RadioEpisodeListItem {
+  return {
+    id: 1,
+    show_id: 10,
+    title: 'Episode Title',
+    air_date: '2026-05-01',
+    air_time: '21:30:00',
+    duration_minutes: 120,
+    archive_url: null,
+    play_count: 18,
+    created_at: '2026-05-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('RadioEpisodeRow', () => {
+  it('links to the episode detail page keyed by air_date', () => {
+    render(
+      <RadioEpisodeRow episode={makeEpisode()} stationSlug="wfmu" showSlug="drummer" />
+    )
+    const link = screen.getByRole('link')
+    expect(link).toHaveAttribute('href', '/radio/wfmu/drummer/2026-05-01')
+  })
+
+  it('renders the episode title when present', () => {
+    render(
+      <RadioEpisodeRow episode={makeEpisode()} stationSlug="wfmu" showSlug="drummer" />
+    )
+    expect(screen.getByText('Episode Title')).toBeInTheDocument()
+  })
+
+  it('formats a 24h air_time into a 12h clock time (PM)', () => {
+    render(
+      <RadioEpisodeRow
+        episode={makeEpisode({ air_time: '21:30:00' })}
+        stationSlug="wfmu"
+        showSlug="drummer"
+      />
+    )
+    expect(screen.getByText(/9:30 PM/)).toBeInTheDocument()
+  })
+
+  it('formats midnight as 12:00 AM', () => {
+    render(
+      <RadioEpisodeRow
+        episode={makeEpisode({ air_time: '00:00:00' })}
+        stationSlug="wfmu"
+        showSlug="drummer"
+      />
+    )
+    expect(screen.getByText(/12:00 AM/)).toBeInTheDocument()
+  })
+
+  it('renders the formatted air date', () => {
+    render(
+      <RadioEpisodeRow episode={makeEpisode()} stationSlug="wfmu" showSlug="drummer" />
+    )
+    // date-only constructor parses in local time → no TZ drift.
+    expect(screen.getByText(/May 1, 2026/)).toBeInTheDocument()
+  })
+
+  it('renders the track/play count', () => {
+    render(
+      <RadioEpisodeRow
+        episode={makeEpisode({ play_count: 18 })}
+        stationSlug="wfmu"
+        showSlug="drummer"
+      />
+    )
+    expect(screen.getByText(/18 tracks/)).toBeInTheDocument()
+  })
+
+  it('renders the duration in minutes', () => {
+    render(
+      <RadioEpisodeRow
+        episode={makeEpisode({ duration_minutes: 120 })}
+        stationSlug="wfmu"
+        showSlug="drummer"
+      />
+    )
+    expect(screen.getByText(/120 min/)).toBeInTheDocument()
+  })
+
+  it('falls back to the date as the primary line when there is no title', () => {
+    render(
+      <RadioEpisodeRow
+        episode={makeEpisode({ title: null })}
+        stationSlug="wfmu"
+        showSlug="drummer"
+      />
+    )
+    // Title-less episodes promote the date into the bold primary slot.
+    expect(screen.getByText(/May 1, 2026/)).toBeInTheDocument()
+    expect(screen.queryByText('Episode Title')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/features/radio/components/RadioPlayRow.test.tsx
+++ b/frontend/features/radio/components/RadioPlayRow.test.tsx
@@ -125,8 +125,10 @@ describe('RadioPlayRow', () => {
     expect(screen.getByText(/\d{1,2}:\d{2}\s?(AM|PM)/)).toBeInTheDocument()
   })
 
-  it('does not render a separator dash when there is no track title', () => {
+  it('omits the track title when it is null', () => {
     render(<RadioPlayRow play={makePlay({ track_title: null })} />)
     expect(screen.queryByText('Sweltering Madness')).not.toBeInTheDocument()
+    // Artist still renders; only the track-title slot (and its leading dash) drop.
+    expect(screen.getByText('Gatecreeper')).toBeInTheDocument()
   })
 })

--- a/frontend/features/radio/components/RadioPlayRow.test.tsx
+++ b/frontend/features/radio/components/RadioPlayRow.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { RadioPlayRow } from './RadioPlayRow'
+import type { RadioPlay } from '../types'
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode; [key: string]: unknown }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}))
+
+function makePlay(overrides: Partial<RadioPlay> = {}): RadioPlay {
+  return {
+    id: 1,
+    episode_id: 10,
+    position: 3,
+    artist_name: 'Gatecreeper',
+    track_title: 'Sweltering Madness',
+    album_title: 'Sonoran Depravation',
+    label_name: 'Relapse',
+    release_year: 2016,
+    is_new: false,
+    rotation_status: null,
+    dj_comment: null,
+    is_live_performance: false,
+    is_request: false,
+    artist_id: null,
+    artist_slug: null,
+    release_id: null,
+    release_slug: null,
+    label_id: null,
+    label_slug: null,
+    musicbrainz_artist_id: null,
+    musicbrainz_recording_id: null,
+    musicbrainz_release_id: null,
+    air_timestamp: null,
+    ...overrides,
+  }
+}
+
+describe('RadioPlayRow', () => {
+  it('renders the artist name and track title', () => {
+    render(<RadioPlayRow play={makePlay()} />)
+    expect(screen.getByText('Gatecreeper')).toBeInTheDocument()
+    expect(screen.getByText('Sweltering Madness')).toBeInTheDocument()
+  })
+
+  it('renders album, label, and release year', () => {
+    render(<RadioPlayRow play={makePlay()} />)
+    expect(screen.getByText('Sonoran Depravation')).toBeInTheDocument()
+    expect(screen.getByText('Relapse')).toBeInTheDocument()
+    expect(screen.getByText('(2016)')).toBeInTheDocument()
+  })
+
+  it('renders the position number by default', () => {
+    render(<RadioPlayRow play={makePlay({ position: 3 })} />)
+    expect(screen.getByText('3')).toBeInTheDocument()
+  })
+
+  it('hides the position number when showPosition is false', () => {
+    render(<RadioPlayRow play={makePlay({ position: 3 })} showPosition={false} />)
+    expect(screen.queryByText('3')).not.toBeInTheDocument()
+  })
+
+  it('links the artist to its catalog page when a slug is present', () => {
+    render(<RadioPlayRow play={makePlay({ artist_slug: 'gatecreeper' })} />)
+    const link = screen.getByText('Gatecreeper').closest('a')
+    expect(link).toHaveAttribute('href', '/artists/gatecreeper')
+  })
+
+  it('renders the artist as plain text when there is no slug', () => {
+    render(<RadioPlayRow play={makePlay({ artist_slug: null })} />)
+    expect(screen.getByText('Gatecreeper').closest('a')).toBeNull()
+  })
+
+  it('links the release and label to their catalog pages', () => {
+    render(
+      <RadioPlayRow
+        play={makePlay({ release_slug: 'sonoran-depravation', label_slug: 'relapse' })}
+      />
+    )
+    expect(screen.getByText('Sonoran Depravation').closest('a')).toHaveAttribute(
+      'href',
+      '/releases/sonoran-depravation'
+    )
+    expect(screen.getByText('Relapse').closest('a')).toHaveAttribute(
+      'href',
+      '/labels/relapse'
+    )
+  })
+
+  it('renders a NEW badge for new plays', () => {
+    render(<RadioPlayRow play={makePlay({ is_new: true })} />)
+    expect(screen.getByText('NEW')).toBeInTheDocument()
+  })
+
+  it('renders a rotation-status badge with its label', () => {
+    render(<RadioPlayRow play={makePlay({ rotation_status: 'heavy' })} />)
+    expect(screen.getByText('Heavy Rotation')).toBeInTheDocument()
+  })
+
+  it('suppresses the rotation badge for library rotation', () => {
+    render(<RadioPlayRow play={makePlay({ rotation_status: 'library' })} />)
+    expect(screen.queryByText('Library')).not.toBeInTheDocument()
+  })
+
+  it('renders LIVE and REQ badges', () => {
+    render(
+      <RadioPlayRow play={makePlay({ is_live_performance: true, is_request: true })} />
+    )
+    expect(screen.getByText('LIVE')).toBeInTheDocument()
+    expect(screen.getByText('REQ')).toBeInTheDocument()
+  })
+
+  it('renders a DJ comment when present', () => {
+    render(<RadioPlayRow play={makePlay({ dj_comment: 'Local legends' })} />)
+    expect(screen.getByText(/Local legends/)).toBeInTheDocument()
+  })
+
+  it('renders a formatted air timestamp when present', () => {
+    render(
+      <RadioPlayRow play={makePlay({ air_timestamp: '2026-05-01T06:32:00Z' })} />
+    )
+    // Exact rendered time depends on the runner TZ; assert the 12h-clock shape.
+    expect(screen.getByText(/\d{1,2}:\d{2}\s?(AM|PM)/)).toBeInTheDocument()
+  })
+
+  it('does not render a separator dash when there is no track title', () => {
+    render(<RadioPlayRow play={makePlay({ track_title: null })} />)
+    expect(screen.queryByText('Sweltering Madness')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/features/radio/components/RadioShowCard.test.tsx
+++ b/frontend/features/radio/components/RadioShowCard.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { RadioShowCard } from './RadioShowCard'
+import type { RadioShowListItem } from '../types'
+
+// next/link is mocked per-test (no global mock in test/setup.ts). EntityCardTitle
+// renders through this same Link, so title-link assertions stay real.
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode; [key: string]: unknown }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}))
+
+function makeShow(overrides: Partial<RadioShowListItem> = {}): RadioShowListItem {
+  return {
+    id: 1,
+    station_id: 10,
+    station_name: 'WFMU',
+    name: 'The Drummer Show',
+    slug: 'drummer',
+    host_name: 'The Drummer',
+    genre_tags: ['punk', 'garage', 'soul'],
+    image_url: null,
+    is_active: true,
+    episode_count: 12,
+    ...overrides,
+  }
+}
+
+describe('RadioShowCard', () => {
+  it('renders the show name as a link to the show detail page', () => {
+    render(<RadioShowCard show={makeShow()} stationSlug="wfmu" />)
+    const link = screen.getByText('The Drummer Show').closest('a')
+    expect(link).toHaveAttribute('href', '/radio/wfmu/drummer')
+  })
+
+  it('renders the host name', () => {
+    render(<RadioShowCard show={makeShow()} stationSlug="wfmu" />)
+    expect(screen.getByText('Hosted by The Drummer')).toBeInTheDocument()
+  })
+
+  it('omits the host line when host_name is null', () => {
+    render(<RadioShowCard show={makeShow({ host_name: null })} stationSlug="wfmu" />)
+    expect(screen.queryByText(/Hosted by/)).not.toBeInTheDocument()
+  })
+
+  it('renders at most three genre tags', () => {
+    render(
+      <RadioShowCard
+        show={makeShow({ genre_tags: ['a', 'b', 'c', 'd', 'e'] })}
+        stationSlug="wfmu"
+      />
+    )
+    expect(screen.getByText('a')).toBeInTheDocument()
+    expect(screen.getByText('b')).toBeInTheDocument()
+    expect(screen.getByText('c')).toBeInTheDocument()
+    expect(screen.queryByText('d')).not.toBeInTheDocument()
+  })
+
+  it('handles a null genre_tags array without crashing', () => {
+    render(<RadioShowCard show={makeShow({ genre_tags: null })} stationSlug="wfmu" />)
+    expect(screen.getByText('The Drummer Show')).toBeInTheDocument()
+  })
+
+  it('pluralizes the episode count', () => {
+    render(<RadioShowCard show={makeShow({ episode_count: 12 })} stationSlug="wfmu" />)
+    expect(screen.getByText('12 episodes')).toBeInTheDocument()
+  })
+
+  it('singularizes a single episode', () => {
+    render(<RadioShowCard show={makeShow({ episode_count: 1 })} stationSlug="wfmu" />)
+    expect(screen.getByText('1 episode')).toBeInTheDocument()
+  })
+
+  it('hides the episode count when there are no episodes', () => {
+    render(<RadioShowCard show={makeShow({ episode_count: 0 })} stationSlug="wfmu" />)
+    expect(screen.queryByText(/episode/)).not.toBeInTheDocument()
+  })
+
+  it('renders the show image with alt text when image_url is set', () => {
+    render(
+      <RadioShowCard
+        show={makeShow({ image_url: 'https://example.com/show.jpg' })}
+        stationSlug="wfmu"
+      />
+    )
+    const img = screen.getByAltText('The Drummer Show')
+    expect(img).toHaveAttribute('src', 'https://example.com/show.jpg')
+  })
+})

--- a/frontend/features/radio/components/RadioStationCard.test.tsx
+++ b/frontend/features/radio/components/RadioStationCard.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { RadioStationCard } from './RadioStationCard'
+import type { RadioStationListItem, RadioSiblingStation } from '../types'
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode; [key: string]: unknown }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}))
+
+function makeSibling(overrides: Partial<RadioSiblingStation> = {}): RadioSiblingStation {
+  return {
+    id: 2,
+    slug: 'wfmu-drummer',
+    name: 'Drummer',
+    broadcast_type: 'internet',
+    frequency_mhz: null,
+    is_flagship: false,
+    ...overrides,
+  }
+}
+
+function makeStation(overrides: Partial<RadioStationListItem> = {}): RadioStationListItem {
+  return {
+    id: 1,
+    name: 'KEXP',
+    slug: 'kexp',
+    city: 'Seattle',
+    state: 'WA',
+    country: 'USA',
+    broadcast_type: 'terrestrial',
+    frequency_mhz: 90.3,
+    logo_url: null,
+    is_active: true,
+    network: null,
+    sibling_stations: [],
+    show_count: 5,
+    ...overrides,
+  }
+}
+
+describe('RadioStationCard', () => {
+  it('renders the station name as a link to the detail page', () => {
+    render(<RadioStationCard station={makeStation()} />)
+    const link = screen.getByText('KEXP').closest('a')
+    expect(link).toHaveAttribute('href', '/radio/kexp')
+  })
+
+  it('renders the broadcast-type label', () => {
+    render(<RadioStationCard station={makeStation({ broadcast_type: 'terrestrial' })} />)
+    expect(screen.getByText('FM/AM')).toBeInTheDocument()
+  })
+
+  it('renders the frequency when present', () => {
+    render(<RadioStationCard station={makeStation({ frequency_mhz: 90.3 })} />)
+    expect(screen.getByText('90.3 MHz')).toBeInTheDocument()
+  })
+
+  it('omits the frequency for internet-only stations', () => {
+    render(<RadioStationCard station={makeStation({ frequency_mhz: null })} />)
+    expect(screen.queryByText(/MHz/)).not.toBeInTheDocument()
+  })
+
+  it('renders city + state location', () => {
+    render(<RadioStationCard station={makeStation()} />)
+    expect(screen.getByText('Seattle, WA')).toBeInTheDocument()
+  })
+
+  it('pluralizes the show count', () => {
+    render(<RadioStationCard station={makeStation({ show_count: 5 })} />)
+    expect(screen.getByText('5 shows')).toBeInTheDocument()
+  })
+
+  it('singularizes a single show', () => {
+    render(<RadioStationCard station={makeStation({ show_count: 1 })} />)
+    expect(screen.getByText('1 show')).toBeInTheDocument()
+  })
+
+  it('hides the show count when zero', () => {
+    render(<RadioStationCard station={makeStation({ show_count: 0 })} />)
+    expect(screen.queryByText(/show/)).not.toBeInTheDocument()
+  })
+
+  it('advertises sibling channels only when the station is the network flagship', () => {
+    const station = makeStation({
+      slug: 'wfmu',
+      network: { slug: 'wfmu', name: 'WFMU', is_flagship: true },
+      sibling_stations: [makeSibling({ id: 2 }), makeSibling({ id: 3 })],
+    })
+    render(<RadioStationCard station={station} />)
+    expect(screen.getByText('+ 2 channels')).toBeInTheDocument()
+  })
+
+  it('singularizes a single sibling channel', () => {
+    const station = makeStation({
+      slug: 'wfmu',
+      network: { slug: 'wfmu', name: 'WFMU', is_flagship: true },
+      sibling_stations: [makeSibling({ id: 2 })],
+    })
+    render(<RadioStationCard station={station} />)
+    expect(screen.getByText('+ 1 channel')).toBeInTheDocument()
+  })
+
+  it('does not advertise channels for a non-flagship station even with siblings', () => {
+    const station = makeStation({
+      slug: 'wfmu-drummer',
+      network: { slug: 'wfmu', name: 'WFMU', is_flagship: false },
+      sibling_stations: [makeSibling({ id: 2 })],
+    })
+    render(<RadioStationCard station={station} />)
+    expect(screen.queryByText(/channel/)).not.toBeInTheDocument()
+  })
+
+  it('links a non-flagship station to its network channel URL', () => {
+    const station = makeStation({
+      name: 'Drummer',
+      slug: 'wfmu-drummer',
+      network: { slug: 'wfmu', name: 'WFMU', is_flagship: false },
+    })
+    render(<RadioStationCard station={station} />)
+    const link = screen.getByText('Drummer').closest('a')
+    expect(link).toHaveAttribute('href', '/radio/wfmu/channel/drummer')
+  })
+
+  it('renders the logo with alt text when logo_url is set', () => {
+    render(
+      <RadioStationCard
+        station={makeStation({ logo_url: 'https://example.com/kexp.png' })}
+      />
+    )
+    const img = screen.getByAltText('KEXP logo')
+    expect(img).toHaveAttribute('src', 'https://example.com/kexp.png')
+  })
+})

--- a/frontend/features/radio/hooks/useArtistRadioPlays.test.tsx
+++ b/frontend/features/radio/hooks/useArtistRadioPlays.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { createWrapper } from '@/test/utils'
+import { radioQueryKeys } from '../api'
+
+const mockApiRequest = vi.fn()
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+}))
+
+import { useArtistRadioPlays } from './useArtistRadioPlays'
+
+const BASE = 'http://localhost:8080'
+
+describe('useArtistRadioPlays', () => {
+  beforeEach(() => {
+    mockApiRequest.mockReset()
+  })
+
+  it('uses the artistPlays(slug) query key', () => {
+    expect(radioQueryKeys.artistPlays('gatecreeper')).toEqual([
+      'artists',
+      'gatecreeper',
+      'radio-plays',
+    ])
+  })
+
+  it('fetches radio plays for the artist', async () => {
+    const mockResponse = {
+      stations: [{ station_id: 1, station_name: 'KEXP', play_count: 4 }],
+      count: 1,
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useArtistRadioPlays('gatecreeper'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      `${BASE}/artists/gatecreeper/radio-plays`,
+      { method: 'GET' }
+    )
+    expect(result.current.data).toEqual(mockResponse)
+  })
+
+  it('does not fetch when slug is empty', () => {
+    const { result } = renderHook(() => useArtistRadioPlays(''), {
+      wrapper: createWrapper(),
+    })
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('does not fetch when explicitly disabled', () => {
+    const { result } = renderHook(() => useArtistRadioPlays('gatecreeper', false), {
+      wrapper: createWrapper(),
+    })
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('starts in a loading state before the request resolves', () => {
+    mockApiRequest.mockReturnValueOnce(new Promise(() => {}))
+    const { result } = renderHook(() => useArtistRadioPlays('gatecreeper'), {
+      wrapper: createWrapper(),
+    })
+    expect(result.current.isLoading).toBe(true)
+  })
+
+  it('surfaces API errors', async () => {
+    const error = new Error('Server error')
+    Object.assign(error, { status: 500 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useArtistRadioPlays('gatecreeper'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect((result.current.error as Error).message).toBe('Server error')
+  })
+})

--- a/frontend/features/radio/hooks/useNewReleaseRadar.test.tsx
+++ b/frontend/features/radio/hooks/useNewReleaseRadar.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { createWrapper } from '@/test/utils'
+import { radioQueryKeys } from '../api'
+
+const mockApiRequest = vi.fn()
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+}))
+
+import { useNewReleaseRadar } from './useNewReleaseRadar'
+
+const BASE = 'http://localhost:8080'
+
+describe('useNewReleaseRadar', () => {
+  beforeEach(() => {
+    mockApiRequest.mockReset()
+  })
+
+  it('carries stationId/limit in the newReleases() query key', () => {
+    expect(radioQueryKeys.newReleases({ stationId: 7, limit: 20 })).toEqual([
+      'radio',
+      'new-releases',
+      { stationId: 7, limit: 20 },
+    ])
+  })
+
+  it('fetches with the default limit and no station filter', async () => {
+    const mockResponse = {
+      releases: [{ artist_name: 'Gatecreeper', play_count: 4, station_count: 2 }],
+      count: 1,
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useNewReleaseRadar(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    // No stationId → only limit param.
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      `${BASE}/radio/new-releases?limit=20`,
+      { method: 'GET' }
+    )
+    expect(result.current.data).toEqual(mockResponse)
+  })
+
+  it('includes station_id when a station filter is supplied', async () => {
+    mockApiRequest.mockResolvedValueOnce({ releases: [], count: 0 })
+
+    const { result } = renderHook(
+      () => useNewReleaseRadar({ stationId: 7, limit: 5 }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const calledUrl = mockApiRequest.mock.calls[0][0]
+    expect(calledUrl).toContain('station_id=7')
+    expect(calledUrl).toContain('limit=5')
+  })
+
+  it('does not fetch when explicitly disabled', () => {
+    const { result } = renderHook(() => useNewReleaseRadar({ enabled: false }), {
+      wrapper: createWrapper(),
+    })
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('starts in a loading state before the request resolves', () => {
+    mockApiRequest.mockReturnValueOnce(new Promise(() => {}))
+    const { result } = renderHook(() => useNewReleaseRadar(), {
+      wrapper: createWrapper(),
+    })
+    expect(result.current.isLoading).toBe(true)
+  })
+
+  it('surfaces API errors', async () => {
+    const error = new Error('Server error')
+    Object.assign(error, { status: 500 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useNewReleaseRadar(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect((result.current.error as Error).message).toBe('Server error')
+  })
+})

--- a/frontend/features/radio/hooks/useRadioEpisode.test.tsx
+++ b/frontend/features/radio/hooks/useRadioEpisode.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { createWrapper } from '@/test/utils'
+import { radioQueryKeys } from '../api'
+
+const mockApiRequest = vi.fn()
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+}))
+
+import { useRadioEpisode } from './useRadioEpisode'
+
+const BASE = 'http://localhost:8080'
+
+describe('useRadioEpisode', () => {
+  beforeEach(() => {
+    mockApiRequest.mockReset()
+  })
+
+  it('uses the episode(slug, date) query key', () => {
+    expect(radioQueryKeys.episode('drummer', '2026-05-01')).toEqual([
+      'radio-shows',
+      'drummer',
+      'episodes',
+      '2026-05-01',
+    ])
+  })
+
+  it('fetches a single episode by show slug + date', async () => {
+    const mockResponse = { id: 1, show_slug: 'drummer', air_date: '2026-05-01' }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useRadioEpisode('drummer', '2026-05-01'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      `${BASE}/radio-shows/drummer/episodes/2026-05-01`,
+      { method: 'GET' }
+    )
+    expect(result.current.data).toEqual(mockResponse)
+  })
+
+  it('does not fetch when slug is empty', () => {
+    const { result } = renderHook(() => useRadioEpisode('', '2026-05-01'), {
+      wrapper: createWrapper(),
+    })
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('does not fetch when date is empty', () => {
+    const { result } = renderHook(() => useRadioEpisode('drummer', ''), {
+      wrapper: createWrapper(),
+    })
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('starts in a loading state before the request resolves', () => {
+    mockApiRequest.mockReturnValueOnce(new Promise(() => {}))
+    const { result } = renderHook(() => useRadioEpisode('drummer', '2026-05-01'), {
+      wrapper: createWrapper(),
+    })
+    expect(result.current.isLoading).toBe(true)
+  })
+
+  it('surfaces a not-found error', async () => {
+    const error = new Error('Episode not found')
+    Object.assign(error, { status: 404 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useRadioEpisode('drummer', '2026-01-01'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect((result.current.error as Error).message).toBe('Episode not found')
+  })
+})

--- a/frontend/features/radio/hooks/useRadioEpisodes.test.tsx
+++ b/frontend/features/radio/hooks/useRadioEpisodes.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { createWrapper } from '@/test/utils'
+import { radioQueryKeys } from '../api'
+
+const mockApiRequest = vi.fn()
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+}))
+
+import { useRadioEpisodes } from './useRadioEpisodes'
+
+const BASE = 'http://localhost:8080'
+
+describe('useRadioEpisodes', () => {
+  beforeEach(() => {
+    mockApiRequest.mockReset()
+  })
+
+  it('carries limit/offset in the episodes() query key', () => {
+    expect(radioQueryKeys.episodes('drummer', { limit: 20, offset: 0 })).toEqual([
+      'radio-shows',
+      'drummer',
+      'episodes',
+      { limit: 20, offset: 0 },
+    ])
+  })
+
+  it('fetches episodes with the default limit query param', async () => {
+    const mockResponse = { episodes: [{ id: 1, air_date: '2026-05-01' }], total: 1 }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useRadioEpisodes({ showSlug: 'drummer' }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    // Default limit=20, offset=0 → offset omitted (falsy), limit kept.
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      `${BASE}/radio-shows/drummer/episodes?limit=20`,
+      { method: 'GET' }
+    )
+    expect(result.current.data).toEqual(mockResponse)
+  })
+
+  it('includes both limit and offset when paginating', async () => {
+    mockApiRequest.mockResolvedValueOnce({ episodes: [], total: 0 })
+
+    const { result } = renderHook(
+      () => useRadioEpisodes({ showSlug: 'drummer', limit: 10, offset: 20 }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const calledUrl = mockApiRequest.mock.calls[0][0]
+    expect(calledUrl).toContain('limit=10')
+    expect(calledUrl).toContain('offset=20')
+  })
+
+  it('does not fetch when showSlug is empty', () => {
+    const { result } = renderHook(() => useRadioEpisodes({ showSlug: '' }), {
+      wrapper: createWrapper(),
+    })
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('does not fetch when explicitly disabled', () => {
+    const { result } = renderHook(
+      () => useRadioEpisodes({ showSlug: 'drummer', enabled: false }),
+      { wrapper: createWrapper() }
+    )
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('starts in a loading state before the request resolves', () => {
+    mockApiRequest.mockReturnValueOnce(new Promise(() => {}))
+    const { result } = renderHook(() => useRadioEpisodes({ showSlug: 'drummer' }), {
+      wrapper: createWrapper(),
+    })
+    expect(result.current.isLoading).toBe(true)
+  })
+
+  it('surfaces API errors', async () => {
+    const error = new Error('Server error')
+    Object.assign(error, { status: 500 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useRadioEpisodes({ showSlug: 'drummer' }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect((result.current.error as Error).message).toBe('Server error')
+  })
+})

--- a/frontend/features/radio/hooks/useRadioShow.test.tsx
+++ b/frontend/features/radio/hooks/useRadioShow.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { createWrapper } from '@/test/utils'
+import { radioQueryKeys } from '../api'
+
+const mockApiRequest = vi.fn()
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+}))
+
+import { useRadioShow } from './useRadioShow'
+
+const BASE = 'http://localhost:8080'
+
+describe('useRadioShow', () => {
+  beforeEach(() => {
+    mockApiRequest.mockReset()
+  })
+
+  it('uses the show(slug) query key', () => {
+    expect(radioQueryKeys.show('drummer')).toEqual(['radio-shows', 'drummer'])
+  })
+
+  it('fetches a single show by slug', async () => {
+    const mockResponse = { id: 1, name: 'The Drummer Show', slug: 'drummer' }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useRadioShow('drummer'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(`${BASE}/radio-shows/drummer`, {
+      method: 'GET',
+    })
+    expect(result.current.data).toEqual(mockResponse)
+  })
+
+  it('does not fetch when slug is empty', () => {
+    const { result } = renderHook(() => useRadioShow(''), {
+      wrapper: createWrapper(),
+    })
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('starts in a loading state before the request resolves', () => {
+    mockApiRequest.mockReturnValueOnce(new Promise(() => {}))
+    const { result } = renderHook(() => useRadioShow('drummer'), {
+      wrapper: createWrapper(),
+    })
+    expect(result.current.isLoading).toBe(true)
+  })
+
+  it('surfaces a not-found error', async () => {
+    const error = new Error('Show not found')
+    Object.assign(error, { status: 404 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useRadioShow('nope'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect((result.current.error as Error).message).toBe('Show not found')
+  })
+})

--- a/frontend/features/radio/hooks/useRadioShows.test.tsx
+++ b/frontend/features/radio/hooks/useRadioShows.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { createWrapper } from '@/test/utils'
+import { radioQueryKeys } from '../api'
+
+const mockApiRequest = vi.fn()
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+}))
+
+import { useRadioShows } from './useRadioShows'
+
+const BASE = 'http://localhost:8080'
+
+describe('useRadioShows', () => {
+  beforeEach(() => {
+    mockApiRequest.mockReset()
+  })
+
+  it('wraps stationId in the shows() query key', () => {
+    expect(radioQueryKeys.shows(7)).toEqual(['radio-shows', { stationId: 7 }])
+  })
+
+  it('fetches shows scoped to a station via station_id query param', async () => {
+    const mockResponse = {
+      shows: [{ id: 1, name: 'The Drummer Show', slug: 'drummer' }],
+      count: 1,
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useRadioShows(7), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      `${BASE}/radio-shows?station_id=7`,
+      { method: 'GET' }
+    )
+    expect(result.current.data).toEqual(mockResponse)
+  })
+
+  it('does not fetch when stationId is omitted', () => {
+    const { result } = renderHook(() => useRadioShows(), {
+      wrapper: createWrapper(),
+    })
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('starts in a loading state before the request resolves', () => {
+    mockApiRequest.mockReturnValueOnce(new Promise(() => {}))
+    const { result } = renderHook(() => useRadioShows(7), {
+      wrapper: createWrapper(),
+    })
+    expect(result.current.isLoading).toBe(true)
+  })
+
+  it('surfaces API errors', async () => {
+    const error = new Error('Server error')
+    Object.assign(error, { status: 500 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useRadioShows(7), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect((result.current.error as Error).message).toBe('Server error')
+  })
+})

--- a/frontend/features/radio/hooks/useRadioStation.test.tsx
+++ b/frontend/features/radio/hooks/useRadioStation.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { createWrapper } from '@/test/utils'
+import { radioQueryKeys } from '../api'
+
+const mockApiRequest = vi.fn()
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+}))
+
+import { useRadioStation } from './useRadioStation'
+
+const BASE = 'http://localhost:8080'
+
+describe('useRadioStation', () => {
+  beforeEach(() => {
+    mockApiRequest.mockReset()
+  })
+
+  it('uses the station(slug) query key', () => {
+    expect(radioQueryKeys.station('kexp')).toEqual(['radio-stations', 'kexp'])
+  })
+
+  it('fetches a single station by slug', async () => {
+    const mockResponse = { id: 1, name: 'KEXP', slug: 'kexp' }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useRadioStation('kexp'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(`${BASE}/radio-stations/kexp`, {
+      method: 'GET',
+    })
+    expect(result.current.data).toEqual(mockResponse)
+  })
+
+  it('does not fetch when slug is empty', () => {
+    const { result } = renderHook(() => useRadioStation(''), {
+      wrapper: createWrapper(),
+    })
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('starts in a loading state before the request resolves', () => {
+    mockApiRequest.mockReturnValueOnce(new Promise(() => {}))
+    const { result } = renderHook(() => useRadioStation('kexp'), {
+      wrapper: createWrapper(),
+    })
+    expect(result.current.isLoading).toBe(true)
+  })
+
+  it('surfaces a not-found error', async () => {
+    const error = new Error('Station not found')
+    Object.assign(error, { status: 404 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useRadioStation('nope'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect((result.current.error as Error).message).toBe('Station not found')
+  })
+})

--- a/frontend/features/radio/hooks/useRadioStations.test.tsx
+++ b/frontend/features/radio/hooks/useRadioStations.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { createWrapper } from '@/test/utils'
+import { radioQueryKeys } from '../api'
+
+const mockApiRequest = vi.fn()
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+}))
+
+import { useRadioStations } from './useRadioStations'
+
+const BASE = 'http://localhost:8080'
+
+describe('useRadioStations', () => {
+  beforeEach(() => {
+    mockApiRequest.mockReset()
+  })
+
+  it('uses the stations() query key', () => {
+    expect(radioQueryKeys.stations()).toEqual(['radio-stations'])
+  })
+
+  it('fetches the station list on the stations endpoint', async () => {
+    const mockResponse = {
+      stations: [{ id: 1, name: 'KEXP', slug: 'kexp' }],
+      count: 1,
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useRadioStations(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(`${BASE}/radio-stations`, {
+      method: 'GET',
+    })
+    expect(result.current.data).toEqual(mockResponse)
+  })
+
+  it('starts in a loading state before the request resolves', () => {
+    mockApiRequest.mockReturnValueOnce(new Promise(() => {}))
+    const { result } = renderHook(() => useRadioStations(), {
+      wrapper: createWrapper(),
+    })
+    expect(result.current.isLoading).toBe(true)
+  })
+
+  it('surfaces API errors', async () => {
+    const error = new Error('Server error')
+    Object.assign(error, { status: 500 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useRadioStations(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect((result.current.error as Error).message).toBe('Server error')
+  })
+})

--- a/frontend/features/radio/hooks/useRadioStats.test.tsx
+++ b/frontend/features/radio/hooks/useRadioStats.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { createWrapper } from '@/test/utils'
+import { radioQueryKeys } from '../api'
+
+const mockApiRequest = vi.fn()
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+}))
+
+import { useRadioStats } from './useRadioStats'
+
+const BASE = 'http://localhost:8080'
+
+describe('useRadioStats', () => {
+  beforeEach(() => {
+    mockApiRequest.mockReset()
+  })
+
+  it('uses the stats() query key', () => {
+    expect(radioQueryKeys.stats()).toEqual(['radio', 'stats'])
+  })
+
+  it('fetches the stats endpoint', async () => {
+    const mockResponse = {
+      total_stations: 3,
+      total_shows: 12,
+      total_episodes: 400,
+      total_plays: 9000,
+      matched_plays: 6000,
+      unique_artists: 1500,
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useRadioStats(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(`${BASE}/radio/stats`, {
+      method: 'GET',
+    })
+    expect(result.current.data).toEqual(mockResponse)
+  })
+
+  it('starts in a loading state before the request resolves', () => {
+    mockApiRequest.mockReturnValueOnce(new Promise(() => {}))
+    const { result } = renderHook(() => useRadioStats(), {
+      wrapper: createWrapper(),
+    })
+    expect(result.current.isLoading).toBe(true)
+  })
+
+  it('surfaces API errors', async () => {
+    const error = new Error('Server error')
+    Object.assign(error, { status: 500 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useRadioStats(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect((result.current.error as Error).message).toBe('Server error')
+  })
+})

--- a/frontend/features/radio/hooks/useRadioTopArtists.test.tsx
+++ b/frontend/features/radio/hooks/useRadioTopArtists.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { createWrapper } from '@/test/utils'
+import { radioQueryKeys } from '../api'
+
+const mockApiRequest = vi.fn()
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+}))
+
+import { useRadioTopArtists } from './useRadioTopArtists'
+
+describe('useRadioTopArtists', () => {
+  beforeEach(() => {
+    mockApiRequest.mockReset()
+  })
+
+  it('carries period/limit in the topArtists() query key', () => {
+    expect(radioQueryKeys.topArtists('drummer', { period: 90, limit: 20 })).toEqual([
+      'radio-shows',
+      'drummer',
+      'top-artists',
+      { period: 90, limit: 20 },
+    ])
+  })
+
+  it('fetches with default period + limit query params', async () => {
+    const mockResponse = {
+      artists: [{ artist_name: 'Gatecreeper', play_count: 4, episode_count: 2 }],
+      count: 1,
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useRadioTopArtists({ showSlug: 'drummer' }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const calledUrl = mockApiRequest.mock.calls[0][0]
+    expect(calledUrl).toContain('/radio-shows/drummer/top-artists?')
+    expect(calledUrl).toContain('period=90')
+    expect(calledUrl).toContain('limit=20')
+    expect(result.current.data).toEqual(mockResponse)
+  })
+
+  it('honors a custom period and limit', async () => {
+    mockApiRequest.mockResolvedValueOnce({ artists: [], count: 0 })
+
+    const { result } = renderHook(
+      () => useRadioTopArtists({ showSlug: 'drummer', period: 30, limit: 5 }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const calledUrl = mockApiRequest.mock.calls[0][0]
+    expect(calledUrl).toContain('period=30')
+    expect(calledUrl).toContain('limit=5')
+  })
+
+  it('does not fetch when showSlug is empty', () => {
+    const { result } = renderHook(() => useRadioTopArtists({ showSlug: '' }), {
+      wrapper: createWrapper(),
+    })
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('does not fetch when explicitly disabled', () => {
+    const { result } = renderHook(
+      () => useRadioTopArtists({ showSlug: 'drummer', enabled: false }),
+      { wrapper: createWrapper() }
+    )
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('starts in a loading state before the request resolves', () => {
+    mockApiRequest.mockReturnValueOnce(new Promise(() => {}))
+    const { result } = renderHook(() => useRadioTopArtists({ showSlug: 'drummer' }), {
+      wrapper: createWrapper(),
+    })
+    expect(result.current.isLoading).toBe(true)
+  })
+
+  it('surfaces API errors', async () => {
+    const error = new Error('Server error')
+    Object.assign(error, { status: 500 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useRadioTopArtists({ showSlug: 'drummer' }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect((result.current.error as Error).message).toBe('Server error')
+  })
+})

--- a/frontend/features/radio/hooks/useRadioTopLabels.test.tsx
+++ b/frontend/features/radio/hooks/useRadioTopLabels.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { createWrapper } from '@/test/utils'
+import { radioQueryKeys } from '../api'
+
+const mockApiRequest = vi.fn()
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+}))
+
+import { useRadioTopLabels } from './useRadioTopLabels'
+
+describe('useRadioTopLabels', () => {
+  beforeEach(() => {
+    mockApiRequest.mockReset()
+  })
+
+  it('carries period/limit in the topLabels() query key', () => {
+    expect(radioQueryKeys.topLabels('drummer', { period: 90, limit: 20 })).toEqual([
+      'radio-shows',
+      'drummer',
+      'top-labels',
+      { period: 90, limit: 20 },
+    ])
+  })
+
+  it('fetches with default period + limit query params', async () => {
+    const mockResponse = {
+      labels: [{ label_name: 'Relapse', play_count: 6 }],
+      count: 1,
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useRadioTopLabels({ showSlug: 'drummer' }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const calledUrl = mockApiRequest.mock.calls[0][0]
+    expect(calledUrl).toContain('/radio-shows/drummer/top-labels?')
+    expect(calledUrl).toContain('period=90')
+    expect(calledUrl).toContain('limit=20')
+    expect(result.current.data).toEqual(mockResponse)
+  })
+
+  it('honors a custom period and limit', async () => {
+    mockApiRequest.mockResolvedValueOnce({ labels: [], count: 0 })
+
+    const { result } = renderHook(
+      () => useRadioTopLabels({ showSlug: 'drummer', period: 30, limit: 5 }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const calledUrl = mockApiRequest.mock.calls[0][0]
+    expect(calledUrl).toContain('period=30')
+    expect(calledUrl).toContain('limit=5')
+  })
+
+  it('does not fetch when showSlug is empty', () => {
+    const { result } = renderHook(() => useRadioTopLabels({ showSlug: '' }), {
+      wrapper: createWrapper(),
+    })
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('does not fetch when explicitly disabled', () => {
+    const { result } = renderHook(
+      () => useRadioTopLabels({ showSlug: 'drummer', enabled: false }),
+      { wrapper: createWrapper() }
+    )
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('starts in a loading state before the request resolves', () => {
+    mockApiRequest.mockReturnValueOnce(new Promise(() => {}))
+    const { result } = renderHook(() => useRadioTopLabels({ showSlug: 'drummer' }), {
+      wrapper: createWrapper(),
+    })
+    expect(result.current.isLoading).toBe(true)
+  })
+
+  it('surfaces API errors', async () => {
+    const error = new Error('Server error')
+    Object.assign(error, { status: 500 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useRadioTopLabels({ showSlug: 'drummer' }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect((result.current.error as Error).message).toBe('Server error')
+  })
+})

--- a/frontend/features/radio/hooks/useReleaseRadioPlays.test.tsx
+++ b/frontend/features/radio/hooks/useReleaseRadioPlays.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { createWrapper } from '@/test/utils'
+import { radioQueryKeys } from '../api'
+
+const mockApiRequest = vi.fn()
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+}))
+
+import { useReleaseRadioPlays } from './useReleaseRadioPlays'
+
+const BASE = 'http://localhost:8080'
+
+describe('useReleaseRadioPlays', () => {
+  beforeEach(() => {
+    mockApiRequest.mockReset()
+  })
+
+  it('uses the releasePlays(slug) query key', () => {
+    expect(radioQueryKeys.releasePlays('an-unkindness')).toEqual([
+      'releases',
+      'an-unkindness',
+      'radio-plays',
+    ])
+  })
+
+  it('fetches radio plays for the release', async () => {
+    const mockResponse = {
+      stations: [{ station_id: 1, station_name: 'KEXP', play_count: 2 }],
+      count: 1,
+    }
+    mockApiRequest.mockResolvedValueOnce(mockResponse)
+
+    const { result } = renderHook(() => useReleaseRadioPlays('an-unkindness'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      `${BASE}/releases/an-unkindness/radio-plays`,
+      { method: 'GET' }
+    )
+    expect(result.current.data).toEqual(mockResponse)
+  })
+
+  it('does not fetch when slug is empty', () => {
+    const { result } = renderHook(() => useReleaseRadioPlays(''), {
+      wrapper: createWrapper(),
+    })
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('does not fetch when explicitly disabled', () => {
+    const { result } = renderHook(() => useReleaseRadioPlays('an-unkindness', false), {
+      wrapper: createWrapper(),
+    })
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('starts in a loading state before the request resolves', () => {
+    mockApiRequest.mockReturnValueOnce(new Promise(() => {}))
+    const { result } = renderHook(() => useReleaseRadioPlays('an-unkindness'), {
+      wrapper: createWrapper(),
+    })
+    expect(result.current.isLoading).toBe(true)
+  })
+
+  it('surfaces API errors', async () => {
+    const error = new Error('Server error')
+    Object.assign(error, { status: 500 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useReleaseRadioPlays('an-unkindness'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect((result.current.error as Error).message).toBe('Server error')
+  })
+})


### PR DESCRIPTION
## Summary
- Closes the 95% test gap in `frontend/features/radio/`: 12 query hooks, 6 components, and the co-located `api.ts` config. The module shipped in Phase 2d (PRs #155, #260-268) with only `types.test.ts`.
- 19 new sibling test files, 153 new tests (161 total in the module incl. the pre-existing `types.test.ts`).
- Per hook: query-key shape, success path, error path, loading state, and the slug/`enabled` fetch gates. Per component: render with representative data, key text/links, empty/null states. `api.ts`: endpoint URL construction + query-key tuples.
- Conventions match existing sibling tests: hooks mock `@/lib/api` `apiRequest` and assert against the real `radioEndpoints` URLs (per `features/shows/hooks/useShows.test.tsx`); components mock `next/link` per-test (per `ShowCard.test.tsx`) and let `EntityCardTitle` render through it so title-link assertions stay real.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run test:run features/radio` — 161/161 passing (19 new test files)

## Manual repro
Test-only diff; no runtime behavior change. The passing suite IS the verification.

## Simplify
Reviewed for reuse/quality/efficiency. No shared mock/fixture helper exists to reuse — local `mockApiRequest` + per-file fixture factories are the established codebase convention. Renamed one `RadioPlayRow` test for accuracy; comments are WHY-only (subtle TZ/falsy-param invariants), no ticket-ref rot.

Closes PSY-685