### PR TITLE
PSY-687: test sweep for features/labels module

### DIFF
--- a/frontend/features/labels/admin/LabelManagement.test.tsx
+++ b/frontend/features/labels/admin/LabelManagement.test.tsx
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders } from '@/test/utils'
+import type { LabelListItem } from '../types'
+
+// List + detail hooks
+const mockUseLabels = vi.fn()
+const mockUseLabel = vi.fn()
+vi.mock('../hooks/useLabels', () => ({
+  useLabels: (...args: unknown[]) => mockUseLabels(...args),
+  useLabel: (...args: unknown[]) => mockUseLabel(...args),
+}))
+
+// Admin mutation hooks
+const mockCreateMutate = vi.fn()
+const mockUpdateMutate = vi.fn()
+const mockDeleteMutate = vi.fn()
+vi.mock('../hooks/useAdminLabels', () => ({
+  useCreateLabel: () => ({ mutate: mockCreateMutate, isPending: false }),
+  useUpdateLabel: () => ({ mutate: mockUpdateMutate, isPending: false }),
+  useDeleteLabel: () => ({ mutate: mockDeleteMutate, isPending: false }),
+}))
+
+import { LabelManagement } from './LabelManagement'
+
+function makeLabel(overrides: Partial<LabelListItem> = {}): LabelListItem {
+  return {
+    id: 1,
+    name: 'Sub Pop',
+    slug: 'sub-pop',
+    city: 'Seattle',
+    state: 'WA',
+    status: 'active',
+    artist_count: 12,
+    release_count: 340,
+    ...overrides,
+  }
+}
+
+describe('LabelManagement', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseLabel.mockReturnValue({ data: null, isLoading: false })
+    mockUseLabels.mockReturnValue({
+      data: { labels: [], count: 0 },
+      isLoading: false,
+      error: null,
+    })
+  })
+
+  it('renders the header and the New Label button', () => {
+    renderWithProviders(<LabelManagement />)
+    expect(
+      screen.getByRole('heading', { name: 'Labels' })
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /New Label/ })).toBeInTheDocument()
+  })
+
+  it('shows the loading spinner while labels are fetching', () => {
+    mockUseLabels.mockReturnValue({ data: undefined, isLoading: true, error: null })
+
+    renderWithProviders(<LabelManagement />)
+    expect(document.querySelector('.animate-spin')).toBeInTheDocument()
+  })
+
+  it('shows the query error banner when the list fails', () => {
+    mockUseLabels.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('Failed to load labels.'),
+    })
+
+    renderWithProviders(<LabelManagement />)
+    expect(screen.getByText('Failed to load labels.')).toBeInTheDocument()
+  })
+
+  it('shows the first-run empty state when there are no labels and no filters', () => {
+    renderWithProviders(<LabelManagement />)
+    expect(screen.getByText('No Labels Found')).toBeInTheDocument()
+    expect(
+      screen.getByText('No labels yet. Create your first label to get started.')
+    ).toBeInTheDocument()
+  })
+
+  it('renders a row per label with status, location, and counts', () => {
+    mockUseLabels.mockReturnValue({
+      data: {
+        labels: [makeLabel({ artist_count: 1, release_count: 2 })],
+        count: 1,
+      },
+      isLoading: false,
+      error: null,
+    })
+
+    renderWithProviders(<LabelManagement />)
+    // Scope to the label row so the "Active" status filter <option> in the
+    // toolbar doesn't collide with the row's "Active" status badge. `.border`
+    // is unique to the outermost row container.
+    const row = screen.getByText('Sub Pop').closest('div.border') as HTMLElement
+    expect(row).toBeInTheDocument()
+    expect(within(row).getByText('Active')).toBeInTheDocument()
+    expect(within(row).getByText('Seattle, WA')).toBeInTheDocument()
+    expect(within(row).getByText('1 artist')).toBeInTheDocument()
+    expect(within(row).getByText('2 releases')).toBeInTheDocument()
+    expect(screen.getByText('1 label')).toBeInTheDocument()
+  })
+
+  it('filters the visible rows client-side by the debounced search input', async () => {
+    const user = userEvent.setup()
+    mockUseLabels.mockReturnValue({
+      data: {
+        labels: [
+          makeLabel({ id: 1, name: 'Sub Pop', slug: 'sub-pop' }),
+          makeLabel({ id: 2, name: 'Merge Records', slug: 'merge-records' }),
+        ],
+        count: 2,
+      },
+      isLoading: false,
+      error: null,
+    })
+
+    renderWithProviders(<LabelManagement />)
+    expect(screen.getByText('Sub Pop')).toBeInTheDocument()
+    expect(screen.getByText('Merge Records')).toBeInTheDocument()
+
+    await user.type(screen.getByPlaceholderText('Search labels...'), 'merge')
+
+    // Search is debounced 300ms; wait for the filtered view to settle.
+    await screen.findByText('1 label matching "merge"')
+    expect(screen.getByText('Merge Records')).toBeInTheDocument()
+    expect(screen.queryByText('Sub Pop')).not.toBeInTheDocument()
+  })
+
+  it('passes the selected status filter through to useLabels', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<LabelManagement />)
+
+    const statusSelect = screen.getByRole('combobox')
+    await user.selectOptions(statusSelect, 'defunct')
+
+    expect(mockUseLabels).toHaveBeenLastCalledWith({ status: 'defunct' })
+  })
+
+  it('opens the create dialog form when New Label is clicked', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<LabelManagement />)
+
+    await user.click(screen.getByRole('button', { name: /New Label/ }))
+
+    const dialog = await screen.findByRole('dialog')
+    // "Create Label" is both the dialog title and the submit button label —
+    // assert the title via its heading role to disambiguate.
+    expect(
+      within(dialog).getByRole('heading', { name: 'Create Label' })
+    ).toBeInTheDocument()
+    expect(within(dialog).getByLabelText('Name *')).toBeInTheDocument()
+  })
+
+  it('blocks create submission and shows an error when name is empty', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<LabelManagement />)
+
+    await user.click(screen.getByRole('button', { name: /New Label/ }))
+    const dialog = await screen.findByRole('dialog')
+    await user.click(within(dialog).getByRole('button', { name: 'Create Label' }))
+
+    expect(within(dialog).getByText('Name is required')).toBeInTheDocument()
+    expect(mockCreateMutate).not.toHaveBeenCalled()
+  })
+
+  it('submits the create mutation with a trimmed name', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<LabelManagement />)
+
+    await user.click(screen.getByRole('button', { name: /New Label/ }))
+    const dialog = await screen.findByRole('dialog')
+    await user.type(within(dialog).getByLabelText('Name *'), '  Hardly Art  ')
+    await user.click(within(dialog).getByRole('button', { name: 'Create Label' }))
+
+    expect(mockCreateMutate).toHaveBeenCalledTimes(1)
+    expect(mockCreateMutate.mock.calls[0][0]).toMatchObject({ name: 'Hardly Art' })
+  })
+
+  it('opens the delete confirmation and fires the delete mutation', async () => {
+    const user = userEvent.setup()
+    mockUseLabels.mockReturnValue({
+      data: { labels: [makeLabel()], count: 1 },
+      isLoading: false,
+      error: null,
+    })
+
+    renderWithProviders(<LabelManagement />)
+
+    // The trash button is the second icon-only ghost button on the row.
+    const rowButtons = screen.getAllByRole('button')
+    const deleteButton = rowButtons[rowButtons.length - 1]
+    await user.click(deleteButton)
+
+    const dialog = await screen.findByRole('dialog')
+    expect(within(dialog).getByText(/Are you sure you want to delete/)).toBeInTheDocument()
+    await user.click(within(dialog).getByRole('button', { name: 'Delete Label' }))
+
+    expect(mockDeleteMutate).toHaveBeenCalledWith(1, expect.any(Object))
+  })
+})

--- a/frontend/features/labels/api.test.ts
+++ b/frontend/features/labels/api.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { API_BASE_URL } from '@/lib/api-base'
+import { labelEndpoints, labelQueryKeys } from './api'
+
+describe('labelEndpoints', () => {
+  it('exposes static collection endpoints rooted at the API base URL', () => {
+    expect(labelEndpoints.LIST).toBe(`${API_BASE_URL}/labels`)
+    expect(labelEndpoints.SEARCH).toBe(`${API_BASE_URL}/labels/search`)
+    expect(labelEndpoints.CREATE).toBe(`${API_BASE_URL}/labels`)
+  })
+
+  it('builds a detail endpoint from a numeric id', () => {
+    expect(labelEndpoints.GET(42)).toBe(`${API_BASE_URL}/labels/42`)
+  })
+
+  it('builds a detail endpoint from a slug', () => {
+    expect(labelEndpoints.GET('sub-pop')).toBe(`${API_BASE_URL}/labels/sub-pop`)
+  })
+
+  it('builds update and delete endpoints from a label id', () => {
+    expect(labelEndpoints.UPDATE(7)).toBe(`${API_BASE_URL}/labels/7`)
+    expect(labelEndpoints.DELETE(7)).toBe(`${API_BASE_URL}/labels/7`)
+  })
+
+  it('builds nested roster and catalog endpoints', () => {
+    expect(labelEndpoints.ARTISTS('sub-pop')).toBe(
+      `${API_BASE_URL}/labels/sub-pop/artists`
+    )
+    expect(labelEndpoints.RELEASES(7)).toBe(`${API_BASE_URL}/labels/7/releases`)
+  })
+})
+
+describe('labelQueryKeys', () => {
+  it('uses a stable root key for cache invalidation', () => {
+    expect(labelQueryKeys.all).toEqual(['labels'])
+  })
+
+  it('namespaces list keys with the filters object', () => {
+    expect(labelQueryKeys.list({ status: 'active' })).toEqual([
+      'labels',
+      'list',
+      { status: 'active' },
+    ])
+  })
+
+  it('produces a list key with undefined filters when none are passed', () => {
+    expect(labelQueryKeys.list()).toEqual(['labels', 'list', undefined])
+  })
+
+  it('lower-cases the query in search keys so case variants share a cache entry', () => {
+    expect(labelQueryKeys.search('Sub POP')).toEqual([
+      'labels',
+      'search',
+      'sub pop',
+    ])
+  })
+
+  it('stringifies ids in detail / roster / catalog keys', () => {
+    expect(labelQueryKeys.detail(42)).toEqual(['labels', 'detail', '42'])
+    expect(labelQueryKeys.roster('sub-pop')).toEqual([
+      'labels',
+      'roster',
+      'sub-pop',
+    ])
+    expect(labelQueryKeys.catalog(7)).toEqual(['labels', 'catalog', '7'])
+  })
+
+  it('produces identical detail keys for the numeric id and its string form', () => {
+    expect(labelQueryKeys.detail(42)).toEqual(labelQueryKeys.detail('42'))
+  })
+})

--- a/frontend/features/labels/components/LabelCard.test.tsx
+++ b/frontend/features/labels/components/LabelCard.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { LabelCard } from './LabelCard'
+import type { LabelListItem } from '../types'
+
+// Mock next/link so hrefs render as plain anchors.
+vi.mock('next/link', () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string
+    children: React.ReactNode
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}))
+
+function makeLabel(overrides: Partial<LabelListItem> = {}): LabelListItem {
+  return {
+    id: 1,
+    name: 'Sub Pop',
+    slug: 'sub-pop',
+    city: 'Seattle',
+    state: 'WA',
+    status: 'active',
+    artist_count: 12,
+    release_count: 340,
+    ...overrides,
+  }
+}
+
+describe('LabelCard', () => {
+  it('renders as an article element', () => {
+    render(<LabelCard label={makeLabel()} />)
+    expect(screen.getByRole('article')).toBeInTheDocument()
+  })
+
+  it('links the label name to its detail page', () => {
+    render(<LabelCard label={makeLabel()} />)
+    const link = screen.getByRole('link', { name: 'Sub Pop' })
+    expect(link).toHaveAttribute('href', '/labels/sub-pop')
+  })
+
+  it('renders the formatted location', () => {
+    render(<LabelCard label={makeLabel()} />)
+    expect(screen.getByText('Seattle, WA')).toBeInTheDocument()
+  })
+
+  it('omits the location when neither city nor state is set', () => {
+    render(<LabelCard label={makeLabel({ city: null, state: null })} />)
+    expect(screen.queryByText(/,/)).not.toBeInTheDocument()
+  })
+
+  it('renders the status badge', () => {
+    render(<LabelCard label={makeLabel({ status: 'defunct' })} />)
+    expect(screen.getByText('Defunct')).toBeInTheDocument()
+  })
+
+  it('pluralizes artist and release counts', () => {
+    render(<LabelCard label={makeLabel({ artist_count: 12, release_count: 340 })} />)
+    expect(screen.getByText('12 artists')).toBeInTheDocument()
+    expect(screen.getByText('340 releases')).toBeInTheDocument()
+  })
+
+  it('uses singular artist and release labels for a count of 1', () => {
+    render(<LabelCard label={makeLabel({ artist_count: 1, release_count: 1 })} />)
+    expect(screen.getByText('1 artist')).toBeInTheDocument()
+    expect(screen.getByText('1 release')).toBeInTheDocument()
+  })
+
+  describe('compact density', () => {
+    it('renders the name link and status but only the artist count', () => {
+      render(<LabelCard label={makeLabel()} density="compact" />)
+      expect(screen.getByRole('link', { name: 'Sub Pop' })).toHaveAttribute(
+        'href',
+        '/labels/sub-pop'
+      )
+      expect(screen.getByText('Active')).toBeInTheDocument()
+      expect(screen.getByText('12 artists')).toBeInTheDocument()
+      // Compact view does not surface the release count.
+      expect(screen.queryByText('340 releases')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('expanded density', () => {
+    it('renders name, status, location, and both counts', () => {
+      render(<LabelCard label={makeLabel()} density="expanded" />)
+      expect(screen.getByText('Sub Pop')).toBeInTheDocument()
+      expect(screen.getByText('Active')).toBeInTheDocument()
+      expect(screen.getByText('Seattle, WA')).toBeInTheDocument()
+      expect(screen.getByText('12 artists')).toBeInTheDocument()
+      expect(screen.getByText('340 releases')).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/features/labels/components/LabelDetail.test.tsx
+++ b/frontend/features/labels/components/LabelDetail.test.tsx
@@ -1,0 +1,441 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, within } from '@testing-library/react'
+import { renderWithProviders } from '@/test/utils'
+import type { LabelDetail as LabelDetailType } from '../types'
+
+// Mock next/link
+vi.mock('next/link', () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string
+    children: React.ReactNode
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}))
+
+// Data hooks
+const mockUseLabel = vi.fn()
+const mockUseLabelRoster = vi.fn()
+const mockUseLabelCatalog = vi.fn()
+vi.mock('../hooks/useLabels', () => ({
+  useLabel: (opts: unknown) => mockUseLabel(opts),
+  useLabelRoster: (opts: unknown) => mockUseLabelRoster(opts),
+  useLabelCatalog: (opts: unknown) => mockUseLabelCatalog(opts),
+}))
+
+const mockUseIsAuthenticated = vi.fn()
+vi.mock('@/features/auth', () => ({
+  useIsAuthenticated: () => mockUseIsAuthenticated(),
+}))
+
+// NB: do NOT mock @tanstack/react-query here — renderWithProviders needs the
+// real QueryClient/QueryClientProvider. LabelDetail only calls useQueryClient
+// inside onSuccess (never fired in these tests), so the real provider suffices.
+
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    labels: { detail: (id: string | number) => ['labels', 'detail', String(id)] },
+  },
+}))
+
+vi.mock('@/features/releases/types', () => ({
+  RELEASE_TYPES: ['lp', 'ep', 'single', 'compilation', 'live', 'remix', 'demo'],
+}))
+
+vi.mock('@/features/collections', () => ({
+  EntityCollections: () => <div data-testid="entity-collections" />,
+}))
+
+vi.mock('@/features/comments', () => ({
+  CommentThread: ({ entityType, entityId }: { entityType: string; entityId: number }) => (
+    <div data-testid="comment-thread">
+      Comments for {entityType} {entityId}
+    </div>
+  ),
+}))
+
+vi.mock('@/features/tags', () => ({
+  EntityTagList: () => <div data-testid="entity-tag-list" />,
+  AddTagDialog: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="add-tag-dialog">Add Tag</div> : null,
+}))
+
+vi.mock('@/features/notifications', () => ({
+  NotifyMeButton: ({ entityName }: { entityName: string }) => (
+    <button data-testid="notify-me-button">Notify {entityName}</button>
+  ),
+}))
+
+vi.mock('@/features/contributions', () => ({
+  AttributionLine: () => null,
+  ContributionPrompt: () => null,
+  EntityEditDrawer: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="edit-drawer">Edit Drawer</div> : null,
+  EntitySaveSuccessBanner: ({ visible }: { visible: boolean }) =>
+    visible ? <div data-testid="save-success-banner">Saved</div> : null,
+  useEntitySaveSuccessBanner: () => ({
+    isVisible: false,
+    handleSaveSuccess: vi.fn(),
+  }),
+}))
+
+vi.mock('@/components/shared', () => ({
+  EntityDetailLayout: ({
+    children,
+    sidebar,
+    header,
+    fallback,
+    entityName,
+  }: {
+    children: React.ReactNode
+    sidebar: React.ReactNode
+    header: React.ReactNode
+    fallback: { href: string; label: string }
+    entityName: string
+  }) => (
+    <div data-testid="entity-layout">
+      <a href={fallback.href}>{fallback.label}</a>
+      <span data-testid="entity-name">{entityName}</span>
+      <div data-testid="header-slot">{header}</div>
+      <div data-testid="sidebar-slot">{sidebar}</div>
+      <div data-testid="content-slot">{children}</div>
+    </div>
+  ),
+  EntityHeader: ({
+    title,
+    subtitle,
+    actions,
+  }: {
+    title: string
+    subtitle?: React.ReactNode
+    actions?: React.ReactNode
+  }) => (
+    <div data-testid="entity-header">
+      <h1>{title}</h1>
+      {subtitle && <div data-testid="subtitle">{subtitle}</div>}
+      {actions && <div data-testid="header-actions">{actions}</div>}
+    </div>
+  ),
+  SocialLinks: () => <div data-testid="social-links">Social Links</div>,
+  FollowButton: ({ entityType, entityId }: { entityType: string; entityId: number }) => (
+    <button data-testid="follow-button">
+      Follow {entityType} {entityId}
+    </button>
+  ),
+  AddToCollectionButton: () => (
+    <button data-testid="add-to-collection">[Add to collection]</button>
+  ),
+  RevisionHistory: () => <div data-testid="revision-history">Revision History</div>,
+  BracketLink: ({
+    label,
+    onClick,
+    title,
+  }: {
+    label: string
+    onClick?: () => void
+    title?: string
+  }) => (
+    <button onClick={onClick} title={title} data-testid={`bracket-${label}`}>
+      [{label}]
+    </button>
+  ),
+  SectionHeader: ({ title }: { title: string }) => <h3>{title}</h3>,
+  StatsList: ({ items }: { items: { label: string; value: React.ReactNode }[] }) => (
+    <dl data-testid="stats-list">
+      {items.map((i) => (
+        <div key={i.label}>
+          <dt>{i.label}</dt>
+          <dd>{i.value}</dd>
+        </div>
+      ))}
+    </dl>
+  ),
+  DenseTable: ({ children }: { children: React.ReactNode }) => (
+    <table data-testid="dense-table">{children}</table>
+  ),
+  DenseTableGroupHeader: ({ title }: { title: string }) => (
+    <tr>
+      <td>{title}</td>
+    </tr>
+  ),
+}))
+
+import { LabelDetail } from './LabelDetail'
+
+function makeLabel(overrides: Partial<LabelDetailType> = {}): LabelDetailType {
+  return {
+    id: 5,
+    name: 'Sub Pop',
+    slug: 'sub-pop',
+    city: 'Seattle',
+    state: 'WA',
+    country: 'USA',
+    founded_year: 1988,
+    status: 'active',
+    description: null,
+    image_url: null,
+    social: {
+      instagram: null,
+      facebook: null,
+      twitter: null,
+      youtube: null,
+      spotify: null,
+      soundcloud: null,
+      bandcamp: null,
+      website: null,
+    },
+    artist_count: 12,
+    release_count: 340,
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('LabelDetail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseIsAuthenticated.mockReturnValue({
+      user: null,
+      isAuthenticated: false,
+      isLoading: false,
+    })
+    mockUseLabelRoster.mockReturnValue({ data: { artists: [] }, isLoading: false })
+    mockUseLabelCatalog.mockReturnValue({ data: { releases: [] }, isLoading: false })
+  })
+
+  describe('loading state', () => {
+    it('shows a spinner while the label is fetching', () => {
+      mockUseLabel.mockReturnValue({ data: undefined, isLoading: true, error: null })
+
+      renderWithProviders(<LabelDetail idOrSlug="sub-pop" />)
+      expect(document.querySelector('.animate-spin')).toBeInTheDocument()
+    })
+  })
+
+  describe('error state', () => {
+    it('shows a 404 message for a not-found error', () => {
+      mockUseLabel.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        error: new Error('Label not found'),
+      })
+
+      renderWithProviders(<LabelDetail idOrSlug="bad-slug" />)
+      expect(screen.getByText('Label Not Found')).toBeInTheDocument()
+    })
+
+    it('shows a generic message for a server error', () => {
+      mockUseLabel.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        error: new Error('Server exploded'),
+      })
+
+      renderWithProviders(<LabelDetail idOrSlug="x" />)
+      expect(screen.getByText('Error Loading Label')).toBeInTheDocument()
+      expect(screen.getByText('Server exploded')).toBeInTheDocument()
+    })
+
+    it('links back to the labels list on error', () => {
+      mockUseLabel.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        error: new Error('not found'),
+      })
+
+      renderWithProviders(<LabelDetail idOrSlug="x" />)
+      expect(screen.getByText('Back to Labels').closest('a')).toHaveAttribute(
+        'href',
+        '/labels'
+      )
+    })
+  })
+
+  describe('no data', () => {
+    it('shows the not-found state when label is null', () => {
+      mockUseLabel.mockReturnValue({ data: null, isLoading: false, error: null })
+
+      renderWithProviders(<LabelDetail idOrSlug="missing" />)
+      expect(screen.getByText('Label Not Found')).toBeInTheDocument()
+    })
+  })
+
+  describe('successful load', () => {
+    beforeEach(() => {
+      mockUseLabel.mockReturnValue({
+        data: makeLabel(),
+        isLoading: false,
+        error: null,
+      })
+    })
+
+    it('renders the label name in the header and breadcrumb', () => {
+      renderWithProviders(<LabelDetail idOrSlug="sub-pop" />)
+      expect(screen.getByTestId('header-slot')).toHaveTextContent('Sub Pop')
+      expect(screen.getByTestId('entity-name')).toHaveTextContent('Sub Pop')
+      expect(screen.getByText('Labels')).toBeInTheDocument()
+    })
+
+    it('renders location and founded year in the subtitle', () => {
+      renderWithProviders(<LabelDetail idOrSlug="sub-pop" />)
+      const subtitle = screen.getByTestId('subtitle')
+      expect(subtitle).toHaveTextContent('Seattle, WA')
+      expect(subtitle).toHaveTextContent('Est. 1988')
+    })
+
+    it('renders the statistics block in the sidebar', () => {
+      renderWithProviders(<LabelDetail idOrSlug="sub-pop" />)
+      const sidebar = screen.getByTestId('sidebar-slot')
+      expect(sidebar).toHaveTextContent('Statistics')
+      expect(sidebar).toHaveTextContent('Roster')
+      expect(sidebar).toHaveTextContent('Catalog')
+    })
+
+    it('renders the comment thread and revision history', () => {
+      renderWithProviders(<LabelDetail idOrSlug="sub-pop" />)
+      expect(screen.getByTestId('comment-thread')).toBeInTheDocument()
+      expect(screen.getByTestId('revision-history')).toBeInTheDocument()
+    })
+
+    it('renders the About section when a description is present', () => {
+      mockUseLabel.mockReturnValue({
+        data: makeLabel({ description: 'A storied Seattle label.' }),
+        isLoading: false,
+        error: null,
+      })
+
+      renderWithProviders(<LabelDetail idOrSlug="sub-pop" />)
+      expect(screen.getByText('About')).toBeInTheDocument()
+      expect(screen.getByText('A storied Seattle label.')).toBeInTheDocument()
+    })
+
+    it('omits the About section when there is no description', () => {
+      renderWithProviders(<LabelDetail idOrSlug="sub-pop" />)
+      expect(screen.queryByText('About')).not.toBeInTheDocument()
+    })
+
+    it('renders the Links section only when a social link exists', () => {
+      mockUseLabel.mockReturnValue({
+        data: makeLabel({
+          social: {
+            instagram: 'https://instagram.com/subpop',
+            facebook: null,
+            twitter: null,
+            youtube: null,
+            spotify: null,
+            soundcloud: null,
+            bandcamp: null,
+            website: null,
+          },
+        }),
+        isLoading: false,
+        error: null,
+      })
+
+      renderWithProviders(<LabelDetail idOrSlug="sub-pop" />)
+      expect(screen.getByText('Links')).toBeInTheDocument()
+      expect(screen.getByTestId('social-links')).toBeInTheDocument()
+    })
+
+    it('omits the Links section when every social value is empty', () => {
+      renderWithProviders(<LabelDetail idOrSlug="sub-pop" />)
+      expect(screen.queryByText('Links')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('social-links')).not.toBeInTheDocument()
+    })
+
+    it('renders the roster section with artist links when artists exist', () => {
+      mockUseLabelRoster.mockReturnValue({
+        data: { artists: [{ id: 1, slug: 'mudhoney', name: 'Mudhoney' }] },
+        isLoading: false,
+      })
+
+      renderWithProviders(<LabelDetail idOrSlug="sub-pop" />)
+      // "Roster" is also a stat label in the sidebar — scope to the content
+      // slot so we assert the actual roster *section*, not the stat.
+      const content = screen.getByTestId('content-slot')
+      expect(within(content).getByText('Roster')).toBeInTheDocument()
+      expect(within(content).getByText('Mudhoney').closest('a')).toHaveAttribute(
+        'href',
+        '/artists/mudhoney'
+      )
+    })
+
+    it('groups the catalog by release type', () => {
+      mockUseLabelCatalog.mockReturnValue({
+        data: {
+          releases: [
+            {
+              id: 1,
+              title: 'Bleach',
+              slug: 'bleach',
+              release_type: 'lp',
+              release_year: 1989,
+              cover_art_url: null,
+              catalog_number: 'SP34',
+            },
+          ],
+        },
+        isLoading: false,
+      })
+
+      renderWithProviders(<LabelDetail idOrSlug="sub-pop" />)
+      // "Catalog" is also a stat label in the sidebar — scope to the content
+      // slot so we assert the catalog *section*, not the stat.
+      const content = screen.getByTestId('content-slot')
+      expect(within(content).getByText('Catalog')).toBeInTheDocument()
+      expect(within(content).getByText('Albums')).toBeInTheDocument()
+      expect(within(content).getByText('Bleach').closest('a')).toHaveAttribute(
+        'href',
+        '/releases/bleach'
+      )
+    })
+
+    it('does not render edit / add-tag bracket links for unauthenticated users', () => {
+      renderWithProviders(<LabelDetail idOrSlug="sub-pop" />)
+      expect(screen.queryByTestId('bracket-Edit')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('bracket-Suggest edit')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('bracket-Add tag')).not.toBeInTheDocument()
+    })
+
+    it('shows a Suggest edit link for an authenticated non-trusted user', () => {
+      mockUseIsAuthenticated.mockReturnValue({
+        user: { is_admin: false },
+        isAuthenticated: true,
+        isLoading: false,
+      })
+
+      renderWithProviders(<LabelDetail idOrSlug="sub-pop" />)
+      expect(screen.getByTestId('bracket-Suggest edit')).toBeInTheDocument()
+      expect(screen.getByTestId('bracket-Add tag')).toBeInTheDocument()
+    })
+
+    it('shows an Edit link for a trusted-tier user', () => {
+      mockUseIsAuthenticated.mockReturnValue({
+        user: { is_admin: false, user_tier: 'trusted_contributor' },
+        isAuthenticated: true,
+        isLoading: false,
+      })
+
+      renderWithProviders(<LabelDetail idOrSlug="sub-pop" />)
+      expect(screen.getByTestId('bracket-Edit')).toBeInTheDocument()
+    })
+
+    it('offers a Suggest description link when there is no description', () => {
+      mockUseIsAuthenticated.mockReturnValue({
+        user: { is_admin: false },
+        isAuthenticated: true,
+        isLoading: false,
+      })
+
+      renderWithProviders(<LabelDetail idOrSlug="sub-pop" />)
+      expect(screen.getByTestId('bracket-Suggest description')).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/features/labels/components/LabelList.test.tsx
+++ b/frontend/features/labels/components/LabelList.test.tsx
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders } from '@/test/utils'
+import type { LabelListItem } from '../types'
+
+// Mock next/navigation
+const mockPush = vi.fn()
+const mockGet = vi.fn()
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+  useSearchParams: () => ({ get: mockGet }),
+}))
+
+// Mock data hook
+const mockUseLabels = vi.fn()
+vi.mock('../hooks/useLabels', () => ({
+  useLabels: (opts: unknown) => mockUseLabels(opts),
+}))
+
+const mockUseDensity = vi.fn()
+vi.mock('@/lib/hooks/common/useDensity', () => ({
+  useDensity: (key: string) => mockUseDensity(key),
+}))
+
+// Mock the search child (its own suite covers it).
+vi.mock('./LabelSearch', () => ({
+  LabelSearch: () => <div data-testid="label-search">LabelSearch</div>,
+}))
+
+vi.mock('@/components/shared', () => ({
+  LoadingSpinner: () => <div data-testid="loading-spinner">Loading...</div>,
+  DensityToggle: ({ density }: { density: string; onDensityChange: (v: string) => void }) => (
+    <div data-testid="density-toggle">{density}</div>
+  ),
+  EntityCardTitle: ({ name, href }: { name: string; href: string }) => (
+    <a href={href}>
+      <h3 title={name}>{name}</h3>
+    </a>
+  ),
+}))
+
+vi.mock('@/features/tags', () => ({
+  TagFacetPanel: () => <div data-testid="tag-facet-panel" />,
+  TagFacetSheet: () => <div data-testid="tag-facet-sheet" />,
+  parseTagsParam: (s: string | null) => (s ? s.split(',').filter(Boolean) : []),
+  buildTagsParam: (slugs: string[]) => slugs.join(','),
+}))
+
+import { LabelList } from './LabelList'
+
+function makeLabel(overrides: Partial<LabelListItem> = {}): LabelListItem {
+  return {
+    id: 1,
+    name: 'Sub Pop',
+    slug: 'sub-pop',
+    city: 'Seattle',
+    state: 'WA',
+    status: 'active',
+    artist_count: 12,
+    release_count: 340,
+    ...overrides,
+  }
+}
+
+describe('LabelList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGet.mockReturnValue(null)
+    mockUseDensity.mockReturnValue({ density: 'comfortable', setDensity: vi.fn() })
+    mockUseLabels.mockReturnValue({
+      data: { labels: [], count: 0 },
+      isLoading: false,
+      isFetching: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+  })
+
+  it('shows the loading spinner on initial load (no data yet)', () => {
+    mockUseLabels.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isFetching: true,
+      error: null,
+      refetch: vi.fn(),
+    })
+
+    renderWithProviders(<LabelList />)
+    expect(screen.getByTestId('loading-spinner')).toBeInTheDocument()
+  })
+
+  it('renders the search component and density toggle', () => {
+    renderWithProviders(<LabelList />)
+    expect(screen.getByTestId('label-search')).toBeInTheDocument()
+    expect(screen.getByTestId('density-toggle')).toHaveTextContent('comfortable')
+  })
+
+  it('renders the unfiltered empty state when there are no labels', () => {
+    renderWithProviders(<LabelList />)
+    expect(
+      screen.getByText('No labels available at this time.')
+    ).toBeInTheDocument()
+  })
+
+  it('renders the filtered empty state when a status filter is applied', () => {
+    mockGet.mockImplementation((key: string) =>
+      key === 'status' ? 'defunct' : null
+    )
+
+    renderWithProviders(<LabelList />)
+    expect(
+      screen.getByText('No labels found matching your filters.')
+    ).toBeInTheDocument()
+    expect(screen.getByText('View all labels')).toBeInTheDocument()
+  })
+
+  it('renders label cards and the count line when data is present', () => {
+    mockUseLabels.mockReturnValue({
+      data: {
+        labels: [
+          makeLabel({ id: 1, name: 'Sub Pop', slug: 'sub-pop' }),
+          makeLabel({ id: 2, name: 'Merge Records', slug: 'merge-records' }),
+        ],
+        count: 2,
+      },
+      isLoading: false,
+      isFetching: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+
+    renderWithProviders(<LabelList />)
+    expect(screen.getByText('Sub Pop')).toBeInTheDocument()
+    expect(screen.getByText('Merge Records')).toBeInTheDocument()
+    expect(screen.getByTestId('label-count')).toHaveTextContent('2 labels')
+  })
+
+  it('uses the singular noun for a single label', () => {
+    mockUseLabels.mockReturnValue({
+      data: { labels: [makeLabel()], count: 1 },
+      isLoading: false,
+      isFetching: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+
+    renderWithProviders(<LabelList />)
+    expect(screen.getByTestId('label-count')).toHaveTextContent('1 label')
+  })
+
+  it('shows an error state with a retry button', () => {
+    mockUseLabels.mockReturnValue({
+      data: { labels: [], count: 0 },
+      isLoading: false,
+      isFetching: false,
+      error: new Error('boom'),
+      refetch: vi.fn(),
+    })
+
+    renderWithProviders(<LabelList />)
+    expect(
+      screen.getByText('Failed to load labels. Please try again later.')
+    ).toBeInTheDocument()
+    expect(screen.getByText('Retry')).toBeInTheDocument()
+  })
+
+  it('calls refetch when the retry button is clicked', async () => {
+    const user = userEvent.setup()
+    const refetch = vi.fn()
+    mockUseLabels.mockReturnValue({
+      data: { labels: [], count: 0 },
+      isLoading: false,
+      isFetching: false,
+      error: new Error('boom'),
+      refetch,
+    })
+
+    renderWithProviders(<LabelList />)
+    await user.click(screen.getByText('Retry'))
+    expect(refetch).toHaveBeenCalledOnce()
+  })
+
+  it('passes the status URL param through to useLabels', () => {
+    mockGet.mockImplementation((key: string) =>
+      key === 'status' ? 'inactive' : null
+    )
+
+    renderWithProviders(<LabelList />)
+    expect(mockUseLabels).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'inactive' })
+    )
+  })
+
+  it('parses tags + tag_match from the URL and forwards them', () => {
+    mockGet.mockImplementation((key: string) => {
+      if (key === 'tags') return 'punk,noise'
+      if (key === 'tag_match') return 'any'
+      return null
+    })
+
+    renderWithProviders(<LabelList />)
+    expect(mockUseLabels).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tags: ['punk', 'noise'],
+        tagMatch: 'any',
+      })
+    )
+  })
+
+  it('navigates to a status-filtered URL when a status chip is clicked', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<LabelList />)
+
+    // The status row renders an "Active" chip among others.
+    await user.click(screen.getByRole('button', { name: 'Active' }))
+    expect(mockPush).toHaveBeenCalledWith('/labels?status=active', {
+      scroll: false,
+    })
+  })
+})

--- a/frontend/features/labels/components/LabelSearch.test.tsx
+++ b/frontend/features/labels/components/LabelSearch.test.tsx
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders } from '@/test/utils'
+
+// Mock next/navigation
+const mockPush = vi.fn()
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}))
+
+// Mock the search hook — the component calls it with { query }. We echo a
+// canned result keyed off the latest query so the dropdown can open.
+const mockSearchResults = vi.fn()
+vi.mock('../hooks/useLabelSearch', () => ({
+  useLabelSearch: ({ query }: { query: string }) => ({
+    data: mockSearchResults(query),
+  }),
+}))
+
+import { LabelSearch } from './LabelSearch'
+
+const SUB_POP = {
+  id: 1,
+  slug: 'sub-pop',
+  name: 'Sub Pop',
+  city: 'Seattle',
+  state: 'WA',
+}
+const MERGE = {
+  id: 2,
+  slug: 'merge-records',
+  name: 'Merge Records',
+  city: 'Durham',
+  state: 'NC',
+}
+
+describe('LabelSearch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSearchResults.mockReturnValue(undefined)
+  })
+
+  it('renders the search input with placeholder', () => {
+    renderWithProviders(<LabelSearch />)
+    expect(screen.getByPlaceholderText('Search labels...')).toBeInTheDocument()
+  })
+
+  it('opens the dropdown with results once the user types', async () => {
+    mockSearchResults.mockReturnValue({ labels: [SUB_POP], count: 1 })
+
+    renderWithProviders(<LabelSearch />)
+    await userEvent.type(screen.getByPlaceholderText('Search labels...'), 'sub')
+
+    expect(screen.getByText('Sub Pop')).toBeInTheDocument()
+  })
+
+  it('shows the location next to each result', async () => {
+    mockSearchResults.mockReturnValue({ labels: [SUB_POP], count: 1 })
+
+    renderWithProviders(<LabelSearch />)
+    await userEvent.type(screen.getByPlaceholderText('Search labels...'), 'sub')
+
+    expect(screen.getByText('Seattle, WA')).toBeInTheDocument()
+  })
+
+  it('does not open the dropdown when the input is empty', async () => {
+    mockSearchResults.mockReturnValue({ labels: [SUB_POP], count: 1 })
+
+    renderWithProviders(<LabelSearch />)
+    // No typing — isOpen stays false even though the hook would return data.
+    expect(screen.queryByText('Sub Pop')).not.toBeInTheDocument()
+  })
+
+  it('navigates to the label page on mousedown selection', async () => {
+    mockSearchResults.mockReturnValue({ labels: [SUB_POP], count: 1 })
+
+    renderWithProviders(<LabelSearch />)
+    await userEvent.type(screen.getByPlaceholderText('Search labels...'), 'sub')
+
+    // mousedown (not click) drives selection — blur is delayed to allow it.
+    fireEvent.mouseDown(screen.getByText('Sub Pop'))
+
+    expect(mockPush).toHaveBeenCalledWith('/labels/sub-pop')
+  })
+
+  it('clears the input after a selection', async () => {
+    mockSearchResults.mockReturnValue({ labels: [SUB_POP], count: 1 })
+
+    renderWithProviders(<LabelSearch />)
+    const input = screen.getByPlaceholderText(
+      'Search labels...'
+    ) as HTMLInputElement
+    await userEvent.type(input, 'sub')
+    fireEvent.mouseDown(screen.getByText('Sub Pop'))
+
+    expect(input.value).toBe('')
+  })
+
+  describe('keyboard navigation', () => {
+    it('selects the active result on ArrowDown + Enter', async () => {
+      const user = userEvent.setup()
+      mockSearchResults.mockReturnValue({
+        labels: [SUB_POP, MERGE],
+        count: 2,
+      })
+
+      renderWithProviders(<LabelSearch />)
+      const input = screen.getByPlaceholderText('Search labels...')
+      await user.type(input, 'records')
+
+      // First ArrowDown highlights index 0 (Sub Pop), then Enter selects it.
+      await user.keyboard('{ArrowDown}{Enter}')
+
+      expect(mockPush).toHaveBeenCalledWith('/labels/sub-pop')
+    })
+
+    it('wraps to the second result with two ArrowDowns', async () => {
+      const user = userEvent.setup()
+      mockSearchResults.mockReturnValue({
+        labels: [SUB_POP, MERGE],
+        count: 2,
+      })
+
+      renderWithProviders(<LabelSearch />)
+      const input = screen.getByPlaceholderText('Search labels...')
+      await user.type(input, 'records')
+
+      await user.keyboard('{ArrowDown}{ArrowDown}{Enter}')
+
+      expect(mockPush).toHaveBeenCalledWith('/labels/merge-records')
+    })
+
+    it('closes the dropdown on Escape without navigating', async () => {
+      const user = userEvent.setup()
+      mockSearchResults.mockReturnValue({ labels: [SUB_POP], count: 1 })
+
+      renderWithProviders(<LabelSearch />)
+      const input = screen.getByPlaceholderText('Search labels...')
+      await user.type(input, 'sub')
+      expect(screen.getByText('Sub Pop')).toBeInTheDocument()
+
+      await user.keyboard('{Escape}')
+
+      expect(screen.queryByText('Sub Pop')).not.toBeInTheDocument()
+      expect(mockPush).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/frontend/features/labels/hooks/useAdminLabels.test.tsx
+++ b/frontend/features/labels/hooks/useAdminLabels.test.tsx
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { createWrapper } from '@/test/utils'
+
+const mockApiRequest = vi.fn()
+const mockInvalidateLabels = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+vi.mock('@/lib/queryClient', () => ({
+  createInvalidateQueries: () => ({
+    labels: mockInvalidateLabels,
+  }),
+}))
+
+vi.mock('@/features/labels/api', () => ({
+  labelEndpoints: {
+    CREATE: '/labels',
+    UPDATE: (labelId: number) => `/labels/${labelId}`,
+    DELETE: (labelId: number) => `/labels/${labelId}`,
+  },
+}))
+
+import { useCreateLabel, useUpdateLabel, useDeleteLabel } from './useAdminLabels'
+
+describe('useCreateLabel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateLabels.mockReset()
+  })
+
+  it('POSTs the new label payload to the create endpoint', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 10, name: 'Sub Pop' })
+
+    const { result } = renderHook(() => useCreateLabel(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ name: 'Sub Pop', city: 'Seattle' })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith('/labels', {
+      method: 'POST',
+      body: JSON.stringify({ name: 'Sub Pop', city: 'Seattle' }),
+    })
+  })
+
+  it('invalidates the labels cache on success', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 10, name: 'Sub Pop' })
+
+    const { result } = renderHook(() => useCreateLabel(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ name: 'Sub Pop' })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockInvalidateLabels).toHaveBeenCalled()
+  })
+
+  it('surfaces the error and skips invalidation on failure', async () => {
+    mockApiRequest.mockRejectedValueOnce(new Error('Name already taken'))
+
+    const { result } = renderHook(() => useCreateLabel(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ name: 'Dupe' })
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect((result.current.error as Error).message).toBe('Name already taken')
+    expect(mockInvalidateLabels).not.toHaveBeenCalled()
+  })
+
+  it('reports the pending state while the request is in flight', async () => {
+    mockApiRequest.mockReturnValue(new Promise(() => {}))
+
+    const { result } = renderHook(() => useCreateLabel(), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.isPending).toBe(false)
+    act(() => {
+      result.current.mutate({ name: 'Slow Pop' })
+    })
+    await waitFor(() => expect(result.current.isPending).toBe(true))
+  })
+})
+
+describe('useUpdateLabel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateLabels.mockReset()
+  })
+
+  it('PUTs the data payload to the label-id endpoint', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 5, name: 'Renamed' })
+
+    const { result } = renderHook(() => useUpdateLabel(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ labelId: 5, data: { name: 'Renamed' } })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith('/labels/5', {
+      method: 'PUT',
+      body: JSON.stringify({ name: 'Renamed' }),
+    })
+  })
+
+  it('invalidates the labels cache on success', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 5, name: 'Renamed' })
+
+    const { result } = renderHook(() => useUpdateLabel(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ labelId: 5, data: { name: 'Renamed' } })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockInvalidateLabels).toHaveBeenCalled()
+  })
+
+  it('surfaces an update error', async () => {
+    mockApiRequest.mockRejectedValueOnce(new Error('Label not found'))
+
+    const { result } = renderHook(() => useUpdateLabel(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ labelId: 999, data: { name: 'Ghost' } })
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect((result.current.error as Error).message).toBe('Label not found')
+  })
+})
+
+describe('useDeleteLabel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateLabels.mockReset()
+  })
+
+  it('DELETEs against the label-id endpoint', async () => {
+    mockApiRequest.mockResolvedValueOnce(undefined)
+
+    const { result } = renderHook(() => useDeleteLabel(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(8)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiRequest).toHaveBeenCalledWith('/labels/8', {
+      method: 'DELETE',
+    })
+  })
+
+  it('invalidates the labels cache on success', async () => {
+    mockApiRequest.mockResolvedValueOnce(undefined)
+
+    const { result } = renderHook(() => useDeleteLabel(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(8)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockInvalidateLabels).toHaveBeenCalled()
+  })
+
+  it('surfaces a delete error', async () => {
+    mockApiRequest.mockRejectedValueOnce(new Error('Delete blocked'))
+
+    const { result } = renderHook(() => useDeleteLabel(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(8)
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect((result.current.error as Error).message).toBe('Delete blocked')
+  })
+})

--- a/frontend/features/labels/hooks/useLabelSearch.test.tsx
+++ b/frontend/features/labels/hooks/useLabelSearch.test.tsx
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { createWrapper } from '@/test/utils'
+
+const mockApiRequest = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+vi.mock('@/features/labels/api', () => ({
+  labelEndpoints: {
+    SEARCH: '/labels/search',
+  },
+  labelQueryKeys: {
+    search: (query: string) => ['labels', 'search', query.toLowerCase()],
+  },
+}))
+
+// Spy wrapper around the real use-debounce. By default it passes the value
+// straight through (synchronous), which lets us assert URL/encoding/enabled
+// behavior without timers, while still recording the (value, delay) args the
+// hook hands it — that's how we verify the debounce is actually wired and what
+// delay it uses (see the "debounce wiring" describe below).
+const debounceSpy = vi.fn((value: string, _delay?: number) => [value] as const)
+vi.mock('use-debounce', () => ({
+  useDebounce: (value: string, delay?: number) => debounceSpy(value, delay),
+}))
+
+import { useLabelSearch } from './useLabelSearch'
+
+describe('useLabelSearch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    debounceSpy.mockImplementation((value: string) => [value] as const)
+  })
+
+  describe('query behavior', () => {
+    it('fetches labels matching the search query', async () => {
+      mockApiRequest.mockResolvedValueOnce({
+        labels: [{ id: 1, slug: 'sub-pop', name: 'Sub Pop' }],
+        count: 1,
+      })
+
+      const { result } = renderHook(() => useLabelSearch({ query: 'sub' }), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      expect(mockApiRequest).toHaveBeenCalledWith('/labels/search?q=sub')
+    })
+
+    it('does not fetch when the query is empty', () => {
+      const { result } = renderHook(() => useLabelSearch({ query: '' }), {
+        wrapper: createWrapper(),
+      })
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+
+    it('URL-encodes special characters in the query', async () => {
+      mockApiRequest.mockResolvedValueOnce({ labels: [], count: 0 })
+
+      const { result } = renderHook(
+        () => useLabelSearch({ query: 'rough & ready' }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/labels/search?q=rough%20%26%20ready'
+      )
+    })
+
+    it('returns the loading state while the request is in flight', () => {
+      mockApiRequest.mockReturnValue(new Promise(() => {}))
+
+      const { result } = renderHook(() => useLabelSearch({ query: 'loading' }), {
+        wrapper: createWrapper(),
+      })
+
+      expect(result.current.isLoading).toBe(true)
+      expect(result.current.data).toBeUndefined()
+    })
+
+    it('surfaces an error when the request rejects', async () => {
+      mockApiRequest.mockRejectedValueOnce(new Error('Search failed'))
+
+      const { result } = renderHook(() => useLabelSearch({ query: 'boom' }), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+      expect((result.current.error as Error).message).toBe('Search failed')
+    })
+  })
+
+  // The factory (lib/hooks/factories.ts createSearchHook) routes the input
+  // query through use-debounce BEFORE it reaches the query key + request. These
+  // tests confirm that wiring and the current delay value without depending on
+  // fragile fake-timer + React-state flush semantics: we assert the (value,
+  // delay) pair handed to use-debounce, and that the DEBOUNCED value (not the
+  // raw input) is what drives the request.
+  describe('debounce wiring', () => {
+    it('passes the raw query through use-debounce with the default 50ms delay', () => {
+      mockApiRequest.mockResolvedValue({ labels: [], count: 0 })
+      renderHook(() => useLabelSearch({ query: 'sub' }), {
+        wrapper: createWrapper(),
+      })
+
+      expect(debounceSpy).toHaveBeenCalledWith('sub', 50)
+    })
+
+    it('passes a caller-supplied debounceMs through to use-debounce', () => {
+      mockApiRequest.mockResolvedValue({ labels: [], count: 0 })
+      renderHook(() => useLabelSearch({ query: 'sub', debounceMs: 300 }), {
+        wrapper: createWrapper(),
+      })
+
+      expect(debounceSpy).toHaveBeenCalledWith('sub', 300)
+    })
+
+    it('drives the request off the DEBOUNCED value, not the raw input', async () => {
+      // Force the debounce to lag: return a stale value regardless of input.
+      debounceSpy.mockReturnValue(['stale'] as const)
+      mockApiRequest.mockResolvedValueOnce({ labels: [], count: 0 })
+
+      const { result } = renderHook(
+        () => useLabelSearch({ query: 'fresh-input' }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      // Proves the hook awaits the debounced value before firing.
+      expect(mockApiRequest).toHaveBeenCalledWith('/labels/search?q=stale')
+      expect(mockApiRequest).not.toHaveBeenCalledWith('/labels/search?q=fresh-input')
+    })
+
+    it('keeps the query disabled while the debounced value is still empty', () => {
+      // Raw input is non-empty, but the debounced value has not caught up yet.
+      debounceSpy.mockReturnValue([''] as const)
+
+      const { result } = renderHook(
+        () => useLabelSearch({ query: 'typing' }),
+        { wrapper: createWrapper() }
+      )
+
+      expect(mockApiRequest).not.toHaveBeenCalled()
+      expect(result.current.fetchStatus).toBe('idle')
+    })
+  })
+})

--- a/frontend/features/labels/types.test.ts
+++ b/frontend/features/labels/types.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest'
+import {
+  LABEL_STATUS_LABELS,
+  LABEL_STATUSES,
+  getLabelStatusVariant,
+  getLabelStatusLabel,
+  formatLabelLocation,
+  type LabelStatus,
+} from './types'
+
+describe('LABEL_STATUSES / LABEL_STATUS_LABELS', () => {
+  it('lists the three known statuses', () => {
+    expect(LABEL_STATUSES).toEqual(['active', 'inactive', 'defunct'])
+  })
+
+  it('has a display label for every status in the list', () => {
+    for (const status of LABEL_STATUSES) {
+      expect(LABEL_STATUS_LABELS[status]).toBeTruthy()
+    }
+  })
+
+  it('maps statuses to title-cased display labels', () => {
+    expect(LABEL_STATUS_LABELS.active).toBe('Active')
+    expect(LABEL_STATUS_LABELS.inactive).toBe('Inactive')
+    expect(LABEL_STATUS_LABELS.defunct).toBe('Defunct')
+  })
+})
+
+describe('getLabelStatusVariant', () => {
+  it('maps active to the default (filled) badge variant', () => {
+    expect(getLabelStatusVariant('active')).toBe('default')
+  })
+
+  it('maps inactive to the secondary badge variant', () => {
+    expect(getLabelStatusVariant('inactive')).toBe('secondary')
+  })
+
+  it('maps defunct to the outline badge variant', () => {
+    expect(getLabelStatusVariant('defunct')).toBe('outline')
+  })
+
+  it('falls back to secondary for an unknown status', () => {
+    expect(getLabelStatusVariant('mystery')).toBe('secondary')
+  })
+})
+
+describe('getLabelStatusLabel', () => {
+  it('returns the mapped label for a known status', () => {
+    expect(getLabelStatusLabel('active')).toBe('Active')
+    expect(getLabelStatusLabel('defunct')).toBe('Defunct')
+  })
+
+  it('title-cases an unknown status as a fallback', () => {
+    expect(getLabelStatusLabel('hiatus')).toBe('Hiatus')
+  })
+
+  it('only capitalizes the first character of an unknown status', () => {
+    // The fallback uppercases char[0] and appends the rest verbatim.
+    expect(getLabelStatusLabel('on hold')).toBe('On hold')
+  })
+
+  it('handles a status that is a non-LabelStatus string narrowed at the call site', () => {
+    const s: string = 'inactive'
+    expect(getLabelStatusLabel(s as LabelStatus)).toBe('Inactive')
+  })
+})
+
+describe('formatLabelLocation', () => {
+  it('joins city and state with a comma when both are present', () => {
+    expect(formatLabelLocation({ city: 'Seattle', state: 'WA' })).toBe(
+      'Seattle, WA'
+    )
+  })
+
+  it('returns just the city when state is null', () => {
+    expect(formatLabelLocation({ city: 'Seattle', state: null })).toBe('Seattle')
+  })
+
+  it('returns just the state when city is null', () => {
+    expect(formatLabelLocation({ city: null, state: 'WA' })).toBe('WA')
+  })
+
+  it('returns null when neither city nor state is present', () => {
+    expect(formatLabelLocation({ city: null, state: null })).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- Adds sibling tests for the nine previously-untested files in `frontend/features/labels/`: `admin/LabelManagement.tsx`, `api.ts`, `components/{LabelCard,LabelDetail,LabelList,LabelSearch}.tsx`, `types.ts`, `hooks/useAdminLabels.ts`, `hooks/useLabelSearch.ts`. (`useLabels` already had coverage; the four `index.ts` barrels are pure re-exports.)
- Components cover render + interactions (status/density/filters, search keyboard nav, dialog open + create/delete mutations, detail loading/error/sections/trust-tier links). Hooks cover success/error/loading + cache invalidation.
- `useLabelSearch` suite verifies the `createSearchHook` debounce is genuinely wired: it asserts the `(query, delay)` pair handed to `use-debounce` (default 50ms + caller override) and that the request is driven off the debounced value, not the raw input.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run test:run features/labels` — 116/116 passing (10 files)

## Manual repro
Test-only diff; no runtime change. Passing suite IS the verification.

## Simplify
Ran review (reuse / quality / efficiency lenses). Code was largely clean — reuses canonical `createWrapper`/`renderWithProviders`, mirrors peer-test mock conventions, local `makeX` factories per established pattern. One fix: stripped a `PSY-687` ticket ref from a doc comment per the strip-ticket-refs convention. No reuse/efficiency issues (test-only).

## Scope-adjacent observation
The ticket flagged that `useLabelSearch` "likely lacks debounce." That hypothesis is incorrect: `useLabelSearch` delegates to `createSearchHook` (`frontend/lib/hooks/factories.ts`), which debounces via `use-debounce` with a 50ms default — same as `useVenueSearch`/`useArtistSearch`. Debounce IS present and is now covered by tests. No bug to file.

Closes PSY-687