### PR TITLE
PSY-688: test coverage for features/releases module

### DIFF
--- a/frontend/features/releases/admin/ReleaseManagement.test.tsx
+++ b/frontend/features/releases/admin/ReleaseManagement.test.tsx
@@ -243,7 +243,7 @@ describe('ReleaseManagement', () => {
     })
     renderWithProviders(<ReleaseManagement />)
 
-    // The pencil icon button is the first action button on the row.
+    // Row actions are icon-only buttons; identify edit by its lucide glyph.
     const editButtons = screen.getAllByRole('button')
     const pencil = editButtons.find((b) =>
       b.querySelector('.lucide-pencil')

--- a/frontend/features/releases/admin/ReleaseManagement.test.tsx
+++ b/frontend/features/releases/admin/ReleaseManagement.test.tsx
@@ -1,0 +1,313 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, within, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders } from '@/test/utils'
+import type { ReleaseListItem, ReleaseDetail } from '../types'
+
+// Data hooks: useReleases drives the admin list; useRelease backs the edit form.
+const mockUseReleases = vi.fn()
+const mockUseRelease = vi.fn()
+vi.mock('../hooks/useReleases', () => ({
+  useReleases: (opts: unknown) => mockUseReleases(opts),
+  useRelease: (opts: unknown) => mockUseRelease(opts),
+}))
+
+// Artist search inside the create-form ArtistPicker.
+vi.mock('@/features/artists', () => ({
+  useArtistSearch: () => ({ data: { artists: [] }, isLoading: false }),
+}))
+
+// Admin mutations. Capture the create/update/delete spies so dialog flows can
+// assert wiring without a live backend.
+const mockCreate = vi.fn()
+const mockUpdate = vi.fn()
+const mockDelete = vi.fn()
+const mockAddLink = vi.fn()
+const mockRemoveLink = vi.fn()
+vi.mock('../hooks/useAdminReleases', () => ({
+  useCreateRelease: () => ({ mutate: mockCreate, isPending: false }),
+  useUpdateRelease: () => ({ mutate: mockUpdate, isPending: false }),
+  useDeleteRelease: () => ({ mutate: mockDelete, isPending: false }),
+  useAddReleaseLink: () => ({ mutate: mockAddLink, isPending: false }),
+  useRemoveReleaseLink: () => ({ mutate: mockRemoveLink, isPending: false }),
+}))
+
+import { ReleaseManagement } from './ReleaseManagement'
+
+function makeListItem(
+  overrides: Partial<ReleaseListItem> = {}
+): ReleaseListItem {
+  return {
+    id: 1,
+    title: 'In Rainbows',
+    slug: 'in-rainbows',
+    release_type: 'lp',
+    release_year: 2007,
+    cover_art_url: null,
+    artist_count: 1,
+    artists: [{ id: 1, name: 'Radiohead', slug: 'radiohead' }],
+    label_name: null,
+    label_slug: null,
+    ...overrides,
+  }
+}
+
+function makeDetail(overrides: Partial<ReleaseDetail> = {}): ReleaseDetail {
+  return {
+    id: 1,
+    title: 'In Rainbows',
+    slug: 'in-rainbows',
+    release_type: 'lp',
+    release_year: 2007,
+    release_date: null,
+    cover_art_url: null,
+    description: null,
+    artists: [{ id: 1, slug: 'radiohead', name: 'Radiohead', role: 'main' }],
+    labels: [],
+    external_links: [],
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('ReleaseManagement', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseReleases.mockReturnValue({
+      data: { releases: [], total: 0, limit: 50, offset: 0 },
+      isLoading: false,
+      error: null,
+    })
+    mockUseRelease.mockReturnValue({ data: undefined, isLoading: false })
+  })
+
+  it('renders the management header and New Release action', () => {
+    renderWithProviders(<ReleaseManagement />)
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'Releases' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /New Release/ })
+    ).toBeInTheDocument()
+  })
+
+  it('shows a spinner while releases load', () => {
+    mockUseReleases.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    })
+    const { container } = renderWithProviders(<ReleaseManagement />)
+    expect(container.querySelector('.animate-spin')).toBeInTheDocument()
+  })
+
+  it('shows an error banner when the query fails', () => {
+    mockUseReleases.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('Failed to load releases'),
+    })
+    renderWithProviders(<ReleaseManagement />)
+    expect(screen.getByText('Failed to load releases')).toBeInTheDocument()
+  })
+
+  it('renders the empty state when there are no releases', () => {
+    renderWithProviders(<ReleaseManagement />)
+    expect(screen.getByText('No Releases Found')).toBeInTheDocument()
+  })
+
+  it('lists releases with their type label and year', () => {
+    mockUseReleases.mockReturnValue({
+      data: {
+        releases: [
+          makeListItem({ id: 1, title: 'In Rainbows', release_type: 'lp' }),
+          makeListItem({
+            id: 2,
+            title: 'Spirit of Eden',
+            release_type: 'ep',
+            release_year: 1988,
+          }),
+        ],
+        total: 2,
+        limit: 50,
+        offset: 0,
+      },
+      isLoading: false,
+      error: null,
+    })
+    renderWithProviders(<ReleaseManagement />)
+    expect(screen.getByText('In Rainbows')).toBeInTheDocument()
+    expect(screen.getByText('Spirit of Eden')).toBeInTheDocument()
+    expect(screen.getByText('2 releases')).toBeInTheDocument()
+  })
+
+  it('filters the list client-side by the debounced search input', async () => {
+    const user = userEvent.setup()
+    mockUseReleases.mockReturnValue({
+      data: {
+        releases: [
+          makeListItem({ id: 1, title: 'In Rainbows' }),
+          makeListItem({ id: 2, title: 'Kid A', slug: 'kid-a' }),
+        ],
+        total: 2,
+        limit: 50,
+        offset: 0,
+      },
+      isLoading: false,
+      error: null,
+    })
+    renderWithProviders(<ReleaseManagement />)
+
+    await user.type(screen.getByPlaceholderText('Search releases...'), 'kid')
+
+    // Filtering is gated behind a 300ms debounce; poll until the non-matching
+    // row drops out (real timers — waitFor's default 1s window covers it).
+    await waitFor(() =>
+      expect(screen.queryByText('In Rainbows')).not.toBeInTheDocument()
+    )
+    expect(screen.getByText('Kid A')).toBeInTheDocument()
+  })
+
+  it('passes the type filter through to useReleases', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<ReleaseManagement />)
+
+    const typeSelect = screen.getByRole('combobox')
+    await user.selectOptions(typeSelect, 'ep')
+
+    expect(mockUseReleases).toHaveBeenLastCalledWith(
+      expect.objectContaining({ releaseType: 'ep' })
+    )
+  })
+
+  it('opens the create dialog from the New Release button', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<ReleaseManagement />)
+
+    await user.click(screen.getByRole('button', { name: /New Release/ }))
+
+    const dialog = await screen.findByRole('dialog')
+    // "Create Release" appears twice in the dialog (title + submit button);
+    // assert the title specifically.
+    expect(
+      within(dialog).getByRole('heading', { name: 'Create Release' })
+    ).toBeInTheDocument()
+    expect(within(dialog).getByLabelText(/Title/)).toBeInTheDocument()
+  })
+
+  it('validates that a title is required before creating', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<ReleaseManagement />)
+
+    await user.click(screen.getByRole('button', { name: /New Release/ }))
+    const dialog = await screen.findByRole('dialog')
+    await user.click(
+      within(dialog).getByRole('button', { name: 'Create Release' })
+    )
+
+    expect(within(dialog).getByText('Title is required')).toBeInTheDocument()
+    expect(mockCreate).not.toHaveBeenCalled()
+  })
+
+  it('submits a valid create payload through the mutation', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<ReleaseManagement />)
+
+    await user.click(screen.getByRole('button', { name: /New Release/ }))
+    const dialog = await screen.findByRole('dialog')
+    await user.type(within(dialog).getByLabelText(/Title/), 'New Album')
+    await user.click(
+      within(dialog).getByRole('button', { name: 'Create Release' })
+    )
+
+    expect(mockCreate).toHaveBeenCalledTimes(1)
+    expect(mockCreate.mock.calls[0][0]).toMatchObject({ title: 'New Album' })
+  })
+
+  it('opens the edit dialog and loads the selected release', async () => {
+    const user = userEvent.setup()
+    mockUseReleases.mockReturnValue({
+      data: {
+        releases: [makeListItem({ id: 7, title: 'Editable' })],
+        total: 1,
+        limit: 50,
+        offset: 0,
+      },
+      isLoading: false,
+      error: null,
+    })
+    mockUseRelease.mockReturnValue({
+      data: makeDetail({ id: 7, title: 'Editable' }),
+      isLoading: false,
+    })
+    renderWithProviders(<ReleaseManagement />)
+
+    // The pencil icon button is the first action button on the row.
+    const editButtons = screen.getAllByRole('button')
+    const pencil = editButtons.find((b) =>
+      b.querySelector('.lucide-pencil')
+    )
+    expect(pencil).toBeDefined()
+    await user.click(pencil!)
+
+    const dialog = await screen.findByRole('dialog')
+    expect(within(dialog).getByText('Edit Release')).toBeInTheDocument()
+    expect(within(dialog).getByDisplayValue('Editable')).toBeInTheDocument()
+  })
+
+  it('opens the delete confirmation with the release title', async () => {
+    const user = userEvent.setup()
+    mockUseReleases.mockReturnValue({
+      data: {
+        releases: [makeListItem({ id: 9, title: 'Doomed Release' })],
+        total: 1,
+        limit: 50,
+        offset: 0,
+      },
+      isLoading: false,
+      error: null,
+    })
+    renderWithProviders(<ReleaseManagement />)
+
+    const trashButton = screen
+      .getAllByRole('button')
+      .find((b) => b.querySelector('.lucide-trash2'))
+    expect(trashButton).toBeDefined()
+    await user.click(trashButton!)
+
+    const dialog = await screen.findByRole('dialog')
+    // "Delete Release" is both the dialog title and the confirm button.
+    expect(
+      within(dialog).getByRole('heading', { name: 'Delete Release' })
+    ).toBeInTheDocument()
+    expect(within(dialog).getByText(/Doomed Release/)).toBeInTheDocument()
+  })
+
+  it('calls the delete mutation when confirmed', async () => {
+    const user = userEvent.setup()
+    mockUseReleases.mockReturnValue({
+      data: {
+        releases: [makeListItem({ id: 9, title: 'Doomed Release' })],
+        total: 1,
+        limit: 50,
+        offset: 0,
+      },
+      isLoading: false,
+      error: null,
+    })
+    renderWithProviders(<ReleaseManagement />)
+
+    const trashButton = screen
+      .getAllByRole('button')
+      .find((b) => b.querySelector('.lucide-trash2'))
+    await user.click(trashButton!)
+
+    const dialog = await screen.findByRole('dialog')
+    await user.click(
+      within(dialog).getByRole('button', { name: 'Delete Release' })
+    )
+
+    expect(mockDelete).toHaveBeenCalledWith(9, expect.anything())
+  })
+})

--- a/frontend/features/releases/api.test.ts
+++ b/frontend/features/releases/api.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// Pin API_BASE_URL so endpoint assertions are deterministic regardless of env.
+vi.mock('@/lib/api-base', () => ({
+  API_BASE_URL: 'http://api.test',
+}))
+
+import { releaseEndpoints, releaseQueryKeys } from './api'
+
+describe('releaseEndpoints', () => {
+  it('builds static collection endpoints', () => {
+    expect(releaseEndpoints.LIST).toBe('http://api.test/releases')
+    expect(releaseEndpoints.SEARCH).toBe('http://api.test/releases/search')
+    expect(releaseEndpoints.CREATE).toBe('http://api.test/releases')
+  })
+
+  it('builds a detail endpoint from a slug', () => {
+    expect(releaseEndpoints.GET('ok-computer')).toBe(
+      'http://api.test/releases/ok-computer'
+    )
+  })
+
+  it('builds a detail endpoint from a numeric id', () => {
+    expect(releaseEndpoints.GET(42)).toBe('http://api.test/releases/42')
+  })
+
+  it('builds update and delete endpoints by id', () => {
+    expect(releaseEndpoints.UPDATE(7)).toBe('http://api.test/releases/7')
+    expect(releaseEndpoints.DELETE(7)).toBe('http://api.test/releases/7')
+  })
+
+  it('builds nested link endpoints', () => {
+    expect(releaseEndpoints.ADD_LINK(7)).toBe(
+      'http://api.test/releases/7/links'
+    )
+    expect(releaseEndpoints.REMOVE_LINK(7, 99)).toBe(
+      'http://api.test/releases/7/links/99'
+    )
+  })
+
+  it('builds the artist-releases endpoint', () => {
+    expect(releaseEndpoints.ARTIST_RELEASES('radiohead')).toBe(
+      'http://api.test/artists/radiohead/releases'
+    )
+  })
+})
+
+describe('releaseQueryKeys', () => {
+  it('exposes a stable root key', () => {
+    expect(releaseQueryKeys.all).toEqual(['releases'])
+  })
+
+  it('namespaces list keys under releases with the filter object', () => {
+    const filters = { releaseType: 'lp' }
+    expect(releaseQueryKeys.list(filters)).toEqual([
+      'releases',
+      'list',
+      filters,
+    ])
+  })
+
+  it('allows an undefined filter for the unfiltered list', () => {
+    expect(releaseQueryKeys.list()).toEqual(['releases', 'list', undefined])
+  })
+
+  it('lowercases search query keys for cache stability', () => {
+    expect(releaseQueryKeys.search('Radiohead')).toEqual([
+      'releases',
+      'search',
+      'radiohead',
+    ])
+  })
+
+  it('stringifies detail keys so id and slug share a cache shape', () => {
+    expect(releaseQueryKeys.detail(42)).toEqual([
+      'releases',
+      'detail',
+      '42',
+    ])
+    expect(releaseQueryKeys.detail('ok-computer')).toEqual([
+      'releases',
+      'detail',
+      'ok-computer',
+    ])
+  })
+
+  it('stringifies artist-releases keys', () => {
+    expect(releaseQueryKeys.artistReleases(5)).toEqual([
+      'releases',
+      'artist',
+      '5',
+    ])
+  })
+})

--- a/frontend/features/releases/components/ReleaseCard.test.tsx
+++ b/frontend/features/releases/components/ReleaseCard.test.tsx
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ReleaseCard } from './ReleaseCard'
+import type { ReleaseListItem } from '../types'
+
+// next/link → plain anchor so href assertions work in jsdom.
+vi.mock('next/link', () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string
+    children: React.ReactNode
+    [key: string]: unknown
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}))
+
+// EntityCardTitle renders the title as a link in comfortable/expanded modes.
+vi.mock('@/components/shared', () => ({
+  EntityCardTitle: ({ name, href }: { name: string; href: string }) => (
+    <a href={href} data-testid="entity-card-title">
+      {name}
+    </a>
+  ),
+}))
+
+function makeRelease(overrides: Partial<ReleaseListItem> = {}): ReleaseListItem {
+  return {
+    id: 1,
+    title: 'In Rainbows',
+    slug: 'in-rainbows',
+    release_type: 'lp',
+    release_year: 2007,
+    cover_art_url: 'https://example.com/in-rainbows.jpg',
+    artist_count: 1,
+    artists: [{ id: 1, name: 'Radiohead', slug: 'radiohead' }],
+    label_name: 'XL Recordings',
+    label_slug: 'xl-recordings',
+    ...overrides,
+  }
+}
+
+describe('ReleaseCard', () => {
+  it('renders as an article element', () => {
+    render(<ReleaseCard release={makeRelease()} />)
+    expect(screen.getByRole('article')).toBeInTheDocument()
+  })
+
+  it('renders the cover art with descriptive alt text', () => {
+    render(<ReleaseCard release={makeRelease()} />)
+    const img = screen.getByAltText('In Rainbows cover art')
+    expect(img).toHaveAttribute('src', 'https://example.com/in-rainbows.jpg')
+  })
+
+  it('renders the release type label, not the raw type', () => {
+    render(<ReleaseCard release={makeRelease({ release_type: 'ep' })} />)
+    expect(screen.getByText('EP')).toBeInTheDocument()
+  })
+
+  it('renders the release year', () => {
+    render(<ReleaseCard release={makeRelease()} />)
+    expect(screen.getByText('2007')).toBeInTheDocument()
+  })
+
+  it('links the title to the release detail page', () => {
+    render(<ReleaseCard release={makeRelease()} />)
+    const title = screen.getByTestId('entity-card-title')
+    expect(title).toHaveAttribute('href', '/releases/in-rainbows')
+  })
+
+  it('links a single artist to its artist page', () => {
+    render(<ReleaseCard release={makeRelease()} />)
+    const artist = screen.getByText('Radiohead')
+    expect(artist.closest('a')).toHaveAttribute('href', '/artists/radiohead')
+  })
+
+  it('links the label to its label page when a slug is present', () => {
+    render(<ReleaseCard release={makeRelease()} />)
+    const label = screen.getByText('XL Recordings')
+    expect(label.closest('a')).toHaveAttribute('href', '/labels/xl-recordings')
+  })
+
+  it('renders the label as plain text when there is no slug', () => {
+    render(
+      <ReleaseCard
+        release={makeRelease({ label_name: 'Self-Released', label_slug: null })}
+      />
+    )
+    const label = screen.getByText('Self-Released')
+    expect(label.closest('a')).toBeNull()
+  })
+
+  it('collapses 4+ artists to "Various Artists"', () => {
+    const release = makeRelease({
+      artists: [
+        { id: 1, name: 'A', slug: 'a' },
+        { id: 2, name: 'B', slug: 'b' },
+        { id: 3, name: 'C', slug: 'c' },
+        { id: 4, name: 'D', slug: 'd' },
+      ],
+      artist_count: 4,
+    })
+    render(<ReleaseCard release={release} />)
+    expect(screen.getByText('Various Artists')).toBeInTheDocument()
+    expect(screen.queryByText('A')).not.toBeInTheDocument()
+  })
+
+  it('joins 2-3 artist names with commas', () => {
+    const release = makeRelease({
+      artists: [
+        { id: 1, name: 'First', slug: 'first' },
+        { id: 2, name: 'Second', slug: 'second' },
+      ],
+      artist_count: 2,
+    })
+    render(<ReleaseCard release={release} />)
+    expect(screen.getByText('First')).toBeInTheDocument()
+    expect(screen.getByText('Second')).toBeInTheDocument()
+  })
+
+  describe('placeholder when no cover art', () => {
+    it('renders no img element', () => {
+      const { container } = render(
+        <ReleaseCard release={makeRelease({ cover_art_url: null })} />
+      )
+      expect(container.querySelector('img')).toBeNull()
+    })
+  })
+
+  describe('missing year', () => {
+    it('omits the year when null', () => {
+      render(<ReleaseCard release={makeRelease({ release_year: null })} />)
+      expect(screen.queryByText('2007')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('compact density', () => {
+    it('renders a flat row without a card border', () => {
+      render(<ReleaseCard release={makeRelease()} density="compact" />)
+      const article = screen.getByRole('article')
+      expect(article.className).toContain('hover:bg-muted/50')
+      expect(article.className).not.toContain('border')
+    })
+
+    it('renders the title inline with the artist name', () => {
+      render(<ReleaseCard release={makeRelease()} density="compact" />)
+      // Compact mode renders "Artist — Title" in a single link.
+      expect(
+        screen.getByText('Radiohead — In Rainbows')
+      ).toBeInTheDocument()
+    })
+
+    it('renders just the title when there are no artists', () => {
+      render(
+        <ReleaseCard
+          release={makeRelease({ artists: [], artist_count: 0 })}
+          density="compact"
+        />
+      )
+      expect(screen.getByText('In Rainbows')).toBeInTheDocument()
+    })
+  })
+
+  describe('expanded density', () => {
+    it('renders a bordered card', () => {
+      render(<ReleaseCard release={makeRelease()} density="expanded" />)
+      const article = screen.getByRole('article')
+      expect(article.className).toContain('border')
+      expect(article.className).toContain('p-6')
+    })
+
+    it('still renders cover art and title link', () => {
+      render(<ReleaseCard release={makeRelease()} density="expanded" />)
+      expect(screen.getByAltText('In Rainbows cover art')).toBeInTheDocument()
+      expect(screen.getByTestId('entity-card-title')).toHaveAttribute(
+        'href',
+        '/releases/in-rainbows'
+      )
+    })
+  })
+
+  describe('comfortable density (default)', () => {
+    it('renders a bordered card with p-4 padding', () => {
+      render(<ReleaseCard release={makeRelease()} />)
+      const article = screen.getByRole('article')
+      expect(article.className).toContain('border')
+      expect(article.className).toContain('p-4')
+    })
+  })
+})

--- a/frontend/features/releases/components/ReleaseDetail.test.tsx
+++ b/frontend/features/releases/components/ReleaseDetail.test.tsx
@@ -1,0 +1,409 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ReleaseDetail } from './ReleaseDetail'
+import type { ReleaseDetail as ReleaseDetailType } from '../types'
+
+// next/link → plain anchor.
+vi.mock('next/link', () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string
+    children: React.ReactNode
+    [key: string]: unknown
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}))
+
+// useRelease drives all three render states.
+const mockUseRelease = vi.fn()
+vi.mock('../hooks/useReleases', () => ({
+  useRelease: (opts: unknown) => mockUseRelease(opts),
+}))
+
+const mockUseIsAuthenticated = vi.fn(() => ({
+  user: null as unknown,
+  isAuthenticated: false,
+}))
+vi.mock('@/features/auth', () => ({
+  useIsAuthenticated: () => mockUseIsAuthenticated(),
+}))
+
+const mockInvalidateQueries = vi.fn()
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ invalidateQueries: mockInvalidateQueries }),
+}))
+
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    releases: {
+      detail: (id: string | number) => ['releases', 'detail', String(id)],
+    },
+  },
+}))
+
+// EntityDetailLayout must render header + sidebar + children so their content
+// is assertable in the same tree.
+vi.mock('@/components/shared', () => ({
+  EntityDetailLayout: ({
+    header,
+    sidebar,
+    children,
+  }: {
+    header: React.ReactNode
+    sidebar: React.ReactNode
+    children: React.ReactNode
+  }) => (
+    <div>
+      <div data-testid="header">{header}</div>
+      <aside data-testid="sidebar">{sidebar}</aside>
+      <main>{children}</main>
+    </div>
+  ),
+  EntityHeader: ({
+    title,
+    subtitle,
+    actions,
+  }: {
+    title: string
+    subtitle?: React.ReactNode
+    actions?: React.ReactNode
+  }) => (
+    <div>
+      <h1>{title}</h1>
+      {subtitle && <div>{subtitle}</div>}
+      {actions && <div>{actions}</div>}
+    </div>
+  ),
+  RevisionHistory: ({ entityType }: { entityType: string }) => (
+    <div data-testid="revision-history">{entityType} revisions</div>
+  ),
+  AddToCollectionButton: () => (
+    <button data-testid="add-to-collection">Collect</button>
+  ),
+  BracketLink: ({ label, onClick }: { label: string; onClick: () => void }) => (
+    <button onClick={onClick}>{label}</button>
+  ),
+}))
+
+vi.mock('@/features/contributions', () => ({
+  AttributionLine: () => null,
+  ContributionPrompt: () => null,
+  EntityEditDrawer: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="edit-drawer">Edit Drawer</div> : null,
+  EntitySaveSuccessBanner: ({ visible }: { visible: boolean }) =>
+    visible ? <div data-testid="save-banner">Saved</div> : null,
+  useEntitySaveSuccessBanner: () => ({
+    isVisible: false,
+    handleSaveSuccess: vi.fn(),
+  }),
+}))
+
+vi.mock('@/features/tags', () => ({
+  EntityTagList: () => <div data-testid="entity-tag-list" />,
+  AddTagDialog: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="add-tag-dialog">Add Tag</div> : null,
+}))
+
+vi.mock('@/features/radio', () => ({
+  AsHeardOn: ({
+    entityType,
+    entitySlug,
+  }: {
+    entityType: string
+    entitySlug: string
+  }) => (
+    <div data-testid="as-heard-on">
+      Radio plays: {entityType}/{entitySlug}
+    </div>
+  ),
+}))
+
+vi.mock('@/features/collections', () => ({
+  EntityCollections: () => <div data-testid="entity-collections" />,
+}))
+
+vi.mock('@/features/comments', () => ({
+  CommentThread: ({
+    entityType,
+    entityId,
+  }: {
+    entityType: string
+    entityId: number
+  }) => (
+    <div data-testid="comment-thread">
+      Comments for {entityType} {entityId}
+    </div>
+  ),
+}))
+
+vi.mock('@/components/ui/badge', () => ({
+  Badge: ({ children }: { children: React.ReactNode }) => (
+    <span>{children}</span>
+  ),
+}))
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({
+    children,
+    asChild,
+    ...props
+  }: {
+    children: React.ReactNode
+    asChild?: boolean
+    [key: string]: unknown
+  }) => {
+    if (asChild) return <>{children}</>
+    return <button {...props}>{children}</button>
+  },
+}))
+
+function makeRelease(
+  overrides: Partial<ReleaseDetailType> = {}
+): ReleaseDetailType {
+  return {
+    id: 1,
+    title: 'In Rainbows',
+    slug: 'in-rainbows',
+    release_type: 'lp',
+    release_year: 2007,
+    release_date: '2007-10-10',
+    cover_art_url: 'https://example.com/in-rainbows.jpg',
+    description: 'The seventh studio album.',
+    artists: [
+      { id: 1, slug: 'radiohead', name: 'Radiohead', role: 'main' },
+    ],
+    labels: [
+      { id: 1, name: 'XL Recordings', slug: 'xl-recordings', catalog_number: 'XLLP324' },
+    ],
+    external_links: [
+      { id: 1, platform: 'bandcamp', url: 'https://radiohead.bandcamp.com' },
+      { id: 2, platform: 'spotify', url: 'https://open.spotify.com/album/x' },
+    ],
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('ReleaseDetail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseIsAuthenticated.mockReturnValue({
+      user: null,
+      isAuthenticated: false,
+    })
+  })
+
+  describe('loading state', () => {
+    it('shows a spinner while loading', () => {
+      mockUseRelease.mockReturnValue({
+        data: undefined,
+        isLoading: true,
+        error: null,
+      })
+      const { container } = render(<ReleaseDetail idOrSlug="in-rainbows" />)
+      expect(container.querySelector('.animate-spin')).toBeInTheDocument()
+    })
+  })
+
+  describe('error state', () => {
+    it('renders a generic error message', () => {
+      mockUseRelease.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        error: new Error('Something broke'),
+      })
+      render(<ReleaseDetail idOrSlug="in-rainbows" />)
+      expect(screen.getByText('Error Loading Release')).toBeInTheDocument()
+      expect(screen.getByText('Something broke')).toBeInTheDocument()
+    })
+
+    it('renders a not-found message for 404-style errors', () => {
+      mockUseRelease.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        error: new Error('release not found'),
+      })
+      render(<ReleaseDetail idOrSlug="missing" />)
+      expect(screen.getByText('Release Not Found')).toBeInTheDocument()
+    })
+
+    it('offers a back-to-releases link on error', () => {
+      mockUseRelease.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        error: new Error('boom'),
+      })
+      render(<ReleaseDetail idOrSlug="x" />)
+      expect(
+        screen.getByText('Back to Releases').closest('a')
+      ).toHaveAttribute('href', '/releases')
+    })
+  })
+
+  describe('no data state', () => {
+    it('renders not-found when data is null', () => {
+      mockUseRelease.mockReturnValue({
+        data: null,
+        isLoading: false,
+        error: null,
+      })
+      render(<ReleaseDetail idOrSlug="x" />)
+      expect(screen.getByText('Release Not Found')).toBeInTheDocument()
+    })
+  })
+
+  describe('with release data', () => {
+    beforeEach(() => {
+      mockUseRelease.mockReturnValue({
+        data: makeRelease(),
+        isLoading: false,
+        error: null,
+      })
+    })
+
+    it('renders the release title as a heading', () => {
+      render(<ReleaseDetail idOrSlug="in-rainbows" />)
+      expect(
+        screen.getByRole('heading', { level: 1, name: 'In Rainbows' })
+      ).toBeInTheDocument()
+    })
+
+    it('renders the cover art in the sidebar', () => {
+      render(<ReleaseDetail idOrSlug="in-rainbows" />)
+      const img = screen.getByAltText('In Rainbows cover art')
+      expect(img).toHaveAttribute('src', 'https://example.com/in-rainbows.jpg')
+    })
+
+    it('renders the description', () => {
+      render(<ReleaseDetail idOrSlug="in-rainbows" />)
+      expect(
+        screen.getByText('The seventh studio album.')
+      ).toBeInTheDocument()
+    })
+
+    it('renders artists linked to their pages', () => {
+      render(<ReleaseDetail idOrSlug="in-rainbows" />)
+      const artist = screen.getByRole('link', { name: 'Radiohead' })
+      expect(artist).toHaveAttribute('href', '/artists/radiohead')
+    })
+
+    it('renders the formatted release date', () => {
+      render(<ReleaseDetail idOrSlug="in-rainbows" />)
+      // Day can shift by one in non-UTC test runners since the date string is
+      // parsed as UTC midnight; match month + year, which are stable.
+      expect(screen.getByText(/Released:\s+October \d+, 2007/)).toBeInTheDocument()
+    })
+
+    it('renders a label with its catalog number', () => {
+      render(<ReleaseDetail idOrSlug="in-rainbows" />)
+      expect(screen.getByText('XL Recordings')).toBeInTheDocument()
+      expect(screen.getByText('(XLLP324)')).toBeInTheDocument()
+    })
+
+    it('renders external listen/buy links with mapped platform labels', () => {
+      render(<ReleaseDetail idOrSlug="in-rainbows" />)
+      const bandcamp = screen.getByText('Bandcamp').closest('a')
+      expect(bandcamp).toHaveAttribute(
+        'href',
+        'https://radiohead.bandcamp.com'
+      )
+      expect(screen.getByText('Spotify')).toBeInTheDocument()
+    })
+
+    it('renders the radio "As Heard On" panel for the release slug', () => {
+      render(<ReleaseDetail idOrSlug="in-rainbows" />)
+      expect(
+        screen.getByText('Radio plays: release/in-rainbows')
+      ).toBeInTheDocument()
+    })
+
+    it('renders the comment thread bound to the release id', () => {
+      render(<ReleaseDetail idOrSlug="in-rainbows" />)
+      expect(
+        screen.getByText('Comments for release 1')
+      ).toBeInTheDocument()
+    })
+
+    it('does not render edit affordances for anonymous users', () => {
+      render(<ReleaseDetail idOrSlug="in-rainbows" />)
+      expect(screen.queryByText('Edit')).not.toBeInTheDocument()
+      expect(screen.queryByText('Suggest edit')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('contributor affordances', () => {
+    it('shows "Suggest edit" for a signed-in non-privileged user', () => {
+      mockUseIsAuthenticated.mockReturnValue({
+        user: { is_admin: false, user_tier: 'contributor' },
+        isAuthenticated: true,
+      })
+      mockUseRelease.mockReturnValue({
+        data: makeRelease(),
+        isLoading: false,
+        error: null,
+      })
+      render(<ReleaseDetail idOrSlug="in-rainbows" />)
+      expect(screen.getByText('Suggest edit')).toBeInTheDocument()
+    })
+
+    it('shows "Edit" for an admin who can edit directly', () => {
+      mockUseIsAuthenticated.mockReturnValue({
+        user: { is_admin: true },
+        isAuthenticated: true,
+      })
+      mockUseRelease.mockReturnValue({
+        data: makeRelease(),
+        isLoading: false,
+        error: null,
+      })
+      render(<ReleaseDetail idOrSlug="in-rainbows" />)
+      expect(screen.getByText('Edit')).toBeInTheDocument()
+    })
+
+    it('offers "Suggest description" when the release has no description', () => {
+      mockUseIsAuthenticated.mockReturnValue({
+        user: { is_admin: false, user_tier: 'contributor' },
+        isAuthenticated: true,
+      })
+      mockUseRelease.mockReturnValue({
+        data: makeRelease({ description: null }),
+        isLoading: false,
+        error: null,
+      })
+      render(<ReleaseDetail idOrSlug="in-rainbows" />)
+      expect(screen.getByText('Suggest description')).toBeInTheDocument()
+    })
+  })
+
+  describe('optional fields omitted', () => {
+    beforeEach(() => {
+      mockUseRelease.mockReturnValue({
+        data: makeRelease({
+          description: null,
+          external_links: [],
+          labels: [],
+          release_date: null,
+        }),
+        isLoading: false,
+        error: null,
+      })
+    })
+
+    it('omits the About section without a description', () => {
+      render(<ReleaseDetail idOrSlug="in-rainbows" />)
+      expect(screen.queryByText('About')).not.toBeInTheDocument()
+    })
+
+    it('omits the Listen / Buy section without external links', () => {
+      render(<ReleaseDetail idOrSlug="in-rainbows" />)
+      expect(screen.queryByText('Listen / Buy')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/features/releases/components/ReleaseList.test.tsx
+++ b/frontend/features/releases/components/ReleaseList.test.tsx
@@ -1,0 +1,301 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders } from '@/test/utils'
+import type { ReleaseListItem } from '../types'
+
+// next/navigation: URL params drive every filter in this component.
+const mockPush = vi.fn()
+const mockGet = vi.fn()
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+  useSearchParams: () => ({ get: mockGet }),
+}))
+
+const mockUseReleases = vi.fn()
+vi.mock('../hooks/useReleases', () => ({
+  useReleases: (opts: unknown) => mockUseReleases(opts),
+}))
+
+const mockUseLabels = vi.fn()
+vi.mock('@/features/labels/hooks/useLabels', () => ({
+  useLabels: () => mockUseLabels(),
+}))
+
+const mockUseDensity = vi.fn()
+vi.mock('@/lib/hooks/common/useDensity', () => ({
+  useDensity: (key: string) => mockUseDensity(key),
+}))
+
+// ReleaseCard is exercised by its own sibling test; stub it to a title marker.
+vi.mock('./ReleaseCard', () => ({
+  ReleaseCard: ({ release }: { release: ReleaseListItem }) => (
+    <div data-testid="release-card">{release.title}</div>
+  ),
+}))
+
+vi.mock('@/components/shared', () => ({
+  LoadingSpinner: () => <div data-testid="loading-spinner">Loading...</div>,
+  DensityToggle: ({ density }: { density: string }) => (
+    <div data-testid="density-toggle">{density}</div>
+  ),
+}))
+
+vi.mock('@/features/tags', () => ({
+  TagFacetPanel: () => <div data-testid="tag-facet-panel" />,
+  TagFacetSheet: () => <div data-testid="tag-facet-sheet" />,
+  parseTagsParam: (s: string | null) => (s ? s.split(',').filter(Boolean) : []),
+  buildTagsParam: (slugs: string[]) => slugs.join(','),
+}))
+
+import { ReleaseList } from './ReleaseList'
+
+function makeRelease(overrides: Partial<ReleaseListItem> = {}): ReleaseListItem {
+  return {
+    id: 1,
+    title: 'In Rainbows',
+    slug: 'in-rainbows',
+    release_type: 'lp',
+    release_year: 2007,
+    cover_art_url: null,
+    artist_count: 1,
+    artists: [{ id: 1, name: 'Radiohead', slug: 'radiohead' }],
+    label_name: 'XL Recordings',
+    label_slug: 'xl-recordings',
+    ...overrides,
+  }
+}
+
+describe('ReleaseList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGet.mockReturnValue(null)
+    mockUseDensity.mockReturnValue({
+      density: 'comfortable',
+      setDensity: vi.fn(),
+    })
+    mockUseLabels.mockReturnValue({ data: { labels: [] } })
+    mockUseReleases.mockReturnValue({
+      data: { releases: [], total: 0, limit: 50, offset: 0 },
+      isLoading: false,
+      isFetching: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+  })
+
+  it('shows the loading spinner on initial load', () => {
+    mockUseReleases.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isFetching: true,
+      error: null,
+      refetch: vi.fn(),
+    })
+    renderWithProviders(<ReleaseList />)
+    expect(screen.getByTestId('loading-spinner')).toBeInTheDocument()
+  })
+
+  it('renders the density toggle with the current density', () => {
+    renderWithProviders(<ReleaseList />)
+    expect(screen.getByTestId('density-toggle')).toHaveTextContent(
+      'comfortable'
+    )
+  })
+
+  it('renders the unfiltered empty state', () => {
+    renderWithProviders(<ReleaseList />)
+    expect(
+      screen.getByText('No releases available at this time.')
+    ).toBeInTheDocument()
+  })
+
+  it('renders the filtered empty state when a type filter is set', () => {
+    mockGet.mockImplementation((key: string) => (key === 'type' ? 'lp' : null))
+    renderWithProviders(<ReleaseList />)
+    expect(
+      screen.getByText('No releases found matching your filters.')
+    ).toBeInTheDocument()
+    expect(screen.getByText('View all releases')).toBeInTheDocument()
+  })
+
+  it('renders release cards when data is available', () => {
+    mockUseReleases.mockReturnValue({
+      data: {
+        releases: [
+          makeRelease({ id: 1, title: 'In Rainbows' }),
+          makeRelease({ id: 2, title: 'Kid A', slug: 'kid-a' }),
+        ],
+        total: 2,
+        limit: 50,
+        offset: 0,
+      },
+      isLoading: false,
+      isFetching: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+    renderWithProviders(<ReleaseList />)
+    expect(screen.getByText('In Rainbows')).toBeInTheDocument()
+    expect(screen.getByText('Kid A')).toBeInTheDocument()
+  })
+
+  it('renders the result count with correct pluralization', () => {
+    mockUseReleases.mockReturnValue({
+      data: {
+        releases: [makeRelease()],
+        total: 1,
+        limit: 50,
+        offset: 0,
+      },
+      isLoading: false,
+      isFetching: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+    renderWithProviders(<ReleaseList />)
+    expect(screen.getByTestId('release-count')).toHaveTextContent('1 release')
+  })
+
+  it('shows the error state with a retry button', () => {
+    mockUseReleases.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isFetching: false,
+      error: new Error('Network error'),
+      refetch: vi.fn(),
+    })
+    renderWithProviders(<ReleaseList />)
+    expect(
+      screen.getByText('Failed to load releases. Please try again later.')
+    ).toBeInTheDocument()
+    expect(screen.getByText('Retry')).toBeInTheDocument()
+  })
+
+  it('calls refetch when the retry button is clicked', async () => {
+    const user = userEvent.setup()
+    const refetch = vi.fn()
+    mockUseReleases.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isFetching: false,
+      error: new Error('Network error'),
+      refetch,
+    })
+    renderWithProviders(<ReleaseList />)
+    await user.click(screen.getByText('Retry'))
+    expect(refetch).toHaveBeenCalledOnce()
+  })
+
+  it('renders the label dropdown when labels are available', () => {
+    mockUseLabels.mockReturnValue({
+      data: {
+        labels: [
+          { id: 1, name: 'XL Recordings' },
+          { id: 2, name: 'Sub Pop' },
+        ],
+      },
+    })
+    renderWithProviders(<ReleaseList />)
+    expect(screen.getByText('All Labels')).toBeInTheDocument()
+    expect(screen.getByText('Sub Pop')).toBeInTheDocument()
+  })
+
+  it('does not render the label dropdown when there are no labels', () => {
+    mockUseLabels.mockReturnValue({ data: { labels: [] } })
+    renderWithProviders(<ReleaseList />)
+    expect(screen.queryByText('All Labels')).not.toBeInTheDocument()
+  })
+
+  it('passes URL filters through to useReleases', () => {
+    mockGet.mockImplementation((key: string) => {
+      const params: Record<string, string> = {
+        type: 'ep',
+        year: '2020',
+        search: 'rainbows',
+        sort: 'oldest',
+        label_id: '3',
+      }
+      return params[key] ?? null
+    })
+    renderWithProviders(<ReleaseList />)
+    expect(mockUseReleases).toHaveBeenCalledWith(
+      expect.objectContaining({
+        releaseType: 'ep',
+        year: 2020,
+        search: 'rainbows',
+        sort: 'oldest',
+        labelId: 3,
+      })
+    )
+  })
+
+  it('parses tags from the URL and passes them with AND semantics by default', () => {
+    mockGet.mockImplementation((key: string) =>
+      key === 'tags' ? 'post-punk,shoegaze' : null
+    )
+    renderWithProviders(<ReleaseList />)
+    expect(mockUseReleases).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tags: ['post-punk', 'shoegaze'],
+        tagMatch: 'all',
+      })
+    )
+  })
+
+  it('honors tag_match=any from the URL', () => {
+    mockGet.mockImplementation((key: string) => {
+      if (key === 'tags') return 'post-punk'
+      if (key === 'tag_match') return 'any'
+      return null
+    })
+    renderWithProviders(<ReleaseList />)
+    expect(mockUseReleases).toHaveBeenCalledWith(
+      expect.objectContaining({ tagMatch: 'any' })
+    )
+  })
+
+  it('computes the page offset from the page URL param', () => {
+    mockGet.mockImplementation((key: string) => (key === 'page' ? '3' : null))
+    renderWithProviders(<ReleaseList />)
+    // Page 3 with PAGE_SIZE 50 → offset 100.
+    expect(mockUseReleases).toHaveBeenCalledWith(
+      expect.objectContaining({ offset: 100, limit: 50 })
+    )
+  })
+
+  it('renders pagination controls when there is more than one page', () => {
+    mockUseReleases.mockReturnValue({
+      data: {
+        releases: [makeRelease()],
+        total: 120,
+        limit: 50,
+        offset: 0,
+      },
+      isLoading: false,
+      isFetching: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+    renderWithProviders(<ReleaseList />)
+    expect(screen.getByText('Page 1 of 3')).toBeInTheDocument()
+    expect(screen.getByText('Next')).toBeInTheDocument()
+  })
+
+  it('does not render pagination for a single page of results', () => {
+    mockUseReleases.mockReturnValue({
+      data: {
+        releases: [makeRelease()],
+        total: 10,
+        limit: 50,
+        offset: 0,
+      },
+      isLoading: false,
+      isFetching: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+    renderWithProviders(<ReleaseList />)
+    expect(screen.queryByText(/Page \d+ of/)).not.toBeInTheDocument()
+  })
+})

--- a/frontend/features/releases/hooks/useAdminReleases.test.tsx
+++ b/frontend/features/releases/hooks/useAdminReleases.test.tsx
@@ -1,0 +1,321 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { createWrapper } from '@/test/utils'
+
+const mockApiRequest = vi.fn()
+const mockInvalidateReleases = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+}))
+
+vi.mock('@/features/releases/api', () => ({
+  releaseEndpoints: {
+    CREATE: '/releases',
+    UPDATE: (id: string | number) => `/releases/${id}`,
+    DELETE: (id: string | number) => `/releases/${id}`,
+    ADD_LINK: (id: string | number) => `/releases/${id}/links`,
+    REMOVE_LINK: (id: string | number, linkId: string | number) =>
+      `/releases/${id}/links/${linkId}`,
+  },
+}))
+
+// createInvalidateQueries(queryClient).releases() is the cache-bust path all
+// five admin mutations share on success.
+vi.mock('@/lib/queryClient', () => ({
+  createInvalidateQueries: () => ({
+    releases: mockInvalidateReleases,
+  }),
+}))
+
+import {
+  useCreateRelease,
+  useUpdateRelease,
+  useDeleteRelease,
+  useAddReleaseLink,
+  useRemoveReleaseLink,
+} from './useAdminReleases'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockApiRequest.mockReset()
+  mockInvalidateReleases.mockReset()
+})
+
+describe('useCreateRelease', () => {
+  it('POSTs the release payload to the create endpoint', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 1, title: 'New LP' })
+
+    const { result } = renderHook(() => useCreateRelease(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ title: 'New LP', release_type: 'lp' })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/releases', {
+      method: 'POST',
+      body: JSON.stringify({ title: 'New LP', release_type: 'lp' }),
+    })
+  })
+
+  it('invalidates the releases cache on success', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 1, title: 'New LP' })
+
+    const { result } = renderHook(() => useCreateRelease(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ title: 'New LP' })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockInvalidateReleases).toHaveBeenCalledTimes(1)
+  })
+
+  it('surfaces errors and does not invalidate the cache', async () => {
+    mockApiRequest.mockRejectedValueOnce(new Error('Validation failed'))
+
+    const { result } = renderHook(() => useCreateRelease(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ title: '' })
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect((result.current.error as Error).message).toBe('Validation failed')
+    expect(mockInvalidateReleases).not.toHaveBeenCalled()
+  })
+
+  it('reports a pending state while in flight', async () => {
+    let resolve!: (value: unknown) => void
+    mockApiRequest.mockReturnValueOnce(
+      new Promise((r) => {
+        resolve = r
+      })
+    )
+
+    const { result } = renderHook(() => useCreateRelease(), {
+      wrapper: createWrapper(),
+    })
+
+    act(() => {
+      result.current.mutate({ title: 'Pending' })
+    })
+
+    await waitFor(() => expect(result.current.isPending).toBe(true))
+
+    await act(async () => {
+      resolve({ id: 2, title: 'Pending' })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+  })
+})
+
+describe('useUpdateRelease', () => {
+  it('PUTs the update payload to the id-scoped endpoint', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 7, title: 'Edited' })
+
+    const { result } = renderHook(() => useUpdateRelease(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({
+        releaseId: 7,
+        data: { title: 'Edited', release_year: null },
+      })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/releases/7', {
+      method: 'PUT',
+      body: JSON.stringify({ title: 'Edited', release_year: null }),
+    })
+  })
+
+  it('invalidates the releases cache on success', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 7, title: 'Edited' })
+
+    const { result } = renderHook(() => useUpdateRelease(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ releaseId: 7, data: { title: 'Edited' } })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockInvalidateReleases).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not invalidate the cache on error', async () => {
+    mockApiRequest.mockRejectedValueOnce(new Error('Not found'))
+
+    const { result } = renderHook(() => useUpdateRelease(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ releaseId: 999, data: { title: 'X' } })
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(mockInvalidateReleases).not.toHaveBeenCalled()
+  })
+})
+
+describe('useDeleteRelease', () => {
+  it('DELETEs the id-scoped endpoint', async () => {
+    mockApiRequest.mockResolvedValueOnce(undefined)
+
+    const { result } = renderHook(() => useDeleteRelease(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(42)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/releases/42', {
+      method: 'DELETE',
+    })
+  })
+
+  it('invalidates the releases cache on success', async () => {
+    mockApiRequest.mockResolvedValueOnce(undefined)
+
+    const { result } = renderHook(() => useDeleteRelease(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(1)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockInvalidateReleases).toHaveBeenCalledTimes(1)
+  })
+
+  it('propagates delete errors without invalidating', async () => {
+    mockApiRequest.mockRejectedValueOnce(new Error('Conflict'))
+
+    const { result } = renderHook(() => useDeleteRelease(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(1)
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(mockInvalidateReleases).not.toHaveBeenCalled()
+  })
+})
+
+describe('useAddReleaseLink', () => {
+  it('POSTs platform + url to the links endpoint', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      id: 5,
+      platform: 'bandcamp',
+      url: 'https://x.bandcamp.com',
+    })
+
+    const { result } = renderHook(() => useAddReleaseLink(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({
+        releaseId: 7,
+        platform: 'bandcamp',
+        url: 'https://x.bandcamp.com',
+      })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/releases/7/links', {
+      method: 'POST',
+      body: JSON.stringify({
+        platform: 'bandcamp',
+        url: 'https://x.bandcamp.com',
+      }),
+    })
+  })
+
+  it('invalidates the releases cache on success', async () => {
+    mockApiRequest.mockResolvedValueOnce({ id: 5 })
+
+    const { result } = renderHook(() => useAddReleaseLink(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ releaseId: 7, platform: 'spotify', url: 'https://s' })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockInvalidateReleases).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('useRemoveReleaseLink', () => {
+  it('DELETEs the nested link endpoint', async () => {
+    mockApiRequest.mockResolvedValueOnce(undefined)
+
+    const { result } = renderHook(() => useRemoveReleaseLink(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ releaseId: 7, linkId: 99 })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/releases/7/links/99', {
+      method: 'DELETE',
+    })
+  })
+
+  it('invalidates the releases cache on success', async () => {
+    mockApiRequest.mockResolvedValueOnce(undefined)
+
+    const { result } = renderHook(() => useRemoveReleaseLink(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ releaseId: 7, linkId: 99 })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockInvalidateReleases).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not invalidate the cache on error', async () => {
+    mockApiRequest.mockRejectedValueOnce(new Error('Server error'))
+
+    const { result } = renderHook(() => useRemoveReleaseLink(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ releaseId: 7, linkId: 99 })
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(mockInvalidateReleases).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/features/releases/types.test.ts
+++ b/frontend/features/releases/types.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import {
+  getReleaseTypeLabel,
+  RELEASE_TYPE_LABELS,
+  RELEASE_TYPES,
+  RELEASE_SORT_OPTIONS,
+} from './types'
+import type { ReleaseType, ReleaseSortOption } from './types'
+
+describe('getReleaseTypeLabel', () => {
+  it('maps every known release type to its display label', () => {
+    const expected: Record<ReleaseType, string> = {
+      lp: 'LP',
+      ep: 'EP',
+      single: 'Single',
+      compilation: 'Compilation',
+      live: 'Live',
+      remix: 'Remix',
+      demo: 'Demo',
+    }
+    for (const [type, label] of Object.entries(expected)) {
+      expect(getReleaseTypeLabel(type)).toBe(label)
+    }
+  })
+
+  it('falls back to the uppercased value for an unknown type', () => {
+    expect(getReleaseTypeLabel('mixtape')).toBe('MIXTAPE')
+  })
+
+  it('uppercases an unknown lowercase string', () => {
+    expect(getReleaseTypeLabel('split')).toBe('SPLIT')
+  })
+
+  it('returns an empty string unchanged (uppercase of empty is empty)', () => {
+    expect(getReleaseTypeLabel('')).toBe('')
+  })
+})
+
+describe('RELEASE_TYPES / RELEASE_TYPE_LABELS', () => {
+  it('lists every type that has a label, with no extras', () => {
+    expect([...RELEASE_TYPES].sort()).toEqual(
+      Object.keys(RELEASE_TYPE_LABELS).sort()
+    )
+  })
+
+  it('has a non-empty label for every type in the list', () => {
+    for (const type of RELEASE_TYPES) {
+      expect(RELEASE_TYPE_LABELS[type]).toBeTruthy()
+    }
+  })
+})
+
+describe('RELEASE_SORT_OPTIONS', () => {
+  it('exposes the five browse sort options with stable values', () => {
+    const values = RELEASE_SORT_OPTIONS.map(o => o.value)
+    const expected: ReleaseSortOption[] = [
+      'newest',
+      'oldest',
+      'title_asc',
+      'title_desc',
+      'recently_added',
+    ]
+    expect(values).toEqual(expected)
+  })
+
+  it('pairs every value with a human label', () => {
+    for (const option of RELEASE_SORT_OPTIONS) {
+      expect(option.label.length).toBeGreaterThan(0)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Add sibling tests for the 7 previously-untested files in `frontend/features/releases/`: `types.ts`, `api.ts`, `components/ReleaseCard.tsx`, `components/ReleaseList.tsx`, `components/ReleaseDetail.tsx`, `hooks/useAdminReleases.ts`, and `admin/ReleaseManagement.tsx`. Every non-barrel source file now has a sibling test (115 tests across 8 files).
- Components render representative release data — cover art, artists, external links, labels, and the radio "As Heard On" panel. Hooks cover success/error/loading. The five admin mutations assert releases-cache invalidation on success and no invalidation on error.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run test:run features/releases` — 115/115 passing

## Manual repro
Test-only diff; no runtime change. Passing suite IS the verification.

## Simplify
Ran. Test code was largely clean. Fixed one inaccurate locator comment in the admin test. Per-file fixture factories were left duplicated intentionally — that matches the established codebase convention (ShowCard/VenueDetail/ArtistList each define local factories; no shared fixtures module exists). No ticket-ref comments leaked.

Closes PSY-688