### PR TITLE
PSY-684: cover app/shows/[slug]/page.tsx server component

### DIFF
--- a/frontend/app/shows/[slug]/page.test.tsx
+++ b/frontend/app/shows/[slug]/page.test.tsx
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import * as Sentry from '@sentry/nextjs'
+
+// `notFound()` in Next.js throws a control-flow error to halt rendering. We
+// mirror that here so tests can assert BOTH that it was called and that
+// execution stopped (no JSON-LD / ShowDetail render after a 404).
+const NOT_FOUND_SENTINEL = 'NEXT_NOT_FOUND'
+const notFoundMock = vi.fn(() => {
+  throw new Error(NOT_FOUND_SENTINEL)
+})
+
+vi.mock('next/navigation', () => ({
+  notFound: () => notFoundMock(),
+}))
+
+vi.mock('@sentry/nextjs', () => ({
+  captureMessage: vi.fn(),
+  captureException: vi.fn(),
+}))
+
+// Stub the heavy shows feature module so invoking the page body doesn't pull
+// in the real ShowDetail render path — this ticket exercises the page-level
+// metadata + JSON-LD + notFound wiring, not ShowDetail.
+vi.mock('@/features/shows', () => ({
+  ShowDetail: () => null,
+}))
+
+import ShowPage, { generateMetadata } from './page'
+
+// Minimal show payload — only the fields generateMetadata / the page body read.
+function buildShow(overrides: Record<string, unknown> = {}) {
+  return {
+    title: 'Test Show',
+    event_date: '2026-03-15T20:00:00Z',
+    slug: 'test-show',
+    description: null,
+    is_sold_out: false,
+    is_cancelled: false,
+    venues: [{ name: 'The Rebel Lounge', slug: 'the-rebel-lounge', city: 'Phoenix', state: 'AZ' }],
+    artists: [
+      { name: 'Headliner Band', slug: 'headliner-band', is_headliner: true, socials: {} },
+    ],
+    ...overrides,
+  }
+}
+
+function okResponse(body: unknown): Response {
+  return { ok: true, status: 200, json: async () => body } as unknown as Response
+}
+
+function errorResponse(status: number): Response {
+  return { ok: false, status, json: async () => ({}) } as unknown as Response
+}
+
+const fetchMock = vi.fn()
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('generateMetadata', () => {
+  it('uses "{headliner} at {venue}" as the title when the show is found', async () => {
+    fetchMock.mockResolvedValueOnce(okResponse(buildShow()))
+
+    const meta = await generateMetadata({ params: Promise.resolve({ slug: 'test-show' }) })
+
+    expect(meta.title).toBe('Headliner Band at The Rebel Lounge')
+  })
+
+  it('prefers the headliner over the first artist for the title', async () => {
+    fetchMock.mockResolvedValueOnce(
+      okResponse(
+        buildShow({
+          artists: [
+            { name: 'Opener', slug: 'opener', is_headliner: false, socials: {} },
+            { name: 'Real Headliner', slug: 'real-headliner', is_headliner: true, socials: {} },
+          ],
+        })
+      )
+    )
+
+    const meta = await generateMetadata({ params: Promise.resolve({ slug: 'test-show' }) })
+
+    expect(meta.title).toBe('Real Headliner at The Rebel Lounge')
+  })
+
+  it('falls back to the "Show" title when the show is missing', async () => {
+    fetchMock.mockResolvedValueOnce(errorResponse(404))
+
+    const meta = await generateMetadata({ params: Promise.resolve({ slug: 'missing' }) })
+
+    expect(meta.title).toBe('Show')
+    expect(meta.description).toBe('View show details')
+    // No canonical alternate on the fallback shape.
+    expect(meta.alternates).toBeUndefined()
+  })
+
+  it('truncates a long description at 155 chars and appends "..."', async () => {
+    const longDescription = 'x'.repeat(300)
+    fetchMock.mockResolvedValueOnce(okResponse(buildShow({ description: longDescription })))
+
+    const meta = await generateMetadata({ params: Promise.resolve({ slug: 'test-show' }) })
+
+    expect(meta.description).toBe('x'.repeat(155) + '...')
+    expect(meta.description).toHaveLength(158)
+  })
+
+  it('does not append "..." when the description is exactly 155 chars', async () => {
+    const exactDescription = 'y'.repeat(155)
+    fetchMock.mockResolvedValueOnce(okResponse(buildShow({ description: exactDescription })))
+
+    const meta = await generateMetadata({ params: Promise.resolve({ slug: 'test-show' }) })
+
+    expect(meta.description).toBe(exactDescription)
+    expect(meta.description).toHaveLength(155)
+  })
+
+  it('generates a description from show details when none is provided', async () => {
+    fetchMock.mockResolvedValueOnce(okResponse(buildShow({ description: null })))
+
+    const meta = await generateMetadata({ params: Promise.resolve({ slug: 'test-show' }) })
+
+    // Generated form: "{headliner} live at {venue} on {date}".
+    expect(meta.description).toContain('Headliner Band live at The Rebel Lounge on')
+  })
+
+  it('sets the canonical URL to https://psychichomily.com/shows/{slug}', async () => {
+    fetchMock.mockResolvedValueOnce(okResponse(buildShow()))
+
+    const meta = await generateMetadata({ params: Promise.resolve({ slug: 'test-show' }) })
+
+    expect(meta.alternates?.canonical).toBe('https://psychichomily.com/shows/test-show')
+    expect(meta.openGraph?.url).toBe('/shows/test-show')
+  })
+})
+
+describe('ShowPage', () => {
+  it('calls notFound() when the slug is empty (post-PSY-733)', async () => {
+    await expect(
+      ShowPage({ params: Promise.resolve({ slug: '' }) })
+    ).rejects.toThrow(NOT_FOUND_SENTINEL)
+
+    expect(notFoundMock).toHaveBeenCalledTimes(1)
+    // Empty slug short-circuits before any fetch.
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('calls notFound() when getShow returns null (404 from API)', async () => {
+    fetchMock.mockResolvedValueOnce(errorResponse(404))
+
+    await expect(
+      ShowPage({ params: Promise.resolve({ slug: 'missing' }) })
+    ).rejects.toThrow(NOT_FOUND_SENTINEL)
+
+    expect(notFoundMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders without calling notFound() when the show is found', async () => {
+    fetchMock.mockResolvedValueOnce(okResponse(buildShow()))
+
+    const result = await ShowPage({ params: Promise.resolve({ slug: 'test-show' }) })
+
+    expect(notFoundMock).not.toHaveBeenCalled()
+    expect(result).toBeTruthy()
+  })
+})
+
+describe('getShow error reporting (via the page body)', () => {
+  it('reports a 5xx response with Sentry.captureMessage and then 404s', async () => {
+    fetchMock.mockResolvedValueOnce(errorResponse(503))
+
+    await expect(
+      ShowPage({ params: Promise.resolve({ slug: 'boom' }) })
+    ).rejects.toThrow(NOT_FOUND_SENTINEL)
+
+    expect(Sentry.captureMessage).toHaveBeenCalledTimes(1)
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      'Show page: API returned 503',
+      expect.objectContaining({
+        level: 'error',
+        tags: { service: 'show-page' },
+        extra: { slug: 'boom', status: 503 },
+      })
+    )
+    // 5xx is reported, not swallowed as an exception.
+    expect(Sentry.captureException).not.toHaveBeenCalled()
+  })
+
+  it('does NOT report a 404 response to Sentry', async () => {
+    fetchMock.mockResolvedValueOnce(errorResponse(404))
+
+    await expect(
+      ShowPage({ params: Promise.resolve({ slug: 'missing' }) })
+    ).rejects.toThrow(NOT_FOUND_SENTINEL)
+
+    expect(Sentry.captureMessage).not.toHaveBeenCalled()
+    expect(Sentry.captureException).not.toHaveBeenCalled()
+  })
+
+  it('reports a thrown fetch error with Sentry.captureException and then 404s', async () => {
+    const networkError = new Error('network down')
+    fetchMock.mockRejectedValueOnce(networkError)
+
+    await expect(
+      ShowPage({ params: Promise.resolve({ slug: 'flaky' }) })
+    ).rejects.toThrow(NOT_FOUND_SENTINEL)
+
+    expect(Sentry.captureException).toHaveBeenCalledTimes(1)
+    expect(Sentry.captureException).toHaveBeenCalledWith(
+      networkError,
+      expect.objectContaining({
+        level: 'error',
+        tags: { service: 'show-page' },
+        extra: { slug: 'flaky' },
+      })
+    )
+    expect(Sentry.captureMessage).not.toHaveBeenCalled()
+  })
+
+  it('captures a 5xx in generateMetadata as well (both call sites share getShow)', async () => {
+    fetchMock.mockResolvedValueOnce(errorResponse(500))
+
+    const meta = await generateMetadata({ params: Promise.resolve({ slug: 'boom' }) })
+
+    // generateMetadata swallows the null and returns the fallback shape.
+    expect(meta.title).toBe('Show')
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      'Show page: API returned 500',
+      expect.objectContaining({ extra: { slug: 'boom', status: 500 } })
+    )
+  })
+})

--- a/frontend/app/shows/[slug]/page.test.tsx
+++ b/frontend/app/shows/[slug]/page.test.tsx
@@ -140,7 +140,8 @@ describe('generateMetadata', () => {
 })
 
 describe('ShowPage', () => {
-  it('calls notFound() when the slug is empty (post-PSY-733)', async () => {
+  // An empty slug 404s rather than rendering an inline placeholder.
+  it('calls notFound() when the slug is empty', async () => {
     await expect(
       ShowPage({ params: Promise.resolve({ slug: '' }) })
     ).rejects.toThrow(NOT_FOUND_SENTINEL)


### PR DESCRIPTION
## Summary
- Add `frontend/app/shows/[slug]/page.test.tsx` covering the shows detail server component (`generateMetadata` + page body + `getShow` error reporting).
- `generateMetadata`: `"{headliner} at {venue}"` title (headliner preferred over first artist), `'Show'` fallback when missing, 155-char description truncation with `...`, generated-description fallback, canonical/OG URL.
- Page body: `notFound()` on empty slug (current post-PSY-733 behavior — short-circuits before fetch) and on null data; renders when found.
- `getShow` Sentry wiring across both call sites: 5xx -> `captureMessage`, thrown fetch -> `captureException`, 404 -> no report.

## Test plan
- [x] `bun run test:run app/shows` passes (14 tests)
- [x] `bun run typecheck` clean
- [x] `/simplify` run (manual fallback; Agent tool unavailable in thread)

## Manual repro
Test-only diff; no runtime behavior change. The `bun run test:run app/shows` suite (14 tests) is the verification. Server-component bodies + `generateMetadata` are invoked directly as async functions; no dev stack/browser applicable.

## Simplify
Manual three-lens fallback (parallel-reviewer Agent tool unavailable inside a dispatched agent). Stripped a `(post-PSY-733)` ticket ref from a comment/test name per the strip-ticket-refs convention; kept the semantic WHY. Committed separately. No reuse/efficiency findings (first server-component page test of this shape; inline Sentry mock matches convention).

Closes PSY-684

🤖 Generated with [Claude Code](https://claude.com/claude-code)
