### PR TITLE
PSY-769: dedup export/restore shows on full timestamp

### DIFF
--- a/backend/internal/services/admin/data_sync.go
+++ b/backend/internal/services/admin/data_sync.go
@@ -509,16 +509,16 @@ func (s *DataSyncService) importShow(show *contracts.ExportedShow, dryRun bool) 
 		venueName = show.Venues[0].Name
 	}
 
-	// Check for duplicate: same title + venue + date
+	// Check for duplicate: same title + venue + event_date. The dedup key is the
+	// full event_date timestamp (not the calendar day), so a matinee and an evening
+	// show at the same title/venue are distinct rows rather than a false duplicate.
+	// EventDate round-trips through RFC3339 on export/import, preserving time-of-day.
 	if venueName != "" {
-		startOfDay := time.Date(eventDate.Year(), eventDate.Month(), eventDate.Day(), 0, 0, 0, 0, time.UTC)
-		endOfDay := startOfDay.Add(24 * time.Hour)
-
 		var existingShow catalogm.Show
 		err := s.db.Joins("JOIN show_venues ON shows.id = show_venues.show_id").
 			Joins("JOIN venues ON show_venues.venue_id = venues.id").
-			Where("LOWER(shows.title) = LOWER(?) AND LOWER(venues.name) = LOWER(?) AND shows.event_date >= ? AND shows.event_date < ?",
-				show.Title, venueName, startOfDay, endOfDay).
+			Where("LOWER(shows.title) = LOWER(?) AND LOWER(venues.name) = LOWER(?) AND shows.event_date = ?",
+				show.Title, venueName, eventDate).
 			First(&existingShow).Error
 		if err == nil {
 			// Backfill slugs for the existing show and its associated entities

--- a/backend/internal/services/admin/data_sync_test.go
+++ b/backend/internal/services/admin/data_sync_test.go
@@ -607,6 +607,42 @@ func (suite *DataSyncServiceIntegrationTestSuite) TestImportShow_Duplicate() {
 	suite.Contains(result.Shows.Messages[0], "DUPLICATE")
 }
 
+func (suite *DataSyncServiceIntegrationTestSuite) TestImportShow_SameDayDifferentTime_NotDuplicate() {
+	// A matinee and an evening show with the same title+venue on the same calendar
+	// day differ only in time-of-day. They are distinct shows, not duplicates: the
+	// dedup gate keys on the full event_date timestamp, so the second import must be
+	// created rather than skipped.
+	venue := suite.createVenue("Matinee Venue", "NYC", "NY", true)
+	day := time.Date(2025, 6, 15, 0, 0, 0, 0, time.UTC)
+	matinee := day.Add(15 * time.Hour) // 15:00 UTC
+	evening := day.Add(21 * time.Hour) // 21:00 UTC
+	existing := suite.createShow("Same Day Show", matinee, catalogm.ShowStatusApproved, venue)
+
+	result, err := suite.service.ImportData(contracts.DataImportRequest{
+		Shows: []contracts.ExportedShow{
+			{
+				Title:     "Same Day Show",
+				EventDate: evening.Format(time.RFC3339),
+				Status:    "approved",
+				Venues:    []contracts.ExportedVenue{{Name: "Matinee Venue", City: "NYC", State: "NY"}},
+			},
+		},
+	})
+	suite.Require().NoError(err)
+	suite.Equal(1, result.Shows.Imported)
+	suite.Equal(0, result.Shows.Duplicates)
+
+	// Both the matinee and the newly imported evening show persist as distinct rows.
+	var count int64
+	suite.db.Model(&catalogm.Show{}).Where("title = ?", "Same Day Show").Count(&count)
+	suite.Equal(int64(2), count)
+
+	var eveningShow catalogm.Show
+	err = suite.db.Where("title = ? AND event_date = ?", "Same Day Show", evening).First(&eveningShow).Error
+	suite.Require().NoError(err)
+	suite.NotEqual(existing.ID, eveningShow.ID)
+}
+
 func (suite *DataSyncServiceIntegrationTestSuite) TestImportShow_DuplicateBackfillSlugs() {
 	// Create entities without slugs
 	venue := &catalogm.Venue{Name: "No Slug Venue", City: "NYC", State: "NY", Verified: true}

--- a/backend/internal/services/admin/data_sync_test.go
+++ b/backend/internal/services/admin/data_sync_test.go
@@ -613,9 +613,8 @@ func (suite *DataSyncServiceIntegrationTestSuite) TestImportShow_SameDayDifferen
 	// dedup gate keys on the full event_date timestamp, so the second import must be
 	// created rather than skipped.
 	venue := suite.createVenue("Matinee Venue", "NYC", "NY", true)
-	day := time.Date(2025, 6, 15, 0, 0, 0, 0, time.UTC)
-	matinee := day.Add(15 * time.Hour) // 15:00 UTC
-	evening := day.Add(21 * time.Hour) // 21:00 UTC
+	matinee := time.Date(2025, 6, 15, 15, 0, 0, 0, time.UTC)
+	evening := time.Date(2025, 6, 15, 21, 0, 0, 0, time.UTC)
 	existing := suite.createShow("Same Day Show", matinee, catalogm.ShowStatusApproved, venue)
 
 	result, err := suite.service.ImportData(contracts.DataImportRequest{


### PR DESCRIPTION
## Summary
- `admin/data_sync.go` `importShow` was the last instance of the same-day-range show-dedup anti-pattern (PSY-752 fixed the three genuine dedup-rejection gates in `catalog/show.go` and `pipeline/discovery.go`).
- The dedup gate computed a start-of-day/end-of-day window and matched `event_date` within that range, discarding the time component. This contradicts the PSY-559 dedup key (full `event_date TIMESTAMPTZ`): a legitimate matinee + evening pair at the same title/venue was false-flagged as a duplicate, so the second show was **silently skipped on restore**.
- Replaced the range with exact-timestamp equality (`event_date = ?`).

### Why this site is a genuine gate (not a documented exemption like PSY-752's site #4)
PSY-752 exempted its `CheckEvents` site because its input was **date-only** (`YYYY-MM-DD`, no time-of-day) and it was read-only. This site is different on both counts:
- **Genuine gate**: on match it returns `"duplicate"` and skips the import (backfills slugs only) — it rejects/skips, never just reads.
- **Full-timestamp input**: `ExportedShow.EventDate` round-trips through RFC3339 — export does `show.EventDate.Format(time.RFC3339)` (data_sync.go:117), import does `time.Parse(time.RFC3339, ...)` (data_sync.go:501), preserving time-of-day. So exact equality is correct and possible here with no contract/wire-format change.

## Test plan
- [x] `cd backend && go build ./...` (exit 0)
- [x] `cd backend && go test ./internal/services/admin/...` (PASS)
- [x] `cd backend && go test ./...` (full suite — 27 packages `ok`, exit 0, zero FAIL)

## Manual repro
The new regression test **is** the repro (backend-only, no migration):
`TestImportShow_SameDayDifferentTime_NotDuplicate` — seeds a matinee at `2025-06-15 15:00:00 UTC`, then imports the same title+venue at `2025-06-15 21:00:00 UTC`. Before: the evening import was flagged `DUPLICATE` and skipped. After: it's imported as a distinct row (asserts `Imported == 1`, `Duplicates == 0`, two rows persist, `eveningShow.ID != existing.ID`). The GORM query log confirms the gate now matches `shows.event_date = '2025-06-15 21:00:00'`. PASS.

Existing same-timestamp dedup still works: `TestImportShow_Duplicate` and `TestImportShow_DuplicateBackfillSlugs` (identical timestamps) still flag true duplicates. PASS.

## Simplify
Ran the three-lens review (reuse / quality / efficiency). One edit: replaced `day.Add(15*time.Hour)` + redundant `// 15:00 UTC` narration comments in the new test with direct `time.Date(...)` literals, matching PSY-752's canonical `TestCreateShow_SameDayDifferentTime_OK`. No reuse or efficiency issues — the fix reuses the already-parsed `eventDate` and GORM's existing parameter binding.

Closes PSY-769