### PR TITLE
PSY-763: route comment sanitizer through canonical MarkdownRenderer

### DIFF
--- a/backend/internal/services/container.go
+++ b/backend/internal/services/container.go
@@ -15,6 +15,7 @@ import (
 	"psychic-homily-backend/internal/services/notification"
 	"psychic-homily-backend/internal/services/pipeline"
 	usersvc "psychic-homily-backend/internal/services/user"
+	"psychic-homily-backend/internal/utils"
 )
 
 // ServiceContainer eagerly creates all services once at startup.
@@ -140,7 +141,7 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 
 	// PSY-289: wire the comment notifier into the comment service so new
 	// comments fan out notification emails fire-and-forget.
-	commentSvc := engagement.NewCommentService(database)
+	commentSvc := engagement.NewCommentService(database, utils.NewMarkdownRenderer())
 	commentNotificationSvc := engagement.NewCommentNotificationService(database, email, cfg.JWT.SecretKey, cfg.Email.FrontendURL)
 	commentSvc.SetNotifier(commentNotificationSvc)
 

--- a/backend/internal/services/engagement/comment_notification_test.go
+++ b/backend/internal/services/engagement/comment_notification_test.go
@@ -16,6 +16,7 @@ import (
 	engagementm "psychic-homily-backend/internal/models/engagement"
 	"psychic-homily-backend/internal/services/contracts"
 	"psychic-homily-backend/internal/testutil"
+	"psychic-homily-backend/internal/utils"
 )
 
 // =============================================================================
@@ -321,7 +322,7 @@ func (s *CommentNotificationServiceIntegrationSuite) TearDownSuite() {
 func (s *CommentNotificationServiceIntegrationSuite) SetupTest() {
 	s.mock = &captureEmailService{configured: true}
 	s.svc = NewCommentNotificationService(s.db, s.mock, "test-secret", "http://localhost:3000")
-	s.comment = NewCommentService(s.db)
+	s.comment = NewCommentService(s.db, utils.NewMarkdownRenderer())
 }
 
 func (s *CommentNotificationServiceIntegrationSuite) TearDownTest() {

--- a/backend/internal/services/engagement/comment_service.go
+++ b/backend/internal/services/engagement/comment_service.go
@@ -87,9 +87,9 @@ func (s *CommentService) SetFollowChecker(fc FollowChecker) {
 	s.followChecker = fc
 }
 
-// renderMarkdown converts a comment/field-note body to sanitized HTML via the
-// canonical utils.MarkdownRenderer. Falls back to a freshly-constructed renderer
-// when the service was built without one (older bare-construction test paths).
+// renderMarkdown delegates to the canonical utils.MarkdownRenderer. Falls back
+// to a freshly-constructed renderer when the service was built without one
+// (older bare-construction test paths).
 func (s *CommentService) renderMarkdown(body string) string {
 	if s.markdownRenderer == nil {
 		s.markdownRenderer = utils.NewMarkdownRenderer()

--- a/backend/internal/services/engagement/comment_service.go
+++ b/backend/internal/services/engagement/comment_service.go
@@ -1,7 +1,6 @@
 package engagement
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -11,8 +10,6 @@ import (
 
 	"log"
 
-	"github.com/microcosm-cc/bluemonday"
-	"github.com/yuin/goldmark"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 
@@ -21,6 +18,7 @@ import (
 	engagementm "psychic-homily-backend/internal/models/engagement"
 	"psychic-homily-backend/internal/services/contracts"
 	"psychic-homily-backend/internal/services/shared"
+	"psychic-homily-backend/internal/utils"
 )
 
 // FollowChecker is the minimal FollowService surface that CommentService
@@ -41,10 +39,13 @@ type commentNotifier interface {
 
 // CommentService implements CommentServiceInterface for comment CRUD and threading.
 type CommentService struct {
-	db            *gorm.DB
-	md            goldmark.Markdown
-	sanitize      *bluemonday.Policy
-	followChecker FollowChecker
+	db *gorm.DB
+	// markdownRenderer is the shared utils.MarkdownRenderer (goldmark +
+	// bluemonday, comment-system allowlist) used to render comment and field-note
+	// bodies on write. Routing through the canonical renderer keeps the
+	// sanitization policy single-sourced — future policy hardening lands once.
+	markdownRenderer *utils.MarkdownRenderer
+	followChecker    FollowChecker
 	// notifier is optional — tests often leave it nil. Production wires it
 	// via SetNotifier() after both services are constructed.
 	notifier commentNotifier
@@ -61,25 +62,16 @@ func (s *CommentService) SetNotifier(n commentNotifier) {
 }
 
 // NewCommentService creates a new CommentService.
-func NewCommentService(db *gorm.DB) *CommentService {
-	// Create sanitization policy: allow safe formatting, no images/raw HTML/tables
-	policy := bluemonday.NewPolicy()
-	policy.AllowStandardURLs()
-	policy.AllowAttrs("href").OnElements("a")
-	policy.AllowElements("p", "br",
-		"strong", "b", "em", "i",
-		"code", "pre",
-		"ul", "ol", "li",
-		"blockquote",
-		"h3", "h4", "h5", "h6",
-	)
-	policy.RequireNoFollowOnLinks(true)
-	policy.AddTargetBlankToFullyQualifiedLinks(true)
-
+//
+// renderer is the canonical utils.MarkdownRenderer (goldmark + bluemonday,
+// comment-system allowlist) used to render comment and field-note bodies. It
+// is injected so the sanitization policy stays single-sourced; when nil
+// (older bare-construction test paths) renderMarkdown lazily falls back to a
+// fresh canonical renderer.
+func NewCommentService(db *gorm.DB, renderer *utils.MarkdownRenderer) *CommentService {
 	svc := &CommentService{
-		db:       db,
-		md:       goldmark.New(),
-		sanitize: policy,
+		db:               db,
+		markdownRenderer: renderer,
 	}
 	// Default FollowChecker is a FollowService bound to the same DB. Tests
 	// that construct CommentService without a DB get a nil checker; the
@@ -95,14 +87,14 @@ func (s *CommentService) SetFollowChecker(fc FollowChecker) {
 	s.followChecker = fc
 }
 
-// renderMarkdown converts markdown body to sanitized HTML.
+// renderMarkdown converts a comment/field-note body to sanitized HTML via the
+// canonical utils.MarkdownRenderer. Falls back to a freshly-constructed renderer
+// when the service was built without one (older bare-construction test paths).
 func (s *CommentService) renderMarkdown(body string) string {
-	var buf bytes.Buffer
-	if err := s.md.Convert([]byte(body), &buf); err != nil {
-		// Fallback: escape and wrap in <p> tag
-		return "<p>" + s.sanitize.Sanitize(body) + "</p>"
+	if s.markdownRenderer == nil {
+		s.markdownRenderer = utils.NewMarkdownRenderer()
 	}
-	return s.sanitize.Sanitize(buf.String())
+	return s.markdownRenderer.Render(body)
 }
 
 // wilsonScore computes the Wilson score lower bound for ranking.

--- a/backend/internal/services/engagement/comment_service_test.go
+++ b/backend/internal/services/engagement/comment_service_test.go
@@ -15,6 +15,7 @@ import (
 	engagementm "psychic-homily-backend/internal/models/engagement"
 	"psychic-homily-backend/internal/services/contracts"
 	"psychic-homily-backend/internal/testutil"
+	"psychic-homily-backend/internal/utils"
 )
 
 // =============================================================================
@@ -22,7 +23,7 @@ import (
 // =============================================================================
 
 func TestCommentService_NilDB(t *testing.T) {
-	svc := NewCommentService(nil)
+	svc := NewCommentService(nil, utils.NewMarkdownRenderer())
 
 	t.Run("CreateComment_NilDB", func(t *testing.T) {
 		_, err := svc.CreateComment(1, &contracts.CreateCommentRequest{
@@ -190,7 +191,7 @@ func TestCommentService_BodyValidation(t *testing.T) {
 }
 
 func TestMarkdownRendering(t *testing.T) {
-	svc := NewCommentService(nil)
+	svc := NewCommentService(nil, utils.NewMarkdownRenderer())
 
 	t.Run("Bold", func(t *testing.T) {
 		html := svc.renderMarkdown("**bold text**")
@@ -345,7 +346,7 @@ type CommentServiceIntegrationTestSuite struct {
 func (suite *CommentServiceIntegrationTestSuite) SetupSuite() {
 	suite.testDB = testutil.SetupTestPostgres(suite.T())
 	suite.db = suite.testDB.DB
-	suite.commentService = NewCommentService(suite.testDB.DB)
+	suite.commentService = NewCommentService(suite.testDB.DB, utils.NewMarkdownRenderer())
 }
 
 func (suite *CommentServiceIntegrationTestSuite) TearDownSuite() {

--- a/backend/internal/services/engagement/field_note_test.go
+++ b/backend/internal/services/engagement/field_note_test.go
@@ -15,6 +15,7 @@ import (
 	engagementm "psychic-homily-backend/internal/models/engagement"
 	"psychic-homily-backend/internal/services/contracts"
 	"psychic-homily-backend/internal/testutil"
+	"psychic-homily-backend/internal/utils"
 )
 
 // =============================================================================
@@ -22,7 +23,7 @@ import (
 // =============================================================================
 
 func TestFieldNote_NilDB(t *testing.T) {
-	svc := NewCommentService(nil)
+	svc := NewCommentService(nil, utils.NewMarkdownRenderer())
 
 	t.Run("CreateFieldNote_NilDB", func(t *testing.T) {
 		_, err := svc.CreateFieldNote(1, &contracts.CreateFieldNoteRequest{
@@ -148,7 +149,7 @@ type FieldNoteIntegrationTestSuite struct {
 func (suite *FieldNoteIntegrationTestSuite) SetupSuite() {
 	suite.testDB = testutil.SetupTestPostgres(suite.T())
 	suite.db = suite.testDB.DB
-	suite.commentService = NewCommentService(suite.testDB.DB)
+	suite.commentService = NewCommentService(suite.testDB.DB, utils.NewMarkdownRenderer())
 }
 
 func (suite *FieldNoteIntegrationTestSuite) TearDownSuite() {


### PR DESCRIPTION
## Summary
- `CommentService` built its own goldmark + bluemonday policy with a byte-identical allowlist to the canonical `utils.MarkdownRenderer`, violating the one-canonical-sanitizer convention. Risk: future policy hardening lands on one and silently leaves comments on the legacy policy.
- Inject `*utils.MarkdownRenderer` into `CommentService` via `NewCommentService`; `renderMarkdown` now delegates to `renderer.Render(body)` (with a defensive lazy-init fallback matching `community/collection.go`). The duplicate `goldmark`/`bluemonday`/`bytes` imports and inline policy builder are deleted.
- Wired the renderer at the container site; updated the 6 `NewCommentService` call sites (1 prod + 5 test).

Pure consolidation — render output is unchanged because both policies were identical.

## Test plan
- [x] `go build ./...` — clean (exit 0)
- [x] `go test ./internal/services/engagement/...` — `ok` (31.6s)
- [x] `go test ./...` — full suite green, all packages `ok`
- [x] `go vet ./internal/services/engagement/` — clean

## Manual repro
- [x] `go test ./internal/services/engagement/ -run TestMarkdownRendering -v` — all 12 subtests pass through the canonical renderer: bold→`<strong>`, italic→`<em>`, link href preserved, code block→`<pre>`/`<code>`, inline code, blockquote, lists, images stripped, `<script>` stripped, h3 allowed, h1/h2 stripped. Identical output to the old inline policy.
- [x] Field-note render assertions (`comment_service_test.go`, `field_note_test.go`: `<strong>bold</strong>`, `<em>italic</em>`) pass unchanged.

Backend-only, no migration — existing comment-render tests passing byte-identical IS the repro.

## Simplify
Ran `/simplify` (reuse / quality / efficiency lenses). The change itself is a reuse fix. Only edit: tightened the `renderMarkdown` doc comment to drop WHAT-narration and keep the non-obvious fallback WHY (separate commit). No logic changes; lazy-init fallback mirrors the established `collection.go` pattern.

Closes PSY-763