### PR TITLE
PSY-744: enforce session subject in JWT validation

### DIFF
--- a/backend/internal/services/auth/jwt.go
+++ b/backend/internal/services/auth/jwt.go
@@ -13,6 +13,18 @@ import (
 	"psychic-homily-backend/internal/services/contracts"
 )
 
+// Session JWT claim values. The issuer and audience are shared by every token
+// this service mints; the subject distinguishes a full session token from the
+// short-lived single-purpose tokens (email-verification, magic-link,
+// account-recovery). ValidateToken asserts all three so a leaked short-lived
+// token — which travels through email URLs, query strings, and browser history
+// — can never be replayed as a session credential.
+const (
+	jwtIssuer         = "psychic-homily-backend"
+	jwtAudience       = "psychic-homily-users"
+	jwtSessionSubject = "session"
+)
+
 type JWTService struct {
 	config      *config.Config
 	userService contracts.UserServiceInterface
@@ -32,8 +44,9 @@ func (s *JWTService) CreateToken(user *authm.User) (string, error) {
 		"email":   user.Email,
 		"exp":     time.Now().Add(time.Duration(s.config.JWT.Expiry) * time.Hour).Unix(),
 		"iat":     time.Now().Unix(),
-		"iss":     "psychic-homily-backend",
-		"aud":     "psychic-homily-users",
+		"iss":     jwtIssuer,
+		"aud":     jwtAudience,
+		"sub":     jwtSessionSubject,
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
@@ -43,12 +56,17 @@ func (s *JWTService) CreateToken(user *authm.User) (string, error) {
 // ValidateToken validates and extracts user info from JWT
 // Fetches the full user from the database to ensure we have current admin status
 func (s *JWTService) ValidateToken(tokenString string) (*authm.User, error) {
+	// Enforce the session subject, issuer, and audience as part of parsing.
+	// WithSubject/WithIssuer/WithAudience require the claim to exist and match,
+	// so single-purpose tokens (email-verification, magic-link,
+	// account-recovery) and legacy session tokens minted before the subject was
+	// added are rejected here rather than being honored as session credentials.
 	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 		}
 		return []byte(s.config.JWT.SecretKey), nil
-	})
+	}, jwt.WithIssuer(jwtIssuer), jwt.WithAudience(jwtAudience), jwt.WithSubject(jwtSessionSubject))
 
 	if err != nil {
 		if errors.Is(err, jwt.ErrTokenExpired) {
@@ -126,11 +144,15 @@ func (s *JWTService) ValidateTokenLenient(tokenString string, gracePeriod time.D
 		return nil, apperrors.ErrTokenExpired(fmt.Errorf("token expired beyond grace period"))
 	}
 
-	// Validate issuer and audience manually
+	// Validate subject, issuer, and audience manually. The without-validation
+	// parse above skips claim checks, so we must assert the session subject here
+	// too — otherwise a leaked single-purpose token (magic-link, verification,
+	// recovery) caught inside the grace window could be refreshed into a session.
+	sub, _ := claims["sub"].(string)
 	iss, _ := claims["iss"].(string)
 	aud, _ := claims["aud"].(string)
-	if iss != "psychic-homily-backend" || aud != "psychic-homily-users" {
-		return nil, apperrors.ErrTokenInvalid(fmt.Errorf("invalid token issuer or audience"))
+	if sub != jwtSessionSubject || iss != jwtIssuer || aud != jwtAudience {
+		return nil, apperrors.ErrTokenInvalid(fmt.Errorf("invalid token subject, issuer, or audience"))
 	}
 
 	// Token is within grace period — extract user

--- a/backend/internal/services/auth/jwt_lenient_test.go
+++ b/backend/internal/services/auth/jwt_lenient_test.go
@@ -88,7 +88,7 @@ func TestValidateTokenLenient(t *testing.T) {
 	})
 
 	t.Run("wrong_issuer_rejected", func(t *testing.T) {
-		// Token with wrong issuer
+		// Token with wrong issuer (subject/audience otherwise valid)
 		claims := jwt.MapClaims{
 			"user_id": float64(123),
 			"email":   "wrong-iss@example.com",
@@ -96,6 +96,7 @@ func TestValidateTokenLenient(t *testing.T) {
 			"iat":     time.Now().Add(-2 * time.Hour).Unix(),
 			"iss":     "wrong-issuer",
 			"aud":     "psychic-homily-users",
+			"sub":     "session",
 		}
 		token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 		tokenStr, err := token.SignedString([]byte(secretKey))
@@ -103,11 +104,11 @@ func TestValidateTokenLenient(t *testing.T) {
 
 		_, err = jwtService.ValidateTokenLenient(tokenStr, gracePeriod)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "invalid token issuer or audience")
+		assert.Contains(t, err.Error(), "invalid token subject, issuer, or audience")
 	})
 
 	t.Run("wrong_audience_rejected", func(t *testing.T) {
-		// Token with wrong audience
+		// Token with wrong audience (subject/issuer otherwise valid)
 		claims := jwt.MapClaims{
 			"user_id": float64(123),
 			"email":   "wrong-aud@example.com",
@@ -115,6 +116,7 @@ func TestValidateTokenLenient(t *testing.T) {
 			"iat":     time.Now().Add(-2 * time.Hour).Unix(),
 			"iss":     "psychic-homily-backend",
 			"aud":     "wrong-audience",
+			"sub":     "session",
 		}
 		token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 		tokenStr, err := token.SignedString([]byte(secretKey))
@@ -122,17 +124,39 @@ func TestValidateTokenLenient(t *testing.T) {
 
 		_, err = jwtService.ValidateTokenLenient(tokenStr, gracePeriod)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "invalid token issuer or audience")
+		assert.Contains(t, err.Error(), "invalid token subject, issuer, or audience")
+	})
+
+	t.Run("wrong_subject_rejected", func(t *testing.T) {
+		// Token with a non-session subject (issuer/audience otherwise valid) —
+		// e.g. a leaked magic-link token caught inside the grace window.
+		claims := jwt.MapClaims{
+			"user_id": float64(123),
+			"email":   "wrong-sub@example.com",
+			"exp":     time.Now().Add(-1 * time.Hour).Unix(),
+			"iat":     time.Now().Add(-2 * time.Hour).Unix(),
+			"iss":     "psychic-homily-backend",
+			"aud":     "psychic-homily-users",
+			"sub":     "magic-link",
+		}
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+		tokenStr, err := token.SignedString([]byte(secretKey))
+		require.NoError(t, err)
+
+		_, err = jwtService.ValidateTokenLenient(tokenStr, gracePeriod)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid token subject, issuer, or audience")
 	})
 
 	t.Run("missing_exp_claim_rejected", func(t *testing.T) {
-		// Token with no exp claim
+		// Token with no exp claim (session subject so it reaches the exp check)
 		claims := jwt.MapClaims{
 			"user_id": float64(123),
 			"email":   "no-exp@example.com",
 			"iat":     time.Now().Unix(),
 			"iss":     "psychic-homily-backend",
 			"aud":     "psychic-homily-users",
+			"sub":     "session",
 		}
 		token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 		tokenStr, err := token.SignedString([]byte(secretKey))
@@ -163,7 +187,9 @@ func TestValidateTokenLenient(t *testing.T) {
 	})
 }
 
-// createTestToken creates a JWT with specific expiration for testing
+// createTestToken creates a session-shaped JWT with a specific expiration for
+// testing. It mirrors CreateToken's claim set — including sub:"session" — so the
+// lenient validator's subject assertion treats it as a genuine session token.
 func createTestToken(t *testing.T, secretKey string, userID int, email string, exp time.Time) string {
 	t.Helper()
 	claims := jwt.MapClaims{
@@ -173,6 +199,7 @@ func createTestToken(t *testing.T, secretKey string, userID int, email string, e
 		"iat":     time.Now().Add(-2 * time.Hour).Unix(),
 		"iss":     "psychic-homily-backend",
 		"aud":     "psychic-homily-users",
+		"sub":     "session",
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	tokenStr, err := token.SignedString([]byte(secretKey))

--- a/backend/internal/services/auth/jwt_test.go
+++ b/backend/internal/services/auth/jwt_test.go
@@ -53,6 +53,7 @@ func TestJWTService_CreateToken(t *testing.T) {
 		assert.Equal(t, "test@example.com", claims["email"])
 		assert.Equal(t, "psychic-homily-backend", claims["iss"])
 		assert.Equal(t, "psychic-homily-users", claims["aud"])
+		assert.Equal(t, "session", claims["sub"])
 		assert.NotNil(t, claims["exp"])
 		assert.NotNil(t, claims["iat"])
 	})
@@ -225,6 +226,99 @@ func TestJWTService_ValidateToken(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "TOKEN_INVALID")
 		assert.Nil(t, validatedUser)
+	})
+}
+
+// TestJWTService_ValidateToken_RejectsCrossTypeTokens proves the session
+// validator refuses every other token the service mints (PSY-744). All four
+// issuers share the same HS256 secret and embed user_id, so before the subject
+// assertion a leaked single-purpose token was a usable session credential.
+// These tokens are rejected at claim validation, before any DB lookup — so the
+// nil-DB user service never gets a chance to mask the failure.
+func TestJWTService_ValidateToken_RejectsCrossTypeTokens(t *testing.T) {
+	secretKey := "test-secret-key-cross-type"
+	cfg := &config.Config{
+		JWT: config.JWTConfig{
+			SecretKey: secretKey,
+			Expiry:    24,
+		},
+	}
+	jwtService := NewJWTService(nil, cfg, newNilDBUserService())
+
+	t.Run("RejectsMagicLinkToken", func(t *testing.T) {
+		token, err := jwtService.CreateMagicLinkToken(123, "magic@example.com")
+		require.NoError(t, err)
+
+		user, err := jwtService.ValidateToken(token)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "TOKEN_INVALID")
+		assert.Nil(t, user)
+	})
+
+	t.Run("RejectsVerificationToken", func(t *testing.T) {
+		token, err := jwtService.CreateVerificationToken(123, "verify@example.com")
+		require.NoError(t, err)
+
+		user, err := jwtService.ValidateToken(token)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "TOKEN_INVALID")
+		assert.Nil(t, user)
+	})
+
+	t.Run("RejectsAccountRecoveryToken", func(t *testing.T) {
+		token, err := jwtService.CreateAccountRecoveryToken(123, "recover@example.com")
+		require.NoError(t, err)
+
+		user, err := jwtService.ValidateToken(token)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "TOKEN_INVALID")
+		assert.Nil(t, user)
+	})
+
+	// A token minted before PSY-744 — correct issuer/audience/user_id but no
+	// "sub" claim. Enforcing immediately (no grace window) means these are
+	// rejected the moment the change deploys, forcing affected users to re-login.
+	t.Run("RejectsLegacySessionTokenWithoutSubject", func(t *testing.T) {
+		claims := jwt.MapClaims{
+			"user_id": uint(123),
+			"email":   "legacy@example.com",
+			"exp":     time.Now().Add(24 * time.Hour).Unix(),
+			"iat":     time.Now().Unix(),
+			"iss":     "psychic-homily-backend",
+			"aud":     "psychic-homily-users",
+			// no "sub" — the pre-PSY-744 session token shape
+		}
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+		tokenStr, err := token.SignedString([]byte(secretKey))
+		require.NoError(t, err)
+
+		user, err := jwtService.ValidateToken(tokenStr)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "TOKEN_INVALID")
+		assert.Nil(t, user)
+	})
+
+	// A forged token with the right user_id but a non-session subject string
+	// must still be rejected — guards against future helpers picking a subject
+	// that isn't exactly "session".
+	t.Run("RejectsWrongSubjectString", func(t *testing.T) {
+		claims := jwt.MapClaims{
+			"user_id": uint(123),
+			"email":   "wrong-sub@example.com",
+			"exp":     time.Now().Add(24 * time.Hour).Unix(),
+			"iat":     time.Now().Unix(),
+			"iss":     "psychic-homily-backend",
+			"aud":     "psychic-homily-users",
+			"sub":     "not-a-session",
+		}
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+		tokenStr, err := token.SignedString([]byte(secretKey))
+		require.NoError(t, err)
+
+		user, err := jwtService.ValidateToken(tokenStr)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "TOKEN_INVALID")
+		assert.Nil(t, user)
 	})
 }
 


### PR DESCRIPTION
## Summary

`JWTService.ValidateToken` (the session validator) did not enforce `sub`/`iss`/`aud`. All four token issuers — `CreateToken`, `CreateVerificationToken`, `CreateMagicLinkToken`, `CreateAccountRecoveryToken` — mint HS256 tokens with the **same** `JWT.SecretKey` and embed `user_id`. So any intercepted short-lived token (which travels through email URLs, query strings, and browser history) was a usable session credential.

- `CreateToken` now sets `sub:"session"` alongside the existing `iss`/`aud`.
- `ValidateToken` enforces all three via `jwt.WithIssuer` / `jwt.WithAudience` / `jwt.WithSubject` parser options (v5.3.0 — each requires the claim to exist and match), so verification/magic-link/recovery tokens and legacy subject-less session tokens are rejected before the DB lookup.
- `ValidateTokenLenient` (refresh path) asserts the same session subject manually, since its without-validation fallback parse skips claim checks — closing the gap where a leaked single-purpose token caught inside the grace window could be refreshed into a session.
- Shared `iss`/`aud`/`sub` values extracted into package constants (`jwtIssuer`, `jwtAudience`, `jwtSessionSubject`).

**Forces re-login on deploy:** enforced immediately with no grace window / dual-accept. Session tokens minted before this change lack the `sub` claim and are rejected the moment it deploys — affected users re-authenticate. This closes the cross-type-token gap instantly.

The `gen-api-token` CLI and the API-token middleware path use the separate `phk_` `APITokenService` mechanism (DB-backed opaque tokens), not session JWTs, so they are unaffected.

## Test plan

- [x] `cd backend && go build ./...` — passes (exit 0)
- [x] `cd backend && go test ./internal/services/auth/...` — passes (unit + real-Postgres integration suite)
- [x] `cd backend && go test ./...` — full backend suite passes, zero FAIL (all packages `ok`, incl. `internal/api/middleware` which exercises `ValidateToken` through the auth middleware)

## Manual repro

The new unit tests in `TestJWTService_ValidateToken_RejectsCrossTypeTokens` ARE the repro — each mints a real token via the corresponding issuer, then asserts `ValidateToken` rejects it with `TOKEN_INVALID` and returns a nil user:

- `RejectsMagicLinkToken` — magic-link token → rejected ✓
- `RejectsVerificationToken` — email-verification token → rejected ✓
- `RejectsAccountRecoveryToken` — account-recovery token → rejected ✓
- `RejectsLegacySessionTokenWithoutSubject` — pre-PSY-744 session token (correct iss/aud/user_id, no `sub`) → rejected ✓ (demonstrates the forced re-login)
- `RejectsWrongSubjectString` — forged token with `sub:"not-a-session"` → rejected ✓

Positive path proven by the real-DB integration test `TestJWTIntegrationSuite/TestValidateToken_ReturnsCorrectUser`: a token from `CreateToken` (now carrying `sub:"session"`) still validates and returns the user. Lenient-path subject enforcement covered by the new `TestValidateTokenLenient/wrong_subject_rejected`.

## Simplify

`/simplify` run after the implementation commit; reviewed reuse/quality/efficiency. Code already clean (reuses library parser options, shared constants remove prior literal duplication, comments are WHY-focused, subject check precedes DB lookup). No edits made.

Closes PSY-744