### PR TITLE
PSY-749: stop magic-link send from leaking verification state

### DIFF
--- a/backend/internal/api/handlers/auth/auth.go
+++ b/backend/internal/api/handlers/auth/auth.go
@@ -739,9 +739,9 @@ type SendMagicLinkRequest struct {
 // SendMagicLinkResponse represents the response for sending a magic link
 type SendMagicLinkResponse struct {
 	Body struct {
-		Success   bool   `json:"success" example:"true" doc:"Success status"`
-		Message   string `json:"message" example:"Magic link sent" doc:"Response message"`
-		ErrorCode string `json:"error_code,omitempty" example:"EMAIL_NOT_VERIFIED" doc:"Error code for programmatic handling"`
+		Success   bool   `json:"success" example:"true" doc:"Success status. Always true for any well-formed request — the response never reveals whether the email is registered or verified."`
+		Message   string `json:"message" example:"If an account exists with this email, a magic link has been sent." doc:"Response message"`
+		ErrorCode string `json:"error_code,omitempty" example:"SERVICE_UNAVAILABLE" doc:"Error code for programmatic handling (only set for pre-lookup validation/config errors, never for account state)"`
 		RequestID string `json:"request_id,omitempty" example:"550e8400-e29b-41d4-a716-446655440000" doc:"Request ID for debugging"`
 	}
 }
@@ -773,36 +773,35 @@ func (h *AuthHandler) SendMagicLinkHandler(ctx context.Context, input *SendMagic
 		return resp, nil
 	}
 
+	// Enumeration-safe response: callers always get the same body regardless
+	// of whether the email is registered, unregistered, or registered but
+	// unverified. Any per-user-state branch — including a token or send
+	// failure for a known account — must surface only in server logs, or the
+	// response becomes an account-existence/verification oracle.
+	resp.Body.Success = true
+	resp.Body.Message = "If an account exists with this email, a magic link has been sent."
+
 	// Find user by email
 	user, err := h.userService.GetUserByEmail(input.Body.Email)
 	if err != nil {
 		logger.AuthError(ctx, "magic_link_user_lookup_failed", err,
 			"email_hash", logger.HashEmail(input.Body.Email),
 		)
-		// Don't reveal if user exists - return success message anyway
-		resp.Body.Success = true
-		resp.Body.Message = "If an account exists with this email, a magic link has been sent."
 		return resp, nil
 	}
 
 	if user == nil {
-		// User doesn't exist - return success to avoid email enumeration
 		logger.AuthDebug(ctx, "magic_link_user_not_found",
 			"email_hash", logger.HashEmail(input.Body.Email),
 		)
-		resp.Body.Success = true
-		resp.Body.Message = "If an account exists with this email, a magic link has been sent."
 		return resp, nil
 	}
 
-	// Check if email is verified - magic links only work for verified emails
+	// Unverified accounts can't receive a magic link (it would skip the
+	// verification step), so re-send the verification email as a side effect
+	// and return the generic response. The user proceeds via that link.
 	if !user.EmailVerified {
-		logger.AuthDebug(ctx, "magic_link_email_not_verified",
-			"user_id", user.ID,
-		)
-		resp.Body.Success = false
-		resp.Body.Message = "Please verify your email address first. Check your inbox for a verification email, or sign in with your password to request a new one."
-		resp.Body.ErrorCode = "EMAIL_NOT_VERIFIED"
+		h.resendVerificationEmail(ctx, user)
 		return resp, nil
 	}
 
@@ -812,9 +811,6 @@ func (h *AuthHandler) SendMagicLinkHandler(ctx context.Context, input *SendMagic
 		logger.AuthError(ctx, "magic_link_token_failed", err,
 			"user_id", user.ID,
 		)
-		resp.Body.Success = false
-		resp.Body.Message = "Failed to generate magic link"
-		resp.Body.ErrorCode = autherrors.CodeServiceUnavailable
 		return resp, nil
 	}
 
@@ -823,9 +819,6 @@ func (h *AuthHandler) SendMagicLinkHandler(ctx context.Context, input *SendMagic
 		logger.AuthError(ctx, "magic_link_email_failed", err,
 			"user_id", user.ID,
 		)
-		resp.Body.Success = false
-		resp.Body.Message = "Failed to send magic link email"
-		resp.Body.ErrorCode = autherrors.CodeServiceUnavailable
 		return resp, nil
 	}
 
@@ -834,9 +827,34 @@ func (h *AuthHandler) SendMagicLinkHandler(ctx context.Context, input *SendMagic
 		"email_hash", logger.HashEmail(input.Body.Email),
 	)
 
-	resp.Body.Success = true
-	resp.Body.Message = "Magic link sent! Check your email to sign in."
 	return resp, nil
+}
+
+// resendVerificationEmail re-sends an email-verification link to an unverified
+// account as a side effect of a magic-link request. It is fire-and-forget:
+// failures are logged but never surfaced to the caller, so the magic-link
+// response stays enumeration-safe.
+func (h *AuthHandler) resendVerificationEmail(ctx context.Context, user *authm.User) {
+	if user.Email == nil || *user.Email == "" {
+		return
+	}
+	token, err := h.jwtService.CreateVerificationToken(user.ID, *user.Email)
+	if err != nil {
+		logger.AuthError(ctx, "magic_link_verification_token_failed", err,
+			"user_id", user.ID,
+		)
+		return
+	}
+	if err := h.emailService.SendVerificationEmail(*user.Email, token); err != nil {
+		logger.AuthError(ctx, "magic_link_verification_email_failed", err,
+			"user_id", user.ID,
+		)
+		return
+	}
+	logger.AuthInfo(ctx, "magic_link_verification_resent",
+		"user_id", user.ID,
+		"email_hash", logger.HashEmail(*user.Email),
+	)
 }
 
 // VerifyMagicLinkRequest represents the request to verify a magic link

--- a/backend/internal/api/handlers/auth/auth_integration_test.go
+++ b/backend/internal/api/handlers/auth/auth_integration_test.go
@@ -441,8 +441,8 @@ func (s *AuthHandlerIntegrationSuite) TestSendMagicLink_EmailNotVerified() {
 
 	resp, err := h.SendMagicLinkHandler(context.Background(), input)
 	s.Require().NoError(err)
-	s.True(resp.Body.Success)         // enumeration prevention
-	s.Empty(resp.Body.ErrorCode)      // no EMAIL_NOT_VERIFIED leak
+	s.True(resp.Body.Success)    // enumeration prevention
+	s.Empty(resp.Body.ErrorCode) // no EMAIL_NOT_VERIFIED leak
 }
 
 // TestSendMagicLink_SendFails verifies a downstream send failure for a

--- a/backend/internal/api/handlers/auth/auth_integration_test.go
+++ b/backend/internal/api/handlers/auth/auth_integration_test.go
@@ -429,6 +429,9 @@ func (s *AuthHandlerIntegrationSuite) TestSendMagicLink_UserNotFound() {
 	s.True(resp.Body.Success) // enumeration prevention
 }
 
+// TestSendMagicLink_EmailNotVerified verifies an unverified account no longer
+// leaks its state: the response is the generic enumeration-safe success body,
+// identical to the unknown-email case (PSY-749).
 func (s *AuthHandlerIntegrationSuite) TestSendMagicLink_EmailNotVerified() {
 	h := s.newAuthHandler(true)
 	s.createUserWithPassword("unverified@test.com", "strong-password-123!")
@@ -438,10 +441,14 @@ func (s *AuthHandlerIntegrationSuite) TestSendMagicLink_EmailNotVerified() {
 
 	resp, err := h.SendMagicLinkHandler(context.Background(), input)
 	s.Require().NoError(err)
-	s.False(resp.Body.Success)
-	s.Equal("EMAIL_NOT_VERIFIED", resp.Body.ErrorCode)
+	s.True(resp.Body.Success)         // enumeration prevention
+	s.Empty(resp.Body.ErrorCode)      // no EMAIL_NOT_VERIFIED leak
 }
 
+// TestSendMagicLink_SendFails verifies a downstream send failure for a
+// known-verified account stays generic — the failure must not surface as a
+// distinct error response, which would leak that the account exists (PSY-749).
+// The fake Resend API key makes the underlying send fail.
 func (s *AuthHandlerIntegrationSuite) TestSendMagicLink_SendFails() {
 	h := s.newAuthHandler(true) // email configured but fake API key
 	user := s.createUserWithPassword("magic-fail@test.com", "strong-password-123!")
@@ -452,8 +459,8 @@ func (s *AuthHandlerIntegrationSuite) TestSendMagicLink_SendFails() {
 
 	resp, err := h.SendMagicLinkHandler(context.Background(), input)
 	s.Require().NoError(err)
-	s.False(resp.Body.Success)
-	s.Equal(autherrors.CodeServiceUnavailable, resp.Body.ErrorCode)
+	s.True(resp.Body.Success)
+	s.Empty(resp.Body.ErrorCode)
 }
 
 // --- VerifyMagicLinkHandler ---

--- a/backend/internal/api/handlers/auth/auth_test.go
+++ b/backend/internal/api/handlers/auth/auth_test.go
@@ -1313,22 +1313,91 @@ func TestConfirmVerificationHandler_SetVerifiedFails(t *testing.T) {
 
 // --- SendMagicLinkHandler mock tests ---
 
-func TestSendMagicLinkHandler_Success(t *testing.T) {
-	email := "test@example.com"
+// magicLinkAccountState models a GetUserByEmail outcome for the enumeration test.
+type magicLinkAccountState struct {
+	name string
+	user func(email string) (*authm.User, error)
+}
+
+// magicLinkAccountStates enumerates the three states whose responses must be
+// indistinguishable (PSY-749): unknown email, known-unverified, known-verified.
+func magicLinkAccountStates(email string) []magicLinkAccountState {
+	return []magicLinkAccountState{
+		{name: "unknown_email", user: func(string) (*authm.User, error) { return nil, nil }},
+		{name: "known_unverified", user: func(e string) (*authm.User, error) {
+			return &authm.User{ID: 1, Email: &e, EmailVerified: false}, nil
+		}},
+		{name: "known_verified", user: func(e string) (*authm.User, error) {
+			return &authm.User{ID: 1, Email: &e, EmailVerified: true}, nil
+		}},
+	}
+}
+
+// TestSendMagicLinkHandler_ResponseIdenticalAcrossAccountStates is the PSY-749
+// regression guard: the response body must be byte-identical regardless of
+// whether the email is unregistered, registered-unverified, or
+// registered-verified, so the endpoint can't be used as an enumeration oracle.
+func TestSendMagicLinkHandler_ResponseIdenticalAcrossAccountStates(t *testing.T) {
+	email := "probe@example.com"
+
+	respFor := func(state magicLinkAccountState) SendMagicLinkResponse {
+		h := authHandler(func(ah *AuthHandler) {
+			ah.emailService = &testhelpers.MockEmailService{
+				IsConfiguredFn:          func() bool { return true },
+				SendMagicLinkEmailFn:    func(string, string) error { return nil },
+				SendVerificationEmailFn: func(string, string) error { return nil },
+			}
+			ah.userService = &testhelpers.MockUserService{GetUserByEmailFn: state.user}
+			ah.jwtService = &testhelpers.MockJWTService{
+				CreateMagicLinkTokenFn:    func(uint, string) (string, error) { return "magic-token", nil },
+				CreateVerificationTokenFn: func(uint, string) (string, error) { return "verify-token", nil },
+			}
+		})
+		input := &SendMagicLinkRequest{}
+		input.Body.Email = email
+		resp, err := h.SendMagicLinkHandler(context.Background(), input)
+		if err != nil {
+			t.Fatalf("[%s] unexpected error: %v", state.name, err)
+		}
+		return *resp
+	}
+
+	states := magicLinkAccountStates(email)
+	want := respFor(states[0])
+	if !want.Body.Success {
+		t.Fatalf("expected success=true for enumeration-safe response, got message=%q", want.Body.Message)
+	}
+	if want.Body.ErrorCode != "" {
+		t.Fatalf("expected empty error_code, got %q", want.Body.ErrorCode)
+	}
+	for _, state := range states[1:] {
+		got := respFor(state)
+		if got.Body != want.Body {
+			t.Errorf("response body for %s differs from %s:\n  got  %+v\n  want %+v",
+				state.name, states[0].name, got.Body, want.Body)
+		}
+	}
+}
+
+// TestSendMagicLinkHandler_UnverifiedResendsVerification asserts the side
+// effect: an unverified account triggers a re-sent verification email (not a
+// magic link), so the user can still proceed (PSY-749).
+func TestSendMagicLinkHandler_UnverifiedResendsVerification(t *testing.T) {
+	email := "unverified@example.com"
+	var verificationSent, magicLinkSent bool
 	h := authHandler(func(ah *AuthHandler) {
 		ah.emailService = &testhelpers.MockEmailService{
-			IsConfiguredFn:       func() bool { return true },
-			SendMagicLinkEmailFn: func(toEmail, token string) error { return nil },
+			IsConfiguredFn:          func() bool { return true },
+			SendVerificationEmailFn: func(string, string) error { verificationSent = true; return nil },
+			SendMagicLinkEmailFn:    func(string, string) error { magicLinkSent = true; return nil },
 		}
 		ah.userService = &testhelpers.MockUserService{
 			GetUserByEmailFn: func(e string) (*authm.User, error) {
-				return &authm.User{ID: 1, Email: &email, EmailVerified: true}, nil
+				return &authm.User{ID: 1, Email: &e, EmailVerified: false}, nil
 			},
 		}
 		ah.jwtService = &testhelpers.MockJWTService{
-			CreateMagicLinkTokenFn: func(userID uint, e string) (string, error) {
-				return "magic-token", nil
-			},
+			CreateVerificationTokenFn: func(uint, string) (string, error) { return "verify-token", nil },
 		}
 	})
 
@@ -1340,45 +1409,34 @@ func TestSendMagicLinkHandler_Success(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if !resp.Body.Success {
-		t.Errorf("expected success=true, got message=%q", resp.Body.Message)
+		t.Error("expected success=true")
+	}
+	if !verificationSent {
+		t.Error("expected verification email to be re-sent for unverified account")
+	}
+	if magicLinkSent {
+		t.Error("expected no magic link email for unverified account")
 	}
 }
 
-func TestSendMagicLinkHandler_UserNotFound(t *testing.T) {
+// TestSendMagicLinkHandler_VerifiedSendsMagicLink asserts the verified path
+// sends a magic link (and not a verification email).
+func TestSendMagicLinkHandler_VerifiedSendsMagicLink(t *testing.T) {
+	email := "verified@example.com"
+	var verificationSent, magicLinkSent bool
 	h := authHandler(func(ah *AuthHandler) {
 		ah.emailService = &testhelpers.MockEmailService{
-			IsConfiguredFn: func() bool { return true },
+			IsConfiguredFn:          func() bool { return true },
+			SendVerificationEmailFn: func(string, string) error { verificationSent = true; return nil },
+			SendMagicLinkEmailFn:    func(string, string) error { magicLinkSent = true; return nil },
 		}
 		ah.userService = &testhelpers.MockUserService{
 			GetUserByEmailFn: func(e string) (*authm.User, error) {
-				return nil, nil // user not found
+				return &authm.User{ID: 1, Email: &e, EmailVerified: true}, nil
 			},
 		}
-	})
-
-	input := &SendMagicLinkRequest{}
-	input.Body.Email = "nobody@example.com"
-
-	resp, err := h.SendMagicLinkHandler(context.Background(), input)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	// Should return success to prevent email enumeration
-	if !resp.Body.Success {
-		t.Error("expected success=true (silent failure)")
-	}
-}
-
-func TestSendMagicLinkHandler_EmailNotVerified(t *testing.T) {
-	email := "unverified@example.com"
-	h := authHandler(func(ah *AuthHandler) {
-		ah.emailService = &testhelpers.MockEmailService{
-			IsConfiguredFn: func() bool { return true },
-		}
-		ah.userService = &testhelpers.MockUserService{
-			GetUserByEmailFn: func(e string) (*authm.User, error) {
-				return &authm.User{ID: 1, Email: &email, EmailVerified: false}, nil
-			},
+		ah.jwtService = &testhelpers.MockJWTService{
+			CreateMagicLinkTokenFn: func(uint, string) (string, error) { return "magic-token", nil },
 		}
 	})
 
@@ -1389,11 +1447,49 @@ func TestSendMagicLinkHandler_EmailNotVerified(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if resp.Body.Success {
-		t.Error("expected success=false")
+	if !resp.Body.Success {
+		t.Error("expected success=true")
 	}
-	if resp.Body.ErrorCode != "EMAIL_NOT_VERIFIED" {
-		t.Errorf("expected error_code=EMAIL_NOT_VERIFIED, got %s", resp.Body.ErrorCode)
+	if !magicLinkSent {
+		t.Error("expected magic link email for verified account")
+	}
+	if verificationSent {
+		t.Error("expected no verification email for verified account")
+	}
+}
+
+// TestSendMagicLinkHandler_SendFailureStaysGeneric asserts that a downstream
+// send failure for a known-verified account does NOT change the response —
+// otherwise the failure response would leak that the account exists (PSY-749).
+func TestSendMagicLinkHandler_SendFailureStaysGeneric(t *testing.T) {
+	email := "verified@example.com"
+	h := authHandler(func(ah *AuthHandler) {
+		ah.emailService = &testhelpers.MockEmailService{
+			IsConfiguredFn:       func() bool { return true },
+			SendMagicLinkEmailFn: func(string, string) error { return fmt.Errorf("resend exploded") },
+		}
+		ah.userService = &testhelpers.MockUserService{
+			GetUserByEmailFn: func(e string) (*authm.User, error) {
+				return &authm.User{ID: 1, Email: &e, EmailVerified: true}, nil
+			},
+		}
+		ah.jwtService = &testhelpers.MockJWTService{
+			CreateMagicLinkTokenFn: func(uint, string) (string, error) { return "magic-token", nil },
+		}
+	})
+
+	input := &SendMagicLinkRequest{}
+	input.Body.Email = email
+
+	resp, err := h.SendMagicLinkHandler(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.Body.Success {
+		t.Error("expected success=true even when send fails (no enumeration leak)")
+	}
+	if resp.Body.ErrorCode != "" {
+		t.Errorf("expected empty error_code on send failure, got %q", resp.Body.ErrorCode)
 	}
 }
 


### PR DESCRIPTION
## Summary
- The magic-link send handler (`POST /auth/magic-link/send`) returned a distinct `EMAIL_NOT_VERIFIED` body for registered-but-unverified accounts, while missing users got the generic "if an account exists" body — a partial enumeration oracle. The verified-success path and the token/send-failure paths also returned bodies distinguishable from the missing-user case.
- All post-lookup branches (unknown email, known-unverified, known-verified, token failure, send failure) now collapse onto **one** enumeration-safe response. Unverified accounts get a re-sent verification email as a fire-and-forget side effect so the user can still proceed; failures are logged server-side, never surfaced. Only pre-lookup validation/email-config errors still set an error code.
- Frontend already shows its own copy and only branches on `success`; the dead `error_code === 'EMAIL_NOT_VERIFIED'` arm is now unreachable (no FE change required in this PR).

## Test plan
- [x] `cd backend && go build ./...` — clean
- [x] `go test ./...` (full suite, testcontainers Postgres) — all packages pass, including `internal/api/handlers/auth` (unit + DB-backed integration suite)
- [x] New unit test `TestSendMagicLinkHandler_ResponseIdenticalAcrossAccountStates` asserts the response body is byte-identical across unknown / known-unverified / known-verified inputs
- [x] New unit tests assert the per-state side effects: `TestSendMagicLinkHandler_UnverifiedResendsVerification` (verification email re-sent, no magic link), `TestSendMagicLinkHandler_VerifiedSendsMagicLink` (magic link sent, no verification email), `TestSendMagicLinkHandler_SendFailureStaysGeneric` (send failure stays generic, no error code)
- [x] Updated integration tests `TestSendMagicLink_EmailNotVerified` + `TestSendMagicLink_SendFails` to assert the new enumeration-safe behavior

## Manual repro
The unit + integration tests ARE the repro (backend-only change, no UI surface):
- `TestSendMagicLinkHandler_ResponseIdenticalAcrossAccountStates` PASS — the three account states produce identical `resp.Body` (success=true, empty error_code, generic message). Before this change the unverified case returned `success=false` + `EMAIL_NOT_VERIFIED`.
- Logs confirmed the side effects: unverified → `magic_link_verification_resent`; verified → `magic_link_sent`; send failure → `magic_link_email_failed` (logged) with the response still generic.

## Simplify
`/simplify` run after the fix commit. Code was clean across reuse / quality / efficiency lenses; the only change was a `gofmt` comment-alignment in the integration test (whitespace-only), committed separately.

## Scope-adjacent (filed as follow-ups, not fixed here)
The audit (AC) found the same distinct-response-by-user-state pattern in other auth paths — left untouched per ticket scope; follow-up tickets to be filed:
- `RequestAccountRecoveryHandler` (`auth.go:1556-1612`): leaks via `ACCOUNT_ACTIVE` (+`has_password`), `ACCOUNT_NOT_RECOVERABLE`, `has_password`/`days_remaining` on success, and `SERVICE_UNAVAILABLE` only for known accounts — strongest oracle (has a generic missing-user path then diverges).
- `RecoverAccountHandler` (`auth.go:1420-1448`): `ACCOUNT_ACTIVE` / `ACCOUNT_NOT_RECOVERABLE` / `NO_PASSWORD` reveal account state.
- `RegisterHandler` (`auth.go:493`) + passkey registration (`passkey.go:654,753`): `CodeUserExists` "An account with this email already exists" — classic registration enumeration.

Closes PSY-749

🤖 Generated with [Claude Code](https://claude.com/claude-code)