### PR TITLE
PSY-747: validate URL schemes + render profile section markdown

### DIFF
--- a/backend/internal/api/handlers/catalog/release.go
+++ b/backend/internal/api/handlers/catalog/release.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 
+	"psychic-homily-backend/internal/api/handlers/shared"
 	"psychic-homily-backend/internal/api/middleware"
 	apperrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/logger"
@@ -209,6 +210,12 @@ func (h *ReleaseHandler) CreateReleaseHandler(ctx context.Context, req *CreateRe
 		return nil, huma.Error422UnprocessableEntity("Title is required")
 	}
 
+	// PSY-747: reject non-http/https cover art URLs (e.g. javascript:, data:)
+	// and cap length.
+	if err := shared.ValidateURLField("cover_art_url", req.Body.CoverArtURL); err != nil {
+		return nil, err
+	}
+
 	// Convert handler types to service types
 	artists := make([]contracts.CreateReleaseArtistEntry, len(req.Body.Artists))
 	for i, a := range req.Body.Artists {
@@ -295,6 +302,12 @@ func (h *ReleaseHandler) UpdateReleaseHandler(ctx context.Context, req *UpdateRe
 	// Resolve release ID
 	releaseID, err := h.resolveReleaseID(req.ReleaseID)
 	if err != nil {
+		return nil, err
+	}
+
+	// PSY-747: reject non-http/https cover art URLs (e.g. javascript:, data:)
+	// and cap length.
+	if err := shared.ValidateURLField("cover_art_url", req.Body.CoverArtURL); err != nil {
 		return nil, err
 	}
 

--- a/backend/internal/api/handlers/catalog/show.go
+++ b/backend/internal/api/handlers/catalog/show.go
@@ -129,12 +129,16 @@ func (r *CreateShowRequestBody) Resolve(ctx huma.Context) []error {
 		})
 	}
 
-	if r.TicketURL != nil && len(*r.TicketURL) > 500 {
-		errors = append(errors, &huma.ErrorDetail{
-			Location: "body.ticket_url",
-			Message:  "Ticket URL must be 500 characters or fewer",
-			Value:    len(*r.TicketURL),
-		})
+	// PSY-747: ticket URL is length-capped AND scheme-validated (http/https
+	// only) — previously it accepted javascript:/data: on a public show.
+	if r.TicketURL != nil {
+		if err := shared.URLSchemeError("ticket_url", *r.TicketURL); err != nil {
+			errors = append(errors, &huma.ErrorDetail{
+				Location: "body.ticket_url",
+				Message:  err.Error(),
+				Value:    *r.TicketURL,
+			})
+		}
 	}
 
 	// Validate price range
@@ -835,8 +839,10 @@ func (h *ShowHandler) UpdateShowHandler(ctx context.Context, req *UpdateShowRequ
 	if req.Body.Price != nil && (*req.Body.Price < 0 || *req.Body.Price > 10000) {
 		return nil, huma.Error422UnprocessableEntity("Price must be between 0 and 10000")
 	}
-	if req.Body.TicketURL != nil && len(*req.Body.TicketURL) > 500 {
-		return nil, huma.Error422UnprocessableEntity("Ticket URL must be 500 characters or fewer")
+	// PSY-747: ticket URL is length-capped AND scheme-validated (http/https
+	// only) — previously it accepted javascript:/data: on a public show.
+	if err := shared.ValidateURLField("ticket_url", req.Body.TicketURL); err != nil {
+		return nil, err
 	}
 	if req.Body.ImageURL != nil && len(*req.Body.ImageURL) > 2048 {
 		return nil, huma.Error422UnprocessableEntity("Image URL must be 2048 characters or fewer")

--- a/backend/internal/api/handlers/community/collection.go
+++ b/backend/internal/api/handlers/community/collection.go
@@ -200,6 +200,12 @@ func (h *CollectionHandler) CreateCollectionHandler(ctx context.Context, req *Cr
 		return nil, huma.Error422UnprocessableEntity("Title is required")
 	}
 
+	// PSY-747: reject non-http/https cover image URLs (e.g. javascript:, data:)
+	// and cap length.
+	if err := shared.ValidateURLField("cover_image_url", req.Body.CoverImageURL); err != nil {
+		return nil, err
+	}
+
 	serviceReq := &contracts.CreateCollectionRequest{
 		Title:         req.Body.Title,
 		Description:   req.Body.Description,
@@ -263,6 +269,12 @@ func (h *CollectionHandler) UpdateCollectionHandler(ctx context.Context, req *Up
 	user := middleware.GetUserFromContext(ctx)
 	if user == nil {
 		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	// PSY-747: reject non-http/https cover image URLs (e.g. javascript:, data:)
+	// and cap length.
+	if err := shared.ValidateURLField("cover_image_url", req.Body.CoverImageURL); err != nil {
+		return nil, err
 	}
 
 	serviceReq := &contracts.UpdateCollectionRequest{

--- a/backend/internal/api/handlers/shared/url_validation.go
+++ b/backend/internal/api/handlers/shared/url_validation.go
@@ -22,23 +22,27 @@ type urlFieldSpec struct {
 // boundary. PSY-525 introduced http/https scheme validation for these fields
 // in the catalog handlers; PSY-549 extends the same rules to the
 // pending-edit suggest path so the two write surfaces agree on what
-// constitutes a valid URL.
+// constitutes a valid URL. PSY-747 closes the gaps for cover_image_url
+// (collection), cover_art_url (release), and ticket_url (show), which were
+// previously length-only and accepted javascript:/data: schemes.
 //
-// Intentionally omitted: flyer_url, ticket_url, cover_art_url, and
-// bandcamp_embed_url. PSY-525 left them to length-only / domain-specific
-// checks (e.g. isValidBandcampURL); PSY-549 matches that scope so the
-// suggest-edit path doesn't enforce stricter rules than the catalog handler
-// would.
+// Intentionally omitted: flyer_url and bandcamp_embed_url — PSY-525 left them
+// to length-only / domain-specific checks (e.g. isValidBandcampURL), and the
+// suggest-edit path matches that scope so it doesn't enforce stricter rules
+// than the catalog handler would.
 var urlFieldSpecs = map[string]urlFieldSpec{
-	"image_url":  {displayName: "Image URL", maxLength: 2048},
-	"instagram":  {displayName: "Instagram URL", maxLength: 255},
-	"facebook":   {displayName: "Facebook URL", maxLength: 500},
-	"twitter":    {displayName: "Twitter URL", maxLength: 255},
-	"youtube":    {displayName: "YouTube URL", maxLength: 500},
-	"spotify":    {displayName: "Spotify URL", maxLength: 500},
-	"soundcloud": {displayName: "SoundCloud URL", maxLength: 500},
-	"bandcamp":   {displayName: "Bandcamp URL", maxLength: 500},
-	"website":    {displayName: "Website URL", maxLength: 500},
+	"image_url":       {displayName: "Image URL", maxLength: 2048},
+	"cover_image_url": {displayName: "Cover image URL", maxLength: 2048},
+	"cover_art_url":   {displayName: "Cover art URL", maxLength: 2048},
+	"ticket_url":      {displayName: "Ticket URL", maxLength: 500},
+	"instagram":       {displayName: "Instagram URL", maxLength: 255},
+	"facebook":        {displayName: "Facebook URL", maxLength: 500},
+	"twitter":         {displayName: "Twitter URL", maxLength: 255},
+	"youtube":         {displayName: "YouTube URL", maxLength: 500},
+	"spotify":         {displayName: "Spotify URL", maxLength: 500},
+	"soundcloud":      {displayName: "SoundCloud URL", maxLength: 500},
+	"bandcamp":        {displayName: "Bandcamp URL", maxLength: 500},
+	"website":         {displayName: "Website URL", maxLength: 500},
 }
 
 // ValidateImageURL applies the http/https scheme check to an optional image
@@ -52,6 +56,33 @@ func ValidateImageURL(imageURL *string) error {
 		return nil
 	}
 	return validateScheme(*imageURL, urlFieldSpecs["image_url"].displayName)
+}
+
+// ValidateURLField applies both the http/https scheme check and the per-field
+// length cap to an optional URL identified by its urlFieldSpecs key. Unlike
+// ValidateImageURL (scheme-only, length enforced by a struct maxLength tag),
+// this helper also caps length, so it works for boundary fields that lack a
+// struct-tag length cap (e.g. collection cover_image_url, release
+// cover_art_url, show ticket_url — PSY-747).
+//
+// Empty strings and nil pass through so callers that allow "clear via empty
+// string" semantics keep working. Unknown field names return nil rather than
+// panicking, so a typo degrades to no-op validation rather than a runtime
+// crash; callers pass a literal key matched against urlFieldSpecs.
+func ValidateURLField(fieldName string, value *string) error {
+	spec, ok := urlFieldSpecs[fieldName]
+	if !ok {
+		return nil
+	}
+	if value == nil || *value == "" {
+		return nil
+	}
+	if len(*value) > spec.maxLength {
+		return huma.Error422UnprocessableEntity(
+			fmt.Sprintf("%s must be %d characters or fewer", spec.displayName, spec.maxLength),
+		)
+	}
+	return validateScheme(*value, spec.displayName)
 }
 
 // ValidateSocialURLs applies the http/https scheme check to the standard set
@@ -126,6 +157,24 @@ func ValidateFieldChangeValue(fieldName string, value any) error {
 		)
 	}
 	return validateScheme(s, spec.displayName)
+}
+
+// URLSchemeError validates the http/https scheme and per-field length cap for
+// a known URL field and returns the underlying error (NOT wrapped as a huma
+// 422). It exists for the huma Resolve()-style request bodies that collect
+// field-level *huma.ErrorDetail entries with a Location — the caller wraps the
+// returned error so the rejection keeps its body-field attribution (PSY-747,
+// show ticket_url create path). Returns nil for unknown fields, nil/empty
+// values, or valid URLs.
+func URLSchemeError(fieldName, value string) error {
+	spec, ok := urlFieldSpecs[fieldName]
+	if !ok || value == "" {
+		return nil
+	}
+	if len(value) > spec.maxLength {
+		return fmt.Errorf("%s must be %d characters or fewer", spec.displayName, spec.maxLength)
+	}
+	return utils.ValidateHTTPURL(value, spec.displayName)
 }
 
 // validateScheme calls utils.ValidateHTTPURL and translates failures into

--- a/backend/internal/api/handlers/shared/url_validation.go
+++ b/backend/internal/api/handlers/shared/url_validation.go
@@ -59,10 +59,10 @@ func ValidateImageURL(imageURL *string) error {
 }
 
 // ValidateURLField applies both the http/https scheme check and the per-field
-// length cap to an optional URL identified by its urlFieldSpecs key. Unlike
-// ValidateImageURL (scheme-only, length enforced by a struct maxLength tag),
-// this helper also caps length, so it works for boundary fields that lack a
-// struct-tag length cap (e.g. collection cover_image_url, release
+// length cap to an optional URL identified by its urlFieldSpecs key, returning
+// a huma 422. Unlike ValidateImageURL (scheme-only, length enforced by a struct
+// maxLength tag), this helper also caps length, so it works for boundary fields
+// that lack a struct-tag length cap (e.g. collection cover_image_url, release
 // cover_art_url, show ticket_url — PSY-747).
 //
 // Empty strings and nil pass through so callers that allow "clear via empty
@@ -70,19 +70,13 @@ func ValidateImageURL(imageURL *string) error {
 // panicking, so a typo degrades to no-op validation rather than a runtime
 // crash; callers pass a literal key matched against urlFieldSpecs.
 func ValidateURLField(fieldName string, value *string) error {
-	spec, ok := urlFieldSpecs[fieldName]
-	if !ok {
+	if value == nil {
 		return nil
 	}
-	if value == nil || *value == "" {
-		return nil
+	if err := URLSchemeError(fieldName, *value); err != nil {
+		return huma.Error422UnprocessableEntity(err.Error())
 	}
-	if len(*value) > spec.maxLength {
-		return huma.Error422UnprocessableEntity(
-			fmt.Sprintf("%s must be %d characters or fewer", spec.displayName, spec.maxLength),
-		)
-	}
-	return validateScheme(*value, spec.displayName)
+	return nil
 }
 
 // ValidateSocialURLs applies the http/https scheme check to the standard set

--- a/backend/internal/api/handlers/shared/url_validation_test.go
+++ b/backend/internal/api/handlers/shared/url_validation_test.go
@@ -242,3 +242,113 @@ func TestValidateFieldChangeValue_ImageURLLargerCap(t *testing.T) {
 	err := ValidateFieldChangeValue("image_url", too2049)
 	testhelpers.AssertHumaError(t, err, 422)
 }
+
+// ============================================================================
+// ValidateURLField — PSY-747: collection cover_image_url, release
+// cover_art_url, show ticket_url (typed *string boundary).
+// ============================================================================
+
+func TestValidateURLField_NilAndEmptyPass(t *testing.T) {
+	for _, field := range []string{"cover_image_url", "cover_art_url", "ticket_url"} {
+		t.Run(field, func(t *testing.T) {
+			if err := ValidateURLField(field, nil); err != nil {
+				t.Errorf("nil should pass, got: %v", err)
+			}
+			if err := ValidateURLField(field, PtrString("")); err != nil {
+				t.Errorf("empty string should pass, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateURLField_UnknownFieldPasses(t *testing.T) {
+	// A field name not in urlFieldSpecs degrades to no-op rather than crashing.
+	if err := ValidateURLField("not_a_url_field", PtrString("javascript:alert(1)")); err != nil {
+		t.Errorf("unknown field should pass, got: %v", err)
+	}
+}
+
+func TestValidateURLField_AcceptsValidHTTPAndHTTPS(t *testing.T) {
+	cases := []struct{ field, value string }{
+		{"cover_image_url", "https://example.com/cover.jpg"},
+		{"cover_image_url", "http://example.com/cover.jpg"},
+		{"cover_art_url", "https://example.com/art.png"},
+		{"ticket_url", "https://tickets.example.com/event/1"},
+	}
+	for _, c := range cases {
+		t.Run(c.field+"="+c.value, func(t *testing.T) {
+			if err := ValidateURLField(c.field, PtrString(c.value)); err != nil {
+				t.Errorf("valid URL should pass, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateURLField_RejectsJavaScriptScheme(t *testing.T) {
+	for _, field := range []string{"cover_image_url", "cover_art_url", "ticket_url"} {
+		t.Run(field, func(t *testing.T) {
+			err := ValidateURLField(field, PtrString("javascript:alert(1)"))
+			testhelpers.AssertHumaError(t, err, 422)
+		})
+	}
+}
+
+func TestValidateURLField_RejectsDataScheme(t *testing.T) {
+	for _, field := range []string{"cover_image_url", "cover_art_url", "ticket_url"} {
+		t.Run(field, func(t *testing.T) {
+			err := ValidateURLField(field, PtrString("data:text/html,<script>alert(1)</script>"))
+			testhelpers.AssertHumaError(t, err, 422)
+		})
+	}
+}
+
+func TestValidateURLField_RejectsLengthExceeded(t *testing.T) {
+	// ticket_url cap is 500; build a 501-char URL.
+	base := "https://tickets.example.com/"
+	long := base + strings.Repeat("a", 501-len(base)+1)
+	err := ValidateURLField("ticket_url", PtrString(long))
+	testhelpers.AssertHumaError(t, err, 422)
+	var he *huma.ErrorModel
+	errors.As(err, &he)
+	if !strings.Contains(he.Detail, "500") {
+		t.Errorf("expected error to mention 500 char cap, got: %s", he.Detail)
+	}
+}
+
+// ============================================================================
+// URLSchemeError — PSY-747: the huma Resolve()-style path (show ticket_url
+// create), which collects field-level *huma.ErrorDetail with a Location.
+// ============================================================================
+
+func TestURLSchemeError_ValidAndEmptyReturnNil(t *testing.T) {
+	if err := URLSchemeError("ticket_url", ""); err != nil {
+		t.Errorf("empty should return nil, got: %v", err)
+	}
+	if err := URLSchemeError("ticket_url", "https://tickets.example.com/1"); err != nil {
+		t.Errorf("valid URL should return nil, got: %v", err)
+	}
+	if err := URLSchemeError("not_a_url_field", "javascript:alert(1)"); err != nil {
+		t.Errorf("unknown field should return nil, got: %v", err)
+	}
+}
+
+func TestURLSchemeError_RejectsNonHTTPScheme(t *testing.T) {
+	// Returns a plain (unwrapped) error so the Resolve() caller can wrap it as
+	// an *huma.ErrorDetail with a Location.
+	err := URLSchemeError("ticket_url", "javascript:alert(1)")
+	if err == nil {
+		t.Fatal("expected error for javascript: scheme, got nil")
+	}
+	if _, isHuma := err.(huma.StatusError); isHuma {
+		t.Errorf("expected a plain error (not huma StatusError), got: %T", err)
+	}
+}
+
+func TestURLSchemeError_RejectsLengthExceeded(t *testing.T) {
+	base := "https://tickets.example.com/"
+	long := base + strings.Repeat("a", 501-len(base)+1)
+	err := URLSchemeError("ticket_url", long)
+	if err == nil || !strings.Contains(err.Error(), "500") {
+		t.Errorf("expected 500-char cap error, got: %v", err)
+	}
+}

--- a/backend/internal/services/contracts/user.go
+++ b/backend/internal/services/contracts/user.go
@@ -215,13 +215,18 @@ type PublicProfileResponse struct {
 
 // ProfileSectionResponse represents a profile section in API responses.
 type ProfileSectionResponse struct {
-	ID        uint      `json:"id"`
-	Title     string    `json:"title"`
-	Content   string    `json:"content"`
-	Position  int       `json:"position"`
-	IsVisible bool      `json:"is_visible"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
+	ID    uint   `json:"id"`
+	Title string `json:"title"`
+	// Content is the raw markdown source, preserved for edit-form round-tripping.
+	Content string `json:"content"`
+	// ContentHTML is Content rendered to sanitized HTML (goldmark + bluemonday),
+	// mirroring tag/collection descriptions (PSY-747). Read this for display;
+	// keep Content for editing. Omitted when Content is empty.
+	ContentHTML string    `json:"content_html,omitempty"`
+	Position    int       `json:"position"`
+	IsVisible   bool      `json:"is_visible"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
 }
 
 // ActivityDay represents a single day's contribution count for the activity heatmap.

--- a/backend/internal/services/user/contributor_profile.go
+++ b/backend/internal/services/user/contributor_profile.go
@@ -14,7 +14,14 @@ import (
 	communitym "psychic-homily-backend/internal/models/community"
 	engagementm "psychic-homily-backend/internal/models/engagement"
 	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/utils"
 )
+
+// profileMarkdown renders profile-section Content to sanitized HTML. The
+// renderer is stateless after construction (goldmark + bluemonday), so a single
+// package-level instance is shared by the package-level buildSectionResponse
+// helpers — same policy used by tag/collection descriptions (PSY-747).
+var profileMarkdown = utils.NewMarkdownRenderer()
 
 // ContributorProfileService handles contributor profile and contribution history operations.
 type ContributorProfileService struct {
@@ -724,13 +731,14 @@ func buildSectionResponses(sections []authm.UserProfileSection) []*contracts.Pro
 
 func buildSectionResponse(section *authm.UserProfileSection) *contracts.ProfileSectionResponse {
 	return &contracts.ProfileSectionResponse{
-		ID:        section.ID,
-		Title:     section.Title,
-		Content:   section.Content,
-		Position:  section.Position,
-		IsVisible: section.IsVisible,
-		CreatedAt: section.CreatedAt,
-		UpdatedAt: section.UpdatedAt,
+		ID:          section.ID,
+		Title:       section.Title,
+		Content:     section.Content,
+		ContentHTML: profileMarkdown.Render(section.Content),
+		Position:    section.Position,
+		IsVisible:   section.IsVisible,
+		CreatedAt:   section.CreatedAt,
+		UpdatedAt:   section.UpdatedAt,
 	}
 }
 

--- a/backend/internal/services/user/contributor_profile_test.go
+++ b/backend/internal/services/user/contributor_profile_test.go
@@ -87,6 +87,41 @@ func TestValidatePrivacySettings(t *testing.T) {
 	})
 }
 
+// TestBuildSectionResponse_RendersContentHTML verifies PSY-747: the profile
+// section response exposes Content rendered to sanitized HTML in ContentHTML
+// while preserving the raw markdown in Content for edit round-tripping.
+func TestBuildSectionResponse_RendersContentHTML(t *testing.T) {
+	t.Run("RendersMarkdownToHTML", func(t *testing.T) {
+		section := &authm.UserProfileSection{
+			ID:      1,
+			Title:   "About",
+			Content: "I like **post-punk** and [shows](https://example.com).",
+		}
+		resp := buildSectionResponse(section)
+
+		// Raw markdown preserved for edit forms.
+		assert.Equal(t, "I like **post-punk** and [shows](https://example.com).", resp.Content)
+		// Rendered HTML carries the bold + link markup.
+		assert.Contains(t, resp.ContentHTML, "<strong>post-punk</strong>")
+		assert.Contains(t, resp.ContentHTML, `href="https://example.com"`)
+	})
+
+	t.Run("SanitizesScriptTags", func(t *testing.T) {
+		section := &authm.UserProfileSection{
+			Content: "Hello <script>alert('xss')</script> world",
+		}
+		resp := buildSectionResponse(section)
+
+		assert.NotContains(t, resp.ContentHTML, "<script>")
+		assert.NotContains(t, resp.ContentHTML, "alert('xss')")
+	})
+
+	t.Run("EmptyContentYieldsEmptyHTML", func(t *testing.T) {
+		resp := buildSectionResponse(&authm.UserProfileSection{Content: ""})
+		assert.Empty(t, resp.ContentHTML)
+	})
+}
+
 // =============================================================================
 // INTEGRATION TESTS (With Real Database)
 // =============================================================================


### PR DESCRIPTION
## Summary
- Reject non-http/https schemes (+ length caps) on `collection.cover_image_url`, `release.cover_art_url`, and `show.ticket_url`, reusing the PSY-525 `shared` URL-validation pattern.
- Render user profile section `Content` through the canonical `utils.MarkdownRenderer`, exposed as `ContentHTML` alongside the raw `Content` (matches tag/collection-description handling).
- Extracts `URLSchemeError` so both the value-style (`ValidateURLField`) and Huma `Resolve()`-style body paths share one length-cap + scheme-check implementation.

## Test plan
- [x] `cd backend && go build ./...` — passed
- [x] `cd backend && go test ./internal/api/handlers/shared/...` — passed
- [x] `cd backend && go test ./...` — full suite, 27 packages ok, 0 failures

## Manual repro
Backend-only, no migration (`--mode=none`) — the new unit tests are the repro. `url_validation_test.go` (+110 lines) asserts `javascript:`/`data:`/over-length values are rejected and valid http(s) accepted on each newly-guarded field; `contributor_profile_test.go` (+35 lines) asserts profile `ContentHTML` is rendered + sanitized via the canonical renderer while raw `Content` round-trips for editing.

## Simplify
Edited 1 file, −6 net lines: `ValidateURLField` now delegates to `URLSchemeError` instead of duplicating the length-cap + scheme logic. Behaviour-preserving; shared-package tests unchanged and green.

## Note for reviewer
Opened by the orchestrator as a take-over: the dispatched agent completed + committed the implementation and ran build+tests green, then hit "API Error: Overloaded" mid-`/simplify` before it could commit the simplify pass, push, or open this PR. The orchestrator committed the (already-build+test-verified) simplify edit, re-ran the full suite (green), and pushed. Follow-up: a frontend ticket may be needed to switch profile-section rendering to `ContentHTML` — being assessed separately.

Closes PSY-747