### PR TITLE
PSY-697: add useUrlHash test coverage

### DIFF
--- a/frontend/lib/hooks/common/useUrlHash.test.ts
+++ b/frontend/lib/hooks/common/useUrlHash.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { useUrlHash, GRAPH_HASH } from './useUrlHash'
+
+/**
+ * Set `window.location.hash` and fire the `hashchange` event the hook
+ * subscribes to. jsdom updates `location.hash` synchronously but does NOT
+ * auto-dispatch `hashchange`, so we dispatch it ourselves.
+ */
+function setHash(hash: string): void {
+  window.location.hash = hash
+  window.dispatchEvent(new HashChangeEvent('hashchange'))
+}
+
+describe('useUrlHash', () => {
+  afterEach(() => {
+    // Reset the shared jsdom location between tests so hash state doesn't leak.
+    window.location.hash = ''
+  })
+
+  it('returns "" on the server (getServerSnapshot)', () => {
+    // useSyncExternalStore calls getServerSnapshot during server rendering.
+    // renderToStaticMarkup exercises that path without touching jsdom's
+    // window.location, so the "" server snapshot is what gets serialized.
+    function Probe() {
+      return createElement('span', null, `[${useUrlHash()}]`)
+    }
+    const html = renderToStaticMarkup(createElement(Probe))
+    expect(html).toBe('<span>[]</span>')
+  })
+
+  it('reads the current hash on the client (getSnapshot)', () => {
+    window.location.hash = GRAPH_HASH
+    const { result } = renderHook(() => useUrlHash())
+    expect(result.current).toBe(GRAPH_HASH)
+  })
+
+  it('updates the value when a hashchange event fires', () => {
+    const { result } = renderHook(() => useUrlHash())
+    expect(result.current).toBe('')
+
+    act(() => {
+      setHash(GRAPH_HASH)
+    })
+    expect(result.current).toBe(GRAPH_HASH)
+
+    act(() => {
+      setHash('#other')
+    })
+    expect(result.current).toBe('#other')
+  })
+
+  it('removes the hashchange listener on unmount', () => {
+    const { result, unmount } = renderHook(() => useUrlHash())
+
+    act(() => {
+      setHash(GRAPH_HASH)
+    })
+    expect(result.current).toBe(GRAPH_HASH)
+
+    unmount()
+
+    // After unmount the listener is gone, so a later hashchange must not
+    // re-render the hook. The last value the hook reported stays put.
+    act(() => {
+      setHash('#after-unmount')
+    })
+    expect(result.current).toBe(GRAPH_HASH)
+  })
+})


### PR DESCRIPTION
## Summary
- Adds `useUrlHash.test.ts` — the last untested hook in `frontend/lib/hooks/common/`. Per the PSY-697 reconciliation comment (2026-05-19), every other hook in scope (`useEntitySearch`, `useFollow`, `useRevisions`, `useCommandPalette`, `usePrefetchRoutes`) is already covered by prior work, leaving this one file.
- `useUrlHash` wraps `useSyncExternalStore`. Tests assert the three contract behaviors: the `""` server snapshot (via `renderToStaticMarkup`, matching `app/global-error.test.tsx`), the client hash read + `hashchange`-driven re-render, and `hashchange` listener cleanup on unmount.
- Follows the in-repo `useSyncExternalStore` test shape from `useLocalStorageEnum.test.ts` (`dispatchEvent(new HashChangeEvent(...))`).

## Test plan
- [x] `cd frontend && bun run typecheck` — passes, no errors
- [x] `cd frontend && bun run test:run lib/hooks/common` — 10 files, 100 tests pass (4 new in `useUrlHash.test.ts`)

## Manual repro
Test-only diff; the scoped suite is the verification. No runtime/UI behavior changes.

## Simplify
Ran the manual 3-lens fallback (reuse / quality / efficiency) — the Agent tool is unavailable in this dispatched context. Code was already clean: reuses established in-repo idioms (`HashChangeEvent` dispatch, `renderToStaticMarkup`, `createElement` in a `.ts` test, exported `GRAPH_HASH` constant), comments capture only non-obvious WHY, and cleanup is handled via both the global RTL `cleanup()` and a file-local hash reset. No edits needed.

Closes PSY-697