### PR TITLE
PSY-734: privacy-mask Sentry session replay

### DIFF
--- a/frontend/instrumentation-client.test.ts
+++ b/frontend/instrumentation-client.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from 'vitest'
+import * as Sentry from '@sentry/nextjs'
+
+// Sentry.init + replayIntegration both run at module-load time, so the
+// mock must be in place before instrumentation-client is imported below.
+vi.mock('@sentry/nextjs', () => ({
+  init: vi.fn(),
+  replayIntegration: vi.fn((options) => ({ name: 'Replay', options })),
+  captureRouterTransitionStart: vi.fn(),
+}))
+
+describe('instrumentation-client.ts', () => {
+  // A single test because the module's Sentry.init / replayIntegration calls
+  // are one-time module-load side effects; the global afterEach clears mock
+  // call records, so a second `it` would see zero recorded calls.
+  it('loads and masks all text + blocks all media in session replay (privacy posture)', async () => {
+    await import('./instrumentation-client')
+
+    expect(Sentry.init).toHaveBeenCalledTimes(1)
+    expect(Sentry.replayIntegration).toHaveBeenCalledWith({
+      maskAllText: true,
+      blockAllMedia: true,
+    })
+  })
+})

--- a/frontend/instrumentation-client.ts
+++ b/frontend/instrumentation-client.ts
@@ -20,9 +20,9 @@ Sentry.init({
   integrations: [
     Sentry.replayIntegration({
       // Mask all text for privacy
-      maskAllText: false,
-      // Block all media for performance
-      blockAllMedia: false,
+      maskAllText: true,
+      // Block all media for privacy
+      blockAllMedia: true,
     }),
   ],
 })


### PR DESCRIPTION
## Summary
- Flip Sentry Session Replay to `maskAllText: true` + `blockAllMedia: true` in `frontend/instrumentation-client.ts` so recorded sessions redact user text and media by default.
- Align the surrounding comments with the values (the `blockAllMedia` comment previously said "for performance" while the intent — and the `maskAllText` comment — is privacy).
- Add `frontend/instrumentation-client.test.ts`: a module-load test asserting `Sentry.init` runs once and `replayIntegration` is configured with both masking flags `true`.

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun run test:run instrumentation` passes (1 test)

## Manual repro
Config-only change. Sentry replay masking is verified at deploy time via a Sentry replay spot-check (confirm a captured session redacts text/media). Local verification is limited to: the module imports without error and `Sentry.init` is called with the masked replay values (asserted by the new test). Per-environment replay sampling lives behind `NODE_ENV === 'production'`, so no replay is captured in local/dev runs.

## Simplify
Ran the simplify review (reuse / quality / efficiency) inline. Findings: `replayIntegration` is configured in exactly one place (replay is client-only; the edge/server Sentry configs don't touch it), so no duplication; the test mock follows the existing `vi.mock('@sentry/nextjs', ...)` convention from `app/global-error.test.tsx`; comments document non-obvious WHY only (no ticket refs in source per project convention); no hot-path or efficiency concerns (startup config, booleans flipped). No changes needed.

Closes PSY-734