### PR TITLE
PSY-706: cover artists/comments/shows/venues api.ts (endpoints + query keys)

### DIFF
--- a/frontend/features/artists/api.test.ts
+++ b/frontend/features/artists/api.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest'
+import { API_BASE_URL } from '@/lib/api-base'
+import { artistEndpoints, artistQueryKeys } from './api'
+
+describe('artistEndpoints', () => {
+  it('exposes static collection endpoints rooted at the API base URL', () => {
+    expect(artistEndpoints.LIST).toBe(`${API_BASE_URL}/artists`)
+    expect(artistEndpoints.CITIES).toBe(`${API_BASE_URL}/artists/cities`)
+    expect(artistEndpoints.SEARCH).toBe(`${API_BASE_URL}/artists/search`)
+  })
+
+  it('builds a detail endpoint from a numeric id or a slug', () => {
+    expect(artistEndpoints.GET(42)).toBe(`${API_BASE_URL}/artists/42`)
+    expect(artistEndpoints.GET('gatecreeper')).toBe(
+      `${API_BASE_URL}/artists/gatecreeper`
+    )
+  })
+
+  it('builds nested relation endpoints from an id or slug', () => {
+    expect(artistEndpoints.SHOWS('gatecreeper')).toBe(
+      `${API_BASE_URL}/artists/gatecreeper/shows`
+    )
+    expect(artistEndpoints.LABELS('gatecreeper')).toBe(
+      `${API_BASE_URL}/artists/gatecreeper/labels`
+    )
+    expect(artistEndpoints.ALIASES(7)).toBe(`${API_BASE_URL}/artists/7/aliases`)
+    expect(artistEndpoints.GRAPH(7)).toBe(`${API_BASE_URL}/artists/7/graph`)
+    expect(artistEndpoints.BILL_COMPOSITION(7)).toBe(
+      `${API_BASE_URL}/artists/7/bill-composition`
+    )
+    expect(artistEndpoints.RELATED(7)).toBe(`${API_BASE_URL}/artists/7/related`)
+  })
+
+  it('builds mutation + report endpoints from an artist id', () => {
+    expect(artistEndpoints.DELETE(7)).toBe(`${API_BASE_URL}/artists/7`)
+    expect(artistEndpoints.REPORT(7)).toBe(`${API_BASE_URL}/artists/7/report`)
+    expect(artistEndpoints.MY_REPORT(7)).toBe(
+      `${API_BASE_URL}/artists/7/my-report`
+    )
+  })
+
+  it('builds relationship endpoints, interpolating both ids in VOTE', () => {
+    expect(artistEndpoints.RELATIONSHIPS.CREATE).toBe(
+      `${API_BASE_URL}/artists/relationships`
+    )
+    expect(artistEndpoints.RELATIONSHIPS.VOTE(3, 9)).toBe(
+      `${API_BASE_URL}/artists/relationships/3/9/vote`
+    )
+  })
+})
+
+describe('artistQueryKeys', () => {
+  it('uses a stable root key for cache invalidation', () => {
+    expect(artistQueryKeys.all).toEqual(['artists'])
+  })
+
+  it('namespaces list keys with the filters object', () => {
+    expect(artistQueryKeys.list()).toEqual(['artists', 'list', undefined])
+    expect(artistQueryKeys.list({ city: 'Phoenix' })).toEqual([
+      'artists',
+      'list',
+      { city: 'Phoenix' },
+    ])
+  })
+
+  it('exposes a static cities key', () => {
+    expect(artistQueryKeys.cities).toEqual(['artists', 'cities'])
+  })
+
+  it('lower-cases the query in search keys so case variants share a cache entry', () => {
+    expect(artistQueryKeys.search('Gatecreeper')).toEqual([
+      'artists',
+      'search',
+      'gatecreeper',
+    ])
+  })
+
+  it('stringifies ids in detail / shows / labels keys for stable equality', () => {
+    expect(artistQueryKeys.detail(42)).toEqual(['artists', 'detail', '42'])
+    expect(artistQueryKeys.detail('gatecreeper')).toEqual([
+      'artists',
+      'detail',
+      'gatecreeper',
+    ])
+    expect(artistQueryKeys.shows(42)).toEqual(['artists', 'shows', '42'])
+    expect(artistQueryKeys.labels(42)).toEqual(['artists', 'labels', '42'])
+  })
+
+  it('produces identical detail keys for a numeric id and its string form', () => {
+    expect(artistQueryKeys.detail(42)).toEqual(artistQueryKeys.detail('42'))
+  })
+
+  it('keeps the aliases key numeric (no stringify)', () => {
+    expect(artistQueryKeys.aliases(7)).toEqual(['artists', 'aliases', 7])
+  })
+
+  it('carries the optional types array in the graph key', () => {
+    expect(artistQueryKeys.graph(7)).toEqual([
+      'artists',
+      'graph',
+      '7',
+      undefined,
+    ])
+    expect(artistQueryKeys.graph(7, ['radio_cooccurrence'])).toEqual([
+      'artists',
+      'graph',
+      '7',
+      ['radio_cooccurrence'],
+    ])
+  })
+
+  it('carries the months window in the billComposition key', () => {
+    expect(artistQueryKeys.billComposition(7, 12)).toEqual([
+      'artists',
+      'billComposition',
+      '7',
+      12,
+    ])
+  })
+})

--- a/frontend/features/comments/api.test.ts
+++ b/frontend/features/comments/api.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import { API_BASE_URL } from '@/lib/api-base'
+import {
+  commentEndpoints,
+  commentPreferencesEndpoints,
+  fieldNoteEndpoints,
+  commentQueryKeys,
+  fieldNoteQueryKeys,
+} from './api'
+
+describe('commentEndpoints', () => {
+  it('builds polymorphic entity comment endpoints from type + id', () => {
+    expect(commentEndpoints.LIST('artist', 42)).toBe(
+      `${API_BASE_URL}/entities/artist/42/comments`
+    )
+    expect(commentEndpoints.CREATE('venue', 7)).toBe(
+      `${API_BASE_URL}/entities/venue/7/comments`
+    )
+  })
+
+  it('builds comment-scoped endpoints from a comment id', () => {
+    expect(commentEndpoints.REPLY(5)).toBe(
+      `${API_BASE_URL}/comments/5/replies`
+    )
+    expect(commentEndpoints.UPDATE(5)).toBe(`${API_BASE_URL}/comments/5`)
+    expect(commentEndpoints.DELETE(5)).toBe(`${API_BASE_URL}/comments/5`)
+    expect(commentEndpoints.VOTE(5)).toBe(`${API_BASE_URL}/comments/5/vote`)
+    expect(commentEndpoints.THREAD(5)).toBe(`${API_BASE_URL}/comments/5/thread`)
+    expect(commentEndpoints.REPLY_PERMISSION(5)).toBe(
+      `${API_BASE_URL}/comments/5/reply-permission`
+    )
+  })
+})
+
+describe('commentPreferencesEndpoints', () => {
+  it('exposes the default-reply-permission preference endpoint', () => {
+    expect(commentPreferencesEndpoints.DEFAULT_REPLY_PERMISSION).toBe(
+      `${API_BASE_URL}/auth/preferences/default-reply-permission`
+    )
+  })
+})
+
+describe('fieldNoteEndpoints', () => {
+  it('builds show-scoped field-note endpoints from a show id', () => {
+    expect(fieldNoteEndpoints.LIST(11)).toBe(
+      `${API_BASE_URL}/shows/11/field-notes`
+    )
+    expect(fieldNoteEndpoints.CREATE(11)).toBe(
+      `${API_BASE_URL}/shows/11/field-notes`
+    )
+  })
+})
+
+describe('commentQueryKeys', () => {
+  it('uses a stable root key for cache invalidation', () => {
+    expect(commentQueryKeys.all).toEqual(['comments'])
+  })
+
+  it('scopes the entity key by both the type and the numeric id', () => {
+    expect(commentQueryKeys.entity('artist', 42)).toEqual([
+      'comments',
+      'artist',
+      42,
+    ])
+  })
+
+  it('namespaces the thread key under the comment id', () => {
+    expect(commentQueryKeys.thread(5)).toEqual(['comments', 'thread', 5])
+  })
+})
+
+describe('fieldNoteQueryKeys', () => {
+  it('uses a stable root key for cache invalidation', () => {
+    expect(fieldNoteQueryKeys.all).toEqual(['field-notes'])
+  })
+
+  it('scopes the show key by the numeric show id', () => {
+    expect(fieldNoteQueryKeys.show(11)).toEqual(['field-notes', 11])
+  })
+})

--- a/frontend/features/shows/api.test.ts
+++ b/frontend/features/shows/api.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest'
+import { API_BASE_URL } from '@/lib/api-base'
+import { showEndpoints, showQueryKeys } from './api'
+
+describe('showEndpoints', () => {
+  it('exposes static collection endpoints rooted at the API base URL', () => {
+    expect(showEndpoints.SUBMIT).toBe(`${API_BASE_URL}/shows`)
+    expect(showEndpoints.UPCOMING).toBe(`${API_BASE_URL}/shows/upcoming`)
+    expect(showEndpoints.CITIES).toBe(`${API_BASE_URL}/shows/cities`)
+    expect(showEndpoints.SEARCH).toBe(`${API_BASE_URL}/shows/search`)
+    expect(showEndpoints.MY_SUBMISSIONS).toBe(
+      `${API_BASE_URL}/shows/my-submissions`
+    )
+  })
+
+  it('builds detail + mutation endpoints from a show id', () => {
+    expect(showEndpoints.GET(42)).toBe(`${API_BASE_URL}/shows/42`)
+    expect(showEndpoints.GET('some-show-slug')).toBe(
+      `${API_BASE_URL}/shows/some-show-slug`
+    )
+    expect(showEndpoints.UPDATE(42)).toBe(`${API_BASE_URL}/shows/42`)
+    expect(showEndpoints.DELETE(42)).toBe(`${API_BASE_URL}/shows/42`)
+  })
+
+  it('builds status-transition endpoints from a show id', () => {
+    expect(showEndpoints.UNPUBLISH(42)).toBe(
+      `${API_BASE_URL}/shows/42/unpublish`
+    )
+    expect(showEndpoints.MAKE_PRIVATE(42)).toBe(
+      `${API_BASE_URL}/shows/42/make-private`
+    )
+    expect(showEndpoints.PUBLISH(42)).toBe(`${API_BASE_URL}/shows/42/publish`)
+    expect(showEndpoints.SET_SOLD_OUT(42)).toBe(
+      `${API_BASE_URL}/shows/42/sold-out`
+    )
+    expect(showEndpoints.SET_CANCELLED(42)).toBe(
+      `${API_BASE_URL}/shows/42/cancelled`
+    )
+  })
+
+  it('builds export + report endpoints from a show id', () => {
+    expect(showEndpoints.EXPORT(42)).toBe(`${API_BASE_URL}/shows/42/export`)
+    expect(showEndpoints.REPORT(42)).toBe(`${API_BASE_URL}/shows/42/report`)
+    expect(showEndpoints.MY_REPORT(42)).toBe(
+      `${API_BASE_URL}/shows/42/my-report`
+    )
+  })
+})
+
+describe('showQueryKeys', () => {
+  it('uses a stable root key for cache invalidation', () => {
+    expect(showQueryKeys.all).toEqual(['shows'])
+  })
+
+  it('namespaces list keys with the filters object', () => {
+    expect(showQueryKeys.list()).toEqual(['shows', 'list', undefined])
+    expect(showQueryKeys.list({ city: 'Phoenix' })).toEqual([
+      'shows',
+      'list',
+      { city: 'Phoenix' },
+    ])
+  })
+
+  it('carries the optional timezone segment in the cities key', () => {
+    expect(showQueryKeys.cities()).toEqual(['shows', 'cities', undefined])
+    expect(showQueryKeys.cities('America/Phoenix')).toEqual([
+      'shows',
+      'cities',
+      'America/Phoenix',
+    ])
+  })
+
+  it('scopes the detail key by id', () => {
+    expect(showQueryKeys.detail('42')).toEqual(['shows', 'detail', '42'])
+  })
+
+  it('scopes the userShows key by user id', () => {
+    expect(showQueryKeys.userShows('user-7')).toEqual([
+      'shows',
+      'user',
+      'user-7',
+    ])
+  })
+
+  it('lower-cases the query in search keys so case variants share a cache entry', () => {
+    expect(showQueryKeys.search('Gatecreeper FEST')).toEqual([
+      'shows',
+      'search',
+      'gatecreeper fest',
+    ])
+  })
+})

--- a/frontend/features/venues/api.test.ts
+++ b/frontend/features/venues/api.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest'
+import { API_BASE_URL } from '@/lib/api-base'
+import { venueEndpoints, venueQueryKeys } from './api'
+
+describe('venueEndpoints', () => {
+  it('exposes static collection endpoints rooted at the API base URL', () => {
+    expect(venueEndpoints.LIST).toBe(`${API_BASE_URL}/venues`)
+    expect(venueEndpoints.CITIES).toBe(`${API_BASE_URL}/venues/cities`)
+    expect(venueEndpoints.SEARCH).toBe(`${API_BASE_URL}/venues/search`)
+  })
+
+  it('builds a detail endpoint from a numeric id or a slug', () => {
+    expect(venueEndpoints.GET(42)).toBe(`${API_BASE_URL}/venues/42`)
+    expect(venueEndpoints.GET('the-rebel-lounge')).toBe(
+      `${API_BASE_URL}/venues/the-rebel-lounge`
+    )
+  })
+
+  it('builds nested relation endpoints from an id or slug', () => {
+    expect(venueEndpoints.SHOWS('the-rebel-lounge')).toBe(
+      `${API_BASE_URL}/venues/the-rebel-lounge/shows`
+    )
+    expect(venueEndpoints.GENRES('the-rebel-lounge')).toBe(
+      `${API_BASE_URL}/venues/the-rebel-lounge/genres`
+    )
+    expect(venueEndpoints.BILL_NETWORK('the-rebel-lounge')).toBe(
+      `${API_BASE_URL}/venues/the-rebel-lounge/bill-network`
+    )
+  })
+
+  it('builds mutation endpoints from an id or slug', () => {
+    expect(venueEndpoints.UPDATE(42)).toBe(`${API_BASE_URL}/venues/42`)
+    expect(venueEndpoints.DELETE(42)).toBe(`${API_BASE_URL}/venues/42`)
+  })
+})
+
+describe('venueQueryKeys', () => {
+  it('uses a stable root key for cache invalidation', () => {
+    expect(venueQueryKeys.all).toEqual(['venues'])
+  })
+
+  it('namespaces list keys with the filters object', () => {
+    expect(venueQueryKeys.list()).toEqual(['venues', 'list', undefined])
+    expect(venueQueryKeys.list({ city: 'Phoenix' })).toEqual([
+      'venues',
+      'list',
+      { city: 'Phoenix' },
+    ])
+  })
+
+  it('exposes a static cities key', () => {
+    expect(venueQueryKeys.cities).toEqual(['venues', 'cities'])
+  })
+
+  it('lower-cases the query in search keys so case variants share a cache entry', () => {
+    expect(venueQueryKeys.search('The Rebel Lounge')).toEqual([
+      'venues',
+      'search',
+      'the rebel lounge',
+    ])
+  })
+
+  it('stringifies ids in detail / shows / genres keys for stable equality', () => {
+    expect(venueQueryKeys.detail(42)).toEqual(['venues', 'detail', '42'])
+    expect(venueQueryKeys.detail('the-rebel-lounge')).toEqual([
+      'venues',
+      'detail',
+      'the-rebel-lounge',
+    ])
+    expect(venueQueryKeys.shows(42)).toEqual(['venues', 'shows', '42'])
+    expect(venueQueryKeys.genres(42)).toEqual(['venues', 'genres', '42'])
+  })
+
+  it('produces identical detail keys for a numeric id and its string form', () => {
+    expect(venueQueryKeys.detail(42)).toEqual(venueQueryKeys.detail('42'))
+  })
+
+  it('keys billNetwork by venue + window, coercing a missing year to null', () => {
+    expect(venueQueryKeys.billNetwork(42, 'all')).toEqual([
+      'venues',
+      'bill-network',
+      '42',
+      'all',
+      null,
+    ])
+    expect(venueQueryKeys.billNetwork(42, 'year', 2025)).toEqual([
+      'venues',
+      'bill-network',
+      '42',
+      'year',
+      2025,
+    ])
+  })
+})


### PR DESCRIPTION
## Summary
- Adds sibling `api.test.ts` for the four feature modules whose `api.ts` was still untested: **artists, comments, shows, venues**. (festivals/labels/radio/releases were already covered by the wave-2 sweeps, per the PSY-706 reconciliation comment.)
- Pure-function tests (plain `describe`/`it`/`expect`, no React/RTL) asserting endpoint URL construction — including param interpolation like `GET(slug)`, `RELATIONSHIPS.VOTE(a, b)`, `billNetwork(id, window, year)` — and query-key tuple shapes.
- 44 new assertions guard against a typo in an endpoint URL or a mismatched cache-key tuple, which otherwise fail silently (caught by React Query → empty state) rather than loudly.

Endpoint base is asserted via `import { API_BASE_URL }` (matching the existing `features/labels/api.test.ts` style), pinned to `http://localhost:8080` by the vitest config.

Closes PSY-706

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run test:run features/artists features/comments features/shows features/venues` — 67 files / 859 tests pass (44 new)
- [x] Test-only change; no production code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)