### PR TITLE
PSY-708: cover remaining hooks/index.ts barrels

### DIFF
--- a/frontend/features/artists/hooks/index.test.ts
+++ b/frontend/features/artists/hooks/index.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import * as hooks from './index'
+
+// Low-cost guard against accidental rename/delete in the barrel: assert each
+// named hook re-export resolves to a callable function. Grouped by source
+// module so a missing module surfaces an obvious cluster of failures.
+describe('artists hooks barrel', () => {
+  it('re-exports the useArtists hooks', () => {
+    expect(typeof hooks.useArtists).toBe('function')
+    expect(typeof hooks.useArtistCities).toBe('function')
+    expect(typeof hooks.useArtist).toBe('function')
+    expect(typeof hooks.useArtistShows).toBe('function')
+  })
+
+  it('re-exports the artist search hook', () => {
+    expect(typeof hooks.useArtistSearch).toBe('function')
+  })
+
+  it('re-exports the artist report hooks', () => {
+    expect(typeof hooks.useMyArtistReport).toBe('function')
+    expect(typeof hooks.useReportArtist).toBe('function')
+  })
+
+  it('re-exports the artist graph hooks', () => {
+    expect(typeof hooks.useArtistGraph).toBe('function')
+    expect(typeof hooks.useArtistRelationshipVote).toBe('function')
+    expect(typeof hooks.useCreateArtistRelationship).toBe('function')
+  })
+
+  it('re-exports the reduced-motion hook', () => {
+    expect(typeof hooks.useReducedMotion).toBe('function')
+  })
+})

--- a/frontend/features/auth/hooks/index.test.ts
+++ b/frontend/features/auth/hooks/index.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import * as hooks from './index'
+
+// Low-cost guard against accidental rename/delete in the barrel: assert each
+// named hook re-export resolves to a callable function. Grouped by source
+// module so a missing module surfaces an obvious cluster of failures.
+describe('auth hooks barrel', () => {
+  it('re-exports the core auth hooks', () => {
+    expect(typeof hooks.useLogin).toBe('function')
+    expect(typeof hooks.useRegister).toBe('function')
+    expect(typeof hooks.useLogout).toBe('function')
+    expect(typeof hooks.useProfile).toBe('function')
+    expect(typeof hooks.useUpdateProfile).toBe('function')
+    expect(typeof hooks.useRefreshToken).toBe('function')
+    expect(typeof hooks.useIsAuthenticated).toBe('function')
+    expect(typeof hooks.useSendVerificationEmail).toBe('function')
+    expect(typeof hooks.useConfirmVerification).toBe('function')
+    expect(typeof hooks.useChangePassword).toBe('function')
+    expect(typeof hooks.useSendMagicLink).toBe('function')
+    expect(typeof hooks.useVerifyMagicLink).toBe('function')
+    expect(typeof hooks.useDeletionSummary).toBe('function')
+    expect(typeof hooks.useDeleteAccount).toBe('function')
+    expect(typeof hooks.useExportData).toBe('function')
+    expect(typeof hooks.useOAuthAccounts).toBe('function')
+    expect(typeof hooks.useUnlinkOAuthAccount).toBe('function')
+    expect(typeof hooks.useRecoverAccount).toBe('function')
+    expect(typeof hooks.useRequestAccountRecovery).toBe('function')
+    expect(typeof hooks.useConfirmAccountRecovery).toBe('function')
+    expect(typeof hooks.useGenerateCLIToken).toBe('function')
+    expect(typeof hooks.useAPITokens).toBe('function')
+    expect(typeof hooks.useCreateAPIToken).toBe('function')
+    expect(typeof hooks.useRevokeAPIToken).toBe('function')
+  })
+
+  it('re-exports the calendar-feed hooks', () => {
+    expect(typeof hooks.useCalendarTokenStatus).toBe('function')
+    expect(typeof hooks.useCreateCalendarToken).toBe('function')
+    expect(typeof hooks.useDeleteCalendarToken).toBe('function')
+  })
+
+  it('re-exports the favorite-cities hook', () => {
+    expect(typeof hooks.useSetFavoriteCities).toBe('function')
+  })
+
+  it('re-exports the favorite-venues hooks', () => {
+    expect(typeof hooks.useFavoriteVenues).toBe('function')
+    expect(typeof hooks.useIsVenueFavorited).toBe('function')
+    expect(typeof hooks.useFavoriteVenue).toBe('function')
+    expect(typeof hooks.useUnfavoriteVenue).toBe('function')
+    expect(typeof hooks.useFavoriteVenueToggle).toBe('function')
+    expect(typeof hooks.useFavoriteVenueShows).toBe('function')
+  })
+
+  it('re-exports the contributor-profile hooks', () => {
+    expect(typeof hooks.usePublicProfile).toBe('function')
+    expect(typeof hooks.usePublicContributions).toBe('function')
+    expect(typeof hooks.useActivityHeatmap).toBe('function')
+    expect(typeof hooks.usePercentileRankings).toBe('function')
+    expect(typeof hooks.useOwnContributorProfile).toBe('function')
+    expect(typeof hooks.useOwnContributions).toBe('function')
+    expect(typeof hooks.useOwnSections).toBe('function')
+    expect(typeof hooks.useUpdateVisibility).toBe('function')
+    expect(typeof hooks.useUpdatePrivacy).toBe('function')
+    expect(typeof hooks.useCreateSection).toBe('function')
+    expect(typeof hooks.useUpdateSection).toBe('function')
+    expect(typeof hooks.useDeleteSection).toBe('function')
+  })
+})

--- a/frontend/features/charts/hooks/index.test.ts
+++ b/frontend/features/charts/hooks/index.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import * as hooks from './index'
+
+// Low-cost guard against accidental rename/delete in the barrel: assert each
+// named hook re-export resolves to a callable function.
+describe('charts hooks barrel', () => {
+  it('re-exports the charts hooks', () => {
+    expect(typeof hooks.useChartsOverview).toBe('function')
+    expect(typeof hooks.useTrendingShows).toBe('function')
+    expect(typeof hooks.usePopularArtists).toBe('function')
+    expect(typeof hooks.useActiveVenues).toBe('function')
+    expect(typeof hooks.useHotReleases).toBe('function')
+  })
+})

--- a/frontend/features/community/hooks/index.test.ts
+++ b/frontend/features/community/hooks/index.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest'
+import * as hooks from './index'
+
+// Low-cost guard against accidental rename/delete in the barrel: assert each
+// named hook re-export resolves to a callable function.
+describe('community hooks barrel', () => {
+  it('re-exports the leaderboard hook', () => {
+    expect(typeof hooks.useLeaderboard).toBe('function')
+  })
+})

--- a/frontend/features/contributions/hooks/index.test.ts
+++ b/frontend/features/contributions/hooks/index.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import * as hooks from './index'
+
+// Low-cost guard against accidental rename/delete in the barrel: assert each
+// named hook re-export resolves to a callable function. Type-only re-exports
+// (EntityAttribution, DataGap) have no runtime presence and are not asserted.
+describe('contributions hooks barrel', () => {
+  it('re-exports the contribution hooks', () => {
+    expect(typeof hooks.useSuggestEdit).toBe('function')
+    expect(typeof hooks.useShowEdit).toBe('function')
+    expect(typeof hooks.useEntityAttribution).toBe('function')
+    expect(typeof hooks.useReportEntity).toBe('function')
+    expect(typeof hooks.useContributeOpportunities).toBe('function')
+    expect(typeof hooks.useContributeCategory).toBe('function')
+    expect(typeof hooks.useDataGaps).toBe('function')
+    expect(typeof hooks.useEntitySaveSuccessBanner).toBe('function')
+    expect(typeof hooks.useMyPendingEdits).toBe('function')
+    expect(typeof hooks.useCancelPendingEdit).toBe('function')
+  })
+})

--- a/frontend/features/labels/hooks/index.test.ts
+++ b/frontend/features/labels/hooks/index.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import * as hooks from './index'
+
+// Low-cost guard against accidental rename/delete in the barrel: assert each
+// named hook re-export resolves to a callable function. Type-only re-exports
+// (CreateLabelInput, UpdateLabelInput) have no runtime presence and are not
+// asserted.
+describe('labels hooks barrel', () => {
+  it('re-exports the read hooks', () => {
+    expect(typeof hooks.useLabels).toBe('function')
+    expect(typeof hooks.useLabel).toBe('function')
+    expect(typeof hooks.useArtistLabels).toBe('function')
+    expect(typeof hooks.useLabelRoster).toBe('function')
+    expect(typeof hooks.useLabelCatalog).toBe('function')
+  })
+
+  it('re-exports the label search hook', () => {
+    expect(typeof hooks.useLabelSearch).toBe('function')
+  })
+
+  it('re-exports the admin mutation hooks', () => {
+    expect(typeof hooks.useCreateLabel).toBe('function')
+    expect(typeof hooks.useUpdateLabel).toBe('function')
+    expect(typeof hooks.useDeleteLabel).toBe('function')
+  })
+})

--- a/frontend/features/radio/hooks/index.test.ts
+++ b/frontend/features/radio/hooks/index.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+import * as hooks from './index'
+
+// Low-cost guard against accidental rename/delete in the barrel: assert each
+// named hook re-export resolves to a callable function.
+describe('radio hooks barrel', () => {
+  it('re-exports the radio hooks', () => {
+    expect(typeof hooks.useRadioStations).toBe('function')
+    expect(typeof hooks.useRadioStation).toBe('function')
+    expect(typeof hooks.useRadioShows).toBe('function')
+    expect(typeof hooks.useRadioShow).toBe('function')
+    expect(typeof hooks.useRadioEpisodes).toBe('function')
+    expect(typeof hooks.useRadioEpisode).toBe('function')
+    expect(typeof hooks.useRadioTopArtists).toBe('function')
+    expect(typeof hooks.useRadioTopLabels).toBe('function')
+    expect(typeof hooks.useArtistRadioPlays).toBe('function')
+    expect(typeof hooks.useReleaseRadioPlays).toBe('function')
+    expect(typeof hooks.useNewReleaseRadar).toBe('function')
+    expect(typeof hooks.useRadioStats).toBe('function')
+  })
+})

--- a/frontend/features/releases/hooks/index.test.ts
+++ b/frontend/features/releases/hooks/index.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import * as hooks from './index'
+
+// Low-cost guard against accidental rename/delete in the barrel: assert each
+// named hook re-export resolves to a callable function. Type-only re-exports
+// (CreateReleaseArtistInput, CreateReleaseLinkInput, CreateReleaseInput,
+// UpdateReleaseInput) have no runtime presence and are not asserted.
+describe('releases hooks barrel', () => {
+  it('re-exports the read hooks', () => {
+    expect(typeof hooks.useReleases).toBe('function')
+    expect(typeof hooks.useRelease).toBe('function')
+    expect(typeof hooks.useArtistReleases).toBe('function')
+  })
+
+  it('re-exports the admin mutation hooks', () => {
+    expect(typeof hooks.useCreateRelease).toBe('function')
+    expect(typeof hooks.useUpdateRelease).toBe('function')
+    expect(typeof hooks.useDeleteRelease).toBe('function')
+    expect(typeof hooks.useAddReleaseLink).toBe('function')
+    expect(typeof hooks.useRemoveReleaseLink).toBe('function')
+  })
+})

--- a/frontend/features/scenes/hooks/index.test.ts
+++ b/frontend/features/scenes/hooks/index.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import * as hooks from './index'
+
+// Low-cost guard against accidental rename/delete in the barrel: assert each
+// named hook re-export resolves to a callable function.
+describe('scenes hooks barrel', () => {
+  it('re-exports the scenes hooks', () => {
+    expect(typeof hooks.useScenes).toBe('function')
+    expect(typeof hooks.useSceneDetail).toBe('function')
+    expect(typeof hooks.useSceneArtists).toBe('function')
+    expect(typeof hooks.useSceneGenres).toBe('function')
+    expect(typeof hooks.useSceneGraph).toBe('function')
+  })
+})

--- a/frontend/features/shows/hooks/index.test.ts
+++ b/frontend/features/shows/hooks/index.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import * as hooks from './index'
+
+// Low-cost guard against accidental rename/delete in the barrel: assert each
+// named hook re-export resolves to a callable function. Grouped by source
+// module so a missing module surfaces an obvious cluster of failures.
+// Type-only re-exports (ExportShowData, VenueMatchResult, ArtistMatchResult,
+// ImportPreviewResponse, ShowSubmission, ShowUpdate*, ShowUpdateResponse) have
+// no runtime presence and are not asserted.
+describe('shows hooks barrel', () => {
+  it('re-exports the useShows read hooks', () => {
+    expect(typeof hooks.useUpcomingShows).toBe('function')
+    expect(typeof hooks.useShow).toBe('function')
+    expect(typeof hooks.useShowCities).toBe('function')
+  })
+
+  it('re-exports the delete / extraction hooks', () => {
+    expect(typeof hooks.useShowDelete).toBe('function')
+    expect(typeof hooks.useShowExtraction).toBe('function')
+  })
+
+  it('re-exports the import hooks', () => {
+    expect(typeof hooks.useShowImportPreview).toBe('function')
+    expect(typeof hooks.useShowImportConfirm).toBe('function')
+  })
+
+  it('re-exports the visibility / reminder hooks', () => {
+    expect(typeof hooks.useShowMakePrivate).toBe('function')
+    expect(typeof hooks.useShowPublish).toBe('function')
+    expect(typeof hooks.useSetShowReminders).toBe('function')
+    expect(typeof hooks.useShowUnpublish).toBe('function')
+  })
+
+  it('re-exports the report hooks', () => {
+    expect(typeof hooks.useMyShowReport).toBe('function')
+    expect(typeof hooks.useReportShow).toBe('function')
+  })
+
+  it('re-exports the submit / update hooks', () => {
+    expect(typeof hooks.useShowSubmit).toBe('function')
+    expect(typeof hooks.useShowUpdate).toBe('function')
+    expect(typeof hooks.useMySubmissions).toBe('function')
+  })
+
+  it('re-exports the saved-shows hooks', () => {
+    expect(typeof hooks.useSavedShows).toBe('function')
+    expect(typeof hooks.useSavedShowBatch).toBe('function')
+    expect(typeof hooks.useIsShowSaved).toBe('function')
+    expect(typeof hooks.useSaveShow).toBe('function')
+    expect(typeof hooks.useUnsaveShow).toBe('function')
+    expect(typeof hooks.useSaveShowToggle).toBe('function')
+  })
+
+  it('re-exports the attendance hooks', () => {
+    expect(typeof hooks.useShowAttendance).toBe('function')
+    expect(typeof hooks.useBatchAttendance).toBe('function')
+    expect(typeof hooks.useSetAttendance).toBe('function')
+    expect(typeof hooks.useRemoveAttendance).toBe('function')
+    expect(typeof hooks.useMyShows).toBe('function')
+  })
+})

--- a/frontend/features/venues/hooks/index.test.ts
+++ b/frontend/features/venues/hooks/index.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import * as hooks from './index'
+
+// Low-cost guard against accidental rename/delete in the barrel: assert each
+// named hook re-export resolves to a callable function. Type-only re-export
+// (TimeFilter) has no runtime presence and is not asserted.
+describe('venues hooks barrel', () => {
+  it('re-exports the useVenues hooks', () => {
+    expect(typeof hooks.useVenues).toBe('function')
+    expect(typeof hooks.useVenue).toBe('function')
+    expect(typeof hooks.useVenueShows).toBe('function')
+    expect(typeof hooks.useVenueCities).toBe('function')
+    expect(typeof hooks.useVenueGenres).toBe('function')
+    expect(typeof hooks.useVenueBillNetwork).toBe('function')
+  })
+
+  it('re-exports the venue search hook', () => {
+    expect(typeof hooks.useVenueSearch).toBe('function')
+  })
+
+  it('re-exports the venue edit hooks', () => {
+    expect(typeof hooks.useVenueUpdate).toBe('function')
+    expect(typeof hooks.useVenueDelete).toBe('function')
+  })
+})


### PR DESCRIPTION
## Summary
- Adds sibling `index.test.ts` barrel-resolution tests for the 11 `features/*/hooks/` barrels that lacked coverage: **artists, auth, charts, community, contributions, labels, radio, releases, scenes, shows, venues**.
- Mirrors the established `features/festivals/hooks/index.test.ts` shape — `import * as hooks` + assert each named hook re-export resolves to a callable function. A low-cost guard against accidental rename/delete breaking the public barrel API.
- Type-only re-exports (e.g. `EntityAttribution`, `CreateLabelInput`, `TimeFilter`) have no runtime presence and are intentionally not asserted.

The remaining barrels (collections, comments, festivals, notifications, requests, tags) were already tested per the PSY-708 reconciliation comment (2026-05-19).

## Test plan
- [x] `bun run typecheck` passes (clean `tsc --noEmit`)
- [x] `bun run test:run features` passes (193 files, 2378 tests; all 11 new barrel tests green)
- [x] Test-only diff — the suite is the verification (no manual repro applicable)

Closes PSY-708

🤖 Generated with [Claude Code](https://claude.com/claude-code)