### PR TITLE
PSY-699: test remaining 6 contributions hooks

### DIFF
--- a/frontend/features/contributions/hooks/useCancelPendingEdit.test.tsx
+++ b/frontend/features/contributions/hooks/useCancelPendingEdit.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { createTestQueryClient, createWrapperWithClient } from '@/test/utils'
+
+const mockApiRequest = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+// Import hook after mocks are wired.
+import { useCancelPendingEdit } from './useCancelPendingEdit'
+
+describe('useCancelPendingEdit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('starts idle and exposes a mutate function', () => {
+    mockApiRequest.mockResolvedValue({ success: true })
+
+    const { result } = renderHook(() => useCancelPendingEdit(), {
+      wrapper: createWrapperWithClient(createTestQueryClient()),
+    })
+
+    expect(result.current.isPending).toBe(false)
+    expect(result.current.isSuccess).toBe(false)
+    expect(typeof result.current.mutate).toBe('function')
+  })
+
+  it('issues a DELETE to the pending-edit endpoint for the given edit id', async () => {
+    mockApiRequest.mockResolvedValueOnce({ success: true })
+
+    const { result } = renderHook(() => useCancelPendingEdit(), {
+      wrapper: createWrapperWithClient(createTestQueryClient()),
+    })
+
+    result.current.mutate(123)
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      'http://localhost:8080/my/pending-edits/123',
+      { method: 'DELETE' }
+    )
+    expect(result.current.data).toEqual({ success: true })
+  })
+
+  it('invalidates the my-pending-edits cache on success', async () => {
+    mockApiRequest.mockResolvedValueOnce({ success: true })
+
+    const queryClient = createTestQueryClient()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const { result } = renderHook(() => useCancelPendingEdit(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+
+    result.current.mutate(7)
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['my-pending-edits'],
+    })
+  })
+
+  it('surfaces an error and does NOT invalidate the cache when the request fails', async () => {
+    mockApiRequest.mockRejectedValueOnce(new Error('Forbidden'))
+
+    const queryClient = createTestQueryClient()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const { result } = renderHook(() => useCancelPendingEdit(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+
+    result.current.mutate(99)
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect(result.current.error).toBeInstanceOf(Error)
+    expect(invalidateSpy).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/features/contributions/hooks/useContributeData.test.tsx
+++ b/frontend/features/contributions/hooks/useContributeData.test.tsx
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { createWrapper } from '@/test/utils'
+
+const mockApiRequest = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+// Import hooks after mocks are wired.
+import { useContributeOpportunities, useContributeCategory } from './useContributeData'
+
+describe('useContributeOpportunities', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches the contribution-opportunities summary', async () => {
+    const summary = {
+      categories: [
+        {
+          key: 'missing_bio',
+          label: 'Missing Bio',
+          entity_type: 'artist',
+          count: 12,
+          description: 'Artists with no description',
+        },
+      ],
+      total_items: 12,
+    }
+    mockApiRequest.mockResolvedValueOnce(summary)
+
+    const { result } = renderHook(() => useContributeOpportunities(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      'http://localhost:8080/contribute/opportunities'
+    )
+    expect(result.current.data).toEqual(summary)
+  })
+
+  it('surfaces an error when the summary request fails', async () => {
+    mockApiRequest.mockRejectedValueOnce(new Error('boom'))
+
+    const { result } = renderHook(() => useContributeOpportunities(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error).toBeInstanceOf(Error)
+  })
+})
+
+describe('useContributeCategory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches the items for a given category with limit=20', async () => {
+    const payload = {
+      items: [
+        {
+          entity_type: 'artist',
+          entity_id: 7,
+          name: 'Phantogram',
+          slug: 'phantogram',
+          reason: 'missing bio',
+          show_count: 3,
+        },
+      ],
+      total: 1,
+    }
+    mockApiRequest.mockResolvedValueOnce(payload)
+
+    const { result } = renderHook(() => useContributeCategory('missing_bio'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      'http://localhost:8080/contribute/opportunities/missing_bio?limit=20'
+    )
+    expect(result.current.data).toEqual(payload)
+  })
+
+  it('is disabled (does not fetch) when the category is an empty string', async () => {
+    const { result } = renderHook(() => useContributeCategory(''), {
+      wrapper: createWrapper(),
+    })
+
+    // enabled: !!category — empty string keeps the query idle (no fetch in
+    // flight) while still pending (no data resolved yet).
+    expect(result.current.fetchStatus).toBe('idle')
+    expect(result.current.isPending).toBe(true)
+    expect(mockApiRequest).not.toHaveBeenCalled()
+  })
+
+  it('surfaces an error when the category request fails', async () => {
+    mockApiRequest.mockRejectedValueOnce(new Error('not found'))
+
+    const { result } = renderHook(() => useContributeCategory('bad_category'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error).toBeInstanceOf(Error)
+  })
+})

--- a/frontend/features/contributions/hooks/useDataGaps.test.tsx
+++ b/frontend/features/contributions/hooks/useDataGaps.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { createWrapper } from '@/test/utils'
+
+const mockApiRequest = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+// Import hook after mocks are wired.
+import { useDataGaps } from './useDataGaps'
+
+describe('useDataGaps', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches data gaps for an entity by type and slug', async () => {
+    const response = {
+      gaps: [
+        { field: 'description', label: 'Description', priority: 1 },
+        { field: 'image_url', label: 'Image', priority: 2 },
+      ],
+    }
+    mockApiRequest.mockResolvedValueOnce(response)
+
+    const { result } = renderHook(
+      () => useDataGaps('artist', 'phantogram'),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      'http://localhost:8080/entities/artist/phantogram/data-gaps'
+    )
+    expect(result.current.data).toEqual(response)
+  })
+
+  it('is disabled (does not fetch) when entitySlug is empty', () => {
+    const { result } = renderHook(() => useDataGaps('artist', ''), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.fetchStatus).toBe('idle')
+    expect(mockApiRequest).not.toHaveBeenCalled()
+  })
+
+  it('is disabled when options.enabled is false, even with a valid slug', () => {
+    const { result } = renderHook(
+      () => useDataGaps('venue', 'the-rebel-lounge', { enabled: false }),
+      { wrapper: createWrapper() }
+    )
+
+    expect(result.current.fetchStatus).toBe('idle')
+    expect(mockApiRequest).not.toHaveBeenCalled()
+  })
+
+  it('fetches when options.enabled is explicitly true', async () => {
+    mockApiRequest.mockResolvedValueOnce({ gaps: [] })
+
+    const { result } = renderHook(
+      () => useDataGaps('venue', 'the-rebel-lounge', { enabled: true }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      'http://localhost:8080/entities/venue/the-rebel-lounge/data-gaps'
+    )
+  })
+
+  it('surfaces an error when the request fails', async () => {
+    mockApiRequest.mockRejectedValueOnce(new Error('500'))
+
+    const { result } = renderHook(
+      () => useDataGaps('label', 'sub-pop'),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error).toBeInstanceOf(Error)
+  })
+})

--- a/frontend/features/contributions/hooks/useEntityAttribution.test.tsx
+++ b/frontend/features/contributions/hooks/useEntityAttribution.test.tsx
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { createWrapper } from '@/test/utils'
+
+const mockApiRequest = vi.fn()
+
+// Spy on apiRequest but keep the real API_ENDPOINTS / API_BASE_URL so the
+// hook builds its true revisions URL (NEXT_PUBLIC_API_URL is pinned to
+// http://localhost:8080 in vitest.config.ts).
+vi.mock('@/lib/api', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/api')>('@/lib/api')
+  return {
+    ...actual,
+    apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  }
+})
+
+// Import hook after mocks are wired.
+import { useEntityAttribution } from './useEntityAttribution'
+
+describe('useEntityAttribution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches the most recent revision and maps it to attribution', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      revisions: [
+        {
+          id: 9,
+          user_id: 3,
+          user_name: 'Alice',
+          user_username: 'alice',
+          created_at: '2026-05-10T12:00:00Z',
+        },
+      ],
+      total: 1,
+    })
+
+    const { result } = renderHook(
+      () => useEntityAttribution('artist', 42),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    // limit=1&offset=0 — only the latest editor is needed.
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      'http://localhost:8080/revisions/artist/42?limit=1&offset=0'
+    )
+    expect(result.current.data).toEqual({
+      user_name: 'Alice',
+      user_username: 'alice',
+      created_at: '2026-05-10T12:00:00Z',
+    })
+  })
+
+  it('returns null when the entity has no revisions', async () => {
+    mockApiRequest.mockResolvedValueOnce({ revisions: [], total: 0 })
+
+    const { result } = renderHook(
+      () => useEntityAttribution('venue', 'the-rebel-lounge'),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toBeNull()
+  })
+
+  it('falls back to "Anonymous" and null username when the revision omits them', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      revisions: [
+        {
+          id: 1,
+          user_id: 5,
+          // user_name / user_username intentionally absent
+          created_at: '2026-05-01T00:00:00Z',
+        },
+      ],
+      total: 1,
+    })
+
+    const { result } = renderHook(
+      () => useEntityAttribution('release', 100),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toEqual({
+      user_name: 'Anonymous',
+      user_username: null,
+      created_at: '2026-05-01T00:00:00Z',
+    })
+  })
+
+  it('is disabled (does not fetch) when options.enabled is false', () => {
+    const { result } = renderHook(
+      () => useEntityAttribution('artist', 42, { enabled: false }),
+      { wrapper: createWrapper() }
+    )
+
+    expect(result.current.fetchStatus).toBe('idle')
+    expect(mockApiRequest).not.toHaveBeenCalled()
+  })
+
+  it('surfaces an error when the revisions request fails', async () => {
+    mockApiRequest.mockRejectedValueOnce(new Error('500'))
+
+    const { result } = renderHook(
+      () => useEntityAttribution('label', 7),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error).toBeInstanceOf(Error)
+  })
+})

--- a/frontend/features/contributions/hooks/useEntitySaveSuccessBanner.test.tsx
+++ b/frontend/features/contributions/hooks/useEntitySaveSuccessBanner.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useEntitySaveSuccessBanner } from './useEntitySaveSuccessBanner'
+
+// Pure client-state hook (no react-query) — drives the page-level
+// "Changes saved" banner that follows a direct admin/trusted save.
+describe('useEntitySaveSuccessBanner', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers()
+    vi.useRealTimers()
+  })
+
+  it('starts hidden', () => {
+    const { result } = renderHook(() => useEntitySaveSuccessBanner())
+
+    expect(result.current.isVisible).toBe(false)
+    expect(typeof result.current.handleSaveSuccess).toBe('function')
+  })
+
+  it('shows the banner on a direct save (applied: true)', () => {
+    const { result } = renderHook(() => useEntitySaveSuccessBanner())
+
+    act(() => {
+      result.current.handleSaveSuccess({ applied: true })
+    })
+
+    expect(result.current.isVisible).toBe(true)
+  })
+
+  it('does NOT show the banner for a pending submission (applied: false)', () => {
+    const { result } = renderHook(() => useEntitySaveSuccessBanner())
+
+    act(() => {
+      result.current.handleSaveSuccess({ applied: false })
+    })
+
+    // Pending submissions keep the in-drawer amber banner instead.
+    expect(result.current.isVisible).toBe(false)
+  })
+
+  it('auto-dismisses the banner after 5 seconds', () => {
+    const { result } = renderHook(() => useEntitySaveSuccessBanner())
+
+    act(() => {
+      result.current.handleSaveSuccess({ applied: true })
+    })
+    expect(result.current.isVisible).toBe(true)
+
+    // Just before the 5s threshold it is still visible.
+    act(() => {
+      vi.advanceTimersByTime(4999)
+    })
+    expect(result.current.isVisible).toBe(true)
+
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(result.current.isVisible).toBe(false)
+  })
+
+  it('clears the pending timer on unmount (no post-unmount state update)', () => {
+    const { result, unmount } = renderHook(() =>
+      useEntitySaveSuccessBanner()
+    )
+
+    act(() => {
+      result.current.handleSaveSuccess({ applied: true })
+    })
+    expect(result.current.isVisible).toBe(true)
+
+    // Unmounting before the timer fires must not throw / leak.
+    expect(() => {
+      unmount()
+      vi.advanceTimersByTime(5000)
+    }).not.toThrow()
+  })
+})

--- a/frontend/features/contributions/hooks/useReportEntity.test.tsx
+++ b/frontend/features/contributions/hooks/useReportEntity.test.tsx
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { createWrapper } from '@/test/utils'
+import type { ReportableEntityType } from '../types'
+
+const mockApiRequest = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+// Import hook after mocks are wired.
+import { useReportEntity } from './useReportEntity'
+
+describe('useReportEntity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('starts idle and exposes a mutate function', () => {
+    mockApiRequest.mockResolvedValue({ success: true })
+
+    const { result } = renderHook(() => useReportEntity(), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.isPending).toBe(false)
+    expect(result.current.isSuccess).toBe(false)
+    expect(typeof result.current.mutate).toBe('function')
+  })
+
+  // URL-shape enumeration locks the CURRENT behavior of useReportEntity per
+  // entity type. The non-comment, non-show branch builds its path via a raw
+  // `entityType + 's'` plural concatenation (the "plural-concat" anti-pattern)
+  // — that is the subject of audit PSY-766 and is intentionally NOT fixed
+  // here. These cases document what the hook builds today so PSY-766 has a
+  // characterization baseline; if PSY-766 swaps in an explicit plural map,
+  // the expected URLs below stay identical for these inputs.
+  const cases: Array<{ entityType: ReportableEntityType; expectedPath: string }> = [
+    { entityType: 'artist', expectedPath: 'artists/42/report' },
+    { entityType: 'venue', expectedPath: 'venues/42/report' },
+    { entityType: 'festival', expectedPath: 'festivals/42/report' },
+    // collection happens to pluralize correctly under raw +'s', but it still
+    // flows through the same concat branch as artist/venue/festival.
+    { entityType: 'collection', expectedPath: 'collections/42/report' },
+    // show uses /entity-report (not /report) — distinct backend route.
+    { entityType: 'show', expectedPath: 'shows/42/entity-report' },
+  ]
+
+  it.each(cases)(
+    'POSTs the report for $entityType to /$expectedPath',
+    async ({ entityType, expectedPath }) => {
+      mockApiRequest.mockResolvedValueOnce({
+        success: true,
+        report: {
+          id: 1,
+          entity_type: entityType,
+          entity_id: 42,
+          report_type: 'inaccurate',
+          status: 'pending',
+        },
+      })
+
+      const { result } = renderHook(() => useReportEntity(), {
+        wrapper: createWrapper(),
+      })
+
+      result.current.mutate({
+        entityType,
+        entityId: 42,
+        reportType: 'inaccurate',
+        details: 'this is wrong',
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        `http://localhost:8080/${expectedPath}`,
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            report_type: 'inaccurate',
+            details: 'this is wrong',
+          }),
+        }
+      )
+    }
+  )
+
+  it('routes comment reports to the dedicated /comments/{id}/report endpoint', async () => {
+    mockApiRequest.mockResolvedValueOnce({ success: true })
+
+    const { result } = renderHook(() => useReportEntity(), {
+      wrapper: createWrapper(),
+    })
+
+    result.current.mutate({
+      entityType: 'comment',
+      entityId: 88,
+      reportType: 'spam',
+      details: 'advertising',
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      'http://localhost:8080/comments/88/report',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          report_type: 'spam',
+          details: 'advertising',
+        }),
+      }
+    )
+  })
+
+  it('omits the details field from the body when not provided', async () => {
+    mockApiRequest.mockResolvedValueOnce({ success: true })
+
+    const { result } = renderHook(() => useReportEntity(), {
+      wrapper: createWrapper(),
+    })
+
+    result.current.mutate({
+      entityType: 'artist',
+      entityId: 5,
+      reportType: 'duplicate',
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      'http://localhost:8080/artists/5/report',
+      {
+        method: 'POST',
+        body: JSON.stringify({ report_type: 'duplicate' }),
+      }
+    )
+  })
+
+  it('surfaces an error when the report request fails', async () => {
+    mockApiRequest.mockRejectedValueOnce(new Error('Rate limited'))
+
+    const { result } = renderHook(() => useReportEntity(), {
+      wrapper: createWrapper(),
+    })
+
+    result.current.mutate({
+      entityType: 'venue',
+      entityId: 3,
+      reportType: 'closed_permanently',
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect(result.current.error).toBeInstanceOf(Error)
+  })
+})

--- a/frontend/features/contributions/hooks/useShowEdit.test.tsx
+++ b/frontend/features/contributions/hooks/useShowEdit.test.tsx
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { createTestQueryClient, createWrapperWithClient } from '@/test/utils'
+
+const mockApiRequest = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+// Import hook after mocks are wired.
+import { useShowEdit } from './useShowEdit'
+
+describe('useShowEdit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('starts idle and exposes a mutate function', () => {
+    mockApiRequest.mockResolvedValue(undefined)
+
+    const { result } = renderHook(() => useShowEdit(), {
+      wrapper: createWrapperWithClient(createTestQueryClient()),
+    })
+
+    expect(result.current.isPending).toBe(false)
+    expect(result.current.isSuccess).toBe(false)
+    expect(typeof result.current.mutate).toBe('function')
+  })
+
+  it('PUTs the show-update body and resolves with a synthetic applied:true result', async () => {
+    mockApiRequest.mockResolvedValueOnce(undefined)
+
+    const { result } = renderHook(() => useShowEdit(), {
+      wrapper: createWrapperWithClient(createTestQueryClient()),
+    })
+
+    result.current.mutate({
+      entityId: 55,
+      changes: [
+        { field: 'title', old_value: 'Old', new_value: 'New Title' },
+        { field: 'age_requirement', old_value: '18+', new_value: '21+' },
+      ],
+      summary: 'fix title + age',
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      'http://localhost:8080/shows/55',
+      {
+        method: 'PUT',
+        body: JSON.stringify({
+          title: 'New Title',
+          age_requirement: '21+',
+          summary: 'fix title + age',
+        }),
+      }
+    )
+
+    // Show edits always apply directly — the hook fabricates a
+    // SuggestEditResponse so the drawer's UI logic doesn't need to fork.
+    expect(result.current.data).toEqual({
+      applied: true,
+      message: 'Changes saved',
+    })
+  })
+
+  it('translates a blanked (null) field to an empty string in the body', async () => {
+    mockApiRequest.mockResolvedValueOnce(undefined)
+
+    const { result } = renderHook(() => useShowEdit(), {
+      wrapper: createWrapperWithClient(createTestQueryClient()),
+    })
+
+    result.current.mutate({
+      entityId: 12,
+      changes: [{ field: 'description', old_value: 'something', new_value: null }],
+      summary: 'clear description',
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      'http://localhost:8080/shows/12',
+      {
+        method: 'PUT',
+        body: JSON.stringify({
+          description: '',
+          summary: 'clear description',
+        }),
+      }
+    )
+  })
+
+  it('invalidates the shows cache on success', async () => {
+    mockApiRequest.mockResolvedValueOnce(undefined)
+
+    const queryClient = createTestQueryClient()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const { result } = renderHook(() => useShowEdit(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+
+    result.current.mutate({
+      entityId: 1,
+      changes: [{ field: 'title', old_value: 'a', new_value: 'b' }],
+      summary: 'rename',
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['shows'] })
+  })
+
+  it('surfaces an error and does NOT invalidate the cache when the PUT fails', async () => {
+    mockApiRequest.mockRejectedValueOnce(new Error('Server error'))
+
+    const queryClient = createTestQueryClient()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const { result } = renderHook(() => useShowEdit(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+
+    result.current.mutate({
+      entityId: 9,
+      changes: [{ field: 'title', old_value: 'a', new_value: 'b' }],
+      summary: 'rename',
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect(result.current.error).toBeInstanceOf(Error)
+    expect(invalidateSpy).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- Adds sibling test coverage for the 6 previously untested hooks in `frontend/features/contributions/hooks/`: `useCancelPendingEdit`, `useContributeData` (covers both `useContributeOpportunities` + `useContributeCategory`), `useDataGaps`, `useEntityAttribution`, `useEntitySaveSuccessBanner`, `useReportEntity`, `useShowEdit`.
- Follows the established `useMyPendingEdits` / `useSuggestEdit` test pattern (mock `@/lib/api`, `createWrapper` / `createWrapperWithClient`, `it.each` URL enumeration).
- Per hook: success / error / loading, plus cache invalidation on mutation success (mutations) or `enabled`-gating (queries).
- `useReportEntity` tests characterize its CURRENT per-entity URL shape, including the `entityType + 's'` plural-concat branch. That anti-pattern is the subject of audit **PSY-766** and is intentionally NOT fixed here; the expected URLs hold under either form.

Test-only diff — no production hook code changed.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run test:run features/contributions/hooks` — 47 passed (9 files; 38 new + 9 pre-existing)

Closes PSY-699