### PR TITLE
PSY-698: cover shows extraction/privacy/publish mutation hooks

### DIFF
--- a/frontend/features/shows/hooks/useShowExtraction.test.tsx
+++ b/frontend/features/shows/hooks/useShowExtraction.test.tsx
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { createWrapper } from '@/test/utils'
+import type {
+  ExtractShowRequest,
+  ExtractShowResponse,
+  ExtractedShowData,
+} from '@/lib/types/extraction'
+
+import { useShowExtraction } from './useShowExtraction'
+
+const extractedData: ExtractedShowData = {
+  artists: [{ name: 'The National', is_headliner: true }],
+  venue: { name: 'Valley Bar', city: 'Phoenix', state: 'AZ' },
+  date: '2025-06-15',
+  time: '20:00',
+  cost: '$25',
+  ages: '21+',
+}
+
+function jsonResponse(
+  body: ExtractShowResponse,
+  ok: boolean,
+  status: number
+): Response {
+  return {
+    ok,
+    status,
+    json: () => Promise.resolve(body),
+    headers: new Headers(),
+  } as Response
+}
+
+describe('useShowExtraction', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('extracts show info from text and returns parsed data', async () => {
+    const response: ExtractShowResponse = { success: true, data: extractedData }
+    vi.mocked(fetch).mockResolvedValueOnce(jsonResponse(response, true, 200))
+
+    const { result } = renderHook(() => useShowExtraction(), {
+      wrapper: createWrapper(),
+    })
+
+    const request: ExtractShowRequest = {
+      type: 'text',
+      text: 'The National at Valley Bar 6/15',
+    }
+
+    await act(async () => {
+      result.current.mutate(request)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data).toEqual(response)
+    expect(result.current.data?.data?.artists[0].name).toBe('The National')
+  })
+
+  it('calls the extraction endpoint with the request body', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      jsonResponse({ success: true, data: extractedData }, true, 200)
+    )
+
+    const { result } = renderHook(() => useShowExtraction(), {
+      wrapper: createWrapper(),
+    })
+
+    const request: ExtractShowRequest = {
+      type: 'image',
+      image_data: 'base64data',
+      media_type: 'image/jpeg',
+    }
+
+    await act(async () => {
+      result.current.mutate(request)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/ai/extract-show',
+      expect.objectContaining({
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(request),
+      })
+    )
+  })
+
+  it('reflects loading state while the request is in flight', async () => {
+    let resolveFetch: ((value: Response) => void) | undefined
+    vi.mocked(fetch).mockReturnValueOnce(
+      new Promise<Response>((resolve) => {
+        resolveFetch = resolve
+      })
+    )
+
+    const { result } = renderHook(() => useShowExtraction(), {
+      wrapper: createWrapper(),
+    })
+
+    act(() => {
+      result.current.mutate({ type: 'text', text: 'pending' })
+    })
+
+    await waitFor(() => expect(result.current.isPending).toBe(true))
+
+    await act(async () => {
+      resolveFetch?.(jsonResponse({ success: true, data: extractedData }, true, 200))
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+  })
+
+  // A 200 OK with success=false is a real failure (e.g. AI could not parse the
+  // flyer). The hook must surface it as an error, never swallow it.
+  it('surfaces success=false as an error even when response.ok is true', async () => {
+    const response: ExtractShowResponse = {
+      success: false,
+      error: 'Could not extract show information from the image',
+    }
+    vi.mocked(fetch).mockResolvedValueOnce(jsonResponse(response, true, 200))
+
+    const { result } = renderHook(() => useShowExtraction(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ type: 'text', text: 'gibberish' })
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect(result.current.data).toBeUndefined()
+    expect((result.current.error as Error).message).toBe(
+      'Could not extract show information from the image'
+    )
+  })
+
+  it('falls back to a generic message when success=false omits an error', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      jsonResponse({ success: false }, true, 200)
+    )
+
+    const { result } = renderHook(() => useShowExtraction(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ type: 'text', text: 'gibberish' })
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect((result.current.error as Error).message).toBe(
+      'Failed to extract show information'
+    )
+  })
+
+  it('surfaces a non-ok HTTP response as an error', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      jsonResponse({ success: false, error: 'Internal server error' }, false, 500)
+    )
+
+    const { result } = renderHook(() => useShowExtraction(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ type: 'text', text: 'boom' })
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect((result.current.error as Error).message).toBe('Internal server error')
+  })
+
+  it('allows retrying after a failure and succeeds on the second attempt', async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(
+        jsonResponse({ success: false, error: 'Temporary failure' }, false, 503)
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({ success: true, data: extractedData }, true, 200)
+      )
+
+    const { result } = renderHook(() => useShowExtraction(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate({ type: 'text', text: 'retry me' })
+    })
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    await act(async () => {
+      result.current.mutate({ type: 'text', text: 'retry me' })
+    })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data?.success).toBe(true)
+    expect(fetch).toHaveBeenCalledTimes(2)
+  })
+})

--- a/frontend/features/shows/hooks/useShowMakePrivate.test.tsx
+++ b/frontend/features/shows/hooks/useShowMakePrivate.test.tsx
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { createWrapper } from '@/test/utils'
+import type { ShowResponse, ShowStatus } from '../types'
+
+// Create mocks
+const mockApiRequest = vi.fn()
+const mockInvalidateShows = vi.fn()
+const mockInvalidateSavedShows = vi.fn()
+
+// Mock the api module
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+}))
+
+vi.mock('@/features/shows/api', () => ({
+  showEndpoints: {
+    MAKE_PRIVATE: (showId: string | number) => `/shows/${showId}/make-private`,
+  },
+}))
+
+// Mock queryClient module
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {},
+  createInvalidateQueries: () => ({
+    shows: mockInvalidateShows,
+    savedShows: mockInvalidateSavedShows,
+  }),
+}))
+
+// Mock showLogger to suppress console output in tests
+vi.mock('@/lib/utils/showLogger', () => ({
+  showLogger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+// Mock errors module
+vi.mock('@/lib/errors', () => ({
+  ShowError: {
+    fromUnknown: (error: unknown) => ({
+      code: 'UNKNOWN',
+      message: error instanceof Error ? error.message : String(error),
+      requestId: undefined,
+    }),
+  },
+  ShowErrorCode: {
+    UNKNOWN: 'UNKNOWN',
+  },
+}))
+
+// Import hook after mocks are set up
+import { useShowMakePrivate } from './useShowMakePrivate'
+
+function showResponse(status: ShowStatus): ShowResponse {
+  return {
+    id: 42,
+    slug: 'test-show',
+    title: 'Test Show',
+    event_date: '2025-06-15T20:00:00Z',
+    status,
+    venues: [],
+    artists: [],
+    created_at: '2025-01-01T00:00:00Z',
+    updated_at: '2025-01-01T00:00:00Z',
+    is_sold_out: false,
+    is_cancelled: false,
+  }
+}
+
+describe('useShowMakePrivate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateShows.mockReset()
+    mockInvalidateSavedShows.mockReset()
+  })
+
+  it('makes a show private with the correct endpoint and method', async () => {
+    mockApiRequest.mockResolvedValueOnce(showResponse('private'))
+
+    const { result } = renderHook(() => useShowMakePrivate(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(42)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/shows/42/make-private', {
+      method: 'POST',
+    })
+    expect(result.current.data?.status).toBe('private')
+  })
+
+  it('reflects loading state while the request is in flight', async () => {
+    let resolve: ((value: ShowResponse) => void) | undefined
+    mockApiRequest.mockReturnValueOnce(
+      new Promise<ShowResponse>((res) => {
+        resolve = res
+      })
+    )
+
+    const { result } = renderHook(() => useShowMakePrivate(), {
+      wrapper: createWrapper(),
+    })
+
+    act(() => {
+      result.current.mutate(42)
+    })
+
+    await waitFor(() => expect(result.current.isPending).toBe(true))
+
+    await act(async () => {
+      resolve?.(showResponse('private'))
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+  })
+
+  it('invalidates shows and savedShows on success', async () => {
+    mockApiRequest.mockResolvedValueOnce(showResponse('private'))
+
+    const { result } = renderHook(() => useShowMakePrivate(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(42)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockInvalidateShows).toHaveBeenCalled()
+    expect(mockInvalidateSavedShows).toHaveBeenCalled()
+  })
+
+  it('handles errors and sets error state', async () => {
+    const error = new Error('Forbidden')
+    Object.assign(error, { status: 403 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useShowMakePrivate(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(42)
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect((result.current.error as Error).message).toBe('Forbidden')
+  })
+
+  it('does not invalidate queries on error', async () => {
+    mockApiRequest.mockRejectedValueOnce(new Error('Server error'))
+
+    const { result } = renderHook(() => useShowMakePrivate(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(42)
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect(mockInvalidateShows).not.toHaveBeenCalled()
+    expect(mockInvalidateSavedShows).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/features/shows/hooks/useShowPublish.test.tsx
+++ b/frontend/features/shows/hooks/useShowPublish.test.tsx
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { createWrapper } from '@/test/utils'
+import type { ShowResponse, ShowStatus } from '../types'
+
+// Create mocks
+const mockApiRequest = vi.fn()
+const mockInvalidateShows = vi.fn()
+const mockInvalidateSavedShows = vi.fn()
+
+// Mock the api module
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+}))
+
+vi.mock('@/features/shows/api', () => ({
+  showEndpoints: {
+    PUBLISH: (showId: string | number) => `/shows/${showId}/publish`,
+  },
+}))
+
+// Mock queryClient module
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {},
+  createInvalidateQueries: () => ({
+    shows: mockInvalidateShows,
+    savedShows: mockInvalidateSavedShows,
+  }),
+}))
+
+// Mock showLogger to suppress console output in tests
+vi.mock('@/lib/utils/showLogger', () => ({
+  showLogger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+// Mock errors module
+vi.mock('@/lib/errors', () => ({
+  ShowError: {
+    fromUnknown: (error: unknown) => ({
+      code: 'UNKNOWN',
+      message: error instanceof Error ? error.message : String(error),
+      requestId: undefined,
+    }),
+  },
+  ShowErrorCode: {
+    UNKNOWN: 'UNKNOWN',
+  },
+}))
+
+// Import hook after mocks are set up
+import { useShowPublish } from './useShowPublish'
+
+function showResponse(status: ShowStatus): ShowResponse {
+  return {
+    id: 42,
+    slug: 'test-show',
+    title: 'Test Show',
+    event_date: '2025-06-15T20:00:00Z',
+    status,
+    venues: [],
+    artists: [],
+    created_at: '2025-01-01T00:00:00Z',
+    updated_at: '2025-01-01T00:00:00Z',
+    is_sold_out: false,
+    is_cancelled: false,
+  }
+}
+
+describe('useShowPublish', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateShows.mockReset()
+    mockInvalidateSavedShows.mockReset()
+  })
+
+  it('publishes a show with the correct endpoint and method', async () => {
+    mockApiRequest.mockResolvedValueOnce(showResponse('approved'))
+
+    const { result } = renderHook(() => useShowPublish(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(42)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/shows/42/publish', {
+      method: 'POST',
+    })
+    expect(result.current.data?.status).toBe('approved')
+  })
+
+  it('reflects loading state while the request is in flight', async () => {
+    let resolve: ((value: ShowResponse) => void) | undefined
+    mockApiRequest.mockReturnValueOnce(
+      new Promise<ShowResponse>((res) => {
+        resolve = res
+      })
+    )
+
+    const { result } = renderHook(() => useShowPublish(), {
+      wrapper: createWrapper(),
+    })
+
+    act(() => {
+      result.current.mutate(42)
+    })
+
+    await waitFor(() => expect(result.current.isPending).toBe(true))
+
+    await act(async () => {
+      resolve?.(showResponse('approved'))
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+  })
+
+  it('invalidates shows and savedShows on success', async () => {
+    mockApiRequest.mockResolvedValueOnce(showResponse('approved'))
+
+    const { result } = renderHook(() => useShowPublish(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(42)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockInvalidateShows).toHaveBeenCalled()
+    expect(mockInvalidateSavedShows).toHaveBeenCalled()
+  })
+
+  // The backend rejects publishing a show that is missing required fields; the
+  // hook surfaces that 422 as an error rather than swallowing it.
+  it('surfaces a validation error when required fields are missing', async () => {
+    const error = new Error('Show is missing required fields')
+    Object.assign(error, { status: 422 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useShowPublish(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(42)
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect((result.current.error as Error).message).toBe(
+      'Show is missing required fields'
+    )
+  })
+
+  it('does not invalidate queries on error', async () => {
+    mockApiRequest.mockRejectedValueOnce(new Error('Server error'))
+
+    const { result } = renderHook(() => useShowPublish(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(42)
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect(mockInvalidateShows).not.toHaveBeenCalled()
+    expect(mockInvalidateSavedShows).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/features/shows/hooks/useShowUnpublish.test.tsx
+++ b/frontend/features/shows/hooks/useShowUnpublish.test.tsx
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { createWrapper } from '@/test/utils'
+import type { ShowResponse, ShowStatus } from '../types'
+
+// Create mocks
+const mockApiRequest = vi.fn()
+const mockInvalidateShows = vi.fn()
+const mockInvalidateSavedShows = vi.fn()
+
+// Mock the api module
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+}))
+
+vi.mock('@/features/shows/api', () => ({
+  showEndpoints: {
+    UNPUBLISH: (showId: string | number) => `/shows/${showId}/unpublish`,
+  },
+}))
+
+// Mock queryClient module
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {},
+  createInvalidateQueries: () => ({
+    shows: mockInvalidateShows,
+    savedShows: mockInvalidateSavedShows,
+  }),
+}))
+
+// Mock showLogger to suppress console output in tests
+vi.mock('@/lib/utils/showLogger', () => ({
+  showLogger: {
+    unpublishAttempt: vi.fn(),
+    unpublishSuccess: vi.fn(),
+    unpublishFailed: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+// Mock errors module
+vi.mock('@/lib/errors', () => ({
+  ShowError: {
+    fromUnknown: (error: unknown) => ({
+      code: 'UNKNOWN',
+      message: error instanceof Error ? error.message : String(error),
+      requestId: undefined,
+    }),
+  },
+  ShowErrorCode: {
+    UNKNOWN: 'UNKNOWN',
+  },
+}))
+
+// Import hook after mocks are set up
+import { useShowUnpublish } from './useShowUnpublish'
+
+function showResponse(status: ShowStatus): ShowResponse {
+  return {
+    id: 42,
+    slug: 'test-show',
+    title: 'Test Show',
+    event_date: '2025-06-15T20:00:00Z',
+    status,
+    venues: [],
+    artists: [],
+    created_at: '2025-01-01T00:00:00Z',
+    updated_at: '2025-01-01T00:00:00Z',
+    is_sold_out: false,
+    is_cancelled: false,
+  }
+}
+
+describe('useShowUnpublish', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateShows.mockReset()
+    mockInvalidateSavedShows.mockReset()
+  })
+
+  it('unpublishes a show with the correct endpoint and method', async () => {
+    mockApiRequest.mockResolvedValueOnce(showResponse('pending'))
+
+    const { result } = renderHook(() => useShowUnpublish(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(42)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/shows/42/unpublish', {
+      method: 'POST',
+    })
+  })
+
+  // Unpublishing an approved show reverts it to a pending (draft) state.
+  it('returns the show reverted to a pending status', async () => {
+    mockApiRequest.mockResolvedValueOnce(showResponse('pending'))
+
+    const { result } = renderHook(() => useShowUnpublish(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(42)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data?.status).toBe('pending')
+  })
+
+  it('reflects loading state while the request is in flight', async () => {
+    let resolve: ((value: ShowResponse) => void) | undefined
+    mockApiRequest.mockReturnValueOnce(
+      new Promise<ShowResponse>((res) => {
+        resolve = res
+      })
+    )
+
+    const { result } = renderHook(() => useShowUnpublish(), {
+      wrapper: createWrapper(),
+    })
+
+    act(() => {
+      result.current.mutate(42)
+    })
+
+    await waitFor(() => expect(result.current.isPending).toBe(true))
+
+    await act(async () => {
+      resolve?.(showResponse('pending'))
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+  })
+
+  it('invalidates shows and savedShows on success', async () => {
+    mockApiRequest.mockResolvedValueOnce(showResponse('pending'))
+
+    const { result } = renderHook(() => useShowUnpublish(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(42)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockInvalidateShows).toHaveBeenCalled()
+    expect(mockInvalidateSavedShows).toHaveBeenCalled()
+  })
+
+  it('handles errors and sets error state', async () => {
+    const error = new Error('Forbidden')
+    Object.assign(error, { status: 403 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useShowUnpublish(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(42)
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect((result.current.error as Error).message).toBe('Forbidden')
+  })
+
+  it('does not invalidate queries on error', async () => {
+    mockApiRequest.mockRejectedValueOnce(new Error('Server error'))
+
+    const { result } = renderHook(() => useShowUnpublish(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      result.current.mutate(42)
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect(mockInvalidateShows).not.toHaveBeenCalled()
+    expect(mockInvalidateSavedShows).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- Adds sibling tests for the four previously-untested mutation hooks in `frontend/features/shows/hooks/`: `useShowExtraction`, `useShowMakePrivate`, `useShowPublish`, `useShowUnpublish`.
- Each covers success / error / loading state, plus cache invalidation on success and its absence on error.
- `useShowExtraction` is verified to surface a `200 OK` response with `success=false` as an error (not swallowed), plus the generic-message fallback and a retry path.

Test-only change; no production code touched.

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run test:run features/shows/hooks` passes (16 files, 126 tests; 23 new across the 4 added files)

Closes PSY-698

🤖 Generated with [Claude Code](https://claude.com/claude-code)