### PR TITLE
PSY-707: cover features/*/types.ts runtime exports with unit tests

### DIFF
--- a/frontend/features/artists/types.test.ts
+++ b/frontend/features/artists/types.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest'
+import { hasAnySocialLink, getArtistLocation, type ArtistSocial } from './types'
+
+function social(overrides: Partial<ArtistSocial> = {}): ArtistSocial {
+  return {
+    instagram: null,
+    facebook: null,
+    twitter: null,
+    youtube: null,
+    spotify: null,
+    soundcloud: null,
+    bandcamp: null,
+    website: null,
+    ...overrides,
+  }
+}
+
+describe('hasAnySocialLink', () => {
+  it('returns false when every link is null', () => {
+    expect(hasAnySocialLink(social())).toBe(false)
+  })
+
+  it('returns false when links are empty or whitespace-only strings', () => {
+    expect(
+      hasAnySocialLink(social({ instagram: '', website: '   ' }))
+    ).toBe(false)
+  })
+
+  it('returns true when any link has a non-empty value', () => {
+    expect(
+      hasAnySocialLink(social({ bandcamp: 'https://x.bandcamp.com' }))
+    ).toBe(true)
+  })
+
+  it('returns true when the only set link has surrounding whitespace', () => {
+    expect(hasAnySocialLink(social({ spotify: '  url  ' }))).toBe(true)
+  })
+})
+
+describe('getArtistLocation (PSY-558 display rule)', () => {
+  it('suppresses "USA" for a domestic city + state', () => {
+    expect(
+      getArtistLocation({ city: 'Phoenix', state: 'AZ', country: 'USA' })
+    ).toBe('Phoenix, AZ')
+  })
+
+  it('renders city + state when no country is provided', () => {
+    expect(getArtistLocation({ city: 'Phoenix', state: 'AZ' })).toBe(
+      'Phoenix, AZ'
+    )
+  })
+
+  it('shows the country for an international city + country', () => {
+    expect(
+      getArtistLocation({ city: 'Tokyo', country: 'Japan' })
+    ).toBe('Tokyo, Japan')
+  })
+
+  it('shows the country when city + state + a non-US country are set', () => {
+    // State alone is not enough to locate an international artist, so the
+    // country is appended even though a state is present.
+    expect(
+      getArtistLocation({
+        city: 'Melbourne',
+        state: 'Victoria',
+        country: 'Australia',
+      })
+    ).toBe('Melbourne, Victoria, Australia')
+  })
+
+  it('drops the city when it is missing', () => {
+    expect(getArtistLocation({ state: 'AZ', country: 'USA' })).toBe('AZ')
+  })
+
+  it('shows country alone when city and state are both missing', () => {
+    expect(getArtistLocation({ country: 'Japan' })).toBe('Japan')
+  })
+
+  // Missing state: "USA" is no longer suppressed because the suppression
+  // requires BOTH a state AND a US country.
+  it('shows "USA" when state is missing (suppression needs a state)', () => {
+    expect(getArtistLocation({ city: 'Phoenix', country: 'USA' })).toBe(
+      'Phoenix, USA'
+    )
+  })
+
+  it('suppresses lowercase "usa" with a state set', () => {
+    expect(
+      getArtistLocation({ city: 'Phoenix', state: 'AZ', country: 'usa' })
+    ).toBe('Phoenix, AZ')
+  })
+
+  it('suppresses "US" (both spellings) with a state set', () => {
+    expect(
+      getArtistLocation({ city: 'Austin', state: 'TX', country: 'US' })
+    ).toBe('Austin, TX')
+    expect(
+      getArtistLocation({ city: 'Austin', state: 'TX', country: 'us' })
+    ).toBe('Austin, TX')
+  })
+
+  it('trims whitespace around the country before comparing', () => {
+    expect(
+      getArtistLocation({ city: 'Austin', state: 'TX', country: '  USA  ' })
+    ).toBe('Austin, TX')
+  })
+
+  it('returns "Location Unknown" when nothing is set', () => {
+    expect(getArtistLocation({})).toBe('Location Unknown')
+  })
+
+  it('treats null fields the same as missing', () => {
+    expect(
+      getArtistLocation({ city: null, state: null, country: null })
+    ).toBe('Location Unknown')
+  })
+})

--- a/frontend/features/comments/types.test.ts
+++ b/frontend/features/comments/types.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  REPLY_PERMISSION_VALUES,
+  REPLY_PERMISSION_LABELS,
+  REPLY_PERMISSION_BADGE_LABELS,
+  FIELD_NOTE_EDIT_WINDOW_MS,
+  isWithinFieldNoteEditWindow,
+} from './types'
+
+describe('reply permission constants', () => {
+  it('exposes the three permission values', () => {
+    expect(REPLY_PERMISSION_VALUES).toEqual([
+      'anyone',
+      'followers',
+      'author_only',
+    ])
+  })
+
+  it('keeps a user-facing label for every permission value', () => {
+    for (const value of REPLY_PERMISSION_VALUES) {
+      expect(REPLY_PERMISSION_LABELS[value]).toBeTruthy()
+    }
+  })
+
+  it('uses an empty badge for "anyone" (no badge when unrestricted)', () => {
+    expect(REPLY_PERMISSION_BADGE_LABELS.anyone).toBe('')
+  })
+
+  it('keeps a non-empty badge for restricted permissions', () => {
+    expect(REPLY_PERMISSION_BADGE_LABELS.followers).toBeTruthy()
+    expect(REPLY_PERMISSION_BADGE_LABELS.author_only).toBeTruthy()
+  })
+})
+
+describe('FIELD_NOTE_EDIT_WINDOW_MS', () => {
+  it('is 30 minutes in milliseconds', () => {
+    expect(FIELD_NOTE_EDIT_WINDOW_MS).toBe(30 * 60 * 1000)
+  })
+})
+
+describe('isWithinFieldNoteEditWindow', () => {
+  // The window is measured against Date.now(); pin the clock so the boundary
+  // assertions are deterministic.
+  const NOW = new Date('2026-05-19T12:00:00Z')
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  function createdMsAgo(ms: number): string {
+    return new Date(NOW.getTime() - ms).toISOString()
+  }
+
+  it('returns true for a note created just now', () => {
+    expect(isWithinFieldNoteEditWindow(createdMsAgo(0))).toBe(true)
+  })
+
+  it('returns true for a note created within the window', () => {
+    expect(isWithinFieldNoteEditWindow(createdMsAgo(29 * 60 * 1000))).toBe(true)
+  })
+
+  it('returns false at exactly the window boundary (strict <)', () => {
+    expect(
+      isWithinFieldNoteEditWindow(createdMsAgo(FIELD_NOTE_EDIT_WINDOW_MS))
+    ).toBe(false)
+  })
+
+  it('returns false for a note older than the window', () => {
+    expect(isWithinFieldNoteEditWindow(createdMsAgo(60 * 60 * 1000))).toBe(
+      false
+    )
+  })
+
+  it('returns false for an unparseable timestamp', () => {
+    expect(isWithinFieldNoteEditWindow('not-a-date')).toBe(false)
+  })
+
+  it('returns false for an empty string', () => {
+    expect(isWithinFieldNoteEditWindow('')).toBe(false)
+  })
+})

--- a/frontend/features/community/types.test.ts
+++ b/frontend/features/community/types.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import {
+  DIMENSION_LABELS,
+  PERIOD_LABELS,
+  type LeaderboardDimension,
+  type LeaderboardPeriod,
+} from './types'
+
+const DIMENSIONS: LeaderboardDimension[] = [
+  'overall',
+  'shows',
+  'venues',
+  'tags',
+  'edits',
+  'requests',
+]
+
+const PERIODS: LeaderboardPeriod[] = ['all_time', 'month', 'week']
+
+describe('DIMENSION_LABELS', () => {
+  it('maps every leaderboard dimension to a non-empty label', () => {
+    for (const dimension of DIMENSIONS) {
+      expect(DIMENSION_LABELS[dimension]).toBeTruthy()
+    }
+  })
+
+  it('uses curated copy for representative dimensions', () => {
+    expect(DIMENSION_LABELS.overall).toBe('Overall')
+    expect(DIMENSION_LABELS.shows).toBe('Shows')
+  })
+
+  it('has exactly one label per known dimension', () => {
+    expect(Object.keys(DIMENSION_LABELS).sort()).toEqual([...DIMENSIONS].sort())
+  })
+})
+
+describe('PERIOD_LABELS', () => {
+  it('maps every leaderboard period to a non-empty label', () => {
+    for (const period of PERIODS) {
+      expect(PERIOD_LABELS[period]).toBeTruthy()
+    }
+  })
+
+  it('expands snake_case keys into human copy', () => {
+    expect(PERIOD_LABELS.all_time).toBe('All Time')
+    expect(PERIOD_LABELS.month).toBe('This Month')
+    expect(PERIOD_LABELS.week).toBe('This Week')
+  })
+})

--- a/frontend/features/notifications/types.test.ts
+++ b/frontend/features/notifications/types.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  NOTIFICATION_ENTITY_COMMENT_REPLY,
+  NOTIFICATION_ENTITY_COMMENT_MENTION,
+  isCommentNotification,
+  NOTIFY_ENTITY_TYPES,
+  formatTimeAgo,
+  getFilterSummary,
+  type NotificationLogEntry,
+  type NotificationFilter,
+} from './types'
+
+function logEntry(overrides: Partial<NotificationLogEntry> = {}): NotificationLogEntry {
+  return {
+    id: 1,
+    entity_type: 'show',
+    entity_id: 10,
+    channel: 'email',
+    sent_at: '2026-05-19T12:00:00Z',
+    ...overrides,
+  }
+}
+
+function filter(overrides: Partial<NotificationFilter> = {}): NotificationFilter {
+  return {
+    id: 1,
+    name: 'My filter',
+    is_active: true,
+    notify_email: true,
+    notify_in_app: false,
+    notify_push: false,
+    match_count: 0,
+    created_at: '2026-05-19T12:00:00Z',
+    updated_at: '2026-05-19T12:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('notification entity constants', () => {
+  it('exposes the two PSY-595 comment row types', () => {
+    expect(NOTIFICATION_ENTITY_COMMENT_REPLY).toBe('comment_reply')
+    expect(NOTIFICATION_ENTITY_COMMENT_MENTION).toBe('comment_mention')
+  })
+
+  it('lists the quick-create entity types', () => {
+    expect(NOTIFY_ENTITY_TYPES).toEqual(['artist', 'venue', 'label', 'tag'])
+  })
+})
+
+describe('isCommentNotification', () => {
+  it('returns true for a comment_reply row', () => {
+    expect(
+      isCommentNotification(logEntry({ entity_type: 'comment_reply' }))
+    ).toBe(true)
+  })
+
+  it('returns true for a comment_mention row', () => {
+    expect(
+      isCommentNotification(logEntry({ entity_type: 'comment_mention' }))
+    ).toBe(true)
+  })
+
+  it('returns false for a show-filter row', () => {
+    expect(isCommentNotification(logEntry({ entity_type: 'show' }))).toBe(false)
+  })
+
+  it('returns false for an unrelated entity type', () => {
+    expect(isCommentNotification(logEntry({ entity_type: 'venue' }))).toBe(
+      false
+    )
+  })
+})
+
+describe('formatTimeAgo', () => {
+  // Compares against Date.now(); pin the clock for deterministic strings.
+  const NOW = new Date('2026-05-19T12:00:00Z')
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  const SECOND = 1000
+  const MINUTE = 60 * SECOND
+  const HOUR = 60 * MINUTE
+  const DAY = 24 * HOUR
+  const WEEK = 7 * DAY
+
+  function ago(ms: number): string {
+    return formatTimeAgo(new Date(NOW.getTime() - ms).toISOString())
+  }
+
+  it('returns "just now" under a minute', () => {
+    expect(ago(30 * SECOND)).toBe('just now')
+  })
+
+  it('singularizes one minute', () => {
+    expect(ago(MINUTE)).toBe('1 minute ago')
+  })
+
+  it('pluralizes minutes', () => {
+    expect(ago(5 * MINUTE)).toBe('5 minutes ago')
+  })
+
+  it('singularizes one hour', () => {
+    expect(ago(HOUR)).toBe('1 hour ago')
+  })
+
+  it('pluralizes hours', () => {
+    expect(ago(3 * HOUR)).toBe('3 hours ago')
+  })
+
+  it('singularizes one day', () => {
+    expect(ago(DAY)).toBe('1 day ago')
+  })
+
+  it('pluralizes days', () => {
+    expect(ago(3 * DAY)).toBe('3 days ago')
+  })
+
+  it('singularizes one week', () => {
+    expect(ago(WEEK)).toBe('1 week ago')
+  })
+
+  it('pluralizes weeks', () => {
+    expect(ago(3 * WEEK)).toBe('3 weeks ago')
+  })
+
+  it('falls back to an absolute date at five weeks (no month branch)', () => {
+    // This formatter has no "months ago" branch — once diffWeeks reaches 5 it
+    // drops straight to a localized absolute date. Compare against the same
+    // toLocaleDateString call so the assertion is timezone-independent.
+    const old = new Date(NOW.getTime() - 5 * WEEK)
+    expect(ago(5 * WEEK)).toBe(
+      old.toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+      })
+    )
+  })
+})
+
+describe('getFilterSummary', () => {
+  it('returns "No criteria set" for an empty filter', () => {
+    expect(getFilterSummary(filter())).toBe('No criteria set')
+  })
+
+  it('singularizes a single artist', () => {
+    expect(getFilterSummary(filter({ artist_ids: [1] }))).toBe('1 artist')
+  })
+
+  it('pluralizes multiple of each entity', () => {
+    expect(
+      getFilterSummary(
+        filter({ artist_ids: [1, 2], venue_ids: [3, 4, 5], label_ids: [6, 7] })
+      )
+    ).toBe('2 artists / 3 venues / 2 labels')
+  })
+
+  it('describes included and excluded tags', () => {
+    expect(
+      getFilterSummary(filter({ tag_ids: [1], exclude_tag_ids: [2, 3] }))
+    ).toBe('1 tag / excluding 2 tags')
+  })
+
+  it('joins multiple cities with semicolons', () => {
+    expect(
+      getFilterSummary(
+        filter({
+          cities: [
+            { city: 'Phoenix', state: 'AZ' },
+            { city: 'Austin', state: 'TX' },
+          ],
+        })
+      )
+    ).toBe('Phoenix, AZ; Austin, TX')
+  })
+
+  it('renders "free only" when the price cap is zero', () => {
+    expect(getFilterSummary(filter({ price_max_cents: 0 }))).toBe('free only')
+  })
+
+  it('formats a non-zero price cap as whole dollars', () => {
+    expect(getFilterSummary(filter({ price_max_cents: 2500 }))).toBe('max $25')
+  })
+
+  it('treats null/empty arrays as unset criteria', () => {
+    expect(
+      getFilterSummary(
+        filter({ artist_ids: [], venue_ids: null, price_max_cents: null })
+      )
+    ).toBe('No criteria set')
+  })
+})

--- a/frontend/features/tags/types.test.ts
+++ b/frontend/features/tags/types.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest'
+import {
+  TAG_CATEGORIES,
+  TAG_SORT_OPTIONS,
+  DEFAULT_TAG_SORT,
+  DEFAULT_TAG_VIEW,
+  TAG_ENTITY_TYPES,
+  LOW_QUALITY_REASON_LABELS,
+  LOW_QUALITY_SIGNAL_CHIPS,
+  getCategoryColor,
+  getCategoryLabel,
+  getEntityUrl,
+  getEntityTypePluralLabel,
+} from './types'
+
+describe('tag constants', () => {
+  it('exposes the three tag categories', () => {
+    expect(TAG_CATEGORIES).toEqual(['genre', 'locale', 'other'])
+  })
+
+  it('maps each sort option to a backend slug', () => {
+    expect(TAG_SORT_OPTIONS).toEqual([
+      { value: 'popularity', label: 'Popularity', backend: 'usage' },
+      { value: 'alphabetical', label: 'Alphabetical', backend: 'name' },
+      { value: 'newest', label: 'Newest', backend: 'created' },
+    ])
+  })
+
+  it('defaults sort to popularity and view to grid', () => {
+    expect(DEFAULT_TAG_SORT).toBe('popularity')
+    expect(DEFAULT_TAG_VIEW).toBe('grid')
+  })
+
+  it('lists the polymorphic tag entity types (collection included)', () => {
+    expect(TAG_ENTITY_TYPES).toEqual([
+      'artist',
+      'release',
+      'label',
+      'show',
+      'venue',
+      'festival',
+      'collection',
+    ])
+  })
+})
+
+describe('low-quality reason labels', () => {
+  it('keeps a label for every low-quality reason', () => {
+    const reasons = [
+      'orphaned',
+      'aging_unused',
+      'downvoted',
+      'short_name',
+      'long_name',
+    ] as const
+    for (const reason of reasons) {
+      expect(LOW_QUALITY_REASON_LABELS[reason]).toBeTruthy()
+    }
+  })
+})
+
+describe('low-quality signal chips', () => {
+  it('merges short_name and long_name into one "Unusual length" chip', () => {
+    const chip = LOW_QUALITY_SIGNAL_CHIPS.find(c => c.id === 'unusual_length')
+    expect(chip?.reasons).toEqual(['short_name', 'long_name'])
+  })
+
+  it('covers every reason across the chip set', () => {
+    const covered = LOW_QUALITY_SIGNAL_CHIPS.flatMap(c => c.reasons).sort()
+    expect(covered).toEqual(
+      ['aging_unused', 'downvoted', 'long_name', 'orphaned', 'short_name'].sort()
+    )
+  })
+})
+
+describe('getCategoryColor', () => {
+  it('returns a distinct class string per known category', () => {
+    expect(getCategoryColor('genre')).toContain('blue')
+    expect(getCategoryColor('locale')).toContain('cyan')
+    expect(getCategoryColor('other')).toContain('zinc')
+  })
+
+  it('falls back to the "other" styling for an unknown category', () => {
+    expect(getCategoryColor('mystery')).toBe(getCategoryColor('other'))
+  })
+})
+
+describe('getCategoryLabel', () => {
+  it('capitalizes the first letter', () => {
+    expect(getCategoryLabel('genre')).toBe('Genre')
+    expect(getCategoryLabel('locale')).toBe('Locale')
+  })
+
+  it('returns an empty string for empty input', () => {
+    expect(getCategoryLabel('')).toBe('')
+  })
+})
+
+describe('getEntityUrl', () => {
+  it.each([
+    ['artist', 'the-band', '/artists/the-band'],
+    ['venue', 'the-club', '/venues/the-club'],
+    ['show', 'a-show', '/shows/a-show'],
+    ['release', 'an-album', '/releases/an-album'],
+    ['label', 'a-label', '/labels/a-label'],
+    ['festival', 'a-fest', '/festivals/a-fest'],
+    ['collection', 'a-list', '/collections/a-list'],
+  ])('builds the %s url', (type, slug, expected) => {
+    expect(getEntityUrl(type, slug)).toBe(expected)
+  })
+
+  it('returns "#" for an unknown entity type', () => {
+    expect(getEntityUrl('mixtape', 'whatever')).toBe('#')
+  })
+})
+
+describe('getEntityTypePluralLabel', () => {
+  it.each([
+    ['artist', 'Artists'],
+    ['venue', 'Venues'],
+    ['show', 'Shows'],
+    ['release', 'Releases'],
+    ['label', 'Labels'],
+    ['festival', 'Festivals'],
+    ['collection', 'Collections'],
+  ])('pluralizes %s', (type, expected) => {
+    expect(getEntityTypePluralLabel(type)).toBe(expected)
+  })
+
+  it('returns the raw value for an unknown entity type', () => {
+    expect(getEntityTypePluralLabel('mixtape')).toBe('mixtape')
+  })
+})

--- a/frontend/features/venues/types.test.ts
+++ b/frontend/features/venues/types.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { getVenueLocation, type Venue } from './types'
+
+function venue(overrides: Partial<Venue> = {}): Venue {
+  return {
+    id: 1,
+    slug: 'the-club',
+    name: 'The Club',
+    address: null,
+    city: 'Phoenix',
+    state: 'AZ',
+    verified: true,
+    created_at: '2026-05-19T12:00:00Z',
+    updated_at: '2026-05-19T12:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('getVenueLocation', () => {
+  it('joins city and state with a comma', () => {
+    expect(getVenueLocation(venue())).toBe('Phoenix, AZ')
+  })
+
+  it('reflects the venue city and state passed in', () => {
+    expect(getVenueLocation(venue({ city: 'Austin', state: 'TX' }))).toBe(
+      'Austin, TX'
+    )
+  })
+
+  it('still renders the separator when a part is an empty string', () => {
+    // The helper is a plain template join with no null/empty guard; an empty
+    // state leaves a trailing ", " so callers can spot missing data.
+    expect(getVenueLocation(venue({ state: '' }))).toBe('Phoenix, ')
+  })
+})


### PR DESCRIPTION
## Summary

Adds sibling `types.test.ts` for the six `frontend/features/*/types.ts` modules that export runtime helpers but had no test, completing the narrowed PSY-707 scope (per the 2026-05-19 reconciliation comment: collections/contributions/festivals/labels/radio/releases/requests were already done).

- **artists** (2 exports): `hasAnySocialLink`, `getArtistLocation`
- **comments** (5): reply-permission value list + 2 label maps, `FIELD_NOTE_EDIT_WINDOW_MS`, `isWithinFieldNoteEditWindow`
- **community** (2): `DIMENSION_LABELS`, `PERIOD_LABELS`
- **notifications** (6): 2 entity constants, `isCommentNotification`, `NOTIFY_ENTITY_TYPES`, `formatTimeAgo`, `getFilterSummary`
- **tags** (11): category/sort/view/entity constants, low-quality reason labels + signal chips, `getCategoryColor`, `getCategoryLabel`, `getEntityUrl`, `getEntityTypePluralLabel`
- **venues** (1): `getVenueLocation`

`getArtistLocation` gets the full PSY-558 enumeration — domestic city+state suppresses `USA`/`US` (case-insensitive + trimmed), international shows always render the country, and missing-city / missing-state cases degrade correctly — guarding against the "Phoenix, AZ, USA" regression. Time-dependent helpers (`formatTimeAgo`, `isWithinFieldNoteEditWindow`) pin the clock with fake timers, following the `requests/types.test.ts` convention.

Test-only change; no source modified.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run test:run features/artists features/comments features/community features/notifications features/tags features/venues` — 60 files / 898 tests pass
- [x] `/simplify` run before PR (trimmed redundant WHAT-comments; inline builders confirmed consistent with peer type-tests, no shared factory to reuse)

Closes PSY-707

🤖 Generated with [Claude Code](https://claude.com/claude-code)