### PR TITLE
PSY-701: cover misc untested feature hooks (venue/tag/artist)

### DIFF
--- a/frontend/features/artists/hooks/useArtistBillComposition.test.tsx
+++ b/frontend/features/artists/hooks/useArtistBillComposition.test.tsx
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { createWrapper } from '@/test/utils'
+
+// Create mocks
+const mockApiRequest = vi.fn()
+
+// Mock the api module
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+// Mock the feature api module
+vi.mock('@/features/artists/api', () => ({
+  artistEndpoints: {
+    BILL_COMPOSITION: (artistId: string | number) =>
+      `/artists/${artistId}/bill-composition`,
+  },
+  artistQueryKeys: {
+    billComposition: (id: string | number, months: number) => [
+      'artists',
+      'billComposition',
+      String(id),
+      months,
+    ],
+  },
+}))
+
+// Import hooks after mocks are set up
+import { useArtistBillComposition } from './useArtistBillComposition'
+
+const mockComposition = {
+  artist: {
+    id: 1,
+    name: 'Center Artist',
+    slug: 'center-artist',
+    upcoming_show_count: 2,
+  },
+  stats: { total_shows: 12, headliner_count: 4, opener_count: 8 },
+  opens_with: [],
+  closes_with: [],
+  graph: { center: { id: 1, name: 'Center Artist', slug: 'center-artist', upcoming_show_count: 2 }, nodes: [], links: [] },
+  below_threshold: false,
+  time_filter_months: 0,
+}
+
+describe('useArtistBillComposition', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches all-time composition (no months param) when months is 0', async () => {
+    mockApiRequest.mockResolvedValueOnce(mockComposition)
+
+    const { result } = renderHook(
+      () => useArtistBillComposition({ artistId: 1, months: 0 }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/artists/1/bill-composition', {
+      method: 'GET',
+    })
+    expect(result.current.data).toEqual(mockComposition)
+  })
+
+  it('appends the months query param when a window is set', async () => {
+    mockApiRequest.mockResolvedValueOnce(mockComposition)
+
+    const { result } = renderHook(
+      () => useArtistBillComposition({ artistId: 1, months: 12 }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/artists/1/bill-composition?months=12',
+      { method: 'GET' }
+    )
+  })
+
+  it('starts in a loading state before the request resolves', () => {
+    // Never-resolving promise keeps the query pending so we can assert the
+    // loading branch the bill-composition panel renders a skeleton for.
+    mockApiRequest.mockReturnValueOnce(new Promise(() => {}))
+
+    const { result } = renderHook(
+      () => useArtistBillComposition({ artistId: 1, months: 0 }),
+      { wrapper: createWrapper() }
+    )
+
+    expect(result.current.isLoading).toBe(true)
+  })
+
+  it('exposes an error when the composition fetch fails', async () => {
+    const error = new Error('Artist not found')
+    Object.assign(error, { status: 404 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(
+      () => useArtistBillComposition({ artistId: 999, months: 0 }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect((result.current.error as Error).message).toBe('Artist not found')
+  })
+
+  it('does not fetch when enabled is false', () => {
+    const { result } = renderHook(
+      () => useArtistBillComposition({ artistId: 1, months: 0, enabled: false }),
+      { wrapper: createWrapper() }
+    )
+
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('does not fetch when artistId is 0 or negative', () => {
+    const { result: result0 } = renderHook(
+      () => useArtistBillComposition({ artistId: 0, months: 0 }),
+      { wrapper: createWrapper() }
+    )
+    const { result: resultNeg } = renderHook(
+      () => useArtistBillComposition({ artistId: -1, months: 0 }),
+      { wrapper: createWrapper() }
+    )
+
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result0.current.fetchStatus).toBe('idle')
+    expect(resultNeg.current.fetchStatus).toBe('idle')
+  })
+})

--- a/frontend/features/artists/hooks/useArtistGraph.test.tsx
+++ b/frontend/features/artists/hooks/useArtistGraph.test.tsx
@@ -1,0 +1,298 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient } from '@tanstack/react-query'
+import { createWrapper, createWrapperWithClient } from '@/test/utils'
+
+// Create mocks
+const mockApiRequest = vi.fn()
+
+// Mock the api module
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+// Mock the feature api module
+vi.mock('@/features/artists/api', () => ({
+  artistEndpoints: {
+    GRAPH: (artistId: string | number) => `/artists/${artistId}/graph`,
+    RELATIONSHIPS: {
+      CREATE: '/artists/relationships',
+      VOTE: (sourceId: number, targetId: number) =>
+        `/artists/relationships/${sourceId}/${targetId}/vote`,
+    },
+  },
+  artistQueryKeys: {
+    graph: (id: string | number, types?: string[]) => [
+      'artists',
+      'graph',
+      String(id),
+      types,
+    ],
+  },
+}))
+
+// Import hooks after mocks are set up
+import {
+  useArtistGraph,
+  useArtistRelationshipVote,
+  useCreateArtistRelationship,
+} from './useArtistGraph'
+
+const mockGraph = {
+  center: {
+    id: 1,
+    name: 'Center Artist',
+    slug: 'center-artist',
+    upcoming_show_count: 3,
+  },
+  nodes: [
+    { id: 2, name: 'Related A', slug: 'related-a', upcoming_show_count: 1 },
+  ],
+  links: [
+    {
+      source_id: 1,
+      target_id: 2,
+      type: 'shared_bills',
+      score: 0.8,
+      votes_up: 4,
+      votes_down: 0,
+    },
+  ],
+}
+
+describe('useArtistGraph', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('fetches the relationship graph for an artist', async () => {
+    mockApiRequest.mockResolvedValueOnce(mockGraph)
+
+    const { result } = renderHook(() => useArtistGraph({ artistId: 1 }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/artists/1/graph', {
+      method: 'GET',
+    })
+    expect(result.current.data).toEqual(mockGraph)
+  })
+
+  it('forwards the types filter as a comma-joined query param', async () => {
+    mockApiRequest.mockResolvedValueOnce(mockGraph)
+
+    const { result } = renderHook(
+      () => useArtistGraph({ artistId: 1, types: ['shared_bills', 'same_label'] }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiRequest.mock.calls[0][0]).toBe(
+      '/artists/1/graph?types=shared_bills%2Csame_label'
+    )
+  })
+
+  it('starts in a loading state before the request resolves', () => {
+    // Never-resolving promise keeps the query pending so we can assert the
+    // loading branch the graph UI renders a spinner for.
+    mockApiRequest.mockReturnValueOnce(new Promise(() => {}))
+
+    const { result } = renderHook(() => useArtistGraph({ artistId: 1 }), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.isLoading).toBe(true)
+  })
+
+  it('exposes an error when the graph fetch fails', async () => {
+    const error = new Error('Artist not found')
+    Object.assign(error, { status: 404 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useArtistGraph({ artistId: 999 }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect((result.current.error as Error).message).toBe('Artist not found')
+  })
+
+  it('does not fetch when enabled is false', () => {
+    const { result } = renderHook(
+      () => useArtistGraph({ artistId: 1, enabled: false }),
+      { wrapper: createWrapper() }
+    )
+
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('does not fetch when artistId is 0 or negative', () => {
+    const { result: result0 } = renderHook(
+      () => useArtistGraph({ artistId: 0 }),
+      { wrapper: createWrapper() }
+    )
+    const { result: resultNeg } = renderHook(
+      () => useArtistGraph({ artistId: -1 }),
+      { wrapper: createWrapper() }
+    )
+
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    expect(result0.current.fetchStatus).toBe('idle')
+    expect(resultNeg.current.fetchStatus).toBe('idle')
+  })
+})
+
+describe('useArtistRelationshipVote', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('POSTs the vote and invalidates the center artist graph', async () => {
+    mockApiRequest.mockResolvedValueOnce(undefined)
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: 0 },
+        mutations: { retry: false },
+      },
+    })
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const { result } = renderHook(() => useArtistRelationshipVote(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        sourceId: 1,
+        targetId: 2,
+        type: 'shared_bills',
+        isUpvote: true,
+        centerArtistId: 1,
+      })
+    })
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/artists/relationships/1/2/vote',
+      {
+        method: 'POST',
+        body: JSON.stringify({ type: 'shared_bills', is_upvote: true }),
+      }
+    )
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['artists', 'graph', '1'],
+    })
+  })
+
+  it('surfaces an error and skips invalidation when the vote fails', async () => {
+    const error = new Error('Unauthorized')
+    Object.assign(error, { status: 401 })
+    mockApiRequest.mockRejectedValueOnce(error)
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: 0 },
+        mutations: { retry: false },
+      },
+    })
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const { result } = renderHook(() => useArtistRelationshipVote(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({
+          sourceId: 1,
+          targetId: 2,
+          type: 'shared_bills',
+          isUpvote: false,
+          centerArtistId: 1,
+        })
+      } catch {
+        // expected
+      }
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect((result.current.error as Error).message).toBe('Unauthorized')
+    expect(invalidateSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('useCreateArtistRelationship', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('POSTs the new relationship and invalidates the center artist graph', async () => {
+    mockApiRequest.mockResolvedValueOnce(undefined)
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: 0 },
+        mutations: { retry: false },
+      },
+    })
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const { result } = renderHook(() => useCreateArtistRelationship(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        sourceArtistId: 1,
+        targetArtistId: 2,
+        type: 'shared_bills',
+        centerArtistId: 1,
+      })
+    })
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/artists/relationships', {
+      method: 'POST',
+      body: JSON.stringify({
+        source_artist_id: 1,
+        target_artist_id: 2,
+        type: 'shared_bills',
+      }),
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['artists', 'graph', '1'],
+    })
+  })
+
+  it('surfaces a duplicate-relationship error', async () => {
+    const error = new Error('relationship already exists')
+    Object.assign(error, { status: 409 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useCreateArtistRelationship(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({
+          sourceArtistId: 1,
+          targetArtistId: 2,
+          type: 'shared_bills',
+          centerArtistId: 1,
+        })
+      } catch {
+        // expected
+      }
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect((result.current.error as Error).message).toBe(
+      'relationship already exists'
+    )
+  })
+})

--- a/frontend/features/tags/admin/useAdminTags.test.tsx
+++ b/frontend/features/tags/admin/useAdminTags.test.tsx
@@ -1,0 +1,239 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient } from '@tanstack/react-query'
+import { createWrapperWithClient } from '@/test/utils'
+
+// Create mocks
+const mockApiRequest = vi.fn()
+
+// Mock the api module
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    TAGS: {
+      GET: (idOrSlug: string | number) => `/tags/${idOrSlug}`,
+      ALIASES: (idOrSlug: string | number) => `/tags/${idOrSlug}/aliases`,
+      DELETE_ALIAS: (tagId: number, aliasId: number) =>
+        `/tags/${tagId}/aliases/${aliasId}`,
+      ADMIN_MERGE: (sourceId: number) => `/admin/tags/${sourceId}/merge`,
+    },
+  },
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+// Mock queryClient module. The hooks call queryClient.invalidateQueries
+// directly with these keys, so we mirror the real key shapes and assert
+// against them via a spy on the live QueryClient below.
+vi.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    tags: {
+      all: ['tags'],
+      detail: (id: string | number) => ['tags', 'detail', String(id)],
+      aliases: (tagId: number) => ['tags', 'aliases', tagId],
+    },
+  },
+}))
+
+// Import hooks after mocks are set up
+import {
+  useDeleteTag,
+  useMergeTags,
+  useCreateAlias,
+  useDeleteAlias,
+} from './useAdminTags'
+
+/** Build a retry-free QueryClient plus a spy on its invalidateQueries. */
+function setupClient() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+  const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+  return { queryClient, invalidateSpy }
+}
+
+describe('useDeleteTag', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('DELETEs the tag and invalidates the tag list on success', async () => {
+    mockApiRequest.mockResolvedValueOnce(undefined)
+    const { queryClient, invalidateSpy } = setupClient()
+
+    const { result } = renderHook(() => useDeleteTag(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+
+    await act(async () => {
+      await result.current.mutateAsync(5)
+    })
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/tags/5', { method: 'DELETE' })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['tags'] })
+  })
+
+  it('surfaces the error and skips invalidation when delete is blocked', async () => {
+    const error = new Error('tag is in use and cannot be deleted')
+    Object.assign(error, { status: 409 })
+    mockApiRequest.mockRejectedValueOnce(error)
+    const { queryClient, invalidateSpy } = setupClient()
+
+    const { result } = renderHook(() => useDeleteTag(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync(5)
+      } catch {
+        // expected
+      }
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect((result.current.error as Error).message).toBe(
+      'tag is in use and cannot be deleted'
+    )
+    expect(invalidateSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('useMergeTags', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('POSTs source→target and invalidates tag lists + aliases on success', async () => {
+    mockApiRequest.mockResolvedValueOnce({ merged_count: 7 })
+    const { queryClient, invalidateSpy } = setupClient()
+
+    const { result } = renderHook(() => useMergeTags(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+
+    await act(async () => {
+      await result.current.mutateAsync({ sourceId: 3, targetId: 8 })
+    })
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/admin/tags/3/merge', {
+      method: 'POST',
+      body: JSON.stringify({ target_id: 8 }),
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['tags'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['tags', 'aliases'] })
+  })
+
+  it('surfaces a merge error and skips invalidation', async () => {
+    const error = new Error('cannot merge a tag into itself')
+    Object.assign(error, { status: 400 })
+    mockApiRequest.mockRejectedValueOnce(error)
+    const { queryClient, invalidateSpy } = setupClient()
+
+    const { result } = renderHook(() => useMergeTags(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({ sourceId: 3, targetId: 3 })
+      } catch {
+        // expected
+      }
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect((result.current.error as Error).message).toBe(
+      'cannot merge a tag into itself'
+    )
+    expect(invalidateSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('useCreateAlias', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('POSTs the alias and invalidates that tag\'s aliases + detail', async () => {
+    mockApiRequest.mockResolvedValueOnce(undefined)
+    const { queryClient, invalidateSpy } = setupClient()
+
+    const { result } = renderHook(() => useCreateAlias(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+
+    await act(async () => {
+      await result.current.mutateAsync({ tagId: 5, alias: 'hardcore-punk' })
+    })
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/tags/5/aliases', {
+      method: 'POST',
+      body: JSON.stringify({ alias: 'hardcore-punk' }),
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['tags', 'aliases', 5],
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['tags', 'detail', '5'],
+    })
+  })
+
+  it('surfaces a duplicate-alias error and skips invalidation', async () => {
+    const error = new Error('alias already exists')
+    Object.assign(error, { status: 409 })
+    mockApiRequest.mockRejectedValueOnce(error)
+    const { queryClient, invalidateSpy } = setupClient()
+
+    const { result } = renderHook(() => useCreateAlias(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({ tagId: 5, alias: 'punk' })
+      } catch {
+        // expected
+      }
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect((result.current.error as Error).message).toBe('alias already exists')
+    expect(invalidateSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('useDeleteAlias', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  it('DELETEs the alias and invalidates that tag\'s aliases + detail', async () => {
+    mockApiRequest.mockResolvedValueOnce(undefined)
+    const { queryClient, invalidateSpy } = setupClient()
+
+    const { result } = renderHook(() => useDeleteAlias(), {
+      wrapper: createWrapperWithClient(queryClient),
+    })
+
+    await act(async () => {
+      await result.current.mutateAsync({ tagId: 5, aliasId: 99 })
+    })
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/tags/5/aliases/99', {
+      method: 'DELETE',
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['tags', 'aliases', 5],
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['tags', 'detail', '5'],
+    })
+  })
+})

--- a/frontend/features/venues/hooks/useVenueEdit.test.tsx
+++ b/frontend/features/venues/hooks/useVenueEdit.test.tsx
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { createWrapper } from '@/test/utils'
+
+// Create mocks
+const mockApiRequest = vi.fn()
+const mockInvalidateVenues = vi.fn()
+
+// Mock the api module
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_BASE_URL: 'http://localhost:8080',
+}))
+
+// Mock the feature api module
+vi.mock('@/features/venues/api', () => ({
+  venueEndpoints: {
+    UPDATE: (venueId: string | number) => `/venues/${venueId}`,
+    DELETE: (venueId: string | number) => `/venues/${venueId}`,
+  },
+}))
+
+// Mock queryClient module — spy on the invalidation helper so we can assert
+// the post-mutation cache refresh without inspecting a real QueryClient.
+vi.mock('@/lib/queryClient', () => ({
+  createInvalidateQueries: () => ({
+    venues: mockInvalidateVenues,
+  }),
+}))
+
+// Import hooks after mocks are set up
+import { useVenueUpdate, useVenueDelete } from './useVenueEdit'
+
+describe('useVenueUpdate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateVenues.mockReset()
+  })
+
+  it('PUTs the edit and invalidates the venues cache on success', async () => {
+    const mockVenue = {
+      id: 7,
+      name: 'The Rebel Lounge',
+      city: 'Phoenix',
+      state: 'AZ',
+    }
+    mockApiRequest.mockResolvedValueOnce(mockVenue)
+
+    const { result } = renderHook(() => useVenueUpdate(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        venueId: 7,
+        data: { name: 'The Rebel Lounge', city: 'Phoenix' },
+      })
+    })
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/venues/7', {
+      method: 'PUT',
+      body: JSON.stringify({ name: 'The Rebel Lounge', city: 'Phoenix' }),
+    })
+    expect(mockInvalidateVenues).toHaveBeenCalled()
+    await waitFor(() => expect(result.current.data).toEqual(mockVenue))
+  })
+
+  // Server-side validation failures surface as a rejected apiRequest. The
+  // mutation must expose the backend message verbatim so the edit form can
+  // render it, and must NOT invalidate the cache (nothing changed).
+  it('surfaces server-side validation feedback and skips cache invalidation', async () => {
+    const error = new Error('name is required')
+    Object.assign(error, { status: 400 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useVenueUpdate(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({
+          venueId: 7,
+          data: { name: '' },
+        })
+      } catch {
+        // expected — assertions below
+      }
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect((result.current.error as Error).message).toBe('name is required')
+    expect(mockInvalidateVenues).not.toHaveBeenCalled()
+  })
+
+  it('exposes a 403 when a non-admin attempts a direct update', async () => {
+    const error = new Error('Forbidden')
+    Object.assign(error, { status: 403 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useVenueUpdate(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({
+          venueId: 7,
+          data: { name: 'Renamed' },
+        })
+      } catch {
+        // expected
+      }
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect((result.current.error as Error).message).toBe('Forbidden')
+    expect(mockInvalidateVenues).not.toHaveBeenCalled()
+  })
+})
+
+describe('useVenueDelete', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+    mockInvalidateVenues.mockReset()
+  })
+
+  it('DELETEs the venue and invalidates the venues cache on success', async () => {
+    mockApiRequest.mockResolvedValueOnce(undefined)
+
+    const { result } = renderHook(() => useVenueDelete(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      await result.current.mutateAsync(7)
+    })
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/venues/7', {
+      method: 'DELETE',
+    })
+    expect(mockInvalidateVenues).toHaveBeenCalled()
+  })
+
+  // Venues with associated shows can't be deleted; the backend rejects with a
+  // 409. The mutation should pass the message through and leave the cache alone.
+  it('surfaces the constraint error when the venue has associated shows', async () => {
+    const error = new Error('venue has associated shows and cannot be deleted')
+    Object.assign(error, { status: 409 })
+    mockApiRequest.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useVenueDelete(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync(7)
+      } catch {
+        // expected
+      }
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect((result.current.error as Error).message).toBe(
+      'venue has associated shows and cannot be deleted'
+    )
+    expect(mockInvalidateVenues).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- Adds sibling unit tests for four previously untested feature hooks: `useVenueEdit`, `useAdminTags`, `useArtistGraph`, `useArtistBillComposition`.
- `useReducedMotion` (also listed on the ticket) already had a sibling test, so it was left untouched.
- Test-only change — no production code modified.

## Coverage added
- **`useVenueEdit`** (5 tests): admin update + delete mutations, server-side validation feedback (400 with field message), 403 non-admin direct-update, show-constraint delete error (409); asserts cache invalidation fires only on success.
- **`useAdminTags`** (7 tests): delete / merge / create-alias / delete-alias mutations with exact endpoints and cache-invalidation keys, plus error branches that must skip invalidation.
- **`useArtistGraph`** (10 tests): graph query success / loading / error / disabled / id-gating, plus the vote + create-relationship mutations and their center-artist graph invalidation.
- **`useArtistBillComposition`** (6 tests): query success / loading / error, `months` query-param shaping, and enabled/id gating.

## Test plan
- [x] `bun run typecheck` passes clean
- [x] `bun run test:run features/venues/hooks/useVenueEdit features/tags/admin/useAdminTags features/artists/hooks/useArtistGraph features/artists/hooks/useArtistBillComposition` — 28/28 pass
- [x] `bun run test:run features/venues features/tags features/artists` — new tests green; one intermittent pre-existing flake in `features/tags/components/EntityTagList.test.tsx` (a `waitFor`-on-`user.click` timeout under parallel load), unrelated to this change and passing 49/49 in isolation
- [x] `/simplify` run before PR (aligned loading-state assertions to the codebase `isLoading` idiom)

Closes PSY-701

🤖 Generated with [Claude Code](https://claude.com/claude-code)