### PR TITLE
PSY-694: cover ArtistEditForm + OrphanedArtistsDialog with tests

### DIFF
--- a/frontend/components/forms/ArtistEditForm.test.tsx
+++ b/frontend/components/forms/ArtistEditForm.test.tsx
@@ -1,0 +1,251 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders } from '@/test/utils'
+import { ArtistEditForm } from './ArtistEditForm'
+import type { Artist } from '@/features/artists'
+
+// --- Mocks ---
+
+// `useArtistUpdate` is imported directly from the admin-artists hook module.
+// A single shared mutate spy lets each test assert what was sent and drive the
+// success / error callbacks the form wires up.
+const mockMutate = vi.fn()
+let mockIsPending = false
+
+vi.mock('@/lib/hooks/admin/useAdminArtists', () => ({
+  useArtistUpdate: () => ({ mutate: mockMutate, isPending: mockIsPending }),
+}))
+
+// --- Helpers ---
+
+function makeArtist(overrides: Partial<Artist> = {}): Artist {
+  return {
+    id: 1,
+    slug: 'artist-a',
+    name: 'Artist A',
+    city: 'Phoenix',
+    state: 'AZ',
+    bandcamp_embed_url: null,
+    social: {
+      instagram: 'https://instagram.com/artist-a',
+      facebook: null,
+      twitter: null,
+      youtube: null,
+      spotify: null,
+      soundcloud: null,
+      bandcamp: null,
+      website: 'https://artist-a.com',
+    },
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('ArtistEditForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsPending = false
+  })
+
+  describe('initial render', () => {
+    it('populates fields from the artist prop', () => {
+      const artist = makeArtist()
+      renderWithProviders(
+        <ArtistEditForm
+          key={artist.id}
+          artist={artist}
+          open
+          onOpenChange={vi.fn()}
+        />
+      )
+
+      expect(screen.getByLabelText(/Name \*/i)).toHaveValue('Artist A')
+      expect(screen.getByLabelText(/City/i)).toHaveValue('Phoenix')
+      expect(screen.getByLabelText(/State/i)).toHaveValue('AZ')
+      expect(screen.getByLabelText(/Instagram/i)).toHaveValue(
+        'https://instagram.com/artist-a'
+      )
+      expect(screen.getByLabelText(/Website/i)).toHaveValue(
+        'https://artist-a.com'
+      )
+    })
+
+    it('renders empty strings for absent optional fields', () => {
+      const artist = makeArtist({
+        city: null,
+        state: null,
+        social: {
+          instagram: null,
+          facebook: null,
+          twitter: null,
+          youtube: null,
+          spotify: null,
+          soundcloud: null,
+          bandcamp: null,
+          website: null,
+        },
+      })
+      renderWithProviders(
+        <ArtistEditForm artist={artist} open onOpenChange={vi.fn()} />
+      )
+
+      expect(screen.getByLabelText(/City/i)).toHaveValue('')
+      expect(screen.getByLabelText(/Spotify/i)).toHaveValue('')
+      // Name is always present.
+      expect(screen.getByLabelText(/Name \*/i)).toHaveValue('Artist A')
+    })
+  })
+
+  describe('field edits + submit', () => {
+    it('calls the update mutation with only the changed fields', async () => {
+      const user = userEvent.setup()
+      const artist = makeArtist()
+      renderWithProviders(
+        <ArtistEditForm artist={artist} open onOpenChange={vi.fn()} />
+      )
+
+      const nameInput = screen.getByLabelText(/Name \*/i)
+      await user.clear(nameInput)
+      await user.type(nameInput, 'Artist B')
+
+      await user.click(screen.getByRole('button', { name: /Save Changes/i }))
+
+      await waitFor(() => expect(mockMutate).toHaveBeenCalledTimes(1))
+      // Only `name` changed — city/state/socials must be omitted from the diff.
+      expect(mockMutate).toHaveBeenCalledWith(
+        { artistId: 1, data: { name: 'Artist B' } },
+        expect.objectContaining({
+          onSuccess: expect.any(Function),
+          onError: expect.any(Function),
+        })
+      )
+    })
+
+    it('does not call the mutation and shows "No changes detected" on an unchanged submit', async () => {
+      const user = userEvent.setup()
+      const artist = makeArtist()
+      renderWithProviders(
+        <ArtistEditForm artist={artist} open onOpenChange={vi.fn()} />
+      )
+
+      await user.click(screen.getByRole('button', { name: /Save Changes/i }))
+
+      expect(await screen.findByText(/No changes detected/i)).toBeInTheDocument()
+      expect(mockMutate).not.toHaveBeenCalled()
+    })
+
+    it('blocks the mutation when the required name is cleared', async () => {
+      // The zod `onSubmit` validator rejects an empty name, so the form's
+      // submit handler never runs. NOTE: the component does not surface the
+      // validation message in the DOM (no field-error rendering) — this test
+      // pins the observable behavior (mutation blocked), not a visible error.
+      const user = userEvent.setup()
+      const artist = makeArtist()
+      renderWithProviders(
+        <ArtistEditForm artist={artist} open onOpenChange={vi.fn()} />
+      )
+
+      await user.clear(screen.getByLabelText(/Name \*/i))
+      await user.click(screen.getByRole('button', { name: /Save Changes/i }))
+
+      // Give the async submit/validation a tick to settle, then assert no call.
+      await waitFor(() =>
+        expect(screen.getByLabelText(/Name \*/i)).toHaveValue('')
+      )
+      expect(mockMutate).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('mutation result handling', () => {
+    it('shows an error alert when the mutation fails', async () => {
+      const user = userEvent.setup()
+      // Drive the onError callback the form passes to mutate().
+      mockMutate.mockImplementation((_vars, { onError }) => {
+        onError(new Error('Server exploded'))
+      })
+
+      const artist = makeArtist()
+      renderWithProviders(
+        <ArtistEditForm artist={artist} open onOpenChange={vi.fn()} />
+      )
+
+      const nameInput = screen.getByLabelText(/Name \*/i)
+      await user.clear(nameInput)
+      await user.type(nameInput, 'Artist B')
+      await user.click(screen.getByRole('button', { name: /Save Changes/i }))
+
+      expect(await screen.findByText(/Server exploded/i)).toBeInTheDocument()
+    })
+
+    it('shows the success alert, then closes the dialog and fires onSuccess', async () => {
+      const user = userEvent.setup()
+      const onOpenChange = vi.fn()
+      const onSuccess = vi.fn()
+      // Drive the onSuccess callback the form passes to mutate().
+      mockMutate.mockImplementation((_vars, { onSuccess: cbSuccess }) => {
+        cbSuccess()
+      })
+
+      const artist = makeArtist()
+      renderWithProviders(
+        <ArtistEditForm
+          artist={artist}
+          open
+          onOpenChange={onOpenChange}
+          onSuccess={onSuccess}
+        />
+      )
+
+      const nameInput = screen.getByLabelText(/Name \*/i)
+      await user.clear(nameInput)
+      await user.type(nameInput, 'Artist B')
+      await user.click(screen.getByRole('button', { name: /Save Changes/i }))
+
+      expect(
+        await screen.findByText(/Artist updated successfully/i)
+      ).toBeInTheDocument()
+
+      // Close + onSuccess are deferred behind a real 1500ms timer; wait it out
+      // with real timers (fake timers + userEvent + findByText interact
+      // badly enough to hang sibling tests when not perfectly torn down).
+      await waitFor(
+        () => {
+          expect(onOpenChange).toHaveBeenCalledWith(false)
+          expect(onSuccess).toHaveBeenCalledTimes(1)
+        },
+        { timeout: 2500 }
+      )
+    })
+  })
+
+  describe('cancel', () => {
+    it('calls onOpenChange(false) when Cancel is clicked', async () => {
+      const user = userEvent.setup()
+      const onOpenChange = vi.fn()
+      const artist = makeArtist()
+      renderWithProviders(
+        <ArtistEditForm artist={artist} open onOpenChange={onOpenChange} />
+      )
+
+      await user.click(screen.getByRole('button', { name: /Cancel/i }))
+
+      expect(onOpenChange).toHaveBeenCalledWith(false)
+    })
+  })
+
+  describe('pending state', () => {
+    it('disables Save and shows the saving label while the mutation is pending', () => {
+      mockIsPending = true
+      const artist = makeArtist()
+      renderWithProviders(
+        <ArtistEditForm artist={artist} open onOpenChange={vi.fn()} />
+      )
+
+      const saveButton = screen.getByRole('button', { name: /Saving/i })
+      expect(saveButton).toBeDisabled()
+      expect(screen.getByRole('button', { name: /Cancel/i })).toBeDisabled()
+    })
+  })
+})

--- a/frontend/components/forms/OrphanedArtistsDialog.test.tsx
+++ b/frontend/components/forms/OrphanedArtistsDialog.test.tsx
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders } from '@/test/utils'
+import { OrphanedArtistsDialog } from './OrphanedArtistsDialog'
+import type { OrphanedArtist } from '@/features/shows'
+
+// --- Mocks ---
+
+// The dialog imports both `apiRequest` and `API_ENDPOINTS` from `@/lib/api`.
+// Mock that surface so deletes hit a spy and the endpoint builder is stable.
+const mockApiRequest = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  API_ENDPOINTS: {
+    ARTISTS: {
+      DELETE: (id: string | number) => `/artists/${id}`,
+    },
+  },
+}))
+
+// --- Helpers ---
+
+function makeArtist(overrides: Partial<OrphanedArtist> = {}): OrphanedArtist {
+  return {
+    id: 1,
+    name: 'Orphan A',
+    slug: 'orphan-a',
+    ...overrides,
+  }
+}
+
+describe('OrphanedArtistsDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiRequest.mockReset()
+  })
+
+  describe('rendering', () => {
+    it('renders the orphaned artist list', () => {
+      const artists = [
+        makeArtist({ id: 1, name: 'Orphan A' }),
+        makeArtist({ id: 2, name: 'Orphan B' }),
+      ]
+      renderWithProviders(
+        <OrphanedArtistsDialog
+          open
+          onOpenChange={vi.fn()}
+          artists={artists}
+        />
+      )
+
+      expect(screen.getByText('Orphan A')).toBeInTheDocument()
+      expect(screen.getByText('Orphan B')).toBeInTheDocument()
+    })
+
+    it('pluralizes the delete button label by artist count', () => {
+      const one = [makeArtist({ id: 1 })]
+      const { rerender } = renderWithProviders(
+        <OrphanedArtistsDialog open onOpenChange={vi.fn()} artists={one} />
+      )
+      expect(
+        screen.getByRole('button', { name: /Delete Artist$/i })
+      ).toBeInTheDocument()
+
+      rerender(
+        <OrphanedArtistsDialog
+          open
+          onOpenChange={vi.fn()}
+          artists={[makeArtist({ id: 1 }), makeArtist({ id: 2 })]}
+        />
+      )
+      expect(
+        screen.getByRole('button', { name: /Delete Artists$/i })
+      ).toBeInTheDocument()
+    })
+
+    it('does not render dialog content when closed', () => {
+      renderWithProviders(
+        <OrphanedArtistsDialog
+          open={false}
+          onOpenChange={vi.fn()}
+          artists={[makeArtist()]}
+        />
+      )
+      expect(screen.queryByText('Orphan A')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('keep all', () => {
+    it('closes the dialog and fires onComplete without deleting', async () => {
+      const user = userEvent.setup()
+      const onOpenChange = vi.fn()
+      const onComplete = vi.fn()
+      renderWithProviders(
+        <OrphanedArtistsDialog
+          open
+          onOpenChange={onOpenChange}
+          artists={[makeArtist()]}
+          onComplete={onComplete}
+        />
+      )
+
+      await user.click(screen.getByRole('button', { name: /Keep All/i }))
+
+      expect(onOpenChange).toHaveBeenCalledWith(false)
+      expect(onComplete).toHaveBeenCalledTimes(1)
+      expect(mockApiRequest).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('delete', () => {
+    it('issues a DELETE per artist, then closes and fires onComplete', async () => {
+      const user = userEvent.setup()
+      const onOpenChange = vi.fn()
+      const onComplete = vi.fn()
+      mockApiRequest.mockResolvedValue(undefined)
+
+      const artists = [
+        makeArtist({ id: 1, name: 'Orphan A' }),
+        makeArtist({ id: 2, name: 'Orphan B' }),
+      ]
+      renderWithProviders(
+        <OrphanedArtistsDialog
+          open
+          onOpenChange={onOpenChange}
+          artists={artists}
+          onComplete={onComplete}
+        />
+      )
+
+      await user.click(screen.getByRole('button', { name: /Delete Artists/i }))
+
+      await waitFor(() =>
+        expect(onComplete).toHaveBeenCalledTimes(1)
+      )
+      expect(mockApiRequest).toHaveBeenCalledTimes(2)
+      expect(mockApiRequest).toHaveBeenCalledWith('/artists/1', {
+        method: 'DELETE',
+      })
+      expect(mockApiRequest).toHaveBeenCalledWith('/artists/2', {
+        method: 'DELETE',
+      })
+      expect(onOpenChange).toHaveBeenCalledWith(false)
+    })
+
+    it('shows an error and stays open when a delete fails', async () => {
+      const user = userEvent.setup()
+      const onOpenChange = vi.fn()
+      const onComplete = vi.fn()
+      mockApiRequest.mockRejectedValue(new Error('still associated'))
+
+      renderWithProviders(
+        <OrphanedArtistsDialog
+          open
+          onOpenChange={onOpenChange}
+          artists={[makeArtist()]}
+          onComplete={onComplete}
+        />
+      )
+
+      await user.click(screen.getByRole('button', { name: /Delete Artist/i }))
+
+      expect(
+        await screen.findByText(/Failed to delete some artists/i)
+      ).toBeInTheDocument()
+      // On failure the dialog must not close or signal completion.
+      expect(onOpenChange).not.toHaveBeenCalled()
+      expect(onComplete).not.toHaveBeenCalled()
+    })
+
+    it('disables both buttons while a delete is in flight', async () => {
+      const user = userEvent.setup()
+      // Hold the request open so the pending UI is observable.
+      let resolveRequest: () => void = () => {}
+      mockApiRequest.mockImplementation(
+        () =>
+          new Promise<void>(resolve => {
+            resolveRequest = resolve
+          })
+      )
+
+      renderWithProviders(
+        <OrphanedArtistsDialog
+          open
+          onOpenChange={vi.fn()}
+          artists={[makeArtist()]}
+        />
+      )
+
+      await user.click(screen.getByRole('button', { name: /Delete Artist/i }))
+
+      await waitFor(() =>
+        expect(
+          screen.getByRole('button', { name: /Deleting/i })
+        ).toBeDisabled()
+      )
+      expect(screen.getByRole('button', { name: /Keep All/i })).toBeDisabled()
+
+      resolveRequest()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Add `ArtistEditForm.test.tsx` (9 tests): prop population, empty-optional rendering, changed-field-only diff submit, no-changes guard, required-name submit block, mutation error/success result handling, cancel, and pending state.
- Add `OrphanedArtistsDialog.test.tsx` (7 tests): orphan list render, delete-button pluralization, closed-state render, keep-all, per-artist DELETE + close/onComplete, delete-failure handling, and in-flight disabled state.
- Test-only diff. Follows the established `renderWithProviders` + factory-helper + `vi.mock` patterns from `VenueEditForm.test.tsx` (PSY-732) and `useAdminReleases.test.tsx`.

Closes PSY-694

## Notes
- `OrphanedArtistsDialog` has no per-artist "merge"/"delete" actions described loosely in the ticket — its real UX is a bulk Keep-All vs Delete-All confirmation. Tests cover the actual current behavior.
- `ArtistEditForm` does not surface zod validation messages in the DOM; the validation test pins the observable behavior (mutation blocked), not a visible error. The component uses `useEffect`-based form-init (scope-adjacent audit PSY-768) — tested as-is, not changed here.

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run test:run components/forms` passes (10 files / 107 tests)
- [x] `/simplify` review run (no issues found)

## Manual repro
Test-only diff; no runtime behavior change. The `bun run test:run components/forms` suite (10 files / 107 tests, 16 new) is the verification. The success-path test uses real timers + `waitFor` (the component defers dialog-close behind a 1500ms `setTimeout`; fake timers + userEvent deadlocked teardown). No dev stack/browser applicable.

## Simplify
Ran (available for this agent). Code already clean — reuses `renderWithProviders` + per-file factory helpers per convention, WHY-only comments, no leaked ticket refs. No fixup commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
