### PR TITLE
PSY-757: batch artist-name fetch in CheckEvents to kill N+1

### DIFF
--- a/backend/internal/services/pipeline/discovery.go
+++ b/backend/internal/services/pipeline/discovery.go
@@ -14,6 +14,7 @@ import (
 	adminm "psychic-homily-backend/internal/models/admin"
 	catalogm "psychic-homily-backend/internal/models/catalog"
 	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/services/shared"
 	"psychic-homily-backend/internal/utils"
 )
 
@@ -839,7 +840,7 @@ func (s *DiscoveryService) CheckEvents(events []contracts.CheckEventInput) (*con
 	for _, show := range fallbackByEventID {
 		showIDs = append(showIDs, show.ID)
 	}
-	artistsByShowID, err := s.fetchShowArtistsByIDs(showIDs)
+	artistsByShowID, err := shared.BatchResolveShowArtistNames(s.db, showIDs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch show artists: %w", err)
 	}
@@ -856,36 +857,9 @@ func (s *DiscoveryService) CheckEvents(events []contracts.CheckEventInput) (*con
 	return result, nil
 }
 
-// fetchShowArtistsByIDs returns artist names for the given show IDs in one
-// query, grouped by show ID and ordered by billing position. Returns an empty
-// map for an empty input so callers can index it unconditionally.
-func (s *DiscoveryService) fetchShowArtistsByIDs(showIDs []uint) (map[uint][]string, error) {
-	byShowID := make(map[uint][]string, len(showIDs))
-	if len(showIDs) == 0 {
-		return byShowID, nil
-	}
-
-	var rows []struct {
-		ShowID uint
-		Name   string
-	}
-	err := s.db.Raw(`SELECT show_artists.show_id, artists.name FROM show_artists
-		JOIN artists ON show_artists.artist_id = artists.id
-		WHERE show_artists.show_id IN (?)
-		ORDER BY show_artists.show_id, show_artists.position`, showIDs).Scan(&rows).Error
-	if err != nil {
-		return nil, err
-	}
-
-	for _, row := range rows {
-		byShowID[row.ShowID] = append(byShowID[row.ShowID], row.Name)
-	}
-	return byShowID, nil
-}
-
 // buildCheckEventStatus creates a CheckEventStatus from a Show model and its
-// pre-fetched artist names (see fetchShowArtistsByIDs — names must not be
-// queried per-show on the discovery hot path).
+// pre-fetched artist names (see shared.BatchResolveShowArtistNames — names must
+// not be queried per-show on the discovery hot path).
 func buildCheckEventStatus(show catalogm.Show, artistNames []string) contracts.CheckEventStatus {
 	return contracts.CheckEventStatus{
 		Exists: true,

--- a/backend/internal/services/pipeline/discovery.go
+++ b/backend/internal/services/pipeline/discovery.go
@@ -771,16 +771,23 @@ func (s *DiscoveryService) CheckEvents(events []contracts.CheckEventInput) (*con
 		return nil, fmt.Errorf("failed to check events: %w", err)
 	}
 
+	// Index the source-key matches by their event ID for O(1) "already matched?"
+	// lookups in the fallback loop below.
+	matchedByEventID := make(map[string]bool, len(shows))
 	for _, show := range shows {
 		if show.SourceEventID != nil {
-			result.Events[*show.SourceEventID] = s.buildCheckEventStatus(show)
+			matchedByEventID[*show.SourceEventID] = true
 		}
 	}
 
 	// Fallback: for events not found by source key, try venue + date match.
 	// This catches manually-created shows that don't have source_venue/source_event_id.
+	// Collect the matched fallback shows here (keyed by the input event ID) so
+	// their artist names can be batched into the single fetch below alongside
+	// the source-key matches — keeping CheckEvents at O(1) artist queries.
+	fallbackByEventID := make(map[string]catalogm.Show)
 	for _, e := range events {
-		if _, found := result.Events[e.ID]; found {
+		if matchedByEventID[e.ID] {
 			continue // Already matched by source key
 		}
 		if e.Date == "" || e.VenueSlug == "" {
@@ -818,20 +825,68 @@ func (s *DiscoveryService) CheckEvents(events []contracts.CheckEventInput) (*con
 			continue // No match found — that's fine
 		}
 
-		result.Events[e.ID] = s.buildCheckEventStatus(matchedShow)
+		fallbackByEventID[e.ID] = matchedShow
+	}
+
+	// Batch-fetch artist names for every matched show (source-key + fallback) in
+	// a single query, keyed by show ID. Avoids the per-show artist query that
+	// previously ran inside buildCheckEventStatus — the admin handler allows up
+	// to 200 events per call, so the per-show query was up to 200 round-trips.
+	showIDs := make([]uint, 0, len(shows)+len(fallbackByEventID))
+	for _, show := range shows {
+		showIDs = append(showIDs, show.ID)
+	}
+	for _, show := range fallbackByEventID {
+		showIDs = append(showIDs, show.ID)
+	}
+	artistsByShowID, err := s.fetchShowArtistsByIDs(showIDs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch show artists: %w", err)
+	}
+
+	for _, show := range shows {
+		if show.SourceEventID != nil {
+			result.Events[*show.SourceEventID] = buildCheckEventStatus(show, artistsByShowID[show.ID])
+		}
+	}
+	for eventID, show := range fallbackByEventID {
+		result.Events[eventID] = buildCheckEventStatus(show, artistsByShowID[show.ID])
 	}
 
 	return result, nil
 }
 
-// buildCheckEventStatus creates a CheckEventStatus from a Show model
-func (s *DiscoveryService) buildCheckEventStatus(show catalogm.Show) contracts.CheckEventStatus {
-	var artistNames []string
-	s.db.Raw(`SELECT artists.name FROM show_artists
-		JOIN artists ON show_artists.artist_id = artists.id
-		WHERE show_artists.show_id = ?
-		ORDER BY show_artists.position`, show.ID).Scan(&artistNames)
+// fetchShowArtistsByIDs returns artist names for the given show IDs in one
+// query, grouped by show ID and ordered by billing position. Returns an empty
+// map for an empty input so callers can index it unconditionally.
+func (s *DiscoveryService) fetchShowArtistsByIDs(showIDs []uint) (map[uint][]string, error) {
+	byShowID := make(map[uint][]string, len(showIDs))
+	if len(showIDs) == 0 {
+		return byShowID, nil
+	}
 
+	var rows []struct {
+		ShowID uint
+		Name   string
+	}
+	err := s.db.Raw(`SELECT show_artists.show_id, artists.name FROM show_artists
+		JOIN artists ON show_artists.artist_id = artists.id
+		WHERE show_artists.show_id IN (?)
+		ORDER BY show_artists.show_id, show_artists.position`, showIDs).Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+
+	for _, row := range rows {
+		byShowID[row.ShowID] = append(byShowID[row.ShowID], row.Name)
+	}
+	return byShowID, nil
+}
+
+// buildCheckEventStatus creates a CheckEventStatus from a Show model and its
+// pre-fetched artist names (see fetchShowArtistsByIDs — names must not be
+// queried per-show on the discovery hot path).
+func buildCheckEventStatus(show catalogm.Show, artistNames []string) contracts.CheckEventStatus {
 	return contracts.CheckEventStatus{
 		Exists: true,
 		ShowID: show.ID,

--- a/backend/internal/services/pipeline/discovery_test.go
+++ b/backend/internal/services/pipeline/discovery_test.go
@@ -2,6 +2,9 @@ package pipeline
 
 import (
 	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -839,4 +842,141 @@ func TestResolveHeadlinerName_NoArtists(t *testing.T) {
 	svc := &DiscoveryService{}
 	event := &contracts.DiscoveredEvent{}
 	assert.Equal(t, "", svc.resolveHeadlinerName(event))
+}
+
+// =============================================================================
+// CheckEvents artist-fetch batching (PSY-757)
+// =============================================================================
+
+// artistQueryCounter counts queries that touch show_artists on the suite DB.
+// CheckEvents fetches artist names via db.Raw(...).Scan(...). GORM's Scan path
+// runs through Rows(), which fires the "gorm:row" callback (NOT the query/raw
+// callbacks), so the counter hooks Row(). This lets the regression tests below
+// assert the artist fetch is O(1) — exactly one query — regardless of how many
+// events are checked.
+var artistQueryCounter atomic.Int64
+
+// registerArtistQueryCounterOnce attaches the counter callback to the shared
+// suite DB exactly once (GORM rejects duplicate callback names).
+var registerArtistQueryCounterOnce sync.Once
+
+func registerArtistQueryCounter(db *gorm.DB) {
+	registerArtistQueryCounterOnce.Do(func() {
+		_ = db.Callback().Row().After("gorm:row").Register("test:count_artist_query", func(tx *gorm.DB) {
+			if tx.Statement != nil && strings.Contains(tx.Statement.SQL.String(), "show_artists") {
+				artistQueryCounter.Add(1)
+			}
+		})
+	})
+}
+
+// TestCheckEvents_BatchesArtistFetch seeds N shows (each with M artists) that
+// all match by source key, then asserts CheckEvents issues exactly ONE Raw
+// query for artist names regardless of N — and that every event still gets its
+// correct, position-ordered artist list. Before PSY-757 this was one Raw query
+// per show (N), an N+1 on the discovery hot path.
+func (suite *DiscoveryIntegrationTestSuite) TestCheckEvents_BatchesArtistFetch() {
+	const numShows = 50
+	const artistsPerShow = 3
+
+	events := make([]contracts.DiscoveredEvent, 0, numShows)
+	expectedArtists := make(map[string][]string, numShows)
+	for i := 0; i < numShows; i++ {
+		eventID := fmt.Sprintf("evt-batch-%d", i)
+		artists := []string{
+			fmt.Sprintf("Headliner %d", i),
+			fmt.Sprintf("Support %d", i),
+			fmt.Sprintf("Opener %d", i),
+		}
+		suite.Require().Len(artists, artistsPerShow)
+		events = append(events, suite.makeEvent(
+			eventID,
+			fmt.Sprintf("Batch Show %d", i),
+			"valley-bar",
+			fmt.Sprintf("2026-12-%02d", (i%28)+1),
+			artists,
+		))
+		expectedArtists[eventID] = artists
+	}
+
+	_, err := suite.svc.ImportEvents(events, false, false, catalogm.ShowStatusApproved)
+	suite.Require().NoError(err)
+
+	checkInputs := make([]contracts.CheckEventInput, 0, numShows)
+	for _, e := range events {
+		checkInputs = append(checkInputs, contracts.CheckEventInput{ID: e.ID, VenueSlug: "valley-bar"})
+	}
+
+	registerArtistQueryCounter(suite.db)
+	artistQueryCounter.Store(0)
+
+	result, err := suite.svc.CheckEvents(checkInputs)
+	suite.Require().NoError(err)
+
+	// O(1) artist queries: exactly one fetch for all 50 shows' artists.
+	suite.Equal(int64(1), artistQueryCounter.Load(),
+		"CheckEvents must batch artist fetches into a single query regardless of event count")
+
+	// Correctness: every event resolves to its own position-ordered artist list.
+	suite.Require().Len(result.Events, numShows)
+	for eventID, want := range expectedArtists {
+		status, ok := result.Events[eventID]
+		suite.Require().True(ok, "event %s should be found", eventID)
+		suite.Require().NotNil(status.CurrentData)
+		suite.Equal(want, status.CurrentData.Artists, "artist names/order for %s", eventID)
+	}
+}
+
+// TestCheckEvents_BatchesArtistFetch_FallbackPath verifies the venue+date
+// fallback path (manually-created shows with no source key) also uses the
+// single batched artist fetch — one Raw query for all fallback matches.
+func (suite *DiscoveryIntegrationTestSuite) TestCheckEvents_BatchesArtistFetch_FallbackPath() {
+	const numShows = 10
+
+	// Seed shows via the normal import (gives them a source key + artists),
+	// then strip source_venue/source_event_id so CheckEvents can only match
+	// them through the venue+date fallback branch.
+	events := make([]contracts.DiscoveredEvent, 0, numShows)
+	expectedArtists := make(map[string][]string, numShows)
+	for i := 0; i < numShows; i++ {
+		eventID := fmt.Sprintf("evt-fallback-%d", i)
+		artists := []string{fmt.Sprintf("FB Headliner %d", i), fmt.Sprintf("FB Opener %d", i)}
+		date := fmt.Sprintf("2026-11-%02d", i+1)
+		events = append(events, suite.makeEvent(eventID, fmt.Sprintf("FB Show %d", i), "valley-bar", date, artists))
+		expectedArtists[date] = artists
+	}
+
+	_, err := suite.svc.ImportEvents(events, false, false, catalogm.ShowStatusApproved)
+	suite.Require().NoError(err)
+
+	// Remove the source key so only the date fallback can match.
+	suite.Require().NoError(
+		suite.db.Model(&catalogm.Show{}).
+			Where("source_event_id LIKE ?", "evt-fallback-%").
+			Updates(map[string]interface{}{"source_venue": nil, "source_event_id": nil}).Error,
+	)
+
+	checkInputs := make([]contracts.CheckEventInput, 0, numShows)
+	for date := range expectedArtists {
+		// Date-only input with no ID match forces the venue+date fallback.
+		checkInputs = append(checkInputs, contracts.CheckEventInput{ID: "no-source-" + date, VenueSlug: "valley-bar", Date: date})
+	}
+
+	registerArtistQueryCounter(suite.db)
+	artistQueryCounter.Store(0)
+
+	result, err := suite.svc.CheckEvents(checkInputs)
+	suite.Require().NoError(err)
+
+	// One query for all fallback-matched shows' artists.
+	suite.Equal(int64(1), artistQueryCounter.Load(),
+		"fallback path must batch artist fetches into a single query")
+
+	suite.Require().Len(result.Events, numShows)
+	for date, want := range expectedArtists {
+		status, ok := result.Events["no-source-"+date]
+		suite.Require().True(ok, "fallback event for %s should be found", date)
+		suite.Require().NotNil(status.CurrentData)
+		suite.Equal(want, status.CurrentData.Artists, "artist names/order for %s", date)
+	}
 }

--- a/backend/internal/services/pipeline/discovery_test.go
+++ b/backend/internal/services/pipeline/discovery_test.go
@@ -877,7 +877,6 @@ func registerArtistQueryCounter(db *gorm.DB) {
 // per show (N), an N+1 on the discovery hot path.
 func (suite *DiscoveryIntegrationTestSuite) TestCheckEvents_BatchesArtistFetch() {
 	const numShows = 50
-	const artistsPerShow = 3
 
 	events := make([]contracts.DiscoveredEvent, 0, numShows)
 	expectedArtists := make(map[string][]string, numShows)
@@ -888,7 +887,6 @@ func (suite *DiscoveryIntegrationTestSuite) TestCheckEvents_BatchesArtistFetch()
 			fmt.Sprintf("Support %d", i),
 			fmt.Sprintf("Opener %d", i),
 		}
-		suite.Require().Len(artists, artistsPerShow)
 		events = append(events, suite.makeEvent(
 			eventID,
 			fmt.Sprintf("Batch Show %d", i),

--- a/backend/internal/services/shared/user_resolver.go
+++ b/backend/internal/services/shared/user_resolver.go
@@ -133,3 +133,32 @@ func BatchResolveUserUsernames(db *gorm.DB, userIDs []uint) (map[uint]*string, e
 	}
 	return result, nil
 }
+
+// BatchResolveShowArtistNames returns the billing-ordered artist names for
+// multiple shows in a single query, grouped by show ID. Avoids the per-show
+// artist query that an N+1 caller would otherwise issue on a hot path.
+//
+// Returns an empty map (not nil) when showIDs is empty so callers can index
+// without nil-check guards. Shows with no artists are absent from the map.
+func BatchResolveShowArtistNames(db *gorm.DB, showIDs []uint) (map[uint][]string, error) {
+	byShowID := make(map[uint][]string, len(showIDs))
+	if len(showIDs) == 0 {
+		return byShowID, nil
+	}
+
+	var rows []struct {
+		ShowID uint
+		Name   string
+	}
+	if err := db.Raw(`SELECT show_artists.show_id, artists.name FROM show_artists
+		JOIN artists ON show_artists.artist_id = artists.id
+		WHERE show_artists.show_id IN (?)
+		ORDER BY show_artists.show_id, show_artists.position`, showIDs).Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+
+	for _, row := range rows {
+		byShowID[row.ShowID] = append(byShowID[row.ShowID], row.Name)
+	}
+	return byShowID, nil
+}

--- a/backend/internal/services/shared/user_resolver_test.go
+++ b/backend/internal/services/shared/user_resolver_test.go
@@ -109,3 +109,17 @@ func TestResolveUserUsername_ReturnsCopy(t *testing.T) {
 		assert.Equal(t, "ph_user", *got)
 	}
 }
+
+// =============================================================================
+// BatchResolveShowArtistNames
+// =============================================================================
+
+func TestBatchResolveShowArtistNames_EmptyInputReturnsEmptyMap(t *testing.T) {
+	// Empty input must short-circuit before touching the DB and return a
+	// non-nil map so callers can index without a nil guard. A nil *gorm.DB
+	// would panic if the early return were ever removed.
+	got, err := BatchResolveShowArtistNames(nil, nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, got)
+	assert.Empty(t, got)
+}


### PR DESCRIPTION
## Summary

`CheckEvents` (admin discovery hot path) batched the show lookup but `buildCheckEventStatus` issued **one artist-name query per matched show**. The admin handler allows up to 200 events per call, so a fully-matched batch fired up to 200 extra round-trips just for artist names — a clear N+1.

This fixes it:
- Both the source-key path and the venue+date fallback now collect their matched show IDs and share a **single** batched artist fetch keyed by show ID, so artist queries are O(1) regardless of event count.
- `buildCheckEventStatus` takes the pre-fetched names instead of querying per-show.
- The batch fetch lives in `shared.BatchResolveShowArtistNames`, next to the existing `BatchResolveUser*` helpers it mirrors (the canonical home for batch ID→value resolvers), so it's reusable beyond discovery.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/services/pipeline/...` — ok (full suite, incl. 2 new CheckEvents batching tests)
- [x] `go test ./internal/services/shared/...` — ok (incl. new empty-input unit test)
- [x] `go test ./...` — full backend suite green, no FAIL/panic
- [x] `/simplify` run before PR

## Manual repro

Backend-only, no migration → the perf/correctness tests ARE the repro:

- **`TestCheckEvents_BatchesArtistFetch`** — seeds 50 shows × 3 artists (all matched by source key), calls `CheckEvents` for all 50, and asserts the artist fetch fires **exactly 1 query** (`artistQueryCounter == 1`, via a `gorm:row` callback matching `show_artists`) plus that every event resolves to its correct, position-ordered artist list. Before this change the counter would be 50 (one query per show).
- **`TestCheckEvents_BatchesArtistFetch_FallbackPath`** — seeds 10 shows, strips their source keys so only the venue+date fallback can match, and asserts the same single-query bound + correct names for the fallback path.

Both pass; the existing `TestCheckEvents_Found / _NotFound / _EmptyInput` still pass unchanged.

## Simplify

`/simplify` promoted the batch fetch from a private `DiscoveryService.fetchShowArtistsByIDs` into `shared.BatchResolveShowArtistNames` (matching the established `BatchResolveUserNames(db, ids)` convention in `services/shared`), replaced an O(N×M) linear scan with an O(1) `matchedByEventID` map for the "already matched?" check, dropped a redundant per-iteration length assertion, and added a direct empty-input unit test for the new helper.

## Coverage gaps / follow-up

- `internal/services/catalog/charts_service.go` has two pre-existing inline copies of this batch-fetch pattern (one show-artists at ~L110, one release-artists at ~L343). They're out of scope here; the show-artists one can migrate to `shared.BatchResolveShowArtistNames`. Tracked in **PSY-777** rather than expanding this PR's surface.

Closes PSY-757
