### PR TITLE
PSY-728: sync PostHog opt-in via has_opted_in_capturing()

### DIFF
--- a/frontend/components/layout/PostHogProvider.test.tsx
+++ b/frontend/components/layout/PostHogProvider.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+import { PostHogProvider } from './PostHogProvider'
+
+// --- Mocks ---
+
+const mockInitPostHog = vi.fn()
+const mockOptInPostHog = vi.fn()
+const mockOptOutPostHog = vi.fn()
+const mockHasOptedInCapturing = vi.fn(() => false)
+const mockCapture = vi.fn()
+const mockIdentify = vi.fn()
+const mockReset = vi.fn()
+
+vi.mock('@/lib/posthog', () => ({
+  initPostHog: () => mockInitPostHog(),
+  optInPostHog: () => mockOptInPostHog(),
+  optOutPostHog: () => mockOptOutPostHog(),
+  posthog: {
+    has_opted_in_capturing: () => mockHasOptedInCapturing(),
+    capture: (...args: unknown[]) => mockCapture(...args),
+    identify: (...args: unknown[]) => mockIdentify(...args),
+    reset: () => mockReset(),
+  },
+}))
+
+const mockUseCookieConsent = vi.fn(() => ({
+  canUseAnalytics: false,
+  isLoaded: true,
+}))
+
+vi.mock('@/lib/context/CookieConsentContext', () => ({
+  useCookieConsent: () => mockUseCookieConsent(),
+}))
+
+const mockUseAuthContext = vi.fn(() => ({
+  user: null,
+  isAuthenticated: false,
+}))
+
+vi.mock('@/lib/context/AuthContext', () => ({
+  useAuthContext: () => mockUseAuthContext(),
+}))
+
+// Suspense + useSearchParams need a navigation mock.
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/',
+  useSearchParams: () => new URLSearchParams(),
+}))
+
+describe('PostHogProvider — consent sync', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockHasOptedInCapturing.mockReturnValue(false)
+    mockUseCookieConsent.mockReturnValue({ canUseAnalytics: false, isLoaded: true })
+    mockUseAuthContext.mockReturnValue({ user: null, isAuthenticated: false })
+  })
+
+  it('does nothing until consent context is loaded', () => {
+    mockUseCookieConsent.mockReturnValue({ canUseAnalytics: true, isLoaded: false })
+    render(<PostHogProvider>child</PostHogProvider>)
+
+    expect(mockOptInPostHog).not.toHaveBeenCalled()
+    expect(mockOptOutPostHog).not.toHaveBeenCalled()
+  })
+
+  it('opts in when consent is granted but PostHog is not yet opted in', () => {
+    mockHasOptedInCapturing.mockReturnValue(false)
+    mockUseCookieConsent.mockReturnValue({ canUseAnalytics: true, isLoaded: true })
+    render(<PostHogProvider>child</PostHogProvider>)
+
+    expect(mockOptInPostHog).toHaveBeenCalledTimes(1)
+    expect(mockOptOutPostHog).not.toHaveBeenCalled()
+  })
+
+  it('does NOT re-fire opt-in when PostHog is already opted in (aligned)', () => {
+    // Latent-bug regression guard: a fresh mount must not re-trigger opt-in
+    // when PostHog's persisted state already matches the granted consent.
+    mockHasOptedInCapturing.mockReturnValue(true)
+    mockUseCookieConsent.mockReturnValue({ canUseAnalytics: true, isLoaded: true })
+    render(<PostHogProvider>child</PostHogProvider>)
+
+    expect(mockOptInPostHog).not.toHaveBeenCalled()
+    expect(mockOptOutPostHog).not.toHaveBeenCalled()
+  })
+
+  it('opts out when consent is withdrawn but PostHog is still opted in', () => {
+    mockHasOptedInCapturing.mockReturnValue(true)
+    mockUseCookieConsent.mockReturnValue({ canUseAnalytics: false, isLoaded: true })
+    render(<PostHogProvider>child</PostHogProvider>)
+
+    expect(mockOptOutPostHog).toHaveBeenCalledTimes(1)
+    expect(mockOptInPostHog).not.toHaveBeenCalled()
+  })
+
+  it('does NOT re-fire opt-out when PostHog is already opted out (aligned)', () => {
+    mockHasOptedInCapturing.mockReturnValue(false)
+    mockUseCookieConsent.mockReturnValue({ canUseAnalytics: false, isLoaded: true })
+    render(<PostHogProvider>child</PostHogProvider>)
+
+    expect(mockOptInPostHog).not.toHaveBeenCalled()
+    expect(mockOptOutPostHog).not.toHaveBeenCalled()
+  })
+
+  it('still initializes PostHog on mount regardless of consent', () => {
+    render(<PostHogProvider>child</PostHogProvider>)
+    expect(mockInitPostHog).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/components/layout/PostHogProvider.tsx
+++ b/frontend/components/layout/PostHogProvider.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Suspense, useEffect, useRef } from 'react'
+import { Suspense, useEffect } from 'react'
 import { usePathname, useSearchParams } from 'next/navigation'
 import { useCookieConsent } from '@/lib/context/CookieConsentContext'
 import { useAuthContext } from '@/lib/context/AuthContext'
@@ -29,17 +29,18 @@ function PostHogPageView() {
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
   const { canUseAnalytics, isLoaded } = useCookieConsent()
   const { user, isAuthenticated } = useAuthContext()
-  const prevConsent = useRef<boolean | null>(null)
 
   // Initialize on mount (doesn't start tracking)
   useEffect(() => {
     initPostHog()
   }, [])
 
-  // Handle consent changes
+  // Sync PostHog's opt-in state to consent. Comparing against PostHog's own
+  // persisted state (rather than a per-mount ref) avoids re-firing opt-in +
+  // session recording on every page load when the user is already opted in.
   useEffect(() => {
-    if (!isLoaded || prevConsent.current === canUseAnalytics) return
-    prevConsent.current = canUseAnalytics
+    if (!isLoaded) return
+    if (canUseAnalytics === posthog.has_opted_in_capturing()) return
     canUseAnalytics ? optInPostHog() : optOutPostHog()
   }, [canUseAnalytics, isLoaded])
 


### PR DESCRIPTION
## Summary
- Replace `PostHogProvider`'s per-mount `prevConsent` ref (a shadow copy of external state) with a direct query to `posthog.has_opted_in_capturing()`.
- Fixes a latent bug: the ref reset to `null` on every fresh mount, so the consent effect re-fired `optInPostHog()` + `startSessionRecording()` on every page load even when the user was already opted in. Comparing against PostHog's persisted opt-in state skips that.
- Init effect (mount) and pageview effect are unchanged — both are PostHog-recommended App-Router patterns. Opt-in/out logic stays in `PostHogProvider`, not pushed into the vendor-agnostic `CookieConsent` handlers.
- `has_opted_in_capturing(): boolean` is confirmed present in the installed `posthog-js@1.336.4` type definitions.

## Test plan
- [x] `bun run typecheck` clean (`tsc --noEmit`, no errors)
- [x] `bun run test:run components/layout` — 120 passed (9 files), including 6 new `PostHogProvider.test.tsx` tests
- [x] New tests assert opt-in/out fire only when consent disagrees with `has_opted_in_capturing()`, and do NOT re-fire when already aligned (the regression guard for the latent bug)

## Manual repro
Exercised the cookie-consent flow against a live dispatch dev stack (`stack-up.sh --mode=shared`, resolved to isolated) via agent-browser on the real Next.js build:
- **Accept All** → PostHog `__ph_opt_in_out_` localStorage key flipped `"0"` → `"1"` (opt-in fired).
- **Reload while opted in** → key stayed `"1"`, banner not re-shown, page rendered with no console crash. This is the latent-bug path: the new code detects alignment and skips the redundant opt-in + `startSessionRecording()` that the old per-mount ref re-fired.
- **Reject All** (after clearing consent + reload) → key flipped back to `"0"` (opt-out fired).

Note: the dev stack has no `NEXT_PUBLIC_POSTHOG_KEY`, so PostHog runs uninitialized; the opt-in/out localStorage persistence (`__ph_opt_in_out_`) is still written by posthog-js and was the observable signal. Component-logic correctness is covered by the unit tests (posthog mocked, including `has_opted_in_capturing`). Stack torn down with `stack-down.sh`.

## Simplify
Ran the `/simplify` review (reuse / quality / efficiency lenses). Code was already clean — the change removes hand-rolled state-shadowing in favor of the vendor API, follows the existing posthog/context mocking conventions (`lib/posthog.test.ts`, `CookieConsentBanner.test.tsx`), carries only a WHY comment with no ticket refs, and reduces work on aligned reloads. No changes needed.

Closes PSY-728