### PR TITLE
PSY-731: sanitize MarkdownEditor preview with marked + DOMPurify

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -27,6 +27,7 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
         "d3-polygon": "^3.0.1",
+        "dompurify": "^3.4.5",
         "gray-matter": "^4.0.3",
         "lucide-react": "^0.554.0",
         "marked": "^18.0.2",
@@ -1214,7 +1215,7 @@
 
     "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
-    "dompurify": ["dompurify@3.3.1", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q=="],
+    "dompurify": ["dompurify@3.4.5", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA=="],
 
     "dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
 
@@ -2415,6 +2416,8 @@
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "posthog-js/dompurify": ["dompurify@3.3.1", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q=="],
 
     "posthog-js/fflate": ["fflate@0.4.8", "", {}, "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="],
 

--- a/frontend/features/collections/components/MarkdownEditor.test.tsx
+++ b/frontend/features/collections/components/MarkdownEditor.test.tsx
@@ -91,7 +91,7 @@ describe('MarkdownEditor', () => {
     const user = userEvent.setup()
     render(
       <MarkdownEditor
-        value="hi <script>alert('x')</script>"
+        value="hi <script>alert(1)</script>"
         onChange={vi.fn()}
       />
     )
@@ -100,6 +100,59 @@ describe('MarkdownEditor', () => {
     const preview = screen.getByTestId('markdown-editor-preview')
     expect(preview.querySelector('script')).toBeNull()
     expect(preview.innerHTML).not.toMatch(/<script\b/i)
+    // The harmless text content survives; only the executable tag is dropped.
+    expect(preview.textContent).toContain('hi')
+  })
+
+  it('strips <img onerror> payloads from the preview', async () => {
+    const user = userEvent.setup()
+    render(
+      <MarkdownEditor
+        value="<img src=x onerror=alert(1)>"
+        onChange={vi.fn()}
+      />
+    )
+
+    await user.click(screen.getByTestId('markdown-editor-preview-tab'))
+    const preview = screen.getByTestId('markdown-editor-preview')
+    // <img> is not in the allowlist, so the whole element is removed.
+    expect(preview.querySelector('img')).toBeNull()
+    expect(preview.innerHTML).not.toMatch(/onerror/i)
+  })
+
+  it('does not resurrect HTML-encoded <script> entities into live tags', async () => {
+    const user = userEvent.setup()
+    // NOTE: pass the entities via a JS expression, not a JSX string literal —
+    // JSX decodes `&lt;` → `<` at parse time, which would test a raw <script>
+    // tag instead of the encoded-entity case we care about here.
+    render(
+      <MarkdownEditor
+        value={'&lt;script&gt;alert(1)&lt;/script&gt;'}
+        onChange={vi.fn()}
+      />
+    )
+
+    await user.click(screen.getByTestId('markdown-editor-preview-tab'))
+    const preview = screen.getByTestId('markdown-editor-preview')
+    // Encoded entities must render as inert text, never as an executable tag:
+    // the markup stays escaped (`&lt;script&gt;`) and decodes only as text.
+    expect(preview.querySelector('script')).toBeNull()
+    expect(preview.innerHTML).not.toMatch(/<script\b/i)
+    expect(preview.textContent).toContain('<script>alert(1)</script>')
+  })
+
+  it('strips javascript: URLs from anchor hrefs in the preview', async () => {
+    const user = userEvent.setup()
+    render(
+      <MarkdownEditor
+        value={'<a href="javascript:alert(1)">x</a>'}
+        onChange={vi.fn()}
+      />
+    )
+
+    await user.click(screen.getByTestId('markdown-editor-preview-tab'))
+    const preview = screen.getByTestId('markdown-editor-preview')
+    expect(preview.innerHTML).not.toMatch(/javascript:/i)
   })
 
   it('strips on* event handlers from the preview', async () => {
@@ -114,6 +167,10 @@ describe('MarkdownEditor', () => {
     await user.click(screen.getByTestId('markdown-editor-preview-tab'))
     const preview = screen.getByTestId('markdown-editor-preview')
     expect(preview.innerHTML).not.toMatch(/onclick=/i)
+    // The anchor itself survives with its safe href intact.
+    expect(preview.querySelector('a')?.getAttribute('href')).toBe(
+      'https://example.com'
+    )
   })
 
   it('shows the empty-preview placeholder when value is blank', async () => {

--- a/frontend/features/collections/components/MarkdownEditor.tsx
+++ b/frontend/features/collections/components/MarkdownEditor.tsx
@@ -14,37 +14,64 @@
  *
  * Allowed primitives (per the comment-system policy): bold, italic, links,
  * blockquotes, lists, inline code/pre, h3+. The preview uses `marked` for
- * markdown → HTML conversion and additionally strips obviously-dangerous
- * fragments (script/style/iframe/event-handlers) defense-in-depth, since
+ * markdown → HTML conversion and `DOMPurify` to sanitize the result, since
  * the rendered preview is shown via `dangerouslySetInnerHTML` to the author.
+ * The allowlist below mirrors the server's bluemonday policy
+ * (`backend/internal/utils/markdown.go`) so the preview is a faithful
+ * approximation of what every other user will eventually see. The server
+ * remains the actual security boundary; this keeps the author-facing preview
+ * from rendering anything the server would strip.
  */
 
 import { useState, useMemo } from 'react'
 import { marked } from 'marked'
+import DOMPurify from 'dompurify'
 import { Eye, Pencil } from 'lucide-react'
 import { Textarea } from '@/components/ui/textarea'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 
 /**
- * Strips a small set of unsafe constructs from preview HTML. The author is
- * the only viewer — but defense-in-depth against accidentally pasting an
- * unsafe snippet is cheap. The server's bluemonday policy is the actual
- * security boundary; this is a hygiene pass for the preview pane only.
+ * Tags the preview is allowed to render. Mirrors the bluemonday allowlist in
+ * `backend/internal/utils/markdown.go` (the comments/field-notes policy):
+ * paragraphs, line breaks, bold/italic, code/pre, lists, blockquote, h3–h6,
+ * and anchors. Anything outside this set (script, style, iframe, img, etc.)
+ * is dropped by DOMPurify.
  */
-function stripUnsafe(html: string): string {
-  return html
-    .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
-    .replace(/<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi, '')
-    .replace(/<iframe\b[^>]*>[\s\S]*?<\/iframe>/gi, '')
-    .replace(/<iframe\b[^>]*\/?>/gi, '')
-    // Strip on* event handlers from any tag.
-    .replace(/\s+on[a-z]+\s*=\s*"[^"]*"/gi, '')
-    .replace(/\s+on[a-z]+\s*=\s*'[^']*'/gi, '')
-    .replace(/\s+on[a-z]+\s*=\s*[^\s>]+/gi, '')
-    // Strip javascript: URLs from href/src.
-    .replace(/(href|src)\s*=\s*"javascript:[^"]*"/gi, '$1="#"')
-    .replace(/(href|src)\s*=\s*'javascript:[^']*'/gi, "$1='#'")
+const PREVIEW_ALLOWED_TAGS = [
+  'p',
+  'br',
+  'strong',
+  'b',
+  'em',
+  'i',
+  'code',
+  'pre',
+  'ul',
+  'ol',
+  'li',
+  'blockquote',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'a',
+]
+
+/** Only `href` survives on anchors; everything else (e.g. on* handlers) is dropped. */
+const PREVIEW_ALLOWED_ATTRS = ['href']
+
+/**
+ * Sanitizes marked-rendered HTML for the preview pane. Returns "" in
+ * non-browser environments (SSR) since DOMPurify needs a DOM; the preview is
+ * a client-only, interaction-gated surface so this never affects first paint.
+ */
+function sanitizePreview(html: string): string {
+  if (typeof window === 'undefined') return ''
+  return DOMPurify.sanitize(html, {
+    ALLOWED_TAGS: PREVIEW_ALLOWED_TAGS,
+    ALLOWED_ATTR: PREVIEW_ALLOWED_ATTRS,
+  })
 }
 
 export interface MarkdownEditorProps {
@@ -94,7 +121,7 @@ export function MarkdownEditor({
       gfm: true,
       breaks: false,
     }) as unknown as string
-    return stripUnsafe(rendered)
+    return sanitizePreview(rendered)
   }, [value])
 
   return (

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,6 +42,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "d3-polygon": "^3.0.1",
+    "dompurify": "^3.4.5",
     "gray-matter": "^4.0.3",
     "lucide-react": "^0.554.0",
     "marked": "^18.0.2",


### PR DESCRIPTION
## Summary
- Replace the hand-rolled regex HTML stripping in the collection `MarkdownEditor` preview pane with `DOMPurify`, configured to an allowlist that mirrors the server's bluemonday policy (`backend/internal/utils/markdown.go` — the comments/field-notes tag set). The regex pass was brittle against common XSS shapes (encoded entities, attribute-less tags, nested constructs); DOMPurify parses the DOM and drops anything outside the allowed tag/attr set.
- `marked` (already a dependency) still does markdown → HTML; DOMPurify now sanitizes the result before it hits `dangerouslySetInnerHTML`. No server round-trip.
- Added `dompurify@3.4.5`. v3 bundles its own TypeScript types, so **no `@types/dompurify`** is needed.
- SSR guard: `sanitizePreview` returns `""` when `window` is undefined (the preview is a `'use client'`, interaction-gated surface, so this never affects first paint).

## Bundle-size delta
Adding `dompurify@3.4.5` (only client-side dependency added; `marked` was already present):

| Build (shipped form) | Raw | Gzipped |
| --- | --- | --- |
| `purify.min.js` (minified UMD — realistic shipped-size proxy) | 26.1 KB | ~9.7 KB |
| `purify.es.mjs` (ESM, unminified — what the bundler ingests, then minifies) | 75.6 KB | ~20.6 KB |

Net client bundle cost is **~9.7 KB gzipped** once minified. This is the standard, well-audited (Cure53) sanitizer; the alternative (regex stripping) carried correctness risk for ~0 KB, which the ticket explicitly traded away.

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun run test:run features/collections` — 283/283 pass (17 in `MarkdownEditor.test.tsx`)
- [x] Extended `MarkdownEditor.test.tsx` with representative XSS payloads: `<script>alert(1)</script>`, `<img src=x onerror=alert(1)>`, HTML-encoded entities (`&lt;script&gt;`), `javascript:` URLs, and `on*` handlers — plus an assertion that safe formatting (`<strong>`, `<em>`, anchor `href`) survives.

## Manual repro
Ran the per-worktree dev stack (`scripts/dispatch/stack-up.sh ... --mode=shared`), logged in as the seeded test user, opened the Create Collection form, and typed into the Description editor:

```
**bold** and *italic* and [a link](https://example.com)

<script>alert("XSS-SCRIPT-PSY731")</script>
<img src=x onerror="alert(...)">
```

Switched to the **Preview** tab and inspected the rendered DOM (alert hook installed beforehand). Result:

- `alerts_fired: []` — no script executed
- `<script>` tag stripped (`has_script_tag: false`)
- `<img onerror>` element stripped entirely (`has_img_tag: false`, `has_onerror_in_html: false`)
- Formatting intact: `<strong>`, `<em>`, anchor `href="https://example.com"` all present

![preview pane renders only safe formatted HTML; script/img/onerror payloads stripped](https://github.com/mtrifilo/psychic-homily-web/releases/download/untagged-7fdb78c953277867504a/preview-sanitized.png)

Stack torn down after; worktree clean.

## Simplify
Ran the `/simplify` review (3 lenses, inline — Agent tool unavailable per harness constraints):
- **Reuse**: DOMPurify is net-new with a single caller (`MarkdownEditor`); `MarkdownContent` renders pre-sanitized server HTML, not raw markdown, so there's no client-side preview duplication to fold into a shared util. Kept `sanitizePreview` local (YAGNI).
- **Quality**: comments explain WHY (security boundary, SSR-guard rationale), allowlist is a module-level constant, no added ticket refs in source comments.
- **Efficiency**: sanitize runs inside the existing `useMemo` keyed on `value`; allowlist arrays are module-level (not re-created per render).

No issues required fixing.

Closes PSY-731