### PR TITLE
PSY-735: cancel ShowForm AI-extraction rAF on unmount

### DIFF
--- a/frontend/components/forms/ShowForm.test.tsx
+++ b/frontend/components/forms/ShowForm.test.tsx
@@ -1,7 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { renderWithProviders } from '@/test/utils'
+import type { ExtractedShowData } from '@/lib/types/extraction'
 
 // Regression guard for the artists list React-key contract: when keyed on
 // array index, removing a middle row caused React to reuse DOM/component
@@ -97,5 +98,92 @@ describe('ShowForm — artists list stable keys', () => {
     // "Artist C" but its internal state (aria-expanded) would belong to the
     // removed empty row, surfacing as aria-expanded="false".
     expect(remaining[1]).toHaveAttribute('aria-expanded', 'true')
+  })
+})
+
+// Regression guard for the AI-extraction effect's requestAnimationFrame
+// cleanup. The effect defers form.setFieldValue calls to the next animation
+// frame to batch state updates. Without cancelAnimationFrame in the cleanup,
+// unmounting the form between the schedule and the callback let setFieldValue
+// run against an unmounted form — producing a React dev warning (and a
+// double-schedule under StrictMode). These tests drive that exact ordering by
+// controlling rAF deterministically: capture the scheduled callback, unmount,
+// then assert the frame was cancelled and that running the stale callback
+// afterward neither warns nor writes extracted values into the DOM.
+describe('ShowForm — AI extraction rAF cleanup', () => {
+  const extraction: ExtractedShowData = {
+    artists: [{ name: 'Extracted Artist', is_headliner: true }],
+    venue: { name: 'Extracted Venue', city: 'Phoenix', state: 'AZ' },
+    date: '2099-12-31',
+    time: '20:00',
+    cost: '$10',
+    ages: '21+',
+    description: 'from the flyer',
+  }
+
+  let rafCallbacks: Map<number, FrameRequestCallback>
+  let cancelled: number[]
+  let nextRafId: number
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    rafCallbacks = new Map()
+    cancelled = []
+    nextRafId = 0
+
+    // Capture rAF callbacks instead of running them, so the test controls
+    // whether the deferred setFieldValue work happens before or after unmount.
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => {
+      const id = ++nextRafId
+      rafCallbacks.set(id, cb)
+      return id
+    })
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(id => {
+      cancelled.push(id)
+      rafCallbacks.delete(id)
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('cancels the pending extraction frame on unmount before it fires', () => {
+    const { unmount } = renderWithProviders(
+      <ShowForm mode="create" initialExtraction={extraction} />
+    )
+
+    // The effect scheduled exactly one frame and has not run it yet.
+    expect(rafCallbacks.size).toBe(1)
+    const [scheduledId] = [...rafCallbacks.keys()]
+
+    // Unmount before the frame fires — the cleanup must cancel it.
+    unmount()
+
+    expect(cancelled).toContain(scheduledId)
+    expect(rafCallbacks.has(scheduledId)).toBe(false)
+  })
+
+  it('does not warn or write extracted values when a stale frame runs after unmount', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const { unmount } = renderWithProviders(
+      <ShowForm mode="create" initialExtraction={extraction} />
+    )
+    const staleCallback = [...rafCallbacks.values()][0]
+
+    unmount()
+
+    // Force the captured frame to run post-unmount, simulating a frame the
+    // browser had already queued slipping through. This proves the deferred
+    // setFieldValue work cannot warn even if a frame leaks past the cleanup.
+    act(() => {
+      staleCallback(performance.now())
+    })
+
+    expect(errorSpy).not.toHaveBeenCalled()
+    // Nothing extracted should be rendered after unmount.
+    expect(screen.queryByDisplayValue('Extracted Artist')).toBeNull()
+    expect(screen.queryByDisplayValue('Extracted Venue')).toBeNull()
   })
 })

--- a/frontend/components/forms/ShowForm.tsx
+++ b/frontend/components/forms/ShowForm.tsx
@@ -306,7 +306,7 @@ export function ShowForm({
     lastAppliedExtraction.current = initialExtraction
 
     // Use requestAnimationFrame to batch state updates and avoid cascading renders
-    requestAnimationFrame(() => {
+    const rafId = requestAnimationFrame(() => {
       // Set artists
       if (initialExtraction.artists.length > 0) {
         form.setFieldValue(
@@ -373,6 +373,11 @@ export function ShowForm({
         form.setFieldValue('description', initialExtraction.description)
       }
     })
+
+    // Cancel the pending frame if the component unmounts (or the effect
+    // re-runs) before it fires, so setFieldValue never touches an unmounted
+    // form — avoids a dev warning and a StrictMode double-schedule.
+    return () => cancelAnimationFrame(rafId)
   }, [initialExtraction, form])
 
   // Handle venue selection to auto-fill city/state and track selected venue


### PR DESCRIPTION
## Summary
- `ShowForm`'s AI-extraction `useEffect` deferred `form.setFieldValue` calls to `requestAnimationFrame` to batch state updates, but never cancelled the frame. If the form unmounted (or the effect re-ran) between schedule and callback, `setFieldValue` ran against an unmounted form — a React dev warning, plus a double-schedule under StrictMode.
- Fix: capture the rAF handle and `cancelAnimationFrame(rafId)` in the effect cleanup. The existing `lastAppliedExtraction.current` dedup guard is preserved.
- Extended `ShowForm.test.tsx` (the file added in PSY-724) with a regression guard.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run test:run components/forms` — 10 files / 109 tests pass
- [x] Regression test, controlling rAF deterministically:
  - asserts the pending frame is cancelled on unmount before it fires (this case **fails** without the fix: `cancelAnimationFrame` never called)
  - asserts a stale frame running post-unmount neither warns (`console.error`) nor writes extracted values into the DOM
  - Note: the no-warning assertion passes on React 19 either way (React 19 dropped the legacy unmount-setState warning), so the *cancel-on-unmount* assertion is the fix-discriminating guard; the no-warning case is a complementary safety check.

## Manual repro
Render-only carveout. An unmount landing between the rAF schedule and its callback is not reliably reproducible by hand in a browser. The regression test (mount with `initialExtraction` → frame scheduled → unmount before it fires → assert cancellation + no post-unmount `setFieldValue`/warning) IS the verification, and it was confirmed to fail against the pre-fix code and pass with the fix.

## Simplify
Ran the 3-lens review manually (Agent/Task tool unavailable in this dispatched context). Findings: the diff was largely clean (reuses `renderWithProviders` + the typed `ExtractedShowData`; WHY-only comments with no ticket refs; minimal local `rafId` handle). One fix applied: removed a redundant per-test `mockImplementationOnce` rAF override (identical to the `beforeEach` mock) and the awkward double-cast it required. Re-ran typecheck + tests green after the edit.

Closes PSY-735