### PR TITLE
PSY-710: cover instrumentation*.ts Sentry init configuration

### DIFF
--- a/frontend/instrumentation-client.test.ts
+++ b/frontend/instrumentation-client.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import * as Sentry from '@sentry/nextjs'
 
 // Sentry.init + replayIntegration both run at module-load time, so the
@@ -9,17 +9,71 @@ vi.mock('@sentry/nextjs', () => ({
   captureRouterTransitionStart: vi.fn(),
 }))
 
+// Re-import fresh per test so the module's top-level Sentry.init re-runs
+// against the current (stubbed) NODE_ENV.
+async function loadInstrumentationClient() {
+  vi.resetModules()
+  return import('./instrumentation-client')
+}
+
 describe('instrumentation-client.ts', () => {
-  // A single test because the module's Sentry.init / replayIntegration calls
-  // are one-time module-load side effects; the global afterEach clears mock
-  // call records, so a second `it` would see zero recorded calls.
-  it('loads and masks all text + blocks all media in session replay (privacy posture)', async () => {
-    await import('./instrumentation-client')
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('initializes Sentry once with the DSN and environment from env vars', async () => {
+    vi.stubEnv('NEXT_PUBLIC_SENTRY_DSN', 'https://example@o0.ingest.sentry.io/0')
+    vi.stubEnv('NODE_ENV', 'production')
+
+    await loadInstrumentationClient()
 
     expect(Sentry.init).toHaveBeenCalledTimes(1)
+    const config = vi.mocked(Sentry.init).mock.calls[0][0]
+    expect(config).toMatchObject({
+      dsn: 'https://example@o0.ingest.sentry.io/0',
+      environment: 'production',
+      debug: false,
+    })
+  })
+
+  it('masks all text + blocks all media in session replay (privacy posture)', async () => {
+    await loadInstrumentationClient()
+
     expect(Sentry.replayIntegration).toHaveBeenCalledWith({
       maskAllText: true,
       blockAllMedia: true,
     })
+  })
+
+  it('disables tracing and replay sampling in development', async () => {
+    vi.stubEnv('NODE_ENV', 'development')
+
+    await loadInstrumentationClient()
+
+    const config = vi.mocked(Sentry.init).mock.calls[0][0]
+    expect(config).toMatchObject({
+      tracesSampleRate: 0,
+      replaysSessionSampleRate: 0,
+      replaysOnErrorSampleRate: 0,
+    })
+  })
+
+  it('uses production sample rates in production', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+
+    await loadInstrumentationClient()
+
+    const config = vi.mocked(Sentry.init).mock.calls[0][0]
+    expect(config).toMatchObject({
+      tracesSampleRate: 0.1,
+      replaysSessionSampleRate: 0.1,
+      replaysOnErrorSampleRate: 1.0,
+    })
+  })
+
+  it('exports onRouterTransitionStart bound to Sentry.captureRouterTransitionStart', async () => {
+    const mod = await loadInstrumentationClient()
+
+    expect(mod.onRouterTransitionStart).toBe(Sentry.captureRouterTransitionStart)
   })
 })

--- a/frontend/instrumentation.test.ts
+++ b/frontend/instrumentation.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from 'vitest'
+import * as Sentry from '@sentry/nextjs'
+
+// instrumentation.ts binds onRequestError = Sentry.captureRequestError at
+// module-load time, so the mock must be in place before the import below.
+vi.mock('@sentry/nextjs', () => ({
+  captureRequestError: vi.fn(),
+}))
+
+describe('instrumentation.ts', () => {
+  it('exports a callable register function', async () => {
+    const mod = await import('./instrumentation')
+
+    expect(typeof mod.register).toBe('function')
+  })
+
+  it('register resolves without throwing when no runtime is set', async () => {
+    const mod = await import('./instrumentation')
+
+    // NEXT_RUNTIME is unset in the test environment, so register should take
+    // neither the nodejs nor edge branch and resolve without importing a
+    // server/edge Sentry config.
+    await expect(mod.register()).resolves.toBeUndefined()
+  })
+
+  it('exports onRequestError bound to Sentry.captureRequestError', async () => {
+    const mod = await import('./instrumentation')
+
+    expect(mod.onRequestError).toBe(Sentry.captureRequestError)
+  })
+})


### PR DESCRIPTION
## Summary
- Extends `frontend/instrumentation-client.test.ts` to assert the full `Sentry.init` config: `dsn`, `environment`, `debug`, plus the dev-vs-prod sample-rate branches (`tracesSampleRate`, `replaysSessionSampleRate`, `replaysOnErrorSampleRate`) and that `onRouterTransitionStart` is bound to `Sentry.captureRouterTransitionStart`. Per-env cases re-import the module under a stubbed `NODE_ENV` so its top-level init re-evaluates. The PSY-734 replay privacy assertion (`maskAllText`/`blockAllMedia`) is preserved.
- Adds `frontend/instrumentation.test.ts`: `register` is a callable function that resolves without throwing when no `NEXT_RUNTIME` is set, and `onRequestError` is bound to `Sentry.captureRequestError`.
- Test-only diff; no production code changed.

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run test:run instrumentation` passes (8 tests: 5 client + 3 server)
- [x] Mutation check: flipping the prod sample rate to `0` fails the prod-branch test, confirming it exercises the production branch rather than the ambient `test` env

Closes PSY-710

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Manual repro
Test-only diff; no runtime behavior change. `bun run test:run instrumentation` (8/8) is the verification — mocked `@sentry/nextjs`, no dev stack applicable.

## Simplify
Manual three-lens review (parallel-reviewer Agent tool unavailable in dispatched context). Trimmed one over-narrating comment. No reuse/efficiency findings.
