### PR TITLE
PSY-705: page-level SEO metadata tests for slug pages

### DIFF
--- a/frontend/app/artists/[slug]/page.test.tsx
+++ b/frontend/app/artists/[slug]/page.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { okResponse, errorResponse } from '@/lib/seo/test-helpers'
 
 vi.mock('next/navigation', () => ({
   notFound: vi.fn(),
@@ -26,14 +27,6 @@ function buildArtist(overrides: Record<string, unknown> = {}) {
     social: {},
     ...overrides,
   }
-}
-
-function okResponse(body: unknown): Response {
-  return { ok: true, status: 200, json: async () => body } as unknown as Response
-}
-
-function errorResponse(status: number): Response {
-  return { ok: false, status, json: async () => ({}) } as unknown as Response
 }
 
 const fetchMock = vi.fn()

--- a/frontend/app/artists/[slug]/page.test.tsx
+++ b/frontend/app/artists/[slug]/page.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('next/navigation', () => ({
+  notFound: vi.fn(),
+}))
+
+vi.mock('@sentry/nextjs', () => ({
+  captureMessage: vi.fn(),
+  captureException: vi.fn(),
+}))
+
+// Stub the heavy artists feature module so invoking generateMetadata doesn't
+// pull in the real ArtistDetail render path.
+vi.mock('@/features/artists', () => ({
+  ArtistDetail: () => null,
+}))
+
+import { generateMetadata } from './page'
+
+function buildArtist(overrides: Record<string, unknown> = {}) {
+  return {
+    name: 'Headliner Band',
+    slug: 'headliner-band',
+    city: 'Phoenix',
+    state: 'AZ',
+    social: {},
+    ...overrides,
+  }
+}
+
+function okResponse(body: unknown): Response {
+  return { ok: true, status: 200, json: async () => body } as unknown as Response
+}
+
+function errorResponse(status: number): Response {
+  return { ok: false, status, json: async () => ({}) } as unknown as Response
+}
+
+const fetchMock = vi.fn()
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('artists/[slug] generateMetadata', () => {
+  it('uses the artist name as the title when the artist is found', async () => {
+    fetchMock.mockResolvedValueOnce(okResponse(buildArtist()))
+
+    const meta = await generateMetadata({ params: Promise.resolve({ slug: 'headliner-band' }) })
+
+    expect(meta.title).toBe('Headliner Band')
+  })
+
+  it('builds the description from the artist name', async () => {
+    fetchMock.mockResolvedValueOnce(okResponse(buildArtist()))
+
+    const meta = await generateMetadata({ params: Promise.resolve({ slug: 'headliner-band' }) })
+
+    expect(meta.description).toBe(
+      'Headliner Band - upcoming shows and artist details on Psychic Homily'
+    )
+  })
+
+  it('sets the canonical URL to https://psychichomily.com/artists/{slug}', async () => {
+    fetchMock.mockResolvedValueOnce(okResponse(buildArtist()))
+
+    const meta = await generateMetadata({ params: Promise.resolve({ slug: 'headliner-band' }) })
+
+    expect(meta.alternates?.canonical).toBe(
+      'https://psychichomily.com/artists/headliner-band'
+    )
+  })
+
+  it('sets openGraph title/description/url/type', async () => {
+    fetchMock.mockResolvedValueOnce(okResponse(buildArtist()))
+
+    const meta = await generateMetadata({ params: Promise.resolve({ slug: 'headliner-band' }) })
+
+    expect(meta.openGraph?.title).toBe('Headliner Band')
+    expect(meta.openGraph?.description).toBe('View upcoming shows featuring Headliner Band')
+    expect(meta.openGraph?.url).toBe('/artists/headliner-band')
+    expect((meta.openGraph as { type?: string })?.type).toBe('website')
+  })
+
+  it('falls back to the "Artist" title when the artist is missing', async () => {
+    fetchMock.mockResolvedValueOnce(errorResponse(404))
+
+    const meta = await generateMetadata({ params: Promise.resolve({ slug: 'missing' }) })
+
+    expect(meta.title).toBe('Artist')
+    expect(meta.description).toBe('View artist details and upcoming shows')
+    // No canonical alternate on the fallback shape.
+    expect(meta.alternates).toBeUndefined()
+    expect(meta.openGraph).toBeUndefined()
+  })
+})

--- a/frontend/app/blog/[slug]/page.test.tsx
+++ b/frontend/app/blog/[slug]/page.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { BlogPost } from '@/features/blog'
+
+vi.mock('next/navigation', () => ({
+  notFound: vi.fn(),
+}))
+
+// The blog page sources posts synchronously from the filesystem-backed blog
+// feature (not fetch). Mock the feature so generateMetadata reads a controlled
+// post payload and the heavy MDX render path is stubbed out.
+const getBlogPostMock = vi.fn()
+
+vi.mock('@/features/blog', () => ({
+  getBlogPost: (slug: string) => getBlogPostMock(slug),
+  getBlogSlugs: vi.fn(() => []),
+  MDXContent: () => null,
+}))
+
+import { generateMetadata } from './page'
+
+function buildPost(overrides: Partial<BlogPost> = {}): BlogPost {
+  return {
+    slug: '2026-01-15-test-post',
+    frontmatter: {
+      title: 'Test Post',
+      date: '2026-01-15',
+      description: 'A test post description',
+      categories: ['Technology'],
+    },
+    content: '# Hello World',
+    excerpt: 'An auto-generated excerpt.',
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('blog/[slug] generateMetadata', () => {
+  it('uses the frontmatter title as the title when the post is found', async () => {
+    getBlogPostMock.mockReturnValueOnce(buildPost())
+
+    const meta = await generateMetadata({ params: Promise.resolve({ slug: '2026-01-15-test-post' }) })
+
+    expect(meta.title).toBe('Test Post')
+  })
+
+  it('uses the frontmatter description when present', async () => {
+    getBlogPostMock.mockReturnValueOnce(buildPost())
+
+    const meta = await generateMetadata({ params: Promise.resolve({ slug: '2026-01-15-test-post' }) })
+
+    expect(meta.description).toBe('A test post description')
+  })
+
+  it('falls back to the excerpt when frontmatter has no description', async () => {
+    getBlogPostMock.mockReturnValueOnce(
+      buildPost({
+        frontmatter: { title: 'No Description Post', date: '2026-01-15' },
+        excerpt: 'An auto-generated excerpt.',
+      })
+    )
+
+    const meta = await generateMetadata({ params: Promise.resolve({ slug: '2026-01-15-test-post' }) })
+
+    expect(meta.description).toBe('An auto-generated excerpt.')
+  })
+
+  it('sets the canonical URL to https://psychichomily.com/blog/{slug}', async () => {
+    getBlogPostMock.mockReturnValueOnce(buildPost())
+
+    const meta = await generateMetadata({ params: Promise.resolve({ slug: '2026-01-15-test-post' }) })
+
+    expect(meta.alternates?.canonical).toBe(
+      'https://psychichomily.com/blog/2026-01-15-test-post'
+    )
+  })
+
+  it('sets openGraph title/description/url and the article type with publishedTime', async () => {
+    getBlogPostMock.mockReturnValueOnce(buildPost())
+
+    const meta = await generateMetadata({ params: Promise.resolve({ slug: '2026-01-15-test-post' }) })
+
+    expect(meta.openGraph?.title).toBe('Test Post')
+    expect(meta.openGraph?.description).toBe('A test post description')
+    expect(meta.openGraph?.url).toBe('/blog/2026-01-15-test-post')
+    // Blog posts use the OpenGraph "article" type (not "website").
+    expect((meta.openGraph as { type?: string })?.type).toBe('article')
+    expect((meta.openGraph as { publishedTime?: string })?.publishedTime).toBe('2026-01-15')
+  })
+
+  it('falls back to the "Post Not Found" title when the post is missing', async () => {
+    getBlogPostMock.mockReturnValueOnce(null)
+
+    const meta = await generateMetadata({ params: Promise.resolve({ slug: 'missing' }) })
+
+    expect(meta.title).toBe('Post Not Found')
+    // No canonical alternate or openGraph on the fallback shape.
+    expect(meta.alternates).toBeUndefined()
+    expect(meta.openGraph).toBeUndefined()
+  })
+})

--- a/frontend/app/collections/[slug]/page.test.tsx
+++ b/frontend/app/collections/[slug]/page.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { okResponse, errorResponse } from '@/lib/seo/test-helpers'
 
 vi.mock('next/navigation', () => ({
   notFound: vi.fn(),
@@ -34,14 +35,6 @@ function buildCollection(overrides: Record<string, unknown> = {}) {
     creator_name: 'matt',
     ...overrides,
   }
-}
-
-function okResponse(body: unknown): Response {
-  return { ok: true, status: 200, json: async () => body } as unknown as Response
-}
-
-function errorResponse(status: number): Response {
-  return { ok: false, status, json: async () => ({}) } as unknown as Response
 }
 
 const fetchMock = vi.fn()

--- a/frontend/app/collections/[slug]/page.test.tsx
+++ b/frontend/app/collections/[slug]/page.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('next/navigation', () => ({
+  notFound: vi.fn(),
+}))
+
+// generateMetadata calls getCollection, which reads the auth cookie (PSY-551
+// cookie-forward). Return an empty cookie store so the anonymous (ISR) fetch
+// path is exercised.
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(async () => ({
+    get: vi.fn(() => undefined),
+  })),
+}))
+
+vi.mock('@sentry/nextjs', () => ({
+  captureMessage: vi.fn(),
+  captureException: vi.fn(),
+}))
+
+// Stub the heavy collections feature module so invoking generateMetadata
+// doesn't pull in the real CollectionDetail render path.
+vi.mock('@/features/collections/components', () => ({
+  CollectionDetail: () => null,
+}))
+
+import { generateMetadata } from './page'
+
+function buildCollection(overrides: Record<string, unknown> = {}) {
+  return {
+    title: 'Best Phoenix Shows',
+    slug: 'best-phoenix-shows',
+    description: 'A hand-picked list of must-see shows.',
+    creator_name: 'matt',
+    ...overrides,
+  }
+}
+
+function okResponse(body: unknown): Response {
+  return { ok: true, status: 200, json: async () => body } as unknown as Response
+}
+
+function errorResponse(status: number): Response {
+  return { ok: false, status, json: async () => ({}) } as unknown as Response
+}
+
+const fetchMock = vi.fn()
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('collections/[slug] generateMetadata', () => {
+  it('uses the collection title as the title when the collection is found', async () => {
+    fetchMock.mockResolvedValueOnce(okResponse(buildCollection()))
+
+    const meta = await generateMetadata({ params: Promise.resolve({ slug: 'best-phoenix-shows' }) })
+
+    expect(meta.title).toBe('Best Phoenix Shows')
+  })
+
+  it('uses the description when present', async () => {
+    fetchMock.mockResolvedValueOnce(okResponse(buildCollection()))
+
+    const meta = await generateMetadata({ params: Promise.resolve({ slug: 'best-phoenix-shows' }) })
+
+    expect(meta.description).toBe('A hand-picked list of must-see shows.')
+  })
+
+  it('truncates a long description at 160 chars (no ellipsis)', async () => {
+    const longDescription = 'z'.repeat(300)
+    fetchMock.mockResolvedValueOnce(okResponse(buildCollection({ description: longDescription })))
+
+    const meta = await generateMetadata({ params: Promise.resolve({ slug: 'best-phoenix-shows' }) })
+
+    expect(meta.description).toBe('z'.repeat(160))
+    expect(meta.description).toHaveLength(160)
+  })
+
+  it('generates a description from the title when none is provided', async () => {
+    fetchMock.mockResolvedValueOnce(okResponse(buildCollection({ description: undefined })))
+
+    const meta = await generateMetadata({ params: Promise.resolve({ slug: 'best-phoenix-shows' }) })
+
+    expect(meta.description).toBe('Best Phoenix Shows - a curated collection on Psychic Homily')
+  })
+
+  it('sets the canonical URL to https://psychichomily.com/collections/{slug}', async () => {
+    fetchMock.mockResolvedValueOnce(okResponse(buildCollection()))
+
+    const meta = await generateMetadata({ params: Promise.resolve({ slug: 'best-phoenix-shows' }) })
+
+    expect(meta.alternates?.canonical).toBe(
+      'https://psychichomily.com/collections/best-phoenix-shows'
+    )
+  })
+
+  it('sets openGraph title/description/url/type', async () => {
+    fetchMock.mockResolvedValueOnce(okResponse(buildCollection()))
+
+    const meta = await generateMetadata({ params: Promise.resolve({ slug: 'best-phoenix-shows' }) })
+
+    expect(meta.openGraph?.title).toBe('Best Phoenix Shows')
+    expect(meta.openGraph?.description).toBe('A hand-picked list of must-see shows.')
+    expect(meta.openGraph?.url).toBe('/collections/best-phoenix-shows')
+    expect((meta.openGraph as { type?: string })?.type).toBe('website')
+  })
+
+  it('falls back to the "Collection" title when the collection is missing', async () => {
+    fetchMock.mockResolvedValueOnce(errorResponse(404))
+
+    const meta = await generateMetadata({ params: Promise.resolve({ slug: 'missing' }) })
+
+    expect(meta.title).toBe('Collection')
+    expect(meta.description).toBe('View collection details')
+    // No canonical alternate on the fallback shape.
+    expect(meta.alternates).toBeUndefined()
+    expect(meta.openGraph).toBeUndefined()
+  })
+})

--- a/frontend/app/shows/[slug]/page.test.tsx
+++ b/frontend/app/shows/[slug]/page.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import * as Sentry from '@sentry/nextjs'
+import { okResponse, errorResponse } from '@/lib/seo/test-helpers'
 
 // `notFound()` in Next.js throws a control-flow error to halt rendering. We
 // mirror that here so tests can assert BOTH that it was called and that
@@ -42,14 +43,6 @@ function buildShow(overrides: Record<string, unknown> = {}) {
     ],
     ...overrides,
   }
-}
-
-function okResponse(body: unknown): Response {
-  return { ok: true, status: 200, json: async () => body } as unknown as Response
-}
-
-function errorResponse(status: number): Response {
-  return { ok: false, status, json: async () => ({}) } as unknown as Response
 }
 
 const fetchMock = vi.fn()

--- a/frontend/app/venues/[slug]/page.test.tsx
+++ b/frontend/app/venues/[slug]/page.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { okResponse, errorResponse } from '@/lib/seo/test-helpers'
 
 vi.mock('next/navigation', () => ({
   notFound: vi.fn(),
@@ -27,14 +28,6 @@ function buildVenue(overrides: Record<string, unknown> = {}) {
     zip_code: '85016',
     ...overrides,
   }
-}
-
-function okResponse(body: unknown): Response {
-  return { ok: true, status: 200, json: async () => body } as unknown as Response
-}
-
-function errorResponse(status: number): Response {
-  return { ok: false, status, json: async () => ({}) } as unknown as Response
 }
 
 const fetchMock = vi.fn()

--- a/frontend/app/venues/[slug]/page.test.tsx
+++ b/frontend/app/venues/[slug]/page.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('next/navigation', () => ({
+  notFound: vi.fn(),
+}))
+
+vi.mock('@sentry/nextjs', () => ({
+  captureMessage: vi.fn(),
+  captureException: vi.fn(),
+}))
+
+// Stub the heavy venues feature module so invoking generateMetadata doesn't
+// pull in the real VenueDetail render path.
+vi.mock('@/features/venues', () => ({
+  VenueDetail: () => null,
+}))
+
+import { generateMetadata } from './page'
+
+function buildVenue(overrides: Record<string, unknown> = {}) {
+  return {
+    name: 'The Rebel Lounge',
+    slug: 'the-rebel-lounge',
+    address: '2303 E Indian School Rd',
+    city: 'Phoenix',
+    state: 'AZ',
+    zip_code: '85016',
+    ...overrides,
+  }
+}
+
+function okResponse(body: unknown): Response {
+  return { ok: true, status: 200, json: async () => body } as unknown as Response
+}
+
+function errorResponse(status: number): Response {
+  return { ok: false, status, json: async () => ({}) } as unknown as Response
+}
+
+const fetchMock = vi.fn()
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('venues/[slug] generateMetadata', () => {
+  it('uses the venue name as the title when the venue is found', async () => {
+    fetchMock.mockResolvedValueOnce(okResponse(buildVenue()))
+
+    const meta = await generateMetadata({ params: Promise.resolve({ slug: 'the-rebel-lounge' }) })
+
+    expect(meta.title).toBe('The Rebel Lounge')
+  })
+
+  it('builds the description from name, city, and state', async () => {
+    fetchMock.mockResolvedValueOnce(okResponse(buildVenue()))
+
+    const meta = await generateMetadata({ params: Promise.resolve({ slug: 'the-rebel-lounge' }) })
+
+    expect(meta.description).toBe(
+      'The Rebel Lounge in Phoenix, AZ - upcoming shows and venue details'
+    )
+  })
+
+  it('sets the canonical URL to https://psychichomily.com/venues/{slug}', async () => {
+    fetchMock.mockResolvedValueOnce(okResponse(buildVenue()))
+
+    const meta = await generateMetadata({ params: Promise.resolve({ slug: 'the-rebel-lounge' }) })
+
+    expect(meta.alternates?.canonical).toBe(
+      'https://psychichomily.com/venues/the-rebel-lounge'
+    )
+  })
+
+  it('sets openGraph title/description/url/type', async () => {
+    fetchMock.mockResolvedValueOnce(okResponse(buildVenue()))
+
+    const meta = await generateMetadata({ params: Promise.resolve({ slug: 'the-rebel-lounge' }) })
+
+    expect(meta.openGraph?.title).toBe('The Rebel Lounge')
+    expect(meta.openGraph?.description).toBe('View upcoming shows at The Rebel Lounge')
+    expect(meta.openGraph?.url).toBe('/venues/the-rebel-lounge')
+    expect((meta.openGraph as { type?: string })?.type).toBe('website')
+  })
+
+  it('falls back to the "Venue" title when the venue is missing', async () => {
+    fetchMock.mockResolvedValueOnce(errorResponse(404))
+
+    const meta = await generateMetadata({ params: Promise.resolve({ slug: 'missing' }) })
+
+    expect(meta.title).toBe('Venue')
+    expect(meta.description).toBe('View venue details and upcoming shows')
+    // No canonical alternate on the fallback shape.
+    expect(meta.alternates).toBeUndefined()
+    expect(meta.openGraph).toBeUndefined()
+  })
+})

--- a/frontend/lib/seo/test-helpers.ts
+++ b/frontend/lib/seo/test-helpers.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared fetch-Response stubs for page-level `generateMetadata` tests.
+ *
+ * The slug pages (shows/venues/artists/collections) read their entity via
+ * `fetch` and branch on `res.ok` / `res.status`. These return the minimal
+ * shape those code paths touch — `ok`, `status`, and a `json()` resolver —
+ * so a single `fetchMock.mockResolvedValueOnce(...)` drives the metadata
+ * branch under test.
+ */
+
+export function okResponse(body: unknown): Response {
+  return { ok: true, status: 200, json: async () => body } as unknown as Response
+}
+
+export function errorResponse(status: number): Response {
+  return { ok: false, status, json: async () => ({}) } as unknown as Response
+}


### PR DESCRIPTION
## Summary
- Add metadata-focused vitest coverage for the slug pages that export `generateMetadata` but lacked a test: **venues**, **artists**, **collections**, and **blog**.
- `shows/[slug]` already has this coverage (added by PSY-684), so it is intentionally skipped — but its duplicated `Response`-stub helpers were folded into the shared helper below.
- `/simplify` extracted the repeated `okResponse`/`errorResponse` fetch stubs into `frontend/lib/seo/test-helpers.ts` (the location the ticket called out), collapsing four identical copies to one source.

Each suite invokes `generateMetadata` directly with mocked params + data source, then asserts `title`, `description`, `alternates.canonical`, and `openGraph.{title,description,url,type}`, plus the entity-missing fallback shape. Fetch-backed pages (venues/artists/collections) mock `fetch`, `@sentry/nextjs`, and `next/navigation`; collections also mocks `next/headers` for its auth-cookie read (PSY-551). The blog page sources posts synchronously from `@/features/blog`, so it mocks that feature and asserts the `article` OG type + `publishedTime`.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run test:run app` — 237 passed (incl. 23 new: venues 5, artists 5, collections 7, blog 6)
- [x] `/simplify` run before PR (manual three-lens review; Agent tool unavailable in this env)

Closes PSY-705

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Manual repro
Test-only diff; no runtime behavior change. `bun run test:run app` (237) is the verification — `generateMetadata` invoked directly with mocked fetch/sentry/navigation. No dev stack applicable.

## Simplify
Manual three-lens review (Agent tool unavailable in dispatched context). Extracted duplicated `okResponse`/`errorResponse` Response stubs to `lib/seo/test-helpers.ts` and adopted across all 4 new tests + the merged shows test (4 copies → 1).
