### PR TITLE
PSY-711: cover ui/dialog + ui/sheet focus-trap and escape behavior

### DIFF
--- a/frontend/components/ui/dialog.test.tsx
+++ b/frontend/components/ui/dialog.test.tsx
@@ -1,0 +1,193 @@
+import { describe, it, expect } from 'vitest'
+import userEvent from '@testing-library/user-event'
+
+import {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from './dialog'
+import { renderWithProviders, screen, waitFor } from '@/test/utils'
+
+/**
+ * Small harness: a trigger plus dialog content with two focusable
+ * children, so we can exercise the focus trap (Tab should cycle within
+ * the dialog rather than escaping to document body).
+ *
+ * `modal` is forwarded to the Radix Root (the wrapper does not expose it
+ * on DialogContent). Note that in this version of @radix-ui/react-dialog,
+ * `modal={false}` only stops freezing outside pointer-events — it does
+ * NOT disable outside-click dismissal. See the modal tests below.
+ */
+function DialogHarness({ modal }: { modal?: boolean }) {
+  return (
+    <Dialog modal={modal}>
+      <DialogTrigger>Open dialog</DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Dialog title</DialogTitle>
+          <DialogDescription>Dialog description</DialogDescription>
+        </DialogHeader>
+        <input type="text" aria-label="first field" />
+        <button type="button">Confirm</button>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+// The shadcn DialogContent renders DialogOverlay as a fixed inset-0 sibling.
+// It is the element a real outside-click lands on. We click it directly
+// because Radix sets `pointer-events: none` on <body> while a modal dialog
+// is open, so `userEvent.click(document.body)` throws under jsdom rather
+// than dismissing — a documented limitation of exercising Radix's
+// document-level pointerdown dismissal in this environment.
+function getOverlay(): HTMLElement {
+  const overlay = document.querySelector<HTMLElement>('.fixed.inset-0')
+  if (!overlay) throw new Error('dialog overlay not found')
+  return overlay
+}
+
+describe('Dialog', () => {
+  it('does not render content until the trigger is activated', () => {
+    renderWithProviders(<DialogHarness />)
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(screen.getByText('Open dialog')).toBeInTheDocument()
+  })
+
+  it('opens and renders content with role="dialog" and an accessible name', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<DialogHarness />)
+
+    await user.click(screen.getByText('Open dialog'))
+
+    const dialog = await screen.findByRole('dialog')
+    expect(dialog).toBeInTheDocument()
+    expect(dialog).toHaveAttribute('data-state', 'open')
+    // This version of Radix conveys modality via role="dialog" plus
+    // aria-labelledby/aria-describedby (and aria-hidden siblings), NOT an
+    // `aria-modal` attribute, so we assert the label association instead.
+    expect(dialog).toHaveAttribute('aria-labelledby')
+    expect(dialog).toHaveAttribute('aria-describedby')
+    expect(dialog).toHaveAccessibleName('Dialog title')
+  })
+
+  it('moves focus inside the dialog on open', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<DialogHarness />)
+
+    await user.click(screen.getByText('Open dialog'))
+
+    const dialog = await screen.findByRole('dialog')
+    // Focus should land somewhere inside the dialog, not back on the
+    // trigger or on document.body.
+    await waitFor(() => {
+      expect(dialog.contains(document.activeElement)).toBe(true)
+    })
+  })
+
+  it('traps focus: Tab cycles within the dialog', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<DialogHarness />)
+
+    await user.click(screen.getByText('Open dialog'))
+
+    const dialog = await screen.findByRole('dialog')
+    await waitFor(() => {
+      expect(dialog.contains(document.activeElement)).toBe(true)
+    })
+
+    // Tab several times; focus must remain inside the dialog the whole
+    // time (the trap prevents it from reaching the document body).
+    for (let i = 0; i < 6; i++) {
+      await user.tab()
+      expect(dialog.contains(document.activeElement)).toBe(true)
+    }
+
+    // Shift+Tab backwards stays inside the trap too.
+    await user.tab({ shift: true })
+    expect(dialog.contains(document.activeElement)).toBe(true)
+  })
+
+  it('closes on Escape', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<DialogHarness />)
+
+    await user.click(screen.getByText('Open dialog'))
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
+
+    await user.keyboard('{Escape}')
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+  })
+
+  it('closes via the built-in Close button', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<DialogHarness />)
+
+    await user.click(screen.getByText('Open dialog'))
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Close' }))
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+  })
+
+  it('closes on outside (overlay) click by default', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<DialogHarness />)
+
+    await user.click(screen.getByText('Open dialog'))
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
+
+    await user.click(getOverlay())
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+  })
+
+  it('freezes outside pointer-events when modal (default)', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<DialogHarness />)
+
+    await user.click(screen.getByText('Open dialog'))
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
+
+    // A modal dialog disables interaction with the rest of the page.
+    expect(document.body.style.pointerEvents).toBe('none')
+  })
+
+  it('does not freeze outside pointer-events when modal={false}', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<DialogHarness modal={false} />)
+
+    await user.click(screen.getByText('Open dialog'))
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
+
+    // The page behind a non-modal dialog stays interactive. (Radix still
+    // closes a non-modal dialog on outside click; `modal` controls
+    // pointer-event freezing, not dismissal.)
+    expect(document.body.style.pointerEvents).not.toBe('none')
+  })
+
+  it('closes on Escape when modal={false}', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<DialogHarness modal={false} />)
+
+    await user.click(screen.getByText('Open dialog'))
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
+
+    await user.keyboard('{Escape}')
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/components/ui/sheet.test.tsx
+++ b/frontend/components/ui/sheet.test.tsx
@@ -1,0 +1,201 @@
+import { describe, it, expect } from 'vitest'
+import userEvent from '@testing-library/user-event'
+
+import {
+  Sheet,
+  SheetTrigger,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from './sheet'
+import { renderWithProviders, screen, waitFor } from '@/test/utils'
+
+type SheetSide = 'top' | 'right' | 'bottom' | 'left'
+
+/**
+ * Small harness: a trigger plus sheet content with two focusable
+ * children, mirroring the dialog harness. `side` and `modal` are
+ * forwarded so individual tests can vary them.
+ *
+ * As with Dialog, `modal={false}` only stops freezing outside
+ * pointer-events in this version of Radix — it does not disable
+ * outside-click dismissal.
+ */
+function SheetHarness({ side, modal }: { side?: SheetSide; modal?: boolean }) {
+  return (
+    <Sheet modal={modal}>
+      <SheetTrigger>Open sheet</SheetTrigger>
+      <SheetContent side={side}>
+        <SheetHeader>
+          <SheetTitle>Sheet title</SheetTitle>
+          <SheetDescription>Sheet description</SheetDescription>
+        </SheetHeader>
+        <input type="text" aria-label="first field" />
+        <button type="button">Confirm</button>
+      </SheetContent>
+    </Sheet>
+  )
+}
+
+// Sheet (built on Radix Dialog) reuses the dialog role for its content,
+// so role="dialog" is the canonical query for its content element.
+//
+// SheetOverlay renders as a fixed inset-0 sibling and is the element a
+// real outside-click lands on. We click it directly because Radix sets
+// `pointer-events: none` on <body> while a modal sheet is open, so
+// clicking document.body throws under jsdom rather than dismissing — a
+// documented limitation of exercising Radix's document-level pointerdown
+// dismissal in this environment.
+function getOverlay(): HTMLElement {
+  const overlay = document.querySelector<HTMLElement>(
+    '[data-slot="sheet-overlay"]'
+  )
+  if (!overlay) throw new Error('sheet overlay not found')
+  return overlay
+}
+
+describe('Sheet', () => {
+  it('does not render content until the trigger is activated', () => {
+    renderWithProviders(<SheetHarness />)
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(screen.getByText('Open sheet')).toBeInTheDocument()
+  })
+
+  it('opens and renders content with role="dialog" and an accessible name', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<SheetHarness />)
+
+    await user.click(screen.getByText('Open sheet'))
+
+    const sheet = await screen.findByRole('dialog')
+    expect(sheet).toBeInTheDocument()
+    expect(sheet).toHaveAttribute('data-state', 'open')
+    expect(sheet).toHaveAttribute('data-slot', 'sheet-content')
+    // This version of Radix conveys modality via role="dialog" plus
+    // aria-labelledby/aria-describedby, NOT an `aria-modal` attribute.
+    expect(sheet).toHaveAttribute('aria-labelledby')
+    expect(sheet).toHaveAttribute('aria-describedby')
+    expect(sheet).toHaveAccessibleName('Sheet title')
+  })
+
+  it('moves focus inside the sheet on open', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<SheetHarness />)
+
+    await user.click(screen.getByText('Open sheet'))
+
+    const sheet = await screen.findByRole('dialog')
+    await waitFor(() => {
+      expect(sheet.contains(document.activeElement)).toBe(true)
+    })
+  })
+
+  it('traps focus: Tab cycles within the sheet', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<SheetHarness />)
+
+    await user.click(screen.getByText('Open sheet'))
+
+    const sheet = await screen.findByRole('dialog')
+    await waitFor(() => {
+      expect(sheet.contains(document.activeElement)).toBe(true)
+    })
+
+    for (let i = 0; i < 6; i++) {
+      await user.tab()
+      expect(sheet.contains(document.activeElement)).toBe(true)
+    }
+
+    await user.tab({ shift: true })
+    expect(sheet.contains(document.activeElement)).toBe(true)
+  })
+
+  it('closes on Escape', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<SheetHarness />)
+
+    await user.click(screen.getByText('Open sheet'))
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
+
+    await user.keyboard('{Escape}')
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+  })
+
+  it('closes via the built-in Close button', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<SheetHarness />)
+
+    await user.click(screen.getByText('Open sheet'))
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Close' }))
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+  })
+
+  it('closes on outside (overlay) click by default', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<SheetHarness />)
+
+    await user.click(screen.getByText('Open sheet'))
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
+
+    await user.click(getOverlay())
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+  })
+
+  it('does not freeze outside pointer-events when modal={false}', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<SheetHarness modal={false} />)
+
+    await user.click(screen.getByText('Open sheet'))
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
+
+    expect(document.body.style.pointerEvents).not.toBe('none')
+  })
+
+  describe('side prop', () => {
+    // The wrapper does not expose `side` as a data attribute; it maps
+    // each side onto the slide-in/out utility classes. Assert on those
+    // class tokens so a regression in the mapping is caught.
+    const cases: Array<{ side: SheetSide; token: string }> = [
+      { side: 'right', token: 'data-[state=open]:slide-in-from-right' },
+      { side: 'left', token: 'data-[state=open]:slide-in-from-left' },
+      { side: 'top', token: 'data-[state=open]:slide-in-from-top' },
+      { side: 'bottom', token: 'data-[state=open]:slide-in-from-bottom' },
+    ]
+
+    it.each(cases)(
+      'applies the $side slide class ($token)',
+      async ({ side, token }) => {
+        const user = userEvent.setup()
+        renderWithProviders(<SheetHarness side={side} />)
+
+        await user.click(screen.getByText('Open sheet'))
+
+        const sheet = await screen.findByRole('dialog')
+        expect(sheet).toHaveClass(token)
+      }
+    )
+
+    it('defaults to the right side when side is omitted', async () => {
+      const user = userEvent.setup()
+      renderWithProviders(<SheetHarness />)
+
+      await user.click(screen.getByText('Open sheet'))
+
+      const sheet = await screen.findByRole('dialog')
+      expect(sheet).toHaveClass('data-[state=open]:slide-in-from-right')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Add `frontend/components/ui/dialog.test.tsx` and `frontend/components/ui/sheet.test.tsx` for the shadcn/Radix Dialog and Sheet wrappers (back every modal flow; previously zero tests).
- Cover focus management (open moves focus inside; Tab/Shift+Tab cycle within = focus trap), Escape + Close-button + outside-click dismissal, ARIA associations on content, the `modal` pointer-events contract, and the Sheet `side` prop class mapping.
- Test-only diff. 23 tests, all passing.

## Notes for reviewers
- This version of `@radix-ui/react-dialog` (^1.1.15) does **not** set `aria-modal`; it conveys modality via `role="dialog"` + `aria-labelledby`/`aria-describedby` + `aria-hidden` siblings. Tests assert those associations instead of `aria-modal`.
- jsdom limitation: while a modal is open Radix sets `pointer-events: none` on `<body>`, so `userEvent.click(document.body)` throws rather than dismissing. The outside-click test clicks the overlay element directly (the real outside-click target). Documented inline.
- The Sheet `side` prop is **not** stored as a `data-side` attribute by the wrapper — it maps onto slide-in/out utility classes. Tests assert the class tokens (`data-[state=open]:slide-in-from-{side}`) so a mapping regression is caught.
- `modal={false}` does not disable outside-click dismissal in this Radix version (it only stops freezing outside pointer-events); tests assert the page-interactivity contract rather than a no-close behavior the wrapper does not provide.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run test:run components/ui` (23 passed)
- [x] `/simplify` (manual fallback — sub-agent cannot spawn review agents; reviewed reuse/quality/efficiency manually, no changes needed)

Closes PSY-711

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Manual repro
Test-only diff; no runtime behavior change. `bun run test:run components/ui` (23) is the verification — focus-trap/escape/ARIA exercised via userEvent on a render harness. jsdom/Radix limits documented inline. No dev stack applicable.

## Simplify
Manual three-lens review (Agent tool unavailable in dispatched context). Clean — canonical helpers reused, WHY-only comments, no changes needed.
