### PR TITLE
PSY-712: cover remaining components/ui primitives with sibling tests

### DIFF
--- a/frontend/components/ui/alert.test.tsx
+++ b/frontend/components/ui/alert.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Alert, AlertTitle, AlertDescription } from './alert'
+
+describe('Alert', () => {
+  it('renders its content with the alert role', () => {
+    render(
+      <Alert>
+        <AlertTitle>Heads up</AlertTitle>
+        <AlertDescription>Something happened</AlertDescription>
+      </Alert>
+    )
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(screen.getByText('Heads up')).toBeInTheDocument()
+    expect(screen.getByText('Something happened')).toBeInTheDocument()
+  })
+
+  it('merges a custom className', () => {
+    render(<Alert className="custom-class">Body</Alert>)
+    expect(screen.getByRole('alert')).toHaveClass('custom-class')
+  })
+
+  it('applies the default variant classes', () => {
+    render(<Alert>Body</Alert>)
+    expect(screen.getByRole('alert')).toHaveClass('bg-card')
+  })
+
+  it('applies the destructive variant classes', () => {
+    render(<Alert variant="destructive">Body</Alert>)
+    expect(screen.getByRole('alert')).toHaveClass('text-destructive')
+  })
+
+  it('tags sub-components with their data-slot', () => {
+    const { container } = render(
+      <Alert>
+        <AlertTitle>Title</AlertTitle>
+        <AlertDescription>Description</AlertDescription>
+      </Alert>
+    )
+    expect(
+      container.querySelector('[data-slot="alert-title"]')
+    ).toBeInTheDocument()
+    expect(
+      container.querySelector('[data-slot="alert-description"]')
+    ).toBeInTheDocument()
+  })
+})

--- a/frontend/components/ui/badge.test.tsx
+++ b/frontend/components/ui/badge.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Badge, badgeVariants } from './badge'
+
+describe('Badge', () => {
+  it('renders its children without throwing', () => {
+    render(<Badge>New</Badge>)
+    expect(screen.getByText('New')).toBeInTheDocument()
+  })
+
+  it('merges a custom className', () => {
+    render(<Badge className="custom-class">New</Badge>)
+    expect(screen.getByText('New')).toHaveClass('custom-class')
+  })
+
+  it('applies the default variant classes', () => {
+    render(<Badge>Default</Badge>)
+    expect(screen.getByText('Default')).toHaveClass('bg-primary')
+  })
+
+  it('applies the destructive variant classes', () => {
+    render(<Badge variant="destructive">Danger</Badge>)
+    expect(screen.getByText('Danger')).toHaveClass('bg-destructive')
+  })
+
+  it('exposes a badgeVariants helper that reflects the variant', () => {
+    expect(badgeVariants({ variant: 'secondary' })).toContain('bg-secondary')
+    expect(badgeVariants({ variant: 'outline' })).toContain('text-foreground')
+  })
+})

--- a/frontend/components/ui/button.test.tsx
+++ b/frontend/components/ui/button.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import { createRef } from 'react'
+import { render, screen } from '@testing-library/react'
+import { Button, buttonVariants } from './button'
+
+describe('Button', () => {
+  it('renders its children without throwing', () => {
+    render(<Button>Click me</Button>)
+    expect(screen.getByRole('button', { name: 'Click me' })).toBeInTheDocument()
+  })
+
+  it('merges a custom className', () => {
+    render(<Button className="custom-class">Go</Button>)
+    expect(screen.getByRole('button')).toHaveClass('custom-class')
+  })
+
+  it('forwards a ref to the underlying button element', () => {
+    const ref = createRef<HTMLButtonElement>()
+    render(<Button ref={ref}>Ref</Button>)
+    expect(ref.current).toBeInstanceOf(HTMLButtonElement)
+  })
+
+  it('applies variant and size classes', () => {
+    render(
+      <Button variant="destructive" size="sm">
+        Delete
+      </Button>
+    )
+    const button = screen.getByRole('button')
+    expect(button).toHaveClass('bg-destructive') // variant=destructive
+    expect(button).toHaveClass('h-8') // size=sm
+  })
+
+  it('honors the disabled prop', () => {
+    render(<Button disabled>Disabled</Button>)
+    expect(screen.getByRole('button')).toBeDisabled()
+  })
+
+  it('renders as a child element when asChild is set', () => {
+    render(
+      <Button asChild>
+        <a href="/somewhere">Link button</a>
+      </Button>
+    )
+    const link = screen.getByRole('link', { name: 'Link button' })
+    expect(link).toHaveAttribute('href', '/somewhere')
+    // The asChild Slot still applies button variant classes.
+    expect(link).toHaveClass('inline-flex')
+  })
+
+  it('exposes a buttonVariants helper that reflects variant/size', () => {
+    const cls = buttonVariants({ variant: 'outline', size: 'lg' })
+    expect(cls).toContain('border')
+    expect(cls).toContain('h-10')
+  })
+})

--- a/frontend/components/ui/card.test.tsx
+++ b/frontend/components/ui/card.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardAction,
+  CardContent,
+  CardFooter,
+} from './card'
+
+describe('Card', () => {
+  it('renders the full card structure without throwing', () => {
+    render(
+      <Card>
+        <CardHeader>
+          <CardTitle>Title</CardTitle>
+          <CardDescription>Description</CardDescription>
+          <CardAction>Action</CardAction>
+        </CardHeader>
+        <CardContent>Content</CardContent>
+        <CardFooter>Footer</CardFooter>
+      </Card>
+    )
+    expect(screen.getByText('Title')).toBeInTheDocument()
+    expect(screen.getByText('Description')).toBeInTheDocument()
+    expect(screen.getByText('Action')).toBeInTheDocument()
+    expect(screen.getByText('Content')).toBeInTheDocument()
+    expect(screen.getByText('Footer')).toBeInTheDocument()
+  })
+
+  it('tags each sub-component with its data-slot', () => {
+    const { container } = render(
+      <Card>
+        <CardHeader>
+          <CardTitle>Title</CardTitle>
+          <CardDescription>Description</CardDescription>
+          <CardAction>Action</CardAction>
+        </CardHeader>
+        <CardContent>Content</CardContent>
+        <CardFooter>Footer</CardFooter>
+      </Card>
+    )
+    expect(container.querySelector('[data-slot="card"]')).toBeInTheDocument()
+    expect(
+      container.querySelector('[data-slot="card-header"]')
+    ).toBeInTheDocument()
+    expect(
+      container.querySelector('[data-slot="card-title"]')
+    ).toBeInTheDocument()
+    expect(
+      container.querySelector('[data-slot="card-description"]')
+    ).toBeInTheDocument()
+    expect(
+      container.querySelector('[data-slot="card-action"]')
+    ).toBeInTheDocument()
+    expect(
+      container.querySelector('[data-slot="card-content"]')
+    ).toBeInTheDocument()
+    expect(
+      container.querySelector('[data-slot="card-footer"]')
+    ).toBeInTheDocument()
+  })
+
+  it('merges a custom className on the root', () => {
+    const { container } = render(<Card className="custom-class">Body</Card>)
+    expect(container.querySelector('[data-slot="card"]')).toHaveClass(
+      'custom-class'
+    )
+  })
+})

--- a/frontend/components/ui/checkbox.test.tsx
+++ b/frontend/components/ui/checkbox.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { createRef } from 'react'
+import { render, screen } from '@testing-library/react'
+import { Checkbox } from './checkbox'
+
+describe('Checkbox', () => {
+  it('renders without throwing', () => {
+    render(<Checkbox aria-label="agree" />)
+    expect(screen.getByRole('checkbox', { name: 'agree' })).toBeInTheDocument()
+  })
+
+  it('merges a custom className', () => {
+    render(<Checkbox aria-label="agree" className="custom-class" />)
+    expect(screen.getByRole('checkbox')).toHaveClass('custom-class')
+  })
+
+  it('forwards a ref to the underlying button element', () => {
+    const ref = createRef<HTMLButtonElement>()
+    render(<Checkbox aria-label="agree" ref={ref} />)
+    expect(ref.current).toBeInstanceOf(HTMLButtonElement)
+  })
+
+  it('reflects the checked state via aria-checked', () => {
+    render(<Checkbox aria-label="agree" defaultChecked />)
+    expect(screen.getByRole('checkbox')).toBeChecked()
+  })
+
+  it('honors the disabled prop', () => {
+    render(<Checkbox aria-label="agree" disabled />)
+    expect(screen.getByRole('checkbox')).toBeDisabled()
+  })
+})

--- a/frontend/components/ui/command.test.tsx
+++ b/frontend/components/ui/command.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeAll } from 'vitest'
+import { createRef } from 'react'
+import { render, screen } from '@testing-library/react'
+import {
+  Command,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandSeparator,
+  CommandShortcut,
+} from './command'
+
+// jsdom does not implement scrollIntoView (required by cmdk).
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+})
+
+describe('Command', () => {
+  it('renders the command list structure without throwing', () => {
+    render(
+      <Command>
+        <CommandInput placeholder="Search..." />
+        <CommandList>
+          <CommandEmpty>No results</CommandEmpty>
+          <CommandGroup heading="Group">
+            <CommandItem>Item one</CommandItem>
+            <CommandSeparator />
+            <CommandItem>
+              Item two
+              <CommandShortcut>⌘K</CommandShortcut>
+            </CommandItem>
+          </CommandGroup>
+        </CommandList>
+      </Command>
+    )
+    expect(screen.getByPlaceholderText('Search...')).toBeInTheDocument()
+    expect(screen.getByText('Item one')).toBeInTheDocument()
+    expect(screen.getByText('Item two')).toBeInTheDocument()
+    expect(screen.getByText('⌘K')).toBeInTheDocument()
+  })
+
+  it('merges a custom className on the root', () => {
+    const { container } = render(<Command className="custom-class" />)
+    expect(container.firstChild).toHaveClass('custom-class')
+  })
+
+  it('forwards a ref to the command root', () => {
+    const ref = createRef<HTMLDivElement>()
+    render(<Command ref={ref} />)
+    expect(ref.current).toBeInstanceOf(HTMLDivElement)
+  })
+
+  it('forwards a ref to the command input', () => {
+    const ref = createRef<HTMLInputElement>()
+    render(
+      <Command>
+        <CommandInput ref={ref} placeholder="Search..." />
+      </Command>
+    )
+    expect(ref.current).toBeInstanceOf(HTMLInputElement)
+  })
+
+  it('merges a custom className on the input', () => {
+    render(
+      <Command>
+        <CommandInput className="custom-class" placeholder="Search..." />
+      </Command>
+    )
+    expect(screen.getByPlaceholderText('Search...')).toHaveClass('custom-class')
+  })
+})

--- a/frontend/components/ui/dropdown-menu.test.tsx
+++ b/frontend/components/ui/dropdown-menu.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+} from './dropdown-menu'
+
+describe('DropdownMenu', () => {
+  it('renders the trigger without throwing', () => {
+    render(
+      <DropdownMenu>
+        <DropdownMenuTrigger>Menu</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem>Edit</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    )
+    expect(screen.getByRole('button', { name: 'Menu' })).toBeInTheDocument()
+  })
+
+  it('renders portal content and items when open', () => {
+    render(
+      <DropdownMenu open>
+        <DropdownMenuTrigger>Menu</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuLabel>Actions</DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem>Edit</DropdownMenuItem>
+          <DropdownMenuItem variant="destructive">Delete</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    )
+    expect(screen.getByText('Actions')).toBeInTheDocument()
+    expect(screen.getByRole('menuitem', { name: 'Edit' })).toBeInTheDocument()
+    expect(screen.getByRole('menuitem', { name: 'Delete' })).toBeInTheDocument()
+  })
+
+  it('applies the destructive variant data attribute on an item', () => {
+    render(
+      <DropdownMenu open>
+        <DropdownMenuTrigger>Menu</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem variant="destructive">Delete</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    )
+    expect(screen.getByRole('menuitem', { name: 'Delete' })).toHaveAttribute(
+      'data-variant',
+      'destructive'
+    )
+  })
+
+  it('merges a custom className on the content', () => {
+    const { baseElement } = render(
+      <DropdownMenu open>
+        <DropdownMenuTrigger>Menu</DropdownMenuTrigger>
+        <DropdownMenuContent className="custom-class">
+          <DropdownMenuItem>Edit</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    )
+    expect(
+      baseElement.querySelector('[data-slot="dropdown-menu-content"]')
+    ).toHaveClass('custom-class')
+  })
+})

--- a/frontend/components/ui/hover-card.test.tsx
+++ b/frontend/components/ui/hover-card.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { createRef } from 'react'
+import { render, screen } from '@testing-library/react'
+import { HoverCard, HoverCardTrigger, HoverCardContent } from './hover-card'
+
+describe('HoverCard', () => {
+  it('renders the trigger without throwing', () => {
+    render(
+      <HoverCard>
+        <HoverCardTrigger>Hover me</HoverCardTrigger>
+        <HoverCardContent>Card</HoverCardContent>
+      </HoverCard>
+    )
+    expect(screen.getByText('Hover me')).toBeInTheDocument()
+  })
+
+  it('renders portal content when open', () => {
+    render(
+      <HoverCard open>
+        <HoverCardTrigger>Hover me</HoverCardTrigger>
+        <HoverCardContent>Card content</HoverCardContent>
+      </HoverCard>
+    )
+    expect(screen.getByText('Card content')).toBeInTheDocument()
+  })
+
+  it('merges a custom className on the content', () => {
+    render(
+      <HoverCard open>
+        <HoverCardTrigger>Hover me</HoverCardTrigger>
+        <HoverCardContent className="custom-class">Card content</HoverCardContent>
+      </HoverCard>
+    )
+    expect(screen.getByText('Card content')).toHaveClass('custom-class')
+  })
+
+  it('forwards a ref to the content', () => {
+    const ref = createRef<HTMLDivElement>()
+    render(
+      <HoverCard open>
+        <HoverCardTrigger>Hover me</HoverCardTrigger>
+        <HoverCardContent ref={ref}>Card content</HoverCardContent>
+      </HoverCard>
+    )
+    expect(ref.current).toBeInstanceOf(HTMLDivElement)
+  })
+})

--- a/frontend/components/ui/input.test.tsx
+++ b/frontend/components/ui/input.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { createRef } from 'react'
+import { render, screen } from '@testing-library/react'
+import { Input } from './input'
+
+describe('Input', () => {
+  it('renders without throwing', () => {
+    render(<Input aria-label="name" />)
+    expect(screen.getByLabelText('name')).toBeInTheDocument()
+  })
+
+  it('merges a custom className', () => {
+    render(<Input aria-label="name" className="custom-class" />)
+    expect(screen.getByLabelText('name')).toHaveClass('custom-class')
+  })
+
+  it('forwards a ref to the underlying input element', () => {
+    const ref = createRef<HTMLInputElement>()
+    render(<Input aria-label="name" ref={ref} />)
+    expect(ref.current).toBeInstanceOf(HTMLInputElement)
+  })
+
+  it('forwards the type attribute', () => {
+    render(<Input aria-label="pw" type="password" />)
+    expect(screen.getByLabelText('pw')).toHaveAttribute('type', 'password')
+  })
+
+  it('honors the disabled prop', () => {
+    render(<Input aria-label="name" disabled />)
+    expect(screen.getByLabelText('name')).toBeDisabled()
+  })
+})

--- a/frontend/components/ui/label.test.tsx
+++ b/frontend/components/ui/label.test.tsx
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Label } from './label'
+
+describe('Label', () => {
+  it('renders its children without throwing', () => {
+    render(<Label>Email</Label>)
+    expect(screen.getByText('Email')).toBeInTheDocument()
+  })
+
+  it('merges a custom className', () => {
+    render(<Label className="custom-class">Email</Label>)
+    expect(screen.getByText('Email')).toHaveClass('custom-class')
+  })
+
+  it('associates with a control via htmlFor', () => {
+    render(<Label htmlFor="email-input">Email</Label>)
+    expect(screen.getByText('Email')).toHaveAttribute('for', 'email-input')
+  })
+})

--- a/frontend/components/ui/password-strength-meter.test.tsx
+++ b/frontend/components/ui/password-strength-meter.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import {
+  PasswordStrengthMeter,
+  calculateStrength,
+  checkRequirements,
+  getStrengthInfo,
+} from './password-strength-meter'
+
+describe('calculateStrength', () => {
+  it('returns 0 for an empty password', () => {
+    expect(calculateStrength('')).toBe(0)
+  })
+
+  it('scores a short single-class password as weak', () => {
+    // "abc": hasLower (+10) only; no length bonuses (< 12 chars).
+    expect(calculateStrength('abc')).toBe(10)
+  })
+
+  it('scores a 12-char four-class password in the middle range', () => {
+    // 12 chars: length>=12 (+20); all four character classes (+40);
+    // entropy bonus requires uniqueChars/length > 0.5 at length>=12.
+    const score = calculateStrength('Abcdef123!@#')
+    expect(score).toBeGreaterThanOrEqual(50)
+    expect(score).toBeLessThan(90)
+  })
+
+  it('scores a long high-variety password as strong (capped at 100)', () => {
+    const score = calculateStrength('Abcdefgh123!@#$%^&*()')
+    expect(score).toBeGreaterThanOrEqual(90)
+    expect(score).toBeLessThanOrEqual(100)
+  })
+})
+
+describe('getStrengthInfo', () => {
+  it('labels low scores as Weak', () => {
+    expect(getStrengthInfo(10).label).toBe('Weak')
+  })
+
+  it('labels mid scores as Good', () => {
+    expect(getStrengthInfo(60).label).toBe('Good')
+  })
+
+  it('labels high scores as Excellent', () => {
+    expect(getStrengthInfo(100).label).toBe('Excellent')
+  })
+})
+
+describe('checkRequirements', () => {
+  it('marks all requirements unmet for a weak password', () => {
+    const reqs = checkRequirements('abc')
+    expect(reqs.every(r => !r.met)).toBe(true)
+  })
+
+  it('marks all requirements met for a strong password', () => {
+    const reqs = checkRequirements('Abcdefgh123!@#')
+    expect(reqs.every(r => r.met)).toBe(true)
+  })
+})
+
+describe('PasswordStrengthMeter', () => {
+  it('renders nothing for an empty password', () => {
+    const { container } = render(<PasswordStrengthMeter password="" />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders the strength label for a non-empty password', () => {
+    render(<PasswordStrengthMeter password="abc" />)
+    expect(screen.getByText('Password strength')).toBeInTheDocument()
+    expect(screen.getByText('Weak')).toBeInTheDocument()
+  })
+
+  it('merges a custom className on the wrapper', () => {
+    const { container } = render(
+      <PasswordStrengthMeter password="abc" className="custom-class" />
+    )
+    expect(container.firstChild).toHaveClass('custom-class')
+  })
+
+  it('omits the requirements checklist when showRequirements is false', () => {
+    render(<PasswordStrengthMeter password="abc" showRequirements={false} />)
+    expect(screen.queryByText('At least 12 characters')).not.toBeInTheDocument()
+  })
+
+  it('shows the requirements checklist by default', () => {
+    render(<PasswordStrengthMeter password="abc" />)
+    expect(screen.getByText('At least 12 characters')).toBeInTheDocument()
+  })
+})

--- a/frontend/components/ui/popover.test.tsx
+++ b/frontend/components/ui/popover.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { createRef } from 'react'
+import { render, screen } from '@testing-library/react'
+import { Popover, PopoverTrigger, PopoverContent } from './popover'
+
+describe('Popover', () => {
+  it('renders the trigger without throwing', () => {
+    render(
+      <Popover>
+        <PopoverTrigger>Open</PopoverTrigger>
+        <PopoverContent>Panel</PopoverContent>
+      </Popover>
+    )
+    expect(screen.getByRole('button', { name: 'Open' })).toBeInTheDocument()
+  })
+
+  it('renders portal content when open', () => {
+    render(
+      <Popover open>
+        <PopoverTrigger>Open</PopoverTrigger>
+        <PopoverContent>Panel content</PopoverContent>
+      </Popover>
+    )
+    expect(screen.getByText('Panel content')).toBeInTheDocument()
+  })
+
+  it('merges a custom className on the content', () => {
+    render(
+      <Popover open>
+        <PopoverTrigger>Open</PopoverTrigger>
+        <PopoverContent className="custom-class">Panel content</PopoverContent>
+      </Popover>
+    )
+    expect(screen.getByText('Panel content')).toHaveClass('custom-class')
+  })
+
+  it('forwards a ref to the content', () => {
+    const ref = createRef<HTMLDivElement>()
+    render(
+      <Popover open>
+        <PopoverTrigger>Open</PopoverTrigger>
+        <PopoverContent ref={ref}>Panel content</PopoverContent>
+      </Popover>
+    )
+    expect(ref.current).toBeInstanceOf(HTMLDivElement)
+  })
+})

--- a/frontend/components/ui/skeleton.test.tsx
+++ b/frontend/components/ui/skeleton.test.tsx
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import { Skeleton } from './skeleton'
+
+describe('Skeleton', () => {
+  it('renders without throwing and applies the pulse animation class', () => {
+    const { container } = render(<Skeleton />)
+    expect(container.firstChild).toHaveClass('animate-pulse')
+  })
+
+  it('merges a custom className', () => {
+    const { container } = render(<Skeleton className="h-4 w-10" />)
+    expect(container.firstChild).toHaveClass('h-4')
+    expect(container.firstChild).toHaveClass('w-10')
+  })
+
+  it('forwards arbitrary props to the underlying div', () => {
+    const { container } = render(<Skeleton data-testid="sk" />)
+    expect(container.firstChild).toHaveAttribute('data-testid', 'sk')
+  })
+})

--- a/frontend/components/ui/switch.test.tsx
+++ b/frontend/components/ui/switch.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Switch } from './switch'
+
+describe('Switch', () => {
+  it('renders without throwing', () => {
+    render(<Switch aria-label="notifications" />)
+    expect(
+      screen.getByRole('switch', { name: 'notifications' })
+    ).toBeInTheDocument()
+  })
+
+  it('merges a custom className', () => {
+    render(<Switch aria-label="notifications" className="custom-class" />)
+    expect(screen.getByRole('switch')).toHaveClass('custom-class')
+  })
+
+  it('applies the default size data attribute', () => {
+    render(<Switch aria-label="notifications" />)
+    expect(screen.getByRole('switch')).toHaveAttribute('data-size', 'default')
+  })
+
+  it('applies the sm size data attribute', () => {
+    render(<Switch aria-label="notifications" size="sm" />)
+    expect(screen.getByRole('switch')).toHaveAttribute('data-size', 'sm')
+  })
+
+  it('reflects the checked state', () => {
+    render(<Switch aria-label="notifications" defaultChecked />)
+    expect(screen.getByRole('switch')).toBeChecked()
+  })
+
+  it('honors the disabled prop', () => {
+    render(<Switch aria-label="notifications" disabled />)
+    expect(screen.getByRole('switch')).toBeDisabled()
+  })
+})

--- a/frontend/components/ui/tabs.test.tsx
+++ b/frontend/components/ui/tabs.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Tabs, TabsList, TabsTrigger, TabsContent } from './tabs'
+
+function renderTabs(extra?: { className?: string }) {
+  return render(
+    <Tabs defaultValue="one" className={extra?.className}>
+      <TabsList>
+        <TabsTrigger value="one">One</TabsTrigger>
+        <TabsTrigger value="two" disabled>
+          Two
+        </TabsTrigger>
+      </TabsList>
+      <TabsContent value="one">First panel</TabsContent>
+      <TabsContent value="two">Second panel</TabsContent>
+    </Tabs>
+  )
+}
+
+describe('Tabs', () => {
+  it('renders triggers and the active panel without throwing', () => {
+    renderTabs()
+    expect(screen.getByRole('tab', { name: 'One' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Two' })).toBeInTheDocument()
+    expect(screen.getByText('First panel')).toBeInTheDocument()
+  })
+
+  it('marks the default tab as selected', () => {
+    renderTabs()
+    expect(screen.getByRole('tab', { name: 'One' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    )
+  })
+
+  it('honors the disabled prop on a trigger', () => {
+    renderTabs()
+    expect(screen.getByRole('tab', { name: 'Two' })).toBeDisabled()
+  })
+
+  it('merges a custom className on the root', () => {
+    const { container } = renderTabs({ className: 'custom-class' })
+    expect(container.querySelector('[data-slot="tabs"]')).toHaveClass(
+      'custom-class'
+    )
+  })
+})

--- a/frontend/components/ui/textarea.test.tsx
+++ b/frontend/components/ui/textarea.test.tsx
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { createRef } from 'react'
+import { render, screen } from '@testing-library/react'
+import { Textarea } from './textarea'
+
+describe('Textarea', () => {
+  it('renders without throwing', () => {
+    render(<Textarea aria-label="bio" />)
+    expect(screen.getByLabelText('bio')).toBeInTheDocument()
+  })
+
+  it('merges a custom className', () => {
+    render(<Textarea aria-label="bio" className="custom-class" />)
+    expect(screen.getByLabelText('bio')).toHaveClass('custom-class')
+  })
+
+  it('forwards a ref to the underlying textarea element', () => {
+    const ref = createRef<HTMLTextAreaElement>()
+    render(<Textarea aria-label="bio" ref={ref} />)
+    expect(ref.current).toBeInstanceOf(HTMLTextAreaElement)
+  })
+
+  it('honors the disabled prop', () => {
+    render(<Textarea aria-label="bio" disabled />)
+    expect(screen.getByLabelText('bio')).toBeDisabled()
+  })
+})

--- a/frontend/components/ui/tooltip.test.tsx
+++ b/frontend/components/ui/tooltip.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { createRef } from 'react'
+import { render, screen } from '@testing-library/react'
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+  TooltipProvider,
+} from './tooltip'
+
+describe('Tooltip', () => {
+  it('renders the trigger without throwing', () => {
+    render(
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger>Trigger</TooltipTrigger>
+          <TooltipContent>Tip</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    )
+    expect(screen.getByText('Trigger')).toBeInTheDocument()
+  })
+
+  it('renders portal content when open', () => {
+    render(
+      <TooltipProvider>
+        <Tooltip open>
+          <TooltipTrigger>Trigger</TooltipTrigger>
+          <TooltipContent>Tip content</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    )
+    // Radix renders a visible tooltip plus a visually-hidden a11y copy.
+    expect(screen.getAllByText('Tip content').length).toBeGreaterThan(0)
+  })
+
+  it('merges a custom className on the content', () => {
+    render(
+      <TooltipProvider>
+        <Tooltip open>
+          <TooltipTrigger>Trigger</TooltipTrigger>
+          <TooltipContent className="custom-class">Tip content</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    )
+    const matches = screen.getAllByText('Tip content')
+    expect(matches.some(el => el.closest('.custom-class'))).toBe(true)
+  })
+
+  it('forwards a ref to the content', () => {
+    const ref = createRef<HTMLDivElement>()
+    render(
+      <TooltipProvider>
+        <Tooltip open>
+          <TooltipTrigger>Trigger</TooltipTrigger>
+          <TooltipContent ref={ref}>Tip content</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    )
+    expect(ref.current).toBeInstanceOf(HTMLDivElement)
+  })
+})


### PR DESCRIPTION
## Summary
- Adds minimal sibling tests for the 17 untested `components/ui` primitives: `alert`, `badge`, `button`, `card`, `checkbox`, `command`, `dropdown-menu`, `hover-card`, `input`, `label`, `password-strength-meter`, `popover`, `skeleton`, `switch`, `tabs`, `textarea`, `tooltip`.
- Excludes `dialog.tsx` and `sheet.tsx` (focus-trap behavior, owned by PSY-711) — not touched.
- Each test asserts: renders without throwing, `className` cn-merge, ref forwarding where applicable, variant/size class application (button: variant+size; badge: variant; card: data-slot structure), and disabled state for interactive primitives (button/input/checkbox/switch/textarea). `password-strength-meter` covers strength calc + label buckets across empty/weak/medium/strong inputs.

85 tests across 17 files. Plain RTL `render` is used (these primitives don't need the QueryClient provider); cmdk's `scrollIntoView` is mocked per the existing `CommandPalette.test.tsx` precedent.

Closes PSY-712

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run test:run components/ui` passes (17 files, 85 tests)
- [x] `/simplify` run before PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Manual repro
Test-only diff; no runtime behavior change. `bun run test:run components/ui` (85) is the verification — render/variant/disabled/ref assertions; password-strength scoring hand-verified against source. No dev stack applicable.

## Simplify
Ran (available for this agent). Trimmed two redundant comments in `button.test.tsx`; kept load-bearing WHY comments. No reuse/efficiency findings.
