### PR TITLE
PSY-736: explicit-locale formatters for PipelineVenues timestamps

### DIFF
--- a/frontend/components/admin/PipelineVenues.test.tsx
+++ b/frontend/components/admin/PipelineVenues.test.tsx
@@ -1,13 +1,19 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import type { PipelineVenueInfo } from '@/lib/hooks/usePipeline'
+import type {
+  PipelineVenueInfo,
+  ImportHistoryEntry,
+  VenueExtractionRun,
+} from '@/lib/hooks/usePipeline'
+import { formatShortDate, formatTimestamp } from '@/lib/utils/formatters'
 
 // `vi.hoisted` lets us share these handles between the hoisted vi.mock factory
 // and the test bodies below. Anything referenced inside `vi.mock` factories
 // MUST live in here, since `vi.mock` calls are hoisted above module-level
 // const declarations.
-const { mockResetMutate, mocks, venueFixture } = vi.hoisted(() => {
+const { mockResetMutate, mocks, venueFixture, runFixture, importFixture } =
+  vi.hoisted(() => {
   type MutateOpts = {
     onSuccess?: () => void
     onError?: (err: unknown) => void
@@ -20,19 +26,42 @@ const { mockResetMutate, mocks, venueFixture } = vi.hoisted(() => {
       mocks.lastResetMutateOpts = opts ?? null
     }
   )
+  const runFixture: VenueExtractionRun = {
+    id: 7,
+    venue_id: 42,
+    run_at: '2026-01-15T19:30:00Z',
+    render_method: 'static',
+    events_extracted: 12,
+    events_imported: 10,
+    duration_ms: 4200,
+    created_at: '2026-01-15T19:30:00Z',
+  }
   const venueFixture: PipelineVenueInfo = {
     venue_id: 42,
     venue_name: 'The Rebel Lounge',
     venue_slug: 'the-rebel-lounge',
     preferred_source: 'ai',
     render_method: 'static',
+    last_extracted_at: '2026-01-15T19:30:00Z',
     events_expected: 0,
     consecutive_failures: 0,
     strategy_locked: false,
     auto_approve: false,
-    total_runs: 0,
+    total_runs: 1,
+    last_run: runFixture,
   }
-  return { mockResetMutate, mocks, venueFixture }
+  const importFixture: ImportHistoryEntry = {
+    id: 99,
+    venue_id: 42,
+    venue_name: 'The Rebel Lounge',
+    venue_slug: 'the-rebel-lounge',
+    source_type: 'ai',
+    run_at: '2026-01-15T19:30:00Z',
+    events_extracted: 12,
+    events_imported: 10,
+    duration_ms: 4200,
+  }
+  return { mockResetMutate, mocks, venueFixture, runFixture, importFixture }
 })
 
 vi.mock('@/lib/hooks/usePipeline', () => ({
@@ -43,11 +72,11 @@ vi.mock('@/lib/hooks/usePipeline', () => ({
   }),
   useVenueRejectionStats: () => ({ data: null, isLoading: false }),
   useVenueExtractionRuns: () => ({
-    data: { runs: [], total: 0 },
+    data: { runs: [runFixture], total: 1 },
     isLoading: false,
   }),
   useImportHistory: () => ({
-    data: { imports: [], total: 0 },
+    data: { imports: [importFixture], total: 1 },
     isLoading: false,
     error: null,
   }),
@@ -147,5 +176,42 @@ describe('PipelineVenues — resetRenderMethod error banner', () => {
     expect(screen.queryByTestId('reset-render-method-error')).not.toBeInTheDocument()
 
     confirmSpy.mockRestore()
+  })
+})
+
+describe('PipelineVenues — explicit-locale timestamp formatting', () => {
+  // Timestamps must render through the canonical explicit-locale formatters
+  // (formatShortDate / formatTimestamp), not bare toLocaleString() whose output
+  // drifts with the viewer's browser/OS locale. Asserting against the helper's
+  // own output keeps these stable across ICU versions while still proving the
+  // component delegates to the canonical formatter rather than inlining a call.
+  const ISO = '2026-01-15T19:30:00Z'
+
+  it('renders the venue Last Run date via formatShortDate (date only, no time)', () => {
+    render(<PipelineVenues />)
+    const expected = formatShortDate(ISO)
+    expect(screen.getByText(`12 events, ${expected}`)).toBeInTheDocument()
+    expect(expected).not.toMatch(/\d{1,2}:\d{2}/)
+  })
+
+  it('renders the Last extracted date in the venue detail panel via formatShortDate', async () => {
+    const user = userEvent.setup()
+    render(<PipelineVenues />)
+    await user.click(screen.getByText('The Rebel Lounge'))
+
+    expect(screen.getByText('Last extracted:')).toBeInTheDocument()
+    // formatShortDate output appears in both the table row and the detail panel.
+    const expected = formatShortDate(ISO)
+    expect(screen.getAllByText(expected, { exact: false }).length).toBeGreaterThan(0)
+  })
+
+  it('renders Import History timestamps via formatTimestamp (date + time)', async () => {
+    const user = userEvent.setup()
+    render(<PipelineVenues />)
+    await user.click(screen.getByRole('button', { name: 'Import History' }))
+
+    const expected = formatTimestamp(ISO)
+    expect(screen.getByText(expected)).toBeInTheDocument()
+    expect(expected).toMatch(/\d{1,2}:\d{2}/)
   })
 })

--- a/frontend/components/admin/PipelineVenues.tsx
+++ b/frontend/components/admin/PipelineVenues.tsx
@@ -16,6 +16,7 @@ import {
 import { useVenueSearch } from '@/features/venues'
 import { Switch } from '@/components/ui/switch'
 import { InlineErrorBanner } from '@/components/shared'
+import { formatShortDate, formatTimestamp } from '@/lib/utils/formatters'
 
 function ApprovalBadge({ rate }: { rate?: number }) {
   if (rate === undefined || rate === null) {
@@ -70,7 +71,7 @@ function RunHistorySection({ venueId }: { venueId: number }) {
                   {data.runs.map((run: VenueExtractionRun) => (
                     <tr key={run.id}>
                       <td className="p-2 text-muted-foreground">
-                        {new Date(run.run_at || run.created_at).toLocaleString()}
+                        {formatTimestamp(run.run_at || run.created_at)}
                       </td>
                       <td className="p-2 text-muted-foreground">{run.render_method ?? '—'}</td>
                       <td className="p-2 text-center">{run.events_extracted}</td>
@@ -420,7 +421,7 @@ function VenueDetailPanel({
             <div>
               <span className="text-muted-foreground">Last extracted:</span>{' '}
               {venue.last_extracted_at
-                ? new Date(venue.last_extracted_at).toLocaleDateString()
+                ? formatShortDate(venue.last_extracted_at)
                 : 'Never'}
             </div>
             <div>
@@ -616,7 +617,7 @@ function ImportHistorySection() {
             {imports.map((entry: ImportHistoryEntry) => (
               <tr key={entry.id}>
                 <td className="p-3 text-muted-foreground text-xs">
-                  {new Date(entry.run_at).toLocaleString()}
+                  {formatTimestamp(entry.run_at)}
                 </td>
                 <td className="p-3">
                   <span className="font-medium">{entry.venue_name}</span>
@@ -790,7 +791,7 @@ export function PipelineVenues() {
                     </td>
                     <td className="p-3 text-muted-foreground text-xs">
                       {venue.last_run
-                        ? `${venue.last_run.events_extracted} events, ${new Date(venue.last_run.created_at).toLocaleDateString()}`
+                        ? `${venue.last_run.events_extracted} events, ${formatShortDate(venue.last_run.created_at)}`
                         : 'Never'}
                     </td>
                     <td className="p-3 text-center">


### PR DESCRIPTION
## Summary
- `PipelineVenues.tsx` rendered timestamps via bare `toLocaleString()` / `toLocaleDateString()` with no locale argument, so each admin saw a different format for the same data depending on browser/OS locale.
- Routed all four sites through the canonical `formatShortDate` / `formatTimestamp` helpers in `lib/utils/formatters.ts` (already the convention elsewhere in the admin surface, e.g. `RejectedShowCard.tsx`), giving stable `en-US` output.
  - Run history (`RunHistorySection`) → `formatTimestamp` (date + time)
  - Detail panel "Last extracted" (`VenueDetailPanel`) → `formatShortDate` (date)
  - Import History (`ImportHistorySection`) → `formatTimestamp` (date + time)
  - Venue table "Last Run" (`PipelineVenues`) → `formatShortDate` (date)
- Extended `PipelineVenues.test.tsx` (from PSY-730) with a regression block asserting each surface delegates to the canonical formatter (stable across ICU versions by comparing to the helper's own output).

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run test:run components/admin` — 137 passed (6 in `PipelineVenues.test.tsx`: 3 prior + 3 new)

## Manual repro
Brought up an isolated dispatch stack (`stack-up.sh --mode=shared` auto-escalated to isolated; no dev backend on :8080), seeded one `venue_source_configs` + one `venue_extraction_runs` row, logged in as the seeded admin, and walked the Data Pipeline tab. Confirmed all four surfaces render consistent `en-US` format:
- Venue table "Last Run": `12 events, Jan 15, 2026`
- Detail panel "Last extracted": `Jan 15, 2026`
- Extraction Run History: `Jan 15, 2026, 12:30 PM`
- Import History "Date": `Jan 15, 2026, 12:30 PM`

Screenshots captured; stack torn down (`stack-down.sh`), seed rows lived only in the ephemeral postgres container.

## Simplify
Ran the `/simplify` review directly (sub-agent context — no nested Agent calls). Production change is pure reuse of the existing canonical formatters, no new utility. Cleanup: stripped a `PSY-` ticket ref and trimmed WHAT-narration comments from the new test block per project convention; kept the load-bearing WHY (locale-drift + ICU-stability rationale). Re-ran typecheck + tests green after the edit.

Closes PSY-736