### PR TITLE
PSY-737: robust markdown-to-plain-text excerpt util

### DIFF
--- a/frontend/app/blog/page.tsx
+++ b/frontend/app/blog/page.tsx
@@ -3,6 +3,7 @@ import { getBlogSlugs, getBlogPost, MDXContent } from '@/features/blog'
 import { JsonLd } from '@/components/seo/JsonLd'
 import { generateItemListSchema, generateBreadcrumbSchema } from '@/lib/seo/jsonld'
 import { formatContentDate } from '@/lib/utils/formatters'
+import { getTextExcerpt } from '@/lib/utils/markdownExcerpt'
 
 export const metadata = {
   title: 'Blog',
@@ -16,26 +17,6 @@ export const metadata = {
     url: '/blog',
     type: 'website',
   },
-}
-
-/**
- * Extract a text-only summary from MDX content (for the excerpt after embed)
- */
-function getTextExcerpt(content: string, maxLength = 200): string {
-  // Remove MDX/JSX components
-  let text = content.replace(/<[^>]+\/>/g, '')
-  text = text.replace(/<[^>]+>[^<]*<\/[^>]+>/g, '')
-  // Remove markdown links but keep text
-  text = text.replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
-  // Remove markdown formatting
-  text = text.replace(/[#*_`]/g, '')
-  // Remove extra whitespace
-  text = text.replace(/\s+/g, ' ').trim()
-  // Truncate
-  if (text.length > maxLength) {
-    text = text.substring(0, maxLength).trim() + '...'
-  }
-  return text
 }
 
 /**

--- a/frontend/app/categories/[category]/page.tsx
+++ b/frontend/app/categories/[category]/page.tsx
@@ -10,6 +10,7 @@ import {
 import { JsonLd } from '@/components/seo/JsonLd'
 import { generateBreadcrumbSchema } from '@/lib/seo/jsonld'
 import { formatContentDate } from '@/lib/utils/formatters'
+import { getTextExcerpt } from '@/lib/utils/markdownExcerpt'
 
 interface CategoryPageProps {
   params: Promise<{ category: string }>
@@ -44,21 +45,6 @@ export async function generateMetadata({ params }: CategoryPageProps) {
       type: 'website',
     },
   }
-}
-
-/**
- * Extract a text-only summary from MDX content
- */
-function getTextExcerpt(content: string, maxLength = 200): string {
-  let text = content.replace(/<[^>]+\/>/g, '')
-  text = text.replace(/<[^>]+>[^<]*<\/[^>]+>/g, '')
-  text = text.replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
-  text = text.replace(/[#*_`]/g, '')
-  text = text.replace(/\s+/g, ' ').trim()
-  if (text.length > maxLength) {
-    text = text.substring(0, maxLength).trim() + '...'
-  }
-  return text
 }
 
 /**

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -4,6 +4,7 @@ import { getBlogSlugs, getBlogPost, getAllMixes, MDXContent, SoundCloud } from '
 import { JsonLd } from '@/components/seo/JsonLd'
 import { generateWebSiteSchema } from '@/lib/seo/jsonld'
 import { formatContentDate } from '@/lib/utils/formatters'
+import { getTextExcerpt } from '@/lib/utils/markdownExcerpt'
 
 export const metadata = {
   title: 'Psychic Homily | Arizona Music Community',
@@ -26,21 +27,6 @@ export const metadata = {
 function extractEmbed(content: string): string | null {
   const embedMatch = content.match(/<(Bandcamp|SoundCloud)[^>]+\/>/)
   return embedMatch ? embedMatch[0] : null
-}
-
-/**
- * Get text excerpt
- */
-function getTextExcerpt(content: string, maxLength = 200): string {
-  let text = content.replace(/<[^>]+\/>/g, '')
-  text = text.replace(/<[^>]+>[^<]*<\/[^>]+>/g, '')
-  text = text.replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
-  text = text.replace(/[#*_`]/g, '')
-  text = text.replace(/\s+/g, ' ').trim()
-  if (text.length > maxLength) {
-    text = text.substring(0, maxLength).trim() + '...'
-  }
-  return text
 }
 
 export default function Home() {

--- a/frontend/features/blog/utils/blog.ts
+++ b/frontend/features/blog/utils/blog.ts
@@ -2,6 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import matter from 'gray-matter'
 import * as Sentry from '@sentry/nextjs'
+import { getTextExcerpt } from '@/lib/utils/markdownExcerpt'
 import type { BlogPost, BlogPostMeta, BlogPostFrontmatter } from '../types'
 
 // Path to blog content (inside frontend directory)
@@ -54,23 +55,6 @@ function convertShortcodesToMDX(content: string): string {
 }
 
 /**
- * Extract a plain text excerpt from markdown content
- */
-function extractExcerpt(content: string, maxLength = 200): string {
-  // Remove MDX components
-  let text = content.replace(/<[^>]+\/>/g, '')
-  // Remove markdown formatting
-  text = text.replace(/[#*_`\[\]]/g, '')
-  // Remove extra whitespace
-  text = text.replace(/\s+/g, ' ').trim()
-  // Truncate
-  if (text.length > maxLength) {
-    text = text.substring(0, maxLength).trim() + '...'
-  }
-  return text
-}
-
-/**
  * Get a single blog post by slug
  */
 export function getBlogPost(slug: string): BlogPost | null {
@@ -91,7 +75,7 @@ export function getBlogPost(slug: string): BlogPost | null {
       slug,
       frontmatter,
       content: mdxContent,
-      excerpt: extractExcerpt(content),
+      excerpt: getTextExcerpt(content),
     }
   } catch (error) {
     Sentry.captureException(error, {

--- a/frontend/lib/utils/markdownExcerpt.test.ts
+++ b/frontend/lib/utils/markdownExcerpt.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest'
+import { markdownToPlainText, getTextExcerpt } from './markdownExcerpt'
+
+describe('markdownToPlainText', () => {
+  it('returns empty string for empty/whitespace input', () => {
+    expect(markdownToPlainText('')).toBe('')
+    expect(markdownToPlainText('   \n  ')).toBe('')
+  })
+
+  it('strips inline emphasis and code markers', () => {
+    expect(markdownToPlainText('This is **bold** and _italic_ text.')).toBe(
+      'This is bold and italic text.'
+    )
+    expect(markdownToPlainText('Run `npm install` first.')).toBe(
+      'Run npm install first.'
+    )
+  })
+
+  it('flattens deeply nested markdown to plain text', () => {
+    expect(
+      markdownToPlainText('This is **bold with _nested italic_ and `code`** here.')
+    ).toBe('This is bold with nested italic and code here.')
+  })
+
+  it('keeps link text but drops the URL and bracket syntax', () => {
+    expect(
+      markdownToPlainText('See [the docs](https://example.com/path?q=1) now.')
+    ).toBe('See the docs now.')
+  })
+
+  it('strips MDX/JSX embed components such as <Bandcamp .../>', () => {
+    const content =
+      '<Bandcamp album="123" artist="x" title="y" />\n\n[Winter](https://example.com) and Hooky have a new EP called _Water Season_ out now.'
+    expect(markdownToPlainText(content)).toBe(
+      'Winter and Hooky have a new EP called Water Season out now.'
+    )
+  })
+
+  it('strips inline HTML tags but preserves the inner text', () => {
+    expect(
+      markdownToPlainText('Some <strong>raw HTML</strong> and <a href="x">a link</a> in text.')
+    ).toBe('Some raw HTML and a link in text.')
+  })
+
+  it('drops block-level HTML', () => {
+    expect(
+      markdownToPlainText('<div class="x">block html</div>\n\nReal paragraph.')
+    ).toBe('Real paragraph.')
+  })
+
+  it('decodes named HTML entities', () => {
+    expect(
+      markdownToPlainText('Tom &amp; Jerry &lt;3 &quot;quotes&quot; and AT&amp;T.')
+    ).toBe('Tom & Jerry <3 "quotes" and AT&T.')
+  })
+
+  it('decodes numeric and hex HTML entities', () => {
+    expect(markdownToPlainText('Caf&#233; &#x2014; end.')).toBe('Café — end.')
+  })
+
+  it('leaves unknown entities untouched', () => {
+    expect(markdownToPlainText('Keep &unknownentity; intact.')).toBe(
+      'Keep &unknownentity; intact.'
+    )
+  })
+
+  it('preserves backslash-escaped markdown characters as literals', () => {
+    expect(
+      markdownToPlainText('Literal \\*asterisks\\* and \\#hash should stay.')
+    ).toBe('Literal *asterisks* and #hash should stay.')
+  })
+
+  it('separates block-level content with a single space', () => {
+    expect(markdownToPlainText('# Title\nBody paragraph here.')).toBe(
+      'Title Body paragraph here.'
+    )
+    expect(markdownToPlainText('> Quoted **wisdom**.\n\nFollow-up.')).toBe(
+      'Quoted wisdom. Follow-up.'
+    )
+  })
+
+  it('separates list items so they do not fuse together', () => {
+    expect(markdownToPlainText('- one\n- two\n- three')).toBe('one two three')
+  })
+
+  it('collapses runs of whitespace into single spaces', () => {
+    expect(markdownToPlainText('a\t\t\tb     c\nd')).toBe('a b c d')
+  })
+})
+
+describe('getTextExcerpt', () => {
+  it('returns the full plain text when under the limit', () => {
+    expect(getTextExcerpt('Short **post**.', 200)).toBe('Short post.')
+  })
+
+  it('truncates and appends an ellipsis when over the limit', () => {
+    const long = 'word '.repeat(100)
+    const result = getTextExcerpt(long, 50)
+    expect(result.endsWith('...')).toBe(true)
+    // 50-char slice, trailing space trimmed, then '...' appended.
+    expect(result.length).toBeLessThanOrEqual(53)
+    expect(result.startsWith('word word')).toBe(true)
+  })
+
+  it('does not append an ellipsis when text length equals the limit', () => {
+    const text = 'a'.repeat(10)
+    expect(getTextExcerpt(text, 10)).toBe(text)
+  })
+
+  it('defaults to a 200-character limit', () => {
+    const long = 'x'.repeat(500)
+    const result = getTextExcerpt(long)
+    expect(result.length).toBe(203) // 200 chars + '...'
+  })
+
+  it('truncates against the plain text, not the raw markdown length', () => {
+    // 60 chars of link markdown collapse to 8 chars of visible text ("the docs"),
+    // which is under the limit — so no truncation despite long raw source.
+    const content = '[the docs](https://example.com/a/very/long/url/that/keeps/going)'
+    expect(getTextExcerpt(content, 20)).toBe('the docs')
+  })
+
+  it('returns empty string for empty input', () => {
+    expect(getTextExcerpt('', 100)).toBe('')
+  })
+})

--- a/frontend/lib/utils/markdownExcerpt.ts
+++ b/frontend/lib/utils/markdownExcerpt.ts
@@ -1,0 +1,170 @@
+import { lexer, type Token } from 'marked'
+
+const DEFAULT_MAX_LENGTH = 200
+const ELLIPSIS = '...'
+
+/**
+ * Top-level token types that introduce a block-level boundary. When we flatten
+ * the markdown into a single line, the text on either side of one of these must
+ * not run together (e.g. a heading immediately followed by a paragraph), so we
+ * emit a separating space. (List items are separated inside the `list` branch,
+ * since marked never emits a bare top-level `list_item`.)
+ */
+const BLOCK_BOUNDARY_TYPES = new Set([
+  'paragraph',
+  'heading',
+  'blockquote',
+  'list',
+  'code',
+  'space',
+  'br',
+  'hr',
+])
+
+/**
+ * Named HTML entities markdown processors emit (the inverse of marked's own
+ * escape table). marked's lexer leaves these encoded in text tokens — decoding
+ * only happens at render time — so we decode them here. `&#39;` is handled by
+ * the numeric branch of `decodeEntities`, so it is intentionally absent.
+ */
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+  nbsp: ' ',
+}
+
+/**
+ * Decode the bounded set of HTML entities that can appear in lexer text
+ * tokens: the named entities markdown emits, plus the fully general numeric
+ * forms (`&#160;` / `&#xA0;`). Anything outside this set is left untouched —
+ * this is intentionally not a full named-entity table, because that input
+ * space does not occur in the markdown/MDX content this util processes.
+ */
+function decodeEntities(text: string): string {
+  if (!text.includes('&')) return text
+  return text.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z][a-zA-Z0-9]*);/g, (match, body) => {
+    if (body[0] === '#') {
+      const codePoint =
+        body[1] === 'x' || body[1] === 'X'
+          ? parseInt(body.slice(2), 16)
+          : parseInt(body.slice(1), 10)
+      if (Number.isNaN(codePoint)) return match
+      try {
+        return String.fromCodePoint(codePoint)
+      } catch {
+        return match
+      }
+    }
+    const named = NAMED_ENTITIES[body]
+    return named ?? match
+  })
+}
+
+/**
+ * Collect the human-readable text out of a single marked token, recursing into
+ * child tokens where present.
+ *
+ * Why walk tokens instead of reading `token.text`? For container tokens
+ * (paragraph, heading, strong, em, link, …) `token.text` is the *raw markdown
+ * source* of their contents, which still includes link syntax, emphasis
+ * markers, and HTML. The child `tokens` array is the already-parsed inner
+ * content, so recursing yields true plain text. Leaf tokens (codespan, fenced
+ * code, escape, and text without children) carry decoded text directly —
+ * marked has already turned `&amp;` into `&` and `\*` into `*` for us.
+ */
+function collectText(token: Token, out: string[]): void {
+  switch (token.type) {
+    // Inline + block HTML (including self-closing MDX/JSX components such as
+    // <Bandcamp .../>): drop the tag entirely. Any human-readable text that
+    // sits between HTML tags is parsed into its own sibling text tokens, so
+    // dropping the tag here strips markup without swallowing prose.
+    case 'html':
+    case 'image':
+    case 'def':
+    case 'br':
+    case 'hr':
+    case 'space':
+      break
+
+    // Leaf tokens whose text we keep. Escaped sequences (\* \#) and code spans
+    // are literal already; entity decoding turns &amp; into & for prose.
+    case 'codespan':
+    case 'escape':
+    case 'code':
+      out.push(decodeEntities(token.text))
+      break
+
+    // `text` tokens are leaves *unless* they were re-tokenized (e.g. inside a
+    // loose list item), in which case the children hold the real content.
+    case 'text':
+      if ('tokens' in token && token.tokens && token.tokens.length > 0) {
+        for (const child of token.tokens) collectText(child, out)
+      } else {
+        out.push(decodeEntities(token.text))
+      }
+      break
+
+    // List is a container of list items; separate each item so adjacent items
+    // don't fuse into one word once whitespace is collapsed.
+    case 'list':
+      for (const item of token.items) {
+        const before = out.length
+        collectText(item, out)
+        if (out.length > before) out.push(' ')
+      }
+      break
+
+    // Container tokens: recurse into the parsed inner content.
+    default:
+      if ('tokens' in token && token.tokens) {
+        for (const child of token.tokens) collectText(child, out)
+      }
+      break
+  }
+}
+
+/**
+ * Convert a markdown (or MDX) string into a single line of plain text.
+ *
+ * Markdown formatting, links, inline/block HTML, and self-closing JSX embeds
+ * are stripped; encoded entities are decoded; whitespace is collapsed. Use this
+ * for excerpts, meta descriptions, or anywhere markdown source would otherwise
+ * leak into a plain-text context.
+ */
+export function markdownToPlainText(markdown: string): string {
+  if (!markdown) return ''
+
+  const tokens = lexer(markdown)
+  const parts: string[] = []
+
+  for (const token of tokens) {
+    const before = parts.length
+    collectText(token, parts)
+    // Insert a separator after a block-level token so its text doesn't fuse
+    // with the next block's text once whitespace is collapsed.
+    if (parts.length > before && BLOCK_BOUNDARY_TYPES.has(token.type)) {
+      parts.push(' ')
+    }
+  }
+
+  return parts.join('').replace(/\s+/g, ' ').trim()
+}
+
+/**
+ * Produce a plain-text excerpt from markdown/MDX content, truncated to
+ * `maxLength` characters with a trailing ellipsis when truncation occurs.
+ *
+ * Truncation is measured against the rendered plain text, not the raw markdown,
+ * so link/HTML syntax never inflates or leaks into the excerpt length.
+ */
+export function getTextExcerpt(
+  content: string,
+  maxLength = DEFAULT_MAX_LENGTH
+): string {
+  const text = markdownToPlainText(content)
+  if (text.length <= maxLength) return text
+  return text.slice(0, maxLength).trim() + ELLIPSIS
+}


### PR DESCRIPTION
## Summary
- The home, blog-listing, and category pages each duplicated a regex-based `getTextExcerpt` that stripped markdown by hand. It worked for current content but broke on nested markdown, inline HTML, and encoded entities — risking raw markdown leaking into first-visitor excerpts and SEO meta descriptions.
- Added shared `frontend/lib/utils/markdownExcerpt.ts`: tokenizes with `marked` (already a dep) and walks the token tree to collect true plain text. Links/emphasis/HTML tags and self-closing JSX embeds (`<Bandcamp .../>`, `<SoundCloud .../>`) are stripped; HTML entities are decoded; truncation is measured against the rendered text (not raw markdown).
- Migrated all four prior copies to the shared util — the three page components plus the SEO-excerpt builder in `features/blog/utils/blog.ts` (which feeds the `<title>`/`og:description` on `app/blog/[slug]/page.tsx`).

## Test plan
- [x] `bun run typecheck` clean.
- [x] `bun run test:run lib/utils app` — 372 passing (20 new in `markdownExcerpt.test.ts`).
- [x] `bun run test:run features/blog` — 59 passing (blog excerpt assertions still hold post-migration).
- [x] New unit tests cover: nested markdown, inline + block HTML, named/numeric/hex entity decoding, unknown-entity passthrough, escaped-char literals, MDX embed stripping, block + list-item separation, whitespace collapse, and truncation length/ellipsis (including raw-vs-rendered length).

## Manual repro
- `scripts/dispatch/stack-up.sh "$(git rev-parse --show-toplevel)" --mode=shared` (auto-escalated to isolated). Loaded `/` and `/blog`.
- Confirmed the link-heavy "Water Season by Winter and Hooky" post renders as clean plain text — the `[Winter](url)`/`[Hooky](url)` markdown links flatten to "Winter"/"Hooky", `_Water Season_` italics and the `<Bandcamp .../>` embed are gone. No `[text](url)`, `**`, or `<strong>` leakage in any excerpt region (verified via SSR HTML grep + screenshots). `stack-down` after.

## Simplify
- Ran `/simplify` (reviewed inline — Agent/Task spawning is unavailable in this dispatched context). Fixes: stripped the `PSY-737` ref from a doc comment (per repo convention), removed a dead `'#39'` named-entity entry (the numeric branch already decodes `&#39;`), and removed a dead `'list_item'` from the block-boundary set (marked never emits a bare top-level `list_item`; items are separated in the `list` branch). Typecheck + tests re-run green after.

Closes PSY-737