### PR TITLE
PSY-753: fix attendance XOR violation + pagination drift

### DIFF
--- a/backend/internal/services/engagement/attendance.go
+++ b/backend/internal/services/engagement/attendance.go
@@ -318,9 +318,8 @@ func (s *AttendanceService) GetUserAttendingShows(userID uint, status string, li
 		return []*contracts.AttendingShowResponse{}, total, nil
 	}
 
-	// Fetch the full row (incl. first venue) for the paged shows. Multiple
-	// rows per show are expected for multi-venue shows; dedup below keeps the
-	// first venue. Same ordering so the dedup loop emits shows in page order.
+	// Fetch the full row (incl. venue) for the paged shows. Same ordering so
+	// the dedup loop below emits shows in page order.
 	type attendingRow struct {
 		ShowID    uint
 		Title     string

--- a/backend/internal/services/engagement/attendance.go
+++ b/backend/internal/services/engagement/attendance.go
@@ -63,11 +63,18 @@ func (s *AttendanceService) SetAttendance(userID, showID uint, status string) er
 	}
 
 	return s.db.Transaction(func(tx *gorm.DB) error {
-		// Remove the opposite status (if any) — ignore "not found"
-		tx.Where(
+		// Remove the opposite status (if any). A no-row match is a no-op
+		// (GORM returns nil error + RowsAffected=0). A real error (lock
+		// timeout, FK trigger, dropped conn) must roll back the whole
+		// transaction — otherwise the upsert below leaves the user with
+		// BOTH going AND interested rows, violating the going-XOR-interested
+		// invariant and double-counting in GetAttendanceCounts.
+		if result := tx.Where(
 			"user_id = ? AND entity_type = ? AND entity_id = ? AND action = ?",
 			userID, engagementm.BookmarkEntityShow, showID, removeAction,
-		).Delete(&engagementm.UserBookmark{})
+		).Delete(&engagementm.UserBookmark{}); result.Error != nil {
+			return fmt.Errorf("failed to remove opposite attendance: %w", result.Error)
+		}
 
 		// Upsert the desired status
 		bookmark := engagementm.UserBookmark{
@@ -285,7 +292,35 @@ func (s *AttendanceService) GetUserAttendingShows(userID uint, status string, li
 		return []*contracts.AttendingShowResponse{}, 0, nil
 	}
 
-	// Query bookmarks joined with shows and first venue
+	// Page on DISTINCT show IDs first, BEFORE joining venues. The data query
+	// below LEFT-JOINs show_venues+venues, so a multi-venue show fans out into
+	// multiple rows. Applying LIMIT/OFFSET to that fanned-out stream would pull
+	// fewer than N distinct shows per page (page drift). Pluck the distinct
+	// page of show IDs here so a page always yields exactly N shows.
+	// Order by (event_date, id) so the tie-break is deterministic and pages
+	// partition cleanly (no show appears on two pages, none is skipped).
+	var showIDs []uint
+	err = s.db.Model(&engagementm.UserBookmark{}).
+		Select("shows.id").
+		Joins("JOIN shows ON shows.id = user_bookmarks.entity_id").
+		Where("user_bookmarks.user_id = ? AND user_bookmarks.entity_type = ? AND user_bookmarks.action IN ?",
+			userID, engagementm.BookmarkEntityShow, actions).
+		Where("shows.status = ? AND shows.event_date >= ?", catalogm.ShowStatusApproved, now).
+		Order("shows.event_date ASC, shows.id ASC").
+		Limit(limit).
+		Offset(offset).
+		Pluck("shows.id", &showIDs).Error
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to page attending show ids: %w", err)
+	}
+
+	if len(showIDs) == 0 {
+		return []*contracts.AttendingShowResponse{}, total, nil
+	}
+
+	// Fetch the full row (incl. first venue) for the paged shows. Multiple
+	// rows per show are expected for multi-venue shows; dedup below keeps the
+	// first venue. Same ordering so the dedup loop emits shows in page order.
 	type attendingRow struct {
 		ShowID    uint
 		Title     string
@@ -318,9 +353,8 @@ func (s *AttendanceService) GetUserAttendingShows(userID uint, status string, li
 		Where("user_bookmarks.user_id = ? AND user_bookmarks.entity_type = ? AND user_bookmarks.action IN ?",
 			userID, engagementm.BookmarkEntityShow, actions).
 		Where("shows.status = ? AND shows.event_date >= ?", catalogm.ShowStatusApproved, now).
-		Order("shows.event_date ASC").
-		Limit(limit).
-		Offset(offset).
+		Where("shows.id IN ?", showIDs).
+		Order("shows.event_date ASC, shows.id ASC").
 		Find(&rows).Error
 
 	if err != nil {
@@ -330,7 +364,7 @@ func (s *AttendanceService) GetUserAttendingShows(userID uint, status string, li
 	// Deduplicate rows by show ID (a show may have multiple venues)
 	// Keep the first venue encountered for each show
 	seen := make(map[uint]bool)
-	responses := make([]*contracts.AttendingShowResponse, 0, len(rows))
+	responses := make([]*contracts.AttendingShowResponse, 0, len(showIDs))
 	for _, row := range rows {
 		if seen[row.ShowID] {
 			continue

--- a/backend/internal/services/engagement/attendance_test.go
+++ b/backend/internal/services/engagement/attendance_test.go
@@ -264,9 +264,8 @@ func (suite *AttendanceServiceIntegrationTestSuite) TestSetAttendance_OppositeDe
 	suite.Require().Error(setErr)
 	suite.Contains(setErr.Error(), "failed to remove opposite attendance")
 
-	// Verification reads are SELECTs, so the DELETE callback does not affect
-	// them; it is removed in the deferred cleanup above.
 	// State unchanged: still exactly the original going row, no interested row.
+	// (These reads are SELECTs, so the registered DELETE-fail callback is inert.)
 	var goingCount, interestedCount int64
 	suite.db.Model(&engagementm.UserBookmark{}).
 		Where("user_id = ? AND entity_type = ? AND entity_id = ? AND action = ?",

--- a/backend/internal/services/engagement/attendance_test.go
+++ b/backend/internal/services/engagement/attendance_test.go
@@ -11,6 +11,7 @@ import (
 	authm "psychic-homily-backend/internal/models/auth"
 	catalogm "psychic-homily-backend/internal/models/catalog"
 	engagementm "psychic-homily-backend/internal/models/engagement"
+	"psychic-homily-backend/internal/services/contracts"
 	"psychic-homily-backend/internal/testutil"
 )
 
@@ -111,6 +112,23 @@ func (suite *AttendanceServiceIntegrationTestSuite) createShowWithVenue(title st
 	return show, venue
 }
 
+// createShowWithVenues creates an approved upcoming show linked to venueCount
+// distinct venues via show_venues. Used to reproduce pagination drift, where a
+// multi-venue show fans out into multiple joined rows.
+func (suite *AttendanceServiceIntegrationTestSuite) createShowWithVenues(title string, userID uint, venueCount int) *catalogm.Show {
+	show := suite.createApprovedShow(title, userID)
+	for v := 0; v < venueCount; v++ {
+		venue := &catalogm.Venue{
+			Name:  fmt.Sprintf("%s venue %d", title, v),
+			City:  "Phoenix",
+			State: "AZ",
+		}
+		suite.Require().NoError(suite.db.Create(venue).Error)
+		suite.Require().NoError(suite.db.Create(&catalogm.ShowVenue{ShowID: show.ID, VenueID: venue.ID}).Error)
+	}
+	return show
+}
+
 // =============================================================================
 // Group 1: SetAttendance
 // =============================================================================
@@ -194,6 +212,72 @@ func (suite *AttendanceServiceIntegrationTestSuite) TestSetAttendance_ToggleInte
 			user.ID, engagementm.BookmarkEntityShow, show.ID, engagementm.BookmarkActionGoing).
 		Count(&goingCount)
 	suite.Equal(int64(1), goingCount)
+}
+
+// TestSetAttendance_ToggleLeavesExactlyOneRow asserts the going-XOR-interested
+// invariant directly: after toggling going → interested, the user has exactly
+// ONE attendance row for the show (not one of each). Guards GetAttendanceCounts
+// against double-counting.
+func (suite *AttendanceServiceIntegrationTestSuite) TestSetAttendance_ToggleLeavesExactlyOneRow() {
+	user := suite.createTestUser()
+	show := suite.createApprovedShow("XOR Toggle Show", user.ID)
+
+	suite.Require().NoError(suite.attendanceService.SetAttendance(user.ID, show.ID, "going"))
+	suite.Require().NoError(suite.attendanceService.SetAttendance(user.ID, show.ID, "interested"))
+
+	var total int64
+	suite.db.Model(&engagementm.UserBookmark{}).
+		Where("user_id = ? AND entity_type = ? AND entity_id = ? AND action IN ?",
+			user.ID, engagementm.BookmarkEntityShow, show.ID,
+			[]engagementm.BookmarkAction{engagementm.BookmarkActionGoing, engagementm.BookmarkActionInterested}).
+		Count(&total)
+	suite.Equal(int64(1), total, "user must have exactly one attendance row after a toggle")
+}
+
+// TestSetAttendance_OppositeDeleteErrorRollsBack asserts the transaction rolls
+// back when the opposite-status DELETE fails. Before the fix the DELETE error
+// was discarded, so the upsert still ran and the user ended with BOTH going and
+// interested rows. A failing Delete callback simulates a lock timeout / FK
+// trigger / dropped connection on that statement.
+func (suite *AttendanceServiceIntegrationTestSuite) TestSetAttendance_OppositeDeleteErrorRollsBack() {
+	user := suite.createTestUser()
+	show := suite.createApprovedShow("Delete Error Show", user.ID)
+
+	// Seed the opposite status so the toggle has a row to delete.
+	suite.Require().NoError(suite.attendanceService.SetAttendance(user.ID, show.ID, "going"))
+
+	// Inject a DELETE failure scoped to user_bookmarks. Callbacks live on the
+	// shared connection processor, so remove it after the test for isolation.
+	const cbName = "test:fail_user_bookmarks_delete"
+	err := suite.db.Callback().Delete().Before("gorm:delete").Register(cbName, func(tx *gorm.DB) {
+		if tx.Statement != nil && tx.Statement.Table == "user_bookmarks" {
+			_ = tx.AddError(fmt.Errorf("simulated delete failure"))
+		}
+	})
+	suite.Require().NoError(err)
+	defer func() {
+		suite.Require().NoError(suite.db.Callback().Delete().Remove(cbName))
+	}()
+
+	// Toggling to interested must trigger the opposite (going) DELETE and fail.
+	setErr := suite.attendanceService.SetAttendance(user.ID, show.ID, "interested")
+	suite.Require().Error(setErr)
+	suite.Contains(setErr.Error(), "failed to remove opposite attendance")
+
+	// Verification reads are SELECTs, so the DELETE callback does not affect
+	// them; it is removed in the deferred cleanup above.
+	// State unchanged: still exactly the original going row, no interested row.
+	var goingCount, interestedCount int64
+	suite.db.Model(&engagementm.UserBookmark{}).
+		Where("user_id = ? AND entity_type = ? AND entity_id = ? AND action = ?",
+			user.ID, engagementm.BookmarkEntityShow, show.ID, engagementm.BookmarkActionGoing).
+		Count(&goingCount)
+	suite.db.Model(&engagementm.UserBookmark{}).
+		Where("user_id = ? AND entity_type = ? AND entity_id = ? AND action = ?",
+			user.ID, engagementm.BookmarkEntityShow, show.ID, engagementm.BookmarkActionInterested).
+		Count(&interestedCount)
+	suite.Equal(int64(1), goingCount, "original going row must survive the rolled-back toggle")
+	suite.Equal(int64(0), interestedCount, "interested row must not be created when DELETE fails")
 }
 
 func (suite *AttendanceServiceIntegrationTestSuite) TestSetAttendance_ClearWithEmptyString() {
@@ -530,6 +614,60 @@ func (suite *AttendanceServiceIntegrationTestSuite) TestGetUserAttendingShows_In
 	suite.Require().Len(shows, 1)
 	suite.Require().NotNil(shows[0].VenueName)
 	suite.Equal(venue.Name, *shows[0].VenueName)
+}
+
+// TestGetUserAttendingShows_PaginationWithMultiVenueShows reproduces the
+// pagination drift bug: 25 attending shows, 5 of which have 2 venues each.
+// Before the fix, LIMIT/OFFSET applied to the venue-joined row stream pulled
+// fewer than N distinct shows when multi-venue shows landed in a page. After
+// the fix, page 1 returns 20 distinct shows and page 2 returns the remaining
+// 5, with no show appearing on both pages.
+func (suite *AttendanceServiceIntegrationTestSuite) TestGetUserAttendingShows_PaginationWithMultiVenueShows() {
+	user := suite.createTestUser()
+
+	const totalShows = 25
+	const multiVenueShows = 5
+	for i := 0; i < totalShows; i++ {
+		var show *catalogm.Show
+		if i < multiVenueShows {
+			show = suite.createShowWithVenues(fmt.Sprintf("Multi Venue Show %02d", i), user.ID, 2)
+		} else {
+			show, _ = suite.createShowWithVenue(fmt.Sprintf("Single Venue Show %02d", i), user.ID)
+		}
+		suite.Require().NoError(suite.attendanceService.SetAttendance(user.ID, show.ID, "going"))
+	}
+
+	page1, total, err := suite.attendanceService.GetUserAttendingShows(user.ID, "all", 20, 0)
+	suite.Require().NoError(err)
+	suite.Equal(int64(totalShows), total)
+	suite.Require().Len(page1, 20, "page 1 must return 20 distinct shows despite multi-venue fan-out")
+	suite.assertDistinctShowIDs(page1)
+
+	page2, _, err := suite.attendanceService.GetUserAttendingShows(user.ID, "all", 20, 20)
+	suite.Require().NoError(err)
+	suite.Require().Len(page2, 5, "page 2 must return the remaining 5 distinct shows")
+	suite.assertDistinctShowIDs(page2)
+
+	// No show may appear on both pages.
+	page1IDs := make(map[uint]bool, len(page1))
+	for _, s := range page1 {
+		page1IDs[s.ShowID] = true
+	}
+	for _, s := range page2 {
+		suite.False(page1IDs[s.ShowID], "show %d appeared on both pages", s.ShowID)
+	}
+
+	// The two pages together cover all 25 distinct shows exactly once.
+	suite.Equal(totalShows, len(page1)+len(page2))
+}
+
+// assertDistinctShowIDs fails if any show ID repeats within a page.
+func (suite *AttendanceServiceIntegrationTestSuite) assertDistinctShowIDs(shows []*contracts.AttendingShowResponse) {
+	seen := make(map[uint]bool, len(shows))
+	for _, s := range shows {
+		suite.False(seen[s.ShowID], "duplicate show %d within a single page", s.ShowID)
+		seen[s.ShowID] = true
+	}
 }
 
 func (suite *AttendanceServiceIntegrationTestSuite) TestGetUserAttendingShows_Empty() {


### PR DESCRIPTION
## Summary
Two correctness bugs in `internal/services/engagement/attendance.go`:

- **Bug A (XOR violation):** `SetAttendance` discarded the opposite-status DELETE error inside the transaction. A failed DELETE (lock timeout, FK trigger, dropped conn) still let the upsert run, leaving the user with BOTH `going` and `interested` rows and double-counting in `GetAttendanceCounts`. Now the result error is checked and propagated so the transaction rolls back; the no-op-when-no-row semantic is preserved (GORM returns nil + `RowsAffected=0`).
- **Bug B (pagination drift):** `GetUserAttendingShows` applied `LIMIT/OFFSET` to a venue-joined row stream, then deduped shows in app code. A multi-venue show fanned out into multiple rows, so a page pulled fewer than N distinct shows. Now it pages on distinct, deterministically-ordered (`event_date, id`) show IDs first, then fetches venues only for that page.

## Test plan
- [x] `cd backend && go build ./...`
- [x] `cd backend && go test ./internal/services/engagement/...` (30/30 pass, incl. 3 new)
- [x] `cd backend && go test ./...` (full suite: 27 pkgs ok, 0 FAIL)

## Manual repro
The three new integration tests (real Postgres via testcontainers) ARE the repro:
- `TestSetAttendance_ToggleLeavesExactlyOneRow` — after going→interested toggle, asserts exactly 1 attendance row (not one of each).
- `TestSetAttendance_OppositeDeleteErrorRollsBack` — injects a `user_bookmarks` DELETE-fail GORM callback; asserts `SetAttendance` errors AND the original `going` row survives with no `interested` row created (transaction rolled back).
- `TestGetUserAttendingShows_PaginationWithMultiVenueShows` — seeds 25 attending shows incl. 5 two-venue shows; asserts page 1 = 20 distinct, page 2 = 5 distinct, no show on both pages, 25 total.

## Simplify
`/simplify` run before PR. Reuse: the two-query "page IDs then fetch by IN" pattern follows existing idiom (`filter_service.go`, `comment_notification.go`); the test callback-injection follows `discovery_test.go`'s `test:` callback convention. Only fix: trimmed two redundant comments (no logic change). Committed separately.

Closes PSY-753