### PR TITLE
PSY-770: widen audit_logs actor_id/entity_id to BIGINT

### DIFF
--- a/backend/db/migrations/20260520165203_widen_audit_logs_ids.down.sql
+++ b/backend/db/migrations/20260520165203_widen_audit_logs_ids.down.sql
@@ -1,0 +1,11 @@
+-- Revert the ID widening: restore the as-created INT column types from
+-- 000022_add_audit_logs.up.sql so the up->down->up round-trip lands back on
+-- the original schema. Narrowing BIGINT -> INT is safe here because the
+-- forward migration only widened the type without introducing out-of-range
+-- values.
+
+ALTER TABLE audit_logs
+    ALTER COLUMN entity_id TYPE INT;
+
+ALTER TABLE audit_logs
+    ALTER COLUMN actor_id TYPE INT;

--- a/backend/db/migrations/20260520165203_widen_audit_logs_ids.up.sql
+++ b/backend/db/migrations/20260520165203_widen_audit_logs_ids.up.sql
@@ -1,0 +1,18 @@
+-- Widen audit_logs.actor_id / entity_id from 32-bit INT to BIGINT.
+--
+-- Sibling fix to the entity_edit_audit_logs ID widening: audit_logs (created
+-- in 000022) still carries `actor_id INT` / `entity_id INT`, even though its
+-- `id` is BIGSERIAL and the Go model (models/admin/audit_log.go) types both
+-- columns as `uint` (64-bit on our platforms). Migration 000038 standardized
+-- only this table's created_at to TIMESTAMPTZ, not the ID widths, leaving a
+-- latent 2^31 overflow once entity ids exceed that range.
+--
+-- This is a metadata-only widening; INT -> BIGINT preserves all values. The
+-- actor_id FK to users(id) (still SERIAL/int4) stays valid because PostgreSQL
+-- compares int4 and int8 across a foreign-key boundary without issue.
+
+ALTER TABLE audit_logs
+    ALTER COLUMN actor_id TYPE BIGINT;
+
+ALTER TABLE audit_logs
+    ALTER COLUMN entity_id TYPE BIGINT;


### PR DESCRIPTION
## Summary
- Sibling fix to merged PSY-754. The `audit_logs` table (migration 000022) still typed `actor_id`/`entity_id` as 32-bit `INT` even though its `id` is `BIGSERIAL` and the Go model (`models/admin/audit_log.go`) already types both columns as `uint`. Migration 000038 standardized only this table's `created_at` to `TIMESTAMPTZ`, not the ID widths — leaving the same latent 2^31 overflow PSY-754 closed on `entity_edit_audit_logs`.
- New timestamp-versioned migration `20260520165203_widen_audit_logs_ids` widens both columns `INT -> BIGINT` (up) and reverses to `INT` (down). No model change (already `uint`); no app-code change.
- The `actor_id` FK to `users(id)` (still `SERIAL`/int4) stays valid — PostgreSQL compares int4/int8 across a foreign-key boundary.

## Test plan
- [x] `go build ./...` — passes
- [x] `go test ./internal/services/admin/...` — `ok` (18.1s)
- [x] `go test ./...` — full suite green (testcontainers runs every migration incl. the new one in a fresh schema)
- [x] Migration up->down->up round-trip (mirrors CI reversibility guard), verified with `migrate` v4.19.1 against the isolated dispatch Postgres

## Manual repro
Isolated dispatch stack (`--mode=isolated`), `migrate` v4.19.1 + `psql` against the stack's Postgres. Column-type evidence for `audit_logs`:

| step | actor_id | entity_id | schema_migrations head |
| --- | --- | --- | --- |
| before (pre-migration) | integer | integer | 20260520004455 |
| UP #1 | **bigint** | **bigint** | 20260520165203 |
| DOWN 1 | integer | integer | 20260520004455 |
| UP #2 | **bigint** | **bigint** | 20260520165203 |

No dirty flag at any step; round-trip lands back on the original schema and re-applies cleanly.

## Simplify
`/simplify` run: two SQL files (29 lines), reviewed against reuse / quality / efficiency. Already clean — ALTER shape mirrors PSY-754's established pattern, comments are WHY-only (FK int4/int8 compatibility, overflow rationale, narrowing safety) with no ticket-ID refs to strip. No edits, no separate commit.

Closes PSY-770