### PR TITLE
PSY-778: URL-encode title path segment in bandcamp-embed link

### DIFF
--- a/frontend/features/blog/components/bandcamp-embed.test.tsx
+++ b/frontend/features/blog/components/bandcamp-embed.test.tsx
@@ -93,6 +93,17 @@ describe('Bandcamp', () => {
     )
   })
 
+  it('URL-encodes the title path segment so a non-slug title stays well-formed', () => {
+    const { container } = render(
+      <Bandcamp album="123" artist="myband" title="live at the / venue & more" />
+    )
+    const link = container.querySelector('iframe a')
+    expect(link).toHaveAttribute(
+      'href',
+      'https://myband.bandcamp.com/album/live%20at%20the%20%2F%20venue%20%26%20more'
+    )
+  })
+
   it('applies the height prop to the iframe style', () => {
     const { container } = render(
       <Bandcamp album="123" artist="myband" title="my-album" height="350" />

--- a/frontend/features/blog/components/bandcamp-embed.tsx
+++ b/frontend/features/blog/components/bandcamp-embed.tsx
@@ -36,9 +36,11 @@ export function Bandcamp({
 
   const embedUrl = `https://bandcamp.com/EmbeddedPlayer/${embedParts.join('/')}/`
 
-  // Build the link URL
+  // Build the link URL. `artist` is an author-authored Bandcamp subdomain slug
+  // (encodeURIComponent is invalid in a hostname), so only the title path
+  // segment is encoded — keeps the href well-formed if a title isn't pre-slugged.
   const linkType = album ? 'album' : 'track'
-  const linkUrl = `https://${artist}.bandcamp.com/${linkType}/${title}`
+  const linkUrl = `https://${artist}.bandcamp.com/${linkType}/${encodeURIComponent(title)}`
 
   return (
     <iframe


### PR DESCRIPTION
## Summary
`bandcamp-embed.tsx` built the fallback link as `https://${artist}.bandcamp.com/${linkType}/${title}` with no URL-encoding. A non-slug `title` containing spaces or path-breaking chars (`/ ? # &`) produced a malformed href.

- **Fix:** wrap the title path segment in `encodeURIComponent`. It is a no-op on the real slug values, so existing links are unchanged.
- **Subdomain left as-is:** the only real usages (`content/blog/*.md`, e.g. `artist="daydreamingwinter"`) author `artist` as a Bandcamp subdomain slug, matching the `scripts/new-blog-post.ts` scaffold (`ARTIST_SLUG`). `encodeURIComponent` is invalid in a hostname and a slugify transform would be speculative, so the verified-slug subdomain is trusted rather than transformed. This is defense-in-depth (author typo safety), not a live data bug.
- Out of scope: `embedParts` (`album=`/`track=`) interpolation — those are numeric IDs.

## Test plan
- [x] `bun run test:run features/blog` (60/60 pass; bandcamp-embed 9/9, incl. 1 new)
- [x] `bun run typecheck` (clean)

## Manual repro
The new unit test IS the repro — this is a pure-render component with no interactive UI. `title="live at the / venue & more"` now yields `https://myband.bandcamp.com/album/live%20at%20the%20%2F%20venue%20%26%20more` (well-formed) instead of a raw-space href. Real posts (`the-date`, `water-season`) are unaffected since `encodeURIComponent` is a no-op on slugs.

## Simplify
`/simplify` run before PR (3 parallel reviewers). Reuse + efficiency clean — `encodeURIComponent` is the native API used inline ~11x across the repo; no higher-level util exists. Quality: removed one redundant `not.toContain(' ')` assertion (the exact-href assertion already covers it).

Closes PSY-778