### PR TITLE
PSY-779: surface inline validation message in ArtistEditForm

### DIFF
--- a/frontend/components/forms/ArtistEditForm.test.tsx
+++ b/frontend/components/forms/ArtistEditForm.test.tsx
@@ -136,11 +136,10 @@ describe('ArtistEditForm', () => {
       expect(mockMutate).not.toHaveBeenCalled()
     })
 
-    it('blocks the mutation when the required name is cleared', async () => {
-      // The zod `onSubmit` validator rejects an empty name, so the form's
-      // submit handler never runs. NOTE: the component does not surface the
-      // validation message in the DOM (no field-error rendering) — this test
-      // pins the observable behavior (mutation blocked), not a visible error.
+    it('surfaces a validation message and blocks the mutation when the required name is cleared', async () => {
+      // The zod `onSubmit` validator rejects an empty name. The form must both
+      // block the mutation AND surface the message inline (via FieldInfo), so
+      // the user isn't left with a silent, dead Save button.
       const user = userEvent.setup()
       const artist = makeArtist()
       renderWithProviders(
@@ -150,10 +149,9 @@ describe('ArtistEditForm', () => {
       await user.clear(screen.getByLabelText(/Name \*/i))
       await user.click(screen.getByRole('button', { name: /Save Changes/i }))
 
-      // Give the async submit/validation a tick to settle, then assert no call.
-      await waitFor(() =>
-        expect(screen.getByLabelText(/Name \*/i)).toHaveValue('')
-      )
+      expect(
+        await screen.findByText(/Artist name is required/i)
+      ).toBeInTheDocument()
       expect(mockMutate).not.toHaveBeenCalled()
     })
   })

--- a/frontend/components/forms/ArtistEditForm.tsx
+++ b/frontend/components/forms/ArtistEditForm.tsx
@@ -18,6 +18,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Alert, AlertDescription } from '@/components/ui/alert'
+import { FieldInfo } from './FormField'
 
 const artistEditSchema = z.object({
   name: z.string().min(1, 'Artist name is required'),
@@ -207,7 +208,9 @@ export function ArtistEditForm({
                     onChange={e => field.handleChange(e.target.value)}
                     onBlur={field.handleBlur}
                     placeholder="e.g. The National"
+                    aria-invalid={field.state.meta.errors.length > 0}
                   />
+                  <FieldInfo field={field} />
                 </div>
               )}
             </form.Field>


### PR DESCRIPTION
## Summary
`ArtistEditForm` validates `name` via a zod `onSubmit` validator, but no field-error rendering existed — clearing the name and clicking Save silently blocked the mutation with no explanation (dead Save button).

- **Fix:** render the field error inline via the shared `FieldInfo` component (the same one `ShowForm` uses), and set `aria-invalid` on the name input. Surgical, scoped to the `name` field (the only field with a validation rule).
- **Why `FieldInfo`, not `FormField`:** `ArtistEditForm` (like `VenueEditForm`) hand-rolls its Label+Input markup with custom ids (`artist-name`). Swapping in the higher-level `FormField` would refactor the whole field for no functional gain — out of scope for a bug fix. `FieldInfo` is the canonical error-display primitive both wrap.

## Test plan
- [x] `bun run test:run components/forms` (109/109 pass; ArtistEditForm 9/9)
- [x] `bun run typecheck` (clean)

## Manual repro
Verified by the existing-style RTL test, which is a real-interaction repro: it renders the actual component with the real `@tanstack/react-form` + zod schema, does `user.clear(name)` → `user.click(Save)`, and asserts `findByText(/Artist name is required/i)` renders while `mockMutate` is never called (flips the prior test that pinned the silent "no message" behavior). `FieldInfo` is already rendering in production via `ShowForm`, so visual rendering is proven. I did **not** stand up the full admin stack (backend + auth + seeded artist) for a separate browser pass — happy to if you want the visual confirmation.

## Simplify
`/simplify` run before PR (3 parallel reviewers) — all clean, no fixes. Reuse: `FieldInfo` is the correct minimal reuse; full `FormField` adoption would be scope creep. Quality/efficiency: no issues.

## Follow-up
`VenueEditForm` hand-rolls its name field the same way and has the **same silent-validation bug** (2nd instance). Filing a separate audit/fix ticket rather than widening this PR's scope.

Closes PSY-779