### PR TITLE
PSY-805: raise Railway backend healthcheckTimeout 30s -> 120s

### DIFF
--- a/backend/railway.toml
+++ b/backend/railway.toml
@@ -4,6 +4,6 @@ dockerfilePath = "Dockerfile"
 
 [deploy]
 healthcheckPath = "/health"
-healthcheckTimeout = 30
+healthcheckTimeout = 120
 restartPolicyType = "on_failure"
 restartPolicyMaxRetries = 3


### PR DESCRIPTION
## Summary
A backend **stage** deploy failed Railway's healthcheck and wasn't promoted — `1/1 replicas never became healthy` within the **30s** retry window — despite a clean build, a clean + current DB, and **no crash** in the container logs. Verified via Railway CLI that it wasn't a code regression (frontend-only / request-time merges; `schema_migrations` clean and at HEAD; the active deploy stayed healthy throughout). The container just didn't bind `:8080` within 30s on a contended cold start.

The server initializes ~8 background services + a DB pool on boot, so `healthcheckTimeout = 30` is tight — especially under deploy churn (three deploys landed within ~1 minute, each triggering a backend redeploy). This raises it to `120`.

- A healthy app answers `/health` in <1s, so the wider window only matters during slow/contended cold starts — pure downside protection, no runtime cost.

## Test plan
- [x] N/A — single config-value change in `backend/railway.toml` (`30` → `120`); no code, no test references this file.

## Manual repro / verification
Verification is the next stage deploy promoting cleanly (this config only takes effect once merged + deployed). A manual `railway redeploy` of the failed commit was also triggered separately to clear the immediate stuck deploy.

## Simplify
N/A — one-line config value change; nothing for the reuse/quality/efficiency reviewers to assess.

## Out of scope
Moving migrations to a dedicated release phase or trimming boot-time work — the timeout bump is the minimal targeted fix.

Closes PSY-805