### PR TITLE
PSY-751: add shared.GoSafe panic guard for fire-and-forget goroutines

### DIFF
--- a/backend/internal/api/handlers/admin/admin_shows.go
+++ b/backend/internal/api/handlers/admin/admin_shows.go
@@ -13,6 +13,7 @@ import (
 	"psychic-homily-backend/internal/logger"
 	catalogm "psychic-homily-backend/internal/models/catalog"
 	"psychic-homily-backend/internal/services/contracts"
+	servicesshared "psychic-homily-backend/internal/services/shared"
 )
 
 // AdminShowHandler handles admin show management
@@ -305,7 +306,7 @@ func (h *AdminShowHandler) ApproveShowHandler(ctx context.Context, req *ApproveS
 
 	// Fire-and-forget: match notification filters for this newly approved show
 	if h.notificationFilterService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "notification_filter_match", func() {
 			showModel := &catalogm.Show{ID: uint(showID), Title: show.Title, EventDate: show.EventDate, Price: show.Price, Slug: shared.PtrString(show.Slug)}
 			if show.City != nil {
 				showModel.City = show.City
@@ -319,7 +320,7 @@ func (h *AdminShowHandler) ApproveShowHandler(ctx context.Context, req *ApproveS
 					"error", err.Error(),
 				)
 			}
-		}()
+		})
 	}
 
 	// Audit log
@@ -400,7 +401,7 @@ func (h *AdminShowHandler) BatchApproveShowsHandler(ctx context.Context, req *Ba
 
 	// Fire-and-forget: match notification filters for batch-approved shows
 	if h.notificationFilterService != nil && len(result.Succeeded) > 0 {
-		go func() {
+		servicesshared.GoSafe(ctx, "notification_filter_match", func() {
 			for _, showID := range result.Succeeded {
 				show, err := h.showService.GetShow(showID)
 				if err != nil || show == nil {
@@ -420,7 +421,7 @@ func (h *AdminShowHandler) BatchApproveShowsHandler(ctx context.Context, req *Ba
 					)
 				}
 			}
-		}()
+		})
 	}
 
 	logger.FromContext(ctx).Info("admin_batch_approve_shows",

--- a/backend/internal/api/handlers/admin/pending_edit.go
+++ b/backend/internal/api/handlers/admin/pending_edit.go
@@ -15,6 +15,7 @@ import (
 	adminm "psychic-homily-backend/internal/models/admin"
 	authm "psychic-homily-backend/internal/models/auth"
 	"psychic-homily-backend/internal/services/contracts"
+	servicesshared "psychic-homily-backend/internal/services/shared"
 )
 
 // PendingEditHandler handles pending entity edit API endpoints.
@@ -432,9 +433,11 @@ func (h *PendingEditHandler) AdminApprovePendingEditHandler(ctx context.Context,
 
 	// Fire-and-forget audit log
 	if h.auditLogService != nil {
-		go h.auditLogService.LogAction(user.ID, "approve_edit_"+approved.EntityType, approved.EntityType, approved.EntityID, map[string]interface{}{
-			"edit_id":      approved.ID,
-			"submitted_by": approved.SubmittedBy,
+		servicesshared.GoSafe(ctx, "audit_log", func() {
+			h.auditLogService.LogAction(user.ID, "approve_edit_"+approved.EntityType, approved.EntityType, approved.EntityID, map[string]interface{}{
+				"edit_id":      approved.ID,
+				"submitted_by": approved.SubmittedBy,
+			})
 		})
 	}
 
@@ -499,10 +502,12 @@ func (h *PendingEditHandler) AdminRejectPendingEditHandler(ctx context.Context, 
 
 	// Fire-and-forget audit log
 	if h.auditLogService != nil {
-		go h.auditLogService.LogAction(user.ID, "reject_edit_"+rejected.EntityType, rejected.EntityType, rejected.EntityID, map[string]interface{}{
-			"edit_id":      rejected.ID,
-			"submitted_by": rejected.SubmittedBy,
-			"reason":       reason,
+		servicesshared.GoSafe(ctx, "audit_log", func() {
+			h.auditLogService.LogAction(user.ID, "reject_edit_"+rejected.EntityType, rejected.EntityType, rejected.EntityID, map[string]interface{}{
+				"edit_id":      rejected.ID,
+				"submitted_by": rejected.SubmittedBy,
+				"reason":       reason,
+			})
 		})
 	}
 

--- a/backend/internal/api/handlers/admin/revision.go
+++ b/backend/internal/api/handlers/admin/revision.go
@@ -16,6 +16,7 @@ import (
 	adminm "psychic-homily-backend/internal/models/admin"
 	authm "psychic-homily-backend/internal/models/auth"
 	"psychic-homily-backend/internal/services/contracts"
+	servicesshared "psychic-homily-backend/internal/services/shared"
 )
 
 // RevisionHandler handles revision history API endpoints.
@@ -119,7 +120,7 @@ func mapRevisionToResponse(r adminm.Revision) RevisionResponseItem {
 		// A local time.Time would otherwise be stamped with "Z" while still
 		// carrying the local clock reading, drifting relative-time renders by
 		// the local UTC offset (e.g. 7h on Phoenix MST).
-		CreatedAt:    r.CreatedAt.UTC().Format(time.RFC3339),
+		CreatedAt: r.CreatedAt.UTC().Format(time.RFC3339),
 	}
 
 	item.Summary = shared.Deref(r.Summary)
@@ -317,8 +318,10 @@ func (h *RevisionHandler) RollbackRevisionHandler(ctx context.Context, req *Roll
 
 	// Fire-and-forget audit log
 	if h.auditLogService != nil {
-		go h.auditLogService.LogAction(user.ID, "revision_rollback", "revision", uint(revisionID), map[string]interface{}{
-			"revision_id": revisionID,
+		servicesshared.GoSafe(ctx, "audit_log", func() {
+			h.auditLogService.LogAction(user.ID, "revision_rollback", "revision", uint(revisionID), map[string]interface{}{
+				"revision_id": revisionID,
+			})
 		})
 	}
 

--- a/backend/internal/api/handlers/catalog/artist.go
+++ b/backend/internal/api/handlers/catalog/artist.go
@@ -16,6 +16,7 @@ import (
 	apperrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/logger"
 	"psychic-homily-backend/internal/services/contracts"
+	servicesshared "psychic-homily-backend/internal/services/shared"
 	"psychic-homily-backend/internal/services/shared/revisiondiff"
 )
 
@@ -877,7 +878,7 @@ func (h *ArtistHandler) AdminUpdateArtistHandler(ctx context.Context, req *Admin
 
 	// Record revision (fire and forget)
 	if h.revisionService != nil && oldArtist != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "record_revision", func() {
 			changes := revisiondiff.Compare(oldArtist, artist, revisiondiff.ArtistFields)
 			if len(changes) > 0 {
 				summary := ""
@@ -891,7 +892,7 @@ func (h *ArtistHandler) AdminUpdateArtistHandler(ctx context.Context, req *Admin
 					)
 				}
 			}
-		}()
+		})
 	}
 
 	logger.FromContext(ctx).Info("admin_update_artist_success",

--- a/backend/internal/api/handlers/catalog/artist_relationship.go
+++ b/backend/internal/api/handlers/catalog/artist_relationship.go
@@ -11,6 +11,7 @@ import (
 	"psychic-homily-backend/internal/api/middleware"
 	"psychic-homily-backend/internal/logger"
 	"psychic-homily-backend/internal/services/contracts"
+	servicesshared "psychic-homily-backend/internal/services/shared"
 )
 
 // ArtistRelationshipHandler handles artist relationship API requests.
@@ -214,12 +215,12 @@ func (h *ArtistRelationshipHandler) CreateRelationshipHandler(ctx context.Contex
 
 	// Audit log (fire and forget)
 	if h.auditLog != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLog.LogAction(user.ID, "create_artist_relationship", "artist", req.Body.SourceArtistID, map[string]interface{}{
 				"target_artist_id": req.Body.TargetArtistID,
 				"type":             req.Body.Type,
 			})
-		}()
+		})
 	}
 
 	resp := &CreateRelationshipResponse{}
@@ -326,12 +327,12 @@ func (h *ArtistRelationshipHandler) DeleteRelationshipHandler(ctx context.Contex
 	}
 
 	if h.auditLog != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLog.LogAction(user.ID, "delete_artist_relationship", "artist", uint(sourceID), map[string]interface{}{
 				"target_artist_id": uint(targetID),
 				"type":             req.Type,
 			})
-		}()
+		})
 	}
 
 	return nil, nil
@@ -372,12 +373,12 @@ func (h *ArtistRelationshipHandler) DeriveRelationshipsHandler(ctx context.Conte
 
 	// Audit log (fire and forget)
 	if h.auditLog != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLog.LogAction(user.ID, "derive_artist_relationships", "system", 0, map[string]interface{}{
 				"shared_bills_upserted":  billsCount,
 				"shared_labels_upserted": labelsCount,
 			})
-		}()
+		})
 	}
 
 	resp := &DeriveRelationshipsResponse{}

--- a/backend/internal/api/handlers/catalog/festival.go
+++ b/backend/internal/api/handlers/catalog/festival.go
@@ -13,6 +13,7 @@ import (
 	apperrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/logger"
 	"psychic-homily-backend/internal/services/contracts"
+	servicesshared "psychic-homily-backend/internal/services/shared"
 	"psychic-homily-backend/internal/services/shared/revisiondiff"
 )
 
@@ -248,9 +249,9 @@ func (h *FestivalHandler) CreateFestivalHandler(ctx context.Context, req *Create
 
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "create_festival", "festival", festival.ID, nil)
-		}()
+		})
 	}
 
 	logger.FromContext(ctx).Info("festival_created",
@@ -351,14 +352,14 @@ func (h *FestivalHandler) UpdateFestivalHandler(ctx context.Context, req *Update
 
 	// Audit log (fire and forget) — PSY-618: edits go to entity_edit_audit_logs
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogEntityEdit(user.ID, "festival", festivalID, nil)
-		}()
+		})
 	}
 
 	// Record revision (fire and forget)
 	if h.revisionService != nil && oldFestival != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "record_revision", func() {
 			changes := revisiondiff.Compare(oldFestival, festival, revisiondiff.FestivalFields)
 			if len(changes) > 0 {
 				summary := ""
@@ -372,7 +373,7 @@ func (h *FestivalHandler) UpdateFestivalHandler(ctx context.Context, req *Update
 					)
 				}
 			}
-		}()
+		})
 	}
 
 	logger.FromContext(ctx).Info("festival_updated",
@@ -422,9 +423,9 @@ func (h *FestivalHandler) DeleteFestivalHandler(ctx context.Context, req *Delete
 
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "delete_festival", "festival", festivalID, nil)
-		}()
+		})
 	}
 
 	logger.FromContext(ctx).Info("festival_deleted",
@@ -547,9 +548,9 @@ func (h *FestivalHandler) AddFestivalArtistHandler(ctx context.Context, req *Add
 
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "add_festival_artist", "festival", uint(festivalID), nil)
-		}()
+		})
 	}
 
 	return &AddFestivalArtistHandlerResponse{Body: artist}, nil
@@ -617,9 +618,9 @@ func (h *FestivalHandler) UpdateFestivalArtistHandler(ctx context.Context, req *
 
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "update_festival_artist", "festival", uint(festivalID), nil)
-		}()
+		})
 	}
 
 	return &UpdateFestivalArtistHandlerResponse{Body: artist}, nil
@@ -665,9 +666,9 @@ func (h *FestivalHandler) RemoveFestivalArtistHandler(ctx context.Context, req *
 
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "remove_festival_artist", "festival", uint(festivalID), nil)
-		}()
+		})
 	}
 
 	return nil, nil
@@ -768,9 +769,9 @@ func (h *FestivalHandler) AddFestivalVenueHandler(ctx context.Context, req *AddF
 
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "add_festival_venue", "festival", uint(festivalID), nil)
-		}()
+		})
 	}
 
 	return &AddFestivalVenueHandlerResponse{Body: venue}, nil
@@ -816,9 +817,9 @@ func (h *FestivalHandler) RemoveFestivalVenueHandler(ctx context.Context, req *R
 
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "remove_festival_venue", "festival", uint(festivalID), nil)
-		}()
+		})
 	}
 
 	return nil, nil

--- a/backend/internal/api/handlers/catalog/label.go
+++ b/backend/internal/api/handlers/catalog/label.go
@@ -13,6 +13,7 @@ import (
 	apperrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/logger"
 	"psychic-homily-backend/internal/services/contracts"
+	servicesshared "psychic-homily-backend/internal/services/shared"
 	"psychic-homily-backend/internal/services/shared/revisiondiff"
 )
 
@@ -226,9 +227,9 @@ func (h *LabelHandler) CreateLabelHandler(ctx context.Context, req *CreateLabelR
 
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "create_label", "label", label.ID, nil)
-		}()
+		})
 	}
 
 	logger.FromContext(ctx).Info("label_created",
@@ -340,14 +341,14 @@ func (h *LabelHandler) UpdateLabelHandler(ctx context.Context, req *UpdateLabelR
 
 	// Audit log (fire and forget) — PSY-618: edits go to entity_edit_audit_logs
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogEntityEdit(user.ID, "label", labelID, nil)
-		}()
+		})
 	}
 
 	// Record revision (fire and forget)
 	if h.revisionService != nil && oldLabel != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "record_revision", func() {
 			changes := revisiondiff.Compare(oldLabel, label, revisiondiff.LabelFields)
 			if len(changes) > 0 {
 				summary := ""
@@ -361,7 +362,7 @@ func (h *LabelHandler) UpdateLabelHandler(ctx context.Context, req *UpdateLabelR
 					)
 				}
 			}
-		}()
+		})
 	}
 
 	logger.FromContext(ctx).Info("label_updated",
@@ -412,9 +413,9 @@ func (h *LabelHandler) DeleteLabelHandler(ctx context.Context, req *DeleteLabelR
 
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "delete_label", "label", labelID, nil)
-		}()
+		})
 	}
 
 	logger.FromContext(ctx).Info("label_deleted",
@@ -562,9 +563,9 @@ func (h *LabelHandler) AddArtistToLabelHandler(ctx context.Context, req *AddArti
 
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "add_artist_to_label", "label", labelID, nil)
-		}()
+		})
 	}
 
 	logger.FromContext(ctx).Info("artist_added_to_label",
@@ -634,9 +635,9 @@ func (h *LabelHandler) AddReleaseToLabelHandler(ctx context.Context, req *AddRel
 
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "add_release_to_label", "label", labelID, nil)
-		}()
+		})
 	}
 
 	logger.FromContext(ctx).Info("release_added_to_label",

--- a/backend/internal/api/handlers/catalog/radio.go
+++ b/backend/internal/api/handlers/catalog/radio.go
@@ -14,6 +14,7 @@ import (
 	apperrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/logger"
 	"psychic-homily-backend/internal/services/contracts"
+	servicesshared "psychic-homily-backend/internal/services/shared"
 )
 
 // ============================================================================
@@ -660,9 +661,9 @@ func (h *RadioHandler) AdminCreateRadioStationHandler(ctx context.Context, req *
 
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "create_radio_station", "radio_station", station.ID, nil)
-		}()
+		})
 	}
 
 	logger.FromContext(ctx).Info("radio_station_created",
@@ -753,9 +754,9 @@ func (h *RadioHandler) AdminUpdateRadioStationHandler(ctx context.Context, req *
 
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "update_radio_station", "radio_station", req.StationID, nil)
-		}()
+		})
 	}
 
 	logger.FromContext(ctx).Info("radio_station_updated",
@@ -800,9 +801,9 @@ func (h *RadioHandler) AdminDeleteRadioStationHandler(ctx context.Context, req *
 
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "delete_radio_station", "radio_station", req.StationID, nil)
-		}()
+		})
 	}
 
 	logger.FromContext(ctx).Info("radio_station_deleted",
@@ -881,11 +882,11 @@ func (h *RadioHandler) AdminCreateRadioShowHandler(ctx context.Context, req *Adm
 
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "create_radio_show", "radio_show", show.ID, map[string]interface{}{
 				"station_id": req.StationID,
 			})
-		}()
+		})
 	}
 
 	logger.FromContext(ctx).Info("radio_show_created",
@@ -959,9 +960,9 @@ func (h *RadioHandler) AdminUpdateRadioShowHandler(ctx context.Context, req *Adm
 
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "update_radio_show", "radio_show", req.ShowID, nil)
-		}()
+		})
 	}
 
 	logger.FromContext(ctx).Info("radio_show_updated",
@@ -1006,9 +1007,9 @@ func (h *RadioHandler) AdminDeleteRadioShowHandler(ctx context.Context, req *Adm
 
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "delete_radio_show", "radio_show", req.ShowID, nil)
-		}()
+		})
 	}
 
 	logger.FromContext(ctx).Info("radio_show_deleted",
@@ -1179,13 +1180,13 @@ func (h *RadioHandler) AdminLinkPlayHandler(ctx context.Context, req *AdminLinkP
 
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "link_radio_play", "radio_play", req.PlayID, map[string]interface{}{
 				"artist_id":  req.Body.ArtistID,
 				"release_id": req.Body.ReleaseID,
 				"label_id":   req.Body.LabelID,
 			})
-		}()
+		})
 	}
 
 	resp := &AdminLinkPlayResponse{}
@@ -1243,13 +1244,13 @@ func (h *RadioHandler) AdminBulkLinkPlaysHandler(ctx context.Context, req *Admin
 
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "bulk_link_radio_plays", "radio_play", 0, map[string]interface{}{
 				"artist_name": req.Body.ArtistName,
 				"artist_id":   req.Body.ArtistID,
 				"updated":     result.Updated,
 			})
-		}()
+		})
 	}
 
 	logger.FromContext(ctx).Info("bulk_link_plays_complete",
@@ -1318,13 +1319,13 @@ func (h *RadioHandler) AdminCreateImportJobHandler(ctx context.Context, req *Adm
 
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "create_radio_import_job", "radio_import_job", job.ID, map[string]interface{}{
 				"show_id": req.ShowID,
 				"since":   req.Body.Since,
 				"until":   req.Body.Until,
 			})
-		}()
+		})
 	}
 
 	logger.FromContext(ctx).Info("radio_import_job_created",
@@ -1396,9 +1397,9 @@ func (h *RadioHandler) AdminCancelImportJobHandler(ctx context.Context, req *Adm
 
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "cancel_radio_import_job", "radio_import_job", req.JobID, nil)
-		}()
+		})
 	}
 
 	logger.FromContext(ctx).Info("radio_import_job_cancelled",

--- a/backend/internal/api/handlers/catalog/release.go
+++ b/backend/internal/api/handlers/catalog/release.go
@@ -13,6 +13,7 @@ import (
 	apperrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/logger"
 	"psychic-homily-backend/internal/services/contracts"
+	servicesshared "psychic-homily-backend/internal/services/shared"
 	"psychic-homily-backend/internal/services/shared/revisiondiff"
 )
 
@@ -256,9 +257,9 @@ func (h *ReleaseHandler) CreateReleaseHandler(ctx context.Context, req *CreateRe
 
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "create_release", "release", release.ID, nil)
-		}()
+		})
 	}
 
 	logger.FromContext(ctx).Info("release_created",
@@ -344,14 +345,14 @@ func (h *ReleaseHandler) UpdateReleaseHandler(ctx context.Context, req *UpdateRe
 
 	// Audit log (fire and forget) — PSY-618: edits go to entity_edit_audit_logs
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogEntityEdit(user.ID, "release", releaseID, nil)
-		}()
+		})
 	}
 
 	// Record revision (fire and forget)
 	if h.revisionService != nil && oldRelease != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "record_revision", func() {
 			changes := revisiondiff.Compare(oldRelease, release, revisiondiff.ReleaseFields)
 			if len(changes) > 0 {
 				summary := ""
@@ -365,7 +366,7 @@ func (h *ReleaseHandler) UpdateReleaseHandler(ctx context.Context, req *UpdateRe
 					)
 				}
 			}
-		}()
+		})
 	}
 
 	logger.FromContext(ctx).Info("release_updated",
@@ -416,9 +417,9 @@ func (h *ReleaseHandler) DeleteReleaseHandler(ctx context.Context, req *DeleteRe
 
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "delete_release", "release", releaseID, nil)
-		}()
+		})
 	}
 
 	logger.FromContext(ctx).Info("release_deleted",
@@ -533,9 +534,9 @@ func (h *ReleaseHandler) AddExternalLinkHandler(ctx context.Context, req *AddExt
 
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "add_release_link", "release", uint(releaseID), nil)
-		}()
+		})
 	}
 
 	return &AddExternalLinkResponse{Body: link}, nil
@@ -573,9 +574,9 @@ func (h *ReleaseHandler) RemoveExternalLinkHandler(ctx context.Context, req *Rem
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
 		releaseID, _ := strconv.ParseUint(req.ReleaseID, 10, 32)
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "remove_release_link", "release", uint(releaseID), nil)
-		}()
+		})
 	}
 
 	return nil, nil

--- a/backend/internal/api/handlers/catalog/show.go
+++ b/backend/internal/api/handlers/catalog/show.go
@@ -16,6 +16,7 @@ import (
 	apperrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/logger"
 	"psychic-homily-backend/internal/services/contracts"
+	servicesshared "psychic-homily-backend/internal/services/shared"
 	"psychic-homily-backend/internal/services/shared/revisiondiff"
 )
 
@@ -940,7 +941,7 @@ func (h *ShowHandler) UpdateShowHandler(ctx context.Context, req *UpdateShowRequ
 		oldShow := existingShow
 		newShow := show
 		summary := shared.Deref(req.Body.Summary)
-		go func() {
+		servicesshared.GoSafe(ctx, "record_revision", func() {
 			changes := revisiondiff.Compare(oldShow, newShow, revisiondiff.ShowFields)
 			if len(changes) > 0 {
 				if err := h.revisionService.RecordRevision("show", uint(showID), user.ID, changes, summary); err != nil {
@@ -950,7 +951,7 @@ func (h *ShowHandler) UpdateShowHandler(ctx context.Context, req *UpdateShowRequ
 					)
 				}
 			}
-		}()
+		})
 	}
 
 	return &UpdateShowResponse{Body: UpdateShowResponseBody{

--- a/backend/internal/api/handlers/catalog/tag.go
+++ b/backend/internal/api/handlers/catalog/tag.go
@@ -12,6 +12,7 @@ import (
 	"psychic-homily-backend/internal/logger"
 	catalogm "psychic-homily-backend/internal/models/catalog"
 	"psychic-homily-backend/internal/services/contracts"
+	servicesshared "psychic-homily-backend/internal/services/shared"
 )
 
 // TagHandler handles tag-related API requests.
@@ -459,12 +460,12 @@ func (h *TagHandler) CreateTagHandler(ctx context.Context, req *CreateTagRequest
 
 	// Audit log (fire and forget)
 	if h.auditLog != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLog.LogAction(user.ID, "create_tag", "tag", tag.ID, map[string]interface{}{
 				"name":     tag.Name,
 				"category": tag.Category,
 			})
-		}()
+		})
 	}
 
 	// Re-fetch with preloads
@@ -515,9 +516,9 @@ func (h *TagHandler) UpdateTagHandler(ctx context.Context, req *UpdateTagRequest
 
 	// Audit log (fire and forget)
 	if h.auditLog != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLog.LogAction(user.ID, "update_tag", "tag", uint(id), nil)
-		}()
+		})
 	}
 
 	resp := buildTagResponse(tag)
@@ -551,9 +552,9 @@ func (h *TagHandler) DeleteTagHandler(ctx context.Context, req *DeleteTagRequest
 
 	// Audit log (fire and forget)
 	if h.auditLog != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLog.LogAction(user.ID, "delete_tag", "tag", uint(id), nil)
-		}()
+		})
 	}
 
 	return nil, nil
@@ -636,11 +637,11 @@ func (h *TagHandler) CreateAliasHandler(ctx context.Context, req *CreateAliasReq
 
 	// Audit log (fire and forget)
 	if h.auditLog != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLog.LogAction(user.ID, "create_tag_alias", "tag", uint(id), map[string]interface{}{
 				"alias": req.Body.Alias,
 			})
-		}()
+		})
 	}
 
 	resp := &contracts.TagAliasResponse{
@@ -676,11 +677,11 @@ func (h *TagHandler) DeleteAliasHandler(ctx context.Context, req *DeleteAliasReq
 	// Audit log (fire and forget)
 	if h.auditLog != nil {
 		tagID, _ := strconv.ParseUint(req.TagID, 10, 32)
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLog.LogAction(user.ID, "delete_tag_alias", "tag", uint(tagID), map[string]interface{}{
 				"alias_id": uint(aliasID),
 			})
-		}()
+		})
 	}
 
 	return nil, nil
@@ -829,12 +830,12 @@ func (h *TagHandler) BulkImportAliasesHandler(ctx context.Context, req *BulkImpo
 	if h.auditLog != nil {
 		imported := result.Imported
 		skipped := len(result.Skipped)
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLog.LogAction(user.ID, "bulk_import_tag_aliases", "tag", 0, map[string]interface{}{
 				"imported": imported,
 				"skipped":  skipped,
 			})
-		}()
+		})
 	}
 
 	return &BulkImportAliasesResponse{Body: result}, nil
@@ -883,9 +884,9 @@ func (h *TagHandler) SnoozeTagHandler(ctx context.Context, req *SnoozeTagRequest
 	}
 
 	if h.auditLog != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLog.LogAction(user.ID, "snooze_low_quality_tag", "tag", uint(id), nil)
-		}()
+		})
 	}
 
 	return nil, nil
@@ -935,7 +936,7 @@ func (h *TagHandler) BulkLowQualityTagsHandler(ctx context.Context, req *BulkLow
 		affected := result.Affected
 		notFound := result.NotFound
 		idsCopy := append([]uint(nil), req.Body.TagIDs...)
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLog.LogAction(user.ID, "bulk_low_quality_tags", "tag", 0, map[string]interface{}{
 				"action":    actionCopy,
 				"requested": requested,
@@ -943,7 +944,7 @@ func (h *TagHandler) BulkLowQualityTagsHandler(ctx context.Context, req *BulkLow
 				"not_found": notFound,
 				"tag_ids":   idsCopy,
 			})
-		}()
+		})
 	}
 
 	return &BulkLowQualityTagsResponse{Body: result}, nil

--- a/backend/internal/api/handlers/catalog/venue.go
+++ b/backend/internal/api/handlers/catalog/venue.go
@@ -12,6 +12,7 @@ import (
 	apperrors "psychic-homily-backend/internal/errors"
 	"psychic-homily-backend/internal/logger"
 	"psychic-homily-backend/internal/services/contracts"
+	servicesshared "psychic-homily-backend/internal/services/shared"
 	"psychic-homily-backend/internal/services/shared/revisiondiff"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -327,13 +328,13 @@ func (h *VenueHandler) AdminCreateVenueHandler(ctx context.Context, req *AdminCr
 
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "create_venue", "venue", venue.ID, map[string]interface{}{
 				"name":  venue.Name,
 				"city":  venue.City,
 				"state": venue.State,
 			})
-		}()
+		})
 	}
 
 	logger.FromContext(ctx).Info("admin_venue_created",
@@ -472,7 +473,7 @@ func (h *VenueHandler) UpdateVenueHandler(ctx context.Context, req *UpdateVenueR
 
 	// Record revision (fire and forget)
 	if h.revisionService != nil && oldVenue != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "record_revision", func() {
 			changes := revisiondiff.Compare(oldVenue, updatedVenue, revisiondiff.VenueFields)
 			if len(changes) > 0 {
 				summary := ""
@@ -486,7 +487,7 @@ func (h *VenueHandler) UpdateVenueHandler(ctx context.Context, req *UpdateVenueR
 					)
 				}
 			}
-		}()
+		})
 	}
 
 	return &UpdateVenueResponse{Body: updatedVenue}, nil

--- a/backend/internal/api/handlers/community/collection.go
+++ b/backend/internal/api/handlers/community/collection.go
@@ -12,6 +12,7 @@ import (
 	"psychic-homily-backend/internal/api/middleware"
 	"psychic-homily-backend/internal/logger"
 	"psychic-homily-backend/internal/services/contracts"
+	servicesshared "psychic-homily-backend/internal/services/shared"
 )
 
 // CollectionHandler handles collection-related API requests
@@ -232,9 +233,9 @@ func (h *CollectionHandler) CreateCollectionHandler(ctx context.Context, req *Cr
 
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "create_collection", "collection", collection.ID, nil)
-		}()
+		})
 	}
 
 	return &CreateCollectionHandlerResponse{Body: collection}, nil
@@ -304,9 +305,9 @@ func (h *CollectionHandler) UpdateCollectionHandler(ctx context.Context, req *Up
 
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "update_collection", "collection", collection.ID, nil)
-		}()
+		})
 	}
 
 	return &UpdateCollectionHandlerResponse{Body: collection}, nil
@@ -348,9 +349,9 @@ func (h *CollectionHandler) DeleteCollectionHandler(ctx context.Context, req *De
 
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "delete_collection", "collection", 0, map[string]interface{}{"slug": req.Slug})
-		}()
+		})
 	}
 
 	return nil, nil
@@ -415,13 +416,13 @@ func (h *CollectionHandler) AddItemHandler(ctx context.Context, req *AddItemHand
 
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "add_collection_item", "collection", item.ID, map[string]interface{}{
 				"slug":        req.Slug,
 				"entity_type": req.Body.EntityType,
 				"entity_id":   req.Body.EntityID,
 			})
-		}()
+		})
 	}
 
 	return &AddItemHandlerResponse{Body: item}, nil
@@ -482,11 +483,11 @@ func (h *CollectionHandler) UpdateItemHandler(ctx context.Context, req *UpdateIt
 
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "update_collection_item", "collection", item.ID, map[string]interface{}{
 				"slug": req.Slug,
 			})
-		}()
+		})
 	}
 
 	return &UpdateItemHandlerResponse{Body: item}, nil
@@ -535,11 +536,11 @@ func (h *CollectionHandler) RemoveItemHandler(ctx context.Context, req *RemoveIt
 
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "remove_collection_item", "collection", uint(itemID), map[string]interface{}{
 				"slug": req.Slug,
 			})
-		}()
+		})
 	}
 
 	return nil, nil
@@ -669,12 +670,12 @@ func (h *CollectionHandler) SetFeaturedHandler(ctx context.Context, req *SetFeat
 
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "set_collection_featured", "collection", 0, map[string]interface{}{
 				"slug":     req.Slug,
 				"featured": req.Body.Featured,
 			})
-		}()
+		})
 	}
 
 	return nil, nil
@@ -927,12 +928,12 @@ func (h *CollectionHandler) CloneCollectionHandler(ctx context.Context, req *Clo
 	// Audit log (fire and forget). The audit feed renders this as
 	// "collection_cloned" via mapActionToEventType in admin/stats.go.
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "clone_collection", "collection", clone.ID, map[string]interface{}{
 				"source_slug": req.Slug,
 				"source_id":   clone.ForkedFromCollectionID,
 			})
-		}()
+		})
 	}
 
 	return &CloneCollectionHandlerResponse{Body: clone}, nil
@@ -1010,13 +1011,13 @@ func (h *CollectionHandler) AddCollectionTagHandler(ctx context.Context, req *Ad
 	}
 
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "add_collection_tag", "collection", 0, map[string]interface{}{
 				"slug":     req.Slug,
 				"tag_id":   req.Body.TagID,
 				"tag_name": req.Body.TagName,
 			})
-		}()
+		})
 	}
 
 	return &AddCollectionTagHandlerResponse{Body: resp}, nil
@@ -1061,12 +1062,12 @@ func (h *CollectionHandler) RemoveCollectionTagHandler(ctx context.Context, req 
 	}
 
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "remove_collection_tag", "collection", 0, map[string]interface{}{
 				"slug":   req.Slug,
 				"tag_id": tagID,
 			})
-		}()
+		})
 	}
 
 	return nil, nil

--- a/backend/internal/api/handlers/community/entity_report.go
+++ b/backend/internal/api/handlers/community/entity_report.go
@@ -11,6 +11,7 @@ import (
 	"psychic-homily-backend/internal/logger"
 	communitym "psychic-homily-backend/internal/models/community"
 	"psychic-homily-backend/internal/services/contracts"
+	servicesshared "psychic-homily-backend/internal/services/shared"
 )
 
 // EntityReportHandler handles entity report API endpoints.
@@ -126,9 +127,11 @@ func (h *EntityReportHandler) reportEntity(ctx context.Context, entityType strin
 
 	// Fire-and-forget audit log
 	if h.auditLogService != nil {
-		go h.auditLogService.LogAction(user.ID, "report_"+entityType, entityType, uint(entityID), map[string]interface{}{
-			"report_id":   report.ID,
-			"report_type": reportType,
+		servicesshared.GoSafe(ctx, "audit_log", func() {
+			h.auditLogService.LogAction(user.ID, "report_"+entityType, entityType, uint(entityID), map[string]interface{}{
+				"report_id":   report.ID,
+				"report_type": reportType,
+			})
 		})
 	}
 
@@ -260,10 +263,12 @@ func (h *EntityReportHandler) AdminResolveEntityReportHandler(ctx context.Contex
 
 	// Fire-and-forget audit log
 	if h.auditLogService != nil {
-		go h.auditLogService.LogAction(user.ID, "resolve_entity_report", resolved.EntityType, resolved.EntityID, map[string]interface{}{
-			"report_id":   resolved.ID,
-			"report_type": resolved.ReportType,
-			"notes":       notes,
+		servicesshared.GoSafe(ctx, "audit_log", func() {
+			h.auditLogService.LogAction(user.ID, "resolve_entity_report", resolved.EntityType, resolved.EntityID, map[string]interface{}{
+				"report_id":   resolved.ID,
+				"report_type": resolved.ReportType,
+				"notes":       notes,
+			})
 		})
 	}
 
@@ -323,10 +328,12 @@ func (h *EntityReportHandler) AdminDismissEntityReportHandler(ctx context.Contex
 
 	// Fire-and-forget audit log
 	if h.auditLogService != nil {
-		go h.auditLogService.LogAction(user.ID, "dismiss_entity_report", dismissed.EntityType, dismissed.EntityID, map[string]interface{}{
-			"report_id":   dismissed.ID,
-			"report_type": dismissed.ReportType,
-			"notes":       notes,
+		servicesshared.GoSafe(ctx, "audit_log", func() {
+			h.auditLogService.LogAction(user.ID, "dismiss_entity_report", dismissed.EntityType, dismissed.EntityID, map[string]interface{}{
+				"report_id":   dismissed.ID,
+				"report_type": dismissed.ReportType,
+				"notes":       notes,
+			})
 		})
 	}
 

--- a/backend/internal/api/handlers/community/request.go
+++ b/backend/internal/api/handlers/community/request.go
@@ -82,11 +82,11 @@ func (h *RequestHandler) CreateRequestHandler(ctx context.Context, req *CreateRe
 
 	// Audit log (fire and forget)
 	if h.auditLog != nil {
-		go func() {
+		shared.GoSafe(ctx, "audit_log", func() {
 			h.auditLog.LogAction(user.ID, "create_request", "request", request.ID, map[string]interface{}{
 				"entity_type": req.Body.EntityType,
 			})
-		}()
+		})
 	}
 
 	resp := buildRequestResponse(request, nil)
@@ -232,9 +232,9 @@ func (h *RequestHandler) UpdateRequestHandler(ctx context.Context, req *UpdateRe
 
 	// Audit log (fire and forget)
 	if h.auditLog != nil {
-		go func() {
+		shared.GoSafe(ctx, "audit_log", func() {
 			h.auditLog.LogAction(user.ID, "update_request", "request", uint(id), nil)
-		}()
+		})
 	}
 
 	resp := buildRequestResponse(request, nil)
@@ -273,9 +273,9 @@ func (h *RequestHandler) DeleteRequestHandler(ctx context.Context, req *DeleteRe
 
 	// Audit log (fire and forget)
 	if h.auditLog != nil {
-		go func() {
+		shared.GoSafe(ctx, "audit_log", func() {
 			h.auditLog.LogAction(user.ID, "delete_request", "request", uint(id), nil)
-		}()
+		})
 	}
 
 	return nil, nil
@@ -385,9 +385,9 @@ func (h *RequestHandler) FulfillRequestHandler(ctx context.Context, req *Fulfill
 
 	// Audit log (fire and forget)
 	if h.auditLog != nil {
-		go func() {
+		shared.GoSafe(ctx, "audit_log", func() {
 			h.auditLog.LogAction(user.ID, "fulfill_request", "request", uint(id), nil)
-		}()
+		})
 	}
 
 	return nil, nil
@@ -425,9 +425,9 @@ func (h *RequestHandler) CloseRequestHandler(ctx context.Context, req *CloseRequ
 
 	// Audit log (fire and forget)
 	if h.auditLog != nil {
-		go func() {
+		shared.GoSafe(ctx, "audit_log", func() {
 			h.auditLog.LogAction(user.ID, "close_request", "request", uint(id), nil)
-		}()
+		})
 	}
 
 	return nil, nil

--- a/backend/internal/api/handlers/engagement/comment.go
+++ b/backend/internal/api/handlers/engagement/comment.go
@@ -15,6 +15,7 @@ import (
 	authm "psychic-homily-backend/internal/models/auth"
 	engagementm "psychic-homily-backend/internal/models/engagement"
 	"psychic-homily-backend/internal/services/contracts"
+	servicesshared "psychic-homily-backend/internal/services/shared"
 )
 
 // rateLimited429 wraps a 429 service-layer error with a `Retry-After` header
@@ -314,11 +315,11 @@ func (h *CommentHandler) CreateCommentHandler(ctx context.Context, req *CreateCo
 
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "create_comment", req.EntityType, comment.ID, map[string]interface{}{
 				"entity_id": uint(entityID),
 			})
-		}()
+		})
 	}
 
 	return &CreateCommentResponse{Body: comment}, nil
@@ -410,12 +411,12 @@ func (h *CommentHandler) CreateReplyHandler(ctx context.Context, req *CreateRepl
 
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "create_comment", parent.EntityType, comment.ID, map[string]interface{}{
 				"entity_id": parent.EntityID,
 				"parent_id": parentIDUint,
 			})
-		}()
+		})
 	}
 
 	return &CreateReplyResponse{Body: comment}, nil
@@ -493,9 +494,9 @@ func (h *CommentHandler) UpdateCommentHandler(ctx context.Context, req *UpdateCo
 
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "edit_comment", "comment", uint(commentID), nil)
-		}()
+		})
 	}
 
 	return &UpdateCommentResponse{Body: comment}, nil
@@ -559,11 +560,11 @@ func (h *CommentHandler) UpdateReplyPermissionHandler(ctx context.Context, req *
 	}
 
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "update_reply_permission", "comment", uint(commentID), map[string]interface{}{
 				"permission": perm,
 			})
-		}()
+		})
 	}
 
 	return &UpdateReplyPermissionResponse{Body: comment}, nil
@@ -612,9 +613,9 @@ func (h *CommentHandler) DeleteCommentHandler(ctx context.Context, req *DeleteCo
 
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "delete_comment", "comment", uint(commentID), nil)
-		}()
+		})
 	}
 
 	return nil, nil

--- a/backend/internal/api/handlers/engagement/comment_admin.go
+++ b/backend/internal/api/handlers/engagement/comment_admin.go
@@ -11,6 +11,7 @@ import (
 	"psychic-homily-backend/internal/api/middleware"
 	"psychic-homily-backend/internal/logger"
 	"psychic-homily-backend/internal/services/contracts"
+	servicesshared "psychic-homily-backend/internal/services/shared"
 )
 
 // ============================================================================
@@ -79,11 +80,11 @@ func (h *CommentAdminHandler) AdminHideCommentHandler(ctx context.Context, req *
 
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "hide_comment", "comment", uint(commentID), map[string]interface{}{
 				"reason": reason,
 			})
-		}()
+		})
 	}
 
 	return nil, nil
@@ -122,9 +123,9 @@ func (h *CommentAdminHandler) AdminRestoreCommentHandler(ctx context.Context, re
 
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "restore_comment", "comment", uint(commentID), nil)
-		}()
+		})
 	}
 
 	return nil, nil
@@ -210,9 +211,9 @@ func (h *CommentAdminHandler) AdminApproveCommentHandler(ctx context.Context, re
 
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "approve_comment", "comment", uint(commentID), nil)
-		}()
+		})
 	}
 
 	return nil, nil
@@ -259,11 +260,11 @@ func (h *CommentAdminHandler) AdminRejectCommentHandler(ctx context.Context, req
 
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "reject_comment", "comment", uint(commentID), map[string]interface{}{
 				"reason": reason,
 			})
-		}()
+		})
 	}
 
 	return nil, nil

--- a/backend/internal/api/handlers/engagement/comment_subscription.go
+++ b/backend/internal/api/handlers/engagement/comment_subscription.go
@@ -11,6 +11,7 @@ import (
 	"psychic-homily-backend/internal/api/middleware"
 	"psychic-homily-backend/internal/logger"
 	"psychic-homily-backend/internal/services/contracts"
+	servicesshared "psychic-homily-backend/internal/services/shared"
 )
 
 // CommentSubscriptionHandler handles comment subscription API requests.
@@ -72,9 +73,9 @@ func (h *CommentSubscriptionHandler) SubscribeHandler(ctx context.Context, req *
 
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "subscribe_comments", req.EntityType, uint(entityID), nil)
-		}()
+		})
 	}
 
 	resp := &SubscribeResponse{}
@@ -117,9 +118,9 @@ func (h *CommentSubscriptionHandler) UnsubscribeHandler(ctx context.Context, req
 
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "unsubscribe_comments", req.EntityType, uint(entityID), nil)
-		}()
+		})
 	}
 
 	return nil, nil

--- a/backend/internal/api/handlers/engagement/field_note.go
+++ b/backend/internal/api/handlers/engagement/field_note.go
@@ -11,6 +11,7 @@ import (
 	"psychic-homily-backend/internal/api/middleware"
 	"psychic-homily-backend/internal/logger"
 	"psychic-homily-backend/internal/services/contracts"
+	servicesshared "psychic-homily-backend/internal/services/shared"
 )
 
 // ============================================================================
@@ -123,11 +124,11 @@ func (h *FieldNoteHandler) CreateFieldNoteHandler(ctx context.Context, req *Crea
 
 	// Audit log (fire and forget)
 	if h.auditLogService != nil {
-		go func() {
+		servicesshared.GoSafe(ctx, "audit_log", func() {
 			h.auditLogService.LogAction(user.ID, "create_field_note", "show", fieldNote.ID, map[string]interface{}{
 				"show_id": uint(showID),
 			})
-		}()
+		})
 	}
 
 	return &CreateFieldNoteResponse{Body: fieldNote}, nil

--- a/backend/internal/services/admin/api_token.go
+++ b/backend/internal/services/admin/api_token.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
@@ -13,6 +14,7 @@ import (
 	adminm "psychic-homily-backend/internal/models/admin"
 	authm "psychic-homily-backend/internal/models/auth"
 	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/services/shared"
 )
 
 const (
@@ -136,9 +138,9 @@ func (s *APITokenService) ValidateToken(plainToken string) (*authm.User, *adminm
 	}
 
 	// Update last used timestamp (async to not slow down requests)
-	go func() {
+	shared.GoSafe(context.Background(), "api_token_last_used", func() {
 		s.db.Model(&token).Update("last_used_at", time.Now())
-	}()
+	})
 
 	return &token.User, &token, nil
 }

--- a/backend/internal/services/catalog/radio_fetch_service.go
+++ b/backend/internal/services/catalog/radio_fetch_service.go
@@ -432,8 +432,18 @@ func (s *RadioFetchService) runDiscoverCycle() {
 		// concurrent provider hits — the existing 1-rps per-instance rate
 		// limiter on each provider handles per-episode pacing.
 		if s.autoBackfillDays > 0 && len(result.NewShowIDs) > 0 {
+			// autoBackfillStation defers s.wg.Done() itself, so the WaitGroup
+			// stays balanced even if it panics (the defer runs during unwind
+			// before GoSafe's recover). GoSafe contains a panic here to this
+			// one goroutine — it would otherwise escape RunTickerLoop's guard,
+			// which only covers the discover-tick goroutine, not its children.
 			s.wg.Add(1)
-			go s.autoBackfillStation(station.Name, result.NewShowIDs, result.NewShowNames)
+			showIDs := result.NewShowIDs
+			showNames := result.NewShowNames
+			stationName := station.Name
+			shared.GoSafe(context.Background(), "radio_auto_backfill", func() {
+				s.autoBackfillStation(stationName, showIDs, showNames)
+			})
 		}
 	}
 

--- a/backend/internal/services/catalog/radio_fetch_service.go
+++ b/backend/internal/services/catalog/radio_fetch_service.go
@@ -432,11 +432,11 @@ func (s *RadioFetchService) runDiscoverCycle() {
 		// concurrent provider hits — the existing 1-rps per-instance rate
 		// limiter on each provider handles per-episode pacing.
 		if s.autoBackfillDays > 0 && len(result.NewShowIDs) > 0 {
-			// autoBackfillStation defers s.wg.Done() itself, so the WaitGroup
-			// stays balanced even if it panics (the defer runs during unwind
-			// before GoSafe's recover). GoSafe contains a panic here to this
-			// one goroutine — it would otherwise escape RunTickerLoop's guard,
-			// which only covers the discover-tick goroutine, not its children.
+			// GoSafe contains a panic here: this child goroutine escapes the
+			// discover tick's RunTickerLoop guard, which only covers the tick
+			// goroutine itself. autoBackfillStation defers s.wg.Done(), which
+			// runs during unwind before GoSafe's recover, so the WaitGroup
+			// stays balanced even on panic.
 			s.wg.Add(1)
 			showIDs := result.NewShowIDs
 			showNames := result.NewShowNames

--- a/backend/internal/services/catalog/radio_import_job.go
+++ b/backend/internal/services/catalog/radio_import_job.go
@@ -1,12 +1,14 @@
 package catalog
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"time"
 
 	catalogm "psychic-homily-backend/internal/models/catalog"
 	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/services/shared"
 )
 
 // CreateImportJob creates a new pending import job for a radio show.
@@ -79,7 +81,9 @@ func (s *RadioService) StartImportJob(jobID uint) error {
 	})
 
 	// Launch the import goroutine
-	go s.runImportJob(job.ID)
+	shared.GoSafe(context.Background(), "radio_import_job", func() {
+		s.runImportJob(job.ID)
+	})
 
 	return nil
 }

--- a/backend/internal/services/catalog/tag_hierarchy.go
+++ b/backend/internal/services/catalog/tag_hierarchy.go
@@ -1,6 +1,7 @@
 package catalog
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -11,6 +12,7 @@ import (
 	apperrors "psychic-homily-backend/internal/errors"
 	adminm "psychic-homily-backend/internal/models/admin"
 	catalogm "psychic-homily-backend/internal/models/catalog"
+	"psychic-homily-backend/internal/services/shared"
 )
 
 // AuditActionSetTagParent is the action name recorded when an admin sets a
@@ -176,7 +178,9 @@ func (s *TagService) SetTagParent(tagID uint, parentID *uint, actorUserID uint) 
 		return fmt.Errorf("failed to set tag parent: %w", err)
 	}
 
-	go s.writeSetParentAuditLog(actorUserID, tag.ID, tag.Name, parentID, parentName)
+	shared.GoSafe(context.Background(), "tag_set_parent_audit_log", func() {
+		s.writeSetParentAuditLog(actorUserID, tag.ID, tag.Name, parentID, parentName)
+	})
 	return nil
 }
 

--- a/backend/internal/services/catalog/tag_merge.go
+++ b/backend/internal/services/catalog/tag_merge.go
@@ -1,6 +1,7 @@
 package catalog
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -13,6 +14,7 @@ import (
 	adminm "psychic-homily-backend/internal/models/admin"
 	catalogm "psychic-homily-backend/internal/models/catalog"
 	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/services/shared"
 )
 
 // AuditActionMergeTags is the action name recorded when an admin merges tags.
@@ -232,7 +234,9 @@ func (s *TagService) MergeTags(sourceID, targetID uint, actorUserID uint) (*cont
 	// Fire-and-forget audit log after the transaction commits, matching the
 	// convention used in neighboring admin services. Errors inside LogAction
 	// are logged but never bubble up.
-	go s.writeMergeAuditLog(actorUserID, sourceID, mergedTagID, sourceName, targetName, &result)
+	shared.GoSafe(context.Background(), "tag_merge_audit_log", func() {
+		s.writeMergeAuditLog(actorUserID, sourceID, mergedTagID, sourceName, targetName, &result)
+	})
 
 	return &result, nil
 }

--- a/backend/internal/services/community/collection.go
+++ b/backend/internal/services/community/collection.go
@@ -1,6 +1,7 @@
 package community
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -583,18 +584,13 @@ func (s *CollectionService) GetBySlug(slug string, viewerID uint) (*contracts.Co
 		collectionID := collection.ID
 		uid := viewerID
 		dbHandle := s.db
-		go func() {
-			defer func() {
-				if r := recover(); r != nil {
-					log.Printf("warning: collection MarkVisited goroutine panicked for user %d collection %d: %v", uid, collectionID, r)
-				}
-			}()
+		shared.GoSafe(context.Background(), "collection_mark_visited", func() {
 			if err := dbHandle.Model(&communitym.CollectionSubscriber{}).
 				Where("collection_id = ? AND user_id = ?", collectionID, uid).
 				Update("last_visited_at", time.Now()).Error; err != nil {
 				log.Printf("warning: failed to bump last_visited_at for user %d collection %d: %v", uid, collectionID, err)
 			}
-		}()
+		})
 	}
 
 	// PSY-354: tag chips on the detail response. Empty slice (not nil) when

--- a/backend/internal/services/engagement/comment_service.go
+++ b/backend/internal/services/engagement/comment_service.go
@@ -1,6 +1,7 @@
 package engagement
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -431,16 +432,16 @@ func (s *CommentService) CreateComment(userID uint, req *contracts.CreateComment
 	// on the top of this method (e.g. reply-permission gate) don't conflict.
 	if s.notifier != nil && comment.Visibility == engagementm.CommentVisibilityVisible {
 		commentID := comment.ID
-		go func() {
+		shared.GoSafe(context.Background(), "comment_notify_subscribers", func() {
 			if nErr := s.notifier.NotifySubscribers(commentID); nErr != nil {
 				log.Printf("warning: comment notification (subscribers) failed for comment %d: %v", commentID, nErr)
 			}
-		}()
-		go func() {
+		})
+		shared.GoSafe(context.Background(), "comment_notify_mentioned", func() {
 			if nErr := s.notifier.NotifyMentioned(commentID); nErr != nil {
 				log.Printf("warning: comment notification (mentions) failed for comment %d: %v", commentID, nErr)
 			}
-		}()
+		})
 	}
 
 	return commentToResponse(comment), nil

--- a/backend/internal/services/notification/discord.go
+++ b/backend/internal/services/notification/discord.go
@@ -2,6 +2,7 @@ package notification
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -97,7 +98,7 @@ func (s *DiscordService) NotifyNewUser(user *authm.User) {
 		},
 	}
 
-	go s.sendWebhook(embed)
+	shared.GoSafe(context.Background(), "discord_webhook", func() { s.sendWebhook(embed) })
 }
 
 // NotifyNewShow sends a notification when a new show is submitted
@@ -131,7 +132,7 @@ func (s *DiscordService) NotifyNewShow(show *contracts.ShowResponse, submitterEm
 		Fields:      fields,
 	}
 
-	go s.sendWebhook(embed)
+	shared.GoSafe(context.Background(), "discord_webhook", func() { s.sendWebhook(embed) })
 }
 
 // NotifyShowStatusChange sends a notification when a show's status changes
@@ -159,7 +160,7 @@ func (s *DiscordService) NotifyShowStatusChange(showTitle string, showID uint, o
 		Fields:      fields,
 	}
 
-	go s.sendWebhook(embed)
+	shared.GoSafe(context.Background(), "discord_webhook", func() { s.sendWebhook(embed) })
 }
 
 // NotifyShowApproved sends a notification when an admin approves a show
@@ -183,7 +184,7 @@ func (s *DiscordService) NotifyShowApproved(show *contracts.ShowResponse) {
 		},
 	}
 
-	go s.sendWebhook(embed)
+	shared.GoSafe(context.Background(), "discord_webhook", func() { s.sendWebhook(embed) })
 }
 
 // NotifyShowRejected sends a notification when an admin rejects a show
@@ -208,7 +209,7 @@ func (s *DiscordService) NotifyShowRejected(show *contracts.ShowResponse, reason
 		},
 	}
 
-	go s.sendWebhook(embed)
+	shared.GoSafe(context.Background(), "discord_webhook", func() { s.sendWebhook(embed) })
 }
 
 // NotifyShowReport sends a notification when a user reports a show issue
@@ -262,7 +263,7 @@ func (s *DiscordService) NotifyShowReport(report *communitym.ShowReport, reporte
 		Fields:    fields,
 	}
 
-	go s.sendWebhook(embed)
+	shared.GoSafe(context.Background(), "discord_webhook", func() { s.sendWebhook(embed) })
 }
 
 // NotifyArtistReport sends a notification when a user reports an artist issue
@@ -311,7 +312,7 @@ func (s *DiscordService) NotifyArtistReport(report *communitym.ArtistReport, rep
 		Fields:    fields,
 	}
 
-	go s.sendWebhook(embed)
+	shared.GoSafe(context.Background(), "discord_webhook", func() { s.sendWebhook(embed) })
 }
 
 // NotifyNewVenue sends a notification when a new unverified venue is created
@@ -347,7 +348,7 @@ func (s *DiscordService) NotifyNewVenue(venueID uint, venueName, city, state str
 		Fields:      fields,
 	}
 
-	go s.sendWebhook(embed)
+	shared.GoSafe(context.Background(), "discord_webhook", func() { s.sendWebhook(embed) })
 }
 
 // NotifyNewRadioShows sends a notification when the periodic discover loop
@@ -378,7 +379,7 @@ func (s *DiscordService) NotifyNewRadioShows(stationName string, newShowNames []
 		},
 	}
 
-	go s.sendWebhook(embed)
+	shared.GoSafe(context.Background(), "discord_webhook", func() { s.sendWebhook(embed) })
 }
 
 // NotifyBackfillCompleted sends one batched notification when the auto-backfill
@@ -410,7 +411,7 @@ func (s *DiscordService) NotifyBackfillCompleted(stationName string, completedSh
 		},
 	}
 
-	go s.sendWebhook(embed)
+	shared.GoSafe(context.Background(), "discord_webhook", func() { s.sendWebhook(embed) })
 }
 
 // sendWebhook sends an embed to the Discord webhook (fire-and-forget)

--- a/backend/internal/services/pipeline/discovery.go
+++ b/backend/internal/services/pipeline/discovery.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -916,7 +917,9 @@ func (s *DiscoveryService) ImportEvents(events []contracts.DiscoveredEvent, dryR
 
 	// Fire-and-forget: queue newly imported shows for enrichment
 	if !dryRun && s.enrichmentService != nil && len(importedEventIDs) > 0 {
-		go s.queueImportedShowsForEnrichment(importedEventIDs)
+		shared.GoSafe(context.Background(), "queue_imported_shows_enrichment", func() {
+			s.queueImportedShowsForEnrichment(importedEventIDs)
+		})
 	}
 
 	return result, nil

--- a/backend/internal/services/pipeline/music_discovery.go
+++ b/backend/internal/services/pipeline/music_discovery.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -11,6 +12,7 @@ import (
 	"github.com/getsentry/sentry-go"
 
 	"psychic-homily-backend/internal/config"
+	"psychic-homily-backend/internal/services/shared"
 	"psychic-homily-backend/internal/utils"
 )
 
@@ -46,7 +48,9 @@ func (s *MusicDiscoveryService) DiscoverMusicForArtist(artistID uint, artistName
 		return
 	}
 
-	go s.triggerDiscovery(artistID, artistName)
+	shared.GoSafe(context.Background(), "music_discovery_trigger", func() {
+		s.triggerDiscovery(artistID, artistName)
+	})
 }
 
 // triggerDiscovery makes the HTTP call to the discovery endpoint

--- a/backend/internal/services/shared/safego.go
+++ b/backend/internal/services/shared/safego.go
@@ -1,0 +1,52 @@
+package shared
+
+import (
+	"context"
+	"log/slog"
+	"runtime/debug"
+)
+
+// GoSafe runs `work` in a new goroutine guarded by a panic recover, then
+// returns immediately. It is the canonical wrapper for fire-and-forget
+// goroutines launched from request handlers and service methods (audit-log
+// writes, Discord webhooks, notification fan-out, async DB touch-ups, etc.).
+//
+// Why this exists: Go treats a panic that escapes a goroutine as fatal — it
+// crashes the entire process. An HTTP handler's Sentry middleware only wraps
+// the request-serving goroutine, NOT the children it spawns with `go`. So a
+// nil-pointer deref inside one fire-and-forget LogAction or sendWebhook would
+// take down the whole server. GoSafe contains that blast radius to the one
+// goroutine.
+//
+// The recover mirrors RunTickerLoop's guard and routes through the same
+// process-wide PanicHandler (installed once in cmd/server/main.go after Sentry
+// init), so a recovered panic is both logged via slog.Default() and escalated
+// to Sentry tagged with `name`. When no handler is set (tests, CLIs), the
+// slog.Error path still fires and the panic is otherwise swallowed.
+//
+// `ctx` is accepted so call sites can hand the goroutine a request- or
+// service-scoped context (deadlines, request-id) and so future work that
+// needs cancellation has a hook. GoSafe itself does not consume `ctx`; the
+// goroutine outlives the request by design (that is the point of
+// fire-and-forget), so `work` should capture only what it needs and must not
+// assume `ctx` stays un-canceled. Pass context.Background() when there is no
+// meaningful parent context.
+//
+// `name` labels the goroutine in logs and the Sentry `service` tag; use a
+// short, stable identifier (e.g. "audit_log", "discord_webhook").
+func GoSafe(ctx context.Context, name string, work func()) {
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				stack := debug.Stack()
+				slog.Default().Error("fire-and-forget goroutine panic — recovered",
+					"goroutine", name,
+					"panic", r,
+					"stack", string(stack),
+				)
+				invokePanicHandler(name, r, stack)
+			}
+		}()
+		work()
+	}()
+}

--- a/backend/internal/services/shared/safego_test.go
+++ b/backend/internal/services/shared/safego_test.go
@@ -1,0 +1,166 @@
+package shared
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// lockedBuffer is a concurrency-safe io.Writer wrapping a bytes.Buffer.
+// GoSafe's slog.Error fires on the spawned goroutine while the test polls the
+// captured output from the main goroutine, so the shared withCapturedSlog
+// helper (which exposes a raw *bytes.Buffer) would race. This wrapper
+// serializes the writes and reads.
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// withSafeCapturedSlog is the concurrency-safe analogue of withCapturedSlog,
+// used by the GoSafe tests because the panic log is emitted off-goroutine.
+func withSafeCapturedSlog(t *testing.T) *lockedBuffer {
+	t.Helper()
+	buf := &lockedBuffer{}
+	original := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(original) })
+	return buf
+}
+
+// TestGoSafe_RecoversPanic is the load-bearing assertion of PSY-751: a
+// fire-and-forget work func that panics is recovered inside the goroutine —
+// the process survives — and both the slog path and the registered
+// PanicHandler (the Sentry wiring point) fire with the goroutine name, panic
+// value, and a stack trace.
+//
+// If GoSafe's recover regressed, the panicking goroutine would crash the test
+// binary (Go makes an unrecovered goroutine panic fatal), so the test reaching
+// its assertions at all already proves recovery.
+func TestGoSafe_RecoversPanic(t *testing.T) {
+	logs := withSafeCapturedSlog(t)
+	snapshot := installRecordingPanicHandler(t)
+
+	done := make(chan struct{})
+	GoSafe(context.Background(), "test-fire-and-forget", func() {
+		defer close(done)
+		panic("boom in fire-and-forget")
+	})
+
+	select {
+	case <-done:
+		// work ran to its panic; the defer closed the channel before
+		// unwinding into GoSafe's recover.
+	case <-time.After(2 * time.Second):
+		t.Fatal("GoSafe work func did not run")
+	}
+
+	// The PanicHandler runs after recover, so poll briefly for it to land.
+	var got []capturedPanic
+	require.Eventually(t, func() bool {
+		got = snapshot()
+		return len(got) == 1
+	}, 2*time.Second, 5*time.Millisecond, "panic handler should be invoked exactly once")
+
+	assert.Equal(t, "test-fire-and-forget", got[0].service)
+	assert.Equal(t, "boom in fire-and-forget", got[0].panicValue)
+	assert.NotEmpty(t, got[0].stack, "stack trace should be populated")
+	assert.Contains(t, string(got[0].stack), "safego.go", "stack should reference the recover site")
+
+	logged := logs.String()
+	assert.Contains(t, logged, "fire-and-forget goroutine panic — recovered", "panic should be logged")
+	assert.Contains(t, logged, `"goroutine":"test-fire-and-forget"`, "goroutine name should be in log")
+	assert.Contains(t, logged, "boom in fire-and-forget", "panic value should be in log")
+}
+
+// TestGoSafe_RunsWorkOnHappyPath sanity-checks the non-panicking path: work
+// runs exactly once and no panic handler fires.
+func TestGoSafe_RunsWorkOnHappyPath(t *testing.T) {
+	_ = withSafeCapturedSlog(t)
+	snapshot := installRecordingPanicHandler(t)
+
+	var calls atomic.Int32
+	done := make(chan struct{})
+	GoSafe(context.Background(), "happy-fire-and-forget", func() {
+		calls.Add(1)
+		close(done)
+	})
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("GoSafe work func did not run")
+	}
+
+	assert.Equal(t, int32(1), calls.Load(), "work should run exactly once")
+	assert.Empty(t, snapshot(), "no panic handler should fire on the happy path")
+}
+
+// TestGoSafe_NilPanicHandlerIsNoop guards that with no handler installed (the
+// package default — e.g. CLIs and tests that don't wire Sentry) a panicking
+// work func is still recovered without crashing and the slog path still fires.
+func TestGoSafe_NilPanicHandlerIsNoop(t *testing.T) {
+	logs := withSafeCapturedSlog(t)
+	SetPanicHandler(nil)
+	t.Cleanup(func() { SetPanicHandler(nil) })
+
+	done := make(chan struct{})
+	GoSafe(context.Background(), "no-handler-fire-and-forget", func() {
+		defer close(done)
+		panic("boom-no-handler")
+	})
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("GoSafe work func did not run")
+	}
+
+	// Give the recover/log a moment to flush after the work func unwinds.
+	require.Eventually(t, func() bool {
+		return len(logs.String()) > 0
+	}, 2*time.Second, 5*time.Millisecond, "slog path should fire even with a nil handler")
+	assert.Contains(t, logs.String(), "boom-no-handler")
+}
+
+// TestGoSafe_ConcurrentLaunchesAllRecover exercises many concurrent GoSafe
+// launches that each panic — none escape, the process survives, and the
+// handler records one capture per launch. Run under -race this also guards the
+// handler's locking.
+func TestGoSafe_ConcurrentLaunchesAllRecover(t *testing.T) {
+	_ = withSafeCapturedSlog(t)
+	snapshot := installRecordingPanicHandler(t)
+
+	const n = 50
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		GoSafe(context.Background(), "concurrent-fire-and-forget", func() {
+			defer wg.Done()
+			panic("boom-concurrent")
+		})
+	}
+	wg.Wait()
+
+	require.Eventually(t, func() bool {
+		return len(snapshot()) == n
+	}, 3*time.Second, 10*time.Millisecond, "every launch should record exactly one panic")
+}


### PR DESCRIPTION
## Summary

- New `shared.GoSafe(ctx, name, work)` in `internal/services/shared/safego.go` — a panic-recovering wrapper for fire-and-forget goroutines launched from request handlers and service methods. It mirrors `RunTickerLoop`'s guard and routes recovered panics through the **same** process-wide `PanicHandler` (slog.Error + Sentry capture tagged with `name`) already wired in `cmd/server/main.go`, so no main.go change was needed.
- **Why:** without a `defer recover()`, a panic inside a fire-and-forget `LogAction`, `sendWebhook`, or notification fan-out crashed the entire server — Go makes an escaped goroutine panic fatal, and the request's Sentry middleware only covers the request goroutine, not children it spawns with `go`.
- Migrated **101 fire-and-forget sites** (81 request-handler + 20 service-layer) from `go func(){...}()` / `go s.method(...)` to `GoSafe(...)`. Re-grepped the current set rather than relying on the audit (sibling tickets added sites since).
- Replaced one hand-rolled `defer recover()` (collection `MarkVisited`) that only logged — it now also escalates to Sentry via the shared handler.

## Test plan

- [x] `cd backend && go build ./...` — passes (catches any missed call-site signature change)
- [x] `cd backend && go test ./...` — full suite passes (wide change), all packages `ok`, zero failures
- [x] `go test ./internal/services/shared/ -run TestGoSafe -race -count=3` — 4 GoSafe tests pass under the race detector
- [x] `go vet` on changed packages — clean
- [x] Grep confirms zero fire-and-forget `go func()` / `go h.`/`go s.` remain in `internal/api/handlers`; the only `go` launches left in `internal/services` are managed long-running loops (`RunTickerLoop` + `wg.Add(1)`) and `GoSafe`'s own implementation

## Manual repro

The `TestGoSafe_RecoversPanic` unit test is the repro: a work func that `panic`s is recovered inside the goroutine (the test binary survives — an unrecovered goroutine panic would crash it), and the registered `PanicHandler` (the Sentry wiring point) fires with `service="test-fire-and-forget"`, the panic value, and a stack trace referencing `safego.go`; the slog path also fires. Additionally exercised the AC's spot-check via a throwaway test that mirrors a migrated handler — `GoSafe(ctx, "audit_log", func(){ panic("test") })` followed by the handler returning its response — and confirmed the "request" returned `"200 OK"` with the process surviving the child panic.

## Simplify

`/simplify` run (reuse / quality / efficiency lenses applied directly — Agent tool unavailable in this context). Code was largely clean: GoSafe reuses the existing `invokePanicHandler`/`PanicHandler` infra (no duplication), the test reuses `installRecordingPanicHandler`/`capturedPanic`, and the `name` string literals follow the existing `RunTickerLoop` service-name convention (no constants, matching precedent). Only fix: tightened one verbose comment in `radio_fetch_service.go` (separate `simplify pass` commit).

## Scope deviation

Managed long-running service supervisors (`go s.run(ctx)`, `runFetchLoop`, `runCleanupLoop`, the scheduler worker pool, etc.) are intentionally **left as-is** — they are `wg.Add(1)`-tracked and run `RunTickerLoop` internally, which is already the canonical panic guard (PSY-615/617). Wrapping them would be wrong. The one wg-tracked goroutine I did wrap is the radio auto-backfill (`radio_fetch_service.go`): it's fired per discover-tick and its panic would escape `RunTickerLoop`'s guard (which only covers the tick goroutine, not children). It's wrapped while preserving WaitGroup balance — `autoBackfillStation` defers `wg.Done()` itself, which runs during unwind before GoSafe's recover.

Closes PSY-751