### PR TITLE
PSY-755: ON CONFLICT DO NOTHING on idempotent toggle paths

### DIFF
--- a/backend/internal/services/catalog/label.go
+++ b/backend/internal/services/catalog/label.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
 	"psychic-homily-backend/db"
 	apperrors "psychic-homily-backend/internal/errors"
@@ -537,12 +538,14 @@ func (s *LabelService) AddArtistToLabel(labelID, artistID uint) error {
 		return fmt.Errorf("failed to get artist: %w", err)
 	}
 
-	// Idempotent: use FirstOrCreate to skip if already exists
+	// Idempotent insert. ON CONFLICT DO NOTHING is safe under concurrent calls
+	// where a SELECT-then-INSERT (FirstOrCreate) would let two callers both
+	// miss the row and trip the artist_labels(artist_id, label_id) primary key.
 	al := catalogm.ArtistLabel{
 		ArtistID: artistID,
 		LabelID:  labelID,
 	}
-	if err := s.db.Where("artist_id = ? AND label_id = ?", artistID, labelID).FirstOrCreate(&al).Error; err != nil {
+	if err := s.db.Clauses(clause.OnConflict{DoNothing: true}).Create(&al).Error; err != nil {
 		return fmt.Errorf("failed to create artist-label link: %w", err)
 	}
 
@@ -573,13 +576,17 @@ func (s *LabelService) AddReleaseToLabel(labelID, releaseID uint, catalogNumber 
 		return fmt.Errorf("failed to get release: %w", err)
 	}
 
-	// Idempotent: use FirstOrCreate to skip if already exists
+	// Idempotent insert. ON CONFLICT DO NOTHING is safe under concurrent calls
+	// where a SELECT-then-INSERT (FirstOrCreate) would let two callers both
+	// miss the row and trip the release_labels(release_id, label_id) primary
+	// key. As with the prior FirstOrCreate, an existing row's catalog_number is
+	// left untouched (the conflict target is the PK, not catalog_number).
 	rl := catalogm.ReleaseLabel{
 		ReleaseID:     releaseID,
 		LabelID:       labelID,
 		CatalogNumber: catalogNumber,
 	}
-	if err := s.db.Where("release_id = ? AND label_id = ?", releaseID, labelID).FirstOrCreate(&rl).Error; err != nil {
+	if err := s.db.Clauses(clause.OnConflict{DoNothing: true}).Create(&rl).Error; err != nil {
 		return fmt.Errorf("failed to create release-label link: %w", err)
 	}
 

--- a/backend/internal/services/community/collection.go
+++ b/backend/internal/services/community/collection.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
 	"psychic-homily-backend/db"
 	apperrors "psychic-homily-backend/internal/errors"
@@ -1303,11 +1304,13 @@ func (s *CollectionService) Subscribe(slug string, userID uint) error {
 		LastVisitedAt: &now,
 	}
 
-	// Use FirstOrCreate to handle idempotent subscribe
-	result := s.db.Where("collection_id = ? AND user_id = ?", collection.ID, userID).
-		FirstOrCreate(subscriber)
-	if result.Error != nil {
-		return fmt.Errorf("failed to subscribe to collection: %w", result.Error)
+	// ON CONFLICT DO NOTHING — idempotent under concurrent subscribes. A plain
+	// FirstOrCreate (SELECT-then-INSERT) lets two simultaneous calls both miss
+	// the row and trip the collection_subscribers(collection_id, user_id)
+	// primary key. As with the prior FirstOrCreate, an existing subscription's
+	// last_visited_at is left untouched on conflict.
+	if err := s.db.Clauses(clause.OnConflict{DoNothing: true}).Create(subscriber).Error; err != nil {
+		return fmt.Errorf("failed to subscribe to collection: %w", err)
 	}
 
 	return nil

--- a/backend/internal/services/engagement/attendance.go
+++ b/backend/internal/services/engagement/attendance.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
 	"psychic-homily-backend/db"
 	apperrors "psychic-homily-backend/internal/errors"
@@ -77,7 +78,13 @@ func (s *AttendanceService) SetAttendance(userID, showID uint, status string) er
 			return fmt.Errorf("failed to remove opposite attendance: %w", result.Error)
 		}
 
-		// Upsert the desired status
+		// Insert the desired status. ON CONFLICT DO NOTHING keeps this
+		// idempotent under concurrent toggles — a plain FirstOrCreate
+		// (SELECT-then-INSERT) lets two simultaneous taps both miss the row
+		// and both INSERT, tripping the unique violation on
+		// user_bookmarks(user_id, entity_type, entity_id, action). When the
+		// row already exists (re-tapping the current status) DO NOTHING leaves
+		// it untouched, which is the desired no-op.
 		bookmark := engagementm.UserBookmark{
 			UserID:     userID,
 			EntityType: engagementm.BookmarkEntityShow,
@@ -85,14 +92,7 @@ func (s *AttendanceService) SetAttendance(userID, showID uint, status string) er
 			Action:     setAction,
 			CreatedAt:  time.Now().UTC(),
 		}
-		return tx.Where(engagementm.UserBookmark{
-			UserID:     userID,
-			EntityType: engagementm.BookmarkEntityShow,
-			EntityID:   showID,
-			Action:     setAction,
-		}).Assign(engagementm.UserBookmark{
-			CreatedAt: bookmark.CreatedAt,
-		}).FirstOrCreate(&bookmark).Error
+		return tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&bookmark).Error
 	}); err != nil {
 		return apperrors.ErrAttendanceInternal(err)
 	}

--- a/backend/internal/services/engagement/attendance_test.go
+++ b/backend/internal/services/engagement/attendance_test.go
@@ -31,17 +31,10 @@ func (suite *AttendanceServiceIntegrationTestSuite) SetupSuite() {
 	suite.testDB = testutil.SetupTestPostgres(suite.T())
 	suite.db = suite.testDB.DB
 
-	// Bound the connection pool. SetAttendance runs inside an explicit
-	// transaction, so each concurrent call holds a connection for its whole
-	// span. TestSetAttendance_ConcurrentIdempotent fires many calls at once;
-	// without a cap the pool opens a connection per goroutine and exhausts the
-	// container's max_connections (53300) before the unique-violation race can
-	// even be exercised. A modest cap queues goroutines at the pool (the
-	// realistic production shape) while still letting enough transactions
-	// interleave to trip a SELECT-then-INSERT race.
-	if sqlDB, err := suite.db.DB(); err == nil {
-		sqlDB.SetMaxOpenConns(25)
-	}
+	// TestSetAttendance_ConcurrentIdempotent fires many calls at once, each
+	// holding a connection for its whole transaction; bound the pool so they
+	// queue rather than exhaust the container's connections.
+	boundTestPool(suite.db)
 
 	suite.attendanceService = NewAttendanceService(suite.testDB.DB)
 }

--- a/backend/internal/services/engagement/attendance_test.go
+++ b/backend/internal/services/engagement/attendance_test.go
@@ -2,6 +2,7 @@ package engagement
 
 import (
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -29,6 +30,18 @@ type AttendanceServiceIntegrationTestSuite struct {
 func (suite *AttendanceServiceIntegrationTestSuite) SetupSuite() {
 	suite.testDB = testutil.SetupTestPostgres(suite.T())
 	suite.db = suite.testDB.DB
+
+	// Bound the connection pool. SetAttendance runs inside an explicit
+	// transaction, so each concurrent call holds a connection for its whole
+	// span. TestSetAttendance_ConcurrentIdempotent fires many calls at once;
+	// without a cap the pool opens a connection per goroutine and exhausts the
+	// container's max_connections (53300) before the unique-violation race can
+	// even be exercised. A modest cap queues goroutines at the pool (the
+	// realistic production shape) while still letting enough transactions
+	// interleave to trip a SELECT-then-INSERT race.
+	if sqlDB, err := suite.db.DB(); err == nil {
+		sqlDB.SetMaxOpenConns(25)
+	}
 
 	suite.attendanceService = NewAttendanceService(suite.testDB.DB)
 }
@@ -330,6 +343,44 @@ func (suite *AttendanceServiceIntegrationTestSuite) TestSetAttendance_Idempotent
 			user.ID, engagementm.BookmarkEntityShow, show.ID, engagementm.BookmarkActionGoing).
 		Count(&count)
 	suite.Equal(int64(1), count)
+}
+
+// TestSetAttendance_ConcurrentIdempotent fires N parallel SetAttendance("going")
+// calls for the same (user, show) and asserts none errors and exactly one row
+// lands. PSY-755: the insert leg used FirstOrCreate (SELECT-then-INSERT) inside
+// the transaction, so two racing taps could both miss the row and both INSERT,
+// surfacing the 23505 unique violation. ON CONFLICT DO NOTHING makes the insert
+// leg idempotent. The opposite-status DELETE + transaction rollback (PSY-753)
+// stay intact and are unaffected here since no opposite row exists.
+func (suite *AttendanceServiceIntegrationTestSuite) TestSetAttendance_ConcurrentIdempotent() {
+	user := suite.createTestUser()
+	show := suite.createApprovedShow("Concurrent Attendance Show", user.ID)
+
+	const n = 150
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	start := make(chan struct{})
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			<-start // release all goroutines together to maximize contention
+			errs[idx] = suite.attendanceService.SetAttendance(user.ID, show.ID, "going")
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		suite.NoError(err, "concurrent SetAttendance #%d must not surface a unique violation", i)
+	}
+
+	var count int64
+	suite.db.Model(&engagementm.UserBookmark{}).
+		Where("user_id = ? AND entity_type = ? AND entity_id = ? AND action = ?",
+			user.ID, engagementm.BookmarkEntityShow, show.ID, engagementm.BookmarkActionGoing).
+		Count(&count)
+	suite.Equal(int64(1), count, "concurrent going taps must collapse to exactly one row")
 }
 
 // =============================================================================

--- a/backend/internal/services/engagement/bookmark.go
+++ b/backend/internal/services/engagement/bookmark.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
 	"psychic-homily-backend/db"
 	engagementm "psychic-homily-backend/internal/models/engagement"
@@ -26,7 +27,8 @@ func NewBookmarkService(database *gorm.DB) *BookmarkService {
 }
 
 // CreateBookmark creates a bookmark for a user on an entity.
-// Idempotent: if the bookmark already exists, it updates the created_at timestamp.
+// Idempotent: if the bookmark already exists, this is a no-op (the existing
+// row, including its created_at and any reminder_sent_at, is left untouched).
 func (s *BookmarkService) CreateBookmark(userID uint, entityType engagementm.BookmarkEntityType, entityID uint, action engagementm.BookmarkAction) error {
 	if s.db == nil {
 		return fmt.Errorf("database not initialized")
@@ -40,15 +42,13 @@ func (s *BookmarkService) CreateBookmark(userID uint, entityType engagementm.Boo
 		CreatedAt:  time.Now().UTC(),
 	}
 
-	err := s.db.Where(engagementm.UserBookmark{
-		UserID:     userID,
-		EntityType: entityType,
-		EntityID:   entityID,
-		Action:     action,
-	}).Assign(engagementm.UserBookmark{
-		CreatedAt: bookmark.CreatedAt,
-	}).FirstOrCreate(&bookmark).Error
-
+	// ON CONFLICT DO NOTHING — idempotent under concurrent toggles. A plain
+	// FirstOrCreate (SELECT-then-INSERT) lets two simultaneous saves both miss
+	// the row and both INSERT, tripping the unique violation on
+	// user_bookmarks(user_id, entity_type, entity_id, action). DO NOTHING
+	// deliberately preserves the existing row's created_at and reminder_sent_at
+	// so a re-save never resets a reminder's already-sent state.
+	err := s.db.Clauses(clause.OnConflict{DoNothing: true}).Create(&bookmark).Error
 	if err != nil {
 		return fmt.Errorf("failed to create bookmark: %w", err)
 	}

--- a/backend/internal/services/engagement/follow.go
+++ b/backend/internal/services/engagement/follow.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
 	"psychic-homily-backend/db"
 	apperrors "psychic-homily-backend/internal/errors"
@@ -67,12 +68,11 @@ func (s *FollowService) Follow(userID uint, entityType string, entityID uint) er
 		CreatedAt:  time.Now().UTC(),
 	}
 
-	if err := s.db.Where(engagementm.UserBookmark{
-		UserID:     userID,
-		EntityType: engagementm.BookmarkEntityType(entityType),
-		EntityID:   entityID,
-		Action:     engagementm.BookmarkActionFollow,
-	}).FirstOrCreate(&bookmark).Error; err != nil {
+	// ON CONFLICT DO NOTHING — idempotent under concurrent toggles. A plain
+	// FirstOrCreate (SELECT-then-INSERT) lets two simultaneous follows both
+	// miss the row and both INSERT, tripping the unique violation. The unique
+	// constraint is user_bookmarks(user_id, entity_type, entity_id, action).
+	if err := s.db.Clauses(clause.OnConflict{DoNothing: true}).Create(&bookmark).Error; err != nil {
 		return apperrors.ErrFollowInternal(err)
 	}
 	return nil

--- a/backend/internal/services/engagement/follow_test.go
+++ b/backend/internal/services/engagement/follow_test.go
@@ -2,6 +2,7 @@ package engagement
 
 import (
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -97,6 +98,17 @@ type FollowServiceIntegrationTestSuite struct {
 func (suite *FollowServiceIntegrationTestSuite) SetupSuite() {
 	suite.testDB = testutil.SetupTestPostgres(suite.T())
 	suite.db = suite.testDB.DB
+
+	// Bound the connection pool. TestFollow_ConcurrentIdempotent fires many
+	// Follow calls at once; without a cap each goroutine opens its own
+	// connection and, especially when other integration suites run in the same
+	// `go test` invocation, exhausts the container's max_connections (53300)
+	// before the unique-violation race can be exercised. A modest cap queues
+	// goroutines at the pool (the realistic production shape) while still
+	// letting enough INSERTs interleave to trip a SELECT-then-INSERT race.
+	if sqlDB, err := suite.db.DB(); err == nil {
+		sqlDB.SetMaxOpenConns(25)
+	}
 
 	suite.followService = NewFollowService(suite.testDB.DB)
 }
@@ -237,6 +249,44 @@ func (suite *FollowServiceIntegrationTestSuite) TestFollow_Idempotent() {
 			user.ID, engagementm.BookmarkEntityArtist, artistID, engagementm.BookmarkActionFollow).
 		Count(&count)
 	suite.Equal(int64(1), count)
+}
+
+// TestFollow_ConcurrentIdempotent fires N parallel Follow calls for the same
+// (user, entity) and asserts none returns an error and exactly one row lands.
+// PSY-755: the prior FirstOrCreate (SELECT-then-INSERT) let two racing calls
+// both miss the row and both INSERT, surfacing the 23505 unique violation as a
+// user-visible error from a supposedly-idempotent op. ON CONFLICT DO NOTHING
+// makes the INSERT itself idempotent so no caller sees a failure under
+// contention.
+func (suite *FollowServiceIntegrationTestSuite) TestFollow_ConcurrentIdempotent() {
+	user := suite.createTestUser()
+	artistID := suite.createTestArtist("Concurrent Follow Artist")
+
+	const n = 100
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	start := make(chan struct{})
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			<-start // release all goroutines together to maximize contention
+			errs[idx] = suite.followService.Follow(user.ID, "artist", artistID)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		suite.NoError(err, "concurrent Follow #%d must not surface a unique violation", i)
+	}
+
+	var count int64
+	suite.db.Model(&engagementm.UserBookmark{}).
+		Where("user_id = ? AND entity_type = ? AND entity_id = ? AND action = ?",
+			user.ID, engagementm.BookmarkEntityArtist, artistID, engagementm.BookmarkActionFollow).
+		Count(&count)
+	suite.Equal(int64(1), count, "concurrent follows must collapse to exactly one row")
 }
 
 func (suite *FollowServiceIntegrationTestSuite) TestFollow_Venue() {

--- a/backend/internal/services/engagement/follow_test.go
+++ b/backend/internal/services/engagement/follow_test.go
@@ -99,16 +99,9 @@ func (suite *FollowServiceIntegrationTestSuite) SetupSuite() {
 	suite.testDB = testutil.SetupTestPostgres(suite.T())
 	suite.db = suite.testDB.DB
 
-	// Bound the connection pool. TestFollow_ConcurrentIdempotent fires many
-	// Follow calls at once; without a cap each goroutine opens its own
-	// connection and, especially when other integration suites run in the same
-	// `go test` invocation, exhausts the container's max_connections (53300)
-	// before the unique-violation race can be exercised. A modest cap queues
-	// goroutines at the pool (the realistic production shape) while still
-	// letting enough INSERTs interleave to trip a SELECT-then-INSERT race.
-	if sqlDB, err := suite.db.DB(); err == nil {
-		sqlDB.SetMaxOpenConns(25)
-	}
+	// TestFollow_ConcurrentIdempotent fires many Follow calls at once; bound
+	// the pool so they queue rather than exhaust the container's connections.
+	boundTestPool(suite.db)
 
 	suite.followService = NewFollowService(suite.testDB.DB)
 }

--- a/backend/internal/services/engagement/test_helpers_test.go
+++ b/backend/internal/services/engagement/test_helpers_test.go
@@ -1,4 +1,22 @@
 package engagement
 
+import "gorm.io/gorm"
+
 // stringPtr returns a pointer to a string. Test helper.
 func stringPtr(s string) *string { return &s }
+
+// concurrentTestPoolSize caps open connections for the concurrent-toggle
+// suites. The cap queues goroutines at the pool (the realistic production
+// shape) rather than opening a connection per goroutine and exhausting the
+// container's max_connections (53300) — which would mask the unique-violation
+// race the tests exist to catch. Sized well under Postgres' default
+// max_connections while leaving enough room for INSERTs to interleave.
+const concurrentTestPoolSize = 25
+
+// boundTestPool caps the connection pool on a test DB. Used by suites whose
+// concurrent tests fire many simultaneous calls; see concurrentTestPoolSize.
+func boundTestPool(db *gorm.DB) {
+	if sqlDB, err := db.DB(); err == nil {
+		sqlDB.SetMaxOpenConns(concurrentTestPoolSize)
+	}
+}


### PR DESCRIPTION
## Summary

Five idempotent toggle paths used GORM `FirstOrCreate` (SELECT-then-INSERT, no upsert lock). Under concurrent toggles (double-tap, retry) two callers can both miss the row in the SELECT then both INSERT, tripping a 23505 unique violation — a user-visible error from a supposedly-idempotent op. Converted all six call sites to `Clauses(clause.OnConflict{DoNothing: true}).Create(...)`, the established PSY-352 convention (already used in collection `Like` + comment auto-subscribe).

Sites converted:
- `engagement/follow.go` — `Follow`
- `engagement/attendance.go` — `SetAttendance` insert leg (the PSY-753 DELETE-error rollback + PSY-761 typed-error wrapper are untouched; only the upsert leg changed)
- `engagement/bookmark.go` — `CreateBookmark`
- `catalog/label.go` — `AddArtistToLabel`, `AddReleaseToLabel`
- `community/collection.go` — `Subscribe`

## ON CONFLICT semantics audit (per acceptance criteria)

No caller relied on `FirstOrCreate`'s row-population/refresh behavior:
- `CreateBookmark` and `SetAttendance` dropped an `Assign(created_at)` timestamp refresh on re-toggle. Reminder dedup keys off `reminder_sent_at` (untouched by DO NOTHING), **not** `created_at`, so there is no behavior change to reminders.
- `Subscribe` (`last_visited_at`) and the two label joins (`catalog_number`) already left existing-row columns untouched on conflict under `FirstOrCreate` — DO NOTHING preserves that.

Underlying unique constraints confirmed present: `user_bookmarks(user_id, entity_type, entity_id, action)`; `artist_labels`/`release_labels`/`collection_subscribers` composite PKs.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` (full suite, testcontainers Postgres) — all packages `ok`
- [x] New `TestFollow_ConcurrentIdempotent` + `TestSetAttendance_ConcurrentIdempotent` — fire N parallel calls, assert no error surfaces and exactly one row lands
- [x] Concurrent tests pass under `-race`
- [x] Discriminating-power verified: with `FirstOrCreate` restored, both tests reliably trip the exact 23505 unique violation (and zero 53300 connection-exhaustion, after bounding the suite pool); with the fix they pass 8/8

## Manual repro

The concurrent-toggle tests **are** the repro. Demonstrated both directions against a real Postgres testcontainer:
- Old `FirstOrCreate` under contention → `duplicate key value violates unique constraint ... (SQLSTATE 23505)` surfaced as a service error.
- New ON CONFLICT DO NOTHING → no error under N parallel calls, exactly one row, race-clean, stable across repeated runs.

Each concurrent suite bounds its connection pool (shared `boundTestPool` helper) so goroutines queue at the pool (production-realistic) rather than exhausting the container's `max_connections` before the race can be exercised.

## Simplify

`/simplify` run before PR. Reuse: the OnConflict call matches the existing convention byte-for-byte (no new abstraction needed). Quality: extracted the verbatim-duplicated pool-cap block from both test suites into a shared `boundTestPool` helper + `concurrentTestPoolSize` constant. Efficiency: net win — ON CONFLICT is one statement vs `FirstOrCreate`'s SELECT+INSERT. Committed as a separate `PSY-755: simplify pass`; affected tests re-run green.

Closes PSY-755

🤖 Generated with [Claude Code](https://claude.com/claude-code)