### PR TITLE
PSY-764: cover audited 0% handler funcs + raise shared helpers to 100%

### DIFF
--- a/backend/internal/api/handlers/admin/admin_stats_test.go
+++ b/backend/internal/api/handlers/admin/admin_stats_test.go
@@ -1,0 +1,49 @@
+package admin
+
+import (
+	"fmt"
+	"testing"
+
+	"psychic-homily-backend/internal/api/handlers/shared/testhelpers"
+	authm "psychic-homily-backend/internal/models/auth"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// =============================================================================
+// GetActivityFeedHandler — admin-gated; middleware guarantees a user.
+// =============================================================================
+
+func TestGetActivityFeedHandler_Success(t *testing.T) {
+	mock := &testhelpers.MockAdminStatsService{
+		GetRecentActivityFn: func() (*contracts.ActivityFeedResponse, error) {
+			return &contracts.ActivityFeedResponse{
+				Events: []contracts.ActivityEvent{
+					{EventType: "edit_approved", ActorName: "admin"},
+				},
+			}, nil
+		},
+	}
+	h := NewAdminStatsHandler(mock)
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
+
+	resp, err := h.GetActivityFeedHandler(ctx, &GetActivityFeedRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Body.Events) != 1 {
+		t.Errorf("expected 1 event, got %d", len(resp.Body.Events))
+	}
+}
+
+func TestGetActivityFeedHandler_ServiceError(t *testing.T) {
+	mock := &testhelpers.MockAdminStatsService{
+		GetRecentActivityFn: func() (*contracts.ActivityFeedResponse, error) {
+			return nil, fmt.Errorf("db error")
+		},
+	}
+	h := NewAdminStatsHandler(mock)
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
+
+	_, err := h.GetActivityFeedHandler(ctx, &GetActivityFeedRequest{})
+	testhelpers.AssertHumaError(t, err, 500)
+}

--- a/backend/internal/api/handlers/admin/auto_promotion_test.go
+++ b/backend/internal/api/handlers/admin/auto_promotion_test.go
@@ -1,0 +1,122 @@
+package admin
+
+import (
+	"fmt"
+	"testing"
+
+	"psychic-homily-backend/internal/api/handlers/shared/testhelpers"
+	authm "psychic-homily-backend/internal/models/auth"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// =============================================================================
+// NewAutoPromotionHandler
+// =============================================================================
+
+func TestNewAutoPromotionHandler_WiresService(t *testing.T) {
+	svc := &testhelpers.MockAutoPromotionService{}
+	h := NewAutoPromotionHandler(svc)
+	if h == nil {
+		t.Fatal("NewAutoPromotionHandler returned nil")
+	}
+	if h.autoPromotionService != svc {
+		t.Error("handler did not retain the injected auto-promotion service")
+	}
+}
+
+// =============================================================================
+// EvaluateAllUsersHandler — admin-gated; middleware guarantees a user.
+// =============================================================================
+
+func TestEvaluateAllUsersHandler_Success(t *testing.T) {
+	mock := &testhelpers.MockAutoPromotionService{
+		EvaluateAllUsersFn: func() (*contracts.AutoPromotionResult, error) {
+			return &contracts.AutoPromotionResult{
+				Promoted:  []contracts.UserTierChange{{UserID: 2, NewTier: "contributor"}},
+				Demoted:   nil,
+				Unchanged: 5,
+				Errors:    0,
+			}, nil
+		},
+	}
+	h := NewAutoPromotionHandler(mock)
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
+
+	resp, err := h.EvaluateAllUsersHandler(ctx, &EvaluateAllUsersRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Body.Promoted) != 1 || resp.Body.Unchanged != 5 {
+		t.Errorf("unexpected result body: %+v", resp.Body)
+	}
+}
+
+func TestEvaluateAllUsersHandler_ServiceError(t *testing.T) {
+	mock := &testhelpers.MockAutoPromotionService{
+		EvaluateAllUsersFn: func() (*contracts.AutoPromotionResult, error) {
+			return nil, fmt.Errorf("db error")
+		},
+	}
+	h := NewAutoPromotionHandler(mock)
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
+
+	_, err := h.EvaluateAllUsersHandler(ctx, &EvaluateAllUsersRequest{})
+	testhelpers.AssertHumaError(t, err, 500)
+}
+
+// =============================================================================
+// EvaluateUserHandler — distinguishes "user not found" (404) from other 500s.
+// =============================================================================
+
+func TestEvaluateUserHandler_Success(t *testing.T) {
+	mock := &testhelpers.MockAutoPromotionService{
+		EvaluateUserFn: func(userID uint) (*contracts.UserEvaluationResult, error) {
+			if userID != 42 {
+				t.Errorf("unexpected userID=%d", userID)
+			}
+			return &contracts.UserEvaluationResult{
+				UserID:      42,
+				CurrentTier: "new",
+				Changed:     true,
+				NewTier:     "contributor",
+			}, nil
+		},
+	}
+	h := NewAutoPromotionHandler(mock)
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
+
+	resp, err := h.EvaluateUserHandler(ctx, &EvaluateUserRequest{UserID: 42})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.UserID != 42 || resp.Body.NewTier != "contributor" {
+		t.Errorf("unexpected result body: %+v", resp.Body)
+	}
+}
+
+func TestEvaluateUserHandler_NotFound(t *testing.T) {
+	mock := &testhelpers.MockAutoPromotionService{
+		EvaluateUserFn: func(_ uint) (*contracts.UserEvaluationResult, error) {
+			// The handler matches on this exact message to return 404.
+			return nil, fmt.Errorf("user not found")
+		},
+	}
+	h := NewAutoPromotionHandler(mock)
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
+
+	_, err := h.EvaluateUserHandler(ctx, &EvaluateUserRequest{UserID: 999})
+	testhelpers.AssertHumaError(t, err, 404)
+}
+
+func TestEvaluateUserHandler_ServiceError(t *testing.T) {
+	mock := &testhelpers.MockAutoPromotionService{
+		EvaluateUserFn: func(_ uint) (*contracts.UserEvaluationResult, error) {
+			return nil, fmt.Errorf("connection reset")
+		},
+	}
+	h := NewAutoPromotionHandler(mock)
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
+
+	_, err := h.EvaluateUserHandler(ctx, &EvaluateUserRequest{UserID: 7})
+	testhelpers.AssertHumaError(t, err, 500)
+}

--- a/backend/internal/api/handlers/admin/pending_edit_test.go
+++ b/backend/internal/api/handlers/admin/pending_edit_test.go
@@ -882,3 +882,48 @@ func TestSuggestEdit_AutoApplyPathStillGates(t *testing.T) {
 		})
 	}
 }
+
+// ============================================================================
+// Tests: SuggestReleaseEditHandler — a thin wrapper over the shared
+// suggestEdit path (already exercised by the artist/venue/festival cases).
+// One happy path + one error path confirm the release allowlist is wired.
+// ============================================================================
+
+func TestSuggestReleaseEditHandler_NewUser_CreatesPending(t *testing.T) {
+	expected := makePendingEditResponse(11)
+	expected.EntityType = "release"
+	h := NewPendingEditHandler(
+		&testhelpers.MockPendingEditService{
+			CreatePendingEditFn: func(req *contracts.CreatePendingEditRequest) (*contracts.PendingEditResponse, error) {
+				if req.EntityType != "release" || req.EntityID != 10 {
+					t.Errorf("unexpected params: %+v", req)
+				}
+				return expected, nil
+			},
+		},
+		nil,
+	)
+
+	req := &SuggestEntityEditRequest{EntityID: "10"}
+	req.Body.Changes = []adminm.FieldChange{{Field: "title", OldValue: "Old", NewValue: "New"}}
+	req.Body.Summary = "Fix title"
+
+	resp, err := h.SuggestReleaseEditHandler(pendingEditNewUserCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.PendingEdit == nil || resp.Body.PendingEdit.ID != 11 {
+		t.Errorf("expected pending edit ID=11, got %+v", resp.Body.PendingEdit)
+	}
+}
+
+func TestSuggestReleaseEditHandler_DisallowedField(t *testing.T) {
+	h := testPendingEditHandler()
+	req := &SuggestEntityEditRequest{EntityID: "1"}
+	// "label_id" is not on the release allowlist (title/release_year/
+	// release_date/release_type/cover_art_url/description only).
+	req.Body.Changes = []adminm.FieldChange{{Field: "label_id", OldValue: 1, NewValue: 2}}
+	req.Body.Summary = "reassign label"
+	_, err := h.SuggestReleaseEditHandler(pendingEditNewUserCtx(), req)
+	testhelpers.AssertHumaError(t, err, 422)
+}

--- a/backend/internal/api/handlers/auth/auth_test.go
+++ b/backend/internal/api/handlers/auth/auth_test.go
@@ -2239,3 +2239,150 @@ func TestGenerateCLITokenHandler_TokenFails(t *testing.T) {
 		t.Errorf("expected error_code=%s, got %s", autherrors.CodeServiceUnavailable, resp.Body.ErrorCode)
 	}
 }
+
+// --- UpdateProfileHandler ---
+//
+// UpdateProfileHandler returns a 200 with a structured Success/ErrorCode body
+// rather than huma errors, so assertions read those fields instead of an HTTP
+// status.
+
+func TestUpdateProfileHandler_NoAuth(t *testing.T) {
+	h := testAuthHandler()
+	resp, err := h.UpdateProfileHandler(context.Background(), &UpdateProfileRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Success {
+		t.Error("expected success=false")
+	}
+	if resp.Body.ErrorCode != autherrors.CodeUnauthorized {
+		t.Errorf("expected error_code=%s, got %s", autherrors.CodeUnauthorized, resp.Body.ErrorCode)
+	}
+}
+
+func TestUpdateProfileHandler_UsernameTooShort(t *testing.T) {
+	h := testAuthHandler()
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1})
+	req := &UpdateProfileRequest{}
+	req.Body.Username = strPtr("ab") // < 3 chars
+
+	resp, err := h.UpdateProfileHandler(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Success || resp.Body.ErrorCode != autherrors.CodeValidationFailed {
+		t.Errorf("expected validation failure, got success=%v code=%s", resp.Body.Success, resp.Body.ErrorCode)
+	}
+}
+
+func TestUpdateProfileHandler_UsernameInvalidChars(t *testing.T) {
+	h := testAuthHandler()
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1})
+	req := &UpdateProfileRequest{}
+	req.Body.Username = strPtr("bad name!") // space + punctuation
+
+	resp, err := h.UpdateProfileHandler(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Success || resp.Body.ErrorCode != autherrors.CodeValidationFailed {
+		t.Errorf("expected validation failure, got success=%v code=%s", resp.Body.Success, resp.Body.ErrorCode)
+	}
+}
+
+func TestUpdateProfileHandler_BioTooLong(t *testing.T) {
+	h := testAuthHandler()
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1})
+	req := &UpdateProfileRequest{}
+	req.Body.Bio = strPtr(strings.Repeat("x", 501))
+
+	resp, err := h.UpdateProfileHandler(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Success || resp.Body.ErrorCode != autherrors.CodeValidationFailed {
+		t.Errorf("expected validation failure, got success=%v code=%s", resp.Body.Success, resp.Body.ErrorCode)
+	}
+}
+
+func TestUpdateProfileHandler_NoFields(t *testing.T) {
+	h := testAuthHandler()
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1})
+
+	resp, err := h.UpdateProfileHandler(ctx, &UpdateProfileRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Success || resp.Body.ErrorCode != autherrors.CodeValidationFailed {
+		t.Errorf("expected validation failure for empty update, got success=%v code=%s", resp.Body.Success, resp.Body.ErrorCode)
+	}
+}
+
+func TestUpdateProfileHandler_Success(t *testing.T) {
+	mock := &testhelpers.MockUserService{
+		UpdateUserFn: func(userID uint, updates map[string]any) (*authm.User, error) {
+			if userID != 1 {
+				t.Errorf("expected userID=1, got %d", userID)
+			}
+			if updates["username"] != "new_name" {
+				t.Errorf("expected username=new_name, got %v", updates["username"])
+			}
+			return &authm.User{ID: 1, Username: strPtr("new_name")}, nil
+		},
+	}
+	h := NewAuthHandler(nil, nil, mock, nil, nil, nil, testConfig())
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1})
+	req := &UpdateProfileRequest{}
+	req.Body.Username = strPtr("new_name")
+
+	resp, err := h.UpdateProfileHandler(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.Body.Success {
+		t.Fatalf("expected success=true, got message=%q code=%s", resp.Body.Message, resp.Body.ErrorCode)
+	}
+	if resp.Body.User == nil || resp.Body.User.Username == nil || *resp.Body.User.Username != "new_name" {
+		t.Errorf("expected updated user with username=new_name, got %+v", resp.Body.User)
+	}
+}
+
+func TestUpdateProfileHandler_DuplicateUsername(t *testing.T) {
+	mock := &testhelpers.MockUserService{
+		UpdateUserFn: func(_ uint, _ map[string]any) (*authm.User, error) {
+			return nil, fmt.Errorf("ERROR: duplicate key value violates unique constraint")
+		},
+	}
+	h := NewAuthHandler(nil, nil, mock, nil, nil, nil, testConfig())
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1})
+	req := &UpdateProfileRequest{}
+	req.Body.Username = strPtr("taken_name")
+
+	resp, err := h.UpdateProfileHandler(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Success || resp.Body.ErrorCode != autherrors.CodeValidationFailed {
+		t.Errorf("expected validation failure for duplicate username, got success=%v code=%s", resp.Body.Success, resp.Body.ErrorCode)
+	}
+}
+
+func TestUpdateProfileHandler_ServiceError(t *testing.T) {
+	mock := &testhelpers.MockUserService{
+		UpdateUserFn: func(_ uint, _ map[string]any) (*authm.User, error) {
+			return nil, fmt.Errorf("db connection lost")
+		},
+	}
+	h := NewAuthHandler(nil, nil, mock, nil, nil, nil, testConfig())
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1})
+	req := &UpdateProfileRequest{}
+	req.Body.FirstName = strPtr("Jane")
+
+	resp, err := h.UpdateProfileHandler(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Success || resp.Body.ErrorCode != autherrors.CodeServiceUnavailable {
+		t.Errorf("expected service-unavailable failure, got success=%v code=%s", resp.Body.Success, resp.Body.ErrorCode)
+	}
+}

--- a/backend/internal/api/handlers/auth/user_preferences_test.go
+++ b/backend/internal/api/handlers/auth/user_preferences_test.go
@@ -439,3 +439,72 @@ func TestSetDefaultReplyPermission_AcceptsAllValidEnumValues(t *testing.T) {
 		})
 	}
 }
+
+// --- SetCollectionDigestHandler ---
+
+func TestSetCollectionDigestHandler_NoAuth(t *testing.T) {
+	h := NewUserPreferencesHandler(&testhelpers.MockUserService{}, "secret")
+	_, err := h.SetCollectionDigestHandler(context.Background(), &SetCollectionDigestRequest{})
+	testhelpers.AssertHumaError(t, err, 401)
+}
+
+func TestSetCollectionDigestHandler_Success_Enable(t *testing.T) {
+	var calledEnabled bool
+	mock := &testhelpers.MockUserService{
+		SetNotifyOnCollectionDigestFn: func(userID uint, enabled bool) error {
+			if userID != 1 {
+				t.Errorf("expected userID=1, got %d", userID)
+			}
+			calledEnabled = enabled
+			return nil
+		},
+	}
+	h := NewUserPreferencesHandler(mock, "secret")
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1})
+	req := &SetCollectionDigestRequest{}
+	req.Body.Enabled = true
+
+	resp, err := h.SetCollectionDigestHandler(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.Body.Success || !resp.Body.NotifyOnCollectionDigest {
+		t.Fatal("expected success=true and notify_on_collection_digest=true")
+	}
+	if !calledEnabled {
+		t.Fatal("expected service called with enabled=true")
+	}
+}
+
+func TestSetCollectionDigestHandler_Success_Disable(t *testing.T) {
+	mock := &testhelpers.MockUserService{
+		SetNotifyOnCollectionDigestFn: func(_ uint, _ bool) error { return nil },
+	}
+	h := NewUserPreferencesHandler(mock, "secret")
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1})
+	req := &SetCollectionDigestRequest{}
+	req.Body.Enabled = false
+
+	resp, err := h.SetCollectionDigestHandler(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.Body.Success || resp.Body.NotifyOnCollectionDigest {
+		t.Fatal("expected success=true and notify_on_collection_digest=false")
+	}
+}
+
+func TestSetCollectionDigestHandler_ServiceError(t *testing.T) {
+	mock := &testhelpers.MockUserService{
+		SetNotifyOnCollectionDigestFn: func(_ uint, _ bool) error {
+			return errors.New("db error")
+		},
+	}
+	h := NewUserPreferencesHandler(mock, "secret")
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1})
+	req := &SetCollectionDigestRequest{}
+	req.Body.Enabled = true
+
+	_, err := h.SetCollectionDigestHandler(ctx, req)
+	testhelpers.AssertHumaError(t, err, 500)
+}

--- a/backend/internal/api/handlers/catalog/artist_relationship_test.go
+++ b/backend/internal/api/handlers/catalog/artist_relationship_test.go
@@ -2,6 +2,7 @@ package catalog
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"psychic-homily-backend/internal/api/handlers/shared/testhelpers"
@@ -250,4 +251,165 @@ func TestSplitAndTrim(t *testing.T) {
 			}
 		}
 	}
+}
+
+// --- GetArtistBillCompositionHandler ---
+
+func TestGetArtistBillComposition_InvalidID(t *testing.T) {
+	h := testArtistRelationshipHandler()
+	_, err := h.GetArtistBillCompositionHandler(context.Background(), &GetArtistBillCompositionRequest{ArtistID: "abc"})
+	testhelpers.AssertHumaError(t, err, 400)
+}
+
+func TestGetArtistBillComposition_NegativeMonths(t *testing.T) {
+	h := testArtistRelationshipHandler()
+	_, err := h.GetArtistBillCompositionHandler(context.Background(), &GetArtistBillCompositionRequest{ArtistID: "1", Months: -1})
+	testhelpers.AssertHumaError(t, err, 422)
+}
+
+func TestGetArtistBillComposition_Success(t *testing.T) {
+	h := NewArtistRelationshipHandler(
+		&testhelpers.MockArtistRelationshipService{
+			GetArtistBillCompositionFn: func(artistID uint, months int) (*contracts.ArtistBillComposition, error) {
+				if artistID != 1 || months != 12 {
+					t.Errorf("unexpected params artistID=%d months=%d", artistID, months)
+				}
+				bc := &contracts.ArtistBillComposition{}
+				bc.Stats.TotalShows = 5
+				bc.TimeFilterMonths = months
+				return bc, nil
+			},
+		},
+		nil,
+	)
+	resp, err := h.GetArtistBillCompositionHandler(context.Background(), &GetArtistBillCompositionRequest{ArtistID: "1", Months: 12})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Stats.TotalShows != 5 {
+		t.Errorf("expected total shows=5, got %d", resp.Body.Stats.TotalShows)
+	}
+}
+
+func TestGetArtistBillComposition_NotFound(t *testing.T) {
+	h := NewArtistRelationshipHandler(
+		&testhelpers.MockArtistRelationshipService{
+			GetArtistBillCompositionFn: func(_ uint, _ int) (*contracts.ArtistBillComposition, error) {
+				// Handler maps an "artist not found"-prefixed error to 404.
+				return nil, fmt.Errorf("artist not found: 99")
+			},
+		},
+		nil,
+	)
+	_, err := h.GetArtistBillCompositionHandler(context.Background(), &GetArtistBillCompositionRequest{ArtistID: "99"})
+	testhelpers.AssertHumaError(t, err, 404)
+}
+
+func TestGetArtistBillComposition_ServiceError(t *testing.T) {
+	h := NewArtistRelationshipHandler(
+		&testhelpers.MockArtistRelationshipService{
+			GetArtistBillCompositionFn: func(_ uint, _ int) (*contracts.ArtistBillComposition, error) {
+				return nil, fmt.Errorf("db error")
+			},
+		},
+		nil,
+	)
+	_, err := h.GetArtistBillCompositionHandler(context.Background(), &GetArtistBillCompositionRequest{ArtistID: "1"})
+	testhelpers.AssertHumaError(t, err, 500)
+}
+
+// --- DeleteRelationshipHandler (admin) ---
+
+func TestDeleteRelationship_Success(t *testing.T) {
+	h := NewArtistRelationshipHandler(
+		&testhelpers.MockArtistRelationshipService{
+			DeleteRelationshipFn: func(sourceID, targetID uint, relType string) error {
+				if sourceID != 1 || targetID != 2 || relType != "similar" {
+					t.Errorf("unexpected params source=%d target=%d type=%q", sourceID, targetID, relType)
+				}
+				return nil
+			},
+		},
+		nil,
+	)
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
+	_, err := h.DeleteRelationshipHandler(ctx, &DeleteRelationshipRequest{SourceID: "1", TargetID: "2", Type: "similar"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDeleteRelationship_ServiceError(t *testing.T) {
+	h := NewArtistRelationshipHandler(
+		&testhelpers.MockArtistRelationshipService{
+			DeleteRelationshipFn: func(_, _ uint, _ string) error {
+				return fmt.Errorf("db error")
+			},
+		},
+		nil,
+	)
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
+	_, err := h.DeleteRelationshipHandler(ctx, &DeleteRelationshipRequest{SourceID: "1", TargetID: "2", Type: "similar"})
+	testhelpers.AssertHumaError(t, err, 500)
+}
+
+// --- DeriveRelationshipsHandler (admin) ---
+
+func TestDeriveRelationships_Success(t *testing.T) {
+	h := NewArtistRelationshipHandler(
+		&testhelpers.MockArtistRelationshipService{
+			DeriveSharedBillsFn: func(minShows int) (int64, error) {
+				if minShows != 2 {
+					t.Errorf("expected minShows=2, got %d", minShows)
+				}
+				return 7, nil
+			},
+			DeriveSharedLabelsFn: func(minLabels int) (int64, error) {
+				if minLabels != 1 {
+					t.Errorf("expected minLabels=1, got %d", minLabels)
+				}
+				return 3, nil
+			},
+		},
+		nil,
+	)
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
+	resp, err := h.DeriveRelationshipsHandler(ctx, &DeriveRelationshipsRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.Body.Success || resp.Body.SharedBillsUpserted != 7 || resp.Body.SharedLabelsUpserted != 3 {
+		t.Errorf("unexpected body: %+v", resp.Body)
+	}
+}
+
+func TestDeriveRelationships_SharedBillsError(t *testing.T) {
+	h := NewArtistRelationshipHandler(
+		&testhelpers.MockArtistRelationshipService{
+			DeriveSharedBillsFn: func(_ int) (int64, error) {
+				return 0, fmt.Errorf("db error")
+			},
+		},
+		nil,
+	)
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
+	_, err := h.DeriveRelationshipsHandler(ctx, &DeriveRelationshipsRequest{})
+	testhelpers.AssertHumaError(t, err, 500)
+}
+
+func TestDeriveRelationships_SharedLabelsError(t *testing.T) {
+	h := NewArtistRelationshipHandler(
+		&testhelpers.MockArtistRelationshipService{
+			DeriveSharedBillsFn: func(_ int) (int64, error) {
+				return 5, nil
+			},
+			DeriveSharedLabelsFn: func(_ int) (int64, error) {
+				return 0, fmt.Errorf("db error")
+			},
+		},
+		nil,
+	)
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
+	_, err := h.DeriveRelationshipsHandler(ctx, &DeriveRelationshipsRequest{})
+	testhelpers.AssertHumaError(t, err, 500)
 }

--- a/backend/internal/api/handlers/catalog/artist_test.go
+++ b/backend/internal/api/handlers/catalog/artist_test.go
@@ -1339,3 +1339,74 @@ func TestAdminCreateArtist_NameTrimmed(t *testing.T) {
 		t.Errorf("expected name='Trimmed Name', got %q", resp.Body.Name)
 	}
 }
+
+// ============================================================================
+// Mock-based tests: GetArtistLabelsHandler
+// ============================================================================
+
+func TestGetArtistLabels_ByID(t *testing.T) {
+	mock := &testhelpers.MockArtistService{
+		GetLabelsForArtistFn: func(artistID uint) ([]*contracts.ArtistLabelResponse, error) {
+			if artistID != 5 {
+				t.Errorf("expected artistID=5, got %d", artistID)
+			}
+			return []*contracts.ArtistLabelResponse{{ID: 1, Name: "Sub Pop"}}, nil
+		},
+	}
+	h := NewArtistHandler(mock, nil, nil, nil)
+
+	resp, err := h.GetArtistLabelsHandler(context.Background(), &GetArtistLabelsRequest{ArtistID: "5"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Count != 1 || resp.Body.Labels[0].Name != "Sub Pop" {
+		t.Errorf("unexpected body: %+v", resp.Body)
+	}
+}
+
+func TestGetArtistLabels_BySlug(t *testing.T) {
+	mock := &testhelpers.MockArtistService{
+		GetArtistBySlugFn: func(slug string) (*contracts.ArtistDetailResponse, error) {
+			return &contracts.ArtistDetailResponse{ID: 10, Slug: slug}, nil
+		},
+		GetLabelsForArtistFn: func(artistID uint) ([]*contracts.ArtistLabelResponse, error) {
+			if artistID != 10 {
+				t.Errorf("expected resolved artistID=10, got %d", artistID)
+			}
+			return nil, nil
+		},
+	}
+	h := NewArtistHandler(mock, nil, nil, nil)
+
+	resp, err := h.GetArtistLabelsHandler(context.Background(), &GetArtistLabelsRequest{ArtistID: "the-national"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Count != 0 {
+		t.Errorf("expected count=0, got %d", resp.Body.Count)
+	}
+}
+
+func TestGetArtistLabels_SlugNotFound(t *testing.T) {
+	mock := &testhelpers.MockArtistService{
+		GetArtistBySlugFn: func(_ string) (*contracts.ArtistDetailResponse, error) {
+			return nil, apperrors.ErrArtistNotFound(0)
+		},
+	}
+	h := NewArtistHandler(mock, nil, nil, nil)
+
+	_, err := h.GetArtistLabelsHandler(context.Background(), &GetArtistLabelsRequest{ArtistID: "ghost"})
+	testhelpers.AssertHumaError(t, err, 404)
+}
+
+func TestGetArtistLabels_ServiceError(t *testing.T) {
+	mock := &testhelpers.MockArtistService{
+		GetLabelsForArtistFn: func(_ uint) ([]*contracts.ArtistLabelResponse, error) {
+			return nil, fmt.Errorf("db error")
+		},
+	}
+	h := NewArtistHandler(mock, nil, nil, nil)
+
+	_, err := h.GetArtistLabelsHandler(context.Background(), &GetArtistLabelsRequest{ArtistID: "5"})
+	testhelpers.AssertHumaError(t, err, 500)
+}

--- a/backend/internal/api/handlers/catalog/radio_test.go
+++ b/backend/internal/api/handlers/catalog/radio_test.go
@@ -1193,3 +1193,143 @@ func TestAdminListImportJobs_ServiceError(t *testing.T) {
 	testhelpers.AssertHumaError(t, err, 500)
 }
 
+// ============================================================================
+// AdminGetUnmatchedPlaysHandler Tests
+// ============================================================================
+
+func TestAdminGetUnmatchedPlays_Success(t *testing.T) {
+	mock := &testhelpers.MockRadioService{
+		GetUnmatchedPlaysFn: func(stationID uint, limit, offset int) ([]*contracts.UnmatchedPlayGroup, int64, error) {
+			// Defaults are applied by the handler when limit<=0 / offset<0.
+			if limit != 50 || offset != 0 {
+				t.Errorf("expected default limit=50 offset=0, got limit=%d offset=%d", limit, offset)
+			}
+			return []*contracts.UnmatchedPlayGroup{
+				{ArtistName: "Unknown Band", PlayCount: 3, StationNames: []string{"KEXP"}},
+			}, 1, nil
+		},
+	}
+	h := testRadioHandler(mock)
+	resp, err := h.AdminGetUnmatchedPlaysHandler(radioAdminCtx(), &AdminGetUnmatchedPlaysRequest{Limit: 0, Offset: -5})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Total != 1 || len(resp.Body.Groups) != 1 {
+		t.Errorf("unexpected response body: %+v", resp.Body)
+	}
+}
+
+func TestAdminGetUnmatchedPlays_ServiceError(t *testing.T) {
+	mock := &testhelpers.MockRadioService{
+		GetUnmatchedPlaysFn: func(_ uint, _, _ int) ([]*contracts.UnmatchedPlayGroup, int64, error) {
+			return nil, 0, fmt.Errorf("database error")
+		},
+	}
+	h := testRadioHandler(mock)
+	_, err := h.AdminGetUnmatchedPlaysHandler(radioAdminCtx(), &AdminGetUnmatchedPlaysRequest{})
+	testhelpers.AssertHumaError(t, err, 500)
+}
+
+// ============================================================================
+// AdminLinkPlayHandler Tests
+// ============================================================================
+
+func TestAdminLinkPlay_Success(t *testing.T) {
+	artistID := uint(123)
+	mock := &testhelpers.MockRadioService{
+		LinkPlayFn: func(playID uint, req *contracts.LinkPlayRequest) error {
+			if playID != 7 {
+				t.Errorf("unexpected playID=%d", playID)
+			}
+			if req.ArtistID == nil || *req.ArtistID != 123 {
+				t.Errorf("unexpected link request: %+v", req)
+			}
+			return nil
+		},
+	}
+	h := testRadioHandler(mock)
+	req := &AdminLinkPlayRequest{PlayID: 7}
+	req.Body.ArtistID = &artistID
+
+	resp, err := h.AdminLinkPlayHandler(radioAdminCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.Body.Success {
+		t.Error("expected success=true")
+	}
+}
+
+func TestAdminLinkPlay_ServiceError(t *testing.T) {
+	mock := &testhelpers.MockRadioService{
+		LinkPlayFn: func(_ uint, _ *contracts.LinkPlayRequest) error {
+			return fmt.Errorf("constraint violation")
+		},
+	}
+	h := testRadioHandler(mock)
+	req := &AdminLinkPlayRequest{PlayID: 7}
+
+	_, err := h.AdminLinkPlayHandler(radioAdminCtx(), req)
+	testhelpers.AssertHumaError(t, err, 500)
+}
+
+// ============================================================================
+// AdminBulkLinkPlaysHandler Tests
+// ============================================================================
+
+func TestAdminBulkLinkPlays_Success(t *testing.T) {
+	mock := &testhelpers.MockRadioService{
+		BulkLinkPlaysFn: func(req *contracts.BulkLinkRequest) (*contracts.BulkLinkResult, error) {
+			if req.ArtistName != "Radiohead" || req.ArtistID != 123 {
+				t.Errorf("unexpected bulk request: %+v", req)
+			}
+			return &contracts.BulkLinkResult{Updated: 9}, nil
+		},
+	}
+	h := testRadioHandler(mock)
+	req := &AdminBulkLinkPlaysRequest{}
+	req.Body.ArtistName = "Radiohead"
+	req.Body.ArtistID = 123
+
+	resp, err := h.AdminBulkLinkPlaysHandler(radioAdminCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Updated != 9 {
+		t.Errorf("expected 9 updated, got %d", resp.Body.Updated)
+	}
+}
+
+func TestAdminBulkLinkPlays_MissingArtistName(t *testing.T) {
+	h := testRadioHandler(&testhelpers.MockRadioService{})
+	req := &AdminBulkLinkPlaysRequest{}
+	req.Body.ArtistID = 123 // name omitted
+
+	_, err := h.AdminBulkLinkPlaysHandler(radioAdminCtx(), req)
+	testhelpers.AssertHumaError(t, err, 422)
+}
+
+func TestAdminBulkLinkPlays_MissingArtistID(t *testing.T) {
+	h := testRadioHandler(&testhelpers.MockRadioService{})
+	req := &AdminBulkLinkPlaysRequest{}
+	req.Body.ArtistName = "Radiohead" // id omitted (zero)
+
+	_, err := h.AdminBulkLinkPlaysHandler(radioAdminCtx(), req)
+	testhelpers.AssertHumaError(t, err, 422)
+}
+
+func TestAdminBulkLinkPlays_ServiceError(t *testing.T) {
+	mock := &testhelpers.MockRadioService{
+		BulkLinkPlaysFn: func(_ *contracts.BulkLinkRequest) (*contracts.BulkLinkResult, error) {
+			return nil, fmt.Errorf("database error")
+		},
+	}
+	h := testRadioHandler(mock)
+	req := &AdminBulkLinkPlaysRequest{}
+	req.Body.ArtistName = "Radiohead"
+	req.Body.ArtistID = 123
+
+	_, err := h.AdminBulkLinkPlaysHandler(radioAdminCtx(), req)
+	testhelpers.AssertHumaError(t, err, 500)
+}
+

--- a/backend/internal/api/handlers/catalog/scene_test.go
+++ b/backend/internal/api/handlers/catalog/scene_test.go
@@ -247,6 +247,112 @@ func TestGetSceneActiveArtists_ServiceError(t *testing.T) {
 }
 
 // ============================================================================
+// GetSceneGraphHandler Tests
+// ============================================================================
+
+func TestGetSceneGraph_Success(t *testing.T) {
+	mock := &testhelpers.MockSceneService{
+		ParseSceneSlugFn: func(slug string) (string, string, error) {
+			return "Phoenix", "AZ", nil
+		},
+		GetSceneGraphFn: func(city, state string, types []string) (*contracts.SceneGraphResponse, error) {
+			resp := &contracts.SceneGraphResponse{}
+			resp.Scene.City = city
+			resp.Scene.State = state
+			resp.Scene.Slug = "phoenix-az"
+			return resp, nil
+		},
+	}
+	h := NewSceneHandler(mock)
+	resp, err := h.GetSceneGraphHandler(context.Background(), &GetSceneGraphRequest{Slug: "phoenix-az"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Scene.City != "Phoenix" {
+		t.Errorf("expected Phoenix, got %s", resp.Body.Scene.City)
+	}
+}
+
+func TestGetSceneGraph_TypeFilterParsed(t *testing.T) {
+	var capturedTypes []string
+	mock := &testhelpers.MockSceneService{
+		ParseSceneSlugFn: func(slug string) (string, string, error) {
+			return "Phoenix", "AZ", nil
+		},
+		GetSceneGraphFn: func(_, _ string, types []string) (*contracts.SceneGraphResponse, error) {
+			capturedTypes = types
+			return &contracts.SceneGraphResponse{}, nil
+		},
+	}
+	h := NewSceneHandler(mock)
+	req := &GetSceneGraphRequest{Slug: "phoenix-az", Types: " shared_bills , shared_label ,"}
+	_, err := h.GetSceneGraphHandler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// parseTypesQueryParam trims whitespace and drops empties.
+	if len(capturedTypes) != 2 || capturedTypes[0] != "shared_bills" || capturedTypes[1] != "shared_label" {
+		t.Errorf("expected [shared_bills shared_label], got %v", capturedTypes)
+	}
+}
+
+func TestGetSceneGraph_SlugNotFound(t *testing.T) {
+	mock := &testhelpers.MockSceneService{
+		ParseSceneSlugFn: func(slug string) (string, string, error) {
+			return "", "", fmt.Errorf("scene not found for slug: %s", slug)
+		},
+	}
+	h := NewSceneHandler(mock)
+	_, err := h.GetSceneGraphHandler(context.Background(), &GetSceneGraphRequest{Slug: "nope-xx"})
+	testhelpers.AssertHumaError(t, err, 404)
+}
+
+func TestGetSceneGraph_SceneNotFound(t *testing.T) {
+	mock := &testhelpers.MockSceneService{
+		ParseSceneSlugFn: func(slug string) (string, string, error) {
+			return "Tiny", "XX", nil
+		},
+		GetSceneGraphFn: func(city, state string, _ []string) (*contracts.SceneGraphResponse, error) {
+			return nil, fmt.Errorf("scene not found: %s, %s", city, state)
+		},
+	}
+	h := NewSceneHandler(mock)
+	_, err := h.GetSceneGraphHandler(context.Background(), &GetSceneGraphRequest{Slug: "tiny-xx"})
+	testhelpers.AssertHumaError(t, err, 404)
+}
+
+func TestGetSceneGraph_ServiceError(t *testing.T) {
+	mock := &testhelpers.MockSceneService{
+		ParseSceneSlugFn: func(slug string) (string, string, error) {
+			return "Phoenix", "AZ", nil
+		},
+		GetSceneGraphFn: func(_, _ string, _ []string) (*contracts.SceneGraphResponse, error) {
+			return nil, fmt.Errorf("database connection lost")
+		},
+	}
+	h := NewSceneHandler(mock)
+	_, err := h.GetSceneGraphHandler(context.Background(), &GetSceneGraphRequest{Slug: "phoenix-az"})
+	testhelpers.AssertHumaError(t, err, 500)
+}
+
+// ============================================================================
+// parseTypesQueryParam Tests
+// ============================================================================
+
+func TestParseTypesQueryParam(t *testing.T) {
+	if got := parseTypesQueryParam(""); got != nil {
+		t.Errorf("parseTypesQueryParam(\"\") = %v, want nil", got)
+	}
+	if got := parseTypesQueryParam("  ,  , "); len(got) != 0 {
+		t.Errorf("parseTypesQueryParam(all-blank) = %v, want empty", got)
+	}
+	got := parseTypesQueryParam(" similar , shared_bills ")
+	if len(got) != 2 || got[0] != "similar" || got[1] != "shared_bills" {
+		t.Errorf("parseTypesQueryParam = %v, want [similar shared_bills]", got)
+	}
+}
+
+// ============================================================================
 // isSceneNotFoundErr Tests
 // ============================================================================
 

--- a/backend/internal/api/handlers/catalog/tag_test.go
+++ b/backend/internal/api/handlers/catalog/tag_test.go
@@ -1,0 +1,183 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"psychic-homily-backend/internal/api/handlers/shared/testhelpers"
+	apperrors "psychic-homily-backend/internal/errors"
+	authm "psychic-homily-backend/internal/models/auth"
+	catalogm "psychic-homily-backend/internal/models/catalog"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// ============================================================================
+// ListTagEntitiesHandler
+// ============================================================================
+
+func TestListTagEntities_ByID(t *testing.T) {
+	mock := &testhelpers.MockTagService{
+		GetTagFn: func(tagID uint) (*catalogm.Tag, error) {
+			return &catalogm.Tag{ID: tagID, Name: "punk", Slug: "punk"}, nil
+		},
+		GetTagEntitiesFn: func(tagID uint, entityType string, limit, offset int) ([]contracts.TaggedEntityItem, int64, error) {
+			if tagID != 3 {
+				t.Errorf("expected tagID=3, got %d", tagID)
+			}
+			return []contracts.TaggedEntityItem{{EntityType: "artist", EntityID: 1, Name: "Band"}}, 1, nil
+		},
+	}
+	h := NewTagHandler(mock, nil)
+	resp, err := h.ListTagEntitiesHandler(context.Background(), &ListTagEntitiesRequest{TagID: "3"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Total != 1 || len(resp.Body.Entities) != 1 {
+		t.Errorf("unexpected body: %+v", resp.Body)
+	}
+}
+
+func TestListTagEntities_BySlug(t *testing.T) {
+	mock := &testhelpers.MockTagService{
+		GetTagBySlugFn: func(slug string) (*catalogm.Tag, error) {
+			return &catalogm.Tag{ID: 9, Name: "post-punk", Slug: slug}, nil
+		},
+		GetTagEntitiesFn: func(tagID uint, _ string, _, _ int) ([]contracts.TaggedEntityItem, int64, error) {
+			if tagID != 9 {
+				t.Errorf("expected resolved tagID=9, got %d", tagID)
+			}
+			return nil, 0, nil
+		},
+	}
+	h := NewTagHandler(mock, nil)
+	resp, err := h.ListTagEntitiesHandler(context.Background(), &ListTagEntitiesRequest{TagID: "post-punk"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Total != 0 {
+		t.Errorf("expected total=0, got %d", resp.Body.Total)
+	}
+}
+
+func TestListTagEntities_TagNotFound(t *testing.T) {
+	// resolveTag returns nil when both ID and slug lookups miss → 404.
+	mock := &testhelpers.MockTagService{
+		GetTagBySlugFn: func(_ string) (*catalogm.Tag, error) {
+			return nil, fmt.Errorf("not found")
+		},
+	}
+	h := NewTagHandler(mock, nil)
+	_, err := h.ListTagEntitiesHandler(context.Background(), &ListTagEntitiesRequest{TagID: "ghost"})
+	testhelpers.AssertHumaError(t, err, 404)
+}
+
+func TestListTagEntities_ServiceError(t *testing.T) {
+	mock := &testhelpers.MockTagService{
+		GetTagFn: func(tagID uint) (*catalogm.Tag, error) {
+			return &catalogm.Tag{ID: tagID}, nil
+		},
+		GetTagEntitiesFn: func(_ uint, _ string, _, _ int) ([]contracts.TaggedEntityItem, int64, error) {
+			return nil, 0, fmt.Errorf("db error")
+		},
+	}
+	h := NewTagHandler(mock, nil)
+	_, err := h.ListTagEntitiesHandler(context.Background(), &ListTagEntitiesRequest{TagID: "3"})
+	testhelpers.AssertHumaError(t, err, 500)
+}
+
+// ============================================================================
+// GetGenreHierarchyHandler
+// ============================================================================
+
+func TestGetGenreHierarchy_Success(t *testing.T) {
+	parentID := uint(1)
+	mock := &testhelpers.MockTagService{
+		GetGenreHierarchyFn: func() ([]*catalogm.Tag, error) {
+			return []*catalogm.Tag{
+				{ID: 1, Name: "rock", Slug: "rock", IsOfficial: true},
+				{ID: 2, Name: "punk", Slug: "punk", ParentID: &parentID, UsageCount: 12},
+			}, nil
+		},
+	}
+	h := NewTagHandler(mock, nil)
+	resp, err := h.GetGenreHierarchyHandler(context.Background(), &struct{}{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Body.Tags) != 2 {
+		t.Fatalf("expected 2 tags, got %d", len(resp.Body.Tags))
+	}
+	if resp.Body.Tags[1].ParentID == nil || *resp.Body.Tags[1].ParentID != 1 {
+		t.Errorf("expected punk parent_id=1, got %+v", resp.Body.Tags[1])
+	}
+}
+
+func TestGetGenreHierarchy_ServiceError(t *testing.T) {
+	mock := &testhelpers.MockTagService{
+		GetGenreHierarchyFn: func() ([]*catalogm.Tag, error) {
+			return nil, fmt.Errorf("db error")
+		},
+	}
+	h := NewTagHandler(mock, nil)
+	_, err := h.GetGenreHierarchyHandler(context.Background(), &struct{}{})
+	testhelpers.AssertHumaError(t, err, 500)
+}
+
+// ============================================================================
+// SetTagParentHandler
+// ============================================================================
+
+func TestSetTagParent_Success(t *testing.T) {
+	newParent := uint(1)
+	mock := &testhelpers.MockTagService{
+		SetTagParentFn: func(tagID uint, parentID *uint, actorUserID uint) error {
+			if tagID != 2 || parentID == nil || *parentID != 1 || actorUserID != 7 {
+				t.Errorf("unexpected params tagID=%d parentID=%v actor=%d", tagID, parentID, actorUserID)
+			}
+			return nil
+		},
+	}
+	h := NewTagHandler(mock, nil)
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 7, IsAdmin: true})
+	req := &SetTagParentRequest{TagID: "2"}
+	req.Body.ParentID = &newParent
+
+	_, err := h.SetTagParentHandler(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSetTagParent_InvalidID(t *testing.T) {
+	h := NewTagHandler(&testhelpers.MockTagService{}, nil)
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 7, IsAdmin: true})
+	_, err := h.SetTagParentHandler(ctx, &SetTagParentRequest{TagID: "abc"})
+	testhelpers.AssertHumaError(t, err, 400)
+}
+
+func TestSetTagParent_CycleMapsToTagError(t *testing.T) {
+	// A hierarchy-cycle TagError flows through shared.MapTagError → 422.
+	mock := &testhelpers.MockTagService{
+		SetTagParentFn: func(_ uint, _ *uint, _ uint) error {
+			return apperrors.ErrTagHierarchyCycle("parent is a descendant")
+		},
+	}
+	h := NewTagHandler(mock, nil)
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 7, IsAdmin: true})
+	_, err := h.SetTagParentHandler(ctx, &SetTagParentRequest{TagID: "2"})
+	testhelpers.AssertHumaError(t, err, 422)
+}
+
+func TestSetTagParent_ServiceError(t *testing.T) {
+	// A non-TagError falls through to a generic 500.
+	mock := &testhelpers.MockTagService{
+		SetTagParentFn: func(_ uint, _ *uint, _ uint) error {
+			return fmt.Errorf("db error")
+		},
+	}
+	h := NewTagHandler(mock, nil)
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 7, IsAdmin: true})
+	_, err := h.SetTagParentHandler(ctx, &SetTagParentRequest{TagID: "2"})
+	testhelpers.AssertHumaError(t, err, 500)
+}

--- a/backend/internal/api/handlers/catalog/venue_test.go
+++ b/backend/internal/api/handlers/catalog/venue_test.go
@@ -2,6 +2,7 @@ package catalog
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"psychic-homily-backend/internal/api/handlers/shared/testhelpers"
@@ -109,4 +110,188 @@ func TestDeleteVenueHandler_OverflowID(t *testing.T) {
 	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1})
 	_, err := h.DeleteVenueHandler(ctx, &DeleteVenueRequest{VenueID: "99999999999"})
 	testhelpers.AssertHumaError(t, err, 400)
+}
+
+// ============================================================================
+// GetVenueGenresHandler
+// ============================================================================
+
+func TestGetVenueGenres_ByID(t *testing.T) {
+	mock := &testhelpers.MockVenueService{
+		GetVenueGenreProfileFn: func(venueID uint) ([]contracts.GenreCount, error) {
+			if venueID != 5 {
+				t.Errorf("expected venueID=5, got %d", venueID)
+			}
+			return []contracts.GenreCount{{TagID: 1, Name: "punk", Slug: "punk", Count: 10}}, nil
+		},
+	}
+	h := NewVenueHandler(mock, nil, nil, nil)
+	resp, err := h.GetVenueGenresHandler(context.Background(), &GetVenueGenresRequest{VenueID: "5"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Body.Genres) != 1 || resp.Body.Genres[0].Name != "punk" {
+		t.Errorf("unexpected body: %+v", resp.Body)
+	}
+}
+
+func TestGetVenueGenres_BySlug(t *testing.T) {
+	mock := &testhelpers.MockVenueService{
+		GetVenueBySlugFn: func(slug string) (*contracts.VenueDetailResponse, error) {
+			return &contracts.VenueDetailResponse{ID: 10}, nil
+		},
+		GetVenueGenreProfileFn: func(venueID uint) ([]contracts.GenreCount, error) {
+			if venueID != 10 {
+				t.Errorf("expected resolved venueID=10, got %d", venueID)
+			}
+			// nil genres → handler coerces to empty (non-nil) slice.
+			return nil, nil
+		},
+	}
+	h := NewVenueHandler(mock, nil, nil, nil)
+	resp, err := h.GetVenueGenresHandler(context.Background(), &GetVenueGenresRequest{VenueID: "valley-bar"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Genres == nil {
+		t.Error("expected non-nil empty genres slice")
+	}
+}
+
+func TestGetVenueGenres_SlugNotFound(t *testing.T) {
+	mock := &testhelpers.MockVenueService{
+		GetVenueBySlugFn: func(_ string) (*contracts.VenueDetailResponse, error) {
+			return nil, fmt.Errorf("not found")
+		},
+	}
+	h := NewVenueHandler(mock, nil, nil, nil)
+	_, err := h.GetVenueGenresHandler(context.Background(), &GetVenueGenresRequest{VenueID: "ghost"})
+	testhelpers.AssertHumaError(t, err, 404)
+}
+
+func TestGetVenueGenres_ServiceError(t *testing.T) {
+	mock := &testhelpers.MockVenueService{
+		GetVenueGenreProfileFn: func(_ uint) ([]contracts.GenreCount, error) {
+			return nil, fmt.Errorf("db error")
+		},
+	}
+	h := NewVenueHandler(mock, nil, nil, nil)
+	_, err := h.GetVenueGenresHandler(context.Background(), &GetVenueGenresRequest{VenueID: "5"})
+	testhelpers.AssertHumaError(t, err, 500)
+}
+
+// ============================================================================
+// GetVenueBillNetworkHandler
+// ============================================================================
+
+func TestGetVenueBillNetwork_Success(t *testing.T) {
+	mock := &testhelpers.MockVenueService{
+		GetVenueBillNetworkFn: func(venueID uint, window string, year *int) (*contracts.VenueBillNetworkResponse, error) {
+			if venueID != 5 || window != "all" || year != nil {
+				t.Errorf("unexpected params venueID=%d window=%q year=%v", venueID, window, year)
+			}
+			return &contracts.VenueBillNetworkResponse{}, nil
+		},
+	}
+	h := NewVenueHandler(mock, nil, nil, nil)
+	_, err := h.GetVenueBillNetworkHandler(context.Background(), &GetVenueBillNetworkRequest{VenueID: "5", Window: "all"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGetVenueBillNetwork_YearWindowRequiresYear(t *testing.T) {
+	h := NewVenueHandler(&testhelpers.MockVenueService{}, nil, nil, nil)
+	// window=year with no year → 422 before the service is consulted.
+	_, err := h.GetVenueBillNetworkHandler(context.Background(), &GetVenueBillNetworkRequest{VenueID: "5", Window: "year"})
+	testhelpers.AssertHumaError(t, err, 422)
+}
+
+func TestGetVenueBillNetwork_NotFound(t *testing.T) {
+	mock := &testhelpers.MockVenueService{
+		GetVenueBillNetworkFn: func(_ uint, _ string, _ *int) (*contracts.VenueBillNetworkResponse, error) {
+			return nil, apperrors.ErrVenueNotFound(99)
+		},
+	}
+	h := NewVenueHandler(mock, nil, nil, nil)
+	_, err := h.GetVenueBillNetworkHandler(context.Background(), &GetVenueBillNetworkRequest{VenueID: "99", Window: "all"})
+	testhelpers.AssertHumaError(t, err, 404)
+}
+
+func TestGetVenueBillNetwork_ServiceError(t *testing.T) {
+	mock := &testhelpers.MockVenueService{
+		GetVenueBillNetworkFn: func(_ uint, _ string, _ *int) (*contracts.VenueBillNetworkResponse, error) {
+			return nil, fmt.Errorf("db error")
+		},
+	}
+	h := NewVenueHandler(mock, nil, nil, nil)
+	_, err := h.GetVenueBillNetworkHandler(context.Background(), &GetVenueBillNetworkRequest{VenueID: "5", Window: "all"})
+	testhelpers.AssertHumaError(t, err, 500)
+}
+
+// ============================================================================
+// AdminCreateVenueHandler
+// ============================================================================
+
+func TestAdminCreateVenue_Success(t *testing.T) {
+	mock := &testhelpers.MockVenueService{
+		CreateVenueFn: func(req *contracts.CreateVenueRequest, isAdmin bool) (*contracts.VenueDetailResponse, error) {
+			if !isAdmin {
+				t.Error("expected isAdmin=true for admin create")
+			}
+			if req.Name != "Valley Bar" || req.SubmittedBy == nil || *req.SubmittedBy != 1 {
+				t.Errorf("unexpected service request: %+v", req)
+			}
+			return &contracts.VenueDetailResponse{ID: 1, Name: req.Name}, nil
+		},
+	}
+	h := NewVenueHandler(mock, nil, nil, nil)
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
+	req := &AdminCreateVenueRequest{}
+	req.Body.Name = "Valley Bar"
+	req.Body.City = "Phoenix"
+	req.Body.State = "AZ"
+
+	resp, err := h.AdminCreateVenueHandler(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Name != "Valley Bar" {
+		t.Errorf("expected name='Valley Bar', got %q", resp.Body.Name)
+	}
+}
+
+func TestAdminCreateVenue_InvalidSocialURL(t *testing.T) {
+	// Social-URL validation runs before the service call; a non-http scheme
+	// is rejected without ever reaching CreateVenue.
+	h := NewVenueHandler(&testhelpers.MockVenueService{}, nil, nil, nil)
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
+	bad := "javascript:alert(1)"
+	req := &AdminCreateVenueRequest{}
+	req.Body.Name = "Valley Bar"
+	req.Body.City = "Phoenix"
+	req.Body.State = "AZ"
+	req.Body.Instagram = &bad
+
+	_, err := h.AdminCreateVenueHandler(ctx, req)
+	if err == nil {
+		t.Fatal("expected error for javascript: URL, got nil")
+	}
+}
+
+func TestAdminCreateVenue_ServiceError(t *testing.T) {
+	mock := &testhelpers.MockVenueService{
+		CreateVenueFn: func(_ *contracts.CreateVenueRequest, _ bool) (*contracts.VenueDetailResponse, error) {
+			return nil, fmt.Errorf("duplicate venue")
+		},
+	}
+	h := NewVenueHandler(mock, nil, nil, nil)
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1, IsAdmin: true})
+	req := &AdminCreateVenueRequest{}
+	req.Body.Name = "Valley Bar"
+	req.Body.City = "Phoenix"
+	req.Body.State = "AZ"
+
+	_, err := h.AdminCreateVenueHandler(ctx, req)
+	testhelpers.AssertHumaError(t, err, 422)
 }

--- a/backend/internal/api/handlers/community/collection_test.go
+++ b/backend/internal/api/handlers/community/collection_test.go
@@ -1,0 +1,163 @@
+package community
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"psychic-homily-backend/internal/api/handlers/shared/testhelpers"
+	apperrors "psychic-homily-backend/internal/errors"
+	authm "psychic-homily-backend/internal/models/auth"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// ============================================================================
+// UpdateItemHandler
+// ============================================================================
+
+func TestUpdateItem_NoAuth(t *testing.T) {
+	h := NewCollectionHandler(&testhelpers.MockCollectionService{}, nil)
+	_, err := h.UpdateItemHandler(context.Background(), &UpdateItemHandlerRequest{Slug: "mix", ItemID: "1"})
+	testhelpers.AssertHumaError(t, err, 401)
+}
+
+func TestUpdateItem_InvalidItemID(t *testing.T) {
+	h := NewCollectionHandler(&testhelpers.MockCollectionService{}, nil)
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1})
+	_, err := h.UpdateItemHandler(ctx, &UpdateItemHandlerRequest{Slug: "mix", ItemID: "abc"})
+	testhelpers.AssertHumaError(t, err, 400)
+}
+
+func TestUpdateItem_Success(t *testing.T) {
+	notes := "great record"
+	mock := &testhelpers.MockCollectionService{
+		UpdateItemFn: func(slug string, itemID, userID uint, isAdmin bool, req *contracts.UpdateCollectionItemRequest) (*contracts.CollectionItemResponse, error) {
+			if slug != "mix" || itemID != 5 || userID != 1 {
+				t.Errorf("unexpected params slug=%q itemID=%d userID=%d", slug, itemID, userID)
+			}
+			return &contracts.CollectionItemResponse{ID: 5, Notes: req.Notes}, nil
+		},
+	}
+	h := NewCollectionHandler(mock, nil)
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1})
+	req := &UpdateItemHandlerRequest{Slug: "mix", ItemID: "5"}
+	req.Body.Notes = &notes
+
+	resp, err := h.UpdateItemHandler(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.ID != 5 {
+		t.Errorf("expected item ID=5, got %d", resp.Body.ID)
+	}
+}
+
+func TestUpdateItem_NotFoundMapsThroughCollectionError(t *testing.T) {
+	// A CollectionError flows through shared.MapCollectionError → 404.
+	mock := &testhelpers.MockCollectionService{
+		UpdateItemFn: func(_ string, _, _ uint, _ bool, _ *contracts.UpdateCollectionItemRequest) (*contracts.CollectionItemResponse, error) {
+			return nil, apperrors.ErrCollectionItemNotFound(5)
+		},
+	}
+	h := NewCollectionHandler(mock, nil)
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1})
+	_, err := h.UpdateItemHandler(ctx, &UpdateItemHandlerRequest{Slug: "mix", ItemID: "5"})
+	testhelpers.AssertHumaError(t, err, 404)
+}
+
+func TestUpdateItem_ServiceError(t *testing.T) {
+	// A non-CollectionError falls through to a generic 500.
+	mock := &testhelpers.MockCollectionService{
+		UpdateItemFn: func(_ string, _, _ uint, _ bool, _ *contracts.UpdateCollectionItemRequest) (*contracts.CollectionItemResponse, error) {
+			return nil, fmt.Errorf("db error")
+		},
+	}
+	h := NewCollectionHandler(mock, nil)
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1})
+	_, err := h.UpdateItemHandler(ctx, &UpdateItemHandlerRequest{Slug: "mix", ItemID: "5"})
+	testhelpers.AssertHumaError(t, err, 500)
+}
+
+// ============================================================================
+// GetEntityCollectionsHandler
+// ============================================================================
+
+func TestGetEntityCollections_Success(t *testing.T) {
+	mock := &testhelpers.MockCollectionService{
+		GetEntityCollectionsFn: func(entityType string, entityID, viewerID uint, limit int) ([]*contracts.CollectionListResponse, error) {
+			if entityType != "artist" || entityID != 42 {
+				t.Errorf("unexpected params type=%q id=%d", entityType, entityID)
+			}
+			return []*contracts.CollectionListResponse{{Slug: "mix"}}, nil
+		},
+	}
+	h := NewCollectionHandler(mock, nil)
+	resp, err := h.GetEntityCollectionsHandler(context.Background(), &GetEntityCollectionsHandlerRequest{EntityType: "artist", EntityID: "42"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Body.Collections) != 1 {
+		t.Errorf("expected 1 collection, got %d", len(resp.Body.Collections))
+	}
+}
+
+func TestGetEntityCollections_InvalidEntityID(t *testing.T) {
+	h := NewCollectionHandler(&testhelpers.MockCollectionService{}, nil)
+	_, err := h.GetEntityCollectionsHandler(context.Background(), &GetEntityCollectionsHandlerRequest{EntityType: "artist", EntityID: "abc"})
+	testhelpers.AssertHumaError(t, err, 400)
+}
+
+func TestGetEntityCollections_InvalidEntityType(t *testing.T) {
+	h := NewCollectionHandler(&testhelpers.MockCollectionService{}, nil)
+	_, err := h.GetEntityCollectionsHandler(context.Background(), &GetEntityCollectionsHandlerRequest{EntityType: "comment", EntityID: "1"})
+	testhelpers.AssertHumaError(t, err, 422)
+}
+
+func TestGetEntityCollections_ServiceError(t *testing.T) {
+	mock := &testhelpers.MockCollectionService{
+		GetEntityCollectionsFn: func(_ string, _, _ uint, _ int) ([]*contracts.CollectionListResponse, error) {
+			return nil, fmt.Errorf("db error")
+		},
+	}
+	h := NewCollectionHandler(mock, nil)
+	_, err := h.GetEntityCollectionsHandler(context.Background(), &GetEntityCollectionsHandlerRequest{EntityType: "artist", EntityID: "42"})
+	testhelpers.AssertHumaError(t, err, 500)
+}
+
+// ============================================================================
+// GetUserPublicCollectionsHandler
+// ============================================================================
+
+func TestGetUserPublicCollections_Success(t *testing.T) {
+	mock := &testhelpers.MockCollectionService{
+		GetUserPublicCollectionsByUsernameFn: func(username string, limit, offset int) ([]*contracts.CollectionListResponse, int64, error) {
+			if username != "johndoe" {
+				t.Errorf("unexpected username=%q", username)
+			}
+			// Default limit is applied when limit<=0.
+			if limit != 20 {
+				t.Errorf("expected default limit=20, got %d", limit)
+			}
+			return []*contracts.CollectionListResponse{{Slug: "mix"}}, 1, nil
+		},
+	}
+	h := NewCollectionHandler(mock, nil)
+	resp, err := h.GetUserPublicCollectionsHandler(context.Background(), &GetUserPublicCollectionsHandlerRequest{Username: "johndoe", Limit: 0})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Total != 1 || len(resp.Body.Collections) != 1 {
+		t.Errorf("unexpected body: %+v", resp.Body)
+	}
+}
+
+func TestGetUserPublicCollections_ServiceError(t *testing.T) {
+	mock := &testhelpers.MockCollectionService{
+		GetUserPublicCollectionsByUsernameFn: func(_ string, _, _ int) ([]*contracts.CollectionListResponse, int64, error) {
+			return nil, 0, fmt.Errorf("db error")
+		},
+	}
+	h := NewCollectionHandler(mock, nil)
+	_, err := h.GetUserPublicCollectionsHandler(context.Background(), &GetUserPublicCollectionsHandlerRequest{Username: "johndoe"})
+	testhelpers.AssertHumaError(t, err, 500)
+}

--- a/backend/internal/api/handlers/community/contributor_profile_rankings_test.go
+++ b/backend/internal/api/handlers/community/contributor_profile_rankings_test.go
@@ -1,0 +1,103 @@
+package community
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"psychic-homily-backend/internal/api/handlers/shared/testhelpers"
+	authm "psychic-homily-backend/internal/models/auth"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// ============================================================================
+// GetPercentileRankingsHandler
+//
+// The full privacy matrix is exercised by the integration suite; these unit
+// tests cover the handler-level branches (public happy path, user-not-found,
+// private-profile gate, and the two service-error paths) without a database.
+// ============================================================================
+
+func TestGetPercentileRankings_PublicSuccess(t *testing.T) {
+	mockUsers := &testhelpers.MockUserService{
+		GetUserByUsernameFn: func(username string) (*authm.User, error) {
+			// Public profile (default visibility + default privacy settings).
+			return &authm.User{ID: 5, ProfileVisibility: "public"}, nil
+		},
+	}
+	mockProfile := &testhelpers.MockContributorProfileService{
+		GetPercentileRankingsFn: func(userID uint) (*contracts.PercentileRankings, error) {
+			if userID != 5 {
+				t.Errorf("expected userID=5, got %d", userID)
+			}
+			return &contracts.PercentileRankings{
+				Rankings:     []contracts.PercentileRanking{},
+				OverallScore: 72,
+			}, nil
+		},
+	}
+	h := NewContributorProfileHandler(mockProfile, mockUsers)
+
+	// Anonymous viewer — public profile falls through to full rankings.
+	resp, err := h.GetPercentileRankingsHandler(context.Background(), &GetPercentileRankingsRequest{Username: "johndoe"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.OverallScore != 72 {
+		t.Errorf("expected overall score=72, got %d", resp.Body.OverallScore)
+	}
+}
+
+func TestGetPercentileRankings_UserNotFound(t *testing.T) {
+	mockUsers := &testhelpers.MockUserService{
+		GetUserByUsernameFn: func(_ string) (*authm.User, error) {
+			return nil, nil // not found → handler returns 404
+		},
+	}
+	h := NewContributorProfileHandler(&testhelpers.MockContributorProfileService{}, mockUsers)
+
+	_, err := h.GetPercentileRankingsHandler(context.Background(), &GetPercentileRankingsRequest{Username: "ghost"})
+	testhelpers.AssertHumaError(t, err, 404)
+}
+
+func TestGetPercentileRankings_PrivateProfileHiddenFromOthers(t *testing.T) {
+	mockUsers := &testhelpers.MockUserService{
+		GetUserByUsernameFn: func(_ string) (*authm.User, error) {
+			return &authm.User{ID: 5, ProfileVisibility: "private"}, nil
+		},
+	}
+	h := NewContributorProfileHandler(&testhelpers.MockContributorProfileService{}, mockUsers)
+
+	// Anonymous (non-owner) viewer → private profile masked as 404.
+	_, err := h.GetPercentileRankingsHandler(context.Background(), &GetPercentileRankingsRequest{Username: "private-user"})
+	testhelpers.AssertHumaError(t, err, 404)
+}
+
+func TestGetPercentileRankings_UserLookupError(t *testing.T) {
+	mockUsers := &testhelpers.MockUserService{
+		GetUserByUsernameFn: func(_ string) (*authm.User, error) {
+			return nil, fmt.Errorf("db error")
+		},
+	}
+	h := NewContributorProfileHandler(&testhelpers.MockContributorProfileService{}, mockUsers)
+
+	_, err := h.GetPercentileRankingsHandler(context.Background(), &GetPercentileRankingsRequest{Username: "johndoe"})
+	testhelpers.AssertHumaError(t, err, 500)
+}
+
+func TestGetPercentileRankings_RankingsServiceError(t *testing.T) {
+	mockUsers := &testhelpers.MockUserService{
+		GetUserByUsernameFn: func(_ string) (*authm.User, error) {
+			return &authm.User{ID: 5, ProfileVisibility: "public"}, nil
+		},
+	}
+	mockProfile := &testhelpers.MockContributorProfileService{
+		GetPercentileRankingsFn: func(_ uint) (*contracts.PercentileRankings, error) {
+			return nil, fmt.Errorf("db error")
+		},
+	}
+	h := NewContributorProfileHandler(mockProfile, mockUsers)
+
+	_, err := h.GetPercentileRankingsHandler(context.Background(), &GetPercentileRankingsRequest{Username: "johndoe"})
+	testhelpers.AssertHumaError(t, err, 500)
+}

--- a/backend/internal/api/handlers/community/entity_report_test.go
+++ b/backend/internal/api/handlers/community/entity_report_test.go
@@ -179,6 +179,41 @@ func TestReportShow_Success(t *testing.T) {
 	}
 }
 
+func TestReportComment_Success(t *testing.T) {
+	expected := makeEntityReportResponse(6, "comment", "harassment")
+	h := NewEntityReportHandler(
+		&testhelpers.MockEntityReportService{
+			CreateEntityReportFn: func(req *contracts.CreateEntityReportRequest) (*contracts.EntityReportResponse, error) {
+				if req.EntityType != "comment" || req.ReportType != "harassment" {
+					t.Errorf("unexpected params: %+v", req)
+				}
+				return expected, nil
+			},
+		},
+		nil,
+	)
+
+	req := &ReportEntityRequest{EntityID: "10"}
+	req.Body.ReportType = "harassment"
+
+	resp, err := h.ReportCommentHandler(entityReportUserCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.EntityType != "comment" {
+		t.Errorf("expected entity_type=comment, got %s", resp.Body.EntityType)
+	}
+}
+
+func TestReportComment_InvalidReportType(t *testing.T) {
+	// "wrong_venue" is valid for shows but not for comments.
+	h := testEntityReportHandler()
+	req := &ReportEntityRequest{EntityID: "1"}
+	req.Body.ReportType = "wrong_venue"
+	_, err := h.ReportCommentHandler(entityReportUserCtx(), req)
+	testhelpers.AssertHumaError(t, err, 422)
+}
+
 // PSY-357: collections accept the same shape as the other entity types.
 // PSY-578: collection-specific taxonomy is spam/inappropriate/misleading/other
 // (diverges from the comment vocabulary — see entity_report.go for rationale).

--- a/backend/internal/api/handlers/community/leaderboard_test.go
+++ b/backend/internal/api/handlers/community/leaderboard_test.go
@@ -1,0 +1,128 @@
+package community
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"psychic-homily-backend/internal/api/handlers/shared/testhelpers"
+	authm "psychic-homily-backend/internal/models/auth"
+	"psychic-homily-backend/internal/services/contracts"
+)
+
+// ============================================================================
+// NewLeaderboardHandler
+// ============================================================================
+
+func TestNewLeaderboardHandler_WiresService(t *testing.T) {
+	svc := &testhelpers.MockLeaderboardService{}
+	h := NewLeaderboardHandler(svc)
+	if h == nil {
+		t.Fatal("NewLeaderboardHandler returned nil")
+	}
+	if h.leaderboardService != svc {
+		t.Error("handler did not retain the injected leaderboard service")
+	}
+}
+
+// ============================================================================
+// GetLeaderboardHandler
+// ============================================================================
+
+func TestGetLeaderboard_DefaultsAndAnonymous(t *testing.T) {
+	mock := &testhelpers.MockLeaderboardService{
+		GetLeaderboardFn: func(dimension, period string, limit int) ([]contracts.LeaderboardEntry, error) {
+			// Empty request → handler applies defaults.
+			if dimension != "overall" || period != "all_time" || limit != 25 {
+				t.Errorf("expected defaults overall/all_time/25, got %s/%s/%d", dimension, period, limit)
+			}
+			return []contracts.LeaderboardEntry{{Rank: 1, UserID: 2, Username: "top", Count: 99}}, nil
+		},
+	}
+	h := NewLeaderboardHandler(mock)
+
+	// Anonymous context → no user-rank lookup, UserRank stays nil.
+	resp, err := h.GetLeaderboardHandler(context.Background(), &GetLeaderboardRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.Dimension != "overall" || resp.Body.Period != "all_time" {
+		t.Errorf("unexpected echoed dimension/period: %+v", resp.Body)
+	}
+	if len(resp.Body.Entries) != 1 || resp.Body.Entries[0].Username != "top" {
+		t.Errorf("unexpected entries: %+v", resp.Body.Entries)
+	}
+	if resp.Body.UserRank != nil {
+		t.Errorf("expected nil UserRank for anonymous viewer, got %v", *resp.Body.UserRank)
+	}
+}
+
+func TestGetLeaderboard_AuthenticatedComputesUserRank(t *testing.T) {
+	rank := 4
+	mock := &testhelpers.MockLeaderboardService{
+		GetLeaderboardFn: func(_, _ string, _ int) ([]contracts.LeaderboardEntry, error) {
+			return []contracts.LeaderboardEntry{}, nil
+		},
+		GetUserRankFn: func(userID uint, dimension, period string) (*int, error) {
+			if userID != 7 {
+				t.Errorf("expected userID=7, got %d", userID)
+			}
+			return &rank, nil
+		},
+	}
+	h := NewLeaderboardHandler(mock)
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 7})
+
+	resp, err := h.GetLeaderboardHandler(ctx, &GetLeaderboardRequest{Dimension: "shows", Period: "month", Limit: 10})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.UserRank == nil || *resp.Body.UserRank != 4 {
+		t.Errorf("expected UserRank=4, got %v", resp.Body.UserRank)
+	}
+}
+
+func TestGetLeaderboard_UserRankErrorIsNonFatal(t *testing.T) {
+	// A GetUserRank failure must not fail the request — the board still returns.
+	mock := &testhelpers.MockLeaderboardService{
+		GetLeaderboardFn: func(_, _ string, _ int) ([]contracts.LeaderboardEntry, error) {
+			return []contracts.LeaderboardEntry{}, nil
+		},
+		GetUserRankFn: func(_ uint, _, _ string) (*int, error) {
+			return nil, fmt.Errorf("rank query failed")
+		},
+	}
+	h := NewLeaderboardHandler(mock)
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 7})
+
+	resp, err := h.GetLeaderboardHandler(ctx, &GetLeaderboardRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body.UserRank != nil {
+		t.Errorf("expected nil UserRank after non-fatal error, got %v", *resp.Body.UserRank)
+	}
+}
+
+func TestGetLeaderboard_InvalidDimension(t *testing.T) {
+	mock := &testhelpers.MockLeaderboardService{
+		GetLeaderboardFn: func(dimension, _ string, _ int) ([]contracts.LeaderboardEntry, error) {
+			// Handler maps this exact message to 422.
+			return nil, fmt.Errorf("invalid dimension: %s", dimension)
+		},
+	}
+	h := NewLeaderboardHandler(mock)
+	_, err := h.GetLeaderboardHandler(context.Background(), &GetLeaderboardRequest{Dimension: "bogus"})
+	testhelpers.AssertHumaError(t, err, 422)
+}
+
+func TestGetLeaderboard_ServiceError(t *testing.T) {
+	mock := &testhelpers.MockLeaderboardService{
+		GetLeaderboardFn: func(_, _ string, _ int) ([]contracts.LeaderboardEntry, error) {
+			return nil, fmt.Errorf("db error")
+		},
+	}
+	h := NewLeaderboardHandler(mock)
+	_, err := h.GetLeaderboardHandler(context.Background(), &GetLeaderboardRequest{})
+	testhelpers.AssertHumaError(t, err, 500)
+}

--- a/backend/internal/api/handlers/engagement/calendar_test.go
+++ b/backend/internal/api/handlers/engagement/calendar_test.go
@@ -3,14 +3,29 @@ package engagement
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/go-chi/chi/v5"
 
 	"psychic-homily-backend/internal/api/handlers/shared/testhelpers"
 	"psychic-homily-backend/internal/config"
 	authm "psychic-homily-backend/internal/models/auth"
 	"psychic-homily-backend/internal/services/contracts"
 )
+
+// feedRequestWithToken builds a GET request whose chi URL param "token" is
+// set to the given value, mirroring how the router populates it in
+// production. An empty token is added as-is so the missing-token branch can
+// be exercised.
+func feedRequestWithToken(token string) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, "/calendar/feed", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("token", token)
+	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+}
 
 func testCalendarConfig() *config.Config {
 	return &config.Config{
@@ -177,6 +192,88 @@ func TestDeleteCalendarTokenHandler_ServiceError(t *testing.T) {
 
 	_, err := h.DeleteCalendarTokenHandler(ctx, &DeleteCalendarTokenRequest{})
 	testhelpers.AssertHumaError(t, err, 422)
+}
+
+// =============================================================================
+// GetCalendarFeedHandler tests (Chi http.HandlerFunc, token-authenticated)
+// =============================================================================
+
+func TestGetCalendarFeedHandler_MissingToken(t *testing.T) {
+	h := NewCalendarHandler(&testhelpers.MockCalendarService{}, testCalendarConfig())
+	w := httptest.NewRecorder()
+
+	h.GetCalendarFeedHandler(w, feedRequestWithToken(""))
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("missing token status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestGetCalendarFeedHandler_InvalidToken(t *testing.T) {
+	mock := &testhelpers.MockCalendarService{
+		ValidateCalendarTokenFn: func(token string) (*authm.User, error) {
+			return nil, fmt.Errorf("token not found")
+		},
+	}
+	h := NewCalendarHandler(mock, testCalendarConfig())
+	w := httptest.NewRecorder()
+
+	h.GetCalendarFeedHandler(w, feedRequestWithToken("phcal_bad"))
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("invalid token status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestGetCalendarFeedHandler_GenerationError(t *testing.T) {
+	mock := &testhelpers.MockCalendarService{
+		ValidateCalendarTokenFn: func(token string) (*authm.User, error) {
+			return &authm.User{ID: 1}, nil
+		},
+		GenerateICSFeedFn: func(userID uint, frontendURL string) ([]byte, error) {
+			return nil, fmt.Errorf("ics build failed")
+		},
+	}
+	h := NewCalendarHandler(mock, testCalendarConfig())
+	w := httptest.NewRecorder()
+
+	h.GetCalendarFeedHandler(w, feedRequestWithToken("phcal_ok"))
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("generation-error status = %d, want %d", w.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestGetCalendarFeedHandler_Success(t *testing.T) {
+	ics := []byte("BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n")
+	mock := &testhelpers.MockCalendarService{
+		ValidateCalendarTokenFn: func(token string) (*authm.User, error) {
+			if token != "phcal_ok" {
+				t.Errorf("unexpected token=%q", token)
+			}
+			return &authm.User{ID: 7}, nil
+		},
+		GenerateICSFeedFn: func(userID uint, frontendURL string) ([]byte, error) {
+			if userID != 7 {
+				t.Errorf("unexpected userID=%d", userID)
+			}
+			return ics, nil
+		},
+	}
+	h := NewCalendarHandler(mock, testCalendarConfig())
+	w := httptest.NewRecorder()
+
+	h.GetCalendarFeedHandler(w, feedRequestWithToken("phcal_ok"))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("success status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "text/calendar; charset=utf-8" {
+		t.Errorf("Content-Type = %q, want text/calendar; charset=utf-8", ct)
+	}
+	if w.Body.String() != string(ics) {
+		t.Errorf("body = %q, want %q", w.Body.String(), string(ics))
+	}
 }
 
 // =============================================================================

--- a/backend/internal/api/handlers/shared/error_mappers_test.go
+++ b/backend/internal/api/handlers/shared/error_mappers_test.go
@@ -1,0 +1,204 @@
+package shared
+
+import (
+	stderrors "errors"
+	"testing"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	apperrors "psychic-homily-backend/internal/errors"
+)
+
+// statusOf type-asserts a Huma error to its HTTP status code. The mappers
+// return values produced by huma.Error4XX(...), all of which satisfy
+// huma.StatusError, so a failed assertion is itself a test failure.
+func statusOf(t *testing.T, err error) int {
+	t.Helper()
+	var statusErr huma.StatusError
+	if !stderrors.As(err, &statusErr) {
+		t.Fatalf("expected huma.StatusError, got %T (%v)", err, err)
+	}
+	return statusErr.GetStatus()
+}
+
+func TestMapTagError_CodeToStatus(t *testing.T) {
+	// Every tag code maps to exactly one status; cover the whole switch so a
+	// future code added without a status mapping is caught.
+	cases := []struct {
+		name   string
+		err    *apperrors.TagError
+		status int
+	}{
+		{"not found", apperrors.ErrTagNotFound(7), 404},
+		{"not found by slug", apperrors.ErrTagNotFoundBySlug("punk"), 404},
+		{"exists", apperrors.ErrTagExists("punk"), 409},
+		{"alias exists", apperrors.ErrTagAliasExists("hardcore"), 409},
+		{"entity tag exists", apperrors.ErrEntityTagExists(1, "artist", 2), 409},
+		{"entity tag not found", apperrors.ErrEntityTagNotFound(1, "artist", 2), 404},
+		{"creation forbidden", apperrors.ErrTagCreationForbidden(), 403},
+		{"name invalid", apperrors.ErrTagNameInvalid("too long"), 422},
+		{"merge invalid", apperrors.ErrTagMergeInvalid("self-merge"), 422},
+		{"merge alias conflict", apperrors.ErrTagMergeAliasConflict("hc", 3), 409},
+		{"hierarchy cycle", apperrors.ErrTagHierarchyCycle("would loop"), 422},
+		{"hierarchy not genre", apperrors.ErrTagHierarchyNotGenre("blue", "mood"), 422},
+		{"bulk action invalid", apperrors.ErrTagBulkActionInvalid("unknown verb"), 422},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := MapTagError(tc.err)
+			if got == nil {
+				t.Fatalf("MapTagError(%v) = nil, want status %d", tc.err, tc.status)
+			}
+			if s := statusOf(t, got); s != tc.status {
+				t.Errorf("MapTagError(%v) status = %d, want %d", tc.err, s, tc.status)
+			}
+		})
+	}
+}
+
+func TestMapTagError_NonTagErrorReturnsNil(t *testing.T) {
+	// A plain error must fall through so the caller can try other mappers.
+	if got := MapTagError(stderrors.New("boom")); got != nil {
+		t.Errorf("MapTagError(plain error) = %v, want nil", got)
+	}
+	// An unknown tag code is not in the switch and also falls through.
+	unknown := &apperrors.TagError{Code: "TAG_SOMETHING_NEW", Message: "x"}
+	if got := MapTagError(unknown); got != nil {
+		t.Errorf("MapTagError(unknown code) = %v, want nil", got)
+	}
+}
+
+func TestMapCollectionError_CodeToStatus(t *testing.T) {
+	cases := []struct {
+		name   string
+		err    *apperrors.CollectionError
+		status int
+	}{
+		{"not found", apperrors.ErrCollectionNotFound("mix"), 404},
+		{"forbidden", apperrors.ErrCollectionForbidden("mix"), 403},
+		{"item exists", apperrors.ErrCollectionItemExists(1, "artist", 2), 409},
+		{"item not found", apperrors.ErrCollectionItemNotFound(3), 404},
+		{"invalid request", apperrors.ErrCollectionInvalidRequest("bad sort"), 422},
+		{"tag limit exceeded", apperrors.ErrCollectionTagLimitExceeded(10, 10), 422},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := MapCollectionError(tc.err)
+			if got == nil {
+				t.Fatalf("MapCollectionError(%v) = nil, want status %d", tc.err, tc.status)
+			}
+			if s := statusOf(t, got); s != tc.status {
+				t.Errorf("MapCollectionError(%v) status = %d, want %d", tc.err, s, tc.status)
+			}
+		})
+	}
+}
+
+func TestMapCollectionError_LimitExceededCarriesStructuredDetail(t *testing.T) {
+	// CodeCollectionLimitExceeded → 403 AND attaches a structured ErrorDetail
+	// (via collectionLimitDetail) so the frontend reads tier/used/limit/kind
+	// off errors[].value without parsing the human string.
+	src := apperrors.ErrCollectionLimitExceeded("free", 5, 5, apperrors.CollectionLimitKindOwned)
+	got := MapCollectionError(src)
+	if got == nil {
+		t.Fatal("MapCollectionError(limit exceeded) = nil, want 403 with detail")
+	}
+	if s := statusOf(t, got); s != 403 {
+		t.Errorf("limit-exceeded status = %d, want 403", s)
+	}
+
+	model, ok := got.(*huma.ErrorModel)
+	if !ok {
+		t.Fatalf("expected *huma.ErrorModel, got %T", got)
+	}
+	if len(model.Errors) != 1 {
+		t.Fatalf("expected 1 structured error detail, got %d", len(model.Errors))
+	}
+	detail := model.Errors[0]
+	if detail.Location != "body" {
+		t.Errorf("detail.Location = %q, want \"body\"", detail.Location)
+	}
+	value, ok := detail.Value.(map[string]any)
+	if !ok {
+		t.Fatalf("detail.Value type = %T, want map[string]any", detail.Value)
+	}
+	if value["code"] != apperrors.CodeCollectionLimitExceeded {
+		t.Errorf("detail code = %v, want %s", value["code"], apperrors.CodeCollectionLimitExceeded)
+	}
+	if value["tier"] != "free" {
+		t.Errorf("detail tier = %v, want \"free\"", value["tier"])
+	}
+	if value["used"] != 5 {
+		t.Errorf("detail used = %v, want 5", value["used"])
+	}
+	if value["limit"] != 5 {
+		t.Errorf("detail limit = %v, want 5", value["limit"])
+	}
+	if value["soft_cap_kind"] != apperrors.CollectionLimitKindOwned {
+		t.Errorf("detail soft_cap_kind = %v, want %s", value["soft_cap_kind"], apperrors.CollectionLimitKindOwned)
+	}
+}
+
+func TestMapCollectionError_NonCollectionErrorReturnsNil(t *testing.T) {
+	if got := MapCollectionError(stderrors.New("boom")); got != nil {
+		t.Errorf("MapCollectionError(plain error) = %v, want nil", got)
+	}
+	unknown := &apperrors.CollectionError{Code: "COLLECTION_NEW_CODE", Message: "x"}
+	if got := MapCollectionError(unknown); got != nil {
+		t.Errorf("MapCollectionError(unknown code) = %v, want nil", got)
+	}
+}
+
+func TestMapFollowError_CodeToStatus(t *testing.T) {
+	if got := MapFollowError(apperrors.ErrFollowInvalidEntityType("genre")); got == nil {
+		t.Fatal("MapFollowError(invalid type) = nil, want 422")
+	} else if s := statusOf(t, got); s != 422 {
+		t.Errorf("invalid-type status = %d, want 422", s)
+	}
+
+	if got := MapFollowError(apperrors.ErrFollowInternal(stderrors.New("db down"))); got == nil {
+		t.Fatal("MapFollowError(internal) = nil, want 500")
+	} else if s := statusOf(t, got); s != 500 {
+		t.Errorf("internal status = %d, want 500", s)
+	}
+}
+
+func TestMapFollowError_NonFollowErrorReturnsNil(t *testing.T) {
+	if got := MapFollowError(stderrors.New("boom")); got != nil {
+		t.Errorf("MapFollowError(plain error) = %v, want nil", got)
+	}
+	unknown := &apperrors.FollowError{Code: "FOLLOW_NEW_CODE", Message: "x"}
+	if got := MapFollowError(unknown); got != nil {
+		t.Errorf("MapFollowError(unknown code) = %v, want nil", got)
+	}
+}
+
+func TestMapAttendanceError_CodeToStatus(t *testing.T) {
+	if got := MapAttendanceError(apperrors.ErrAttendanceShowNotFound()); got == nil {
+		t.Fatal("MapAttendanceError(show not found) = nil, want 404")
+	} else if s := statusOf(t, got); s != 404 {
+		t.Errorf("show-not-found status = %d, want 404", s)
+	}
+
+	if got := MapAttendanceError(apperrors.ErrAttendanceInvalidStatus("maybe")); got == nil {
+		t.Fatal("MapAttendanceError(invalid status) = nil, want 422")
+	} else if s := statusOf(t, got); s != 422 {
+		t.Errorf("invalid-status status = %d, want 422", s)
+	}
+
+	if got := MapAttendanceError(apperrors.ErrAttendanceInternal(stderrors.New("db down"))); got == nil {
+		t.Fatal("MapAttendanceError(internal) = nil, want 500")
+	} else if s := statusOf(t, got); s != 500 {
+		t.Errorf("internal status = %d, want 500", s)
+	}
+}
+
+func TestMapAttendanceError_NonAttendanceErrorReturnsNil(t *testing.T) {
+	if got := MapAttendanceError(stderrors.New("boom")); got != nil {
+		t.Errorf("MapAttendanceError(plain error) = %v, want nil", got)
+	}
+	unknown := &apperrors.AttendanceError{Code: "ATTENDANCE_NEW_CODE", Message: "x"}
+	if got := MapAttendanceError(unknown); got != nil {
+		t.Errorf("MapAttendanceError(unknown code) = %v, want nil", got)
+	}
+}

--- a/backend/internal/api/handlers/shared/helpers_test.go
+++ b/backend/internal/api/handlers/shared/helpers_test.go
@@ -1,0 +1,40 @@
+package shared
+
+import (
+	"testing"
+
+	authm "psychic-homily-backend/internal/models/auth"
+)
+
+func TestGetUserID_NilReturnsZero(t *testing.T) {
+	if got := GetUserID(nil); got != 0 {
+		t.Errorf("GetUserID(nil) = %d, want 0", got)
+	}
+}
+
+func TestGetUserID_ReturnsUserID(t *testing.T) {
+	user := &authm.User{}
+	user.ID = 42
+	if got := GetUserID(user); got != 42 {
+		t.Errorf("GetUserID(user{ID:42}) = %d, want 42", got)
+	}
+}
+
+func TestParseDate_Valid(t *testing.T) {
+	got, err := ParseDate("2026-05-20")
+	if err != nil {
+		t.Fatalf("ParseDate(\"2026-05-20\") error = %v, want nil", err)
+	}
+	if got.Year() != 2026 || got.Month() != 5 || got.Day() != 20 {
+		t.Errorf("ParseDate(\"2026-05-20\") = %v, want 2026-05-20", got)
+	}
+}
+
+func TestParseDate_Invalid(t *testing.T) {
+	// Wrong format (slashes) and a non-date string both must error.
+	for _, in := range []string{"05/20/2026", "not-a-date", "2026-13-40", ""} {
+		if _, err := ParseDate(in); err == nil {
+			t.Errorf("ParseDate(%q) error = nil, want non-nil", in)
+		}
+	}
+}

--- a/backend/internal/api/handlers/system/health_integration_test.go
+++ b/backend/internal/api/handlers/system/health_integration_test.go
@@ -1,0 +1,41 @@
+package system
+
+import (
+	"context"
+	"testing"
+
+	"psychic-homily-backend/db"
+	"psychic-homily-backend/internal/testutil"
+)
+
+// TestHealthHandler_DBHealthy_Integration covers the success branch of
+// checkDatabaseHealth (and HealthHandler's healthy overall status) against a
+// live Postgres test container. checkDatabaseHealth reads the db package
+// global rather than an injected handle, so we point the global at the test
+// connection for the duration of the test and restore it afterward.
+func TestHealthHandler_DBHealthy_Integration(t *testing.T) {
+	testDB := testutil.SetupTestPostgres(t)
+	t.Cleanup(testDB.Cleanup)
+
+	prev := db.DB
+	db.DB = testDB.DB
+	t.Cleanup(func() { db.DB = prev })
+
+	resp, err := HealthHandler(context.Background(), &struct{}{})
+	if err != nil {
+		t.Fatalf("HealthHandler returned error: %v", err)
+	}
+	if resp.Body.Status != "healthy" {
+		t.Errorf("overall status = %q, want \"healthy\"", resp.Body.Status)
+	}
+	dbHealth, ok := resp.Body.Components["database"]
+	if !ok {
+		t.Fatal("expected a \"database\" component in the response")
+	}
+	if dbHealth.Status != "healthy" {
+		t.Errorf("database status = %q, want \"healthy\" (error: %s)", dbHealth.Status, dbHealth.Error)
+	}
+	if dbHealth.Latency == "" {
+		t.Error("expected non-empty latency on the healthy path")
+	}
+}

--- a/backend/internal/api/handlers/system/health_test.go
+++ b/backend/internal/api/handlers/system/health_test.go
@@ -1,0 +1,56 @@
+package system
+
+import (
+	"context"
+	"testing"
+
+	"psychic-homily-backend/db"
+)
+
+// TestHealthHandler_DBNotInitialized exercises the no-DB branch with no
+// external dependencies: when the global GORM handle is nil, the database
+// component is reported unhealthy and the overall status follows.
+func TestHealthHandler_DBNotInitialized(t *testing.T) {
+	// db.DB is a package global; save and restore it so this test never
+	// leaks a nil handle into a later test that expects a real connection.
+	prev := db.DB
+	db.DB = nil
+	t.Cleanup(func() { db.DB = prev })
+
+	resp, err := HealthHandler(context.Background(), &struct{}{})
+	if err != nil {
+		t.Fatalf("HealthHandler returned error: %v", err)
+	}
+	if resp.Body.Status != "unhealthy" {
+		t.Errorf("overall status = %q, want \"unhealthy\"", resp.Body.Status)
+	}
+	if resp.Body.Timestamp == "" {
+		t.Error("expected non-empty timestamp")
+	}
+	dbHealth, ok := resp.Body.Components["database"]
+	if !ok {
+		t.Fatal("expected a \"database\" component in the response")
+	}
+	if dbHealth.Status != "unhealthy" {
+		t.Errorf("database status = %q, want \"unhealthy\"", dbHealth.Status)
+	}
+	if dbHealth.Error != "database not initialized" {
+		t.Errorf("database error = %q, want \"database not initialized\"", dbHealth.Error)
+	}
+}
+
+// TestCheckDatabaseHealth_NotInitialized covers checkDatabaseHealth's nil
+// branch directly (the same condition, asserted at the function boundary).
+func TestCheckDatabaseHealth_NotInitialized(t *testing.T) {
+	prev := db.DB
+	db.DB = nil
+	t.Cleanup(func() { db.DB = prev })
+
+	got := checkDatabaseHealth(context.Background())
+	if got.Status != "unhealthy" {
+		t.Errorf("status = %q, want \"unhealthy\"", got.Status)
+	}
+	if got.Latency == "" {
+		t.Error("expected non-empty latency even on the failure path")
+	}
+}


### PR DESCRIPTION
## Summary

Raises backend test coverage on the `api/handlers/shared` helpers and the audited 0% handler functions across admin/auth/catalog/community/engagement/system. **Tests-only — no production code change.**

Coverage (full `go test ./... -cover`):

| Package | Before | After |
| --- | --- | --- |
| `api/handlers/shared` | 51.1% | **100.0%** |
| `api/handlers/system` | 0.0% | **89.5%** |
| `api/handlers/community` | 78.8% | **88.2%** |
| `api/handlers/catalog` | 74.0% | **80.7%** |
| `api/handlers/admin` | 87.5% | **90.5%** |
| `api/handlers/auth` | 79.2% | **83.5%** |
| `api/handlers/engagement` | 91.6% | **93.8%** |
| **Total backend** | **67.0%** | **68.6%** |

### Re-baseline note
The ticket's audit was point-in-time (66.5% / `a3a3bd13`). Re-running on current main (`f25c53ec`) gave **67.0%**, and two siblings had shifted the target list:
- **PSY-759** (`revisiondiff` consolidation) removed the `compute*Changes` funcs the audit listed — they no longer exist, so they're not retested here.
- **PSY-761** added `MapFollowError` / `MapAttendanceError` to `api/handlers/shared` — both are now covered.

I targeted the functions genuinely uncovered now (verified via `go tool cover -func`), not the stale list.

### What got tested
- **shared**: `MapTagError`, `MapCollectionError` (+ structured `collectionLimitDetail` payload), `MapFollowError`, `MapAttendanceError`, `GetUserID`, `ParseDate` — each with code→status mapping + fall-through-to-nil cases.
- **admin**: `NewAutoPromotionHandler`, `EvaluateAllUsersHandler`, `EvaluateUserHandler`, `GetActivityFeedHandler`, `SuggestReleaseEditHandler`.
- **auth**: `UpdateProfileHandler`, `SetCollectionDigestHandler`.
- **catalog**: `GetArtistLabelsHandler`, `GetArtistBillCompositionHandler`, `DeleteRelationshipHandler`, `DeriveRelationshipsHandler`, `AdminGetUnmatchedPlaysHandler`, `AdminLinkPlayHandler`, `AdminBulkLinkPlaysHandler`, `GetSceneGraphHandler` + `parseTypesQueryParam`, `ListTagEntitiesHandler`, `GetGenreHierarchyHandler`, `SetTagParentHandler`, `AdminCreateVenueHandler`, `GetVenueGenresHandler`, `GetVenueBillNetworkHandler`.
- **community**: `UpdateItemHandler`, `GetEntityCollectionsHandler`, `GetUserPublicCollectionsHandler`, `GetPercentileRankingsHandler`, `ReportCommentHandler`, `NewLeaderboardHandler`, `GetLeaderboardHandler`.
- **engagement**: `GetCalendarFeedHandler` (chi `http.HandlerFunc` via `httptest`).
- **system**: `HealthHandler` + `checkDatabaseHealth` (unit test for the nil-DB branch; testcontainer integration test for the healthy ping branch).

Each handler gets ≥1 happy-path + ≥1 error-path test, reusing the existing `handlers/shared/testhelpers` fixtures (`AssertHumaError`, `CtxWithUser`, generated mocks) and the per-package handler-test templates.

## Test plan
- [x] `cd backend && go build ./...` — passes
- [x] `cd backend && go test ./... -cover` — all packages pass
- [x] `go tool cover -func` confirms every targeted function moved off 0% (67.7%–100%)

## Manual repro
Tests-only ticket; the coverage delta IS the deliverable. Before→after totals and per-package numbers are in the table above. `api/handlers/shared` is at 100% (≥85% target met); total backend 67.0%→68.6%.

## Simplify
`/simplify` run before PR (reuse / quality / efficiency lenses). Code reuses existing test helpers, mocks, and per-package constructors; no duplication beyond idiomatic Go table-free test structure. Only fixes were rewording two comments that referenced the coverage motive to focus on durable WHY. No `PSY-{N}` refs in added code.

## Scope-adjacent observations (dead code, NOT touched)
Two functions surfaced as genuinely unreachable while triaging the catalog 0% list — flagging for a follow-up, not removed here (tests-only):
- `catalog/artist.go:907 ptrToStr` — defined + documented but never called (likely orphaned by the PSY-759 `computeArtistChanges` removal).
- `catalog/show.go ExportShowResponse` + its `SetContentType` method — the type is never constructed; `ExportShowHandler` returns `*huma.StreamResponse`.

Closes PSY-764