### PR TITLE
PSY-756: RFC 8058 List-Unsubscribe + opt-out for tier/edit emails

### DIFF
--- a/backend/db/migrations/20260521012633_tier_edit_notification_prefs.down.sql
+++ b/backend/db/migrations/20260521012633_tier_edit_notification_prefs.down.sql
@@ -1,0 +1,5 @@
+-- Revert PSY-756 additions.
+
+ALTER TABLE user_preferences
+    DROP COLUMN IF EXISTS notify_on_edit_notifications,
+    DROP COLUMN IF EXISTS notify_on_tier_notifications;

--- a/backend/db/migrations/20260521012633_tier_edit_notification_prefs.up.sql
+++ b/backend/db/migrations/20260521012633_tier_edit_notification_prefs.up.sql
@@ -1,0 +1,25 @@
+-- PSY-756: per-category notification preferences for tier-change and
+-- edit-review emails.
+--
+-- Five notification senders (tier promotion/demotion/demotion-warning, edit
+-- approved/rejected) lacked RFC 8058 List-Unsubscribe headers and an in-body
+-- opt-out. Wiring those requires a preference flag the unsubscribe link can
+-- flip and the senders can gate on.
+--
+-- Two columns (per-category), matching the locked decision to let users opt
+-- out of tier-change emails separately from edit-review emails:
+--
+--   * notify_on_tier_notifications  — promotion / demotion / demotion-warning
+--   * notify_on_edit_notifications  — edit approved / rejected
+--
+-- Both default TRUE (opt-OUT), matching notify_on_comment_subscription and
+-- notify_on_mention: each is a single email triggered by one discrete action
+-- the user took (submitting an edit) or that directly concerns their account
+-- (a tier change). This is the standard opt-OUT default per project policy
+-- (feedback_default_optout_notifications). The collection-digest opt-IN
+-- (DEFAULT FALSE) stays the documented exception — it is the only firehose
+-- that can deliver many emails with no direct interaction.
+
+ALTER TABLE user_preferences
+    ADD COLUMN notify_on_tier_notifications BOOLEAN NOT NULL DEFAULT TRUE,
+    ADD COLUMN notify_on_edit_notifications BOOLEAN NOT NULL DEFAULT TRUE;

--- a/backend/internal/api/handlers/auth/unsubscribe_collection_digest.go
+++ b/backend/internal/api/handlers/auth/unsubscribe_collection_digest.go
@@ -65,18 +65,23 @@ func (h *UserPreferencesHandler) UnsubscribeCollectionDigestPageHandler(w http.R
 	)
 
 	if isOneClickPost(r) {
-		// RFC 8058: respond with 200 and a minimal body. The body is not
-		// strictly required, but Gmail's documented examples include one
-		// and including it makes manual debugging easier.
-		w.Header().Set("Content-Type", "application/json; charset=utf-8")
-		w.Header().Set("Cache-Control", "no-store")
-		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(map[string]bool{"unsubscribed": true})
+		writeOneClickUnsubscribed(w)
 		return
 	}
 
 	// GET (manual click) — render an HTML confirmation page.
 	writeUnsubscribeConfirmation(w, r)
+}
+
+// writeOneClickUnsubscribed writes the RFC 8058 one-click POST success
+// response: 200 with a minimal JSON body. The body is not strictly required,
+// but Gmail's documented examples include one and it makes manual debugging
+// easier. Shared by every one-click unsubscribe handler.
+func writeOneClickUnsubscribed(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]bool{"unsubscribed": true})
 }
 
 // isOneClickPost returns true when the request is a POST with body
@@ -95,6 +100,17 @@ func writeUnsubscribeConfirmation(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Cache-Control", "no-store")
 	w.WriteHeader(http.StatusOK)
 	fmt.Fprint(w, unsubscribeConfirmationHTML)
+}
+
+// writeScopedUnsubscribeConfirmation renders a GET success page whose body
+// names the specific category the recipient unsubscribed from. The noun is
+// supplied by the handler (e.g. "tier-change emails") and is from a fixed
+// internal allowlist, not user input, so it's safe to interpolate.
+func writeScopedUnsubscribeConfirmation(w http.ResponseWriter, noun string) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprintf(w, scopedUnsubscribeConfirmationTemplate, noun)
 }
 
 // writeUnsubscribeError renders an error page on GET, or a JSON body on POST,
@@ -134,6 +150,32 @@ const unsubscribeConfirmationHTML = `<!DOCTYPE html>
         <h1 style="margin: 0 0 12px; font-size: 22px; font-weight: 600;">You&rsquo;re unsubscribed</h1>
         <p style="margin: 0 0 24px; color: #555; line-height: 1.5;">
             You&rsquo;ve been unsubscribed from collection digest emails.
+            You can re-enable this anytime in your notification settings.
+        </p>
+        <p style="margin: 0;">
+            <a href="/settings" style="display: inline-block; padding: 10px 20px; border-radius: 8px; background: #f97316; color: #ffffff; text-decoration: none; font-weight: 600;">Go to notification settings</a>
+        </p>
+    </div>
+</body>
+</html>`
+
+// scopedUnsubscribeConfirmationTemplate is the GET success page for the
+// scoped unsubscribe handlers. The single %s is the category noun (e.g.
+// "tier-change emails"). Literal CSS percent signs are escaped (%%) because
+// this is rendered via fmt.Fprintf.
+const scopedUnsubscribeConfirmationTemplate = `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Unsubscribed | Psychic Homily</title>
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; margin: 0; padding: 32px 16px; background: #fafafa; color: #1a1a1a;">
+    <div style="max-width: 480px; margin: 48px auto; background: #ffffff; border: 1px solid #e5e5e5; border-radius: 12px; padding: 32px; text-align: center;">
+        <div style="width: 56px; height: 56px; margin: 0 auto 16px; border-radius: 50%%; background: #d1fae5; display: flex; align-items: center; justify-content: center; font-size: 28px;">&#10003;</div>
+        <h1 style="margin: 0 0 12px; font-size: 22px; font-weight: 600;">You&rsquo;re unsubscribed</h1>
+        <p style="margin: 0 0 24px; color: #555; line-height: 1.5;">
+            You&rsquo;ve been unsubscribed from %s.
             You can re-enable this anytime in your notification settings.
         </p>
         <p style="margin: 0;">

--- a/backend/internal/api/handlers/auth/unsubscribe_scoped.go
+++ b/backend/internal/api/handlers/auth/unsubscribe_scoped.go
@@ -1,0 +1,93 @@
+package auth
+
+import (
+	"net/http"
+	"strconv"
+
+	"psychic-homily-backend/internal/logger"
+	"psychic-homily-backend/internal/services/engagement"
+)
+
+// Chi-level (NOT Huma) unsubscribe handlers for the tier-change and
+// edit-review notification categories. Same dual-method shape as the
+// collection-digest handler (UnsubscribeCollectionDigestPageHandler):
+//
+//   - GET renders an HTML confirmation page for a recipient who clicks the
+//     visible in-body link.
+//   - POST accepts the RFC 8058 / RFC 2369 one-click body Gmail/Yahoo send
+//     when a recipient clicks the native "Unsubscribe" button.
+//
+// Both read uid+sig from the query string and verify the per-scope HMAC; no
+// login required. The scope binds the signature so a link minted for one
+// category can't be replayed against another.
+
+// scopedUnsubscribeConfig pairs an unsubscribe scope with the preference
+// mutation it performs and the human-readable noun for the confirmation page.
+type scopedUnsubscribeConfig struct {
+	scope     string
+	setPref   func(userID uint) error
+	noun      string // e.g. "tier-change emails"
+	logSuffix string // structured-log event discriminator
+}
+
+// UnsubscribeTierNotificationsPageHandler serves /unsubscribe/tier-notifications.
+func (h *UserPreferencesHandler) UnsubscribeTierNotificationsPageHandler(w http.ResponseWriter, r *http.Request) {
+	h.handleScopedUnsubscribe(w, r, scopedUnsubscribeConfig{
+		scope:     engagement.UnsubscribeScopeTierNotifications,
+		setPref:   func(uid uint) error { return h.userService.SetNotifyOnTierNotifications(uid, false) },
+		noun:      "tier-change emails",
+		logSuffix: "tier_notifications",
+	})
+}
+
+// UnsubscribeEditNotificationsPageHandler serves /unsubscribe/edit-notifications.
+func (h *UserPreferencesHandler) UnsubscribeEditNotificationsPageHandler(w http.ResponseWriter, r *http.Request) {
+	h.handleScopedUnsubscribe(w, r, scopedUnsubscribeConfig{
+		scope:     engagement.UnsubscribeScopeEditNotifications,
+		setPref:   func(uid uint) error { return h.userService.SetNotifyOnEditNotifications(uid, false) },
+		noun:      "edit-review emails",
+		logSuffix: "edit_notifications",
+	})
+}
+
+// handleScopedUnsubscribe is the shared GET/POST body for the scoped
+// unsubscribe handlers. Mirrors UnsubscribeCollectionDigestPageHandler but
+// parameterized by scope + preference setter.
+func (h *UserPreferencesHandler) handleScopedUnsubscribe(w http.ResponseWriter, r *http.Request, cfg scopedUnsubscribeConfig) {
+	uidStr := r.URL.Query().Get("uid")
+	sig := r.URL.Query().Get("sig")
+
+	uid64, err := strconv.ParseUint(uidStr, 10, 64)
+	if err != nil || uid64 == 0 || sig == "" {
+		writeUnsubscribeError(w, r, http.StatusBadRequest, "Missing or invalid unsubscribe parameters.")
+		return
+	}
+	uid := uint(uid64)
+
+	if !engagement.VerifyScopedUnsubscribeSignature(uid, cfg.scope, sig, h.jwtSecret) {
+		writeUnsubscribeError(w, r, http.StatusForbidden, "This unsubscribe link is invalid or has been tampered with.")
+		return
+	}
+
+	if err := cfg.setPref(uid); err != nil {
+		logger.FromContext(r.Context()).Error("unsubscribe_"+cfg.logSuffix+"_failed",
+			"error", err.Error(),
+			"user_id", uid,
+			"method", r.Method,
+		)
+		writeUnsubscribeError(w, r, http.StatusInternalServerError, "We couldn't process your unsubscribe right now. Please try again, or open your notification settings to disable these emails directly.")
+		return
+	}
+
+	logger.FromContext(r.Context()).Info("unsubscribe_"+cfg.logSuffix+"_success",
+		"user_id", uid,
+		"method", r.Method,
+	)
+
+	if isOneClickPost(r) {
+		writeOneClickUnsubscribed(w)
+		return
+	}
+
+	writeScopedUnsubscribeConfirmation(w, cfg.noun)
+}

--- a/backend/internal/api/handlers/auth/unsubscribe_scoped_test.go
+++ b/backend/internal/api/handlers/auth/unsubscribe_scoped_test.go
@@ -1,0 +1,172 @@
+package auth
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"psychic-homily-backend/internal/api/handlers/shared/testhelpers"
+	"psychic-homily-backend/internal/services/engagement"
+)
+
+// PSY-756: tests for the scoped unsubscribe handlers backing
+// /unsubscribe/tier-notifications and /unsubscribe/edit-notifications. Same
+// dual GET/POST shape as the collection-digest handler.
+
+func TestUnsubscribeTierNotifications_GET_Success(t *testing.T) {
+	secret := "test-secret"
+	uid := uint(99)
+	sig := engagement.ComputeScopedUnsubscribeSignature(uid, engagement.UnsubscribeScopeTierNotifications, secret)
+
+	var gotUID uint
+	var gotEnabled = true
+	mock := &testhelpers.MockUserService{
+		SetNotifyOnTierNotificationsFn: func(userID uint, enabled bool) error {
+			gotUID = userID
+			gotEnabled = enabled
+			return nil
+		},
+	}
+	h := NewUserPreferencesHandler(mock, secret)
+
+	req := httptest.NewRequest(http.MethodGet, "/unsubscribe/tier-notifications?uid=99&sig="+sig, nil)
+	w := httptest.NewRecorder()
+	h.UnsubscribeTierNotificationsPageHandler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		t.Fatalf("expected text/html on GET, got %q", ct)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "unsubscribed") {
+		t.Errorf("confirmation page must mention being unsubscribed, body was: %s", body)
+	}
+	if !strings.Contains(body, "tier-change emails") {
+		t.Errorf("confirmation page must name the category, body was: %s", body)
+	}
+	if gotUID != uid || gotEnabled {
+		t.Errorf("expected SetNotifyOnTierNotifications(uid=%d, false), got (uid=%d, enabled=%v)", uid, gotUID, gotEnabled)
+	}
+}
+
+func TestUnsubscribeEditNotifications_POST_OneClick_Success(t *testing.T) {
+	secret := "test-secret"
+	uid := uint(7)
+	sig := engagement.ComputeScopedUnsubscribeSignature(uid, engagement.UnsubscribeScopeEditNotifications, secret)
+
+	var called bool
+	mock := &testhelpers.MockUserService{
+		SetNotifyOnEditNotificationsFn: func(_ uint, enabled bool) error {
+			called = true
+			if enabled {
+				t.Errorf("POST one-click must always disable; got enabled=true")
+			}
+			return nil
+		},
+	}
+	h := NewUserPreferencesHandler(mock, secret)
+
+	req := httptest.NewRequest(http.MethodPost,
+		"/unsubscribe/edit-notifications?uid=7&sig="+sig, strings.NewReader("List-Unsubscribe=One-Click"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	h.UnsubscribeEditNotificationsPageHandler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body=%s)", w.Code, w.Body.String())
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("POST response should be JSON, got %q", ct)
+	}
+	if !strings.Contains(w.Body.String(), `"unsubscribed":true`) {
+		t.Errorf("POST response should contain unsubscribed:true, body was %q", w.Body.String())
+	}
+	if !called {
+		t.Error("expected SetNotifyOnEditNotifications to be called")
+	}
+}
+
+func TestUnsubscribeScoped_InvalidSignature(t *testing.T) {
+	h := NewUserPreferencesHandler(&testhelpers.MockUserService{}, "secret")
+
+	// Tier handler, GET, bad sig -> 403 HTML.
+	req := httptest.NewRequest(http.MethodGet, "/unsubscribe/tier-notifications?uid=42&sig=bogus", nil)
+	w := httptest.NewRecorder()
+	h.UnsubscribeTierNotificationsPageHandler(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", w.Code)
+	}
+
+	// Edit handler, POST, bad sig -> 403 JSON.
+	req = httptest.NewRequest(http.MethodPost, "/unsubscribe/edit-notifications?uid=42&sig=bogus",
+		strings.NewReader("List-Unsubscribe=One-Click"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w = httptest.NewRecorder()
+	h.UnsubscribeEditNotificationsPageHandler(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("POST error should be JSON, got %q", ct)
+	}
+}
+
+func TestUnsubscribeScoped_CrossScopeSignatureRejected(t *testing.T) {
+	// A signature minted for the tier scope must not unsubscribe edit emails.
+	secret := "test-secret"
+	uid := uint(11)
+	tierSig := engagement.ComputeScopedUnsubscribeSignature(uid, engagement.UnsubscribeScopeTierNotifications, secret)
+
+	mock := &testhelpers.MockUserService{
+		SetNotifyOnEditNotificationsFn: func(uint, bool) error {
+			t.Error("edit preference must not be flipped by a tier-scoped signature")
+			return nil
+		},
+	}
+	h := NewUserPreferencesHandler(mock, secret)
+
+	req := httptest.NewRequest(http.MethodGet, "/unsubscribe/edit-notifications?uid=11&sig="+tierSig, nil)
+	w := httptest.NewRecorder()
+	h.UnsubscribeEditNotificationsPageHandler(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for cross-scope signature, got %d", w.Code)
+	}
+}
+
+func TestUnsubscribeScoped_MissingParams(t *testing.T) {
+	h := NewUserPreferencesHandler(&testhelpers.MockUserService{}, "secret")
+
+	req := httptest.NewRequest(http.MethodGet, "/unsubscribe/tier-notifications", nil)
+	w := httptest.NewRecorder()
+	h.UnsubscribeTierNotificationsPageHandler(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		t.Fatalf("GET error should render HTML, got Content-Type %q", ct)
+	}
+}
+
+func TestUnsubscribeScoped_ServiceError(t *testing.T) {
+	secret := "test-secret"
+	uid := uint(50)
+	sig := engagement.ComputeScopedUnsubscribeSignature(uid, engagement.UnsubscribeScopeTierNotifications, secret)
+
+	mock := &testhelpers.MockUserService{
+		SetNotifyOnTierNotificationsFn: func(uint, bool) error {
+			return errors.New("db unavailable")
+		},
+	}
+	h := NewUserPreferencesHandler(mock, secret)
+
+	req := httptest.NewRequest(http.MethodGet, "/unsubscribe/tier-notifications?uid=50&sig="+sig, nil)
+	w := httptest.NewRecorder()
+	h.UnsubscribeTierNotificationsPageHandler(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+}

--- a/backend/internal/api/handlers/auth/user_preferences.go
+++ b/backend/internal/api/handlers/auth/user_preferences.go
@@ -491,3 +491,84 @@ func (h *UserPreferencesHandler) SetCollectionDigestHandler(ctx context.Context,
 //     unsubscribe button): returns 200 with a small JSON body.
 // See UnsubscribeCollectionDigestPageHandler in this package and the
 // route registration in routes.go.
+
+// ──────────────────────────────────────────────
+// Tier-change + edit-review notification preferences (opt-OUT)
+// ──────────────────────────────────────────────
+
+// SetTierEditNotificationsRequest toggles the two notification preferences.
+// Both fields are pointers so a caller can update one without touching the
+// other (same shape as SetCommentNotificationsRequest).
+type SetTierEditNotificationsRequest struct {
+	Body struct {
+		NotifyOnTierNotifications *bool `json:"notify_on_tier_notifications,omitempty" required:"false" doc:"Receive emails when your contributor tier changes"`
+		NotifyOnEditNotifications *bool `json:"notify_on_edit_notifications,omitempty" required:"false" doc:"Receive emails when your submitted edits are approved or rejected"`
+	}
+}
+
+// SetTierEditNotificationsResponse reports the resulting preference state.
+type SetTierEditNotificationsResponse struct {
+	Body struct {
+		Success                   bool `json:"success"`
+		NotifyOnTierNotifications bool `json:"notify_on_tier_notifications"`
+		NotifyOnEditNotifications bool `json:"notify_on_edit_notifications"`
+	}
+}
+
+// SetTierEditNotificationsHandler handles PATCH /auth/preferences/tier-edit-notifications.
+// Sends one update per non-nil field, then reloads the current state.
+func (h *UserPreferencesHandler) SetTierEditNotificationsHandler(ctx context.Context, req *SetTierEditNotificationsRequest) (*SetTierEditNotificationsResponse, error) {
+	user := middleware.GetUserFromContext(ctx)
+	if user == nil {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	if req.Body.NotifyOnTierNotifications == nil && req.Body.NotifyOnEditNotifications == nil {
+		return nil, huma.Error422UnprocessableEntity("No preferences provided")
+	}
+
+	if req.Body.NotifyOnTierNotifications != nil {
+		if err := h.userService.SetNotifyOnTierNotifications(user.ID, *req.Body.NotifyOnTierNotifications); err != nil {
+			logger.FromContext(ctx).Error("set_notify_on_tier_notifications_failed",
+				"error", err.Error(),
+				"user_id", user.ID,
+			)
+			return nil, huma.Error500InternalServerError(
+				fmt.Sprintf("Failed to update preference: %s", err.Error()),
+			)
+		}
+	}
+	if req.Body.NotifyOnEditNotifications != nil {
+		if err := h.userService.SetNotifyOnEditNotifications(user.ID, *req.Body.NotifyOnEditNotifications); err != nil {
+			logger.FromContext(ctx).Error("set_notify_on_edit_notifications_failed",
+				"error", err.Error(),
+				"user_id", user.ID,
+			)
+			return nil, huma.Error500InternalServerError(
+				fmt.Sprintf("Failed to update preference: %s", err.Error()),
+			)
+		}
+	}
+
+	// Reload current state from DB (authoritative).
+	refreshed, err := h.userService.GetUserByID(user.ID)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Failed to reload user")
+	}
+	resp := &SetTierEditNotificationsResponse{}
+	resp.Body.Success = true
+	if refreshed.Preferences != nil {
+		resp.Body.NotifyOnTierNotifications = refreshed.Preferences.NotifyOnTierNotifications
+		resp.Body.NotifyOnEditNotifications = refreshed.Preferences.NotifyOnEditNotifications
+	} else {
+		// No prefs row — return the defaults we requested (both default TRUE).
+		resp.Body.NotifyOnTierNotifications = shared.DerefOr(req.Body.NotifyOnTierNotifications, true)
+		resp.Body.NotifyOnEditNotifications = shared.DerefOr(req.Body.NotifyOnEditNotifications, true)
+	}
+	return resp, nil
+}
+
+// The tier-notifications + edit-notifications unsubscribe handlers are
+// registered as chi routes (not Huma), same dual GET/POST shape as the
+// collection-digest handler. See UnsubscribeTierNotificationsPageHandler and
+// UnsubscribeEditNotificationsPageHandler in this package.

--- a/backend/internal/api/handlers/auth/user_preferences_test.go
+++ b/backend/internal/api/handlers/auth/user_preferences_test.go
@@ -508,3 +508,79 @@ func TestSetCollectionDigestHandler_ServiceError(t *testing.T) {
 	_, err := h.SetCollectionDigestHandler(ctx, req)
 	testhelpers.AssertHumaError(t, err, 500)
 }
+
+// ──────────────────────────────────────────────
+// PSY-756: tier-edit-notifications preference handler
+// ──────────────────────────────────────────────
+
+func TestSetTierEditNotificationsHandler_NoAuth(t *testing.T) {
+	h := NewUserPreferencesHandler(&testhelpers.MockUserService{}, "secret")
+	req := &SetTierEditNotificationsRequest{}
+	enabled := false
+	req.Body.NotifyOnTierNotifications = &enabled
+	_, err := h.SetTierEditNotificationsHandler(context.Background(), req)
+	testhelpers.AssertHumaError(t, err, 401)
+}
+
+func TestSetTierEditNotificationsHandler_NoFieldsRejected(t *testing.T) {
+	h := NewUserPreferencesHandler(&testhelpers.MockUserService{}, "secret")
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1})
+	req := &SetTierEditNotificationsRequest{}
+	_, err := h.SetTierEditNotificationsHandler(ctx, req)
+	testhelpers.AssertHumaError(t, err, 422)
+}
+
+func TestSetTierEditNotificationsHandler_Success(t *testing.T) {
+	var tierEnabled, editEnabled *bool
+	mock := &testhelpers.MockUserService{
+		SetNotifyOnTierNotificationsFn: func(_ uint, enabled bool) error {
+			e := enabled
+			tierEnabled = &e
+			return nil
+		},
+		SetNotifyOnEditNotificationsFn: func(_ uint, enabled bool) error {
+			e := enabled
+			editEnabled = &e
+			return nil
+		},
+		GetUserByIDFn: func(uid uint) (*authm.User, error) {
+			return &authm.User{
+				ID: uid,
+				Preferences: &authm.UserPreferences{
+					UserID:                    uid,
+					NotifyOnTierNotifications: false,
+					NotifyOnEditNotifications: true,
+				},
+			}, nil
+		},
+	}
+	h := NewUserPreferencesHandler(mock, "secret")
+	ctx := testhelpers.CtxWithUser(&authm.User{ID: 1})
+
+	no := false
+	yes := true
+	req := &SetTierEditNotificationsRequest{}
+	req.Body.NotifyOnTierNotifications = &no
+	req.Body.NotifyOnEditNotifications = &yes
+
+	resp, err := h.SetTierEditNotificationsHandler(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.Body.Success {
+		t.Fatal("expected success=true")
+	}
+	if tierEnabled == nil || *tierEnabled {
+		t.Fatalf("expected SetNotifyOnTierNotifications(false); got %v", tierEnabled)
+	}
+	if editEnabled == nil || !*editEnabled {
+		t.Fatalf("expected SetNotifyOnEditNotifications(true); got %v", editEnabled)
+	}
+	// Response mirrors DB state via GetUserByID.
+	if resp.Body.NotifyOnTierNotifications {
+		t.Fatal("expected response to reflect DB state (false)")
+	}
+	if !resp.Body.NotifyOnEditNotifications {
+		t.Fatal("expected response to reflect DB state (true)")
+	}
+}

--- a/backend/internal/api/handlers/shared/testhelpers/mocks_gen.go
+++ b/backend/internal/api/handlers/shared/testhelpers/mocks_gen.go
@@ -1349,11 +1349,11 @@ type MockEmailService struct {
 	SendAccountRecoveryEmailFn     func(string, string, int) error
 	SendShowReminderEmailFn        func(string, string, string, string, time.Time, []string) error
 	SendFilterNotificationEmailFn  func(string, string, string, string) error
-	SendTierPromotionEmailFn       func(string, string, string, string, string, []string) error
-	SendTierDemotionEmailFn        func(string, string, string, string, string) error
-	SendTierDemotionWarningEmailFn func(string, string, string, float64, float64) error
-	SendEditApprovedEmailFn        func(string, string, string, string, string) error
-	SendEditRejectedEmailFn        func(string, string, string, string, string) error
+	SendTierPromotionEmailFn       func(string, string, string, string, string, string, []string) error
+	SendTierDemotionEmailFn        func(string, string, string, string, string, string) error
+	SendTierDemotionWarningEmailFn func(string, string, string, float64, float64, string) error
+	SendEditApprovedEmailFn        func(string, string, string, string, string, string) error
+	SendEditRejectedEmailFn        func(string, string, string, string, string, string) error
 	SendCommentNotificationFn      func(string, string, string, string, string, string, string) error
 	SendMentionNotificationFn      func(string, string, string, string, string, string, string) error
 	SendCollectionDigestEmailFn    func(string, []contracts.CollectionDigestGroup, string) error
@@ -1395,33 +1395,33 @@ func (m *MockEmailService) SendFilterNotificationEmail(toEmail string, subject s
 	}
 	return nil
 }
-func (m *MockEmailService) SendTierPromotionEmail(toEmail string, username string, oldTier string, newTier string, reason string, newPermissions []string) error {
+func (m *MockEmailService) SendTierPromotionEmail(toEmail string, username string, oldTier string, newTier string, reason string, unsubscribeURL string, newPermissions []string) error {
 	if m.SendTierPromotionEmailFn != nil {
-		return m.SendTierPromotionEmailFn(toEmail, username, oldTier, newTier, reason, newPermissions)
+		return m.SendTierPromotionEmailFn(toEmail, username, oldTier, newTier, reason, unsubscribeURL, newPermissions)
 	}
 	return nil
 }
-func (m *MockEmailService) SendTierDemotionEmail(toEmail string, username string, oldTier string, newTier string, reason string) error {
+func (m *MockEmailService) SendTierDemotionEmail(toEmail string, username string, oldTier string, newTier string, reason string, unsubscribeURL string) error {
 	if m.SendTierDemotionEmailFn != nil {
-		return m.SendTierDemotionEmailFn(toEmail, username, oldTier, newTier, reason)
+		return m.SendTierDemotionEmailFn(toEmail, username, oldTier, newTier, reason, unsubscribeURL)
 	}
 	return nil
 }
-func (m *MockEmailService) SendTierDemotionWarningEmail(toEmail string, username string, currentTier string, currentRate float64, threshold float64) error {
+func (m *MockEmailService) SendTierDemotionWarningEmail(toEmail string, username string, currentTier string, currentRate float64, threshold float64, unsubscribeURL string) error {
 	if m.SendTierDemotionWarningEmailFn != nil {
-		return m.SendTierDemotionWarningEmailFn(toEmail, username, currentTier, currentRate, threshold)
+		return m.SendTierDemotionWarningEmailFn(toEmail, username, currentTier, currentRate, threshold, unsubscribeURL)
 	}
 	return nil
 }
-func (m *MockEmailService) SendEditApprovedEmail(toEmail string, username string, entityType string, entityName string, entityURL string) error {
+func (m *MockEmailService) SendEditApprovedEmail(toEmail string, username string, entityType string, entityName string, entityURL string, unsubscribeURL string) error {
 	if m.SendEditApprovedEmailFn != nil {
-		return m.SendEditApprovedEmailFn(toEmail, username, entityType, entityName, entityURL)
+		return m.SendEditApprovedEmailFn(toEmail, username, entityType, entityName, entityURL, unsubscribeURL)
 	}
 	return nil
 }
-func (m *MockEmailService) SendEditRejectedEmail(toEmail string, username string, entityType string, entityName string, rejectionReason string) error {
+func (m *MockEmailService) SendEditRejectedEmail(toEmail string, username string, entityType string, entityName string, rejectionReason string, unsubscribeURL string) error {
 	if m.SendEditRejectedEmailFn != nil {
-		return m.SendEditRejectedEmailFn(toEmail, username, entityType, entityName, rejectionReason)
+		return m.SendEditRejectedEmailFn(toEmail, username, entityType, entityName, rejectionReason, unsubscribeURL)
 	}
 	return nil
 }
@@ -3413,6 +3413,8 @@ type MockUserService struct {
 	SetNotifyOnCommentSubscriptionFn  func(uint, bool) error
 	SetNotifyOnMentionFn              func(uint, bool) error
 	SetNotifyOnCollectionDigestFn     func(uint, bool) error
+	SetNotifyOnTierNotificationsFn    func(uint, bool) error
+	SetNotifyOnEditNotificationsFn    func(uint, bool) error
 }
 
 func (m *MockUserService) ListUsers(limit int, offset int, filters contracts.AdminUserFilters) ([]*contracts.AdminUserResponse, int64, error) {
@@ -3646,6 +3648,18 @@ func (m *MockUserService) SetNotifyOnMention(userID uint, enabled bool) error {
 func (m *MockUserService) SetNotifyOnCollectionDigest(userID uint, enabled bool) error {
 	if m.SetNotifyOnCollectionDigestFn != nil {
 		return m.SetNotifyOnCollectionDigestFn(userID, enabled)
+	}
+	return nil
+}
+func (m *MockUserService) SetNotifyOnTierNotifications(userID uint, enabled bool) error {
+	if m.SetNotifyOnTierNotificationsFn != nil {
+		return m.SetNotifyOnTierNotificationsFn(userID, enabled)
+	}
+	return nil
+}
+func (m *MockUserService) SetNotifyOnEditNotifications(userID uint, enabled bool) error {
+	if m.SetNotifyOnEditNotificationsFn != nil {
+		return m.SetNotifyOnEditNotificationsFn(userID, enabled)
 	}
 	return nil
 }

--- a/backend/internal/api/routes/auth.go
+++ b/backend/internal/api/routes/auth.go
@@ -121,6 +121,8 @@ func setupProtectedAuthRoutes(rc RouteContext) {
 	huma.Patch(rc.Protected, "/auth/preferences/comment-notifications", userPrefsHandler.SetCommentNotificationsHandler)
 	// PSY-350: collection digest preference toggle (weekly cadence; opt-IN).
 	huma.Patch(rc.Protected, "/auth/preferences/collection-digest", userPrefsHandler.SetCollectionDigestHandler)
+	// Tier-change + edit-review notification toggles (opt-OUT).
+	huma.Patch(rc.Protected, "/auth/preferences/tier-edit-notifications", userPrefsHandler.SetTierEditNotificationsHandler)
 
 	// Public unsubscribe endpoint (HMAC-signed, no auth required)
 	huma.Post(rc.API, "/auth/unsubscribe/show-reminders", userPrefsHandler.UnsubscribeShowRemindersHandler)
@@ -135,6 +137,11 @@ func setupProtectedAuthRoutes(rc RouteContext) {
 	// the email body. Both verify the same HMAC signature.
 	rc.Router.Get("/unsubscribe/collection-digest", userPrefsHandler.UnsubscribeCollectionDigestPageHandler)
 	rc.Router.Post("/unsubscribe/collection-digest", userPrefsHandler.UnsubscribeCollectionDigestPageHandler)
+	// Tier-change + edit-review unsubscribe (same chi GET+POST shape).
+	rc.Router.Get("/unsubscribe/tier-notifications", userPrefsHandler.UnsubscribeTierNotificationsPageHandler)
+	rc.Router.Post("/unsubscribe/tier-notifications", userPrefsHandler.UnsubscribeTierNotificationsPageHandler)
+	rc.Router.Get("/unsubscribe/edit-notifications", userPrefsHandler.UnsubscribeEditNotificationsPageHandler)
+	rc.Router.Post("/unsubscribe/edit-notifications", userPrefsHandler.UnsubscribeEditNotificationsPageHandler)
 
 	// Public email verification confirm endpoint (user clicks link from email)
 	huma.Post(rc.API, "/auth/verify-email/confirm", authHandler.ConfirmVerificationHandler)

--- a/backend/internal/models/auth/user.go
+++ b/backend/internal/models/auth/user.go
@@ -105,6 +105,13 @@ type UserPreferences struct {
 	// PSY-289 opt-OUT defaults. See migration
 	// 20260428003421_collection_digest_columns.up.sql for rationale.
 	NotifyOnCollectionDigest bool `json:"notify_on_collection_digest" gorm:"column:notify_on_collection_digest;not null;default:false"`
+
+	// Per-category opt-out for tier-change and edit-review emails. Each is a
+	// single email per discrete action, so both default TRUE (opt-OUT) like
+	// the comment/mention flags. Flipped off by the one-click unsubscribe link
+	// in those emails and gated on by the senders' callers.
+	NotifyOnTierNotifications bool `json:"notify_on_tier_notifications" gorm:"column:notify_on_tier_notifications;not null;default:true"`
+	NotifyOnEditNotifications bool `json:"notify_on_edit_notifications" gorm:"column:notify_on_edit_notifications;not null;default:true"`
 }
 
 // TableName specifies the table name for UserPreferences

--- a/backend/internal/services/admin/auto_promotion.go
+++ b/backend/internal/services/admin/auto_promotion.go
@@ -16,6 +16,7 @@ import (
 	adminm "psychic-homily-backend/internal/models/admin"
 	authm "psychic-homily-backend/internal/models/auth"
 	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/services/engagement"
 	"psychic-homily-backend/internal/services/notification"
 	"psychic-homily-backend/internal/services/shared"
 )
@@ -69,10 +70,14 @@ type AutoPromotionService struct {
 	stopCh       chan struct{}
 	wg           sync.WaitGroup
 	logger       *slog.Logger
+	// backendURL + jwtSecret mint the HMAC-signed tier-notifications
+	// unsubscribe URL placed in the tier-change emails.
+	backendURL string
+	jwtSecret  string
 }
 
 // NewAutoPromotionService creates a new auto-promotion service.
-func NewAutoPromotionService(database *gorm.DB, emailService contracts.EmailServiceInterface) *AutoPromotionService {
+func NewAutoPromotionService(database *gorm.DB, emailService contracts.EmailServiceInterface, backendURL, jwtSecret string) *AutoPromotionService {
 	if database == nil {
 		database = db.GetDB()
 	}
@@ -90,6 +95,8 @@ func NewAutoPromotionService(database *gorm.DB, emailService contracts.EmailServ
 		interval:     interval,
 		stopCh:       make(chan struct{}),
 		logger:       slog.Default(),
+		backendURL:   backendURL,
+		jwtSecret:    jwtSecret,
 	}
 }
 
@@ -245,25 +252,42 @@ func (s *AutoPromotionService) sendTierChangeEmail(user *authm.User, change cont
 		return
 	}
 
+	if !s.tierNotificationsEnabled(user.ID) {
+		return
+	}
+
 	email := *user.Email
 	username := change.Username
+	unsubURL := engagement.GenerateScopedUnsubscribeURL(s.backendURL, user.ID, engagement.UnsubscribeScopeTierNotifications, s.jwtSecret)
 
 	if isPromotion {
 		newPermissions := notification.TierPermissions(change.NewTier)
-		if err := s.emailService.SendTierPromotionEmail(email, username, change.OldTier, change.NewTier, change.Reason, newPermissions); err != nil {
+		if err := s.emailService.SendTierPromotionEmail(email, username, change.OldTier, change.NewTier, change.Reason, unsubURL, newPermissions); err != nil {
 			s.logger.Error("failed to send tier promotion email",
 				"user_id", user.ID,
 				"error", err,
 			)
 		}
 	} else {
-		if err := s.emailService.SendTierDemotionEmail(email, username, change.OldTier, change.NewTier, change.Reason); err != nil {
+		if err := s.emailService.SendTierDemotionEmail(email, username, change.OldTier, change.NewTier, change.Reason, unsubURL); err != nil {
 			s.logger.Error("failed to send tier demotion email",
 				"user_id", user.ID,
 				"error", err,
 			)
 		}
 	}
+}
+
+// tierNotificationsEnabled reports whether the user wants tier-change emails.
+// Defaults to TRUE (opt-OUT): a missing preferences row or a read error means
+// the user hasn't opted out, so we send. Only an explicit FALSE suppresses.
+func (s *AutoPromotionService) tierNotificationsEnabled(userID uint) bool {
+	var prefs authm.UserPreferences
+	if err := s.db.Select("notify_on_tier_notifications").
+		Where("user_id = ?", userID).First(&prefs).Error; err != nil {
+		return true
+	}
+	return prefs.NotifyOnTierNotifications
 }
 
 // writeTierChangeAuditLog records a tier change in the audit log.

--- a/backend/internal/services/admin/auto_promotion_email_test.go
+++ b/backend/internal/services/admin/auto_promotion_email_test.go
@@ -32,15 +32,17 @@ type promotionCall struct {
 	oldTier        string
 	newTier        string
 	reason         string
+	unsubscribeURL string
 	newPermissions []string
 }
 
 type demotionCall struct {
-	toEmail  string
-	username string
-	oldTier  string
-	newTier  string
-	reason   string
+	toEmail        string
+	username       string
+	oldTier        string
+	newTier        string
+	reason         string
+	unsubscribeURL string
 }
 
 type demotionWarningCall struct {
@@ -60,23 +62,23 @@ func (m *mockEmailService) SendShowReminderEmail(_, _, _, _ string, _ time.Time,
 }
 func (m *mockEmailService) SendFilterNotificationEmail(_, _, _, _ string) error { return nil }
 
-func (m *mockEmailService) SendTierPromotionEmail(toEmail, username, oldTier, newTier, reason string, newPermissions []string) error {
-	m.promotionCalls = append(m.promotionCalls, promotionCall{toEmail, username, oldTier, newTier, reason, newPermissions})
+func (m *mockEmailService) SendTierPromotionEmail(toEmail, username, oldTier, newTier, reason, unsubscribeURL string, newPermissions []string) error {
+	m.promotionCalls = append(m.promotionCalls, promotionCall{toEmail, username, oldTier, newTier, reason, unsubscribeURL, newPermissions})
 	return m.promotionError
 }
 
-func (m *mockEmailService) SendTierDemotionEmail(toEmail, username, oldTier, newTier, reason string) error {
-	m.demotionCalls = append(m.demotionCalls, demotionCall{toEmail, username, oldTier, newTier, reason})
+func (m *mockEmailService) SendTierDemotionEmail(toEmail, username, oldTier, newTier, reason, unsubscribeURL string) error {
+	m.demotionCalls = append(m.demotionCalls, demotionCall{toEmail, username, oldTier, newTier, reason, unsubscribeURL})
 	return m.demotionError
 }
 
-func (m *mockEmailService) SendTierDemotionWarningEmail(toEmail, username, currentTier string, currentRate float64, threshold float64) error {
+func (m *mockEmailService) SendTierDemotionWarningEmail(toEmail, username, currentTier string, currentRate float64, threshold float64, _ string) error {
 	m.demotionWarningCalls = append(m.demotionWarningCalls, demotionWarningCall{toEmail, username, currentTier, currentRate, threshold})
 	return m.demotionWarningError
 }
 
-func (m *mockEmailService) SendEditApprovedEmail(_, _, _, _, _ string) error { return nil }
-func (m *mockEmailService) SendEditRejectedEmail(_, _, _, _, _ string) error { return nil }
+func (m *mockEmailService) SendEditApprovedEmail(_, _, _, _, _, _ string) error { return nil }
+func (m *mockEmailService) SendEditRejectedEmail(_, _, _, _, _, _ string) error { return nil }
 func (m *mockEmailService) SendCommentNotification(_, _, _, _, _, _, _ string) error {
 	return nil
 }
@@ -114,6 +116,7 @@ func (s *AutoPromotionEmailTestSuite) TearDownTest() {
 	_, _ = sqlDB.Exec("DELETE FROM revisions")
 	_, _ = sqlDB.Exec("DELETE FROM artists")
 	_, _ = sqlDB.Exec("DELETE FROM venues")
+	_, _ = sqlDB.Exec("DELETE FROM user_preferences")
 	_, _ = sqlDB.Exec("DELETE FROM users")
 }
 
@@ -187,7 +190,7 @@ func (s *AutoPromotionEmailTestSuite) createTestArtist(name string) *catalogm.Ar
 // TestPromotionSendsEmail verifies that a promotion triggers a promotion email.
 func (s *AutoPromotionEmailTestSuite) TestPromotionSendsEmail() {
 	emailSvc := &mockEmailService{configured: true}
-	svc := NewAutoPromotionService(s.db, emailSvc)
+	svc := NewAutoPromotionService(s.db, emailSvc, "http://localhost:8080", "test-jwt-secret")
 
 	user := s.createUserWithEmail(TierNewUser, true, time.Now().Add(-15*24*time.Hour), "promo@test.com")
 	artist := s.createTestArtist("Promo Artist")
@@ -207,12 +210,52 @@ func (s *AutoPromotionEmailTestSuite) TestPromotionSendsEmail() {
 	s.Equal(TierNewUser, call.oldTier)
 	s.Equal(TierContributor, call.newTier)
 	s.NotEmpty(call.newPermissions)
+	// PSY-756: a tier-notifications unsubscribe URL is minted and passed.
+	s.Contains(call.unsubscribeURL, "/unsubscribe/tier-notifications", "expected an HMAC-signed tier-notifications unsubscribe URL")
+	s.Contains(call.unsubscribeURL, "uid=")
+	s.Contains(call.unsubscribeURL, "sig=")
+}
+
+// TestPromotionSuppressedWhenOptedOut verifies the tier-notifications opt-out
+// flag suppresses the email but not the tier change itself (PSY-756).
+func (s *AutoPromotionEmailTestSuite) TestPromotionSuppressedWhenOptedOut() {
+	emailSvc := &mockEmailService{configured: true}
+	svc := NewAutoPromotionService(s.db, emailSvc, "http://localhost:8080", "test-jwt-secret")
+
+	user := s.createUserWithEmail(TierNewUser, true, time.Now().Add(-15*24*time.Hour), "optout@test.com")
+	// Opt the user out of tier-change emails.
+	s.Require().NoError(s.db.Create(&authm.UserPreferences{
+		UserID:                    user.ID,
+		NotifyOnTierNotifications: false,
+	}).Error)
+	// Re-assert false: GORM skips the zero-value bool on Create, and the
+	// column default is TRUE, so set it explicitly.
+	s.Require().NoError(s.db.Model(&authm.UserPreferences{}).
+		Where("user_id = ?", user.ID).
+		Update("notify_on_tier_notifications", false).Error)
+
+	artist := s.createTestArtist("Optout Artist")
+	for i := 0; i < 5; i++ {
+		s.createApprovedEdit(user.ID, "artist", artist.ID)
+	}
+
+	result, err := svc.EvaluateAllUsers()
+	s.Require().NoError(err)
+	s.Require().Len(result.Promoted, 1, "tier change must still happen even when emails are opted out")
+
+	// No email should have been sent.
+	s.Empty(emailSvc.promotionCalls, "promotion email must be suppressed when opted out")
+
+	// But the DB tier was still updated.
+	var updated authm.User
+	s.Require().NoError(s.db.First(&updated, user.ID).Error)
+	s.Equal(TierContributor, updated.UserTier)
 }
 
 // TestDemotionSendsEmail verifies that a demotion triggers a demotion email.
 func (s *AutoPromotionEmailTestSuite) TestDemotionSendsEmail() {
 	emailSvc := &mockEmailService{configured: true}
-	svc := NewAutoPromotionService(s.db, emailSvc)
+	svc := NewAutoPromotionService(s.db, emailSvc, "http://localhost:8080", "test-jwt-secret")
 
 	user := s.createUserWithEmail(TierContributor, true, time.Now().Add(-60*24*time.Hour), "demote@test.com")
 	artist := s.createTestArtist("Demote Artist")
@@ -241,7 +284,7 @@ func (s *AutoPromotionEmailTestSuite) TestEmailErrorDoesNotFailPromotion() {
 		configured:     true,
 		promotionError: fmt.Errorf("email send failed"),
 	}
-	svc := NewAutoPromotionService(s.db, emailSvc)
+	svc := NewAutoPromotionService(s.db, emailSvc, "http://localhost:8080", "test-jwt-secret")
 
 	user := s.createUserWithEmail(TierNewUser, true, time.Now().Add(-15*24*time.Hour), "fail@test.com")
 	artist := s.createTestArtist("Error Artist")
@@ -266,7 +309,7 @@ func (s *AutoPromotionEmailTestSuite) TestEmailErrorDoesNotFailPromotion() {
 
 // TestNilEmailServiceDoesNotPanic verifies that nil email service is handled gracefully.
 func (s *AutoPromotionEmailTestSuite) TestNilEmailServiceDoesNotPanic() {
-	svc := NewAutoPromotionService(s.db, nil)
+	svc := NewAutoPromotionService(s.db, nil, "http://localhost:8080", "test-jwt-secret")
 
 	user := s.createUserWithEmail(TierNewUser, true, time.Now().Add(-15*24*time.Hour), "nil@test.com")
 	artist := s.createTestArtist("Nil Artist")
@@ -284,7 +327,7 @@ func (s *AutoPromotionEmailTestSuite) TestNilEmailServiceDoesNotPanic() {
 // TestUnconfiguredEmailServiceSkipsEmail verifies that unconfigured email service is handled.
 func (s *AutoPromotionEmailTestSuite) TestUnconfiguredEmailServiceSkipsEmail() {
 	emailSvc := &mockEmailService{configured: false}
-	svc := NewAutoPromotionService(s.db, emailSvc)
+	svc := NewAutoPromotionService(s.db, emailSvc, "http://localhost:8080", "test-jwt-secret")
 
 	user := s.createUserWithEmail(TierNewUser, true, time.Now().Add(-15*24*time.Hour), "unconfig@test.com")
 	artist := s.createTestArtist("Unconfig Artist")
@@ -303,7 +346,7 @@ func (s *AutoPromotionEmailTestSuite) TestUnconfiguredEmailServiceSkipsEmail() {
 
 // TestAuditLogWrittenOnPromotion verifies that an audit log entry is created for promotions.
 func (s *AutoPromotionEmailTestSuite) TestAuditLogWrittenOnPromotion() {
-	svc := NewAutoPromotionService(s.db, nil)
+	svc := NewAutoPromotionService(s.db, nil, "http://localhost:8080", "test-jwt-secret")
 
 	user := s.createUserWithEmail(TierNewUser, true, time.Now().Add(-15*24*time.Hour), "audit@test.com")
 	artist := s.createTestArtist("Audit Artist")
@@ -330,7 +373,7 @@ func (s *AutoPromotionEmailTestSuite) TestAuditLogWrittenOnPromotion() {
 
 // TestAuditLogWrittenOnDemotion verifies that an audit log entry is created for demotions.
 func (s *AutoPromotionEmailTestSuite) TestAuditLogWrittenOnDemotion() {
-	svc := NewAutoPromotionService(s.db, nil)
+	svc := NewAutoPromotionService(s.db, nil, "http://localhost:8080", "test-jwt-secret")
 
 	user := s.createUserWithEmail(TierContributor, true, time.Now().Add(-60*24*time.Hour), "audit-demote@test.com")
 	artist := s.createTestArtist("Audit Demote Artist")

--- a/backend/internal/services/admin/auto_promotion_test.go
+++ b/backend/internal/services/admin/auto_promotion_test.go
@@ -22,7 +22,7 @@ import (
 // =============================================================================
 
 func TestNewAutoPromotionService(t *testing.T) {
-	svc := NewAutoPromotionService(nil, nil)
+	svc := NewAutoPromotionService(nil, nil, "http://localhost:8080", "test-jwt-secret")
 	assert.NotNil(t, svc)
 	assert.Equal(t, DefaultAutoPromotionInterval, svc.interval)
 	assert.NotNil(t, svc.stopCh)
@@ -31,19 +31,19 @@ func TestNewAutoPromotionService(t *testing.T) {
 
 func TestNewAutoPromotionService_EnvOverride(t *testing.T) {
 	t.Setenv("AUTO_PROMOTION_INTERVAL_HOURS", "12")
-	svc := NewAutoPromotionService(nil, nil)
+	svc := NewAutoPromotionService(nil, nil, "http://localhost:8080", "test-jwt-secret")
 	assert.Equal(t, 12*time.Hour, svc.interval)
 }
 
 func TestNewAutoPromotionService_InvalidEnvIgnored(t *testing.T) {
 	t.Setenv("AUTO_PROMOTION_INTERVAL_HOURS", "not-a-number")
-	svc := NewAutoPromotionService(nil, nil)
+	svc := NewAutoPromotionService(nil, nil, "http://localhost:8080", "test-jwt-secret")
 	assert.Equal(t, DefaultAutoPromotionInterval, svc.interval)
 }
 
 func TestNewAutoPromotionService_ZeroEnvIgnored(t *testing.T) {
 	t.Setenv("AUTO_PROMOTION_INTERVAL_HOURS", "0")
-	svc := NewAutoPromotionService(nil, nil)
+	svc := NewAutoPromotionService(nil, nil, "http://localhost:8080", "test-jwt-secret")
 	assert.Equal(t, DefaultAutoPromotionInterval, svc.interval)
 }
 
@@ -64,7 +64,7 @@ func TestAutoPromotionService_EvaluateUser_NilDB(t *testing.T) {
 }
 
 func TestAutoPromotionService_StartStop(t *testing.T) {
-	svc := NewAutoPromotionService(nil, nil)
+	svc := NewAutoPromotionService(nil, nil, "http://localhost:8080", "test-jwt-secret")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -110,7 +110,7 @@ type AutoPromotionIntegrationTestSuite struct {
 func (s *AutoPromotionIntegrationTestSuite) SetupSuite() {
 	s.testDB = testutil.SetupTestPostgres(s.T())
 	s.db = s.testDB.DB
-	s.svc = NewAutoPromotionService(s.db, nil)
+	s.svc = NewAutoPromotionService(s.db, nil, "http://localhost:8080", "test-jwt-secret")
 }
 
 func (s *AutoPromotionIntegrationTestSuite) TearDownSuite() {

--- a/backend/internal/services/admin/pending_edit.go
+++ b/backend/internal/services/admin/pending_edit.go
@@ -14,6 +14,7 @@ import (
 	adminm "psychic-homily-backend/internal/models/admin"
 	authm "psychic-homily-backend/internal/models/auth"
 	"psychic-homily-backend/internal/services/contracts"
+	"psychic-homily-backend/internal/services/engagement"
 	"psychic-homily-backend/internal/services/shared"
 	"psychic-homily-backend/internal/utils"
 )
@@ -30,11 +31,15 @@ type PendingEditService struct {
 	revisionService contracts.RevisionServiceInterface
 	emailService    contracts.EmailServiceInterface
 	frontendURL     string
-	md              *utils.MarkdownRenderer
+	// backendURL + jwtSecret mint the HMAC-signed edit-notifications
+	// unsubscribe URL placed in the approval/rejection emails.
+	backendURL string
+	jwtSecret  string
+	md         *utils.MarkdownRenderer
 }
 
 // NewPendingEditService creates a new PendingEditService.
-func NewPendingEditService(database *gorm.DB, revisionService contracts.RevisionServiceInterface, emailService contracts.EmailServiceInterface, frontendURL string) *PendingEditService {
+func NewPendingEditService(database *gorm.DB, revisionService contracts.RevisionServiceInterface, emailService contracts.EmailServiceInterface, frontendURL, backendURL, jwtSecret string) *PendingEditService {
 	if database == nil {
 		database = db.GetDB()
 	}
@@ -43,6 +48,8 @@ func NewPendingEditService(database *gorm.DB, revisionService contracts.Revision
 		revisionService: revisionService,
 		emailService:    emailService,
 		frontendURL:     frontendURL,
+		backendURL:      backendURL,
+		jwtSecret:       jwtSecret,
 		md:              utils.NewMarkdownRenderer(),
 	}
 }
@@ -494,10 +501,15 @@ func (s *PendingEditService) sendApprovalEmail(edit *adminm.PendingEntityEdit) {
 		return
 	}
 
+	if !s.editNotificationsEnabled(user.ID) {
+		return
+	}
+
 	entityName, entityURL := s.resolveEntityInfo(edit.EntityType, edit.EntityID)
 	username := shared.ResolveUserName(&user)
+	unsubURL := engagement.GenerateScopedUnsubscribeURL(s.backendURL, user.ID, engagement.UnsubscribeScopeEditNotifications, s.jwtSecret)
 
-	if err := s.emailService.SendEditApprovedEmail(*user.Email, username, edit.EntityType, entityName, entityURL); err != nil {
+	if err := s.emailService.SendEditApprovedEmail(*user.Email, username, edit.EntityType, entityName, entityURL, unsubURL); err != nil {
 		log.Printf("sendApprovalEmail: failed to send email to %s: %v", *user.Email, err)
 	}
 }
@@ -519,12 +531,29 @@ func (s *PendingEditService) sendRejectionEmail(edit *adminm.PendingEntityEdit, 
 		return
 	}
 
+	if !s.editNotificationsEnabled(user.ID) {
+		return
+	}
+
 	entityName, _ := s.resolveEntityInfo(edit.EntityType, edit.EntityID)
 	username := shared.ResolveUserName(&user)
+	unsubURL := engagement.GenerateScopedUnsubscribeURL(s.backendURL, user.ID, engagement.UnsubscribeScopeEditNotifications, s.jwtSecret)
 
-	if err := s.emailService.SendEditRejectedEmail(*user.Email, username, edit.EntityType, entityName, reason); err != nil {
+	if err := s.emailService.SendEditRejectedEmail(*user.Email, username, edit.EntityType, entityName, reason, unsubURL); err != nil {
 		log.Printf("sendRejectionEmail: failed to send email to %s: %v", *user.Email, err)
 	}
+}
+
+// editNotificationsEnabled reports whether the user wants edit-review emails.
+// Defaults to TRUE (opt-OUT): a missing preferences row or a read error means
+// the user hasn't opted out, so we send. Only an explicit FALSE suppresses.
+func (s *PendingEditService) editNotificationsEnabled(userID uint) bool {
+	var prefs authm.UserPreferences
+	if err := s.db.Select("notify_on_edit_notifications").
+		Where("user_id = ?", userID).First(&prefs).Error; err != nil {
+		return true
+	}
+	return prefs.NotifyOnEditNotifications
 }
 
 // resolveEntityInfo looks up an entity's name and builds its frontend URL.

--- a/backend/internal/services/admin/pending_edit_test.go
+++ b/backend/internal/services/admin/pending_edit_test.go
@@ -47,11 +47,12 @@ type mockEmailServiceForPendingEdit struct {
 }
 
 type editApprovedCall struct {
-	ToEmail    string
-	Username   string
-	EntityType string
-	EntityName string
-	EntityURL  string
+	ToEmail        string
+	Username       string
+	EntityType     string
+	EntityName     string
+	EntityURL      string
+	UnsubscribeURL string
 }
 
 type editRejectedCall struct {
@@ -60,6 +61,7 @@ type editRejectedCall struct {
 	EntityType      string
 	EntityName      string
 	RejectionReason string
+	UnsubscribeURL  string
 }
 
 func (m *mockEmailServiceForPendingEdit) IsConfigured() bool                      { return m.configured }
@@ -74,26 +76,26 @@ func (m *mockEmailServiceForPendingEdit) SendShowReminderEmail(_, _, _, _ string
 func (m *mockEmailServiceForPendingEdit) SendFilterNotificationEmail(_, _, _, _ string) error {
 	return nil
 }
-func (m *mockEmailServiceForPendingEdit) SendTierPromotionEmail(_, _, _, _, _ string, _ []string) error {
+func (m *mockEmailServiceForPendingEdit) SendTierPromotionEmail(_, _, _, _, _, _ string, _ []string) error {
 	return nil
 }
-func (m *mockEmailServiceForPendingEdit) SendTierDemotionEmail(_, _, _, _, _ string) error {
+func (m *mockEmailServiceForPendingEdit) SendTierDemotionEmail(_, _, _, _, _, _ string) error {
 	return nil
 }
-func (m *mockEmailServiceForPendingEdit) SendTierDemotionWarningEmail(_, _, _ string, _, _ float64) error {
+func (m *mockEmailServiceForPendingEdit) SendTierDemotionWarningEmail(_, _, _ string, _, _ float64, _ string) error {
 	return nil
 }
-func (m *mockEmailServiceForPendingEdit) SendEditApprovedEmail(toEmail, username, entityType, entityName, entityURL string) error {
+func (m *mockEmailServiceForPendingEdit) SendEditApprovedEmail(toEmail, username, entityType, entityName, entityURL, unsubscribeURL string) error {
 	m.editApprovedCalls = append(m.editApprovedCalls, editApprovedCall{
 		ToEmail: toEmail, Username: username, EntityType: entityType,
-		EntityName: entityName, EntityURL: entityURL,
+		EntityName: entityName, EntityURL: entityURL, UnsubscribeURL: unsubscribeURL,
 	})
 	return m.editApprovedErr
 }
-func (m *mockEmailServiceForPendingEdit) SendEditRejectedEmail(toEmail, username, entityType, entityName, rejectionReason string) error {
+func (m *mockEmailServiceForPendingEdit) SendEditRejectedEmail(toEmail, username, entityType, entityName, rejectionReason, unsubscribeURL string) error {
 	m.editRejectedCalls = append(m.editRejectedCalls, editRejectedCall{
 		ToEmail: toEmail, Username: username, EntityType: entityType,
-		EntityName: entityName, RejectionReason: rejectionReason,
+		EntityName: entityName, RejectionReason: rejectionReason, UnsubscribeURL: unsubscribeURL,
 	})
 	return m.editRejectedErr
 }
@@ -121,7 +123,7 @@ func (s *PendingEditServiceIntegrationTestSuite) SetupSuite() {
 	s.db = s.testDB.DB
 	s.revisionSvc = NewRevisionService(s.db)
 	s.mockEmail = &mockEmailServiceForPendingEdit{configured: true}
-	s.svc = NewPendingEditService(s.db, s.revisionSvc, s.mockEmail, "http://localhost:3000")
+	s.svc = NewPendingEditService(s.db, s.revisionSvc, s.mockEmail, "http://localhost:3000", "http://localhost:8080", "test-jwt-secret")
 }
 
 func (s *PendingEditServiceIntegrationTestSuite) TearDownSuite() {
@@ -136,6 +138,7 @@ func (s *PendingEditServiceIntegrationTestSuite) TearDownTest() {
 	_, _ = sqlDB.Exec("DELETE FROM artists")
 	_, _ = sqlDB.Exec("DELETE FROM venues")
 	_, _ = sqlDB.Exec("DELETE FROM festivals")
+	_, _ = sqlDB.Exec("DELETE FROM user_preferences")
 	_, _ = sqlDB.Exec("DELETE FROM users")
 	// Reset mock email state between tests
 	s.mockEmail.editApprovedCalls = nil
@@ -1117,6 +1120,40 @@ func (s *PendingEditServiceIntegrationTestSuite) TestApprovePendingEdit_SendsApp
 	s.Equal("The Cool Band", call.EntityName) // Entity was updated, so name should reflect the update
 	s.Contains(call.EntityURL, "/artists/")
 	s.Contains(call.EntityURL, "http://localhost:3000")
+	// PSY-756: an edit-notifications unsubscribe URL is minted and passed.
+	s.Contains(call.UnsubscribeURL, "/unsubscribe/edit-notifications", "expected an HMAC-signed edit-notifications unsubscribe URL")
+	s.Contains(call.UnsubscribeURL, "uid=")
+	s.Contains(call.UnsubscribeURL, "sig=")
+}
+
+// TestApprovePendingEdit_SuppressedWhenOptedOut verifies the edit-notifications
+// opt-out flag suppresses the email without blocking the approval (PSY-756).
+func (s *PendingEditServiceIntegrationTestSuite) TestApprovePendingEdit_SuppressedWhenOptedOut() {
+	user := s.createTestUser()
+	reviewer := s.createTestUser()
+	artist := s.createTestArtist("Optout Band")
+
+	// Opt the submitter out of edit-review emails.
+	s.Require().NoError(s.db.Create(&authm.UserPreferences{
+		UserID:                    user.ID,
+		NotifyOnEditNotifications: false,
+	}).Error)
+	s.Require().NoError(s.db.Model(&authm.UserPreferences{}).
+		Where("user_id = ?", user.ID).
+		Update("notify_on_edit_notifications", false).Error)
+
+	created, err := s.svc.CreatePendingEdit(&contracts.CreatePendingEditRequest{
+		EntityType: "artist", EntityID: artist.ID, UserID: user.ID,
+		Changes: makeChanges("name", "Optout Band", "The Optout Band"), Summary: "add 'The'",
+	})
+	s.Require().NoError(err)
+
+	resp, err := s.svc.ApprovePendingEdit(created.ID, reviewer.ID)
+	s.NoError(err)
+	s.Equal(adminm.PendingEditStatusApproved, resp.Status, "approval must still succeed when emails are opted out")
+
+	// No email should have been sent.
+	s.Empty(s.mockEmail.editApprovedCalls, "approval email must be suppressed when opted out")
 }
 
 func (s *PendingEditServiceIntegrationTestSuite) TestApprovePendingEdit_EmailErrorDoesNotFail() {
@@ -1230,7 +1267,7 @@ func (s *PendingEditServiceIntegrationTestSuite) TestApprovePendingEdit_Festival
 
 func TestPendingEditService_NilEmailServiceDoesNotPanic(t *testing.T) {
 	// Constructor with nil email service should work fine
-	svc := NewPendingEditService(nil, nil, nil, "")
+	svc := NewPendingEditService(nil, nil, nil, "", "", "")
 	assert.NotNil(t, svc)
 
 	// sendApprovalEmail and sendRejectionEmail should not panic with nil email service
@@ -1240,7 +1277,7 @@ func TestPendingEditService_NilEmailServiceDoesNotPanic(t *testing.T) {
 
 func TestPendingEditService_UnconfiguredEmailServiceDoesNotPanic(t *testing.T) {
 	mockEmail := &mockEmailServiceForPendingEdit{configured: false}
-	svc := NewPendingEditService(nil, nil, mockEmail, "http://localhost:3000")
+	svc := NewPendingEditService(nil, nil, mockEmail, "http://localhost:3000", "http://localhost:8080", "test-jwt-secret")
 
 	// Should return early without attempting to send
 	svc.sendApprovalEmail(&adminm.PendingEntityEdit{SubmittedBy: 1, EntityType: "artist", EntityID: 1})

--- a/backend/internal/services/auth/test_helpers_test.go
+++ b/backend/internal/services/auth/test_helpers_test.go
@@ -163,6 +163,14 @@ func (n *nilDBUserService) SetNotifyOnCollectionDigest(userID uint, enabled bool
 	return fmt.Errorf("database not initialized")
 }
 
+func (n *nilDBUserService) SetNotifyOnTierNotifications(userID uint, enabled bool) error {
+	return fmt.Errorf("database not initialized")
+}
+
+func (n *nilDBUserService) SetNotifyOnEditNotifications(userID uint, enabled bool) error {
+	return fmt.Errorf("database not initialized")
+}
+
 // newNilDBUserService returns a UserServiceInterface that returns
 // "database not initialized" for every DB-dependent method.
 func newNilDBUserService() contracts.UserServiceInterface {

--- a/backend/internal/services/container.go
+++ b/backend/internal/services/container.go
@@ -159,7 +159,7 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 		APIToken:               adminsvc.NewAPITokenService(database),
 		DataQuality:            adminsvc.NewDataQualityService(database),
 		Revision:               revisionSvc,
-		PendingEdit:            adminsvc.NewPendingEditService(database, revisionSvc, email, cfg.Email.FrontendURL),
+		PendingEdit:            adminsvc.NewPendingEditService(database, revisionSvc, email, cfg.Email.FrontendURL, engagement.DeriveBackendURL(cfg.Email.FrontendURL), cfg.JWT.SecretKey),
 		Charts:                 catalog.NewChartsService(database),
 		Artist:                 artist,
 		ContributorProfile:     usersvc.NewContributorProfileService(database),
@@ -219,7 +219,7 @@ func NewServiceContainer(database *gorm.DB, cfg *config.Config) *ServiceContaine
 		Scheduler:        pipeline.NewSchedulerService(database, pipelineSvc, venueSourceConfig, discord),
 		Enrichment:       enrichmentSvc,
 		EnrichmentWorker: enrichmentWorker,
-		AutoPromotion:    adminsvc.NewAutoPromotionService(database, email),
+		AutoPromotion:    adminsvc.NewAutoPromotionService(database, email, engagement.DeriveBackendURL(cfg.Email.FrontendURL), cfg.JWT.SecretKey),
 		CollectionDigest: engagement.NewCollectionDigestService(database, email, cfg),
 	}
 }

--- a/backend/internal/services/contracts/notification.go
+++ b/backend/internal/services/contracts/notification.go
@@ -41,11 +41,12 @@ type EmailServiceInterface interface {
 	SendAccountRecoveryEmail(toEmail, token string, daysRemaining int) error
 	SendShowReminderEmail(toEmail, showTitle, showURL, unsubscribeURL string, eventDate time.Time, venues []string) error
 	SendFilterNotificationEmail(toEmail, subject, htmlBody, unsubscribeURL string) error
-	SendTierPromotionEmail(toEmail, username, oldTier, newTier, reason string, newPermissions []string) error
-	SendTierDemotionEmail(toEmail, username, oldTier, newTier, reason string) error
-	SendTierDemotionWarningEmail(toEmail, username, currentTier string, currentRate float64, threshold float64) error
-	SendEditApprovedEmail(toEmail, username, entityType, entityName, entityURL string) error
-	SendEditRejectedEmail(toEmail, username, entityType, entityName, rejectionReason string) error
+	// Each takes an HMAC-signed unsubscribeURL (RFC 8058 one-click).
+	SendTierPromotionEmail(toEmail, username, oldTier, newTier, reason, unsubscribeURL string, newPermissions []string) error
+	SendTierDemotionEmail(toEmail, username, oldTier, newTier, reason, unsubscribeURL string) error
+	SendTierDemotionWarningEmail(toEmail, username, currentTier string, currentRate float64, threshold float64, unsubscribeURL string) error
+	SendEditApprovedEmail(toEmail, username, entityType, entityName, entityURL, unsubscribeURL string) error
+	SendEditRejectedEmail(toEmail, username, entityType, entityName, rejectionReason, unsubscribeURL string) error
 	// PSY-289: comment + mention notifications.
 	SendCommentNotification(toEmail, commenterName, entityType, entityName, commentExcerpt, entityURL, unsubscribeURL string) error
 	SendMentionNotification(toEmail, mentionerName, entityType, entityName, commentExcerpt, commentURL, unsubscribeURL string) error

--- a/backend/internal/services/contracts/user.go
+++ b/backend/internal/services/contracts/user.go
@@ -328,6 +328,9 @@ type UserServiceInterface interface {
 	SetNotifyOnMention(userID uint, enabled bool) error
 	// PSY-350: collection digest preference toggle (weekly cadence; opt-IN).
 	SetNotifyOnCollectionDigest(userID uint, enabled bool) error
+	// Per-category tier-change + edit-review email toggles (opt-OUT).
+	SetNotifyOnTierNotifications(userID uint, enabled bool) error
+	SetNotifyOnEditNotifications(userID uint, enabled bool) error
 }
 
 // ──────────────────────────────────────────────

--- a/backend/internal/services/engagement/collection_digest.go
+++ b/backend/internal/services/engagement/collection_digest.go
@@ -77,15 +77,17 @@ func NewCollectionDigestService(database *gorm.DB, emailService contracts.EmailS
 		stopCh:       make(chan struct{}),
 		logger:       slog.Default(),
 		frontendURL:  cfg.Email.FrontendURL,
-		backendURL:   deriveBackendURL(cfg.Email.FrontendURL),
+		backendURL:   DeriveBackendURL(cfg.Email.FrontendURL),
 		jwtSecret:    cfg.JWT.SecretKey,
 	}
 }
 
-// deriveBackendURL maps a frontend URL to the corresponding public API URL.
+// DeriveBackendURL maps a frontend URL to the corresponding public API URL.
 // Mirrors handlers.getAPIBaseURL — pulled inline to avoid cross-package
-// imports. Defaults to localhost:8080 in dev.
-func deriveBackendURL(frontendURL string) string {
+// imports. Defaults to localhost:8080 in dev. Exported so other services that
+// mint backend-hosted unsubscribe URLs (e.g. the admin tier/edit emails) can
+// reuse the same mapping rather than copy it again.
+func DeriveBackendURL(frontendURL string) string {
 	switch frontendURL {
 	case "https://psychichomily.com":
 		return "https://api.psychichomily.com"

--- a/backend/internal/services/engagement/collection_digest_test.go
+++ b/backend/internal/services/engagement/collection_digest_test.go
@@ -138,15 +138,15 @@ func (m *captureDigestEmailService) SendShowReminderEmail(_, _, _, _ string, _ t
 	return nil
 }
 func (m *captureDigestEmailService) SendFilterNotificationEmail(_, _, _, _ string) error { return nil }
-func (m *captureDigestEmailService) SendTierPromotionEmail(_, _, _, _, _ string, _ []string) error {
+func (m *captureDigestEmailService) SendTierPromotionEmail(_, _, _, _, _, _ string, _ []string) error {
 	return nil
 }
-func (m *captureDigestEmailService) SendTierDemotionEmail(_, _, _, _, _ string) error { return nil }
-func (m *captureDigestEmailService) SendTierDemotionWarningEmail(_, _, _ string, _, _ float64) error {
+func (m *captureDigestEmailService) SendTierDemotionEmail(_, _, _, _, _, _ string) error { return nil }
+func (m *captureDigestEmailService) SendTierDemotionWarningEmail(_, _, _ string, _, _ float64, _ string) error {
 	return nil
 }
-func (m *captureDigestEmailService) SendEditApprovedEmail(_, _, _, _, _ string) error { return nil }
-func (m *captureDigestEmailService) SendEditRejectedEmail(_, _, _, _, _ string) error { return nil }
+func (m *captureDigestEmailService) SendEditApprovedEmail(_, _, _, _, _, _ string) error { return nil }
+func (m *captureDigestEmailService) SendEditRejectedEmail(_, _, _, _, _, _ string) error { return nil }
 func (m *captureDigestEmailService) SendCommentNotification(_, _, _, _, _, _, _ string) error {
 	return nil
 }

--- a/backend/internal/services/engagement/comment_notification_test.go
+++ b/backend/internal/services/engagement/comment_notification_test.go
@@ -240,15 +240,15 @@ func (m *captureEmailService) SendShowReminderEmail(_, _, _, _ string, _ time.Ti
 	return nil
 }
 func (m *captureEmailService) SendFilterNotificationEmail(_, _, _, _ string) error { return nil }
-func (m *captureEmailService) SendTierPromotionEmail(_, _, _, _, _ string, _ []string) error {
+func (m *captureEmailService) SendTierPromotionEmail(_, _, _, _, _, _ string, _ []string) error {
 	return nil
 }
-func (m *captureEmailService) SendTierDemotionEmail(_, _, _, _, _ string) error { return nil }
-func (m *captureEmailService) SendTierDemotionWarningEmail(_, _, _ string, _, _ float64) error {
+func (m *captureEmailService) SendTierDemotionEmail(_, _, _, _, _, _ string) error { return nil }
+func (m *captureEmailService) SendTierDemotionWarningEmail(_, _, _ string, _, _ float64, _ string) error {
 	return nil
 }
-func (m *captureEmailService) SendEditApprovedEmail(_, _, _, _, _ string) error { return nil }
-func (m *captureEmailService) SendEditRejectedEmail(_, _, _, _, _ string) error { return nil }
+func (m *captureEmailService) SendEditApprovedEmail(_, _, _, _, _, _ string) error { return nil }
+func (m *captureEmailService) SendEditRejectedEmail(_, _, _, _, _, _ string) error { return nil }
 func (m *captureEmailService) SendCollectionDigestEmail(_ string, _ []contracts.CollectionDigestGroup, _ string) error {
 	return nil
 }

--- a/backend/internal/services/engagement/reminder_test.go
+++ b/backend/internal/services/engagement/reminder_test.go
@@ -185,15 +185,15 @@ func (m *mockReminderEmailService) SendShowReminderEmail(toEmail, showTitle, sho
 func (m *mockReminderEmailService) SendFilterNotificationEmail(_, _, _, _ string) error {
 	return nil
 }
-func (m *mockReminderEmailService) SendTierPromotionEmail(_, _, _, _, _ string, _ []string) error {
+func (m *mockReminderEmailService) SendTierPromotionEmail(_, _, _, _, _, _ string, _ []string) error {
 	return nil
 }
-func (m *mockReminderEmailService) SendTierDemotionEmail(_, _, _, _, _ string) error { return nil }
-func (m *mockReminderEmailService) SendTierDemotionWarningEmail(_, _, _ string, _, _ float64) error {
+func (m *mockReminderEmailService) SendTierDemotionEmail(_, _, _, _, _, _ string) error { return nil }
+func (m *mockReminderEmailService) SendTierDemotionWarningEmail(_, _, _ string, _, _ float64, _ string) error {
 	return nil
 }
-func (m *mockReminderEmailService) SendEditApprovedEmail(_, _, _, _, _ string) error { return nil }
-func (m *mockReminderEmailService) SendEditRejectedEmail(_, _, _, _, _ string) error { return nil }
+func (m *mockReminderEmailService) SendEditApprovedEmail(_, _, _, _, _, _ string) error { return nil }
+func (m *mockReminderEmailService) SendEditRejectedEmail(_, _, _, _, _, _ string) error { return nil }
 func (m *mockReminderEmailService) SendCommentNotification(_, _, _, _, _, _, _ string) error {
 	return nil
 }

--- a/backend/internal/services/engagement/unsubscribe_scope.go
+++ b/backend/internal/services/engagement/unsubscribe_scope.go
@@ -1,0 +1,45 @@
+package engagement
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+)
+
+// Unsubscribe scopes used to bind an HMAC signature to one notification
+// category, so a link minted for one email can't be replayed against another.
+// These string values are part of the signed payload — changing one
+// invalidates every URL already in recipients' inboxes for that scope.
+const (
+	UnsubscribeScopeTierNotifications = "tier-notifications"
+	UnsubscribeScopeEditNotifications = "edit-notifications"
+)
+
+// ComputeScopedUnsubscribeSignature computes HMAC-SHA256 over
+// "unsubscribe:<scope>:<userID>" — the same payload shape as the older
+// per-domain helpers (ComputeUnsubscribeSignature for show-reminders,
+// ComputeCollectionDigestUnsubscribeSignature for collection-digest), but with
+// the scope passed in rather than baked into the function. Used for the
+// tier-change and edit-review categories.
+func ComputeScopedUnsubscribeSignature(userID uint, scope, secret string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(fmt.Sprintf("unsubscribe:%s:%d", scope, userID)))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// VerifyScopedUnsubscribeSignature constant-time-compares a signature against
+// the expected value for (userID, scope). Constant-time via hmac.Equal.
+func VerifyScopedUnsubscribeSignature(userID uint, scope, signature, secret string) bool {
+	expected := ComputeScopedUnsubscribeSignature(userID, scope, secret)
+	return hmac.Equal([]byte(expected), []byte(signature))
+}
+
+// GenerateScopedUnsubscribeURL mints the HMAC-signed one-click unsubscribe URL
+// for a notification category. `baseURL` must be the public backend URL (NOT
+// the frontend) — the chi route at /unsubscribe/<scope> serves an HTML
+// confirmation page on GET and accepts an RFC 8058 one-click POST.
+func GenerateScopedUnsubscribeURL(baseURL string, userID uint, scope, secret string) string {
+	sig := ComputeScopedUnsubscribeSignature(userID, scope, secret)
+	return fmt.Sprintf("%s/unsubscribe/%s?uid=%d&sig=%s", baseURL, scope, userID, sig)
+}

--- a/backend/internal/services/engagement/unsubscribe_scope_test.go
+++ b/backend/internal/services/engagement/unsubscribe_scope_test.go
@@ -1,0 +1,62 @@
+package engagement
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// PSY-756: tests for the generic scoped unsubscribe HMAC helpers.
+
+func TestComputeScopedUnsubscribeSignature_Deterministic(t *testing.T) {
+	sig1 := ComputeScopedUnsubscribeSignature(42, UnsubscribeScopeTierNotifications, testSecret)
+	sig2 := ComputeScopedUnsubscribeSignature(42, UnsubscribeScopeTierNotifications, testSecret)
+	assert.NotEmpty(t, sig1)
+	assert.Equal(t, sig1, sig2, "same inputs should produce the same signature")
+	assert.Len(t, sig1, 64, "HMAC-SHA256 hex output should be 64 characters")
+}
+
+func TestComputeScopedUnsubscribeSignature_ScopeIsolation(t *testing.T) {
+	// A signature minted for one scope must not be valid for another, so a
+	// leaked tier-notifications link can't unsubscribe edit-notifications.
+	tierSig := ComputeScopedUnsubscribeSignature(42, UnsubscribeScopeTierNotifications, testSecret)
+	editSig := ComputeScopedUnsubscribeSignature(42, UnsubscribeScopeEditNotifications, testSecret)
+	assert.NotEqual(t, tierSig, editSig, "different scopes must produce different signatures")
+
+	assert.False(t, VerifyScopedUnsubscribeSignature(42, UnsubscribeScopeEditNotifications, tierSig, testSecret),
+		"a tier-scope signature must not verify under the edit scope")
+}
+
+func TestComputeScopedUnsubscribeSignature_DistinctFromShowReminders(t *testing.T) {
+	// The legacy show-reminders helper hardcodes the "show-reminders" scope;
+	// the generic helper must produce a different value for other scopes so
+	// the domains stay separated.
+	legacy := ComputeUnsubscribeSignature(42, testSecret)
+	tier := ComputeScopedUnsubscribeSignature(42, UnsubscribeScopeTierNotifications, testSecret)
+	assert.NotEqual(t, legacy, tier)
+}
+
+func TestVerifyScopedUnsubscribeSignature(t *testing.T) {
+	sig := ComputeScopedUnsubscribeSignature(7, UnsubscribeScopeEditNotifications, testSecret)
+	assert.True(t, VerifyScopedUnsubscribeSignature(7, UnsubscribeScopeEditNotifications, sig, testSecret))
+	// Wrong user, wrong sig, wrong secret, empty sig all fail.
+	assert.False(t, VerifyScopedUnsubscribeSignature(8, UnsubscribeScopeEditNotifications, sig, testSecret))
+	assert.False(t, VerifyScopedUnsubscribeSignature(7, UnsubscribeScopeEditNotifications, "deadbeef", testSecret))
+	assert.False(t, VerifyScopedUnsubscribeSignature(7, UnsubscribeScopeEditNotifications, sig, "other-secret"))
+	assert.False(t, VerifyScopedUnsubscribeSignature(7, UnsubscribeScopeEditNotifications, "", testSecret))
+}
+
+func TestGenerateScopedUnsubscribeURL_Format(t *testing.T) {
+	result := GenerateScopedUnsubscribeURL("https://api.example.com", 42, UnsubscribeScopeTierNotifications, testSecret)
+
+	parsed, err := url.Parse(result)
+	assert.NoError(t, err)
+	assert.Equal(t, "https", parsed.Scheme)
+	assert.Equal(t, "api.example.com", parsed.Host)
+	assert.Equal(t, "/unsubscribe/"+UnsubscribeScopeTierNotifications, parsed.Path)
+	assert.Equal(t, "42", parsed.Query().Get("uid"))
+
+	expectedSig := ComputeScopedUnsubscribeSignature(42, UnsubscribeScopeTierNotifications, testSecret)
+	assert.Equal(t, expectedSig, parsed.Query().Get("sig"))
+}

--- a/backend/internal/services/notification/email.go
+++ b/backend/internal/services/notification/email.go
@@ -349,7 +349,8 @@ func TierPermissions(tier string) []string {
 }
 
 // SendTierPromotionEmail sends a congratulatory email when a user is promoted to a higher tier.
-func (s *EmailService) SendTierPromotionEmail(toEmail, username, oldTier, newTier, reason string, newPermissions []string) error {
+// unsubscribeURL is the HMAC-signed tier-notifications opt-out link (RFC 8058).
+func (s *EmailService) SendTierPromotionEmail(toEmail, username, oldTier, newTier, reason, unsubscribeURL string, newPermissions []string) error {
 	if !s.IsConfigured() {
 		return fmt.Errorf("email service is not configured")
 	}
@@ -401,18 +402,21 @@ func (s *EmailService) SendTierPromotionEmail(toEmail, username, oldTier, newTie
         %s
     </div>
 
+    %s
+
     <div style="text-align: center; font-size: 12px; color: #999;">
         <p>Thank you for contributing to the Psychic Homily community.</p>
     </div>
 </body>
 </html>
-`, greeting, oldDisplayName, displayName, reason, permissionsHTML, nextTierHTML)
+`, greeting, oldDisplayName, displayName, reason, permissionsHTML, nextTierHTML, unsubscribeCardHTML(unsubscribeURL, "tier-change emails"))
 
 	params := &resend.SendEmailRequest{
 		From:    fmt.Sprintf("Psychic Homily <%s>", s.fromEmail),
 		To:      []string{toEmail},
 		Subject: fmt.Sprintf("You've been promoted to %s!", displayName),
 		Html:    html,
+		Headers: unsubscribeHeaders(unsubscribeURL),
 	}
 
 	_, err := s.client.Emails.Send(params)
@@ -429,7 +433,8 @@ func (s *EmailService) SendTierPromotionEmail(toEmail, username, oldTier, newTie
 }
 
 // SendTierDemotionEmail sends a notification when a user is demoted to a lower tier.
-func (s *EmailService) SendTierDemotionEmail(toEmail, username, oldTier, newTier, reason string) error {
+// unsubscribeURL is the HMAC-signed tier-notifications opt-out link (RFC 8058).
+func (s *EmailService) SendTierDemotionEmail(toEmail, username, oldTier, newTier, reason, unsubscribeURL string) error {
 	if !s.IsConfigured() {
 		return fmt.Errorf("email service is not configured")
 	}
@@ -467,18 +472,21 @@ func (s *EmailService) SendTierDemotionEmail(toEmail, username, oldTier, newTier
         </ul>
     </div>
 
+    %s
+
     <div style="text-align: center; font-size: 12px; color: #999;">
         <p>Your contributions are valued. Keep at it and you'll regain your tier.</p>
     </div>
 </body>
 </html>
-`, greeting, oldDisplayName, newDisplayName, reason)
+`, greeting, oldDisplayName, newDisplayName, reason, unsubscribeCardHTML(unsubscribeURL, "tier-change emails"))
 
 	params := &resend.SendEmailRequest{
 		From:    fmt.Sprintf("Psychic Homily <%s>", s.fromEmail),
 		To:      []string{toEmail},
 		Subject: "Your contributor tier has changed",
 		Html:    html,
+		Headers: unsubscribeHeaders(unsubscribeURL),
 	}
 
 	_, err := s.client.Emails.Send(params)
@@ -495,7 +503,8 @@ func (s *EmailService) SendTierDemotionEmail(toEmail, username, oldTier, newTier
 }
 
 // SendTierDemotionWarningEmail sends a warning when a user's approval rate is approaching the demotion threshold.
-func (s *EmailService) SendTierDemotionWarningEmail(toEmail, username, currentTier string, currentRate float64, threshold float64) error {
+// unsubscribeURL is the HMAC-signed tier-notifications opt-out link (RFC 8058).
+func (s *EmailService) SendTierDemotionWarningEmail(toEmail, username, currentTier string, currentRate float64, threshold float64, unsubscribeURL string) error {
 	if !s.IsConfigured() {
 		return fmt.Errorf("email service is not configured")
 	}
@@ -531,18 +540,21 @@ func (s *EmailService) SendTierDemotionWarningEmail(toEmail, username, currentTi
         </ul>
     </div>
 
+    %s
+
     <div style="text-align: center; font-size: 12px; color: #999;">
         <p>This is a friendly heads-up to help you maintain your contributor status.</p>
     </div>
 </body>
 </html>
-`, greeting, currentRate*100, threshold*100, displayName)
+`, greeting, currentRate*100, threshold*100, displayName, unsubscribeCardHTML(unsubscribeURL, "tier-change emails"))
 
 	params := &resend.SendEmailRequest{
 		From:    fmt.Sprintf("Psychic Homily <%s>", s.fromEmail),
 		To:      []string{toEmail},
 		Subject: "Your contributor status is at risk",
 		Html:    html,
+		Headers: unsubscribeHeaders(unsubscribeURL),
 	}
 
 	_, err := s.client.Emails.Send(params)
@@ -559,7 +571,8 @@ func (s *EmailService) SendTierDemotionWarningEmail(toEmail, username, currentTi
 }
 
 // SendEditApprovedEmail sends a notification when a user's pending edit is approved.
-func (s *EmailService) SendEditApprovedEmail(toEmail, username, entityType, entityName, entityURL string) error {
+// unsubscribeURL is the HMAC-signed edit-notifications opt-out link (RFC 8058).
+func (s *EmailService) SendEditApprovedEmail(toEmail, username, entityType, entityName, entityURL, unsubscribeURL string) error {
 	if !s.IsConfigured() {
 		return fmt.Errorf("email service is not configured")
 	}
@@ -594,18 +607,21 @@ func (s *EmailService) SendEditApprovedEmail(toEmail, username, entityType, enti
         <p style="font-size: 14px; color: #444;">Thank you for improving the Psychic Homily database. Every contribution helps the community discover great music.</p>
     </div>
 
+    %s
+
     <div style="text-align: center; font-size: 12px; color: #999;">
         <p>Keep contributing to build your reputation and unlock new permissions.</p>
     </div>
 </body>
 </html>
-`, greeting, entityType, entityName, entityURL, entityTypeTitle)
+`, greeting, entityType, entityName, entityURL, entityTypeTitle, unsubscribeCardHTML(unsubscribeURL, "edit-review emails"))
 
 	params := &resend.SendEmailRequest{
 		From:    fmt.Sprintf("Psychic Homily <%s>", s.fromEmail),
 		To:      []string{toEmail},
 		Subject: fmt.Sprintf("Your edit to %s was approved!", entityName),
 		Html:    html,
+		Headers: unsubscribeHeaders(unsubscribeURL),
 	}
 
 	_, err := s.client.Emails.Send(params)
@@ -859,15 +875,7 @@ func (s *EmailService) SendCollectionDigestEmail(toEmail string, groups []contra
 		To:      []string{toEmail},
 		Subject: subject,
 		Html:    html,
-		// RFC 8058 / RFC 2369 — Gmail & Yahoo bulk-sender requirement. The
-		// header value MUST be a single HTTPS URL or mailto wrapped in <>;
-		// see RFC 2369 §3. List-Unsubscribe-Post tells the receiver this
-		// link supports RFC 8058 one-click POST so it can render the
-		// "Unsubscribe" button next to the sender name.
-		Headers: map[string]string{
-			"List-Unsubscribe":      fmt.Sprintf("<%s>", unsubscribeURL),
-			"List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
-		},
+		Headers: unsubscribeHeaders(unsubscribeURL),
 	}
 
 	_, err := s.client.Emails.Send(params)
@@ -881,6 +889,34 @@ func (s *EmailService) SendCollectionDigestEmail(toEmail string, groups []contra
 	}
 
 	return nil
+}
+
+// unsubscribeCardHTML renders the prominent in-body opt-out block shared by
+// the notification emails. `label` describes the category in the recipient's
+// words (e.g. "tier-change emails"). The same `unsubscribeURL`
+// goes in the List-Unsubscribe header — RFC 8058 one-click and the visible
+// in-body link are the same endpoint, so a recipient and a mailbox provider
+// both have a single way out. The endpoint requires no login (HMAC-signed).
+func unsubscribeCardHTML(unsubscribeURL, label string) string {
+	return fmt.Sprintf(`
+    <div style="background: #fff7ed; border: 1px solid #fed7aa; border-radius: 8px; padding: 16px 20px; margin-bottom: 20px;">
+        <p style="margin: 0; font-size: 14px; color: #444;">
+            Don&rsquo;t want %s?
+            <a href="%s" style="color: #c2410c; font-weight: 600;">Unsubscribe in one click</a> &mdash;
+            no login required.
+        </p>
+    </div>`, label, unsubscribeURL)
+}
+
+// unsubscribeHeaders returns the RFC 8058 / RFC 2369 List-Unsubscribe headers.
+// The value MUST be a single HTTPS URL wrapped in <> (RFC 2369 §3);
+// List-Unsubscribe-Post advertises RFC 8058 one-click POST so Gmail/Yahoo
+// render the native "Unsubscribe" button next to the sender name.
+func unsubscribeHeaders(unsubscribeURL string) map[string]string {
+	return map[string]string{
+		"List-Unsubscribe":      fmt.Sprintf("<%s>", unsubscribeURL),
+		"List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+	}
 }
 
 // pluralize returns word with an "s" appended if n != 1.
@@ -908,7 +944,8 @@ func htmlEscape(s string) string {
 }
 
 // SendEditRejectedEmail sends a notification when a user's pending edit is rejected.
-func (s *EmailService) SendEditRejectedEmail(toEmail, username, entityType, entityName, rejectionReason string) error {
+// unsubscribeURL is the HMAC-signed edit-notifications opt-out link (RFC 8058).
+func (s *EmailService) SendEditRejectedEmail(toEmail, username, entityType, entityName, rejectionReason, unsubscribeURL string) error {
 	if !s.IsConfigured() {
 		return fmt.Errorf("email service is not configured")
 	}
@@ -943,18 +980,21 @@ func (s *EmailService) SendEditRejectedEmail(toEmail, username, entityType, enti
         </ul>
     </div>
 
+    %s
+
     <div style="text-align: center; font-size: 12px; color: #999;">
         <p>Don't be discouraged — your contributions are valued. Feel free to submit a revised edit.</p>
     </div>
 </body>
 </html>
-`, entityName, greeting, entityType, entityName, rejectionReason)
+`, entityName, greeting, entityType, entityName, rejectionReason, unsubscribeCardHTML(unsubscribeURL, "edit-review emails"))
 
 	params := &resend.SendEmailRequest{
 		From:    fmt.Sprintf("Psychic Homily <%s>", s.fromEmail),
 		To:      []string{toEmail},
 		Subject: fmt.Sprintf("Update on your edit to %s", entityName),
 		Html:    html,
+		Headers: unsubscribeHeaders(unsubscribeURL),
 	}
 
 	_, err := s.client.Emails.Send(params)

--- a/backend/internal/services/notification/email_edit_test.go
+++ b/backend/internal/services/notification/email_edit_test.go
@@ -20,6 +20,7 @@ func TestSendEditApprovedEmail_Success(t *testing.T) {
 		"artist",
 		"The Cool Band",
 		"http://localhost:3000/artists/the-cool-band",
+		"http://api.test.local/unsubscribe/edit-notifications?uid=7&sig=abc",
 	)
 
 	require.NoError(t, err)
@@ -38,7 +39,7 @@ func TestSendEditApprovedEmail_Success(t *testing.T) {
 func TestSendEditApprovedEmail_NotConfigured(t *testing.T) {
 	svc := &EmailService{client: nil, fromEmail: ""}
 
-	err := svc.SendEditApprovedEmail("user@test.com", "user", "artist", "Band", "http://example.com")
+	err := svc.SendEditApprovedEmail("user@test.com", "user", "artist", "Band", "http://example.com", "http://unsub")
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "not configured")
@@ -47,7 +48,7 @@ func TestSendEditApprovedEmail_NotConfigured(t *testing.T) {
 func TestSendEditApprovedEmail_APIError(t *testing.T) {
 	svc := setupEmailTestError(t)
 
-	err := svc.SendEditApprovedEmail("user@test.com", "user", "artist", "Band", "http://example.com")
+	err := svc.SendEditApprovedEmail("user@test.com", "user", "artist", "Band", "http://example.com", "http://unsub")
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to send edit approved email")
@@ -56,7 +57,7 @@ func TestSendEditApprovedEmail_APIError(t *testing.T) {
 func TestSendEditApprovedEmail_EmptyUsername(t *testing.T) {
 	svc, emails, _ := setupEmailTest(t)
 
-	err := svc.SendEditApprovedEmail("user@test.com", "", "venue", "Valley Bar", "http://localhost:3000/venues/valley-bar")
+	err := svc.SendEditApprovedEmail("user@test.com", "", "venue", "Valley Bar", "http://localhost:3000/venues/valley-bar", "http://unsub")
 
 	require.NoError(t, err)
 	email := <-emails
@@ -67,7 +68,7 @@ func TestSendEditApprovedEmail_EmptyUsername(t *testing.T) {
 func TestSendEditApprovedEmail_VenueEntity(t *testing.T) {
 	svc, emails, _ := setupEmailTest(t)
 
-	err := svc.SendEditApprovedEmail("user@test.com", "admin", "venue", "Crescent Ballroom", "http://localhost:3000/venues/crescent-ballroom")
+	err := svc.SendEditApprovedEmail("user@test.com", "admin", "venue", "Crescent Ballroom", "http://localhost:3000/venues/crescent-ballroom", "http://unsub")
 
 	require.NoError(t, err)
 	email := <-emails
@@ -80,7 +81,7 @@ func TestSendEditApprovedEmail_VenueEntity(t *testing.T) {
 func TestSendEditApprovedEmail_FestivalEntity(t *testing.T) {
 	svc, emails, _ := setupEmailTest(t)
 
-	err := svc.SendEditApprovedEmail("user@test.com", "testuser", "festival", "M3F Fest 2026", "http://localhost:3000/festivals/m3f-fest-2026")
+	err := svc.SendEditApprovedEmail("user@test.com", "testuser", "festival", "M3F Fest 2026", "http://localhost:3000/festivals/m3f-fest-2026", "http://unsub")
 
 	require.NoError(t, err)
 	email := <-emails
@@ -102,6 +103,7 @@ func TestSendEditRejectedEmail_Success(t *testing.T) {
 		"artist",
 		"Some Artist",
 		"The name does not match the artist's official spelling",
+		"http://api.test.local/unsubscribe/edit-notifications?uid=7&sig=abc",
 	)
 
 	require.NoError(t, err)
@@ -120,7 +122,7 @@ func TestSendEditRejectedEmail_Success(t *testing.T) {
 func TestSendEditRejectedEmail_NotConfigured(t *testing.T) {
 	svc := &EmailService{client: nil, fromEmail: ""}
 
-	err := svc.SendEditRejectedEmail("user@test.com", "user", "artist", "Band", "reason")
+	err := svc.SendEditRejectedEmail("user@test.com", "user", "artist", "Band", "reason", "http://unsub")
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "not configured")
@@ -129,7 +131,7 @@ func TestSendEditRejectedEmail_NotConfigured(t *testing.T) {
 func TestSendEditRejectedEmail_APIError(t *testing.T) {
 	svc := setupEmailTestError(t)
 
-	err := svc.SendEditRejectedEmail("user@test.com", "user", "artist", "Band", "reason")
+	err := svc.SendEditRejectedEmail("user@test.com", "user", "artist", "Band", "reason", "http://unsub")
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to send edit rejected email")
@@ -138,7 +140,7 @@ func TestSendEditRejectedEmail_APIError(t *testing.T) {
 func TestSendEditRejectedEmail_EmptyUsername(t *testing.T) {
 	svc, emails, _ := setupEmailTest(t)
 
-	err := svc.SendEditRejectedEmail("user@test.com", "", "venue", "Valley Bar", "incorrect info")
+	err := svc.SendEditRejectedEmail("user@test.com", "", "venue", "Valley Bar", "incorrect info", "http://unsub")
 
 	require.NoError(t, err)
 	email := <-emails
@@ -149,7 +151,7 @@ func TestSendEditRejectedEmail_EmptyUsername(t *testing.T) {
 func TestSendEditRejectedEmail_ContainsEncouragement(t *testing.T) {
 	svc, emails, _ := setupEmailTest(t)
 
-	err := svc.SendEditRejectedEmail("user@test.com", "testuser", "artist", "Band", "wrong info")
+	err := svc.SendEditRejectedEmail("user@test.com", "testuser", "artist", "Band", "wrong info", "http://unsub")
 
 	require.NoError(t, err)
 	email := <-emails

--- a/backend/internal/services/notification/email_tier_test.go
+++ b/backend/internal/services/notification/email_tier_test.go
@@ -62,21 +62,21 @@ func TestTierPermissions(t *testing.T) {
 
 func TestSendTierPromotionEmail_NotConfigured(t *testing.T) {
 	svc := &EmailService{}
-	err := svc.SendTierPromotionEmail("test@example.com", "testuser", "new_user", "contributor", "5 approved edits", []string{"Submit edits"})
+	err := svc.SendTierPromotionEmail("test@example.com", "testuser", "new_user", "contributor", "5 approved edits", "http://unsub", []string{"Submit edits"})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "email service is not configured")
 }
 
 func TestSendTierDemotionEmail_NotConfigured(t *testing.T) {
 	svc := &EmailService{}
-	err := svc.SendTierDemotionEmail("test@example.com", "testuser", "contributor", "new_user", "low approval rate")
+	err := svc.SendTierDemotionEmail("test@example.com", "testuser", "contributor", "new_user", "low approval rate", "http://unsub")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "email service is not configured")
 }
 
 func TestSendTierDemotionWarningEmail_NotConfigured(t *testing.T) {
 	svc := &EmailService{}
-	err := svc.SendTierDemotionWarningEmail("test@example.com", "testuser", "contributor", 0.82, 0.80)
+	err := svc.SendTierDemotionWarningEmail("test@example.com", "testuser", "contributor", 0.82, 0.80, "http://unsub")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "email service is not configured")
 }

--- a/backend/internal/services/notification/email_unsubscribe_headers_test.go
+++ b/backend/internal/services/notification/email_unsubscribe_headers_test.go
@@ -1,0 +1,100 @@
+package notification
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	resend "github.com/resend/resend-go/v2"
+)
+
+// PSY-756: the tier-change and edit-review senders must set RFC 8058
+// List-Unsubscribe headers AND carry a prominent in-body opt-out card, the
+// same as the already-compliant collection-digest sender. These tests use a
+// harness that captures the Headers map (the legacy capturedEmail in
+// email_test.go does not).
+
+// setupHeaderCapturingEmailTest mirrors setupDigestEmailTest but lives here so
+// the tier/edit header tests don't depend on the digest test file's harness.
+func setupHeaderCapturingEmailTest(t *testing.T) (*EmailService, chan capturedDigestEmail) {
+	t.Helper()
+	requests := make(chan capturedDigestEmail, 4)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req capturedDigestEmail
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		requests <- req
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"id": "test-email-id"})
+	}))
+	t.Cleanup(server.Close)
+
+	client := resend.NewCustomClient(server.Client(), "test-api-key")
+	serverURL, _ := url.Parse(server.URL)
+	client.BaseURL = serverURL
+
+	return &EmailService{
+		client:      client,
+		fromEmail:   "noreply@test.com",
+		frontendURL: "http://localhost:3000",
+	}, requests
+}
+
+// assertUnsubscribeWired checks the RFC 8058 headers and that the unsubscribe
+// URL appears in the body as a one-click opt-out card.
+func assertUnsubscribeWired(t *testing.T, email capturedDigestEmail, unsubURL string) {
+	t.Helper()
+	require.NotNil(t, email.Headers, "Headers must be set so Gmail/Yahoo render the native Unsubscribe button")
+	assert.Equal(t, "<"+unsubURL+">", email.Headers["List-Unsubscribe"],
+		"List-Unsubscribe must wrap the URL in <> per RFC 2369")
+	assert.Equal(t, "List-Unsubscribe=One-Click", email.Headers["List-Unsubscribe-Post"],
+		"List-Unsubscribe-Post must be exactly 'List-Unsubscribe=One-Click' per RFC 8058")
+	assert.Contains(t, email.Html, unsubURL,
+		"the unsubscribe URL must appear as a clickable link in the email body")
+	assert.Contains(t, email.Html, "one click",
+		"the in-body opt-out card must communicate the one-click affordance")
+}
+
+func TestSendTierPromotionEmail_UnsubscribeWired(t *testing.T) {
+	svc, emails := setupHeaderCapturingEmailTest(t)
+	unsubURL := "http://api.test.local/unsubscribe/tier-notifications?uid=42&sig=abc"
+
+	require.NoError(t, svc.SendTierPromotionEmail("u@test.com", "alice", "new_user", "contributor", "5 edits", unsubURL, []string{"Submit edits"}))
+	assertUnsubscribeWired(t, <-emails, unsubURL)
+}
+
+func TestSendTierDemotionEmail_UnsubscribeWired(t *testing.T) {
+	svc, emails := setupHeaderCapturingEmailTest(t)
+	unsubURL := "http://api.test.local/unsubscribe/tier-notifications?uid=42&sig=abc"
+
+	require.NoError(t, svc.SendTierDemotionEmail("u@test.com", "alice", "contributor", "new_user", "low rate", unsubURL))
+	assertUnsubscribeWired(t, <-emails, unsubURL)
+}
+
+func TestSendTierDemotionWarningEmail_UnsubscribeWired(t *testing.T) {
+	svc, emails := setupHeaderCapturingEmailTest(t)
+	unsubURL := "http://api.test.local/unsubscribe/tier-notifications?uid=42&sig=abc"
+
+	require.NoError(t, svc.SendTierDemotionWarningEmail("u@test.com", "alice", "contributor", 0.82, 0.80, unsubURL))
+	assertUnsubscribeWired(t, <-emails, unsubURL)
+}
+
+func TestSendEditApprovedEmail_UnsubscribeWired(t *testing.T) {
+	svc, emails := setupHeaderCapturingEmailTest(t)
+	unsubURL := "http://api.test.local/unsubscribe/edit-notifications?uid=42&sig=abc"
+
+	require.NoError(t, svc.SendEditApprovedEmail("u@test.com", "alice", "artist", "Band", "http://localhost:3000/artists/band", unsubURL))
+	assertUnsubscribeWired(t, <-emails, unsubURL)
+}
+
+func TestSendEditRejectedEmail_UnsubscribeWired(t *testing.T) {
+	svc, emails := setupHeaderCapturingEmailTest(t)
+	unsubURL := "http://api.test.local/unsubscribe/edit-notifications?uid=42&sig=abc"
+
+	require.NoError(t, svc.SendEditRejectedEmail("u@test.com", "alice", "artist", "Band", "wrong info", unsubURL))
+	assertUnsubscribeWired(t, <-emails, unsubURL)
+}

--- a/backend/internal/services/notification/filter_service_test.go
+++ b/backend/internal/services/notification/filter_service_test.go
@@ -872,15 +872,15 @@ func (m *mockEmailService) SendFilterNotificationEmail(_, _, _, _ string) error 
 	m.sendCalls++
 	return nil
 }
-func (m *mockEmailService) SendTierPromotionEmail(_, _, _, _, _ string, _ []string) error {
+func (m *mockEmailService) SendTierPromotionEmail(_, _, _, _, _, _ string, _ []string) error {
 	return nil
 }
-func (m *mockEmailService) SendTierDemotionEmail(_, _, _, _, _ string) error { return nil }
-func (m *mockEmailService) SendTierDemotionWarningEmail(_, _, _ string, _, _ float64) error {
+func (m *mockEmailService) SendTierDemotionEmail(_, _, _, _, _, _ string) error { return nil }
+func (m *mockEmailService) SendTierDemotionWarningEmail(_, _, _ string, _, _ float64, _ string) error {
 	return nil
 }
-func (m *mockEmailService) SendEditApprovedEmail(_, _, _, _, _ string) error { return nil }
-func (m *mockEmailService) SendEditRejectedEmail(_, _, _, _, _ string) error { return nil }
+func (m *mockEmailService) SendEditApprovedEmail(_, _, _, _, _, _ string) error { return nil }
+func (m *mockEmailService) SendEditRejectedEmail(_, _, _, _, _, _ string) error { return nil }
 func (m *mockEmailService) SendCommentNotification(_, _, _, _, _, _, _ string) error {
 	return nil
 }

--- a/backend/internal/services/user/user.go
+++ b/backend/internal/services/user/user.go
@@ -1212,6 +1212,24 @@ func (s *UserService) SetNotifyOnCollectionDigest(userID uint, enabled bool) err
 	return nil
 }
 
+// SetNotifyOnTierNotifications toggles the tier-change email preference.
+// Upserts — see setNotificationFlagPref.
+func (s *UserService) SetNotifyOnTierNotifications(userID uint, enabled bool) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+	return s.setNotificationFlagPref(userID, "notify_on_tier_notifications", enabled)
+}
+
+// SetNotifyOnEditNotifications toggles the edit-review email preference.
+// Upserts — see setNotificationFlagPref.
+func (s *UserService) SetNotifyOnEditNotifications(userID uint, enabled bool) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+	return s.setNotificationFlagPref(userID, "notify_on_edit_notifications", enabled)
+}
+
 // setCommentNotificationPref updates one or both of the PSY-289 preference
 // flags on the user_preferences row, creating the row if it doesn't exist.
 func (s *UserService) setCommentNotificationPref(userID uint, updates map[string]interface{}) error {
@@ -1237,6 +1255,46 @@ func (s *UserService) setCommentNotificationPref(userID uint, updates map[string
 		}
 		if err := s.db.Create(prefs).Error; err != nil {
 			return fmt.Errorf("failed to create user preferences: %w", err)
+		}
+	}
+	return nil
+}
+
+// setNotificationFlagPref updates a single default-TRUE notification flag,
+// creating the preferences row if it doesn't exist yet. Used by the tier/edit
+// toggles. The created row carries the other default-TRUE flags
+// (comment/mention/tier/edit) at TRUE and applies the one incoming override.
+//
+// GORM bool gotcha: a freshly Create-d struct skips false fields (zero value),
+// but every column here defaults TRUE, so a "disable" path (enabled=false on
+// the target column) needs an explicit follow-up Update. We just rebuild the
+// targeted column with Update after Create when disabling.
+func (s *UserService) setNotificationFlagPref(userID uint, column string, enabled bool) error {
+	result := s.db.Model(&authm.UserPreferences{}).
+		Where("user_id = ?", userID).
+		Update(column, enabled)
+	if result.Error != nil {
+		return fmt.Errorf("failed to update %s: %w", column, result.Error)
+	}
+	if result.RowsAffected == 0 {
+		prefs := &authm.UserPreferences{
+			UserID:                      userID,
+			NotifyOnCommentSubscription: true,
+			NotifyOnMention:             true,
+			NotifyOnTierNotifications:   true,
+			NotifyOnEditNotifications:   true,
+		}
+		if err := s.db.Create(prefs).Error; err != nil {
+			return fmt.Errorf("failed to create user preferences: %w", err)
+		}
+		// Create skipped the column if `enabled` is false (zero value) and the
+		// column default is TRUE — apply the disable explicitly.
+		if !enabled {
+			if err := s.db.Model(&authm.UserPreferences{}).
+				Where("user_id = ?", userID).
+				Update(column, false).Error; err != nil {
+				return fmt.Errorf("failed to update %s: %w", column, err)
+			}
 		}
 	}
 	return nil

--- a/backend/internal/services/user/user_test.go
+++ b/backend/internal/services/user/user_test.go
@@ -340,6 +340,56 @@ func (suite *UserServiceIntegrationTestSuite) TestFindOrCreateUser_ExistingOAuth
 	assert.Equal(suite.T(), *user.Email, *retrievedUser.Email)
 }
 
+// PSY-756: tier/edit notification preference setters. The opt-OUT defaults
+// (column DEFAULT TRUE) make the "disable on a fresh prefs row" path the
+// interesting one — GORM skips the false zero-value on Create, so the setter
+// needs an explicit follow-up Update.
+
+func (suite *UserServiceIntegrationTestSuite) TestSetNotifyOnTierNotifications_DisableCreatesRowAsFalse() {
+	user := &authm.User{Email: stringPtr("tier-optout@example.com"), IsActive: true}
+	suite.Require().NoError(suite.db.Create(user).Error)
+
+	// No prefs row exists yet — disabling must create one with the flag false.
+	suite.Require().NoError(suite.userService.SetNotifyOnTierNotifications(user.ID, false))
+
+	var prefs authm.UserPreferences
+	suite.Require().NoError(suite.db.Where("user_id = ?", user.ID).First(&prefs).Error)
+	suite.False(prefs.NotifyOnTierNotifications, "fresh-row disable must persist as false despite the TRUE column default")
+	// The other notification flags should be created at their TRUE defaults.
+	suite.True(prefs.NotifyOnEditNotifications)
+	suite.True(prefs.NotifyOnCommentSubscription)
+}
+
+func (suite *UserServiceIntegrationTestSuite) TestSetNotifyOnEditNotifications_ToggleExistingRow() {
+	user := &authm.User{Email: stringPtr("edit-toggle@example.com"), IsActive: true}
+	suite.Require().NoError(suite.db.Create(user).Error)
+
+	// Enable on a fresh row (default is already TRUE, but exercise the path).
+	suite.Require().NoError(suite.userService.SetNotifyOnEditNotifications(user.ID, true))
+	var prefs authm.UserPreferences
+	suite.Require().NoError(suite.db.Where("user_id = ?", user.ID).First(&prefs).Error)
+	suite.True(prefs.NotifyOnEditNotifications)
+
+	// Now disable on the existing row.
+	suite.Require().NoError(suite.userService.SetNotifyOnEditNotifications(user.ID, false))
+	suite.Require().NoError(suite.db.Where("user_id = ?", user.ID).First(&prefs).Error)
+	suite.False(prefs.NotifyOnEditNotifications)
+}
+
+func TestUserService_SetNotifyOnTierNotifications_NilDB(t *testing.T) {
+	svc := &UserService{}
+	err := svc.SetNotifyOnTierNotifications(1, false)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "database not initialized")
+}
+
+func TestUserService_SetNotifyOnEditNotifications_NilDB(t *testing.T) {
+	svc := &UserService{}
+	err := svc.SetNotifyOnEditNotifications(1, false)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "database not initialized")
+}
+
 // Run the integration test suite
 func TestUserServiceIntegrationTestSuite(t *testing.T) {
 	suite.Run(t, new(UserServiceIntegrationTestSuite))


### PR DESCRIPTION
## Summary

The five tier-change and edit-review notification senders lacked the RFC 8058 `List-Unsubscribe` + `List-Unsubscribe-Post: List-Unsubscribe=One-Click` headers Gmail/Yahoo require of bulk senders, and had no in-body opt-out:

- `SendTierPromotionEmail`, `SendTierDemotionEmail`, `SendTierDemotionWarningEmail`
- `SendEditApprovedEmail`, `SendEditRejectedEmail`

Each now sets both headers and renders a prominent one-click opt-out card, matching the already-compliant collection-digest sender.

**Per-category opt-out** (locked decision — not a single blanket toggle): two opt-OUT preference columns let users unsubscribe from tier-change emails separately from edit-review emails.

- Migration `20260521012633_tier_edit_notification_prefs` adds `notify_on_tier_notifications` + `notify_on_edit_notifications`, both `DEFAULT TRUE` (opt-OUT, matching the comment/mention flags — each is a single email per discrete action; the collection-digest opt-IN stays the firehose exception).
- Generic `ComputeScopedUnsubscribeSignature` / `VerifyScopedUnsubscribeSignature` / `GenerateScopedUnsubscribeURL` helpers bind each HMAC to its scope (`tier-notifications` / `edit-notifications`) so a leaked link can't be replayed across categories. Constant-time compare via `hmac.Equal`. The pre-existing `ComputeUnsubscribeSignature` (show-reminders) is left untouched.
- New chi handlers at `/unsubscribe/{tier,edit}-notifications` serve a GET HTML confirmation page and an RFC 8058 one-click POST (JSON 200), no login required — mirroring the canonical collection-digest handler. Shared `writeOneClickUnsubscribed` + `writeScopedUnsubscribeConfirmation` helpers extracted.
- The admin senders' callers (`auto_promotion.go`, `pending_edit.go`) mint the scoped URL and gate the send on the preference (suppress only on explicit opt-out; missing prefs row / read error still sends).
- `PATCH /auth/preferences/tier-edit-notifications` exposes the toggles for a future settings UI.

## Test plan

- [x] `go build ./...` — exit 0
- [x] `go test ./...` — 28 packages `ok`, 0 FAIL (run after `/simplify`; `/tmp/psy756_final.log`)
- [x] Migration up→down→up round-trip against a live Postgres — `down 1` removed both columns (0 rows), `up 1` re-added them (2 rows); reversibility CI guard will pass
- [x] New unit tests: scoped-signature determinism + scope-isolation + cross-scope-rejection (`unsubscribe_scope_test.go`); all 5 senders set the headers + in-body card (`email_unsubscribe_headers_test.go`); chi handler GET-html / POST-one-click / 403-bad-sig / 400-missing-params / cross-scope-403 (`unsubscribe_scoped_test.go`); PATCH toggle handler (`user_preferences_test.go`)
- [x] New integration tests: tier + edit emails carry the unsubscribe URL and are suppressed (but the tier change / approval still happen) when opted out (`auto_promotion_email_test.go`, `pending_edit_test.go`); service-layer setter upsert + opt-out-default round-trip (`user_test.go`)
- [x] `/simplify` — see below

## Manual repro

Brought up an isolated dispatch stack (`--mode=isolated`); migrations applied cleanly and both columns confirmed present (`DEFAULT TRUE`, `NOT NULL`). Curled the live backend (`:62899`) for user 1 (both flags initially `t`):

- `GET /unsubscribe/tier-notifications?uid=1&sig=<valid>` → `200 text/html`, page shows "tier-change emails" + "unsubscribed" + `/settings`
- `POST /unsubscribe/edit-notifications` (one-click) → `200 application/json` `{"unsubscribed":true}`
- DB after: both flags flipped `t` → `f`
- Invalid sig → `403`; missing params → `400`; tier-scoped sig replayed on edit endpoint → `403` (scope isolation confirmed)

Stack torn down with `stack-down.sh`.

## Simplify

`/simplify` ran. Fixes: unified the collection-digest sender onto the new shared `unsubscribeHeaders()` helper (removed a duplicated header map); stripped `PSY-756` ticket refs from production Go doc comments (kept the WHY; migration SQL + test annotations retain refs per convention). Full suite re-run green afterward. No correctness concerns surfaced.

## Coverage gaps

- `SendTierDemotionWarningEmail` is wired with headers + opt-out + a unit test, but has no production caller today (only tests invoke it). No behavior change there — it's compliant for when a caller is added.
- UI toggle is backend-only here (`PATCH` endpoint + columns); the settings-page checkbox is a paired frontend follow-up (filing separately per `feedback_pair_backend_with_ui_surface`).

Closes PSY-756